### PR TITLE
Reparse 2014 precinct files from SOS sources

### DIFF
--- a/2014/20141104-totals.csv
+++ b/2014/20141104-totals.csv
@@ -1,0 +1,1829 @@
+Allen,0001 Carlyle,Voters,,,Ballots cast,132
+Allen,0002 Cottage Grove,Voters,,,Ballots cast,86
+Allen,0003 Deer Creek,Voters,,,Ballots cast,52
+Allen,0004 E Elm twp-Laharpe,Voters,,,Ballots cast,230
+Allen,0005 W Elm twp,Voters,,,Ballots cast,429
+Allen,0006 N Elsmore twp,Voters,,,Ballots cast,65
+Allen,0007 S Elsmore twp,Voters,,,Ballots cast,54
+Allen,0008 Geneva,Voters,,,Ballots cast,56
+Allen,0009 Humboldt twp,Voters,,,Ballots cast,112
+Allen,0010 N Iola twp,Voters,,,Ballots cast,108
+Allen,0011 S Iola twp,Voters,,,Ballots cast,254
+Allen,0012 Logan,Voters,,,Ballots cast,85
+Allen,0013 Marmaton,Voters,,,Ballots cast,265
+Allen,0014 Osage,Voters,,,Ballots cast,98
+Allen,0015 Salem,Voters,,,Ballots cast,106
+Allen,"0016 City of Humboldt, WD 1",Voters,,,Ballots cast,253
+Allen,0017 City of Humboldt- WD 2,Voters,,,Ballots cast,312
+Allen,"0018 City of Iola, Wd 1",Voters,,,Ballots cast,406
+Allen,"0019 City of Iola, Wd 2",Voters,,,Ballots cast,528
+Allen,"0020 City of Iola, Wd 3",Voters,,,Ballots cast,451
+Allen,"0021 City of Iola, Wd 4",Voters,,,Ballots cast,455
+Allen,0001 Carlyle,Voters,,,Registration,211
+Allen,0002 Cottage Grove,Voters,,,Registration,144
+Allen,0003 Deer Creek,Voters,,,Registration,94
+Allen,0004 E Elm twp-Laharpe,Voters,,,Registration,442
+Allen,0005 W Elm twp,Voters,,,Registration,665
+Allen,0006 N Elsmore twp,Voters,,,Registration,133
+Allen,0007 S Elsmore twp,Voters,,,Registration,112
+Allen,0008 Geneva,Voters,,,Registration,101
+Allen,0009 Humboldt twp,Voters,,,Registration,191
+Allen,0010 N Iola twp,Voters,,,Registration,168
+Allen,0011 S Iola twp,Voters,,,Registration,386
+Allen,0012 Logan,Voters,,,Registration,142
+Allen,0013 Marmaton,Voters,,,Registration,530
+Allen,0014 Osage,Voters,,,Registration,199
+Allen,0015 Salem,Voters,,,Registration,194
+Allen,"0016 City of Humboldt, WD 1",Voters,,,Registration,614
+Allen,0017 City of Humboldt- WD 2,Voters,,,Registration,608
+Allen,"0018 City of Iola, Wd 1",Voters,,,Registration,749
+Allen,"0019 City of Iola, Wd 2",Voters,,,Registration,1120
+Allen,"0020 City of Iola, Wd 3",Voters,,,Registration,862
+Allen,"0021 City of Iola, Wd 4",Voters,,,Registration,838
+Brown,0001 HIAWATHA WARD 1,Voters,,,BALLOTS CAST - TOTAL,156
+Brown,0002 HIAWATHA WARD 2,Voters,,,BALLOTS CAST - TOTAL,482
+Brown,0003 HIAWATHA WARD 3,Voters,,,BALLOTS CAST - TOTAL,375
+Brown,0004 HIAWATHA WARD 4,Voters,,,BALLOTS CAST - TOTAL,58
+Brown,0005 HORTON WARD 1,Voters,,,BALLOTS CAST - TOTAL,198
+Brown,0006 HORTON WARD 2,Voters,,,BALLOTS CAST - TOTAL,135
+Brown,0007 HORTON WARD 3,Voters,,,BALLOTS CAST - TOTAL,79
+Brown,0008 RESERVE  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,42
+Brown,0009 HAMLIN PRECINCT,Voters,,,BALLOTS CAST - TOTAL,72
+Brown,0010 HIAWATHA TWP,Voters,,,BALLOTS CAST - TOTAL,257
+Brown,0011 IRVING PRECINCT,Voters,,,BALLOTS CAST - TOTAL,96
+Brown,0012 MISSION PRECINCT,Voters,,,BALLOTS CAST - TOTAL,253
+Brown,0013 MORRILL PRECINCT,Voters,,,BALLOTS CAST - TOTAL,182
+Brown,0014 PADONIA PRECINCT,Voters,,,BALLOTS CAST - TOTAL,75
+Brown,0015 POWHATTAN  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,204
+Brown,0016 ROBINSON  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,169
+Brown,0017 WALNUT  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,254
+Brown,0018 WASHINGTON  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,158
+Brown,0001 HIAWATHA WARD 1,Voters,,,REGISTERED VOTERS - TOTAL,279
+Brown,0002 HIAWATHA WARD 2,Voters,,,REGISTERED VOTERS - TOTAL,787
+Brown,0003 HIAWATHA WARD 3,Voters,,,REGISTERED VOTERS - TOTAL,689
+Brown,0004 HIAWATHA WARD 4,Voters,,,REGISTERED VOTERS - TOTAL,159
+Brown,0005 HORTON WARD 1,Voters,,,REGISTERED VOTERS - TOTAL,423
+Brown,0006 HORTON WARD 2,Voters,,,REGISTERED VOTERS - TOTAL,306
+Brown,0007 HORTON WARD 3,Voters,,,REGISTERED VOTERS - TOTAL,225
+Brown,0008 RESERVE  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,88
+Brown,0009 HAMLIN PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,108
+Brown,0010 HIAWATHA TWP,Voters,,,REGISTERED VOTERS - TOTAL,409
+Brown,0011 IRVING PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,189
+Brown,0012 MISSION PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,381
+Brown,0013 MORRILL PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,296
+Brown,0014 PADONIA PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,132
+Brown,0015 POWHATTAN  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,439
+Brown,0016 ROBINSON  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,264
+Brown,0017 WALNUT  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,399
+Brown,0018 WASHINGTON  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,310
+Cherokee,0001 Baxter Sprs W1,Voters,,,BALLOTS CAST,193,3,18,166,6
+Cherokee,0002 Baxter Sprs W2,Voters,,,BALLOTS CAST,142,5,12,118,7
+Cherokee,0003 Baxter Sprs W3,Voters,,,BALLOTS CAST,410,15,22,364,9
+Cherokee,0004 Baxter Sprs W4,Voters,,,BALLOTS CAST,200,11,16,163,10
+Cherokee,0005 Columbus W1,Voters,,,BALLOTS CAST,137,14,16,106,1
+Cherokee,0006 Columbus W2,Voters,,,BALLOTS CAST,261,31,30,200,0
+Cherokee,0007 Columbus W3,Voters,,,BALLOTS CAST,240,20,27,191,2
+Cherokee,0008 Columbus W4,Voters,,,BALLOTS CAST,145,14,19,112,0
+Cherokee,0009 Columbus W5,Voters,,,BALLOTS CAST,183,14,36,132,1
+Cherokee,0010 Galena W1,Voters,,,BALLOTS CAST,160,6,14,129,11
+Cherokee,0011 Galena W2,Voters,,,BALLOTS CAST,132,3,15,111,3
+Cherokee,0012 Galena W3,Voters,,,BALLOTS CAST,220,1,22,192,5
+Cherokee,0013 Galena W4,Voters,,,BALLOTS CAST,91,0,11,80,0
+Cherokee,0014 Scammon W1,Voters,,,BALLOTS CAST,40,3,1,35,1
+Cherokee,0015 Scammon W2,Voters,,,BALLOTS CAST,47,3,7,37,0
+Cherokee,0016 Scammon W3,Voters,,,BALLOTS CAST,63,4,6,53,0
+Cherokee,0017 Weir W1,Voters,,,BALLOTS CAST,46,1,1,42,2
+Cherokee,0018 Weir W2,Voters,,,BALLOTS CAST,102,1,8,91,2
+Cherokee,0019 Weir W3,Voters,,,BALLOTS CAST,61,1,10,50,0
+Cherokee,0001 Baxter Sprs W1,Voters,,,REGISTERED VOTERS,720,,,,
+Cherokee,0002 Baxter Sprs W2,Voters,,,REGISTERED VOTERS,785,,,,
+Cherokee,0003 Baxter Sprs W3,Voters,,,REGISTERED VOTERS,1186,,,,
+Cherokee,0004 Baxter Sprs W4,Voters,,,REGISTERED VOTERS,899,,,,
+Cherokee,0005 Columbus W1,Voters,,,REGISTERED VOTERS,381,,,,
+Cherokee,0006 Columbus W2,Voters,,,REGISTERED VOTERS,586,,,,
+Cherokee,0007 Columbus W3,Voters,,,REGISTERED VOTERS,556,,,,
+Cherokee,0008 Columbus W4,Voters,,,REGISTERED VOTERS,297,,,,
+Cherokee,0009 Columbus W5,Voters,,,REGISTERED VOTERS,537,,,,
+Cherokee,0010 Galena W1,Voters,,,REGISTERED VOTERS,722,,,,
+Cherokee,0011 Galena W2,Voters,,,REGISTERED VOTERS,531,,,,
+Cherokee,0012 Galena W3,Voters,,,REGISTERED VOTERS,766,,,,
+Cherokee,0013 Galena W4,Voters,,,REGISTERED VOTERS,459,,,,
+Cherokee,0015 Scammon W2,Voters,,,REGISTERED VOTERS,139,,,,
+Cherokee,0016 Scammon W3,Voters,,,REGISTERED VOTERS,134,,,,
+Cherokee,0017 Weir W1,Voters,,,REGISTERED VOTERS,120,,,,
+Cherokee,0018 Weir W2,Voters,,,REGISTERED VOTERS,271,,,,
+Cherokee,0019 Weir W3,Voters,,,REGISTERED VOTERS,129,,,,
+Cheyenne,Benkelman Township,Voters,,,Registration,27
+Cheyenne,Bird City Township,Voters,,,Registration,436
+Cheyenne,Calhoun Township,Voters,,,Registration,36
+Cheyenne,Cleveland Run Township,Voters,,,Registration,42
+Cheyenne,Jaqua Township,Voters,,,Registration,15
+Cheyenne,Orlando Township,Voters,,,Registration,45
+Cheyenne,Wano 1 Township,Voters,,,Registration,520
+Cheyenne,Wano 2 Township,Voters,,,Registration,745
+Cheyenne,Benkelman Township,Voters,,,Voted,17
+Cheyenne,Bird City Township,Voters,,,Voted,245
+Cheyenne,Calhoun Township,Voters,,,Voted,26
+Cheyenne,Cleveland Run Township,Voters,,,Voted,30
+Cheyenne,Jaqua Township,Voters,,,Voted,10
+Cheyenne,Orlando Township,Voters,,,Voted,26
+Cheyenne,Wano 1 Township,Voters,,,Voted,285
+Cheyenne,Wano 2 Township,Voters,,,Voted,437
+Clay,Ward 1,Voters,,,Registered,859
+Clay,Ward 1,Voters,,,Ballots cast,504
+Clay,Ward 2,Voters,,,Registered,915
+Clay,Ward 2,Voters,,,Ballots cast,547
+Clay,Ward 3,Voters,,,Registered,619
+Clay,Ward 3,Voters,,,Ballots cast,298
+Clay,Blaine,Voters,,,Registered,197
+Clay,Blaine,Voters,,,Ballots cast,125
+Clay,Bloom,Voters,,,Registered,80
+Clay,Bloom,Voters,,,Ballots cast,53
+Clay,Clay Ctr twp,Voters,,,Registered,266
+Clay,Clay Ctr twp,Voters,,,Ballots cast,162
+Clay,Exeter,Voters,,,Registered,61
+Clay,Exeter,Voters,,,Ballots cast,40
+Clay,Five Creeks,Voters,,,Registered,82
+Clay,Five Creeks,Voters,,,Ballots cast,46
+Clay,Garfield,Voters,,,Registered,72
+Clay,Garfield,Voters,,,Ballots cast,40
+Clay,Goshen,Voters,,,Registered,45
+Clay,Goshen,Voters,,,Ballots cast,24
+Clay,Grant,Voters,,,Registered,134
+Clay,Grant,Voters,,,Ballots cast,76
+Clay,Hayes,Voters,,,Registered,142
+Clay,Hayes,Voters,,,Ballots cast,98
+Clay,Highland,Voters,,,Registered,186
+Clay,Highland,Voters,,,Ballots cast,119
+Clay,Mulberry,Voters,,,Registered,193
+Clay,Mulberry,Voters,,,Ballots cast,84
+Clay,Sherman,Voters,,,Registered,181
+Clay,Sherman,Voters,,,Ballots cast,89
+Clay,Ward 4,Voters,,,Registered,603
+Clay,Ward 4,Voters,,,Ballots cast,255
+Clay,Athelstane,Voters,,,Registered,80
+Clay,Athelstane,Voters,,,Ballots cast,59
+Clay,Chapman,Voters,,,Registered,143
+Clay,Chapman,Voters,,,Ballots cast,60
+Clay,Gill,Voters,,,Registered,112
+Clay,Gill,Voters,,,Ballots cast,70
+Clay,Oakland,Voters,,,Registered,74
+Clay,Oakland,Voters,,,Ballots cast,36
+Clay,Republican,Voters,,,Registered,647
+Clay,Republican,Voters,,,Ballots cast,318
+Clay,Union,Voters,,,Registered,120
+Clay,Union,Voters,,,Ballots cast,87
+Crawford,01 Arcadia,REG,,,Registered Voters,236,,,
+Crawford,02 Baker,REG,,,Registered Voters,688,,,
+Crawford,03 Beulah,REG,,,Registered Voters,191,,,
+Crawford,04 Brazilton,REG,,,Registered Voters,48,,,
+Crawford,05 Capaldo,REG,,,Registered Voters,60,,,
+Crawford,06 Capaldo,REG,,,Registered Voters,299,,,
+Crawford,07 Cherokee,REG,,,Registered Voters,380,,,
+Crawford,08 Cherokee-Sheridan,REG,,,Registered Voters,209,,,
+Crawford,09 Chicopee,REG,,,Registered Voters,357,,,
+Crawford,10 Crawford,REG,,,Registered Voters,290,,,
+Crawford,11 Crowe,REG,,,Registered Voters,173,,,
+Crawford,12 Franklin,REG,,,Registered Voters,280,,,
+Crawford,13 Franklin,REG,,,Registered Voters,19,,,
+Crawford,14 Frontenac W1,REG,,,Registered Voters,667,,,
+Crawford,15 Frontenac W2,REG,,,Registered Voters,874,,,
+Crawford,16 Frontenac W3,REG,,,Registered Voters,361,,,
+Crawford,17 Frontenac W4,REG,,,Registered Voters,298,,,
+Crawford,18 Girard W1,REG,,,Registered Voters,202,,,
+Crawford,19 Girard W2,REG,,,Registered Voters,566,,,
+Crawford,20 Girard W3,REG,,,Registered Voters,400,,,
+Crawford,21 Girard W4,REG,,,Registered Voters,526,,,
+Crawford,22 Grant,REG,,,Registered Voters,182,,,
+Crawford,23 Hepler,REG,,,Registered Voters,73,,,
+Crawford,24 Lincoln,REG,,,Registered Voters,230,,,
+Crawford,25 Lincoln,REG,,,Registered Voters,7,,,
+Crawford,26 Lincoln-Arcadia,REG,,,Registered Voters,94,,,
+Crawford,27 Lone Star,REG,,,Registered Voters,847,,,
+Crawford,28 McCune,REG,,,Registered Voters,265,,,
+Crawford,29 Mulberry W1,REG,,,Registered Voters,147,,,
+Crawford,30 Mulberry W2,REG,,,Registered Voters,180,,,
+Crawford,31 North Arma,REG,,,Registered Voters,577,,,
+Crawford,32 Opolis,REG,,,Registered Voters,249,,,
+Crawford,33 Osage-McCune,REG,,,Registered Voters,256,,,
+Crawford,34 Parkview,REG,,,Registered Voters,161,,,
+Crawford,35 Parkview,REG,,,Registered Voters,179,,,
+Crawford,36 Pittsburg W1P1,REG,,,Registered Voters,602,,,
+Crawford,37 Pittsburg W1P2,REG,,,Registered Voters,986,,,
+Crawford,38 Pittsburg W1P3,REG,,,Registered Voters,"1,796",,,
+Crawford,39 Pittsburg W2P1,REG,,,Registered Voters,452,,,
+Crawford,40 Pittsburg W2P2,REG,,,Registered Voters,489,,,
+Crawford,41 Pittsburg W2P3,REG,,,Registered Voters,598,,,
+Crawford,42 Pittsburg W2P4,REG,,,Registered Voters,407,,,
+Crawford,43 Pittsburg W2P5,REG,,,Registered Voters,772,,,
+Crawford,44 Pittsburg W3P1,REG,,,Registered Voters,631,,,
+Crawford,45 Pittsburg W3P2,REG,,,Registered Voters,721,,,
+Crawford,46 Pittsburg W4P1,REG,,,Registered Voters,285,,,
+Crawford,47 Pittsburg W4P2,REG,,,Registered Voters,546,,,
+Crawford,48 Pittsburg W4P3,REG,,,Registered Voters,816,,,
+Crawford,49 Pittsburg W4P4,REG,,,Registered Voters,502,,,
+Crawford,50 Pittsburg W4P5,REG,,,Registered Voters,987,,,
+Crawford,51 Pittsburg W4P6,REG,,,Registered Voters,148,,,
+Crawford,52 Raymond,REG,,,Registered Voters,490,,,
+Crawford,53 Sheridan-Cherokee,REG,,,Registered Voters,82,,,
+Crawford,54 Sheridan,REG,,,Registered Voters,89,,,
+Crawford,55 Sherman,REG,,,Registered Voters,394,,,
+Crawford,56 Smelter,REG,,,Registered Voters,389,,,
+Crawford,57 South Arma,REG,,,Registered Voters,625,,,
+Crawford,58 Walnut,REG,,,Registered Voters,118,,,
+Crawford,59 Walnut twp,REG,,,Registered Voters,2,,,
+Crawford,60 Walnut twp,REG,,,Registered Voters,29,,,
+Crawford,61 Walnut-Hepler,REG,,,Registered Voters,6,,,
+Crawford,62 Walnut-Hepler,REG,,,Registered Voters,44,,,
+Douglas,1,Voters,,,Registered,903
+Douglas,2,Voters,,,Registered,912
+Douglas,3,Voters,,,Registered,982
+Douglas,4,Voters,,,Registered,1003
+Douglas,5,Voters,,,Registered,1173
+Douglas,6,Voters,,,Registered,996
+Douglas,7,Voters,,,Registered,955
+Douglas,8,Voters,,,Registered,1033
+Douglas,9,Voters,,,Registered,798
+Douglas,10,Voters,,,Registered,1077
+Douglas,11,Voters,,,Registered,803
+Douglas,12,Voters,,,Registered,1460
+Douglas,13,Voters,,,Registered,986
+Douglas,14,Voters,,,Registered,2558
+Douglas,15,Voters,,,Registered,1418
+Douglas,16,Voters,,,Registered,1126
+Douglas,17,Voters,,,Registered,908
+Douglas,18,Voters,,,Registered,1706
+Douglas,19,Voters,,,Registered,1272
+Douglas,20,Voters,,,Registered,1752
+Douglas,21,Voters,,,Registered,745
+Douglas,22,Voters,,,Registered,1612
+Douglas,23,Voters,,,Registered,790
+Douglas,24,Voters,,,Registered,791
+Douglas,25,Voters,,,Registered,1280
+Douglas,26,Voters,,,Registered,1034
+Douglas,27,Voters,,,Registered,1004
+Douglas,28,Voters,,,Registered,521
+Douglas,29,Voters,,,Registered,884
+Douglas,30 S2,Voters,,,Registered,336
+Douglas,30 S3,Voters,,,Registered,838
+Douglas,31,Voters,,,Registered,1086
+Douglas,32,Voters,,,Registered,983
+Douglas,33,Voters,,,Registered,930
+Douglas,34 S2,Voters,,,Registered,572
+Douglas,34 S3,Voters,,,Registered,314
+Douglas,35 S2,Voters,,,Registered,1073
+Douglas,35 S3,Voters,,,Registered,65
+Douglas,36  S2,Voters,,,Registered,931
+Douglas,36  S3,Voters,,,Registered,838
+Douglas,37 H10,Voters,,,Registered,1583
+Douglas,37  H46,Voters,,,Registered,127
+Douglas,38  H10,Voters,,,Registered,1226
+Douglas,39,Voters,,,Registered,1048
+Douglas,40,Voters,,,Registered,972
+Douglas,41 S3 H46,Voters,,,Registered,1694
+Douglas,41 S3 H45,Voters,,,Registered,10
+Douglas,41 S2 H46,Voters,,,Registered,24
+Douglas,42  H46,Voters,,,Registered,479
+Douglas,42 H45,Voters,,,Registered,441
+Douglas,43  CC1,Voters,,,Registered,744
+Douglas,43  CC3,Voters,,,Registered,776
+Douglas,44  H45,Voters,,,Registered,703
+Douglas,44 H44,Voters,,,Registered,152
+Douglas,45,Voters,,,Registered,2725
+Douglas,46  S3,Voters,,,Registered,2145
+Douglas,47,Voters,,,Registered,615
+Douglas,48,Voters,,,Registered,1337
+Douglas,49,Voters,,,Registered,1301
+Douglas,70 Lawrence / Willow,Voters,,,Registered,14
+Douglas,71 Lawrence / Willow,Voters,,,Registered,1298
+Douglas,1,Voters,,,Cast,403
+Douglas,2,Voters,,,Cast,481
+Douglas,3,Voters,,,Cast,464
+Douglas,4,Voters,,,Cast,406
+Douglas,5,Voters,,,Cast,600
+Douglas,6,Voters,,,Cast,604
+Douglas,7,Voters,,,Cast,169
+Douglas,8,Voters,,,Cast,262
+Douglas,9,Voters,,,Cast,251
+Douglas,10,Voters,,,Cast,137
+Douglas,11,Voters,,,Cast,423
+Douglas,12,Voters,,,Cast,718
+Douglas,13,Voters,,,Cast,670
+Douglas,14,Voters,,,Cast,984
+Douglas,15,Voters,,,Cast,728
+Douglas,16,Voters,,,Cast,615
+Douglas,17,Voters,,,Cast,570
+Douglas,18,Voters,,,Cast,1003
+Douglas,19,Voters,,,Cast,855
+Douglas,20,Voters,,,Cast,1023
+Douglas,21,Voters,,,Cast,362
+Douglas,22,Voters,,,Cast,708
+Douglas,23,Voters,,,Cast,480
+Douglas,24,Voters,,,Cast,421
+Douglas,25,Voters,,,Cast,284
+Douglas,26,Voters,,,Cast,403
+Douglas,27,Voters,,,Cast,421
+Douglas,28,Voters,,,Cast,303
+Douglas,29,Voters,,,Cast,408
+Douglas,30 S2,Voters,,,Cast,165
+Douglas,30 S3,Voters,,,Cast,195
+Douglas,31,Voters,,,Cast,625
+Douglas,32,Voters,,,Cast,310
+Douglas,33,Voters,,,Cast,604
+Douglas,34 S2,Voters,,,Cast,356
+Douglas,34 S3,Voters,,,Cast,67
+Douglas,35 S2,Voters,,,Cast,477
+Douglas,35 S3,Voters,,,Cast,35
+Douglas,36  S2,Voters,,,Cast,402
+Douglas,36  S3,Voters,,,Cast,331
+Douglas,37 H10,Voters,,,Cast,764
+Douglas,37  H46,Voters,,,Cast,28
+Douglas,38  H10,Voters,,,Cast,632
+Douglas,39,Voters,,,Cast,528
+Douglas,40,Voters,,,Cast,485
+Douglas,41 S3 H46,Voters,,,Cast,909
+Douglas,41 S3 H45,Voters,,,Cast,1
+Douglas,41 S2 H46,Voters,,,Cast,7
+Douglas,42  H46,Voters,,,Cast,198
+Douglas,42 H45,Voters,,,Cast,239
+Douglas,43  CC1,Voters,,,Cast,419
+Douglas,43  CC3,Voters,,,Cast,438
+Douglas,44  H45,Voters,,,Cast,385
+Douglas,44 H44,Voters,,,Cast,106
+Douglas,45,Voters,,,Cast,1713
+Douglas,46  S3,Voters,,,Cast,930
+Douglas,47,Voters,,,Cast,360
+Douglas,48,Voters,,,Cast,880
+Douglas,49,Voters,,,Cast,724
+Douglas,70 Lawrence / Willow,Voters,,,Cast,10
+Douglas,71 Lawrence / Willow,Voters,,,Cast,644
+Douglas,50 Eudora W,Voters,,,Registered,1507
+Douglas,51 Clinton,Voters,,,Registered,478
+Douglas,52 Eudora,Voters,,,Registered,726
+Douglas,53 Eudora S H10,Voters,,,Registered,646
+Douglas,53 Eudora S H42,Voters,,,Registered,764
+Douglas,54 C Eudora,Voters,,,Registered,1135
+Douglas,55 Grant S2 H45,Voters,,,Registered,46
+Douglas,55 Grant S3 H46,Voters,,,Registered,66
+Douglas,55 Grant S3 H45,Voters,,,Registered,182
+Douglas,56 Kawaka S19,Voters,,,Registered,1068
+Douglas,56 Kawaka S2,Voters,,,Registered,81
+Douglas,57 Lecompton S2,Voters,,,Registered,699
+Douglas,57 Lecompton S19,Voters,,,Registered,185
+Douglas,58 Big Springs / Lec,Voters,,,Registered,296
+Douglas,59 Marion H45,Voters,,,Registered,271
+Douglas,59 Marion,Voters,,,Registered,341
+Douglas,60 Baldwin NW Palmyra,Voters,,,Registered,1138
+Douglas,61 Baldwin NE Palmyra,Voters,,,Registered,1531
+Douglas,62 Baldwin S Palmyra ,Voters,,,Registered,1333
+Douglas,63 Vinland Palmyra,Voters,,,Registered,879
+Douglas,64 Wakarusa N H45,Voters,,,Registered,296
+Douglas,64 Wakarusa N H46,Voters,,,Registered,1
+Douglas,65 Wakarusa E H10,Voters,,,Registered,555
+Douglas,65 Wakarusa E H46,Voters,,,Registered,43
+Douglas,66 Wakarusa W S19 H45,Voters,,,Registered,275
+Douglas,66 Wakarusa W S3 H45,Voters,,,Registered,3
+Douglas,66 Wakarusa W S19 H10,Voters,,,Registered,347
+Douglas,66 Wakarusa W S3   H10,Voters,,,Registered,213
+Douglas,67 Willow S19  H54,Voters,,,Registered,453
+Douglas,67 Willow S19  H45,Voters,,,Registered,403
+Douglas,67 Willow S3  H45,Voters,,,Registered,126
+Douglas,67 Willow S3  H54,Voters,,,Registered,94
+Douglas,50 Eudora W,Voters,,,Cast,765
+Douglas,51 Clinton,Voters,,,Cast,333
+Douglas,52 Eudora,Voters,,,Cast,327
+Douglas,53 Eudora S H10,Voters,,,Cast,403
+Douglas,53 Eudora S H42,Voters,,,Cast,430
+Douglas,54 C Eudora,Voters,,,Cast,506
+Douglas,55 Grant S2 H45,Voters,,,Cast,28
+Douglas,55 Grant S3 H46,Voters,,,Cast,37
+Douglas,55 Grant S3 H45,Voters,,,Cast,116
+Douglas,56 Kawaka S19,Voters,,,Cast,689
+Douglas,56 Kawaka S2,Voters,,,Cast,49
+Douglas,57 Lecompton S2,Voters,,,Cast,395
+Douglas,57 Lecompton S19,Voters,,,Cast,127
+Douglas,58 Big Springs / Lec,Voters,,,Cast,164
+Douglas,59 Marion H45,Voters,,,Cast,161
+Douglas,59 Marion,Voters,,,Cast,235
+Douglas,60 Baldwin NW Palmyra,Voters,,,Cast,556
+Douglas,61 Baldwin NE Palmyra,Voters,,,Cast,731
+Douglas,62 Baldwin S Palmyra ,Voters,,,Cast,738
+Douglas,63 Vinland Palmyra,Voters,,,Cast,556
+Douglas,64 Wakarusa N H45,Voters,,,Cast,202
+Douglas,64 Wakarusa N H46,Voters,,,Cast,1
+Douglas,65 Wakarusa E H10,Voters,,,Cast,328
+Douglas,65 Wakarusa E H46,Voters,,,Cast,24
+Douglas,66 Wakarusa W S19 H45,Voters,,,Cast,166
+Douglas,66 Wakarusa W S3 H45,Voters,,,Cast,2
+Douglas,66 Wakarusa W S19 H10,Voters,,,Cast,246
+Douglas,66 Wakarusa W S3   H10,Voters,,,Cast,145
+Douglas,67 Willow S19  H54,Voters,,,Cast,272
+Douglas,67 Willow S19  H45,Voters,,,Cast,262
+Douglas,67 Willow S3  H45,Voters,,,Cast,82
+Douglas,67 Willow S3  H54,Voters,,,Cast,47
+Elk,Liberty,Voters,,,Registered,71
+Elk,Busby-Painterhood,Voters,,,Registered,127
+Elk,Longton,Voters,,,Registered,256
+Elk,Oak Valley,Voters,,,Registered,73
+Elk,Union Ctr,Voters,,,Registered,61
+Elk,Howard,Voters,,,Registered,554
+Elk,Flat-Paw Paw,Voters,,,Registered,82
+Elk,Grenola-Greenfield,Voters,,,Registered,66
+Elk,Moline-Wildcat,Voters,,,Registered,355
+Elk,Elk Falls,Voters,,,Registered,138
+Elk,Advance,Voters,,,Registered,0
+Elk,Prov,Voters,,,Registered,0
+Grant,Ward 1,Voters,,,Provisional,5
+Grant,Ward 2,Voters,,,Provisional,10
+Grant,Ward 3,Voters,,,Provisional,22
+Grant,Prec 4,Voters,,,Provisional,14
+Grant,Ward 1,Voters,,,Registered voters,574
+Grant,Ward 2,Voters,,,Registered voters,978
+Grant,Ward 3,Voters,,,Registered voters,1129
+Grant,Prec 4,Voters,,,Registered voters,724
+Grant,Ward 1,Voters,,,Total Votes Cast,192
+Grant,Ward 2,Voters,,,Total Votes Cast,447
+Grant,Ward 3,Voters,,,Total Votes Cast,436
+Grant,Prec 4,Voters,,,Total Votes Cast,325
+Grant,Ward 1,Voters,,,Votes cast at polls,187
+Grant,Ward 2,Voters,,,Votes cast at polls,437
+Grant,Ward 3,Voters,,,Votes cast at polls,414
+Grant,Prec 4,Voters,,,Votes cast at polls,311
+Greeley,MSD,Voters,,,Registered,566,,
+Greeley,GSD,Voters,,,Registered,287,,
+Greeley,HC,Voters,,,Registered,73,,
+Greeley,MSD,Voters,,,Cast,346,,
+Greeley,GSD,Voters,,,Cast,174,,
+Greeley,HC,Voters,,,Cast,56,,
+Jackson,Wd 1,Voters,,,Cast,262,,,
+Jackson,Wd 2,Voters,,,Cast,293,,,
+Jackson,Wd 3,Voters,,,Cast,249,,,
+Jackson,Wd 1,Voters,,,Registered,760,,,
+Jackson,Wd 2,Voters,,,Registered,821,,,
+Jackson,Wd 3,Voters,,,Registered,596,,,
+Jackson,Adrian,Voters,,,Cast,47,,,
+Jackson,Banner,Voters,,,Cast,120,,,
+Jackson,Cedar,Voters,,,Cast,393,,,
+Jackson,Douglas,Voters,,,Cast,765,,,
+Jackson,Franklin,Voters,,,Cast,333,,,
+Jackson,Garfield,Voters,,,Cast,221,,,
+Jackson,Grant,Voters,,,Cast,63,,,
+Jackson,Jefferson,Voters,,,Cast,186,,,
+Jackson,Liberty,Voters,,,Cast,192,,,
+Jackson,Lincoln,Voters,,,Cast,300,,,
+Jackson,Netawaka,Voters,,,Cast,117,,,
+Jackson,Soldier,Voters,,,Cast,138,,,
+Jackson,St. Creek,Voters,,,Cast,44,,,
+Jackson,Washington,Voters,,,Cast,186,,,
+Jackson,Whiting,Voters,,,Cast,129,,,
+Jackson,Advance,Voters,,,Cast,852,,,
+Jackson,Adrian,Voters,,,Registered,106,,,
+Jackson,Banner,Voters,,,Registered,216,,,
+Jackson,Cedar,Voters,,,Registered,900,,,
+Jackson,Douglas,Voters,,,Registered,1580,,,
+Jackson,Franklin,Voters,,,Registered,689,,,
+Jackson,Garfield,Voters,,,Registered,400,,,
+Jackson,Grant,Voters,,,Registered,114,,,
+Jackson,Jefferson,Voters,,,Registered,365,,,
+Jackson,Liberty,Voters,,,Registered,382,,,
+Jackson,Lincoln,Voters,,,Registered,762,,,
+Jackson,Netawaka,Voters,,,Registered,223,,,
+Jackson,Soldier,Voters,,,Registered,263,,,
+Jackson,St. Creek,Voters,,,Registered,116,,,
+Jackson,Washington,Voters,,,Registered,348,,,
+Jackson,Whiting,Voters,,,Registered,257,,,
+Jefferson,Delaware,Voters,,,Registered,1302,,
+Jefferson,East Fairview,Voters,,,Registered,745,,
+Jefferson,Jefferson,Voters,,,Registered,774,,
+Jefferson,Kaw,Voters,,,Registered,944,,
+Jefferson,Kentucky,Voters,,,Registered,1116,,
+Jefferson,Norton,Voters,,,Registered,543,,
+Jefferson,Oskaloosa,Voters,,,Registered,1459,,
+Jefferson,Ozawkie,Voters,,,Registered,1171,,
+Jefferson,Rock Creek,Voters,,,Registered,1848,,
+Jefferson,Rural,Voters,,,Registered,524,,
+Jefferson,Sarcoxie,Voters,,,Registered,800,,
+Jefferson,Union,Voters,,,Registered,1182,,
+Jefferson,West Fairview,Voters,,,Registered,480,,
+Jefferson,JEFFERSON KS,Voters,,,Registered,12888,,
+Jefferson,Delaware,Voters,,,Cast,634,55,579
+Jefferson,East Fairview,Voters,,,Cast,321,38,283
+Jefferson,Jefferson,Voters,,,Cast,348,29,319
+Jefferson,Kaw,Voters,,,Cast,578,51,527
+Jefferson,Kentucky,Voters,,,Cast,605,52,553
+Jefferson,Norton,Voters,,,Cast,290,16,274
+Jefferson,Oskaloosa,Voters,,,Cast,707,96,611
+Jefferson,Ozawkie,Voters,,,Cast,596,68,528
+Jefferson,Rock Creek,Voters,,,Cast,974,78,896
+Jefferson,Rural,Voters,,,Cast,294,48,246
+Jefferson,Sarcoxie,Voters,,,Cast,457,50,407
+Jefferson,Union,Voters,,,Cast,538,46,492
+Jefferson,West Fairview,Voters,,,Cast,282,39,243
+Jefferson,JEFFERSON KS,Voters,,,Cast,6624,666,5958
+Lyon,Emporia 01.01,Voters,,,Registration,800
+Lyon,Emporia 02.01,Voters,,,Registration,676
+Lyon,Emporia 03.01,Voters,,,Registration,808
+Lyon,Emporia 04.01,Voters,,,Registration,877
+Lyon,Emporia 4A.01,Voters,,,Registration,4
+Lyon,Emporia 4B.01,Voters,,,Registration,6
+Lyon,Emporia 4C.01,Voters,,,Registration,6
+Lyon,Emporia 05.01,Voters,,,Registration,668
+Lyon,Emporia 06.01,Voters,,,Registration,717
+Lyon,Emporia 07.01,Voters,,,Registration,434
+Lyon,Emporia 08.01,Voters,,,Registration,796
+Lyon,Emporia 09.01,Voters,,,Registration,553
+Lyon,Emporia 10.01,Voters,,,Registration,544
+Lyon,Emporia 11.01,Voters,,,Registration,539
+Lyon,Emporia 12.01,Voters,,,Registration,480
+Lyon,Emporia 13.01,Voters,,,Registration,755
+Lyon,Emporia 14.01,Voters,,,Registration,753
+Lyon,Emporia 15.01,Voters,,,Registration,426
+Lyon,Emporia 16.01,Voters,,,Registration,715
+Lyon,Emporia 17.01,Voters,,,Registration,698
+Lyon,Emporia 18.01,Voters,,,Registration,569
+Lyon,Emporia 19.01,Voters,,,Registration,952
+Lyon,Emporia 20.01,Voters,,,Registration,760
+Lyon,Precinct 21.01,Voters,,,Registration,298
+Lyon,Precinct 22.01,Voters,,,Registration,148
+Lyon,Precinct 23.01,Voters,,,Registration,197
+Lyon,Precinct 24.01,Voters,,,Registration,921
+Lyon,Precinct 25.01,Voters,,,Registration,641
+Lyon,Precinct 26.01,Voters,,,Registration,315
+Lyon,Precinct 27.01,Voters,,,Registration,571
+Lyon,Precinct 28.01,Voters,,,Registration,477
+Lyon,Precinct 29.01,Voters,,,Registration,220
+Lyon,Precinct 29D.01,Voters,,,Registration,8
+Lyon,Precinct 30.01,Voters,,,Registration,700
+Lyon,Precinct 31.01,Voters,,,Registration,827
+Lyon,Precinct 32.01,Voters,,,Registration,535
+Lyon,Emporia 01.01,Voters,,,Ballots Cast,326
+Lyon,Emporia 02.01,Voters,,,Ballots Cast,227
+Lyon,Emporia 03.01,Voters,,,Ballots Cast,274
+Lyon,Emporia 04.01,Voters,,,Ballots Cast,314
+Lyon,Emporia 4A.01,Voters,,,Ballots Cast,4
+Lyon,Emporia 4B.01,Voters,,,Ballots Cast,2
+Lyon,Emporia 4C.01,Voters,,,Ballots Cast,5
+Lyon,Emporia 05.01,Voters,,,Ballots Cast,181
+Lyon,Emporia 06.01,Voters,,,Ballots Cast,212
+Lyon,Emporia 07.01,Voters,,,Ballots Cast,91
+Lyon,Emporia 08.01,Voters,,,Ballots Cast,204
+Lyon,Emporia 09.01,Voters,,,Ballots Cast,207
+Lyon,Emporia 10.01,Voters,,,Ballots Cast,274
+Lyon,Emporia 11.01,Voters,,,Ballots Cast,205
+Lyon,Emporia 12.01,Voters,,,Ballots Cast,219
+Lyon,Emporia 13.01,Voters,,,Ballots Cast,310
+Lyon,Emporia 14.01,Voters,,,Ballots Cast,436
+Lyon,Emporia 15.01,Voters,,,Ballots Cast,236
+Lyon,Emporia 16.01,Voters,,,Ballots Cast,360
+Lyon,Emporia 17.01,Voters,,,Ballots Cast,359
+Lyon,Emporia 18.01,Voters,,,Ballots Cast,330
+Lyon,Emporia 19.01,Voters,,,Ballots Cast,541
+Lyon,Emporia 20.01,Voters,,,Ballots Cast,466
+Lyon,Precinct 21.01,Voters,,,Ballots Cast,155
+Lyon,Precinct 22.01,Voters,,,Ballots Cast,98
+Lyon,Precinct 23.01,Voters,,,Ballots Cast,110
+Lyon,Precinct 24.01,Voters,,,Ballots Cast,478
+Lyon,Precinct 25.01,Voters,,,Ballots Cast,400
+Lyon,Precinct 26.01,Voters,,,Ballots Cast,191
+Lyon,Precinct 27.01,Voters,,,Ballots Cast,282
+Lyon,Precinct 28.01,Voters,,,Ballots Cast,271
+Lyon,Precinct 29.01,Voters,,,Ballots Cast,139
+Lyon,Precinct 29D.01,Voters,,,Ballots Cast,3
+Lyon,Precinct 30.01,Voters,,,Ballots Cast,383
+Lyon,Precinct 31.01,Voters,,,Ballots Cast,502
+Lyon,Precinct 32.01,Voters,,,Ballots Cast,276
+Marshall,Advance Voters,U.S. Senate,,IND,Greg Orman,453
+Marshall,Advance Voters,U.S. Senate,,R,Pat Roberts,482
+Marshall,Advance Voters,U.S. Senate,,LBT,Randall Batson,25
+Marshall,Advance Voters,U.S. House,1,R,Tim Huelskamp,348
+Marshall,Advance Voters,U.S. House,1,D,Jim Sherow,296
+Marshall,Advance Voters,U.S. House,2,R,Lynn Jenkins,188
+Marshall,Advance Voters,U.S. House,2,D,Margie Wakefield,112
+Marshall,Advance Voters,U.S. House,2,LBT,Christopher Clemmons,10
+Marshall,Advance Voters,Governor,,D,Paul Davis,495
+Marshall,Advance Voters,Governor,,LBT,Keen Umbehr,31
+Marshall,Advance Voters,Governor,,R,Sam Brownback,442
+Marshall,Advance Voters,Secretary of State,,D,Jean Schodorf,396
+Marshall,Advance Voters,Secretary of State,,R,Kris Kobach,553
+Marshall,Advance Voters,Attorney General,,R,Derek Schmidt,619
+Marshall,Advance Voters,Attorney General,,D,A.J. Kotich,314
+Marshall,Advance Voters,State Treasurer,,R,Ron Estes,589
+Marshall,Advance Voters,State Treasurer,,D,Carmen Alldritt,335
+Marshall,Advance Voters,Insurance Commissioner,,R,Ken Selzer,538
+Marshall,Advance Voters,Insurance Commissioner,,D,Dennis Anderson,372
+Marshall,Advance Voters,State House,106,R,Schwartz,763
+Miami,EMC(2),Voters,,,Registered,178,,
+Miami,EMC(3),Voters,,,Registered,588,,
+Miami,EV,Voters,,,Registered,300,,
+Miami,FC,Voters,,,Registered,104,,
+Miami,LC 01,Voters,,,Registered,564,,
+Miami,LC 02,Voters,,,Registered,725,,
+Miami,LC 03,Voters,,,Registered,705,,
+Miami,LC 04,Voters,,,Registered,657,,
+Miami,MI,Voters,,,Registered,380,,
+Miami,MND,Voters,,,Registered,477,,
+Miami,NMV(2),Voters,,,Registered,190,,
+Miami,NMV(3),Voters,,,Registered,555,,
+Miami,NPW,Voters,,,Registered,328,,
+Miami,NPE Prt1,Voters,,,Registered,14,,
+Miami,NPE Prt2,Voters,,,Registered,105,,
+Miami,NW,Voters,,,Registered,457,,
+Miami,OSAGE,Voters,,,Registered,312,,
+Miami,OC 01,Voters,,,Registered,468,,
+Miami,OC 02,Voters,,,Registered,593,,
+Miami,OC 03,Voters,,,Registered,633,,
+Miami,OC 04,Voters,,,Registered,481,,
+Miami,OSA TWP,Voters,,,Registered,481,,
+Miami,PC 01,Voters,,,Registered,846,,
+Miami,PC 02,Voters,,,Registered,836,,
+Miami,PC 03,Voters,,,Registered,842,,
+Miami,PC 04,Voters,,,Registered,943,,
+Miami,RICH,Voters,,,Registered,1413,,
+Miami,SMV(3),Voters,,,Registered,21,,
+Miami,SMV(2),Voters,,,Registered,950,,
+Miami,SPE Prt2,Voters,,,Registered,136,,
+Miami,SPW,Voters,,,Registered,220,,
+Miami,SW,Voters,,,Registered,996,,
+Miami,SH 01,Voters,,,Registered,1107,,
+Miami,SH 02,Voters,,,Registered,292,,
+Miami,SH 03,Voters,,,Registered,69,,
+Miami,STAN 368,Voters,,,Registered,439,,
+Miami,STAN 367,Voters,,,Registered,194,,
+Miami,SC,Voters,,,Registered,319,,
+Miami,TM,Voters,,,Registered,1007,,
+Miami,WMC 416,Voters,,,Registered,139,,
+Miami,WMC 368,Voters,,,Registered,394,,
+Miami,WV(6),Voters,,,Registered,184,,
+Miami,WV(12) 368,Voters,,,Registered,95,,
+Miami,WV(12) 367,Voters,,,Registered,187,,
+Miami,WV(5),Voters,,,Registered,201,,
+Miami,EMC(2),Voters,,,Cast,92,,
+Miami,EMC(3),Voters,,,Cast,336,,
+Miami,EV,Voters,,,Cast,177,,
+Miami,FC,Voters,,,Cast,46,,
+Miami,LC 01,Voters,,,Cast,269,,
+Miami,LC 02,Voters,,,Cast,338,,
+Miami,LC 03,Voters,,,Cast,332,,
+Miami,LC 04,Voters,,,Cast,319,,
+Miami,MI,Voters,,,Cast,219,,
+Miami,MND,Voters,,,Cast,249,,
+Miami,NMV(2),Voters,,,Cast,108,,
+Miami,NMV(3),Voters,,,Cast,309,,
+Miami,NPW,Voters,,,Cast,187,,
+Miami,NPE Prt1,Voters,,,Cast,9,,
+Miami,NPE Prt2,Voters,,,Cast,70,,
+Miami,NW,Voters,,,Cast,265,,
+Miami,OSAGE,Voters,,,Cast,173,,
+Miami,OC 01,Voters,,,Cast,172,,
+Miami,OC 02,Voters,,,Cast,278,,
+Miami,OC 03,Voters,,,Cast,299,,
+Miami,OC 04,Voters,,,Cast,153,,
+Miami,OSA TWP,Voters,,,Cast,260,,
+Miami,PC 01,Voters,,,Cast,403,,
+Miami,PC 02,Voters,,,Cast,319,,
+Miami,PC 03,Voters,,,Cast,402,,
+Miami,PC 04,Voters,,,Cast,451,,
+Miami,RICH,Voters,,,Cast,764,,
+Miami,SMV(3),Voters,,,Cast,7,,
+Miami,SMV(2),Voters,,,Cast,523,,
+Miami,SPE Prt2,Voters,,,Cast,74,,
+Miami,SPW,Voters,,,Cast,113,,
+Miami,SW,Voters,,,Cast,591,,
+Miami,SH 01,Voters,,,Cast,454,,
+Miami,SH 02,Voters,,,Cast,137,,
+Miami,SH 03,Voters,,,Cast,39,,
+Miami,STAN 368,Voters,,,Cast,214,,
+Miami,STAN 367,Voters,,,Cast,106,,
+Miami,SC,Voters,,,Cast,173,,
+Miami,TM,Voters,,,Cast,559,,
+Miami,WMC 416,Voters,,,Cast,65,,
+Miami,WMC 368,Voters,,,Cast,215,,
+Miami,WV(6),Voters,,,Cast,97,,
+Miami,WV(12) 368,Voters,,,Cast,46,,
+Miami,WV(12) 367,Voters,,,Cast,119,,
+Miami,WV(5),Voters,,,Cast,96,,
+Montgomery,CANEY W1P1,Voters,,,,116
+Montgomery,CANEY W1P2 H12,Voters,,,,4
+Montgomery,CANEY W2P1,Voters,,,,101
+Montgomery,CANEY W3P1,Voters,,,,121
+Montgomery,CANEY W3P2,Voters,,,,2
+Montgomery,CANEY W4P1,Voters,,,,142
+Montgomery,CANEY W4P2,Voters,,,,1
+Montgomery,CHERRYVALE 1,Voters,,,,303
+Montgomery,CHERRYVALE 2,Voters,,,,233
+Montgomery,COFFEYVILLE 1,Voters,,,,27
+Montgomery,COFFEYVILLE 2,Voters,,,,81
+Montgomery,COFFEYVILLE 3,Voters,,,,123
+Montgomery,COFFEYVILLE 4,Voters,,,,150
+Montgomery,COFFEYVILLE 5,Voters,,,,193
+Montgomery,COFFEYVILLE 6,Voters,,,,59
+Montgomery,COFFEYVILLE 7,Voters,,,,77
+Montgomery,COFFEYVILLE 8,Voters,,,,105
+Montgomery,COFFEYVILLE 9,Voters,,,,34
+Montgomery,COFFEYVILLE 10,Voters,,,,105
+Montgomery,COFFEYVILLE 11,Voters,,,,266
+Montgomery,COFFEYVILLE 12,Voters,,,,375
+Montgomery,COFFEYVILLE 13,Voters,,,,324
+Montgomery,INDEPENDENCE W1P1,Voters,,,,109
+Montgomery,INDEPENDENCE W1P2,Voters,,,,197
+Montgomery,INDEPENDENCE W2P1,Voters,,,,81
+Montgomery,INDEPENDENCE W2P2,Voters,,,,64
+Montgomery,INDEPENDENCE W3P1,Voters,,,,158
+Montgomery,INDEPENDENCE W3P2,Voters,,,,87
+Montgomery,INDEPENDENCE W3P2 EX,Voters,,,,1
+Montgomery,INDEPENDENCE W4P1,Voters,,,,175
+Montgomery,INDEPENDENCE W4P2,Voters,,,,110
+Montgomery,INDEPENDENCE W5P1,Voters,,,,106
+Montgomery,INDEPENDENCE W5P2,Voters,,,,211
+Montgomery,INDEPENDENCE W6P1 H11,Voters,,,,21
+Montgomery,INDEPENDENCE W6P1 H12,Voters,,,,286
+Montgomery,INDEPENDENCE W6P2 H11,Voters,,,,232
+Montgomery,INDEPENDENCE W6P2 H12,Voters,,,,74
+Montgomery,INDEPENDENCE W6P2 H11A,Voters,,,,111
+Montgomery,INDEPENDENCE W6P2 H12A,Voters,,,,9
+Montgomery,CANEY-HAVANA,Voters,,,,201
+Montgomery,CANEY-TYRO,Voters,,,,240
+Montgomery,CHEROKEE,Voters,,,,133
+Montgomery,CHERRY,Voters,,,,204
+Montgomery,DRUM CREEK ,Voters,,,,207
+Montgomery,FAWN CREEK-DEARING,Voters,,,,533
+Montgomery,FAWN CREEK-TYRO,Voters,,,,150
+Montgomery,INDEPENDENCE TWP 1 H11,Voters,,,,532
+Montgomery,INDEPENDENCE TWP 1 H12,Voters,,,,102
+Montgomery,INDEPENDENCE TWP 2 A H12,Voters,,,,136
+Montgomery,INDEPENDENCE TWP 2 C H11,Voters,,,,40
+Montgomery,LIBERTY,Voters,,,,185
+Montgomery,LOUISBURG,Voters,,,,175
+Montgomery,PARKER 1,Voters,,,,93
+Montgomery,PARKER 2,Voters,,,,308
+Montgomery,PARKER 2 EX H11,Voters,,,,10
+Montgomery,RUTLAND,Voters,,,,132
+Montgomery,SYCAMORE,Voters,,,,340
+Montgomery,WEST CHERRY,Voters,,,,103
+Osage,09 Grant Township,Voters,,,Ballots Cast,119
+Osage,01 Agency Township,Voters,,,Ballots Cast,154
+Osage,02 Arvonia Township,Voters,,,Ballots Cast,56
+Osage,03 Barclay Township,Voters,,,Ballots Cast,83
+Osage,06 Dragoon Township,Voters,,,Ballots Cast,96
+Osage,07 Elk Township,Voters,,,Ballots Cast,747
+Osage,08 Fairfax Township,Voters,,,Ballots Cast,255
+Osage,12 Lincoln Township,Voters,,,Ballots Cast,43
+Osage,13 Melvern Township,Voters,,,Ballots Cast,248
+Osage,10 Michigan Valley Township,Voters,,,Ballots Cast,167
+Osage,04 North Burlingame,Voters,,,Ballots Cast,351
+Osage,15 North Ridgeway,Voters,,,Ballots Cast,435
+Osage,19 North Valleybrook,Voters,,,Ballots Cast,397
+Osage,14 Olivet Township,Voters,,,Ballots Cast,93
+Osage,21 Osage City Ward 1,Voters,,,Ballots Cast,286
+Osage,22 Osage City Ward 2,Voters,,,Ballots Cast,156
+Osage,23 Osage City Ward 3,Voters,,,Ballots Cast,202
+Osage,24 Osage City Ward 4,Voters,,,Ballots Cast,262
+Osage,17 Scranton Township,Voters,,,Ballots Cast,369
+Osage,05 South Burlingame,Voters,,,Ballots Cast,311
+Osage,16 South Ridgeway,Voters,,,Ballots Cast,421
+Osage,20 South Valleybrook,Voters,,,Ballots Cast,166
+Osage,18 Superior Township,Voters,,,Ballots Cast,127
+Osage,11 Vassar Township,Voters,,,Ballots Cast,302
+Reno,CITY #01-H102,Voters,,,Ballots,138,38,100
+Reno,CITY #01-HII4,Voters,,,Ballots,8,3,5
+Reno,CITY #02,Voters,,,Ballots,119,36,83
+Reno,CITY #03,Voters,,,Ballots,77,25,52
+Reno,CITY #04,Voters,,,Ballots,717,281,436
+Reno,CITY #05,Voters,,,Ballots,247,76,171
+Reno,CITY #06,Voters,,,Ballots,228,71,157
+Reno,CITY #07,Voters,,,Ballots,328,98,230
+Reno,CITY #08,Voters,,,Ballots,167,52,115
+Reno,CITY #09,Voters,,,Ballots,491,198,293
+Reno,CITY #10,Voters,,,Ballots,612,152,460
+Reno,CITY #11,Voters,,,Ballots,619,203,416
+Reno,CITY #12,Voters,,,Ballots,342,106,236
+Reno,CITY #13,Voters,,,Ballots,393,95,298
+Reno,CITY #14,Voters,,,Ballots,280,72,208
+Reno,CITY #15,Voters,,,Ballots,167,54,113
+Reno,CITY #16,Voters,,,Ballots,335,83,252
+Reno,CITY #17,Voters,,,Ballots,450,146,304
+Reno,CITY #18,Voters,,,Ballots,149,50,99
+Reno,CITY #19,Voters,,,Ballots,163,42,121
+Reno,CITY #20,Voters,,,Ballots,266,60,206
+Reno,CITY #21,Voters,,,Ballots,221,57,164
+Reno,CITY #22,Voters,,,Ballots,511,181,330
+Reno,CITY #23,Voters,,,Ballots,710,286,424
+Reno,CITY #23 EX,Voters,,,Ballots,144,38,106
+Reno,CITY #24,Voters,,,Ballots,456,131,325
+Reno,CITY #25,Voters,,,Ballots,201,60,141
+Reno,CITY #26,Voters,,,Ballots,140,45,95
+Reno,CITY #26 EX,Voters,,,Ballots,28,8,20
+Reno,CITY #27,Voters,,,Ballots,303,87,216
+Reno,CITY #28,Voters,,,Ballots,679,175,504
+Reno,CITY #28 EX,Voters,,,Ballots,347,118,229
+Reno,CITY #29,Voters,,,Ballots,316,104,212
+Reno,CITY #30,Voters,,,Ballots,136,39,97
+Reno,CITY #31,Voters,,,Ballots,281,98,183
+Reno,CITY #32,Voters,,,Ballots,102,29,73
+Reno,CITY #33,Voters,,,Ballots,169,36,133
+Reno,CITY #34,Voters,,,Ballots,50,16,34
+Reno,CITY #34 EX,Voters,,,Ballots,1,0,1
+Reno,CITY #35,Voters,,,Ballots,149,31,118
+Reno,CITY #01-H102,Voters,,,Registered,545,545,545
+Reno,CITY #01-HII4,Voters,,,Registered,33,33,33
+Reno,CITY #02,Voters,,,Registered,551,551,551
+Reno,CITY #03,Voters,,,Registered,327,327,327
+Reno,CITY #04,Voters,,,Registered,1171,1171,1171
+Reno,CITY #05,Voters,,,Registered,878,878,878
+Reno,CITY #06,Voters,,,Registered,681,681,681
+Reno,CITY #07,Voters,,,Registered,844,844,844
+Reno,CITY #08,Voters,,,Registered,370,370,370
+Reno,CITY #09,Voters,,,Registered,1009,1009,1009
+Reno,CITY #10,Voters,,,Registered,1026,1026,1026
+Reno,CITY #11,Voters,,,Registered,1052,1052,1052
+Reno,CITY #12,Voters,,,Registered,719,719,719
+Reno,CITY #13,Voters,,,Registered,807,807,807
+Reno,CITY #14,Voters,,,Registered,705,705,705
+Reno,CITY #15,Voters,,,Registered,691,691,691
+Reno,CITY #16,Voters,,,Registered,984,984,984
+Reno,CITY #17,Voters,,,Registered,864,864,864
+Reno,CITY #18,Voters,,,Registered,465,465,465
+Reno,CITY #19,Voters,,,Registered,552,552,552
+Reno,CITY #20,Voters,,,Registered,753,753,753
+Reno,CITY #21,Voters,,,Registered,1250,1250,1250
+Reno,CITY #22,Voters,,,Registered,1043,1043,1043
+Reno,CITY #23,Voters,,,Registered,1316,1316,1316
+Reno,CITY #23 EX,Voters,,,Registered,257,257,257
+Reno,CITY #24,Voters,,,Registered,847,847,847
+Reno,CITY #25,Voters,,,Registered,843,843,843
+Reno,CITY #26,Voters,,,Registered,366,366,366
+Reno,CITY #26 EX,Voters,,,Registered,87,87,87
+Reno,CITY #27,Voters,,,Registered,635,635,635
+Reno,CITY #28,Voters,,,Registered,1203,1203,1203
+Reno,CITY #28 EX,Voters,,,Registered,517,517,517
+Reno,CITY #29,Voters,,,Registered,576,576,576
+Reno,CITY #30,Voters,,,Registered,448,448,448
+Reno,CITY #31,Voters,,,Registered,676,676,676
+Reno,CITY #32,Voters,,,Registered,152,152,152
+Reno,CITY #33,Voters,,,Registered,249,249,249
+Reno,CITY #34,Voters,,,Registered,141,141,141
+Reno,CITY #34 EX,Voters,,,Registered,1,1,1
+Reno,CITY #35,Voters,,,Registered,360,360,360
+Reno,Albion twp,Voters,,,Ballots,330,33,297
+Reno,Arlington twp,Voters,,,Ballots,186,23,163
+Reno,Bell twp,Voters,,,Ballots,34,4,30
+Reno,Castleton twp,Voters,,,Ballots,125,16,109
+Reno,Center twp,Voters,,,Ballots,135,17,118
+Reno,Clay N twp,Voters,,,Ballots,393,92,301
+Reno,Clay S 101 twp,Voters,,,Ballots,378,68,310
+Reno,Clay S H102A twp,Voters,,,Ballots,8,4,4
+Reno,Enterprise twp,Voters,,,Ballots,63,8,55
+Reno,Grant twp,Voters,,,Ballots,629,127,502
+Reno,Grove twp,Voters,,,Ballots,21,2,19
+Reno,Haven twp,Voters,,,Ballots,571,58,513
+Reno,Hayes twp,Voters,,,Ballots,30,11,19
+Reno,Huntsville twp,Voters,,,Ballots,50,5,45
+Reno,Langdon twp,Voters,,,Ballots,44,5,39
+Reno,Lincoln twp,Voters,,,Ballots,155,14,141
+Reno,Little River twp,Voters,,,Ballots,806,132,674
+Reno,Loda twp,Voters,,,Ballots,42,9,33
+Reno,Medford twp,Voters,,,Ballots,63,10,53
+Reno,Medora twp,Voters,,,Ballots,670,145,525
+Reno,Miami twp,Voters,,,Ballots,119,14,105
+Reno,Nickerson Ward #1,Voters,,,Ballots,130,17,113
+Reno,Nickerson Ward #2,Voters,,,Ballots,73,12,61
+Reno,Nickerson Ward #3,Voters,,,Ballots,88,20,68
+Reno,Ninnescah twp,Voters,,,Ballots,78,15,63
+Reno,Plevna twp,Voters,,,Ballots,98,11,87
+Reno,Reno N twp,Voters,,,Ballots,564,124,440
+Reno,Reno S twp,Voters,,,Ballots,107,14,93
+Reno,Roscoe twp,Voters,,,Ballots,42,4,38
+Reno,S Hutchinson #1,Voters,,,Ballots,158,34,124
+Reno,S Hutchinson #2,Voters,,,Ballots,329,56,273
+Reno,S Hutchinson #3,Voters,,,Ballots,275,37,238
+Reno,Salt Creek twp,Voters,,,Ballots,142,15,127
+Reno,Sumner twp,Voters,,,Ballots,234,16,218
+Reno,Sylvia twp,Voters,,,Ballots,104,13,91
+Reno,Troy twp,Voters,,,Ballots,53,8,45
+Reno,Valley twp,Voters,,,Ballots,317,90,227
+Reno,Walnut twp,Voters,,,Ballots,54,11,43
+Reno,Westminster twp,Voters,,,Ballots,91,8,83
+Reno,Yoder twp,Voters,,,Ballots,202,31,171
+Reno,Albion twp,Voters,,,Registered,607,607,607
+Reno,Arlington twp,Voters,,,Registered,393,393,393
+Reno,Bell twp,Voters,,,Registered,56,56,56
+Reno,Castleton twp,Voters,,,Registered,201,201,201
+Reno,Center twp,Voters,,,Registered,305,305,305
+Reno,Clay N twp,Voters,,,Registered,662,662,662
+Reno,Clay S 101 twp,Voters,,,Registered,749,749,749
+Reno,Clay S H102A twp,Voters,,,Registered,6,6,6
+Reno,Enterprise twp,Voters,,,Registered,92,92,92
+Reno,Grant twp,Voters,,,Registered,1070,1070,1070
+Reno,Grove twp,Voters,,,Registered,33,33,33
+Reno,Haven twp,Voters,,,Registered,1110,1110,1110
+Reno,Hayes twp,Voters,,,Registered,63,63,63
+Reno,Huntsville twp,Voters,,,Registered,81,81,81
+Reno,Langdon twp,Voters,,,Registered,100,100,100
+Reno,Lincoln twp,Voters,,,Registered,329,329,329
+Reno,Little River twp,Voters,,,Registered,1276,1276,1276
+Reno,Loda twp,Voters,,,Registered,70,70,70
+Reno,Medford twp,Voters,,,Registered,106,106,106
+Reno,Medora twp,Voters,,,Registered,1092,1092,1092
+Reno,Miami twp,Voters,,,Registered,282,282,282
+Reno,Nickerson Ward #1,Voters,,,Registered,298,298,298
+Reno,Nickerson Ward #2,Voters,,,Registered,192,192,192
+Reno,Nickerson Ward #3,Voters,,,Registered,227,227,227
+Reno,Ninnescah twp,Voters,,,Registered,163,163,163
+Reno,Plevna twp,Voters,,,Registered,172,172,172
+Reno,Reno N twp,Voters,,,Registered,1108,1108,1108
+Reno,Reno S twp,Voters,,,Registered,199,199,199
+Reno,Roscoe twp,Voters,,,Registered,82,82,82
+Reno,S Hutchinson #1,Voters,,,Registered,468,468,468
+Reno,S Hutchinson #2,Voters,,,Registered,691,691,691
+Reno,S Hutchinson #3,Voters,,,Registered,442,442,442
+Reno,Salt Creek twp,Voters,,,Registered,250,250,250
+Reno,Sumner twp,Voters,,,Registered,377,377,377
+Reno,Sylvia twp,Voters,,,Registered,214,214,214
+Reno,Troy twp,Voters,,,Registered,82,82,82
+Reno,Valley twp,Voters,,,Registered,579,579,579
+Reno,Walnut twp,Voters,,,Registered,69,69,69
+Reno,Westminster twp,Voters,,,Registered,156,156,156
+Reno,Yoder twp,Voters,,,Registered,387,387,387
+Riley,W1P1,Voters,,,Registered,1234,RI01
+Riley,W2P1,Voters,,,Registered,1346,RI02
+Riley,W2P2,Voters,,,Registered,524,RI03
+Riley,W2P3,Voters,,,Registered,1862,RI04
+Riley,W2P4,Voters,,,Registered,1112,RI05
+Riley,W3P2,Voters,,,Registered,906,RI06
+Riley,W3P3,Voters,,,Registered,1603,RI07
+Riley,W4P2,Voters,,,Registered,334,RI08
+Riley,W4P3,Voters,,,Registered,961,RI09
+Riley,W4P4,Voters,,,Registered,1648,RI10
+Riley,W4P5,Voters,,,Registered,992,RI11
+Riley,W4P6,Voters,,,Registered,431,RI12
+Riley,W4P7,Voters,,,Registered,52,RI13
+Riley,W5P2,Voters,,,Registered,1210,RI14
+Riley,W5P3,Voters,,,Registered,1388,RI15
+Riley,W5P5,Voters,,,Registered,634,RI16
+Riley,W5P6,Voters,,,Registered,1066,RI17
+Riley,W5P7,Voters,,,Registered,472,RI18
+Riley,W5P8,Voters,,,Registered,672,RI19
+Riley,W5P9,Voters,,,Registered,1656,RI20
+Riley,W5P10,Voters,,,Registered,1658,RI21
+Riley,W5P11,Voters,,,Registered,1958,RI22
+Riley,W6P1,Voters,,,Registered,49,RI23
+Riley,W8P1,Voters,,,Registered,438,RI24
+Riley,W8P2,Voters,,,Registered,8,RI25
+Riley,W8P3,Voters,,,Registered,640,RI26
+Riley,W9P1,Voters,,,Registered,165,RI27
+Riley,W9P2,Voters,,,Registered,149,RI28
+Riley,W9P3,Voters,,,Registered,67,RI29
+Riley,W10P1,Voters,,,Registered,65,RI30
+Riley,W11P1,Voters,,,Registered,449,RI31
+Riley,W11P1B,Voters,,,Registered,259,RI32
+Riley,W11P3,Voters,,,Registered,50,RI33
+Riley,Ashland,Voters,,,Registered,117,RI34
+Riley,Bala,Voters,,,Registered,445,RI35
+Riley,Center,Voters,,,Registered,54,RI36
+Riley,Fancy Creek,Voters,,,Registered,73,RI37
+Riley,Grant ,Voters,,,Registered,731,RI38
+Riley,Jackson,Voters,,,Registered,221,RI39
+Riley,Madison H64,Voters,,,Registered,718,RI40
+Riley,Madison H67,Voters,,,Registered,24,RI41
+Riley,Man twp 1,Voters,,,Registered,417,RI42
+Riley,Man twp 2,Voters,,,Registered,395,RI43
+Riley,Man twp 3,Voters,,,Registered,150,RI44
+Riley,Man twp 4,Voters,,,Registered,530,RI45
+Riley,May Day,Voters,,,Registered,53,RI46
+Riley,Ogden,Voters,,,Registered,292,RI47
+Riley,Ogden/Ft Ril A,Voters,,,Registered,929,RI48
+Riley,Sherman,Voters,,,Registered,421,RI49
+Riley,Swede Creek,Voters,,,Registered,93,RI50
+Riley,Wildcat,Voters,,,Registered,636,RI51
+Riley,Zeandale,Voters,,,Registered,274,RI52
+Riley,Mad/Ft Ril A,Voters,,,Registered,602,RI53
+Riley,Mad/Ft Ril B,Voters,,,Registered,340,RI54
+Riley,W1P1,Voters,,,Cast,482,RI01
+Riley,W2P1,Voters,,,Cast,404,RI02
+Riley,W2P2,Voters,,,Cast,193,RI03
+Riley,W2P3,Voters,,,Cast,856,RI04
+Riley,W2P4,Voters,,,Cast,461,RI05
+Riley,W3P2,Voters,,,Cast,198,RI06
+Riley,W3P3,Voters,,,Cast,507,RI07
+Riley,W4P2,Voters,,,Cast,207,RI08
+Riley,W4P3,Voters,,,Cast,499,RI09
+Riley,W4P4,Voters,,,Cast,955,RI10
+Riley,W4P5,Voters,,,Cast,492,RI11
+Riley,W4P6,Voters,,,Cast,243,RI12
+Riley,W4P7,Voters,,,Cast,14,RI13
+Riley,W5P2,Voters,,,Cast,454,RI14
+Riley,W5P3,Voters,,,Cast,452,RI15
+Riley,W5P5,Voters,,,Cast,255,RI16
+Riley,W5P6,Voters,,,Cast,629,RI17
+Riley,W5P7,Voters,,,Cast,247,RI18
+Riley,W5P8,Voters,,,Cast,389,RI19
+Riley,W5P9,Voters,,,Cast,1018,RI20
+Riley,W5P10,Voters,,,Cast,981,RI21
+Riley,W5P11,Voters,,,Cast,1008,RI22
+Riley,W6P1,Voters,,,Cast,2,RI23
+Riley,W8P1,Voters,,,Cast,139,RI24
+Riley,W8P2,Voters,,,Cast,1,RI25
+Riley,W8P3,Voters,,,Cast,163,RI26
+Riley,W9P1,Voters,,,Cast,92,RI27
+Riley,W9P2,Voters,,,Cast,116,RI28
+Riley,W9P3,Voters,,,Cast,37,RI29
+Riley,W10P1,Voters,,,Cast,34,RI30
+Riley,W11P1,Voters,,,Cast,119,RI31
+Riley,W11P1B,Voters,,,Cast,100,RI32
+Riley,W11P3,Voters,,,Cast,22,RI33
+Riley,Ashland,Voters,,,Cast,99,RI34
+Riley,Bala,Voters,,,Cast,270,RI35
+Riley,Center,Voters,,,Cast,40,RI36
+Riley,Fancy Creek,Voters,,,Cast,57,RI37
+Riley,Grant ,Voters,,,Cast,524,RI38
+Riley,Jackson,Voters,,,Cast,129,RI39
+Riley,Madison H64,Voters,,,Cast,406,RI40
+Riley,Madison H67,Voters,,,Cast,15,RI41
+Riley,Man twp 1,Voters,,,Cast,242,RI42
+Riley,Man twp 2,Voters,,,Cast,263,RI43
+Riley,Man twp 3,Voters,,,Cast,91,RI44
+Riley,Man twp 4,Voters,,,Cast,223,RI45
+Riley,May Day,Voters,,,Cast,35,RI46
+Riley,Ogden,Voters,,,Cast,163,RI47
+Riley,Ogden/Ft Ril A,Voters,,,Cast,252,RI48
+Riley,Sherman,Voters,,,Cast,245,RI49
+Riley,Swede Creek,Voters,,,Cast,62,RI50
+Riley,Wildcat,Voters,,,Cast,421,RI51
+Riley,Zeandale,Voters,,,Cast,181,RI52
+Riley,Mad/Ft Ril A,Voters,,,Cast,11,RI53
+Riley,Mad/Ft Ril B,Voters,,,Cast,8,RI54
+Rush,Alexander - Belle Prairie Township,Voters,,,Registered,89
+Rush,Banner Township,Voters,,,Registered,105
+Rush,Big Timber Township,Voters,,,Registered,116
+Rush,Brookdale,Voters,,,Registered,388
+Rush,Center Township,Voters,,,Registered,192
+Rush,Garfield Township,Voters,,,Registered,88
+Rush,Hampton - Fairview Township,Voters,,,Registered,193
+Rush,Illinois Township,Voters,,,Registered,40
+Rush,LaCrosse,Voters,,,Registered,596
+Rush,Lone Star Township,Voters,,,Registered,201
+Rush,Pioneer Township,Voters,,,Registered,227
+Rush,Pleasantdale Township,Voters,,,Registered,22
+Rush,Union Township,Voters,,,Registered,41
+Russell,Gorham City /Big Creek Township,Voters,,,Cast,175
+Russell,Center Township,Voters,,,Cast,136
+Russell,Fairfield Township,Voters,,,Cast,16
+Russell,Lucas City / Fairview Township,Voters,,,Cast,191
+Russell,Grant Township,Voters,,,Cast,88
+Russell,Lincoln Township,Voters,,,Cast,61
+Russell,Luray City / Luray Township,Voters,,,Cast,110
+Russell,Paradise City / Paradise Township,Voters,,,Cast,80
+Russell,Dorrance City / Plymouth Township,Voters,,,Cast,107
+Russell,Russell Township,Voters,,,Cast,45
+Russell,Russell Ward 1,Voters,,,Cast,344
+Russell,Russell Ward 2,Voters,,,Cast,450
+Russell,Russell Ward 3,Voters,,,Cast,365
+Russell,Russell Ward 4,Voters,,,Cast,370
+Russell,Waldo City / Waldo Township,Voters,,,Cast,42
+Russell,Winterset Township,Voters,,,Cast,40
+Sedgwick,101,Voters,,,Registered,1727
+Sedgwick,102,Voters,,,Registered,1126
+Sedgwick,103,Voters,,,Registered,193
+Sedgwick,104,Voters,,,Registered,96
+Sedgwick,105,Voters,,,Registered,983
+Sedgwick,106,Voters,,,Registered,2097
+Sedgwick,107,Voters,,,Registered,1785
+Sedgwick,108,Voters,,,Registered,1263
+Sedgwick,109,Voters,,,Registered,1848
+Sedgwick,110,Voters,,,Registered,1721
+Sedgwick,111,Voters,,,Registered,446
+Sedgwick,112,Voters,,,Registered,1739
+Sedgwick,113,Voters,,,Registered,1551
+Sedgwick,114,Voters,,,Registered,1503
+Sedgwick,116,Voters,,,Registered,2122
+Sedgwick,117,Voters,,,Registered,1855
+Sedgwick,118,Voters,,,Registered,1666
+Sedgwick,119,Voters,,,Registered,1444
+Sedgwick,120,Voters,,,Registered,1408
+Sedgwick,121,Voters,,,Registered,1088
+Sedgwick,122,Voters,,,Registered,2258
+Sedgwick,123,Voters,,,Registered,558
+Sedgwick,124,Voters,,,Registered,1
+Sedgwick,127,Voters,,,Registered,409
+Sedgwick,128,Voters,,,Registered,1363
+Sedgwick,129,Voters,,,Registered,518
+Sedgwick,130,Voters,,,Registered,1035
+Sedgwick,205,Voters,,,Registered,735
+Sedgwick,206,Voters,,,Registered,595
+Sedgwick,207,Voters,,,Registered,2888
+Sedgwick,208,Voters,,,Registered,536
+Sedgwick,209,Voters,,,Registered,1467
+Sedgwick,210,Voters,,,Registered,1923
+Sedgwick,211,Voters,,,Registered,929
+Sedgwick,212,Voters,,,Registered,1512
+Sedgwick,213,Voters,,,Registered,1788
+Sedgwick,214,Voters,,,Registered,1722
+Sedgwick,215,Voters,,,Registered,2367
+Sedgwick,216,Voters,,,Registered,1472
+Sedgwick,217,Voters,,,Registered,1751
+Sedgwick,218,Voters,,,Registered,2626
+Sedgwick,221,Voters,,,Registered,1081
+Sedgwick,222,Voters,,,Registered,1609
+Sedgwick,223,Voters,,,Registered,1845
+Sedgwick,224,Voters,,,Registered,2591
+Sedgwick,225,Voters,,,Registered,2374
+Sedgwick,226,Voters,,,Registered,2442
+Sedgwick,227,Voters,,,Registered,1266
+Sedgwick,228,Voters,,,Registered,1669
+Sedgwick,233,Voters,,,Registered,668
+Sedgwick,235,Voters,,,Registered,528
+Sedgwick,236,Voters,,,Registered,1225
+Sedgwick,239,Voters,,,Registered,37
+Sedgwick,241,Voters,,,Registered,435
+Sedgwick,301,Voters,,,Registered,851
+Sedgwick,302,Voters,,,Registered,1738
+Sedgwick,303,Voters,,,Registered,749
+Sedgwick,304,Voters,,,Registered,731
+Sedgwick,305,Voters,,,Registered,1989
+Sedgwick,306,Voters,,,Registered,2251
+Sedgwick,307,Voters,,,Registered,1296
+Sedgwick,308,Voters,,,Registered,1615
+Sedgwick,309,Voters,,,Registered,1808
+Sedgwick,310,Voters,,,Registered,1482
+Sedgwick,311,Voters,,,Registered,817
+Sedgwick,312,Voters,,,Registered,796
+Sedgwick,313,Voters,,,Registered,2056
+Sedgwick,314,Voters,,,Registered,1743
+Sedgwick,315,Voters,,,Registered,1627
+Sedgwick,316,Voters,,,Registered,1632
+Sedgwick,317,Voters,,,Registered,21
+Sedgwick,318,Voters,,,Registered,57
+Sedgwick,319,Voters,,,Registered,469
+Sedgwick,320,Voters,,,Registered,461
+Sedgwick,321,Voters,,,Registered,75
+Sedgwick,324,Voters,,,Registered,785
+Sedgwick,325,Voters,,,Registered,1369
+Sedgwick,326,Voters,,,Registered,146
+Sedgwick,401,Voters,,,Registered,888
+Sedgwick,402,Voters,,,Registered,736
+Sedgwick,403,Voters,,,Registered,1068
+Sedgwick,404,Voters,,,Registered,2203
+Sedgwick,405,Voters,,,Registered,1480
+Sedgwick,406,Voters,,,Registered,1466
+Sedgwick,407,Voters,,,Registered,190
+Sedgwick,408,Voters,,,Registered,1417
+Sedgwick,409,Voters,,,Registered,824
+Sedgwick,410,Voters,,,Registered,2264
+Sedgwick,412,Voters,,,Registered,2670
+Sedgwick,413,Voters,,,Registered,2039
+Sedgwick,414,Voters,,,Registered,404
+Sedgwick,416,Voters,,,Registered,1199
+Sedgwick,417,Voters,,,Registered,1144
+Sedgwick,418,Voters,,,Registered,1593
+Sedgwick,419,Voters,,,Registered,1341
+Sedgwick,420,Voters,,,Registered,1545
+Sedgwick,422,Voters,,,Registered,1072
+Sedgwick,423,Voters,,,Registered,1379
+Sedgwick,424,Voters,,,Registered,434
+Sedgwick,425,Voters,,,Registered,2031
+Sedgwick,429,Voters,,,Registered,864
+Sedgwick,433,Voters,,,Registered,501
+Sedgwick,437,Voters,,,Registered,595
+Sedgwick,503,Voters,,,Registered,1902
+Sedgwick,504,Voters,,,Registered,1283
+Sedgwick,506,Voters,,,Registered,1904
+Sedgwick,507,Voters,,,Registered,1782
+Sedgwick,508,Voters,,,Registered,1573
+Sedgwick,509,Voters,,,Registered,1483
+Sedgwick,510,Voters,,,Registered,1794
+Sedgwick,512,Voters,,,Registered,3222
+Sedgwick,513,Voters,,,Registered,842
+Sedgwick,514,Voters,,,Registered,2125
+Sedgwick,515,Voters,,,Registered,1854
+Sedgwick,516,Voters,,,Registered,1179
+Sedgwick,517,Voters,,,Registered,1233
+Sedgwick,518,Voters,,,Registered,1487
+Sedgwick,519,Voters,,,Registered,1667
+Sedgwick,522,Voters,,,Registered,1548
+Sedgwick,523,Voters,,,Registered,1482
+Sedgwick,524,Voters,,,Registered,2334
+Sedgwick,525,Voters,,,Registered,1730
+Sedgwick,526,Voters,,,Registered,1800
+Sedgwick,527,Voters,,,Registered,1791
+Sedgwick,530,Voters,,,Registered,1555
+Sedgwick,531,Voters,,,Registered,2402
+Sedgwick,534,Voters,,,Registered,189
+Sedgwick,538,Voters,,,Registered,375
+Sedgwick,539,Voters,,,Registered,967
+Sedgwick,601,Voters,,,Registered,1656
+Sedgwick,602,Voters,,,Registered,1978
+Sedgwick,603,Voters,,,Registered,742
+Sedgwick,604,Voters,,,Registered,1913
+Sedgwick,605,Voters,,,Registered,731
+Sedgwick,606,Voters,,,Registered,577
+Sedgwick,607,Voters,,,Registered,1835
+Sedgwick,608,Voters,,,Registered,1610
+Sedgwick,609,Voters,,,Registered,2323
+Sedgwick,610,Voters,,,Registered,1600
+Sedgwick,611,Voters,,,Registered,1111
+Sedgwick,612,Voters,,,Registered,1963
+Sedgwick,613,Voters,,,Registered,1712
+Sedgwick,614,Voters,,,Registered,814
+Sedgwick,615,Voters,,,Registered,2312
+Sedgwick,616,Voters,,,Registered,1159
+Sedgwick,617,Voters,,,Registered,742
+Sedgwick,618,Voters,,,Registered,1588
+Sedgwick,619,Voters,,,Registered,1662
+Sedgwick,621,Voters,,,Registered,74
+Sedgwick,622,Voters,,,Registered,1772
+Sedgwick,623,Voters,,,Registered,1578
+Sedgwick,624,Voters,,,Registered,179
+Sedgwick,627,Voters,,,Registered,142
+Sedgwick,101,Voters,,,Cast,742
+Sedgwick,102,Voters,,,Cast,735
+Sedgwick,103,Voters,,,Cast,101
+Sedgwick,104,Voters,,,Cast,30
+Sedgwick,105,Voters,,,Cast,416
+Sedgwick,106,Voters,,,Cast,724
+Sedgwick,107,Voters,,,Cast,1126
+Sedgwick,108,Voters,,,Cast,609
+Sedgwick,109,Voters,,,Cast,710
+Sedgwick,110,Voters,,,Cast,1139
+Sedgwick,111,Voters,,,Cast,299
+Sedgwick,112,Voters,,,Cast,795
+Sedgwick,113,Voters,,,Cast,520
+Sedgwick,114,Voters,,,Cast,453
+Sedgwick,116,Voters,,,Cast,679
+Sedgwick,117,Voters,,,Cast,632
+Sedgwick,118,Voters,,,Cast,779
+Sedgwick,119,Voters,,,Cast,615
+Sedgwick,120,Voters,,,Cast,609
+Sedgwick,121,Voters,,,Cast,682
+Sedgwick,122,Voters,,,Cast,1036
+Sedgwick,123,Voters,,,Cast,297
+Sedgwick,124,Voters,,,Cast,1
+Sedgwick,127,Voters,,,Cast,214
+Sedgwick,128,Voters,,,Cast,847
+Sedgwick,129,Voters,,,Cast,165
+Sedgwick,130,Voters,,,Cast,461
+Sedgwick,205,Voters,,,Cast,207
+Sedgwick,206,Voters,,,Cast,237
+Sedgwick,207,Voters,,,Cast,1315
+Sedgwick,208,Voters,,,Cast,258
+Sedgwick,209,Voters,,,Cast,624
+Sedgwick,210,Voters,,,Cast,777
+Sedgwick,211,Voters,,,Cast,555
+Sedgwick,212,Voters,,,Cast,1068
+Sedgwick,213,Voters,,,Cast,1184
+Sedgwick,214,Voters,,,Cast,1083
+Sedgwick,215,Voters,,,Cast,1446
+Sedgwick,216,Voters,,,Cast,916
+Sedgwick,217,Voters,,,Cast,1127
+Sedgwick,218,Voters,,,Cast,1567
+Sedgwick,221,Voters,,,Cast,709
+Sedgwick,222,Voters,,,Cast,965
+Sedgwick,223,Voters,,,Cast,1171
+Sedgwick,224,Voters,,,Cast,1121
+Sedgwick,225,Voters,,,Cast,1164
+Sedgwick,226,Voters,,,Cast,1506
+Sedgwick,227,Voters,,,Cast,819
+Sedgwick,228,Voters,,,Cast,1081
+Sedgwick,233,Voters,,,Cast,297
+Sedgwick,235,Voters,,,Cast,232
+Sedgwick,236,Voters,,,Cast,710
+Sedgwick,239,Voters,,,Cast,19
+Sedgwick,241,Voters,,,Cast,280
+Sedgwick,301,Voters,,,Cast,331
+Sedgwick,302,Voters,,,Cast,586
+Sedgwick,303,Voters,,,Cast,274
+Sedgwick,304,Voters,,,Cast,316
+Sedgwick,305,Voters,,,Cast,1040
+Sedgwick,306,Voters,,,Cast,940
+Sedgwick,307,Voters,,,Cast,407
+Sedgwick,308,Voters,,,Cast,702
+Sedgwick,309,Voters,,,Cast,819
+Sedgwick,310,Voters,,,Cast,365
+Sedgwick,311,Voters,,,Cast,310
+Sedgwick,312,Voters,,,Cast,310
+Sedgwick,313,Voters,,,Cast,886
+Sedgwick,314,Voters,,,Cast,807
+Sedgwick,315,Voters,,,Cast,610
+Sedgwick,316,Voters,,,Cast,736
+Sedgwick,317,Voters,,,Cast,12
+Sedgwick,318,Voters,,,Cast,23
+Sedgwick,319,Voters,,,Cast,187
+Sedgwick,320,Voters,,,Cast,122
+Sedgwick,321,Voters,,,Cast,18
+Sedgwick,324,Voters,,,Cast,274
+Sedgwick,325,Voters,,,Cast,656
+Sedgwick,326,Voters,,,Cast,73
+Sedgwick,401,Voters,,,Cast,430
+Sedgwick,402,Voters,,,Cast,453
+Sedgwick,403,Voters,,,Cast,685
+Sedgwick,404,Voters,,,Cast,929
+Sedgwick,405,Voters,,,Cast,683
+Sedgwick,406,Voters,,,Cast,567
+Sedgwick,407,Voters,,,Cast,76
+Sedgwick,408,Voters,,,Cast,582
+Sedgwick,409,Voters,,,Cast,325
+Sedgwick,410,Voters,,,Cast,1438
+Sedgwick,412,Voters,,,Cast,1381
+Sedgwick,413,Voters,,,Cast,1009
+Sedgwick,414,Voters,,,Cast,207
+Sedgwick,416,Voters,,,Cast,676
+Sedgwick,417,Voters,,,Cast,514
+Sedgwick,418,Voters,,,Cast,761
+Sedgwick,419,Voters,,,Cast,661
+Sedgwick,420,Voters,,,Cast,710
+Sedgwick,422,Voters,,,Cast,443
+Sedgwick,423,Voters,,,Cast,528
+Sedgwick,424,Voters,,,Cast,171
+Sedgwick,425,Voters,,,Cast,1000
+Sedgwick,429,Voters,,,Cast,360
+Sedgwick,433,Voters,,,Cast,239
+Sedgwick,437,Voters,,,Cast,233
+Sedgwick,503,Voters,,,Cast,789
+Sedgwick,504,Voters,,,Cast,553
+Sedgwick,506,Voters,,,Cast,1042
+Sedgwick,507,Voters,,,Cast,984
+Sedgwick,508,Voters,,,Cast,882
+Sedgwick,509,Voters,,,Cast,852
+Sedgwick,510,Voters,,,Cast,1231
+Sedgwick,512,Voters,,,Cast,1820
+Sedgwick,513,Voters,,,Cast,520
+Sedgwick,514,Voters,,,Cast,1222
+Sedgwick,515,Voters,,,Cast,1086
+Sedgwick,516,Voters,,,Cast,732
+Sedgwick,517,Voters,,,Cast,743
+Sedgwick,518,Voters,,,Cast,896
+Sedgwick,519,Voters,,,Cast,998
+Sedgwick,522,Voters,,,Cast,956
+Sedgwick,523,Voters,,,Cast,967
+Sedgwick,524,Voters,,,Cast,1538
+Sedgwick,525,Voters,,,Cast,1031
+Sedgwick,526,Voters,,,Cast,1074
+Sedgwick,527,Voters,,,Cast,1050
+Sedgwick,530,Voters,,,Cast,1027
+Sedgwick,531,Voters,,,Cast,1656
+Sedgwick,534,Voters,,,Cast,97
+Sedgwick,538,Voters,,,Cast,204
+Sedgwick,539,Voters,,,Cast,512
+Sedgwick,601,Voters,,,Cast,508
+Sedgwick,602,Voters,,,Cast,964
+Sedgwick,603,Voters,,,Cast,472
+Sedgwick,604,Voters,,,Cast,931
+Sedgwick,605,Voters,,,Cast,347
+Sedgwick,606,Voters,,,Cast,301
+Sedgwick,607,Voters,,,Cast,1190
+Sedgwick,608,Voters,,,Cast,665
+Sedgwick,609,Voters,,,Cast,1289
+Sedgwick,610,Voters,,,Cast,995
+Sedgwick,611,Voters,,,Cast,506
+Sedgwick,612,Voters,,,Cast,1219
+Sedgwick,613,Voters,,,Cast,962
+Sedgwick,614,Voters,,,Cast,361
+Sedgwick,615,Voters,,,Cast,860
+Sedgwick,616,Voters,,,Cast,464
+Sedgwick,617,Voters,,,Cast,274
+Sedgwick,618,Voters,,,Cast,919
+Sedgwick,619,Voters,,,Cast,956
+Sedgwick,621,Voters,,,Cast,38
+Sedgwick,622,Voters,,,Cast,1185
+Sedgwick,623,Voters,,,Cast,1009
+Sedgwick,624,Voters,,,Cast,73
+Sedgwick,627,Voters,,,Cast,77
+Sedgwick,AF,Voters,,,Registration,1019
+Sedgwick,AT02,Voters,,,Registration,242
+Sedgwick,AT03,Voters,,,Registration,745
+Sedgwick,AT04,Voters,,,Registration,1
+Sedgwick,AT05,Voters,,,Registration,300
+Sedgwick,AT06,Voters,,,Registration,62
+Sedgwick,AT08,Voters,,,Registration,83
+Sedgwick,BA01,Voters,,,Registration,1754
+Sedgwick,BA02,Voters,,,Registration,1669
+Sedgwick,BA03,Voters,,,Registration,1267
+Sedgwick,DB11,Voters,,,Registration,1809
+Sedgwick,DB12,Voters,,,Registration,1176
+Sedgwick,DB14,Voters,,,Registration,685
+Sedgwick,DB15,Voters,,,Registration,60
+Sedgwick,DB21,Voters,,,Registration,1110
+Sedgwick,DB22,Voters,,,Registration,1063
+Sedgwick,DB23,Voters,,,Registration,1141
+Sedgwick,DB24,Voters,,,Registration,248
+Sedgwick,DB25,Voters,,,Registration,122
+Sedgwick,DB31,Voters,,,Registration,404
+Sedgwick,DB32,Voters,,,Registration,1221
+Sedgwick,DB36,Voters,,,Registration,1584
+Sedgwick,DB37,Voters,,,Registration,299
+Sedgwick,DB41,Voters,,,Registration,827
+Sedgwick,DB42,Voters,,,Registration,2538
+Sedgwick,DL02,Voters,,,Registration,0
+Sedgwick,DL03,Voters,,,Registration,2
+Sedgwick,DL04,Voters,,,Registration,2
+Sedgwick,EA,Voters,,,Registration,670
+Sedgwick,ER,Voters,,,Registration,53
+Sedgwick,GA,Voters,,,Registration,1214
+Sedgwick,GD,Voters,,,Registration,392
+Sedgwick,GN01,Voters,,,Registration,923
+Sedgwick,GO,Voters,,,Registration,2574
+Sedgwick,GR,Voters,,,Registration,630
+Sedgwick,GY01,Voters,,,Registration,2222
+Sedgwick,GY02,Voters,,,Registration,202
+Sedgwick,GY03,Voters,,,Registration,71
+Sedgwick,HA11,Voters,,,Registration,1161
+Sedgwick,HA21,Voters,,,Registration,1513
+Sedgwick,HA31,Voters,,,Registration,1607
+Sedgwick,HA41,Voters,,,Registration,1217
+Sedgwick,HA42,Voters,,,Registration,335
+Sedgwick,IL01,Voters,,,Registration,1181
+Sedgwick,KE01,Voters,,,Registration,16
+Sedgwick,KE03,Voters,,,Registration,1123
+Sedgwick,KE04,Voters,,,Registration,64
+Sedgwick,KE07,Voters,,,Registration,25
+Sedgwick,KE08,Voters,,,Registration,19
+Sedgwick,LI,Voters,,,Registration,348
+Sedgwick,MI01,Voters,,,Registration,1503
+Sedgwick,MI02,Voters,,,Registration,586
+Sedgwick,MI03,Voters,,,Registration,28
+Sedgwick,MI04,Voters,,,Registration,3
+Sedgwick,MI05,Voters,,,Registration,6
+Sedgwick,MI07,Voters,,,Registration,21
+Sedgwick,MI09,Voters,,,Registration,314
+Sedgwick,MI14,Voters,,,Registration,140
+Sedgwick,MO,Voters,,,Registration,1563
+Sedgwick,MV01,Voters,,,Registration,989
+Sedgwick,MV02,Voters,,,Registration,2254
+Sedgwick,NI,Voters,,,Registration,1618
+Sedgwick,NI01,Voters,,,Registration,327
+Sedgwick,OH01,Voters,,,Registration,897
+Sedgwick,PA01,Voters,,,Registration,381
+Sedgwick,PA02,Voters,,,Registration,230
+Sedgwick,PA05,Voters,,,Registration,2050
+Sedgwick,PA06,Voters,,,Registration,75
+Sedgwick,PA09,Voters,,,Registration,8
+Sedgwick,PC11,Voters,,,Registration,790
+Sedgwick,PC13,Voters,,,Registration,269
+Sedgwick,PC21,Voters,,,Registration,1165
+Sedgwick,PC31,Voters,,,Registration,1645
+Sedgwick,PC43,Voters,,,Registration,379
+Sedgwick,PY01,Voters,,,Registration,712
+Sedgwick,RI01,Voters,,,Registration,70
+Sedgwick,RI03,Voters,,,Registration,685
+Sedgwick,RI06,Voters,,,Registration,179
+Sedgwick,RI07,Voters,,,Registration,736
+Sedgwick,RI13,Voters,,,Registration,12
+Sedgwick,RO01,Voters,,,Registration,621
+Sedgwick,RO03,Voters,,,Registration,396
+Sedgwick,SA01,Voters,,,Registration,1508
+Sedgwick,SA02,Voters,,,Registration,1039
+Sedgwick,SH,Voters,,,Registration,1059
+Sedgwick,UN01,Voters,,,Registration,1394
+Sedgwick,UN02,Voters,,,Registration,100
+Sedgwick,VA,Voters,,,Registration,741
+Sedgwick,VC11,Voters,,,Registration,1093
+Sedgwick,VC21,Voters,,,Registration,1037
+Sedgwick,VC31,Voters,,,Registration,935
+Sedgwick,VC41,Voters,,,Registration,757
+Sedgwick,VC42,Voters,,,Registration,343
+Sedgwick,VI,Voters,,,Registration,304
+Sedgwick,WA01,Voters,,,Registration,93
+Sedgwick,WA02,Voters,,,Registration,359
+Sedgwick,WA03,Voters,,,Registration,18
+Sedgwick,WA12,Voters,,,Registration,3
+Sedgwick,AF,Voters,,,Cast,629
+Sedgwick,AT02,Voters,,,Cast,106
+Sedgwick,AT03,Voters,,,Cast,484
+Sedgwick,AT04,Voters,,,Cast,3
+Sedgwick,AT05,Voters,,,Cast,211
+Sedgwick,AT06,Voters,,,Cast,45
+Sedgwick,AT08,Voters,,,Cast,46
+Sedgwick,BA01,Voters,,,Cast,1126
+Sedgwick,BA02,Voters,,,Cast,998
+Sedgwick,BA03,Voters,,,Cast,719
+Sedgwick,DB11,Voters,,,Cast,979
+Sedgwick,DB12,Voters,,,Cast,528
+Sedgwick,DB14,Voters,,,Cast,369
+Sedgwick,DB15,Voters,,,Cast,29
+Sedgwick,DB21,Voters,,,Cast,535
+Sedgwick,DB22,Voters,,,Cast,576
+Sedgwick,DB23,Voters,,,Cast,714
+Sedgwick,DB24,Voters,,,Cast,131
+Sedgwick,DB25,Voters,,,Cast,52
+Sedgwick,DB31,Voters,,,Cast,215
+Sedgwick,DB32,Voters,,,Cast,668
+Sedgwick,DB36,Voters,,,Cast,885
+Sedgwick,DB37,Voters,,,Cast,129
+Sedgwick,DB41,Voters,,,Cast,404
+Sedgwick,DB42,Voters,,,Cast,1486
+Sedgwick,DL02,Voters,,,Cast,0
+Sedgwick,DL03,Voters,,,Cast,2
+Sedgwick,DL04,Voters,,,Cast,1
+Sedgwick,EA,Voters,,,Cast,379
+Sedgwick,ER,Voters,,,Cast,40
+Sedgwick,GA,Voters,,,Cast,785
+Sedgwick,GD,Voters,,,Cast,232
+Sedgwick,GN01,Voters,,,Cast,640
+Sedgwick,GO,Voters,,,Cast,1350
+Sedgwick,GR,Voters,,,Cast,386
+Sedgwick,GY01,Voters,,,Cast,1314
+Sedgwick,GY02,Voters,,,Cast,18
+Sedgwick,GY03,Voters,,,Cast,39
+Sedgwick,HA11,Voters,,,Cast,639
+Sedgwick,HA21,Voters,,,Cast,703
+Sedgwick,HA31,Voters,,,Cast,744
+Sedgwick,HA41,Voters,,,Cast,636
+Sedgwick,HA42,Voters,,,Cast,144
+Sedgwick,IL01,Voters,,,Cast,714
+Sedgwick,KE01,Voters,,,Cast,13
+Sedgwick,KE03,Voters,,,Cast,748
+Sedgwick,KE04,Voters,,,Cast,38
+Sedgwick,KE07,Voters,,,Cast,18
+Sedgwick,KE08,Voters,,,Cast,11
+Sedgwick,LI,Voters,,,Cast,253
+Sedgwick,MI01,Voters,,,Cast,1080
+Sedgwick,MI02,Voters,,,Cast,449
+Sedgwick,MI03,Voters,,,Cast,12
+Sedgwick,MI04,Voters,,,Cast,2
+Sedgwick,MI05,Voters,,,Cast,2
+Sedgwick,MI07,Voters,,,Cast,11
+Sedgwick,MI09,Voters,,,Cast,210
+Sedgwick,MI14,Voters,,,Cast,99
+Sedgwick,MO,Voters,,,Cast,918
+Sedgwick,MV01,Voters,,,Cast,556
+Sedgwick,MV02,Voters,,,Cast,1260
+Sedgwick,NI,Voters,,,Cast,900
+Sedgwick,NI01,Voters,,,Cast,190
+Sedgwick,OH01,Voters,,,Cast,544
+Sedgwick,PA01,Voters,,,Cast,211
+Sedgwick,PA02,Voters,,,Cast,119
+Sedgwick,PA05,Voters,,,Cast,1101
+Sedgwick,PA06,Voters,,,Cast,55
+Sedgwick,PA09,Voters,,,Cast,7
+Sedgwick,PC11,Voters,,,Cast,384
+Sedgwick,PC13,Voters,,,Cast,129
+Sedgwick,PC21,Voters,,,Cast,630
+Sedgwick,PC31,Voters,,,Cast,770
+Sedgwick,PC43,Voters,,,Cast,219
+Sedgwick,PY01,Voters,,,Cast,453
+Sedgwick,RI01,Voters,,,Cast,39
+Sedgwick,RI03,Voters,,,Cast,242
+Sedgwick,RI06,Voters,,,Cast,122
+Sedgwick,RI07,Voters,,,Cast,209
+Sedgwick,RI13,Voters,,,Cast,7
+Sedgwick,RO01,Voters,,,Cast,376
+Sedgwick,RO03,Voters,,,Cast,245
+Sedgwick,SA01,Voters,,,Cast,774
+Sedgwick,SA02,Voters,,,Cast,552
+Sedgwick,SH,Voters,,,Cast,592
+Sedgwick,UN01,Voters,,,Cast,835
+Sedgwick,UN02,Voters,,,Cast,59
+Sedgwick,VA,Voters,,,Cast,394
+Sedgwick,VC11,Voters,,,Cast,577
+Sedgwick,VC21,Voters,,,Cast,621
+Sedgwick,VC31,Voters,,,Cast,501
+Sedgwick,VC41,Voters,,,Cast,450
+Sedgwick,VC42,Voters,,,Cast,190
+Sedgwick,VI,Voters,,,Cast,191
+Sedgwick,WA01,Voters,,,Cast,53
+Sedgwick,WA02,Voters,,,Cast,214
+Sedgwick,WA03,Voters,,,Cast,12
+Sedgwick,WA12,Voters,,,Cast,2
+Seward,W1P1,Voters,,,Reg,894,894,0,0
+Seward,W1P2,Voters,,,Reg,1395,1395,0,0
+Seward,W1P3,Voters,,,Reg,952,952,0,0
+Seward,W2,Voters,,,Reg,924,924,0,0
+Seward,W3,Voters,,,Reg,839,839,0,0
+Seward,W4,Voters,,,Reg,589,589,0,0
+Seward,W5,Voters,,,Reg,537,537,0,0
+Seward,W6P1,Voters,,,Reg,1456,1456,0,0
+Seward,W6P2,Voters,,,Reg,1077,1077,0,0
+Seward,W1P1,Voters,,,Cast,213,150,54,9
+Seward,W1P2,Voters,,,Cast,283,186,95,2
+Seward,W1P3,Voters,,,Cast,272,165,99,8
+Seward,W2,Voters,,,Cast,323,226,86,11
+Seward,W3,Voters,,,Cast,152,93,54,5
+Seward,W4,Voters,,,Cast,220,151,63,6
+Seward,W5,Voters,,,Cast,193,127,62,4
+Seward,W6P1,Voters,,,Cast,718,473,232,13
+Seward,W6P2,Voters,,,Cast,430,283,132,15
+Wyandotte,BS 1-1,Voters,,,Registration,1135
+Wyandotte,BS 2-1,Voters,,,Registration,885
+Wyandotte,BS 3-1,Voters,,,Registration,1111
+Wyandotte,BS 4-1,Voters,,,Registration,1229
+Wyandotte,DE 1-1,Voters,,,Registration,30
+Wyandotte,ED 1-1,Voters,,,Registration,2151
+Wyandotte,ED 2-1,Voters,,,Registration,366
+Wyandotte,KC 1-1,Voters,,,Registration,444
+Wyandotte,KC 1-2,Voters,,,Registration,379
+Wyandotte,KC 1-3,Voters,,,Registration,164
+Wyandotte,KC 2-1,Voters,,,Registration,440
+Wyandotte,KC 2-2,Voters,,,Registration,387
+Wyandotte,KC 2-3,Voters,,,Registration,120
+Wyandotte,KC 2-4,Voters,,,Registration,389
+Wyandotte,KC 2-5,Voters,,,Registration,708
+Wyandotte,KC 3-1,Voters,,,Registration,890
+Wyandotte,KC 3-2,Voters,,,Registration,1013
+Wyandotte,KC 3-3,Voters,,,Registration,224
+Wyandotte,KC 3-4,Voters,,,Registration,777
+Wyandotte,KC 4-1,Voters,,,Registration,663
+Wyandotte,KC 4-2,Voters,,,Registration,239
+Wyandotte,KC 4-3,Voters,,,Registration,445
+Wyandotte,KC 4-4,Voters,,,Registration,788
+Wyandotte,KC 5-1,Voters,,,Registration,730
+Wyandotte,KC 5-2,Voters,,,Registration,456
+Wyandotte,KC 5-3,Voters,,,Registration,421
+Wyandotte,KC 5-4,Voters,,,Registration,377
+Wyandotte,KC 5-5,Voters,,,Registration,467
+Wyandotte,KC 6-1,Voters,,,Registration,527
+Wyandotte,KC 6-2,Voters,,,Registration,232
+Wyandotte,KC 7-1,Voters,,,Registration,574
+Wyandotte,KC 7-2,Voters,,,Registration,399
+Wyandotte,KC 7-3,Voters,,,Registration,654
+Wyandotte,KC 7-4,Voters,,,Registration,879
+Wyandotte,KC 7-5,Voters,,,Registration,236
+Wyandotte,KC 7-6,Voters,,,Registration,986
+Wyandotte,KC 7-7,Voters,,,Registration,513
+Wyandotte,KC 7-8,Voters,,,Registration,1352
+Wyandotte,KC 7-9,Voters,,,Registration,1091
+Wyandotte,KC 8-1,Voters,,,Registration,819
+Wyandotte,KC 8-2,Voters,,,Registration,826
+Wyandotte,KC 8-3,Voters,,,Registration,1089
+Wyandotte,KC 8-4,Voters,,,Registration,919
+Wyandotte,KC 9-1,Voters,,,Registration,136
+Wyandotte,KC 9-2,Voters,,,Registration,693
+Wyandotte,KC 9-3,Voters,,,Registration,1468
+Wyandotte,KC 9-4,Voters,,,Registration,227
+Wyandotte,KC 9-5,Voters,,,Registration,61
+Wyandotte,KC 9-6,Voters,,,Registration,965
+Wyandotte,KC 9-7,Voters,,,Registration,1004
+Wyandotte,KC 9-8,Voters,,,Registration,439
+Wyandotte,KC 9-9,Voters,,,Registration,368
+Wyandotte,KC 9-10,Voters,,,Registration,961
+Wyandotte,KC 9-11,Voters,,,Registration,1105
+Wyandotte,KC 9-12,Voters,,,Registration,977
+Wyandotte,KC 9-13,Voters,,,Registration,738
+Wyandotte,KC 9-14,Voters,,,Registration,881
+Wyandotte,KC 9-15,Voters,,,Registration,1
+Wyandotte,KC 9-16,Voters,,,Registration,1082
+Wyandotte,KC 10-1,Voters,,,Registration,970
+Wyandotte,KC 10-2,Voters,,,Registration,1431
+Wyandotte,KC 10-3,Voters,,,Registration,64
+Wyandotte,KC 10-4,Voters,,,Registration,578
+Wyandotte,KC 10-5,Voters,,,Registration,996
+Wyandotte,KC 11-1,Voters,,,Registration,936
+Wyandotte,KC 11-2,Voters,,,Registration,815
+Wyandotte,KC 11-3,Voters,,,Registration,1091
+Wyandotte,KC 11-4,Voters,,,Registration,963
+Wyandotte,KC 11-5,Voters,,,Registration,1144
+Wyandotte,KC 11-6,Voters,,,Registration,787
+Wyandotte,KC 11-7,Voters,,,Registration,590
+Wyandotte,KC 11-8,Voters,,,Registration,1038
+Wyandotte,KC 11-9,Voters,,,Registration,781
+Wyandotte,KC 11-10,Voters,,,Registration,848
+Wyandotte,KC 11-11,Voters,,,Registration,1022
+Wyandotte,KC 11-12,Voters,,,Registration,176
+Wyandotte,KC 12-1,Voters,,,Registration,807
+Wyandotte,KC 12-2,Voters,,,Registration,525
+Wyandotte,KC 12-3,Voters,,,Registration,835
+Wyandotte,KC 12-4,Voters,,,Registration,885
+Wyandotte,KC 12-5,Voters,,,Registration,794
+Wyandotte,KC 12-6,Voters,,,Registration,828
+Wyandotte,KC 12-7,Voters,,,Registration,829
+Wyandotte,KC 12-8,Voters,,,Registration,824
+Wyandotte,KC 12-9,Voters,,,Registration,790
+Wyandotte,KC 12-10,Voters,,,Registration,518
+Wyandotte,KC 12-11,Voters,,,Registration,298
+Wyandotte,KC 13-1,Voters,,,Registration,1052
+Wyandotte,KC 13-2,Voters,,,Registration,801
+Wyandotte,KC 13-3,Voters,,,Registration,697
+Wyandotte,KC 13-4,Voters,,,Registration,582
+Wyandotte,KC 13-5,Voters,,,Registration,824
+Wyandotte,KC 13-6,Voters,,,Registration,787
+Wyandotte,KC 13-7,Voters,,,Registration,540
+Wyandotte,KC 13-8,Voters,,,Registration,656
+Wyandotte,KC 13-9,Voters,,,Registration,871
+Wyandotte,KC 14-1,Voters,,,Registration,815
+Wyandotte,KC 14-2,Voters,,,Registration,383
+Wyandotte,KC 14-3,Voters,,,Registration,366
+Wyandotte,KC 14-4,Voters,,,Registration,741
+Wyandotte,KC 14-5,Voters,,,Registration,688
+Wyandotte,KC 14-6,Voters,,,Registration,964
+Wyandotte,KC 14-7,Voters,,,Registration,1127
+Wyandotte,KC 14-8,Voters,,,Registration,860
+Wyandotte,KC 14-9,Voters,,,Registration,405
+Wyandotte,KC 14-10,Voters,,,Registration,1218
+Wyandotte,KC 14-11,Voters,,,Registration,741
+Wyandotte,KC 14-12,Voters,,,Registration,1175
+Wyandotte,KC 14-13,Voters,,,Registration,978
+Wyandotte,KC 14-14,Voters,,,Registration,1395
+Wyandotte,KC 14-15,Voters,,,Registration,1406
+Wyandotte,KC 14-16,Voters,,,Registration,417
+Wyandotte,OC 1-1,Voters,,,Registration,37
+Wyandotte,BS 1-1,Voters,,,Ballots,462
+Wyandotte,BS 2-1,Voters,,,Ballots,349
+Wyandotte,BS 3-1,Voters,,,Ballots,503
+Wyandotte,BS 4-1,Voters,,,Ballots,595
+Wyandotte,DE 1-1,Voters,,,Ballots,13
+Wyandotte,ED 1-1,Voters,,,Ballots,819
+Wyandotte,ED 2-1,Voters,,,Ballots,135
+Wyandotte,KC 1-1,Voters,,,Ballots,86
+Wyandotte,KC 1-2,Voters,,,Ballots,94
+Wyandotte,KC 1-3,Voters,,,Ballots,69
+Wyandotte,KC 2-1,Voters,,,Ballots,146
+Wyandotte,KC 2-2,Voters,,,Ballots,95
+Wyandotte,KC 2-3,Voters,,,Ballots,30
+Wyandotte,KC 2-4,Voters,,,Ballots,107
+Wyandotte,KC 2-5,Voters,,,Ballots,193
+Wyandotte,KC 3-1,Voters,,,Ballots,273
+Wyandotte,KC 3-2,Voters,,,Ballots,271
+Wyandotte,KC 3-3,Voters,,,Ballots,49
+Wyandotte,KC 3-4,Voters,,,Ballots,163
+Wyandotte,KC 4-1,Voters,,,Ballots,199
+Wyandotte,KC 4-2,Voters,,,Ballots,56
+Wyandotte,KC 4-3,Voters,,,Ballots,138
+Wyandotte,KC 4-4,Voters,,,Ballots,289
+Wyandotte,KC 5-1,Voters,,,Ballots,199
+Wyandotte,KC 5-2,Voters,,,Ballots,60
+Wyandotte,KC 5-3,Voters,,,Ballots,49
+Wyandotte,KC 5-4,Voters,,,Ballots,77
+Wyandotte,KC 5-5,Voters,,,Ballots,111
+Wyandotte,KC 6-1,Voters,,,Ballots,114
+Wyandotte,KC 6-2,Voters,,,Ballots,38
+Wyandotte,KC 7-1,Voters,,,Ballots,166
+Wyandotte,KC 7-2,Voters,,,Ballots,114
+Wyandotte,KC 7-3,Voters,,,Ballots,192
+Wyandotte,KC 7-4,Voters,,,Ballots,325
+Wyandotte,KC 7-5,Voters,,,Ballots,56
+Wyandotte,KC 7-6,Voters,,,Ballots,311
+Wyandotte,KC 7-7,Voters,,,Ballots,98
+Wyandotte,KC 7-8,Voters,,,Ballots,403
+Wyandotte,KC 7-9,Voters,,,Ballots,366
+Wyandotte,KC 8-1,Voters,,,Ballots,227
+Wyandotte,KC 8-2,Voters,,,Ballots,259
+Wyandotte,KC 8-3,Voters,,,Ballots,437
+Wyandotte,KC 8-4,Voters,,,Ballots,259
+Wyandotte,KC 9-1,Voters,,,Ballots,60
+Wyandotte,KC 9-2,Voters,,,Ballots,175
+Wyandotte,KC 9-3,Voters,,,Ballots,438
+Wyandotte,KC 9-4,Voters,,,Ballots,75
+Wyandotte,KC 9-5,Voters,,,Ballots,21
+Wyandotte,KC 9-6,Voters,,,Ballots,231
+Wyandotte,KC 9-7,Voters,,,Ballots,260
+Wyandotte,KC 9-8,Voters,,,Ballots,196
+Wyandotte,KC 9-9,Voters,,,Ballots,112
+Wyandotte,KC 9-10,Voters,,,Ballots,377
+Wyandotte,KC 9-11,Voters,,,Ballots,398
+Wyandotte,KC 9-12,Voters,,,Ballots,336
+Wyandotte,KC 9-13,Voters,,,Ballots,244
+Wyandotte,KC 9-14,Voters,,,Ballots,343
+Wyandotte,KC 9-15,Voters,,,Ballots,0
+Wyandotte,KC 9-16,Voters,,,Ballots,432
+Wyandotte,KC 10-1,Voters,,,Ballots,281
+Wyandotte,KC 10-2,Voters,,,Ballots,428
+Wyandotte,KC 10-3,Voters,,,Ballots,16
+Wyandotte,KC 10-4,Voters,,,Ballots,173
+Wyandotte,KC 10-5,Voters,,,Ballots,330
+Wyandotte,KC 11-1,Voters,,,Ballots,301
+Wyandotte,KC 11-2,Voters,,,Ballots,246
+Wyandotte,KC 11-3,Voters,,,Ballots,367
+Wyandotte,KC 11-4,Voters,,,Ballots,272
+Wyandotte,KC 11-5,Voters,,,Ballots,263
+Wyandotte,KC 11-6,Voters,,,Ballots,261
+Wyandotte,KC 11-7,Voters,,,Ballots,241
+Wyandotte,KC 11-8,Voters,,,Ballots,285
+Wyandotte,KC 11-9,Voters,,,Ballots,292
+Wyandotte,KC 11-10,Voters,,,Ballots,373
+Wyandotte,KC 11-11,Voters,,,Ballots,537
+Wyandotte,KC 11-12,Voters,,,Ballots,79
+Wyandotte,KC 12-1,Voters,,,Ballots,247
+Wyandotte,KC 12-2,Voters,,,Ballots,80
+Wyandotte,KC 12-3,Voters,,,Ballots,233
+Wyandotte,KC 12-4,Voters,,,Ballots,335
+Wyandotte,KC 12-5,Voters,,,Ballots,306
+Wyandotte,KC 12-6,Voters,,,Ballots,279
+Wyandotte,KC 12-7,Voters,,,Ballots,212
+Wyandotte,KC 12-8,Voters,,,Ballots,296
+Wyandotte,KC 12-9,Voters,,,Ballots,316
+Wyandotte,KC 12-10,Voters,,,Ballots,252
+Wyandotte,KC 12-11,Voters,,,Ballots,129
+Wyandotte,KC 13-1,Voters,,,Ballots,333
+Wyandotte,KC 13-2,Voters,,,Ballots,319
+Wyandotte,KC 13-3,Voters,,,Ballots,244
+Wyandotte,KC 13-4,Voters,,,Ballots,196
+Wyandotte,KC 13-5,Voters,,,Ballots,251
+Wyandotte,KC 13-6,Voters,,,Ballots,278
+Wyandotte,KC 13-7,Voters,,,Ballots,206
+Wyandotte,KC 13-8,Voters,,,Ballots,245
+Wyandotte,KC 13-9,Voters,,,Ballots,321
+Wyandotte,KC 14-1,Voters,,,Ballots,341
+Wyandotte,KC 14-2,Voters,,,Ballots,176
+Wyandotte,KC 14-3,Voters,,,Ballots,158
+Wyandotte,KC 14-4,Voters,,,Ballots,328
+Wyandotte,KC 14-5,Voters,,,Ballots,287
+Wyandotte,KC 14-6,Voters,,,Ballots,378
+Wyandotte,KC 14-7,Voters,,,Ballots,485
+Wyandotte,KC 14-8,Voters,,,Ballots,350
+Wyandotte,KC 14-9,Voters,,,Ballots,247
+Wyandotte,KC 14-10,Voters,,,Ballots,638
+Wyandotte,KC 14-11,Voters,,,Ballots,343
+Wyandotte,KC 14-12,Voters,,,Ballots,632
+Wyandotte,KC 14-13,Voters,,,Ballots,457
+Wyandotte,KC 14-14,Voters,,,Ballots,681
+Wyandotte,KC 14-15,Voters,,,Ballots,837
+Wyandotte,KC 14-16,Voters,,,Ballots,242
+Wyandotte,OC 1-1,Voters,,,Ballots,27

--- a/2014/20141104__ks__general__allen__precinct.csv
+++ b/2014/20141104__ks__general__allen__precinct.csv
@@ -1,421 +1,505 @@
-county,precinct,office,district,party,candidate,votes
-Allen,0001 Carlyle,Voters,,,Ballots cast,132
-Allen,0002 Cottage Grove,Voters,,,Ballots cast,86
-Allen,0003 Deer Creek,Voters,,,Ballots cast,52
-Allen,0004 E Elm twp-Laharpe,Voters,,,Ballots cast,230
-Allen,0005 W Elm twp,Voters,,,Ballots cast,429
-Allen,0006 N Elsmore twp,Voters,,,Ballots cast,65
-Allen,0007 S Elsmore twp,Voters,,,Ballots cast,54
-Allen,0008 Geneva,Voters,,,Ballots cast,56
-Allen,0009 Humboldt twp,Voters,,,Ballots cast,112
-Allen,0010 N Iola twp,Voters,,,Ballots cast,108
-Allen,0011 S Iola twp,Voters,,,Ballots cast,254
-Allen,0012 Logan,Voters,,,Ballots cast,85
-Allen,0013 Marmaton,Voters,,,Ballots cast,265
-Allen,0014 Osage,Voters,,,Ballots cast,98
-Allen,0015 Salem,Voters,,,Ballots cast,106
-Allen,"0016 City of Humboldt, WD 1",Voters,,,Ballots cast,253
-Allen,0017 City of Humboldt- WD 2,Voters,,,Ballots cast,312
-Allen,"0018 City of Iola, Wd 1",Voters,,,Ballots cast,406
-Allen,"0019 City of Iola, Wd 2",Voters,,,Ballots cast,528
-Allen,"0020 City of Iola, Wd 3",Voters,,,Ballots cast,451
-Allen,"0021 City of Iola, Wd 4",Voters,,,Ballots cast,455
-Allen,0001 Carlyle,Voters,,,Registration,211
-Allen,0002 Cottage Grove,Voters,,,Registration,144
-Allen,0003 Deer Creek,Voters,,,Registration,94
-Allen,0004 E Elm twp-Laharpe,Voters,,,Registration,442
-Allen,0005 W Elm twp,Voters,,,Registration,665
-Allen,0006 N Elsmore twp,Voters,,,Registration,133
-Allen,0007 S Elsmore twp,Voters,,,Registration,112
-Allen,0008 Geneva,Voters,,,Registration,101
-Allen,0009 Humboldt twp,Voters,,,Registration,191
-Allen,0010 N Iola twp,Voters,,,Registration,168
-Allen,0011 S Iola twp,Voters,,,Registration,386
-Allen,0012 Logan,Voters,,,Registration,142
-Allen,0013 Marmaton,Voters,,,Registration,530
-Allen,0014 Osage,Voters,,,Registration,199
-Allen,0015 Salem,Voters,,,Registration,194
-Allen,"0016 City of Humboldt, WD 1",Voters,,,Registration,614
-Allen,0017 City of Humboldt- WD 2,Voters,,,Registration,608
-Allen,"0018 City of Iola, Wd 1",Voters,,,Registration,749
-Allen,"0019 City of Iola, Wd 2",Voters,,,Registration,1120
-Allen,"0020 City of Iola, Wd 3",Voters,,,Registration,862
-Allen,"0021 City of Iola, Wd 4",Voters,,,Registration,838
-Allen,0001 Carlyle,U.S. Senate,,R,Pat Roberts,98
-Allen,0002 Cottage Grove,U.S. Senate,,R,Pat Roberts,63
-Allen,0003 Deer Creek,U.S. Senate,,R,Pat Roberts,29
-Allen,0004 E Elm twp-Laharpe,U.S. Senate,,R,Pat Roberts,111
-Allen,0005 W Elm twp,U.S. Senate,,R,Pat Roberts,271
-Allen,0006 N Elsmore twp,U.S. Senate,,R,Pat Roberts,44
-Allen,0007 S Elsmore twp,U.S. Senate,,R,Pat Roberts,29
-Allen,0008 Geneva,U.S. Senate,,R,Pat Roberts,40
-Allen,0009 Humboldt twp,U.S. Senate,,R,Pat Roberts,65
-Allen,0010 N Iola twp,U.S. Senate,,R,Pat Roberts,78
-Allen,0011 S Iola twp,U.S. Senate,,R,Pat Roberts,154
-Allen,0012 Logan,U.S. Senate,,R,Pat Roberts,50
-Allen,0013 Marmaton,U.S. Senate,,R,Pat Roberts,136
-Allen,0014 Osage,U.S. Senate,,R,Pat Roberts,56
-Allen,0015 Salem,U.S. Senate,,R,Pat Roberts,55
-Allen,"0016 City of Humboldt, WD 1",U.S. Senate,,R,Pat Roberts,118
-Allen,0017 City of Humboldt- WD 2,U.S. Senate,,R,Pat Roberts,150
-Allen,"0018 City of Iola, Wd 1",U.S. Senate,,R,Pat Roberts,210
-Allen,"0019 City of Iola, Wd 2",U.S. Senate,,R,Pat Roberts,322
-Allen,"0020 City of Iola, Wd 3",U.S. Senate,,R,Pat Roberts,213
-Allen,"0021 City of Iola, Wd 4",U.S. Senate,,R,Pat Roberts,239
-Allen,0001 Carlyle,U.S. Senate,,I,Greg Orman,26
-Allen,0002 Cottage Grove,U.S. Senate,,I,Greg Orman,19
-Allen,0003 Deer Creek,U.S. Senate,,I,Greg Orman,15
-Allen,0004 E Elm twp-Laharpe,U.S. Senate,,I,Greg Orman,88
-Allen,0005 W Elm twp,U.S. Senate,,I,Greg Orman,116
-Allen,0006 N Elsmore twp,U.S. Senate,,I,Greg Orman,11
-Allen,0007 S Elsmore twp,U.S. Senate,,I,Greg Orman,19
-Allen,0008 Geneva,U.S. Senate,,I,Greg Orman,11
-Allen,0009 Humboldt twp,U.S. Senate,,I,Greg Orman,35
-Allen,0010 N Iola twp,U.S. Senate,,I,Greg Orman,23
-Allen,0011 S Iola twp,U.S. Senate,,I,Greg Orman,79
-Allen,0012 Logan,U.S. Senate,,I,Greg Orman,24
-Allen,0013 Marmaton,U.S. Senate,,I,Greg Orman,97
-Allen,0014 Osage,U.S. Senate,,I,Greg Orman,37
-Allen,0015 Salem,U.S. Senate,,I,Greg Orman,39
-Allen,"0016 City of Humboldt, WD 1",U.S. Senate,,I,Greg Orman,100
-Allen,0017 City of Humboldt- WD 2,U.S. Senate,,I,Greg Orman,119
-Allen,"0018 City of Iola, Wd 1",U.S. Senate,,I,Greg Orman,155
-Allen,"0019 City of Iola, Wd 2",U.S. Senate,,I,Greg Orman,177
-Allen,"0020 City of Iola, Wd 3",U.S. Senate,,I,Greg Orman,189
-Allen,"0021 City of Iola, Wd 4",U.S. Senate,,I,Greg Orman,185
-Allen,0001 Carlyle,U.S. Senate,,L,Randall Batson,6
-Allen,0002 Cottage Grove,U.S. Senate,,L,Randall Batson,4
-Allen,0003 Deer Creek,U.S. Senate,,L,Randall Batson,6
-Allen,0004 E Elm twp-Laharpe,U.S. Senate,,L,Randall Batson,21
-Allen,0005 W Elm twp,U.S. Senate,,L,Randall Batson,28
-Allen,0006 N Elsmore twp,U.S. Senate,,L,Randall Batson,4
-Allen,0007 S Elsmore twp,U.S. Senate,,L,Randall Batson,3
-Allen,0008 Geneva,U.S. Senate,,L,Randall Batson,3
-Allen,0009 Humboldt twp,U.S. Senate,,L,Randall Batson,9
-Allen,0010 N Iola twp,U.S. Senate,,L,Randall Batson,9
-Allen,0011 S Iola twp,U.S. Senate,,L,Randall Batson,17
-Allen,0012 Logan,U.S. Senate,,L,Randall Batson,8
-Allen,0013 Marmaton,U.S. Senate,,L,Randall Batson,26
-Allen,0014 Osage,U.S. Senate,,L,Randall Batson,5
-Allen,0015 Salem,U.S. Senate,,L,Randall Batson,11
-Allen,"0016 City of Humboldt, WD 1",U.S. Senate,,L,Randall Batson,29
-Allen,0017 City of Humboldt- WD 2,U.S. Senate,,L,Randall Batson,33
-Allen,"0018 City of Iola, Wd 1",U.S. Senate,,L,Randall Batson,31
-Allen,"0019 City of Iola, Wd 2",U.S. Senate,,L,Randall Batson,20
-Allen,"0020 City of Iola, Wd 3",U.S. Senate,,L,Randall Batson,34
-Allen,"0021 City of Iola, Wd 4",U.S. Senate,,L,Randall Batson,26
-Allen,0001 Carlyle,U.S. House,2,R,Lynn Jenkins,99
-Allen,0002 Cottage Grove,U.S. House,2,R,Lynn Jenkins,67
-Allen,0003 Deer Creek,U.S. House,2,R,Lynn Jenkins,33
-Allen,0004 E Elm twp-Laharpe,U.S. House,2,R,Lynn Jenkins,132
-Allen,0005 W Elm twp,U.S. House,2,R,Lynn Jenkins,288
-Allen,0006 N Elsmore twp,U.S. House,2,R,Lynn Jenkins,48
-Allen,0007 S Elsmore twp,U.S. House,2,R,Lynn Jenkins,31
-Allen,0008 Geneva,U.S. House,2,R,Lynn Jenkins,44
-Allen,0009 Humboldt twp,U.S. House,2,R,Lynn Jenkins,74
-Allen,0010 N Iola twp,U.S. House,2,R,Lynn Jenkins,77
-Allen,0011 S Iola twp,U.S. House,2,R,Lynn Jenkins,167
-Allen,0012 Logan,U.S. House,2,R,Lynn Jenkins,57
-Allen,0013 Marmaton,U.S. House,2,R,Lynn Jenkins,160
-Allen,0014 Osage,U.S. House,2,R,Lynn Jenkins,59
-Allen,0015 Salem,U.S. House,2,R,Lynn Jenkins,64
-Allen,"0016 City of Humboldt, WD 1",U.S. House,2,R,Lynn Jenkins,126
-Allen,0017 City of Humboldt- WD 2,U.S. House,2,R,Lynn Jenkins,185
-Allen,"0018 City of Iola, Wd 1",U.S. House,2,R,Lynn Jenkins,237
-Allen,"0019 City of Iola, Wd 2",U.S. House,2,R,Lynn Jenkins,345
-Allen,"0020 City of Iola, Wd 3",U.S. House,2,R,Lynn Jenkins,249
-Allen,"0021 City of Iola, Wd 4",U.S. House,2,R,Lynn Jenkins,258
-Allen,0001 Carlyle,U.S. House,2,D,Margie Wakefield,29
-Allen,0002 Cottage Grove,U.S. House,2,D,Margie Wakefield,17
-Allen,0003 Deer Creek,U.S. House,2,D,Margie Wakefield,12
-Allen,0004 E Elm twp-Laharpe,U.S. House,2,D,Margie Wakefield,72
-Allen,0005 W Elm twp,U.S. House,2,D,Margie Wakefield,113
-Allen,0006 N Elsmore twp,U.S. House,2,D,Margie Wakefield,14
-Allen,0007 S Elsmore twp,U.S. House,2,D,Margie Wakefield,19
-Allen,0008 Geneva,U.S. House,2,D,Margie Wakefield,9
-Allen,0009 Humboldt twp,U.S. House,2,D,Margie Wakefield,28
-Allen,0010 N Iola twp,U.S. House,2,D,Margie Wakefield,25
-Allen,0011 S Iola twp,U.S. House,2,D,Margie Wakefield,64
-Allen,0012 Logan,U.S. House,2,D,Margie Wakefield,22
-Allen,0013 Marmaton,U.S. House,2,D,Margie Wakefield,84
-Allen,0014 Osage,U.S. House,2,D,Margie Wakefield,35
-Allen,0015 Salem,U.S. House,2,D,Margie Wakefield,31
-Allen,"0016 City of Humboldt, WD 1",U.S. House,2,D,Margie Wakefield,93
-Allen,0017 City of Humboldt- WD 2,U.S. House,2,D,Margie Wakefield,99
-Allen,"0018 City of Iola, Wd 1",U.S. House,2,D,Margie Wakefield,132
-Allen,"0019 City of Iola, Wd 2",U.S. House,2,D,Margie Wakefield,155
-Allen,"0020 City of Iola, Wd 3",U.S. House,2,D,Margie Wakefield,168
-Allen,"0021 City of Iola, Wd 4",U.S. House,2,D,Margie Wakefield,165
-Allen,0001 Carlyle,U.S. House,2,L,Chris Clemmons,3
-Allen,0002 Cottage Grove,U.S. House,2,L,Chris Clemmons,2
-Allen,0003 Deer Creek,U.S. House,2,L,Chris Clemmons,6
-Allen,0004 E Elm twp-Laharpe,U.S. House,2,L,Chris Clemmons,19
-Allen,0005 W Elm twp,U.S. House,2,L,Chris Clemmons,22
-Allen,0006 N Elsmore twp,U.S. House,2,L,Chris Clemmons,2
-Allen,0007 S Elsmore twp,U.S. House,2,L,Chris Clemmons,3
-Allen,0008 Geneva,U.S. House,2,L,Chris Clemmons,2
-Allen,0009 Humboldt twp,U.S. House,2,L,Chris Clemmons,7
-Allen,0010 N Iola twp,U.S. House,2,L,Chris Clemmons,6
-Allen,0011 S Iola twp,U.S. House,2,L,Chris Clemmons,18
-Allen,0012 Logan,U.S. House,2,L,Chris Clemmons,4
-Allen,0013 Marmaton,U.S. House,2,L,Chris Clemmons,17
-Allen,0014 Osage,U.S. House,2,L,Chris Clemmons,3
-Allen,0015 Salem,U.S. House,2,L,Chris Clemmons,10
-Allen,"0016 City of Humboldt, WD 1",U.S. House,2,L,Chris Clemmons,28
-Allen,0017 City of Humboldt- WD 2,U.S. House,2,L,Chris Clemmons,20
-Allen,"0018 City of Iola, Wd 1",U.S. House,2,L,Chris Clemmons,27
-Allen,"0019 City of Iola, Wd 2",U.S. House,2,L,Chris Clemmons,20
-Allen,"0020 City of Iola, Wd 3",U.S. House,2,L,Chris Clemmons,24
-Allen,"0021 City of Iola, Wd 4",U.S. House,2,L,Chris Clemmons,25
-Allen,0001 Carlyle,Governor,,R ,Sam Brownback,88
-Allen,0002 Cottage Grove,Governor,,R ,Sam Brownback,64
-Allen,0003 Deer Creek,Governor,,R ,Sam Brownback,28
-Allen,0004 E Elm twp-Laharpe,Governor,,R ,Sam Brownback,108
-Allen,0005 W Elm twp,Governor,,R ,Sam Brownback,228
-Allen,0006 N Elsmore twp,Governor,,R ,Sam Brownback,39
-Allen,0007 S Elsmore twp,Governor,,R ,Sam Brownback,27
-Allen,0008 Geneva,Governor,,R ,Sam Brownback,39
-Allen,0009 Humboldt twp,Governor,,R ,Sam Brownback,66
-Allen,0010 N Iola twp,Governor,,R ,Sam Brownback,70
-Allen,0011 S Iola twp,Governor,,R ,Sam Brownback,137
-Allen,0012 Logan,Governor,,R ,Sam Brownback,53
-Allen,0013 Marmaton,Governor,,R ,Sam Brownback,121
-Allen,0014 Osage,Governor,,R ,Sam Brownback,46
-Allen,0015 Salem,Governor,,R ,Sam Brownback,50
-Allen,"0016 City of Humboldt, WD 1",Governor,,R ,Sam Brownback,104
-Allen,0017 City of Humboldt- WD 2,Governor,,R ,Sam Brownback,152
-Allen,"0018 City of Iola, Wd 1",Governor,,R ,Sam Brownback,185
-Allen,"0019 City of Iola, Wd 2",Governor,,R ,Sam Brownback,268
-Allen,"0020 City of Iola, Wd 3",Governor,,R ,Sam Brownback,189
-Allen,"0021 City of Iola, Wd 4",Governor,,R ,Sam Brownback,206
-Allen,0001 Carlyle,Governor,,D,Paul Davis,39
-Allen,0002 Cottage Grove,Governor,,D,Paul Davis,20
-Allen,0003 Deer Creek,Governor,,D,Paul Davis,20
-Allen,0004 E Elm twp-Laharpe,Governor,,D,Paul Davis,100
-Allen,0005 W Elm twp,Governor,,D,Paul Davis,183
-Allen,0006 N Elsmore twp,Governor,,D,Paul Davis,18
-Allen,0007 S Elsmore twp,Governor,,D,Paul Davis,26
-Allen,0008 Geneva,Governor,,D,Paul Davis,14
-Allen,0009 Humboldt twp,Governor,,D,Paul Davis,37
-Allen,0010 N Iola twp,Governor,,D,Paul Davis,34
-Allen,0011 S Iola twp,Governor,,D,Paul Davis,100
-Allen,0012 Logan,Governor,,D,Paul Davis,25
-Allen,0013 Marmaton,Governor,,D,Paul Davis,122
-Allen,0014 Osage,Governor,,D,Paul Davis,43
-Allen,0015 Salem,Governor,,D,Paul Davis,49
-Allen,"0016 City of Humboldt, WD 1",Governor,,D,Paul Davis,127
-Allen,0017 City of Humboldt- WD 2,Governor,,D,Paul Davis,139
-Allen,"0018 City of Iola, Wd 1",Governor,,D,Paul Davis,192
-Allen,"0019 City of Iola, Wd 2",Governor,,D,Paul Davis,241
-Allen,"0020 City of Iola, Wd 3",Governor,,D,Paul Davis,234
-Allen,"0021 City of Iola, Wd 4",Governor,,D,Paul Davis,218
-Allen,0001 Carlyle,Governor,,L,Keen Umbehr,3
-Allen,0002 Cottage Grove,Governor,,L,Keen Umbehr,2
-Allen,0003 Deer Creek,Governor,,L,Keen Umbehr,3
-Allen,0004 E Elm twp-Laharpe,Governor,,L,Keen Umbehr,11
-Allen,0005 W Elm twp,Governor,,L,Keen Umbehr,12
-Allen,0006 N Elsmore twp,Governor,,L,Keen Umbehr,6
-Allen,0007 S Elsmore twp,Governor,,L,Keen Umbehr,0
-Allen,0008 Geneva,Governor,,L,Keen Umbehr,2
-Allen,0009 Humboldt twp,Governor,,L,Keen Umbehr,6
-Allen,0010 N Iola twp,Governor,,L,Keen Umbehr,6
-Allen,0011 S Iola twp,Governor,,L,Keen Umbehr,14
-Allen,0012 Logan,Governor,,L,Keen Umbehr,4
-Allen,0013 Marmaton,Governor,,L,Keen Umbehr,19
-Allen,0014 Osage,Governor,,L,Keen Umbehr,8
-Allen,0015 Salem,Governor,,L,Keen Umbehr,7
-Allen,"0016 City of Humboldt, WD 1",Governor,,L,Keen Umbehr,17
-Allen,0017 City of Humboldt- WD 2,Governor,,L,Keen Umbehr,16
-Allen,"0018 City of Iola, Wd 1",Governor,,L,Keen Umbehr,20
-Allen,"0019 City of Iola, Wd 2",Governor,,L,Keen Umbehr,11
-Allen,"0020 City of Iola, Wd 3",Governor,,L,Keen Umbehr,21
-Allen,"0021 City of Iola, Wd 4",Governor,,L,Keen Umbehr,23
-Allen,0001 Carlyle,Secretary of State,,R ,Kris Kobach,96
-Allen,0002 Cottage Grove,Secretary of State,,R ,Kris Kobach,64
-Allen,0003 Deer Creek,Secretary of State,,R ,Kris Kobach,33
-Allen,0004 E Elm twp-Laharpe,Secretary of State,,R ,Kris Kobach,135
-Allen,0005 W Elm twp,Secretary of State,,R ,Kris Kobach,288
-Allen,0006 N Elsmore twp,Secretary of State,,R ,Kris Kobach,45
-Allen,0007 S Elsmore twp,Secretary of State,,R ,Kris Kobach,31
-Allen,0008 Geneva,Secretary of State,,R ,Kris Kobach,41
-Allen,0009 Humboldt twp,Secretary of State,,R ,Kris Kobach,78
-Allen,0010 N Iola twp,Secretary of State,,R ,Kris Kobach,78
-Allen,0011 S Iola twp,Secretary of State,,R ,Kris Kobach,166
-Allen,0012 Logan,Secretary of State,,R ,Kris Kobach,58
-Allen,0013 Marmaton,Secretary of State,,R ,Kris Kobach,166
-Allen,0014 Osage,Secretary of State,,R ,Kris Kobach,59
-Allen,0015 Salem,Secretary of State,,R ,Kris Kobach,64
-Allen,"0016 City of Humboldt, WD 1",Secretary of State,,R ,Kris Kobach,142
-Allen,0017 City of Humboldt- WD 2,Secretary of State,,R ,Kris Kobach,194
-Allen,"0018 City of Iola, Wd 1",Secretary of State,,R ,Kris Kobach,236
-Allen,"0019 City of Iola, Wd 2",Secretary of State,,R ,Kris Kobach,348
-Allen,"0020 City of Iola, Wd 3",Secretary of State,,R ,Kris Kobach,247
-Allen,"0021 City of Iola, Wd 4",Secretary of State,,R ,Kris Kobach,257
-Allen,0001 Carlyle,Secretary of State,,D,Jean Schodorf,29
-Allen,0002 Cottage Grove,Secretary of State,,D,Jean Schodorf,19
-Allen,0003 Deer Creek,Secretary of State,,D,Jean Schodorf,18
-Allen,0004 E Elm twp-Laharpe,Secretary of State,,D,Jean Schodorf,79
-Allen,0005 W Elm twp,Secretary of State,,D,Jean Schodorf,127
-Allen,0006 N Elsmore twp,Secretary of State,,D,Jean Schodorf,16
-Allen,0007 S Elsmore twp,Secretary of State,,D,Jean Schodorf,20
-Allen,0008 Geneva,Secretary of State,,D,Jean Schodorf,14
-Allen,0009 Humboldt twp,Secretary of State,,D,Jean Schodorf,27
-Allen,0010 N Iola twp,Secretary of State,,D,Jean Schodorf,29
-Allen,0011 S Iola twp,Secretary of State,,D,Jean Schodorf,77
-Allen,0012 Logan,Secretary of State,,D,Jean Schodorf,23
-Allen,0013 Marmaton,Secretary of State,,D,Jean Schodorf,89
-Allen,0014 Osage,Secretary of State,,D,Jean Schodorf,36
-Allen,0015 Salem,Secretary of State,,D,Jean Schodorf,42
-Allen,"0016 City of Humboldt, WD 1",Secretary of State,,D,Jean Schodorf,102
-Allen,0017 City of Humboldt- WD 2,Secretary of State,,D,Jean Schodorf,105
-Allen,"0018 City of Iola, Wd 1",Secretary of State,,D,Jean Schodorf,153
-Allen,"0019 City of Iola, Wd 2",Secretary of State,,D,Jean Schodorf,162
-Allen,"0020 City of Iola, Wd 3",Secretary of State,,D,Jean Schodorf,191
-Allen,"0021 City of Iola, Wd 4",Secretary of State,,D,Jean Schodorf,184
-Allen,0001 Carlyle,Attorney General,,R ,Derek Schmidt,110
-Allen,0002 Cottage Grove,Attorney General,,R ,Derek Schmidt,71
-Allen,0003 Deer Creek,Attorney General,,R ,Derek Schmidt,41
-Allen,0004 E Elm twp-Laharpe,Attorney General,,R ,Derek Schmidt,151
-Allen,0005 W Elm twp,Attorney General,,R ,Derek Schmidt,322
-Allen,0006 N Elsmore twp,Attorney General,,R ,Derek Schmidt,54
-Allen,0007 S Elsmore twp,Attorney General,,R ,Derek Schmidt,39
-Allen,0008 Geneva,Attorney General,,R ,Derek Schmidt,46
-Allen,0009 Humboldt twp,Attorney General,,R ,Derek Schmidt,88
-Allen,0010 N Iola twp,Attorney General,,R ,Derek Schmidt,87
-Allen,0011 S Iola twp,Attorney General,,R ,Derek Schmidt,203
-Allen,0012 Logan,Attorney General,,R ,Derek Schmidt,68
-Allen,0013 Marmaton,Attorney General,,R ,Derek Schmidt,204
-Allen,0014 Osage,Attorney General,,R ,Derek Schmidt,71
-Allen,0015 Salem,Attorney General,,R ,Derek Schmidt,76
-Allen,"0016 City of Humboldt, WD 1",Attorney General,,R ,Derek Schmidt,162
-Allen,0017 City of Humboldt- WD 2,Attorney General,,R ,Derek Schmidt,228
-Allen,"0018 City of Iola, Wd 1",Attorney General,,R ,Derek Schmidt,306
-Allen,"0019 City of Iola, Wd 2",Attorney General,,R ,Derek Schmidt,425
-Allen,"0020 City of Iola, Wd 3",Attorney General,,R ,Derek Schmidt,311
-Allen,"0021 City of Iola, Wd 4",Attorney General,,R ,Derek Schmidt,310
-Allen,0001 Carlyle,Attorney General,,D,A J Kotich,18
-Allen,0002 Cottage Grove,Attorney General,,D,A J Kotich,13
-Allen,0003 Deer Creek,Attorney General,,D,A J Kotich,11
-Allen,0004 E Elm twp-Laharpe,Attorney General,,D,A J Kotich,65
-Allen,0005 W Elm twp,Attorney General,,D,A J Kotich,92
-Allen,0006 N Elsmore twp,Attorney General,,D,A J Kotich,10
-Allen,0007 S Elsmore twp,Attorney General,,D,A J Kotich,14
-Allen,0008 Geneva,Attorney General,,D,A J Kotich,9
-Allen,0009 Humboldt twp,Attorney General,,D,A J Kotich,22
-Allen,0010 N Iola twp,Attorney General,,D,A J Kotich,21
-Allen,0011 S Iola twp,Attorney General,,D,A J Kotich,46
-Allen,0012 Logan,Attorney General,,D,A J Kotich,13
-Allen,0013 Marmaton,Attorney General,,D,A J Kotich,60
-Allen,0014 Osage,Attorney General,,D,A J Kotich,25
-Allen,0015 Salem,Attorney General,,D,A J Kotich,29
-Allen,"0016 City of Humboldt, WD 1",Attorney General,,D,A J Kotich,82
-Allen,0017 City of Humboldt- WD 2,Attorney General,,D,A J Kotich,74
-Allen,"0018 City of Iola, Wd 1",Attorney General,,D,A J Kotich,87
-Allen,"0019 City of Iola, Wd 2",Attorney General,,D,A J Kotich,87
-Allen,"0020 City of Iola, Wd 3",Attorney General,,D,A J Kotich,125
-Allen,"0021 City of Iola, Wd 4",Attorney General,,D,A J Kotich,133
-Allen,0001 Carlyle,State Treasurer,,R ,Ron Estes,105
-Allen,0002 Cottage Grove,State Treasurer,,R ,Ron Estes,69
-Allen,0003 Deer Creek,State Treasurer,,R ,Ron Estes,35
-Allen,0004 E Elm twp-Laharpe,State Treasurer,,R ,Ron Estes,141
-Allen,0005 W Elm twp,State Treasurer,,R ,Ron Estes,298
-Allen,0006 N Elsmore twp,State Treasurer,,R ,Ron Estes,53
-Allen,0007 S Elsmore twp,State Treasurer,,R ,Ron Estes,35
-Allen,0008 Geneva,State Treasurer,,R ,Ron Estes,42
-Allen,0009 Humboldt twp,State Treasurer,,R ,Ron Estes,80
-Allen,0010 N Iola twp,State Treasurer,,R ,Ron Estes,82
-Allen,0011 S Iola twp,State Treasurer,,R ,Ron Estes,177
-Allen,0012 Logan,State Treasurer,,R ,Ron Estes,61
-Allen,0013 Marmaton,State Treasurer,,R ,Ron Estes,180
-Allen,0014 Osage,State Treasurer,,R ,Ron Estes,69
-Allen,0015 Salem,State Treasurer,,R ,Ron Estes,70
-Allen,"0016 City of Humboldt, WD 1",State Treasurer,,R ,Ron Estes,152
-Allen,0017 City of Humboldt- WD 2,State Treasurer,,R ,Ron Estes,213
-Allen,"0018 City of Iola, Wd 1",State Treasurer,,R ,Ron Estes,255
-Allen,"0019 City of Iola, Wd 2",State Treasurer,,R ,Ron Estes,365
-Allen,"0020 City of Iola, Wd 3",State Treasurer,,R ,Ron Estes,272
-Allen,"0021 City of Iola, Wd 4",State Treasurer,,R ,Ron Estes,276
-Allen,0001 Carlyle,State Treasurer,,D,Carmen Alldritt,105
-Allen,0002 Cottage Grove,State Treasurer,,D,Carmen Alldritt,69
-Allen,0003 Deer Creek,State Treasurer,,D,Carmen Alldritt,35
-Allen,0004 E Elm twp-Laharpe,State Treasurer,,D,Carmen Alldritt,141
-Allen,0005 W Elm twp,State Treasurer,,D,Carmen Alldritt,298
-Allen,0006 N Elsmore twp,State Treasurer,,D,Carmen Alldritt,53
-Allen,0007 S Elsmore twp,State Treasurer,,D,Carmen Alldritt,35
-Allen,0008 Geneva,State Treasurer,,D,Carmen Alldritt,42
-Allen,0009 Humboldt twp,State Treasurer,,D,Carmen Alldritt,80
-Allen,0010 N Iola twp,State Treasurer,,D,Carmen Alldritt,82
-Allen,0011 S Iola twp,State Treasurer,,D,Carmen Alldritt,177
-Allen,0012 Logan,State Treasurer,,D,Carmen Alldritt,61
-Allen,0013 Marmaton,State Treasurer,,D,Carmen Alldritt,180
-Allen,0014 Osage,State Treasurer,,D,Carmen Alldritt,69
-Allen,0015 Salem,State Treasurer,,D,Carmen Alldritt,70
-Allen,"0016 City of Humboldt, WD 1",State Treasurer,,D,Carmen Alldritt,152
-Allen,0017 City of Humboldt- WD 2,State Treasurer,,D,Carmen Alldritt,213
-Allen,"0018 City of Iola, Wd 1",State Treasurer,,D,Carmen Alldritt,255
-Allen,"0019 City of Iola, Wd 2",State Treasurer,,D,Carmen Alldritt,365
-Allen,"0020 City of Iola, Wd 3",State Treasurer,,D,Carmen Alldritt,272
-Allen,"0021 City of Iola, Wd 4",State Treasurer,,D,Carmen Alldritt,276
-Allen,0001 Carlyle,Insurance Commissioner,,R ,Ken Selzer,94
-Allen,0002 Cottage Grove,Insurance Commissioner,,R ,Ken Selzer,70
-Allen,0003 Deer Creek,Insurance Commissioner,,R ,Ken Selzer,32
-Allen,0004 E Elm twp-Laharpe,Insurance Commissioner,,R ,Ken Selzer,122
-Allen,0005 W Elm twp,Insurance Commissioner,,R ,Ken Selzer,284
-Allen,0006 N Elsmore twp,Insurance Commissioner,,R ,Ken Selzer,46
-Allen,0007 S Elsmore twp,Insurance Commissioner,,R ,Ken Selzer,35
-Allen,0008 Geneva,Insurance Commissioner,,R ,Ken Selzer,40
-Allen,0009 Humboldt twp,Insurance Commissioner,,R ,Ken Selzer,73
-Allen,0010 N Iola twp,Insurance Commissioner,,R ,Ken Selzer,80
-Allen,0011 S Iola twp,Insurance Commissioner,,R ,Ken Selzer,161
-Allen,0012 Logan,Insurance Commissioner,,R ,Ken Selzer,52
-Allen,0013 Marmaton,Insurance Commissioner,,R ,Ken Selzer,170
-Allen,0014 Osage,Insurance Commissioner,,R ,Ken Selzer,60
-Allen,0015 Salem,Insurance Commissioner,,R ,Ken Selzer,66
-Allen,"0016 City of Humboldt, WD 1",Insurance Commissioner,,R ,Ken Selzer,133
-Allen,0017 City of Humboldt- WD 2,Insurance Commissioner,,R ,Ken Selzer,187
-Allen,"0018 City of Iola, Wd 1",Insurance Commissioner,,R ,Ken Selzer,231
-Allen,"0019 City of Iola, Wd 2",Insurance Commissioner,,R ,Ken Selzer,342
-Allen,"0020 City of Iola, Wd 3",Insurance Commissioner,,R ,Ken Selzer,233
-Allen,"0021 City of Iola, Wd 4",Insurance Commissioner,,R ,Ken Selzer,247
-Allen,0001 Carlyle,Insurance Commissioner,,D,Dennis Anderson,29
-Allen,0002 Cottage Grove,Insurance Commissioner,,D,Dennis Anderson,14
-Allen,0003 Deer Creek,Insurance Commissioner,,D,Dennis Anderson,17
-Allen,0004 E Elm twp-Laharpe,Insurance Commissioner,,D,Dennis Anderson,87
-Allen,0005 W Elm twp,Insurance Commissioner,,D,Dennis Anderson,123
-Allen,0006 N Elsmore twp,Insurance Commissioner,,D,Dennis Anderson,16
-Allen,0007 S Elsmore twp,Insurance Commissioner,,D,Dennis Anderson,18
-Allen,0008 Geneva,Insurance Commissioner,,D,Dennis Anderson,13
-Allen,0009 Humboldt twp,Insurance Commissioner,,D,Dennis Anderson,31
-Allen,0010 N Iola twp,Insurance Commissioner,,D,Dennis Anderson,27
-Allen,0011 S Iola twp,Insurance Commissioner,,D,Dennis Anderson,77
-Allen,0012 Logan,Insurance Commissioner,,D,Dennis Anderson,28
-Allen,0013 Marmaton,Insurance Commissioner,,D,Dennis Anderson,80
-Allen,0014 Osage,Insurance Commissioner,,D,Dennis Anderson,34
-Allen,0015 Salem,Insurance Commissioner,,D,Dennis Anderson,39
-Allen,"0016 City of Humboldt, WD 1",Insurance Commissioner,,D,Dennis Anderson,108
-Allen,0017 City of Humboldt- WD 2,Insurance Commissioner,,D,Dennis Anderson,106
-Allen,"0018 City of Iola, Wd 1",Insurance Commissioner,,D,Dennis Anderson,151
-Allen,"0019 City of Iola, Wd 2",Insurance Commissioner,,D,Dennis Anderson,150
-Allen,"0020 City of Iola, Wd 3",Insurance Commissioner,,D,Dennis Anderson,190
-Allen,"0021 City of Iola, Wd 4",Insurance Commissioner,,D,Dennis Anderson,180
-Allen,0001 CARLYLE TWP,State House,9,R,Kent L. Thompson (REP),111
-Allen,0002 COTTAGE GROVE TWP,State House,9,R,Kent L. Thompson (REP),76
-Allen,0003 DEER CREEK TWP,State House,9,R,Kent L. Thompson (REP),42
-Allen,0004 EAST ELM TWP-LAHARPE,State House,9,R,Kent L. Thompson (REP),183
-Allen,0005 WEST ELM TWP,State House,9,R,Kent L. Thompson (REP),357
-Allen,0008 GENEVA TWP,State House,9,R,Kent L. Thompson (REP),48
-Allen,0009 HUMBOLDT TWP,State House,9,R,Kent L. Thompson (REP),98
-Allen,0010 NORTH IOLA TWP,State House,9,R,Kent L. Thompson (REP),97
-Allen,0011 SOUTH IOLA TWP,State House,9,R,Kent L. Thompson (REP),224
-Allen,0012 LOGAN TWP,State House,9,R,Kent L. Thompson (REP),77
-Allen,0015 SALEM TWP,State House,9,R,Kent L. Thompson (REP),95
-Allen,"0016 CITY OF HUMBOLDT, WD 1",State House,9,R,Kent L. Thompson (REP),209
-Allen,0017 CITY OF HUMBOLDT- WD 2,State House,9,R,Kent L. Thompson (REP),282
-Allen,"0018 City of Iola, Wd 1",State House,9,R,Kent L. Thompson (REP),342
-Allen,"0019 City of Iola, Wd 2",State House,9,R,Kent L. Thompson (REP),463
-Allen,"0020 City of Iola, Wd 3",State House,9,R,Kent L. Thompson (REP),389
-Allen,"0021 City of Iola, Wd 4",State House,9,R,Kent L. Thompson (REP),376
-Allen,0006 NORTH ELSMORE TWP,State House,2,D,"Adam J. Lusker, Sr. (DEM)",31
-Allen,0007 SOUTH ELSMORE TWP,State House,2,D,"Adam J. Lusker, Sr. (DEM)",28
-Allen,0013 MARMATON TWP,State House,2,D,"Adam J. Lusker, Sr. (DEM)",181
-Allen,0014 OSAGE TWP,State House,2,D,"Adam J. Lusker, Sr. (DEM)",61
+county,precinct,office,district,party,candidate,votes,vtd
+ALLEN,Carlyle Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000010
+ALLEN,Carlyle Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000010
+ALLEN,Carlyle Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",88,000010
+ALLEN,Cottage Grove Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000020
+ALLEN,Cottage Grove Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+ALLEN,Cottage Grove Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000020
+ALLEN,Deer Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000030
+ALLEN,Deer Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000030
+ALLEN,Deer Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000030
+ALLEN,East Elm,Governor / Lt. Governor,,Democratic,"Davis, Paul",100,000040
+ALLEN,East Elm,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000040
+ALLEN,East Elm,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,000040
+ALLEN,Geneva Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000050
+ALLEN,Geneva Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000050
+ALLEN,Geneva Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000050
+ALLEN,Humboldt Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,00006A
+ALLEN,Humboldt Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00006A
+ALLEN,Humboldt Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,00006A
+ALLEN,Humboldt Township Rural Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006B
+ALLEN,Humboldt Township Rural Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006B
+ALLEN,Humboldt Township Split,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006C
+ALLEN,Humboldt Township Split,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006C
+ALLEN,Humboldt Township Split,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006C
+ALLEN,Humboldt Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",127,000070
+ALLEN,Humboldt Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000070
+ALLEN,Humboldt Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",104,000070
+ALLEN,Humboldt Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",139,000080
+ALLEN,Humboldt Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000080
+ALLEN,Humboldt Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",152,000080
+ALLEN,Iola Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",192,000090
+ALLEN,Iola Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000090
+ALLEN,Iola Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",185,000090
+ALLEN,Iola Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",241,00010A
+ALLEN,Iola Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,00010A
+ALLEN,Iola Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",268,00010A
+ALLEN,Iola Ward 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00010B
+ALLEN,Iola Ward 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00010B
+ALLEN,Iola Ward 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00010B
+ALLEN,Iola Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",234,000110
+ALLEN,Iola Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000110
+ALLEN,Iola Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",189,000110
+ALLEN,Iola Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",218,000120
+ALLEN,Iola Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000120
+ALLEN,Iola Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",206,000120
+ALLEN,Marmaton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",122,000140
+ALLEN,Marmaton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000140
+ALLEN,Marmaton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",121,000140
+ALLEN,North Elsmore,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000150
+ALLEN,North Elsmore,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000150
+ALLEN,North Elsmore,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000150
+ALLEN,North Iola Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,00016A
+ALLEN,North Iola Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00016A
+ALLEN,North Iola Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,00016A
+ALLEN,North Iola Part A Rural Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00016B
+ALLEN,North Iola Part A Rural Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00016B
+ALLEN,North Iola Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00016C
+ALLEN,North Iola Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00016C
+ALLEN,North Iola Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00016C
+ALLEN,Osage Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000170
+ALLEN,Osage Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000170
+ALLEN,Osage Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000170
+ALLEN,Salem Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000180
+ALLEN,Salem Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000180
+ALLEN,Salem Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000180
+ALLEN,South Elsmore,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000190
+ALLEN,South Elsmore,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000190
+ALLEN,South Elsmore,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000190
+ALLEN,South Iola,Governor / Lt. Governor,,Democratic,"Davis, Paul",100,00020A
+ALLEN,South Iola,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00020A
+ALLEN,South Iola,Governor / Lt. Governor,,Republican,"Brownback, Sam",137,00020A
+ALLEN,South Iola Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00020B
+ALLEN,South Iola Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00020B
+ALLEN,South Iola Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00020B
+ALLEN,West Elm,Governor / Lt. Governor,,Democratic,"Davis, Paul",183,000210
+ALLEN,West Elm,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000210
+ALLEN,West Elm,Governor / Lt. Governor,,Republican,"Brownback, Sam",228,000210
+ALLEN,Logan Township S12,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,120020
+ALLEN,Logan Township S12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,120020
+ALLEN,Logan Township S12,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,120020
+ALLEN,Logan Township S15,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120030
+ALLEN,Logan Township S15,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+ALLEN,Logan Township S15,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120030
+ALLEN,Carlyle Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",111,000010
+ALLEN,Cottage Grove Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",76,000020
+ALLEN,Deer Creek Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",42,000030
+ALLEN,East Elm,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",183,000040
+ALLEN,Geneva Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",48,000050
+ALLEN,Humboldt Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",98,00006A
+ALLEN,Humboldt Township Rural Enclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00006B
+ALLEN,Humboldt Township Split,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00006C
+ALLEN,Humboldt Ward 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",209,000070
+ALLEN,Humboldt Ward 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",282,000080
+ALLEN,Iola Ward 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",342,000090
+ALLEN,Iola Ward 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",463,00010A
+ALLEN,Iola Ward 2 Exclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00010B
+ALLEN,Iola Ward 3,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",389,000110
+ALLEN,Iola Ward 4,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",376,000120
+ALLEN,Marmaton Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",181,000140
+ALLEN,North Elsmore,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",31,000150
+ALLEN,North Iola Part A,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",97,00016A
+ALLEN,North Iola Part A Rural Enclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00016B
+ALLEN,North Iola Part B,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00016C
+ALLEN,Osage Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",61,000170
+ALLEN,Salem Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",95,000180
+ALLEN,South Elsmore,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",28,000190
+ALLEN,South Iola,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",224,00020A
+ALLEN,South Iola Enclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00020B
+ALLEN,West Elm,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",357,000210
+ALLEN,Logan Township S12,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",77,120020
+ALLEN,Logan Township S15,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,120030
+ALLEN,Carlyle Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",29,000010
+ALLEN,Carlyle Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000010
+ALLEN,Carlyle Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000010
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000020
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000020
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,000020
+ALLEN,Deer Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",12,000030
+ALLEN,Deer Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000030
+ALLEN,Deer Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000030
+ALLEN,East Elm,United States House of Representatives,2,Democratic,"Wakefield, Margie",72,000040
+ALLEN,East Elm,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000040
+ALLEN,East Elm,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,000040
+ALLEN,Geneva Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000050
+ALLEN,Geneva Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000050
+ALLEN,Geneva Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,000050
+ALLEN,Humboldt Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,00006A
+ALLEN,Humboldt Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,00006A
+ALLEN,Humboldt Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",74,00006A
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006B
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00006C
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00006C
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006C
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",93,000070
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",28,000070
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",126,000070
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",99,000080
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,000080
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,000080
+ALLEN,Iola Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",132,000090
+ALLEN,Iola Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,000090
+ALLEN,Iola Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",237,000090
+ALLEN,Iola Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",155,00010A
+ALLEN,Iola Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,00010A
+ALLEN,Iola Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",345,00010A
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+ALLEN,Iola Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",168,000110
+ALLEN,Iola Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000110
+ALLEN,Iola Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",249,000110
+ALLEN,Iola Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",165,000120
+ALLEN,Iola Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",25,000120
+ALLEN,Iola Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",258,000120
+ALLEN,Marmaton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",84,000140
+ALLEN,Marmaton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000140
+ALLEN,Marmaton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",160,000140
+ALLEN,North Elsmore,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,000150
+ALLEN,North Elsmore,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000150
+ALLEN,North Elsmore,United States House of Representatives,2,Republican,"Jenkins, Lynn",48,000150
+ALLEN,North Iola Part A,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,00016A
+ALLEN,North Iola Part A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,00016A
+ALLEN,North Iola Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,00016A
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016B
+ALLEN,North Iola Part B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00016C
+ALLEN,North Iola Part B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00016C
+ALLEN,North Iola Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016C
+ALLEN,Osage Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",35,000170
+ALLEN,Osage Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000170
+ALLEN,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000170
+ALLEN,Salem Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,000180
+ALLEN,Salem Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000180
+ALLEN,Salem Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000180
+ALLEN,South Elsmore,United States House of Representatives,2,Democratic,"Wakefield, Margie",19,000190
+ALLEN,South Elsmore,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000190
+ALLEN,South Elsmore,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000190
+ALLEN,South Iola,United States House of Representatives,2,Democratic,"Wakefield, Margie",64,00020A
+ALLEN,South Iola,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,00020A
+ALLEN,South Iola,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,00020A
+ALLEN,South Iola Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00020B
+ALLEN,South Iola Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00020B
+ALLEN,South Iola Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020B
+ALLEN,West Elm,United States House of Representatives,2,Democratic,"Wakefield, Margie",113,000210
+ALLEN,West Elm,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,000210
+ALLEN,West Elm,United States House of Representatives,2,Republican,"Jenkins, Lynn",288,000210
+ALLEN,Logan Township S12,United States House of Representatives,2,Democratic,"Wakefield, Margie",22,120020
+ALLEN,Logan Township S12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,120020
+ALLEN,Logan Township S12,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,120020
+ALLEN,Logan Township S15,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120030
+ALLEN,Logan Township S15,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120030
+ALLEN,Logan Township S15,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+ALLEN,Carlyle Township,Attorney General,,Democratic,"Kotich, A.J.",18,000010
+ALLEN,Carlyle Township,Attorney General,,Republican,"Schmidt, Derek",110,000010
+ALLEN,Cottage Grove Township,Attorney General,,Democratic,"Kotich, A.J.",13,000020
+ALLEN,Cottage Grove Township,Attorney General,,Republican,"Schmidt, Derek",71,000020
+ALLEN,Deer Creek Township,Attorney General,,Democratic,"Kotich, A.J.",11,000030
+ALLEN,Deer Creek Township,Attorney General,,Republican,"Schmidt, Derek",41,000030
+ALLEN,East Elm,Attorney General,,Democratic,"Kotich, A.J.",65,000040
+ALLEN,East Elm,Attorney General,,Republican,"Schmidt, Derek",151,000040
+ALLEN,Geneva Township,Attorney General,,Democratic,"Kotich, A.J.",9,000050
+ALLEN,Geneva Township,Attorney General,,Republican,"Schmidt, Derek",46,000050
+ALLEN,Humboldt Township,Attorney General,,Democratic,"Kotich, A.J.",22,00006A
+ALLEN,Humboldt Township,Attorney General,,Republican,"Schmidt, Derek",88,00006A
+ALLEN,Humboldt Township Rural Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00006B
+ALLEN,Humboldt Township Split,Attorney General,,Democratic,"Kotich, A.J.",0,00006C
+ALLEN,Humboldt Township Split,Attorney General,,Republican,"Schmidt, Derek",0,00006C
+ALLEN,Humboldt Ward 1,Attorney General,,Democratic,"Kotich, A.J.",82,000070
+ALLEN,Humboldt Ward 1,Attorney General,,Republican,"Schmidt, Derek",162,000070
+ALLEN,Humboldt Ward 2,Attorney General,,Democratic,"Kotich, A.J.",74,000080
+ALLEN,Humboldt Ward 2,Attorney General,,Republican,"Schmidt, Derek",228,000080
+ALLEN,Iola Ward 1,Attorney General,,Democratic,"Kotich, A.J.",87,000090
+ALLEN,Iola Ward 1,Attorney General,,Republican,"Schmidt, Derek",306,000090
+ALLEN,Iola Ward 2,Attorney General,,Democratic,"Kotich, A.J.",87,00010A
+ALLEN,Iola Ward 2,Attorney General,,Republican,"Schmidt, Derek",425,00010A
+ALLEN,Iola Ward 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00010B
+ALLEN,Iola Ward 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00010B
+ALLEN,Iola Ward 3,Attorney General,,Democratic,"Kotich, A.J.",125,000110
+ALLEN,Iola Ward 3,Attorney General,,Republican,"Schmidt, Derek",311,000110
+ALLEN,Iola Ward 4,Attorney General,,Democratic,"Kotich, A.J.",133,000120
+ALLEN,Iola Ward 4,Attorney General,,Republican,"Schmidt, Derek",310,000120
+ALLEN,Marmaton Township,Attorney General,,Democratic,"Kotich, A.J.",60,000140
+ALLEN,Marmaton Township,Attorney General,,Republican,"Schmidt, Derek",204,000140
+ALLEN,North Elsmore,Attorney General,,Democratic,"Kotich, A.J.",10,000150
+ALLEN,North Elsmore,Attorney General,,Republican,"Schmidt, Derek",54,000150
+ALLEN,North Iola Part A,Attorney General,,Democratic,"Kotich, A.J.",21,00016A
+ALLEN,North Iola Part A,Attorney General,,Republican,"Schmidt, Derek",87,00016A
+ALLEN,North Iola Part A Rural Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00016B
+ALLEN,North Iola Part B,Attorney General,,Democratic,"Kotich, A.J.",0,00016C
+ALLEN,North Iola Part B,Attorney General,,Republican,"Schmidt, Derek",0,00016C
+ALLEN,Osage Township,Attorney General,,Democratic,"Kotich, A.J.",25,000170
+ALLEN,Osage Township,Attorney General,,Republican,"Schmidt, Derek",71,000170
+ALLEN,Salem Township,Attorney General,,Democratic,"Kotich, A.J.",29,000180
+ALLEN,Salem Township,Attorney General,,Republican,"Schmidt, Derek",76,000180
+ALLEN,South Elsmore,Attorney General,,Democratic,"Kotich, A.J.",14,000190
+ALLEN,South Elsmore,Attorney General,,Republican,"Schmidt, Derek",39,000190
+ALLEN,South Iola,Attorney General,,Democratic,"Kotich, A.J.",46,00020A
+ALLEN,South Iola,Attorney General,,Republican,"Schmidt, Derek",203,00020A
+ALLEN,South Iola Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00020B
+ALLEN,South Iola Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00020B
+ALLEN,West Elm,Attorney General,,Democratic,"Kotich, A.J.",92,000210
+ALLEN,West Elm,Attorney General,,Republican,"Schmidt, Derek",322,000210
+ALLEN,Logan Township S12,Attorney General,,Democratic,"Kotich, A.J.",13,120020
+ALLEN,Logan Township S12,Attorney General,,Republican,"Schmidt, Derek",68,120020
+ALLEN,Logan Township S15,Attorney General,,Democratic,"Kotich, A.J.",0,120030
+ALLEN,Logan Township S15,Attorney General,,Republican,"Schmidt, Derek",0,120030
+ALLEN,Carlyle Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000010
+ALLEN,Carlyle Township,Commissioner of Insurance,,Republican,"Selzer, Ken",94,000010
+ALLEN,Cottage Grove Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000020
+ALLEN,Cottage Grove Township,Commissioner of Insurance,,Republican,"Selzer, Ken",70,000020
+ALLEN,Deer Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000030
+ALLEN,Deer Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000030
+ALLEN,East Elm,Commissioner of Insurance,,Democratic,"Anderson, Dennis",87,000040
+ALLEN,East Elm,Commissioner of Insurance,,Republican,"Selzer, Ken",122,000040
+ALLEN,Geneva Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000050
+ALLEN,Geneva Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000050
+ALLEN,Humboldt Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,00006A
+ALLEN,Humboldt Township,Commissioner of Insurance,,Republican,"Selzer, Ken",73,00006A
+ALLEN,Humboldt Township Rural Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006B
+ALLEN,Humboldt Township Rural Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006B
+ALLEN,Humboldt Township Split,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006C
+ALLEN,Humboldt Township Split,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006C
+ALLEN,Humboldt Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",108,000070
+ALLEN,Humboldt Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000070
+ALLEN,Humboldt Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",106,000080
+ALLEN,Humboldt Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",187,000080
+ALLEN,Iola Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",151,000090
+ALLEN,Iola Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",231,000090
+ALLEN,Iola Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",150,00010A
+ALLEN,Iola Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",342,00010A
+ALLEN,Iola Ward 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00010B
+ALLEN,Iola Ward 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00010B
+ALLEN,Iola Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",190,000110
+ALLEN,Iola Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",233,000110
+ALLEN,Iola Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",180,000120
+ALLEN,Iola Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",247,000120
+ALLEN,Marmaton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000140
+ALLEN,Marmaton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",170,000140
+ALLEN,North Elsmore,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000150
+ALLEN,North Elsmore,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000150
+ALLEN,North Iola Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,00016A
+ALLEN,North Iola Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",80,00016A
+ALLEN,North Iola Part A Rural Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00016B
+ALLEN,North Iola Part A Rural Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00016B
+ALLEN,North Iola Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00016C
+ALLEN,North Iola Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00016C
+ALLEN,Osage Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000170
+ALLEN,Osage Township,Commissioner of Insurance,,Republican,"Selzer, Ken",60,000170
+ALLEN,Salem Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000180
+ALLEN,Salem Township,Commissioner of Insurance,,Republican,"Selzer, Ken",66,000180
+ALLEN,South Elsmore,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000190
+ALLEN,South Elsmore,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000190
+ALLEN,South Iola,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,00020A
+ALLEN,South Iola,Commissioner of Insurance,,Republican,"Selzer, Ken",161,00020A
+ALLEN,South Iola Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00020B
+ALLEN,South Iola Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00020B
+ALLEN,West Elm,Commissioner of Insurance,,Democratic,"Anderson, Dennis",123,000210
+ALLEN,West Elm,Commissioner of Insurance,,Republican,"Selzer, Ken",284,000210
+ALLEN,Logan Township S12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,120020
+ALLEN,Logan Township S12,Commissioner of Insurance,,Republican,"Selzer, Ken",52,120020
+ALLEN,Logan Township S15,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120030
+ALLEN,Logan Township S15,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120030
+ALLEN,Carlyle Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000010
+ALLEN,Carlyle Township,Secretary of State,,Republican,"Kobach, Kris",96,000010
+ALLEN,Cottage Grove Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000020
+ALLEN,Cottage Grove Township,Secretary of State,,Republican,"Kobach, Kris",64,000020
+ALLEN,Deer Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000030
+ALLEN,Deer Creek Township,Secretary of State,,Republican,"Kobach, Kris",33,000030
+ALLEN,East Elm,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",79,000040
+ALLEN,East Elm,Secretary of State,,Republican,"Kobach, Kris",135,000040
+ALLEN,Geneva Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000050
+ALLEN,Geneva Township,Secretary of State,,Republican,"Kobach, Kris",41,000050
+ALLEN,Humboldt Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,00006A
+ALLEN,Humboldt Township,Secretary of State,,Republican,"Kobach, Kris",78,00006A
+ALLEN,Humboldt Township Rural Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006B
+ALLEN,Humboldt Township Rural Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00006B
+ALLEN,Humboldt Township Split,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006C
+ALLEN,Humboldt Township Split,Secretary of State,,Republican,"Kobach, Kris",0,00006C
+ALLEN,Humboldt Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",102,000070
+ALLEN,Humboldt Ward 1,Secretary of State,,Republican,"Kobach, Kris",142,000070
+ALLEN,Humboldt Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,000080
+ALLEN,Humboldt Ward 2,Secretary of State,,Republican,"Kobach, Kris",194,000080
+ALLEN,Iola Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",153,000090
+ALLEN,Iola Ward 1,Secretary of State,,Republican,"Kobach, Kris",236,000090
+ALLEN,Iola Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",162,00010A
+ALLEN,Iola Ward 2,Secretary of State,,Republican,"Kobach, Kris",348,00010A
+ALLEN,Iola Ward 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00010B
+ALLEN,Iola Ward 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00010B
+ALLEN,Iola Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",191,000110
+ALLEN,Iola Ward 3,Secretary of State,,Republican,"Kobach, Kris",247,000110
+ALLEN,Iola Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",184,000120
+ALLEN,Iola Ward 4,Secretary of State,,Republican,"Kobach, Kris",257,000120
+ALLEN,Marmaton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,000140
+ALLEN,Marmaton Township,Secretary of State,,Republican,"Kobach, Kris",166,000140
+ALLEN,North Elsmore,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000150
+ALLEN,North Elsmore,Secretary of State,,Republican,"Kobach, Kris",45,000150
+ALLEN,North Iola Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,00016A
+ALLEN,North Iola Part A,Secretary of State,,Republican,"Kobach, Kris",78,00016A
+ALLEN,North Iola Part A Rural Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00016B
+ALLEN,North Iola Part A Rural Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00016B
+ALLEN,North Iola Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00016C
+ALLEN,North Iola Part B,Secretary of State,,Republican,"Kobach, Kris",0,00016C
+ALLEN,Osage Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000170
+ALLEN,Osage Township,Secretary of State,,Republican,"Kobach, Kris",59,000170
+ALLEN,Salem Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000180
+ALLEN,Salem Township,Secretary of State,,Republican,"Kobach, Kris",64,000180
+ALLEN,South Elsmore,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000190
+ALLEN,South Elsmore,Secretary of State,,Republican,"Kobach, Kris",31,000190
+ALLEN,South Iola,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,00020A
+ALLEN,South Iola,Secretary of State,,Republican,"Kobach, Kris",166,00020A
+ALLEN,South Iola Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00020B
+ALLEN,South Iola Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00020B
+ALLEN,West Elm,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",127,000210
+ALLEN,West Elm,Secretary of State,,Republican,"Kobach, Kris",288,000210
+ALLEN,Logan Township S12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,120020
+ALLEN,Logan Township S12,Secretary of State,,Republican,"Kobach, Kris",58,120020
+ALLEN,Logan Township S15,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120030
+ALLEN,Logan Township S15,Secretary of State,,Republican,"Kobach, Kris",0,120030
+ALLEN,Carlyle Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000010
+ALLEN,Carlyle Township,State Treasurer,,Republican,"Estes, Ron",105,000010
+ALLEN,Cottage Grove Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000020
+ALLEN,Cottage Grove Township,State Treasurer,,Republican,"Estes, Ron",69,000020
+ALLEN,Deer Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000030
+ALLEN,Deer Creek Township,State Treasurer,,Republican,"Estes, Ron",35,000030
+ALLEN,East Elm,State Treasurer,,Democratic,"Alldritt, Carmen",72,000040
+ALLEN,East Elm,State Treasurer,,Republican,"Estes, Ron",141,000040
+ALLEN,Geneva Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000050
+ALLEN,Geneva Township,State Treasurer,,Republican,"Estes, Ron",42,000050
+ALLEN,Humboldt Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,00006A
+ALLEN,Humboldt Township,State Treasurer,,Republican,"Estes, Ron",80,00006A
+ALLEN,Humboldt Township Rural Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006B
+ALLEN,Humboldt Township Rural Enclave,State Treasurer,,Republican,"Estes, Ron",0,00006B
+ALLEN,Humboldt Township Split,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006C
+ALLEN,Humboldt Township Split,State Treasurer,,Republican,"Estes, Ron",0,00006C
+ALLEN,Humboldt Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",92,000070
+ALLEN,Humboldt Ward 1,State Treasurer,,Republican,"Estes, Ron",152,000070
+ALLEN,Humboldt Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",86,000080
+ALLEN,Humboldt Ward 2,State Treasurer,,Republican,"Estes, Ron",213,000080
+ALLEN,Iola Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",131,000090
+ALLEN,Iola Ward 1,State Treasurer,,Republican,"Estes, Ron",255,000090
+ALLEN,Iola Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",135,00010A
+ALLEN,Iola Ward 2,State Treasurer,,Republican,"Estes, Ron",365,00010A
+ALLEN,Iola Ward 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00010B
+ALLEN,Iola Ward 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00010B
+ALLEN,Iola Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",158,000110
+ALLEN,Iola Ward 3,State Treasurer,,Republican,"Estes, Ron",272,000110
+ALLEN,Iola Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",159,000120
+ALLEN,Iola Ward 4,State Treasurer,,Republican,"Estes, Ron",276,000120
+ALLEN,Marmaton Township,State Treasurer,,Democratic,"Alldritt, Carmen",76,000140
+ALLEN,Marmaton Township,State Treasurer,,Republican,"Estes, Ron",180,000140
+ALLEN,North Elsmore,State Treasurer,,Democratic,"Alldritt, Carmen",10,000150
+ALLEN,North Elsmore,State Treasurer,,Republican,"Estes, Ron",53,000150
+ALLEN,North Iola Part A,State Treasurer,,Democratic,"Alldritt, Carmen",24,00016A
+ALLEN,North Iola Part A,State Treasurer,,Republican,"Estes, Ron",82,00016A
+ALLEN,North Iola Part A Rural Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00016B
+ALLEN,North Iola Part A Rural Enclave,State Treasurer,,Republican,"Estes, Ron",0,00016B
+ALLEN,North Iola Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00016C
+ALLEN,North Iola Part B,State Treasurer,,Republican,"Estes, Ron",0,00016C
+ALLEN,Osage Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000170
+ALLEN,Osage Township,State Treasurer,,Republican,"Estes, Ron",69,000170
+ALLEN,Salem Township,State Treasurer,,Democratic,"Alldritt, Carmen",35,000180
+ALLEN,Salem Township,State Treasurer,,Republican,"Estes, Ron",70,000180
+ALLEN,South Elsmore,State Treasurer,,Democratic,"Alldritt, Carmen",18,000190
+ALLEN,South Elsmore,State Treasurer,,Republican,"Estes, Ron",35,000190
+ALLEN,South Iola,State Treasurer,,Democratic,"Alldritt, Carmen",65,00020A
+ALLEN,South Iola,State Treasurer,,Republican,"Estes, Ron",177,00020A
+ALLEN,South Iola Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00020B
+ALLEN,South Iola Enclave,State Treasurer,,Republican,"Estes, Ron",0,00020B
+ALLEN,West Elm,State Treasurer,,Democratic,"Alldritt, Carmen",113,000210
+ALLEN,West Elm,State Treasurer,,Republican,"Estes, Ron",298,000210
+ALLEN,Logan Township S12,State Treasurer,,Democratic,"Alldritt, Carmen",20,120020
+ALLEN,Logan Township S12,State Treasurer,,Republican,"Estes, Ron",61,120020
+ALLEN,Logan Township S15,State Treasurer,,Democratic,"Alldritt, Carmen",0,120030
+ALLEN,Logan Township S15,State Treasurer,,Republican,"Estes, Ron",0,120030
+ALLEN,Carlyle Township,United States Senate,,independent,"Orman, Greg",26,000010
+ALLEN,Carlyle Township,United States Senate,,Libertarian,"Batson, Randall",6,000010
+ALLEN,Carlyle Township,United States Senate,,Republican,"Roberts, Pat",98,000010
+ALLEN,Cottage Grove Township,United States Senate,,independent,"Orman, Greg",19,000020
+ALLEN,Cottage Grove Township,United States Senate,,Libertarian,"Batson, Randall",4,000020
+ALLEN,Cottage Grove Township,United States Senate,,Republican,"Roberts, Pat",63,000020
+ALLEN,Deer Creek Township,United States Senate,,independent,"Orman, Greg",15,000030
+ALLEN,Deer Creek Township,United States Senate,,Libertarian,"Batson, Randall",6,000030
+ALLEN,Deer Creek Township,United States Senate,,Republican,"Roberts, Pat",29,000030
+ALLEN,East Elm,United States Senate,,independent,"Orman, Greg",88,000040
+ALLEN,East Elm,United States Senate,,Libertarian,"Batson, Randall",21,000040
+ALLEN,East Elm,United States Senate,,Republican,"Roberts, Pat",111,000040
+ALLEN,Geneva Township,United States Senate,,independent,"Orman, Greg",11,000050
+ALLEN,Geneva Township,United States Senate,,Libertarian,"Batson, Randall",3,000050
+ALLEN,Geneva Township,United States Senate,,Republican,"Roberts, Pat",40,000050
+ALLEN,Humboldt Township,United States Senate,,independent,"Orman, Greg",35,00006A
+ALLEN,Humboldt Township,United States Senate,,Libertarian,"Batson, Randall",9,00006A
+ALLEN,Humboldt Township,United States Senate,,Republican,"Roberts, Pat",65,00006A
+ALLEN,Humboldt Township Rural Enclave,United States Senate,,independent,"Orman, Greg",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States Senate,,Republican,"Roberts, Pat",0,00006B
+ALLEN,Humboldt Township Split,United States Senate,,independent,"Orman, Greg",0,00006C
+ALLEN,Humboldt Township Split,United States Senate,,Libertarian,"Batson, Randall",0,00006C
+ALLEN,Humboldt Township Split,United States Senate,,Republican,"Roberts, Pat",0,00006C
+ALLEN,Humboldt Ward 1,United States Senate,,independent,"Orman, Greg",100,000070
+ALLEN,Humboldt Ward 1,United States Senate,,Libertarian,"Batson, Randall",29,000070
+ALLEN,Humboldt Ward 1,United States Senate,,Republican,"Roberts, Pat",118,000070
+ALLEN,Humboldt Ward 2,United States Senate,,independent,"Orman, Greg",119,000080
+ALLEN,Humboldt Ward 2,United States Senate,,Libertarian,"Batson, Randall",33,000080
+ALLEN,Humboldt Ward 2,United States Senate,,Republican,"Roberts, Pat",150,000080
+ALLEN,Iola Ward 1,United States Senate,,independent,"Orman, Greg",155,000090
+ALLEN,Iola Ward 1,United States Senate,,Libertarian,"Batson, Randall",31,000090
+ALLEN,Iola Ward 1,United States Senate,,Republican,"Roberts, Pat",210,000090
+ALLEN,Iola Ward 2,United States Senate,,independent,"Orman, Greg",177,00010A
+ALLEN,Iola Ward 2,United States Senate,,Libertarian,"Batson, Randall",20,00010A
+ALLEN,Iola Ward 2,United States Senate,,Republican,"Roberts, Pat",322,00010A
+ALLEN,Iola Ward 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00010B
+ALLEN,Iola Ward 3,United States Senate,,independent,"Orman, Greg",189,000110
+ALLEN,Iola Ward 3,United States Senate,,Libertarian,"Batson, Randall",34,000110
+ALLEN,Iola Ward 3,United States Senate,,Republican,"Roberts, Pat",213,000110
+ALLEN,Iola Ward 4,United States Senate,,independent,"Orman, Greg",185,000120
+ALLEN,Iola Ward 4,United States Senate,,Libertarian,"Batson, Randall",26,000120
+ALLEN,Iola Ward 4,United States Senate,,Republican,"Roberts, Pat",239,000120
+ALLEN,Marmaton Township,United States Senate,,independent,"Orman, Greg",97,000140
+ALLEN,Marmaton Township,United States Senate,,Libertarian,"Batson, Randall",26,000140
+ALLEN,Marmaton Township,United States Senate,,Republican,"Roberts, Pat",136,000140
+ALLEN,North Elsmore,United States Senate,,independent,"Orman, Greg",11,000150
+ALLEN,North Elsmore,United States Senate,,Libertarian,"Batson, Randall",4,000150
+ALLEN,North Elsmore,United States Senate,,Republican,"Roberts, Pat",44,000150
+ALLEN,North Iola Part A,United States Senate,,independent,"Orman, Greg",23,00016A
+ALLEN,North Iola Part A,United States Senate,,Libertarian,"Batson, Randall",9,00016A
+ALLEN,North Iola Part A,United States Senate,,Republican,"Roberts, Pat",78,00016A
+ALLEN,North Iola Part A Rural Enclave,United States Senate,,independent,"Orman, Greg",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States Senate,,Republican,"Roberts, Pat",0,00016B
+ALLEN,North Iola Part B,United States Senate,,independent,"Orman, Greg",0,00016C
+ALLEN,North Iola Part B,United States Senate,,Libertarian,"Batson, Randall",0,00016C
+ALLEN,North Iola Part B,United States Senate,,Republican,"Roberts, Pat",0,00016C
+ALLEN,Osage Township,United States Senate,,independent,"Orman, Greg",37,000170
+ALLEN,Osage Township,United States Senate,,Libertarian,"Batson, Randall",5,000170
+ALLEN,Osage Township,United States Senate,,Republican,"Roberts, Pat",56,000170
+ALLEN,Salem Township,United States Senate,,independent,"Orman, Greg",39,000180
+ALLEN,Salem Township,United States Senate,,Libertarian,"Batson, Randall",11,000180
+ALLEN,Salem Township,United States Senate,,Republican,"Roberts, Pat",55,000180
+ALLEN,South Elsmore,United States Senate,,independent,"Orman, Greg",19,000190
+ALLEN,South Elsmore,United States Senate,,Libertarian,"Batson, Randall",3,000190
+ALLEN,South Elsmore,United States Senate,,Republican,"Roberts, Pat",29,000190
+ALLEN,South Iola,United States Senate,,independent,"Orman, Greg",79,00020A
+ALLEN,South Iola,United States Senate,,Libertarian,"Batson, Randall",17,00020A
+ALLEN,South Iola,United States Senate,,Republican,"Roberts, Pat",154,00020A
+ALLEN,South Iola Enclave,United States Senate,,independent,"Orman, Greg",0,00020B
+ALLEN,South Iola Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00020B
+ALLEN,South Iola Enclave,United States Senate,,Republican,"Roberts, Pat",0,00020B
+ALLEN,West Elm,United States Senate,,independent,"Orman, Greg",116,000210
+ALLEN,West Elm,United States Senate,,Libertarian,"Batson, Randall",28,000210
+ALLEN,West Elm,United States Senate,,Republican,"Roberts, Pat",271,000210
+ALLEN,Logan Township S12,United States Senate,,independent,"Orman, Greg",24,120020
+ALLEN,Logan Township S12,United States Senate,,Libertarian,"Batson, Randall",8,120020
+ALLEN,Logan Township S12,United States Senate,,Republican,"Roberts, Pat",50,120020
+ALLEN,Logan Township S15,United States Senate,,independent,"Orman, Greg",0,120030
+ALLEN,Logan Township S15,United States Senate,,Libertarian,"Batson, Randall",0,120030
+ALLEN,Logan Township S15,United States Senate,,Republican,"Roberts, Pat",0,120030

--- a/2014/20141104__ks__general__anderson__precinct.csv
+++ b/2014/20141104__ks__general__anderson__precinct.csv
@@ -1,396 +1,343 @@
-county,precinct,office,district,party,candidate,votes
-Anderson,Reeder,Ballots,,,Votes Cast,181
-Anderson,Putnam,Ballots,,,Votes Cast,221
-Anderson,Walker,Ballots,,,Votes Cast,458
-Anderson,Monroe,Ballots,,,Votes Cast,239
-Anderson,Jackson,Ballots,,,Votes Cast,288
-Anderson,Westphalia,Ballots,,,Votes Cast,238
-Anderson,Washington,Ballots,,,Votes Cast,193
-Anderson,Welda,Ballots,,,Votes Cast,209
-Anderson,Lincoln,Ballots,,,Votes Cast,136
-Anderson,Rich ,Ballots,,,Votes Cast,268
-Anderson,Lone Elm,Ballots,,,Votes Cast,168
-Anderson,Ozark,Ballots,,,Votes Cast,413
-Anderson,Indian Creek,Ballots,,,Votes Cast,93
-Anderson,Garnett Wd 1,Ballots,,,Votes Cast,763
-Anderson,Garnett Wd 2,Ballots,,,Votes Cast,657
-Anderson,Garnett Wd 3,Ballots,,,Votes Cast,645
-Anderson,Garnett Wd 4,Ballots,,,Votes Cast,159
-Anderson,Reeder,U.S. Senate,,R,Pat Roberts,34
-Anderson,Putnam,U.S. Senate,,R,Pat Roberts,41
-Anderson,Walker,U.S. Senate,,R,Pat Roberts,116
-Anderson,Monroe,U.S. Senate,,R,Pat Roberts,72
-Anderson,Jackson,U.S. Senate,,R,Pat Roberts,92
-Anderson,Westphalia,U.S. Senate,,R,Pat Roberts,71
-Anderson,Washington,U.S. Senate,,R,Pat Roberts,49
-Anderson,Welda,U.S. Senate,,R,Pat Roberts,60
-Anderson,Lincoln,U.S. Senate,,R,Pat Roberts,40
-Anderson,Rich ,U.S. Senate,,R,Pat Roberts,70
-Anderson,Lone Elm,U.S. Senate,,R,Pat Roberts,47
-Anderson,Ozark,U.S. Senate,,R,Pat Roberts,124
-Anderson,Indian Creek,U.S. Senate,,R,Pat Roberts,29
-Anderson,Garnett Wd 1,U.S. Senate,,R,Pat Roberts,172
-Anderson,Garnett Wd 2,U.S. Senate,,R,Pat Roberts,172
-Anderson,Garnett Wd 3,U.S. Senate,,R,Pat Roberts,121
-Anderson,Garnett Wd 4,U.S. Senate,,R,Pat Roberts,27
-Anderson,Prov,U.S. Senate,,R,Pat Roberts,24
-Anderson,Absent,U.S. Senate,,R,Pat Roberts,193
-Anderson,Reeder,U.S. Senate,,I,Greg Orton,17
-Anderson,Putnam,U.S. Senate,,I,Greg Orton,28
-Anderson,Walker,U.S. Senate,,I,Greg Orton,87
-Anderson,Monroe,U.S. Senate,,I,Greg Orton,39
-Anderson,Jackson,U.S. Senate,,I,Greg Orton,37
-Anderson,Westphalia,U.S. Senate,,I,Greg Orton,18
-Anderson,Washington,U.S. Senate,,I,Greg Orton,32
-Anderson,Welda,U.S. Senate,,I,Greg Orton,31
-Anderson,Lincoln,U.S. Senate,,I,Greg Orton,19
-Anderson,Rich ,U.S. Senate,,I,Greg Orton,36
-Anderson,Lone Elm,U.S. Senate,,I,Greg Orton,23
-Anderson,Ozark,U.S. Senate,,I,Greg Orton,46
-Anderson,Indian Creek,U.S. Senate,,I,Greg Orton,9
-Anderson,Garnett Wd 1,U.S. Senate,,I,Greg Orton,98
-Anderson,Garnett Wd 2,U.S. Senate,,I,Greg Orton,91
-Anderson,Garnett Wd 3,U.S. Senate,,I,Greg Orton,74
-Anderson,Garnett Wd 4,U.S. Senate,,I,Greg Orton,18
-Anderson,Prov,U.S. Senate,,I,Greg Orton,9
-Anderson,Absent,U.S. Senate,,I,Greg Orton,114
-Anderson,Reeder,U.S. Senate,,L,Randall Batson,3
-Anderson,Putnam,U.S. Senate,,L,Randall Batson,11
-Anderson,Walker,U.S. Senate,,L,Randall Batson,21
-Anderson,Monroe,U.S. Senate,,L,Randall Batson,3
-Anderson,Jackson,U.S. Senate,,L,Randall Batson,4
-Anderson,Westphalia,U.S. Senate,,L,Randall Batson,5
-Anderson,Washington,U.S. Senate,,L,Randall Batson,2
-Anderson,Welda,U.S. Senate,,L,Randall Batson,8
-Anderson,Lincoln,U.S. Senate,,L,Randall Batson,2
-Anderson,Rich ,U.S. Senate,,L,Randall Batson,7
-Anderson,Lone Elm,U.S. Senate,,L,Randall Batson,3
-Anderson,Ozark,U.S. Senate,,L,Randall Batson,13
-Anderson,Indian Creek,U.S. Senate,,L,Randall Batson,1
-Anderson,Garnett Wd 1,U.S. Senate,,L,Randall Batson,22
-Anderson,Garnett Wd 2,U.S. Senate,,L,Randall Batson,17
-Anderson,Garnett Wd 3,U.S. Senate,,L,Randall Batson,13
-Anderson,Garnett Wd 4,U.S. Senate,,L,Randall Batson,3
-Anderson,Prov,U.S. Senate,,L,Randall Batson,4
-Anderson,Absent,U.S. Senate,,L,Randall Batson,15
-Anderson,Reeder,U.S. House,2,R,Lynn Jenkins,39
-Anderson,Putnam,U.S. House,2,R,Lynn Jenkins,45
-Anderson,Walker,U.S. House,2,R,Lynn Jenkins,151
-Anderson,Monroe,U.S. House,2,R,Lynn Jenkins,83
-Anderson,Jackson,U.S. House,2,R,Lynn Jenkins,111
-Anderson,Westphalia,U.S. House,2,R,Lynn Jenkins,69
-Anderson,Washington,U.S. House,2,R,Lynn Jenkins,58
-Anderson,Welda,U.S. House,2,R,Lynn Jenkins,69
-Anderson,Lincoln,U.S. House,2,R,Lynn Jenkins,49
-Anderson,Rich ,U.S. House,2,R,Lynn Jenkins,95
-Anderson,Lone Elm,U.S. House,2,R,Lynn Jenkins,55
-Anderson,Ozark,U.S. House,2,R,Lynn Jenkins,144
-Anderson,Indian Creek,U.S. House,2,R,Lynn Jenkins,35
-Anderson,Garnett Wd 1,U.S. House,2,R,Lynn Jenkins,214
-Anderson,Garnett Wd 2,U.S. House,2,R,Lynn Jenkins,206
-Anderson,Garnett Wd 3,U.S. House,2,R,Lynn Jenkins,149
-Anderson,Garnett Wd 4,U.S. House,2,R,Lynn Jenkins,33
-Anderson,Prov,U.S. House,2,R,Lynn Jenkins,30
-Anderson,Absent,U.S. House,2,R,Lynn Jenkins,209
-Anderson,Reeder,U.S. House,2,D,Margie Wakefield,13
-Anderson,Putnam,U.S. House,2,D,Margie Wakefield,29
-Anderson,Walker,U.S. House,2,D,Margie Wakefield,59
-Anderson,Monroe,U.S. House,2,D,Margie Wakefield,30
-Anderson,Jackson,U.S. House,2,D,Margie Wakefield,23
-Anderson,Westphalia,U.S. House,2,D,Margie Wakefield,24
-Anderson,Washington,U.S. House,2,D,Margie Wakefield,22
-Anderson,Welda,U.S. House,2,D,Margie Wakefield,23
-Anderson,Lincoln,U.S. House,2,D,Margie Wakefield,7
-Anderson,Rich ,U.S. House,2,D,Margie Wakefield,19
-Anderson,Lone Elm,U.S. House,2,D,Margie Wakefield,13
-Anderson,Ozark,U.S. House,2,D,Margie Wakefield,34
-Anderson,Indian Creek,U.S. House,2,D,Margie Wakefield,4
-Anderson,Garnett Wd 1,U.S. House,2,D,Margie Wakefield,58
-Anderson,Garnett Wd 2,U.S. House,2,D,Margie Wakefield,62
-Anderson,Garnett Wd 3,U.S. House,2,D,Margie Wakefield,55
-Anderson,Garnett Wd 4,U.S. House,2,D,Margie Wakefield,13
-Anderson,Prov,U.S. House,2,D,Margie Wakefield,7
-Anderson,Absent,U.S. House,2,D,Margie Wakefield,112
-Anderson,Reeder,U.S. House,2,L,Christopher Clemmons,2
-Anderson,Putnam,U.S. House,2,L,Christopher Clemmons,8
-Anderson,Walker,U.S. House,2,L,Christopher Clemmons,13
-Anderson,Monroe,U.S. House,2,L,Christopher Clemmons,1
-Anderson,Jackson,U.S. House,2,L,Christopher Clemmons,1
-Anderson,Westphalia,U.S. House,2,L,Christopher Clemmons,2
-Anderson,Washington,U.S. House,2,L,Christopher Clemmons,3
-Anderson,Welda,U.S. House,2,L,Christopher Clemmons,6
-Anderson,Lincoln,U.S. House,2,L,Christopher Clemmons,4
-Anderson,Rich ,U.S. House,2,L,Christopher Clemmons,3
-Anderson,Lone Elm,U.S. House,2,L,Christopher Clemmons,5
-Anderson,Ozark,U.S. House,2,L,Christopher Clemmons,8
-Anderson,Indian Creek,U.S. House,2,L,Christopher Clemmons,2
-Anderson,Garnett Wd 1,U.S. House,2,L,Christopher Clemmons,23
-Anderson,Garnett Wd 2,U.S. House,2,L,Christopher Clemmons,13
-Anderson,Garnett Wd 3,U.S. House,2,L,Christopher Clemmons,7
-Anderson,Garnett Wd 4,U.S. House,2,L,Christopher Clemmons,2
-Anderson,Prov,U.S. House,2,L,Christopher Clemmons,4
-Anderson,Absent,U.S. House,2,L,Christopher Clemmons,7
-Anderson,Reeder,Governor,,R,Sam Brownback,32
-Anderson,Putnam,Governor,,R,Sam Brownback,38
-Anderson,Walker,Governor,,R,Sam Brownback,110
-Anderson,Monroe,Governor,,R,Sam Brownback,67
-Anderson,Jackson,Governor,,R,Sam Brownback,92
-Anderson,Westphalia,Governor,,R,Sam Brownback,64
-Anderson,Washington,Governor,,R,Sam Brownback,48
-Anderson,Welda,Governor,,R,Sam Brownback,50
-Anderson,Lincoln,Governor,,R,Sam Brownback,39
-Anderson,Rich ,Governor,,R,Sam Brownback,72
-Anderson,Lone Elm,Governor,,R,Sam Brownback,46
-Anderson,Ozark,Governor,,R,Sam Brownback,118
-Anderson,Indian Creek,Governor,,R,Sam Brownback,34
-Anderson,Garnett Wd 1,Governor,,R,Sam Brownback,164
-Anderson,Garnett Wd 2,Governor,,R,Sam Brownback,162
-Anderson,Garnett Wd 3,Governor,,R,Sam Brownback,120
-Anderson,Garnett Wd 4,Governor,,R,Sam Brownback,27
-Anderson,Prov,Governor,,R,Sam Brownback,22
-Anderson,Absent,Governor,,R,Sam Brownback,179
-Anderson,Reeder,Governor,,D,Paul Davis,18
-Anderson,Putnam,Governor,,D,Paul Davis,40
-Anderson,Walker,Governor,,D,Paul Davis,99
-Anderson,Monroe,Governor,,D,Paul Davis,46
-Anderson,Jackson,Governor,,D,Paul Davis,39
-Anderson,Westphalia,Governor,,D,Paul Davis,32
-Anderson,Washington,Governor,,D,Paul Davis,33
-Anderson,Welda,Governor,,D,Paul Davis,41
-Anderson,Lincoln,Governor,,D,Paul Davis,16
-Anderson,Rich ,Governor,,D,Paul Davis,35
-Anderson,Lone Elm,Governor,,D,Paul Davis,19
-Anderson,Ozark,Governor,,D,Paul Davis,53
-Anderson,Indian Creek,Governor,,D,Paul Davis,7
-Anderson,Garnett Wd 1,Governor,,D,Paul Davis,110
-Anderson,Garnett Wd 2,Governor,,D,Paul Davis,104
-Anderson,Garnett Wd 3,Governor,,D,Paul Davis,83
-Anderson,Garnett Wd 4,Governor,,D,Paul Davis,19
-Anderson,Prov,Governor,,D,Paul Davis,10
-Anderson,Absent,Governor,,D,Paul Davis,136
-Anderson,Reeder,Governor,,L,Keen Umbehr,4
-Anderson,Putnam,Governor,,L,Keen Umbehr,4
-Anderson,Walker,Governor,,L,Keen Umbehr,21
-Anderson,Monroe,Governor,,L,Keen Umbehr,1
-Anderson,Jackson,Governor,,L,Keen Umbehr,4
-Anderson,Westphalia,Governor,,L,Keen Umbehr,3
-Anderson,Washington,Governor,,L,Keen Umbehr,2
-Anderson,Welda,Governor,,L,Keen Umbehr,9
-Anderson,Lincoln,Governor,,L,Keen Umbehr,5
-Anderson,Rich ,Governor,,L,Keen Umbehr,6
-Anderson,Lone Elm,Governor,,L,Keen Umbehr,9
-Anderson,Ozark,Governor,,L,Keen Umbehr,14
-Anderson,Indian Creek,Governor,,L,Keen Umbehr,0
-Anderson,Garnett Wd 1,Governor,,L,Keen Umbehr,22
-Anderson,Garnett Wd 2,Governor,,L,Keen Umbehr,15
-Anderson,Garnett Wd 3,Governor,,L,Keen Umbehr,8
-Anderson,Garnett Wd 4,Governor,,L,Keen Umbehr,3
-Anderson,Prov,Governor,,L,Keen Umbehr,5
-Anderson,Absent,Governor,,L,Keen Umbehr,12
-Anderson,Reeder,Secretary of State,,R,Kris Kobach,40
-Anderson,Putnam,Secretary of State,,R,Kris Kobach,45
-Anderson,Walker,Secretary of State,,R,Kris Kobach,136
-Anderson,Monroe,Secretary of State,,R,Kris Kobach,79
-Anderson,Jackson,Secretary of State,,R,Kris Kobach,101
-Anderson,Westphalia,Secretary of State,,R,Kris Kobach,66
-Anderson,Washington,Secretary of State,,R,Kris Kobach,57
-Anderson,Welda,Secretary of State,,R,Kris Kobach,65
-Anderson,Lincoln,Secretary of State,,R,Kris Kobach,47
-Anderson,Rich ,Secretary of State,,R,Kris Kobach,87
-Anderson,Lone Elm,Secretary of State,,R,Kris Kobach,51
-Anderson,Ozark,Secretary of State,,R,Kris Kobach,144
-Anderson,Indian Creek,Secretary of State,,R,Kris Kobach,33
-Anderson,Garnett Wd 1,Secretary of State,,R,Kris Kobach,204
-Anderson,Garnett Wd 2,Secretary of State,,R,Kris Kobach,194
-Anderson,Garnett Wd 3,Secretary of State,,R,Kris Kobach,140
-Anderson,Garnett Wd 4,Secretary of State,,R,Kris Kobach,34
-Anderson,Prov,Secretary of State,,R,Kris Kobach,27
-Anderson,Absent,Secretary of State,,R,Kris Kobach,193
-Anderson,Reeder,Secretary of State,,D,Jean Schodorf,12
-Anderson,Putnam,Secretary of State,,D,Jean Schodorf,30
-Anderson,Walker,Secretary of State,,D,Jean Schodorf,86
-Anderson,Monroe,Secretary of State,,D,Jean Schodorf,33
-Anderson,Jackson,Secretary of State,,D,Jean Schodorf,33
-Anderson,Westphalia,Secretary of State,,D,Jean Schodorf,29
-Anderson,Washington,Secretary of State,,D,Jean Schodorf,26
-Anderson,Welda,Secretary of State,,D,Jean Schodorf,32
-Anderson,Lincoln,Secretary of State,,D,Jean Schodorf,13
-Anderson,Rich ,Secretary of State,,D,Jean Schodorf,23
-Anderson,Lone Elm,Secretary of State,,D,Jean Schodorf,22
-Anderson,Ozark,Secretary of State,,D,Jean Schodorf,40
-Anderson,Indian Creek,Secretary of State,,D,Jean Schodorf,7
-Anderson,Garnett Wd 1,Secretary of State,,D,Jean Schodorf,85
-Anderson,Garnett Wd 2,Secretary of State,,D,Jean Schodorf,82
-Anderson,Garnett Wd 3,Secretary of State,,D,Jean Schodorf,65
-Anderson,Garnett Wd 4,Secretary of State,,D,Jean Schodorf,15
-Anderson,Prov,Secretary of State,,D,Jean Schodorf,10
-Anderson,Absent,Secretary of State,,D,Jean Schodorf,126
-Anderson,Reeder,Attorney General,,R,Derek Schmidt,42
-Anderson,Putnam,Attorney General,,R,Derek Schmidt,44
-Anderson,Walker,Attorney General,,R,Derek Schmidt,144
-Anderson,Monroe,Attorney General,,R,Derek Schmidt,85
-Anderson,Jackson,Attorney General,,R,Derek Schmidt,105
-Anderson,Westphalia,Attorney General,,R,Derek Schmidt,74
-Anderson,Washington,Attorney General,,R,Derek Schmidt,60
-Anderson,Welda,Attorney General,,R,Derek Schmidt,67
-Anderson,Lincoln,Attorney General,,R,Derek Schmidt,52
-Anderson,Rich ,Attorney General,,R,Derek Schmidt,91
-Anderson,Lone Elm,Attorney General,,R,Derek Schmidt,54
-Anderson,Ozark,Attorney General,,R,Derek Schmidt,148
-Anderson,Indian Creek,Attorney General,,R,Derek Schmidt,36
-Anderson,Garnett Wd 1,Attorney General,,R,Derek Schmidt,215
-Anderson,Garnett Wd 2,Attorney General,,R,Derek Schmidt,213
-Anderson,Garnett Wd 3,Attorney General,,R,Derek Schmidt,150
-Anderson,Garnett Wd 4,Attorney General,,R,Derek Schmidt,33
-Anderson,Prov,Attorney General,,R,Derek Schmidt,30
-Anderson,Absent,Attorney General,,R,Derek Schmidt,217
-Anderson,Reeder,Attorney General,,D,AJ Kotich,11
-Anderson,Putnam,Attorney General,,D,AJ Kotich,31
-Anderson,Walker,Attorney General,,D,AJ Kotich,72
-Anderson,Monroe,Attorney General,,D,AJ Kotich,27
-Anderson,Jackson,Attorney General,,D,AJ Kotich,30
-Anderson,Westphalia,Attorney General,,D,AJ Kotich,19
-Anderson,Washington,Attorney General,,D,AJ Kotich,20
-Anderson,Welda,Attorney General,,D,AJ Kotich,32
-Anderson,Lincoln,Attorney General,,D,AJ Kotich,7
-Anderson,Rich ,Attorney General,,D,AJ Kotich,21
-Anderson,Lone Elm,Attorney General,,D,AJ Kotich,18
-Anderson,Ozark,Attorney General,,D,AJ Kotich,34
-Anderson,Indian Creek,Attorney General,,D,AJ Kotich,5
-Anderson,Garnett Wd 1,Attorney General,,D,AJ Kotich,75
-Anderson,Garnett Wd 2,Attorney General,,D,AJ Kotich,66
-Anderson,Garnett Wd 3,Attorney General,,D,AJ Kotich,60
-Anderson,Garnett Wd 4,Attorney General,,D,AJ Kotich,16
-Anderson,Prov,Attorney General,,D,AJ Kotich,7
-Anderson,Absent,Attorney General,,D,AJ Kotich,103
-Anderson,Reeder,State Treasurer,,R,Ron Estes,40
-Anderson,Putnam,State Treasurer,,R,Ron Estes,45
-Anderson,Walker,State Treasurer,,R,Ron Estes,129
-Anderson,Monroe,State Treasurer,,R,Ron Estes,79
-Anderson,Jackson,State Treasurer,,R,Ron Estes,96
-Anderson,Westphalia,State Treasurer,,R,Ron Estes,66
-Anderson,Washington,State Treasurer,,R,Ron Estes,57
-Anderson,Welda,State Treasurer,,R,Ron Estes,70
-Anderson,Lincoln,State Treasurer,,R,Ron Estes,47
-Anderson,Rich ,State Treasurer,,R,Ron Estes,82
-Anderson,Lone Elm,State Treasurer,,R,Ron Estes,55
-Anderson,Ozark,State Treasurer,,R,Ron Estes,132
-Anderson,Indian Creek,State Treasurer,,R,Ron Estes,34
-Anderson,Garnett Wd 1,State Treasurer,,R,Ron Estes,212
-Anderson,Garnett Wd 2,State Treasurer,,R,Ron Estes,203
-Anderson,Garnett Wd 3,State Treasurer,,R,Ron Estes,140
-Anderson,Garnett Wd 4,State Treasurer,,R,Ron Estes,30
-Anderson,Prov,State Treasurer,,R,Ron Estes,26
-Anderson,Absent,State Treasurer,,R,Ron Estes,194
-Anderson,Reeder,State Treasurer,,D,Carmen Alldritt,13
-Anderson,Putnam,State Treasurer,,D,Carmen Alldritt,31
-Anderson,Walker,State Treasurer,,D,Carmen Alldritt,93
-Anderson,Monroe,State Treasurer,,D,Carmen Alldritt,31
-Anderson,Jackson,State Treasurer,,D,Carmen Alldritt,36
-Anderson,Westphalia,State Treasurer,,D,Carmen Alldritt,29
-Anderson,Washington,State Treasurer,,D,Carmen Alldritt,24
-Anderson,Welda,State Treasurer,,D,Carmen Alldritt,28
-Anderson,Lincoln,State Treasurer,,D,Carmen Alldritt,12
-Anderson,Rich ,State Treasurer,,D,Carmen Alldritt,24
-Anderson,Lone Elm,State Treasurer,,D,Carmen Alldritt,16
-Anderson,Ozark,State Treasurer,,D,Carmen Alldritt,49
-Anderson,Indian Creek,State Treasurer,,D,Carmen Alldritt,4
-Anderson,Garnett Wd 1,State Treasurer,,D,Carmen Alldritt,76
-Anderson,Garnett Wd 2,State Treasurer,,D,Carmen Alldritt,75
-Anderson,Garnett Wd 3,State Treasurer,,D,Carmen Alldritt,66
-Anderson,Garnett Wd 4,State Treasurer,,D,Carmen Alldritt,17
-Anderson,Prov,State Treasurer,,D,Carmen Alldritt,10
-Anderson,Absent,State Treasurer,,D,Carmen Alldritt,121
-Anderson,Reeder,Insurance Commissioner,,R,Ken Selzer,37
-Anderson,Putnam,Insurance Commissioner,,R,Ken Selzer,41
-Anderson,Walker,Insurance Commissioner,,R,Ken Selzer,129
-Anderson,Monroe,Insurance Commissioner,,R,Ken Selzer,73
-Anderson,Jackson,Insurance Commissioner,,R,Ken Selzer,97
-Anderson,Westphalia,Insurance Commissioner,,R,Ken Selzer,65
-Anderson,Washington,Insurance Commissioner,,R,Ken Selzer,47
-Anderson,Welda,Insurance Commissioner,,R,Ken Selzer,63
-Anderson,Lincoln,Insurance Commissioner,,R,Ken Selzer,50
-Anderson,Rich ,Insurance Commissioner,,R,Ken Selzer,78
-Anderson,Lone Elm,Insurance Commissioner,,R,Ken Selzer,49
-Anderson,Ozark,Insurance Commissioner,,R,Ken Selzer,140
-Anderson,Indian Creek,Insurance Commissioner,,R,Ken Selzer,31
-Anderson,Garnett Wd 1,Insurance Commissioner,,R,Ken Selzer,196
-Anderson,Garnett Wd 2,Insurance Commissioner,,R,Ken Selzer,189
-Anderson,Garnett Wd 3,Insurance Commissioner,,R,Ken Selzer,137
-Anderson,Garnett Wd 4,Insurance Commissioner,,R,Ken Selzer,29
-Anderson,Prov,Insurance Commissioner,,R,Ken Selzer,27
-Anderson,Absent,Insurance Commissioner,,R,Ken Selzer,191
-Anderson,Reeder,Insurance Commissioner,,D,Dennis Anderson,15
-Anderson,Putnam,Insurance Commissioner,,D,Dennis Anderson,33
-Anderson,Walker,Insurance Commissioner,,D,Dennis Anderson,90
-Anderson,Monroe,Insurance Commissioner,,D,Dennis Anderson,38
-Anderson,Jackson,Insurance Commissioner,,D,Dennis Anderson,35
-Anderson,Westphalia,Insurance Commissioner,,D,Dennis Anderson,29
-Anderson,Washington,Insurance Commissioner,,D,Dennis Anderson,33
-Anderson,Welda,Insurance Commissioner,,D,Dennis Anderson,33
-Anderson,Lincoln,Insurance Commissioner,,D,Dennis Anderson,10
-Anderson,Rich ,Insurance Commissioner,,D,Dennis Anderson,30
-Anderson,Lone Elm,Insurance Commissioner,,D,Dennis Anderson,22
-Anderson,Ozark,Insurance Commissioner,,D,Dennis Anderson,40
-Anderson,Indian Creek,Insurance Commissioner,,D,Dennis Anderson,7
-Anderson,Garnett Wd 1,Insurance Commissioner,,D,Dennis Anderson,86
-Anderson,Garnett Wd 2,Insurance Commissioner,,D,Dennis Anderson,90
-Anderson,Garnett Wd 3,Insurance Commissioner,,D,Dennis Anderson,61
-Anderson,Garnett Wd 4,Insurance Commissioner,,D,Dennis Anderson,20
-Anderson,Prov,Insurance Commissioner,,D,Dennis Anderson,8
-Anderson,Absent,Insurance Commissioner,,D,Dennis Anderson,125
-Anderson,Reeder,State House,5,R,Kevin Jones,38
-Anderson,Putnam,State House,5,R,Kevin Jones,44
-Anderson,Walker,State House,5,R,Kevin Jones,128
-Anderson,Monroe,State House,5,R,Kevin Jones,67
-Anderson,Jackson,State House,5,R,Kevin Jones,90
-Anderson,Westphalia,State House,5,R,Kevin Jones,66
-Anderson,Washington,State House,5,R,Kevin Jones,45
-Anderson,Welda,State House,5,R,Kevin Jones,59
-Anderson,Lincoln,State House,5,R,Kevin Jones,46
-Anderson,Rich ,State House,4,R,Martin Reed,98
-Anderson,Lone Elm,State House,4,R,Martin Reed,56
-Anderson,Ozark,State House,5,R,Kevin Jones,137
-Anderson,Indian Creek,State House,5,R,Kevin Jones,31
-Anderson,Garnett Wd 1,State House,5,R,Kevin Jones,184
-Anderson,Garnett Wd 2,State House,5,R,Kevin Jones,178
-Anderson,Garnett Wd 3,State House,5,R,Kevin Jones,123
-Anderson,Garnett Wd 4,State House,5,R,Kevin Jones,31
-Anderson,Prov,State House,4,R,Martin Reed,3
-Anderson,Absent,State House,4,R,Martin Reed,20
-Anderson,Prov,State House,5,R,Kevin Jones,22
-Anderson,Absent,State House,5,R,Kevin Jones,159
-Anderson,Reeder,State House,5,D,Cleon Rickel,16
-Anderson,Putnam,State House,5,D,Cleon Rickel,34
-Anderson,Walker,State House,5,D,Cleon Rickel,97
-Anderson,Monroe,State House,5,D,Cleon Rickel,45
-Anderson,Jackson,State House,5,D,Cleon Rickel,45
-Anderson,Westphalia,State House,5,D,Cleon Rickel,29
-Anderson,Washington,State House,5,D,Cleon Rickel,37
-Anderson,Welda,State House,5,D,Cleon Rickel,42
-Anderson,Lincoln,State House,5,D,Cleon Rickel,15
-Anderson,Rich ,State House,4,D,Lucas Cousens,18
-Anderson,Lone Elm,State House,4,D,Lucas Cousens,16
-Anderson,Ozark,State House,5,D,Cleon Rickel,45
-Anderson,Indian Creek,State House,5,D,Cleon Rickel,8
-Anderson,Garnett Wd 1,State House,5,D,Cleon Rickel,109
-Anderson,Garnett Wd 2,State House,5,D,Cleon Rickel,99
-Anderson,Garnett Wd 3,State House,5,D,Cleon Rickel,85
-Anderson,Garnett Wd 4,State House,5,D,Cleon Rickel,18
-Anderson,Prov,State House,4,D,Lucas Cousens,8
-Anderson,Absent,State House,4,D,Lucas Cousens,20
-Anderson,Prov,State House,5,D,Cleon Rickel,12
-Anderson,Absent,State House,5,D,Cleon Rickel,136
-Anderson,Walker,State House,5,wri,wri,1
-Anderson,Garnett Wd 1,U.S. Senate,,wri,wri,1
-Anderson,Garnett Wd 2,U.S. Senate,,wri,wri,1
-Anderson,Garnett Wd 3,U.S. Senate,,wri,wri,1
-Anderson,Garnett Wd 2,Governor,,wri,wri,1
-Anderson,Garnett Wd 3,Governor,,wri,wri,1
-Anderson,Garnett Wd 2,Secretary of State,,wri,wri,1
-Anderson,Garnett Wd 3,Secretary of State,,wri,wri,1
-Anderson,Garnett Wd 3,Attorney General,,wri,wri,1
-Anderson,Garnett Wd 3,State Treasurer,,wri,wri,1
-Anderson,Garnett Wd 1,Insurance Commissioner,,wri,wri,1
-Anderson,Garnett Wd 2,Insurance Commissioner,,wri,wri,1
-Anderson,Garnett Wd 3,Insurance Commissioner,,wri,wri,1
+county,precinct,office,district,party,candidate,votes,vtd
+ANDERSON,Garnett Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",134,00002A
+ANDERSON,Garnett Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,00002A
+ANDERSON,Garnett Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",187,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002B
+ANDERSON,Garnett Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",123,000030
+ANDERSON,Garnett Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000030
+ANDERSON,Garnett Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",189,000030
+ANDERSON,Garnett Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",95,000040
+ANDERSON,Garnett Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000040
+ANDERSON,Garnett Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",137,000040
+ANDERSON,Garnett Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000050
+ANDERSON,Garnett Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000050
+ANDERSON,Garnett Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000050
+ANDERSON,Indian Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000080
+ANDERSON,Indian Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+ANDERSON,Indian Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000080
+ANDERSON,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000110
+ANDERSON,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000110
+ANDERSON,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000110
+ANDERSON,Monroe Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,00014A
+ANDERSON,Monroe Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,00014A
+ANDERSON,Monroe Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",78,00014A
+ANDERSON,Putnam Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",60,000170
+ANDERSON,Putnam Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000170
+ANDERSON,Putnam Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000170
+ANDERSON,Reeder Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000180
+ANDERSON,Reeder Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000180
+ANDERSON,Reeder Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000180
+ANDERSON,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000210
+ANDERSON,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000210
+ANDERSON,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",61,000210
+ANDERSON,Welda Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",44,000220
+ANDERSON,Welda Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000220
+ANDERSON,Welda Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000220
+ANDERSON,Lone Elm Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,130010
+ANDERSON,Lone Elm Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,130010
+ANDERSON,Lone Elm Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,130010
+ANDERSON,Ozark Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",59,130020
+ANDERSON,Ozark Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,130020
+ANDERSON,Ozark Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,130020
+ANDERSON,Rich Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,130030
+ANDERSON,Rich Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,130030
+ANDERSON,Rich Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",77,130030
+ANDERSON,Walker Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,130040
+ANDERSON,Walker Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,130040
+ANDERSON,Walker Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",120,130040
+ANDERSON,Westphalia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,130050
+ANDERSON,Westphalia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,130050
+ANDERSON,Westphalia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,130050
+ANDERSON,Jackson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,140010
+ANDERSON,Jackson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,140010
+ANDERSON,Jackson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,140010
+ANDERSON,Garnett Precinct 1,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",135,00002A
+ANDERSON,Garnett Precinct 1,Kansas House of Representatives,5,Republican,"Jones, Kevin",211,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00002B
+ANDERSON,Garnett Precinct 2,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",116,000030
+ANDERSON,Garnett Precinct 2,Kansas House of Representatives,5,Republican,"Jones, Kevin",204,000030
+ANDERSON,Garnett Precinct 3,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",96,000040
+ANDERSON,Garnett Precinct 3,Kansas House of Representatives,5,Republican,"Jones, Kevin",137,000040
+ANDERSON,Garnett Precinct 4,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",21,000050
+ANDERSON,Garnett Precinct 4,Kansas House of Representatives,5,Republican,"Jones, Kevin",34,000050
+ANDERSON,Indian Creek Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",14,000080
+ANDERSON,Indian Creek Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",32,000080
+ANDERSON,Lincoln Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",18,000110
+ANDERSON,Lincoln Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",57,000110
+ANDERSON,Monroe Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",52,00014A
+ANDERSON,Monroe Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",78,00014A
+ANDERSON,Putnam Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",53,000170
+ANDERSON,Putnam Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",62,000170
+ANDERSON,Reeder Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",30,000180
+ANDERSON,Reeder Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",50,000180
+ANDERSON,Washington Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",45,000210
+ANDERSON,Washington Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",57,000210
+ANDERSON,Welda Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",45,000220
+ANDERSON,Welda Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",64,000220
+ANDERSON,Lone Elm Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",18,130010
+ANDERSON,Lone Elm Township,Kansas House of Representatives,4,Republican,"Read, Marty",74,130010
+ANDERSON,Ozark Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",52,130020
+ANDERSON,Ozark Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",149,130020
+ANDERSON,Rich Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",24,130030
+ANDERSON,Rich Township,Kansas House of Representatives,4,Republican,"Read, Marty",103,130030
+ANDERSON,Walker Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",104,130040
+ANDERSON,Walker Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",138,130040
+ANDERSON,Westphalia Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",35,130050
+ANDERSON,Westphalia Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",74,130050
+ANDERSON,Jackson Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",53,140010
+ANDERSON,Jackson Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",96,140010
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",74,00002A
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",26,00002A
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",246,00002A
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002B
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",76,000030
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000030
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",238,000030
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",66,000040
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000040
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000040
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000050
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000050
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",35,000050
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000080
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000080
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,000080
+ANDERSON,Lincoln Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",10,000110
+ANDERSON,Lincoln Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000110
+ANDERSON,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000110
+ANDERSON,Monroe Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",35,00014A
+ANDERSON,Monroe Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,00014A
+ANDERSON,Monroe Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,00014A
+ANDERSON,Putnam Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",46,000170
+ANDERSON,Putnam Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000170
+ANDERSON,Putnam Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,000170
+ANDERSON,Reeder Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,000180
+ANDERSON,Reeder Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000180
+ANDERSON,Reeder Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000180
+ANDERSON,Washington Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,000210
+ANDERSON,Washington Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000210
+ANDERSON,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000210
+ANDERSON,Welda Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,000220
+ANDERSON,Welda Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000220
+ANDERSON,Welda Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000220
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,130010
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,130010
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,130010
+ANDERSON,Ozark Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,130020
+ANDERSON,Ozark Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,130020
+ANDERSON,Ozark Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",158,130020
+ANDERSON,Rich Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",23,130030
+ANDERSON,Rich Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,130030
+ANDERSON,Rich Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",101,130030
+ANDERSON,Walker Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",67,130040
+ANDERSON,Walker Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,130040
+ANDERSON,Walker Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",160,130040
+ANDERSON,Westphalia Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,130050
+ANDERSON,Westphalia Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,130050
+ANDERSON,Westphalia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",83,130050
+ANDERSON,Jackson Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",29,140010
+ANDERSON,Jackson Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,140010
+ANDERSON,Jackson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,140010
+ANDERSON,Garnett Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",91,00002A
+ANDERSON,Garnett Precinct 1,Attorney General,,Republican,"Schmidt, Derek",250,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00002B
+ANDERSON,Garnett Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",79,000030
+ANDERSON,Garnett Precinct 2,Attorney General,,Republican,"Schmidt, Derek",243,000030
+ANDERSON,Garnett Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",71,000040
+ANDERSON,Garnett Precinct 3,Attorney General,,Republican,"Schmidt, Derek",167,000040
+ANDERSON,Garnett Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",19,000050
+ANDERSON,Garnett Precinct 4,Attorney General,,Republican,"Schmidt, Derek",36,000050
+ANDERSON,Indian Creek Township,Attorney General,,Democratic,"Kotich, A.J.",11,000080
+ANDERSON,Indian Creek Township,Attorney General,,Republican,"Schmidt, Derek",38,000080
+ANDERSON,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",9,000110
+ANDERSON,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",66,000110
+ANDERSON,Monroe Township,Attorney General,,Democratic,"Kotich, A.J.",31,00014A
+ANDERSON,Monroe Township,Attorney General,,Republican,"Schmidt, Derek",99,00014A
+ANDERSON,Putnam Township,Attorney General,,Democratic,"Kotich, A.J.",47,000170
+ANDERSON,Putnam Township,Attorney General,,Republican,"Schmidt, Derek",65,000170
+ANDERSON,Reeder Township,Attorney General,,Democratic,"Kotich, A.J.",20,000180
+ANDERSON,Reeder Township,Attorney General,,Republican,"Schmidt, Derek",59,000180
+ANDERSON,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",24,000210
+ANDERSON,Washington Township,Attorney General,,Republican,"Schmidt, Derek",76,000210
+ANDERSON,Welda Township,Attorney General,,Democratic,"Kotich, A.J.",35,000220
+ANDERSON,Welda Township,Attorney General,,Republican,"Schmidt, Derek",71,000220
+ANDERSON,Lone Elm Township,Attorney General,,Democratic,"Kotich, A.J.",19,130010
+ANDERSON,Lone Elm Township,Attorney General,,Republican,"Schmidt, Derek",73,130010
+ANDERSON,Ozark Township,Attorney General,,Democratic,"Kotich, A.J.",41,130020
+ANDERSON,Ozark Township,Attorney General,,Republican,"Schmidt, Derek",159,130020
+ANDERSON,Rich Township,Attorney General,,Democratic,"Kotich, A.J.",26,130030
+ANDERSON,Rich Township,Attorney General,,Republican,"Schmidt, Derek",97,130030
+ANDERSON,Walker Township,Attorney General,,Democratic,"Kotich, A.J.",77,130040
+ANDERSON,Walker Township,Attorney General,,Republican,"Schmidt, Derek",156,130040
+ANDERSON,Westphalia Township,Attorney General,,Democratic,"Kotich, A.J.",20,130050
+ANDERSON,Westphalia Township,Attorney General,,Republican,"Schmidt, Derek",87,130050
+ANDERSON,Jackson Township,Attorney General,,Democratic,"Kotich, A.J.",34,140010
+ANDERSON,Jackson Township,Attorney General,,Republican,"Schmidt, Derek",118,140010
+ANDERSON,Garnett Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",106,00002A
+ANDERSON,Garnett Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",227,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002B
+ANDERSON,Garnett Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",103,000030
+ANDERSON,Garnett Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",219,000030
+ANDERSON,Garnett Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000040
+ANDERSON,Garnett Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",153,000040
+ANDERSON,Garnett Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000050
+ANDERSON,Garnett Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000050
+ANDERSON,Indian Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000080
+ANDERSON,Indian Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000080
+ANDERSON,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000110
+ANDERSON,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",59,000110
+ANDERSON,Monroe Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,00014A
+ANDERSON,Monroe Township,Commissioner of Insurance,,Republican,"Selzer, Ken",86,00014A
+ANDERSON,Putnam Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000170
+ANDERSON,Putnam Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000170
+ANDERSON,Reeder Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000180
+ANDERSON,Reeder Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000180
+ANDERSON,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000210
+ANDERSON,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",63,000210
+ANDERSON,Welda Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000220
+ANDERSON,Welda Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000220
+ANDERSON,Lone Elm Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,130010
+ANDERSON,Lone Elm Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,130010
+ANDERSON,Ozark Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,130020
+ANDERSON,Ozark Township,Commissioner of Insurance,,Republican,"Selzer, Ken",153,130020
+ANDERSON,Rich Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,130030
+ANDERSON,Rich Township,Commissioner of Insurance,,Republican,"Selzer, Ken",83,130030
+ANDERSON,Walker Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",95,130040
+ANDERSON,Walker Township,Commissioner of Insurance,,Republican,"Selzer, Ken",141,130040
+ANDERSON,Westphalia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,130050
+ANDERSON,Westphalia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",74,130050
+ANDERSON,Jackson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,140010
+ANDERSON,Jackson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",107,140010
+ANDERSON,Garnett Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",107,00002A
+ANDERSON,Garnett Precinct 1,Secretary of State,,Republican,"Kobach, Kris",232,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00002B
+ANDERSON,Garnett Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",97,000030
+ANDERSON,Garnett Precinct 2,Secretary of State,,Republican,"Kobach, Kris",223,000030
+ANDERSON,Garnett Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000040
+ANDERSON,Garnett Precinct 3,Secretary of State,,Republican,"Kobach, Kris",158,000040
+ANDERSON,Garnett Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000050
+ANDERSON,Garnett Precinct 4,Secretary of State,,Republican,"Kobach, Kris",37,000050
+ANDERSON,Indian Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000080
+ANDERSON,Indian Creek Township,Secretary of State,,Republican,"Kobach, Kris",34,000080
+ANDERSON,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000110
+ANDERSON,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",56,000110
+ANDERSON,Monroe Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,00014A
+ANDERSON,Monroe Township,Secretary of State,,Republican,"Kobach, Kris",92,00014A
+ANDERSON,Putnam Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000170
+ANDERSON,Putnam Township,Secretary of State,,Republican,"Kobach, Kris",62,000170
+ANDERSON,Reeder Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000180
+ANDERSON,Reeder Township,Secretary of State,,Republican,"Kobach, Kris",57,000180
+ANDERSON,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000210
+ANDERSON,Washington Township,Secretary of State,,Republican,"Kobach, Kris",72,000210
+ANDERSON,Welda Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000220
+ANDERSON,Welda Township,Secretary of State,,Republican,"Kobach, Kris",69,000220
+ANDERSON,Lone Elm Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,130010
+ANDERSON,Lone Elm Township,Secretary of State,,Republican,"Kobach, Kris",69,130010
+ANDERSON,Ozark Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,130020
+ANDERSON,Ozark Township,Secretary of State,,Republican,"Kobach, Kris",156,130020
+ANDERSON,Rich Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,130030
+ANDERSON,Rich Township,Secretary of State,,Republican,"Kobach, Kris",92,130030
+ANDERSON,Walker Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",93,130040
+ANDERSON,Walker Township,Secretary of State,,Republican,"Kobach, Kris",146,130040
+ANDERSON,Westphalia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",32,130050
+ANDERSON,Westphalia Township,Secretary of State,,Republican,"Kobach, Kris",77,130050
+ANDERSON,Jackson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,140010
+ANDERSON,Jackson Township,Secretary of State,,Republican,"Kobach, Kris",111,140010
+ANDERSON,Garnett Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",94,00002A
+ANDERSON,Garnett Precinct 1,State Treasurer,,Republican,"Estes, Ron",245,00002A
+ANDERSON,Garnett Precinct 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00002B
+ANDERSON,Garnett Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",89,000030
+ANDERSON,Garnett Precinct 2,State Treasurer,,Republican,"Estes, Ron",231,000030
+ANDERSON,Garnett Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",79,000040
+ANDERSON,Garnett Precinct 3,State Treasurer,,Republican,"Estes, Ron",155,000040
+ANDERSON,Garnett Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",20,000050
+ANDERSON,Garnett Precinct 4,State Treasurer,,Republican,"Estes, Ron",33,000050
+ANDERSON,Indian Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000080
+ANDERSON,Indian Creek Township,State Treasurer,,Republican,"Estes, Ron",34,000080
+ANDERSON,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000110
+ANDERSON,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",57,000110
+ANDERSON,Monroe Township,State Treasurer,,Democratic,"Alldritt, Carmen",37,00014A
+ANDERSON,Monroe Township,State Treasurer,,Republican,"Estes, Ron",91,00014A
+ANDERSON,Putnam Township,State Treasurer,,Democratic,"Alldritt, Carmen",50,000170
+ANDERSON,Putnam Township,State Treasurer,,Republican,"Estes, Ron",63,000170
+ANDERSON,Reeder Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000180
+ANDERSON,Reeder Township,State Treasurer,,Republican,"Estes, Ron",54,000180
+ANDERSON,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000210
+ANDERSON,Washington Township,State Treasurer,,Republican,"Estes, Ron",74,000210
+ANDERSON,Welda Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000220
+ANDERSON,Welda Township,State Treasurer,,Republican,"Estes, Ron",76,000220
+ANDERSON,Lone Elm Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,130010
+ANDERSON,Lone Elm Township,State Treasurer,,Republican,"Estes, Ron",72,130010
+ANDERSON,Ozark Township,State Treasurer,,Democratic,"Alldritt, Carmen",57,130020
+ANDERSON,Ozark Township,State Treasurer,,Republican,"Estes, Ron",143,130020
+ANDERSON,Rich Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,130030
+ANDERSON,Rich Township,State Treasurer,,Republican,"Estes, Ron",88,130030
+ANDERSON,Walker Township,State Treasurer,,Democratic,"Alldritt, Carmen",99,130040
+ANDERSON,Walker Township,State Treasurer,,Republican,"Estes, Ron",140,130040
+ANDERSON,Westphalia Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,130050
+ANDERSON,Westphalia Township,State Treasurer,,Republican,"Estes, Ron",75,130050
+ANDERSON,Jackson Township,State Treasurer,,Democratic,"Alldritt, Carmen",43,140010
+ANDERSON,Jackson Township,State Treasurer,,Republican,"Estes, Ron",106,140010
+ANDERSON,Garnett Precinct 1,United States Senate,,independent,"Orman, Greg",116,00002A
+ANDERSON,Garnett Precinct 1,United States Senate,,Libertarian,"Batson, Randall",25,00002A
+ANDERSON,Garnett Precinct 1,United States Senate,,Republican,"Roberts, Pat",202,00002A
+ANDERSON,Garnett Precinct 1 Exclave,United States Senate,,independent,"Orman, Greg",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00002B
+ANDERSON,Garnett Precinct 2,United States Senate,,independent,"Orman, Greg",110,000030
+ANDERSON,Garnett Precinct 2,United States Senate,,Libertarian,"Batson, Randall",20,000030
+ANDERSON,Garnett Precinct 2,United States Senate,,Republican,"Roberts, Pat",195,000030
+ANDERSON,Garnett Precinct 3,United States Senate,,independent,"Orman, Greg",82,000040
+ANDERSON,Garnett Precinct 3,United States Senate,,Libertarian,"Batson, Randall",14,000040
+ANDERSON,Garnett Precinct 3,United States Senate,,Republican,"Roberts, Pat",141,000040
+ANDERSON,Garnett Precinct 4,United States Senate,,independent,"Orman, Greg",21,000050
+ANDERSON,Garnett Precinct 4,United States Senate,,Libertarian,"Batson, Randall",3,000050
+ANDERSON,Garnett Precinct 4,United States Senate,,Republican,"Roberts, Pat",29,000050
+ANDERSON,Indian Creek Township,United States Senate,,independent,"Orman, Greg",14,000080
+ANDERSON,Indian Creek Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+ANDERSON,Indian Creek Township,United States Senate,,Republican,"Roberts, Pat",30,000080
+ANDERSON,Lincoln Township,United States Senate,,independent,"Orman, Greg",24,000110
+ANDERSON,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",3,000110
+ANDERSON,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",49,000110
+ANDERSON,Monroe Township,United States Senate,,independent,"Orman, Greg",45,00014A
+ANDERSON,Monroe Township,United States Senate,,Libertarian,"Batson, Randall",3,00014A
+ANDERSON,Monroe Township,United States Senate,,Republican,"Roberts, Pat",83,00014A
+ANDERSON,Putnam Township,United States Senate,,independent,"Orman, Greg",46,000170
+ANDERSON,Putnam Township,United States Senate,,Libertarian,"Batson, Randall",12,000170
+ANDERSON,Putnam Township,United States Senate,,Republican,"Roberts, Pat",59,000170
+ANDERSON,Reeder Township,United States Senate,,independent,"Orman, Greg",25,000180
+ANDERSON,Reeder Township,United States Senate,,Libertarian,"Batson, Randall",7,000180
+ANDERSON,Reeder Township,United States Senate,,Republican,"Roberts, Pat",48,000180
+ANDERSON,Washington Township,United States Senate,,independent,"Orman, Greg",37,000210
+ANDERSON,Washington Township,United States Senate,,Libertarian,"Batson, Randall",2,000210
+ANDERSON,Washington Township,United States Senate,,Republican,"Roberts, Pat",64,000210
+ANDERSON,Welda Township,United States Senate,,independent,"Orman, Greg",34,000220
+ANDERSON,Welda Township,United States Senate,,Libertarian,"Batson, Randall",9,000220
+ANDERSON,Welda Township,United States Senate,,Republican,"Roberts, Pat",65,000220
+ANDERSON,Lone Elm Township,United States Senate,,independent,"Orman, Greg",25,130010
+ANDERSON,Lone Elm Township,United States Senate,,Libertarian,"Batson, Randall",3,130010
+ANDERSON,Lone Elm Township,United States Senate,,Republican,"Roberts, Pat",65,130010
+ANDERSON,Ozark Township,United States Senate,,independent,"Orman, Greg",52,130020
+ANDERSON,Ozark Township,United States Senate,,Libertarian,"Batson, Randall",16,130020
+ANDERSON,Ozark Township,United States Senate,,Republican,"Roberts, Pat",134,130020
+ANDERSON,Rich Township,United States Senate,,independent,"Orman, Greg",40,130030
+ANDERSON,Rich Township,United States Senate,,Libertarian,"Batson, Randall",8,130030
+ANDERSON,Rich Township,United States Senate,,Republican,"Roberts, Pat",77,130030
+ANDERSON,Walker Township,United States Senate,,independent,"Orman, Greg",94,130040
+ANDERSON,Walker Township,United States Senate,,Libertarian,"Batson, Randall",21,130040
+ANDERSON,Walker Township,United States Senate,,Republican,"Roberts, Pat",127,130040
+ANDERSON,Westphalia Township,United States Senate,,independent,"Orman, Greg",20,130050
+ANDERSON,Westphalia Township,United States Senate,,Libertarian,"Batson, Randall",5,130050
+ANDERSON,Westphalia Township,United States Senate,,Republican,"Roberts, Pat",83,130050
+ANDERSON,Jackson Township,United States Senate,,independent,"Orman, Greg",41,140010
+ANDERSON,Jackson Township,United States Senate,,Libertarian,"Batson, Randall",5,140010
+ANDERSON,Jackson Township,United States Senate,,Republican,"Roberts, Pat",103,140010

--- a/2014/20141104__ks__general__atchison__precinct.csv
+++ b/2014/20141104__ks__general__atchison__precinct.csv
@@ -1,328 +1,466 @@
-county,precinct,office,district,party,candidate,votes
-Atchison,ONLY 1ST,Attorney General,,D,A.J. KOTICH,69
-Atchison,EAST 2ND,Attorney General,,D,A.J. KOTICH,77
-Atchison,WEST 2ND,Attorney General,,D,A.J. KOTICH,88
-Atchison,EAST 3RD,Attorney General,,D,A.J. KOTICH,165
-Atchison,WEST 3RD,Attorney General,,D,A.J. KOTICH,205
-Atchison,ONLY 4TH,Attorney General,,D,A.J. KOTICH,175
-Atchison,NORTH 5TH,Attorney General,,D,A.J. KOTICH,173
-Atchison,SOUTH 5TH ,Attorney General,,D,A.J. KOTICH,98
-Atchison,ONLY 1ST,Attorney General,,R,DEREK SCHMIDT,104
-Atchison,EAST 2ND,Attorney General,,R,DEREK SCHMIDT,133
-Atchison,WEST 2ND,Attorney General,,R,DEREK SCHMIDT,108
-Atchison,EAST 3RD,Attorney General,,R,DEREK SCHMIDT,209
-Atchison,WEST 3RD,Attorney General,,R,DEREK SCHMIDT,294
-Atchison,ONLY 4TH,Attorney General,,R,DEREK SCHMIDT,160
-Atchison,NORTH 5TH,Attorney General,,R,DEREK SCHMIDT,226
-Atchison,SOUTH 5TH ,Attorney General,,R,DEREK SCHMIDT,122
-Atchison,ONLY 1ST,U.S. House,2,L,CHRISTOPHER CLEMMONS,4
-Atchison,EAST 2ND,U.S. House,2,L,CHRISTOPHER CLEMMONS,6
-Atchison,WEST 2ND,U.S. House,2,L,CHRISTOPHER CLEMMONS,7
-Atchison,EAST 3RD,U.S. House,2,L,CHRISTOPHER CLEMMONS,9
-Atchison,WEST 3RD,U.S. House,2,L,CHRISTOPHER CLEMMONS,16
-Atchison,ONLY 4TH,U.S. House,2,L,CHRISTOPHER CLEMMONS,14
-Atchison,NORTH 5TH,U.S. House,2,L,CHRISTOPHER CLEMMONS,9
-Atchison,SOUTH 5TH ,U.S. House,2,L,CHRISTOPHER CLEMMONS,9
-Atchison,ONLY 1ST,U.S. House,2,R,LYNN JENKINS,121
-Atchison,EAST 2ND,U.S. House,2,R,LYNN JENKINS,140
-Atchison,WEST 2ND,U.S. House,2,R,LYNN JENKINS,127
-Atchison,EAST 3RD,U.S. House,2,R,LYNN JENKINS,227
-Atchison,WEST 3RD,U.S. House,2,R,LYNN JENKINS,327
-Atchison,ONLY 4TH,U.S. House,2,R,LYNN JENKINS,182
-Atchison,NORTH 5TH,U.S. House,2,R,LYNN JENKINS,255
-Atchison,SOUTH 5TH ,U.S. House,2,R,LYNN JENKINS,130
-Atchison,ONLY 1ST,U.S. House,2,D,MARGIE WAKEFIELD,51
-Atchison,EAST 2ND,U.S. House,2,D,MARGIE WAKEFIELD,70
-Atchison,WEST 2ND,U.S. House,2,D,MARGIE WAKEFIELD,65
-Atchison,EAST 3RD,U.S. House,2,D,MARGIE WAKEFIELD,146
-Atchison,WEST 3RD,U.S. House,2,D,MARGIE WAKEFIELD,172
-Atchison,ONLY 4TH,U.S. House,2,D,MARGIE WAKEFIELD,146
-Atchison,NORTH 5TH,U.S. House,2,D,MARGIE WAKEFIELD,147
-Atchison,SOUTH 5TH ,U.S. House,2,D,MARGIE WAKEFIELD,83
-Atchison,ONLY 1ST,Governor,,L,KEEN A UMBEHR,8
-Atchison,EAST 2ND,Governor,,L,KEEN A UMBEHR,10
-Atchison,WEST 2ND,Governor,,L,KEEN A UMBEHR,9
-Atchison,EAST 3RD,Governor,,L,KEEN A UMBEHR,7
-Atchison,WEST 3RD,Governor,,L,KEEN A UMBEHR,7
-Atchison,ONLY 4TH,Governor,,L,KEEN A UMBEHR,10
-Atchison,NORTH 5TH,Governor,,L,KEEN A UMBEHR,17
-Atchison,SOUTH 5TH ,Governor,,L,KEEN A UMBEHR,8
-Atchison,ONLY 1ST,Governor,,D,PAUL DAVIS,78
-Atchison,EAST 2ND,Governor,,D,PAUL DAVIS,88
-Atchison,WEST 2ND,Governor,,D,PAUL DAVIS,91
-Atchison,EAST 3RD,Governor,,D,PAUL DAVIS,184
-Atchison,WEST 3RD,Governor,,D,PAUL DAVIS,262
-Atchison,ONLY 4TH,Governor,,D,PAUL DAVIS,205
-Atchison,NORTH 5TH,Governor,,D,PAUL DAVIS,191
-Atchison,SOUTH 5TH ,Governor,,D,PAUL DAVIS,104
-Atchison,ONLY 1ST,Governor,,R,SAM BROWNBACK,90
-Atchison,EAST 2ND,Governor,,R,SAM BROWNBACK,120
-Atchison,WEST 2ND,Governor,,R,SAM BROWNBACK,101
-Atchison,EAST 3RD,Governor,,R,SAM BROWNBACK,197
-Atchison,WEST 3RD,Governor,,R,SAM BROWNBACK,242
-Atchison,ONLY 4TH,Governor,,R,SAM BROWNBACK,125
-Atchison,NORTH 5TH,Governor,,R,SAM BROWNBACK,202
-Atchison,SOUTH 5TH ,Governor,,R,SAM BROWNBACK,109
-Atchison,ONLY 1ST,Insurance Commissioner,,D,DENNIS ANDERSON,72
-Atchison,EAST 2ND,Insurance Commissioner,,D,DENNIS ANDERSON,84
-Atchison,WEST 2ND,Insurance Commissioner,,D,DENNIS ANDERSON,89
-Atchison,EAST 3RD,Insurance Commissioner,,D,DENNIS ANDERSON,176
-Atchison,WEST 3RD,Insurance Commissioner,,D,DENNIS ANDERSON,212
-Atchison,ONLY 4TH,Insurance Commissioner,,D,DENNIS ANDERSON,197
-Atchison,NORTH 5TH,Insurance Commissioner,,D,DENNIS ANDERSON,180
-Atchison,SOUTH 5TH ,Insurance Commissioner,,D,DENNIS ANDERSON,93
-Atchison,ONLY 1ST,Insurance Commissioner,,R,KEN SELZER,103
-Atchison,EAST 2ND,Insurance Commissioner,,R,KEN SELZER,127
-Atchison,WEST 2ND,Insurance Commissioner,,R,KEN SELZER,105
-Atchison,EAST 3RD,Insurance Commissioner,,R,KEN SELZER,193
-Atchison,WEST 3RD,Insurance Commissioner,,R,KEN SELZER,282
-Atchison,ONLY 4TH,Insurance Commissioner,,R,KEN SELZER,134
-Atchison,NORTH 5TH,Insurance Commissioner,,R,KEN SELZER,217
-Atchison,SOUTH 5TH ,Insurance Commissioner,,R,KEN SELZER,122
-Atchison,ONLY 1ST,Secretary of State,,D,JEAN KURTIS SCHODORF,64
-Atchison,EAST 2ND,Secretary of State,,D,JEAN KURTIS SCHODORF,80
-Atchison,WEST 2ND,Secretary of State,,D,JEAN KURTIS SCHODORF,83
-Atchison,EAST 3RD,Secretary of State,,D,JEAN KURTIS SCHODORF,171
-Atchison,WEST 3RD,Secretary of State,,D,JEAN KURTIS SCHODORF,218
-Atchison,ONLY 4TH,Secretary of State,,D,JEAN KURTIS SCHODORF,174
-Atchison,NORTH 5TH,Secretary of State,,D,JEAN KURTIS SCHODORF,174
-Atchison,SOUTH 5TH ,Secretary of State,,D,JEAN KURTIS SCHODORF,94
-Atchison,ONLY 1ST,Secretary of State,,R,KRIS KOBACH,110
-Atchison,EAST 2ND,Secretary of State,,R,KRIS KOBACH,133
-Atchison,WEST 2ND,Secretary of State,,R,KRIS KOBACH,113
-Atchison,EAST 3RD,Secretary of State,,R,KRIS KOBACH,205
-Atchison,WEST 3RD,Secretary of State,,R,KRIS KOBACH,284
-Atchison,ONLY 4TH,Secretary of State,,R,KRIS KOBACH,163
-Atchison,NORTH 5TH,Secretary of State,,R,KRIS KOBACH,225
-Atchison,SOUTH 5TH ,Secretary of State,,R,KRIS KOBACH,127
-Atchison,ONLY 1ST,SR063,63,D,JERRY HENRY,153
-Atchison,EAST 2ND,SR063,63,D,JERRY HENRY,166
-Atchison,WEST 2ND,SR063,63,D,JERRY HENRY,161
-Atchison,EAST 3RD,SR063,63,D,JERRY HENRY,322
-Atchison,WEST 3RD,SR063,63,D,JERRY HENRY,430
-Atchison,ONLY 4TH,SR063,63,D,JERRY HENRY,302
-Atchison,NORTH 5TH,SR063,63,D,JERRY HENRY,344
-Atchison,SOUTH 5TH ,SR063,63,D,JERRY HENRY,188
-Atchison,ONLY 1ST,State Treasurer,,D,CARMEN ALLDRITT,59
-Atchison,EAST 2ND,State Treasurer,,D,CARMEN ALLDRITT,70
-Atchison,WEST 2ND,State Treasurer,,D,CARMEN ALLDRITT,72
-Atchison,EAST 3RD,State Treasurer,,D,CARMEN ALLDRITT,153
-Atchison,WEST 3RD,State Treasurer,,D,CARMEN ALLDRITT,176
-Atchison,ONLY 4TH,State Treasurer,,D,CARMEN ALLDRITT,166
-Atchison,NORTH 5TH,State Treasurer,,D,CARMEN ALLDRITT,162
-Atchison,SOUTH 5TH ,State Treasurer,,D,CARMEN ALLDRITT,86
-Atchison,ONLY 1ST,State Treasurer,,R,RON ESTES,114
-Atchison,EAST 2ND,State Treasurer,,R,RON ESTES,140
-Atchison,WEST 2ND,State Treasurer,,R,RON ESTES,125
-Atchison,EAST 3RD,State Treasurer,,R,RON ESTES,226
-Atchison,WEST 3RD,State Treasurer,,R,RON ESTES,323
-Atchison,ONLY 4TH,State Treasurer,,R,RON ESTES,167
-Atchison,NORTH 5TH,State Treasurer,,R,RON ESTES,237
-Atchison,SOUTH 5TH ,State Treasurer,,R,RON ESTES,129
-Atchison,ONLY 1ST,U.S. Senate,,I,GREG ORMAN,71
-Atchison,EAST 2ND,U.S. Senate,,I,GREG ORMAN,86
-Atchison,WEST 2ND,U.S. Senate,,I,GREG ORMAN,83
-Atchison,EAST 3RD,U.S. Senate,,I,GREG ORMAN,179
-Atchison,WEST 3RD,U.S. Senate,,I,GREG ORMAN,230
-Atchison,ONLY 4TH,U.S. Senate,,I,GREG ORMAN,189
-Atchison,NORTH 5TH,U.S. Senate,,I,GREG ORMAN,182
-Atchison,SOUTH 5TH ,U.S. Senate,,I,GREG ORMAN,103
-Atchison,ONLY 1ST,U.S. Senate,,R,PAT ROBERTS,93
-Atchison,EAST 2ND,U.S. Senate,,R,PAT ROBERTS,115
-Atchison,WEST 2ND,U.S. Senate,,R,PAT ROBERTS,104
-Atchison,EAST 3RD,U.S. Senate,,R,PAT ROBERTS,193
-Atchison,WEST 3RD,U.S. Senate,,R,PAT ROBERTS,253
-Atchison,ONLY 4TH,U.S. Senate,,R,PAT ROBERTS,129
-Atchison,NORTH 5TH,U.S. Senate,,R,PAT ROBERTS,200
-Atchison,SOUTH 5TH ,U.S. Senate,,R,PAT ROBERTS,107
-Atchison,ONLY 1ST,U.S. Senate,,L,RANDALL BATSON,12
-Atchison,EAST 2ND,U.S. Senate,,L,RANDALL BATSON,15
-Atchison,WEST 2ND,U.S. Senate,,L,RANDALL BATSON,12
-Atchison,EAST 3RD,U.S. Senate,,L,RANDALL BATSON,11
-Atchison,WEST 3RD,U.S. Senate,,L,RANDALL BATSON,24
-Atchison,ONLY 4TH,U.S. Senate,,L,RANDALL BATSON,20
-Atchison,NORTH 5TH,U.S. Senate,,L,RANDALL BATSON,22
-Atchison,SOUTH 5TH ,U.S. Senate,,L,RANDALL BATSON,11
-Atchison,BENTON H62,Attorney General,,D,A.J. KOTICH,105
-Atchison,BENTON H63,Attorney General,,D,A.J. KOTICH,26
-Atchison,CENTER,Attorney General,,D,A.J. KOTICH,62
-Atchison,GRASSHOPPER,Attorney General,,D,A.J. KOTICH,58
-Atchison,HURON,Attorney General,,D,A.J. KOTICH,28
-Atchison,KAPIOMA,Attorney General,,D,A.J. KOTICH,29
-Atchison,LANCASTER,Attorney General,,D,A.J. KOTICH,80
-Atchison,MT. PLEASANT,Attorney General,,D,A.J. KOTICH,108
-Atchison,SHANNON,Attorney General,,D,A.J. KOTICH,145
-Atchison,WALNUT,Attorney General,,D,A.J. KOTICH,74
-Atchison,BENTON H62,Attorney General,,R,DEREK SCHMIDT,174
-Atchison,BENTON H63,Attorney General,,R,DEREK SCHMIDT,56
-Atchison,CENTER,Attorney General,,R,DEREK SCHMIDT,196
-Atchison,GRASSHOPPER,Attorney General,,R,DEREK SCHMIDT,193
-Atchison,HURON,Attorney General,,R,DEREK SCHMIDT,38
-Atchison,KAPIOMA,Attorney General,,R,DEREK SCHMIDT,94
-Atchison,LANCASTER,Attorney General,,R,DEREK SCHMIDT,129
-Atchison,MT. PLEASANT,Attorney General,,R,DEREK SCHMIDT,235
-Atchison,SHANNON,Attorney General,,R,DEREK SCHMIDT,286
-Atchison,WALNUT,Attorney General,,R,DEREK SCHMIDT,96
-Atchison,BENTON H62,U.S. House,2,L,CHRISTOPHER CLEMMONS,12
-Atchison,BENTON H63,U.S. House,2,L,CHRISTOPHER CLEMMONS,3
-Atchison,CENTER,U.S. House,2,L,CHRISTOPHER CLEMMONS,7
-Atchison,GRASSHOPPER,U.S. House,2,L,CHRISTOPHER CLEMMONS,6
-Atchison,HURON,U.S. House,2,L,CHRISTOPHER CLEMMONS,2
-Atchison,KAPIOMA,U.S. House,2,L,CHRISTOPHER CLEMMONS,9
-Atchison,LANCASTER,U.S. House,2,L,CHRISTOPHER CLEMMONS,17
-Atchison,MT. PLEASANT,U.S. House,2,L,CHRISTOPHER CLEMMONS,15
-Atchison,SHANNON,U.S. House,2,L,CHRISTOPHER CLEMMONS,16
-Atchison,WALNUT,U.S. House,2,L,CHRISTOPHER CLEMMONS,14
-Atchison,BENTON H62,U.S. House,2,R,LYNN JENKINS,212
-Atchison,BENTON H63,U.S. House,2,R,LYNN JENKINS,59
-Atchison,CENTER,U.S. House,2,R,LYNN JENKINS,211
-Atchison,GRASSHOPPER,U.S. House,2,R,LYNN JENKINS,204
-Atchison,HURON,U.S. House,2,R,LYNN JENKINS,57
-Atchison,KAPIOMA,U.S. House,2,R,LYNN JENKINS,88
-Atchison,LANCASTER,U.S. House,2,R,LYNN JENKINS,156
-Atchison,MT. PLEASANT,U.S. House,2,R,LYNN JENKINS,263
-Atchison,SHANNON,U.S. House,2,R,LYNN JENKINS,312
-Atchison,WALNUT,U.S. House,2,R,LYNN JENKINS,99
-Atchison,BENTON H62,U.S. House,2,D,MARGIE WAKEFIELD,70
-Atchison,BENTON H63,U.S. House,2,D,MARGIE WAKEFIELD,21
-Atchison,CENTER,U.S. House,2,D,MARGIE WAKEFIELD,53
-Atchison,GRASSHOPPER,U.S. House,2,D,MARGIE WAKEFIELD,45
-Atchison,HURON,U.S. House,2,D,MARGIE WAKEFIELD,13
-Atchison,KAPIOMA,U.S. House,2,D,MARGIE WAKEFIELD,25
-Atchison,LANCASTER,U.S. House,2,D,MARGIE WAKEFIELD,52
-Atchison,MT. PLEASANT,U.S. House,2,D,MARGIE WAKEFIELD,74
-Atchison,SHANNON,U.S. House,2,D,MARGIE WAKEFIELD,124
-Atchison,WALNUT,U.S. House,2,D,MARGIE WAKEFIELD,65
-Atchison,BENTON H62,Governor,,L,KEEN A UMBEHR,15
-Atchison,BENTON H63,Governor,,L,KEEN A UMBEHR,5
-Atchison,CENTER,Governor,,L,KEEN A UMBEHR,7
-Atchison,GRASSHOPPER,Governor,,L,KEEN A UMBEHR,6
-Atchison,HURON,Governor,,L,KEEN A UMBEHR,6
-Atchison,KAPIOMA,Governor,,L,KEEN A UMBEHR,10
-Atchison,LANCASTER,Governor,,L,KEEN A UMBEHR,16
-Atchison,MT. PLEASANT,Governor,,L,KEEN A UMBEHR,14
-Atchison,SHANNON,Governor,,L,KEEN A UMBEHR,14
-Atchison,WALNUT,Governor,,L,KEEN A UMBEHR,9
-Atchison,BENTON H62,Governor,,D,PAUL DAVIS,148
-Atchison,BENTON H63,Governor,,D,PAUL DAVIS,38
-Atchison,CENTER,Governor,,D,PAUL DAVIS,89
-Atchison,GRASSHOPPER,Governor,,D,PAUL DAVIS,76
-Atchison,HURON,Governor,,D,PAUL DAVIS,25
-Atchison,KAPIOMA,Governor,,D,PAUL DAVIS,43
-Atchison,LANCASTER,Governor,,D,PAUL DAVIS,98
-Atchison,MT. PLEASANT,Governor,,D,PAUL DAVIS,138
-Atchison,SHANNON,Governor,,D,PAUL DAVIS,192
-Atchison,WALNUT,Governor,,D,PAUL DAVIS,79
-Atchison,BENTON H62,Governor,,R,SAM BROWNBACK,131
-Atchison,BENTON H63,Governor,,R,SAM BROWNBACK,41
-Atchison,CENTER,Governor,,R,SAM BROWNBACK,171
-Atchison,GRASSHOPPER,Governor,,R,SAM BROWNBACK,172
-Atchison,HURON,Governor,,R,SAM BROWNBACK,43
-Atchison,KAPIOMA,Governor,,R,SAM BROWNBACK,70
-Atchison,LANCASTER,Governor,,R,SAM BROWNBACK,106
-Atchison,MT. PLEASANT,Governor,,R,SAM BROWNBACK,202
-Atchison,SHANNON,Governor,,R,SAM BROWNBACK,248
-Atchison,WALNUT,Governor,,R,SAM BROWNBACK,91
-Atchison,BENTON H62,Insurance Commissioner,,D,DENNIS ANDERSON,108
-Atchison,BENTON H63,Insurance Commissioner,,D,DENNIS ANDERSON,32
-Atchison,CENTER,Insurance Commissioner,,D,DENNIS ANDERSON,73
-Atchison,GRASSHOPPER,Insurance Commissioner,,D,DENNIS ANDERSON,61
-Atchison,HURON,Insurance Commissioner,,D,DENNIS ANDERSON,34
-Atchison,KAPIOMA,Insurance Commissioner,,D,DENNIS ANDERSON,40
-Atchison,LANCASTER,Insurance Commissioner,,D,DENNIS ANDERSON,95
-Atchison,MT. PLEASANT,Insurance Commissioner,,D,DENNIS ANDERSON,110
-Atchison,SHANNON,Insurance Commissioner,,D,DENNIS ANDERSON,165
-Atchison,WALNUT,Insurance Commissioner,,D,DENNIS ANDERSON,80
-Atchison,BENTON H62,Insurance Commissioner,,R,KEN SELZER,163
-Atchison,BENTON H63,Insurance Commissioner,,R,KEN SELZER,48
-Atchison,CENTER,Insurance Commissioner,,R,KEN SELZER,180
-Atchison,GRASSHOPPER,Insurance Commissioner,,R,KEN SELZER,184
-Atchison,HURON,Insurance Commissioner,,R,KEN SELZER,32
-Atchison,KAPIOMA,Insurance Commissioner,,R,KEN SELZER,79
-Atchison,LANCASTER,Insurance Commissioner,,R,KEN SELZER,110
-Atchison,MT. PLEASANT,Insurance Commissioner,,R,KEN SELZER,231
-Atchison,SHANNON,Insurance Commissioner,,R,KEN SELZER,259
-Atchison,WALNUT,Insurance Commissioner,,R,KEN SELZER,90
-Atchison,BENTON H62,Secretary of State,,D,JEAN KURTIS SCHODORF,92
-Atchison,BENTON H63,Secretary of State,,D,JEAN KURTIS SCHODORF,25
-Atchison,CENTER,Secretary of State,,D,JEAN KURTIS SCHODORF,64
-Atchison,GRASSHOPPER,Secretary of State,,D,JEAN KURTIS SCHODORF,48
-Atchison,HURON,Secretary of State,,D,JEAN KURTIS SCHODORF,25
-Atchison,KAPIOMA,Secretary of State,,D,JEAN KURTIS SCHODORF,29
-Atchison,LANCASTER,Secretary of State,,D,JEAN KURTIS SCHODORF,71
-Atchison,MT. PLEASANT,Secretary of State,,D,JEAN KURTIS SCHODORF,106
-Atchison,SHANNON,Secretary of State,,D,JEAN KURTIS SCHODORF,146
-Atchison,WALNUT,Secretary of State,,D,JEAN KURTIS SCHODORF,73
-Atchison,BENTON H62,Secretary of State,,R,KRIS KOBACH,194
-Atchison,BENTON H63,Secretary of State,,R,KRIS KOBACH,56
-Atchison,CENTER,Secretary of State,,R,KRIS KOBACH,202
-Atchison,GRASSHOPPER,Secretary of State,,R,KRIS KOBACH,205
-Atchison,HURON,Secretary of State,,R,KRIS KOBACH,44
-Atchison,KAPIOMA,Secretary of State,,R,KRIS KOBACH,95
-Atchison,LANCASTER,Secretary of State,,R,KRIS KOBACH,141
-Atchison,MT. PLEASANT,Secretary of State,,R,KRIS KOBACH,240
-Atchison,SHANNON,Secretary of State,,R,KRIS KOBACH,293
-Atchison,WALNUT,Secretary of State,,R,KRIS KOBACH,102
-Atchison,KAPIOMA,State House,62,D,STEVE LUKERT,48
-Atchison,GRASSHOPPER,State House,62,D,STEVE LUKERT,71
-Atchison,KAPIOMA,State House,62,R,RANDY GARBER,77
-Atchison,BENTON H62,State House,62,D,STEVE LUKERT,130
-Atchison,BENTON H62,State House,62,R,RANDY GARBER,148
-Atchison,GRASSHOPPER,State House,62,R,RANDY GARBER,184
-Atchison,BENTON H63,SR063,63,D,JERRY HENRY,78
-Atchison,CENTER,SR063,63,D,JERRY HENRY,214
-Atchison,HURON,SR063,63,D,JERRY HENRY,60
-Atchison,LANCASTER,SR063,63,D,JERRY HENRY,206
-Atchison,MT. PLEASANT,SR063,63,D,JERRY HENRY,283
-Atchison,SHANNON,SR063,63,D,JERRY HENRY,393
-Atchison,WALNUT,SR063,63,D,JERRY HENRY,147
-Atchison,BENTON H62,State Treasurer,,D,CARMEN ALLDRITT,89
-Atchison,BENTON H63,State Treasurer,,D,CARMEN ALLDRITT,25
-Atchison,CENTER,State Treasurer,,D,CARMEN ALLDRITT,51
-Atchison,GRASSHOPPER,State Treasurer,,D,CARMEN ALLDRITT,46
-Atchison,HURON,State Treasurer,,D,CARMEN ALLDRITT,19
-Atchison,KAPIOMA,State Treasurer,,D,CARMEN ALLDRITT,24
-Atchison,LANCASTER,State Treasurer,,D,CARMEN ALLDRITT,65
-Atchison,MT. PLEASANT,State Treasurer,,D,CARMEN ALLDRITT,86
-Atchison,SHANNON,State Treasurer,,D,CARMEN ALLDRITT,121
-Atchison,WALNUT,State Treasurer,,D,CARMEN ALLDRITT,73
-Atchison,BENTON H62,State Treasurer,,R,RON ESTES,193
-Atchison,BENTON H63,State Treasurer,,R,RON ESTES,57
-Atchison,CENTER,State Treasurer,,R,RON ESTES,209
-Atchison,GRASSHOPPER,State Treasurer,,R,RON ESTES,202
-Atchison,HURON,State Treasurer,,R,RON ESTES,48
-Atchison,KAPIOMA,State Treasurer,,R,RON ESTES,98
-Atchison,LANCASTER,State Treasurer,,R,RON ESTES,145
-Atchison,MT. PLEASANT,State Treasurer,,R,RON ESTES,258
-Atchison,SHANNON,State Treasurer,,R,RON ESTES,319
-Atchison,WALNUT,State Treasurer,,R,RON ESTES,101
-Atchison,BENTON H62,U.S. Senate,,I,GREG ORMAN,123
-Atchison,BENTON H63,U.S. Senate,,I,GREG ORMAN,29
-Atchison,CENTER,U.S. Senate,,I,GREG ORMAN,84
-Atchison,GRASSHOPPER,U.S. Senate,,I,GREG ORMAN,69
-Atchison,HURON,U.S. Senate,,I,GREG ORMAN,21
-Atchison,KAPIOMA,U.S. Senate,,I,GREG ORMAN,41
-Atchison,LANCASTER,U.S. Senate,,I,GREG ORMAN,84
-Atchison,MT. PLEASANT,U.S. Senate,,I,GREG ORMAN,127
-Atchison,SHANNON,U.S. Senate,,I,GREG ORMAN,179
-Atchison,WALNUT,U.S. Senate,,I,GREG ORMAN,73
-Atchison,BENTON H62,U.S. Senate,,R,PAT ROBERTS,147
-Atchison,BENTON H63,U.S. Senate,,R,PAT ROBERTS,46
-Atchison,CENTER,U.S. Senate,,R,PAT ROBERTS,164
-Atchison,GRASSHOPPER,U.S. Senate,,R,PAT ROBERTS,173
-Atchison,HURON,U.S. Senate,,R,PAT ROBERTS,46
-Atchison,KAPIOMA,U.S. Senate,,R,PAT ROBERTS,79
-Atchison,LANCASTER,U.S. Senate,,R,PAT ROBERTS,115
-Atchison,MT. PLEASANT,U.S. Senate,,R,PAT ROBERTS,199
-Atchison,SHANNON,U.S. Senate,,R,PAT ROBERTS,236
-Atchison,WALNUT,U.S. Senate,,R,PAT ROBERTS,91
-Atchison,BENTON H62,U.S. Senate,,L,RANDALL BATSON,25
-Atchison,BENTON H63,U.S. Senate,,L,RANDALL BATSON,8
-Atchison,CENTER,U.S. Senate,,L,RANDALL BATSON,16
-Atchison,GRASSHOPPER,U.S. Senate,,L,RANDALL BATSON,10
-Atchison,HURON,U.S. Senate,,L,RANDALL BATSON,5
-Atchison,KAPIOMA,U.S. Senate,,L,RANDALL BATSON,5
-Atchison,LANCASTER,U.S. Senate,,L,RANDALL BATSON,23
-Atchison,MT. PLEASANT,U.S. Senate,,L,RANDALL BATSON,21
-Atchison,SHANNON,U.S. Senate,,L,RANDALL BATSON,35
-Atchison,WALNUT,U.S. Senate,,L,RANDALL BATSON,11
+county,precinct,office,district,party,candidate,votes,vtd
+ATCHISON,Atchison Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,000010
+ATCHISON,Atchison Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000010
+ATCHISON,Atchison Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",90,000010
+ATCHISON,Atchison Precinct 2 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",88,000020
+ATCHISON,Atchison Precinct 2 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000020
+ATCHISON,Atchison Precinct 2 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",120,000020
+ATCHISON,Atchison Precinct 2 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",91,000030
+ATCHISON,Atchison Precinct 2 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000030
+ATCHISON,Atchison Precinct 2 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,000030
+ATCHISON,Atchison Precinct 3 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",184,000040
+ATCHISON,Atchison Precinct 3 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000040
+ATCHISON,Atchison Precinct 3 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",197,000040
+ATCHISON,Atchison Precinct 3 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",262,00005A
+ATCHISON,Atchison Precinct 3 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00005A
+ATCHISON,Atchison Precinct 3 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",242,00005A
+ATCHISON,Atchison Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",205,00006A
+ATCHISON,Atchison Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,00006A
+ATCHISON,Atchison Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006C
+ATCHISON,Atchison Precinct 5 North,Governor / Lt. Governor,,Democratic,"Davis, Paul",191,00007A
+ATCHISON,Atchison Precinct 5 North,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,00007A
+ATCHISON,Atchison Precinct 5 North,Governor / Lt. Governor,,Republican,"Brownback, Sam",202,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00007C
+ATCHISON,Atchison Precinct 5 South,Governor / Lt. Governor,,Democratic,"Davis, Paul",104,00008A
+ATCHISON,Atchison Precinct 5 South,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00008A
+ATCHISON,Atchison Precinct 5 South,Governor / Lt. Governor,,Republican,"Brownback, Sam",109,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008D
+ATCHISON,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,000100
+ATCHISON,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000100
+ATCHISON,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",171,000100
+ATCHISON,Grasshopper Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,000110
+ATCHISON,Grasshopper Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000110
+ATCHISON,Grasshopper Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,000110
+ATCHISON,Huron Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000120
+ATCHISON,Huron Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000120
+ATCHISON,Huron Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000120
+ATCHISON,Kapioma Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000130
+ATCHISON,Kapioma Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000130
+ATCHISON,Kapioma Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000130
+ATCHISON,Lancaster Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",98,000140
+ATCHISON,Lancaster Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000140
+ATCHISON,Lancaster Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",106,000140
+ATCHISON,Shannon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",192,00016A
+ATCHISON,Shannon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00016A
+ATCHISON,Shannon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",248,00016A
+ATCHISON,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",79,00017A
+ATCHISON,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,00017A
+ATCHISON,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,00017A
+ATCHISON,Walnut Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00017B
+ATCHISON,Walnut Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00017B
+ATCHISON,Walnut Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00017B
+ATCHISON,Mount Pleasant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",138,100050
+ATCHISON,Mount Pleasant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,100050
+ATCHISON,Mount Pleasant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",202,100050
+ATCHISON,Benton Township H62,Governor / Lt. Governor,,Democratic,"Davis, Paul",148,120020
+ATCHISON,Benton Township H62,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,120020
+ATCHISON,Benton Township H62,Governor / Lt. Governor,,Republican,"Brownback, Sam",131,120020
+ATCHISON,Benton Township H63,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,120030
+ATCHISON,Benton Township H63,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120030
+ATCHISON,Benton Township H63,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,120030
+ATCHISON,Atchison Precinct 1,Kansas House of Representatives,63,Democratic,"Henry, Jerry",153,000010
+ATCHISON,Atchison Precinct 2 East,Kansas House of Representatives,63,Democratic,"Henry, Jerry",166,000020
+ATCHISON,Atchison Precinct 2 West,Kansas House of Representatives,63,Democratic,"Henry, Jerry",161,000030
+ATCHISON,Atchison Precinct 3 East,Kansas House of Representatives,63,Democratic,"Henry, Jerry",322,000040
+ATCHISON,Atchison Precinct 3 West,Kansas House of Representatives,63,Democratic,"Henry, Jerry",430,00005A
+ATCHISON,Atchison Precinct 4,Kansas House of Representatives,63,Democratic,"Henry, Jerry",302,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00006C
+ATCHISON,Atchison Precinct 5 North,Kansas House of Representatives,63,Democratic,"Henry, Jerry",344,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00007C
+ATCHISON,Atchison Precinct 5 South,Kansas House of Representatives,63,Democratic,"Henry, Jerry",188,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00008D
+ATCHISON,Center Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",214,000100
+ATCHISON,Grasshopper Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",71,000110
+ATCHISON,Grasshopper Township,Kansas House of Representatives,62,Republican,"Garber, Randy",184,000110
+ATCHISON,Huron Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",60,000120
+ATCHISON,Kapioma Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",48,000130
+ATCHISON,Kapioma Township,Kansas House of Representatives,62,Republican,"Garber, Randy",77,000130
+ATCHISON,Lancaster Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",206,000140
+ATCHISON,Shannon Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",393,00016A
+ATCHISON,Walnut Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",147,00017A
+ATCHISON,Walnut Township Enclave,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00017B
+ATCHISON,Mount Pleasant Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",283,100050
+ATCHISON,Benton Township H62,Kansas House of Representatives,62,Democratic,"Lukert, Steve",130,120020
+ATCHISON,Benton Township H62,Kansas House of Representatives,62,Republican,"Garber, Randy",148,120020
+ATCHISON,Benton Township H63,Kansas House of Representatives,63,Democratic,"Henry, Jerry",78,120030
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",51,000010
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000010
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",121,000010
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Democratic,"Wakefield, Margie",70,000020
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000020
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Republican,"Jenkins, Lynn",140,000020
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Democratic,"Wakefield, Margie",65,000030
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000030
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Republican,"Jenkins, Lynn",127,000030
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Democratic,"Wakefield, Margie",146,000040
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000040
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Republican,"Jenkins, Lynn",227,000040
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Democratic,"Wakefield, Margie",172,00005A
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,00005A
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Republican,"Jenkins, Lynn",327,00005A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",146,00006A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,00006A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",182,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006C
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Democratic,"Wakefield, Margie",147,00007A
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,00007A
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Republican,"Jenkins, Lynn",255,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00007C
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Democratic,"Wakefield, Margie",83,00008A
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,00008A
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008D
+ATCHISON,Center Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,000100
+ATCHISON,Center Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000100
+ATCHISON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,000100
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",45,000110
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000110
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",204,000110
+ATCHISON,Huron Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",13,000120
+ATCHISON,Huron Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000120
+ATCHISON,Huron Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000120
+ATCHISON,Kapioma Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000130
+ATCHISON,Kapioma Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000130
+ATCHISON,Kapioma Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",88,000130
+ATCHISON,Lancaster Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",52,000140
+ATCHISON,Lancaster Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000140
+ATCHISON,Lancaster Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000140
+ATCHISON,Shannon Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",124,00016A
+ATCHISON,Shannon Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,00016A
+ATCHISON,Shannon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",312,00016A
+ATCHISON,Walnut Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",65,00017A
+ATCHISON,Walnut Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,00017A
+ATCHISON,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,00017A
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00017B
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00017B
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017B
+ATCHISON,Mount Pleasant Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",74,100050
+ATCHISON,Mount Pleasant Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,100050
+ATCHISON,Mount Pleasant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",263,100050
+ATCHISON,Benton Township H62,United States House of Representatives,2,Democratic,"Wakefield, Margie",70,120020
+ATCHISON,Benton Township H62,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,120020
+ATCHISON,Benton Township H62,United States House of Representatives,2,Republican,"Jenkins, Lynn",212,120020
+ATCHISON,Benton Township H63,United States House of Representatives,2,Democratic,"Wakefield, Margie",21,120030
+ATCHISON,Benton Township H63,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,120030
+ATCHISON,Benton Township H63,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,120030
+ATCHISON,Atchison Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",69,000010
+ATCHISON,Atchison Precinct 1,Attorney General,,Republican,"Schmidt, Derek",104,000010
+ATCHISON,Atchison Precinct 2 East,Attorney General,,Democratic,"Kotich, A.J.",77,000020
+ATCHISON,Atchison Precinct 2 East,Attorney General,,Republican,"Schmidt, Derek",133,000020
+ATCHISON,Atchison Precinct 2 West,Attorney General,,Democratic,"Kotich, A.J.",88,000030
+ATCHISON,Atchison Precinct 2 West,Attorney General,,Republican,"Schmidt, Derek",108,000030
+ATCHISON,Atchison Precinct 3 East,Attorney General,,Democratic,"Kotich, A.J.",165,000040
+ATCHISON,Atchison Precinct 3 East,Attorney General,,Republican,"Schmidt, Derek",209,000040
+ATCHISON,Atchison Precinct 3 West,Attorney General,,Democratic,"Kotich, A.J.",205,00005A
+ATCHISON,Atchison Precinct 3 West,Attorney General,,Republican,"Schmidt, Derek",294,00005A
+ATCHISON,Atchison Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",175,00006A
+ATCHISON,Atchison Precinct 4,Attorney General,,Republican,"Schmidt, Derek",160,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00006C
+ATCHISON,Atchison Precinct 5 North,Attorney General,,Democratic,"Kotich, A.J.",173,00007A
+ATCHISON,Atchison Precinct 5 North,Attorney General,,Republican,"Schmidt, Derek",226,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00007C
+ATCHISON,Atchison Precinct 5 South,Attorney General,,Democratic,"Kotich, A.J.",98,00008A
+ATCHISON,Atchison Precinct 5 South,Attorney General,,Republican,"Schmidt, Derek",122,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,Attorney General,,Democratic,"Kotich, A.J.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,Attorney General,,Republican,"Schmidt, Derek",0,00008D
+ATCHISON,Center Township,Attorney General,,Democratic,"Kotich, A.J.",62,000100
+ATCHISON,Center Township,Attorney General,,Republican,"Schmidt, Derek",196,000100
+ATCHISON,Grasshopper Township,Attorney General,,Democratic,"Kotich, A.J.",58,000110
+ATCHISON,Grasshopper Township,Attorney General,,Republican,"Schmidt, Derek",193,000110
+ATCHISON,Huron Township,Attorney General,,Democratic,"Kotich, A.J.",28,000120
+ATCHISON,Huron Township,Attorney General,,Republican,"Schmidt, Derek",38,000120
+ATCHISON,Kapioma Township,Attorney General,,Democratic,"Kotich, A.J.",29,000130
+ATCHISON,Kapioma Township,Attorney General,,Republican,"Schmidt, Derek",94,000130
+ATCHISON,Lancaster Township,Attorney General,,Democratic,"Kotich, A.J.",80,000140
+ATCHISON,Lancaster Township,Attorney General,,Republican,"Schmidt, Derek",129,000140
+ATCHISON,Shannon Township,Attorney General,,Democratic,"Kotich, A.J.",145,00016A
+ATCHISON,Shannon Township,Attorney General,,Republican,"Schmidt, Derek",286,00016A
+ATCHISON,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",74,00017A
+ATCHISON,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",96,00017A
+ATCHISON,Walnut Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00017B
+ATCHISON,Walnut Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00017B
+ATCHISON,Mount Pleasant Township,Attorney General,,Democratic,"Kotich, A.J.",108,100050
+ATCHISON,Mount Pleasant Township,Attorney General,,Republican,"Schmidt, Derek",235,100050
+ATCHISON,Benton Township H62,Attorney General,,Democratic,"Kotich, A.J.",105,120020
+ATCHISON,Benton Township H62,Attorney General,,Republican,"Schmidt, Derek",174,120020
+ATCHISON,Benton Township H63,Attorney General,,Democratic,"Kotich, A.J.",26,120030
+ATCHISON,Benton Township H63,Attorney General,,Republican,"Schmidt, Derek",56,120030
+ATCHISON,Atchison Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000010
+ATCHISON,Atchison Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000010
+ATCHISON,Atchison Precinct 2 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",84,000020
+ATCHISON,Atchison Precinct 2 East,Commissioner of Insurance,,Republican,"Selzer, Ken",127,000020
+ATCHISON,Atchison Precinct 2 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",89,000030
+ATCHISON,Atchison Precinct 2 West,Commissioner of Insurance,,Republican,"Selzer, Ken",105,000030
+ATCHISON,Atchison Precinct 3 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",176,000040
+ATCHISON,Atchison Precinct 3 East,Commissioner of Insurance,,Republican,"Selzer, Ken",193,000040
+ATCHISON,Atchison Precinct 3 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",212,00005A
+ATCHISON,Atchison Precinct 3 West,Commissioner of Insurance,,Republican,"Selzer, Ken",282,00005A
+ATCHISON,Atchison Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",197,00006A
+ATCHISON,Atchison Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",134,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006C
+ATCHISON,Atchison Precinct 5 North,Commissioner of Insurance,,Democratic,"Anderson, Dennis",180,00007A
+ATCHISON,Atchison Precinct 5 North,Commissioner of Insurance,,Republican,"Selzer, Ken",217,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00007C
+ATCHISON,Atchison Precinct 5 South,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,00008A
+ATCHISON,Atchison Precinct 5 South,Commissioner of Insurance,,Republican,"Selzer, Ken",122,00008A
+ATCHISON,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000100
+ATCHISON,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",180,000100
+ATCHISON,Grasshopper Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,000110
+ATCHISON,Grasshopper Township,Commissioner of Insurance,,Republican,"Selzer, Ken",184,000110
+ATCHISON,Huron Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000120
+ATCHISON,Huron Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000120
+ATCHISON,Kapioma Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000130
+ATCHISON,Kapioma Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000130
+ATCHISON,Lancaster Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",95,000140
+ATCHISON,Lancaster Township,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000140
+ATCHISON,Shannon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",165,00016A
+ATCHISON,Shannon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",259,00016A
+ATCHISON,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,00017A
+ATCHISON,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",90,00017A
+ATCHISON,Walnut Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00017B
+ATCHISON,Walnut Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00017B
+ATCHISON,Mount Pleasant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",110,100050
+ATCHISON,Mount Pleasant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",231,100050
+ATCHISON,Benton Township H62,Commissioner of Insurance,,Democratic,"Anderson, Dennis",108,120020
+ATCHISON,Benton Township H62,Commissioner of Insurance,,Republican,"Selzer, Ken",163,120020
+ATCHISON,Benton Township H63,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,120030
+ATCHISON,Benton Township H63,Commissioner of Insurance,,Republican,"Selzer, Ken",48,120030
+ATCHISON,Atchison Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",64,000010
+ATCHISON,Atchison Precinct 1,Secretary of State,,Republican,"Kobach, Kris",110,000010
+ATCHISON,Atchison Precinct 2 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",80,000020
+ATCHISON,Atchison Precinct 2 East,Secretary of State,,Republican,"Kobach, Kris",133,000020
+ATCHISON,Atchison Precinct 2 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",83,000030
+ATCHISON,Atchison Precinct 2 West,Secretary of State,,Republican,"Kobach, Kris",113,000030
+ATCHISON,Atchison Precinct 3 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",171,000040
+ATCHISON,Atchison Precinct 3 East,Secretary of State,,Republican,"Kobach, Kris",205,000040
+ATCHISON,Atchison Precinct 3 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",218,00005A
+ATCHISON,Atchison Precinct 3 West,Secretary of State,,Republican,"Kobach, Kris",284,00005A
+ATCHISON,Atchison Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",174,00006A
+ATCHISON,Atchison Precinct 4,Secretary of State,,Republican,"Kobach, Kris",163,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00006C
+ATCHISON,Atchison Precinct 5 North,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",174,00007A
+ATCHISON,Atchison Precinct 5 North,Secretary of State,,Republican,"Kobach, Kris",225,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00007C
+ATCHISON,Atchison Precinct 5 South,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,00008A
+ATCHISON,Atchison Precinct 5 South,Secretary of State,,Republican,"Kobach, Kris",127,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,Secretary of State,,Republican,"Kobach, Kris",0,00008D
+ATCHISON,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",64,000100
+ATCHISON,Center Township,Secretary of State,,Republican,"Kobach, Kris",202,000100
+ATCHISON,Grasshopper Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000110
+ATCHISON,Grasshopper Township,Secretary of State,,Republican,"Kobach, Kris",205,000110
+ATCHISON,Huron Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000120
+ATCHISON,Huron Township,Secretary of State,,Republican,"Kobach, Kris",44,000120
+ATCHISON,Kapioma Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000130
+ATCHISON,Kapioma Township,Secretary of State,,Republican,"Kobach, Kris",95,000130
+ATCHISON,Lancaster Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,000140
+ATCHISON,Lancaster Township,Secretary of State,,Republican,"Kobach, Kris",141,000140
+ATCHISON,Shannon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,00016A
+ATCHISON,Shannon Township,Secretary of State,,Republican,"Kobach, Kris",293,00016A
+ATCHISON,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,00017A
+ATCHISON,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",102,00017A
+ATCHISON,Walnut Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00017B
+ATCHISON,Walnut Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00017B
+ATCHISON,Mount Pleasant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",106,100050
+ATCHISON,Mount Pleasant Township,Secretary of State,,Republican,"Kobach, Kris",240,100050
+ATCHISON,Benton Township H62,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",92,120020
+ATCHISON,Benton Township H62,Secretary of State,,Republican,"Kobach, Kris",194,120020
+ATCHISON,Benton Township H63,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,120030
+ATCHISON,Benton Township H63,Secretary of State,,Republican,"Kobach, Kris",56,120030
+ATCHISON,Atchison Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",59,000010
+ATCHISON,Atchison Precinct 1,State Treasurer,,Republican,"Estes, Ron",114,000010
+ATCHISON,Atchison Precinct 2 East,State Treasurer,,Democratic,"Alldritt, Carmen",70,000020
+ATCHISON,Atchison Precinct 2 East,State Treasurer,,Republican,"Estes, Ron",140,000020
+ATCHISON,Atchison Precinct 2 West,State Treasurer,,Democratic,"Alldritt, Carmen",72,000030
+ATCHISON,Atchison Precinct 2 West,State Treasurer,,Republican,"Estes, Ron",125,000030
+ATCHISON,Atchison Precinct 3 East,State Treasurer,,Democratic,"Alldritt, Carmen",153,000040
+ATCHISON,Atchison Precinct 3 East,State Treasurer,,Republican,"Estes, Ron",226,000040
+ATCHISON,Atchison Precinct 3 West,State Treasurer,,Democratic,"Alldritt, Carmen",176,00005A
+ATCHISON,Atchison Precinct 3 West,State Treasurer,,Republican,"Estes, Ron",323,00005A
+ATCHISON,Atchison Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",166,00006A
+ATCHISON,Atchison Precinct 4,State Treasurer,,Republican,"Estes, Ron",167,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00006C
+ATCHISON,Atchison Precinct 5 North,State Treasurer,,Democratic,"Alldritt, Carmen",162,00007A
+ATCHISON,Atchison Precinct 5 North,State Treasurer,,Republican,"Estes, Ron",237,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00007C
+ATCHISON,Atchison Precinct 5 South,State Treasurer,,Democratic,"Alldritt, Carmen",86,00008A
+ATCHISON,Atchison Precinct 5 South,State Treasurer,,Republican,"Estes, Ron",129,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,State Treasurer,,Republican,"Estes, Ron",0,00008D
+ATCHISON,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",51,000100
+ATCHISON,Center Township,State Treasurer,,Republican,"Estes, Ron",209,000100
+ATCHISON,Grasshopper Township,State Treasurer,,Democratic,"Alldritt, Carmen",46,000110
+ATCHISON,Grasshopper Township,State Treasurer,,Republican,"Estes, Ron",202,000110
+ATCHISON,Huron Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000120
+ATCHISON,Huron Township,State Treasurer,,Republican,"Estes, Ron",48,000120
+ATCHISON,Kapioma Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000130
+ATCHISON,Kapioma Township,State Treasurer,,Republican,"Estes, Ron",98,000130
+ATCHISON,Lancaster Township,State Treasurer,,Democratic,"Alldritt, Carmen",65,000140
+ATCHISON,Lancaster Township,State Treasurer,,Republican,"Estes, Ron",145,000140
+ATCHISON,Shannon Township,State Treasurer,,Democratic,"Alldritt, Carmen",121,00016A
+ATCHISON,Shannon Township,State Treasurer,,Republican,"Estes, Ron",319,00016A
+ATCHISON,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",73,00017A
+ATCHISON,Walnut Township,State Treasurer,,Republican,"Estes, Ron",101,00017A
+ATCHISON,Walnut Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00017B
+ATCHISON,Walnut Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,00017B
+ATCHISON,Mount Pleasant Township,State Treasurer,,Democratic,"Alldritt, Carmen",86,100050
+ATCHISON,Mount Pleasant Township,State Treasurer,,Republican,"Estes, Ron",258,100050
+ATCHISON,Benton Township H62,State Treasurer,,Democratic,"Alldritt, Carmen",89,120020
+ATCHISON,Benton Township H62,State Treasurer,,Republican,"Estes, Ron",193,120020
+ATCHISON,Benton Township H63,State Treasurer,,Democratic,"Alldritt, Carmen",25,120030
+ATCHISON,Benton Township H63,State Treasurer,,Republican,"Estes, Ron",57,120030
+ATCHISON,Atchison Precinct 1,United States Senate,,independent,"Orman, Greg",71,000010
+ATCHISON,Atchison Precinct 1,United States Senate,,Libertarian,"Batson, Randall",12,000010
+ATCHISON,Atchison Precinct 1,United States Senate,,Republican,"Roberts, Pat",93,000010
+ATCHISON,Atchison Precinct 2 East,United States Senate,,independent,"Orman, Greg",86,000020
+ATCHISON,Atchison Precinct 2 East,United States Senate,,Libertarian,"Batson, Randall",15,000020
+ATCHISON,Atchison Precinct 2 East,United States Senate,,Republican,"Roberts, Pat",115,000020
+ATCHISON,Atchison Precinct 2 West,United States Senate,,independent,"Orman, Greg",83,000030
+ATCHISON,Atchison Precinct 2 West,United States Senate,,Libertarian,"Batson, Randall",12,000030
+ATCHISON,Atchison Precinct 2 West,United States Senate,,Republican,"Roberts, Pat",104,000030
+ATCHISON,Atchison Precinct 3 East,United States Senate,,independent,"Orman, Greg",179,000040
+ATCHISON,Atchison Precinct 3 East,United States Senate,,Libertarian,"Batson, Randall",11,000040
+ATCHISON,Atchison Precinct 3 East,United States Senate,,Republican,"Roberts, Pat",193,000040
+ATCHISON,Atchison Precinct 3 West,United States Senate,,independent,"Orman, Greg",230,00005A
+ATCHISON,Atchison Precinct 3 West,United States Senate,,Libertarian,"Batson, Randall",24,00005A
+ATCHISON,Atchison Precinct 3 West,United States Senate,,Republican,"Roberts, Pat",253,00005A
+ATCHISON,Atchison Precinct 4,United States Senate,,independent,"Orman, Greg",189,00006A
+ATCHISON,Atchison Precinct 4,United States Senate,,Libertarian,"Batson, Randall",20,00006A
+ATCHISON,Atchison Precinct 4,United States Senate,,Republican,"Roberts, Pat",129,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,United States Senate,,independent,"Orman, Greg",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,United States Senate,,independent,"Orman, Greg",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00006C
+ATCHISON,Atchison Precinct 5 North,United States Senate,,independent,"Orman, Greg",182,00007A
+ATCHISON,Atchison Precinct 5 North,United States Senate,,Libertarian,"Batson, Randall",22,00007A
+ATCHISON,Atchison Precinct 5 North,United States Senate,,Republican,"Roberts, Pat",200,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,United States Senate,,independent,"Orman, Greg",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,United States Senate,,independent,"Orman, Greg",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00007C
+ATCHISON,Atchison Precinct 5 South,United States Senate,,independent,"Orman, Greg",103,00008A
+ATCHISON,Atchison Precinct 5 South,United States Senate,,Libertarian,"Batson, Randall",11,00008A
+ATCHISON,Atchison Precinct 5 South,United States Senate,,Republican,"Roberts, Pat",107,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,United States Senate,,independent,"Orman, Greg",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,United States Senate,,independent,"Orman, Greg",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,United States Senate,,independent,"Orman, Greg",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States Senate,,Libertarian,"Batson, Randall",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States Senate,,Republican,"Roberts, Pat",0,00008D
+ATCHISON,Center Township,United States Senate,,independent,"Orman, Greg",84,000100
+ATCHISON,Center Township,United States Senate,,Libertarian,"Batson, Randall",16,000100
+ATCHISON,Center Township,United States Senate,,Republican,"Roberts, Pat",164,000100
+ATCHISON,Grasshopper Township,United States Senate,,independent,"Orman, Greg",69,000110
+ATCHISON,Grasshopper Township,United States Senate,,Libertarian,"Batson, Randall",10,000110
+ATCHISON,Grasshopper Township,United States Senate,,Republican,"Roberts, Pat",173,000110
+ATCHISON,Huron Township,United States Senate,,independent,"Orman, Greg",21,000120
+ATCHISON,Huron Township,United States Senate,,Libertarian,"Batson, Randall",5,000120
+ATCHISON,Huron Township,United States Senate,,Republican,"Roberts, Pat",46,000120
+ATCHISON,Kapioma Township,United States Senate,,independent,"Orman, Greg",41,000130
+ATCHISON,Kapioma Township,United States Senate,,Libertarian,"Batson, Randall",5,000130
+ATCHISON,Kapioma Township,United States Senate,,Republican,"Roberts, Pat",79,000130
+ATCHISON,Lancaster Township,United States Senate,,independent,"Orman, Greg",84,000140
+ATCHISON,Lancaster Township,United States Senate,,Libertarian,"Batson, Randall",23,000140
+ATCHISON,Lancaster Township,United States Senate,,Republican,"Roberts, Pat",115,000140
+ATCHISON,Shannon Township,United States Senate,,independent,"Orman, Greg",179,00016A
+ATCHISON,Shannon Township,United States Senate,,Libertarian,"Batson, Randall",35,00016A
+ATCHISON,Shannon Township,United States Senate,,Republican,"Roberts, Pat",236,00016A
+ATCHISON,Walnut Township,United States Senate,,independent,"Orman, Greg",73,00017A
+ATCHISON,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",11,00017A
+ATCHISON,Walnut Township,United States Senate,,Republican,"Roberts, Pat",91,00017A
+ATCHISON,Walnut Township Enclave,United States Senate,,independent,"Orman, Greg",0,00017B
+ATCHISON,Walnut Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00017B
+ATCHISON,Walnut Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,00017B
+ATCHISON,Mount Pleasant Township,United States Senate,,independent,"Orman, Greg",127,100050
+ATCHISON,Mount Pleasant Township,United States Senate,,Libertarian,"Batson, Randall",21,100050
+ATCHISON,Mount Pleasant Township,United States Senate,,Republican,"Roberts, Pat",199,100050
+ATCHISON,Benton Township H62,United States Senate,,independent,"Orman, Greg",123,120020
+ATCHISON,Benton Township H62,United States Senate,,Libertarian,"Batson, Randall",25,120020
+ATCHISON,Benton Township H62,United States Senate,,Republican,"Roberts, Pat",147,120020
+ATCHISON,Benton Township H63,United States Senate,,independent,"Orman, Greg",29,120030
+ATCHISON,Benton Township H63,United States Senate,,Libertarian,"Batson, Randall",8,120030
+ATCHISON,Benton Township H63,United States Senate,,Republican,"Roberts, Pat",46,120030

--- a/2014/20141104__ks__general__barber__precinct.csv
+++ b/2014/20141104__ks__general__barber__precinct.csv
@@ -1,382 +1,392 @@
-county,precinct,office,district,party,candidate,votes
-Barber,Aetna,U.S. Senate,,R,Pat Roberts,4
-Barber,Deerhead,U.S. Senate,,R,Pat Roberts,5
-Barber,Eagle,U.S. Senate,,R,Pat Roberts,14
-Barber,Elm Mills,U.S. Senate,,R,Pat Roberts,39
-Barber,Elwood,U.S. Senate,,R,Pat Roberts,40
-Barber,Hazelton,U.S. Senate,,R,Pat Roberts,42
-Barber,Kiowa E,U.S. Senate,,R,Pat Roberts,186
-Barber,Kiowa W,U.S. Senate,,R,Pat Roberts,108
-Barber,Lake City,U.S. Senate,,R,Pat Roberts,21
-Barber,McAdoo,U.S. Senate,,R,Pat Roberts,7
-Barber,Med Lodge 1,U.S. Senate,,R,Pat Roberts,171
-Barber,Med Lodge 2,U.S. Senate,,R,Pat Roberts,140
-Barber,Med Lodge 3,U.S. Senate,,R,Pat Roberts,90
-Barber,Med Lodge 4,U.S. Senate,,R,Pat Roberts,90
-Barber,Med Lodge 5,U.S. Senate,,R,Pat Roberts,16
-Barber,Mingona,U.S. Senate,,R,Pat Roberts,22
-Barber,Moore,U.S. Senate,,R,Pat Roberts,8
-Barber,Nippawalla,U.S. Senate,,R,Pat Roberts,15
-Barber,Sharon,U.S. Senate,,R,Pat Roberts,110
-Barber,Sun City,U.S. Senate,,R,Pat Roberts,18
-Barber,Turkey Creek,U.S. Senate,,R,Pat Roberts,4
-Barber,Valley,U.S. Senate,,R,Pat Roberts,46
-Barber,Aetna,U.S. Senate,,I,Greg Orman,0
-Barber,Deerhead,U.S. Senate,,I,Greg Orman,0
-Barber,Eagle,U.S. Senate,,I,Greg Orman,0
-Barber,Elm Mills,U.S. Senate,,I,Greg Orman,18
-Barber,Elwood,U.S. Senate,,I,Greg Orman,18
-Barber,Hazelton,U.S. Senate,,I,Greg Orman,22
-Barber,Kiowa E,U.S. Senate,,I,Greg Orman,51
-Barber,Kiowa W,U.S. Senate,,I,Greg Orman,51
-Barber,Lake City,U.S. Senate,,I,Greg Orman,7
-Barber,McAdoo,U.S. Senate,,I,Greg Orman,2
-Barber,Med Lodge 1,U.S. Senate,,I,Greg Orman,87
-Barber,Med Lodge 2,U.S. Senate,,I,Greg Orman,56
-Barber,Med Lodge 3,U.S. Senate,,I,Greg Orman,46
-Barber,Med Lodge 4,U.S. Senate,,I,Greg Orman,20
-Barber,Med Lodge 5,U.S. Senate,,I,Greg Orman,9
-Barber,Mingona,U.S. Senate,,I,Greg Orman,12
-Barber,Moore,U.S. Senate,,I,Greg Orman,5
-Barber,Nippawalla,U.S. Senate,,I,Greg Orman,1
-Barber,Sharon,U.S. Senate,,I,Greg Orman,27
-Barber,Sun City,U.S. Senate,,I,Greg Orman,1
-Barber,Turkey Creek,U.S. Senate,,I,Greg Orman,5
-Barber,Valley,U.S. Senate,,I,Greg Orman,9
-Barber,Aetna,U.S. Senate,,L,Randall Batson,0
-Barber,Deerhead,U.S. Senate,,L,Randall Batson,0
-Barber,Eagle,U.S. Senate,,L,Randall Batson,0
-Barber,Elm Mills,U.S. Senate,,L,Randall Batson,2
-Barber,Elwood,U.S. Senate,,L,Randall Batson,2
-Barber,Hazelton,U.S. Senate,,L,Randall Batson,6
-Barber,Kiowa E,U.S. Senate,,L,Randall Batson,0
-Barber,Kiowa W,U.S. Senate,,L,Randall Batson,19
-Barber,Lake City,U.S. Senate,,L,Randall Batson,1
-Barber,McAdoo,U.S. Senate,,L,Randall Batson,0
-Barber,Med Lodge 1,U.S. Senate,,L,Randall Batson,9
-Barber,Med Lodge 2,U.S. Senate,,L,Randall Batson,7
-Barber,Med Lodge 3,U.S. Senate,,L,Randall Batson,1
-Barber,Med Lodge 4,U.S. Senate,,L,Randall Batson,5
-Barber,Med Lodge 5,U.S. Senate,,L,Randall Batson,1
-Barber,Mingona,U.S. Senate,,L,Randall Batson,0
-Barber,Moore,U.S. Senate,,L,Randall Batson,0
-Barber,Nippawalla,U.S. Senate,,L,Randall Batson,0
-Barber,Sharon,U.S. Senate,,L,Randall Batson,8
-Barber,Sun City,U.S. Senate,,L,Randall Batson,1
-Barber,Turkey Creek,U.S. Senate,,L,Randall Batson,0
-Barber,Valley,U.S. Senate,,L,Randall Batson,1
-Barber,Aetna,U.S. House,4,R,Mike Pompeo,4
-Barber,Deerhead,U.S. House,4,R,Mike Pompeo,5
-Barber,Eagle,U.S. House,4,R,Mike Pompeo,13
-Barber,Elm Mills,U.S. House,4,R,Mike Pompeo,51
-Barber,Elwood,U.S. House,4,R,Mike Pompeo,49
-Barber,Hazelton,U.S. House,4,R,Mike Pompeo,51
-Barber,Kiowa E,U.S. House,4,R,Mike Pompeo,224
-Barber,Kiowa W,U.S. House,4,R,Mike Pompeo,126
-Barber,Lake City,U.S. House,4,R,Mike Pompeo,20
-Barber,McAdoo,U.S. House,4,R,Mike Pompeo,9
-Barber,Med Lodge 1,U.S. House,4,R,Mike Pompeo,209
-Barber,Med Lodge 2,U.S. House,4,R,Mike Pompeo,154
-Barber,Med Lodge 3,U.S. House,4,R,Mike Pompeo,111
-Barber,Med Lodge 4,U.S. House,4,R,Mike Pompeo,102
-Barber,Med Lodge 5,U.S. House,4,R,Mike Pompeo,24
-Barber,Mingona,U.S. House,4,R,Mike Pompeo,25
-Barber,Moore,U.S. House,4,R,Mike Pompeo,8
-Barber,Nippawalla,U.S. House,4,R,Mike Pompeo,15
-Barber,Sharon,U.S. House,4,R,Mike Pompeo,125
-Barber,Sun City,U.S. House,4,R,Mike Pompeo,20
-Barber,Turkey Creek,U.S. House,4,R,Mike Pompeo,6
-Barber,Valley,U.S. House,4,R,Mike Pompeo,52
-Barber,Aetna,U.S. House,4,D,Perry Schuckman,0
-Barber,Deerhead,U.S. House,4,D,Perry Schuckman,0
-Barber,Eagle,U.S. House,4,D,Perry Schuckman,1
-Barber,Elm Mills,U.S. House,4,D,Perry Schuckman,11
-Barber,Elwood,U.S. House,4,D,Perry Schuckman,16
-Barber,Hazelton,U.S. House,4,D,Perry Schuckman,21
-Barber,Kiowa E,U.S. House,4,D,Perry Schuckman,32
-Barber,Kiowa W,U.S. House,4,D,Perry Schuckman,40
-Barber,Lake City,U.S. House,4,D,Perry Schuckman,6
-Barber,McAdoo,U.S. House,4,D,Perry Schuckman,0
-Barber,Med Lodge 1,U.S. House,4,D,Perry Schuckman,64
-Barber,Med Lodge 2,U.S. House,4,D,Perry Schuckman,47
-Barber,Med Lodge 3,U.S. House,4,D,Perry Schuckman,28
-Barber,Med Lodge 4,U.S. House,4,D,Perry Schuckman,15
-Barber,Med Lodge 5,U.S. House,4,D,Perry Schuckman,3
-Barber,Mingona,U.S. House,4,D,Perry Schuckman,9
-Barber,Moore,U.S. House,4,D,Perry Schuckman,5
-Barber,Nippawalla,U.S. House,4,D,Perry Schuckman,1
-Barber,Sharon,U.S. House,4,D,Perry Schuckman,24
-Barber,Sun City,U.S. House,4,D,Perry Schuckman,2
-Barber,Turkey Creek,U.S. House,4,D,Perry Schuckman,4
-Barber,Valley,U.S. House,4,D,Perry Schuckman,5
-Barber,Aetna,Governor,,R,Sam Brownback,4
-Barber,Deerhead,Governor,,R,Sam Brownback,5
-Barber,Eagle,Governor,,R,Sam Brownback,14
-Barber,Elm Mills,Governor,,R,Sam Brownback,43
-Barber,Elwood,Governor,,R,Sam Brownback,43
-Barber,Hazelton,Governor,,R,Sam Brownback,39
-Barber,Kiowa E,Governor,,R,Sam Brownback,169
-Barber,Kiowa W,Governor,,R,Sam Brownback,102
-Barber,Lake City,Governor,,R,Sam Brownback,22
-Barber,McAdoo,Governor,,R,Sam Brownback,8
-Barber,Med Lodge 1,Governor,,R,Sam Brownback,160
-Barber,Med Lodge 2,Governor,,R,Sam Brownback,129
-Barber,Med Lodge 3,Governor,,R,Sam Brownback,83
-Barber,Med Lodge 4,Governor,,R,Sam Brownback,89
-Barber,Med Lodge 5,Governor,,R,Sam Brownback,21
-Barber,Mingona,Governor,,R,Sam Brownback,24
-Barber,Moore,Governor,,R,Sam Brownback,7
-Barber,Nippawalla,Governor,,R,Sam Brownback,16
-Barber,Sharon,Governor,,R,Sam Brownback,109
-Barber,Sun City,Governor,,R,Sam Brownback,19
-Barber,Turkey Creek,Governor,,R,Sam Brownback,5
-Barber,Valley,Governor,,R,Sam Brownback,46
-Barber,Aetna,Governor,,D,Paul Davis,0
-Barber,Deerhead,Governor,,D,Paul Davis,0
-Barber,Eagle,Governor,,D,Paul Davis,0
-Barber,Elm Mills,Governor,,D,Paul Davis,15
-Barber,Elwood,Governor,,D,Paul Davis,18
-Barber,Hazelton,Governor,,D,Paul Davis,30
-Barber,Kiowa E,Governor,,D,Paul Davis,70
-Barber,Kiowa W,Governor,,D,Paul Davis,57
-Barber,Lake City,Governor,,D,Paul Davis,8
-Barber,McAdoo,Governor,,D,Paul Davis,1
-Barber,Med Lodge 1,Governor,,D,Paul Davis,107
-Barber,Med Lodge 2,Governor,,D,Paul Davis,62
-Barber,Med Lodge 3,Governor,,D,Paul Davis,55
-Barber,Med Lodge 4,Governor,,D,Paul Davis,25
-Barber,Med Lodge 5,Governor,,D,Paul Davis,5
-Barber,Mingona,Governor,,D,Paul Davis,10
-Barber,Moore,Governor,,D,Paul Davis,6
-Barber,Nippawalla,Governor,,D,Paul Davis,0
-Barber,Sharon,Governor,,D,Paul Davis,34
-Barber,Sun City,Governor,,D,Paul Davis,1
-Barber,Turkey Creek,Governor,,D,Paul Davis,5
-Barber,Valley,Governor,,D,Paul Davis,11
-Barber,Aetna,Governor,,L,Keen Umbehr,0
-Barber,Deerhead,Governor,,L,Keen Umbehr,0
-Barber,Eagle,Governor,,L,Keen Umbehr,0
-Barber,Elm Mills,Governor,,L,Keen Umbehr,3
-Barber,Elwood,Governor,,L,Keen Umbehr,4
-Barber,Hazelton,Governor,,L,Keen Umbehr,3
-Barber,Kiowa E,Governor,,L,Keen Umbehr,14
-Barber,Kiowa W,Governor,,L,Keen Umbehr,10
-Barber,Lake City,Governor,,L,Keen Umbehr,0
-Barber,McAdoo,Governor,,L,Keen Umbehr,0
-Barber,Med Lodge 1,Governor,,L,Keen Umbehr,10
-Barber,Med Lodge 2,Governor,,L,Keen Umbehr,11
-Barber,Med Lodge 3,Governor,,L,Keen Umbehr,3
-Barber,Med Lodge 4,Governor,,L,Keen Umbehr,5
-Barber,Med Lodge 5,Governor,,L,Keen Umbehr,1
-Barber,Mingona,Governor,,L,Keen Umbehr,0
-Barber,Moore,Governor,,L,Keen Umbehr,0
-Barber,Nippawalla,Governor,,L,Keen Umbehr,0
-Barber,Sharon,Governor,,L,Keen Umbehr,7
-Barber,Sun City,Governor,,L,Keen Umbehr,1
-Barber,Turkey Creek,Governor,,L,Keen Umbehr,0
-Barber,Valley,Governor,,L,Keen Umbehr,0
-Barber,Aetna,Secretary of State,,R,Kris Kobach,4
-Barber,Deerhead,Secretary of State,,R,Kris Kobach,5
-Barber,Eagle,Secretary of State,,R,Kris Kobach,11
-Barber,Elm Mills,Secretary of State,,R,Kris Kobach,46
-Barber,Elwood,Secretary of State,,R,Kris Kobach,46
-Barber,Hazelton,Secretary of State,,R,Kris Kobach,43
-Barber,Kiowa E,Secretary of State,,R,Kris Kobach,201
-Barber,Kiowa W,Secretary of State,,R,Kris Kobach,110
-Barber,Lake City,Secretary of State,,R,Kris Kobach,21
-Barber,McAdoo,Secretary of State,,R,Kris Kobach,6
-Barber,Med Lodge 1,Secretary of State,,R,Kris Kobach,188
-Barber,Med Lodge 2,Secretary of State,,R,Kris Kobach,138
-Barber,Med Lodge 3,Secretary of State,,R,Kris Kobach,102
-Barber,Med Lodge 4,Secretary of State,,R,Kris Kobach,87
-Barber,Med Lodge 5,Secretary of State,,R,Kris Kobach,22
-Barber,Mingona,Secretary of State,,R,Kris Kobach,24
-Barber,Moore,Secretary of State,,R,Kris Kobach,8
-Barber,Nippawalla,Secretary of State,,R,Kris Kobach,14
-Barber,Sharon,Secretary of State,,R,Kris Kobach,114
-Barber,Sun City,Secretary of State,,R,Kris Kobach,18
-Barber,Turkey Creek,Secretary of State,,R,Kris Kobach,6
-Barber,Valley,Secretary of State,,R,Kris Kobach,50
-Barber,Aetna,Secretary of State,,D,Jean Schodorf,0
-Barber,Deerhead,Secretary of State,,D,Jean Schodorf,0
-Barber,Eagle,Secretary of State,,D,Jean Schodorf,2
-Barber,Elm Mills,Secretary of State,,D,Jean Schodorf,16
-Barber,Elwood,Secretary of State,,D,Jean Schodorf,19
-Barber,Hazelton,Secretary of State,,D,Jean Schodorf,26
-Barber,Kiowa E,Secretary of State,,D,Jean Schodorf,54
-Barber,Kiowa W,Secretary of State,,D,Jean Schodorf,58
-Barber,Lake City,Secretary of State,,D,Jean Schodorf,7
-Barber,McAdoo,Secretary of State,,D,Jean Schodorf,3
-Barber,Med Lodge 1,Secretary of State,,D,Jean Schodorf,87
-Barber,Med Lodge 2,Secretary of State,,D,Jean Schodorf,66
-Barber,Med Lodge 3,Secretary of State,,D,Jean Schodorf,39
-Barber,Med Lodge 4,Secretary of State,,D,Jean Schodorf,29
-Barber,Med Lodge 5,Secretary of State,,D,Jean Schodorf,5
-Barber,Mingona,Secretary of State,,D,Jean Schodorf,10
-Barber,Moore,Secretary of State,,D,Jean Schodorf,5
-Barber,Nippawalla,Secretary of State,,D,Jean Schodorf,2
-Barber,Sharon,Secretary of State,,D,Jean Schodorf,36
-Barber,Sun City,Secretary of State,,D,Jean Schodorf,1
-Barber,Turkey Creek,Secretary of State,,D,Jean Schodorf,4
-Barber,Valley,Secretary of State,,D,Jean Schodorf,7
-Barber,Aetna,Attorney General,,R,Derek Schmidt,4
-Barber,Deerhead,Attorney General,,R,Derek Schmidt,5
-Barber,Eagle,Attorney General,,R,Derek Schmidt,13
-Barber,Elm Mills,Attorney General,,R,Derek Schmidt,51
-Barber,Elwood,Attorney General,,R,Derek Schmidt,53
-Barber,Hazelton,Attorney General,,R,Derek Schmidt,48
-Barber,Kiowa E,Attorney General,,R,Derek Schmidt,212
-Barber,Kiowa W,Attorney General,,R,Derek Schmidt,129
-Barber,Lake City,Attorney General,,R,Derek Schmidt,23
-Barber,McAdoo,Attorney General,,R,Derek Schmidt,9
-Barber,Med Lodge 1,Attorney General,,R,Derek Schmidt,214
-Barber,Med Lodge 2,Attorney General,,R,Derek Schmidt,157
-Barber,Med Lodge 3,Attorney General,,R,Derek Schmidt,121
-Barber,Med Lodge 4,Attorney General,,R,Derek Schmidt,96
-Barber,Med Lodge 5,Attorney General,,R,Derek Schmidt,24
-Barber,Mingona,Attorney General,,R,Derek Schmidt,26
-Barber,Moore,Attorney General,,R,Derek Schmidt,8
-Barber,Nippawalla,Attorney General,,R,Derek Schmidt,14
-Barber,Sharon,Attorney General,,R,Derek Schmidt,132
-Barber,Sun City,Attorney General,,R,Derek Schmidt,16
-Barber,Turkey Creek,Attorney General,,R,Derek Schmidt,6
-Barber,Valley,Attorney General,,R,Derek Schmidt,49
-Barber,Aetna,Attorney General,,D,A J Kotich,0
-Barber,Deerhead,Attorney General,,D,A J Kotich,0
-Barber,Eagle,Attorney General,,D,A J Kotich,1
-Barber,Elm Mills,Attorney General,,D,A J Kotich,9
-Barber,Elwood,Attorney General,,D,A J Kotich,12
-Barber,Hazelton,Attorney General,,D,A J Kotich,19
-Barber,Kiowa E,Attorney General,,D,A J Kotich,37
-Barber,Kiowa W,Attorney General,,D,A J Kotich,39
-Barber,Lake City,Attorney General,,D,A J Kotich,5
-Barber,McAdoo,Attorney General,,D,A J Kotich,0
-Barber,Med Lodge 1,Attorney General,,D,A J Kotich,57
-Barber,Med Lodge 2,Attorney General,,D,A J Kotich,42
-Barber,Med Lodge 3,Attorney General,,D,A J Kotich,17
-Barber,Med Lodge 4,Attorney General,,D,A J Kotich,17
-Barber,Med Lodge 5,Attorney General,,D,A J Kotich,3
-Barber,Mingona,Attorney General,,D,A J Kotich,6
-Barber,Moore,Attorney General,,D,A J Kotich,5
-Barber,Nippawalla,Attorney General,,D,A J Kotich,1
-Barber,Sharon,Attorney General,,D,A J Kotich,14
-Barber,Sun City,Attorney General,,D,A J Kotich,3
-Barber,Turkey Creek,Attorney General,,D,A J Kotich,4
-Barber,Valley,Attorney General,,D,A J Kotich,6
-Barber,Aetna,State Treasurer,,R,Ron Estes,4
-Barber,Deerhead,State Treasurer,,R,Ron Estes,5
-Barber,Eagle,State Treasurer,,R,Ron Estes,13
-Barber,Elm Mills,State Treasurer,,R,Ron Estes,51
-Barber,Elwood,State Treasurer,,R,Ron Estes,53
-Barber,Hazelton,State Treasurer,,R,Ron Estes,48
-Barber,Kiowa E,State Treasurer,,R,Ron Estes,212
-Barber,Kiowa W,State Treasurer,,R,Ron Estes,121
-Barber,Lake City,State Treasurer,,R,Ron Estes,21
-Barber,McAdoo,State Treasurer,,R,Ron Estes,7
-Barber,Med Lodge 1,State Treasurer,,R,Ron Estes,209
-Barber,Med Lodge 2,State Treasurer,,R,Ron Estes,157
-Barber,Med Lodge 3,State Treasurer,,R,Ron Estes,114
-Barber,Med Lodge 4,State Treasurer,,R,Ron Estes,94
-Barber,Med Lodge 5,State Treasurer,,R,Ron Estes,23
-Barber,Mingona,State Treasurer,,R,Ron Estes,23
-Barber,Moore,State Treasurer,,R,Ron Estes,9
-Barber,Nippawalla,State Treasurer,,R,Ron Estes,13
-Barber,Sharon,State Treasurer,,R,Ron Estes,120
-Barber,Sun City,State Treasurer,,R,Ron Estes,18
-Barber,Turkey Creek,State Treasurer,,R,Ron Estes,5
-Barber,Valley,State Treasurer,,R,Ron Estes,50
-Barber,Aetna,State Treasurer,,D,Carmen Alldritt,0
-Barber,Deerhead,State Treasurer,,D,Carmen Alldritt,0
-Barber,Eagle,State Treasurer,,D,Carmen Alldritt,1
-Barber,Elm Mills,State Treasurer,,D,Carmen Alldritt,9
-Barber,Elwood,State Treasurer,,D,Carmen Alldritt,18
-Barber,Hazelton,State Treasurer,,D,Carmen Alldritt,18
-Barber,Kiowa E,State Treasurer,,D,Carmen Alldritt,32
-Barber,Kiowa W,State Treasurer,,D,Carmen Alldritt,47
-Barber,Lake City,State Treasurer,,D,Carmen Alldritt,7
-Barber,McAdoo,State Treasurer,,D,Carmen Alldritt,2
-Barber,Med Lodge 1,State Treasurer,,D,Carmen Alldritt,62
-Barber,Med Lodge 2,State Treasurer,,D,Carmen Alldritt,44
-Barber,Med Lodge 3,State Treasurer,,D,Carmen Alldritt,25
-Barber,Med Lodge 4,State Treasurer,,D,Carmen Alldritt,19
-Barber,Med Lodge 5,State Treasurer,,D,Carmen Alldritt,4
-Barber,Mingona,State Treasurer,,D,Carmen Alldritt,9
-Barber,Moore,State Treasurer,,D,Carmen Alldritt,4
-Barber,Nippawalla,State Treasurer,,D,Carmen Alldritt,2
-Barber,Sharon,State Treasurer,,D,Carmen Alldritt,26
-Barber,Sun City,State Treasurer,,D,Carmen Alldritt,0
-Barber,Turkey Creek,State Treasurer,,D,Carmen Alldritt,3
-Barber,Valley,State Treasurer,,D,Carmen Alldritt,7
-Barber,Aetna,Insurance Commissioner,,R,Ken Selzer,2
-Barber,Deerhead,Insurance Commissioner,,R,Ken Selzer,5
-Barber,Eagle,Insurance Commissioner,,R,Ken Selzer,13
-Barber,Elm Mills,Insurance Commissioner,,R,Ken Selzer,48
-Barber,Elwood,Insurance Commissioner,,R,Ken Selzer,51
-Barber,Hazelton,Insurance Commissioner,,R,Ken Selzer,46
-Barber,Kiowa E,Insurance Commissioner,,R,Ken Selzer,202
-Barber,Kiowa W,Insurance Commissioner,,R,Ken Selzer,115
-Barber,Lake City,Insurance Commissioner,,R,Ken Selzer,20
-Barber,McAdoo,Insurance Commissioner,,R,Ken Selzer,7
-Barber,Med Lodge 1,Insurance Commissioner,,R,Ken Selzer,200
-Barber,Med Lodge 2,Insurance Commissioner,,R,Ken Selzer,143
-Barber,Med Lodge 3,Insurance Commissioner,,R,Ken Selzer,105
-Barber,Med Lodge 4,Insurance Commissioner,,R,Ken Selzer,93
-Barber,Med Lodge 5,Insurance Commissioner,,R,Ken Selzer,24
-Barber,Mingona,Insurance Commissioner,,R,Ken Selzer,23
-Barber,Moore,Insurance Commissioner,,R,Ken Selzer,8
-Barber,Nippawalla,Insurance Commissioner,,R,Ken Selzer,13
-Barber,Sharon,Insurance Commissioner,,R,Ken Selzer,122
-Barber,Sun City,Insurance Commissioner,,R,Ken Selzer,19
-Barber,Turkey Creek,Insurance Commissioner,,R,Ken Selzer,5
-Barber,Valley,Insurance Commissioner,,R,Ken Selzer,50
-Barber,Aetna,Insurance Commissioner,,D,Dennis Anderson,1
-Barber,Deerhead,Insurance Commissioner,,D,Dennis Anderson,0
-Barber,Eagle,Insurance Commissioner,,D,Dennis Anderson,1
-Barber,Elm Mills,Insurance Commissioner,,D,Dennis Anderson,13
-Barber,Elwood,Insurance Commissioner,,D,Dennis Anderson,14
-Barber,Hazelton,Insurance Commissioner,,D,Dennis Anderson,19
-Barber,Kiowa E,Insurance Commissioner,,D,Dennis Anderson,44
-Barber,Kiowa W,Insurance Commissioner,,D,Dennis Anderson,46
-Barber,Lake City,Insurance Commissioner,,D,Dennis Anderson,5
-Barber,McAdoo,Insurance Commissioner,,D,Dennis Anderson,2
-Barber,Med Lodge 1,Insurance Commissioner,,D,Dennis Anderson,72
-Barber,Med Lodge 2,Insurance Commissioner,,D,Dennis Anderson,58
-Barber,Med Lodge 3,Insurance Commissioner,,D,Dennis Anderson,33
-Barber,Med Lodge 4,Insurance Commissioner,,D,Dennis Anderson,18
-Barber,Med Lodge 5,Insurance Commissioner,,D,Dennis Anderson,3
-Barber,Mingona,Insurance Commissioner,,D,Dennis Anderson,7
-Barber,Moore,Insurance Commissioner,,D,Dennis Anderson,5
-Barber,Nippawalla,Insurance Commissioner,,D,Dennis Anderson,3
-Barber,Sharon,Insurance Commissioner,,D,Dennis Anderson,22
-Barber,Sun City,Insurance Commissioner,,D,Dennis Anderson,0
-Barber,Turkey Creek,Insurance Commissioner,,D,Dennis Anderson,2
-Barber,Valley,Insurance Commissioner,,D,Dennis Anderson,3
-Barber,Aetna,State House,116,R,Kyle Hoffman,4
-Barber,Deerhead,State House,116,R,Kyle Hoffman,5
-Barber,Eagle,State House,116,R,Kyle Hoffman,14
-Barber,Elm Mills,State House,116,R,Kyle Hoffman,55
-Barber,Elwood,State House,116,R,Kyle Hoffman,57
-Barber,Hazelton,State House,116,R,Kyle Hoffman,66
-Barber,Kiowa E,State House,116,R,Kyle Hoffman,236
-Barber,Kiowa W,State House,116,R,Kyle Hoffman,148
-Barber,Lake City,State House,116,R,Kyle Hoffman,25
-Barber,McAdoo,State House,116,R,Kyle Hoffman,9
-Barber,Med Lodge 1,State House,116,R,Kyle Hoffman,238
-Barber,Med Lodge 2,State House,116,R,Kyle Hoffman,181
-Barber,Med Lodge 3,State House,116,R,Kyle Hoffman,128
-Barber,Med Lodge 4,State House,116,R,Kyle Hoffman,110
-Barber,Med Lodge 5,State House,116,R,Kyle Hoffman,25
-Barber,Mingona,State House,116,R,Kyle Hoffman,28
-Barber,Moore,State House,116,R,Kyle Hoffman,10
-Barber,Nippawalla,State House,116,R,Kyle Hoffman,14
-Barber,Sharon,State House,116,R,Kyle Hoffman,136
-Barber,Sun City,State House,116,R,Kyle Hoffman,20
-Barber,Turkey Creek,State House,116,R,Kyle Hoffman,6
-Barber,Valley,State House,116,R,Kyle Hoffman,53
-Barber,Kiowa E,State House,116,wri,Ron Molz [wri],1
-Barber,Kiowa W,State House,116,wri,Miranda Allen [wri],1
-Barber,Kiowa W,State House,116,wri,Dennis McKinney [wri],1
-Barber,Med Lodge 2,State House,116,wri,Alan Goering [wri],1
-Barber,Med Lodge 4,State House,116,wri,Alan Goering [wri],2
-Barber,Sharon,State House,116,wri,Alan Albers [wri],1
-Barber,Kiowa East,Governor,,wri,Teresa Rothgaber,1
+county,precinct,office,district,party,candidate,votes,vtd
+BARBER,Aetna Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000010
+BARBER,Aetna Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+BARBER,Aetna Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,000010
+BARBER,Deerhead Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000020
+BARBER,Deerhead Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+BARBER,Deerhead Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,000020
+BARBER,Eagle Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000030
+BARBER,Eagle Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+BARBER,Eagle Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000030
+BARBER,Elm Mills Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000040
+BARBER,Elm Mills Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+BARBER,Elm Mills Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000040
+BARBER,Elwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000050
+BARBER,Elwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000050
+BARBER,Elwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000050
+BARBER,Hazelton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000060
+BARBER,Hazelton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000060
+BARBER,Hazelton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000060
+BARBER,Kiowa East Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",70,000070
+BARBER,Kiowa East Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000070
+BARBER,Kiowa East Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",169,000070
+BARBER,Kiowa West Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",57,000080
+BARBER,Kiowa West Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000080
+BARBER,Kiowa West Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000080
+BARBER,Lake City Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000090
+BARBER,Lake City Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+BARBER,Lake City Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000090
+BARBER,McAdoo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000100
+BARBER,McAdoo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+BARBER,McAdoo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000100
+BARBER,Medicine Lodge Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,000110
+BARBER,Medicine Lodge Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000110
+BARBER,Medicine Lodge Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",160,000110
+BARBER,Medicine Lodge Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,00012A
+BARBER,Medicine Lodge Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,00012A
+BARBER,Medicine Lodge Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",129,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00012B
+BARBER,Medicine Lodge Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000130
+BARBER,Medicine Lodge Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000130
+BARBER,Medicine Lodge Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",83,000130
+BARBER,Medicine Lodge Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000140
+BARBER,Medicine Lodge Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000140
+BARBER,Medicine Lodge Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000140
+BARBER,Medicine Lodge Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000150
+BARBER,Medicine Lodge Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+BARBER,Medicine Lodge Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000150
+BARBER,Mingona Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000160
+BARBER,Mingona Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000160
+BARBER,Mingona Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000160
+BARBER,Moore Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000170
+BARBER,Moore Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000170
+BARBER,Moore Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,000170
+BARBER,Nippawalla Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000180
+BARBER,Nippawalla Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000180
+BARBER,Nippawalla Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000180
+BARBER,Sun City Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000210
+BARBER,Sun City Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000210
+BARBER,Sun City Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000210
+BARBER,Turkey Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000220
+BARBER,Turkey Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000220
+BARBER,Turkey Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,000220
+BARBER,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000230
+BARBER,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+BARBER,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000230
+BARBER,Sharon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,130010
+BARBER,Sharon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,130010
+BARBER,Sharon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",109,130010
+BARBER,Aetna Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",4,000010
+BARBER,Deerhead Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",5,000020
+BARBER,Eagle Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",14,000030
+BARBER,Elm Mills Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",55,000040
+BARBER,Elwood Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",57,000050
+BARBER,Hazelton Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",66,000060
+BARBER,Kiowa East Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",236,000070
+BARBER,Kiowa West Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",148,000080
+BARBER,Lake City Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",25,000090
+BARBER,McAdoo Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",9,000100
+BARBER,Medicine Lodge Precinct 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",238,000110
+BARBER,Medicine Lodge Precinct 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",181,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,00012B
+BARBER,Medicine Lodge Precinct 3,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",128,000130
+BARBER,Medicine Lodge Precinct 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",110,000140
+BARBER,Medicine Lodge Precinct 5,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",25,000150
+BARBER,Mingona Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",28,000160
+BARBER,Moore Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",10,000170
+BARBER,Nippawalla Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",14,000180
+BARBER,Sun City Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",20,000210
+BARBER,Turkey Creek Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",6,000220
+BARBER,Valley Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",53,000230
+BARBER,Sharon Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",136,130010
+BARBER,Aetna Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000010
+BARBER,Aetna Township,United States House of Representatives,4,Republican,"Pompeo, Mike",4,000010
+BARBER,Deerhead Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000020
+BARBER,Deerhead Township,United States House of Representatives,4,Republican,"Pompeo, Mike",5,000020
+BARBER,Eagle Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,000030
+BARBER,Eagle Township,United States House of Representatives,4,Republican,"Pompeo, Mike",13,000030
+BARBER,Elm Mills Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,000040
+BARBER,Elm Mills Township,United States House of Representatives,4,Republican,"Pompeo, Mike",51,000040
+BARBER,Elwood Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",16,000050
+BARBER,Elwood Township,United States House of Representatives,4,Republican,"Pompeo, Mike",49,000050
+BARBER,Hazelton Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",21,000060
+BARBER,Hazelton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",51,000060
+BARBER,Kiowa East Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",32,000070
+BARBER,Kiowa East Township,United States House of Representatives,4,Republican,"Pompeo, Mike",224,000070
+BARBER,Kiowa West Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",42,000080
+BARBER,Kiowa West Township,United States House of Representatives,4,Republican,"Pompeo, Mike",126,000080
+BARBER,Lake City Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",6,000090
+BARBER,Lake City Township,United States House of Representatives,4,Republican,"Pompeo, Mike",20,000090
+BARBER,McAdoo Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000100
+BARBER,McAdoo Township,United States House of Representatives,4,Republican,"Pompeo, Mike",9,000100
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",64,000110
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",209,000110
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",47,00012A
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",154,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00012B
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",28,000130
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",111,000130
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",15,000140
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Mike",102,000140
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,000150
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,Republican,"Pompeo, Mike",24,000150
+BARBER,Mingona Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,000160
+BARBER,Mingona Township,United States House of Representatives,4,Republican,"Pompeo, Mike",25,000160
+BARBER,Moore Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000170
+BARBER,Moore Township,United States House of Representatives,4,Republican,"Pompeo, Mike",8,000170
+BARBER,Nippawalla Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,000180
+BARBER,Nippawalla Township,United States House of Representatives,4,Republican,"Pompeo, Mike",15,000180
+BARBER,Sun City Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000210
+BARBER,Sun City Township,United States House of Representatives,4,Republican,"Pompeo, Mike",20,000210
+BARBER,Turkey Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000220
+BARBER,Turkey Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",6,000220
+BARBER,Valley Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000230
+BARBER,Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",52,000230
+BARBER,Sharon Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",24,130010
+BARBER,Sharon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",125,130010
+BARBER,Aetna Township,Attorney General,,Democratic,"Kotich, A.J.",0,000010
+BARBER,Aetna Township,Attorney General,,Republican,"Schmidt, Derek",4,000010
+BARBER,Deerhead Township,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+BARBER,Deerhead Township,Attorney General,,Republican,"Schmidt, Derek",5,000020
+BARBER,Eagle Township,Attorney General,,Democratic,"Kotich, A.J.",1,000030
+BARBER,Eagle Township,Attorney General,,Republican,"Schmidt, Derek",13,000030
+BARBER,Elm Mills Township,Attorney General,,Democratic,"Kotich, A.J.",9,000040
+BARBER,Elm Mills Township,Attorney General,,Republican,"Schmidt, Derek",53,000040
+BARBER,Elwood Township,Attorney General,,Democratic,"Kotich, A.J.",18,000050
+BARBER,Elwood Township,Attorney General,,Republican,"Schmidt, Derek",47,000050
+BARBER,Hazelton Township,Attorney General,,Democratic,"Kotich, A.J.",18,000060
+BARBER,Hazelton Township,Attorney General,,Republican,"Schmidt, Derek",51,000060
+BARBER,Kiowa East Township,Attorney General,,Democratic,"Kotich, A.J.",32,000070
+BARBER,Kiowa East Township,Attorney General,,Republican,"Schmidt, Derek",215,000070
+BARBER,Kiowa West Township,Attorney General,,Democratic,"Kotich, A.J.",39,000080
+BARBER,Kiowa West Township,Attorney General,,Republican,"Schmidt, Derek",127,000080
+BARBER,Lake City Township,Attorney General,,Democratic,"Kotich, A.J.",5,000090
+BARBER,Lake City Township,Attorney General,,Republican,"Schmidt, Derek",23,000090
+BARBER,McAdoo Township,Attorney General,,Democratic,"Kotich, A.J.",0,000100
+BARBER,McAdoo Township,Attorney General,,Republican,"Schmidt, Derek",9,000100
+BARBER,Medicine Lodge Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",57,000110
+BARBER,Medicine Lodge Precinct 1,Attorney General,,Republican,"Schmidt, Derek",214,000110
+BARBER,Medicine Lodge Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",42,00012A
+BARBER,Medicine Lodge Precinct 2,Attorney General,,Republican,"Schmidt, Derek",157,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00012B
+BARBER,Medicine Lodge Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",17,000130
+BARBER,Medicine Lodge Precinct 3,Attorney General,,Republican,"Schmidt, Derek",121,000130
+BARBER,Medicine Lodge Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",17,000140
+BARBER,Medicine Lodge Precinct 4,Attorney General,,Republican,"Schmidt, Derek",96,000140
+BARBER,Medicine Lodge Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",3,000150
+BARBER,Medicine Lodge Precinct 5,Attorney General,,Republican,"Schmidt, Derek",24,000150
+BARBER,Mingona Township,Attorney General,,Democratic,"Kotich, A.J.",6,000160
+BARBER,Mingona Township,Attorney General,,Republican,"Schmidt, Derek",26,000160
+BARBER,Moore Township,Attorney General,,Democratic,"Kotich, A.J.",5,000170
+BARBER,Moore Township,Attorney General,,Republican,"Schmidt, Derek",8,000170
+BARBER,Nippawalla Township,Attorney General,,Democratic,"Kotich, A.J.",1,000180
+BARBER,Nippawalla Township,Attorney General,,Republican,"Schmidt, Derek",14,000180
+BARBER,Sun City Township,Attorney General,,Democratic,"Kotich, A.J.",3,000210
+BARBER,Sun City Township,Attorney General,,Republican,"Schmidt, Derek",16,000210
+BARBER,Turkey Creek Township,Attorney General,,Democratic,"Kotich, A.J.",4,000220
+BARBER,Turkey Creek Township,Attorney General,,Republican,"Schmidt, Derek",6,000220
+BARBER,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",6,000230
+BARBER,Valley Township,Attorney General,,Republican,"Schmidt, Derek",49,000230
+BARBER,Sharon Township,Attorney General,,Democratic,"Kotich, A.J.",14,130010
+BARBER,Sharon Township,Attorney General,,Republican,"Schmidt, Derek",132,130010
+BARBER,Aetna Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000010
+BARBER,Aetna Township,Commissioner of Insurance,,Republican,"Selzer, Ken",2,000010
+BARBER,Deerhead Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000020
+BARBER,Deerhead Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,000020
+BARBER,Eagle Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000030
+BARBER,Eagle Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000030
+BARBER,Elm Mills Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000040
+BARBER,Elm Mills Township,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000040
+BARBER,Elwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000050
+BARBER,Elwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000050
+BARBER,Hazelton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000060
+BARBER,Hazelton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000060
+BARBER,Kiowa East Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",44,000070
+BARBER,Kiowa East Township,Commissioner of Insurance,,Republican,"Selzer, Ken",202,000070
+BARBER,Kiowa West Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000080
+BARBER,Kiowa West Township,Commissioner of Insurance,,Republican,"Selzer, Ken",115,000080
+BARBER,Lake City Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000090
+BARBER,Lake City Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000090
+BARBER,McAdoo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000100
+BARBER,McAdoo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000100
+BARBER,Medicine Lodge Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000110
+BARBER,Medicine Lodge Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",200,000110
+BARBER,Medicine Lodge Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,00012A
+BARBER,Medicine Lodge Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",143,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00012B
+BARBER,Medicine Lodge Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000130
+BARBER,Medicine Lodge Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",105,000130
+BARBER,Medicine Lodge Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000140
+BARBER,Medicine Lodge Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",93,000140
+BARBER,Medicine Lodge Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000150
+BARBER,Medicine Lodge Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000150
+BARBER,Mingona Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000160
+BARBER,Mingona Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000160
+BARBER,Moore Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000170
+BARBER,Moore Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000170
+BARBER,Nippawalla Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000180
+BARBER,Nippawalla Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000180
+BARBER,Sun City Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000210
+BARBER,Sun City Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000210
+BARBER,Turkey Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000220
+BARBER,Turkey Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,000220
+BARBER,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000230
+BARBER,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000230
+BARBER,Sharon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,130010
+BARBER,Sharon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",122,130010
+BARBER,Aetna Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000010
+BARBER,Aetna Township,Secretary of State,,Republican,"Kobach, Kris",4,000010
+BARBER,Deerhead Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+BARBER,Deerhead Township,Secretary of State,,Republican,"Kobach, Kris",5,000020
+BARBER,Eagle Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000030
+BARBER,Eagle Township,Secretary of State,,Republican,"Kobach, Kris",11,000030
+BARBER,Elm Mills Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000040
+BARBER,Elm Mills Township,Secretary of State,,Republican,"Kobach, Kris",46,000040
+BARBER,Elwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000050
+BARBER,Elwood Township,Secretary of State,,Republican,"Kobach, Kris",46,000050
+BARBER,Hazelton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000060
+BARBER,Hazelton Township,Secretary of State,,Republican,"Kobach, Kris",43,000060
+BARBER,Kiowa East Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,000070
+BARBER,Kiowa East Township,Secretary of State,,Republican,"Kobach, Kris",201,000070
+BARBER,Kiowa West Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000080
+BARBER,Kiowa West Township,Secretary of State,,Republican,"Kobach, Kris",110,000080
+BARBER,Lake City Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000090
+BARBER,Lake City Township,Secretary of State,,Republican,"Kobach, Kris",21,000090
+BARBER,McAdoo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000100
+BARBER,McAdoo Township,Secretary of State,,Republican,"Kobach, Kris",6,000100
+BARBER,Medicine Lodge Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",87,000110
+BARBER,Medicine Lodge Precinct 1,Secretary of State,,Republican,"Kobach, Kris",188,000110
+BARBER,Medicine Lodge Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,00012A
+BARBER,Medicine Lodge Precinct 2,Secretary of State,,Republican,"Kobach, Kris",138,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00012B
+BARBER,Medicine Lodge Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000130
+BARBER,Medicine Lodge Precinct 3,Secretary of State,,Republican,"Kobach, Kris",102,000130
+BARBER,Medicine Lodge Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000140
+BARBER,Medicine Lodge Precinct 4,Secretary of State,,Republican,"Kobach, Kris",87,000140
+BARBER,Medicine Lodge Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000150
+BARBER,Medicine Lodge Precinct 5,Secretary of State,,Republican,"Kobach, Kris",22,000150
+BARBER,Mingona Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000160
+BARBER,Mingona Township,Secretary of State,,Republican,"Kobach, Kris",24,000160
+BARBER,Moore Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000170
+BARBER,Moore Township,Secretary of State,,Republican,"Kobach, Kris",8,000170
+BARBER,Nippawalla Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000180
+BARBER,Nippawalla Township,Secretary of State,,Republican,"Kobach, Kris",14,000180
+BARBER,Sun City Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000210
+BARBER,Sun City Township,Secretary of State,,Republican,"Kobach, Kris",18,000210
+BARBER,Turkey Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000220
+BARBER,Turkey Creek Township,Secretary of State,,Republican,"Kobach, Kris",6,000220
+BARBER,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000230
+BARBER,Valley Township,Secretary of State,,Republican,"Kobach, Kris",50,000230
+BARBER,Sharon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,130010
+BARBER,Sharon Township,Secretary of State,,Republican,"Kobach, Kris",114,130010
+BARBER,Aetna Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000010
+BARBER,Aetna Township,State Treasurer,,Republican,"Estes, Ron",4,000010
+BARBER,Deerhead Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+BARBER,Deerhead Township,State Treasurer,,Republican,"Estes, Ron",5,000020
+BARBER,Eagle Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000030
+BARBER,Eagle Township,State Treasurer,,Republican,"Estes, Ron",13,000030
+BARBER,Elm Mills Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000040
+BARBER,Elm Mills Township,State Treasurer,,Republican,"Estes, Ron",51,000040
+BARBER,Elwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000050
+BARBER,Elwood Township,State Treasurer,,Republican,"Estes, Ron",53,000050
+BARBER,Hazelton Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000060
+BARBER,Hazelton Township,State Treasurer,,Republican,"Estes, Ron",48,000060
+BARBER,Kiowa East Township,State Treasurer,,Democratic,"Alldritt, Carmen",37,000070
+BARBER,Kiowa East Township,State Treasurer,,Republican,"Estes, Ron",212,000070
+BARBER,Kiowa West Township,State Treasurer,,Democratic,"Alldritt, Carmen",46,000080
+BARBER,Kiowa West Township,State Treasurer,,Republican,"Estes, Ron",121,000080
+BARBER,Lake City Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000090
+BARBER,Lake City Township,State Treasurer,,Republican,"Estes, Ron",21,000090
+BARBER,McAdoo Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000100
+BARBER,McAdoo Township,State Treasurer,,Republican,"Estes, Ron",7,000100
+BARBER,Medicine Lodge Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",63,000110
+BARBER,Medicine Lodge Precinct 1,State Treasurer,,Republican,"Estes, Ron",209,000110
+BARBER,Medicine Lodge Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",44,00012A
+BARBER,Medicine Lodge Precinct 2,State Treasurer,,Republican,"Estes, Ron",157,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00012B
+BARBER,Medicine Lodge Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",25,000130
+BARBER,Medicine Lodge Precinct 3,State Treasurer,,Republican,"Estes, Ron",114,000130
+BARBER,Medicine Lodge Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",19,000140
+BARBER,Medicine Lodge Precinct 4,State Treasurer,,Republican,"Estes, Ron",94,000140
+BARBER,Medicine Lodge Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",4,000150
+BARBER,Medicine Lodge Precinct 5,State Treasurer,,Republican,"Estes, Ron",23,000150
+BARBER,Mingona Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000160
+BARBER,Mingona Township,State Treasurer,,Republican,"Estes, Ron",23,000160
+BARBER,Moore Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000170
+BARBER,Moore Township,State Treasurer,,Republican,"Estes, Ron",9,000170
+BARBER,Nippawalla Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000180
+BARBER,Nippawalla Township,State Treasurer,,Republican,"Estes, Ron",13,000180
+BARBER,Sun City Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000210
+BARBER,Sun City Township,State Treasurer,,Republican,"Estes, Ron",18,000210
+BARBER,Turkey Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000220
+BARBER,Turkey Creek Township,State Treasurer,,Republican,"Estes, Ron",5,000220
+BARBER,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000230
+BARBER,Valley Township,State Treasurer,,Republican,"Estes, Ron",50,000230
+BARBER,Sharon Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,130010
+BARBER,Sharon Township,State Treasurer,,Republican,"Estes, Ron",120,130010
+BARBER,Aetna Township,United States Senate,,independent,"Orman, Greg",0,000010
+BARBER,Aetna Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+BARBER,Aetna Township,United States Senate,,Republican,"Roberts, Pat",4,000010
+BARBER,Deerhead Township,United States Senate,,independent,"Orman, Greg",0,000020
+BARBER,Deerhead Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+BARBER,Deerhead Township,United States Senate,,Republican,"Roberts, Pat",5,000020
+BARBER,Eagle Township,United States Senate,,independent,"Orman, Greg",0,000030
+BARBER,Eagle Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+BARBER,Eagle Township,United States Senate,,Republican,"Roberts, Pat",14,000030
+BARBER,Elm Mills Township,United States Senate,,independent,"Orman, Greg",18,000040
+BARBER,Elm Mills Township,United States Senate,,Libertarian,"Batson, Randall",2,000040
+BARBER,Elm Mills Township,United States Senate,,Republican,"Roberts, Pat",39,000040
+BARBER,Elwood Township,United States Senate,,independent,"Orman, Greg",18,000050
+BARBER,Elwood Township,United States Senate,,Libertarian,"Batson, Randall",2,000050
+BARBER,Elwood Township,United States Senate,,Republican,"Roberts, Pat",40,000050
+BARBER,Hazelton Township,United States Senate,,independent,"Orman, Greg",22,000060
+BARBER,Hazelton Township,United States Senate,,Libertarian,"Batson, Randall",6,000060
+BARBER,Hazelton Township,United States Senate,,Republican,"Roberts, Pat",42,000060
+BARBER,Kiowa East Township,United States Senate,,independent,"Orman, Greg",51,000070
+BARBER,Kiowa East Township,United States Senate,,Libertarian,"Batson, Randall",10,000070
+BARBER,Kiowa East Township,United States Senate,,Republican,"Roberts, Pat",186,000070
+BARBER,Kiowa West Township,United States Senate,,independent,"Orman, Greg",51,000080
+BARBER,Kiowa West Township,United States Senate,,Libertarian,"Batson, Randall",9,000080
+BARBER,Kiowa West Township,United States Senate,,Republican,"Roberts, Pat",108,000080
+BARBER,Lake City Township,United States Senate,,independent,"Orman, Greg",7,000090
+BARBER,Lake City Township,United States Senate,,Libertarian,"Batson, Randall",1,000090
+BARBER,Lake City Township,United States Senate,,Republican,"Roberts, Pat",21,000090
+BARBER,McAdoo Township,United States Senate,,independent,"Orman, Greg",2,000100
+BARBER,McAdoo Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+BARBER,McAdoo Township,United States Senate,,Republican,"Roberts, Pat",7,000100
+BARBER,Medicine Lodge Precinct 1,United States Senate,,independent,"Orman, Greg",87,000110
+BARBER,Medicine Lodge Precinct 1,United States Senate,,Libertarian,"Batson, Randall",9,000110
+BARBER,Medicine Lodge Precinct 1,United States Senate,,Republican,"Roberts, Pat",171,000110
+BARBER,Medicine Lodge Precinct 2,United States Senate,,independent,"Orman, Greg",56,00012A
+BARBER,Medicine Lodge Precinct 2,United States Senate,,Libertarian,"Batson, Randall",7,00012A
+BARBER,Medicine Lodge Precinct 2,United States Senate,,Republican,"Roberts, Pat",140,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00012B
+BARBER,Medicine Lodge Precinct 3,United States Senate,,independent,"Orman, Greg",46,000130
+BARBER,Medicine Lodge Precinct 3,United States Senate,,Libertarian,"Batson, Randall",1,000130
+BARBER,Medicine Lodge Precinct 3,United States Senate,,Republican,"Roberts, Pat",90,000130
+BARBER,Medicine Lodge Precinct 4,United States Senate,,independent,"Orman, Greg",20,000140
+BARBER,Medicine Lodge Precinct 4,United States Senate,,Libertarian,"Batson, Randall",5,000140
+BARBER,Medicine Lodge Precinct 4,United States Senate,,Republican,"Roberts, Pat",90,000140
+BARBER,Medicine Lodge Precinct 5,United States Senate,,independent,"Orman, Greg",9,000150
+BARBER,Medicine Lodge Precinct 5,United States Senate,,Libertarian,"Batson, Randall",1,000150
+BARBER,Medicine Lodge Precinct 5,United States Senate,,Republican,"Roberts, Pat",16,000150
+BARBER,Mingona Township,United States Senate,,independent,"Orman, Greg",12,000160
+BARBER,Mingona Township,United States Senate,,Libertarian,"Batson, Randall",0,000160
+BARBER,Mingona Township,United States Senate,,Republican,"Roberts, Pat",22,000160
+BARBER,Moore Township,United States Senate,,independent,"Orman, Greg",5,000170
+BARBER,Moore Township,United States Senate,,Libertarian,"Batson, Randall",0,000170
+BARBER,Moore Township,United States Senate,,Republican,"Roberts, Pat",8,000170
+BARBER,Nippawalla Township,United States Senate,,independent,"Orman, Greg",1,000180
+BARBER,Nippawalla Township,United States Senate,,Libertarian,"Batson, Randall",0,000180
+BARBER,Nippawalla Township,United States Senate,,Republican,"Roberts, Pat",15,000180
+BARBER,Sun City Township,United States Senate,,independent,"Orman, Greg",1,000210
+BARBER,Sun City Township,United States Senate,,Libertarian,"Batson, Randall",1,000210
+BARBER,Sun City Township,United States Senate,,Republican,"Roberts, Pat",18,000210
+BARBER,Turkey Creek Township,United States Senate,,independent,"Orman, Greg",5,000220
+BARBER,Turkey Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000220
+BARBER,Turkey Creek Township,United States Senate,,Republican,"Roberts, Pat",4,000220
+BARBER,Valley Township,United States Senate,,independent,"Orman, Greg",9,000230
+BARBER,Valley Township,United States Senate,,Libertarian,"Batson, Randall",1,000230
+BARBER,Valley Township,United States Senate,,Republican,"Roberts, Pat",46,000230
+BARBER,Sharon Township,United States Senate,,independent,"Orman, Greg",27,130010
+BARBER,Sharon Township,United States Senate,,Libertarian,"Batson, Randall",8,130010
+BARBER,Sharon Township,United States Senate,,Republican,"Roberts, Pat",110,130010

--- a/2014/20141104__ks__general__barton__precinct.csv
+++ b/2014/20141104__ks__general__barton__precinct.csv
@@ -1,1072 +1,886 @@
-county,precinct,office,district,party,candidate,votes
-Barton,Great Bend City,Attorney General,,D,A.J. Kotich,846
-Barton,Great Bend City,Attorney General,,R,Derek Schmidt,3076
-Barton,Great Bend City,Attorney General,,,Write-ins,5
-Barton,Great Bend City,Commissioner of Insurance,,D,Dennis Anderson,1114
-Barton,Great Bend City,Commissioner of Insurance,,R,Ken Selzer,2738
-Barton,Great Bend City,Commissioner of Insurance,,,Write-ins,4
-Barton,Great Bend City,Governor,,D,Paul Davis,1519
-Barton,Great Bend City,Governor,,L,Keen Umbehr,180
-Barton,Great Bend City,Governor,,R,Sam Brownback,2293
-Barton,Great Bend City,Governor,,,Write-ins,4
-Barton,Great Bend City,Secretary of State,,D,Jean Kurtis Schodorf,1135
-Barton,Great Bend City,Secretary of State,,R,Kris Kobach,2822
-Barton,Great Bend City,Secretary of State,,,Write-ins,3
-Barton,Great Bend City,State House,112,D,Steve Muehleisen,1036
-Barton,Great Bend City,State House,112,R,John Edmonds,2926
-Barton,Great Bend City,State House,112,,Write-ins,10
-Barton,Great Bend City,State Treasurer,,D,Carmen Alldritt,806
-Barton,Great Bend City,State Treasurer,,R,Ron Estes,3110
-Barton,Great Bend City,State Treasurer,,,Write-ins,3
-Barton,Great Bend City,U.S. Senate,,I,Greg Orman,1283
-Barton,Great Bend City,U.S. Senate,,L,Randall Batson,180
-Barton,Great Bend City,U.S. Senate,,R,Pat Roberts,2520
-Barton,Great Bend City,U.S. Senate,,,Write-ins,11
-Barton,Great Bend City,U.S. House,1,D,James Sherow,1176
-Barton,Great Bend City,U.S. House,1,R,Tim Huelskamp,2770
-Barton,Great Bend City,U.S. House,1,,Write-ins,5
-Barton,GBC 1st Prec - 1st Ward,Attorney General,,D,A.J. Kotich,65
-Barton,GBC 2nd Prec - 1st Ward,Attorney General,,D,A.J. Kotich,86
-Barton,GBC 3rd Prec - 1st Ward,Attorney General,,D,A.J. Kotich,60
-Barton,GBC 1st Prec - 2nd Ward,Attorney General,,D,A.J. Kotich,88
-Barton,GBC 2nd Prec - 2nd Ward,Attorney General,,D,A.J. Kotich,100
-Barton,GBC 3rd Prec - 2nd Ward,Attorney General,,D,A.J. Kotich,101
-Barton,GBC 1st Prec - 3rd Ward,Attorney General,,D,A.J. Kotich,55
-Barton,GBC 2nd Prec - 3rd Ward,Attorney General,,D,A.J. Kotich,92
-Barton,GBC 3rd Prec - 3rd Ward,Attorney General,,D,A.J. Kotich,84
-Barton,GBC 1st Prec - 4th Ward,Attorney General,,D,A.J. Kotich,55
-Barton,GBC 2nd Prec - 4th Ward,Attorney General,,D,A.J. Kotich,44
-Barton,GBC 3rd Prec - 4th Ward,Attorney General,,D,A.J. Kotich,16
-Barton,GBC 1st Prec - 1st Ward,Attorney General,,R,Derek Schmidt,152
-Barton,GBC 2nd Prec - 1st Ward,Attorney General,,R,Derek Schmidt,285
-Barton,GBC 3rd Prec - 1st Ward,Attorney General,,R,Derek Schmidt,224
-Barton,GBC 1st Prec - 2nd Ward,Attorney General,,R,Derek Schmidt,390
-Barton,GBC 2nd Prec - 2nd Ward,Attorney General,,R,Derek Schmidt,381
-Barton,GBC 3rd Prec - 2nd Ward,Attorney General,,R,Derek Schmidt,479
-Barton,GBC 1st Prec - 3rd Ward,Attorney General,,R,Derek Schmidt,257
-Barton,GBC 2nd Prec - 3rd Ward,Attorney General,,R,Derek Schmidt,265
-Barton,GBC 3rd Prec - 3rd Ward,Attorney General,,R,Derek Schmidt,345
-Barton,GBC 1st Prec - 4th Ward,Attorney General,,R,Derek Schmidt,148
-Barton,GBC 2nd Prec - 4th Ward,Attorney General,,R,Derek Schmidt,108
-Barton,GBC 3rd Prec - 4th Ward,Attorney General,,R,Derek Schmidt,42
-Barton,GBC 1st Prec - 1st Ward,Attorney General,,,Write-ins,0
-Barton,GBC 2nd Prec - 1st Ward,Attorney General,,,Write-ins,1
-Barton,GBC 3rd Prec - 1st Ward,Attorney General,,,Write-ins,0
-Barton,GBC 1st Prec - 2nd Ward,Attorney General,,,Write-ins,0
-Barton,GBC 2nd Prec - 2nd Ward,Attorney General,,,Write-ins,0
-Barton,GBC 3rd Prec - 2nd Ward,Attorney General,,,Write-ins,1
-Barton,GBC 1st Prec - 3rd Ward,Attorney General,,,Write-ins,0
-Barton,GBC 2nd Prec - 3rd Ward,Attorney General,,,Write-ins,1
-Barton,GBC 3rd Prec - 3rd Ward,Attorney General,,,Write-ins,1
-Barton,GBC 1st Prec - 4th Ward,Attorney General,,,Write-ins,0
-Barton,GBC 2nd Prec - 4th Ward,Attorney General,,,Write-ins,1
-Barton,GBC 3rd Prec - 4th Ward,Attorney General,,,Write-ins,0
-Barton,GBC 1st Prec - 1st Ward,Insurance Commissioner,,,Dennis Anderson,87
-Barton,GBC 2nd Prec - 1st Ward,Insurance Commissioner,,,Dennis Anderson,117
-Barton,GBC 3rd Prec - 1st Ward,Insurance Commissioner,,,Dennis Anderson,64
-Barton,GBC 1st Prec - 2nd Ward,Insurance Commissioner,,,Dennis Anderson,124
-Barton,GBC 2nd Prec - 2nd Ward,Insurance Commissioner,,,Dennis Anderson,125
-Barton,GBC 3rd Prec - 2nd Ward,Insurance Commissioner,,,Dennis Anderson,140
-Barton,GBC 1st Prec - 3rd Ward,Insurance Commissioner,,,Dennis Anderson,73
-Barton,GBC 2nd Prec - 3rd Ward,Insurance Commissioner,,,Dennis Anderson,113
-Barton,GBC 3rd Prec - 3rd Ward,Insurance Commissioner,,,Dennis Anderson,123
-Barton,GBC 1st Prec - 4th Ward,Insurance Commissioner,,,Dennis Anderson,72
-Barton,GBC 2nd Prec - 4th Ward,Insurance Commissioner,,,Dennis Anderson,56
-Barton,GBC 3rd Prec - 4th Ward,Insurance Commissioner,,,Dennis Anderson,20
-Barton,GBC 1st Prec - 1st Ward,Insurance Commissioner,,,Ken Selzer,127
-Barton,GBC 2nd Prec - 1st Ward,Insurance Commissioner,,,Ken Selzer,253
-Barton,GBC 3rd Prec - 1st Ward,Insurance Commissioner,,,Ken Selzer,217
-Barton,GBC 1st Prec - 2nd Ward,Insurance Commissioner,,,Ken Selzer,341
-Barton,GBC 2nd Prec - 2nd Ward,Insurance Commissioner,,,Ken Selzer,349
-Barton,GBC 3rd Prec - 2nd Ward,Insurance Commissioner,,,Ken Selzer,429
-Barton,GBC 1st Prec - 3rd Ward,Insurance Commissioner,,,Ken Selzer,230
-Barton,GBC 2nd Prec - 3rd Ward,Insurance Commissioner,,,Ken Selzer,238
-Barton,GBC 3rd Prec - 3rd Ward,Insurance Commissioner,,,Ken Selzer,296
-Barton,GBC 1st Prec - 4th Ward,Insurance Commissioner,,,Ken Selzer,129
-Barton,GBC 2nd Prec - 4th Ward,Insurance Commissioner,,,Ken Selzer,93
-Barton,GBC 3rd Prec - 4th Ward,Insurance Commissioner,,,Ken Selzer,36
-Barton,GBC 1st Prec - 1st Ward,Insurance Commissioner,,,Write-ins,0
-Barton,GBC 2nd Prec - 1st Ward,Insurance Commissioner,,,Write-ins,0
-Barton,GBC 3rd Prec - 1st Ward,Insurance Commissioner,,,Write-ins,0
-Barton,GBC 1st Prec - 2nd Ward,Insurance Commissioner,,,Write-ins,0
-Barton,GBC 2nd Prec - 2nd Ward,Insurance Commissioner,,,Write-ins,0
-Barton,GBC 3rd Prec - 2nd Ward,Insurance Commissioner,,,Write-ins,1
-Barton,GBC 1st Prec - 3rd Ward,Insurance Commissioner,,,Write-ins,1
-Barton,GBC 2nd Prec - 3rd Ward,Insurance Commissioner,,,Write-ins,1
-Barton,GBC 3rd Prec - 3rd Ward,Insurance Commissioner,,,Write-ins,0
-Barton,GBC 1st Prec - 4th Ward,Insurance Commissioner,,,Write-ins,0
-Barton,GBC 2nd Prec - 4th Ward,Insurance Commissioner,,,Write-ins,1
-Barton,GBC 3rd Prec - 4th Ward,Insurance Commissioner,,,Write-ins,0
-Barton,GBC 1st Prec - 1st Ward,Governor,,,Keen Umbehr,12
-Barton,GBC 2nd Prec - 1st Ward,Governor,,,Keen Umbehr,14
-Barton,GBC 3rd Prec - 1st Ward,Governor,,,Keen Umbehr,20
-Barton,GBC 1st Prec - 2nd Ward,Governor,,,Keen Umbehr,18
-Barton,GBC 2nd Prec - 2nd Ward,Governor,,,Keen Umbehr,20
-Barton,GBC 3rd Prec - 2nd Ward,Governor,,,Keen Umbehr,12
-Barton,GBC 1st Prec - 3rd Ward,Governor,,,Keen Umbehr,6
-Barton,GBC 2nd Prec - 3rd Ward,Governor,,,Keen Umbehr,20
-Barton,GBC 3rd Prec - 3rd Ward,Governor,,,Keen Umbehr,19
-Barton,GBC 1st Prec - 4th Ward,Governor,,,Keen Umbehr,26
-Barton,GBC 2nd Prec - 4th Ward,Governor,,,Keen Umbehr,6
-Barton,GBC 3rd Prec - 4th Ward,Governor,,,Keen Umbehr,7
-Barton,GBC 1st Prec - 1st Ward,Governor,,,Paul Davis,107
-Barton,GBC 2nd Prec - 1st Ward,Governor,,,Paul Davis,159
-Barton,GBC 3rd Prec - 1st Ward,Governor,,,Paul Davis,102
-Barton,GBC 1st Prec - 2nd Ward,Governor,,,Paul Davis,186
-Barton,GBC 2nd Prec - 2nd Ward,Governor,,,Paul Davis,184
-Barton,GBC 3rd Prec - 2nd Ward,Governor,,,Paul Davis,187
-Barton,GBC 1st Prec - 3rd Ward,Governor,,,Paul Davis,119
-Barton,GBC 2nd Prec - 3rd Ward,Governor,,,Paul Davis,155
-Barton,GBC 3rd Prec - 3rd Ward,Governor,,,Paul Davis,162
-Barton,GBC 1st Prec - 4th Ward,Governor,,,Paul Davis,74
-Barton,GBC 2nd Prec - 4th Ward,Governor,,,Paul Davis,64
-Barton,GBC 3rd Prec - 4th Ward,Governor,,,Paul Davis,20
-Barton,GBC 1st Prec - 1st Ward,Governor,,,Sam Brownback,101
-Barton,GBC 2nd Prec - 1st Ward,Governor,,,Sam Brownback,205
-Barton,GBC 3rd Prec - 1st Ward,Governor,,,Sam Brownback,170
-Barton,GBC 1st Prec - 2nd Ward,Governor,,,Sam Brownback,282
-Barton,GBC 2nd Prec - 2nd Ward,Governor,,,Sam Brownback,281
-Barton,GBC 3rd Prec - 2nd Ward,Governor,,,Sam Brownback,397
-Barton,GBC 1st Prec - 3rd Ward,Governor,,,Sam Brownback,193
-Barton,GBC 2nd Prec - 3rd Ward,Governor,,,Sam Brownback,194
-Barton,GBC 3rd Prec - 3rd Ward,Governor,,,Sam Brownback,250
-Barton,GBC 1st Prec - 4th Ward,Governor,,,Sam Brownback,107
-Barton,GBC 2nd Prec - 4th Ward,Governor,,,Sam Brownback,81
-Barton,GBC 3rd Prec - 4th Ward,Governor,,,Sam Brownback,32
-Barton,GBC 1st Prec - 1st Ward,Governor,,,Write-ins,0
-Barton,GBC 2nd Prec - 1st Ward,Governor,,,Write-ins,1
-Barton,GBC 3rd Prec - 1st Ward,Governor,,,Write-ins,0
-Barton,GBC 1st Prec - 2nd Ward,Governor,,,Write-ins,0
-Barton,GBC 2nd Prec - 2nd Ward,Governor,,,Write-ins,0
-Barton,GBC 3rd Prec - 2nd Ward,Governor,,,Write-ins,0
-Barton,GBC 1st Prec - 3rd Ward,Governor,,,Write-ins,0
-Barton,GBC 2nd Prec - 3rd Ward,Governor,,,Write-ins,1
-Barton,GBC 3rd Prec - 3rd Ward,Governor,,,Write-ins,1
-Barton,GBC 1st Prec - 4th Ward,Governor,,,Write-ins,0
-Barton,GBC 2nd Prec - 4th Ward,Governor,,,Write-ins,1
-Barton,GBC 3rd Prec - 4th Ward,Governor,,,Write-ins,0
-Barton,GBC 1st Prec - 1st Ward,Secretary of State,,,Jean Kurtis Schodorf,82
-Barton,GBC 2nd Prec - 1st Ward,Secretary of State,,,Jean Kurtis Schodorf,115
-Barton,GBC 3rd Prec - 1st Ward,Secretary of State,,,Jean Kurtis Schodorf,72
-Barton,GBC 1st Prec - 2nd Ward,Secretary of State,,,Jean Kurtis Schodorf,130
-Barton,GBC 2nd Prec - 2nd Ward,Secretary of State,,,Jean Kurtis Schodorf,140
-Barton,GBC 3rd Prec - 2nd Ward,Secretary of State,,,Jean Kurtis Schodorf,144
-Barton,GBC 1st Prec - 3rd Ward,Secretary of State,,,Jean Kurtis Schodorf,84
-Barton,GBC 2nd Prec - 3rd Ward,Secretary of State,,,Jean Kurtis Schodorf,119
-Barton,GBC 3rd Prec - 3rd Ward,Secretary of State,,,Jean Kurtis Schodorf,110
-Barton,GBC 1st Prec - 4th Ward,Secretary of State,,,Jean Kurtis Schodorf,68
-Barton,GBC 2nd Prec - 4th Ward,Secretary of State,,,Jean Kurtis Schodorf,57
-Barton,GBC 3rd Prec - 4th Ward,Secretary of State,,,Jean Kurtis Schodorf,14
-Barton,GBC 1st Prec - 1st Ward,Secretary of State,,,Kris Kobach,138
-Barton,GBC 2nd Prec - 1st Ward,Secretary of State,,,Kris Kobach,263
-Barton,GBC 3rd Prec - 1st Ward,Secretary of State,,,Kris Kobach,217
-Barton,GBC 1st Prec - 2nd Ward,Secretary of State,,,Kris Kobach,349
-Barton,GBC 2nd Prec - 2nd Ward,Secretary of State,,,Kris Kobach,343
-Barton,GBC 3rd Prec - 2nd Ward,Secretary of State,,,Kris Kobach,444
-Barton,GBC 1st Prec - 3rd Ward,Secretary of State,,,Kris Kobach,230
-Barton,GBC 2nd Prec - 3rd Ward,Secretary of State,,,Kris Kobach,242
-Barton,GBC 3rd Prec - 3rd Ward,Secretary of State,,,Kris Kobach,321
-Barton,GBC 1st Prec - 4th Ward,Secretary of State,,,Kris Kobach,137
-Barton,GBC 2nd Prec - 4th Ward,Secretary of State,,,Kris Kobach,94
-Barton,GBC 3rd Prec - 4th Ward,Secretary of State,,,Kris Kobach,44
-Barton,GBC 1st Prec - 1st Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 2nd Prec - 1st Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 3rd Prec - 1st Ward,Secretary of State,,,Write-ins,1
-Barton,GBC 1st Prec - 2nd Ward,Secretary of State,,,Write-ins,1
-Barton,GBC 2nd Prec - 2nd Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 3rd Prec - 2nd Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 1st Prec - 3rd Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 2nd Prec - 3rd Ward,Secretary of State,,,Write-ins,1
-Barton,GBC 3rd Prec - 3rd Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 1st Prec - 4th Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 2nd Prec - 4th Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 3rd Prec - 4th Ward,Secretary of State,,,Write-ins,0
-Barton,GBC 1st Prec - 1st Ward,State House,H112,R,John Edmonds,137
-Barton,GBC 2nd Prec - 1st Ward,State House,H112,R,John Edmonds,271
-Barton,GBC 3rd Prec - 1st Ward,State House,H112,R,John Edmonds,200
-Barton,GBC 1st Prec - 2nd Ward,State House,H112,R,John Edmonds,353
-Barton,GBC 2nd Prec - 2nd Ward,State House,H112,R,John Edmonds,373
-Barton,GBC 3rd Prec - 2nd Ward,State House,H112,R,John Edmonds,473
-Barton,GBC 1st Prec - 3rd Ward,State House,H112,R,John Edmonds,240
-Barton,GBC 2nd Prec - 3rd Ward,State House,H112,R,John Edmonds,265
-Barton,GBC 3rd Prec - 3rd Ward,State House,H112,R,John Edmonds,329
-Barton,GBC 1st Prec - 4th Ward,State House,H112,R,John Edmonds,143
-Barton,GBC 2nd Prec - 4th Ward,State House,H112,R,John Edmonds,103
-Barton,GBC 3rd Prec - 4th Ward,State House,H112,R,John Edmonds,39
-Barton,GBC 1st Prec - 1st Ward,State House,H112,D,Steve Muehleisen,81
-Barton,GBC 2nd Prec - 1st Ward,State House,H112,D,Steve Muehleisen,108
-Barton,GBC 3rd Prec - 1st Ward,State House,H112,D,Steve Muehleisen,86
-Barton,GBC 1st Prec - 2nd Ward,State House,H112,D,Steve Muehleisen,125
-Barton,GBC 2nd Prec - 2nd Ward,State House,H112,D,Steve Muehleisen,113
-Barton,GBC 3rd Prec - 2nd Ward,State House,H112,D,Steve Muehleisen,119
-Barton,GBC 1st Prec - 3rd Ward,State House,H112,D,Steve Muehleisen,73
-Barton,GBC 2nd Prec - 3rd Ward,State House,H112,D,Steve Muehleisen,100
-Barton,GBC 3rd Prec - 3rd Ward,State House,H112,D,Steve Muehleisen,103
-Barton,GBC 1st Prec - 4th Ward,State House,H112,D,Steve Muehleisen,61
-Barton,GBC 2nd Prec - 4th Ward,State House,H112,D,Steve Muehleisen,49
-Barton,GBC 3rd Prec - 4th Ward,State House,H112,D,Steve Muehleisen,18
-Barton,GBC 1st Prec - 1st Ward,State House,H112,,Write-ins,1
-Barton,GBC 2nd Prec - 1st Ward,State House,H112,,Write-ins,0
-Barton,GBC 3rd Prec - 1st Ward,State House,H112,,Write-ins,1
-Barton,GBC 1st Prec - 2nd Ward,State House,H112,,Write-ins,1
-Barton,GBC 2nd Prec - 2nd Ward,State House,H112,,Write-ins,1
-Barton,GBC 3rd Prec - 2nd Ward,State House,H112,,Write-ins,0
-Barton,GBC 1st Prec - 3rd Ward,State House,H112,,Write-ins,1
-Barton,GBC 2nd Prec - 3rd Ward,State House,H112,,Write-ins,1
-Barton,GBC 3rd Prec - 3rd Ward,State House,H112,,Write-ins,1
-Barton,GBC 1st Prec - 4th Ward,State House,H112,,Write-ins,2
-Barton,GBC 2nd Prec - 4th Ward,State House,H112,,Write-ins,1
-Barton,GBC 3rd Prec - 4th Ward,State House,H112,,Write-ins,0
-Barton,GBC 1st Prec - 1st Ward,State Treasurer,,D,Carmen Alldritt,71
-Barton,GBC 2nd Prec - 1st Ward,State Treasurer,,D,Carmen Alldritt,80
-Barton,GBC 3rd Prec - 1st Ward,State Treasurer,,D,Carmen Alldritt,49
-Barton,GBC 1st Prec - 2nd Ward,State Treasurer,,D,Carmen Alldritt,96
-Barton,GBC 2nd Prec - 2nd Ward,State Treasurer,,D,Carmen Alldritt,88
-Barton,GBC 3rd Prec - 2nd Ward,State Treasurer,,D,Carmen Alldritt,94
-Barton,GBC 1st Prec - 3rd Ward,State Treasurer,,D,Carmen Alldritt,50
-Barton,GBC 2nd Prec - 3rd Ward,State Treasurer,,D,Carmen Alldritt,79
-Barton,GBC 3rd Prec - 3rd Ward,State Treasurer,,D,Carmen Alldritt,79
-Barton,GBC 1st Prec - 4th Ward,State Treasurer,,D,Carmen Alldritt,60
-Barton,GBC 2nd Prec - 4th Ward,State Treasurer,,D,Carmen Alldritt,44
-Barton,GBC 3rd Prec - 4th Ward,State Treasurer,,D,Carmen Alldritt,16
-Barton,GBC 1st Prec - 1st Ward,State Treasurer,,R,Ron Estes,144
-Barton,GBC 2nd Prec - 1st Ward,State Treasurer,,R,Ron Estes,289
-Barton,GBC 3rd Prec - 1st Ward,State Treasurer,,R,Ron Estes,235
-Barton,GBC 1st Prec - 2nd Ward,State Treasurer,,R,Ron Estes,379
-Barton,GBC 2nd Prec - 2nd Ward,State Treasurer,,R,Ron Estes,395
-Barton,GBC 3rd Prec - 2nd Ward,State Treasurer,,R,Ron Estes,488
-Barton,GBC 1st Prec - 3rd Ward,State Treasurer,,R,Ron Estes,263
-Barton,GBC 2nd Prec - 3rd Ward,State Treasurer,,R,Ron Estes,277
-Barton,GBC 3rd Prec - 3rd Ward,State Treasurer,,R,Ron Estes,347
-Barton,GBC 1st Prec - 4th Ward,State Treasurer,,R,Ron Estes,144
-Barton,GBC 2nd Prec - 4th Ward,State Treasurer,,R,Ron Estes,109
-Barton,GBC 3rd Prec - 4th Ward,State Treasurer,,R,Ron Estes,40
-Barton,GBC 1st Prec - 1st Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 2nd Prec - 1st Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 3rd Prec - 1st Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 1st Prec - 2nd Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 2nd Prec - 2nd Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 3rd Prec - 2nd Ward,State Treasurer,,,Write-ins,2
-Barton,GBC 1st Prec - 3rd Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 2nd Prec - 3rd Ward,State Treasurer,,,Write-ins,1
-Barton,GBC 3rd Prec - 3rd Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 1st Prec - 4th Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 2nd Prec - 4th Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 3rd Prec - 4th Ward,State Treasurer,,,Write-ins,0
-Barton,GBC 1st Prec - 1st Ward,U.S. Senate,,I,Greg Orman,97
-Barton,GBC 2nd Prec - 1st Ward,U.S. Senate,,I,Greg Orman,137
-Barton,GBC 3rd Prec - 1st Ward,U.S. Senate,,I,Greg Orman,90
-Barton,GBC 1st Prec - 2nd Ward,U.S. Senate,,I,Greg Orman,148
-Barton,GBC 2nd Prec - 2nd Ward,U.S. Senate,,I,Greg Orman,142
-Barton,GBC 3rd Prec - 2nd Ward,U.S. Senate,,I,Greg Orman,159
-Barton,GBC 1st Prec - 3rd Ward,U.S. Senate,,I,Greg Orman,92
-Barton,GBC 2nd Prec - 3rd Ward,U.S. Senate,,I,Greg Orman,133
-Barton,GBC 3rd Prec - 3rd Ward,U.S. Senate,,I,Greg Orman,142
-Barton,GBC 1st Prec - 4th Ward,U.S. Senate,,I,Greg Orman,71
-Barton,GBC 2nd Prec - 4th Ward,U.S. Senate,,I,Greg Orman,57
-Barton,GBC 3rd Prec - 4th Ward,U.S. Senate,,I,Greg Orman,15
-Barton,GBC 1st Prec - 1st Ward,U.S. Senate,,R,Pat Roberts,114
-Barton,GBC 2nd Prec - 1st Ward,U.S. Senate,,R,Pat Roberts,226
-Barton,GBC 3rd Prec - 1st Ward,U.S. Senate,,R,Pat Roberts,178
-Barton,GBC 1st Prec - 2nd Ward,U.S. Senate,,R,Pat Roberts,321
-Barton,GBC 2nd Prec - 2nd Ward,U.S. Senate,,R,Pat Roberts,323
-Barton,GBC 3rd Prec - 2nd Ward,U.S. Senate,,R,Pat Roberts,425
-Barton,GBC 1st Prec - 3rd Ward,U.S. Senate,,R,Pat Roberts,211
-Barton,GBC 2nd Prec - 3rd Ward,U.S. Senate,,R,Pat Roberts,211
-Barton,GBC 3rd Prec - 3rd Ward,U.S. Senate,,R,Pat Roberts,273
-Barton,GBC 1st Prec - 4th Ward,U.S. Senate,,R,Pat Roberts,114
-Barton,GBC 2nd Prec - 4th Ward,U.S. Senate,,R,Pat Roberts,87
-Barton,GBC 3rd Prec - 4th Ward,U.S. Senate,,R,Pat Roberts,37
-Barton,GBC 1st Prec - 1st Ward,U.S. Senate,,L,Randall Batson,11
-Barton,GBC 2nd Prec - 1st Ward,U.S. Senate,,L,Randall Batson,13
-Barton,GBC 3rd Prec - 1st Ward,U.S. Senate,,L,Randall Batson,22
-Barton,GBC 1st Prec - 2nd Ward,U.S. Senate,,L,Randall Batson,17
-Barton,GBC 2nd Prec - 2nd Ward,U.S. Senate,,L,Randall Batson,22
-Barton,GBC 3rd Prec - 2nd Ward,U.S. Senate,,L,Randall Batson,9
-Barton,GBC 1st Prec - 3rd Ward,U.S. Senate,,L,Randall Batson,12
-Barton,GBC 2nd Prec - 3rd Ward,U.S. Senate,,L,Randall Batson,21
-Barton,GBC 3rd Prec - 3rd Ward,U.S. Senate,,L,Randall Batson,17
-Barton,GBC 1st Prec - 4th Ward,U.S. Senate,,L,Randall Batson,21
-Barton,GBC 2nd Prec - 4th Ward,U.S. Senate,,L,Randall Batson,9
-Barton,GBC 3rd Prec - 4th Ward,U.S. Senate,,L,Randall Batson,6
-Barton,GBC 1st Prec - 1st Ward,U.S. Senate,,,Write-ins,0
-Barton,GBC 2nd Prec - 1st Ward,U.S. Senate,,,Write-ins,1
-Barton,GBC 3rd Prec - 1st Ward,U.S. Senate,,,Write-ins,0
-Barton,GBC 1st Prec - 2nd Ward,U.S. Senate,,,Write-ins,1
-Barton,GBC 2nd Prec - 2nd Ward,U.S. Senate,,,Write-ins,1
-Barton,GBC 3rd Prec - 2nd Ward,U.S. Senate,,,Write-ins,2
-Barton,GBC 1st Prec - 3rd Ward,U.S. Senate,,,Write-ins,2
-Barton,GBC 2nd Prec - 3rd Ward,U.S. Senate,,,Write-ins,1
-Barton,GBC 3rd Prec - 3rd Ward,U.S. Senate,,,Write-ins,1
-Barton,GBC 1st Prec - 4th Ward,U.S. Senate,,,Write-ins,1
-Barton,GBC 2nd Prec - 4th Ward,U.S. Senate,,,Write-ins,1
-Barton,GBC 3rd Prec - 4th Ward,U.S. Senate,,,Write-ins,0
-Barton,GBC 1st Prec - 1st Ward,U.S. House,1,D,James Sherow,86
-Barton,GBC 2nd Prec - 1st Ward,U.S. House,1,D,James Sherow,107
-Barton,GBC 3rd Prec - 1st Ward,U.S. House,1,D,James Sherow,79
-Barton,GBC 1st Prec - 2nd Ward,U.S. House,1,D,James Sherow,144
-Barton,GBC 2nd Prec - 2nd Ward,U.S. House,1,D,James Sherow,148
-Barton,GBC 3rd Prec - 2nd Ward,U.S. House,1,D,James Sherow,163
-Barton,GBC 1st Prec - 3rd Ward,U.S. House,1,D,James Sherow,80
-Barton,GBC 2nd Prec - 3rd Ward,U.S. House,1,D,James Sherow,117
-Barton,GBC 3rd Prec - 3rd Ward,U.S. House,1,D,James Sherow,113
-Barton,GBC 1st Prec - 4th Ward,U.S. House,1,D,James Sherow,71
-Barton,GBC 2nd Prec - 4th Ward,U.S. House,1,D,James Sherow,53
-Barton,GBC 3rd Prec - 4th Ward,U.S. House,1,D,James Sherow,15
-Barton,GBC 1st Prec - 1st Ward,U.S. House,1,R,Tim Huelskamp,132
-Barton,GBC 2nd Prec - 1st Ward,U.S. House,1,R,Tim Huelskamp,269
-Barton,GBC 3rd Prec - 1st Ward,U.S. House,1,R,Tim Huelskamp,209
-Barton,GBC 1st Prec - 2nd Ward,U.S. House,1,R,Tim Huelskamp,336
-Barton,GBC 2nd Prec - 2nd Ward,U.S. House,1,R,Tim Huelskamp,336
-Barton,GBC 3rd Prec - 2nd Ward,U.S. House,1,R,Tim Huelskamp,423
-Barton,GBC 1st Prec - 3rd Ward,U.S. House,1,R,Tim Huelskamp,232
-Barton,GBC 2nd Prec - 3rd Ward,U.S. House,1,R,Tim Huelskamp,244
-Barton,GBC 3rd Prec - 3rd Ward,U.S. House,1,R,Tim Huelskamp,314
-Barton,GBC 1st Prec - 4th Ward,U.S. House,1,R,Tim Huelskamp,135
-Barton,GBC 2nd Prec - 4th Ward,U.S. House,1,R,Tim Huelskamp,97
-Barton,GBC 3rd Prec - 4th Ward,U.S. House,1,R,Tim Huelskamp,43
-Barton,GBC 1st Prec - 1st Ward,U.S. House,1,,Write-ins,0
-Barton,GBC 2nd Prec - 1st Ward,U.S. House,1,,Write-ins,0
-Barton,GBC 3rd Prec - 1st Ward,U.S. House,1,,Write-ins,0
-Barton,GBC 1st Prec - 2nd Ward,U.S. House,1,,Write-ins,1
-Barton,GBC 2nd Prec - 2nd Ward,U.S. House,1,,Write-ins,0
-Barton,GBC 3rd Prec - 2nd Ward,U.S. House,1,,Write-ins,1
-Barton,GBC 1st Prec - 3rd Ward,U.S. House,1,,Write-ins,0
-Barton,GBC 2nd Prec - 3rd Ward,U.S. House,1,,Write-ins,1
-Barton,GBC 3rd Prec - 3rd Ward,U.S. House,1,,Write-ins,1
-Barton,GBC 1st Prec - 4th Ward,U.S. House,1,,Write-ins,0
-Barton,GBC 2nd Prec - 4th Ward,U.S. House,1,,Write-ins,1
-Barton,GBC 3rd Prec - 4th Ward,U.S. House,1,,Write-ins,0
-Barton,Barton rural,Attorney General,,D,A.J. Kotich,1557
-Barton,Barton rural,Attorney General,,R,Derek Schmidt,6343
-Barton,Barton rural,Attorney General,,,Write-ins,9
-Barton,Barton rural,Commissioner of Insurance,,D,Dennis Anderson,2053
-Barton,Barton rural,Commissioner of Insurance,,R,Ken Selzer,5705
-Barton,Barton rural,Commissioner of Insurance,,,Write-ins,7
-Barton,Barton rural,Governor,,L,Keen Umbehr,334
-Barton,Barton rural,Governor,,D,Paul Davis,2769
-Barton,Barton rural,Governor,,R,Sam Brownback,4973
-Barton,Barton rural,Governor,,,Write-ins,7
-Barton,Barton rural,Secretary of State,,D,Jean Kurtis Schodorf,2071
-Barton,Barton rural,Secretary of State,,R,Kris Kobach,5940
-Barton,Barton rural,Secretary of State,,,Write-ins,4
-Barton,Barton rural,State House,109,R,Troy Waymaster,740
-Barton,Barton rural,State House,109,,Write-ins,2
-Barton,Barton rural,State House,112,R,John Edmonds,4559
-Barton,Barton rural,State House,112,D,Steve Muehleisen,1480
-Barton,Barton rural,State House,112,,Write-ins,15
-Barton,Barton rural,State House,113,R,Jeremy 'Basil' Dannebohm,1004
-Barton,Barton rural,State House,113,,Write-ins,16
-Barton,Barton rural,State Treasurer,,D,Carmen Alldritt,1475
-Barton,Barton rural,State Treasurer,,R,Ron Estes,6436
-Barton,Barton rural,State Treasurer,,,Write-ins,6
-Barton,Barton rural,U.S. Senate,,I,Greg Orman,2313
-Barton,Barton rural,U.S. Senate,,R,Pat Roberts,5403
-Barton,Barton rural,U.S. Senate,,L,Randall Batson,354
-Barton,Barton rural,U.S. Senate,,,Write-ins,17
-Barton,Barton rural,U.S. House,1,D,James Sherow,2170
-Barton,Barton rural,U.S. House,1,R,Tim Huelskamp,5814
-Barton,Barton rural,U.S. House,1,,Write-ins,8
-Barton,Hoisington City 1st Ward,Attorney General,,D,A.J. Kotich,49
-Barton,Hoisington City 3rd Ward,Attorney General,,D,A.J. Kotich,32
-Barton,Hoisington City 2nd Ward,Attorney General,,D,A.J. Kotich,37
-Barton,Hoisington City 4th Ward,Attorney General,,D,A.J. Kotich,32
-Barton,Hoisington City 1st Ward,Attorney General,,R,Derek Schmidt,152
-Barton,Hoisington City 3rd Ward,Attorney General,,R,Derek Schmidt,166
-Barton,Hoisington City 2nd Ward,Attorney General,,R,Derek Schmidt,182
-Barton,Hoisington City 4th Ward,Attorney General,,R,Derek Schmidt,129
-Barton,Hoisington City 1st Ward,Attorney General,,,Write-ins,0
-Barton,Hoisington City 3rd Ward,Attorney General,,,Write-ins,0
-Barton,Hoisington City 2nd Ward,Attorney General,,,Write-ins,0
-Barton,Hoisington City 4th Ward,Attorney General,,,Write-ins,1
-Barton,Hoisington City 1st Ward,Insurance Commissioner,,D,Dennis Anderson,73
-Barton,Hoisington City 3rd Ward,Insurance Commissioner,,D,Dennis Anderson,47
-Barton,Hoisington City 2nd Ward,Insurance Commissioner,,D,Dennis Anderson,62
-Barton,Hoisington City 4th Ward,Insurance Commissioner,,D,Dennis Anderson,48
-Barton,Hoisington City 1st Ward,Insurance Commissioner,,R,Ken Selzer,124
-Barton,Hoisington City 3rd Ward,Insurance Commissioner,,R,Ken Selzer,152
-Barton,Hoisington City 2nd Ward,Insurance Commissioner,,R,Ken Selzer,149
-Barton,Hoisington City 4th Ward,Insurance Commissioner,,R,Ken Selzer,113
-Barton,Hoisington City 1st Ward,Insurance Commissioner,,,Write-ins,0
-Barton,Hoisington City 3rd Ward,Insurance Commissioner,,,Write-ins,0
-Barton,Hoisington City 2nd Ward,Insurance Commissioner,,,Write-ins,0
-Barton,Hoisington City 4th Ward,Insurance Commissioner,,,Write-ins,0
-Barton,Hoisington City 1st Ward,Governor,,L,Keen Umbehr,8
-Barton,Hoisington City 3rd Ward,Governor,,L,Keen Umbehr,9
-Barton,Hoisington City 2nd Ward,Governor,,L,Keen Umbehr,9
-Barton,Hoisington City 4th Ward,Governor,,L,Keen Umbehr,6
-Barton,Hoisington City 1st Ward,Governor,,D,Paul Davis,85
-Barton,Hoisington City 3rd Ward,Governor,,D,Paul Davis,64
-Barton,Hoisington City 2nd Ward,Governor,,D,Paul Davis,83
-Barton,Hoisington City 4th Ward,Governor,,D,Paul Davis,66
-Barton,Hoisington City 1st Ward,Governor,,R,Sam Brownback,113
-Barton,Hoisington City 3rd Ward,Governor,,R,Sam Brownback,128
-Barton,Hoisington City 2nd Ward,Governor,,R,Sam Brownback,133
-Barton,Hoisington City 4th Ward,Governor,,R,Sam Brownback,98
-Barton,Hoisington City 1st Ward,Governor,,,Write-ins,0
-Barton,Hoisington City 3rd Ward,Governor,,,Write-ins,0
-Barton,Hoisington City 2nd Ward,Governor,,,Write-ins,0
-Barton,Hoisington City 4th Ward,Governor,,,Write-ins,0
-Barton,Hoisington City 1st Ward,Secretary of State,,D,Jean Kurtis Schodorf,62
-Barton,Hoisington City 3rd Ward,Secretary of State,,D,Jean Kurtis Schodorf,45
-Barton,Hoisington City 2nd Ward,Secretary of State,,D,Jean Kurtis Schodorf,55
-Barton,Hoisington City 4th Ward,Secretary of State,,D,Jean Kurtis Schodorf,46
-Barton,Hoisington City 1st Ward,Secretary of State,,R,Kris Kobach,142
-Barton,Hoisington City 3rd Ward,Secretary of State,,R,Kris Kobach,154
-Barton,Hoisington City 2nd Ward,Secretary of State,,R,Kris Kobach,167
-Barton,Hoisington City 4th Ward,Secretary of State,,R,Kris Kobach,120
-Barton,Hoisington City 1st Ward,Secretary of State,,,Write-ins,0
-Barton,Hoisington City 3rd Ward,Secretary of State,,,Write-ins,0
-Barton,Hoisington City 2nd Ward,Secretary of State,,,Write-ins,0
-Barton,Hoisington City 4th Ward,Secretary of State,,,Write-ins,0
-Barton,Hoisington City 1st Ward,State House,112,R,John Edmonds,151
-Barton,Hoisington City 3rd Ward,State House,112,R,John Edmonds,162
-Barton,Hoisington City 2nd Ward,State House,112,R,John Edmonds,176
-Barton,Hoisington City 4th Ward,State House,112,R,John Edmonds,126
-Barton,Hoisington City 1st Ward,State House,112,D,Steve Muehleisen,51
-Barton,Hoisington City 3rd Ward,State House,112,D,Steve Muehleisen,37
-Barton,Hoisington City 2nd Ward,State House,112,D,Steve Muehleisen,43
-Barton,Hoisington City 4th Ward,State House,112,D,Steve Muehleisen,39
-Barton,Hoisington City 1st Ward,State House,112,,Write-ins,0
-Barton,Hoisington City 3rd Ward,State House,112,,Write-ins,1
-Barton,Hoisington City 2nd Ward,State House,112,,Write-ins,1
-Barton,Hoisington City 4th Ward,State House,112,,Write-ins,0
-Barton,Hoisington City 1st Ward,State Treasurer,,D,Carmen Alldritt,55
-Barton,Hoisington City 3rd Ward,State Treasurer,,D,Carmen Alldritt,32
-Barton,Hoisington City 2nd Ward,State Treasurer,,D,Carmen Alldritt,39
-Barton,Hoisington City 4th Ward,State Treasurer,,D,Carmen Alldritt,30
-Barton,Hoisington City 1st Ward,State Treasurer,,R,Ron Estes,147
-Barton,Hoisington City 3rd Ward,State Treasurer,,R,Ron Estes,164
-Barton,Hoisington City 2nd Ward,State Treasurer,,R,Ron Estes,183
-Barton,Hoisington City 4th Ward,State Treasurer,,R,Ron Estes,133
-Barton,Hoisington City 1st Ward,State Treasurer,,,Write-ins,0
-Barton,Hoisington City 3rd Ward,State Treasurer,,,Write-ins,0
-Barton,Hoisington City 2nd Ward,State Treasurer,,,Write-ins,0
-Barton,Hoisington City 4th Ward,State Treasurer,,,Write-ins,0
-Barton,Hoisington City 1st Ward,U.S. Senate,,I,Greg Orman,67
-Barton,Hoisington City 3rd Ward,U.S. Senate,,I,Greg Orman,60
-Barton,Hoisington City 2nd Ward,U.S. Senate,,I,Greg Orman,62
-Barton,Hoisington City 4th Ward,U.S. Senate,,I,Greg Orman,49
-Barton,Hoisington City 1st Ward,U.S. Senate,,R,Pat Roberts,122
-Barton,Hoisington City 3rd Ward,U.S. Senate,,R,Pat Roberts,132
-Barton,Hoisington City 2nd Ward,U.S. Senate,,R,Pat Roberts,154
-Barton,Hoisington City 4th Ward,U.S. Senate,,R,Pat Roberts,112
-Barton,Hoisington City 1st Ward,U.S. Senate,,L,Randall Batson,16
-Barton,Hoisington City 3rd Ward,U.S. Senate,,L,Randall Batson,10
-Barton,Hoisington City 2nd Ward,U.S. Senate,,L,Randall Batson,7
-Barton,Hoisington City 4th Ward,U.S. Senate,,L,Randall Batson,8
-Barton,Hoisington City 1st Ward,U.S. Senate,,,Write-ins,0
-Barton,Hoisington City 3rd Ward,U.S. Senate,,,Write-ins,0
-Barton,Hoisington City 2nd Ward,U.S. Senate,,,Write-ins,0
-Barton,Hoisington City 4th Ward,U.S. Senate,,,Write-ins,1
-Barton,Hoisington City 1st Ward,U.S. House,1,D,James Sherow,66
-Barton,Hoisington City 3rd Ward,U.S. House,1,D,James Sherow,55
-Barton,Hoisington City 2nd Ward,U.S. House,1,D,James Sherow,56
-Barton,Hoisington City 4th Ward,U.S. House,1,D,James Sherow,43
-Barton,Hoisington City 1st Ward,U.S. House,1,R,Tim Huelskamp,137
-Barton,Hoisington City 3rd Ward,U.S. House,1,R,Tim Huelskamp,146
-Barton,Hoisington City 2nd Ward,U.S. House,1,R,Tim Huelskamp,167
-Barton,Hoisington City 4th Ward,U.S. House,1,R,Tim Huelskamp,120
-Barton,Hoisington City 1st Ward,U.S. House,1,,Write-ins,0
-Barton,Hoisington City 3rd Ward,U.S. House,1,,Write-ins,0
-Barton,Hoisington City 2nd Ward,U.S. House,1,,Write-ins,0
-Barton,Hoisington City 4th Ward,U.S. House,1,,Write-ins,1
-Barton,Albion Township ,Attorney General,,D,A.J. Kotich,2
-Barton,Beaver Township            ,Attorney General,,D,A.J. Kotich,7
-Barton,Buffalo Township                    ,Attorney General,,D,A.J. Kotich,36
-Barton,Cheyenne Township                   ,Attorney General,,D,A.J. Kotich,13
-Barton,Clarence Township,Attorney General,,D,A.J. Kotich,11
-Barton,Cleveland Township,Attorney General,,D,A.J. Kotich,1
-Barton,Comanche Township,Attorney General,,D,A.J. Kotich,25
-Barton,Eureka Township,Attorney General,,D,A.J. Kotich,5
-Barton,Fairview Township,Attorney General,,D,A.J. Kotich,6
-Barton,Grant Township,Attorney General,,D,A.J. Kotich,8
-Barton,Great Bend Twp-A,Attorney General,,D,A.J. Kotich,68
-Barton,Great Bend Twp-B,Attorney General,,D,A.J. Kotich,12
-Barton,Independent Township,Attorney General,,D,A.J. Kotich,46
-Barton,Lakin Township,Attorney General,,D,A.J. Kotich,145
-Barton,Liberty Township,Attorney General,,D,A.J. Kotich,11
-Barton,Logan Township,Attorney General,,D,A.J. Kotich,9
-Barton,North Homestead Township,Attorney General,,D,A.J. Kotich,10
-Barton,Pawnee Rock Township,Attorney General,,D,A.J. Kotich,27
-Barton,South Bend Township,Attorney General,,D,A.J. Kotich,46
-Barton,South Homestead Township,Attorney General,,D,A.J. Kotich,21
-Barton,Union Township,Attorney General,,D,A.J. Kotich,13
-Barton,Walnut-Albert Township,Attorney General,,D,A.J. Kotich,17
-Barton,Walnut-Olmitz Township,Attorney General,,D,A.J. Kotich,19
-Barton,Wheatland Township,Attorney General,,D,A.J. Kotich,3
-Barton,Albion Township ,Attorney General,,R,Derek Schmidt,18
-Barton,Beaver Township            ,Attorney General,,R,Derek Schmidt,31
-Barton,Buffalo Township                    ,Attorney General,,R,Derek Schmidt,137
-Barton,Cheyenne Township                   ,Attorney General,,R,Derek Schmidt,79
-Barton,Clarence Township,Attorney General,,R,Derek Schmidt,43
-Barton,Cleveland Township,Attorney General,,R,Derek Schmidt,17
-Barton,Comanche Township,Attorney General,,R,Derek Schmidt,140
-Barton,Eureka Township,Attorney General,,R,Derek Schmidt,32
-Barton,Fairview Township,Attorney General,,R,Derek Schmidt,30
-Barton,Grant Township,Attorney General,,R,Derek Schmidt,18
-Barton,Great Bend Twp-A,Attorney General,,R,Derek Schmidt,400
-Barton,Great Bend Twp-B,Attorney General,,R,Derek Schmidt,67
-Barton,Independent Township,Attorney General,,R,Derek Schmidt,224
-Barton,Lakin Township,Attorney General,,R,Derek Schmidt,669
-Barton,Liberty Township,Attorney General,,R,Derek Schmidt,89
-Barton,Logan Township,Attorney General,,R,Derek Schmidt,59
-Barton,North Homestead Township,Attorney General,,R,Derek Schmidt,38
-Barton,Pawnee Rock Township,Attorney General,,R,Derek Schmidt,106
-Barton,South Bend Township,Attorney General,,R,Derek Schmidt,180
-Barton,South Homestead Township,Attorney General,,R,Derek Schmidt,110
-Barton,Union Township,Attorney General,,R,Derek Schmidt,30
-Barton,Walnut-Albert Township,Attorney General,,R,Derek Schmidt,57
-Barton,Walnut-Olmitz Township,Attorney General,,R,Derek Schmidt,41
-Barton,Wheatland Township,Attorney General,,R,Derek Schmidt,23
-Barton,Albion Township ,Attorney General,,,Write-ins,0
-Barton,Beaver Township            ,Attorney General,,,Write-ins,0
-Barton,Buffalo Township                    ,Attorney General,,,Write-ins,0
-Barton,Cheyenne Township                   ,Attorney General,,,Write-ins,0
-Barton,Clarence Township,Attorney General,,,Write-ins,0
-Barton,Cleveland Township,Attorney General,,,Write-ins,0
-Barton,Comanche Township,Attorney General,,,Write-ins,0
-Barton,Eureka Township,Attorney General,,,Write-ins,1
-Barton,Fairview Township,Attorney General,,,Write-ins,0
-Barton,Grant Township,Attorney General,,,Write-ins,0
-Barton,Great Bend Twp-A,Attorney General,,,Write-ins,0
-Barton,Great Bend Twp-B,Attorney General,,,Write-ins,0
-Barton,Independent Township,Attorney General,,,Write-ins,0
-Barton,Lakin Township,Attorney General,,,Write-ins,1
-Barton,Liberty Township,Attorney General,,,Write-ins,0
-Barton,Logan Township,Attorney General,,,Write-ins,0
-Barton,North Homestead Township,Attorney General,,,Write-ins,0
-Barton,Pawnee Rock Township,Attorney General,,,Write-ins,0
-Barton,South Bend Township,Attorney General,,,Write-ins,1
-Barton,South Homestead Township,Attorney General,,,Write-ins,0
-Barton,Union Township,Attorney General,,,Write-ins,0
-Barton,Walnut-Albert Township,Attorney General,,,Write-ins,0
-Barton,Walnut-Olmitz Township,Attorney General,,,Write-ins,0
-Barton,Wheatland Township,Attorney General,,,Write-ins,0
-Barton,Albion Township ,Insurance Commissioner,,D,Dennis Anderson,2
-Barton,Beaver Township            ,Insurance Commissioner,,D,Dennis Anderson,11
-Barton,Buffalo Township                    ,Insurance Commissioner,,D,Dennis Anderson,42
-Barton,Cheyenne Township                   ,Insurance Commissioner,,D,Dennis Anderson,16
-Barton,Clarence Township,Insurance Commissioner,,D,Dennis Anderson,14
-Barton,Cleveland Township,Insurance Commissioner,,D,Dennis Anderson,1
-Barton,Comanche Township,Insurance Commissioner,,D,Dennis Anderson,28
-Barton,Eureka Township,Insurance Commissioner,,D,Dennis Anderson,7
-Barton,Fairview Township,Insurance Commissioner,,D,Dennis Anderson,7
-Barton,Grant Township,Insurance Commissioner,,D,Dennis Anderson,7
-Barton,Great Bend Twp-A,Insurance Commissioner,,D,Dennis Anderson,96
-Barton,Great Bend Twp-B,Insurance Commissioner,,D,Dennis Anderson,18
-Barton,Independent Township,Insurance Commissioner,,D,Dennis Anderson,61
-Barton,Lakin Township,Insurance Commissioner,,D,Dennis Anderson,184
-Barton,Liberty Township,Insurance Commissioner,,D,Dennis Anderson,16
-Barton,Logan Township,Insurance Commissioner,,D,Dennis Anderson,10
-Barton,North Homestead Township,Insurance Commissioner,,D,Dennis Anderson,12
-Barton,Pawnee Rock Township,Insurance Commissioner,,D,Dennis Anderson,32
-Barton,South Bend Township,Insurance Commissioner,,D,Dennis Anderson,54
-Barton,South Homestead Township,Insurance Commissioner,,D,Dennis Anderson,25
-Barton,Union Township,Insurance Commissioner,,D,Dennis Anderson,13
-Barton,Walnut-Albert Township,Insurance Commissioner,,D,Dennis Anderson,26
-Barton,Walnut-Olmitz Township,Insurance Commissioner,,D,Dennis Anderson,27
-Barton,Wheatland Township,Insurance Commissioner,,D,Dennis Anderson,0
-Barton,Albion Township ,Insurance Commissioner,,R,Ken Selzer,18
-Barton,Beaver Township            ,Insurance Commissioner,,R,Ken Selzer,25
-Barton,Buffalo Township                    ,Insurance Commissioner,,R,Ken Selzer,130
-Barton,Cheyenne Township                   ,Insurance Commissioner,,R,Ken Selzer,75
-Barton,Clarence Township,Insurance Commissioner,,R,Ken Selzer,41
-Barton,Cleveland Township,Insurance Commissioner,,R,Ken Selzer,17
-Barton,Comanche Township,Insurance Commissioner,,R,Ken Selzer,130
-Barton,Eureka Township,Insurance Commissioner,,R,Ken Selzer,29
-Barton,Fairview Township,Insurance Commissioner,,R,Ken Selzer,27
-Barton,Grant Township,Insurance Commissioner,,R,Ken Selzer,18
-Barton,Great Bend Twp-A,Insurance Commissioner,,R,Ken Selzer,368
-Barton,Great Bend Twp-B,Insurance Commissioner,,R,Ken Selzer,62
-Barton,Independent Township,Insurance Commissioner,,R,Ken Selzer,198
-Barton,Lakin Township,Insurance Commissioner,,R,Ken Selzer,608
-Barton,Liberty Township,Insurance Commissioner,,R,Ken Selzer,83
-Barton,Logan Township,Insurance Commissioner,,R,Ken Selzer,57
-Barton,North Homestead Township,Insurance Commissioner,,R,Ken Selzer,35
-Barton,Pawnee Rock Township,Insurance Commissioner,,R,Ken Selzer,98
-Barton,South Bend Township,Insurance Commissioner,,R,Ken Selzer,172
-Barton,South Homestead Township,Insurance Commissioner,,R,Ken Selzer,103
-Barton,Union Township,Insurance Commissioner,,R,Ken Selzer,30
-Barton,Walnut-Albert Township,Insurance Commissioner,,R,Ken Selzer,45
-Barton,Walnut-Olmitz Township,Insurance Commissioner,,R,Ken Selzer,35
-Barton,Wheatland Township,Insurance Commissioner,,R,Ken Selzer,25
-Barton,Albion Township ,Insurance Commissioner,,,Write-ins,0
-Barton,Beaver Township            ,Insurance Commissioner,,,Write-ins,0
-Barton,Buffalo Township                    ,Insurance Commissioner,,,Write-ins,0
-Barton,Cheyenne Township                   ,Insurance Commissioner,,,Write-ins,0
-Barton,Clarence Township,Insurance Commissioner,,,Write-ins,0
-Barton,Cleveland Township,Insurance Commissioner,,,Write-ins,0
-Barton,Comanche Township,Insurance Commissioner,,,Write-ins,0
-Barton,Eureka Township,Insurance Commissioner,,,Write-ins,1
-Barton,Fairview Township,Insurance Commissioner,,,Write-ins,0
-Barton,Grant Township,Insurance Commissioner,,,Write-ins,0
-Barton,Great Bend Twp-A,Insurance Commissioner,,,Write-ins,0
-Barton,Great Bend Twp-B,Insurance Commissioner,,,Write-ins,0
-Barton,Independent Township,Insurance Commissioner,,,Write-ins,0
-Barton,Lakin Township,Insurance Commissioner,,,Write-ins,1
-Barton,Liberty Township,Insurance Commissioner,,,Write-ins,0
-Barton,Logan Township,Insurance Commissioner,,,Write-ins,0
-Barton,North Homestead Township,Insurance Commissioner,,,Write-ins,0
-Barton,Pawnee Rock Township,Insurance Commissioner,,,Write-ins,0
-Barton,South Bend Township,Insurance Commissioner,,,Write-ins,1
-Barton,South Homestead Township,Insurance Commissioner,,,Write-ins,0
-Barton,Union Township,Insurance Commissioner,,,Write-ins,0
-Barton,Walnut-Albert Township,Insurance Commissioner,,,Write-ins,0
-Barton,Walnut-Olmitz Township,Insurance Commissioner,,,Write-ins,0
-Barton,Wheatland Township,Insurance Commissioner,,,Write-ins,0
-Barton,Albion Township ,Governor,,L,Keen Umbehr,0
-Barton,Beaver Township            ,Governor,,L,Keen Umbehr,1
-Barton,Buffalo Township                    ,Governor,,L,Keen Umbehr,2
-Barton,Cheyenne Township                   ,Governor,,L,Keen Umbehr,4
-Barton,Clarence Township,Governor,,L,Keen Umbehr,1
-Barton,Cleveland Township,Governor,,L,Keen Umbehr,0
-Barton,Comanche Township,Governor,,L,Keen Umbehr,5
-Barton,Eureka Township,Governor,,L,Keen Umbehr,0
-Barton,Fairview Township,Governor,,L,Keen Umbehr,4
-Barton,Grant Township,Governor,,L,Keen Umbehr,0
-Barton,Great Bend Twp-A,Governor,,L,Keen Umbehr,14
-Barton,Great Bend Twp-B,Governor,,L,Keen Umbehr,6
-Barton,Independent Township,Governor,,L,Keen Umbehr,17
-Barton,Lakin Township,Governor,,L,Keen Umbehr,30
-Barton,Liberty Township,Governor,,L,Keen Umbehr,2
-Barton,Logan Township,Governor,,L,Keen Umbehr,2
-Barton,North Homestead Township,Governor,,L,Keen Umbehr,1
-Barton,Pawnee Rock Township,Governor,,L,Keen Umbehr,6
-Barton,South Bend Township,Governor,,L,Keen Umbehr,15
-Barton,South Homestead Township,Governor,,L,Keen Umbehr,6
-Barton,Union Township,Governor,,L,Keen Umbehr,5
-Barton,Walnut-Albert Township,Governor,,L,Keen Umbehr,1
-Barton,Walnut-Olmitz Township,Governor,,L,Keen Umbehr,0
-Barton,Wheatland Township,Governor,,L,Keen Umbehr,0
-Barton,Albion Township ,Governor,,D,Paul Davis,1
-Barton,Beaver Township            ,Governor,,D,Paul Davis,9
-Barton,Buffalo Township                    ,Governor,,D,Paul Davis,54
-Barton,Cheyenne Township                   ,Governor,,D,Paul Davis,18
-Barton,Clarence Township,Governor,,D,Paul Davis,15
-Barton,Cleveland Township,Governor,,D,Paul Davis,5
-Barton,Comanche Township,Governor,,D,Paul Davis,47
-Barton,Eureka Township,Governor,,D,Paul Davis,10
-Barton,Fairview Township,Governor,,D,Paul Davis,6
-Barton,Grant Township,Governor,,D,Paul Davis,13
-Barton,Great Bend Twp-A,Governor,,D,Paul Davis,144
-Barton,Great Bend Twp-B,Governor,,D,Paul Davis,17
-Barton,Independent Township,Governor,,D,Paul Davis,73
-Barton,Lakin Township,Governor,,D,Paul Davis,262
-Barton,Liberty Township,Governor,,D,Paul Davis,32
-Barton,Logan Township,Governor,,D,Paul Davis,18
-Barton,North Homestead Township,Governor,,D,Paul Davis,19
-Barton,Pawnee Rock Township,Governor,,D,Paul Davis,41
-Barton,South Bend Township,Governor,,D,Paul Davis,62
-Barton,South Homestead Township,Governor,,D,Paul Davis,34
-Barton,Union Township,Governor,,D,Paul Davis,13
-Barton,Walnut-Albert Township,Governor,,D,Paul Davis,31
-Barton,Walnut-Olmitz Township,Governor,,D,Paul Davis,26
-Barton,Wheatland Township,Governor,,D,Paul Davis,2
-Barton,Albion Township ,Governor,,R,Sam Brownback,19
-Barton,Beaver Township            ,Governor,,R,Sam Brownback,29
-Barton,Buffalo Township                    ,Governor,,R,Sam Brownback,121
-Barton,Cheyenne Township                   ,Governor,,R,Sam Brownback,72
-Barton,Clarence Township,Governor,,R,Sam Brownback,40
-Barton,Cleveland Township,Governor,,R,Sam Brownback,13
-Barton,Comanche Township,Governor,,R,Sam Brownback,114
-Barton,Eureka Township,Governor,,R,Sam Brownback,29
-Barton,Fairview Township,Governor,,R,Sam Brownback,28
-Barton,Grant Township,Governor,,R,Sam Brownback,14
-Barton,Great Bend Twp-A,Governor,,R,Sam Brownback,315
-Barton,Great Bend Twp-B,Governor,,R,Sam Brownback,57
-Barton,Independent Township,Governor,,R,Sam Brownback,185
-Barton,Lakin Township,Governor,,R,Sam Brownback,552
-Barton,Liberty Township,Governor,,R,Sam Brownback,70
-Barton,Logan Township,Governor,,R,Sam Brownback,50
-Barton,North Homestead Township,Governor,,R,Sam Brownback,30
-Barton,Pawnee Rock Township,Governor,,R,Sam Brownback,87
-Barton,South Bend Township,Governor,,R,Sam Brownback,155
-Barton,South Homestead Township,Governor,,R,Sam Brownback,91
-Barton,Union Township,Governor,,R,Sam Brownback,26
-Barton,Walnut-Albert Township,Governor,,R,Sam Brownback,45
-Barton,Walnut-Olmitz Township,Governor,,R,Sam Brownback,41
-Barton,Wheatland Township,Governor,,R,Sam Brownback,25
-Barton,Albion Township ,Governor,,,Write-ins,0
-Barton,Beaver Township            ,Governor,,,Write-ins,0
-Barton,Buffalo Township                    ,Governor,,,Write-ins,0
-Barton,Cheyenne Township                   ,Governor,,,Write-ins,0
-Barton,Clarence Township,Governor,,,Write-ins,0
-Barton,Cleveland Township,Governor,,,Write-ins,0
-Barton,Comanche Township,Governor,,,Write-ins,1
-Barton,Eureka Township,Governor,,,Write-ins,0
-Barton,Fairview Township,Governor,,,Write-ins,0
-Barton,Grant Township,Governor,,,Write-ins,0
-Barton,Great Bend Twp-A,Governor,,,Write-ins,0
-Barton,Great Bend Twp-B,Governor,,,Write-ins,0
-Barton,Independent Township,Governor,,,Write-ins,0
-Barton,Lakin Township,Governor,,,Write-ins,1
-Barton,Liberty Township,Governor,,,Write-ins,0
-Barton,Logan Township,Governor,,,Write-ins,0
-Barton,North Homestead Township,Governor,,,Write-ins,0
-Barton,Pawnee Rock Township,Governor,,,Write-ins,1
-Barton,South Bend Township,Governor,,,Write-ins,0
-Barton,South Homestead Township,Governor,,,Write-ins,0
-Barton,Union Township,Governor,,,Write-ins,0
-Barton,Walnut-Albert Township,Governor,,,Write-ins,0
-Barton,Walnut-Olmitz Township,Governor,,,Write-ins,0
-Barton,Wheatland Township,Governor,,,Write-ins,0
-Barton,Albion Township ,Secretary of State,,D,Jean Kurtis Schodorf,2
-Barton,Beaver Township            ,Secretary of State,,D,Jean Kurtis Schodorf,7
-Barton,Buffalo Township                    ,Secretary of State,,D,Jean Kurtis Schodorf,39
-Barton,Cheyenne Township                   ,Secretary of State,,D,Jean Kurtis Schodorf,19
-Barton,Clarence Township,Secretary of State,,D,Jean Kurtis Schodorf,11
-Barton,Cleveland Township,Secretary of State,,D,Jean Kurtis Schodorf,1
-Barton,Comanche Township,Secretary of State,,D,Jean Kurtis Schodorf,40
-Barton,Eureka Township,Secretary of State,,D,Jean Kurtis Schodorf,8
-Barton,Fairview Township,Secretary of State,,D,Jean Kurtis Schodorf,7
-Barton,Grant Township,Secretary of State,,D,Jean Kurtis Schodorf,7
-Barton,Great Bend Twp-A,Secretary of State,,D,Jean Kurtis Schodorf,105
-Barton,Great Bend Twp-B,Secretary of State,,D,Jean Kurtis Schodorf,15
-Barton,Independent Township,Secretary of State,,D,Jean Kurtis Schodorf,53
-Barton,Lakin Township,Secretary of State,,D,Jean Kurtis Schodorf,198
-Barton,Liberty Township,Secretary of State,,D,Jean Kurtis Schodorf,18
-Barton,Logan Township,Secretary of State,,D,Jean Kurtis Schodorf,14
-Barton,North Homestead Township,Secretary of State,,D,Jean Kurtis Schodorf,15
-Barton,Pawnee Rock Township,Secretary of State,,D,Jean Kurtis Schodorf,38
-Barton,South Bend Township,Secretary of State,,D,Jean Kurtis Schodorf,56
-Barton,South Homestead Township,Secretary of State,,D,Jean Kurtis Schodorf,22
-Barton,Union Township,Secretary of State,,D,Jean Kurtis Schodorf,10
-Barton,Walnut-Albert Township,Secretary of State,,D,Jean Kurtis Schodorf,16
-Barton,Walnut-Olmitz Township,Secretary of State,,D,Jean Kurtis Schodorf,22
-Barton,Wheatland Township,Secretary of State,,D,Jean Kurtis Schodorf,5
-Barton,Albion Township ,Secretary of State,,R,Kris Kobach,18
-Barton,Beaver Township            ,Secretary of State,,R,Kris Kobach,32
-Barton,Buffalo Township                    ,Secretary of State,,R,Kris Kobach,135
-Barton,Cheyenne Township                   ,Secretary of State,,R,Kris Kobach,74
-Barton,Clarence Township,Secretary of State,,R,Kris Kobach,45
-Barton,Cleveland Township,Secretary of State,,R,Kris Kobach,17
-Barton,Comanche Township,Secretary of State,,R,Kris Kobach,128
-Barton,Eureka Township,Secretary of State,,R,Kris Kobach,31
-Barton,Fairview Township,Secretary of State,,R,Kris Kobach,29
-Barton,Grant Township,Secretary of State,,R,Kris Kobach,19
-Barton,Great Bend Twp-A,Secretary of State,,R,Kris Kobach,369
-Barton,Great Bend Twp-B,Secretary of State,,R,Kris Kobach,66
-Barton,Independent Township,Secretary of State,,R,Kris Kobach,223
-Barton,Lakin Township,Secretary of State,,R,Kris Kobach,638
-Barton,Liberty Township,Secretary of State,,R,Kris Kobach,85
-Barton,Logan Township,Secretary of State,,R,Kris Kobach,55
-Barton,North Homestead Township,Secretary of State,,R,Kris Kobach,34
-Barton,Pawnee Rock Township,Secretary of State,,R,Kris Kobach,97
-Barton,South Bend Township,Secretary of State,,R,Kris Kobach,174
-Barton,South Homestead Township,Secretary of State,,R,Kris Kobach,109
-Barton,Union Township,Secretary of State,,R,Kris Kobach,35
-Barton,Walnut-Albert Township,Secretary of State,,R,Kris Kobach,59
-Barton,Walnut-Olmitz Township,Secretary of State,,R,Kris Kobach,41
-Barton,Wheatland Township,Secretary of State,,R,Kris Kobach,22
-Barton,Albion Township ,Secretary of State,,,Write-ins,0
-Barton,Beaver Township            ,Secretary of State,,,Write-ins,0
-Barton,Buffalo Township                    ,Secretary of State,,,Write-ins,0
-Barton,Cheyenne Township                   ,Secretary of State,,,Write-ins,0
-Barton,Clarence Township,Secretary of State,,,Write-ins,0
-Barton,Cleveland Township,Secretary of State,,,Write-ins,0
-Barton,Comanche Township,Secretary of State,,,Write-ins,0
-Barton,Eureka Township,Secretary of State,,,Write-ins,0
-Barton,Fairview Township,Secretary of State,,,Write-ins,0
-Barton,Grant Township,Secretary of State,,,Write-ins,0
-Barton,Great Bend Twp-A,Secretary of State,,,Write-ins,0
-Barton,Great Bend Twp-B,Secretary of State,,,Write-ins,0
-Barton,Independent Township,Secretary of State,,,Write-ins,0
-Barton,Lakin Township,Secretary of State,,,Write-ins,1
-Barton,Liberty Township,Secretary of State,,,Write-ins,0
-Barton,Logan Township,Secretary of State,,,Write-ins,0
-Barton,North Homestead Township,Secretary of State,,,Write-ins,0
-Barton,Pawnee Rock Township,Secretary of State,,,Write-ins,0
-Barton,South Bend Township,Secretary of State,,,Write-ins,0
-Barton,South Homestead Township,Secretary of State,,,Write-ins,0
-Barton,Union Township,Secretary of State,,,Write-ins,0
-Barton,Walnut-Albert Township,Secretary of State,,,Write-ins,0
-Barton,Walnut-Olmitz Township,Secretary of State,,,Write-ins,0
-Barton,Wheatland Township,Secretary of State,,,Write-ins,0
-Barton,Cleveland Township,State House,109,R,Troy Waymastrer,18
-Barton,Grant Township,State House,109,R,Troy Waymastrer,23
-Barton,Wheatland Township,State House,109,R,Troy Waymastrer,25
-Barton,Beaver Township            ,State House,109,R,Troy Waymastrer,35
-Barton,Fairview Township,State House,109,R,Troy Waymastrer,36
-Barton,Union Township,State House,109,R,Troy Waymastrer,40
-Barton,Clarence Township,State House,109,R,Troy Waymastrer,49
-Barton,Walnut-Olmitz Township,State House,109,R,Troy Waymastrer,52
-Barton,Logan Township,State House,109,R,Troy Waymastrer,59
-Barton,Walnut-Albert Township,State House,109,R,Troy Waymastrer,70
-Barton,Cheyenne Township                   ,State House,109,R,Troy Waymastrer,85
-Barton,Independent Township,State House,109,R,Troy Waymastrer,248
-Barton,Clarence Township,State House,109,,Write-ins,1
-Barton,Union Township,State House,109,,Write-ins,1
-Barton,Albion Township ,State Rep 112th Dist,112,R,John Edmonds,18
-Barton,Buffalo Township                    ,State Rep 112th Dist,112,R,John Edmonds,132
-Barton,Eureka Township,State Rep 112th Dist,112,R,John Edmonds,28
-Barton,Great Bend Twp-A,State Rep 112th Dist,112,R,John Edmonds,363
-Barton,Great Bend Twp-B,State Rep 112th Dist,112,R,John Edmonds,62
-Barton,Liberty Township,State Rep 112th Dist,112,R,John Edmonds,88
-Barton,North Homestead Township,State Rep 112th Dist,112,R,John Edmonds,38
-Barton,South Bend Township,State Rep 112th Dist,112,R,John Edmonds,183
-Barton,South Homestead Township,State Rep 112th Dist,112,R,John Edmonds,106
-Barton,Albion Township ,State Rep 112th Dist,112,D,Steve Muehleisen,2
-Barton,Buffalo Township                    ,State Rep 112th Dist,112,D,Steve Muehleisen,43
-Barton,Eureka Township,State Rep 112th Dist,112,D,Steve Muehleisen,9
-Barton,Great Bend Twp-A,State Rep 112th Dist,112,D,Steve Muehleisen,103
-Barton,Great Bend Twp-B,State Rep 112th Dist,112,D,Steve Muehleisen,18
-Barton,Liberty Township,State Rep 112th Dist,112,D,Steve Muehleisen,16
-Barton,North Homestead Township,State Rep 112th Dist,112,D,Steve Muehleisen,10
-Barton,South Bend Township,State Rep 112th Dist,112,D,Steve Muehleisen,47
-Barton,South Homestead Township,State Rep 112th Dist,112,D,Steve Muehleisen,26
-Barton,Albion Township ,State Rep 112th Dist,112,,Write-ins,0
-Barton,Buffalo Township                    ,State Rep 112th Dist,112,,Write-ins,0
-Barton,Eureka Township,State Rep 112th Dist,112,,Write-ins,1
-Barton,Great Bend Twp-A,State Rep 112th Dist,112,,Write-ins,0
-Barton,Great Bend Twp-B,State Rep 112th Dist,112,,Write-ins,1
-Barton,Liberty Township,State Rep 112th Dist,112,,Write-ins,0
-Barton,North Homestead Township,State Rep 112th Dist,112,,Write-ins,0
-Barton,South Bend Township,State Rep 112th Dist,112,,Write-ins,1
-Barton,South Homestead Township,State Rep 112th Dist,112,,Write-ins,0
-Barton,Comanche Township,State House,113,R,Jeremy Dannebohm,158
-Barton,Lakin Township,State House,113,R,Jeremy Dannebohm,729
-Barton,Pawnee Rock Township,State House,113,R,Jeremy Dannebohm,117
-Barton,Comanche Township,State House,113,,Write-ins,1
-Barton,Lakin Township,State House,113,,Write-ins,14
-Barton,Pawnee Rock Township,State House,113,,Write-ins,1
-Barton,Albion Township ,State Treasurer,,D,Carmen Alldritt,2
-Barton,Beaver Township            ,State Treasurer,,D,Carmen Alldritt,11
-Barton,Buffalo Township                    ,State Treasurer,,D,Carmen Alldritt,30
-Barton,Cheyenne Township                   ,State Treasurer,,D,Carmen Alldritt,14
-Barton,Clarence Township,State Treasurer,,D,Carmen Alldritt,11
-Barton,Cleveland Township,State Treasurer,,D,Carmen Alldritt,0
-Barton,Comanche Township,State Treasurer,,D,Carmen Alldritt,22
-Barton,Eureka Township,State Treasurer,,D,Carmen Alldritt,6
-Barton,Fairview Township,State Treasurer,,D,Carmen Alldritt,5
-Barton,Grant Township,State Treasurer,,D,Carmen Alldritt,7
-Barton,Great Bend Twp-A,State Treasurer,,D,Carmen Alldritt,70
-Barton,Great Bend Twp-B,State Treasurer,,D,Carmen Alldritt,12
-Barton,Independent Township,State Treasurer,,D,Carmen Alldritt,38
-Barton,Lakin Township,State Treasurer,,D,Carmen Alldritt,130
-Barton,Liberty Township,State Treasurer,,D,Carmen Alldritt,10
-Barton,Logan Township,State Treasurer,,D,Carmen Alldritt,6
-Barton,North Homestead Township,State Treasurer,,D,Carmen Alldritt,12
-Barton,Pawnee Rock Township,State Treasurer,,D,Carmen Alldritt,24
-Barton,South Bend Township,State Treasurer,,D,Carmen Alldritt,40
-Barton,South Homestead Township,State Treasurer,,D,Carmen Alldritt,24
-Barton,Union Township,State Treasurer,,D,Carmen Alldritt,8
-Barton,Walnut-Albert Township,State Treasurer,,D,Carmen Alldritt,14
-Barton,Walnut-Olmitz Township,State Treasurer,,D,Carmen Alldritt,16
-Barton,Wheatland Township,State Treasurer,,D,Carmen Alldritt,1
-Barton,Albion Township ,State Treasurer,,R,Ron Estes,18
-Barton,Beaver Township            ,State Treasurer,,R,Ron Estes,27
-Barton,Buffalo Township                    ,State Treasurer,,R,Ron Estes,143
-Barton,Cheyenne Township                   ,State Treasurer,,R,Ron Estes,79
-Barton,Clarence Township,State Treasurer,,R,Ron Estes,44
-Barton,Cleveland Township,State Treasurer,,R,Ron Estes,17
-Barton,Comanche Township,State Treasurer,,R,Ron Estes,143
-Barton,Eureka Township,State Treasurer,,R,Ron Estes,32
-Barton,Fairview Township,State Treasurer,,R,Ron Estes,30
-Barton,Grant Township,State Treasurer,,R,Ron Estes,20
-Barton,Great Bend Twp-A,State Treasurer,,R,Ron Estes,401
-Barton,Great Bend Twp-B,State Treasurer,,R,Ron Estes,68
-Barton,Independent Township,State Treasurer,,R,Ron Estes,228
-Barton,Lakin Township,State Treasurer,,R,Ron Estes,686
-Barton,Liberty Township,State Treasurer,,R,Ron Estes,93
-Barton,Logan Township,State Treasurer,,R,Ron Estes,62
-Barton,North Homestead Township,State Treasurer,,R,Ron Estes,36
-Barton,Pawnee Rock Township,State Treasurer,,R,Ron Estes,108
-Barton,South Bend Township,State Treasurer,,R,Ron Estes,190
-Barton,South Homestead Township,State Treasurer,,R,Ron Estes,106
-Barton,Union Township,State Treasurer,,R,Ron Estes,37
-Barton,Walnut-Albert Township,State Treasurer,,R,Ron Estes,61
-Barton,Walnut-Olmitz Township,State Treasurer,,R,Ron Estes,46
-Barton,Wheatland Township,State Treasurer,,R,Ron Estes,24
-Barton,Albion Township ,State Treasurer,,,Write-ins,0
-Barton,Beaver Township            ,State Treasurer,,,Write-ins,0
-Barton,Buffalo Township                    ,State Treasurer,,,Write-ins,0
-Barton,Cheyenne Township                   ,State Treasurer,,,Write-ins,0
-Barton,Clarence Township,State Treasurer,,,Write-ins,0
-Barton,Cleveland Township,State Treasurer,,,Write-ins,0
-Barton,Comanche Township,State Treasurer,,,Write-ins,0
-Barton,Eureka Township,State Treasurer,,,Write-ins,1
-Barton,Fairview Township,State Treasurer,,,Write-ins,0
-Barton,Grant Township,State Treasurer,,,Write-ins,0
-Barton,Great Bend Twp-A,State Treasurer,,,Write-ins,0
-Barton,Great Bend Twp-B,State Treasurer,,,Write-ins,0
-Barton,Independent Township,State Treasurer,,,Write-ins,0
-Barton,Lakin Township,State Treasurer,,,Write-ins,1
-Barton,Liberty Township,State Treasurer,,,Write-ins,0
-Barton,Logan Township,State Treasurer,,,Write-ins,0
-Barton,North Homestead Township,State Treasurer,,,Write-ins,0
-Barton,Pawnee Rock Township,State Treasurer,,,Write-ins,0
-Barton,South Bend Township,State Treasurer,,,Write-ins,1
-Barton,South Homestead Township,State Treasurer,,,Write-ins,0
-Barton,Union Township,State Treasurer,,,Write-ins,0
-Barton,Walnut-Albert Township,State Treasurer,,,Write-ins,0
-Barton,Walnut-Olmitz Township,State Treasurer,,,Write-ins,0
-Barton,Wheatland Township,State Treasurer,,,Write-ins,0
-Barton,Albion Township ,U.S. Senate,,I,Greg Orman,0
-Barton,Beaver Township            ,U.S. Senate,,I,Greg Orman,11
-Barton,Buffalo Township                    ,U.S. Senate,,I,Greg Orman,48
-Barton,Cheyenne Township                   ,U.S. Senate,,I,Greg Orman,9
-Barton,Clarence Township,U.S. Senate,,I,Greg Orman,13
-Barton,Cleveland Township,U.S. Senate,,I,Greg Orman,2
-Barton,Comanche Township,U.S. Senate,,I,Greg Orman,39
-Barton,Eureka Township,U.S. Senate,,I,Greg Orman,5
-Barton,Fairview Township,U.S. Senate,,I,Greg Orman,7
-Barton,Grant Township,U.S. Senate,,I,Greg Orman,12
-Barton,Great Bend Twp-A,U.S. Senate,,I,Greg Orman,116
-Barton,Great Bend Twp-B,U.S. Senate,,I,Greg Orman,17
-Barton,Independent Township,U.S. Senate,,I,Greg Orman,47
-Barton,Lakin Township,U.S. Senate,,I,Greg Orman,237
-Barton,Liberty Township,U.S. Senate,,I,Greg Orman,25
-Barton,Logan Township,U.S. Senate,,I,Greg Orman,10
-Barton,North Homestead Township,U.S. Senate,,I,Greg Orman,12
-Barton,Pawnee Rock Township,U.S. Senate,,I,Greg Orman,37
-Barton,South Bend Township,U.S. Senate,,I,Greg Orman,57
-Barton,South Homestead Township,U.S. Senate,,I,Greg Orman,33
-Barton,Union Township,U.S. Senate,,I,Greg Orman,9
-Barton,Walnut-Albert Township,U.S. Senate,,I,Greg Orman,24
-Barton,Walnut-Olmitz Township,U.S. Senate,,I,Greg Orman,20
-Barton,Wheatland Township,U.S. Senate,,I,Greg Orman,2
-Barton,Albion Township ,U.S. Senate,,R,Pat Roberts,20
-Barton,Beaver Township            ,U.S. Senate,,R,Pat Roberts,27
-Barton,Buffalo Township                    ,U.S. Senate,,R,Pat Roberts,122
-Barton,Cheyenne Township                   ,U.S. Senate,,R,Pat Roberts,80
-Barton,Clarence Township,U.S. Senate,,R,Pat Roberts,43
-Barton,Cleveland Township,U.S. Senate,,R,Pat Roberts,16
-Barton,Comanche Township,U.S. Senate,,R,Pat Roberts,127
-Barton,Eureka Township,U.S. Senate,,R,Pat Roberts,32
-Barton,Fairview Township,U.S. Senate,,R,Pat Roberts,28
-Barton,Grant Township,U.S. Senate,,R,Pat Roberts,14
-Barton,Great Bend Twp-A,U.S. Senate,,R,Pat Roberts,339
-Barton,Great Bend Twp-B,U.S. Senate,,R,Pat Roberts,61
-Barton,Independent Township,U.S. Senate,,R,Pat Roberts,205
-Barton,Lakin Township,U.S. Senate,,R,Pat Roberts,584
-Barton,Liberty Township,U.S. Senate,,R,Pat Roberts,77
-Barton,Logan Township,U.S. Senate,,R,Pat Roberts,58
-Barton,North Homestead Township,U.S. Senate,,R,Pat Roberts,37
-Barton,Pawnee Rock Township,U.S. Senate,,R,Pat Roberts,92
-Barton,South Bend Township,U.S. Senate,,R,Pat Roberts,163
-Barton,South Homestead Township,U.S. Senate,,R,Pat Roberts,94
-Barton,Union Township,U.S. Senate,,R,Pat Roberts,28
-Barton,Walnut-Albert Township,U.S. Senate,,R,Pat Roberts,50
-Barton,Walnut-Olmitz Township,U.S. Senate,,R,Pat Roberts,44
-Barton,Wheatland Township,U.S. Senate,,R,Pat Roberts,22
-Barton,Albion Township ,U.S. Senate,,L,Randall Batson,0
-Barton,Beaver Township            ,U.S. Senate,,L,Randall Batson,1
-Barton,Buffalo Township                    ,U.S. Senate,,L,Randall Batson,8
-Barton,Cheyenne Township                   ,U.S. Senate,,L,Randall Batson,6
-Barton,Clarence Township,U.S. Senate,,L,Randall Batson,0
-Barton,Cleveland Township,U.S. Senate,,L,Randall Batson,0
-Barton,Comanche Township,U.S. Senate,,L,Randall Batson,5
-Barton,Eureka Township,U.S. Senate,,L,Randall Batson,2
-Barton,Fairview Township,U.S. Senate,,L,Randall Batson,4
-Barton,Grant Township,U.S. Senate,,L,Randall Batson,1
-Barton,Great Bend Twp-A,U.S. Senate,,L,Randall Batson,18
-Barton,Great Bend Twp-B,U.S. Senate,,L,Randall Batson,3
-Barton,Independent Township,U.S. Senate,,L,Randall Batson,23
-Barton,Lakin Township,U.S. Senate,,L,Randall Batson,26
-Barton,Liberty Township,U.S. Senate,,L,Randall Batson,2
-Barton,Logan Township,U.S. Senate,,L,Randall Batson,2
-Barton,North Homestead Township,U.S. Senate,,L,Randall Batson,1
-Barton,Pawnee Rock Township,U.S. Senate,,L,Randall Batson,6
-Barton,South Bend Township,U.S. Senate,,L,Randall Batson,10
-Barton,South Homestead Township,U.S. Senate,,L,Randall Batson,3
-Barton,Union Township,U.S. Senate,,L,Randall Batson,4
-Barton,Walnut-Albert Township,U.S. Senate,,L,Randall Batson,3
-Barton,Walnut-Olmitz Township,U.S. Senate,,L,Randall Batson,4
-Barton,Wheatland Township,U.S. Senate,,L,Randall Batson,1
-Barton,Albion Township ,U.S. Senate,,,Write-ins,0
-Barton,Beaver Township            ,U.S. Senate,,,Write-ins,0
-Barton,Buffalo Township                    ,U.S. Senate,,,Write-ins,0
-Barton,Cheyenne Township                   ,U.S. Senate,,,Write-ins,0
-Barton,Clarence Township,U.S. Senate,,,Write-ins,0
-Barton,Cleveland Township,U.S. Senate,,,Write-ins,0
-Barton,Comanche Township,U.S. Senate,,,Write-ins,0
-Barton,Eureka Township,U.S. Senate,,,Write-ins,0
-Barton,Fairview Township,U.S. Senate,,,Write-ins,0
-Barton,Grant Township,U.S. Senate,,,Write-ins,0
-Barton,Great Bend Twp-A,U.S. Senate,,,Write-ins,0
-Barton,Great Bend Twp-B,U.S. Senate,,,Write-ins,0
-Barton,Independent Township,U.S. Senate,,,Write-ins,0
-Barton,Lakin Township,U.S. Senate,,,Write-ins,3
-Barton,Liberty Township,U.S. Senate,,,Write-ins,0
-Barton,Logan Township,U.S. Senate,,,Write-ins,0
-Barton,North Homestead Township,U.S. Senate,,,Write-ins,0
-Barton,Pawnee Rock Township,U.S. Senate,,,Write-ins,0
-Barton,South Bend Township,U.S. Senate,,,Write-ins,1
-Barton,South Homestead Township,U.S. Senate,,,Write-ins,1
-Barton,Union Township,U.S. Senate,,,Write-ins,0
-Barton,Walnut-Albert Township,U.S. Senate,,,Write-ins,0
-Barton,Walnut-Olmitz Township,U.S. Senate,,,Write-ins,0
-Barton,Wheatland Township,U.S. Senate,,,Write-ins,0
-Barton,Albion Township ,U.S. House,1,D,James Sherow,1
-Barton,Beaver Township            ,U.S. House,1,D,James Sherow,11
-Barton,Buffalo Township                    ,U.S. House,1,D,James Sherow,38
-Barton,Cheyenne Township                   ,U.S. House,1,D,James Sherow,18
-Barton,Clarence Township,U.S. House,1,D,James Sherow,12
-Barton,Cleveland Township,U.S. House,1,D,James Sherow,3
-Barton,Comanche Township,U.S. House,1,D,James Sherow,40
-Barton,Eureka Township,U.S. House,1,D,James Sherow,9
-Barton,Fairview Township,U.S. House,1,D,James Sherow,9
-Barton,Grant Township,U.S. House,1,D,James Sherow,11
-Barton,Great Bend Twp-A,U.S. House,1,D,James Sherow,105
-Barton,Great Bend Twp-B,U.S. House,1,D,James Sherow,17
-Barton,Independent Township,U.S. House,1,D,James Sherow,57
-Barton,Lakin Township,U.S. House,1,D,James Sherow,216
-Barton,Liberty Township,U.S. House,1,D,James Sherow,17
-Barton,Logan Township,U.S. House,1,D,James Sherow,18
-Barton,North Homestead Township,U.S. House,1,D,James Sherow,20
-Barton,Pawnee Rock Township,U.S. House,1,D,James Sherow,38
-Barton,South Bend Township,U.S. House,1,D,James Sherow,51
-Barton,South Homestead Township,U.S. House,1,D,James Sherow,28
-Barton,Union Township,U.S. House,1,D,James Sherow,17
-Barton,Walnut-Albert Township,U.S. House,1,D,James Sherow,19
-Barton,Walnut-Olmitz Township,U.S. House,1,D,James Sherow,16
-Barton,Wheatland Township,U.S. House,1,D,James Sherow,3
-Barton,Albion Township ,U.S. House,1,R,Tim Huelskamp,19
-Barton,Beaver Township            ,U.S. House,1,R,Tim Huelskamp,28
-Barton,Buffalo Township                    ,U.S. House,1,R,Tim Huelskamp,137
-Barton,Cheyenne Township                   ,U.S. House,1,R,Tim Huelskamp,78
-Barton,Clarence Township,U.S. House,1,R,Tim Huelskamp,43
-Barton,Cleveland Township,U.S. House,1,R,Tim Huelskamp,15
-Barton,Comanche Township,U.S. House,1,R,Tim Huelskamp,127
-Barton,Eureka Township,U.S. House,1,R,Tim Huelskamp,30
-Barton,Fairview Township,U.S. House,1,R,Tim Huelskamp,29
-Barton,Grant Township,U.S. House,1,R,Tim Huelskamp,15
-Barton,Great Bend Twp-A,U.S. House,1,R,Tim Huelskamp,365
-Barton,Great Bend Twp-B,U.S. House,1,R,Tim Huelskamp,64
-Barton,Independent Township,U.S. House,1,R,Tim Huelskamp,215
-Barton,Lakin Township,U.S. House,1,R,Tim Huelskamp,618
-Barton,Liberty Township,U.S. House,1,R,Tim Huelskamp,87
-Barton,Logan Township,U.S. House,1,R,Tim Huelskamp,49
-Barton,North Homestead Township,U.S. House,1,R,Tim Huelskamp,29
-Barton,Pawnee Rock Township,U.S. House,1,R,Tim Huelskamp,95
-Barton,South Bend Township,U.S. House,1,R,Tim Huelskamp,176
-Barton,South Homestead Township,U.S. House,1,R,Tim Huelskamp,102
-Barton,Union Township,U.S. House,1,R,Tim Huelskamp,27
-Barton,Walnut-Albert Township,U.S. House,1,R,Tim Huelskamp,54
-Barton,Walnut-Olmitz Township,U.S. House,1,R,Tim Huelskamp,49
-Barton,Wheatland Township,U.S. House,1,R,Tim Huelskamp,23
-Barton,Albion Township ,U.S. House,1,,Write-ins,0
-Barton,Beaver Township            ,U.S. House,1,,Write-ins,0
-Barton,Buffalo Township                    ,U.S. House,1,,Write-ins,0
-Barton,Cheyenne Township                   ,U.S. House,1,,Write-ins,0
-Barton,Clarence Township,U.S. House,1,,Write-ins,0
-Barton,Cleveland Township,U.S. House,1,,Write-ins,0
-Barton,Comanche Township,U.S. House,1,,Write-ins,0
-Barton,Eureka Township,U.S. House,1,,Write-ins,0
-Barton,Fairview Township,U.S. House,1,,Write-ins,0
-Barton,Grant Township,U.S. House,1,,Write-ins,0
-Barton,Great Bend Twp-A,U.S. House,1,,Write-ins,0
-Barton,Great Bend Twp-B,U.S. House,1,,Write-ins,0
-Barton,Independent Township,U.S. House,1,,Write-ins,0
-Barton,Lakin Township,U.S. House,1,,Write-ins,1
-Barton,Liberty Township,U.S. House,1,,Write-ins,0
-Barton,Logan Township,U.S. House,1,,Write-ins,0
-Barton,North Homestead Township,U.S. House,1,,Write-ins,0
-Barton,Pawnee Rock Township,U.S. House,1,,Write-ins,0
-Barton,South Bend Township,U.S. House,1,,Write-ins,1
-Barton,South Homestead Township,U.S. House,1,,Write-ins,0
-Barton,Union Township,U.S. House,1,,Write-ins,0
-Barton,Walnut-Albert Township,U.S. House,1,,Write-ins,0
-Barton,Walnut-Olmitz Township,U.S. House,1,,Write-ins,0
-Barton,Wheatland Township,U.S. House,1,,Write-ins,0
+county,precinct,office,district,party,candidate,votes,vtd
+BARTON,Albion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000010
+BARTON,Albion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+BARTON,Albion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000010
+BARTON,Beaver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000020
+BARTON,Beaver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+BARTON,Beaver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000020
+BARTON,Buffalo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",54,000030
+BARTON,Buffalo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000030
+BARTON,Buffalo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",121,000030
+BARTON,Cheyenne Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000040
+BARTON,Cheyenne Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000040
+BARTON,Cheyenne Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000040
+BARTON,Clarence Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000050
+BARTON,Clarence Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+BARTON,Clarence Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000050
+BARTON,Cleveland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000060
+BARTON,Cleveland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+BARTON,Cleveland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000060
+BARTON,Comanche Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,000070
+BARTON,Comanche Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000070
+BARTON,Comanche Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",114,000070
+BARTON,Eureka Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000080
+BARTON,Eureka Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+BARTON,Eureka Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000080
+BARTON,Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000090
+BARTON,Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000090
+BARTON,Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000090
+BARTON,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000100
+BARTON,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+BARTON,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",159,000120
+BARTON,Great Bend City Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000120
+BARTON,Great Bend City Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",205,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",102,000130
+BARTON,Great Bend City Ward 1 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000130
+BARTON,Great Bend City Ward 1 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",170,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",186,000140
+BARTON,Great Bend City Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000140
+BARTON,Great Bend City Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",282,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",184,000150
+BARTON,Great Bend City Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000150
+BARTON,Great Bend City Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",281,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",187,000160
+BARTON,Great Bend City Ward 2 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000160
+BARTON,Great Bend City Ward 2 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",397,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000170
+BARTON,Great Bend City Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000170
+BARTON,Great Bend City Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",193,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",155,000180
+BARTON,Great Bend City Ward 3 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000180
+BARTON,Great Bend City Ward 3 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",194,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",162,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",250,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000200
+BARTON,Great Bend City Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000200
+BARTON,Great Bend City Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",64,000210
+BARTON,Great Bend City Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000210
+BARTON,Great Bend City Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022F
+BARTON,Great Bend Township Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,00023A
+BARTON,Great Bend Township Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00023A
+BARTON,Great Bend Township Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",315,00023A
+BARTON,Great Bend Township Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,00023B
+BARTON,Great Bend Township Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00023B
+BARTON,Great Bend Township Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,00023B
+BARTON,Great Bend Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00023C
+BARTON,Great Bend Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00023C
+BARTON,Great Bend Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00023C
+BARTON,Hoisington Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",85,000240
+BARTON,Hoisington Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000240
+BARTON,Hoisington Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,000240
+BARTON,Hoisington Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",83,000250
+BARTON,Hoisington Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000250
+BARTON,Hoisington Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000250
+BARTON,Hoisington Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",64,000260
+BARTON,Hoisington Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000260
+BARTON,Hoisington Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000260
+BARTON,Hoisington Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,00027A
+BARTON,Hoisington Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00027A
+BARTON,Hoisington Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",98,00027A
+BARTON,Hoisington Ward 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00027B
+BARTON,Hoisington Ward 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00027B
+BARTON,Independent Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000280
+BARTON,Independent Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000280
+BARTON,Independent Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",185,000280
+BARTON,Lakin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",262,000290
+BARTON,Lakin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000290
+BARTON,Lakin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",552,000290
+BARTON,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000300
+BARTON,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000300
+BARTON,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000300
+BARTON,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000310
+BARTON,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000310
+BARTON,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000310
+BARTON,North Homestead Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000320
+BARTON,North Homestead Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000320
+BARTON,North Homestead Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000320
+BARTON,Pawnee Rock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000330
+BARTON,Pawnee Rock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000330
+BARTON,Pawnee Rock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,000330
+BARTON,South Bend Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,000340
+BARTON,South Bend Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000340
+BARTON,South Bend Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",155,000340
+BARTON,South Homestead Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000350
+BARTON,South Homestead Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000350
+BARTON,South Homestead Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000350
+BARTON,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000360
+BARTON,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000360
+BARTON,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000360
+BARTON,Walnut Township Albert,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000370
+BARTON,Walnut Township Albert,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000370
+BARTON,Walnut Township Albert,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,000370
+BARTON,Walnut Township Olmitz,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000380
+BARTON,Walnut Township Olmitz,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000380
+BARTON,Walnut Township Olmitz,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000380
+BARTON,Wheatland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000390
+BARTON,Wheatland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000390
+BARTON,Wheatland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000390
+BARTON,Hoisington Landfill,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+BARTON,Hoisington Landfill,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+BARTON,Hoisington Landfill,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+BARTON,Albion Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",2,000010
+BARTON,Albion Township,Kansas House of Representatives,112,Republican,"Edmonds, John",18,000010
+BARTON,Beaver Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",35,000020
+BARTON,Buffalo Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",43,000030
+BARTON,Buffalo Township,Kansas House of Representatives,112,Republican,"Edmonds, John",132,000030
+BARTON,Cheyenne Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",85,000040
+BARTON,Clarence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",49,000050
+BARTON,Cleveland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",18,000060
+BARTON,Comanche Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",158,000070
+BARTON,Eureka Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",9,000080
+BARTON,Eureka Township,Kansas House of Representatives,112,Republican,"Edmonds, John",28,000080
+BARTON,Fairview Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",36,000090
+BARTON,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",23,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",81,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,Kansas House of Representatives,112,Republican,"Edmonds, John",137,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",108,000120
+BARTON,Great Bend City Ward 1 Precinct 2,Kansas House of Representatives,112,Republican,"Edmonds, John",271,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",86,000130
+BARTON,Great Bend City Ward 1 Precinct 3,Kansas House of Representatives,112,Republican,"Edmonds, John",200,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",125,000140
+BARTON,Great Bend City Ward 2 Precinct 1,Kansas House of Representatives,112,Republican,"Edmonds, John",353,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",113,000150
+BARTON,Great Bend City Ward 2 Precinct 2,Kansas House of Representatives,112,Republican,"Edmonds, John",373,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",119,000160
+BARTON,Great Bend City Ward 2 Precinct 3,Kansas House of Representatives,112,Republican,"Edmonds, John",473,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",73,000170
+BARTON,Great Bend City Ward 3 Precinct 1,Kansas House of Representatives,112,Republican,"Edmonds, John",240,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",100,000180
+BARTON,Great Bend City Ward 3 Precinct 2,Kansas House of Representatives,112,Republican,"Edmonds, John",265,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",103,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,Kansas House of Representatives,112,Republican,"Edmonds, John",329,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",61,000200
+BARTON,Great Bend City Ward 4 Precinct 1,Kansas House of Representatives,112,Republican,"Edmonds, John",143,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",49,000210
+BARTON,Great Bend City Ward 4 Precinct 2,Kansas House of Representatives,112,Republican,"Edmonds, John",103,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",18,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,Kansas House of Representatives,112,Republican,"Edmonds, John",39,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022F
+BARTON,Great Bend Township Part A,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",103,00023A
+BARTON,Great Bend Township Part A,Kansas House of Representatives,112,Republican,"Edmonds, John",363,00023A
+BARTON,Great Bend Township Part B,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",18,00023B
+BARTON,Great Bend Township Part B,Kansas House of Representatives,112,Republican,"Edmonds, John",62,00023B
+BARTON,Great Bend Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00023C
+BARTON,Great Bend Township,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00023C
+BARTON,Hoisington Ward 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",51,000240
+BARTON,Hoisington Ward 1,Kansas House of Representatives,112,Republican,"Edmonds, John",151,000240
+BARTON,Hoisington Ward 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",43,000250
+BARTON,Hoisington Ward 2,Kansas House of Representatives,112,Republican,"Edmonds, John",176,000250
+BARTON,Hoisington Ward 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",37,000260
+BARTON,Hoisington Ward 3,Kansas House of Representatives,112,Republican,"Edmonds, John",162,000260
+BARTON,Hoisington Ward 4,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",39,00027A
+BARTON,Hoisington Ward 4,Kansas House of Representatives,112,Republican,"Edmonds, John",126,00027A
+BARTON,Hoisington Ward 4 Exclave,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00027B
+BARTON,Hoisington Ward 4 Exclave,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00027B
+BARTON,Independent Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",248,000280
+BARTON,Lakin Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",729,000290
+BARTON,Liberty Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",16,000300
+BARTON,Liberty Township,Kansas House of Representatives,112,Republican,"Edmonds, John",88,000300
+BARTON,Logan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",59,000310
+BARTON,North Homestead Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",10,000320
+BARTON,North Homestead Township,Kansas House of Representatives,112,Republican,"Edmonds, John",38,000320
+BARTON,Pawnee Rock Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",117,000330
+BARTON,South Bend Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",47,000340
+BARTON,South Bend Township,Kansas House of Representatives,112,Republican,"Edmonds, John",183,000340
+BARTON,South Homestead Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",26,000350
+BARTON,South Homestead Township,Kansas House of Representatives,112,Republican,"Edmonds, John",106,000350
+BARTON,Union Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",40,000360
+BARTON,Walnut Township Albert,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",70,000370
+BARTON,Walnut Township Olmitz,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",52,000380
+BARTON,Wheatland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000390
+BARTON,Hoisington Landfill,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,900010
+BARTON,Hoisington Landfill,Kansas House of Representatives,112,Republican,"Edmonds, John",0,900010
+BARTON,Albion Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000010
+BARTON,Albion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000010
+BARTON,Beaver Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000020
+BARTON,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000020
+BARTON,Buffalo Township,United States House of Representatives,1,Democratic,"Sherow, James E.",38,000030
+BARTON,Buffalo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",137,000030
+BARTON,Cheyenne Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000040
+BARTON,Cheyenne Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000040
+BARTON,Clarence Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000050
+BARTON,Clarence Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000050
+BARTON,Cleveland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000060
+BARTON,Cleveland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000060
+BARTON,Comanche Township,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000070
+BARTON,Comanche Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",127,000070
+BARTON,Eureka Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000080
+BARTON,Eureka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000080
+BARTON,Fairview Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000090
+BARTON,Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000090
+BARTON,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000100
+BARTON,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000100
+BARTON,Great Bend City Ward 1 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",86,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",132,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",107,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",269,000120
+BARTON,Great Bend City Ward 1 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",79,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",209,000130
+BARTON,Great Bend City Ward 2 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",144,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",336,000140
+BARTON,Great Bend City Ward 2 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",148,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",336,000150
+BARTON,Great Bend City Ward 2 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",163,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",423,000160
+BARTON,Great Bend City Ward 3 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",80,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",232,000170
+BARTON,Great Bend City Ward 3 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",117,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",244,000180
+BARTON,Great Bend City Ward 3 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",113,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",314,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",71,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",135,000200
+BARTON,Great Bend City Ward 4 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",53,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",97,000210
+BARTON,Great Bend City Ward 4 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",15,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022F
+BARTON,Great Bend Township Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",105,00023A
+BARTON,Great Bend Township Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",365,00023A
+BARTON,Great Bend Township Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",17,00023B
+BARTON,Great Bend Township Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,00023B
+BARTON,Great Bend Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00023C
+BARTON,Great Bend Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00023C
+BARTON,Hoisington Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",66,000240
+BARTON,Hoisington Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",137,000240
+BARTON,Hoisington Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",56,000250
+BARTON,Hoisington Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",167,000250
+BARTON,Hoisington Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",55,000260
+BARTON,Hoisington Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",146,000260
+BARTON,Hoisington Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",43,00027A
+BARTON,Hoisington Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",120,00027A
+BARTON,Hoisington Ward 4 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00027B
+BARTON,Independent Township,United States House of Representatives,1,Democratic,"Sherow, James E.",57,000280
+BARTON,Independent Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",215,000280
+BARTON,Lakin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",216,000290
+BARTON,Lakin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",618,000290
+BARTON,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000300
+BARTON,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",87,000300
+BARTON,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000310
+BARTON,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000310
+BARTON,North Homestead Township,United States House of Representatives,1,Democratic,"Sherow, James E.",20,000320
+BARTON,North Homestead Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000320
+BARTON,Pawnee Rock Township,United States House of Representatives,1,Democratic,"Sherow, James E.",38,000330
+BARTON,Pawnee Rock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000330
+BARTON,South Bend Township,United States House of Representatives,1,Democratic,"Sherow, James E.",51,000340
+BARTON,South Bend Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",176,000340
+BARTON,South Homestead Township,United States House of Representatives,1,Democratic,"Sherow, James E.",28,000350
+BARTON,South Homestead Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",102,000350
+BARTON,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000360
+BARTON,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000360
+BARTON,Walnut Township Albert,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000370
+BARTON,Walnut Township Albert,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,000370
+BARTON,Walnut Township Olmitz,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000380
+BARTON,Walnut Township Olmitz,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000380
+BARTON,Wheatland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000390
+BARTON,Wheatland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000390
+BARTON,Hoisington Landfill,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+BARTON,Hoisington Landfill,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+BARTON,Albion Township,Attorney General,,Democratic,"Kotich, A.J.",2,000010
+BARTON,Albion Township,Attorney General,,Republican,"Schmidt, Derek",18,000010
+BARTON,Beaver Township,Attorney General,,Democratic,"Kotich, A.J.",7,000020
+BARTON,Beaver Township,Attorney General,,Republican,"Schmidt, Derek",31,000020
+BARTON,Buffalo Township,Attorney General,,Democratic,"Kotich, A.J.",36,000030
+BARTON,Buffalo Township,Attorney General,,Republican,"Schmidt, Derek",137,000030
+BARTON,Cheyenne Township,Attorney General,,Democratic,"Kotich, A.J.",13,000040
+BARTON,Cheyenne Township,Attorney General,,Republican,"Schmidt, Derek",79,000040
+BARTON,Clarence Township,Attorney General,,Democratic,"Kotich, A.J.",11,000050
+BARTON,Clarence Township,Attorney General,,Republican,"Schmidt, Derek",43,000050
+BARTON,Cleveland Township,Attorney General,,Democratic,"Kotich, A.J.",1,000060
+BARTON,Cleveland Township,Attorney General,,Republican,"Schmidt, Derek",17,000060
+BARTON,Comanche Township,Attorney General,,Democratic,"Kotich, A.J.",25,000070
+BARTON,Comanche Township,Attorney General,,Republican,"Schmidt, Derek",140,000070
+BARTON,Eureka Township,Attorney General,,Democratic,"Kotich, A.J.",5,000080
+BARTON,Eureka Township,Attorney General,,Republican,"Schmidt, Derek",32,000080
+BARTON,Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",6,000090
+BARTON,Fairview Township,Attorney General,,Republican,"Schmidt, Derek",30,000090
+BARTON,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",8,000100
+BARTON,Grant Township,Attorney General,,Republican,"Schmidt, Derek",18,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",65,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",152,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Attorney General,,Democratic,"Kotich, A.J.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Attorney General,,Republican,"Schmidt, Derek",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",86,000120
+BARTON,Great Bend City Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",285,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",60,000130
+BARTON,Great Bend City Ward 1 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",224,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",88,000140
+BARTON,Great Bend City Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",390,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",100,000150
+BARTON,Great Bend City Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",381,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",101,000160
+BARTON,Great Bend City Ward 2 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",479,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",55,000170
+BARTON,Great Bend City Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",257,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",92,000180
+BARTON,Great Bend City Ward 3 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",265,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",84,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",345,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",55,000200
+BARTON,Great Bend City Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",148,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",44,000210
+BARTON,Great Bend City Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",108,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",16,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",42,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Attorney General,,Democratic,"Kotich, A.J.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Attorney General,,Republican,"Schmidt, Derek",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Attorney General,,Democratic,"Kotich, A.J.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Attorney General,,Republican,"Schmidt, Derek",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Attorney General,,Democratic,"Kotich, A.J.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Attorney General,,Republican,"Schmidt, Derek",0,00022F
+BARTON,Great Bend Township Part A,Attorney General,,Democratic,"Kotich, A.J.",68,00023A
+BARTON,Great Bend Township Part A,Attorney General,,Republican,"Schmidt, Derek",400,00023A
+BARTON,Great Bend Township Part B,Attorney General,,Democratic,"Kotich, A.J.",12,00023B
+BARTON,Great Bend Township Part B,Attorney General,,Republican,"Schmidt, Derek",67,00023B
+BARTON,Great Bend Township,Attorney General,,Democratic,"Kotich, A.J.",0,00023C
+BARTON,Great Bend Township,Attorney General,,Republican,"Schmidt, Derek",0,00023C
+BARTON,Hoisington Ward 1,Attorney General,,Democratic,"Kotich, A.J.",49,000240
+BARTON,Hoisington Ward 1,Attorney General,,Republican,"Schmidt, Derek",152,000240
+BARTON,Hoisington Ward 2,Attorney General,,Democratic,"Kotich, A.J.",37,000250
+BARTON,Hoisington Ward 2,Attorney General,,Republican,"Schmidt, Derek",182,000250
+BARTON,Hoisington Ward 3,Attorney General,,Democratic,"Kotich, A.J.",32,000260
+BARTON,Hoisington Ward 3,Attorney General,,Republican,"Schmidt, Derek",166,000260
+BARTON,Hoisington Ward 4,Attorney General,,Democratic,"Kotich, A.J.",32,00027A
+BARTON,Hoisington Ward 4,Attorney General,,Republican,"Schmidt, Derek",129,00027A
+BARTON,Hoisington Ward 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00027B
+BARTON,Independent Township,Attorney General,,Democratic,"Kotich, A.J.",46,000280
+BARTON,Independent Township,Attorney General,,Republican,"Schmidt, Derek",224,000280
+BARTON,Lakin Township,Attorney General,,Democratic,"Kotich, A.J.",145,000290
+BARTON,Lakin Township,Attorney General,,Republican,"Schmidt, Derek",669,000290
+BARTON,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",11,000300
+BARTON,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",89,000300
+BARTON,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",9,000310
+BARTON,Logan Township,Attorney General,,Republican,"Schmidt, Derek",59,000310
+BARTON,North Homestead Township,Attorney General,,Democratic,"Kotich, A.J.",10,000320
+BARTON,North Homestead Township,Attorney General,,Republican,"Schmidt, Derek",38,000320
+BARTON,Pawnee Rock Township,Attorney General,,Democratic,"Kotich, A.J.",27,000330
+BARTON,Pawnee Rock Township,Attorney General,,Republican,"Schmidt, Derek",106,000330
+BARTON,South Bend Township,Attorney General,,Democratic,"Kotich, A.J.",46,000340
+BARTON,South Bend Township,Attorney General,,Republican,"Schmidt, Derek",180,000340
+BARTON,South Homestead Township,Attorney General,,Democratic,"Kotich, A.J.",21,000350
+BARTON,South Homestead Township,Attorney General,,Republican,"Schmidt, Derek",110,000350
+BARTON,Union Township,Attorney General,,Democratic,"Kotich, A.J.",13,000360
+BARTON,Union Township,Attorney General,,Republican,"Schmidt, Derek",30,000360
+BARTON,Walnut Township Albert,Attorney General,,Democratic,"Kotich, A.J.",17,000370
+BARTON,Walnut Township Albert,Attorney General,,Republican,"Schmidt, Derek",57,000370
+BARTON,Walnut Township Olmitz,Attorney General,,Democratic,"Kotich, A.J.",19,000380
+BARTON,Walnut Township Olmitz,Attorney General,,Republican,"Schmidt, Derek",41,000380
+BARTON,Wheatland Township,Attorney General,,Democratic,"Kotich, A.J.",3,000390
+BARTON,Wheatland Township,Attorney General,,Republican,"Schmidt, Derek",23,000390
+BARTON,Hoisington Landfill,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+BARTON,Hoisington Landfill,Attorney General,,Republican,"Schmidt, Derek",0,900010
+BARTON,Albion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000010
+BARTON,Albion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000010
+BARTON,Beaver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000020
+BARTON,Beaver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000020
+BARTON,Buffalo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000030
+BARTON,Buffalo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",130,000030
+BARTON,Cheyenne Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000040
+BARTON,Cheyenne Township,Commissioner of Insurance,,Republican,"Selzer, Ken",75,000040
+BARTON,Clarence Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000050
+BARTON,Clarence Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000050
+BARTON,Cleveland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000060
+BARTON,Cleveland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000060
+BARTON,Comanche Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000070
+BARTON,Comanche Township,Commissioner of Insurance,,Republican,"Selzer, Ken",130,000070
+BARTON,Eureka Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000080
+BARTON,Eureka Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000080
+BARTON,Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000090
+BARTON,Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000090
+BARTON,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000100
+BARTON,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",87,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",127,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",117,000120
+BARTON,Great Bend City Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",253,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",64,000130
+BARTON,Great Bend City Ward 1 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",217,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",124,000140
+BARTON,Great Bend City Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",341,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",125,000150
+BARTON,Great Bend City Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",349,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",140,000160
+BARTON,Great Bend City Ward 2 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",429,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000170
+BARTON,Great Bend City Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",230,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",113,000180
+BARTON,Great Bend City Ward 3 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",238,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",123,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",296,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000200
+BARTON,Great Bend City Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,000210
+BARTON,Great Bend City Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",93,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",36,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022F
+BARTON,Great Bend Township Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",96,00023A
+BARTON,Great Bend Township Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",368,00023A
+BARTON,Great Bend Township Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,00023B
+BARTON,Great Bend Township Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",62,00023B
+BARTON,Great Bend Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00023C
+BARTON,Great Bend Township,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00023C
+BARTON,Hoisington Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000240
+BARTON,Hoisington Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",124,000240
+BARTON,Hoisington Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,000250
+BARTON,Hoisington Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",149,000250
+BARTON,Hoisington Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000260
+BARTON,Hoisington Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",152,000260
+BARTON,Hoisington Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,00027A
+BARTON,Hoisington Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",113,00027A
+BARTON,Hoisington Ward 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00027B
+BARTON,Hoisington Ward 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00027B
+BARTON,Independent Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,000280
+BARTON,Independent Township,Commissioner of Insurance,,Republican,"Selzer, Ken",198,000280
+BARTON,Lakin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",184,000290
+BARTON,Lakin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",608,000290
+BARTON,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000300
+BARTON,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",83,000300
+BARTON,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000310
+BARTON,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000310
+BARTON,North Homestead Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000320
+BARTON,North Homestead Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000320
+BARTON,Pawnee Rock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,000330
+BARTON,Pawnee Rock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",98,000330
+BARTON,South Bend Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000340
+BARTON,South Bend Township,Commissioner of Insurance,,Republican,"Selzer, Ken",172,000340
+BARTON,South Homestead Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000350
+BARTON,South Homestead Township,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000350
+BARTON,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000360
+BARTON,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000360
+BARTON,Walnut Township Albert,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000370
+BARTON,Walnut Township Albert,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000370
+BARTON,Walnut Township Olmitz,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000380
+BARTON,Walnut Township Olmitz,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000380
+BARTON,Wheatland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000390
+BARTON,Wheatland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000390
+BARTON,Hoisington Landfill,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+BARTON,Hoisington Landfill,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+BARTON,Albion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000010
+BARTON,Albion Township,Secretary of State,,Republican,"Kobach, Kris",18,000010
+BARTON,Beaver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000020
+BARTON,Beaver Township,Secretary of State,,Republican,"Kobach, Kris",32,000020
+BARTON,Buffalo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000030
+BARTON,Buffalo Township,Secretary of State,,Republican,"Kobach, Kris",135,000030
+BARTON,Cheyenne Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000040
+BARTON,Cheyenne Township,Secretary of State,,Republican,"Kobach, Kris",74,000040
+BARTON,Clarence Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000050
+BARTON,Clarence Township,Secretary of State,,Republican,"Kobach, Kris",45,000050
+BARTON,Cleveland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000060
+BARTON,Cleveland Township,Secretary of State,,Republican,"Kobach, Kris",17,000060
+BARTON,Comanche Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000070
+BARTON,Comanche Township,Secretary of State,,Republican,"Kobach, Kris",128,000070
+BARTON,Eureka Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000080
+BARTON,Eureka Township,Secretary of State,,Republican,"Kobach, Kris",31,000080
+BARTON,Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000090
+BARTON,Fairview Township,Secretary of State,,Republican,"Kobach, Kris",29,000090
+BARTON,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000100
+BARTON,Grant Township,Secretary of State,,Republican,"Kobach, Kris",19,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",82,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",138,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Secretary of State,,Republican,"Kobach, Kris",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",115,000120
+BARTON,Great Bend City Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",263,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,000130
+BARTON,Great Bend City Ward 1 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",217,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",130,000140
+BARTON,Great Bend City Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",349,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",140,000150
+BARTON,Great Bend City Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",343,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",144,000160
+BARTON,Great Bend City Ward 2 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",444,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",84,000170
+BARTON,Great Bend City Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",230,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",119,000180
+BARTON,Great Bend City Ward 3 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",242,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",321,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000200
+BARTON,Great Bend City Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",137,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000210
+BARTON,Great Bend City Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",94,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",44,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Secretary of State,,Republican,"Kobach, Kris",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Secretary of State,,Republican,"Kobach, Kris",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Secretary of State,,Republican,"Kobach, Kris",0,00022F
+BARTON,Great Bend Township Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,00023A
+BARTON,Great Bend Township Part A,Secretary of State,,Republican,"Kobach, Kris",369,00023A
+BARTON,Great Bend Township Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,00023B
+BARTON,Great Bend Township Part B,Secretary of State,,Republican,"Kobach, Kris",66,00023B
+BARTON,Great Bend Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00023C
+BARTON,Great Bend Township,Secretary of State,,Republican,"Kobach, Kris",0,00023C
+BARTON,Hoisington Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,000240
+BARTON,Hoisington Ward 1,Secretary of State,,Republican,"Kobach, Kris",142,000240
+BARTON,Hoisington Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000250
+BARTON,Hoisington Ward 2,Secretary of State,,Republican,"Kobach, Kris",167,000250
+BARTON,Hoisington Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000260
+BARTON,Hoisington Ward 3,Secretary of State,,Republican,"Kobach, Kris",154,000260
+BARTON,Hoisington Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,00027A
+BARTON,Hoisington Ward 4,Secretary of State,,Republican,"Kobach, Kris",120,00027A
+BARTON,Hoisington Ward 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00027B
+BARTON,Hoisington Ward 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00027B
+BARTON,Independent Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,000280
+BARTON,Independent Township,Secretary of State,,Republican,"Kobach, Kris",223,000280
+BARTON,Lakin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",198,000290
+BARTON,Lakin Township,Secretary of State,,Republican,"Kobach, Kris",638,000290
+BARTON,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000300
+BARTON,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",85,000300
+BARTON,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000310
+BARTON,Logan Township,Secretary of State,,Republican,"Kobach, Kris",55,000310
+BARTON,North Homestead Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000320
+BARTON,North Homestead Township,Secretary of State,,Republican,"Kobach, Kris",34,000320
+BARTON,Pawnee Rock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000330
+BARTON,Pawnee Rock Township,Secretary of State,,Republican,"Kobach, Kris",97,000330
+BARTON,South Bend Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,000340
+BARTON,South Bend Township,Secretary of State,,Republican,"Kobach, Kris",174,000340
+BARTON,South Homestead Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000350
+BARTON,South Homestead Township,Secretary of State,,Republican,"Kobach, Kris",109,000350
+BARTON,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000360
+BARTON,Union Township,Secretary of State,,Republican,"Kobach, Kris",35,000360
+BARTON,Walnut Township Albert,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000370
+BARTON,Walnut Township Albert,Secretary of State,,Republican,"Kobach, Kris",59,000370
+BARTON,Walnut Township Olmitz,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000380
+BARTON,Walnut Township Olmitz,Secretary of State,,Republican,"Kobach, Kris",41,000380
+BARTON,Wheatland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000390
+BARTON,Wheatland Township,Secretary of State,,Republican,"Kobach, Kris",22,000390
+BARTON,Hoisington Landfill,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+BARTON,Hoisington Landfill,Secretary of State,,Republican,"Kobach, Kris",0,900010
+BARTON,Albion Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+BARTON,Albion Township,State Treasurer,,Republican,"Estes, Ron",18,000010
+BARTON,Beaver Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000020
+BARTON,Beaver Township,State Treasurer,,Republican,"Estes, Ron",27,000020
+BARTON,Buffalo Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000030
+BARTON,Buffalo Township,State Treasurer,,Republican,"Estes, Ron",143,000030
+BARTON,Cheyenne Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000040
+BARTON,Cheyenne Township,State Treasurer,,Republican,"Estes, Ron",79,000040
+BARTON,Clarence Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000050
+BARTON,Clarence Township,State Treasurer,,Republican,"Estes, Ron",44,000050
+BARTON,Cleveland Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000060
+BARTON,Cleveland Township,State Treasurer,,Republican,"Estes, Ron",17,000060
+BARTON,Comanche Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000070
+BARTON,Comanche Township,State Treasurer,,Republican,"Estes, Ron",143,000070
+BARTON,Eureka Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000080
+BARTON,Eureka Township,State Treasurer,,Republican,"Estes, Ron",32,000080
+BARTON,Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000090
+BARTON,Fairview Township,State Treasurer,,Republican,"Estes, Ron",30,000090
+BARTON,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000100
+BARTON,Grant Township,State Treasurer,,Republican,"Estes, Ron",20,000100
+BARTON,Great Bend City Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",71,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",144,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,State Treasurer,,Democratic,"Alldritt, Carmen",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,State Treasurer,,Republican,"Estes, Ron",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",80,000120
+BARTON,Great Bend City Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",289,000120
+BARTON,Great Bend City Ward 1 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",49,000130
+BARTON,Great Bend City Ward 1 Precinct 3,State Treasurer,,Republican,"Estes, Ron",235,000130
+BARTON,Great Bend City Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",96,000140
+BARTON,Great Bend City Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",379,000140
+BARTON,Great Bend City Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",88,000150
+BARTON,Great Bend City Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",395,000150
+BARTON,Great Bend City Ward 2 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",94,000160
+BARTON,Great Bend City Ward 2 Precinct 3,State Treasurer,,Republican,"Estes, Ron",488,000160
+BARTON,Great Bend City Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",50,000170
+BARTON,Great Bend City Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",263,000170
+BARTON,Great Bend City Ward 3 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",79,000180
+BARTON,Great Bend City Ward 3 Precinct 2,State Treasurer,,Republican,"Estes, Ron",277,000180
+BARTON,Great Bend City Ward 3 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",79,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,State Treasurer,,Republican,"Estes, Ron",347,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",60,000200
+BARTON,Great Bend City Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",144,000200
+BARTON,Great Bend City Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",44,000210
+BARTON,Great Bend City Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",109,000210
+BARTON,Great Bend City Ward 4 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",16,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,State Treasurer,,Republican,"Estes, Ron",40,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,State Treasurer,,Republican,"Estes, Ron",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,State Treasurer,,Republican,"Estes, Ron",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,State Treasurer,,Republican,"Estes, Ron",0,00022F
+BARTON,Great Bend Township Part A,State Treasurer,,Democratic,"Alldritt, Carmen",70,00023A
+BARTON,Great Bend Township Part A,State Treasurer,,Republican,"Estes, Ron",401,00023A
+BARTON,Great Bend Township Part B,State Treasurer,,Democratic,"Alldritt, Carmen",12,00023B
+BARTON,Great Bend Township Part B,State Treasurer,,Republican,"Estes, Ron",68,00023B
+BARTON,Great Bend Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,00023C
+BARTON,Great Bend Township,State Treasurer,,Republican,"Estes, Ron",0,00023C
+BARTON,Hoisington Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",55,000240
+BARTON,Hoisington Ward 1,State Treasurer,,Republican,"Estes, Ron",147,000240
+BARTON,Hoisington Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",39,000250
+BARTON,Hoisington Ward 2,State Treasurer,,Republican,"Estes, Ron",183,000250
+BARTON,Hoisington Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",32,000260
+BARTON,Hoisington Ward 3,State Treasurer,,Republican,"Estes, Ron",164,000260
+BARTON,Hoisington Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",30,00027A
+BARTON,Hoisington Ward 4,State Treasurer,,Republican,"Estes, Ron",133,00027A
+BARTON,Hoisington Ward 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00027B
+BARTON,Hoisington Ward 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00027B
+BARTON,Independent Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000280
+BARTON,Independent Township,State Treasurer,,Republican,"Estes, Ron",228,000280
+BARTON,Lakin Township,State Treasurer,,Democratic,"Alldritt, Carmen",130,000290
+BARTON,Lakin Township,State Treasurer,,Republican,"Estes, Ron",686,000290
+BARTON,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000300
+BARTON,Liberty Township,State Treasurer,,Republican,"Estes, Ron",93,000300
+BARTON,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000310
+BARTON,Logan Township,State Treasurer,,Republican,"Estes, Ron",62,000310
+BARTON,North Homestead Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000320
+BARTON,North Homestead Township,State Treasurer,,Republican,"Estes, Ron",36,000320
+BARTON,Pawnee Rock Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000330
+BARTON,Pawnee Rock Township,State Treasurer,,Republican,"Estes, Ron",108,000330
+BARTON,South Bend Township,State Treasurer,,Democratic,"Alldritt, Carmen",40,000340
+BARTON,South Bend Township,State Treasurer,,Republican,"Estes, Ron",190,000340
+BARTON,South Homestead Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000350
+BARTON,South Homestead Township,State Treasurer,,Republican,"Estes, Ron",106,000350
+BARTON,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000360
+BARTON,Union Township,State Treasurer,,Republican,"Estes, Ron",37,000360
+BARTON,Walnut Township Albert,State Treasurer,,Democratic,"Alldritt, Carmen",14,000370
+BARTON,Walnut Township Albert,State Treasurer,,Republican,"Estes, Ron",61,000370
+BARTON,Walnut Township Olmitz,State Treasurer,,Democratic,"Alldritt, Carmen",16,000380
+BARTON,Walnut Township Olmitz,State Treasurer,,Republican,"Estes, Ron",46,000380
+BARTON,Wheatland Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000390
+BARTON,Wheatland Township,State Treasurer,,Republican,"Estes, Ron",24,000390
+BARTON,Hoisington Landfill,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+BARTON,Hoisington Landfill,State Treasurer,,Republican,"Estes, Ron",0,900010
+BARTON,Albion Township,United States Senate,,independent,"Orman, Greg",0,000010
+BARTON,Albion Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+BARTON,Albion Township,United States Senate,,Republican,"Roberts, Pat",20,000010
+BARTON,Beaver Township,United States Senate,,independent,"Orman, Greg",11,000020
+BARTON,Beaver Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+BARTON,Beaver Township,United States Senate,,Republican,"Roberts, Pat",27,000020
+BARTON,Buffalo Township,United States Senate,,independent,"Orman, Greg",48,000030
+BARTON,Buffalo Township,United States Senate,,Libertarian,"Batson, Randall",8,000030
+BARTON,Buffalo Township,United States Senate,,Republican,"Roberts, Pat",122,000030
+BARTON,Cheyenne Township,United States Senate,,independent,"Orman, Greg",9,000040
+BARTON,Cheyenne Township,United States Senate,,Libertarian,"Batson, Randall",6,000040
+BARTON,Cheyenne Township,United States Senate,,Republican,"Roberts, Pat",80,000040
+BARTON,Clarence Township,United States Senate,,independent,"Orman, Greg",13,000050
+BARTON,Clarence Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+BARTON,Clarence Township,United States Senate,,Republican,"Roberts, Pat",43,000050
+BARTON,Cleveland Township,United States Senate,,independent,"Orman, Greg",2,000060
+BARTON,Cleveland Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+BARTON,Cleveland Township,United States Senate,,Republican,"Roberts, Pat",16,000060
+BARTON,Comanche Township,United States Senate,,independent,"Orman, Greg",39,000070
+BARTON,Comanche Township,United States Senate,,Libertarian,"Batson, Randall",5,000070
+BARTON,Comanche Township,United States Senate,,Republican,"Roberts, Pat",127,000070
+BARTON,Eureka Township,United States Senate,,independent,"Orman, Greg",5,000080
+BARTON,Eureka Township,United States Senate,,Libertarian,"Batson, Randall",2,000080
+BARTON,Eureka Township,United States Senate,,Republican,"Roberts, Pat",32,000080
+BARTON,Fairview Township,United States Senate,,independent,"Orman, Greg",7,000090
+BARTON,Fairview Township,United States Senate,,Libertarian,"Batson, Randall",4,000090
+BARTON,Fairview Township,United States Senate,,Republican,"Roberts, Pat",28,000090
+BARTON,Grant Township,United States Senate,,independent,"Orman, Greg",12,000100
+BARTON,Grant Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+BARTON,Grant Township,United States Senate,,Republican,"Roberts, Pat",14,000100
+BARTON,Great Bend City Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",97,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",11,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",114,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States Senate,,independent,"Orman, Greg",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States Senate,,Libertarian,"Batson, Randall",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States Senate,,Republican,"Roberts, Pat",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",137,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",13,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",226,000120
+BARTON,Great Bend City Ward 1 Precinct 3,United States Senate,,independent,"Orman, Greg",90,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",22,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States Senate,,Republican,"Roberts, Pat",178,000130
+BARTON,Great Bend City Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",148,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",17,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",321,000140
+BARTON,Great Bend City Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",142,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",22,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",323,000150
+BARTON,Great Bend City Ward 2 Precinct 3,United States Senate,,independent,"Orman, Greg",159,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",9,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States Senate,,Republican,"Roberts, Pat",425,000160
+BARTON,Great Bend City Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",92,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",12,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",211,000170
+BARTON,Great Bend City Ward 3 Precinct 2,United States Senate,,independent,"Orman, Greg",133,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",21,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States Senate,,Republican,"Roberts, Pat",211,000180
+BARTON,Great Bend City Ward 3 Precinct 3,United States Senate,,independent,"Orman, Greg",142,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",17,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States Senate,,Republican,"Roberts, Pat",273,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States Senate,,independent,"Orman, Greg",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",71,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",21,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",114,000200
+BARTON,Great Bend City Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",57,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",9,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",87,000210
+BARTON,Great Bend City Ward 4 Precinct 3,United States Senate,,independent,"Orman, Greg",15,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",6,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States Senate,,Republican,"Roberts, Pat",37,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States Senate,,independent,"Orman, Greg",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States Senate,,independent,"Orman, Greg",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States Senate,,independent,"Orman, Greg",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States Senate,,Libertarian,"Batson, Randall",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States Senate,,Republican,"Roberts, Pat",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States Senate,,independent,"Orman, Greg",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States Senate,,Libertarian,"Batson, Randall",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States Senate,,Republican,"Roberts, Pat",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States Senate,,independent,"Orman, Greg",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States Senate,,Libertarian,"Batson, Randall",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States Senate,,Republican,"Roberts, Pat",0,00022F
+BARTON,Great Bend Township Part A,United States Senate,,independent,"Orman, Greg",116,00023A
+BARTON,Great Bend Township Part A,United States Senate,,Libertarian,"Batson, Randall",18,00023A
+BARTON,Great Bend Township Part A,United States Senate,,Republican,"Roberts, Pat",339,00023A
+BARTON,Great Bend Township Part B,United States Senate,,independent,"Orman, Greg",17,00023B
+BARTON,Great Bend Township Part B,United States Senate,,Libertarian,"Batson, Randall",3,00023B
+BARTON,Great Bend Township Part B,United States Senate,,Republican,"Roberts, Pat",61,00023B
+BARTON,Great Bend Township,United States Senate,,independent,"Orman, Greg",0,00023C
+BARTON,Great Bend Township,United States Senate,,Libertarian,"Batson, Randall",0,00023C
+BARTON,Great Bend Township,United States Senate,,Republican,"Roberts, Pat",0,00023C
+BARTON,Hoisington Ward 1,United States Senate,,independent,"Orman, Greg",67,000240
+BARTON,Hoisington Ward 1,United States Senate,,Libertarian,"Batson, Randall",16,000240
+BARTON,Hoisington Ward 1,United States Senate,,Republican,"Roberts, Pat",122,000240
+BARTON,Hoisington Ward 2,United States Senate,,independent,"Orman, Greg",62,000250
+BARTON,Hoisington Ward 2,United States Senate,,Libertarian,"Batson, Randall",7,000250
+BARTON,Hoisington Ward 2,United States Senate,,Republican,"Roberts, Pat",154,000250
+BARTON,Hoisington Ward 3,United States Senate,,independent,"Orman, Greg",60,000260
+BARTON,Hoisington Ward 3,United States Senate,,Libertarian,"Batson, Randall",10,000260
+BARTON,Hoisington Ward 3,United States Senate,,Republican,"Roberts, Pat",132,000260
+BARTON,Hoisington Ward 4,United States Senate,,independent,"Orman, Greg",49,00027A
+BARTON,Hoisington Ward 4,United States Senate,,Libertarian,"Batson, Randall",8,00027A
+BARTON,Hoisington Ward 4,United States Senate,,Republican,"Roberts, Pat",112,00027A
+BARTON,Hoisington Ward 4 Exclave,United States Senate,,independent,"Orman, Greg",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00027B
+BARTON,Independent Township,United States Senate,,independent,"Orman, Greg",47,000280
+BARTON,Independent Township,United States Senate,,Libertarian,"Batson, Randall",23,000280
+BARTON,Independent Township,United States Senate,,Republican,"Roberts, Pat",205,000280
+BARTON,Lakin Township,United States Senate,,independent,"Orman, Greg",237,000290
+BARTON,Lakin Township,United States Senate,,Libertarian,"Batson, Randall",26,000290
+BARTON,Lakin Township,United States Senate,,Republican,"Roberts, Pat",584,000290
+BARTON,Liberty Township,United States Senate,,independent,"Orman, Greg",25,000300
+BARTON,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",2,000300
+BARTON,Liberty Township,United States Senate,,Republican,"Roberts, Pat",77,000300
+BARTON,Logan Township,United States Senate,,independent,"Orman, Greg",10,000310
+BARTON,Logan Township,United States Senate,,Libertarian,"Batson, Randall",2,000310
+BARTON,Logan Township,United States Senate,,Republican,"Roberts, Pat",58,000310
+BARTON,North Homestead Township,United States Senate,,independent,"Orman, Greg",12,000320
+BARTON,North Homestead Township,United States Senate,,Libertarian,"Batson, Randall",1,000320
+BARTON,North Homestead Township,United States Senate,,Republican,"Roberts, Pat",37,000320
+BARTON,Pawnee Rock Township,United States Senate,,independent,"Orman, Greg",37,000330
+BARTON,Pawnee Rock Township,United States Senate,,Libertarian,"Batson, Randall",6,000330
+BARTON,Pawnee Rock Township,United States Senate,,Republican,"Roberts, Pat",92,000330
+BARTON,South Bend Township,United States Senate,,independent,"Orman, Greg",57,000340
+BARTON,South Bend Township,United States Senate,,Libertarian,"Batson, Randall",10,000340
+BARTON,South Bend Township,United States Senate,,Republican,"Roberts, Pat",163,000340
+BARTON,South Homestead Township,United States Senate,,independent,"Orman, Greg",33,000350
+BARTON,South Homestead Township,United States Senate,,Libertarian,"Batson, Randall",3,000350
+BARTON,South Homestead Township,United States Senate,,Republican,"Roberts, Pat",94,000350
+BARTON,Union Township,United States Senate,,independent,"Orman, Greg",9,000360
+BARTON,Union Township,United States Senate,,Libertarian,"Batson, Randall",4,000360
+BARTON,Union Township,United States Senate,,Republican,"Roberts, Pat",28,000360
+BARTON,Walnut Township Albert,United States Senate,,independent,"Orman, Greg",24,000370
+BARTON,Walnut Township Albert,United States Senate,,Libertarian,"Batson, Randall",3,000370
+BARTON,Walnut Township Albert,United States Senate,,Republican,"Roberts, Pat",50,000370
+BARTON,Walnut Township Olmitz,United States Senate,,independent,"Orman, Greg",20,000380
+BARTON,Walnut Township Olmitz,United States Senate,,Libertarian,"Batson, Randall",4,000380
+BARTON,Walnut Township Olmitz,United States Senate,,Republican,"Roberts, Pat",44,000380
+BARTON,Wheatland Township,United States Senate,,independent,"Orman, Greg",2,000390
+BARTON,Wheatland Township,United States Senate,,Libertarian,"Batson, Randall",1,000390
+BARTON,Wheatland Township,United States Senate,,Republican,"Roberts, Pat",22,000390
+BARTON,Hoisington Landfill,United States Senate,,independent,"Orman, Greg",0,900010
+BARTON,Hoisington Landfill,United States Senate,,Libertarian,"Batson, Randall",0,900010
+BARTON,Hoisington Landfill,United States Senate,,Republican,"Roberts, Pat",0,900010

--- a/2014/20141104__ks__general__bourbon__precinct.csv
+++ b/2014/20141104__ks__general__bourbon__precinct.csv
@@ -1,360 +1,569 @@
-county,precinct,office,district,party,candidate,votes
-Bourbon,Fort Scott Ward 1,U.S. Senate,,R,Pat Roberts,162
-Bourbon,Fort Scott Ward 2,U.S. Senate,,R,Pat Roberts,167
-Bourbon,Fort Scott Ward 3,U.S. Senate,,R,Pat Roberts,71
-Bourbon,Fort Scott Ward 4,U.S. Senate,,R,Pat Roberts,182
-Bourbon,Fort Scott Ward 5,U.S. Senate,,R,Pat Roberts,242
-Bourbon,Fort Scott Ward 6,U.S. Senate,,R,Pat Roberts,308
-Bourbon,Fort Scott Ward 7,U.S. Senate,,R,Pat Roberts,240
-Bourbon,Drywood Township,U.S. Senate,,R,Pat Roberts,124
-Bourbon,Franklin Township,U.S. Senate,,R,Pat Roberts,79
-Bourbon,Freedom Township,U.S. Senate,,R,Pat Roberts,106
-Bourbon,Marion Township,U.S. Senate,,R,Pat Roberts,267
-Bourbon,Marmaton Township,U.S. Senate,,R,Pat Roberts,198
-Bourbon,Mill Creek Township,U.S. Senate,,R,Pat Roberts,107
-Bourbon,North Scott Township,U.S. Senate,,R,Pat Roberts,188
-Bourbon,Osage Township,U.S. Senate,,R,Pat Roberts,94
-Bourbon,Pawnee Township,U.S. Senate,,R,Pat Roberts,84
-Bourbon,South Scott Township,U.S. Senate,,R,Pat Roberts,483
-Bourbon,Timberhill Township,U.S. Senate,,R,Pat Roberts,58
-Bourbon,Walnut Twp,U.S. Senate,,R,Pat Roberts,30
-Bourbon,Fort Scott Ward 1,U.S. Senate,,I ,Greg Orman,114
-Bourbon,Fort Scott Ward 2,U.S. Senate,,I ,Greg Orman,98
-Bourbon,Fort Scott Ward 3,U.S. Senate,,I ,Greg Orman,38
-Bourbon,Fort Scott Ward 4,U.S. Senate,,I ,Greg Orman,107
-Bourbon,Fort Scott Ward 5,U.S. Senate,,I ,Greg Orman,120
-Bourbon,Fort Scott Ward 6,U.S. Senate,,I ,Greg Orman,143
-Bourbon,Fort Scott Ward 7,U.S. Senate,,I ,Greg Orman,141
-Bourbon,Drywood Township,U.S. Senate,,I ,Greg Orman,33
-Bourbon,Franklin Township,U.S. Senate,,I ,Greg Orman,33
-Bourbon,Freedom Township,U.S. Senate,,I ,Greg Orman,40
-Bourbon,Marion Township,U.S. Senate,,I ,Greg Orman,114
-Bourbon,Marmaton Township,U.S. Senate,,I ,Greg Orman,83
-Bourbon,Mill Creek Township,U.S. Senate,,I ,Greg Orman,48
-Bourbon,North Scott Township,U.S. Senate,,I ,Greg Orman,96
-Bourbon,Osage Township,U.S. Senate,,I ,Greg Orman,35
-Bourbon,Pawnee Township,U.S. Senate,,I ,Greg Orman,26
-Bourbon,South Scott Township,U.S. Senate,,I ,Greg Orman,159
-Bourbon,Timberhill Township,U.S. Senate,,I ,Greg Orman,22
-Bourbon,Walnut Twp,U.S. Senate,,I ,Greg Orman,6
-Bourbon,Fort Scott Ward 1,U.S. Senate,,L,Randall Batson,24
-Bourbon,Fort Scott Ward 2,U.S. Senate,,L,Randall Batson,42
-Bourbon,Fort Scott Ward 3,U.S. Senate,,L,Randall Batson,9
-Bourbon,Fort Scott Ward 4,U.S. Senate,,L,Randall Batson,20
-Bourbon,Fort Scott Ward 5,U.S. Senate,,L,Randall Batson,16
-Bourbon,Fort Scott Ward 6,U.S. Senate,,L,Randall Batson,25
-Bourbon,Fort Scott Ward 7,U.S. Senate,,L,Randall Batson,31
-Bourbon,Drywood Township,U.S. Senate,,L,Randall Batson,7
-Bourbon,Franklin Township,U.S. Senate,,L,Randall Batson,6
-Bourbon,Freedom Township,U.S. Senate,,L,Randall Batson,9
-Bourbon,Marion Township,U.S. Senate,,L,Randall Batson,26
-Bourbon,Marmaton Township,U.S. Senate,,L,Randall Batson,16
-Bourbon,Mill Creek Township,U.S. Senate,,L,Randall Batson,11
-Bourbon,North Scott Township,U.S. Senate,,L,Randall Batson,21
-Bourbon,Osage Township,U.S. Senate,,L,Randall Batson,8
-Bourbon,Pawnee Township,U.S. Senate,,L,Randall Batson,5
-Bourbon,South Scott Township,U.S. Senate,,L,Randall Batson,32
-Bourbon,Timberhill Township,U.S. Senate,,L,Randall Batson,3
-Bourbon,Walnut Twp,U.S. Senate,,L,Randall Batson,1
-Bourbon,Fort Scott Ward 1,U.S. House,2,D,Margie Wakefield,104
-Bourbon,Fort Scott Ward 2,U.S. House,2,D,Margie Wakefield,105
-Bourbon,Fort Scott Ward 3,U.S. House,2,D,Margie Wakefield,34
-Bourbon,Fort Scott Ward 4,U.S. House,2,D,Margie Wakefield,94
-Bourbon,Fort Scott Ward 5,U.S. House,2,D,Margie Wakefield,91
-Bourbon,Fort Scott Ward 6,U.S. House,2,D,Margie Wakefield,106
-Bourbon,Fort Scott Ward 7,U.S. House,2,D,Margie Wakefield,119
-Bourbon,Drywood Township,U.S. House,2,D,Margie Wakefield,23
-Bourbon,Franklin Township,U.S. House,2,D,Margie Wakefield,26
-Bourbon,Freedom Township,U.S. House,2,D,Margie Wakefield,28
-Bourbon,Marion Township,U.S. House,2,D,Margie Wakefield,87
-Bourbon,Marmaton Township,U.S. House,2,D,Margie Wakefield,66
-Bourbon,Mill Creek Township,U.S. House,2,D,Margie Wakefield,41
-Bourbon,North Scott Township,U.S. House,2,D,Margie Wakefield,82
-Bourbon,Osage Township,U.S. House,2,D,Margie Wakefield,30
-Bourbon,Pawnee Township,U.S. House,2,D,Margie Wakefield,26
-Bourbon,South Scott Township,U.S. House,2,D,Margie Wakefield,138
-Bourbon,Timberhill Township,U.S. House,2,D,Margie Wakefield,19
-Bourbon,Walnut Twp,U.S. House,2,D,Margie Wakefield,2
-Bourbon,Fort Scott Ward 1,U.S. House,2,R,Lynn Jenkins,179
-Bourbon,Fort Scott Ward 2,U.S. House,2,R,Lynn Jenkins,188
-Bourbon,Fort Scott Ward 3,U.S. House,2,R,Lynn Jenkins,72
-Bourbon,Fort Scott Ward 4,U.S. House,2,R,Lynn Jenkins,208
-Bourbon,Fort Scott Ward 5,U.S. House,2,R,Lynn Jenkins,273
-Bourbon,Fort Scott Ward 6,U.S. House,2,R,Lynn Jenkins,360
-Bourbon,Fort Scott Ward 7,U.S. House,2,R,Lynn Jenkins,285
-Bourbon,Drywood Township,U.S. House,2,R,Lynn Jenkins,133
-Bourbon,Franklin Township,U.S. House,2,R,Lynn Jenkins,90
-Bourbon,Freedom Township,U.S. House,2,R,Lynn Jenkins,116
-Bourbon,Marion Township,U.S. House,2,R,Lynn Jenkins,301
-Bourbon,Marmaton Township,U.S. House,2,R,Lynn Jenkins,221
-Bourbon,Mill Creek Township,U.S. House,2,R,Lynn Jenkins,125
-Bourbon,North Scott Township,U.S. House,2,R,Lynn Jenkins,204
-Bourbon,Osage Township,U.S. House,2,R,Lynn Jenkins,101
-Bourbon,Pawnee Township,U.S. House,2,R,Lynn Jenkins,86
-Bourbon,South Scott Township,U.S. House,2,R,Lynn Jenkins,512
-Bourbon,Timberhill Township,U.S. House,2,R,Lynn Jenkins,57
-Bourbon,Walnut Twp,U.S. House,2,R,Lynn Jenkins,31
-Bourbon,Fort Scott Ward 1,U.S. House,2,L,Chris Clemmons,21
-Bourbon,Fort Scott Ward 2,U.S. House,2,L,Chris Clemmons,24
-Bourbon,Fort Scott Ward 3,U.S. House,2,L,Chris Clemmons,9
-Bourbon,Fort Scott Ward 4,U.S. House,2,L,Chris Clemmons,18
-Bourbon,Fort Scott Ward 5,U.S. House,2,L,Chris Clemmons,15
-Bourbon,Fort Scott Ward 6,U.S. House,2,L,Chris Clemmons,18
-Bourbon,Fort Scott Ward 7,U.S. House,2,L,Chris Clemmons,20
-Bourbon,Drywood Township,U.S. House,2,L,Chris Clemmons,6
-Bourbon,Franklin Township,U.S. House,2,L,Chris Clemmons,3
-Bourbon,Freedom Township,U.S. House,2,L,Chris Clemmons,11
-Bourbon,Marion Township,U.S. House,2,L,Chris Clemmons,24
-Bourbon,Marmaton Township,U.S. House,2,L,Chris Clemmons,14
-Bourbon,Mill Creek Township,U.S. House,2,L,Chris Clemmons,3
-Bourbon,North Scott Township,U.S. House,2,L,Chris Clemmons,19
-Bourbon,Osage Township,U.S. House,2,L,Chris Clemmons,8
-Bourbon,Pawnee Township,U.S. House,2,L,Chris Clemmons,6
-Bourbon,South Scott Township,U.S. House,2,L,Chris Clemmons,25
-Bourbon,Timberhill Township,U.S. House,2,L,Chris Clemmons,4
-Bourbon,Walnut Twp,U.S. House,2,L,Chris Clemmons,4
-Bourbon,Fort Scott Ward 1,Governor,,D,Paul Davis,126
-Bourbon,Fort Scott Ward 2,Governor,,D,Paul Davis,145
-Bourbon,Fort Scott Ward 3,Governor,,D,Paul Davis,45
-Bourbon,Fort Scott Ward 4,Governor,,D,Paul Davis,144
-Bourbon,Fort Scott Ward 5,Governor,,D,Paul Davis,144
-Bourbon,Fort Scott Ward 6,Governor,,D,Paul Davis,186
-Bourbon,Fort Scott Ward 7,Governor,,D,Paul Davis,176
-Bourbon,Drywood Township,Governor,,D,Paul Davis,32
-Bourbon,Franklin Township,Governor,,D,Paul Davis,32
-Bourbon,Freedom Township,Governor,,D,Paul Davis,45
-Bourbon,Marion Township,Governor,,D,Paul Davis,132
-Bourbon,Marmaton Township,Governor,,D,Paul Davis,99
-Bourbon,Mill Creek Township,Governor,,D,Paul Davis,59
-Bourbon,North Scott Township,Governor,,D,Paul Davis,130
-Bourbon,Osage Township,Governor,,D,Paul Davis,45
-Bourbon,Pawnee Township,Governor,,D,Paul Davis,43
-Bourbon,South Scott Township,Governor,,D,Paul Davis,224
-Bourbon,Timberhill Township,Governor,,D,Paul Davis,28
-Bourbon,Walnut Twp,Governor,,D,Paul Davis,9
-Bourbon,Fort Scott Ward 1,Governor,,R,Sam Brownback,158
-Bourbon,Fort Scott Ward 2,Governor,,R,Sam Brownback,163
-Bourbon,Fort Scott Ward 3,Governor,,R,Sam Brownback,64
-Bourbon,Fort Scott Ward 4,Governor,,R,Sam Brownback,159
-Bourbon,Fort Scott Ward 5,Governor,,R,Sam Brownback,217
-Bourbon,Fort Scott Ward 6,Governor,,R,Sam Brownback,287
-Bourbon,Fort Scott Ward 7,Governor,,R,Sam Brownback,231
-Bourbon,Drywood Township,Governor,,R,Sam Brownback,123
-Bourbon,Franklin Township,Governor,,R,Sam Brownback,84
-Bourbon,Freedom Township,Governor,,R,Sam Brownback,110
-Bourbon,Marion Township,Governor,,R,Sam Brownback,266
-Bourbon,Marmaton Township,Governor,,R,Sam Brownback,192
-Bourbon,Mill Creek Township,Governor,,R,Sam Brownback,107
-Bourbon,North Scott Township,Governor,,R,Sam Brownback,173
-Bourbon,Osage Township,Governor,,R,Sam Brownback,87
-Bourbon,Pawnee Township,Governor,,R,Sam Brownback,75
-Bourbon,South Scott Township,Governor,,R,Sam Brownback,434
-Bourbon,Timberhill Township,Governor,,R,Sam Brownback,53
-Bourbon,Walnut Twp,Governor,,R,Sam Brownback,27
-Bourbon,Fort Scott Ward 1,Governor,,L,Keen Umbehr,22
-Bourbon,Fort Scott Ward 2,Governor,,L,Keen Umbehr,12
-Bourbon,Fort Scott Ward 3,Governor,,L,Keen Umbehr,9
-Bourbon,Fort Scott Ward 4,Governor,,L,Keen Umbehr,14
-Bourbon,Fort Scott Ward 5,Governor,,L,Keen Umbehr,16
-Bourbon,Fort Scott Ward 6,Governor,,L,Keen Umbehr,12
-Bourbon,Fort Scott Ward 7,Governor,,L,Keen Umbehr,16
-Bourbon,Drywood Township,Governor,,L,Keen Umbehr,5
-Bourbon,Franklin Township,Governor,,L,Keen Umbehr,7
-Bourbon,Freedom Township,Governor,,L,Keen Umbehr,4
-Bourbon,Marion Township,Governor,,L,Keen Umbehr,20
-Bourbon,Marmaton Township,Governor,,L,Keen Umbehr,14
-Bourbon,Mill Creek Township,Governor,,L,Keen Umbehr,6
-Bourbon,North Scott Township,Governor,,L,Keen Umbehr,5
-Bourbon,Osage Township,Governor,,L,Keen Umbehr,7
-Bourbon,Pawnee Township,Governor,,L,Keen Umbehr,2
-Bourbon,South Scott Township,Governor,,L,Keen Umbehr,21
-Bourbon,Timberhill Township,Governor,,L,Keen Umbehr,3
-Bourbon,Walnut Twp,Governor,,L,Keen Umbehr,1
-Bourbon,Fort Scott Ward 1,Secretary of State,,D,Jean Schodorf,118
-Bourbon,Fort Scott Ward 2,Secretary of State,,D,Jean Schodorf,126
-Bourbon,Fort Scott Ward 3,Secretary of State,,D,Jean Schodorf,42
-Bourbon,Fort Scott Ward 4,Secretary of State,,D,Jean Schodorf,115
-Bourbon,Fort Scott Ward 5,Secretary of State,,D,Jean Schodorf,112
-Bourbon,Fort Scott Ward 6,Secretary of State,,D,Jean Schodorf,144
-Bourbon,Fort Scott Ward 7,Secretary of State,,D,Jean Schodorf,146
-Bourbon,Drywood Township,Secretary of State,,D,Jean Schodorf,34
-Bourbon,Franklin Township,Secretary of State,,D,Jean Schodorf,33
-Bourbon,Freedom Township,Secretary of State,,D,Jean Schodorf,41
-Bourbon,Marion Township,Secretary of State,,D,Jean Schodorf,100
-Bourbon,Marmaton Township,Secretary of State,,D,Jean Schodorf,80
-Bourbon,Mill Creek Township,Secretary of State,,D,Jean Schodorf,44
-Bourbon,North Scott Township,Secretary of State,,D,Jean Schodorf,101
-Bourbon,Osage Township,Secretary of State,,D,Jean Schodorf,39
-Bourbon,Pawnee Township,Secretary of State,,D,Jean Schodorf,30
-Bourbon,South Scott Township,Secretary of State,,D,Jean Schodorf,185
-Bourbon,Timberhill Township,Secretary of State,,D,Jean Schodorf,21
-Bourbon,Walnut Twp,Secretary of State,,D,Jean Schodorf,7
-Bourbon,Fort Scott Ward 1,Secretary of State,,R,Kris Kobach,180
-Bourbon,Fort Scott Ward 2,Secretary of State,,R,Kris Kobach,183
-Bourbon,Fort Scott Ward 3,Secretary of State,,R,Kris Kobach,74
-Bourbon,Fort Scott Ward 4,Secretary of State,,R,Kris Kobach,198
-Bourbon,Fort Scott Ward 5,Secretary of State,,R,Kris Kobach,261
-Bourbon,Fort Scott Ward 6,Secretary of State,,R,Kris Kobach,330
-Bourbon,Fort Scott Ward 7,Secretary of State,,R,Kris Kobach,265
-Bourbon,Drywood Township,Secretary of State,,R,Kris Kobach,125
-Bourbon,Franklin Township,Secretary of State,,R,Kris Kobach,83
-Bourbon,Freedom Township,Secretary of State,,R,Kris Kobach,114
-Bourbon,Marion Township,Secretary of State,,R,Kris Kobach,292
-Bourbon,Marmaton Township,Secretary of State,,R,Kris Kobach,218
-Bourbon,Mill Creek Township,Secretary of State,,R,Kris Kobach,122
-Bourbon,North Scott Township,Secretary of State,,R,Kris Kobach,203
-Bourbon,Osage Township,Secretary of State,,R,Kris Kobach,100
-Bourbon,Pawnee Township,Secretary of State,,R,Kris Kobach,88
-Bourbon,South Scott Township,Secretary of State,,R,Kris Kobach,480
-Bourbon,Timberhill Township,Secretary of State,,R,Kris Kobach,56
-Bourbon,Walnut Twp,Secretary of State,,R,Kris Kobach,30
-Bourbon,Fort Scott Ward 1,Attorney General,,D,A J Kotich,116
-Bourbon,Fort Scott Ward 2,Attorney General,,D,A J Kotich,116
-Bourbon,Fort Scott Ward 3,Attorney General,,D,A J Kotich,36
-Bourbon,Fort Scott Ward 4,Attorney General,,D,A J Kotich,103
-Bourbon,Fort Scott Ward 5,Attorney General,,D,A J Kotich,102
-Bourbon,Fort Scott Ward 6,Attorney General,,D,A J Kotich,125
-Bourbon,Fort Scott Ward 7,Attorney General,,D,A J Kotich,133
-Bourbon,Drywood Township,Attorney General,,D,A J Kotich,23
-Bourbon,Franklin Township,Attorney General,,D,A J Kotich,29
-Bourbon,Freedom Township,Attorney General,,D,A J Kotich,41
-Bourbon,Marion Township,Attorney General,,D,A J Kotich,85
-Bourbon,Marmaton Township,Attorney General,,D,A J Kotich,68
-Bourbon,Mill Creek Township,Attorney General,,D,A J Kotich,40
-Bourbon,North Scott Township,Attorney General,,D,A J Kotich,101
-Bourbon,Osage Township,Attorney General,,D,A J Kotich,36
-Bourbon,Pawnee Township,Attorney General,,D,A J Kotich,31
-Bourbon,South Scott Township,Attorney General,,D,A J Kotich,148
-Bourbon,Timberhill Township,Attorney General,,D,A J Kotich,23
-Bourbon,Walnut Twp,Attorney General,,D,A J Kotich,5
-Bourbon,Fort Scott Ward 1,Attorney General,,R,Derek Schmidt,180
-Bourbon,Fort Scott Ward 2,Attorney General,,R,Derek Schmidt,193
-Bourbon,Fort Scott Ward 3,Attorney General,,R,Derek Schmidt,81
-Bourbon,Fort Scott Ward 4,Attorney General,,R,Derek Schmidt,209
-Bourbon,Fort Scott Ward 5,Attorney General,,R,Derek Schmidt,269
-Bourbon,Fort Scott Ward 6,Attorney General,,R,Derek Schmidt,342
-Bourbon,Fort Scott Ward 7,Attorney General,,R,Derek Schmidt,275
-Bourbon,Drywood Township,Attorney General,,R,Derek Schmidt,134
-Bourbon,Franklin Township,Attorney General,,R,Derek Schmidt,84
-Bourbon,Freedom Township,Attorney General,,R,Derek Schmidt,116
-Bourbon,Marion Township,Attorney General,,R,Derek Schmidt,308
-Bourbon,Marmaton Township,Attorney General,,R,Derek Schmidt,230
-Bourbon,Mill Creek Township,Attorney General,,R,Derek Schmidt,125
-Bourbon,North Scott Township,Attorney General,,R,Derek Schmidt,195
-Bourbon,Osage Township,Attorney General,,R,Derek Schmidt,102
-Bourbon,Pawnee Township,Attorney General,,R,Derek Schmidt,87
-Bourbon,South Scott Township,Attorney General,,R,Derek Schmidt,514
-Bourbon,Timberhill Township,Attorney General,,R,Derek Schmidt,56
-Bourbon,Walnut Twp,Attorney General,,R,Derek Schmidt,32
-Bourbon,Fort Scott Ward 1,State Treasurer,,D,Carmen Alldritt,119
-Bourbon,Fort Scott Ward 2,State Treasurer,,D,Carmen Alldritt,121
-Bourbon,Fort Scott Ward 3,State Treasurer,,D,Carmen Alldritt,37
-Bourbon,Fort Scott Ward 4,State Treasurer,,D,Carmen Alldritt,104
-Bourbon,Fort Scott Ward 5,State Treasurer,,D,Carmen Alldritt,109
-Bourbon,Fort Scott Ward 6,State Treasurer,,D,Carmen Alldritt,123
-Bourbon,Fort Scott Ward 7,State Treasurer,,D,Carmen Alldritt,139
-Bourbon,Drywood Township,State Treasurer,,D,Carmen Alldritt,25
-Bourbon,Franklin Township,State Treasurer,,D,Carmen Alldritt,29
-Bourbon,Freedom Township,State Treasurer,,D,Carmen Alldritt,41
-Bourbon,Marion Township,State Treasurer,,D,Carmen Alldritt,90
-Bourbon,Marmaton Township,State Treasurer,,D,Carmen Alldritt,72
-Bourbon,Mill Creek Township,State Treasurer,,D,Carmen Alldritt,40
-Bourbon,North Scott Township,State Treasurer,,D,Carmen Alldritt,105
-Bourbon,Osage Township,State Treasurer,,D,Carmen Alldritt,38
-Bourbon,Pawnee Township,State Treasurer,,D,Carmen Alldritt,27
-Bourbon,South Scott Township,State Treasurer,,D,Carmen Alldritt,151
-Bourbon,Timberhill Township,State Treasurer,,D,Carmen Alldritt,23
-Bourbon,Walnut Twp,State Treasurer,,D,Carmen Alldritt,4
-Bourbon,Fort Scott Ward 1,State Treasurer,,R,Ron Estes,174
-Bourbon,Fort Scott Ward 2,State Treasurer,,R,Ron Estes,186
-Bourbon,Fort Scott Ward 3,State Treasurer,,R,Ron Estes,79
-Bourbon,Fort Scott Ward 4,State Treasurer,,R,Ron Estes,209
-Bourbon,Fort Scott Ward 5,State Treasurer,,R,Ron Estes,262
-Bourbon,Fort Scott Ward 6,State Treasurer,,R,Ron Estes,338
-Bourbon,Fort Scott Ward 7,State Treasurer,,R,Ron Estes,266
-Bourbon,Drywood Township,State Treasurer,,R,Ron Estes,128
-Bourbon,Franklin Township,State Treasurer,,R,Ron Estes,81
-Bourbon,Freedom Township,State Treasurer,,R,Ron Estes,116
-Bourbon,Marion Township,State Treasurer,,R,Ron Estes,302
-Bourbon,Marmaton Township,State Treasurer,,R,Ron Estes,223
-Bourbon,Mill Creek Township,State Treasurer,,R,Ron Estes,124
-Bourbon,North Scott Township,State Treasurer,,R,Ron Estes,193
-Bourbon,Osage Township,State Treasurer,,R,Ron Estes,100
-Bourbon,Pawnee Township,State Treasurer,,R,Ron Estes,91
-Bourbon,South Scott Township,State Treasurer,,R,Ron Estes,510
-Bourbon,Timberhill Township,State Treasurer,,R,Ron Estes,53
-Bourbon,Walnut Twp,State Treasurer,,R,Ron Estes,33
-Bourbon,Fort Scott Ward 1,Insurance Commissioner,,D,Dennis Anderson,127
-Bourbon,Fort Scott Ward 2,Insurance Commissioner,,D,Dennis Anderson,142
-Bourbon,Fort Scott Ward 3,Insurance Commissioner,,D,Dennis Anderson,43
-Bourbon,Fort Scott Ward 4,Insurance Commissioner,,D,Dennis Anderson,110
-Bourbon,Fort Scott Ward 5,Insurance Commissioner,,D,Dennis Anderson,115
-Bourbon,Fort Scott Ward 6,Insurance Commissioner,,D,Dennis Anderson,144
-Bourbon,Fort Scott Ward 7,Insurance Commissioner,,D,Dennis Anderson,151
-Bourbon,Drywood Township,Insurance Commissioner,,D,Dennis Anderson,31
-Bourbon,Franklin Township,Insurance Commissioner,,D,Dennis Anderson,31
-Bourbon,Freedom Township,Insurance Commissioner,,D,Dennis Anderson,46
-Bourbon,Marion Township,Insurance Commissioner,,D,Dennis Anderson,97
-Bourbon,Marmaton Township,Insurance Commissioner,,D,Dennis Anderson,93
-Bourbon,Mill Creek Township,Insurance Commissioner,,D,Dennis Anderson,48
-Bourbon,North Scott Township,Insurance Commissioner,,D,Dennis Anderson,113
-Bourbon,Osage Township,Insurance Commissioner,,D,Dennis Anderson,46
-Bourbon,Pawnee Township,Insurance Commissioner,,D,Dennis Anderson,33
-Bourbon,South Scott Township,Insurance Commissioner,,D,Dennis Anderson,177
-Bourbon,Timberhill Township,Insurance Commissioner,,D,Dennis Anderson,27
-Bourbon,Walnut Twp,Insurance Commissioner,,D,Dennis Anderson,5
-Bourbon,Fort Scott Ward 1,Insurance Commissioner,,R,Ken Setzer,165
-Bourbon,Fort Scott Ward 2,Insurance Commissioner,,R,Ken Setzer,168
-Bourbon,Fort Scott Ward 3,Insurance Commissioner,,R,Ken Setzer,73
-Bourbon,Fort Scott Ward 4,Insurance Commissioner,,R,Ken Setzer,197
-Bourbon,Fort Scott Ward 5,Insurance Commissioner,,R,Ken Setzer,249
-Bourbon,Fort Scott Ward 6,Insurance Commissioner,,R,Ken Setzer,322
-Bourbon,Fort Scott Ward 7,Insurance Commissioner,,R,Ken Setzer,258
-Bourbon,Drywood Township,Insurance Commissioner,,R,Ken Setzer,125
-Bourbon,Franklin Township,Insurance Commissioner,,R,Ken Setzer,81
-Bourbon,Freedom Township,Insurance Commissioner,,R,Ken Setzer,112
-Bourbon,Marion Township,Insurance Commissioner,,R,Ken Setzer,280
-Bourbon,Marmaton Township,Insurance Commissioner,,R,Ken Setzer,199
-Bourbon,Mill Creek Township,Insurance Commissioner,,R,Ken Setzer,115
-Bourbon,North Scott Township,Insurance Commissioner,,R,Ken Setzer,184
-Bourbon,Osage Township,Insurance Commissioner,,R,Ken Setzer,90
-Bourbon,Pawnee Township,Insurance Commissioner,,R,Ken Setzer,84
-Bourbon,South Scott Township,Insurance Commissioner,,R,Ken Setzer,479
-Bourbon,Timberhill Township,Insurance Commissioner,,R,Ken Setzer,50
-Bourbon,Walnut Twp,Insurance Commissioner,,R,Ken Setzer,32
-Bourbon,Fort Scott Ward 1,State House,4,R,Marty Read,143
-Bourbon,Fort Scott Ward 2,State House,4,R,Marty Read,163
-Bourbon,Fort Scott Ward 3,State House,4,R,Marty Read,58
-Bourbon,Fort Scott Ward 4,State House,4,R,Marty Read,160
-Bourbon,Fort Scott Ward 5,State House,4,R,Marty Read,226
-Bourbon,Fort Scott Ward 6,State House,4,R,Marty Read,283
-Bourbon,Fort Scott Ward 7,State House,4,R,Marty Read,236
-Bourbon,Franklin Township,State House,4,R,Marty Read,128
-Bourbon,Freedom Township,State House,4,R,Marty Read,95
-Bourbon,Marion Township,State House,4,R,Marty Read,118
-Bourbon,Mill Creek Township,State House,4,R,Marty Read,223
-Bourbon,North Scott Township,State House,4,R,Marty Read,124
-Bourbon,Osage Township,State House,4,R,Marty Read,181
-Bourbon,Pawnee Township,State House,4,R,Marty Read,92
-Bourbon,South Scott Township,State House,4,R,Marty Read,80
-Bourbon,Timberhill Township,State House,4,R,Marty Read,457
-Bourbon,Walnut Twp,State House,4,R,Marty Read,57
-Bourbon,Fort Scott Ward 1,State House,4,D,Lucas B Cosens,165
-Bourbon,Fort Scott Ward 2,State House,4,D,Lucas B Cosens,153
-Bourbon,Fort Scott Ward 3,State House,4,D,Lucas B Cosens,61
-Bourbon,Fort Scott Ward 4,State House,4,D,Lucas B Cosens,159
-Bourbon,Fort Scott Ward 5,State House,4,D,Lucas B Cosens,157
-Bourbon,Fort Scott Ward 6,State House,4,D,Lucas B Cosens,207
-Bourbon,Fort Scott Ward 7,State House,4,D,Lucas B Cosens,188
-Bourbon,Drywood Township,State House,4,D,Lucas B Cosens,33
-Bourbon,Franklin Township,State House,4,D,Lucas B Cosens,26
-Bourbon,Freedom Township,State House,4,D,Lucas B Cosens,40
-Bourbon,Marion Township,State House,2,D,Adam Lusker,234
-Bourbon,Marmaton Township,State House,4,D,Lucas B Cosens,84
-Bourbon,Mill Creek Township,State House,4,D,Lucas B Cosens,47
-Bourbon,North Scott Township,State House,4,D,Lucas B Cosens,129
-Bourbon,Osage Township,State House,4,D,Lucas B Cosens,47
-Bourbon,Pawnee Township,State House,4,D,Lucas B Cosens,39
-Bourbon,South Scott Township,State House,4,D,Lucas B Cosens,227
-Bourbon,Timberhill Township,State House,4,D,Lucas B Cosens,25
-Bourbon,Walnut Twp,State House,2,D,Adam Lusker,23
+county,precinct,office,district,party,candidate,votes,vtd
+BOURBON,Drywood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000010
+BOURBON,Drywood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000010
+BOURBON,Drywood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",123,000010
+BOURBON,Fort Scott Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",126,00002A
+BOURBON,Fort Scott Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,00002A
+BOURBON,Fort Scott Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",158,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002F
+BOURBON,Fort Scott Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",145,00003A
+BOURBON,Fort Scott Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00003A
+BOURBON,Fort Scott Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",163,00003A
+BOURBON,Fort Scott Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000040
+BOURBON,Fort Scott Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000040
+BOURBON,Fort Scott Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000040
+BOURBON,Fort Scott Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,00005A
+BOURBON,Fort Scott Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00005A
+BOURBON,Fort Scott Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",159,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005D
+BOURBON,Fort Scott Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,000060
+BOURBON,Fort Scott Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000060
+BOURBON,Fort Scott Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",217,000060
+BOURBON,Fort Scott Ward 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",186,000070
+BOURBON,Fort Scott Ward 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000070
+BOURBON,Fort Scott Ward 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",287,000070
+BOURBON,Fort Scott Ward 7,Governor / Lt. Governor,,Democratic,"Davis, Paul",176,000080
+BOURBON,Fort Scott Ward 7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000080
+BOURBON,Fort Scott Ward 7,Governor / Lt. Governor,,Republican,"Brownback, Sam",231,000080
+BOURBON,Franklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000090
+BOURBON,Franklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000090
+BOURBON,Franklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",84,000090
+BOURBON,Freedom Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000100
+BOURBON,Freedom Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000100
+BOURBON,Freedom Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",110,000100
+BOURBON,Marion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",132,000110
+BOURBON,Marion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000110
+BOURBON,Marion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",266,000110
+BOURBON,Marmaton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",99,000120
+BOURBON,Marmaton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000120
+BOURBON,Marmaton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",192,000120
+BOURBON,Mill Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",59,000130
+BOURBON,Mill Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000130
+BOURBON,Mill Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000130
+BOURBON,North Scott Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",130,000140
+BOURBON,North Scott Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000140
+BOURBON,North Scott Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",173,000140
+BOURBON,Osage Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000150
+BOURBON,Osage Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000150
+BOURBON,Osage Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,000150
+BOURBON,Pawnee Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000160
+BOURBON,Pawnee Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000160
+BOURBON,Pawnee Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000160
+BOURBON,South Scott Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",224,000170
+BOURBON,South Scott Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000170
+BOURBON,South Scott Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",434,000170
+BOURBON,Timberhill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000180
+BOURBON,Timberhill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000180
+BOURBON,Timberhill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000180
+BOURBON,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000190
+BOURBON,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000190
+BOURBON,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+BOURBON,Drywood Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",33,000010
+BOURBON,Drywood Township,Kansas House of Representatives,4,Republican,"Read, Marty",128,000010
+BOURBON,Fort Scott Ward 1,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",165,00002A
+BOURBON,Fort Scott Ward 1,Kansas House of Representatives,4,Republican,"Read, Marty",143,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002F
+BOURBON,Fort Scott Ward 2,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",153,00003A
+BOURBON,Fort Scott Ward 2,Kansas House of Representatives,4,Republican,"Read, Marty",163,00003A
+BOURBON,Fort Scott Ward 3,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",61,000040
+BOURBON,Fort Scott Ward 3,Kansas House of Representatives,4,Republican,"Read, Marty",58,000040
+BOURBON,Fort Scott Ward 4,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",159,00005A
+BOURBON,Fort Scott Ward 4,Kansas House of Representatives,4,Republican,"Read, Marty",160,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas House of Representatives,4,Republican,"Read, Marty",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas House of Representatives,4,Republican,"Read, Marty",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Republican,"Read, Marty",0,00005D
+BOURBON,Fort Scott Ward 5,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",157,000060
+BOURBON,Fort Scott Ward 5,Kansas House of Representatives,4,Republican,"Read, Marty",226,000060
+BOURBON,Fort Scott Ward 6,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",207,000070
+BOURBON,Fort Scott Ward 6,Kansas House of Representatives,4,Republican,"Read, Marty",283,000070
+BOURBON,Fort Scott Ward 7,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",188,000080
+BOURBON,Fort Scott Ward 7,Kansas House of Representatives,4,Republican,"Read, Marty",236,000080
+BOURBON,Franklin Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",26,000090
+BOURBON,Franklin Township,Kansas House of Representatives,4,Republican,"Read, Marty",95,000090
+BOURBON,Freedom Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",40,000100
+BOURBON,Freedom Township,Kansas House of Representatives,4,Republican,"Read, Marty",118,000100
+BOURBON,Marion Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",234,000110
+BOURBON,Marmaton Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",84,000120
+BOURBON,Marmaton Township,Kansas House of Representatives,4,Republican,"Read, Marty",223,000120
+BOURBON,Mill Creek Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",47,000130
+BOURBON,Mill Creek Township,Kansas House of Representatives,4,Republican,"Read, Marty",124,000130
+BOURBON,North Scott Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",129,000140
+BOURBON,North Scott Township,Kansas House of Representatives,4,Republican,"Read, Marty",181,000140
+BOURBON,Osage Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",47,000150
+BOURBON,Osage Township,Kansas House of Representatives,4,Republican,"Read, Marty",92,000150
+BOURBON,Pawnee Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",39,000160
+BOURBON,Pawnee Township,Kansas House of Representatives,4,Republican,"Read, Marty",80,000160
+BOURBON,South Scott Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",227,000170
+BOURBON,South Scott Township,Kansas House of Representatives,4,Republican,"Read, Marty",457,000170
+BOURBON,Timberhill Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",25,000180
+BOURBON,Timberhill Township,Kansas House of Representatives,4,Republican,"Read, Marty",57,000180
+BOURBON,Walnut Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",23,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas House of Representatives,4,Republican,"Read, Marty",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Republican,"Read, Marty",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas House of Representatives,4,Republican,"Read, Marty",0,900030
+BOURBON,Drywood Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",23,000010
+BOURBON,Drywood Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000010
+BOURBON,Drywood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",133,000010
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",104,00002A
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,00002A
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002F
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",105,00003A
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,00003A
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,00003A
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",34,000040
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000040
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000040
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",94,00005A
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,00005A
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",208,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005D
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",91,000060
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000060
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",273,000060
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Democratic,"Wakefield, Margie",106,000070
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000070
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",360,000070
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Democratic,"Wakefield, Margie",119,000080
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,000080
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Republican,"Jenkins, Lynn",285,000080
+BOURBON,Franklin Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000090
+BOURBON,Franklin Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000090
+BOURBON,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,000090
+BOURBON,Freedom Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,000100
+BOURBON,Freedom Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000100
+BOURBON,Freedom Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",116,000100
+BOURBON,Marion Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",87,000110
+BOURBON,Marion Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000110
+BOURBON,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",301,000110
+BOURBON,Marmaton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",66,000120
+BOURBON,Marmaton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000120
+BOURBON,Marmaton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",221,000120
+BOURBON,Mill Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",41,000130
+BOURBON,Mill Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000130
+BOURBON,Mill Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",125,000130
+BOURBON,North Scott Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,000140
+BOURBON,North Scott Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000140
+BOURBON,North Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",204,000140
+BOURBON,Osage Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",30,000150
+BOURBON,Osage Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000150
+BOURBON,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",101,000150
+BOURBON,Pawnee Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000160
+BOURBON,Pawnee Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000160
+BOURBON,Pawnee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,000160
+BOURBON,South Scott Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",138,000170
+BOURBON,South Scott Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",25,000170
+BOURBON,South Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",512,000170
+BOURBON,Timberhill Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",19,000180
+BOURBON,Timberhill Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000180
+BOURBON,Timberhill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000180
+BOURBON,Walnut Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",2,000190
+BOURBON,Walnut Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000190
+BOURBON,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000190
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+BOURBON,Drywood Township,Attorney General,,Democratic,"Kotich, A.J.",23,000010
+BOURBON,Drywood Township,Attorney General,,Republican,"Schmidt, Derek",134,000010
+BOURBON,Fort Scott Ward 1,Attorney General,,Democratic,"Kotich, A.J.",116,00002A
+BOURBON,Fort Scott Ward 1,Attorney General,,Republican,"Schmidt, Derek",180,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Attorney General,,Democratic,"Kotich, A.J.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Attorney General,,Republican,"Schmidt, Derek",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Attorney General,,Democratic,"Kotich, A.J.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Attorney General,,Republican,"Schmidt, Derek",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Attorney General,,Democratic,"Kotich, A.J.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Attorney General,,Republican,"Schmidt, Derek",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Attorney General,,Democratic,"Kotich, A.J.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Attorney General,,Republican,"Schmidt, Derek",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Attorney General,,Democratic,"Kotich, A.J.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Attorney General,,Republican,"Schmidt, Derek",0,00002F
+BOURBON,Fort Scott Ward 2,Attorney General,,Democratic,"Kotich, A.J.",116,00003A
+BOURBON,Fort Scott Ward 2,Attorney General,,Republican,"Schmidt, Derek",193,00003A
+BOURBON,Fort Scott Ward 3,Attorney General,,Democratic,"Kotich, A.J.",36,000040
+BOURBON,Fort Scott Ward 3,Attorney General,,Republican,"Schmidt, Derek",81,000040
+BOURBON,Fort Scott Ward 4,Attorney General,,Democratic,"Kotich, A.J.",103,00005A
+BOURBON,Fort Scott Ward 4,Attorney General,,Republican,"Schmidt, Derek",209,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Attorney General,,Democratic,"Kotich, A.J.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Attorney General,,Republican,"Schmidt, Derek",0,00005D
+BOURBON,Fort Scott Ward 5,Attorney General,,Democratic,"Kotich, A.J.",102,000060
+BOURBON,Fort Scott Ward 5,Attorney General,,Republican,"Schmidt, Derek",269,000060
+BOURBON,Fort Scott Ward 6,Attorney General,,Democratic,"Kotich, A.J.",125,000070
+BOURBON,Fort Scott Ward 6,Attorney General,,Republican,"Schmidt, Derek",342,000070
+BOURBON,Fort Scott Ward 7,Attorney General,,Democratic,"Kotich, A.J.",133,000080
+BOURBON,Fort Scott Ward 7,Attorney General,,Republican,"Schmidt, Derek",275,000080
+BOURBON,Franklin Township,Attorney General,,Democratic,"Kotich, A.J.",29,000090
+BOURBON,Franklin Township,Attorney General,,Republican,"Schmidt, Derek",84,000090
+BOURBON,Freedom Township,Attorney General,,Democratic,"Kotich, A.J.",41,000100
+BOURBON,Freedom Township,Attorney General,,Republican,"Schmidt, Derek",116,000100
+BOURBON,Marion Township,Attorney General,,Democratic,"Kotich, A.J.",85,000110
+BOURBON,Marion Township,Attorney General,,Republican,"Schmidt, Derek",308,000110
+BOURBON,Marmaton Township,Attorney General,,Democratic,"Kotich, A.J.",68,000120
+BOURBON,Marmaton Township,Attorney General,,Republican,"Schmidt, Derek",230,000120
+BOURBON,Mill Creek Township,Attorney General,,Democratic,"Kotich, A.J.",40,000130
+BOURBON,Mill Creek Township,Attorney General,,Republican,"Schmidt, Derek",125,000130
+BOURBON,North Scott Township,Attorney General,,Democratic,"Kotich, A.J.",101,000140
+BOURBON,North Scott Township,Attorney General,,Republican,"Schmidt, Derek",195,000140
+BOURBON,Osage Township,Attorney General,,Democratic,"Kotich, A.J.",36,000150
+BOURBON,Osage Township,Attorney General,,Republican,"Schmidt, Derek",102,000150
+BOURBON,Pawnee Township,Attorney General,,Democratic,"Kotich, A.J.",31,000160
+BOURBON,Pawnee Township,Attorney General,,Republican,"Schmidt, Derek",87,000160
+BOURBON,South Scott Township,Attorney General,,Democratic,"Kotich, A.J.",148,000170
+BOURBON,South Scott Township,Attorney General,,Republican,"Schmidt, Derek",514,000170
+BOURBON,Timberhill Township,Attorney General,,Democratic,"Kotich, A.J.",23,000180
+BOURBON,Timberhill Township,Attorney General,,Republican,"Schmidt, Derek",56,000180
+BOURBON,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",5,000190
+BOURBON,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",32,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Attorney General,,Republican,"Schmidt, Derek",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Attorney General,,Republican,"Schmidt, Derek",0,900030
+BOURBON,Drywood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000010
+BOURBON,Drywood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",125,000010
+BOURBON,Fort Scott Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",127,00002A
+BOURBON,Fort Scott Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",165,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002F
+BOURBON,Fort Scott Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",142,00003A
+BOURBON,Fort Scott Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",168,00003A
+BOURBON,Fort Scott Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000040
+BOURBON,Fort Scott Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000040
+BOURBON,Fort Scott Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",110,00005A
+BOURBON,Fort Scott Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",197,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005D
+BOURBON,Fort Scott Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,000060
+BOURBON,Fort Scott Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",249,000060
+BOURBON,Fort Scott Ward 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",144,000070
+BOURBON,Fort Scott Ward 6,Commissioner of Insurance,,Republican,"Selzer, Ken",322,000070
+BOURBON,Fort Scott Ward 7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",151,000080
+BOURBON,Fort Scott Ward 7,Commissioner of Insurance,,Republican,"Selzer, Ken",258,000080
+BOURBON,Franklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000090
+BOURBON,Franklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",81,000090
+BOURBON,Freedom Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000100
+BOURBON,Freedom Township,Commissioner of Insurance,,Republican,"Selzer, Ken",112,000100
+BOURBON,Marion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,000110
+BOURBON,Marion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",280,000110
+BOURBON,Marmaton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,000120
+BOURBON,Marmaton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",199,000120
+BOURBON,Mill Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000130
+BOURBON,Mill Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",115,000130
+BOURBON,North Scott Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",113,000140
+BOURBON,North Scott Township,Commissioner of Insurance,,Republican,"Selzer, Ken",184,000140
+BOURBON,Osage Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000150
+BOURBON,Osage Township,Commissioner of Insurance,,Republican,"Selzer, Ken",90,000150
+BOURBON,Pawnee Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000160
+BOURBON,Pawnee Township,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000160
+BOURBON,South Scott Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",177,000170
+BOURBON,South Scott Township,Commissioner of Insurance,,Republican,"Selzer, Ken",479,000170
+BOURBON,Timberhill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000180
+BOURBON,Timberhill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000180
+BOURBON,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000190
+BOURBON,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+BOURBON,Drywood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000010
+BOURBON,Drywood Township,Secretary of State,,Republican,"Kobach, Kris",125,000010
+BOURBON,Fort Scott Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",118,00002A
+BOURBON,Fort Scott Ward 1,Secretary of State,,Republican,"Kobach, Kris",180,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Secretary of State,,Republican,"Kobach, Kris",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Secretary of State,,Republican,"Kobach, Kris",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Secretary of State,,Republican,"Kobach, Kris",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Secretary of State,,Republican,"Kobach, Kris",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Secretary of State,,Republican,"Kobach, Kris",0,00002F
+BOURBON,Fort Scott Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",126,00003A
+BOURBON,Fort Scott Ward 2,Secretary of State,,Republican,"Kobach, Kris",183,00003A
+BOURBON,Fort Scott Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000040
+BOURBON,Fort Scott Ward 3,Secretary of State,,Republican,"Kobach, Kris",74,000040
+BOURBON,Fort Scott Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",115,00005A
+BOURBON,Fort Scott Ward 4,Secretary of State,,Republican,"Kobach, Kris",198,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Secretary of State,,Republican,"Kobach, Kris",0,00005D
+BOURBON,Fort Scott Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",112,000060
+BOURBON,Fort Scott Ward 5,Secretary of State,,Republican,"Kobach, Kris",261,000060
+BOURBON,Fort Scott Ward 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",144,000070
+BOURBON,Fort Scott Ward 6,Secretary of State,,Republican,"Kobach, Kris",330,000070
+BOURBON,Fort Scott Ward 7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,000080
+BOURBON,Fort Scott Ward 7,Secretary of State,,Republican,"Kobach, Kris",265,000080
+BOURBON,Franklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000090
+BOURBON,Franklin Township,Secretary of State,,Republican,"Kobach, Kris",83,000090
+BOURBON,Freedom Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000100
+BOURBON,Freedom Township,Secretary of State,,Republican,"Kobach, Kris",114,000100
+BOURBON,Marion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",100,000110
+BOURBON,Marion Township,Secretary of State,,Republican,"Kobach, Kris",292,000110
+BOURBON,Marmaton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",80,000120
+BOURBON,Marmaton Township,Secretary of State,,Republican,"Kobach, Kris",218,000120
+BOURBON,Mill Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000130
+BOURBON,Mill Creek Township,Secretary of State,,Republican,"Kobach, Kris",122,000130
+BOURBON,North Scott Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",101,000140
+BOURBON,North Scott Township,Secretary of State,,Republican,"Kobach, Kris",203,000140
+BOURBON,Osage Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000150
+BOURBON,Osage Township,Secretary of State,,Republican,"Kobach, Kris",100,000150
+BOURBON,Pawnee Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000160
+BOURBON,Pawnee Township,Secretary of State,,Republican,"Kobach, Kris",88,000160
+BOURBON,South Scott Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",185,000170
+BOURBON,South Scott Township,Secretary of State,,Republican,"Kobach, Kris",480,000170
+BOURBON,Timberhill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000180
+BOURBON,Timberhill Township,Secretary of State,,Republican,"Kobach, Kris",56,000180
+BOURBON,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000190
+BOURBON,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",30,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Secretary of State,,Republican,"Kobach, Kris",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Secretary of State,,Republican,"Kobach, Kris",0,900030
+BOURBON,Drywood Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000010
+BOURBON,Drywood Township,State Treasurer,,Republican,"Estes, Ron",128,000010
+BOURBON,Fort Scott Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",119,00002A
+BOURBON,Fort Scott Ward 1,State Treasurer,,Republican,"Estes, Ron",174,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,State Treasurer,,Republican,"Estes, Ron",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,State Treasurer,,Republican,"Estes, Ron",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,State Treasurer,,Republican,"Estes, Ron",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,State Treasurer,,Republican,"Estes, Ron",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,State Treasurer,,Republican,"Estes, Ron",0,00002F
+BOURBON,Fort Scott Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",121,00003A
+BOURBON,Fort Scott Ward 2,State Treasurer,,Republican,"Estes, Ron",186,00003A
+BOURBON,Fort Scott Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",37,000040
+BOURBON,Fort Scott Ward 3,State Treasurer,,Republican,"Estes, Ron",79,000040
+BOURBON,Fort Scott Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",104,00005A
+BOURBON,Fort Scott Ward 4,State Treasurer,,Republican,"Estes, Ron",209,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,State Treasurer,,Republican,"Estes, Ron",0,00005D
+BOURBON,Fort Scott Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",109,000060
+BOURBON,Fort Scott Ward 5,State Treasurer,,Republican,"Estes, Ron",262,000060
+BOURBON,Fort Scott Ward 6,State Treasurer,,Democratic,"Alldritt, Carmen",123,000070
+BOURBON,Fort Scott Ward 6,State Treasurer,,Republican,"Estes, Ron",338,000070
+BOURBON,Fort Scott Ward 7,State Treasurer,,Democratic,"Alldritt, Carmen",139,000080
+BOURBON,Fort Scott Ward 7,State Treasurer,,Republican,"Estes, Ron",266,000080
+BOURBON,Franklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000090
+BOURBON,Franklin Township,State Treasurer,,Republican,"Estes, Ron",81,000090
+BOURBON,Freedom Township,State Treasurer,,Democratic,"Alldritt, Carmen",41,000100
+BOURBON,Freedom Township,State Treasurer,,Republican,"Estes, Ron",116,000100
+BOURBON,Marion Township,State Treasurer,,Democratic,"Alldritt, Carmen",90,000110
+BOURBON,Marion Township,State Treasurer,,Republican,"Estes, Ron",302,000110
+BOURBON,Marmaton Township,State Treasurer,,Democratic,"Alldritt, Carmen",72,000120
+BOURBON,Marmaton Township,State Treasurer,,Republican,"Estes, Ron",223,000120
+BOURBON,Mill Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",40,000130
+BOURBON,Mill Creek Township,State Treasurer,,Republican,"Estes, Ron",124,000130
+BOURBON,North Scott Township,State Treasurer,,Democratic,"Alldritt, Carmen",105,000140
+BOURBON,North Scott Township,State Treasurer,,Republican,"Estes, Ron",193,000140
+BOURBON,Osage Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000150
+BOURBON,Osage Township,State Treasurer,,Republican,"Estes, Ron",100,000150
+BOURBON,Pawnee Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000160
+BOURBON,Pawnee Township,State Treasurer,,Republican,"Estes, Ron",91,000160
+BOURBON,South Scott Township,State Treasurer,,Democratic,"Alldritt, Carmen",151,000170
+BOURBON,South Scott Township,State Treasurer,,Republican,"Estes, Ron",510,000170
+BOURBON,Timberhill Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000180
+BOURBON,Timberhill Township,State Treasurer,,Republican,"Estes, Ron",53,000180
+BOURBON,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000190
+BOURBON,Walnut Township,State Treasurer,,Republican,"Estes, Ron",33,000190
+BOURBON,Fort Scott Ward 6 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,State Treasurer,,Republican,"Estes, Ron",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,State Treasurer,,Republican,"Estes, Ron",0,900030
+BOURBON,Drywood Township,United States Senate,,independent,"Orman, Greg",33,000010
+BOURBON,Drywood Township,United States Senate,,Libertarian,"Batson, Randall",7,000010
+BOURBON,Drywood Township,United States Senate,,Republican,"Roberts, Pat",124,000010
+BOURBON,Fort Scott Ward 1,United States Senate,,independent,"Orman, Greg",114,00002A
+BOURBON,Fort Scott Ward 1,United States Senate,,Libertarian,"Batson, Randall",24,00002A
+BOURBON,Fort Scott Ward 1,United States Senate,,Republican,"Roberts, Pat",162,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States Senate,,independent,"Orman, Greg",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States Senate,,Libertarian,"Batson, Randall",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States Senate,,Republican,"Roberts, Pat",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States Senate,,independent,"Orman, Greg",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States Senate,,Libertarian,"Batson, Randall",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States Senate,,Republican,"Roberts, Pat",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States Senate,,independent,"Orman, Greg",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States Senate,,Libertarian,"Batson, Randall",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States Senate,,Republican,"Roberts, Pat",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States Senate,,independent,"Orman, Greg",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States Senate,,Libertarian,"Batson, Randall",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States Senate,,Republican,"Roberts, Pat",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States Senate,,independent,"Orman, Greg",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States Senate,,Libertarian,"Batson, Randall",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States Senate,,Republican,"Roberts, Pat",0,00002F
+BOURBON,Fort Scott Ward 2,United States Senate,,independent,"Orman, Greg",98,00003A
+BOURBON,Fort Scott Ward 2,United States Senate,,Libertarian,"Batson, Randall",42,00003A
+BOURBON,Fort Scott Ward 2,United States Senate,,Republican,"Roberts, Pat",167,00003A
+BOURBON,Fort Scott Ward 3,United States Senate,,independent,"Orman, Greg",38,000040
+BOURBON,Fort Scott Ward 3,United States Senate,,Libertarian,"Batson, Randall",9,000040
+BOURBON,Fort Scott Ward 3,United States Senate,,Republican,"Roberts, Pat",71,000040
+BOURBON,Fort Scott Ward 4,United States Senate,,independent,"Orman, Greg",107,00005A
+BOURBON,Fort Scott Ward 4,United States Senate,,Libertarian,"Batson, Randall",20,00005A
+BOURBON,Fort Scott Ward 4,United States Senate,,Republican,"Roberts, Pat",182,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,United States Senate,,independent,"Orman, Greg",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,United States Senate,,independent,"Orman, Greg",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,independent,"Orman, Greg",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Libertarian,"Batson, Randall",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Republican,"Roberts, Pat",0,00005D
+BOURBON,Fort Scott Ward 5,United States Senate,,independent,"Orman, Greg",120,000060
+BOURBON,Fort Scott Ward 5,United States Senate,,Libertarian,"Batson, Randall",16,000060
+BOURBON,Fort Scott Ward 5,United States Senate,,Republican,"Roberts, Pat",242,000060
+BOURBON,Fort Scott Ward 6,United States Senate,,independent,"Orman, Greg",143,000070
+BOURBON,Fort Scott Ward 6,United States Senate,,Libertarian,"Batson, Randall",25,000070
+BOURBON,Fort Scott Ward 6,United States Senate,,Republican,"Roberts, Pat",308,000070
+BOURBON,Fort Scott Ward 7,United States Senate,,independent,"Orman, Greg",141,000080
+BOURBON,Fort Scott Ward 7,United States Senate,,Libertarian,"Batson, Randall",31,000080
+BOURBON,Fort Scott Ward 7,United States Senate,,Republican,"Roberts, Pat",240,000080
+BOURBON,Franklin Township,United States Senate,,independent,"Orman, Greg",33,000090
+BOURBON,Franklin Township,United States Senate,,Libertarian,"Batson, Randall",6,000090
+BOURBON,Franklin Township,United States Senate,,Republican,"Roberts, Pat",79,000090
+BOURBON,Freedom Township,United States Senate,,independent,"Orman, Greg",40,000100
+BOURBON,Freedom Township,United States Senate,,Libertarian,"Batson, Randall",9,000100
+BOURBON,Freedom Township,United States Senate,,Republican,"Roberts, Pat",106,000100
+BOURBON,Marion Township,United States Senate,,independent,"Orman, Greg",114,000110
+BOURBON,Marion Township,United States Senate,,Libertarian,"Batson, Randall",26,000110
+BOURBON,Marion Township,United States Senate,,Republican,"Roberts, Pat",267,000110
+BOURBON,Marmaton Township,United States Senate,,independent,"Orman, Greg",83,000120
+BOURBON,Marmaton Township,United States Senate,,Libertarian,"Batson, Randall",16,000120
+BOURBON,Marmaton Township,United States Senate,,Republican,"Roberts, Pat",198,000120
+BOURBON,Mill Creek Township,United States Senate,,independent,"Orman, Greg",48,000130
+BOURBON,Mill Creek Township,United States Senate,,Libertarian,"Batson, Randall",11,000130
+BOURBON,Mill Creek Township,United States Senate,,Republican,"Roberts, Pat",107,000130
+BOURBON,North Scott Township,United States Senate,,independent,"Orman, Greg",96,000140
+BOURBON,North Scott Township,United States Senate,,Libertarian,"Batson, Randall",21,000140
+BOURBON,North Scott Township,United States Senate,,Republican,"Roberts, Pat",188,000140
+BOURBON,Osage Township,United States Senate,,independent,"Orman, Greg",35,000150
+BOURBON,Osage Township,United States Senate,,Libertarian,"Batson, Randall",8,000150
+BOURBON,Osage Township,United States Senate,,Republican,"Roberts, Pat",94,000150
+BOURBON,Pawnee Township,United States Senate,,independent,"Orman, Greg",26,000160
+BOURBON,Pawnee Township,United States Senate,,Libertarian,"Batson, Randall",5,000160
+BOURBON,Pawnee Township,United States Senate,,Republican,"Roberts, Pat",84,000160
+BOURBON,South Scott Township,United States Senate,,independent,"Orman, Greg",159,000170
+BOURBON,South Scott Township,United States Senate,,Libertarian,"Batson, Randall",32,000170
+BOURBON,South Scott Township,United States Senate,,Republican,"Roberts, Pat",483,000170
+BOURBON,Timberhill Township,United States Senate,,independent,"Orman, Greg",22,000180
+BOURBON,Timberhill Township,United States Senate,,Libertarian,"Batson, Randall",3,000180
+BOURBON,Timberhill Township,United States Senate,,Republican,"Roberts, Pat",58,000180
+BOURBON,Walnut Township,United States Senate,,independent,"Orman, Greg",6,000190
+BOURBON,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",1,000190
+BOURBON,Walnut Township,United States Senate,,Republican,"Roberts, Pat",30,000190
+BOURBON,Fort Scott Ward 6 Exclave A,United States Senate,,independent,"Orman, Greg",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,independent,"Orman, Greg",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Libertarian,"Batson, Randall",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Republican,"Roberts, Pat",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,United States Senate,,independent,"Orman, Greg",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States Senate,,Libertarian,"Batson, Randall",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States Senate,,Republican,"Roberts, Pat",0,900030

--- a/2014/20141104__ks__general__brown__precinct.csv
+++ b/2014/20141104__ks__general__brown__precinct.csv
@@ -1,407 +1,533 @@
-county,precinct,office,district,party,candidate,votes
-Brown,0001 HIAWATHA WARD 1,Attorney General,,D,A. J. Kotich,51
-Brown,0002 HIAWATHA WARD 2,Attorney General,,D,A. J. Kotich,123
-Brown,0003 HIAWATHA WARD 3,Attorney General,,D,A. J. Kotich,103
-Brown,0004 HIAWATHA WARD 4,Attorney General,,D,A. J. Kotich,10
-Brown,0005 HORTON WARD 1,Attorney General,,D,A. J. Kotich,54
-Brown,0006 HORTON WARD 2,Attorney General,,D,A. J. Kotich,33
-Brown,0007 HORTON WARD 3,Attorney General,,D,A. J. Kotich,21
-Brown,0008 RESERVE  PRECINCT,Attorney General,,D,A. J. Kotich,9
-Brown,0009 HAMLIN PRECINCT,Attorney General,,D,A. J. Kotich,12
-Brown,0010 HIAWATHA TWP,Attorney General,,D,A. J. Kotich,48
-Brown,0011 IRVING PRECINCT,Attorney General,,D,A. J. Kotich,23
-Brown,0012 MISSION PRECINCT,Attorney General,,D,A. J. Kotich,57
-Brown,0013 MORRILL PRECINCT,Attorney General,,D,A. J. Kotich,16
-Brown,0014 PADONIA PRECINCT,Attorney General,,D,A. J. Kotich,16
-Brown,0015 POWHATTAN  PRECINCT,Attorney General,,D,A. J. Kotich,74
-Brown,0016 ROBINSON  PRECINCT,Attorney General,,D,A. J. Kotich,45
-Brown,0017 WALNUT  PRECINCT,Attorney General,,D,A. J. Kotich,52
-Brown,0018 WASHINGTON  PRECINCT,Attorney General,,D,A. J. Kotich,27
-Brown,0001 HIAWATHA WARD 1,Attorney General,,R,Derek Schmidt,103
-Brown,0002 HIAWATHA WARD 2,Attorney General,,R,Derek Schmidt,343
-Brown,0003 HIAWATHA WARD 3,Attorney General,,R,Derek Schmidt,260
-Brown,0004 HIAWATHA WARD 4,Attorney General,,R,Derek Schmidt,48
-Brown,0005 HORTON WARD 1,Attorney General,,R,Derek Schmidt,142
-Brown,0006 HORTON WARD 2,Attorney General,,R,Derek Schmidt,99
-Brown,0007 HORTON WARD 3,Attorney General,,R,Derek Schmidt,56
-Brown,0008 RESERVE  PRECINCT,Attorney General,,R,Derek Schmidt,30
-Brown,0009 HAMLIN PRECINCT,Attorney General,,R,Derek Schmidt,58
-Brown,0010 HIAWATHA TWP,Attorney General,,R,Derek Schmidt,205
-Brown,0011 IRVING PRECINCT,Attorney General,,R,Derek Schmidt,70
-Brown,0012 MISSION PRECINCT,Attorney General,,R,Derek Schmidt,194
-Brown,0013 MORRILL PRECINCT,Attorney General,,R,Derek Schmidt,161
-Brown,0014 PADONIA PRECINCT,Attorney General,,R,Derek Schmidt,53
-Brown,0015 POWHATTAN  PRECINCT,Attorney General,,R,Derek Schmidt,129
-Brown,0016 ROBINSON  PRECINCT,Attorney General,,R,Derek Schmidt,119
-Brown,0017 WALNUT  PRECINCT,Attorney General,,R,Derek Schmidt,195
-Brown,0018 WASHINGTON  PRECINCT,Attorney General,,R,Derek Schmidt,129
-Brown,0005 HORTON WARD 1,Attorney General,,,Write-ins,1
-Brown,0014 PADONIA PRECINCT,Attorney General,,,Write-ins,1
-Brown,0015 POWHATTAN  PRECINCT,Attorney General,,,Write-ins,1
-Brown,0018 WASHINGTON  PRECINCT,Attorney General,,,Write-ins,1
-Brown,0001 HIAWATHA WARD 1,U.S. House,2,L,Christopher Clemmons,5
-Brown,0002 HIAWATHA WARD 2,U.S. House,2,L,Christopher Clemmons,19
-Brown,0003 HIAWATHA WARD 3,U.S. House,2,L,Christopher Clemmons,12
-Brown,0004 HIAWATHA WARD 4,U.S. House,2,L,Christopher Clemmons,4
-Brown,0005 HORTON WARD 1,U.S. House,2,L,Christopher Clemmons,10
-Brown,0006 HORTON WARD 2,U.S. House,2,L,Christopher Clemmons,4
-Brown,0007 HORTON WARD 3,U.S. House,2,L,Christopher Clemmons,8
-Brown,0008 RESERVE  PRECINCT,U.S. House,2,L,Christopher Clemmons,4
-Brown,0009 HAMLIN PRECINCT,U.S. House,2,L,Christopher Clemmons,5
-Brown,0010 HIAWATHA TWP,U.S. House,2,L,Christopher Clemmons,9
-Brown,0011 IRVING PRECINCT,U.S. House,2,L,Christopher Clemmons,2
-Brown,0012 MISSION PRECINCT,U.S. House,2,L,Christopher Clemmons,5
-Brown,0013 MORRILL PRECINCT,U.S. House,2,L,Christopher Clemmons,8
-Brown,0014 PADONIA PRECINCT,U.S. House,2,L,Christopher Clemmons,11
-Brown,0015 POWHATTAN  PRECINCT,U.S. House,2,L,Christopher Clemmons,11
-Brown,0016 ROBINSON  PRECINCT,U.S. House,2,L,Christopher Clemmons,7
-Brown,0017 WALNUT  PRECINCT,U.S. House,2,L,Christopher Clemmons,10
-Brown,0018 WASHINGTON  PRECINCT,U.S. House,2,L,Christopher Clemmons,4
-Brown,0001 HIAWATHA WARD 1,U.S. House,2,R,Lynn Jenkins,96
-Brown,0002 HIAWATHA WARD 2,U.S. House,2,R,Lynn Jenkins,316
-Brown,0003 HIAWATHA WARD 3,U.S. House,2,R,Lynn Jenkins,252
-Brown,0004 HIAWATHA WARD 4,U.S. House,2,R,Lynn Jenkins,44
-Brown,0005 HORTON WARD 1,U.S. House,2,R,Lynn Jenkins,140
-Brown,0006 HORTON WARD 2,U.S. House,2,R,Lynn Jenkins,91
-Brown,0007 HORTON WARD 3,U.S. House,2,R,Lynn Jenkins,46
-Brown,0008 RESERVE  PRECINCT,U.S. House,2,R,Lynn Jenkins,27
-Brown,0009 HAMLIN PRECINCT,U.S. House,2,R,Lynn Jenkins,60
-Brown,0010 HIAWATHA TWP,U.S. House,2,R,Lynn Jenkins,191
-Brown,0011 IRVING PRECINCT,U.S. House,2,R,Lynn Jenkins,69
-Brown,0012 MISSION PRECINCT,U.S. House,2,R,Lynn Jenkins,191
-Brown,0013 MORRILL PRECINCT,U.S. House,2,R,Lynn Jenkins,150
-Brown,0014 PADONIA PRECINCT,U.S. House,2,R,Lynn Jenkins,48
-Brown,0015 POWHATTAN  PRECINCT,U.S. House,2,R,Lynn Jenkins,119
-Brown,0016 ROBINSON  PRECINCT,U.S. House,2,R,Lynn Jenkins,118
-Brown,0017 WALNUT  PRECINCT,U.S. House,2,R,Lynn Jenkins,182
-Brown,0018 WASHINGTON  PRECINCT,U.S. House,2,R,Lynn Jenkins,125
-Brown,0001 HIAWATHA WARD 1,U.S. House,2,D,Margie Wakefield,53
-Brown,0002 HIAWATHA WARD 2,U.S. House,2,D,Margie Wakefield (DEM),139
-Brown,0003 HIAWATHA WARD 3,U.S. House,2,D,Margie Wakefield (DEM),109
-Brown,0004 HIAWATHA WARD 4,U.S. House,2,D,Margie Wakefield (DEM),10
-Brown,0005 HORTON WARD 1,U.S. House,2,D,Margie Wakefield (DEM),47
-Brown,0006 HORTON WARD 2,U.S. House,2,D,Margie Wakefield (DEM),38
-Brown,0007 HORTON WARD 3,U.S. House,2,D,Margie Wakefield (DEM),24
-Brown,0008 RESERVE  PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),11
-Brown,0009 HAMLIN PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),7
-Brown,0010 HIAWATHA TWP,U.S. House,2,D,Margie Wakefield (DEM),53
-Brown,0011 IRVING PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),25
-Brown,0012 MISSION PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),57
-Brown,0013 MORRILL PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),24
-Brown,0014 PADONIA PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),15
-Brown,0015 POWHATTAN  PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),73
-Brown,0016 ROBINSON  PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),40
-Brown,0017 WALNUT  PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),58
-Brown,0018 WASHINGTON  PRECINCT,U.S. House,2,D,Margie Wakefield (DEM),28
-Brown,0002 HIAWATHA WARD 2,U.S. House,2,,Write-ins,1
-Brown,0005 HORTON WARD 1,U.S. House,2,,Write-ins,1
-Brown,0016 ROBINSON  PRECINCT,U.S. House,2,,Write-ins,1
-Brown,0017 WALNUT  PRECINCT,U.S. House,2,,Write-ins,1
-Brown,0001 HIAWATHA WARD 1,Governor,,R,Sam Brownback,73
-Brown,0002 HIAWATHA WARD 2,Governor,,R,Sam Brownback,215
-Brown,0003 HIAWATHA WARD 3,Governor,,R,Sam Brownback,188
-Brown,0004 HIAWATHA WARD 4,Governor,,R,Sam Brownback,31
-Brown,0005 HORTON WARD 1,Governor,,R,Sam Brownback,108
-Brown,0006 HORTON WARD 2,Governor,,R,Sam Brownback,76
-Brown,0007 HORTON WARD 3,Governor,,R,Sam Brownback,37
-Brown,0008 RESERVE  PRECINCT,Governor,,R,Sam Brownback,27
-Brown,0009 HAMLIN PRECINCT,Governor,,R,Sam Brownback,50
-Brown,0010 HIAWATHA TWP,Governor,,R,Sam Brownback,161
-Brown,0011 IRVING PRECINCT,Governor,,R,Sam Brownback,57
-Brown,0012 MISSION PRECINCT,Governor,,R,Sam Brownback,151
-Brown,0013 MORRILL PRECINCT,Governor,,R,Sam Brownback,141
-Brown,0014 PADONIA PRECINCT,Governor,,R,Sam Brownback,44
-Brown,0015 POWHATTAN  PRECINCT,Governor,,R,Sam Brownback,101
-Brown,0016 ROBINSON  PRECINCT,Governor,,R,Sam Brownback,101
-Brown,0017 WALNUT  PRECINCT,Governor,,R,Sam Brownback,158
-Brown,0018 WASHINGTON  PRECINCT,Governor,,R,Sam Brownback,106
-Brown,0001 HIAWATHA WARD 1,Governor,,D,Paul Davis,69
-Brown,0002 HIAWATHA WARD 2,Governor,,D,Paul Davis,242
-Brown,0003 HIAWATHA WARD 3,Governor,,D,Paul Davis,174
-Brown,0004 HIAWATHA WARD 4,Governor,,D,Paul Davis,24
-Brown,0005 HORTON WARD 1,Governor,,D,Paul Davis,78
-Brown,0006 HORTON WARD 2,Governor,,D,Paul Davis,45
-Brown,0007 HORTON WARD 3,Governor,,D,Paul Davis,31
-Brown,0008 RESERVE  PRECINCT,Governor,,D,Paul Davis,12
-Brown,0009 HAMLIN PRECINCT,Governor,,D,Paul Davis,15
-Brown,0010 HIAWATHA TWP,Governor,,D,Paul Davis,87
-Brown,0011 IRVING PRECINCT,Governor,,D,Paul Davis,36
-Brown,0012 MISSION PRECINCT,Governor,,D,Paul Davis,92
-Brown,0013 MORRILL PRECINCT,Governor,,D,Paul Davis,36
-Brown,0014 PADONIA PRECINCT,Governor,,D,Paul Davis,21
-Brown,0015 POWHATTAN  PRECINCT,Governor,,D,Paul Davis,93
-Brown,0016 ROBINSON  PRECINCT,Governor,,D,Paul Davis,58
-Brown,0017 WALNUT  PRECINCT,Governor,,D,Paul Davis,77
-Brown,0018 WASHINGTON  PRECINCT,Governor,,D,Paul Davis,46
-Brown,0001 HIAWATHA WARD 1,Governor,,L,Keen Umbehr,13
-Brown,0002 HIAWATHA WARD 2,Governor,,L,Keen Umbehr,14
-Brown,0003 HIAWATHA WARD 3,Governor,,L,Keen Umbehr,10
-Brown,0004 HIAWATHA WARD 4,Governor,,L,Keen Umbehr,2
-Brown,0005 HORTON WARD 1,Governor,,L,Keen Umbehr,9
-Brown,0006 HORTON WARD 2,Governor,,L,Keen Umbehr,8
-Brown,0007 HORTON WARD 3,Governor,,L,Keen Umbehr,7
-Brown,0008 RESERVE  PRECINCT,Governor,,L,Keen Umbehr,3
-Brown,0009 HAMLIN PRECINCT,Governor,,L,Keen Umbehr,7
-Brown,0010 HIAWATHA TWP,Governor,,L,Keen Umbehr,8
-Brown,0011 IRVING PRECINCT,Governor,,L,Keen Umbehr,2
-Brown,0012 MISSION PRECINCT,Governor,,L,Keen Umbehr,6
-Brown,0013 MORRILL PRECINCT,Governor,,L,Keen Umbehr,4
-Brown,0014 PADONIA PRECINCT,Governor,,L,Keen Umbehr,10
-Brown,0015 POWHATTAN  PRECINCT,Governor,,L,Keen Umbehr,7
-Brown,0016 ROBINSON  PRECINCT,Governor,,L,Keen Umbehr,8
-Brown,0017 WALNUT  PRECINCT,Governor,,L,Keen Umbehr,15
-Brown,0018 WASHINGTON  PRECINCT,Governor,,L,Keen Umbehr,6
-Brown,0002 HIAWATHA WARD 2,Governor,,,Write-ins,1
-Brown,0006 HORTON WARD 2,Governor,,,Write-ins,2
-Brown,0007 HORTON WARD 3,Governor,,,Write-ins,1
-Brown,0001 HIAWATHA WARD 1,Insurance Commissioner,,D,Dennis Anderson,57
-Brown,0002 HIAWATHA WARD 2,Insurance Commissioner,,D,Dennis Anderson,141
-Brown,0003 HIAWATHA WARD 3,Insurance Commissioner,,D,Dennis Anderson,114
-Brown,0004 HIAWATHA WARD 4,Insurance Commissioner,,D,Dennis Anderson,18
-Brown,0005 HORTON WARD 1,Insurance Commissioner,,D,Dennis Anderson,65
-Brown,0006 HORTON WARD 2,Insurance Commissioner,,D,Dennis Anderson,39
-Brown,0007 HORTON WARD 3,Insurance Commissioner,,D,Dennis Anderson,25
-Brown,0008 RESERVE  PRECINCT,Insurance Commissioner,,D,Dennis Anderson,11
-Brown,0009 HAMLIN PRECINCT,Insurance Commissioner,,D,Dennis Anderson,13
-Brown,0010 HIAWATHA TWP,Insurance Commissioner,,D,Dennis Anderson,54
-Brown,0011 IRVING PRECINCT,Insurance Commissioner,,D,Dennis Anderson,29
-Brown,0012 MISSION PRECINCT,Insurance Commissioner,,D,Dennis Anderson,62
-Brown,0013 MORRILL PRECINCT,Insurance Commissioner,,D,Dennis Anderson,22
-Brown,0014 PADONIA PRECINCT,Insurance Commissioner,,D,Dennis Anderson,12
-Brown,0015 POWHATTAN  PRECINCT,Insurance Commissioner,,D,Dennis Anderson,83
-Brown,0016 ROBINSON  PRECINCT,Insurance Commissioner,,D,Dennis Anderson,53
-Brown,0017 WALNUT  PRECINCT,Insurance Commissioner,,D,Dennis Anderson,59
-Brown,0018 WASHINGTON  PRECINCT,Insurance Commissioner,,D,Dennis Anderson,38
-Brown,0001 HIAWATHA WARD 1,Insurance Commissioner,,R,Ken Selzer,94
-Brown,0002 HIAWATHA WARD 2,Insurance Commissioner,,R,Ken Selzer,315
-Brown,0003 HIAWATHA WARD 3,Insurance Commissioner,,R,Ken Selzer,241
-Brown,0004 HIAWATHA WARD 4,Insurance Commissioner,,R,Ken Selzer,40
-Brown,0005 HORTON WARD 1,Insurance Commissioner,,R,Ken Selzer,127
-Brown,0006 HORTON WARD 2,Insurance Commissioner,,R,Ken Selzer,92
-Brown,0007 HORTON WARD 3,Insurance Commissioner,,R,Ken Selzer,51
-Brown,0008 RESERVE  PRECINCT,Insurance Commissioner,,R,Ken Selzer,28
-Brown,0009 HAMLIN PRECINCT,Insurance Commissioner,,R,Ken Selzer,56
-Brown,0010 HIAWATHA TWP,Insurance Commissioner,,R,Ken Selzer,194
-Brown,0011 IRVING PRECINCT,Insurance Commissioner,,R,Ken Selzer,66
-Brown,0012 MISSION PRECINCT,Insurance Commissioner,,R,Ken Selzer,184
-Brown,0013 MORRILL PRECINCT,Insurance Commissioner,,R,Ken Selzer,149
-Brown,0014 PADONIA PRECINCT,Insurance Commissioner,,R,Ken Selzer,57
-Brown,0015 POWHATTAN  PRECINCT,Insurance Commissioner,,R,Ken Selzer,116
-Brown,0016 ROBINSON  PRECINCT,Insurance Commissioner,,R,Ken Selzer,111
-Brown,0017 WALNUT  PRECINCT,Insurance Commissioner,,R,Ken Selzer,181
-Brown,0018 WASHINGTON  PRECINCT,Insurance Commissioner,,R,Ken Selzer,115
-Brown,0002 HIAWATHA WARD 2,Insurance Commissioner,,,Write-ins,1
-Brown,0005 HORTON WARD 1,Insurance Commissioner,,,Write-ins,1
-Brown,0015 POWHATTAN  PRECINCT,Insurance Commissioner,,,Write-ins,1
-Brown,0001 HIAWATHA WARD 1,Secretary of State,,D,Jean Kurtis Schodorf,54
-Brown,0002 HIAWATHA WARD 2,Secretary of State,,D,Jean Kurtis Schodorf,160
-Brown,0003 HIAWATHA WARD 3,Secretary of State,,D,Jean Kurtis Schodorf,116
-Brown,0004 HIAWATHA WARD 4,Secretary of State,,D,Jean Kurtis Schodorf,12
-Brown,0005 HORTON WARD 1,Secretary of State,,D,Jean Kurtis Schodorf,59
-Brown,0006 HORTON WARD 2,Secretary of State,,D,Jean Kurtis Schodorf,36
-Brown,0007 HORTON WARD 3,Secretary of State,,D,Jean Kurtis Schodorf,30
-Brown,0008 RESERVE  PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,12
-Brown,0009 HAMLIN PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,11
-Brown,0010 HIAWATHA TWP,Secretary of State,,D,Jean Kurtis Schodorf,48
-Brown,0011 IRVING PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,25
-Brown,0012 MISSION PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,60
-Brown,0013 MORRILL PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,18
-Brown,0014 PADONIA PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,13
-Brown,0015 POWHATTAN  PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,86
-Brown,0016 ROBINSON  PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,45
-Brown,0017 WALNUT  PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,67
-Brown,0018 WASHINGTON  PRECINCT,Secretary of State,,D,Jean Kurtis Schodorf,22
-Brown,0001 HIAWATHA WARD 1,Secretary of State,,R,Kris Kobach,101
-Brown,0002 HIAWATHA WARD 2,Secretary of State,,R,Kris Kobach,308
-Brown,0003 HIAWATHA WARD 3,Secretary of State,,R,Kris Kobach,244
-Brown,0004 HIAWATHA WARD 4,Secretary of State,,R,Kris Kobach,45
-Brown,0005 HORTON WARD 1,Secretary of State,,R,Kris Kobach,136
-Brown,0006 HORTON WARD 2,Secretary of State,,R,Kris Kobach,97
-Brown,0007 HORTON WARD 3,Secretary of State,,R,Kris Kobach,46
-Brown,0008 RESERVE  PRECINCT,Secretary of State,,R,Kris Kobach,27
-Brown,0009 HAMLIN PRECINCT,Secretary of State,,R,Kris Kobach,61
-Brown,0010 HIAWATHA TWP,Secretary of State,,R,Kris Kobach,205
-Brown,0011 IRVING PRECINCT,Secretary of State,,R,Kris Kobach,68
-Brown,0012 MISSION PRECINCT,Secretary of State,,R,Kris Kobach,188
-Brown,0013 MORRILL PRECINCT,Secretary of State,,R,Kris Kobach,162
-Brown,0014 PADONIA PRECINCT,Secretary of State,,R,Kris Kobach,58
-Brown,0015 POWHATTAN  PRECINCT,Secretary of State,,R,Kris Kobach,116
-Brown,0016 ROBINSON  PRECINCT,Secretary of State,,R,Kris Kobach,122
-Brown,0017 WALNUT  PRECINCT,Secretary of State,,R,Kris Kobach,185
-Brown,0018 WASHINGTON  PRECINCT,Secretary of State,,R,Kris Kobach,133
-Brown,0002 HIAWATHA WARD 2,Secretary of State,,,Write-ins,1
-Brown,0003 HIAWATHA WARD 3,Secretary of State,,,Write-ins,1
-Brown,0001 HIAWATHA WARD 1,State House,62,R,Randy Garber,71
-Brown,0002 HIAWATHA WARD 2,State House,62,R,Randy Garber,227
-Brown,0003 HIAWATHA WARD 3,State House,62,R,Randy Garber,207
-Brown,0004 HIAWATHA WARD 4,State House,62,R,Randy Garber,42
-Brown,0005 HORTON WARD 1,State House,62,R,Randy Garber,111
-Brown,0006 HORTON WARD 2,State House,62,R,Randy Garber,82
-Brown,0007 HORTON WARD 3,State House,62,R,Randy Garber,43
-Brown,0008 RESERVE  PRECINCT,State House,62,R,Randy Garber,28
-Brown,0009 HAMLIN PRECINCT,State House,62,R,Randy Garber,50
-Brown,0010 HIAWATHA TWP,State House,62,R,Randy Garber,145
-Brown,0011 IRVING PRECINCT,State House,62,R,Randy Garber,47
-Brown,0012 MISSION PRECINCT,State House,62,R,Randy Garber,152
-Brown,0013 MORRILL PRECINCT,State House,62,R,Randy Garber,139
-Brown,0014 PADONIA PRECINCT,State House,62,R,Randy Garber,43
-Brown,0015 POWHATTAN  PRECINCT,State House,62,R,Randy Garber,104
-Brown,0016 ROBINSON  PRECINCT,State House,62,R,Randy Garber,99
-Brown,0017 WALNUT  PRECINCT,State House,62,R,Randy Garber,148
-Brown,0018 WASHINGTON  PRECINCT,State House,62,R,Randy Garber,99
-Brown,0001 HIAWATHA WARD 1,State House,62,D,Steve Lukert ,83
-Brown,0002 HIAWATHA WARD 2,State House,62,D,Steve Lukert ,247
-Brown,0003 HIAWATHA WARD 3,State House,62,D,Steve Lukert ,161
-Brown,0004 HIAWATHA WARD 4,State House,62,D,Steve Lukert ,15
-Brown,0005 HORTON WARD 1,State House,62,D,Steve Lukert ,85
-Brown,0006 HORTON WARD 2,State House,62,D,Steve Lukert ,52
-Brown,0007 HORTON WARD 3,State House,62,D,Steve Lukert ,33
-Brown,0008 RESERVE  PRECINCT,State House,62,D,Steve Lukert ,13
-Brown,0009 HAMLIN PRECINCT,State House,62,D,Steve Lukert ,22
-Brown,0010 HIAWATHA TWP,State House,62,D,Steve Lukert ,110
-Brown,0011 IRVING PRECINCT,State House,62,D,Steve Lukert ,48
-Brown,0012 MISSION PRECINCT,State House,62,D,Steve Lukert ,101
-Brown,0013 MORRILL PRECINCT,State House,62,D,Steve Lukert ,43
-Brown,0014 PADONIA PRECINCT,State House,62,D,Steve Lukert ,32
-Brown,0015 POWHATTAN  PRECINCT,State House,62,D,Steve Lukert ,98
-Brown,0016 ROBINSON  PRECINCT,State House,62,D,Steve Lukert ,67
-Brown,0017 WALNUT  PRECINCT,State House,62,D,Steve Lukert ,104
-Brown,0018 WASHINGTON  PRECINCT,State House,62,D,Steve Lukert ,58
-Brown,0001 HIAWATHA WARD 1,State House,,,Write-ins,2
-Brown,0002 HIAWATHA WARD 2,State House,,,Write-ins,1
-Brown,0006 HORTON WARD 2,State House,,,Write-ins,1
-Brown,0015 POWHATTAN  PRECINCT,State House,,,Write-ins,2
-Brown,0001 HIAWATHA WARD 1,State Treasurer,,D,Carmen Alldritt ,52
-Brown,0002 HIAWATHA WARD 2,State Treasurer,,D,Carmen Alldritt ,122
-Brown,0003 HIAWATHA WARD 3,State Treasurer,,D,Carmen Alldritt ,92
-Brown,0004 HIAWATHA WARD 4,State Treasurer,,D,Carmen Alldritt ,15
-Brown,0005 HORTON WARD 1,State Treasurer,,D,Carmen Alldritt ,53
-Brown,0006 HORTON WARD 2,State Treasurer,,D,Carmen Alldritt ,28
-Brown,0007 HORTON WARD 3,State Treasurer,,D,Carmen Alldritt ,24
-Brown,0008 RESERVE  PRECINCT,State Treasurer,,D,Carmen Alldritt ,9
-Brown,0009 HAMLIN PRECINCT,State Treasurer,,D,Carmen Alldritt ,12
-Brown,0010 HIAWATHA TWP,State Treasurer,,D,Carmen Alldritt ,38
-Brown,0011 IRVING PRECINCT,State Treasurer,,D,Carmen Alldritt ,22
-Brown,0012 MISSION PRECINCT,State Treasurer,,D,Carmen Alldritt ,48
-Brown,0013 MORRILL PRECINCT,State Treasurer,,D,Carmen Alldritt ,19
-Brown,0014 PADONIA PRECINCT,State Treasurer,,D,Carmen Alldritt ,9
-Brown,0015 POWHATTAN  PRECINCT,State Treasurer,,D,Carmen Alldritt ,74
-Brown,0016 ROBINSON  PRECINCT,State Treasurer,,D,Carmen Alldritt ,41
-Brown,0017 WALNUT  PRECINCT,State Treasurer,,D,Carmen Alldritt ,55
-Brown,0018 WASHINGTON  PRECINCT,State Treasurer,,D,Carmen Alldritt ,26
-Brown,0001 HIAWATHA WARD 1,State Treasurer,,R,Ron Estes,98
-Brown,0002 HIAWATHA WARD 2,State Treasurer,,R,Ron Estes,344
-Brown,0003 HIAWATHA WARD 3,State Treasurer,,R,Ron Estes,267
-Brown,0004 HIAWATHA WARD 4,State Treasurer,,R,Ron Estes,43
-Brown,0005 HORTON WARD 1,State Treasurer,,R,Ron Estes,134
-Brown,0006 HORTON WARD 2,State Treasurer,,R,Ron Estes,101
-Brown,0007 HORTON WARD 3,State Treasurer,,R,Ron Estes,52
-Brown,0008 RESERVE  PRECINCT,State Treasurer,,R,Ron Estes,31
-Brown,0009 HAMLIN PRECINCT,State Treasurer,,R,Ron Estes,58
-Brown,0010 HIAWATHA TWP,State Treasurer,,R,Ron Estes,213
-Brown,0011 IRVING PRECINCT,State Treasurer,,R,Ron Estes,74
-Brown,0012 MISSION PRECINCT,State Treasurer,,R,Ron Estes,201
-Brown,0013 MORRILL PRECINCT,State Treasurer,,R,Ron Estes,157
-Brown,0014 PADONIA PRECINCT,State Treasurer,,R,Ron Estes,62
-Brown,0015 POWHATTAN  PRECINCT,State Treasurer,,R,Ron Estes,129
-Brown,0016 ROBINSON  PRECINCT,State Treasurer,,R,Ron Estes,124
-Brown,0017 WALNUT  PRECINCT,State Treasurer,,R,Ron Estes,189
-Brown,0018 WASHINGTON  PRECINCT,State Treasurer,,R,Ron Estes,130
-Brown,0015 POWHATTAN  PRECINCT,State Treasurer,,,Write-ins,1
-Brown,0001 HIAWATHA WARD 1,U.S. Senate,,I,Greg Orman,54
-Brown,0002 HIAWATHA WARD 2,U.S. Senate,,I,Greg Orman,174
-Brown,0003 HIAWATHA WARD 3,U.S. Senate,,I,Greg Orman,128
-Brown,0004 HIAWATHA WARD 4,U.S. Senate,,I,Greg Orman,16
-Brown,0005 HORTON WARD 1,U.S. Senate,,I,Greg Orman,58
-Brown,0006 HORTON WARD 2,U.S. Senate,,I,Greg Orman,45
-Brown,0007 HORTON WARD 3,U.S. Senate,,I,Greg Orman,28
-Brown,0008 RESERVE  PRECINCT,U.S. Senate,,I,Greg Orman,9
-Brown,0009 HAMLIN PRECINCT,U.S. Senate,,I,Greg Orman,13
-Brown,0010 HIAWATHA TWP,U.S. Senate,,I,Greg Orman,58
-Brown,0011 IRVING PRECINCT,U.S. Senate,,I,Greg Orman,29
-Brown,0012 MISSION PRECINCT,U.S. Senate,,I,Greg Orman,74
-Brown,0013 MORRILL PRECINCT,U.S. Senate,,I,Greg Orman,24
-Brown,0014 PADONIA PRECINCT,U.S. Senate,,I,Greg Orman,16
-Brown,0015 POWHATTAN  PRECINCT,U.S. Senate,,I,Greg Orman,87
-Brown,0016 ROBINSON  PRECINCT,U.S. Senate,,I,Greg Orman,50
-Brown,0017 WALNUT  PRECINCT,U.S. Senate,,I,Greg Orman,69
-Brown,0018 WASHINGTON  PRECINCT,U.S. Senate,,I,Greg Orman,32
-Brown,0001 HIAWATHA WARD 1,U.S. Senate,,R,Pat Roberts,89
-Brown,0002 HIAWATHA WARD 2,U.S. Senate,,R,Pat Roberts,282
-Brown,0003 HIAWATHA WARD 3,U.S. Senate,,R,Pat Roberts,215
-Brown,0004 HIAWATHA WARD 4,U.S. Senate,,R,Pat Roberts,36
-Brown,0005 HORTON WARD 1,U.S. Senate,,R,Pat Roberts,126
-Brown,0006 HORTON WARD 2,U.S. Senate,,R,Pat Roberts,83
-Brown,0007 HORTON WARD 3,U.S. Senate,,R,Pat Roberts,40
-Brown,0008 RESERVE  PRECINCT,U.S. Senate,,R,Pat Roberts,27
-Brown,0009 HAMLIN PRECINCT,U.S. Senate,,R,Pat Roberts,53
-Brown,0010 HIAWATHA TWP,U.S. Senate,,R,Pat Roberts,187
-Brown,0011 IRVING PRECINCT,U.S. Senate,,R,Pat Roberts,63
-Brown,0012 MISSION PRECINCT,U.S. Senate,,R,Pat Roberts,174
-Brown,0013 MORRILL PRECINCT,U.S. Senate,,R,Pat Roberts,151
-Brown,0014 PADONIA PRECINCT,U.S. Senate,,R,Pat Roberts,47
-Brown,0015 POWHATTAN  PRECINCT,U.S. Senate,,R,Pat Roberts,106
-Brown,0016 ROBINSON  PRECINCT,U.S. Senate,,R,Pat Roberts,102
-Brown,0017 WALNUT  PRECINCT,U.S. Senate,,R,Pat Roberts,173
-Brown,0018 WASHINGTON  PRECINCT,U.S. Senate,,R,Pat Roberts,120
-Brown,0001 HIAWATHA WARD 1,U.S. Senate,,L,Randall Batson,12
-Brown,0002 HIAWATHA WARD 2,U.S. Senate,,L,Randall Batson,17
-Brown,0003 HIAWATHA WARD 3,U.S. Senate,,L,Randall Batson,20
-Brown,0004 HIAWATHA WARD 4,U.S. Senate,,L,Randall Batson,5
-Brown,0005 HORTON WARD 1,U.S. Senate,,L,Randall Batson,11
-Brown,0006 HORTON WARD 2,U.S. Senate,,L,Randall Batson,5
-Brown,0007 HORTON WARD 3,U.S. Senate,,L,Randall Batson,9
-Brown,0008 RESERVE  PRECINCT,U.S. Senate,,L,Randall Batson,5
-Brown,0009 HAMLIN PRECINCT,U.S. Senate,,L,Randall Batson,6
-Brown,0010 HIAWATHA TWP,U.S. Senate,,L,Randall Batson,8
-Brown,0011 IRVING PRECINCT,U.S. Senate,,L,Randall Batson,4
-Brown,0012 MISSION PRECINCT,U.S. Senate,,L,Randall Batson,5
-Brown,0013 MORRILL PRECINCT,U.S. Senate,,L,Randall Batson,6
-Brown,0014 PADONIA PRECINCT,U.S. Senate,,L,Randall Batson,11
-Brown,0015 POWHATTAN  PRECINCT,U.S. Senate,,L,Randall Batson,7
-Brown,0016 ROBINSON  PRECINCT,U.S. Senate,,L,Randall Batson,9
-Brown,0017 WALNUT  PRECINCT,U.S. Senate,,L,Randall Batson,7
-Brown,0018 WASHINGTON  PRECINCT,U.S. Senate,,L,Randall Batson,3
-Brown,0002 HIAWATHA WARD 2,U.S. Senate,,,Write-ins,1
-Brown,0005 HORTON WARD 1,U.S. Senate,,,Write-ins,1
-Brown,0006 HORTON WARD 2,U.S. Senate,,,Write-ins,2
-Brown,0014 PADONIA PRECINCT,U.S. Senate,,,Write-ins,1
-Brown,0015 POWHATTAN  PRECINCT,U.S. Senate,,,Write-ins,1
-Brown,0016 ROBINSON  PRECINCT,U.S. Senate,,,Write-ins,1
-Brown,0017 WALNUT  PRECINCT,U.S. Senate,,,Write-ins,1
-Brown,0001 HIAWATHA WARD 1,Voters,,,BALLOTS CAST - TOTAL,156
-Brown,0002 HIAWATHA WARD 2,Voters,,,BALLOTS CAST - TOTAL,482
-Brown,0003 HIAWATHA WARD 3,Voters,,,BALLOTS CAST - TOTAL,375
-Brown,0004 HIAWATHA WARD 4,Voters,,,BALLOTS CAST - TOTAL,58
-Brown,0005 HORTON WARD 1,Voters,,,BALLOTS CAST - TOTAL,198
-Brown,0006 HORTON WARD 2,Voters,,,BALLOTS CAST - TOTAL,135
-Brown,0007 HORTON WARD 3,Voters,,,BALLOTS CAST - TOTAL,79
-Brown,0008 RESERVE  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,42
-Brown,0009 HAMLIN PRECINCT,Voters,,,BALLOTS CAST - TOTAL,72
-Brown,0010 HIAWATHA TWP,Voters,,,BALLOTS CAST - TOTAL,257
-Brown,0011 IRVING PRECINCT,Voters,,,BALLOTS CAST - TOTAL,96
-Brown,0012 MISSION PRECINCT,Voters,,,BALLOTS CAST - TOTAL,253
-Brown,0013 MORRILL PRECINCT,Voters,,,BALLOTS CAST - TOTAL,182
-Brown,0014 PADONIA PRECINCT,Voters,,,BALLOTS CAST - TOTAL,75
-Brown,0015 POWHATTAN  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,204
-Brown,0016 ROBINSON  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,169
-Brown,0017 WALNUT  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,254
-Brown,0018 WASHINGTON  PRECINCT,Voters,,,BALLOTS CAST - TOTAL,158
-Brown,0001 HIAWATHA WARD 1,Voters,,,REGISTERED VOTERS - TOTAL,279
-Brown,0002 HIAWATHA WARD 2,Voters,,,REGISTERED VOTERS - TOTAL,787
-Brown,0003 HIAWATHA WARD 3,Voters,,,REGISTERED VOTERS - TOTAL,689
-Brown,0004 HIAWATHA WARD 4,Voters,,,REGISTERED VOTERS - TOTAL,159
-Brown,0005 HORTON WARD 1,Voters,,,REGISTERED VOTERS - TOTAL,423
-Brown,0006 HORTON WARD 2,Voters,,,REGISTERED VOTERS - TOTAL,306
-Brown,0007 HORTON WARD 3,Voters,,,REGISTERED VOTERS - TOTAL,225
-Brown,0008 RESERVE  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,88
-Brown,0009 HAMLIN PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,108
-Brown,0010 HIAWATHA TWP,Voters,,,REGISTERED VOTERS - TOTAL,409
-Brown,0011 IRVING PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,189
-Brown,0012 MISSION PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,381
-Brown,0013 MORRILL PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,296
-Brown,0014 PADONIA PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,132
-Brown,0015 POWHATTAN  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,439
-Brown,0016 ROBINSON  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,264
-Brown,0017 WALNUT  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,399
-Brown,0018 WASHINGTON  PRECINCT,Voters,,,REGISTERED VOTERS - TOTAL,310
+county,precinct,office,district,party,candidate,votes,vtd
+BROWN,Hamlin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000010
+BROWN,Hamlin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000010
+BROWN,Hamlin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000010
+BROWN,Hiawatha City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",69,000020
+BROWN,Hiawatha City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000020
+BROWN,Hiawatha City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000020
+BROWN,Hiawatha City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",242,000030
+BROWN,Hiawatha City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000030
+BROWN,Hiawatha City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",215,000030
+BROWN,Hiawatha City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",174,00004A
+BROWN,Hiawatha City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,00004A
+BROWN,Hiawatha City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",188,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00004B
+BROWN,Hiawatha City Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,00005A
+BROWN,Hiawatha City Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00005A
+BROWN,Hiawatha City Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+BROWN,Hiawatha Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",87,000060
+BROWN,Hiawatha Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000060
+BROWN,Hiawatha Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",161,000060
+BROWN,Horton Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,000070
+BROWN,Horton Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000070
+BROWN,Horton Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,000070
+BROWN,Horton Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000080
+BROWN,Horton Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000080
+BROWN,Horton Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000080
+BROWN,Horton Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,00009A
+BROWN,Horton Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00009A
+BROWN,Horton Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,00009A
+BROWN,Horton Ward 3 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00009B
+BROWN,Horton Ward 3 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00009B
+BROWN,Horton Ward 3 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00009B
+BROWN,Horton Ward 3 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00009C
+BROWN,Horton Ward 3 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00009C
+BROWN,Horton Ward 3 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00009C
+BROWN,Irving Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000100
+BROWN,Irving Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000100
+BROWN,Irving Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000100
+BROWN,Mission Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000110
+BROWN,Mission Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000110
+BROWN,Mission Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",151,000110
+BROWN,Morrill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000120
+BROWN,Morrill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000120
+BROWN,Morrill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,000120
+BROWN,Padonia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000130
+BROWN,Padonia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000130
+BROWN,Padonia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000130
+BROWN,Powhattan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,000140
+BROWN,Powhattan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000140
+BROWN,Powhattan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,000140
+BROWN,Reserve Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000150
+BROWN,Reserve Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000150
+BROWN,Reserve Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000150
+BROWN,Robinson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",58,000160
+BROWN,Robinson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000160
+BROWN,Robinson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,000160
+BROWN,Sabetha Ward 1 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00017A
+BROWN,Sabetha Ward 1 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00017A
+BROWN,Sabetha Ward 1 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00017A
+BROWN,Sabetha Ward 1 Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00017B
+BROWN,Sabetha Ward 1 Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00017B
+BROWN,Sabetha Ward 1 Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00017B
+BROWN,Sabetha Ward 4 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018A
+BROWN,Sabetha Ward 4 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018A
+BROWN,Sabetha Ward 4 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018A
+BROWN,Sabetha Ward 4 Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018B
+BROWN,Sabetha Ward 4 Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018B
+BROWN,Sabetha Ward 4 Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018B
+BROWN,Sabetha Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000190
+BROWN,Sabetha Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000190
+BROWN,Sabetha Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000190
+BROWN,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",77,000200
+BROWN,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000200
+BROWN,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",158,000200
+BROWN,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000210
+BROWN,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000210
+BROWN,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",106,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+BROWN,Hamlin Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",22,000010
+BROWN,Hamlin Township,Kansas House of Representatives,62,Republican,"Garber, Randy",50,000010
+BROWN,Hiawatha City Ward 1,Kansas House of Representatives,62,Democratic,"Lukert, Steve",83,000020
+BROWN,Hiawatha City Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",71,000020
+BROWN,Hiawatha City Ward 2,Kansas House of Representatives,62,Democratic,"Lukert, Steve",247,000030
+BROWN,Hiawatha City Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",227,000030
+BROWN,Hiawatha City Ward 3,Kansas House of Representatives,62,Democratic,"Lukert, Steve",161,00004A
+BROWN,Hiawatha City Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",207,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00004B
+BROWN,Hiawatha City Ward 4,Kansas House of Representatives,62,Democratic,"Lukert, Steve",15,00005A
+BROWN,Hiawatha City Ward 4,Kansas House of Representatives,62,Republican,"Garber, Randy",42,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00005B
+BROWN,Hiawatha Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",110,000060
+BROWN,Hiawatha Township,Kansas House of Representatives,62,Republican,"Garber, Randy",145,000060
+BROWN,Horton Ward 1,Kansas House of Representatives,62,Democratic,"Lukert, Steve",85,000070
+BROWN,Horton Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",111,000070
+BROWN,Horton Ward 2,Kansas House of Representatives,62,Democratic,"Lukert, Steve",52,000080
+BROWN,Horton Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",82,000080
+BROWN,Horton Ward 3,Kansas House of Representatives,62,Democratic,"Lukert, Steve",33,00009A
+BROWN,Horton Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",43,00009A
+BROWN,Horton Ward 3 Exclave A,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00009B
+BROWN,Horton Ward 3 Exclave A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00009B
+BROWN,Horton Ward 3 Exclave B,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00009C
+BROWN,Horton Ward 3 Exclave B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00009C
+BROWN,Irving Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",48,000100
+BROWN,Irving Township,Kansas House of Representatives,62,Republican,"Garber, Randy",47,000100
+BROWN,Mission Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",101,000110
+BROWN,Mission Township,Kansas House of Representatives,62,Republican,"Garber, Randy",152,000110
+BROWN,Morrill Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",43,000120
+BROWN,Morrill Township,Kansas House of Representatives,62,Republican,"Garber, Randy",139,000120
+BROWN,Padonia Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",32,000130
+BROWN,Padonia Township,Kansas House of Representatives,62,Republican,"Garber, Randy",43,000130
+BROWN,Powhattan Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",98,000140
+BROWN,Powhattan Township,Kansas House of Representatives,62,Republican,"Garber, Randy",104,000140
+BROWN,Reserve Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",13,000150
+BROWN,Reserve Township,Kansas House of Representatives,62,Republican,"Garber, Randy",28,000150
+BROWN,Robinson Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",67,000160
+BROWN,Robinson Township,Kansas House of Representatives,62,Republican,"Garber, Randy",99,000160
+BROWN,Sabetha Ward 1 Part A,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00017A
+BROWN,Sabetha Ward 1 Part A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00017A
+BROWN,Sabetha Ward 1 Part B,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00017B
+BROWN,Sabetha Ward 1 Part B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00017B
+BROWN,Sabetha Ward 4 Part A,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00018A
+BROWN,Sabetha Ward 4 Part A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00018A
+BROWN,Sabetha Ward 4 Part B,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00018B
+BROWN,Sabetha Ward 4 Part B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00018B
+BROWN,Sabetha Ward 5,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,000190
+BROWN,Sabetha Ward 5,Kansas House of Representatives,62,Republican,"Garber, Randy",0,000190
+BROWN,Walnut Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",104,000200
+BROWN,Walnut Township,Kansas House of Representatives,62,Republican,"Garber, Randy",148,000200
+BROWN,Washington Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",58,000210
+BROWN,Washington Township,Kansas House of Representatives,62,Republican,"Garber, Randy",99,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900010
+BROWN,Hamlin Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",7,000010
+BROWN,Hamlin Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000010
+BROWN,Hamlin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,000010
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,000020
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000020
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,000020
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",139,000030
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000030
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",316,000030
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",109,00004A
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,00004A
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",252,00004A
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",10,00005A
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,00005A
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+BROWN,Hiawatha Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,000060
+BROWN,Hiawatha Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000060
+BROWN,Hiawatha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",191,000060
+BROWN,Horton Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,000070
+BROWN,Horton Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000070
+BROWN,Horton Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",140,000070
+BROWN,Horton Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,000080
+BROWN,Horton Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000080
+BROWN,Horton Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,000080
+BROWN,Horton Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,00009A
+BROWN,Horton Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,00009A
+BROWN,Horton Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,00009A
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00009B
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00009C
+BROWN,Irving Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000100
+BROWN,Irving Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000100
+BROWN,Irving Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",69,000100
+BROWN,Mission Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",57,000110
+BROWN,Mission Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000110
+BROWN,Mission Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",191,000110
+BROWN,Morrill Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,000120
+BROWN,Morrill Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000120
+BROWN,Morrill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",150,000120
+BROWN,Padonia Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,000130
+BROWN,Padonia Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000130
+BROWN,Padonia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",48,000130
+BROWN,Powhattan Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",73,000140
+BROWN,Powhattan Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000140
+BROWN,Powhattan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",119,000140
+BROWN,Reserve Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",11,000150
+BROWN,Reserve Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000150
+BROWN,Reserve Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",27,000150
+BROWN,Robinson Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",40,000160
+BROWN,Robinson Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000160
+BROWN,Robinson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",118,000160
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017A
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017B
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018A
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018B
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,000190
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000190
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000190
+BROWN,Walnut Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",58,000200
+BROWN,Walnut Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000200
+BROWN,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",182,000200
+BROWN,Washington Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,000210
+BROWN,Washington Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000210
+BROWN,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",125,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+BROWN,Hamlin Township,Attorney General,,Democratic,"Kotich, A.J.",12,000010
+BROWN,Hamlin Township,Attorney General,,Republican,"Schmidt, Derek",58,000010
+BROWN,Hiawatha City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",51,000020
+BROWN,Hiawatha City Ward 1,Attorney General,,Republican,"Schmidt, Derek",103,000020
+BROWN,Hiawatha City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",123,000030
+BROWN,Hiawatha City Ward 2,Attorney General,,Republican,"Schmidt, Derek",343,000030
+BROWN,Hiawatha City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",103,00004A
+BROWN,Hiawatha City Ward 3,Attorney General,,Republican,"Schmidt, Derek",260,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00004B
+BROWN,Hiawatha City Ward 4,Attorney General,,Democratic,"Kotich, A.J.",10,00005A
+BROWN,Hiawatha City Ward 4,Attorney General,,Republican,"Schmidt, Derek",48,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+BROWN,Hiawatha Township,Attorney General,,Democratic,"Kotich, A.J.",48,000060
+BROWN,Hiawatha Township,Attorney General,,Republican,"Schmidt, Derek",205,000060
+BROWN,Horton Ward 1,Attorney General,,Democratic,"Kotich, A.J.",54,000070
+BROWN,Horton Ward 1,Attorney General,,Republican,"Schmidt, Derek",142,000070
+BROWN,Horton Ward 2,Attorney General,,Democratic,"Kotich, A.J.",33,000080
+BROWN,Horton Ward 2,Attorney General,,Republican,"Schmidt, Derek",99,000080
+BROWN,Horton Ward 3,Attorney General,,Democratic,"Kotich, A.J.",21,00009A
+BROWN,Horton Ward 3,Attorney General,,Republican,"Schmidt, Derek",56,00009A
+BROWN,Horton Ward 3 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00009B
+BROWN,Horton Ward 3 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00009B
+BROWN,Horton Ward 3 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00009C
+BROWN,Horton Ward 3 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00009C
+BROWN,Irving Township,Attorney General,,Democratic,"Kotich, A.J.",23,000100
+BROWN,Irving Township,Attorney General,,Republican,"Schmidt, Derek",70,000100
+BROWN,Mission Township,Attorney General,,Democratic,"Kotich, A.J.",57,000110
+BROWN,Mission Township,Attorney General,,Republican,"Schmidt, Derek",194,000110
+BROWN,Morrill Township,Attorney General,,Democratic,"Kotich, A.J.",16,000120
+BROWN,Morrill Township,Attorney General,,Republican,"Schmidt, Derek",161,000120
+BROWN,Padonia Township,Attorney General,,Democratic,"Kotich, A.J.",16,000130
+BROWN,Padonia Township,Attorney General,,Republican,"Schmidt, Derek",53,000130
+BROWN,Powhattan Township,Attorney General,,Democratic,"Kotich, A.J.",74,000140
+BROWN,Powhattan Township,Attorney General,,Republican,"Schmidt, Derek",129,000140
+BROWN,Reserve Township,Attorney General,,Democratic,"Kotich, A.J.",9,000150
+BROWN,Reserve Township,Attorney General,,Republican,"Schmidt, Derek",30,000150
+BROWN,Robinson Township,Attorney General,,Democratic,"Kotich, A.J.",45,000160
+BROWN,Robinson Township,Attorney General,,Republican,"Schmidt, Derek",119,000160
+BROWN,Sabetha Ward 1 Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00017A
+BROWN,Sabetha Ward 1 Part A,Attorney General,,Republican,"Schmidt, Derek",0,00017A
+BROWN,Sabetha Ward 1 Part B,Attorney General,,Democratic,"Kotich, A.J.",0,00017B
+BROWN,Sabetha Ward 1 Part B,Attorney General,,Republican,"Schmidt, Derek",0,00017B
+BROWN,Sabetha Ward 4 Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00018A
+BROWN,Sabetha Ward 4 Part A,Attorney General,,Republican,"Schmidt, Derek",0,00018A
+BROWN,Sabetha Ward 4 Part B,Attorney General,,Democratic,"Kotich, A.J.",0,00018B
+BROWN,Sabetha Ward 4 Part B,Attorney General,,Republican,"Schmidt, Derek",0,00018B
+BROWN,Sabetha Ward 5,Attorney General,,Democratic,"Kotich, A.J.",0,000190
+BROWN,Sabetha Ward 5,Attorney General,,Republican,"Schmidt, Derek",0,000190
+BROWN,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",52,000200
+BROWN,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",195,000200
+BROWN,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",27,000210
+BROWN,Washington Township,Attorney General,,Republican,"Schmidt, Derek",129,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+BROWN,Hamlin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000010
+BROWN,Hamlin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",56,000010
+BROWN,Hiawatha City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000020
+BROWN,Hiawatha City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",94,000020
+BROWN,Hiawatha City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",141,000030
+BROWN,Hiawatha City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",315,000030
+BROWN,Hiawatha City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",114,00004A
+BROWN,Hiawatha City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",241,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00004B
+BROWN,Hiawatha City Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,00005A
+BROWN,Hiawatha City Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",40,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+BROWN,Hiawatha Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000060
+BROWN,Hiawatha Township,Commissioner of Insurance,,Republican,"Selzer, Ken",194,000060
+BROWN,Horton Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,000070
+BROWN,Horton Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",127,000070
+BROWN,Horton Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000080
+BROWN,Horton Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",92,000080
+BROWN,Horton Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,00009A
+BROWN,Horton Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",51,00009A
+BROWN,Horton Ward 3 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00009B
+BROWN,Horton Ward 3 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00009B
+BROWN,Horton Ward 3 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00009C
+BROWN,Horton Ward 3 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00009C
+BROWN,Irving Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000100
+BROWN,Irving Township,Commissioner of Insurance,,Republican,"Selzer, Ken",66,000100
+BROWN,Mission Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,000110
+BROWN,Mission Township,Commissioner of Insurance,,Republican,"Selzer, Ken",184,000110
+BROWN,Morrill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000120
+BROWN,Morrill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",149,000120
+BROWN,Padonia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000130
+BROWN,Padonia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000130
+BROWN,Powhattan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",83,000140
+BROWN,Powhattan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",116,000140
+BROWN,Reserve Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000150
+BROWN,Reserve Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000150
+BROWN,Robinson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000160
+BROWN,Robinson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000160
+BROWN,Sabetha Ward 1 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00017A
+BROWN,Sabetha Ward 1 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00017A
+BROWN,Sabetha Ward 1 Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00017B
+BROWN,Sabetha Ward 1 Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00017B
+BROWN,Sabetha Ward 4 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018A
+BROWN,Sabetha Ward 4 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018A
+BROWN,Sabetha Ward 4 Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018B
+BROWN,Sabetha Ward 4 Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018B
+BROWN,Sabetha Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000190
+BROWN,Sabetha Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000190
+BROWN,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000200
+BROWN,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",181,000200
+BROWN,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000210
+BROWN,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",115,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+BROWN,Hamlin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000010
+BROWN,Hamlin Township,Secretary of State,,Republican,"Kobach, Kris",61,000010
+BROWN,Hiawatha City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,000020
+BROWN,Hiawatha City Ward 1,Secretary of State,,Republican,"Kobach, Kris",101,000020
+BROWN,Hiawatha City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",160,000030
+BROWN,Hiawatha City Ward 2,Secretary of State,,Republican,"Kobach, Kris",308,000030
+BROWN,Hiawatha City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",116,00004A
+BROWN,Hiawatha City Ward 3,Secretary of State,,Republican,"Kobach, Kris",244,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00004B
+BROWN,Hiawatha City Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,00005A
+BROWN,Hiawatha City Ward 4,Secretary of State,,Republican,"Kobach, Kris",45,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+BROWN,Hiawatha Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000060
+BROWN,Hiawatha Township,Secretary of State,,Republican,"Kobach, Kris",205,000060
+BROWN,Horton Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000070
+BROWN,Horton Ward 1,Secretary of State,,Republican,"Kobach, Kris",136,000070
+BROWN,Horton Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000080
+BROWN,Horton Ward 2,Secretary of State,,Republican,"Kobach, Kris",97,000080
+BROWN,Horton Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,00009A
+BROWN,Horton Ward 3,Secretary of State,,Republican,"Kobach, Kris",46,00009A
+BROWN,Horton Ward 3 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00009B
+BROWN,Horton Ward 3 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00009B
+BROWN,Horton Ward 3 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00009C
+BROWN,Horton Ward 3 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00009C
+BROWN,Irving Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000100
+BROWN,Irving Township,Secretary of State,,Republican,"Kobach, Kris",68,000100
+BROWN,Mission Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,000110
+BROWN,Mission Township,Secretary of State,,Republican,"Kobach, Kris",188,000110
+BROWN,Morrill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000120
+BROWN,Morrill Township,Secretary of State,,Republican,"Kobach, Kris",162,000120
+BROWN,Padonia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000130
+BROWN,Padonia Township,Secretary of State,,Republican,"Kobach, Kris",58,000130
+BROWN,Powhattan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,000140
+BROWN,Powhattan Township,Secretary of State,,Republican,"Kobach, Kris",116,000140
+BROWN,Reserve Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000150
+BROWN,Reserve Township,Secretary of State,,Republican,"Kobach, Kris",27,000150
+BROWN,Robinson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000160
+BROWN,Robinson Township,Secretary of State,,Republican,"Kobach, Kris",122,000160
+BROWN,Sabetha Ward 1 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00017A
+BROWN,Sabetha Ward 1 Part A,Secretary of State,,Republican,"Kobach, Kris",0,00017A
+BROWN,Sabetha Ward 1 Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00017B
+BROWN,Sabetha Ward 1 Part B,Secretary of State,,Republican,"Kobach, Kris",0,00017B
+BROWN,Sabetha Ward 4 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018A
+BROWN,Sabetha Ward 4 Part A,Secretary of State,,Republican,"Kobach, Kris",0,00018A
+BROWN,Sabetha Ward 4 Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018B
+BROWN,Sabetha Ward 4 Part B,Secretary of State,,Republican,"Kobach, Kris",0,00018B
+BROWN,Sabetha Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000190
+BROWN,Sabetha Ward 5,Secretary of State,,Republican,"Kobach, Kris",0,000190
+BROWN,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000200
+BROWN,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",185,000200
+BROWN,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000210
+BROWN,Washington Township,Secretary of State,,Republican,"Kobach, Kris",133,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+BROWN,Hamlin Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000010
+BROWN,Hamlin Township,State Treasurer,,Republican,"Estes, Ron",58,000010
+BROWN,Hiawatha City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",52,000020
+BROWN,Hiawatha City Ward 1,State Treasurer,,Republican,"Estes, Ron",98,000020
+BROWN,Hiawatha City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",122,000030
+BROWN,Hiawatha City Ward 2,State Treasurer,,Republican,"Estes, Ron",344,000030
+BROWN,Hiawatha City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",92,00004A
+BROWN,Hiawatha City Ward 3,State Treasurer,,Republican,"Estes, Ron",267,00004A
+BROWN,Hiawatha City Ward 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00004B
+BROWN,Hiawatha City Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",15,00005A
+BROWN,Hiawatha City Ward 4,State Treasurer,,Republican,"Estes, Ron",43,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,State Treasurer,,Republican,"Estes, Ron",0,00005B
+BROWN,Hiawatha Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000060
+BROWN,Hiawatha Township,State Treasurer,,Republican,"Estes, Ron",213,000060
+BROWN,Horton Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",53,000070
+BROWN,Horton Ward 1,State Treasurer,,Republican,"Estes, Ron",134,000070
+BROWN,Horton Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",28,000080
+BROWN,Horton Ward 2,State Treasurer,,Republican,"Estes, Ron",101,000080
+BROWN,Horton Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",24,00009A
+BROWN,Horton Ward 3,State Treasurer,,Republican,"Estes, Ron",52,00009A
+BROWN,Horton Ward 3 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00009B
+BROWN,Horton Ward 3 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00009B
+BROWN,Horton Ward 3 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00009C
+BROWN,Horton Ward 3 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00009C
+BROWN,Irving Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000100
+BROWN,Irving Township,State Treasurer,,Republican,"Estes, Ron",74,000100
+BROWN,Mission Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000110
+BROWN,Mission Township,State Treasurer,,Republican,"Estes, Ron",201,000110
+BROWN,Morrill Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000120
+BROWN,Morrill Township,State Treasurer,,Republican,"Estes, Ron",157,000120
+BROWN,Padonia Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000130
+BROWN,Padonia Township,State Treasurer,,Republican,"Estes, Ron",62,000130
+BROWN,Powhattan Township,State Treasurer,,Democratic,"Alldritt, Carmen",74,000140
+BROWN,Powhattan Township,State Treasurer,,Republican,"Estes, Ron",129,000140
+BROWN,Reserve Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000150
+BROWN,Reserve Township,State Treasurer,,Republican,"Estes, Ron",31,000150
+BROWN,Robinson Township,State Treasurer,,Democratic,"Alldritt, Carmen",41,000160
+BROWN,Robinson Township,State Treasurer,,Republican,"Estes, Ron",124,000160
+BROWN,Sabetha Ward 1 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00017A
+BROWN,Sabetha Ward 1 Part A,State Treasurer,,Republican,"Estes, Ron",0,00017A
+BROWN,Sabetha Ward 1 Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00017B
+BROWN,Sabetha Ward 1 Part B,State Treasurer,,Republican,"Estes, Ron",0,00017B
+BROWN,Sabetha Ward 4 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018A
+BROWN,Sabetha Ward 4 Part A,State Treasurer,,Republican,"Estes, Ron",0,00018A
+BROWN,Sabetha Ward 4 Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018B
+BROWN,Sabetha Ward 4 Part B,State Treasurer,,Republican,"Estes, Ron",0,00018B
+BROWN,Sabetha Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",0,000190
+BROWN,Sabetha Ward 5,State Treasurer,,Republican,"Estes, Ron",0,000190
+BROWN,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",55,000200
+BROWN,Walnut Township,State Treasurer,,Republican,"Estes, Ron",189,000200
+BROWN,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000210
+BROWN,Washington Township,State Treasurer,,Republican,"Estes, Ron",130,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+BROWN,Hamlin Township,United States Senate,,independent,"Orman, Greg",13,000010
+BROWN,Hamlin Township,United States Senate,,Libertarian,"Batson, Randall",6,000010
+BROWN,Hamlin Township,United States Senate,,Republican,"Roberts, Pat",53,000010
+BROWN,Hiawatha City Ward 1,United States Senate,,independent,"Orman, Greg",54,000020
+BROWN,Hiawatha City Ward 1,United States Senate,,Libertarian,"Batson, Randall",12,000020
+BROWN,Hiawatha City Ward 1,United States Senate,,Republican,"Roberts, Pat",89,000020
+BROWN,Hiawatha City Ward 2,United States Senate,,independent,"Orman, Greg",174,000030
+BROWN,Hiawatha City Ward 2,United States Senate,,Libertarian,"Batson, Randall",17,000030
+BROWN,Hiawatha City Ward 2,United States Senate,,Republican,"Roberts, Pat",282,000030
+BROWN,Hiawatha City Ward 3,United States Senate,,independent,"Orman, Greg",128,00004A
+BROWN,Hiawatha City Ward 3,United States Senate,,Libertarian,"Batson, Randall",20,00004A
+BROWN,Hiawatha City Ward 3,United States Senate,,Republican,"Roberts, Pat",215,00004A
+BROWN,Hiawatha City Ward 3 Exclave,United States Senate,,independent,"Orman, Greg",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00004B
+BROWN,Hiawatha City Ward 4,United States Senate,,independent,"Orman, Greg",16,00005A
+BROWN,Hiawatha City Ward 4,United States Senate,,Libertarian,"Batson, Randall",5,00005A
+BROWN,Hiawatha City Ward 4,United States Senate,,Republican,"Roberts, Pat",36,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,United States Senate,,independent,"Orman, Greg",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States Senate,,Republican,"Roberts, Pat",0,00005B
+BROWN,Hiawatha Township,United States Senate,,independent,"Orman, Greg",58,000060
+BROWN,Hiawatha Township,United States Senate,,Libertarian,"Batson, Randall",8,000060
+BROWN,Hiawatha Township,United States Senate,,Republican,"Roberts, Pat",187,000060
+BROWN,Horton Ward 1,United States Senate,,independent,"Orman, Greg",58,000070
+BROWN,Horton Ward 1,United States Senate,,Libertarian,"Batson, Randall",11,000070
+BROWN,Horton Ward 1,United States Senate,,Republican,"Roberts, Pat",126,000070
+BROWN,Horton Ward 2,United States Senate,,independent,"Orman, Greg",45,000080
+BROWN,Horton Ward 2,United States Senate,,Libertarian,"Batson, Randall",5,000080
+BROWN,Horton Ward 2,United States Senate,,Republican,"Roberts, Pat",83,000080
+BROWN,Horton Ward 3,United States Senate,,independent,"Orman, Greg",28,00009A
+BROWN,Horton Ward 3,United States Senate,,Libertarian,"Batson, Randall",9,00009A
+BROWN,Horton Ward 3,United States Senate,,Republican,"Roberts, Pat",40,00009A
+BROWN,Horton Ward 3 Exclave A,United States Senate,,independent,"Orman, Greg",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00009B
+BROWN,Horton Ward 3 Exclave B,United States Senate,,independent,"Orman, Greg",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00009C
+BROWN,Irving Township,United States Senate,,independent,"Orman, Greg",29,000100
+BROWN,Irving Township,United States Senate,,Libertarian,"Batson, Randall",4,000100
+BROWN,Irving Township,United States Senate,,Republican,"Roberts, Pat",63,000100
+BROWN,Mission Township,United States Senate,,independent,"Orman, Greg",74,000110
+BROWN,Mission Township,United States Senate,,Libertarian,"Batson, Randall",5,000110
+BROWN,Mission Township,United States Senate,,Republican,"Roberts, Pat",174,000110
+BROWN,Morrill Township,United States Senate,,independent,"Orman, Greg",24,000120
+BROWN,Morrill Township,United States Senate,,Libertarian,"Batson, Randall",6,000120
+BROWN,Morrill Township,United States Senate,,Republican,"Roberts, Pat",151,000120
+BROWN,Padonia Township,United States Senate,,independent,"Orman, Greg",16,000130
+BROWN,Padonia Township,United States Senate,,Libertarian,"Batson, Randall",11,000130
+BROWN,Padonia Township,United States Senate,,Republican,"Roberts, Pat",47,000130
+BROWN,Powhattan Township,United States Senate,,independent,"Orman, Greg",87,000140
+BROWN,Powhattan Township,United States Senate,,Libertarian,"Batson, Randall",7,000140
+BROWN,Powhattan Township,United States Senate,,Republican,"Roberts, Pat",106,000140
+BROWN,Reserve Township,United States Senate,,independent,"Orman, Greg",9,000150
+BROWN,Reserve Township,United States Senate,,Libertarian,"Batson, Randall",5,000150
+BROWN,Reserve Township,United States Senate,,Republican,"Roberts, Pat",27,000150
+BROWN,Robinson Township,United States Senate,,independent,"Orman, Greg",50,000160
+BROWN,Robinson Township,United States Senate,,Libertarian,"Batson, Randall",9,000160
+BROWN,Robinson Township,United States Senate,,Republican,"Roberts, Pat",102,000160
+BROWN,Sabetha Ward 1 Part A,United States Senate,,independent,"Orman, Greg",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States Senate,,Libertarian,"Batson, Randall",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States Senate,,Republican,"Roberts, Pat",0,00017A
+BROWN,Sabetha Ward 1 Part B,United States Senate,,independent,"Orman, Greg",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States Senate,,Libertarian,"Batson, Randall",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States Senate,,Republican,"Roberts, Pat",0,00017B
+BROWN,Sabetha Ward 4 Part A,United States Senate,,independent,"Orman, Greg",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States Senate,,Libertarian,"Batson, Randall",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States Senate,,Republican,"Roberts, Pat",0,00018A
+BROWN,Sabetha Ward 4 Part B,United States Senate,,independent,"Orman, Greg",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States Senate,,Libertarian,"Batson, Randall",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States Senate,,Republican,"Roberts, Pat",0,00018B
+BROWN,Sabetha Ward 5,United States Senate,,independent,"Orman, Greg",0,000190
+BROWN,Sabetha Ward 5,United States Senate,,Libertarian,"Batson, Randall",0,000190
+BROWN,Sabetha Ward 5,United States Senate,,Republican,"Roberts, Pat",0,000190
+BROWN,Walnut Township,United States Senate,,independent,"Orman, Greg",69,000200
+BROWN,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",7,000200
+BROWN,Walnut Township,United States Senate,,Republican,"Roberts, Pat",173,000200
+BROWN,Washington Township,United States Senate,,independent,"Orman, Greg",32,000210
+BROWN,Washington Township,United States Senate,,Libertarian,"Batson, Randall",3,000210
+BROWN,Washington Township,United States Senate,,Republican,"Roberts, Pat",120,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States Senate,,independent,"Orman, Greg",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900010

--- a/2014/20141104__ks__general__butler__precinct.csv
+++ b/2014/20141104__ks__general__butler__precinct.csv
@@ -1,845 +1,848 @@
-county,precinct,office,district,party,candidate,votes
-BUTLER,Andover W1,U.S. Senate,,R,Pat Roberts,1015
-BUTLER,Andover W2,U.S. Senate,,R,Pat Roberts,832
-BUTLER,Andover W3,U.S. Senate,,R,Pat Roberts,366
-BUTLER,Andover W4,U.S. Senate,,R,Pat Roberts,97
-BUTLER,Augusta City W1,U.S. Senate,,R,Pat Roberts,293
-BUTLER,Augusta City W2,U.S. Senate,,R,Pat Roberts,227
-BUTLER,Augusta City W3,U.S. Senate,,R,Pat Roberts,479
-BUTLER,Augusta City W4,U.S. Senate,,R,Pat Roberts,483
-BUTLER,Augusta Twp - 14,U.S. Senate,,R,Pat Roberts,75
-BUTLER,Augusta Twp - 16,U.S. Senate,,R,Pat Roberts,204
-BUTLER,Benton City/Benton Twp,U.S. Senate,,R,Pat Roberts,606
-BUTLER,Bloomington Twp,U.S. Senate,,R,Pat Roberts,101
-BUTLER,Bruno Twp North - 77,U.S. Senate,,R,Pat Roberts,311
-BUTLER,Bruno Twp North - 99,U.S. Senate,,R,Pat Roberts,161
-BUTLER,Bruno Twp South - 77,U.S. Senate,,R,Pat Roberts,68
-BUTLER,Bruno Twp South - 99,U.S. Senate,,R,Pat Roberts,68
-BUTLER,Cassoday/Sycamore Twp,U.S. Senate,,R,Pat Roberts,84
-BUTLER,Chelsea Twp,U.S. Senate,,R,Pat Roberts,57
-BUTLER,Clay Twp,U.S. Senate,,R,Pat Roberts,23
-BUTLER,Clifford Twp,U.S. Senate,,R,Pat Roberts,77
-BUTLER,Douglass City/Twp,U.S. Senate,,R,Pat Roberts,353
-BUTLER,El Dorado Twp East,U.S. Senate,,R,Pat Roberts,29
-BUTLER,El Dorado Twp West,U.S. Senate,,R,Pat Roberts,120
-BUTLER,El Dorado W1,U.S. Senate,,R,Pat Roberts,733
-BUTLER,El Dorado W2,U.S. Senate,,R,Pat Roberts,474
-BUTLER,El Dorado W3,U.S. Senate,,R,Pat Roberts,374
-BUTLER,El Dorado W4,U.S. Senate,,R,Pat Roberts,259
-BUTLER,Elbing City/Fairmount Twp,U.S. Senate,,R,Pat Roberts,205
-BUTLER,Fairview Twp,U.S. Senate,,R,Pat Roberts,130
-BUTLER,Glencoe Twp,U.S. Senate,,R,Pat Roberts,32
-BUTLER,Hickory Twp,U.S. Senate,,R,Pat Roberts,30
-BUTLER,Latham/Union,U.S. Senate,,R,Pat Roberts,36
-BUTLER,Leon/Little Walnut,U.S. Senate,,R,Pat Roberts,162
-BUTLER,Lincoln Twp,U.S. Senate,,R,Pat Roberts,72
-BUTLER,Logan Twp,U.S. Senate,,R,Pat Roberts,35
-BUTLER,Milton Twp - 75,U.S. Senate,,R,Pat Roberts,141
-BUTLER,Murdock Twp,U.S. Senate,,R,Pat Roberts,134
-BUTLER,Pleasant Twp,U.S. Senate,,R,Pat Roberts,779
-BUTLER,Potwin/Plum Grove,U.S. Senate,,R,Pat Roberts,118
-BUTLER,Prospect Twp,U.S. Senate,,R,Pat Roberts,246
-BUTLER,Richland Twp,U.S. Senate,,R,Pat Roberts,339
-BUTLER,Rock Creek Twp,U.S. Senate,,R,Pat Roberts,77
-BUTLER,Rosalia Twp,U.S. Senate,,R,Pat Roberts,148
-BUTLER,Rose Hill City,U.S. Senate,,R,Pat Roberts,487
-BUTLER,Spring Twp,U.S. Senate,,R,Pat Roberts,327
-BUTLER,Towanda City/Towanda Twp,U.S. Senate,,R,Pat Roberts,594
-BUTLER,Walnut Twp,U.S. Senate,,R,Pat Roberts,142
-BUTLER,Whitewater/Milton - 72,U.S. Senate,,R,Pat Roberts,184
-BUTLER,Andover W1,U.S. Senate,,[I],Greg Orman,668
-BUTLER,Andover W2,U.S. Senate,,[I],Greg Orman,531
-BUTLER,Andover W3,U.S. Senate,,[I],Greg Orman,230
-BUTLER,Andover W4,U.S. Senate,,[I],Greg Orman,29
-BUTLER,Augusta City W1,U.S. Senate,,[I],Greg Orman,236
-BUTLER,Augusta City W2,U.S. Senate,,[I],Greg Orman,157
-BUTLER,Augusta City W3,U.S. Senate,,[I],Greg Orman,392
-BUTLER,Augusta City W4,U.S. Senate,,[I],Greg Orman,314
-BUTLER,Augusta Twp - 14,U.S. Senate,,[I],Greg Orman,55
-BUTLER,Augusta Twp - 16,U.S. Senate,,[I],Greg Orman,89
-BUTLER,Benton City/Benton Twp,U.S. Senate,,[I],Greg Orman,270
-BUTLER,Bloomington Twp,U.S. Senate,,[I],Greg Orman,51
-BUTLER,Bruno Twp North - 77,U.S. Senate,,[I],Greg Orman,102
-BUTLER,Bruno Twp North - 99,U.S. Senate,,[I],Greg Orman,71
-BUTLER,Bruno Twp South - 77,U.S. Senate,,[I],Greg Orman,31
-BUTLER,Bruno Twp South - 99,U.S. Senate,,[I],Greg Orman,28
-BUTLER,Cassoday/Sycamore Twp,U.S. Senate,,[I],Greg Orman,33
-BUTLER,Chelsea Twp,U.S. Senate,,[I],Greg Orman,25
-BUTLER,Clay Twp,U.S. Senate,,[I],Greg Orman,9
-BUTLER,Clifford Twp,U.S. Senate,,[I],Greg Orman,13
-BUTLER,Douglass City/Twp,U.S. Senate,,[I],Greg Orman,236
-BUTLER,El Dorado Twp East,U.S. Senate,,[I],Greg Orman,37
-BUTLER,El Dorado Twp West,U.S. Senate,,[I],Greg Orman,66
-BUTLER,El Dorado W1,U.S. Senate,,[I],Greg Orman,499
-BUTLER,El Dorado W2,U.S. Senate,,[I],Greg Orman,448
-BUTLER,El Dorado W3,U.S. Senate,,[I],Greg Orman,337
-BUTLER,El Dorado W4,U.S. Senate,,[I],Greg Orman,235
-BUTLER,Elbing City/Fairmount Twp,U.S. Senate,,[I],Greg Orman,47
-BUTLER,Fairview Twp,U.S. Senate,,[I],Greg Orman,53
-BUTLER,Glencoe Twp,U.S. Senate,,[I],Greg Orman,33
-BUTLER,Hickory Twp,U.S. Senate,,[I],Greg Orman,8
-BUTLER,Latham/Union,U.S. Senate,,[I],Greg Orman,14
-BUTLER,Leon/Little Walnut,U.S. Senate,,[I],Greg Orman,102
-BUTLER,Lincoln Twp,U.S. Senate,,[I],Greg Orman,26
-BUTLER,Logan Twp,U.S. Senate,,[I],Greg Orman,14
-BUTLER,Milton Twp - 75,U.S. Senate,,[I],Greg Orman,40
-BUTLER,Murdock Twp,U.S. Senate,,[I],Greg Orman,40
-BUTLER,Pleasant Twp,U.S. Senate,,[I],Greg Orman,382
-BUTLER,Potwin/Plum Grove,U.S. Senate,,[I],Greg Orman,79
-BUTLER,Prospect Twp,U.S. Senate,,[I],Greg Orman,139
-BUTLER,Richland Twp,U.S. Senate,,[I],Greg Orman,188
-BUTLER,Rock Creek Twp,U.S. Senate,,[I],Greg Orman,34
-BUTLER,Rosalia Twp,U.S. Senate,,[I],Greg Orman,68
-BUTLER,Rose Hill City,U.S. Senate,,[I],Greg Orman,305
-BUTLER,Spring Twp,U.S. Senate,,[I],Greg Orman,196
-BUTLER,Towanda City/Towanda Twp,U.S. Senate,,[I],Greg Orman,307
-BUTLER,Walnut Twp,U.S. Senate,,[I],Greg Orman,79
-BUTLER,Whitewater/Milton - 72,U.S. Senate,,[I],Greg Orman,67
-BUTLER,Andover W1,U.S. Senate,,L,Randall Batson,62
-BUTLER,Andover W2,U.S. Senate,,L,Randall Batson,43
-BUTLER,Andover W3,U.S. Senate,,L,Randall Batson,33
-BUTLER,Andover W4,U.S. Senate,,L,Randall Batson,3
-BUTLER,Augusta City W1,U.S. Senate,,L,Randall Batson,33
-BUTLER,Augusta City W2,U.S. Senate,,L,Randall Batson,30
-BUTLER,Augusta City W3,U.S. Senate,,L,Randall Batson,42
-BUTLER,Augusta City W4,U.S. Senate,,L,Randall Batson,19
-BUTLER,Augusta Twp - 14,U.S. Senate,,L,Randall Batson,4
-BUTLER,Augusta Twp - 16,U.S. Senate,,L,Randall Batson,9
-BUTLER,Benton City/Benton Twp,U.S. Senate,,L,Randall Batson,38
-BUTLER,Bloomington Twp,U.S. Senate,,L,Randall Batson,7
-BUTLER,Bruno Twp North - 77,U.S. Senate,,L,Randall Batson,15
-BUTLER,Bruno Twp North - 99,U.S. Senate,,L,Randall Batson,13
-BUTLER,Bruno Twp South - 77,U.S. Senate,,L,Randall Batson,3
-BUTLER,Bruno Twp South - 99,U.S. Senate,,L,Randall Batson,7
-BUTLER,Cassoday/Sycamore Twp,U.S. Senate,,L,Randall Batson,13
-BUTLER,Chelsea Twp,U.S. Senate,,L,Randall Batson,7
-BUTLER,Clay Twp,U.S. Senate,,L,Randall Batson,2
-BUTLER,Clifford Twp,U.S. Senate,,L,Randall Batson,0
-BUTLER,Douglass City/Twp,U.S. Senate,,L,Randall Batson,34
-BUTLER,El Dorado Twp East,U.S. Senate,,L,Randall Batson,3
-BUTLER,El Dorado Twp West,U.S. Senate,,L,Randall Batson,6
-BUTLER,El Dorado W1,U.S. Senate,,L,Randall Batson,43
-BUTLER,El Dorado W2,U.S. Senate,,L,Randall Batson,60
-BUTLER,El Dorado W3,U.S. Senate,,L,Randall Batson,51
-BUTLER,El Dorado W4,U.S. Senate,,L,Randall Batson,31
-BUTLER,Elbing City/Fairmount Twp,U.S. Senate,,L,Randall Batson,6
-BUTLER,Fairview Twp,U.S. Senate,,L,Randall Batson,8
-BUTLER,Glencoe Twp,U.S. Senate,,L,Randall Batson,3
-BUTLER,Hickory Twp,U.S. Senate,,L,Randall Batson,0
-BUTLER,Latham/Union,U.S. Senate,,L,Randall Batson,5
-BUTLER,Leon/Little Walnut,U.S. Senate,,L,Randall Batson,27
-BUTLER,Lincoln Twp,U.S. Senate,,L,Randall Batson,7
-BUTLER,Logan Twp,U.S. Senate,,L,Randall Batson,3
-BUTLER,Milton Twp - 75,U.S. Senate,,L,Randall Batson,3
-BUTLER,Murdock Twp,U.S. Senate,,L,Randall Batson,6
-BUTLER,Pleasant Twp,U.S. Senate,,L,Randall Batson,38
-BUTLER,Potwin/Plum Grove,U.S. Senate,,L,Randall Batson,11
-BUTLER,Prospect Twp,U.S. Senate,,L,Randall Batson,23
-BUTLER,Richland Twp,U.S. Senate,,L,Randall Batson,21
-BUTLER,Rock Creek Twp,U.S. Senate,,L,Randall Batson,5
-BUTLER,Rosalia Twp,U.S. Senate,,L,Randall Batson,15
-BUTLER,Rose Hill City,U.S. Senate,,L,Randall Batson,38
-BUTLER,Spring Twp,U.S. Senate,,L,Randall Batson,23
-BUTLER,Towanda City/Towanda Twp,U.S. Senate,,L,Randall Batson,52
-BUTLER,Walnut Twp,U.S. Senate,,L,Randall Batson,15
-BUTLER,Whitewater/Milton - 72,U.S. Senate,,L,Randall Batson,17
-BUTLER,Andover W1,U.S. House,4,R,Mike Pompeo,1263
-BUTLER,Andover W2,U.S. House,4,R,Mike Pompeo,1012
-BUTLER,Andover W3,U.S. House,4,R,Mike Pompeo,466
-BUTLER,Andover W4,U.S. House,4,R,Mike Pompeo,112
-BUTLER,Augusta City W1,U.S. House,4,R,Mike Pompeo,375
-BUTLER,Augusta City W2,U.S. House,4,R,Mike Pompeo,294
-BUTLER,Augusta City W3,U.S. House,4,R,Mike Pompeo,623
-BUTLER,Augusta City W4,U.S. House,4,R,Mike Pompeo,622
-BUTLER,Augusta Twp - 14,U.S. House,4,R,Mike Pompeo,94
-BUTLER,Augusta Twp - 16,U.S. House,4,R,Mike Pompeo,234
-BUTLER,Benton City/Benton Twp,U.S. House,4,R,Mike Pompeo,715
-BUTLER,Bloomington Twp,U.S. House,4,R,Mike Pompeo,114
-BUTLER,Bruno Twp North - 77,U.S. House,4,R,Mike Pompeo,340
-BUTLER,Bruno Twp North - 99,U.S. House,4,R,Mike Pompeo,185
-BUTLER,Bruno Twp South - 77,U.S. House,4,R,Mike Pompeo,80
-BUTLER,Bruno Twp South - 99,U.S. House,4,R,Mike Pompeo,82
-BUTLER,Cassoday/Sycamore Twp,U.S. House,4,R,Mike Pompeo,110
-BUTLER,Chelsea Twp,U.S. House,4,R,Mike Pompeo,62
-BUTLER,Clay Twp,U.S. House,4,R,Mike Pompeo,24
-BUTLER,Clifford Twp,U.S. House,4,R,Mike Pompeo,75
-BUTLER,Douglass City/Twp,U.S. House,4,R,Mike Pompeo,442
-BUTLER,El Dorado Twp East,U.S. House,4,R,Mike Pompeo,42
-BUTLER,El Dorado Twp West,U.S. House,4,R,Mike Pompeo,148
-BUTLER,El Dorado W1,U.S. House,4,R,Mike Pompeo,944
-BUTLER,El Dorado W2,U.S. House,4,R,Mike Pompeo,599
-BUTLER,El Dorado W3,U.S. House,4,R,Mike Pompeo,500
-BUTLER,El Dorado W4,U.S. House,4,R,Mike Pompeo,333
-BUTLER,Elbing City/Fairmount Twp,U.S. House,4,R,Mike Pompeo,211
-BUTLER,Fairview Twp,U.S. House,4,R,Mike Pompeo,146
-BUTLER,Glencoe Twp,U.S. House,4,R,Mike Pompeo,40
-BUTLER,Hickory Twp,U.S. House,4,R,Mike Pompeo,30
-BUTLER,Latham/Union,U.S. House,4,R,Mike Pompeo,43
-BUTLER,Leon/Little Walnut,U.S. House,4,R,Mike Pompeo,214
-BUTLER,Lincoln Twp,U.S. House,4,R,Mike Pompeo,86
-BUTLER,Logan Twp,U.S. House,4,R,Mike Pompeo,38
-BUTLER,Milton Twp - 75,U.S. House,4,R,Mike Pompeo,145
-BUTLER,Murdock Twp,U.S. House,4,R,Mike Pompeo,150
-BUTLER,Pleasant Twp,U.S. House,4,R,Mike Pompeo,915
-BUTLER,Potwin/Plum Grove,U.S. House,4,R,Mike Pompeo,147
-BUTLER,Prospect Twp,U.S. House,4,R,Mike Pompeo,300
-BUTLER,Richland Twp,U.S. House,4,R,Mike Pompeo,417
-BUTLER,Rock Creek Twp,U.S. House,4,R,Mike Pompeo,85
-BUTLER,Rosalia Twp,U.S. House,4,R,Mike Pompeo,178
-BUTLER,Rose Hill City,U.S. House,4,R,Mike Pompeo,607
-BUTLER,Spring Twp,U.S. House,4,R,Mike Pompeo,385
-BUTLER,Towanda City/Towanda Twp,U.S. House,4,R,Mike Pompeo,717
-BUTLER,Walnut Twp,U.S. House,4,R,Mike Pompeo,186
-BUTLER,Whitewater/Milton - 72,U.S. House,4,R,Mike Pompeo,209
-BUTLER,Andover W1,U.S. House,4,D,Perry Schuckman,462
-BUTLER,Andover W2,U.S. House,4,D,Perry Schuckman,381
-BUTLER,Andover W3,U.S. House,4,D,Perry Schuckman,159
-BUTLER,Andover W4,U.S. House,4,D,Perry Schuckman,17
-BUTLER,Augusta City W1,U.S. House,4,D,Perry Schuckman,182
-BUTLER,Augusta City W2,U.S. House,4,D,Perry Schuckman,118
-BUTLER,Augusta City W3,U.S. House,4,D,Perry Schuckman,285
-BUTLER,Augusta City W4,U.S. House,4,D,Perry Schuckman,192
-BUTLER,Augusta Twp - 14,U.S. House,4,D,Perry Schuckman,39
-BUTLER,Augusta Twp - 16,U.S. House,4,D,Perry Schuckman,64
-BUTLER,Benton City/Benton Twp,U.S. House,4,D,Perry Schuckman,189
-BUTLER,Bloomington Twp,U.S. House,4,D,Perry Schuckman,45
-BUTLER,Bruno Twp North - 77,U.S. House,4,D,Perry Schuckman,82
-BUTLER,Bruno Twp North - 99,U.S. House,4,D,Perry Schuckman,57
-BUTLER,Bruno Twp South - 77,U.S. House,4,D,Perry Schuckman,22
-BUTLER,Bruno Twp South - 99,U.S. House,4,D,Perry Schuckman,23
-BUTLER,Cassoday/Sycamore Twp,U.S. House,4,D,Perry Schuckman,18
-BUTLER,Chelsea Twp,U.S. House,4,D,Perry Schuckman,26
-BUTLER,Clay Twp,U.S. House,4,D,Perry Schuckman,9
-BUTLER,Clifford Twp,U.S. House,4,D,Perry Schuckman,15
-BUTLER,Douglass City/Twp,U.S. House,4,D,Perry Schuckman,174
-BUTLER,El Dorado Twp East,U.S. House,4,D,Perry Schuckman,27
-BUTLER,El Dorado Twp West,U.S. House,4,D,Perry Schuckman,47
-BUTLER,El Dorado W1,U.S. House,4,D,Perry Schuckman,335
-BUTLER,El Dorado W2,U.S. House,4,D,Perry Schuckman,364
-BUTLER,El Dorado W3,U.S. House,4,D,Perry Schuckman,252
-BUTLER,El Dorado W4,U.S. House,4,D,Perry Schuckman,190
-BUTLER,Elbing City/Fairmount Twp,U.S. House,4,D,Perry Schuckman,46
-BUTLER,Fairview Twp,U.S. House,4,D,Perry Schuckman,46
-BUTLER,Glencoe Twp,U.S. House,4,D,Perry Schuckman,29
-BUTLER,Hickory Twp,U.S. House,4,D,Perry Schuckman,7
-BUTLER,Latham/Union,U.S. House,4,D,Perry Schuckman,14
-BUTLER,Leon/Little Walnut,U.S. House,4,D,Perry Schuckman,71
-BUTLER,Lincoln Twp,U.S. House,4,D,Perry Schuckman,19
-BUTLER,Logan Twp,U.S. House,4,D,Perry Schuckman,13
-BUTLER,Milton Twp - 75,U.S. House,4,D,Perry Schuckman,31
-BUTLER,Murdock Twp,U.S. House,4,D,Perry Schuckman,32
-BUTLER,Pleasant Twp,U.S. House,4,D,Perry Schuckman,268
-BUTLER,Potwin/Plum Grove,U.S. House,4,D,Perry Schuckman,63
-BUTLER,Prospect Twp,U.S. House,4,D,Perry Schuckman,108
-BUTLER,Richland Twp,U.S. House,4,D,Perry Schuckman,124
-BUTLER,Rock Creek Twp,U.S. House,4,D,Perry Schuckman,31
-BUTLER,Rosalia Twp,U.S. House,4,D,Perry Schuckman,48
-BUTLER,Rose Hill City,U.S. House,4,D,Perry Schuckman,211
-BUTLER,Spring Twp,U.S. House,4,D,Perry Schuckman,156
-BUTLER,Towanda City/Towanda Twp,U.S. House,4,D,Perry Schuckman,230
-BUTLER,Walnut Twp,U.S. House,4,D,Perry Schuckman,45
-BUTLER,Whitewater/Milton - 72,U.S. House,4,D,Perry Schuckman,58
-BUTLER,Andover W1,Governor,,R,Sam Brownback,955
-BUTLER,Andover W2,Governor,,R,Sam Brownback,781
-BUTLER,Andover W3,Governor,,R,Sam Brownback,350
-BUTLER,Andover W4,Governor,,R,Sam Brownback,100
-BUTLER,Augusta City W1,Governor,,R,Sam Brownback,272
-BUTLER,Augusta City W2,Governor,,R,Sam Brownback,215
-BUTLER,Augusta City W3,Governor,,R,Sam Brownback,463
-BUTLER,Augusta City W4,Governor,,R,Sam Brownback,470
-BUTLER,Augusta Twp - 14,Governor,,R,Sam Brownback,75
-BUTLER,Augusta Twp - 16,Governor,,R,Sam Brownback,198
-BUTLER,Benton City/Benton Twp,Governor,,R,Sam Brownback,586
-BUTLER,Bloomington Twp,Governor,,R,Sam Brownback,98
-BUTLER,Bruno Twp North - 77,Governor,,R,Sam Brownback,304
-BUTLER,Bruno Twp North - 99,Governor,,R,Sam Brownback,154
-BUTLER,Bruno Twp South - 77,Governor,,R,Sam Brownback,64
-BUTLER,Bruno Twp South - 99,Governor,,R,Sam Brownback,71
-BUTLER,Cassoday/Sycamore Twp,Governor,,R,Sam Brownback,79
-BUTLER,Chelsea Twp,Governor,,R,Sam Brownback,52
-BUTLER,Clay Twp,Governor,,R,Sam Brownback,22
-BUTLER,Clifford Twp,Governor,,R,Sam Brownback,70
-BUTLER,Douglass City/Twp,Governor,,R,Sam Brownback,316
-BUTLER,El Dorado Twp East,Governor,,R,Sam Brownback,27
-BUTLER,El Dorado Twp West,Governor,,R,Sam Brownback,104
-BUTLER,El Dorado W1,Governor,,R,Sam Brownback,655
-BUTLER,El Dorado W2,Governor,,R,Sam Brownback,441
-BUTLER,El Dorado W3,Governor,,R,Sam Brownback,361
-BUTLER,El Dorado W4,Governor,,R,Sam Brownback,246
-BUTLER,Elbing City/Fairmount Twp,Governor,,R,Sam Brownback,197
-BUTLER,Fairview Twp,Governor,,R,Sam Brownback,124
-BUTLER,Glencoe Twp,Governor,,R,Sam Brownback,34
-BUTLER,Hickory Twp,Governor,,R,Sam Brownback,26
-BUTLER,Latham/Union,Governor,,R,Sam Brownback,39
-BUTLER,Leon/Little Walnut,Governor,,R,Sam Brownback,153
-BUTLER,Lincoln Twp,Governor,,R,Sam Brownback,74
-BUTLER,Logan Twp,Governor,,R,Sam Brownback,32
-BUTLER,Milton Twp - 75,Governor,,R,Sam Brownback,139
-BUTLER,Murdock Twp,Governor,,R,Sam Brownback,135
-BUTLER,Pleasant Twp,Governor,,R,Sam Brownback,746
-BUTLER,Potwin/Plum Grove,Governor,,R,Sam Brownback,112
-BUTLER,Prospect Twp,Governor,,R,Sam Brownback,222
-BUTLER,Richland Twp,Governor,,R,Sam Brownback,336
-BUTLER,Rock Creek Twp,Governor,,R,Sam Brownback,73
-BUTLER,Rosalia Twp,Governor,,R,Sam Brownback,148
-BUTLER,Rose Hill City,Governor,,R,Sam Brownback,475
-BUTLER,Spring Twp,Governor,,R,Sam Brownback,316
-BUTLER,Towanda City/Towanda Twp,Governor,,R,Sam Brownback,569
-BUTLER,Walnut Twp,Governor,,R,Sam Brownback,148
-BUTLER,Whitewater/Milton - 72,Governor,,R,Sam Brownback,176
-BUTLER,Andover W1,Governor,,D,Paul Davis,723
-BUTLER,Andover W2,Governor,,D,Paul Davis,575
-BUTLER,Andover W3,Governor,,D,Paul Davis,252
-BUTLER,Andover W4,Governor,,D,Paul Davis,28
-BUTLER,Augusta City W1,Governor,,D,Paul Davis,252
-BUTLER,Augusta City W2,Governor,,D,Paul Davis,183
-BUTLER,Augusta City W3,Governor,,D,Paul Davis,420
-BUTLER,Augusta City W4,Governor,,D,Paul Davis,316
-BUTLER,Augusta Twp - 14,Governor,,D,Paul Davis,54
-BUTLER,Augusta Twp - 16,Governor,,D,Paul Davis,91
-BUTLER,Benton City/Benton Twp,Governor,,D,Paul Davis,290
-BUTLER,Bloomington Twp,Governor,,D,Paul Davis,56
-BUTLER,Bruno Twp North - 77,Governor,,D,Paul Davis,108
-BUTLER,Bruno Twp North - 99,Governor,,D,Paul Davis,82
-BUTLER,Bruno Twp South - 77,Governor,,D,Paul Davis,32
-BUTLER,Bruno Twp South - 99,Governor,,D,Paul Davis,31
-BUTLER,Cassoday/Sycamore Twp,Governor,,D,Paul Davis,43
-BUTLER,Chelsea Twp,Governor,,D,Paul Davis,32
-BUTLER,Clay Twp,Governor,,D,Paul Davis,11
-BUTLER,Clifford Twp,Governor,,D,Paul Davis,19
-BUTLER,Douglass City/Twp,Governor,,D,Paul Davis,270
-BUTLER,El Dorado Twp East,Governor,,D,Paul Davis,38
-BUTLER,El Dorado Twp West,Governor,,D,Paul Davis,82
-BUTLER,El Dorado W1,Governor,,D,Paul Davis,571
-BUTLER,El Dorado W2,Governor,,D,Paul Davis,484
-BUTLER,El Dorado W3,Governor,,D,Paul Davis,357
-BUTLER,El Dorado W4,Governor,,D,Paul Davis,255
-BUTLER,Elbing City/Fairmount Twp,Governor,,D,Paul Davis,58
-BUTLER,Fairview Twp,Governor,,D,Paul Davis,63
-BUTLER,Glencoe Twp,Governor,,D,Paul Davis,31
-BUTLER,Hickory Twp,Governor,,D,Paul Davis,9
-BUTLER,Latham/Union,Governor,,D,Paul Davis,11
-BUTLER,Leon/Little Walnut,Governor,,D,Paul Davis,103
-BUTLER,Lincoln Twp,Governor,,D,Paul Davis,27
-BUTLER,Logan Twp,Governor,,D,Paul Davis,18
-BUTLER,Milton Twp - 75,Governor,,D,Paul Davis,39
-BUTLER,Murdock Twp,Governor,,D,Paul Davis,45
-BUTLER,Pleasant Twp,Governor,,D,Paul Davis,400
-BUTLER,Potwin/Plum Grove,Governor,,D,Paul Davis,87
-BUTLER,Prospect Twp,Governor,,D,Paul Davis,168
-BUTLER,Richland Twp,Governor,,D,Paul Davis,183
-BUTLER,Rock Creek Twp,Governor,,D,Paul Davis,33
-BUTLER,Rosalia Twp,Governor,,D,Paul Davis,67
-BUTLER,Rose Hill City,Governor,,D,Paul Davis,317
-BUTLER,Spring Twp,Governor,,D,Paul Davis,209
-BUTLER,Towanda City/Towanda Twp,Governor,,D,Paul Davis,332
-BUTLER,Walnut Twp,Governor,,D,Paul Davis,75
-BUTLER,Whitewater/Milton - 72,Governor,,D,Paul Davis,76
-BUTLER,Andover W1,Governor,,L,Keen Umbehr,67
-BUTLER,Andover W2,Governor,,L,Keen Umbehr,52
-BUTLER,Andover W3,Governor,,L,Keen Umbehr,32
-BUTLER,Andover W4,Governor,,L,Keen Umbehr,2
-BUTLER,Augusta City W1,Governor,,L,Keen Umbehr,37
-BUTLER,Augusta City W2,Governor,,L,Keen Umbehr,22
-BUTLER,Augusta City W3,Governor,,L,Keen Umbehr,37
-BUTLER,Augusta City W4,Governor,,L,Keen Umbehr,37
-BUTLER,Augusta Twp - 14,Governor,,L,Keen Umbehr,6
-BUTLER,Augusta Twp - 16,Governor,,L,Keen Umbehr,12
-BUTLER,Benton City/Benton Twp,Governor,,L,Keen Umbehr,42
-BUTLER,Bloomington Twp,Governor,,L,Keen Umbehr,7
-BUTLER,Bruno Twp North - 77,Governor,,L,Keen Umbehr,16
-BUTLER,Bruno Twp North - 99,Governor,,L,Keen Umbehr,10
-BUTLER,Bruno Twp South - 77,Governor,,L,Keen Umbehr,7
-BUTLER,Bruno Twp South - 99,Governor,,L,Keen Umbehr,3
-BUTLER,Cassoday/Sycamore Twp,Governor,,L,Keen Umbehr,7
-BUTLER,Chelsea Twp,Governor,,L,Keen Umbehr,5
-BUTLER,Clay Twp,Governor,,L,Keen Umbehr,1
-BUTLER,Clifford Twp,Governor,,L,Keen Umbehr,1
-BUTLER,Douglass City/Twp,Governor,,L,Keen Umbehr,38
-BUTLER,El Dorado Twp East,Governor,,L,Keen Umbehr,4
-BUTLER,El Dorado Twp West,Governor,,L,Keen Umbehr,6
-BUTLER,El Dorado W1,Governor,,L,Keen Umbehr,49
-BUTLER,El Dorado W2,Governor,,L,Keen Umbehr,56
-BUTLER,El Dorado W3,Governor,,L,Keen Umbehr,41
-BUTLER,El Dorado W4,Governor,,L,Keen Umbehr,25
-BUTLER,Elbing City/Fairmount Twp,Governor,,L,Keen Umbehr,5
-BUTLER,Fairview Twp,Governor,,L,Keen Umbehr,7
-BUTLER,Glencoe Twp,Governor,,L,Keen Umbehr,3
-BUTLER,Hickory Twp,Governor,,L,Keen Umbehr,3
-BUTLER,Latham/Union,Governor,,L,Keen Umbehr,7
-BUTLER,Leon/Little Walnut,Governor,,L,Keen Umbehr,35
-BUTLER,Lincoln Twp,Governor,,L,Keen Umbehr,4
-BUTLER,Logan Twp,Governor,,L,Keen Umbehr,2
-BUTLER,Milton Twp - 75,Governor,,L,Keen Umbehr,6
-BUTLER,Murdock Twp,Governor,,L,Keen Umbehr,2
-BUTLER,Pleasant Twp,Governor,,L,Keen Umbehr,48
-BUTLER,Potwin/Plum Grove,Governor,,L,Keen Umbehr,8
-BUTLER,Prospect Twp,Governor,,L,Keen Umbehr,20
-BUTLER,Richland Twp,Governor,,L,Keen Umbehr,27
-BUTLER,Rock Creek Twp,Governor,,L,Keen Umbehr,8
-BUTLER,Rosalia Twp,Governor,,L,Keen Umbehr,16
-BUTLER,Rose Hill City,Governor,,L,Keen Umbehr,37
-BUTLER,Spring Twp,Governor,,L,Keen Umbehr,21
-BUTLER,Towanda City/Towanda Twp,Governor,,L,Keen Umbehr,49
-BUTLER,Walnut Twp,Governor,,L,Keen Umbehr,14
-BUTLER,Whitewater/Milton - 72,Governor,,L,Keen Umbehr,17
-BUTLER,Andover W1,Secretary of State,,R,Kris Kobach,1108
-BUTLER,Andover W2,Secretary of State,,R,Kris Kobach,902
-BUTLER,Andover W3,Secretary of State,,R,Kris Kobach,387
-BUTLER,Andover W4,Secretary of State,,R,Kris Kobach,92
-BUTLER,Augusta City W1,Secretary of State,,R,Kris Kobach,339
-BUTLER,Augusta City W2,Secretary of State,,R,Kris Kobach,253
-BUTLER,Augusta City W3,Secretary of State,,R,Kris Kobach,541
-BUTLER,Augusta City W4,Secretary of State,,R,Kris Kobach,531
-BUTLER,Augusta Twp - 14,Secretary of State,,R,Kris Kobach,87
-BUTLER,Augusta Twp - 16,Secretary of State,,R,Kris Kobach,210
-BUTLER,Benton City/Benton Twp,Secretary of State,,R,Kris Kobach,664
-BUTLER,Bloomington Twp,Secretary of State,,R,Kris Kobach,112
-BUTLER,Bruno Twp North - 77,Secretary of State,,R,Kris Kobach,325
-BUTLER,Bruno Twp North - 99,Secretary of State,,R,Kris Kobach,175
-BUTLER,Bruno Twp South - 77,Secretary of State,,R,Kris Kobach,71
-BUTLER,Bruno Twp South - 99,Secretary of State,,R,Kris Kobach,80
-BUTLER,Cassoday/Sycamore Twp,Secretary of State,,R,Kris Kobach,94
-BUTLER,Chelsea Twp,Secretary of State,,R,Kris Kobach,54
-BUTLER,Clay Twp,Secretary of State,,R,Kris Kobach,20
-BUTLER,Clifford Twp,Secretary of State,,R,Kris Kobach,70
-BUTLER,Douglass City/Twp,Secretary of State,,R,Kris Kobach,385
-BUTLER,El Dorado Twp East,Secretary of State,,R,Kris Kobach,32
-BUTLER,El Dorado Twp West,Secretary of State,,R,Kris Kobach,137
-BUTLER,El Dorado W1,Secretary of State,,R,Kris Kobach,778
-BUTLER,El Dorado W2,Secretary of State,,R,Kris Kobach,522
-BUTLER,El Dorado W3,Secretary of State,,R,Kris Kobach,435
-BUTLER,El Dorado W4,Secretary of State,,R,Kris Kobach,278
-BUTLER,Elbing City/Fairmount Twp,Secretary of State,,R,Kris Kobach,207
-BUTLER,Fairview Twp,Secretary of State,,R,Kris Kobach,133
-BUTLER,Glencoe Twp,Secretary of State,,R,Kris Kobach,36
-BUTLER,Hickory Twp,Secretary of State,,R,Kris Kobach,28
-BUTLER,Latham/Union,Secretary of State,,R,Kris Kobach,42
-BUTLER,Leon/Little Walnut,Secretary of State,,R,Kris Kobach,182
-BUTLER,Lincoln Twp,Secretary of State,,R,Kris Kobach,79
-BUTLER,Logan Twp,Secretary of State,,R,Kris Kobach,35
-BUTLER,Milton Twp - 75,Secretary of State,,R,Kris Kobach,146
-BUTLER,Murdock Twp,Secretary of State,,R,Kris Kobach,141
-BUTLER,Pleasant Twp,Secretary of State,,R,Kris Kobach,822
-BUTLER,Potwin/Plum Grove,Secretary of State,,R,Kris Kobach,131
-BUTLER,Prospect Twp,Secretary of State,,R,Kris Kobach,278
-BUTLER,Richland Twp,Secretary of State,,R,Kris Kobach,380
-BUTLER,Rock Creek Twp,Secretary of State,,R,Kris Kobach,81
-BUTLER,Rosalia Twp,Secretary of State,,R,Kris Kobach,169
-BUTLER,Rose Hill City,Secretary of State,,R,Kris Kobach,537
-BUTLER,Spring Twp,Secretary of State,,R,Kris Kobach,361
-BUTLER,Towanda City/Towanda Twp,Secretary of State,,R,Kris Kobach,660
-BUTLER,Walnut Twp,Secretary of State,,R,Kris Kobach,168
-BUTLER,Whitewater/Milton - 72,Secretary of State,,R,Kris Kobach,186
-BUTLER,Andover W1,Secretary of State,,D,Jean Schodorf,617
-BUTLER,Andover W2,Secretary of State,,D,Jean Schodorf,491
-BUTLER,Andover W3,Secretary of State,,D,Jean Schodorf,234
-BUTLER,Andover W4,Secretary of State,,D,Jean Schodorf,36
-BUTLER,Augusta City W1,Secretary of State,,D,Jean Schodorf,225
-BUTLER,Augusta City W2,Secretary of State,,D,Jean Schodorf,162
-BUTLER,Augusta City W3,Secretary of State,,D,Jean Schodorf,368
-BUTLER,Augusta City W4,Secretary of State,,D,Jean Schodorf,287
-BUTLER,Augusta Twp - 14,Secretary of State,,D,Jean Schodorf,46
-BUTLER,Augusta Twp - 16,Secretary of State,,D,Jean Schodorf,87
-BUTLER,Benton City/Benton Twp,Secretary of State,,D,Jean Schodorf,243
-BUTLER,Bloomington Twp,Secretary of State,,D,Jean Schodorf,49
-BUTLER,Bruno Twp North - 77,Secretary of State,,D,Jean Schodorf,103
-BUTLER,Bruno Twp North - 99,Secretary of State,,D,Jean Schodorf,69
-BUTLER,Bruno Twp South - 77,Secretary of State,,D,Jean Schodorf,32
-BUTLER,Bruno Twp South - 99,Secretary of State,,D,Jean Schodorf,25
-BUTLER,Cassoday/Sycamore Twp,Secretary of State,,D,Jean Schodorf,36
-BUTLER,Chelsea Twp,Secretary of State,,D,Jean Schodorf,34
-BUTLER,Clay Twp,Secretary of State,,D,Jean Schodorf,13
-BUTLER,Clifford Twp,Secretary of State,,D,Jean Schodorf,20
-BUTLER,Douglass City/Twp,Secretary of State,,D,Jean Schodorf,232
-BUTLER,El Dorado Twp East,Secretary of State,,D,Jean Schodorf,36
-BUTLER,El Dorado Twp West,Secretary of State,,D,Jean Schodorf,57
-BUTLER,El Dorado W1,Secretary of State,,D,Jean Schodorf,497
-BUTLER,El Dorado W2,Secretary of State,,D,Jean Schodorf,451
-BUTLER,El Dorado W3,Secretary of State,,D,Jean Schodorf,322
-BUTLER,El Dorado W4,Secretary of State,,D,Jean Schodorf,239
-BUTLER,Elbing City/Fairmount Twp,Secretary of State,,D,Jean Schodorf,49
-BUTLER,Fairview Twp,Secretary of State,,D,Jean Schodorf,62
-BUTLER,Glencoe Twp,Secretary of State,,D,Jean Schodorf,31
-BUTLER,Hickory Twp,Secretary of State,,D,Jean Schodorf,10
-BUTLER,Latham/Union,Secretary of State,,D,Jean Schodorf,15
-BUTLER,Leon/Little Walnut,Secretary of State,,D,Jean Schodorf,105
-BUTLER,Lincoln Twp,Secretary of State,,D,Jean Schodorf,27
-BUTLER,Logan Twp,Secretary of State,,D,Jean Schodorf,16
-BUTLER,Milton Twp - 75,Secretary of State,,D,Jean Schodorf,39
-BUTLER,Murdock Twp,Secretary of State,,D,Jean Schodorf,40
-BUTLER,Pleasant Twp,Secretary of State,,D,Jean Schodorf,358
-BUTLER,Potwin/Plum Grove,Secretary of State,,D,Jean Schodorf,78
-BUTLER,Prospect Twp,Secretary of State,,D,Jean Schodorf,134
-BUTLER,Richland Twp,Secretary of State,,D,Jean Schodorf,167
-BUTLER,Rock Creek Twp,Secretary of State,,D,Jean Schodorf,33
-BUTLER,Rosalia Twp,Secretary of State,,D,Jean Schodorf,59
-BUTLER,Rose Hill City,Secretary of State,,D,Jean Schodorf,279
-BUTLER,Spring Twp,Secretary of State,,D,Jean Schodorf,183
-BUTLER,Towanda City/Towanda Twp,Secretary of State,,D,Jean Schodorf,289
-BUTLER,Walnut Twp,Secretary of State,,D,Jean Schodorf,65
-BUTLER,Whitewater/Milton - 72,Secretary of State,,D,Jean Schodorf,78
-BUTLER,Andover W1,Attorney General,,R,Derek Schmidt,1248
-BUTLER,Andover W2,Attorney General,,R,Derek Schmidt,1031
-BUTLER,Andover W3,Attorney General,,R,Derek Schmidt,462
-BUTLER,Andover W4,Attorney General,,R,Derek Schmidt,113
-BUTLER,Augusta City W1,Attorney General,,R,Derek Schmidt,377
-BUTLER,Augusta City W2,Attorney General,,R,Derek Schmidt,290
-BUTLER,Augusta City W3,Attorney General,,R,Derek Schmidt,633
-BUTLER,Augusta City W4,Attorney General,,R,Derek Schmidt,627
-BUTLER,Augusta Twp - 14,Attorney General,,R,Derek Schmidt,98
-BUTLER,Augusta Twp - 16,Attorney General,,R,Derek Schmidt,233
-BUTLER,Benton City/Benton Twp,Attorney General,,R,Derek Schmidt,742
-BUTLER,Bloomington Twp,Attorney General,,R,Derek Schmidt,120
-BUTLER,Bruno Twp North - 77,Attorney General,,R,Derek Schmidt,345
-BUTLER,Bruno Twp North - 99,Attorney General,,R,Derek Schmidt,183
-BUTLER,Bruno Twp South - 77,Attorney General,,R,Derek Schmidt,85
-BUTLER,Bruno Twp South - 99,Attorney General,,R,Derek Schmidt,85
-BUTLER,Cassoday/Sycamore Twp,Attorney General,,R,Derek Schmidt,103
-BUTLER,Chelsea Twp,Attorney General,,R,Derek Schmidt,64
-BUTLER,Clay Twp,Attorney General,,R,Derek Schmidt,20
-BUTLER,Clifford Twp,Attorney General,,R,Derek Schmidt,82
-BUTLER,Douglass City/Twp,Attorney General,,R,Derek Schmidt,458
-BUTLER,El Dorado Twp East,Attorney General,,R,Derek Schmidt,39
-BUTLER,El Dorado Twp West,Attorney General,,R,Derek Schmidt,149
-BUTLER,El Dorado W1,Attorney General,,R,Derek Schmidt,943
-BUTLER,El Dorado W2,Attorney General,,R,Derek Schmidt,627
-BUTLER,El Dorado W3,Attorney General,,R,Derek Schmidt,525
-BUTLER,El Dorado W4,Attorney General,,R,Derek Schmidt,325
-BUTLER,Elbing City/Fairmount Twp,Attorney General,,R,Derek Schmidt,215
-BUTLER,Fairview Twp,Attorney General,,R,Derek Schmidt,154
-BUTLER,Glencoe Twp,Attorney General,,R,Derek Schmidt,44
-BUTLER,Hickory Twp,Attorney General,,R,Derek Schmidt,31
-BUTLER,Latham/Union,Attorney General,,R,Derek Schmidt,46
-BUTLER,Leon/Little Walnut,Attorney General,,R,Derek Schmidt,214
-BUTLER,Lincoln Twp,Attorney General,,R,Derek Schmidt,85
-BUTLER,Logan Twp,Attorney General,,R,Derek Schmidt,38
-BUTLER,Milton Twp - 75,Attorney General,,R,Derek Schmidt,151
-BUTLER,Murdock Twp,Attorney General,,R,Derek Schmidt,146
-BUTLER,Pleasant Twp,Attorney General,,R,Derek Schmidt,938
-BUTLER,Potwin/Plum Grove,Attorney General,,R,Derek Schmidt,155
-BUTLER,Prospect Twp,Attorney General,,R,Derek Schmidt,298
-BUTLER,Richland Twp,Attorney General,,R,Derek Schmidt,422
-BUTLER,Rock Creek Twp,Attorney General,,R,Derek Schmidt,92
-BUTLER,Rosalia Twp,Attorney General,,R,Derek Schmidt,182
-BUTLER,Rose Hill City,Attorney General,,R,Derek Schmidt,631
-BUTLER,Spring Twp,Attorney General,,R,Derek Schmidt,412
-BUTLER,Towanda City/Towanda Twp,Attorney General,,R,Derek Schmidt,714
-BUTLER,Walnut Twp,Attorney General,,R,Derek Schmidt,186
-BUTLER,Whitewater/Milton - 72,Attorney General,,R,Derek Schmidt,214
-BUTLER,Andover W1,Attorney General,,D,A J Kotich,442
-BUTLER,Andover W2,Attorney General,,D,A J Kotich,341
-BUTLER,Andover W3,Attorney General,,D,A J Kotich,148
-BUTLER,Andover W4,Attorney General,,D,A J Kotich,15
-BUTLER,Augusta City W1,Attorney General,,D,A J Kotich,181
-BUTLER,Augusta City W2,Attorney General,,D,A J Kotich,121
-BUTLER,Augusta City W3,Attorney General,,D,A J Kotich,260
-BUTLER,Augusta City W4,Attorney General,,D,A J Kotich,177
-BUTLER,Augusta Twp - 14,Attorney General,,D,A J Kotich,34
-BUTLER,Augusta Twp - 16,Attorney General,,D,A J Kotich,64
-BUTLER,Benton City/Benton Twp,Attorney General,,D,A J Kotich,160
-BUTLER,Bloomington Twp,Attorney General,,D,A J Kotich,39
-BUTLER,Bruno Twp North - 77,Attorney General,,D,A J Kotich,74
-BUTLER,Bruno Twp North - 99,Attorney General,,D,A J Kotich,59
-BUTLER,Bruno Twp South - 77,Attorney General,,D,A J Kotich,17
-BUTLER,Bruno Twp South - 99,Attorney General,,D,A J Kotich,18
-BUTLER,Cassoday/Sycamore Twp,Attorney General,,D,A J Kotich,22
-BUTLER,Chelsea Twp,Attorney General,,D,A J Kotich,24
-BUTLER,Clay Twp,Attorney General,,D,A J Kotich,11
-BUTLER,Clifford Twp,Attorney General,,D,A J Kotich,8
-BUTLER,Douglass City/Twp,Attorney General,,D,A J Kotich,153
-BUTLER,El Dorado Twp East,Attorney General,,D,A J Kotich,28
-BUTLER,El Dorado Twp West,Attorney General,,D,A J Kotich,45
-BUTLER,El Dorado W1,Attorney General,,D,A J Kotich,308
-BUTLER,El Dorado W2,Attorney General,,D,A J Kotich,330
-BUTLER,El Dorado W3,Attorney General,,D,A J Kotich,226
-BUTLER,El Dorado W4,Attorney General,,D,A J Kotich,190
-BUTLER,Elbing City/Fairmount Twp,Attorney General,,D,A J Kotich,35
-BUTLER,Fairview Twp,Attorney General,,D,A J Kotich,39
-BUTLER,Glencoe Twp,Attorney General,,D,A J Kotich,24
-BUTLER,Hickory Twp,Attorney General,,D,A J Kotich,7
-BUTLER,Latham/Union,Attorney General,,D,A J Kotich,10
-BUTLER,Leon/Little Walnut,Attorney General,,D,A J Kotich,69
-BUTLER,Lincoln Twp,Attorney General,,D,A J Kotich,18
-BUTLER,Logan Twp,Attorney General,,D,A J Kotich,13
-BUTLER,Milton Twp - 75,Attorney General,,D,A J Kotich,23
-BUTLER,Murdock Twp,Attorney General,,D,A J Kotich,34
-BUTLER,Pleasant Twp,Attorney General,,D,A J Kotich,235
-BUTLER,Potwin/Plum Grove,Attorney General,,D,A J Kotich,53
-BUTLER,Prospect Twp,Attorney General,,D,A J Kotich,107
-BUTLER,Richland Twp,Attorney General,,D,A J Kotich,115
-BUTLER,Rock Creek Twp,Attorney General,,D,A J Kotich,21
-BUTLER,Rosalia Twp,Attorney General,,D,A J Kotich,42
-BUTLER,Rose Hill City,Attorney General,,D,A J Kotich,176
-BUTLER,Spring Twp,Attorney General,,D,A J Kotich,124
-BUTLER,Towanda City/Towanda Twp,Attorney General,,D,A J Kotich,219
-BUTLER,Walnut Twp,Attorney General,,D,A J Kotich,43
-BUTLER,Whitewater/Milton - 72,Attorney General,,D,A J Kotich,47
-BUTLER,Andover W1,State Treasurer,,R,Ron Estes,1323
-BUTLER,Andover W2,State Treasurer,,R,Ron Estes,1073
-BUTLER,Andover W3,State Treasurer,,R,Ron Estes,473
-BUTLER,Andover W4,State Treasurer,,R,Ron Estes,110
-BUTLER,Augusta City W1,State Treasurer,,R,Ron Estes,377
-BUTLER,Augusta City W2,State Treasurer,,R,Ron Estes,293
-BUTLER,Augusta City W3,State Treasurer,,R,Ron Estes,635
-BUTLER,Augusta City W4,State Treasurer,,R,Ron Estes,650
-BUTLER,Augusta Twp - 14,State Treasurer,,R,Ron Estes,98
-BUTLER,Augusta Twp - 16,State Treasurer,,R,Ron Estes,242
-BUTLER,Benton City/Benton Twp,State Treasurer,,R,Ron Estes,741
-BUTLER,Bloomington Twp,State Treasurer,,R,Ron Estes,119
-BUTLER,Bruno Twp North - 77,State Treasurer,,R,Ron Estes,345
-BUTLER,Bruno Twp North - 99,State Treasurer,,R,Ron Estes,199
-BUTLER,Bruno Twp South - 77,State Treasurer,,R,Ron Estes,83
-BUTLER,Bruno Twp South - 99,State Treasurer,,R,Ron Estes,86
-BUTLER,Cassoday/Sycamore Twp,State Treasurer,,R,Ron Estes,106
-BUTLER,Chelsea Twp,State Treasurer,,R,Ron Estes,68
-BUTLER,Clay Twp,State Treasurer,,R,Ron Estes,23
-BUTLER,Clifford Twp,State Treasurer,,R,Ron Estes,79
-BUTLER,Douglass City/Twp,State Treasurer,,R,Ron Estes,469
-BUTLER,El Dorado Twp East,State Treasurer,,R,Ron Estes,46
-BUTLER,El Dorado Twp West,State Treasurer,,R,Ron Estes,158
-BUTLER,El Dorado W1,State Treasurer,,R,Ron Estes,946
-BUTLER,El Dorado W2,State Treasurer,,R,Ron Estes,654
-BUTLER,El Dorado W3,State Treasurer,,R,Ron Estes,512
-BUTLER,El Dorado W4,State Treasurer,,R,Ron Estes,342
-BUTLER,Elbing City/Fairmount Twp,State Treasurer,,R,Ron Estes,211
-BUTLER,Fairview Twp,State Treasurer,,R,Ron Estes,155
-BUTLER,Glencoe Twp,State Treasurer,,R,Ron Estes,48
-BUTLER,Hickory Twp,State Treasurer,,R,Ron Estes,31
-BUTLER,Latham/Union,State Treasurer,,R,Ron Estes,42
-BUTLER,Leon/Little Walnut,State Treasurer,,R,Ron Estes,219
-BUTLER,Lincoln Twp,State Treasurer,,R,Ron Estes,84
-BUTLER,Logan Twp,State Treasurer,,R,Ron Estes,37
-BUTLER,Milton Twp - 75,State Treasurer,,R,Ron Estes,156
-BUTLER,Murdock Twp,State Treasurer,,R,Ron Estes,151
-BUTLER,Pleasant Twp,State Treasurer,,R,Ron Estes,948
-BUTLER,Potwin/Plum Grove,State Treasurer,,R,Ron Estes,155
-BUTLER,Prospect Twp,State Treasurer,,R,Ron Estes,299
-BUTLER,Richland Twp,State Treasurer,,R,Ron Estes,437
-BUTLER,Rock Creek Twp,State Treasurer,,R,Ron Estes,88
-BUTLER,Rosalia Twp,State Treasurer,,R,Ron Estes,172
-BUTLER,Rose Hill City,State Treasurer,,R,Ron Estes,638
-BUTLER,Spring Twp,State Treasurer,,R,Ron Estes,408
-BUTLER,Towanda City/Towanda Twp,State Treasurer,,R,Ron Estes,723
-BUTLER,Walnut Twp,State Treasurer,,R,Ron Estes,191
-BUTLER,Whitewater/Milton - 72,State Treasurer,,R,Ron Estes,220
-BUTLER,Andover W1,State Treasurer,,D,Carmen Alldritt,368
-BUTLER,Andover W2,State Treasurer,,D,Carmen Alldritt,303
-BUTLER,Andover W3,State Treasurer,,D,Carmen Alldritt,140
-BUTLER,Andover W4,State Treasurer,,D,Carmen Alldritt,19
-BUTLER,Augusta City W1,State Treasurer,,D,Carmen Alldritt,179
-BUTLER,Augusta City W2,State Treasurer,,D,Carmen Alldritt,117
-BUTLER,Augusta City W3,State Treasurer,,D,Carmen Alldritt,252
-BUTLER,Augusta City W4,State Treasurer,,D,Carmen Alldritt,154
-BUTLER,Augusta Twp - 14,State Treasurer,,D,Carmen Alldritt,34
-BUTLER,Augusta Twp - 16,State Treasurer,,D,Carmen Alldritt,57
-BUTLER,Benton City/Benton Twp,State Treasurer,,D,Carmen Alldritt,159
-BUTLER,Bloomington Twp,State Treasurer,,D,Carmen Alldritt,36
-BUTLER,Bruno Twp North - 77,State Treasurer,,D,Carmen Alldritt,73
-BUTLER,Bruno Twp North - 99,State Treasurer,,D,Carmen Alldritt,44
-BUTLER,Bruno Twp South - 77,State Treasurer,,D,Carmen Alldritt,17
-BUTLER,Bruno Twp South - 99,State Treasurer,,D,Carmen Alldritt,19
-BUTLER,Cassoday/Sycamore Twp,State Treasurer,,D,Carmen Alldritt,22
-BUTLER,Chelsea Twp,State Treasurer,,D,Carmen Alldritt,20
-BUTLER,Clay Twp,State Treasurer,,D,Carmen Alldritt,10
-BUTLER,Clifford Twp,State Treasurer,,D,Carmen Alldritt,11
-BUTLER,Douglass City/Twp,State Treasurer,,D,Carmen Alldritt,143
-BUTLER,El Dorado Twp East,State Treasurer,,D,Carmen Alldritt,21
-BUTLER,El Dorado Twp West,State Treasurer,,D,Carmen Alldritt,37
-BUTLER,El Dorado W1,State Treasurer,,D,Carmen Alldritt,311
-BUTLER,El Dorado W2,State Treasurer,,D,Carmen Alldritt,307
-BUTLER,El Dorado W3,State Treasurer,,D,Carmen Alldritt,235
-BUTLER,El Dorado W4,State Treasurer,,D,Carmen Alldritt,174
-BUTLER,Elbing City/Fairmount Twp,State Treasurer,,D,Carmen Alldritt,37
-BUTLER,Fairview Twp,State Treasurer,,D,Carmen Alldritt,37
-BUTLER,Glencoe Twp,State Treasurer,,D,Carmen Alldritt,20
-BUTLER,Hickory Twp,State Treasurer,,D,Carmen Alldritt,7
-BUTLER,Latham/Union,State Treasurer,,D,Carmen Alldritt,15
-BUTLER,Leon/Little Walnut,State Treasurer,,D,Carmen Alldritt,67
-BUTLER,Lincoln Twp,State Treasurer,,D,Carmen Alldritt,19
-BUTLER,Logan Twp,State Treasurer,,D,Carmen Alldritt,13
-BUTLER,Milton Twp - 75,State Treasurer,,D,Carmen Alldritt,25
-BUTLER,Murdock Twp,State Treasurer,,D,Carmen Alldritt,30
-BUTLER,Pleasant Twp,State Treasurer,,D,Carmen Alldritt,225
-BUTLER,Potwin/Plum Grove,State Treasurer,,D,Carmen Alldritt,55
-BUTLER,Prospect Twp,State Treasurer,,D,Carmen Alldritt,105
-BUTLER,Richland Twp,State Treasurer,,D,Carmen Alldritt,100
-BUTLER,Rock Creek Twp,State Treasurer,,D,Carmen Alldritt,24
-BUTLER,Rosalia Twp,State Treasurer,,D,Carmen Alldritt,47
-BUTLER,Rose Hill City,State Treasurer,,D,Carmen Alldritt,168
-BUTLER,Spring Twp,State Treasurer,,D,Carmen Alldritt,126
-BUTLER,Towanda City/Towanda Twp,State Treasurer,,D,Carmen Alldritt,213
-BUTLER,Walnut Twp,State Treasurer,,D,Carmen Alldritt,39
-BUTLER,Whitewater/Milton - 72,State Treasurer,,D,Carmen Alldritt,42
-BUTLER,Andover W1,Insurance Commissioner,,R,Ken Selzer,1169
-BUTLER,Andover W2,Insurance Commissioner,,R,Ken Selzer,952
-BUTLER,Andover W3,Insurance Commissioner,,R,Ken Selzer,418
-BUTLER,Andover W4,Insurance Commissioner,,R,Ken Selzer,100
-BUTLER,Augusta City W1,Insurance Commissioner,,R,Ken Selzer,345
-BUTLER,Augusta City W2,Insurance Commissioner,,R,Ken Selzer,268
-BUTLER,Augusta City W3,Insurance Commissioner,,R,Ken Selzer,573
-BUTLER,Augusta City W4,Insurance Commissioner,,R,Ken Selzer,572
-BUTLER,Augusta Twp - 14,Insurance Commissioner,,R,Ken Selzer,87
-BUTLER,Augusta Twp - 16,Insurance Commissioner,,R,Ken Selzer,220
-BUTLER,Benton City/Benton Twp,Insurance Commissioner,,R,Ken Selzer,681
-BUTLER,Bloomington Twp,Insurance Commissioner,,R,Ken Selzer,108
-BUTLER,Bruno Twp North - 77,Insurance Commissioner,,R,Ken Selzer,328
-BUTLER,Bruno Twp North - 99,Insurance Commissioner,,R,Ken Selzer,173
-BUTLER,Bruno Twp South - 77,Insurance Commissioner,,R,Ken Selzer,76
-BUTLER,Bruno Twp South - 99,Insurance Commissioner,,R,Ken Selzer,80
-BUTLER,Cassoday/Sycamore Twp,Insurance Commissioner,,R,Ken Selzer,93
-BUTLER,Chelsea Twp,Insurance Commissioner,,R,Ken Selzer,57
-BUTLER,Clay Twp,Insurance Commissioner,,R,Ken Selzer,20
-BUTLER,Clifford Twp,Insurance Commissioner,,R,Ken Selzer,76
-BUTLER,Douglass City/Twp,Insurance Commissioner,,R,Ken Selzer,407
-BUTLER,El Dorado Twp East,Insurance Commissioner,,R,Ken Selzer,35
-BUTLER,El Dorado Twp West,Insurance Commissioner,,R,Ken Selzer,144
-BUTLER,El Dorado W1,Insurance Commissioner,,R,Ken Selzer,852
-BUTLER,El Dorado W2,Insurance Commissioner,,R,Ken Selzer,575
-BUTLER,El Dorado W3,Insurance Commissioner,,R,Ken Selzer,449
-BUTLER,El Dorado W4,Insurance Commissioner,,R,Ken Selzer,295
-BUTLER,Elbing City/Fairmount Twp,Insurance Commissioner,,R,Ken Selzer,210
-BUTLER,Fairview Twp,Insurance Commissioner,,R,Ken Selzer,144
-BUTLER,Glencoe Twp,Insurance Commissioner,,R,Ken Selzer,37
-BUTLER,Hickory Twp,Insurance Commissioner,,R,Ken Selzer,30
-BUTLER,Latham/Union,Insurance Commissioner,,R,Ken Selzer,39
-BUTLER,Leon/Little Walnut,Insurance Commissioner,,R,Ken Selzer,201
-BUTLER,Lincoln Twp,Insurance Commissioner,,R,Ken Selzer,79
-BUTLER,Logan Twp,Insurance Commissioner,,R,Ken Selzer,37
-BUTLER,Milton Twp - 75,Insurance Commissioner,,R,Ken Selzer,145
-BUTLER,Murdock Twp,Insurance Commissioner,,R,Ken Selzer,147
-BUTLER,Pleasant Twp,Insurance Commissioner,,R,Ken Selzer,857
-BUTLER,Potwin/Plum Grove,Insurance Commissioner,,R,Ken Selzer,131
-BUTLER,Prospect Twp,Insurance Commissioner,,R,Ken Selzer,279
-BUTLER,Richland Twp,Insurance Commissioner,,R,Ken Selzer,404
-BUTLER,Rock Creek Twp,Insurance Commissioner,,R,Ken Selzer,84
-BUTLER,Rosalia Twp,Insurance Commissioner,,R,Ken Selzer,164
-BUTLER,Rose Hill City,Insurance Commissioner,,R,Ken Selzer,555
-BUTLER,Spring Twp,Insurance Commissioner,,R,Ken Selzer,375
-BUTLER,Towanda City/Towanda Twp,Insurance Commissioner,,R,Ken Selzer,681
-BUTLER,Walnut Twp,Insurance Commissioner,,R,Ken Selzer,173
-BUTLER,Whitewater/Milton - 72,Insurance Commissioner,,R,Ken Selzer,205
-BUTLER,Andover W1,Insurance Commissioner,,D,Dennis Anderson,494
-BUTLER,Andover W2,Insurance Commissioner,,D,Dennis Anderson,387
-BUTLER,Andover W3,Insurance Commissioner,,D,Dennis Anderson,179
-BUTLER,Andover W4,Insurance Commissioner,,D,Dennis Anderson,24
-BUTLER,Augusta City W1,Insurance Commissioner,,D,Dennis Anderson,195
-BUTLER,Augusta City W2,Insurance Commissioner,,D,Dennis Anderson,141
-BUTLER,Augusta City W3,Insurance Commissioner,,D,Dennis Anderson,300
-BUTLER,Augusta City W4,Insurance Commissioner,,D,Dennis Anderson,219
-BUTLER,Augusta Twp - 14,Insurance Commissioner,,D,Dennis Anderson,40
-BUTLER,Augusta Twp - 16,Insurance Commissioner,,D,Dennis Anderson,73
-BUTLER,Benton City/Benton Twp,Insurance Commissioner,,D,Dennis Anderson,202
-BUTLER,Bloomington Twp,Insurance Commissioner,,D,Dennis Anderson,45
-BUTLER,Bruno Twp North - 77,Insurance Commissioner,,D,Dennis Anderson,86
-BUTLER,Bruno Twp North - 99,Insurance Commissioner,,D,Dennis Anderson,59
-BUTLER,Bruno Twp South - 77,Insurance Commissioner,,D,Dennis Anderson,23
-BUTLER,Bruno Twp South - 99,Insurance Commissioner,,D,Dennis Anderson,22
-BUTLER,Cassoday/Sycamore Twp,Insurance Commissioner,,D,Dennis Anderson,31
-BUTLER,Chelsea Twp,Insurance Commissioner,,D,Dennis Anderson,30
-BUTLER,Clay Twp,Insurance Commissioner,,D,Dennis Anderson,10
-BUTLER,Clifford Twp,Insurance Commissioner,,D,Dennis Anderson,13
-BUTLER,Douglass City/Twp,Insurance Commissioner,,D,Dennis Anderson,184
-BUTLER,El Dorado Twp East,Insurance Commissioner,,D,Dennis Anderson,29
-BUTLER,El Dorado Twp West,Insurance Commissioner,,D,Dennis Anderson,47
-BUTLER,El Dorado W1,Insurance Commissioner,,D,Dennis Anderson,393
-BUTLER,El Dorado W2,Insurance Commissioner,,D,Dennis Anderson,367
-BUTLER,El Dorado W3,Insurance Commissioner,,D,Dennis Anderson,286
-BUTLER,El Dorado W4,Insurance Commissioner,,D,Dennis Anderson,217
-BUTLER,Elbing City/Fairmount Twp,Insurance Commissioner,,D,Dennis Anderson,39
-BUTLER,Fairview Twp,Insurance Commissioner,,D,Dennis Anderson,43
-BUTLER,Glencoe Twp,Insurance Commissioner,,D,Dennis Anderson,29
-BUTLER,Hickory Twp,Insurance Commissioner,,D,Dennis Anderson,7
-BUTLER,Latham/Union,Insurance Commissioner,,D,Dennis Anderson,16
-BUTLER,Leon/Little Walnut,Insurance Commissioner,,D,Dennis Anderson,83
-BUTLER,Lincoln Twp,Insurance Commissioner,,D,Dennis Anderson,21
-BUTLER,Logan Twp,Insurance Commissioner,,D,Dennis Anderson,11
-BUTLER,Milton Twp - 75,Insurance Commissioner,,D,Dennis Anderson,32
-BUTLER,Murdock Twp,Insurance Commissioner,,D,Dennis Anderson,31
-BUTLER,Pleasant Twp,Insurance Commissioner,,D,Dennis Anderson,293
-BUTLER,Potwin/Plum Grove,Insurance Commissioner,,D,Dennis Anderson,73
-BUTLER,Prospect Twp,Insurance Commissioner,,D,Dennis Anderson,118
-BUTLER,Richland Twp,Insurance Commissioner,,D,Dennis Anderson,120
-BUTLER,Rock Creek Twp,Insurance Commissioner,,D,Dennis Anderson,27
-BUTLER,Rosalia Twp,Insurance Commissioner,,D,Dennis Anderson,54
-BUTLER,Rose Hill City,Insurance Commissioner,,D,Dennis Anderson,243
-BUTLER,Spring Twp,Insurance Commissioner,,D,Dennis Anderson,151
-BUTLER,Towanda City/Towanda Twp,Insurance Commissioner,,D,Dennis Anderson,246
-BUTLER,Walnut Twp,Insurance Commissioner,,D,Dennis Anderson,51
-BUTLER,Whitewater/Milton - 72,Insurance Commissioner,,D,Dennis Anderson,58
-BUTLER,Andover W1,State House,99,R,Dennis Hedke,1428
-BUTLER,Andover W2,State House,99,R,Dennis Hedke,1135
-BUTLER,Andover W3,State House,99,R,Dennis Hedke,515
-BUTLER,Andover W4,State House,77,R,Kristey Williams,111
-BUTLER,Augusta City W1,State House,77,R,Kristey Williams,472
-BUTLER,Augusta City W2,State House,77,R,Kristey Williams,342
-BUTLER,Augusta City W3,State House,77,R,Kristey Williams,780
-BUTLER,Augusta City W4,State House,77,R,Kristey Williams,704
-BUTLER,Augusta Twp - 14,State House,77,R,Kristey Williams,103
-BUTLER,Augusta Twp - 16,State House,77,R,Kristey Williams,276
-BUTLER,Benton City/Benton Twp,State House,85,R,Steve Brunk,473
-BUTLER,Bloomington Twp,State House,12,R,Virgil Peck,52
-BUTLER,Bruno Twp North - 77,State House,77,R,Kristey Williams,375
-BUTLER,Bruno Twp North - 99,State House,99,R,Dennis Hedke,210
-BUTLER,Bruno Twp South - 77,State House,77,R,Kristey Williams,86
-BUTLER,Bruno Twp South - 99,State House,99,R,Dennis Hedke,93
-BUTLER,Cassoday/Sycamore Twp,State House,75,R,Will Carpenter,97
-BUTLER,Chelsea Twp,State House,75,R,Will Carpenter,57
-BUTLER,Clay Twp,State House,12,R,Virgil Peck,14
-BUTLER,Clifford Twp,State House,75,R,Will Carpenter,72
-BUTLER,Douglass City/Twp,State House,77,R,Kristey Williams,534
-BUTLER,El Dorado Twp East,State House,75,R,Will Carpenter,45
-BUTLER,El Dorado Twp West,State House,75,R,Will Carpenter,141
-BUTLER,El Dorado W1,State House,75,R,Will Carpenter,841
-BUTLER,El Dorado W2,State House,75,R,Will Carpenter,573
-BUTLER,El Dorado W3,State House,75,R,Will Carpenter,471
-BUTLER,El Dorado W4,State House,75,R,Will Carpenter,301
-BUTLER,Elbing City/Fairmount Twp,State House,75,R,Will Carpenter,193
-BUTLER,Fairview Twp,State House,75,R,Will Carpenter,142
-BUTLER,Glencoe Twp,State House,12,R,Virgil Peck,24
-BUTLER,Hickory Twp,State House,12,R,Virgil Peck,21
-BUTLER,Latham/Union,State House,12,R,Virgil Peck,17
-BUTLER,Leon/Little Walnut,State House,12,R,Virgil Peck,113
-BUTLER,Lincoln Twp,State House,75,R,Will Carpenter,91
-BUTLER,Logan Twp,State House,12,R,Virgil Peck,19
-BUTLER,Milton Twp - 75,State House,75,R,Will Carpenter,147
-BUTLER,Murdock Twp,State House,75,R,Will Carpenter,136
-BUTLER,Pleasant Twp,State House,77,R,Kristey Williams,1017
-BUTLER,Potwin/Plum Grove,State House,75,R,Will Carpenter,155
-BUTLER,Prospect Twp,State House,75,R,Will Carpenter,284
-BUTLER,Richland Twp,State House,77,R,Kristey Williams,476
-BUTLER,Rock Creek Twp,State House,12,R,Virgil Peck,64
-BUTLER,Rosalia Twp,State House,12,R,Virgil Peck,135
-BUTLER,Rose Hill City,State House,77,R,Kristey Williams,710
-BUTLER,Spring Twp,State House,12,R,Virgil Peck,178
-BUTLER,Towanda City/Towanda Twp,State House,75,R,Will Carpenter,671
-BUTLER,Walnut Twp,State House,77,R,Kristey Williams,201
-BUTLER,Whitewater/Milton - 72,State House,H072,R,Marc Rhoades,243
-BUTLER,Benton City/Benton twp,State House,85,D,Patrick Thorpe,316
-BUTLER,Bloomington Twp,State House,77,D,Eden Fuson,91
-BUTLER,Cassoday/Sycamore Twp,State House,75,D,Kerri Ratliff,27
-BUTLER,Chelsea Twp,State House,12,D,Kerri Ratliff,31
-BUTLER,Clay Twp,State House,75,D,Eden Fuson,16
-BUTLER,Clifford Twp,State House,77,D,Kerri Ratliff,11
-BUTLER,El Dorado Twp East,State House,75,D,Kerri Ratliff,22
-BUTLER,El Dorado Twp West,State House,75,D,Kerri Ratliff,51
-BUTLER,El Dorado W1,State House,75,D,Kerri Ratliff,398
-BUTLER,El Dorado W2,State House,75,D,Kerri Ratliff,369
-BUTLER,El Dorado W3,State House,75,D,Kerri Ratliff,268
-BUTLER,El Dorado W4,State House,75,D,Kerri Ratliff,212
-BUTLER,Elbing City/Fairmount Twp,State House,75,D,Kerri Ratliff,42
-BUTLER,Fairview Twp,State House,12,D,Kerri Ratliff,47
-BUTLER,Glencoe Twp,State House,12,D,Eden Fuson,35
-BUTLER,Hickory Twp,State House,12,D,Eden Fuson,14
-BUTLER,Latham/Union,State House,12,D,Eden Fuson,34
-BUTLER,Leon/Little Walnut,State House,75,D,Eden Fuson,151
-BUTLER,Lincoln Twp,State House,12,D,Kerri Ratliff,13
-BUTLER,Logan Twp,State House,75,D,Eden Fuson,27
-BUTLER,Milton Twp - 75,State House,75,D,Kerri Ratliff,29
-BUTLER,Murdock Twp,State House,77,D,Kerri Ratliff,32
-BUTLER,Potwin/Plum Grove,State House,75,D,Kerri Ratliff,54
-BUTLER,Prospect Twp,State House,77,D,Kerri Ratliff,113
-BUTLER,Rock Creek Twp,State House,12,D,Eden Fuson,46
-BUTLER,Rosalia Twp,State House,77,D,Eden Fuson,76
-BUTLER,Spring Twp,State House,75,D,Eden Fuson,324
-BUTLER,Towanda City/Towanda Twp,State House,77,D,Kerri Ratliff,261
+county,precinct,office,district,party,candidate,votes,vtd
+BUTLER,Andover Ward 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",723,00001A
+BUTLER,Andover Ward 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",67,00001A
+BUTLER,Andover Ward 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",955,00001A
+BUTLER,Augusta City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",252,00002A
+BUTLER,Augusta City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",37,00002A
+BUTLER,Augusta City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",272,00002A
+BUTLER,Augusta City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",183,000030
+BUTLER,Augusta City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000030
+BUTLER,Augusta City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",215,000030
+BUTLER,Augusta City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",420,00004A
+BUTLER,Augusta City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",37,00004A
+BUTLER,Augusta City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",463,00004A
+BUTLER,Augusta City Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",316,000050
+BUTLER,Augusta City Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",37,000050
+BUTLER,Augusta City Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",470,000050
+BUTLER,Benton Township / City,Governor / Lt. Governor,,Democratic,"Davis, Paul",290,000070
+BUTLER,Benton Township / City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",42,000070
+BUTLER,Benton Township / City,Governor / Lt. Governor,,Republican,"Brownback, Sam",586,000070
+BUTLER,Bloomington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,000080
+BUTLER,Bloomington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000080
+BUTLER,Bloomington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",98,000080
+BUTLER,Sycamore/Cassoday,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000100
+BUTLER,Sycamore/Cassoday,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000100
+BUTLER,Sycamore/Cassoday,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000100
+BUTLER,Clay Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000110
+BUTLER,Clay Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000110
+BUTLER,Clay Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000110
+BUTLER,Clifford Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000120
+BUTLER,Clifford Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000120
+BUTLER,Clifford Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000120
+BUTLER,Douglass Township/City,Governor / Lt. Governor,,Democratic,"Davis, Paul",270,000130
+BUTLER,Douglass Township/City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",38,000130
+BUTLER,Douglass Township/City,Governor / Lt. Governor,,Republican,"Brownback, Sam",316,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",571,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",49,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",655,00014A
+BUTLER,El Dorado Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",484,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",56,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",441,00016A
+BUTLER,El Dorado Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",357,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",41,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",361,000190
+BUTLER,El Dorado Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",255,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",246,000220
+BUTLER,Fairmount Township/Elbing,Governor / Lt. Governor,,Democratic,"Davis, Paul",58,000240
+BUTLER,Fairmount Township/Elbing,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000240
+BUTLER,Fairmount Township/Elbing,Governor / Lt. Governor,,Republican,"Brownback, Sam",197,000240
+BUTLER,Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",63,000250
+BUTLER,Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000250
+BUTLER,Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",124,000250
+BUTLER,Glencoe Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000260
+BUTLER,Glencoe Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000260
+BUTLER,Glencoe Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000260
+BUTLER,Hickory Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000270
+BUTLER,Hickory Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000270
+BUTLER,Hickory Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000270
+BUTLER,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000280
+BUTLER,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000280
+BUTLER,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",74,000280
+BUTLER,Little Walnut Township/Leon,Governor / Lt. Governor,,Democratic,"Davis, Paul",103,000290
+BUTLER,Little Walnut Township/Leon,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",35,000290
+BUTLER,Little Walnut Township/Leon,Governor / Lt. Governor,,Republican,"Brownback, Sam",153,000290
+BUTLER,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000300
+BUTLER,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000300
+BUTLER,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000300
+BUTLER,Murdock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000320
+BUTLER,Murdock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000320
+BUTLER,Murdock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,000320
+BUTLER,El Dorado Township West,Governor / Lt. Governor,,Democratic,"Davis, Paul",82,000330
+BUTLER,El Dorado Township West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000330
+BUTLER,El Dorado Township West,Governor / Lt. Governor,,Republican,"Brownback, Sam",104,000330
+BUTLER,Pleasant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",400,000340
+BUTLER,Pleasant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",48,000340
+BUTLER,Pleasant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",746,000340
+BUTLER,Plum Grove Township/Potwin,Governor / Lt. Governor,,Democratic,"Davis, Paul",87,000350
+BUTLER,Plum Grove Township/Potwin,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000350
+BUTLER,Plum Grove Township/Potwin,Governor / Lt. Governor,,Republican,"Brownback, Sam",112,000350
+BUTLER,Prospect Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",168,000360
+BUTLER,Prospect Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000360
+BUTLER,Prospect Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",222,000360
+BUTLER,Rock Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000380
+BUTLER,Rock Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000380
+BUTLER,Rock Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000380
+BUTLER,Rosalia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000390
+BUTLER,Rosalia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000390
+BUTLER,Rosalia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",148,000390
+BUTLER,Spring Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",209,000410
+BUTLER,Spring Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000410
+BUTLER,Spring Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",316,000410
+BUTLER,Towanda Township/City,Governor / Lt. Governor,,Democratic,"Davis, Paul",332,000430
+BUTLER,Towanda Township/City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",49,000430
+BUTLER,Towanda Township/City,Governor / Lt. Governor,,Republican,"Brownback, Sam",569,000430
+BUTLER,Union Township / Latham,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000440
+BUTLER,Union Township / Latham,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000440
+BUTLER,Union Township / Latham,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000440
+BUTLER,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",75,000450
+BUTLER,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000450
+BUTLER,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",148,000450
+BUTLER,Augusta Township S14,Governor / Lt. Governor,,Democratic,"Davis, Paul",54,120040
+BUTLER,Augusta Township S14,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120040
+BUTLER,Augusta Township S14,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,120040
+BUTLER,Augusta Township S16,Governor / Lt. Governor,,Democratic,"Davis, Paul",91,120050
+BUTLER,Augusta Township S16,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,120050
+BUTLER,Augusta Township S16,Governor / Lt. Governor,,Republican,"Brownback, Sam",198,120050
+BUTLER,Whitewater / Milton Township H72,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,120080
+BUTLER,Whitewater / Milton Township H72,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,120080
+BUTLER,Whitewater / Milton Township H72,Governor / Lt. Governor,,Republican,"Brownback, Sam",176,120080
+BUTLER,Whitewater / Milton Township H75,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,120090
+BUTLER,Whitewater / Milton Township H75,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120090
+BUTLER,Whitewater / Milton Township H75,Governor / Lt. Governor,,Republican,"Brownback, Sam",139,120090
+BUTLER,Andover Ward 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",575,140010
+BUTLER,Andover Ward 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",52,140010
+BUTLER,Andover Ward 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",781,140010
+BUTLER,Andover Ward 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",252,140020
+BUTLER,Andover Ward 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",32,140020
+BUTLER,Andover Ward 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",350,140020
+BUTLER,Andover Ward 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,140030
+BUTLER,Andover Ward 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,140030
+BUTLER,Andover Ward 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",100,140030
+BUTLER,Bruno Township North H77,Governor / Lt. Governor,,Democratic,"Davis, Paul",108,140040
+BUTLER,Bruno Township North H77,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,140040
+BUTLER,Bruno Township North H77,Governor / Lt. Governor,,Republican,"Brownback, Sam",304,140040
+BUTLER,Bruno Township North H99,Governor / Lt. Governor,,Democratic,"Davis, Paul",82,140050
+BUTLER,Bruno Township North H99,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,140050
+BUTLER,Bruno Township North H99,Governor / Lt. Governor,,Republican,"Brownback, Sam",154,140050
+BUTLER,Bruno Township South H77,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,140060
+BUTLER,Bruno Township South H77,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,140060
+BUTLER,Bruno Township South H77,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,140060
+BUTLER,Bruno Township South H99,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,140070
+BUTLER,Bruno Township South H99,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,140070
+BUTLER,Bruno Township South H99,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,140070
+BUTLER,El Dorado Township East,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,140080
+BUTLER,El Dorado Township East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,140080
+BUTLER,El Dorado Township East,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,140080
+BUTLER,Rose Hill City,Governor / Lt. Governor,,Democratic,"Davis, Paul",317,200010
+BUTLER,Rose Hill City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",37,200010
+BUTLER,Rose Hill City,Governor / Lt. Governor,,Republican,"Brownback, Sam",475,200010
+BUTLER,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",183,200020
+BUTLER,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",27,200020
+BUTLER,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",336,200020
+BUTLER,Chelsea Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,800050
+BUTLER,Chelsea Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,800050
+BUTLER,Chelsea Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,800050
+BUTLER,Andover Ward 01,Kansas House of Representatives,99,Republican,"Hedke, Dennis E.",1428,00001A
+BUTLER,Augusta City Ward 1,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",472,00002A
+BUTLER,Augusta City Ward 2,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",342,000030
+BUTLER,Augusta City Ward 3,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",780,00004A
+BUTLER,Augusta City Ward 4,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",704,000050
+BUTLER,Benton Township / City,Kansas House of Representatives,85,Democratic,"Thorpe, Patrick",316,000070
+BUTLER,Benton Township / City,Kansas House of Representatives,85,Republican,"Brunk, Steven",473,000070
+BUTLER,Bloomington Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",91,000080
+BUTLER,Bloomington Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",52,000080
+BUTLER,Sycamore/Cassoday,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",27,000100
+BUTLER,Sycamore/Cassoday,Kansas House of Representatives,75,Republican,"Carpenter, Will",97,000100
+BUTLER,Clay Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",16,000110
+BUTLER,Clay Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",14,000110
+BUTLER,Clifford Township,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",11,000120
+BUTLER,Clifford Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",72,000120
+BUTLER,Douglass Township/City,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",534,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",398,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas House of Representatives,75,Republican,"Carpenter, Will",841,00014A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",369,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas House of Representatives,75,Republican,"Carpenter, Will",573,00016A
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",268,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas House of Representatives,75,Republican,"Carpenter, Will",471,000190
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",212,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas House of Representatives,75,Republican,"Carpenter, Will",301,000220
+BUTLER,Fairmount Township/Elbing,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",42,000240
+BUTLER,Fairmount Township/Elbing,Kansas House of Representatives,75,Republican,"Carpenter, Will",193,000240
+BUTLER,Fairview Township,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",47,000250
+BUTLER,Fairview Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",142,000250
+BUTLER,Glencoe Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",35,000260
+BUTLER,Glencoe Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",24,000260
+BUTLER,Hickory Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",14,000270
+BUTLER,Hickory Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",21,000270
+BUTLER,Lincoln Township,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",13,000280
+BUTLER,Lincoln Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",91,000280
+BUTLER,Little Walnut Township/Leon,Kansas House of Representatives,12,Democratic,"Fuson, Eden",151,000290
+BUTLER,Little Walnut Township/Leon,Kansas House of Representatives,12,Republican,"Peck, Virgil",113,000290
+BUTLER,Logan Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",27,000300
+BUTLER,Logan Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",19,000300
+BUTLER,Murdock Township,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",32,000320
+BUTLER,Murdock Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",136,000320
+BUTLER,El Dorado Township West,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",51,000330
+BUTLER,El Dorado Township West,Kansas House of Representatives,75,Republican,"Carpenter, Will",141,000330
+BUTLER,Pleasant Township,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",1017,000340
+BUTLER,Plum Grove Township/Potwin,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",54,000350
+BUTLER,Plum Grove Township/Potwin,Kansas House of Representatives,75,Republican,"Carpenter, Will",155,000350
+BUTLER,Prospect Township,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",113,000360
+BUTLER,Prospect Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",284,000360
+BUTLER,Rock Creek Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",46,000380
+BUTLER,Rock Creek Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",64,000380
+BUTLER,Rosalia Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",76,000390
+BUTLER,Rosalia Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",135,000390
+BUTLER,Spring Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",324,000410
+BUTLER,Spring Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",178,000410
+BUTLER,Towanda Township/City,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",261,000430
+BUTLER,Towanda Township/City,Kansas House of Representatives,75,Republican,"Carpenter, Will",671,000430
+BUTLER,Union Township / Latham,Kansas House of Representatives,12,Democratic,"Fuson, Eden",34,000440
+BUTLER,Union Township / Latham,Kansas House of Representatives,12,Republican,"Peck, Virgil",17,000440
+BUTLER,Walnut Township,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",201,000450
+BUTLER,Augusta Township S14,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",103,120040
+BUTLER,Augusta Township S16,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",276,120050
+BUTLER,Whitewater / Milton Township H72,Kansas House of Representatives,72,Republican,"Rhoades, Marc",243,120080
+BUTLER,Whitewater / Milton Township H75,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",29,120090
+BUTLER,Whitewater / Milton Township H75,Kansas House of Representatives,75,Republican,"Carpenter, Will",147,120090
+BUTLER,Andover Ward 02,Kansas House of Representatives,99,Republican,"Hedke, Dennis E.",1135,140010
+BUTLER,Andover Ward 03,Kansas House of Representatives,99,Republican,"Hedke, Dennis E.",515,140020
+BUTLER,Andover Ward 04,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",111,140030
+BUTLER,Bruno Township North H77,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",375,140040
+BUTLER,Bruno Township North H99,Kansas House of Representatives,99,Republican,"Hedke, Dennis E.",210,140050
+BUTLER,Bruno Township South H77,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",86,140060
+BUTLER,Bruno Township South H99,Kansas House of Representatives,99,Republican,"Hedke, Dennis E.",93,140070
+BUTLER,El Dorado Township East,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",22,140080
+BUTLER,El Dorado Township East,Kansas House of Representatives,75,Republican,"Carpenter, Will",45,140080
+BUTLER,Rose Hill City,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",710,200010
+BUTLER,Richland Township,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",476,200020
+BUTLER,Chelsea Township,Kansas House of Representatives,75,Democratic,"Ratliff, Keri",31,800050
+BUTLER,Chelsea Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",57,800050
+BUTLER,Andover Ward 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",462,00001A
+BUTLER,Andover Ward 01,United States House of Representatives,4,Republican,"Pompeo, Mike",1263,00001A
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",182,00002A
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",375,00002A
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",118,000030
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",294,000030
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",285,00004A
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",623,00004A
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",192,000050
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",622,000050
+BUTLER,Benton Township / City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",189,000070
+BUTLER,Benton Township / City,United States House of Representatives,4,Republican,"Pompeo, Mike",715,000070
+BUTLER,Bloomington Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",45,000080
+BUTLER,Bloomington Township,United States House of Representatives,4,Republican,"Pompeo, Mike",114,000080
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",18,000100
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,Republican,"Pompeo, Mike",110,000100
+BUTLER,Clay Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,000110
+BUTLER,Clay Township,United States House of Representatives,4,Republican,"Pompeo, Mike",24,000110
+BUTLER,Clifford Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",15,000120
+BUTLER,Clifford Township,United States House of Representatives,4,Republican,"Pompeo, Mike",75,000120
+BUTLER,Douglass Township/City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",174,000130
+BUTLER,Douglass Township/City,United States House of Representatives,4,Republican,"Pompeo, Mike",442,000130
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",335,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",944,00014A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",364,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",599,00016A
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",252,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",500,000190
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",190,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",333,000220
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",46,000240
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,Republican,"Pompeo, Mike",211,000240
+BUTLER,Fairview Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",46,000250
+BUTLER,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Mike",146,000250
+BUTLER,Glencoe Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",29,000260
+BUTLER,Glencoe Township,United States House of Representatives,4,Republican,"Pompeo, Mike",40,000260
+BUTLER,Hickory Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",7,000270
+BUTLER,Hickory Township,United States House of Representatives,4,Republican,"Pompeo, Mike",30,000270
+BUTLER,Lincoln Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,000280
+BUTLER,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Mike",86,000280
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",71,000290
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,Republican,"Pompeo, Mike",214,000290
+BUTLER,Logan Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",13,000300
+BUTLER,Logan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000300
+BUTLER,Murdock Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",32,000320
+BUTLER,Murdock Township,United States House of Representatives,4,Republican,"Pompeo, Mike",150,000320
+BUTLER,El Dorado Township West,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",47,000330
+BUTLER,El Dorado Township West,United States House of Representatives,4,Republican,"Pompeo, Mike",148,000330
+BUTLER,Pleasant Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",268,000340
+BUTLER,Pleasant Township,United States House of Representatives,4,Republican,"Pompeo, Mike",915,000340
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",63,000350
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,Republican,"Pompeo, Mike",147,000350
+BUTLER,Prospect Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",108,000360
+BUTLER,Prospect Township,United States House of Representatives,4,Republican,"Pompeo, Mike",300,000360
+BUTLER,Rock Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",31,000380
+BUTLER,Rock Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",85,000380
+BUTLER,Rosalia Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",48,000390
+BUTLER,Rosalia Township,United States House of Representatives,4,Republican,"Pompeo, Mike",178,000390
+BUTLER,Spring Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",156,000410
+BUTLER,Spring Township,United States House of Representatives,4,Republican,"Pompeo, Mike",385,000410
+BUTLER,Towanda Township/City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",230,000430
+BUTLER,Towanda Township/City,United States House of Representatives,4,Republican,"Pompeo, Mike",717,000430
+BUTLER,Union Township / Latham,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",14,000440
+BUTLER,Union Township / Latham,United States House of Representatives,4,Republican,"Pompeo, Mike",43,000440
+BUTLER,Walnut Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",45,000450
+BUTLER,Walnut Township,United States House of Representatives,4,Republican,"Pompeo, Mike",186,000450
+BUTLER,Augusta Township S14,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",39,120040
+BUTLER,Augusta Township S14,United States House of Representatives,4,Republican,"Pompeo, Mike",94,120040
+BUTLER,Augusta Township S16,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",64,120050
+BUTLER,Augusta Township S16,United States House of Representatives,4,Republican,"Pompeo, Mike",234,120050
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",58,120080
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,Republican,"Pompeo, Mike",209,120080
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",31,120090
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,Republican,"Pompeo, Mike",145,120090
+BUTLER,Andover Ward 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",381,140010
+BUTLER,Andover Ward 02,United States House of Representatives,4,Republican,"Pompeo, Mike",1012,140010
+BUTLER,Andover Ward 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",159,140020
+BUTLER,Andover Ward 03,United States House of Representatives,4,Republican,"Pompeo, Mike",466,140020
+BUTLER,Andover Ward 04,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",17,140030
+BUTLER,Andover Ward 04,United States House of Representatives,4,Republican,"Pompeo, Mike",112,140030
+BUTLER,Bruno Township North H77,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",82,140040
+BUTLER,Bruno Township North H77,United States House of Representatives,4,Republican,"Pompeo, Mike",340,140040
+BUTLER,Bruno Township North H99,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",57,140050
+BUTLER,Bruno Township North H99,United States House of Representatives,4,Republican,"Pompeo, Mike",185,140050
+BUTLER,Bruno Township South H77,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",22,140060
+BUTLER,Bruno Township South H77,United States House of Representatives,4,Republican,"Pompeo, Mike",80,140060
+BUTLER,Bruno Township South H99,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",23,140070
+BUTLER,Bruno Township South H99,United States House of Representatives,4,Republican,"Pompeo, Mike",82,140070
+BUTLER,El Dorado Township East,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",27,140080
+BUTLER,El Dorado Township East,United States House of Representatives,4,Republican,"Pompeo, Mike",42,140080
+BUTLER,Rose Hill City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",211,200010
+BUTLER,Rose Hill City,United States House of Representatives,4,Republican,"Pompeo, Mike",607,200010
+BUTLER,Richland Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",124,200020
+BUTLER,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",417,200020
+BUTLER,Chelsea Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",26,800050
+BUTLER,Chelsea Township,United States House of Representatives,4,Republican,"Pompeo, Mike",62,800050
+BUTLER,Andover Ward 01,Attorney General,,Democratic,"Kotich, A.J.",442,00001A
+BUTLER,Andover Ward 01,Attorney General,,Republican,"Schmidt, Derek",1248,00001A
+BUTLER,Augusta City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",181,00002A
+BUTLER,Augusta City Ward 1,Attorney General,,Republican,"Schmidt, Derek",377,00002A
+BUTLER,Augusta City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",121,000030
+BUTLER,Augusta City Ward 2,Attorney General,,Republican,"Schmidt, Derek",290,000030
+BUTLER,Augusta City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",260,00004A
+BUTLER,Augusta City Ward 3,Attorney General,,Republican,"Schmidt, Derek",633,00004A
+BUTLER,Augusta City Ward 4,Attorney General,,Democratic,"Kotich, A.J.",177,000050
+BUTLER,Augusta City Ward 4,Attorney General,,Republican,"Schmidt, Derek",627,000050
+BUTLER,Benton Township / City,Attorney General,,Democratic,"Kotich, A.J.",160,000070
+BUTLER,Benton Township / City,Attorney General,,Republican,"Schmidt, Derek",742,000070
+BUTLER,Bloomington Township,Attorney General,,Democratic,"Kotich, A.J.",39,000080
+BUTLER,Bloomington Township,Attorney General,,Republican,"Schmidt, Derek",120,000080
+BUTLER,Sycamore/Cassoday,Attorney General,,Democratic,"Kotich, A.J.",22,000100
+BUTLER,Sycamore/Cassoday,Attorney General,,Republican,"Schmidt, Derek",103,000100
+BUTLER,Clay Township,Attorney General,,Democratic,"Kotich, A.J.",11,000110
+BUTLER,Clay Township,Attorney General,,Republican,"Schmidt, Derek",20,000110
+BUTLER,Clifford Township,Attorney General,,Democratic,"Kotich, A.J.",8,000120
+BUTLER,Clifford Township,Attorney General,,Republican,"Schmidt, Derek",82,000120
+BUTLER,Douglass Township/City,Attorney General,,Democratic,"Kotich, A.J.",153,000130
+BUTLER,Douglass Township/City,Attorney General,,Republican,"Schmidt, Derek",458,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",308,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",943,00014A
+BUTLER,El Dorado Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",330,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",627,00016A
+BUTLER,El Dorado Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",226,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",525,000190
+BUTLER,El Dorado Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",190,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",325,000220
+BUTLER,Fairmount Township/Elbing,Attorney General,,Democratic,"Kotich, A.J.",35,000240
+BUTLER,Fairmount Township/Elbing,Attorney General,,Republican,"Schmidt, Derek",215,000240
+BUTLER,Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",39,000250
+BUTLER,Fairview Township,Attorney General,,Republican,"Schmidt, Derek",154,000250
+BUTLER,Glencoe Township,Attorney General,,Democratic,"Kotich, A.J.",24,000260
+BUTLER,Glencoe Township,Attorney General,,Republican,"Schmidt, Derek",44,000260
+BUTLER,Hickory Township,Attorney General,,Democratic,"Kotich, A.J.",7,000270
+BUTLER,Hickory Township,Attorney General,,Republican,"Schmidt, Derek",31,000270
+BUTLER,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",18,000280
+BUTLER,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",85,000280
+BUTLER,Little Walnut Township/Leon,Attorney General,,Democratic,"Kotich, A.J.",69,000290
+BUTLER,Little Walnut Township/Leon,Attorney General,,Republican,"Schmidt, Derek",214,000290
+BUTLER,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",13,000300
+BUTLER,Logan Township,Attorney General,,Republican,"Schmidt, Derek",38,000300
+BUTLER,Murdock Township,Attorney General,,Democratic,"Kotich, A.J.",34,000320
+BUTLER,Murdock Township,Attorney General,,Republican,"Schmidt, Derek",146,000320
+BUTLER,El Dorado Township West,Attorney General,,Democratic,"Kotich, A.J.",45,000330
+BUTLER,El Dorado Township West,Attorney General,,Republican,"Schmidt, Derek",149,000330
+BUTLER,Pleasant Township,Attorney General,,Democratic,"Kotich, A.J.",235,000340
+BUTLER,Pleasant Township,Attorney General,,Republican,"Schmidt, Derek",938,000340
+BUTLER,Plum Grove Township/Potwin,Attorney General,,Democratic,"Kotich, A.J.",53,000350
+BUTLER,Plum Grove Township/Potwin,Attorney General,,Republican,"Schmidt, Derek",155,000350
+BUTLER,Prospect Township,Attorney General,,Democratic,"Kotich, A.J.",107,000360
+BUTLER,Prospect Township,Attorney General,,Republican,"Schmidt, Derek",298,000360
+BUTLER,Rock Creek Township,Attorney General,,Democratic,"Kotich, A.J.",21,000380
+BUTLER,Rock Creek Township,Attorney General,,Republican,"Schmidt, Derek",92,000380
+BUTLER,Rosalia Township,Attorney General,,Democratic,"Kotich, A.J.",42,000390
+BUTLER,Rosalia Township,Attorney General,,Republican,"Schmidt, Derek",182,000390
+BUTLER,Spring Township,Attorney General,,Democratic,"Kotich, A.J.",124,000410
+BUTLER,Spring Township,Attorney General,,Republican,"Schmidt, Derek",412,000410
+BUTLER,Towanda Township/City,Attorney General,,Democratic,"Kotich, A.J.",219,000430
+BUTLER,Towanda Township/City,Attorney General,,Republican,"Schmidt, Derek",714,000430
+BUTLER,Union Township / Latham,Attorney General,,Democratic,"Kotich, A.J.",10,000440
+BUTLER,Union Township / Latham,Attorney General,,Republican,"Schmidt, Derek",46,000440
+BUTLER,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",43,000450
+BUTLER,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",186,000450
+BUTLER,Augusta Township S14,Attorney General,,Democratic,"Kotich, A.J.",34,120040
+BUTLER,Augusta Township S14,Attorney General,,Republican,"Schmidt, Derek",98,120040
+BUTLER,Augusta Township S16,Attorney General,,Democratic,"Kotich, A.J.",64,120050
+BUTLER,Augusta Township S16,Attorney General,,Republican,"Schmidt, Derek",233,120050
+BUTLER,Whitewater / Milton Township H72,Attorney General,,Democratic,"Kotich, A.J.",47,120080
+BUTLER,Whitewater / Milton Township H72,Attorney General,,Republican,"Schmidt, Derek",214,120080
+BUTLER,Whitewater / Milton Township H75,Attorney General,,Democratic,"Kotich, A.J.",23,120090
+BUTLER,Whitewater / Milton Township H75,Attorney General,,Republican,"Schmidt, Derek",151,120090
+BUTLER,Andover Ward 02,Attorney General,,Democratic,"Kotich, A.J.",341,140010
+BUTLER,Andover Ward 02,Attorney General,,Republican,"Schmidt, Derek",1031,140010
+BUTLER,Andover Ward 03,Attorney General,,Democratic,"Kotich, A.J.",148,140020
+BUTLER,Andover Ward 03,Attorney General,,Republican,"Schmidt, Derek",462,140020
+BUTLER,Andover Ward 04,Attorney General,,Democratic,"Kotich, A.J.",15,140030
+BUTLER,Andover Ward 04,Attorney General,,Republican,"Schmidt, Derek",113,140030
+BUTLER,Bruno Township North H77,Attorney General,,Democratic,"Kotich, A.J.",74,140040
+BUTLER,Bruno Township North H77,Attorney General,,Republican,"Schmidt, Derek",345,140040
+BUTLER,Bruno Township North H99,Attorney General,,Democratic,"Kotich, A.J.",59,140050
+BUTLER,Bruno Township North H99,Attorney General,,Republican,"Schmidt, Derek",183,140050
+BUTLER,Bruno Township South H77,Attorney General,,Democratic,"Kotich, A.J.",17,140060
+BUTLER,Bruno Township South H77,Attorney General,,Republican,"Schmidt, Derek",85,140060
+BUTLER,Bruno Township South H99,Attorney General,,Democratic,"Kotich, A.J.",18,140070
+BUTLER,Bruno Township South H99,Attorney General,,Republican,"Schmidt, Derek",85,140070
+BUTLER,El Dorado Township East,Attorney General,,Democratic,"Kotich, A.J.",28,140080
+BUTLER,El Dorado Township East,Attorney General,,Republican,"Schmidt, Derek",39,140080
+BUTLER,Rose Hill City,Attorney General,,Democratic,"Kotich, A.J.",176,200010
+BUTLER,Rose Hill City,Attorney General,,Republican,"Schmidt, Derek",631,200010
+BUTLER,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",115,200020
+BUTLER,Richland Township,Attorney General,,Republican,"Schmidt, Derek",422,200020
+BUTLER,Chelsea Township,Attorney General,,Democratic,"Kotich, A.J.",24,800050
+BUTLER,Chelsea Township,Attorney General,,Republican,"Schmidt, Derek",64,800050
+BUTLER,Andover Ward 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",494,00001A
+BUTLER,Andover Ward 01,Commissioner of Insurance,,Republican,"Selzer, Ken",1169,00001A
+BUTLER,Augusta City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",195,00002A
+BUTLER,Augusta City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",345,00002A
+BUTLER,Augusta City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",141,000030
+BUTLER,Augusta City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",268,000030
+BUTLER,Augusta City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",300,00004A
+BUTLER,Augusta City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",573,00004A
+BUTLER,Augusta City Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",219,000050
+BUTLER,Augusta City Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",572,000050
+BUTLER,Benton Township / City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",202,000070
+BUTLER,Benton Township / City,Commissioner of Insurance,,Republican,"Selzer, Ken",681,000070
+BUTLER,Bloomington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000080
+BUTLER,Bloomington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",108,000080
+BUTLER,Sycamore/Cassoday,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000100
+BUTLER,Sycamore/Cassoday,Commissioner of Insurance,,Republican,"Selzer, Ken",93,000100
+BUTLER,Clay Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000110
+BUTLER,Clay Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000110
+BUTLER,Clifford Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000120
+BUTLER,Clifford Township,Commissioner of Insurance,,Republican,"Selzer, Ken",76,000120
+BUTLER,Douglass Township/City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",184,000130
+BUTLER,Douglass Township/City,Commissioner of Insurance,,Republican,"Selzer, Ken",407,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",393,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",852,00014A
+BUTLER,El Dorado Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",367,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",575,00016A
+BUTLER,El Dorado Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",286,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",449,000190
+BUTLER,El Dorado Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",217,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",295,000220
+BUTLER,Fairmount Township/Elbing,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000240
+BUTLER,Fairmount Township/Elbing,Commissioner of Insurance,,Republican,"Selzer, Ken",210,000240
+BUTLER,Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000250
+BUTLER,Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",144,000250
+BUTLER,Glencoe Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000260
+BUTLER,Glencoe Township,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000260
+BUTLER,Hickory Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000270
+BUTLER,Hickory Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000270
+BUTLER,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000280
+BUTLER,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000280
+BUTLER,Little Walnut Township/Leon,Commissioner of Insurance,,Democratic,"Anderson, Dennis",83,000290
+BUTLER,Little Walnut Township/Leon,Commissioner of Insurance,,Republican,"Selzer, Ken",201,000290
+BUTLER,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000300
+BUTLER,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000300
+BUTLER,Murdock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000320
+BUTLER,Murdock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",147,000320
+BUTLER,El Dorado Township West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000330
+BUTLER,El Dorado Township West,Commissioner of Insurance,,Republican,"Selzer, Ken",144,000330
+BUTLER,Pleasant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",293,000340
+BUTLER,Pleasant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",857,000340
+BUTLER,Plum Grove Township/Potwin,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000350
+BUTLER,Plum Grove Township/Potwin,Commissioner of Insurance,,Republican,"Selzer, Ken",131,000350
+BUTLER,Prospect Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",118,000360
+BUTLER,Prospect Township,Commissioner of Insurance,,Republican,"Selzer, Ken",279,000360
+BUTLER,Rock Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000380
+BUTLER,Rock Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000380
+BUTLER,Rosalia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000390
+BUTLER,Rosalia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",164,000390
+BUTLER,Spring Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",151,000410
+BUTLER,Spring Township,Commissioner of Insurance,,Republican,"Selzer, Ken",375,000410
+BUTLER,Towanda Township/City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",246,000430
+BUTLER,Towanda Township/City,Commissioner of Insurance,,Republican,"Selzer, Ken",681,000430
+BUTLER,Union Township / Latham,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000440
+BUTLER,Union Township / Latham,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000440
+BUTLER,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,000450
+BUTLER,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000450
+BUTLER,Augusta Township S14,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,120040
+BUTLER,Augusta Township S14,Commissioner of Insurance,,Republican,"Selzer, Ken",87,120040
+BUTLER,Augusta Township S16,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,120050
+BUTLER,Augusta Township S16,Commissioner of Insurance,,Republican,"Selzer, Ken",220,120050
+BUTLER,Whitewater / Milton Township H72,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,120080
+BUTLER,Whitewater / Milton Township H72,Commissioner of Insurance,,Republican,"Selzer, Ken",205,120080
+BUTLER,Whitewater / Milton Township H75,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,120090
+BUTLER,Whitewater / Milton Township H75,Commissioner of Insurance,,Republican,"Selzer, Ken",145,120090
+BUTLER,Andover Ward 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",387,140010
+BUTLER,Andover Ward 02,Commissioner of Insurance,,Republican,"Selzer, Ken",952,140010
+BUTLER,Andover Ward 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",179,140020
+BUTLER,Andover Ward 03,Commissioner of Insurance,,Republican,"Selzer, Ken",418,140020
+BUTLER,Andover Ward 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,140030
+BUTLER,Andover Ward 04,Commissioner of Insurance,,Republican,"Selzer, Ken",100,140030
+BUTLER,Bruno Township North H77,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,140040
+BUTLER,Bruno Township North H77,Commissioner of Insurance,,Republican,"Selzer, Ken",328,140040
+BUTLER,Bruno Township North H99,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,140050
+BUTLER,Bruno Township North H99,Commissioner of Insurance,,Republican,"Selzer, Ken",173,140050
+BUTLER,Bruno Township South H77,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,140060
+BUTLER,Bruno Township South H77,Commissioner of Insurance,,Republican,"Selzer, Ken",76,140060
+BUTLER,Bruno Township South H99,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,140070
+BUTLER,Bruno Township South H99,Commissioner of Insurance,,Republican,"Selzer, Ken",80,140070
+BUTLER,El Dorado Township East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,140080
+BUTLER,El Dorado Township East,Commissioner of Insurance,,Republican,"Selzer, Ken",35,140080
+BUTLER,Rose Hill City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",243,200010
+BUTLER,Rose Hill City,Commissioner of Insurance,,Republican,"Selzer, Ken",555,200010
+BUTLER,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",120,200020
+BUTLER,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",404,200020
+BUTLER,Chelsea Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,800050
+BUTLER,Chelsea Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,800050
+BUTLER,Andover Ward 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",617,00001A
+BUTLER,Andover Ward 01,Secretary of State,,Republican,"Kobach, Kris",1108,00001A
+BUTLER,Augusta City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",225,00002A
+BUTLER,Augusta City Ward 1,Secretary of State,,Republican,"Kobach, Kris",339,00002A
+BUTLER,Augusta City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",162,000030
+BUTLER,Augusta City Ward 2,Secretary of State,,Republican,"Kobach, Kris",253,000030
+BUTLER,Augusta City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",368,00004A
+BUTLER,Augusta City Ward 3,Secretary of State,,Republican,"Kobach, Kris",541,00004A
+BUTLER,Augusta City Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",287,000050
+BUTLER,Augusta City Ward 4,Secretary of State,,Republican,"Kobach, Kris",531,000050
+BUTLER,Benton Township / City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",243,000070
+BUTLER,Benton Township / City,Secretary of State,,Republican,"Kobach, Kris",664,000070
+BUTLER,Bloomington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000080
+BUTLER,Bloomington Township,Secretary of State,,Republican,"Kobach, Kris",112,000080
+BUTLER,Sycamore/Cassoday,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000100
+BUTLER,Sycamore/Cassoday,Secretary of State,,Republican,"Kobach, Kris",94,000100
+BUTLER,Clay Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000110
+BUTLER,Clay Township,Secretary of State,,Republican,"Kobach, Kris",20,000110
+BUTLER,Clifford Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000120
+BUTLER,Clifford Township,Secretary of State,,Republican,"Kobach, Kris",70,000120
+BUTLER,Douglass Township/City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",232,000130
+BUTLER,Douglass Township/City,Secretary of State,,Republican,"Kobach, Kris",385,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",497,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",778,00014A
+BUTLER,El Dorado Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",451,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",522,00016A
+BUTLER,El Dorado Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",322,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",435,000190
+BUTLER,El Dorado Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",239,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",278,000220
+BUTLER,Fairmount Township/Elbing,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000240
+BUTLER,Fairmount Township/Elbing,Secretary of State,,Republican,"Kobach, Kris",207,000240
+BUTLER,Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,000250
+BUTLER,Fairview Township,Secretary of State,,Republican,"Kobach, Kris",133,000250
+BUTLER,Glencoe Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000260
+BUTLER,Glencoe Township,Secretary of State,,Republican,"Kobach, Kris",36,000260
+BUTLER,Hickory Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000270
+BUTLER,Hickory Township,Secretary of State,,Republican,"Kobach, Kris",28,000270
+BUTLER,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000280
+BUTLER,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",79,000280
+BUTLER,Little Walnut Township/Leon,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,000290
+BUTLER,Little Walnut Township/Leon,Secretary of State,,Republican,"Kobach, Kris",182,000290
+BUTLER,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000300
+BUTLER,Logan Township,Secretary of State,,Republican,"Kobach, Kris",35,000300
+BUTLER,Murdock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000320
+BUTLER,Murdock Township,Secretary of State,,Republican,"Kobach, Kris",141,000320
+BUTLER,El Dorado Township West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000330
+BUTLER,El Dorado Township West,Secretary of State,,Republican,"Kobach, Kris",137,000330
+BUTLER,Pleasant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",358,000340
+BUTLER,Pleasant Township,Secretary of State,,Republican,"Kobach, Kris",822,000340
+BUTLER,Plum Grove Township/Potwin,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,000350
+BUTLER,Plum Grove Township/Potwin,Secretary of State,,Republican,"Kobach, Kris",131,000350
+BUTLER,Prospect Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",134,000360
+BUTLER,Prospect Township,Secretary of State,,Republican,"Kobach, Kris",278,000360
+BUTLER,Rock Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000380
+BUTLER,Rock Creek Township,Secretary of State,,Republican,"Kobach, Kris",81,000380
+BUTLER,Rosalia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000390
+BUTLER,Rosalia Township,Secretary of State,,Republican,"Kobach, Kris",169,000390
+BUTLER,Spring Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",183,000410
+BUTLER,Spring Township,Secretary of State,,Republican,"Kobach, Kris",361,000410
+BUTLER,Towanda Township/City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",289,000430
+BUTLER,Towanda Township/City,Secretary of State,,Republican,"Kobach, Kris",660,000430
+BUTLER,Union Township / Latham,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000440
+BUTLER,Union Township / Latham,Secretary of State,,Republican,"Kobach, Kris",42,000440
+BUTLER,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000450
+BUTLER,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",168,000450
+BUTLER,Augusta Township S14,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,120040
+BUTLER,Augusta Township S14,Secretary of State,,Republican,"Kobach, Kris",87,120040
+BUTLER,Augusta Township S16,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",87,120050
+BUTLER,Augusta Township S16,Secretary of State,,Republican,"Kobach, Kris",210,120050
+BUTLER,Whitewater / Milton Township H72,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,120080
+BUTLER,Whitewater / Milton Township H72,Secretary of State,,Republican,"Kobach, Kris",186,120080
+BUTLER,Whitewater / Milton Township H75,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,120090
+BUTLER,Whitewater / Milton Township H75,Secretary of State,,Republican,"Kobach, Kris",146,120090
+BUTLER,Andover Ward 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",491,140010
+BUTLER,Andover Ward 02,Secretary of State,,Republican,"Kobach, Kris",902,140010
+BUTLER,Andover Ward 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",234,140020
+BUTLER,Andover Ward 03,Secretary of State,,Republican,"Kobach, Kris",387,140020
+BUTLER,Andover Ward 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,140030
+BUTLER,Andover Ward 04,Secretary of State,,Republican,"Kobach, Kris",92,140030
+BUTLER,Bruno Township North H77,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,140040
+BUTLER,Bruno Township North H77,Secretary of State,,Republican,"Kobach, Kris",325,140040
+BUTLER,Bruno Township North H99,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",69,140050
+BUTLER,Bruno Township North H99,Secretary of State,,Republican,"Kobach, Kris",175,140050
+BUTLER,Bruno Township South H77,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",32,140060
+BUTLER,Bruno Township South H77,Secretary of State,,Republican,"Kobach, Kris",71,140060
+BUTLER,Bruno Township South H99,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,140070
+BUTLER,Bruno Township South H99,Secretary of State,,Republican,"Kobach, Kris",80,140070
+BUTLER,El Dorado Township East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,140080
+BUTLER,El Dorado Township East,Secretary of State,,Republican,"Kobach, Kris",32,140080
+BUTLER,Rose Hill City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",279,200010
+BUTLER,Rose Hill City,Secretary of State,,Republican,"Kobach, Kris",537,200010
+BUTLER,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",167,200020
+BUTLER,Richland Township,Secretary of State,,Republican,"Kobach, Kris",380,200020
+BUTLER,Chelsea Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,800050
+BUTLER,Chelsea Township,Secretary of State,,Republican,"Kobach, Kris",54,800050
+BUTLER,Andover Ward 01,State Treasurer,,Democratic,"Alldritt, Carmen",368,00001A
+BUTLER,Andover Ward 01,State Treasurer,,Republican,"Estes, Ron",1323,00001A
+BUTLER,Augusta City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",179,00002A
+BUTLER,Augusta City Ward 1,State Treasurer,,Republican,"Estes, Ron",377,00002A
+BUTLER,Augusta City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",117,000030
+BUTLER,Augusta City Ward 2,State Treasurer,,Republican,"Estes, Ron",293,000030
+BUTLER,Augusta City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",252,00004A
+BUTLER,Augusta City Ward 3,State Treasurer,,Republican,"Estes, Ron",635,00004A
+BUTLER,Augusta City Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",154,000050
+BUTLER,Augusta City Ward 4,State Treasurer,,Republican,"Estes, Ron",650,000050
+BUTLER,Benton Township / City,State Treasurer,,Democratic,"Alldritt, Carmen",159,000070
+BUTLER,Benton Township / City,State Treasurer,,Republican,"Estes, Ron",741,000070
+BUTLER,Bloomington Township,State Treasurer,,Democratic,"Alldritt, Carmen",36,000080
+BUTLER,Bloomington Township,State Treasurer,,Republican,"Estes, Ron",119,000080
+BUTLER,Sycamore/Cassoday,State Treasurer,,Democratic,"Alldritt, Carmen",22,000100
+BUTLER,Sycamore/Cassoday,State Treasurer,,Republican,"Estes, Ron",106,000100
+BUTLER,Clay Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000110
+BUTLER,Clay Township,State Treasurer,,Republican,"Estes, Ron",23,000110
+BUTLER,Clifford Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000120
+BUTLER,Clifford Township,State Treasurer,,Republican,"Estes, Ron",79,000120
+BUTLER,Douglass Township/City,State Treasurer,,Democratic,"Alldritt, Carmen",143,000130
+BUTLER,Douglass Township/City,State Treasurer,,Republican,"Estes, Ron",469,000130
+BUTLER,El Dorado Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",311,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",946,00014A
+BUTLER,El Dorado Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",307,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",654,00016A
+BUTLER,El Dorado Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",235,000190
+BUTLER,El Dorado Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",512,000190
+BUTLER,El Dorado Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",174,000220
+BUTLER,El Dorado Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",342,000220
+BUTLER,Fairmount Township/Elbing,State Treasurer,,Democratic,"Alldritt, Carmen",37,000240
+BUTLER,Fairmount Township/Elbing,State Treasurer,,Republican,"Estes, Ron",211,000240
+BUTLER,Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",37,000250
+BUTLER,Fairview Township,State Treasurer,,Republican,"Estes, Ron",155,000250
+BUTLER,Glencoe Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000260
+BUTLER,Glencoe Township,State Treasurer,,Republican,"Estes, Ron",48,000260
+BUTLER,Hickory Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000270
+BUTLER,Hickory Township,State Treasurer,,Republican,"Estes, Ron",31,000270
+BUTLER,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000280
+BUTLER,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",84,000280
+BUTLER,Little Walnut Township/Leon,State Treasurer,,Democratic,"Alldritt, Carmen",67,000290
+BUTLER,Little Walnut Township/Leon,State Treasurer,,Republican,"Estes, Ron",219,000290
+BUTLER,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000300
+BUTLER,Logan Township,State Treasurer,,Republican,"Estes, Ron",37,000300
+BUTLER,Murdock Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000320
+BUTLER,Murdock Township,State Treasurer,,Republican,"Estes, Ron",151,000320
+BUTLER,El Dorado Township West,State Treasurer,,Democratic,"Alldritt, Carmen",37,000330
+BUTLER,El Dorado Township West,State Treasurer,,Republican,"Estes, Ron",158,000330
+BUTLER,Pleasant Township,State Treasurer,,Democratic,"Alldritt, Carmen",225,000340
+BUTLER,Pleasant Township,State Treasurer,,Republican,"Estes, Ron",948,000340
+BUTLER,Plum Grove Township/Potwin,State Treasurer,,Democratic,"Alldritt, Carmen",55,000350
+BUTLER,Plum Grove Township/Potwin,State Treasurer,,Republican,"Estes, Ron",155,000350
+BUTLER,Prospect Township,State Treasurer,,Democratic,"Alldritt, Carmen",105,000360
+BUTLER,Prospect Township,State Treasurer,,Republican,"Estes, Ron",299,000360
+BUTLER,Rock Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000380
+BUTLER,Rock Creek Township,State Treasurer,,Republican,"Estes, Ron",88,000380
+BUTLER,Rosalia Township,State Treasurer,,Democratic,"Alldritt, Carmen",47,000390
+BUTLER,Rosalia Township,State Treasurer,,Republican,"Estes, Ron",172,000390
+BUTLER,Spring Township,State Treasurer,,Democratic,"Alldritt, Carmen",126,000410
+BUTLER,Spring Township,State Treasurer,,Republican,"Estes, Ron",408,000410
+BUTLER,Towanda Township/City,State Treasurer,,Democratic,"Alldritt, Carmen",213,000430
+BUTLER,Towanda Township/City,State Treasurer,,Republican,"Estes, Ron",723,000430
+BUTLER,Union Township / Latham,State Treasurer,,Democratic,"Alldritt, Carmen",15,000440
+BUTLER,Union Township / Latham,State Treasurer,,Republican,"Estes, Ron",42,000440
+BUTLER,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",39,000450
+BUTLER,Walnut Township,State Treasurer,,Republican,"Estes, Ron",191,000450
+BUTLER,Augusta Township S14,State Treasurer,,Democratic,"Alldritt, Carmen",34,120040
+BUTLER,Augusta Township S14,State Treasurer,,Republican,"Estes, Ron",98,120040
+BUTLER,Augusta Township S16,State Treasurer,,Democratic,"Alldritt, Carmen",57,120050
+BUTLER,Augusta Township S16,State Treasurer,,Republican,"Estes, Ron",242,120050
+BUTLER,Whitewater / Milton Township H72,State Treasurer,,Democratic,"Alldritt, Carmen",42,120080
+BUTLER,Whitewater / Milton Township H72,State Treasurer,,Republican,"Estes, Ron",220,120080
+BUTLER,Whitewater / Milton Township H75,State Treasurer,,Democratic,"Alldritt, Carmen",25,120090
+BUTLER,Whitewater / Milton Township H75,State Treasurer,,Republican,"Estes, Ron",156,120090
+BUTLER,Andover Ward 02,State Treasurer,,Democratic,"Alldritt, Carmen",303,140010
+BUTLER,Andover Ward 02,State Treasurer,,Republican,"Estes, Ron",1073,140010
+BUTLER,Andover Ward 03,State Treasurer,,Democratic,"Alldritt, Carmen",140,140020
+BUTLER,Andover Ward 03,State Treasurer,,Republican,"Estes, Ron",473,140020
+BUTLER,Andover Ward 04,State Treasurer,,Democratic,"Alldritt, Carmen",19,140030
+BUTLER,Andover Ward 04,State Treasurer,,Republican,"Estes, Ron",110,140030
+BUTLER,Bruno Township North H77,State Treasurer,,Democratic,"Alldritt, Carmen",73,140040
+BUTLER,Bruno Township North H77,State Treasurer,,Republican,"Estes, Ron",345,140040
+BUTLER,Bruno Township North H99,State Treasurer,,Democratic,"Alldritt, Carmen",44,140050
+BUTLER,Bruno Township North H99,State Treasurer,,Republican,"Estes, Ron",199,140050
+BUTLER,Bruno Township South H77,State Treasurer,,Democratic,"Alldritt, Carmen",17,140060
+BUTLER,Bruno Township South H77,State Treasurer,,Republican,"Estes, Ron",83,140060
+BUTLER,Bruno Township South H99,State Treasurer,,Democratic,"Alldritt, Carmen",19,140070
+BUTLER,Bruno Township South H99,State Treasurer,,Republican,"Estes, Ron",86,140070
+BUTLER,El Dorado Township East,State Treasurer,,Democratic,"Alldritt, Carmen",21,140080
+BUTLER,El Dorado Township East,State Treasurer,,Republican,"Estes, Ron",46,140080
+BUTLER,Rose Hill City,State Treasurer,,Democratic,"Alldritt, Carmen",168,200010
+BUTLER,Rose Hill City,State Treasurer,,Republican,"Estes, Ron",638,200010
+BUTLER,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",100,200020
+BUTLER,Richland Township,State Treasurer,,Republican,"Estes, Ron",437,200020
+BUTLER,Chelsea Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,800050
+BUTLER,Chelsea Township,State Treasurer,,Republican,"Estes, Ron",68,800050
+BUTLER,Andover Ward 01,United States Senate,,independent,"Orman, Greg",668,00001A
+BUTLER,Andover Ward 01,United States Senate,,Libertarian,"Batson, Randall",62,00001A
+BUTLER,Andover Ward 01,United States Senate,,Republican,"Roberts, Pat",1015,00001A
+BUTLER,Augusta City Ward 1,United States Senate,,independent,"Orman, Greg",236,00002A
+BUTLER,Augusta City Ward 1,United States Senate,,Libertarian,"Batson, Randall",33,00002A
+BUTLER,Augusta City Ward 1,United States Senate,,Republican,"Roberts, Pat",293,00002A
+BUTLER,Augusta City Ward 2,United States Senate,,independent,"Orman, Greg",157,000030
+BUTLER,Augusta City Ward 2,United States Senate,,Libertarian,"Batson, Randall",30,000030
+BUTLER,Augusta City Ward 2,United States Senate,,Republican,"Roberts, Pat",227,000030
+BUTLER,Augusta City Ward 3,United States Senate,,independent,"Orman, Greg",392,00004A
+BUTLER,Augusta City Ward 3,United States Senate,,Libertarian,"Batson, Randall",42,00004A
+BUTLER,Augusta City Ward 3,United States Senate,,Republican,"Roberts, Pat",479,00004A
+BUTLER,Augusta City Ward 4,United States Senate,,independent,"Orman, Greg",314,000050
+BUTLER,Augusta City Ward 4,United States Senate,,Libertarian,"Batson, Randall",19,000050
+BUTLER,Augusta City Ward 4,United States Senate,,Republican,"Roberts, Pat",483,000050
+BUTLER,Benton Township / City,United States Senate,,independent,"Orman, Greg",270,000070
+BUTLER,Benton Township / City,United States Senate,,Libertarian,"Batson, Randall",38,000070
+BUTLER,Benton Township / City,United States Senate,,Republican,"Roberts, Pat",606,000070
+BUTLER,Bloomington Township,United States Senate,,independent,"Orman, Greg",51,000080
+BUTLER,Bloomington Township,United States Senate,,Libertarian,"Batson, Randall",7,000080
+BUTLER,Bloomington Township,United States Senate,,Republican,"Roberts, Pat",101,000080
+BUTLER,Sycamore/Cassoday,United States Senate,,independent,"Orman, Greg",33,000100
+BUTLER,Sycamore/Cassoday,United States Senate,,Libertarian,"Batson, Randall",13,000100
+BUTLER,Sycamore/Cassoday,United States Senate,,Republican,"Roberts, Pat",84,000100
+BUTLER,Clay Township,United States Senate,,independent,"Orman, Greg",9,000110
+BUTLER,Clay Township,United States Senate,,Libertarian,"Batson, Randall",2,000110
+BUTLER,Clay Township,United States Senate,,Republican,"Roberts, Pat",23,000110
+BUTLER,Clifford Township,United States Senate,,independent,"Orman, Greg",13,000120
+BUTLER,Clifford Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+BUTLER,Clifford Township,United States Senate,,Republican,"Roberts, Pat",77,000120
+BUTLER,Douglass Township/City,United States Senate,,independent,"Orman, Greg",236,000130
+BUTLER,Douglass Township/City,United States Senate,,Libertarian,"Batson, Randall",34,000130
+BUTLER,Douglass Township/City,United States Senate,,Republican,"Roberts, Pat",353,000130
+BUTLER,El Dorado Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",499,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",43,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",733,00014A
+BUTLER,El Dorado Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",448,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",60,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",474,00016A
+BUTLER,El Dorado Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",337,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",51,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",374,000190
+BUTLER,El Dorado Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",235,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",31,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",259,000220
+BUTLER,Fairmount Township/Elbing,United States Senate,,independent,"Orman, Greg",47,000240
+BUTLER,Fairmount Township/Elbing,United States Senate,,Libertarian,"Batson, Randall",6,000240
+BUTLER,Fairmount Township/Elbing,United States Senate,,Republican,"Roberts, Pat",205,000240
+BUTLER,Fairview Township,United States Senate,,independent,"Orman, Greg",53,000250
+BUTLER,Fairview Township,United States Senate,,Libertarian,"Batson, Randall",8,000250
+BUTLER,Fairview Township,United States Senate,,Republican,"Roberts, Pat",130,000250
+BUTLER,Glencoe Township,United States Senate,,independent,"Orman, Greg",33,000260
+BUTLER,Glencoe Township,United States Senate,,Libertarian,"Batson, Randall",3,000260
+BUTLER,Glencoe Township,United States Senate,,Republican,"Roberts, Pat",32,000260
+BUTLER,Hickory Township,United States Senate,,independent,"Orman, Greg",8,000270
+BUTLER,Hickory Township,United States Senate,,Libertarian,"Batson, Randall",0,000270
+BUTLER,Hickory Township,United States Senate,,Republican,"Roberts, Pat",30,000270
+BUTLER,Lincoln Township,United States Senate,,independent,"Orman, Greg",26,000280
+BUTLER,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",7,000280
+BUTLER,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",72,000280
+BUTLER,Little Walnut Township/Leon,United States Senate,,independent,"Orman, Greg",102,000290
+BUTLER,Little Walnut Township/Leon,United States Senate,,Libertarian,"Batson, Randall",27,000290
+BUTLER,Little Walnut Township/Leon,United States Senate,,Republican,"Roberts, Pat",162,000290
+BUTLER,Logan Township,United States Senate,,independent,"Orman, Greg",14,000300
+BUTLER,Logan Township,United States Senate,,Libertarian,"Batson, Randall",3,000300
+BUTLER,Logan Township,United States Senate,,Republican,"Roberts, Pat",35,000300
+BUTLER,Murdock Township,United States Senate,,independent,"Orman, Greg",40,000320
+BUTLER,Murdock Township,United States Senate,,Libertarian,"Batson, Randall",6,000320
+BUTLER,Murdock Township,United States Senate,,Republican,"Roberts, Pat",134,000320
+BUTLER,El Dorado Township West,United States Senate,,independent,"Orman, Greg",66,000330
+BUTLER,El Dorado Township West,United States Senate,,Libertarian,"Batson, Randall",6,000330
+BUTLER,El Dorado Township West,United States Senate,,Republican,"Roberts, Pat",120,000330
+BUTLER,Pleasant Township,United States Senate,,independent,"Orman, Greg",382,000340
+BUTLER,Pleasant Township,United States Senate,,Libertarian,"Batson, Randall",38,000340
+BUTLER,Pleasant Township,United States Senate,,Republican,"Roberts, Pat",779,000340
+BUTLER,Plum Grove Township/Potwin,United States Senate,,independent,"Orman, Greg",79,000350
+BUTLER,Plum Grove Township/Potwin,United States Senate,,Libertarian,"Batson, Randall",11,000350
+BUTLER,Plum Grove Township/Potwin,United States Senate,,Republican,"Roberts, Pat",118,000350
+BUTLER,Prospect Township,United States Senate,,independent,"Orman, Greg",139,000360
+BUTLER,Prospect Township,United States Senate,,Libertarian,"Batson, Randall",23,000360
+BUTLER,Prospect Township,United States Senate,,Republican,"Roberts, Pat",246,000360
+BUTLER,Rock Creek Township,United States Senate,,independent,"Orman, Greg",34,000380
+BUTLER,Rock Creek Township,United States Senate,,Libertarian,"Batson, Randall",5,000380
+BUTLER,Rock Creek Township,United States Senate,,Republican,"Roberts, Pat",77,000380
+BUTLER,Rosalia Township,United States Senate,,independent,"Orman, Greg",68,000390
+BUTLER,Rosalia Township,United States Senate,,Libertarian,"Batson, Randall",15,000390
+BUTLER,Rosalia Township,United States Senate,,Republican,"Roberts, Pat",148,000390
+BUTLER,Spring Township,United States Senate,,independent,"Orman, Greg",196,000410
+BUTLER,Spring Township,United States Senate,,Libertarian,"Batson, Randall",23,000410
+BUTLER,Spring Township,United States Senate,,Republican,"Roberts, Pat",327,000410
+BUTLER,Towanda Township/City,United States Senate,,independent,"Orman, Greg",307,000430
+BUTLER,Towanda Township/City,United States Senate,,Libertarian,"Batson, Randall",52,000430
+BUTLER,Towanda Township/City,United States Senate,,Republican,"Roberts, Pat",594,000430
+BUTLER,Union Township / Latham,United States Senate,,independent,"Orman, Greg",14,000440
+BUTLER,Union Township / Latham,United States Senate,,Libertarian,"Batson, Randall",5,000440
+BUTLER,Union Township / Latham,United States Senate,,Republican,"Roberts, Pat",36,000440
+BUTLER,Walnut Township,United States Senate,,independent,"Orman, Greg",79,000450
+BUTLER,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",15,000450
+BUTLER,Walnut Township,United States Senate,,Republican,"Roberts, Pat",142,000450
+BUTLER,Augusta Township S14,United States Senate,,independent,"Orman, Greg",55,120040
+BUTLER,Augusta Township S14,United States Senate,,Libertarian,"Batson, Randall",4,120040
+BUTLER,Augusta Township S14,United States Senate,,Republican,"Roberts, Pat",75,120040
+BUTLER,Augusta Township S16,United States Senate,,independent,"Orman, Greg",89,120050
+BUTLER,Augusta Township S16,United States Senate,,Libertarian,"Batson, Randall",9,120050
+BUTLER,Augusta Township S16,United States Senate,,Republican,"Roberts, Pat",204,120050
+BUTLER,Whitewater / Milton Township H72,United States Senate,,independent,"Orman, Greg",67,120080
+BUTLER,Whitewater / Milton Township H72,United States Senate,,Libertarian,"Batson, Randall",17,120080
+BUTLER,Whitewater / Milton Township H72,United States Senate,,Republican,"Roberts, Pat",184,120080
+BUTLER,Whitewater / Milton Township H75,United States Senate,,independent,"Orman, Greg",40,120090
+BUTLER,Whitewater / Milton Township H75,United States Senate,,Libertarian,"Batson, Randall",3,120090
+BUTLER,Whitewater / Milton Township H75,United States Senate,,Republican,"Roberts, Pat",141,120090
+BUTLER,Andover Ward 02,United States Senate,,independent,"Orman, Greg",531,140010
+BUTLER,Andover Ward 02,United States Senate,,Libertarian,"Batson, Randall",43,140010
+BUTLER,Andover Ward 02,United States Senate,,Republican,"Roberts, Pat",832,140010
+BUTLER,Andover Ward 03,United States Senate,,independent,"Orman, Greg",230,140020
+BUTLER,Andover Ward 03,United States Senate,,Libertarian,"Batson, Randall",33,140020
+BUTLER,Andover Ward 03,United States Senate,,Republican,"Roberts, Pat",366,140020
+BUTLER,Andover Ward 04,United States Senate,,independent,"Orman, Greg",29,140030
+BUTLER,Andover Ward 04,United States Senate,,Libertarian,"Batson, Randall",3,140030
+BUTLER,Andover Ward 04,United States Senate,,Republican,"Roberts, Pat",97,140030
+BUTLER,Bruno Township North H77,United States Senate,,independent,"Orman, Greg",102,140040
+BUTLER,Bruno Township North H77,United States Senate,,Libertarian,"Batson, Randall",15,140040
+BUTLER,Bruno Township North H77,United States Senate,,Republican,"Roberts, Pat",311,140040
+BUTLER,Bruno Township North H99,United States Senate,,independent,"Orman, Greg",71,140050
+BUTLER,Bruno Township North H99,United States Senate,,Libertarian,"Batson, Randall",13,140050
+BUTLER,Bruno Township North H99,United States Senate,,Republican,"Roberts, Pat",161,140050
+BUTLER,Bruno Township South H77,United States Senate,,independent,"Orman, Greg",31,140060
+BUTLER,Bruno Township South H77,United States Senate,,Libertarian,"Batson, Randall",3,140060
+BUTLER,Bruno Township South H77,United States Senate,,Republican,"Roberts, Pat",68,140060
+BUTLER,Bruno Township South H99,United States Senate,,independent,"Orman, Greg",28,140070
+BUTLER,Bruno Township South H99,United States Senate,,Libertarian,"Batson, Randall",7,140070
+BUTLER,Bruno Township South H99,United States Senate,,Republican,"Roberts, Pat",68,140070
+BUTLER,El Dorado Township East,United States Senate,,independent,"Orman, Greg",37,140080
+BUTLER,El Dorado Township East,United States Senate,,Libertarian,"Batson, Randall",3,140080
+BUTLER,El Dorado Township East,United States Senate,,Republican,"Roberts, Pat",29,140080
+BUTLER,Rose Hill City,United States Senate,,independent,"Orman, Greg",305,200010
+BUTLER,Rose Hill City,United States Senate,,Libertarian,"Batson, Randall",38,200010
+BUTLER,Rose Hill City,United States Senate,,Republican,"Roberts, Pat",487,200010
+BUTLER,Richland Township,United States Senate,,independent,"Orman, Greg",188,200020
+BUTLER,Richland Township,United States Senate,,Libertarian,"Batson, Randall",21,200020
+BUTLER,Richland Township,United States Senate,,Republican,"Roberts, Pat",339,200020
+BUTLER,Chelsea Township,United States Senate,,independent,"Orman, Greg",25,800050
+BUTLER,Chelsea Township,United States Senate,,Libertarian,"Batson, Randall",7,800050
+BUTLER,Chelsea Township,United States Senate,,Republican,"Roberts, Pat",57,800050
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States Senate,,independent,"Orman, Greg",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,80020B

--- a/2014/20141104__ks__general__chase__precinct.csv
+++ b/2014/20141104__ks__general__chase__precinct.csv
@@ -1,232 +1,199 @@
-county,precinct,office,district,party,candidate,votes
-Chase,Bazaar Township,U.S. Senate,,R,Pat Roberts,35
-Chase,Cedar Township,U.S. Senate,,R,Pat Roberts,21
-Chase,Cottonwood Township,U.S. Senate,,R,Pat Roberts,38
-Chase,Diamond Township,U.S. Senate,,R,Pat Roberts,81
-Chase,East Falls Township,U.S. Senate,,R,Pat Roberts,111
-Chase,East Strong Township,U.S. Senate,,R,Pat Roberts,92
-Chase,Homestead Township,U.S. Senate,,R,Pat Roberts,14
-Chase,Matfield Township,U.S. Senate,,R,Pat Roberts,33
-Chase,Toledo Township,U.S. Senate,,R,Pat Roberts,85
-Chase,West Falls Township,U.S. Senate,,R,Pat Roberts,111
-Chase,West Strong Township,U.S. Senate,,R,Pat Roberts,28
-Chase,CHASE KS,U.S. Senate,,R,Pat Roberts,649
-Chase,Bazaar Township,U.S. Senate,,I,Greg Orman,5
-Chase,Cedar Township,U.S. Senate,,I,Greg Orman,12
-Chase,Cottonwood Township,U.S. Senate,,I,Greg Orman,21
-Chase,Diamond Township,U.S. Senate,,I,Greg Orman,28
-Chase,East Falls Township,U.S. Senate,,I,Greg Orman,39
-Chase,East Strong Township,U.S. Senate,,I,Greg Orman,76
-Chase,Homestead Township,U.S. Senate,,I,Greg Orman,8
-Chase,Matfield Township,U.S. Senate,,I,Greg Orman,22
-Chase,Toledo Township,U.S. Senate,,I,Greg Orman,55
-Chase,West Falls Township,U.S. Senate,,I,Greg Orman,89
-Chase,West Strong Township,U.S. Senate,,I,Greg Orman,22
-CHASE,CHASE KS,U.S. Senate,,I,greg Orman,377
-Chase,Bazaar Township,U.S. Senate,,L,Nathan Batson,1
-Chase,Cedar Township,U.S. Senate,,L,Nathan Batson,3
-Chase,Cottonwood Township,U.S. Senate,,L,Nathan Batson,2
-Chase,Diamond Township,U.S. Senate,,L,Nathan Batson,3
-Chase,East Falls Township,U.S. Senate,,L,Nathan Batson,8
-Chase,East Strong Township,U.S. Senate,,L,Nathan Batson,16
-Chase,Homestead Township,U.S. Senate,,L,Nathan Batson,0
-Chase,Matfield Township,U.S. Senate,,L,Nathan Batson,3
-Chase,Toledo Township,U.S. Senate,,L,Nathan Batson,6
-Chase,West Falls Township,U.S. Senate,,L,Nathan Batson,13
-Chase,West Strong Township,U.S. Senate,,L,Nathan Batson,2
-Chase,PROVISIONALS,U.S. Senate,,L,Nathan Batson,0
-CHASE,CHASE KS,U.S. Senate,,L,Nathan Batson,57
-Chase,Bazaar Township,U.S. House,1,R,Tim Huelskamp,38
-Chase,Cedar Township,U.S. House,1,R,Tim Huelskamp,22
-Chase,Cottonwood Township,U.S. House,1,R,Tim Huelskamp,41
-Chase,Diamond Township,U.S. House,1,R,Tim Huelskamp,76
-Chase,East Falls Township,U.S. House,1,R,Tim Huelskamp,112
-Chase,East Strong Township,U.S. House,1,R,Tim Huelskamp,97
-Chase,Homestead Township,U.S. House,1,R,Tim Huelskamp,15
-Chase,Matfield Township,U.S. House,1,R,Tim Huelskamp,39
-Chase,Toledo Township,U.S. House,1,R,Tim Huelskamp,90
-Chase,West Falls Township,U.S. House,1,R,Tim Huelskamp,132
-Chase,West Strong Township,U.S. House,1,R,Tim Huelskamp,30
-Chase,PROVISIONALS,U.S. House,1,R,Tim Huelskamp,19
-CHASE,CHASE KS,U.S. House,1,R,Tim Huelskamp,711
-Chase,Bazaar Township,U.S. House,1,D,James Sherow,4
-Chase,Cedar Township,U.S. House,1,D,James Sherow,13
-Chase,Cottonwood Township,U.S. House,1,D,James Sherow,20
-Chase,Diamond Township,U.S. House,1,D,James Sherow,26
-Chase,East Falls Township,U.S. House,1,D,James Sherow,38
-Chase,East Strong Township,U.S. House,1,D,James Sherow,77
-Chase,Homestead Township,U.S. House,1,D,James Sherow,7
-Chase,Matfield Township,U.S. House,1,D,James Sherow,18
-Chase,Toledo Township,U.S. House,1,D,James Sherow,53
-Chase,West Falls Township,U.S. House,1,D,James Sherow,74
-Chase,West Strong Township,U.S. House,1,D,James Sherow,22
-Chase,PROVISIONALS,U.S. House,1,D,James Sherow,4
-CHASE,CHASE KS,U.S. House,1,D,James Sherow,356
-Chase,Bazaar Township,Governor,,R,Sam Brownback,37
-Chase,Cedar Township,Governor,,R,Sam Brownback,21
-Chase,Cottonwood Township,Governor,,R,Sam Brownback,36
-Chase,Diamond Township,Governor,,R,Sam Brownback,72
-Chase,East Falls Township,Governor,,R,Sam Brownback,91
-Chase,East Strong Township,Governor,,R,Sam Brownback,74
-Chase,Homestead Township,Governor,,R,Sam Brownback,12
-Chase,Matfield Township,Governor,,R,Sam Brownback,30
-Chase,Toledo Township,Governor,,R,Sam Brownback,79
-Chase,West Falls Township,Governor,,R,Sam Brownback,95
-Chase,West Strong Township,Governor,,R,Sam Brownback,25
-Chase,PROVISIONALS,Governor,,R,Sam Brownback,14
-CHASE,CHASE KS,Governor,,R,Sam Brownback,586
-Chase,Bazaar Township,Governor,,D,Paul Davis,5
-Chase,Cedar Township,Governor,,D,Paul Davis,13
-Chase,Cottonwood Township,Governor,,D,Paul Davis,21
-Chase,Diamond Township,Governor,,D,Paul Davis,32
-Chase,East Falls Township,Governor,,D,Paul Davis,54
-Chase,East Strong Township,Governor,,D,Paul Davis,94
-Chase,Homestead Township,Governor,,D,Paul Davis,10
-Chase,Matfield Township,Governor,,D,Paul Davis,24
-Chase,Toledo Township,Governor,,D,Paul Davis,56
-Chase,West Falls Township,Governor,,D,Paul Davis,101
-Chase,West Strong Township,Governor,,D,Paul Davis,23
-Chase,PROVISIONALS,Governor,,D,Paul Davis,7
-CHASE,CHASE KS,Governor,,D,Paul Davis,440
-Chase,Bazaar Township,Governor,,L,Keen Umbehr,0
-Chase,Cedar Township,Governor,,L,Keen Umbehr,2
-Chase,Cottonwood Township,Governor,,L,Keen Umbehr,4
-Chase,Diamond Township,Governor,,L,Keen Umbehr,3
-Chase,East Falls Township,Governor,,L,Keen Umbehr,7
-Chase,East Strong Township,Governor,,L,Keen Umbehr,10
-Chase,Homestead Township,Governor,,L,Keen Umbehr,0
-Chase,Matfield Township,Governor,,L,Keen Umbehr,2
-Chase,Toledo Township,Governor,,L,Keen Umbehr,9
-Chase,West Falls Township,Governor,,L,Keen Umbehr,13
-Chase,West Strong Township,Governor,,L,Keen Umbehr,4
-Chase,PROVISIONALS,Governor,,L,Keen Umbehr,1
-CHASE,CHASE KS,Governor,,L,Keen Umbehr,55
-Chase,Bazaar Township,Secretary of State,,R,Kris Kobach,38
-Chase,Cedar Township,Secretary of State,,R,Kris Kobach,20
-Chase,Cottonwood Township,Secretary of State,,R,Kris Kobach,39
-Chase,Diamond Township,Secretary of State,,R,Kris Kobach,75
-Chase,East Falls Township,Secretary of State,,R,Kris Kobach,118
-Chase,East Strong Township,Secretary of State,,R,Kris Kobach,96
-Chase,Homestead Township,Secretary of State,,R,Kris Kobach,13
-Chase,Matfield Township,Secretary of State,,R,Kris Kobach,36
-Chase,Toledo Township,Secretary of State,,R,Kris Kobach,92
-Chase,West Falls Township,Secretary of State,,R,Kris Kobach,132
-Chase,West Strong Township,Secretary of State,,R,Kris Kobach,29
-Chase,PROVISIONALS,Secretary of State,,R,Kris Kobach,19
-CHASE,CHASE KS,Secretary of State,,R,Kris Kobach,707
-Chase,Bazaar Township,Secretary of State,,D,Jean Schodorf,3
-Chase,Cedar Township,Secretary of State,,D,Jean Schodorf,16
-Chase,Cottonwood Township,Secretary of State,,D,Jean Schodorf,22
-Chase,Diamond Township,Secretary of State,,D,Jean Schodorf,31
-Chase,East Falls Township,Secretary of State,,D,Jean Schodorf,30
-Chase,East Strong Township,Secretary of State,,D,Jean Schodorf,77
-Chase,Homestead Township,Secretary of State,,D,Jean Schodorf,9
-Chase,Matfield Township,Secretary of State,,D,Jean Schodorf,21
-Chase,Toledo Township,Secretary of State,,D,Jean Schodorf,51
-Chase,West Falls Township,Secretary of State,,D,Jean Schodorf,77
-Chase,West Strong Township,Secretary of State,,D,Jean Schodorf,23
-Chase,PROVISIONALS,Secretary of State,,D,Jean Schodorf,4
-Chase,CHASE KS,Secretary of State,,D,Jean Schodorf,364
-Chase,Bazaar Township,Attorney General,,R,Derek Schmidt,38
-Chase,Cedar Township,Attorney General,,R,Derek Schmidt,25
-Chase,Cottonwood Township,Attorney General,,R,Derek Schmidt,44
-Chase,Diamond Township,Attorney General,,R,Derek Schmidt,87
-Chase,East Falls Township,Attorney General,,R,Derek Schmidt,126
-Chase,East Strong Township,Attorney General,,R,Derek Schmidt,111
-Chase,Homestead Township,Attorney General,,R,Derek Schmidt,17
-Chase,Matfield Township,Attorney General,,R,Derek Schmidt,37
-Chase,Toledo Township,Attorney General,,R,Derek Schmidt,105
-Chase,West Falls Township,Attorney General,,R,Derek Schmidt,153
-Chase,West Strong Township,Attorney General,,R,Derek Schmidt,33
-Chase,PROVISIONALS,Attorney General,,R,Derek Schmidt,18
-CHASE,CHASE KS,Attorney General,,R,Derek Schmidt,794
-Chase,Bazaar Township,Attorney General,,D,AJ Kotich,1
-Chase,Cedar Township,Attorney General,,D,AJ Kotich,11
-Chase,Cottonwood Township,Attorney General,,D,AJ Kotich,15
-Chase,Diamond Township,Attorney General,,D,AJ Kotich,16
-Chase,East Falls Township,Attorney General,,D,AJ Kotich,22
-Chase,East Strong Township,Attorney General,,D,AJ Kotich,61
-Chase,Homestead Township,Attorney General,,D,AJ Kotich,4
-Chase,Matfield Township,Attorney General,,D,AJ Kotich,16
-Chase,Toledo Township,Attorney General,,D,AJ Kotich,35
-Chase,West Falls Township,Attorney General,,D,AJ Kotich,52
-Chase,West Strong Township,Attorney General,,D,AJ Kotich,18
-Chase,PROVISIONALS,Attorney General,,D,AJ Kotich,5
-CHASE,CHASE KS,Attorney General,,D,AJ Kotich,256
-Chase,Bazaar Township,State Treasurer,,R,Ron Estes,38
-Chase,Cedar Township,State Treasurer,,R,Ron Estes,22
-Chase,Cottonwood Township,State Treasurer,,R,Ron Estes,43
-Chase,Diamond Township,State Treasurer,,R,Ron Estes,81
-Chase,East Falls Township,State Treasurer,,R,Ron Estes,124
-Chase,East Strong Township,State Treasurer,,R,Ron Estes,121
-Chase,Homestead Township,State Treasurer,,R,Ron Estes,17
-Chase,Matfield Township,State Treasurer,,R,Ron Estes,42
-Chase,Toledo Township,State Treasurer,,R,Ron Estes,101
-Chase,West Falls Township,State Treasurer,,R,Ron Estes,156
-Chase,West Strong Township,State Treasurer,,R,Ron Estes,34
-Chase,PROVISIONALS,State Treasurer,,R,Ron Estes,19
-CHASE,CHASE KS,State Treasurer,,R,Ron Estes,798
-Chase,Bazaar Township,State Treasurer,,D,Carmen Alldritt,1
-Chase,Cedar Township,State Treasurer,,D,Carmen Alldritt,13
-Chase,Cottonwood Township,State Treasurer,,D,Carmen Alldritt,16
-Chase,Diamond Township,State Treasurer,,D,Carmen Alldritt,22
-Chase,East Falls Township,State Treasurer,,D,Carmen Alldritt,25
-Chase,East Strong Township,State Treasurer,,D,Carmen Alldritt,51
-Chase,Homestead Township,State Treasurer,,D,Carmen Alldritt,4
-Chase,Matfield Township,State Treasurer,,D,Carmen Alldritt,13
-Chase,Toledo Township,State Treasurer,,D,Carmen Alldritt,40
-Chase,West Falls Township,State Treasurer,,D,Carmen Alldritt,48
-Chase,West Strong Township,State Treasurer,,D,Carmen Alldritt,15
-Chase,PROVISIONALS,State Treasurer,,D,Carmen Alldritt,3
-CHASE,CHASE KS,State Treasurer,,D,Carmen Alldritt,251
-Chase,Bazaar Township,Insurance Commissioner,,R,Ken Selzer,35
-Chase,Cedar Township,Insurance Commissioner,,R,Ken Selzer,23
-Chase,Cottonwood Township,Insurance Commissioner,,R,Ken Selzer,42
-Chase,Diamond Township,Insurance Commissioner,,R,Ken Selzer,81
-Chase,East Falls Township,Insurance Commissioner,,R,Ken Selzer,107
-Chase,East Strong Township,Insurance Commissioner,,R,Ken Selzer,108
-Chase,Homestead Township,Insurance Commissioner,,R,Ken Selzer,17
-Chase,Matfield Township,Insurance Commissioner,,R,Ken Selzer,37
-Chase,Toledo Township,Insurance Commissioner,,R,Ken Selzer,100
-Chase,West Falls Township,Insurance Commissioner,,R,Ken Selzer,139
-Chase,West Strong Township,Insurance Commissioner,,R,Ken Selzer,31
-Chase,PROVISIONALS,Insurance Commissioner,,R,Ken Selzer,17
-CHASE,CHASE KS,Insurance Commissioner,,R,Ken Selzer,737
-Chase,Bazaar Township,Insurance Commissioner,,D,Dennis Anderson,4
-Chase,Cedar Township,Insurance Commissioner,,D,Dennis Anderson,13
-Chase,Cottonwood Township,Insurance Commissioner,,D,Dennis Anderson,17
-Chase,Diamond Township,Insurance Commissioner,,D,Dennis Anderson,20
-Chase,East Falls Township,Insurance Commissioner,,D,Dennis Anderson,35
-Chase,East Strong Township,Insurance Commissioner,,D,Dennis Anderson,61
-Chase,Homestead Township,Insurance Commissioner,,D,Dennis Anderson,5
-Chase,Matfield Township,Insurance Commissioner,,D,Dennis Anderson,17
-Chase,Toledo Township,Insurance Commissioner,,D,Dennis Anderson,40
-Chase,West Falls Township,Insurance Commissioner,,D,Dennis Anderson,62
-Chase,West Strong Township,Insurance Commissioner,,D,Dennis Anderson,19
-Chase,PROVISIONALS,Insurance Commissioner,,D,Dennis Anderson,4
-CHASE,CHASE KS,Insurance Commissioner,,D,Dennis Anderson,297
-Chase,Bazaar Township,State Senate,35,R,Richard Wilborn,34
-Chase,Cedar Township,State Senate,35,R,Richard Wilborn,28
-Chase,Cottonwood Township,State Senate,35,R,Richard Wilborn,45
-Chase,Diamond Township,State Senate,35,R,Richard Wilborn,85
-Chase,East Falls Township,State Senate,35,R,Richard Wilborn,132
-Chase,East Strong Township,State Senate,35,R,Richard Wilborn,128
-Chase,Homestead Township,State Senate,35,R,Richard Wilborn,17
-Chase,Matfield Township,State Senate,35,R,Richard Wilborn,44
-Chase,Toledo Township,State Senate,35,R,Richard Wilborn,117
-Chase,West Falls Township,State Senate,35,R,Richard Wilborn,167
-Chase,West Strong Township,State Senate,35,R,Richard Wilborn,39
-Chase,PROVISIONALS,State Senate,35,R,Richard Wilborn,0
-Chase,Bazaar Township,State House,68,R,Tom Moxley,37
-Chase,Cedar Township,State House,68,R,Tom Moxley,30
-Chase,Cottonwood Township,State House,68,R,Tom Moxley,42
-Chase,Diamond Township,State House,68,R,Tom Moxley,90
-Chase,East Falls Township,State House,68,R,Tom Moxley,139
-Chase,East Strong Township,State House,68,R,Tom Moxley,143
-Chase,Homestead Township,State House,68,R,Tom Moxley,18
-Chase,Matfield Township,State House,68,R,Tom Moxley,45
-Chase,Toledo Township,State House,68,R,Tom Moxley,126
-Chase,West Falls Township,State House,68,R,Tom Moxley,187
-Chase,West Strong Township,State House,68,R,Tom Moxley,44
-Chase,PROVISIONALS,State House,68,R,Tom Moxley,0
-CHASE,CHASE KS,State House,68,R,Tom Moxley,901
+county,precinct,office,district,party,candidate,votes,vtd
+CHASE,Bazaar Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000010
+CHASE,Bazaar Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+CHASE,Bazaar Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000010
+CHASE,Cedar Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000020
+CHASE,Cedar Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+CHASE,Cedar Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000020
+CHASE,Cottonwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000030
+CHASE,Cottonwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000030
+CHASE,Cottonwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000030
+CHASE,Diamond Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000040
+CHASE,Diamond Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+CHASE,Diamond Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",78,000040
+CHASE,East Falls Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,000050
+CHASE,East Falls Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000050
+CHASE,East Falls Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,000050
+CHASE,East Strong Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",96,000060
+CHASE,East Strong Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000060
+CHASE,East Strong Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000060
+CHASE,Homestead Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000070
+CHASE,Homestead Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+CHASE,Homestead Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000070
+CHASE,Matfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000080
+CHASE,Matfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+CHASE,Matfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000080
+CHASE,Toledo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,000090
+CHASE,Toledo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000090
+CHASE,Toledo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,000090
+CHASE,West Falls Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",102,000100
+CHASE,West Falls Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000100
+CHASE,West Falls Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,000100
+CHASE,West Strong Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000110
+CHASE,West Strong Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000110
+CHASE,West Strong Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000110
+CHASE,Bazaar Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",37,000010
+CHASE,Cedar Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",30,000020
+CHASE,Cottonwood Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",42,000030
+CHASE,Diamond Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",96,000040
+CHASE,East Falls Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",139,000050
+CHASE,East Strong Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",146,000060
+CHASE,Homestead Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",18,000070
+CHASE,Matfield Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",45,000080
+CHASE,Toledo Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",128,000090
+CHASE,West Falls Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",191,000100
+CHASE,West Strong Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",45,000110
+CHASE,Bazaar Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000010
+CHASE,Bazaar Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000010
+CHASE,Cedar Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000020
+CHASE,Cedar Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000020
+CHASE,Cottonwood Township,United States House of Representatives,1,Democratic,"Sherow, James E.",20,000030
+CHASE,Cottonwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000030
+CHASE,Diamond Township,United States House of Representatives,1,Democratic,"Sherow, James E.",26,000040
+CHASE,Diamond Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,000040
+CHASE,East Falls Township,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000050
+CHASE,East Falls Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",115,000050
+CHASE,East Strong Township,United States House of Representatives,1,Democratic,"Sherow, James E.",78,000060
+CHASE,East Strong Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",100,000060
+CHASE,Homestead Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000070
+CHASE,Homestead Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000070
+CHASE,Matfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000080
+CHASE,Matfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000080
+CHASE,Toledo Township,United States House of Representatives,1,Democratic,"Sherow, James E.",53,000090
+CHASE,Toledo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,000090
+CHASE,West Falls Township,United States House of Representatives,1,Democratic,"Sherow, James E.",74,000100
+CHASE,West Falls Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",136,000100
+CHASE,West Strong Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000110
+CHASE,West Strong Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000110
+CHASE,Bazaar Township,Attorney General,,Democratic,"Kotich, A.J.",1,000010
+CHASE,Bazaar Township,Attorney General,,Republican,"Schmidt, Derek",38,000010
+CHASE,Cedar Township,Attorney General,,Democratic,"Kotich, A.J.",11,000020
+CHASE,Cedar Township,Attorney General,,Republican,"Schmidt, Derek",25,000020
+CHASE,Cottonwood Township,Attorney General,,Democratic,"Kotich, A.J.",15,000030
+CHASE,Cottonwood Township,Attorney General,,Republican,"Schmidt, Derek",44,000030
+CHASE,Diamond Township,Attorney General,,Democratic,"Kotich, A.J.",16,000040
+CHASE,Diamond Township,Attorney General,,Republican,"Schmidt, Derek",93,000040
+CHASE,East Falls Township,Attorney General,,Democratic,"Kotich, A.J.",23,000050
+CHASE,East Falls Township,Attorney General,,Republican,"Schmidt, Derek",130,000050
+CHASE,East Strong Township,Attorney General,,Democratic,"Kotich, A.J.",62,000060
+CHASE,East Strong Township,Attorney General,,Republican,"Schmidt, Derek",114,000060
+CHASE,Homestead Township,Attorney General,,Democratic,"Kotich, A.J.",4,000070
+CHASE,Homestead Township,Attorney General,,Republican,"Schmidt, Derek",17,000070
+CHASE,Matfield Township,Attorney General,,Democratic,"Kotich, A.J.",17,000080
+CHASE,Matfield Township,Attorney General,,Republican,"Schmidt, Derek",37,000080
+CHASE,Toledo Township,Attorney General,,Democratic,"Kotich, A.J.",35,000090
+CHASE,Toledo Township,Attorney General,,Republican,"Schmidt, Derek",107,000090
+CHASE,West Falls Township,Attorney General,,Democratic,"Kotich, A.J.",54,000100
+CHASE,West Falls Township,Attorney General,,Republican,"Schmidt, Derek",155,000100
+CHASE,West Strong Township,Attorney General,,Democratic,"Kotich, A.J.",18,000110
+CHASE,West Strong Township,Attorney General,,Republican,"Schmidt, Derek",34,000110
+CHASE,Bazaar Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000010
+CHASE,Bazaar Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000010
+CHASE,Cedar Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000020
+CHASE,Cedar Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000020
+CHASE,Cottonwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000030
+CHASE,Cottonwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000030
+CHASE,Diamond Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000040
+CHASE,Diamond Township,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000040
+CHASE,East Falls Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000050
+CHASE,East Falls Township,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000050
+CHASE,East Strong Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,000060
+CHASE,East Strong Township,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000060
+CHASE,Homestead Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000070
+CHASE,Homestead Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000070
+CHASE,Matfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000080
+CHASE,Matfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000080
+CHASE,Toledo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000090
+CHASE,Toledo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",102,000090
+CHASE,West Falls Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,000100
+CHASE,West Falls Township,Commissioner of Insurance,,Republican,"Selzer, Ken",141,000100
+CHASE,West Strong Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000110
+CHASE,West Strong Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000110
+CHASE,Bazaar Township,Kansas Senate,35,Republican,"Wilborn, Richard",34,000010
+CHASE,Cedar Township,Kansas Senate,35,Republican,"Wilborn, Richard",28,000020
+CHASE,Cottonwood Township,Kansas Senate,35,Republican,"Wilborn, Richard",45,000030
+CHASE,Diamond Township,Kansas Senate,35,Republican,"Wilborn, Richard",91,000040
+CHASE,East Falls Township,Kansas Senate,35,Republican,"Wilborn, Richard",137,000050
+CHASE,East Strong Township,Kansas Senate,35,Republican,"Wilborn, Richard",131,000060
+CHASE,Homestead Township,Kansas Senate,35,Republican,"Wilborn, Richard",17,000070
+CHASE,Matfield Township,Kansas Senate,35,Republican,"Wilborn, Richard",44,000080
+CHASE,Toledo Township,Kansas Senate,35,Republican,"Wilborn, Richard",119,000090
+CHASE,West Falls Township,Kansas Senate,35,Republican,"Wilborn, Richard",170,000100
+CHASE,West Strong Township,Kansas Senate,35,Republican,"Wilborn, Richard",40,000110
+CHASE,Bazaar Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+CHASE,Bazaar Township,Secretary of State,,Republican,"Kobach, Kris",38,000010
+CHASE,Cedar Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000020
+CHASE,Cedar Township,Secretary of State,,Republican,"Kobach, Kris",20,000020
+CHASE,Cottonwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000030
+CHASE,Cottonwood Township,Secretary of State,,Republican,"Kobach, Kris",39,000030
+CHASE,Diamond Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000040
+CHASE,Diamond Township,Secretary of State,,Republican,"Kobach, Kris",81,000040
+CHASE,East Falls Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",32,000050
+CHASE,East Falls Township,Secretary of State,,Republican,"Kobach, Kris",121,000050
+CHASE,East Strong Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,000060
+CHASE,East Strong Township,Secretary of State,,Republican,"Kobach, Kris",99,000060
+CHASE,Homestead Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000070
+CHASE,Homestead Township,Secretary of State,,Republican,"Kobach, Kris",13,000070
+CHASE,Matfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000080
+CHASE,Matfield Township,Secretary of State,,Republican,"Kobach, Kris",36,000080
+CHASE,Toledo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000090
+CHASE,Toledo Township,Secretary of State,,Republican,"Kobach, Kris",94,000090
+CHASE,West Falls Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,000100
+CHASE,West Falls Township,Secretary of State,,Republican,"Kobach, Kris",136,000100
+CHASE,West Strong Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000110
+CHASE,West Strong Township,Secretary of State,,Republican,"Kobach, Kris",30,000110
+CHASE,Bazaar Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000010
+CHASE,Bazaar Township,State Treasurer,,Republican,"Estes, Ron",38,000010
+CHASE,Cedar Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000020
+CHASE,Cedar Township,State Treasurer,,Republican,"Estes, Ron",22,000020
+CHASE,Cottonwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000030
+CHASE,Cottonwood Township,State Treasurer,,Republican,"Estes, Ron",43,000030
+CHASE,Diamond Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000040
+CHASE,Diamond Township,State Treasurer,,Republican,"Estes, Ron",87,000040
+CHASE,East Falls Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000050
+CHASE,East Falls Township,State Treasurer,,Republican,"Estes, Ron",128,000050
+CHASE,East Strong Township,State Treasurer,,Democratic,"Alldritt, Carmen",52,000060
+CHASE,East Strong Township,State Treasurer,,Republican,"Estes, Ron",123,000060
+CHASE,Homestead Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000070
+CHASE,Homestead Township,State Treasurer,,Republican,"Estes, Ron",17,000070
+CHASE,Matfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000080
+CHASE,Matfield Township,State Treasurer,,Republican,"Estes, Ron",42,000080
+CHASE,Toledo Township,State Treasurer,,Democratic,"Alldritt, Carmen",40,000090
+CHASE,Toledo Township,State Treasurer,,Republican,"Estes, Ron",103,000090
+CHASE,West Falls Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000100
+CHASE,West Falls Township,State Treasurer,,Republican,"Estes, Ron",160,000100
+CHASE,West Strong Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000110
+CHASE,West Strong Township,State Treasurer,,Republican,"Estes, Ron",35,000110
+CHASE,Bazaar Township,United States Senate,,independent,"Orman, Greg",5,000010
+CHASE,Bazaar Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+CHASE,Bazaar Township,United States Senate,,Republican,"Roberts, Pat",35,000010
+CHASE,Cedar Township,United States Senate,,independent,"Orman, Greg",12,000020
+CHASE,Cedar Township,United States Senate,,Libertarian,"Batson, Randall",3,000020
+CHASE,Cedar Township,United States Senate,,Republican,"Roberts, Pat",21,000020
+CHASE,Cottonwood Township,United States Senate,,independent,"Orman, Greg",21,000030
+CHASE,Cottonwood Township,United States Senate,,Libertarian,"Batson, Randall",2,000030
+CHASE,Cottonwood Township,United States Senate,,Republican,"Roberts, Pat",38,000030
+CHASE,Diamond Township,United States Senate,,independent,"Orman, Greg",28,000040
+CHASE,Diamond Township,United States Senate,,Libertarian,"Batson, Randall",3,000040
+CHASE,Diamond Township,United States Senate,,Republican,"Roberts, Pat",81,000040
+CHASE,East Falls Township,United States Senate,,independent,"Orman, Greg",39,000050
+CHASE,East Falls Township,United States Senate,,Libertarian,"Batson, Randall",8,000050
+CHASE,East Falls Township,United States Senate,,Republican,"Roberts, Pat",111,000050
+CHASE,East Strong Township,United States Senate,,independent,"Orman, Greg",76,000060
+CHASE,East Strong Township,United States Senate,,Libertarian,"Batson, Randall",16,000060
+CHASE,East Strong Township,United States Senate,,Republican,"Roberts, Pat",92,000060
+CHASE,Homestead Township,United States Senate,,independent,"Orman, Greg",8,000070
+CHASE,Homestead Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+CHASE,Homestead Township,United States Senate,,Republican,"Roberts, Pat",14,000070
+CHASE,Matfield Township,United States Senate,,independent,"Orman, Greg",22,000080
+CHASE,Matfield Township,United States Senate,,Libertarian,"Batson, Randall",3,000080
+CHASE,Matfield Township,United States Senate,,Republican,"Roberts, Pat",33,000080
+CHASE,Toledo Township,United States Senate,,independent,"Orman, Greg",55,000090
+CHASE,Toledo Township,United States Senate,,Libertarian,"Batson, Randall",6,000090
+CHASE,Toledo Township,United States Senate,,Republican,"Roberts, Pat",85,000090
+CHASE,West Falls Township,United States Senate,,independent,"Orman, Greg",89,000100
+CHASE,West Falls Township,United States Senate,,Libertarian,"Batson, Randall",13,000100
+CHASE,West Falls Township,United States Senate,,Republican,"Roberts, Pat",111,000100
+CHASE,West Strong Township,United States Senate,,independent,"Orman, Greg",22,000110
+CHASE,West Strong Township,United States Senate,,Libertarian,"Batson, Randall",2,000110
+CHASE,West Strong Township,United States Senate,,Republican,"Roberts, Pat",28,000110

--- a/2014/20141104__ks__general__chautauqua__precinct.csv
+++ b/2014/20141104__ks__general__chautauqua__precinct.csv
@@ -1,217 +1,253 @@
-county,precinct,office,district,party,candidate,votes
-Chautauqua,Belleville,Attorney General,,D,A. J. Kotich,15
-Chautauqua,Caneyville,Attorney General,,D,A. J. Kotich,2
-Chautauqua,Center,Attorney General,,D,A. J. Kotich,0
-Chautauqua,Harrison,Attorney General,,D,A. J. Kotich,2
-Chautauqua,Hendricks,Attorney General,,D,A. J. Kotich,11
-Chautauqua,Jefferson,Attorney General,,D,A. J. Kotich,30
-Chautauqua,Lafayette,Attorney General,,R,A. J. Kotich,2
-Chautauqua,Lafayette,Attorney General,,R,A. J. Kotich,2
-Chautauqua,Little Caney,Attorney General,,D,A. J. Kotich,8
-Chautauqua,Sedan,Attorney General,,D,A. J. Kotich,47
-Chautauqua,Summit,Attorney General,,D,A. J. Kotich,3
-Chautauqua,Washington,Attorney General,,D,A. J. Kotich,0
-Chautauqua,Belleville,Attorney General,,R,Derek Schmidt,169
-Chautauqua,Caneyville,Attorney General,,R,Derek Schmidt,38
-Chautauqua,Center,Attorney General,,R,Derek Schmidt,26
-Chautauqua,Harrison,Attorney General,,R,Derek Schmidt,26
-Chautauqua,Hendricks,Attorney General,,R,Derek Schmidt,24
-Chautauqua,Jefferson,Attorney General,,R,Derek Schmidt,134
-Chautauqua,Little Caney,Attorney General,,R,Derek Schmidt,78
-Chautauqua,Salt Creek,Attorney General,,D,Derek Schmidt,19
-Chautauqua,Salt Creek,Attorney General,,D,Derek Schmidt,43
-Chautauqua,Sedan,Attorney General,,R,Derek Schmidt,367
-Chautauqua,Summit,Attorney General,,R,Derek Schmidt,33
-Chautauqua,Washington,Attorney General,,R,Derek Schmidt,34
-Chautauqua,Belleville,U.S. House,4,R,Mike Pompeo,163
-Chautauqua,Caneyville,U.S. House,4,R,Mike Pompeo,35
-Chautauqua,Center,U.S. House,4,R,Mike Pompeo,24
-Chautauqua,Harrison,U.S. House,4,R,Mike Pompeo,26
-Chautauqua,Hendricks,U.S. House,4,R,Mike Pompeo,22
-Chautauqua,Jefferson,U.S. House,4,R,Mike Pompeo,117
-Chautauqua,Lafayette,U.S. House,4,R,Mike Pompeo,16
-Chautauqua,Lafayette,U.S. House,4,R,Mike Pompeo,40
-Chautauqua,Little Caney,U.S. House,4,R,Mike Pompeo,72
-Chautauqua,Sedan,U.S. House,4,R,Mike Pompeo,331
-Chautauqua,Summit,U.S. House,4,R,Mike Pompeo,32
-Chautauqua,Washington,U.S. House,4,R,Mike Pompeo,30
-Chautauqua,Belleville,U.S. House,4,D,Perry L. Schuckman,22
-Chautauqua,Caneyville,U.S. House,4,D,Perry L. Schuckman,3
-Chautauqua,Center,U.S. House,4,D,Perry L. Schuckman,2
-Chautauqua,Harrison,U.S. House,4,D,Perry L. Schuckman,2
-Chautauqua,Hendricks,U.S. House,4,D,Perry L. Schuckman,11
-Chautauqua,Jefferson,U.S. House,4,D,Perry L. Schuckman,47
-Chautauqua,Little Caney,U.S. House,4,D,Perry L. Schuckman,13
-Chautauqua,Salt Creek,U.S. House,4,D,Perry L. Schuckman,4
-Chautauqua,Salt Creek,U.S. House,4,D,Perry L. Schuckman,5
-Chautauqua,Sedan,U.S. House,4,D,Perry L. Schuckman,76
-Chautauqua,Summit,U.S. House,4,D,Perry L. Schuckman,3
-Chautauqua,Washington,U.S. House,4,D,Perry L. Schuckman,4
-Chautauqua,Belleville,Governor,,L,Keen A. Umbehr,16
-Chautauqua,Caneyville,Governor,,L,Keen A. Umbehr,3
-Chautauqua,Center,Governor,,L,Keen A. Umbehr,2
-Chautauqua,Harrison,Governor,,L,Keen A. Umbehr,0
-Chautauqua,Hendricks,Governor,,L,Keen A. Umbehr,2
-Chautauqua,Jefferson,Governor,,L,Keen A. Umbehr,9
-Chautauqua,Little Caney,Governor,,L,Keen A. Umbehr,2
-Chautauqua,Salt Creek,Governor,,L,Keen A. Umbehr,4
-Chautauqua,Salt Creek,Governor,,L,Keen A. Umbehr,0
-Chautauqua,Sedan,Governor,,L,Keen A. Umbehr,29
-Chautauqua,Summit,Governor,,L,Keen A. Umbehr,5
-Chautauqua,Washington,Governor,,L,Keen A. Umbehr,2
-Chautauqua,Belleville,Governor,,D,Paul Davis,29
-Chautauqua,Caneyville,Governor,,D,Paul Davis,9
-Chautauqua,Center,Governor,,D,Paul Davis,2
-Chautauqua,Harrison,Governor,,D,Paul Davis,4
-Chautauqua,Hendricks,Governor,,D,Paul Davis,13
-Chautauqua,Jefferson,Governor,,D,Paul Davis,63
-Chautauqua,Lafayette,Governor,,D,Paul Davis,5
-Chautauqua,Little Caney,Governor,,D,Paul Davis,18
-Chautauqua,Salt Creek,Governor,,D,Paul Davis,7
-Chautauqua,Sedan,Governor,,D,Paul Davis,119
-Chautauqua,Summit,Governor,,D,Paul Davis,7
-Chautauqua,Washington,Governor,,D,Paul Davis,4
-Chautauqua,Belleville,Governor,,R,Sam Brownback,140
-Chautauqua,Caneyville,Governor,,R,Sam Brownback,26
-Chautauqua,Center,Governor,,R,Sam Brownback,22
-Chautauqua,Harrison,Governor,,R,Sam Brownback,24
-Chautauqua,Hendricks,Governor,,R,Sam Brownback,20
-Chautauqua,Jefferson,Governor,,R,Sam Brownback,94
-Chautauqua,Lafayette,Governor,,R,Sam Brownback,12
-Chautauqua,Lafayette,Governor,,R,Sam Brownback,38
-Chautauqua,Little Caney,Governor,,R,Sam Brownback,66
-Chautauqua,Sedan,Governor,,R,Sam Brownback,263
-Chautauqua,Summit,Governor,,R,Sam Brownback,24
-Chautauqua,Washington,Governor,,R,Sam Brownback,29
-Chautauqua,Belleville,Insurance Commissioner,,D,Dennis Anderson,25
-Chautauqua,Caneyville,Insurance Commissioner,,D,Dennis Anderson,8
-Chautauqua,Center,Insurance Commissioner,,D,Dennis Anderson,1
-Chautauqua,Harrison,Insurance Commissioner,,D,Dennis Anderson,3
-Chautauqua,Hendricks,Insurance Commissioner,,D,Dennis Anderson,17
-Chautauqua,Jefferson,Insurance Commissioner,,D,Dennis Anderson,47
-Chautauqua,Lafayette,Insurance Commissioner,,D,Dennis Anderson,3
-Chautauqua,Lafayette,Insurance Commissioner,,D,Dennis Anderson,5
-Chautauqua,Little Caney,Insurance Commissioner,,D,Dennis Anderson,16
-Chautauqua,Sedan,Insurance Commissioner,,D,Dennis Anderson,78
-Chautauqua,Summit,Insurance Commissioner,,D,Dennis Anderson,2
-Chautauqua,Washington,Insurance Commissioner,,D,Dennis Anderson,5
-Chautauqua,Belleville,Insurance Commissioner,,R,Ken Selzer,146
-Chautauqua,Caneyville,Insurance Commissioner,,R,Ken Selzer,32
-Chautauqua,Center,Insurance Commissioner,,R,Ken Selzer,25
-Chautauqua,Harrison,Insurance Commissioner,,R,Ken Selzer,21
-Chautauqua,Hendricks,Insurance Commissioner,,R,Ken Selzer,19
-Chautauqua,Jefferson,Insurance Commissioner,,R,Ken Selzer,109
-Chautauqua,Little Caney,Insurance Commissioner,,R,Ken Selzer,66
-Chautauqua,Salt Creek,Insurance Commissioner,,R,Ken Selzer,17
-Chautauqua,Salt Creek,Insurance Commissioner,,R,Ken Selzer,40
-Chautauqua,Sedan,Insurance Commissioner,,R,Ken Selzer,318
-Chautauqua,Summit,Insurance Commissioner,,R,Ken Selzer,30
-Chautauqua,Washington,Insurance Commissioner,,R,Ken Selzer,30
-Chautauqua,Belleville,Secretary of State,,D,Jean Kurtis Schodorf,31
-Chautauqua,Caneyville,Secretary of State,,D,Jean Kurtis Schodorf,9
-Chautauqua,Center,Secretary of State,,D,Jean Kurtis Schodorf,0
-Chautauqua,Harrison,Secretary of State,,D,Jean Kurtis Schodorf,7
-Chautauqua,Hendricks,Secretary of State,,D,Jean Kurtis Schodorf,16
-Chautauqua,Jefferson,Secretary of State,,D,Jean Kurtis Schodorf,55
-Chautauqua,Little Caney,Secretary of State,,D,Jean Kurtis Schodorf,19
-Chautauqua,Salt Creek,Secretary of State,,D,Jean Kurtis Schodorf,6
-Chautauqua,Salt Creek,Secretary of State,,D,Jean Kurtis Schodorf,5
-Chautauqua,Sedan,Secretary of State,,D,Jean Kurtis Schodorf,134
-Chautauqua,Summit,Secretary of State,,D,Jean Kurtis Schodorf,8
-Chautauqua,Washington,Secretary of State,,D,Jean Kurtis Schodorf,7
-Chautauqua,Belleville,Secretary of State,,R,Kris Kobach,152
-Chautauqua,Caneyville,Secretary of State,,R,Kris Kobach,31
-Chautauqua,Center,Secretary of State,,R,Kris Kobach,26
-Chautauqua,Harrison,Secretary of State,,R,Kris Kobach,20
-Chautauqua,Hendricks,Secretary of State,,R,Kris Kobach,19
-Chautauqua,Jefferson,Secretary of State,,R,Kris Kobach,110
-Chautauqua,Lafayette,Secretary of State,,R,Kris Kobach,15
-Chautauqua,Lafayette,Secretary of State,,R,Kris Kobach,40
-Chautauqua,Little Caney,Secretary of State,,R,Kris Kobach,67
-Chautauqua,Sedan,Secretary of State,,R,Kris Kobach,277
-Chautauqua,Summit,Secretary of State,,R,Kris Kobach,27
-Chautauqua,Washington,Secretary of State,,R,Kris Kobach,27
-Chautauqua,Belleville,State House,12,D,Eden Fuson,27
-Chautauqua,Caneyville,State House,12,D,Eden Fuson,4
-Chautauqua,Center,State House,12,D,Eden Fuson,1
-Chautauqua,Harrison,State House,12,D,Eden Fuson,3
-Chautauqua,Hendricks,State House,12,D,Eden Fuson,17
-Chautauqua,Jefferson,State House,12,D,Eden Fuson,41
-Chautauqua,Lafayette,State House,12,D,Eden Fuson,3
-Chautauqua,Lafayette,State House,12,D,Eden Fuson,5
-Chautauqua,Little Caney,State House,12,D,Eden Fuson,17
-Chautauqua,Sedan,State House,12,D,Eden Fuson,92
-Chautauqua,Summit,State House,12,D,Eden Fuson,2
-Chautauqua,Washington,State House,12,D,Eden Fuson,4
-Chautauqua,Belleville,State House,12,R,Virgil Peck,157
-Chautauqua,Caneyville,State House,12,R,Virgil Peck,35
-Chautauqua,Center,State House,12,R,Virgil Peck,25
-Chautauqua,Harrison,State House,12,R,Virgil Peck,25
-Chautauqua,Hendricks,State House,12,R,Virgil Peck,18
-Chautauqua,Jefferson,State House,12,R,Virgil Peck,121
-Chautauqua,Little Caney,State House,12,R,Virgil Peck,66
-Chautauqua,Salt Creek,State House,12,R,Virgil Peck,18
-Chautauqua,Salt Creek,State House,12,R,Virgil Peck,40
-Chautauqua,Sedan,State House,12,R,Virgil Peck,320
-Chautauqua,Summit,State House,12,R,Virgil Peck,33
-Chautauqua,Washington,State House,12,R,Virgil Peck,31
-Chautauqua,Belleville,State Treasurer,,D,Carmen Aildritt,25
-Chautauqua,Caneyville,State Treasurer,,D,Carmen Aildritt,2
-Chautauqua,Center,State Treasurer,,D,Carmen Aildritt,1
-Chautauqua,Harrison,State Treasurer,,D,Carmen Aildritt,2
-Chautauqua,Hendricks,State Treasurer,,D,Carmen Aildritt,14
-Chautauqua,Jefferson,State Treasurer,,D,Carmen Aildritt,29
-Chautauqua,Lafayette,State Treasurer,,D,Carmen Aildritt,3
-Chautauqua,Lafayette,State Treasurer,,D,Carmen Aildritt,5
-Chautauqua,Little Caney,State Treasurer,,D,Carmen Aildritt,10
-Chautauqua,Sedan,State Treasurer,,D,Carmen Aildritt,68
-Chautauqua,Summit,State Treasurer,,D,Carmen Aildritt,2
-Chautauqua,Washington,State Treasurer,,D,Carmen Aildritt,3
-Chautauqua,Belleville,State Treasurer,,R,Ron Estes,157
-Chautauqua,Caneyville,State Treasurer,,R,Ron Estes,37
-Chautauqua,Center,State Treasurer,,R,Ron Estes,25
-Chautauqua,Harrison,State Treasurer,,R,Ron Estes,25
-Chautauqua,Hendricks,State Treasurer,,R,Ron Estes,20
-Chautauqua,Jefferson,State Treasurer,,R,Ron Estes,131
-Chautauqua,Little Caney,State Treasurer,,R,Ron Estes,72
-Chautauqua,Salt Creek,State Treasurer,,R,Ron Estes,18
-Chautauqua,Salt Creek,State Treasurer,,R,Ron Estes,40
-Chautauqua,Sedan,State Treasurer,,R,Ron Estes,337
-Chautauqua,Summit,State Treasurer,,R,Ron Estes,31
-Chautauqua,Washington,State Treasurer,,R,Ron Estes,32
-Chautauqua,Belleville,U.S. Senate,,I,Greg Orman,20
-Chautauqua,Caneyville,U.S. Senate,,I,Greg Orman,5
-Chautauqua,Center,U.S. Senate,,I,Greg Orman,2
-Chautauqua,Harrison,U.S. Senate,,I,Greg Orman,4
-Chautauqua,Hendricks,U.S. Senate,,I,Greg Orman,11
-Chautauqua,Jefferson,U.S. Senate,,I,Greg Orman,51
-Chautauqua,Lafayette,U.S. Senate,,I,Greg Orman,5
-Chautauqua,Lafayette,U.S. Senate,,I,Greg Orman,4
-Chautauqua,Little Caney,U.S. Senate,,I,Greg Orman,15
-Chautauqua,Sedan,U.S. Senate,,I,Greg Orman,95
-Chautauqua,Summit,U.S. Senate,,I,Greg Orman,6
-Chautauqua,Washington,U.S. Senate,,I,Greg Orman,3
-Chautauqua,Belleville,U.S. Senate,,R,Pat Roberts,153
-Chautauqua,Caneyville,U.S. Senate,,R,Pat Roberts,34
-Chautauqua,Center,U.S. Senate,,R,Pat Roberts,24
-Chautauqua,Harrison,U.S. Senate,,R,Pat Roberts,24
-Chautauqua,Hendricks,U.S. Senate,,R,Pat Roberts,22
-Chautauqua,Jefferson,U.S. Senate,,R,Pat Roberts,104
-Chautauqua,Lafayette,U.S. Senate,,R,Pat Roberts,13
-Chautauqua,Little Caney,U.S. Senate,,R,Pat Roberts,68
-Chautauqua,Salt Creek,U.S. Senate,,R,Pat Roberts,39
-Chautauqua,Sedan,U.S. Senate,,R,Pat Roberts,298
-Chautauqua,Summit,U.S. Senate,,R,Pat Roberts,29
-Chautauqua,Washington,U.S. Senate,,R,Pat Roberts,29
-Chautauqua,Belleville,U.S. Senate,,L,Randall Batson,12
-Chautauqua,Caneyville,U.S. Senate,,L,Randall Batson,0
-Chautauqua,Center,U.S. Senate,,L,Randall Batson,0
-Chautauqua,Harrison,U.S. Senate,,L,Randall Batson,0
-Chautauqua,Hendricks,U.S. Senate,,L,Randall Batson,1
-Chautauqua,Jefferson,U.S. Senate,,L,Randall Batson,10
-Chautauqua,Little Caney,U.S. Senate,,L,Randall Batson,1
-Chautauqua,Salt Creek,U.S. Senate,,L,Randall Batson,3
-Chautauqua,Salt Creek,U.S. Senate,,L,Randall Batson,2
-Chautauqua,Sedan,U.S. Senate,,L,Randall Batson,16
-Chautauqua,Summit,U.S. Senate,,L,Randall Batson,1
-Chautauqua,Washington,U.S. Senate,,L,Randall Batson,3
+county,precinct,office,district,party,candidate,votes,vtd
+CHAUTAUQUA,Caneyville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000010
+CHAUTAUQUA,Caneyville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000010
+CHAUTAUQUA,Caneyville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000010
+CHAUTAUQUA,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000020
+CHAUTAUQUA,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+CHAUTAUQUA,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000020
+CHAUTAUQUA,Chautauqua,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000030
+CHAUTAUQUA,Chautauqua,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000030
+CHAUTAUQUA,Chautauqua,Governor / Lt. Governor,,Republican,"Brownback, Sam",59,000030
+CHAUTAUQUA,Harrison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000040
+CHAUTAUQUA,Harrison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+CHAUTAUQUA,Harrison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000040
+CHAUTAUQUA,Hendricks Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000050
+CHAUTAUQUA,Hendricks Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000050
+CHAUTAUQUA,Hendricks Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000050
+CHAUTAUQUA,Jefferson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",63,000060
+CHAUTAUQUA,Jefferson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000060
+CHAUTAUQUA,Jefferson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,000060
+CHAUTAUQUA,Lafayette Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000070
+CHAUTAUQUA,Lafayette Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000070
+CHAUTAUQUA,Lafayette Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000070
+CHAUTAUQUA,Little Caney Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000080
+CHAUTAUQUA,Little Caney Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+CHAUTAUQUA,Little Caney Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,000080
+CHAUTAUQUA,North Sedan,Governor / Lt. Governor,,Democratic,"Davis, Paul",82,000090
+CHAUTAUQUA,North Sedan,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000090
+CHAUTAUQUA,North Sedan,Governor / Lt. Governor,,Republican,"Brownback, Sam",139,000090
+CHAUTAUQUA,Peru,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000100
+CHAUTAUQUA,Peru,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000100
+CHAUTAUQUA,Peru,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,000100
+CHAUTAUQUA,Salt Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000110
+CHAUTAUQUA,Salt Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+CHAUTAUQUA,Salt Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000110
+CHAUTAUQUA,South Sedan,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000120
+CHAUTAUQUA,South Sedan,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000120
+CHAUTAUQUA,South Sedan,Governor / Lt. Governor,,Republican,"Brownback, Sam",124,000120
+CHAUTAUQUA,Summit Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000130
+CHAUTAUQUA,Summit Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000130
+CHAUTAUQUA,Summit Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000130
+CHAUTAUQUA,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000140
+CHAUTAUQUA,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000140
+CHAUTAUQUA,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000140
+CHAUTAUQUA,Caneyville Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",4,000010
+CHAUTAUQUA,Caneyville Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",35,000010
+CHAUTAUQUA,Center Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",1,000020
+CHAUTAUQUA,Center Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",25,000020
+CHAUTAUQUA,Chautauqua,Kansas House of Representatives,12,Democratic,"Fuson, Eden",10,000030
+CHAUTAUQUA,Chautauqua,Kansas House of Representatives,12,Republican,"Peck, Virgil",61,000030
+CHAUTAUQUA,Harrison Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",3,000040
+CHAUTAUQUA,Harrison Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",25,000040
+CHAUTAUQUA,Hendricks Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",17,000050
+CHAUTAUQUA,Hendricks Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",18,000050
+CHAUTAUQUA,Jefferson Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",41,000060
+CHAUTAUQUA,Jefferson Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",121,000060
+CHAUTAUQUA,Lafayette Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",3,000070
+CHAUTAUQUA,Lafayette Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",18,000070
+CHAUTAUQUA,Little Caney Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",17,000080
+CHAUTAUQUA,Little Caney Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",66,000080
+CHAUTAUQUA,North Sedan,Kansas House of Representatives,12,Democratic,"Fuson, Eden",60,000090
+CHAUTAUQUA,North Sedan,Kansas House of Representatives,12,Republican,"Peck, Virgil",181,000090
+CHAUTAUQUA,Peru,Kansas House of Representatives,12,Democratic,"Fuson, Eden",17,000100
+CHAUTAUQUA,Peru,Kansas House of Representatives,12,Republican,"Peck, Virgil",96,000100
+CHAUTAUQUA,Salt Creek Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",5,000110
+CHAUTAUQUA,Salt Creek Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",40,000110
+CHAUTAUQUA,South Sedan,Kansas House of Representatives,12,Democratic,"Fuson, Eden",32,000120
+CHAUTAUQUA,South Sedan,Kansas House of Representatives,12,Republican,"Peck, Virgil",139,000120
+CHAUTAUQUA,Summit Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",2,000130
+CHAUTAUQUA,Summit Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",33,000130
+CHAUTAUQUA,Washington Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",4,000140
+CHAUTAUQUA,Washington Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",31,000140
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,000010
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,Republican,"Pompeo, Mike",35,000010
+CHAUTAUQUA,Center Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000020
+CHAUTAUQUA,Center Township,United States House of Representatives,4,Republican,"Pompeo, Mike",24,000020
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000030
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,Republican,"Pompeo, Mike",63,000030
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000040
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,Republican,"Pompeo, Mike",26,000040
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,000050
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,Republican,"Pompeo, Mike",22,000050
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",47,000060
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,Republican,"Pompeo, Mike",117,000060
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000070
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000070
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",13,000080
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,Republican,"Pompeo, Mike",72,000080
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",49,000090
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,Republican,"Pompeo, Mike",191,000090
+CHAUTAUQUA,Peru,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",14,000100
+CHAUTAUQUA,Peru,United States House of Representatives,4,Republican,"Pompeo, Mike",100,000100
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000110
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",40,000110
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",27,000120
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,Republican,"Pompeo, Mike",140,000120
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,000130
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,Republican,"Pompeo, Mike",32,000130
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000140
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,Republican,"Pompeo, Mike",30,000140
+CHAUTAUQUA,Caneyville Township,Attorney General,,Democratic,"Kotich, A.J.",2,000010
+CHAUTAUQUA,Caneyville Township,Attorney General,,Republican,"Schmidt, Derek",38,000010
+CHAUTAUQUA,Center Township,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+CHAUTAUQUA,Center Township,Attorney General,,Republican,"Schmidt, Derek",26,000020
+CHAUTAUQUA,Chautauqua,Attorney General,,Democratic,"Kotich, A.J.",7,000030
+CHAUTAUQUA,Chautauqua,Attorney General,,Republican,"Schmidt, Derek",65,000030
+CHAUTAUQUA,Harrison Township,Attorney General,,Democratic,"Kotich, A.J.",2,000040
+CHAUTAUQUA,Harrison Township,Attorney General,,Republican,"Schmidt, Derek",26,000040
+CHAUTAUQUA,Hendricks Township,Attorney General,,Democratic,"Kotich, A.J.",11,000050
+CHAUTAUQUA,Hendricks Township,Attorney General,,Republican,"Schmidt, Derek",24,000050
+CHAUTAUQUA,Jefferson Township,Attorney General,,Democratic,"Kotich, A.J.",30,000060
+CHAUTAUQUA,Jefferson Township,Attorney General,,Republican,"Schmidt, Derek",134,000060
+CHAUTAUQUA,Lafayette Township,Attorney General,,Democratic,"Kotich, A.J.",2,000070
+CHAUTAUQUA,Lafayette Township,Attorney General,,Republican,"Schmidt, Derek",19,000070
+CHAUTAUQUA,Little Caney Township,Attorney General,,Democratic,"Kotich, A.J.",8,000080
+CHAUTAUQUA,Little Caney Township,Attorney General,,Republican,"Schmidt, Derek",78,000080
+CHAUTAUQUA,North Sedan,Attorney General,,Democratic,"Kotich, A.J.",28,000090
+CHAUTAUQUA,North Sedan,Attorney General,,Republican,"Schmidt, Derek",215,000090
+CHAUTAUQUA,Peru,Attorney General,,Democratic,"Kotich, A.J.",8,000100
+CHAUTAUQUA,Peru,Attorney General,,Republican,"Schmidt, Derek",104,000100
+CHAUTAUQUA,Salt Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000110
+CHAUTAUQUA,Salt Creek Township,Attorney General,,Republican,"Schmidt, Derek",43,000110
+CHAUTAUQUA,South Sedan,Attorney General,,Democratic,"Kotich, A.J.",19,000120
+CHAUTAUQUA,South Sedan,Attorney General,,Republican,"Schmidt, Derek",152,000120
+CHAUTAUQUA,Summit Township,Attorney General,,Democratic,"Kotich, A.J.",3,000130
+CHAUTAUQUA,Summit Township,Attorney General,,Republican,"Schmidt, Derek",33,000130
+CHAUTAUQUA,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",0,000140
+CHAUTAUQUA,Washington Township,Attorney General,,Republican,"Schmidt, Derek",34,000140
+CHAUTAUQUA,Caneyville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000010
+CHAUTAUQUA,Caneyville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000010
+CHAUTAUQUA,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000020
+CHAUTAUQUA,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000020
+CHAUTAUQUA,Chautauqua,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000030
+CHAUTAUQUA,Chautauqua,Commissioner of Insurance,,Republican,"Selzer, Ken",59,000030
+CHAUTAUQUA,Harrison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000040
+CHAUTAUQUA,Harrison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000040
+CHAUTAUQUA,Hendricks Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000050
+CHAUTAUQUA,Hendricks Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000050
+CHAUTAUQUA,Jefferson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000060
+CHAUTAUQUA,Jefferson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",109,000060
+CHAUTAUQUA,Lafayette Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000070
+CHAUTAUQUA,Lafayette Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000070
+CHAUTAUQUA,Little Caney Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000080
+CHAUTAUQUA,Little Caney Township,Commissioner of Insurance,,Republican,"Selzer, Ken",66,000080
+CHAUTAUQUA,North Sedan,Commissioner of Insurance,,Democratic,"Anderson, Dennis",49,000090
+CHAUTAUQUA,North Sedan,Commissioner of Insurance,,Republican,"Selzer, Ken",180,000090
+CHAUTAUQUA,Peru,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000100
+CHAUTAUQUA,Peru,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000100
+CHAUTAUQUA,Salt Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000110
+CHAUTAUQUA,Salt Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000110
+CHAUTAUQUA,South Sedan,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000120
+CHAUTAUQUA,South Sedan,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000120
+CHAUTAUQUA,Summit Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000130
+CHAUTAUQUA,Summit Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000130
+CHAUTAUQUA,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000140
+CHAUTAUQUA,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000140
+CHAUTAUQUA,Caneyville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000010
+CHAUTAUQUA,Caneyville Township,Secretary of State,,Republican,"Kobach, Kris",31,000010
+CHAUTAUQUA,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+CHAUTAUQUA,Center Township,Secretary of State,,Republican,"Kobach, Kris",26,000020
+CHAUTAUQUA,Chautauqua,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000030
+CHAUTAUQUA,Chautauqua,Secretary of State,,Republican,"Kobach, Kris",58,000030
+CHAUTAUQUA,Harrison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000040
+CHAUTAUQUA,Harrison Township,Secretary of State,,Republican,"Kobach, Kris",20,000040
+CHAUTAUQUA,Hendricks Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000050
+CHAUTAUQUA,Hendricks Township,Secretary of State,,Republican,"Kobach, Kris",19,000050
+CHAUTAUQUA,Jefferson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000060
+CHAUTAUQUA,Jefferson Township,Secretary of State,,Republican,"Kobach, Kris",110,000060
+CHAUTAUQUA,Lafayette Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000070
+CHAUTAUQUA,Lafayette Township,Secretary of State,,Republican,"Kobach, Kris",15,000070
+CHAUTAUQUA,Little Caney Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000080
+CHAUTAUQUA,Little Caney Township,Secretary of State,,Republican,"Kobach, Kris",67,000080
+CHAUTAUQUA,North Sedan,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",88,000090
+CHAUTAUQUA,North Sedan,Secretary of State,,Republican,"Kobach, Kris",153,000090
+CHAUTAUQUA,Peru,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000100
+CHAUTAUQUA,Peru,Secretary of State,,Republican,"Kobach, Kris",94,000100
+CHAUTAUQUA,Salt Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000110
+CHAUTAUQUA,Salt Creek Township,Secretary of State,,Republican,"Kobach, Kris",40,000110
+CHAUTAUQUA,South Sedan,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000120
+CHAUTAUQUA,South Sedan,Secretary of State,,Republican,"Kobach, Kris",124,000120
+CHAUTAUQUA,Summit Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000130
+CHAUTAUQUA,Summit Township,Secretary of State,,Republican,"Kobach, Kris",27,000130
+CHAUTAUQUA,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000140
+CHAUTAUQUA,Washington Township,Secretary of State,,Republican,"Kobach, Kris",27,000140
+CHAUTAUQUA,Caneyville Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+CHAUTAUQUA,Caneyville Township,State Treasurer,,Republican,"Estes, Ron",37,000010
+CHAUTAUQUA,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000020
+CHAUTAUQUA,Center Township,State Treasurer,,Republican,"Estes, Ron",25,000020
+CHAUTAUQUA,Chautauqua,State Treasurer,,Democratic,"Alldritt, Carmen",11,000030
+CHAUTAUQUA,Chautauqua,State Treasurer,,Republican,"Estes, Ron",60,000030
+CHAUTAUQUA,Harrison Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000040
+CHAUTAUQUA,Harrison Township,State Treasurer,,Republican,"Estes, Ron",25,000040
+CHAUTAUQUA,Hendricks Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000050
+CHAUTAUQUA,Hendricks Township,State Treasurer,,Republican,"Estes, Ron",20,000050
+CHAUTAUQUA,Jefferson Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000060
+CHAUTAUQUA,Jefferson Township,State Treasurer,,Republican,"Estes, Ron",131,000060
+CHAUTAUQUA,Lafayette Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000070
+CHAUTAUQUA,Lafayette Township,State Treasurer,,Republican,"Estes, Ron",18,000070
+CHAUTAUQUA,Little Caney Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000080
+CHAUTAUQUA,Little Caney Township,State Treasurer,,Republican,"Estes, Ron",72,000080
+CHAUTAUQUA,North Sedan,State Treasurer,,Democratic,"Alldritt, Carmen",40,000090
+CHAUTAUQUA,North Sedan,State Treasurer,,Republican,"Estes, Ron",197,000090
+CHAUTAUQUA,Peru,State Treasurer,,Democratic,"Alldritt, Carmen",14,000100
+CHAUTAUQUA,Peru,State Treasurer,,Republican,"Estes, Ron",97,000100
+CHAUTAUQUA,Salt Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000110
+CHAUTAUQUA,Salt Creek Township,State Treasurer,,Republican,"Estes, Ron",40,000110
+CHAUTAUQUA,South Sedan,State Treasurer,,Democratic,"Alldritt, Carmen",28,000120
+CHAUTAUQUA,South Sedan,State Treasurer,,Republican,"Estes, Ron",140,000120
+CHAUTAUQUA,Summit Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000130
+CHAUTAUQUA,Summit Township,State Treasurer,,Republican,"Estes, Ron",31,000130
+CHAUTAUQUA,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000140
+CHAUTAUQUA,Washington Township,State Treasurer,,Republican,"Estes, Ron",32,000140
+CHAUTAUQUA,Caneyville Township,United States Senate,,independent,"Orman, Greg",5,000010
+CHAUTAUQUA,Caneyville Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+CHAUTAUQUA,Caneyville Township,United States Senate,,Republican,"Roberts, Pat",34,000010
+CHAUTAUQUA,Center Township,United States Senate,,independent,"Orman, Greg",2,000020
+CHAUTAUQUA,Center Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+CHAUTAUQUA,Center Township,United States Senate,,Republican,"Roberts, Pat",24,000020
+CHAUTAUQUA,Chautauqua,United States Senate,,independent,"Orman, Greg",6,000030
+CHAUTAUQUA,Chautauqua,United States Senate,,Libertarian,"Batson, Randall",5,000030
+CHAUTAUQUA,Chautauqua,United States Senate,,Republican,"Roberts, Pat",61,000030
+CHAUTAUQUA,Harrison Township,United States Senate,,independent,"Orman, Greg",4,000040
+CHAUTAUQUA,Harrison Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+CHAUTAUQUA,Harrison Township,United States Senate,,Republican,"Roberts, Pat",24,000040
+CHAUTAUQUA,Hendricks Township,United States Senate,,independent,"Orman, Greg",11,000050
+CHAUTAUQUA,Hendricks Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+CHAUTAUQUA,Hendricks Township,United States Senate,,Republican,"Roberts, Pat",22,000050
+CHAUTAUQUA,Jefferson Township,United States Senate,,independent,"Orman, Greg",51,000060
+CHAUTAUQUA,Jefferson Township,United States Senate,,Libertarian,"Batson, Randall",10,000060
+CHAUTAUQUA,Jefferson Township,United States Senate,,Republican,"Roberts, Pat",104,000060
+CHAUTAUQUA,Lafayette Township,United States Senate,,independent,"Orman, Greg",5,000070
+CHAUTAUQUA,Lafayette Township,United States Senate,,Libertarian,"Batson, Randall",3,000070
+CHAUTAUQUA,Lafayette Township,United States Senate,,Republican,"Roberts, Pat",13,000070
+CHAUTAUQUA,Little Caney Township,United States Senate,,independent,"Orman, Greg",15,000080
+CHAUTAUQUA,Little Caney Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+CHAUTAUQUA,Little Caney Township,United States Senate,,Republican,"Roberts, Pat",68,000080
+CHAUTAUQUA,North Sedan,United States Senate,,independent,"Orman, Greg",71,000090
+CHAUTAUQUA,North Sedan,United States Senate,,Libertarian,"Batson, Randall",7,000090
+CHAUTAUQUA,North Sedan,United States Senate,,Republican,"Roberts, Pat",163,000090
+CHAUTAUQUA,Peru,United States Senate,,independent,"Orman, Greg",14,000100
+CHAUTAUQUA,Peru,United States Senate,,Libertarian,"Batson, Randall",7,000100
+CHAUTAUQUA,Peru,United States Senate,,Republican,"Roberts, Pat",92,000100
+CHAUTAUQUA,Salt Creek Township,United States Senate,,independent,"Orman, Greg",4,000110
+CHAUTAUQUA,Salt Creek Township,United States Senate,,Libertarian,"Batson, Randall",2,000110
+CHAUTAUQUA,Salt Creek Township,United States Senate,,Republican,"Roberts, Pat",39,000110
+CHAUTAUQUA,South Sedan,United States Senate,,independent,"Orman, Greg",24,000120
+CHAUTAUQUA,South Sedan,United States Senate,,Libertarian,"Batson, Randall",9,000120
+CHAUTAUQUA,South Sedan,United States Senate,,Republican,"Roberts, Pat",135,000120
+CHAUTAUQUA,Summit Township,United States Senate,,independent,"Orman, Greg",6,000130
+CHAUTAUQUA,Summit Township,United States Senate,,Libertarian,"Batson, Randall",1,000130
+CHAUTAUQUA,Summit Township,United States Senate,,Republican,"Roberts, Pat",29,000130
+CHAUTAUQUA,Washington Township,United States Senate,,independent,"Orman, Greg",3,000140
+CHAUTAUQUA,Washington Township,United States Senate,,Libertarian,"Batson, Randall",3,000140
+CHAUTAUQUA,Washington Township,United States Senate,,Republican,"Roberts, Pat",29,000140

--- a/2014/20141104__ks__general__cherokee__precinct.csv
+++ b/2014/20141104__ks__general__cherokee__precinct.csv
@@ -1,856 +1,989 @@
-county,precinct,office,district,party,candidate,votes,early,advance,poll,provisional
-Cherokee,0001 Baxter Sprs W1,Attorney General,,DEM,A.J. Kotich,54,1,8,42,3
-Cherokee,0002 Baxter Sprs W2,Attorney General,,DEM,A.J. Kotich,43,2,5,32,4
-Cherokee,0003 Baxter Sprs W3,Attorney General,,DEM,A.J. Kotich,117,7,12,95,3
-Cherokee,0004 Baxter Sprs W4,Attorney General,,DEM,A.J. Kotich,62,5,7,46,4
-Cherokee,0005 Columbus W1,Attorney General,,DEM,A.J. Kotich,45,6,5,33,1
-Cherokee,0006 Columbus W2,Attorney General,,DEM,A.J. Kotich,70,7,13,50,0
-Cherokee,0007 Columbus W3,Attorney General,,DEM,A.J. Kotich,57,6,12,37,2
-Cherokee,0008 Columbus W4,Attorney General,,DEM,A.J. Kotich,45,4,11,30,0
-Cherokee,0009 Columbus W5,Attorney General,,DEM,A.J. Kotich,68,5,19,44,0
-Cherokee,0010 Galena W1,Attorney General,,DEM,A.J. Kotich,61,4,9,44,4
-Cherokee,0011 Galena W2,Attorney General,,DEM,A.J. Kotich,41,0,6,35,0
-Cherokee,0012 Galena W3,Attorney General,,DEM,A.J. Kotich,63,0,9,51,3
-Cherokee,0013 Galena W4,Attorney General,,DEM,A.J. Kotich,32,0,3,29,0
-Cherokee,0014 Scammon W1,Attorney General,,DEM,A.J. Kotich,20,2,0,17,1
-Cherokee,0015 Scammon W2,Attorney General,,DEM,A.J. Kotich,20,0,3,17,0
-Cherokee,0016 Scammon W3,Attorney General,,DEM,A.J. Kotich,29,3,3,23,0
-Cherokee,0017 Weir W1,Attorney General,,DEM,A.J. Kotich,23,1,1,20,1
-Cherokee,0018 Weir W2,Attorney General,,DEM,A.J. Kotich,55,0,2,52,1
-Cherokee,0019 Weir W3,Attorney General,,DEM,A.J. Kotich,27,1,4,22,0
-Cherokee,0001 Baxter Sprs W1,Attorney General,,REP,Derek Schmidt,132,2,9,119,2
-Cherokee,0002 Baxter Sprs W2,Attorney General,,REP,Derek Schmidt,95,3,6,84,2
-Cherokee,0003 Baxter Sprs W3,Attorney General,,REP,Derek Schmidt,281,8,9,258,6
-Cherokee,0004 Baxter Sprs W4,Attorney General,,REP,Derek Schmidt,135,6,9,114,6
-Cherokee,0005 Columbus W1,Attorney General,,REP,Derek Schmidt,87,8,9,70,0
-Cherokee,0006 Columbus W2,Attorney General,,REP,Derek Schmidt,185,24,16,145,0
-Cherokee,0007 Columbus W3,Attorney General,,REP,Derek Schmidt,179,13,15,151,0
-Cherokee,0008 Columbus W4,Attorney General,,REP,Derek Schmidt,97,10,8,79,0
-Cherokee,0009 Columbus W5,Attorney General,,REP,Derek Schmidt,110,7,15,87,1
-Cherokee,0010 Galena W1,Attorney General,,REP,Derek Schmidt,94,2,4,81,7
-Cherokee,0011 Galena W2,Attorney General,,REP,Derek Schmidt,88,3,9,73,3
-Cherokee,0012 Galena W3,Attorney General,,REP,Derek Schmidt,150,1,11,137,1
-Cherokee,0013 Galena W4,Attorney General,,REP,Derek Schmidt,59,0,8,51,0
-Cherokee,0014 Scammon W1,Attorney General,,REP,Derek Schmidt,19,1,0,18,0
-Cherokee,0015 Scammon W2,Attorney General,,REP,Derek Schmidt,27,3,4,20,0
-Cherokee,0016 Scammon W3,Attorney General,,REP,Derek Schmidt,32,1,3,28,0
-Cherokee,0017 Weir W1,Attorney General,,REP,Derek Schmidt,23,0,0,22,1
-Cherokee,0018 Weir W2,Attorney General,,REP,Derek Schmidt,47,1,6,39,1
-Cherokee,0019 Weir W3,Attorney General,,REP,Derek Schmidt,34,0,6,28,0
-Cherokee,0001 Baxter Sprs W1,Attorney General,,,Write-ins,1,0,0,1,0
-Cherokee,0005 Columbus W1,Attorney General,,,Write-ins,1,0,0,1,0
-Cherokee,0001 Baxter Sprs W1,U.S. House,2,LIB,Christopher Clemmons,12,1,0,10,1
-Cherokee,0002 Baxter Sprs W2,U.S. House,2,LIB,Christopher Clemmons,21,0,0,20,1
-Cherokee,0003 Baxter Sprs W3,U.S. House,2,LIB,Christopher Clemmons,18,1,3,13,1
-Cherokee,0004 Baxter Sprs W4,U.S. House,2,LIB,Christopher Clemmons,16,1,0,15,0
-Cherokee,0005 Columbus W1,U.S. House,2,LIB,Christopher Clemmons,12,0,1,11,0
-Cherokee,0006 Columbus W2,U.S. House,2,LIB,Christopher Clemmons,6,0,0,6,0
-Cherokee,0007 Columbus W3,U.S. House,2,LIB,Christopher Clemmons,13,1,2,10,0
-Cherokee,0008 Columbus W4,U.S. House,2,LIB,Christopher Clemmons,10,0,1,9,0
-Cherokee,0009 Columbus W5,U.S. House,2,LIB,Christopher Clemmons,7,0,0,7,0
-Cherokee,0010 Galena W1,U.S. House,2,LIB,Christopher Clemmons,8,0,2,4,2
-Cherokee,0011 Galena W2,U.S. House,2,LIB,Christopher Clemmons,11,0,1,10,0
-Cherokee,0012 Galena W3,U.S. House,2,LIB,Christopher Clemmons,14,0,3,11,0
-Cherokee,0013 Galena W4,U.S. House,2,LIB,Christopher Clemmons,7,0,0,7,0
-Cherokee,0014 Scammon W1,U.S. House,2,LIB,Christopher Clemmons,3,0,1,2,0
-Cherokee,0015 Scammon W2,U.S. House,2,LIB,Christopher Clemmons,8,0,1,7,0
-Cherokee,0016 Scammon W3,U.S. House,2,LIB,Christopher Clemmons,3,0,0,3,0
-Cherokee,0017 Weir W1,U.S. House,2,LIB,Christopher Clemmons,1,0,0,1,0
-Cherokee,0018 Weir W2,U.S. House,2,LIB,Christopher Clemmons,9,0,0,9,0
-Cherokee,0019 Weir W3,U.S. House,2,LIB,Christopher Clemmons,4,0,1,3,0
-Cherokee,0001 Baxter Sprs W1,U.S. House,2,REP,Lynn Jenkins,133,1,12,115,5
-Cherokee,0002 Baxter Sprs W2,U.S. House,2,REP,Lynn Jenkins,86,3,5,76,2
-Cherokee,0003 Baxter Sprs W3,U.S. House,2,REP,Lynn Jenkins,289,8,8,268,5
-Cherokee,0004 Baxter Sprs W4,U.S. House,2,REP,Lynn Jenkins,134,7,11,109,7
-Cherokee,0005 Columbus W1,U.S. House,2,REP,Lynn Jenkins,92,9,9,73,1
-Cherokee,0006 Columbus W2,U.S. House,2,REP,Lynn Jenkins,179,23,15,141,0
-Cherokee,0007 Columbus W3,U.S. House,2,REP,Lynn Jenkins,166,13,14,138,1
-Cherokee,0008 Columbus W4,U.S. House,2,REP,Lynn Jenkins,98,9,8,81,0
-Cherokee,0009 Columbus W5,U.S. House,2,REP,Lynn Jenkins,109,7,21,80,1
-Cherokee,0010 Galena W1,U.S. House,2,REP,Lynn Jenkins,102,4,6,86,6
-Cherokee,0011 Galena W2,U.S. House,2,REP,Lynn Jenkins,87,3,10,71,3
-Cherokee,0012 Galena W3,U.S. House,2,REP,Lynn Jenkins,146,1,14,130,1
-Cherokee,0013 Galena W4,U.S. House,2,REP,Lynn Jenkins,59,0,9,50,0
-Cherokee,0014 Scammon W1,U.S. House,2,REP,Lynn Jenkins,20,2,0,17,1
-Cherokee,0015 Scammon W2,U.S. House,2,REP,Lynn Jenkins,23,3,3,17,0
-Cherokee,0016 Scammon W3,U.S. House,2,REP,Lynn Jenkins,33,1,3,29,0
-Cherokee,0017 Weir W1,U.S. House,2,REP,Lynn Jenkins,24,0,0,24,0
-Cherokee,0018 Weir W2,U.S. House,2,REP,Lynn Jenkins,45,1,7,36,1
-Cherokee,0019 Weir W3,U.S. House,2,REP,Lynn Jenkins,28,0,4,24,0
-Cherokee,0001 Baxter Sprs W1,U.S. House,2,DEM,Margie Wakefield,47,1,6,40,0
-Cherokee,0002 Baxter Sprs W2,U.S. House,2,DEM,Margie Wakefield,34,2,7,21,4
-Cherokee,0003 Baxter Sprs W3,U.S. House,2,DEM,Margie Wakefield,99,6,10,80,3
-Cherokee,0004 Baxter Sprs W4,U.S. House,2,DEM,Margie Wakefield,50,3,5,39,3
-Cherokee,0005 Columbus W1,U.S. House,2,DEM,Margie Wakefield,33,5,6,22,0
-Cherokee,0006 Columbus W2,U.S. House,2,DEM,Margie Wakefield,74,8,14,52,0
-Cherokee,0007 Columbus W3,U.S. House,2,DEM,Margie Wakefield,59,6,11,41,1
-Cherokee,0008 Columbus W4,U.S. House,2,DEM,Margie Wakefield,36,5,10,21,0
-Cherokee,0009 Columbus W5,U.S. House,2,DEM,Margie Wakefield,64,6,15,43,0
-Cherokee,0010 Galena W1,U.S. House,2,DEM,Margie Wakefield,49,2,6,39,2
-Cherokee,0011 Galena W2,U.S. House,2,DEM,Margie Wakefield,32,0,4,28,0
-Cherokee,0012 Galena W3,U.S. House,2,DEM,Margie Wakefield,59,0,5,50,4
-Cherokee,0013 Galena W4,U.S. House,2,DEM,Margie Wakefield,23,0,2,21,0
-Cherokee,0014 Scammon W1,U.S. House,2,DEM,Margie Wakefield,17,1,0,16,0
-Cherokee,0015 Scammon W2,U.S. House,2,DEM,Margie Wakefield,14,0,1,13,0
-Cherokee,0016 Scammon W3,U.S. House,2,DEM,Margie Wakefield,27,3,3,21,0
-Cherokee,0017 Weir W1,U.S. House,2,DEM,Margie Wakefield,20,1,1,16,2
-Cherokee,0018 Weir W2,U.S. House,2,DEM,Margie Wakefield,46,0,1,44,1
-Cherokee,0019 Weir W3,U.S. House,2,DEM,Margie Wakefield,29,1,5,23,0
-Cherokee,0002 Baxter Sprs W2,U.S. House,2,,Write-ins,1,0,0,1,0
-Cherokee,0007 Columbus W3,U.S. House,2,,Write-ins,1,0,0,1,0
-Cherokee,0015 Scammon W2,U.S. House,2,,Write-ins,1,0,1,0,0
-Cherokee,0018 Weir W2,U.S. House,2,,Write-ins,1,0,0,1,0
-Cherokee,0001 Baxter Sprs W1,Governor,,LIB,Keen A. Umbehr,5,0,0,4,1
-Cherokee,0002 Baxter Sprs W2,Governor,,LIB,Keen A. Umbehr,11,0,0,11,0
-Cherokee,0003 Baxter Sprs W3,Governor,,LIB,Keen A. Umbehr,11,0,1,10,0
-Cherokee,0004 Baxter Sprs W4,Governor,,LIB,Keen A. Umbehr,12,0,0,11,1
-Cherokee,0005 Columbus W1,Governor,,LIB,Keen A. Umbehr,11,2,1,8,0
-Cherokee,0006 Columbus W2,Governor,,LIB,Keen A. Umbehr,5,0,0,5,0
-Cherokee,0007 Columbus W3,Governor,,LIB,Keen A. Umbehr,13,2,0,10,1
-Cherokee,0008 Columbus W4,Governor,,LIB,Keen A. Umbehr,5,0,2,3,0
-Cherokee,0009 Columbus W5,Governor,,LIB,Keen A. Umbehr,7,2,0,5,0
-Cherokee,0010 Galena W1,Governor,,LIB,Keen A. Umbehr,7,1,2,4,0
-Cherokee,0011 Galena W2,Governor,,LIB,Keen A. Umbehr,6,0,2,4,0
-Cherokee,0012 Galena W3,Governor,,LIB,Keen A. Umbehr,9,0,1,8,0
-Cherokee,0013 Galena W4,Governor,,LIB,Keen A. Umbehr,6,0,0,6,0
-Cherokee,0014 Scammon W1,Governor,,LIB,Keen A. Umbehr,0,0,0,0,0
-Cherokee,0015 Scammon W2,Governor,,LIB,Keen A. Umbehr,5,0,2,3,0
-Cherokee,0016 Scammon W3,Governor,,LIB,Keen A. Umbehr,1,0,0,1,0
-Cherokee,0017 Weir W1,Governor,,LIB,Keen A. Umbehr,0,0,0,0,0
-Cherokee,0018 Weir W2,Governor,,LIB,Keen A. Umbehr,1,0,0,1,0
-Cherokee,0019 Weir W3,Governor,,LIB,Keen A. Umbehr,3,0,0,3,0
-Cherokee,0001 Baxter Sprs W1,Governor,,DEM,Paul Davis,61,1,7,52,1
-Cherokee,0002 Baxter Sprs W2,Governor,,DEM,Paul Davis,55,2,7,42,4
-Cherokee,0003 Baxter Sprs W3,Governor,,DEM,Paul Davis,146,6,11,125,4
-Cherokee,0004 Baxter Sprs W4,Governor,,DEM,Paul Davis,68,5,6,53,4
-Cherokee,0005 Columbus W1,Governor,,DEM,Paul Davis,51,6,7,38,0
-Cherokee,0006 Columbus W2,Governor,,DEM,Paul Davis,104,12,13,79,0
-Cherokee,0007 Columbus W3,Governor,,DEM,Paul Davis,93,8,17,67,1
-Cherokee,0008 Columbus W4,Governor,,DEM,Paul Davis,53,7,12,34,0
-Cherokee,0009 Columbus W5,Governor,,DEM,Paul Davis,79,4,19,56,0
-Cherokee,0010 Galena W1,Governor,,DEM,Paul Davis,60,4,7,46,3
-Cherokee,0011 Galena W2,Governor,,DEM,Paul Davis,49,1,6,42,0
-Cherokee,0012 Galena W3,Governor,,DEM,Paul Davis,74,0,8,62,4
-Cherokee,0013 Galena W4,Governor,,DEM,Paul Davis,24,0,1,23,0
-Cherokee,0014 Scammon W1,Governor,,DEM,Paul Davis,27,2,1,24,0
-Cherokee,0015 Scammon W2,Governor,,DEM,Paul Davis,21,0,2,19,0
-Cherokee,0016 Scammon W3,Governor,,DEM,Paul Davis,34,3,3,28,0
-Cherokee,0017 Weir W1,Governor,,DEM,Paul Davis,28,1,1,24,2
-Cherokee,0018 Weir W2,Governor,,DEM,Paul Davis,63,1,1,60,1
-Cherokee,0019 Weir W3,Governor,,DEM,Paul Davis,34,1,7,26,0
-Cherokee,0001 Baxter Sprs W1,Governor,,REP,Sam Brownback,125,2,11,108,4
-Cherokee,0002 Baxter Sprs W2,Governor,,REP,Sam Brownback,76,3,5,65,3
-Cherokee,0003 Baxter Sprs W3,Governor,,REP,Sam Brownback,249,8,9,227,5
-Cherokee,0004 Baxter Sprs W4,Governor,,REP,Sam Brownback,118,6,10,97,5
-Cherokee,0005 Columbus W1,Governor,,REP,Sam Brownback,75,6,8,60,1
-Cherokee,0006 Columbus W2,Governor,,REP,Sam Brownback,150,19,16,115,0
-Cherokee,0007 Columbus W3,Governor,,REP,Sam Brownback,133,10,10,113,0
-Cherokee,0008 Columbus W4,Governor,,REP,Sam Brownback,87,7,5,75,0
-Cherokee,0009 Columbus W5,Governor,,REP,Sam Brownback,96,8,16,71,1
-Cherokee,0010 Galena W1,Governor,,REP,Sam Brownback,90,1,4,78,7
-Cherokee,0011 Galena W2,Governor,,REP,Sam Brownback,76,2,7,64,3
-Cherokee,0012 Galena W3,Governor,,REP,Sam Brownback,136,1,13,121,1
-Cherokee,0013 Galena W4,Governor,,REP,Sam Brownback,60,0,9,51,0
-Cherokee,0014 Scammon W1,Governor,,REP,Sam Brownback,13,1,0,11,1
-Cherokee,0015 Scammon W2,Governor,,REP,Sam Brownback,21,3,3,15,0
-Cherokee,0016 Scammon W3,Governor,,REP,Sam Brownback,28,1,3,24,0
-Cherokee,0017 Weir W1,Governor,,REP,Sam Brownback,18,0,0,18,0
-Cherokee,0018 Weir W2,Governor,,REP,Sam Brownback,37,0,7,29,1
-Cherokee,0019 Weir W3,Governor,,REP,Sam Brownback,23,0,2,21,0
-Cherokee,0007 Columbus W3,Governor,,,Write-ins,1,0,0,1,0
-Cherokee,0001 Baxter Sprs W1,Insurance Commissioner,,DEM,Dennis Anderson,58,1,8,46,3
-Cherokee,0002 Baxter Sprs W2,Insurance Commissioner,,DEM,Dennis Anderson,54,2,7,41,4
-Cherokee,0003 Baxter Sprs W3,Insurance Commissioner,,DEM,Dennis Anderson,128,6,11,108,3
-Cherokee,0004 Baxter Sprs W4,Insurance Commissioner,,DEM,Dennis Anderson,66,6,8,48,4
-Cherokee,0005 Columbus W1,Insurance Commissioner,,DEM,Dennis Anderson,60,7,7,45,1
-Cherokee,0006 Columbus W2,Insurance Commissioner,,DEM,Dennis Anderson,78,7,13,58,0
-Cherokee,0007 Columbus W3,Insurance Commissioner,,DEM,Dennis Anderson,76,8,14,52,2
-Cherokee,0008 Columbus W4,Insurance Commissioner,,DEM,Dennis Anderson,56,5,12,39,0
-Cherokee,0009 Columbus W5,Insurance Commissioner,,DEM,Dennis Anderson,82,6,20,56,0
-Cherokee,0010 Galena W1,Insurance Commissioner,,DEM,Dennis Anderson,63,5,8,47,3
-Cherokee,0011 Galena W2,Insurance Commissioner,,DEM,Dennis Anderson,45,0,5,40,0
-Cherokee,0012 Galena W3,Insurance Commissioner,,DEM,Dennis Anderson,75,0,11,60,4
-Cherokee,0013 Galena W4,Insurance Commissioner,,DEM,Dennis Anderson,37,0,5,32,0
-Cherokee,0014 Scammon W1,Insurance Commissioner,,DEM,Dennis Anderson,22,1,0,21,0
-Cherokee,0015 Scammon W2,Insurance Commissioner,,DEM,Dennis Anderson,22,0,2,20,0
-Cherokee,0016 Scammon W3,Insurance Commissioner,,DEM,Dennis Anderson,30,3,3,24,0
-Cherokee,0017 Weir W1,Insurance Commissioner,,DEM,Dennis Anderson,26,1,1,22,2
-Cherokee,0018 Weir W2,Insurance Commissioner,,DEM,Dennis Anderson,59,0,1,57,1
-Cherokee,0019 Weir W3,Insurance Commissioner,,DEM,Dennis Anderson,36,1,7,28,0
-Cherokee,0001 Baxter Sprs W1,Insurance Commissioner,,REP,Ken Selzer,130,2,10,115,3
-Cherokee,0002 Baxter Sprs W2,Insurance Commissioner,,REP,Ken Selzer,83,3,4,73,3
-Cherokee,0003 Baxter Sprs W3,Insurance Commissioner,,REP,Ken Selzer,263,8,10,239,6
-Cherokee,0004 Baxter Sprs W4,Insurance Commissioner,,REP,Ken Selzer,125,5,8,106,6
-Cherokee,0005 Columbus W1,Insurance Commissioner,,REP,Ken Selzer,71,7,7,57,0
-Cherokee,0006 Columbus W2,Insurance Commissioner,,REP,Ken Selzer,173,24,14,135,0
-Cherokee,0007 Columbus W3,Insurance Commissioner,,REP,Ken Selzer,158,12,12,134,0
-Cherokee,0008 Columbus W4,Insurance Commissioner,,REP,Ken Selzer,82,9,7,66,0
-Cherokee,0009 Columbus W5,Insurance Commissioner,,REP,Ken Selzer,89,6,12,70,1
-Cherokee,0010 Galena W1,Insurance Commissioner,,REP,Ken Selzer,90,1,5,76,8
-Cherokee,0011 Galena W2,Insurance Commissioner,,REP,Ken Selzer,82,3,9,67,3
-Cherokee,0012 Galena W3,Insurance Commissioner,,REP,Ken Selzer,137,1,11,124,1
-Cherokee,0013 Galena W4,Insurance Commissioner,,REP,Ken Selzer,54,0,6,48,0
-Cherokee,0014 Scammon W1,Insurance Commissioner,,REP,Ken Selzer,17,2,0,14,1
-Cherokee,0015 Scammon W2,Insurance Commissioner,,REP,Ken Selzer,24,3,5,16,0
-Cherokee,0016 Scammon W3,Insurance Commissioner,,REP,Ken Selzer,31,1,3,27,0
-Cherokee,0017 Weir W1,Insurance Commissioner,,REP,Ken Selzer,20,0,0,20,0
-Cherokee,0018 Weir W2,Insurance Commissioner,,REP,Ken Selzer,43,1,7,34,1
-Cherokee,0019 Weir W3,Insurance Commissioner,,REP,Ken Selzer,25,0,3,22,0
-Cherokee,0001 Baxter Sprs W1,Secretary of State,,DEM,Jean Kurtis Schodorf,57,1,7,46,3
-Cherokee,0002 Baxter Sprs W2,Secretary of State,,DEM,Jean Kurtis Schodorf,48,2,6,36,4
-Cherokee,0003 Baxter Sprs W3,Secretary of State,,DEM,Jean Kurtis Schodorf,128,7,11,107,3
-Cherokee,0004 Baxter Sprs W4,Secretary of State,,DEM,Jean Kurtis Schodorf,68,6,8,51,3
-Cherokee,0005 Columbus W1,Secretary of State,,DEM,Jean Kurtis Schodorf,47,7,6,34,0
-Cherokee,0006 Columbus W2,Secretary of State,,DEM,Jean Kurtis Schodorf,73,7,11,55,0
-Cherokee,0007 Columbus W3,Secretary of State,,DEM,Jean Kurtis Schodorf,76,8,16,51,1
-Cherokee,0008 Columbus W4,Secretary of State,,DEM,Jean Kurtis Schodorf,54,5,13,36,0
-Cherokee,0009 Columbus W5,Secretary of State,,DEM,Jean Kurtis Schodorf,79,6,20,53,0
-Cherokee,0010 Galena W1,Secretary of State,,DEM,Jean Kurtis Schodorf,58,3,8,44,3
-Cherokee,0011 Galena W2,Secretary of State,,DEM,Jean Kurtis Schodorf,47,0,6,41,0
-Cherokee,0012 Galena W3,Secretary of State,,DEM,Jean Kurtis Schodorf,67,0,8,56,3
-Cherokee,0013 Galena W4,Secretary of State,,DEM,Jean Kurtis Schodorf,33,0,5,28,0
-Cherokee,0014 Scammon W1,Secretary of State,,DEM,Jean Kurtis Schodorf,24,2,0,22,0
-Cherokee,0015 Scammon W2,Secretary of State,,DEM,Jean Kurtis Schodorf,20,0,3,17,0
-Cherokee,0016 Scammon W3,Secretary of State,,DEM,Jean Kurtis Schodorf,30,3,4,23,0
-Cherokee,0017 Weir W1,Secretary of State,,DEM,Jean Kurtis Schodorf,23,1,1,20,1
-Cherokee,0018 Weir W2,Secretary of State,,DEM,Jean Kurtis Schodorf,58,0,1,55,2
-Cherokee,0019 Weir W3,Secretary of State,,DEM,Jean Kurtis Schodorf,36,1,6,29,0
-Cherokee,0001 Baxter Sprs W1,Secretary of State,,REP,Kris Kobach,133,2,10,118,3
-Cherokee,0002 Baxter Sprs W2,Secretary of State,,REP,Kris Kobach,93,3,5,82,3
-Cherokee,0003 Baxter Sprs W3,Secretary of State,,REP,Kris Kobach,270,8,10,246,6
-Cherokee,0004 Baxter Sprs W4,Secretary of State,,REP,Kris Kobach,126,5,8,106,7
-Cherokee,0005 Columbus W1,Secretary of State,,REP,Kris Kobach,85,7,8,69,1
-Cherokee,0006 Columbus W2,Secretary of State,,REP,Kris Kobach,183,24,18,141,0
-Cherokee,0007 Columbus W3,Secretary of State,,REP,Kris Kobach,159,11,10,137,1
-Cherokee,0008 Columbus W4,Secretary of State,,REP,Kris Kobach,87,9,6,72,0
-Cherokee,0009 Columbus W5,Secretary of State,,REP,Kris Kobach,99,6,14,78,1
-Cherokee,0010 Galena W1,Secretary of State,,REP,Kris Kobach,97,3,5,82,7
-Cherokee,0011 Galena W2,Secretary of State,,REP,Kris Kobach,81,3,8,67,3
-Cherokee,0012 Galena W3,Secretary of State,,REP,Kris Kobach,147,1,13,132,1
-Cherokee,0013 Galena W4,Secretary of State,,REP,Kris Kobach,57,0,6,51,0
-Cherokee,0014 Scammon W1,Secretary of State,,REP,Kris Kobach,16,1,1,13,1
-Cherokee,0015 Scammon W2,Secretary of State,,REP,Kris Kobach,26,3,4,19,0
-Cherokee,0016 Scammon W3,Secretary of State,,REP,Kris Kobach,32,1,2,29,0
-Cherokee,0017 Weir W1,Secretary of State,,REP,Kris Kobach,23,0,0,22,1
-Cherokee,0018 Weir W2,Secretary of State,,REP,Kris Kobach,44,1,7,36,0
-Cherokee,0019 Weir W3,Secretary of State,,REP,Kris Kobach,25,0,4,21,0
-Cherokee,0001 Baxter Sprs W1,State House,1,DEM,Brian Caswell,102,2,8,89,3
-Cherokee,0002 Baxter Sprs W2,State House,1,DEM,Brian Caswell,72,2,11,55,4
-Cherokee,0003 Baxter Sprs W3,State House,1,DEM,Brian Caswell,203,6,13,179,5
-Cherokee,0004 Baxter Sprs W4,State House,1,DEM,Brian Caswell,98,5,10,77,6
-Cherokee,0005 Columbus W1,State House,1,DEM,Brian Caswell,38,3,7,28,0
-Cherokee,0006 Columbus W2,State House,1,DEM,Brian Caswell,103,10,11,82,0
-Cherokee,0007 Columbus W3,State House,1,DEM,Brian Caswell,85,7,16,60,2
-Cherokee,0008 Columbus W4,State House,1,DEM,Brian Caswell,58,6,12,40,0
-Cherokee,0009 Columbus W5,State House,1,DEM,Brian Caswell,76,5,19,52,0
-Cherokee,0010 Galena W1,State House,1,DEM,Brian Caswell,68,4,12,49,3
-Cherokee,0011 Galena W2,State House,1,DEM,Brian Caswell,59,2,8,49,0
-Cherokee,0012 Galena W3,State House,1,DEM,Brian Caswell,82,0,9,70,3
-Cherokee,0013 Galena W4,State House,1,DEM,Brian Caswell,38,0,4,34,0
-Cherokee,0014 Scammon W1,State House,1,DEM,Brian Caswell,26,1,1,24,0
-Cherokee,0015 Scammon W2,State House,1,DEM,Brian Caswell,24,0,2,22,0
-Cherokee,0016 Scammon W3,State House,1,DEM,Brian Caswell,29,3,3,23,0
-Cherokee,0017 Weir W1,State House,1,DEM,Brian Caswell,23,1,1,20,1
-Cherokee,0018 Weir W2,State House,1,DEM,Brian Caswell,60,0,3,55,2
-Cherokee,0019 Weir W3,State House,1,DEM,Brian Caswell,29,1,5,23,0
-Cherokee,0001 Baxter Sprs W1,State House,1,REP,Michael Houser,91,1,10,77,3
-Cherokee,0002 Baxter Sprs W2,State House,1,REP,Michael Houser,69,3,1,62,3
-Cherokee,0003 Baxter Sprs W3,State House,1,REP,Michael Houser,202,9,8,181,4
-Cherokee,0004 Baxter Sprs W4,State House,1,REP,Michael Houser,101,6,6,85,4
-Cherokee,0005 Columbus W1,State House,1,REP,Michael Houser,98,11,8,78,1
-Cherokee,0006 Columbus W2,State House,1,REP,Michael Houser,155,21,18,116,0
-Cherokee,0007 Columbus W3,State House,1,REP,Michael Houser,152,13,10,129,0
-Cherokee,0008 Columbus W4,State House,1,REP,Michael Houser,83,8,6,69,0
-Cherokee,0009 Columbus W5,State House,1,REP,Michael Houser,107,9,17,80,1
-Cherokee,0010 Galena W1,State House,1,REP,Michael Houser,88,2,1,78,7
-Cherokee,0011 Galena W2,State House,1,REP,Michael Houser,71,1,7,60,3
-Cherokee,0012 Galena W3,State House,1,REP,Michael Houser,138,1,13,122,2
-Cherokee,0013 Galena W4,State House,1,REP,Michael Houser,53,0,7,46,0
-Cherokee,0014 Scammon W1,State House,1,REP,Michael Houser,14,2,0,11,1
-Cherokee,0015 Scammon W2,State House,1,REP,Michael Houser,22,3,4,15,0
-Cherokee,0016 Scammon W3,State House,1,REP,Michael Houser,34,1,3,30,0
-Cherokee,0017 Weir W1,State House,1,REP,Michael Houser,23,0,0,22,1
-Cherokee,0018 Weir W2,State House,1,REP,Michael Houser,41,1,5,35,0
-Cherokee,0019 Weir W3,State House,1,REP,Michael Houser,30,0,5,25,0
-Cherokee,0001 Baxter Sprs W1,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0002 Baxter Sprs W2,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0003 Baxter Sprs W3,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0004 Baxter Sprs W4,State House,1,,Write-ins,1,0,0,1,0
-Cherokee,0005 Columbus W1,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0006 Columbus W2,State House,1,,Write-ins,2,0,0,2,0
-Cherokee,0007 Columbus W3,State House,1,,Write-ins,1,0,0,1,0
-Cherokee,0008 Columbus W4,State House,1,,Write-ins,1,0,0,1,0
-Cherokee,0009 Columbus W5,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0010 Galena W1,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0011 Galena W2,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0012 Galena W3,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0013 Galena W4,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0014 Scammon W1,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0015 Scammon W2,State House,1,,Write-ins,1,0,1,0,0
-Cherokee,0016 Scammon W3,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0017 Weir W1,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0018 Weir W2,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0019 Weir W3,State House,1,,Write-ins,0,0,0,0,0
-Cherokee,0001 Baxter Sprs W1,State Treasurer,,DEM,Carmen Alldritt,58,1,10,44,3
-Cherokee,0002 Baxter Sprs W2,State Treasurer,,DEM,Carmen Alldritt,43,2,5,33,3
-Cherokee,0003 Baxter Sprs W3,State Treasurer,,DEM,Carmen Alldritt,117,7,12,95,3
-Cherokee,0004 Baxter Sprs W4,State Treasurer,,DEM,Carmen Alldritt,52,5,6,38,3
-Cherokee,0005 Columbus W1,State Treasurer,,DEM,Carmen Alldritt,47,8,7,31,1
-Cherokee,0006 Columbus W2,State Treasurer,,DEM,Carmen Alldritt,68,7,10,51,0
-Cherokee,0007 Columbus W3,State Treasurer,,DEM,Carmen Alldritt,64,7,11,45,1
-Cherokee,0008 Columbus W4,State Treasurer,,DEM,Carmen Alldritt,45,4,11,30,0
-Cherokee,0009 Columbus W5,State Treasurer,,DEM,Carmen Alldritt,73,7,20,46,0
-Cherokee,0010 Galena W1,State Treasurer,,DEM,Carmen Alldritt,57,4,9,41,3
-Cherokee,0011 Galena W2,State Treasurer,,DEM,Carmen Alldritt,43,0,6,37,0
-Cherokee,0012 Galena W3,State Treasurer,,DEM,Carmen Alldritt,63,0,7,53,3
-Cherokee,0013 Galena W4,State Treasurer,,DEM,Carmen Alldritt,31,0,4,27,0
-Cherokee,0014 Scammon W1,State Treasurer,,DEM,Carmen Alldritt,18,1,1,16,0
-Cherokee,0015 Scammon W2,State Treasurer,,DEM,Carmen Alldritt,19,0,2,17,0
-Cherokee,0016 Scammon W3,State Treasurer,,DEM,Carmen Alldritt,27,1,3,23,0
-Cherokee,0017 Weir W1,State Treasurer,,DEM,Carmen Alldritt,24,1,1,21,1
-Cherokee,0018 Weir W2,State Treasurer,,DEM,Carmen Alldritt,57,0,3,53,1
-Cherokee,0019 Weir W3,State Treasurer,,DEM,Carmen Alldritt,34,1,4,29,0
-Cherokee,0001 Baxter Sprs W1,State Treasurer,,REP,Ron Estes,131,2,7,119,3
-Cherokee,0002 Baxter Sprs W2,State Treasurer,,REP,Ron Estes,99,3,7,85,4
-Cherokee,0003 Baxter Sprs W3,State Treasurer,,REP,Ron Estes,277,8,9,254,6
-Cherokee,0004 Baxter Sprs W4,State Treasurer,,REP,Ron Estes,143,6,10,120,7
-Cherokee,0005 Columbus W1,State Treasurer,,REP,Ron Estes,86,6,7,73,0
-Cherokee,0006 Columbus W2,State Treasurer,,REP,Ron Estes,189,24,19,146,0
-Cherokee,0007 Columbus W3,State Treasurer,,REP,Ron Estes,173,13,16,143,1
-Cherokee,0008 Columbus W4,State Treasurer,,REP,Ron Estes,94,10,8,76,0
-Cherokee,0009 Columbus W5,State Treasurer,,REP,Ron Estes,105,6,14,84,1
-Cherokee,0010 Galena W1,State Treasurer,,REP,Ron Estes,98,2,4,85,7
-Cherokee,0011 Galena W2,State Treasurer,,REP,Ron Estes,84,3,9,69,3
-Cherokee,0012 Galena W3,State Treasurer,,REP,Ron Estes,149,1,12,134,2
-Cherokee,0013 Galena W4,State Treasurer,,REP,Ron Estes,60,0,7,53,0
-Cherokee,0014 Scammon W1,State Treasurer,,REP,Ron Estes,22,2,0,19,1
-Cherokee,0015 Scammon W2,State Treasurer,,REP,Ron Estes,28,3,5,20,0
-Cherokee,0016 Scammon W3,State Treasurer,,REP,Ron Estes,34,3,3,28,0
-Cherokee,0017 Weir W1,State Treasurer,,REP,Ron Estes,22,0,0,21,1
-Cherokee,0018 Weir W2,State Treasurer,,REP,Ron Estes,45,1,5,38,1
-Cherokee,0019 Weir W3,State Treasurer,,REP,Ron Estes,26,0,5,21,0
-Cherokee,0010 Galena W1,State Treasurer,,,Write-ins,1,0,0,0,1
-Cherokee,0019 Weir W3,State Treasurer,,,Write-ins,1,0,1,0,0
-Cherokee,0001 Baxter Sprs W1,U.S. Senate,,(IND),Greg Orman,52,1,9,42,0
-Cherokee,0002 Baxter Sprs W2,U.S. Senate,,(IND),Greg Orman,50,1,6,39,4
-Cherokee,0003 Baxter Sprs W3,U.S. Senate,,(IND),Greg Orman,117,6,9,99,3
-Cherokee,0004 Baxter Sprs W4,U.S. Senate,,(IND),Greg Orman,49,5,5,34,5
-Cherokee,0005 Columbus W1,U.S. Senate,,(IND),Greg Orman,41,10,4,27,0
-Cherokee,0006 Columbus W2,U.S. Senate,,(IND),Greg Orman,79,6,12,61,0
-Cherokee,0007 Columbus W3,U.S. Senate,,(IND),Greg Orman,71,6,9,55,1
-Cherokee,0008 Columbus W4,U.S. Senate,,(IND),Greg Orman,44,5,10,29,0
-Cherokee,0009 Columbus W5,U.S. Senate,,(IND),Greg Orman,65,4,11,50,0
-Cherokee,0010 Galena W1,U.S. Senate,,(IND),Greg Orman,55,3,6,43,3
-Cherokee,0011 Galena W2,U.S. Senate,,(IND),Greg Orman,31,0,3,28,0
-Cherokee,0012 Galena W3,U.S. Senate,,(IND),Greg Orman,64,0,6,55,3
-Cherokee,0013 Galena W4,U.S. Senate,,(IND),Greg Orman,26,0,2,24,0
-Cherokee,0014 Scammon W1,U.S. Senate,,(IND),Greg Orman,20,1,1,18,0
-Cherokee,0015 Scammon W2,U.S. Senate,,(IND),Greg Orman,17,0,1,16,0
-Cherokee,0016 Scammon W3,U.S. Senate,,(IND),Greg Orman,30,3,4,23,0
-Cherokee,0017 Weir W1,U.S. Senate,,(IND),Greg Orman,17,0,1,14,2
-Cherokee,0018 Weir W2,U.S. Senate,,(IND),Greg Orman,46,0,1,44,1
-Cherokee,0019 Weir W3,U.S. Senate,,(IND),Greg Orman,32,1,5,26,0
-Cherokee,0001 Baxter Sprs W1,U.S. Senate,,REP,Pat Roberts,119,1,6,108,4
-Cherokee,0002 Baxter Sprs W2,U.S. Senate,,REP,Pat Roberts,75,3,4,65,3
-Cherokee,0003 Baxter Sprs W3,U.S. Senate,,REP,Pat Roberts,259,9,10,235,5
-Cherokee,0004 Baxter Sprs W4,U.S. Senate,,REP,Pat Roberts,128,6,10,107,5
-Cherokee,0005 Columbus W1,U.S. Senate,,REP,Pat Roberts,78,4,12,62,0
-Cherokee,0006 Columbus W2,U.S. Senate,,REP,Pat Roberts,157,22,15,120,0
-Cherokee,0007 Columbus W3,U.S. Senate,,REP,Pat Roberts,155,12,15,128,0
-Cherokee,0008 Columbus W4,U.S. Senate,,REP,Pat Roberts,88,9,8,71,0
-Cherokee,0009 Columbus W5,U.S. Senate,,REP,Pat Roberts,104,8,21,74,1
-Cherokee,0010 Galena W1,U.S. Senate,,REP,Pat Roberts,87,2,6,72,7
-Cherokee,0011 Galena W2,U.S. Senate,,REP,Pat Roberts,82,3,9,67,3
-Cherokee,0012 Galena W3,U.S. Senate,,REP,Pat Roberts,136,1,14,120,1
-Cherokee,0013 Galena W4,U.S. Senate,,REP,Pat Roberts,51,0,7,44,0
-Cherokee,0014 Scammon W1,U.S. Senate,,REP,Pat Roberts,16,2,0,13,1
-Cherokee,0015 Scammon W2,U.S. Senate,,REP,Pat Roberts,24,3,5,16,0
-Cherokee,0016 Scammon W3,U.S. Senate,,REP,Pat Roberts,27,1,2,24,0
-Cherokee,0017 Weir W1,U.S. Senate,,REP,Pat Roberts,23,0,0,23,0
-Cherokee,0018 Weir W2,U.S. Senate,,REP,Pat Roberts,45,1,7,37,0
-Cherokee,0019 Weir W3,U.S. Senate,,REP,Pat Roberts,23,0,5,18,0
-Cherokee,0001 Baxter Sprs W1,U.S. Senate,,LIB,Randall Batson,19,1,2,15,1
-Cherokee,0002 Baxter Sprs W2,U.S. Senate,,LIB,Randall Batson,15,1,0,14,0
-Cherokee,0003 Baxter Sprs W3,U.S. Senate,,LIB,Randall Batson,25,0,1,23,1
-Cherokee,0004 Baxter Sprs W4,U.S. Senate,,LIB,Randall Batson,21,0,1,20,0
-Cherokee,0005 Columbus W1,U.S. Senate,,LIB,Randall Batson,18,0,0,17,1
-Cherokee,0006 Columbus W2,U.S. Senate,,LIB,Randall Batson,18,2,2,14,0
-Cherokee,0007 Columbus W3,U.S. Senate,,LIB,Randall Batson,10,0,2,7,1
-Cherokee,0008 Columbus W4,U.S. Senate,,LIB,Randall Batson,11,0,1,10,0
-Cherokee,0009 Columbus W5,U.S. Senate,,LIB,Randall Batson,8,1,1,6,0
-Cherokee,0010 Galena W1,U.S. Senate,,LIB,Randall Batson,13,1,1,11,0
-Cherokee,0011 Galena W2,U.S. Senate,,LIB,Randall Batson,13,0,2,11,0
-Cherokee,0012 Galena W3,U.S. Senate,,LIB,Randall Batson,16,0,2,13,1
-Cherokee,0013 Galena W4,U.S. Senate,,LIB,Randall Batson,12,0,1,11,0
-Cherokee,0014 Scammon W1,U.S. Senate,,LIB,Randall Batson,4,0,0,4,0
-Cherokee,0015 Scammon W2,U.S. Senate,,LIB,Randall Batson,4,0,0,4,0
-Cherokee,0016 Scammon W3,U.S. Senate,,LIB,Randall Batson,4,0,0,4,0
-Cherokee,0017 Weir W1,U.S. Senate,,LIB,Randall Batson,5,1,0,4,0
-Cherokee,0018 Weir W2,U.S. Senate,,LIB,Randall Batson,8,0,0,7,1
-Cherokee,0019 Weir W3,U.S. Senate,,LIB,Randall Batson,4,0,0,4,0
-Cherokee,0003 Baxter Sprs W3,U.S. Senate,,,Write-ins,1,0,0,1,0
-Cherokee,0006 Columbus W2,U.S. Senate,,,Write-ins,1,0,0,1,0
-Cherokee,0008 Columbus W4,U.S. Senate,,,Write-ins,1,0,0,1,0
-Cherokee,0010 Galena W1,U.S. Senate,,,Write-ins,1,0,0,1,0
-Cherokee,0015 Scammon W2,U.S. Senate,,,Write-ins,1,0,1,0,0
-Cherokee,0016 Scammon W3,U.S. Senate,,,Write-ins,1,0,0,1,0
-Cherokee,0001 Baxter Sprs W1,Voters,,,BALLOTS CAST,193,3,18,166,6
-Cherokee,0002 Baxter Sprs W2,Voters,,,BALLOTS CAST,142,5,12,118,7
-Cherokee,0003 Baxter Sprs W3,Voters,,,BALLOTS CAST,410,15,22,364,9
-Cherokee,0004 Baxter Sprs W4,Voters,,,BALLOTS CAST,200,11,16,163,10
-Cherokee,0005 Columbus W1,Voters,,,BALLOTS CAST,137,14,16,106,1
-Cherokee,0006 Columbus W2,Voters,,,BALLOTS CAST,261,31,30,200,0
-Cherokee,0007 Columbus W3,Voters,,,BALLOTS CAST,240,20,27,191,2
-Cherokee,0008 Columbus W4,Voters,,,BALLOTS CAST,145,14,19,112,0
-Cherokee,0009 Columbus W5,Voters,,,BALLOTS CAST,183,14,36,132,1
-Cherokee,0010 Galena W1,Voters,,,BALLOTS CAST,160,6,14,129,11
-Cherokee,0011 Galena W2,Voters,,,BALLOTS CAST,132,3,15,111,3
-Cherokee,0012 Galena W3,Voters,,,BALLOTS CAST,220,1,22,192,5
-Cherokee,0013 Galena W4,Voters,,,BALLOTS CAST,91,0,11,80,0
-Cherokee,0014 Scammon W1,Voters,,,BALLOTS CAST,40,3,1,35,1
-Cherokee,0015 Scammon W2,Voters,,,BALLOTS CAST,47,3,7,37,0
-Cherokee,0016 Scammon W3,Voters,,,BALLOTS CAST,63,4,6,53,0
-Cherokee,0017 Weir W1,Voters,,,BALLOTS CAST,46,1,1,42,2
-Cherokee,0018 Weir W2,Voters,,,BALLOTS CAST,102,1,8,91,2
-Cherokee,0019 Weir W3,Voters,,,BALLOTS CAST,61,1,10,50,0
-Cherokee,0001 Baxter Sprs W1,Voters,,,REGISTERED VOTERS,720,,,,
-Cherokee,0002 Baxter Sprs W2,Voters,,,REGISTERED VOTERS,785,,,,
-Cherokee,0003 Baxter Sprs W3,Voters,,,REGISTERED VOTERS,1186,,,,
-Cherokee,0004 Baxter Sprs W4,Voters,,,REGISTERED VOTERS,899,,,,
-Cherokee,0005 Columbus W1,Voters,,,REGISTERED VOTERS,381,,,,
-Cherokee,0006 Columbus W2,Voters,,,REGISTERED VOTERS,586,,,,
-Cherokee,0007 Columbus W3,Voters,,,REGISTERED VOTERS,556,,,,
-Cherokee,0008 Columbus W4,Voters,,,REGISTERED VOTERS,297,,,,
-Cherokee,0009 Columbus W5,Voters,,,REGISTERED VOTERS,537,,,,
-Cherokee,0010 Galena W1,Voters,,,REGISTERED VOTERS,722,,,,
-Cherokee,0011 Galena W2,Voters,,,REGISTERED VOTERS,531,,,,
-Cherokee,0012 Galena W3,Voters,,,REGISTERED VOTERS,766,,,,
-Cherokee,0013 Galena W4,Voters,,,REGISTERED VOTERS,459,,,,
-Cherokee,0014 Scammon W1,voters,,,REGISTERED VOTERS,73,,,,
-Cherokee,0015 Scammon W2,Voters,,,REGISTERED VOTERS,139,,,,
-Cherokee,0016 Scammon W3,Voters,,,REGISTERED VOTERS,134,,,,
-Cherokee,0017 Weir W1,Voters,,,REGISTERED VOTERS,120,,,,
-Cherokee,0018 Weir W2,Voters,,,REGISTERED VOTERS,271,,,,
-Cherokee,0019 Weir W3,Voters,,,REGISTERED VOTERS,129,,,,
-Cherokee,0020 Cherokee,Attorney General,,DEM,A.J. Kotich,51,0,11,40,0
-Cherokee,0021 Crawford,Attorney General,,DEM,A.J. Kotich,62,2,8,52,0
-Cherokee,0022 Garden-Lowell,Attorney General,,DEM,A.J. Kotich,215,15,38,161,1
-Cherokee,0023 Garden-Stanley Mines,Attorney General,,DEM,A.J. Kotich,46,1,6,39,0
-Cherokee,0024 Lola,Attorney General,,DEM,A.J. Kotich,20,3,6,11,0
-Cherokee,0025 Lowell,Attorney General,,DEM,A.J. Kotich,57,3,10,44,0
-Cherokee,0026 Lyon-Lyon,Attorney General,,DEM,A.J. Kotich,30,2,0,28,0
-Cherokee,0027 Mineral,Attorney General,,DEM,A.J. Kotich,9,0,0,9,0
-Cherokee,0028 Neosho-Faulkner,Attorney General,,DEM,A.J. Kotich,6,0,1,5,0
-Cherokee,0029 Neosho-Melrose,Attorney General,,DEM,A.J. Kotich,12,1,0,11,0
-Cherokee,0030 Pleasant View,Attorney General,,DEM,A.J. Kotich,50,3,8,39,0
-Cherokee,0031 Ross-Belleview,Attorney General,,DEM,A.J. Kotich,27,0,7,20,0
-Cherokee,0032 Ross-Roseland,Attorney General,,DEM,A.J. Kotich,49,2,17,30,0
-Cherokee,0033 Ross-West Mineral,Attorney General,,DEM,A.J. Kotich,45,1,12,31,1
-Cherokee,0034 Salamanca,Attorney General,,DEM,A.J. Kotich,58,8,2,48,0
-Cherokee,0035 Shawnee,Attorney General,,DEM,A.J. Kotich,33,1,5,27,0
-Cherokee,0036 Sheridan,Attorney General,,DEM,A.J. Kotich,25,3,3,19,0
-Cherokee,0037 Spring Valley-Neutral,Attorney General,,DEM,A.J. Kotich,62,3,17,42,0
-Cherokee,0038 Spring Valley-SV,Attorney General,,DEM,A.J. Kotich,34,0,2,31,1
-Cherokee,0020 Cherokee,Attorney General,,REP,Derek Schmidt,85,3,7,75,0
-Cherokee,0021 Crawford,Attorney General,,REP,Derek Schmidt,197,13,14,165,5
-Cherokee,0022 Garden-Lowell,Attorney General,,REP,Derek Schmidt,432,18,21,382,11
-Cherokee,0023 Garden-Stanley Mines,Attorney General,,REP,Derek Schmidt,140,5,10,121,4
-Cherokee,0024 Lola,Attorney General,,REP,Derek Schmidt,73,9,8,55,1
-Cherokee,0025 Lowell,Attorney General,,REP,Derek Schmidt,160,4,14,140,2
-Cherokee,0026 Lyon-Lyon,Attorney General,,REP,Derek Schmidt,103,8,2,93,0
-Cherokee,0027 Mineral,Attorney General,,REP,Derek Schmidt,64,0,5,57,2
-Cherokee,0028 Neosho-Faulkner,Attorney General,,REP,Derek Schmidt,25,2,1,21,1
-Cherokee,0029 Neosho-Melrose,Attorney General,,REP,Derek Schmidt,33,1,3,29,0
-Cherokee,0030 Pleasant View,Attorney General,,REP,Derek Schmidt,158,4,11,143,0
-Cherokee,0031 Ross-Belleview,Attorney General,,REP,Derek Schmidt,44,5,2,37,0
-Cherokee,0032 Ross-Roseland,Attorney General,,REP,Derek Schmidt,55,4,4,47,0
-Cherokee,0033 Ross-West Mineral,Attorney General,,REP,Derek Schmidt,39,3,2,33,1
-Cherokee,0034 Salamanca,Attorney General,,REP,Derek Schmidt,165,11,6,147,1
-Cherokee,0035 Shawnee,Attorney General,,REP,Derek Schmidt,148,13,12,122,1
-Cherokee,0036 Sheridan,Attorney General,,REP,Derek Schmidt,57,5,14,38,0
-Cherokee,0037 Spring Valley-Neutral,Attorney General,,REP,Derek Schmidt,158,9,26,121,2
-Cherokee,0038 Spring Valley-SV,Attorney General,,REP,Derek Schmidt,108,4,6,93,5
-Cherokee,0025 Lowell,Attorney General,,,Write-ins,1,0,0,1,0
-Cherokee,0026 Lyon-Lyon,Attorney General,,,Write-ins,1,0,0,1,0
-Cherokee,0020 Cherokee,U.S. House,2,LIB,Christopher Clemmons,6,0,0,6,0
-Cherokee,0021 Crawford,U.S. House,2,LIB,Christopher Clemmons,17,0,2,14,1
-Cherokee,0022 Garden-Lowell,U.S. House,2,LIB,Christopher Clemmons,31,1,2,28,0
-Cherokee,0023 Garden-Stanley Mines,U.S. House,2,LIB,Christopher Clemmons,17,0,3,14,0
-Cherokee,0024 Lola,U.S. House,2,LIB,Christopher Clemmons,4,0,0,4,0
-Cherokee,0025 Lowell,U.S. House,2,LIB,Christopher Clemmons,10,0,0,10,0
-Cherokee,0026 Lyon-Lyon,U.S. House,2,LIB,Christopher Clemmons,13,2,0,11,0
-Cherokee,0027 Mineral,U.S. House,2,LIB,Christopher Clemmons,3,0,0,3,0
-Cherokee,0028 Neosho-Faulkner,U.S. House,2,LIB,Christopher Clemmons,1,0,0,1,0
-Cherokee,0029 Neosho-Melrose,U.S. House,2,LIB,Christopher Clemmons,1,0,0,1,0
-Cherokee,0030 Pleasant View,U.S. House,2,LIB,Christopher Clemmons,7,0,2,5,0
-Cherokee,0031 Ross-Belleview,U.S. House,2,LIB,Christopher Clemmons,1,0,0,1,0
-Cherokee,0032 Ross-Roseland,U.S. House,2,LIB,Christopher Clemmons,8,1,0,7,0
-Cherokee,0033 Ross-West Mineral,U.S. House,2,LIB,Christopher Clemmons,9,1,2,6,0
-Cherokee,0034 Salamanca,U.S. House,2,LIB,Christopher Clemmons,10,0,1,8,1
-Cherokee,0035 Shawnee,U.S. House,2,LIB,Christopher Clemmons,13,1,0,12,0
-Cherokee,0036 Sheridan,U.S. House,2,LIB,Christopher Clemmons,2,0,1,1,0
-Cherokee,0037 Spring Valley-Neutral,U.S. House,2,LIB,Christopher Clemmons,14,0,5,9,0
-Cherokee,0038 Spring Valley-SV,U.S. House,2,LIB,Christopher Clemmons,4,0,0,3,1
-Cherokee,0020 Cherokee,U.S. House,2,REP,Lynn Jenkins,80,3,6,71,0
-Cherokee,0021 Crawford,U.S. House,2,REP,Lynn Jenkins,188,13,12,159,4
-Cherokee,0022 Garden-Lowell,U.S. House,2,REP,Lynn Jenkins,434,17,21,386,10
-Cherokee,0023 Garden-Stanley Mines,U.S. House,2,REP,Lynn Jenkins,127,4,8,110,5
-Cherokee,0024 Lola,U.S. House,2,REP,Lynn Jenkins,72,9,8,54,1
-Cherokee,0025 Lowell,U.S. House,2,REP,Lynn Jenkins,165,4,16,143,2
-Cherokee,0026 Lyon-Lyon,U.S. House,2,REP,Lynn Jenkins,90,7,2,81,0
-Cherokee,0027 Mineral,U.S. House,2,REP,Lynn Jenkins,62,1,6,53,2
-Cherokee,0028 Neosho-Faulkner,U.S. House,2,REP,Lynn Jenkins,25,2,1,21,1
-Cherokee,0029 Neosho-Melrose,U.S. House,2,REP,Lynn Jenkins,33,1,3,29,0
-Cherokee,0030 Pleasant View,U.S. House,2,REP,Lynn Jenkins,164,4,10,150,0
-Cherokee,0031 Ross-Belleview,U.S. House,2,REP,Lynn Jenkins,38,5,2,31,0
-Cherokee,0032 Ross-Roseland,U.S. House,2,REP,Lynn Jenkins,48,3,3,42,0
-Cherokee,0033 Ross-West Mineral,U.S. House,2,REP,Lynn Jenkins,39,3,2,32,2
-Cherokee,0034 Salamanca,U.S. House,2,REP,Lynn Jenkins,154,8,6,140,0
-Cherokee,0035 Shawnee,U.S. House,2,REP,Lynn Jenkins,138,14,11,112,1
-Cherokee,0036 Sheridan,U.S. House,2,REP,Lynn Jenkins,57,5,14,38,0
-Cherokee,0037 Spring Valley-Neutral,U.S. House,2,REP,Lynn Jenkins,140,8,19,111,2
-Cherokee,0038 Spring Valley-SV,U.S. House,2,REP,Lynn Jenkins,110,3,6,96,5
-Cherokee,0020 Cherokee,U.S. House,2,DEM,Margie Wakefield,53,0,12,41,0
-Cherokee,0021 Crawford,U.S. House,2,DEM,Margie Wakefield,53,2,8,43,0
-Cherokee,0022 Garden-Lowell,U.S. House,2,DEM,Margie Wakefield,188,15,39,132,2
-Cherokee,0023 Garden-Stanley Mines,U.S. House,2,DEM,Margie Wakefield,47,2,5,40,0
-Cherokee,0024 Lola,U.S. House,2,DEM,Margie Wakefield,18,3,6,9,0
-Cherokee,0025 Lowell,U.S. House,2,DEM,Margie Wakefield,46,4,9,33,0
-Cherokee,0026 Lyon-Lyon,U.S. House,2,DEM,Margie Wakefield,32,1,0,31,0
-Cherokee,0027 Mineral,U.S. House,2,DEM,Margie Wakefield,11,0,0,11,0
-Cherokee,0028 Neosho-Faulkner,U.S. House,2,DEM,Margie Wakefield,7,0,1,6,0
-Cherokee,0029 Neosho-Melrose,U.S. House,2,DEM,Margie Wakefield,11,1,0,10,0
-Cherokee,0030 Pleasant View,U.S. House,2,DEM,Margie Wakefield,43,3,8,32,0
-Cherokee,0031 Ross-Belleview,U.S. House,2,DEM,Margie Wakefield,31,0,7,24,0
-Cherokee,0032 Ross-Roseland,U.S. House,2,DEM,Margie Wakefield,47,2,17,28,0
-Cherokee,0033 Ross-West Mineral,U.S. House,2,DEM,Margie Wakefield,37,1,10,26,0
-Cherokee,0034 Salamanca,U.S. House,2,DEM,Margie Wakefield,60,10,1,49,0
-Cherokee,0035 Shawnee,U.S. House,2,DEM,Margie Wakefield,34,1,6,27,0
-Cherokee,0036 Sheridan,U.S. House,2,DEM,Margie Wakefield,23,3,2,18,0
-Cherokee,0037 Spring Valley-Neutral,U.S. House,2,DEM,Margie Wakefield,68,4,18,46,0
-Cherokee,0038 Spring Valley-SV,U.S. House,2,DEM,Margie Wakefield,29,1,1,27,0
-Cherokee,0025 Lowell,U.S. House,2,,Write-ins,1,0,0,1,0
-Cherokee,0020 Cherokee,Governor,,LIB,Keen A. Umbehr,3,0,0,3,0
-Cherokee,0021 Crawford,Governor,,LIB,Keen A. Umbehr,4,0,1,2,1
-Cherokee,0022 Garden-Lowell,Governor,,LIB,Keen A. Umbehr,28,1,1,26,0
-Cherokee,0023 Garden-Stanley Mines,Governor,,LIB,Keen A. Umbehr,6,0,0,5,1
-Cherokee,0024 Lola,Governor,,LIB,Keen A. Umbehr,0,0,0,0,0
-Cherokee,0025 Lowell,Governor,,LIB,Keen A. Umbehr,7,0,0,7,0
-Cherokee,0026 Lyon-Lyon,Governor,,LIB,Keen A. Umbehr,3,1,0,2,0
-Cherokee,0027 Mineral,Governor,,LIB,Keen A. Umbehr,4,0,0,4,0
-Cherokee,0028 Neosho-Faulkner,Governor,,LIB,Keen A. Umbehr,0,0,0,0,0
-Cherokee,0029 Neosho-Melrose,Governor,,LIB,Keen A. Umbehr,0,0,0,0,0
-Cherokee,0030 Pleasant View,Governor,,LIB,Keen A. Umbehr,8,0,0,8,0
-Cherokee,0031 Ross-Belleview,Governor,,LIB,Keen A. Umbehr,1,0,0,1,0
-Cherokee,0032 Ross-Roseland,Governor,,LIB,Keen A. Umbehr,4,0,0,4,0
-Cherokee,0033 Ross-West Mineral,Governor,,LIB,Keen A. Umbehr,5,0,3,2,0
-Cherokee,0034 Salamanca,Governor,,LIB,Keen A. Umbehr,10,0,0,9,1
-Cherokee,0035 Shawnee,Governor,,LIB,Keen A. Umbehr,6,0,0,6,0
-Cherokee,0036 Sheridan,Governor,,LIB,Keen A. Umbehr,3,0,2,1,0
-Cherokee,0037 Spring Valley-Neutral,Governor,,LIB,Keen A. Umbehr,9,0,2,7,0
-Cherokee,0038 Spring Valley-SV,Governor,,LIB,Keen A. Umbehr,6,0,0,6,0
-Cherokee,0020 Cherokee,Governor,,DEM,Paul Davis,67,0,12,55,0
-Cherokee,0021 Crawford,Governor,,DEM,Paul Davis,102,3,12,87,0
-Cherokee,0022 Garden-Lowell,Governor,,DEM,Paul Davis,244,19,42,181,2
-Cherokee,0023 Garden-Stanley Mines,Governor,,DEM,Paul Davis,60,2,3,55,0
-Cherokee,0024 Lola,Governor,,DEM,Paul Davis,30,4,6,20,0
-Cherokee,0025 Lowell,Governor,,DEM,Paul Davis,66,6,11,49,0
-Cherokee,0026 Lyon-Lyon,Governor,,DEM,Paul Davis,38,3,0,35,0
-Cherokee,0027 Mineral,Governor,,DEM,Paul Davis,16,1,0,15,0
-Cherokee,0028 Neosho-Faulkner,Governor,,DEM,Paul Davis,7,0,1,6,0
-Cherokee,0029 Neosho-Melrose,Governor,,DEM,Paul Davis,12,1,0,11,0
-Cherokee,0030 Pleasant View,Governor,,DEM,Paul Davis,66,3,10,53,0
-Cherokee,0031 Ross-Belleview,Governor,,DEM,Paul Davis,32,0,8,24,0
-Cherokee,0032 Ross-Roseland,Governor,,DEM,Paul Davis,53,3,17,33,0
-Cherokee,0033 Ross-West Mineral,Governor,,DEM,Paul Davis,49,4,11,33,1
-Cherokee,0034 Salamanca,Governor,,DEM,Paul Davis,83,13,4,66,0
-Cherokee,0035 Shawnee,Governor,,DEM,Paul Davis,48,1,8,39,0
-Cherokee,0036 Sheridan,Governor,,DEM,Paul Davis,33,3,3,27,0
-Cherokee,0037 Spring Valley-Neutral,Governor,,DEM,Paul Davis,92,6,20,66,0
-Cherokee,0038 Spring Valley-SV,Governor,,DEM,Paul Davis,40,1,3,36,0
-Cherokee,0020 Cherokee,Governor,,REP,Sam Brownback,69,3,6,60,0
-Cherokee,0021 Crawford,Governor,,REP,Sam Brownback,153,12,9,128,4
-Cherokee,0022 Garden-Lowell,Governor,,REP,Sam Brownback,384,13,19,342,10
-Cherokee,0023 Garden-Stanley Mines,Governor,,REP,Sam Brownback,125,4,13,104,4
-Cherokee,0024 Lola,Governor,,REP,Sam Brownback,64,8,8,47,1
-Cherokee,0025 Lowell,Governor,,REP,Sam Brownback,149,2,14,131,2
-Cherokee,0026 Lyon-Lyon,Governor,,REP,Sam Brownback,95,6,2,87,0
-Cherokee,0027 Mineral,Governor,,REP,Sam Brownback,57,0,7,48,2
-Cherokee,0028 Neosho-Faulkner,Governor,,REP,Sam Brownback,26,2,1,22,1
-Cherokee,0029 Neosho-Melrose,Governor,,REP,Sam Brownback,33,1,3,29,0
-Cherokee,0030 Pleasant View,Governor,,REP,Sam Brownback,142,5,10,127,0
-Cherokee,0031 Ross-Belleview,Governor,,REP,Sam Brownback,38,5,1,32,0
-Cherokee,0032 Ross-Roseland,Governor,,REP,Sam Brownback,46,3,4,39,0
-Cherokee,0033 Ross-West Mineral,Governor,,REP,Sam Brownback,32,1,0,30,1
-Cherokee,0034 Salamanca,Governor,,REP,Sam Brownback,133,6,4,123,0
-Cherokee,0035 Shawnee,Governor,,REP,Sam Brownback,131,15,9,106,1
-Cherokee,0036 Sheridan,Governor,,REP,Sam Brownback,46,5,12,29,0
-Cherokee,0037 Spring Valley-Neutral,Governor,,REP,Sam Brownback,119,6,19,92,2
-Cherokee,0038 Spring Valley-SV,Governor,,REP,Sam Brownback,99,3,5,85,6
-Cherokee,0021 Crawford,Governor,,,Write-ins,1,0,0,1,0
-Cherokee,0020 Cherokee,Insurance Commissioner,,DEM,Dennis Anderson,64,0,12,52,0
-Cherokee,0021 Crawford,Insurance Commissioner,,DEM,Dennis Anderson,85,3,10,72,0
-Cherokee,0022 Garden-Lowell,Insurance Commissioner,,DEM,Dennis Anderson,231,16,40,173,2
-Cherokee,0023 Garden-Stanley Mines,Insurance Commissioner,,DEM,Dennis Anderson,57,2,9,46,0
-Cherokee,0024 Lola,Insurance Commissioner,,DEM,Dennis Anderson,27,4,7,16,0
-Cherokee,0025 Lowell,Insurance Commissioner,,DEM,Dennis Anderson,58,3,11,44,0
-Cherokee,0026 Lyon-Lyon,Insurance Commissioner,,DEM,Dennis Anderson,34,2,0,32,0
-Cherokee,0027 Mineral,Insurance Commissioner,,DEM,Dennis Anderson,8,0,0,8,0
-Cherokee,0028 Neosho-Faulkner,Insurance Commissioner,,DEM,Dennis Anderson,9,0,1,8,0
-Cherokee,0029 Neosho-Melrose,Insurance Commissioner,,DEM,Dennis Anderson,13,0,0,13,0
-Cherokee,0030 Pleasant View,Insurance Commissioner,,DEM,Dennis Anderson,53,3,9,41,0
-Cherokee,0031 Ross-Belleview,Insurance Commissioner,,DEM,Dennis Anderson,28,0,7,21,0
-Cherokee,0032 Ross-Roseland,Insurance Commissioner,,DEM,Dennis Anderson,52,4,15,33,0
-Cherokee,0033 Ross-West Mineral,Insurance Commissioner,,DEM,Dennis Anderson,47,2,13,32,0
-Cherokee,0034 Salamanca,Insurance Commissioner,,DEM,Dennis Anderson,79,9,6,64,0
-Cherokee,0035 Shawnee,Insurance Commissioner,,DEM,Dennis Anderson,49,0,8,41,0
-Cherokee,0036 Sheridan,Insurance Commissioner,,DEM,Dennis Anderson,29,3,4,22,0
-Cherokee,0037 Spring Valley-Neutral,Insurance Commissioner,,DEM,Dennis Anderson,77,5,20,52,0
-Cherokee,0038 Spring Valley-SV,Insurance Commissioner,,DEM,Dennis Anderson,38,1,2,35,0
-Cherokee,0020 Cherokee,Insurance Commissioner,,REP,Ken Selzer,72,3,6,63,0
-Cherokee,0021 Crawford,Insurance Commissioner,,REP,Ken Selzer,165,12,12,137,4
-Cherokee,0022 Garden-Lowell,Insurance Commissioner,,REP,Ken Selzer,403,16,20,359,8
-Cherokee,0023 Garden-Stanley Mines,Insurance Commissioner,,REP,Ken Selzer,131,4,7,116,4
-Cherokee,0024 Lola,Insurance Commissioner,,REP,Ken Selzer,65,8,7,49,1
-Cherokee,0025 Lowell,Insurance Commissioner,,REP,Ken Selzer,158,4,13,139,2
-Cherokee,0026 Lyon-Lyon,Insurance Commissioner,,REP,Ken Selzer,98,8,2,88,0
-Cherokee,0027 Mineral,Insurance Commissioner,,REP,Ken Selzer,62,0,4,56,2
-Cherokee,0028 Neosho-Faulkner,Insurance Commissioner,,REP,Ken Selzer,22,2,1,18,1
-Cherokee,0029 Neosho-Melrose,Insurance Commissioner,,REP,Ken Selzer,30,1,3,26,0
-Cherokee,0030 Pleasant View,Insurance Commissioner,,REP,Ken Selzer,151,4,9,138,0
-Cherokee,0031 Ross-Belleview,Insurance Commissioner,,REP,Ken Selzer,42,5,2,35,0
-Cherokee,0032 Ross-Roseland,Insurance Commissioner,,REP,Ken Selzer,50,2,4,44,0
-Cherokee,0033 Ross-West Mineral,Insurance Commissioner,,REP,Ken Selzer,37,2,1,32,2
-Cherokee,0034 Salamanca,Insurance Commissioner,,REP,Ken Selzer,141,9,2,129,1
-Cherokee,0035 Shawnee,Insurance Commissioner,,REP,Ken Selzer,130,14,9,106,1
-Cherokee,0036 Sheridan,Insurance Commissioner,,REP,Ken Selzer,52,4,13,35,0
-Cherokee,0037 Spring Valley-Neutral,Insurance Commissioner,,REP,Ken Selzer,140,6,23,109,2
-Cherokee,0038 Spring Valley-SV,Insurance Commissioner,,REP,Ken Selzer,99,0,6,84,6
-Cherokee,0021 Crawford,Insurance Commissioner,,,Write-ins,2,0,0,2,0
-Cherokee,0025 Lowell,Insurance Commissioner,,,Write-ins,1,0,0,1,0
-Cherokee,0035 Shawnee,Insurance Commissioner,,,Write-ins,1,0,0,1,0
-Cherokee,0037 Spring Valley-Neutral,Insurance Commissioner,,,Write-ins,1,0,0,1,0
-Cherokee,0038 Spring Valley-SV,Insurance Commissioner,,,Write-ins,2,0,0,2,0
-Cherokee,0020 Cherokee,Secretary of State,,DEM,Jean Kurtis Schodorf,58,0,12,46,0
-Cherokee,0021 Crawford,Secretary of State,,DEM,Jean Kurtis Schodorf,74,1,10,63,0
-Cherokee,0022 Garden-Lowell,Secretary of State,,DEM,Jean Kurtis Schodorf,220,14,39,167,0
-Cherokee,0023 Garden-Stanley Mines,Secretary of State,,DEM,Jean Kurtis Schodorf,49,1,8,39,1
-Cherokee,0024 Lola,Secretary of State,,DEM,Jean Kurtis Schodorf,28,3,6,18,1
-Cherokee,0025 Lowell,Secretary of State,,DEM,Jean Kurtis Schodorf,60,3,10,47,0
-Cherokee,0026 Lyon-Lyon,Secretary of State,,DEM,Jean Kurtis Schodorf,40,3,0,37,0
-Cherokee,0027 Mineral,Secretary of State,,DEM,Jean Kurtis Schodorf,16,0,0,16,0
-Cherokee,0028 Neosho-Faulkner,Secretary of State,,DEM,Jean Kurtis Schodorf,7,0,1,6,0
-Cherokee,0029 Neosho-Melrose,Secretary of State,,DEM,Jean Kurtis Schodorf,11,1,0,10,0
-Cherokee,0030 Pleasant View,Secretary of State,,DEM,Jean Kurtis Schodorf,56,3,9,44,0
-Cherokee,0031 Ross-Belleview,Secretary of State,,DEM,Jean Kurtis Schodorf,30,0,8,22,0
-Cherokee,0032 Ross-Roseland,Secretary of State,,DEM,Jean Kurtis Schodorf,51,3,16,32,0
-Cherokee,0033 Ross-West Mineral,Secretary of State,,DEM,Jean Kurtis Schodorf,44,2,12,29,1
-Cherokee,0034 Salamanca,Secretary of State,,DEM,Jean Kurtis Schodorf,72,9,3,60,0
-Cherokee,0035 Shawnee,Secretary of State,,DEM,Jean Kurtis Schodorf,42,0,6,36,0
-Cherokee,0036 Sheridan,Secretary of State,,DEM,Jean Kurtis Schodorf,27,3,4,20,0
-Cherokee,0037 Spring Valley-Neutral,Secretary of State,,DEM,Jean Kurtis Schodorf,65,4,16,45,0
-Cherokee,0038 Spring Valley-SV,Secretary of State,,DEM,Jean Kurtis Schodorf,34,1,2,31,0
-Cherokee,0020 Cherokee,Secretary of State,,REP,Kris Kobach,78,3,6,69,0
-Cherokee,0021 Crawford,Secretary of State,,REP,Kris Kobach,182,14,12,151,5
-Cherokee,0022 Garden-Lowell,Secretary of State,,REP,Kris Kobach,427,19,21,376,11
-Cherokee,0023 Garden-Stanley Mines,Secretary of State,,REP,Kris Kobach,138,5,8,122,3
-Cherokee,0024 Lola,Secretary of State,,REP,Kris Kobach,65,9,8,48,0
-Cherokee,0025 Lowell,Secretary of State,,REP,Kris Kobach,157,4,15,136,2
-Cherokee,0026 Lyon-Lyon,Secretary of State,,REP,Kris Kobach,93,7,2,84,0
-Cherokee,0027 Mineral,Secretary of State,,REP,Kris Kobach,57,0,5,50,2
-Cherokee,0028 Neosho-Faulkner,Secretary of State,,REP,Kris Kobach,24,2,1,20,1
-Cherokee,0029 Neosho-Melrose,Secretary of State,,REP,Kris Kobach,34,1,3,30,0
-Cherokee,0030 Pleasant View,Secretary of State,,REP,Kris Kobach,155,5,9,141,0
-Cherokee,0031 Ross-Belleview,Secretary of State,,REP,Kris Kobach,40,5,1,34,0
-Cherokee,0032 Ross-Roseland,Secretary of State,,REP,Kris Kobach,52,3,4,45,0
-Cherokee,0033 Ross-West Mineral,Secretary of State,,REP,Kris Kobach,39,1,2,35,1
-Cherokee,0034 Salamanca,Secretary of State,,REP,Kris Kobach,150,9,5,135,1
-Cherokee,0035 Shawnee,Secretary of State,,REP,Kris Kobach,138,14,11,112,1
-Cherokee,0036 Sheridan,Secretary of State,,REP,Kris Kobach,55,5,13,37,0
-Cherokee,0037 Spring Valley-Neutral,Secretary of State,,REP,Kris Kobach,157,8,27,120,2
-Cherokee,0038 Spring Valley-SV,Secretary of State,,REP,Kris Kobach,108,3,6,93,6
-Cherokee,0025 Lowell,Secretary of State,,,Write-ins,1,0,0,1,0
-Cherokee,0032 Ross-Roseland,Secretary of State,,,Write-ins,1,0,1,0,0
-Cherokee,0037 Spring Valley-Neutral,Secretary of State,,,Write-ins,1,0,0,1,0
-Cherokee,0020 Cherokee,State House,1,DEM,Brian Caswell,71,0,12,59,0
-Cherokee,0021 Crawford,State House,1,DEM,Brian Caswell,80,2,8,70,0
-Cherokee,0022 Garden-Lowell,State House,1,DEM,Brian Caswell,267,15,44,206,2
-Cherokee,0023 Garden-Stanley Mines,State House,1,DEM,Brian Caswell,77,3,7,64,3
-Cherokee,0024 Lola,State House,1,DEM,Brian Caswell,22,2,5,15,0
-Cherokee,0025 Lowell,State House,1,DEM,Brian Caswell,62,5,9,48,0
-Cherokee,0026 Lyon-Lyon,State House,1,DEM,Brian Caswell,41,3,0,38,0
-Cherokee,0027 Mineral,State House,1,DEM,Brian Caswell,22,0,5,17,0
-Cherokee,0028 Neosho-Faulkner,State House,1,DEM,Brian Caswell,12,0,1,11,0
-Cherokee,0029 Neosho-Melrose,State House,1,DEM,Brian Caswell,16,1,0,15,0
-Cherokee,0030 Pleasant View,State House,1,DEM,Brian Caswell,70,3,11,56,0
-Cherokee,0031 Ross-Belleview,State House,1,DEM,Brian Caswell,30,0,8,22,0
-Cherokee,0032 Ross-Roseland,State House,1,DEM,Brian Caswell,55,3,16,36,0
-Cherokee,0033 Ross-West Mineral,State House,1,DEM,Brian Caswell,48,4,14,30,0
-Cherokee,0034 Salamanca,State House,1,DEM,Brian Caswell,84,11,3,69,1
-Cherokee,0035 Shawnee,State House,1,DEM,Brian Caswell,41,1,8,32,0
-Cherokee,0036 Sheridan,State House,1,DEM,Brian Caswell,25,3,3,19,0
-Cherokee,0037 Spring Valley-Neutral,State House,1,DEM,Brian Caswell,87,5,23,59,0
-Cherokee,0038 Spring Valley-SV,State House,1,DEM,Brian Caswell,55,1,3,49,2
-Cherokee,0020 Cherokee,State House,1,REP,Michael Houser,67,3,5,59,0
-Cherokee,0021 Crawford,State House,1,REP,Michael Houser,179,13,15,146,5
-Cherokee,0022 Garden-Lowell,State House,1,REP,Michael Houser,384,18,17,339,10
-Cherokee,0023 Garden-Stanley Mines,State House,1,REP,Michael Houser,110,3,10,95,2
-Cherokee,0024 Lola,State House,1,REP,Michael Houser,71,10,9,51,1
-Cherokee,0025 Lowell,State House,1,REP,Michael Houser,158,3,16,137,2
-Cherokee,0026 Lyon-Lyon,State House,1,REP,Michael Houser,94,7,2,85,0
-Cherokee,0027 Mineral,State House,1,REP,Michael Houser,53,1,1,49,2
-Cherokee,0028 Neosho-Faulkner,State House,1,REP,Michael Houser,20,2,1,16,1
-Cherokee,0029 Neosho-Melrose,State House,1,REP,Michael Houser,28,1,3,24,0
-Cherokee,0030 Pleasant View,State House,1,REP,Michael Houser,142,5,9,128,0
-Cherokee,0031 Ross-Belleview,State House,1,REP,Michael Houser,41,5,1,35,0
-Cherokee,0032 Ross-Roseland,State House,1,REP,Michael Houser,46,3,4,39,0
-Cherokee,0033 Ross-West Mineral,State House,1,REP,Michael Houser,37,1,0,34,2
-Cherokee,0034 Salamanca,State House,1,REP,Michael Houser,141,8,5,128,0
-Cherokee,0035 Shawnee,State House,1,REP,Michael Houser,139,14,9,115,1
-Cherokee,0036 Sheridan,State House,1,REP,Michael Houser,57,5,14,38,0
-Cherokee,0037 Spring Valley-Neutral,State House,1,REP,Michael Houser,135,7,19,107,2
-Cherokee,0038 Spring Valley-SV,State House,1,REP,Michael Houser,90,3,5,78,4
-Cherokee,0022 Garden-Lowell,State House,1,,Write-ins,1,0,0,1,0
-Cherokee,0023 Garden-Stanley Mines,State House,1,,Write-ins,1,0,0,1,0
-Cherokee,0025 Lowell,State House,1,,Write-ins,1,0,0,1,0
-Cherokee,0026 Lyon-Lyon,State House,1,,Write-ins,1,0,0,1,0
-Cherokee,0029 Neosho-Melrose,State House,1,,Write-ins,1,0,0,1,0
-Cherokee,0020 Cherokee,State Treasurer,,DEM,Carmen Alldritt,54,0,10,44,0
-Cherokee,0021 Crawford,State Treasurer,,DEM,Carmen Alldritt,76,2,9,65,0
-Cherokee,0022 Garden-Lowell,State Treasurer,,DEM,Carmen Alldritt,211,15,36,159,1
-Cherokee,0023 Garden-Stanley Mines,State Treasurer,,DEM,Carmen Alldritt,44,1,6,37,0
-Cherokee,0024 Lola,State Treasurer,,DEM,Carmen Alldritt,20,2,5,13,0
-Cherokee,0025 Lowell,State Treasurer,,DEM,Carmen Alldritt,54,3,8,43,0
-Cherokee,0026 Lyon-Lyon,State Treasurer,,DEM,Carmen Alldritt,33,2,0,31,0
-Cherokee,0027 Mineral,State Treasurer,,DEM,Carmen Alldritt,7,0,0,7,0
-Cherokee,0028 Neosho-Faulkner,State Treasurer,,DEM,Carmen Alldritt,7,0,1,6,0
-Cherokee,0029 Neosho-Melrose,State Treasurer,,DEM,Carmen Alldritt,9,1,0,8,0
-Cherokee,0030 Pleasant View,State Treasurer,,DEM,Carmen Alldritt,48,1,8,39,0
-Cherokee,0031 Ross-Belleview,State Treasurer,,DEM,Carmen Alldritt,29,0,7,22,0
-Cherokee,0032 Ross-Roseland,State Treasurer,,DEM,Carmen Alldritt,45,3,16,26,0
-Cherokee,0033 Ross-West Mineral,State Treasurer,,DEM,Carmen Alldritt,47,3,12,31,1
-Cherokee,0034 Salamanca,State Treasurer,,DEM,Carmen Alldritt,64,8,5,51,0
-Cherokee,0035 Shawnee,State Treasurer,,DEM,Carmen Alldritt,39,0,7,32,0
-Cherokee,0036 Sheridan,State Treasurer,,DEM,Carmen Alldritt,30,3,3,24,0
-Cherokee,0037 Spring Valley-Neutral,State Treasurer,,DEM,Carmen Alldritt,70,5,18,47,0
-Cherokee,0038 Spring Valley-SV,State Treasurer,,DEM,Carmen Alldritt,38,1,2,35,0
-Cherokee,0020 Cherokee,State Treasurer,,REP,Ron Estes,83,3,8,72,0
-Cherokee,0021 Crawford,State Treasurer,,REP,Ron Estes,182,13,13,151,5
-Cherokee,0022 Garden-Lowell,State Treasurer,,REP,Ron Estes,437,18,23,386,10
-Cherokee,0023 Garden-Stanley Mines,State Treasurer,,REP,Ron Estes,140,5,9,122,4
-Cherokee,0024 Lola,State Treasurer,,REP,Ron Estes,73,10,9,53,1
-Cherokee,0025 Lowell,State Treasurer,,REP,Ron Estes,163,4,15,142,2
-Cherokee,0026 Lyon-Lyon,State Treasurer,,REP,Ron Estes,102,8,2,92,0
-Cherokee,0027 Mineral,State Treasurer,,REP,Ron Estes,65,0,5,58,2
-Cherokee,0028 Neosho-Faulkner,State Treasurer,,REP,Ron Estes,24,2,1,20,1
-Cherokee,0029 Neosho-Melrose,State Treasurer,,REP,Ron Estes,35,1,3,31,0
-Cherokee,0030 Pleasant View,State Treasurer,,REP,Ron Estes,161,6,12,143,0
-Cherokee,0031 Ross-Belleview,State Treasurer,,REP,Ron Estes,42,5,2,35,0
-Cherokee,0032 Ross-Roseland,State Treasurer,,REP,Ron Estes,59,3,5,51,0
-Cherokee,0033 Ross-West Mineral,State Treasurer,,REP,Ron Estes,38,2,2,33,1
-Cherokee,0034 Salamanca,State Treasurer,,REP,Ron Estes,158,10,3,144,1
-Cherokee,0035 Shawnee,State Treasurer,,REP,Ron Estes,139,13,10,115,1
-Cherokee,0036 Sheridan,State Treasurer,,REP,Ron Estes,52,5,14,33,0
-Cherokee,0037 Spring Valley-Neutral,State Treasurer,,REP,Ron Estes,150,7,25,116,2
-Cherokee,0038 Spring Valley-SV,State Treasurer,,REP,Ron Estes,103,6,3,6,88
-Cherokee,0020 Cherokee,U.S. Senate,,(IND),Greg Orman,55,0,12,43,0
-Cherokee,0021 Crawford,U.S. Senate,,(IND),Greg Orman,63,2,8,53,0
-Cherokee,0022 Garden-Lowell,U.S. Senate,,(IND),Greg Orman,201,11,31,157,2
-Cherokee,0023 Garden-Stanley Mines,U.S. Senate,,(IND),Greg Orman,50,1,4,44,1
-Cherokee,0024 Lola,U.S. Senate,,(IND),Greg Orman,23,3,4,16,0
-Cherokee,0025 Lowell,U.S. Senate,,(IND),Greg Orman,55,3,9,43,0
-Cherokee,0026 Lyon-Lyon,U.S. Senate,,(IND),Greg Orman,29,2,0,27,0
-Cherokee,0027 Mineral,U.S. Senate,,(IND),Greg Orman,15,0,0,15,0
-Cherokee,0028 Neosho-Faulkner,U.S. Senate,,(IND),Greg Orman,6,0,0,6,0
-Cherokee,0029 Neosho-Melrose,U.S. Senate,,(IND),Greg Orman,8,0,0,8,0
-Cherokee,0030 Pleasant View,U.S. Senate,,(IND),Greg Orman,55,3,8,44,0
-Cherokee,0031 Ross-Belleview,U.S. Senate,,(IND),Greg Orman,27,0,7,20,0
-Cherokee,0032 Ross-Roseland,U.S. Senate,,(IND),Greg Orman,41,2,10,29,0
-Cherokee,0033 Ross-West Mineral,U.S. Senate,,(IND),Greg Orman,36,2,7,27,0
-Cherokee,0034 Salamanca,U.S. Senate,,(IND),Greg Orman,67,9,2,56,0
-Cherokee,0035 Shawnee,U.S. Senate,,(IND),Greg Orman,45,0,9,36,0
-Cherokee,0036 Sheridan,U.S. Senate,,(IND),Greg Orman,19,3,2,14,0
-Cherokee,0037 Spring Valley-Neutral,U.S. Senate,,(IND),Greg Orman,63,4,13,46,0
-Cherokee,0038 Spring Valley-SV,U.S. Senate,,(IND),Greg Orman,36,0,2,34,0
-Cherokee,0020 Cherokee,U.S. Senate,,REP,Pat Roberts,72,3,6,63,0
-Cherokee,0021 Crawford,U.S. Senate,,REP,Pat Roberts,172,13,11,144,4
-Cherokee,0022 Garden-Lowell,U.S. Senate,,REP,Pat Roberts,385,19,24,333,9
-Cherokee,0023 Garden-Stanley Mines,U.S. Senate,,REP,Pat Roberts,124,4,10,106,4
-Cherokee,0024 Lola,U.S. Senate,,REP,Pat Roberts,64,8,9,46,1
-Cherokee,0025 Lowell,U.S. Senate,,REP,Pat Roberts,147,4,14,127,2
-Cherokee,0026 Lyon-Lyon,U.S. Senate,,REP,Pat Roberts,94,7,2,85,0
-Cherokee,0027 Mineral,U.S. Senate,,REP,Pat Roberts,57,1,6,48,2
-Cherokee,0028 Neosho-Faulkner,U.S. Senate,,REP,Pat Roberts,25,2,1,21,1
-Cherokee,0029 Neosho-Melrose,U.S. Senate,,REP,Pat Roberts,29,1,3,25,0
-Cherokee,0030 Pleasant View,U.S. Senate,,REP,Pat Roberts,145,5,8,132,0
-Cherokee,0031 Ross-Belleview,U.S. Senate,,REP,Pat Roberts,38,5,2,31,0
-Cherokee,0032 Ross-Roseland,U.S. Senate,,REP,Pat Roberts,51,3,5,43,0
-Cherokee,0033 Ross-West Mineral,U.S. Senate,,REP,Pat Roberts,38,2,3,31,2
-Cherokee,0034 Salamanca,U.S. Senate,,REP,Pat Roberts,142,8,6,128,0
-Cherokee,0035 Shawnee,U.S. Senate,,REP,Pat Roberts,128,15,8,104,1
-Cherokee,0036 Sheridan,U.S. Senate,,REP,Pat Roberts,53,5,13,35,0
-Cherokee,0037 Spring Valley-Neutral,U.S. Senate,,REP,Pat Roberts,136,6,24,104,2
-Cherokee,0038 Spring Valley-SV,U.S. Senate,,REP,Pat Roberts,98,4,6,82,6
-Cherokee,0020 Cherokee,U.S. Senate,,LIB,Randall Batson,9,0,0,9,0
-Cherokee,0021 Crawford,U.S. Senate,,LIB,Randall Batson,19,0,2,16,1
-Cherokee,0022 Garden-Lowell,U.S. Senate,,LIB,Randall Batson,58,3,5,50,0
-Cherokee,0023 Garden-Stanley Mines,U.S. Senate,,LIB,Randall Batson,15,1,2,12,0
-Cherokee,0024 Lola,U.S. Senate,,LIB,Randall  Batson,4,0,0,4,0
-Cherokee,0025 Lowell,U.S. Senate,,LIB,Randall Batson,19,1,2,16,0
-Cherokee,0026 Lyon-Lyon,U.S. Senate,,LIB,Randall Batson,11,1,0,10,0
-Cherokee,0027 Mineral,U.S. Senate,,LIB,Randall Batson,4,0,0,4,0
-Cherokee,0028 Neosho-Faulkner,U.S. Senate,,LIB,Randall Batson,0,0,0,0,0
-Cherokee,0029 Neosho-Melrose,U.S. Senate,,LIB,Randall  Batson,4,0,0,4,0
-Cherokee,0030 Pleasant View,U.S. Senate,,LIB,Randall Batson,11,0,2,9,0
-Cherokee,0034 Salamanca,U.S. Senate,,LIB,Randall  Batson,12,0,0,11,1
-Cherokee,0031 Ross-Belleview,U.S. Senate,,LIB,Randall Batson,4,0,0,4,0
-Cherokee,0032 Ross-Roseland,U.S. Senate,,LIB,Randall Batson,6,1,0,5,0
-Cherokee,0033 Ross-West Mineral,U.S. Senate,,LIB,Randall Batson,9,0,2,7,0
-Cherokee,0035 Shawnee,U.S. Senate,,LIB,Randall Batson,8,1,0,7,0
-Cherokee,0036 Sheridan,U.S. Senate,,LIB,Randall Batson,10,0,2,8,0
-Cherokee,0037 Spring Valley-Neutral,U.S. Senate,,LIB,Randall Batson,21,2,4,15,0
-Cherokee,0038 Spring Valley-SV,U.S. Senate,,LIB,Randall Batson,7,0,0,7,0
-Cherokee,0020 Cherokee,U.S. Senate,,,Write-ins,1,0,0,1,0
-Cherokee,0022 Garden-Lowell,U.S. Senate,,,Write-ins,2,0,0,1,1
-Cherokee,0023 Garden-Stanley Mines,U.S. Senate,,,Write-ins,2,0,0,2,0
-Cherokee,0029 Neosho-Melrose,U.S. Senate,,,Write-ins,1,0,0,1,0
-Cherokee,0030 Pleasant View,U.S. Senate,,,Write-ins,2,0,0,2,0
-Cherokee,0032 Ross-Roseland,U.S. Senate,,,Write-ins,1,0,1,0,0
-Cherokee,0020 Cherokee,Votes,,,BALLOTS CAST,139,3,18,118,0
-Cherokee,0021 Crawford,Votes,,,BALLOTS CAST,261,15,23,218,5
-Cherokee,0022 Garden-Lowell,Votes,,,BALLOTS CAST,659,33,62,552,12
-Cherokee,0023 Garden-Stanley Mines,Votes,,,BALLOTS CAST,192,6,17,164,5
-Cherokee,0024 Lola,Votes,,,BALLOTS CAST,94,12,14,67,1
-Cherokee,0025 Lowell,Votes,,,BALLOTS CAST,222,8,25,187,2
-Cherokee,0026 Lyon-Lyon,Votes,,,BALLOTS CAST,136,10,2,124,0
-Cherokee,0027 Mineral,Votes,,,BALLOTS CAST,77,1,7,67,2
-Cherokee,0028 Neosho-Faulkner,Votes,,,BALLOTS CAST,33,2,2,28,1
-Cherokee,0029 Neosho-Melrose,Votes,,,BALLOTS CAST,45,2,3,40,0
-Cherokee,0030 Pleasant View,Votes,,,BALLOTS CAST,216,8,20,188,0
-Cherokee,0031 Ross-Belleview,Votes,,,BALLOTS CAST,71,5,9,57,0
-Cherokee,0032 Ross-Roseland,Votes,,,BALLOTS CAST,104,6,21,77,0
-Cherokee,0033 Ross-West Mineral,Votes,,,BALLOTS CAST,86,5,14,65,2
-Cherokee,0034 Salamanca,Votes,,,BALLOTS CAST,226,19,8,198,1
-Cherokee,0035 Shawnee,Votes,,,BALLOTS CAST,185,16,17,151,1
-Cherokee,0036 Sheridan,Votes,,,BALLOTS CAST,82,8,17,57,0
-Cherokee,0037 Spring Valley-Neutral,Votes,,,BALLOTS CAST,223,12,43,166,2
-Cherokee,0038 Spring Valley-SV,Votes,,,BALLOTS CAST,145,4,8,127,6
-Cherokee,0020 Cherokee,Votes,,,REGISTERED VOTERS,228,,,,
-Cherokee,0021 Crawford,Votes,,,REGISTERED VOTERS,465,,,,
-Cherokee,0022 Garden-Lowell,Votes,,,REGISTERED VOTERS,1791,,,,
-Cherokee,0023 Garden-Stanley Mines,Votes,,,REGISTERED VOTERS,479,,,,
-Cherokee,0024 Lola,Votes,,,REGISTERED VOTERS,244,,,,
-Cherokee,0025 Lowell,Votes,,,REGISTERED VOTERS,525,,,,
-Cherokee,0026 Lyon-Lyon,Votes,,,REGISTERED VOTERS,316,,,,
-Cherokee,0027 Mineral,Votes,,,REGISTERED VOTERS,150,,,,
-Cherokee,0028 Neosho-Faulkner,Votes,,,REGISTERED VOTERS,81,,,,
-Cherokee,0029 Neosho-Melrose,Votes,,,REGISTERED VOTERS,123,,,,
-Cherokee,0030 Pleasant View,Votes,,,REGISTERED VOTERS,466,,,,
-Cherokee,0031 Ross-Belleview,Votes,,,REGISTERED VOTERS,145,,,,
-Cherokee,0032 Ross-Roseland,Votes,,,REGISTERED VOTERS,198,,,,
-Cherokee,0033 Ross-West Mineral,Votes,,,REGISTERED VOTERS,184,,,,
-Cherokee,0034 Salamanca,Votes,,,REGISTERED VOTERS,415,,,,
-Cherokee,0035 Shawnee,Votes,,,REGISTERED VOTERS,390,,,,
-Cherokee,0036 Sheridan,Votes,,,REGISTERED VOTERS,149,,,,
-Cherokee,0037 Spring Valley-Neutral,Votes,,,REGISTERED VOTERS,468,,,,
-Cherokee,0038 Spring Valley-SV,Votes,,,REGISTERED VOTERS,344,,,,
+county,precinct,office,district,party,candidate,votes,vtd
+CHEROKEE,Baxter Springs Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",61,000010
+CHEROKEE,Baxter Springs Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000010
+CHEROKEE,Baxter Springs Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000010
+CHEROKEE,Baxter Springs Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000020
+CHEROKEE,Baxter Springs Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000020
+CHEROKEE,Baxter Springs Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000020
+CHEROKEE,Baxter Springs Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",146,000030
+CHEROKEE,Baxter Springs Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000030
+CHEROKEE,Baxter Springs Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",249,000030
+CHEROKEE,Baxter Springs Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",68,00004A
+CHEROKEE,Baxter Springs Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00004A
+CHEROKEE,Baxter Springs Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",118,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00004B
+CHEROKEE,Cherokee Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000050
+CHEROKEE,Cherokee Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000050
+CHEROKEE,Cherokee Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000050
+CHEROKEE,Columbus Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",51,000060
+CHEROKEE,Columbus Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000060
+CHEROKEE,Columbus Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000060
+CHEROKEE,Columbus Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",104,000070
+CHEROKEE,Columbus Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000070
+CHEROKEE,Columbus Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",150,000070
+CHEROKEE,Columbus Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,000080
+CHEROKEE,Columbus Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000080
+CHEROKEE,Columbus Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000080
+CHEROKEE,Columbus Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000090
+CHEROKEE,Columbus Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000090
+CHEROKEE,Columbus Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,000090
+CHEROKEE,Columbus Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",79,00010A
+CHEROKEE,Columbus Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00010A
+CHEROKEE,Columbus Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00010B
+CHEROKEE,Crawford Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",102,000110
+CHEROKEE,Crawford Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000110
+CHEROKEE,Crawford Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",153,000110
+CHEROKEE,Galena Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",60,000120
+CHEROKEE,Galena Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000120
+CHEROKEE,Galena Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",90,000120
+CHEROKEE,Galena Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,00013A
+CHEROKEE,Galena Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00013A
+CHEROKEE,Galena Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013D
+CHEROKEE,Galena Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000140
+CHEROKEE,Galena Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000140
+CHEROKEE,Galena Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,000140
+CHEROKEE,Galena Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,00015A
+CHEROKEE,Galena Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00015A
+CHEROKEE,Galena Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,00015A
+CHEROKEE,Galena Ward 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00015B
+CHEROKEE,Garden Township Lowell,Governor / Lt. Governor,,Democratic,"Davis, Paul",244,000170
+CHEROKEE,Garden Township Lowell,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000170
+CHEROKEE,Garden Township Lowell,Governor / Lt. Governor,,Republican,"Brownback, Sam",384,000170
+CHEROKEE,Garden Township Stanley Mine,Governor / Lt. Governor,,Democratic,"Davis, Paul",60,00018A
+CHEROKEE,Garden Township Stanley Mine,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00018A
+CHEROKEE,Garden Township Stanley Mine,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018C
+CHEROKEE,Lola Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000190
+CHEROKEE,Lola Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000190
+CHEROKEE,Lola Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000190
+CHEROKEE,Lowell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,000200
+CHEROKEE,Lowell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000200
+CHEROKEE,Lowell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",149,000200
+CHEROKEE,Mineral Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000220
+CHEROKEE,Mineral Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000220
+CHEROKEE,Mineral Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000220
+CHEROKEE,Neosho Township Faulkner,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000230
+CHEROKEE,Neosho Township Faulkner,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+CHEROKEE,Neosho Township Faulkner,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000230
+CHEROKEE,Neosho Township Melrose,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000240
+CHEROKEE,Neosho Township Melrose,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000240
+CHEROKEE,Neosho Township Melrose,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000240
+CHEROKEE,Pleasant View Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,000250
+CHEROKEE,Pleasant View Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000250
+CHEROKEE,Pleasant View Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",142,000250
+CHEROKEE,Roseland City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000260
+CHEROKEE,Roseland City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000260
+CHEROKEE,Roseland City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000260
+CHEROKEE,Ross Township Belleview,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000270
+CHEROKEE,Ross Township Belleview,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000270
+CHEROKEE,Ross Township Belleview,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000270
+CHEROKEE,Ross Township Roseland,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000280
+CHEROKEE,Ross Township Roseland,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000280
+CHEROKEE,Ross Township Roseland,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000280
+CHEROKEE,Ross Township West Mineral,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000290
+CHEROKEE,Ross Township West Mineral,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000290
+CHEROKEE,Ross Township West Mineral,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000290
+CHEROKEE,Salamanca Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",83,00030A
+CHEROKEE,Salamanca Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,00030A
+CHEROKEE,Salamanca Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,00030A
+CHEROKEE,Salamanca Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00030B
+CHEROKEE,Salamanca Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00030B
+CHEROKEE,Salamanca Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00030B
+CHEROKEE,Scammon Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000310
+CHEROKEE,Scammon Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000310
+CHEROKEE,Scammon Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000310
+CHEROKEE,Scammon Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000320
+CHEROKEE,Scammon Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000320
+CHEROKEE,Scammon Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000320
+CHEROKEE,Scammon Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000330
+CHEROKEE,Scammon Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000330
+CHEROKEE,Scammon Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000330
+CHEROKEE,Shawnee Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000340
+CHEROKEE,Shawnee Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000340
+CHEROKEE,Shawnee Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",131,000340
+CHEROKEE,Sheridan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000350
+CHEROKEE,Sheridan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000350
+CHEROKEE,Sheridan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000350
+CHEROKEE,Spring Valley Township Neutral,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000360
+CHEROKEE,Spring Valley Township Neutral,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000360
+CHEROKEE,Spring Valley Township Neutral,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000360
+CHEROKEE,Spring Valley Township Spring Valley,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00037C
+CHEROKEE,Weir Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,00039A
+CHEROKEE,Weir Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00039A
+CHEROKEE,Weir Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,00039A
+CHEROKEE,Weir Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",63,000400
+CHEROKEE,Weir Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000400
+CHEROKEE,Weir Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000400
+CHEROKEE,Weir Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000410
+CHEROKEE,Weir Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000410
+CHEROKEE,Weir Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000410
+CHEROKEE,West Mineral City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00042A
+CHEROKEE,West Mineral City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00042A
+CHEROKEE,West Mineral City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00042B
+CHEROKEE,Lyon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,140010
+CHEROKEE,Lyon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,140010
+CHEROKEE,Lyon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",95,140010
+CHEROKEE,Baxter Springs Ward 1,Kansas House of Representatives,1,Democratic,"Caswell, Brian",102,000010
+CHEROKEE,Baxter Springs Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",91,000010
+CHEROKEE,Baxter Springs Ward 2,Kansas House of Representatives,1,Democratic,"Caswell, Brian",72,000020
+CHEROKEE,Baxter Springs Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",69,000020
+CHEROKEE,Baxter Springs Ward 3,Kansas House of Representatives,1,Democratic,"Caswell, Brian",203,000030
+CHEROKEE,Baxter Springs Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",202,000030
+CHEROKEE,Baxter Springs Ward 4,Kansas House of Representatives,1,Democratic,"Caswell, Brian",98,00004A
+CHEROKEE,Baxter Springs Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",101,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00004B
+CHEROKEE,Cherokee Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",71,000050
+CHEROKEE,Cherokee Township,Kansas House of Representatives,1,Republican,"Houser, Michael",67,000050
+CHEROKEE,Columbus Ward 1,Kansas House of Representatives,1,Democratic,"Caswell, Brian",38,000060
+CHEROKEE,Columbus Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",98,000060
+CHEROKEE,Columbus Ward 2,Kansas House of Representatives,1,Democratic,"Caswell, Brian",103,000070
+CHEROKEE,Columbus Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",155,000070
+CHEROKEE,Columbus Ward 3,Kansas House of Representatives,1,Democratic,"Caswell, Brian",85,000080
+CHEROKEE,Columbus Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",152,000080
+CHEROKEE,Columbus Ward 4,Kansas House of Representatives,1,Democratic,"Caswell, Brian",58,000090
+CHEROKEE,Columbus Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",83,000090
+CHEROKEE,Columbus Ward 5,Kansas House of Representatives,1,Democratic,"Caswell, Brian",76,00010A
+CHEROKEE,Columbus Ward 5,Kansas House of Representatives,1,Republican,"Houser, Michael",107,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00010B
+CHEROKEE,Crawford Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",80,000110
+CHEROKEE,Crawford Township,Kansas House of Representatives,1,Republican,"Houser, Michael",179,000110
+CHEROKEE,Galena Ward 1,Kansas House of Representatives,1,Democratic,"Caswell, Brian",68,000120
+CHEROKEE,Galena Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",88,000120
+CHEROKEE,Galena Ward 2,Kansas House of Representatives,1,Democratic,"Caswell, Brian",59,00013A
+CHEROKEE,Galena Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",71,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013D
+CHEROKEE,Galena Ward 3,Kansas House of Representatives,1,Democratic,"Caswell, Brian",82,000140
+CHEROKEE,Galena Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",138,000140
+CHEROKEE,Galena Ward 4,Kansas House of Representatives,1,Democratic,"Caswell, Brian",38,00015A
+CHEROKEE,Galena Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",53,00015A
+CHEROKEE,Galena Ward 4 Exclave,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00015B
+CHEROKEE,Garden Township Lowell,Kansas House of Representatives,1,Democratic,"Caswell, Brian",267,000170
+CHEROKEE,Garden Township Lowell,Kansas House of Representatives,1,Republican,"Houser, Michael",384,000170
+CHEROKEE,Garden Township Stanley Mine,Kansas House of Representatives,1,Democratic,"Caswell, Brian",77,00018A
+CHEROKEE,Garden Township Stanley Mine,Kansas House of Representatives,1,Republican,"Houser, Michael",110,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00018C
+CHEROKEE,Lola Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",22,000190
+CHEROKEE,Lola Township,Kansas House of Representatives,1,Republican,"Houser, Michael",71,000190
+CHEROKEE,Lowell Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",62,000200
+CHEROKEE,Lowell Township,Kansas House of Representatives,1,Republican,"Houser, Michael",158,000200
+CHEROKEE,Mineral Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",22,000220
+CHEROKEE,Mineral Township,Kansas House of Representatives,1,Republican,"Houser, Michael",53,000220
+CHEROKEE,Neosho Township Faulkner,Kansas House of Representatives,1,Democratic,"Caswell, Brian",12,000230
+CHEROKEE,Neosho Township Faulkner,Kansas House of Representatives,1,Republican,"Houser, Michael",20,000230
+CHEROKEE,Neosho Township Melrose,Kansas House of Representatives,1,Democratic,"Caswell, Brian",16,000240
+CHEROKEE,Neosho Township Melrose,Kansas House of Representatives,1,Republican,"Houser, Michael",28,000240
+CHEROKEE,Pleasant View Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",70,000250
+CHEROKEE,Pleasant View Township,Kansas House of Representatives,1,Republican,"Houser, Michael",142,000250
+CHEROKEE,Roseland City,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,000260
+CHEROKEE,Roseland City,Kansas House of Representatives,1,Republican,"Houser, Michael",0,000260
+CHEROKEE,Ross Township Belleview,Kansas House of Representatives,1,Democratic,"Caswell, Brian",30,000270
+CHEROKEE,Ross Township Belleview,Kansas House of Representatives,1,Republican,"Houser, Michael",41,000270
+CHEROKEE,Ross Township Roseland,Kansas House of Representatives,1,Democratic,"Caswell, Brian",55,000280
+CHEROKEE,Ross Township Roseland,Kansas House of Representatives,1,Republican,"Houser, Michael",46,000280
+CHEROKEE,Ross Township West Mineral,Kansas House of Representatives,1,Democratic,"Caswell, Brian",48,000290
+CHEROKEE,Ross Township West Mineral,Kansas House of Representatives,1,Republican,"Houser, Michael",37,000290
+CHEROKEE,Salamanca Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",84,00030A
+CHEROKEE,Salamanca Township,Kansas House of Representatives,1,Republican,"Houser, Michael",141,00030A
+CHEROKEE,Salamanca Township Enclave,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00030B
+CHEROKEE,Salamanca Township Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00030B
+CHEROKEE,Scammon Ward 1,Kansas House of Representatives,1,Democratic,"Caswell, Brian",26,000310
+CHEROKEE,Scammon Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",14,000310
+CHEROKEE,Scammon Ward 2,Kansas House of Representatives,1,Democratic,"Caswell, Brian",24,000320
+CHEROKEE,Scammon Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",22,000320
+CHEROKEE,Scammon Ward 3,Kansas House of Representatives,1,Democratic,"Caswell, Brian",29,000330
+CHEROKEE,Scammon Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",34,000330
+CHEROKEE,Shawnee Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",41,000340
+CHEROKEE,Shawnee Township,Kansas House of Representatives,1,Republican,"Houser, Michael",139,000340
+CHEROKEE,Sheridan Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",25,000350
+CHEROKEE,Sheridan Township,Kansas House of Representatives,1,Republican,"Houser, Michael",57,000350
+CHEROKEE,Spring Valley Township Neutral,Kansas House of Representatives,1,Democratic,"Caswell, Brian",87,000360
+CHEROKEE,Spring Valley Township Neutral,Kansas House of Representatives,1,Republican,"Houser, Michael",135,000360
+CHEROKEE,Spring Valley Township Spring Valley,Kansas House of Representatives,1,Democratic,"Caswell, Brian",55,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Kansas House of Representatives,1,Republican,"Houser, Michael",90,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00037C
+CHEROKEE,Weir Ward 1,Kansas House of Representatives,1,Democratic,"Caswell, Brian",23,00039A
+CHEROKEE,Weir Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",23,00039A
+CHEROKEE,Weir Ward 2,Kansas House of Representatives,1,Democratic,"Caswell, Brian",60,000400
+CHEROKEE,Weir Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",41,000400
+CHEROKEE,Weir Ward 3,Kansas House of Representatives,1,Democratic,"Caswell, Brian",29,000410
+CHEROKEE,Weir Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",30,000410
+CHEROKEE,West Mineral City,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00042A
+CHEROKEE,West Mineral City,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00042B
+CHEROKEE,Lyon Township,Kansas House of Representatives,1,Democratic,"Caswell, Brian",41,140010
+CHEROKEE,Lyon Township,Kansas House of Representatives,1,Republican,"Houser, Michael",94,140010
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,000010
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000010
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",133,000010
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",34,000020
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,000020
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,000020
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",99,000030
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000030
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",289,000030
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",50,00004A
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,00004A
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,000050
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000050
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000050
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",33,000060
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000060
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,000060
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",74,000070
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000070
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,000070
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",59,000080
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000080
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000080
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",36,000090
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000090
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",98,000090
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",64,00010A
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,00010A
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",109,00010A
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+CHEROKEE,Crawford Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,000110
+CHEROKEE,Crawford Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000110
+CHEROKEE,Crawford Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,000110
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",49,000120
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000120
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000120
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",32,00013A
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,00013A
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013D
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",59,000140
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000140
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",146,000140
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",23,00015A
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,00015A
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,00015A
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00015B
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Democratic,"Wakefield, Margie",188,000170
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",31,000170
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Republican,"Jenkins, Lynn",434,000170
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,00018A
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,00018A
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Republican,"Jenkins, Lynn",127,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018C
+CHEROKEE,Lola Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000190
+CHEROKEE,Lola Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000190
+CHEROKEE,Lola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000190
+CHEROKEE,Lowell Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",46,000200
+CHEROKEE,Lowell Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000200
+CHEROKEE,Lowell Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",165,000200
+CHEROKEE,Mineral Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",11,000220
+CHEROKEE,Mineral Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000220
+CHEROKEE,Mineral Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000220
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Democratic,"Wakefield, Margie",7,000230
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000230
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Republican,"Jenkins, Lynn",25,000230
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Democratic,"Wakefield, Margie",11,000240
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000240
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000240
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",43,000250
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000250
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",164,000250
+CHEROKEE,Roseland City,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,000260
+CHEROKEE,Roseland City,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000260
+CHEROKEE,Roseland City,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000260
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,000270
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000270
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,000270
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,000280
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000280
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Republican,"Jenkins, Lynn",48,000280
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Democratic,"Wakefield, Margie",37,000290
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000290
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Republican,"Jenkins, Lynn",39,000290
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",60,00030A
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,00030A
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",154,00030A
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00030B
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000310
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000310
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",20,000310
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,000320
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000320
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",23,000320
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,000330
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000330
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000330
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",34,000340
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000340
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,000340
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",23,000350
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000350
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000350
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Democratic,"Wakefield, Margie",68,000360
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000360
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Republican,"Jenkins, Lynn",140,000360
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Democratic,"Wakefield, Margie",29,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00037C
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,00039A
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,00039A
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",24,00039A
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",46,000400
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000400
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000400
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",29,000410
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000410
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",28,000410
+CHEROKEE,West Mineral City,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00042A
+CHEROKEE,West Mineral City,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00042A
+CHEROKEE,West Mineral City,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00042B
+CHEROKEE,Lyon Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",32,140010
+CHEROKEE,Lyon Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,140010
+CHEROKEE,Lyon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,140010
+CHEROKEE,Baxter Springs Ward 1,Attorney General,,Democratic,"Kotich, A.J.",54,000010
+CHEROKEE,Baxter Springs Ward 1,Attorney General,,Republican,"Schmidt, Derek",132,000010
+CHEROKEE,Baxter Springs Ward 2,Attorney General,,Democratic,"Kotich, A.J.",43,000020
+CHEROKEE,Baxter Springs Ward 2,Attorney General,,Republican,"Schmidt, Derek",95,000020
+CHEROKEE,Baxter Springs Ward 3,Attorney General,,Democratic,"Kotich, A.J.",117,000030
+CHEROKEE,Baxter Springs Ward 3,Attorney General,,Republican,"Schmidt, Derek",281,000030
+CHEROKEE,Baxter Springs Ward 4,Attorney General,,Democratic,"Kotich, A.J.",62,00004A
+CHEROKEE,Baxter Springs Ward 4,Attorney General,,Republican,"Schmidt, Derek",135,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00004B
+CHEROKEE,Cherokee Township,Attorney General,,Democratic,"Kotich, A.J.",51,000050
+CHEROKEE,Cherokee Township,Attorney General,,Republican,"Schmidt, Derek",85,000050
+CHEROKEE,Columbus Ward 1,Attorney General,,Democratic,"Kotich, A.J.",45,000060
+CHEROKEE,Columbus Ward 1,Attorney General,,Republican,"Schmidt, Derek",87,000060
+CHEROKEE,Columbus Ward 2,Attorney General,,Democratic,"Kotich, A.J.",70,000070
+CHEROKEE,Columbus Ward 2,Attorney General,,Republican,"Schmidt, Derek",185,000070
+CHEROKEE,Columbus Ward 3,Attorney General,,Democratic,"Kotich, A.J.",57,000080
+CHEROKEE,Columbus Ward 3,Attorney General,,Republican,"Schmidt, Derek",179,000080
+CHEROKEE,Columbus Ward 4,Attorney General,,Democratic,"Kotich, A.J.",45,000090
+CHEROKEE,Columbus Ward 4,Attorney General,,Republican,"Schmidt, Derek",97,000090
+CHEROKEE,Columbus Ward 5,Attorney General,,Democratic,"Kotich, A.J.",68,00010A
+CHEROKEE,Columbus Ward 5,Attorney General,,Republican,"Schmidt, Derek",110,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00010B
+CHEROKEE,Crawford Township,Attorney General,,Democratic,"Kotich, A.J.",62,000110
+CHEROKEE,Crawford Township,Attorney General,,Republican,"Schmidt, Derek",197,000110
+CHEROKEE,Galena Ward 1,Attorney General,,Democratic,"Kotich, A.J.",61,000120
+CHEROKEE,Galena Ward 1,Attorney General,,Republican,"Schmidt, Derek",94,000120
+CHEROKEE,Galena Ward 2,Attorney General,,Democratic,"Kotich, A.J.",41,00013A
+CHEROKEE,Galena Ward 2,Attorney General,,Republican,"Schmidt, Derek",88,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Attorney General,,Democratic,"Kotich, A.J.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Attorney General,,Republican,"Schmidt, Derek",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Attorney General,,Democratic,"Kotich, A.J.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Attorney General,,Republican,"Schmidt, Derek",0,00013D
+CHEROKEE,Galena Ward 3,Attorney General,,Democratic,"Kotich, A.J.",63,000140
+CHEROKEE,Galena Ward 3,Attorney General,,Republican,"Schmidt, Derek",150,000140
+CHEROKEE,Galena Ward 4,Attorney General,,Democratic,"Kotich, A.J.",32,00015A
+CHEROKEE,Galena Ward 4,Attorney General,,Republican,"Schmidt, Derek",59,00015A
+CHEROKEE,Galena Ward 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00015B
+CHEROKEE,Garden Township Lowell,Attorney General,,Democratic,"Kotich, A.J.",215,000170
+CHEROKEE,Garden Township Lowell,Attorney General,,Republican,"Schmidt, Derek",432,000170
+CHEROKEE,Garden Township Stanley Mine,Attorney General,,Democratic,"Kotich, A.J.",46,00018A
+CHEROKEE,Garden Township Stanley Mine,Attorney General,,Republican,"Schmidt, Derek",140,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,00018C
+CHEROKEE,Lola Township,Attorney General,,Democratic,"Kotich, A.J.",20,000190
+CHEROKEE,Lola Township,Attorney General,,Republican,"Schmidt, Derek",73,000190
+CHEROKEE,Lowell Township,Attorney General,,Democratic,"Kotich, A.J.",57,000200
+CHEROKEE,Lowell Township,Attorney General,,Republican,"Schmidt, Derek",160,000200
+CHEROKEE,Mineral Township,Attorney General,,Democratic,"Kotich, A.J.",9,000220
+CHEROKEE,Mineral Township,Attorney General,,Republican,"Schmidt, Derek",64,000220
+CHEROKEE,Neosho Township Faulkner,Attorney General,,Democratic,"Kotich, A.J.",6,000230
+CHEROKEE,Neosho Township Faulkner,Attorney General,,Republican,"Schmidt, Derek",25,000230
+CHEROKEE,Neosho Township Melrose,Attorney General,,Democratic,"Kotich, A.J.",12,000240
+CHEROKEE,Neosho Township Melrose,Attorney General,,Republican,"Schmidt, Derek",33,000240
+CHEROKEE,Pleasant View Township,Attorney General,,Democratic,"Kotich, A.J.",50,000250
+CHEROKEE,Pleasant View Township,Attorney General,,Republican,"Schmidt, Derek",158,000250
+CHEROKEE,Roseland City,Attorney General,,Democratic,"Kotich, A.J.",0,000260
+CHEROKEE,Roseland City,Attorney General,,Republican,"Schmidt, Derek",0,000260
+CHEROKEE,Ross Township Belleview,Attorney General,,Democratic,"Kotich, A.J.",27,000270
+CHEROKEE,Ross Township Belleview,Attorney General,,Republican,"Schmidt, Derek",44,000270
+CHEROKEE,Ross Township Roseland,Attorney General,,Democratic,"Kotich, A.J.",49,000280
+CHEROKEE,Ross Township Roseland,Attorney General,,Republican,"Schmidt, Derek",55,000280
+CHEROKEE,Ross Township West Mineral,Attorney General,,Democratic,"Kotich, A.J.",45,000290
+CHEROKEE,Ross Township West Mineral,Attorney General,,Republican,"Schmidt, Derek",39,000290
+CHEROKEE,Salamanca Township,Attorney General,,Democratic,"Kotich, A.J.",58,00030A
+CHEROKEE,Salamanca Township,Attorney General,,Republican,"Schmidt, Derek",165,00030A
+CHEROKEE,Salamanca Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00030B
+CHEROKEE,Salamanca Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00030B
+CHEROKEE,Scammon Ward 1,Attorney General,,Democratic,"Kotich, A.J.",20,000310
+CHEROKEE,Scammon Ward 1,Attorney General,,Republican,"Schmidt, Derek",19,000310
+CHEROKEE,Scammon Ward 2,Attorney General,,Democratic,"Kotich, A.J.",20,000320
+CHEROKEE,Scammon Ward 2,Attorney General,,Republican,"Schmidt, Derek",27,000320
+CHEROKEE,Scammon Ward 3,Attorney General,,Democratic,"Kotich, A.J.",29,000330
+CHEROKEE,Scammon Ward 3,Attorney General,,Republican,"Schmidt, Derek",32,000330
+CHEROKEE,Shawnee Township,Attorney General,,Democratic,"Kotich, A.J.",33,000340
+CHEROKEE,Shawnee Township,Attorney General,,Republican,"Schmidt, Derek",148,000340
+CHEROKEE,Sheridan Township,Attorney General,,Democratic,"Kotich, A.J.",25,000350
+CHEROKEE,Sheridan Township,Attorney General,,Republican,"Schmidt, Derek",57,000350
+CHEROKEE,Spring Valley Township Neutral,Attorney General,,Democratic,"Kotich, A.J.",62,000360
+CHEROKEE,Spring Valley Township Neutral,Attorney General,,Republican,"Schmidt, Derek",158,000360
+CHEROKEE,Spring Valley Township Spring Valley,Attorney General,,Democratic,"Kotich, A.J.",34,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Attorney General,,Republican,"Schmidt, Derek",108,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00037C
+CHEROKEE,Weir Ward 1,Attorney General,,Democratic,"Kotich, A.J.",23,00039A
+CHEROKEE,Weir Ward 1,Attorney General,,Republican,"Schmidt, Derek",23,00039A
+CHEROKEE,Weir Ward 2,Attorney General,,Democratic,"Kotich, A.J.",55,000400
+CHEROKEE,Weir Ward 2,Attorney General,,Republican,"Schmidt, Derek",47,000400
+CHEROKEE,Weir Ward 3,Attorney General,,Democratic,"Kotich, A.J.",27,000410
+CHEROKEE,Weir Ward 3,Attorney General,,Republican,"Schmidt, Derek",34,000410
+CHEROKEE,West Mineral City,Attorney General,,Democratic,"Kotich, A.J.",0,00042A
+CHEROKEE,West Mineral City,Attorney General,,Republican,"Schmidt, Derek",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Attorney General,,Democratic,"Kotich, A.J.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Attorney General,,Republican,"Schmidt, Derek",0,00042B
+CHEROKEE,Lyon Township,Attorney General,,Democratic,"Kotich, A.J.",30,140010
+CHEROKEE,Lyon Township,Attorney General,,Republican,"Schmidt, Derek",103,140010
+CHEROKEE,Baxter Springs Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,000010
+CHEROKEE,Baxter Springs Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",130,000010
+CHEROKEE,Baxter Springs Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000020
+CHEROKEE,Baxter Springs Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",83,000020
+CHEROKEE,Baxter Springs Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",128,000030
+CHEROKEE,Baxter Springs Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",263,000030
+CHEROKEE,Baxter Springs Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,00004A
+CHEROKEE,Baxter Springs Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",125,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00004B
+CHEROKEE,Cherokee Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",64,000050
+CHEROKEE,Cherokee Township,Commissioner of Insurance,,Republican,"Selzer, Ken",72,000050
+CHEROKEE,Columbus Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",60,000060
+CHEROKEE,Columbus Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",71,000060
+CHEROKEE,Columbus Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",78,000070
+CHEROKEE,Columbus Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000070
+CHEROKEE,Columbus Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,000080
+CHEROKEE,Columbus Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000080
+CHEROKEE,Columbus Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,000090
+CHEROKEE,Columbus Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",82,000090
+CHEROKEE,Columbus Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",82,00010A
+CHEROKEE,Columbus Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",89,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00010B
+CHEROKEE,Crawford Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",85,000110
+CHEROKEE,Crawford Township,Commissioner of Insurance,,Republican,"Selzer, Ken",165,000110
+CHEROKEE,Galena Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,000120
+CHEROKEE,Galena Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",90,000120
+CHEROKEE,Galena Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,00013A
+CHEROKEE,Galena Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",82,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013D
+CHEROKEE,Galena Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",75,000140
+CHEROKEE,Galena Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",137,000140
+CHEROKEE,Galena Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,00015A
+CHEROKEE,Galena Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",54,00015A
+CHEROKEE,Galena Ward 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00015B
+CHEROKEE,Garden Township Lowell,Commissioner of Insurance,,Democratic,"Anderson, Dennis",231,000170
+CHEROKEE,Garden Township Lowell,Commissioner of Insurance,,Republican,"Selzer, Ken",403,000170
+CHEROKEE,Garden Township Stanley Mine,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,00018A
+CHEROKEE,Garden Township Stanley Mine,Commissioner of Insurance,,Republican,"Selzer, Ken",131,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018C
+CHEROKEE,Lola Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000190
+CHEROKEE,Lola Township,Commissioner of Insurance,,Republican,"Selzer, Ken",65,000190
+CHEROKEE,Lowell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,000200
+CHEROKEE,Lowell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000200
+CHEROKEE,Mineral Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000220
+CHEROKEE,Mineral Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000220
+CHEROKEE,Neosho Township Faulkner,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000230
+CHEROKEE,Neosho Township Faulkner,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000230
+CHEROKEE,Neosho Township Melrose,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000240
+CHEROKEE,Neosho Township Melrose,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000240
+CHEROKEE,Pleasant View Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000250
+CHEROKEE,Pleasant View Township,Commissioner of Insurance,,Republican,"Selzer, Ken",151,000250
+CHEROKEE,Roseland City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000260
+CHEROKEE,Roseland City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000260
+CHEROKEE,Ross Township Belleview,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000270
+CHEROKEE,Ross Township Belleview,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000270
+CHEROKEE,Ross Township Roseland,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000280
+CHEROKEE,Ross Township Roseland,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000280
+CHEROKEE,Ross Township West Mineral,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000290
+CHEROKEE,Ross Township West Mineral,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000290
+CHEROKEE,Salamanca Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",79,00030A
+CHEROKEE,Salamanca Township,Commissioner of Insurance,,Republican,"Selzer, Ken",141,00030A
+CHEROKEE,Salamanca Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00030B
+CHEROKEE,Salamanca Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00030B
+CHEROKEE,Scammon Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000310
+CHEROKEE,Scammon Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000310
+CHEROKEE,Scammon Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000320
+CHEROKEE,Scammon Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000320
+CHEROKEE,Scammon Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000330
+CHEROKEE,Scammon Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000330
+CHEROKEE,Shawnee Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",49,000340
+CHEROKEE,Shawnee Township,Commissioner of Insurance,,Republican,"Selzer, Ken",130,000340
+CHEROKEE,Sheridan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000350
+CHEROKEE,Sheridan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",52,000350
+CHEROKEE,Spring Valley Township Neutral,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000360
+CHEROKEE,Spring Valley Township Neutral,Commissioner of Insurance,,Republican,"Selzer, Ken",140,000360
+CHEROKEE,Spring Valley Township Spring Valley,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Commissioner of Insurance,,Republican,"Selzer, Ken",99,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00037C
+CHEROKEE,Weir Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,00039A
+CHEROKEE,Weir Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",20,00039A
+CHEROKEE,Weir Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000400
+CHEROKEE,Weir Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",43,000400
+CHEROKEE,Weir Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000410
+CHEROKEE,Weir Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000410
+CHEROKEE,West Mineral City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00042A
+CHEROKEE,West Mineral City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00042B
+CHEROKEE,Lyon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,140010
+CHEROKEE,Lyon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",98,140010
+CHEROKEE,Baxter Springs Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000010
+CHEROKEE,Baxter Springs Ward 1,Secretary of State,,Republican,"Kobach, Kris",133,000010
+CHEROKEE,Baxter Springs Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000020
+CHEROKEE,Baxter Springs Ward 2,Secretary of State,,Republican,"Kobach, Kris",93,000020
+CHEROKEE,Baxter Springs Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",128,000030
+CHEROKEE,Baxter Springs Ward 3,Secretary of State,,Republican,"Kobach, Kris",270,000030
+CHEROKEE,Baxter Springs Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,00004A
+CHEROKEE,Baxter Springs Ward 4,Secretary of State,,Republican,"Kobach, Kris",126,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00004B
+CHEROKEE,Cherokee Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000050
+CHEROKEE,Cherokee Township,Secretary of State,,Republican,"Kobach, Kris",78,000050
+CHEROKEE,Columbus Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000060
+CHEROKEE,Columbus Ward 1,Secretary of State,,Republican,"Kobach, Kris",85,000060
+CHEROKEE,Columbus Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,000070
+CHEROKEE,Columbus Ward 2,Secretary of State,,Republican,"Kobach, Kris",183,000070
+CHEROKEE,Columbus Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",76,000080
+CHEROKEE,Columbus Ward 3,Secretary of State,,Republican,"Kobach, Kris",159,000080
+CHEROKEE,Columbus Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,000090
+CHEROKEE,Columbus Ward 4,Secretary of State,,Republican,"Kobach, Kris",87,000090
+CHEROKEE,Columbus Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",79,00010A
+CHEROKEE,Columbus Ward 5,Secretary of State,,Republican,"Kobach, Kris",99,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00010B
+CHEROKEE,Crawford Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000110
+CHEROKEE,Crawford Township,Secretary of State,,Republican,"Kobach, Kris",182,000110
+CHEROKEE,Galena Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000120
+CHEROKEE,Galena Ward 1,Secretary of State,,Republican,"Kobach, Kris",97,000120
+CHEROKEE,Galena Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,00013A
+CHEROKEE,Galena Ward 2,Secretary of State,,Republican,"Kobach, Kris",81,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Secretary of State,,Republican,"Kobach, Kris",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Secretary of State,,Republican,"Kobach, Kris",0,00013D
+CHEROKEE,Galena Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000140
+CHEROKEE,Galena Ward 3,Secretary of State,,Republican,"Kobach, Kris",147,000140
+CHEROKEE,Galena Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,00015A
+CHEROKEE,Galena Ward 4,Secretary of State,,Republican,"Kobach, Kris",57,00015A
+CHEROKEE,Galena Ward 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00015B
+CHEROKEE,Garden Township Lowell,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",220,000170
+CHEROKEE,Garden Township Lowell,Secretary of State,,Republican,"Kobach, Kris",427,000170
+CHEROKEE,Garden Township Stanley Mine,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,00018A
+CHEROKEE,Garden Township Stanley Mine,Secretary of State,,Republican,"Kobach, Kris",138,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,00018C
+CHEROKEE,Lola Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000190
+CHEROKEE,Lola Township,Secretary of State,,Republican,"Kobach, Kris",65,000190
+CHEROKEE,Lowell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,000200
+CHEROKEE,Lowell Township,Secretary of State,,Republican,"Kobach, Kris",157,000200
+CHEROKEE,Mineral Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000220
+CHEROKEE,Mineral Township,Secretary of State,,Republican,"Kobach, Kris",57,000220
+CHEROKEE,Neosho Township Faulkner,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000230
+CHEROKEE,Neosho Township Faulkner,Secretary of State,,Republican,"Kobach, Kris",24,000230
+CHEROKEE,Neosho Township Melrose,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000240
+CHEROKEE,Neosho Township Melrose,Secretary of State,,Republican,"Kobach, Kris",34,000240
+CHEROKEE,Pleasant View Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,000250
+CHEROKEE,Pleasant View Township,Secretary of State,,Republican,"Kobach, Kris",155,000250
+CHEROKEE,Roseland City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000260
+CHEROKEE,Roseland City,Secretary of State,,Republican,"Kobach, Kris",0,000260
+CHEROKEE,Ross Township Belleview,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000270
+CHEROKEE,Ross Township Belleview,Secretary of State,,Republican,"Kobach, Kris",40,000270
+CHEROKEE,Ross Township Roseland,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000280
+CHEROKEE,Ross Township Roseland,Secretary of State,,Republican,"Kobach, Kris",52,000280
+CHEROKEE,Ross Township West Mineral,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000290
+CHEROKEE,Ross Township West Mineral,Secretary of State,,Republican,"Kobach, Kris",39,000290
+CHEROKEE,Salamanca Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,00030A
+CHEROKEE,Salamanca Township,Secretary of State,,Republican,"Kobach, Kris",150,00030A
+CHEROKEE,Salamanca Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00030B
+CHEROKEE,Salamanca Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00030B
+CHEROKEE,Scammon Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000310
+CHEROKEE,Scammon Ward 1,Secretary of State,,Republican,"Kobach, Kris",16,000310
+CHEROKEE,Scammon Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000320
+CHEROKEE,Scammon Ward 2,Secretary of State,,Republican,"Kobach, Kris",26,000320
+CHEROKEE,Scammon Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000330
+CHEROKEE,Scammon Ward 3,Secretary of State,,Republican,"Kobach, Kris",32,000330
+CHEROKEE,Shawnee Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000340
+CHEROKEE,Shawnee Township,Secretary of State,,Republican,"Kobach, Kris",138,000340
+CHEROKEE,Sheridan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000350
+CHEROKEE,Sheridan Township,Secretary of State,,Republican,"Kobach, Kris",55,000350
+CHEROKEE,Spring Valley Township Neutral,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000360
+CHEROKEE,Spring Valley Township Neutral,Secretary of State,,Republican,"Kobach, Kris",157,000360
+CHEROKEE,Spring Valley Township Spring Valley,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Secretary of State,,Republican,"Kobach, Kris",108,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00037C
+CHEROKEE,Weir Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,00039A
+CHEROKEE,Weir Ward 1,Secretary of State,,Republican,"Kobach, Kris",23,00039A
+CHEROKEE,Weir Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000400
+CHEROKEE,Weir Ward 2,Secretary of State,,Republican,"Kobach, Kris",44,000400
+CHEROKEE,Weir Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000410
+CHEROKEE,Weir Ward 3,Secretary of State,,Republican,"Kobach, Kris",25,000410
+CHEROKEE,West Mineral City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00042A
+CHEROKEE,West Mineral City,Secretary of State,,Republican,"Kobach, Kris",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Secretary of State,,Republican,"Kobach, Kris",0,00042B
+CHEROKEE,Lyon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,140010
+CHEROKEE,Lyon Township,Secretary of State,,Republican,"Kobach, Kris",93,140010
+CHEROKEE,Baxter Springs Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",58,000010
+CHEROKEE,Baxter Springs Ward 1,State Treasurer,,Republican,"Estes, Ron",131,000010
+CHEROKEE,Baxter Springs Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",43,000020
+CHEROKEE,Baxter Springs Ward 2,State Treasurer,,Republican,"Estes, Ron",99,000020
+CHEROKEE,Baxter Springs Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",117,000030
+CHEROKEE,Baxter Springs Ward 3,State Treasurer,,Republican,"Estes, Ron",277,000030
+CHEROKEE,Baxter Springs Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",52,00004A
+CHEROKEE,Baxter Springs Ward 4,State Treasurer,,Republican,"Estes, Ron",143,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00004B
+CHEROKEE,Cherokee Township,State Treasurer,,Democratic,"Alldritt, Carmen",54,000050
+CHEROKEE,Cherokee Township,State Treasurer,,Republican,"Estes, Ron",83,000050
+CHEROKEE,Columbus Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",47,000060
+CHEROKEE,Columbus Ward 1,State Treasurer,,Republican,"Estes, Ron",86,000060
+CHEROKEE,Columbus Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",68,000070
+CHEROKEE,Columbus Ward 2,State Treasurer,,Republican,"Estes, Ron",189,000070
+CHEROKEE,Columbus Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",64,000080
+CHEROKEE,Columbus Ward 3,State Treasurer,,Republican,"Estes, Ron",173,000080
+CHEROKEE,Columbus Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",45,000090
+CHEROKEE,Columbus Ward 4,State Treasurer,,Republican,"Estes, Ron",94,000090
+CHEROKEE,Columbus Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",73,00010A
+CHEROKEE,Columbus Ward 5,State Treasurer,,Republican,"Estes, Ron",105,00010A
+CHEROKEE,Columbus Ward 5 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00010B
+CHEROKEE,Crawford Township,State Treasurer,,Democratic,"Alldritt, Carmen",76,000110
+CHEROKEE,Crawford Township,State Treasurer,,Republican,"Estes, Ron",182,000110
+CHEROKEE,Galena Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",57,000120
+CHEROKEE,Galena Ward 1,State Treasurer,,Republican,"Estes, Ron",98,000120
+CHEROKEE,Galena Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",43,00013A
+CHEROKEE,Galena Ward 2,State Treasurer,,Republican,"Estes, Ron",84,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,State Treasurer,,Democratic,"Alldritt, Carmen",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,State Treasurer,,Republican,"Estes, Ron",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,State Treasurer,,Republican,"Estes, Ron",0,00013D
+CHEROKEE,Galena Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",63,000140
+CHEROKEE,Galena Ward 3,State Treasurer,,Republican,"Estes, Ron",149,000140
+CHEROKEE,Galena Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",31,00015A
+CHEROKEE,Galena Ward 4,State Treasurer,,Republican,"Estes, Ron",60,00015A
+CHEROKEE,Galena Ward 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00015B
+CHEROKEE,Garden Township Lowell,State Treasurer,,Democratic,"Alldritt, Carmen",211,000170
+CHEROKEE,Garden Township Lowell,State Treasurer,,Republican,"Estes, Ron",437,000170
+CHEROKEE,Garden Township Stanley Mine,State Treasurer,,Democratic,"Alldritt, Carmen",44,00018A
+CHEROKEE,Garden Township Stanley Mine,State Treasurer,,Republican,"Estes, Ron",140,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,State Treasurer,,Republican,"Estes, Ron",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,State Treasurer,,Republican,"Estes, Ron",0,00018C
+CHEROKEE,Lola Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000190
+CHEROKEE,Lola Township,State Treasurer,,Republican,"Estes, Ron",73,000190
+CHEROKEE,Lowell Township,State Treasurer,,Democratic,"Alldritt, Carmen",54,000200
+CHEROKEE,Lowell Township,State Treasurer,,Republican,"Estes, Ron",163,000200
+CHEROKEE,Mineral Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000220
+CHEROKEE,Mineral Township,State Treasurer,,Republican,"Estes, Ron",65,000220
+CHEROKEE,Neosho Township Faulkner,State Treasurer,,Democratic,"Alldritt, Carmen",7,000230
+CHEROKEE,Neosho Township Faulkner,State Treasurer,,Republican,"Estes, Ron",24,000230
+CHEROKEE,Neosho Township Melrose,State Treasurer,,Democratic,"Alldritt, Carmen",9,000240
+CHEROKEE,Neosho Township Melrose,State Treasurer,,Republican,"Estes, Ron",35,000240
+CHEROKEE,Pleasant View Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000250
+CHEROKEE,Pleasant View Township,State Treasurer,,Republican,"Estes, Ron",161,000250
+CHEROKEE,Roseland City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000260
+CHEROKEE,Roseland City,State Treasurer,,Republican,"Estes, Ron",0,000260
+CHEROKEE,Ross Township Belleview,State Treasurer,,Democratic,"Alldritt, Carmen",29,000270
+CHEROKEE,Ross Township Belleview,State Treasurer,,Republican,"Estes, Ron",42,000270
+CHEROKEE,Ross Township Roseland,State Treasurer,,Democratic,"Alldritt, Carmen",45,000280
+CHEROKEE,Ross Township Roseland,State Treasurer,,Republican,"Estes, Ron",59,000280
+CHEROKEE,Ross Township West Mineral,State Treasurer,,Democratic,"Alldritt, Carmen",47,000290
+CHEROKEE,Ross Township West Mineral,State Treasurer,,Republican,"Estes, Ron",38,000290
+CHEROKEE,Salamanca Township,State Treasurer,,Democratic,"Alldritt, Carmen",64,00030A
+CHEROKEE,Salamanca Township,State Treasurer,,Republican,"Estes, Ron",158,00030A
+CHEROKEE,Salamanca Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00030B
+CHEROKEE,Salamanca Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,00030B
+CHEROKEE,Scammon Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",18,000310
+CHEROKEE,Scammon Ward 1,State Treasurer,,Republican,"Estes, Ron",22,000310
+CHEROKEE,Scammon Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",19,000320
+CHEROKEE,Scammon Ward 2,State Treasurer,,Republican,"Estes, Ron",28,000320
+CHEROKEE,Scammon Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",27,000330
+CHEROKEE,Scammon Ward 3,State Treasurer,,Republican,"Estes, Ron",34,000330
+CHEROKEE,Shawnee Township,State Treasurer,,Democratic,"Alldritt, Carmen",39,000340
+CHEROKEE,Shawnee Township,State Treasurer,,Republican,"Estes, Ron",139,000340
+CHEROKEE,Sheridan Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000350
+CHEROKEE,Sheridan Township,State Treasurer,,Republican,"Estes, Ron",52,000350
+CHEROKEE,Spring Valley Township Neutral,State Treasurer,,Democratic,"Alldritt, Carmen",70,000360
+CHEROKEE,Spring Valley Township Neutral,State Treasurer,,Republican,"Estes, Ron",150,000360
+CHEROKEE,Spring Valley Township Spring Valley,State Treasurer,,Democratic,"Alldritt, Carmen",38,00037A
+CHEROKEE,Spring Valley Township Spring Valley,State Treasurer,,Republican,"Estes, Ron",103,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,State Treasurer,,Republican,"Estes, Ron",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,State Treasurer,,Republican,"Estes, Ron",0,00037C
+CHEROKEE,Weir Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",24,00039A
+CHEROKEE,Weir Ward 1,State Treasurer,,Republican,"Estes, Ron",22,00039A
+CHEROKEE,Weir Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",57,000400
+CHEROKEE,Weir Ward 2,State Treasurer,,Republican,"Estes, Ron",45,000400
+CHEROKEE,Weir Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",34,000410
+CHEROKEE,Weir Ward 3,State Treasurer,,Republican,"Estes, Ron",26,000410
+CHEROKEE,West Mineral City,State Treasurer,,Democratic,"Alldritt, Carmen",0,00042A
+CHEROKEE,West Mineral City,State Treasurer,,Republican,"Estes, Ron",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,State Treasurer,,Democratic,"Alldritt, Carmen",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,State Treasurer,,Republican,"Estes, Ron",0,00042B
+CHEROKEE,Lyon Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,140010
+CHEROKEE,Lyon Township,State Treasurer,,Republican,"Estes, Ron",102,140010
+CHEROKEE,Baxter Springs Ward 1,United States Senate,,independent,"Orman, Greg",52,000010
+CHEROKEE,Baxter Springs Ward 1,United States Senate,,Libertarian,"Batson, Randall",19,000010
+CHEROKEE,Baxter Springs Ward 1,United States Senate,,Republican,"Roberts, Pat",119,000010
+CHEROKEE,Baxter Springs Ward 2,United States Senate,,independent,"Orman, Greg",50,000020
+CHEROKEE,Baxter Springs Ward 2,United States Senate,,Libertarian,"Batson, Randall",15,000020
+CHEROKEE,Baxter Springs Ward 2,United States Senate,,Republican,"Roberts, Pat",75,000020
+CHEROKEE,Baxter Springs Ward 3,United States Senate,,independent,"Orman, Greg",117,000030
+CHEROKEE,Baxter Springs Ward 3,United States Senate,,Libertarian,"Batson, Randall",25,000030
+CHEROKEE,Baxter Springs Ward 3,United States Senate,,Republican,"Roberts, Pat",259,000030
+CHEROKEE,Baxter Springs Ward 4,United States Senate,,independent,"Orman, Greg",49,00004A
+CHEROKEE,Baxter Springs Ward 4,United States Senate,,Libertarian,"Batson, Randall",21,00004A
+CHEROKEE,Baxter Springs Ward 4,United States Senate,,Republican,"Roberts, Pat",128,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States Senate,,independent,"Orman, Greg",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00004B
+CHEROKEE,Cherokee Township,United States Senate,,independent,"Orman, Greg",55,000050
+CHEROKEE,Cherokee Township,United States Senate,,Libertarian,"Batson, Randall",9,000050
+CHEROKEE,Cherokee Township,United States Senate,,Republican,"Roberts, Pat",72,000050
+CHEROKEE,Columbus Ward 1,United States Senate,,independent,"Orman, Greg",41,000060
+CHEROKEE,Columbus Ward 1,United States Senate,,Libertarian,"Batson, Randall",18,000060
+CHEROKEE,Columbus Ward 1,United States Senate,,Republican,"Roberts, Pat",78,000060
+CHEROKEE,Columbus Ward 2,United States Senate,,independent,"Orman, Greg",79,000070
+CHEROKEE,Columbus Ward 2,United States Senate,,Libertarian,"Batson, Randall",18,000070
+CHEROKEE,Columbus Ward 2,United States Senate,,Republican,"Roberts, Pat",157,000070
+CHEROKEE,Columbus Ward 3,United States Senate,,independent,"Orman, Greg",71,000080
+CHEROKEE,Columbus Ward 3,United States Senate,,Libertarian,"Batson, Randall",10,000080
+CHEROKEE,Columbus Ward 3,United States Senate,,Republican,"Roberts, Pat",155,000080
+CHEROKEE,Columbus Ward 4,United States Senate,,independent,"Orman, Greg",44,000090
+CHEROKEE,Columbus Ward 4,United States Senate,,Libertarian,"Batson, Randall",11,000090
+CHEROKEE,Columbus Ward 4,United States Senate,,Republican,"Roberts, Pat",88,000090
+CHEROKEE,Columbus Ward 5,United States Senate,,independent,"Orman, Greg",65,00010A
+CHEROKEE,Columbus Ward 5,United States Senate,,Libertarian,"Batson, Randall",8,00010A
+CHEROKEE,Columbus Ward 5,United States Senate,,Republican,"Roberts, Pat",104,00010A
+CHEROKEE,Columbus Ward 5 Exclave,United States Senate,,independent,"Orman, Greg",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00010B
+CHEROKEE,Crawford Township,United States Senate,,independent,"Orman, Greg",63,000110
+CHEROKEE,Crawford Township,United States Senate,,Libertarian,"Batson, Randall",19,000110
+CHEROKEE,Crawford Township,United States Senate,,Republican,"Roberts, Pat",172,000110
+CHEROKEE,Galena Ward 1,United States Senate,,independent,"Orman, Greg",55,000120
+CHEROKEE,Galena Ward 1,United States Senate,,Libertarian,"Batson, Randall",13,000120
+CHEROKEE,Galena Ward 1,United States Senate,,Republican,"Roberts, Pat",87,000120
+CHEROKEE,Galena Ward 2,United States Senate,,independent,"Orman, Greg",31,00013A
+CHEROKEE,Galena Ward 2,United States Senate,,Libertarian,"Batson, Randall",13,00013A
+CHEROKEE,Galena Ward 2,United States Senate,,Republican,"Roberts, Pat",82,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States Senate,,independent,"Orman, Greg",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States Senate,,Libertarian,"Batson, Randall",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States Senate,,Republican,"Roberts, Pat",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,United States Senate,,independent,"Orman, Greg",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,United States Senate,,independent,"Orman, Greg",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States Senate,,Libertarian,"Batson, Randall",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States Senate,,Republican,"Roberts, Pat",0,00013D
+CHEROKEE,Galena Ward 3,United States Senate,,independent,"Orman, Greg",64,000140
+CHEROKEE,Galena Ward 3,United States Senate,,Libertarian,"Batson, Randall",16,000140
+CHEROKEE,Galena Ward 3,United States Senate,,Republican,"Roberts, Pat",136,000140
+CHEROKEE,Galena Ward 4,United States Senate,,independent,"Orman, Greg",26,00015A
+CHEROKEE,Galena Ward 4,United States Senate,,Libertarian,"Batson, Randall",12,00015A
+CHEROKEE,Galena Ward 4,United States Senate,,Republican,"Roberts, Pat",51,00015A
+CHEROKEE,Galena Ward 4 Exclave,United States Senate,,independent,"Orman, Greg",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00015B
+CHEROKEE,Garden Township Lowell,United States Senate,,independent,"Orman, Greg",201,000170
+CHEROKEE,Garden Township Lowell,United States Senate,,Libertarian,"Batson, Randall",58,000170
+CHEROKEE,Garden Township Lowell,United States Senate,,Republican,"Roberts, Pat",385,000170
+CHEROKEE,Garden Township Stanley Mine,United States Senate,,independent,"Orman, Greg",50,00018A
+CHEROKEE,Garden Township Stanley Mine,United States Senate,,Libertarian,"Batson, Randall",15,00018A
+CHEROKEE,Garden Township Stanley Mine,United States Senate,,Republican,"Roberts, Pat",124,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States Senate,,independent,"Orman, Greg",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States Senate,,Republican,"Roberts, Pat",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States Senate,,independent,"Orman, Greg",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States Senate,,Republican,"Roberts, Pat",0,00018C
+CHEROKEE,Lola Township,United States Senate,,independent,"Orman, Greg",23,000190
+CHEROKEE,Lola Township,United States Senate,,Libertarian,"Batson, Randall",4,000190
+CHEROKEE,Lola Township,United States Senate,,Republican,"Roberts, Pat",64,000190
+CHEROKEE,Lowell Township,United States Senate,,independent,"Orman, Greg",55,000200
+CHEROKEE,Lowell Township,United States Senate,,Libertarian,"Batson, Randall",19,000200
+CHEROKEE,Lowell Township,United States Senate,,Republican,"Roberts, Pat",147,000200
+CHEROKEE,Mineral Township,United States Senate,,independent,"Orman, Greg",15,000220
+CHEROKEE,Mineral Township,United States Senate,,Libertarian,"Batson, Randall",4,000220
+CHEROKEE,Mineral Township,United States Senate,,Republican,"Roberts, Pat",57,000220
+CHEROKEE,Neosho Township Faulkner,United States Senate,,independent,"Orman, Greg",6,000230
+CHEROKEE,Neosho Township Faulkner,United States Senate,,Libertarian,"Batson, Randall",0,000230
+CHEROKEE,Neosho Township Faulkner,United States Senate,,Republican,"Roberts, Pat",25,000230
+CHEROKEE,Neosho Township Melrose,United States Senate,,independent,"Orman, Greg",8,000240
+CHEROKEE,Neosho Township Melrose,United States Senate,,Libertarian,"Batson, Randall",4,000240
+CHEROKEE,Neosho Township Melrose,United States Senate,,Republican,"Roberts, Pat",29,000240
+CHEROKEE,Pleasant View Township,United States Senate,,independent,"Orman, Greg",55,000250
+CHEROKEE,Pleasant View Township,United States Senate,,Libertarian,"Batson, Randall",11,000250
+CHEROKEE,Pleasant View Township,United States Senate,,Republican,"Roberts, Pat",145,000250
+CHEROKEE,Roseland City,United States Senate,,independent,"Orman, Greg",0,000260
+CHEROKEE,Roseland City,United States Senate,,Libertarian,"Batson, Randall",0,000260
+CHEROKEE,Roseland City,United States Senate,,Republican,"Roberts, Pat",0,000260
+CHEROKEE,Ross Township Belleview,United States Senate,,independent,"Orman, Greg",27,000270
+CHEROKEE,Ross Township Belleview,United States Senate,,Libertarian,"Batson, Randall",4,000270
+CHEROKEE,Ross Township Belleview,United States Senate,,Republican,"Roberts, Pat",38,000270
+CHEROKEE,Ross Township Roseland,United States Senate,,independent,"Orman, Greg",41,000280
+CHEROKEE,Ross Township Roseland,United States Senate,,Libertarian,"Batson, Randall",6,000280
+CHEROKEE,Ross Township Roseland,United States Senate,,Republican,"Roberts, Pat",51,000280
+CHEROKEE,Ross Township West Mineral,United States Senate,,independent,"Orman, Greg",36,000290
+CHEROKEE,Ross Township West Mineral,United States Senate,,Libertarian,"Batson, Randall",9,000290
+CHEROKEE,Ross Township West Mineral,United States Senate,,Republican,"Roberts, Pat",38,000290
+CHEROKEE,Salamanca Township,United States Senate,,independent,"Orman, Greg",67,00030A
+CHEROKEE,Salamanca Township,United States Senate,,Libertarian,"Batson, Randall",12,00030A
+CHEROKEE,Salamanca Township,United States Senate,,Republican,"Roberts, Pat",142,00030A
+CHEROKEE,Salamanca Township Enclave,United States Senate,,independent,"Orman, Greg",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,00030B
+CHEROKEE,Scammon Ward 1,United States Senate,,independent,"Orman, Greg",20,000310
+CHEROKEE,Scammon Ward 1,United States Senate,,Libertarian,"Batson, Randall",4,000310
+CHEROKEE,Scammon Ward 1,United States Senate,,Republican,"Roberts, Pat",16,000310
+CHEROKEE,Scammon Ward 2,United States Senate,,independent,"Orman, Greg",17,000320
+CHEROKEE,Scammon Ward 2,United States Senate,,Libertarian,"Batson, Randall",4,000320
+CHEROKEE,Scammon Ward 2,United States Senate,,Republican,"Roberts, Pat",24,000320
+CHEROKEE,Scammon Ward 3,United States Senate,,independent,"Orman, Greg",30,000330
+CHEROKEE,Scammon Ward 3,United States Senate,,Libertarian,"Batson, Randall",4,000330
+CHEROKEE,Scammon Ward 3,United States Senate,,Republican,"Roberts, Pat",27,000330
+CHEROKEE,Shawnee Township,United States Senate,,independent,"Orman, Greg",45,000340
+CHEROKEE,Shawnee Township,United States Senate,,Libertarian,"Batson, Randall",8,000340
+CHEROKEE,Shawnee Township,United States Senate,,Republican,"Roberts, Pat",128,000340
+CHEROKEE,Sheridan Township,United States Senate,,independent,"Orman, Greg",19,000350
+CHEROKEE,Sheridan Township,United States Senate,,Libertarian,"Batson, Randall",10,000350
+CHEROKEE,Sheridan Township,United States Senate,,Republican,"Roberts, Pat",53,000350
+CHEROKEE,Spring Valley Township Neutral,United States Senate,,independent,"Orman, Greg",63,000360
+CHEROKEE,Spring Valley Township Neutral,United States Senate,,Libertarian,"Batson, Randall",21,000360
+CHEROKEE,Spring Valley Township Neutral,United States Senate,,Republican,"Roberts, Pat",136,000360
+CHEROKEE,Spring Valley Township Spring Valley,United States Senate,,independent,"Orman, Greg",36,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States Senate,,Libertarian,"Batson, Randall",7,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States Senate,,Republican,"Roberts, Pat",98,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,independent,"Orman, Greg",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Republican,"Roberts, Pat",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,independent,"Orman, Greg",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Republican,"Roberts, Pat",0,00037C
+CHEROKEE,Weir Ward 1,United States Senate,,independent,"Orman, Greg",17,00039A
+CHEROKEE,Weir Ward 1,United States Senate,,Libertarian,"Batson, Randall",5,00039A
+CHEROKEE,Weir Ward 1,United States Senate,,Republican,"Roberts, Pat",23,00039A
+CHEROKEE,Weir Ward 2,United States Senate,,independent,"Orman, Greg",46,000400
+CHEROKEE,Weir Ward 2,United States Senate,,Libertarian,"Batson, Randall",8,000400
+CHEROKEE,Weir Ward 2,United States Senate,,Republican,"Roberts, Pat",45,000400
+CHEROKEE,Weir Ward 3,United States Senate,,independent,"Orman, Greg",32,000410
+CHEROKEE,Weir Ward 3,United States Senate,,Libertarian,"Batson, Randall",4,000410
+CHEROKEE,Weir Ward 3,United States Senate,,Republican,"Roberts, Pat",23,000410
+CHEROKEE,West Mineral City,United States Senate,,independent,"Orman, Greg",0,00042A
+CHEROKEE,West Mineral City,United States Senate,,Libertarian,"Batson, Randall",0,00042A
+CHEROKEE,West Mineral City,United States Senate,,Republican,"Roberts, Pat",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,United States Senate,,independent,"Orman, Greg",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States Senate,,Libertarian,"Batson, Randall",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States Senate,,Republican,"Roberts, Pat",0,00042B
+CHEROKEE,Lyon Township,United States Senate,,independent,"Orman, Greg",29,140010
+CHEROKEE,Lyon Township,United States Senate,,Libertarian,"Batson, Randall",11,140010
+CHEROKEE,Lyon Township,United States Senate,,Republican,"Roberts, Pat",94,140010

--- a/2014/20141104__ks__general__cheyenne__precinct.csv
+++ b/2014/20141104__ks__general__cheyenne__precinct.csv
@@ -1,153 +1,137 @@
-county,precinct,office,district,party,candidate,votes
-Cheyenne,Benkelman Township,Voters,,,Registration,27
-Cheyenne,Bird City Township,Voters,,,Registration,436
-Cheyenne,Calhoun Township,Voters,,,Registration,36
-Cheyenne,Cleveland Run Township,Voters,,,Registration,42
-Cheyenne,Jaqua Township,Voters,,,Registration,15
-Cheyenne,Orlando Township,Voters,,,Registration,45
-Cheyenne,Wano 1 Township,Voters,,,Registration,520
-Cheyenne,Wano 2 Township,Voters,,,Registration,745
-Cheyenne,Benkelman Township,Voters,,,Voted,17
-Cheyenne,Bird City Township,Voters,,,Voted,245
-Cheyenne,Calhoun Township,Voters,,,Voted,26
-Cheyenne,Cleveland Run Township,Voters,,,Voted,30
-Cheyenne,Jaqua Township,Voters,,,Voted,10
-Cheyenne,Orlando Township,Voters,,,Voted,26
-Cheyenne,Wano 1 Township,Voters,,,Voted,285
-Cheyenne,Wano 2 Township,Voters,,,Voted,437
-Cheyenne,Benkelman Township,U.S. Senate,,R,Pat Roberts,13
-Cheyenne,Bird City Township,U.S. Senate,,R,Pat Roberts,180
-Cheyenne,Calhoun Township,U.S. Senate,,R,Pat Roberts,24
-Cheyenne,Cleveland Run Township,U.S. Senate,,R,Pat Roberts,26
-Cheyenne,Jaqua Township,U.S. Senate,,R,Pat Roberts,6
-Cheyenne,Orlando Township,U.S. Senate,,R,Pat Roberts,24
-Cheyenne,Wano 1 Township,U.S. Senate,,R,Pat Roberts,220
-Cheyenne,Wano 2 Township,U.S. Senate,,R,Pat Roberts,330
-Cheyenne,Benkelman Township,U.S. Senate,,I,Greg Orman,3
-Cheyenne,Bird City Township,U.S. Senate,,I,Greg Orman,51
-Cheyenne,Calhoun Township,U.S. Senate,,I,Greg Orman,1
-Cheyenne,Cleveland Run Township,U.S. Senate,,I,Greg Orman,2
-Cheyenne,Jaqua Township,U.S. Senate,,I,Greg Orman,3
-Cheyenne,Orlando Township,U.S. Senate,,I,Greg Orman,1
-Cheyenne,Wano 1 Township,U.S. Senate,,I,Greg Orman,47
-Cheyenne,Wano 2 Township,U.S. Senate,,I,Greg Orman,88
-Cheyenne,Benkelman Township,U.S. Senate,,L,Randall Batson,0
-Cheyenne,Bird City Township,U.S. Senate,,L,Randall Batson,7
-Cheyenne,Calhoun Township,U.S. Senate,,L,Randall Batson,0
-Cheyenne,Cleveland Run Township,U.S. Senate,,L,Randall Batson,0
-Cheyenne,Jaqua Township,U.S. Senate,,L,Randall Batson,1
-Cheyenne,Orlando Township,U.S. Senate,,L,Randall Batson,0
-Cheyenne,Wano 1 Township,U.S. Senate,,L,Randall Batson,9
-Cheyenne,Wano 2 Township,U.S. Senate,,L,Randall Batson,13
-Cheyenne,Benkelman Township,U.S. House,1,R,Tim Huelskamp,13
-Cheyenne,Bird City Township,U.S. House,1,R,Tim Huelskamp,189
-Cheyenne,Calhoun Township,U.S. House,1,R,Tim Huelskamp,25
-Cheyenne,Cleveland Run Township,U.S. House,1,R,Tim Huelskamp,27
-Cheyenne,Jaqua Township,U.S. House,1,R,Tim Huelskamp,8
-Cheyenne,Orlando Township,U.S. House,1,R,Tim Huelskamp,23
-Cheyenne,Wano 1 Township,U.S. House,1,R,Tim Huelskamp,217
-Cheyenne,Wano 2 Township,U.S. House,1,R,Tim Huelskamp,342
-Cheyenne,Benkelman Township,U.S. House,1,D,James Sherow,3
-Cheyenne,Bird City Township,U.S. House,1,D,James Sherow,48
-Cheyenne,Calhoun Township,U.S. House,1,D,James Sherow,0
-Cheyenne,Cleveland Run Township,U.S. House,1,D,James Sherow,1
-Cheyenne,Jaqua Township,U.S. House,1,D,James Sherow,2
-Cheyenne,Orlando Township,U.S. House,1,D,James Sherow,2
-Cheyenne,Wano 1 Township,U.S. House,1,D,James Sherow,57
-Cheyenne,Wano 2 Township,U.S. House,1,D,James Sherow,85
-Cheyenne,Benkelman Township,Governor,,R,Sam Brownback,14
-Cheyenne,Bird City Township,Governor,,R,Sam Brownback,178
-Cheyenne,Calhoun Township,Governor,,R,Sam Brownback,25
-Cheyenne,Cleveland Run Township,Governor,,R,Sam Brownback,27
-Cheyenne,Jaqua Township,Governor,,R,Sam Brownback,7
-Cheyenne,Orlando Township,Governor,,R,Sam Brownback,19
-Cheyenne,Wano 1 Township,Governor,,R,Sam Brownback,213
-Cheyenne,Wano 2 Township,Governor,,R,Sam Brownback,321
-Cheyenne,Benkelman Township,Governor,,D,Paul Davis,2
-Cheyenne,Bird City Township,Governor,,D,Paul Davis,52
-Cheyenne,Calhoun Township,Governor,,D,Paul Davis,1
-Cheyenne,Cleveland Run Township,Governor,,D,Paul Davis,2
-Cheyenne,Jaqua Township,Governor,,D,Paul Davis,2
-Cheyenne,Orlando Township,Governor,,D,Paul Davis,6
-Cheyenne,Wano 1 Township,Governor,,D,Paul Davis,55
-Cheyenne,Wano 2 Township,Governor,,D,Paul Davis,99
-Cheyenne,Benkelman Township,Governor,,L,Keen Umbehr,1
-Cheyenne,Bird City Township,Governor,,L,Keen Umbehr,12
-Cheyenne,Calhoun Township,Governor,,L,Keen Umbehr,0
-Cheyenne,Cleveland Run Township,Governor,,L,Keen Umbehr,0
-Cheyenne,Jaqua Township,Governor,,L,Keen Umbehr,1
-Cheyenne,Orlando Township,Governor,,L,Keen Umbehr,1
-Cheyenne,Wano 1 Township,Governor,,L,Keen Umbehr,12
-Cheyenne,Wano 2 Township,Governor,,L,Keen Umbehr,13
-Cheyenne,Benkelman Township,Secretary of State,,R,Kris Kobach,14
-Cheyenne,Bird City Township,Secretary of State,,R,Kris Kobach,192
-Cheyenne,Calhoun Township,Secretary of State,,R,Kris Kobach,26
-Cheyenne,Cleveland Run Township,Secretary of State,,R,Kris Kobach,28
-Cheyenne,Jaqua Township,Secretary of State,,R,Kris Kobach,8
-Cheyenne,Orlando Township,Secretary of State,,R,Kris Kobach,24
-Cheyenne,Wano 1 Township,Secretary of State,,R,Kris Kobach,222
-Cheyenne,Wano 2 Township,Secretary of State,,R,Kris Kobach,330
-Cheyenne,Benkelman Township,Secretary of State,,D,Jean Schodorf,3
-Cheyenne,Bird City Township,Secretary of State,,D,Jean Schodorf,40
-Cheyenne,Calhoun Township,Secretary of State,,D,Jean Schodorf,0
-Cheyenne,Cleveland Run Township,Secretary of State,,D,Jean Schodorf,0
-Cheyenne,Jaqua Township,Secretary of State,,D,Jean Schodorf,2
-Cheyenne,Orlando Township,Secretary of State,,D,Jean Schodorf,2
-Cheyenne,Wano 1 Township,Secretary of State,,D,Jean Schodorf,47
-Cheyenne,Wano 2 Township,Secretary of State,,D,Jean Schodorf,94
-Cheyenne,Benkelman Township,Attorney General,,R,Derek Schmidt,14
-Cheyenne,Bird City Township,Attorney General,,R,Derek Schmidt,197
-Cheyenne,Calhoun Township,Attorney General,,R,Derek Schmidt,24
-Cheyenne,Cleveland Run Township,Attorney General,,R,Derek Schmidt,26
-Cheyenne,Jaqua Township,Attorney General,,R,Derek Schmidt,9
-Cheyenne,Orlando Township,Attorney General,,R,Derek Schmidt,26
-Cheyenne,Wano 1 Township,Attorney General,,R,Derek Schmidt,230
-Cheyenne,Wano 2 Township,Attorney General,,R,Derek Schmidt,350
-Cheyenne,Benkelman Township,Attorney General,,D,AJ Kotich,3
-Cheyenne,Bird City Township,Attorney General,,D,AJ Kotich,31
-Cheyenne,Calhoun Township,Attorney General,,D,AJ Kotich,2
-Cheyenne,Cleveland Run Township,Attorney General,,D,AJ Kotich,2
-Cheyenne,Jaqua Township,Attorney General,,D,AJ Kotich,1
-Cheyenne,Orlando Township,Attorney General,,D,AJ Kotich,0
-Cheyenne,Wano 1 Township,Attorney General,,D,AJ Kotich,37
-Cheyenne,Wano 2 Township,Attorney General,,D,AJ Kotich,70
-Cheyenne,Benkelman Township,State Treasurer,,R,Ron Estes,14
-Cheyenne,Bird City Township,State Treasurer,,R,Ron Estes,198
-Cheyenne,Calhoun Township,State Treasurer,,R,Ron Estes,26
-Cheyenne,Cleveland Run Township,State Treasurer,,R,Ron Estes,25
-Cheyenne,Jaqua Township,State Treasurer,,R,Ron Estes,8
-Cheyenne,Orlando Township,State Treasurer,,R,Ron Estes,26
-Cheyenne,Wano 1 Township,State Treasurer,,R,Ron Estes,229
-Cheyenne,Wano 2 Township,State Treasurer,,R,Ron Estes,355
-Cheyenne,Benkelman Township,State Treasurer,,D,Carmen Alldritt,3
-Cheyenne,Bird City Township,State Treasurer,,D,Carmen Alldritt,32
-Cheyenne,Calhoun Township,State Treasurer,,D,Carmen Alldritt,0
-Cheyenne,Cleveland Run Township,State Treasurer,,D,Carmen Alldritt,2
-Cheyenne,Jaqua Township,State Treasurer,,D,Carmen Alldritt,2
-Cheyenne,Orlando Township,State Treasurer,,D,Carmen Alldritt,0
-Cheyenne,Wano 1 Township,State Treasurer,,D,Carmen Alldritt,34
-Cheyenne,Wano 2 Township,State Treasurer,,D,Carmen Alldritt,67
-Cheyenne,Benkelman Township,Insurance Commissioner,,R,Ron Selzer,15
-Cheyenne,Bird City Township,Insurance Commissioner,,R,Ron Selzer,193
-Cheyenne,Calhoun Township,Insurance Commissioner,,R,Ron Selzer,25
-Cheyenne,Cleveland Run Township,Insurance Commissioner,,R,Ron Selzer,27
-Cheyenne,Jaqua Township,Insurance Commissioner,,R,Ron Selzer,8
-Cheyenne,Orlando Township,Insurance Commissioner,,R,Ron Selzer,24
-Cheyenne,Wano 1 Township,Insurance Commissioner,,R,Ron Selzer,222
-Cheyenne,Wano 2 Township,Insurance Commissioner,,R,Ron Selzer,338
-Cheyenne,Benkelman Township,Insurance Commissioner,,D,Dennis Anderson,2
-Cheyenne,Bird City Township,Insurance Commissioner,,D,Dennis Anderson,30
-Cheyenne,Calhoun Township,Insurance Commissioner,,D,Dennis Anderson,1
-Cheyenne,Cleveland Run Township,Insurance Commissioner,,D,Dennis Anderson,2
-Cheyenne,Jaqua Township,Insurance Commissioner,,D,Dennis Anderson,2
-Cheyenne,Orlando Township,Insurance Commissioner,,D,Dennis Anderson,2
-Cheyenne,Wano 1 Township,Insurance Commissioner,,D,Dennis Anderson,42
-Cheyenne,Wano 2 Township,Insurance Commissioner,,D,Dennis Anderson,73
-Cheyenne,Benkelman Township,State House,120,R,Rick Billinger R,16
-Cheyenne,Bird City Township,State House,120,R,Rick Billinger R,216
-Cheyenne,Calhoun Township,State House,120,R,Rick Billinger R,26
-Cheyenne,Cleveland Run Township,State House,120,R,Rick Billinger R,27
-Cheyenne,Jaqua Township,State House,120,R,Rick Billinger R,10
-Cheyenne,Orlando Township,State House,120,R,Rick Billinger R,26
-Cheyenne,Wano 1 Township,State House,120,R,Rick Billinger R,256
-Cheyenne,Wano 2 Township,State House,120,R,Rick Billinger R,388
+county,precinct,office,district,party,candidate,votes,vtd
+CHEYENNE,Benkelman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000010
+CHEYENNE,Benkelman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+CHEYENNE,Benkelman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000010
+CHEYENNE,Bird City Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",52,000020
+CHEYENNE,Bird City Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000020
+CHEYENNE,Bird City Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",178,000020
+CHEYENNE,Calhoun Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000030
+CHEYENNE,Calhoun Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+CHEYENNE,Calhoun Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000030
+CHEYENNE,Cleveland Run Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000040
+CHEYENNE,Cleveland Run Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+CHEYENNE,Cleveland Run Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000040
+CHEYENNE,Jaqua Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000050
+CHEYENNE,Jaqua Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+CHEYENNE,Jaqua Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,000050
+CHEYENNE,Orlando Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000060
+CHEYENNE,Orlando Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+CHEYENNE,Orlando Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000060
+CHEYENNE,Wano 1 Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000070
+CHEYENNE,Wano 1 Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000070
+CHEYENNE,Wano 1 Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",213,000070
+CHEYENNE,Wano 2 Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",99,000080
+CHEYENNE,Wano 2 Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000080
+CHEYENNE,Wano 2 Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",321,000080
+CHEYENNE,Benkelman Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",16,000010
+CHEYENNE,Bird City Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",216,000020
+CHEYENNE,Calhoun Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",26,000030
+CHEYENNE,Cleveland Run Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",27,000040
+CHEYENNE,Jaqua Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",10,000050
+CHEYENNE,Orlando Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",26,000060
+CHEYENNE,Wano 1 Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",256,000070
+CHEYENNE,Wano 2 Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",388,000080
+CHEYENNE,Benkelman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000010
+CHEYENNE,Benkelman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000010
+CHEYENNE,Bird City Township,United States House of Representatives,1,Democratic,"Sherow, James E.",48,000020
+CHEYENNE,Bird City Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",189,000020
+CHEYENNE,Calhoun Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000030
+CHEYENNE,Calhoun Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000030
+CHEYENNE,Cleveland Run Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000040
+CHEYENNE,Cleveland Run Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000040
+CHEYENNE,Jaqua Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000050
+CHEYENNE,Jaqua Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000050
+CHEYENNE,Orlando Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000060
+CHEYENNE,Orlando Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000060
+CHEYENNE,Wano 1 Township,United States House of Representatives,1,Democratic,"Sherow, James E.",57,000070
+CHEYENNE,Wano 1 Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",217,000070
+CHEYENNE,Wano 2 Township,United States House of Representatives,1,Democratic,"Sherow, James E.",85,000080
+CHEYENNE,Wano 2 Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",342,000080
+CHEYENNE,Benkelman Township,Attorney General,,Democratic,"Kotich, A.J.",3,000010
+CHEYENNE,Benkelman Township,Attorney General,,Republican,"Schmidt, Derek",14,000010
+CHEYENNE,Bird City Township,Attorney General,,Democratic,"Kotich, A.J.",31,000020
+CHEYENNE,Bird City Township,Attorney General,,Republican,"Schmidt, Derek",197,000020
+CHEYENNE,Calhoun Township,Attorney General,,Democratic,"Kotich, A.J.",2,000030
+CHEYENNE,Calhoun Township,Attorney General,,Republican,"Schmidt, Derek",24,000030
+CHEYENNE,Cleveland Run Township,Attorney General,,Democratic,"Kotich, A.J.",2,000040
+CHEYENNE,Cleveland Run Township,Attorney General,,Republican,"Schmidt, Derek",26,000040
+CHEYENNE,Jaqua Township,Attorney General,,Democratic,"Kotich, A.J.",1,000050
+CHEYENNE,Jaqua Township,Attorney General,,Republican,"Schmidt, Derek",9,000050
+CHEYENNE,Orlando Township,Attorney General,,Democratic,"Kotich, A.J.",0,000060
+CHEYENNE,Orlando Township,Attorney General,,Republican,"Schmidt, Derek",26,000060
+CHEYENNE,Wano 1 Township,Attorney General,,Democratic,"Kotich, A.J.",37,000070
+CHEYENNE,Wano 1 Township,Attorney General,,Republican,"Schmidt, Derek",230,000070
+CHEYENNE,Wano 2 Township,Attorney General,,Democratic,"Kotich, A.J.",70,000080
+CHEYENNE,Wano 2 Township,Attorney General,,Republican,"Schmidt, Derek",350,000080
+CHEYENNE,Benkelman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000010
+CHEYENNE,Benkelman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000010
+CHEYENNE,Bird City Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000020
+CHEYENNE,Bird City Township,Commissioner of Insurance,,Republican,"Selzer, Ken",193,000020
+CHEYENNE,Calhoun Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000030
+CHEYENNE,Calhoun Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000030
+CHEYENNE,Cleveland Run Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000040
+CHEYENNE,Cleveland Run Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000040
+CHEYENNE,Jaqua Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000050
+CHEYENNE,Jaqua Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000050
+CHEYENNE,Orlando Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000060
+CHEYENNE,Orlando Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000060
+CHEYENNE,Wano 1 Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000070
+CHEYENNE,Wano 1 Township,Commissioner of Insurance,,Republican,"Selzer, Ken",222,000070
+CHEYENNE,Wano 2 Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000080
+CHEYENNE,Wano 2 Township,Commissioner of Insurance,,Republican,"Selzer, Ken",338,000080
+CHEYENNE,Benkelman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+CHEYENNE,Benkelman Township,Secretary of State,,Republican,"Kobach, Kris",14,000010
+CHEYENNE,Bird City Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000020
+CHEYENNE,Bird City Township,Secretary of State,,Republican,"Kobach, Kris",192,000020
+CHEYENNE,Calhoun Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000030
+CHEYENNE,Calhoun Township,Secretary of State,,Republican,"Kobach, Kris",26,000030
+CHEYENNE,Cleveland Run Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000040
+CHEYENNE,Cleveland Run Township,Secretary of State,,Republican,"Kobach, Kris",28,000040
+CHEYENNE,Jaqua Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000050
+CHEYENNE,Jaqua Township,Secretary of State,,Republican,"Kobach, Kris",8,000050
+CHEYENNE,Orlando Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000060
+CHEYENNE,Orlando Township,Secretary of State,,Republican,"Kobach, Kris",24,000060
+CHEYENNE,Wano 1 Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000070
+CHEYENNE,Wano 1 Township,Secretary of State,,Republican,"Kobach, Kris",222,000070
+CHEYENNE,Wano 2 Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000080
+CHEYENNE,Wano 2 Township,Secretary of State,,Republican,"Kobach, Kris",330,000080
+CHEYENNE,Benkelman Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000010
+CHEYENNE,Benkelman Township,State Treasurer,,Republican,"Estes, Ron",14,000010
+CHEYENNE,Bird City Township,State Treasurer,,Democratic,"Alldritt, Carmen",32,000020
+CHEYENNE,Bird City Township,State Treasurer,,Republican,"Estes, Ron",198,000020
+CHEYENNE,Calhoun Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000030
+CHEYENNE,Calhoun Township,State Treasurer,,Republican,"Estes, Ron",26,000030
+CHEYENNE,Cleveland Run Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000040
+CHEYENNE,Cleveland Run Township,State Treasurer,,Republican,"Estes, Ron",25,000040
+CHEYENNE,Jaqua Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000050
+CHEYENNE,Jaqua Township,State Treasurer,,Republican,"Estes, Ron",8,000050
+CHEYENNE,Orlando Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000060
+CHEYENNE,Orlando Township,State Treasurer,,Republican,"Estes, Ron",26,000060
+CHEYENNE,Wano 1 Township,State Treasurer,,Democratic,"Alldritt, Carmen",34,000070
+CHEYENNE,Wano 1 Township,State Treasurer,,Republican,"Estes, Ron",229,000070
+CHEYENNE,Wano 2 Township,State Treasurer,,Democratic,"Alldritt, Carmen",67,000080
+CHEYENNE,Wano 2 Township,State Treasurer,,Republican,"Estes, Ron",355,000080
+CHEYENNE,Benkelman Township,United States Senate,,independent,"Orman, Greg",3,000010
+CHEYENNE,Benkelman Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+CHEYENNE,Benkelman Township,United States Senate,,Republican,"Roberts, Pat",13,000010
+CHEYENNE,Bird City Township,United States Senate,,independent,"Orman, Greg",51,000020
+CHEYENNE,Bird City Township,United States Senate,,Libertarian,"Batson, Randall",7,000020
+CHEYENNE,Bird City Township,United States Senate,,Republican,"Roberts, Pat",180,000020
+CHEYENNE,Calhoun Township,United States Senate,,independent,"Orman, Greg",1,000030
+CHEYENNE,Calhoun Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+CHEYENNE,Calhoun Township,United States Senate,,Republican,"Roberts, Pat",24,000030
+CHEYENNE,Cleveland Run Township,United States Senate,,independent,"Orman, Greg",2,000040
+CHEYENNE,Cleveland Run Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+CHEYENNE,Cleveland Run Township,United States Senate,,Republican,"Roberts, Pat",26,000040
+CHEYENNE,Jaqua Township,United States Senate,,independent,"Orman, Greg",3,000050
+CHEYENNE,Jaqua Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+CHEYENNE,Jaqua Township,United States Senate,,Republican,"Roberts, Pat",6,000050
+CHEYENNE,Orlando Township,United States Senate,,independent,"Orman, Greg",1,000060
+CHEYENNE,Orlando Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+CHEYENNE,Orlando Township,United States Senate,,Republican,"Roberts, Pat",24,000060
+CHEYENNE,Wano 1 Township,United States Senate,,independent,"Orman, Greg",47,000070
+CHEYENNE,Wano 1 Township,United States Senate,,Libertarian,"Batson, Randall",9,000070
+CHEYENNE,Wano 1 Township,United States Senate,,Republican,"Roberts, Pat",220,000070
+CHEYENNE,Wano 2 Township,United States Senate,,independent,"Orman, Greg",88,000080
+CHEYENNE,Wano 2 Township,United States Senate,,Libertarian,"Batson, Randall",13,000080
+CHEYENNE,Wano 2 Township,United States Senate,,Republican,"Roberts, Pat",330,000080

--- a/2014/20141104__ks__general__clark__precinct.csv
+++ b/2014/20141104__ks__general__clark__precinct.csv
@@ -1,128 +1,127 @@
-county,precinct,office,district,party,candidate,votes
-Clark,Appleton,Attorney General,,D,A.J. Kotich,38
-Clark,Center 1,Attorney General,,D,A.J. Kotich,31
-Clark,Center 2,Attorney General,,D,A.J. Kotich,24
-Clark,Englewood,Attorney General,,D,A.J. Kotich,12
-Clark,Lexington,Attorney General,,D,A.J. Kotich,2
-Clark,Liberty,Attorney General,,D,A.J. Kotich,0
-Clark,Sitka,Attorney General,,D,A.J. Kotich,3
-Clark,Appleton,Attorney General,,R,Derek Schmidt,277
-Clark,Center 1,Attorney General,,R,Derek Schmidt,169
-Clark,Center 2,Attorney General,,R,Derek Schmidt,133
-Clark,Englewood,Attorney General,,R,Derek Schmidt,40
-Clark,Lexington,Attorney General,,R,Derek Schmidt,22
-Clark,Liberty,Attorney General,,R,Derek Schmidt,16
-Clark,Sitka,Attorney General,,R,Derek Schmidt,31
-Clark,Appleton,Governor,,L,Keen Umbehr,15
-Clark,Center 1,Governor,,L,Keen Umbehr,7
-Clark,Center 2,Governor,,L,Keen Umbehr,8
-Clark,Englewood,Governor,,L,Keen Umbehr,4
-Clark,Lexington,Governor,,L,Keen Umbehr,0
-Clark,Liberty,Governor,,L,Keen Umbehr,0
-Clark,Sitka,Governor,,L,Keen Umbehr,0
-Clark,Appleton,Governor,,D,Paul Davis,83
-Clark,Center 1,Governor,,D,Paul Davis,73
-Clark,Center 2,Governor,,D,Paul Davis,48
-Clark,Englewood,Governor,,D,Paul Davis,14
-Clark,Lexington,Governor,,D,Paul Davis,5
-Clark,Liberty,Governor,,D,Paul Davis,3
-Clark,Sitka,Governor,,D,Paul Davis,14
-Clark,Appleton,Governor,,R,Sam Brownback,231
-Clark,Center 1,Governor,,R,Sam Brownback,130
-Clark,Center 2,Governor,,R,Sam Brownback,103
-Clark,Englewood,Governor,,R,Sam Brownback,35
-Clark,Lexington,Governor,,R,Sam Brownback,20
-Clark,Liberty,Governor,,R,Sam Brownback,14
-Clark,Sitka,Governor,,R,Sam Brownback,23
-Clark,Appleton,Insurance Commissioner,,D,Dennis Anderson,71
-Clark,Center 1,Insurance Commissioner,,D,Dennis Anderson,45
-Clark,Center 2,Insurance Commissioner,,D,Dennis Anderson,39
-Clark,Englewood,Insurance Commissioner,,D,Dennis Anderson,15
-Clark,Lexington,Insurance Commissioner,,D,Dennis Anderson,3
-Clark,Liberty,Insurance Commissioner,,D,Dennis Anderson,0
-Clark,Sitka,Insurance Commissioner,,D,Dennis Anderson,9
-Clark,Appleton,Insurance Commissioner,,R,Ken Selzer,240
-Clark,Center 1,Insurance Commissioner,,R,Ken Selzer,145
-Clark,Center 2,Insurance Commissioner,,R,Ken Selzer,111
-Clark,Englewood,Insurance Commissioner,,R,Ken Selzer,35
-Clark,Lexington,Insurance Commissioner,,R,Ken Selzer,20
-Clark,Liberty,Insurance Commissioner,,R,Ken Selzer,15
-Clark,Sitka,Insurance Commissioner,,R,Ken Selzer,24
-Clark,Appleton,Secretary of State,,D,Jean Kurtis Schodorf,63
-Clark,Center 1,Secretary of State,,D,Jean Kurtis Schodorf,53
-Clark,Center 2,Secretary of State,,D,Jean Kurtis Schodorf,39
-Clark,Englewood,Secretary of State,,D,Jean Kurtis Schodorf,20
-Clark,Lexington,Secretary of State,,D,Jean Kurtis Schodorf,3
-Clark,Liberty,Secretary of State,,D,Jean Kurtis Schodorf,0
-Clark,Sitka,Secretary of State,,D,Jean Kurtis Schodorf,8
-Clark,Appleton,Secretary of State,,R,Kris Kobach,265
-Clark,Center 1,Secretary of State,,R,Kris Kobach,155
-Clark,Center 2,Secretary of State,,R,Kris Kobach,117
-Clark,Englewood,Secretary of State,,R,Kris Kobach,29
-Clark,Lexington,Secretary of State,,R,Kris Kobach,20
-Clark,Liberty,Secretary of State,,R,Kris Kobach,16
-Clark,Sitka,Secretary of State,,R,Kris Kobach,26
-Clark,Appleton,State House,115,D,Mark Low,92
-Clark,Center 1,State House,115,D,Mark Low,56
-Clark,Center 2,State House,115,D,Mark Low,43
-Clark,Englewood,State House,115,D,Mark Low,17
-Clark,Lexington,State House,115,D,Mark Low,4
-Clark,Liberty,State House,115,D,Mark Low,0
-Clark,Sitka,State House,115,D,Mark Low,7
-Clark,Appleton,State House,115,R,"Ronald W Ryckman, Sr.",237
-Clark,Center 1,State House,115,R,"Ronald W Ryckman, Sr.",148
-Clark,Center 2,State House,115,R,"Ronald W Ryckman, Sr.",112
-Clark,Englewood,State House,115,R,"Ronald W Ryckman, Sr.",36
-Clark,Lexington,State House,115,R,"Ronald W Ryckman, Sr.",20
-Clark,Liberty,State House,115,R,"Ronald W Ryckman, Sr.",16
-Clark,Sitka,State House,115,R,"Ronald W Ryckman, Sr.",30
-Clark,Appleton,State Treasurer,,D,Carmen Alldritt,35
-Clark,Center 1,State Treasurer,,D,Carmen Alldritt,30
-Clark,Center 2,State Treasurer,,D,Carmen Alldritt,26
-Clark,Englewood,State Treasurer,,D,Carmen Alldritt,13
-Clark,Lexington,State Treasurer,,D,Carmen Alldritt,2
-Clark,Liberty,State Treasurer,,D,Carmen Alldritt,0
-Clark,Sitka,State Treasurer,,D,Carmen Alldritt,2
-Clark,Appleton,State Treasurer,,R,Ron Estes,289
-Clark,Center 1,State Treasurer,,R,Ron Estes,172
-Clark,Center 2,State Treasurer,,R,Ron Estes,126
-Clark,Englewood,State Treasurer,,R,Ron Estes,39
-Clark,Lexington,State Treasurer,,R,Ron Estes,22
-Clark,Liberty,State Treasurer,,R,Ron Estes,16
-Clark,Sitka,State Treasurer,,R,Ron Estes,34
-Clark,Appleton,U.S. House,1,D,James E. Sherow,67
-Clark,Center 1,U.S. House,1,D,James E. Sherow,49
-Clark,Center 2,U.S. House,1,D,James E. Sherow,43
-Clark,Englewood,U.S. House,1,D,James E. Sherow,20
-Clark,Lexington,U.S. House,1,D,James E. Sherow,4
-Clark,Liberty,U.S. House,1,D,James E. Sherow,0
-Clark,Sitka,U.S. House,1,D,James E. Sherow,12
-Clark,Appleton,U.S. House,1,R,Tim Huelskamp,259
-Clark,Center 1,U.S. House,1,R,Tim Huelskamp,162
-Clark,Center 2,U.S. House,1,R,Tim Huelskamp,109
-Clark,Englewood,U.S. House,1,R,Tim Huelskamp,30
-Clark,Lexington,U.S. House,1,R,Tim Huelskamp,21
-Clark,Liberty,U.S. House,1,R,Tim Huelskamp,17
-Clark,Sitka,U.S. House,1,R,Tim Huelskamp,25
-Clark,Appleton,U.S. Senate,,I,Greg Orman,64
-Clark,Center 1,U.S. Senate,,I,Greg Orman,54
-Clark,Center 2,U.S. Senate,,I,Greg Orman,33
-Clark,Englewood,U.S. Senate,,I,Greg Orman,12
-Clark,Lexington,U.S. Senate,,I,Greg Orman,4
-Clark,Liberty,U.S. Senate,,I,Greg Orman,2
-Clark,Sitka,U.S. Senate,,I,Greg Orman,8
-Clark,Appleton,U.S. Senate,,,Howard Wideman [wri],1
-Clark,Appleton,U.S. Senate,,R,Pat Roberts,239
-Clark,Center 1,U.S. Senate,,R,Pat Roberts,147
-Clark,Center 2,U.S. Senate,,R,Pat Roberts,120
-Clark,Englewood,U.S. Senate,,R,Pat Roberts,38
-Clark,Lexington,U.S. Senate,,R,Pat Roberts,19
-Clark,Liberty,U.S. Senate,,R,Pat Roberts,15
-Clark,Sitka,U.S. Senate,,R,Pat Roberts,29
-Clark,Appleton,U.S. Senate,,L,Randall Batson,19
-Clark,Center 1,U.S. Senate,,L,Randall Batson,7
-Clark,Center 2,U.S. Senate,,L,Randall Batson,5
-Clark,Englewood,U.S. Senate,,L,Randall Batson,2
-Clark,Lexington,U.S. Senate,,L,Randall Batson,1
-Clark,Liberty,U.S. Senate,,L,Randall Batson,0
-Clark,Sitka,U.S. Senate,,L,Randall Batson,0
+county,precinct,office,district,party,candidate,votes,vtd
+CLARK,Appleton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",83,000010
+CLARK,Appleton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000010
+CLARK,Appleton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",231,000010
+CLARK,Center 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000020
+CLARK,Center 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000020
+CLARK,Center 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000020
+CLARK,Center 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000030
+CLARK,Center 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000030
+CLARK,Center 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000030
+CLARK,Englewood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000040
+CLARK,Englewood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000040
+CLARK,Englewood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000040
+CLARK,Lexington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000050
+CLARK,Lexington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+CLARK,Lexington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000050
+CLARK,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000060
+CLARK,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+CLARK,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000060
+CLARK,Sitka Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000070
+CLARK,Sitka Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+CLARK,Sitka Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000070
+CLARK,Appleton Township,Kansas House of Representatives,115,Democratic,"Low, Mark",92,000010
+CLARK,Appleton Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",237,000010
+CLARK,Center 1,Kansas House of Representatives,115,Democratic,"Low, Mark",56,000020
+CLARK,Center 1,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",148,000020
+CLARK,Center 2,Kansas House of Representatives,115,Democratic,"Low, Mark",43,000030
+CLARK,Center 2,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",112,000030
+CLARK,Englewood Township,Kansas House of Representatives,115,Democratic,"Low, Mark",17,000040
+CLARK,Englewood Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",36,000040
+CLARK,Lexington Township,Kansas House of Representatives,115,Democratic,"Low, Mark",4,000050
+CLARK,Lexington Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",20,000050
+CLARK,Liberty Township,Kansas House of Representatives,115,Democratic,"Low, Mark",0,000060
+CLARK,Liberty Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",16,000060
+CLARK,Sitka Township,Kansas House of Representatives,115,Democratic,"Low, Mark",7,000070
+CLARK,Sitka Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",30,000070
+CLARK,Appleton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",67,000010
+CLARK,Appleton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",259,000010
+CLARK,Center 1,United States House of Representatives,1,Democratic,"Sherow, James E.",49,000020
+CLARK,Center 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",162,000020
+CLARK,Center 2,United States House of Representatives,1,Democratic,"Sherow, James E.",43,000030
+CLARK,Center 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",109,000030
+CLARK,Englewood Township,United States House of Representatives,1,Democratic,"Sherow, James E.",20,000040
+CLARK,Englewood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000040
+CLARK,Lexington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000050
+CLARK,Lexington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000050
+CLARK,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000060
+CLARK,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000060
+CLARK,Sitka Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000070
+CLARK,Sitka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000070
+CLARK,Appleton Township,Attorney General,,Democratic,"Kotich, A.J.",38,000010
+CLARK,Appleton Township,Attorney General,,Republican,"Schmidt, Derek",277,000010
+CLARK,Center 1,Attorney General,,Democratic,"Kotich, A.J.",31,000020
+CLARK,Center 1,Attorney General,,Republican,"Schmidt, Derek",169,000020
+CLARK,Center 2,Attorney General,,Democratic,"Kotich, A.J.",24,000030
+CLARK,Center 2,Attorney General,,Republican,"Schmidt, Derek",133,000030
+CLARK,Englewood Township,Attorney General,,Democratic,"Kotich, A.J.",12,000040
+CLARK,Englewood Township,Attorney General,,Republican,"Schmidt, Derek",40,000040
+CLARK,Lexington Township,Attorney General,,Democratic,"Kotich, A.J.",2,000050
+CLARK,Lexington Township,Attorney General,,Republican,"Schmidt, Derek",22,000050
+CLARK,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",0,000060
+CLARK,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",16,000060
+CLARK,Sitka Township,Attorney General,,Democratic,"Kotich, A.J.",3,000070
+CLARK,Sitka Township,Attorney General,,Republican,"Schmidt, Derek",31,000070
+CLARK,Appleton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000010
+CLARK,Appleton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",240,000010
+CLARK,Center 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000020
+CLARK,Center 1,Commissioner of Insurance,,Republican,"Selzer, Ken",145,000020
+CLARK,Center 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000030
+CLARK,Center 2,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000030
+CLARK,Englewood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000040
+CLARK,Englewood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000040
+CLARK,Lexington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000050
+CLARK,Lexington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000050
+CLARK,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000060
+CLARK,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000060
+CLARK,Sitka Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000070
+CLARK,Sitka Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000070
+CLARK,Appleton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",63,000010
+CLARK,Appleton Township,Secretary of State,,Republican,"Kobach, Kris",265,000010
+CLARK,Center 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,000020
+CLARK,Center 1,Secretary of State,,Republican,"Kobach, Kris",155,000020
+CLARK,Center 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000030
+CLARK,Center 2,Secretary of State,,Republican,"Kobach, Kris",117,000030
+CLARK,Englewood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000040
+CLARK,Englewood Township,Secretary of State,,Republican,"Kobach, Kris",29,000040
+CLARK,Lexington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000050
+CLARK,Lexington Township,Secretary of State,,Republican,"Kobach, Kris",20,000050
+CLARK,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000060
+CLARK,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",16,000060
+CLARK,Sitka Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000070
+CLARK,Sitka Township,Secretary of State,,Republican,"Kobach, Kris",26,000070
+CLARK,Appleton Township,State Treasurer,,Democratic,"Alldritt, Carmen",35,000010
+CLARK,Appleton Township,State Treasurer,,Republican,"Estes, Ron",289,000010
+CLARK,Center 1,State Treasurer,,Democratic,"Alldritt, Carmen",30,000020
+CLARK,Center 1,State Treasurer,,Republican,"Estes, Ron",172,000020
+CLARK,Center 2,State Treasurer,,Democratic,"Alldritt, Carmen",26,000030
+CLARK,Center 2,State Treasurer,,Republican,"Estes, Ron",126,000030
+CLARK,Englewood Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000040
+CLARK,Englewood Township,State Treasurer,,Republican,"Estes, Ron",39,000040
+CLARK,Lexington Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000050
+CLARK,Lexington Township,State Treasurer,,Republican,"Estes, Ron",22,000050
+CLARK,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000060
+CLARK,Liberty Township,State Treasurer,,Republican,"Estes, Ron",16,000060
+CLARK,Sitka Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000070
+CLARK,Sitka Township,State Treasurer,,Republican,"Estes, Ron",34,000070
+CLARK,Appleton Township,United States Senate,,independent,"Orman, Greg",64,000010
+CLARK,Appleton Township,United States Senate,,Libertarian,"Batson, Randall",19,000010
+CLARK,Appleton Township,United States Senate,,Republican,"Roberts, Pat",239,000010
+CLARK,Center 1,United States Senate,,independent,"Orman, Greg",54,000020
+CLARK,Center 1,United States Senate,,Libertarian,"Batson, Randall",7,000020
+CLARK,Center 1,United States Senate,,Republican,"Roberts, Pat",147,000020
+CLARK,Center 2,United States Senate,,independent,"Orman, Greg",33,000030
+CLARK,Center 2,United States Senate,,Libertarian,"Batson, Randall",5,000030
+CLARK,Center 2,United States Senate,,Republican,"Roberts, Pat",120,000030
+CLARK,Englewood Township,United States Senate,,independent,"Orman, Greg",12,000040
+CLARK,Englewood Township,United States Senate,,Libertarian,"Batson, Randall",2,000040
+CLARK,Englewood Township,United States Senate,,Republican,"Roberts, Pat",38,000040
+CLARK,Lexington Township,United States Senate,,independent,"Orman, Greg",4,000050
+CLARK,Lexington Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+CLARK,Lexington Township,United States Senate,,Republican,"Roberts, Pat",19,000050
+CLARK,Liberty Township,United States Senate,,independent,"Orman, Greg",2,000060
+CLARK,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+CLARK,Liberty Township,United States Senate,,Republican,"Roberts, Pat",15,000060
+CLARK,Sitka Township,United States Senate,,independent,"Orman, Greg",8,000070
+CLARK,Sitka Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+CLARK,Sitka Township,United States Senate,,Republican,"Roberts, Pat",29,000070

--- a/2014/20141104__ks__general__clay__precinct.csv
+++ b/2014/20141104__ks__general__clay__precinct.csv
@@ -1,546 +1,426 @@
-county,precinct,office,district,party,candidate,votes
-Clay,Ward 1,Voters,,,Registered,859
-Clay,Ward 1,Voters,,,Ballots cast,504
-Clay,Ward 1,U.S. Senate,,L,Randall Batson,24
-Clay,Ward 1,U.S. Senate,,I,Greg Orman,171
-Clay,Ward 1,U.S. Senate,,R,Pat Roberts,300
-Clay,Ward 1,U.S. House,1,R,Tim Huelskamp,307
-Clay,Ward 1,U.S. House,1,D,James Sherow,185
-Clay,Ward 1,U.S. House,1,,Write-ins,1
-Clay,Ward 1,Governor,,R,Sam Brownback,250
-Clay,Ward 1,Governor,,D,Paul Davis,219
-Clay,Ward 1,Governor,,L,Keen Umbehr,28
-Clay,Ward 1,Governor,,,Write-ins,1
-Clay,Ward 1,Secretary of State,,R,Kris Kobach,337
-Clay,Ward 1,Secretary of State,,D,Jean Schodorf,152
-Clay,Ward 1,Secretary of State,,,Write-ins,2
-Clay,Ward 1,Attorney General,,R,A J Kotich,90
-Clay,Ward 1,Attorney General,,D,Derek Schmidt,393
-Clay,Ward 1,State Treasurer,,D,Carmen Alldritt,84
-Clay,Ward 1,State Treasurer,,R,Ron Estes,393
-Clay,Ward 1,Insurance Commissioner,,D,Dennis Anderson,116
-Clay,Ward 1,Insurance Commissioner,,R,Ken Selzer,355
-Clay,Ward 1,State House,64,R,Susie Swanson,436
-Clay,Ward 1,State House,64,,Write-ins,23
-Clay,Ward 2,Voters,,,Registered,915
-Clay,Ward 2,Voters,,,Ballots cast,547
-Clay,Ward 2,U.S. Senate,,L,Randall Batson,23
-Clay,Ward 2,U.S. Senate,,I,Greg Orman,170
-Clay,Ward 2,U.S. Senate,,R,Pat Roberts,350
-Clay,Ward 2,U.S. House,1,R,Tim Huelskamp,343
-Clay,Ward 2,U.S. House,1,D,James Sherow,189
-Clay,Ward 2,U.S. House,1,,Write-ins,0
-Clay,Ward 2,Governor,,R,Sam Brownback,289
-Clay,Ward 2,Governor,,D,Paul Davis,236
-Clay,Ward 2,Governor,,L,Keen Umbehr,15
-Clay,Ward 2,Governor,,,Write-ins,0
-Clay,Ward 2,Secretary of State,,R,Kris Kobach,373
-Clay,Ward 2,Secretary of State,,D,Jean Schodorf,164
-Clay,Ward 2,Secretary of State,,,Write-ins,0
-Clay,Ward 2,Attorney General,,R,A J Kotich,109
-Clay,Ward 2,Attorney General,,D,Derek Schmidt,421
-Clay,Ward 2,Attorney General,,,Write-ins,1
-Clay,Ward 2,State Treasurer,,D,Carmen Alldritt,106
-Clay,Ward 2,State Treasurer,,R,Ron Estes,413
-Clay,Ward 2,Insurance Commissioner,,D,Dennis Anderson,124
-Clay,Ward 2,Insurance Commissioner,,R,Ken Selzer,391
-Clay,Ward 2,State House,64,R,Susie Swanson,485
-Clay,Ward 2,State House,64,,Write-ins,20
-Clay,Ward 3,Voters,,,Registered,619
-Clay,Ward 3,Voters,,,Ballots cast,298
-Clay,Ward 3,U.S. Senate,,L,Randall Batson,14
-Clay,Ward 3,U.S. Senate,,I,Greg Orman,83
-Clay,Ward 3,U.S. Senate,,R,Pat Roberts,199
-Clay,Ward 3,U.S. House,1,R,Tim Huelskamp,198
-Clay,Ward 3,U.S. House,1,D,James Sherow,92
-Clay,Ward 3,U.S. House,1,,Write-ins,0
-Clay,Ward 3,Governor,,R,Sam Brownback,170
-Clay,Ward 3,Governor,,D,Paul Davis,112
-Clay,Ward 3,Governor,,L,Keen Umbehr,10
-Clay,Ward 3,Governor,,,Write-ins,0
-Clay,Ward 3,Secretary of State,,R,Kris Kobach,213
-Clay,Ward 3,Secretary of State,,D,Jean Schodorf,76
-Clay,Ward 3,Secretary of State,,,Write-ins,0
-Clay,Ward 3,Attorney General,,R,A J Kotich,57
-Clay,Ward 3,Attorney General,,D,Derek Schmidt,233
-Clay,Ward 3,Attorney General,,,Write-ins,0
-Clay,Ward 3,State Treasurer,,D,Carmen Alldritt,48
-Clay,Ward 3,State Treasurer,,R,Ron Estes,239
-Clay,Ward 3,Insurance Commissioner,,D,Dennis Anderson,61
-Clay,Ward 3,Insurance Commissioner,,R,Ken Selzer,223
-Clay,Ward 3,State House,64,R,Susie Swanson,258
-Clay,Ward 3,State House,64,,Write-ins,17
-Clay,Blaine,Voters,,,Registered,197
-Clay,Blaine,Voters,,,Ballots cast,125
-Clay,Blaine,U.S. Senate,,L,Randall Batson,0
-Clay,Blaine,U.S. Senate,,I,Greg Orman,27
-Clay,Blaine,U.S. Senate,,R,Pat Roberts,97
-Clay,Blaine,U.S. House,1,R,Tim Huelskamp,91
-Clay,Blaine,U.S. House,1,D,James Sherow,34
-Clay,Blaine,U.S. House,1,,Write-ins,0
-Clay,Blaine,Governor,,R,Sam Brownback,83
-Clay,Blaine,Governor,,D,Paul Davis,38
-Clay,Blaine,Governor,,L,Keen Umbehr,2
-Clay,Blaine,Governor,,,Write-ins,0
-Clay,Blaine,Secretary of State,,R,Kris Kobach,97
-Clay,Blaine,Secretary of State,,D,Jean Schodorf,27
-Clay,Blaine,Secretary of State,,,Write-ins,0
-Clay,Blaine,Attorney General,,R,A J Kotich,12
-Clay,Blaine,Attorney General,,D,Derek Schmidt,111
-Clay,Blaine,Attorney General,,,Write-ins,0
-Clay,Blaine,State Treasurer,,D,Carmen Alldritt,9
-Clay,Blaine,State Treasurer,,R,Ron Estes,112
-Clay,Blaine,Insurance Commissioner,,D,Dennis Anderson,21
-Clay,Blaine,Insurance Commissioner,,R,Ken Selzer,100
-Clay,Blaine,Insurance Commissioner,,,Write-ins,1
-Clay,Blaine,State House,64,R,Susie Swanson,106
-Clay,Blaine,State House,64,,Write-ins,5
-Clay,Bloom,Voters,,,Registered,80
-Clay,Bloom,Voters,,,Ballots cast,53
-Clay,Bloom,U.S. Senate,,L,Randall Batson,2
-Clay,Bloom,U.S. Senate,,I,Greg Orman,6
-Clay,Bloom,U.S. Senate,,R,Pat Roberts,45
-Clay,Bloom,U.S. House,1,R,Tim Huelskamp,44
-Clay,Bloom,U.S. House,1,D,James Sherow,8
-Clay,Bloom,U.S. House,1,,Write-ins,0
-Clay,Bloom,Governor,,R,Sam Brownback,40
-Clay,Bloom,Governor,,D,Paul Davis,8
-Clay,Bloom,Governor,,L,Keen Umbehr,3
-Clay,Bloom,Governor,,,Write-ins,1
-Clay,Bloom,Secretary of State,,R,Kris Kobach,45
-Clay,Bloom,Secretary of State,,D,Jean Schodorf,6
-Clay,Bloom,Secretary of State,,,Write-ins,0
-Clay,Bloom,Attorney General,,R,A J Kotich,1
-Clay,Bloom,Attorney General,,D,Derek Schmidt,50
-Clay,Bloom,Attorney General,,,Write-ins,0
-Clay,Bloom,State Treasurer,,D,Carmen Alldritt,1
-Clay,Bloom,State Treasurer,,R,Ron Estes,49
-Clay,Bloom,Insurance Commissioner,,D,Dennis Anderson,3
-Clay,Bloom,Insurance Commissioner,,R,Ken Selzer,45
-Clay,Bloom,Insurance Commissioner,,,Write-ins,0
-Clay,Bloom,State House,64,R,Susie Swanson,43
-Clay,Bloom,State House,64,,Write-ins,2
-Clay,Clay Ctr twp,Voters,,,Registered,266
-Clay,Clay Ctr twp,Voters,,,Ballots cast,162
-Clay,Clay Ctr twp,U.S. Senate,,L,Randall Batson,3
-Clay,Clay Ctr twp,U.S. Senate,,I,Greg Orman,46
-Clay,Clay Ctr twp,U.S. Senate,,R,Pat Roberts,112
-Clay,Clay Ctr twp,U.S. House,1,R,Tim Huelskamp,112
-Clay,Clay Ctr twp,U.S. House,1,D,James Sherow,46
-Clay,Clay Ctr twp,U.S. House,1,,Write-ins,0
-Clay,Clay Ctr twp,Governor,,R,Sam Brownback,97
-Clay,Clay Ctr twp,Governor,,D,Paul Davis,54
-Clay,Clay Ctr twp,Governor,,L,Keen Umbehr,7
-Clay,Clay Ctr twp,Governor,,,Write-ins,0
-Clay,Clay Ctr twp,Secretary of State,,R,Kris Kobach,126
-Clay,Clay Ctr twp,Secretary of State,,D,Jean Schodorf,32
-Clay,Clay Ctr twp,Secretary of State,,,Write-ins,0
-Clay,Clay Ctr twp,Attorney General,,R,A J Kotich,20
-Clay,Clay Ctr twp,Attorney General,,D,Derek Schmidt,138
-Clay,Clay Ctr twp,Attorney General,,,Write-ins,0
-Clay,Clay Ctr twp,State Treasurer,,D,Carmen Alldritt,20
-Clay,Clay Ctr twp,State Treasurer,,R,Ron Estes,135
-Clay,Clay Ctr twp,Insurance Commissioner,,D,Dennis Anderson,24
-Clay,Clay Ctr twp,Insurance Commissioner,,R,Ken Selzer,131
-Clay,Clay Ctr twp,Insurance Commissioner,,,Write-ins,0
-Clay,Clay Ctr twp,State House,64,R,Susie Swanson,140
-Clay,Clay Ctr twp,State House,64,,Write-ins,7
-Clay,Exeter,Voters,,,Registered,61
-Clay,Exeter,Voters,,,Ballots cast,40
-Clay,Exeter,U.S. Senate,,L,Randall Batson,1
-Clay,Exeter,U.S. Senate,,I,Greg Orman,4
-Clay,Exeter,U.S. Senate,,R,Pat Roberts,35
-Clay,Exeter,U.S. House,1,R,Tim Huelskamp,32
-Clay,Exeter,U.S. House,1,D,James Sherow,6
-Clay,Exeter,U.S. House,1,,Write-ins,0
-Clay,Exeter,Governor,,R,Sam Brownback,33
-Clay,Exeter,Governor,,D,Paul Davis,5
-Clay,Exeter,Governor,,L,Keen Umbehr,2
-Clay,Exeter,Governor,,,Write-ins,0
-Clay,Exeter,Secretary of State,,R,Kris Kobach,36
-Clay,Exeter,Secretary of State,,D,Jean Schodorf,2
-Clay,Exeter,Secretary of State,,,Write-ins,0
-Clay,Exeter,Attorney General,,R,A J Kotich,2
-Clay,Exeter,Attorney General,,D,Derek Schmidt,36
-Clay,Exeter,Attorney General,,,Write-ins,0
-Clay,Exeter,State Treasurer,,D,Carmen Alldritt,1
-Clay,Exeter,State Treasurer,,R,Ron Estes,36
-Clay,Exeter,Insurance Commissioner,,D,Dennis Anderson,1
-Clay,Exeter,Insurance Commissioner,,R,Ken Selzer,35
-Clay,Exeter,Insurance Commissioner,,,Write-ins,0
-Clay,Exeter,State House,64,R,Susie Swanson,32
-Clay,Exeter,State House,64,,Write-ins,3
-Clay,Five Creeks,Voters,,,Registered,82
-Clay,Five Creeks,Voters,,,Ballots cast,46
-Clay,Five Creeks,U.S. Senate,,L,Randall Batson,1
-Clay,Five Creeks,U.S. Senate,,I,Greg Orman,11
-Clay,Five Creeks,U.S. Senate,,R,Pat Roberts,34
-Clay,Five Creeks,U.S. House,1,R,Tim Huelskamp,35
-Clay,Five Creeks,U.S. House,1,D,James Sherow,8
-Clay,Five Creeks,U.S. House,1,,Write-ins,0
-Clay,Five Creeks,Governor,,R,Sam Brownback,29
-Clay,Five Creeks,Governor,,D,Paul Davis,13
-Clay,Five Creeks,Governor,,L,Keen Umbehr,4
-Clay,Five Creeks,Governor,,,Write-ins,0
-Clay,Five Creeks,Secretary of State,,R,Kris Kobach,36
-Clay,Five Creeks,Secretary of State,,D,Jean Schodorf,8
-Clay,Five Creeks,Secretary of State,,,Write-ins,0
-Clay,Five Creeks,Attorney General,,R,A J Kotich,4
-Clay,Five Creeks,Attorney General,,D,Derek Schmidt,42
-Clay,Five Creeks,Attorney General,,,Write-ins,0
-Clay,Five Creeks,State Treasurer,,D,Carmen Alldritt,4
-Clay,Five Creeks,State Treasurer,,R,Ron Estes,42
-Clay,Five Creeks,Insurance Commissioner,,D,Dennis Anderson,8
-Clay,Five Creeks,Insurance Commissioner,,R,Ken Selzer,36
-Clay,Five Creeks,Insurance Commissioner,,,Write-ins,0
-Clay,Five Creeks,State House,64,R,Susie Swanson,38
-Clay,Five Creeks,State House,64,,Write-ins,2
-Clay,Garfield,Voters,,,Registered,72
-Clay,Garfield,Voters,,,Ballots cast,40
-Clay,Garfield,U.S. Senate,,L,Randall Batson,1
-Clay,Garfield,U.S. Senate,,I,Greg Orman,7
-Clay,Garfield,U.S. Senate,,R,Pat Roberts,30
-Clay,Garfield,U.S. House,1,R,Tim Huelskamp,32
-Clay,Garfield,U.S. House,1,D,James Sherow,6
-Clay,Garfield,U.S. House,1,,Write-ins,0
-Clay,Garfield,Governor,,R,Sam Brownback,30
-Clay,Garfield,Governor,,D,Paul Davis,6
-Clay,Garfield,Governor,,L,Keen Umbehr,2
-Clay,Garfield,Governor,,,Write-ins,0
-Clay,Garfield,Secretary of State,,R,Kris Kobach,34
-Clay,Garfield,Secretary of State,,D,Jean Schodorf,5
-Clay,Garfield,Secretary of State,,,Write-ins,0
-Clay,Garfield,Attorney General,,R,A J Kotich,3
-Clay,Garfield,Attorney General,,D,Derek Schmidt,35
-Clay,Garfield,Attorney General,,,Write-ins,0
-Clay,Garfield,State Treasurer,,D,Carmen Alldritt,3
-Clay,Garfield,State Treasurer,,R,Ron Estes,36
-Clay,Garfield,Insurance Commissioner,,D,Dennis Anderson,5
-Clay,Garfield,Insurance Commissioner,,R,Ken Selzer,31
-Clay,Garfield,Insurance Commissioner,,,Write-ins,0
-Clay,Garfield,State House,64,R,Susie Swanson,34
-Clay,Garfield,State House,64,,Write-ins,3
-Clay,Goshen,Voters,,,Registered,45
-Clay,Goshen,Voters,,,Ballots cast,24
-Clay,Goshen,U.S. Senate,,L,Randall Batson,0
-Clay,Goshen,U.S. Senate,,I,Greg Orman,6
-Clay,Goshen,U.S. Senate,,R,Pat Roberts,17
-Clay,Goshen,U.S. House,1,R,Tim Huelskamp,18
-Clay,Goshen,U.S. House,1,D,James Sherow,6
-Clay,Goshen,U.S. House,1,,Write-ins,0
-Clay,Goshen,Governor,,R,Sam Brownback,13
-Clay,Goshen,Governor,,D,Paul Davis,9
-Clay,Goshen,Governor,,L,Keen Umbehr,1
-Clay,Goshen,Governor,,,Write-ins,0
-Clay,Goshen,Secretary of State,,R,Kris Kobach,17
-Clay,Goshen,Secretary of State,,D,Jean Schodorf,5
-Clay,Goshen,Secretary of State,,,Write-ins,0
-Clay,Goshen,Attorney General,,R,A J Kotich,5
-Clay,Goshen,Attorney General,,D,Derek Schmidt,17
-Clay,Goshen,Attorney General,,,Write-ins,0
-Clay,Goshen,State Treasurer,,D,Carmen Alldritt,6
-Clay,Goshen,State Treasurer,,R,Ron Estes,16
-Clay,Goshen,Insurance Commissioner,,D,Dennis Anderson,7
-Clay,Goshen,Insurance Commissioner,,R,Ken Selzer,15
-Clay,Goshen,Insurance Commissioner,,,Write-ins,0
-Clay,Goshen,State House,64,R,Susie Swanson,21
-Clay,Goshen,State House,64,,Write-ins,0
-Clay,Grant,Voters,,,Registered,134
-Clay,Grant,Voters,,,Ballots cast,76
-Clay,Grant,U.S. Senate,,L,Randall Batson,2
-Clay,Grant,U.S. Senate,,I,Greg Orman,9
-Clay,Grant,U.S. Senate,,R,Pat Roberts,64
-Clay,Grant,U.S. House,1,R,Tim Huelskamp,59
-Clay,Grant,U.S. House,1,D,James Sherow,15
-Clay,Grant,U.S. House,1,,Write-ins,0
-Clay,Grant,Governor,,R,Sam Brownback,58
-Clay,Grant,Governor,,D,Paul Davis,13
-Clay,Grant,Governor,,L,Keen Umbehr,4
-Clay,Grant,Governor,,,Write-ins,0
-Clay,Grant,Secretary of State,,R,Kris Kobach,63
-Clay,Grant,Secretary of State,,D,Jean Schodorf,12
-Clay,Grant,Secretary of State,,,Write-ins,0
-Clay,Grant,Attorney General,,R,A J Kotich,7
-Clay,Grant,Attorney General,,D,Derek Schmidt,69
-Clay,Grant,Attorney General,,,Write-ins,0
-Clay,Grant,State Treasurer,,D,Carmen Alldritt,10
-Clay,Grant,State Treasurer,,R,Ron Estes,65
-Clay,Grant,Insurance Commissioner,,D,Dennis Anderson,7
-Clay,Grant,Insurance Commissioner,,R,Ken Selzer,68
-Clay,Grant,Insurance Commissioner,,,Write-ins,0
-Clay,Grant,State House,64,R,Susie Swanson,56
-Clay,Grant,State House,64,,Write-ins,10
-Clay,Hayes,Voters,,,Registered,142
-Clay,Hayes,Voters,,,Ballots cast,98
-Clay,Hayes,U.S. Senate,,L,Randall Batson,2
-Clay,Hayes,U.S. Senate,,I,Greg Orman,14
-Clay,Hayes,U.S. Senate,,R,Pat Roberts,81
-Clay,Hayes,U.S. House,1,R,Tim Huelskamp,75
-Clay,Hayes,U.S. House,1,D,James Sherow,22
-Clay,Hayes,U.S. House,1,,Write-ins,0
-Clay,Hayes,Governor,,R,Sam Brownback,71
-Clay,Hayes,Governor,,D,Paul Davis,23
-Clay,Hayes,Governor,,L,Keen Umbehr,4
-Clay,Hayes,Governor,,,Write-ins,0
-Clay,Hayes,Secretary of State,,R,Kris Kobach,79
-Clay,Hayes,Secretary of State,,D,Jean Schodorf,17
-Clay,Hayes,Secretary of State,,,Write-ins,0
-Clay,Hayes,Attorney General,,R,A J Kotich,12
-Clay,Hayes,Attorney General,,D,Derek Schmidt,83
-Clay,Hayes,State Treasurer,,D,Carmen Alldritt,8
-Clay,Hayes,State Treasurer,,R,Ron Estes,88
-Clay,Hayes,Insurance Commissioner,,D,Dennis Anderson,12
-Clay,Hayes,Insurance Commissioner,,R,Ken Selzer,81
-Clay,Hayes,Insurance Commissioner,,,Write-ins,1
-Clay,Hayes,State House,64,R,Susie Swanson,85
-Clay,Hayes,State House,64,,Write-ins,6
-Clay,Highland,Voters,,,Registered,186
-Clay,Highland,Voters,,,Ballots cast,119
-Clay,Highland,U.S. Senate,,L,Randall Batson,4
-Clay,Highland,U.S. Senate,,I,Greg Orman,33
-Clay,Highland,U.S. Senate,,R,Pat Roberts,80
-Clay,Highland,U.S. House,1,R,Tim Huelskamp,85
-Clay,Highland,U.S. House,1,D,James Sherow,28
-Clay,Highland,U.S. House,1,,Write-ins,0
-Clay,Highland,Governor,,R,Sam Brownback,80
-Clay,Highland,Governor,,D,Paul Davis,33
-Clay,Highland,Governor,,L,Keen Umbehr,5
-Clay,Highland,Governor,,,Write-ins,0
-Clay,Highland,Secretary of State,,R,Kris Kobach,93
-Clay,Highland,Secretary of State,,D,Jean Schodorf,24
-Clay,Highland,Secretary of State,,,Write-ins,0
-Clay,Highland,Attorney General,,R,A J Kotich,21
-Clay,Highland,Attorney General,,D,Derek Schmidt,94
-Clay,Highland,Attorney General,,,Write-ins,0
-Clay,Highland,State Treasurer,,D,Carmen Alldritt,24
-Clay,Highland,State Treasurer,,R,Ron Estes,92
-Clay,Highland,Insurance Commissioner,,D,Dennis Anderson,27
-Clay,Highland,Insurance Commissioner,,R,Ken Selzer,85
-Clay,Highland,State House,64,R,Susie Swanson,91
-Clay,Highland,State House,64,,Write-ins,6
-Clay,Mulberry,Voters,,,Registered,193
-Clay,Mulberry,Voters,,,Ballots cast,84
-Clay,Mulberry,U.S. Senate,,L,Randall Batson,2
-Clay,Mulberry,U.S. Senate,,I,Greg Orman,20
-Clay,Mulberry,U.S. Senate,,R,Pat Roberts,62
-Clay,Mulberry,U.S. House,1,R,Tim Huelskamp,60
-Clay,Mulberry,U.S. House,1,D,James Sherow,21
-Clay,Mulberry,U.S. House,1,,Write-ins,2
-Clay,Mulberry,Governor,,R,Sam Brownback,54
-Clay,Mulberry,Governor,,D,Paul Davis,24
-Clay,Mulberry,Governor,,L,Keen Umbehr,4
-Clay,Mulberry,Governor,,,Write-ins,0
-Clay,Mulberry,Secretary of State,,R,Kris Kobach,63
-Clay,Mulberry,Secretary of State,,D,Jean Schodorf,18
-Clay,Mulberry,Secretary of State,,,Write-ins,1
-Clay,Mulberry,Attorney General,,R,A J Kotich,8
-Clay,Mulberry,Attorney General,,D,Derek Schmidt,72
-Clay,Mulberry,Attorney General,,,Write-ins,0
-Clay,Mulberry,State Treasurer,,D,Carmen Alldritt,8
-Clay,Mulberry,State Treasurer,,R,Ron Estes,72
-Clay,Mulberry,State Treasurer,,,Write-ins,1
-Clay,Mulberry,Insurance Commissioner,,D,Dennis Anderson,10
-Clay,Mulberry,Insurance Commissioner,,R,Ken Selzer,69
-Clay,Mulberry,State House,64,R,Susie Swanson,72
-Clay,Mulberry,State House,64,,Write-ins,0
-Clay,Sherman,Voters,,,Registered,181
-Clay,Sherman,Voters,,,Ballots cast,89
-Clay,Sherman,U.S. Senate,,L,Randall Batson,3
-Clay,Sherman,U.S. Senate,,I,Greg Orman,28
-Clay,Sherman,U.S. Senate,,R,Pat Roberts,56
-Clay,Sherman,U.S. Senate,,,Write-ins,1
-Clay,Sherman,U.S. House,1,R,Tim Huelskamp,51
-Clay,Sherman,U.S. House,1,D,James Sherow,36
-Clay,Sherman,U.S. House,1,,Write-ins,0
-Clay,Sherman,Governor,,R,Sam Brownback,50
-Clay,Sherman,Governor,,D,Paul Davis,32
-Clay,Sherman,Governor,,L,Keen Umbehr,5
-Clay,Sherman,Governor,,,Write-ins,0
-Clay,Sherman,Secretary of State,,R,Kris Kobach,59
-Clay,Sherman,Secretary of State,,D,Jean Schodorf,28
-Clay,Sherman,Secretary of State,,,Write-ins,0
-Clay,Sherman,Attorney General,,R,A J Kotich,21
-Clay,Sherman,Attorney General,,D,Derek Schmidt,65
-Clay,Sherman,Attorney General,,,Write-ins,0
-Clay,Sherman,State Treasurer,,D,Carmen Alldritt,19
-Clay,Sherman,State Treasurer,,R,Ron Estes,69
-Clay,Sherman,Insurance Commissioner,,D,Dennis Anderson,26
-Clay,Sherman,Insurance Commissioner,,R,Ken Selzer,62
-Clay,Sherman,Insurance Commissioner,,,Write-ins,0
-Clay,Sherman,State House,64,R,Susie Swanson,76
-Clay,Sherman,State House,64,,Write-ins,1
-Clay,Ward 4,Voters,,,Registered,603
-Clay,Ward 4,Voters,,,Ballots cast,255
-Clay,Ward 4,U.S. Senate,,L,Randall Batson,16
-Clay,Ward 4,U.S. Senate,,I,Greg Orman,87
-Clay,Ward 4,U.S. Senate,,R,Pat Roberts,151
-Clay,Ward 4,U.S. House,1,R,Tim Huelskamp,153
-Clay,Ward 4,U.S. House,1,D,James Sherow,97
-Clay,Ward 4,U.S. House,1,,Write-ins,0
-Clay,Ward 4,Governor,,R,Sam Brownback,120
-Clay,Ward 4,Governor,,D,Paul Davis,115
-Clay,Ward 4,Governor,,L,Keen Umbehr,15
-Clay,Ward 4,Governor,,,Write-ins,2
-Clay,Ward 4,Secretary of State,,R,Kris Kobach,161
-Clay,Ward 4,Secretary of State,,D,Jean Schodorf,86
-Clay,Ward 4,Secretary of State,,,Write-ins,1
-Clay,Ward 4,Attorney General,,R,A J Kotich,65
-Clay,Ward 4,Attorney General,,D,Derek Schmidt,182
-Clay,Ward 4,Attorney General,,,Write-ins,0
-Clay,Ward 4,State Treasurer,,D,Carmen Alldritt,66
-Clay,Ward 4,State Treasurer,,R,Ron Estes,178
-Clay,Ward 4,Insurance Commissioner,,D,Dennis Anderson,71
-Clay,Ward 4,Insurance Commissioner,,R,Ken Selzer,168
-Clay,Ward 4,Insurance Commissioner,,,Write-ins,0
-Clay,Ward 4,State House,64,R,Susie Swanson,221
-Clay,Ward 4,State House,64,,Write-ins,14
-Clay,Athelstane,Voters,,,Registered,80
-Clay,Athelstane,Voters,,,Ballots cast,59
-Clay,Athelstane,U.S. Senate,,L,Randall Batson,0
-Clay,Athelstane,U.S. Senate,,I,Greg Orman,5
-Clay,Athelstane,U.S. Senate,,R,Pat Roberts,54
-Clay,Athelstane,U.S. House,1,R,Tim Huelskamp,51
-Clay,Athelstane,U.S. House,1,D,James Sherow,8
-Clay,Athelstane,U.S. House,1,,Write-ins,0
-Clay,Athelstane,Governor,,R,Sam Brownback,54
-Clay,Athelstane,Governor,,D,Paul Davis,2
-Clay,Athelstane,Governor,,L,Keen Umbehr,3
-Clay,Athelstane,Governor,,,Write-ins,0
-Clay,Athelstane,Secretary of State,,R,Kris Kobach,56
-Clay,Athelstane,Secretary of State,,D,Jean Schodorf,3
-Clay,Athelstane,Secretary of State,,,Write-ins,0
-Clay,Athelstane,Attorney General,,R,A J Kotich,2
-Clay,Athelstane,Attorney General,,D,Derek Schmidt,57
-Clay,Athelstane,Attorney General,,,Write-ins,0
-Clay,Athelstane,State Treasurer,,D,Carmen Alldritt,2
-Clay,Athelstane,State Treasurer,,R,Ron Estes,56
-Clay,Athelstane,Insurance Commissioner,,D,Dennis Anderson,1
-Clay,Athelstane,Insurance Commissioner,,R,Ken Selzer,58
-Clay,Athelstane,Insurance Commissioner,,,Write-ins,0
-Clay,Athelstane,State House,64,R,Susie Swanson,57
-Clay,Athelstane,State House,64,,Write-ins,0
-Clay,Chapman,Voters,,,Registered,143
-Clay,Chapman,Voters,,,Ballots cast,60
-Clay,Chapman,U.S. Senate,,L,Randall Batson,4
-Clay,Chapman,U.S. Senate,,I,Greg Orman,17
-Clay,Chapman,U.S. Senate,,R,Pat Roberts,39
-Clay,Chapman,U.S. House,1,R,Tim Huelskamp,39
-Clay,Chapman,U.S. House,1,D,James Sherow,21
-Clay,Chapman,U.S. House,1,,Write-ins,0
-Clay,Chapman,Governor,,R,Sam Brownback,32
-Clay,Chapman,Governor,,D,Paul Davis,23
-Clay,Chapman,Governor,,L,Keen Umbehr,4
-Clay,Chapman,Governor,,,Write-ins,0
-Clay,Chapman,Secretary of State,,R,Kris Kobach,40
-Clay,Chapman,Secretary of State,,D,Jean Schodorf,20
-Clay,Chapman,Secretary of State,,,Write-ins,0
-Clay,Chapman,Attorney General,,R,A J Kotich,14
-Clay,Chapman,Attorney General,,D,Derek Schmidt,45
-Clay,Chapman,Attorney General,,,Write-ins,0
-Clay,Chapman,State Treasurer,,D,Carmen Alldritt,13
-Clay,Chapman,State Treasurer,,R,Ron Estes,46
-Clay,Chapman,Insurance Commissioner,,D,Dennis Anderson,18
-Clay,Chapman,Insurance Commissioner,,R,Ken Selzer,40
-Clay,Chapman,Insurance Commissioner,,,Write-ins,0
-Clay,Chapman,State House,70,R,John Barker,53
-Clay,Chapman,State House,70,,Write-ins,1
-Clay,Gill,Voters,,,Registered,112
-Clay,Gill,Voters,,,Ballots cast,70
-Clay,Gill,U.S. Senate,,L,Randall Batson,2
-Clay,Gill,U.S. Senate,,I,Greg Orman,14
-Clay,Gill,U.S. Senate,,R,Pat Roberts,53
-Clay,Gill,U.S. House,1,R,Tim Huelskamp,51
-Clay,Gill,U.S. House,1,D,James Sherow,18
-Clay,Gill,U.S. House,1,,Write-ins,0
-Clay,Gill,Governor,,R,Sam Brownback,52
-Clay,Gill,Governor,,D,Paul Davis,17
-Clay,Gill,Governor,,L,Keen Umbehr,1
-Clay,Gill,Governor,,,Write-ins,0
-Clay,Gill,Secretary of State,,R,Kris Kobach,55
-Clay,Gill,Secretary of State,,D,Jean Schodorf,14
-Clay,Gill,Secretary of State,,,Write-ins,0
-Clay,Gill,Attorney General,,R,A J Kotich,9
-Clay,Gill,Attorney General,,D,Derek Schmidt,60
-Clay,Gill,Attorney General,,,Write-ins,0
-Clay,Gill,State Treasurer,,D,Carmen Alldritt,9
-Clay,Gill,State Treasurer,,R,Ron Estes,59
-Clay,Gill,Insurance Commissioner,,D,Dennis Anderson,9
-Clay,Gill,Insurance Commissioner,,R,Ken Selzer,60
-Clay,Gill,Insurance Commissioner,,,Write-ins,0
-Clay,Gill,State House,64,R,Susie Swanson,63
-Clay,Gill,State House,64,,Write-ins,2
-Clay,Oakland,Voters,,,Registered,74
-Clay,Oakland,Voters,,,Ballots cast,36
-Clay,Oakland,U.S. Senate,,L,Randall Batson,0
-Clay,Oakland,U.S. Senate,,I,Greg Orman,12
-Clay,Oakland,U.S. Senate,,R,Pat Roberts,23
-Clay,Oakland,U.S. House,1,R,Tim Huelskamp,24
-Clay,Oakland,U.S. House,1,D,James Sherow,10
-Clay,Oakland,U.S. House,1,,Write-ins,0
-Clay,Oakland,Governor,,R,Sam Brownback,20
-Clay,Oakland,Governor,,D,Paul Davis,13
-Clay,Oakland,Governor,,L,Keen Umbehr,2
-Clay,Oakland,Governor,,,Write-ins,0
-Clay,Oakland,Secretary of State,,R,Kris Kobach,23
-Clay,Oakland,Secretary of State,,D,Jean Schodorf,10
-Clay,Oakland,Secretary of State,,,Write-ins,0
-Clay,Oakland,Attorney General,,R,A J Kotich,10
-Clay,Oakland,Attorney General,,D,Derek Schmidt,23
-Clay,Oakland,Attorney General,,,Write-ins,0
-Clay,Oakland,State Treasurer,,D,Carmen Alldritt,6
-Clay,Oakland,State Treasurer,,R,Ron Estes,26
-Clay,Oakland,Insurance Commissioner,,D,Dennis Anderson,13
-Clay,Oakland,Insurance Commissioner,,R,Ken Selzer,17
-Clay,Oakland,Insurance Commissioner,,,Write-ins,0
-Clay,Oakland,State House,64,R,Susie Swanson,25
-Clay,Oakland,State House,64,,Write-ins,3
-Clay,Republican,Voters,,,Registered,647
-Clay,Republican,Voters,,,Ballots cast,318
-Clay,Republican,U.S. Senate,,L,Randall Batson,25
-Clay,Republican,U.S. Senate,,I,Greg Orman,74
-Clay,Republican,U.S. Senate,,R,Pat Roberts,216
-Clay,Republican,U.S. House,1,R,Tim Huelskamp,230
-Clay,Republican,U.S. House,1,D,James Sherow,82
-Clay,Republican,U.S. House,1,,Write-ins,0
-Clay,Republican,Governor,,R,Sam Brownback,194
-Clay,Republican,Governor,,D,Paul Davis,101
-Clay,Republican,Governor,,L,Keen Umbehr,21
-Clay,Republican,Governor,,,Write-ins,0
-Clay,Republican,Secretary of State,,R,Kris Kobach,250
-Clay,Republican,Secretary of State,,D,Jean Schodorf,63
-Clay,Republican,Secretary of State,,,Write-ins,0
-Clay,Republican,Attorney General,,R,A J Kotich,54
-Clay,Republican,Attorney General,,D,Derek Schmidt,255
-Clay,Republican,Attorney General,,,Write-ins,0
-Clay,Republican,State Treasurer,,D,Carmen Alldritt,58
-Clay,Republican,State Treasurer,,R,Ron Estes,246
-Clay,Republican,Insurance Commissioner,,D,Dennis Anderson,55
-Clay,Republican,Insurance Commissioner,,R,Ken Selzer,251
-Clay,Republican,Insurance Commissioner,,,Write-ins,0
-Clay,Republican,State House,64,R,Susie Swanson,290
-Clay,Republican,State House,64,,Write-ins,8
-Clay,Union,Voters,,,Registered,120
-Clay,Union,Voters,,,Ballots cast,87
-Clay,Union,U.S. Senate,,L,Randall Batson,2
-Clay,Union,U.S. Senate,,I,Greg Orman,25
-Clay,Union,U.S. Senate,,R,Pat Roberts,58
-Clay,Union,U.S. House,1,R,Tim Huelskamp,55
-Clay,Union,U.S. House,1,D,James Sherow,29
-Clay,Union,U.S. House,1,,Write-ins,0
-Clay,Union,Governor,,R,Sam Brownback,53
-Clay,Union,Governor,,D,Paul Davis,29
-Clay,Union,Governor,,L,Keen Umbehr,4
-Clay,Union,Governor,,,Write-ins,0
-Clay,Union,Secretary of State,,R,Kris Kobach,62
-Clay,Union,Secretary of State,,D,Jean Schodorf,24
-Clay,Union,Secretary of State,,,Write-ins,0
-Clay,Union,Attorney General,,R,A J Kotich,13
-Clay,Union,Attorney General,,D,Derek Schmidt,71
-Clay,Union,Attorney General,,,Write-ins,0
-Clay,Union,State Treasurer,,D,Carmen Alldritt,13
-Clay,Union,State Treasurer,,R,Ron Estes,70
-Clay,Union,Insurance Commissioner,,D,Dennis Anderson,20
-Clay,Union,Insurance Commissioner,,R,Ken Selzer,60
-Clay,Union,Insurance Commissioner,,,Write-ins,1
-Clay,Union,State House,64,R,Susie Swanson,77
-Clay,Union,State House,64,,Write-ins,1
+county,precinct,office,district,party,candidate,votes,vtd
+CLAY,Athelstane Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000010
+CLAY,Athelstane Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000010
+CLAY,Athelstane Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000010
+CLAY,Blaine Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,000020
+CLAY,Blaine Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+CLAY,Blaine Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",83,000020
+CLAY,Bloom Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+CLAY,Bloom Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000030
+CLAY,Bloom Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000030
+CLAY,Chapman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000040
+CLAY,Chapman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000040
+CLAY,Chapman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000040
+CLAY,Clay Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",54,00005A
+CLAY,Clay Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00005A
+CLAY,Clay Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",97,00005A
+CLAY,Clay Center Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+CLAY,Clay Center Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+CLAY,Clay Center Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+CLAY,Clay Center Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",219,00006A
+CLAY,Clay Center Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,00006A
+CLAY,Clay Center Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",250,00006A
+CLAY,Clay Center Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006B
+CLAY,Clay Center Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006B
+CLAY,Clay Center Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",236,000070
+CLAY,Clay Center Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000070
+CLAY,Clay Center Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",289,000070
+CLAY,Clay Center Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",112,000080
+CLAY,Clay Center Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000080
+CLAY,Clay Center Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",170,000080
+CLAY,Clay Center Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",115,000090
+CLAY,Clay Center Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000090
+CLAY,Clay Center Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",120,000090
+CLAY,Exeter Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000100
+CLAY,Exeter Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000100
+CLAY,Exeter Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000100
+CLAY,Five Creeks Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000110
+CLAY,Five Creeks Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000110
+CLAY,Five Creeks Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000110
+CLAY,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000120
+CLAY,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000120
+CLAY,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000120
+CLAY,Gill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000130
+CLAY,Gill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000130
+CLAY,Gill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000130
+CLAY,Goshen Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000140
+CLAY,Goshen Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+CLAY,Goshen Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000140
+CLAY,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000150
+CLAY,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000150
+CLAY,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000150
+CLAY,Hayes Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000160
+CLAY,Hayes Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000160
+CLAY,Hayes Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000160
+CLAY,Highland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000170
+CLAY,Highland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000170
+CLAY,Highland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000170
+CLAY,Mulberry Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000180
+CLAY,Mulberry Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000180
+CLAY,Mulberry Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000180
+CLAY,Oakland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000190
+CLAY,Oakland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000190
+CLAY,Oakland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000190
+CLAY,Republican Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",101,000200
+CLAY,Republican Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000200
+CLAY,Republican Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",194,000200
+CLAY,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000210
+CLAY,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000210
+CLAY,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000210
+CLAY,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000220
+CLAY,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000220
+CLAY,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000220
+CLAY,Clay Center Ward 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900230
+CLAY,Clay Center Ward 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900230
+CLAY,Clay Center Ward 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900230
+CLAY,Athelstane Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",57,000010
+CLAY,Blaine Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",106,000020
+CLAY,Bloom Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",43,000030
+CLAY,Chapman Township,Kansas House of Representatives,70,Republican,"Barker, John E",53,000040
+CLAY,Clay Center Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",140,00005A
+CLAY,Clay Center Township Enclave,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,00005B
+CLAY,Clay Center Ward 1,Kansas House of Representatives,64,Republican,"Swanson, Susie",436,00006A
+CLAY,Clay Center Ward 1 Exclave,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,00006B
+CLAY,Clay Center Ward 2,Kansas House of Representatives,64,Republican,"Swanson, Susie",485,000070
+CLAY,Clay Center Ward 3,Kansas House of Representatives,64,Republican,"Swanson, Susie",258,000080
+CLAY,Clay Center Ward 4,Kansas House of Representatives,64,Republican,"Swanson, Susie",221,000090
+CLAY,Exeter Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",32,000100
+CLAY,Five Creeks Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",38,000110
+CLAY,Garfield Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",34,000120
+CLAY,Gill Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",63,000130
+CLAY,Goshen Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",21,000140
+CLAY,Grant Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",56,000150
+CLAY,Hayes Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",85,000160
+CLAY,Highland Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",91,000170
+CLAY,Mulberry Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",72,000180
+CLAY,Oakland Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",25,000190
+CLAY,Republican Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",290,000200
+CLAY,Sherman Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",76,000210
+CLAY,Union Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",77,000220
+CLAY,Clay Center Ward 4 Exclave,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,900230
+CLAY,Athelstane Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000010
+CLAY,Athelstane Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000010
+CLAY,Blaine Township,United States House of Representatives,1,Democratic,"Sherow, James E.",34,000020
+CLAY,Blaine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",91,000020
+CLAY,Bloom Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000030
+CLAY,Bloom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000030
+CLAY,Chapman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",21,000040
+CLAY,Chapman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000040
+CLAY,Clay Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",46,00005A
+CLAY,Clay Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",112,00005A
+CLAY,Clay Center Township Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00005B
+CLAY,Clay Center Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+CLAY,Clay Center Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",185,00006A
+CLAY,Clay Center Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",307,00006A
+CLAY,Clay Center Ward 1 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+CLAY,Clay Center Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",189,000070
+CLAY,Clay Center Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",343,000070
+CLAY,Clay Center Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",92,000080
+CLAY,Clay Center Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",198,000080
+CLAY,Clay Center Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",97,000090
+CLAY,Clay Center Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",153,000090
+CLAY,Exeter Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000100
+CLAY,Exeter Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000100
+CLAY,Five Creeks Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000110
+CLAY,Five Creeks Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000110
+CLAY,Garfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000120
+CLAY,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000120
+CLAY,Gill Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000130
+CLAY,Gill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000130
+CLAY,Goshen Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000140
+CLAY,Goshen Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000140
+CLAY,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000150
+CLAY,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000150
+CLAY,Hayes Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000160
+CLAY,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",75,000160
+CLAY,Highland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",28,000170
+CLAY,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,000170
+CLAY,Mulberry Township,United States House of Representatives,1,Democratic,"Sherow, James E.",21,000180
+CLAY,Mulberry Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000180
+CLAY,Oakland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000190
+CLAY,Oakland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000190
+CLAY,Republican Township,United States House of Representatives,1,Democratic,"Sherow, James E.",82,000200
+CLAY,Republican Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",230,000200
+CLAY,Sherman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000210
+CLAY,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000210
+CLAY,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000220
+CLAY,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000220
+CLAY,Clay Center Ward 4 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900230
+CLAY,Athelstane Township,Attorney General,,Democratic,"Kotich, A.J.",2,000010
+CLAY,Athelstane Township,Attorney General,,Republican,"Schmidt, Derek",57,000010
+CLAY,Blaine Township,Attorney General,,Democratic,"Kotich, A.J.",12,000020
+CLAY,Blaine Township,Attorney General,,Republican,"Schmidt, Derek",111,000020
+CLAY,Bloom Township,Attorney General,,Democratic,"Kotich, A.J.",1,000030
+CLAY,Bloom Township,Attorney General,,Republican,"Schmidt, Derek",50,000030
+CLAY,Chapman Township,Attorney General,,Democratic,"Kotich, A.J.",14,000040
+CLAY,Chapman Township,Attorney General,,Republican,"Schmidt, Derek",45,000040
+CLAY,Clay Center Township,Attorney General,,Democratic,"Kotich, A.J.",20,00005A
+CLAY,Clay Center Township,Attorney General,,Republican,"Schmidt, Derek",138,00005A
+CLAY,Clay Center Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+CLAY,Clay Center Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+CLAY,Clay Center Ward 1,Attorney General,,Democratic,"Kotich, A.J.",90,00006A
+CLAY,Clay Center Ward 1,Attorney General,,Republican,"Schmidt, Derek",393,00006A
+CLAY,Clay Center Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00006B
+CLAY,Clay Center Ward 2,Attorney General,,Democratic,"Kotich, A.J.",109,000070
+CLAY,Clay Center Ward 2,Attorney General,,Republican,"Schmidt, Derek",421,000070
+CLAY,Clay Center Ward 3,Attorney General,,Democratic,"Kotich, A.J.",57,000080
+CLAY,Clay Center Ward 3,Attorney General,,Republican,"Schmidt, Derek",233,000080
+CLAY,Clay Center Ward 4,Attorney General,,Democratic,"Kotich, A.J.",65,000090
+CLAY,Clay Center Ward 4,Attorney General,,Republican,"Schmidt, Derek",182,000090
+CLAY,Exeter Township,Attorney General,,Democratic,"Kotich, A.J.",2,000100
+CLAY,Exeter Township,Attorney General,,Republican,"Schmidt, Derek",36,000100
+CLAY,Five Creeks Township,Attorney General,,Democratic,"Kotich, A.J.",4,000110
+CLAY,Five Creeks Township,Attorney General,,Republican,"Schmidt, Derek",42,000110
+CLAY,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",3,000120
+CLAY,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",35,000120
+CLAY,Gill Township,Attorney General,,Democratic,"Kotich, A.J.",9,000130
+CLAY,Gill Township,Attorney General,,Republican,"Schmidt, Derek",60,000130
+CLAY,Goshen Township,Attorney General,,Democratic,"Kotich, A.J.",5,000140
+CLAY,Goshen Township,Attorney General,,Republican,"Schmidt, Derek",17,000140
+CLAY,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",7,000150
+CLAY,Grant Township,Attorney General,,Republican,"Schmidt, Derek",69,000150
+CLAY,Hayes Township,Attorney General,,Democratic,"Kotich, A.J.",12,000160
+CLAY,Hayes Township,Attorney General,,Republican,"Schmidt, Derek",83,000160
+CLAY,Highland Township,Attorney General,,Democratic,"Kotich, A.J.",21,000170
+CLAY,Highland Township,Attorney General,,Republican,"Schmidt, Derek",94,000170
+CLAY,Mulberry Township,Attorney General,,Democratic,"Kotich, A.J.",8,000180
+CLAY,Mulberry Township,Attorney General,,Republican,"Schmidt, Derek",72,000180
+CLAY,Oakland Township,Attorney General,,Democratic,"Kotich, A.J.",10,000190
+CLAY,Oakland Township,Attorney General,,Republican,"Schmidt, Derek",23,000190
+CLAY,Republican Township,Attorney General,,Democratic,"Kotich, A.J.",54,000200
+CLAY,Republican Township,Attorney General,,Republican,"Schmidt, Derek",255,000200
+CLAY,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",21,000210
+CLAY,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",65,000210
+CLAY,Union Township,Attorney General,,Democratic,"Kotich, A.J.",13,000220
+CLAY,Union Township,Attorney General,,Republican,"Schmidt, Derek",71,000220
+CLAY,Clay Center Ward 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900230
+CLAY,Clay Center Ward 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900230
+CLAY,Athelstane Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000010
+CLAY,Athelstane Township,Commissioner of Insurance,,Republican,"Selzer, Ken",58,000010
+CLAY,Blaine Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000020
+CLAY,Blaine Township,Commissioner of Insurance,,Republican,"Selzer, Ken",100,000020
+CLAY,Bloom Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000030
+CLAY,Bloom Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000030
+CLAY,Chapman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000040
+CLAY,Chapman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000040
+CLAY,Clay Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,00005A
+CLAY,Clay Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",131,00005A
+CLAY,Clay Center Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+CLAY,Clay Center Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+CLAY,Clay Center Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",116,00006A
+CLAY,Clay Center Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",355,00006A
+CLAY,Clay Center Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006B
+CLAY,Clay Center Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006B
+CLAY,Clay Center Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",124,000070
+CLAY,Clay Center Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",391,000070
+CLAY,Clay Center Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,000080
+CLAY,Clay Center Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",223,000080
+CLAY,Clay Center Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000090
+CLAY,Clay Center Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",168,000090
+CLAY,Exeter Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000100
+CLAY,Exeter Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000100
+CLAY,Five Creeks Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000110
+CLAY,Five Creeks Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000110
+CLAY,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000120
+CLAY,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000120
+CLAY,Gill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000130
+CLAY,Gill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",60,000130
+CLAY,Goshen Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000140
+CLAY,Goshen Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000140
+CLAY,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000150
+CLAY,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",68,000150
+CLAY,Hayes Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000160
+CLAY,Hayes Township,Commissioner of Insurance,,Republican,"Selzer, Ken",81,000160
+CLAY,Highland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000170
+CLAY,Highland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",85,000170
+CLAY,Mulberry Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000180
+CLAY,Mulberry Township,Commissioner of Insurance,,Republican,"Selzer, Ken",69,000180
+CLAY,Oakland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000190
+CLAY,Oakland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000190
+CLAY,Republican Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",55,000200
+CLAY,Republican Township,Commissioner of Insurance,,Republican,"Selzer, Ken",251,000200
+CLAY,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000210
+CLAY,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000210
+CLAY,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000220
+CLAY,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",60,000220
+CLAY,Clay Center Ward 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900230
+CLAY,Clay Center Ward 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900230
+CLAY,Athelstane Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+CLAY,Athelstane Township,Secretary of State,,Republican,"Kobach, Kris",56,000010
+CLAY,Blaine Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000020
+CLAY,Blaine Township,Secretary of State,,Republican,"Kobach, Kris",97,000020
+CLAY,Bloom Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000030
+CLAY,Bloom Township,Secretary of State,,Republican,"Kobach, Kris",45,000030
+CLAY,Chapman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000040
+CLAY,Chapman Township,Secretary of State,,Republican,"Kobach, Kris",40,000040
+CLAY,Clay Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",32,00005A
+CLAY,Clay Center Township,Secretary of State,,Republican,"Kobach, Kris",126,00005A
+CLAY,Clay Center Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+CLAY,Clay Center Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+CLAY,Clay Center Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",152,00006A
+CLAY,Clay Center Ward 1,Secretary of State,,Republican,"Kobach, Kris",337,00006A
+CLAY,Clay Center Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006B
+CLAY,Clay Center Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00006B
+CLAY,Clay Center Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",164,000070
+CLAY,Clay Center Ward 2,Secretary of State,,Republican,"Kobach, Kris",373,000070
+CLAY,Clay Center Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",76,000080
+CLAY,Clay Center Ward 3,Secretary of State,,Republican,"Kobach, Kris",213,000080
+CLAY,Clay Center Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,000090
+CLAY,Clay Center Ward 4,Secretary of State,,Republican,"Kobach, Kris",161,000090
+CLAY,Exeter Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000100
+CLAY,Exeter Township,Secretary of State,,Republican,"Kobach, Kris",36,000100
+CLAY,Five Creeks Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000110
+CLAY,Five Creeks Township,Secretary of State,,Republican,"Kobach, Kris",36,000110
+CLAY,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000120
+CLAY,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",34,000120
+CLAY,Gill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000130
+CLAY,Gill Township,Secretary of State,,Republican,"Kobach, Kris",55,000130
+CLAY,Goshen Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000140
+CLAY,Goshen Township,Secretary of State,,Republican,"Kobach, Kris",17,000140
+CLAY,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000150
+CLAY,Grant Township,Secretary of State,,Republican,"Kobach, Kris",63,000150
+CLAY,Hayes Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000160
+CLAY,Hayes Township,Secretary of State,,Republican,"Kobach, Kris",79,000160
+CLAY,Highland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000170
+CLAY,Highland Township,Secretary of State,,Republican,"Kobach, Kris",93,000170
+CLAY,Mulberry Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000180
+CLAY,Mulberry Township,Secretary of State,,Republican,"Kobach, Kris",63,000180
+CLAY,Oakland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000190
+CLAY,Oakland Township,Secretary of State,,Republican,"Kobach, Kris",23,000190
+CLAY,Republican Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",63,000200
+CLAY,Republican Township,Secretary of State,,Republican,"Kobach, Kris",250,000200
+CLAY,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000210
+CLAY,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",59,000210
+CLAY,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000220
+CLAY,Union Township,Secretary of State,,Republican,"Kobach, Kris",62,000220
+CLAY,Clay Center Ward 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900230
+CLAY,Clay Center Ward 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900230
+CLAY,Athelstane Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+CLAY,Athelstane Township,State Treasurer,,Republican,"Estes, Ron",56,000010
+CLAY,Blaine Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000020
+CLAY,Blaine Township,State Treasurer,,Republican,"Estes, Ron",112,000020
+CLAY,Bloom Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000030
+CLAY,Bloom Township,State Treasurer,,Republican,"Estes, Ron",49,000030
+CLAY,Chapman Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000040
+CLAY,Chapman Township,State Treasurer,,Republican,"Estes, Ron",46,000040
+CLAY,Clay Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,00005A
+CLAY,Clay Center Township,State Treasurer,,Republican,"Estes, Ron",135,00005A
+CLAY,Clay Center Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+CLAY,Clay Center Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,00005B
+CLAY,Clay Center Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",84,00006A
+CLAY,Clay Center Ward 1,State Treasurer,,Republican,"Estes, Ron",393,00006A
+CLAY,Clay Center Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006B
+CLAY,Clay Center Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00006B
+CLAY,Clay Center Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",106,000070
+CLAY,Clay Center Ward 2,State Treasurer,,Republican,"Estes, Ron",413,000070
+CLAY,Clay Center Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",48,000080
+CLAY,Clay Center Ward 3,State Treasurer,,Republican,"Estes, Ron",239,000080
+CLAY,Clay Center Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",66,000090
+CLAY,Clay Center Ward 4,State Treasurer,,Republican,"Estes, Ron",178,000090
+CLAY,Exeter Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000100
+CLAY,Exeter Township,State Treasurer,,Republican,"Estes, Ron",36,000100
+CLAY,Five Creeks Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000110
+CLAY,Five Creeks Township,State Treasurer,,Republican,"Estes, Ron",42,000110
+CLAY,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000120
+CLAY,Garfield Township,State Treasurer,,Republican,"Estes, Ron",36,000120
+CLAY,Gill Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000130
+CLAY,Gill Township,State Treasurer,,Republican,"Estes, Ron",59,000130
+CLAY,Goshen Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000140
+CLAY,Goshen Township,State Treasurer,,Republican,"Estes, Ron",16,000140
+CLAY,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000150
+CLAY,Grant Township,State Treasurer,,Republican,"Estes, Ron",65,000150
+CLAY,Hayes Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000160
+CLAY,Hayes Township,State Treasurer,,Republican,"Estes, Ron",88,000160
+CLAY,Highland Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000170
+CLAY,Highland Township,State Treasurer,,Republican,"Estes, Ron",92,000170
+CLAY,Mulberry Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000180
+CLAY,Mulberry Township,State Treasurer,,Republican,"Estes, Ron",72,000180
+CLAY,Oakland Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000190
+CLAY,Oakland Township,State Treasurer,,Republican,"Estes, Ron",26,000190
+CLAY,Republican Township,State Treasurer,,Democratic,"Alldritt, Carmen",58,000200
+CLAY,Republican Township,State Treasurer,,Republican,"Estes, Ron",246,000200
+CLAY,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000210
+CLAY,Sherman Township,State Treasurer,,Republican,"Estes, Ron",69,000210
+CLAY,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000220
+CLAY,Union Township,State Treasurer,,Republican,"Estes, Ron",70,000220
+CLAY,Clay Center Ward 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900230
+CLAY,Clay Center Ward 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900230
+CLAY,Athelstane Township,United States Senate,,independent,"Orman, Greg",5,000010
+CLAY,Athelstane Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+CLAY,Athelstane Township,United States Senate,,Republican,"Roberts, Pat",54,000010
+CLAY,Blaine Township,United States Senate,,independent,"Orman, Greg",27,000020
+CLAY,Blaine Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+CLAY,Blaine Township,United States Senate,,Republican,"Roberts, Pat",97,000020
+CLAY,Bloom Township,United States Senate,,independent,"Orman, Greg",6,000030
+CLAY,Bloom Township,United States Senate,,Libertarian,"Batson, Randall",2,000030
+CLAY,Bloom Township,United States Senate,,Republican,"Roberts, Pat",45,000030
+CLAY,Chapman Township,United States Senate,,independent,"Orman, Greg",17,000040
+CLAY,Chapman Township,United States Senate,,Libertarian,"Batson, Randall",4,000040
+CLAY,Chapman Township,United States Senate,,Republican,"Roberts, Pat",39,000040
+CLAY,Clay Center Township,United States Senate,,independent,"Orman, Greg",46,00005A
+CLAY,Clay Center Township,United States Senate,,Libertarian,"Batson, Randall",3,00005A
+CLAY,Clay Center Township,United States Senate,,Republican,"Roberts, Pat",112,00005A
+CLAY,Clay Center Township Enclave,United States Senate,,independent,"Orman, Greg",0,00005B
+CLAY,Clay Center Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+CLAY,Clay Center Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,00005B
+CLAY,Clay Center Ward 1,United States Senate,,independent,"Orman, Greg",171,00006A
+CLAY,Clay Center Ward 1,United States Senate,,Libertarian,"Batson, Randall",24,00006A
+CLAY,Clay Center Ward 1,United States Senate,,Republican,"Roberts, Pat",300,00006A
+CLAY,Clay Center Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00006B
+CLAY,Clay Center Ward 2,United States Senate,,independent,"Orman, Greg",170,000070
+CLAY,Clay Center Ward 2,United States Senate,,Libertarian,"Batson, Randall",23,000070
+CLAY,Clay Center Ward 2,United States Senate,,Republican,"Roberts, Pat",350,000070
+CLAY,Clay Center Ward 3,United States Senate,,independent,"Orman, Greg",83,000080
+CLAY,Clay Center Ward 3,United States Senate,,Libertarian,"Batson, Randall",14,000080
+CLAY,Clay Center Ward 3,United States Senate,,Republican,"Roberts, Pat",199,000080
+CLAY,Clay Center Ward 4,United States Senate,,independent,"Orman, Greg",87,000090
+CLAY,Clay Center Ward 4,United States Senate,,Libertarian,"Batson, Randall",16,000090
+CLAY,Clay Center Ward 4,United States Senate,,Republican,"Roberts, Pat",151,000090
+CLAY,Exeter Township,United States Senate,,independent,"Orman, Greg",4,000100
+CLAY,Exeter Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+CLAY,Exeter Township,United States Senate,,Republican,"Roberts, Pat",35,000100
+CLAY,Five Creeks Township,United States Senate,,independent,"Orman, Greg",11,000110
+CLAY,Five Creeks Township,United States Senate,,Libertarian,"Batson, Randall",1,000110
+CLAY,Five Creeks Township,United States Senate,,Republican,"Roberts, Pat",34,000110
+CLAY,Garfield Township,United States Senate,,independent,"Orman, Greg",7,000120
+CLAY,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",1,000120
+CLAY,Garfield Township,United States Senate,,Republican,"Roberts, Pat",30,000120
+CLAY,Gill Township,United States Senate,,independent,"Orman, Greg",14,000130
+CLAY,Gill Township,United States Senate,,Libertarian,"Batson, Randall",2,000130
+CLAY,Gill Township,United States Senate,,Republican,"Roberts, Pat",53,000130
+CLAY,Goshen Township,United States Senate,,independent,"Orman, Greg",6,000140
+CLAY,Goshen Township,United States Senate,,Libertarian,"Batson, Randall",0,000140
+CLAY,Goshen Township,United States Senate,,Republican,"Roberts, Pat",17,000140
+CLAY,Grant Township,United States Senate,,independent,"Orman, Greg",9,000150
+CLAY,Grant Township,United States Senate,,Libertarian,"Batson, Randall",2,000150
+CLAY,Grant Township,United States Senate,,Republican,"Roberts, Pat",64,000150
+CLAY,Hayes Township,United States Senate,,independent,"Orman, Greg",14,000160
+CLAY,Hayes Township,United States Senate,,Libertarian,"Batson, Randall",2,000160
+CLAY,Hayes Township,United States Senate,,Republican,"Roberts, Pat",81,000160
+CLAY,Highland Township,United States Senate,,independent,"Orman, Greg",33,000170
+CLAY,Highland Township,United States Senate,,Libertarian,"Batson, Randall",4,000170
+CLAY,Highland Township,United States Senate,,Republican,"Roberts, Pat",80,000170
+CLAY,Mulberry Township,United States Senate,,independent,"Orman, Greg",20,000180
+CLAY,Mulberry Township,United States Senate,,Libertarian,"Batson, Randall",2,000180
+CLAY,Mulberry Township,United States Senate,,Republican,"Roberts, Pat",62,000180
+CLAY,Oakland Township,United States Senate,,independent,"Orman, Greg",12,000190
+CLAY,Oakland Township,United States Senate,,Libertarian,"Batson, Randall",0,000190
+CLAY,Oakland Township,United States Senate,,Republican,"Roberts, Pat",23,000190
+CLAY,Republican Township,United States Senate,,independent,"Orman, Greg",74,000200
+CLAY,Republican Township,United States Senate,,Libertarian,"Batson, Randall",25,000200
+CLAY,Republican Township,United States Senate,,Republican,"Roberts, Pat",216,000200
+CLAY,Sherman Township,United States Senate,,independent,"Orman, Greg",28,000210
+CLAY,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",3,000210
+CLAY,Sherman Township,United States Senate,,Republican,"Roberts, Pat",56,000210
+CLAY,Union Township,United States Senate,,independent,"Orman, Greg",25,000220
+CLAY,Union Township,United States Senate,,Libertarian,"Batson, Randall",2,000220
+CLAY,Union Township,United States Senate,,Republican,"Roberts, Pat",58,000220
+CLAY,Clay Center Ward 4 Exclave,United States Senate,,independent,"Orman, Greg",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900230

--- a/2014/20141104__ks__general__cloud__precinct.csv
+++ b/2014/20141104__ks__general__cloud__precinct.csv
@@ -1,443 +1,494 @@
-county,precinct,race,district,party,candidate,votes
-Cloud,Arion,Attorney General ,,Dem,A.J. Kotich,8
-Cloud,Aurora,Attorney General ,,Dem,A.J. Kotich,7
-Cloud,Buffalo,Attorney General ,,Dem,A.J. Kotich,3
-Cloud,Center,Attorney General ,,Dem,A.J. Kotich,2
-Cloud,Colfax,Attorney General ,,Dem,A.J. Kotich,2
-Cloud,Elk,Attorney General ,,Dem,A.J. Kotich,55
-Cloud,Grant,Attorney General ,,Dem,A.J. Kotich,20
-Cloud,N. Lawrence,Attorney General ,,Dem,A.J. Kotich,4
-Cloud,S. Lawrence,Attorney General ,,Dem,A.J. Kotich,5
-Cloud,E. Lincoln,Attorney General ,,Dem,A.J. Kotich,17
-Cloud,W. Lincoln,Attorney General ,,Dem,A.J. Kotich,22
-Cloud,Lyon,Attorney General ,,Dem,A.J. Kotich,4
-Cloud,E. Meredith,Attorney General ,,Dem,A.J. Kotich,1
-Cloud,W. Meredith,Attorney General ,,Dem,A.J. Kotich,3
-Cloud,Nelson,Attorney General ,,Dem,A.J. Kotich,3
-Cloud,Oakland,Attorney General ,,Dem,A.J. Kotich,1
-Cloud,Shirley,Attorney General ,,Dem,A.J. Kotich,7
-Cloud,Sibley,Attorney General ,,Dem,A.J. Kotich,17
-Cloud,Solomon,Attorney General ,,Dem,A.J. Kotich,28
-Cloud,Starr,Attorney General ,,Dem,A.J. Kotich,37
-Cloud,Summitt,Attorney General ,,Dem,A.J. Kotich,2
-Cloud,1st Ward,Attorney General ,,Dem,A.J. Kotich,63
-Cloud,1st Pct 2nd Ward,Attorney General ,,Dem,A.J. Kotich,62
-Cloud,2nd Pct 2nd Ward,Attorney General ,,Dem,A.J. Kotich,58
-Cloud,3rd Ward,Attorney General ,,Dem,A.J. Kotich,75
-Cloud,4th Ward,Attorney General ,,Dem,A.J. Kotich,41
-Cloud,Arion,Attorney General ,,Rep,Derek Schmidt,23
-Cloud,Aurora,Attorney General ,,Rep,Derek Schmidt,32
-Cloud,Buffalo,Attorney General ,,Rep,Derek Schmidt,38
-Cloud,Center,Attorney General ,,Rep,Derek Schmidt,65
-Cloud,Colfax,Attorney General ,,Rep,Derek Schmidt,14
-Cloud,Elk,Attorney General ,,Rep,Derek Schmidt,189
-Cloud,Grant,Attorney General ,,Rep,Derek Schmidt,80
-Cloud,N. Lawrence,Attorney General ,,Rep,Derek Schmidt,18
-Cloud,S. Lawrence,Attorney General ,,Rep,Derek Schmidt,12
-Cloud,E. Lincoln,Attorney General ,,Rep,Derek Schmidt,67
-Cloud,W. Lincoln,Attorney General ,,Rep,Derek Schmidt,34
-Cloud,Lyon,Attorney General ,,Rep,Derek Schmidt,32
-Cloud,E. Meredith,Attorney General ,,Rep,Derek Schmidt,14
-Cloud,W. Meredith,Attorney General ,,Rep,Derek Schmidt,9
-Cloud,Nelson,Attorney General ,,Rep,Derek Schmidt,39
-Cloud,Oakland,Attorney General ,,Rep,Derek Schmidt,19
-Cloud,Shirley,Attorney General ,,Rep,Derek Schmidt,44
-Cloud,Sibley,Attorney General ,,Rep,Derek Schmidt,52
-Cloud,Solomon,Attorney General ,,Rep,Derek Schmidt,137
-Cloud,Starr,Attorney General ,,Rep,Derek Schmidt,144
-Cloud,Summitt,Attorney General ,,Rep,Derek Schmidt,23
-Cloud,1st Ward,Attorney General ,,Rep,Derek Schmidt,131
-Cloud,1st Pct 2nd Ward,Attorney General ,,Rep,Derek Schmidt,153
-Cloud,2nd Pct 2nd Ward,Attorney General ,,Rep,Derek Schmidt,237
-Cloud,3rd Ward,Attorney General ,,Rep,Derek Schmidt,266
-Cloud,4th Ward,Attorney General ,,Rep,Derek Schmidt,123
-Cloud,Arion,Commissioner of Insurance,,Dem,Dennis Anderson,6
-Cloud,Aurora,Commissioner of Insurance,,Dem,Dennis Anderson,8
-Cloud,Buffalo,Commissioner of Insurance,,Dem,Dennis Anderson,5
-Cloud,Center,Commissioner of Insurance,,Dem,Dennis Anderson,9
-Cloud,Colfax,Commissioner of Insurance,,Dem,Dennis Anderson,1
-Cloud,Elk,Commissioner of Insurance,,Dem,Dennis Anderson,77
-Cloud,Grant,Commissioner of Insurance,,Dem,Dennis Anderson,14
-Cloud,N. Lawrence,Commissioner of Insurance,,Dem,Dennis Anderson,2
-Cloud,S. Lawrence,Commissioner of Insurance,,Dem,Dennis Anderson,6
-Cloud,E. Lincoln,Commissioner of Insurance,,Dem,Dennis Anderson,20
-Cloud,W. Lincoln,Commissioner of Insurance,,Dem,Dennis Anderson,22
-Cloud,Lyon,Commissioner of Insurance,,Dem,Dennis Anderson,7
-Cloud,E. Meredith,Commissioner of Insurance,,Dem,Dennis Anderson,2
-Cloud,W. Meredith,Commissioner of Insurance,,Dem,Dennis Anderson,4
-Cloud,Nelson,Commissioner of Insurance,,Dem,Dennis Anderson,4
-Cloud,Oakland,Commissioner of Insurance,,Dem,Dennis Anderson,0
-Cloud,Shirley,Commissioner of Insurance,,Dem,Dennis Anderson,9
-Cloud,Sibley,Commissioner of Insurance,,Dem,Dennis Anderson,19
-Cloud,Solomon,Commissioner of Insurance,,Dem,Dennis Anderson,43
-Cloud,Starr,Commissioner of Insurance,,Dem,Dennis Anderson,41
-Cloud,Summitt,Commissioner of Insurance,,Dem,Dennis Anderson,3
-Cloud,1st Ward,Commissioner of Insurance,,Dem,Dennis Anderson,71
-Cloud,1st Pct 2nd Ward,Commissioner of Insurance,,Dem,Dennis Anderson,71
-Cloud,2nd Pct 2nd Ward,Commissioner of Insurance,,Dem,Dennis Anderson,83
-Cloud,3rd Ward,Commissioner of Insurance,,Dem,Dennis Anderson,105
-Cloud,4th Ward,Commissioner of Insurance,,Dem,Dennis Anderson,52
-Cloud,Arion,Commissioner of Insurance,,Rep,Ken Selzer,25
-Cloud,Aurora,Commissioner of Insurance,,Rep,Ken Selzer,32
-Cloud,Buffalo,Commissioner of Insurance,,Rep,Ken Selzer,33
-Cloud,Center,Commissioner of Insurance,,Rep,Ken Selzer,54
-Cloud,Colfax,Commissioner of Insurance,,Rep,Ken Selzer,15
-Cloud,Elk,Commissioner of Insurance,,Rep,Ken Selzer,155
-Cloud,Grant,Commissioner of Insurance,,Rep,Ken Selzer,83
-Cloud,N. Lawrence,Commissioner of Insurance,,Rep,Ken Selzer,16
-Cloud,S. Lawrence,Commissioner of Insurance,,Rep,Ken Selzer,12
-Cloud,E. Lincoln,Commissioner of Insurance,,Rep,Ken Selzer,62
-Cloud,W. Lincoln,Commissioner of Insurance,,Rep,Ken Selzer,33
-Cloud,Lyon,Commissioner of Insurance,,Rep,Ken Selzer,26
-Cloud,E. Meredith,Commissioner of Insurance,,Rep,Ken Selzer,13
-Cloud,W. Meredith,Commissioner of Insurance,,Rep,Ken Selzer,8
-Cloud,Nelson,Commissioner of Insurance,,Rep,Ken Selzer,36
-Cloud,Oakland,Commissioner of Insurance,,Rep,Ken Selzer,17
-Cloud,Shirley,Commissioner of Insurance,,Rep,Ken Selzer,38
-Cloud,Sibley,Commissioner of Insurance,,Rep,Ken Selzer,48
-Cloud,Solomon,Commissioner of Insurance,,Rep,Ken Selzer,116
-Cloud,Starr,Commissioner of Insurance,,Rep,Ken Selzer,135
-Cloud,Summitt,Commissioner of Insurance,,Rep,Ken Selzer,22
-Cloud,1st Ward,Commissioner of Insurance,,Rep,Ken Selzer,122
-Cloud,1st Pct 2nd Ward,Commissioner of Insurance,,Rep,Ken Selzer,143
-Cloud,2nd Pct 2nd Ward,Commissioner of Insurance,,Rep,Ken Selzer,199
-Cloud,3rd Ward,Commissioner of Insurance,,Rep,Ken Selzer,229
-Cloud,4th Ward,Commissioner of Insurance,,Rep,Ken Selzer,108
-Cloud,Arion,Governor,,Lib,Keen Umbehr,1
-Cloud,Aurora,Governor,,Lib,Keen Umbehr,1
-Cloud,Buffalo,Governor,,Lib,Keen Umbehr,1
-Cloud,Center,Governor,,Lib,Keen Umbehr,2
-Cloud,Colfax,Governor,,Lib,Keen Umbehr,0
-Cloud,Elk,Governor,,Lib,Keen Umbehr,13
-Cloud,Grant,Governor,,Lib,Keen Umbehr,5
-Cloud,N. Lawrence,Governor,,Lib,Keen Umbehr,2
-Cloud,S. Lawrence,Governor,,Lib,Keen Umbehr,2
-Cloud,E. Lincoln,Governor,,Lib,Keen Umbehr,2
-Cloud,W. Lincoln,Governor,,Lib,Keen Umbehr,0
-Cloud,Lyon,Governor,,Lib,Keen Umbehr,1
-Cloud,E. Meredith,Governor,,Lib,Keen Umbehr,0
-Cloud,W. Meredith,Governor,,Lib,Keen Umbehr,0
-Cloud,Nelson,Governor,,Lib,Keen Umbehr,0
-Cloud,Oakland,Governor,,Lib,Keen Umbehr,0
-Cloud,Shirley,Governor,,Lib,Keen Umbehr,5
-Cloud,Sibley,Governor,,Lib,Keen Umbehr,0
-Cloud,Solomon,Governor,,Lib,Keen Umbehr,19
-Cloud,Starr,Governor,,Lib,Keen Umbehr,12
-Cloud,Summitt,Governor,,Lib,Keen Umbehr,1
-Cloud,1st Ward,Governor,,Lib,Keen Umbehr,10
-Cloud,1st Pct 2nd Ward,Governor,,Lib,Keen Umbehr,8
-Cloud,2nd Pct 2nd Ward,Governor,,Lib,Keen Umbehr,10
-Cloud,3rd Ward,Governor,,Lib,Keen Umbehr,16
-Cloud,4th Ward,Governor,,Lib,Keen Umbehr,8
-Cloud,Arion,Governor,,Dem,Paul Davis,11
-Cloud,Aurora,Governor,,Dem,Paul Davis,14
-Cloud,Buffalo,Governor,,Dem,Paul Davis,10
-Cloud,Center,Governor,,Dem,Paul Davis,15
-Cloud,Colfax,Governor,,Dem,Paul Davis,1
-Cloud,Elk,Governor,,Dem,Paul Davis,100
-Cloud,Grant,Governor,,Dem,Paul Davis,30
-Cloud,N. Lawrence,Governor,,Dem,Paul Davis,7
-Cloud,S. Lawrence,Governor,,Dem,Paul Davis,5
-Cloud,E. Lincoln,Governor,,Dem,Paul Davis,23
-Cloud,W. Lincoln,Governor,,Dem,Paul Davis,20
-Cloud,Lyon,Governor,,Dem,Paul Davis,10
-Cloud,E. Meredith,Governor,,Dem,Paul Davis,5
-Cloud,W. Meredith,Governor,,Dem,Paul Davis,5
-Cloud,Nelson,Governor,,Dem,Paul Davis,4
-Cloud,Oakland,Governor,,Dem,Paul Davis,0
-Cloud,Shirley,Governor,,Dem,Paul Davis,15
-Cloud,Sibley,Governor,,Dem,Paul Davis,30
-Cloud,Solomon,Governor,,Dem,Paul Davis,43
-Cloud,Starr,Governor,,Dem,Paul Davis,48
-Cloud,Summitt,Governor,,Dem,Paul Davis,2
-Cloud,1st Ward,Governor,,Dem,Paul Davis,91
-Cloud,1st Pct 2nd Ward,Governor,,Dem,Paul Davis,110
-Cloud,2nd Pct 2nd Ward,Governor,,Dem,Paul Davis,116
-Cloud,3rd Ward,Governor,,Dem,Paul Davis,150
-Cloud,4th Ward,Governor,,Dem,Paul Davis,67
-Cloud,Arion,Governor,,Rep,Sam Brownback,19
-Cloud,Aurora,Governor,,Rep,Sam Brownback,28
-Cloud,Buffalo,Governor,,Rep,Sam Brownback,32
-Cloud,Center,Governor,,Rep,Sam Brownback,52
-Cloud,Colfax,Governor,,Rep,Sam Brownback,16
-Cloud,Elk,Governor,,Rep,Sam Brownback,152
-Cloud,Grant,Governor,,Rep,Sam Brownback,68
-Cloud,N. Lawrence,Governor,,Rep,Sam Brownback,13
-Cloud,S. Lawrence,Governor,,Rep,Sam Brownback,11
-Cloud,E. Lincoln,Governor,,Rep,Sam Brownback,58
-Cloud,W. Lincoln,Governor,,Rep,Sam Brownback,35
-Cloud,Lyon,Governor,,Rep,Sam Brownback,26
-Cloud,E. Meredith,Governor,,Rep,Sam Brownback,10
-Cloud,W. Meredith,Governor,,Rep,Sam Brownback,7
-Cloud,Nelson,Governor,,Rep,Sam Brownback,38
-Cloud,Oakland,Governor,,Rep,Sam Brownback,21
-Cloud,Shirley,Governor,,Rep,Sam Brownback,35
-Cloud,Sibley,Governor,,Rep,Sam Brownback,40
-Cloud,Solomon,Governor,,Rep,Sam Brownback,103
-Cloud,Starr,Governor,,Rep,Sam Brownback,126
-Cloud,Summitt,Governor,,Rep,Sam Brownback,23
-Cloud,1st Ward,Governor,,Rep,Sam Brownback,97
-Cloud,1st Pct 2nd Ward,Governor,,Rep,Sam Brownback,102
-Cloud,2nd Pct 2nd Ward,Governor,,Rep,Sam Brownback,173
-Cloud,3rd Ward,Governor,,Rep,Sam Brownback,183
-Cloud,4th Ward,Governor,,Rep,Sam Brownback,91
-Cloud,Arion,Secretary of State,,Dem,Jean Kurtis Schodorf,10
-Cloud,Aurora,Secretary of State,,Dem,Jean Kurtis Schodorf,6
-Cloud,Buffalo,Secretary of State,,Dem,Jean Kurtis Schodorf,7
-Cloud,Center,Secretary of State,,Dem,Jean Kurtis Schodorf,12
-Cloud,Colfax,Secretary of State,,Dem,Jean Kurtis Schodorf,0
-Cloud,Elk,Secretary of State,,Dem,Jean Kurtis Schodorf,91
-Cloud,Grant,Secretary of State,,Dem,Jean Kurtis Schodorf,19
-Cloud,N. Lawrence,Secretary of State,,Dem,Jean Kurtis Schodorf,5
-Cloud,S. Lawrence,Secretary of State,,Dem,Jean Kurtis Schodorf,3
-Cloud,E. Lincoln,Secretary of State,,Dem,Jean Kurtis Schodorf,19
-Cloud,W. Lincoln,Secretary of State,,Dem,Jean Kurtis Schodorf,17
-Cloud,Lyon,Secretary of State,,Dem,Jean Kurtis Schodorf,9
-Cloud,E. Meredith,Secretary of State,,Dem,Jean Kurtis Schodorf,3
-Cloud,W. Meredith,Secretary of State,,Dem,Jean Kurtis Schodorf,4
-Cloud,Nelson,Secretary of State,,Dem,Jean Kurtis Schodorf,3
-Cloud,Oakland,Secretary of State,,Dem,Jean Kurtis Schodorf,1
-Cloud,Shirley,Secretary of State,,Dem,Jean Kurtis Schodorf,11
-Cloud,Sibley,Secretary of State,,Dem,Jean Kurtis Schodorf,25
-Cloud,Solomon,Secretary of State,,Dem,Jean Kurtis Schodorf,39
-Cloud,Starr,Secretary of State,,Dem,Jean Kurtis Schodorf,39
-Cloud,Summitt,Secretary of State,,Dem,Jean Kurtis Schodorf,3
-Cloud,1st Ward,Secretary of State,,Dem,Jean Kurtis Schodorf,75
-Cloud,1st Pct 2nd Ward,Secretary of State,,Dem,Jean Kurtis Schodorf,86
-Cloud,2nd Pct 2nd Ward,Secretary of State,,Dem,Jean Kurtis Schodorf,92
-Cloud,3rd Ward,Secretary of State,,Dem,Jean Kurtis Schodorf,106
-Cloud,4th Ward,Secretary of State,,Dem,Jean Kurtis Schodorf,53
-Cloud,Arion,Secretary of State,,Rep,Kris Kobach,21
-Cloud,Aurora,Secretary of State,,Rep,Kris Kobach,35
-Cloud,Buffalo,Secretary of State,,Rep,Kris Kobach,34
-Cloud,Center,Secretary of State,,Rep,Kris Kobach,58
-Cloud,Colfax,Secretary of State,,Rep,Kris Kobach,16
-Cloud,Elk,Secretary of State,,Rep,Kris Kobach,168
-Cloud,Grant,Secretary of State,,Rep,Kris Kobach,83
-Cloud,N. Lawrence,Secretary of State,,Rep,Kris Kobach,17
-Cloud,S. Lawrence,Secretary of State,,Rep,Kris Kobach,15
-Cloud,E. Lincoln,Secretary of State,,Rep,Kris Kobach,65
-Cloud,W. Lincoln,Secretary of State,,Rep,Kris Kobach,39
-Cloud,Lyon,Secretary of State,,Rep,Kris Kobach,27
-Cloud,E. Meredith,Secretary of State,,Rep,Kris Kobach,12
-Cloud,W. Meredith,Secretary of State,,Rep,Kris Kobach,8
-Cloud,Nelson,Secretary of State,,Rep,Kris Kobach,38
-Cloud,Oakland,Secretary of State,,Rep,Kris Kobach,19
-Cloud,Shirley,Secretary of State,,Rep,Kris Kobach,41
-Cloud,Sibley,Secretary of State,,Rep,Kris Kobach,46
-Cloud,Solomon,Secretary of State,,Rep,Kris Kobach,127
-Cloud,Starr,Secretary of State,,Rep,Kris Kobach,146
-Cloud,Summitt,Secretary of State,,Rep,Kris Kobach,24
-Cloud,1st Ward,Secretary of State,,Rep,Kris Kobach,122
-Cloud,1st Pct 2nd Ward,Secretary of State,,Rep,Kris Kobach,131
-Cloud,2nd Pct 2nd Ward,Secretary of State,,Rep,Kris Kobach,204
-Cloud,3rd Ward,Secretary of State,,Rep,Kris Kobach,239
-Cloud,4th Ward,Secretary of State,,Rep,Kris Kobach,112
-Cloud,Arion,State House,107,Rep,Susan L Concannon,26
-Cloud,Aurora,State House,107,Rep,Susan L Concannon,37
-Cloud,Buffalo,State House,107,Rep,Susan L Concannon,37
-Cloud,Center,State House,107,Rep,Susan L Concannon,61
-Cloud,Colfax,State House,107,Rep,Susan L Concannon,16
-Cloud,Elk,State House,107,Rep,Susan L Concannon,212
-Cloud,Grant,State House,107,Rep,Susan L Concannon,95
-Cloud,N. Lawrence,State House,107,Rep,Susan L Concannon,19
-Cloud,S. Lawrence,State House,107,Rep,Susan L Concannon,16
-Cloud,E. Lincoln,State House,107,Rep,Susan L Concannon,76
-Cloud,W. Lincoln,State House,107,Rep,Susan L Concannon,46
-Cloud,Lyon,State House,107,Rep,Susan L Concannon,35
-Cloud,E. Meredith,State House,107,Rep,Susan L Concannon,13
-Cloud,W. Meredith,State House,107,Rep,Susan L Concannon,11
-Cloud,Nelson,State House,107,Rep,Susan L Concannon,43
-Cloud,Oakland,State House,107,Rep,Susan L Concannon,18
-Cloud,Shirley,State House,107,Rep,Susan L Concannon,44
-Cloud,Sibley,State House,107,Rep,Susan L Concannon,64
-Cloud,Solomon,State House,107,Rep,Susan L Concannon,155
-Cloud,Starr,State House,107,Rep,Susan L Concannon,167
-Cloud,Summitt,State House,107,Rep,Susan L Concannon,27
-Cloud,1st Ward,State House,107,Rep,Susan L Concannon,172
-Cloud,1st Pct 2nd Ward,State House,107,Rep,Susan L Concannon,200
-Cloud,2nd Pct 2nd Ward,State House,107,Rep,Susan L Concannon,276
-Cloud,3rd Ward,State House,107,Rep,Susan L Concannon,314
-Cloud,4th Ward,State House,107,Rep,Susan L Concannon,141
-Cloud,Arion,State Treasurer,,Dem,Carmen Alldritt,9
-Cloud,Aurora,State Treasurer,,Dem,Carmen Alldritt,5
-Cloud,Buffalo,State Treasurer,,Dem,Carmen Alldritt,3
-Cloud,Center,State Treasurer,,Dem,Carmen Alldritt,10
-Cloud,Colfax,State Treasurer,,Dem,Carmen Alldritt,1
-Cloud,Elk,State Treasurer,,Dem,Carmen Alldritt,55
-Cloud,Grant,State Treasurer,,Dem,Carmen Alldritt,13
-Cloud,N. Lawrence,State Treasurer,,Dem,Carmen Alldritt,2
-Cloud,S. Lawrence,State Treasurer,,Dem,Carmen Alldritt,4
-Cloud,E. Lincoln,State Treasurer,,Dem,Carmen Alldritt,20
-Cloud,W. Lincoln,State Treasurer,,Dem,Carmen Alldritt,20
-Cloud,Lyon,State Treasurer,,Dem,Carmen Alldritt,7
-Cloud,E. Meredith,State Treasurer,,Dem,Carmen Alldritt,1
-Cloud,W. Meredith,State Treasurer,,Dem,Carmen Alldritt,4
-Cloud,Nelson,State Treasurer,,Dem,Carmen Alldritt,6
-Cloud,Oakland,State Treasurer,,Dem,Carmen Alldritt,0
-Cloud,Shirley,State Treasurer,,Dem,Carmen Alldritt,6
-Cloud,Sibley,State Treasurer,,Dem,Carmen Alldritt,20
-Cloud,Solomon,State Treasurer,,Dem,Carmen Alldritt,33
-Cloud,Starr,State Treasurer,,Dem,Carmen Alldritt,34
-Cloud,Summitt,State Treasurer,,Dem,Carmen Alldritt,1
-Cloud,1st Ward,State Treasurer,,Dem,Carmen Alldritt,57
-Cloud,1st Pct 2nd Ward,State Treasurer,,Dem,Carmen Alldritt,63
-Cloud,2nd Pct 2nd Ward,State Treasurer,,Dem,Carmen Alldritt,68
-Cloud,3rd Ward,State Treasurer,,Dem,Carmen Alldritt,78
-Cloud,4th Ward,State Treasurer,,Dem,Carmen Alldritt,44
-Cloud,Arion,State Treasurer,,Rep,Ron Estes,22
-Cloud,Aurora,State Treasurer,,Rep,Ron Estes,35
-Cloud,Buffalo,State Treasurer,,Rep,Ron Estes,34
-Cloud,Center,State Treasurer,,Rep,Ron Estes,55
-Cloud,Colfax,State Treasurer,,Rep,Ron Estes,15
-Cloud,Elk,State Treasurer,,Rep,Ron Estes,184
-Cloud,Grant,State Treasurer,,Rep,Ron Estes,87
-Cloud,N. Lawrence,State Treasurer,,Rep,Ron Estes,17
-Cloud,S. Lawrence,State Treasurer,,Rep,Ron Estes,13
-Cloud,E. Lincoln,State Treasurer,,Rep,Ron Estes,64
-Cloud,W. Lincoln,State Treasurer,,Rep,Ron Estes,36
-Cloud,Lyon,State Treasurer,,Rep,Ron Estes,28
-Cloud,E. Meredith,State Treasurer,,Rep,Ron Estes,14
-Cloud,W. Meredith,State Treasurer,,Rep,Ron Estes,8
-Cloud,Nelson,State Treasurer,,Rep,Ron Estes,34
-Cloud,Oakland,State Treasurer,,Rep,Ron Estes,20
-Cloud,Shirley,State Treasurer,,Rep,Ron Estes,43
-Cloud,Sibley,State Treasurer,,Rep,Ron Estes,50
-Cloud,Solomon,State Treasurer,,Rep,Ron Estes,132
-Cloud,Starr,State Treasurer,,Rep,Ron Estes,148
-Cloud,Summitt,State Treasurer,,Rep,Ron Estes,25
-Cloud,1st Ward,State Treasurer,,Rep,Ron Estes,137
-Cloud,1st Pct 2nd Ward,State Treasurer,,Rep,Ron Estes,156
-Cloud,2nd Pct 2nd Ward,State Treasurer,,Rep,Ron Estes,225
-Cloud,3rd Ward,State Treasurer,,Rep,Ron Estes,262
-Cloud,4th Ward,State Treasurer,,Rep,Ron Estes,120
-Cloud,Arion,U.S. House,1,Dem,James E Sherow,7
-Cloud,Aurora,U.S. House,1,Dem,James E Sherow,13
-Cloud,Buffalo,U.S. House,1,Dem,James E Sherow,9
-Cloud,Center,U.S. House,1,Dem,James E Sherow,17
-Cloud,Colfax,U.S. House,1,Dem,James E Sherow,0
-Cloud,Elk,U.S. House,1,Dem,James E Sherow,102
-Cloud,Grant,U.S. House,1,Dem,James E Sherow,25
-Cloud,N. Lawrence,U.S. House,1,Dem,James E Sherow,5
-Cloud,S. Lawrence,U.S. House,1,Dem,James E Sherow,5
-Cloud,E. Lincoln,U.S. House,1,Dem,James E Sherow,24
-Cloud,W. Lincoln,U.S. House,1,Dem,James E Sherow,21
-Cloud,Lyon,U.S. House,1,Dem,James E Sherow,12
-Cloud,E. Meredith,U.S. House,1,Dem,James E Sherow,5
-Cloud,W. Meredith,U.S. House,1,Dem,James E Sherow,4
-Cloud,Nelson,U.S. House,1,Dem,James E Sherow,6
-Cloud,Oakland,U.S. House,1,Dem,James E Sherow,3
-Cloud,Shirley,U.S. House,1,Dem,James E Sherow,18
-Cloud,Sibley,U.S. House,1,Dem,James E Sherow,27
-Cloud,Solomon,U.S. House,1,Dem,James E Sherow,45
-Cloud,Starr,U.S. House,1,Dem,James E Sherow,37
-Cloud,Summitt,U.S. House,1,Dem,James E Sherow,1
-Cloud,1st Ward,U.S. House,1,Dem,James E Sherow,88
-Cloud,1st Pct 2nd Ward,U.S. House,1,Dem,James E Sherow,99
-Cloud,2nd Pct 2nd Ward,U.S. House,1,Dem,James E Sherow,102
-Cloud,3rd Ward,U.S. House,1,Dem,James E Sherow,121
-Cloud,4th Ward,U.S. House,1,Dem,James E Sherow,59
-Cloud,Arion,U.S. House,1,Rep,Tim Huelskamp,23
-Cloud,Aurora,U.S. House,1,Rep,Tim Huelskamp,29
-Cloud,Buffalo,U.S. House,1,Rep,Tim Huelskamp,34
-Cloud,Center,U.S. House,1,Rep,Tim Huelskamp,51
-Cloud,Colfax,U.S. House,1,Rep,Tim Huelskamp,14
-Cloud,Elk,U.S. House,1,Rep,Tim Huelskamp,147
-Cloud,Grant,U.S. House,1,Rep,Tim Huelskamp,77
-Cloud,N. Lawrence,U.S. House,1,Rep,Tim Huelskamp,16
-Cloud,S. Lawrence,U.S. House,1,Rep,Tim Huelskamp,13
-Cloud,E. Lincoln,U.S. House,1,Rep,Tim Huelskamp,58
-Cloud,W. Lincoln,U.S. House,1,Rep,Tim Huelskamp,35
-Cloud,Lyon,U.S. House,1,Rep,Tim Huelskamp,25
-Cloud,E. Meredith,U.S. House,1,Rep,Tim Huelskamp,10
-Cloud,W. Meredith,U.S. House,1,Rep,Tim Huelskamp,8
-Cloud,Nelson,U.S. House,1,Rep,Tim Huelskamp,36
-Cloud,Oakland,U.S. House,1,Rep,Tim Huelskamp,17
-Cloud,Shirley,U.S. House,1,Rep,Tim Huelskamp,33
-Cloud,Sibley,U.S. House,1,Rep,Tim Huelskamp,40
-Cloud,Solomon,U.S. House,1,Rep,Tim Huelskamp,119
-Cloud,Starr,U.S. House,1,Rep,Tim Huelskamp,148
-Cloud,Summitt,U.S. House,1,Rep,Tim Huelskamp,25
-Cloud,1st Ward,U.S. House,1,Rep,Tim Huelskamp,109
-Cloud,1st Pct 2nd Ward,U.S. House,1,Rep,Tim Huelskamp,117
-Cloud,2nd Pct 2nd Ward,U.S. House,1,Rep,Tim Huelskamp,196
-Cloud,3rd Ward,U.S. House,1,Rep,Tim Huelskamp,221
-Cloud,4th Ward,U.S. House,1,Rep,Tim Huelskamp,104
-CLOUD,Arion Township,U.S. Senate,,Rep,Pat Roberts,27
-CLOUD,Aurora Township,U.S. Senate,,Rep,Pat Roberts,36
-CLOUD,Buffalo Township,U.S. Senate,,Rep,Pat Roberts,47
-CLOUD,Center Township,U.S. Senate,,Rep,Pat Roberts,74
-CLOUD,Colfax Township,U.S. Senate,,Rep,Pat Roberts,17
-CLOUD,Concordia Ward 1,U.S. Senate,,Rep,Pat Roberts,155
-CLOUD,Concordia Ward 2 Precinct 1,U.S. Senate,,Rep,Pat Roberts,165
-CLOUD,Concordia Ward 2 Precinct 2,U.S. Senate,,Rep,Pat Roberts,244
-CLOUD,Concordia Ward 3,U.S. Senate,,Rep,Pat Roberts,275
-CLOUD,Concordia Ward 4,U.S. Senate,,Rep,Pat Roberts,127
-CLOUD,East Lincoln,U.S. Senate,,Rep,Pat Roberts,68
-CLOUD,East Meredith,U.S. Senate,,Rep,Pat Roberts,11
-CLOUD,Elk Township,U.S. Senate,,Rep,Pat Roberts,198
-CLOUD,Grant Township,U.S. Senate,,Rep,Pat Roberts,86
-CLOUD,Lyon Township,U.S. Senate,,Rep,Pat Roberts,35
-CLOUD,Nelson Township,U.S. Senate,,Rep,Pat Roberts,42
-CLOUD,North Lawrence,U.S. Senate,,Rep,Pat Roberts,26
-CLOUD,Oakland Township,U.S. Senate,,Rep,Pat Roberts,22
-CLOUD,Shirley Township,U.S. Senate,,Rep,Pat Roberts,50
-CLOUD,Sibley Township,U.S. Senate,,Rep,Pat Roberts,52
-CLOUD,Solomon Township,U.S. Senate,,Rep,Pat Roberts,123
-CLOUD,South Lawrence,U.S. Senate,,Rep,Pat Roberts,14
-CLOUD,Starr Township,U.S. Senate,,Rep,Pat Roberts,154
-CLOUD,Summit Township,U.S. Senate,,Rep,Pat Roberts,23
-CLOUD,West Lincoln,U.S. Senate,,Rep,Pat Roberts,44
-CLOUD,West Meredith,U.S. Senate,,Rep,Pat Roberts,8
-CLOUD,Arion Township,U.S. Senate,,Ind,Greg Orman,13
-CLOUD,Aurora Township,U.S. Senate,,Ind,Greg Orman,10
-CLOUD,Buffalo Township,U.S. Senate,,Ind,Greg Orman,5
-CLOUD,Center Township,U.S. Senate,,Ind,Greg Orman,12
-CLOUD,Colfax Township,U.S. Senate,,Ind,Greg Orman,0
-CLOUD,Concordia Ward 1,U.S. Senate,,Ind,Greg Orman,91
-CLOUD,Concordia Ward 2 Precinct 1,U.S. Senate,,Ind,Greg Orman,123
-CLOUD,Concordia Ward 2 Precinct 2,U.S. Senate,,Ind,Greg Orman,120
-CLOUD,Concordia Ward 3,U.S. Senate,,Ind,Greg Orman,133
-CLOUD,Concordia Ward 4,U.S. Senate,,Ind,Greg Orman,59
-CLOUD,East Lincoln,U.S. Senate,,Ind,Greg Orman,25
-CLOUD,East Meredith,U.S. Senate,,Ind,Greg Orman,7
-CLOUD,Elk Township,U.S. Senate,,Ind,Greg Orman,107
-CLOUD,Grant Township,U.S. Senate,,Ind,Greg Orman,18
-CLOUD,Lyon Township,U.S. Senate,,Ind,Greg Orman,8
-CLOUD,Nelson Township,U.S. Senate,,Ind,Greg Orman,8
-CLOUD,North Lawrence,U.S. Senate,,Ind,Greg Orman,6
-CLOUD,Oakland Township,U.S. Senate,,Ind,Greg Orman,0
-CLOUD,Shirley Township,U.S. Senate,,Ind,Greg Orman,13
-CLOUD,Sibley Township,U.S. Senate,,Ind,Greg Orman,35
-CLOUD,Solomon Township,U.S. Senate,,Ind,Greg Orman,36
-CLOUD,South Lawrence,U.S. Senate,,Ind,Greg Orman,7
-CLOUD,Starr Township,U.S. Senate,,Ind,Greg Orman,41
-CLOUD,Summit Township,U.S. Senate,,Ind,Greg Orman,5
-CLOUD,West Lincoln,U.S. Senate,,Ind,Greg Orman,20
-CLOUD,West Meredith,U.S. Senate,,Ind,Greg Orman,4
-CLOUD,Arion Township,U.S. Senate,,Lib,Randall Batson,2
-CLOUD,Aurora Township,U.S. Senate,,Lib,Randall Batson,4
-CLOUD,Buffalo Township,U.S. Senate,,Lib,Randall Batson,0
-CLOUD,Center Township,U.S. Senate,,Lib,Randall Batson,3
-CLOUD,Colfax Township,U.S. Senate,,Lib,Randall Batson,0
-CLOUD,Concordia Ward 1,U.S. Senate,,Lib,Randall Batson,12
-CLOUD,Concordia Ward 2 Precinct 1,U.S. Senate,,Lib,Randall Batson,17
-CLOUD,Concordia Ward 2 Precinct 2,U.S. Senate,,Lib,Randall Batson,16
-CLOUD,Concordia Ward 3,U.S. Senate,,Lib,Randall Batson,25
-CLOUD,Concordia Ward 4,U.S. Senate,,Lib,Randall Batson,13
-CLOUD,East Lincoln,U.S. Senate,,Lib,Randall Batson,7
-CLOUD,East Meredith,U.S. Senate,,Lib,Randall Batson,0
-CLOUD,Elk Township,U.S. Senate,,Lib,Randall Batson,15
-CLOUD,Grant Township,U.S. Senate,,Lib,Randall Batson,8
-CLOUD,Lyon Township,U.S. Senate,,Lib,Randall Batson,4
-CLOUD,Nelson Township,U.S. Senate,,Lib,Randall Batson,0
-CLOUD,North Lawrence,U.S. Senate,,Lib,Randall Batson,3
-CLOUD,Oakland Township,U.S. Senate,,Lib,Randall Batson,0
-CLOUD,Shirley Township,U.S. Senate,,Lib,Randall Batson,1
-CLOUD,Sibley Township,U.S. Senate,,Lib,Randall Batson,2
-CLOUD,Solomon Township,U.S. Senate,,Lib,Randall Batson,19
-CLOUD,South Lawrence,U.S. Senate,,Lib,Randall Batson,1
-CLOUD,Starr Township,U.S. Senate,,Lib,Randall Batson,10
-CLOUD,Summit Township,U.S. Senate,,Lib,Randall Batson,2
-CLOUD,West Lincoln,U.S. Senate,,Lib,Randall Batson,3
-CLOUD,West Meredith,U.S. Senate,,Lib,Randall Batson,1
+county,precinct,office,district,party,candidate,votes,vtd
+CLOUD,Arion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000010
+CLOUD,Arion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+CLOUD,Arion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000010
+CLOUD,Aurora Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000020
+CLOUD,Aurora Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+CLOUD,Aurora Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000020
+CLOUD,Buffalo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000030
+CLOUD,Buffalo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+CLOUD,Buffalo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000030
+CLOUD,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000040
+CLOUD,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+CLOUD,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000040
+CLOUD,Colfax Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000050
+CLOUD,Colfax Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+CLOUD,Colfax Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000050
+CLOUD,Concordia Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,00006A
+CLOUD,Concordia Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00006A
+CLOUD,Concordia Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,00006A
+CLOUD,Concordia Ward 1 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",157,000070
+CLOUD,Concordia Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000070
+CLOUD,Concordia Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,000070
+CLOUD,Concordia Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",152,00008A
+CLOUD,Concordia Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,00008A
+CLOUD,Concordia Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",218,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008B
+CLOUD,Concordia Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",189,000090
+CLOUD,Concordia Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000090
+CLOUD,Concordia Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",224,000090
+CLOUD,Concordia Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",84,000100
+CLOUD,Concordia Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000100
+CLOUD,Concordia Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000100
+CLOUD,East Lincoln,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,00011A
+CLOUD,East Lincoln,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,00011A
+CLOUD,East Lincoln,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,00011A
+CLOUD,East Lincoln Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00011B
+CLOUD,East Lincoln Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00011B
+CLOUD,East Lincoln Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00011B
+CLOUD,East Meredith,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000120
+CLOUD,East Meredith,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+CLOUD,East Meredith,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000120
+CLOUD,Elk Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000130
+CLOUD,Elk Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000130
+CLOUD,Elk Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",181,000130
+CLOUD,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000140
+CLOUD,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000140
+CLOUD,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000140
+CLOUD,Lyon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000150
+CLOUD,Lyon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+CLOUD,Lyon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000150
+CLOUD,Nelson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000160
+CLOUD,Nelson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000160
+CLOUD,Nelson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000160
+CLOUD,North Lawrence,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000170
+CLOUD,North Lawrence,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000170
+CLOUD,North Lawrence,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000170
+CLOUD,Oakland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000180
+CLOUD,Oakland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000180
+CLOUD,Oakland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000180
+CLOUD,Shirley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000190
+CLOUD,Shirley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000190
+CLOUD,Shirley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000190
+CLOUD,Sibley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000200
+CLOUD,Sibley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000200
+CLOUD,Sibley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,000200
+CLOUD,Solomon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000210
+CLOUD,Solomon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000210
+CLOUD,Solomon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",114,000210
+CLOUD,South Lawrence,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000220
+CLOUD,South Lawrence,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000220
+CLOUD,South Lawrence,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000220
+CLOUD,Starr Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000230
+CLOUD,Starr Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000230
+CLOUD,Starr Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",140,000230
+CLOUD,Summit Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000240
+CLOUD,Summit Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000240
+CLOUD,Summit Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000240
+CLOUD,West Lincoln,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000250
+CLOUD,West Lincoln,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000250
+CLOUD,West Lincoln,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000250
+CLOUD,West Meredith,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000260
+CLOUD,West Meredith,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000260
+CLOUD,West Meredith,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000260
+CLOUD,Arion Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",34,000010
+CLOUD,Aurora Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",43,000020
+CLOUD,Buffalo Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",45,000030
+CLOUD,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",77,000040
+CLOUD,Colfax Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",16,000050
+CLOUD,Concordia Ward 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",227,00006A
+CLOUD,Concordia Ward 1 Exclave A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",269,000070
+CLOUD,Concordia Ward 2 Precinct 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",348,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00008B
+CLOUD,Concordia Ward 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",389,000090
+CLOUD,Concordia Ward 4,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",169,000100
+CLOUD,East Lincoln,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",90,00011A
+CLOUD,East Lincoln Enclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00011B
+CLOUD,East Meredith,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",16,000120
+CLOUD,Elk Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",256,000130
+CLOUD,Grant Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",104,000140
+CLOUD,Lyon Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",43,000150
+CLOUD,Nelson Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",48,000160
+CLOUD,North Lawrence,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",30,000170
+CLOUD,Oakland Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",19,000180
+CLOUD,Shirley Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",53,000190
+CLOUD,Sibley Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",76,000200
+CLOUD,Solomon Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",169,000210
+CLOUD,South Lawrence,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",19,000220
+CLOUD,Starr Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",185,000230
+CLOUD,Summit Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",28,000240
+CLOUD,West Lincoln,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",54,000250
+CLOUD,West Meredith,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",12,000260
+CLOUD,Arion Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000010
+CLOUD,Arion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000010
+CLOUD,Aurora Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000020
+CLOUD,Aurora Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000020
+CLOUD,Buffalo Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000030
+CLOUD,Buffalo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000030
+CLOUD,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000040
+CLOUD,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,000040
+CLOUD,Colfax Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000050
+CLOUD,Colfax Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000050
+CLOUD,Concordia Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",113,00006A
+CLOUD,Concordia Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",143,00006A
+CLOUD,Concordia Ward 1 Exclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",146,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",156,000070
+CLOUD,Concordia Ward 2 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",142,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",239,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008B
+CLOUD,Concordia Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",161,000090
+CLOUD,Concordia Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",261,000090
+CLOUD,Concordia Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",77,000100
+CLOUD,Concordia Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",120,000100
+CLOUD,East Lincoln,United States House of Representatives,1,Democratic,"Sherow, James E.",29,00011A
+CLOUD,East Lincoln,United States House of Representatives,1,Republican,"Huelskamp, Tim",68,00011A
+CLOUD,East Lincoln Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00011B
+CLOUD,East Lincoln Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00011B
+CLOUD,East Meredith,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000120
+CLOUD,East Meredith,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000120
+CLOUD,Elk Township,United States House of Representatives,1,Democratic,"Sherow, James E.",121,000130
+CLOUD,Elk Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",180,000130
+CLOUD,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000140
+CLOUD,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000140
+CLOUD,Lyon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000150
+CLOUD,Lyon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000150
+CLOUD,Nelson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000160
+CLOUD,Nelson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000160
+CLOUD,North Lawrence,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000170
+CLOUD,North Lawrence,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000170
+CLOUD,Oakland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000180
+CLOUD,Oakland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000180
+CLOUD,Shirley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000190
+CLOUD,Shirley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000190
+CLOUD,Sibley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",39,000200
+CLOUD,Sibley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000200
+CLOUD,Solomon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",50,000210
+CLOUD,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",131,000210
+CLOUD,South Lawrence,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000220
+CLOUD,South Lawrence,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000220
+CLOUD,Starr Township,United States House of Representatives,1,Democratic,"Sherow, James E.",42,000230
+CLOUD,Starr Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",163,000230
+CLOUD,Summit Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000240
+CLOUD,Summit Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000240
+CLOUD,West Lincoln,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000250
+CLOUD,West Lincoln,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000250
+CLOUD,West Meredith,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000260
+CLOUD,West Meredith,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000260
+CLOUD,Arion Township,Attorney General,,Democratic,"Kotich, A.J.",12,000010
+CLOUD,Arion Township,Attorney General,,Republican,"Schmidt, Derek",30,000010
+CLOUD,Aurora Township,Attorney General,,Democratic,"Kotich, A.J.",9,000020
+CLOUD,Aurora Township,Attorney General,,Republican,"Schmidt, Derek",36,000020
+CLOUD,Buffalo Township,Attorney General,,Democratic,"Kotich, A.J.",5,000030
+CLOUD,Buffalo Township,Attorney General,,Republican,"Schmidt, Derek",45,000030
+CLOUD,Center Township,Attorney General,,Democratic,"Kotich, A.J.",3,000040
+CLOUD,Center Township,Attorney General,,Republican,"Schmidt, Derek",81,000040
+CLOUD,Colfax Township,Attorney General,,Democratic,"Kotich, A.J.",2,000050
+CLOUD,Colfax Township,Attorney General,,Republican,"Schmidt, Derek",14,000050
+CLOUD,Concordia Ward 1,Attorney General,,Democratic,"Kotich, A.J.",82,00006A
+CLOUD,Concordia Ward 1,Attorney General,,Republican,"Schmidt, Derek",172,00006A
+CLOUD,Concordia Ward 1 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",94,000070
+CLOUD,Concordia Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",208,000070
+CLOUD,Concordia Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",81,00008A
+CLOUD,Concordia Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",297,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00008B
+CLOUD,Concordia Ward 3,Attorney General,,Democratic,"Kotich, A.J.",102,000090
+CLOUD,Concordia Ward 3,Attorney General,,Republican,"Schmidt, Derek",321,000090
+CLOUD,Concordia Ward 4,Attorney General,,Democratic,"Kotich, A.J.",56,000100
+CLOUD,Concordia Ward 4,Attorney General,,Republican,"Schmidt, Derek",142,000100
+CLOUD,East Lincoln,Attorney General,,Democratic,"Kotich, A.J.",23,00011A
+CLOUD,East Lincoln,Attorney General,,Republican,"Schmidt, Derek",77,00011A
+CLOUD,East Lincoln Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00011B
+CLOUD,East Lincoln Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00011B
+CLOUD,East Meredith,Attorney General,,Democratic,"Kotich, A.J.",1,000120
+CLOUD,East Meredith,Attorney General,,Republican,"Schmidt, Derek",17,000120
+CLOUD,Elk Township,Attorney General,,Democratic,"Kotich, A.J.",72,000130
+CLOUD,Elk Township,Attorney General,,Republican,"Schmidt, Derek",224,000130
+CLOUD,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",22,000140
+CLOUD,Grant Township,Attorney General,,Republican,"Schmidt, Derek",87,000140
+CLOUD,Lyon Township,Attorney General,,Democratic,"Kotich, A.J.",6,000150
+CLOUD,Lyon Township,Attorney General,,Republican,"Schmidt, Derek",39,000150
+CLOUD,Nelson Township,Attorney General,,Democratic,"Kotich, A.J.",6,000160
+CLOUD,Nelson Township,Attorney General,,Republican,"Schmidt, Derek",43,000160
+CLOUD,North Lawrence,Attorney General,,Democratic,"Kotich, A.J.",5,000170
+CLOUD,North Lawrence,Attorney General,,Republican,"Schmidt, Derek",29,000170
+CLOUD,Oakland Township,Attorney General,,Democratic,"Kotich, A.J.",1,000180
+CLOUD,Oakland Township,Attorney General,,Republican,"Schmidt, Derek",20,000180
+CLOUD,Shirley Township,Attorney General,,Democratic,"Kotich, A.J.",9,000190
+CLOUD,Shirley Township,Attorney General,,Republican,"Schmidt, Derek",52,000190
+CLOUD,Sibley Township,Attorney General,,Democratic,"Kotich, A.J.",23,000200
+CLOUD,Sibley Township,Attorney General,,Republican,"Schmidt, Derek",62,000200
+CLOUD,Solomon Township,Attorney General,,Democratic,"Kotich, A.J.",31,000210
+CLOUD,Solomon Township,Attorney General,,Republican,"Schmidt, Derek",150,000210
+CLOUD,South Lawrence,Attorney General,,Democratic,"Kotich, A.J.",8,000220
+CLOUD,South Lawrence,Attorney General,,Republican,"Schmidt, Derek",14,000220
+CLOUD,Starr Township,Attorney General,,Democratic,"Kotich, A.J.",39,000230
+CLOUD,Starr Township,Attorney General,,Republican,"Schmidt, Derek",162,000230
+CLOUD,Summit Township,Attorney General,,Democratic,"Kotich, A.J.",2,000240
+CLOUD,Summit Township,Attorney General,,Republican,"Schmidt, Derek",26,000240
+CLOUD,West Lincoln,Attorney General,,Democratic,"Kotich, A.J.",24,000250
+CLOUD,West Lincoln,Attorney General,,Republican,"Schmidt, Derek",43,000250
+CLOUD,West Meredith,Attorney General,,Democratic,"Kotich, A.J.",4,000260
+CLOUD,West Meredith,Attorney General,,Republican,"Schmidt, Derek",9,000260
+CLOUD,Arion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000010
+CLOUD,Arion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000010
+CLOUD,Aurora Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000020
+CLOUD,Aurora Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000020
+CLOUD,Buffalo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000030
+CLOUD,Buffalo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000030
+CLOUD,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000040
+CLOUD,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",72,000040
+CLOUD,Colfax Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000050
+CLOUD,Colfax Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000050
+CLOUD,Concordia Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,00006A
+CLOUD,Concordia Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",160,00006A
+CLOUD,Concordia Ward 1 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",109,000070
+CLOUD,Concordia Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",188,000070
+CLOUD,Concordia Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",119,00008A
+CLOUD,Concordia Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",244,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00008B
+CLOUD,Concordia Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",139,000090
+CLOUD,Concordia Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",276,000090
+CLOUD,Concordia Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000100
+CLOUD,Concordia Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",125,000100
+CLOUD,East Lincoln,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,00011A
+CLOUD,East Lincoln,Commissioner of Insurance,,Republican,"Selzer, Ken",72,00011A
+CLOUD,East Lincoln Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00011B
+CLOUD,East Lincoln Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00011B
+CLOUD,East Meredith,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000120
+CLOUD,East Meredith,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000120
+CLOUD,Elk Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,000130
+CLOUD,Elk Township,Commissioner of Insurance,,Republican,"Selzer, Ken",185,000130
+CLOUD,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000140
+CLOUD,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",90,000140
+CLOUD,Lyon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000150
+CLOUD,Lyon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000150
+CLOUD,Nelson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000160
+CLOUD,Nelson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000160
+CLOUD,North Lawrence,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000170
+CLOUD,North Lawrence,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000170
+CLOUD,Oakland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000180
+CLOUD,Oakland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000180
+CLOUD,Shirley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000190
+CLOUD,Shirley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000190
+CLOUD,Sibley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000200
+CLOUD,Sibley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",56,000200
+CLOUD,Solomon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000210
+CLOUD,Solomon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",127,000210
+CLOUD,South Lawrence,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000220
+CLOUD,South Lawrence,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000220
+CLOUD,Starr Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000230
+CLOUD,Starr Township,Commissioner of Insurance,,Republican,"Selzer, Ken",150,000230
+CLOUD,Summit Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000240
+CLOUD,Summit Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000240
+CLOUD,West Lincoln,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000250
+CLOUD,West Lincoln,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000250
+CLOUD,West Meredith,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000260
+CLOUD,West Meredith,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000260
+CLOUD,Arion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000010
+CLOUD,Arion Township,Secretary of State,,Republican,"Kobach, Kris",28,000010
+CLOUD,Aurora Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000020
+CLOUD,Aurora Township,Secretary of State,,Republican,"Kobach, Kris",40,000020
+CLOUD,Buffalo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000030
+CLOUD,Buffalo Township,Secretary of State,,Republican,"Kobach, Kris",43,000030
+CLOUD,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000040
+CLOUD,Center Township,Secretary of State,,Republican,"Kobach, Kris",72,000040
+CLOUD,Colfax Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000050
+CLOUD,Colfax Township,Secretary of State,,Republican,"Kobach, Kris",16,000050
+CLOUD,Concordia Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,00006A
+CLOUD,Concordia Ward 1,Secretary of State,,Republican,"Kobach, Kris",163,00006A
+CLOUD,Concordia Ward 1 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",130,000070
+CLOUD,Concordia Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",174,000070
+CLOUD,Concordia Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",131,00008A
+CLOUD,Concordia Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",249,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00008B
+CLOUD,Concordia Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",140,000090
+CLOUD,Concordia Ward 3,Secretary of State,,Republican,"Kobach, Kris",288,000090
+CLOUD,Concordia Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000100
+CLOUD,Concordia Ward 4,Secretary of State,,Republican,"Kobach, Kris",131,000100
+CLOUD,East Lincoln,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,00011A
+CLOUD,East Lincoln,Secretary of State,,Republican,"Kobach, Kris",76,00011A
+CLOUD,East Lincoln Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00011B
+CLOUD,East Lincoln Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00011B
+CLOUD,East Meredith,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000120
+CLOUD,East Meredith,Secretary of State,,Republican,"Kobach, Kris",14,000120
+CLOUD,Elk Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",108,000130
+CLOUD,Elk Township,Secretary of State,,Republican,"Kobach, Kris",204,000130
+CLOUD,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000140
+CLOUD,Grant Township,Secretary of State,,Republican,"Kobach, Kris",90,000140
+CLOUD,Lyon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000150
+CLOUD,Lyon Township,Secretary of State,,Republican,"Kobach, Kris",33,000150
+CLOUD,Nelson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000160
+CLOUD,Nelson Township,Secretary of State,,Republican,"Kobach, Kris",42,000160
+CLOUD,North Lawrence,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000170
+CLOUD,North Lawrence,Secretary of State,,Republican,"Kobach, Kris",27,000170
+CLOUD,Oakland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000180
+CLOUD,Oakland Township,Secretary of State,,Republican,"Kobach, Kris",20,000180
+CLOUD,Shirley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000190
+CLOUD,Shirley Township,Secretary of State,,Republican,"Kobach, Kris",47,000190
+CLOUD,Sibley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000200
+CLOUD,Sibley Township,Secretary of State,,Republican,"Kobach, Kris",54,000200
+CLOUD,Solomon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000210
+CLOUD,Solomon Township,Secretary of State,,Republican,"Kobach, Kris",136,000210
+CLOUD,South Lawrence,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000220
+CLOUD,South Lawrence,Secretary of State,,Republican,"Kobach, Kris",17,000220
+CLOUD,Starr Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000230
+CLOUD,Starr Township,Secretary of State,,Republican,"Kobach, Kris",162,000230
+CLOUD,Summit Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000240
+CLOUD,Summit Township,Secretary of State,,Republican,"Kobach, Kris",27,000240
+CLOUD,West Lincoln,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000250
+CLOUD,West Lincoln,Secretary of State,,Republican,"Kobach, Kris",47,000250
+CLOUD,West Meredith,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000260
+CLOUD,West Meredith,Secretary of State,,Republican,"Kobach, Kris",8,000260
+CLOUD,Arion Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000010
+CLOUD,Arion Township,State Treasurer,,Republican,"Estes, Ron",29,000010
+CLOUD,Aurora Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000020
+CLOUD,Aurora Township,State Treasurer,,Republican,"Estes, Ron",40,000020
+CLOUD,Buffalo Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+CLOUD,Buffalo Township,State Treasurer,,Republican,"Estes, Ron",42,000030
+CLOUD,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000040
+CLOUD,Center Township,State Treasurer,,Republican,"Estes, Ron",73,000040
+CLOUD,Colfax Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000050
+CLOUD,Colfax Township,State Treasurer,,Republican,"Estes, Ron",15,000050
+CLOUD,Concordia Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",72,00006A
+CLOUD,Concordia Ward 1,State Treasurer,,Republican,"Estes, Ron",181,00006A
+CLOUD,Concordia Ward 1 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",96,000070
+CLOUD,Concordia Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",208,000070
+CLOUD,Concordia Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",94,00008A
+CLOUD,Concordia Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",281,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00008B
+CLOUD,Concordia Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",106,000090
+CLOUD,Concordia Ward 3,State Treasurer,,Republican,"Estes, Ron",316,000090
+CLOUD,Concordia Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",59,000100
+CLOUD,Concordia Ward 4,State Treasurer,,Republican,"Estes, Ron",139,000100
+CLOUD,East Lincoln,State Treasurer,,Democratic,"Alldritt, Carmen",26,00011A
+CLOUD,East Lincoln,State Treasurer,,Republican,"Estes, Ron",74,00011A
+CLOUD,East Lincoln Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00011B
+CLOUD,East Lincoln Enclave,State Treasurer,,Republican,"Estes, Ron",0,00011B
+CLOUD,East Meredith,State Treasurer,,Democratic,"Alldritt, Carmen",2,000120
+CLOUD,East Meredith,State Treasurer,,Republican,"Estes, Ron",16,000120
+CLOUD,Elk Township,State Treasurer,,Democratic,"Alldritt, Carmen",74,000130
+CLOUD,Elk Township,State Treasurer,,Republican,"Estes, Ron",216,000130
+CLOUD,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000140
+CLOUD,Grant Township,State Treasurer,,Republican,"Estes, Ron",94,000140
+CLOUD,Lyon Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000150
+CLOUD,Lyon Township,State Treasurer,,Republican,"Estes, Ron",36,000150
+CLOUD,Nelson Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000160
+CLOUD,Nelson Township,State Treasurer,,Republican,"Estes, Ron",37,000160
+CLOUD,North Lawrence,State Treasurer,,Democratic,"Alldritt, Carmen",5,000170
+CLOUD,North Lawrence,State Treasurer,,Republican,"Estes, Ron",28,000170
+CLOUD,Oakland Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000180
+CLOUD,Oakland Township,State Treasurer,,Republican,"Estes, Ron",21,000180
+CLOUD,Shirley Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000190
+CLOUD,Shirley Township,State Treasurer,,Republican,"Estes, Ron",50,000190
+CLOUD,Sibley Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000200
+CLOUD,Sibley Township,State Treasurer,,Republican,"Estes, Ron",61,000200
+CLOUD,Solomon Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000210
+CLOUD,Solomon Township,State Treasurer,,Republican,"Estes, Ron",143,000210
+CLOUD,South Lawrence,State Treasurer,,Democratic,"Alldritt, Carmen",6,000220
+CLOUD,South Lawrence,State Treasurer,,Republican,"Estes, Ron",16,000220
+CLOUD,Starr Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000230
+CLOUD,Starr Township,State Treasurer,,Republican,"Estes, Ron",164,000230
+CLOUD,Summit Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000240
+CLOUD,Summit Township,State Treasurer,,Republican,"Estes, Ron",28,000240
+CLOUD,West Lincoln,State Treasurer,,Democratic,"Alldritt, Carmen",22,000250
+CLOUD,West Lincoln,State Treasurer,,Republican,"Estes, Ron",45,000250
+CLOUD,West Meredith,State Treasurer,,Democratic,"Alldritt, Carmen",4,000260
+CLOUD,West Meredith,State Treasurer,,Republican,"Estes, Ron",9,000260
+CLOUD,Arion Township,United States Senate,,independent,"Orman, Greg",13,000010
+CLOUD,Arion Township,United States Senate,,Libertarian,"Batson, Randall",2,000010
+CLOUD,Arion Township,United States Senate,,Republican,"Roberts, Pat",27,000010
+CLOUD,Aurora Township,United States Senate,,independent,"Orman, Greg",10,000020
+CLOUD,Aurora Township,United States Senate,,Libertarian,"Batson, Randall",4,000020
+CLOUD,Aurora Township,United States Senate,,Republican,"Roberts, Pat",36,000020
+CLOUD,Buffalo Township,United States Senate,,independent,"Orman, Greg",5,000030
+CLOUD,Buffalo Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+CLOUD,Buffalo Township,United States Senate,,Republican,"Roberts, Pat",47,000030
+CLOUD,Center Township,United States Senate,,independent,"Orman, Greg",12,000040
+CLOUD,Center Township,United States Senate,,Libertarian,"Batson, Randall",3,000040
+CLOUD,Center Township,United States Senate,,Republican,"Roberts, Pat",74,000040
+CLOUD,Colfax Township,United States Senate,,independent,"Orman, Greg",0,000050
+CLOUD,Colfax Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+CLOUD,Colfax Township,United States Senate,,Republican,"Roberts, Pat",17,000050
+CLOUD,Concordia Ward 1,United States Senate,,independent,"Orman, Greg",91,00006A
+CLOUD,Concordia Ward 1,United States Senate,,Libertarian,"Batson, Randall",12,00006A
+CLOUD,Concordia Ward 1,United States Senate,,Republican,"Roberts, Pat",155,00006A
+CLOUD,Concordia Ward 1 Exclave A,United States Senate,,independent,"Orman, Greg",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",123,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",17,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",165,000070
+CLOUD,Concordia Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",120,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",16,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",244,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00008B
+CLOUD,Concordia Ward 3,United States Senate,,independent,"Orman, Greg",133,000090
+CLOUD,Concordia Ward 3,United States Senate,,Libertarian,"Batson, Randall",25,000090
+CLOUD,Concordia Ward 3,United States Senate,,Republican,"Roberts, Pat",275,000090
+CLOUD,Concordia Ward 4,United States Senate,,independent,"Orman, Greg",59,000100
+CLOUD,Concordia Ward 4,United States Senate,,Libertarian,"Batson, Randall",13,000100
+CLOUD,Concordia Ward 4,United States Senate,,Republican,"Roberts, Pat",127,000100
+CLOUD,East Lincoln,United States Senate,,independent,"Orman, Greg",25,00011A
+CLOUD,East Lincoln,United States Senate,,Libertarian,"Batson, Randall",7,00011A
+CLOUD,East Lincoln,United States Senate,,Republican,"Roberts, Pat",68,00011A
+CLOUD,East Lincoln Enclave,United States Senate,,independent,"Orman, Greg",0,00011B
+CLOUD,East Lincoln Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00011B
+CLOUD,East Lincoln Enclave,United States Senate,,Republican,"Roberts, Pat",0,00011B
+CLOUD,East Meredith,United States Senate,,independent,"Orman, Greg",7,000120
+CLOUD,East Meredith,United States Senate,,Libertarian,"Batson, Randall",0,000120
+CLOUD,East Meredith,United States Senate,,Republican,"Roberts, Pat",11,000120
+CLOUD,Elk Township,United States Senate,,independent,"Orman, Greg",107,000130
+CLOUD,Elk Township,United States Senate,,Libertarian,"Batson, Randall",15,000130
+CLOUD,Elk Township,United States Senate,,Republican,"Roberts, Pat",198,000130
+CLOUD,Grant Township,United States Senate,,independent,"Orman, Greg",18,000140
+CLOUD,Grant Township,United States Senate,,Libertarian,"Batson, Randall",8,000140
+CLOUD,Grant Township,United States Senate,,Republican,"Roberts, Pat",86,000140
+CLOUD,Lyon Township,United States Senate,,independent,"Orman, Greg",8,000150
+CLOUD,Lyon Township,United States Senate,,Libertarian,"Batson, Randall",4,000150
+CLOUD,Lyon Township,United States Senate,,Republican,"Roberts, Pat",35,000150
+CLOUD,Nelson Township,United States Senate,,independent,"Orman, Greg",8,000160
+CLOUD,Nelson Township,United States Senate,,Libertarian,"Batson, Randall",0,000160
+CLOUD,Nelson Township,United States Senate,,Republican,"Roberts, Pat",42,000160
+CLOUD,North Lawrence,United States Senate,,independent,"Orman, Greg",6,000170
+CLOUD,North Lawrence,United States Senate,,Libertarian,"Batson, Randall",3,000170
+CLOUD,North Lawrence,United States Senate,,Republican,"Roberts, Pat",26,000170
+CLOUD,Oakland Township,United States Senate,,independent,"Orman, Greg",0,000180
+CLOUD,Oakland Township,United States Senate,,Libertarian,"Batson, Randall",0,000180
+CLOUD,Oakland Township,United States Senate,,Republican,"Roberts, Pat",22,000180
+CLOUD,Shirley Township,United States Senate,,independent,"Orman, Greg",13,000190
+CLOUD,Shirley Township,United States Senate,,Libertarian,"Batson, Randall",1,000190
+CLOUD,Shirley Township,United States Senate,,Republican,"Roberts, Pat",50,000190
+CLOUD,Sibley Township,United States Senate,,independent,"Orman, Greg",35,000200
+CLOUD,Sibley Township,United States Senate,,Libertarian,"Batson, Randall",2,000200
+CLOUD,Sibley Township,United States Senate,,Republican,"Roberts, Pat",52,000200
+CLOUD,Solomon Township,United States Senate,,independent,"Orman, Greg",36,000210
+CLOUD,Solomon Township,United States Senate,,Libertarian,"Batson, Randall",19,000210
+CLOUD,Solomon Township,United States Senate,,Republican,"Roberts, Pat",123,000210
+CLOUD,South Lawrence,United States Senate,,independent,"Orman, Greg",7,000220
+CLOUD,South Lawrence,United States Senate,,Libertarian,"Batson, Randall",1,000220
+CLOUD,South Lawrence,United States Senate,,Republican,"Roberts, Pat",14,000220
+CLOUD,Starr Township,United States Senate,,independent,"Orman, Greg",41,000230
+CLOUD,Starr Township,United States Senate,,Libertarian,"Batson, Randall",10,000230
+CLOUD,Starr Township,United States Senate,,Republican,"Roberts, Pat",154,000230
+CLOUD,Summit Township,United States Senate,,independent,"Orman, Greg",5,000240
+CLOUD,Summit Township,United States Senate,,Libertarian,"Batson, Randall",2,000240
+CLOUD,Summit Township,United States Senate,,Republican,"Roberts, Pat",23,000240
+CLOUD,West Lincoln,United States Senate,,independent,"Orman, Greg",20,000250
+CLOUD,West Lincoln,United States Senate,,Libertarian,"Batson, Randall",3,000250
+CLOUD,West Lincoln,United States Senate,,Republican,"Roberts, Pat",44,000250
+CLOUD,West Meredith,United States Senate,,independent,"Orman, Greg",4,000260
+CLOUD,West Meredith,United States Senate,,Libertarian,"Batson, Randall",1,000260
+CLOUD,West Meredith,United States Senate,,Republican,"Roberts, Pat",8,000260

--- a/2014/20141104__ks__general__coffey__precinct.csv
+++ b/2014/20141104__ks__general__coffey__precinct.csv
@@ -1,341 +1,461 @@
-county,precinct,office,district,party,candidate,votes
-Coffey,Avon twp,U.S. Senate,,R,Pat Roberts,57
-Coffey,Burlington twp,U.S. Senate,,R,Pat Roberts,119
-Coffey,Burlington 1,U.S. Senate,,R,Pat Roberts,205
-Coffey,Burlington 2,U.S. Senate,,R,Pat Roberts,168
-Coffey,Burlington 3,U.S. Senate,,R,Pat Roberts,189
-Coffey,Hampden twp,U.S. Senate,,R,Pat Roberts,47
-Coffey,Key West twp,U.S. Senate,,R,Pat Roberts,63
-Coffey,Leroy twp,U.S. Senate,,R,Pat Roberts,148
-Coffey,Liberty twp,U.S. Senate,,R,Pat Roberts,145
-Coffey,Lincoln twp,U.S. Senate,,R,Pat Roberts,272
-Coffey,Neosho twp,U.S. Senate,,R,Pat Roberts,34
-Coffey,Ottumwa twp,U.S. Senate,,R,Pat Roberts,195
-Coffey,Pleasant twp,U.S. Senate,,R,Pat Roberts,51
-Coffey,Pottawatomie twp,U.S. Senate,,R,Pat Roberts,66
-Coffey,Rock Creek twp,U.S. Senate,,R,Pat Roberts,177
-Coffey,Spring Creek twp,U.S. Senate,,R,Pat Roberts,46
-Coffey,Tar twp,U.S. Senate,,R,Pat Roberts,43
-Coffey,Avon twp,U.S. Senate,,I,Greg Orman,23
-Coffey,Burlington twp,U.S. Senate,,I,Greg Orman,32
-Coffey,Burlington 1,U.S. Senate,,I,Greg Orman,108
-Coffey,Burlington 2,U.S. Senate,,I,Greg Orman,66
-Coffey,Burlington 3,U.S. Senate,,I,Greg Orman,79
-Coffey,Hampden twp,U.S. Senate,,I,Greg Orman,25
-Coffey,Key West twp,U.S. Senate,,I,Greg Orman,28
-Coffey,Leroy twp,U.S. Senate,,I,Greg Orman,64
-Coffey,Liberty twp,U.S. Senate,,I,Greg Orman,67
-Coffey,Lincoln twp,U.S. Senate,,I,Greg Orman,149
-Coffey,Neosho twp,U.S. Senate,,I,Greg Orman,16
-Coffey,Ottumwa twp,U.S. Senate,,I,Greg Orman,98
-Coffey,Pleasant twp,U.S. Senate,,I,Greg Orman,36
-Coffey,Pottawatomie twp,U.S. Senate,,I,Greg Orman,12
-Coffey,Rock Creek twp,U.S. Senate,,I,Greg Orman,113
-Coffey,Spring Creek twp,U.S. Senate,,I,Greg Orman,14
-Coffey,Tar twp,U.S. Senate,,I,Greg Orman,21
-Coffey,Avon twp,U.S. Senate,,L,Randall Batson,3
-Coffey,Burlington twp,U.S. Senate,,L,Randall Batson,3
-Coffey,Burlington 1,U.S. Senate,,L,Randall Batson,8
-Coffey,Burlington 2,U.S. Senate,,L,Randall Batson,15
-Coffey,Burlington 3,U.S. Senate,,L,Randall Batson,21
-Coffey,Hampden twp,U.S. Senate,,L,Randall Batson,0
-Coffey,Key West twp,U.S. Senate,,L,Randall Batson,7
-Coffey,Leroy twp,U.S. Senate,,L,Randall Batson,14
-Coffey,Liberty twp,U.S. Senate,,L,Randall Batson,15
-Coffey,Lincoln twp,U.S. Senate,,L,Randall Batson,27
-Coffey,Neosho twp,U.S. Senate,,L,Randall Batson,1
-Coffey,Ottumwa twp,U.S. Senate,,L,Randall Batson,19
-Coffey,Pleasant twp,U.S. Senate,,L,Randall Batson,5
-Coffey,Pottawatomie twp,U.S. Senate,,L,Randall Batson,5
-Coffey,Rock Creek twp,U.S. Senate,,L,Randall Batson,18
-Coffey,Spring Creek twp,U.S. Senate,,L,Randall Batson,4
-Coffey,Tar twp,U.S. Senate,,L,Randall Batson,3
-Coffey,Avon twp,U.S. House,2,R,Lynn Jenkins,67
-Coffey,Burlington twp,U.S. House,2,R,Lynn Jenkins,128
-Coffey,Burlington 1,U.S. House,2,R,Lynn Jenkins,233
-Coffey,Burlington 2,U.S. House,2,R,Lynn Jenkins,188
-Coffey,Burlington 3,U.S. House,2,R,Lynn Jenkins,214
-Coffey,Hampden twp,U.S. House,2,R,Lynn Jenkins,55
-Coffey,Key West twp,U.S. House,2,R,Lynn Jenkins,71
-Coffey,Leroy twp,U.S. House,2,R,Lynn Jenkins,167
-Coffey,Liberty twp,U.S. House,2,R,Lynn Jenkins,168
-Coffey,Lincoln twp,U.S. House,2,R,Lynn Jenkins,293
-Coffey,Neosho twp,U.S. House,2,R,Lynn Jenkins,40
-Coffey,Ottumwa twp,U.S. House,2,R,Lynn Jenkins,217
-Coffey,Pleasant twp,U.S. House,2,R,Lynn Jenkins,59
-Coffey,Pottawatomie twp,U.S. House,2,R,Lynn Jenkins,69
-Coffey,Rock Creek twp,U.S. House,2,R,Lynn Jenkins,207
-Coffey,Spring Creek twp,U.S. House,2,R,Lynn Jenkins,54
-Coffey,Tar twp,U.S. House,2,R,Lynn Jenkins,49
-Coffey,Avon twp,U.S. House,2,D,Margie Wakefield,14
-Coffey,Burlington twp,U.S. House,2,D,Margie Wakefield,25
-Coffey,Burlington 1,U.S. House,2,D,Margie Wakefield,75
-Coffey,Burlington 2,U.S. House,2,D,Margie Wakefield,49
-Coffey,Burlington 3,U.S. House,2,D,Margie Wakefield,56
-Coffey,Hampden twp,U.S. House,2,D,Margie Wakefield,16
-Coffey,Key West twp,U.S. House,2,D,Margie Wakefield,19
-Coffey,Leroy twp,U.S. House,2,D,Margie Wakefield,43
-Coffey,Liberty twp,U.S. House,2,D,Margie Wakefield,48
-Coffey,Lincoln twp,U.S. House,2,D,Margie Wakefield,132
-Coffey,Neosho twp,U.S. House,2,D,Margie Wakefield,9
-Coffey,Ottumwa twp,U.S. House,2,D,Margie Wakefield,76
-Coffey,Pleasant twp,U.S. House,2,D,Margie Wakefield,29
-Coffey,Pottawatomie twp,U.S. House,2,D,Margie Wakefield,9
-Coffey,Rock Creek twp,U.S. House,2,D,Margie Wakefield,89
-Coffey,Spring Creek twp,U.S. House,2,D,Margie Wakefield,11
-Coffey,Tar twp,U.S. House,2,D,Margie Wakefield,16
-Coffey,Avon twp,U.S. House,2,L,Christopher Clemmons,2
-Coffey,Burlington twp,U.S. House,2,L,Christopher Clemmons,3
-Coffey,Burlington 1,U.S. House,2,L,Christopher Clemmons,14
-Coffey,Burlington 2,U.S. House,2,L,Christopher Clemmons,12
-Coffey,Burlington 3,U.S. House,2,L,Christopher Clemmons,22
-Coffey,Hampden twp,U.S. House,2,L,Christopher Clemmons,2
-Coffey,Key West twp,U.S. House,2,L,Christopher Clemmons,7
-Coffey,Leroy twp,U.S. House,2,L,Christopher Clemmons,18
-Coffey,Liberty twp,U.S. House,2,L,Christopher Clemmons,13
-Coffey,Lincoln twp,U.S. House,2,L,Christopher Clemmons,24
-Coffey,Neosho twp,U.S. House,2,L,Christopher Clemmons,1
-Coffey,Ottumwa twp,U.S. House,2,L,Christopher Clemmons,17
-Coffey,Pleasant twp,U.S. House,2,L,Christopher Clemmons,4
-Coffey,Pottawatomie twp,U.S. House,2,L,Christopher Clemmons,5
-Coffey,Rock Creek twp,U.S. House,2,L,Christopher Clemmons,12
-Coffey,Spring Creek twp,U.S. House,2,L,Christopher Clemmons,3
-Coffey,Tar twp,U.S. House,2,L,Christopher Clemmons,2
-Coffey,Avon twp,Governor,,R,Sam Brownback,55
-Coffey,Burlington twp,Governor,,R,Sam Brownback,103
-Coffey,Burlington 1,Governor,,R,Sam Brownback,190
-Coffey,Burlington 2,Governor,,R,Sam Brownback,161
-Coffey,Burlington 3,Governor,,R,Sam Brownback,157
-Coffey,Hampden twp,Governor,,R,Sam Brownback,43
-Coffey,Key West twp,Governor,,R,Sam Brownback,55
-Coffey,Leroy twp,Governor,,R,Sam Brownback,134
-Coffey,Liberty twp,Governor,,R,Sam Brownback,130
-Coffey,Lincoln twp,Governor,,R,Sam Brownback,218
-Coffey,Neosho twp,Governor,,R,Sam Brownback,30
-Coffey,Ottumwa twp,Governor,,R,Sam Brownback,186
-Coffey,Pleasant twp,Governor,,R,Sam Brownback,50
-Coffey,Pottawatomie twp,Governor,,R,Sam Brownback,62
-Coffey,Rock Creek twp,Governor,,R,Sam Brownback,157
-Coffey,Spring Creek twp,Governor,,R,Sam Brownback,48
-Coffey,Tar twp,Governor,,R,Sam Brownback,39
-Coffey,Avon twp,Governor,,D,Paul Davis,23
-Coffey,Burlington twp,Governor,,D,Paul Davis,43
-Coffey,Burlington 1,Governor,,D,Paul Davis,121
-Coffey,Burlington 2,Governor,,D,Paul Davis,76
-Coffey,Burlington 3,Governor,,D,Paul Davis,112
-Coffey,Hampden twp,Governor,,D,Paul Davis,28
-Coffey,Key West twp,Governor,,D,Paul Davis,37
-Coffey,Leroy twp,Governor,,D,Paul Davis,78
-Coffey,Liberty twp,Governor,,D,Paul Davis,92
-Coffey,Lincoln twp,Governor,,D,Paul Davis,200
-Coffey,Neosho twp,Governor,,D,Paul Davis,16
-Coffey,Ottumwa twp,Governor,,D,Paul Davis,108
-Coffey,Pleasant twp,Governor,,D,Paul Davis,35
-Coffey,Pottawatomie twp,Governor,,D,Paul Davis,19
-Coffey,Rock Creek twp,Governor,,D,Paul Davis,138
-Coffey,Spring Creek twp,Governor,,D,Paul Davis,15
-Coffey,Tar twp,Governor,,D,Paul Davis,26
-Coffey,Avon twp,Governor,,L,Keen Umbehr,5
-Coffey,Burlington twp,Governor,,L,Keen Umbehr,10
-Coffey,Burlington 1,Governor,,L,Keen Umbehr,12
-Coffey,Burlington 2,Governor,,L,Keen Umbehr,14
-Coffey,Burlington 3,Governor,,L,Keen Umbehr,22
-Coffey,Hampden twp,Governor,,L,Keen Umbehr,1
-Coffey,Key West twp,Governor,,L,Keen Umbehr,6
-Coffey,Leroy twp,Governor,,L,Keen Umbehr,12
-Coffey,Liberty twp,Governor,,L,Keen Umbehr,10
-Coffey,Lincoln twp,Governor,,L,Keen Umbehr,33
-Coffey,Neosho twp,Governor,,L,Keen Umbehr,3
-Coffey,Ottumwa twp,Governor,,L,Keen Umbehr,18
-Coffey,Pleasant twp,Governor,,L,Keen Umbehr,7
-Coffey,Pottawatomie twp,Governor,,L,Keen Umbehr,2
-Coffey,Rock Creek twp,Governor,,L,Keen Umbehr,14
-Coffey,Spring Creek twp,Governor,,L,Keen Umbehr,3
-Coffey,Tar twp,Governor,,L,Keen Umbehr,2
-Coffey,Avon twp,Secretary of State,,R,Kris Kobach,62
-Coffey,Burlington twp,Secretary of State,,R,Kris Kobach,127
-Coffey,Burlington 1,Secretary of State,,R,Kris Kobach,240
-Coffey,Burlington 2,Secretary of State,,R,Kris Kobach,190
-Coffey,Burlington 3,Secretary of State,,R,Kris Kobach,227
-Coffey,Hampden twp,Secretary of State,,R,Kris Kobach,52
-Coffey,Key West twp,Secretary of State,,R,Kris Kobach,71
-Coffey,Leroy twp,Secretary of State,,R,Kris Kobach,184
-Coffey,Liberty twp,Secretary of State,,R,Kris Kobach,175
-Coffey,Lincoln twp,Secretary of State,,R,Kris Kobach,326
-Coffey,Neosho twp,Secretary of State,,R,Kris Kobach,37
-Coffey,Ottumwa twp,Secretary of State,,R,Kris Kobach,241
-Coffey,Pleasant twp,Secretary of State,,R,Kris Kobach,66
-Coffey,Pottawatomie twp,Secretary of State,,R,Kris Kobach,69
-Coffey,Rock Creek twp,Secretary of State,,R,Kris Kobach,221
-Coffey,Spring Creek twp,Secretary of State,,R,Kris Kobach,55
-Coffey,Tar twp,Secretary of State,,R,Kris Kobach,45
-Coffey,Avon twp,Secretary of State,,D,Jean Schodorf,18
-Coffey,Burlington twp,Secretary of State,,D,Jean Schodorf,28
-Coffey,Burlington 1,Secretary of State,,D,Jean Schodorf,81
-Coffey,Burlington 2,Secretary of State,,D,Jean Schodorf,57
-Coffey,Burlington 3,Secretary of State,,D,Jean Schodorf,60
-Coffey,Hampden twp,Secretary of State,,D,Jean Schodorf,20
-Coffey,Key West twp,Secretary of State,,D,Jean Schodorf,26
-Coffey,Leroy twp,Secretary of State,,D,Jean Schodorf,39
-Coffey,Liberty twp,Secretary of State,,D,Jean Schodorf,51
-Coffey,Lincoln twp,Secretary of State,,D,Jean Schodorf,117
-Coffey,Neosho twp,Secretary of State,,D,Jean Schodorf,12
-Coffey,Ottumwa twp,Secretary of State,,D,Jean Schodorf,67
-Coffey,Pleasant twp,Secretary of State,,D,Jean Schodorf,26
-Coffey,Pottawatomie twp,Secretary of State,,D,Jean Schodorf,14
-Coffey,Rock Creek twp,Secretary of State,,D,Jean Schodorf,85
-Coffey,Spring Creek twp,Secretary of State,,D,Jean Schodorf,12
-Coffey,Tar twp,Secretary of State,,D,Jean Schodorf,22
-Coffey,Avon twp,Attorney General,,R,Derek Schmidt,75
-Coffey,Burlington twp,Attorney General,,R,Derek Schmidt,136
-Coffey,Burlington 1,Attorney General,,R,Derek Schmidt,252
-Coffey,Burlington 2,Attorney General,,R,Derek Schmidt,193
-Coffey,Burlington 3,Attorney General,,R,Derek Schmidt,250
-Coffey,Hampden twp,Attorney General,,R,Derek Schmidt,57
-Coffey,Key West twp,Attorney General,,R,Derek Schmidt,72
-Coffey,Leroy twp,Attorney General,,R,Derek Schmidt,198
-Coffey,Liberty twp,Attorney General,,R,Derek Schmidt,190
-Coffey,Lincoln twp,Attorney General,,R,Derek Schmidt,345
-Coffey,Neosho twp,Attorney General,,R,Derek Schmidt,42
-Coffey,Ottumwa twp,Attorney General,,R,Derek Schmidt,252
-Coffey,Pleasant twp,Attorney General,,R,Derek Schmidt,79
-Coffey,Pottawatomie twp,Attorney General,,R,Derek Schmidt,74
-Coffey,Rock Creek twp,Attorney General,,R,Derek Schmidt,242
-Coffey,Spring Creek twp,Attorney General,,R,Derek Schmidt,62
-Coffey,Tar twp,Attorney General,,R,Derek Schmidt,52
-Coffey,Avon twp,Attorney General,,D,AJ Kotich,7
-Coffey,Burlington twp,Attorney General,,D,AJ Kotich,21
-Coffey,Burlington 1,Attorney General,,D,AJ Kotich,70
-Coffey,Burlington 2,Attorney General,,D,AJ Kotich,47
-Coffey,Burlington 3,Attorney General,,D,AJ Kotich,40
-Coffey,Hampden twp,Attorney General,,D,AJ Kotich,15
-Coffey,Key West twp,Attorney General,,D,AJ Kotich,22
-Coffey,Leroy twp,Attorney General,,D,AJ Kotich,26
-Coffey,Liberty twp,Attorney General,,D,AJ Kotich,36
-Coffey,Lincoln twp,Attorney General,,D,AJ Kotich,96
-Coffey,Neosho twp,Attorney General,,D,AJ Kotich,8
-Coffey,Ottumwa twp,Attorney General,,D,AJ Kotich,56
-Coffey,Pleasant twp,Attorney General,,D,AJ Kotich,13
-Coffey,Pottawatomie twp,Attorney General,,D,AJ Kotich,8
-Coffey,Rock Creek twp,Attorney General,,D,AJ Kotich,67
-Coffey,Spring Creek twp,Attorney General,,D,AJ Kotich,5
-Coffey,Tar twp,Attorney General,,D,AJ Kotich,15
-Coffey,Avon twp,State Treasurer,,R,Ron Estes,65
-Coffey,Burlington twp,State Treasurer,,R,Ron Estes,125
-Coffey,Burlington 1,State Treasurer,,R,Ron Estes,244
-Coffey,Burlington 2,State Treasurer,,R,Ron Estes,201
-Coffey,Burlington 3,State Treasurer,,R,Ron Estes,228
-Coffey,Hampden twp,State Treasurer,,R,Ron Estes,56
-Coffey,Key West twp,State Treasurer,,R,Ron Estes,71
-Coffey,Leroy twp,State Treasurer,,R,Ron Estes,173
-Coffey,Liberty twp,State Treasurer,,R,Ron Estes,188
-Coffey,Lincoln twp,State Treasurer,,R,Ron Estes,328
-Coffey,Neosho twp,State Treasurer,,R,Ron Estes,35
-Coffey,Ottumwa twp,State Treasurer,,R,Ron Estes,241
-Coffey,Pleasant twp,State Treasurer,,R,Ron Estes,69
-Coffey,Pottawatomie twp,State Treasurer,,R,Ron Estes,72
-Coffey,Rock Creek twp,State Treasurer,,R,Ron Estes,232
-Coffey,Spring Creek twp,State Treasurer,,R,Ron Estes,58
-Coffey,Tar twp,State Treasurer,,R,Ron Estes,50
-Coffey,Avon twp,State Treasurer,,D,Carmen Alldritt,11
-Coffey,Burlington twp,State Treasurer,,D,Carmen Alldritt,26
-Coffey,Burlington 1,State Treasurer,,D,Carmen Alldritt,72
-Coffey,Burlington 2,State Treasurer,,D,Carmen Alldritt,43
-Coffey,Burlington 3,State Treasurer,,D,Carmen Alldritt,57
-Coffey,Hampden twp,State Treasurer,,D,Carmen Alldritt,15
-Coffey,Key West twp,State Treasurer,,D,Carmen Alldritt,22
-Coffey,Leroy twp,State Treasurer,,D,Carmen Alldritt,48
-Coffey,Liberty twp,State Treasurer,,D,Carmen Alldritt,32
-Coffey,Lincoln twp,State Treasurer,,D,Carmen Alldritt,111
-Coffey,Neosho twp,State Treasurer,,D,Carmen Alldritt,14
-Coffey,Ottumwa twp,State Treasurer,,D,Carmen Alldritt,63
-Coffey,Pleasant twp,State Treasurer,,D,Carmen Alldritt,21
-Coffey,Pottawatomie twp,State Treasurer,,D,Carmen Alldritt,9
-Coffey,Rock Creek twp,State Treasurer,,D,Carmen Alldritt,71
-Coffey,Spring Creek twp,State Treasurer,,D,Carmen Alldritt,6
-Coffey,Tar twp,State Treasurer,,D,Carmen Alldritt,15
-Coffey,Avon twp,Insurance Commissioner,,R,Ken Selzer,57
-Coffey,Burlington twp,Insurance Commissioner,,R,Ken Selzer,114
-Coffey,Burlington 1,Insurance Commissioner,,R,Ken Selzer,212
-Coffey,Burlington 2,Insurance Commissioner,,R,Ken Selzer,173
-Coffey,Burlington 3,Insurance Commissioner,,R,Ken Selzer,211
-Coffey,Hampden twp,Insurance Commissioner,,R,Ken Selzer,49
-Coffey,Key West twp,Insurance Commissioner,,R,Ken Selzer,67
-Coffey,Leroy twp,Insurance Commissioner,,R,Ken Selzer,165
-Coffey,Liberty twp,Insurance Commissioner,,R,Ken Selzer,156
-Coffey,Lincoln twp,Insurance Commissioner,,R,Ken Selzer,291
-Coffey,Neosho twp,Insurance Commissioner,,R,Ken Selzer,33
-Coffey,Ottumwa twp,Insurance Commissioner,,R,Ken Selzer,223
-Coffey,Pleasant twp,Insurance Commissioner,,R,Ken Selzer,60
-Coffey,Pottawatomie twp,Insurance Commissioner,,R,Ken Selzer,64
-Coffey,Rock Creek twp,Insurance Commissioner,,R,Ken Selzer,209
-Coffey,Spring Creek twp,Insurance Commissioner,,R,Ken Selzer,55
-Coffey,Tar twp,Insurance Commissioner,,R,Ken Selzer,47
-Coffey,Avon twp,Insurance Commissioner,,D,Dennis Anderson,19
-Coffey,Burlington twp,Insurance Commissioner,,D,Dennis Anderson,32
-Coffey,Burlington 1,Insurance Commissioner,,D,Dennis Anderson,97
-Coffey,Burlington 2,Insurance Commissioner,,D,Dennis Anderson,63
-Coffey,Burlington 3,Insurance Commissioner,,D,Dennis Anderson,71
-Coffey,Hampden twp,Insurance Commissioner,,D,Dennis Anderson,19
-Coffey,Key West twp,Insurance Commissioner,,D,Dennis Anderson,26
-Coffey,Leroy twp,Insurance Commissioner,,D,Dennis Anderson,52
-Coffey,Liberty twp,Insurance Commissioner,,D,Dennis Anderson,54
-Coffey,Lincoln twp,Insurance Commissioner,,D,Dennis Anderson,147
-Coffey,Neosho twp,Insurance Commissioner,,D,Dennis Anderson,15
-Coffey,Ottumwa twp,Insurance Commissioner,,D,Dennis Anderson,77
-Coffey,Pleasant twp,Insurance Commissioner,,D,Dennis Anderson,27
-Coffey,Pottawatomie twp,Insurance Commissioner,,D,Dennis Anderson,16
-Coffey,Rock Creek twp,Insurance Commissioner,,D,Dennis Anderson,91
-Coffey,Spring Creek twp,Insurance Commissioner,,D,Dennis Anderson,8
-Coffey,Tar twp,Insurance Commissioner,,D,Dennis Anderson,16
-Coffey,Avon twp,State House,76,R,Peggy Mast,32
-Coffey,Burlington twp,State House,76,R,Peggy Mast,85
-Coffey,Burlington 1,State House,76,R,Peggy Mast,165
-Coffey,Burlington 2,State House,76,R,Peggy Mast,133
-Coffey,Burlington 3,State House,76,R,Peggy Mast,158
-Coffey,Hampden twp,State House,76,R,Peggy Mast,45
-Coffey,Key West twp,State House,76,R,Peggy Mast,47
-Coffey,Leroy twp,State House,76,R,Peggy Mast,74
-Coffey,Liberty twp,State House,76,R,Peggy Mast,60
-Coffey,Lincoln twp,State House,76,R,Peggy Mast,213
-Coffey,Neosho twp,State House,76,R,Peggy Mast,21
-Coffey,Ottumwa twp,State House,76,R,Peggy Mast,176
-Coffey,Pleasant twp,State House,76,R,Peggy Mast,40
-Coffey,Pottawatomie twp,State House,76,R,Peggy Mast,49
-Coffey,Rock Creek twp,State House,76,R,Peggy Mast,162
-Coffey,Spring Creek twp,State House,76,R,Peggy Mast,23
-Coffey,Tar twp,State House,76,R,Peggy Mast,43
-Coffey,Avon twp,State House,76,D,Teresa Briggs,12
-Coffey,Burlington twp,State House,76,D,Teresa Briggs,20
-Coffey,Burlington 1,State House,76,D,Teresa Briggs,55
-Coffey,Burlington 2,State House,76,D,Teresa Briggs,35
-Coffey,Burlington 3,State House,76,D,Teresa Briggs,45
-Coffey,Hampden twp,State House,76,D,Teresa Briggs,12
-Coffey,Key West twp,State House,76,D,Teresa Briggs,21
-Coffey,Leroy twp,State House,76,D,Teresa Briggs,16
-Coffey,Liberty twp,State House,76,D,Teresa Briggs,48
-Coffey,Lincoln twp,State House,76,D,Teresa Briggs,165
-Coffey,Neosho twp,State House,76,D,Teresa Briggs,4
-Coffey,Ottumwa twp,State House,76,D,Teresa Briggs,56
-Coffey,Pleasant twp,State House,76,D,Teresa Briggs,24
-Coffey,Pottawatomie twp,State House,76,D,Teresa Briggs,16
-Coffey,Rock Creek twp,State House,76,D,Teresa Briggs,76
-Coffey,Spring Creek twp,State House,76,D,Teresa Briggs,3
-Coffey,Tar twp,State House,76,D,Teresa Briggs,11
-Coffey,Avon twp,State House,76,I,Bill Otto,39
-Coffey,Burlington twp,State House,76,I,Bill Otto,51
-Coffey,Burlington 1,State House,76,I,Bill Otto,105
-Coffey,Burlington 2,State House,76,I,Bill Otto,84
-Coffey,Burlington 3,State House,76,I,Bill Otto,89
-Coffey,Hampden twp,State House,76,I,Bill Otto,17
-Coffey,Key West twp,State House,76,I,Bill Otto,27
-Coffey,Leroy twp,State House,76,I,Bill Otto,136
-Coffey,Liberty twp,State House,76,I,Bill Otto,124
-Coffey,Lincoln twp,State House,76,I,Bill Otto,71
-Coffey,Neosho twp,State House,76,I,Bill Otto,26
-Coffey,Ottumwa twp,State House,76,I,Bill Otto,79
-Coffey,Pleasant twp,State House,76,I,Bill Otto,28
-Coffey,Pottawatomie twp,State House,76,I,Bill Otto,17
-Coffey,Rock Creek twp,State House,76,I,Bill Otto,70
-Coffey,Spring Creek twp,State House,76,I,Bill Otto,42
-Coffey,Tar twp,State House,76,I,Bill Otto,13
+county,precinct,office,district,party,candidate,votes,vtd
+COFFEY,Avon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000010
+COFFEY,Avon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000010
+COFFEY,Avon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000010
+COFFEY,Burlington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000020
+COFFEY,Burlington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000020
+COFFEY,Burlington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000020
+COFFEY,Burlington Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",121,000030
+COFFEY,Burlington Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000030
+COFFEY,Burlington Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",190,000030
+COFFEY,Burlington Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,00004A
+COFFEY,Burlington Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00004A
+COFFEY,Burlington Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",161,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00004B
+COFFEY,Burlington Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",112,00005A
+COFFEY,Burlington Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,00005A
+COFFEY,Burlington Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",157,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005C
+COFFEY,Hampden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000060
+COFFEY,Hampden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+COFFEY,Hampden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000060
+COFFEY,Key West Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000070
+COFFEY,Key West Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000070
+COFFEY,Key West Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000070
+COFFEY,Leroy Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,000080
+COFFEY,Leroy Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000080
+COFFEY,Leroy Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",134,000080
+COFFEY,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000090
+COFFEY,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000090
+COFFEY,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000090
+COFFEY,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",200,000100
+COFFEY,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",33,000100
+COFFEY,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",218,000100
+COFFEY,Neosho Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000110
+COFFEY,Neosho Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000110
+COFFEY,Neosho Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000110
+COFFEY,Ottumwa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",108,000120
+COFFEY,Ottumwa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000120
+COFFEY,Ottumwa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",186,000120
+COFFEY,Pleasant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,000130
+COFFEY,Pleasant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000130
+COFFEY,Pleasant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000130
+COFFEY,Pottawatomie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000140
+COFFEY,Pottawatomie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000140
+COFFEY,Pottawatomie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",62,000140
+COFFEY,Rock Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",138,000150
+COFFEY,Rock Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000150
+COFFEY,Rock Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",157,000150
+COFFEY,Spring Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000160
+COFFEY,Spring Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000160
+COFFEY,Spring Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000160
+COFFEY,Star Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000170
+COFFEY,Star Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000170
+COFFEY,Star Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000170
+COFFEY,Burlington Ward 2 Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+COFFEY,Burlington Township Enclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+COFFEY,Burlington Township Enclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+COFFEY,Burlington Township Enclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+COFFEY,Burlington Township Enclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+COFFEY,Burlington Township Enclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+COFFEY,Burlington Township Enclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+COFFEY,Avon Township,Kansas House of Representatives,76,independent,"Otto, Bill",39,000010
+COFFEY,Avon Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",12,000010
+COFFEY,Avon Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",32,000010
+COFFEY,Burlington Township,Kansas House of Representatives,76,independent,"Otto, Bill",51,000020
+COFFEY,Burlington Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",20,000020
+COFFEY,Burlington Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",85,000020
+COFFEY,Burlington Ward 1,Kansas House of Representatives,76,independent,"Otto, Bill",105,000030
+COFFEY,Burlington Ward 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",55,000030
+COFFEY,Burlington Ward 1,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",165,000030
+COFFEY,Burlington Ward 2,Kansas House of Representatives,76,independent,"Otto, Bill",84,00004A
+COFFEY,Burlington Ward 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",35,00004A
+COFFEY,Burlington Ward 2,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",133,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas House of Representatives,76,independent,"Otto, Bill",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,00004B
+COFFEY,Burlington Ward 3,Kansas House of Representatives,76,independent,"Otto, Bill",89,00005A
+COFFEY,Burlington Ward 3,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",45,00005A
+COFFEY,Burlington Ward 3,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",158,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas House of Representatives,76,independent,"Otto, Bill",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas House of Representatives,76,independent,"Otto, Bill",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,00005C
+COFFEY,Hampden Township,Kansas House of Representatives,76,independent,"Otto, Bill",17,000060
+COFFEY,Hampden Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",12,000060
+COFFEY,Hampden Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",45,000060
+COFFEY,Key West Township,Kansas House of Representatives,76,independent,"Otto, Bill",27,000070
+COFFEY,Key West Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",21,000070
+COFFEY,Key West Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",47,000070
+COFFEY,Leroy Township,Kansas House of Representatives,76,independent,"Otto, Bill",136,000080
+COFFEY,Leroy Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",16,000080
+COFFEY,Leroy Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",74,000080
+COFFEY,Liberty Township,Kansas House of Representatives,76,independent,"Otto, Bill",124,000090
+COFFEY,Liberty Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",48,000090
+COFFEY,Liberty Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",60,000090
+COFFEY,Lincoln Township,Kansas House of Representatives,76,independent,"Otto, Bill",71,000100
+COFFEY,Lincoln Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",165,000100
+COFFEY,Lincoln Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",213,000100
+COFFEY,Neosho Township,Kansas House of Representatives,76,independent,"Otto, Bill",26,000110
+COFFEY,Neosho Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",4,000110
+COFFEY,Neosho Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",21,000110
+COFFEY,Ottumwa Township,Kansas House of Representatives,76,independent,"Otto, Bill",79,000120
+COFFEY,Ottumwa Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",56,000120
+COFFEY,Ottumwa Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",176,000120
+COFFEY,Pleasant Township,Kansas House of Representatives,76,independent,"Otto, Bill",28,000130
+COFFEY,Pleasant Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",24,000130
+COFFEY,Pleasant Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",40,000130
+COFFEY,Pottawatomie Township,Kansas House of Representatives,76,independent,"Otto, Bill",17,000140
+COFFEY,Pottawatomie Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",16,000140
+COFFEY,Pottawatomie Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",49,000140
+COFFEY,Rock Creek Township,Kansas House of Representatives,76,independent,"Otto, Bill",70,000150
+COFFEY,Rock Creek Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",76,000150
+COFFEY,Rock Creek Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",162,000150
+COFFEY,Spring Creek Township,Kansas House of Representatives,76,independent,"Otto, Bill",42,000160
+COFFEY,Spring Creek Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",3,000160
+COFFEY,Spring Creek Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",23,000160
+COFFEY,Star Township,Kansas House of Representatives,76,independent,"Otto, Bill",13,000170
+COFFEY,Star Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",11,000170
+COFFEY,Star Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",43,000170
+COFFEY,Burlington Ward 2 Exclave 2,Kansas House of Representatives,76,independent,"Otto, Bill",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,900010
+COFFEY,Burlington Township Enclave 1,Kansas House of Representatives,76,independent,"Otto, Bill",0,900020
+COFFEY,Burlington Township Enclave 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900020
+COFFEY,Burlington Township Enclave 1,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,900020
+COFFEY,Burlington Township Enclave 2,Kansas House of Representatives,76,independent,"Otto, Bill",0,900030
+COFFEY,Burlington Township Enclave 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900030
+COFFEY,Burlington Township Enclave 2,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,900030
+COFFEY,Avon Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,000010
+COFFEY,Avon Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000010
+COFFEY,Avon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,000010
+COFFEY,Burlington Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000020
+COFFEY,Burlington Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000020
+COFFEY,Burlington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,000020
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",75,000030
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000030
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",233,000030
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",49,00004A
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,00004A
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",56,00005A
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,00005A
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+COFFEY,Hampden Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000060
+COFFEY,Hampden Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000060
+COFFEY,Hampden Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000060
+COFFEY,Key West Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",19,000070
+COFFEY,Key West Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000070
+COFFEY,Key West Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",71,000070
+COFFEY,Leroy Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",43,000080
+COFFEY,Leroy Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000080
+COFFEY,Leroy Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000080
+COFFEY,Liberty Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",48,000090
+COFFEY,Liberty Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000090
+COFFEY,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",168,000090
+COFFEY,Lincoln Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",132,000100
+COFFEY,Lincoln Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000100
+COFFEY,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",293,000100
+COFFEY,Neosho Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000110
+COFFEY,Neosho Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000110
+COFFEY,Neosho Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000110
+COFFEY,Ottumwa Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",76,000120
+COFFEY,Ottumwa Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000120
+COFFEY,Ottumwa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",217,000120
+COFFEY,Pleasant Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",29,000130
+COFFEY,Pleasant Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000130
+COFFEY,Pleasant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000130
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000140
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000140
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",69,000140
+COFFEY,Rock Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",89,000150
+COFFEY,Rock Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000150
+COFFEY,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,000150
+COFFEY,Spring Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",11,000160
+COFFEY,Spring Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000160
+COFFEY,Spring Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000160
+COFFEY,Star Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000170
+COFFEY,Star Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000170
+COFFEY,Star Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000170
+COFFEY,Burlington Ward 2 Exclave 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+COFFEY,Burlington Township Enclave 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+COFFEY,Burlington Township Enclave 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+COFFEY,Burlington Township Enclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+COFFEY,Avon Township,Attorney General,,Democratic,"Kotich, A.J.",7,000010
+COFFEY,Avon Township,Attorney General,,Republican,"Schmidt, Derek",75,000010
+COFFEY,Burlington Township,Attorney General,,Democratic,"Kotich, A.J.",21,000020
+COFFEY,Burlington Township,Attorney General,,Republican,"Schmidt, Derek",136,000020
+COFFEY,Burlington Ward 1,Attorney General,,Democratic,"Kotich, A.J.",70,000030
+COFFEY,Burlington Ward 1,Attorney General,,Republican,"Schmidt, Derek",252,000030
+COFFEY,Burlington Ward 2,Attorney General,,Democratic,"Kotich, A.J.",47,00004A
+COFFEY,Burlington Ward 2,Attorney General,,Republican,"Schmidt, Derek",198,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Attorney General,,Democratic,"Kotich, A.J.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Attorney General,,Republican,"Schmidt, Derek",0,00004B
+COFFEY,Burlington Ward 3,Attorney General,,Democratic,"Kotich, A.J.",40,00005A
+COFFEY,Burlington Ward 3,Attorney General,,Republican,"Schmidt, Derek",250,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Attorney General,,Democratic,"Kotich, A.J.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Attorney General,,Republican,"Schmidt, Derek",0,00005C
+COFFEY,Hampden Township,Attorney General,,Democratic,"Kotich, A.J.",15,000060
+COFFEY,Hampden Township,Attorney General,,Republican,"Schmidt, Derek",57,000060
+COFFEY,Key West Township,Attorney General,,Democratic,"Kotich, A.J.",22,000070
+COFFEY,Key West Township,Attorney General,,Republican,"Schmidt, Derek",72,000070
+COFFEY,Leroy Township,Attorney General,,Democratic,"Kotich, A.J.",26,000080
+COFFEY,Leroy Township,Attorney General,,Republican,"Schmidt, Derek",198,000080
+COFFEY,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",36,000090
+COFFEY,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",190,000090
+COFFEY,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",96,000100
+COFFEY,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",345,000100
+COFFEY,Neosho Township,Attorney General,,Democratic,"Kotich, A.J.",8,000110
+COFFEY,Neosho Township,Attorney General,,Republican,"Schmidt, Derek",42,000110
+COFFEY,Ottumwa Township,Attorney General,,Democratic,"Kotich, A.J.",56,000120
+COFFEY,Ottumwa Township,Attorney General,,Republican,"Schmidt, Derek",252,000120
+COFFEY,Pleasant Township,Attorney General,,Democratic,"Kotich, A.J.",13,000130
+COFFEY,Pleasant Township,Attorney General,,Republican,"Schmidt, Derek",79,000130
+COFFEY,Pottawatomie Township,Attorney General,,Democratic,"Kotich, A.J.",8,000140
+COFFEY,Pottawatomie Township,Attorney General,,Republican,"Schmidt, Derek",74,000140
+COFFEY,Rock Creek Township,Attorney General,,Democratic,"Kotich, A.J.",67,000150
+COFFEY,Rock Creek Township,Attorney General,,Republican,"Schmidt, Derek",242,000150
+COFFEY,Spring Creek Township,Attorney General,,Democratic,"Kotich, A.J.",5,000160
+COFFEY,Spring Creek Township,Attorney General,,Republican,"Schmidt, Derek",62,000160
+COFFEY,Star Township,Attorney General,,Democratic,"Kotich, A.J.",15,000170
+COFFEY,Star Township,Attorney General,,Republican,"Schmidt, Derek",52,000170
+COFFEY,Burlington Ward 2 Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900010
+COFFEY,Burlington Township Enclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+COFFEY,Burlington Township Enclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900020
+COFFEY,Burlington Township Enclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+COFFEY,Burlington Township Enclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900030
+COFFEY,Avon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000010
+COFFEY,Avon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000010
+COFFEY,Burlington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,000020
+COFFEY,Burlington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",114,000020
+COFFEY,Burlington Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,000030
+COFFEY,Burlington Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",212,000030
+COFFEY,Burlington Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,00004A
+COFFEY,Burlington Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",173,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00004B
+COFFEY,Burlington Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,00005A
+COFFEY,Burlington Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",211,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005C
+COFFEY,Hampden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000060
+COFFEY,Hampden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000060
+COFFEY,Key West Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000070
+COFFEY,Key West Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000070
+COFFEY,Leroy Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000080
+COFFEY,Leroy Township,Commissioner of Insurance,,Republican,"Selzer, Ken",165,000080
+COFFEY,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000090
+COFFEY,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",156,000090
+COFFEY,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",147,000100
+COFFEY,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",291,000100
+COFFEY,Neosho Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000110
+COFFEY,Neosho Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000110
+COFFEY,Ottumwa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000120
+COFFEY,Ottumwa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",223,000120
+COFFEY,Pleasant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000130
+COFFEY,Pleasant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",60,000130
+COFFEY,Pottawatomie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000140
+COFFEY,Pottawatomie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",64,000140
+COFFEY,Rock Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,000150
+COFFEY,Rock Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",209,000150
+COFFEY,Spring Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000160
+COFFEY,Spring Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000160
+COFFEY,Star Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000170
+COFFEY,Star Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000170
+COFFEY,Burlington Ward 2 Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+COFFEY,Burlington Township Enclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+COFFEY,Burlington Township Enclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+COFFEY,Burlington Township Enclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+COFFEY,Burlington Township Enclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+COFFEY,Avon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000010
+COFFEY,Avon Township,Secretary of State,,Republican,"Kobach, Kris",62,000010
+COFFEY,Burlington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000020
+COFFEY,Burlington Township,Secretary of State,,Republican,"Kobach, Kris",127,000020
+COFFEY,Burlington Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",81,000030
+COFFEY,Burlington Ward 1,Secretary of State,,Republican,"Kobach, Kris",240,000030
+COFFEY,Burlington Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,00004A
+COFFEY,Burlington Ward 2,Secretary of State,,Republican,"Kobach, Kris",190,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Secretary of State,,Republican,"Kobach, Kris",0,00004B
+COFFEY,Burlington Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,00005A
+COFFEY,Burlington Ward 3,Secretary of State,,Republican,"Kobach, Kris",227,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Secretary of State,,Republican,"Kobach, Kris",0,00005C
+COFFEY,Hampden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000060
+COFFEY,Hampden Township,Secretary of State,,Republican,"Kobach, Kris",52,000060
+COFFEY,Key West Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000070
+COFFEY,Key West Township,Secretary of State,,Republican,"Kobach, Kris",71,000070
+COFFEY,Leroy Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000080
+COFFEY,Leroy Township,Secretary of State,,Republican,"Kobach, Kris",184,000080
+COFFEY,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000090
+COFFEY,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",175,000090
+COFFEY,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",117,000100
+COFFEY,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",326,000100
+COFFEY,Neosho Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000110
+COFFEY,Neosho Township,Secretary of State,,Republican,"Kobach, Kris",37,000110
+COFFEY,Ottumwa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000120
+COFFEY,Ottumwa Township,Secretary of State,,Republican,"Kobach, Kris",241,000120
+COFFEY,Pleasant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000130
+COFFEY,Pleasant Township,Secretary of State,,Republican,"Kobach, Kris",66,000130
+COFFEY,Pottawatomie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000140
+COFFEY,Pottawatomie Township,Secretary of State,,Republican,"Kobach, Kris",69,000140
+COFFEY,Rock Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",85,000150
+COFFEY,Rock Creek Township,Secretary of State,,Republican,"Kobach, Kris",221,000150
+COFFEY,Spring Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000160
+COFFEY,Spring Creek Township,Secretary of State,,Republican,"Kobach, Kris",55,000160
+COFFEY,Star Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000170
+COFFEY,Star Township,Secretary of State,,Republican,"Kobach, Kris",45,000170
+COFFEY,Burlington Ward 2 Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900010
+COFFEY,Burlington Township Enclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+COFFEY,Burlington Township Enclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900020
+COFFEY,Burlington Township Enclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+COFFEY,Burlington Township Enclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900030
+COFFEY,Avon Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000010
+COFFEY,Avon Township,State Treasurer,,Republican,"Estes, Ron",65,000010
+COFFEY,Burlington Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000020
+COFFEY,Burlington Township,State Treasurer,,Republican,"Estes, Ron",125,000020
+COFFEY,Burlington Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",72,000030
+COFFEY,Burlington Ward 1,State Treasurer,,Republican,"Estes, Ron",244,000030
+COFFEY,Burlington Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",43,00004A
+COFFEY,Burlington Ward 2,State Treasurer,,Republican,"Estes, Ron",201,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,State Treasurer,,Democratic,"Alldritt, Carmen",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,State Treasurer,,Republican,"Estes, Ron",0,00004B
+COFFEY,Burlington Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",57,00005A
+COFFEY,Burlington Ward 3,State Treasurer,,Republican,"Estes, Ron",228,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,State Treasurer,,Republican,"Estes, Ron",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,State Treasurer,,Republican,"Estes, Ron",0,00005C
+COFFEY,Hampden Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000060
+COFFEY,Hampden Township,State Treasurer,,Republican,"Estes, Ron",56,000060
+COFFEY,Key West Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000070
+COFFEY,Key West Township,State Treasurer,,Republican,"Estes, Ron",71,000070
+COFFEY,Leroy Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000080
+COFFEY,Leroy Township,State Treasurer,,Republican,"Estes, Ron",173,000080
+COFFEY,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",32,000090
+COFFEY,Liberty Township,State Treasurer,,Republican,"Estes, Ron",188,000090
+COFFEY,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",111,000100
+COFFEY,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",328,000100
+COFFEY,Neosho Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000110
+COFFEY,Neosho Township,State Treasurer,,Republican,"Estes, Ron",35,000110
+COFFEY,Ottumwa Township,State Treasurer,,Democratic,"Alldritt, Carmen",63,000120
+COFFEY,Ottumwa Township,State Treasurer,,Republican,"Estes, Ron",241,000120
+COFFEY,Pleasant Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000130
+COFFEY,Pleasant Township,State Treasurer,,Republican,"Estes, Ron",69,000130
+COFFEY,Pottawatomie Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000140
+COFFEY,Pottawatomie Township,State Treasurer,,Republican,"Estes, Ron",72,000140
+COFFEY,Rock Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",71,000150
+COFFEY,Rock Creek Township,State Treasurer,,Republican,"Estes, Ron",232,000150
+COFFEY,Spring Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000160
+COFFEY,Spring Creek Township,State Treasurer,,Republican,"Estes, Ron",58,000160
+COFFEY,Star Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000170
+COFFEY,Star Township,State Treasurer,,Republican,"Estes, Ron",50,000170
+COFFEY,Burlington Ward 2 Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900010
+COFFEY,Burlington Township Enclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+COFFEY,Burlington Township Enclave 1,State Treasurer,,Republican,"Estes, Ron",0,900020
+COFFEY,Burlington Township Enclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+COFFEY,Burlington Township Enclave 2,State Treasurer,,Republican,"Estes, Ron",0,900030
+COFFEY,Avon Township,United States Senate,,independent,"Orman, Greg",23,000010
+COFFEY,Avon Township,United States Senate,,Libertarian,"Batson, Randall",3,000010
+COFFEY,Avon Township,United States Senate,,Republican,"Roberts, Pat",57,000010
+COFFEY,Burlington Township,United States Senate,,independent,"Orman, Greg",32,000020
+COFFEY,Burlington Township,United States Senate,,Libertarian,"Batson, Randall",3,000020
+COFFEY,Burlington Township,United States Senate,,Republican,"Roberts, Pat",119,000020
+COFFEY,Burlington Ward 1,United States Senate,,independent,"Orman, Greg",108,000030
+COFFEY,Burlington Ward 1,United States Senate,,Libertarian,"Batson, Randall",8,000030
+COFFEY,Burlington Ward 1,United States Senate,,Republican,"Roberts, Pat",205,000030
+COFFEY,Burlington Ward 2,United States Senate,,independent,"Orman, Greg",66,00004A
+COFFEY,Burlington Ward 2,United States Senate,,Libertarian,"Batson, Randall",15,00004A
+COFFEY,Burlington Ward 2,United States Senate,,Republican,"Roberts, Pat",168,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,United States Senate,,independent,"Orman, Greg",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States Senate,,Libertarian,"Batson, Randall",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States Senate,,Republican,"Roberts, Pat",0,00004B
+COFFEY,Burlington Ward 3,United States Senate,,independent,"Orman, Greg",79,00005A
+COFFEY,Burlington Ward 3,United States Senate,,Libertarian,"Batson, Randall",21,00005A
+COFFEY,Burlington Ward 3,United States Senate,,Republican,"Roberts, Pat",189,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States Senate,,independent,"Orman, Greg",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States Senate,,Republican,"Roberts, Pat",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States Senate,,independent,"Orman, Greg",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States Senate,,Libertarian,"Batson, Randall",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States Senate,,Republican,"Roberts, Pat",0,00005C
+COFFEY,Hampden Township,United States Senate,,independent,"Orman, Greg",25,000060
+COFFEY,Hampden Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+COFFEY,Hampden Township,United States Senate,,Republican,"Roberts, Pat",47,000060
+COFFEY,Key West Township,United States Senate,,independent,"Orman, Greg",28,000070
+COFFEY,Key West Township,United States Senate,,Libertarian,"Batson, Randall",7,000070
+COFFEY,Key West Township,United States Senate,,Republican,"Roberts, Pat",63,000070
+COFFEY,Leroy Township,United States Senate,,independent,"Orman, Greg",64,000080
+COFFEY,Leroy Township,United States Senate,,Libertarian,"Batson, Randall",14,000080
+COFFEY,Leroy Township,United States Senate,,Republican,"Roberts, Pat",148,000080
+COFFEY,Liberty Township,United States Senate,,independent,"Orman, Greg",67,000090
+COFFEY,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",15,000090
+COFFEY,Liberty Township,United States Senate,,Republican,"Roberts, Pat",145,000090
+COFFEY,Lincoln Township,United States Senate,,independent,"Orman, Greg",149,000100
+COFFEY,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",27,000100
+COFFEY,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",272,000100
+COFFEY,Neosho Township,United States Senate,,independent,"Orman, Greg",16,000110
+COFFEY,Neosho Township,United States Senate,,Libertarian,"Batson, Randall",1,000110
+COFFEY,Neosho Township,United States Senate,,Republican,"Roberts, Pat",34,000110
+COFFEY,Ottumwa Township,United States Senate,,independent,"Orman, Greg",98,000120
+COFFEY,Ottumwa Township,United States Senate,,Libertarian,"Batson, Randall",19,000120
+COFFEY,Ottumwa Township,United States Senate,,Republican,"Roberts, Pat",195,000120
+COFFEY,Pleasant Township,United States Senate,,independent,"Orman, Greg",36,000130
+COFFEY,Pleasant Township,United States Senate,,Libertarian,"Batson, Randall",5,000130
+COFFEY,Pleasant Township,United States Senate,,Republican,"Roberts, Pat",51,000130
+COFFEY,Pottawatomie Township,United States Senate,,independent,"Orman, Greg",12,000140
+COFFEY,Pottawatomie Township,United States Senate,,Libertarian,"Batson, Randall",5,000140
+COFFEY,Pottawatomie Township,United States Senate,,Republican,"Roberts, Pat",66,000140
+COFFEY,Rock Creek Township,United States Senate,,independent,"Orman, Greg",113,000150
+COFFEY,Rock Creek Township,United States Senate,,Libertarian,"Batson, Randall",18,000150
+COFFEY,Rock Creek Township,United States Senate,,Republican,"Roberts, Pat",177,000150
+COFFEY,Spring Creek Township,United States Senate,,independent,"Orman, Greg",14,000160
+COFFEY,Spring Creek Township,United States Senate,,Libertarian,"Batson, Randall",4,000160
+COFFEY,Spring Creek Township,United States Senate,,Republican,"Roberts, Pat",46,000160
+COFFEY,Star Township,United States Senate,,independent,"Orman, Greg",21,000170
+COFFEY,Star Township,United States Senate,,Libertarian,"Batson, Randall",3,000170
+COFFEY,Star Township,United States Senate,,Republican,"Roberts, Pat",43,000170
+COFFEY,Burlington Ward 2 Exclave 2,United States Senate,,independent,"Orman, Greg",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900010
+COFFEY,Burlington Township Enclave 1,United States Senate,,independent,"Orman, Greg",0,900020
+COFFEY,Burlington Township Enclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900020
+COFFEY,Burlington Township Enclave 1,United States Senate,,Republican,"Roberts, Pat",0,900020
+COFFEY,Burlington Township Enclave 2,United States Senate,,independent,"Orman, Greg",0,900030
+COFFEY,Burlington Township Enclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900030
+COFFEY,Burlington Township Enclave 2,United States Senate,,Republican,"Roberts, Pat",0,900030

--- a/2014/20141104__ks__general__comanche__precinct.csv
+++ b/2014/20141104__ks__general__comanche__precinct.csv
@@ -1,87 +1,87 @@
-county,precinct,office,district,party,candidate,votes
-Comanche,Avilla,U.S. Senate,,R,Pat Roberts,25
-Comanche,Coldwater,U.S. Senate,,R,Pat Roberts,242
-Comanche,Powell,U.S. Senate,,R,Pat Roberts,28
-Comanche,Protection 115,U.S. Senate,,R,Pat Roberts,112
-Comanche,Protection 116,U.S. Senate,,R,Pat Roberts,89
-Comanche,Avilla,U.S. Senate,,I,Greg Orman,5
-Comanche,Coldwater,U.S. Senate,,I,Greg Orman,104
-Comanche,Powell,U.S. Senate,,I,Greg Orman,9
-Comanche,Protection 115,U.S. Senate,,I,Greg Orman,43
-Comanche,Protection 116,U.S. Senate,,I,Greg Orman,2
-Comanche,Avilla,U.S. Senate,,L,Randall Batson,4
-Comanche,Coldwater,U.S. Senate,,L,Randall Batson,23
-Comanche,Powell,U.S. Senate,,L,Randall Batson,0
-Comanche,Protection 115,U.S. Senate,,L,Randall Batson,7
-Comanche,Protection 116,U.S. Senate,,L,Randall Batson,3
-Comanche,Avilla,U.S. House,4,R,Mike Pompeo,33
-Comanche,Coldwater,U.S. House,4,R,Mike Pompeo,285
-Comanche,Powell,U.S. House,4,R,Mike Pompeo,30
-Comanche,Protection 115,U.S. House,4,R,Mike Pompeo,182
-Comanche,Protection 116,U.S. House,4,R,Mike Pompeo,32
-Comanche,Avilla,U.S. House,4,D,Perry Schuckman,1
-Comanche,Coldwater,U.S. House,4,D,Perry Schuckman,77
-Comanche,Powell,U.S. House,4,D,Perry Schuckman,5
-Comanche,Protection 115,U.S. House,4,D,Perry Schuckman,35
-Comanche,Protection 116,U.S. House,4,D,Perry Schuckman,2
-Comanche,Avilla,Governor,,R,Sam Brownback,26
-Comanche,Coldwater,Governor,,R,Sam Brownback,224
-Comanche,Powell,Governor,,R,Sam Brownback,28
-Comanche,Protection 115,Governor,,R,Sam Brownback,108
-Comanche,Protection 116,Governor,,R,Sam Brownback,76
-Comanche,Avilla,Governor,,D,Paul Davis,5
-Comanche,Coldwater,Governor,,D,Paul Davis,124
-Comanche,Powell,Governor,,D,Paul Davis,8
-Comanche,Protection 115,Governor,,D,Paul Davis,46
-Comanche,Protection 116,Governor,,D,Paul Davis,4
-Comanche,Avilla,Governor,,L,Keen Umbehr,2
-Comanche,Coldwater,Governor,,L,Keen Umbehr,4
-Comanche,Powell,Governor,,L,Keen Umbehr,1
-Comanche,Protection 115,Governor,,L,Keen Umbehr,10
-Comanche,Protection 116,Governor,,L,Keen Umbehr,14
-Comanche,Avilla,Secretary of State,,R,Kris Kobach,28
-Comanche,Coldwater,Secretary of State,,R,Kris Kobach,249
-Comanche,Powell,Secretary of State,,R,Kris Kobach,28
-Comanche,Protection 115,Secretary of State,,R,Kris Kobach,120
-Comanche,Protection 116,Secretary of State,,R,Kris Kobach,94
-Comanche,Avilla,Secretary of State,,D,Jean Schodorf,5
-Comanche,Coldwater,Secretary of State,,D,Jean Schodorf,112
-Comanche,Powell,Secretary of State,,D,Jean Schodorf,7
-Comanche,Protection 115,Secretary of State,,D,Jean Schodorf,29
-Comanche,Protection 116,Secretary of State,,D,Jean Schodorf,10
-Comanche,Avilla,Attorney General,,R,Derek Schmidt,27
-Comanche,Coldwater,Attorney General,,R,Derek Schmidt,273
-Comanche,Powell,Attorney General,,R,Derek Schmidt,27
-Comanche,Protection 115,Attorney General,,R,Derek Schmidt,180
-Comanche,Protection 116,Attorney General,,R,Derek Schmidt,46
-Comanche,Avilla,Attorney General,,D,A J Kotich,5
-Comanche,Coldwater,Attorney General,,D,A J Kotich,79
-Comanche,Powell,Attorney General,,D,A J Kotich,5
-Comanche,Protection 115,Attorney General,,D,A J Kotich,26
-Comanche,Protection 116,Attorney General,,D,A J Kotich,4
-Comanche,Avilla,State Treasurer,,R,Ron Estes,31
-Comanche,Coldwater,State Treasurer,,R,Ron Estes,261
-Comanche,Powell,State Treasurer,,R,Ron Estes,29
-Comanche,Protection 115,State Treasurer,,R,Ron Estes,188
-Comanche,Protection 116,State Treasurer,,R,Ron Estes,45
-Comanche,Avilla,State Treasurer,,D,Carmen Alldritt,2
-Comanche,Coldwater,State Treasurer,,D,Carmen Alldritt,90
-Comanche,Powell,State Treasurer,,D,Carmen Alldritt,4
-Comanche,Protection 115,State Treasurer,,D,Carmen Alldritt,12
-Comanche,Protection 116,State Treasurer,,D,Carmen Alldritt,16
-Comanche,Avilla,Insurance Commissioner,,R,Ken Selzer,28
-Comanche,Coldwater,Insurance Commissioner,,R,Ken Selzer,268
-Comanche,Powell,Insurance Commissioner,,R,Ken Selzer,26
-Comanche,Protection 115,Insurance Commissioner,,R,Ken Selzer,176
-Comanche,Protection 116,Insurance Commissioner,,R,Ken Selzer,33
-Comanche,Avilla,Insurance Commissioner,,D,Dennis Anderson,6
-Comanche,Coldwater,Insurance Commissioner,,D,Dennis Anderson,89
-Comanche,Powell,Insurance Commissioner,,D,Dennis Anderson,6
-Comanche,Protection 115,Insurance Commissioner,,D,Dennis Anderson,33
-Comanche,Protection 116,Insurance Commissioner,,D,Dennis Anderson,7
-Comanche,Avilla,State House,116,R,Kyle Hoffman,27
-Comanche,Coldwater,State House,116,R,Kyle Hoffman,274
-Comanche,Powell,State House,116,R,Kyle Hoffman,30
-Comanche,Protection 115,State House,115,R,Ronald Ryckman,167
-Comanche,Protection 116,State House,116,R,Kyle Hoffman,43
-Comanche,Protection 115,State House,115,D,Mark Low,38
+county,precinct,office,district,party,candidate,votes,vtd
+COMANCHE,Avilla Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000010
+COMANCHE,Avilla Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+COMANCHE,Avilla Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000010
+COMANCHE,Coldwater Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000020
+COMANCHE,Coldwater Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000020
+COMANCHE,Coldwater Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",224,000020
+COMANCHE,Powell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+COMANCHE,Powell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+COMANCHE,Powell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000030
+COMANCHE,Protection Township H115,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,120020
+COMANCHE,Protection Township H115,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,120020
+COMANCHE,Protection Township H115,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,120020
+COMANCHE,Protection Township H116,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,120030
+COMANCHE,Protection Township H116,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,120030
+COMANCHE,Protection Township H116,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,120030
+COMANCHE,Avilla Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",27,000010
+COMANCHE,Coldwater Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",274,000020
+COMANCHE,Powell Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",30,000030
+COMANCHE,Protection Township H115,Kansas House of Representatives,115,Democratic,"Low, Mark",38,120020
+COMANCHE,Protection Township H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",167,120020
+COMANCHE,Protection Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",43,120030
+COMANCHE,Avilla Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,000010
+COMANCHE,Avilla Township,United States House of Representatives,4,Republican,"Pompeo, Mike",33,000010
+COMANCHE,Coldwater Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",77,000020
+COMANCHE,Coldwater Township,United States House of Representatives,4,Republican,"Pompeo, Mike",285,000020
+COMANCHE,Powell Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000030
+COMANCHE,Powell Township,United States House of Representatives,4,Republican,"Pompeo, Mike",30,000030
+COMANCHE,Protection Township H115,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",35,120020
+COMANCHE,Protection Township H115,United States House of Representatives,4,Republican,"Pompeo, Mike",182,120020
+COMANCHE,Protection Township H116,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,120030
+COMANCHE,Protection Township H116,United States House of Representatives,4,Republican,"Pompeo, Mike",32,120030
+COMANCHE,Avilla Township,Attorney General,,Democratic,"Kotich, A.J.",5,000010
+COMANCHE,Avilla Township,Attorney General,,Republican,"Schmidt, Derek",27,000010
+COMANCHE,Coldwater Township,Attorney General,,Democratic,"Kotich, A.J.",79,000020
+COMANCHE,Coldwater Township,Attorney General,,Republican,"Schmidt, Derek",273,000020
+COMANCHE,Powell Township,Attorney General,,Democratic,"Kotich, A.J.",5,000030
+COMANCHE,Powell Township,Attorney General,,Republican,"Schmidt, Derek",27,000030
+COMANCHE,Protection Township H115,Attorney General,,Democratic,"Kotich, A.J.",25,120020
+COMANCHE,Protection Township H115,Attorney General,,Republican,"Schmidt, Derek",180,120020
+COMANCHE,Protection Township H116,Attorney General,,Democratic,"Kotich, A.J.",5,120030
+COMANCHE,Protection Township H116,Attorney General,,Republican,"Schmidt, Derek",46,120030
+COMANCHE,Avilla Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000010
+COMANCHE,Avilla Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000010
+COMANCHE,Coldwater Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",89,000020
+COMANCHE,Coldwater Township,Commissioner of Insurance,,Republican,"Selzer, Ken",268,000020
+COMANCHE,Powell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000030
+COMANCHE,Powell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000030
+COMANCHE,Protection Township H115,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,120020
+COMANCHE,Protection Township H115,Commissioner of Insurance,,Republican,"Selzer, Ken",176,120020
+COMANCHE,Protection Township H116,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,120030
+COMANCHE,Protection Township H116,Commissioner of Insurance,,Republican,"Selzer, Ken",33,120030
+COMANCHE,Avilla Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000010
+COMANCHE,Avilla Township,Secretary of State,,Republican,"Kobach, Kris",28,000010
+COMANCHE,Coldwater Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",112,000020
+COMANCHE,Coldwater Township,Secretary of State,,Republican,"Kobach, Kris",249,000020
+COMANCHE,Powell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000030
+COMANCHE,Powell Township,Secretary of State,,Republican,"Kobach, Kris",28,000030
+COMANCHE,Protection Township H115,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,120020
+COMANCHE,Protection Township H115,Secretary of State,,Republican,"Kobach, Kris",120,120020
+COMANCHE,Protection Township H116,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,120030
+COMANCHE,Protection Township H116,Secretary of State,,Republican,"Kobach, Kris",94,120030
+COMANCHE,Avilla Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+COMANCHE,Avilla Township,State Treasurer,,Republican,"Estes, Ron",31,000010
+COMANCHE,Coldwater Township,State Treasurer,,Democratic,"Alldritt, Carmen",90,000020
+COMANCHE,Coldwater Township,State Treasurer,,Republican,"Estes, Ron",261,000020
+COMANCHE,Powell Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+COMANCHE,Powell Township,State Treasurer,,Republican,"Estes, Ron",29,000030
+COMANCHE,Protection Township H115,State Treasurer,,Democratic,"Alldritt, Carmen",12,120020
+COMANCHE,Protection Township H115,State Treasurer,,Republican,"Estes, Ron",188,120020
+COMANCHE,Protection Township H116,State Treasurer,,Democratic,"Alldritt, Carmen",16,120030
+COMANCHE,Protection Township H116,State Treasurer,,Republican,"Estes, Ron",45,120030
+COMANCHE,Avilla Township,United States Senate,,independent,"Orman, Greg",5,000010
+COMANCHE,Avilla Township,United States Senate,,Libertarian,"Batson, Randall",4,000010
+COMANCHE,Avilla Township,United States Senate,,Republican,"Roberts, Pat",25,000010
+COMANCHE,Coldwater Township,United States Senate,,independent,"Orman, Greg",104,000020
+COMANCHE,Coldwater Township,United States Senate,,Libertarian,"Batson, Randall",23,000020
+COMANCHE,Coldwater Township,United States Senate,,Republican,"Roberts, Pat",242,000020
+COMANCHE,Powell Township,United States Senate,,independent,"Orman, Greg",9,000030
+COMANCHE,Powell Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+COMANCHE,Powell Township,United States Senate,,Republican,"Roberts, Pat",28,000030
+COMANCHE,Protection Township H115,United States Senate,,independent,"Orman, Greg",43,120020
+COMANCHE,Protection Township H115,United States Senate,,Libertarian,"Batson, Randall",7,120020
+COMANCHE,Protection Township H115,United States Senate,,Republican,"Roberts, Pat",112,120020
+COMANCHE,Protection Township H116,United States Senate,,independent,"Orman, Greg",2,120030
+COMANCHE,Protection Township H116,United States Senate,,Libertarian,"Batson, Randall",3,120030
+COMANCHE,Protection Township H116,United States Senate,,Republican,"Roberts, Pat",89,120030

--- a/2014/20141104__ks__general__cowley__precinct.csv
+++ b/2014/20141104__ks__general__cowley__precinct.csv
@@ -1,1008 +1,1198 @@
-county,precinct,office,district,party,candidate,votes
-Cowley,AC1A,Attorney General,,D,A.J. Kotich,55
-Cowley,AC1B,Attorney General,,D,A.J. Kotich,31
-Cowley,AC1C,Attorney General,,D,A.J. Kotich,60
-Cowley,AC1D,Attorney General,,D,A.J. Kotich,63
-Cowley,AC2A,Attorney General,,D,A.J. Kotich,78
-Cowley,AC2B,Attorney General,,D,A.J. Kotich,22
-Cowley,AC2B-A,Attorney General,,D,A.J. Kotich,23
-Cowley,AC2C,Attorney General,,D,A.J. Kotich,11
-Cowley,AC2D,Attorney General,,D,A.J. Kotich,20
-Cowley,AC3A,Attorney General,,D,A.J. Kotich,11
-Cowley,AC3B,Attorney General,,D,A.J. Kotich,20
-Cowley,AC3C,Attorney General,,D,A.J. Kotich,26
-Cowley,AC4A,Attorney General,,D,A.J. Kotich,82
-Cowley,AC4B,Attorney General,,D,A.J. Kotich,170
-Cowley,AC4C,Attorney General,,D,A.J. Kotich,71
-Cowley,AC4D,Attorney General,,D,A.J. Kotich,131
-Cowley,AC1A,Attorney General,,R,Derek Schmidt,86
-Cowley,AC1B,Attorney General,,R,Derek Schmidt,87
-Cowley,AC1C,Attorney General,,R,Derek Schmidt,138
-Cowley,AC1D,Attorney General,,R,Derek Schmidt,123
-Cowley,AC2A,Attorney General,,R,Derek Schmidt,192
-Cowley,AC2B,Attorney General,,R,Derek Schmidt,60
-Cowley,AC2B-A,Attorney General,,R,Derek Schmidt,48
-Cowley,AC2C,Attorney General,,R,Derek Schmidt,18
-Cowley,AC2D,Attorney General,,R,Derek Schmidt,17
-Cowley,AC3A,Attorney General,,R,Derek Schmidt,34
-Cowley,AC3B,Attorney General,,R,Derek Schmidt,45
-Cowley,AC3C,Attorney General,,R,Derek Schmidt,37
-Cowley,AC4A,Attorney General,,R,Derek Schmidt,122
-Cowley,AC4B,Attorney General,,R,Derek Schmidt,284
-Cowley,AC4C,Attorney General,,R,Derek Schmidt,112
-Cowley,AC4D,Attorney General,,R,Derek Schmidt,236
-Cowley,AC1A,Governor,,L,Keen A. Umbehr,9
-Cowley,AC1B,Governor,,L,Keen A. Umbehr,9
-Cowley,AC1C,Governor,,L,Keen A. Umbehr,10
-Cowley,AC1D,Governor,,L,Keen A. Umbehr,9
-Cowley,AC2A,Governor,,L,Keen A. Umbehr,13
-Cowley,AC2B,Governor,,L,Keen A. Umbehr,4
-Cowley,AC2B-A,Governor,,L,Keen A. Umbehr,1
-Cowley,AC2C,Governor,,L,Keen A. Umbehr,4
-Cowley,AC2D,Governor,,L,Keen A. Umbehr,4
-Cowley,AC3A,Governor,,L,Keen A. Umbehr,2
-Cowley,AC3B,Governor,,L,Keen A. Umbehr,2
-Cowley,AC3C,Governor,,L,Keen A. Umbehr,3
-Cowley,AC4A,Governor,,L,Keen A. Umbehr,7
-Cowley,AC4B,Governor,,L,Keen A. Umbehr,21
-Cowley,AC4C,Governor,,L,Keen A. Umbehr,8
-Cowley,AC4D,Governor,,L,Keen A. Umbehr,31
-Cowley,AC1A,Governor,,D,Paul Davis,79
-Cowley,AC1B,Governor,,D,Paul Davis,63
-Cowley,AC1C,Governor,,D,Paul Davis,101
-Cowley,AC1D,Governor,,D,Paul Davis,115
-Cowley,AC2A,Governor,,D,Paul Davis,132
-Cowley,AC2B,Governor,,D,Paul Davis,40
-Cowley,AC2B-A,Governor,,D,Paul Davis,35
-Cowley,AC2C,Governor,,D,Paul Davis,13
-Cowley,AC2D,Governor,,D,Paul Davis,18
-Cowley,AC3A,Governor,,D,Paul Davis,24
-Cowley,AC3B,Governor,,D,Paul Davis,35
-Cowley,AC3C,Governor,,D,Paul Davis,29
-Cowley,AC4A,Governor,,D,Paul Davis,119
-Cowley,AC4B,Governor,,D,Paul Davis,241
-Cowley,AC4C,Governor,,D,Paul Davis,106
-Cowley,AC4D,Governor,,D,Paul Davis,189
-Cowley,AC1A,Governor,,R,Sam Brownback,56
-Cowley,AC1B,Governor,,R,Sam Brownback,52
-Cowley,AC1C,Governor,,R,Sam Brownback,89
-Cowley,AC1D,Governor,,R,Sam Brownback,68
-Cowley,AC2A,Governor,,R,Sam Brownback,132
-Cowley,AC2B,Governor,,R,Sam Brownback,41
-Cowley,AC2B-A,Governor,,R,Sam Brownback,35
-Cowley,AC2C,Governor,,R,Sam Brownback,12
-Cowley,AC2D,Governor,,R,Sam Brownback,16
-Cowley,AC3A,Governor,,R,Sam Brownback,21
-Cowley,AC3B,Governor,,R,Sam Brownback,29
-Cowley,AC3C,Governor,,R,Sam Brownback,31
-Cowley,AC4A,Governor,,R,Sam Brownback,81
-Cowley,AC4B,Governor,,R,Sam Brownback,199
-Cowley,AC4C,Governor,,R,Sam Brownback,71
-Cowley,AC4D,Governor,,R,Sam Brownback,157
-Cowley,AC1A,Insurance Commissioner,,D,Dennis Anderson,63
-Cowley,AC1B,Insurance Commissioner,,D,Dennis Anderson,45
-Cowley,AC1C,Insurance Commissioner,,D,Dennis Anderson,77
-Cowley,AC1D,Insurance Commissioner,,D,Dennis Anderson,80
-Cowley,AC2A,Insurance Commissioner,,D,Dennis Anderson,88
-Cowley,AC2B,Insurance Commissioner,,D,Dennis Anderson,26
-Cowley,AC2B-A,Insurance Commissioner,,D,Dennis Anderson,27
-Cowley,AC2C,Insurance Commissioner,,D,Dennis Anderson,14
-Cowley,AC2D,Insurance Commissioner,,D,Dennis Anderson,19
-Cowley,AC3A,Insurance Commissioner,,D,Dennis Anderson,17
-Cowley,AC3B,Insurance Commissioner,,D,Dennis Anderson,31
-Cowley,AC3C,Insurance Commissioner,,D,Dennis Anderson,24
-Cowley,AC4A,Insurance Commissioner,,D,Dennis Anderson,101
-Cowley,AC4B,Insurance Commissioner,,D,Dennis Anderson,197
-Cowley,AC4C,Insurance Commissioner,,D,Dennis Anderson,82
-Cowley,AC4D,Insurance Commissioner,,D,Dennis Anderson,147
-Cowley,AC1A,Insurance Commissioner,,R,Ken Selzer,74
-Cowley,AC1B,Insurance Commissioner,,R,Ken Selzer,74
-Cowley,AC1C,Insurance Commissioner,,R,Ken Selzer,119
-Cowley,AC1D,Insurance Commissioner,,R,Ken Selzer,106
-Cowley,AC2A,Insurance Commissioner,,R,Ken Selzer,182
-Cowley,AC2B,Insurance Commissioner,,R,Ken Selzer,58
-Cowley,AC2B-A,Insurance Commissioner,,R,Ken Selzer,42
-Cowley,AC2C,Insurance Commissioner,,R,Ken Selzer,15
-Cowley,AC2D,Insurance Commissioner,,R,Ken Selzer,18
-Cowley,AC3A,Insurance Commissioner,,R,Ken Selzer,29
-Cowley,AC3B,Insurance Commissioner,,R,Ken Selzer,33
-Cowley,AC3C,Insurance Commissioner,,R,Ken Selzer,39
-Cowley,AC4A,Insurance Commissioner,,R,Ken Selzer,102
-Cowley,AC4B,Insurance Commissioner,,R,Ken Selzer,250
-Cowley,AC4C,Insurance Commissioner,,R,Ken Selzer,95
-Cowley,AC4D,Insurance Commissioner,,R,Ken Selzer,218
-Cowley,AC1A,Secretary of State,,D,Jean Kurtis Schodorf,68
-Cowley,AC1B,Secretary of State,,D,Jean Kurtis Schodorf,46
-Cowley,AC1C,Secretary of State,,D,Jean Kurtis Schodorf,87
-Cowley,AC1D,Secretary of State,,D,Jean Kurtis Schodorf,90
-Cowley,AC2A,Secretary of State,,D,Jean Kurtis Schodorf,121
-Cowley,AC2B,Secretary of State,,D,Jean Kurtis Schodorf,33
-Cowley,AC2B-A,Secretary of State,,D,Jean Kurtis Schodorf,27
-Cowley,AC2C,Secretary of State,,D,Jean Kurtis Schodorf,16
-Cowley,AC2D,Secretary of State,,D,Jean Kurtis Schodorf,20
-Cowley,AC3A,Secretary of State,,D,Jean Kurtis Schodorf,18
-Cowley,AC3B,Secretary of State,,D,Jean Kurtis Schodorf,33
-Cowley,AC3C,Secretary of State,,D,Jean Kurtis Schodorf,23
-Cowley,AC4A,Secretary of State,,D,Jean Kurtis Schodorf,104
-Cowley,AC4B,Secretary of State,,D,Jean Kurtis Schodorf,220
-Cowley,AC4C,Secretary of State,,D,Jean Kurtis Schodorf,86
-Cowley,AC4D,Secretary of State,,D,Jean Kurtis Schodorf,175
-Cowley,AC1A,Secretary of State,,R,Kris Kobach,75
-Cowley,AC1B,Secretary of State,,R,Kris Kobach,77
-Cowley,AC1C,Secretary of State,,R,Kris Kobach,113
-Cowley,AC1D,Secretary of State,,R,Kris Kobach,100
-Cowley,AC2A,Secretary of State,,R,Kris Kobach,153
-Cowley,AC2B,Secretary of State,,R,Kris Kobach,52
-Cowley,AC2B-A,Secretary of State,,R,Kris Kobach,44
-Cowley,AC2C,Secretary of State,,R,Kris Kobach,12
-Cowley,AC2D,Secretary of State,,R,Kris Kobach,16
-Cowley,AC3A,Secretary of State,,R,Kris Kobach,29
-Cowley,AC3B,Secretary of State,,R,Kris Kobach,33
-Cowley,AC3C,Secretary of State,,R,Kris Kobach,40
-Cowley,AC4A,Secretary of State,,R,Kris Kobach,100
-Cowley,AC4B,Secretary of State,,R,Kris Kobach,240
-Cowley,AC4C,Secretary of State,,R,Kris Kobach,95
-Cowley,AC4D,Secretary of State,,R,Kris Kobach,194
-Cowley,AC1A,State House,,R,Kasha Kelley,95
-Cowley,AC1B,State House,,R,Kasha Kelley,92
-Cowley,AC1C,State House,,R,Kasha Kelley,151
-Cowley,AC1D,State House,,R,Kasha Kelley,128
-Cowley,AC2A,State House,,R,Kasha Kelley,203
-Cowley,AC2B,State House,,R,Kasha Kelley,65
-Cowley,AC2B-A,State House,,R,Kasha Kelley,49
-Cowley,AC2C,State House,,R,Kasha Kelley,24
-Cowley,AC2D,State House,,R,Kasha Kelley,27
-Cowley,AC3A,State House,,R,Kasha Kelley,38
-Cowley,AC3B,State House,,R,Kasha Kelley,49
-Cowley,AC3C,State House,,R,Kasha Kelley,46
-Cowley,AC4A,State House,,R,Kasha Kelley,154
-Cowley,AC4B,State House,,R,Kasha Kelley,341
-Cowley,AC4C,State House,,R,Kasha Kelley,125
-Cowley,AC4D,State House,,R,Kasha Kelley,278
-Cowley,AC1A,State Treasurer,,D,Carmen Alldritt,55
-Cowley,AC1B,State Treasurer,,D,Carmen Alldritt,37
-Cowley,AC1C,State Treasurer,,D,Carmen Alldritt,59
-Cowley,AC1D,State Treasurer,,D,Carmen Alldritt,64
-Cowley,AC2A,State Treasurer,,D,Carmen Alldritt,74
-Cowley,AC2B,State Treasurer,,D,Carmen Alldritt,26
-Cowley,AC2B-A,State Treasurer,,D,Carmen Alldritt,26
-Cowley,AC2C,State Treasurer,,D,Carmen Alldritt,9
-Cowley,AC2D,State Treasurer,,D,Carmen Alldritt,16
-Cowley,AC3A,State Treasurer,,D,Carmen Alldritt,14
-Cowley,AC3B,State Treasurer,,D,Carmen Alldritt,18
-Cowley,AC3C,State Treasurer,,D,Carmen Alldritt,22
-Cowley,AC4A,State Treasurer,,D,Carmen Alldritt,89
-Cowley,AC4B,State Treasurer,,D,Carmen Alldritt,158
-Cowley,AC4C,State Treasurer,,D,Carmen Alldritt,67
-Cowley,AC4D,State Treasurer,,D,Carmen Alldritt,128
-Cowley,AC1A,State Treasurer,,R,Ron Estes,83
-Cowley,AC1B,State Treasurer,,R,Ron Estes,83
-Cowley,AC1C,State Treasurer,,R,Ron Estes,139
-Cowley,AC1D,State Treasurer,,R,Ron Estes,124
-Cowley,AC2A,State Treasurer,,R,Ron Estes,197
-Cowley,AC2B,State Treasurer,,R,Ron Estes,58
-Cowley,AC2B-A,State Treasurer,,R,Ron Estes,44
-Cowley,AC2C,State Treasurer,,R,Ron Estes,20
-Cowley,AC2D,State Treasurer,,R,Ron Estes,20
-Cowley,AC3A,State Treasurer,,R,Ron Estes,32
-Cowley,AC3B,State Treasurer,,R,Ron Estes,44
-Cowley,AC3C,State Treasurer,,R,Ron Estes,41
-Cowley,AC4A,State Treasurer,,R,Ron Estes,113
-Cowley,AC4B,State Treasurer,,R,Ron Estes,295
-Cowley,AC4C,State Treasurer,,R,Ron Estes,113
-Cowley,AC4D,State Treasurer,,R,Ron Estes,238
-Cowley,AC1A,U.S. Senate,,I,Greg Orman,71
-Cowley,AC1B,U.S. Senate,,I,Greg Orman,47
-Cowley,AC1C,U.S. Senate,,I,Greg Orman,91
-Cowley,AC1D,U.S. Senate,,I,Greg Orman,92
-Cowley,AC2A,U.S. Senate,,I,Greg Orman,121
-Cowley,AC2B,U.S. Senate,,I,Greg Orman,29
-Cowley,AC2B-A,U.S. Senate,,I,Greg Orman,30
-Cowley,AC2C,U.S. Senate,,I,Greg Orman,10
-Cowley,AC2D,U.S. Senate,,I,Greg Orman,17
-Cowley,AC3A,U.S. Senate,,I,Greg Orman,17
-Cowley,AC3B,U.S. Senate,,I,Greg Orman,29
-Cowley,AC3C,U.S. Senate,,I,Greg Orman,26
-Cowley,AC4A,U.S. Senate,,I,Greg Orman,102
-Cowley,AC4B,U.S. Senate,,I,Greg Orman,210
-Cowley,AC4C,U.S. Senate,,I,Greg Orman,97
-Cowley,AC4D,U.S. Senate,,I,Greg Orman,176
-Cowley,AC1A,U.S. Senate,,R,Pat Roberts,60
-Cowley,AC1B,U.S. Senate,,R,Pat Roberts,62
-Cowley,AC1C,U.S. Senate,,R,Pat Roberts,100
-Cowley,AC1D,U.S. Senate,,R,Pat Roberts,84
-Cowley,AC2A,U.S. Senate,,R,Pat Roberts,144
-Cowley,AC2B,U.S. Senate,,R,Pat Roberts,46
-Cowley,AC2B-A,U.S. Senate,,R,Pat Roberts,38
-Cowley,AC2C,U.S. Senate,,R,Pat Roberts,11
-Cowley,AC2D,U.S. Senate,,R,Pat Roberts,16
-Cowley,AC3A,U.S. Senate,,R,Pat Roberts,24
-Cowley,AC3B,U.S. Senate,,R,Pat Roberts,33
-Cowley,AC3C,U.S. Senate,,R,Pat Roberts,31
-Cowley,AC4A,U.S. Senate,,R,Pat Roberts,92
-Cowley,AC4B,U.S. Senate,,R,Pat Roberts,218
-Cowley,AC4C,U.S. Senate,,R,Pat Roberts,78
-Cowley,AC4D,U.S. Senate,,R,Pat Roberts,171
-Cowley,AC1A,U.S. Senate,,L,Randall Batson,13
-Cowley,AC1B,U.S. Senate,,L,Randall Batson,14
-Cowley,AC1C,U.S. Senate,,L,Randall Batson,10
-Cowley,AC1D,U.S. Senate,,L,Randall Batson,13
-Cowley,AC2A,U.S. Senate,,L,Randall Batson,12
-Cowley,AC2B,U.S. Senate,,L,Randall Batson,10
-Cowley,AC2B-A,U.S. Senate,,L,Randall Batson,3
-Cowley,AC2C,U.S. Senate,,L,Randall Batson,8
-Cowley,AC2D,U.S. Senate,,L,Randall Batson,4
-Cowley,AC3A,U.S. Senate,,L,Randall Batson,5
-Cowley,AC3B,U.S. Senate,,L,Randall Batson,4
-Cowley,AC3C,U.S. Senate,,L,Randall Batson,7
-Cowley,AC4A,U.S. Senate,,L,Randall Batson,13
-Cowley,AC4B,U.S. Senate,,L,Randall Batson,35
-Cowley,AC4C,U.S. Senate,,L,Randall Batson,10
-Cowley,AC4D,U.S. Senate,,L,Randall Batson,28
-Cowley,AC1A,U.S. House,4,R,Mike Pompeo,74
-Cowley,AC1B,U.S. House,4,R,Mike Pompeo,81
-Cowley,AC1C,U.S. House,4,R,Mike Pompeo,126
-Cowley,AC1D,U.S. House,4,R,Mike Pompeo,117
-Cowley,AC2A,U.S. House,4,R,Mike Pompeo,190
-Cowley,AC2B,U.S. House,4,R,Mike Pompeo,49
-Cowley,AC2B-A,U.S. House,4,R,Mike Pompeo,44
-Cowley,AC2C,U.S. House,4,R,Mike Pompeo,15
-Cowley,AC2D,U.S. House,4,R,Mike Pompeo,17
-Cowley,AC3A,U.S. House,4,R,Mike Pompeo,30
-Cowley,AC3B,U.S. House,4,R,Mike Pompeo,34
-Cowley,AC3C,U.S. House,4,R,Mike Pompeo,38
-Cowley,AC4A,U.S. House,4,R,Mike Pompeo,95
-Cowley,AC4B,U.S. House,4,R,Mike Pompeo,260
-Cowley,AC4C,U.S. House,4,R,Mike Pompeo,100
-Cowley,AC4D,U.S. House,4,R,Mike Pompeo,228
-Cowley,AC1A,U.S. House,4,D,Perry L. Schuckman,66
-Cowley,AC1B,U.S. House,4,D,Perry L. Schuckman,42
-Cowley,AC1C,U.S. House,4,D,Perry L. Schuckman,71
-Cowley,AC1D,U.S. House,4,D,Perry L. Schuckman,73
-Cowley,AC2A,U.S. House,4,D,Perry L. Schuckman,83
-Cowley,AC2B,U.S. House,4,D,Perry L. Schuckman,33
-Cowley,AC2B-A,U.S. House,4,D,Perry L. Schuckman,28
-Cowley,AC2C,U.S. House,4,D,Perry L. Schuckman,14
-Cowley,AC2D,U.S. House,4,D,Perry L. Schuckman,19
-Cowley,AC3A,U.S. House,4,D,Perry L. Schuckman,16
-Cowley,AC3B,U.S. House,4,D,Perry L. Schuckman,31
-Cowley,AC3C,U.S. House,4,D,Perry L. Schuckman,25
-Cowley,AC4A,U.S. House,4,D,Perry L. Schuckman,106
-Cowley,AC4B,U.S. House,4,D,Perry L. Schuckman,195
-Cowley,AC4C,U.S. House,4,D,Perry L. Schuckman,81
-Cowley,AC4D,U.S. House,4,D,Perry L. Schuckman,144
-Cowley,WD1E,Attorney General,,D,A.J. Kotich,96
-Cowley,WD1W,Attorney General,,D,A.J. Kotich,46
-Cowley,WD2C,Attorney General,,D,A.J. Kotich,66
-Cowley,WD2E,Attorney General,,D,A.J. Kotich,75
-Cowley,WD2S,Attorney General,,D,A.J. Kotich,82
-Cowley,WD2W,Attorney General,,D,A.J. Kotich,57
-Cowley,WD3,Attorney General,,D,A.J. Kotich,82
-Cowley,WD3S,Attorney General,,D,A.J. Kotich,15
-Cowley,WD4,Attorney General,,D,A.J. Kotich,18
-Cowley,WD5E,Attorney General,,D,A.J. Kotich,144
-Cowley,WD5W,Attorney General,,D,A.J. Kotich,55
-Cowley,WD6,Attorney General,,D,A.J. Kotich,102
-Cowley,WD6A,Attorney General,,D,A.J. Kotich,36
-Cowley,WD7,Attorney General,,D,A.J. Kotich,80
-Cowley,WD8,Attorney General,,D,A.J. Kotich,7
-Cowley,WD1E,Attorney General,,R,Derek Schmidt,177
-Cowley,WD1W,Attorney General,,R,Derek Schmidt,100
-Cowley,WD2C,Attorney General,,R,Derek Schmidt,113
-Cowley,WD2E,Attorney General,,R,Derek Schmidt,141
-Cowley,WD2S,Attorney General,,R,Derek Schmidt,241
-Cowley,WD2W,Attorney General,,R,Derek Schmidt,130
-Cowley,WD3,Attorney General,,R,Derek Schmidt,160
-Cowley,WD3S,Attorney General,,R,Derek Schmidt,81
-Cowley,WD4,Attorney General,,R,Derek Schmidt,62
-Cowley,WD5E,Attorney General,,R,Derek Schmidt,209
-Cowley,WD5W,Attorney General,,R,Derek Schmidt,75
-Cowley,WD6,Attorney General,,R,Derek Schmidt,260
-Cowley,WD6A,Attorney General,,R,Derek Schmidt,126
-Cowley,WD7,Attorney General,,R,Derek Schmidt,167
-Cowley,WD8,Attorney General,,R,Derek Schmidt,25
-Cowley,WD1E,Governor,,L,Keen A. Umbehr,15
-Cowley,WD1W,Governor,,L,Keen A. Umbehr,9
-Cowley,WD2C,Governor,,L,Keen A. Umbehr,11
-Cowley,WD2E,Governor,,L,Keen A. Umbehr,8
-Cowley,WD2S,Governor,,L,Keen A. Umbehr,11
-Cowley,WD2W,Governor,,L,Keen A. Umbehr,10
-Cowley,WD3,Governor,,L,Keen A. Umbehr,15
-Cowley,WD3S,Governor,,L,Keen A. Umbehr,2
-Cowley,WD4,Governor,,L,Keen A. Umbehr,4
-Cowley,WD5E,Governor,,L,Keen A. Umbehr,12
-Cowley,WD5W,Governor,,L,Keen A. Umbehr,11
-Cowley,WD6,Governor,,L,Keen A. Umbehr,11
-Cowley,WD6A,Governor,,L,Keen A. Umbehr,1
-Cowley,WD7,Governor,,L,Keen A. Umbehr,5
-Cowley,WD8,Governor,,L,Keen A. Umbehr,0
-Cowley,WD1E,Governor,,D,Paul Davis,165
-Cowley,WD1W,Governor,,D,Paul Davis,81
-Cowley,WD2C,Governor,,D,Paul Davis,115
-Cowley,WD2E,Governor,,D,Paul Davis,129
-Cowley,WD2S,Governor,,D,Paul Davis,179
-Cowley,WD2W,Governor,,D,Paul Davis,103
-Cowley,WD3,Governor,,D,Paul Davis,135
-Cowley,WD3S,Governor,,D,Paul Davis,33
-Cowley,WD4,Governor,,D,Paul Davis,43
-Cowley,WD5E,Governor,,D,Paul Davis,219
-Cowley,WD5W,Governor,,D,Paul Davis,75
-Cowley,WD6,Governor,,D,Paul Davis,185
-Cowley,WD6A,Governor,,D,Paul Davis,74
-Cowley,WD7,Governor,,D,Paul Davis,142
-Cowley,WD8,Governor,,D,Paul Davis,17
-Cowley,WD1E,Governor,,R,Sam Brownback,102
-Cowley,WD1W,Governor,,R,Sam Brownback,60
-Cowley,WD2C,Governor,,R,Sam Brownback,65
-Cowley,WD2E,Governor,,R,Sam Brownback,85
-Cowley,WD2S,Governor,,R,Sam Brownback,136
-Cowley,WD2W,Governor,,R,Sam Brownback,74
-Cowley,WD3,Governor,,R,Sam Brownback,97
-Cowley,WD3S,Governor,,R,Sam Brownback,63
-Cowley,WD4,Governor,,R,Sam Brownback,32
-Cowley,WD5E,Governor,,R,Sam Brownback,136
-Cowley,WD5W,Governor,,R,Sam Brownback,48
-Cowley,WD6,Governor,,R,Sam Brownback,173
-Cowley,WD6A,Governor,,R,Sam Brownback,87
-Cowley,WD7,Governor,,R,Sam Brownback,103
-Cowley,WD8,Governor,,R,Sam Brownback,14
-Cowley,WD1E,Insurance Commissioner,,D,Dennis Anderson,122
-Cowley,WD1W,Insurance Commissioner,,D,Dennis Anderson,57
-Cowley,WD2C,Insurance Commissioner,,D,Dennis Anderson,77
-Cowley,WD2E,Insurance Commissioner,,D,Dennis Anderson,91
-Cowley,WD2S,Insurance Commissioner,,D,Dennis Anderson,126
-Cowley,WD2W,Insurance Commissioner,,D,Dennis Anderson,76
-Cowley,WD3,Insurance Commissioner,,D,Dennis Anderson,111
-Cowley,WD3S,Insurance Commissioner,,D,Dennis Anderson,20
-Cowley,WD4,Insurance Commissioner,,D,Dennis Anderson,27
-Cowley,WD5E,Insurance Commissioner,,D,Dennis Anderson,186
-Cowley,WD5W,Insurance Commissioner,,D,Dennis Anderson,74
-Cowley,WD6,Insurance Commissioner,,D,Dennis Anderson,137
-Cowley,WD6A,Insurance Commissioner,,D,Dennis Anderson,47
-Cowley,WD7,Insurance Commissioner,,D,Dennis Anderson,99
-Cowley,WD8,Insurance Commissioner,,D,Dennis Anderson,7
-Cowley,WD1E,Insurance Commissioner,,R,Ken Selzer,145
-Cowley,WD1W,Insurance Commissioner,,R,Ken Selzer,87
-Cowley,WD2C,Insurance Commissioner,,R,Ken Selzer,99
-Cowley,WD2E,Insurance Commissioner,,R,Ken Selzer,117
-Cowley,WD2S,Insurance Commissioner,,R,Ken Selzer,196
-Cowley,WD2W,Insurance Commissioner,,R,Ken Selzer,110
-Cowley,WD3,Insurance Commissioner,,R,Ken Selzer,133
-Cowley,WD3S,Insurance Commissioner,,R,Ken Selzer,73
-Cowley,WD4,Insurance Commissioner,,R,Ken Selzer,51
-Cowley,WD5E,Insurance Commissioner,,R,Ken Selzer,168
-Cowley,WD5W,Insurance Commissioner,,R,Ken Selzer,56
-Cowley,WD6,Insurance Commissioner,,R,Ken Selzer,218
-Cowley,WD6A,Insurance Commissioner,,R,Ken Selzer,114
-Cowley,WD7,Insurance Commissioner,,R,Ken Selzer,140
-Cowley,WD8,Insurance Commissioner,,R,Ken Selzer,24
-Cowley,WD1E,Secretary of State,,D,Jean Kurtis Schodorf,159
-Cowley,WD1W,Secretary of State,,D,Jean Kurtis Schodorf,71
-Cowley,WD2C,Secretary of State,,D,Jean Kurtis Schodorf,95
-Cowley,WD2E,Secretary of State,,D,Jean Kurtis Schodorf,106
-Cowley,WD2S,Secretary of State,,D,Jean Kurtis Schodorf,152
-Cowley,WD2W,Secretary of State,,D,Jean Kurtis Schodorf,94
-Cowley,WD3,Secretary of State,,D,Jean Kurtis Schodorf,117
-Cowley,WD3S,Secretary of State,,D,Jean Kurtis Schodorf,34
-Cowley,WD4,Secretary of State,,D,Jean Kurtis Schodorf,36
-Cowley,WD5E,Secretary of State,,D,Jean Kurtis Schodorf,197
-Cowley,WD5W,Secretary of State,,D,Jean Kurtis Schodorf,71
-Cowley,WD6,Secretary of State,,D,Jean Kurtis Schodorf,166
-Cowley,WD6A,Secretary of State,,D,Jean Kurtis Schodorf,61
-Cowley,WD7,Secretary of State,,D,Jean Kurtis Schodorf,123
-Cowley,WD8,Secretary of State,,D,Jean Kurtis Schodorf,15
-Cowley,WD1E,Secretary of State,,R,Kris Kobach,120
-Cowley,WD1W,Secretary of State,,R,Kris Kobach,77
-Cowley,WD2C,Secretary of State,,R,Kris Kobach,91
-Cowley,WD2E,Secretary of State,,R,Kris Kobach,113
-Cowley,WD2S,Secretary of State,,R,Kris Kobach,174
-Cowley,WD2W,Secretary of State,,R,Kris Kobach,92
-Cowley,WD3,Secretary of State,,R,Kris Kobach,131
-Cowley,WD3S,Secretary of State,,R,Kris Kobach,64
-Cowley,WD4,Secretary of State,,R,Kris Kobach,44
-Cowley,WD5E,Secretary of State,,R,Kris Kobach,164
-Cowley,WD5W,Secretary of State,,R,Kris Kobach,61
-Cowley,WD6,Secretary of State,,R,Kris Kobach,199
-Cowley,WD6A,Secretary of State,,R,Kris Kobach,102
-Cowley,WD7,Secretary of State,,R,Kris Kobach,128
-Cowley,WD8,Secretary of State,,R,Kris Kobach,16
-Cowley,WD1E,State House,79,D,Ed Trimmer,183
-Cowley,WD1W,State House,79,D,Ed Trimmer,85
-Cowley,WD2C,State House,79,D,Ed Trimmer,113
-Cowley,WD2E,State House,79,D,Ed Trimmer,149
-Cowley,WD2S,State House,79,D,Ed Trimmer,182
-Cowley,WD2W,State House,79,D,Ed Trimmer,120
-Cowley,WD3,State House,79,D,Ed Trimmer,148
-Cowley,WD3S,State House,79,D,Ed Trimmer,32
-Cowley,WD4,State House,79,D,Ed Trimmer,40
-Cowley,WD5E,State House,79,D,Ed Trimmer,245
-Cowley,WD5W,State House,79,D,Ed Trimmer,84
-Cowley,WD6,State House,79,D,Ed Trimmer,210
-Cowley,WD6A,State House,79,D,Ed Trimmer,75
-Cowley,WD7,State House,79,D,Ed Trimmer,157
-Cowley,WD8,State House,79,D,Ed Trimmer,16
-Cowley,WD1E,State House,79,R,Larry Alley,99
-Cowley,WD1W,State House,79,R,Larry Alley,68
-Cowley,WD2C,State House,79,R,Larry Alley,81
-Cowley,WD2E,State House,79,R,Larry Alley,74
-Cowley,WD2S,State House,79,R,Larry Alley,145
-Cowley,WD2W,State House,79,R,Larry Alley,67
-Cowley,WD3,State House,79,R,Larry Alley,102
-Cowley,WD3S,State House,79,R,Larry Alley,66
-Cowley,WD4,State House,79,R,Larry Alley,40
-Cowley,WD5E,State House,79,R,Larry Alley,125
-Cowley,WD5W,State House,79,R,Larry Alley,49
-Cowley,WD6,State House,79,R,Larry Alley,157
-Cowley,WD6A,State House,79,R,Larry Alley,88
-Cowley,WD7,State House,79,R,Larry Alley,99
-Cowley,WD8,State House,79,R,Larry Alley,15
-Cowley,WD1E,State Treasurer,,D,Carmen Alldritt,95
-Cowley,WD1W,State Treasurer,,D,Carmen Alldritt,41
-Cowley,WD2C,State Treasurer,,D,Carmen Alldritt,65
-Cowley,WD2E,State Treasurer,,D,Carmen Alldritt,74
-Cowley,WD2S,State Treasurer,,D,Carmen Alldritt,80
-Cowley,WD2W,State Treasurer,,D,Carmen Alldritt,51
-Cowley,WD3,State Treasurer,,D,Carmen Alldritt,76
-Cowley,WD3S,State Treasurer,,D,Carmen Alldritt,13
-Cowley,WD4,State Treasurer,,D,Carmen Alldritt,21
-Cowley,WD5E,State Treasurer,,D,Carmen Alldritt,148
-Cowley,WD5W,State Treasurer,,D,Carmen Alldritt,58
-Cowley,WD6,State Treasurer,,D,Carmen Alldritt,91
-Cowley,WD6A,State Treasurer,,D,Carmen Alldritt,35
-Cowley,WD7,State Treasurer,,D,Carmen Alldritt,68
-Cowley,WD8,State Treasurer,,D,Carmen Alldritt,8
-Cowley,WD1E,State Treasurer,,R,Ron Estes,179
-Cowley,WD1W,State Treasurer,,R,Ron Estes,107
-Cowley,WD2C,State Treasurer,,R,Ron Estes,112
-Cowley,WD2E,State Treasurer,,R,Ron Estes,141
-Cowley,WD2S,State Treasurer,,R,Ron Estes,241
-Cowley,WD2W,State Treasurer,,R,Ron Estes,134
-Cowley,WD3,State Treasurer,,R,Ron Estes,167
-Cowley,WD3S,State Treasurer,,R,Ron Estes,84
-Cowley,WD4,State Treasurer,,R,Ron Estes,56
-Cowley,WD5E,State Treasurer,,R,Ron Estes,210
-Cowley,WD5W,State Treasurer,,R,Ron Estes,75
-Cowley,WD6,State Treasurer,,R,Ron Estes,271
-Cowley,WD6A,State Treasurer,,R,Ron Estes,127
-Cowley,WD7,State Treasurer,,R,Ron Estes,175
-Cowley,WD8,State Treasurer,,R,Ron Estes,23
-Cowley,WD1E,U.S. Senate,,I,Greg Orman,144
-Cowley,WD1W,U.S. Senate,,I,Greg Orman,65
-Cowley,WD2C,U.S. Senate,,I,Greg Orman,100
-Cowley,WD2E,U.S. Senate,,I,Greg Orman,97
-Cowley,WD2S,U.S. Senate,,I,Greg Orman,155
-Cowley,WD2W,U.S. Senate,,I,Greg Orman,96
-Cowley,WD3,U.S. Senate,,I,Greg Orman,109
-Cowley,WD3S,U.S. Senate,,I,Greg Orman,32
-Cowley,WD4,U.S. Senate,,I,Greg Orman,40
-Cowley,WD5E,U.S. Senate,,I,Greg Orman,195
-Cowley,WD5W,U.S. Senate,,I,Greg Orman,67
-Cowley,WD6,U.S. Senate,,I,Greg Orman,150
-Cowley,WD6A,U.S. Senate,,I,Greg Orman,63
-Cowley,WD7,U.S. Senate,,I,Greg Orman,123
-Cowley,WD8,U.S. Senate,,I,Greg Orman,11
-Cowley,WD1E,U.S. Senate,,R,Pat Roberts,116
-Cowley,WD1W,U.S. Senate,,R,Pat Roberts,76
-Cowley,WD2C,U.S. Senate,,R,Pat Roberts,75
-Cowley,WD2E,U.S. Senate,,R,Pat Roberts,113
-Cowley,WD2S,U.S. Senate,,R,Pat Roberts,162
-Cowley,WD2W,U.S. Senate,,R,Pat Roberts,81
-Cowley,WD3,U.S. Senate,,R,Pat Roberts,120
-Cowley,WD3S,U.S. Senate,,R,Pat Roberts,65
-Cowley,WD4,U.S. Senate,,R,Pat Roberts,33
-Cowley,WD5E,U.S. Senate,,R,Pat Roberts,154
-Cowley,WD5W,U.S. Senate,,R,Pat Roberts,53
-Cowley,WD6,U.S. Senate,,R,Pat Roberts,195
-Cowley,WD6A,U.S. Senate,,R,Pat Roberts,97
-Cowley,WD7,U.S. Senate,,R,Pat Roberts,116
-Cowley,WD8,U.S. Senate,,R,Pat Roberts,20
-Cowley,WD1E,U.S. Senate,,L,Randall Batson,21
-Cowley,WD1W,U.S. Senate,,L,Randall Batson,9
-Cowley,WD2C,U.S. Senate,,L,Randall Batson,14
-Cowley,WD2E,U.S. Senate,,L,Randall Batson,11
-Cowley,WD2S,U.S. Senate,,L,Randall Batson,9
-Cowley,WD2W,U.S. Senate,,L,Randall Batson,9
-Cowley,WD3,U.S. Senate,,L,Randall Batson,20
-Cowley,WD3S,U.S. Senate,,L,Randall Batson,1
-Cowley,WD4,U.S. Senate,,L,Randall Batson,3
-Cowley,WD5E,U.S. Senate,,L,Randall Batson,15
-Cowley,WD5W,U.S. Senate,,L,Randall Batson,11
-Cowley,WD6,U.S. Senate,,L,Randall Batson,19
-Cowley,WD6A,U.S. Senate,,L,Randall Batson,4
-Cowley,WD7,U.S. Senate,,L,Randall Batson,11
-Cowley,WD8,U.S. Senate,,L,Randall Batson,0
-Cowley,WD1E,U.S. House,4,R,Mike Pompeo,162
-Cowley,WD1W,U.S. House,4,R,Mike Pompeo,97
-Cowley,WD2C,U.S. House,4,R,Mike Pompeo,113
-Cowley,WD2E,U.S. House,4,R,Mike Pompeo,138
-Cowley,WD2S,U.S. House,4,R,Mike Pompeo,223
-Cowley,WD2W,U.S. House,4,R,Mike Pompeo,119
-Cowley,WD3,U.S. House,4,R,Mike Pompeo,148
-Cowley,WD3S,U.S. House,4,R,Mike Pompeo,73
-Cowley,WD4,U.S. House,4,R,Mike Pompeo,54
-Cowley,WD5E,U.S. House,4,R,Mike Pompeo,199
-Cowley,WD5W,U.S. House,4,R,Mike Pompeo,68
-Cowley,WD6,U.S. House,4,R,Mike Pompeo,237
-Cowley,WD6A,U.S. House,4,R,Mike Pompeo,117
-Cowley,WD7,U.S. House,4,R,Mike Pompeo,150
-Cowley,WD8,U.S. House,4,R,Mike Pompeo,24
-Cowley,WD1E,U.S. House,4,D,Perry L. Schuckman,114
-Cowley,WD1W,U.S. House,4,D,Perry L. Schuckman,50
-Cowley,WD2C,U.S. House,4,D,Perry L. Schuckman,75
-Cowley,WD2E,U.S. House,4,D,Perry L. Schuckman,81
-Cowley,WD2S,U.S. House,4,D,Perry L. Schuckman,103
-Cowley,WD2W,U.S. House,4,D,Perry L. Schuckman,68
-Cowley,WD3,U.S. House,4,D,Perry L. Schuckman,97
-Cowley,WD3S,U.S. House,4,D,Perry L. Schuckman,24
-Cowley,WD4,U.S. House,4,D,Perry L. Schuckman,25
-Cowley,WD5E,U.S. House,4,D,Perry L. Schuckman,163
-Cowley,WD5W,U.S. House,4,D,Perry L. Schuckman,65
-Cowley,WD6,U.S. House,4,D,Perry L. Schuckman,123
-Cowley,WD6A,U.S. House,4,D,Perry L. Schuckman,46
-Cowley,WD7,U.S. House,4,D,Perry L. Schuckman,98
-Cowley,WD8,U.S. House,4,D,Perry L. Schuckman,7
-Cowley,Beaver,U.S. Senate,,R,Pat Roberts,52
-Cowley,Bolton,U.S. Senate,,R,Pat Roberts,306
-Cowley,Cedar,U.S. Senate,,R,Pat Roberts,13
-Cowley,Creswell E,U.S. Senate,,R,Pat Roberts,306
-Cowley,Creswell W,U.S. Senate,,R,Pat Roberts,141
-Cowley,Dexter,U.S. Senate,,R,Pat Roberts,113
-Cowley,Fairview,U.S. Senate,,R,Pat Roberts,59
-Cowley,Grant,U.S. Senate,,R,Pat Roberts,20
-Cowley,Harvey,U.S. Senate,,R,Pat Roberts,28
-Cowley,Liberty,U.S. Senate,,R,Pat Roberts,46
-Cowley,Maple,U.S. Senate,,R,Pat Roberts,159
-Cowley,Ninnescah,U.S. Senate,,R,Pat Roberts,207
-Cowley,Omina,U.S. Senate,,R,Pat Roberts,78
-Cowley,Otter,U.S. Senate,,R,Pat Roberts,15
-Cowley,Pleas Valley,U.S. Senate,,R,Pat Roberts,190
-Cowley,Richland,U.S. Senate,,R,Pat Roberts,62
-Cowley,Rock Creek,U.S. Senate,,R,Pat Roberts,47
-Cowley,Salem,U.S. Senate,,R,Pat Roberts,66
-Cowley,Sheridan,U.S. Senate,,R,Pat Roberts,40
-Cowley,Silver Creek,U.S. Senate,,R,Pat Roberts,149
-Cowley,Silverdale,U.S. Senate,,R,Pat Roberts,78
-Cowley,Spring Ck,U.S. Senate,,R,Pat Roberts,21
-Cowley,Tisdale,U.S. Senate,,R,Pat Roberts,97
-Cowley,Vernon,U.S. Senate,,R,Pat Roberts,117
-Cowley,Walnut,U.S. Senate,,R,Pat Roberts,158
-Cowley,Windsor,U.S. Senate,,R,Pat Roberts,40
-Cowley,Beaver,U.S. Senate,,I ,Greg Orman,37
-Cowley,Bolton,U.S. Senate,,I ,Greg Orman,143
-Cowley,Cedar,U.S. Senate,,I ,Greg Orman,0
-Cowley,Creswell E,U.S. Senate,,I ,Greg Orman,167
-Cowley,Creswell W,U.S. Senate,,I ,Greg Orman,78
-Cowley,Dexter,U.S. Senate,,I ,Greg Orman,35
-Cowley,Fairview,U.S. Senate,,I ,Greg Orman,40
-Cowley,Grant,U.S. Senate,,I ,Greg Orman,6
-Cowley,Harvey,U.S. Senate,,I ,Greg Orman,11
-Cowley,Liberty,U.S. Senate,,I ,Greg Orman,10
-Cowley,Maple,U.S. Senate,,I ,Greg Orman,89
-Cowley,Ninnescah,U.S. Senate,,I ,Greg Orman,130
-Cowley,Omina,U.S. Senate,,I ,Greg Orman,21
-Cowley,Otter,U.S. Senate,,I ,Greg Orman,1
-Cowley,Pleas Valley,U.S. Senate,,I ,Greg Orman,130
-Cowley,Richland,U.S. Senate,,I ,Greg Orman,27
-Cowley,Rock Creek,U.S. Senate,,I ,Greg Orman,24
-Cowley,Salem,U.S. Senate,,I ,Greg Orman,35
-Cowley,Sheridan,U.S. Senate,,I ,Greg Orman,21
-Cowley,Silver Creek,U.S. Senate,,I ,Greg Orman,67
-Cowley,Silverdale,U.S. Senate,,I ,Greg Orman,36
-Cowley,Spring Ck,U.S. Senate,,I ,Greg Orman,9
-Cowley,Tisdale,U.S. Senate,,I ,Greg Orman,37
-Cowley,Vernon,U.S. Senate,,I ,Greg Orman,56
-Cowley,Walnut,U.S. Senate,,I ,Greg Orman,99
-Cowley,Windsor,U.S. Senate,,I ,Greg Orman,26
-Cowley,Beaver,U.S. Senate,,L,Randall Batson,2
-Cowley,Bolton,U.S. Senate,,L,Randall Batson,41
-Cowley,Cedar,U.S. Senate,,L,Randall Batson,1
-Cowley,Creswell E,U.S. Senate,,L,Randall Batson,24
-Cowley,Creswell W,U.S. Senate,,L,Randall Batson,9
-Cowley,Dexter,U.S. Senate,,L,Randall Batson,7
-Cowley,Fairview,U.S. Senate,,L,Randall Batson,5
-Cowley,Grant,U.S. Senate,,L,Randall Batson,0
-Cowley,Harvey,U.S. Senate,,L,Randall Batson,1
-Cowley,Liberty,U.S. Senate,,L,Randall Batson,1
-Cowley,Maple,U.S. Senate,,L,Randall Batson,9
-Cowley,Ninnescah,U.S. Senate,,L,Randall Batson,15
-Cowley,Omina,U.S. Senate,,L,Randall Batson,6
-Cowley,Otter,U.S. Senate,,L,Randall Batson,0
-Cowley,Pleas Valley,U.S. Senate,,L,Randall Batson,17
-Cowley,Richland,U.S. Senate,,L,Randall Batson,5
-Cowley,Rock Creek,U.S. Senate,,L,Randall Batson,2
-Cowley,Salem,U.S. Senate,,L,Randall Batson,5
-Cowley,Sheridan,U.S. Senate,,L,Randall Batson,4
-Cowley,Silver Creek,U.S. Senate,,L,Randall Batson,16
-Cowley,Silverdale,U.S. Senate,,L,Randall Batson,7
-Cowley,Spring Ck,U.S. Senate,,L,Randall Batson,0
-Cowley,Tisdale,U.S. Senate,,L,Randall Batson,14
-Cowley,Vernon,U.S. Senate,,L,Randall Batson,16
-Cowley,Walnut,U.S. Senate,,L,Randall Batson,18
-Cowley,Windsor,U.S. Senate,,L,Randall Batson,4
-Cowley,Beaver,U.S. House,4,R,Mike Pompeo,64
-Cowley,Bolton,U.S. House,4,R,Mike Pompeo,349
-Cowley,Cedar,U.S. House,4,R,Mike Pompeo,14
-Cowley,Creswell E,U.S. House,4,R,Mike Pompeo,335
-Cowley,Creswell W,U.S. House,4,R,Mike Pompeo,154
-Cowley,Dexter,U.S. House,4,R,Mike Pompeo,131
-Cowley,Fairview,U.S. House,4,R,Mike Pompeo,76
-Cowley,Grant,U.S. House,4,R,Mike Pompeo,23
-Cowley,Harvey,U.S. House,4,R,Mike Pompeo,31
-Cowley,Liberty,U.S. House,4,R,Mike Pompeo,49
-Cowley,Maple,U.S. House,4,R,Mike Pompeo,194
-Cowley,Ninnescah,U.S. House,4,R,Mike Pompeo,252
-Cowley,Omina,U.S. House,4,R,Mike Pompeo,82
-Cowley,Otter,U.S. House,4,R,Mike Pompeo,15
-Cowley,Pleas Valley,U.S. House,4,R,Mike Pompeo,236
-Cowley,Richland,U.S. House,4,R,Mike Pompeo,69
-Cowley,Rock Creek,U.S. House,4,R,Mike Pompeo,54
-Cowley,Salem,U.S. House,4,R,Mike Pompeo,82
-Cowley,Sheridan,U.S. House,4,R,Mike Pompeo,50
-Cowley,Silver Creek,U.S. House,4,R,Mike Pompeo,175
-Cowley,Silverdale,U.S. House,4,R,Mike Pompeo,92
-Cowley,Spring Ck,U.S. House,4,R,Mike Pompeo,24
-Cowley,Tisdale,U.S. House,4,R,Mike Pompeo,117
-Cowley,Vernon,U.S. House,4,R,Mike Pompeo,140
-Cowley,Walnut,U.S. House,4,R,Mike Pompeo,207
-Cowley,Windsor,U.S. House,4,R,Mike Pompeo,51
-Cowley,Beaver,U.S. House,4,D,Perry Schuckman,29
-Cowley,Bolton,U.S. House,4,D,Perry Schuckman,143
-Cowley,Cedar,U.S. House,4,D,Perry Schuckman,0
-Cowley,Creswell E,U.S. House,4,D,Perry Schuckman,154
-Cowley,Creswell W,U.S. House,4,D,Perry Schuckman,68
-Cowley,Dexter,U.S. House,4,D,Perry Schuckman,28
-Cowley,Fairview,U.S. House,4,D,Perry Schuckman,29
-Cowley,Grant,U.S. House,4,D,Perry Schuckman,4
-Cowley,Harvey,U.S. House,4,D,Perry Schuckman,9
-Cowley,Liberty,U.S. House,4,D,Perry Schuckman,9
-Cowley,Maple,U.S. House,4,D,Perry Schuckman,68
-Cowley,Ninnescah,U.S. House,4,D,Perry Schuckman,101
-Cowley,Omina,U.S. House,4,D,Perry Schuckman,22
-Cowley,Otter,U.S. House,4,D,Perry Schuckman,1
-Cowley,Pleas Valley,U.S. House,4,D,Perry Schuckman,103
-Cowley,Richland,U.S. House,4,D,Perry Schuckman,23
-Cowley,Rock Creek,U.S. House,4,D,Perry Schuckman,17
-Cowley,Salem,U.S. House,4,D,Perry Schuckman,23
-Cowley,Sheridan,U.S. House,4,D,Perry Schuckman,14
-Cowley,Silver Creek,U.S. House,4,D,Perry Schuckman,53
-Cowley,Silverdale,U.S. House,4,D,Perry Schuckman,29
-Cowley,Spring Ck,U.S. House,4,D,Perry Schuckman,5
-Cowley,Tisdale,U.S. House,4,D,Perry Schuckman,32
-Cowley,Vernon,U.S. House,4,D,Perry Schuckman,49
-Cowley,Walnut,U.S. House,4,D,Perry Schuckman,65
-Cowley,Windsor,U.S. House,4,D,Perry Schuckman,19
-Cowley,Beaver,Governor,,R,Sam Brownback,53
-Cowley,Bolton,Governor,,R,Sam Brownback,286
-Cowley,Cedar,Governor,,R,Sam Brownback,11
-Cowley,Creswell E,Governor,,R,Sam Brownback,268
-Cowley,Creswell W,Governor,,R,Sam Brownback,129
-Cowley,Dexter,Governor,,R,Sam Brownback,110
-Cowley,Fairview,Governor,,R,Sam Brownback,57
-Cowley,Grant,Governor,,R,Sam Brownback,20
-Cowley,Harvey,Governor,,R,Sam Brownback,25
-Cowley,Liberty,Governor,,R,Sam Brownback,46
-Cowley,Maple,Governor,,R,Sam Brownback,149
-Cowley,Ninnescah,Governor,,R,Sam Brownback,188
-Cowley,Omina,Governor,,R,Sam Brownback,73
-Cowley,Otter,Governor,,R,Sam Brownback,12
-Cowley,Pleas Valley,Governor,,R,Sam Brownback,185
-Cowley,Richland,Governor,,R,Sam Brownback,55
-Cowley,Rock Creek,Governor,,R,Sam Brownback,39
-Cowley,Salem,Governor,,R,Sam Brownback,58
-Cowley,Sheridan,Governor,,R,Sam Brownback,39
-Cowley,Silver Creek,Governor,,R,Sam Brownback,133
-Cowley,Silverdale,Governor,,R,Sam Brownback,71
-Cowley,Spring Ck,Governor,,R,Sam Brownback,22
-Cowley,Tisdale,Governor,,R,Sam Brownback,92
-Cowley,Vernon,Governor,,R,Sam Brownback,115
-Cowley,Walnut,Governor,,R,Sam Brownback,133
-Cowley,Windsor,Governor,,R,Sam Brownback,35
-Cowley,Beaver,Governor,,D,Paul Davis,39
-Cowley,Bolton,Governor,,D,Paul Davis,176
-Cowley,Cedar,Governor,,D,Paul Davis,2
-Cowley,Creswell E,Governor,,D,Paul Davis,209
-Cowley,Creswell W,Governor,,D,Paul Davis,88
-Cowley,Dexter,Governor,,D,Paul Davis,45
-Cowley,Fairview,Governor,,D,Paul Davis,45
-Cowley,Grant,Governor,,D,Paul Davis,7
-Cowley,Harvey,Governor,,D,Paul Davis,14
-Cowley,Liberty,Governor,,D,Paul Davis,10
-Cowley,Maple,Governor,,D,Paul Davis,89
-Cowley,Ninnescah,Governor,,D,Paul Davis,144
-Cowley,Omina,Governor,,D,Paul Davis,29
-Cowley,Otter,Governor,,D,Paul Davis,3
-Cowley,Pleas Valley,Governor,,D,Paul Davis,152
-Cowley,Richland,Governor,,D,Paul Davis,32
-Cowley,Rock Creek,Governor,,D,Paul Davis,30
-Cowley,Salem,Governor,,D,Paul Davis,46
-Cowley,Sheridan,Governor,,D,Paul Davis,22
-Cowley,Silver Creek,Governor,,D,Paul Davis,86
-Cowley,Silverdale,Governor,,D,Paul Davis,43
-Cowley,Spring Ck,Governor,,D,Paul Davis,8
-Cowley,Tisdale,Governor,,D,Paul Davis,48
-Cowley,Vernon,Governor,,D,Paul Davis,67
-Cowley,Walnut,Governor,,D,Paul Davis,120
-Cowley,Windsor,Governor,,D,Paul Davis,30
-Cowley,Beaver,Governor,,L,Keen Umbehr,2
-Cowley,Bolton,Governor,,L,Keen Umbehr,32
-Cowley,Cedar,Governor,,L,Keen Umbehr,1
-Cowley,Creswell E,Governor,,L,Keen Umbehr,18
-Cowley,Creswell W,Governor,,L,Keen Umbehr,11
-Cowley,Dexter,Governor,,L,Keen Umbehr,4
-Cowley,Fairview,Governor,,L,Keen Umbehr,2
-Cowley,Grant,Governor,,L,Keen Umbehr,0
-Cowley,Harvey,Governor,,L,Keen Umbehr,1
-Cowley,Liberty,Governor,,L,Keen Umbehr,1
-Cowley,Maple,Governor,,L,Keen Umbehr,23
-Cowley,Ninnescah,Governor,,L,Keen Umbehr,24
-Cowley,Omina,Governor,,L,Keen Umbehr,3
-Cowley,Otter,Governor,,L,Keen Umbehr,1
-Cowley,Pleas Valley,Governor,,L,Keen Umbehr,5
-Cowley,Richland,Governor,,L,Keen Umbehr,6
-Cowley,Rock Creek,Governor,,L,Keen Umbehr,4
-Cowley,Salem,Governor,,L,Keen Umbehr,4
-Cowley,Sheridan,Governor,,L,Keen Umbehr,4
-Cowley,Silver Creek,Governor,,L,Keen Umbehr,10
-Cowley,Silverdale,Governor,,L,Keen Umbehr,7
-Cowley,Spring Ck,Governor,,L,Keen Umbehr,0
-Cowley,Tisdale,Governor,,L,Keen Umbehr,10
-Cowley,Vernon,Governor,,L,Keen Umbehr,6
-Cowley,Walnut,Governor,,L,Keen Umbehr,20
-Cowley,Windsor,Governor,,L,Keen Umbehr,5
-Cowley,Beaver,Secretary of State,,R,Kris Kobach,56
-Cowley,Bolton,Secretary of State,,R,Kris Kobach,343
-Cowley,Cedar,Secretary of State,,R,Kris Kobach,12
-Cowley,Creswell E,Secretary of State,,R,Kris Kobach,317
-Cowley,Creswell W,Secretary of State,,R,Kris Kobach,159
-Cowley,Dexter,Secretary of State,,R,Kris Kobach,113
-Cowley,Fairview,Secretary of State,,R,Kris Kobach,63
-Cowley,Grant,Secretary of State,,R,Kris Kobach,22
-Cowley,Harvey,Secretary of State,,R,Kris Kobach,28
-Cowley,Liberty,Secretary of State,,R,Kris Kobach,47
-Cowley,Maple,Secretary of State,,R,Kris Kobach,177
-Cowley,Ninnescah,Secretary of State,,R,Kris Kobach,207
-Cowley,Omina,Secretary of State,,R,Kris Kobach,82
-Cowley,Otter,Secretary of State,,R,Kris Kobach,14
-Cowley,Pleas Valley,Secretary of State,,R,Kris Kobach,207
-Cowley,Richland,Secretary of State,,R,Kris Kobach,61
-Cowley,Rock Creek,Secretary of State,,R,Kris Kobach,44
-Cowley,Salem,Secretary of State,,R,Kris Kobach,66
-Cowley,Sheridan,Secretary of State,,R,Kris Kobach,49
-Cowley,Silver Creek,Secretary of State,,R,Kris Kobach,156
-Cowley,Silverdale,Secretary of State,,R,Kris Kobach,82
-Cowley,Spring Ck,Secretary of State,,R,Kris Kobach,24
-Cowley,Tisdale,Secretary of State,,R,Kris Kobach,106
-Cowley,Vernon,Secretary of State,,R,Kris Kobach,124
-Cowley,Walnut,Secretary of State,,R,Kris Kobach,162
-Cowley,Windsor,Secretary of State,,R,Kris Kobach,45
-Cowley,Beaver,Secretary of State,,D,Jean Schodorf,38
-Cowley,Bolton,Secretary of State,,D,Jean Schodorf,148
-Cowley,Cedar,Secretary of State,,D,Jean Schodorf,1
-Cowley,Creswell E,Secretary of State,,D,Jean Schodorf,173
-Cowley,Creswell W,Secretary of State,,D,Jean Schodorf,69
-Cowley,Dexter,Secretary of State,,D,Jean Schodorf,47
-Cowley,Fairview,Secretary of State,,D,Jean Schodorf,40
-Cowley,Grant,Secretary of State,,D,Jean Schodorf,5
-Cowley,Harvey,Secretary of State,,D,Jean Schodorf,12
-Cowley,Liberty,Secretary of State,,D,Jean Schodorf,11
-Cowley,Maple,Secretary of State,,D,Jean Schodorf,83
-Cowley,Ninnescah,Secretary of State,,D,Jean Schodorf,146
-Cowley,Omina,Secretary of State,,D,Jean Schodorf,22
-Cowley,Otter,Secretary of State,,D,Jean Schodorf,2
-Cowley,Pleas Valley,Secretary of State,,D,Jean Schodorf,131
-Cowley,Richland,Secretary of State,,D,Jean Schodorf,32
-Cowley,Rock Creek,Secretary of State,,D,Jean Schodorf,27
-Cowley,Salem,Secretary of State,,D,Jean Schodorf,41
-Cowley,Sheridan,Secretary of State,,D,Jean Schodorf,16
-Cowley,Silver Creek,Secretary of State,,D,Jean Schodorf,67
-Cowley,Silverdale,Secretary of State,,D,Jean Schodorf,41
-Cowley,Spring Ck,Secretary of State,,D,Jean Schodorf,5
-Cowley,Tisdale,Secretary of State,,D,Jean Schodorf,43
-Cowley,Vernon,Secretary of State,,D,Jean Schodorf,66
-Cowley,Walnut,Secretary of State,,D,Jean Schodorf,109
-Cowley,Windsor,Secretary of State,,D,Jean Schodorf,25
-Cowley,Beaver,Attorney General,,R,Derek Schmidt,68
-Cowley,Bolton,Attorney General,,R,Derek Schmidt,373
-Cowley,Cedar,Attorney General,,R,Derek Schmidt,14
-Cowley,Creswell E,Attorney General,,R,Derek Schmidt,370
-Cowley,Creswell W,Attorney General,,R,Derek Schmidt,170
-Cowley,Dexter,Attorney General,,R,Derek Schmidt,139
-Cowley,Fairview,Attorney General,,R,Derek Schmidt,76
-Cowley,Grant,Attorney General,,R,Derek Schmidt,22
-Cowley,Harvey,Attorney General,,R,Derek Schmidt,32
-Cowley,Liberty,Attorney General,,R,Derek Schmidt,49
-Cowley,Maple,Attorney General,,R,Derek Schmidt,204
-Cowley,Ninnescah,Attorney General,,R,Derek Schmidt,259
-Cowley,Omina,Attorney General,,R,Derek Schmidt,90
-Cowley,Otter,Attorney General,,R,Derek Schmidt,15
-Cowley,Pleas Valley,Attorney General,,R,Derek Schmidt,247
-Cowley,Richland,Attorney General,,R,Derek Schmidt,71
-Cowley,Rock Creek,Attorney General,,R,Derek Schmidt,58
-Cowley,Salem,Attorney General,,R,Derek Schmidt,80
-Cowley,Sheridan,Attorney General,,R,Derek Schmidt,52
-Cowley,Silver Creek,Attorney General,,R,Derek Schmidt,181
-Cowley,Silverdale,Attorney General,,R,Derek Schmidt,98
-Cowley,Spring Ck,Attorney General,,R,Derek Schmidt,27
-Cowley,Tisdale,Attorney General,,R,Derek Schmidt,122
-Cowley,Vernon,Attorney General,,R,Derek Schmidt,149
-Cowley,Walnut,Attorney General,,R,Derek Schmidt,215
-Cowley,Windsor,Attorney General,,R,Derek Schmidt,57
-Cowley,Beaver,Attorney General,,D,A J Kotich,24
-Cowley,Bolton,Attorney General,,D,A J Kotich,115
-Cowley,Cedar,Attorney General,,D,A J Kotich,0
-Cowley,Creswell E,Attorney General,,D,A J Kotich,117
-Cowley,Creswell W,Attorney General,,D,A J Kotich,53
-Cowley,Dexter,Attorney General,,D,A J Kotich,20
-Cowley,Fairview,Attorney General,,D,A J Kotich,25
-Cowley,Grant,Attorney General,,D,A J Kotich,5
-Cowley,Harvey,Attorney General,,D,A J Kotich,6
-Cowley,Liberty,Attorney General,,D,A J Kotich,9
-Cowley,Maple,Attorney General,,D,A J Kotich,56
-Cowley,Ninnescah,Attorney General,,D,A J Kotich,89
-Cowley,Omina,Attorney General,,D,A J Kotich,12
-Cowley,Otter,Attorney General,,D,A J Kotich,1
-Cowley,Pleas Valley,Attorney General,,D,A J Kotich,87
-Cowley,Richland,Attorney General,,D,A J Kotich,20
-Cowley,Rock Creek,Attorney General,,D,A J Kotich,14
-Cowley,Salem,Attorney General,,D,A J Kotich,26
-Cowley,Sheridan,Attorney General,,D,A J Kotich,11
-Cowley,Silver Creek,Attorney General,,D,A J Kotich,38
-Cowley,Silverdale,Attorney General,,D,A J Kotich,24
-Cowley,Spring Ck,Attorney General,,D,A J Kotich,2
-Cowley,Tisdale,Attorney General,,D,A J Kotich,27
-Cowley,Vernon,Attorney General,,D,A J Kotich,34
-Cowley,Walnut,Attorney General,,D,A J Kotich,53
-Cowley,Windsor,Attorney General,,D,A J Kotich,12
-Cowley,Beaver,State Treasurer,,R,Ron Estes,68
-Cowley,Bolton,State Treasurer,,R,Ron Estes,374
-Cowley,Cedar,State Treasurer,,R,Ron Estes,13
-Cowley,Creswell E,State Treasurer,,R,Ron Estes,371
-Cowley,Creswell W,State Treasurer,,R,Ron Estes,165
-Cowley,Dexter,State Treasurer,,R,Ron Estes,136
-Cowley,Fairview,State Treasurer,,R,Ron Estes,80
-Cowley,Grant,State Treasurer,,R,Ron Estes,23
-Cowley,Harvey,State Treasurer,,R,Ron Estes,32
-Cowley,Liberty,State Treasurer,,R,Ron Estes,51
-Cowley,Maple,State Treasurer,,R,Ron Estes,202
-Cowley,Ninnescah,State Treasurer,,R,Ron Estes,259
-Cowley,Omina,State Treasurer,,R,Ron Estes,90
-Cowley,Otter,State Treasurer,,R,Ron Estes,14
-Cowley,Pleas Valley,State Treasurer,,R,Ron Estes,249
-Cowley,Richland,State Treasurer,,R,Ron Estes,76
-Cowley,Rock Creek,State Treasurer,,R,Ron Estes,56
-Cowley,Salem,State Treasurer,,R,Ron Estes,87
-Cowley,Sheridan,State Treasurer,,R,Ron Estes,53
-Cowley,Silver Creek,State Treasurer,,R,Ron Estes,177
-Cowley,Silverdale,State Treasurer,,R,Ron Estes,98
-Cowley,Spring Ck,State Treasurer,,R,Ron Estes,25
-Cowley,Tisdale,State Treasurer,,R,Ron Estes,117
-Cowley,Vernon,State Treasurer,,R,Ron Estes,152
-Cowley,Walnut,State Treasurer,,R,Ron Estes,213
-Cowley,Windsor,State Treasurer,,R,Ron Estes,50
-Cowley,Beaver,State Treasurer,,D,Carmen Alldritt,25
-Cowley,Bolton,State Treasurer,,D,Carmen Alldritt,111
-Cowley,Cedar,State Treasurer,,D,Carmen Alldritt,0
-Cowley,Creswell E,State Treasurer,,D,Carmen Alldritt,120
-Cowley,Creswell W,State Treasurer,,D,Carmen Alldritt,58
-Cowley,Dexter,State Treasurer,,D,Carmen Alldritt,20
-Cowley,Fairview,State Treasurer,,D,Carmen Alldritt,24
-Cowley,Grant,State Treasurer,,D,Carmen Alldritt,4
-Cowley,Harvey,State Treasurer,,D,Carmen Alldritt,6
-Cowley,Liberty,State Treasurer,,D,Carmen Alldritt,7
-Cowley,Maple,State Treasurer,,D,Carmen Alldritt,57
-Cowley,Ninnescah,State Treasurer,,D,Carmen Alldritt,87
-Cowley,Omina,State Treasurer,,D,Carmen Alldritt,13
-Cowley,Otter,State Treasurer,,D,Carmen Alldritt,2
-Cowley,Pleas Valley,State Treasurer,,D,Carmen Alldritt,87
-Cowley,Richland,State Treasurer,,D,Carmen Alldritt,17
-Cowley,Rock Creek,State Treasurer,,D,Carmen Alldritt,13
-Cowley,Salem,State Treasurer,,D,Carmen Alldritt,19
-Cowley,Sheridan,State Treasurer,,D,Carmen Alldritt,11
-Cowley,Silver Creek,State Treasurer,,D,Carmen Alldritt,45
-Cowley,Silverdale,State Treasurer,,D,Carmen Alldritt,23
-Cowley,Spring Ck,State Treasurer,,D,Carmen Alldritt,4
-Cowley,Tisdale,State Treasurer,,D,Carmen Alldritt,31
-Cowley,Vernon,State Treasurer,,D,Carmen Alldritt,33
-Cowley,Walnut,State Treasurer,,D,Carmen Alldritt,54
-Cowley,Windsor,State Treasurer,,D,Carmen Alldritt,18
-Cowley,Beaver,Insurance Commissioner,,R,Ken Selzer,60
-Cowley,Bolton,Insurance Commissioner,,R,Ken Selzer,347
-Cowley,Cedar,Insurance Commissioner,,R,Ken Selzer,12
-Cowley,Creswell E,Insurance Commissioner,,R,Ken Selzer,328
-Cowley,Creswell W,Insurance Commissioner,,R,Ken Selzer,155
-Cowley,Dexter,Insurance Commissioner,,R,Ken Selzer,121
-Cowley,Fairview,Insurance Commissioner,,R,Ken Selzer,69
-Cowley,Grant,Insurance Commissioner,,R,Ken Selzer,23
-Cowley,Harvey,Insurance Commissioner,,R,Ken Selzer,30
-Cowley,Liberty,Insurance Commissioner,,R,Ken Selzer,47
-Cowley,Maple,Insurance Commissioner,,R,Ken Selzer,191
-Cowley,Ninnescah,Insurance Commissioner,,R,Ken Selzer,237
-Cowley,Omina,Insurance Commissioner,,R,Ken Selzer,78
-Cowley,Otter,Insurance Commissioner,,R,Ken Selzer,14
-Cowley,Pleas Valley,Insurance Commissioner,,R,Ken Selzer,223
-Cowley,Richland,Insurance Commissioner,,R,Ken Selzer,64
-Cowley,Rock Creek,Insurance Commissioner,,R,Ken Selzer,48
-Cowley,Salem,Insurance Commissioner,,R,Ken Selzer,73
-Cowley,Sheridan,Insurance Commissioner,,R,Ken Selzer,46
-Cowley,Silver Creek,Insurance Commissioner,,R,Ken Selzer,159
-Cowley,Silverdale,Insurance Commissioner,,R,Ken Selzer,88
-Cowley,Spring Ck,Insurance Commissioner,,R,Ken Selzer,22
-Cowley,Tisdale,Insurance Commissioner,,R,Ken Selzer,105
-Cowley,Vernon,Insurance Commissioner,,R,Ken Selzer,131
-Cowley,Walnut,Insurance Commissioner,,R,Ken Selzer,184
-Cowley,Windsor,Insurance Commissioner,,R,Ken Selzer,48
-Cowley,Beaver,Insurance Commissioner,,D,Dennis Anderson,31
-Cowley,Bolton,Insurance Commissioner,,D,Dennis Anderson,136
-Cowley,Cedar,Insurance Commissioner,,D,Dennis Anderson,0
-Cowley,Creswell E,Insurance Commissioner,,D,Dennis Anderson,154
-Cowley,Creswell W,Insurance Commissioner,,D,Dennis Anderson,67
-Cowley,Dexter,Insurance Commissioner,,D,Dennis Anderson,36
-Cowley,Fairview,Insurance Commissioner,,D,Dennis Anderson,30
-Cowley,Grant,Insurance Commissioner,,D,Dennis Anderson,3
-Cowley,Harvey,Insurance Commissioner,,D,Dennis Anderson,9
-Cowley,Liberty,Insurance Commissioner,,D,Dennis Anderson,11
-Cowley,Maple,Insurance Commissioner,,D,Dennis Anderson,67
-Cowley,Ninnescah,Insurance Commissioner,,D,Dennis Anderson,114
-Cowley,Omina,Insurance Commissioner,,D,Dennis Anderson,22
-Cowley,Otter,Insurance Commissioner,,D,Dennis Anderson,2
-Cowley,Pleas Valley,Insurance Commissioner,,D,Dennis Anderson,111
-Cowley,Richland,Insurance Commissioner,,D,Dennis Anderson,28
-Cowley,Rock Creek,Insurance Commissioner,,D,Dennis Anderson,18
-Cowley,Salem,Insurance Commissioner,,D,Dennis Anderson,32
-Cowley,Sheridan,Insurance Commissioner,,D,Dennis Anderson,15
-Cowley,Silver Creek,Insurance Commissioner,,D,Dennis Anderson,54
-Cowley,Silverdale,Insurance Commissioner,,D,Dennis Anderson,31
-Cowley,Spring Ck,Insurance Commissioner,,D,Dennis Anderson,6
-Cowley,Tisdale,Insurance Commissioner,,D,Dennis Anderson,42
-Cowley,Vernon,Insurance Commissioner,,D,Dennis Anderson,50
-Cowley,Walnut,Insurance Commissioner,,D,Dennis Anderson,78
-Cowley,Windsor,Insurance Commissioner,,D,Dennis Anderson,21
-Cowley,Beaver,State House,79,R,Larry Alley,54
-Cowley,Bolton,State House,80,R,Kasha Kelley,392
-Cowley,Cedar,State House,12,R,Virgil Peck,14
-Cowley,Creswell E,State House,80,R,Kasha Kelley,380
-Cowley,Creswell W,State House,80,R,Kasha Kelley,180
-Cowley,Dexter,State House,12,R,Virgil Peck,123
-Cowley,Fairview,State House,79,R,Larry Alley,50
-Cowley,Grant,State House,12,R,Virgil Peck,23
-Cowley,Harvey,State House,12,R,Virgil Peck,29
-Cowley,Liberty,State House,12,R,Virgil Peck,50
-Cowley,Maple,State House,79,R,Larry Alley,183
-Cowley,Ninnescah,State House,79,R,Larry Alley,180
-Cowley,Omina,State House,12,R,Virgil Peck,83
-Cowley,Otter,State House,12,R,Virgil Peck,14
-Cowley,Pleas Valley,State House,79,R,Larry Alley,163
-Cowley,Richland,State House,12,R,Virgil Peck,68
-Cowley,Rock Creek,State House,79,R,Larry Alley,38
-Cowley,Salem,State House,12,R,Virgil Peck,67
-Cowley,Sheridan,State House,12,R,Virgil Peck,48
-Cowley,Silver Creek,State House,12,R,Virgil Peck,165
-Cowley,Silverdale,State House,12,R,Virgil Peck,88
-Cowley,Spring Ck,State House,12,R,Virgil Peck,25
-Cowley,Tisdale,State House,12,R,Virgil Peck,109
-Cowley,Vernon,State House,79,R,Larry Alley,119
-Cowley,Walnut,State House,79,R,Larry Alley,127
-Cowley,Windsor,State House,12,R,Virgil Peck,51
-Cowley,Beaver,State House,79,D,Ed Trimmer,37
-Cowley,Cedar,State House,12,D,Eden Fuson,0
-Cowley,Dexter,State House,12,D,Eden Fuson,35
-Cowley,Fairview,State House,79,D,Ed Trimmer,52
-Cowley,Grant,State House,12,D,Eden Fuson,4
-Cowley,Harvey,State House,12,D,Eden Fuson,10
-Cowley,Liberty,State House,12,D,Eden Fuson,8
-Cowley,Maple,State House,79,D,Ed Trimmer,80
-Cowley,Ninnescah,State House,79,D,Ed Trimmer,175
-Cowley,Omina,State House,12,D,Eden Fuson,20
-Cowley,Otter,State House,12,D,Eden Fuson,2
-Cowley,Pleas Valley,State House,79,D,Ed Trimmer,179
-Cowley,Richland,State House,12,D,Eden Fuson,25
-Cowley,Rock Creek,State House,79,D,Ed Trimmer,35
-Cowley,Salem,State House,12,D,Eden Fuson,36
-Cowley,Sheridan,State House,12,D,Eden Fuson,16
-Cowley,Silver Creek,State House,12,D,Eden Fuson,59
-Cowley,Silverdale,State House,12,D,Eden Fuson,33
-Cowley,Spring Ck,State House,12,D,Eden Fuson,4
-Cowley,Tisdale,State House,12,D,Eden Fuson,38
-Cowley,Vernon,State House,79,D,Ed Trimmer,69
-Cowley,Walnut,State House,79,D,Ed Trimmer,150
-Cowley,Windsor,State House,12,D,Eden Fuson,18
+county,precinct,office,district,party,candidate,votes,vtd
+COWLEY,Arkansas City Ward 1 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,00001A
+COWLEY,Arkansas City Ward 1 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00001A
+COWLEY,Arkansas City Ward 1 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00001C
+COWLEY,Arkansas City Ward 1 B,Governor / Lt. Governor,,Democratic,"Davis, Paul",63,000020
+COWLEY,Arkansas City Ward 1 B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000020
+COWLEY,Arkansas City Ward 1 B,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000020
+COWLEY,Arkansas City Ward 1 C,Governor / Lt. Governor,,Democratic,"Davis, Paul",101,000030
+COWLEY,Arkansas City Ward 1 C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000030
+COWLEY,Arkansas City Ward 1 C,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000030
+COWLEY,Arkansas City Ward 1 D,Governor / Lt. Governor,,Democratic,"Davis, Paul",115,000040
+COWLEY,Arkansas City Ward 1 D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000040
+COWLEY,Arkansas City Ward 1 D,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000040
+COWLEY,Arkansas City Ward 2 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",132,000050
+COWLEY,Arkansas City Ward 2 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000050
+COWLEY,Arkansas City Ward 2 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000050
+COWLEY,Arkansas City Ward 2 B - 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,00006A
+COWLEY,Arkansas City Ward 2 B - 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,00006A
+COWLEY,Arkansas City Ward 2 B - 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,00006B
+COWLEY,Arkansas City Ward 2 B - 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,00006B
+COWLEY,Arkansas City Ward 2 B - 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,00006B
+COWLEY,Arkansas City Ward 2 C,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000070
+COWLEY,Arkansas City Ward 2 C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000070
+COWLEY,Arkansas City Ward 2 C,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000070
+COWLEY,Arkansas City Ward 2 D,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000080
+COWLEY,Arkansas City Ward 2 D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000080
+COWLEY,Arkansas City Ward 2 D,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000080
+COWLEY,Arkansas City Ward 3 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000090
+COWLEY,Arkansas City Ward 3 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000090
+COWLEY,Arkansas City Ward 3 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000090
+COWLEY,Arkansas City Ward 3 B,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,000100
+COWLEY,Arkansas City Ward 3 B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000100
+COWLEY,Arkansas City Ward 3 B,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000100
+COWLEY,Arkansas City Ward 3 C,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000110
+COWLEY,Arkansas City Ward 3 C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000110
+COWLEY,Arkansas City Ward 3 C,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000110
+COWLEY,Arkansas City Ward 4 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000120
+COWLEY,Arkansas City Ward 4 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000120
+COWLEY,Arkansas City Ward 4 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,000120
+COWLEY,Arkansas City Ward 4 B,Governor / Lt. Governor,,Democratic,"Davis, Paul",241,00013A
+COWLEY,Arkansas City Ward 4 B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,00013A
+COWLEY,Arkansas City Ward 4 B,Governor / Lt. Governor,,Republican,"Brownback, Sam",199,00013A
+COWLEY,Arkansas City Ward 4 C,Governor / Lt. Governor,,Democratic,"Davis, Paul",106,000140
+COWLEY,Arkansas City Ward 4 C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000140
+COWLEY,Arkansas City Ward 4 C,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000140
+COWLEY,Arkansas City Ward 4 D,Governor / Lt. Governor,,Democratic,"Davis, Paul",189,000150
+COWLEY,Arkansas City Ward 4 D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",31,000150
+COWLEY,Arkansas City Ward 4 D,Governor / Lt. Governor,,Republican,"Brownback, Sam",157,000150
+COWLEY,Beaver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000170
+COWLEY,Beaver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000170
+COWLEY,Beaver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000170
+COWLEY,Cedar Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000180
+COWLEY,Cedar Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000180
+COWLEY,Cedar Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000180
+COWLEY,Dexter Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000190
+COWLEY,Dexter Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000190
+COWLEY,Dexter Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",110,000190
+COWLEY,East Creswell,Governor / Lt. Governor,,Democratic,"Davis, Paul",209,000210
+COWLEY,East Creswell,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000210
+COWLEY,East Creswell,Governor / Lt. Governor,,Republican,"Brownback, Sam",268,000210
+COWLEY,Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000220
+COWLEY,Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000220
+COWLEY,Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000220
+COWLEY,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000230
+COWLEY,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+COWLEY,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000230
+COWLEY,Harvey Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000240
+COWLEY,Harvey Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000240
+COWLEY,Harvey Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000240
+COWLEY,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000250
+COWLEY,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000250
+COWLEY,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000250
+COWLEY,Maple Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,000260
+COWLEY,Maple Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000260
+COWLEY,Maple Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",149,000260
+COWLEY,Ninnescah Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,000270
+COWLEY,Ninnescah Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000270
+COWLEY,Ninnescah Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",188,000270
+COWLEY,Omnia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000280
+COWLEY,Omnia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000280
+COWLEY,Omnia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000280
+COWLEY,Otter Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000290
+COWLEY,Otter Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000290
+COWLEY,Otter Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000290
+COWLEY,Pleasant Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",152,000300
+COWLEY,Pleasant Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000300
+COWLEY,Pleasant Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",185,000300
+COWLEY,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000310
+COWLEY,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000310
+COWLEY,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000310
+COWLEY,Rock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000320
+COWLEY,Rock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000320
+COWLEY,Rock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000320
+COWLEY,Salem Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000330
+COWLEY,Salem Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000330
+COWLEY,Salem Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000330
+COWLEY,Sheridan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000340
+COWLEY,Sheridan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000340
+COWLEY,Sheridan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000340
+COWLEY,Silver Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",86,000350
+COWLEY,Silver Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000350
+COWLEY,Silver Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000350
+COWLEY,Silverdale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000360
+COWLEY,Silverdale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000360
+COWLEY,Silverdale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000360
+COWLEY,Spring Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000370
+COWLEY,Spring Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000370
+COWLEY,Spring Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000370
+COWLEY,Tisdale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000380
+COWLEY,Tisdale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000380
+COWLEY,Tisdale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,000380
+COWLEY,Vernon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000390
+COWLEY,Vernon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000390
+COWLEY,Vernon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000390
+COWLEY,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",120,000400
+COWLEY,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000400
+COWLEY,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000400
+COWLEY,West Bolton Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00041B
+COWLEY,West Bolton Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00041B
+COWLEY,West Bolton Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00041B
+COWLEY,West Creswell,Governor / Lt. Governor,,Democratic,"Davis, Paul",88,00042A
+COWLEY,West Creswell,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,00042A
+COWLEY,West Creswell,Governor / Lt. Governor,,Republican,"Brownback, Sam",129,00042A
+COWLEY,Windsor Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000430
+COWLEY,Windsor Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000430
+COWLEY,Windsor Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000430
+COWLEY,Winfield Ward 1 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",165,000440
+COWLEY,Winfield Ward 1 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000440
+COWLEY,Winfield Ward 1 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000440
+COWLEY,Winfield Ward 1 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000450
+COWLEY,Winfield Ward 1 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000450
+COWLEY,Winfield Ward 1 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,000450
+COWLEY,Winfield Ward 2 Central,Governor / Lt. Governor,,Democratic,"Davis, Paul",115,000460
+COWLEY,Winfield Ward 2 Central,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000460
+COWLEY,Winfield Ward 2 Central,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,000460
+COWLEY,Winfield Ward 2 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",129,000470
+COWLEY,Winfield Ward 2 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000470
+COWLEY,Winfield Ward 2 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",85,000470
+COWLEY,Winfield Ward 2 South,Governor / Lt. Governor,,Democratic,"Davis, Paul",179,000480
+COWLEY,Winfield Ward 2 South,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000480
+COWLEY,Winfield Ward 2 South,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,000480
+COWLEY,Winfield Ward 2 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",103,000490
+COWLEY,Winfield Ward 2 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000490
+COWLEY,Winfield Ward 2 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",74,000490
+COWLEY,Winfield Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",135,000500
+COWLEY,Winfield Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000500
+COWLEY,Winfield Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",97,000500
+COWLEY,Winfield Ward 3 South,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,00051A
+COWLEY,Winfield Ward 3 South,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00051A
+COWLEY,Winfield Ward 3 South,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,00051A
+COWLEY,Winfield Ward 8,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,00051B
+COWLEY,Winfield Ward 8,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00051B
+COWLEY,Winfield Ward 8,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,00051B
+COWLEY,Winfield Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000520
+COWLEY,Winfield Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000520
+COWLEY,Winfield Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000520
+COWLEY,Winfield Ward 5 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",219,00053A
+COWLEY,Winfield Ward 5 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00053A
+COWLEY,Winfield Ward 5 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00053B
+COWLEY,Winfield Ward 5 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",75,000540
+COWLEY,Winfield Ward 5 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000540
+COWLEY,Winfield Ward 5 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000540
+COWLEY,Winfield Ward 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",185,000550
+COWLEY,Winfield Ward 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000550
+COWLEY,Winfield Ward 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",173,000550
+COWLEY,Winfield Ward 6 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000560
+COWLEY,Winfield Ward 6 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000560
+COWLEY,Winfield Ward 6 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,000560
+COWLEY,Winfield Ward 7,Governor / Lt. Governor,,Democratic,"Davis, Paul",142,000570
+COWLEY,Winfield Ward 7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000570
+COWLEY,Winfield Ward 7,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000570
+COWLEY,Bolton,Governor / Lt. Governor,,Democratic,"Davis, Paul",176,130010
+COWLEY,Bolton,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",32,130010
+COWLEY,Bolton,Governor / Lt. Governor,,Republican,"Brownback, Sam",286,130010
+COWLEY,Arkansas City Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+COWLEY,Arkansas City Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+COWLEY,Arkansas City Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+COWLEY,West Creswell Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+COWLEY,West Creswell Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+COWLEY,West Creswell Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+COWLEY,West Creswell Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+COWLEY,West Creswell Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+COWLEY,West Creswell Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+COWLEY,West Creswell Enclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+COWLEY,West Creswell Enclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+COWLEY,West Creswell Enclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900060
+COWLEY,Winfield Ward 9,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900070
+COWLEY,Winfield Ward 9,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900070
+COWLEY,Winfield Ward 9,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900070
+COWLEY,Arkansas City Ward 1 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",83,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",11,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",1,00001C
+COWLEY,Arkansas City Ward 1 B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",92,000020
+COWLEY,Arkansas City Ward 1 C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",151,000030
+COWLEY,Arkansas City Ward 1 D,Kansas House of Representatives,80,Republican,"Kelley, Kasha",128,000040
+COWLEY,Arkansas City Ward 2 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",203,000050
+COWLEY,Arkansas City Ward 2 B - 1,Kansas House of Representatives,80,Republican,"Kelley, Kasha",65,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Kansas House of Representatives,80,Republican,"Kelley, Kasha",49,00006B
+COWLEY,Arkansas City Ward 2 C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",24,000070
+COWLEY,Arkansas City Ward 2 D,Kansas House of Representatives,80,Republican,"Kelley, Kasha",27,000080
+COWLEY,Arkansas City Ward 3 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",38,000090
+COWLEY,Arkansas City Ward 3 B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",49,000100
+COWLEY,Arkansas City Ward 3 C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",46,000110
+COWLEY,Arkansas City Ward 4 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",154,000120
+COWLEY,Arkansas City Ward 4 B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",341,00013A
+COWLEY,Arkansas City Ward 4 C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",125,000140
+COWLEY,Arkansas City Ward 4 D,Kansas House of Representatives,80,Republican,"Kelley, Kasha",278,000150
+COWLEY,Beaver Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",37,000170
+COWLEY,Beaver Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",54,000170
+COWLEY,Cedar Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,000180
+COWLEY,Cedar Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",14,000180
+COWLEY,Dexter Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",35,000190
+COWLEY,Dexter Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",123,000190
+COWLEY,East Creswell,Kansas House of Representatives,80,Republican,"Kelley, Kasha",380,000210
+COWLEY,Fairview Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",52,000220
+COWLEY,Fairview Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",50,000220
+COWLEY,Grant Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",4,000230
+COWLEY,Grant Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",23,000230
+COWLEY,Harvey Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",10,000240
+COWLEY,Harvey Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",29,000240
+COWLEY,Liberty Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",8,000250
+COWLEY,Liberty Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",50,000250
+COWLEY,Maple Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",80,000260
+COWLEY,Maple Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",183,000260
+COWLEY,Ninnescah Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",175,000270
+COWLEY,Ninnescah Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",180,000270
+COWLEY,Omnia Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",20,000280
+COWLEY,Omnia Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",83,000280
+COWLEY,Otter Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",2,000290
+COWLEY,Otter Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",14,000290
+COWLEY,Pleasant Valley Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",179,000300
+COWLEY,Pleasant Valley Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",163,000300
+COWLEY,Richland Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",25,000310
+COWLEY,Richland Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",68,000310
+COWLEY,Rock Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",35,000320
+COWLEY,Rock Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",38,000320
+COWLEY,Salem Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",36,000330
+COWLEY,Salem Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",67,000330
+COWLEY,Sheridan Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",16,000340
+COWLEY,Sheridan Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",48,000340
+COWLEY,Silver Creek Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",59,000350
+COWLEY,Silver Creek Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",165,000350
+COWLEY,Silverdale Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",33,000360
+COWLEY,Silverdale Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",88,000360
+COWLEY,Spring Creek Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",4,000370
+COWLEY,Spring Creek Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",25,000370
+COWLEY,Tisdale Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",38,000380
+COWLEY,Tisdale Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",109,000380
+COWLEY,Vernon Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",69,000390
+COWLEY,Vernon Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",119,000390
+COWLEY,Walnut Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",150,000400
+COWLEY,Walnut Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",127,000400
+COWLEY,West Bolton Enclave A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,00041B
+COWLEY,West Creswell,Kansas House of Representatives,80,Republican,"Kelley, Kasha",180,00042A
+COWLEY,Windsor Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",18,000430
+COWLEY,Windsor Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",51,000430
+COWLEY,Winfield Ward 1 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",183,000440
+COWLEY,Winfield Ward 1 East,Kansas House of Representatives,79,Republican,"Alley, Larry W.",99,000440
+COWLEY,Winfield Ward 1 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",85,000450
+COWLEY,Winfield Ward 1 West,Kansas House of Representatives,79,Republican,"Alley, Larry W.",68,000450
+COWLEY,Winfield Ward 2 Central,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",113,000460
+COWLEY,Winfield Ward 2 Central,Kansas House of Representatives,79,Republican,"Alley, Larry W.",81,000460
+COWLEY,Winfield Ward 2 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",149,000470
+COWLEY,Winfield Ward 2 East,Kansas House of Representatives,79,Republican,"Alley, Larry W.",74,000470
+COWLEY,Winfield Ward 2 South,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",182,000480
+COWLEY,Winfield Ward 2 South,Kansas House of Representatives,79,Republican,"Alley, Larry W.",145,000480
+COWLEY,Winfield Ward 2 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",120,000490
+COWLEY,Winfield Ward 2 West,Kansas House of Representatives,79,Republican,"Alley, Larry W.",67,000490
+COWLEY,Winfield Ward 3,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",148,000500
+COWLEY,Winfield Ward 3,Kansas House of Representatives,79,Republican,"Alley, Larry W.",102,000500
+COWLEY,Winfield Ward 3 South,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",32,00051A
+COWLEY,Winfield Ward 3 South,Kansas House of Representatives,79,Republican,"Alley, Larry W.",66,00051A
+COWLEY,Winfield Ward 8,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",16,00051B
+COWLEY,Winfield Ward 8,Kansas House of Representatives,79,Republican,"Alley, Larry W.",15,00051B
+COWLEY,Winfield Ward 4,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",40,000520
+COWLEY,Winfield Ward 4,Kansas House of Representatives,79,Republican,"Alley, Larry W.",40,000520
+COWLEY,Winfield Ward 5 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",245,00053A
+COWLEY,Winfield Ward 5 East,Kansas House of Representatives,79,Republican,"Alley, Larry W.",125,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,00053B
+COWLEY,Winfield Ward 5 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",84,000540
+COWLEY,Winfield Ward 5 West,Kansas House of Representatives,79,Republican,"Alley, Larry W.",49,000540
+COWLEY,Winfield Ward 6,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",210,000550
+COWLEY,Winfield Ward 6,Kansas House of Representatives,79,Republican,"Alley, Larry W.",157,000550
+COWLEY,Winfield Ward 6 A,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",75,000560
+COWLEY,Winfield Ward 6 A,Kansas House of Representatives,79,Republican,"Alley, Larry W.",88,000560
+COWLEY,Winfield Ward 7,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",157,000570
+COWLEY,Winfield Ward 7,Kansas House of Representatives,79,Republican,"Alley, Larry W.",99,000570
+COWLEY,Bolton,Kansas House of Representatives,80,Republican,"Kelley, Kasha",392,130010
+COWLEY,Arkansas City Ward 5,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",0,900010
+COWLEY,Arkansas City Ward 5,Kansas House of Representatives,79,Republican,"Alley, Larry W.",0,900010
+COWLEY,West Creswell Enclave A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900020
+COWLEY,West Creswell Enclave B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900030
+COWLEY,West Creswell Enclave C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900060
+COWLEY,Winfield Ward 9,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",0,900070
+COWLEY,Winfield Ward 9,Kansas House of Representatives,79,Republican,"Alley, Larry W.",0,900070
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",61,00001A
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,Republican,"Pompeo, Mike",61,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",12,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,Republican,"Pompeo, Mike",1,00001C
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",42,000020
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,Republican,"Pompeo, Mike",81,000020
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",71,000030
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,Republican,"Pompeo, Mike",126,000030
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",73,000040
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,Republican,"Pompeo, Mike",117,000040
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",83,000050
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,Republican,"Pompeo, Mike",190,000050
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",33,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,Republican,"Pompeo, Mike",49,00006A
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",28,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,Republican,"Pompeo, Mike",44,00006B
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",14,000070
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,Republican,"Pompeo, Mike",15,000070
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,000080
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,Republican,"Pompeo, Mike",17,000080
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",16,000090
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,Republican,"Pompeo, Mike",30,000090
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",31,000100
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,Republican,"Pompeo, Mike",34,000100
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",25,000110
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000110
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",106,000120
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,Republican,"Pompeo, Mike",95,000120
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",195,00013A
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,Republican,"Pompeo, Mike",260,00013A
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",81,000140
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,Republican,"Pompeo, Mike",100,000140
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",144,000150
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,Republican,"Pompeo, Mike",228,000150
+COWLEY,Beaver Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",29,000170
+COWLEY,Beaver Township,United States House of Representatives,4,Republican,"Pompeo, Mike",64,000170
+COWLEY,Cedar Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000180
+COWLEY,Cedar Township,United States House of Representatives,4,Republican,"Pompeo, Mike",14,000180
+COWLEY,Dexter Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",28,000190
+COWLEY,Dexter Township,United States House of Representatives,4,Republican,"Pompeo, Mike",131,000190
+COWLEY,East Creswell,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",154,000210
+COWLEY,East Creswell,United States House of Representatives,4,Republican,"Pompeo, Mike",335,000210
+COWLEY,Fairview Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",29,000220
+COWLEY,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Mike",76,000220
+COWLEY,Grant Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000230
+COWLEY,Grant Township,United States House of Representatives,4,Republican,"Pompeo, Mike",23,000230
+COWLEY,Harvey Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,000240
+COWLEY,Harvey Township,United States House of Representatives,4,Republican,"Pompeo, Mike",31,000240
+COWLEY,Liberty Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,000250
+COWLEY,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Mike",49,000250
+COWLEY,Maple Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",68,000260
+COWLEY,Maple Township,United States House of Representatives,4,Republican,"Pompeo, Mike",194,000260
+COWLEY,Ninnescah Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",101,000270
+COWLEY,Ninnescah Township,United States House of Representatives,4,Republican,"Pompeo, Mike",252,000270
+COWLEY,Omnia Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",22,000280
+COWLEY,Omnia Township,United States House of Representatives,4,Republican,"Pompeo, Mike",82,000280
+COWLEY,Otter Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,000290
+COWLEY,Otter Township,United States House of Representatives,4,Republican,"Pompeo, Mike",15,000290
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",103,000300
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",236,000300
+COWLEY,Richland Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",23,000310
+COWLEY,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",69,000310
+COWLEY,Rock Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",17,000320
+COWLEY,Rock Township,United States House of Representatives,4,Republican,"Pompeo, Mike",54,000320
+COWLEY,Salem Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",23,000330
+COWLEY,Salem Township,United States House of Representatives,4,Republican,"Pompeo, Mike",82,000330
+COWLEY,Sheridan Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",14,000340
+COWLEY,Sheridan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",50,000340
+COWLEY,Silver Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",53,000350
+COWLEY,Silver Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",175,000350
+COWLEY,Silverdale Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",29,000360
+COWLEY,Silverdale Township,United States House of Representatives,4,Republican,"Pompeo, Mike",92,000360
+COWLEY,Spring Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000370
+COWLEY,Spring Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",24,000370
+COWLEY,Tisdale Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",32,000380
+COWLEY,Tisdale Township,United States House of Representatives,4,Republican,"Pompeo, Mike",117,000380
+COWLEY,Vernon Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",49,000390
+COWLEY,Vernon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",140,000390
+COWLEY,Walnut Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",65,000400
+COWLEY,Walnut Township,United States House of Representatives,4,Republican,"Pompeo, Mike",207,000400
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00041B
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00041B
+COWLEY,West Creswell,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",68,00042A
+COWLEY,West Creswell,United States House of Representatives,4,Republican,"Pompeo, Mike",154,00042A
+COWLEY,Windsor Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,000430
+COWLEY,Windsor Township,United States House of Representatives,4,Republican,"Pompeo, Mike",51,000430
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",114,000440
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,Republican,"Pompeo, Mike",162,000440
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",50,000450
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,Republican,"Pompeo, Mike",97,000450
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",75,000460
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,Republican,"Pompeo, Mike",113,000460
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",81,000470
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,Republican,"Pompeo, Mike",138,000470
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",103,000480
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,Republican,"Pompeo, Mike",223,000480
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",68,000490
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,Republican,"Pompeo, Mike",119,000490
+COWLEY,Winfield Ward 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",97,000500
+COWLEY,Winfield Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",148,000500
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",24,00051A
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,Republican,"Pompeo, Mike",73,00051A
+COWLEY,Winfield Ward 8,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",7,00051B
+COWLEY,Winfield Ward 8,United States House of Representatives,4,Republican,"Pompeo, Mike",24,00051B
+COWLEY,Winfield Ward 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",25,000520
+COWLEY,Winfield Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",54,000520
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",163,00053A
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,Republican,"Pompeo, Mike",199,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00053B
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",65,000540
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,Republican,"Pompeo, Mike",68,000540
+COWLEY,Winfield Ward 6,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",123,000550
+COWLEY,Winfield Ward 6,United States House of Representatives,4,Republican,"Pompeo, Mike",237,000550
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",46,000560
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,Republican,"Pompeo, Mike",117,000560
+COWLEY,Winfield Ward 7,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",98,000570
+COWLEY,Winfield Ward 7,United States House of Representatives,4,Republican,"Pompeo, Mike",150,000570
+COWLEY,Bolton,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",143,130010
+COWLEY,Bolton,United States House of Representatives,4,Republican,"Pompeo, Mike",349,130010
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900010
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900010
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900020
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900020
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900030
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900030
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900040
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900060
+COWLEY,Winfield Ward 9,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900070
+COWLEY,Winfield Ward 9,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900070
+COWLEY,Arkansas City Ward 1 A,Attorney General,,Democratic,"Kotich, A.J.",50,00001A
+COWLEY,Arkansas City Ward 1 A,Attorney General,,Republican,"Schmidt, Derek",74,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Attorney General,,Democratic,"Kotich, A.J.",5,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,Attorney General,,Republican,"Schmidt, Derek",11,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,Attorney General,,Republican,"Schmidt, Derek",1,00001C
+COWLEY,Arkansas City Ward 1 B,Attorney General,,Democratic,"Kotich, A.J.",31,000020
+COWLEY,Arkansas City Ward 1 B,Attorney General,,Republican,"Schmidt, Derek",87,000020
+COWLEY,Arkansas City Ward 1 C,Attorney General,,Democratic,"Kotich, A.J.",60,000030
+COWLEY,Arkansas City Ward 1 C,Attorney General,,Republican,"Schmidt, Derek",138,000030
+COWLEY,Arkansas City Ward 1 D,Attorney General,,Democratic,"Kotich, A.J.",63,000040
+COWLEY,Arkansas City Ward 1 D,Attorney General,,Republican,"Schmidt, Derek",123,000040
+COWLEY,Arkansas City Ward 2 A,Attorney General,,Democratic,"Kotich, A.J.",78,000050
+COWLEY,Arkansas City Ward 2 A,Attorney General,,Republican,"Schmidt, Derek",192,000050
+COWLEY,Arkansas City Ward 2 B - 1,Attorney General,,Democratic,"Kotich, A.J.",22,00006A
+COWLEY,Arkansas City Ward 2 B - 1,Attorney General,,Republican,"Schmidt, Derek",60,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Attorney General,,Democratic,"Kotich, A.J.",23,00006B
+COWLEY,Arkansas City Ward 2 B - 2,Attorney General,,Republican,"Schmidt, Derek",48,00006B
+COWLEY,Arkansas City Ward 2 C,Attorney General,,Democratic,"Kotich, A.J.",11,000070
+COWLEY,Arkansas City Ward 2 C,Attorney General,,Republican,"Schmidt, Derek",18,000070
+COWLEY,Arkansas City Ward 2 D,Attorney General,,Democratic,"Kotich, A.J.",20,000080
+COWLEY,Arkansas City Ward 2 D,Attorney General,,Republican,"Schmidt, Derek",17,000080
+COWLEY,Arkansas City Ward 3 A,Attorney General,,Democratic,"Kotich, A.J.",11,000090
+COWLEY,Arkansas City Ward 3 A,Attorney General,,Republican,"Schmidt, Derek",34,000090
+COWLEY,Arkansas City Ward 3 B,Attorney General,,Democratic,"Kotich, A.J.",20,000100
+COWLEY,Arkansas City Ward 3 B,Attorney General,,Republican,"Schmidt, Derek",45,000100
+COWLEY,Arkansas City Ward 3 C,Attorney General,,Democratic,"Kotich, A.J.",26,000110
+COWLEY,Arkansas City Ward 3 C,Attorney General,,Republican,"Schmidt, Derek",37,000110
+COWLEY,Arkansas City Ward 4 A,Attorney General,,Democratic,"Kotich, A.J.",82,000120
+COWLEY,Arkansas City Ward 4 A,Attorney General,,Republican,"Schmidt, Derek",122,000120
+COWLEY,Arkansas City Ward 4 B,Attorney General,,Democratic,"Kotich, A.J.",170,00013A
+COWLEY,Arkansas City Ward 4 B,Attorney General,,Republican,"Schmidt, Derek",284,00013A
+COWLEY,Arkansas City Ward 4 C,Attorney General,,Democratic,"Kotich, A.J.",71,000140
+COWLEY,Arkansas City Ward 4 C,Attorney General,,Republican,"Schmidt, Derek",112,000140
+COWLEY,Arkansas City Ward 4 D,Attorney General,,Democratic,"Kotich, A.J.",131,000150
+COWLEY,Arkansas City Ward 4 D,Attorney General,,Republican,"Schmidt, Derek",236,000150
+COWLEY,Beaver Township,Attorney General,,Democratic,"Kotich, A.J.",24,000170
+COWLEY,Beaver Township,Attorney General,,Republican,"Schmidt, Derek",68,000170
+COWLEY,Cedar Township,Attorney General,,Democratic,"Kotich, A.J.",0,000180
+COWLEY,Cedar Township,Attorney General,,Republican,"Schmidt, Derek",14,000180
+COWLEY,Dexter Township,Attorney General,,Democratic,"Kotich, A.J.",20,000190
+COWLEY,Dexter Township,Attorney General,,Republican,"Schmidt, Derek",139,000190
+COWLEY,East Creswell,Attorney General,,Democratic,"Kotich, A.J.",117,000210
+COWLEY,East Creswell,Attorney General,,Republican,"Schmidt, Derek",370,000210
+COWLEY,Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",25,000220
+COWLEY,Fairview Township,Attorney General,,Republican,"Schmidt, Derek",76,000220
+COWLEY,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",5,000230
+COWLEY,Grant Township,Attorney General,,Republican,"Schmidt, Derek",22,000230
+COWLEY,Harvey Township,Attorney General,,Democratic,"Kotich, A.J.",6,000240
+COWLEY,Harvey Township,Attorney General,,Republican,"Schmidt, Derek",32,000240
+COWLEY,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",9,000250
+COWLEY,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",49,000250
+COWLEY,Maple Township,Attorney General,,Democratic,"Kotich, A.J.",56,000260
+COWLEY,Maple Township,Attorney General,,Republican,"Schmidt, Derek",204,000260
+COWLEY,Ninnescah Township,Attorney General,,Democratic,"Kotich, A.J.",89,000270
+COWLEY,Ninnescah Township,Attorney General,,Republican,"Schmidt, Derek",259,000270
+COWLEY,Omnia Township,Attorney General,,Democratic,"Kotich, A.J.",12,000280
+COWLEY,Omnia Township,Attorney General,,Republican,"Schmidt, Derek",90,000280
+COWLEY,Otter Township,Attorney General,,Democratic,"Kotich, A.J.",1,000290
+COWLEY,Otter Township,Attorney General,,Republican,"Schmidt, Derek",15,000290
+COWLEY,Pleasant Valley Township,Attorney General,,Democratic,"Kotich, A.J.",87,000300
+COWLEY,Pleasant Valley Township,Attorney General,,Republican,"Schmidt, Derek",247,000300
+COWLEY,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",20,000310
+COWLEY,Richland Township,Attorney General,,Republican,"Schmidt, Derek",71,000310
+COWLEY,Rock Township,Attorney General,,Democratic,"Kotich, A.J.",14,000320
+COWLEY,Rock Township,Attorney General,,Republican,"Schmidt, Derek",58,000320
+COWLEY,Salem Township,Attorney General,,Democratic,"Kotich, A.J.",26,000330
+COWLEY,Salem Township,Attorney General,,Republican,"Schmidt, Derek",80,000330
+COWLEY,Sheridan Township,Attorney General,,Democratic,"Kotich, A.J.",11,000340
+COWLEY,Sheridan Township,Attorney General,,Republican,"Schmidt, Derek",52,000340
+COWLEY,Silver Creek Township,Attorney General,,Democratic,"Kotich, A.J.",38,000350
+COWLEY,Silver Creek Township,Attorney General,,Republican,"Schmidt, Derek",181,000350
+COWLEY,Silverdale Township,Attorney General,,Democratic,"Kotich, A.J.",24,000360
+COWLEY,Silverdale Township,Attorney General,,Republican,"Schmidt, Derek",98,000360
+COWLEY,Spring Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000370
+COWLEY,Spring Creek Township,Attorney General,,Republican,"Schmidt, Derek",27,000370
+COWLEY,Tisdale Township,Attorney General,,Democratic,"Kotich, A.J.",27,000380
+COWLEY,Tisdale Township,Attorney General,,Republican,"Schmidt, Derek",122,000380
+COWLEY,Vernon Township,Attorney General,,Democratic,"Kotich, A.J.",34,000390
+COWLEY,Vernon Township,Attorney General,,Republican,"Schmidt, Derek",149,000390
+COWLEY,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",53,000400
+COWLEY,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",215,000400
+COWLEY,West Bolton Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00041B
+COWLEY,West Bolton Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,00041B
+COWLEY,West Creswell,Attorney General,,Democratic,"Kotich, A.J.",53,00042A
+COWLEY,West Creswell,Attorney General,,Republican,"Schmidt, Derek",170,00042A
+COWLEY,Windsor Township,Attorney General,,Democratic,"Kotich, A.J.",12,000430
+COWLEY,Windsor Township,Attorney General,,Republican,"Schmidt, Derek",57,000430
+COWLEY,Winfield Ward 1 East,Attorney General,,Democratic,"Kotich, A.J.",96,000440
+COWLEY,Winfield Ward 1 East,Attorney General,,Republican,"Schmidt, Derek",177,000440
+COWLEY,Winfield Ward 1 West,Attorney General,,Democratic,"Kotich, A.J.",46,000450
+COWLEY,Winfield Ward 1 West,Attorney General,,Republican,"Schmidt, Derek",100,000450
+COWLEY,Winfield Ward 2 Central,Attorney General,,Democratic,"Kotich, A.J.",66,000460
+COWLEY,Winfield Ward 2 Central,Attorney General,,Republican,"Schmidt, Derek",113,000460
+COWLEY,Winfield Ward 2 East,Attorney General,,Democratic,"Kotich, A.J.",75,000470
+COWLEY,Winfield Ward 2 East,Attorney General,,Republican,"Schmidt, Derek",141,000470
+COWLEY,Winfield Ward 2 South,Attorney General,,Democratic,"Kotich, A.J.",82,000480
+COWLEY,Winfield Ward 2 South,Attorney General,,Republican,"Schmidt, Derek",241,000480
+COWLEY,Winfield Ward 2 West,Attorney General,,Democratic,"Kotich, A.J.",57,000490
+COWLEY,Winfield Ward 2 West,Attorney General,,Republican,"Schmidt, Derek",130,000490
+COWLEY,Winfield Ward 3,Attorney General,,Democratic,"Kotich, A.J.",82,000500
+COWLEY,Winfield Ward 3,Attorney General,,Republican,"Schmidt, Derek",160,000500
+COWLEY,Winfield Ward 3 South,Attorney General,,Democratic,"Kotich, A.J.",15,00051A
+COWLEY,Winfield Ward 3 South,Attorney General,,Republican,"Schmidt, Derek",81,00051A
+COWLEY,Winfield Ward 8,Attorney General,,Democratic,"Kotich, A.J.",7,00051B
+COWLEY,Winfield Ward 8,Attorney General,,Republican,"Schmidt, Derek",25,00051B
+COWLEY,Winfield Ward 4,Attorney General,,Democratic,"Kotich, A.J.",18,000520
+COWLEY,Winfield Ward 4,Attorney General,,Republican,"Schmidt, Derek",62,000520
+COWLEY,Winfield Ward 5 East,Attorney General,,Democratic,"Kotich, A.J.",144,00053A
+COWLEY,Winfield Ward 5 East,Attorney General,,Republican,"Schmidt, Derek",209,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Attorney General,,Democratic,"Kotich, A.J.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Attorney General,,Republican,"Schmidt, Derek",0,00053B
+COWLEY,Winfield Ward 5 West,Attorney General,,Democratic,"Kotich, A.J.",55,000540
+COWLEY,Winfield Ward 5 West,Attorney General,,Republican,"Schmidt, Derek",75,000540
+COWLEY,Winfield Ward 6,Attorney General,,Democratic,"Kotich, A.J.",102,000550
+COWLEY,Winfield Ward 6,Attorney General,,Republican,"Schmidt, Derek",260,000550
+COWLEY,Winfield Ward 6 A,Attorney General,,Democratic,"Kotich, A.J.",36,000560
+COWLEY,Winfield Ward 6 A,Attorney General,,Republican,"Schmidt, Derek",126,000560
+COWLEY,Winfield Ward 7,Attorney General,,Democratic,"Kotich, A.J.",80,000570
+COWLEY,Winfield Ward 7,Attorney General,,Republican,"Schmidt, Derek",167,000570
+COWLEY,Bolton,Attorney General,,Democratic,"Kotich, A.J.",115,130010
+COWLEY,Bolton,Attorney General,,Republican,"Schmidt, Derek",373,130010
+COWLEY,Arkansas City Ward 5,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+COWLEY,Arkansas City Ward 5,Attorney General,,Republican,"Schmidt, Derek",0,900010
+COWLEY,West Creswell Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+COWLEY,West Creswell Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,900020
+COWLEY,West Creswell Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+COWLEY,West Creswell Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,900030
+COWLEY,West Creswell Enclave C,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+COWLEY,West Creswell Enclave C,Attorney General,,Republican,"Schmidt, Derek",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,900060
+COWLEY,Winfield Ward 9,Attorney General,,Democratic,"Kotich, A.J.",0,900070
+COWLEY,Winfield Ward 9,Attorney General,,Republican,"Schmidt, Derek",0,900070
+COWLEY,Arkansas City Ward 1 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,00001A
+COWLEY,Arkansas City Ward 1 A,Commissioner of Insurance,,Republican,"Selzer, Ken",62,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",11,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",1,00001C
+COWLEY,Arkansas City Ward 1 B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000020
+COWLEY,Arkansas City Ward 1 B,Commissioner of Insurance,,Republican,"Selzer, Ken",74,000020
+COWLEY,Arkansas City Ward 1 C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000030
+COWLEY,Arkansas City Ward 1 C,Commissioner of Insurance,,Republican,"Selzer, Ken",119,000030
+COWLEY,Arkansas City Ward 1 D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000040
+COWLEY,Arkansas City Ward 1 D,Commissioner of Insurance,,Republican,"Selzer, Ken",106,000040
+COWLEY,Arkansas City Ward 2 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",88,000050
+COWLEY,Arkansas City Ward 2 A,Commissioner of Insurance,,Republican,"Selzer, Ken",182,000050
+COWLEY,Arkansas City Ward 2 B - 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,00006A
+COWLEY,Arkansas City Ward 2 B - 1,Commissioner of Insurance,,Republican,"Selzer, Ken",58,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,00006B
+COWLEY,Arkansas City Ward 2 B - 2,Commissioner of Insurance,,Republican,"Selzer, Ken",42,00006B
+COWLEY,Arkansas City Ward 2 C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000070
+COWLEY,Arkansas City Ward 2 C,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000070
+COWLEY,Arkansas City Ward 2 D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000080
+COWLEY,Arkansas City Ward 2 D,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000080
+COWLEY,Arkansas City Ward 3 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000090
+COWLEY,Arkansas City Ward 3 A,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000090
+COWLEY,Arkansas City Ward 3 B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000100
+COWLEY,Arkansas City Ward 3 B,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000100
+COWLEY,Arkansas City Ward 3 C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000110
+COWLEY,Arkansas City Ward 3 C,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000110
+COWLEY,Arkansas City Ward 4 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",101,000120
+COWLEY,Arkansas City Ward 4 A,Commissioner of Insurance,,Republican,"Selzer, Ken",102,000120
+COWLEY,Arkansas City Ward 4 B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",197,00013A
+COWLEY,Arkansas City Ward 4 B,Commissioner of Insurance,,Republican,"Selzer, Ken",250,00013A
+COWLEY,Arkansas City Ward 4 C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",82,000140
+COWLEY,Arkansas City Ward 4 C,Commissioner of Insurance,,Republican,"Selzer, Ken",95,000140
+COWLEY,Arkansas City Ward 4 D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",147,000150
+COWLEY,Arkansas City Ward 4 D,Commissioner of Insurance,,Republican,"Selzer, Ken",218,000150
+COWLEY,Beaver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000170
+COWLEY,Beaver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",60,000170
+COWLEY,Cedar Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000180
+COWLEY,Cedar Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000180
+COWLEY,Dexter Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000190
+COWLEY,Dexter Township,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000190
+COWLEY,East Creswell,Commissioner of Insurance,,Democratic,"Anderson, Dennis",154,000210
+COWLEY,East Creswell,Commissioner of Insurance,,Republican,"Selzer, Ken",328,000210
+COWLEY,Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000220
+COWLEY,Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",69,000220
+COWLEY,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000230
+COWLEY,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000230
+COWLEY,Harvey Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000240
+COWLEY,Harvey Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000240
+COWLEY,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000250
+COWLEY,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000250
+COWLEY,Maple Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,000260
+COWLEY,Maple Township,Commissioner of Insurance,,Republican,"Selzer, Ken",191,000260
+COWLEY,Ninnescah Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",114,000270
+COWLEY,Ninnescah Township,Commissioner of Insurance,,Republican,"Selzer, Ken",237,000270
+COWLEY,Omnia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000280
+COWLEY,Omnia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",78,000280
+COWLEY,Otter Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000290
+COWLEY,Otter Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000290
+COWLEY,Pleasant Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",111,000300
+COWLEY,Pleasant Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",223,000300
+COWLEY,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000310
+COWLEY,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",64,000310
+COWLEY,Rock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000320
+COWLEY,Rock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000320
+COWLEY,Salem Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,000330
+COWLEY,Salem Township,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000330
+COWLEY,Sheridan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000340
+COWLEY,Sheridan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000340
+COWLEY,Silver Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000350
+COWLEY,Silver Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",159,000350
+COWLEY,Silverdale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000360
+COWLEY,Silverdale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",88,000360
+COWLEY,Spring Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000370
+COWLEY,Spring Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000370
+COWLEY,Tisdale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000380
+COWLEY,Tisdale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",105,000380
+COWLEY,Vernon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000390
+COWLEY,Vernon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",131,000390
+COWLEY,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",78,000400
+COWLEY,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",184,000400
+COWLEY,West Bolton Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00041B
+COWLEY,West Bolton Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00041B
+COWLEY,West Creswell,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,00042A
+COWLEY,West Creswell,Commissioner of Insurance,,Republican,"Selzer, Ken",155,00042A
+COWLEY,Windsor Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000430
+COWLEY,Windsor Township,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000430
+COWLEY,Winfield Ward 1 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",122,000440
+COWLEY,Winfield Ward 1 East,Commissioner of Insurance,,Republican,"Selzer, Ken",145,000440
+COWLEY,Winfield Ward 1 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000450
+COWLEY,Winfield Ward 1 West,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000450
+COWLEY,Winfield Ward 2 Central,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000460
+COWLEY,Winfield Ward 2 Central,Commissioner of Insurance,,Republican,"Selzer, Ken",99,000460
+COWLEY,Winfield Ward 2 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,000470
+COWLEY,Winfield Ward 2 East,Commissioner of Insurance,,Republican,"Selzer, Ken",117,000470
+COWLEY,Winfield Ward 2 South,Commissioner of Insurance,,Democratic,"Anderson, Dennis",126,000480
+COWLEY,Winfield Ward 2 South,Commissioner of Insurance,,Republican,"Selzer, Ken",196,000480
+COWLEY,Winfield Ward 2 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,000490
+COWLEY,Winfield Ward 2 West,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000490
+COWLEY,Winfield Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",111,000500
+COWLEY,Winfield Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000500
+COWLEY,Winfield Ward 3 South,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,00051A
+COWLEY,Winfield Ward 3 South,Commissioner of Insurance,,Republican,"Selzer, Ken",73,00051A
+COWLEY,Winfield Ward 8,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,00051B
+COWLEY,Winfield Ward 8,Commissioner of Insurance,,Republican,"Selzer, Ken",24,00051B
+COWLEY,Winfield Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000520
+COWLEY,Winfield Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000520
+COWLEY,Winfield Ward 5 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",186,00053A
+COWLEY,Winfield Ward 5 East,Commissioner of Insurance,,Republican,"Selzer, Ken",168,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00053B
+COWLEY,Winfield Ward 5 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",74,000540
+COWLEY,Winfield Ward 5 West,Commissioner of Insurance,,Republican,"Selzer, Ken",56,000540
+COWLEY,Winfield Ward 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",137,000550
+COWLEY,Winfield Ward 6,Commissioner of Insurance,,Republican,"Selzer, Ken",218,000550
+COWLEY,Winfield Ward 6 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000560
+COWLEY,Winfield Ward 6 A,Commissioner of Insurance,,Republican,"Selzer, Ken",114,000560
+COWLEY,Winfield Ward 7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",99,000570
+COWLEY,Winfield Ward 7,Commissioner of Insurance,,Republican,"Selzer, Ken",140,000570
+COWLEY,Bolton,Commissioner of Insurance,,Democratic,"Anderson, Dennis",136,130010
+COWLEY,Bolton,Commissioner of Insurance,,Republican,"Selzer, Ken",347,130010
+COWLEY,Arkansas City Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+COWLEY,Arkansas City Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+COWLEY,West Creswell Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+COWLEY,West Creswell Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+COWLEY,West Creswell Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+COWLEY,West Creswell Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+COWLEY,West Creswell Enclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+COWLEY,West Creswell Enclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900060
+COWLEY,Winfield Ward 9,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900070
+COWLEY,Winfield Ward 9,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900070
+COWLEY,Arkansas City Ward 1 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",64,00001A
+COWLEY,Arkansas City Ward 1 A,Secretary of State,,Republican,"Kobach, Kris",61,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,Secretary of State,,Republican,"Kobach, Kris",13,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,Secretary of State,,Republican,"Kobach, Kris",1,00001C
+COWLEY,Arkansas City Ward 1 B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000020
+COWLEY,Arkansas City Ward 1 B,Secretary of State,,Republican,"Kobach, Kris",77,000020
+COWLEY,Arkansas City Ward 1 C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",87,000030
+COWLEY,Arkansas City Ward 1 C,Secretary of State,,Republican,"Kobach, Kris",113,000030
+COWLEY,Arkansas City Ward 1 D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,000040
+COWLEY,Arkansas City Ward 1 D,Secretary of State,,Republican,"Kobach, Kris",100,000040
+COWLEY,Arkansas City Ward 2 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",121,000050
+COWLEY,Arkansas City Ward 2 A,Secretary of State,,Republican,"Kobach, Kris",153,000050
+COWLEY,Arkansas City Ward 2 B - 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,00006A
+COWLEY,Arkansas City Ward 2 B - 1,Secretary of State,,Republican,"Kobach, Kris",52,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,00006B
+COWLEY,Arkansas City Ward 2 B - 2,Secretary of State,,Republican,"Kobach, Kris",44,00006B
+COWLEY,Arkansas City Ward 2 C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000070
+COWLEY,Arkansas City Ward 2 C,Secretary of State,,Republican,"Kobach, Kris",12,000070
+COWLEY,Arkansas City Ward 2 D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000080
+COWLEY,Arkansas City Ward 2 D,Secretary of State,,Republican,"Kobach, Kris",16,000080
+COWLEY,Arkansas City Ward 3 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000090
+COWLEY,Arkansas City Ward 3 A,Secretary of State,,Republican,"Kobach, Kris",29,000090
+COWLEY,Arkansas City Ward 3 B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000100
+COWLEY,Arkansas City Ward 3 B,Secretary of State,,Republican,"Kobach, Kris",33,000100
+COWLEY,Arkansas City Ward 3 C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000110
+COWLEY,Arkansas City Ward 3 C,Secretary of State,,Republican,"Kobach, Kris",40,000110
+COWLEY,Arkansas City Ward 4 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",104,000120
+COWLEY,Arkansas City Ward 4 A,Secretary of State,,Republican,"Kobach, Kris",100,000120
+COWLEY,Arkansas City Ward 4 B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",220,00013A
+COWLEY,Arkansas City Ward 4 B,Secretary of State,,Republican,"Kobach, Kris",240,00013A
+COWLEY,Arkansas City Ward 4 C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,000140
+COWLEY,Arkansas City Ward 4 C,Secretary of State,,Republican,"Kobach, Kris",95,000140
+COWLEY,Arkansas City Ward 4 D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",175,000150
+COWLEY,Arkansas City Ward 4 D,Secretary of State,,Republican,"Kobach, Kris",194,000150
+COWLEY,Beaver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000170
+COWLEY,Beaver Township,Secretary of State,,Republican,"Kobach, Kris",56,000170
+COWLEY,Cedar Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000180
+COWLEY,Cedar Township,Secretary of State,,Republican,"Kobach, Kris",12,000180
+COWLEY,Dexter Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000190
+COWLEY,Dexter Township,Secretary of State,,Republican,"Kobach, Kris",113,000190
+COWLEY,East Creswell,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",173,000210
+COWLEY,East Creswell,Secretary of State,,Republican,"Kobach, Kris",317,000210
+COWLEY,Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000220
+COWLEY,Fairview Township,Secretary of State,,Republican,"Kobach, Kris",63,000220
+COWLEY,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000230
+COWLEY,Grant Township,Secretary of State,,Republican,"Kobach, Kris",22,000230
+COWLEY,Harvey Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000240
+COWLEY,Harvey Township,Secretary of State,,Republican,"Kobach, Kris",28,000240
+COWLEY,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000250
+COWLEY,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",47,000250
+COWLEY,Maple Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",83,000260
+COWLEY,Maple Township,Secretary of State,,Republican,"Kobach, Kris",177,000260
+COWLEY,Ninnescah Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,000270
+COWLEY,Ninnescah Township,Secretary of State,,Republican,"Kobach, Kris",207,000270
+COWLEY,Omnia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000280
+COWLEY,Omnia Township,Secretary of State,,Republican,"Kobach, Kris",82,000280
+COWLEY,Otter Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000290
+COWLEY,Otter Township,Secretary of State,,Republican,"Kobach, Kris",14,000290
+COWLEY,Pleasant Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",131,000300
+COWLEY,Pleasant Valley Township,Secretary of State,,Republican,"Kobach, Kris",207,000300
+COWLEY,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",32,000310
+COWLEY,Richland Township,Secretary of State,,Republican,"Kobach, Kris",61,000310
+COWLEY,Rock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000320
+COWLEY,Rock Township,Secretary of State,,Republican,"Kobach, Kris",44,000320
+COWLEY,Salem Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000330
+COWLEY,Salem Township,Secretary of State,,Republican,"Kobach, Kris",66,000330
+COWLEY,Sheridan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000340
+COWLEY,Sheridan Township,Secretary of State,,Republican,"Kobach, Kris",49,000340
+COWLEY,Silver Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000350
+COWLEY,Silver Creek Township,Secretary of State,,Republican,"Kobach, Kris",156,000350
+COWLEY,Silverdale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000360
+COWLEY,Silverdale Township,Secretary of State,,Republican,"Kobach, Kris",82,000360
+COWLEY,Spring Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000370
+COWLEY,Spring Creek Township,Secretary of State,,Republican,"Kobach, Kris",24,000370
+COWLEY,Tisdale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000380
+COWLEY,Tisdale Township,Secretary of State,,Republican,"Kobach, Kris",106,000380
+COWLEY,Vernon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,000390
+COWLEY,Vernon Township,Secretary of State,,Republican,"Kobach, Kris",124,000390
+COWLEY,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",109,000400
+COWLEY,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",162,000400
+COWLEY,West Bolton Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00041B
+COWLEY,West Bolton Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,00041B
+COWLEY,West Creswell,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",69,00042A
+COWLEY,West Creswell,Secretary of State,,Republican,"Kobach, Kris",159,00042A
+COWLEY,Windsor Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000430
+COWLEY,Windsor Township,Secretary of State,,Republican,"Kobach, Kris",45,000430
+COWLEY,Winfield Ward 1 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",159,000440
+COWLEY,Winfield Ward 1 East,Secretary of State,,Republican,"Kobach, Kris",120,000440
+COWLEY,Winfield Ward 1 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,000450
+COWLEY,Winfield Ward 1 West,Secretary of State,,Republican,"Kobach, Kris",77,000450
+COWLEY,Winfield Ward 2 Central,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",95,000460
+COWLEY,Winfield Ward 2 Central,Secretary of State,,Republican,"Kobach, Kris",91,000460
+COWLEY,Winfield Ward 2 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",106,000470
+COWLEY,Winfield Ward 2 East,Secretary of State,,Republican,"Kobach, Kris",113,000470
+COWLEY,Winfield Ward 2 South,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",152,000480
+COWLEY,Winfield Ward 2 South,Secretary of State,,Republican,"Kobach, Kris",174,000480
+COWLEY,Winfield Ward 2 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000490
+COWLEY,Winfield Ward 2 West,Secretary of State,,Republican,"Kobach, Kris",92,000490
+COWLEY,Winfield Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",117,000500
+COWLEY,Winfield Ward 3,Secretary of State,,Republican,"Kobach, Kris",131,000500
+COWLEY,Winfield Ward 3 South,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,00051A
+COWLEY,Winfield Ward 3 South,Secretary of State,,Republican,"Kobach, Kris",64,00051A
+COWLEY,Winfield Ward 8,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,00051B
+COWLEY,Winfield Ward 8,Secretary of State,,Republican,"Kobach, Kris",16,00051B
+COWLEY,Winfield Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000520
+COWLEY,Winfield Ward 4,Secretary of State,,Republican,"Kobach, Kris",44,000520
+COWLEY,Winfield Ward 5 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",197,00053A
+COWLEY,Winfield Ward 5 East,Secretary of State,,Republican,"Kobach, Kris",164,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Secretary of State,,Republican,"Kobach, Kris",0,00053B
+COWLEY,Winfield Ward 5 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,000540
+COWLEY,Winfield Ward 5 West,Secretary of State,,Republican,"Kobach, Kris",61,000540
+COWLEY,Winfield Ward 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",166,000550
+COWLEY,Winfield Ward 6,Secretary of State,,Republican,"Kobach, Kris",199,000550
+COWLEY,Winfield Ward 6 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000560
+COWLEY,Winfield Ward 6 A,Secretary of State,,Republican,"Kobach, Kris",102,000560
+COWLEY,Winfield Ward 7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",123,000570
+COWLEY,Winfield Ward 7,Secretary of State,,Republican,"Kobach, Kris",128,000570
+COWLEY,Bolton,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",148,130010
+COWLEY,Bolton,Secretary of State,,Republican,"Kobach, Kris",343,130010
+COWLEY,Arkansas City Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+COWLEY,Arkansas City Ward 5,Secretary of State,,Republican,"Kobach, Kris",0,900010
+COWLEY,West Creswell Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+COWLEY,West Creswell Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,900020
+COWLEY,West Creswell Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+COWLEY,West Creswell Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,900030
+COWLEY,West Creswell Enclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+COWLEY,West Creswell Enclave C,Secretary of State,,Republican,"Kobach, Kris",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,900060
+COWLEY,Winfield Ward 9,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900070
+COWLEY,Winfield Ward 9,Secretary of State,,Republican,"Kobach, Kris",0,900070
+COWLEY,Arkansas City Ward 1 A,State Treasurer,,Democratic,"Alldritt, Carmen",52,00001A
+COWLEY,Arkansas City Ward 1 A,State Treasurer,,Republican,"Estes, Ron",69,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",3,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,State Treasurer,,Republican,"Estes, Ron",13,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,State Treasurer,,Republican,"Estes, Ron",1,00001C
+COWLEY,Arkansas City Ward 1 B,State Treasurer,,Democratic,"Alldritt, Carmen",37,000020
+COWLEY,Arkansas City Ward 1 B,State Treasurer,,Republican,"Estes, Ron",83,000020
+COWLEY,Arkansas City Ward 1 C,State Treasurer,,Democratic,"Alldritt, Carmen",59,000030
+COWLEY,Arkansas City Ward 1 C,State Treasurer,,Republican,"Estes, Ron",139,000030
+COWLEY,Arkansas City Ward 1 D,State Treasurer,,Democratic,"Alldritt, Carmen",64,000040
+COWLEY,Arkansas City Ward 1 D,State Treasurer,,Republican,"Estes, Ron",124,000040
+COWLEY,Arkansas City Ward 2 A,State Treasurer,,Democratic,"Alldritt, Carmen",74,000050
+COWLEY,Arkansas City Ward 2 A,State Treasurer,,Republican,"Estes, Ron",197,000050
+COWLEY,Arkansas City Ward 2 B - 1,State Treasurer,,Democratic,"Alldritt, Carmen",26,00006A
+COWLEY,Arkansas City Ward 2 B - 1,State Treasurer,,Republican,"Estes, Ron",58,00006A
+COWLEY,Arkansas City Ward 2 B - 2,State Treasurer,,Democratic,"Alldritt, Carmen",26,00006B
+COWLEY,Arkansas City Ward 2 B - 2,State Treasurer,,Republican,"Estes, Ron",44,00006B
+COWLEY,Arkansas City Ward 2 C,State Treasurer,,Democratic,"Alldritt, Carmen",9,000070
+COWLEY,Arkansas City Ward 2 C,State Treasurer,,Republican,"Estes, Ron",20,000070
+COWLEY,Arkansas City Ward 2 D,State Treasurer,,Democratic,"Alldritt, Carmen",16,000080
+COWLEY,Arkansas City Ward 2 D,State Treasurer,,Republican,"Estes, Ron",20,000080
+COWLEY,Arkansas City Ward 3 A,State Treasurer,,Democratic,"Alldritt, Carmen",14,000090
+COWLEY,Arkansas City Ward 3 A,State Treasurer,,Republican,"Estes, Ron",32,000090
+COWLEY,Arkansas City Ward 3 B,State Treasurer,,Democratic,"Alldritt, Carmen",18,000100
+COWLEY,Arkansas City Ward 3 B,State Treasurer,,Republican,"Estes, Ron",44,000100
+COWLEY,Arkansas City Ward 3 C,State Treasurer,,Democratic,"Alldritt, Carmen",22,000110
+COWLEY,Arkansas City Ward 3 C,State Treasurer,,Republican,"Estes, Ron",41,000110
+COWLEY,Arkansas City Ward 4 A,State Treasurer,,Democratic,"Alldritt, Carmen",89,000120
+COWLEY,Arkansas City Ward 4 A,State Treasurer,,Republican,"Estes, Ron",113,000120
+COWLEY,Arkansas City Ward 4 B,State Treasurer,,Democratic,"Alldritt, Carmen",158,00013A
+COWLEY,Arkansas City Ward 4 B,State Treasurer,,Republican,"Estes, Ron",295,00013A
+COWLEY,Arkansas City Ward 4 C,State Treasurer,,Democratic,"Alldritt, Carmen",67,000140
+COWLEY,Arkansas City Ward 4 C,State Treasurer,,Republican,"Estes, Ron",113,000140
+COWLEY,Arkansas City Ward 4 D,State Treasurer,,Democratic,"Alldritt, Carmen",128,000150
+COWLEY,Arkansas City Ward 4 D,State Treasurer,,Republican,"Estes, Ron",238,000150
+COWLEY,Beaver Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000170
+COWLEY,Beaver Township,State Treasurer,,Republican,"Estes, Ron",68,000170
+COWLEY,Cedar Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000180
+COWLEY,Cedar Township,State Treasurer,,Republican,"Estes, Ron",13,000180
+COWLEY,Dexter Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000190
+COWLEY,Dexter Township,State Treasurer,,Republican,"Estes, Ron",136,000190
+COWLEY,East Creswell,State Treasurer,,Democratic,"Alldritt, Carmen",120,000210
+COWLEY,East Creswell,State Treasurer,,Republican,"Estes, Ron",371,000210
+COWLEY,Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000220
+COWLEY,Fairview Township,State Treasurer,,Republican,"Estes, Ron",80,000220
+COWLEY,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000230
+COWLEY,Grant Township,State Treasurer,,Republican,"Estes, Ron",23,000230
+COWLEY,Harvey Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000240
+COWLEY,Harvey Township,State Treasurer,,Republican,"Estes, Ron",32,000240
+COWLEY,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000250
+COWLEY,Liberty Township,State Treasurer,,Republican,"Estes, Ron",51,000250
+COWLEY,Maple Township,State Treasurer,,Democratic,"Alldritt, Carmen",57,000260
+COWLEY,Maple Township,State Treasurer,,Republican,"Estes, Ron",202,000260
+COWLEY,Ninnescah Township,State Treasurer,,Democratic,"Alldritt, Carmen",87,000270
+COWLEY,Ninnescah Township,State Treasurer,,Republican,"Estes, Ron",259,000270
+COWLEY,Omnia Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000280
+COWLEY,Omnia Township,State Treasurer,,Republican,"Estes, Ron",90,000280
+COWLEY,Otter Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000290
+COWLEY,Otter Township,State Treasurer,,Republican,"Estes, Ron",14,000290
+COWLEY,Pleasant Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",87,000300
+COWLEY,Pleasant Valley Township,State Treasurer,,Republican,"Estes, Ron",249,000300
+COWLEY,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000310
+COWLEY,Richland Township,State Treasurer,,Republican,"Estes, Ron",76,000310
+COWLEY,Rock Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000320
+COWLEY,Rock Township,State Treasurer,,Republican,"Estes, Ron",56,000320
+COWLEY,Salem Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000330
+COWLEY,Salem Township,State Treasurer,,Republican,"Estes, Ron",87,000330
+COWLEY,Sheridan Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000340
+COWLEY,Sheridan Township,State Treasurer,,Republican,"Estes, Ron",53,000340
+COWLEY,Silver Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",45,000350
+COWLEY,Silver Creek Township,State Treasurer,,Republican,"Estes, Ron",177,000350
+COWLEY,Silverdale Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000360
+COWLEY,Silverdale Township,State Treasurer,,Republican,"Estes, Ron",98,000360
+COWLEY,Spring Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000370
+COWLEY,Spring Creek Township,State Treasurer,,Republican,"Estes, Ron",25,000370
+COWLEY,Tisdale Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000380
+COWLEY,Tisdale Township,State Treasurer,,Republican,"Estes, Ron",117,000380
+COWLEY,Vernon Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,000390
+COWLEY,Vernon Township,State Treasurer,,Republican,"Estes, Ron",152,000390
+COWLEY,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",54,000400
+COWLEY,Walnut Township,State Treasurer,,Republican,"Estes, Ron",213,000400
+COWLEY,West Bolton Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00041B
+COWLEY,West Bolton Enclave A,State Treasurer,,Republican,"Estes, Ron",0,00041B
+COWLEY,West Creswell,State Treasurer,,Democratic,"Alldritt, Carmen",58,00042A
+COWLEY,West Creswell,State Treasurer,,Republican,"Estes, Ron",165,00042A
+COWLEY,Windsor Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000430
+COWLEY,Windsor Township,State Treasurer,,Republican,"Estes, Ron",50,000430
+COWLEY,Winfield Ward 1 East,State Treasurer,,Democratic,"Alldritt, Carmen",95,000440
+COWLEY,Winfield Ward 1 East,State Treasurer,,Republican,"Estes, Ron",179,000440
+COWLEY,Winfield Ward 1 West,State Treasurer,,Democratic,"Alldritt, Carmen",41,000450
+COWLEY,Winfield Ward 1 West,State Treasurer,,Republican,"Estes, Ron",107,000450
+COWLEY,Winfield Ward 2 Central,State Treasurer,,Democratic,"Alldritt, Carmen",65,000460
+COWLEY,Winfield Ward 2 Central,State Treasurer,,Republican,"Estes, Ron",112,000460
+COWLEY,Winfield Ward 2 East,State Treasurer,,Democratic,"Alldritt, Carmen",74,000470
+COWLEY,Winfield Ward 2 East,State Treasurer,,Republican,"Estes, Ron",141,000470
+COWLEY,Winfield Ward 2 South,State Treasurer,,Democratic,"Alldritt, Carmen",80,000480
+COWLEY,Winfield Ward 2 South,State Treasurer,,Republican,"Estes, Ron",241,000480
+COWLEY,Winfield Ward 2 West,State Treasurer,,Democratic,"Alldritt, Carmen",51,000490
+COWLEY,Winfield Ward 2 West,State Treasurer,,Republican,"Estes, Ron",134,000490
+COWLEY,Winfield Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",76,000500
+COWLEY,Winfield Ward 3,State Treasurer,,Republican,"Estes, Ron",167,000500
+COWLEY,Winfield Ward 3 South,State Treasurer,,Democratic,"Alldritt, Carmen",13,00051A
+COWLEY,Winfield Ward 3 South,State Treasurer,,Republican,"Estes, Ron",84,00051A
+COWLEY,Winfield Ward 8,State Treasurer,,Democratic,"Alldritt, Carmen",8,00051B
+COWLEY,Winfield Ward 8,State Treasurer,,Republican,"Estes, Ron",23,00051B
+COWLEY,Winfield Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",21,000520
+COWLEY,Winfield Ward 4,State Treasurer,,Republican,"Estes, Ron",56,000520
+COWLEY,Winfield Ward 5 East,State Treasurer,,Democratic,"Alldritt, Carmen",148,00053A
+COWLEY,Winfield Ward 5 East,State Treasurer,,Republican,"Estes, Ron",210,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,State Treasurer,,Democratic,"Alldritt, Carmen",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,State Treasurer,,Republican,"Estes, Ron",0,00053B
+COWLEY,Winfield Ward 5 West,State Treasurer,,Democratic,"Alldritt, Carmen",58,000540
+COWLEY,Winfield Ward 5 West,State Treasurer,,Republican,"Estes, Ron",75,000540
+COWLEY,Winfield Ward 6,State Treasurer,,Democratic,"Alldritt, Carmen",91,000550
+COWLEY,Winfield Ward 6,State Treasurer,,Republican,"Estes, Ron",271,000550
+COWLEY,Winfield Ward 6 A,State Treasurer,,Democratic,"Alldritt, Carmen",35,000560
+COWLEY,Winfield Ward 6 A,State Treasurer,,Republican,"Estes, Ron",127,000560
+COWLEY,Winfield Ward 7,State Treasurer,,Democratic,"Alldritt, Carmen",68,000570
+COWLEY,Winfield Ward 7,State Treasurer,,Republican,"Estes, Ron",175,000570
+COWLEY,Bolton,State Treasurer,,Democratic,"Alldritt, Carmen",111,130010
+COWLEY,Bolton,State Treasurer,,Republican,"Estes, Ron",374,130010
+COWLEY,Arkansas City Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+COWLEY,Arkansas City Ward 5,State Treasurer,,Republican,"Estes, Ron",0,900010
+COWLEY,West Creswell Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+COWLEY,West Creswell Enclave A,State Treasurer,,Republican,"Estes, Ron",0,900020
+COWLEY,West Creswell Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+COWLEY,West Creswell Enclave B,State Treasurer,,Republican,"Estes, Ron",0,900030
+COWLEY,West Creswell Enclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+COWLEY,West Creswell Enclave C,State Treasurer,,Republican,"Estes, Ron",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,State Treasurer,,Republican,"Estes, Ron",0,900060
+COWLEY,Winfield Ward 9,State Treasurer,,Democratic,"Alldritt, Carmen",0,900070
+COWLEY,Winfield Ward 9,State Treasurer,,Republican,"Estes, Ron",0,900070
+COWLEY,Arkansas City Ward 1 A,United States Senate,,independent,"Orman, Greg",65,00001A
+COWLEY,Arkansas City Ward 1 A,United States Senate,,Libertarian,"Batson, Randall",12,00001A
+COWLEY,Arkansas City Ward 1 A,United States Senate,,Republican,"Roberts, Pat",49,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,United States Senate,,independent,"Orman, Greg",6,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States Senate,,Libertarian,"Batson, Randall",1,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States Senate,,Republican,"Roberts, Pat",10,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,United States Senate,,independent,"Orman, Greg",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States Senate,,Republican,"Roberts, Pat",1,00001C
+COWLEY,Arkansas City Ward 1 B,United States Senate,,independent,"Orman, Greg",47,000020
+COWLEY,Arkansas City Ward 1 B,United States Senate,,Libertarian,"Batson, Randall",14,000020
+COWLEY,Arkansas City Ward 1 B,United States Senate,,Republican,"Roberts, Pat",62,000020
+COWLEY,Arkansas City Ward 1 C,United States Senate,,independent,"Orman, Greg",91,000030
+COWLEY,Arkansas City Ward 1 C,United States Senate,,Libertarian,"Batson, Randall",10,000030
+COWLEY,Arkansas City Ward 1 C,United States Senate,,Republican,"Roberts, Pat",100,000030
+COWLEY,Arkansas City Ward 1 D,United States Senate,,independent,"Orman, Greg",92,000040
+COWLEY,Arkansas City Ward 1 D,United States Senate,,Libertarian,"Batson, Randall",13,000040
+COWLEY,Arkansas City Ward 1 D,United States Senate,,Republican,"Roberts, Pat",84,000040
+COWLEY,Arkansas City Ward 2 A,United States Senate,,independent,"Orman, Greg",121,000050
+COWLEY,Arkansas City Ward 2 A,United States Senate,,Libertarian,"Batson, Randall",12,000050
+COWLEY,Arkansas City Ward 2 A,United States Senate,,Republican,"Roberts, Pat",144,000050
+COWLEY,Arkansas City Ward 2 B - 1,United States Senate,,independent,"Orman, Greg",29,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States Senate,,Libertarian,"Batson, Randall",10,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States Senate,,Republican,"Roberts, Pat",46,00006A
+COWLEY,Arkansas City Ward 2 B - 2,United States Senate,,independent,"Orman, Greg",30,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States Senate,,Libertarian,"Batson, Randall",3,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States Senate,,Republican,"Roberts, Pat",38,00006B
+COWLEY,Arkansas City Ward 2 C,United States Senate,,independent,"Orman, Greg",10,000070
+COWLEY,Arkansas City Ward 2 C,United States Senate,,Libertarian,"Batson, Randall",8,000070
+COWLEY,Arkansas City Ward 2 C,United States Senate,,Republican,"Roberts, Pat",11,000070
+COWLEY,Arkansas City Ward 2 D,United States Senate,,independent,"Orman, Greg",17,000080
+COWLEY,Arkansas City Ward 2 D,United States Senate,,Libertarian,"Batson, Randall",4,000080
+COWLEY,Arkansas City Ward 2 D,United States Senate,,Republican,"Roberts, Pat",16,000080
+COWLEY,Arkansas City Ward 3 A,United States Senate,,independent,"Orman, Greg",17,000090
+COWLEY,Arkansas City Ward 3 A,United States Senate,,Libertarian,"Batson, Randall",5,000090
+COWLEY,Arkansas City Ward 3 A,United States Senate,,Republican,"Roberts, Pat",24,000090
+COWLEY,Arkansas City Ward 3 B,United States Senate,,independent,"Orman, Greg",29,000100
+COWLEY,Arkansas City Ward 3 B,United States Senate,,Libertarian,"Batson, Randall",4,000100
+COWLEY,Arkansas City Ward 3 B,United States Senate,,Republican,"Roberts, Pat",33,000100
+COWLEY,Arkansas City Ward 3 C,United States Senate,,independent,"Orman, Greg",26,000110
+COWLEY,Arkansas City Ward 3 C,United States Senate,,Libertarian,"Batson, Randall",7,000110
+COWLEY,Arkansas City Ward 3 C,United States Senate,,Republican,"Roberts, Pat",31,000110
+COWLEY,Arkansas City Ward 4 A,United States Senate,,independent,"Orman, Greg",102,000120
+COWLEY,Arkansas City Ward 4 A,United States Senate,,Libertarian,"Batson, Randall",13,000120
+COWLEY,Arkansas City Ward 4 A,United States Senate,,Republican,"Roberts, Pat",92,000120
+COWLEY,Arkansas City Ward 4 B,United States Senate,,independent,"Orman, Greg",210,00013A
+COWLEY,Arkansas City Ward 4 B,United States Senate,,Libertarian,"Batson, Randall",35,00013A
+COWLEY,Arkansas City Ward 4 B,United States Senate,,Republican,"Roberts, Pat",218,00013A
+COWLEY,Arkansas City Ward 4 C,United States Senate,,independent,"Orman, Greg",97,000140
+COWLEY,Arkansas City Ward 4 C,United States Senate,,Libertarian,"Batson, Randall",10,000140
+COWLEY,Arkansas City Ward 4 C,United States Senate,,Republican,"Roberts, Pat",78,000140
+COWLEY,Arkansas City Ward 4 D,United States Senate,,independent,"Orman, Greg",176,000150
+COWLEY,Arkansas City Ward 4 D,United States Senate,,Libertarian,"Batson, Randall",28,000150
+COWLEY,Arkansas City Ward 4 D,United States Senate,,Republican,"Roberts, Pat",171,000150
+COWLEY,Beaver Township,United States Senate,,independent,"Orman, Greg",37,000170
+COWLEY,Beaver Township,United States Senate,,Libertarian,"Batson, Randall",2,000170
+COWLEY,Beaver Township,United States Senate,,Republican,"Roberts, Pat",52,000170
+COWLEY,Cedar Township,United States Senate,,independent,"Orman, Greg",0,000180
+COWLEY,Cedar Township,United States Senate,,Libertarian,"Batson, Randall",1,000180
+COWLEY,Cedar Township,United States Senate,,Republican,"Roberts, Pat",13,000180
+COWLEY,Dexter Township,United States Senate,,independent,"Orman, Greg",35,000190
+COWLEY,Dexter Township,United States Senate,,Libertarian,"Batson, Randall",7,000190
+COWLEY,Dexter Township,United States Senate,,Republican,"Roberts, Pat",113,000190
+COWLEY,East Creswell,United States Senate,,independent,"Orman, Greg",167,000210
+COWLEY,East Creswell,United States Senate,,Libertarian,"Batson, Randall",24,000210
+COWLEY,East Creswell,United States Senate,,Republican,"Roberts, Pat",306,000210
+COWLEY,Fairview Township,United States Senate,,independent,"Orman, Greg",40,000220
+COWLEY,Fairview Township,United States Senate,,Libertarian,"Batson, Randall",5,000220
+COWLEY,Fairview Township,United States Senate,,Republican,"Roberts, Pat",59,000220
+COWLEY,Grant Township,United States Senate,,independent,"Orman, Greg",6,000230
+COWLEY,Grant Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+COWLEY,Grant Township,United States Senate,,Republican,"Roberts, Pat",20,000230
+COWLEY,Harvey Township,United States Senate,,independent,"Orman, Greg",11,000240
+COWLEY,Harvey Township,United States Senate,,Libertarian,"Batson, Randall",1,000240
+COWLEY,Harvey Township,United States Senate,,Republican,"Roberts, Pat",28,000240
+COWLEY,Liberty Township,United States Senate,,independent,"Orman, Greg",10,000250
+COWLEY,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",1,000250
+COWLEY,Liberty Township,United States Senate,,Republican,"Roberts, Pat",46,000250
+COWLEY,Maple Township,United States Senate,,independent,"Orman, Greg",89,000260
+COWLEY,Maple Township,United States Senate,,Libertarian,"Batson, Randall",9,000260
+COWLEY,Maple Township,United States Senate,,Republican,"Roberts, Pat",159,000260
+COWLEY,Ninnescah Township,United States Senate,,independent,"Orman, Greg",130,000270
+COWLEY,Ninnescah Township,United States Senate,,Libertarian,"Batson, Randall",15,000270
+COWLEY,Ninnescah Township,United States Senate,,Republican,"Roberts, Pat",207,000270
+COWLEY,Omnia Township,United States Senate,,independent,"Orman, Greg",21,000280
+COWLEY,Omnia Township,United States Senate,,Libertarian,"Batson, Randall",6,000280
+COWLEY,Omnia Township,United States Senate,,Republican,"Roberts, Pat",78,000280
+COWLEY,Otter Township,United States Senate,,independent,"Orman, Greg",1,000290
+COWLEY,Otter Township,United States Senate,,Libertarian,"Batson, Randall",0,000290
+COWLEY,Otter Township,United States Senate,,Republican,"Roberts, Pat",15,000290
+COWLEY,Pleasant Valley Township,United States Senate,,independent,"Orman, Greg",130,000300
+COWLEY,Pleasant Valley Township,United States Senate,,Libertarian,"Batson, Randall",17,000300
+COWLEY,Pleasant Valley Township,United States Senate,,Republican,"Roberts, Pat",190,000300
+COWLEY,Richland Township,United States Senate,,independent,"Orman, Greg",27,000310
+COWLEY,Richland Township,United States Senate,,Libertarian,"Batson, Randall",5,000310
+COWLEY,Richland Township,United States Senate,,Republican,"Roberts, Pat",62,000310
+COWLEY,Rock Township,United States Senate,,independent,"Orman, Greg",24,000320
+COWLEY,Rock Township,United States Senate,,Libertarian,"Batson, Randall",2,000320
+COWLEY,Rock Township,United States Senate,,Republican,"Roberts, Pat",47,000320
+COWLEY,Salem Township,United States Senate,,independent,"Orman, Greg",35,000330
+COWLEY,Salem Township,United States Senate,,Libertarian,"Batson, Randall",5,000330
+COWLEY,Salem Township,United States Senate,,Republican,"Roberts, Pat",66,000330
+COWLEY,Sheridan Township,United States Senate,,independent,"Orman, Greg",21,000340
+COWLEY,Sheridan Township,United States Senate,,Libertarian,"Batson, Randall",4,000340
+COWLEY,Sheridan Township,United States Senate,,Republican,"Roberts, Pat",40,000340
+COWLEY,Silver Creek Township,United States Senate,,independent,"Orman, Greg",67,000350
+COWLEY,Silver Creek Township,United States Senate,,Libertarian,"Batson, Randall",16,000350
+COWLEY,Silver Creek Township,United States Senate,,Republican,"Roberts, Pat",149,000350
+COWLEY,Silverdale Township,United States Senate,,independent,"Orman, Greg",36,000360
+COWLEY,Silverdale Township,United States Senate,,Libertarian,"Batson, Randall",7,000360
+COWLEY,Silverdale Township,United States Senate,,Republican,"Roberts, Pat",78,000360
+COWLEY,Spring Creek Township,United States Senate,,independent,"Orman, Greg",9,000370
+COWLEY,Spring Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000370
+COWLEY,Spring Creek Township,United States Senate,,Republican,"Roberts, Pat",21,000370
+COWLEY,Tisdale Township,United States Senate,,independent,"Orman, Greg",37,000380
+COWLEY,Tisdale Township,United States Senate,,Libertarian,"Batson, Randall",14,000380
+COWLEY,Tisdale Township,United States Senate,,Republican,"Roberts, Pat",97,000380
+COWLEY,Vernon Township,United States Senate,,independent,"Orman, Greg",56,000390
+COWLEY,Vernon Township,United States Senate,,Libertarian,"Batson, Randall",16,000390
+COWLEY,Vernon Township,United States Senate,,Republican,"Roberts, Pat",117,000390
+COWLEY,Walnut Township,United States Senate,,independent,"Orman, Greg",99,000400
+COWLEY,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",18,000400
+COWLEY,Walnut Township,United States Senate,,Republican,"Roberts, Pat",158,000400
+COWLEY,West Bolton Enclave A,United States Senate,,independent,"Orman, Greg",0,00041B
+COWLEY,West Bolton Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,00041B
+COWLEY,West Bolton Enclave A,United States Senate,,Republican,"Roberts, Pat",0,00041B
+COWLEY,West Creswell,United States Senate,,independent,"Orman, Greg",78,00042A
+COWLEY,West Creswell,United States Senate,,Libertarian,"Batson, Randall",9,00042A
+COWLEY,West Creswell,United States Senate,,Republican,"Roberts, Pat",141,00042A
+COWLEY,Windsor Township,United States Senate,,independent,"Orman, Greg",26,000430
+COWLEY,Windsor Township,United States Senate,,Libertarian,"Batson, Randall",4,000430
+COWLEY,Windsor Township,United States Senate,,Republican,"Roberts, Pat",40,000430
+COWLEY,Winfield Ward 1 East,United States Senate,,independent,"Orman, Greg",144,000440
+COWLEY,Winfield Ward 1 East,United States Senate,,Libertarian,"Batson, Randall",21,000440
+COWLEY,Winfield Ward 1 East,United States Senate,,Republican,"Roberts, Pat",116,000440
+COWLEY,Winfield Ward 1 West,United States Senate,,independent,"Orman, Greg",65,000450
+COWLEY,Winfield Ward 1 West,United States Senate,,Libertarian,"Batson, Randall",9,000450
+COWLEY,Winfield Ward 1 West,United States Senate,,Republican,"Roberts, Pat",76,000450
+COWLEY,Winfield Ward 2 Central,United States Senate,,independent,"Orman, Greg",100,000460
+COWLEY,Winfield Ward 2 Central,United States Senate,,Libertarian,"Batson, Randall",14,000460
+COWLEY,Winfield Ward 2 Central,United States Senate,,Republican,"Roberts, Pat",75,000460
+COWLEY,Winfield Ward 2 East,United States Senate,,independent,"Orman, Greg",97,000470
+COWLEY,Winfield Ward 2 East,United States Senate,,Libertarian,"Batson, Randall",11,000470
+COWLEY,Winfield Ward 2 East,United States Senate,,Republican,"Roberts, Pat",113,000470
+COWLEY,Winfield Ward 2 South,United States Senate,,independent,"Orman, Greg",155,000480
+COWLEY,Winfield Ward 2 South,United States Senate,,Libertarian,"Batson, Randall",9,000480
+COWLEY,Winfield Ward 2 South,United States Senate,,Republican,"Roberts, Pat",162,000480
+COWLEY,Winfield Ward 2 West,United States Senate,,independent,"Orman, Greg",96,000490
+COWLEY,Winfield Ward 2 West,United States Senate,,Libertarian,"Batson, Randall",9,000490
+COWLEY,Winfield Ward 2 West,United States Senate,,Republican,"Roberts, Pat",81,000490
+COWLEY,Winfield Ward 3,United States Senate,,independent,"Orman, Greg",109,000500
+COWLEY,Winfield Ward 3,United States Senate,,Libertarian,"Batson, Randall",20,000500
+COWLEY,Winfield Ward 3,United States Senate,,Republican,"Roberts, Pat",120,000500
+COWLEY,Winfield Ward 3 South,United States Senate,,independent,"Orman, Greg",32,00051A
+COWLEY,Winfield Ward 3 South,United States Senate,,Libertarian,"Batson, Randall",1,00051A
+COWLEY,Winfield Ward 3 South,United States Senate,,Republican,"Roberts, Pat",65,00051A
+COWLEY,Winfield Ward 8,United States Senate,,independent,"Orman, Greg",11,00051B
+COWLEY,Winfield Ward 8,United States Senate,,Libertarian,"Batson, Randall",0,00051B
+COWLEY,Winfield Ward 8,United States Senate,,Republican,"Roberts, Pat",20,00051B
+COWLEY,Winfield Ward 4,United States Senate,,independent,"Orman, Greg",40,000520
+COWLEY,Winfield Ward 4,United States Senate,,Libertarian,"Batson, Randall",3,000520
+COWLEY,Winfield Ward 4,United States Senate,,Republican,"Roberts, Pat",33,000520
+COWLEY,Winfield Ward 5 East,United States Senate,,independent,"Orman, Greg",195,00053A
+COWLEY,Winfield Ward 5 East,United States Senate,,Libertarian,"Batson, Randall",15,00053A
+COWLEY,Winfield Ward 5 East,United States Senate,,Republican,"Roberts, Pat",154,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,United States Senate,,independent,"Orman, Greg",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States Senate,,Libertarian,"Batson, Randall",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States Senate,,Republican,"Roberts, Pat",0,00053B
+COWLEY,Winfield Ward 5 West,United States Senate,,independent,"Orman, Greg",67,000540
+COWLEY,Winfield Ward 5 West,United States Senate,,Libertarian,"Batson, Randall",11,000540
+COWLEY,Winfield Ward 5 West,United States Senate,,Republican,"Roberts, Pat",53,000540
+COWLEY,Winfield Ward 6,United States Senate,,independent,"Orman, Greg",150,000550
+COWLEY,Winfield Ward 6,United States Senate,,Libertarian,"Batson, Randall",19,000550
+COWLEY,Winfield Ward 6,United States Senate,,Republican,"Roberts, Pat",195,000550
+COWLEY,Winfield Ward 6 A,United States Senate,,independent,"Orman, Greg",63,000560
+COWLEY,Winfield Ward 6 A,United States Senate,,Libertarian,"Batson, Randall",4,000560
+COWLEY,Winfield Ward 6 A,United States Senate,,Republican,"Roberts, Pat",97,000560
+COWLEY,Winfield Ward 7,United States Senate,,independent,"Orman, Greg",123,000570
+COWLEY,Winfield Ward 7,United States Senate,,Libertarian,"Batson, Randall",11,000570
+COWLEY,Winfield Ward 7,United States Senate,,Republican,"Roberts, Pat",116,000570
+COWLEY,Bolton,United States Senate,,independent,"Orman, Greg",143,130010
+COWLEY,Bolton,United States Senate,,Libertarian,"Batson, Randall",41,130010
+COWLEY,Bolton,United States Senate,,Republican,"Roberts, Pat",306,130010
+COWLEY,Arkansas City Ward 5,United States Senate,,independent,"Orman, Greg",0,900010
+COWLEY,Arkansas City Ward 5,United States Senate,,Libertarian,"Batson, Randall",0,900010
+COWLEY,Arkansas City Ward 5,United States Senate,,Republican,"Roberts, Pat",0,900010
+COWLEY,West Creswell Enclave A,United States Senate,,independent,"Orman, Greg",0,900020
+COWLEY,West Creswell Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,900020
+COWLEY,West Creswell Enclave A,United States Senate,,Republican,"Roberts, Pat",0,900020
+COWLEY,West Creswell Enclave B,United States Senate,,independent,"Orman, Greg",0,900030
+COWLEY,West Creswell Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,900030
+COWLEY,West Creswell Enclave B,United States Senate,,Republican,"Roberts, Pat",0,900030
+COWLEY,West Creswell Enclave C,United States Senate,,independent,"Orman, Greg",0,900040
+COWLEY,West Creswell Enclave C,United States Senate,,Libertarian,"Batson, Randall",0,900040
+COWLEY,West Creswell Enclave C,United States Senate,,Republican,"Roberts, Pat",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States Senate,,independent,"Orman, Greg",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,United States Senate,,independent,"Orman, Greg",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States Senate,,Republican,"Roberts, Pat",0,900060
+COWLEY,Winfield Ward 9,United States Senate,,independent,"Orman, Greg",0,900070
+COWLEY,Winfield Ward 9,United States Senate,,Libertarian,"Batson, Randall",0,900070
+COWLEY,Winfield Ward 9,United States Senate,,Republican,"Roberts, Pat",0,900070

--- a/2014/20141104__ks__general__crawford__precinct.csv
+++ b/2014/20141104__ks__general__crawford__precinct.csv
@@ -1,1370 +1,1142 @@
-county,precinct,office,district,party,candidate,votes,adv,ed,prov
-Crawford,01 Arcadia,Attorney General,,D,A.J. Kotich,55,16,36,3
-Crawford,02 Baker,Attorney General,,D,A.J. Kotich,139,39,92,8
-Crawford,03 Beulah,Attorney General,,D,A.J. Kotich,31,6,25,0
-Crawford,04 Brazilton,Attorney General,,D,A.J. Kotich,6,0,6,0
-Crawford,05 Capaldo,Attorney General,,D,A.J. Kotich,8,1,7,0
-Crawford,06 Capaldo,Attorney General,,D,A.J. Kotich,60,13,46,1
-Crawford,07 Cherokee,Attorney General,,D,A.J. Kotich,70,5,64,1
-Crawford,08 Cherokee-Sheridan,Attorney General,,D,A.J. Kotich,39,2,37,0
-Crawford,09 Chicopee,Attorney General,,D,A.J. Kotich,83,17,63,3
-Crawford,10 Crawford,Attorney General,,D,A.J. Kotich,30,3,26,1
-Crawford,11 Crowe,Attorney General,,D,A.J. Kotich,37,12,23,2
-Crawford,12 Franklin,Attorney General,,D,A.J. Kotich,66,17,47,2
-Crawford,13 Franklin,Attorney General,,D,A.J. Kotich,2,0,2,0
-Crawford,14 Frontenac W1,Attorney General,,D,A.J. Kotich,164,56,102,6
-Crawford,15 Frontenac W2,Attorney General,,D,A.J. Kotich,254,50,200,4
-Crawford,16 Frontenac W3,Attorney General,,D,A.J. Kotich,93,19,71,3
-Crawford,17 Frontenac W4,Attorney General,,D,A.J. Kotich,82,26,54,2
-Crawford,18 Girard W1,Attorney General,,D,A.J. Kotich,31,5,26,0
-Crawford,19 Girard W2,Attorney General,,D,A.J. Kotich,92,17,75,0
-Crawford,20 Girard W3,Attorney General,,D,A.J. Kotich,80,16,63,1
-Crawford,21 Girard W4,Attorney General,,D,A.J. Kotich,87,11,75,1
-Crawford,22 Grant,Attorney General,,D,A.J. Kotich,34,6,28,0
-Crawford,23 Hepler,Attorney General,,D,A.J. Kotich,16,4,11,1
-Crawford,24 Lincoln,Attorney General,,D,A.J. Kotich,48,12,35,1
-Crawford,25 Lincoln,Attorney General,,D,A.J. Kotich,0,0,0,
-Crawford,26 Lincoln-Arcadia,Attorney General,,D,A.J. Kotich,17,2,15,0
-Crawford,27 Lone Star,Attorney General,,D,A.J. Kotich,174,30,140,4
-Crawford,28 McCune,Attorney General,,D,A.J. Kotich,50,6,42,2
-Crawford,29 Mulberry W1,Attorney General,,D,A.J. Kotich,18,0,18,0
-Crawford,30 Mulberry W2,Attorney General,,D,A.J. Kotich,15,6,9,0
-Crawford,31 North Arma,Attorney General,,D,A.J. Kotich,104,27,75,2
-Crawford,32 Opolis,Attorney General,,D,A.J. Kotich,45,10,33,2
-Crawford,33 Osage-McCune,Attorney General,,D,A.J. Kotich,29,4,25,0
-Crawford,34 Parkview,Attorney General,,D,A.J. Kotich,43,13,28,2
-Crawford,35 Parkview,Attorney General,,D,A.J. Kotich,47,12,30,5
-Crawford,36 Pittsburg W1P1,Attorney General,,D,A.J. Kotich,68,16,46,6
-Crawford,37 Pittsburg W1P2,Attorney General,,D,A.J. Kotich,161,39,114,8
-Crawford,38 Pittsburg W1P3,Attorney General,,D,A.J. Kotich,348,101,236,11
-Crawford,39 Pittsburg W2P1,Attorney General,,D,A.J. Kotich,71,10,58,3
-Crawford,40 Pittsburg W2P2,Attorney General,,D,A.J. Kotich,112,28,79,5
-Crawford,41 Pittsburg W2P3,Attorney General,,D,A.J. Kotich,135,35,94,6
-Crawford,42 Pittsburg W2P4,Attorney General,,D,A.J. Kotich,89,26,61,2
-Crawford,43 Pittsburg W2P5,Attorney General,,D,A.J. Kotich,95,25,62,8
-Crawford,44 Pittsburg W3P1,Attorney General,,D,A.J. Kotich,104,20,78,6
-Crawford,45 Pittsburg W3P2,Attorney General,,D,A.J. Kotich,109,29,75,5
-Crawford,46 Pittsburg W4P1,Attorney General,,D,A.J. Kotich,48,8,37,3
-Crawford,47 Pittsburg W4P2,Attorney General,,D,A.J. Kotich,84,28,50,6
-Crawford,48 Pittsburg W4P3,Attorney General,,D,A.J. Kotich,152,47,102,3
-Crawford,49 Pittsburg W4P4,Attorney General,,D,A.J. Kotich,72,16,51,5
-Crawford,50 Pittsburg W4P5,Attorney General,,D,A.J. Kotich,188,47,137,4
-Crawford,51 Pittsburg W4P6,Attorney General,,D,A.J. Kotich,22,7,15,0
-Crawford,52 Raymond,Attorney General,,D,A.J. Kotich,88,18,68,2
-Crawford,53 Sheridan-Cherokee,Attorney General,,D,A.J. Kotich,22,2,19,1
-Crawford,54 Sheridan,Attorney General,,D,A.J. Kotich,20,2,18,0
-Crawford,55 Sherman,Attorney General,,D,A.J. Kotich,69,13,56,0
-Crawford,56 Smelter,Attorney General,,D,A.J. Kotich,94,29,63,2
-Crawford,57 South Arma,Attorney General,,D,A.J. Kotich,132,37,91,4
-Crawford,58 Walnut,Attorney General,,D,A.J. Kotich,16,4,12,0
-Crawford,59 Walnut twp,Attorney General,,D,A.J. Kotich,2,0,2,0
-Crawford,60 Walnut twp,Attorney General,,D,A.J. Kotich,5,0,5,0
-Crawford,61 Walnut-Hepler,Attorney General,,D,A.J. Kotich,1,0,1,0
-Crawford,62 Walnut-Hepler,Attorney General,,D,A.J. Kotich,5,0,5,0
-Crawford,01 Arcadia,Attorney General,,R,Derek Schmidt,43,6,37,0
-Crawford,02 Baker,Attorney General,,R,Derek Schmidt,247,18,220,9
-Crawford,03 Beulah,Attorney General,,R,Derek Schmidt,56,8,46,2
-Crawford,04 Brazilton,Attorney General,,R,Derek Schmidt,24,2,21,1
-Crawford,05 Capaldo,Attorney General,,R,Derek Schmidt,13,1,12,0
-Crawford,06 Capaldo,Attorney General,,R,Derek Schmidt,86,17,69,0
-Crawford,07 Cherokee,Attorney General,,R,Derek Schmidt,115,8,101,6
-Crawford,08 Cherokee-Sheridan,Attorney General,,R,Derek Schmidt,83,6,76,1
-Crawford,09 Chicopee,Attorney General,,R,Derek Schmidt,146,24,120,2
-Crawford,10 Crawford,Attorney General,,R,Derek Schmidt,136,13,120,3
-Crawford,11 Crowe,Attorney General,,R,Derek Schmidt,43,4,39,0
-Crawford,12 Franklin,Attorney General,,R,Derek Schmidt,65,8,54,3
-Crawford,13 Franklin,Attorney General,,R,Derek Schmidt,4,1,3,0
-Crawford,14 Frontenac W1,Attorney General,,R,Derek Schmidt,130,18,107,5
-Crawford,15 Frontenac W2,Attorney General,,R,Derek Schmidt,189,38,146,5
-Crawford,16 Frontenac W3,Attorney General,,R,Derek Schmidt,81,8,71,2
-Crawford,17 Frontenac W4,Attorney General,,R,Derek Schmidt,50,7,42,1
-Crawford,18 Girard W1,Attorney General,,R,Derek Schmidt,50,3,47,0
-Crawford,19 Girard W2,Attorney General,,R,Derek Schmidt,157,29,126,2
-Crawford,20 Girard W3,Attorney General,,R,Derek Schmidt,89,11,74,4
-Crawford,21 Girard W4,Attorney General,,R,Derek Schmidt,152,27,119,6
-Crawford,22 Grant,Attorney General,,R,Derek Schmidt,73,6,67,0
-Crawford,23 Hepler,Attorney General,,R,Derek Schmidt,17,0,16,1
-Crawford,24 Lincoln,Attorney General,,R,Derek Schmidt,75,9,66,0
-Crawford,25 Lincoln,Attorney General,,R,Derek Schmidt,4,0,4,0
-Crawford,26 Lincoln-Arcadia,Attorney General,,R,Derek Schmidt,14,3,10,1
-Crawford,27 Lone Star,Attorney General,,R,Derek Schmidt,263,25,234,4
-Crawford,28 McCune,Attorney General,,R,Derek Schmidt,67,6,60,1
-Crawford,29 Mulberry W1,Attorney General,,R,Derek Schmidt,32,4,28,0
-Crawford,30 Mulberry W2,Attorney General,,R,Derek Schmidt,30,1,29,0
-Crawford,31 North Arma,Attorney General,,R,Derek Schmidt,129,18,109,2
-Crawford,32 Opolis,Attorney General,,R,Derek Schmidt,89,12,76,1
-Crawford,33 Osage-McCune,Attorney General,,R,Derek Schmidt,130,10,120,0
-Crawford,34 Parkview,Attorney General,,R,Derek Schmidt,34,2,30,2
-Crawford,35 Parkview,Attorney General,,R,Derek Schmidt,41,4,35,2
-Crawford,36 Pittsburg W1P1,Attorney General,,R,Derek Schmidt,103,15,82,6
-Crawford,37 Pittsburg W1P2,Attorney General,,R,Derek Schmidt,188,23,160,5
-Crawford,38 Pittsburg W1P3,Attorney General,,R,Derek Schmidt,495,83,405,7
-Crawford,39 Pittsburg W2P1,Attorney General,,R,Derek Schmidt,75,7,67,1
-Crawford,40 Pittsburg W2P2,Attorney General,,R,Derek Schmidt,104,13,88,3
-Crawford,41 Pittsburg W2P3,Attorney General,,R,Derek Schmidt,110,20,87,3
-Crawford,42 Pittsburg W2P4,Attorney General,,R,Derek Schmidt,124,14,108,2
-Crawford,43 Pittsburg W2P5,Attorney General,,R,Derek Schmidt,188,20,163,5
-Crawford,44 Pittsburg W3P1,Attorney General,,R,Derek Schmidt,96,10,80,6
-Crawford,45 Pittsburg W3P2,Attorney General,,R,Derek Schmidt,125,19,103,3
-Crawford,46 Pittsburg W4P1,Attorney General,,R,Derek Schmidt,34,4,28,2
-Crawford,47 Pittsburg W4P2,Attorney General,,R,Derek Schmidt,63,12,44,7
-Crawford,48 Pittsburg W4P3,Attorney General,,R,Derek Schmidt,163,18,137,8
-Crawford,49 Pittsburg W4P4,Attorney General,,R,Derek Schmidt,69,8,56,5
-Crawford,50 Pittsburg W4P5,Attorney General,,R,Derek Schmidt,287,47,236,4
-Crawford,51 Pittsburg W4P6,Attorney General,,R,Derek Schmidt,55,4,51,0
-Crawford,52 Raymond,Attorney General,,R,Derek Schmidt,182,26,152,4
-Crawford,53 Sheridan-Cherokee,Attorney General,,R,Derek Schmidt,19,1,18,0
-Crawford,54 Sheridan,Attorney General,,R,Derek Schmidt,24,1,23,0
-Crawford,55 Sherman,Attorney General,,R,Derek Schmidt,151,9,140,2
-Crawford,56 Smelter,Attorney General,,R,Derek Schmidt,156,8,146,2
-Crawford,57 South Arma,Attorney General,,R,Derek Schmidt,138,21,115,2
-Crawford,58 Walnut,Attorney General,,R,Derek Schmidt,30,1,29,0
-Crawford,59 Walnut twp,Attorney General,,R,Derek Schmidt,0,0,0,0
-Crawford,60 Walnut twp,Attorney General,,R,Derek Schmidt,11,0,9,2
-Crawford,61 Walnut-Hepler,Attorney General,,R,Derek Schmidt,0,0,0,0
-Crawford,62 Walnut-Hepler,Attorney General,,R,Derek Schmidt,14,2,12,0
-Crawford,08 Cherokee-Sheridan,Attorney General,,,Write-ins,1,0,1,0
-Crawford,09 Chicopee,Attorney General,,,Write-ins,1,0,1,0
-Crawford,15 Frontenac W2,Attorney General,,,Write-ins,1,0,1,0
-Crawford,27 Lone Star,Attorney General,,,Write-ins,2,0,2,0
-Crawford,28 McCune,Attorney General,,,Write-ins,1,0,1,0
-Crawford,45 Pittsburg W3P2,Attorney General,,,Write-ins,2,1,1,0
-Crawford,48 Pittsburg W4P3,Attorney General,,,Write-ins,1,0,1,0
-Crawford,01 Arcadia,Ballots,,,Ballots Cast,99,22,73,4
-Crawford,02 Baker,Ballots,,,Ballots Cast,409,59,333,17
-Crawford,03 Beulah,Ballots,,,Ballots Cast,93,14,77,2
-Crawford,04 Brazilton,Ballots,,,Ballots Cast,30,2,27,1
-Crawford,05 Capaldo,Ballots,,,Ballots Cast,21,2,19,0
-Crawford,06 Capaldo,Ballots,,,Ballots Cast,150,30,119,1
-Crawford,07 Cherokee,Ballots,,,Ballots Cast,193,16,170,7
-Crawford,08 Cherokee-Sheridan,Ballots,,,Ballots Cast,125,9,115,1
-Crawford,09 Chicopee,Ballots,,,Ballots Cast,241,43,193,5
-Crawford,10 Crawford,Ballots,,,Ballots Cast,174,16,154,4
-Crawford,11 Crowe,Ballots,,,Ballots Cast,84,17,65,2
-Crawford,12 Franklin,Ballots,,,Ballots Cast,132,25,102,5
-Crawford,13 Franklin,Ballots,,,Ballots Cast,6,1,5,0
-Crawford,14 Frontenac W1,Ballots,,,Ballots Cast,306,77,216,13
-Crawford,15 Frontenac W2,Ballots,,,Ballots Cast,461,97,353,11
-Crawford,16 Frontenac W3,Ballots,,,Ballots Cast,184,30,149,5
-Crawford,17 Frontenac W4,Ballots,,,Ballots Cast,141,33,104,4
-Crawford,18 Girard W1,Ballots,,,Ballots Cast,83,9,74,0
-Crawford,19 Girard W2,Ballots,,,Ballots Cast,270,50,218,2
-Crawford,20 Girard W3,Ballots,,,Ballots Cast,171,27,139,5
-Crawford,21 Girard W4,Ballots,,,Ballots Cast,250,41,202,7
-Crawford,22 Grant,Ballots,,,Ballots Cast,116,13,103,0
-Crawford,23 Hepler,Ballots,,,Ballots Cast,36,4,30,2
-Crawford,24 Lincoln,Ballots,,,Ballots Cast,126,21,104,1
-Crawford,25 Lincoln,Ballots,,,Ballots Cast,5,0,5,0
-Crawford,26 Lincoln-Arcadia,Ballots,,,Ballots Cast,32,6,25,1
-Crawford,27 Lone Star,Ballots,,,Ballots Cast,451,57,386,8
-Crawford,28 McCune,Ballots,,,Ballots Cast,121,13,105,3
-Crawford,29 Mulberry W1,Ballots,,,Ballots Cast,51,4,47,0
-Crawford,30 Mulberry W2,Ballots,,,Ballots Cast,49,7,42,0
-Crawford,31 North Arma,Ballots,,,Ballots Cast,247,48,195,4
-Crawford,32 Opolis,Ballots,,,Ballots Cast,134,22,109,3
-Crawford,33 Osage-McCune,Ballots,,,Ballots Cast,164,14,150,0
-Crawford,34 Parkview,Ballots,,,Ballots Cast,78,16,58,4
-Crawford,35 Parkview,Ballots,,,Ballots Cast,94,17,70,7
-Crawford,36 Pittsburg W1P1,Ballots,,,Ballots Cast,182,31,138,13
-Crawford,37 Pittsburg W1P2,Ballots,,,Ballots Cast,369,68,288,13
-Crawford,38 Pittsburg W1P3,Ballots,,,Ballots Cast,875,190,666,19
-Crawford,39 Pittsburg W2P1,Ballots,,,Ballots Cast,153,19,130,4
-Crawford,40 Pittsburg W2P2,Ballots,,,Ballots Cast,219,42,169,8
-Crawford,41 Pittsburg W2P3,Ballots,,,Ballots Cast,253,57,187,9
-Crawford,42 Pittsburg W2P4,Ballots,,,Ballots Cast,218,43,171,4
-Crawford,43 Pittsburg W2P5,Ballots,,,Ballots Cast,295,48,232,15
-Crawford,44 Pittsburg W3P1,Ballots,,,Ballots Cast,205,32,161,12
-Crawford,45 Pittsburg W3P2,Ballots,,,Ballots Cast,243,49,186,8
-Crawford,46 Pittsburg W4P1,Ballots,,,Ballots Cast,85,13,67,5
-Crawford,47 Pittsburg W4P2,Ballots,,,Ballots Cast,158,42,100,16
-Crawford,48 Pittsburg W4P3,Ballots,,,Ballots Cast,328,67,249,12
-Crawford,49 Pittsburg W4P4,Ballots,,,Ballots Cast,147,28,108,11
-Crawford,50 Pittsburg W4P5,Ballots,,,Ballots Cast,496,97,390,9
-Crawford,51 Pittsburg W4P6,Ballots,,,Ballots Cast,78,11,67,0
-Crawford,52 Raymond,Ballots,,,Ballots Cast,279,46,227,6
-Crawford,53 Sheridan-Cherokee,Ballots,,,Ballots Cast,43,3,39,1
-Crawford,54 Sheridan,Ballots,,,Ballots Cast,46,4,42,0
-Crawford,55 Sherman,Ballots,,,Ballots Cast,231,23,206,2
-Crawford,56 Smelter,Ballots,,,Ballots Cast,253,37,212,4
-Crawford,57 South Arma,Ballots,,,Ballots Cast,279,61,212,6
-Crawford,58 Walnut,Ballots,,,Ballots Cast,49,5,44,0
-Crawford,59 Walnut twp,Ballots,,,Ballots Cast,2,0,2,0
-Crawford,60 Walnut twp,Ballots,,,Ballots Cast,17,1,14,2
-Crawford,61 Walnut-Hepler,Ballots,,,Ballots Cast,2,0,2,0
-Crawford,62 Walnut-Hepler,Ballots,,,Ballots Cast,19,2,17,0
-Crawford,01 Arcadia,U.S. House,2,L,Christopher Clemmons,7,0,7,0
-Crawford,02 Baker,U.S. House,2,L,Christopher Clemmons,16,4,12,0
-Crawford,03 Beulah,U.S. House,2,L,Christopher Clemmons,7,1,6,0
-Crawford,04 Brazilton,U.S. House,2,L,Christopher Clemmons,2,0,2,0
-Crawford,05 Capaldo,U.S. House,2,L,Christopher Clemmons,0,0,0,
-Crawford,06 Capaldo,U.S. House,2,L,Christopher Clemmons,6,0,6,0
-Crawford,07 Cherokee,U.S. House,2,L,Christopher Clemmons,23,2,21,0
-Crawford,08 Cherokee-Sheridan,U.S. House,2,L,Christopher Clemmons,7,0,7,0
-Crawford,09 Chicopee,U.S. House,2,L,Christopher Clemmons,10,1,9,0
-Crawford,10 Crawford,U.S. House,2,L,Christopher Clemmons,10,0,10,0
-Crawford,11 Crowe,U.S. House,2,L,Christopher Clemmons,9,5,4,0
-Crawford,12 Franklin,U.S. House,2,L,Christopher Clemmons,8,0,7,1
-Crawford,13 Franklin,U.S. House,2,L,Christopher Clemmons,1,0,1,0
-Crawford,14 Frontenac W1,U.S. House,2,L,Christopher Clemmons,10,3,7,0
-Crawford,15 Frontenac W2,U.S. House,2,L,Christopher Clemmons,27,8,19,0
-Crawford,16 Frontenac W3,U.S. House,2,L,Christopher Clemmons,10,2,8,0
-Crawford,17 Frontenac W4,U.S. House,2,L,Christopher Clemmons,6,0,5,1
-Crawford,18 Girard W1,U.S. House,2,L,Christopher Clemmons,7,0,7,0
-Crawford,19 Girard W2,U.S. House,2,L,Christopher Clemmons,8,1,7,0
-Crawford,20 Girard W3,U.S. House,2,L,Christopher Clemmons,13,1,11,1
-Crawford,21 Girard W4,U.S. House,2,L,Christopher Clemmons,17,3,13,1
-Crawford,22 Grant,U.S. House,2,L,Christopher Clemmons,3,0,3,0
-Crawford,23 Hepler,U.S. House,2,L,Christopher Clemmons,5,0,5,0
-Crawford,24 Lincoln,U.S. House,2,L,Christopher Clemmons,7,2,5,0
-Crawford,25 Lincoln,U.S. House,2,L,Christopher Clemmons,0,0,0,
-Crawford,26 Lincoln-Arcadia,U.S. House,2,L,Christopher Clemmons,3,1,2,0
-Crawford,27 Lone Star,U.S. House,2,L,Christopher Clemmons,28,1,27,0
-Crawford,28 McCune,U.S. House,2,L,Christopher Clemmons,13,0,13,0
-Crawford,29 Mulberry W1,U.S. House,2,L,Christopher Clemmons,4,0,4,0
-Crawford,30 Mulberry W2,U.S. House,2,L,Christopher Clemmons,6,2,4,0
-Crawford,31 North Arma,U.S. House,2,L,Christopher Clemmons,5,0,5,0
-Crawford,32 Opolis,U.S. House,2,L,Christopher Clemmons,7,1,6,0
-Crawford,33 Osage-McCune,U.S. House,2,L,Christopher Clemmons,5,0,5,0
-Crawford,34 Parkview,U.S. House,2,L,Christopher Clemmons,4,0,4,0
-Crawford,35 Parkview,U.S. House,2,L,Christopher Clemmons,4,0,4,0
-Crawford,36 Pittsburg W1P1,U.S. House,2,L,Christopher Clemmons,7,2,3,2
-Crawford,37 Pittsburg W1P2,U.S. House,2,L,Christopher Clemmons,7,1,5,1
-Crawford,38 Pittsburg W1P3,U.S. House,2,L,Christopher Clemmons,29,1,26,2
-Crawford,39 Pittsburg W2P1,U.S. House,2,L,Christopher Clemmons,11,0,11,0
-Crawford,40 Pittsburg W2P2,U.S. House,2,L,Christopher Clemmons,10,1,6,3
-Crawford,41 Pittsburg W2P3,U.S. House,2,L,Christopher Clemmons,10,3,6,1
-Crawford,42 Pittsburg W2P4,U.S. House,2,L,Christopher Clemmons,2,0,2,0
-Crawford,43 Pittsburg W2P5,U.S. House,2,L,Christopher Clemmons,13,1,12,0
-Crawford,44 Pittsburg W3P1,U.S. House,2,L,Christopher Clemmons,9,1,8,0
-Crawford,45 Pittsburg W3P2,U.S. House,2,L,Christopher Clemmons,11,2,9,0
-Crawford,46 Pittsburg W4P1,U.S. House,2,L,Christopher Clemmons,6,2,3,1
-Crawford,47 Pittsburg W4P2,U.S. House,2,L,Christopher Clemmons,4,2,2,0
-Crawford,48 Pittsburg W4P3,U.S. House,2,L,Christopher Clemmons,26,1,24,1
-Crawford,49 Pittsburg W4P4,U.S. House,2,L,Christopher Clemmons,6,1,4,1
-Crawford,50 Pittsburg W4P5,U.S. House,2,L,Christopher Clemmons,24,3,20,1
-Crawford,51 Pittsburg W4P6,U.S. House,2,L,Christopher Clemmons,4,3,1,0
-Crawford,52 Raymond,U.S. House,2,L,Christopher Clemmons,12,0,11,1
-Crawford,53 Sheridan-Cherokee,U.S. House,2,L,Christopher Clemmons,6,1,5,0
-Crawford,54 Sheridan,U.S. House,2,L,Christopher Clemmons,3,0,3,0
-Crawford,55 Sherman,U.S. House,2,L,Christopher Clemmons,15,2,13,0
-Crawford,56 Smelter,U.S. House,2,L,Christopher Clemmons,10,2,8,0
-Crawford,57 South Arma,U.S. House,2,L,Christopher Clemmons,12,4,8,0
-Crawford,58 Walnut,U.S. House,2,L,Christopher Clemmons,5,1,4,0
-Crawford,59 Walnut twp,U.S. House,2,L,Christopher Clemmons,1,0,1,0
-Crawford,60 Walnut twp,U.S. House,2,L,Christopher Clemmons,1,0,1,0
-Crawford,61 Walnut-Hepler,U.S. House,2,L,Christopher Clemmons,1,0,1,0
-Crawford,62 Walnut-Hepler,U.S. House,2,L,Christopher Clemmons,1,0,1,0
-Crawford,01 Arcadia,U.S. House,2,R,Lynn Jenkins,49,8,41,0
-Crawford,02 Baker,U.S. House,2,R,Lynn Jenkins,244,19,218,7
-Crawford,03 Beulah,U.S. House,2,R,Lynn Jenkins,55,7,46,2
-Crawford,04 Brazilton,U.S. House,2,R,Lynn Jenkins,21,2,19,0
-Crawford,05 Capaldo,U.S. House,2,R,Lynn Jenkins,14,1,13,0
-Crawford,06 Capaldo,U.S. House,2,R,Lynn Jenkins,75,11,64,0
-Crawford,07 Cherokee,U.S. House,2,R,Lynn Jenkins,96,8,83,5
-Crawford,08 Cherokee-Sheridan,U.S. House,2,R,Lynn Jenkins,81,6,74,1
-Crawford,09 Chicopee,U.S. House,2,R,Lynn Jenkins,143,22,118,3
-Crawford,10 Crawford,U.S. House,2,R,Lynn Jenkins,125,12,109,4
-Crawford,11 Crowe,U.S. House,2,R,Lynn Jenkins,40,1,38,1
-Crawford,12 Franklin,U.S. House,2,R,Lynn Jenkins,62,7,53,2
-Crawford,13 Franklin,U.S. House,2,R,Lynn Jenkins,3,1,2,0
-Crawford,14 Frontenac W1,U.S. House,2,R,Lynn Jenkins,123,20,97,6
-Crawford,15 Frontenac W2,U.S. House,2,R,Lynn Jenkins,179,31,140,8
-Crawford,16 Frontenac W3,U.S. House,2,R,Lynn Jenkins,78,8,67,3
-Crawford,17 Frontenac W4,U.S. House,2,R,Lynn Jenkins,59,9,48,2
-Crawford,18 Girard W1,U.S. House,2,R,Lynn Jenkins,43,4,39,0
-Crawford,19 Girard W2,U.S. House,2,R,Lynn Jenkins,155,25,128,2
-Crawford,20 Girard W3,U.S. House,2,R,Lynn Jenkins,76,8,64,4
-Crawford,21 Girard W4,U.S. House,2,R,Lynn Jenkins,143,24,116,3
-Crawford,22 Grant,U.S. House,2,R,Lynn Jenkins,87,7,80,0
-Crawford,23 Hepler,U.S. House,2,R,Lynn Jenkins,22,2,18,2
-Crawford,24 Lincoln,U.S. House,2,R,Lynn Jenkins,73,8,65,0
-Crawford,25 Lincoln,U.S. House,2,R,Lynn Jenkins,4,0,4,0
-Crawford,26 Lincoln-Arcadia,U.S. House,2,R,Lynn Jenkins,14,2,11,1
-Crawford,27 Lone Star,U.S. House,2,R,Lynn Jenkins,241,24,214,3
-Crawford,28 McCune,U.S. House,2,R,Lynn Jenkins,60,7,51,2
-Crawford,29 Mulberry W1,U.S. House,2,R,Lynn Jenkins,33,4,29,0
-Crawford,30 Mulberry W2,U.S. House,2,R,Lynn Jenkins,25,1,24,0
-Crawford,31 North Arma,U.S. House,2,R,Lynn Jenkins,134,16,116,2
-Crawford,32 Opolis,U.S. House,2,R,Lynn Jenkins,76,10,65,1
-Crawford,33 Osage-McCune,U.S. House,2,R,Lynn Jenkins,132,11,121,0
-Crawford,34 Parkview,U.S. House,2,R,Lynn Jenkins,27,5,20,2
-Crawford,35 Parkview,U.S. House,2,R,Lynn Jenkins,43,4,37,2
-Crawford,36 Pittsburg W1P1,U.S. House,2,R,Lynn Jenkins,105,12,89,4
-Crawford,37 Pittsburg W1P2,U.S. House,2,R,Lynn Jenkins,185,23,159,3
-Crawford,38 Pittsburg W1P3,U.S. House,2,R,Lynn Jenkins,472,78,387,7
-Crawford,39 Pittsburg W2P1,U.S. House,2,R,Lynn Jenkins,73,6,66,1
-Crawford,40 Pittsburg W2P2,U.S. House,2,R,Lynn Jenkins,100,10,88,2
-Crawford,41 Pittsburg W2P3,U.S. House,2,R,Lynn Jenkins,103,15,85,3
-Crawford,42 Pittsburg W2P4,U.S. House,2,R,Lynn Jenkins,122,17,102,3
-Crawford,43 Pittsburg W2P5,U.S. House,2,R,Lynn Jenkins,170,20,146,4
-Crawford,44 Pittsburg W3P1,U.S. House,2,R,Lynn Jenkins,97,11,80,6
-Crawford,45 Pittsburg W3P2,U.S. House,2,R,Lynn Jenkins,122,16,102,4
-Crawford,46 Pittsburg W4P1,U.S. House,2,R,Lynn Jenkins,32,5,25,2
-Crawford,47 Pittsburg W4P2,U.S. House,2,R,Lynn Jenkins,66,9,47,10
-Crawford,48 Pittsburg W4P3,U.S. House,2,R,Lynn Jenkins,151,19,125,7
-Crawford,49 Pittsburg W4P4,U.S. House,2,R,Lynn Jenkins,69,11,51,7
-Crawford,50 Pittsburg W4P5,U.S. House,2,R,Lynn Jenkins,278,45,229,4
-Crawford,51 Pittsburg W4P6,U.S. House,2,R,Lynn Jenkins,52,4,48,0
-Crawford,52 Raymond,U.S. House,2,R,Lynn Jenkins,171,19,148,4
-Crawford,53 Sheridan-Cherokee,U.S. House,2,R,Lynn Jenkins,19,1,18,0
-Crawford,54 Sheridan,U.S. House,2,R,Lynn Jenkins,22,1,21,0
-Crawford,55 Sherman,U.S. House,2,R,Lynn Jenkins,138,8,128,2
-Crawford,56 Smelter,U.S. House,2,R,Lynn Jenkins,152,9,141,2
-Crawford,57 South Arma,U.S. House,2,R,Lynn Jenkins,141,18,121,2
-Crawford,58 Walnut,U.S. House,2,R,Lynn Jenkins,33,2,31,0
-Crawford,59 Walnut twp,U.S. House,2,R,Lynn Jenkins,0,0,0,
-Crawford,60 Walnut twp,U.S. House,2,R,Lynn Jenkins,10,0,9,1
-Crawford,61 Walnut-Hepler,U.S. House,2,R,Lynn Jenkins,0,0,0,
-Crawford,62 Walnut-Hepler,U.S. House,2,R,Lynn Jenkins,10,2,8,0
-Crawford,01 Arcadia,U.S. House,2,D,Margie Wakefield,41,14,24,3
-Crawford,02 Baker,U.S. House,2,D,Margie Wakefield,144,35,99,10
-Crawford,03 Beulah,U.S. House,2,D,Margie Wakefield,28,6,22,0
-Crawford,04 Brazilton,U.S. House,2,D,Margie Wakefield,7,0,6,1
-Crawford,05 Capaldo,U.S. House,2,D,Margie Wakefield,7,1,6,0
-Crawford,06 Capaldo,U.S. House,2,D,Margie Wakefield,68,19,48,1
-Crawford,07 Cherokee,U.S. House,2,D,Margie Wakefield,72,6,64,2
-Crawford,08 Cherokee-Sheridan,U.S. House,2,D,Margie Wakefield,36,3,33,0
-Crawford,09 Chicopee,U.S. House,2,D,Margie Wakefield,84,19,63,2
-Crawford,10 Crawford,U.S. House,2,D,Margie Wakefield,37,4,33,0
-Crawford,11 Crowe,U.S. House,2,D,Margie Wakefield,32,10,21,1
-Crawford,12 Franklin,U.S. House,2,D,Margie Wakefield,62,18,42,2
-Crawford,13 Franklin,U.S. House,2,D,Margie Wakefield,2,0,2,0
-Crawford,14 Frontenac W1,U.S. House,2,D,Margie Wakefield,166,52,108,6
-Crawford,15 Frontenac W2,U.S. House,2,D,Margie Wakefield,245,53,189,3
-Crawford,16 Frontenac W3,U.S. House,2,D,Margie Wakefield,91,18,71,2
-Crawford,17 Frontenac W4,U.S. House,2,D,Margie Wakefield,76,24,51,1
-Crawford,18 Girard W1,U.S. House,2,D,Margie Wakefield,31,4,27,0
-Crawford,19 Girard W2,U.S. House,2,D,Margie Wakefield,102,24,78,0
-Crawford,20 Girard W3,U.S. House,2,D,Margie Wakefield,82,18,64,0
-Crawford,21 Girard W4,U.S. House,2,D,Margie Wakefield,84,14,67,3
-Crawford,22 Grant,U.S. House,2,D,Margie Wakefield,26,6,20,0
-Crawford,23 Hepler,U.S. House,2,D,Margie Wakefield,7,2,5,0
-Crawford,24 Lincoln,U.S. House,2,D,Margie Wakefield,45,11,33,1
-Crawford,25 Lincoln,U.S. House,2,D,Margie Wakefield,1,0,1,0
-Crawford,26 Lincoln-Arcadia,U.S. House,2,D,Margie Wakefield,14,3,11,0
-Crawford,27 Lone Star,U.S. House,2,D,Margie Wakefield,177,31,141,5
-Crawford,28 McCune,U.S. House,2,D,Margie Wakefield,47,6,40,1
-Crawford,29 Mulberry W1,U.S. House,2,D,Margie Wakefield,13,0,13,0
-Crawford,30 Mulberry W2,U.S. House,2,D,Margie Wakefield,16,3,13,0
-Crawford,31 North Arma,U.S. House,2,D,Margie Wakefield,101,28,71,2
-Crawford,32 Opolis,U.S. House,2,D,Margie Wakefield,48,11,35,2
-Crawford,33 Osage-McCune,U.S. House,2,D,Margie Wakefield,26,3,23,0
-Crawford,34 Parkview,U.S. House,2,D,Margie Wakefield,47,11,34,2
-Crawford,35 Parkview,U.S. House,2,D,Margie Wakefield,45,13,27,5
-Crawford,36 Pittsburg W1P1,U.S. House,2,D,Margie Wakefield,68,17,45,6
-Crawford,37 Pittsburg W1P2,U.S. House,2,D,Margie Wakefield,166,41,116,9
-Crawford,38 Pittsburg W1P3,U.S. House,2,D,Margie Wakefield,358,109,239,10
-Crawford,39 Pittsburg W2P1,U.S. House,2,D,Margie Wakefield,66,13,50,3
-Crawford,40 Pittsburg W2P2,U.S. House,2,D,Margie Wakefield,107,30,74,3
-Crawford,41 Pittsburg W2P3,U.S. House,2,D,Margie Wakefield,139,39,95,5
-Crawford,42 Pittsburg W2P4,U.S. House,2,D,Margie Wakefield,91,24,66,1
-Crawford,43 Pittsburg W2P5,U.S. House,2,D,Margie Wakefield,108,27,71,10
-Crawford,44 Pittsburg W3P1,U.S. House,2,D,Margie Wakefield,96,18,72,6
-Crawford,45 Pittsburg W3P2,U.S. House,2,D,Margie Wakefield,106,29,74,3
-Crawford,46 Pittsburg W4P1,U.S. House,2,D,Margie Wakefield,45,6,37,2
-Crawford,47 Pittsburg W4P2,U.S. House,2,D,Margie Wakefield,82,30,48,4
-Crawford,48 Pittsburg W4P3,U.S. House,2,D,Margie Wakefield,146,47,95,4
-Crawford,49 Pittsburg W4P4,U.S. House,2,D,Margie Wakefield,71,16,52,3
-Crawford,50 Pittsburg W4P5,U.S. House,2,D,Margie Wakefield,185,49,133,3
-Crawford,51 Pittsburg W4P6,U.S. House,2,D,Margie Wakefield,21,3,18,0
-Crawford,52 Raymond,U.S. House,2,D,Margie Wakefield,93,26,66,1
-Crawford,53 Sheridan-Cherokee,U.S. House,2,D,Margie Wakefield,18,1,16,1
-Crawford,54 Sheridan,U.S. House,2,D,Margie Wakefield,19,2,17,0
-Crawford,55 Sherman,U.S. House,2,D,Margie Wakefield,74,13,61,0
-Crawford,56 Smelter,U.S. House,2,D,Margie Wakefield,87,26,59,2
-Crawford,57 South Arma,U.S. House,2,D,Margie Wakefield,120,36,80,4
-Crawford,58 Walnut,U.S. House,2,D,Margie Wakefield,8,2,6,0
-Crawford,59 Walnut twp,U.S. House,2,D,Margie Wakefield,1,0,1,0
-Crawford,60 Walnut twp,U.S. House,2,D,Margie Wakefield,5,0,4,1
-Crawford,61 Walnut-Hepler,U.S. House,2,D,Margie Wakefield,1,0,1,0
-Crawford,62 Walnut-Hepler,U.S. House,2,D,Margie Wakefield,8,0,8,0
-Crawford,09 Chicopee,U.S. House,2,,Write-ins,1,0,1,0
-Crawford,15 Frontenac W2,U.S. House,2,,Write-ins,2,0,2,0
-Crawford,27 Lone Star,U.S. House,2,,Write-ins,1,0,1,0
-Crawford,31 North Arma,U.S. House,2,,Write-ins,1,1,0,0
-Crawford,32 Opolis,U.S. House,2,,Write-ins,2,0,2,0
-Crawford,37 Pittsburg W1P2,U.S. House,2,,Write-ins,4,0,4,0
-Crawford,40 Pittsburg W2P2,U.S. House,2,,Write-ins,1,0,1,0
-Crawford,45 Pittsburg W3P2,U.S. House,2,,Write-ins,1,1,0,0
-Crawford,46 Pittsburg W4P1,U.S. House,2,,Write-ins,1,0,1,0
-Crawford,47 Pittsburg W4P2,U.S. House,2,,Write-ins,2,0,2,0
-Crawford,48 Pittsburg W4P3,U.S. House,2,,Write-ins,1,0,1,0
-Crawford,56 Smelter,U.S. House,2,,Write-ins,1,0,1,0
-Crawford,01 Arcadia,Governor,,L,Keen Umbehr,6,1,5,0
-Crawford,02 Baker,Governor,,L,Keen Umbehr,12,3,9,0
-Crawford,03 Beulah,Governor,,L,Keen Umbehr,2,0,2,0
-Crawford,04 Brazilton,Governor,,L,Keen Umbehr,3,0,3,0
-Crawford,05 Capaldo,Governor,,L,Keen Umbehr,0,0,0,
-Crawford,06 Capaldo,Governor,,L,Keen Umbehr,5,1,4,0
-Crawford,07 Cherokee,Governor,,L,Keen Umbehr,9,2,7,0
-Crawford,08 Cherokee-Sheridan,Governor,,L,Keen Umbehr,6,0,6,0
-Crawford,09 Chicopee,Governor,,L,Keen Umbehr,4,0,4,0
-Crawford,10 Crawford,Governor,,L,Keen Umbehr,10,0,10,0
-Crawford,11 Crowe,Governor,,L,Keen Umbehr,4,2,2,0
-Crawford,12 Franklin,Governor,,L,Keen Umbehr,5,0,5,0
-Crawford,13 Franklin,Governor,,L,Keen Umbehr,0,0,0,
-Crawford,14 Frontenac W1,Governor,,L,Keen Umbehr,7,0,6,1
-Crawford,15 Frontenac W2,Governor,,L,Keen Umbehr,11,2,9,0
-Crawford,16 Frontenac W3,Governor,,L,Keen Umbehr,10,1,9,0
-Crawford,17 Frontenac W4,Governor,,L,Keen Umbehr,4,0,3,1
-Crawford,18 Girard W1,Governor,,L,Keen Umbehr,6,0,6,0
-Crawford,19 Girard W2,Governor,,L,Keen Umbehr,8,0,8,0
-Crawford,20 Girard W3,Governor,,L,Keen Umbehr,7,2,5,0
-Crawford,21 Girard W4,Governor,,L,Keen Umbehr,13,2,10,1
-Crawford,22 Grant,Governor,,L,Keen Umbehr,3,0,3,0
-Crawford,23 Hepler,Governor,,L,Keen Umbehr,1,0,1,0
-Crawford,24 Lincoln,Governor,,L,Keen Umbehr,5,1,4,0
-Crawford,25 Lincoln,Governor,,L,Keen Umbehr,0,0,0,
-Crawford,26 Lincoln-Arcadia,Governor,,L,Keen Umbehr,2,0,2,0
-Crawford,27 Lone Star,Governor,,L,Keen Umbehr,13,0,12,1
-Crawford,28 McCune,Governor,,L,Keen Umbehr,10,0,10,0
-Crawford,29 Mulberry W1,Governor,,L,Keen Umbehr,2,0,2,0
-Crawford,30 Mulberry W2,Governor,,L,Keen Umbehr,3,0,3,0
-Crawford,31 North Arma,Governor,,L,Keen Umbehr,2,0,1,1
-Crawford,32 Opolis,Governor,,L,Keen Umbehr,1,1,0,0
-Crawford,33 Osage-McCune,Governor,,L,Keen Umbehr,3,0,3,0
-Crawford,34 Parkview,Governor,,L,Keen Umbehr,3,0,3,0
-Crawford,35 Parkview,Governor,,L,Keen Umbehr,4,0,4,0
-Crawford,36 Pittsburg W1P1,Governor,,L,Keen Umbehr,7,1,5,1
-Crawford,37 Pittsburg W1P2,Governor,,L,Keen Umbehr,6,0,4,2
-Crawford,38 Pittsburg W1P3,Governor,,L,Keen Umbehr,25,4,20,1
-Crawford,39 Pittsburg W2P1,Governor,,L,Keen Umbehr,5,0,5,0
-Crawford,40 Pittsburg W2P2,Governor,,L,Keen Umbehr,5,0,3,2
-Crawford,41 Pittsburg W2P3,Governor,,L,Keen Umbehr,8,1,7,0
-Crawford,42 Pittsburg W2P4,Governor,,L,Keen Umbehr,4,2,2,0
-Crawford,43 Pittsburg W2P5,Governor,,L,Keen Umbehr,5,1,3,1
-Crawford,44 Pittsburg W3P1,Governor,,L,Keen Umbehr,8,0,8,0
-Crawford,45 Pittsburg W3P2,Governor,,L,Keen Umbehr,11,1,10,0
-Crawford,46 Pittsburg W4P1,Governor,,L,Keen Umbehr,2,1,1,0
-Crawford,47 Pittsburg W4P2,Governor,,L,Keen Umbehr,5,0,5,0
-Crawford,48 Pittsburg W4P3,Governor,,L,Keen Umbehr,12,0,10,2
-Crawford,49 Pittsburg W4P4,Governor,,L,Keen Umbehr,6,0,5,1
-Crawford,50 Pittsburg W4P5,Governor,,L,Keen Umbehr,10,3,7,0
-Crawford,51 Pittsburg W4P6,Governor,,L,Keen Umbehr,0,0,0,
-Crawford,52 Raymond,Governor,,L,Keen Umbehr,9,0,9,0
-Crawford,53 Sheridan-Cherokee,Governor,,L,Keen Umbehr,6,1,5,0
-Crawford,54 Sheridan,Governor,,L,Keen Umbehr,4,0,4,0
-Crawford,55 Sherman,Governor,,L,Keen Umbehr,8,1,7,0
-Crawford,56 Smelter,Governor,,L,Keen Umbehr,7,2,5,0
-Crawford,57 South Arma,Governor,,L,Keen Umbehr,13,2,11,0
-Crawford,58 Walnut,Governor,,L,Keen Umbehr,3,1,2,0
-Crawford,59 Walnut twp,Governor,,L,Keen Umbehr,0,0,0,
-Crawford,60 Walnut twp,Governor,,L,Keen Umbehr,0,0,0,
-Crawford,61 Walnut-Hepler,Governor,,L,Keen Umbehr,1,0,1,0
-Crawford,62 Walnut-Hepler,Governor,,L,Keen Umbehr,2,0,2,0
-Crawford,01 Arcadia,Governor,,D,Paul Davis,53,16,33,4
-Crawford,02 Baker,Governor,,D,Paul Davis,192,40,142,10
-Crawford,03 Beulah,Governor,,D,Paul Davis,45,8,36,1
-Crawford,04 Brazilton,Governor,,D,Paul Davis,12,0,11,1
-Crawford,05 Capaldo,Governor,,D,Paul Davis,13,1,12,0
-Crawford,06 Capaldo,Governor,,D,Paul Davis,85,19,65,1
-Crawford,07 Cherokee,Governor,,D,Paul Davis,89,7,80,2
-Crawford,08 Cherokee-Sheridan,Governor,,D,Paul Davis,57,5,52,0
-Crawford,09 Chicopee,Governor,,D,Paul Davis,125,23,98,4
-Crawford,10 Crawford,Governor,,D,Paul Davis,59,7,49,3
-Crawford,11 Crowe,Governor,,D,Paul Davis,42,11,30,1
-Crawford,12 Franklin,Governor,,D,Paul Davis,73,20,50,3
-Crawford,13 Franklin,Governor,,D,Paul Davis,4,0,4,0
-Crawford,14 Frontenac W1,Governor,,D,Paul Davis,204,60,137,7
-Crawford,15 Frontenac W2,Governor,,D,Paul Davis,302,60,237,5
-Crawford,16 Frontenac W3,Governor,,D,Paul Davis,116,24,89,3
-Crawford,17 Frontenac W4,Governor,,D,Paul Davis,96,29,65,2
-Crawford,18 Girard W1,Governor,,D,Paul Davis,42,7,35,0
-Crawford,19 Girard W2,Governor,,D,Paul Davis,133,24,109,0
-Crawford,20 Girard W3,Governor,,D,Paul Davis,108,20,86,2
-Crawford,21 Girard W4,Governor,,D,Paul Davis,116,19,95,2
-Crawford,22 Grant,Governor,,D,Paul Davis,45,6,39,0
-Crawford,23 Hepler,Governor,,D,Paul Davis,22,4,17,1
-Crawford,24 Lincoln,Governor,,D,Paul Davis,56,13,42,1
-Crawford,25 Lincoln,Governor,,D,Paul Davis,1,0,1,0
-Crawford,26 Lincoln-Arcadia,Governor,,D,Paul Davis,19,5,14,0
-Crawford,27 Lone Star,Governor,,D,Paul Davis,233,40,189,4
-Crawford,28 McCune,Governor,,D,Paul Davis,61,7,52,2
-Crawford,29 Mulberry W1,Governor,,D,Paul Davis,26,0,26,0
-Crawford,30 Mulberry W2,Governor,,D,Paul Davis,19,6,13,0
-Crawford,31 North Arma,Governor,,D,Paul Davis,122,30,90,2
-Crawford,32 Opolis,Governor,,D,Paul Davis,69,13,54,2
-Crawford,33 Osage-McCune,Governor,,D,Paul Davis,45,6,39,0
-Crawford,34 Parkview,Governor,,D,Paul Davis,55,16,37,2
-Crawford,35 Parkview,Governor,,D,Paul Davis,50,14,30,6
-Crawford,36 Pittsburg W1P1,Governor,,D,Paul Davis,84,18,58,8
-Crawford,37 Pittsburg W1P2,Governor,,D,Paul Davis,211,50,151,10
-Crawford,38 Pittsburg W1P3,Governor,,D,Paul Davis,450,123,317,10
-Crawford,39 Pittsburg W2P1,Governor,,D,Paul Davis,90,13,74,3
-Crawford,40 Pittsburg W2P2,Governor,,D,Paul Davis,128,33,90,5
-Crawford,41 Pittsburg W2P3,Governor,,D,Paul Davis,160,40,114,6
-Crawford,42 Pittsburg W2P4,Governor,,D,Paul Davis,114,29,84,1
-Crawford,43 Pittsburg W2P5,Governor,,D,Paul Davis,143,27,107,9
-Crawford,44 Pittsburg W3P1,Governor,,D,Paul Davis,110,19,86,5
-Crawford,45 Pittsburg W3P2,Governor,,D,Paul Davis,131,33,94,4
-Crawford,46 Pittsburg W4P1,Governor,,D,Paul Davis,56,8,44,4
-Crawford,47 Pittsburg W4P2,Governor,,D,Paul Davis,103,31,67,5
-Crawford,48 Pittsburg W4P3,Governor,,D,Paul Davis,192,53,132,7
-Crawford,49 Pittsburg W4P4,Governor,,D,Paul Davis,87,20,61,6
-Crawford,50 Pittsburg W4P5,Governor,,D,Paul Davis,253,53,196,4
-Crawford,51 Pittsburg W4P6,Governor,,D,Paul Davis,29,7,22,0
-Crawford,52 Raymond,Governor,,D,Paul Davis,142,28,111,3
-Crawford,53 Sheridan-Cherokee,Governor,,D,Paul Davis,22,1,20,1
-Crawford,54 Sheridan,Governor,,D,Paul Davis,19,1,18,0
-Crawford,55 Sherman,Governor,,D,Paul Davis,105,17,87,1
-Crawford,56 Smelter,Governor,,D,Paul Davis,114,29,83,2
-Crawford,57 South Arma,Governor,,D,Paul Davis,159,41,113,5
-Crawford,58 Walnut,Governor,,D,Paul Davis,22,2,20,0
-Crawford,59 Walnut twp,Governor,,D,Paul Davis,2,0,2,0
-Crawford,60 Walnut twp,Governor,,D,Paul Davis,7,0,5,2
-Crawford,61 Walnut-Hepler,Governor,,D,Paul Davis,1,0,1,0
-Crawford,62 Walnut-Hepler,Governor,,D,Paul Davis,9,1,8,0
-Crawford,01 Arcadia,Governor,,R,Sam Brownback,39,5,34,0
-Crawford,02 Baker,Governor,,R,Sam Brownback,197,16,174,7
-Crawford,03 Beulah,Governor,,R,Sam Brownback,45,6,38,1
-Crawford,04 Brazilton,Governor,,R,Sam Brownback,15,2,13,0
-Crawford,05 Capaldo,Governor,,R,Sam Brownback,7,1,6,0
-Crawford,06 Capaldo,Governor,,R,Sam Brownback,59,10,49,0
-Crawford,07 Cherokee,Governor,,R,Sam Brownback,93,7,81,5
-Crawford,08 Cherokee-Sheridan,Governor,,R,Sam Brownback,60,4,55,1
-Crawford,09 Chicopee,Governor,,R,Sam Brownback,111,20,90,1
-Crawford,10 Crawford,Governor,,R,Sam Brownback,100,8,91,1
-Crawford,11 Crowe,Governor,,R,Sam Brownback,35,3,31,1
-Crawford,12 Franklin,Governor,,R,Sam Brownback,54,5,47,2
-Crawford,13 Franklin,Governor,,R,Sam Brownback,2,1,1,0
-Crawford,14 Frontenac W1,Governor,,R,Sam Brownback,93,17,71,5
-Crawford,15 Frontenac W2,Governor,,R,Sam Brownback,144,33,106,5
-Crawford,16 Frontenac W3,Governor,,R,Sam Brownback,56,4,50,2
-Crawford,17 Frontenac W4,Governor,,R,Sam Brownback,39,3,35,1
-Crawford,18 Girard W1,Governor,,R,Sam Brownback,34,2,32,0
-Crawford,19 Girard W2,Governor,,R,Sam Brownback,125,24,99,2
-Crawford,20 Girard W3,Governor,,R,Sam Brownback,55,5,47,3
-Crawford,21 Girard W4,Governor,,R,Sam Brownback,118,20,94,4
-Crawford,22 Grant,Governor,,R,Sam Brownback,65,6,59,0
-Crawford,23 Hepler,Governor,,R,Sam Brownback,10,0,9,1
-Crawford,24 Lincoln,Governor,,R,Sam Brownback,63,7,56,0
-Crawford,25 Lincoln,Governor,,R,Sam Brownback,4,0,4,0
-Crawford,26 Lincoln-Arcadia,Governor,,R,Sam Brownback,11,1,9,1
-Crawford,27 Lone Star,Governor,,R,Sam Brownback,202,17,182,3
-Crawford,28 McCune,Governor,,R,Sam Brownback,50,6,43,1
-Crawford,29 Mulberry W1,Governor,,R,Sam Brownback,23,4,19,0
-Crawford,30 Mulberry W2,Governor,,R,Sam Brownback,26,1,25,0
-Crawford,31 North Arma,Governor,,R,Sam Brownback,120,17,102,1
-Crawford,32 Opolis,Governor,,R,Sam Brownback,65,8,56,1
-Crawford,33 Osage-McCune,Governor,,R,Sam Brownback,116,8,108,0
-Crawford,34 Parkview,Governor,,R,Sam Brownback,20,0,18,2
-Crawford,35 Parkview,Governor,,R,Sam Brownback,40,3,36,1
-Crawford,36 Pittsburg W1P1,Governor,,R,Sam Brownback,90,12,74,4
-Crawford,37 Pittsburg W1P2,Governor,,R,Sam Brownback,147,16,130,1
-Crawford,38 Pittsburg W1P3,Governor,,R,Sam Brownback,393,61,325,7
-Crawford,39 Pittsburg W2P1,Governor,,R,Sam Brownback,55,4,50,1
-Crawford,40 Pittsburg W2P2,Governor,,R,Sam Brownback,85,8,76,1
-Crawford,41 Pittsburg W2P3,Governor,,R,Sam Brownback,84,15,66,3
-Crawford,42 Pittsburg W2P4,Governor,,R,Sam Brownback,97,11,83,3
-Crawford,43 Pittsburg W2P5,Governor,,R,Sam Brownback,146,20,121,5
-Crawford,44 Pittsburg W3P1,Governor,,R,Sam Brownback,85,12,67,6
-Crawford,45 Pittsburg W3P2,Governor,,R,Sam Brownback,100,14,82,4
-Crawford,46 Pittsburg W4P1,Governor,,R,Sam Brownback,27,4,22,1
-Crawford,47 Pittsburg W4P2,Governor,,R,Sam Brownback,48,10,29,9
-Crawford,48 Pittsburg W4P3,Governor,,R,Sam Brownback,121,14,104,3
-Crawford,49 Pittsburg W4P4,Governor,,R,Sam Brownback,53,7,42,4
-Crawford,50 Pittsburg W4P5,Governor,,R,Sam Brownback,227,38,185,4
-Crawford,51 Pittsburg W4P6,Governor,,R,Sam Brownback,49,4,45,0
-Crawford,52 Raymond,Governor,,R,Sam Brownback,127,18,106,3
-Crawford,53 Sheridan-Cherokee,Governor,,R,Sam Brownback,15,1,14,0
-Crawford,54 Sheridan,Governor,,R,Sam Brownback,21,2,19,0
-Crawford,55 Sherman,Governor,,R,Sam Brownback,114,5,108,1
-Crawford,56 Smelter,Governor,,R,Sam Brownback,130,6,122,2
-Crawford,57 South Arma,Governor,,R,Sam Brownback,103,16,86,1
-Crawford,58 Walnut,Governor,,R,Sam Brownback,22,2,20,0
-Crawford,59 Walnut twp,Governor,,R,Sam Brownback,0,0,0,
-Crawford,60 Walnut twp,Governor,,R,Sam Brownback,9,0,9,0
-Crawford,61 Walnut-Hepler,Governor,,R,Sam Brownback,0,0,0,
-Crawford,62 Walnut-Hepler,Governor,,R,Sam Brownback,8,1,7,0
-Crawford,02 Baker,Governor,,,Write-ins,2,0,2,0
-Crawford,15 Frontenac W2,Governor,,,Write-ins,1,0,1,0
-Crawford,27 Lone Star,Governor,,,Write-ins,1,0,1,0
-Crawford,43 Pittsburg W2P5,Governor,,,Write-ins,1,0,1,0
-Crawford,50 Pittsburg W4P5,Governor,,,Write-ins,1,0,0,1
-Crawford,01 Arcadia,Insurance Commissioner,,D,Dennis Anderson,57,16,39,2
-Crawford,02 Baker,Insurance Commissioner,,D,Dennis Anderson,157,41,108,8
-Crawford,03 Beulah,Insurance Commissioner,,D,Dennis Anderson,30,5,25,0
-Crawford,04 Brazilton,Insurance Commissioner,,D,Dennis Anderson,6,0,5,1
-Crawford,05 Capaldo,Insurance Commissioner,,D,Dennis Anderson,9,1,8,0
-Crawford,06 Capaldo,Insurance Commissioner,,D,Dennis Anderson,72,17,54,1
-Crawford,07 Cherokee,Insurance Commissioner,,D,Dennis Anderson,85,7,76,2
-Crawford,08 Cherokee-Sheridan,Insurance Commissioner,,D,Dennis Anderson,45,3,42,0
-Crawford,09 Chicopee,Insurance Commissioner,,D,Dennis Anderson,91,20,68,3
-Crawford,10 Crawford,Insurance Commissioner,,D,Dennis Anderson,31,3,27,1
-Crawford,11 Crowe,Insurance Commissioner,,D,Dennis Anderson,40,13,25,2
-Crawford,12 Franklin,Insurance Commissioner,,D,Dennis Anderson,68,19,46,3
-Crawford,13 Franklin,Insurance Commissioner,,D,Dennis Anderson,3,0,3,0
-Crawford,14 Frontenac W1,Insurance Commissioner,,D,Dennis Anderson,174,58,110,6
-Crawford,15 Frontenac W2,Insurance Commissioner,,D,Dennis Anderson,266,54,207,5
-Crawford,16 Frontenac W3,Insurance Commissioner,,D,Dennis Anderson,97,22,73,2
-Crawford,17 Frontenac W4,Insurance Commissioner,,D,Dennis Anderson,81,25,54,2
-Crawford,18 Girard W1,Insurance Commissioner,,D,Dennis Anderson,39,6,33,0
-Crawford,19 Girard W2,Insurance Commissioner,,D,Dennis Anderson,114,24,90,0
-Crawford,20 Girard W3,Insurance Commissioner,,D,Dennis Anderson,92,18,72,2
-Crawford,21 Girard W4,Insurance Commissioner,,D,Dennis Anderson,99,16,81,2
-Crawford,22 Grant,Insurance Commissioner,,D,Dennis Anderson,37,6,31,0
-Crawford,23 Hepler,Insurance Commissioner,,D,Dennis Anderson,19,4,13,2
-Crawford,24 Lincoln,Insurance Commissioner,,D,Dennis Anderson,53,14,38,1
-Crawford,25 Lincoln,Insurance Commissioner,,D,Dennis Anderson,0,0,0,
-Crawford,26 Lincoln-Arcadia,Insurance Commissioner,,D,Dennis Anderson,22,5,17,0
-Crawford,27 Lone Star,Insurance Commissioner,,D,Dennis Anderson,187,34,149,4
-Crawford,28 McCune,Insurance Commissioner,,D,Dennis Anderson,58,8,48,2
-Crawford,29 Mulberry W1,Insurance Commissioner,,D,Dennis Anderson,28,0,28,0
-Crawford,30 Mulberry W2,Insurance Commissioner,,D,Dennis Anderson,19,5,14,0
-Crawford,31 North Arma,Insurance Commissioner,,D,Dennis Anderson,112,30,80,2
-Crawford,32 Opolis,Insurance Commissioner,,D,Dennis Anderson,50,11,37,2
-Crawford,33 Osage-McCune,Insurance Commissioner,,D,Dennis Anderson,35,5,30,0
-Crawford,34 Parkview,Insurance Commissioner,,D,Dennis Anderson,46,13,31,2
-Crawford,35 Parkview,Insurance Commissioner,,D,Dennis Anderson,51,13,32,6
-Crawford,36 Pittsburg W1P1,Insurance Commissioner,,D,Dennis Anderson,73,18,50,5
-Crawford,37 Pittsburg W1P2,Insurance Commissioner,,D,Dennis Anderson,175,43,123,9
-Crawford,38 Pittsburg W1P3,Insurance Commissioner,,D,Dennis Anderson,388,112,264,12
-Crawford,39 Pittsburg W2P1,Insurance Commissioner,,D,Dennis Anderson,82,12,67,3
-Crawford,40 Pittsburg W2P2,Insurance Commissioner,,D,Dennis Anderson,114,31,78,5
-Crawford,41 Pittsburg W2P3,Insurance Commissioner,,D,Dennis Anderson,139,40,93,6
-Crawford,42 Pittsburg W2P4,Insurance Commissioner,,D,Dennis Anderson,95,26,67,2
-Crawford,43 Pittsburg W2P5,Insurance Commissioner,,D,Dennis Anderson,110,28,75,7
-Crawford,44 Pittsburg W3P1,Insurance Commissioner,,D,Dennis Anderson,104,18,80,6
-Crawford,45 Pittsburg W3P2,Insurance Commissioner,,D,Dennis Anderson,119,31,83,5
-Crawford,46 Pittsburg W4P1,Insurance Commissioner,,D,Dennis Anderson,52,10,39,3
-Crawford,47 Pittsburg W4P2,Insurance Commissioner,,D,Dennis Anderson,94,30,57,7
-Crawford,48 Pittsburg W4P3,Insurance Commissioner,,D,Dennis Anderson,173,47,120,6
-Crawford,49 Pittsburg W4P4,Insurance Commissioner,,D,Dennis Anderson,82,20,58,4
-Crawford,50 Pittsburg W4P5,Insurance Commissioner,,D,Dennis Anderson,198,50,146,2
-Crawford,51 Pittsburg W4P6,Insurance Commissioner,,D,Dennis Anderson,27,7,20,0
-Crawford,52 Raymond,Insurance Commissioner,,D,Dennis Anderson,99,26,71,2
-Crawford,53 Sheridan-Cherokee,Insurance Commissioner,,D,Dennis Anderson,24,2,21,1
-Crawford,54 Sheridan,Insurance Commissioner,,D,Dennis Anderson,23,2,21,0
-Crawford,55 Sherman,Insurance Commissioner,,D,Dennis Anderson,81,14,67,0
-Crawford,56 Smelter,Insurance Commissioner,,D,Dennis Anderson,94,27,65,2
-Crawford,57 South Arma,Insurance Commissioner,,D,Dennis Anderson,146,43,99,4
-Crawford,58 Walnut,Insurance Commissioner,,D,Dennis Anderson,19,3,16,0
-Crawford,59 Walnut twp,Insurance Commissioner,,D,Dennis Anderson,1,0,1,0
-Crawford,60 Walnut twp,Insurance Commissioner,,D,Dennis Anderson,4,0,4,0
-Crawford,61 Walnut-Hepler,Insurance Commissioner,,D,Dennis Anderson,1,0,1,0
-Crawford,62 Walnut-Hepler,Insurance Commissioner,,D,Dennis Anderson,6,0,6,0
-Crawford,01 Arcadia,Insurance Commissioner,,R,Ken Selzer,41,6,34,1
-Crawford,02 Baker,Insurance Commissioner,,R,Ken Selzer,228,16,204,8
-Crawford,03 Beulah,Insurance Commissioner,,R,Ken Selzer,55,9,44,2
-Crawford,04 Brazilton,Insurance Commissioner,,R,Ken Selzer,24,2,22,0
-Crawford,05 Capaldo,Insurance Commissioner,,R,Ken Selzer,12,1,11,0
-Crawford,06 Capaldo,Insurance Commissioner,,R,Ken Selzer,72,12,60,0
-Crawford,07 Cherokee,Insurance Commissioner,,R,Ken Selzer,100,7,88,5
-Crawford,08 Cherokee-Sheridan,Insurance Commissioner,,R,Ken Selzer,75,5,69,1
-Crawford,09 Chicopee,Insurance Commissioner,,R,Ken Selzer,139,21,116,2
-Crawford,10 Crawford,Insurance Commissioner,,R,Ken Selzer,133,12,118,3
-Crawford,11 Crowe,Insurance Commissioner,,R,Ken Selzer,40,3,37,0
-Crawford,12 Franklin,Insurance Commissioner,,R,Ken Selzer,61,5,54,2
-Crawford,13 Franklin,Insurance Commissioner,,R,Ken Selzer,3,1,2,0
-Crawford,14 Frontenac W1,Insurance Commissioner,,R,Ken Selzer,114,17,93,4
-Crawford,15 Frontenac W2,Insurance Commissioner,,R,Ken Selzer,176,33,137,6
-Crawford,16 Frontenac W3,Insurance Commissioner,,R,Ken Selzer,75,5,67,3
-Crawford,17 Frontenac W4,Insurance Commissioner,,R,Ken Selzer,55,8,46,1
-Crawford,18 Girard W1,Insurance Commissioner,,R,Ken Selzer,40,2,38,0
-Crawford,19 Girard W2,Insurance Commissioner,,R,Ken Selzer,136,22,112,2
-Crawford,20 Girard W3,Insurance Commissioner,,R,Ken Selzer,75,9,63,3
-Crawford,21 Girard W4,Insurance Commissioner,,R,Ken Selzer,138,21,112,5
-Crawford,22 Grant,Insurance Commissioner,,R,Ken Selzer,67,5,62,0
-Crawford,23 Hepler,Insurance Commissioner,,R,Ken Selzer,14,0,14,0
-Crawford,24 Lincoln,Insurance Commissioner,,R,Ken Selzer,70,7,63,0
-Crawford,25 Lincoln,Insurance Commissioner,,R,Ken Selzer,4,0,4,0
-Crawford,26 Lincoln-Arcadia,Insurance Commissioner,,R,Ken Selzer,9,1,7,1
-Crawford,27 Lone Star,Insurance Commissioner,,R,Ken Selzer,249,22,223,4
-Crawford,28 McCune,Insurance Commissioner,,R,Ken Selzer,57,4,52,1
-Crawford,29 Mulberry W1,Insurance Commissioner,,R,Ken Selzer,22,3,19,0
-Crawford,30 Mulberry W2,Insurance Commissioner,,R,Ken Selzer,25,1,24,0
-Crawford,31 North Arma,Insurance Commissioner,,R,Ken Selzer,121,14,105,2
-Crawford,32 Opolis,Insurance Commissioner,,R,Ken Selzer,84,11,72,1
-Crawford,33 Osage-McCune,Insurance Commissioner,,R,Ken Selzer,126,9,117,0
-Crawford,34 Parkview,Insurance Commissioner,,R,Ken Selzer,30,2,26,2
-Crawford,35 Parkview,Insurance Commissioner,,R,Ken Selzer,38,4,33,1
-Crawford,36 Pittsburg W1P1,Insurance Commissioner,,R,Ken Selzer,96,13,76,7
-Crawford,37 Pittsburg W1P2,Insurance Commissioner,,R,Ken Selzer,182,22,156,4
-Crawford,38 Pittsburg W1P3,Insurance Commissioner,,R,Ken Selzer,447,71,369,7
-Crawford,39 Pittsburg W2P1,Insurance Commissioner,,R,Ken Selzer,63,5,57,1
-Crawford,40 Pittsburg W2P2,Insurance Commissioner,,R,Ken Selzer,98,9,86,3
-Crawford,41 Pittsburg W2P3,Insurance Commissioner,,R,Ken Selzer,107,16,88,3
-Crawford,42 Pittsburg W2P4,Insurance Commissioner,,R,Ken Selzer,117,15,100,2
-Crawford,43 Pittsburg W2P5,Insurance Commissioner,,R,Ken Selzer,170,18,147,5
-Crawford,44 Pittsburg W3P1,Insurance Commissioner,,R,Ken Selzer,93,11,76,6
-Crawford,45 Pittsburg W3P2,Insurance Commissioner,,R,Ken Selzer,113,17,93,3
-Crawford,46 Pittsburg W4P1,Insurance Commissioner,,R,Ken Selzer,31,3,26,2
-Crawford,47 Pittsburg W4P2,Insurance Commissioner,,R,Ken Selzer,52,10,36,6
-Crawford,48 Pittsburg W4P3,Insurance Commissioner,,R,Ken Selzer,145,18,121,6
-Crawford,49 Pittsburg W4P4,Insurance Commissioner,,R,Ken Selzer,58,5,47,6
-Crawford,50 Pittsburg W4P5,Insurance Commissioner,,R,Ken Selzer,264,43,215,6
-Crawford,51 Pittsburg W4P6,Insurance Commissioner,,R,Ken Selzer,48,4,44,0
-Crawford,52 Raymond,Insurance Commissioner,,R,Ken Selzer,167,18,147,2
-Crawford,53 Sheridan-Cherokee,Insurance Commissioner,,R,Ken Selzer,17,1,16,0
-Crawford,54 Sheridan,Insurance Commissioner,,R,Ken Selzer,21,1,20,0
-Crawford,55 Sherman,Insurance Commissioner,,R,Ken Selzer,136,6,129,1
-Crawford,56 Smelter,Insurance Commissioner,,R,Ken Selzer,152,8,142,2
-Crawford,57 South Arma,Insurance Commissioner,,R,Ken Selzer,121,13,106,2
-Crawford,58 Walnut,Insurance Commissioner,,R,Ken Selzer,24,2,22,0
-Crawford,59 Walnut twp,Insurance Commissioner,,R,Ken Selzer,1,0,1,0
-Crawford,60 Walnut twp,Insurance Commissioner,,R,Ken Selzer,11,0,9,2
-Crawford,61 Walnut-Hepler,Insurance Commissioner,,R,Ken Selzer,0,0,0,
-Crawford,62 Walnut-Hepler,Insurance Commissioner,,R,Ken Selzer,13,2,11,0
-Crawford,02 Baker,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,08 Cherokee-Sheridan,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,09 Chicopee,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,15 Frontenac W2,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,26 Lincoln-Arcadia,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,27 Lone Star,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,38 Pittsburg W1P3,Insurance Commissioner,,,Write-ins,1,1,0,0
-Crawford,40 Pittsburg W2P2,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,42 Pittsburg W2P4,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,45 Pittsburg W3P2,Insurance Commissioner,,,Write-ins,2,1,1,0
-Crawford,48 Pittsburg W4P3,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,57 South Arma,Insurance Commissioner,,,Write-ins,1,0,1,0
-Crawford,01 Arcadia,REG,,,Registered Voters,236,,,
-Crawford,02 Baker,REG,,,Registered Voters,688,,,
-Crawford,03 Beulah,REG,,,Registered Voters,191,,,
-Crawford,04 Brazilton,REG,,,Registered Voters,48,,,
-Crawford,05 Capaldo,REG,,,Registered Voters,60,,,
-Crawford,06 Capaldo,REG,,,Registered Voters,299,,,
-Crawford,07 Cherokee,REG,,,Registered Voters,380,,,
-Crawford,08 Cherokee-Sheridan,REG,,,Registered Voters,209,,,
-Crawford,09 Chicopee,REG,,,Registered Voters,357,,,
-Crawford,10 Crawford,REG,,,Registered Voters,290,,,
-Crawford,11 Crowe,REG,,,Registered Voters,173,,,
-Crawford,12 Franklin,REG,,,Registered Voters,280,,,
-Crawford,13 Franklin,REG,,,Registered Voters,19,,,
-Crawford,14 Frontenac W1,REG,,,Registered Voters,667,,,
-Crawford,15 Frontenac W2,REG,,,Registered Voters,874,,,
-Crawford,16 Frontenac W3,REG,,,Registered Voters,361,,,
-Crawford,17 Frontenac W4,REG,,,Registered Voters,298,,,
-Crawford,18 Girard W1,REG,,,Registered Voters,202,,,
-Crawford,19 Girard W2,REG,,,Registered Voters,566,,,
-Crawford,20 Girard W3,REG,,,Registered Voters,400,,,
-Crawford,21 Girard W4,REG,,,Registered Voters,526,,,
-Crawford,22 Grant,REG,,,Registered Voters,182,,,
-Crawford,23 Hepler,REG,,,Registered Voters,73,,,
-Crawford,24 Lincoln,REG,,,Registered Voters,230,,,
-Crawford,25 Lincoln,REG,,,Registered Voters,7,,,
-Crawford,26 Lincoln-Arcadia,REG,,,Registered Voters,94,,,
-Crawford,27 Lone Star,REG,,,Registered Voters,847,,,
-Crawford,28 McCune,REG,,,Registered Voters,265,,,
-Crawford,29 Mulberry W1,REG,,,Registered Voters,147,,,
-Crawford,30 Mulberry W2,REG,,,Registered Voters,180,,,
-Crawford,31 North Arma,REG,,,Registered Voters,577,,,
-Crawford,32 Opolis,REG,,,Registered Voters,249,,,
-Crawford,33 Osage-McCune,REG,,,Registered Voters,256,,,
-Crawford,34 Parkview,REG,,,Registered Voters,161,,,
-Crawford,35 Parkview,REG,,,Registered Voters,179,,,
-Crawford,36 Pittsburg W1P1,REG,,,Registered Voters,602,,,
-Crawford,37 Pittsburg W1P2,REG,,,Registered Voters,986,,,
-Crawford,38 Pittsburg W1P3,REG,,,Registered Voters,"1,796",,,
-Crawford,39 Pittsburg W2P1,REG,,,Registered Voters,452,,,
-Crawford,40 Pittsburg W2P2,REG,,,Registered Voters,489,,,
-Crawford,41 Pittsburg W2P3,REG,,,Registered Voters,598,,,
-Crawford,42 Pittsburg W2P4,REG,,,Registered Voters,407,,,
-Crawford,43 Pittsburg W2P5,REG,,,Registered Voters,772,,,
-Crawford,44 Pittsburg W3P1,REG,,,Registered Voters,631,,,
-Crawford,45 Pittsburg W3P2,REG,,,Registered Voters,721,,,
-Crawford,46 Pittsburg W4P1,REG,,,Registered Voters,285,,,
-Crawford,47 Pittsburg W4P2,REG,,,Registered Voters,546,,,
-Crawford,48 Pittsburg W4P3,REG,,,Registered Voters,816,,,
-Crawford,49 Pittsburg W4P4,REG,,,Registered Voters,502,,,
-Crawford,50 Pittsburg W4P5,REG,,,Registered Voters,987,,,
-Crawford,51 Pittsburg W4P6,REG,,,Registered Voters,148,,,
-Crawford,52 Raymond,REG,,,Registered Voters,490,,,
-Crawford,53 Sheridan-Cherokee,REG,,,Registered Voters,82,,,
-Crawford,54 Sheridan,REG,,,Registered Voters,89,,,
-Crawford,55 Sherman,REG,,,Registered Voters,394,,,
-Crawford,56 Smelter,REG,,,Registered Voters,389,,,
-Crawford,57 South Arma,REG,,,Registered Voters,625,,,
-Crawford,58 Walnut,REG,,,Registered Voters,118,,,
-Crawford,59 Walnut twp,REG,,,Registered Voters,2,,,
-Crawford,60 Walnut twp,REG,,,Registered Voters,29,,,
-Crawford,61 Walnut-Hepler,REG,,,Registered Voters,6,,,
-Crawford,62 Walnut-Hepler,REG,,,Registered Voters,44,,,
-Crawford,01 Arcadia,State House,2,D,Adam Lusker,85,20,62,3
-Crawford,03 Beulah,State House,2,D,Adam Lusker,67,7,58,2
-Crawford,04 Brazilton,State House,2,D,Adam Lusker,20,0,19,1
-Crawford,05 Capaldo,State House,2,D,Adam Lusker,18,1,17,0
-Crawford,06 Capaldo,State House,2,D,Adam Lusker,119,21,97,1
-Crawford,07 Cherokee,State House,2,D,Adam Lusker,134,11,119,4
-Crawford,08 Cherokee-Sheridan,State House,2,D,Adam Lusker,85,5,80,0
-Crawford,10 Crawford,State House,2,D,Adam Lusker,108,8,97,3
-Crawford,11 Crowe,State House,2,D,Adam Lusker,61,15,44,2
-Crawford,12 Franklin,State House,2,D,Adam Lusker,99,21,74,4
-Crawford,13 Franklin,State House,2,D,Adam Lusker,6,1,5,0
-Crawford,14 Frontenac W1,State House,2,D,Adam Lusker,260,68,180,12
-Crawford,15 Frontenac W2,State House,2,D,Adam Lusker,401,81,311,9
-Crawford,16 Frontenac W3,State House,2,D,Adam Lusker,161,29,128,4
-Crawford,17 Frontenac W4,State House,2,D,Adam Lusker,123,28,92,3
-Crawford,18 Girard W1,State House,2,D,Adam Lusker,62,6,56,0
-Crawford,19 Girard W2,State House,2,D,Adam Lusker,196,35,159,2
-Crawford,20 Girard W3,State House,2,D,Adam Lusker,143,24,115,4
-Crawford,21 Girard W4,State House,2,D,Adam Lusker,184,26,151,7
-Crawford,22 Grant,State House,2,D,Adam Lusker,80,11,69,0
-Crawford,23 Hepler,State House,2,D,Adam Lusker,26,4,20,2
-Crawford,24 Lincoln,State House,2,D,Adam Lusker,93,17,76,0
-Crawford,25 Lincoln,State House,2,D,Adam Lusker,2,0,2,0
-Crawford,26 Lincoln-Arcadia,State House,2,D,Adam Lusker,25,4,21,0
-Crawford,28 McCune,State House,2,D,Adam Lusker,91,10,79,2
-Crawford,29 Mulberry W1,State House,2,D,Adam Lusker,43,4,39,0
-Crawford,30 Mulberry W2,State House,2,D,Adam Lusker,29,6,23,0
-Crawford,31 North Arma,State House,2,D,Adam Lusker,176,34,138,4
-Crawford,33 Osage-McCune,State House,2,D,Adam Lusker,103,8,95,0
-Crawford,34 Parkview,State House,2,D,Adam Lusker,67,13,52,2
-Crawford,35 Parkview,State House,2,D,Adam Lusker,78,14,58,6
-Crawford,52 Raymond,State House,2,D,Adam Lusker,203,39,160,4
-Crawford,53 Sheridan-Cherokee,State House,2,D,Adam Lusker,34,3,30,1
-Crawford,55 Sherman,State House,2,D,Adam Lusker,158,20,136,2
-Crawford,57 South Arma,State House,2,D,Adam Lusker,220,52,162,6
-Crawford,58 Walnut,State House,2,D,Adam Lusker,37,3,34,0
-Crawford,59 Walnut twp,State House,2,D,Adam Lusker,2,0,2,0
-Crawford,60 Walnut twp,State House,2,D,Adam Lusker,15,0,13,2
-Crawford,61 Walnut-Hepler,State House,2,D,Adam Lusker,2,0,2,0
-Crawford,62 Walnut-Hepler,State House,2,D,Adam Lusker,16,1,15,0
-Crawford,01 Arcadia,State House,2,,Write-ins,2,0,2,0
-Crawford,03 Beulah,State House,2,,Write-ins,2,0,2,0
-Crawford,06 Capaldo,State House,2,,Write-ins,1,0,1,0
-Crawford,07 Cherokee,State House,2,,Write-ins,7,0,7,0
-Crawford,08 Cherokee-Sheridan,State House,2,,Write-ins,5,0,5,0
-Crawford,10 Crawford,State House,2,,Write-ins,3,0,3,0
-Crawford,11 Crowe,State House,2,,Write-ins,5,0,5,0
-Crawford,12 Franklin,State House,2,,Write-ins,5,0,5,0
-Crawford,14 Frontenac W1,State House,2,,Write-ins,5,0,4,1
-Crawford,15 Frontenac W2,State House,2,,Write-ins,8,1,7,0
-Crawford,16 Frontenac W3,State House,2,,Write-ins,6,0,6,0
-Crawford,17 Frontenac W4,State House,2,,Write-ins,1,1,0,0
-Crawford,18 Girard W1,State House,2,,Write-ins,3,1,2,0
-Crawford,19 Girard W2,State House,2,,Write-ins,4,0,4,0
-Crawford,20 Girard W3,State House,2,,Write-ins,6,0,5,1
-Crawford,21 Girard W4,State House,2,,Write-ins,6,1,5,0
-Crawford,22 Grant,State House,2,,Write-ins,1,0,1,0
-Crawford,24 Lincoln,State House,2,,Write-ins,5,0,5,0
-Crawford,25 Lincoln,State House,2,,Write-ins,1,0,1,0
-Crawford,26 Lincoln-Arcadia,State House,2,,Write-ins,3,1,2,0
-Crawford,28 McCune,State House,2,,Write-ins,7,0,7,0
-Crawford,29 Mulberry W1,State House,2,,Write-ins,2,0,2,0
-Crawford,30 Mulberry W2,State House,2,,Write-ins,1,0,1,0
-Crawford,31 North Arma,State House,2,,Write-ins,5,0,5,0
-Crawford,33 Osage-McCune,State House,2,,Write-ins,5,1,4,0
-Crawford,34 Parkview,State House,2,,Write-ins,2,0,2,0
-Crawford,35 Parkview,State House,2,,Write-ins,5,0,5,0
-Crawford,52 Raymond,State House,2,,Write-ins,8,1,7,0
-Crawford,55 Sherman,State House,2,,Write-ins,3,0,3,0
-Crawford,57 South Arma,State House,2,,Write-ins,7,1,6,0
-Crawford,02 Baker,State House,3,R,Charles Smith,226,17,199,10
-Crawford,02 Baker,State House,3,D,Julie Menghini,179,42,130,7
-Crawford,02 Baker,State House,3,,Write-ins,1,0,1,0
-Crawford,09 Chicopee,State House,3,R,Charles Smith,143,22,118,3
-Crawford,27 Lone Star,State House,3,R,Charles Smith,247,27,217,3
-Crawford,32 Opolis,State House,3,R,Charles Smith,79,9,69,1
-Crawford,36 Pittsburg W1P1,State House,3,R,Charles Smith,91,12,75,4
-Crawford,37 Pittsburg W1P2,State House,3,R,Charles Smith,170,18,147,5
-Crawford,38 Pittsburg W1P3,State House,3,R,Charles Smith,447,70,369,8
-Crawford,39 Pittsburg W2P1,State House,3,R,Charles Smith,69,6,62,1
-Crawford,40 Pittsburg W2P2,State House,3,R,Charles Smith,97,9,86,2
-Crawford,41 Pittsburg W2P3,State House,3,R,Charles Smith,107,16,89,2
-Crawford,42 Pittsburg W2P4,State House,3,R,Charles Smith,111,14,94,3
-Crawford,43 Pittsburg W2P5,State House,3,R,Charles Smith,147,18,124,5
-Crawford,44 Pittsburg W3P1,State House,3,R,Charles Smith,95,11,78,6
-Crawford,45 Pittsburg W3P2,State House,3,R,Charles Smith,119,18,96,5
-Crawford,46 Pittsburg W4P1,State House,3,R,Charles Smith,39,6,31,2
-Crawford,47 Pittsburg W4P2,State House,3,R,Charles Smith,58,13,38,7
-Crawford,48 Pittsburg W4P3,State House,3,R,Charles Smith,158,22,128,8
-Crawford,49 Pittsburg W4P4,State House,3,R,Charles Smith,65,9,49,7
-Crawford,50 Pittsburg W4P5,State House,3,R,Charles Smith,260,37,219,4
-Crawford,51 Pittsburg W4P6,State House,3,R,Charles Smith,51,4,47,0
-Crawford,54 Sheridan,State House,3,R,Charles Smith,26,2,24,0
-Crawford,56 Smelter,State House,3,R,Charles Smith,139,9,128,2
-Crawford,09 Chicopee,State House,3,D,Julie Menghini,91,20,69,2
-Crawford,27 Lone Star,State House,3,D,Julie Menghini,200,30,165,5
-Crawford,32 Opolis,State House,3,D,Julie Menghini,55,13,40,2
-Crawford,36 Pittsburg W1P1,State House,3,D,Julie Menghini,89,19,61,9
-Crawford,37 Pittsburg W1P2,State House,3,D,Julie Menghini,198,50,140,8
-Crawford,38 Pittsburg W1P3,State House,3,D,Julie Menghini,423,118,295,10
-Crawford,39 Pittsburg W2P1,State House,3,D,Julie Menghini,83,12,68,3
-Crawford,40 Pittsburg W2P2,State House,3,D,Julie Menghini,122,33,83,6
-Crawford,41 Pittsburg W2P3,State House,3,D,Julie Menghini,145,41,97,7
-Crawford,42 Pittsburg W2P4,State House,3,D,Julie Menghini,104,29,74,1
-Crawford,43 Pittsburg W2P5,State House,3,D,Julie Menghini,144,30,104,10
-Crawford,44 Pittsburg W3P1,State House,3,D,Julie Menghini,104,20,79,5
-Crawford,45 Pittsburg W3P2,State House,3,D,Julie Menghini,118,31,84,3
-Crawford,46 Pittsburg W4P1,State House,3,D,Julie Menghini,43,6,35,2
-Crawford,47 Pittsburg W4P2,State House,3,D,Julie Menghini,98,28,62,8
-Crawford,48 Pittsburg W4P3,State House,3,D,Julie Menghini,163,44,117,2
-Crawford,49 Pittsburg W4P4,State House,3,D,Julie Menghini,81,19,58,4
-Crawford,50 Pittsburg W4P5,State House,3,D,Julie Menghini,233,59,169,5
-Crawford,51 Pittsburg W4P6,State House,3,D,Julie Menghini,27,7,20,0
-Crawford,54 Sheridan,State House,3,D,Julie Menghini,19,1,18,0
-Crawford,56 Smelter,State House,3,D,Julie Menghini,111,28,81,2
-Crawford,27 Lone Star,State House,3,,Write-ins,2,0,2,0
-Crawford,32 Opolis,State House,3,,Write-ins,1,0,1,0
-Crawford,38 Pittsburg W1P3,State House,3,,Write-ins,1,0,1,0
-Crawford,41 Pittsburg W2P3,State House,3,,Write-ins,1,0,1,0
-Crawford,45 Pittsburg W3P2,State House,3,,Write-ins,1,0,1,0
-Crawford,48 Pittsburg W4P3,State House,3,,Write-ins,1,0,0,1
-Crawford,56 Smelter,State House,3,,Write-ins,1,0,1,0
-Crawford,01 Arcadia,Secretary of State,,D,Jean Schodorf,56,17,36,3
-Crawford,02 Baker,Secretary of State,,D,Jean Schodorf,160,37,116,7
-Crawford,03 Beulah,Secretary of State,,D,Jean Schodorf,32,6,26,0
-Crawford,04 Brazilton,Secretary of State,,D,Jean Schodorf,10,0,9,1
-Crawford,05 Capaldo,Secretary of State,,D,Jean Schodorf,11,0,11,0
-Crawford,06 Capaldo,Secretary of State,,D,Jean Schodorf,76,22,53,1
-Crawford,07 Cherokee,Secretary of State,,D,Jean Schodorf,77,6,70,1
-Crawford,08 Cherokee-Sheridan,Secretary of State,,D,Jean Schodorf,49,2,47,0
-Crawford,09 Chicopee,Secretary of State,,D,Jean Schodorf,96,19,74,3
-Crawford,10 Crawford,Secretary of State,,D,Jean Schodorf,38,3,35,0
-Crawford,11 Crowe,Secretary of State,,D,Jean Schodorf,35,11,22,2
-Crawford,12 Franklin,Secretary of State,,D,Jean Schodorf,68,19,46,3
-Crawford,13 Franklin,Secretary of State,,D,Jean Schodorf,2,0,2,0
-Crawford,14 Frontenac W1,Secretary of State,,D,Jean Schodorf,171,58,107,6
-Crawford,15 Frontenac W2,Secretary of State,,D,Jean Schodorf,262,56,199,7
-Crawford,16 Frontenac W3,Secretary of State,,D,Jean Schodorf,99,22,74,3
-Crawford,17 Frontenac W4,Secretary of State,,D,Jean Schodorf,84,25,56,3
-Crawford,18 Girard W1,Secretary of State,,D,Jean Schodorf,38,5,33,0
-Crawford,19 Girard W2,Secretary of State,,D,Jean Schodorf,105,20,84,1
-Crawford,20 Girard W3,Secretary of State,,D,Jean Schodorf,99,23,75,1
-Crawford,21 Girard W4,Secretary of State,,D,Jean Schodorf,101,16,83,2
-Crawford,22 Grant,Secretary of State,,D,Jean Schodorf,38,6,32,0
-Crawford,23 Hepler,Secretary of State,,D,Jean Schodorf,15,4,11,0
-Crawford,24 Lincoln,Secretary of State,,D,Jean Schodorf,53,12,40,1
-Crawford,25 Lincoln,Secretary of State,,D,Jean Schodorf,0,0,0,
-Crawford,26 Lincoln-Arcadia,Secretary of State,,D,Jean Schodorf,20,5,15,0
-Crawford,27 Lone Star,Secretary of State,,D,Jean Schodorf,192,32,156,4
-Crawford,28 McCune,Secretary of State,,D,Jean Schodorf,60,7,51,2
-Crawford,29 Mulberry W1,Secretary of State,,D,Jean Schodorf,25,0,25,0
-Crawford,30 Mulberry W2,Secretary of State,,D,Jean Schodorf,18,6,12,0
-Crawford,31 North Arma,Secretary of State,,D,Jean Schodorf,110,31,77,2
-Crawford,32 Opolis,Secretary of State,,D,Jean Schodorf,51,11,38,2
-Crawford,33 Osage-McCune,Secretary of State,,D,Jean Schodorf,38,5,33,0
-Crawford,34 Parkview,Secretary of State,,D,Jean Schodorf,51,15,34,2
-Crawford,35 Parkview,Secretary of State,,D,Jean Schodorf,52,13,34,5
-Crawford,36 Pittsburg W1P1,Secretary of State,,D,Jean Schodorf,78,18,54,6
-Crawford,37 Pittsburg W1P2,Secretary of State,,D,Jean Schodorf,178,46,125,7
-Crawford,38 Pittsburg W1P3,Secretary of State,,D,Jean Schodorf,389,110,268,11
-Crawford,39 Pittsburg W2P1,Secretary of State,,D,Jean Schodorf,77,11,63,3
-Crawford,40 Pittsburg W2P2,Secretary of State,,D,Jean Schodorf,113,31,77,5
-Crawford,41 Pittsburg W2P3,Secretary of State,,D,Jean Schodorf,142,38,99,5
-Crawford,42 Pittsburg W2P4,Secretary of State,,D,Jean Schodorf,105,28,75,2
-Crawford,43 Pittsburg W2P5,Secretary of State,,D,Jean Schodorf,118,29,81,8
-Crawford,44 Pittsburg W3P1,Secretary of State,,D,Jean Schodorf,109,20,83,6
-Crawford,45 Pittsburg W3P2,Secretary of State,,D,Jean Schodorf,127,32,90,5
-Crawford,46 Pittsburg W4P1,Secretary of State,,D,Jean Schodorf,51,10,38,3
-Crawford,47 Pittsburg W4P2,Secretary of State,,D,Jean Schodorf,89,30,53,6
-Crawford,48 Pittsburg W4P3,Secretary of State,,D,Jean Schodorf,162,49,106,7
-Crawford,49 Pittsburg W4P4,Secretary of State,,D,Jean Schodorf,75,18,53,4
-Crawford,50 Pittsburg W4P5,Secretary of State,,D,Jean Schodorf,204,50,149,5
-Crawford,51 Pittsburg W4P6,Secretary of State,,D,Jean Schodorf,30,6,24,0
-Crawford,52 Raymond,Secretary of State,,D,Jean Schodorf,106,26,78,2
-Crawford,53 Sheridan-Cherokee,Secretary of State,,D,Jean Schodorf,24,2,21,1
-Crawford,54 Sheridan,Secretary of State,,D,Jean Schodorf,21,2,19,0
-Crawford,55 Sherman,Secretary of State,,D,Jean Schodorf,78,14,64,0
-Crawford,56 Smelter,Secretary of State,,D,Jean Schodorf,94,28,64,2
-Crawford,57 South Arma,Secretary of State,,D,Jean Schodorf,140,41,95,4
-Crawford,58 Walnut,Secretary of State,,D,Jean Schodorf,18,3,15,0
-Crawford,59 Walnut twp,Secretary of State,,D,Jean Schodorf,2,0,2,0
-Crawford,60 Walnut twp,Secretary of State,,D,Jean Schodorf,5,0,4,1
-Crawford,61 Walnut-Hepler,Secretary of State,,D,Jean Schodorf,0,0,0,
-Crawford,62 Walnut-Hepler,Secretary of State,,D,Jean Schodorf,8,0,8,0
-Crawford,01 Arcadia,Secretary of State,,R,Kris Kobach,41,5,36,0
-Crawford,02 Baker,Secretary of State,,R,Kris Kobach,233,20,203,10
-Crawford,03 Beulah,Secretary of State,,R,Kris Kobach,54,8,44,2
-Crawford,04 Brazilton,Secretary of State,,R,Kris Kobach,20,2,18,0
-Crawford,05 Capaldo,Secretary of State,,R,Kris Kobach,10,2,8,0
-Crawford,06 Capaldo,Secretary of State,,R,Kris Kobach,70,7,63,0
-Crawford,07 Cherokee,Secretary of State,,R,Kris Kobach,108,7,95,6
-Crawford,08 Cherokee-Sheridan,Secretary of State,,R,Kris Kobach,73,6,66,1
-Crawford,09 Chicopee,Secretary of State,,R,Kris Kobach,138,23,113,2
-Crawford,10 Crawford,Secretary of State,,R,Kris Kobach,131,13,114,4
-Crawford,11 Crowe,Secretary of State,,R,Kris Kobach,43,5,38,0
-Crawford,12 Franklin,Secretary of State,,R,Kris Kobach,63,6,55,2
-Crawford,13 Franklin,Secretary of State,,R,Kris Kobach,4,1,3,0
-Crawford,14 Frontenac W1,Secretary of State,,R,Kris Kobach,122,16,101,5
-Crawford,15 Frontenac W2,Secretary of State,,R,Kris Kobach,185,35,146,4
-Crawford,16 Frontenac W3,Secretary of State,,R,Kris Kobach,77,5,70,2
-Crawford,17 Frontenac W4,Secretary of State,,R,Kris Kobach,52,8,43,1
-Crawford,18 Girard W1,Secretary of State,,R,Kris Kobach,42,3,39,0
-Crawford,19 Girard W2,Secretary of State,,R,Kris Kobach,147,26,120,1
-Crawford,20 Girard W3,Secretary of State,,R,Kris Kobach,69,4,61,4
-Crawford,21 Girard W4,Secretary of State,,R,Kris Kobach,140,22,113,5
-Crawford,22 Grant,Secretary of State,,R,Kris Kobach,67,6,61,0
-Crawford,23 Hepler,Secretary of State,,R,Kris Kobach,18,0,16,2
-Crawford,24 Lincoln,Secretary of State,,R,Kris Kobach,73,9,64,0
-Crawford,25 Lincoln,Secretary of State,,R,Kris Kobach,5,0,5,0
-Crawford,26 Lincoln-Arcadia,Secretary of State,,R,Kris Kobach,12,1,10,1
-Crawford,27 Lone Star,Secretary of State,,R,Kris Kobach,248,23,221,4
-Crawford,28 McCune,Secretary of State,,R,Kris Kobach,59,5,53,1
-Crawford,29 Mulberry W1,Secretary of State,,R,Kris Kobach,26,4,22,0
-Crawford,30 Mulberry W2,Secretary of State,,R,Kris Kobach,27,1,26,0
-Crawford,31 North Arma,Secretary of State,,R,Kris Kobach,124,14,108,2
-Crawford,32 Opolis,Secretary of State,,R,Kris Kobach,83,11,71,1
-Crawford,33 Osage-McCune,Secretary of State,,R,Kris Kobach,123,9,114,0
-Crawford,34 Parkview,Secretary of State,,R,Kris Kobach,26,0,24,2
-Crawford,35 Parkview,Secretary of State,,R,Kris Kobach,40,4,34,2
-Crawford,36 Pittsburg W1P1,Secretary of State,,R,Kris Kobach,93,13,73,7
-Crawford,37 Pittsburg W1P2,Secretary of State,,R,Kris Kobach,182,19,157,6
-Crawford,38 Pittsburg W1P3,Secretary of State,,R,Kris Kobach,463,75,381,7
-Crawford,39 Pittsburg W2P1,Secretary of State,,R,Kris Kobach,71,6,64,1
-Crawford,40 Pittsburg W2P2,Secretary of State,,R,Kris Kobach,104,10,91,3
-Crawford,41 Pittsburg W2P3,Secretary of State,,R,Kris Kobach,103,18,81,4
-Crawford,42 Pittsburg W2P4,Secretary of State,,R,Kris Kobach,111,14,95,2
-Crawford,43 Pittsburg W2P5,Secretary of State,,R,Kris Kobach,165,17,143,5
-Crawford,44 Pittsburg W3P1,Secretary of State,,R,Kris Kobach,92,10,76,6
-Crawford,45 Pittsburg W3P2,Secretary of State,,R,Kris Kobach,109,17,89,3
-Crawford,46 Pittsburg W4P1,Secretary of State,,R,Kris Kobach,31,2,27,2
-Crawford,47 Pittsburg W4P2,Secretary of State,,R,Kris Kobach,59,10,42,7
-Crawford,48 Pittsburg W4P3,Secretary of State,,R,Kris Kobach,158,16,137,5
-Crawford,49 Pittsburg W4P4,Secretary of State,,R,Kris Kobach,68,8,54,6
-Crawford,50 Pittsburg W4P5,Secretary of State,,R,Kris Kobach,274,44,226,4
-Crawford,51 Pittsburg W4P6,Secretary of State,,R,Kris Kobach,47,5,42,0
-Crawford,52 Raymond,Secretary of State,,R,Kris Kobach,164,18,144,2
-Crawford,53 Sheridan-Cherokee,Secretary of State,,R,Kris Kobach,18,1,17,0
-Crawford,54 Sheridan,Secretary of State,,R,Kris Kobach,24,1,23,0
-Crawford,55 Sherman,Secretary of State,,R,Kris Kobach,143,8,133,2
-Crawford,56 Smelter,Secretary of State,,R,Kris Kobach,156,9,145,2
-Crawford,57 South Arma,Secretary of State,,R,Kris Kobach,130,16,112,2
-Crawford,58 Walnut,Secretary of State,,R,Kris Kobach,28,2,26,0
-Crawford,59 Walnut twp,Secretary of State,,R,Kris Kobach,0,0,0,
-Crawford,60 Walnut twp,Secretary of State,,R,Kris Kobach,11,0,10,1
-Crawford,61 Walnut-Hepler,Secretary of State,,R,Kris Kobach,1,0,1,0
-Crawford,62 Walnut-Hepler,Secretary of State,,R,Kris Kobach,11,2,9,0
-Crawford,08 Cherokee-Sheridan,Secretary of State,,,Write-ins,1,0,1,0
-Crawford,09 Chicopee,Secretary of State,,,Write-ins,1,0,1,0
-Crawford,15 Frontenac W2,Secretary of State,,,Write-ins,1,0,1,0
-Crawford,27 Lone Star,Secretary of State,,,Write-ins,1,0,1,0
-Crawford,45 Pittsburg W3P2,Secretary of State,,,Write-ins,1,0,1,0
-Crawford,48 Pittsburg W4P3,Secretary of State,,,Write-ins,1,0,1,0
-Crawford,01 Arcadia,State Treasurer,,D,Carmen Alldritt,50,16,31,3
-Crawford,02 Baker,State Treasurer,,D,Carmen Alldritt,145,39,99,7
-Crawford,03 Beulah,State Treasurer,,D,Carmen Alldritt,22,4,18,0
-Crawford,04 Brazilton,State Treasurer,,D,Carmen Alldritt,5,0,5,0
-Crawford,05 Capaldo,State Treasurer,,D,Carmen Alldritt,10,1,9,0
-Crawford,06 Capaldo,State Treasurer,,D,Carmen Alldritt,60,13,46,1
-Crawford,07 Cherokee,State Treasurer,,D,Carmen Alldritt,74,5,68,1
-Crawford,08 Cherokee-Sheridan,State Treasurer,,D,Carmen Alldritt,36,3,33,0
-Crawford,09 Chicopee,State Treasurer,,D,Carmen Alldritt,86,17,66,3
-Crawford,10 Crawford,State Treasurer,,D,Carmen Alldritt,33,2,30,1
-Crawford,11 Crowe,State Treasurer,,D,Carmen Alldritt,37,14,21,2
-Crawford,12 Franklin,State Treasurer,,D,Carmen Alldritt,67,17,47,3
-Crawford,13 Franklin,State Treasurer,,D,Carmen Alldritt,4,1,3,0
-Crawford,14 Frontenac W1,State Treasurer,,D,Carmen Alldritt,160,52,102,6
-Crawford,15 Frontenac W2,State Treasurer,,D,Carmen Alldritt,242,52,186,4
-Crawford,16 Frontenac W3,State Treasurer,,D,Carmen Alldritt,87,18,67,2
-Crawford,17 Frontenac W4,State Treasurer,,D,Carmen Alldritt,79,24,53,2
-Crawford,18 Girard W1,State Treasurer,,D,Carmen Alldritt,33,6,27,0
-Crawford,19 Girard W2,State Treasurer,,D,Carmen Alldritt,87,19,68,0
-Crawford,20 Girard W3,State Treasurer,,D,Carmen Alldritt,83,16,67,0
-Crawford,21 Girard W4,State Treasurer,,D,Carmen Alldritt,92,13,77,2
-Crawford,22 Grant,State Treasurer,,D,Carmen Alldritt,31,6,25,0
-Crawford,23 Hepler,State Treasurer,,D,Carmen Alldritt,14,4,10,0
-Crawford,24 Lincoln,State Treasurer,,D,Carmen Alldritt,49,12,36,1
-Crawford,25 Lincoln,State Treasurer,,D,Carmen Alldritt,0,0,0,
-Crawford,26 Lincoln-Arcadia,State Treasurer,,D,Carmen Alldritt,18,4,14,0
-Crawford,27 Lone Star,State Treasurer,,D,Carmen Alldritt,173,30,139,4
-Crawford,28 McCune,State Treasurer,,D,Carmen Alldritt,48,6,40,2
-Crawford,29 Mulberry W1,State Treasurer,,D,Carmen Alldritt,24,0,24,0
-Crawford,30 Mulberry W2,State Treasurer,,D,Carmen Alldritt,18,5,13,0
-Crawford,31 North Arma,State Treasurer,,D,Carmen Alldritt,101,30,69,2
-Crawford,32 Opolis,State Treasurer,,D,Carmen Alldritt,48,12,34,2
-Crawford,33 Osage-McCune,State Treasurer,,D,Carmen Alldritt,30,5,25,0
-Crawford,34 Parkview,State Treasurer,,D,Carmen Alldritt,46,12,32,2
-Crawford,35 Parkview,State Treasurer,,D,Carmen Alldritt,45,12,29,4
-Crawford,36 Pittsburg W1P1,State Treasurer,,D,Carmen Alldritt,66,15,44,7
-Crawford,37 Pittsburg W1P2,State Treasurer,,D,Carmen Alldritt,160,34,117,9
-Crawford,38 Pittsburg W1P3,State Treasurer,,D,Carmen Alldritt,349,104,234,11
-Crawford,39 Pittsburg W2P1,State Treasurer,,D,Carmen Alldritt,74,12,59,3
-Crawford,40 Pittsburg W2P2,State Treasurer,,D,Carmen Alldritt,107,27,74,6
-Crawford,41 Pittsburg W2P3,State Treasurer,,D,Carmen Alldritt,131,37,90,4
-Crawford,42 Pittsburg W2P4,State Treasurer,,D,Carmen Alldritt,87,23,62,2
-Crawford,43 Pittsburg W2P5,State Treasurer,,D,Carmen Alldritt,96,22,65,9
-Crawford,44 Pittsburg W3P1,State Treasurer,,D,Carmen Alldritt,100,20,74,6
-Crawford,45 Pittsburg W3P2,State Treasurer,,D,Carmen Alldritt,111,29,78,4
-Crawford,46 Pittsburg W4P1,State Treasurer,,D,Carmen Alldritt,50,9,38,3
-Crawford,47 Pittsburg W4P2,State Treasurer,,D,Carmen Alldritt,88,28,54,6
-Crawford,48 Pittsburg W4P3,State Treasurer,,D,Carmen Alldritt,164,50,110,4
-Crawford,49 Pittsburg W4P4,State Treasurer,,D,Carmen Alldritt,73,16,53,4
-Crawford,50 Pittsburg W4P5,State Treasurer,,D,Carmen Alldritt,188,43,142,3
-Crawford,51 Pittsburg W4P6,State Treasurer,,D,Carmen Alldritt,25,7,18,0
-Crawford,52 Raymond,State Treasurer,,D,Carmen Alldritt,85,18,65,2
-Crawford,53 Sheridan-Cherokee,State Treasurer,,D,Carmen Alldritt,21,2,18,1
-Crawford,54 Sheridan,State Treasurer,,D,Carmen Alldritt,20,2,18,0
-Crawford,55 Sherman,State Treasurer,,D,Carmen Alldritt,72,14,57,1
-Crawford,56 Smelter,State Treasurer,,D,Carmen Alldritt,93,27,64,2
-Crawford,57 South Arma,State Treasurer,,D,Carmen Alldritt,134,38,92,4
-Crawford,58 Walnut,State Treasurer,,D,Carmen Alldritt,16,4,12,0
-Crawford,59 Walnut twp,State Treasurer,,D,Carmen Alldritt,0,0,0,
-Crawford,60 Walnut twp,State Treasurer,,D,Carmen Alldritt,6,0,6,0
-Crawford,61 Walnut-Hepler,State Treasurer,,D,Carmen Alldritt,1,0,1,0
-Crawford,62 Walnut-Hepler,State Treasurer,,D,Carmen Alldritt,8,0,8,0
-Crawford,01 Arcadia,State Treasurer,,R,Ken Estes,48,6,42,0
-Crawford,02 Baker,State Treasurer,,R,Ken Estes,243,18,215,10
-Crawford,03 Beulah,State Treasurer,,R,Ken Estes,62,10,51,1
-Crawford,04 Brazilton,State Treasurer,,R,Ken Estes,25,2,22,1
-Crawford,05 Capaldo,State Treasurer,,R,Ken Estes,11,1,10,0
-Crawford,06 Capaldo,State Treasurer,,R,Ken Estes,84,17,67,0
-Crawford,07 Cherokee,State Treasurer,,R,Ken Estes,113,9,98,6
-Crawford,08 Cherokee-Sheridan,State Treasurer,,R,Ken Estes,86,5,80,1
-Crawford,09 Chicopee,State Treasurer,,R,Ken Estes,145,24,119,2
-Crawford,10 Crawford,State Treasurer,,R,Ken Estes,132,13,116,3
-Crawford,11 Crowe,State Treasurer,,R,Ken Estes,43,2,41,0
-Crawford,12 Franklin,State Treasurer,,R,Ken Estes,64,8,54,2
-Crawford,13 Franklin,State Treasurer,,R,Ken Estes,2,0,2,0
-Crawford,14 Frontenac W1,State Treasurer,,R,Ken Estes,129,21,103,5
-Crawford,15 Frontenac W2,State Treasurer,,R,Ken Estes,199,34,160,5
-Crawford,16 Frontenac W3,State Treasurer,,R,Ken Estes,85,9,73,3
-Crawford,17 Frontenac W4,State Treasurer,,R,Ken Estes,57,9,47,1
-Crawford,18 Girard W1,State Treasurer,,R,Ken Estes,46,2,44,0
-Crawford,19 Girard W2,State Treasurer,,R,Ken Estes,162,27,133,2
-Crawford,20 Girard W3,State Treasurer,,R,Ken Estes,84,11,68,5
-Crawford,21 Girard W4,State Treasurer,,R,Ken Estes,146,25,116,5
-Crawford,22 Grant,State Treasurer,,R,Ken Estes,75,6,69,0
-Crawford,23 Hepler,State Treasurer,,R,Ken Estes,19,0,17,2
-Crawford,24 Lincoln,State Treasurer,,R,Ken Estes,75,9,66,0
-Crawford,25 Lincoln,State Treasurer,,R,Ken Estes,4,0,4,0
-Crawford,26 Lincoln-Arcadia,State Treasurer,,R,Ken Estes,11,1,10,0
-Crawford,27 Lone Star,State Treasurer,,R,Ken Estes,263,25,234,4
-Crawford,28 McCune,State Treasurer,,R,Ken Estes,69,6,62,1
-Crawford,29 Mulberry W1,State Treasurer,,R,Ken Estes,27,4,23,0
-Crawford,30 Mulberry W2,State Treasurer,,R,Ken Estes,26,1,25,0
-Crawford,31 North Arma,State Treasurer,,R,Ken Estes,131,15,114,2
-Crawford,32 Opolis,State Treasurer,,R,Ken Estes,87,10,76,1
-Crawford,33 Osage-McCune,State Treasurer,,R,Ken Estes,130,9,121,0
-Crawford,34 Parkview,State Treasurer,,R,Ken Estes,31,3,26,2
-Crawford,35 Parkview,State Treasurer,,R,Ken Estes,43,4,36,3
-Crawford,36 Pittsburg W1P1,State Treasurer,,R,Ken Estes,105,16,84,5
-Crawford,37 Pittsburg W1P2,State Treasurer,,R,Ken Estes,195,30,161,4
-Crawford,38 Pittsburg W1P3,State Treasurer,,R,Ken Estes,489,80,402,7
-Crawford,39 Pittsburg W2P1,State Treasurer,,R,Ken Estes,73,5,67,1
-Crawford,40 Pittsburg W2P2,State Treasurer,,R,Ken Estes,106,13,91,2
-Crawford,41 Pittsburg W2P3,State Treasurer,,R,Ken Estes,113,18,90,5
-Crawford,42 Pittsburg W2P4,State Treasurer,,R,Ken Estes,126,18,106,2
-Crawford,43 Pittsburg W2P5,State Treasurer,,R,Ken Estes,186,24,158,4
-Crawford,44 Pittsburg W3P1,State Treasurer,,R,Ken Estes,100,10,84,6
-Crawford,45 Pittsburg W3P2,State Treasurer,,R,Ken Estes,122,19,99,4
-Crawford,46 Pittsburg W4P1,State Treasurer,,R,Ken Estes,32,3,27,2
-Crawford,47 Pittsburg W4P2,State Treasurer,,R,Ken Estes,57,11,40,6
-Crawford,48 Pittsburg W4P3,State Treasurer,,R,Ken Estes,154,15,131,8
-Crawford,49 Pittsburg W4P4,State Treasurer,,R,Ken Estes,68,9,53,6
-Crawford,50 Pittsburg W4P5,State Treasurer,,R,Ken Estes,281,50,226,5
-Crawford,51 Pittsburg W4P6,State Treasurer,,R,Ken Estes,52,4,48,0
-Crawford,52 Raymond,State Treasurer,,R,Ken Estes,183,25,156,2
-Crawford,53 Sheridan-Cherokee,State Treasurer,,R,Ken Estes,19,1,18,0
-Crawford,54 Sheridan,State Treasurer,,R,Ken Estes,24,1,23,0
-Crawford,55 Sherman,State Treasurer,,R,Ken Estes,146,9,136,1
-Crawford,56 Smelter,State Treasurer,,R,Ken Estes,156,9,145,2
-Crawford,57 South Arma,State Treasurer,,R,Ken Estes,133,18,113,2
-Crawford,58 Walnut,State Treasurer,,R,Ken Estes,26,1,25,0
-Crawford,59 Walnut twp,State Treasurer,,R,Ken Estes,2,0,2,0
-Crawford,60 Walnut twp,State Treasurer,,R,Ken Estes,10,0,8,2
-Crawford,61 Walnut-Hepler,State Treasurer,,R,Ken Estes,0,0,0,
-Crawford,62 Walnut-Hepler,State Treasurer,,R,Ken Estes,10,1,9,0
-Crawford,15 Frontenac W2,State Treasurer,,,Write-ins,1,0,1,0
-Crawford,26 Lincoln-Arcadia,State Treasurer,,,Write-ins,1,0,1,0
-Crawford,27 Lone Star,State Treasurer,,,Write-ins,2,0,2,0
-Crawford,28 McCune,State Treasurer,,,Write-ins,1,0,1,0
-Crawford,40 Pittsburg W2P2,State Treasurer,,,Write-ins,1,0,1,0
-Crawford,42 Pittsburg W2P4,State Treasurer,,,Write-ins,1,0,1,0
-Crawford,45 Pittsburg W3P2,State Treasurer,,,Write-ins,2,1,1,0
-Crawford,48 Pittsburg W4P3,State Treasurer,,,Write-ins,1,0,1,0
-Crawford,01 Arcadia,U.S. Senate,,I,Greg Orman,34,7,24,3
-Crawford,02 Baker,U.S. Senate,,I,Greg Orman,147,30,109,8
-Crawford,03 Beulah,U.S. Senate,,I,Greg Orman,34,6,28,0
-Crawford,04 Brazilton,U.S. Senate,,I,Greg Orman,10,0,9,1
-Crawford,05 Capaldo,U.S. Senate,,I,Greg Orman,10,1,9,0
-Crawford,06 Capaldo,U.S. Senate,,I,Greg Orman,64,16,47,1
-Crawford,07 Cherokee,U.S. Senate,,I,Greg Orman,66,5,61,0
-Crawford,08 Cherokee-Sheridan,U.S. Senate,,I,Greg Orman,49,2,47,0
-Crawford,09 Chicopee,U.S. Senate,,I,Greg Orman,89,20,67,2
-Crawford,10 Crawford,U.S. Senate,,I,Greg Orman,39,4,34,1
-Crawford,11 Crowe,U.S. Senate,,I,Greg Orman,41,11,29,1
-Crawford,12 Franklin,U.S. Senate,,I,Greg Orman,56,16,37,3
-Crawford,13 Franklin,U.S. Senate,,I,Greg Orman,4,0,4,0
-Crawford,14 Frontenac W1,U.S. Senate,,I,Greg Orman,147,41,100,6
-Crawford,15 Frontenac W2,U.S. Senate,,I,Greg Orman,222,43,175,4
-Crawford,16 Frontenac W3,U.S. Senate,,I,Greg Orman,91,18,70,3
-Crawford,17 Frontenac W4,U.S. Senate,,I,Greg Orman,73,22,50,1
-Crawford,18 Girard W1,U.S. Senate,,I,Greg Orman,37,4,33,0
-Crawford,19 Girard W2,U.S. Senate,,I,Greg Orman,100,19,81,0
-Crawford,20 Girard W3,U.S. Senate,,I,Greg Orman,81,13,65,3
-Crawford,21 Girard W4,U.S. Senate,,I,Greg Orman,87,9,75,3
-Crawford,22 Grant,U.S. Senate,,I,Greg Orman,40,8,32,0
-Crawford,23 Hepler,U.S. Senate,,I,Greg Orman,10,2,8,0
-Crawford,24 Lincoln,U.S. Senate,,I,Greg Orman,41,8,33,0
-Crawford,25 Lincoln,U.S. Senate,,I,Greg Orman,1,0,1,0
-Crawford,26 Lincoln-Arcadia,U.S. Senate,,I,Greg Orman,15,3,12,0
-Crawford,27 Lone Star,U.S. Senate,,I,Greg Orman,177,26,147,4
-Crawford,28 McCune,U.S. Senate,,I,Greg Orman,54,7,45,2
-Crawford,29 Mulberry W1,U.S. Senate,,I,Greg Orman,24,0,24,0
-Crawford,30 Mulberry W2,U.S. Senate,,I,Greg Orman,14,3,11,0
-Crawford,31 North Arma,U.S. Senate,,I,Greg Orman,94,20,71,3
-Crawford,32 Opolis,U.S. Senate,,I,Greg Orman,48,11,35,2
-Crawford,33 Osage-McCune,U.S. Senate,,I,Greg Orman,36,4,32,0
-Crawford,34 Parkview,U.S. Senate,,I,Greg Orman,41,9,31,1
-Crawford,35 Parkview,U.S. Senate,,I,Greg Orman,46,12,29,5
-Crawford,36 Pittsburg W1P1,U.S. Senate,,I,Greg Orman,76,15,54,7
-Crawford,37 Pittsburg W1P2,U.S. Senate,,I,Greg Orman,157,33,118,6
-Crawford,38 Pittsburg W1P3,U.S. Senate,,I,Greg Orman,379,98,270,11
-Crawford,39 Pittsburg W2P1,U.S. Senate,,I,Greg Orman,71,8,61,2
-Crawford,40 Pittsburg W2P2,U.S. Senate,,I,Greg Orman,113,27,81,5
-Crawford,41 Pittsburg W2P3,U.S. Senate,,I,Greg Orman,150,41,103,6
-Crawford,42 Pittsburg W2P4,U.S. Senate,,I,Greg Orman,105,25,78,2
-Crawford,43 Pittsburg W2P5,U.S. Senate,,I,Greg Orman,119,24,89,6
-Crawford,44 Pittsburg W3P1,U.S. Senate,,I,Greg Orman,85,16,64,5
-Crawford,45 Pittsburg W3P2,U.S. Senate,,I,Greg Orman,112,26,81,5
-Crawford,46 Pittsburg W4P1,U.S. Senate,,I,Greg Orman,39,3,33,3
-Crawford,47 Pittsburg W4P2,U.S. Senate,,I,Greg Orman,83,28,51,4
-Crawford,48 Pittsburg W4P3,U.S. Senate,,I,Greg Orman,143,36,102,5
-Crawford,49 Pittsburg W4P4,U.S. Senate,,I,Greg Orman,68,15,48,5
-Crawford,50 Pittsburg W4P5,U.S. Senate,,I,Greg Orman,213,44,166,3
-Crawford,51 Pittsburg W4P6,U.S. Senate,,I,Greg Orman,19,5,14,0
-Crawford,52 Raymond,U.S. Senate,,I,Greg Orman,108,27,79,2
-Crawford,53 Sheridan-Cherokee,U.S. Senate,,I,Greg Orman,18,1,17,0
-Crawford,54 Sheridan,U.S. Senate,,I,Greg Orman,22,2,20,0
-Crawford,55 Sherman,U.S. Senate,,I,Greg Orman,83,17,65,1
-Crawford,56 Smelter,U.S. Senate,,I,Greg Orman,96,26,68,2
-Crawford,57 South Arma,U.S. Senate,,I,Greg Orman,127,36,87,4
-Crawford,58 Walnut,U.S. Senate,,I,Greg Orman,17,1,16,0
-Crawford,59 Walnut twp,U.S. Senate,,I,Greg Orman,1,0,1,0
-Crawford,60 Walnut twp,U.S. Senate,,I,Greg Orman,4,0,3,1
-Crawford,61 Walnut-Hepler,U.S. Senate,,I,Greg Orman,1,0,1,0
-Crawford,62 Walnut-Hepler,U.S. Senate,,I,Greg Orman,8,1,7,0
-Crawford,01 Arcadia,U.S. Senate,,R,Pat Roberts,41,7,34,0
-Crawford,02 Baker,U.S. Senate,,R,Pat Roberts,218,22,188,8
-Crawford,03 Beulah,U.S. Senate,,R,Pat Roberts,51,8,41,2
-Crawford,04 Brazilton,U.S. Senate,,R,Pat Roberts,17,2,15,0
-Crawford,05 Capaldo,U.S. Senate,,R,Pat Roberts,9,1,8,0
-Crawford,06 Capaldo,U.S. Senate,,R,Pat Roberts,67,9,58,0
-Crawford,07 Cherokee,U.S. Senate,,R,Pat Roberts,95,7,82,6
-Crawford,08 Cherokee-Sheridan,U.S. Senate,,R,Pat Roberts,64,6,57,1
-Crawford,09 Chicopee,U.S. Senate,,R,Pat Roberts,124,20,102,2
-Crawford,10 Crawford,U.S. Senate,,R,Pat Roberts,117,11,103,3
-Crawford,11 Crowe,U.S. Senate,,R,Pat Roberts,34,1,33,0
-Crawford,12 Franklin,U.S. Senate,,R,Pat Roberts,61,9,51,1
-Crawford,13 Franklin,U.S. Senate,,R,Pat Roberts,2,1,1,0
-Crawford,14 Frontenac W1,U.S. Senate,,R,Pat Roberts,115,24,88,3
-Crawford,15 Frontenac W2,U.S. Senate,,R,Pat Roberts,175,31,137,7
-Crawford,16 Frontenac W3,U.S. Senate,,R,Pat Roberts,64,6,56,2
-Crawford,17 Frontenac W4,U.S. Senate,,R,Pat Roberts,53,7,44,2
-Crawford,18 Girard W1,U.S. Senate,,R,Pat Roberts,35,2,33,0
-Crawford,19 Girard W2,U.S. Senate,,R,Pat Roberts,139,28,109,2
-Crawford,20 Girard W3,U.S. Senate,,R,Pat Roberts,70,11,57,2
-Crawford,21 Girard W4,U.S. Senate,,R,Pat Roberts,127,25,99,3
-Crawford,22 Grant,U.S. Senate,,R,Pat Roberts,64,3,61,0
-Crawford,23 Hepler,U.S. Senate,,R,Pat Roberts,17,2,14,1
-Crawford,24 Lincoln,U.S. Senate,,R,Pat Roberts,68,9,59,0
-Crawford,25 Lincoln,U.S. Senate,,R,Pat Roberts,4,0,4,0
-Crawford,26 Lincoln-Arcadia,U.S. Senate,,R,Pat Roberts,12,2,9,1
-Crawford,27 Lone Star,U.S. Senate,,R,Pat Roberts,229,28,197,4
-Crawford,28 McCune,U.S. Senate,,R,Pat Roberts,48,3,44,1
-Crawford,29 Mulberry W1,U.S. Senate,,R,Pat Roberts,21,4,17,0
-Crawford,30 Mulberry W2,U.S. Senate,,R,Pat Roberts,25,2,23,0
-Crawford,31 North Arma,U.S. Senate,,R,Pat Roberts,120,17,102,1
-Crawford,32 Opolis,U.S. Senate,,R,Pat Roberts,77,10,66,1
-Crawford,33 Osage-McCune,U.S. Senate,,R,Pat Roberts,115,9,106,0
-Crawford,34 Parkview,U.S. Senate,,R,Pat Roberts,25,2,21,2
-Crawford,35 Parkview,U.S. Senate,,R,Pat Roberts,43,5,36,2
-Crawford,36 Pittsburg W1P1,U.S. Senate,,R,Pat Roberts,94,14,77,3
-Crawford,37 Pittsburg W1P2,U.S. Senate,,R,Pat Roberts,175,25,147,3
-Crawford,38 Pittsburg W1P3,U.S. Senate,,R,Pat Roberts,430,75,348,7
-Crawford,39 Pittsburg W2P1,U.S. Senate,,R,Pat Roberts,62,5,56,1
-Crawford,40 Pittsburg W2P2,U.S. Senate,,R,Pat Roberts,92,11,80,1
-Crawford,41 Pittsburg W2P3,U.S. Senate,,R,Pat Roberts,88,14,72,2
-Crawford,42 Pittsburg W2P4,U.S. Senate,,R,Pat Roberts,103,13,88,2
-Crawford,43 Pittsburg W2P5,U.S. Senate,,R,Pat Roberts,152,20,126,6
-Crawford,44 Pittsburg W3P1,U.S. Senate,,R,Pat Roberts,93,11,76,6
-Crawford,45 Pittsburg W3P2,U.S. Senate,,R,Pat Roberts,107,21,83,3
-Crawford,46 Pittsburg W4P1,U.S. Senate,,R,Pat Roberts,34,8,25,1
-Crawford,47 Pittsburg W4P2,U.S. Senate,,R,Pat Roberts,50,7,33,10
-Crawford,48 Pittsburg W4P3,U.S. Senate,,R,Pat Roberts,140,18,117,5
-Crawford,49 Pittsburg W4P4,U.S. Senate,,R,Pat Roberts,67,10,52,5
-Crawford,50 Pittsburg W4P5,U.S. Senate,,R,Pat Roberts,239,44,190,5
-Crawford,51 Pittsburg W4P6,U.S. Senate,,R,Pat Roberts,50,4,46,0
-Crawford,52 Raymond,U.S. Senate,,R,Pat Roberts,147,18,125,4
-Crawford,53 Sheridan-Cherokee,U.S. Senate,,R,Pat Roberts,16,2,14,0
-Crawford,54 Sheridan,U.S. Senate,,R,Pat Roberts,19,1,18,0
-Crawford,55 Sherman,U.S. Senate,,R,Pat Roberts,123,6,117,0
-Crawford,56 Smelter,U.S. Senate,,R,Pat Roberts,141,7,132,2
-Crawford,57 South Arma,U.S. Senate,,R,Pat Roberts,125,18,105,2
-Crawford,58 Walnut,U.S. Senate,,R,Pat Roberts,23,3,20,0
-Crawford,59 Walnut twp,U.S. Senate,,R,Pat Roberts,0,0,0,
-Crawford,60 Walnut twp,U.S. Senate,,R,Pat Roberts,10,0,9,1
-Crawford,61 Walnut-Hepler,U.S. Senate,,R,Pat Roberts,0,0,0,
-Crawford,62 Walnut-Hepler,U.S. Senate,,R,Pat Roberts,10,1,9,0
-Crawford,01 Arcadia,U.S. Senate,,L,Randall Batson,12,1,11,0
-Crawford,02 Baker,U.S. Senate,,L,Randall Batson,28,4,24,0
-Crawford,03 Beulah,U.S. Senate,,L,Randall Batson,6,0,6,0
-Crawford,04 Brazilton,U.S. Senate,,L,Randall Batson,3,0,3,0
-Crawford,05 Capaldo,U.S. Senate,,L,Randall Batson,1,0,1,0
-Crawford,06 Capaldo,U.S. Senate,,L,Randall Batson,15,5,10,0
-Crawford,07 Cherokee,U.S. Senate,,L,Randall Batson,25,1,24,0
-Crawford,08 Cherokee-Sheridan,U.S. Senate,,L,Randall Batson,9,0,9,0
-Crawford,09 Chicopee,U.S. Senate,,L,Randall Batson,17,1,16,0
-Crawford,10 Crawford,U.S. Senate,,L,Randall Batson,15,0,15,0
-Crawford,11 Crowe,U.S. Senate,,L,Randall Batson,8,4,3,1
-Crawford,12 Franklin,U.S. Senate,,L,Randall Batson,13,0,12,1
-Crawford,13 Franklin,U.S. Senate,,L,Randall Batson,0,0,0,
-Crawford,14 Frontenac W1,U.S. Senate,,L,Randall Batson,26,4,20,2
-Crawford,15 Frontenac W2,U.S. Senate,,L,Randall Batson,33,9,24,0
-Crawford,16 Frontenac W3,U.S. Senate,,L,Randall Batson,14,1,13,0
-Crawford,17 Frontenac W4,U.S. Senate,,L,Randall Batson,9,3,5,1
-Crawford,18 Girard W1,U.S. Senate,,L,Randall Batson,10,2,8,0
-Crawford,19 Girard W2,U.S. Senate,,L,Randall Batson,22,1,21,0
-Crawford,20 Girard W3,U.S. Senate,,L,Randall Batson,16,3,13,0
-Crawford,21 Girard W4,U.S. Senate,,L,Randall Batson,28,6,21,1
-Crawford,22 Grant,U.S. Senate,,L,Randall Batson,8,2,6,0
-Crawford,23 Hepler,U.S. Senate,,L,Randall Batson,3,0,2,1
-Crawford,24 Lincoln,U.S. Senate,,L,Randall Batson,12,3,9,0
-Crawford,25 Lincoln,U.S. Senate,,L,Randall Batson,0,0,0,
-Crawford,26 Lincoln-Arcadia,U.S. Senate,,L,Randall Batson,2,0,2,0
-Crawford,27 Lone Star,U.S. Senate,,L,Randall Batson,33,2,31,0
-Crawford,28 McCune,U.S. Senate,,L,Randall Batson,16,1,15,0
-Crawford,29 Mulberry W1,U.S. Senate,,L,Randall Batson,6,0,6,0
-Crawford,30 Mulberry W2,U.S. Senate,,L,Randall Batson,8,2,6,0
-Crawford,31 North Arma,U.S. Senate,,L,Randall Batson,17,2,15,0
-Crawford,32 Opolis,U.S. Senate,,L,Randall Batson,5,1,4,0
-Crawford,33 Osage-McCune,U.S. Senate,,L,Randall Batson,10,1,9,0
-Crawford,34 Parkview,U.S. Senate,,L,Randall Batson,9,2,6,1
-Crawford,35 Parkview,U.S. Senate,,L,Randall Batson,2,0,2,0
-Crawford,36 Pittsburg W1P1,U.S. Senate,,L,Randall Batson,9,1,5,3
-Crawford,37 Pittsburg W1P2,U.S. Senate,,L,Randall Batson,22,4,14,4
-Crawford,38 Pittsburg W1P3,U.S. Senate,,L,Randall Batson,38,11,26,1
-Crawford,39 Pittsburg W2P1,U.S. Senate,,L,Randall Batson,16,3,12,1
-Crawford,40 Pittsburg W2P2,U.S. Senate,,L,Randall Batson,9,2,5,2
-Crawford,41 Pittsburg W2P3,U.S. Senate,,L,Randall Batson,14,2,11,1
-Crawford,42 Pittsburg W2P4,U.S. Senate,,L,Randall Batson,6,3,3,0
-Crawford,43 Pittsburg W2P5,U.S. Senate,,L,Randall Batson,14,2,10,2
-Crawford,44 Pittsburg W3P1,U.S. Senate,,L,Randall Batson,19,2,17,0
-Crawford,45 Pittsburg W3P2,U.S. Senate,,L,Randall Batson,17,2,15,0
-Crawford,46 Pittsburg W4P1,U.S. Senate,,L,Randall Batson,7,0,6,1
-Crawford,47 Pittsburg W4P2,U.S. Senate,,L,Randall Batson,17,3,14,0
-Crawford,48 Pittsburg W4P3,U.S. Senate,,L,Randall Batson,35,8,25,2
-Crawford,49 Pittsburg W4P4,U.S. Senate,,L,Randall Batson,11,2,8,1
-Crawford,50 Pittsburg W4P5,U.S. Senate,,L,Randall Batson,24,2,22,0
-Crawford,51 Pittsburg W4P6,U.S. Senate,,L,Randall Batson,6,2,4,0
-Crawford,52 Raymond,U.S. Senate,,L,Randall Batson,18,0,18,0
-Crawford,53 Sheridan-Cherokee,U.S. Senate,,L,Randall Batson,8,0,7,1
-Crawford,54 Sheridan,U.S. Senate,,L,Randall Batson,2,0,2,0
-Crawford,55 Sherman,U.S. Senate,,L,Randall Batson,18,0,18,0
-Crawford,56 Smelter,U.S. Senate,,L,Randall Batson,11,4,7,0
-Crawford,57 South Arma,U.S. Senate,,L,Randall Batson,18,4,14,0
-Crawford,58 Walnut,U.S. Senate,,L,Randall Batson,6,1,5,0
-Crawford,59 Walnut twp,U.S. Senate,,L,Randall Batson,1,0,1,0
-Crawford,60 Walnut twp,U.S. Senate,,L,Randall Batson,1,0,1,0
-Crawford,61 Walnut-Hepler,U.S. Senate,,L,Randall Batson,1,0,1,0
-Crawford,62 Walnut-Hepler,U.S. Senate,,L,Randall Batson,1,0,1,0
-Crawford,01 Arcadia,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,02 Baker,U.S. Senate,,,Write-ins,1,0,0,1
-Crawford,07 Cherokee,U.S. Senate,,,Write-ins,1,1,0,0
-Crawford,09 Chicopee,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,14 Frontenac W1,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,15 Frontenac W2,U.S. Senate,,,Write-ins,3,1,2,0
-Crawford,16 Frontenac W3,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,17 Frontenac W4,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,28 McCune,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,31 North Arma,U.S. Senate,,,Write-ins,2,1,1,0
-Crawford,32 Opolis,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,37 Pittsburg W1P2,U.S. Senate,,,Write-ins,2,0,2,0
-Crawford,38 Pittsburg W1P3,U.S. Senate,,,Write-ins,3,1,2,0
-Crawford,42 Pittsburg W2P4,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,44 Pittsburg W3P1,U.S. Senate,,,Write-ins,2,0,1,1
-Crawford,46 Pittsburg W4P1,U.S. Senate,,,Write-ins,2,1,1,0
-Crawford,47 Pittsburg W4P2,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,48 Pittsburg W4P3,U.S. Senate,,,Write-ins,1,0,1,0
-Crawford,56 Smelter,U.S. Senate,,,Write-ins,2,0,2,0
+county,precinct,office,district,party,candidate,votes,vtd
+CRAWFORD,Lincoln - Arcadia,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000A41
+CRAWFORD,Lincoln - Arcadia,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000A41
+CRAWFORD,Lincoln - Arcadia,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000A41
+CRAWFORD,Osage - McCune,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000A51
+CRAWFORD,Osage - McCune,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000A51
+CRAWFORD,Osage - McCune,Governor / Lt. Governor,,Republican,"Brownback, Sam",116,000A51
+CRAWFORD,Cherokee - Sheridan,Governor / Lt. Governor,,Democratic,"Davis, Paul",57,000A62
+CRAWFORD,Cherokee - Sheridan,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000A62
+CRAWFORD,Cherokee - Sheridan,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,000A62
+CRAWFORD,Walnut - Helper,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000A82
+CRAWFORD,Walnut - Helper,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000A82
+CRAWFORD,Walnut - Helper,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000A82
+CRAWFORD,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000A83
+CRAWFORD,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000A83
+CRAWFORD,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000A83
+CRAWFORD,Arcadia,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000010
+CRAWFORD,Arcadia,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000010
+CRAWFORD,Arcadia,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000010
+CRAWFORD,Baker,Governor / Lt. Governor,,Democratic,"Davis, Paul",192,000020
+CRAWFORD,Baker,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000020
+CRAWFORD,Baker,Governor / Lt. Governor,,Republican,"Brownback, Sam",197,000020
+CRAWFORD,Beulah,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000030
+CRAWFORD,Beulah,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000030
+CRAWFORD,Beulah,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,000030
+CRAWFORD,Sheridan - Cherokee City,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000033
+CRAWFORD,Sheridan - Cherokee City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000033
+CRAWFORD,Sheridan - Cherokee City,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000033
+CRAWFORD,Brazilton,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000040
+CRAWFORD,Brazilton,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+CRAWFORD,Brazilton,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000040
+CRAWFORD,Capaldo,Governor / Lt. Governor,,Democratic,"Davis, Paul",98,000050
+CRAWFORD,Capaldo,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000050
+CRAWFORD,Capaldo,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,000050
+CRAWFORD,Cherokee,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,000060
+CRAWFORD,Cherokee,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000060
+CRAWFORD,Cherokee,Governor / Lt. Governor,,Republican,"Brownback, Sam",93,000060
+CRAWFORD,Chicopee,Governor / Lt. Governor,,Democratic,"Davis, Paul",125,000070
+CRAWFORD,Chicopee,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000070
+CRAWFORD,Chicopee,Governor / Lt. Governor,,Republican,"Brownback, Sam",111,000070
+CRAWFORD,Crawford,Governor / Lt. Governor,,Democratic,"Davis, Paul",59,000080
+CRAWFORD,Crawford,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000080
+CRAWFORD,Crawford,Governor / Lt. Governor,,Republican,"Brownback, Sam",100,000080
+CRAWFORD,Crowe,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000090
+CRAWFORD,Crowe,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000090
+CRAWFORD,Crowe,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000090
+CRAWFORD,Frontenac Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",204,000110
+CRAWFORD,Frontenac Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000110
+CRAWFORD,Frontenac Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",93,000110
+CRAWFORD,Frontenac Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",302,00012A
+CRAWFORD,Frontenac Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,00012A
+CRAWFORD,Frontenac Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",144,00012A
+CRAWFORD,Frontenac Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",116,00013A
+CRAWFORD,Frontenac Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,00013A
+CRAWFORD,Frontenac Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013B
+CRAWFORD,Frontenac Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",96,00014A
+CRAWFORD,Frontenac Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,00014A
+CRAWFORD,Frontenac Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,00014A
+CRAWFORD,Girard Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000150
+CRAWFORD,Girard Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000150
+CRAWFORD,Girard Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000150
+CRAWFORD,Girard Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",133,00016A
+CRAWFORD,Girard Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00016A
+CRAWFORD,Girard Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,00016A
+CRAWFORD,Girard Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",108,00017A
+CRAWFORD,Girard Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00017A
+CRAWFORD,Girard Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00017B
+CRAWFORD,Girard Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",116,000180
+CRAWFORD,Girard Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000180
+CRAWFORD,Girard Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",118,000180
+CRAWFORD,Grant,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000190
+CRAWFORD,Grant,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000190
+CRAWFORD,Grant,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,000190
+CRAWFORD,Hepler,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000200
+CRAWFORD,Hepler,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000200
+CRAWFORD,Hepler,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000200
+CRAWFORD,Lincoln,Governor / Lt. Governor,,Democratic,"Davis, Paul",57,000210
+CRAWFORD,Lincoln,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000210
+CRAWFORD,Lincoln,Governor / Lt. Governor,,Republican,"Brownback, Sam",67,000210
+CRAWFORD,Lone Star,Governor / Lt. Governor,,Democratic,"Davis, Paul",233,00022A
+CRAWFORD,Lone Star,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,00022A
+CRAWFORD,Lone Star,Governor / Lt. Governor,,Republican,"Brownback, Sam",202,00022A
+CRAWFORD,McCune,Governor / Lt. Governor,,Democratic,"Davis, Paul",61,000230
+CRAWFORD,McCune,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000230
+CRAWFORD,McCune,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000230
+CRAWFORD,Mulberry Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000240
+CRAWFORD,Mulberry Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000240
+CRAWFORD,Mulberry Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000240
+CRAWFORD,Mulberry Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000250
+CRAWFORD,Mulberry Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000250
+CRAWFORD,Mulberry Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000250
+CRAWFORD,North Arma,Governor / Lt. Governor,,Democratic,"Davis, Paul",122,000260
+CRAWFORD,North Arma,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000260
+CRAWFORD,North Arma,Governor / Lt. Governor,,Republican,"Brownback, Sam",120,000260
+CRAWFORD,Opolis,Governor / Lt. Governor,,Democratic,"Davis, Paul",69,000270
+CRAWFORD,Opolis,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000270
+CRAWFORD,Opolis,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,000270
+CRAWFORD,Parkview,Governor / Lt. Governor,,Democratic,"Davis, Paul",105,000280
+CRAWFORD,Parkview,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000280
+CRAWFORD,Parkview,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",84,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",90,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",211,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",147,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",450,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",393,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",128,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",85,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",160,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",84,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",114,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",97,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",143,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",146,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",110,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",85,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",131,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",100,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",103,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",192,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",121,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",87,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",253,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",227,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,00044A
+CRAWFORD,Raymond,Governor / Lt. Governor,,Democratic,"Davis, Paul",142,000450
+CRAWFORD,Raymond,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000450
+CRAWFORD,Raymond,Governor / Lt. Governor,,Republican,"Brownback, Sam",127,000450
+CRAWFORD,Sheridan,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000460
+CRAWFORD,Sheridan,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000460
+CRAWFORD,Sheridan,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000460
+CRAWFORD,Sherman,Governor / Lt. Governor,,Democratic,"Davis, Paul",105,000470
+CRAWFORD,Sherman,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000470
+CRAWFORD,Sherman,Governor / Lt. Governor,,Republican,"Brownback, Sam",114,000470
+CRAWFORD,Smelter,Governor / Lt. Governor,,Democratic,"Davis, Paul",114,000480
+CRAWFORD,Smelter,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000480
+CRAWFORD,Smelter,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000480
+CRAWFORD,South Arma,Governor / Lt. Governor,,Democratic,"Davis, Paul",159,000490
+CRAWFORD,South Arma,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000490
+CRAWFORD,South Arma,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000490
+CRAWFORD,Walnut,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000500
+CRAWFORD,Walnut,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000500
+CRAWFORD,Walnut,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000500
+CRAWFORD,Franklin,Governor / Lt. Governor,,Democratic,"Davis, Paul",77,700100
+CRAWFORD,Franklin,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,700100
+CRAWFORD,Franklin,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,700100
+CRAWFORD,Baker Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+CRAWFORD,Baker Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+CRAWFORD,Baker Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+CRAWFORD,Parkview Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+CRAWFORD,Parkview Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+CRAWFORD,Parkview Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+CRAWFORD,Lincoln - Arcadia,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",25,000A41
+CRAWFORD,Osage - McCune,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",103,000A51
+CRAWFORD,Cherokee - Sheridan,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",85,000A62
+CRAWFORD,Walnut - Helper,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",18,000A82
+CRAWFORD,Walnut Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",17,000A83
+CRAWFORD,Arcadia,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",85,000010
+CRAWFORD,Baker,Kansas House of Representatives,3,Democratic,"Menghini, Julie",179,000020
+CRAWFORD,Baker,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",226,000020
+CRAWFORD,Beulah,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",67,000030
+CRAWFORD,Sheridan - Cherokee City,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",34,000033
+CRAWFORD,Brazilton,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",20,000040
+CRAWFORD,Capaldo,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",137,000050
+CRAWFORD,Cherokee,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",134,000060
+CRAWFORD,Chicopee,Kansas House of Representatives,3,Democratic,"Menghini, Julie",91,000070
+CRAWFORD,Chicopee,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",143,000070
+CRAWFORD,Crawford,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",108,000080
+CRAWFORD,Crowe,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",61,000090
+CRAWFORD,Frontenac Ward 1,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",260,000110
+CRAWFORD,Frontenac Ward 2,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",401,00012A
+CRAWFORD,Frontenac Ward 3,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",161,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",0,00013B
+CRAWFORD,Frontenac Ward 4,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",123,00014A
+CRAWFORD,Girard Ward 1,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",62,000150
+CRAWFORD,Girard Ward 2,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",196,00016A
+CRAWFORD,Girard Ward 3,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",143,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",0,00017B
+CRAWFORD,Girard Ward 4,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",184,000180
+CRAWFORD,Grant,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",80,000190
+CRAWFORD,Hepler,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",26,000200
+CRAWFORD,Lincoln,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",95,000210
+CRAWFORD,Lone Star,Kansas House of Representatives,3,Democratic,"Menghini, Julie",200,00022A
+CRAWFORD,Lone Star,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",247,00022A
+CRAWFORD,McCune,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",91,000230
+CRAWFORD,Mulberry Ward 1,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",43,000240
+CRAWFORD,Mulberry Ward 2,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",29,000250
+CRAWFORD,North Arma,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",176,000260
+CRAWFORD,Opolis,Kansas House of Representatives,3,Democratic,"Menghini, Julie",55,000270
+CRAWFORD,Opolis,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",79,000270
+CRAWFORD,Parkview,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",145,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas House of Representatives,3,Democratic,"Menghini, Julie",89,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",91,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas House of Representatives,3,Democratic,"Menghini, Julie",198,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",170,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas House of Representatives,3,Democratic,"Menghini, Julie",423,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",447,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas House of Representatives,3,Democratic,"Menghini, Julie",83,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",69,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas House of Representatives,3,Democratic,"Menghini, Julie",122,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",97,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas House of Representatives,3,Democratic,"Menghini, Julie",145,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",107,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas House of Representatives,3,Democratic,"Menghini, Julie",104,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",111,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas House of Representatives,3,Democratic,"Menghini, Julie",144,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",147,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas House of Representatives,3,Democratic,"Menghini, Julie",104,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",95,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas House of Representatives,3,Democratic,"Menghini, Julie",118,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",119,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas House of Representatives,3,Democratic,"Menghini, Julie",43,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",39,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas House of Representatives,3,Democratic,"Menghini, Julie",98,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",58,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas House of Representatives,3,Democratic,"Menghini, Julie",163,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",158,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas House of Representatives,3,Democratic,"Menghini, Julie",81,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",65,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas House of Representatives,3,Democratic,"Menghini, Julie",233,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",260,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas House of Representatives,3,Democratic,"Menghini, Julie",27,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",51,00044A
+CRAWFORD,Raymond,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",203,000450
+CRAWFORD,Sheridan,Kansas House of Representatives,3,Democratic,"Menghini, Julie",19,000460
+CRAWFORD,Sheridan,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",26,000460
+CRAWFORD,Sherman,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",158,000470
+CRAWFORD,Smelter,Kansas House of Representatives,3,Democratic,"Menghini, Julie",111,000480
+CRAWFORD,Smelter,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",139,000480
+CRAWFORD,South Arma,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",220,000490
+CRAWFORD,Walnut,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",37,000500
+CRAWFORD,Franklin,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",105,700100
+CRAWFORD,Baker Enclave,Kansas House of Representatives,3,Democratic,"Menghini, Julie",0,900010
+CRAWFORD,Baker Enclave,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",0,900010
+CRAWFORD,Parkview Enclave,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Kansas House of Representatives,3,Democratic,"Menghini, Julie",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Kansas House of Representatives,3,Democratic,"Menghini, Julie",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",0,900040
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,000A41
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000A41
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Republican,"Jenkins, Lynn",14,000A41
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000A51
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000A51
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,000A51
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Democratic,"Wakefield, Margie",36,000A62
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000A62
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Republican,"Jenkins, Lynn",81,000A62
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000A82
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000A82
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Republican,"Jenkins, Lynn",10,000A82
+CRAWFORD,Walnut Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,000A83
+CRAWFORD,Walnut Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000A83
+CRAWFORD,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",10,000A83
+CRAWFORD,Arcadia,United States House of Representatives,2,Democratic,"Wakefield, Margie",41,000010
+CRAWFORD,Arcadia,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000010
+CRAWFORD,Arcadia,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000010
+CRAWFORD,Baker,United States House of Representatives,2,Democratic,"Wakefield, Margie",144,000020
+CRAWFORD,Baker,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,000020
+CRAWFORD,Baker,United States House of Representatives,2,Republican,"Jenkins, Lynn",244,000020
+CRAWFORD,Beulah,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,000030
+CRAWFORD,Beulah,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000030
+CRAWFORD,Beulah,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000030
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000033
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000033
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Republican,"Jenkins, Lynn",19,000033
+CRAWFORD,Brazilton,United States House of Representatives,2,Democratic,"Wakefield, Margie",7,000040
+CRAWFORD,Brazilton,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000040
+CRAWFORD,Brazilton,United States House of Representatives,2,Republican,"Jenkins, Lynn",21,000040
+CRAWFORD,Capaldo,United States House of Representatives,2,Democratic,"Wakefield, Margie",75,000050
+CRAWFORD,Capaldo,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000050
+CRAWFORD,Capaldo,United States House of Representatives,2,Republican,"Jenkins, Lynn",89,000050
+CRAWFORD,Cherokee,United States House of Representatives,2,Democratic,"Wakefield, Margie",72,000060
+CRAWFORD,Cherokee,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,000060
+CRAWFORD,Cherokee,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,000060
+CRAWFORD,Chicopee,United States House of Representatives,2,Democratic,"Wakefield, Margie",84,000070
+CRAWFORD,Chicopee,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000070
+CRAWFORD,Chicopee,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000070
+CRAWFORD,Crawford,United States House of Representatives,2,Democratic,"Wakefield, Margie",37,000080
+CRAWFORD,Crawford,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000080
+CRAWFORD,Crawford,United States House of Representatives,2,Republican,"Jenkins, Lynn",125,000080
+CRAWFORD,Crowe,United States House of Representatives,2,Democratic,"Wakefield, Margie",32,000090
+CRAWFORD,Crowe,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000090
+CRAWFORD,Crowe,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000090
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",166,000110
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000110
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",123,000110
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",245,00012A
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,00012A
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,00012A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",91,00013A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,00013A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",76,00014A
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,00014A
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,00014A
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,000150
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000150
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,000150
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",102,00016A
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,00016A
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",155,00016A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,00017A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,00017A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017B
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",84,000180
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000180
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000180
+CRAWFORD,Grant,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000190
+CRAWFORD,Grant,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000190
+CRAWFORD,Grant,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,000190
+CRAWFORD,Hepler,United States House of Representatives,2,Democratic,"Wakefield, Margie",7,000200
+CRAWFORD,Hepler,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000200
+CRAWFORD,Hepler,United States House of Representatives,2,Republican,"Jenkins, Lynn",22,000200
+CRAWFORD,Lincoln,United States House of Representatives,2,Democratic,"Wakefield, Margie",46,000210
+CRAWFORD,Lincoln,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000210
+CRAWFORD,Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,000210
+CRAWFORD,Lone Star,United States House of Representatives,2,Democratic,"Wakefield, Margie",177,00022A
+CRAWFORD,Lone Star,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",28,00022A
+CRAWFORD,Lone Star,United States House of Representatives,2,Republican,"Jenkins, Lynn",241,00022A
+CRAWFORD,McCune,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,000230
+CRAWFORD,McCune,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000230
+CRAWFORD,McCune,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,000230
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",13,000240
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000240
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000240
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000250
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000250
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",25,000250
+CRAWFORD,North Arma,United States House of Representatives,2,Democratic,"Wakefield, Margie",101,000260
+CRAWFORD,North Arma,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000260
+CRAWFORD,North Arma,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,000260
+CRAWFORD,Opolis,United States House of Representatives,2,Democratic,"Wakefield, Margie",48,000270
+CRAWFORD,Opolis,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000270
+CRAWFORD,Opolis,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000270
+CRAWFORD,Parkview,United States House of Representatives,2,Democratic,"Wakefield, Margie",92,000280
+CRAWFORD,Parkview,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000280
+CRAWFORD,Parkview,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",68,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",105,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",166,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",358,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",29,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",472,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",66,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",107,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",139,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",103,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",91,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",108,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",170,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",96,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",97,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",106,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",45,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",32,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",146,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",26,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",151,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",71,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",69,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",185,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",278,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Democratic,"Wakefield, Margie",21,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,00044A
+CRAWFORD,Raymond,United States House of Representatives,2,Democratic,"Wakefield, Margie",93,000450
+CRAWFORD,Raymond,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000450
+CRAWFORD,Raymond,United States House of Representatives,2,Republican,"Jenkins, Lynn",171,000450
+CRAWFORD,Sheridan,United States House of Representatives,2,Democratic,"Wakefield, Margie",19,000460
+CRAWFORD,Sheridan,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000460
+CRAWFORD,Sheridan,United States House of Representatives,2,Republican,"Jenkins, Lynn",22,000460
+CRAWFORD,Sherman,United States House of Representatives,2,Democratic,"Wakefield, Margie",74,000470
+CRAWFORD,Sherman,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000470
+CRAWFORD,Sherman,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,000470
+CRAWFORD,Smelter,United States House of Representatives,2,Democratic,"Wakefield, Margie",87,000480
+CRAWFORD,Smelter,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000480
+CRAWFORD,Smelter,United States House of Representatives,2,Republican,"Jenkins, Lynn",152,000480
+CRAWFORD,South Arma,United States House of Representatives,2,Democratic,"Wakefield, Margie",120,000490
+CRAWFORD,South Arma,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000490
+CRAWFORD,South Arma,United States House of Representatives,2,Republican,"Jenkins, Lynn",141,000490
+CRAWFORD,Walnut,United States House of Representatives,2,Democratic,"Wakefield, Margie",8,000500
+CRAWFORD,Walnut,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000500
+CRAWFORD,Walnut,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000500
+CRAWFORD,Franklin,United States House of Representatives,2,Democratic,"Wakefield, Margie",64,700100
+CRAWFORD,Franklin,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,700100
+CRAWFORD,Franklin,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,700100
+CRAWFORD,Baker Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+CRAWFORD,Baker Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+CRAWFORD,Baker Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+CRAWFORD,Parkview Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+CRAWFORD,Parkview Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+CRAWFORD,Parkview Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+CRAWFORD,Lincoln - Arcadia,Attorney General,,Democratic,"Kotich, A.J.",17,000A41
+CRAWFORD,Lincoln - Arcadia,Attorney General,,Republican,"Schmidt, Derek",14,000A41
+CRAWFORD,Osage - McCune,Attorney General,,Democratic,"Kotich, A.J.",29,000A51
+CRAWFORD,Osage - McCune,Attorney General,,Republican,"Schmidt, Derek",130,000A51
+CRAWFORD,Cherokee - Sheridan,Attorney General,,Democratic,"Kotich, A.J.",39,000A62
+CRAWFORD,Cherokee - Sheridan,Attorney General,,Republican,"Schmidt, Derek",83,000A62
+CRAWFORD,Walnut - Helper,Attorney General,,Democratic,"Kotich, A.J.",6,000A82
+CRAWFORD,Walnut - Helper,Attorney General,,Republican,"Schmidt, Derek",14,000A82
+CRAWFORD,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",7,000A83
+CRAWFORD,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",11,000A83
+CRAWFORD,Arcadia,Attorney General,,Democratic,"Kotich, A.J.",55,000010
+CRAWFORD,Arcadia,Attorney General,,Republican,"Schmidt, Derek",43,000010
+CRAWFORD,Baker,Attorney General,,Democratic,"Kotich, A.J.",139,000020
+CRAWFORD,Baker,Attorney General,,Republican,"Schmidt, Derek",247,000020
+CRAWFORD,Beulah,Attorney General,,Democratic,"Kotich, A.J.",31,000030
+CRAWFORD,Beulah,Attorney General,,Republican,"Schmidt, Derek",56,000030
+CRAWFORD,Sheridan - Cherokee City,Attorney General,,Democratic,"Kotich, A.J.",22,000033
+CRAWFORD,Sheridan - Cherokee City,Attorney General,,Republican,"Schmidt, Derek",19,000033
+CRAWFORD,Brazilton,Attorney General,,Democratic,"Kotich, A.J.",6,000040
+CRAWFORD,Brazilton,Attorney General,,Republican,"Schmidt, Derek",24,000040
+CRAWFORD,Capaldo,Attorney General,,Democratic,"Kotich, A.J.",68,000050
+CRAWFORD,Capaldo,Attorney General,,Republican,"Schmidt, Derek",99,000050
+CRAWFORD,Cherokee,Attorney General,,Democratic,"Kotich, A.J.",70,000060
+CRAWFORD,Cherokee,Attorney General,,Republican,"Schmidt, Derek",115,000060
+CRAWFORD,Chicopee,Attorney General,,Democratic,"Kotich, A.J.",83,000070
+CRAWFORD,Chicopee,Attorney General,,Republican,"Schmidt, Derek",146,000070
+CRAWFORD,Crawford,Attorney General,,Democratic,"Kotich, A.J.",30,000080
+CRAWFORD,Crawford,Attorney General,,Republican,"Schmidt, Derek",136,000080
+CRAWFORD,Crowe,Attorney General,,Democratic,"Kotich, A.J.",37,000090
+CRAWFORD,Crowe,Attorney General,,Republican,"Schmidt, Derek",43,000090
+CRAWFORD,Frontenac Ward 1,Attorney General,,Democratic,"Kotich, A.J.",164,000110
+CRAWFORD,Frontenac Ward 1,Attorney General,,Republican,"Schmidt, Derek",130,000110
+CRAWFORD,Frontenac Ward 2,Attorney General,,Democratic,"Kotich, A.J.",254,00012A
+CRAWFORD,Frontenac Ward 2,Attorney General,,Republican,"Schmidt, Derek",189,00012A
+CRAWFORD,Frontenac Ward 3,Attorney General,,Democratic,"Kotich, A.J.",93,00013A
+CRAWFORD,Frontenac Ward 3,Attorney General,,Republican,"Schmidt, Derek",81,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,Attorney General,,Democratic,"Kotich, A.J.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,Attorney General,,Republican,"Schmidt, Derek",0,00013B
+CRAWFORD,Frontenac Ward 4,Attorney General,,Democratic,"Kotich, A.J.",82,00014A
+CRAWFORD,Frontenac Ward 4,Attorney General,,Republican,"Schmidt, Derek",50,00014A
+CRAWFORD,Girard Ward 1,Attorney General,,Democratic,"Kotich, A.J.",31,000150
+CRAWFORD,Girard Ward 1,Attorney General,,Republican,"Schmidt, Derek",50,000150
+CRAWFORD,Girard Ward 2,Attorney General,,Democratic,"Kotich, A.J.",92,00016A
+CRAWFORD,Girard Ward 2,Attorney General,,Republican,"Schmidt, Derek",157,00016A
+CRAWFORD,Girard Ward 3,Attorney General,,Democratic,"Kotich, A.J.",80,00017A
+CRAWFORD,Girard Ward 3,Attorney General,,Republican,"Schmidt, Derek",89,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Attorney General,,Democratic,"Kotich, A.J.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Attorney General,,Republican,"Schmidt, Derek",0,00017B
+CRAWFORD,Girard Ward 4,Attorney General,,Democratic,"Kotich, A.J.",87,000180
+CRAWFORD,Girard Ward 4,Attorney General,,Republican,"Schmidt, Derek",152,000180
+CRAWFORD,Grant,Attorney General,,Democratic,"Kotich, A.J.",34,000190
+CRAWFORD,Grant,Attorney General,,Republican,"Schmidt, Derek",73,000190
+CRAWFORD,Hepler,Attorney General,,Democratic,"Kotich, A.J.",16,000200
+CRAWFORD,Hepler,Attorney General,,Republican,"Schmidt, Derek",17,000200
+CRAWFORD,Lincoln,Attorney General,,Democratic,"Kotich, A.J.",48,000210
+CRAWFORD,Lincoln,Attorney General,,Republican,"Schmidt, Derek",79,000210
+CRAWFORD,Lone Star,Attorney General,,Democratic,"Kotich, A.J.",174,00022A
+CRAWFORD,Lone Star,Attorney General,,Republican,"Schmidt, Derek",263,00022A
+CRAWFORD,McCune,Attorney General,,Democratic,"Kotich, A.J.",50,000230
+CRAWFORD,McCune,Attorney General,,Republican,"Schmidt, Derek",67,000230
+CRAWFORD,Mulberry Ward 1,Attorney General,,Democratic,"Kotich, A.J.",18,000240
+CRAWFORD,Mulberry Ward 1,Attorney General,,Republican,"Schmidt, Derek",32,000240
+CRAWFORD,Mulberry Ward 2,Attorney General,,Democratic,"Kotich, A.J.",15,000250
+CRAWFORD,Mulberry Ward 2,Attorney General,,Republican,"Schmidt, Derek",30,000250
+CRAWFORD,North Arma,Attorney General,,Democratic,"Kotich, A.J.",104,000260
+CRAWFORD,North Arma,Attorney General,,Republican,"Schmidt, Derek",129,000260
+CRAWFORD,Opolis,Attorney General,,Democratic,"Kotich, A.J.",45,000270
+CRAWFORD,Opolis,Attorney General,,Republican,"Schmidt, Derek",89,000270
+CRAWFORD,Parkview,Attorney General,,Democratic,"Kotich, A.J.",90,000280
+CRAWFORD,Parkview,Attorney General,,Republican,"Schmidt, Derek",75,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",68,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",103,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",161,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",188,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",348,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",495,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",71,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",75,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",112,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",104,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",135,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",110,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",89,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",124,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",95,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Attorney General,,Republican,"Schmidt, Derek",188,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",104,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",96,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",109,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",125,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",48,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",34,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",84,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",63,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",152,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",163,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",72,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",69,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",188,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Attorney General,,Republican,"Schmidt, Derek",287,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Attorney General,,Democratic,"Kotich, A.J.",22,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Attorney General,,Republican,"Schmidt, Derek",55,00044A
+CRAWFORD,Raymond,Attorney General,,Democratic,"Kotich, A.J.",88,000450
+CRAWFORD,Raymond,Attorney General,,Republican,"Schmidt, Derek",182,000450
+CRAWFORD,Sheridan,Attorney General,,Democratic,"Kotich, A.J.",20,000460
+CRAWFORD,Sheridan,Attorney General,,Republican,"Schmidt, Derek",24,000460
+CRAWFORD,Sherman,Attorney General,,Democratic,"Kotich, A.J.",69,000470
+CRAWFORD,Sherman,Attorney General,,Republican,"Schmidt, Derek",151,000470
+CRAWFORD,Smelter,Attorney General,,Democratic,"Kotich, A.J.",94,000480
+CRAWFORD,Smelter,Attorney General,,Republican,"Schmidt, Derek",156,000480
+CRAWFORD,South Arma,Attorney General,,Democratic,"Kotich, A.J.",132,000490
+CRAWFORD,South Arma,Attorney General,,Republican,"Schmidt, Derek",138,000490
+CRAWFORD,Walnut,Attorney General,,Democratic,"Kotich, A.J.",16,000500
+CRAWFORD,Walnut,Attorney General,,Republican,"Schmidt, Derek",30,000500
+CRAWFORD,Franklin,Attorney General,,Democratic,"Kotich, A.J.",68,700100
+CRAWFORD,Franklin,Attorney General,,Republican,"Schmidt, Derek",69,700100
+CRAWFORD,Baker Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+CRAWFORD,Baker Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+CRAWFORD,Parkview Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+CRAWFORD,Parkview Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,900040
+CRAWFORD,Lincoln - Arcadia,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000A41
+CRAWFORD,Lincoln - Arcadia,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000A41
+CRAWFORD,Osage - McCune,Commissioner of Insurance,,Democratic,"Anderson, Dennis",35,000A51
+CRAWFORD,Osage - McCune,Commissioner of Insurance,,Republican,"Selzer, Ken",126,000A51
+CRAWFORD,Cherokee - Sheridan,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000A62
+CRAWFORD,Cherokee - Sheridan,Commissioner of Insurance,,Republican,"Selzer, Ken",75,000A62
+CRAWFORD,Walnut - Helper,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000A82
+CRAWFORD,Walnut - Helper,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000A82
+CRAWFORD,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000A83
+CRAWFORD,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000A83
+CRAWFORD,Arcadia,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000010
+CRAWFORD,Arcadia,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000010
+CRAWFORD,Baker,Commissioner of Insurance,,Democratic,"Anderson, Dennis",157,000020
+CRAWFORD,Baker,Commissioner of Insurance,,Republican,"Selzer, Ken",228,000020
+CRAWFORD,Beulah,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000030
+CRAWFORD,Beulah,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000030
+CRAWFORD,Sheridan - Cherokee City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000033
+CRAWFORD,Sheridan - Cherokee City,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000033
+CRAWFORD,Brazilton,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000040
+CRAWFORD,Brazilton,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000040
+CRAWFORD,Capaldo,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000050
+CRAWFORD,Capaldo,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000050
+CRAWFORD,Cherokee,Commissioner of Insurance,,Democratic,"Anderson, Dennis",85,000060
+CRAWFORD,Cherokee,Commissioner of Insurance,,Republican,"Selzer, Ken",100,000060
+CRAWFORD,Chicopee,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,000070
+CRAWFORD,Chicopee,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000070
+CRAWFORD,Crawford,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000080
+CRAWFORD,Crawford,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000080
+CRAWFORD,Crowe,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000090
+CRAWFORD,Crowe,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000090
+CRAWFORD,Frontenac Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",174,000110
+CRAWFORD,Frontenac Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",114,000110
+CRAWFORD,Frontenac Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",266,00012A
+CRAWFORD,Frontenac Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",176,00012A
+CRAWFORD,Frontenac Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,00013A
+CRAWFORD,Frontenac Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",75,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013B
+CRAWFORD,Frontenac Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,00014A
+CRAWFORD,Frontenac Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",55,00014A
+CRAWFORD,Girard Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000150
+CRAWFORD,Girard Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000150
+CRAWFORD,Girard Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",114,00016A
+CRAWFORD,Girard Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",136,00016A
+CRAWFORD,Girard Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,00017A
+CRAWFORD,Girard Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",75,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00017B
+CRAWFORD,Girard Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",99,000180
+CRAWFORD,Girard Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000180
+CRAWFORD,Grant,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000190
+CRAWFORD,Grant,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000190
+CRAWFORD,Hepler,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000200
+CRAWFORD,Hepler,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000200
+CRAWFORD,Lincoln,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000210
+CRAWFORD,Lincoln,Commissioner of Insurance,,Republican,"Selzer, Ken",74,000210
+CRAWFORD,Lone Star,Commissioner of Insurance,,Democratic,"Anderson, Dennis",187,00022A
+CRAWFORD,Lone Star,Commissioner of Insurance,,Republican,"Selzer, Ken",249,00022A
+CRAWFORD,McCune,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,000230
+CRAWFORD,McCune,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000230
+CRAWFORD,Mulberry Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000240
+CRAWFORD,Mulberry Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000240
+CRAWFORD,Mulberry Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000250
+CRAWFORD,Mulberry Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000250
+CRAWFORD,North Arma,Commissioner of Insurance,,Democratic,"Anderson, Dennis",112,000260
+CRAWFORD,North Arma,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000260
+CRAWFORD,Opolis,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000270
+CRAWFORD,Opolis,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000270
+CRAWFORD,Parkview,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,000280
+CRAWFORD,Parkview,Commissioner of Insurance,,Republican,"Selzer, Ken",68,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",96,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",175,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",182,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",388,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",447,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",82,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",63,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",114,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",98,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",139,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",107,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",95,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",117,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",110,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",170,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",104,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",93,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",119,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",113,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",94,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",52,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",173,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",145,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",82,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",58,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",198,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",264,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Commissioner of Insurance,,Republican,"Selzer, Ken",48,00044A
+CRAWFORD,Raymond,Commissioner of Insurance,,Democratic,"Anderson, Dennis",99,000450
+CRAWFORD,Raymond,Commissioner of Insurance,,Republican,"Selzer, Ken",167,000450
+CRAWFORD,Sheridan,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000460
+CRAWFORD,Sheridan,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000460
+CRAWFORD,Sherman,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000470
+CRAWFORD,Sherman,Commissioner of Insurance,,Republican,"Selzer, Ken",136,000470
+CRAWFORD,Smelter,Commissioner of Insurance,,Democratic,"Anderson, Dennis",94,000480
+CRAWFORD,Smelter,Commissioner of Insurance,,Republican,"Selzer, Ken",152,000480
+CRAWFORD,South Arma,Commissioner of Insurance,,Democratic,"Anderson, Dennis",146,000490
+CRAWFORD,South Arma,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000490
+CRAWFORD,Walnut,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000500
+CRAWFORD,Walnut,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000500
+CRAWFORD,Franklin,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,700100
+CRAWFORD,Franklin,Commissioner of Insurance,,Republican,"Selzer, Ken",64,700100
+CRAWFORD,Baker Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+CRAWFORD,Baker Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+CRAWFORD,Parkview Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+CRAWFORD,Parkview Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+CRAWFORD,Lincoln - Arcadia,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000A41
+CRAWFORD,Lincoln - Arcadia,Secretary of State,,Republican,"Kobach, Kris",12,000A41
+CRAWFORD,Osage - McCune,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000A51
+CRAWFORD,Osage - McCune,Secretary of State,,Republican,"Kobach, Kris",123,000A51
+CRAWFORD,Cherokee - Sheridan,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000A62
+CRAWFORD,Cherokee - Sheridan,Secretary of State,,Republican,"Kobach, Kris",73,000A62
+CRAWFORD,Walnut - Helper,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000A82
+CRAWFORD,Walnut - Helper,Secretary of State,,Republican,"Kobach, Kris",12,000A82
+CRAWFORD,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000A83
+CRAWFORD,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",11,000A83
+CRAWFORD,Arcadia,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,000010
+CRAWFORD,Arcadia,Secretary of State,,Republican,"Kobach, Kris",41,000010
+CRAWFORD,Baker,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",160,000020
+CRAWFORD,Baker,Secretary of State,,Republican,"Kobach, Kris",233,000020
+CRAWFORD,Beulah,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",32,000030
+CRAWFORD,Beulah,Secretary of State,,Republican,"Kobach, Kris",54,000030
+CRAWFORD,Sheridan - Cherokee City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000033
+CRAWFORD,Sheridan - Cherokee City,Secretary of State,,Republican,"Kobach, Kris",18,000033
+CRAWFORD,Brazilton,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000040
+CRAWFORD,Brazilton,Secretary of State,,Republican,"Kobach, Kris",20,000040
+CRAWFORD,Capaldo,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",87,000050
+CRAWFORD,Capaldo,Secretary of State,,Republican,"Kobach, Kris",80,000050
+CRAWFORD,Cherokee,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,000060
+CRAWFORD,Cherokee,Secretary of State,,Republican,"Kobach, Kris",108,000060
+CRAWFORD,Chicopee,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",96,000070
+CRAWFORD,Chicopee,Secretary of State,,Republican,"Kobach, Kris",138,000070
+CRAWFORD,Crawford,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000080
+CRAWFORD,Crawford,Secretary of State,,Republican,"Kobach, Kris",131,000080
+CRAWFORD,Crowe,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000090
+CRAWFORD,Crowe,Secretary of State,,Republican,"Kobach, Kris",43,000090
+CRAWFORD,Frontenac Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",171,000110
+CRAWFORD,Frontenac Ward 1,Secretary of State,,Republican,"Kobach, Kris",122,000110
+CRAWFORD,Frontenac Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",262,00012A
+CRAWFORD,Frontenac Ward 2,Secretary of State,,Republican,"Kobach, Kris",185,00012A
+CRAWFORD,Frontenac Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",99,00013A
+CRAWFORD,Frontenac Ward 3,Secretary of State,,Republican,"Kobach, Kris",77,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,Secretary of State,,Republican,"Kobach, Kris",0,00013B
+CRAWFORD,Frontenac Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",84,00014A
+CRAWFORD,Frontenac Ward 4,Secretary of State,,Republican,"Kobach, Kris",52,00014A
+CRAWFORD,Girard Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000150
+CRAWFORD,Girard Ward 1,Secretary of State,,Republican,"Kobach, Kris",42,000150
+CRAWFORD,Girard Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,00016A
+CRAWFORD,Girard Ward 2,Secretary of State,,Republican,"Kobach, Kris",147,00016A
+CRAWFORD,Girard Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",99,00017A
+CRAWFORD,Girard Ward 3,Secretary of State,,Republican,"Kobach, Kris",69,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Secretary of State,,Republican,"Kobach, Kris",0,00017B
+CRAWFORD,Girard Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",101,000180
+CRAWFORD,Girard Ward 4,Secretary of State,,Republican,"Kobach, Kris",140,000180
+CRAWFORD,Grant,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000190
+CRAWFORD,Grant,Secretary of State,,Republican,"Kobach, Kris",67,000190
+CRAWFORD,Hepler,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000200
+CRAWFORD,Hepler,Secretary of State,,Republican,"Kobach, Kris",18,000200
+CRAWFORD,Lincoln,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,000210
+CRAWFORD,Lincoln,Secretary of State,,Republican,"Kobach, Kris",78,000210
+CRAWFORD,Lone Star,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",192,00022A
+CRAWFORD,Lone Star,Secretary of State,,Republican,"Kobach, Kris",248,00022A
+CRAWFORD,McCune,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,000230
+CRAWFORD,McCune,Secretary of State,,Republican,"Kobach, Kris",59,000230
+CRAWFORD,Mulberry Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000240
+CRAWFORD,Mulberry Ward 1,Secretary of State,,Republican,"Kobach, Kris",26,000240
+CRAWFORD,Mulberry Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000250
+CRAWFORD,Mulberry Ward 2,Secretary of State,,Republican,"Kobach, Kris",27,000250
+CRAWFORD,North Arma,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,000260
+CRAWFORD,North Arma,Secretary of State,,Republican,"Kobach, Kris",124,000260
+CRAWFORD,Opolis,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000270
+CRAWFORD,Opolis,Secretary of State,,Republican,"Kobach, Kris",83,000270
+CRAWFORD,Parkview,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,000280
+CRAWFORD,Parkview,Secretary of State,,Republican,"Kobach, Kris",66,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",93,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",178,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",182,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",389,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",463,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",71,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",113,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",104,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",142,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",103,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",111,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",118,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Secretary of State,,Republican,"Kobach, Kris",165,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",109,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",92,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",127,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",109,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",31,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",59,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",162,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",158,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",68,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",204,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Secretary of State,,Republican,"Kobach, Kris",274,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Secretary of State,,Republican,"Kobach, Kris",47,00044A
+CRAWFORD,Raymond,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",106,000450
+CRAWFORD,Raymond,Secretary of State,,Republican,"Kobach, Kris",164,000450
+CRAWFORD,Sheridan,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000460
+CRAWFORD,Sheridan,Secretary of State,,Republican,"Kobach, Kris",24,000460
+CRAWFORD,Sherman,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,000470
+CRAWFORD,Sherman,Secretary of State,,Republican,"Kobach, Kris",143,000470
+CRAWFORD,Smelter,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000480
+CRAWFORD,Smelter,Secretary of State,,Republican,"Kobach, Kris",156,000480
+CRAWFORD,South Arma,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",140,000490
+CRAWFORD,South Arma,Secretary of State,,Republican,"Kobach, Kris",130,000490
+CRAWFORD,Walnut,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000500
+CRAWFORD,Walnut,Secretary of State,,Republican,"Kobach, Kris",28,000500
+CRAWFORD,Franklin,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,700100
+CRAWFORD,Franklin,Secretary of State,,Republican,"Kobach, Kris",67,700100
+CRAWFORD,Baker Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+CRAWFORD,Baker Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+CRAWFORD,Parkview Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+CRAWFORD,Parkview Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,900040
+CRAWFORD,Lincoln - Arcadia,State Treasurer,,Democratic,"Alldritt, Carmen",18,000A41
+CRAWFORD,Lincoln - Arcadia,State Treasurer,,Republican,"Estes, Ron",11,000A41
+CRAWFORD,Osage - McCune,State Treasurer,,Democratic,"Alldritt, Carmen",30,000A51
+CRAWFORD,Osage - McCune,State Treasurer,,Republican,"Estes, Ron",130,000A51
+CRAWFORD,Cherokee - Sheridan,State Treasurer,,Democratic,"Alldritt, Carmen",36,000A62
+CRAWFORD,Cherokee - Sheridan,State Treasurer,,Republican,"Estes, Ron",86,000A62
+CRAWFORD,Walnut - Helper,State Treasurer,,Democratic,"Alldritt, Carmen",9,000A82
+CRAWFORD,Walnut - Helper,State Treasurer,,Republican,"Estes, Ron",10,000A82
+CRAWFORD,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000A83
+CRAWFORD,Walnut Township,State Treasurer,,Republican,"Estes, Ron",12,000A83
+CRAWFORD,Arcadia,State Treasurer,,Democratic,"Alldritt, Carmen",50,000010
+CRAWFORD,Arcadia,State Treasurer,,Republican,"Estes, Ron",48,000010
+CRAWFORD,Baker,State Treasurer,,Democratic,"Alldritt, Carmen",145,000020
+CRAWFORD,Baker,State Treasurer,,Republican,"Estes, Ron",243,000020
+CRAWFORD,Beulah,State Treasurer,,Democratic,"Alldritt, Carmen",22,000030
+CRAWFORD,Beulah,State Treasurer,,Republican,"Estes, Ron",62,000030
+CRAWFORD,Sheridan - Cherokee City,State Treasurer,,Democratic,"Alldritt, Carmen",21,000033
+CRAWFORD,Sheridan - Cherokee City,State Treasurer,,Republican,"Estes, Ron",19,000033
+CRAWFORD,Brazilton,State Treasurer,,Democratic,"Alldritt, Carmen",5,000040
+CRAWFORD,Brazilton,State Treasurer,,Republican,"Estes, Ron",25,000040
+CRAWFORD,Capaldo,State Treasurer,,Democratic,"Alldritt, Carmen",70,000050
+CRAWFORD,Capaldo,State Treasurer,,Republican,"Estes, Ron",95,000050
+CRAWFORD,Cherokee,State Treasurer,,Democratic,"Alldritt, Carmen",74,000060
+CRAWFORD,Cherokee,State Treasurer,,Republican,"Estes, Ron",113,000060
+CRAWFORD,Chicopee,State Treasurer,,Democratic,"Alldritt, Carmen",86,000070
+CRAWFORD,Chicopee,State Treasurer,,Republican,"Estes, Ron",145,000070
+CRAWFORD,Crawford,State Treasurer,,Democratic,"Alldritt, Carmen",33,000080
+CRAWFORD,Crawford,State Treasurer,,Republican,"Estes, Ron",132,000080
+CRAWFORD,Crowe,State Treasurer,,Democratic,"Alldritt, Carmen",37,000090
+CRAWFORD,Crowe,State Treasurer,,Republican,"Estes, Ron",43,000090
+CRAWFORD,Frontenac Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",160,000110
+CRAWFORD,Frontenac Ward 1,State Treasurer,,Republican,"Estes, Ron",129,000110
+CRAWFORD,Frontenac Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",242,00012A
+CRAWFORD,Frontenac Ward 2,State Treasurer,,Republican,"Estes, Ron",199,00012A
+CRAWFORD,Frontenac Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",87,00013A
+CRAWFORD,Frontenac Ward 3,State Treasurer,,Republican,"Estes, Ron",85,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,State Treasurer,,Democratic,"Alldritt, Carmen",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,State Treasurer,,Republican,"Estes, Ron",0,00013B
+CRAWFORD,Frontenac Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",79,00014A
+CRAWFORD,Frontenac Ward 4,State Treasurer,,Republican,"Estes, Ron",57,00014A
+CRAWFORD,Girard Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",33,000150
+CRAWFORD,Girard Ward 1,State Treasurer,,Republican,"Estes, Ron",46,000150
+CRAWFORD,Girard Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",87,00016A
+CRAWFORD,Girard Ward 2,State Treasurer,,Republican,"Estes, Ron",162,00016A
+CRAWFORD,Girard Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",83,00017A
+CRAWFORD,Girard Ward 3,State Treasurer,,Republican,"Estes, Ron",84,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,State Treasurer,,Democratic,"Alldritt, Carmen",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,State Treasurer,,Republican,"Estes, Ron",0,00017B
+CRAWFORD,Girard Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",92,000180
+CRAWFORD,Girard Ward 4,State Treasurer,,Republican,"Estes, Ron",146,000180
+CRAWFORD,Grant,State Treasurer,,Democratic,"Alldritt, Carmen",31,000190
+CRAWFORD,Grant,State Treasurer,,Republican,"Estes, Ron",75,000190
+CRAWFORD,Hepler,State Treasurer,,Democratic,"Alldritt, Carmen",14,000200
+CRAWFORD,Hepler,State Treasurer,,Republican,"Estes, Ron",19,000200
+CRAWFORD,Lincoln,State Treasurer,,Democratic,"Alldritt, Carmen",49,000210
+CRAWFORD,Lincoln,State Treasurer,,Republican,"Estes, Ron",79,000210
+CRAWFORD,Lone Star,State Treasurer,,Democratic,"Alldritt, Carmen",173,00022A
+CRAWFORD,Lone Star,State Treasurer,,Republican,"Estes, Ron",263,00022A
+CRAWFORD,McCune,State Treasurer,,Democratic,"Alldritt, Carmen",48,000230
+CRAWFORD,McCune,State Treasurer,,Republican,"Estes, Ron",69,000230
+CRAWFORD,Mulberry Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",24,000240
+CRAWFORD,Mulberry Ward 1,State Treasurer,,Republican,"Estes, Ron",27,000240
+CRAWFORD,Mulberry Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",18,000250
+CRAWFORD,Mulberry Ward 2,State Treasurer,,Republican,"Estes, Ron",26,000250
+CRAWFORD,North Arma,State Treasurer,,Democratic,"Alldritt, Carmen",101,000260
+CRAWFORD,North Arma,State Treasurer,,Republican,"Estes, Ron",131,000260
+CRAWFORD,Opolis,State Treasurer,,Democratic,"Alldritt, Carmen",48,000270
+CRAWFORD,Opolis,State Treasurer,,Republican,"Estes, Ron",87,000270
+CRAWFORD,Parkview,State Treasurer,,Democratic,"Alldritt, Carmen",91,000280
+CRAWFORD,Parkview,State Treasurer,,Republican,"Estes, Ron",74,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",66,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",105,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",160,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",195,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",349,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,State Treasurer,,Republican,"Estes, Ron",489,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",74,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",73,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",107,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",106,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",131,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,State Treasurer,,Republican,"Estes, Ron",113,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",87,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,State Treasurer,,Republican,"Estes, Ron",126,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",96,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,State Treasurer,,Republican,"Estes, Ron",186,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",100,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",100,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",111,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,State Treasurer,,Republican,"Estes, Ron",122,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",50,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",32,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",88,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",57,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",164,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,State Treasurer,,Republican,"Estes, Ron",154,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",73,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,State Treasurer,,Republican,"Estes, Ron",68,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",188,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,State Treasurer,,Republican,"Estes, Ron",281,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,State Treasurer,,Democratic,"Alldritt, Carmen",25,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,State Treasurer,,Republican,"Estes, Ron",52,00044A
+CRAWFORD,Raymond,State Treasurer,,Democratic,"Alldritt, Carmen",85,000450
+CRAWFORD,Raymond,State Treasurer,,Republican,"Estes, Ron",183,000450
+CRAWFORD,Sheridan,State Treasurer,,Democratic,"Alldritt, Carmen",20,000460
+CRAWFORD,Sheridan,State Treasurer,,Republican,"Estes, Ron",24,000460
+CRAWFORD,Sherman,State Treasurer,,Democratic,"Alldritt, Carmen",72,000470
+CRAWFORD,Sherman,State Treasurer,,Republican,"Estes, Ron",146,000470
+CRAWFORD,Smelter,State Treasurer,,Democratic,"Alldritt, Carmen",93,000480
+CRAWFORD,Smelter,State Treasurer,,Republican,"Estes, Ron",156,000480
+CRAWFORD,South Arma,State Treasurer,,Democratic,"Alldritt, Carmen",134,000490
+CRAWFORD,South Arma,State Treasurer,,Republican,"Estes, Ron",133,000490
+CRAWFORD,Walnut,State Treasurer,,Democratic,"Alldritt, Carmen",16,000500
+CRAWFORD,Walnut,State Treasurer,,Republican,"Estes, Ron",26,000500
+CRAWFORD,Franklin,State Treasurer,,Democratic,"Alldritt, Carmen",71,700100
+CRAWFORD,Franklin,State Treasurer,,Republican,"Estes, Ron",66,700100
+CRAWFORD,Baker Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+CRAWFORD,Baker Enclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+CRAWFORD,Parkview Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+CRAWFORD,Parkview Enclave,State Treasurer,,Republican,"Estes, Ron",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,900040
+CRAWFORD,Lincoln - Arcadia,United States Senate,,independent,"Orman, Greg",15,000A41
+CRAWFORD,Lincoln - Arcadia,United States Senate,,Libertarian,"Batson, Randall",2,000A41
+CRAWFORD,Lincoln - Arcadia,United States Senate,,Republican,"Roberts, Pat",12,000A41
+CRAWFORD,Osage - McCune,United States Senate,,independent,"Orman, Greg",36,000A51
+CRAWFORD,Osage - McCune,United States Senate,,Libertarian,"Batson, Randall",10,000A51
+CRAWFORD,Osage - McCune,United States Senate,,Republican,"Roberts, Pat",115,000A51
+CRAWFORD,Cherokee - Sheridan,United States Senate,,independent,"Orman, Greg",49,000A62
+CRAWFORD,Cherokee - Sheridan,United States Senate,,Libertarian,"Batson, Randall",9,000A62
+CRAWFORD,Cherokee - Sheridan,United States Senate,,Republican,"Roberts, Pat",64,000A62
+CRAWFORD,Walnut - Helper,United States Senate,,independent,"Orman, Greg",9,000A82
+CRAWFORD,Walnut - Helper,United States Senate,,Libertarian,"Batson, Randall",2,000A82
+CRAWFORD,Walnut - Helper,United States Senate,,Republican,"Roberts, Pat",10,000A82
+CRAWFORD,Walnut Township,United States Senate,,independent,"Orman, Greg",5,000A83
+CRAWFORD,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",2,000A83
+CRAWFORD,Walnut Township,United States Senate,,Republican,"Roberts, Pat",10,000A83
+CRAWFORD,Arcadia,United States Senate,,independent,"Orman, Greg",34,000010
+CRAWFORD,Arcadia,United States Senate,,Libertarian,"Batson, Randall",12,000010
+CRAWFORD,Arcadia,United States Senate,,Republican,"Roberts, Pat",41,000010
+CRAWFORD,Baker,United States Senate,,independent,"Orman, Greg",147,000020
+CRAWFORD,Baker,United States Senate,,Libertarian,"Batson, Randall",28,000020
+CRAWFORD,Baker,United States Senate,,Republican,"Roberts, Pat",218,000020
+CRAWFORD,Beulah,United States Senate,,independent,"Orman, Greg",34,000030
+CRAWFORD,Beulah,United States Senate,,Libertarian,"Batson, Randall",6,000030
+CRAWFORD,Beulah,United States Senate,,Republican,"Roberts, Pat",51,000030
+CRAWFORD,Sheridan - Cherokee City,United States Senate,,independent,"Orman, Greg",18,000033
+CRAWFORD,Sheridan - Cherokee City,United States Senate,,Libertarian,"Batson, Randall",8,000033
+CRAWFORD,Sheridan - Cherokee City,United States Senate,,Republican,"Roberts, Pat",16,000033
+CRAWFORD,Brazilton,United States Senate,,independent,"Orman, Greg",10,000040
+CRAWFORD,Brazilton,United States Senate,,Libertarian,"Batson, Randall",3,000040
+CRAWFORD,Brazilton,United States Senate,,Republican,"Roberts, Pat",17,000040
+CRAWFORD,Capaldo,United States Senate,,independent,"Orman, Greg",74,000050
+CRAWFORD,Capaldo,United States Senate,,Libertarian,"Batson, Randall",16,000050
+CRAWFORD,Capaldo,United States Senate,,Republican,"Roberts, Pat",76,000050
+CRAWFORD,Cherokee,United States Senate,,independent,"Orman, Greg",66,000060
+CRAWFORD,Cherokee,United States Senate,,Libertarian,"Batson, Randall",25,000060
+CRAWFORD,Cherokee,United States Senate,,Republican,"Roberts, Pat",95,000060
+CRAWFORD,Chicopee,United States Senate,,independent,"Orman, Greg",89,000070
+CRAWFORD,Chicopee,United States Senate,,Libertarian,"Batson, Randall",17,000070
+CRAWFORD,Chicopee,United States Senate,,Republican,"Roberts, Pat",124,000070
+CRAWFORD,Crawford,United States Senate,,independent,"Orman, Greg",39,000080
+CRAWFORD,Crawford,United States Senate,,Libertarian,"Batson, Randall",15,000080
+CRAWFORD,Crawford,United States Senate,,Republican,"Roberts, Pat",117,000080
+CRAWFORD,Crowe,United States Senate,,independent,"Orman, Greg",41,000090
+CRAWFORD,Crowe,United States Senate,,Libertarian,"Batson, Randall",8,000090
+CRAWFORD,Crowe,United States Senate,,Republican,"Roberts, Pat",34,000090
+CRAWFORD,Frontenac Ward 1,United States Senate,,independent,"Orman, Greg",147,000110
+CRAWFORD,Frontenac Ward 1,United States Senate,,Libertarian,"Batson, Randall",26,000110
+CRAWFORD,Frontenac Ward 1,United States Senate,,Republican,"Roberts, Pat",115,000110
+CRAWFORD,Frontenac Ward 2,United States Senate,,independent,"Orman, Greg",222,00012A
+CRAWFORD,Frontenac Ward 2,United States Senate,,Libertarian,"Batson, Randall",33,00012A
+CRAWFORD,Frontenac Ward 2,United States Senate,,Republican,"Roberts, Pat",175,00012A
+CRAWFORD,Frontenac Ward 3,United States Senate,,independent,"Orman, Greg",91,00013A
+CRAWFORD,Frontenac Ward 3,United States Senate,,Libertarian,"Batson, Randall",14,00013A
+CRAWFORD,Frontenac Ward 3,United States Senate,,Republican,"Roberts, Pat",64,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States Senate,,independent,"Orman, Greg",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States Senate,,Libertarian,"Batson, Randall",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States Senate,,Republican,"Roberts, Pat",0,00013B
+CRAWFORD,Frontenac Ward 4,United States Senate,,independent,"Orman, Greg",73,00014A
+CRAWFORD,Frontenac Ward 4,United States Senate,,Libertarian,"Batson, Randall",9,00014A
+CRAWFORD,Frontenac Ward 4,United States Senate,,Republican,"Roberts, Pat",53,00014A
+CRAWFORD,Girard Ward 1,United States Senate,,independent,"Orman, Greg",37,000150
+CRAWFORD,Girard Ward 1,United States Senate,,Libertarian,"Batson, Randall",10,000150
+CRAWFORD,Girard Ward 1,United States Senate,,Republican,"Roberts, Pat",35,000150
+CRAWFORD,Girard Ward 2,United States Senate,,independent,"Orman, Greg",100,00016A
+CRAWFORD,Girard Ward 2,United States Senate,,Libertarian,"Batson, Randall",22,00016A
+CRAWFORD,Girard Ward 2,United States Senate,,Republican,"Roberts, Pat",139,00016A
+CRAWFORD,Girard Ward 3,United States Senate,,independent,"Orman, Greg",81,00017A
+CRAWFORD,Girard Ward 3,United States Senate,,Libertarian,"Batson, Randall",16,00017A
+CRAWFORD,Girard Ward 3,United States Senate,,Republican,"Roberts, Pat",70,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States Senate,,independent,"Orman, Greg",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States Senate,,Libertarian,"Batson, Randall",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States Senate,,Republican,"Roberts, Pat",0,00017B
+CRAWFORD,Girard Ward 4,United States Senate,,independent,"Orman, Greg",87,000180
+CRAWFORD,Girard Ward 4,United States Senate,,Libertarian,"Batson, Randall",28,000180
+CRAWFORD,Girard Ward 4,United States Senate,,Republican,"Roberts, Pat",127,000180
+CRAWFORD,Grant,United States Senate,,independent,"Orman, Greg",40,000190
+CRAWFORD,Grant,United States Senate,,Libertarian,"Batson, Randall",8,000190
+CRAWFORD,Grant,United States Senate,,Republican,"Roberts, Pat",64,000190
+CRAWFORD,Hepler,United States Senate,,independent,"Orman, Greg",10,000200
+CRAWFORD,Hepler,United States Senate,,Libertarian,"Batson, Randall",3,000200
+CRAWFORD,Hepler,United States Senate,,Republican,"Roberts, Pat",17,000200
+CRAWFORD,Lincoln,United States Senate,,independent,"Orman, Greg",42,000210
+CRAWFORD,Lincoln,United States Senate,,Libertarian,"Batson, Randall",12,000210
+CRAWFORD,Lincoln,United States Senate,,Republican,"Roberts, Pat",72,000210
+CRAWFORD,Lone Star,United States Senate,,independent,"Orman, Greg",177,00022A
+CRAWFORD,Lone Star,United States Senate,,Libertarian,"Batson, Randall",33,00022A
+CRAWFORD,Lone Star,United States Senate,,Republican,"Roberts, Pat",229,00022A
+CRAWFORD,McCune,United States Senate,,independent,"Orman, Greg",54,000230
+CRAWFORD,McCune,United States Senate,,Libertarian,"Batson, Randall",16,000230
+CRAWFORD,McCune,United States Senate,,Republican,"Roberts, Pat",48,000230
+CRAWFORD,Mulberry Ward 1,United States Senate,,independent,"Orman, Greg",24,000240
+CRAWFORD,Mulberry Ward 1,United States Senate,,Libertarian,"Batson, Randall",6,000240
+CRAWFORD,Mulberry Ward 1,United States Senate,,Republican,"Roberts, Pat",21,000240
+CRAWFORD,Mulberry Ward 2,United States Senate,,independent,"Orman, Greg",14,000250
+CRAWFORD,Mulberry Ward 2,United States Senate,,Libertarian,"Batson, Randall",8,000250
+CRAWFORD,Mulberry Ward 2,United States Senate,,Republican,"Roberts, Pat",25,000250
+CRAWFORD,North Arma,United States Senate,,independent,"Orman, Greg",94,000260
+CRAWFORD,North Arma,United States Senate,,Libertarian,"Batson, Randall",17,000260
+CRAWFORD,North Arma,United States Senate,,Republican,"Roberts, Pat",120,000260
+CRAWFORD,Opolis,United States Senate,,independent,"Orman, Greg",48,000270
+CRAWFORD,Opolis,United States Senate,,Libertarian,"Batson, Randall",5,000270
+CRAWFORD,Opolis,United States Senate,,Republican,"Roberts, Pat",77,000270
+CRAWFORD,Parkview,United States Senate,,independent,"Orman, Greg",87,000280
+CRAWFORD,Parkview,United States Senate,,Libertarian,"Batson, Randall",11,000280
+CRAWFORD,Parkview,United States Senate,,Republican,"Roberts, Pat",68,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",76,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",9,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",94,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",157,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",22,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",175,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States Senate,,independent,"Orman, Greg",379,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",38,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States Senate,,Republican,"Roberts, Pat",430,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",71,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",16,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",62,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",113,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",9,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",92,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States Senate,,independent,"Orman, Greg",150,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",14,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States Senate,,Republican,"Roberts, Pat",88,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States Senate,,independent,"Orman, Greg",105,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",6,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States Senate,,Republican,"Roberts, Pat",103,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States Senate,,independent,"Orman, Greg",119,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States Senate,,Libertarian,"Batson, Randall",14,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States Senate,,Republican,"Roberts, Pat",152,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",85,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",19,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",93,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States Senate,,independent,"Orman, Greg",112,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",17,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States Senate,,Republican,"Roberts, Pat",107,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",39,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",7,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",34,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",83,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",17,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",50,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States Senate,,independent,"Orman, Greg",143,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",35,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States Senate,,Republican,"Roberts, Pat",140,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States Senate,,independent,"Orman, Greg",68,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",11,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States Senate,,Republican,"Roberts, Pat",67,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States Senate,,independent,"Orman, Greg",213,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States Senate,,Libertarian,"Batson, Randall",24,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States Senate,,Republican,"Roberts, Pat",239,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States Senate,,independent,"Orman, Greg",19,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States Senate,,Libertarian,"Batson, Randall",6,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States Senate,,Republican,"Roberts, Pat",50,00044A
+CRAWFORD,Raymond,United States Senate,,independent,"Orman, Greg",108,000450
+CRAWFORD,Raymond,United States Senate,,Libertarian,"Batson, Randall",18,000450
+CRAWFORD,Raymond,United States Senate,,Republican,"Roberts, Pat",147,000450
+CRAWFORD,Sheridan,United States Senate,,independent,"Orman, Greg",22,000460
+CRAWFORD,Sheridan,United States Senate,,Libertarian,"Batson, Randall",2,000460
+CRAWFORD,Sheridan,United States Senate,,Republican,"Roberts, Pat",19,000460
+CRAWFORD,Sherman,United States Senate,,independent,"Orman, Greg",83,000470
+CRAWFORD,Sherman,United States Senate,,Libertarian,"Batson, Randall",18,000470
+CRAWFORD,Sherman,United States Senate,,Republican,"Roberts, Pat",123,000470
+CRAWFORD,Smelter,United States Senate,,independent,"Orman, Greg",96,000480
+CRAWFORD,Smelter,United States Senate,,Libertarian,"Batson, Randall",11,000480
+CRAWFORD,Smelter,United States Senate,,Republican,"Roberts, Pat",141,000480
+CRAWFORD,South Arma,United States Senate,,independent,"Orman, Greg",127,000490
+CRAWFORD,South Arma,United States Senate,,Libertarian,"Batson, Randall",18,000490
+CRAWFORD,South Arma,United States Senate,,Republican,"Roberts, Pat",125,000490
+CRAWFORD,Walnut,United States Senate,,independent,"Orman, Greg",17,000500
+CRAWFORD,Walnut,United States Senate,,Libertarian,"Batson, Randall",6,000500
+CRAWFORD,Walnut,United States Senate,,Republican,"Roberts, Pat",23,000500
+CRAWFORD,Franklin,United States Senate,,independent,"Orman, Greg",60,700100
+CRAWFORD,Franklin,United States Senate,,Libertarian,"Batson, Randall",13,700100
+CRAWFORD,Franklin,United States Senate,,Republican,"Roberts, Pat",63,700100
+CRAWFORD,Baker Enclave,United States Senate,,independent,"Orman, Greg",0,900010
+CRAWFORD,Baker Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+CRAWFORD,Baker Enclave,United States Senate,,Republican,"Roberts, Pat",0,900010
+CRAWFORD,Parkview Enclave,United States Senate,,independent,"Orman, Greg",0,900020
+CRAWFORD,Parkview Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900020
+CRAWFORD,Parkview Enclave,United States Senate,,Republican,"Roberts, Pat",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States Senate,,independent,"Orman, Greg",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States Senate,,independent,"Orman, Greg",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,900040

--- a/2014/20141104__ks__general__decatur__precinct.csv
+++ b/2014/20141104__ks__general__decatur__precinct.csv
@@ -1,460 +1,477 @@
-county,precinct,office,district,party,candidate,votes
-Decatur,Dresden-Custer,U.S. Senate,,L,Randall Batson,0
-Decatur,Dresden-Lyon,U.S. Senate,,L,Randall Batson,0
-Decatur,Dresden-Dresden twp,U.S. Senate,,L,Randall Batson,0
-Decatur,Dresden-Custer,U.S. Senate,,I,Greg Orman,0
-Decatur,Dresden-Lyon,U.S. Senate,,I,Greg Orman,3
-Decatur,Dresden-Dresden twp,U.S. Senate,,I,Greg Orman,13
-Decatur,Dresden-Custer,U.S. Senate,,R,Pat Roberts,20
-Decatur,Dresden-Lyon,U.S. Senate,,R,Pat Roberts,2
-Decatur,Dresden-Dresden twp,U.S. Senate,,R,Pat Roberts,37
-Decatur,Dresden-Custer,U.S. House,1,R,Tim Huelskamp,18
-Decatur,Dresden-Lyon,U.S. House,1,R,Tim Huelskamp,2
-Decatur,Dresden-Dresden twp,U.S. House,1,R,Tim Huelskamp,38
-Decatur,Dresden-Custer,U.S. House,1,D,James Sherow,1
-Decatur,Dresden-Lyon,U.S. House,1,D,James Sherow,3
-Decatur,Dresden-Dresden twp,U.S. House,1,D,James Sherow,11
-Decatur,Dresden-Custer,Governor,,R,Sam Brownback,20
-Decatur,Dresden-Lyon,Governor,,R,Sam Brownback,2
-Decatur,Dresden-Dresden twp,Governor,,R,Sam Brownback,40
-Decatur,Dresden-Custer,Governor,,D,Paul Davis,0
-Decatur,Dresden-Lyon,Governor,,D,Paul Davis,3
-Decatur,Dresden-Dresden twp,Governor,,D,Paul Davis,12
-Decatur,Dresden-Custer,Governor,,L,Keen Umbehr,0
-Decatur,Dresden-Lyon,Governor,,L,Keen Umbehr,0
-Decatur,Dresden-Dresden twp,Governor,,L,Keen Umbehr,2
-Decatur,Dresden-Custer,Secretary of State,,R,Kris Kobach,19
-Decatur,Dresden-Lyon,Secretary of State,,R,Kris Kobach,3
-Decatur,Dresden-Dresden twp,Secretary of State,,R,Kris Kobach,39
-Decatur,Dresden-Custer,Secretary of State,,D,Jean Schodorf,1
-Decatur,Dresden-Lyon,Secretary of State,,D,Jean Schodorf,2
-Decatur,Dresden-Dresden twp,Secretary of State,,D,Jean Schodorf,11
-Decatur,Dresden-Custer,Attorney General,,D,AJ Kotich,2
-Decatur,Dresden-Lyon,Attorney General,,D,AJ Kotich,3
-Decatur,Dresden-Dresden twp,Attorney General,,D,AJ Kotich,9
-Decatur,Dresden-Custer,Attorney General,,R,Derek Schmidt,18
-Decatur,Dresden-Lyon,Attorney General,,R,Derek Schmidt,2
-Decatur,Dresden-Dresden twp,Attorney General,,R,Derek Schmidt,40
-Decatur,Dresden-Custer,State Treasurer,,D,Carmen Alldritt,0
-Decatur,Dresden-Lyon,State Treasurer,,D,Carmen Alldritt,1
-Decatur,Dresden-Dresden twp,State Treasurer,,D,Carmen Alldritt,10
-Decatur,Dresden-Custer,State Treasurer,,R,Ron Estes,19
-Decatur,Dresden-Lyon,State Treasurer,,R,Ron Estes,4
-Decatur,Dresden-Dresden twp,State Treasurer,,R,Ron Estes,39
-Decatur,Dresden-Custer,Insurance Commissioner,,D,Dennis Anderson,1
-Decatur,Dresden-Lyon,Insurance Commissioner,,D,Dennis Anderson,3
-Decatur,Dresden-Dresden twp,Insurance Commissioner,,D,Dennis Anderson,12
-Decatur,Dresden-Custer,Insurance Commissioner,,R,Ken Selzer,17
-Decatur,Dresden-Lyon,Insurance Commissioner,,R,Ken Selzer,2
-Decatur,Dresden-Dresden twp,Insurance Commissioner,,R,Ken Selzer,36
-Decatur,Dresden-Custer,State House,120,R,Rick Billinger,19
-Decatur,Dresden-Lyon,State House,120,R,Rick Billinger,4
-Decatur,Dresden-Dresden twp,State House,120,R,Rick Billinger,42
-Decatur,Jennings-Allison,U.S. Senate,,L,Randall Batson,0
-Decatur,Jennings-Pleas Valley,U.S. Senate,,L,Randall Batson,0
-Decatur,Jennings-Jennings twp,U.S. Senate,,L,Randall Batson,2
-Decatur,Jennings-Allison,U.S. Senate,,I,Greg Orman,3
-Decatur,Jennings-Pleas Valley,U.S. Senate,,I,Greg Orman,4
-Decatur,Jennings-Jennings twp,U.S. Senate,,I,Greg Orman,20
-Decatur,Jennings-Allison,U.S. Senate,,R,Pat Roberts,6
-Decatur,Jennings-Pleas Valley,U.S. Senate,,R,Pat Roberts,14
-Decatur,Jennings-Jennings twp,U.S. Senate,,R,Pat Roberts,44
-Decatur,Jennings-Allison,U.S. House,1,R,Tim Huelskamp,7
-Decatur,Jennings-Pleas Valley,U.S. House,1,R,Tim Huelskamp,14
-Decatur,Jennings-Jennings twp,U.S. House,1,R,Tim Huelskamp,46
-Decatur,Jennings-Allison,U.S. House,1,D,James Sherow,1
-Decatur,Jennings-Pleas Valley,U.S. House,1,D,James Sherow,4
-Decatur,Jennings-Jennings twp,U.S. House,1,D,James Sherow,21
-Decatur,Jennings-Allison,Governor,,R,Sam Brownback,4
-Decatur,Jennings-Pleas Valley,Governor,,R,Sam Brownback,12
-Decatur,Jennings-Jennings twp,Governor,,R,Sam Brownback,38
-Decatur,Jennings-Allison,Governor,,D,Paul Davis,5
-Decatur,Jennings-Pleas Valley,Governor,,D,Paul Davis,5
-Decatur,Jennings-Jennings twp,Governor,,D,Paul Davis,26
-Decatur,Jennings-Allison,Governor,,L,Keen Umbehr,0
-Decatur,Jennings-Pleas Valley,Governor,,L,Keen Umbehr,1
-Decatur,Jennings-Jennings twp,Governor,,L,Keen Umbehr,2
-Decatur,Jennings-Allison,Secretary of State,,R,Kris Kobach,6
-Decatur,Jennings-Pleas Valley,Secretary of State,,R,Kris Kobach,14
-Decatur,Jennings-Jennings twp,Secretary of State,,R,Kris Kobach,40
-Decatur,Jennings-Allison,Secretary of State,,D,Jean Schodorf,3
-Decatur,Jennings-Pleas Valley,Secretary of State,,D,Jean Schodorf,4
-Decatur,Jennings-Jennings twp,Secretary of State,,D,Jean Schodorf,25
-Decatur,Jennings-Allison,Attorney General,,D,AJ Kotich,3
-Decatur,Jennings-Pleas Valley,Attorney General,,D,AJ Kotich,1
-Decatur,Jennings-Jennings twp,Attorney General,,D,AJ Kotich,18
-Decatur,Jennings-Allison,Attorney General,,R,Derek Schmidt,6
-Decatur,Jennings-Pleas Valley,Attorney General,,R,Derek Schmidt,16
-Decatur,Jennings-Jennings twp,Attorney General,,R,Derek Schmidt,47
-Decatur,Jennings-Allison,State Treasurer,,D,Carmen Alldritt,2
-Decatur,Jennings-Pleas Valley,State Treasurer,,D,Carmen Alldritt,1
-Decatur,Jennings-Jennings twp,State Treasurer,,D,Carmen Alldritt,19
-Decatur,Jennings-Allison,State Treasurer,,R,Ron Estes,7
-Decatur,Jennings-Pleas Valley,State Treasurer,,R,Ron Estes,16
-Decatur,Jennings-Jennings twp,State Treasurer,,R,Ron Estes,44
-Decatur,Jennings-Allison,Insurance Commissioner,,D,Dennis Anderson,4
-Decatur,Jennings-Pleas Valley,Insurance Commissioner,,D,Dennis Anderson,5
-Decatur,Jennings-Jennings twp,Insurance Commissioner,,D,Dennis Anderson,24
-Decatur,Jennings-Allison,Insurance Commissioner,,R,Ken Selzer,5
-Decatur,Jennings-Pleas Valley,Insurance Commissioner,,R,Ken Selzer,12
-Decatur,Jennings-Jennings twp,Insurance Commissioner,,R,Ken Selzer,38
-Decatur,Jennings-Allison,State House,120,R,Rick Billinger,7
-Decatur,Jennings-Pleas Valley,State House,120,R,Rick Billinger,18
-Decatur,Jennings-Jennings twp,State House,120,R,Rick Billinger,54
-Decatur,Norcatur-Garfield,U.S. Senate,,L,Randall Batson,1
-Decatur,Norcatur-Grant,U.S. Senate,,L,Randall Batson,0
-Decatur,Norcatur-Lincoln,U.S. Senate,,L,Randall Batson,3
-Decatur,Norcatur-Garfield,U.S. Senate,,I,Greg Orman,6
-Decatur,Norcatur-Grant,U.S. Senate,,I,Greg Orman,0
-Decatur,Norcatur-Lincoln,U.S. Senate,,I,Greg Orman,13
-Decatur,Norcatur-Garfield,U.S. Senate,,R,Pat Roberts,12
-Decatur,Norcatur-Grant,U.S. Senate,,R,Pat Roberts,3
-Decatur,Norcatur-Lincoln,U.S. Senate,,R,Pat Roberts,43
-Decatur,Norcatur-Garfield,U.S. House,1,R,Tim Huelskamp,13
-Decatur,Norcatur-Grant,U.S. House,1,R,Tim Huelskamp,3
-Decatur,Norcatur-Lincoln,U.S. House,1,R,Tim Huelskamp,45
-Decatur,Norcatur-Garfield,U.S. House,1,D,James Sherow,7
-Decatur,Norcatur-Grant,U.S. House,1,D,James Sherow,0
-Decatur,Norcatur-Lincoln,U.S. House,1,D,James Sherow,13
-Decatur,Norcatur-Garfield,Governor,,R,Sam Brownback,13
-Decatur,Norcatur-Grant,Governor,,R,Sam Brownback,3
-Decatur,Norcatur-Lincoln,Governor,,R,Sam Brownback,43
-Decatur,Norcatur-Garfield,Governor,,D,Paul Davis,7
-Decatur,Norcatur-Grant,Governor,,D,Paul Davis,0
-Decatur,Norcatur-Lincoln,Governor,,D,Paul Davis,18
-Decatur,Norcatur-Garfield,Governor,,L,Keen Umbehr,0
-Decatur,Norcatur-Grant,Governor,,L,Keen Umbehr,0
-Decatur,Norcatur-Lincoln,Governor,,L,Keen Umbehr,1
-Decatur,Norcatur-Garfield,Secretary of State,,R,Kris Kobach,13
-Decatur,Norcatur-Grant,Secretary of State,,R,Kris Kobach,3
-Decatur,Norcatur-Lincoln,Secretary of State,,R,Kris Kobach,46
-Decatur,Norcatur-Garfield,Secretary of State,,D,Jean Schodorf,7
-Decatur,Norcatur-Grant,Secretary of State,,D,Jean Schodorf,0
-Decatur,Norcatur-Lincoln,Secretary of State,,D,Jean Schodorf,14
-Decatur,Norcatur-Garfield,Attorney General,,D,AJ Kotich,4
-Decatur,Norcatur-Grant,Attorney General,,D,AJ Kotich,0
-Decatur,Norcatur-Lincoln,Attorney General,,D,AJ Kotich,10
-Decatur,Norcatur-Garfield,Attorney General,,R,Derek Schmidt,16
-Decatur,Norcatur-Grant,Attorney General,,R,Derek Schmidt,3
-Decatur,Norcatur-Lincoln,Attorney General,,R,Derek Schmidt,52
-Decatur,Norcatur-Garfield,State Treasurer,,D,Carmen Alldritt,4
-Decatur,Norcatur-Grant,State Treasurer,,D,Carmen Alldritt,0
-Decatur,Norcatur-Lincoln,State Treasurer,,D,Carmen Alldritt,12
-Decatur,Norcatur-Garfield,State Treasurer,,R,Ron Estes,16
-Decatur,Norcatur-Grant,State Treasurer,,R,Ron Estes,3
-Decatur,Norcatur-Lincoln,State Treasurer,,R,Ron Estes,51
-Decatur,Norcatur-Garfield,Insurance Commissioner,,D,Dennis Anderson,5
-Decatur,Norcatur-Grant,Insurance Commissioner,,D,Dennis Anderson,0
-Decatur,Norcatur-Lincoln,Insurance Commissioner,,D,Dennis Anderson,15
-Decatur,Norcatur-Garfield,Insurance Commissioner,,R,Ken Selzer,14
-Decatur,Norcatur-Grant,Insurance Commissioner,,R,Ken Selzer,3
-Decatur,Norcatur-Lincoln,Insurance Commissioner,,R,Ken Selzer,46
-Decatur,Norcatur-Garfield,State House,120,R,Rick Billinger,16
-Decatur,Norcatur-Grant,State House,120,R,Rick Billinger,2
-Decatur,Norcatur-Lincoln,State House,120,R,Rick Billinger,58
-Decatur,North-Beaver,U.S. Senate,,L,Randall Batson,0
-Decatur,North-Finley,U.S. Senate,,L,Randall Batson,0
-Decatur,North-Harlan,U.S. Senate,,L,Randall Batson,0
-Decatur,North-Liberty,U.S. Senate,,L,Randall Batson,2
-Decatur,North-Logan,U.S. Senate,,L,Randall Batson,0
-Decatur,North-Olive,U.S. Senate,,L,Randall Batson,0
-Decatur,North-Roosevelt,U.S. Senate,,L,Randall Batson,0
-Decatur,North-Sherman,U.S. Senate,,L,Randall Batson,1
-Decatur,South-Altory,U.S. Senate,,L,Randall Batson,0
-Decatur,South-Bassettville,U.S. Senate,,L,Randall Batson,0
-Decatur,South-Center,U.S. Senate,,L,Randall Batson,3
-Decatur,South-Cook,U.S. Senate,,L,Randall Batson,0
-Decatur,South-Oberlin,U.S. Senate,,L,Randall Batson,3
-Decatur,South-Prairie Dog,U.S. Senate,,L,Randall Batson,1
-Decatur,South-Sappa,U.S. Senate,,L,Randall Batson,0
-Decatur,South-Summit,U.S. Senate,,L,Randall Batson,0
-Decatur,Oberlin City 1,U.S. Senate,,L,Randall Batson,10
-Decatur,Oberlin City 2,U.S. Senate,,L,Randall Batson,22
-Decatur,North-Beaver,U.S. Senate,,I,Greg Orman,2
-Decatur,North-Finley,U.S. Senate,,I,Greg Orman,3
-Decatur,North-Harlan,U.S. Senate,,I,Greg Orman,1
-Decatur,North-Liberty,U.S. Senate,,I,Greg Orman,4
-Decatur,North-Logan,U.S. Senate,,I,Greg Orman,0
-Decatur,North-Olive,U.S. Senate,,I,Greg Orman,5
-Decatur,North-Roosevelt,U.S. Senate,,I,Greg Orman,3
-Decatur,North-Sherman,U.S. Senate,,I,Greg Orman,1
-Decatur,South-Altory,U.S. Senate,,I,Greg Orman,1
-Decatur,South-Bassettville,U.S. Senate,,I,Greg Orman,1
-Decatur,South-Center,U.S. Senate,,I,Greg Orman,3
-Decatur,South-Cook,U.S. Senate,,I,Greg Orman,0
-Decatur,South-Oberlin,U.S. Senate,,I,Greg Orman,8
-Decatur,South-Prairie Dog,U.S. Senate,,I,Greg Orman,0
-Decatur,South-Sappa,U.S. Senate,,I,Greg Orman,0
-Decatur,South-Summit,U.S. Senate,,I,Greg Orman,4
-Decatur,Oberlin City 1,U.S. Senate,,I,Greg Orman,70
-Decatur,Oberlin City 2,U.S. Senate,,I,Greg Orman,63
-Decatur,North-Beaver,U.S. Senate,,R,Pat Roberts,11
-Decatur,North-Finley,U.S. Senate,,R,Pat Roberts,11
-Decatur,North-Harlan,U.S. Senate,,R,Pat Roberts,11
-Decatur,North-Liberty,U.S. Senate,,R,Pat Roberts,21
-Decatur,North-Logan,U.S. Senate,,R,Pat Roberts,16
-Decatur,North-Olive,U.S. Senate,,R,Pat Roberts,21
-Decatur,North-Roosevelt,U.S. Senate,,R,Pat Roberts,5
-Decatur,North-Sherman,U.S. Senate,,R,Pat Roberts,5
-Decatur,South-Altory,U.S. Senate,,R,Pat Roberts,9
-Decatur,South-Bassettville,U.S. Senate,,R,Pat Roberts,9
-Decatur,South-Center,U.S. Senate,,R,Pat Roberts,18
-Decatur,South-Cook,U.S. Senate,,R,Pat Roberts,16
-Decatur,South-Oberlin,U.S. Senate,,R,Pat Roberts,36
-Decatur,South-Prairie Dog,U.S. Senate,,R,Pat Roberts,13
-Decatur,South-Sappa,U.S. Senate,,R,Pat Roberts,19
-Decatur,South-Summit,U.S. Senate,,R,Pat Roberts,9
-Decatur,Oberlin City 1,U.S. Senate,,R,Pat Roberts,224
-Decatur,Oberlin City 2,U.S. Senate,,R,Pat Roberts,308
-Decatur,North-Beaver,U.S. House,1,R,Tim Huelskamp,12
-Decatur,North-Finley,U.S. House,1,R,Tim Huelskamp,12
-Decatur,North-Harlan,U.S. House,1,R,Tim Huelskamp,11
-Decatur,North-Liberty,U.S. House,1,R,Tim Huelskamp,24
-Decatur,North-Logan,U.S. House,1,R,Tim Huelskamp,16
-Decatur,North-Olive,U.S. House,1,R,Tim Huelskamp,21
-Decatur,North-Roosevelt,U.S. House,1,R,Tim Huelskamp,7
-Decatur,North-Sherman,U.S. House,1,R,Tim Huelskamp,7
-Decatur,South-Altory,U.S. House,1,R,Tim Huelskamp,9
-Decatur,South-Bassettville,U.S. House,1,R,Tim Huelskamp,8
-Decatur,South-Center,U.S. House,1,R,Tim Huelskamp,21
-Decatur,South-Cook,U.S. House,1,R,Tim Huelskamp,15
-Decatur,South-Oberlin,U.S. House,1,R,Tim Huelskamp,37
-Decatur,South-Prairie Dog,U.S. House,1,R,Tim Huelskamp,13
-Decatur,South-Sappa,U.S. House,1,R,Tim Huelskamp,19
-Decatur,South-Summit,U.S. House,1,R,Tim Huelskamp,9
-Decatur,Oberlin City 1,U.S. House,1,R,Tim Huelskamp,235
-Decatur,Oberlin City 2,U.S. House,1,R,Tim Huelskamp,323
-Decatur,North-Beaver,U.S. House,1,D,James Sherow,1
-Decatur,North-Finley,U.S. House,1,D,James Sherow,2
-Decatur,North-Harlan,U.S. House,1,D,James Sherow,1
-Decatur,North-Liberty,U.S. House,1,D,James Sherow,2
-Decatur,North-Logan,U.S. House,1,D,James Sherow,0
-Decatur,North-Olive,U.S. House,1,D,James Sherow,4
-Decatur,North-Roosevelt,U.S. House,1,D,James Sherow,1
-Decatur,North-Sherman,U.S. House,1,D,James Sherow,0
-Decatur,South-Altory,U.S. House,1,D,James Sherow,1
-Decatur,South-Bassettville,U.S. House,1,D,James Sherow,2
-Decatur,South-Center,U.S. House,1,D,James Sherow,1
-Decatur,South-Cook,U.S. House,1,D,James Sherow,0
-Decatur,South-Oberlin,U.S. House,1,D,James Sherow,9
-Decatur,South-Prairie Dog,U.S. House,1,D,James Sherow,1
-Decatur,South-Sappa,U.S. House,1,D,James Sherow,0
-Decatur,South-Summit,U.S. House,1,D,James Sherow,3
-Decatur,Oberlin City 1,U.S. House,1,D,James Sherow,61
-Decatur,Oberlin City 2,U.S. House,1,D,James Sherow,64
-Decatur,North-Beaver,Governor,,R,Sam Brownback,11
-Decatur,North-Finley,Governor,,R,Sam Brownback,12
-Decatur,North-Harlan,Governor,,R,Sam Brownback,11
-Decatur,North-Liberty,Governor,,R,Sam Brownback,23
-Decatur,North-Logan,Governor,,R,Sam Brownback,15
-Decatur,North-Olive,Governor,,R,Sam Brownback,15
-Decatur,North-Roosevelt,Governor,,R,Sam Brownback,5
-Decatur,North-Sherman,Governor,,R,Sam Brownback,7
-Decatur,South-Altory,Governor,,R,Sam Brownback,6
-Decatur,South-Bassettville,Governor,,R,Sam Brownback,8
-Decatur,South-Center,Governor,,R,Sam Brownback,17
-Decatur,South-Cook,Governor,,R,Sam Brownback,14
-Decatur,South-Oberlin,Governor,,R,Sam Brownback,33
-Decatur,South-Prairie Dog,Governor,,R,Sam Brownback,13
-Decatur,South-Sappa,Governor,,R,Sam Brownback,19
-Decatur,South-Summit,Governor,,R,Sam Brownback,9
-Decatur,Oberlin City 1,Governor,,R,Sam Brownback,214
-Decatur,Oberlin City 2,Governor,,R,Sam Brownback,297
-Decatur,North-Beaver,Governor,,D,Paul Davis,3
-Decatur,North-Finley,Governor,,D,Paul Davis,2
-Decatur,North-Harlan,Governor,,D,Paul Davis,1
-Decatur,North-Liberty,Governor,,D,Paul Davis,2
-Decatur,North-Logan,Governor,,D,Paul Davis,1
-Decatur,North-Olive,Governor,,D,Paul Davis,7
-Decatur,North-Roosevelt,Governor,,D,Paul Davis,3
-Decatur,North-Sherman,Governor,,D,Paul Davis,0
-Decatur,South-Altory,Governor,,D,Paul Davis,3
-Decatur,South-Bassettville,Governor,,D,Paul Davis,2
-Decatur,South-Center,Governor,,D,Paul Davis,5
-Decatur,South-Cook,Governor,,D,Paul Davis,2
-Decatur,South-Oberlin,Governor,,D,Paul Davis,11
-Decatur,South-Prairie Dog,Governor,,D,Paul Davis,1
-Decatur,South-Sappa,Governor,,D,Paul Davis,0
-Decatur,South-Summit,Governor,,D,Paul Davis,3
-Decatur,Oberlin City 1,Governor,,D,Paul Davis,80
-Decatur,Oberlin City 2,Governor,,D,Paul Davis,90
-Decatur,North-Beaver,Governor,,L,Keen Umbehr,0
-Decatur,North-Finley,Governor,,L,Keen Umbehr,0
-Decatur,North-Harlan,Governor,,L,Keen Umbehr,0
-Decatur,North-Liberty,Governor,,L,Keen Umbehr,1
-Decatur,North-Logan,Governor,,L,Keen Umbehr,0
-Decatur,North-Olive,Governor,,L,Keen Umbehr,3
-Decatur,North-Roosevelt,Governor,,L,Keen Umbehr,0
-Decatur,North-Sherman,Governor,,L,Keen Umbehr,0
-Decatur,South-Altory,Governor,,L,Keen Umbehr,0
-Decatur,South-Bassettville,Governor,,L,Keen Umbehr,0
-Decatur,South-Center,Governor,,L,Keen Umbehr,2
-Decatur,South-Cook,Governor,,L,Keen Umbehr,0
-Decatur,South-Oberlin,Governor,,L,Keen Umbehr,3
-Decatur,South-Prairie Dog,Governor,,L,Keen Umbehr,0
-Decatur,South-Sappa,Governor,,L,Keen Umbehr,0
-Decatur,South-Summit,Governor,,L,Keen Umbehr,1
-Decatur,Oberlin City 1,Governor,,L,Keen Umbehr,11
-Decatur,Oberlin City 2,Governor,,L,Keen Umbehr,10
-Decatur,North-Beaver,Secretary of State,,R,Kris Kobach,13
-Decatur,North-Finley,Secretary of State,,R,Kris Kobach,12
-Decatur,North-Harlan,Secretary of State,,R,Kris Kobach,11
-Decatur,North-Liberty,Secretary of State,,R,Kris Kobach,24
-Decatur,North-Logan,Secretary of State,,R,Kris Kobach,16
-Decatur,North-Olive,Secretary of State,,R,Kris Kobach,21
-Decatur,North-Roosevelt,Secretary of State,,R,Kris Kobach,5
-Decatur,North-Sherman,Secretary of State,,R,Kris Kobach,7
-Decatur,South-Altory,Secretary of State,,R,Kris Kobach,9
-Decatur,South-Bassettville,Secretary of State,,R,Kris Kobach,8
-Decatur,South-Center,Secretary of State,,R,Kris Kobach,19
-Decatur,South-Cook,Secretary of State,,R,Kris Kobach,15
-Decatur,South-Oberlin,Secretary of State,,R,Kris Kobach,36
-Decatur,South-Prairie Dog,Secretary of State,,R,Kris Kobach,12
-Decatur,South-Sappa,Secretary of State,,R,Kris Kobach,18
-Decatur,South-Summit,Secretary of State,,R,Kris Kobach,9
-Decatur,Oberlin City 1,Secretary of State,,R,Kris Kobach,232
-Decatur,Oberlin City 2,Secretary of State,,R,Kris Kobach,323
-Decatur,North-Beaver,Secretary of State,,D,Jean Schodorf,1
-Decatur,North-Finley,Secretary of State,,D,Jean Schodorf,2
-Decatur,North-Harlan,Secretary of State,,D,Jean Schodorf,1
-Decatur,North-Liberty,Secretary of State,,D,Jean Schodorf,3
-Decatur,North-Logan,Secretary of State,,D,Jean Schodorf,0
-Decatur,North-Olive,Secretary of State,,D,Jean Schodorf,4
-Decatur,North-Roosevelt,Secretary of State,,D,Jean Schodorf,3
-Decatur,North-Sherman,Secretary of State,,D,Jean Schodorf,0
-Decatur,South-Altory,Secretary of State,,D,Jean Schodorf,0
-Decatur,South-Bassettville,Secretary of State,,D,Jean Schodorf,2
-Decatur,South-Center,Secretary of State,,D,Jean Schodorf,4
-Decatur,South-Cook,Secretary of State,,D,Jean Schodorf,1
-Decatur,South-Oberlin,Secretary of State,,D,Jean Schodorf,9
-Decatur,South-Prairie Dog,Secretary of State,,D,Jean Schodorf,2
-Decatur,South-Sappa,Secretary of State,,D,Jean Schodorf,1
-Decatur,South-Summit,Secretary of State,,D,Jean Schodorf,4
-Decatur,Oberlin City 1,Secretary of State,,D,Jean Schodorf,65
-Decatur,Oberlin City 2,Secretary of State,,D,Jean Schodorf,69
-Decatur,North-Beaver,Attorney General,,D,AJ Kotich,1
-Decatur,North-Finley,Attorney General,,D,AJ Kotich,3
-Decatur,North-Harlan,Attorney General,,D,AJ Kotich,2
-Decatur,North-Liberty,Attorney General,,D,AJ Kotich,2
-Decatur,North-Logan,Attorney General,,D,AJ Kotich,0
-Decatur,North-Olive,Attorney General,,D,AJ Kotich,4
-Decatur,North-Roosevelt,Attorney General,,D,AJ Kotich,0
-Decatur,North-Sherman,Attorney General,,D,AJ Kotich,1
-Decatur,South-Altory,Attorney General,,D,AJ Kotich,2
-Decatur,South-Bassettville,Attorney General,,D,AJ Kotich,2
-Decatur,South-Center,Attorney General,,D,AJ Kotich,2
-Decatur,South-Cook,Attorney General,,D,AJ Kotich,0
-Decatur,South-Oberlin,Attorney General,,D,AJ Kotich,5
-Decatur,South-Prairie Dog,Attorney General,,D,AJ Kotich,0
-Decatur,South-Sappa,Attorney General,,D,AJ Kotich,0
-Decatur,South-Summit,Attorney General,,D,AJ Kotich,3
-Decatur,Oberlin City 1,Attorney General,,D,AJ Kotich,53
-Decatur,Oberlin City 2,Attorney General,,D,AJ Kotich,55
-Decatur,North-Beaver,Attorney General,,R,Derek Schmidt,13
-Decatur,North-Finley,Attorney General,,R,Derek Schmidt,11
-Decatur,North-Harlan,Attorney General,,R,Derek Schmidt,9
-Decatur,North-Liberty,Attorney General,,R,Derek Schmidt,23
-Decatur,North-Logan,Attorney General,,R,Derek Schmidt,16
-Decatur,North-Olive,Attorney General,,R,Derek Schmidt,20
-Decatur,North-Roosevelt,Attorney General,,R,Derek Schmidt,8
-Decatur,North-Sherman,Attorney General,,R,Derek Schmidt,6
-Decatur,South-Altory,Attorney General,,R,Derek Schmidt,7
-Decatur,South-Bassettville,Attorney General,,R,Derek Schmidt,8
-Decatur,South-Center,Attorney General,,R,Derek Schmidt,22
-Decatur,South-Cook,Attorney General,,R,Derek Schmidt,15
-Decatur,South-Oberlin,Attorney General,,R,Derek Schmidt,39
-Decatur,South-Prairie Dog,Attorney General,,R,Derek Schmidt,14
-Decatur,South-Sappa,Attorney General,,R,Derek Schmidt,19
-Decatur,South-Summit,Attorney General,,R,Derek Schmidt,10
-Decatur,Oberlin City 1,Attorney General,,R,Derek Schmidt,239
-Decatur,Oberlin City 2,Attorney General,,R,Derek Schmidt,323
-Decatur,North-Beaver,State Treasurer,,D,Carmen Alldritt,1
-Decatur,North-Finley,State Treasurer,,D,Carmen Alldritt,2
-Decatur,North-Harlan,State Treasurer,,D,Carmen Alldritt,2
-Decatur,North-Liberty,State Treasurer,,D,Carmen Alldritt,3
-Decatur,North-Logan,State Treasurer,,D,Carmen Alldritt,0
-Decatur,North-Olive,State Treasurer,,D,Carmen Alldritt,2
-Decatur,North-Roosevelt,State Treasurer,,D,Carmen Alldritt,3
-Decatur,North-Sherman,State Treasurer,,D,Carmen Alldritt,0
-Decatur,South-Altory,State Treasurer,,D,Carmen Alldritt,1
-Decatur,South-Bassettville,State Treasurer,,D,Carmen Alldritt,2
-Decatur,South-Center,State Treasurer,,D,Carmen Alldritt,1
-Decatur,South-Cook,State Treasurer,,D,Carmen Alldritt,0
-Decatur,South-Oberlin,State Treasurer,,D,Carmen Alldritt,5
-Decatur,South-Prairie Dog,State Treasurer,,D,Carmen Alldritt,0
-Decatur,South-Sappa,State Treasurer,,D,Carmen Alldritt,0
-Decatur,South-Summit,State Treasurer,,D,Carmen Alldritt,3
-Decatur,Oberlin City 1,State Treasurer,,D,Carmen Alldritt,54
-Decatur,Oberlin City 2,State Treasurer,,D,Carmen Alldritt,52
-Decatur,North-Beaver,State Treasurer,,R,Ron Estes,13
-Decatur,North-Finley,State Treasurer,,R,Ron Estes,12
-Decatur,North-Harlan,State Treasurer,,R,Ron Estes,9
-Decatur,North-Liberty,State Treasurer,,R,Ron Estes,23
-Decatur,North-Logan,State Treasurer,,R,Ron Estes,16
-Decatur,North-Olive,State Treasurer,,R,Ron Estes,20
-Decatur,North-Roosevelt,State Treasurer,,R,Ron Estes,5
-Decatur,North-Sherman,State Treasurer,,R,Ron Estes,7
-Decatur,South-Altory,State Treasurer,,R,Ron Estes,8
-Decatur,South-Bassettville,State Treasurer,,R,Ron Estes,7
-Decatur,South-Center,State Treasurer,,R,Ron Estes,21
-Decatur,South-Cook,State Treasurer,,R,Ron Estes,15
-Decatur,South-Oberlin,State Treasurer,,R,Ron Estes,37
-Decatur,South-Prairie Dog,State Treasurer,,R,Ron Estes,14
-Decatur,South-Sappa,State Treasurer,,R,Ron Estes,19
-Decatur,South-Summit,State Treasurer,,R,Ron Estes,9
-Decatur,Oberlin City 1,State Treasurer,,R,Ron Estes,241
-Decatur,Oberlin City 2,State Treasurer,,R,Ron Estes,327
-Decatur,North-Beaver,Insurance Commissioner,,D,Dennis Anderson,1
-Decatur,North-Finley,Insurance Commissioner,,D,Dennis Anderson,2
-Decatur,North-Harlan,Insurance Commissioner,,D,Dennis Anderson,2
-Decatur,North-Liberty,Insurance Commissioner,,D,Dennis Anderson,2
-Decatur,North-Logan,Insurance Commissioner,,D,Dennis Anderson,0
-Decatur,North-Olive,Insurance Commissioner,,D,Dennis Anderson,3
-Decatur,North-Roosevelt,Insurance Commissioner,,D,Dennis Anderson,3
-Decatur,North-Sherman,Insurance Commissioner,,D,Dennis Anderson,1
-Decatur,South-Altory,Insurance Commissioner,,D,Dennis Anderson,1
-Decatur,South-Bassettville,Insurance Commissioner,,D,Dennis Anderson,3
-Decatur,South-Center,Insurance Commissioner,,D,Dennis Anderson,2
-Decatur,South-Cook,Insurance Commissioner,,D,Dennis Anderson,0
-Decatur,South-Oberlin,Insurance Commissioner,,D,Dennis Anderson,4
-Decatur,South-Prairie Dog,Insurance Commissioner,,D,Dennis Anderson,1
-Decatur,South-Sappa,Insurance Commissioner,,D,Dennis Anderson,0
-Decatur,South-Summit,Insurance Commissioner,,D,Dennis Anderson,3
-Decatur,Oberlin City 1,Insurance Commissioner,,D,Dennis Anderson,57
-Decatur,Oberlin City 2,Insurance Commissioner,,D,Dennis Anderson,72
-Decatur,North-Beaver,Insurance Commissioner,,R,Ken Selzer,13
-Decatur,North-Finley,Insurance Commissioner,,R,Ken Selzer,12
-Decatur,North-Harlan,Insurance Commissioner,,R,Ken Selzer,9
-Decatur,North-Liberty,Insurance Commissioner,,R,Ken Selzer,23
-Decatur,North-Logan,Insurance Commissioner,,R,Ken Selzer,16
-Decatur,North-Olive,Insurance Commissioner,,R,Ken Selzer,18
-Decatur,North-Roosevelt,Insurance Commissioner,,R,Ken Selzer,4
-Decatur,North-Sherman,Insurance Commissioner,,R,Ken Selzer,6
-Decatur,South-Altory,Insurance Commissioner,,R,Ken Selzer,5
-Decatur,South-Bassettville,Insurance Commissioner,,R,Ken Selzer,7
-Decatur,South-Center,Insurance Commissioner,,R,Ken Selzer,20
-Decatur,South-Cook,Insurance Commissioner,,R,Ken Selzer,15
-Decatur,South-Oberlin,Insurance Commissioner,,R,Ken Selzer,38
-Decatur,South-Prairie Dog,Insurance Commissioner,,R,Ken Selzer,13
-Decatur,South-Sappa,Insurance Commissioner,,R,Ken Selzer,19
-Decatur,South-Summit,Insurance Commissioner,,R,Ken Selzer,10
-Decatur,Oberlin City 1,Insurance Commissioner,,R,Ken Selzer,237
-Decatur,Oberlin City 2,Insurance Commissioner,,R,Ken Selzer,301
-Decatur,North-Beaver,State House,120,R,Rick Billinger,14
-Decatur,North-Finley,State House,120,R,Rick Billinger,11
-Decatur,North-Harlan,State House,120,R,Rick Billinger,12
-Decatur,North-Liberty,State House,120,R,Rick Billinger,25
-Decatur,North-Logan,State House,120,R,Rick Billinger,15
-Decatur,North-Olive,State House,120,R,Rick Billinger,22
-Decatur,North-Roosevelt,State House,120,R,Rick Billinger,6
-Decatur,North-Sherman,State House,120,R,Rick Billinger,7
-Decatur,South-Altory,State House,120,R,Rick Billinger,7
-Decatur,South-Bassettville,State House,120,R,Rick Billinger,10
-Decatur,South-Center,State House,120,R,Rick Billinger,22
-Decatur,South-Cook,State House,120,R,Rick Billinger,15
-Decatur,South-Oberlin,State House,120,R,Rick Billinger,40
-Decatur,South-Prairie Dog,State House,120,R,Rick Billinger,14
-Decatur,South-Sappa,State House,120,R,Rick Billinger,19
-Decatur,South-Summit,State House,120,R,Rick Billinger,13
-Decatur,Oberlin City 1,State House,120,R,Rick Billinger,272
-Decatur,Oberlin City 2,State House,120,R,Rick Billinger,355
+county,precinct,office,district,party,candidate,votes,vtd
+DECATUR,Allison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000010
+DECATUR,Allison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+DECATUR,Allison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,000010
+DECATUR,Altory Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000020
+DECATUR,Altory Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+DECATUR,Altory Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",6,000020
+DECATUR,Bassettville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000030
+DECATUR,Bassettville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+DECATUR,Bassettville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000030
+DECATUR,Beaver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000040
+DECATUR,Beaver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+DECATUR,Beaver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000040
+DECATUR,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000050
+DECATUR,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000050
+DECATUR,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000050
+DECATUR,Cook Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000060
+DECATUR,Cook Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+DECATUR,Cook Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000060
+DECATUR,Custer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000070
+DECATUR,Custer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+DECATUR,Custer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000070
+DECATUR,Dresden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000080
+DECATUR,Dresden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+DECATUR,Dresden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000080
+DECATUR,Finley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000090
+DECATUR,Finley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+DECATUR,Finley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000090
+DECATUR,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000100
+DECATUR,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+DECATUR,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000100
+DECATUR,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000110
+DECATUR,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+DECATUR,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000110
+DECATUR,Harlan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000120
+DECATUR,Harlan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+DECATUR,Harlan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000120
+DECATUR,Jennings Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000130
+DECATUR,Jennings Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000130
+DECATUR,Jennings Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000130
+DECATUR,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000140
+DECATUR,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+DECATUR,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000140
+DECATUR,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000150
+DECATUR,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+DECATUR,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000150
+DECATUR,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000160
+DECATUR,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000160
+DECATUR,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000160
+DECATUR,Lyon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000170
+DECATUR,Lyon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000170
+DECATUR,Lyon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,000170
+DECATUR,Oberlin City Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",80,000180
+DECATUR,Oberlin City Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000180
+DECATUR,Oberlin City Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",214,000180
+DECATUR,Oberlin City Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,00019A
+DECATUR,Oberlin City Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,00019A
+DECATUR,Oberlin City Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",297,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00019B
+DECATUR,Oberlin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000200
+DECATUR,Oberlin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000200
+DECATUR,Oberlin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000200
+DECATUR,Olive Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000210
+DECATUR,Olive Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000210
+DECATUR,Olive Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000210
+DECATUR,Pleasant Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000220
+DECATUR,Pleasant Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000220
+DECATUR,Pleasant Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000220
+DECATUR,Prairie Dog Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000230
+DECATUR,Prairie Dog Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+DECATUR,Prairie Dog Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000230
+DECATUR,Roosevelt Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000240
+DECATUR,Roosevelt Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000240
+DECATUR,Roosevelt Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,000240
+DECATUR,Sappa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000250
+DECATUR,Sappa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000250
+DECATUR,Sappa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000250
+DECATUR,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000260
+DECATUR,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000260
+DECATUR,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,000260
+DECATUR,Summit Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000270
+DECATUR,Summit Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000270
+DECATUR,Summit Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000270
+DECATUR,Allison Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",7,000010
+DECATUR,Altory Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",7,000020
+DECATUR,Bassettville Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",10,000030
+DECATUR,Beaver Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",14,000040
+DECATUR,Center Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",22,000050
+DECATUR,Cook Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",15,000060
+DECATUR,Custer Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",19,000070
+DECATUR,Dresden Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",42,000080
+DECATUR,Finley Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",11,000090
+DECATUR,Garfield Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",16,000100
+DECATUR,Grant Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",2,000110
+DECATUR,Harlan Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",12,000120
+DECATUR,Jennings Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",54,000130
+DECATUR,Liberty Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",25,000140
+DECATUR,Lincoln Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",58,000150
+DECATUR,Logan Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",15,000160
+DECATUR,Lyon Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",4,000170
+DECATUR,Oberlin City Precinct 1,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",272,000180
+DECATUR,Oberlin City Precinct 2,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",355,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",0,00019B
+DECATUR,Oberlin Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",40,000200
+DECATUR,Olive Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",22,000210
+DECATUR,Pleasant Valley Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",18,000220
+DECATUR,Prairie Dog Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",14,000230
+DECATUR,Roosevelt Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",6,000240
+DECATUR,Sappa Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",19,000250
+DECATUR,Sherman Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",7,000260
+DECATUR,Summit Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",13,000270
+DECATUR,Allison Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000010
+DECATUR,Allison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000010
+DECATUR,Altory Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000020
+DECATUR,Altory Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000020
+DECATUR,Bassettville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000030
+DECATUR,Bassettville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000030
+DECATUR,Beaver Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000040
+DECATUR,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000040
+DECATUR,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000050
+DECATUR,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000050
+DECATUR,Cook Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000060
+DECATUR,Cook Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000060
+DECATUR,Custer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000070
+DECATUR,Custer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000070
+DECATUR,Dresden Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000080
+DECATUR,Dresden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000080
+DECATUR,Finley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000090
+DECATUR,Finley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000090
+DECATUR,Garfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000100
+DECATUR,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000100
+DECATUR,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000110
+DECATUR,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000110
+DECATUR,Harlan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000120
+DECATUR,Harlan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000120
+DECATUR,Jennings Township,United States House of Representatives,1,Democratic,"Sherow, James E.",21,000130
+DECATUR,Jennings Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000130
+DECATUR,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000140
+DECATUR,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000140
+DECATUR,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000150
+DECATUR,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000150
+DECATUR,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000160
+DECATUR,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000160
+DECATUR,Lyon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000170
+DECATUR,Lyon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,000170
+DECATUR,Oberlin City Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",61,000180
+DECATUR,Oberlin City Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",235,000180
+DECATUR,Oberlin City Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",64,00019A
+DECATUR,Oberlin City Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",323,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019B
+DECATUR,Oberlin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000200
+DECATUR,Oberlin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000200
+DECATUR,Olive Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000210
+DECATUR,Olive Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000210
+DECATUR,Pleasant Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000220
+DECATUR,Pleasant Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000220
+DECATUR,Prairie Dog Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000230
+DECATUR,Prairie Dog Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000230
+DECATUR,Roosevelt Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000240
+DECATUR,Roosevelt Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000240
+DECATUR,Sappa Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000250
+DECATUR,Sappa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000250
+DECATUR,Sherman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000260
+DECATUR,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000260
+DECATUR,Summit Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000270
+DECATUR,Summit Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000270
+DECATUR,Allison Township,Attorney General,,Democratic,"Kotich, A.J.",3,000010
+DECATUR,Allison Township,Attorney General,,Republican,"Schmidt, Derek",6,000010
+DECATUR,Altory Township,Attorney General,,Democratic,"Kotich, A.J.",2,000020
+DECATUR,Altory Township,Attorney General,,Republican,"Schmidt, Derek",7,000020
+DECATUR,Bassettville Township,Attorney General,,Democratic,"Kotich, A.J.",2,000030
+DECATUR,Bassettville Township,Attorney General,,Republican,"Schmidt, Derek",8,000030
+DECATUR,Beaver Township,Attorney General,,Democratic,"Kotich, A.J.",1,000040
+DECATUR,Beaver Township,Attorney General,,Republican,"Schmidt, Derek",13,000040
+DECATUR,Center Township,Attorney General,,Democratic,"Kotich, A.J.",2,000050
+DECATUR,Center Township,Attorney General,,Republican,"Schmidt, Derek",22,000050
+DECATUR,Cook Township,Attorney General,,Democratic,"Kotich, A.J.",0,000060
+DECATUR,Cook Township,Attorney General,,Republican,"Schmidt, Derek",15,000060
+DECATUR,Custer Township,Attorney General,,Democratic,"Kotich, A.J.",2,000070
+DECATUR,Custer Township,Attorney General,,Republican,"Schmidt, Derek",18,000070
+DECATUR,Dresden Township,Attorney General,,Democratic,"Kotich, A.J.",9,000080
+DECATUR,Dresden Township,Attorney General,,Republican,"Schmidt, Derek",40,000080
+DECATUR,Finley Township,Attorney General,,Democratic,"Kotich, A.J.",3,000090
+DECATUR,Finley Township,Attorney General,,Republican,"Schmidt, Derek",11,000090
+DECATUR,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",4,000100
+DECATUR,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",16,000100
+DECATUR,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",0,000110
+DECATUR,Grant Township,Attorney General,,Republican,"Schmidt, Derek",3,000110
+DECATUR,Harlan Township,Attorney General,,Democratic,"Kotich, A.J.",2,000120
+DECATUR,Harlan Township,Attorney General,,Republican,"Schmidt, Derek",9,000120
+DECATUR,Jennings Township,Attorney General,,Democratic,"Kotich, A.J.",18,000130
+DECATUR,Jennings Township,Attorney General,,Republican,"Schmidt, Derek",47,000130
+DECATUR,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",2,000140
+DECATUR,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",23,000140
+DECATUR,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",10,000150
+DECATUR,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",52,000150
+DECATUR,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",0,000160
+DECATUR,Logan Township,Attorney General,,Republican,"Schmidt, Derek",16,000160
+DECATUR,Lyon Township,Attorney General,,Democratic,"Kotich, A.J.",3,000170
+DECATUR,Lyon Township,Attorney General,,Republican,"Schmidt, Derek",2,000170
+DECATUR,Oberlin City Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",53,000180
+DECATUR,Oberlin City Precinct 1,Attorney General,,Republican,"Schmidt, Derek",239,000180
+DECATUR,Oberlin City Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",55,00019A
+DECATUR,Oberlin City Precinct 2,Attorney General,,Republican,"Schmidt, Derek",323,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00019B
+DECATUR,Oberlin Township,Attorney General,,Democratic,"Kotich, A.J.",5,000200
+DECATUR,Oberlin Township,Attorney General,,Republican,"Schmidt, Derek",39,000200
+DECATUR,Olive Township,Attorney General,,Democratic,"Kotich, A.J.",4,000210
+DECATUR,Olive Township,Attorney General,,Republican,"Schmidt, Derek",20,000210
+DECATUR,Pleasant Valley Township,Attorney General,,Democratic,"Kotich, A.J.",1,000220
+DECATUR,Pleasant Valley Township,Attorney General,,Republican,"Schmidt, Derek",16,000220
+DECATUR,Prairie Dog Township,Attorney General,,Democratic,"Kotich, A.J.",0,000230
+DECATUR,Prairie Dog Township,Attorney General,,Republican,"Schmidt, Derek",14,000230
+DECATUR,Roosevelt Township,Attorney General,,Democratic,"Kotich, A.J.",0,000240
+DECATUR,Roosevelt Township,Attorney General,,Republican,"Schmidt, Derek",8,000240
+DECATUR,Sappa Township,Attorney General,,Democratic,"Kotich, A.J.",0,000250
+DECATUR,Sappa Township,Attorney General,,Republican,"Schmidt, Derek",19,000250
+DECATUR,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",1,000260
+DECATUR,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",6,000260
+DECATUR,Summit Township,Attorney General,,Democratic,"Kotich, A.J.",3,000270
+DECATUR,Summit Township,Attorney General,,Republican,"Schmidt, Derek",10,000270
+DECATUR,Allison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000010
+DECATUR,Allison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,000010
+DECATUR,Altory Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000020
+DECATUR,Altory Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,000020
+DECATUR,Bassettville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000030
+DECATUR,Bassettville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000030
+DECATUR,Beaver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000040
+DECATUR,Beaver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000040
+DECATUR,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000050
+DECATUR,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000050
+DECATUR,Cook Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000060
+DECATUR,Cook Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000060
+DECATUR,Custer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000070
+DECATUR,Custer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000070
+DECATUR,Dresden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000080
+DECATUR,Dresden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000080
+DECATUR,Finley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000090
+DECATUR,Finley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000090
+DECATUR,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000100
+DECATUR,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000100
+DECATUR,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000110
+DECATUR,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",3,000110
+DECATUR,Harlan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000120
+DECATUR,Harlan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000120
+DECATUR,Jennings Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000130
+DECATUR,Jennings Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000130
+DECATUR,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000140
+DECATUR,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000140
+DECATUR,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000150
+DECATUR,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000150
+DECATUR,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000160
+DECATUR,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000160
+DECATUR,Lyon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000170
+DECATUR,Lyon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",2,000170
+DECATUR,Oberlin City Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000180
+DECATUR,Oberlin City Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",237,000180
+DECATUR,Oberlin City Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,00019A
+DECATUR,Oberlin City Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",301,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00019B
+DECATUR,Oberlin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000200
+DECATUR,Oberlin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000200
+DECATUR,Olive Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000210
+DECATUR,Olive Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000210
+DECATUR,Pleasant Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000220
+DECATUR,Pleasant Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000220
+DECATUR,Prairie Dog Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000230
+DECATUR,Prairie Dog Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000230
+DECATUR,Roosevelt Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000240
+DECATUR,Roosevelt Township,Commissioner of Insurance,,Republican,"Selzer, Ken",4,000240
+DECATUR,Sappa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000250
+DECATUR,Sappa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000250
+DECATUR,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000260
+DECATUR,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",6,000260
+DECATUR,Summit Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000270
+DECATUR,Summit Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000270
+DECATUR,Allison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+DECATUR,Allison Township,Secretary of State,,Republican,"Kobach, Kris",6,000010
+DECATUR,Altory Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+DECATUR,Altory Township,Secretary of State,,Republican,"Kobach, Kris",9,000020
+DECATUR,Bassettville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000030
+DECATUR,Bassettville Township,Secretary of State,,Republican,"Kobach, Kris",8,000030
+DECATUR,Beaver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000040
+DECATUR,Beaver Township,Secretary of State,,Republican,"Kobach, Kris",13,000040
+DECATUR,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000050
+DECATUR,Center Township,Secretary of State,,Republican,"Kobach, Kris",19,000050
+DECATUR,Cook Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000060
+DECATUR,Cook Township,Secretary of State,,Republican,"Kobach, Kris",15,000060
+DECATUR,Custer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000070
+DECATUR,Custer Township,Secretary of State,,Republican,"Kobach, Kris",19,000070
+DECATUR,Dresden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000080
+DECATUR,Dresden Township,Secretary of State,,Republican,"Kobach, Kris",39,000080
+DECATUR,Finley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000090
+DECATUR,Finley Township,Secretary of State,,Republican,"Kobach, Kris",12,000090
+DECATUR,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000100
+DECATUR,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",13,000100
+DECATUR,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000110
+DECATUR,Grant Township,Secretary of State,,Republican,"Kobach, Kris",3,000110
+DECATUR,Harlan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000120
+DECATUR,Harlan Township,Secretary of State,,Republican,"Kobach, Kris",11,000120
+DECATUR,Jennings Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000130
+DECATUR,Jennings Township,Secretary of State,,Republican,"Kobach, Kris",40,000130
+DECATUR,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000140
+DECATUR,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",24,000140
+DECATUR,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000150
+DECATUR,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",46,000150
+DECATUR,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000160
+DECATUR,Logan Township,Secretary of State,,Republican,"Kobach, Kris",16,000160
+DECATUR,Lyon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000170
+DECATUR,Lyon Township,Secretary of State,,Republican,"Kobach, Kris",3,000170
+DECATUR,Oberlin City Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000180
+DECATUR,Oberlin City Precinct 1,Secretary of State,,Republican,"Kobach, Kris",232,000180
+DECATUR,Oberlin City Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",69,00019A
+DECATUR,Oberlin City Precinct 2,Secretary of State,,Republican,"Kobach, Kris",323,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00019B
+DECATUR,Oberlin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000200
+DECATUR,Oberlin Township,Secretary of State,,Republican,"Kobach, Kris",36,000200
+DECATUR,Olive Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000210
+DECATUR,Olive Township,Secretary of State,,Republican,"Kobach, Kris",21,000210
+DECATUR,Pleasant Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000220
+DECATUR,Pleasant Valley Township,Secretary of State,,Republican,"Kobach, Kris",14,000220
+DECATUR,Prairie Dog Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000230
+DECATUR,Prairie Dog Township,Secretary of State,,Republican,"Kobach, Kris",12,000230
+DECATUR,Roosevelt Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000240
+DECATUR,Roosevelt Township,Secretary of State,,Republican,"Kobach, Kris",5,000240
+DECATUR,Sappa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000250
+DECATUR,Sappa Township,Secretary of State,,Republican,"Kobach, Kris",18,000250
+DECATUR,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000260
+DECATUR,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",7,000260
+DECATUR,Summit Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000270
+DECATUR,Summit Township,Secretary of State,,Republican,"Kobach, Kris",9,000270
+DECATUR,Allison Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+DECATUR,Allison Township,State Treasurer,,Republican,"Estes, Ron",7,000010
+DECATUR,Altory Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000020
+DECATUR,Altory Township,State Treasurer,,Republican,"Estes, Ron",8,000020
+DECATUR,Bassettville Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000030
+DECATUR,Bassettville Township,State Treasurer,,Republican,"Estes, Ron",7,000030
+DECATUR,Beaver Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000040
+DECATUR,Beaver Township,State Treasurer,,Republican,"Estes, Ron",13,000040
+DECATUR,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000050
+DECATUR,Center Township,State Treasurer,,Republican,"Estes, Ron",21,000050
+DECATUR,Cook Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000060
+DECATUR,Cook Township,State Treasurer,,Republican,"Estes, Ron",15,000060
+DECATUR,Custer Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000070
+DECATUR,Custer Township,State Treasurer,,Republican,"Estes, Ron",19,000070
+DECATUR,Dresden Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000080
+DECATUR,Dresden Township,State Treasurer,,Republican,"Estes, Ron",39,000080
+DECATUR,Finley Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000090
+DECATUR,Finley Township,State Treasurer,,Republican,"Estes, Ron",12,000090
+DECATUR,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000100
+DECATUR,Garfield Township,State Treasurer,,Republican,"Estes, Ron",16,000100
+DECATUR,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000110
+DECATUR,Grant Township,State Treasurer,,Republican,"Estes, Ron",3,000110
+DECATUR,Harlan Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000120
+DECATUR,Harlan Township,State Treasurer,,Republican,"Estes, Ron",9,000120
+DECATUR,Jennings Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000130
+DECATUR,Jennings Township,State Treasurer,,Republican,"Estes, Ron",44,000130
+DECATUR,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000140
+DECATUR,Liberty Township,State Treasurer,,Republican,"Estes, Ron",23,000140
+DECATUR,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000150
+DECATUR,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",51,000150
+DECATUR,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000160
+DECATUR,Logan Township,State Treasurer,,Republican,"Estes, Ron",16,000160
+DECATUR,Lyon Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000170
+DECATUR,Lyon Township,State Treasurer,,Republican,"Estes, Ron",4,000170
+DECATUR,Oberlin City Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",54,000180
+DECATUR,Oberlin City Precinct 1,State Treasurer,,Republican,"Estes, Ron",241,000180
+DECATUR,Oberlin City Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",52,00019A
+DECATUR,Oberlin City Precinct 2,State Treasurer,,Republican,"Estes, Ron",327,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00019B
+DECATUR,Oberlin Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000200
+DECATUR,Oberlin Township,State Treasurer,,Republican,"Estes, Ron",37,000200
+DECATUR,Olive Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000210
+DECATUR,Olive Township,State Treasurer,,Republican,"Estes, Ron",20,000210
+DECATUR,Pleasant Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000220
+DECATUR,Pleasant Valley Township,State Treasurer,,Republican,"Estes, Ron",16,000220
+DECATUR,Prairie Dog Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000230
+DECATUR,Prairie Dog Township,State Treasurer,,Republican,"Estes, Ron",14,000230
+DECATUR,Roosevelt Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000240
+DECATUR,Roosevelt Township,State Treasurer,,Republican,"Estes, Ron",5,000240
+DECATUR,Sappa Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000250
+DECATUR,Sappa Township,State Treasurer,,Republican,"Estes, Ron",19,000250
+DECATUR,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000260
+DECATUR,Sherman Township,State Treasurer,,Republican,"Estes, Ron",7,000260
+DECATUR,Summit Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000270
+DECATUR,Summit Township,State Treasurer,,Republican,"Estes, Ron",9,000270
+DECATUR,Allison Township,United States Senate,,independent,"Orman, Greg",3,000010
+DECATUR,Allison Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+DECATUR,Allison Township,United States Senate,,Republican,"Roberts, Pat",6,000010
+DECATUR,Altory Township,United States Senate,,independent,"Orman, Greg",1,000020
+DECATUR,Altory Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+DECATUR,Altory Township,United States Senate,,Republican,"Roberts, Pat",9,000020
+DECATUR,Bassettville Township,United States Senate,,independent,"Orman, Greg",1,000030
+DECATUR,Bassettville Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+DECATUR,Bassettville Township,United States Senate,,Republican,"Roberts, Pat",9,000030
+DECATUR,Beaver Township,United States Senate,,independent,"Orman, Greg",2,000040
+DECATUR,Beaver Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+DECATUR,Beaver Township,United States Senate,,Republican,"Roberts, Pat",11,000040
+DECATUR,Center Township,United States Senate,,independent,"Orman, Greg",3,000050
+DECATUR,Center Township,United States Senate,,Libertarian,"Batson, Randall",3,000050
+DECATUR,Center Township,United States Senate,,Republican,"Roberts, Pat",18,000050
+DECATUR,Cook Township,United States Senate,,independent,"Orman, Greg",0,000060
+DECATUR,Cook Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+DECATUR,Cook Township,United States Senate,,Republican,"Roberts, Pat",16,000060
+DECATUR,Custer Township,United States Senate,,independent,"Orman, Greg",0,000070
+DECATUR,Custer Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+DECATUR,Custer Township,United States Senate,,Republican,"Roberts, Pat",20,000070
+DECATUR,Dresden Township,United States Senate,,independent,"Orman, Greg",13,000080
+DECATUR,Dresden Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+DECATUR,Dresden Township,United States Senate,,Republican,"Roberts, Pat",37,000080
+DECATUR,Finley Township,United States Senate,,independent,"Orman, Greg",3,000090
+DECATUR,Finley Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+DECATUR,Finley Township,United States Senate,,Republican,"Roberts, Pat",11,000090
+DECATUR,Garfield Township,United States Senate,,independent,"Orman, Greg",6,000100
+DECATUR,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+DECATUR,Garfield Township,United States Senate,,Republican,"Roberts, Pat",12,000100
+DECATUR,Grant Township,United States Senate,,independent,"Orman, Greg",0,000110
+DECATUR,Grant Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+DECATUR,Grant Township,United States Senate,,Republican,"Roberts, Pat",3,000110
+DECATUR,Harlan Township,United States Senate,,independent,"Orman, Greg",1,000120
+DECATUR,Harlan Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+DECATUR,Harlan Township,United States Senate,,Republican,"Roberts, Pat",11,000120
+DECATUR,Jennings Township,United States Senate,,independent,"Orman, Greg",20,000130
+DECATUR,Jennings Township,United States Senate,,Libertarian,"Batson, Randall",2,000130
+DECATUR,Jennings Township,United States Senate,,Republican,"Roberts, Pat",44,000130
+DECATUR,Liberty Township,United States Senate,,independent,"Orman, Greg",4,000140
+DECATUR,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",2,000140
+DECATUR,Liberty Township,United States Senate,,Republican,"Roberts, Pat",21,000140
+DECATUR,Lincoln Township,United States Senate,,independent,"Orman, Greg",13,000150
+DECATUR,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",3,000150
+DECATUR,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",43,000150
+DECATUR,Logan Township,United States Senate,,independent,"Orman, Greg",0,000160
+DECATUR,Logan Township,United States Senate,,Libertarian,"Batson, Randall",0,000160
+DECATUR,Logan Township,United States Senate,,Republican,"Roberts, Pat",16,000160
+DECATUR,Lyon Township,United States Senate,,independent,"Orman, Greg",3,000170
+DECATUR,Lyon Township,United States Senate,,Libertarian,"Batson, Randall",0,000170
+DECATUR,Lyon Township,United States Senate,,Republican,"Roberts, Pat",2,000170
+DECATUR,Oberlin City Precinct 1,United States Senate,,independent,"Orman, Greg",70,000180
+DECATUR,Oberlin City Precinct 1,United States Senate,,Libertarian,"Batson, Randall",10,000180
+DECATUR,Oberlin City Precinct 1,United States Senate,,Republican,"Roberts, Pat",224,000180
+DECATUR,Oberlin City Precinct 2,United States Senate,,independent,"Orman, Greg",63,00019A
+DECATUR,Oberlin City Precinct 2,United States Senate,,Libertarian,"Batson, Randall",22,00019A
+DECATUR,Oberlin City Precinct 2,United States Senate,,Republican,"Roberts, Pat",308,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00019B
+DECATUR,Oberlin Township,United States Senate,,independent,"Orman, Greg",8,000200
+DECATUR,Oberlin Township,United States Senate,,Libertarian,"Batson, Randall",3,000200
+DECATUR,Oberlin Township,United States Senate,,Republican,"Roberts, Pat",36,000200
+DECATUR,Olive Township,United States Senate,,independent,"Orman, Greg",5,000210
+DECATUR,Olive Township,United States Senate,,Libertarian,"Batson, Randall",0,000210
+DECATUR,Olive Township,United States Senate,,Republican,"Roberts, Pat",21,000210
+DECATUR,Pleasant Valley Township,United States Senate,,independent,"Orman, Greg",4,000220
+DECATUR,Pleasant Valley Township,United States Senate,,Libertarian,"Batson, Randall",0,000220
+DECATUR,Pleasant Valley Township,United States Senate,,Republican,"Roberts, Pat",14,000220
+DECATUR,Prairie Dog Township,United States Senate,,independent,"Orman, Greg",0,000230
+DECATUR,Prairie Dog Township,United States Senate,,Libertarian,"Batson, Randall",1,000230
+DECATUR,Prairie Dog Township,United States Senate,,Republican,"Roberts, Pat",13,000230
+DECATUR,Roosevelt Township,United States Senate,,independent,"Orman, Greg",3,000240
+DECATUR,Roosevelt Township,United States Senate,,Libertarian,"Batson, Randall",0,000240
+DECATUR,Roosevelt Township,United States Senate,,Republican,"Roberts, Pat",5,000240
+DECATUR,Sappa Township,United States Senate,,independent,"Orman, Greg",0,000250
+DECATUR,Sappa Township,United States Senate,,Libertarian,"Batson, Randall",0,000250
+DECATUR,Sappa Township,United States Senate,,Republican,"Roberts, Pat",19,000250
+DECATUR,Sherman Township,United States Senate,,independent,"Orman, Greg",1,000260
+DECATUR,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",1,000260
+DECATUR,Sherman Township,United States Senate,,Republican,"Roberts, Pat",5,000260
+DECATUR,Summit Township,United States Senate,,independent,"Orman, Greg",4,000270
+DECATUR,Summit Township,United States Senate,,Libertarian,"Batson, Randall",0,000270
+DECATUR,Summit Township,United States Senate,,Republican,"Roberts, Pat",9,000270

--- a/2014/20141104__ks__general__dickinson__precinct.csv
+++ b/2014/20141104__ks__general__dickinson__precinct.csv
@@ -1,596 +1,664 @@
-county,precinct,office,district,party,candidate,votes
-Dickinson,Abilene W1,Attorney General,,D,A.J. Kotich,77
-Dickinson,Abilene W2,Attorney General,,D,A.J. Kotich,132
-Dickinson,Abilene W3,Attorney General,,D,A.J. Kotich,76
-Dickinson,Abilene W4P1,Attorney General,,D,A.J. Kotich,140
-Dickinson,Abilene W4P2,Attorney General,,D,A.J. Kotich,124
-Dickinson,Abilene W1,Attorney General,,R,Derek Schmidt,203
-Dickinson,Abilene W2,Attorney General,,R,Derek Schmidt,402
-Dickinson,Abilene W3,Attorney General,,R,Derek Schmidt,200
-Dickinson,Abilene W4P1,Attorney General,,R,Derek Schmidt,315
-Dickinson,Abilene W4P2,Attorney General,,R,Derek Schmidt,443
-Dickinson,Abilene W1,U.S. House,1,D,James E. Sherow,108
-Dickinson,Abilene W2,U.S. House,1,D,James E. Sherow,189
-Dickinson,Abilene W3,U.S. House,1,D,James E. Sherow,95
-Dickinson,Abilene W4P1,U.S. House,1,D,James E. Sherow,174
-Dickinson,Abilene W4P2,U.S. House,1,D,James E. Sherow,183
-Dickinson,Abilene W1,U.S. House,1,R,Tim Huelskamp,181
-Dickinson,Abilene W2,U.S. House,1,R,Tim Huelskamp,355
-Dickinson,Abilene W3,U.S. House,1,R,Tim Huelskamp,183
-Dickinson,Abilene W4P1,U.S. House,1,R,Tim Huelskamp,289
-Dickinson,Abilene W4P2,U.S. House,1,R,Tim Huelskamp,383
-Dickinson,Abilene W1,Governor,,D,Paul Davis,112
-Dickinson,Abilene W2,Governor,,D,Paul Davis,211
-Dickinson,Abilene W3,Governor,,D,Paul Davis,114
-Dickinson,Abilene W4P1,Governor,,D,Paul Davis,184
-Dickinson,Abilene W4P2,Governor,,D,Paul Davis,208
-Dickinson,Abilene W1,Governor,,L,Keen A. Umbehr,35
-Dickinson,Abilene W2,Governor,,L,Keen A. Umbehr,56
-Dickinson,Abilene W3,Governor,,L,Keen A. Umbehr,25
-Dickinson,Abilene W4P1,Governor,,L,Keen A. Umbehr,32
-Dickinson,Abilene W4P2,Governor,,L,Keen A. Umbehr,30
-Dickinson,Abilene W1,Governor,,R,Sam Brownback,145
-Dickinson,Abilene W2,Governor,,R,Sam Brownback,277
-Dickinson,Abilene W3,Governor,,R,Sam Brownback,139
-Dickinson,Abilene W4P1,Governor,,R,Sam Brownback,249
-Dickinson,Abilene W4P2,Governor,,R,Sam Brownback,338
-Dickinson,Abilene W1,Insurance Commissioner,,D,Dennis Anderson,94
-Dickinson,Abilene W2,Insurance Commissioner,,D,Dennis Anderson,157
-Dickinson,Abilene W3,Insurance Commissioner,,D,Dennis Anderson,84
-Dickinson,Abilene W4P1,Insurance Commissioner,,D,Dennis Anderson,149
-Dickinson,Abilene W4P2,Insurance Commissioner,,D,Dennis Anderson,147
-Dickinson,Abilene W1,Insurance Commissioner,,R,Ken Selzer,183
-Dickinson,Abilene W2,Insurance Commissioner,,R,Ken Selzer,371
-Dickinson,Abilene W3,Insurance Commissioner,,R,Ken Selzer,195
-Dickinson,Abilene W4P1,Insurance Commissioner,,R,Ken Selzer,310
-Dickinson,Abilene W4P2,Insurance Commissioner,,R,Ken Selzer,406
-Dickinson,Abilene W1,Secretary of State,,D,Jean Kurtis Schodorf,100
-Dickinson,Abilene W2,Secretary of State,,D,Jean Kurtis Schodorf,163
-Dickinson,Abilene W3,Secretary of State,,D,Jean Kurtis Schodorf,96
-Dickinson,Abilene W4P1,Secretary of State,,D,Jean Kurtis Schodorf,179
-Dickinson,Abilene W4P2,Secretary of State,,D,Jean Kurtis Schodorf,177
-Dickinson,Abilene W1,Secretary of State,,R,Kris Kobach,184
-Dickinson,Abilene W2,Secretary of State,,R,Kris Kobach,376
-Dickinson,Abilene W3,Secretary of State,,R,Kris Kobach,185
-Dickinson,Abilene W4P1,Secretary of State,,R,Kris Kobach,288
-Dickinson,Abilene W4P2,Secretary of State,,R,Kris Kobach,398
-Dickinson,Abilene W1,State House,70,R,John E. Barker,244
-Dickinson,Abilene W2,State House,70,R,John E. Barker,476
-Dickinson,Abilene W3,State House,70,R,John E. Barker,230
-Dickinson,Abilene W4P1,State House,70,R,John E. Barker,389
-Dickinson,Abilene W4P2,State House,70,R,John E. Barker,500
-Dickinson,Abilene W1,State Treasurer,,D,Carmen Alldritt,83
-Dickinson,Abilene W2,State Treasurer,,D,Carmen Alldritt,142
-Dickinson,Abilene W3,State Treasurer,,D,Carmen Alldritt,70
-Dickinson,Abilene W4P1,State Treasurer,,D,Carmen Alldritt,132
-Dickinson,Abilene W4P2,State Treasurer,,D,Carmen Alldritt,134
-Dickinson,Abilene W1,State Treasurer,,R,Ron Estes,195
-Dickinson,Abilene W2,State Treasurer,,R,Ron Estes,391
-Dickinson,Abilene W3,State Treasurer,,R,Ron Estes,207
-Dickinson,Abilene W4P1,State Treasurer,,R,Ron Estes,328
-Dickinson,Abilene W4P2,State Treasurer,,R,Ron Estes,428
-Dickinson,Abilene W1,U.S. Senate,,I,Greg Orman,110
-Dickinson,Abilene W2,U.S. Senate,,I,Greg Orman,179
-Dickinson,Abilene W3,U.S. Senate,,I,Greg Orman,97
-Dickinson,Abilene W4P1,U.S. Senate,,I,Greg Orman,173
-Dickinson,Abilene W4P2,U.S. Senate,,I,Greg Orman,178
-Dickinson,Abilene W1,U.S. Senate,,L,Randall Batson,23
-Dickinson,Abilene W2,U.S. Senate,,L,Randall Batson,38
-Dickinson,Abilene W3,U.S. Senate,,L,Randall Batson,23
-Dickinson,Abilene W4P1,U.S. Senate,,L,Randall Batson,24
-Dickinson,Abilene W4P2,U.S. Senate,,L,Randall Batson,20
-Dickinson,Abilene W1,U.S. Senate,,R,Pat Roberts,160
-Dickinson,Abilene W2,U.S. Senate,,R,Pat Roberts,332
-Dickinson,Abilene W3,U.S. Senate,,R,Pat Roberts,160
-Dickinson,Abilene W4P1,U.S. Senate,,R,Pat Roberts,269
-Dickinson,Abilene W4P2,U.S. Senate,,R,Pat Roberts,377
-Dickinson,Banner,Attorney General,,D,A.J. Kotich,7
-Dickinson,Buckeye,Attorney General,,D,A.J. Kotich,30
-Dickinson,Center,Attorney General,,D,A.J. Kotich,56
-Dickinson,Cheever,Attorney General,,D,A.J. Kotich,6
-Dickinson,Flora,Attorney General,,D,A.J. Kotich,16
-Dickinson,Fragrant Hill,Attorney General,,D,A.J. Kotich,15
-Dickinson,Garfield,Attorney General,,D,A.J. Kotich,13
-Dickinson,Grant,Attorney General,,D,A.J. Kotich,70
-Dickinson,Hayes,Attorney General,,D,A.J. Kotich,15
-Dickinson,Herington W1,Attorney General,,D,A.J. Kotich,82
-Dickinson,Herington W2,Attorney General,,D,A.J. Kotich,85
-Dickinson,Herington W3,Attorney General,,D,A.J. Kotich,37
-Dickinson,Holland,Attorney General,,D,A.J. Kotich,4
-Dickinson,Hope,Attorney General,,D,A.J. Kotich,43
-Dickinson,Jefferson,Attorney General,,D,A.J. Kotich,14
-Dickinson,Liberty,Attorney General,,D,A.J. Kotich,33
-Dickinson,Lincoln,Attorney General,,D,A.J. Kotich,89
-Dickinson,Logan,Attorney General,,D,A.J. Kotich,17
-Dickinson,Lyon 68,Attorney General,,D,A.J. Kotich,8
-Dickinson,Lyon 68A,Attorney General,,D,A.J. Kotich,1
-Dickinson,Lyon 70,Attorney General,,D,A.J. Kotich,8
-Dickinson,Newbern,Attorney General,,D,A.J. Kotich,31
-Dickinson,Noble,Attorney General,,D,A.J. Kotich,128
-Dickinson,Ridge,Attorney General,,D,A.J. Kotich,5
-Dickinson,Rinehart,Attorney General,,D,A.J. Kotich,14
-Dickinson,Sherman,Attorney General,,D,A.J. Kotich,10
-Dickinson,Union,Attorney General,,D,A.J. Kotich,7
-Dickinson,Wheatland,Attorney General,,D,A.J. Kotich,4
-Dickinson,Willowdale,Attorney General,,D,A.J. Kotich,17
-Dickinson,Banner,Attorney General,,R,Derek Schmidt,40
-Dickinson,Buckeye,Attorney General,,R,Derek Schmidt,154
-Dickinson,Center,Attorney General,,R,Derek Schmidt,285
-Dickinson,Cheever,Attorney General,,R,Derek Schmidt,46
-Dickinson,Flora,Attorney General,,R,Derek Schmidt,51
-Dickinson,Fragrant Hill,Attorney General,,R,Derek Schmidt,99
-Dickinson,Garfield,Attorney General,,R,Derek Schmidt,66
-Dickinson,Grant,Attorney General,,R,Derek Schmidt,302
-Dickinson,Hayes,Attorney General,,R,Derek Schmidt,97
-Dickinson,Herington W1,Attorney General,,R,Derek Schmidt,139
-Dickinson,Herington W2,Attorney General,,R,Derek Schmidt,143
-Dickinson,Herington W3,Attorney General,,R,Derek Schmidt,95
-Dickinson,Holland,Attorney General,,R,Derek Schmidt,39
-Dickinson,Hope,Attorney General,,R,Derek Schmidt,122
-Dickinson,Jefferson,Attorney General,,R,Derek Schmidt,82
-Dickinson,Liberty,Attorney General,,R,Derek Schmidt,85
-Dickinson,Lincoln,Attorney General,,R,Derek Schmidt,402
-Dickinson,Logan,Attorney General,,R,Derek Schmidt,59
-Dickinson,Lyon 68,Attorney General,,R,Derek Schmidt,15
-Dickinson,Lyon 68A,Attorney General,,R,Derek Schmidt,5
-Dickinson,Lyon 70,Attorney General,,R,Derek Schmidt,51
-Dickinson,Newbern,Attorney General,,R,Derek Schmidt,148
-Dickinson,Noble,Attorney General,,R,Derek Schmidt,455
-Dickinson,Ridge,Attorney General,,R,Derek Schmidt,56
-Dickinson,Rinehart,Attorney General,,R,Derek Schmidt,82
-Dickinson,Sherman,Attorney General,,R,Derek Schmidt,53
-Dickinson,Union,Attorney General,,R,Derek Schmidt,54
-Dickinson,Wheatland,Attorney General,,R,Derek Schmidt,51
-Dickinson,Willowdale,Attorney General,,R,Derek Schmidt,83
-Dickinson,Banner,U.S. House,1,D,James E. Sherow,11
-Dickinson,Buckeye,U.S. House,1,D,James E. Sherow,34
-Dickinson,Center,U.S. House,1,D,James E. Sherow,78
-Dickinson,Cheever,U.S. House,1,D,James E. Sherow,10
-Dickinson,Flora,U.S. House,1,D,James E. Sherow,19
-Dickinson,Fragrant Hill,U.S. House,1,D,James E. Sherow,20
-Dickinson,Garfield,U.S. House,1,D,James E. Sherow,23
-Dickinson,Grant,U.S. House,1,D,James E. Sherow,100
-Dickinson,Hayes,U.S. House,1,D,James E. Sherow,18
-Dickinson,Herington W1,U.S. House,1,D,James E. Sherow,92
-Dickinson,Herington W2,U.S. House,1,D,James E. Sherow,101
-Dickinson,Herington W3,U.S. House,1,D,James E. Sherow,38
-Dickinson,Holland,U.S. House,1,D,James E. Sherow,8
-Dickinson,Hope,U.S. House,1,D,James E. Sherow,61
-Dickinson,Jefferson,U.S. House,1,D,James E. Sherow,18
-Dickinson,Liberty,U.S. House,1,D,James E. Sherow,37
-Dickinson,Lincoln,U.S. House,1,D,James E. Sherow,130
-Dickinson,Logan,U.S. House,1,D,James E. Sherow,26
-Dickinson,Lyon 68,U.S. House,1,D,James E. Sherow,10
-Dickinson,Lyon 68A,U.S. House,1,D,James E. Sherow,3
-Dickinson,Lyon 70,U.S. House,1,D,James E. Sherow,16
-Dickinson,Newbern,U.S. House,1,D,James E. Sherow,38
-Dickinson,Noble,U.S. House,1,D,James E. Sherow,172
-Dickinson,Ridge,U.S. House,1,D,James E. Sherow,11
-Dickinson,Rinehart,U.S. House,1,D,James E. Sherow,15
-Dickinson,Sherman,U.S. House,1,D,James E. Sherow,15
-Dickinson,Union,U.S. House,1,D,James E. Sherow,13
-Dickinson,Wheatland,U.S. House,1,D,James E. Sherow,9
-Dickinson,Willowdale,U.S. House,1,D,James E. Sherow,22
-Dickinson,Banner,U.S. House,1,R,Tim Huelskamp,37
-Dickinson,Buckeye,U.S. House,1,R,Tim Huelskamp,150
-Dickinson,Center,U.S. House,1,R,Tim Huelskamp,266
-Dickinson,Cheever,U.S. House,1,R,Tim Huelskamp,43
-Dickinson,Flora,U.S. House,1,R,Tim Huelskamp,48
-Dickinson,Fragrant Hill,U.S. House,1,R,Tim Huelskamp,97
-Dickinson,Garfield,U.S. House,1,R,Tim Huelskamp,56
-Dickinson,Grant,U.S. House,1,R,Tim Huelskamp,275
-Dickinson,Hayes,U.S. House,1,R,Tim Huelskamp,95
-Dickinson,Herington W1,U.S. House,1,R,Tim Huelskamp,131
-Dickinson,Herington W2,U.S. House,1,R,Tim Huelskamp,135
-Dickinson,Herington W3,U.S. House,1,R,Tim Huelskamp,95
-Dickinson,Holland,U.S. House,1,R,Tim Huelskamp,36
-Dickinson,Hope,U.S. House,1,R,Tim Huelskamp,101
-Dickinson,Jefferson,U.S. House,1,R,Tim Huelskamp,79
-Dickinson,Liberty,U.S. House,1,R,Tim Huelskamp,83
-Dickinson,Lincoln,U.S. House,1,R,Tim Huelskamp,365
-Dickinson,Logan,U.S. House,1,R,Tim Huelskamp,49
-Dickinson,Lyon 68,U.S. House,1,R,Tim Huelskamp,13
-Dickinson,Lyon 68A,U.S. House,1,R,Tim Huelskamp,3
-Dickinson,Lyon 70,U.S. House,1,R,Tim Huelskamp,45
-Dickinson,Newbern,U.S. House,1,R,Tim Huelskamp,143
-Dickinson,Noble,U.S. House,1,R,Tim Huelskamp,413
-Dickinson,Ridge,U.S. House,1,R,Tim Huelskamp,50
-Dickinson,Rinehart,U.S. House,1,R,Tim Huelskamp,81
-Dickinson,Sherman,U.S. House,1,R,Tim Huelskamp,50
-Dickinson,Union,U.S. House,1,R,Tim Huelskamp,48
-Dickinson,Wheatland,U.S. House,1,R,Tim Huelskamp,47
-Dickinson,Willowdale,U.S. House,1,R,Tim Huelskamp,79
-Dickinson,Banner,Governor,,D,Paul Davis,11
-Dickinson,Buckeye,Governor,,D,Paul Davis,49
-Dickinson,Center,Governor,,D,Paul Davis,86
-Dickinson,Cheever,Governor,,D,Paul Davis,10
-Dickinson,Flora,Governor,,D,Paul Davis,22
-Dickinson,Fragrant Hill,Governor,,D,Paul Davis,23
-Dickinson,Garfield,Governor,,D,Paul Davis,22
-Dickinson,Grant,Governor,,D,Paul Davis,108
-Dickinson,Hayes,Governor,,D,Paul Davis,21
-Dickinson,Herington W1,Governor,,D,Paul Davis,121
-Dickinson,Herington W2,Governor,,D,Paul Davis,106
-Dickinson,Herington W3,Governor,,D,Paul Davis,49
-Dickinson,Holland,Governor,,D,Paul Davis,11
-Dickinson,Hope,Governor,,D,Paul Davis,74
-Dickinson,Jefferson,Governor,,D,Paul Davis,21
-Dickinson,Liberty,Governor,,D,Paul Davis,46
-Dickinson,Lincoln,Governor,,D,Paul Davis,162
-Dickinson,Logan,Governor,,D,Paul Davis,29
-Dickinson,Lyon 68,Governor,,D,Paul Davis,12
-Dickinson,Lyon 68A,Governor,,D,Paul Davis,1
-Dickinson,Lyon 70,Governor,,D,Paul Davis,22
-Dickinson,Newbern,Governor,,D,Paul Davis,51
-Dickinson,Noble,Governor,,D,Paul Davis,224
-Dickinson,Ridge,Governor,,D,Paul Davis,12
-Dickinson,Rinehart,Governor,,D,Paul Davis,17
-Dickinson,Sherman,Governor,,D,Paul Davis,10
-Dickinson,Union,Governor,,D,Paul Davis,20
-Dickinson,Wheatland,Governor,,D,Paul Davis,6
-Dickinson,Willowdale,Governor,,D,Paul Davis,29
-Dickinson,Banner,Governor,,L,Keen A. Umbehr,2
-Dickinson,Buckeye,Governor,,L,Keen A. Umbehr,8
-Dickinson,Center,Governor,,L,Keen A. Umbehr,27
-Dickinson,Cheever,Governor,,L,Keen A. Umbehr,6
-Dickinson,Flora,Governor,,L,Keen A. Umbehr,3
-Dickinson,Fragrant Hill,Governor,,L,Keen A. Umbehr,7
-Dickinson,Garfield,Governor,,L,Keen A. Umbehr,4
-Dickinson,Grant,Governor,,L,Keen A. Umbehr,21
-Dickinson,Hayes,Governor,,L,Keen A. Umbehr,3
-Dickinson,Herington W1,Governor,,L,Keen A. Umbehr,14
-Dickinson,Herington W2,Governor,,L,Keen A. Umbehr,22
-Dickinson,Herington W3,Governor,,L,Keen A. Umbehr,14
-Dickinson,Holland,Governor,,L,Keen A. Umbehr,1
-Dickinson,Hope,Governor,,L,Keen A. Umbehr,7
-Dickinson,Jefferson,Governor,,L,Keen A. Umbehr,2
-Dickinson,Liberty,Governor,,L,Keen A. Umbehr,3
-Dickinson,Lincoln,Governor,,L,Keen A. Umbehr,34
-Dickinson,Logan,Governor,,L,Keen A. Umbehr,6
-Dickinson,Lyon 68,Governor,,L,Keen A. Umbehr,0
-Dickinson,Lyon 68A,Governor,,L,Keen A. Umbehr,1
-Dickinson,Lyon 70,Governor,,L,Keen A. Umbehr,0
-Dickinson,Newbern,Governor,,L,Keen A. Umbehr,12
-Dickinson,Noble,Governor,,L,Keen A. Umbehr,33
-Dickinson,Ridge,Governor,,L,Keen A. Umbehr,1
-Dickinson,Rinehart,Governor,,L,Keen A. Umbehr,2
-Dickinson,Sherman,Governor,,L,Keen A. Umbehr,3
-Dickinson,Union,Governor,,L,Keen A. Umbehr,2
-Dickinson,Wheatland,Governor,,L,Keen A. Umbehr,0
-Dickinson,Willowdale,Governor,,L,Keen A. Umbehr,4
-Dickinson,Banner,Governor,,R,Sam Brownback,35
-Dickinson,Buckeye,Governor,,R,Sam Brownback,129
-Dickinson,Center,Governor,,R,Sam Brownback,237
-Dickinson,Cheever,Governor,,R,Sam Brownback,37
-Dickinson,Flora,Governor,,R,Sam Brownback,40
-Dickinson,Fragrant Hill,Governor,,R,Sam Brownback,86
-Dickinson,Garfield,Governor,,R,Sam Brownback,53
-Dickinson,Grant,Governor,,R,Sam Brownback,248
-Dickinson,Hayes,Governor,,R,Sam Brownback,88
-Dickinson,Herington W1,Governor,,R,Sam Brownback,89
-Dickinson,Herington W2,Governor,,R,Sam Brownback,108
-Dickinson,Herington W3,Governor,,R,Sam Brownback,68
-Dickinson,Holland,Governor,,R,Sam Brownback,32
-Dickinson,Hope,Governor,,R,Sam Brownback,86
-Dickinson,Jefferson,Governor,,R,Sam Brownback,75
-Dickinson,Liberty,Governor,,R,Sam Brownback,71
-Dickinson,Lincoln,Governor,,R,Sam Brownback,308
-Dickinson,Logan,Governor,,R,Sam Brownback,42
-Dickinson,Lyon 68,Governor,,R,Sam Brownback,11
-Dickinson,Lyon 68A,Governor,,R,Sam Brownback,4
-Dickinson,Lyon 70,Governor,,R,Sam Brownback,40
-Dickinson,Newbern,Governor,,R,Sam Brownback,122
-Dickinson,Noble,Governor,,R,Sam Brownback,332
-Dickinson,Ridge,Governor,,R,Sam Brownback,47
-Dickinson,Rinehart,Governor,,R,Sam Brownback,77
-Dickinson,Sherman,Governor,,R,Sam Brownback,52
-Dickinson,Union,Governor,,R,Sam Brownback,40
-Dickinson,Wheatland,Governor,,R,Sam Brownback,49
-Dickinson,Willowdale,Governor,,R,Sam Brownback,70
-Dickinson,Banner,Insurance Commissioner,,D,Dennis Anderson,7
-Dickinson,Buckeye,Insurance Commissioner,,D,Dennis Anderson,37
-Dickinson,Center,Insurance Commissioner,,D,Dennis Anderson,72
-Dickinson,Cheever,Insurance Commissioner,,D,Dennis Anderson,6
-Dickinson,Flora,Insurance Commissioner,,D,Dennis Anderson,21
-Dickinson,Fragrant Hill,Insurance Commissioner,,D,Dennis Anderson,24
-Dickinson,Garfield,Insurance Commissioner,,D,Dennis Anderson,25
-Dickinson,Grant,Insurance Commissioner,,D,Dennis Anderson,85
-Dickinson,Hayes,Insurance Commissioner,,D,Dennis Anderson,15
-Dickinson,Herington W1,Insurance Commissioner,,D,Dennis Anderson,93
-Dickinson,Herington W2,Insurance Commissioner,,D,Dennis Anderson,95
-Dickinson,Herington W3,Insurance Commissioner,,D,Dennis Anderson,46
-Dickinson,Holland,Insurance Commissioner,,D,Dennis Anderson,5
-Dickinson,Hope,Insurance Commissioner,,D,Dennis Anderson,57
-Dickinson,Jefferson,Insurance Commissioner,,D,Dennis Anderson,14
-Dickinson,Liberty,Insurance Commissioner,,D,Dennis Anderson,38
-Dickinson,Lincoln,Insurance Commissioner,,D,Dennis Anderson,114
-Dickinson,Logan,Insurance Commissioner,,D,Dennis Anderson,19
-Dickinson,Lyon 68,Insurance Commissioner,,D,Dennis Anderson,11
-Dickinson,Lyon 68A,Insurance Commissioner,,D,Dennis Anderson,1
-Dickinson,Lyon 70,Insurance Commissioner,,D,Dennis Anderson,12
-Dickinson,Newbern,Insurance Commissioner,,D,Dennis Anderson,37
-Dickinson,Noble,Insurance Commissioner,,D,Dennis Anderson,160
-Dickinson,Ridge,Insurance Commissioner,,D,Dennis Anderson,12
-Dickinson,Rinehart,Insurance Commissioner,,D,Dennis Anderson,17
-Dickinson,Sherman,Insurance Commissioner,,D,Dennis Anderson,13
-Dickinson,Union,Insurance Commissioner,,D,Dennis Anderson,15
-Dickinson,Wheatland,Insurance Commissioner,,D,Dennis Anderson,5
-Dickinson,Willowdale,Insurance Commissioner,,D,Dennis Anderson,17
-Dickinson,Banner,Insurance Commissioner,,R,Ken Selzer,39
-Dickinson,Buckeye,Insurance Commissioner,,R,Ken Selzer,141
-Dickinson,Center,Insurance Commissioner,,R,Ken Selzer,265
-Dickinson,Cheever,Insurance Commissioner,,R,Ken Selzer,47
-Dickinson,Flora,Insurance Commissioner,,R,Ken Selzer,45
-Dickinson,Fragrant Hill,Insurance Commissioner,,R,Ken Selzer,90
-Dickinson,Garfield,Insurance Commissioner,,R,Ken Selzer,51
-Dickinson,Grant,Insurance Commissioner,,R,Ken Selzer,286
-Dickinson,Hayes,Insurance Commissioner,,R,Ken Selzer,93
-Dickinson,Herington W1,Insurance Commissioner,,R,Ken Selzer,119
-Dickinson,Herington W2,Insurance Commissioner,,R,Ken Selzer,129
-Dickinson,Herington W3,Insurance Commissioner,,R,Ken Selzer,84
-Dickinson,Holland,Insurance Commissioner,,R,Ken Selzer,36
-Dickinson,Hope,Insurance Commissioner,,R,Ken Selzer,97
-Dickinson,Jefferson,Insurance Commissioner,,R,Ken Selzer,79
-Dickinson,Liberty,Insurance Commissioner,,R,Ken Selzer,79
-Dickinson,Lincoln,Insurance Commissioner,,R,Ken Selzer,367
-Dickinson,Logan,Insurance Commissioner,,R,Ken Selzer,54
-Dickinson,Lyon 68,Insurance Commissioner,,R,Ken Selzer,12
-Dickinson,Lyon 68A,Insurance Commissioner,,R,Ken Selzer,5
-Dickinson,Lyon 70,Insurance Commissioner,,R,Ken Selzer,46
-Dickinson,Newbern,Insurance Commissioner,,R,Ken Selzer,139
-Dickinson,Noble,Insurance Commissioner,,R,Ken Selzer,421
-Dickinson,Ridge,Insurance Commissioner,,R,Ken Selzer,49
-Dickinson,Rinehart,Insurance Commissioner,,R,Ken Selzer,79
-Dickinson,Sherman,Insurance Commissioner,,R,Ken Selzer,49
-Dickinson,Union,Insurance Commissioner,,R,Ken Selzer,47
-Dickinson,Wheatland,Insurance Commissioner,,R,Ken Selzer,50
-Dickinson,Willowdale,Insurance Commissioner,,R,Ken Selzer,80
-Dickinson,Banner,Secretary of State,,D,Jean Kurtis Schodorf,9
-Dickinson,Buckeye,Secretary of State,,D,Jean Kurtis Schodorf,40
-Dickinson,Center,Secretary of State,,D,Jean Kurtis Schodorf,74
-Dickinson,Cheever,Secretary of State,,D,Jean Kurtis Schodorf,9
-Dickinson,Flora,Secretary of State,,D,Jean Kurtis Schodorf,17
-Dickinson,Fragrant Hill,Secretary of State,,D,Jean Kurtis Schodorf,17
-Dickinson,Garfield,Secretary of State,,D,Jean Kurtis Schodorf,21
-Dickinson,Grant,Secretary of State,,D,Jean Kurtis Schodorf,95
-Dickinson,Hayes,Secretary of State,,D,Jean Kurtis Schodorf,23
-Dickinson,Herington W1,Secretary of State,,D,Jean Kurtis Schodorf,97
-Dickinson,Herington W2,Secretary of State,,D,Jean Kurtis Schodorf,101
-Dickinson,Herington W3,Secretary of State,,D,Jean Kurtis Schodorf,48
-Dickinson,Holland,Secretary of State,,D,Jean Kurtis Schodorf,9
-Dickinson,Hope,Secretary of State,,D,Jean Kurtis Schodorf,72
-Dickinson,Jefferson,Secretary of State,,D,Jean Kurtis Schodorf,18
-Dickinson,Liberty,Secretary of State,,D,Jean Kurtis Schodorf,36
-Dickinson,Lincoln,Secretary of State,,D,Jean Kurtis Schodorf,125
-Dickinson,Logan,Secretary of State,,D,Jean Kurtis Schodorf,27
-Dickinson,Lyon 68,Secretary of State,,D,Jean Kurtis Schodorf,9
-Dickinson,Lyon 68A,Secretary of State,,D,Jean Kurtis Schodorf,1
-Dickinson,Lyon 70,Secretary of State,,D,Jean Kurtis Schodorf,14
-Dickinson,Newbern,Secretary of State,,D,Jean Kurtis Schodorf,42
-Dickinson,Noble,Secretary of State,,D,Jean Kurtis Schodorf,170
-Dickinson,Ridge,Secretary of State,,D,Jean Kurtis Schodorf,11
-Dickinson,Rinehart,Secretary of State,,D,Jean Kurtis Schodorf,17
-Dickinson,Sherman,Secretary of State,,D,Jean Kurtis Schodorf,12
-Dickinson,Union,Secretary of State,,D,Jean Kurtis Schodorf,17
-Dickinson,Wheatland,Secretary of State,,D,Jean Kurtis Schodorf,11
-Dickinson,Willowdale,Secretary of State,,D,Jean Kurtis Schodorf,17
-Dickinson,Banner,Secretary of State,,R,Kris Kobach,38
-Dickinson,Buckeye,Secretary of State,,R,Kris Kobach,144
-Dickinson,Center,Secretary of State,,R,Kris Kobach,274
-Dickinson,Cheever,Secretary of State,,R,Kris Kobach,44
-Dickinson,Flora,Secretary of State,,R,Kris Kobach,49
-Dickinson,Fragrant Hill,Secretary of State,,R,Kris Kobach,99
-Dickinson,Garfield,Secretary of State,,R,Kris Kobach,58
-Dickinson,Grant,Secretary of State,,R,Kris Kobach,280
-Dickinson,Hayes,Secretary of State,,R,Kris Kobach,90
-Dickinson,Herington W1,Secretary of State,,R,Kris Kobach,126
-Dickinson,Herington W2,Secretary of State,,R,Kris Kobach,134
-Dickinson,Herington W3,Secretary of State,,R,Kris Kobach,84
-Dickinson,Holland,Secretary of State,,R,Kris Kobach,35
-Dickinson,Hope,Secretary of State,,R,Kris Kobach,93
-Dickinson,Jefferson,Secretary of State,,R,Kris Kobach,80
-Dickinson,Liberty,Secretary of State,,R,Kris Kobach,82
-Dickinson,Lincoln,Secretary of State,,R,Kris Kobach,370
-Dickinson,Logan,Secretary of State,,R,Kris Kobach,49
-Dickinson,Lyon 68,Secretary of State,,R,Kris Kobach,14
-Dickinson,Lyon 68A,Secretary of State,,R,Kris Kobach,5
-Dickinson,Lyon 70,Secretary of State,,R,Kris Kobach,45
-Dickinson,Newbern,Secretary of State,,R,Kris Kobach,141
-Dickinson,Noble,Secretary of State,,R,Kris Kobach,423
-Dickinson,Ridge,Secretary of State,,R,Kris Kobach,50
-Dickinson,Rinehart,Secretary of State,,R,Kris Kobach,79
-Dickinson,Sherman,Secretary of State,,R,Kris Kobach,52
-Dickinson,Union,Secretary of State,,R,Kris Kobach,45
-Dickinson,Wheatland,Secretary of State,,R,Kris Kobach,45
-Dickinson,Willowdale,Secretary of State,,R,Kris Kobach,82
-Dickinson,Herington W2,State House,68,R,Tom J Mosley,202
-Dickinson,Herington W1,State House,68,R,Tom J Mosley,182
-Dickinson,Herington W3,State House,68,R,Tom J Mosley,112
-Dickinson,Lyon 68,State House,68,R,Tom J Mosley,18
-Dickinson,Lyon 68A,State House,68,R,Tom J Mosley,5
-Dickinson,Noble,State House,70,R,John E. Barker,516
-Dickinson,Lincoln,State House,70,R,John E. Barker,452
-Dickinson,Grant,State House,70,R,John E. Barker,335
-Dickinson,Center,State House,70,R,John E. Barker,313
-Dickinson,Buckeye,State House,70,R,John E. Barker,166
-Dickinson,Newbern,State House,70,R,John E. Barker,160
-Dickinson,Hope,State House,70,R,John E. Barker,124
-Dickinson,Hayes,State House,70,R,John E. Barker,111
-Dickinson,Fragrant Hill,State House,70,R,John E. Barker,107
-Dickinson,Liberty,State House,70,R,John E. Barker,107
-Dickinson,Willowdale,State House,70,R,John E. Barker,94
-Dickinson,Rinehart,State House,70,R,John E. Barker,93
-Dickinson,Jefferson,State House,70,R,John E. Barker,88
-Dickinson,Logan,State House,70,R,John E. Barker,70
-Dickinson,Garfield,State House,70,R,John E. Barker,65
-Dickinson,Flora,State House,70,R,John E. Barker,56
-Dickinson,Ridge,State House,70,R,John E. Barker,55
-Dickinson,Lyon 70,State House,70,R,John E. Barker,54
-Dickinson,Union,State House,70,R,John E. Barker,51
-Dickinson,Wheatland,State House,70,R,John E. Barker,51
-Dickinson,Cheever,State House,70,R,John E. Barker,50
-Dickinson,Sherman,State House,70,R,John E. Barker,50
-Dickinson,Banner,State House,70,R,John E. Barker,44
-Dickinson,Holland,State House,70,R,John E. Barker,41
-Dickinson,Herington W2,State Senate,35,R,Richard Wilborn,187
-Dickinson,Herington W1,State Senate,35,R,Richard Wilborn,172
-Dickinson,Newbern,State Senate,35,R,Richard Wilborn,161
-Dickinson,Hope,State Senate,35,R,Richard Wilborn,117
-Dickinson,Herington W3,State Senate,35,R,Richard Wilborn,114
-Dickinson,Liberty,State Senate,35,R,Richard Wilborn,97
-Dickinson,Jefferson,State Senate,35,R,Richard Wilborn,79
-Dickinson,Garfield,State Senate,35,R,Richard Wilborn,69
-Dickinson,Logan,State Senate,35,R,Richard Wilborn,63
-Dickinson,Ridge,State Senate,35,R,Richard Wilborn,58
-Dickinson,Lyon 70,State Senate,35,R,Richard Wilborn,53
-Dickinson,Wheatland,State Senate,35,R,Richard Wilborn,51
-Dickinson,Union,State Senate,35,R,Richard Wilborn,48
-Dickinson,Banner,State Senate,35,R,Richard Wilborn,42
-Dickinson,Holland,State Senate,35,R,Richard Wilborn,40
-Dickinson,Lyon 68,State Senate,35,R,Richard Wilborn,17
-Dickinson,Lyon 68A,State Senate,35,R,Richard Wilborn,5
-Dickinson,Banner,State Treasurer,,D,Carmen Alldritt,6
-Dickinson,Buckeye,State Treasurer,,D,Carmen Alldritt,23
-Dickinson,Center,State Treasurer,,D,Carmen Alldritt,62
-Dickinson,Cheever,State Treasurer,,D,Carmen Alldritt,6
-Dickinson,Flora,State Treasurer,,D,Carmen Alldritt,18
-Dickinson,Fragrant Hill,State Treasurer,,D,Carmen Alldritt,18
-Dickinson,Garfield,State Treasurer,,D,Carmen Alldritt,16
-Dickinson,Grant,State Treasurer,,D,Carmen Alldritt,74
-Dickinson,Hayes,State Treasurer,,D,Carmen Alldritt,19
-Dickinson,Herington W1,State Treasurer,,D,Carmen Alldritt,71
-Dickinson,Herington W2,State Treasurer,,D,Carmen Alldritt,84
-Dickinson,Herington W3,State Treasurer,,D,Carmen Alldritt,42
-Dickinson,Holland,State Treasurer,,D,Carmen Alldritt,3
-Dickinson,Hope,State Treasurer,,D,Carmen Alldritt,39
-Dickinson,Jefferson,State Treasurer,,D,Carmen Alldritt,11
-Dickinson,Liberty,State Treasurer,,D,Carmen Alldritt,33
-Dickinson,Lincoln,State Treasurer,,D,Carmen Alldritt,103
-Dickinson,Logan,State Treasurer,,D,Carmen Alldritt,17
-Dickinson,Lyon 68,State Treasurer,,D,Carmen Alldritt,11
-Dickinson,Lyon 68A,State Treasurer,,D,Carmen Alldritt,1
-Dickinson,Lyon 70,State Treasurer,,D,Carmen Alldritt,12
-Dickinson,Newbern,State Treasurer,,D,Carmen Alldritt,27
-Dickinson,Noble,State Treasurer,,D,Carmen Alldritt,120
-Dickinson,Ridge,State Treasurer,,D,Carmen Alldritt,9
-Dickinson,Rinehart,State Treasurer,,D,Carmen Alldritt,13
-Dickinson,Sherman,State Treasurer,,D,Carmen Alldritt,10
-Dickinson,Union,State Treasurer,,D,Carmen Alldritt,10
-Dickinson,Wheatland,State Treasurer,,D,Carmen Alldritt,3
-Dickinson,Willowdale,State Treasurer,,D,Carmen Alldritt,16
-Dickinson,Banner,State Treasurer,,R,Ron Estes,41
-Dickinson,Buckeye,State Treasurer,,R,Ron Estes,159
-Dickinson,Center,State Treasurer,,R,Ron Estes,276
-Dickinson,Cheever,State Treasurer,,R,Ron Estes,47
-Dickinson,Flora,State Treasurer,,R,Ron Estes,49
-Dickinson,Fragrant Hill,State Treasurer,,R,Ron Estes,98
-Dickinson,Garfield,State Treasurer,,R,Ron Estes,60
-Dickinson,Grant,State Treasurer,,R,Ron Estes,297
-Dickinson,Hayes,State Treasurer,,R,Ron Estes,92
-Dickinson,Herington W1,State Treasurer,,R,Ron Estes,148
-Dickinson,Herington W2,State Treasurer,,R,Ron Estes,148
-Dickinson,Herington W3,State Treasurer,,R,Ron Estes,88
-Dickinson,Holland,State Treasurer,,R,Ron Estes,38
-Dickinson,Hope,State Treasurer,,R,Ron Estes,122
-Dickinson,Jefferson,State Treasurer,,R,Ron Estes,86
-Dickinson,Liberty,State Treasurer,,R,Ron Estes,84
-Dickinson,Lincoln,State Treasurer,,R,Ron Estes,386
-Dickinson,Logan,State Treasurer,,R,Ron Estes,58
-Dickinson,Lyon 68,State Treasurer,,R,Ron Estes,12
-Dickinson,Lyon 68A,State Treasurer,,R,Ron Estes,5
-Dickinson,Lyon 70,State Treasurer,,R,Ron Estes,47
-Dickinson,Newbern,State Treasurer,,R,Ron Estes,149
-Dickinson,Noble,State Treasurer,,R,Ron Estes,468
-Dickinson,Ridge,State Treasurer,,R,Ron Estes,52
-Dickinson,Rinehart,State Treasurer,,R,Ron Estes,83
-Dickinson,Sherman,State Treasurer,,R,Ron Estes,54
-Dickinson,Union,State Treasurer,,R,Ron Estes,50
-Dickinson,Wheatland,State Treasurer,,R,Ron Estes,51
-Dickinson,Willowdale,State Treasurer,,R,Ron Estes,82
-Dickinson,Banner,U.S. Senate,,I,Greg Orman,6
-Dickinson,Buckeye,U.S. Senate,,I,Greg Orman,42
-Dickinson,Center,U.S. Senate,,I,Greg Orman,79
-Dickinson,Cheever,U.S. Senate,,I,Greg Orman,4
-Dickinson,Flora,U.S. Senate,,I,Greg Orman,17
-Dickinson,Fragrant Hill,U.S. Senate,,I,Greg Orman,21
-Dickinson,Garfield,U.S. Senate,,I,Greg Orman,20
-Dickinson,Grant,U.S. Senate,,I,Greg Orman,101
-Dickinson,Hayes,U.S. Senate,,I,Greg Orman,17
-Dickinson,Herington W1,U.S. Senate,,I,Greg Orman,105
-Dickinson,Herington W2,U.S. Senate,,I,Greg Orman,106
-Dickinson,Herington W3,U.S. Senate,,I,Greg Orman,52
-Dickinson,Holland,U.S. Senate,,I,Greg Orman,7
-Dickinson,Hope,U.S. Senate,,I,Greg Orman,65
-Dickinson,Jefferson,U.S. Senate,,I,Greg Orman,15
-Dickinson,Liberty,U.S. Senate,,I,Greg Orman,40
-Dickinson,Lincoln,U.S. Senate,,I,Greg Orman,132
-Dickinson,Logan,U.S. Senate,,I,Greg Orman,26
-Dickinson,Lyon 68,U.S. Senate,,I,Greg Orman,10
-Dickinson,Lyon 68A,U.S. Senate,,I,Greg Orman,2
-Dickinson,Lyon 70,U.S. Senate,,I,Greg Orman,14
-Dickinson,Newbern,U.S. Senate,,I,Greg Orman,56
-Dickinson,Noble,U.S. Senate,,I,Greg Orman,180
-Dickinson,Ridge,U.S. Senate,,I,Greg Orman,11
-Dickinson,Rinehart,U.S. Senate,,I,Greg Orman,17
-Dickinson,Sherman,U.S. Senate,,I,Greg Orman,12
-Dickinson,Union,U.S. Senate,,I,Greg Orman,18
-Dickinson,Wheatland,U.S. Senate,,I,Greg Orman,13
-Dickinson,Willowdale,U.S. Senate,,I,Greg Orman,26
-Dickinson,Banner,U.S. Senate,,L,Randall Batson,2
-Dickinson,Buckeye,U.S. Senate,,L,Randall Batson,8
-Dickinson,Center,U.S. Senate,,L,Randall Batson,16
-Dickinson,Cheever,U.S. Senate,,L,Randall Batson,2
-Dickinson,Flora,U.S. Senate,,L,Randall Batson,4
-Dickinson,Fragrant Hill,U.S. Senate,,L,Randall Batson,6
-Dickinson,Garfield,U.S. Senate,,L,Randall Batson,1
-Dickinson,Grant,U.S. Senate,,L,Randall Batson,15
-Dickinson,Hayes,U.S. Senate,,L,Randall Batson,4
-Dickinson,Herington W1,U.S. Senate,,L,Randall Batson,14
-Dickinson,Herington W2,U.S. Senate,,L,Randall Batson,18
-Dickinson,Herington W3,U.S. Senate,,L,Randall Batson,13
-Dickinson,Holland,U.S. Senate,,L,Randall Batson,5
-Dickinson,Hope,U.S. Senate,,L,Randall Batson,10
-Dickinson,Jefferson,U.S. Senate,,L,Randall Batson,2
-Dickinson,Liberty,U.S. Senate,,L,Randall Batson,4
-Dickinson,Lincoln,U.S. Senate,,L,Randall Batson,29
-Dickinson,Logan,U.S. Senate,,L,Randall Batson,0
-Dickinson,Lyon 68,U.S. Senate,,L,Randall Batson,0
-Dickinson,Lyon 68A,U.S. Senate,,L,Randall Batson,0
-Dickinson,Lyon 70,U.S. Senate,,L,Randall Batson,2
-Dickinson,Newbern,U.S. Senate,,L,Randall Batson,3
-Dickinson,Noble,U.S. Senate,,L,Randall Batson,39
-Dickinson,Ridge,U.S. Senate,,L,Randall Batson,2
-Dickinson,Rinehart,U.S. Senate,,L,Randall Batson,7
-Dickinson,Sherman,U.S. Senate,,L,Randall Batson,0
-Dickinson,Union,U.S. Senate,,L,Randall Batson,1
-Dickinson,Wheatland,U.S. Senate,,L,Randall Batson,2
-Dickinson,Willowdale,U.S. Senate,,L,Randall Batson,3
-Dickinson,Banner,U.S. Senate,,R,Pat Roberts,40
-Dickinson,Buckeye,U.S. Senate,,R,Pat Roberts,135
-Dickinson,Center,U.S. Senate,,R,Pat Roberts,252
-Dickinson,Cheever,U.S. Senate,,R,Pat Roberts,48
-Dickinson,Flora,U.S. Senate,,R,Pat Roberts,44
-Dickinson,Fragrant Hill,U.S. Senate,,R,Pat Roberts,90
-Dickinson,Garfield,U.S. Senate,,R,Pat Roberts,57
-Dickinson,Grant,U.S. Senate,,R,Pat Roberts,258
-Dickinson,Hayes,U.S. Senate,,R,Pat Roberts,92
-Dickinson,Herington W1,U.S. Senate,,R,Pat Roberts,104
-Dickinson,Herington W2,U.S. Senate,,R,Pat Roberts,113
-Dickinson,Herington W3,U.S. Senate,,R,Pat Roberts,68
-Dickinson,Holland,U.S. Senate,,R,Pat Roberts,32
-Dickinson,Hope,U.S. Senate,,R,Pat Roberts,92
-Dickinson,Jefferson,U.S. Senate,,R,Pat Roberts,81
-Dickinson,Liberty,U.S. Senate,,R,Pat Roberts,74
-Dickinson,Lincoln,U.S. Senate,,R,Pat Roberts,344
-Dickinson,Logan,U.S. Senate,,R,Pat Roberts,49
-Dickinson,Lyon 68,U.S. Senate,,R,Pat Roberts,13
-Dickinson,Lyon 68A,U.S. Senate,,R,Pat Roberts,4
-Dickinson,Lyon 70,U.S. Senate,,R,Pat Roberts,46
-Dickinson,Newbern,U.S. Senate,,R,Pat Roberts,126
-Dickinson,Noble,U.S. Senate,,R,Pat Roberts,370
-Dickinson,Ridge,U.S. Senate,,R,Pat Roberts,48
-Dickinson,Rinehart,U.S. Senate,,R,Pat Roberts,72
-Dickinson,Sherman,U.S. Senate,,R,Pat Roberts,53
-Dickinson,Union,U.S. Senate,,R,Pat Roberts,43
-Dickinson,Wheatland,U.S. Senate,,R,Pat Roberts,40
-Dickinson,Willowdale,U.S. Senate,,R,Pat Roberts,74
+county,precinct,office,district,party,candidate,votes,vtd
+DICKINSON,Abilene Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",112,000010
+DICKINSON,Abilene Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",35,000010
+DICKINSON,Abilene Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",145,000010
+DICKINSON,Abilene Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",211,00002A
+DICKINSON,Abilene Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",56,00002A
+DICKINSON,Abilene Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",277,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002B
+DICKINSON,Abilene Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",114,000030
+DICKINSON,Abilene Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000030
+DICKINSON,Abilene Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",139,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",184,000040
+DICKINSON,Abilene Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",32,000040
+DICKINSON,Abilene Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",249,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",208,000050
+DICKINSON,Abilene Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000050
+DICKINSON,Abilene Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",338,000050
+DICKINSON,Banner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000060
+DICKINSON,Banner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000060
+DICKINSON,Banner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000060
+DICKINSON,Buckeye Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000070
+DICKINSON,Buckeye Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000070
+DICKINSON,Buckeye Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",129,000070
+DICKINSON,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",86,000080
+DICKINSON,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",27,000080
+DICKINSON,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",237,000080
+DICKINSON,Cheever Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000090
+DICKINSON,Cheever Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000090
+DICKINSON,Cheever Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000090
+DICKINSON,Flora Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000100
+DICKINSON,Flora Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000100
+DICKINSON,Flora Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000100
+DICKINSON,Fragrant Hill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000110
+DICKINSON,Fragrant Hill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000110
+DICKINSON,Fragrant Hill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,000110
+DICKINSON,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000120
+DICKINSON,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000120
+DICKINSON,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000120
+DICKINSON,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",108,000130
+DICKINSON,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000130
+DICKINSON,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",248,000130
+DICKINSON,Hayes Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000140
+DICKINSON,Hayes Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000140
+DICKINSON,Hayes Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",88,000140
+DICKINSON,Herington Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",121,000150
+DICKINSON,Herington Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000150
+DICKINSON,Herington Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000150
+DICKINSON,Herington Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",106,000160
+DICKINSON,Herington Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000160
+DICKINSON,Herington Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,000160
+DICKINSON,Herington Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000170
+DICKINSON,Herington Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000170
+DICKINSON,Herington Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000170
+DICKINSON,Holland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000180
+DICKINSON,Holland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000180
+DICKINSON,Holland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000180
+DICKINSON,Hope Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000190
+DICKINSON,Hope Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000190
+DICKINSON,Hope Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,000190
+DICKINSON,Jefferson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000200
+DICKINSON,Jefferson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000200
+DICKINSON,Jefferson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000200
+DICKINSON,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000210
+DICKINSON,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000210
+DICKINSON,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000210
+DICKINSON,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",162,000220
+DICKINSON,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",34,000220
+DICKINSON,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",308,000220
+DICKINSON,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000230
+DICKINSON,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000230
+DICKINSON,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000230
+DICKINSON,Newbern Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",51,000250
+DICKINSON,Newbern Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000250
+DICKINSON,Newbern Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",122,000250
+DICKINSON,Noble Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",224,000260
+DICKINSON,Noble Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",33,000260
+DICKINSON,Noble Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",332,000260
+DICKINSON,Ridge Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000270
+DICKINSON,Ridge Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000270
+DICKINSON,Ridge Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,000270
+DICKINSON,Rinehart Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000280
+DICKINSON,Rinehart Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000280
+DICKINSON,Rinehart Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",77,000280
+DICKINSON,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000290
+DICKINSON,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000290
+DICKINSON,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000290
+DICKINSON,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000300
+DICKINSON,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000300
+DICKINSON,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000300
+DICKINSON,Wheatland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000310
+DICKINSON,Wheatland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000310
+DICKINSON,Wheatland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000310
+DICKINSON,Willowdale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000320
+DICKINSON,Willowdale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000320
+DICKINSON,Willowdale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000320
+DICKINSON,Lyon Township H68 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,12002A
+DICKINSON,Lyon Township H68 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,12002A
+DICKINSON,Lyon Township H68 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,12002A
+DICKINSON,Lyon Township H68,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,120020
+DICKINSON,Lyon Township H68,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120020
+DICKINSON,Lyon Township H68,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,120020
+DICKINSON,Lyon Township H70,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,120030
+DICKINSON,Lyon Township H70,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+DICKINSON,Lyon Township H70,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,120030
+DICKINSON,Abilene Ward 1 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+DICKINSON,Grant Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+DICKINSON,Grant Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+DICKINSON,Grant Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+DICKINSON,Abilene Ward 1,Kansas House of Representatives,70,Republican,"Barker, John E",244,000010
+DICKINSON,Abilene Ward 2,Kansas House of Representatives,70,Republican,"Barker, John E",476,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Kansas House of Representatives,70,Republican,"Barker, John E",0,00002B
+DICKINSON,Abilene Ward 3,Kansas House of Representatives,70,Republican,"Barker, John E",230,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Kansas House of Representatives,70,Republican,"Barker, John E",389,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Kansas House of Representatives,70,Republican,"Barker, John E",500,000050
+DICKINSON,Banner Township,Kansas House of Representatives,70,Republican,"Barker, John E",44,000060
+DICKINSON,Buckeye Township,Kansas House of Representatives,70,Republican,"Barker, John E",166,000070
+DICKINSON,Center Township,Kansas House of Representatives,70,Republican,"Barker, John E",313,000080
+DICKINSON,Cheever Township,Kansas House of Representatives,70,Republican,"Barker, John E",50,000090
+DICKINSON,Flora Township,Kansas House of Representatives,70,Republican,"Barker, John E",56,000100
+DICKINSON,Fragrant Hill Township,Kansas House of Representatives,70,Republican,"Barker, John E",107,000110
+DICKINSON,Garfield Township,Kansas House of Representatives,70,Republican,"Barker, John E",65,000120
+DICKINSON,Grant Township,Kansas House of Representatives,70,Republican,"Barker, John E",335,000130
+DICKINSON,Hayes Township,Kansas House of Representatives,70,Republican,"Barker, John E",111,000140
+DICKINSON,Herington Ward 1,Kansas House of Representatives,68,Republican,"Moxley, Tom",182,000150
+DICKINSON,Herington Ward 2,Kansas House of Representatives,68,Republican,"Moxley, Tom",202,000160
+DICKINSON,Herington Ward 4,Kansas House of Representatives,68,Republican,"Moxley, Tom",112,000170
+DICKINSON,Holland Township,Kansas House of Representatives,70,Republican,"Barker, John E",41,000180
+DICKINSON,Hope Township,Kansas House of Representatives,70,Republican,"Barker, John E",124,000190
+DICKINSON,Jefferson Township,Kansas House of Representatives,70,Republican,"Barker, John E",88,000200
+DICKINSON,Liberty Township,Kansas House of Representatives,70,Republican,"Barker, John E",107,000210
+DICKINSON,Lincoln Township,Kansas House of Representatives,70,Republican,"Barker, John E",452,000220
+DICKINSON,Logan Township,Kansas House of Representatives,70,Republican,"Barker, John E",70,000230
+DICKINSON,Newbern Township,Kansas House of Representatives,70,Republican,"Barker, John E",160,000250
+DICKINSON,Noble Township,Kansas House of Representatives,70,Republican,"Barker, John E",516,000260
+DICKINSON,Ridge Township,Kansas House of Representatives,70,Republican,"Barker, John E",55,000270
+DICKINSON,Rinehart Township,Kansas House of Representatives,70,Republican,"Barker, John E",93,000280
+DICKINSON,Sherman Township,Kansas House of Representatives,70,Republican,"Barker, John E",50,000290
+DICKINSON,Union Township,Kansas House of Representatives,70,Republican,"Barker, John E",51,000300
+DICKINSON,Wheatland Township,Kansas House of Representatives,70,Republican,"Barker, John E",51,000310
+DICKINSON,Willowdale Township,Kansas House of Representatives,70,Republican,"Barker, John E",94,000320
+DICKINSON,Lyon Township H68 A,Kansas House of Representatives,68,Republican,"Moxley, Tom",5,12002A
+DICKINSON,Lyon Township H68,Kansas House of Representatives,68,Republican,"Moxley, Tom",18,120020
+DICKINSON,Lyon Township H70,Kansas House of Representatives,70,Republican,"Barker, John E",54,120030
+DICKINSON,Abilene Ward 1 Exclave A,Kansas House of Representatives,70,Republican,"Barker, John E",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Kansas House of Representatives,70,Republican,"Barker, John E",0,900020
+DICKINSON,Grant Township Enclave,Kansas House of Representatives,70,Republican,"Barker, John E",0,900030
+DICKINSON,Abilene Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",108,000010
+DICKINSON,Abilene Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",181,000010
+DICKINSON,Abilene Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",189,00002A
+DICKINSON,Abilene Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",355,00002A
+DICKINSON,Abilene Ward 2 Exclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002B
+DICKINSON,Abilene Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",95,000030
+DICKINSON,Abilene Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",183,000030
+DICKINSON,Abilene Ward 4 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",174,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",289,000040
+DICKINSON,Abilene Ward 4 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",183,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",383,000050
+DICKINSON,Banner Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000060
+DICKINSON,Banner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000060
+DICKINSON,Buckeye Township,United States House of Representatives,1,Democratic,"Sherow, James E.",34,000070
+DICKINSON,Buckeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",150,000070
+DICKINSON,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",78,000080
+DICKINSON,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",266,000080
+DICKINSON,Cheever Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000090
+DICKINSON,Cheever Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000090
+DICKINSON,Flora Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000100
+DICKINSON,Flora Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000100
+DICKINSON,Fragrant Hill Township,United States House of Representatives,1,Democratic,"Sherow, James E.",20,000110
+DICKINSON,Fragrant Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",97,000110
+DICKINSON,Garfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",23,000120
+DICKINSON,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000120
+DICKINSON,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",100,000130
+DICKINSON,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",275,000130
+DICKINSON,Hayes Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000140
+DICKINSON,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000140
+DICKINSON,Herington Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",92,000150
+DICKINSON,Herington Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",131,000150
+DICKINSON,Herington Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",101,000160
+DICKINSON,Herington Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",135,000160
+DICKINSON,Herington Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",38,000170
+DICKINSON,Herington Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000170
+DICKINSON,Holland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000180
+DICKINSON,Holland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000180
+DICKINSON,Hope Township,United States House of Representatives,1,Democratic,"Sherow, James E.",61,000190
+DICKINSON,Hope Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000190
+DICKINSON,Jefferson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000200
+DICKINSON,Jefferson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",79,000200
+DICKINSON,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",37,000210
+DICKINSON,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",83,000210
+DICKINSON,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",130,000220
+DICKINSON,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",365,000220
+DICKINSON,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",26,000230
+DICKINSON,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000230
+DICKINSON,Newbern Township,United States House of Representatives,1,Democratic,"Sherow, James E.",38,000250
+DICKINSON,Newbern Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",143,000250
+DICKINSON,Noble Township,United States House of Representatives,1,Democratic,"Sherow, James E.",172,000260
+DICKINSON,Noble Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",413,000260
+DICKINSON,Ridge Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000270
+DICKINSON,Ridge Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000270
+DICKINSON,Rinehart Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000280
+DICKINSON,Rinehart Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000280
+DICKINSON,Sherman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000290
+DICKINSON,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000290
+DICKINSON,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000300
+DICKINSON,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000300
+DICKINSON,Wheatland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000310
+DICKINSON,Wheatland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000310
+DICKINSON,Willowdale Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000320
+DICKINSON,Willowdale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",79,000320
+DICKINSON,Lyon Township H68 A,United States House of Representatives,1,Democratic,"Sherow, James E.",3,12002A
+DICKINSON,Lyon Township H68 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,12002A
+DICKINSON,Lyon Township H68,United States House of Representatives,1,Democratic,"Sherow, James E.",10,120020
+DICKINSON,Lyon Township H68,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,120020
+DICKINSON,Lyon Township H70,United States House of Representatives,1,Democratic,"Sherow, James E.",16,120030
+DICKINSON,Lyon Township H70,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,120030
+DICKINSON,Abilene Ward 1 Exclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+DICKINSON,Grant Township Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900030
+DICKINSON,Grant Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+DICKINSON,Abilene Ward 1,Attorney General,,Democratic,"Kotich, A.J.",77,000010
+DICKINSON,Abilene Ward 1,Attorney General,,Republican,"Schmidt, Derek",203,000010
+DICKINSON,Abilene Ward 2,Attorney General,,Democratic,"Kotich, A.J.",132,00002A
+DICKINSON,Abilene Ward 2,Attorney General,,Republican,"Schmidt, Derek",402,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00002B
+DICKINSON,Abilene Ward 3,Attorney General,,Democratic,"Kotich, A.J.",76,000030
+DICKINSON,Abilene Ward 3,Attorney General,,Republican,"Schmidt, Derek",200,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",140,000040
+DICKINSON,Abilene Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",315,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",124,000050
+DICKINSON,Abilene Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",443,000050
+DICKINSON,Banner Township,Attorney General,,Democratic,"Kotich, A.J.",7,000060
+DICKINSON,Banner Township,Attorney General,,Republican,"Schmidt, Derek",40,000060
+DICKINSON,Buckeye Township,Attorney General,,Democratic,"Kotich, A.J.",30,000070
+DICKINSON,Buckeye Township,Attorney General,,Republican,"Schmidt, Derek",154,000070
+DICKINSON,Center Township,Attorney General,,Democratic,"Kotich, A.J.",56,000080
+DICKINSON,Center Township,Attorney General,,Republican,"Schmidt, Derek",285,000080
+DICKINSON,Cheever Township,Attorney General,,Democratic,"Kotich, A.J.",6,000090
+DICKINSON,Cheever Township,Attorney General,,Republican,"Schmidt, Derek",46,000090
+DICKINSON,Flora Township,Attorney General,,Democratic,"Kotich, A.J.",16,000100
+DICKINSON,Flora Township,Attorney General,,Republican,"Schmidt, Derek",51,000100
+DICKINSON,Fragrant Hill Township,Attorney General,,Democratic,"Kotich, A.J.",15,000110
+DICKINSON,Fragrant Hill Township,Attorney General,,Republican,"Schmidt, Derek",99,000110
+DICKINSON,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",13,000120
+DICKINSON,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",66,000120
+DICKINSON,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",70,000130
+DICKINSON,Grant Township,Attorney General,,Republican,"Schmidt, Derek",302,000130
+DICKINSON,Hayes Township,Attorney General,,Democratic,"Kotich, A.J.",15,000140
+DICKINSON,Hayes Township,Attorney General,,Republican,"Schmidt, Derek",97,000140
+DICKINSON,Herington Ward 1,Attorney General,,Democratic,"Kotich, A.J.",82,000150
+DICKINSON,Herington Ward 1,Attorney General,,Republican,"Schmidt, Derek",139,000150
+DICKINSON,Herington Ward 2,Attorney General,,Democratic,"Kotich, A.J.",85,000160
+DICKINSON,Herington Ward 2,Attorney General,,Republican,"Schmidt, Derek",143,000160
+DICKINSON,Herington Ward 4,Attorney General,,Democratic,"Kotich, A.J.",37,000170
+DICKINSON,Herington Ward 4,Attorney General,,Republican,"Schmidt, Derek",95,000170
+DICKINSON,Holland Township,Attorney General,,Democratic,"Kotich, A.J.",4,000180
+DICKINSON,Holland Township,Attorney General,,Republican,"Schmidt, Derek",39,000180
+DICKINSON,Hope Township,Attorney General,,Democratic,"Kotich, A.J.",43,000190
+DICKINSON,Hope Township,Attorney General,,Republican,"Schmidt, Derek",122,000190
+DICKINSON,Jefferson Township,Attorney General,,Democratic,"Kotich, A.J.",14,000200
+DICKINSON,Jefferson Township,Attorney General,,Republican,"Schmidt, Derek",82,000200
+DICKINSON,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",33,000210
+DICKINSON,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",85,000210
+DICKINSON,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",89,000220
+DICKINSON,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",402,000220
+DICKINSON,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",17,000230
+DICKINSON,Logan Township,Attorney General,,Republican,"Schmidt, Derek",59,000230
+DICKINSON,Newbern Township,Attorney General,,Democratic,"Kotich, A.J.",31,000250
+DICKINSON,Newbern Township,Attorney General,,Republican,"Schmidt, Derek",148,000250
+DICKINSON,Noble Township,Attorney General,,Democratic,"Kotich, A.J.",128,000260
+DICKINSON,Noble Township,Attorney General,,Republican,"Schmidt, Derek",455,000260
+DICKINSON,Ridge Township,Attorney General,,Democratic,"Kotich, A.J.",5,000270
+DICKINSON,Ridge Township,Attorney General,,Republican,"Schmidt, Derek",56,000270
+DICKINSON,Rinehart Township,Attorney General,,Democratic,"Kotich, A.J.",14,000280
+DICKINSON,Rinehart Township,Attorney General,,Republican,"Schmidt, Derek",82,000280
+DICKINSON,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",10,000290
+DICKINSON,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",53,000290
+DICKINSON,Union Township,Attorney General,,Democratic,"Kotich, A.J.",7,000300
+DICKINSON,Union Township,Attorney General,,Republican,"Schmidt, Derek",54,000300
+DICKINSON,Wheatland Township,Attorney General,,Democratic,"Kotich, A.J.",4,000310
+DICKINSON,Wheatland Township,Attorney General,,Republican,"Schmidt, Derek",51,000310
+DICKINSON,Willowdale Township,Attorney General,,Democratic,"Kotich, A.J.",17,000320
+DICKINSON,Willowdale Township,Attorney General,,Republican,"Schmidt, Derek",83,000320
+DICKINSON,Lyon Township H68 A,Attorney General,,Democratic,"Kotich, A.J.",1,12002A
+DICKINSON,Lyon Township H68 A,Attorney General,,Republican,"Schmidt, Derek",5,12002A
+DICKINSON,Lyon Township H68,Attorney General,,Democratic,"Kotich, A.J.",8,120020
+DICKINSON,Lyon Township H68,Attorney General,,Republican,"Schmidt, Derek",15,120020
+DICKINSON,Lyon Township H70,Attorney General,,Democratic,"Kotich, A.J.",8,120030
+DICKINSON,Lyon Township H70,Attorney General,,Republican,"Schmidt, Derek",51,120030
+DICKINSON,Abilene Ward 1 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,900020
+DICKINSON,Grant Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+DICKINSON,Grant Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900030
+DICKINSON,Abilene Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",94,000010
+DICKINSON,Abilene Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",183,000010
+DICKINSON,Abilene Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",157,00002A
+DICKINSON,Abilene Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",371,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002B
+DICKINSON,Abilene Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",84,000030
+DICKINSON,Abilene Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",195,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",149,000040
+DICKINSON,Abilene Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",310,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",147,000050
+DICKINSON,Abilene Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",406,000050
+DICKINSON,Banner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000060
+DICKINSON,Banner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000060
+DICKINSON,Buckeye Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000070
+DICKINSON,Buckeye Township,Commissioner of Insurance,,Republican,"Selzer, Ken",141,000070
+DICKINSON,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000080
+DICKINSON,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",265,000080
+DICKINSON,Cheever Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000090
+DICKINSON,Cheever Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000090
+DICKINSON,Flora Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000100
+DICKINSON,Flora Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000100
+DICKINSON,Fragrant Hill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000110
+DICKINSON,Fragrant Hill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",90,000110
+DICKINSON,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000120
+DICKINSON,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000120
+DICKINSON,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",85,000130
+DICKINSON,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",286,000130
+DICKINSON,Hayes Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000140
+DICKINSON,Hayes Township,Commissioner of Insurance,,Republican,"Selzer, Ken",93,000140
+DICKINSON,Herington Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,000150
+DICKINSON,Herington Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",119,000150
+DICKINSON,Herington Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",95,000160
+DICKINSON,Herington Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000160
+DICKINSON,Herington Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000170
+DICKINSON,Herington Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000170
+DICKINSON,Holland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000180
+DICKINSON,Holland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000180
+DICKINSON,Hope Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000190
+DICKINSON,Hope Township,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000190
+DICKINSON,Jefferson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000200
+DICKINSON,Jefferson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000200
+DICKINSON,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000210
+DICKINSON,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000210
+DICKINSON,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",114,000220
+DICKINSON,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",367,000220
+DICKINSON,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000230
+DICKINSON,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",54,000230
+DICKINSON,Newbern Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000250
+DICKINSON,Newbern Township,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000250
+DICKINSON,Noble Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",160,000260
+DICKINSON,Noble Township,Commissioner of Insurance,,Republican,"Selzer, Ken",421,000260
+DICKINSON,Ridge Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000270
+DICKINSON,Ridge Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000270
+DICKINSON,Rinehart Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000280
+DICKINSON,Rinehart Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000280
+DICKINSON,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000290
+DICKINSON,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000290
+DICKINSON,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000300
+DICKINSON,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000300
+DICKINSON,Wheatland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000310
+DICKINSON,Wheatland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000310
+DICKINSON,Willowdale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000320
+DICKINSON,Willowdale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",80,000320
+DICKINSON,Lyon Township H68 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,12002A
+DICKINSON,Lyon Township H68 A,Commissioner of Insurance,,Republican,"Selzer, Ken",5,12002A
+DICKINSON,Lyon Township H68,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,120020
+DICKINSON,Lyon Township H68,Commissioner of Insurance,,Republican,"Selzer, Ken",12,120020
+DICKINSON,Lyon Township H70,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,120030
+DICKINSON,Lyon Township H70,Commissioner of Insurance,,Republican,"Selzer, Ken",46,120030
+DICKINSON,Abilene Ward 1 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+DICKINSON,Grant Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+DICKINSON,Grant Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+DICKINSON,Banner Township,Kansas Senate,35,Republican,"Wilborn, Richard",42,000060
+DICKINSON,Garfield Township,Kansas Senate,35,Republican,"Wilborn, Richard",69,000120
+DICKINSON,Herington Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",172,000150
+DICKINSON,Herington Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",187,000160
+DICKINSON,Herington Ward 4,Kansas Senate,35,Republican,"Wilborn, Richard",114,000170
+DICKINSON,Holland Township,Kansas Senate,35,Republican,"Wilborn, Richard",40,000180
+DICKINSON,Hope Township,Kansas Senate,35,Republican,"Wilborn, Richard",117,000190
+DICKINSON,Jefferson Township,Kansas Senate,35,Republican,"Wilborn, Richard",79,000200
+DICKINSON,Liberty Township,Kansas Senate,35,Republican,"Wilborn, Richard",97,000210
+DICKINSON,Logan Township,Kansas Senate,35,Republican,"Wilborn, Richard",63,000230
+DICKINSON,Newbern Township,Kansas Senate,35,Republican,"Wilborn, Richard",161,000250
+DICKINSON,Ridge Township,Kansas Senate,35,Republican,"Wilborn, Richard",58,000270
+DICKINSON,Union Township,Kansas Senate,35,Republican,"Wilborn, Richard",48,000300
+DICKINSON,Wheatland Township,Kansas Senate,35,Republican,"Wilborn, Richard",51,000310
+DICKINSON,Lyon Township H68 A,Kansas Senate,35,Republican,"Wilborn, Richard",5,12002A
+DICKINSON,Lyon Township H68,Kansas Senate,35,Republican,"Wilborn, Richard",17,120020
+DICKINSON,Lyon Township H70,Kansas Senate,35,Republican,"Wilborn, Richard",53,120030
+DICKINSON,Abilene Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",100,000010
+DICKINSON,Abilene Ward 1,Secretary of State,,Republican,"Kobach, Kris",184,000010
+DICKINSON,Abilene Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",163,00002A
+DICKINSON,Abilene Ward 2,Secretary of State,,Republican,"Kobach, Kris",376,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00002B
+DICKINSON,Abilene Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",96,000030
+DICKINSON,Abilene Ward 3,Secretary of State,,Republican,"Kobach, Kris",185,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",179,000040
+DICKINSON,Abilene Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",288,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",177,000050
+DICKINSON,Abilene Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",398,000050
+DICKINSON,Banner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000060
+DICKINSON,Banner Township,Secretary of State,,Republican,"Kobach, Kris",38,000060
+DICKINSON,Buckeye Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000070
+DICKINSON,Buckeye Township,Secretary of State,,Republican,"Kobach, Kris",144,000070
+DICKINSON,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000080
+DICKINSON,Center Township,Secretary of State,,Republican,"Kobach, Kris",274,000080
+DICKINSON,Cheever Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000090
+DICKINSON,Cheever Township,Secretary of State,,Republican,"Kobach, Kris",44,000090
+DICKINSON,Flora Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000100
+DICKINSON,Flora Township,Secretary of State,,Republican,"Kobach, Kris",49,000100
+DICKINSON,Fragrant Hill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000110
+DICKINSON,Fragrant Hill Township,Secretary of State,,Republican,"Kobach, Kris",99,000110
+DICKINSON,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000120
+DICKINSON,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",58,000120
+DICKINSON,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",95,000130
+DICKINSON,Grant Township,Secretary of State,,Republican,"Kobach, Kris",280,000130
+DICKINSON,Hayes Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000140
+DICKINSON,Hayes Township,Secretary of State,,Republican,"Kobach, Kris",90,000140
+DICKINSON,Herington Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",97,000150
+DICKINSON,Herington Ward 1,Secretary of State,,Republican,"Kobach, Kris",126,000150
+DICKINSON,Herington Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",101,000160
+DICKINSON,Herington Ward 2,Secretary of State,,Republican,"Kobach, Kris",134,000160
+DICKINSON,Herington Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000170
+DICKINSON,Herington Ward 4,Secretary of State,,Republican,"Kobach, Kris",84,000170
+DICKINSON,Holland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000180
+DICKINSON,Holland Township,Secretary of State,,Republican,"Kobach, Kris",35,000180
+DICKINSON,Hope Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,000190
+DICKINSON,Hope Township,Secretary of State,,Republican,"Kobach, Kris",93,000190
+DICKINSON,Jefferson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000200
+DICKINSON,Jefferson Township,Secretary of State,,Republican,"Kobach, Kris",80,000200
+DICKINSON,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000210
+DICKINSON,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",82,000210
+DICKINSON,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",125,000220
+DICKINSON,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",370,000220
+DICKINSON,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000230
+DICKINSON,Logan Township,Secretary of State,,Republican,"Kobach, Kris",49,000230
+DICKINSON,Newbern Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000250
+DICKINSON,Newbern Township,Secretary of State,,Republican,"Kobach, Kris",141,000250
+DICKINSON,Noble Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",170,000260
+DICKINSON,Noble Township,Secretary of State,,Republican,"Kobach, Kris",423,000260
+DICKINSON,Ridge Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000270
+DICKINSON,Ridge Township,Secretary of State,,Republican,"Kobach, Kris",50,000270
+DICKINSON,Rinehart Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000280
+DICKINSON,Rinehart Township,Secretary of State,,Republican,"Kobach, Kris",79,000280
+DICKINSON,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000290
+DICKINSON,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",52,000290
+DICKINSON,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000300
+DICKINSON,Union Township,Secretary of State,,Republican,"Kobach, Kris",45,000300
+DICKINSON,Wheatland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000310
+DICKINSON,Wheatland Township,Secretary of State,,Republican,"Kobach, Kris",45,000310
+DICKINSON,Willowdale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000320
+DICKINSON,Willowdale Township,Secretary of State,,Republican,"Kobach, Kris",82,000320
+DICKINSON,Lyon Township H68 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,12002A
+DICKINSON,Lyon Township H68 A,Secretary of State,,Republican,"Kobach, Kris",5,12002A
+DICKINSON,Lyon Township H68,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,120020
+DICKINSON,Lyon Township H68,Secretary of State,,Republican,"Kobach, Kris",14,120020
+DICKINSON,Lyon Township H70,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,120030
+DICKINSON,Lyon Township H70,Secretary of State,,Republican,"Kobach, Kris",45,120030
+DICKINSON,Abilene Ward 1 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,900020
+DICKINSON,Grant Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+DICKINSON,Grant Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900030
+DICKINSON,Abilene Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",83,000010
+DICKINSON,Abilene Ward 1,State Treasurer,,Republican,"Estes, Ron",195,000010
+DICKINSON,Abilene Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",142,00002A
+DICKINSON,Abilene Ward 2,State Treasurer,,Republican,"Estes, Ron",391,00002A
+DICKINSON,Abilene Ward 2 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00002B
+DICKINSON,Abilene Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",70,000030
+DICKINSON,Abilene Ward 3,State Treasurer,,Republican,"Estes, Ron",207,000030
+DICKINSON,Abilene Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",132,000040
+DICKINSON,Abilene Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",328,000040
+DICKINSON,Abilene Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",134,000050
+DICKINSON,Abilene Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",428,000050
+DICKINSON,Banner Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000060
+DICKINSON,Banner Township,State Treasurer,,Republican,"Estes, Ron",41,000060
+DICKINSON,Buckeye Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000070
+DICKINSON,Buckeye Township,State Treasurer,,Republican,"Estes, Ron",159,000070
+DICKINSON,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",62,000080
+DICKINSON,Center Township,State Treasurer,,Republican,"Estes, Ron",276,000080
+DICKINSON,Cheever Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000090
+DICKINSON,Cheever Township,State Treasurer,,Republican,"Estes, Ron",47,000090
+DICKINSON,Flora Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000100
+DICKINSON,Flora Township,State Treasurer,,Republican,"Estes, Ron",49,000100
+DICKINSON,Fragrant Hill Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000110
+DICKINSON,Fragrant Hill Township,State Treasurer,,Republican,"Estes, Ron",98,000110
+DICKINSON,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000120
+DICKINSON,Garfield Township,State Treasurer,,Republican,"Estes, Ron",60,000120
+DICKINSON,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",74,000130
+DICKINSON,Grant Township,State Treasurer,,Republican,"Estes, Ron",297,000130
+DICKINSON,Hayes Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000140
+DICKINSON,Hayes Township,State Treasurer,,Republican,"Estes, Ron",92,000140
+DICKINSON,Herington Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",71,000150
+DICKINSON,Herington Ward 1,State Treasurer,,Republican,"Estes, Ron",148,000150
+DICKINSON,Herington Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",84,000160
+DICKINSON,Herington Ward 2,State Treasurer,,Republican,"Estes, Ron",148,000160
+DICKINSON,Herington Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",42,000170
+DICKINSON,Herington Ward 4,State Treasurer,,Republican,"Estes, Ron",88,000170
+DICKINSON,Holland Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000180
+DICKINSON,Holland Township,State Treasurer,,Republican,"Estes, Ron",38,000180
+DICKINSON,Hope Township,State Treasurer,,Democratic,"Alldritt, Carmen",39,000190
+DICKINSON,Hope Township,State Treasurer,,Republican,"Estes, Ron",122,000190
+DICKINSON,Jefferson Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000200
+DICKINSON,Jefferson Township,State Treasurer,,Republican,"Estes, Ron",86,000200
+DICKINSON,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,000210
+DICKINSON,Liberty Township,State Treasurer,,Republican,"Estes, Ron",84,000210
+DICKINSON,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",103,000220
+DICKINSON,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",386,000220
+DICKINSON,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000230
+DICKINSON,Logan Township,State Treasurer,,Republican,"Estes, Ron",58,000230
+DICKINSON,Newbern Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000250
+DICKINSON,Newbern Township,State Treasurer,,Republican,"Estes, Ron",149,000250
+DICKINSON,Noble Township,State Treasurer,,Democratic,"Alldritt, Carmen",120,000260
+DICKINSON,Noble Township,State Treasurer,,Republican,"Estes, Ron",468,000260
+DICKINSON,Ridge Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000270
+DICKINSON,Ridge Township,State Treasurer,,Republican,"Estes, Ron",52,000270
+DICKINSON,Rinehart Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000280
+DICKINSON,Rinehart Township,State Treasurer,,Republican,"Estes, Ron",83,000280
+DICKINSON,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000290
+DICKINSON,Sherman Township,State Treasurer,,Republican,"Estes, Ron",54,000290
+DICKINSON,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000300
+DICKINSON,Union Township,State Treasurer,,Republican,"Estes, Ron",50,000300
+DICKINSON,Wheatland Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000310
+DICKINSON,Wheatland Township,State Treasurer,,Republican,"Estes, Ron",51,000310
+DICKINSON,Willowdale Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000320
+DICKINSON,Willowdale Township,State Treasurer,,Republican,"Estes, Ron",82,000320
+DICKINSON,Lyon Township H68 A,State Treasurer,,Democratic,"Alldritt, Carmen",1,12002A
+DICKINSON,Lyon Township H68 A,State Treasurer,,Republican,"Estes, Ron",5,12002A
+DICKINSON,Lyon Township H68,State Treasurer,,Democratic,"Alldritt, Carmen",11,120020
+DICKINSON,Lyon Township H68,State Treasurer,,Republican,"Estes, Ron",12,120020
+DICKINSON,Lyon Township H70,State Treasurer,,Democratic,"Alldritt, Carmen",12,120030
+DICKINSON,Lyon Township H70,State Treasurer,,Republican,"Estes, Ron",47,120030
+DICKINSON,Abilene Ward 1 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,900020
+DICKINSON,Grant Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+DICKINSON,Grant Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,900030
+DICKINSON,Abilene Ward 1,United States Senate,,independent,"Orman, Greg",110,000010
+DICKINSON,Abilene Ward 1,United States Senate,,Libertarian,"Batson, Randall",23,000010
+DICKINSON,Abilene Ward 1,United States Senate,,Republican,"Roberts, Pat",160,000010
+DICKINSON,Abilene Ward 2,United States Senate,,independent,"Orman, Greg",179,00002A
+DICKINSON,Abilene Ward 2,United States Senate,,Libertarian,"Batson, Randall",38,00002A
+DICKINSON,Abilene Ward 2,United States Senate,,Republican,"Roberts, Pat",332,00002A
+DICKINSON,Abilene Ward 2 Exclave A,United States Senate,,independent,"Orman, Greg",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00002B
+DICKINSON,Abilene Ward 3,United States Senate,,independent,"Orman, Greg",97,000030
+DICKINSON,Abilene Ward 3,United States Senate,,Libertarian,"Batson, Randall",23,000030
+DICKINSON,Abilene Ward 3,United States Senate,,Republican,"Roberts, Pat",160,000030
+DICKINSON,Abilene Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",173,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",24,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",269,000040
+DICKINSON,Abilene Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",178,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",20,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",377,000050
+DICKINSON,Banner Township,United States Senate,,independent,"Orman, Greg",6,000060
+DICKINSON,Banner Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+DICKINSON,Banner Township,United States Senate,,Republican,"Roberts, Pat",40,000060
+DICKINSON,Buckeye Township,United States Senate,,independent,"Orman, Greg",42,000070
+DICKINSON,Buckeye Township,United States Senate,,Libertarian,"Batson, Randall",8,000070
+DICKINSON,Buckeye Township,United States Senate,,Republican,"Roberts, Pat",135,000070
+DICKINSON,Center Township,United States Senate,,independent,"Orman, Greg",79,000080
+DICKINSON,Center Township,United States Senate,,Libertarian,"Batson, Randall",16,000080
+DICKINSON,Center Township,United States Senate,,Republican,"Roberts, Pat",252,000080
+DICKINSON,Cheever Township,United States Senate,,independent,"Orman, Greg",4,000090
+DICKINSON,Cheever Township,United States Senate,,Libertarian,"Batson, Randall",2,000090
+DICKINSON,Cheever Township,United States Senate,,Republican,"Roberts, Pat",48,000090
+DICKINSON,Flora Township,United States Senate,,independent,"Orman, Greg",17,000100
+DICKINSON,Flora Township,United States Senate,,Libertarian,"Batson, Randall",4,000100
+DICKINSON,Flora Township,United States Senate,,Republican,"Roberts, Pat",44,000100
+DICKINSON,Fragrant Hill Township,United States Senate,,independent,"Orman, Greg",21,000110
+DICKINSON,Fragrant Hill Township,United States Senate,,Libertarian,"Batson, Randall",6,000110
+DICKINSON,Fragrant Hill Township,United States Senate,,Republican,"Roberts, Pat",90,000110
+DICKINSON,Garfield Township,United States Senate,,independent,"Orman, Greg",20,000120
+DICKINSON,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",1,000120
+DICKINSON,Garfield Township,United States Senate,,Republican,"Roberts, Pat",57,000120
+DICKINSON,Grant Township,United States Senate,,independent,"Orman, Greg",101,000130
+DICKINSON,Grant Township,United States Senate,,Libertarian,"Batson, Randall",15,000130
+DICKINSON,Grant Township,United States Senate,,Republican,"Roberts, Pat",258,000130
+DICKINSON,Hayes Township,United States Senate,,independent,"Orman, Greg",17,000140
+DICKINSON,Hayes Township,United States Senate,,Libertarian,"Batson, Randall",4,000140
+DICKINSON,Hayes Township,United States Senate,,Republican,"Roberts, Pat",92,000140
+DICKINSON,Herington Ward 1,United States Senate,,independent,"Orman, Greg",105,000150
+DICKINSON,Herington Ward 1,United States Senate,,Libertarian,"Batson, Randall",14,000150
+DICKINSON,Herington Ward 1,United States Senate,,Republican,"Roberts, Pat",104,000150
+DICKINSON,Herington Ward 2,United States Senate,,independent,"Orman, Greg",106,000160
+DICKINSON,Herington Ward 2,United States Senate,,Libertarian,"Batson, Randall",18,000160
+DICKINSON,Herington Ward 2,United States Senate,,Republican,"Roberts, Pat",113,000160
+DICKINSON,Herington Ward 4,United States Senate,,independent,"Orman, Greg",52,000170
+DICKINSON,Herington Ward 4,United States Senate,,Libertarian,"Batson, Randall",13,000170
+DICKINSON,Herington Ward 4,United States Senate,,Republican,"Roberts, Pat",68,000170
+DICKINSON,Holland Township,United States Senate,,independent,"Orman, Greg",7,000180
+DICKINSON,Holland Township,United States Senate,,Libertarian,"Batson, Randall",5,000180
+DICKINSON,Holland Township,United States Senate,,Republican,"Roberts, Pat",32,000180
+DICKINSON,Hope Township,United States Senate,,independent,"Orman, Greg",65,000190
+DICKINSON,Hope Township,United States Senate,,Libertarian,"Batson, Randall",10,000190
+DICKINSON,Hope Township,United States Senate,,Republican,"Roberts, Pat",92,000190
+DICKINSON,Jefferson Township,United States Senate,,independent,"Orman, Greg",15,000200
+DICKINSON,Jefferson Township,United States Senate,,Libertarian,"Batson, Randall",2,000200
+DICKINSON,Jefferson Township,United States Senate,,Republican,"Roberts, Pat",81,000200
+DICKINSON,Liberty Township,United States Senate,,independent,"Orman, Greg",40,000210
+DICKINSON,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",4,000210
+DICKINSON,Liberty Township,United States Senate,,Republican,"Roberts, Pat",74,000210
+DICKINSON,Lincoln Township,United States Senate,,independent,"Orman, Greg",132,000220
+DICKINSON,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",29,000220
+DICKINSON,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",344,000220
+DICKINSON,Logan Township,United States Senate,,independent,"Orman, Greg",26,000230
+DICKINSON,Logan Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+DICKINSON,Logan Township,United States Senate,,Republican,"Roberts, Pat",49,000230
+DICKINSON,Newbern Township,United States Senate,,independent,"Orman, Greg",56,000250
+DICKINSON,Newbern Township,United States Senate,,Libertarian,"Batson, Randall",3,000250
+DICKINSON,Newbern Township,United States Senate,,Republican,"Roberts, Pat",126,000250
+DICKINSON,Noble Township,United States Senate,,independent,"Orman, Greg",180,000260
+DICKINSON,Noble Township,United States Senate,,Libertarian,"Batson, Randall",39,000260
+DICKINSON,Noble Township,United States Senate,,Republican,"Roberts, Pat",370,000260
+DICKINSON,Ridge Township,United States Senate,,independent,"Orman, Greg",11,000270
+DICKINSON,Ridge Township,United States Senate,,Libertarian,"Batson, Randall",2,000270
+DICKINSON,Ridge Township,United States Senate,,Republican,"Roberts, Pat",48,000270
+DICKINSON,Rinehart Township,United States Senate,,independent,"Orman, Greg",17,000280
+DICKINSON,Rinehart Township,United States Senate,,Libertarian,"Batson, Randall",7,000280
+DICKINSON,Rinehart Township,United States Senate,,Republican,"Roberts, Pat",72,000280
+DICKINSON,Sherman Township,United States Senate,,independent,"Orman, Greg",12,000290
+DICKINSON,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",0,000290
+DICKINSON,Sherman Township,United States Senate,,Republican,"Roberts, Pat",53,000290
+DICKINSON,Union Township,United States Senate,,independent,"Orman, Greg",18,000300
+DICKINSON,Union Township,United States Senate,,Libertarian,"Batson, Randall",1,000300
+DICKINSON,Union Township,United States Senate,,Republican,"Roberts, Pat",43,000300
+DICKINSON,Wheatland Township,United States Senate,,independent,"Orman, Greg",13,000310
+DICKINSON,Wheatland Township,United States Senate,,Libertarian,"Batson, Randall",2,000310
+DICKINSON,Wheatland Township,United States Senate,,Republican,"Roberts, Pat",40,000310
+DICKINSON,Willowdale Township,United States Senate,,independent,"Orman, Greg",26,000320
+DICKINSON,Willowdale Township,United States Senate,,Libertarian,"Batson, Randall",3,000320
+DICKINSON,Willowdale Township,United States Senate,,Republican,"Roberts, Pat",74,000320
+DICKINSON,Lyon Township H68 A,United States Senate,,independent,"Orman, Greg",2,12002A
+DICKINSON,Lyon Township H68 A,United States Senate,,Libertarian,"Batson, Randall",0,12002A
+DICKINSON,Lyon Township H68 A,United States Senate,,Republican,"Roberts, Pat",4,12002A
+DICKINSON,Lyon Township H68,United States Senate,,independent,"Orman, Greg",10,120020
+DICKINSON,Lyon Township H68,United States Senate,,Libertarian,"Batson, Randall",0,120020
+DICKINSON,Lyon Township H68,United States Senate,,Republican,"Roberts, Pat",13,120020
+DICKINSON,Lyon Township H70,United States Senate,,independent,"Orman, Greg",14,120030
+DICKINSON,Lyon Township H70,United States Senate,,Libertarian,"Batson, Randall",2,120030
+DICKINSON,Lyon Township H70,United States Senate,,Republican,"Roberts, Pat",46,120030
+DICKINSON,Abilene Ward 1 Exclave A,United States Senate,,independent,"Orman, Greg",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,United States Senate,,independent,"Orman, Greg",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,900020
+DICKINSON,Grant Township Enclave,United States Senate,,independent,"Orman, Greg",0,900030
+DICKINSON,Grant Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900030
+DICKINSON,Grant Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,900030

--- a/2014/20141104__ks__general__doniphan__precinct.csv
+++ b/2014/20141104__ks__general__doniphan__precinct.csv
@@ -1,235 +1,235 @@
-county,precinct,office,district,party,candidate,votes
-Doniphan,BENDENA,U.S. Senate,,R,Pat Roberts,81
-Doniphan,BLAIR,U.S. Senate,,R,Pat Roberts,42
-Doniphan,BURR OAK,U.S. Senate,,R,Pat Roberts,45
-Doniphan,DENTON,U.S. Senate,,R,Pat Roberts,88
-Doniphan,ELWOOD,U.S. Senate,,R,Pat Roberts,77
-Doniphan,HIGHLAND,U.S. Senate,,R,Pat Roberts,259
-Doniphan,LEONA,U.S. Senate,,R,Pat Roberts,30
-Doniphan,MARION,U.S. Senate,,R,Pat Roberts,74
-Doniphan,SEVERANCE,U.S. Senate,,R,Pat Roberts,59
-Doniphan,TROY,U.S. Senate,,R,Pat Roberts,381
-Doniphan,WATHENA,U.S. Senate,,R,Pat Roberts,315
-Doniphan,WAYNE,U.S. Senate,,R,Pat Roberts,51
-Doniphan,WHITE CLOUD,U.S. Senate,,R,Pat Roberts,53
-Doniphan,BENDENA,U.S. Senate,,I,Greg Orman,33
-Doniphan,BLAIR,U.S. Senate,,I,Greg Orman,17
-Doniphan,BURR OAK,U.S. Senate,,I,Greg Orman,5
-Doniphan,DENTON,U.S. Senate,,I,Greg Orman,40
-Doniphan,ELWOOD,U.S. Senate,,I,Greg Orman,67
-Doniphan,HIGHLAND,U.S. Senate,,I,Greg Orman,98
-Doniphan,LEONA,U.S. Senate,,I,Greg Orman,1
-Doniphan,MARION,U.S. Senate,,I,Greg Orman,16
-Doniphan,SEVERANCE,U.S. Senate,,I,Greg Orman,14
-Doniphan,TROY,U.S. Senate,,I,Greg Orman,117
-Doniphan,WATHENA,U.S. Senate,,I,Greg Orman,101
-Doniphan,WAYNE,U.S. Senate,,I,Greg Orman,12
-Doniphan,WHITE CLOUD,U.S. Senate,,I,Greg Orman,31
-Doniphan,BENDENA,U.S. Senate,,L,Randall Batson,9
-Doniphan,BLAIR,U.S. Senate,,L,Randall Batson,4
-Doniphan,BURR OAK,U.S. Senate,,L,Randall Batson,1
-Doniphan,DENTON,U.S. Senate,,L,Randall Batson,8
-Doniphan,ELWOOD,U.S. Senate,,L,Randall Batson,17
-Doniphan,HIGHLAND,U.S. Senate,,L,Randall Batson,22
-Doniphan,LEONA,U.S. Senate,,L,Randall Batson,2
-Doniphan,MARION,U.S. Senate,,L,Randall Batson,10
-Doniphan,SEVERANCE,U.S. Senate,,L,Randall Batson,6
-Doniphan,TROY,U.S. Senate,,L,Randall Batson,23
-Doniphan,WATHENA,U.S. Senate,,L,Randall Batson,27
-Doniphan,WAYNE,U.S. Senate,,L,Randall Batson,2
-Doniphan,WHITE CLOUD,U.S. Senate,,L,Randall Batson,5
-Doniphan,BENDENA,U.S. House,2,R,Lynn Jenkins,94
-Doniphan,BLAIR,U.S. House,2,R,Lynn Jenkins,49
-Doniphan,BURR OAK,U.S. House,2,R,Lynn Jenkins,45
-Doniphan,DENTON,U.S. House,2,R,Lynn Jenkins,108
-Doniphan,ELWOOD,U.S. House,2,R,Lynn Jenkins,109
-Doniphan,HIGHLAND,U.S. House,2,R,Lynn Jenkins,281
-Doniphan,LEONA,U.S. House,2,R,Lynn Jenkins,31
-Doniphan,MARION,U.S. House,2,R,Lynn Jenkins,77
-Doniphan,SEVERANCE,U.S. House,2,R,Lynn Jenkins,65
-Doniphan,TROY,U.S. House,2,R,Lynn Jenkins,417
-Doniphan,WATHENA,U.S. House,2,R,Lynn Jenkins,356
-Doniphan,WAYNE,U.S. House,2,R,Lynn Jenkins,54
-Doniphan,WHITE CLOUD,U.S. House,2,R,Lynn Jenkins,63
-Doniphan,BENDENA,U.S. House,2,D,Margie Wakefield,24
-Doniphan,BLAIR,U.S. House,2,D,Margie Wakefield,13
-Doniphan,BURR OAK,U.S. House,2,D,Margie Wakefield,3
-Doniphan,DENTON,U.S. House,2,D,Margie Wakefield,18
-Doniphan,ELWOOD,U.S. House,2,D,Margie Wakefield,45
-Doniphan,HIGHLAND,U.S. House,2,D,Margie Wakefield,71
-Doniphan,LEONA,U.S. House,2,D,Margie Wakefield,1
-Doniphan,MARION,U.S. House,2,D,Margie Wakefield,19
-Doniphan,SEVERANCE,U.S. House,2,D,Margie Wakefield,12
-Doniphan,TROY,U.S. House,2,D,Margie Wakefield,77
-Doniphan,WATHENA,U.S. House,2,D,Margie Wakefield,77
-Doniphan,WAYNE,U.S. House,2,D,Margie Wakefield,10
-Doniphan,WHITE CLOUD,U.S. House,2,D,Margie Wakefield,21
-Doniphan,BENDENA,U.S. House,2,L,Chris Clemmons,3
-Doniphan,BLAIR,U.S. House,2,L,Chris Clemmons,3
-Doniphan,BURR OAK,U.S. House,2,L,Chris Clemmons,3
-Doniphan,DENTON,U.S. House,2,L,Chris Clemmons,11
-Doniphan,ELWOOD,U.S. House,2,L,Chris Clemmons,14
-Doniphan,HIGHLAND,U.S. House,2,L,Chris Clemmons,23
-Doniphan,LEONA,U.S. House,2,L,Chris Clemmons,1
-Doniphan,MARION,U.S. House,2,L,Chris Clemmons,6
-Doniphan,SEVERANCE,U.S. House,2,L,Chris Clemmons,3
-Doniphan,TROY,U.S. House,2,L,Chris Clemmons,24
-Doniphan,WATHENA,U.S. House,2,L,Chris Clemmons,18
-Doniphan,WAYNE,U.S. House,2,L,Chris Clemmons,0
-Doniphan,WHITE CLOUD,U.S. House,2,L,Chris Clemmons,6
-Doniphan,BENDENA,Governor,,R,Sam Brownback,72
-Doniphan,BLAIR,Governor,,R,Sam Brownback,46
-Doniphan,BURR OAK,Governor,,R,Sam Brownback,46
-Doniphan,DENTON,Governor,,R,Sam Brownback,90
-Doniphan,ELWOOD,Governor,,R,Sam Brownback,86
-Doniphan,HIGHLAND,Governor,,R,Sam Brownback,233
-Doniphan,LEONA,Governor,,R,Sam Brownback,25
-Doniphan,MARION,Governor,,R,Sam Brownback,71
-Doniphan,SEVERANCE,Governor,,R,Sam Brownback,55
-Doniphan,TROY,Governor,,R,Sam Brownback,366
-Doniphan,WATHENA,Governor,,R,Sam Brownback,308
-Doniphan,WAYNE,Governor,,R,Sam Brownback,45
-Doniphan,WHITE CLOUD,Governor,,R,Sam Brownback,48
-Doniphan,BENDENA,Governor,,D,Paul Davis,48
-Doniphan,BLAIR,Governor,,D,Paul Davis,17
-Doniphan,BURR OAK,Governor,,D,Paul Davis,2
-Doniphan,DENTON,Governor,,D,Paul Davis,40
-Doniphan,ELWOOD,Governor,,D,Paul Davis,66
-Doniphan,HIGHLAND,Governor,,D,Paul Davis,134
-Doniphan,LEONA,Governor,,D,Paul Davis,8
-Doniphan,MARION,Governor,,D,Paul Davis,25
-Doniphan,SEVERANCE,Governor,,D,Paul Davis,21
-Doniphan,TROY,Governor,,D,Paul Davis,128
-Doniphan,WATHENA,Governor,,D,Paul Davis,124
-Doniphan,WAYNE,Governor,,D,Paul Davis,19
-Doniphan,WHITE CLOUD,Governor,,D,Paul Davis,36
-Doniphan,BENDENA,Governor,,L,Keen Umbehr,1
-Doniphan,BLAIR,Governor,,L,Keen Umbehr,4
-Doniphan,BURR OAK,Governor,,L,Keen Umbehr,3
-Doniphan,DENTON,Governor,,L,Keen Umbehr,4
-Doniphan,ELWOOD,Governor,,L,Keen Umbehr,17
-Doniphan,HIGHLAND,Governor,,L,Keen Umbehr,15
-Doniphan,LEONA,Governor,,L,Keen Umbehr,0
-Doniphan,MARION,Governor,,L,Keen Umbehr,5
-Doniphan,SEVERANCE,Governor,,L,Keen Umbehr,3
-Doniphan,TROY,Governor,,L,Keen Umbehr,28
-Doniphan,WATHENA,Governor,,L,Keen Umbehr,21
-Doniphan,WAYNE,Governor,,L,Keen Umbehr,0
-Doniphan,WHITE CLOUD,Governor,,L,Keen Umbehr,8
-Doniphan,BENDENA,Secretary of State,,R,Kris Kobach,80
-Doniphan,BLAIR,Secretary of State,,R,Kris Kobach,47
-Doniphan,BURR OAK,Secretary of State,,R,Kris Kobach,46
-Doniphan,DENTON,Secretary of State,,R,Kris Kobach,111
-Doniphan,ELWOOD,Secretary of State,,R,Kris Kobach,96
-Doniphan,HIGHLAND,Secretary of State,,R,Kris Kobach,264
-Doniphan,LEONA,Secretary of State,,R,Kris Kobach,30
-Doniphan,MARION,Secretary of State,,R,Kris Kobach,73
-Doniphan,SEVERANCE,Secretary of State,,R,Kris Kobach,68
-Doniphan,TROY,Secretary of State,,R,Kris Kobach,410
-Doniphan,WATHENA,Secretary of State,,R,Kris Kobach,347
-Doniphan,WAYNE,Secretary of State,,R,Kris Kobach,54
-Doniphan,WHITE CLOUD,Secretary of State,,R,Kris Kobach,59
-Doniphan,BENDENA,Secretary of State,,D,Jean Schodorf,37
-Doniphan,BLAIR,Secretary of State,,D,Jean Schodorf,17
-Doniphan,BURR OAK,Secretary of State,,D,Jean Schodorf,5
-Doniphan,DENTON,Secretary of State,,D,Jean Schodorf,21
-Doniphan,ELWOOD,Secretary of State,,D,Jean Schodorf,70
-Doniphan,HIGHLAND,Secretary of State,,D,Jean Schodorf,93
-Doniphan,LEONA,Secretary of State,,D,Jean Schodorf,3
-Doniphan,MARION,Secretary of State,,D,Jean Schodorf,25
-Doniphan,SEVERANCE,Secretary of State,,D,Jean Schodorf,11
-Doniphan,TROY,Secretary of State,,D,Jean Schodorf,92
-Doniphan,WATHENA,Secretary of State,,D,Jean Schodorf,91
-Doniphan,WAYNE,Secretary of State,,D,Jean Schodorf,8
-Doniphan,WHITE CLOUD,Secretary of State,,D,Jean Schodorf,30
-Doniphan,BENDENA,Attorney General,,R,Derek Schmidt,84
-Doniphan,BLAIR,Attorney General,,R,Derek Schmidt,47
-Doniphan,BURR OAK,Attorney General,,R,Derek Schmidt,47
-Doniphan,DENTON,Attorney General,,R,Derek Schmidt,98
-Doniphan,ELWOOD,Attorney General,,R,Derek Schmidt,98
-Doniphan,HIGHLAND,Attorney General,,R,Derek Schmidt,268
-Doniphan,LEONA,Attorney General,,R,Derek Schmidt,29
-Doniphan,MARION,Attorney General,,R,Derek Schmidt,72
-Doniphan,SEVERANCE,Attorney General,,R,Derek Schmidt,63
-Doniphan,TROY,Attorney General,,R,Derek Schmidt,409
-Doniphan,WATHENA,Attorney General,,R,Derek Schmidt,355
-Doniphan,WAYNE,Attorney General,,R,Derek Schmidt,51
-Doniphan,WHITE CLOUD,Attorney General,,R,Derek Schmidt,62
-Doniphan,BENDENA,Attorney General,,D,A J Kotich,27
-Doniphan,BLAIR,Attorney General,,D,A J Kotich,16
-Doniphan,BURR OAK,Attorney General,,D,A J Kotich,3
-Doniphan,DENTON,Attorney General,,D,A J Kotich,28
-Doniphan,ELWOOD,Attorney General,,D,A J Kotich,65
-Doniphan,HIGHLAND,Attorney General,,D,A J Kotich,78
-Doniphan,LEONA,Attorney General,,D,A J Kotich,3
-Doniphan,MARION,Attorney General,,D,A J Kotich,24
-Doniphan,SEVERANCE,Attorney General,,D,A J Kotich,15
-Doniphan,TROY,Attorney General,,D,A J Kotich,89
-Doniphan,WATHENA,Attorney General,,D,A J Kotich,81
-Doniphan,WAYNE,Attorney General,,D,A J Kotich,10
-Doniphan,WHITE CLOUD,Attorney General,,D,A J Kotich,26
-Doniphan,BENDENA,State Treasurer,,R,Ron Estes,87
-Doniphan,BLAIR,State Treasurer,,R,Ron Estes,46
-Doniphan,BURR OAK,State Treasurer,,R,Ron Estes,45
-Doniphan,DENTON,State Treasurer,,R,Ron Estes,102
-Doniphan,ELWOOD,State Treasurer,,R,Ron Estes,97
-Doniphan,HIGHLAND,State Treasurer,,R,Ron Estes,285
-Doniphan,LEONA,State Treasurer,,R,Ron Estes,31
-Doniphan,MARION,State Treasurer,,R,Ron Estes,69
-Doniphan,SEVERANCE,State Treasurer,,R,Ron Estes,67
-Doniphan,TROY,State Treasurer,,R,Ron Estes,411
-Doniphan,WATHENA,State Treasurer,,R,Ron Estes,351
-Doniphan,WAYNE,State Treasurer,,R,Ron Estes,54
-Doniphan,WHITE CLOUD,State Treasurer,,R,Ron Estes,56
-Doniphan,BENDENA,State Treasurer,,D,Carmen Alldritt,28
-Doniphan,BLAIR,State Treasurer,,D,Carmen Alldritt,17
-Doniphan,BURR OAK,State Treasurer,,D,Carmen Alldritt,6
-Doniphan,DENTON,State Treasurer,,D,Carmen Alldritt,27
-Doniphan,ELWOOD,State Treasurer,,D,Carmen Alldritt,66
-Doniphan,HIGHLAND,State Treasurer,,D,Carmen Alldritt,63
-Doniphan,LEONA,State Treasurer,,D,Carmen Alldritt,1
-Doniphan,MARION,State Treasurer,,D,Carmen Alldritt,25
-Doniphan,SEVERANCE,State Treasurer,,D,Carmen Alldritt,13
-Doniphan,TROY,State Treasurer,,D,Carmen Alldritt,90
-Doniphan,WATHENA,State Treasurer,,D,Carmen Alldritt,91
-Doniphan,WAYNE,State Treasurer,,D,Carmen Alldritt,8
-Doniphan,WHITE CLOUD,State Treasurer,,D,Carmen Alldritt,31
-Doniphan,BENDENA,Insurance Commissioner,,R,Ken Slezer,72
-Doniphan,BLAIR,Insurance Commissioner,,R,Ken Slezer,44
-Doniphan,BURR OAK,Insurance Commissioner,,R,Ken Slezer,46
-Doniphan,DENTON,Insurance Commissioner,,R,Ken Slezer,92
-Doniphan,ELWOOD,Insurance Commissioner,,R,Ken Slezer,96
-Doniphan,HIGHLAND,Insurance Commissioner,,R,Ken Slezer,255
-Doniphan,LEONA,Insurance Commissioner,,R,Ken Slezer,28
-Doniphan,MARION,Insurance Commissioner,,R,Ken Slezer,67
-Doniphan,SEVERANCE,Insurance Commissioner,,R,Ken Slezer,61
-Doniphan,TROY,Insurance Commissioner,,R,Ken Slezer,402
-Doniphan,WATHENA,Insurance Commissioner,,R,Ken Slezer,340
-Doniphan,WAYNE,Insurance Commissioner,,R,Ken Slezer,49
-Doniphan,WHITE CLOUD,Insurance Commissioner,,R,Ken Slezer,54
-Doniphan,BENDENA,Insurance Commissioner,,D,Dennis Anderson,43
-Doniphan,BLAIR,Insurance Commissioner,,D,Dennis Anderson,17
-Doniphan,BURR OAK,Insurance Commissioner,,D,Dennis Anderson,5
-Doniphan,DENTON,Insurance Commissioner,,D,Dennis Anderson,31
-Doniphan,ELWOOD,Insurance Commissioner,,D,Dennis Anderson,63
-Doniphan,HIGHLAND,Insurance Commissioner,,D,Dennis Anderson,85
-Doniphan,LEONA,Insurance Commissioner,,D,Dennis Anderson,3
-Doniphan,MARION,Insurance Commissioner,,D,Dennis Anderson,27
-Doniphan,SEVERANCE,Insurance Commissioner,,D,Dennis Anderson,15
-Doniphan,TROY,Insurance Commissioner,,D,Dennis Anderson,86
-Doniphan,WATHENA,Insurance Commissioner,,D,Dennis Anderson,90
-Doniphan,WAYNE,Insurance Commissioner,,D,Dennis Anderson,11
-Doniphan,WHITE CLOUD,Insurance Commissioner,,D,Dennis Anderson,33
-Doniphan,BENDENA,State House,63,D,Jerry Henry,100
-Doniphan,BLAIR,State House,63,D,Jerry Henry,34
-Doniphan,BURR OAK,State House,63,D,Jerry Henry,24
-Doniphan,DENTON,State House,63,D,Jerry Henry,113
-Doniphan,ELWOOD,State House,63,D,Jerry Henry,106
-Doniphan,HIGHLAND,State House,63,D,Jerry Henry,235
-Doniphan,LEONA,State House,63,D,Jerry Henry,21
-Doniphan,MARION,State House,63,D,Jerry Henry,52
-Doniphan,SEVERANCE,State House,63,D,Jerry Henry,65
-Doniphan,TROY,State House,63,D,Jerry Henry,293
-Doniphan,WATHENA,State House,63,D,Jerry Henry,262
-Doniphan,WAYNE,State House,63,D,Jerry Henry,53
-Doniphan,WHITE CLOUD,State House,63,D,Jerry Henry,51
+county,precinct,office,district,party,candidate,votes,vtd
+DONIPHAN,Bendena Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000010
+DONIPHAN,Bendena Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+DONIPHAN,Bendena Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000010
+DONIPHAN,Blair Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000020
+DONIPHAN,Blair Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000020
+DONIPHAN,Blair Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000020
+DONIPHAN,Burr Oak Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000030
+DONIPHAN,Burr Oak Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000030
+DONIPHAN,Burr Oak Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000030
+DONIPHAN,Denton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000040
+DONIPHAN,Denton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000040
+DONIPHAN,Denton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",90,000040
+DONIPHAN,Elwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,000050
+DONIPHAN,Elwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000050
+DONIPHAN,Elwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,000050
+DONIPHAN,Highland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",134,000060
+DONIPHAN,Highland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000060
+DONIPHAN,Highland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",233,000060
+DONIPHAN,Leona Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000070
+DONIPHAN,Leona Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+DONIPHAN,Leona Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000070
+DONIPHAN,Marion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000080
+DONIPHAN,Marion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000080
+DONIPHAN,Marion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000080
+DONIPHAN,Severance Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000090
+DONIPHAN,Severance Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000090
+DONIPHAN,Severance Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000090
+DONIPHAN,Troy Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",128,000100
+DONIPHAN,Troy Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000100
+DONIPHAN,Troy Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",366,000100
+DONIPHAN,Wathena Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000110
+DONIPHAN,Wathena Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000110
+DONIPHAN,Wathena Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",308,000110
+DONIPHAN,Wayne Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000120
+DONIPHAN,Wayne Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+DONIPHAN,Wayne Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,000120
+DONIPHAN,White Cloud Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000130
+DONIPHAN,White Cloud Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000130
+DONIPHAN,White Cloud Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000130
+DONIPHAN,Bendena Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",100,000010
+DONIPHAN,Blair Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",34,000020
+DONIPHAN,Burr Oak Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",24,000030
+DONIPHAN,Denton Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",113,000040
+DONIPHAN,Elwood Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",106,000050
+DONIPHAN,Highland Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",235,000060
+DONIPHAN,Leona Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",21,000070
+DONIPHAN,Marion Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",52,000080
+DONIPHAN,Severance Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",65,000090
+DONIPHAN,Troy Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",293,000100
+DONIPHAN,Wathena Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",262,000110
+DONIPHAN,Wayne Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",53,000120
+DONIPHAN,White Cloud Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",51,000130
+DONIPHAN,Bendena Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,000010
+DONIPHAN,Bendena Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000010
+DONIPHAN,Bendena Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000010
+DONIPHAN,Blair Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",13,000020
+DONIPHAN,Blair Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000020
+DONIPHAN,Blair Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000020
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",3,000030
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000030
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000030
+DONIPHAN,Denton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000040
+DONIPHAN,Denton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000040
+DONIPHAN,Denton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",108,000040
+DONIPHAN,Elwood Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",45,000050
+DONIPHAN,Elwood Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000050
+DONIPHAN,Elwood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",109,000050
+DONIPHAN,Highland Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",71,000060
+DONIPHAN,Highland Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,000060
+DONIPHAN,Highland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",281,000060
+DONIPHAN,Leona Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",1,000070
+DONIPHAN,Leona Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000070
+DONIPHAN,Leona Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000070
+DONIPHAN,Marion Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",19,000080
+DONIPHAN,Marion Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000080
+DONIPHAN,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,000080
+DONIPHAN,Severance Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",12,000090
+DONIPHAN,Severance Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000090
+DONIPHAN,Severance Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,000090
+DONIPHAN,Troy Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",77,000100
+DONIPHAN,Troy Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000100
+DONIPHAN,Troy Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",417,000100
+DONIPHAN,Wathena Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",77,000110
+DONIPHAN,Wathena Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000110
+DONIPHAN,Wathena Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",356,000110
+DONIPHAN,Wayne Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",10,000120
+DONIPHAN,Wayne Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000120
+DONIPHAN,Wayne Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000120
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",21,000130
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000130
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000130
+DONIPHAN,Bendena Township,Attorney General,,Democratic,"Kotich, A.J.",27,000010
+DONIPHAN,Bendena Township,Attorney General,,Republican,"Schmidt, Derek",84,000010
+DONIPHAN,Blair Township,Attorney General,,Democratic,"Kotich, A.J.",16,000020
+DONIPHAN,Blair Township,Attorney General,,Republican,"Schmidt, Derek",47,000020
+DONIPHAN,Burr Oak Township,Attorney General,,Democratic,"Kotich, A.J.",3,000030
+DONIPHAN,Burr Oak Township,Attorney General,,Republican,"Schmidt, Derek",47,000030
+DONIPHAN,Denton Township,Attorney General,,Democratic,"Kotich, A.J.",28,000040
+DONIPHAN,Denton Township,Attorney General,,Republican,"Schmidt, Derek",98,000040
+DONIPHAN,Elwood Township,Attorney General,,Democratic,"Kotich, A.J.",65,000050
+DONIPHAN,Elwood Township,Attorney General,,Republican,"Schmidt, Derek",98,000050
+DONIPHAN,Highland Township,Attorney General,,Democratic,"Kotich, A.J.",78,000060
+DONIPHAN,Highland Township,Attorney General,,Republican,"Schmidt, Derek",268,000060
+DONIPHAN,Leona Township,Attorney General,,Democratic,"Kotich, A.J.",3,000070
+DONIPHAN,Leona Township,Attorney General,,Republican,"Schmidt, Derek",29,000070
+DONIPHAN,Marion Township,Attorney General,,Democratic,"Kotich, A.J.",24,000080
+DONIPHAN,Marion Township,Attorney General,,Republican,"Schmidt, Derek",72,000080
+DONIPHAN,Severance Township,Attorney General,,Democratic,"Kotich, A.J.",15,000090
+DONIPHAN,Severance Township,Attorney General,,Republican,"Schmidt, Derek",63,000090
+DONIPHAN,Troy Township,Attorney General,,Democratic,"Kotich, A.J.",89,000100
+DONIPHAN,Troy Township,Attorney General,,Republican,"Schmidt, Derek",409,000100
+DONIPHAN,Wathena Township,Attorney General,,Democratic,"Kotich, A.J.",81,000110
+DONIPHAN,Wathena Township,Attorney General,,Republican,"Schmidt, Derek",355,000110
+DONIPHAN,Wayne Township,Attorney General,,Democratic,"Kotich, A.J.",10,000120
+DONIPHAN,Wayne Township,Attorney General,,Republican,"Schmidt, Derek",51,000120
+DONIPHAN,White Cloud Township,Attorney General,,Democratic,"Kotich, A.J.",26,000130
+DONIPHAN,White Cloud Township,Attorney General,,Republican,"Schmidt, Derek",62,000130
+DONIPHAN,Bendena Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000010
+DONIPHAN,Bendena Township,Commissioner of Insurance,,Republican,"Selzer, Ken",72,000010
+DONIPHAN,Blair Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000020
+DONIPHAN,Blair Township,Commissioner of Insurance,,Republican,"Selzer, Ken",44,000020
+DONIPHAN,Burr Oak Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000030
+DONIPHAN,Burr Oak Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000030
+DONIPHAN,Denton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000040
+DONIPHAN,Denton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",92,000040
+DONIPHAN,Elwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,000050
+DONIPHAN,Elwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",96,000050
+DONIPHAN,Highland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",85,000060
+DONIPHAN,Highland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",255,000060
+DONIPHAN,Leona Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000070
+DONIPHAN,Leona Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000070
+DONIPHAN,Marion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000080
+DONIPHAN,Marion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000080
+DONIPHAN,Severance Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000090
+DONIPHAN,Severance Township,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000090
+DONIPHAN,Troy Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,000100
+DONIPHAN,Troy Township,Commissioner of Insurance,,Republican,"Selzer, Ken",402,000100
+DONIPHAN,Wathena Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",90,000110
+DONIPHAN,Wathena Township,Commissioner of Insurance,,Republican,"Selzer, Ken",340,000110
+DONIPHAN,Wayne Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000120
+DONIPHAN,Wayne Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000120
+DONIPHAN,White Cloud Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000130
+DONIPHAN,White Cloud Township,Commissioner of Insurance,,Republican,"Selzer, Ken",54,000130
+DONIPHAN,Bendena Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000010
+DONIPHAN,Bendena Township,Secretary of State,,Republican,"Kobach, Kris",80,000010
+DONIPHAN,Blair Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000020
+DONIPHAN,Blair Township,Secretary of State,,Republican,"Kobach, Kris",47,000020
+DONIPHAN,Burr Oak Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000030
+DONIPHAN,Burr Oak Township,Secretary of State,,Republican,"Kobach, Kris",46,000030
+DONIPHAN,Denton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000040
+DONIPHAN,Denton Township,Secretary of State,,Republican,"Kobach, Kris",111,000040
+DONIPHAN,Elwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,000050
+DONIPHAN,Elwood Township,Secretary of State,,Republican,"Kobach, Kris",96,000050
+DONIPHAN,Highland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",93,000060
+DONIPHAN,Highland Township,Secretary of State,,Republican,"Kobach, Kris",264,000060
+DONIPHAN,Leona Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000070
+DONIPHAN,Leona Township,Secretary of State,,Republican,"Kobach, Kris",30,000070
+DONIPHAN,Marion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000080
+DONIPHAN,Marion Township,Secretary of State,,Republican,"Kobach, Kris",73,000080
+DONIPHAN,Severance Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000090
+DONIPHAN,Severance Township,Secretary of State,,Republican,"Kobach, Kris",68,000090
+DONIPHAN,Troy Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",92,000100
+DONIPHAN,Troy Township,Secretary of State,,Republican,"Kobach, Kris",410,000100
+DONIPHAN,Wathena Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",91,000110
+DONIPHAN,Wathena Township,Secretary of State,,Republican,"Kobach, Kris",347,000110
+DONIPHAN,Wayne Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000120
+DONIPHAN,Wayne Township,Secretary of State,,Republican,"Kobach, Kris",54,000120
+DONIPHAN,White Cloud Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000130
+DONIPHAN,White Cloud Township,Secretary of State,,Republican,"Kobach, Kris",59,000130
+DONIPHAN,Bendena Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000010
+DONIPHAN,Bendena Township,State Treasurer,,Republican,"Estes, Ron",87,000010
+DONIPHAN,Blair Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000020
+DONIPHAN,Blair Township,State Treasurer,,Republican,"Estes, Ron",46,000020
+DONIPHAN,Burr Oak Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000030
+DONIPHAN,Burr Oak Township,State Treasurer,,Republican,"Estes, Ron",45,000030
+DONIPHAN,Denton Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000040
+DONIPHAN,Denton Township,State Treasurer,,Republican,"Estes, Ron",102,000040
+DONIPHAN,Elwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",66,000050
+DONIPHAN,Elwood Township,State Treasurer,,Republican,"Estes, Ron",97,000050
+DONIPHAN,Highland Township,State Treasurer,,Democratic,"Alldritt, Carmen",63,000060
+DONIPHAN,Highland Township,State Treasurer,,Republican,"Estes, Ron",285,000060
+DONIPHAN,Leona Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000070
+DONIPHAN,Leona Township,State Treasurer,,Republican,"Estes, Ron",31,000070
+DONIPHAN,Marion Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000080
+DONIPHAN,Marion Township,State Treasurer,,Republican,"Estes, Ron",69,000080
+DONIPHAN,Severance Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000090
+DONIPHAN,Severance Township,State Treasurer,,Republican,"Estes, Ron",67,000090
+DONIPHAN,Troy Township,State Treasurer,,Democratic,"Alldritt, Carmen",90,000100
+DONIPHAN,Troy Township,State Treasurer,,Republican,"Estes, Ron",411,000100
+DONIPHAN,Wathena Township,State Treasurer,,Democratic,"Alldritt, Carmen",91,000110
+DONIPHAN,Wathena Township,State Treasurer,,Republican,"Estes, Ron",351,000110
+DONIPHAN,Wayne Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000120
+DONIPHAN,Wayne Township,State Treasurer,,Republican,"Estes, Ron",54,000120
+DONIPHAN,White Cloud Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000130
+DONIPHAN,White Cloud Township,State Treasurer,,Republican,"Estes, Ron",56,000130
+DONIPHAN,Bendena Township,United States Senate,,independent,"Orman, Greg",33,000010
+DONIPHAN,Bendena Township,United States Senate,,Libertarian,"Batson, Randall",9,000010
+DONIPHAN,Bendena Township,United States Senate,,Republican,"Roberts, Pat",81,000010
+DONIPHAN,Blair Township,United States Senate,,independent,"Orman, Greg",17,000020
+DONIPHAN,Blair Township,United States Senate,,Libertarian,"Batson, Randall",4,000020
+DONIPHAN,Blair Township,United States Senate,,Republican,"Roberts, Pat",42,000020
+DONIPHAN,Burr Oak Township,United States Senate,,independent,"Orman, Greg",5,000030
+DONIPHAN,Burr Oak Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+DONIPHAN,Burr Oak Township,United States Senate,,Republican,"Roberts, Pat",45,000030
+DONIPHAN,Denton Township,United States Senate,,independent,"Orman, Greg",40,000040
+DONIPHAN,Denton Township,United States Senate,,Libertarian,"Batson, Randall",8,000040
+DONIPHAN,Denton Township,United States Senate,,Republican,"Roberts, Pat",88,000040
+DONIPHAN,Elwood Township,United States Senate,,independent,"Orman, Greg",67,000050
+DONIPHAN,Elwood Township,United States Senate,,Libertarian,"Batson, Randall",17,000050
+DONIPHAN,Elwood Township,United States Senate,,Republican,"Roberts, Pat",77,000050
+DONIPHAN,Highland Township,United States Senate,,independent,"Orman, Greg",98,000060
+DONIPHAN,Highland Township,United States Senate,,Libertarian,"Batson, Randall",22,000060
+DONIPHAN,Highland Township,United States Senate,,Republican,"Roberts, Pat",259,000060
+DONIPHAN,Leona Township,United States Senate,,independent,"Orman, Greg",1,000070
+DONIPHAN,Leona Township,United States Senate,,Libertarian,"Batson, Randall",2,000070
+DONIPHAN,Leona Township,United States Senate,,Republican,"Roberts, Pat",30,000070
+DONIPHAN,Marion Township,United States Senate,,independent,"Orman, Greg",16,000080
+DONIPHAN,Marion Township,United States Senate,,Libertarian,"Batson, Randall",10,000080
+DONIPHAN,Marion Township,United States Senate,,Republican,"Roberts, Pat",74,000080
+DONIPHAN,Severance Township,United States Senate,,independent,"Orman, Greg",14,000090
+DONIPHAN,Severance Township,United States Senate,,Libertarian,"Batson, Randall",6,000090
+DONIPHAN,Severance Township,United States Senate,,Republican,"Roberts, Pat",59,000090
+DONIPHAN,Troy Township,United States Senate,,independent,"Orman, Greg",117,000100
+DONIPHAN,Troy Township,United States Senate,,Libertarian,"Batson, Randall",23,000100
+DONIPHAN,Troy Township,United States Senate,,Republican,"Roberts, Pat",381,000100
+DONIPHAN,Wathena Township,United States Senate,,independent,"Orman, Greg",101,000110
+DONIPHAN,Wathena Township,United States Senate,,Libertarian,"Batson, Randall",27,000110
+DONIPHAN,Wathena Township,United States Senate,,Republican,"Roberts, Pat",315,000110
+DONIPHAN,Wayne Township,United States Senate,,independent,"Orman, Greg",12,000120
+DONIPHAN,Wayne Township,United States Senate,,Libertarian,"Batson, Randall",2,000120
+DONIPHAN,Wayne Township,United States Senate,,Republican,"Roberts, Pat",51,000120
+DONIPHAN,White Cloud Township,United States Senate,,independent,"Orman, Greg",31,000130
+DONIPHAN,White Cloud Township,United States Senate,,Libertarian,"Batson, Randall",5,000130
+DONIPHAN,White Cloud Township,United States Senate,,Republican,"Roberts, Pat",53,000130

--- a/2014/20141104__ks__general__douglas__precinct.csv
+++ b/2014/20141104__ks__general__douglas__precinct.csv
@@ -1,1912 +1,2316 @@
-county,precinct,office,district,party,candidate,votes
-Douglas,1,Voters,,,Registered,903
-Douglas,2,Voters,,,Registered,912
-Douglas,3,Voters,,,Registered,982
-Douglas,4,Voters,,,Registered,1003
-Douglas,5,Voters,,,Registered,1173
-Douglas,6,Voters,,,Registered,996
-Douglas,7,Voters,,,Registered,955
-Douglas,8,Voters,,,Registered,1033
-Douglas,9,Voters,,,Registered,798
-Douglas,10,Voters,,,Registered,1077
-Douglas,11,Voters,,,Registered,803
-Douglas,12,Voters,,,Registered,1460
-Douglas,13,Voters,,,Registered,986
-Douglas,14,Voters,,,Registered,2558
-Douglas,15,Voters,,,Registered,1418
-Douglas,16,Voters,,,Registered,1126
-Douglas,17,Voters,,,Registered,908
-Douglas,18,Voters,,,Registered,1706
-Douglas,19,Voters,,,Registered,1272
-Douglas,20,Voters,,,Registered,1752
-Douglas,21,Voters,,,Registered,745
-Douglas,22,Voters,,,Registered,1612
-Douglas,23,Voters,,,Registered,790
-Douglas,24,Voters,,,Registered,791
-Douglas,25,Voters,,,Registered,1280
-Douglas,26,Voters,,,Registered,1034
-Douglas,27,Voters,,,Registered,1004
-Douglas,28,Voters,,,Registered,521
-Douglas,29,Voters,,,Registered,884
-Douglas,30 S2,Voters,,,Registered,336
-Douglas,30 S3,Voters,,,Registered,838
-Douglas,31,Voters,,,Registered,1086
-Douglas,32,Voters,,,Registered,983
-Douglas,33,Voters,,,Registered,930
-Douglas,34 S2,Voters,,,Registered,572
-Douglas,34 S3,Voters,,,Registered,314
-Douglas,35 S2,Voters,,,Registered,1073
-Douglas,35 S3,Voters,,,Registered,65
-Douglas,36  S2,Voters,,,Registered,931
-Douglas,36  S3,Voters,,,Registered,838
-Douglas,37 H10,Voters,,,Registered,1583
-Douglas,37  H46,Voters,,,Registered,127
-Douglas,38  H10,Voters,,,Registered,1226
-Douglas,39,Voters,,,Registered,1048
-Douglas,40,Voters,,,Registered,972
-Douglas,41 S3 H46,Voters,,,Registered,1694
-Douglas,41 S3 H45,Voters,,,Registered,10
-Douglas,41 S2 H46,Voters,,,Registered,24
-Douglas,42  H46,Voters,,,Registered,479
-Douglas,42 H45,Voters,,,Registered,441
-Douglas,43  CC1,Voters,,,Registered,744
-Douglas,43  CC3,Voters,,,Registered,776
-Douglas,44  H45,Voters,,,Registered,703
-Douglas,44 H44,Voters,,,Registered,152
-Douglas,45,Voters,,,Registered,2725
-Douglas,46  S3,Voters,,,Registered,2145
-Douglas,47,Voters,,,Registered,615
-Douglas,48,Voters,,,Registered,1337
-Douglas,49,Voters,,,Registered,1301
-Douglas,70 Lawrence / Willow,Voters,,,Registered,14
-Douglas,71 Lawrence / Willow,Voters,,,Registered,1298
-Douglas,1,Voters,,,Cast,403
-Douglas,2,Voters,,,Cast,481
-Douglas,3,Voters,,,Cast,464
-Douglas,4,Voters,,,Cast,406
-Douglas,5,Voters,,,Cast,600
-Douglas,6,Voters,,,Cast,604
-Douglas,7,Voters,,,Cast,169
-Douglas,8,Voters,,,Cast,262
-Douglas,9,Voters,,,Cast,251
-Douglas,10,Voters,,,Cast,137
-Douglas,11,Voters,,,Cast,423
-Douglas,12,Voters,,,Cast,718
-Douglas,13,Voters,,,Cast,670
-Douglas,14,Voters,,,Cast,984
-Douglas,15,Voters,,,Cast,728
-Douglas,16,Voters,,,Cast,615
-Douglas,17,Voters,,,Cast,570
-Douglas,18,Voters,,,Cast,1003
-Douglas,19,Voters,,,Cast,855
-Douglas,20,Voters,,,Cast,1023
-Douglas,21,Voters,,,Cast,362
-Douglas,22,Voters,,,Cast,708
-Douglas,23,Voters,,,Cast,480
-Douglas,24,Voters,,,Cast,421
-Douglas,25,Voters,,,Cast,284
-Douglas,26,Voters,,,Cast,403
-Douglas,27,Voters,,,Cast,421
-Douglas,28,Voters,,,Cast,303
-Douglas,29,Voters,,,Cast,408
-Douglas,30 S2,Voters,,,Cast,165
-Douglas,30 S3,Voters,,,Cast,195
-Douglas,31,Voters,,,Cast,625
-Douglas,32,Voters,,,Cast,310
-Douglas,33,Voters,,,Cast,604
-Douglas,34 S2,Voters,,,Cast,356
-Douglas,34 S3,Voters,,,Cast,67
-Douglas,35 S2,Voters,,,Cast,477
-Douglas,35 S3,Voters,,,Cast,35
-Douglas,36  S2,Voters,,,Cast,402
-Douglas,36  S3,Voters,,,Cast,331
-Douglas,37 H10,Voters,,,Cast,764
-Douglas,37  H46,Voters,,,Cast,28
-Douglas,38  H10,Voters,,,Cast,632
-Douglas,39,Voters,,,Cast,528
-Douglas,40,Voters,,,Cast,485
-Douglas,41 S3 H46,Voters,,,Cast,909
-Douglas,41 S3 H45,Voters,,,Cast,1
-Douglas,41 S2 H46,Voters,,,Cast,7
-Douglas,42  H46,Voters,,,Cast,198
-Douglas,42 H45,Voters,,,Cast,239
-Douglas,43  CC1,Voters,,,Cast,419
-Douglas,43  CC3,Voters,,,Cast,438
-Douglas,44  H45,Voters,,,Cast,385
-Douglas,44 H44,Voters,,,Cast,106
-Douglas,45,Voters,,,Cast,1713
-Douglas,46  S3,Voters,,,Cast,930
-Douglas,47,Voters,,,Cast,360
-Douglas,48,Voters,,,Cast,880
-Douglas,49,Voters,,,Cast,724
-Douglas,70 Lawrence / Willow,Voters,,,Cast,10
-Douglas,71 Lawrence / Willow,Voters,,,Cast,644
-Douglas,1,U.S. Senate,,R,Pat Roberts,46
-Douglas,2,U.S. Senate,,R,Pat Roberts,52
-Douglas,3,U.S. Senate,,R,Pat Roberts,47
-Douglas,4,U.S. Senate,,R,Pat Roberts,57
-Douglas,5,U.S. Senate,,R,Pat Roberts,182
-Douglas,6,U.S. Senate,,R,Pat Roberts,190
-Douglas,7,U.S. Senate,,R,Pat Roberts,9
-Douglas,8,U.S. Senate,,R,Pat Roberts,20
-Douglas,9,U.S. Senate,,R,Pat Roberts,34
-Douglas,10,U.S. Senate,,R,Pat Roberts,20
-Douglas,11,U.S. Senate,,R,Pat Roberts,93
-Douglas,12,U.S. Senate,,R,Pat Roberts,156
-Douglas,13,U.S. Senate,,R,Pat Roberts,177
-Douglas,14,U.S. Senate,,R,Pat Roberts,276
-Douglas,15,U.S. Senate,,R,Pat Roberts,145
-Douglas,16,U.S. Senate,,R,Pat Roberts,141
-Douglas,17,U.S. Senate,,R,Pat Roberts,186
-Douglas,18,U.S. Senate,,R,Pat Roberts,299
-Douglas,19,U.S. Senate,,R,Pat Roberts,331
-Douglas,20,U.S. Senate,,R,Pat Roberts,274
-Douglas,21,U.S. Senate,,R,Pat Roberts,69
-Douglas,22,U.S. Senate,,R,Pat Roberts,189
-Douglas,23,U.S. Senate,,R,Pat Roberts,120
-Douglas,24,U.S. Senate,,R,Pat Roberts,126
-Douglas,25,U.S. Senate,,R,Pat Roberts,30
-Douglas,26,U.S. Senate,,R,Pat Roberts,40
-Douglas,27,U.S. Senate,,R,Pat Roberts,72
-Douglas,28,U.S. Senate,,R,Pat Roberts,45
-Douglas,29,U.S. Senate,,R,Pat Roberts,86
-Douglas,30 S2,U.S. Senate,,R,Pat Roberts,44
-Douglas,30 S3,U.S. Senate,,R,Pat Roberts,34
-Douglas,31,U.S. Senate,,R,Pat Roberts,164
-Douglas,32,U.S. Senate,,R,Pat Roberts,81
-Douglas,33,U.S. Senate,,R,Pat Roberts,84
-Douglas,34 S2,U.S. Senate,,R,Pat Roberts,51
-Douglas,34 S3,U.S. Senate,,R,Pat Roberts,5
-Douglas,35 S2,U.S. Senate,,R,Pat Roberts,72
-Douglas,35 S3,U.S. Senate,,R,Pat Roberts,9
-Douglas,36  S2,U.S. Senate,,R,Pat Roberts,84
-Douglas,36  S3,U.S. Senate,,R,Pat Roberts,66
-Douglas,37 H10,U.S. Senate,,R,Pat Roberts,208
-Douglas,37  H46,U.S. Senate,,R,Pat Roberts,9
-Douglas,38  H10,U.S. Senate,,R,Pat Roberts,152
-Douglas,39,U.S. Senate,,R,Pat Roberts,36
-Douglas,40,U.S. Senate,,R,Pat Roberts,20
-Douglas,41 S3 H46,U.S. Senate,,R,Pat Roberts,167
-Douglas,41 S3 H45,U.S. Senate,,R,Pat Roberts,0
-Douglas,41 S2 H46,U.S. Senate,,R,Pat Roberts,2
-Douglas,42  H46,U.S. Senate,,R,Pat Roberts,35
-Douglas,42 H45,U.S. Senate,,R,Pat Roberts,75
-Douglas,43  CC1,U.S. Senate,,R,Pat Roberts,137
-Douglas,43  CC3,U.S. Senate,,R,Pat Roberts,146
-Douglas,44  H45,U.S. Senate,,R,Pat Roberts,114
-Douglas,44 H44,U.S. Senate,,R,Pat Roberts,29
-Douglas,45,U.S. Senate,,R,Pat Roberts,583
-Douglas,46  S3,U.S. Senate,,R,Pat Roberts,245
-Douglas,47,U.S. Senate,,R,Pat Roberts,125
-Douglas,48,U.S. Senate,,R,Pat Roberts,255
-Douglas,49,U.S. Senate,,R,Pat Roberts,290
-Douglas,70 Lawrence / Willow,U.S. Senate,,R,Pat Roberts,6
-Douglas,71 Lawrence / Willow,U.S. Senate,,R,Pat Roberts,201
-Douglas,1,U.S. Senate,,D,Paul Davis,324
-Douglas,2,U.S. Senate,,D,Paul Davis,421
-Douglas,3,U.S. Senate,,D,Paul Davis,396
-Douglas,4,U.S. Senate,,D,Paul Davis,324
-Douglas,5,U.S. Senate,,D,Paul Davis,396
-Douglas,6,U.S. Senate,,D,Paul Davis,393
-Douglas,7,U.S. Senate,,D,Paul Davis,150
-Douglas,8,U.S. Senate,,D,Paul Davis,224
-Douglas,9,U.S. Senate,,D,Paul Davis,204
-Douglas,10,U.S. Senate,,D,Paul Davis,102
-Douglas,11,U.S. Senate,,D,Paul Davis,305
-Douglas,12,U.S. Senate,,D,Paul Davis,524
-Douglas,13,U.S. Senate,,D,Paul Davis,467
-Douglas,14,U.S. Senate,,D,Paul Davis,667
-Douglas,15,U.S. Senate,,D,Paul Davis,555
-Douglas,16,U.S. Senate,,D,Paul Davis,448
-Douglas,17,U.S. Senate,,D,Paul Davis,357
-Douglas,18,U.S. Senate,,D,Paul Davis,676
-Douglas,19,U.S. Senate,,D,Paul Davis,502
-Douglas,20,U.S. Senate,,D,Paul Davis,699
-Douglas,21,U.S. Senate,,D,Paul Davis,284
-Douglas,22,U.S. Senate,,D,Paul Davis,485
-Douglas,23,U.S. Senate,,D,Paul Davis,344
-Douglas,24,U.S. Senate,,D,Paul Davis,285
-Douglas,25,U.S. Senate,,D,Paul Davis,235
-Douglas,26,U.S. Senate,,D,Paul Davis,350
-Douglas,27,U.S. Senate,,D,Paul Davis,322
-Douglas,28,U.S. Senate,,D,Paul Davis,242
-Douglas,29,U.S. Senate,,D,Paul Davis,300
-Douglas,30 S2,U.S. Senate,,D,Paul Davis,112
-Douglas,30 S3,U.S. Senate,,D,Paul Davis,147
-Douglas,31,U.S. Senate,,D,Paul Davis,434
-Douglas,32,U.S. Senate,,D,Paul Davis,209
-Douglas,33,U.S. Senate,,D,Paul Davis,501
-Douglas,34 S2,U.S. Senate,,D,Paul Davis,291
-Douglas,34 S3,U.S. Senate,,D,Paul Davis,59
-Douglas,35 S2,U.S. Senate,,D,Paul Davis,361
-Douglas,35 S3,U.S. Senate,,D,Paul Davis,23
-Douglas,36  S2,U.S. Senate,,D,Paul Davis,287
-Douglas,36  S3,U.S. Senate,,D,Paul Davis,226
-Douglas,37 H10,U.S. Senate,,D,Paul Davis,497
-Douglas,37  H46,U.S. Senate,,D,Paul Davis,16
-Douglas,38  H10,U.S. Senate,,D,Paul Davis,445
-Douglas,39,U.S. Senate,,D,Paul Davis,463
-Douglas,40,U.S. Senate,,D,Paul Davis,434
-Douglas,41 S3 H46,U.S. Senate,,D,Paul Davis,685
-Douglas,41 S3 H45,U.S. Senate,,D,Paul Davis,1
-Douglas,41 S2 H46,U.S. Senate,,D,Paul Davis,5
-Douglas,42  H46,U.S. Senate,,D,Paul Davis,151
-Douglas,42 H45,U.S. Senate,,D,Paul Davis,158
-Douglas,43  CC1,U.S. Senate,,D,Paul Davis,264
-Douglas,43  CC3,U.S. Senate,,D,Paul Davis,279
-Douglas,44  H45,U.S. Senate,,D,Paul Davis,250
-Douglas,44 H44,U.S. Senate,,D,Paul Davis,69
-Douglas,45,U.S. Senate,,D,Paul Davis,1067
-Douglas,46  S3,U.S. Senate,,D,Paul Davis,641
-Douglas,47,U.S. Senate,,D,Paul Davis,227
-Douglas,48,U.S. Senate,,D,Paul Davis,601
-Douglas,49,U.S. Senate,,D,Paul Davis,411
-Douglas,70 Lawrence / Willow,U.S. Senate,,D,Paul Davis,4
-Douglas,71 Lawrence / Willow,U.S. Senate,,D,Paul Davis,424
-Douglas,1,U.S. Senate,,L,Randall Batson,25
-Douglas,2,U.S. Senate,,L,Randall Batson,7
-Douglas,3,U.S. Senate,,L,Randall Batson,15
-Douglas,4,U.S. Senate,,L,Randall Batson,19
-Douglas,5,U.S. Senate,,L,Randall Batson,17
-Douglas,6,U.S. Senate,,L,Randall Batson,14
-Douglas,7,U.S. Senate,,L,Randall Batson,7
-Douglas,8,U.S. Senate,,L,Randall Batson,11
-Douglas,9,U.S. Senate,,L,Randall Batson,9
-Douglas,10,U.S. Senate,,L,Randall Batson,11
-Douglas,11,U.S. Senate,,L,Randall Batson,16
-Douglas,12,U.S. Senate,,L,Randall Batson,29
-Douglas,13,U.S. Senate,,L,Randall Batson,15
-Douglas,14,U.S. Senate,,L,Randall Batson,25
-Douglas,15,U.S. Senate,,L,Randall Batson,18
-Douglas,16,U.S. Senate,,L,Randall Batson,18
-Douglas,17,U.S. Senate,,L,Randall Batson,19
-Douglas,18,U.S. Senate,,L,Randall Batson,19
-Douglas,19,U.S. Senate,,L,Randall Batson,12
-Douglas,20,U.S. Senate,,L,Randall Batson,37
-Douglas,21,U.S. Senate,,L,Randall Batson,4
-Douglas,22,U.S. Senate,,L,Randall Batson,22
-Douglas,23,U.S. Senate,,L,Randall Batson,11
-Douglas,24,U.S. Senate,,L,Randall Batson,8
-Douglas,25,U.S. Senate,,L,Randall Batson,11
-Douglas,26,U.S. Senate,,L,Randall Batson,9
-Douglas,27,U.S. Senate,,L,Randall Batson,21
-Douglas,28,U.S. Senate,,L,Randall Batson,10
-Douglas,29,U.S. Senate,,L,Randall Batson,14
-Douglas,30 S2,U.S. Senate,,L,Randall Batson,7
-Douglas,30 S3,U.S. Senate,,L,Randall Batson,10
-Douglas,31,U.S. Senate,,L,Randall Batson,19
-Douglas,32,U.S. Senate,,L,Randall Batson,13
-Douglas,33,U.S. Senate,,L,Randall Batson,13
-Douglas,34 S2,U.S. Senate,,L,Randall Batson,12
-Douglas,34 S3,U.S. Senate,,L,Randall Batson,3
-Douglas,35 S2,U.S. Senate,,L,Randall Batson,35
-Douglas,35 S3,U.S. Senate,,L,Randall Batson,3
-Douglas,36  S2,U.S. Senate,,L,Randall Batson,22
-Douglas,36  S3,U.S. Senate,,L,Randall Batson,35
-Douglas,37 H10,U.S. Senate,,L,Randall Batson,47
-Douglas,37  H46,U.S. Senate,,L,Randall Batson,3
-Douglas,38  H10,U.S. Senate,,L,Randall Batson,27
-Douglas,39,U.S. Senate,,L,Randall Batson,16
-Douglas,40,U.S. Senate,,L,Randall Batson,20
-Douglas,41 S3 H46,U.S. Senate,,L,Randall Batson,40
-Douglas,41 S3 H45,U.S. Senate,,L,Randall Batson,0
-Douglas,41 S2 H46,U.S. Senate,,L,Randall Batson,0
-Douglas,42  H46,U.S. Senate,,L,Randall Batson,11
-Douglas,42 H45,U.S. Senate,,L,Randall Batson,6
-Douglas,43  CC1,U.S. Senate,,L,Randall Batson,13
-Douglas,43  CC3,U.S. Senate,,L,Randall Batson,5
-Douglas,44  H45,U.S. Senate,,L,Randall Batson,17
-Douglas,44 H44,U.S. Senate,,L,Randall Batson,4
-Douglas,45,U.S. Senate,,L,Randall Batson,40
-Douglas,46  S3,U.S. Senate,,L,Randall Batson,34
-Douglas,47,U.S. Senate,,L,Randall Batson,4
-Douglas,48,U.S. Senate,,L,Randall Batson,13
-Douglas,49,U.S. Senate,,L,Randall Batson,15
-Douglas,70 Lawrence / Willow,U.S. Senate,,L,Randall Batson,0
-Douglas,71 Lawrence / Willow,U.S. Senate,,L,Randall Batson,15
-Douglas,1,U.S. House,2,R,Lynn Jenkins,63
-Douglas,2,U.S. House,2,R,Lynn Jenkins,61
-Douglas,3,U.S. House,2,R,Lynn Jenkins,53
-Douglas,4,U.S. House,2,R,Lynn Jenkins,73
-Douglas,5,U.S. House,2,R,Lynn Jenkins,216
-Douglas,6,U.S. House,2,R,Lynn Jenkins,244
-Douglas,7,U.S. House,2,R,Lynn Jenkins,12
-Douglas,8,U.S. House,2,R,Lynn Jenkins,29
-Douglas,9,U.S. House,2,R,Lynn Jenkins,43
-Douglas,10,U.S. House,2,R,Lynn Jenkins,28
-Douglas,11,U.S. House,2,R,Lynn Jenkins,106
-Douglas,12,U.S. House,2,R,Lynn Jenkins,177
-Douglas,13,U.S. House,2,R,Lynn Jenkins,208
-Douglas,14,U.S. House,2,R,Lynn Jenkins,330
-Douglas,15,U.S. House,2,R,Lynn Jenkins,159
-Douglas,16,U.S. House,2,R,Lynn Jenkins,176
-Douglas,17,U.S. House,2,R,Lynn Jenkins,214
-Douglas,18,U.S. House,2,R,Lynn Jenkins,381
-Douglas,19,U.S. House,2,R,Lynn Jenkins,397
-Douglas,20,U.S. House,2,R,Lynn Jenkins,347
-Douglas,21,U.S. House,2,R,Lynn Jenkins,84
-Douglas,22,U.S. House,2,R,Lynn Jenkins,232
-Douglas,23,U.S. House,2,R,Lynn Jenkins,143
-Douglas,24,U.S. House,2,R,Lynn Jenkins,156
-Douglas,25,U.S. House,2,R,Lynn Jenkins,40
-Douglas,26,U.S. House,2,R,Lynn Jenkins,57
-Douglas,27,U.S. House,2,R,Lynn Jenkins,80
-Douglas,28,U.S. House,2,R,Lynn Jenkins,58
-Douglas,29,U.S. House,2,R,Lynn Jenkins,88
-Douglas,30 S2,U.S. House,2,R,Lynn Jenkins,46
-Douglas,30 S3,U.S. House,2,R,Lynn Jenkins,38
-Douglas,31,U.S. House,2,R,Lynn Jenkins,186
-Douglas,32,U.S. House,2,R,Lynn Jenkins,99
-Douglas,33,U.S. House,2,R,Lynn Jenkins,94
-Douglas,34 S2,U.S. House,2,R,Lynn Jenkins,56
-Douglas,34 S3,U.S. House,2,R,Lynn Jenkins,5
-Douglas,35 S2,U.S. House,2,R,Lynn Jenkins,94
-Douglas,35 S3,U.S. House,2,R,Lynn Jenkins,10
-Douglas,36  S2,U.S. House,2,R,Lynn Jenkins,116
-Douglas,36  S3,U.S. House,2,R,Lynn Jenkins,97
-Douglas,37 H10,U.S. House,2,R,Lynn Jenkins,260
-Douglas,37  H46,U.S. House,2,R,Lynn Jenkins,12
-Douglas,38  H10,U.S. House,2,R,Lynn Jenkins,201
-Douglas,39,U.S. House,2,R,Lynn Jenkins,45
-Douglas,40,U.S. House,2,R,Lynn Jenkins,28
-Douglas,41 S3 H46,U.S. House,2,R,Lynn Jenkins,202
-Douglas,41 S3 H45,U.S. House,2,R,Lynn Jenkins,0
-Douglas,41 S2 H46,U.S. House,2,R,Lynn Jenkins,2
-Douglas,42  H46,U.S. House,2,R,Lynn Jenkins,45
-Douglas,42 H45,U.S. House,2,R,Lynn Jenkins,91
-Douglas,43  CC1,U.S. House,2,R,Lynn Jenkins,161
-Douglas,43  CC3,U.S. House,2,R,Lynn Jenkins,173
-Douglas,44  H45,U.S. House,2,R,Lynn Jenkins,149
-Douglas,44 H44,U.S. House,2,R,Lynn Jenkins,36
-Douglas,45,U.S. House,2,R,Lynn Jenkins,741
-Douglas,46  S3,U.S. House,2,R,Lynn Jenkins,328
-Douglas,47,U.S. House,2,R,Lynn Jenkins,154
-Douglas,48,U.S. House,2,R,Lynn Jenkins,320
-Douglas,49,U.S. House,2,R,Lynn Jenkins,357
-Douglas,70 Lawrence / Willow,U.S. House,2,R,Lynn Jenkins,6
-Douglas,71 Lawrence / Willow,U.S. House,2,R,Lynn Jenkins,259
-Douglas,1,U.S. House,2,D,Margie Wakefield,319
-Douglas,2,U.S. House,2,D,Margie Wakefield,411
-Douglas,3,U.S. House,2,D,Margie Wakefield,398
-Douglas,4,U.S. House,2,D,Margie Wakefield,313
-Douglas,5,U.S. House,2,D,Margie Wakefield,366
-Douglas,6,U.S. House,2,D,Margie Wakefield,341
-Douglas,7,U.S. House,2,D,Margie Wakefield,147
-Douglas,8,U.S. House,2,D,Margie Wakefield,224
-Douglas,9,U.S. House,2,D,Margie Wakefield,202
-Douglas,10,U.S. House,2,D,Margie Wakefield,90
-Douglas,11,U.S. House,2,D,Margie Wakefield,300
-Douglas,12,U.S. House,2,D,Margie Wakefield,511
-Douglas,13,U.S. House,2,D,Margie Wakefield,435
-Douglas,14,U.S. House,2,D,Margie Wakefield,612
-Douglas,15,U.S. House,2,D,Margie Wakefield,536
-Douglas,16,U.S. House,2,D,Margie Wakefield,421
-Douglas,17,U.S. House,2,D,Margie Wakefield,336
-Douglas,18,U.S. House,2,D,Margie Wakefield,585
-Douglas,19,U.S. House,2,D,Margie Wakefield,441
-Douglas,20,U.S. House,2,D,Margie Wakefield,615
-Douglas,21,U.S. House,2,D,Margie Wakefield,270
-Douglas,22,U.S. House,2,D,Margie Wakefield,435
-Douglas,23,U.S. House,2,D,Margie Wakefield,313
-Douglas,24,U.S. House,2,D,Margie Wakefield,246
-Douglas,25,U.S. House,2,D,Margie Wakefield,231
-Douglas,26,U.S. House,2,D,Margie Wakefield,328
-Douglas,27,U.S. House,2,D,Margie Wakefield,318
-Douglas,28,U.S. House,2,D,Margie Wakefield,231
-Douglas,29,U.S. House,2,D,Margie Wakefield,303
-Douglas,30 S2,U.S. House,2,D,Margie Wakefield,108
-Douglas,30 S3,U.S. House,2,D,Margie Wakefield,146
-Douglas,31,U.S. House,2,D,Margie Wakefield,413
-Douglas,32,U.S. House,2,D,Margie Wakefield,190
-Douglas,33,U.S. House,2,D,Margie Wakefield,488
-Douglas,34 S2,U.S. House,2,D,Margie Wakefield,291
-Douglas,34 S3,U.S. House,2,D,Margie Wakefield,60
-Douglas,35 S2,U.S. House,2,D,Margie Wakefield,352
-Douglas,35 S3,U.S. House,2,D,Margie Wakefield,22
-Douglas,36  S2,U.S. House,2,D,Margie Wakefield,260
-Douglas,36  S3,U.S. House,2,D,Margie Wakefield,209
-Douglas,37 H10,U.S. House,2,D,Margie Wakefield,465
-Douglas,37  H46,U.S. House,2,D,Margie Wakefield,15
-Douglas,38  H10,U.S. House,2,D,Margie Wakefield,395
-Douglas,39,U.S. House,2,D,Margie Wakefield,466
-Douglas,40,U.S. House,2,D,Margie Wakefield,442
-Douglas,41 S3 H46,U.S. House,2,D,Margie Wakefield,659
-Douglas,41 S3 H45,U.S. House,2,D,Margie Wakefield,1
-Douglas,41 S2 H46,U.S. House,2,D,Margie Wakefield,5
-Douglas,42  H46,U.S. House,2,D,Margie Wakefield,149
-Douglas,42 H45,U.S. House,2,D,Margie Wakefield,140
-Douglas,43  CC1,U.S. House,2,D,Margie Wakefield,247
-Douglas,43  CC3,U.S. House,2,D,Margie Wakefield,254
-Douglas,44  H45,U.S. House,2,D,Margie Wakefield,219
-Douglas,44 H44,U.S. House,2,D,Margie Wakefield,63
-Douglas,45,U.S. House,2,D,Margie Wakefield,916
-Douglas,46  S3,U.S. House,2,D,Margie Wakefield,565
-Douglas,47,U.S. House,2,D,Margie Wakefield,197
-Douglas,48,U.S. House,2,D,Margie Wakefield,536
-Douglas,49,U.S. House,2,D,Margie Wakefield,346
-Douglas,70 Lawrence / Willow,U.S. House,2,D,Margie Wakefield,4
-Douglas,71 Lawrence / Willow,U.S. House,2,D,Margie Wakefield,370
-Douglas,1,U.S. House,2,L,Chris Clemmons,16
-Douglas,2,U.S. House,2,L,Chris Clemmons,7
-Douglas,3,U.S. House,2,L,Chris Clemmons,8
-Douglas,4,U.S. House,2,L,Chris Clemmons,15
-Douglas,5,U.S. House,2,L,Chris Clemmons,15
-Douglas,6,U.S. House,2,L,Chris Clemmons,15
-Douglas,7,U.S. House,2,L,Chris Clemmons,7
-Douglas,8,U.S. House,2,L,Chris Clemmons,5
-Douglas,9,U.S. House,2,L,Chris Clemmons,3
-Douglas,10,U.S. House,2,L,Chris Clemmons,15
-Douglas,11,U.S. House,2,L,Chris Clemmons,9
-Douglas,12,U.S. House,2,L,Chris Clemmons,26
-Douglas,13,U.S. House,2,L,Chris Clemmons,13
-Douglas,14,U.S. House,2,L,Chris Clemmons,27
-Douglas,15,U.S. House,2,L,Chris Clemmons,27
-Douglas,16,U.S. House,2,L,Chris Clemmons,15
-Douglas,17,U.S. House,2,L,Chris Clemmons,14
-Douglas,18,U.S. House,2,L,Chris Clemmons,24
-Douglas,19,U.S. House,2,L,Chris Clemmons,11
-Douglas,20,U.S. House,2,L,Chris Clemmons,43
-Douglas,21,U.S. House,2,L,Chris Clemmons,4
-Douglas,22,U.S. House,2,L,Chris Clemmons,34
-Douglas,23,U.S. House,2,L,Chris Clemmons,15
-Douglas,24,U.S. House,2,L,Chris Clemmons,14
-Douglas,25,U.S. House,2,L,Chris Clemmons,8
-Douglas,26,U.S. House,2,L,Chris Clemmons,10
-Douglas,27,U.S. House,2,L,Chris Clemmons,18
-Douglas,28,U.S. House,2,L,Chris Clemmons,10
-Douglas,29,U.S. House,2,L,Chris Clemmons,9
-Douglas,30 S2,U.S. House,2,L,Chris Clemmons,9
-Douglas,30 S3,U.S. House,2,L,Chris Clemmons,9
-Douglas,31,U.S. House,2,L,Chris Clemmons,19
-Douglas,32,U.S. House,2,L,Chris Clemmons,14
-Douglas,33,U.S. House,2,L,Chris Clemmons,15
-Douglas,34 S2,U.S. House,2,L,Chris Clemmons,6
-Douglas,34 S3,U.S. House,2,L,Chris Clemmons,2
-Douglas,35 S2,U.S. House,2,L,Chris Clemmons,24
-Douglas,35 S3,U.S. House,2,L,Chris Clemmons,3
-Douglas,36  S2,U.S. House,2,L,Chris Clemmons,18
-Douglas,36  S3,U.S. House,2,L,Chris Clemmons,17
-Douglas,37 H10,U.S. House,2,L,Chris Clemmons,31
-Douglas,37  H46,U.S. House,2,L,Chris Clemmons,1
-Douglas,38  H10,U.S. House,2,L,Chris Clemmons,26
-Douglas,39,U.S. House,2,L,Chris Clemmons,12
-Douglas,40,U.S. House,2,L,Chris Clemmons,11
-Douglas,41 S3 H46,U.S. House,2,L,Chris Clemmons,37
-Douglas,41 S3 H45,U.S. House,2,L,Chris Clemmons,0
-Douglas,41 S2 H46,U.S. House,2,L,Chris Clemmons,0
-Douglas,42  H46,U.S. House,2,L,Chris Clemmons,4
-Douglas,42 H45,U.S. House,2,L,Chris Clemmons,7
-Douglas,43  CC1,U.S. House,2,L,Chris Clemmons,9
-Douglas,43  CC3,U.S. House,2,L,Chris Clemmons,8
-Douglas,44  H45,U.S. House,2,L,Chris Clemmons,11
-Douglas,44 H44,U.S. House,2,L,Chris Clemmons,5
-Douglas,45,U.S. House,2,L,Chris Clemmons,36
-Douglas,46  S3,U.S. House,2,L,Chris Clemmons,27
-Douglas,47,U.S. House,2,L,Chris Clemmons,5
-Douglas,48,U.S. House,2,L,Chris Clemmons,13
-Douglas,49,U.S. House,2,L,Chris Clemmons,14
-Douglas,70 Lawrence / Willow,U.S. House,2,L,Chris Clemmons,0
-Douglas,71 Lawrence / Willow,U.S. House,2,L,Chris Clemmons,11
-Douglas,1,Governor,,R,Sam Brownback,346
-Douglas,2,Governor,,R,Sam Brownback,425
-Douglas,3,Governor,,R,Sam Brownback,411
-Douglas,4,Governor,,R,Sam Brownback,341
-Douglas,5,Governor,,R,Sam Brownback,436
-Douglas,6,Governor,,R,Sam Brownback,424
-Douglas,7,Governor,,R,Sam Brownback,156
-Douglas,8,Governor,,R,Sam Brownback,235
-Douglas,9,Governor,,R,Sam Brownback,221
-Douglas,10,Governor,,R,Sam Brownback,109
-Douglas,11,Governor,,R,Sam Brownback,342
-Douglas,12,Governor,,R,Sam Brownback,568
-Douglas,13,Governor,,R,Sam Brownback,508
-Douglas,14,Governor,,R,Sam Brownback,716
-Douglas,15,Governor,,R,Sam Brownback,592
-Douglas,16,Governor,,R,Sam Brownback,479
-Douglas,17,Governor,,R,Sam Brownback,392
-Douglas,18,Governor,,R,Sam Brownback,724
-Douglas,19,Governor,,R,Sam Brownback,561
-Douglas,20,Governor,,R,Sam Brownback,757
-Douglas,21,Governor,,R,Sam Brownback,297
-Douglas,22,Governor,,R,Sam Brownback,517
-Douglas,23,Governor,,R,Sam Brownback,362
-Douglas,24,Governor,,R,Sam Brownback,306
-Douglas,25,Governor,,R,Sam Brownback,255
-Douglas,26,Governor,,R,Sam Brownback,357
-Douglas,27,Governor,,R,Sam Brownback,341
-Douglas,28,Governor,,R,Sam Brownback,265
-Douglas,29,Governor,,R,Sam Brownback,329
-Douglas,30 S2,Governor,,R,Sam Brownback,129
-Douglas,30 S3,Governor,,R,Sam Brownback,161
-Douglas,31,Governor,,R,Sam Brownback,472
-Douglas,32,Governor,,R,Sam Brownback,220
-Douglas,33,Governor,,R,Sam Brownback,524
-Douglas,34 S2,Governor,,R,Sam Brownback,309
-Douglas,34 S3,Governor,,R,Sam Brownback,59
-Douglas,35 S2,Governor,,R,Sam Brownback,398
-Douglas,35 S3,Governor,,R,Sam Brownback,29
-Douglas,36  S2,Governor,,R,Sam Brownback,311
-Douglas,36  S3,Governor,,R,Sam Brownback,238
-Douglas,37 H10,Governor,,R,Sam Brownback,557
-Douglas,37  H46,Governor,,R,Sam Brownback,19
-Douglas,38  H10,Governor,,R,Sam Brownback,482
-Douglas,39,Governor,,R,Sam Brownback,496
-Douglas,40,Governor,,R,Sam Brownback,467
-Douglas,41 S3 H46,Governor,,R,Sam Brownback,729
-Douglas,41 S3 H45,Governor,,R,Sam Brownback,1
-Douglas,41 S2 H46,Governor,,R,Sam Brownback,6
-Douglas,42  H46,Governor,,R,Sam Brownback,163
-Douglas,42 H45,Governor,,R,Sam Brownback,172
-Douglas,43  CC1,Governor,,R,Sam Brownback,292
-Douglas,43  CC3,Governor,,R,Sam Brownback,298
-Douglas,44  H45,Governor,,R,Sam Brownback,276
-Douglas,44 H44,Governor,,R,Sam Brownback,80
-Douglas,45,Governor,,R,Sam Brownback,1185
-Douglas,46  S3,Governor,,R,Sam Brownback,693
-Douglas,47,Governor,,R,Sam Brownback,251
-Douglas,48,Governor,,R,Sam Brownback,650
-Douglas,49,Governor,,R,Sam Brownback,454
-Douglas,70 Lawrence / Willow,Governor,,R,Sam Brownback,7
-Douglas,71 Lawrence / Willow,Governor,,R,Sam Brownback,469
-Douglas,1,Governor,,D,Paul Davis,39
-Douglas,2,Governor,,D,Paul Davis,50
-Douglas,3,Governor,,D,Paul Davis,46
-Douglas,4,Governor,,D,Paul Davis,45
-Douglas,5,Governor,,D,Paul Davis,146
-Douglas,6,Governor,,D,Paul Davis,164
-Douglas,7,Governor,,D,Paul Davis,7
-Douglas,8,Governor,,D,Paul Davis,19
-Douglas,9,Governor,,D,Paul Davis,26
-Douglas,10,Governor,,D,Paul Davis,15
-Douglas,11,Governor,,D,Paul Davis,71
-Douglas,12,Governor,,D,Paul Davis,128
-Douglas,13,Governor,,D,Paul Davis,144
-Douglas,14,Governor,,D,Paul Davis,218
-Douglas,15,Governor,,D,Paul Davis,115
-Douglas,16,Governor,,D,Paul Davis,122
-Douglas,17,Governor,,D,Paul Davis,168
-Douglas,18,Governor,,D,Paul Davis,259
-Douglas,19,Governor,,D,Paul Davis,277
-Douglas,20,Governor,,D,Paul Davis,228
-Douglas,21,Governor,,D,Paul Davis,52
-Douglas,22,Governor,,D,Paul Davis,169
-Douglas,23,Governor,,D,Paul Davis,99
-Douglas,24,Governor,,D,Paul Davis,106
-Douglas,25,Governor,,D,Paul Davis,23
-Douglas,26,Governor,,D,Paul Davis,37
-Douglas,27,Governor,,D,Paul Davis,64
-Douglas,28,Governor,,D,Paul Davis,30
-Douglas,29,Governor,,D,Paul Davis,66
-Douglas,30 S2,Governor,,D,Paul Davis,29
-Douglas,30 S3,Governor,,D,Paul Davis,27
-Douglas,31,Governor,,D,Paul Davis,132
-Douglas,32,Governor,,D,Paul Davis,72
-Douglas,33,Governor,,D,Paul Davis,67
-Douglas,34 S2,Governor,,D,Paul Davis,44
-Douglas,34 S3,Governor,,D,Paul Davis,4
-Douglas,35 S2,Governor,,D,Paul Davis,57
-Douglas,35 S3,Governor,,D,Paul Davis,5
-Douglas,36  S2,Governor,,D,Paul Davis,79
-Douglas,36  S3,Governor,,D,Paul Davis,71
-Douglas,37 H10,Governor,,D,Paul Davis,180
-Douglas,37  H46,Governor,,D,Paul Davis,9
-Douglas,38  H10,Governor,,D,Paul Davis,130
-Douglas,39,Governor,,D,Paul Davis,27
-Douglas,40,Governor,,D,Paul Davis,11
-Douglas,41 S3 H46,Governor,,D,Paul Davis,142
-Douglas,41 S3 H45,Governor,,D,Paul Davis,0
-Douglas,41 S2 H46,Governor,,D,Paul Davis,1
-Douglas,42  H46,Governor,,D,Paul Davis,30
-Douglas,42 H45,Governor,,D,Paul Davis,54
-Douglas,43  CC1,Governor,,D,Paul Davis,118
-Douglas,43  CC3,Governor,,D,Paul Davis,127
-Douglas,44  H45,Governor,,D,Paul Davis,98
-Douglas,44 H44,Governor,,D,Paul Davis,22
-Douglas,45,Governor,,D,Paul Davis,484
-Douglas,46  S3,Governor,,D,Paul Davis,213
-Douglas,47,Governor,,D,Paul Davis,103
-Douglas,48,Governor,,D,Paul Davis,211
-Douglas,49,Governor,,D,Paul Davis,250
-Douglas,70 Lawrence / Willow,Governor,,D,Paul Davis,3
-Douglas,71 Lawrence / Willow,Governor,,D,Paul Davis,167
-Douglas,1,Governor,,L,Keen Umbehr,13
-Douglas,2,Governor,,L,Keen Umbehr,5
-Douglas,3,Governor,,L,Keen Umbehr,5
-Douglas,4,Governor,,L,Keen Umbehr,16
-Douglas,5,Governor,,L,Keen Umbehr,14
-Douglas,6,Governor,,L,Keen Umbehr,10
-Douglas,7,Governor,,L,Keen Umbehr,6
-Douglas,8,Governor,,L,Keen Umbehr,7
-Douglas,9,Governor,,L,Keen Umbehr,3
-Douglas,10,Governor,,L,Keen Umbehr,10
-Douglas,11,Governor,,L,Keen Umbehr,6
-Douglas,12,Governor,,L,Keen Umbehr,18
-Douglas,13,Governor,,L,Keen Umbehr,11
-Douglas,14,Governor,,L,Keen Umbehr,37
-Douglas,15,Governor,,L,Keen Umbehr,14
-Douglas,16,Governor,,L,Keen Umbehr,10
-Douglas,17,Governor,,L,Keen Umbehr,7
-Douglas,18,Governor,,L,Keen Umbehr,16
-Douglas,19,Governor,,L,Keen Umbehr,7
-Douglas,20,Governor,,L,Keen Umbehr,32
-Douglas,21,Governor,,L,Keen Umbehr,7
-Douglas,22,Governor,,L,Keen Umbehr,19
-Douglas,23,Governor,,L,Keen Umbehr,9
-Douglas,24,Governor,,L,Keen Umbehr,7
-Douglas,25,Governor,,L,Keen Umbehr,5
-Douglas,26,Governor,,L,Keen Umbehr,8
-Douglas,27,Governor,,L,Keen Umbehr,12
-Douglas,28,Governor,,L,Keen Umbehr,6
-Douglas,29,Governor,,L,Keen Umbehr,9
-Douglas,30 S2,Governor,,L,Keen Umbehr,6
-Douglas,30 S3,Governor,,L,Keen Umbehr,6
-Douglas,31,Governor,,L,Keen Umbehr,15
-Douglas,32,Governor,,L,Keen Umbehr,13
-Douglas,33,Governor,,L,Keen Umbehr,9
-Douglas,34 S2,Governor,,L,Keen Umbehr,2
-Douglas,34 S3,Governor,,L,Keen Umbehr,4
-Douglas,35 S2,Governor,,L,Keen Umbehr,16
-Douglas,35 S3,Governor,,L,Keen Umbehr,1
-Douglas,36  S2,Governor,,L,Keen Umbehr,11
-Douglas,36  S3,Governor,,L,Keen Umbehr,18
-Douglas,37 H10,Governor,,L,Keen Umbehr,24
-Douglas,37  H46,Governor,,L,Keen Umbehr,0
-Douglas,38  H10,Governor,,L,Keen Umbehr,13
-Douglas,39,Governor,,L,Keen Umbehr,5
-Douglas,40,Governor,,L,Keen Umbehr,4
-Douglas,41 S3 H46,Governor,,L,Keen Umbehr,30
-Douglas,41 S3 H45,Governor,,L,Keen Umbehr,0
-Douglas,41 S2 H46,Governor,,L,Keen Umbehr,0
-Douglas,42  H46,Governor,,L,Keen Umbehr,3
-Douglas,42 H45,Governor,,L,Keen Umbehr,10
-Douglas,43  CC1,Governor,,L,Keen Umbehr,7
-Douglas,43  CC3,Governor,,L,Keen Umbehr,13
-Douglas,44  H45,Governor,,L,Keen Umbehr,7
-Douglas,44 H44,Governor,,L,Keen Umbehr,3
-Douglas,45,Governor,,L,Keen Umbehr,30
-Douglas,46  S3,Governor,,L,Keen Umbehr,20
-Douglas,47,Governor,,L,Keen Umbehr,4
-Douglas,48,Governor,,L,Keen Umbehr,10
-Douglas,49,Governor,,L,Keen Umbehr,14
-Douglas,70 Lawrence / Willow,Governor,,L,Keen Umbehr,0
-Douglas,71 Lawrence / Willow,Governor,,L,Keen Umbehr,6
-Douglas,1,Secretary of State,,R,Kris Kobach,61
-Douglas,2,Secretary of State,,R,Kris Kobach,62
-Douglas,3,Secretary of State,,R,Kris Kobach,48
-Douglas,4,Secretary of State,,R,Kris Kobach,68
-Douglas,5,Secretary of State,,R,Kris Kobach,202
-Douglas,6,Secretary of State,,R,Kris Kobach,212
-Douglas,7,Secretary of State,,R,Kris Kobach,9
-Douglas,8,Secretary of State,,R,Kris Kobach,28
-Douglas,9,Secretary of State,,R,Kris Kobach,38
-Douglas,10,Secretary of State,,R,Kris Kobach,30
-Douglas,11,Secretary of State,,R,Kris Kobach,105
-Douglas,12,Secretary of State,,R,Kris Kobach,178
-Douglas,13,Secretary of State,,R,Kris Kobach,178
-Douglas,14,Secretary of State,,R,Kris Kobach,318
-Douglas,15,Secretary of State,,R,Kris Kobach,153
-Douglas,16,Secretary of State,,R,Kris Kobach,164
-Douglas,17,Secretary of State,,R,Kris Kobach,206
-Douglas,18,Secretary of State,,R,Kris Kobach,341
-Douglas,19,Secretary of State,,R,Kris Kobach,329
-Douglas,20,Secretary of State,,R,Kris Kobach,336
-Douglas,21,Secretary of State,,R,Kris Kobach,57
-Douglas,22,Secretary of State,,R,Kris Kobach,223
-Douglas,23,Secretary of State,,R,Kris Kobach,130
-Douglas,24,Secretary of State,,R,Kris Kobach,134
-Douglas,25,Secretary of State,,R,Kris Kobach,33
-Douglas,26,Secretary of State,,R,Kris Kobach,54
-Douglas,27,Secretary of State,,R,Kris Kobach,78
-Douglas,28,Secretary of State,,R,Kris Kobach,51
-Douglas,29,Secretary of State,,R,Kris Kobach,81
-Douglas,30 S2,Secretary of State,,R,Kris Kobach,45
-Douglas,30 S3,Secretary of State,,R,Kris Kobach,37
-Douglas,31,Secretary of State,,R,Kris Kobach,174
-Douglas,32,Secretary of State,,R,Kris Kobach,95
-Douglas,33,Secretary of State,,R,Kris Kobach,92
-Douglas,34 S2,Secretary of State,,R,Kris Kobach,51
-Douglas,34 S3,Secretary of State,,R,Kris Kobach,4
-Douglas,35 S2,Secretary of State,,R,Kris Kobach,104
-Douglas,35 S3,Secretary of State,,R,Kris Kobach,9
-Douglas,36  S2,Secretary of State,,R,Kris Kobach,109
-Douglas,36  S3,Secretary of State,,R,Kris Kobach,107
-Douglas,37 H10,Secretary of State,,R,Kris Kobach,256
-Douglas,37  H46,Secretary of State,,R,Kris Kobach,11
-Douglas,38  H10,Secretary of State,,R,Kris Kobach,194
-Douglas,39,Secretary of State,,R,Kris Kobach,36
-Douglas,40,Secretary of State,,R,Kris Kobach,30
-Douglas,41 S3 H46,Secretary of State,,R,Kris Kobach,194
-Douglas,41 S3 H45,Secretary of State,,R,Kris Kobach,0
-Douglas,41 S2 H46,Secretary of State,,R,Kris Kobach,3
-Douglas,42  H46,Secretary of State,,R,Kris Kobach,47
-Douglas,42 H45,Secretary of State,,R,Kris Kobach,85
-Douglas,43  CC1,Secretary of State,,R,Kris Kobach,145
-Douglas,43  CC3,Secretary of State,,R,Kris Kobach,161
-Douglas,44  H45,Secretary of State,,R,Kris Kobach,133
-Douglas,44 H44,Secretary of State,,R,Kris Kobach,32
-Douglas,45,Secretary of State,,R,Kris Kobach,681
-Douglas,46  S3,Secretary of State,,R,Kris Kobach,317
-Douglas,47,Secretary of State,,R,Kris Kobach,135
-Douglas,48,Secretary of State,,R,Kris Kobach,258
-Douglas,49,Secretary of State,,R,Kris Kobach,312
-Douglas,70 Lawrence / Willow,Secretary of State,,R,Kris Kobach,6
-Douglas,71 Lawrence / Willow,Secretary of State,,R,Kris Kobach,232
-Douglas,1,Secretary of State,,D,Jean Schodorf,333
-Douglas,2,Secretary of State,,D,Jean Schodorf,413
-Douglas,3,Secretary of State,,D,Jean Schodorf,406
-Douglas,4,Secretary of State,,D,Jean Schodorf,333
-Douglas,5,Secretary of State,,D,Jean Schodorf,382
-Douglas,6,Secretary of State,,D,Jean Schodorf,377
-Douglas,7,Secretary of State,,D,Jean Schodorf,157
-Douglas,8,Secretary of State,,D,Jean Schodorf,225
-Douglas,9,Secretary of State,,D,Jean Schodorf,210
-Douglas,10,Secretary of State,,D,Jean Schodorf,100
-Douglas,11,Secretary of State,,D,Jean Schodorf,307
-Douglas,12,Secretary of State,,D,Jean Schodorf,527
-Douglas,13,Secretary of State,,D,Jean Schodorf,471
-Douglas,14,Secretary of State,,D,Jean Schodorf,645
-Douglas,15,Secretary of State,,D,Jean Schodorf,562
-Douglas,16,Secretary of State,,D,Jean Schodorf,438
-Douglas,17,Secretary of State,,D,Jean Schodorf,354
-Douglas,18,Secretary of State,,D,Jean Schodorf,642
-Douglas,19,Secretary of State,,D,Jean Schodorf,510
-Douglas,20,Secretary of State,,D,Jean Schodorf,659
-Douglas,21,Secretary of State,,D,Jean Schodorf,293
-Douglas,22,Secretary of State,,D,Jean Schodorf,473
-Douglas,23,Secretary of State,,D,Jean Schodorf,328
-Douglas,24,Secretary of State,,D,Jean Schodorf,274
-Douglas,25,Secretary of State,,D,Jean Schodorf,239
-Douglas,26,Secretary of State,,D,Jean Schodorf,337
-Douglas,27,Secretary of State,,D,Jean Schodorf,332
-Douglas,28,Secretary of State,,D,Jean Schodorf,245
-Douglas,29,Secretary of State,,D,Jean Schodorf,315
-Douglas,30 S2,Secretary of State,,D,Jean Schodorf,115
-Douglas,30 S3,Secretary of State,,D,Jean Schodorf,152
-Douglas,31,Secretary of State,,D,Jean Schodorf,437
-Douglas,32,Secretary of State,,D,Jean Schodorf,203
-Douglas,33,Secretary of State,,D,Jean Schodorf,497
-Douglas,34 S2,Secretary of State,,D,Jean Schodorf,300
-Douglas,34 S3,Secretary of State,,D,Jean Schodorf,62
-Douglas,35 S2,Secretary of State,,D,Jean Schodorf,359
-Douglas,35 S3,Secretary of State,,D,Jean Schodorf,26
-Douglas,36  S2,Secretary of State,,D,Jean Schodorf,287
-Douglas,36  S3,Secretary of State,,D,Jean Schodorf,211
-Douglas,37 H10,Secretary of State,,D,Jean Schodorf,496
-Douglas,37  H46,Secretary of State,,D,Jean Schodorf,17
-Douglas,38  H10,Secretary of State,,D,Jean Schodorf,416
-Douglas,39,Secretary of State,,D,Jean Schodorf,481
-Douglas,40,Secretary of State,,D,Jean Schodorf,447
-Douglas,41 S3 H46,Secretary of State,,D,Jean Schodorf,688
-Douglas,41 S3 H45,Secretary of State,,D,Jean Schodorf,1
-Douglas,41 S2 H46,Secretary of State,,D,Jean Schodorf,4
-Douglas,42  H46,Secretary of State,,D,Jean Schodorf,147
-Douglas,42 H45,Secretary of State,,D,Jean Schodorf,152
-Douglas,43  CC1,Secretary of State,,D,Jean Schodorf,264
-Douglas,43  CC3,Secretary of State,,D,Jean Schodorf,266
-Douglas,44  H45,Secretary of State,,D,Jean Schodorf,243
-Douglas,44 H44,Secretary of State,,D,Jean Schodorf,68
-Douglas,45,Secretary of State,,D,Jean Schodorf,989
-Douglas,46  S3,Secretary of State,,D,Jean Schodorf,595
-Douglas,47,Secretary of State,,D,Jean Schodorf,214
-Douglas,48,Secretary of State,,D,Jean Schodorf,599
-Douglas,49,Secretary of State,,D,Jean Schodorf,398
-Douglas,70 Lawrence / Willow,Secretary of State,,D,Jean Schodorf,0
-Douglas,71 Lawrence / Willow,Secretary of State,,D,Jean Schodorf,406
-Douglas,1,Attorney General,,D,A J Kortich,306
-Douglas,2,Attorney General,,D,A J Kortich,379
-Douglas,3,Attorney General,,D,A J Kortich,361
-Douglas,4,Attorney General,,D,A J Kortich,297
-Douglas,5,Attorney General,,D,A J Kortich,339
-Douglas,6,Attorney General,,D,A J Kortich,334
-Douglas,7,Attorney General,,D,A J Kortich,138
-Douglas,8,Attorney General,,D,A J Kortich,209
-Douglas,9,Attorney General,,D,A J Kortich,191
-Douglas,10,Attorney General,,D,A J Kortich,90
-Douglas,11,Attorney General,,D,A J Kortich,280
-Douglas,12,Attorney General,,D,A J Kortich,480
-Douglas,13,Attorney General,,D,A J Kortich,388
-Douglas,14,Attorney General,,D,A J Kortich,576
-Douglas,15,Attorney General,,D,A J Kortich,489
-Douglas,16,Attorney General,,D,A J Kortich,375
-Douglas,17,Attorney General,,D,A J Kortich,313
-Douglas,18,Attorney General,,D,A J Kortich,535
-Douglas,19,Attorney General,,D,A J Kortich,384
-Douglas,20,Attorney General,,D,A J Kortich,579
-Douglas,21,Attorney General,,D,A J Kortich,246
-Douglas,22,Attorney General,,D,A J Kortich,425
-Douglas,23,Attorney General,,D,A J Kortich,282
-Douglas,24,Attorney General,,D,A J Kortich,220
-Douglas,25,Attorney General,,D,A J Kortich,214
-Douglas,26,Attorney General,,D,A J Kortich,304
-Douglas,27,Attorney General,,D,A J Kortich,305
-Douglas,28,Attorney General,,D,A J Kortich,215
-Douglas,29,Attorney General,,D,A J Kortich,295
-Douglas,30 S2,Attorney General,,D,A J Kortich,109
-Douglas,30 S3,Attorney General,,D,A J Kortich,133
-Douglas,31,Attorney General,,D,A J Kortich,381
-Douglas,32,Attorney General,,D,A J Kortich,178
-Douglas,33,Attorney General,,D,A J Kortich,458
-Douglas,34 S2,Attorney General,,D,A J Kortich,271
-Douglas,34 S3,Attorney General,,D,A J Kortich,58
-Douglas,35 S2,Attorney General,,D,A J Kortich,357
-Douglas,35 S3,Attorney General,,D,A J Kortich,23
-Douglas,36  S2,Attorney General,,D,A J Kortich,253
-Douglas,36  S3,Attorney General,,D,A J Kortich,194
-Douglas,37 H10,Attorney General,,D,A J Kortich,466
-Douglas,37  H46,Attorney General,,D,A J Kortich,17
-Douglas,38  H10,Attorney General,,D,A J Kortich,371
-Douglas,39,Attorney General,,D,A J Kortich,446
-Douglas,40,Attorney General,,D,A J Kortich,424
-Douglas,41 S3 H46,Attorney General,,D,A J Kortich,632
-Douglas,41 S3 H45,Attorney General,,D,A J Kortich,1
-Douglas,41 S2 H46,Attorney General,,D,A J Kortich,5
-Douglas,42  H46,Attorney General,,D,A J Kortich,137
-Douglas,42 H45,Attorney General,,D,A J Kortich,142
-Douglas,43  CC1,Attorney General,,D,A J Kortich,213
-Douglas,43  CC3,Attorney General,,D,A J Kortich,225
-Douglas,44  H45,Attorney General,,D,A J Kortich,206
-Douglas,44 H44,Attorney General,,D,A J Kortich,60
-Douglas,45,Attorney General,,D,A J Kortich,829
-Douglas,46  S3,Attorney General,,D,A J Kortich,512
-Douglas,47,Attorney General,,D,A J Kortich,168
-Douglas,48,Attorney General,,D,A J Kortich,492
-Douglas,49,Attorney General,,D,A J Kortich,324
-Douglas,70 Lawrence / Willow,Attorney General,,D,A J Kortich,1
-Douglas,71 Lawrence / Willow,Attorney General,,D,A J Kortich,342
-Douglas,1,Attorney General,,R,Derek Schmidt,75
-Douglas,2,Attorney General,,R,Derek Schmidt,79
-Douglas,3,Attorney General,,R,Derek Schmidt,76
-Douglas,4,Attorney General,,R,Derek Schmidt,84
-Douglas,5,Attorney General,,R,Derek Schmidt,233
-Douglas,6,Attorney General,,R,Derek Schmidt,244
-Douglas,7,Attorney General,,R,Derek Schmidt,21
-Douglas,8,Attorney General,,R,Derek Schmidt,37
-Douglas,9,Attorney General,,R,Derek Schmidt,53
-Douglas,10,Attorney General,,R,Derek Schmidt,35
-Douglas,11,Attorney General,,R,Derek Schmidt,120
-Douglas,12,Attorney General,,R,Derek Schmidt,207
-Douglas,13,Attorney General,,R,Derek Schmidt,247
-Douglas,14,Attorney General,,R,Derek Schmidt,358
-Douglas,15,Attorney General,,R,Derek Schmidt,204
-Douglas,16,Attorney General,,R,Derek Schmidt,204
-Douglas,17,Attorney General,,R,Derek Schmidt,236
-Douglas,18,Attorney General,,R,Derek Schmidt,407
-Douglas,19,Attorney General,,R,Derek Schmidt,417
-Douglas,20,Attorney General,,R,Derek Schmidt,387
-Douglas,21,Attorney General,,R,Derek Schmidt,91
-Douglas,22,Attorney General,,R,Derek Schmidt,255
-Douglas,23,Attorney General,,R,Derek Schmidt,156
-Douglas,24,Attorney General,,R,Derek Schmidt,178
-Douglas,25,Attorney General,,R,Derek Schmidt,49
-Douglas,26,Attorney General,,R,Derek Schmidt,73
-Douglas,27,Attorney General,,R,Derek Schmidt,95
-Douglas,28,Attorney General,,R,Derek Schmidt,71
-Douglas,29,Attorney General,,R,Derek Schmidt,93
-Douglas,30 S2,Attorney General,,R,Derek Schmidt,45
-Douglas,30 S3,Attorney General,,R,Derek Schmidt,51
-Douglas,31,Attorney General,,R,Derek Schmidt,207
-Douglas,32,Attorney General,,R,Derek Schmidt,108
-Douglas,33,Attorney General,,R,Derek Schmidt,114
-Douglas,34 S2,Attorney General,,R,Derek Schmidt,72
-Douglas,34 S3,Attorney General,,R,Derek Schmidt,9
-Douglas,35 S2,Attorney General,,R,Derek Schmidt,96
-Douglas,35 S3,Attorney General,,R,Derek Schmidt,12
-Douglas,36  S2,Attorney General,,R,Derek Schmidt,126
-Douglas,36  S3,Attorney General,,R,Derek Schmidt,119
-Douglas,37 H10,Attorney General,,R,Derek Schmidt,266
-Douglas,37  H46,Attorney General,,R,Derek Schmidt,11
-Douglas,38  H10,Attorney General,,R,Derek Schmidt,223
-Douglas,39,Attorney General,,R,Derek Schmidt,55
-Douglas,40,Attorney General,,R,Derek Schmidt,39
-Douglas,41 S3 H46,Attorney General,,R,Derek Schmidt,220
-Douglas,41 S3 H45,Attorney General,,R,Derek Schmidt,0
-Douglas,41 S2 H46,Attorney General,,R,Derek Schmidt,2
-Douglas,42  H46,Attorney General,,R,Derek Schmidt,49
-Douglas,42 H45,Attorney General,,R,Derek Schmidt,90
-Douglas,43  CC1,Attorney General,,R,Derek Schmidt,182
-Douglas,43  CC3,Attorney General,,R,Derek Schmidt,190
-Douglas,44  H45,Attorney General,,R,Derek Schmidt,156
-Douglas,44 H44,Attorney General,,R,Derek Schmidt,36
-Douglas,45,Attorney General,,R,Derek Schmidt,784
-Douglas,46  S3,Attorney General,,R,Derek Schmidt,364
-Douglas,47,Attorney General,,R,Derek Schmidt,172
-Douglas,48,Attorney General,,R,Derek Schmidt,333
-Douglas,49,Attorney General,,R,Derek Schmidt,366
-Douglas,70 Lawrence / Willow,Attorney General,,R,Derek Schmidt,5
-Douglas,71 Lawrence / Willow,Attorney General,,R,Derek Schmidt,282
-Douglas,1,State Treasurer,,D,Carmen Alldritt,300
-Douglas,2,State Treasurer,,D,Carmen Alldritt,385
-Douglas,3,State Treasurer,,D,Carmen Alldritt,365
-Douglas,4,State Treasurer,,D,Carmen Alldritt,308
-Douglas,5,State Treasurer,,D,Carmen Alldritt,323
-Douglas,6,State Treasurer,,D,Carmen Alldritt,318
-Douglas,7,State Treasurer,,D,Carmen Alldritt,135
-Douglas,8,State Treasurer,,D,Carmen Alldritt,208
-Douglas,9,State Treasurer,,D,Carmen Alldritt,194
-Douglas,10,State Treasurer,,D,Carmen Alldritt,88
-Douglas,11,State Treasurer,,D,Carmen Alldritt,278
-Douglas,12,State Treasurer,,D,Carmen Alldritt,483
-Douglas,13,State Treasurer,,D,Carmen Alldritt,392
-Douglas,14,State Treasurer,,D,Carmen Alldritt,579
-Douglas,15,State Treasurer,,D,Carmen Alldritt,489
-Douglas,16,State Treasurer,,D,Carmen Alldritt,396
-Douglas,17,State Treasurer,,D,Carmen Alldritt,304
-Douglas,18,State Treasurer,,D,Carmen Alldritt,542
-Douglas,19,State Treasurer,,D,Carmen Alldritt,394
-Douglas,20,State Treasurer,,D,Carmen Alldritt,573
-Douglas,21,State Treasurer,,D,Carmen Alldritt,251
-Douglas,22,State Treasurer,,D,Carmen Alldritt,425
-Douglas,23,State Treasurer,,D,Carmen Alldritt,288
-Douglas,24,State Treasurer,,D,Carmen Alldritt,217
-Douglas,25,State Treasurer,,D,Carmen Alldritt,221
-Douglas,26,State Treasurer,,D,Carmen Alldritt,305
-Douglas,27,State Treasurer,,D,Carmen Alldritt,303
-Douglas,28,State Treasurer,,D,Carmen Alldritt,216
-Douglas,29,State Treasurer,,D,Carmen Alldritt,296
-Douglas,30 S2,State Treasurer,,D,Carmen Alldritt,107
-Douglas,30 S3,State Treasurer,,D,Carmen Alldritt,135
-Douglas,31,State Treasurer,,D,Carmen Alldritt,383
-Douglas,32,State Treasurer,,D,Carmen Alldritt,180
-Douglas,33,State Treasurer,,D,Carmen Alldritt,455
-Douglas,34 S2,State Treasurer,,D,Carmen Alldritt,283
-Douglas,34 S3,State Treasurer,,D,Carmen Alldritt,59
-Douglas,35 S2,State Treasurer,,D,Carmen Alldritt,346
-Douglas,35 S3,State Treasurer,,D,Carmen Alldritt,23
-Douglas,36  S2,State Treasurer,,D,Carmen Alldritt,263
-Douglas,36  S3,State Treasurer,,D,Carmen Alldritt,206
-Douglas,37 H10,State Treasurer,,D,Carmen Alldritt,458
-Douglas,37  H46,State Treasurer,,D,Carmen Alldritt,17
-Douglas,38  H10,State Treasurer,,D,Carmen Alldritt,386
-Douglas,39,State Treasurer,,D,Carmen Alldritt,450
-Douglas,40,State Treasurer,,D,Carmen Alldritt,424
-Douglas,41 S3 H46,State Treasurer,,D,Carmen Alldritt,651
-Douglas,41 S3 H45,State Treasurer,,D,Carmen Alldritt,1
-Douglas,41 S2 H46,State Treasurer,,D,Carmen Alldritt,4
-Douglas,42  H46,State Treasurer,,D,Carmen Alldritt,135
-Douglas,42 H45,State Treasurer,,D,Carmen Alldritt,135
-Douglas,43  CC1,State Treasurer,,D,Carmen Alldritt,216
-Douglas,43  CC3,State Treasurer,,D,Carmen Alldritt,224
-Douglas,44  H45,State Treasurer,,D,Carmen Alldritt,204
-Douglas,44 H44,State Treasurer,,D,Carmen Alldritt,54
-Douglas,45,State Treasurer,,D,Carmen Alldritt,793
-Douglas,46  S3,State Treasurer,,D,Carmen Alldritt,529
-Douglas,47,State Treasurer,,D,Carmen Alldritt,180
-Douglas,48,State Treasurer,,D,Carmen Alldritt,493
-Douglas,49,State Treasurer,,D,Carmen Alldritt,320
-Douglas,70 Lawrence / Willow,State Treasurer,,D,Carmen Alldritt,1
-Douglas,71 Lawrence / Willow,State Treasurer,,D,Carmen Alldritt,328
-Douglas,1,State Treasurer,,R,Ron Estes,77
-Douglas,2,State Treasurer,,R,Ron Estes,70
-Douglas,3,State Treasurer,,R,Ron Estes,64
-Douglas,4,State Treasurer,,R,Ron Estes,82
-Douglas,5,State Treasurer,,R,Ron Estes,237
-Douglas,6,State Treasurer,,R,Ron Estes,250
-Douglas,7,State Treasurer,,R,Ron Estes,22
-Douglas,8,State Treasurer,,R,Ron Estes,37
-Douglas,9,State Treasurer,,R,Ron Estes,43
-Douglas,10,State Treasurer,,R,Ron Estes,37
-Douglas,11,State Treasurer,,R,Ron Estes,127
-Douglas,12,State Treasurer,,R,Ron Estes,202
-Douglas,13,State Treasurer,,R,Ron Estes,230
-Douglas,14,State Treasurer,,R,Ron Estes,355
-Douglas,15,State Treasurer,,R,Ron Estes,191
-Douglas,16,State Treasurer,,R,Ron Estes,190
-Douglas,17,State Treasurer,,R,Ron Estes,242
-Douglas,18,State Treasurer,,R,Ron Estes,402
-Douglas,19,State Treasurer,,R,Ron Estes,416
-Douglas,20,State Treasurer,,R,Ron Estes,378
-Douglas,21,State Treasurer,,R,Ron Estes,84
-Douglas,22,State Treasurer,,R,Ron Estes,253
-Douglas,23,State Treasurer,,R,Ron Estes,144
-Douglas,24,State Treasurer,,R,Ron Estes,174
-Douglas,25,State Treasurer,,R,Ron Estes,46
-Douglas,26,State Treasurer,,R,Ron Estes,73
-Douglas,27,State Treasurer,,R,Ron Estes,91
-Douglas,28,State Treasurer,,R,Ron Estes,64
-Douglas,29,State Treasurer,,R,Ron Estes,90
-Douglas,30 S2,State Treasurer,,R,Ron Estes,50
-Douglas,30 S3,State Treasurer,,R,Ron Estes,50
-Douglas,31,State Treasurer,,R,Ron Estes,201
-Douglas,32,State Treasurer,,R,Ron Estes,109
-Douglas,33,State Treasurer,,R,Ron Estes,107
-Douglas,34 S2,State Treasurer,,R,Ron Estes,64
-Douglas,34 S3,State Treasurer,,R,Ron Estes,6
-Douglas,35 S2,State Treasurer,,R,Ron Estes,101
-Douglas,35 S3,State Treasurer,,R,Ron Estes,11
-Douglas,36  S2,State Treasurer,,R,Ron Estes,124
-Douglas,36  S3,State Treasurer,,R,Ron Estes,110
-Douglas,37 H10,State Treasurer,,R,Ron Estes,274
-Douglas,37  H46,State Treasurer,,R,Ron Estes,10
-Douglas,38  H10,State Treasurer,,R,Ron Estes,210
-Douglas,39,State Treasurer,,R,Ron Estes,48
-Douglas,40,State Treasurer,,R,Ron Estes,38
-Douglas,41 S3 H46,State Treasurer,,R,Ron Estes,207
-Douglas,41 S3 H45,State Treasurer,,R,Ron Estes,0
-Douglas,41 S2 H46,State Treasurer,,R,Ron Estes,2
-Douglas,42  H46,State Treasurer,,R,Ron Estes,54
-Douglas,42 H45,State Treasurer,,R,Ron Estes,96
-Douglas,43  CC1,State Treasurer,,R,Ron Estes,177
-Douglas,43  CC3,State Treasurer,,R,Ron Estes,188
-Douglas,44  H45,State Treasurer,,R,Ron Estes,151
-Douglas,44 H44,State Treasurer,,R,Ron Estes,43
-Douglas,45,State Treasurer,,R,Ron Estes,809
-Douglas,46  S3,State Treasurer,,R,Ron Estes,339
-Douglas,47,State Treasurer,,R,Ron Estes,157
-Douglas,48,State Treasurer,,R,Ron Estes,318
-Douglas,49,State Treasurer,,R,Ron Estes,373
-Douglas,70 Lawrence / Willow,State Treasurer,,R,Ron Estes,5
-Douglas,71 Lawrence / Willow,State Treasurer,,R,Ron Estes,286
-Douglas,1,Attorney General,,D,Dennis Anderson,322
-Douglas,2,Attorney General,,D,Dennis Anderson,391
-Douglas,3,Attorney General,,D,Dennis Anderson,381
-Douglas,4,Attorney General,,D,Dennis Anderson,323
-Douglas,5,Attorney General,,D,Dennis Anderson,354
-Douglas,6,Attorney General,,D,Dennis Anderson,352
-Douglas,7,Attorney General,,D,Dennis Anderson,141
-Douglas,8,Attorney General,,D,Dennis Anderson,216
-Douglas,9,Attorney General,,D,Dennis Anderson,203
-Douglas,10,Attorney General,,D,Dennis Anderson,98
-Douglas,11,Attorney General,,D,Dennis Anderson,301
-Douglas,12,Attorney General,,D,Dennis Anderson,504
-Douglas,13,Attorney General,,D,Dennis Anderson,428
-Douglas,14,Attorney General,,D,Dennis Anderson,615
-Douglas,15,Attorney General,,D,Dennis Anderson,523
-Douglas,16,Attorney General,,D,Dennis Anderson,412
-Douglas,17,Attorney General,,D,Dennis Anderson,336
-Douglas,18,Attorney General,,D,Dennis Anderson,581
-Douglas,19,Attorney General,,D,Dennis Anderson,435
-Douglas,20,Attorney General,,D,Dennis Anderson,617
-Douglas,21,Attorney General,,D,Dennis Anderson,265
-Douglas,22,Attorney General,,D,Dennis Anderson,457
-Douglas,23,Attorney General,,D,Dennis Anderson,306
-Douglas,24,Attorney General,,D,Dennis Anderson,244
-Douglas,25,Attorney General,,D,Dennis Anderson,224
-Douglas,26,Attorney General,,D,Dennis Anderson,323
-Douglas,27,Attorney General,,D,Dennis Anderson,307
-Douglas,28,Attorney General,,D,Dennis Anderson,232
-Douglas,29,Attorney General,,D,Dennis Anderson,311
-Douglas,30 S2,Attorney General,,D,Dennis Anderson,111
-Douglas,30 S3,Attorney General,,D,Dennis Anderson,145
-Douglas,31,Attorney General,,D,Dennis Anderson,404
-Douglas,32,Attorney General,,D,Dennis Anderson,191
-Douglas,33,Attorney General,,D,Dennis Anderson,480
-Douglas,34 S2,Attorney General,,D,Dennis Anderson,293
-Douglas,34 S3,Attorney General,,D,Dennis Anderson,61
-Douglas,35 S2,Attorney General,,D,Dennis Anderson,357
-Douglas,35 S3,Attorney General,,D,Dennis Anderson,26
-Douglas,36  S2,Attorney General,,D,Dennis Anderson,278
-Douglas,36  S3,Attorney General,,D,Dennis Anderson,220
-Douglas,37 H10,Attorney General,,D,Dennis Anderson,485
-Douglas,37  H46,Attorney General,,D,Dennis Anderson,17
-Douglas,38  H10,Attorney General,,D,Dennis Anderson,400
-Douglas,39,Attorney General,,D,Dennis Anderson,461
-Douglas,40,Attorney General,,D,Dennis Anderson,432
-Douglas,41 S3 H46,Attorney General,,D,Dennis Anderson,656
-Douglas,41 S3 H45,Attorney General,,D,Dennis Anderson,1
-Douglas,41 S2 H46,Attorney General,,D,Dennis Anderson,4
-Douglas,42  H46,Attorney General,,D,Dennis Anderson,143
-Douglas,42 H45,Attorney General,,D,Dennis Anderson,157
-Douglas,43  CC1,Attorney General,,D,Dennis Anderson,237
-Douglas,43  CC3,Attorney General,,D,Dennis Anderson,251
-Douglas,44  H45,Attorney General,,D,Dennis Anderson,226
-Douglas,44 H44,Attorney General,,D,Dennis Anderson,64
-Douglas,45,Attorney General,,D,Dennis Anderson,893
-Douglas,46  S3,Attorney General,,D,Dennis Anderson,574
-Douglas,47,Attorney General,,D,Dennis Anderson,200
-Douglas,48,Attorney General,,D,Dennis Anderson,546
-Douglas,49,Attorney General,,D,Dennis Anderson,336
-Douglas,70 Lawrence / Willow,Attorney General,,D,Dennis Anderson,0
-Douglas,71 Lawrence / Willow,Attorney General,,D,Dennis Anderson,384
-Douglas,1,Attorney General,,R,Ken Selzer,62
-Douglas,2,Attorney General,,R,Ken Selzer,61
-Douglas,3,Attorney General,,R,Ken Selzer,50
-Douglas,4,Attorney General,,R,Ken Selzer,70
-Douglas,5,Attorney General,,R,Ken Selzer,210
-Douglas,6,Attorney General,,R,Ken Selzer,210
-Douglas,7,Attorney General,,R,Ken Selzer,17
-Douglas,8,Attorney General,,R,Ken Selzer,34
-Douglas,9,Attorney General,,R,Ken Selzer,36
-Douglas,10,Attorney General,,R,Ken Selzer,27
-Douglas,11,Attorney General,,R,Ken Selzer,97
-Douglas,12,Attorney General,,R,Ken Selzer,168
-Douglas,13,Attorney General,,R,Ken Selzer,189
-Douglas,14,Attorney General,,R,Ken Selzer,318
-Douglas,15,Attorney General,,R,Ken Selzer,166
-Douglas,16,Attorney General,,R,Ken Selzer,173
-Douglas,17,Attorney General,,R,Ken Selzer,201
-Douglas,18,Attorney General,,R,Ken Selzer,356
-Douglas,19,Attorney General,,R,Ken Selzer,360
-Douglas,20,Attorney General,,R,Ken Selzer,341
-Douglas,21,Attorney General,,R,Ken Selzer,71
-Douglas,22,Attorney General,,R,Ken Selzer,220
-Douglas,23,Attorney General,,R,Ken Selzer,129
-Douglas,24,Attorney General,,R,Ken Selzer,149
-Douglas,25,Attorney General,,R,Ken Selzer,34
-Douglas,26,Attorney General,,R,Ken Selzer,55
-Douglas,27,Attorney General,,R,Ken Selzer,82
-Douglas,28,Attorney General,,R,Ken Selzer,49
-Douglas,29,Attorney General,,R,Ken Selzer,74
-Douglas,30 S2,Attorney General,,R,Ken Selzer,43
-Douglas,30 S3,Attorney General,,R,Ken Selzer,41
-Douglas,31,Attorney General,,R,Ken Selzer,175
-Douglas,32,Attorney General,,R,Ken Selzer,97
-Douglas,33,Attorney General,,R,Ken Selzer,84
-Douglas,34 S2,Attorney General,,R,Ken Selzer,53
-Douglas,34 S3,Attorney General,,R,Ken Selzer,5
-Douglas,35 S2,Attorney General,,R,Ken Selzer,91
-Douglas,35 S3,Attorney General,,R,Ken Selzer,9
-Douglas,36  S2,Attorney General,,R,Ken Selzer,107
-Douglas,36  S3,Attorney General,,R,Ken Selzer,95
-Douglas,37 H10,Attorney General,,R,Ken Selzer,237
-Douglas,37  H46,Attorney General,,R,Ken Selzer,10
-Douglas,38  H10,Attorney General,,R,Ken Selzer,199
-Douglas,39,Attorney General,,R,Ken Selzer,37
-Douglas,40,Attorney General,,R,Ken Selzer,30
-Douglas,41 S3 H46,Attorney General,,R,Ken Selzer,192
-Douglas,41 S3 H45,Attorney General,,R,Ken Selzer,0
-Douglas,41 S2 H46,Attorney General,,R,Ken Selzer,2
-Douglas,42  H46,Attorney General,,R,Ken Selzer,42
-Douglas,42 H45,Attorney General,,R,Ken Selzer,75
-Douglas,43  CC1,Attorney General,,R,Ken Selzer,159
-Douglas,43  CC3,Attorney General,,R,Ken Selzer,163
-Douglas,44  H45,Attorney General,,R,Ken Selzer,131
-Douglas,44 H44,Attorney General,,R,Ken Selzer,31
-Douglas,45,Attorney General,,R,Ken Selzer,714
-Douglas,46  S3,Attorney General,,R,Ken Selzer,303
-Douglas,47,Attorney General,,R,Ken Selzer,139
-Douglas,48,Attorney General,,R,Ken Selzer,273
-Douglas,49,Attorney General,,R,Ken Selzer,346
-Douglas,70 Lawrence / Willow,Attorney General,,R,Ken Selzer,5
-Douglas,71 Lawrence / Willow,Attorney General,,R,Ken Selzer,232
-Douglas,1,State House,46,R,Douglas Robinson,63
-Douglas,2,State House,46,R,Douglas Robinson,59
-Douglas,3,State House,46,R,Douglas Robinson,45
-Douglas,4,State House,46,R,Douglas Robinson,71
-Douglas,6,State House,45,R,Tom Sloan,465
-Douglas,7,State House,46,R,Douglas Robinson,15
-Douglas,8,State House,46,R,Douglas Robinson,29
-Douglas,9,State House,46,R,Douglas Robinson,37
-Douglas,10,State House,46,R,Douglas Robinson,21
-Douglas,13,State House,45,R,Tom Sloan,468
-Douglas,20,State House,45,R,Tom Sloan,764
-Douglas,21,State House,46,R,Douglas Robinson,66
-Douglas,25,State House,46,R,Douglas Robinson,33
-Douglas,26,State House,46,R,Douglas Robinson,56
-Douglas,27,State House,10,R,Nicholas VanWyhe,73
-Douglas,28,State House,10,R,Nicholas VanWyhe,53
-Douglas,29,State House,10,R,Nicholas VanWyhe,82
-Douglas,30 S2,State House,10,R,Nicholas VanWyhe,41
-Douglas,30 S3,State House,10,R,Nicholas VanWyhe,32
-Douglas,31,State House,10,R,Nicholas VanWyhe,170
-Douglas,32,State House,10,R,Nicholas VanWyhe,93
-Douglas,33,State House,46,R,Douglas Robinson,85
-Douglas,34 S2,State House,10,R,Nicholas VanWyhe,49
-Douglas,34 S3,State House,10,R,Nicholas VanWyhe,2
-Douglas,35 S2,State House,46,R,Douglas Robinson,88
-Douglas,35 S3,State House,46,R,Douglas Robinson,10
-Douglas,36  S2,State House,46,R,Douglas Robinson,105
-Douglas,36  S3,State House,46,R,Douglas Robinson,89
-Douglas,37 H10,State House,10,R,Nicholas VanWyhe,233
-Douglas,37  H46,State House,46,R,Douglas Robinson,8
-Douglas,38  H10,State House,10,R,Nicholas VanWyhe,182
-Douglas,39,State House,46,R,Douglas Robinson,38
-Douglas,40,State House,46,R,Douglas Robinson,24
-Douglas,41 S3 H46,State House,46,R,Douglas Robinson,207
-Douglas,41 S3 H45,State House,45,R,Tom Sloan,0
-Douglas,41 S2 H46,State House,46,R,Douglas Robinson,2
-Douglas,42 H46,State House,46,R,Douglas Robinson,42
-Douglas,42 H45,State House,45,R,Tom Sloan,181
-Douglas,43  CC1,State House,45,R,Tom Sloan,315
-Douglas,43  CC3,State House,45,R,Tom Sloan,310
-Douglas,44  H45,State House,45,R,Tom Sloan,291
-Douglas,45,State House,45,R,Tom Sloan,1339
-Douglas,46  S3,State House,45,R,Tom Sloan,652
-Douglas,49,State House,45,R,Tom Sloan,575
-Douglas,70,State House,45,R,Tom Sloan,7
-Douglas,71,State House,45,R,Tom Sloan,499
-Douglas,1,State House,46,D,Dennis Highberger,330
-Douglas,2,State House,46,D,Dennis Highberger,416
-Douglas,3,State House,46,D,Dennis Highberger,409
-Douglas,4,State House,46,D,Dennis Highberger,328
-Douglas,5,State House,44,D,Barbara Ballard,478
-Douglas,7,State House,46,D,Dennis Highberger,151
-Douglas,8,State House,46,D,Dennis Highberger,224
-Douglas,9,State House,46,D,Dennis Highberger,208
-Douglas,10,State House,46,D,Dennis Highberger,78
-Douglas,11,State House,44,D,Barbara Ballard,356
-Douglas,12,State House,44,D,Barbara Ballard,593
-Douglas,14,State House,44,D,Barbara Ballard,816
-Douglas,15,State House,44,D,Barbara Ballard,632
-Douglas,16,State House,44,D,Barbara Ballard,504
-Douglas,17,State House,44,D,Barbara Ballard,443
-Douglas,18,State House,44,D,Barbara Ballard,797
-Douglas,19,State House,44,D,Barbara Ballard,628
-Douglas,21,State House,46,D,Dennis Highberger,284
-Douglas,22,State House,44,D,Barbara Ballard,586
-Douglas,23,State House,44,D,Barbara Ballard,381
-Douglas,24,State House,44,D,Barbara Ballard,330
-Douglas,25,State House,46,D,Dennis Highberger,234
-Douglas,26,State House,46,D,Dennis Highberger,333
-Douglas,27,State House,10,D,John Wilson,328
-Douglas,28,State House,10,D,John Wilson,240
-Douglas,29,State House,10,D,John Wilson,311
-Douglas,30 S2,State House,10,D,John Wilson,119
-Douglas,30 S3,State House,10,D,John Wilson,155
-Douglas,31,State House,10,D,John Wilson,431
-Douglas,32,State House,10,D,John Wilson,197
-Douglas,33,State House,46,D,Dennis Highberger,498
-Douglas,34 S2,State House,10,D,John Wilson,296
-Douglas,34 S3,State House,10,D,John Wilson,64
-Douglas,35 S2,State House,46,D,Dennis Highberger,371
-Douglas,35 S3,State House,46,D,Dennis Highberger,24
-Douglas,36  S2,State House,46,D,Dennis Highberger,284
-Douglas,36  S3,State House,46,D,Dennis Highberger,232
-Douglas,37 H10,State House,10,D,John Wilson,501
-Douglas,37  H46,State House,46,D,Dennis Highberger,19
-Douglas,38  H10,State House,10,D,John Wilson,425
-Douglas,39,State House,46,D,Dennis Highberger,484
-Douglas,40,State House,46,D,Dennis Highberger,449
-Douglas,41 S3 H46,State House,46,D,Dennis Highberger,682
-Douglas,41 S2 H46,State House,46,D,Dennis Highberger,5
-Douglas,42  H46,State House,46,D,Dennis Highberger,143
-Douglas,44 H44,State House,44,D,Barbara Ballard,79
-Douglas,47,State House,44,D,Barbara Ballard,287
-Douglas,48,State House,44,D,Barbara Ballard,716
-Douglas,50 Eudora W,Voters,,,Registered,1507
-Douglas,51 Clinton,Voters,,,Registered,478
-Douglas,52 Eudora,Voters,,,Registered,726
-Douglas,53 Eudora S H10,Voters,,,Registered,646
-Douglas,53 Eudora S H42,Voters,,,Registered,764
-Douglas,54 C Eudora,Voters,,,Registered,1135
-Douglas,55 Grant S2 H45,Voters,,,Registered,46
-Douglas,55 Grant S3 H46,Voters,,,Registered,66
-Douglas,55 Grant S3 H45,Voters,,,Registered,182
-Douglas,56 Kawaka S19,Voters,,,Registered,1068
-Douglas,56 Kawaka S2,Voters,,,Registered,81
-Douglas,57 Lecompton S2,Voters,,,Registered,699
-Douglas,57 Lecompton S19,Voters,,,Registered,185
-Douglas,58 Big Springs / Lec,Voters,,,Registered,296
-Douglas,59 Marion H45,Voters,,,Registered,271
-Douglas,59 Marion,Voters,,,Registered,341
-Douglas,60 Baldwin NW Palmyra,Voters,,,Registered,1138
-Douglas,61 Baldwin NE Palmyra,Voters,,,Registered,1531
-Douglas,62 Baldwin S Palmyra ,Voters,,,Registered,1333
-Douglas,63 Vinland Palmyra,Voters,,,Registered,879
-Douglas,64 Wakarusa N H45,Voters,,,Registered,296
-Douglas,64 Wakarusa N H46,Voters,,,Registered,1
-Douglas,65 Wakarusa E H10,Voters,,,Registered,555
-Douglas,65 Wakarusa E H46,Voters,,,Registered,43
-Douglas,66 Wakarusa W S19 H45,Voters,,,Registered,275
-Douglas,66 Wakarusa W S3 H45,Voters,,,Registered,3
-Douglas,66 Wakarusa W S19 H10,Voters,,,Registered,347
-Douglas,66 Wakarusa W S3   H10,Voters,,,Registered,213
-Douglas,67 Willow S19  H54,Voters,,,Registered,453
-Douglas,67 Willow S19  H45,Voters,,,Registered,403
-Douglas,67 Willow S3  H45,Voters,,,Registered,126
-Douglas,67 Willow S3  H54,Voters,,,Registered,94
-Douglas,50 Eudora W,Voters,,,Cast,765
-Douglas,51 Clinton,Voters,,,Cast,333
-Douglas,52 Eudora,Voters,,,Cast,327
-Douglas,53 Eudora S H10,Voters,,,Cast,403
-Douglas,53 Eudora S H42,Voters,,,Cast,430
-Douglas,54 C Eudora,Voters,,,Cast,506
-Douglas,55 Grant S2 H45,Voters,,,Cast,28
-Douglas,55 Grant S3 H46,Voters,,,Cast,37
-Douglas,55 Grant S3 H45,Voters,,,Cast,116
-Douglas,56 Kawaka S19,Voters,,,Cast,689
-Douglas,56 Kawaka S2,Voters,,,Cast,49
-Douglas,57 Lecompton S2,Voters,,,Cast,395
-Douglas,57 Lecompton S19,Voters,,,Cast,127
-Douglas,58 Big Springs / Lec,Voters,,,Cast,164
-Douglas,59 Marion H45,Voters,,,Cast,161
-Douglas,59 Marion,Voters,,,Cast,235
-Douglas,60 Baldwin NW Palmyra,Voters,,,Cast,556
-Douglas,61 Baldwin NE Palmyra,Voters,,,Cast,731
-Douglas,62 Baldwin S Palmyra ,Voters,,,Cast,738
-Douglas,63 Vinland Palmyra,Voters,,,Cast,556
-Douglas,64 Wakarusa N H45,Voters,,,Cast,202
-Douglas,64 Wakarusa N H46,Voters,,,Cast,1
-Douglas,65 Wakarusa E H10,Voters,,,Cast,328
-Douglas,65 Wakarusa E H46,Voters,,,Cast,24
-Douglas,66 Wakarusa W S19 H45,Voters,,,Cast,166
-Douglas,66 Wakarusa W S3 H45,Voters,,,Cast,2
-Douglas,66 Wakarusa W S19 H10,Voters,,,Cast,246
-Douglas,66 Wakarusa W S3   H10,Voters,,,Cast,145
-Douglas,67 Willow S19  H54,Voters,,,Cast,272
-Douglas,67 Willow S19  H45,Voters,,,Cast,262
-Douglas,67 Willow S3  H45,Voters,,,Cast,82
-Douglas,67 Willow S3  H54,Voters,,,Cast,47
-Douglas,50 Eudora W,U.S. Senate,,R,Pat Roberts,363
-Douglas,51 Clinton,U.S. Senate,,R,Pat Roberts,162
-Douglas,52 Eudora,U.S. Senate,,R,Pat Roberts,133
-Douglas,53 Eudora S H10,U.S. Senate,,R,Pat Roberts,226
-Douglas,53 Eudora S H42,U.S. Senate,,R,Pat Roberts,220
-Douglas,54 C Eudora,U.S. Senate,,R,Pat Roberts,234
-Douglas,55 Grant S2 H45,U.S. Senate,,R,Pat Roberts,8
-Douglas,55 Grant S3 H46,U.S. Senate,,R,Pat Roberts,9
-Douglas,55 Grant S3 H45,U.S. Senate,,R,Pat Roberts,42
-Douglas,56 Kawaka S19,U.S. Senate,,R,Pat Roberts,290
-Douglas,56 Kawaka S2,U.S. Senate,,R,Pat Roberts,11
-Douglas,57 Lecompton S2,U.S. Senate,,R,Pat Roberts,149
-Douglas,57 Lecompton S19,U.S. Senate,,R,Pat Roberts,64
-Douglas,58 Big Springs / Lec,U.S. Senate,,R,Pat Roberts,69
-Douglas,59 Marion H45,U.S. Senate,,R,Pat Roberts,87
-Douglas,59 Marion,U.S. Senate,,R,Pat Roberts,97
-Douglas,60 Baldwin NW Palmyra,U.S. Senate,,R,Pat Roberts,228
-Douglas,61 Baldwin NE Palmyra,U.S. Senate,,R,Pat Roberts,302
-Douglas,62 Baldwin S Palmyra ,U.S. Senate,,R,Pat Roberts,366
-Douglas,63 Vinland Palmyra,U.S. Senate,,R,Pat Roberts,238
-Douglas,64 Wakarusa N H45,U.S. Senate,,R,Pat Roberts,63
-Douglas,64 Wakarusa N H46,U.S. Senate,,R,Pat Roberts,0
-Douglas,65 Wakarusa E H10,U.S. Senate,,R,Pat Roberts,144
-Douglas,65 Wakarusa E H46,U.S. Senate,,R,Pat Roberts,1
-Douglas,66 Wakarusa W S19 H45,U.S. Senate,,R,Pat Roberts,70
-Douglas,66 Wakarusa W S3 H45,U.S. Senate,,R,Pat Roberts,0
-Douglas,66 Wakarusa W S19 H10,U.S. Senate,,R,Pat Roberts,119
-Douglas,66 Wakarusa W S3   H10,U.S. Senate,,R,Pat Roberts,69
-Douglas,67 Willow S19  H54,U.S. Senate,,R,Pat Roberts,155
-Douglas,67 Willow S19  H45,U.S. Senate,,R,Pat Roberts,104
-Douglas,67 Willow S3  H45,U.S. Senate,,R,Pat Roberts,34
-Douglas,67 Willow S3  H54,U.S. Senate,,R,Pat Roberts,18
-Douglas,50 Eudora W,U.S. Senate,,I,Greg Orman,341
-Douglas,51 Clinton,U.S. Senate,,I,Greg Orman,163
-Douglas,52 Eudora,U.S. Senate,,I,Greg Orman,160
-Douglas,53 Eudora S H10,U.S. Senate,,I,Greg Orman,151
-Douglas,53 Eudora S H42,U.S. Senate,,I,Greg Orman,191
-Douglas,54 C Eudora,U.S. Senate,,I,Greg Orman,236
-Douglas,55 Grant S2 H45,U.S. Senate,,I,Greg Orman,20
-Douglas,55 Grant S3 H46,U.S. Senate,,I,Greg Orman,27
-Douglas,55 Grant S3 H45,U.S. Senate,,I,Greg Orman,67
-Douglas,56 Kawaka S19,U.S. Senate,,I,Greg Orman,369
-Douglas,56 Kawaka S2,U.S. Senate,,I,Greg Orman,37
-Douglas,57 Lecompton S2,U.S. Senate,,I,Greg Orman,221
-Douglas,57 Lecompton S19,U.S. Senate,,I,Greg Orman,58
-Douglas,58 Big Springs / Lec,U.S. Senate,,I,Greg Orman,85
-Douglas,59 Marion H45,U.S. Senate,,I,Greg Orman,70
-Douglas,59 Marion,U.S. Senate,,I,Greg Orman,131
-Douglas,60 Baldwin NW Palmyra,U.S. Senate,,I,Greg Orman,307
-Douglas,61 Baldwin NE Palmyra,U.S. Senate,,I,Greg Orman,400
-Douglas,62 Baldwin S Palmyra ,U.S. Senate,,I,Greg Orman,325
-Douglas,63 Vinland Palmyra,U.S. Senate,,I,Greg Orman,292
-Douglas,64 Wakarusa N H45,U.S. Senate,,I,Greg Orman,130
-Douglas,64 Wakarusa N H46,U.S. Senate,,I,Greg Orman,1
-Douglas,65 Wakarusa E H10,U.S. Senate,,I,Greg Orman,174
-Douglas,65 Wakarusa E H46,U.S. Senate,,I,Greg Orman,23
-Douglas,66 Wakarusa W S19 H45,U.S. Senate,,I,Greg Orman,93
-Douglas,66 Wakarusa W S3 H45,U.S. Senate,,I,Greg Orman,2
-Douglas,66 Wakarusa W S19 H10,U.S. Senate,,I,Greg Orman,119
-Douglas,66 Wakarusa W S3   H10,U.S. Senate,,I,Greg Orman,69
-Douglas,67 Willow S19  H54,U.S. Senate,,I,Greg Orman,110
-Douglas,67 Willow S19  H45,U.S. Senate,,I,Greg Orman,148
-Douglas,67 Willow S3  H45,U.S. Senate,,I,Greg Orman,44
-Douglas,67 Willow S3  H54,U.S. Senate,,I,Greg Orman,28
-Douglas,50 Eudora W,U.S. Senate,,L,Randall Batson,48
-Douglas,51 Clinton,U.S. Senate,,L,Randall Batson,8
-Douglas,52 Eudora,U.S. Senate,,L,Randall Batson,27
-Douglas,53 Eudora S H10,U.S. Senate,,L,Randall Batson,20
-Douglas,53 Eudora S H42,U.S. Senate,,L,Randall Batson,16
-Douglas,54 C Eudora,U.S. Senate,,L,Randall Batson,31
-Douglas,55 Grant S2 H45,U.S. Senate,,L,Randall Batson,0
-Douglas,55 Grant S3 H46,U.S. Senate,,L,Randall Batson,0
-Douglas,55 Grant S3 H45,U.S. Senate,,L,Randall Batson,7
-Douglas,56 Kawaka S19,U.S. Senate,,L,Randall Batson,24
-Douglas,56 Kawaka S2,U.S. Senate,,L,Randall Batson,0
-Douglas,57 Lecompton S2,U.S. Senate,,L,Randall Batson,22
-Douglas,57 Lecompton S19,U.S. Senate,,L,Randall Batson,2
-Douglas,58 Big Springs / Lec,U.S. Senate,,L,Randall Batson,6
-Douglas,59 Marion H45,U.S. Senate,,L,Randall Batson,4
-Douglas,59 Marion,U.S. Senate,,L,Randall Batson,5
-Douglas,60 Baldwin NW Palmyra,U.S. Senate,,L,Randall Batson,20
-Douglas,61 Baldwin NE Palmyra,U.S. Senate,,L,Randall Batson,27
-Douglas,62 Baldwin S Palmyra ,U.S. Senate,,L,Randall Batson,36
-Douglas,63 Vinland Palmyra,U.S. Senate,,L,Randall Batson,21
-Douglas,64 Wakarusa N H45,U.S. Senate,,L,Randall Batson,8
-Douglas,64 Wakarusa N H46,U.S. Senate,,L,Randall Batson,0
-Douglas,65 Wakarusa E H10,U.S. Senate,,L,Randall Batson,8
-Douglas,65 Wakarusa E H46,U.S. Senate,,L,Randall Batson,0
-Douglas,66 Wakarusa W S19 H45,U.S. Senate,,L,Randall Batson,2
-Douglas,66 Wakarusa W S3 H45,U.S. Senate,,L,Randall Batson,0
-Douglas,66 Wakarusa W S19 H10,U.S. Senate,,L,Randall Batson,5
-Douglas,66 Wakarusa W S3   H10,U.S. Senate,,L,Randall Batson,6
-Douglas,67 Willow S19  H54,U.S. Senate,,L,Randall Batson,6
-Douglas,67 Willow S19  H45,U.S. Senate,,L,Randall Batson,8
-Douglas,67 Willow S3  H45,U.S. Senate,,L,Randall Batson,4
-Douglas,67 Willow S3  H54,U.S. Senate,,L,Randall Batson,1
-Douglas,50 Eudora W,U.S. House,2,R,Lynn Jenkins,447
-Douglas,51 Clinton,U.S. House,2,R,Lynn Jenkins,194
-Douglas,52 Eudora,U.S. House,2,R,Lynn Jenkins,160
-Douglas,53 Eudora S H10,U.S. House,2,R,Lynn Jenkins,263
-Douglas,53 Eudora S H42,U.S. House,2,R,Lynn Jenkins,254
-Douglas,54 C Eudora,U.S. House,2,R,Lynn Jenkins,276
-Douglas,55 Grant S2 H45,U.S. House,2,R,Lynn Jenkins,9
-Douglas,55 Grant S3 H46,U.S. House,2,R,Lynn Jenkins,11
-Douglas,55 Grant S3 H45,U.S. House,2,R,Lynn Jenkins,51
-Douglas,56 Kawaka S19,U.S. House,2,R,Lynn Jenkins,348
-Douglas,56 Kawaka S2,U.S. House,2,R,Lynn Jenkins,17
-Douglas,57 Lecompton S2,U.S. House,2,R,Lynn Jenkins,199
-Douglas,57 Lecompton S19,U.S. House,2,R,Lynn Jenkins,76
-Douglas,58 Big Springs / Lec,U.S. House,2,R,Lynn Jenkins,84
-Douglas,59 Marion H45,U.S. House,2,R,Lynn Jenkins,111
-Douglas,59 Marion,U.S. House,2,R,Lynn Jenkins,118
-Douglas,60 Baldwin NW Palmyra,U.S. House,2,R,Lynn Jenkins,267
-Douglas,61 Baldwin NE Palmyra,U.S. House,2,R,Lynn Jenkins,387
-Douglas,62 Baldwin S Palmyra ,U.S. House,2,R,Lynn Jenkins,448
-Douglas,63 Vinland Palmyra,U.S. House,2,R,Lynn Jenkins,294
-Douglas,64 Wakarusa N H45,U.S. House,2,R,Lynn Jenkins,67
-Douglas,64 Wakarusa N H46,U.S. House,2,R,Lynn Jenkins,0
-Douglas,65 Wakarusa E H10,U.S. House,2,R,Lynn Jenkins,177
-Douglas,65 Wakarusa E H46,U.S. House,2,R,Lynn Jenkins,4
-Douglas,66 Wakarusa W S19 H45,U.S. House,2,R,Lynn Jenkins,85
-Douglas,66 Wakarusa W S3 H45,U.S. House,2,R,Lynn Jenkins,0
-Douglas,66 Wakarusa W S19 H10,U.S. House,2,R,Lynn Jenkins,137
-Douglas,66 Wakarusa W S3   H10,U.S. House,2,R,Lynn Jenkins,82
-Douglas,67 Willow S19  H54,U.S. House,2,R,Lynn Jenkins,179
-Douglas,67 Willow S19  H45,U.S. House,2,R,Lynn Jenkins,119
-Douglas,67 Willow S3  H45,U.S. House,2,R,Lynn Jenkins,38
-Douglas,67 Willow S3  H54,U.S. House,2,R,Lynn Jenkins,23
-Douglas,50 Eudora W,U.S. House,2,D,Margie Wakefield,271
-Douglas,51 Clinton,U.S. House,2,D,Margie Wakefield,131
-Douglas,52 Eudora,U.S. House,2,D,Margie Wakefield,144
-Douglas,53 Eudora S H10,U.S. House,2,D,Margie Wakefield,122
-Douglas,53 Eudora S H42,U.S. House,2,D,Margie Wakefield,154
-Douglas,54 C Eudora,U.S. House,2,D,Margie Wakefield,188
-Douglas,55 Grant S2 H45,U.S. House,2,D,Margie Wakefield,19
-Douglas,55 Grant S3 H46,U.S. House,2,D,Margie Wakefield,24
-Douglas,55 Grant S3 H45,U.S. House,2,D,Margie Wakefield,59
-Douglas,56 Kawaka S19,U.S. House,2,D,Margie Wakefield,312
-Douglas,56 Kawaka S2,U.S. House,2,D,Margie Wakefield,31
-Douglas,57 Lecompton S2,U.S. House,2,D,Margie Wakefield,177
-Douglas,57 Lecompton S19,U.S. House,2,D,Margie Wakefield,47
-Douglas,58 Big Springs / Lec,U.S. House,2,D,Margie Wakefield,67
-Douglas,59 Marion H45,U.S. House,2,D,Margie Wakefield,48
-Douglas,59 Marion,U.S. House,2,D,Margie Wakefield,111
-Douglas,60 Baldwin NW Palmyra,U.S. House,2,D,Margie Wakefield,260
-Douglas,61 Baldwin NE Palmyra,U.S. House,2,D,Margie Wakefield,310
-Douglas,62 Baldwin S Palmyra ,U.S. House,2,D,Margie Wakefield,254
-Douglas,63 Vinland Palmyra,U.S. House,2,D,Margie Wakefield,244
-Douglas,64 Wakarusa N H45,U.S. House,2,D,Margie Wakefield,127
-Douglas,64 Wakarusa N H46,U.S. House,2,D,Margie Wakefield,1
-Douglas,65 Wakarusa E H10,U.S. House,2,D,Margie Wakefield,139
-Douglas,65 Wakarusa E H46,U.S. House,2,D,Margie Wakefield,20
-Douglas,66 Wakarusa W S19 H45,U.S. House,2,D,Margie Wakefield,74
-Douglas,66 Wakarusa W S3 H45,U.S. House,2,D,Margie Wakefield,2
-Douglas,66 Wakarusa W S19 H10,U.S. House,2,D,Margie Wakefield,104
-Douglas,66 Wakarusa W S3   H10,U.S. House,2,D,Margie Wakefield,56
-Douglas,67 Willow S19  H54,U.S. House,2,D,Margie Wakefield,87
-Douglas,67 Willow S19  H45,U.S. House,2,D,Margie Wakefield,133
-Douglas,67 Willow S3  H45,U.S. House,2,D,Margie Wakefield,42
-Douglas,67 Willow S3  H54,U.S. House,2,D,Margie Wakefield,22
-Douglas,50 Eudora W,U.S. House,2,L,Chris Clemmons,43
-Douglas,51 Clinton,U.S. House,2,L,Chris Clemmons,6
-Douglas,52 Eudora,U.S. House,2,L,Chris Clemmons,19
-Douglas,53 Eudora S H10,U.S. House,2,L,Chris Clemmons,17
-Douglas,53 Eudora S H42,U.S. House,2,L,Chris Clemmons,17
-Douglas,54 C Eudora,U.S. House,2,L,Chris Clemmons,31
-Douglas,55 Grant S2 H45,U.S. House,2,L,Chris Clemmons,0
-Douglas,55 Grant S3 H46,U.S. House,2,L,Chris Clemmons,2
-Douglas,55 Grant S3 H45,U.S. House,2,L,Chris Clemmons,6
-Douglas,56 Kawaka S19,U.S. House,2,L,Chris Clemmons,22
-Douglas,56 Kawaka S2,U.S. House,2,L,Chris Clemmons,1
-Douglas,57 Lecompton S2,U.S. House,2,L,Chris Clemmons,18
-Douglas,57 Lecompton S19,U.S. House,2,L,Chris Clemmons,3
-Douglas,58 Big Springs / Lec,U.S. House,2,L,Chris Clemmons,10
-Douglas,59 Marion H45,U.S. House,2,L,Chris Clemmons,2
-Douglas,59 Marion,U.S. House,2,L,Chris Clemmons,5
-Douglas,60 Baldwin NW Palmyra,U.S. House,2,L,Chris Clemmons,24
-Douglas,61 Baldwin NE Palmyra,U.S. House,2,L,Chris Clemmons,29
-Douglas,62 Baldwin S Palmyra ,U.S. House,2,L,Chris Clemmons,26
-Douglas,63 Vinland Palmyra,U.S. House,2,L,Chris Clemmons,16
-Douglas,64 Wakarusa N H45,U.S. House,2,L,Chris Clemmons,6
-Douglas,64 Wakarusa N H46,U.S. House,2,L,Chris Clemmons,0
-Douglas,65 Wakarusa E H10,U.S. House,2,L,Chris Clemmons,11
-Douglas,65 Wakarusa E H46,U.S. House,2,L,Chris Clemmons,0
-Douglas,66 Wakarusa W S19 H45,U.S. House,2,L,Chris Clemmons,6
-Douglas,66 Wakarusa W S3 H45,U.S. House,2,L,Chris Clemmons,0
-Douglas,66 Wakarusa W S19 H10,U.S. House,2,L,Chris Clemmons,5
-Douglas,66 Wakarusa W S3   H10,U.S. House,2,L,Chris Clemmons,7
-Douglas,67 Willow S19  H54,U.S. House,2,L,Chris Clemmons,3
-Douglas,67 Willow S19  H45,U.S. House,2,L,Chris Clemmons,9
-Douglas,67 Willow S3  H45,U.S. House,2,L,Chris Clemmons,2
-Douglas,67 Willow S3  H54,U.S. House,2,L,Chris Clemmons,2
-Douglas,50 Eudora W,Governor,,D,Paul Davis,376
-Douglas,51 Clinton,Governor,,D,Paul Davis,177
-Douglas,52 Eudora,Governor,,D,Paul Davis,184
-Douglas,53 Eudora S H10,Governor,,D,Paul Davis,180
-Douglas,53 Eudora S H42,Governor,,D,Paul Davis,214
-Douglas,54 C Eudora,Governor,,D,Paul Davis,273
-Douglas,55 Grant S2 H45,Governor,,D,Paul Davis,20
-Douglas,55 Grant S3 H46,Governor,,D,Paul Davis,30
-Douglas,55 Grant S3 H45,Governor,,D,Paul Davis,72
-Douglas,56 Kawaka S19,Governor,,D,Paul Davis,397
-Douglas,56 Kawaka S2,Governor,,D,Paul Davis,37
-Douglas,57 Lecompton S2,Governor,,D,Paul Davis,240
-Douglas,57 Lecompton S19,Governor,,D,Paul Davis,65
-Douglas,58 Big Springs / Lec,Governor,,D,Paul Davis,88
-Douglas,59 Marion H45,Governor,,D,Paul Davis,81
-Douglas,59 Marion,Governor,,D,Paul Davis,141
-Douglas,60 Baldwin NW Palmyra,Governor,,D,Paul Davis,339
-Douglas,61 Baldwin NE Palmyra,Governor,,D,Paul Davis,420
-Douglas,62 Baldwin S Palmyra ,Governor,,D,Paul Davis,353
-Douglas,63 Vinland Palmyra,Governor,,D,Paul Davis,313
-Douglas,64 Wakarusa N H45,Governor,,D,Paul Davis,150
-Douglas,64 Wakarusa N H46,Governor,,D,Paul Davis,1
-Douglas,65 Wakarusa E H10,Governor,,D,Paul Davis,183
-Douglas,65 Wakarusa E H46,Governor,,D,Paul Davis,22
-Douglas,66 Wakarusa W S19 H45,Governor,,D,Paul Davis,96
-Douglas,66 Wakarusa W S3 H45,Governor,,D,Paul Davis,2
-Douglas,66 Wakarusa W S19 H10,Governor,,D,Paul Davis,139
-Douglas,66 Wakarusa W S3   H10,Governor,,D,Paul Davis,83
-Douglas,67 Willow S19  H54,Governor,,D,Paul Davis,129
-Douglas,67 Willow S19  H45,Governor,,D,Paul Davis,163
-Douglas,67 Willow S3  H45,Governor,,D,Paul Davis,54
-Douglas,67 Willow S3  H54,Governor,,D,Paul Davis,33
-Douglas,50 Eudora W,Governor,,R,Sam Brownback,326
-Douglas,51 Clinton,Governor,,R,Sam Brownback,141
-Douglas,52 Eudora,Governor,,R,Sam Brownback,120
-Douglas,53 Eudora S H10,Governor,,R,Sam Brownback,205
-Douglas,53 Eudora S H42,Governor,,R,Sam Brownback,201
-Douglas,54 C Eudora,Governor,,R,Sam Brownback,201
-Douglas,55 Grant S2 H45,Governor,,R,Sam Brownback,7
-Douglas,55 Grant S3 H46,Governor,,R,Sam Brownback,7
-Douglas,55 Grant S3 H45,Governor,,R,Sam Brownback,38
-Douglas,56 Kawaka S19,Governor,,R,Sam Brownback,273
-Douglas,56 Kawaka S2,Governor,,R,Sam Brownback,11
-Douglas,57 Lecompton S2,Governor,,R,Sam Brownback,133
-Douglas,57 Lecompton S19,Governor,,R,Sam Brownback,54
-Douglas,58 Big Springs / Lec,Governor,,R,Sam Brownback,59
-Douglas,59 Marion H45,Governor,,R,Sam Brownback,79
-Douglas,59 Marion,Governor,,R,Sam Brownback,86
-Douglas,60 Baldwin NW Palmyra,Governor,,R,Sam Brownback,193
-Douglas,61 Baldwin NE Palmyra,Governor,,R,Sam Brownback,278
-Douglas,62 Baldwin S Palmyra ,Governor,,R,Sam Brownback,345
-Douglas,63 Vinland Palmyra,Governor,,R,Sam Brownback,219
-Douglas,64 Wakarusa N H45,Governor,,R,Sam Brownback,46
-Douglas,64 Wakarusa N H46,Governor,,R,Sam Brownback,0
-Douglas,65 Wakarusa E H10,Governor,,R,Sam Brownback,130
-Douglas,65 Wakarusa E H46,Governor,,R,Sam Brownback,2
-Douglas,66 Wakarusa W S19 H45,Governor,,R,Sam Brownback,66
-Douglas,66 Wakarusa W S3 H45,Governor,,R,Sam Brownback,0
-Douglas,66 Wakarusa W S19 H10,Governor,,R,Sam Brownback,103
-Douglas,66 Wakarusa W S3   H10,Governor,,R,Sam Brownback,57
-Douglas,67 Willow S19  H54,Governor,,R,Sam Brownback,136
-Douglas,67 Willow S19  H45,Governor,,R,Sam Brownback,91
-Douglas,67 Willow S3  H45,Governor,,R,Sam Brownback,26
-Douglas,67 Willow S3  H54,Governor,,R,Sam Brownback,12
-Douglas,50 Eudora W,Governor,,L,Keen Umbehr,51
-Douglas,51 Clinton,Governor,,L,Keen Umbehr,11
-Douglas,52 Eudora,Governor,,L,Keen Umbehr,17
-Douglas,53 Eudora S H10,Governor,,L,Keen Umbehr,14
-Douglas,53 Eudora S H42,Governor,,L,Keen Umbehr,13
-Douglas,54 C Eudora,Governor,,L,Keen Umbehr,30
-Douglas,55 Grant S2 H45,Governor,,L,Keen Umbehr,0
-Douglas,55 Grant S3 H46,Governor,,L,Keen Umbehr,0
-Douglas,55 Grant S3 H45,Governor,,L,Keen Umbehr,5
-Douglas,56 Kawaka S19,Governor,,L,Keen Umbehr,13
-Douglas,56 Kawaka S2,Governor,,L,Keen Umbehr,0
-Douglas,57 Lecompton S2,Governor,,L,Keen Umbehr,19
-Douglas,57 Lecompton S19,Governor,,L,Keen Umbehr,6
-Douglas,58 Big Springs / Lec,Governor,,L,Keen Umbehr,14
-Douglas,59 Marion H45,Governor,,L,Keen Umbehr,1
-Douglas,59 Marion,Governor,,L,Keen Umbehr,7
-Douglas,60 Baldwin NW Palmyra,Governor,,L,Keen Umbehr,19
-Douglas,61 Baldwin NE Palmyra,Governor,,L,Keen Umbehr,26
-Douglas,62 Baldwin S Palmyra ,Governor,,L,Keen Umbehr,33
-Douglas,63 Vinland Palmyra,Governor,,L,Keen Umbehr,20
-Douglas,64 Wakarusa N H45,Governor,,L,Keen Umbehr,4
-Douglas,64 Wakarusa N H46,Governor,,L,Keen Umbehr,0
-Douglas,65 Wakarusa E H10,Governor,,L,Keen Umbehr,12
-Douglas,65 Wakarusa E H46,Governor,,L,Keen Umbehr,0
-Douglas,66 Wakarusa W S19 H45,Governor,,L,Keen Umbehr,3
-Douglas,66 Wakarusa W S3 H45,Governor,,L,Keen Umbehr,0
-Douglas,66 Wakarusa W S19 H10,Governor,,L,Keen Umbehr,4
-Douglas,66 Wakarusa W S3   H10,Governor,,L,Keen Umbehr,5
-Douglas,67 Willow S19  H54,Governor,,L,Keen Umbehr,5
-Douglas,67 Willow S19  H45,Governor,,L,Keen Umbehr,6
-Douglas,67 Willow S3  H45,Governor,,L,Keen Umbehr,2
-Douglas,67 Willow S3  H54,Governor,,L,Keen Umbehr,1
-Douglas,50 Eudora W,Secretary of State,,R,Kris Kobach,438
-Douglas,51 Clinton,Secretary of State,,R,Kris Kobach,179
-Douglas,52 Eudora,Secretary of State,,R,Kris Kobach,156
-Douglas,53 Eudora S H10,Secretary of State,,R,Kris Kobach,253
-Douglas,53 Eudora S H42,Secretary of State,,R,Kris Kobach,258
-Douglas,54 C Eudora,Secretary of State,,R,Kris Kobach,284
-Douglas,55 Grant S2 H45,Secretary of State,,R,Kris Kobach,7
-Douglas,55 Grant S3 H46,Secretary of State,,R,Kris Kobach,9
-Douglas,55 Grant S3 H45,Secretary of State,,R,Kris Kobach,43
-Douglas,56 Kawaka S19,Secretary of State,,R,Kris Kobach,339
-Douglas,56 Kawaka S2,Secretary of State,,R,Kris Kobach,14
-Douglas,57 Lecompton S2,Secretary of State,,R,Kris Kobach,191
-Douglas,57 Lecompton S19,Secretary of State,,R,Kris Kobach,69
-Douglas,58 Big Springs / Lec,Secretary of State,,R,Kris Kobach,81
-Douglas,59 Marion H45,Secretary of State,,R,Kris Kobach,104
-Douglas,59 Marion,Secretary of State,,R,Kris Kobach,107
-Douglas,60 Baldwin NW Palmyra,Secretary of State,,R,Kris Kobach,266
-Douglas,61 Baldwin NE Palmyra,Secretary of State,,R,Kris Kobach,369
-Douglas,62 Baldwin S Palmyra ,Secretary of State,,R,Kris Kobach,440
-Douglas,63 Vinland Palmyra,Secretary of State,,R,Kris Kobach,284
-Douglas,64 Wakarusa N H45,Secretary of State,,R,Kris Kobach,68
-Douglas,64 Wakarusa N H46,Secretary of State,,R,Kris Kobach,0
-Douglas,65 Wakarusa E H10,Secretary of State,,R,Kris Kobach,164
-Douglas,65 Wakarusa E H46,Secretary of State,,R,Kris Kobach,2
-Douglas,66 Wakarusa W S19 H45,Secretary of State,,R,Kris Kobach,82
-Douglas,66 Wakarusa W S3 H45,Secretary of State,,R,Kris Kobach,0
-Douglas,66 Wakarusa W S19 H10,Secretary of State,,R,Kris Kobach,120
-Douglas,66 Wakarusa W S3   H10,Secretary of State,,R,Kris Kobach,82
-Douglas,67 Willow S19  H54,Secretary of State,,R,Kris Kobach,168
-Douglas,67 Willow S19  H45,Secretary of State,,R,Kris Kobach,112
-Douglas,67 Willow S3  H45,Secretary of State,,R,Kris Kobach,34
-Douglas,67 Willow S3  H54,Secretary of State,,R,Kris Kobach,18
-Douglas,50 Eudora W,Secretary of State,,D,Jean Schodorf,313
-Douglas,51 Clinton,Secretary of State,,D,Jean Schodorf,145
-Douglas,52 Eudora,Secretary of State,,D,Jean Schodorf,160
-Douglas,53 Eudora S H10,Secretary of State,,D,Jean Schodorf,143
-Douglas,53 Eudora S H42,Secretary of State,,D,Jean Schodorf,164
-Douglas,54 C Eudora,Secretary of State,,D,Jean Schodorf,203
-Douglas,55 Grant S2 H45,Secretary of State,,D,Jean Schodorf,19
-Douglas,55 Grant S3 H46,Secretary of State,,D,Jean Schodorf,28
-Douglas,55 Grant S3 H45,Secretary of State,,D,Jean Schodorf,72
-Douglas,56 Kawaka S19,Secretary of State,,D,Jean Schodorf,338
-Douglas,56 Kawaka S2,Secretary of State,,D,Jean Schodorf,35
-Douglas,57 Lecompton S2,Secretary of State,,D,Jean Schodorf,199
-Douglas,57 Lecompton S19,Secretary of State,,D,Jean Schodorf,56
-Douglas,58 Big Springs / Lec,Secretary of State,,D,Jean Schodorf,78
-Douglas,59 Marion H45,Secretary of State,,D,Jean Schodorf,57
-Douglas,59 Marion,Secretary of State,,D,Jean Schodorf,124
-Douglas,60 Baldwin NW Palmyra,Secretary of State,,D,Jean Schodorf,281
-Douglas,61 Baldwin NE Palmyra,Secretary of State,,D,Jean Schodorf,350
-Douglas,62 Baldwin S Palmyra ,Secretary of State,,D,Jean Schodorf,287
-Douglas,63 Vinland Palmyra,Secretary of State,,D,Jean Schodorf,263
-Douglas,64 Wakarusa N H45,Secretary of State,,D,Jean Schodorf,131
-Douglas,64 Wakarusa N H46,Secretary of State,,D,Jean Schodorf,1
-Douglas,65 Wakarusa E H10,Secretary of State,,D,Jean Schodorf,156
-Douglas,65 Wakarusa E H46,Secretary of State,,D,Jean Schodorf,22
-Douglas,66 Wakarusa W S19 H45,Secretary of State,,D,Jean Schodorf,83
-Douglas,66 Wakarusa W S3 H45,Secretary of State,,D,Jean Schodorf,2
-Douglas,66 Wakarusa W S19 H10,Secretary of State,,D,Jean Schodorf,122
-Douglas,66 Wakarusa W S3   H10,Secretary of State,,D,Jean Schodorf,58
-Douglas,67 Willow S19  H54,Secretary of State,,D,Jean Schodorf,97
-Douglas,67 Willow S19  H45,Secretary of State,,D,Jean Schodorf,148
-Douglas,67 Willow S3  H45,Secretary of State,,D,Jean Schodorf,46
-Douglas,67 Willow S3  H54,Secretary of State,,D,Jean Schodorf,29
-Douglas,50 Eudora W,Attorney General,,R,Derek Schmidt,271
-Douglas,51 Clinton,Attorney General,,R,Derek Schmidt,129
-Douglas,52 Eudora,Attorney General,,R,Derek Schmidt,159
-Douglas,53 Eudora S H10,Attorney General,,R,Derek Schmidt,123
-Douglas,53 Eudora S H42,Attorney General,,R,Derek Schmidt,152
-Douglas,54 C Eudora,Attorney General,,R,Derek Schmidt,190
-Douglas,55 Grant S2 H45,Attorney General,,R,Derek Schmidt,18
-Douglas,55 Grant S3 H46,Attorney General,,R,Derek Schmidt,24
-Douglas,55 Grant S3 H45,Attorney General,,R,Derek Schmidt,65
-Douglas,56 Kawaka S19,Attorney General,,R,Derek Schmidt,272
-Douglas,56 Kawaka S2,Attorney General,,R,Derek Schmidt,29
-Douglas,57 Lecompton S2,Attorney General,,R,Derek Schmidt,182
-Douglas,57 Lecompton S19,Attorney General,,R,Derek Schmidt,45
-Douglas,58 Big Springs / Lec,Attorney General,,R,Derek Schmidt,71
-Douglas,59 Marion H45,Attorney General,,R,Derek Schmidt,51
-Douglas,59 Marion,Attorney General,,R,Derek Schmidt,106
-Douglas,60 Baldwin NW Palmyra,Attorney General,,R,Derek Schmidt,248
-Douglas,61 Baldwin NE Palmyra,Attorney General,,R,Derek Schmidt,310
-Douglas,62 Baldwin S Palmyra ,Attorney General,,R,Derek Schmidt,255
-Douglas,63 Vinland Palmyra,Attorney General,,R,Derek Schmidt,235
-Douglas,64 Wakarusa N H45,Attorney General,,R,Derek Schmidt,118
-Douglas,64 Wakarusa N H46,Attorney General,,R,Derek Schmidt,1
-Douglas,65 Wakarusa E H10,Attorney General,,R,Derek Schmidt,149
-Douglas,65 Wakarusa E H46,Attorney General,,R,Derek Schmidt,21
-Douglas,66 Wakarusa W S19 H45,Attorney General,,R,Derek Schmidt,68
-Douglas,66 Wakarusa W S3 H45,Attorney General,,R,Derek Schmidt,2
-Douglas,66 Wakarusa W S19 H10,Attorney General,,R,Derek Schmidt,102
-Douglas,66 Wakarusa W S3   H10,Attorney General,,R,Derek Schmidt,54
-Douglas,67 Willow S19  H54,Attorney General,,R,Derek Schmidt,85
-Douglas,67 Willow S19  H45,Attorney General,,R,Derek Schmidt,135
-Douglas,67 Willow S3  H45,Attorney General,,R,Derek Schmidt,38
-Douglas,67 Willow S3  H54,Attorney General,,R,Derek Schmidt,23
-Douglas,50 Eudora W,Attorney General,,D,A J Kotich,460
-Douglas,51 Clinton,Attorney General,,D,A J Kotich,192
-Douglas,52 Eudora,Attorney General,,D,A J Kotich,151
-Douglas,53 Eudora S H10,Attorney General,,D,A J Kotich,267
-Douglas,53 Eudora S H42,Attorney General,,D,A J Kotich,258
-Douglas,54 C Eudora,Attorney General,,D,A J Kotich,284
-Douglas,55 Grant S2 H45,Attorney General,,D,A J Kotich,7
-Douglas,55 Grant S3 H46,Attorney General,,D,A J Kotich,12
-Douglas,55 Grant S3 H45,Attorney General,,D,A J Kotich,42
-Douglas,56 Kawaka S19,Attorney General,,D,A J Kotich,394
-Douglas,56 Kawaka S2,Attorney General,,D,A J Kotich,19
-Douglas,57 Lecompton S2,Attorney General,,D,A J Kotich,202
-Douglas,57 Lecompton S19,Attorney General,,D,A J Kotich,80
-Douglas,58 Big Springs / Lec,Attorney General,,D,A J Kotich,82
-Douglas,59 Marion H45,Attorney General,,D,A J Kotich,107
-Douglas,59 Marion,Attorney General,,D,A J Kotich,124
-Douglas,60 Baldwin NW Palmyra,Attorney General,,D,A J Kotich,279
-Douglas,61 Baldwin NE Palmyra,Attorney General,,D,A J Kotich,374
-Douglas,62 Baldwin S Palmyra ,Attorney General,,D,A J Kotich,451
-Douglas,63 Vinland Palmyra,Attorney General,,D,A J Kotich,298
-Douglas,64 Wakarusa N H45,Attorney General,,D,A J Kotich,71
-Douglas,64 Wakarusa N H46,Attorney General,,D,A J Kotich,0
-Douglas,65 Wakarusa E H10,Attorney General,,D,A J Kotich,160
-Douglas,65 Wakarusa E H46,Attorney General,,D,A J Kotich,3
-Douglas,66 Wakarusa W S19 H45,Attorney General,,D,A J Kotich,92
-Douglas,66 Wakarusa W S3 H45,Attorney General,,D,A J Kotich,0
-Douglas,66 Wakarusa W S19 H10,Attorney General,,D,A J Kotich,130
-Douglas,66 Wakarusa W S3   H10,Attorney General,,D,A J Kotich,81
-Douglas,67 Willow S19  H54,Attorney General,,D,A J Kotich,172
-Douglas,67 Willow S19  H45,Attorney General,,D,A J Kotich,121
-Douglas,67 Willow S3  H45,Attorney General,,D,A J Kotich,42
-Douglas,67 Willow S3  H54,Attorney General,,D,A J Kotich,24
-Douglas,50 Eudora W,State Treasurer,,R,Ron Estes,264
-Douglas,51 Clinton,State Treasurer,,R,Ron Estes,122
-Douglas,52 Eudora,State Treasurer,,R,Ron Estes,158
-Douglas,53 Eudora S H10,State Treasurer,,R,Ron Estes,120
-Douglas,53 Eudora S H42,State Treasurer,,R,Ron Estes,146
-Douglas,54 C Eudora,State Treasurer,,R,Ron Estes,192
-Douglas,55 Grant S2 H45,State Treasurer,,R,Ron Estes,19
-Douglas,55 Grant S3 H46,State Treasurer,,R,Ron Estes,23
-Douglas,55 Grant S3 H45,State Treasurer,,R,Ron Estes,60
-Douglas,56 Kawaka S19,State Treasurer,,R,Ron Estes,278
-Douglas,56 Kawaka S2,State Treasurer,,R,Ron Estes,29
-Douglas,57 Lecompton S2,State Treasurer,,R,Ron Estes,182
-Douglas,57 Lecompton S19,State Treasurer,,R,Ron Estes,52
-Douglas,58 Big Springs / Lec,State Treasurer,,R,Ron Estes,65
-Douglas,59 Marion H45,State Treasurer,,R,Ron Estes,54
-Douglas,59 Marion,State Treasurer,,R,Ron Estes,104
-Douglas,60 Baldwin NW Palmyra,State Treasurer,,R,Ron Estes,255
-Douglas,61 Baldwin NE Palmyra,State Treasurer,,R,Ron Estes,314
-Douglas,62 Baldwin S Palmyra ,State Treasurer,,R,Ron Estes,257
-Douglas,63 Vinland Palmyra,State Treasurer,,R,Ron Estes,236
-Douglas,64 Wakarusa N H45,State Treasurer,,R,Ron Estes,120
-Douglas,64 Wakarusa N H46,State Treasurer,,R,Ron Estes,0
-Douglas,65 Wakarusa E H10,State Treasurer,,R,Ron Estes,146
-Douglas,65 Wakarusa E H46,State Treasurer,,R,Ron Estes,22
-Douglas,66 Wakarusa W S19 H45,State Treasurer,,R,Ron Estes,68
-Douglas,66 Wakarusa W S3 H45,State Treasurer,,R,Ron Estes,2
-Douglas,66 Wakarusa W S19 H10,State Treasurer,,R,Ron Estes,95
-Douglas,66 Wakarusa W S3   H10,State Treasurer,,R,Ron Estes,51
-Douglas,67 Willow S19  H54,State Treasurer,,R,Ron Estes,84
-Douglas,67 Willow S19  H45,State Treasurer,,R,Ron Estes,126
-Douglas,67 Willow S3  H45,State Treasurer,,R,Ron Estes,41
-Douglas,67 Willow S3  H54,State Treasurer,,R,Ron Estes,21
-Douglas,50 Eudora W,State Treasurer,,D,Carmen Alldritt,464
-Douglas,51 Clinton,State Treasurer,,D,Carmen Alldritt,195
-Douglas,52 Eudora,State Treasurer,,D,Carmen Alldritt,150
-Douglas,53 Eudora S H10,State Treasurer,,D,Carmen Alldritt,265
-Douglas,53 Eudora S H42,State Treasurer,,D,Carmen Alldritt,259
-Douglas,54 C Eudora,State Treasurer,,D,Carmen Alldritt,278
-Douglas,55 Grant S2 H45,State Treasurer,,D,Carmen Alldritt,7
-Douglas,55 Grant S3 H46,State Treasurer,,D,Carmen Alldritt,13
-Douglas,55 Grant S3 H45,State Treasurer,,D,Carmen Alldritt,46
-Douglas,56 Kawaka S19,State Treasurer,,D,Carmen Alldritt,382
-Douglas,56 Kawaka S2,State Treasurer,,D,Carmen Alldritt,15
-Douglas,57 Lecompton S2,State Treasurer,,D,Carmen Alldritt,199
-Douglas,57 Lecompton S19,State Treasurer,,D,Carmen Alldritt,74
-Douglas,58 Big Springs / Lec,State Treasurer,,D,Carmen Alldritt,89
-Douglas,59 Marion H45,State Treasurer,,D,Carmen Alldritt,103
-Douglas,59 Marion,State Treasurer,,D,Carmen Alldritt,121
-Douglas,60 Baldwin NW Palmyra,State Treasurer,,D,Carmen Alldritt,274
-Douglas,61 Baldwin NE Palmyra,State Treasurer,,D,Carmen Alldritt,375
-Douglas,62 Baldwin S Palmyra ,State Treasurer,,D,Carmen Alldritt,447
-Douglas,63 Vinland Palmyra,State Treasurer,,D,Carmen Alldritt,296
-Douglas,64 Wakarusa N H45,State Treasurer,,D,Carmen Alldritt,68
-Douglas,64 Wakarusa N H46,State Treasurer,,D,Carmen Alldritt,1
-Douglas,65 Wakarusa E H10,State Treasurer,,D,Carmen Alldritt,161
-Douglas,65 Wakarusa E H46,State Treasurer,,D,Carmen Alldritt,2
-Douglas,66 Wakarusa W S19 H45,State Treasurer,,D,Carmen Alldritt,90
-Douglas,66 Wakarusa W S3 H45,State Treasurer,,D,Carmen Alldritt,0
-Douglas,66 Wakarusa W S19 H10,State Treasurer,,D,Carmen Alldritt,134
-Douglas,66 Wakarusa W S3   H10,State Treasurer,,D,Carmen Alldritt,80
-Douglas,67 Willow S19  H54,State Treasurer,,D,Carmen Alldritt,170
-Douglas,67 Willow S19  H45,State Treasurer,,D,Carmen Alldritt,126
-Douglas,67 Willow S3  H45,State Treasurer,,D,Carmen Alldritt,39
-Douglas,67 Willow S3  H54,State Treasurer,,D,Carmen Alldritt,26
-Douglas,50 Eudora W,Insurance Commissioner,,R,Ken Selzer,291
-Douglas,51 Clinton,Insurance Commissioner,,R,Ken Selzer,141
-Douglas,52 Eudora,Insurance Commissioner,,R,Ken Selzer,167
-Douglas,53 Eudora S H10,Insurance Commissioner,,R,Ken Selzer,134
-Douglas,53 Eudora S H42,Insurance Commissioner,,R,Ken Selzer,161
-Douglas,54 C Eudora,Insurance Commissioner,,R,Ken Selzer,191
-Douglas,55 Grant S2 H45,Insurance Commissioner,,R,Ken Selzer,19
-Douglas,55 Grant S3 H46,Insurance Commissioner,,R,Ken Selzer,26
-Douglas,55 Grant S3 H45,Insurance Commissioner,,R,Ken Selzer,65
-Douglas,56 Kawaka S19,Insurance Commissioner,,R,Ken Selzer,316
-Douglas,56 Kawaka S2,Insurance Commissioner,,R,Ken Selzer,33
-Douglas,57 Lecompton S2,Insurance Commissioner,,R,Ken Selzer,204
-Douglas,57 Lecompton S19,Insurance Commissioner,,R,Ken Selzer,52
-Douglas,58 Big Springs / Lec,Insurance Commissioner,,R,Ken Selzer,74
-Douglas,59 Marion H45,Insurance Commissioner,,R,Ken Selzer,54
-Douglas,59 Marion,Insurance Commissioner,,R,Ken Selzer,118
-Douglas,60 Baldwin NW Palmyra,Insurance Commissioner,,R,Ken Selzer,266
-Douglas,61 Baldwin NE Palmyra,Insurance Commissioner,,R,Ken Selzer,333
-Douglas,62 Baldwin S Palmyra ,Insurance Commissioner,,R,Ken Selzer,270
-Douglas,63 Vinland Palmyra,Insurance Commissioner,,R,Ken Selzer,255
-Douglas,64 Wakarusa N H45,Insurance Commissioner,,R,Ken Selzer,127
-Douglas,64 Wakarusa N H46,Insurance Commissioner,,R,Ken Selzer,0
-Douglas,65 Wakarusa E H10,Insurance Commissioner,,R,Ken Selzer,156
-Douglas,65 Wakarusa E H46,Insurance Commissioner,,R,Ken Selzer,21
-Douglas,66 Wakarusa W S19 H45,Insurance Commissioner,,R,Ken Selzer,75
-Douglas,66 Wakarusa W S3 H45,Insurance Commissioner,,R,Ken Selzer,2
-Douglas,66 Wakarusa W S19 H10,Insurance Commissioner,,R,Ken Selzer,107
-Douglas,66 Wakarusa W S3   H10,Insurance Commissioner,,R,Ken Selzer,57
-Douglas,67 Willow S19  H54,Insurance Commissioner,,R,Ken Selzer,90
-Douglas,67 Willow S19  H45,Insurance Commissioner,,R,Ken Selzer,141
-Douglas,67 Willow S3  H45,Insurance Commissioner,,R,Ken Selzer,46
-Douglas,67 Willow S3  H54,Insurance Commissioner,,R,Ken Selzer,26
-Douglas,50 Eudora W,Insurance Commissioner,,D,Dennis Anderson,430
-Douglas,51 Clinton,Insurance Commissioner,,D,Dennis Anderson,169
-Douglas,52 Eudora,Insurance Commissioner,,D,Dennis Anderson,140
-Douglas,53 Eudora S H10,Insurance Commissioner,,D,Dennis Anderson,256
-Douglas,53 Eudora S H42,Insurance Commissioner,,D,Dennis Anderson,247
-Douglas,54 C Eudora,Insurance Commissioner,,D,Dennis Anderson,275
-Douglas,55 Grant S2 H45,Insurance Commissioner,,D,Dennis Anderson,7
-Douglas,55 Grant S3 H46,Insurance Commissioner,,D,Dennis Anderson,9
-Douglas,55 Grant S3 H45,Insurance Commissioner,,D,Dennis Anderson,42
-Douglas,56 Kawaka S19,Insurance Commissioner,,D,Dennis Anderson,333
-Douglas,56 Kawaka S2,Insurance Commissioner,,D,Dennis Anderson,12
-Douglas,57 Lecompton S2,Insurance Commissioner,,D,Dennis Anderson,182
-Douglas,57 Lecompton S19,Insurance Commissioner,,D,Dennis Anderson,69
-Douglas,58 Big Springs / Lec,Insurance Commissioner,,D,Dennis Anderson,78
-Douglas,59 Marion H45,Insurance Commissioner,,D,Dennis Anderson,103
-Douglas,59 Marion,Insurance Commissioner,,D,Dennis Anderson,110
-Douglas,60 Baldwin NW Palmyra,Insurance Commissioner,,D,Dennis Anderson,262
-Douglas,61 Baldwin NE Palmyra,Insurance Commissioner,,D,Dennis Anderson,357
-Douglas,62 Baldwin S Palmyra ,Insurance Commissioner,,D,Dennis Anderson,441
-Douglas,63 Vinland Palmyra,Insurance Commissioner,,D,Dennis Anderson,287
-Douglas,64 Wakarusa N H45,Insurance Commissioner,,D,Dennis Anderson,62
-Douglas,64 Wakarusa N H46,Insurance Commissioner,,D,Dennis Anderson,1
-Douglas,65 Wakarusa E H10,Insurance Commissioner,,D,Dennis Anderson,156
-Douglas,65 Wakarusa E H46,Insurance Commissioner,,D,Dennis Anderson,3
-Douglas,66 Wakarusa W S19 H45,Insurance Commissioner,,D,Dennis Anderson,81
-Douglas,66 Wakarusa W S3 H45,Insurance Commissioner,,D,Dennis Anderson,0
-Douglas,66 Wakarusa W S19 H10,Insurance Commissioner,,D,Dennis Anderson,123
-Douglas,66 Wakarusa W S3   H10,Insurance Commissioner,,D,Dennis Anderson,74
-Douglas,67 Willow S19  H54,Insurance Commissioner,,D,Dennis Anderson,163
-Douglas,67 Willow S19  H45,Insurance Commissioner,,D,Dennis Anderson,111
-Douglas,67 Willow S3  H45,Insurance Commissioner,,D,Dennis Anderson,35
-Douglas,67 Willow S3  H54,Insurance Commissioner,,D,Dennis Anderson,20
-Douglas,50 Eudora W,State House,42,R,Connie O'Brien,443
-Douglas,51 Clinton,State House,H045,R,Tom Sloan,271
-Douglas,52 Eudora,State House,42,R,Connie O'Brien,155
-Douglas,53 Eudora S H10,State House,H010,R,Nicholas VanWyhe,239
-Douglas,53 Eudora S H42,State House,42,R,Connie O'Brien,241
-Douglas,54 C Eudora,State House,42,R,Connie O'Brien,278
-Douglas,55 Grant S2 H45,State House,H045,R,Tom Sloan,15
-Douglas,55 Grant S3 H46,State House,H046,R,Douglas Robinson,11
-Douglas,55 Grant S3 H45,State House,H045,R,Tom Sloan,85
-Douglas,56 Kawaka S19,State House,H045,R,Tom Sloan,570
-Douglas,56 Kawaka S2,State House,H045,R,Tom Sloan,42
-Douglas,57 Lecompton S2,State House,H045,R,Tom Sloan,325
-Douglas,57 Lecompton S19,State House,H045,R,Tom Sloan,106
-Douglas,58 Big Springs / Lec,State House,H045,R,Tom Sloan,130
-Douglas,59 Marion H45,State House,54,R,Ken Corbet,78
-Douglas,59 Marion,State House,H045,R,Tom Sloan,197
-Douglas,60 Baldwin NW Palmyra,State House,H010,R,Nicholas VanWyhe,245
-Douglas,61 Baldwin NE Palmyra,State House,H010,R,Nicholas VanWyhe,329
-Douglas,62 Baldwin S Palmyra ,State House,H010,R,Nicholas VanWyhe,393
-Douglas,63 Vinland Palmyra,State House,H010,R,Nicholas VanWyhe,269
-Douglas,64 Wakarusa N H45,State House,H045,R,Tom Sloan,141
-Douglas,64 Wakarusa N H46,State House,H046,R,Douglas Robinson,0
-Douglas,65 Wakarusa E H10,State House,H010,R,Nicholas VanWyhe,142
-Douglas,65 Wakarusa E H46,State House,H046,R,Douglas Robinson,4
-Douglas,66 Wakarusa W S19 H45,State House,H045,R,Tom Sloan,139
-Douglas,66 Wakarusa W S3 H45,State House,H045,R,Tom Sloan,0
-Douglas,66 Wakarusa W S19 H10,State House,H010,R,Nicholas VanWyhe,114
-Douglas,66 Wakarusa W S3   H10,State House,H010,R,Nicholas VanWyhe,70
-Douglas,67 Willow S19  H54,State House,54,R,Ken Corbet,144
-Douglas,67 Willow S19  H45,State House,H045,R,Tom Sloan,200
-Douglas,67 Willow S3  H45,State House,H045,R,Tom Sloan,64
-Douglas,67 Willow S3  H54,State House,54,R,Ken Corbet,21
-Douglas,50 Eudora W,State House,42,D,Austin Harris,305
-Douglas,52 Eudora,State House,42,D,Austin Harris,160
-Douglas,53 Eudora S H10,State House,H010,D,John Wilson,152
-Douglas,53 Eudora S H42,State House,42,D,Austin Harris,166
-Douglas,54 C Eudora,State House,42,D,Austin Harris,201
-Douglas,55 Grant S3 H46,State House,H046,D,Dennis Highberger,25
-Douglas,59 Marion H45,State House,54,D,Anne Mah,82
-Douglas,60 Baldwin NW Palmyra,State House,H010,D,John Wilson,280
-Douglas,61 Baldwin NE Palmyra,State House,H010,D,John Wilson,373
-Douglas,62 Baldwin S Palmyra ,State House,H010,D,John Wilson,325
-Douglas,63 Vinland Palmyra,State House,H010,D,John Wilson,278
-Douglas,64 Wakarusa N H46,State House,H046,D,Dennis Highberger,1
-Douglas,65 Wakarusa E H10,State House,H010,D,John Wilson,168
-Douglas,65 Wakarusa E H46,State House,H046,D,Dennis Highberger,20
-Douglas,66 Wakarusa W S19 H10,State House,H010,D,John Wilson,119
-Douglas,66 Wakarusa W S3   H10,State House,H010,D,John Wilson,66
-Douglas,67 Willow S19  H54,State House,54,D,Anne Mah,120
-Douglas,67 Willow S3  H54,State House,54,D,Anne Mah,26
+county,precinct,office,district,party,candidate,votes,vtd
+DOUGLAS,Big Springs Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",88,000010
+DOUGLAS,Big Springs Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000010
+DOUGLAS,Big Springs Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",59,000010
+DOUGLAS,Central Eudora,Governor / Lt. Governor,,Democratic,"Davis, Paul",273,000020
+DOUGLAS,Central Eudora,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000020
+DOUGLAS,Central Eudora,Governor / Lt. Governor,,Republican,"Brownback, Sam",201,000020
+DOUGLAS,Clinton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",177,000030
+DOUGLAS,Clinton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000030
+DOUGLAS,Clinton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,000030
+DOUGLAS,Lawrence Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",346,00007A
+DOUGLAS,Lawrence Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,00007A
+DOUGLAS,Lawrence Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,00007A
+DOUGLAS,Lawrence Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",425,000080
+DOUGLAS,Lawrence Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000080
+DOUGLAS,Lawrence Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000080
+DOUGLAS,Lawrence Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",411,000090
+DOUGLAS,Lawrence Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000090
+DOUGLAS,Lawrence Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000090
+DOUGLAS,Lawrence Precinct 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",341,00010A
+DOUGLAS,Lawrence Precinct 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00010A
+DOUGLAS,Lawrence Precinct 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,00010A
+DOUGLAS,Lawrence Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",436,000110
+DOUGLAS,Lawrence Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000110
+DOUGLAS,Lawrence Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",146,000110
+DOUGLAS,Lawrence Precinct 06,Governor / Lt. Governor,,Democratic,"Davis, Paul",424,00012A
+DOUGLAS,Lawrence Precinct 06,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,00012A
+DOUGLAS,Lawrence Precinct 06,Governor / Lt. Governor,,Republican,"Brownback, Sam",164,00012A
+DOUGLAS,Lawrence Precinct 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",156,000130
+DOUGLAS,Lawrence Precinct 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000130
+DOUGLAS,Lawrence Precinct 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,000130
+DOUGLAS,Lawrence Precinct 08,Governor / Lt. Governor,,Democratic,"Davis, Paul",235,000140
+DOUGLAS,Lawrence Precinct 08,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000140
+DOUGLAS,Lawrence Precinct 08,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000140
+DOUGLAS,Lawrence Precinct 09,Governor / Lt. Governor,,Democratic,"Davis, Paul",221,000150
+DOUGLAS,Lawrence Precinct 09,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000150
+DOUGLAS,Lawrence Precinct 09,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000150
+DOUGLAS,Lawrence Precinct 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",109,000160
+DOUGLAS,Lawrence Precinct 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000160
+DOUGLAS,Lawrence Precinct 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000160
+DOUGLAS,Lawrence Precinct 11,Governor / Lt. Governor,,Democratic,"Davis, Paul",342,000170
+DOUGLAS,Lawrence Precinct 11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000170
+DOUGLAS,Lawrence Precinct 11,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000170
+DOUGLAS,Lawrence Precinct 12,Governor / Lt. Governor,,Democratic,"Davis, Paul",568,000180
+DOUGLAS,Lawrence Precinct 12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000180
+DOUGLAS,Lawrence Precinct 12,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000180
+DOUGLAS,Lawrence Precinct 13,Governor / Lt. Governor,,Democratic,"Davis, Paul",508,000190
+DOUGLAS,Lawrence Precinct 13,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000190
+DOUGLAS,Lawrence Precinct 13,Governor / Lt. Governor,,Republican,"Brownback, Sam",144,000190
+DOUGLAS,Lawrence Precinct 14,Governor / Lt. Governor,,Democratic,"Davis, Paul",716,000200
+DOUGLAS,Lawrence Precinct 14,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",37,000200
+DOUGLAS,Lawrence Precinct 14,Governor / Lt. Governor,,Republican,"Brownback, Sam",218,000200
+DOUGLAS,Lawrence Precinct 15,Governor / Lt. Governor,,Democratic,"Davis, Paul",592,000210
+DOUGLAS,Lawrence Precinct 15,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000210
+DOUGLAS,Lawrence Precinct 15,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000210
+DOUGLAS,Lawrence Precinct 16,Governor / Lt. Governor,,Democratic,"Davis, Paul",479,000220
+DOUGLAS,Lawrence Precinct 16,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000220
+DOUGLAS,Lawrence Precinct 16,Governor / Lt. Governor,,Republican,"Brownback, Sam",122,000220
+DOUGLAS,Lawrence Precinct 17,Governor / Lt. Governor,,Democratic,"Davis, Paul",392,000230
+DOUGLAS,Lawrence Precinct 17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000230
+DOUGLAS,Lawrence Precinct 17,Governor / Lt. Governor,,Republican,"Brownback, Sam",168,000230
+DOUGLAS,Lawrence Precinct 18,Governor / Lt. Governor,,Democratic,"Davis, Paul",724,000240
+DOUGLAS,Lawrence Precinct 18,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000240
+DOUGLAS,Lawrence Precinct 18,Governor / Lt. Governor,,Republican,"Brownback, Sam",259,000240
+DOUGLAS,Lawrence Precinct 19,Governor / Lt. Governor,,Democratic,"Davis, Paul",561,000250
+DOUGLAS,Lawrence Precinct 19,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000250
+DOUGLAS,Lawrence Precinct 19,Governor / Lt. Governor,,Republican,"Brownback, Sam",277,000250
+DOUGLAS,Lawrence Precinct 20,Governor / Lt. Governor,,Democratic,"Davis, Paul",757,000260
+DOUGLAS,Lawrence Precinct 20,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",32,000260
+DOUGLAS,Lawrence Precinct 20,Governor / Lt. Governor,,Republican,"Brownback, Sam",228,000260
+DOUGLAS,Lawrence Precinct 21,Governor / Lt. Governor,,Democratic,"Davis, Paul",297,000270
+DOUGLAS,Lawrence Precinct 21,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000270
+DOUGLAS,Lawrence Precinct 21,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000270
+DOUGLAS,Lawrence Precinct 22,Governor / Lt. Governor,,Democratic,"Davis, Paul",517,000280
+DOUGLAS,Lawrence Precinct 22,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000280
+DOUGLAS,Lawrence Precinct 22,Governor / Lt. Governor,,Republican,"Brownback, Sam",169,000280
+DOUGLAS,Lawrence Precinct 23,Governor / Lt. Governor,,Democratic,"Davis, Paul",362,000290
+DOUGLAS,Lawrence Precinct 23,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000290
+DOUGLAS,Lawrence Precinct 23,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,000290
+DOUGLAS,Lawrence Precinct 24,Governor / Lt. Governor,,Democratic,"Davis, Paul",306,000300
+DOUGLAS,Lawrence Precinct 24,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000300
+DOUGLAS,Lawrence Precinct 24,Governor / Lt. Governor,,Republican,"Brownback, Sam",106,000300
+DOUGLAS,Lawrence Precinct 25,Governor / Lt. Governor,,Democratic,"Davis, Paul",255,000310
+DOUGLAS,Lawrence Precinct 25,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000310
+DOUGLAS,Lawrence Precinct 25,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000310
+DOUGLAS,Lawrence Precinct 26,Governor / Lt. Governor,,Democratic,"Davis, Paul",357,000320
+DOUGLAS,Lawrence Precinct 26,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000320
+DOUGLAS,Lawrence Precinct 26,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000320
+DOUGLAS,Lawrence Precinct 27,Governor / Lt. Governor,,Democratic,"Davis, Paul",341,000330
+DOUGLAS,Lawrence Precinct 27,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000330
+DOUGLAS,Lawrence Precinct 27,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000330
+DOUGLAS,Lawrence Precinct 28,Governor / Lt. Governor,,Democratic,"Davis, Paul",265,000340
+DOUGLAS,Lawrence Precinct 28,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000340
+DOUGLAS,Lawrence Precinct 28,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000340
+DOUGLAS,Lawrence Precinct 29,Governor / Lt. Governor,,Democratic,"Davis, Paul",329,000350
+DOUGLAS,Lawrence Precinct 29,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000350
+DOUGLAS,Lawrence Precinct 29,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,000350
+DOUGLAS,Lawrence Precinct 31,Governor / Lt. Governor,,Democratic,"Davis, Paul",472,000370
+DOUGLAS,Lawrence Precinct 31,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000370
+DOUGLAS,Lawrence Precinct 31,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000370
+DOUGLAS,Lawrence Precinct 32,Governor / Lt. Governor,,Democratic,"Davis, Paul",220,000380
+DOUGLAS,Lawrence Precinct 32,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000380
+DOUGLAS,Lawrence Precinct 32,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000380
+DOUGLAS,Lawrence Precinct 33,Governor / Lt. Governor,,Democratic,"Davis, Paul",524,000400
+DOUGLAS,Lawrence Precinct 33,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000400
+DOUGLAS,Lawrence Precinct 33,Governor / Lt. Governor,,Republican,"Brownback, Sam",67,000400
+DOUGLAS,Lawrence Precinct 38,Governor / Lt. Governor,,Democratic,"Davis, Paul",482,000450
+DOUGLAS,Lawrence Precinct 38,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000450
+DOUGLAS,Lawrence Precinct 38,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000450
+DOUGLAS,Lawrence Precinct 39,Governor / Lt. Governor,,Democratic,"Davis, Paul",496,000460
+DOUGLAS,Lawrence Precinct 39,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000460
+DOUGLAS,Lawrence Precinct 39,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000460
+DOUGLAS,Lawrence Precinct 40,Governor / Lt. Governor,,Democratic,"Davis, Paul",467,000470
+DOUGLAS,Lawrence Precinct 40,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000470
+DOUGLAS,Lawrence Precinct 40,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",292,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",118,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00050C
+DOUGLAS,Lawrence Precinct 45,Governor / Lt. Governor,,Democratic,"Davis, Paul",1185,00052A
+DOUGLAS,Lawrence Precinct 45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,00052A
+DOUGLAS,Lawrence Precinct 45,Governor / Lt. Governor,,Republican,"Brownback, Sam",484,00052A
+DOUGLAS,Lawrence Precinct 49,Governor / Lt. Governor,,Democratic,"Davis, Paul",454,000560
+DOUGLAS,Lawrence Precinct 49,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000560
+DOUGLAS,Lawrence Precinct 49,Governor / Lt. Governor,,Republican,"Brownback, Sam",250,000560
+DOUGLAS,North Eudora Precinct 52,Governor / Lt. Governor,,Democratic,"Davis, Paul",184,000600
+DOUGLAS,North Eudora Precinct 52,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000600
+DOUGLAS,North Eudora Precinct 52,Governor / Lt. Governor,,Republican,"Brownback, Sam",120,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Governor / Lt. Governor,,Democratic,"Davis, Paul",420,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Governor / Lt. Governor,,Republican,"Brownback, Sam",278,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Governor / Lt. Governor,,Democratic,"Davis, Paul",339,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Governor / Lt. Governor,,Republican,"Brownback, Sam",193,000630
+DOUGLAS,South Baldwin Precinct 62,Governor / Lt. Governor,,Democratic,"Davis, Paul",353,000640
+DOUGLAS,South Baldwin Precinct 62,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",33,000640
+DOUGLAS,South Baldwin Precinct 62,Governor / Lt. Governor,,Republican,"Brownback, Sam",345,000640
+DOUGLAS,Vinland Precinct 63,Governor / Lt. Governor,,Democratic,"Davis, Paul",313,000660
+DOUGLAS,Vinland Precinct 63,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000660
+DOUGLAS,Vinland Precinct 63,Governor / Lt. Governor,,Republican,"Brownback, Sam",219,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120030
+DOUGLAS,Grant Township S2 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,120040
+DOUGLAS,Grant Township S2 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120040
+DOUGLAS,Grant Township S2 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,120040
+DOUGLAS,Grant Township S3 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,120050
+DOUGLAS,Grant Township S3 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120050
+DOUGLAS,Grant Township S3 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,120050
+DOUGLAS,Grant Township S3 H46,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,120060
+DOUGLAS,Grant Township S3 H46,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120060
+DOUGLAS,Grant Township S3 H46,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,120060
+DOUGLAS,Kawaka Township S19,Governor / Lt. Governor,,Democratic,"Davis, Paul",397,120070
+DOUGLAS,Kawaka Township S19,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,120070
+DOUGLAS,Kawaka Township S19,Governor / Lt. Governor,,Republican,"Brownback, Sam",273,120070
+DOUGLAS,Kawaka Township S2,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,120080
+DOUGLAS,Kawaka Township S2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120080
+DOUGLAS,Kawaka Township S2,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,120080
+DOUGLAS,Lawrence Precinct 30 S2,Governor / Lt. Governor,,Democratic,"Davis, Paul",129,120090
+DOUGLAS,Lawrence Precinct 30 S2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120090
+DOUGLAS,Lawrence Precinct 30 S2,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,120090
+DOUGLAS,Lawrence Precinct 30 S3,Governor / Lt. Governor,,Democratic,"Davis, Paul",161,120100
+DOUGLAS,Lawrence Precinct 30 S3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120100
+DOUGLAS,Lawrence Precinct 30 S3,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,120100
+DOUGLAS,Lawrence Precinct 34 S2,Governor / Lt. Governor,,Democratic,"Davis, Paul",309,120110
+DOUGLAS,Lawrence Precinct 34 S2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120110
+DOUGLAS,Lawrence Precinct 34 S2,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,120110
+DOUGLAS,Lawrence Precinct 34 S3,Governor / Lt. Governor,,Democratic,"Davis, Paul",59,120120
+DOUGLAS,Lawrence Precinct 34 S3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,120120
+DOUGLAS,Lawrence Precinct 34 S3,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,120120
+DOUGLAS,Lawrence Precinct 35 S2,Governor / Lt. Governor,,Democratic,"Davis, Paul",398,120130
+DOUGLAS,Lawrence Precinct 35 S2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,120130
+DOUGLAS,Lawrence Precinct 35 S2,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,120130
+DOUGLAS,Lawrence Precinct 35 S3,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,120140
+DOUGLAS,Lawrence Precinct 35 S3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120140
+DOUGLAS,Lawrence Precinct 35 S3,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,120140
+DOUGLAS,Lawrence Precinct 36 S2,Governor / Lt. Governor,,Democratic,"Davis, Paul",311,120150
+DOUGLAS,Lawrence Precinct 36 S2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,120150
+DOUGLAS,Lawrence Precinct 36 S2,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,120150
+DOUGLAS,Lawrence Precinct 36 S3,Governor / Lt. Governor,,Democratic,"Davis, Paul",238,120160
+DOUGLAS,Lawrence Precinct 36 S3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,120160
+DOUGLAS,Lawrence Precinct 36 S3,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,120160
+DOUGLAS,Lawrence Precinct 37 H10,Governor / Lt. Governor,,Democratic,"Davis, Paul",557,120170
+DOUGLAS,Lawrence Precinct 37 H10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,120170
+DOUGLAS,Lawrence Precinct 37 H10,Governor / Lt. Governor,,Republican,"Brownback, Sam",180,120170
+DOUGLAS,Lawrence Precinct 37 H46,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,120180
+DOUGLAS,Lawrence Precinct 37 H46,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,Governor / Lt. Governor,,Republican,"Brownback, Sam",1,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Governor / Lt. Governor,,Democratic,"Davis, Paul",729,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,Governor / Lt. Governor,,Republican,"Brownback, Sam",142,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",172,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Governor / Lt. Governor,,Democratic,"Davis, Paul",163,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,120260
+DOUGLAS,Lawrence Precinct 44 H44,Governor / Lt. Governor,,Democratic,"Davis, Paul",80,120270
+DOUGLAS,Lawrence Precinct 44 H44,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,120270
+DOUGLAS,Lawrence Precinct 44 H44,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",276,120280
+DOUGLAS,Lawrence Precinct 44 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,120280
+DOUGLAS,Lawrence Precinct 44 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",98,120280
+DOUGLAS,Lawrence Precinct 46 S19,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Governor / Lt. Governor,,Democratic,"Davis, Paul",693,120300
+DOUGLAS,Lawrence Precinct 46 S3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,120300
+DOUGLAS,Lawrence Precinct 46 S3,Governor / Lt. Governor,,Republican,"Brownback, Sam",213,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Governor / Lt. Governor,,Democratic,"Davis, Paul",240,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,120320
+DOUGLAS,Marion Township Precinct 59 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,120330
+DOUGLAS,Marion Township Precinct 59 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120330
+DOUGLAS,Marion Township Precinct 59 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,120330
+DOUGLAS,Marion Township Precinct 59 H54,Governor / Lt. Governor,,Democratic,"Davis, Paul",141,120340
+DOUGLAS,Marion Township Precinct 59 H54,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,120340
+DOUGLAS,Marion Township Precinct 59 H54,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",150,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,Governor / Lt. Governor,,Democratic,"Davis, Paul",180,120370
+DOUGLAS,South Eudora Precinct 53 H10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,120370
+DOUGLAS,South Eudora Precinct 53 H10,Governor / Lt. Governor,,Republican,"Brownback, Sam",205,120370
+DOUGLAS,South Eudora Precinct 53 H42,Governor / Lt. Governor,,Democratic,"Davis, Paul",214,120380
+DOUGLAS,South Eudora Precinct 53 H42,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,120380
+DOUGLAS,South Eudora Precinct 53 H42,Governor / Lt. Governor,,Republican,"Brownback, Sam",201,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Governor / Lt. Governor,,Democratic,"Davis, Paul",139,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",96,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Governor / Lt. Governor,,Democratic,"Davis, Paul",83,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120420
+DOUGLAS,Willow Springs Township S19 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",163,120430
+DOUGLAS,Willow Springs Township S19 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120430
+DOUGLAS,Willow Springs Township S19 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,120430
+DOUGLAS,Willow Springs Township S19 H54,Governor / Lt. Governor,,Democratic,"Davis, Paul",129,120440
+DOUGLAS,Willow Springs Township S19 H54,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120440
+DOUGLAS,Willow Springs Township S19 H54,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,120440
+DOUGLAS,Willow Springs Township S3 H45,Governor / Lt. Governor,,Democratic,"Davis, Paul",54,120450
+DOUGLAS,Willow Springs Township S3 H45,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120450
+DOUGLAS,Willow Springs Township S3 H45,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,120450
+DOUGLAS,Willow Springs Township S3 H54,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,120460
+DOUGLAS,Willow Springs Township S3 H54,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120460
+DOUGLAS,Willow Springs Township S3 H54,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,Governor / Lt. Governor,,Democratic,"Davis, Paul",183,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,400010
+DOUGLAS,Lawrence Precinct 47,Governor / Lt. Governor,,Democratic,"Davis, Paul",251,400030
+DOUGLAS,Lawrence Precinct 47,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,400030
+DOUGLAS,Lawrence Precinct 47,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,400030
+DOUGLAS,Lawrence Precinct 48,Governor / Lt. Governor,,Democratic,"Davis, Paul",650,400040
+DOUGLAS,Lawrence Precinct 48,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,400040
+DOUGLAS,Lawrence Precinct 48,Governor / Lt. Governor,,Republican,"Brownback, Sam",211,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",376,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",51,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",326,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,400110
+DOUGLAS,Lawrence Precinct 68,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+DOUGLAS,Lawrence Precinct 68,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+DOUGLAS,Lawrence Precinct 68,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+DOUGLAS,Lawrence Precinct 69,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+DOUGLAS,Lawrence Precinct 69,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+DOUGLAS,Lawrence Precinct 69,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+DOUGLAS,Lawrence Precinct 70,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,900040
+DOUGLAS,Lawrence Precinct 70,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+DOUGLAS,Lawrence Precinct 70,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,900040
+DOUGLAS,Lawrence Precinct 71,Governor / Lt. Governor,,Democratic,"Davis, Paul",469,900050
+DOUGLAS,Lawrence Precinct 71,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,900050
+DOUGLAS,Lawrence Precinct 71,Governor / Lt. Governor,,Republican,"Brownback, Sam",167,900050
+DOUGLAS,Lawrence Precinct 72,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900060
+DOUGLAS,Lawrence Precinct 72,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+DOUGLAS,Lawrence Precinct 72,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900060
+DOUGLAS,Lawrence Precinct 73,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900070
+DOUGLAS,Lawrence Precinct 73,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900070
+DOUGLAS,Lawrence Precinct 73,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900070
+DOUGLAS,Lawrence Precinct 74,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900080
+DOUGLAS,Lawrence Precinct 74,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900080
+DOUGLAS,Lawrence Precinct 74,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",298,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",127,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900170
+DOUGLAS,Big Springs Township,Kansas House of Representatives,45,Republican,"Sloan, Tom",130,000010
+DOUGLAS,Central Eudora,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",201,000020
+DOUGLAS,Central Eudora,Kansas House of Representatives,42,Republican,"O'Brien, Connie",278,000020
+DOUGLAS,Clinton Township,Kansas House of Representatives,45,Republican,"Sloan, Tom",271,000030
+DOUGLAS,Lawrence Precinct 01,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",330,00007A
+DOUGLAS,Lawrence Precinct 01,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",63,00007A
+DOUGLAS,Lawrence Precinct 02,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",416,000080
+DOUGLAS,Lawrence Precinct 02,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",59,000080
+DOUGLAS,Lawrence Precinct 03,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",409,000090
+DOUGLAS,Lawrence Precinct 03,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",45,000090
+DOUGLAS,Lawrence Precinct 04,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",328,00010A
+DOUGLAS,Lawrence Precinct 04,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",71,00010A
+DOUGLAS,Lawrence Precinct 05,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",478,000110
+DOUGLAS,Lawrence Precinct 06,Kansas House of Representatives,45,Republican,"Sloan, Tom",465,00012A
+DOUGLAS,Lawrence Precinct 07,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",151,000130
+DOUGLAS,Lawrence Precinct 07,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",15,000130
+DOUGLAS,Lawrence Precinct 08,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",224,000140
+DOUGLAS,Lawrence Precinct 08,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",29,000140
+DOUGLAS,Lawrence Precinct 09,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",208,000150
+DOUGLAS,Lawrence Precinct 09,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",37,000150
+DOUGLAS,Lawrence Precinct 10,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",78,000160
+DOUGLAS,Lawrence Precinct 10,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",21,000160
+DOUGLAS,Lawrence Precinct 11,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",356,000170
+DOUGLAS,Lawrence Precinct 12,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",593,000180
+DOUGLAS,Lawrence Precinct 13,Kansas House of Representatives,45,Republican,"Sloan, Tom",468,000190
+DOUGLAS,Lawrence Precinct 14,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",816,000200
+DOUGLAS,Lawrence Precinct 15,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",632,000210
+DOUGLAS,Lawrence Precinct 16,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",504,000220
+DOUGLAS,Lawrence Precinct 17,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",443,000230
+DOUGLAS,Lawrence Precinct 18,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",797,000240
+DOUGLAS,Lawrence Precinct 19,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",628,000250
+DOUGLAS,Lawrence Precinct 20,Kansas House of Representatives,45,Republican,"Sloan, Tom",764,000260
+DOUGLAS,Lawrence Precinct 21,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",284,000270
+DOUGLAS,Lawrence Precinct 21,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",66,000270
+DOUGLAS,Lawrence Precinct 22,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",586,000280
+DOUGLAS,Lawrence Precinct 23,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",381,000290
+DOUGLAS,Lawrence Precinct 24,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",330,000300
+DOUGLAS,Lawrence Precinct 25,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",234,000310
+DOUGLAS,Lawrence Precinct 25,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",33,000310
+DOUGLAS,Lawrence Precinct 26,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",333,000320
+DOUGLAS,Lawrence Precinct 26,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",56,000320
+DOUGLAS,Lawrence Precinct 27,Kansas House of Representatives,10,Democratic,"Wilson, John",328,000330
+DOUGLAS,Lawrence Precinct 27,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",73,000330
+DOUGLAS,Lawrence Precinct 28,Kansas House of Representatives,10,Democratic,"Wilson, John",240,000340
+DOUGLAS,Lawrence Precinct 28,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",53,000340
+DOUGLAS,Lawrence Precinct 29,Kansas House of Representatives,10,Democratic,"Wilson, John",311,000350
+DOUGLAS,Lawrence Precinct 29,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",82,000350
+DOUGLAS,Lawrence Precinct 31,Kansas House of Representatives,10,Democratic,"Wilson, John",431,000370
+DOUGLAS,Lawrence Precinct 31,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",170,000370
+DOUGLAS,Lawrence Precinct 32,Kansas House of Representatives,10,Democratic,"Wilson, John",197,000380
+DOUGLAS,Lawrence Precinct 32,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",93,000380
+DOUGLAS,Lawrence Precinct 33,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",498,000400
+DOUGLAS,Lawrence Precinct 33,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",85,000400
+DOUGLAS,Lawrence Precinct 38,Kansas House of Representatives,10,Democratic,"Wilson, John",425,000450
+DOUGLAS,Lawrence Precinct 38,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",182,000450
+DOUGLAS,Lawrence Precinct 39,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",484,000460
+DOUGLAS,Lawrence Precinct 39,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",38,000460
+DOUGLAS,Lawrence Precinct 40,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",449,000470
+DOUGLAS,Lawrence Precinct 40,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",24,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Kansas House of Representatives,45,Republican,"Sloan, Tom",315,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00050C
+DOUGLAS,Lawrence Precinct 45,Kansas House of Representatives,45,Republican,"Sloan, Tom",1339,00052A
+DOUGLAS,Lawrence Precinct 49,Kansas House of Representatives,45,Republican,"Sloan, Tom",575,000560
+DOUGLAS,North Eudora Precinct 52,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",160,000600
+DOUGLAS,North Eudora Precinct 52,Kansas House of Representatives,42,Republican,"O'Brien, Connie",155,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas House of Representatives,10,Democratic,"Wilson, John",373,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",329,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas House of Representatives,10,Democratic,"Wilson, John",280,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",245,000630
+DOUGLAS,South Baldwin Precinct 62,Kansas House of Representatives,10,Democratic,"Wilson, John",325,000640
+DOUGLAS,South Baldwin Precinct 62,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",393,000640
+DOUGLAS,Vinland Precinct 63,Kansas House of Representatives,10,Democratic,"Wilson, John",278,000660
+DOUGLAS,Vinland Precinct 63,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",269,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",0,120030
+DOUGLAS,Grant Township S2 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",15,120040
+DOUGLAS,Grant Township S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",85,120050
+DOUGLAS,Grant Township S3 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",25,120060
+DOUGLAS,Grant Township S3 H46,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",11,120060
+DOUGLAS,Kawaka Township S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",570,120070
+DOUGLAS,Kawaka Township S2,Kansas House of Representatives,45,Republican,"Sloan, Tom",42,120080
+DOUGLAS,Lawrence Precinct 30 S2,Kansas House of Representatives,10,Democratic,"Wilson, John",119,120090
+DOUGLAS,Lawrence Precinct 30 S2,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",41,120090
+DOUGLAS,Lawrence Precinct 30 S3,Kansas House of Representatives,10,Democratic,"Wilson, John",155,120100
+DOUGLAS,Lawrence Precinct 30 S3,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",32,120100
+DOUGLAS,Lawrence Precinct 34 S2,Kansas House of Representatives,10,Democratic,"Wilson, John",296,120110
+DOUGLAS,Lawrence Precinct 34 S2,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",49,120110
+DOUGLAS,Lawrence Precinct 34 S3,Kansas House of Representatives,10,Democratic,"Wilson, John",64,120120
+DOUGLAS,Lawrence Precinct 34 S3,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",2,120120
+DOUGLAS,Lawrence Precinct 35 S2,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",371,120130
+DOUGLAS,Lawrence Precinct 35 S2,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",88,120130
+DOUGLAS,Lawrence Precinct 35 S3,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",24,120140
+DOUGLAS,Lawrence Precinct 35 S3,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",10,120140
+DOUGLAS,Lawrence Precinct 36 S2,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",284,120150
+DOUGLAS,Lawrence Precinct 36 S2,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",105,120150
+DOUGLAS,Lawrence Precinct 36 S3,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",232,120160
+DOUGLAS,Lawrence Precinct 36 S3,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",89,120160
+DOUGLAS,Lawrence Precinct 37 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",501,120170
+DOUGLAS,Lawrence Precinct 37 H10,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",233,120170
+DOUGLAS,Lawrence Precinct 37 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",19,120180
+DOUGLAS,Lawrence Precinct 37 H46,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",8,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",5,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",2,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",682,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",207,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",181,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",143,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",42,120260
+DOUGLAS,Lawrence Precinct 44 H44,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",79,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",291,120280
+DOUGLAS,Lawrence Precinct 46 S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Kansas House of Representatives,45,Republican,"Sloan, Tom",652,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",106,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Kansas House of Representatives,45,Republican,"Sloan, Tom",325,120320
+DOUGLAS,Marion Township Precinct 59 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",197,120330
+DOUGLAS,Marion Township Precinct 59 H54,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",82,120340
+DOUGLAS,Marion Township Precinct 59 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",78,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",141,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",152,120370
+DOUGLAS,South Eudora Precinct 53 H10,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",239,120370
+DOUGLAS,South Eudora Precinct 53 H42,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",166,120380
+DOUGLAS,South Eudora Precinct 53 H42,Kansas House of Representatives,42,Republican,"O'Brien, Connie",241,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",119,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",114,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",139,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",66,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",70,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120420
+DOUGLAS,Willow Springs Township S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",200,120430
+DOUGLAS,Willow Springs Township S19 H54,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",120,120440
+DOUGLAS,Willow Springs Township S19 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",144,120440
+DOUGLAS,Willow Springs Township S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",64,120450
+DOUGLAS,Willow Springs Township S3 H54,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",26,120460
+DOUGLAS,Willow Springs Township S3 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",21,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas House of Representatives,10,Democratic,"Wilson, John",168,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",142,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400010
+DOUGLAS,Lawrence Precinct 47,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",287,400030
+DOUGLAS,Lawrence Precinct 48,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",716,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas House of Representatives,42,Republican,"O'Brien, Connie",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",305,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas House of Representatives,42,Republican,"O'Brien, Connie",443,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas House of Representatives,42,Republican,"O'Brien, Connie",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400110
+DOUGLAS,Lawrence Precinct 68,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900010
+DOUGLAS,Lawrence Precinct 69,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900020
+DOUGLAS,Lawrence Precinct 69,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",0,900020
+DOUGLAS,Lawrence Precinct 70,Kansas House of Representatives,45,Republican,"Sloan, Tom",7,900040
+DOUGLAS,Lawrence Precinct 71,Kansas House of Representatives,45,Republican,"Sloan, Tom",499,900050
+DOUGLAS,Lawrence Precinct 72,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900060
+DOUGLAS,Lawrence Precinct 73,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900070
+DOUGLAS,Lawrence Precinct 74,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",310,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",20,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",4,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,Kansas House of Representatives,46,Republican,"Robinson, J. Douglas",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas House of Representatives,10,Republican,"VanWyhe, Nicolas D.",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900170
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",67,000010
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000010
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000010
+DOUGLAS,Central Eudora,United States House of Representatives,2,Democratic,"Wakefield, Margie",188,000020
+DOUGLAS,Central Eudora,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",31,000020
+DOUGLAS,Central Eudora,United States House of Representatives,2,Republican,"Jenkins, Lynn",276,000020
+DOUGLAS,Clinton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",131,000030
+DOUGLAS,Clinton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000030
+DOUGLAS,Clinton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",194,000030
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",319,00007A
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,00007A
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,00007A
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",411,000080
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000080
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000080
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",398,000090
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000090
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000090
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",313,00010A
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,00010A
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,00010A
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",366,000110
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000110
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",216,000110
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",341,00012A
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,00012A
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",244,00012A
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",147,000130
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000130
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",12,000130
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",224,000140
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000140
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",29,000140
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",202,000150
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000150
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,000150
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",90,000160
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000160
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",28,000160
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",300,000170
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000170
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000170
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Democratic,"Wakefield, Margie",511,000180
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",26,000180
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Republican,"Jenkins, Lynn",177,000180
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Democratic,"Wakefield, Margie",435,000190
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000190
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Republican,"Jenkins, Lynn",208,000190
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Democratic,"Wakefield, Margie",612,000200
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,000200
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Republican,"Jenkins, Lynn",330,000200
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Democratic,"Wakefield, Margie",536,000210
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,000210
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Republican,"Jenkins, Lynn",159,000210
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Democratic,"Wakefield, Margie",421,000220
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000220
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000220
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Democratic,"Wakefield, Margie",336,000230
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000230
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000230
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Democratic,"Wakefield, Margie",585,000240
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000240
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Republican,"Jenkins, Lynn",381,000240
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Democratic,"Wakefield, Margie",441,000250
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000250
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Republican,"Jenkins, Lynn",397,000250
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Democratic,"Wakefield, Margie",615,000260
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",43,000260
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Republican,"Jenkins, Lynn",347,000260
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Democratic,"Wakefield, Margie",270,000270
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000270
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000270
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Democratic,"Wakefield, Margie",435,000280
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",34,000280
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Republican,"Jenkins, Lynn",232,000280
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Democratic,"Wakefield, Margie",313,000290
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000290
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000290
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Democratic,"Wakefield, Margie",246,000300
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000300
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000300
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Democratic,"Wakefield, Margie",231,000310
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000310
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000310
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Democratic,"Wakefield, Margie",328,000320
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000320
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000320
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Democratic,"Wakefield, Margie",318,000330
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000330
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000330
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Democratic,"Wakefield, Margie",231,000340
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000340
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Republican,"Jenkins, Lynn",58,000340
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Democratic,"Wakefield, Margie",303,000350
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000350
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Republican,"Jenkins, Lynn",88,000350
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Democratic,"Wakefield, Margie",413,000370
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000370
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Republican,"Jenkins, Lynn",186,000370
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Democratic,"Wakefield, Margie",190,000380
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000380
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000380
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Democratic,"Wakefield, Margie",488,000400
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000400
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000400
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Democratic,"Wakefield, Margie",395,000450
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",26,000450
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Republican,"Jenkins, Lynn",201,000450
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Democratic,"Wakefield, Margie",466,000460
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000460
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000460
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Democratic,"Wakefield, Margie",442,000470
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000470
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Republican,"Jenkins, Lynn",28,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",247,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00050C
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Democratic,"Wakefield, Margie",916,00052A
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",36,00052A
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Republican,"Jenkins, Lynn",741,00052A
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Democratic,"Wakefield, Margie",346,000560
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000560
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Republican,"Jenkins, Lynn",357,000560
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Democratic,"Wakefield, Margie",144,000600
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000600
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Republican,"Jenkins, Lynn",160,000600
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Democratic,"Wakefield, Margie",310,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",29,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Republican,"Jenkins, Lynn",387,000620
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Democratic,"Wakefield, Margie",260,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Republican,"Jenkins, Lynn",267,000630
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Democratic,"Wakefield, Margie",254,000640
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",26,000640
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Republican,"Jenkins, Lynn",448,000640
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Democratic,"Wakefield, Margie",244,000660
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,000660
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Republican,"Jenkins, Lynn",294,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",19,120040
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120040
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",9,120040
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",59,120050
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,120050
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,120050
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,120060
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120060
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",11,120060
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Democratic,"Wakefield, Margie",312,120070
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,120070
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",348,120070
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,120080
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,120080
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",17,120080
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Democratic,"Wakefield, Margie",108,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,120090
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Democratic,"Wakefield, Margie",146,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,120100
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Democratic,"Wakefield, Margie",291,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,120110
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Democratic,"Wakefield, Margie",60,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",5,120120
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Democratic,"Wakefield, Margie",352,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,120130
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Democratic,"Wakefield, Margie",22,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",10,120140
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Democratic,"Wakefield, Margie",260,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",116,120150
+DOUGLAS,Lawrence Precinct 36 S3,United States House of Representatives,2,Democratic,"Wakefield, Margie",209,120160
+DOUGLAS,Lawrence Precinct 36 S3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,120160
+DOUGLAS,Lawrence Precinct 36 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",97,120160
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Democratic,"Wakefield, Margie",465,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",31,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",260,120170
+DOUGLAS,Lawrence Precinct 37 H46,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,120180
+DOUGLAS,Lawrence Precinct 37 H46,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,120180
+DOUGLAS,Lawrence Precinct 37 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",12,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Democratic,"Wakefield, Margie",5,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",2,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Democratic,"Wakefield, Margie",659,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",37,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",202,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",140,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Democratic,"Wakefield, Margie",149,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,120260
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Democratic,"Wakefield, Margie",63,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",219,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",149,120280
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Democratic,"Wakefield, Margie",565,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",328,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Democratic,"Wakefield, Margie",177,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,120320
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",48,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",111,120330
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Democratic,"Wakefield, Margie",111,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",118,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",127,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Democratic,"Wakefield, Margie",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Democratic,"Wakefield, Margie",122,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",263,120370
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Democratic,"Wakefield, Margie",154,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",254,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Democratic,"Wakefield, Margie",104,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",74,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Democratic,"Wakefield, Margie",56,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120420
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",133,120430
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,120430
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",119,120430
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Democratic,"Wakefield, Margie",87,120440
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,120440
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,120440
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Democratic,"Wakefield, Margie",42,120450
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120450
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,120450
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Democratic,"Wakefield, Margie",22,120460
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120460
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",23,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Democratic,"Wakefield, Margie",139,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Republican,"Jenkins, Lynn",177,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400010
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Democratic,"Wakefield, Margie",197,400030
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,400030
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Republican,"Jenkins, Lynn",154,400030
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Democratic,"Wakefield, Margie",536,400040
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,400040
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Republican,"Jenkins, Lynn",320,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",271,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",43,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",447,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400110
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Democratic,"Wakefield, Margie",4,900040
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900040
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Republican,"Jenkins, Lynn",6,900040
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Democratic,"Wakefield, Margie",370,900050
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,900050
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Republican,"Jenkins, Lynn",259,900050
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900060
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900060
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900060
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900070
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900070
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900070
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900080
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900080
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",254,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",173,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",4,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900170
+DOUGLAS,Big Springs Township,Attorney General,,Democratic,"Kotich, A.J.",71,000010
+DOUGLAS,Big Springs Township,Attorney General,,Republican,"Schmidt, Derek",82,000010
+DOUGLAS,Central Eudora,Attorney General,,Democratic,"Kotich, A.J.",190,000020
+DOUGLAS,Central Eudora,Attorney General,,Republican,"Schmidt, Derek",284,000020
+DOUGLAS,Clinton Township,Attorney General,,Democratic,"Kotich, A.J.",129,000030
+DOUGLAS,Clinton Township,Attorney General,,Republican,"Schmidt, Derek",192,000030
+DOUGLAS,Lawrence Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",306,00007A
+DOUGLAS,Lawrence Precinct 01,Attorney General,,Republican,"Schmidt, Derek",75,00007A
+DOUGLAS,Lawrence Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",379,000080
+DOUGLAS,Lawrence Precinct 02,Attorney General,,Republican,"Schmidt, Derek",79,000080
+DOUGLAS,Lawrence Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",361,000090
+DOUGLAS,Lawrence Precinct 03,Attorney General,,Republican,"Schmidt, Derek",76,000090
+DOUGLAS,Lawrence Precinct 04,Attorney General,,Democratic,"Kotich, A.J.",297,00010A
+DOUGLAS,Lawrence Precinct 04,Attorney General,,Republican,"Schmidt, Derek",84,00010A
+DOUGLAS,Lawrence Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",339,000110
+DOUGLAS,Lawrence Precinct 05,Attorney General,,Republican,"Schmidt, Derek",233,000110
+DOUGLAS,Lawrence Precinct 06,Attorney General,,Democratic,"Kotich, A.J.",334,00012A
+DOUGLAS,Lawrence Precinct 06,Attorney General,,Republican,"Schmidt, Derek",244,00012A
+DOUGLAS,Lawrence Precinct 07,Attorney General,,Democratic,"Kotich, A.J.",138,000130
+DOUGLAS,Lawrence Precinct 07,Attorney General,,Republican,"Schmidt, Derek",21,000130
+DOUGLAS,Lawrence Precinct 08,Attorney General,,Democratic,"Kotich, A.J.",209,000140
+DOUGLAS,Lawrence Precinct 08,Attorney General,,Republican,"Schmidt, Derek",37,000140
+DOUGLAS,Lawrence Precinct 09,Attorney General,,Democratic,"Kotich, A.J.",191,000150
+DOUGLAS,Lawrence Precinct 09,Attorney General,,Republican,"Schmidt, Derek",53,000150
+DOUGLAS,Lawrence Precinct 10,Attorney General,,Democratic,"Kotich, A.J.",90,000160
+DOUGLAS,Lawrence Precinct 10,Attorney General,,Republican,"Schmidt, Derek",35,000160
+DOUGLAS,Lawrence Precinct 11,Attorney General,,Democratic,"Kotich, A.J.",280,000170
+DOUGLAS,Lawrence Precinct 11,Attorney General,,Republican,"Schmidt, Derek",120,000170
+DOUGLAS,Lawrence Precinct 12,Attorney General,,Democratic,"Kotich, A.J.",480,000180
+DOUGLAS,Lawrence Precinct 12,Attorney General,,Republican,"Schmidt, Derek",207,000180
+DOUGLAS,Lawrence Precinct 13,Attorney General,,Democratic,"Kotich, A.J.",388,000190
+DOUGLAS,Lawrence Precinct 13,Attorney General,,Republican,"Schmidt, Derek",247,000190
+DOUGLAS,Lawrence Precinct 14,Attorney General,,Democratic,"Kotich, A.J.",576,000200
+DOUGLAS,Lawrence Precinct 14,Attorney General,,Republican,"Schmidt, Derek",358,000200
+DOUGLAS,Lawrence Precinct 15,Attorney General,,Democratic,"Kotich, A.J.",489,000210
+DOUGLAS,Lawrence Precinct 15,Attorney General,,Republican,"Schmidt, Derek",204,000210
+DOUGLAS,Lawrence Precinct 16,Attorney General,,Democratic,"Kotich, A.J.",375,000220
+DOUGLAS,Lawrence Precinct 16,Attorney General,,Republican,"Schmidt, Derek",204,000220
+DOUGLAS,Lawrence Precinct 17,Attorney General,,Democratic,"Kotich, A.J.",313,000230
+DOUGLAS,Lawrence Precinct 17,Attorney General,,Republican,"Schmidt, Derek",236,000230
+DOUGLAS,Lawrence Precinct 18,Attorney General,,Democratic,"Kotich, A.J.",535,000240
+DOUGLAS,Lawrence Precinct 18,Attorney General,,Republican,"Schmidt, Derek",407,000240
+DOUGLAS,Lawrence Precinct 19,Attorney General,,Democratic,"Kotich, A.J.",384,000250
+DOUGLAS,Lawrence Precinct 19,Attorney General,,Republican,"Schmidt, Derek",417,000250
+DOUGLAS,Lawrence Precinct 20,Attorney General,,Democratic,"Kotich, A.J.",579,000260
+DOUGLAS,Lawrence Precinct 20,Attorney General,,Republican,"Schmidt, Derek",387,000260
+DOUGLAS,Lawrence Precinct 21,Attorney General,,Democratic,"Kotich, A.J.",246,000270
+DOUGLAS,Lawrence Precinct 21,Attorney General,,Republican,"Schmidt, Derek",91,000270
+DOUGLAS,Lawrence Precinct 22,Attorney General,,Democratic,"Kotich, A.J.",425,000280
+DOUGLAS,Lawrence Precinct 22,Attorney General,,Republican,"Schmidt, Derek",255,000280
+DOUGLAS,Lawrence Precinct 23,Attorney General,,Democratic,"Kotich, A.J.",282,000290
+DOUGLAS,Lawrence Precinct 23,Attorney General,,Republican,"Schmidt, Derek",156,000290
+DOUGLAS,Lawrence Precinct 24,Attorney General,,Democratic,"Kotich, A.J.",220,000300
+DOUGLAS,Lawrence Precinct 24,Attorney General,,Republican,"Schmidt, Derek",178,000300
+DOUGLAS,Lawrence Precinct 25,Attorney General,,Democratic,"Kotich, A.J.",214,000310
+DOUGLAS,Lawrence Precinct 25,Attorney General,,Republican,"Schmidt, Derek",49,000310
+DOUGLAS,Lawrence Precinct 26,Attorney General,,Democratic,"Kotich, A.J.",304,000320
+DOUGLAS,Lawrence Precinct 26,Attorney General,,Republican,"Schmidt, Derek",73,000320
+DOUGLAS,Lawrence Precinct 27,Attorney General,,Democratic,"Kotich, A.J.",305,000330
+DOUGLAS,Lawrence Precinct 27,Attorney General,,Republican,"Schmidt, Derek",95,000330
+DOUGLAS,Lawrence Precinct 28,Attorney General,,Democratic,"Kotich, A.J.",215,000340
+DOUGLAS,Lawrence Precinct 28,Attorney General,,Republican,"Schmidt, Derek",71,000340
+DOUGLAS,Lawrence Precinct 29,Attorney General,,Democratic,"Kotich, A.J.",295,000350
+DOUGLAS,Lawrence Precinct 29,Attorney General,,Republican,"Schmidt, Derek",93,000350
+DOUGLAS,Lawrence Precinct 31,Attorney General,,Democratic,"Kotich, A.J.",381,000370
+DOUGLAS,Lawrence Precinct 31,Attorney General,,Republican,"Schmidt, Derek",207,000370
+DOUGLAS,Lawrence Precinct 32,Attorney General,,Democratic,"Kotich, A.J.",178,000380
+DOUGLAS,Lawrence Precinct 32,Attorney General,,Republican,"Schmidt, Derek",108,000380
+DOUGLAS,Lawrence Precinct 33,Attorney General,,Democratic,"Kotich, A.J.",458,000400
+DOUGLAS,Lawrence Precinct 33,Attorney General,,Republican,"Schmidt, Derek",114,000400
+DOUGLAS,Lawrence Precinct 38,Attorney General,,Democratic,"Kotich, A.J.",371,000450
+DOUGLAS,Lawrence Precinct 38,Attorney General,,Republican,"Schmidt, Derek",223,000450
+DOUGLAS,Lawrence Precinct 39,Attorney General,,Democratic,"Kotich, A.J.",446,000460
+DOUGLAS,Lawrence Precinct 39,Attorney General,,Republican,"Schmidt, Derek",55,000460
+DOUGLAS,Lawrence Precinct 40,Attorney General,,Democratic,"Kotich, A.J.",424,000470
+DOUGLAS,Lawrence Precinct 40,Attorney General,,Republican,"Schmidt, Derek",39,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,Attorney General,,Democratic,"Kotich, A.J.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,Attorney General,,Republican,"Schmidt, Derek",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Attorney General,,Democratic,"Kotich, A.J.",213,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,Attorney General,,Republican,"Schmidt, Derek",182,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Attorney General,,Democratic,"Kotich, A.J.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,Attorney General,,Republican,"Schmidt, Derek",0,00050C
+DOUGLAS,Lawrence Precinct 45,Attorney General,,Democratic,"Kotich, A.J.",829,00052A
+DOUGLAS,Lawrence Precinct 45,Attorney General,,Republican,"Schmidt, Derek",784,00052A
+DOUGLAS,Lawrence Precinct 49,Attorney General,,Democratic,"Kotich, A.J.",324,000560
+DOUGLAS,Lawrence Precinct 49,Attorney General,,Republican,"Schmidt, Derek",366,000560
+DOUGLAS,North Eudora Precinct 52,Attorney General,,Democratic,"Kotich, A.J.",159,000600
+DOUGLAS,North Eudora Precinct 52,Attorney General,,Republican,"Schmidt, Derek",151,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Attorney General,,Democratic,"Kotich, A.J.",310,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Attorney General,,Republican,"Schmidt, Derek",374,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Attorney General,,Democratic,"Kotich, A.J.",248,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Attorney General,,Republican,"Schmidt, Derek",279,000630
+DOUGLAS,South Baldwin Precinct 62,Attorney General,,Democratic,"Kotich, A.J.",255,000640
+DOUGLAS,South Baldwin Precinct 62,Attorney General,,Republican,"Schmidt, Derek",451,000640
+DOUGLAS,Vinland Precinct 63,Attorney General,,Democratic,"Kotich, A.J.",235,000660
+DOUGLAS,Vinland Precinct 63,Attorney General,,Republican,"Schmidt, Derek",298,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Attorney General,,Democratic,"Kotich, A.J.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Attorney General,,Republican,"Schmidt, Derek",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Attorney General,,Democratic,"Kotich, A.J.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Attorney General,,Republican,"Schmidt, Derek",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Attorney General,,Democratic,"Kotich, A.J.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Attorney General,,Republican,"Schmidt, Derek",0,120030
+DOUGLAS,Grant Township S2 H45,Attorney General,,Democratic,"Kotich, A.J.",18,120040
+DOUGLAS,Grant Township S2 H45,Attorney General,,Republican,"Schmidt, Derek",7,120040
+DOUGLAS,Grant Township S3 H45,Attorney General,,Democratic,"Kotich, A.J.",65,120050
+DOUGLAS,Grant Township S3 H45,Attorney General,,Republican,"Schmidt, Derek",42,120050
+DOUGLAS,Grant Township S3 H46,Attorney General,,Democratic,"Kotich, A.J.",24,120060
+DOUGLAS,Grant Township S3 H46,Attorney General,,Republican,"Schmidt, Derek",12,120060
+DOUGLAS,Kawaka Township S19,Attorney General,,Democratic,"Kotich, A.J.",272,120070
+DOUGLAS,Kawaka Township S19,Attorney General,,Republican,"Schmidt, Derek",394,120070
+DOUGLAS,Kawaka Township S2,Attorney General,,Democratic,"Kotich, A.J.",29,120080
+DOUGLAS,Kawaka Township S2,Attorney General,,Republican,"Schmidt, Derek",19,120080
+DOUGLAS,Lawrence Precinct 30 S2,Attorney General,,Democratic,"Kotich, A.J.",109,120090
+DOUGLAS,Lawrence Precinct 30 S2,Attorney General,,Republican,"Schmidt, Derek",45,120090
+DOUGLAS,Lawrence Precinct 30 S3,Attorney General,,Democratic,"Kotich, A.J.",133,120100
+DOUGLAS,Lawrence Precinct 30 S3,Attorney General,,Republican,"Schmidt, Derek",51,120100
+DOUGLAS,Lawrence Precinct 34 S2,Attorney General,,Democratic,"Kotich, A.J.",271,120110
+DOUGLAS,Lawrence Precinct 34 S2,Attorney General,,Republican,"Schmidt, Derek",72,120110
+DOUGLAS,Lawrence Precinct 34 S3,Attorney General,,Democratic,"Kotich, A.J.",58,120120
+DOUGLAS,Lawrence Precinct 34 S3,Attorney General,,Republican,"Schmidt, Derek",9,120120
+DOUGLAS,Lawrence Precinct 35 S2,Attorney General,,Democratic,"Kotich, A.J.",357,120130
+DOUGLAS,Lawrence Precinct 35 S2,Attorney General,,Republican,"Schmidt, Derek",96,120130
+DOUGLAS,Lawrence Precinct 35 S3,Attorney General,,Democratic,"Kotich, A.J.",23,120140
+DOUGLAS,Lawrence Precinct 35 S3,Attorney General,,Republican,"Schmidt, Derek",12,120140
+DOUGLAS,Lawrence Precinct 36 S2,Attorney General,,Democratic,"Kotich, A.J.",253,120150
+DOUGLAS,Lawrence Precinct 36 S2,Attorney General,,Republican,"Schmidt, Derek",126,120150
+DOUGLAS,Lawrence Precinct 36 S3,Attorney General,,Democratic,"Kotich, A.J.",194,120160
+DOUGLAS,Lawrence Precinct 36 S3,Attorney General,,Republican,"Schmidt, Derek",119,120160
+DOUGLAS,Lawrence Precinct 37 H10,Attorney General,,Democratic,"Kotich, A.J.",466,120170
+DOUGLAS,Lawrence Precinct 37 H10,Attorney General,,Republican,"Schmidt, Derek",266,120170
+DOUGLAS,Lawrence Precinct 37 H46,Attorney General,,Democratic,"Kotich, A.J.",17,120180
+DOUGLAS,Lawrence Precinct 37 H46,Attorney General,,Republican,"Schmidt, Derek",11,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Attorney General,,Democratic,"Kotich, A.J.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Attorney General,,Republican,"Schmidt, Derek",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Attorney General,,Democratic,"Kotich, A.J.",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Attorney General,,Republican,"Schmidt, Derek",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Attorney General,,Democratic,"Kotich, A.J.",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Attorney General,,Republican,"Schmidt, Derek",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Attorney General,,Democratic,"Kotich, A.J.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Attorney General,,Republican,"Schmidt, Derek",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Attorney General,,Democratic,"Kotich, A.J.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,Attorney General,,Republican,"Schmidt, Derek",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Attorney General,,Democratic,"Kotich, A.J.",5,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,Attorney General,,Republican,"Schmidt, Derek",2,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Attorney General,,Democratic,"Kotich, A.J.",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,Attorney General,,Republican,"Schmidt, Derek",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Attorney General,,Democratic,"Kotich, A.J.",632,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,Attorney General,,Republican,"Schmidt, Derek",220,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Attorney General,,Democratic,"Kotich, A.J.",142,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Attorney General,,Republican,"Schmidt, Derek",90,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Attorney General,,Democratic,"Kotich, A.J.",137,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Attorney General,,Republican,"Schmidt, Derek",49,120260
+DOUGLAS,Lawrence Precinct 44 H44,Attorney General,,Democratic,"Kotich, A.J.",60,120270
+DOUGLAS,Lawrence Precinct 44 H44,Attorney General,,Republican,"Schmidt, Derek",36,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Attorney General,,Democratic,"Kotich, A.J.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,Attorney General,,Republican,"Schmidt, Derek",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Attorney General,,Democratic,"Kotich, A.J.",206,120280
+DOUGLAS,Lawrence Precinct 44 H45,Attorney General,,Republican,"Schmidt, Derek",156,120280
+DOUGLAS,Lawrence Precinct 46 S19,Attorney General,,Democratic,"Kotich, A.J.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,Attorney General,,Republican,"Schmidt, Derek",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Attorney General,,Democratic,"Kotich, A.J.",512,120300
+DOUGLAS,Lawrence Precinct 46 S3,Attorney General,,Republican,"Schmidt, Derek",364,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Attorney General,,Democratic,"Kotich, A.J.",45,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,Attorney General,,Republican,"Schmidt, Derek",80,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Attorney General,,Democratic,"Kotich, A.J.",182,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,Attorney General,,Republican,"Schmidt, Derek",202,120320
+DOUGLAS,Marion Township Precinct 59 H45,Attorney General,,Democratic,"Kotich, A.J.",51,120330
+DOUGLAS,Marion Township Precinct 59 H45,Attorney General,,Republican,"Schmidt, Derek",107,120330
+DOUGLAS,Marion Township Precinct 59 H54,Attorney General,,Democratic,"Kotich, A.J.",106,120340
+DOUGLAS,Marion Township Precinct 59 H54,Attorney General,,Republican,"Schmidt, Derek",124,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Attorney General,,Democratic,"Kotich, A.J.",118,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,Attorney General,,Republican,"Schmidt, Derek",71,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Attorney General,,Democratic,"Kotich, A.J.",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,Attorney General,,Republican,"Schmidt, Derek",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,Attorney General,,Democratic,"Kotich, A.J.",123,120370
+DOUGLAS,South Eudora Precinct 53 H10,Attorney General,,Republican,"Schmidt, Derek",267,120370
+DOUGLAS,South Eudora Precinct 53 H42,Attorney General,,Democratic,"Kotich, A.J.",152,120380
+DOUGLAS,South Eudora Precinct 53 H42,Attorney General,,Republican,"Schmidt, Derek",258,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Attorney General,,Democratic,"Kotich, A.J.",102,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Attorney General,,Republican,"Schmidt, Derek",130,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Attorney General,,Democratic,"Kotich, A.J.",68,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Attorney General,,Republican,"Schmidt, Derek",92,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Attorney General,,Democratic,"Kotich, A.J.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Attorney General,,Republican,"Schmidt, Derek",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Attorney General,,Democratic,"Kotich, A.J.",54,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Attorney General,,Republican,"Schmidt, Derek",81,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Attorney General,,Democratic,"Kotich, A.J.",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Attorney General,,Republican,"Schmidt, Derek",0,120420
+DOUGLAS,Willow Springs Township S19 H45,Attorney General,,Democratic,"Kotich, A.J.",135,120430
+DOUGLAS,Willow Springs Township S19 H45,Attorney General,,Republican,"Schmidt, Derek",121,120430
+DOUGLAS,Willow Springs Township S19 H54,Attorney General,,Democratic,"Kotich, A.J.",85,120440
+DOUGLAS,Willow Springs Township S19 H54,Attorney General,,Republican,"Schmidt, Derek",172,120440
+DOUGLAS,Willow Springs Township S3 H45,Attorney General,,Democratic,"Kotich, A.J.",38,120450
+DOUGLAS,Willow Springs Township S3 H45,Attorney General,,Republican,"Schmidt, Derek",42,120450
+DOUGLAS,Willow Springs Township S3 H54,Attorney General,,Democratic,"Kotich, A.J.",23,120460
+DOUGLAS,Willow Springs Township S3 H54,Attorney General,,Republican,"Schmidt, Derek",24,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,Attorney General,,Democratic,"Kotich, A.J.",149,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Attorney General,,Republican,"Schmidt, Derek",160,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Attorney General,,Democratic,"Kotich, A.J.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,Attorney General,,Republican,"Schmidt, Derek",0,400010
+DOUGLAS,Lawrence Precinct 47,Attorney General,,Democratic,"Kotich, A.J.",168,400030
+DOUGLAS,Lawrence Precinct 47,Attorney General,,Republican,"Schmidt, Derek",172,400030
+DOUGLAS,Lawrence Precinct 48,Attorney General,,Democratic,"Kotich, A.J.",492,400040
+DOUGLAS,Lawrence Precinct 48,Attorney General,,Republican,"Schmidt, Derek",333,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Attorney General,,Democratic,"Kotich, A.J.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Attorney General,,Republican,"Schmidt, Derek",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Attorney General,,Democratic,"Kotich, A.J.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,Attorney General,,Republican,"Schmidt, Derek",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Attorney General,,Democratic,"Kotich, A.J.",271,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Attorney General,,Republican,"Schmidt, Derek",460,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Attorney General,,Democratic,"Kotich, A.J.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Attorney General,,Republican,"Schmidt, Derek",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Attorney General,,Democratic,"Kotich, A.J.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Attorney General,,Republican,"Schmidt, Derek",0,400110
+DOUGLAS,Lawrence Precinct 68,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+DOUGLAS,Lawrence Precinct 68,Attorney General,,Republican,"Schmidt, Derek",0,900010
+DOUGLAS,Lawrence Precinct 69,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+DOUGLAS,Lawrence Precinct 69,Attorney General,,Republican,"Schmidt, Derek",0,900020
+DOUGLAS,Lawrence Precinct 70,Attorney General,,Democratic,"Kotich, A.J.",1,900040
+DOUGLAS,Lawrence Precinct 70,Attorney General,,Republican,"Schmidt, Derek",5,900040
+DOUGLAS,Lawrence Precinct 71,Attorney General,,Democratic,"Kotich, A.J.",342,900050
+DOUGLAS,Lawrence Precinct 71,Attorney General,,Republican,"Schmidt, Derek",282,900050
+DOUGLAS,Lawrence Precinct 72,Attorney General,,Democratic,"Kotich, A.J.",0,900060
+DOUGLAS,Lawrence Precinct 72,Attorney General,,Republican,"Schmidt, Derek",0,900060
+DOUGLAS,Lawrence Precinct 73,Attorney General,,Democratic,"Kotich, A.J.",0,900070
+DOUGLAS,Lawrence Precinct 73,Attorney General,,Republican,"Schmidt, Derek",0,900070
+DOUGLAS,Lawrence Precinct 74,Attorney General,,Democratic,"Kotich, A.J.",0,900080
+DOUGLAS,Lawrence Precinct 74,Attorney General,,Republican,"Schmidt, Derek",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Attorney General,,Democratic,"Kotich, A.J.",225,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,Attorney General,,Republican,"Schmidt, Derek",190,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Attorney General,,Democratic,"Kotich, A.J.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Attorney General,,Republican,"Schmidt, Derek",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Attorney General,,Democratic,"Kotich, A.J.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Attorney General,,Republican,"Schmidt, Derek",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Attorney General,,Democratic,"Kotich, A.J.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Attorney General,,Republican,"Schmidt, Derek",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Attorney General,,Democratic,"Kotich, A.J.",21,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Attorney General,,Republican,"Schmidt, Derek",3,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Attorney General,,Democratic,"Kotich, A.J.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Attorney General,,Republican,"Schmidt, Derek",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Attorney General,,Democratic,"Kotich, A.J.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,Attorney General,,Republican,"Schmidt, Derek",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Attorney General,,Democratic,"Kotich, A.J.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Attorney General,,Republican,"Schmidt, Derek",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Attorney General,,Democratic,"Kotich, A.J.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,Attorney General,,Republican,"Schmidt, Derek",0,900170
+DOUGLAS,Big Springs Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",74,000010
+DOUGLAS,Big Springs Township,Commissioner of Insurance,,Republican,"Selzer, Ken",78,000010
+DOUGLAS,Central Eudora,Commissioner of Insurance,,Democratic,"Anderson, Dennis",191,000020
+DOUGLAS,Central Eudora,Commissioner of Insurance,,Republican,"Selzer, Ken",275,000020
+DOUGLAS,Clinton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",141,000030
+DOUGLAS,Clinton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",169,000030
+DOUGLAS,Lawrence Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",322,00007A
+DOUGLAS,Lawrence Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",62,00007A
+DOUGLAS,Lawrence Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",391,000080
+DOUGLAS,Lawrence Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000080
+DOUGLAS,Lawrence Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",381,000090
+DOUGLAS,Lawrence Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000090
+DOUGLAS,Lawrence Precinct 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",323,00010A
+DOUGLAS,Lawrence Precinct 04,Commissioner of Insurance,,Republican,"Selzer, Ken",70,00010A
+DOUGLAS,Lawrence Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",354,000110
+DOUGLAS,Lawrence Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",210,000110
+DOUGLAS,Lawrence Precinct 06,Commissioner of Insurance,,Democratic,"Anderson, Dennis",352,00012A
+DOUGLAS,Lawrence Precinct 06,Commissioner of Insurance,,Republican,"Selzer, Ken",210,00012A
+DOUGLAS,Lawrence Precinct 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",141,000130
+DOUGLAS,Lawrence Precinct 07,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000130
+DOUGLAS,Lawrence Precinct 08,Commissioner of Insurance,,Democratic,"Anderson, Dennis",216,000140
+DOUGLAS,Lawrence Precinct 08,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000140
+DOUGLAS,Lawrence Precinct 09,Commissioner of Insurance,,Democratic,"Anderson, Dennis",203,000150
+DOUGLAS,Lawrence Precinct 09,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000150
+DOUGLAS,Lawrence Precinct 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",98,000160
+DOUGLAS,Lawrence Precinct 10,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000160
+DOUGLAS,Lawrence Precinct 11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",301,000170
+DOUGLAS,Lawrence Precinct 11,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000170
+DOUGLAS,Lawrence Precinct 12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",504,000180
+DOUGLAS,Lawrence Precinct 12,Commissioner of Insurance,,Republican,"Selzer, Ken",168,000180
+DOUGLAS,Lawrence Precinct 13,Commissioner of Insurance,,Democratic,"Anderson, Dennis",428,000190
+DOUGLAS,Lawrence Precinct 13,Commissioner of Insurance,,Republican,"Selzer, Ken",189,000190
+DOUGLAS,Lawrence Precinct 14,Commissioner of Insurance,,Democratic,"Anderson, Dennis",615,000200
+DOUGLAS,Lawrence Precinct 14,Commissioner of Insurance,,Republican,"Selzer, Ken",318,000200
+DOUGLAS,Lawrence Precinct 15,Commissioner of Insurance,,Democratic,"Anderson, Dennis",523,000210
+DOUGLAS,Lawrence Precinct 15,Commissioner of Insurance,,Republican,"Selzer, Ken",166,000210
+DOUGLAS,Lawrence Precinct 16,Commissioner of Insurance,,Democratic,"Anderson, Dennis",412,000220
+DOUGLAS,Lawrence Precinct 16,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000220
+DOUGLAS,Lawrence Precinct 17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",336,000230
+DOUGLAS,Lawrence Precinct 17,Commissioner of Insurance,,Republican,"Selzer, Ken",201,000230
+DOUGLAS,Lawrence Precinct 18,Commissioner of Insurance,,Democratic,"Anderson, Dennis",581,000240
+DOUGLAS,Lawrence Precinct 18,Commissioner of Insurance,,Republican,"Selzer, Ken",356,000240
+DOUGLAS,Lawrence Precinct 19,Commissioner of Insurance,,Democratic,"Anderson, Dennis",435,000250
+DOUGLAS,Lawrence Precinct 19,Commissioner of Insurance,,Republican,"Selzer, Ken",360,000250
+DOUGLAS,Lawrence Precinct 20,Commissioner of Insurance,,Democratic,"Anderson, Dennis",617,000260
+DOUGLAS,Lawrence Precinct 20,Commissioner of Insurance,,Republican,"Selzer, Ken",341,000260
+DOUGLAS,Lawrence Precinct 21,Commissioner of Insurance,,Democratic,"Anderson, Dennis",265,000270
+DOUGLAS,Lawrence Precinct 21,Commissioner of Insurance,,Republican,"Selzer, Ken",71,000270
+DOUGLAS,Lawrence Precinct 22,Commissioner of Insurance,,Democratic,"Anderson, Dennis",457,000280
+DOUGLAS,Lawrence Precinct 22,Commissioner of Insurance,,Republican,"Selzer, Ken",220,000280
+DOUGLAS,Lawrence Precinct 23,Commissioner of Insurance,,Democratic,"Anderson, Dennis",306,000290
+DOUGLAS,Lawrence Precinct 23,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000290
+DOUGLAS,Lawrence Precinct 24,Commissioner of Insurance,,Democratic,"Anderson, Dennis",244,000300
+DOUGLAS,Lawrence Precinct 24,Commissioner of Insurance,,Republican,"Selzer, Ken",149,000300
+DOUGLAS,Lawrence Precinct 25,Commissioner of Insurance,,Democratic,"Anderson, Dennis",224,000310
+DOUGLAS,Lawrence Precinct 25,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000310
+DOUGLAS,Lawrence Precinct 26,Commissioner of Insurance,,Democratic,"Anderson, Dennis",323,000320
+DOUGLAS,Lawrence Precinct 26,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000320
+DOUGLAS,Lawrence Precinct 27,Commissioner of Insurance,,Democratic,"Anderson, Dennis",307,000330
+DOUGLAS,Lawrence Precinct 27,Commissioner of Insurance,,Republican,"Selzer, Ken",82,000330
+DOUGLAS,Lawrence Precinct 28,Commissioner of Insurance,,Democratic,"Anderson, Dennis",232,000340
+DOUGLAS,Lawrence Precinct 28,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000340
+DOUGLAS,Lawrence Precinct 29,Commissioner of Insurance,,Democratic,"Anderson, Dennis",311,000350
+DOUGLAS,Lawrence Precinct 29,Commissioner of Insurance,,Republican,"Selzer, Ken",74,000350
+DOUGLAS,Lawrence Precinct 31,Commissioner of Insurance,,Democratic,"Anderson, Dennis",404,000370
+DOUGLAS,Lawrence Precinct 31,Commissioner of Insurance,,Republican,"Selzer, Ken",175,000370
+DOUGLAS,Lawrence Precinct 32,Commissioner of Insurance,,Democratic,"Anderson, Dennis",191,000380
+DOUGLAS,Lawrence Precinct 32,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000380
+DOUGLAS,Lawrence Precinct 33,Commissioner of Insurance,,Democratic,"Anderson, Dennis",480,000400
+DOUGLAS,Lawrence Precinct 33,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000400
+DOUGLAS,Lawrence Precinct 38,Commissioner of Insurance,,Democratic,"Anderson, Dennis",400,000450
+DOUGLAS,Lawrence Precinct 38,Commissioner of Insurance,,Republican,"Selzer, Ken",199,000450
+DOUGLAS,Lawrence Precinct 39,Commissioner of Insurance,,Democratic,"Anderson, Dennis",461,000460
+DOUGLAS,Lawrence Precinct 39,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000460
+DOUGLAS,Lawrence Precinct 40,Commissioner of Insurance,,Democratic,"Anderson, Dennis",432,000470
+DOUGLAS,Lawrence Precinct 40,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",237,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,Commissioner of Insurance,,Republican,"Selzer, Ken",159,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00050C
+DOUGLAS,Lawrence Precinct 45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",893,00052A
+DOUGLAS,Lawrence Precinct 45,Commissioner of Insurance,,Republican,"Selzer, Ken",714,00052A
+DOUGLAS,Lawrence Precinct 49,Commissioner of Insurance,,Democratic,"Anderson, Dennis",336,000560
+DOUGLAS,Lawrence Precinct 49,Commissioner of Insurance,,Republican,"Selzer, Ken",346,000560
+DOUGLAS,North Eudora Precinct 52,Commissioner of Insurance,,Democratic,"Anderson, Dennis",167,000600
+DOUGLAS,North Eudora Precinct 52,Commissioner of Insurance,,Republican,"Selzer, Ken",140,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Commissioner of Insurance,,Democratic,"Anderson, Dennis",333,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Commissioner of Insurance,,Republican,"Selzer, Ken",357,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Commissioner of Insurance,,Democratic,"Anderson, Dennis",266,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Commissioner of Insurance,,Republican,"Selzer, Ken",262,000630
+DOUGLAS,South Baldwin Precinct 62,Commissioner of Insurance,,Democratic,"Anderson, Dennis",270,000640
+DOUGLAS,South Baldwin Precinct 62,Commissioner of Insurance,,Republican,"Selzer, Ken",441,000640
+DOUGLAS,Vinland Precinct 63,Commissioner of Insurance,,Democratic,"Anderson, Dennis",255,000660
+DOUGLAS,Vinland Precinct 63,Commissioner of Insurance,,Republican,"Selzer, Ken",287,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120030
+DOUGLAS,Grant Township S2 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,120040
+DOUGLAS,Grant Township S2 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",7,120040
+DOUGLAS,Grant Township S3 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,120050
+DOUGLAS,Grant Township S3 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",42,120050
+DOUGLAS,Grant Township S3 H46,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,120060
+DOUGLAS,Grant Township S3 H46,Commissioner of Insurance,,Republican,"Selzer, Ken",9,120060
+DOUGLAS,Kawaka Township S19,Commissioner of Insurance,,Democratic,"Anderson, Dennis",316,120070
+DOUGLAS,Kawaka Township S19,Commissioner of Insurance,,Republican,"Selzer, Ken",333,120070
+DOUGLAS,Kawaka Township S2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,120080
+DOUGLAS,Kawaka Township S2,Commissioner of Insurance,,Republican,"Selzer, Ken",12,120080
+DOUGLAS,Lawrence Precinct 30 S2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",111,120090
+DOUGLAS,Lawrence Precinct 30 S2,Commissioner of Insurance,,Republican,"Selzer, Ken",43,120090
+DOUGLAS,Lawrence Precinct 30 S3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",145,120100
+DOUGLAS,Lawrence Precinct 30 S3,Commissioner of Insurance,,Republican,"Selzer, Ken",41,120100
+DOUGLAS,Lawrence Precinct 34 S2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",293,120110
+DOUGLAS,Lawrence Precinct 34 S2,Commissioner of Insurance,,Republican,"Selzer, Ken",53,120110
+DOUGLAS,Lawrence Precinct 34 S3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,120120
+DOUGLAS,Lawrence Precinct 34 S3,Commissioner of Insurance,,Republican,"Selzer, Ken",5,120120
+DOUGLAS,Lawrence Precinct 35 S2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",357,120130
+DOUGLAS,Lawrence Precinct 35 S2,Commissioner of Insurance,,Republican,"Selzer, Ken",91,120130
+DOUGLAS,Lawrence Precinct 35 S3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,120140
+DOUGLAS,Lawrence Precinct 35 S3,Commissioner of Insurance,,Republican,"Selzer, Ken",9,120140
+DOUGLAS,Lawrence Precinct 36 S2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",278,120150
+DOUGLAS,Lawrence Precinct 36 S2,Commissioner of Insurance,,Republican,"Selzer, Ken",107,120150
+DOUGLAS,Lawrence Precinct 36 S3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",220,120160
+DOUGLAS,Lawrence Precinct 36 S3,Commissioner of Insurance,,Republican,"Selzer, Ken",95,120160
+DOUGLAS,Lawrence Precinct 37 H10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",485,120170
+DOUGLAS,Lawrence Precinct 37 H10,Commissioner of Insurance,,Republican,"Selzer, Ken",237,120170
+DOUGLAS,Lawrence Precinct 37 H46,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,120180
+DOUGLAS,Lawrence Precinct 37 H46,Commissioner of Insurance,,Republican,"Selzer, Ken",10,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,Commissioner of Insurance,,Republican,"Selzer, Ken",2,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Commissioner of Insurance,,Democratic,"Anderson, Dennis",656,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,Commissioner of Insurance,,Republican,"Selzer, Ken",192,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",157,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",75,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Commissioner of Insurance,,Democratic,"Anderson, Dennis",143,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Commissioner of Insurance,,Republican,"Selzer, Ken",42,120260
+DOUGLAS,Lawrence Precinct 44 H44,Commissioner of Insurance,,Democratic,"Anderson, Dennis",64,120270
+DOUGLAS,Lawrence Precinct 44 H44,Commissioner of Insurance,,Republican,"Selzer, Ken",31,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",226,120280
+DOUGLAS,Lawrence Precinct 44 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",131,120280
+DOUGLAS,Lawrence Precinct 46 S19,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",574,120300
+DOUGLAS,Lawrence Precinct 46 S3,Commissioner of Insurance,,Republican,"Selzer, Ken",303,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,Commissioner of Insurance,,Republican,"Selzer, Ken",69,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",204,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,Commissioner of Insurance,,Republican,"Selzer, Ken",182,120320
+DOUGLAS,Marion Township Precinct 59 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,120330
+DOUGLAS,Marion Township Precinct 59 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",103,120330
+DOUGLAS,Marion Township Precinct 59 H54,Commissioner of Insurance,,Democratic,"Anderson, Dennis",118,120340
+DOUGLAS,Marion Township Precinct 59 H54,Commissioner of Insurance,,Republican,"Selzer, Ken",110,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",127,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",62,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,Commissioner of Insurance,,Republican,"Selzer, Ken",1,120360
+DOUGLAS,South Eudora Precinct 53 H10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",134,120370
+DOUGLAS,South Eudora Precinct 53 H10,Commissioner of Insurance,,Republican,"Selzer, Ken",256,120370
+DOUGLAS,South Eudora Precinct 53 H42,Commissioner of Insurance,,Democratic,"Anderson, Dennis",161,120380
+DOUGLAS,South Eudora Precinct 53 H42,Commissioner of Insurance,,Republican,"Selzer, Ken",247,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",107,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Commissioner of Insurance,,Republican,"Selzer, Ken",123,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",75,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",81,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Commissioner of Insurance,,Republican,"Selzer, Ken",74,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120420
+DOUGLAS,Willow Springs Township S19 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",141,120430
+DOUGLAS,Willow Springs Township S19 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",111,120430
+DOUGLAS,Willow Springs Township S19 H54,Commissioner of Insurance,,Democratic,"Anderson, Dennis",90,120440
+DOUGLAS,Willow Springs Township S19 H54,Commissioner of Insurance,,Republican,"Selzer, Ken",163,120440
+DOUGLAS,Willow Springs Township S3 H45,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,120450
+DOUGLAS,Willow Springs Township S3 H45,Commissioner of Insurance,,Republican,"Selzer, Ken",35,120450
+DOUGLAS,Willow Springs Township S3 H54,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,120460
+DOUGLAS,Willow Springs Township S3 H54,Commissioner of Insurance,,Republican,"Selzer, Ken",20,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,Commissioner of Insurance,,Democratic,"Anderson, Dennis",156,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Commissioner of Insurance,,Republican,"Selzer, Ken",156,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,400010
+DOUGLAS,Lawrence Precinct 47,Commissioner of Insurance,,Democratic,"Anderson, Dennis",200,400030
+DOUGLAS,Lawrence Precinct 47,Commissioner of Insurance,,Republican,"Selzer, Ken",139,400030
+DOUGLAS,Lawrence Precinct 48,Commissioner of Insurance,,Democratic,"Anderson, Dennis",546,400040
+DOUGLAS,Lawrence Precinct 48,Commissioner of Insurance,,Republican,"Selzer, Ken",273,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",291,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",430,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,400110
+DOUGLAS,Lawrence Precinct 68,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+DOUGLAS,Lawrence Precinct 68,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+DOUGLAS,Lawrence Precinct 69,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+DOUGLAS,Lawrence Precinct 69,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+DOUGLAS,Lawrence Precinct 70,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+DOUGLAS,Lawrence Precinct 70,Commissioner of Insurance,,Republican,"Selzer, Ken",5,900040
+DOUGLAS,Lawrence Precinct 71,Commissioner of Insurance,,Democratic,"Anderson, Dennis",384,900050
+DOUGLAS,Lawrence Precinct 71,Commissioner of Insurance,,Republican,"Selzer, Ken",232,900050
+DOUGLAS,Lawrence Precinct 72,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900060
+DOUGLAS,Lawrence Precinct 72,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900060
+DOUGLAS,Lawrence Precinct 73,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900070
+DOUGLAS,Lawrence Precinct 73,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900070
+DOUGLAS,Lawrence Precinct 74,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900080
+DOUGLAS,Lawrence Precinct 74,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",251,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",163,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Commissioner of Insurance,,Republican,"Selzer, Ken",3,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900170
+DOUGLAS,Big Springs Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,000010
+DOUGLAS,Big Springs Township,Secretary of State,,Republican,"Kobach, Kris",81,000010
+DOUGLAS,Central Eudora,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",203,000020
+DOUGLAS,Central Eudora,Secretary of State,,Republican,"Kobach, Kris",284,000020
+DOUGLAS,Clinton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",145,000030
+DOUGLAS,Clinton Township,Secretary of State,,Republican,"Kobach, Kris",179,000030
+DOUGLAS,Lawrence Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",333,00007A
+DOUGLAS,Lawrence Precinct 01,Secretary of State,,Republican,"Kobach, Kris",61,00007A
+DOUGLAS,Lawrence Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",413,000080
+DOUGLAS,Lawrence Precinct 02,Secretary of State,,Republican,"Kobach, Kris",62,000080
+DOUGLAS,Lawrence Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",406,000090
+DOUGLAS,Lawrence Precinct 03,Secretary of State,,Republican,"Kobach, Kris",48,000090
+DOUGLAS,Lawrence Precinct 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",333,00010A
+DOUGLAS,Lawrence Precinct 04,Secretary of State,,Republican,"Kobach, Kris",68,00010A
+DOUGLAS,Lawrence Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",382,000110
+DOUGLAS,Lawrence Precinct 05,Secretary of State,,Republican,"Kobach, Kris",202,000110
+DOUGLAS,Lawrence Precinct 06,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",377,00012A
+DOUGLAS,Lawrence Precinct 06,Secretary of State,,Republican,"Kobach, Kris",212,00012A
+DOUGLAS,Lawrence Precinct 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",157,000130
+DOUGLAS,Lawrence Precinct 07,Secretary of State,,Republican,"Kobach, Kris",9,000130
+DOUGLAS,Lawrence Precinct 08,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",225,000140
+DOUGLAS,Lawrence Precinct 08,Secretary of State,,Republican,"Kobach, Kris",28,000140
+DOUGLAS,Lawrence Precinct 09,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",210,000150
+DOUGLAS,Lawrence Precinct 09,Secretary of State,,Republican,"Kobach, Kris",38,000150
+DOUGLAS,Lawrence Precinct 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",100,000160
+DOUGLAS,Lawrence Precinct 10,Secretary of State,,Republican,"Kobach, Kris",30,000160
+DOUGLAS,Lawrence Precinct 11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",307,000170
+DOUGLAS,Lawrence Precinct 11,Secretary of State,,Republican,"Kobach, Kris",105,000170
+DOUGLAS,Lawrence Precinct 12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",527,000180
+DOUGLAS,Lawrence Precinct 12,Secretary of State,,Republican,"Kobach, Kris",178,000180
+DOUGLAS,Lawrence Precinct 13,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",471,000190
+DOUGLAS,Lawrence Precinct 13,Secretary of State,,Republican,"Kobach, Kris",178,000190
+DOUGLAS,Lawrence Precinct 14,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",645,000200
+DOUGLAS,Lawrence Precinct 14,Secretary of State,,Republican,"Kobach, Kris",318,000200
+DOUGLAS,Lawrence Precinct 15,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",562,000210
+DOUGLAS,Lawrence Precinct 15,Secretary of State,,Republican,"Kobach, Kris",153,000210
+DOUGLAS,Lawrence Precinct 16,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",438,000220
+DOUGLAS,Lawrence Precinct 16,Secretary of State,,Republican,"Kobach, Kris",164,000220
+DOUGLAS,Lawrence Precinct 17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",354,000230
+DOUGLAS,Lawrence Precinct 17,Secretary of State,,Republican,"Kobach, Kris",206,000230
+DOUGLAS,Lawrence Precinct 18,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",642,000240
+DOUGLAS,Lawrence Precinct 18,Secretary of State,,Republican,"Kobach, Kris",341,000240
+DOUGLAS,Lawrence Precinct 19,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",510,000250
+DOUGLAS,Lawrence Precinct 19,Secretary of State,,Republican,"Kobach, Kris",329,000250
+DOUGLAS,Lawrence Precinct 20,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",659,000260
+DOUGLAS,Lawrence Precinct 20,Secretary of State,,Republican,"Kobach, Kris",336,000260
+DOUGLAS,Lawrence Precinct 21,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",293,000270
+DOUGLAS,Lawrence Precinct 21,Secretary of State,,Republican,"Kobach, Kris",57,000270
+DOUGLAS,Lawrence Precinct 22,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",473,000280
+DOUGLAS,Lawrence Precinct 22,Secretary of State,,Republican,"Kobach, Kris",223,000280
+DOUGLAS,Lawrence Precinct 23,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",328,000290
+DOUGLAS,Lawrence Precinct 23,Secretary of State,,Republican,"Kobach, Kris",130,000290
+DOUGLAS,Lawrence Precinct 24,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",274,000300
+DOUGLAS,Lawrence Precinct 24,Secretary of State,,Republican,"Kobach, Kris",134,000300
+DOUGLAS,Lawrence Precinct 25,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",239,000310
+DOUGLAS,Lawrence Precinct 25,Secretary of State,,Republican,"Kobach, Kris",33,000310
+DOUGLAS,Lawrence Precinct 26,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",337,000320
+DOUGLAS,Lawrence Precinct 26,Secretary of State,,Republican,"Kobach, Kris",54,000320
+DOUGLAS,Lawrence Precinct 27,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",332,000330
+DOUGLAS,Lawrence Precinct 27,Secretary of State,,Republican,"Kobach, Kris",78,000330
+DOUGLAS,Lawrence Precinct 28,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",245,000340
+DOUGLAS,Lawrence Precinct 28,Secretary of State,,Republican,"Kobach, Kris",51,000340
+DOUGLAS,Lawrence Precinct 29,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",315,000350
+DOUGLAS,Lawrence Precinct 29,Secretary of State,,Republican,"Kobach, Kris",81,000350
+DOUGLAS,Lawrence Precinct 31,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",437,000370
+DOUGLAS,Lawrence Precinct 31,Secretary of State,,Republican,"Kobach, Kris",174,000370
+DOUGLAS,Lawrence Precinct 32,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",203,000380
+DOUGLAS,Lawrence Precinct 32,Secretary of State,,Republican,"Kobach, Kris",95,000380
+DOUGLAS,Lawrence Precinct 33,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",497,000400
+DOUGLAS,Lawrence Precinct 33,Secretary of State,,Republican,"Kobach, Kris",92,000400
+DOUGLAS,Lawrence Precinct 38,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",416,000450
+DOUGLAS,Lawrence Precinct 38,Secretary of State,,Republican,"Kobach, Kris",194,000450
+DOUGLAS,Lawrence Precinct 39,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",481,000460
+DOUGLAS,Lawrence Precinct 39,Secretary of State,,Republican,"Kobach, Kris",36,000460
+DOUGLAS,Lawrence Precinct 40,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",447,000470
+DOUGLAS,Lawrence Precinct 40,Secretary of State,,Republican,"Kobach, Kris",30,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,Secretary of State,,Republican,"Kobach, Kris",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",264,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,Secretary of State,,Republican,"Kobach, Kris",145,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,Secretary of State,,Republican,"Kobach, Kris",0,00050C
+DOUGLAS,Lawrence Precinct 45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",989,00052A
+DOUGLAS,Lawrence Precinct 45,Secretary of State,,Republican,"Kobach, Kris",681,00052A
+DOUGLAS,Lawrence Precinct 49,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",398,000560
+DOUGLAS,Lawrence Precinct 49,Secretary of State,,Republican,"Kobach, Kris",312,000560
+DOUGLAS,North Eudora Precinct 52,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",160,000600
+DOUGLAS,North Eudora Precinct 52,Secretary of State,,Republican,"Kobach, Kris",156,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",350,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Secretary of State,,Republican,"Kobach, Kris",369,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",281,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Secretary of State,,Republican,"Kobach, Kris",266,000630
+DOUGLAS,South Baldwin Precinct 62,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",287,000640
+DOUGLAS,South Baldwin Precinct 62,Secretary of State,,Republican,"Kobach, Kris",440,000640
+DOUGLAS,Vinland Precinct 63,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",263,000660
+DOUGLAS,Vinland Precinct 63,Secretary of State,,Republican,"Kobach, Kris",284,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Secretary of State,,Republican,"Kobach, Kris",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Secretary of State,,Republican,"Kobach, Kris",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Secretary of State,,Republican,"Kobach, Kris",0,120030
+DOUGLAS,Grant Township S2 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,120040
+DOUGLAS,Grant Township S2 H45,Secretary of State,,Republican,"Kobach, Kris",7,120040
+DOUGLAS,Grant Township S3 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,120050
+DOUGLAS,Grant Township S3 H45,Secretary of State,,Republican,"Kobach, Kris",43,120050
+DOUGLAS,Grant Township S3 H46,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,120060
+DOUGLAS,Grant Township S3 H46,Secretary of State,,Republican,"Kobach, Kris",9,120060
+DOUGLAS,Kawaka Township S19,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",338,120070
+DOUGLAS,Kawaka Township S19,Secretary of State,,Republican,"Kobach, Kris",339,120070
+DOUGLAS,Kawaka Township S2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,120080
+DOUGLAS,Kawaka Township S2,Secretary of State,,Republican,"Kobach, Kris",14,120080
+DOUGLAS,Lawrence Precinct 30 S2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",115,120090
+DOUGLAS,Lawrence Precinct 30 S2,Secretary of State,,Republican,"Kobach, Kris",45,120090
+DOUGLAS,Lawrence Precinct 30 S3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",152,120100
+DOUGLAS,Lawrence Precinct 30 S3,Secretary of State,,Republican,"Kobach, Kris",37,120100
+DOUGLAS,Lawrence Precinct 34 S2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",300,120110
+DOUGLAS,Lawrence Precinct 34 S2,Secretary of State,,Republican,"Kobach, Kris",51,120110
+DOUGLAS,Lawrence Precinct 34 S3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,120120
+DOUGLAS,Lawrence Precinct 34 S3,Secretary of State,,Republican,"Kobach, Kris",4,120120
+DOUGLAS,Lawrence Precinct 35 S2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",359,120130
+DOUGLAS,Lawrence Precinct 35 S2,Secretary of State,,Republican,"Kobach, Kris",104,120130
+DOUGLAS,Lawrence Precinct 35 S3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,120140
+DOUGLAS,Lawrence Precinct 35 S3,Secretary of State,,Republican,"Kobach, Kris",9,120140
+DOUGLAS,Lawrence Precinct 36 S2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",287,120150
+DOUGLAS,Lawrence Precinct 36 S2,Secretary of State,,Republican,"Kobach, Kris",109,120150
+DOUGLAS,Lawrence Precinct 36 S3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",211,120160
+DOUGLAS,Lawrence Precinct 36 S3,Secretary of State,,Republican,"Kobach, Kris",107,120160
+DOUGLAS,Lawrence Precinct 37 H10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",496,120170
+DOUGLAS,Lawrence Precinct 37 H10,Secretary of State,,Republican,"Kobach, Kris",256,120170
+DOUGLAS,Lawrence Precinct 37 H46,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,120180
+DOUGLAS,Lawrence Precinct 37 H46,Secretary of State,,Republican,"Kobach, Kris",11,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Secretary of State,,Republican,"Kobach, Kris",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Secretary of State,,Republican,"Kobach, Kris",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Secretary of State,,Republican,"Kobach, Kris",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Secretary of State,,Republican,"Kobach, Kris",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,Secretary of State,,Republican,"Kobach, Kris",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,Secretary of State,,Republican,"Kobach, Kris",3,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,Secretary of State,,Republican,"Kobach, Kris",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",688,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,Secretary of State,,Republican,"Kobach, Kris",194,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",152,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Secretary of State,,Republican,"Kobach, Kris",85,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",147,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Secretary of State,,Republican,"Kobach, Kris",47,120260
+DOUGLAS,Lawrence Precinct 44 H44,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,120270
+DOUGLAS,Lawrence Precinct 44 H44,Secretary of State,,Republican,"Kobach, Kris",32,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,Secretary of State,,Republican,"Kobach, Kris",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",243,120280
+DOUGLAS,Lawrence Precinct 44 H45,Secretary of State,,Republican,"Kobach, Kris",133,120280
+DOUGLAS,Lawrence Precinct 46 S19,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,Secretary of State,,Republican,"Kobach, Kris",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",595,120300
+DOUGLAS,Lawrence Precinct 46 S3,Secretary of State,,Republican,"Kobach, Kris",317,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,Secretary of State,,Republican,"Kobach, Kris",69,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",199,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,Secretary of State,,Republican,"Kobach, Kris",191,120320
+DOUGLAS,Marion Township Precinct 59 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,120330
+DOUGLAS,Marion Township Precinct 59 H45,Secretary of State,,Republican,"Kobach, Kris",104,120330
+DOUGLAS,Marion Township Precinct 59 H54,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",124,120340
+DOUGLAS,Marion Township Precinct 59 H54,Secretary of State,,Republican,"Kobach, Kris",107,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",131,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,Secretary of State,,Republican,"Kobach, Kris",68,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,Secretary of State,,Republican,"Kobach, Kris",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",143,120370
+DOUGLAS,South Eudora Precinct 53 H10,Secretary of State,,Republican,"Kobach, Kris",253,120370
+DOUGLAS,South Eudora Precinct 53 H42,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",164,120380
+DOUGLAS,South Eudora Precinct 53 H42,Secretary of State,,Republican,"Kobach, Kris",258,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",122,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Secretary of State,,Republican,"Kobach, Kris",120,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",83,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Secretary of State,,Republican,"Kobach, Kris",82,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Secretary of State,,Republican,"Kobach, Kris",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Secretary of State,,Republican,"Kobach, Kris",82,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Secretary of State,,Republican,"Kobach, Kris",0,120420
+DOUGLAS,Willow Springs Township S19 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",148,120430
+DOUGLAS,Willow Springs Township S19 H45,Secretary of State,,Republican,"Kobach, Kris",112,120430
+DOUGLAS,Willow Springs Township S19 H54,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",97,120440
+DOUGLAS,Willow Springs Township S19 H54,Secretary of State,,Republican,"Kobach, Kris",168,120440
+DOUGLAS,Willow Springs Township S3 H45,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,120450
+DOUGLAS,Willow Springs Township S3 H45,Secretary of State,,Republican,"Kobach, Kris",34,120450
+DOUGLAS,Willow Springs Township S3 H54,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,120460
+DOUGLAS,Willow Springs Township S3 H54,Secretary of State,,Republican,"Kobach, Kris",18,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",156,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Secretary of State,,Republican,"Kobach, Kris",164,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,Secretary of State,,Republican,"Kobach, Kris",0,400010
+DOUGLAS,Lawrence Precinct 47,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",214,400030
+DOUGLAS,Lawrence Precinct 47,Secretary of State,,Republican,"Kobach, Kris",135,400030
+DOUGLAS,Lawrence Precinct 48,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",599,400040
+DOUGLAS,Lawrence Precinct 48,Secretary of State,,Republican,"Kobach, Kris",258,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Secretary of State,,Republican,"Kobach, Kris",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,Secretary of State,,Republican,"Kobach, Kris",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",313,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Secretary of State,,Republican,"Kobach, Kris",438,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Secretary of State,,Republican,"Kobach, Kris",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Secretary of State,,Republican,"Kobach, Kris",0,400110
+DOUGLAS,Lawrence Precinct 68,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+DOUGLAS,Lawrence Precinct 68,Secretary of State,,Republican,"Kobach, Kris",0,900010
+DOUGLAS,Lawrence Precinct 69,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+DOUGLAS,Lawrence Precinct 69,Secretary of State,,Republican,"Kobach, Kris",0,900020
+DOUGLAS,Lawrence Precinct 70,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+DOUGLAS,Lawrence Precinct 70,Secretary of State,,Republican,"Kobach, Kris",6,900040
+DOUGLAS,Lawrence Precinct 71,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",406,900050
+DOUGLAS,Lawrence Precinct 71,Secretary of State,,Republican,"Kobach, Kris",232,900050
+DOUGLAS,Lawrence Precinct 72,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900060
+DOUGLAS,Lawrence Precinct 72,Secretary of State,,Republican,"Kobach, Kris",0,900060
+DOUGLAS,Lawrence Precinct 73,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900070
+DOUGLAS,Lawrence Precinct 73,Secretary of State,,Republican,"Kobach, Kris",0,900070
+DOUGLAS,Lawrence Precinct 74,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900080
+DOUGLAS,Lawrence Precinct 74,Secretary of State,,Republican,"Kobach, Kris",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",266,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,Secretary of State,,Republican,"Kobach, Kris",161,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Secretary of State,,Republican,"Kobach, Kris",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Secretary of State,,Republican,"Kobach, Kris",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Secretary of State,,Republican,"Kobach, Kris",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Secretary of State,,Republican,"Kobach, Kris",2,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Secretary of State,,Republican,"Kobach, Kris",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,Secretary of State,,Republican,"Kobach, Kris",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Secretary of State,,Republican,"Kobach, Kris",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,Secretary of State,,Republican,"Kobach, Kris",0,900170
+DOUGLAS,Big Springs Township,State Treasurer,,Democratic,"Alldritt, Carmen",65,000010
+DOUGLAS,Big Springs Township,State Treasurer,,Republican,"Estes, Ron",89,000010
+DOUGLAS,Central Eudora,State Treasurer,,Democratic,"Alldritt, Carmen",192,000020
+DOUGLAS,Central Eudora,State Treasurer,,Republican,"Estes, Ron",278,000020
+DOUGLAS,Clinton Township,State Treasurer,,Democratic,"Alldritt, Carmen",122,000030
+DOUGLAS,Clinton Township,State Treasurer,,Republican,"Estes, Ron",195,000030
+DOUGLAS,Lawrence Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",300,00007A
+DOUGLAS,Lawrence Precinct 01,State Treasurer,,Republican,"Estes, Ron",77,00007A
+DOUGLAS,Lawrence Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",385,000080
+DOUGLAS,Lawrence Precinct 02,State Treasurer,,Republican,"Estes, Ron",70,000080
+DOUGLAS,Lawrence Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",365,000090
+DOUGLAS,Lawrence Precinct 03,State Treasurer,,Republican,"Estes, Ron",64,000090
+DOUGLAS,Lawrence Precinct 04,State Treasurer,,Democratic,"Alldritt, Carmen",308,00010A
+DOUGLAS,Lawrence Precinct 04,State Treasurer,,Republican,"Estes, Ron",82,00010A
+DOUGLAS,Lawrence Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",323,000110
+DOUGLAS,Lawrence Precinct 05,State Treasurer,,Republican,"Estes, Ron",237,000110
+DOUGLAS,Lawrence Precinct 06,State Treasurer,,Democratic,"Alldritt, Carmen",318,00012A
+DOUGLAS,Lawrence Precinct 06,State Treasurer,,Republican,"Estes, Ron",250,00012A
+DOUGLAS,Lawrence Precinct 07,State Treasurer,,Democratic,"Alldritt, Carmen",135,000130
+DOUGLAS,Lawrence Precinct 07,State Treasurer,,Republican,"Estes, Ron",22,000130
+DOUGLAS,Lawrence Precinct 08,State Treasurer,,Democratic,"Alldritt, Carmen",208,000140
+DOUGLAS,Lawrence Precinct 08,State Treasurer,,Republican,"Estes, Ron",37,000140
+DOUGLAS,Lawrence Precinct 09,State Treasurer,,Democratic,"Alldritt, Carmen",194,000150
+DOUGLAS,Lawrence Precinct 09,State Treasurer,,Republican,"Estes, Ron",43,000150
+DOUGLAS,Lawrence Precinct 10,State Treasurer,,Democratic,"Alldritt, Carmen",88,000160
+DOUGLAS,Lawrence Precinct 10,State Treasurer,,Republican,"Estes, Ron",37,000160
+DOUGLAS,Lawrence Precinct 11,State Treasurer,,Democratic,"Alldritt, Carmen",278,000170
+DOUGLAS,Lawrence Precinct 11,State Treasurer,,Republican,"Estes, Ron",127,000170
+DOUGLAS,Lawrence Precinct 12,State Treasurer,,Democratic,"Alldritt, Carmen",483,000180
+DOUGLAS,Lawrence Precinct 12,State Treasurer,,Republican,"Estes, Ron",202,000180
+DOUGLAS,Lawrence Precinct 13,State Treasurer,,Democratic,"Alldritt, Carmen",392,000190
+DOUGLAS,Lawrence Precinct 13,State Treasurer,,Republican,"Estes, Ron",230,000190
+DOUGLAS,Lawrence Precinct 14,State Treasurer,,Democratic,"Alldritt, Carmen",579,000200
+DOUGLAS,Lawrence Precinct 14,State Treasurer,,Republican,"Estes, Ron",355,000200
+DOUGLAS,Lawrence Precinct 15,State Treasurer,,Democratic,"Alldritt, Carmen",489,000210
+DOUGLAS,Lawrence Precinct 15,State Treasurer,,Republican,"Estes, Ron",191,000210
+DOUGLAS,Lawrence Precinct 16,State Treasurer,,Democratic,"Alldritt, Carmen",396,000220
+DOUGLAS,Lawrence Precinct 16,State Treasurer,,Republican,"Estes, Ron",190,000220
+DOUGLAS,Lawrence Precinct 17,State Treasurer,,Democratic,"Alldritt, Carmen",304,000230
+DOUGLAS,Lawrence Precinct 17,State Treasurer,,Republican,"Estes, Ron",242,000230
+DOUGLAS,Lawrence Precinct 18,State Treasurer,,Democratic,"Alldritt, Carmen",542,000240
+DOUGLAS,Lawrence Precinct 18,State Treasurer,,Republican,"Estes, Ron",402,000240
+DOUGLAS,Lawrence Precinct 19,State Treasurer,,Democratic,"Alldritt, Carmen",394,000250
+DOUGLAS,Lawrence Precinct 19,State Treasurer,,Republican,"Estes, Ron",416,000250
+DOUGLAS,Lawrence Precinct 20,State Treasurer,,Democratic,"Alldritt, Carmen",573,000260
+DOUGLAS,Lawrence Precinct 20,State Treasurer,,Republican,"Estes, Ron",378,000260
+DOUGLAS,Lawrence Precinct 21,State Treasurer,,Democratic,"Alldritt, Carmen",251,000270
+DOUGLAS,Lawrence Precinct 21,State Treasurer,,Republican,"Estes, Ron",84,000270
+DOUGLAS,Lawrence Precinct 22,State Treasurer,,Democratic,"Alldritt, Carmen",425,000280
+DOUGLAS,Lawrence Precinct 22,State Treasurer,,Republican,"Estes, Ron",253,000280
+DOUGLAS,Lawrence Precinct 23,State Treasurer,,Democratic,"Alldritt, Carmen",288,000290
+DOUGLAS,Lawrence Precinct 23,State Treasurer,,Republican,"Estes, Ron",144,000290
+DOUGLAS,Lawrence Precinct 24,State Treasurer,,Democratic,"Alldritt, Carmen",217,000300
+DOUGLAS,Lawrence Precinct 24,State Treasurer,,Republican,"Estes, Ron",174,000300
+DOUGLAS,Lawrence Precinct 25,State Treasurer,,Democratic,"Alldritt, Carmen",221,000310
+DOUGLAS,Lawrence Precinct 25,State Treasurer,,Republican,"Estes, Ron",46,000310
+DOUGLAS,Lawrence Precinct 26,State Treasurer,,Democratic,"Alldritt, Carmen",305,000320
+DOUGLAS,Lawrence Precinct 26,State Treasurer,,Republican,"Estes, Ron",73,000320
+DOUGLAS,Lawrence Precinct 27,State Treasurer,,Democratic,"Alldritt, Carmen",303,000330
+DOUGLAS,Lawrence Precinct 27,State Treasurer,,Republican,"Estes, Ron",91,000330
+DOUGLAS,Lawrence Precinct 28,State Treasurer,,Democratic,"Alldritt, Carmen",216,000340
+DOUGLAS,Lawrence Precinct 28,State Treasurer,,Republican,"Estes, Ron",64,000340
+DOUGLAS,Lawrence Precinct 29,State Treasurer,,Democratic,"Alldritt, Carmen",296,000350
+DOUGLAS,Lawrence Precinct 29,State Treasurer,,Republican,"Estes, Ron",90,000350
+DOUGLAS,Lawrence Precinct 31,State Treasurer,,Democratic,"Alldritt, Carmen",383,000370
+DOUGLAS,Lawrence Precinct 31,State Treasurer,,Republican,"Estes, Ron",201,000370
+DOUGLAS,Lawrence Precinct 32,State Treasurer,,Democratic,"Alldritt, Carmen",180,000380
+DOUGLAS,Lawrence Precinct 32,State Treasurer,,Republican,"Estes, Ron",109,000380
+DOUGLAS,Lawrence Precinct 33,State Treasurer,,Democratic,"Alldritt, Carmen",455,000400
+DOUGLAS,Lawrence Precinct 33,State Treasurer,,Republican,"Estes, Ron",107,000400
+DOUGLAS,Lawrence Precinct 38,State Treasurer,,Democratic,"Alldritt, Carmen",386,000450
+DOUGLAS,Lawrence Precinct 38,State Treasurer,,Republican,"Estes, Ron",210,000450
+DOUGLAS,Lawrence Precinct 39,State Treasurer,,Democratic,"Alldritt, Carmen",450,000460
+DOUGLAS,Lawrence Precinct 39,State Treasurer,,Republican,"Estes, Ron",48,000460
+DOUGLAS,Lawrence Precinct 40,State Treasurer,,Democratic,"Alldritt, Carmen",424,000470
+DOUGLAS,Lawrence Precinct 40,State Treasurer,,Republican,"Estes, Ron",38,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,State Treasurer,,Republican,"Estes, Ron",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,State Treasurer,,Democratic,"Alldritt, Carmen",216,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,State Treasurer,,Republican,"Estes, Ron",177,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,State Treasurer,,Republican,"Estes, Ron",0,00050C
+DOUGLAS,Lawrence Precinct 45,State Treasurer,,Democratic,"Alldritt, Carmen",793,00052A
+DOUGLAS,Lawrence Precinct 45,State Treasurer,,Republican,"Estes, Ron",809,00052A
+DOUGLAS,Lawrence Precinct 49,State Treasurer,,Democratic,"Alldritt, Carmen",320,000560
+DOUGLAS,Lawrence Precinct 49,State Treasurer,,Republican,"Estes, Ron",373,000560
+DOUGLAS,North Eudora Precinct 52,State Treasurer,,Democratic,"Alldritt, Carmen",158,000600
+DOUGLAS,North Eudora Precinct 52,State Treasurer,,Republican,"Estes, Ron",150,000600
+DOUGLAS,Northeast Baldwin Precinct 61,State Treasurer,,Democratic,"Alldritt, Carmen",314,000620
+DOUGLAS,Northeast Baldwin Precinct 61,State Treasurer,,Republican,"Estes, Ron",375,000620
+DOUGLAS,Northwest Baldwin Precinct 60,State Treasurer,,Democratic,"Alldritt, Carmen",255,000630
+DOUGLAS,Northwest Baldwin Precinct 60,State Treasurer,,Republican,"Estes, Ron",274,000630
+DOUGLAS,South Baldwin Precinct 62,State Treasurer,,Democratic,"Alldritt, Carmen",257,000640
+DOUGLAS,South Baldwin Precinct 62,State Treasurer,,Republican,"Estes, Ron",447,000640
+DOUGLAS,Vinland Precinct 63,State Treasurer,,Democratic,"Alldritt, Carmen",236,000660
+DOUGLAS,Vinland Precinct 63,State Treasurer,,Republican,"Estes, Ron",296,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,State Treasurer,,Republican,"Estes, Ron",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,State Treasurer,,Democratic,"Alldritt, Carmen",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,State Treasurer,,Republican,"Estes, Ron",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,State Treasurer,,Democratic,"Alldritt, Carmen",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,State Treasurer,,Republican,"Estes, Ron",0,120030
+DOUGLAS,Grant Township S2 H45,State Treasurer,,Democratic,"Alldritt, Carmen",19,120040
+DOUGLAS,Grant Township S2 H45,State Treasurer,,Republican,"Estes, Ron",7,120040
+DOUGLAS,Grant Township S3 H45,State Treasurer,,Democratic,"Alldritt, Carmen",60,120050
+DOUGLAS,Grant Township S3 H45,State Treasurer,,Republican,"Estes, Ron",46,120050
+DOUGLAS,Grant Township S3 H46,State Treasurer,,Democratic,"Alldritt, Carmen",23,120060
+DOUGLAS,Grant Township S3 H46,State Treasurer,,Republican,"Estes, Ron",13,120060
+DOUGLAS,Kawaka Township S19,State Treasurer,,Democratic,"Alldritt, Carmen",278,120070
+DOUGLAS,Kawaka Township S19,State Treasurer,,Republican,"Estes, Ron",382,120070
+DOUGLAS,Kawaka Township S2,State Treasurer,,Democratic,"Alldritt, Carmen",29,120080
+DOUGLAS,Kawaka Township S2,State Treasurer,,Republican,"Estes, Ron",15,120080
+DOUGLAS,Lawrence Precinct 30 S2,State Treasurer,,Democratic,"Alldritt, Carmen",107,120090
+DOUGLAS,Lawrence Precinct 30 S2,State Treasurer,,Republican,"Estes, Ron",50,120090
+DOUGLAS,Lawrence Precinct 30 S3,State Treasurer,,Democratic,"Alldritt, Carmen",135,120100
+DOUGLAS,Lawrence Precinct 30 S3,State Treasurer,,Republican,"Estes, Ron",50,120100
+DOUGLAS,Lawrence Precinct 34 S2,State Treasurer,,Democratic,"Alldritt, Carmen",283,120110
+DOUGLAS,Lawrence Precinct 34 S2,State Treasurer,,Republican,"Estes, Ron",64,120110
+DOUGLAS,Lawrence Precinct 34 S3,State Treasurer,,Democratic,"Alldritt, Carmen",59,120120
+DOUGLAS,Lawrence Precinct 34 S3,State Treasurer,,Republican,"Estes, Ron",6,120120
+DOUGLAS,Lawrence Precinct 35 S2,State Treasurer,,Democratic,"Alldritt, Carmen",346,120130
+DOUGLAS,Lawrence Precinct 35 S2,State Treasurer,,Republican,"Estes, Ron",101,120130
+DOUGLAS,Lawrence Precinct 35 S3,State Treasurer,,Democratic,"Alldritt, Carmen",23,120140
+DOUGLAS,Lawrence Precinct 35 S3,State Treasurer,,Republican,"Estes, Ron",11,120140
+DOUGLAS,Lawrence Precinct 36 S2,State Treasurer,,Democratic,"Alldritt, Carmen",263,120150
+DOUGLAS,Lawrence Precinct 36 S2,State Treasurer,,Republican,"Estes, Ron",124,120150
+DOUGLAS,Lawrence Precinct 36 S3,State Treasurer,,Democratic,"Alldritt, Carmen",206,120160
+DOUGLAS,Lawrence Precinct 36 S3,State Treasurer,,Republican,"Estes, Ron",110,120160
+DOUGLAS,Lawrence Precinct 37 H10,State Treasurer,,Democratic,"Alldritt, Carmen",458,120170
+DOUGLAS,Lawrence Precinct 37 H10,State Treasurer,,Republican,"Estes, Ron",274,120170
+DOUGLAS,Lawrence Precinct 37 H46,State Treasurer,,Democratic,"Alldritt, Carmen",17,120180
+DOUGLAS,Lawrence Precinct 37 H46,State Treasurer,,Republican,"Estes, Ron",10,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,State Treasurer,,Democratic,"Alldritt, Carmen",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,State Treasurer,,Republican,"Estes, Ron",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,State Treasurer,,Republican,"Estes, Ron",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,State Treasurer,,Democratic,"Alldritt, Carmen",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,State Treasurer,,Republican,"Estes, Ron",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,State Treasurer,,Republican,"Estes, Ron",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,State Treasurer,,Democratic,"Alldritt, Carmen",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,State Treasurer,,Republican,"Estes, Ron",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,State Treasurer,,Democratic,"Alldritt, Carmen",4,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,State Treasurer,,Republican,"Estes, Ron",2,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,State Treasurer,,Democratic,"Alldritt, Carmen",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,State Treasurer,,Republican,"Estes, Ron",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,State Treasurer,,Democratic,"Alldritt, Carmen",651,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,State Treasurer,,Republican,"Estes, Ron",207,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,State Treasurer,,Democratic,"Alldritt, Carmen",135,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,State Treasurer,,Republican,"Estes, Ron",96,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,State Treasurer,,Democratic,"Alldritt, Carmen",135,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,State Treasurer,,Republican,"Estes, Ron",54,120260
+DOUGLAS,Lawrence Precinct 44 H44,State Treasurer,,Democratic,"Alldritt, Carmen",54,120270
+DOUGLAS,Lawrence Precinct 44 H44,State Treasurer,,Republican,"Estes, Ron",43,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,State Treasurer,,Republican,"Estes, Ron",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,State Treasurer,,Democratic,"Alldritt, Carmen",204,120280
+DOUGLAS,Lawrence Precinct 44 H45,State Treasurer,,Republican,"Estes, Ron",151,120280
+DOUGLAS,Lawrence Precinct 46 S19,State Treasurer,,Democratic,"Alldritt, Carmen",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,State Treasurer,,Republican,"Estes, Ron",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,State Treasurer,,Democratic,"Alldritt, Carmen",529,120300
+DOUGLAS,Lawrence Precinct 46 S3,State Treasurer,,Republican,"Estes, Ron",339,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,State Treasurer,,Democratic,"Alldritt, Carmen",52,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,State Treasurer,,Republican,"Estes, Ron",74,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,State Treasurer,,Democratic,"Alldritt, Carmen",182,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,State Treasurer,,Republican,"Estes, Ron",199,120320
+DOUGLAS,Marion Township Precinct 59 H45,State Treasurer,,Democratic,"Alldritt, Carmen",54,120330
+DOUGLAS,Marion Township Precinct 59 H45,State Treasurer,,Republican,"Estes, Ron",103,120330
+DOUGLAS,Marion Township Precinct 59 H54,State Treasurer,,Democratic,"Alldritt, Carmen",104,120340
+DOUGLAS,Marion Township Precinct 59 H54,State Treasurer,,Republican,"Estes, Ron",121,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,State Treasurer,,Democratic,"Alldritt, Carmen",120,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,State Treasurer,,Republican,"Estes, Ron",68,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,State Treasurer,,Democratic,"Alldritt, Carmen",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,State Treasurer,,Republican,"Estes, Ron",1,120360
+DOUGLAS,South Eudora Precinct 53 H10,State Treasurer,,Democratic,"Alldritt, Carmen",120,120370
+DOUGLAS,South Eudora Precinct 53 H10,State Treasurer,,Republican,"Estes, Ron",265,120370
+DOUGLAS,South Eudora Precinct 53 H42,State Treasurer,,Democratic,"Alldritt, Carmen",146,120380
+DOUGLAS,South Eudora Precinct 53 H42,State Treasurer,,Republican,"Estes, Ron",259,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,State Treasurer,,Democratic,"Alldritt, Carmen",95,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,State Treasurer,,Republican,"Estes, Ron",134,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,State Treasurer,,Democratic,"Alldritt, Carmen",68,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,State Treasurer,,Republican,"Estes, Ron",90,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,State Treasurer,,Democratic,"Alldritt, Carmen",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,State Treasurer,,Republican,"Estes, Ron",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,State Treasurer,,Democratic,"Alldritt, Carmen",51,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,State Treasurer,,Republican,"Estes, Ron",80,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,State Treasurer,,Democratic,"Alldritt, Carmen",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,State Treasurer,,Republican,"Estes, Ron",0,120420
+DOUGLAS,Willow Springs Township S19 H45,State Treasurer,,Democratic,"Alldritt, Carmen",126,120430
+DOUGLAS,Willow Springs Township S19 H45,State Treasurer,,Republican,"Estes, Ron",126,120430
+DOUGLAS,Willow Springs Township S19 H54,State Treasurer,,Democratic,"Alldritt, Carmen",84,120440
+DOUGLAS,Willow Springs Township S19 H54,State Treasurer,,Republican,"Estes, Ron",170,120440
+DOUGLAS,Willow Springs Township S3 H45,State Treasurer,,Democratic,"Alldritt, Carmen",41,120450
+DOUGLAS,Willow Springs Township S3 H45,State Treasurer,,Republican,"Estes, Ron",39,120450
+DOUGLAS,Willow Springs Township S3 H54,State Treasurer,,Democratic,"Alldritt, Carmen",21,120460
+DOUGLAS,Willow Springs Township S3 H54,State Treasurer,,Republican,"Estes, Ron",26,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,State Treasurer,,Democratic,"Alldritt, Carmen",146,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,State Treasurer,,Republican,"Estes, Ron",161,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,State Treasurer,,Republican,"Estes, Ron",0,400010
+DOUGLAS,Lawrence Precinct 47,State Treasurer,,Democratic,"Alldritt, Carmen",180,400030
+DOUGLAS,Lawrence Precinct 47,State Treasurer,,Republican,"Estes, Ron",157,400030
+DOUGLAS,Lawrence Precinct 48,State Treasurer,,Democratic,"Alldritt, Carmen",493,400040
+DOUGLAS,Lawrence Precinct 48,State Treasurer,,Republican,"Estes, Ron",318,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,State Treasurer,,Republican,"Estes, Ron",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,State Treasurer,,Republican,"Estes, Ron",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",264,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,State Treasurer,,Republican,"Estes, Ron",464,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,State Treasurer,,Republican,"Estes, Ron",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,State Treasurer,,Republican,"Estes, Ron",0,400110
+DOUGLAS,Lawrence Precinct 68,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+DOUGLAS,Lawrence Precinct 68,State Treasurer,,Republican,"Estes, Ron",0,900010
+DOUGLAS,Lawrence Precinct 69,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+DOUGLAS,Lawrence Precinct 69,State Treasurer,,Republican,"Estes, Ron",0,900020
+DOUGLAS,Lawrence Precinct 70,State Treasurer,,Democratic,"Alldritt, Carmen",1,900040
+DOUGLAS,Lawrence Precinct 70,State Treasurer,,Republican,"Estes, Ron",5,900040
+DOUGLAS,Lawrence Precinct 71,State Treasurer,,Democratic,"Alldritt, Carmen",328,900050
+DOUGLAS,Lawrence Precinct 71,State Treasurer,,Republican,"Estes, Ron",286,900050
+DOUGLAS,Lawrence Precinct 72,State Treasurer,,Democratic,"Alldritt, Carmen",0,900060
+DOUGLAS,Lawrence Precinct 72,State Treasurer,,Republican,"Estes, Ron",0,900060
+DOUGLAS,Lawrence Precinct 73,State Treasurer,,Democratic,"Alldritt, Carmen",0,900070
+DOUGLAS,Lawrence Precinct 73,State Treasurer,,Republican,"Estes, Ron",0,900070
+DOUGLAS,Lawrence Precinct 74,State Treasurer,,Democratic,"Alldritt, Carmen",0,900080
+DOUGLAS,Lawrence Precinct 74,State Treasurer,,Republican,"Estes, Ron",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",224,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,State Treasurer,,Republican,"Estes, Ron",188,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,State Treasurer,,Republican,"Estes, Ron",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,State Treasurer,,Republican,"Estes, Ron",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,State Treasurer,,Republican,"Estes, Ron",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,State Treasurer,,Democratic,"Alldritt, Carmen",22,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,State Treasurer,,Republican,"Estes, Ron",2,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,State Treasurer,,Democratic,"Alldritt, Carmen",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,State Treasurer,,Republican,"Estes, Ron",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,State Treasurer,,Democratic,"Alldritt, Carmen",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,State Treasurer,,Republican,"Estes, Ron",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,State Treasurer,,Republican,"Estes, Ron",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,State Treasurer,,Democratic,"Alldritt, Carmen",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,State Treasurer,,Republican,"Estes, Ron",0,900170
+DOUGLAS,Big Springs Township,United States Senate,,independent,"Orman, Greg",85,000010
+DOUGLAS,Big Springs Township,United States Senate,,Libertarian,"Batson, Randall",6,000010
+DOUGLAS,Big Springs Township,United States Senate,,Republican,"Roberts, Pat",69,000010
+DOUGLAS,Central Eudora,United States Senate,,independent,"Orman, Greg",236,000020
+DOUGLAS,Central Eudora,United States Senate,,Libertarian,"Batson, Randall",31,000020
+DOUGLAS,Central Eudora,United States Senate,,Republican,"Roberts, Pat",234,000020
+DOUGLAS,Clinton Township,United States Senate,,independent,"Orman, Greg",163,000030
+DOUGLAS,Clinton Township,United States Senate,,Libertarian,"Batson, Randall",8,000030
+DOUGLAS,Clinton Township,United States Senate,,Republican,"Roberts, Pat",162,000030
+DOUGLAS,Lawrence Precinct 01,United States Senate,,independent,"Orman, Greg",324,00007A
+DOUGLAS,Lawrence Precinct 01,United States Senate,,Libertarian,"Batson, Randall",25,00007A
+DOUGLAS,Lawrence Precinct 01,United States Senate,,Republican,"Roberts, Pat",46,00007A
+DOUGLAS,Lawrence Precinct 02,United States Senate,,independent,"Orman, Greg",421,000080
+DOUGLAS,Lawrence Precinct 02,United States Senate,,Libertarian,"Batson, Randall",7,000080
+DOUGLAS,Lawrence Precinct 02,United States Senate,,Republican,"Roberts, Pat",52,000080
+DOUGLAS,Lawrence Precinct 03,United States Senate,,independent,"Orman, Greg",396,000090
+DOUGLAS,Lawrence Precinct 03,United States Senate,,Libertarian,"Batson, Randall",15,000090
+DOUGLAS,Lawrence Precinct 03,United States Senate,,Republican,"Roberts, Pat",47,000090
+DOUGLAS,Lawrence Precinct 04,United States Senate,,independent,"Orman, Greg",324,00010A
+DOUGLAS,Lawrence Precinct 04,United States Senate,,Libertarian,"Batson, Randall",19,00010A
+DOUGLAS,Lawrence Precinct 04,United States Senate,,Republican,"Roberts, Pat",57,00010A
+DOUGLAS,Lawrence Precinct 05,United States Senate,,independent,"Orman, Greg",396,000110
+DOUGLAS,Lawrence Precinct 05,United States Senate,,Libertarian,"Batson, Randall",17,000110
+DOUGLAS,Lawrence Precinct 05,United States Senate,,Republican,"Roberts, Pat",182,000110
+DOUGLAS,Lawrence Precinct 06,United States Senate,,independent,"Orman, Greg",393,00012A
+DOUGLAS,Lawrence Precinct 06,United States Senate,,Libertarian,"Batson, Randall",14,00012A
+DOUGLAS,Lawrence Precinct 06,United States Senate,,Republican,"Roberts, Pat",190,00012A
+DOUGLAS,Lawrence Precinct 07,United States Senate,,independent,"Orman, Greg",150,000130
+DOUGLAS,Lawrence Precinct 07,United States Senate,,Libertarian,"Batson, Randall",7,000130
+DOUGLAS,Lawrence Precinct 07,United States Senate,,Republican,"Roberts, Pat",9,000130
+DOUGLAS,Lawrence Precinct 08,United States Senate,,independent,"Orman, Greg",224,000140
+DOUGLAS,Lawrence Precinct 08,United States Senate,,Libertarian,"Batson, Randall",11,000140
+DOUGLAS,Lawrence Precinct 08,United States Senate,,Republican,"Roberts, Pat",20,000140
+DOUGLAS,Lawrence Precinct 09,United States Senate,,independent,"Orman, Greg",204,000150
+DOUGLAS,Lawrence Precinct 09,United States Senate,,Libertarian,"Batson, Randall",9,000150
+DOUGLAS,Lawrence Precinct 09,United States Senate,,Republican,"Roberts, Pat",34,000150
+DOUGLAS,Lawrence Precinct 10,United States Senate,,independent,"Orman, Greg",102,000160
+DOUGLAS,Lawrence Precinct 10,United States Senate,,Libertarian,"Batson, Randall",11,000160
+DOUGLAS,Lawrence Precinct 10,United States Senate,,Republican,"Roberts, Pat",20,000160
+DOUGLAS,Lawrence Precinct 11,United States Senate,,independent,"Orman, Greg",305,000170
+DOUGLAS,Lawrence Precinct 11,United States Senate,,Libertarian,"Batson, Randall",16,000170
+DOUGLAS,Lawrence Precinct 11,United States Senate,,Republican,"Roberts, Pat",93,000170
+DOUGLAS,Lawrence Precinct 12,United States Senate,,independent,"Orman, Greg",524,000180
+DOUGLAS,Lawrence Precinct 12,United States Senate,,Libertarian,"Batson, Randall",29,000180
+DOUGLAS,Lawrence Precinct 12,United States Senate,,Republican,"Roberts, Pat",156,000180
+DOUGLAS,Lawrence Precinct 13,United States Senate,,independent,"Orman, Greg",467,000190
+DOUGLAS,Lawrence Precinct 13,United States Senate,,Libertarian,"Batson, Randall",15,000190
+DOUGLAS,Lawrence Precinct 13,United States Senate,,Republican,"Roberts, Pat",177,000190
+DOUGLAS,Lawrence Precinct 14,United States Senate,,independent,"Orman, Greg",667,000200
+DOUGLAS,Lawrence Precinct 14,United States Senate,,Libertarian,"Batson, Randall",25,000200
+DOUGLAS,Lawrence Precinct 14,United States Senate,,Republican,"Roberts, Pat",276,000200
+DOUGLAS,Lawrence Precinct 15,United States Senate,,independent,"Orman, Greg",555,000210
+DOUGLAS,Lawrence Precinct 15,United States Senate,,Libertarian,"Batson, Randall",18,000210
+DOUGLAS,Lawrence Precinct 15,United States Senate,,Republican,"Roberts, Pat",145,000210
+DOUGLAS,Lawrence Precinct 16,United States Senate,,independent,"Orman, Greg",448,000220
+DOUGLAS,Lawrence Precinct 16,United States Senate,,Libertarian,"Batson, Randall",18,000220
+DOUGLAS,Lawrence Precinct 16,United States Senate,,Republican,"Roberts, Pat",141,000220
+DOUGLAS,Lawrence Precinct 17,United States Senate,,independent,"Orman, Greg",357,000230
+DOUGLAS,Lawrence Precinct 17,United States Senate,,Libertarian,"Batson, Randall",19,000230
+DOUGLAS,Lawrence Precinct 17,United States Senate,,Republican,"Roberts, Pat",186,000230
+DOUGLAS,Lawrence Precinct 18,United States Senate,,independent,"Orman, Greg",676,000240
+DOUGLAS,Lawrence Precinct 18,United States Senate,,Libertarian,"Batson, Randall",19,000240
+DOUGLAS,Lawrence Precinct 18,United States Senate,,Republican,"Roberts, Pat",299,000240
+DOUGLAS,Lawrence Precinct 19,United States Senate,,independent,"Orman, Greg",502,000250
+DOUGLAS,Lawrence Precinct 19,United States Senate,,Libertarian,"Batson, Randall",12,000250
+DOUGLAS,Lawrence Precinct 19,United States Senate,,Republican,"Roberts, Pat",331,000250
+DOUGLAS,Lawrence Precinct 20,United States Senate,,independent,"Orman, Greg",699,000260
+DOUGLAS,Lawrence Precinct 20,United States Senate,,Libertarian,"Batson, Randall",37,000260
+DOUGLAS,Lawrence Precinct 20,United States Senate,,Republican,"Roberts, Pat",274,000260
+DOUGLAS,Lawrence Precinct 21,United States Senate,,independent,"Orman, Greg",284,000270
+DOUGLAS,Lawrence Precinct 21,United States Senate,,Libertarian,"Batson, Randall",4,000270
+DOUGLAS,Lawrence Precinct 21,United States Senate,,Republican,"Roberts, Pat",69,000270
+DOUGLAS,Lawrence Precinct 22,United States Senate,,independent,"Orman, Greg",485,000280
+DOUGLAS,Lawrence Precinct 22,United States Senate,,Libertarian,"Batson, Randall",22,000280
+DOUGLAS,Lawrence Precinct 22,United States Senate,,Republican,"Roberts, Pat",189,000280
+DOUGLAS,Lawrence Precinct 23,United States Senate,,independent,"Orman, Greg",344,000290
+DOUGLAS,Lawrence Precinct 23,United States Senate,,Libertarian,"Batson, Randall",11,000290
+DOUGLAS,Lawrence Precinct 23,United States Senate,,Republican,"Roberts, Pat",120,000290
+DOUGLAS,Lawrence Precinct 24,United States Senate,,independent,"Orman, Greg",285,000300
+DOUGLAS,Lawrence Precinct 24,United States Senate,,Libertarian,"Batson, Randall",8,000300
+DOUGLAS,Lawrence Precinct 24,United States Senate,,Republican,"Roberts, Pat",126,000300
+DOUGLAS,Lawrence Precinct 25,United States Senate,,independent,"Orman, Greg",235,000310
+DOUGLAS,Lawrence Precinct 25,United States Senate,,Libertarian,"Batson, Randall",11,000310
+DOUGLAS,Lawrence Precinct 25,United States Senate,,Republican,"Roberts, Pat",30,000310
+DOUGLAS,Lawrence Precinct 26,United States Senate,,independent,"Orman, Greg",350,000320
+DOUGLAS,Lawrence Precinct 26,United States Senate,,Libertarian,"Batson, Randall",9,000320
+DOUGLAS,Lawrence Precinct 26,United States Senate,,Republican,"Roberts, Pat",40,000320
+DOUGLAS,Lawrence Precinct 27,United States Senate,,independent,"Orman, Greg",322,000330
+DOUGLAS,Lawrence Precinct 27,United States Senate,,Libertarian,"Batson, Randall",21,000330
+DOUGLAS,Lawrence Precinct 27,United States Senate,,Republican,"Roberts, Pat",72,000330
+DOUGLAS,Lawrence Precinct 28,United States Senate,,independent,"Orman, Greg",242,000340
+DOUGLAS,Lawrence Precinct 28,United States Senate,,Libertarian,"Batson, Randall",10,000340
+DOUGLAS,Lawrence Precinct 28,United States Senate,,Republican,"Roberts, Pat",45,000340
+DOUGLAS,Lawrence Precinct 29,United States Senate,,independent,"Orman, Greg",300,000350
+DOUGLAS,Lawrence Precinct 29,United States Senate,,Libertarian,"Batson, Randall",14,000350
+DOUGLAS,Lawrence Precinct 29,United States Senate,,Republican,"Roberts, Pat",86,000350
+DOUGLAS,Lawrence Precinct 31,United States Senate,,independent,"Orman, Greg",434,000370
+DOUGLAS,Lawrence Precinct 31,United States Senate,,Libertarian,"Batson, Randall",19,000370
+DOUGLAS,Lawrence Precinct 31,United States Senate,,Republican,"Roberts, Pat",164,000370
+DOUGLAS,Lawrence Precinct 32,United States Senate,,independent,"Orman, Greg",209,000380
+DOUGLAS,Lawrence Precinct 32,United States Senate,,Libertarian,"Batson, Randall",13,000380
+DOUGLAS,Lawrence Precinct 32,United States Senate,,Republican,"Roberts, Pat",81,000380
+DOUGLAS,Lawrence Precinct 33,United States Senate,,independent,"Orman, Greg",501,000400
+DOUGLAS,Lawrence Precinct 33,United States Senate,,Libertarian,"Batson, Randall",13,000400
+DOUGLAS,Lawrence Precinct 33,United States Senate,,Republican,"Roberts, Pat",84,000400
+DOUGLAS,Lawrence Precinct 38,United States Senate,,independent,"Orman, Greg",445,000450
+DOUGLAS,Lawrence Precinct 38,United States Senate,,Libertarian,"Batson, Randall",27,000450
+DOUGLAS,Lawrence Precinct 38,United States Senate,,Republican,"Roberts, Pat",152,000450
+DOUGLAS,Lawrence Precinct 39,United States Senate,,independent,"Orman, Greg",463,000460
+DOUGLAS,Lawrence Precinct 39,United States Senate,,Libertarian,"Batson, Randall",16,000460
+DOUGLAS,Lawrence Precinct 39,United States Senate,,Republican,"Roberts, Pat",36,000460
+DOUGLAS,Lawrence Precinct 40,United States Senate,,independent,"Orman, Greg",434,000470
+DOUGLAS,Lawrence Precinct 40,United States Senate,,Libertarian,"Batson, Randall",20,000470
+DOUGLAS,Lawrence Precinct 40,United States Senate,,Republican,"Roberts, Pat",20,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States Senate,,independent,"Orman, Greg",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States Senate,,independent,"Orman, Greg",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States Senate,,independent,"Orman, Greg",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States Senate,,Libertarian,"Batson, Randall",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States Senate,,Republican,"Roberts, Pat",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,United States Senate,,independent,"Orman, Greg",264,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States Senate,,Libertarian,"Batson, Randall",13,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States Senate,,Republican,"Roberts, Pat",137,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,United States Senate,,independent,"Orman, Greg",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States Senate,,Libertarian,"Batson, Randall",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States Senate,,Republican,"Roberts, Pat",0,00050C
+DOUGLAS,Lawrence Precinct 45,United States Senate,,independent,"Orman, Greg",1067,00052A
+DOUGLAS,Lawrence Precinct 45,United States Senate,,Libertarian,"Batson, Randall",40,00052A
+DOUGLAS,Lawrence Precinct 45,United States Senate,,Republican,"Roberts, Pat",583,00052A
+DOUGLAS,Lawrence Precinct 49,United States Senate,,independent,"Orman, Greg",411,000560
+DOUGLAS,Lawrence Precinct 49,United States Senate,,Libertarian,"Batson, Randall",15,000560
+DOUGLAS,Lawrence Precinct 49,United States Senate,,Republican,"Roberts, Pat",290,000560
+DOUGLAS,North Eudora Precinct 52,United States Senate,,independent,"Orman, Greg",160,000600
+DOUGLAS,North Eudora Precinct 52,United States Senate,,Libertarian,"Batson, Randall",27,000600
+DOUGLAS,North Eudora Precinct 52,United States Senate,,Republican,"Roberts, Pat",133,000600
+DOUGLAS,Northeast Baldwin Precinct 61,United States Senate,,independent,"Orman, Greg",400,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States Senate,,Libertarian,"Batson, Randall",27,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States Senate,,Republican,"Roberts, Pat",302,000620
+DOUGLAS,Northwest Baldwin Precinct 60,United States Senate,,independent,"Orman, Greg",307,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States Senate,,Libertarian,"Batson, Randall",20,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States Senate,,Republican,"Roberts, Pat",228,000630
+DOUGLAS,South Baldwin Precinct 62,United States Senate,,independent,"Orman, Greg",325,000640
+DOUGLAS,South Baldwin Precinct 62,United States Senate,,Libertarian,"Batson, Randall",36,000640
+DOUGLAS,South Baldwin Precinct 62,United States Senate,,Republican,"Roberts, Pat",366,000640
+DOUGLAS,Vinland Precinct 63,United States Senate,,independent,"Orman, Greg",292,000660
+DOUGLAS,Vinland Precinct 63,United States Senate,,Libertarian,"Batson, Randall",21,000660
+DOUGLAS,Vinland Precinct 63,United States Senate,,Republican,"Roberts, Pat",238,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States Senate,,independent,"Orman, Greg",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States Senate,,Libertarian,"Batson, Randall",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States Senate,,Republican,"Roberts, Pat",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States Senate,,independent,"Orman, Greg",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States Senate,,Libertarian,"Batson, Randall",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States Senate,,Republican,"Roberts, Pat",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States Senate,,independent,"Orman, Greg",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States Senate,,Libertarian,"Batson, Randall",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States Senate,,Republican,"Roberts, Pat",0,120030
+DOUGLAS,Grant Township S2 H45,United States Senate,,independent,"Orman, Greg",20,120040
+DOUGLAS,Grant Township S2 H45,United States Senate,,Libertarian,"Batson, Randall",0,120040
+DOUGLAS,Grant Township S2 H45,United States Senate,,Republican,"Roberts, Pat",8,120040
+DOUGLAS,Grant Township S3 H45,United States Senate,,independent,"Orman, Greg",67,120050
+DOUGLAS,Grant Township S3 H45,United States Senate,,Libertarian,"Batson, Randall",7,120050
+DOUGLAS,Grant Township S3 H45,United States Senate,,Republican,"Roberts, Pat",42,120050
+DOUGLAS,Grant Township S3 H46,United States Senate,,independent,"Orman, Greg",27,120060
+DOUGLAS,Grant Township S3 H46,United States Senate,,Libertarian,"Batson, Randall",0,120060
+DOUGLAS,Grant Township S3 H46,United States Senate,,Republican,"Roberts, Pat",9,120060
+DOUGLAS,Kawaka Township S19,United States Senate,,independent,"Orman, Greg",369,120070
+DOUGLAS,Kawaka Township S19,United States Senate,,Libertarian,"Batson, Randall",24,120070
+DOUGLAS,Kawaka Township S19,United States Senate,,Republican,"Roberts, Pat",290,120070
+DOUGLAS,Kawaka Township S2,United States Senate,,independent,"Orman, Greg",37,120080
+DOUGLAS,Kawaka Township S2,United States Senate,,Libertarian,"Batson, Randall",0,120080
+DOUGLAS,Kawaka Township S2,United States Senate,,Republican,"Roberts, Pat",11,120080
+DOUGLAS,Lawrence Precinct 30 S2,United States Senate,,independent,"Orman, Greg",112,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States Senate,,Libertarian,"Batson, Randall",7,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States Senate,,Republican,"Roberts, Pat",44,120090
+DOUGLAS,Lawrence Precinct 30 S3,United States Senate,,independent,"Orman, Greg",147,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States Senate,,Libertarian,"Batson, Randall",10,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States Senate,,Republican,"Roberts, Pat",34,120100
+DOUGLAS,Lawrence Precinct 34 S2,United States Senate,,independent,"Orman, Greg",291,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States Senate,,Libertarian,"Batson, Randall",12,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States Senate,,Republican,"Roberts, Pat",51,120110
+DOUGLAS,Lawrence Precinct 34 S3,United States Senate,,independent,"Orman, Greg",59,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States Senate,,Libertarian,"Batson, Randall",3,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States Senate,,Republican,"Roberts, Pat",5,120120
+DOUGLAS,Lawrence Precinct 35 S2,United States Senate,,independent,"Orman, Greg",361,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States Senate,,Libertarian,"Batson, Randall",35,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States Senate,,Republican,"Roberts, Pat",72,120130
+DOUGLAS,Lawrence Precinct 35 S3,United States Senate,,independent,"Orman, Greg",23,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States Senate,,Libertarian,"Batson, Randall",3,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States Senate,,Republican,"Roberts, Pat",9,120140
+DOUGLAS,Lawrence Precinct 36 S2,United States Senate,,independent,"Orman, Greg",287,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States Senate,,Libertarian,"Batson, Randall",22,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States Senate,,Republican,"Roberts, Pat",84,120150
+DOUGLAS,Lawrence Precinct 36 S3,United States Senate,,independent,"Orman, Greg",226,120160
+DOUGLAS,Lawrence Precinct 36 S3,United States Senate,,Libertarian,"Batson, Randall",35,120160
+DOUGLAS,Lawrence Precinct 36 S3,United States Senate,,Republican,"Roberts, Pat",66,120160
+DOUGLAS,Lawrence Precinct 37 H10,United States Senate,,independent,"Orman, Greg",497,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States Senate,,Libertarian,"Batson, Randall",47,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States Senate,,Republican,"Roberts, Pat",208,120170
+DOUGLAS,Lawrence Precinct 37 H46,United States Senate,,independent,"Orman, Greg",16,120180
+DOUGLAS,Lawrence Precinct 37 H46,United States Senate,,Libertarian,"Batson, Randall",3,120180
+DOUGLAS,Lawrence Precinct 37 H46,United States Senate,,Republican,"Roberts, Pat",9,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States Senate,,independent,"Orman, Greg",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States Senate,,Libertarian,"Batson, Randall",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States Senate,,Republican,"Roberts, Pat",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States Senate,,independent,"Orman, Greg",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States Senate,,Libertarian,"Batson, Randall",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States Senate,,Republican,"Roberts, Pat",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States Senate,,independent,"Orman, Greg",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States Senate,,Libertarian,"Batson, Randall",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States Senate,,Republican,"Roberts, Pat",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States Senate,,independent,"Orman, Greg",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States Senate,,Libertarian,"Batson, Randall",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States Senate,,Republican,"Roberts, Pat",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States Senate,,independent,"Orman, Greg",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States Senate,,Libertarian,"Batson, Randall",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States Senate,,Republican,"Roberts, Pat",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States Senate,,independent,"Orman, Greg",5,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States Senate,,Libertarian,"Batson, Randall",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States Senate,,Republican,"Roberts, Pat",2,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States Senate,,independent,"Orman, Greg",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States Senate,,Libertarian,"Batson, Randall",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States Senate,,Republican,"Roberts, Pat",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States Senate,,independent,"Orman, Greg",685,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States Senate,,Libertarian,"Batson, Randall",40,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States Senate,,Republican,"Roberts, Pat",167,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States Senate,,independent,"Orman, Greg",158,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States Senate,,Libertarian,"Batson, Randall",6,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States Senate,,Republican,"Roberts, Pat",75,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States Senate,,independent,"Orman, Greg",151,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States Senate,,Libertarian,"Batson, Randall",11,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States Senate,,Republican,"Roberts, Pat",35,120260
+DOUGLAS,Lawrence Precinct 44 H44,United States Senate,,independent,"Orman, Greg",69,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States Senate,,Libertarian,"Batson, Randall",4,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States Senate,,Republican,"Roberts, Pat",29,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,United States Senate,,independent,"Orman, Greg",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States Senate,,Libertarian,"Batson, Randall",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States Senate,,Republican,"Roberts, Pat",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,United States Senate,,independent,"Orman, Greg",250,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States Senate,,Libertarian,"Batson, Randall",17,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States Senate,,Republican,"Roberts, Pat",114,120280
+DOUGLAS,Lawrence Precinct 46 S19,United States Senate,,independent,"Orman, Greg",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States Senate,,Libertarian,"Batson, Randall",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States Senate,,Republican,"Roberts, Pat",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,United States Senate,,independent,"Orman, Greg",641,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States Senate,,Libertarian,"Batson, Randall",34,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States Senate,,Republican,"Roberts, Pat",245,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,United States Senate,,independent,"Orman, Greg",58,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States Senate,,Libertarian,"Batson, Randall",2,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States Senate,,Republican,"Roberts, Pat",64,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,United States Senate,,independent,"Orman, Greg",221,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States Senate,,Libertarian,"Batson, Randall",22,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States Senate,,Republican,"Roberts, Pat",149,120320
+DOUGLAS,Marion Township Precinct 59 H45,United States Senate,,independent,"Orman, Greg",70,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States Senate,,Libertarian,"Batson, Randall",4,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States Senate,,Republican,"Roberts, Pat",87,120330
+DOUGLAS,Marion Township Precinct 59 H54,United States Senate,,independent,"Orman, Greg",131,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States Senate,,Libertarian,"Batson, Randall",5,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States Senate,,Republican,"Roberts, Pat",97,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,United States Senate,,independent,"Orman, Greg",130,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States Senate,,Libertarian,"Batson, Randall",8,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States Senate,,Republican,"Roberts, Pat",63,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,United States Senate,,independent,"Orman, Greg",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States Senate,,Libertarian,"Batson, Randall",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States Senate,,Republican,"Roberts, Pat",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,United States Senate,,independent,"Orman, Greg",151,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States Senate,,Libertarian,"Batson, Randall",20,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States Senate,,Republican,"Roberts, Pat",226,120370
+DOUGLAS,South Eudora Precinct 53 H42,United States Senate,,independent,"Orman, Greg",191,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States Senate,,Libertarian,"Batson, Randall",16,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States Senate,,Republican,"Roberts, Pat",220,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States Senate,,independent,"Orman, Greg",119,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States Senate,,Libertarian,"Batson, Randall",5,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States Senate,,Republican,"Roberts, Pat",119,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,independent,"Orman, Greg",93,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Libertarian,"Batson, Randall",2,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Republican,"Roberts, Pat",70,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,independent,"Orman, Greg",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Libertarian,"Batson, Randall",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Republican,"Roberts, Pat",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States Senate,,independent,"Orman, Greg",69,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States Senate,,Libertarian,"Batson, Randall",6,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States Senate,,Republican,"Roberts, Pat",69,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States Senate,,independent,"Orman, Greg",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States Senate,,Libertarian,"Batson, Randall",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States Senate,,Republican,"Roberts, Pat",0,120420
+DOUGLAS,Willow Springs Township S19 H45,United States Senate,,independent,"Orman, Greg",148,120430
+DOUGLAS,Willow Springs Township S19 H45,United States Senate,,Libertarian,"Batson, Randall",8,120430
+DOUGLAS,Willow Springs Township S19 H45,United States Senate,,Republican,"Roberts, Pat",104,120430
+DOUGLAS,Willow Springs Township S19 H54,United States Senate,,independent,"Orman, Greg",110,120440
+DOUGLAS,Willow Springs Township S19 H54,United States Senate,,Libertarian,"Batson, Randall",6,120440
+DOUGLAS,Willow Springs Township S19 H54,United States Senate,,Republican,"Roberts, Pat",155,120440
+DOUGLAS,Willow Springs Township S3 H45,United States Senate,,independent,"Orman, Greg",44,120450
+DOUGLAS,Willow Springs Township S3 H45,United States Senate,,Libertarian,"Batson, Randall",4,120450
+DOUGLAS,Willow Springs Township S3 H45,United States Senate,,Republican,"Roberts, Pat",34,120450
+DOUGLAS,Willow Springs Township S3 H54,United States Senate,,independent,"Orman, Greg",28,120460
+DOUGLAS,Willow Springs Township S3 H54,United States Senate,,Libertarian,"Batson, Randall",1,120460
+DOUGLAS,Willow Springs Township S3 H54,United States Senate,,Republican,"Roberts, Pat",18,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,United States Senate,,independent,"Orman, Greg",174,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States Senate,,Libertarian,"Batson, Randall",8,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States Senate,,Republican,"Roberts, Pat",144,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States Senate,,independent,"Orman, Greg",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States Senate,,Libertarian,"Batson, Randall",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States Senate,,Republican,"Roberts, Pat",0,400010
+DOUGLAS,Lawrence Precinct 47,United States Senate,,independent,"Orman, Greg",227,400030
+DOUGLAS,Lawrence Precinct 47,United States Senate,,Libertarian,"Batson, Randall",4,400030
+DOUGLAS,Lawrence Precinct 47,United States Senate,,Republican,"Roberts, Pat",125,400030
+DOUGLAS,Lawrence Precinct 48,United States Senate,,independent,"Orman, Greg",601,400040
+DOUGLAS,Lawrence Precinct 48,United States Senate,,Libertarian,"Batson, Randall",13,400040
+DOUGLAS,Lawrence Precinct 48,United States Senate,,Republican,"Roberts, Pat",255,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,United States Senate,,independent,"Orman, Greg",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States Senate,,Libertarian,"Batson, Randall",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States Senate,,Republican,"Roberts, Pat",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,United States Senate,,independent,"Orman, Greg",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States Senate,,Libertarian,"Batson, Randall",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States Senate,,Republican,"Roberts, Pat",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,United States Senate,,independent,"Orman, Greg",341,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States Senate,,Libertarian,"Batson, Randall",48,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States Senate,,Republican,"Roberts, Pat",363,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,United States Senate,,independent,"Orman, Greg",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States Senate,,Libertarian,"Batson, Randall",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States Senate,,Republican,"Roberts, Pat",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States Senate,,independent,"Orman, Greg",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States Senate,,Libertarian,"Batson, Randall",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States Senate,,Republican,"Roberts, Pat",0,400110
+DOUGLAS,Lawrence Precinct 68,United States Senate,,independent,"Orman, Greg",0,900010
+DOUGLAS,Lawrence Precinct 68,United States Senate,,Libertarian,"Batson, Randall",0,900010
+DOUGLAS,Lawrence Precinct 68,United States Senate,,Republican,"Roberts, Pat",0,900010
+DOUGLAS,Lawrence Precinct 69,United States Senate,,independent,"Orman, Greg",0,900020
+DOUGLAS,Lawrence Precinct 69,United States Senate,,Libertarian,"Batson, Randall",0,900020
+DOUGLAS,Lawrence Precinct 69,United States Senate,,Republican,"Roberts, Pat",0,900020
+DOUGLAS,Lawrence Precinct 70,United States Senate,,independent,"Orman, Greg",4,900040
+DOUGLAS,Lawrence Precinct 70,United States Senate,,Libertarian,"Batson, Randall",0,900040
+DOUGLAS,Lawrence Precinct 70,United States Senate,,Republican,"Roberts, Pat",6,900040
+DOUGLAS,Lawrence Precinct 71,United States Senate,,independent,"Orman, Greg",424,900050
+DOUGLAS,Lawrence Precinct 71,United States Senate,,Libertarian,"Batson, Randall",15,900050
+DOUGLAS,Lawrence Precinct 71,United States Senate,,Republican,"Roberts, Pat",201,900050
+DOUGLAS,Lawrence Precinct 72,United States Senate,,independent,"Orman, Greg",0,900060
+DOUGLAS,Lawrence Precinct 72,United States Senate,,Libertarian,"Batson, Randall",0,900060
+DOUGLAS,Lawrence Precinct 72,United States Senate,,Republican,"Roberts, Pat",0,900060
+DOUGLAS,Lawrence Precinct 73,United States Senate,,independent,"Orman, Greg",0,900070
+DOUGLAS,Lawrence Precinct 73,United States Senate,,Libertarian,"Batson, Randall",0,900070
+DOUGLAS,Lawrence Precinct 73,United States Senate,,Republican,"Roberts, Pat",0,900070
+DOUGLAS,Lawrence Precinct 74,United States Senate,,independent,"Orman, Greg",0,900080
+DOUGLAS,Lawrence Precinct 74,United States Senate,,Libertarian,"Batson, Randall",0,900080
+DOUGLAS,Lawrence Precinct 74,United States Senate,,Republican,"Roberts, Pat",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,United States Senate,,independent,"Orman, Greg",279,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States Senate,,Libertarian,"Batson, Randall",5,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States Senate,,Republican,"Roberts, Pat",146,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States Senate,,independent,"Orman, Greg",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States Senate,,Libertarian,"Batson, Randall",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States Senate,,Republican,"Roberts, Pat",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States Senate,,independent,"Orman, Greg",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States Senate,,Libertarian,"Batson, Randall",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States Senate,,Republican,"Roberts, Pat",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States Senate,,independent,"Orman, Greg",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States Senate,,Libertarian,"Batson, Randall",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States Senate,,Republican,"Roberts, Pat",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States Senate,,independent,"Orman, Greg",23,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States Senate,,Libertarian,"Batson, Randall",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States Senate,,Republican,"Roberts, Pat",1,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States Senate,,independent,"Orman, Greg",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States Senate,,Libertarian,"Batson, Randall",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States Senate,,Republican,"Roberts, Pat",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,United States Senate,,independent,"Orman, Greg",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States Senate,,Libertarian,"Batson, Randall",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States Senate,,Republican,"Roberts, Pat",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,United States Senate,,independent,"Orman, Greg",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States Senate,,Libertarian,"Batson, Randall",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States Senate,,Republican,"Roberts, Pat",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,United States Senate,,independent,"Orman, Greg",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States Senate,,Libertarian,"Batson, Randall",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States Senate,,Republican,"Roberts, Pat",0,900170

--- a/2014/20141104__ks__general__edwards__precinct.csv
+++ b/2014/20141104__ks__general__edwards__precinct.csv
@@ -1,361 +1,222 @@
-county,precinct,office,district,party,candidate,votes,precinct_number
-Edwards,01 Kinsley Ward 1,,,,Ballots Cast,285,ED000050
-Edwards,02 Kinsley Ward 2,,,,Ballots Cast,259,ED000060
-Edwards,03 Lewis City,,,,Ballots Cast,121,ED000122
-Edwards,04 Offerle City,,,,Ballots Cast,77,ED000112
-Edwards,05 Belpre City,,,,Ballots Cast,22,ED000012
-Edwards,06 Logan Township,,,,Ballots Cast,15,ED000080
-Edwards,07 Jackson Township,,,,Ballots Cast,33,ED000030
-Edwards,08 Kinsley Township,,,,Ballots Cast,63,ED000040
-Edwards,09 Wayne Township,,,,Ballots Cast,47,ED000121
-Edwards,10 Belpre Township,,,,Ballots Cast,40,ED000011
-Edwards,11 Lincoln Township,,,,Ballots Cast,61,ED000070
-Edwards,12 Franklin Township,,,,Ballots Cast,41,ED000020
-Edwards,13 North Brown Township,,,,Ballots Cast,24,ED000090
-Edwards,14 Trenton Township,,,,Ballots Cast,36,ED000111
-Edwards,15 South Brown Township,,,,Ballots Cast,40,ED000100
-Edwards,01 Kinsley Ward 1,U.S. Senate,,REP,Pat Roberts,196,ED000050
-Edwards,02 Kinsley Ward 2,U.S. Senate,,REP,Pat Roberts,149,ED000060
-Edwards,03 Lewis City,U.S. Senate,,REP,Pat Roberts,85,ED000122
-Edwards,04 Offerle City,U.S. Senate,,REP,Pat Roberts,50,ED000112
-Edwards,05 Belpre City,U.S. Senate,,REP,Pat Roberts,12,ED000012
-Edwards,06 Logan Township,U.S. Senate,,REP,Pat Roberts,8,ED000080
-Edwards,07 Jackson Township,U.S. Senate,,REP,Pat Roberts,26,ED000030
-Edwards,08 Kinsley Township,U.S. Senate,,REP,Pat Roberts,47,ED000040
-Edwards,09 Wayne Township,U.S. Senate,,REP,Pat Roberts,34,ED000121
-Edwards,10 Belpre Township,U.S. Senate,,REP,Pat Roberts,29,ED000011
-Edwards,11 Lincoln Township,U.S. Senate,,REP,Pat Roberts,48,ED000070
-Edwards,12 Franklin Township,U.S. Senate,,REP,Pat Roberts,39,ED000020
-Edwards,13 North Brown Township,U.S. Senate,,REP,Pat Roberts,19,ED000090
-Edwards,14 Trenton Township,U.S. Senate,,REP,Pat Roberts,30,ED000111
-Edwards,15 South Brown Township,U.S. Senate,,REP,Pat Roberts,34,ED000100
-Edwards,01 Kinsley Ward 1,U.S. Senate,,IND,Greg Orman,73,ED000050
-Edwards,02 Kinsley Ward 2,U.S. Senate,,IND,Greg Orman,95,ED000060
-Edwards,03 Lewis City,U.S. Senate,,IND,Greg Orman,31,ED000122
-Edwards,04 Offerle City,U.S. Senate,,IND,Greg Orman,18,ED000112
-Edwards,05 Belpre City,U.S. Senate,,IND,Greg Orman,8,ED000012
-Edwards,06 Logan Township,U.S. Senate,,IND,Greg Orman,6,ED000080
-Edwards,07 Jackson Township,U.S. Senate,,IND,Greg Orman,5,ED000030
-Edwards,08 Kinsley Township,U.S. Senate,,IND,Greg Orman,14,ED000040
-Edwards,09 Wayne Township,U.S. Senate,,IND,Greg Orman,9,ED000121
-Edwards,10 Belpre Township,U.S. Senate,,IND,Greg Orman,9,ED000011
-Edwards,11 Lincoln Township,U.S. Senate,,IND,Greg Orman,9,ED000070
-Edwards,12 Franklin Township,U.S. Senate,,IND,Greg Orman,1,ED000020
-Edwards,13 North Brown Township,U.S. Senate,,IND,Greg Orman,4,ED000090
-Edwards,14 Trenton Township,U.S. Senate,,IND,Greg Orman,6,ED000111
-Edwards,15 South Brown Township,U.S. Senate,,IND,Greg Orman,6,ED000100
-Edwards,01 Kinsley Ward 1,U.S. Senate,,LIB,Randall Batson,13,ED000050
-Edwards,02 Kinsley Ward 2,U.S. Senate,,LIB,Randall Batson,11,ED000060
-Edwards,03 Lewis City,U.S. Senate,,LIB,Randall Batson,4,ED000122
-Edwards,04 Offerle City,U.S. Senate,,LIB,Randall Batson,5,ED000112
-Edwards,05 Belpre City,U.S. Senate,,LIB,Randall Batson,1,ED000012
-Edwards,06 Logan Township,U.S. Senate,,LIB,Randall Batson,1,ED000080
-Edwards,07 Jackson Township,U.S. Senate,,LIB,Randall Batson,1,ED000030
-Edwards,08 Kinsley Township,U.S. Senate,,LIB,Randall Batson,2,ED000040
-Edwards,09 Wayne Township,U.S. Senate,,LIB,Randall Batson,4,ED000121
-Edwards,10 Belpre Township,U.S. Senate,,LIB,Randall Batson,0,ED000011
-Edwards,11 Lincoln Township,U.S. Senate,,LIB,Randall Batson,3,ED000070
-Edwards,12 Franklin Township,U.S. Senate,,LIB,Randall Batson,1,ED000020
-Edwards,13 North Brown Township,U.S. Senate,,LIB,Randall Batson,1,ED000090
-Edwards,14 Trenton Township,U.S. Senate,,LIB,Randall Batson,0,ED000111
-Edwards,15 South Brown Township,U.S. Senate,,LIB,Randall Batson,0,ED000100
-Edwards,01 Kinsley Ward 1,U.S. Senate,,,Write-ins,0,ED000050
-Edwards,02 Kinsley Ward 2,U.S. Senate,,,Write-ins,0,ED000060
-Edwards,03 Lewis City,U.S. Senate,,,Write-ins,0,ED000122
-Edwards,04 Offerle City,U.S. Senate,,,Write-ins,0,ED000112
-Edwards,05 Belpre City,U.S. Senate,,,Write-ins,0,ED000012
-Edwards,06 Logan Township,U.S. Senate,,,Write-ins,0,ED000080
-Edwards,07 Jackson Township,U.S. Senate,,,Write-ins,1,ED000030
-Edwards,08 Kinsley Township,U.S. Senate,,,Write-ins,0,ED000040
-Edwards,09 Wayne Township,U.S. Senate,,,Write-ins,0,ED000121
-Edwards,10 Belpre Township,U.S. Senate,,,Write-ins,0,ED000011
-Edwards,11 Lincoln Township,U.S. Senate,,,Write-ins,0,ED000070
-Edwards,12 Franklin Township,U.S. Senate,,,Write-ins,0,ED000020
-Edwards,13 North Brown Township,U.S. Senate,,,Write-ins,0,ED000090
-Edwards,14 Trenton Township,U.S. Senate,,,Write-ins,0,ED000111
-Edwards,15 South Brown Township,U.S. Senate,,,Write-ins,0,ED000100
-Edwards,01 Kinsley Ward 1,U.S. House,4,REP,Mike Pompeo,204,ED000050
-Edwards,02 Kinsley Ward 2,U.S. House,4,REP,Mike Pompeo,194,ED000060
-Edwards,03 Lewis City,U.S. House,4,REP,Mike Pompeo,87,ED000122
-Edwards,04 Offerle City,U.S. House,4,REP,Mike Pompeo,65,ED000112
-Edwards,05 Belpre City,U.S. House,4,REP,Mike Pompeo,18,ED000012
-Edwards,06 Logan Township,U.S. House,4,REP,Mike Pompeo,11,ED000080
-Edwards,07 Jackson Township,U.S. House,4,REP,Mike Pompeo,25,ED000030
-Edwards,08 Kinsley Township,U.S. House,4,REP,Mike Pompeo,52,ED000040
-Edwards,09 Wayne Township,U.S. House,4,REP,Mike Pompeo,42,ED000121
-Edwards,10 Belpre Township,U.S. House,4,REP,Mike Pompeo,32,ED000011
-Edwards,11 Lincoln Township,U.S. House,4,REP,Mike Pompeo,55,ED000070
-Edwards,12 Franklin Township,U.S. House,4,REP,Mike Pompeo,40,ED000020
-Edwards,13 North Brown Township,U.S. House,4,REP,Mike Pompeo,22,ED000090
-Edwards,14 Trenton Township,U.S. House,4,REP,Mike Pompeo,30,ED000111
-Edwards,15 South Brown Township,U.S. House,4,REP,Mike Pompeo,38,ED000100
-Edwards,01 Kinsley Ward 1,U.S. House,4,DEM,Perry Schuckman,68,ED000050
-Edwards,02 Kinsley Ward 2,U.S. House,4,DEM,Perry Schuckman,63,ED000060
-Edwards,03 Lewis City,U.S. House,4,DEM,Perry Schuckman,34,ED000122
-Edwards,04 Offerle City,U.S. House,4,DEM,Perry Schuckman,8,ED000112
-Edwards,05 Belpre City,U.S. House,4,DEM,Perry Schuckman,3,ED000012
-Edwards,06 Logan Township,U.S. House,4,DEM,Perry Schuckman,4,ED000080
-Edwards,07 Jackson Township,U.S. House,4,DEM,Perry Schuckman,7,ED000030
-Edwards,08 Kinsley Township,U.S. House,4,DEM,Perry Schuckman,8,ED000040
-Edwards,09 Wayne Township,U.S. House,4,DEM,Perry Schuckman,4,ED000121
-Edwards,10 Belpre Township,U.S. House,4,DEM,Perry Schuckman,7,ED000011
-Edwards,11 Lincoln Township,U.S. House,4,DEM,Perry Schuckman,4,ED000070
-Edwards,12 Franklin Township,U.S. House,4,DEM,Perry Schuckman,0,ED000020
-Edwards,13 North Brown Township,U.S. House,4,DEM,Perry Schuckman,2,ED000090
-Edwards,14 Trenton Township,U.S. House,4,DEM,Perry Schuckman,5,ED000111
-Edwards,15 South Brown Township,U.S. House,4,DEM,Perry Schuckman,2,ED000100
-Edwards,01 Kinsley Ward 1,Governor,,REP,Sam Brownback,172,ED000050
-Edwards,02 Kinsley Ward 2,Governor,,REP,Sam Brownback,145,ED000060
-Edwards,03 Lewis City,Governor,,REP,Sam Brownback,81,ED000122
-Edwards,04 Offerle City,Governor,,REP,Sam Brownback,51,ED000112
-Edwards,05 Belpre City,Governor,,REP,Sam Brownback,13,ED000012
-Edwards,06 Logan Township,Governor,,REP,Sam Brownback,8,ED000080
-Edwards,07 Jackson Township,Governor,,REP,Sam Brownback,23,ED000030
-Edwards,08 Kinsley Township,Governor,,REP,Sam Brownback,47,ED000040
-Edwards,09 Wayne Township,Governor,,REP,Sam Brownback,32,ED000121
-Edwards,10 Belpre Township,Governor,,REP,Sam Brownback,30,ED000011
-Edwards,11 Lincoln Township,Governor,,REP,Sam Brownback,48,ED000070
-Edwards,12 Franklin Township,Governor,,REP,Sam Brownback,39,ED000020
-Edwards,13 North Brown Township,Governor,,REP,Sam Brownback,19,ED000090
-Edwards,14 Trenton Township,Governor,,REP,Sam Brownback,28,ED000111
-Edwards,15 South Brown Township,Governor,,REP,Sam Brownback,30,ED000100
-Edwards,01 Kinsley Ward 1,Governor,,DEM,Paul Davis,99,ED000050
-Edwards,02 Kinsley Ward 2,Governor,,DEM,Paul Davis,103,ED000060
-Edwards,03 Lewis City,Governor,,DEM,Paul Davis,34,ED000122
-Edwards,04 Offerle City,Governor,,DEM,Paul Davis,23,ED000112
-Edwards,05 Belpre City,Governor,,DEM,Paul Davis,8,ED000012
-Edwards,06 Logan Township,Governor,,DEM,Paul Davis,6,ED000080
-Edwards,07 Jackson Township,Governor,,DEM,Paul Davis,8,ED000030
-Edwards,08 Kinsley Township,Governor,,DEM,Paul Davis,15,ED000040
-Edwards,09 Wayne Township,Governor,,DEM,Paul Davis,12,ED000121
-Edwards,10 Belpre Township,Governor,,DEM,Paul Davis,8,ED000011
-Edwards,11 Lincoln Township,Governor,,DEM,Paul Davis,11,ED000070
-Edwards,12 Franklin Township,Governor,,DEM,Paul Davis,1,ED000020
-Edwards,13 North Brown Township,Governor,,DEM,Paul Davis,5,ED000090
-Edwards,14 Trenton Township,Governor,,DEM,Paul Davis,5,ED000111
-Edwards,15 South Brown Township,Governor,,DEM,Paul Davis,9,ED000100
-Edwards,01 Kinsley Ward 1,Governor,,LIB,Keen Umbehr,8,ED000050
-Edwards,02 Kinsley Ward 2,Governor,,LIB,Keen Umbehr,8,ED000060
-Edwards,03 Lewis City,Governor,,LIB,Keen Umbehr,5,ED000122
-Edwards,04 Offerle City,Governor,,LIB,Keen Umbehr,3,ED000112
-Edwards,05 Belpre City,Governor,,LIB,Keen Umbehr,1,ED000012
-Edwards,06 Logan Township,Governor,,LIB,Keen Umbehr,1,ED000080
-Edwards,07 Jackson Township,Governor,,LIB,Keen Umbehr,1,ED000030
-Edwards,08 Kinsley Township,Governor,,LIB,Keen Umbehr,1,ED000040
-Edwards,09 Wayne Township,Governor,,LIB,Keen Umbehr,3,ED000121
-Edwards,10 Belpre Township,Governor,,LIB,Keen Umbehr,2,ED000011
-Edwards,11 Lincoln Township,Governor,,LIB,Keen Umbehr,2,ED000070
-Edwards,12 Franklin Township,Governor,,LIB,Keen Umbehr,1,ED000020
-Edwards,13 North Brown Township,Governor,,LIB,Keen Umbehr,0,ED000090
-Edwards,14 Trenton Township,Governor,,LIB,Keen Umbehr,2,ED000111
-Edwards,15 South Brown Township,Governor,,LIB,Keen Umbehr,0,ED000100
-Edwards,01 Kinsley Ward 1,Secretary of State,,REP,Kris Kobach,203,ED000050
-Edwards,02 Kinsley Ward 2,Secretary of State,,REP,Kris Kobach,181,ED000060
-Edwards,03 Lewis City,Secretary of State,,REP,Kris Kobach,88,ED000122
-Edwards,04 Offerle City,Secretary of State,,REP,Kris Kobach,58,ED000112
-Edwards,05 Belpre City,Secretary of State,,REP,Kris Kobach,14,ED000012
-Edwards,06 Logan Township,Secretary of State,,REP,Kris Kobach,10,ED000080
-Edwards,07 Jackson Township,Secretary of State,,REP,Kris Kobach,28,ED000030
-Edwards,08 Kinsley Township,Secretary of State,,REP,Kris Kobach,52,ED000040
-Edwards,09 Wayne Township,Secretary of State,,REP,Kris Kobach,44,ED000121
-Edwards,10 Belpre Township,Secretary of State,,REP,Kris Kobach,32,ED000011
-Edwards,11 Lincoln Township,Secretary of State,,REP,Kris Kobach,51,ED000070
-Edwards,12 Franklin Township,Secretary of State,,REP,Kris Kobach,41,ED000020
-Edwards,13 North Brown Township,Secretary of State,,REP,Kris Kobach,19,ED000090
-Edwards,14 Trenton Township,Secretary of State,,REP,Kris Kobach,30,ED000111
-Edwards,15 South Brown Township,Secretary of State,,REP,Kris Kobach,38,ED000100
-Edwards,01 Kinsley Ward 1,Secretary of State,,DEM,Jean Schodorf,72,ED000050
-Edwards,02 Kinsley Ward 2,Secretary of State,,DEM,Jean Schodorf,72,ED000060
-Edwards,03 Lewis City,Secretary of State,,DEM,Jean Schodorf,30,ED000122
-Edwards,04 Offerle City,Secretary of State,,DEM,Jean Schodorf,16,ED000112
-Edwards,05 Belpre City,Secretary of State,,DEM,Jean Schodorf,8,ED000012
-Edwards,06 Logan Township,Secretary of State,,DEM,Jean Schodorf,5,ED000080
-Edwards,07 Jackson Township,Secretary of State,,DEM,Jean Schodorf,5,ED000030
-Edwards,08 Kinsley Township,Secretary of State,,DEM,Jean Schodorf,9,ED000040
-Edwards,09 Wayne Township,Secretary of State,,DEM,Jean Schodorf,3,ED000121
-Edwards,10 Belpre Township,Secretary of State,,DEM,Jean Schodorf,8,ED000011
-Edwards,11 Lincoln Township,Secretary of State,,DEM,Jean Schodorf,10,ED000070
-Edwards,12 Franklin Township,Secretary of State,,DEM,Jean Schodorf,0,ED000020
-Edwards,13 North Brown Township,Secretary of State,,DEM,Jean Schodorf,5,ED000090
-Edwards,14 Trenton Township,Secretary of State,,DEM,Jean Schodorf,6,ED000111
-Edwards,15 South Brown Township,Secretary of State,,DEM,Jean Schodorf,2,ED000100
-Edwards,01 Kinsley Ward 1,Secretary of State,,,Write-ins,1,ED000050
-Edwards,02 Kinsley Ward 2,Secretary of State,,,Write-ins,0,ED000060
-Edwards,03 Lewis City,Secretary of State,,,Write-ins,1,ED000122
-Edwards,04 Offerle City,Secretary of State,,,Write-ins,0,ED000112
-Edwards,05 Belpre City,Secretary of State,,,Write-ins,0,ED000012
-Edwards,06 Logan Township,Secretary of State,,,Write-ins,0,ED000080
-Edwards,07 Jackson Township,Secretary of State,,,Write-ins,0,ED000030
-Edwards,08 Kinsley Township,Secretary of State,,,Write-ins,0,ED000040
-Edwards,09 Wayne Township,Secretary of State,,,Write-ins,0,ED000121
-Edwards,10 Belpre Township,Secretary of State,,,Write-ins,0,ED000011
-Edwards,11 Lincoln Township,Secretary of State,,,Write-ins,0,ED000070
-Edwards,12 Franklin Township,Secretary of State,,,Write-ins,0,ED000020
-Edwards,13 North Brown Township,Secretary of State,,,Write-ins,0,ED000090
-Edwards,14 Trenton Township,Secretary of State,,,Write-ins,0,ED000111
-Edwards,15 South Brown Township,Secretary of State,,,Write-ins,0,ED000100
-Edwards,01 Kinsley Ward 1,Attorney General,,REP,Derek Schmidt,221,ED000050
-Edwards,02 Kinsley Ward 2,Attorney General,,REP,Derek Schmidt,203,ED000060
-Edwards,03 Lewis City,Attorney General,,REP,Derek Schmidt,91,ED000122
-Edwards,04 Offerle City,Attorney General,,REP,Derek Schmidt,64,ED000112
-Edwards,05 Belpre City,Attorney General,,REP,Derek Schmidt,18,ED000012
-Edwards,06 Logan Township,Attorney General,,REP,Derek Schmidt,14,ED000080
-Edwards,07 Jackson Township,Attorney General,,REP,Derek Schmidt,28,ED000030
-Edwards,08 Kinsley Township,Attorney General,,REP,Derek Schmidt,57,ED000040
-Edwards,09 Wayne Township,Attorney General,,REP,Derek Schmidt,43,ED000121
-Edwards,10 Belpre Township,Attorney General,,REP,Derek Schmidt,36,ED000011
-Edwards,11 Lincoln Township,Attorney General,,REP,Derek Schmidt,55,ED000070
-Edwards,12 Franklin Township,Attorney General,,REP,Derek Schmidt,39,ED000020
-Edwards,13 North Brown Township,Attorney General,,REP,Derek Schmidt,22,ED000090
-Edwards,14 Trenton Township,Attorney General,,REP,Derek Schmidt,32,ED000111
-Edwards,15 South Brown Township,Attorney General,,REP,Derek Schmidt,39,ED000100
-Edwards,01 Kinsley Ward 1,Attorney General,,DEM,A J Kotich,53,ED000050
-Edwards,02 Kinsley Ward 2,Attorney General,,DEM,A J Kotich,50,ED000060
-Edwards,03 Lewis City,Attorney General,,DEM,A J Kotich,27,ED000122
-Edwards,04 Offerle City,Attorney General,,DEM,A J Kotich,11,ED000112
-Edwards,05 Belpre City,Attorney General,,DEM,A J Kotich,3,ED000012
-Edwards,06 Logan Township,Attorney General,,DEM,A J Kotich,1,ED000080
-Edwards,07 Jackson Township,Attorney General,,DEM,A J Kotich,5,ED000030
-Edwards,08 Kinsley Township,Attorney General,,DEM,A J Kotich,4,ED000040
-Edwards,09 Wayne Township,Attorney General,,DEM,A J Kotich,0,ED000121
-Edwards,10 Belpre Township,Attorney General,,DEM,A J Kotich,3,ED000011
-Edwards,11 Lincoln Township,Attorney General,,DEM,A J Kotich,5,ED000070
-Edwards,12 Franklin Township,Attorney General,,DEM,A J Kotich,1,ED000020
-Edwards,13 North Brown Township,Attorney General,,DEM,A J Kotich,2,ED000090
-Edwards,14 Trenton Township,Attorney General,,DEM,A J Kotich,4,ED000111
-Edwards,15 South Brown Township,Attorney General,,DEM,A J Kotich,0,ED000100
-Edwards,01 Kinsley Ward 1,Attorney General,,,Write-ins,0,ED000050
-Edwards,02 Kinsley Ward 2,Attorney General,,,Write-ins,0,ED000060
-Edwards,03 Lewis City,Attorney General,,,Write-ins,0,ED000122
-Edwards,04 Offerle City,Attorney General,,,Write-ins,0,ED000112
-Edwards,05 Belpre City,Attorney General,,,Write-ins,0,ED000012
-Edwards,06 Logan Township,Attorney General,,,Write-ins,0,ED000080
-Edwards,07 Jackson Township,Attorney General,,,Write-ins,0,ED000030
-Edwards,08 Kinsley Township,Attorney General,,,Write-ins,0,ED000040
-Edwards,09 Wayne Township,Attorney General,,,Write-ins,1,ED000121
-Edwards,10 Belpre Township,Attorney General,,,Write-ins,0,ED000011
-Edwards,11 Lincoln Township,Attorney General,,,Write-ins,0,ED000070
-Edwards,12 Franklin Township,Attorney General,,,Write-ins,0,ED000020
-Edwards,13 North Brown Township,Attorney General,,,Write-ins,0,ED000090
-Edwards,14 Trenton Township,Attorney General,,,Write-ins,0,ED000111
-Edwards,15 South Brown Township,Attorney General,,,Write-ins,0,ED000100
-Edwards,01 Kinsley Ward 1,State Treasurer,,REP,Ron Estes,223,ED000050
-Edwards,02 Kinsley Ward 2,State Treasurer,,REP,Ron Estes,205,ED000060
-Edwards,03 Lewis City,State Treasurer,,REP,Ron Estes,95,ED000122
-Edwards,04 Offerle City,State Treasurer,,REP,Ron Estes,71,ED000112
-Edwards,05 Belpre City,State Treasurer,,REP,Ron Estes,15,ED000012
-Edwards,06 Logan Township,State Treasurer,,REP,Ron Estes,14,ED000080
-Edwards,07 Jackson Township,State Treasurer,,REP,Ron Estes,26,ED000030
-Edwards,08 Kinsley Township,State Treasurer,,REP,Ron Estes,55,ED000040
-Edwards,09 Wayne Township,State Treasurer,,REP,Ron Estes,44,ED000121
-Edwards,10 Belpre Township,State Treasurer,,REP,Ron Estes,34,ED000011
-Edwards,11 Lincoln Township,State Treasurer,,REP,Ron Estes,56,ED000070
-Edwards,12 Franklin Township,State Treasurer,,REP,Ron Estes,41,ED000020
-Edwards,13 North Brown Township,State Treasurer,,REP,Ron Estes,22,ED000090
-Edwards,14 Trenton Township,State Treasurer,,REP,Ron Estes,33,ED000111
-Edwards,15 South Brown Township,State Treasurer,,REP,Ron Estes,38,ED000100
-Edwards,01 Kinsley Ward 1,State Treasurer,,DEM,Carmen Alldritt,51,ED000050
-Edwards,02 Kinsley Ward 2,State Treasurer,,DEM,Carmen Alldritt,47,ED000060
-Edwards,03 Lewis City,State Treasurer,,DEM,Carmen Alldritt,24,ED000122
-Edwards,04 Offerle City,State Treasurer,,DEM,Carmen Alldritt,5,ED000112
-Edwards,05 Belpre City,State Treasurer,,DEM,Carmen Alldritt,6,ED000012
-Edwards,06 Logan Township,State Treasurer,,DEM,Carmen Alldritt,0,ED000080
-Edwards,07 Jackson Township,State Treasurer,,DEM,Carmen Alldritt,6,ED000030
-Edwards,08 Kinsley Township,State Treasurer,,DEM,Carmen Alldritt,7,ED000040
-Edwards,09 Wayne Township,State Treasurer,,DEM,Carmen Alldritt,0,ED000121
-Edwards,10 Belpre Township,State Treasurer,,DEM,Carmen Alldritt,4,ED000011
-Edwards,11 Lincoln Township,State Treasurer,,DEM,Carmen Alldritt,4,ED000070
-Edwards,12 Franklin Township,State Treasurer,,DEM,Carmen Alldritt,0,ED000020
-Edwards,13 North Brown Township,State Treasurer,,DEM,Carmen Alldritt,2,ED000090
-Edwards,14 Trenton Township,State Treasurer,,DEM,Carmen Alldritt,2,ED000111
-Edwards,15 South Brown Township,State Treasurer,,DEM,Carmen Alldritt,1,ED000100
-Edwards,01 Kinsley Ward 1,State Treasurer,,,Write-ins,1,ED000050
-Edwards,02 Kinsley Ward 2,State Treasurer,,,Write-ins,0,ED000060
-Edwards,03 Lewis City,State Treasurer,,,Write-ins,0,ED000122
-Edwards,04 Offerle City,State Treasurer,,,Write-ins,0,ED000112
-Edwards,05 Belpre City,State Treasurer,,,Write-ins,0,ED000012
-Edwards,06 Logan Township,State Treasurer,,,Write-ins,0,ED000080
-Edwards,07 Jackson Township,State Treasurer,,,Write-ins,0,ED000030
-Edwards,08 Kinsley Township,State Treasurer,,,Write-ins,0,ED000040
-Edwards,09 Wayne Township,State Treasurer,,,Write-ins,0,ED000121
-Edwards,10 Belpre Township,State Treasurer,,,Write-ins,0,ED000011
-Edwards,11 Lincoln Township,State Treasurer,,,Write-ins,0,ED000070
-Edwards,12 Franklin Township,State Treasurer,,,Write-ins,0,ED000020
-Edwards,13 North Brown Township,State Treasurer,,,Write-ins,0,ED000090
-Edwards,14 Trenton Township,State Treasurer,,,Write-ins,0,ED000111
-Edwards,15 South Brown Township,State Treasurer,,,Write-ins,0,ED000100
-Edwards,01 Kinsley Ward 1,Insurance Commissioner,,REP,Ken Selzer,191,ED000050
-Edwards,02 Kinsley Ward 2,Insurance Commissioner,,REP,Ken Selzer,160,ED000060
-Edwards,03 Lewis City,Insurance Commissioner,,REP,Ken Selzer,81,ED000122
-Edwards,04 Offerle City,Insurance Commissioner,,REP,Ken Selzer,64,ED000112
-Edwards,05 Belpre City,Insurance Commissioner,,REP,Ken Selzer,15,ED000012
-Edwards,06 Logan Township,Insurance Commissioner,,REP,Ken Selzer,7,ED000080
-Edwards,07 Jackson Township,Insurance Commissioner,,REP,Ken Selzer,24,ED000030
-Edwards,08 Kinsley Township,Insurance Commissioner,,REP,Ken Selzer,49,ED000040
-Edwards,09 Wayne Township,Insurance Commissioner,,REP,Ken Selzer,41,ED000121
-Edwards,10 Belpre Township,Insurance Commissioner,,REP,Ken Selzer,33,ED000011
-Edwards,11 Lincoln Township,Insurance Commissioner,,REP,Ken Selzer,51,ED000070
-Edwards,12 Franklin Township,Insurance Commissioner,,REP,Ken Selzer,39,ED000020
-Edwards,13 North Brown Township,Insurance Commissioner,,REP,Ken Selzer,21,ED000090
-Edwards,14 Trenton Township,Insurance Commissioner,,REP,Ken Selzer,30,ED000111
-Edwards,15 South Brown Township,Insurance Commissioner,,REP,Ken Selzer,32,ED000100
-Edwards,01 Kinsley Ward 1,Insurance Commissioner,,DEM,Dennis Anderson,76,ED000050
-Edwards,02 Kinsley Ward 2,Insurance Commissioner,,DEM,Dennis Anderson,84,ED000060
-Edwards,03 Lewis City,Insurance Commissioner,,DEM,Dennis Anderson,34,ED000122
-Edwards,04 Offerle City,Insurance Commissioner,,DEM,Dennis Anderson,12,ED000112
-Edwards,05 Belpre City,Insurance Commissioner,,DEM,Dennis Anderson,5,ED000012
-Edwards,06 Logan Township,Insurance Commissioner,,DEM,Dennis Anderson,8,ED000080
-Edwards,07 Jackson Township,Insurance Commissioner,,DEM,Dennis Anderson,8,ED000030
-Edwards,08 Kinsley Township,Insurance Commissioner,,DEM,Dennis Anderson,13,ED000040
-Edwards,09 Wayne Township,Insurance Commissioner,,DEM,Dennis Anderson,4,ED000121
-Edwards,10 Belpre Township,Insurance Commissioner,,DEM,Dennis Anderson,5,ED000011
-Edwards,11 Lincoln Township,Insurance Commissioner,,DEM,Dennis Anderson,6,ED000070
-Edwards,12 Franklin Township,Insurance Commissioner,,DEM,Dennis Anderson,1,ED000020
-Edwards,13 North Brown Township,Insurance Commissioner,,DEM,Dennis Anderson,2,ED000090
-Edwards,14 Trenton Township,Insurance Commissioner,,DEM,Dennis Anderson,5,ED000111
-Edwards,15 South Brown Township,Insurance Commissioner,,DEM,Dennis Anderson,5,ED000100
-Edwards,01 Kinsley Ward 1,Insurance Commissioner,,,Write-ins,0,ED000050
-Edwards,02 Kinsley Ward 2,Insurance Commissioner,,,Write-ins,1,ED000060
-Edwards,03 Lewis City,Insurance Commissioner,,,Write-ins,1,ED000122
-Edwards,04 Offerle City,Insurance Commissioner,,,Write-ins,0,ED000112
-Edwards,05 Belpre City,Insurance Commissioner,,,Write-ins,0,ED000012
-Edwards,06 Logan Township,Insurance Commissioner,,,Write-ins,0,ED000080
-Edwards,07 Jackson Township,Insurance Commissioner,,,Write-ins,0,ED000030
-Edwards,08 Kinsley Township,Insurance Commissioner,,,Write-ins,0,ED000040
-Edwards,09 Wayne Township,Insurance Commissioner,,,Write-ins,0,ED000121
-Edwards,10 Belpre Township,Insurance Commissioner,,,Write-ins,0,ED000011
-Edwards,11 Lincoln Township,Insurance Commissioner,,,Write-ins,0,ED000070
-Edwards,12 Franklin Township,Insurance Commissioner,,,Write-ins,1,ED000020
-Edwards,13 North Brown Township,Insurance Commissioner,,,Write-ins,0,ED000090
-Edwards,14 Trenton Township,Insurance Commissioner,,,Write-ins,0,ED000111
-Edwards,15 South Brown Township,Insurance Commissioner,,,Write-ins,1,ED000100
-Edwards,01 Kinsley Ward 1,State House,117,REP,John Ewy,260,ED000050
-Edwards,02 Kinsley Ward 2,State House,117,REP,John Ewy,228,ED000060
-Edwards,03 Lewis City,State House,117,REP,John Ewy,105,ED000122
-Edwards,04 Offerle City,State House,117,REP,John Ewy,72,ED000112
-Edwards,05 Belpre City,State House,117,REP,John Ewy,20,ED000012
-Edwards,06 Logan Township,State House,117,REP,John Ewy,15,ED000080
-Edwards,07 Jackson Township,State House,117,REP,John Ewy,32,ED000030
-Edwards,08 Kinsley Township,State House,117,REP,John Ewy,55,ED000040
-Edwards,09 Wayne Township,State House,117,REP,John Ewy,46,ED000121
-Edwards,10 Belpre Township,State House,117,REP,John Ewy,34,ED000011
-Edwards,11 Lincoln Township,State House,117,REP,John Ewy,56,ED000070
-Edwards,12 Franklin Township,State House,117,REP,John Ewy,40,ED000020
-Edwards,13 North Brown Township,State House,117,REP,John Ewy,21,ED000090
-Edwards,14 Trenton Township,State House,117,REP,John Ewy,32,ED000111
-Edwards,15 South Brown Township,State House,117,REP,John Ewy,37,ED000100
-Edwards,01 Kinsley Ward 1,State House,117,,Write-ins,5,ED000050
-Edwards,02 Kinsley Ward 2,State House,117,,Write-ins,3,ED000060
-Edwards,03 Lewis City,State House,117,,Write-ins,1,ED000122
-Edwards,04 Offerle City,State House,117,,Write-ins,0,ED000112
-Edwards,05 Belpre City,State House,117,,Write-ins,0,ED000012
-Edwards,06 Logan Township,State House,117,,Write-ins,0,ED000080
-Edwards,07 Jackson Township,State House,117,,Write-ins,1,ED000030
-Edwards,08 Kinsley Township,State House,117,,Write-ins,0,ED000040
-Edwards,09 Wayne Township,State House,117,,Write-ins,0,ED000121
-Edwards,10 Belpre Township,State House,117,,Write-ins,0,ED000011
-Edwards,11 Lincoln Township,State House,117,,Write-ins,1,ED000070
-Edwards,12 Franklin Township,State House,117,,Write-ins,0,ED000020
-Edwards,13 North Brown Township,State House,117,,Write-ins,0,ED000090
-Edwards,14 Trenton Township,State House,117,,Write-ins,0,ED000111
-Edwards,15 South Brown Township,State House,117,,Write-ins,1,ED000100
+county,precinct,office,district,party,candidate,votes,vtd
+EDWARDS,Belpre Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000010
+EDWARDS,Belpre Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000010
+EDWARDS,Belpre Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000010
+EDWARDS,Franklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000020
+EDWARDS,Franklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+EDWARDS,Franklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000020
+EDWARDS,Jackson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+EDWARDS,Jackson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+EDWARDS,Jackson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000030
+EDWARDS,Kinsley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000040
+EDWARDS,Kinsley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+EDWARDS,Kinsley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,000040
+EDWARDS,Kinsley Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",99,000050
+EDWARDS,Kinsley Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000050
+EDWARDS,Kinsley Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,000050
+EDWARDS,Kinsley Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",103,00006A
+EDWARDS,Kinsley Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00006A
+EDWARDS,Kinsley Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",145,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006B
+EDWARDS,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000070
+EDWARDS,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000070
+EDWARDS,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000070
+EDWARDS,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000080
+EDWARDS,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+EDWARDS,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000080
+EDWARDS,North Brown Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000090
+EDWARDS,North Brown Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+EDWARDS,North Brown Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000090
+EDWARDS,South Brown Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000100
+EDWARDS,South Brown Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+EDWARDS,South Brown Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000100
+EDWARDS,Trenton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000110
+EDWARDS,Trenton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000110
+EDWARDS,Trenton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000110
+EDWARDS,Wayne Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000120
+EDWARDS,Wayne Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000120
+EDWARDS,Wayne Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,000120
+EDWARDS,Belpre Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",54,000010
+EDWARDS,Franklin Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",40,000020
+EDWARDS,Jackson Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",32,000030
+EDWARDS,Kinsley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",55,000040
+EDWARDS,Kinsley Ward 1,Kansas House of Representatives,117,Republican,"Ewy, John L.",260,000050
+EDWARDS,Kinsley Ward 2,Kansas House of Representatives,117,Republican,"Ewy, John L.",228,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Kansas House of Representatives,117,Republican,"Ewy, John L.",0,00006B
+EDWARDS,Lincoln Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",56,000070
+EDWARDS,Logan Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",15,000080
+EDWARDS,North Brown Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",21,000090
+EDWARDS,South Brown Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",37,000100
+EDWARDS,Trenton Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",104,000110
+EDWARDS,Wayne Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",151,000120
+EDWARDS,Belpre Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",10,000010
+EDWARDS,Belpre Township,United States House of Representatives,4,Republican,"Pompeo, Mike",50,000010
+EDWARDS,Franklin Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000020
+EDWARDS,Franklin Township,United States House of Representatives,4,Republican,"Pompeo, Mike",40,000020
+EDWARDS,Jackson Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",7,000030
+EDWARDS,Jackson Township,United States House of Representatives,4,Republican,"Pompeo, Mike",25,000030
+EDWARDS,Kinsley Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000040
+EDWARDS,Kinsley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",52,000040
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",68,000050
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",204,000050
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",63,00006A
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",194,00006A
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00006B
+EDWARDS,Lincoln Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000070
+EDWARDS,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Mike",55,000070
+EDWARDS,Logan Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000080
+EDWARDS,Logan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",11,000080
+EDWARDS,North Brown Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000090
+EDWARDS,North Brown Township,United States House of Representatives,4,Republican,"Pompeo, Mike",22,000090
+EDWARDS,South Brown Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000100
+EDWARDS,South Brown Township,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000100
+EDWARDS,Trenton Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",13,000110
+EDWARDS,Trenton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",95,000110
+EDWARDS,Wayne Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",38,000120
+EDWARDS,Wayne Township,United States House of Representatives,4,Republican,"Pompeo, Mike",129,000120
+EDWARDS,Belpre Township,Attorney General,,Democratic,"Kotich, A.J.",6,000010
+EDWARDS,Belpre Township,Attorney General,,Republican,"Schmidt, Derek",54,000010
+EDWARDS,Franklin Township,Attorney General,,Democratic,"Kotich, A.J.",1,000020
+EDWARDS,Franklin Township,Attorney General,,Republican,"Schmidt, Derek",39,000020
+EDWARDS,Jackson Township,Attorney General,,Democratic,"Kotich, A.J.",5,000030
+EDWARDS,Jackson Township,Attorney General,,Republican,"Schmidt, Derek",28,000030
+EDWARDS,Kinsley Township,Attorney General,,Democratic,"Kotich, A.J.",4,000040
+EDWARDS,Kinsley Township,Attorney General,,Republican,"Schmidt, Derek",57,000040
+EDWARDS,Kinsley Ward 1,Attorney General,,Democratic,"Kotich, A.J.",53,000050
+EDWARDS,Kinsley Ward 1,Attorney General,,Republican,"Schmidt, Derek",221,000050
+EDWARDS,Kinsley Ward 2,Attorney General,,Democratic,"Kotich, A.J.",50,00006A
+EDWARDS,Kinsley Ward 2,Attorney General,,Republican,"Schmidt, Derek",203,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00006B
+EDWARDS,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",5,000070
+EDWARDS,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",55,000070
+EDWARDS,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",1,000080
+EDWARDS,Logan Township,Attorney General,,Republican,"Schmidt, Derek",14,000080
+EDWARDS,North Brown Township,Attorney General,,Democratic,"Kotich, A.J.",2,000090
+EDWARDS,North Brown Township,Attorney General,,Republican,"Schmidt, Derek",22,000090
+EDWARDS,South Brown Township,Attorney General,,Democratic,"Kotich, A.J.",0,000100
+EDWARDS,South Brown Township,Attorney General,,Republican,"Schmidt, Derek",39,000100
+EDWARDS,Trenton Township,Attorney General,,Democratic,"Kotich, A.J.",15,000110
+EDWARDS,Trenton Township,Attorney General,,Republican,"Schmidt, Derek",96,000110
+EDWARDS,Wayne Township,Attorney General,,Democratic,"Kotich, A.J.",27,000120
+EDWARDS,Wayne Township,Attorney General,,Republican,"Schmidt, Derek",134,000120
+EDWARDS,Belpre Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000010
+EDWARDS,Belpre Township,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000010
+EDWARDS,Franklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000020
+EDWARDS,Franklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000020
+EDWARDS,Jackson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000030
+EDWARDS,Jackson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000030
+EDWARDS,Kinsley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000040
+EDWARDS,Kinsley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000040
+EDWARDS,Kinsley Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,000050
+EDWARDS,Kinsley Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",191,000050
+EDWARDS,Kinsley Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",84,00006A
+EDWARDS,Kinsley Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",160,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006B
+EDWARDS,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000070
+EDWARDS,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000070
+EDWARDS,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000080
+EDWARDS,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000080
+EDWARDS,North Brown Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000090
+EDWARDS,North Brown Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000090
+EDWARDS,South Brown Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000100
+EDWARDS,South Brown Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000100
+EDWARDS,Trenton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000110
+EDWARDS,Trenton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",94,000110
+EDWARDS,Wayne Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000120
+EDWARDS,Wayne Township,Commissioner of Insurance,,Republican,"Selzer, Ken",122,000120
+EDWARDS,Belpre Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000010
+EDWARDS,Belpre Township,Secretary of State,,Republican,"Kobach, Kris",46,000010
+EDWARDS,Franklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+EDWARDS,Franklin Township,Secretary of State,,Republican,"Kobach, Kris",41,000020
+EDWARDS,Jackson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000030
+EDWARDS,Jackson Township,Secretary of State,,Republican,"Kobach, Kris",28,000030
+EDWARDS,Kinsley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000040
+EDWARDS,Kinsley Township,Secretary of State,,Republican,"Kobach, Kris",52,000040
+EDWARDS,Kinsley Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,000050
+EDWARDS,Kinsley Ward 1,Secretary of State,,Republican,"Kobach, Kris",203,000050
+EDWARDS,Kinsley Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,00006A
+EDWARDS,Kinsley Ward 2,Secretary of State,,Republican,"Kobach, Kris",181,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00006B
+EDWARDS,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000070
+EDWARDS,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",51,000070
+EDWARDS,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000080
+EDWARDS,Logan Township,Secretary of State,,Republican,"Kobach, Kris",10,000080
+EDWARDS,North Brown Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000090
+EDWARDS,North Brown Township,Secretary of State,,Republican,"Kobach, Kris",19,000090
+EDWARDS,South Brown Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000100
+EDWARDS,South Brown Township,Secretary of State,,Republican,"Kobach, Kris",38,000100
+EDWARDS,Trenton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000110
+EDWARDS,Trenton Township,Secretary of State,,Republican,"Kobach, Kris",88,000110
+EDWARDS,Wayne Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000120
+EDWARDS,Wayne Township,Secretary of State,,Republican,"Kobach, Kris",132,000120
+EDWARDS,Belpre Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000010
+EDWARDS,Belpre Township,State Treasurer,,Republican,"Estes, Ron",49,000010
+EDWARDS,Franklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+EDWARDS,Franklin Township,State Treasurer,,Republican,"Estes, Ron",41,000020
+EDWARDS,Jackson Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000030
+EDWARDS,Jackson Township,State Treasurer,,Republican,"Estes, Ron",26,000030
+EDWARDS,Kinsley Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000040
+EDWARDS,Kinsley Township,State Treasurer,,Republican,"Estes, Ron",55,000040
+EDWARDS,Kinsley Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",51,000050
+EDWARDS,Kinsley Ward 1,State Treasurer,,Republican,"Estes, Ron",223,000050
+EDWARDS,Kinsley Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",47,00006A
+EDWARDS,Kinsley Ward 2,State Treasurer,,Republican,"Estes, Ron",205,00006A
+EDWARDS,Kinsley Ward 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00006B
+EDWARDS,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000070
+EDWARDS,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",56,000070
+EDWARDS,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000080
+EDWARDS,Logan Township,State Treasurer,,Republican,"Estes, Ron",14,000080
+EDWARDS,North Brown Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000090
+EDWARDS,North Brown Township,State Treasurer,,Republican,"Estes, Ron",22,000090
+EDWARDS,South Brown Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000100
+EDWARDS,South Brown Township,State Treasurer,,Republican,"Estes, Ron",38,000100
+EDWARDS,Trenton Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000110
+EDWARDS,Trenton Township,State Treasurer,,Republican,"Estes, Ron",104,000110
+EDWARDS,Wayne Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000120
+EDWARDS,Wayne Township,State Treasurer,,Republican,"Estes, Ron",139,000120
+EDWARDS,Belpre Township,United States Senate,,independent,"Orman, Greg",17,000010
+EDWARDS,Belpre Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+EDWARDS,Belpre Township,United States Senate,,Republican,"Roberts, Pat",41,000010
+EDWARDS,Franklin Township,United States Senate,,independent,"Orman, Greg",1,000020
+EDWARDS,Franklin Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+EDWARDS,Franklin Township,United States Senate,,Republican,"Roberts, Pat",39,000020
+EDWARDS,Jackson Township,United States Senate,,independent,"Orman, Greg",5,000030
+EDWARDS,Jackson Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+EDWARDS,Jackson Township,United States Senate,,Republican,"Roberts, Pat",26,000030
+EDWARDS,Kinsley Township,United States Senate,,independent,"Orman, Greg",14,000040
+EDWARDS,Kinsley Township,United States Senate,,Libertarian,"Batson, Randall",2,000040
+EDWARDS,Kinsley Township,United States Senate,,Republican,"Roberts, Pat",47,000040
+EDWARDS,Kinsley Ward 1,United States Senate,,independent,"Orman, Greg",73,000050
+EDWARDS,Kinsley Ward 1,United States Senate,,Libertarian,"Batson, Randall",13,000050
+EDWARDS,Kinsley Ward 1,United States Senate,,Republican,"Roberts, Pat",196,000050
+EDWARDS,Kinsley Ward 2,United States Senate,,independent,"Orman, Greg",95,00006A
+EDWARDS,Kinsley Ward 2,United States Senate,,Libertarian,"Batson, Randall",11,00006A
+EDWARDS,Kinsley Ward 2,United States Senate,,Republican,"Roberts, Pat",149,00006A
+EDWARDS,Kinsley Ward 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00006B
+EDWARDS,Lincoln Township,United States Senate,,independent,"Orman, Greg",9,000070
+EDWARDS,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",3,000070
+EDWARDS,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",48,000070
+EDWARDS,Logan Township,United States Senate,,independent,"Orman, Greg",6,000080
+EDWARDS,Logan Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+EDWARDS,Logan Township,United States Senate,,Republican,"Roberts, Pat",8,000080
+EDWARDS,North Brown Township,United States Senate,,independent,"Orman, Greg",4,000090
+EDWARDS,North Brown Township,United States Senate,,Libertarian,"Batson, Randall",1,000090
+EDWARDS,North Brown Township,United States Senate,,Republican,"Roberts, Pat",19,000090
+EDWARDS,South Brown Township,United States Senate,,independent,"Orman, Greg",6,000100
+EDWARDS,South Brown Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+EDWARDS,South Brown Township,United States Senate,,Republican,"Roberts, Pat",34,000100
+EDWARDS,Trenton Township,United States Senate,,independent,"Orman, Greg",24,000110
+EDWARDS,Trenton Township,United States Senate,,Libertarian,"Batson, Randall",5,000110
+EDWARDS,Trenton Township,United States Senate,,Republican,"Roberts, Pat",80,000110
+EDWARDS,Wayne Township,United States Senate,,independent,"Orman, Greg",40,000120
+EDWARDS,Wayne Township,United States Senate,,Libertarian,"Batson, Randall",8,000120
+EDWARDS,Wayne Township,United States Senate,,Republican,"Roberts, Pat",119,000120

--- a/2014/20141104__ks__general__elk__precinct.csv
+++ b/2014/20141104__ks__general__elk__precinct.csv
@@ -1,236 +1,174 @@
-county,precinct,office,district,party,candidate,votes
-Elk,Liberty,Voters,,,Registered,71
-Elk,Busby-Painterhood,Voters,,,Registered,127
-Elk,Longton,Voters,,,Registered,256
-Elk,Oak Valley,Voters,,,Registered,73
-Elk,Union Ctr,Voters,,,Registered,61
-Elk,Howard,Voters,,,Registered,554
-Elk,Flat-Paw Paw,Voters,,,Registered,82
-Elk,Grenola-Greenfield,Voters,,,Registered,66
-Elk,Moline-Wildcat,Voters,,,Registered,355
-Elk,Elk Falls,Voters,,,Registered,138
-Elk,Advance,Voters,,,Registered,0
-Elk,Prov,Voters,,,Registered,0
-Elk,Liberty,U.S. Senate,,R,Pat Roberts,11
-Elk,Busby-Painterhood,U.S. Senate,,R,Pat Roberts,8
-Elk,Longton,U.S. Senate,,R,Pat Roberts,81
-Elk,Oak Valley,U.S. Senate,,R,Pat Roberts,27
-Elk,Union Ctr,U.S. Senate,,R,Pat Roberts,22
-Elk,Howard,U.S. Senate,,R,Pat Roberts,178
-Elk,Flat-Paw Paw,U.S. Senate,,R,Pat Roberts,20
-Elk,Grenola-Greenfield,U.S. Senate,,R,Pat Roberts,60
-Elk,Moline-Wildcat,U.S. Senate,,R,Pat Roberts,106
-Elk,Elk Falls,U.S. Senate,,R,Pat Roberts,33
-Elk,Advance,U.S. Senate,,R,Pat Roberts,118
-Elk,Prov,U.S. Senate,,R,Pat Roberts,9
-Elk,Liberty,U.S. Senate,,I,Greg Orman,8
-Elk,Busby-Painterhood,U.S. Senate,,I,Greg Orman,3
-Elk,Longton,U.S. Senate,,I,Greg Orman,28
-Elk,Oak Valley,U.S. Senate,,I,Greg Orman,14
-Elk,Union Ctr,U.S. Senate,,I,Greg Orman,6
-Elk,Howard,U.S. Senate,,I,Greg Orman,94
-Elk,Flat-Paw Paw,U.S. Senate,,I,Greg Orman,9
-Elk,Grenola-Greenfield,U.S. Senate,,I,Greg Orman,11
-Elk,Moline-Wildcat,U.S. Senate,,I,Greg Orman,64
-Elk,Elk Falls,U.S. Senate,,I,Greg Orman,11
-Elk,Advance,U.S. Senate,,I,Greg Orman,63
-Elk,Prov,U.S. Senate,,I,Greg Orman,7
-Elk,Liberty,U.S. Senate,,L,Randall Batson,1
-Elk,Busby-Painterhood,U.S. Senate,,L,Randall Batson,0
-Elk,Longton,U.S. Senate,,L,Randall Batson,15
-Elk,Oak Valley,U.S. Senate,,L,Randall Batson,2
-Elk,Union Ctr,U.S. Senate,,L,Randall Batson,4
-Elk,Howard,U.S. Senate,,L,Randall Batson,16
-Elk,Flat-Paw Paw,U.S. Senate,,L,Randall Batson,3
-Elk,Grenola-Greenfield,U.S. Senate,,L,Randall Batson,3
-Elk,Moline-Wildcat,U.S. Senate,,L,Randall Batson,17
-Elk,Elk Falls,U.S. Senate,,L,Randall Batson,7
-Elk,Advance,U.S. Senate,,L,Randall Batson,16
-Elk,Prov,U.S. Senate,,L,Randall Batson,2
-Elk,Liberty,U.S. House,4,R,Mike Pompeo,14
-Elk,Busby-Painterhood,U.S. House,4,R,Mike Pompeo,11
-Elk,Longton,U.S. House,4,R,Mike Pompeo,96
-Elk,Oak Valley,U.S. House,4,R,Mike Pompeo,32
-Elk,Union Ctr,U.S. House,4,R,Mike Pompeo,25
-Elk,Howard,U.S. House,4,R,Mike Pompeo,223
-Elk,Flat-Paw Paw,U.S. House,4,R,Mike Pompeo,26
-Elk,Grenola-Greenfield,U.S. House,4,R,Mike Pompeo,58
-Elk,Moline-Wildcat,U.S. House,4,R,Mike Pompeo,131
-Elk,Elk Falls,U.S. House,4,R,Mike Pompeo,39
-Elk,Advance,U.S. House,4,R,Mike Pompeo,166
-Elk,Prov,U.S. House,4,R,Mike Pompeo,14
-Elk,Liberty,U.S. House,4,R,Mike Pompeo,14
-Elk,Busby-Painterhood,U.S. House,4,R,Mike Pompeo,11
-Elk,Longton,U.S. House,4,R,Mike Pompeo,96
-Elk,Oak Valley,U.S. House,4,R,Mike Pompeo,32
-Elk,Union Ctr,U.S. House,4,R,Mike Pompeo,25
-Elk,Howard,U.S. House,4,R,Mike Pompeo,223
-Elk,Flat-Paw Paw,U.S. House,4,R,Mike Pompeo,26
-Elk,Grenola-Greenfield,U.S. House,4,R,Mike Pompeo,58
-Elk,Moline-Wildcat,U.S. House,4,R,Mike Pompeo,131
-Elk,Elk Falls,U.S. House,4,R,Mike Pompeo,39
-Elk,Advance,U.S. House,4,R,Mike Pompeo,166
-Elk,Prov,U.S. House,4,R,Mike Pompeo,14
-Elk,Liberty,U.S. House,4,D,Perry Schuckman,6
-Elk,Busby-Painterhood,U.S. House,4,D,Perry Schuckman,0
-Elk,Longton,U.S. House,4,D,Perry Schuckman,26
-Elk,Oak Valley,U.S. House,4,D,Perry Schuckman,10
-Elk,Union Ctr,U.S. House,4,D,Perry Schuckman,7
-Elk,Howard,U.S. House,4,D,Perry Schuckman,67
-Elk,Flat-Paw Paw,U.S. House,4,D,Perry Schuckman,6
-Elk,Grenola-Greenfield,U.S. House,4,D,Perry Schuckman,16
-Elk,Moline-Wildcat,U.S. House,4,D,Perry Schuckman,57
-Elk,Elk Falls,U.S. House,4,D,Perry Schuckman,12
-Elk,Advance,U.S. House,4,D,Perry Schuckman,37
-Elk,Prov,U.S. House,4,D,Perry Schuckman,3
-Elk,Liberty,Governor,,R,Sam Brownback,13
-Elk,Busby-Painterhood,Governor,,R,Sam Brownback,7
-Elk,Longton,Governor,,R,Sam Brownback,79
-Elk,Oak Valley,Governor,,R,Sam Brownback,27
-Elk,Union Ctr,Governor,,R,Sam Brownback,20
-Elk,Howard,Governor,,R,Sam Brownback,158
-Elk,Flat-Paw Paw,Governor,,R,Sam Brownback,23
-Elk,Grenola-Greenfield,Governor,,R,Sam Brownback,49
-Elk,Moline-Wildcat,Governor,,R,Sam Brownback,93
-Elk,Elk Falls,Governor,,R,Sam Brownback,29
-Elk,Advance,Governor,,R,Sam Brownback,117
-Elk,Prov,Governor,,R,Sam Brownback,7
-Elk,Liberty,Governor,,D,Paul Davis,5
-Elk,Busby-Painterhood,Governor,,D,Paul Davis,5
-Elk,Longton,Governor,,D,Paul Davis,36
-Elk,Oak Valley,Governor,,D,Paul Davis,16
-Elk,Union Ctr,Governor,,D,Paul Davis,11
-Elk,Howard,Governor,,D,Paul Davis,117
-Elk,Flat-Paw Paw,Governor,,D,Paul Davis,7
-Elk,Grenola-Greenfield,Governor,,D,Paul Davis,20
-Elk,Moline-Wildcat,Governor,,D,Paul Davis,82
-Elk,Elk Falls,Governor,,D,Paul Davis,17
-Elk,Advance,Governor,,D,Paul Davis,76
-Elk,Prov,Governor,,D,Paul Davis,9
-Elk,Liberty,Governor,,L,Keen Umbehr,2
-Elk,Busby-Painterhood,Governor,,L,Keen Umbehr,0
-Elk,Longton,Governor,,L,Keen Umbehr,11
-Elk,Oak Valley,Governor,,L,Keen Umbehr,1
-Elk,Union Ctr,Governor,,L,Keen Umbehr,1
-Elk,Howard,Governor,,L,Keen Umbehr,14
-Elk,Flat-Paw Paw,Governor,,L,Keen Umbehr,2
-Elk,Grenola-Greenfield,Governor,,L,Keen Umbehr,4
-Elk,Moline-Wildcat,Governor,,L,Keen Umbehr,14
-Elk,Elk Falls,Governor,,L,Keen Umbehr,5
-Elk,Advance,Governor,,L,Keen Umbehr,16
-Elk,Prov,Governor,,L,Keen Umbehr,2
-Elk,Liberty,Secretary of State,,R,Kris Kobach,11
-Elk,Busby-Painterhood,Secretary of State,,R,Kris Kobach,8
-Elk,Longton,Secretary of State,,R,Kris Kobach,94
-Elk,Oak Valley,Secretary of State,,R,Kris Kobach,34
-Elk,Union Ctr,Secretary of State,,R,Kris Kobach,21
-Elk,Howard,Secretary of State,,R,Kris Kobach,190
-Elk,Flat-Paw Paw,Secretary of State,,R,Kris Kobach,22
-Elk,Grenola-Greenfield,Secretary of State,,R,Kris Kobach,56
-Elk,Moline-Wildcat,Secretary of State,,R,Kris Kobach,126
-Elk,Elk Falls,Secretary of State,,R,Kris Kobach,35
-Elk,Advance,Secretary of State,,R,Kris Kobach,137
-Elk,Prov,Secretary of State,,R,Kris Kobach,12
-Elk,Liberty,Secretary of State,,D,Jean Schodorf,8
-Elk,Busby-Painterhood,Secretary of State,,D,Jean Schodorf,4
-Elk,Longton,Secretary of State,,D,Jean Schodorf,30
-Elk,Oak Valley,Secretary of State,,D,Jean Schodorf,11
-Elk,Union Ctr,Secretary of State,,D,Jean Schodorf,11
-Elk,Howard,Secretary of State,,D,Jean Schodorf,96
-Elk,Flat-Paw Paw,Secretary of State,,D,Jean Schodorf,10
-Elk,Grenola-Greenfield,Secretary of State,,D,Jean Schodorf,18
-Elk,Moline-Wildcat,Secretary of State,,D,Jean Schodorf,66
-Elk,Elk Falls,Secretary of State,,D,Jean Schodorf,17
-Elk,Advance,Secretary of State,,D,Jean Schodorf,62
-Elk,Prov,Secretary of State,,D,Jean Schodorf,5
-Elk,Liberty,Attorney General,,R,Derek Schmidt,14
-Elk,Busby-Painterhood,Attorney General,,R,Derek Schmidt,11
-Elk,Longton,Attorney General,,R,Derek Schmidt,102
-Elk,Oak Valley,Attorney General,,R,Derek Schmidt,38
-Elk,Union Ctr,Attorney General,,R,Derek Schmidt,26
-Elk,Howard,Attorney General,,R,Derek Schmidt,256
-Elk,Flat-Paw Paw,Attorney General,,R,Derek Schmidt,29
-Elk,Grenola-Greenfield,Attorney General,,R,Derek Schmidt,63
-Elk,Moline-Wildcat,Attorney General,,R,Derek Schmidt,161
-Elk,Elk Falls,Attorney General,,R,Derek Schmidt,45
-Elk,Advance,Attorney General,,R,Derek Schmidt,182
-Elk,Prov,Attorney General,,R,Derek Schmidt,14
-Elk,Liberty,Attorney General,,D,AJ Kotich,5
-Elk,Busby-Painterhood,Attorney General,,D,AJ Kotich,1
-Elk,Longton,Attorney General,,D,AJ Kotich,21
-Elk,Oak Valley,Attorney General,,D,AJ Kotich,7
-Elk,Union Ctr,Attorney General,,D,AJ Kotich,6
-Elk,Howard,Attorney General,,D,AJ Kotich,32
-Elk,Flat-Paw Paw,Attorney General,,D,AJ Kotich,3
-Elk,Grenola-Greenfield,Attorney General,,D,AJ Kotich,11
-Elk,Moline-Wildcat,Attorney General,,D,AJ Kotich,30
-Elk,Elk Falls,Attorney General,,D,AJ Kotich,7
-Elk,Advance,Attorney General,,D,AJ Kotich,22
-Elk,Prov,Attorney General,,D,AJ Kotich,3
-Elk,Liberty,State Treasurer,,R,Ron Estes,14
-Elk,Busby-Painterhood,State Treasurer,,R,Ron Estes,12
-Elk,Longton,State Treasurer,,R,Ron Estes,99
-Elk,Oak Valley,State Treasurer,,R,Ron Estes,36
-Elk,Union Ctr,State Treasurer,,R,Ron Estes,27
-Elk,Howard,State Treasurer,,R,Ron Estes,240
-Elk,Flat-Paw Paw,State Treasurer,,R,Ron Estes,25
-Elk,Grenola-Greenfield,State Treasurer,,R,Ron Estes,60
-Elk,Moline-Wildcat,State Treasurer,,R,Ron Estes,135
-Elk,Elk Falls,State Treasurer,,R,Ron Estes,40
-Elk,Advance,State Treasurer,,R,Ron Estes,168
-Elk,Prov,State Treasurer,,R,Ron Estes,13
-Elk,Liberty,State Treasurer,,D,Carmen Alldritt,5
-Elk,Busby-Painterhood,State Treasurer,,D,Carmen Alldritt,0
-Elk,Longton,State Treasurer,,D,Carmen Alldritt,24
-Elk,Oak Valley,State Treasurer,,D,Carmen Alldritt,8
-Elk,Union Ctr,State Treasurer,,D,Carmen Alldritt,5
-Elk,Howard,State Treasurer,,D,Carmen Alldritt,46
-Elk,Flat-Paw Paw,State Treasurer,,D,Carmen Alldritt,6
-Elk,Grenola-Greenfield,State Treasurer,,D,Carmen Alldritt,14
-Elk,Moline-Wildcat,State Treasurer,,D,Carmen Alldritt,50
-Elk,Elk Falls,State Treasurer,,D,Carmen Alldritt,11
-Elk,Advance,State Treasurer,,D,Carmen Alldritt,31
-Elk,Prov,State Treasurer,,D,Carmen Alldritt,2
-Elk,Liberty,Insurance Commissioner,,R,Ken Selzer,14
-Elk,Busby-Painterhood,Insurance Commissioner,,R,Ken Selzer,9
-Elk,Longton,Insurance Commissioner,,R,Ken Selzer,98
-Elk,Oak Valley,Insurance Commissioner,,R,Ken Selzer,32
-Elk,Union Ctr,Insurance Commissioner,,R,Ken Selzer,23
-Elk,Howard,Insurance Commissioner,,R,Ken Selzer,210
-Elk,Flat-Paw Paw,Insurance Commissioner,,R,Ken Selzer,26
-Elk,Grenola-Greenfield,Insurance Commissioner,,R,Ken Selzer,56
-Elk,Moline-Wildcat,Insurance Commissioner,,R,Ken Selzer,114
-Elk,Elk Falls,Insurance Commissioner,,R,Ken Selzer,37
-Elk,Advance,Insurance Commissioner,,R,Ken Selzer,150
-Elk,Prov,Insurance Commissioner,,R,Ken Selzer,13
-Elk,Liberty,Insurance Commissioner,,D,Dennis Anderson,5
-Elk,Busby-Painterhood,Insurance Commissioner,,D,Dennis Anderson,2
-Elk,Longton,Insurance Commissioner,,D,Dennis Anderson,24
-Elk,Oak Valley,Insurance Commissioner,,D,Dennis Anderson,10
-Elk,Union Ctr,Insurance Commissioner,,D,Dennis Anderson,8
-Elk,Howard,Insurance Commissioner,,D,Dennis Anderson,65
-Elk,Flat-Paw Paw,Insurance Commissioner,,D,Dennis Anderson,5
-Elk,Grenola-Greenfield,Insurance Commissioner,,D,Dennis Anderson,17
-Elk,Moline-Wildcat,Insurance Commissioner,,D,Dennis Anderson,56
-Elk,Elk Falls,Insurance Commissioner,,D,Dennis Anderson,14
-Elk,Advance,Insurance Commissioner,,D,Dennis Anderson,45
-Elk,Prov,Insurance Commissioner,,D,Dennis Anderson,3
-Elk,Liberty,State House,13,R,Larry Hibbard,20
-Elk,Busby-Painterhood,State House,13,R,Larry Hibbard,11
-Elk,Longton,State House,12,R,Virgil Peck,100
-Elk,Oak Valley,State House,12,R,Virgil Peck,35
-Elk,Union Ctr,State House,13,R,Larry Hibbard,31
-Elk,Howard,State House,13,R,Larry Hibbard,258
-Elk,Flat-Paw Paw,State House,13,R,Larry Hibbard,30
-Elk,Grenola-Greenfield,State House,13,R,Larry Hibbard,66
-Elk,Moline-Wildcat,State House,13,R,Larry Hibbard,162
-Elk,Elk Falls,State House,12,R,Virgil Peck,39
-Elk,Advance,State House,12,R,Virgil Peck,23
-Elk,Prov,State House,12,R,Virgil Peck,11
-Elk,Advance,State House,13,R,Larry Hibbard,155
-Elk,Prov,State House,13,R,Larry Hibbard,3
-Elk,Longton,State House,12,D,Eden Fuson,23
-Elk,Oak Valley,State House,12,D,Eden Fuson,9
-Elk,Elk Falls,State House,12,D,Eden Fuson,13
-Elk,Advance,State House,12,D,Eden Fuson,5
-Elk,Prov,State House,12,D,Eden Fuson,3
+county,precinct,office,district,party,candidate,votes,vtd
+ELK,Elk Falls Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000010
+ELK,Elk Falls Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000010
+ELK,Elk Falls Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000010
+ELK,Greenfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000020
+ELK,Greenfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000020
+ELK,Greenfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,000020
+ELK,Howard Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",146,000030
+ELK,Howard Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000030
+ELK,Howard Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",188,000030
+ELK,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000040
+ELK,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+ELK,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000040
+ELK,Longton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000050
+ELK,Longton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000050
+ELK,Longton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000050
+ELK,Oak Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000060
+ELK,Oak Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000060
+ELK,Oak Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000060
+ELK,Painterhood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000070
+ELK,Painterhood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+ELK,Painterhood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000070
+ELK,Paw Paw Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000080
+ELK,Paw Paw Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+ELK,Paw Paw Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000080
+ELK,Union Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000090
+ELK,Union Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+ELK,Union Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000090
+ELK,Wildcat Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000100
+ELK,Wildcat Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000100
+ELK,Wildcat Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,000100
+ELK,Elk Falls Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",19,000010
+ELK,Elk Falls Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",57,000010
+ELK,Greenfield Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",99,000020
+ELK,Howard Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",312,000030
+ELK,Liberty Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",43,000040
+ELK,Longton Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",24,000050
+ELK,Longton Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",113,000050
+ELK,Oak Valley Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",10,000060
+ELK,Oak Valley Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",38,000060
+ELK,Painterhood Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",21,000070
+ELK,Paw Paw Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",39,000080
+ELK,Union Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",38,000090
+ELK,Wildcat Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",184,000100
+ELK,Elk Falls Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",15,000010
+ELK,Elk Falls Township,United States House of Representatives,4,Republican,"Pompeo, Mike",59,000010
+ELK,Greenfield Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",23,000020
+ELK,Greenfield Township,United States House of Representatives,4,Republican,"Pompeo, Mike",87,000020
+ELK,Howard Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",82,000030
+ELK,Howard Township,United States House of Representatives,4,Republican,"Pompeo, Mike",271,000030
+ELK,Liberty Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000040
+ELK,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000040
+ELK,Longton Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",26,000050
+ELK,Longton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",111,000050
+ELK,Oak Valley Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,000060
+ELK,Oak Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",35,000060
+ELK,Painterhood Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,000070
+ELK,Painterhood Township,United States House of Representatives,4,Republican,"Pompeo, Mike",19,000070
+ELK,Paw Paw Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",6,000080
+ELK,Paw Paw Township,United States House of Representatives,4,Republican,"Pompeo, Mike",35,000080
+ELK,Union Center Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000090
+ELK,Union Center Township,United States House of Representatives,4,Republican,"Pompeo, Mike",32,000090
+ELK,Wildcat Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",65,000100
+ELK,Wildcat Township,United States House of Representatives,4,Republican,"Pompeo, Mike",149,000100
+ELK,Elk Falls Township,Attorney General,,Democratic,"Kotich, A.J.",10,000010
+ELK,Elk Falls Township,Attorney General,,Republican,"Schmidt, Derek",65,000010
+ELK,Greenfield Township,Attorney General,,Democratic,"Kotich, A.J.",16,000020
+ELK,Greenfield Township,Attorney General,,Republican,"Schmidt, Derek",96,000020
+ELK,Howard Township,Attorney General,,Democratic,"Kotich, A.J.",37,000030
+ELK,Howard Township,Attorney General,,Republican,"Schmidt, Derek",313,000030
+ELK,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",7,000040
+ELK,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",45,000040
+ELK,Longton Township,Attorney General,,Democratic,"Kotich, A.J.",21,000050
+ELK,Longton Township,Attorney General,,Republican,"Schmidt, Derek",109,000050
+ELK,Oak Valley Township,Attorney General,,Democratic,"Kotich, A.J.",7,000060
+ELK,Oak Valley Township,Attorney General,,Republican,"Schmidt, Derek",42,000060
+ELK,Painterhood Township,Attorney General,,Democratic,"Kotich, A.J.",2,000070
+ELK,Painterhood Township,Attorney General,,Republican,"Schmidt, Derek",21,000070
+ELK,Paw Paw Township,Attorney General,,Democratic,"Kotich, A.J.",3,000080
+ELK,Paw Paw Township,Attorney General,,Republican,"Schmidt, Derek",37,000080
+ELK,Union Center Township,Attorney General,,Democratic,"Kotich, A.J.",8,000090
+ELK,Union Center Township,Attorney General,,Republican,"Schmidt, Derek",32,000090
+ELK,Wildcat Township,Attorney General,,Democratic,"Kotich, A.J.",37,000100
+ELK,Wildcat Township,Attorney General,,Republican,"Schmidt, Derek",181,000100
+ELK,Elk Falls Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000010
+ELK,Elk Falls Township,Commissioner of Insurance,,Republican,"Selzer, Ken",54,000010
+ELK,Greenfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000020
+ELK,Greenfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",83,000020
+ELK,Howard Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000030
+ELK,Howard Township,Commissioner of Insurance,,Republican,"Selzer, Ken",254,000030
+ELK,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000040
+ELK,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000040
+ELK,Longton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000050
+ELK,Longton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",112,000050
+ELK,Oak Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000060
+ELK,Oak Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000060
+ELK,Painterhood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000070
+ELK,Painterhood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000070
+ELK,Paw Paw Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000080
+ELK,Paw Paw Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000080
+ELK,Union Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000090
+ELK,Union Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000090
+ELK,Wildcat Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,000100
+ELK,Wildcat Township,Commissioner of Insurance,,Republican,"Selzer, Ken",134,000100
+ELK,Elk Falls Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000010
+ELK,Elk Falls Township,Secretary of State,,Republican,"Kobach, Kris",51,000010
+ELK,Greenfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000020
+ELK,Greenfield Township,Secretary of State,,Republican,"Kobach, Kris",79,000020
+ELK,Howard Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",117,000030
+ELK,Howard Township,Secretary of State,,Republican,"Kobach, Kris",233,000030
+ELK,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000040
+ELK,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",25,000040
+ELK,Longton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000050
+ELK,Longton Township,Secretary of State,,Republican,"Kobach, Kris",109,000050
+ELK,Oak Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000060
+ELK,Oak Valley Township,Secretary of State,,Republican,"Kobach, Kris",35,000060
+ELK,Painterhood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000070
+ELK,Painterhood Township,Secretary of State,,Republican,"Kobach, Kris",15,000070
+ELK,Paw Paw Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000080
+ELK,Paw Paw Township,Secretary of State,,Republican,"Kobach, Kris",29,000080
+ELK,Union Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000090
+ELK,Union Center Township,Secretary of State,,Republican,"Kobach, Kris",26,000090
+ELK,Wildcat Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000100
+ELK,Wildcat Township,Secretary of State,,Republican,"Kobach, Kris",144,000100
+ELK,Elk Falls Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000010
+ELK,Elk Falls Township,State Treasurer,,Republican,"Estes, Ron",58,000010
+ELK,Greenfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000020
+ELK,Greenfield Township,State Treasurer,,Republican,"Estes, Ron",91,000020
+ELK,Howard Township,State Treasurer,,Democratic,"Alldritt, Carmen",56,000030
+ELK,Howard Township,State Treasurer,,Republican,"Estes, Ron",292,000030
+ELK,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000040
+ELK,Liberty Township,State Treasurer,,Republican,"Estes, Ron",34,000040
+ELK,Longton Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000050
+ELK,Longton Township,State Treasurer,,Republican,"Estes, Ron",111,000050
+ELK,Oak Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000060
+ELK,Oak Valley Township,State Treasurer,,Republican,"Estes, Ron",39,000060
+ELK,Painterhood Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000070
+ELK,Painterhood Township,State Treasurer,,Republican,"Estes, Ron",23,000070
+ELK,Paw Paw Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000080
+ELK,Paw Paw Township,State Treasurer,,Republican,"Estes, Ron",33,000080
+ELK,Union Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000090
+ELK,Union Center Township,State Treasurer,,Republican,"Estes, Ron",33,000090
+ELK,Wildcat Township,State Treasurer,,Democratic,"Alldritt, Carmen",57,000100
+ELK,Wildcat Township,State Treasurer,,Republican,"Estes, Ron",155,000100
+ELK,Elk Falls Township,United States Senate,,independent,"Orman, Greg",18,000010
+ELK,Elk Falls Township,United States Senate,,Libertarian,"Batson, Randall",9,000010
+ELK,Elk Falls Township,United States Senate,,Republican,"Roberts, Pat",48,000010
+ELK,Greenfield Township,United States Senate,,independent,"Orman, Greg",23,000020
+ELK,Greenfield Township,United States Senate,,Libertarian,"Batson, Randall",8,000020
+ELK,Greenfield Township,United States Senate,,Republican,"Roberts, Pat",79,000020
+ELK,Howard Township,United States Senate,,independent,"Orman, Greg",120,000030
+ELK,Howard Township,United States Senate,,Libertarian,"Batson, Randall",19,000030
+ELK,Howard Township,United States Senate,,Republican,"Roberts, Pat",211,000030
+ELK,Liberty Township,United States Senate,,independent,"Orman, Greg",12,000040
+ELK,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",5,000040
+ELK,Liberty Township,United States Senate,,Republican,"Roberts, Pat",28,000040
+ELK,Longton Township,United States Senate,,independent,"Orman, Greg",30,000050
+ELK,Longton Township,United States Senate,,Libertarian,"Batson, Randall",17,000050
+ELK,Longton Township,United States Senate,,Republican,"Roberts, Pat",92,000050
+ELK,Oak Valley Township,United States Senate,,independent,"Orman, Greg",17,000060
+ELK,Oak Valley Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+ELK,Oak Valley Township,United States Senate,,Republican,"Roberts, Pat",28,000060
+ELK,Painterhood Township,United States Senate,,independent,"Orman, Greg",5,000070
+ELK,Painterhood Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+ELK,Painterhood Township,United States Senate,,Republican,"Roberts, Pat",17,000070
+ELK,Paw Paw Township,United States Senate,,independent,"Orman, Greg",9,000080
+ELK,Paw Paw Township,United States Senate,,Libertarian,"Batson, Randall",4,000080
+ELK,Paw Paw Township,United States Senate,,Republican,"Roberts, Pat",29,000080
+ELK,Union Center Township,United States Senate,,independent,"Orman, Greg",9,000090
+ELK,Union Center Township,United States Senate,,Libertarian,"Batson, Randall",4,000090
+ELK,Union Center Township,United States Senate,,Republican,"Roberts, Pat",27,000090
+ELK,Wildcat Township,United States Senate,,independent,"Orman, Greg",75,000100
+ELK,Wildcat Township,United States Senate,,Libertarian,"Batson, Randall",18,000100
+ELK,Wildcat Township,United States Senate,,Republican,"Roberts, Pat",121,000100

--- a/2014/20141104__ks__general__ellis__precinct.csv
+++ b/2014/20141104__ks__general__ellis__precinct.csv
@@ -1,685 +1,764 @@
-county,precinct,office,district,party,candidate,votes
-Ellis,Hays W1P1,Attorney General,,D,A J Kotich,27
-Ellis,Hays W1P2,Attorney General,,D,A J Kotich,50
-Ellis,Hays W2P1,Attorney General,,D,A J Kotich,101
-Ellis,Hays W2P2,Attorney General,,D,A J Kotich,117
-Ellis,Hays W2P5,Attorney General,,D,A J Kotich,55
-Ellis,Hays W3P1,Attorney General,,D,A J Kotich,91
-Ellis,Hays W3P4,Attorney General,,D,A J Kotich,191
-Ellis,Hays W4P1,Attorney General,,D,A J Kotich,90
-Ellis,Hays W4P2,Attorney General,,D,A J Kotich,114
-Ellis,Hays W4P3,Attorney General,,D,A J Kotich,92
-Ellis,Hays W4P4,Attorney General,,D,A J Kotich,169
-Ellis,Hays W2P3,Attorney General,,D,A J Kotich,82
-Ellis,Hays W2P4,Attorney General,,D,A J Kotich,93
-Ellis,Hays W3P2,Attorney General,,D,A J Kotich,110
-Ellis,Hays W3P3,Attorney General,,D,A J Kotich,106
-Ellis,Hays W4P5,Attorney General,,D,A J Kotich,121
-Ellis,Hays W1P1,Attorney General,,R,Derek Schmidt,40
-Ellis,Hays W1P2,Attorney General,,R,Derek Schmidt,118
-Ellis,Hays W2P1,Attorney General,,R,Derek Schmidt,230
-Ellis,Hays W2P2,Attorney General,,R,Derek Schmidt,186
-Ellis,Hays W2P5,Attorney General,,R,Derek Schmidt,131
-Ellis,Hays W3P1,Attorney General,,R,Derek Schmidt,211
-Ellis,Hays W3P4,Attorney General,,R,Derek Schmidt,766
-Ellis,Hays W4P1,Attorney General,,R,Derek Schmidt,281
-Ellis,Hays W4P2,Attorney General,,R,Derek Schmidt,302
-Ellis,Hays W4P3,Attorney General,,R,Derek Schmidt,295
-Ellis,Hays W4P4,Attorney General,,R,Derek Schmidt,539
-Ellis,Hays W2P3,Attorney General,,R,Derek Schmidt,154
-Ellis,Hays W2P4,Attorney General,,R,Derek Schmidt,171
-Ellis,Hays W3P2,Attorney General,,R,Derek Schmidt,386
-Ellis,Hays W3P3,Attorney General,,R,Derek Schmidt,462
-Ellis,Hays W4P5,Attorney General,,R,Derek Schmidt,384
-Ellis,Hays W2P1,Attorney General,,,Write-ins,1
-Ellis,Hays W4P1,Attorney General,,,Write-ins,1
-Ellis,Hays W4P2,Attorney General,,,Write-ins,1
-Ellis,Hays W4P4,Attorney General,,,Write-ins,1
-Ellis,Hays W3P2,Attorney General,,,Write-ins,1
-Ellis,Hays W1P1,U.S. House,1,D,James Sherow,38
-Ellis,Hays W1P2,U.S. House,1,D,James Sherow,65
-Ellis,Hays W2P1,U.S. House,1,D,James Sherow,135
-Ellis,Hays W2P2,U.S. House,1,D,James Sherow,153
-Ellis,Hays W2P5,U.S. House,1,D,James Sherow,80
-Ellis,Hays W3P1,U.S. House,1,D,James Sherow,121
-Ellis,Hays W3P4,U.S. House,1,D,James Sherow,334
-Ellis,Hays W4P1,U.S. House,1,D,James Sherow,143
-Ellis,Hays W4P2,U.S. House,1,D,James Sherow,160
-Ellis,Hays W4P3,U.S. House,1,D,James Sherow,143
-Ellis,Hays W4P4,U.S. House,1,D,James Sherow,278
-Ellis,Hays W2P3,U.S. House,1,D,James Sherow,100
-Ellis,Hays W2P4,U.S. House,1,D,James Sherow,115
-Ellis,Hays W3P2,U.S. House,1,D,James Sherow,171
-Ellis,Hays W3P3,U.S. House,1,D,James Sherow,210
-Ellis,Hays W4P5,U.S. House,1,D,James Sherow,181
-Ellis,Hays W1P1,U.S. House,1,R,Tim Huelskamp,32
-Ellis,Hays W1P2,U.S. House,1,R,Tim Huelskamp,105
-Ellis,Hays W2P1,U.S. House,1,R,Tim Huelskamp,208
-Ellis,Hays W2P2,U.S. House,1,R,Tim Huelskamp,152
-Ellis,Hays W2P5,U.S. House,1,R,Tim Huelskamp,105
-Ellis,Hays W3P1,U.S. House,1,R,Tim Huelskamp,179
-Ellis,Hays W3P4,U.S. House,1,R,Tim Huelskamp,640
-Ellis,Hays W4P1,U.S. House,1,R,Tim Huelskamp,230
-Ellis,Hays W4P2,U.S. House,1,R,Tim Huelskamp,256
-Ellis,Hays W4P3,U.S. House,1,R,Tim Huelskamp,243
-Ellis,Hays W4P4,U.S. House,1,R,Tim Huelskamp,451
-Ellis,Hays W2P3,U.S. House,1,R,Tim Huelskamp,135
-Ellis,Hays W2P4,U.S. House,1,R,Tim Huelskamp,149
-Ellis,Hays W3P2,U.S. House,1,R,Tim Huelskamp,326
-Ellis,Hays W3P3,U.S. House,1,R,Tim Huelskamp,359
-Ellis,Hays W4P5,U.S. House,1,R,Tim Huelskamp,329
-Ellis,Hays W2P1,U.S. House,1,,Write-ins,1
-Ellis,Hays W2P2,U.S. House,1,,Write-ins,1
-Ellis,Hays W3P1,U.S. House,1,,Write-ins,1
-Ellis,Hays W3P4,U.S. House,1,,Write-ins,4
-Ellis,Hays W4P3,U.S. House,1,,Write-ins,1
-Ellis,Hays W4P4,U.S. House,1,,Write-ins,2
-Ellis,Hays W2P4,U.S. House,1,,Write-ins,1
-Ellis,Hays W1P1,Governor,,L,Keen Umbehr,5
-Ellis,Hays W1P2,Governor,,L,Keen Umbehr,16
-Ellis,Hays W2P1,Governor,,L,Keen Umbehr,24
-Ellis,Hays W2P2,Governor,,L,Keen Umbehr,11
-Ellis,Hays W2P5,Governor,,L,Keen Umbehr,11
-Ellis,Hays W3P1,Governor,,L,Keen Umbehr,10
-Ellis,Hays W3P4,Governor,,L,Keen Umbehr,18
-Ellis,Hays W4P1,Governor,,L,Keen Umbehr,22
-Ellis,Hays W4P2,Governor,,L,Keen Umbehr,19
-Ellis,Hays W4P3,Governor,,L,Keen Umbehr,16
-Ellis,Hays W4P4,Governor,,L,Keen Umbehr,27
-Ellis,Hays W2P3,Governor,,L,Keen Umbehr,9
-Ellis,Hays W2P4,Governor,,L,Keen Umbehr,12
-Ellis,Hays W3P2,Governor,,L,Keen Umbehr,23
-Ellis,Hays W3P3,Governor,,L,Keen Umbehr,6
-Ellis,Hays W4P5,Governor,,L,Keen Umbehr,12
-Ellis,Hays W1P1,Governor,,D,Paul Davis,42
-Ellis,Hays W1P2,Governor,,D,Paul Davis,78
-Ellis,Hays W2P1,Governor,,D,Paul Davis,154
-Ellis,Hays W2P2,Governor,,D,Paul Davis,169
-Ellis,Hays W2P5,Governor,,D,Paul Davis,87
-Ellis,Hays W3P1,Governor,,D,Paul Davis,146
-Ellis,Hays W3P4,Governor,,D,Paul Davis,410
-Ellis,Hays W4P1,Governor,,D,Paul Davis,165
-Ellis,Hays W4P2,Governor,,D,Paul Davis,197
-Ellis,Hays W4P3,Governor,,D,Paul Davis,180
-Ellis,Hays W4P4,Governor,,D,Paul Davis,336
-Ellis,Hays W2P3,Governor,,D,Paul Davis,119
-Ellis,Hays W2P4,Governor,,D,Paul Davis,136
-Ellis,Hays W3P2,Governor,,D,Paul Davis,213
-Ellis,Hays W3P3,Governor,,D,Paul Davis,276
-Ellis,Hays W4P5,Governor,,D,Paul Davis,254
-Ellis,Hays W1P1,Governor,,R,Sam Brownback,23
-Ellis,Hays W1P2,Governor,,R,Sam Brownback,81
-Ellis,Hays W2P1,Governor,,R,Sam Brownback,162
-Ellis,Hays W2P2,Governor,,R,Sam Brownback,127
-Ellis,Hays W2P5,Governor,,R,Sam Brownback,89
-Ellis,Hays W3P1,Governor,,R,Sam Brownback,149
-Ellis,Hays W3P4,Governor,,R,Sam Brownback,558
-Ellis,Hays W4P1,Governor,,R,Sam Brownback,190
-Ellis,Hays W4P2,Governor,,R,Sam Brownback,210
-Ellis,Hays W4P3,Governor,,R,Sam Brownback,198
-Ellis,Hays W4P4,Governor,,R,Sam Brownback,373
-Ellis,Hays W2P3,Governor,,R,Sam Brownback,111
-Ellis,Hays W2P4,Governor,,R,Sam Brownback,116
-Ellis,Hays W3P2,Governor,,R,Sam Brownback,260
-Ellis,Hays W3P3,Governor,,R,Sam Brownback,297
-Ellis,Hays W4P5,Governor,,R,Sam Brownback,261
-Ellis,Hays W2P1,Governor,,,writiens,2
-Ellis,Hays W3P4,Governor,,,writiens,2
-Ellis,Hays W4P1,Governor,,,writiens,1
-Ellis,Hays W4P3,Governor,,,writiens,1
-Ellis,Hays W2P4,Governor,,,writiens,1
-Ellis,Hays W3P2,Governor,,,writiens,1
-Ellis,Hays W1P1,Insurance Commissioner,,D,Dennis Anderson,33
-Ellis,Hays W1P2,Insurance Commissioner,,D,Dennis Anderson,63
-Ellis,Hays W2P1,Insurance Commissioner,,D,Dennis Anderson,128
-Ellis,Hays W2P2,Insurance Commissioner,,D,Dennis Anderson,144
-Ellis,Hays W2P5,Insurance Commissioner,,D,Dennis Anderson,71
-Ellis,Hays W3P1,Insurance Commissioner,,D,Dennis Anderson,103
-Ellis,Hays W3P4,Insurance Commissioner,,D,Dennis Anderson,265
-Ellis,Hays W4P1,Insurance Commissioner,,D,Dennis Anderson,126
-Ellis,Hays W4P2,Insurance Commissioner,,D,Dennis Anderson,164
-Ellis,Hays W4P3,Insurance Commissioner,,D,Dennis Anderson,132
-Ellis,Hays W4P4,Insurance Commissioner,,D,Dennis Anderson,246
-Ellis,Hays W2P3,Insurance Commissioner,,D,Dennis Anderson,107
-Ellis,Hays W2P4,Insurance Commissioner,,D,Dennis Anderson,110
-Ellis,Hays W3P2,Insurance Commissioner,,D,Dennis Anderson,155
-Ellis,Hays W3P3,Insurance Commissioner,,D,Dennis Anderson,175
-Ellis,Hays W4P5,Insurance Commissioner,,D,Dennis Anderson,161
-Ellis,Hays W1P1,Insurance Commissioner,,R,Ken Selzer,35
-Ellis,Hays W1P2,Insurance Commissioner,,R,Ken Selzer,104
-Ellis,Hays W2P1,Insurance Commissioner,,R,Ken Selzer,194
-Ellis,Hays W2P2,Insurance Commissioner,,R,Ken Selzer,151
-Ellis,Hays W2P5,Insurance Commissioner,,R,Ken Selzer,107
-Ellis,Hays W3P1,Insurance Commissioner,,R,Ken Selzer,187
-Ellis,Hays W3P4,Insurance Commissioner,,R,Ken Selzer,664
-Ellis,Hays W4P1,Insurance Commissioner,,R,Ken Selzer,233
-Ellis,Hays W4P2,Insurance Commissioner,,R,Ken Selzer,238
-Ellis,Hays W4P3,Insurance Commissioner,,R,Ken Selzer,248
-Ellis,Hays W4P4,Insurance Commissioner,,R,Ken Selzer,442
-Ellis,Hays W2P3,Insurance Commissioner,,R,Ken Selzer,122
-Ellis,Hays W2P4,Insurance Commissioner,,R,Ken Selzer,144
-Ellis,Hays W3P2,Insurance Commissioner,,R,Ken Selzer,320
-Ellis,Hays W3P3,Insurance Commissioner,,R,Ken Selzer,372
-Ellis,Hays W4P5,Insurance Commissioner,,R,Ken Selzer,326
-Ellis,Hays W3P1,Insurance Commissioner,,,Write-ins,1
-Ellis,Hays W3P4,Insurance Commissioner,,,Write-ins,1
-Ellis,Hays W4P2,Insurance Commissioner,,,Write-ins,1
-Ellis,Hays W4P4,Insurance Commissioner,,,Write-ins,1
-Ellis,Hays W3P3,Insurance Commissioner,,,Write-ins,1
-Ellis,Hays W1P1,State House,111,D,James Leiker,36
-Ellis,Hays W1P2,State House,111,D,James Leiker,78
-Ellis,Hays W2P1,State House,111,D,James Leiker,156
-Ellis,Hays W2P2,State House,111,D,James Leiker,159
-Ellis,Hays W2P5,State House,111,D,James Leiker,86
-Ellis,Hays W3P1,State House,111,D,James Leiker,132
-Ellis,Hays W3P4,State House,111,D,James Leiker,364
-Ellis,Hays W4P1,State House,111,D,James Leiker,164
-Ellis,Hays W4P2,State House,111,D,James Leiker,194
-Ellis,Hays W4P3,State House,111,D,James Leiker,174
-Ellis,Hays W4P4,State House,111,D,James Leiker,323
-Ellis,Hays W2P3,State House,111,D,James Leiker,124
-Ellis,Hays W2P4,State House,111,D,James Leiker,141
-Ellis,Hays W3P2,State House,111,D,James Leiker,198
-Ellis,Hays W3P3,State House,111,D,James Leiker,254
-Ellis,Hays W4P5,State House,111,D,James Leiker,217
-Ellis,Hays W1P1,State House,111,R,Sue Boldra,33
-Ellis,Hays W1P2,State House,111,R,Sue Boldra,95
-Ellis,Hays W2P1,State House,111,R,Sue Boldra,187
-Ellis,Hays W2P2,State House,111,R,Sue Boldra,152
-Ellis,Hays W2P5,State House,111,R,Sue Boldra,98
-Ellis,Hays W3P1,State House,111,R,Sue Boldra,170
-Ellis,Hays W3P4,State House,111,R,Sue Boldra,628
-Ellis,Hays W4P1,State House,111,R,Sue Boldra,216
-Ellis,Hays W4P2,State House,111,R,Sue Boldra,233
-Ellis,Hays W4P3,State House,111,R,Sue Boldra,220
-Ellis,Hays W4P4,State House,111,R,Sue Boldra,409
-Ellis,Hays W2P3,State House,111,R,Sue Boldra,113
-Ellis,Hays W2P4,State House,111,R,Sue Boldra,125
-Ellis,Hays W3P2,State House,111,R,Sue Boldra,305
-Ellis,Hays W3P3,State House,111,R,Sue Boldra,321
-Ellis,Hays W4P5,State House,111,R,Sue Boldra,307
-Ellis,Hays W3P4,State House,111,,Write-ins,2
-Ellis,Hays W4P2,State House,111,,Write-ins,1
-Ellis,Hays W4P4,State House,111,,Write-ins,1
-Ellis,Hays W3P3,State House,111,,Write-ins,1
-Ellis,Hays W4P5,State House,111,,Write-ins,1
-Ellis,Hays W1P1,Secretary of State,,D,Jean Schodorf,36
-Ellis,Hays W1P2,Secretary of State,,D,Jean Schodorf,66
-Ellis,Hays W2P1,Secretary of State,,D,Jean Schodorf,128
-Ellis,Hays W2P2,Secretary of State,,D,Jean Schodorf,146
-Ellis,Hays W2P5,Secretary of State,,D,Jean Schodorf,80
-Ellis,Hays W3P1,Secretary of State,,D,Jean Schodorf,113
-Ellis,Hays W3P4,Secretary of State,,D,Jean Schodorf,299
-Ellis,Hays W4P1,Secretary of State,,D,Jean Schodorf,132
-Ellis,Hays W4P2,Secretary of State,,D,Jean Schodorf,150
-Ellis,Hays W4P3,Secretary of State,,D,Jean Schodorf,126
-Ellis,Hays W4P4,Secretary of State,,D,Jean Schodorf,257
-Ellis,Hays W2P3,Secretary of State,,D,Jean Schodorf,94
-Ellis,Hays W2P4,Secretary of State,,D,Jean Schodorf,122
-Ellis,Hays W3P2,Secretary of State,,D,Jean Schodorf,162
-Ellis,Hays W3P3,Secretary of State,,D,Jean Schodorf,186
-Ellis,Hays W4P5,Secretary of State,,D,Jean Schodorf,169
-Ellis,Hays W1P1,Secretary of State,,R,Kris Kobach,30
-Ellis,Hays W1P2,Secretary of State,,R,Kris Kobach,104
-Ellis,Hays W2P1,Secretary of State,,R,Kris Kobach,207
-Ellis,Hays W2P2,Secretary of State,,R,Kris Kobach,157
-Ellis,Hays W2P5,Secretary of State,,R,Kris Kobach,106
-Ellis,Hays W3P1,Secretary of State,,R,Kris Kobach,188
-Ellis,Hays W3P4,Secretary of State,,R,Kris Kobach,664
-Ellis,Hays W4P1,Secretary of State,,R,Kris Kobach,238
-Ellis,Hays W4P2,Secretary of State,,R,Kris Kobach,263
-Ellis,Hays W4P3,Secretary of State,,R,Kris Kobach,255
-Ellis,Hays W4P4,Secretary of State,,R,Kris Kobach,460
-Ellis,Hays W2P3,Secretary of State,,R,Kris Kobach,142
-Ellis,Hays W2P4,Secretary of State,,R,Kris Kobach,139
-Ellis,Hays W3P2,Secretary of State,,R,Kris Kobach,332
-Ellis,Hays W3P3,Secretary of State,,R,Kris Kobach,381
-Ellis,Hays W4P5,Secretary of State,,R,Kris Kobach,340
-Ellis,Hays W2P1,Secretary of State,,,Write-ins,1
-Ellis,Hays W3P4,Secretary of State,,,Write-ins,2
-Ellis,Hays W4P2,Secretary of State,,,Write-ins,1
-Ellis,Hays W4P4,Secretary of State,,,Write-ins,1
-Ellis,Hays W4P5,Secretary of State,,,Write-ins,1
-Ellis,Hays W1P1,State Treasurer,,D,Carmen Alldritt,29
-Ellis,Hays W1P2,State Treasurer,,D,Carmen Alldritt,56
-Ellis,Hays W2P1,State Treasurer,,D,Carmen Alldritt,105
-Ellis,Hays W2P2,State Treasurer,,D,Carmen Alldritt,111
-Ellis,Hays W2P5,State Treasurer,,D,Carmen Alldritt,67
-Ellis,Hays W3P1,State Treasurer,,D,Carmen Alldritt,87
-Ellis,Hays W3P4,State Treasurer,,D,Carmen Alldritt,198
-Ellis,Hays W4P1,State Treasurer,,D,Carmen Alldritt,104
-Ellis,Hays W4P2,State Treasurer,,D,Carmen Alldritt,131
-Ellis,Hays W4P3,State Treasurer,,D,Carmen Alldritt,103
-Ellis,Hays W4P4,State Treasurer,,D,Carmen Alldritt,196
-Ellis,Hays W2P3,State Treasurer,,D,Carmen Alldritt,85
-Ellis,Hays W2P4,State Treasurer,,D,Carmen Alldritt,92
-Ellis,Hays W3P2,State Treasurer,,D,Carmen Alldritt,118
-Ellis,Hays W3P3,State Treasurer,,D,Carmen Alldritt,118
-Ellis,Hays W4P5,State Treasurer,,D,Carmen Alldritt,130
-Ellis,Hays W1P1,State Treasurer,,R,Ron Estes,37
-Ellis,Hays W1P2,State Treasurer,,R,Ron Estes,113
-Ellis,Hays W2P1,State Treasurer,,R,Ron Estes,223
-Ellis,Hays W2P2,State Treasurer,,R,Ron Estes,194
-Ellis,Hays W2P5,State Treasurer,,R,Ron Estes,113
-Ellis,Hays W3P1,State Treasurer,,R,Ron Estes,206
-Ellis,Hays W3P4,State Treasurer,,R,Ron Estes,746
-Ellis,Hays W4P1,State Treasurer,,R,Ron Estes,263
-Ellis,Hays W4P2,State Treasurer,,R,Ron Estes,278
-Ellis,Hays W4P3,State Treasurer,,R,Ron Estes,278
-Ellis,Hays W4P4,State Treasurer,,R,Ron Estes,508
-Ellis,Hays W2P3,State Treasurer,,R,Ron Estes,147
-Ellis,Hays W2P4,State Treasurer,,R,Ron Estes,165
-Ellis,Hays W3P2,State Treasurer,,R,Ron Estes,368
-Ellis,Hays W3P3,State Treasurer,,R,Ron Estes,440
-Ellis,Hays W4P5,State Treasurer,,R,Ron Estes,367
-Ellis,Hays W3P1,State Treasurer,,,writiens,2
-Ellis,Hays W4P2,State Treasurer,,,writiens,1
-Ellis,Hays W4P3,State Treasurer,,,writiens,1
-Ellis,Hays W4P4,State Treasurer,,,writiens,1
-Ellis,Hays W2P4,State Treasurer,,,writiens,1
-Ellis,Hays W1P1,U.S. Senate,,I,Greg Orman,38
-Ellis,Hays W1P2,U.S. Senate,,I,Greg Orman,64
-Ellis,Hays W2P1,U.S. Senate,,I,Greg Orman,132
-Ellis,Hays W2P2,U.S. Senate,,I,Greg Orman,157
-Ellis,Hays W2P5,U.S. Senate,,I,Greg Orman,75
-Ellis,Hays W3P1,U.S. Senate,,I,Greg Orman,125
-Ellis,Hays W3P4,U.S. Senate,,I,Greg Orman,332
-Ellis,Hays W4P1,U.S. Senate,,I,Greg Orman,146
-Ellis,Hays W4P2,U.S. Senate,,I,Greg Orman,162
-Ellis,Hays W4P3,U.S. Senate,,I,Greg Orman,143
-Ellis,Hays W4P4,U.S. Senate,,I,Greg Orman,282
-Ellis,Hays W2P3,U.S. Senate,,I,Greg Orman,102
-Ellis,Hays W2P4,U.S. Senate,,I,Greg Orman,125
-Ellis,Hays W3P2,U.S. Senate,,I,Greg Orman,173
-Ellis,Hays W3P3,U.S. Senate,,I,Greg Orman,196
-Ellis,Hays W4P5,U.S. Senate,,I,Greg Orman,190
-Ellis,Hays W1P1,U.S. Senate,,R,Pat Roberts,28
-Ellis,Hays W1P2,U.S. Senate,,R,Pat Roberts,97
-Ellis,Hays W2P1,U.S. Senate,,R,Pat Roberts,189
-Ellis,Hays W2P2,U.S. Senate,,R,Pat Roberts,142
-Ellis,Hays W2P5,U.S. Senate,,R,Pat Roberts,95
-Ellis,Hays W3P1,U.S. Senate,,R,Pat Roberts,170
-Ellis,Hays W3P4,U.S. Senate,,R,Pat Roberts,625
-Ellis,Hays W4P1,U.S. Senate,,R,Pat Roberts,214
-Ellis,Hays W4P2,U.S. Senate,,R,Pat Roberts,241
-Ellis,Hays W4P3,U.S. Senate,,R,Pat Roberts,234
-Ellis,Hays W4P4,U.S. Senate,,R,Pat Roberts,418
-Ellis,Hays W2P3,U.S. Senate,,R,Pat Roberts,123
-Ellis,Hays W2P4,U.S. Senate,,R,Pat Roberts,124
-Ellis,Hays W3P2,U.S. Senate,,R,Pat Roberts,308
-Ellis,Hays W3P3,U.S. Senate,,R,Pat Roberts,361
-Ellis,Hays W4P5,U.S. Senate,,R,Pat Roberts,310
-Ellis,Hays W1P1,U.S. Senate,,L,Randall Batson,4
-Ellis,Hays W1P2,U.S. Senate,,L,Randall Batson,13
-Ellis,Hays W2P1,U.S. Senate,,L,Randall Batson,22
-Ellis,Hays W2P2,U.S. Senate,,L,Randall Batson,11
-Ellis,Hays W2P5,U.S. Senate,,L,Randall Batson,17
-Ellis,Hays W3P1,U.S. Senate,,L,Randall Batson,11
-Ellis,Hays W3P4,U.S. Senate,,L,Randall Batson,25
-Ellis,Hays W4P1,U.S. Senate,,L,Randall Batson,19
-Ellis,Hays W4P2,U.S. Senate,,L,Randall Batson,22
-Ellis,Hays W4P3,U.S. Senate,,L,Randall Batson,17
-Ellis,Hays W4P4,U.S. Senate,,L,Randall Batson,32
-Ellis,Hays W2P3,U.S. Senate,,L,Randall Batson,13
-Ellis,Hays W2P4,U.S. Senate,,L,Randall Batson,14
-Ellis,Hays W3P2,U.S. Senate,,L,Randall Batson,22
-Ellis,Hays W3P3,U.S. Senate,,L,Randall Batson,16
-Ellis,Hays W4P5,U.S. Senate,,L,Randall Batson,21
-Ellis,Hays W2P1,U.S. Senate,,,Write-ins,2
-Ellis,Hays W2P2,U.S. Senate,,,Write-ins,1
-Ellis,Hays W3P4,U.S. Senate,,,Write-ins,1
-Ellis,Hays W4P3,U.S. Senate,,,Write-ins,1
-Ellis,Hays W4P4,U.S. Senate,,,Write-ins,2
-Ellis,Hays W3P2,U.S. Senate,,,Write-ins,1
-Ellis,Hays W3P3,U.S. Senate,,,Write-ins,2
-Ellis,Buckeye,Attorney General,,D,A J Kotich,22
-Ellis,Catherine,Attorney General,,D,A J Kotich,22
-Ellis,East Big Creek,Attorney General,,D,A J Kotich,54
-Ellis,Ellis twp,Attorney General,,D,A J Kotich,32
-Ellis,Ellis W1,Attorney General,,D,A J Kotich,58
-Ellis,Ellis W2,Attorney General,,D,A J Kotich,102
-Ellis,Ellis W3,Attorney General,,D,A J Kotich,51
-Ellis,Freedom,Attorney General,,D,A J Kotich,6
-Ellis,Herzog 110,Attorney General,,D,A J Kotich,16
-Ellis,Herzog 111,Attorney General,,D,A J Kotich,45
-Ellis,North Big Creek 110,Attorney General,,D,A J Kotich,22
-Ellis,North Big Creek 111,Attorney General,,D,A J Kotich,38
-Ellis,North Lookout 110,Attorney General,,D,A J Kotich,9
-Ellis,North Lookout 111,Attorney General,,D,A J Kotich,9
-Ellis,South Lookout 110,Attorney General,,D,A J Kotich,16
-Ellis,Victoria,Attorney General,,D,A J Kotich,64
-Ellis,West Big Creek 110,Attorney General,,D,A J Kotich,6
-Ellis,West Big Creek 111,Attorney General,,D,A J Kotich,3
-Ellis,Wheatland,Attorney General,,D,A J Kotich,23
-Ellis,Buckeye,Attorney General,,R,Derek Schmidt,147
-Ellis,Catherine,Attorney General,,R,Derek Schmidt,112
-Ellis,East Big Creek,Attorney General,,R,Derek Schmidt,248
-Ellis,Ellis twp,Attorney General,,R,Derek Schmidt,165
-Ellis,Ellis W1,Attorney General,,R,Derek Schmidt,186
-Ellis,Ellis W2,Attorney General,,R,Derek Schmidt,258
-Ellis,Ellis W3,Attorney General,,R,Derek Schmidt,140
-Ellis,Freedom,Attorney General,,R,Derek Schmidt,34
-Ellis,Herzog 110,Attorney General,,R,Derek Schmidt,87
-Ellis,Herzog 111,Attorney General,,R,Derek Schmidt,144
-Ellis,North Big Creek 110,Attorney General,,R,Derek Schmidt,57
-Ellis,North Big Creek 111,Attorney General,,R,Derek Schmidt,178
-Ellis,North Lookout 110,Attorney General,,R,Derek Schmidt,51
-Ellis,North Lookout 111,Attorney General,,R,Derek Schmidt,51
-Ellis,South Lookout 110,Attorney General,,R,Derek Schmidt,94
-Ellis,Victoria,Attorney General,,R,Derek Schmidt,280
-Ellis,West Big Creek 110,Attorney General,,R,Derek Schmidt,26
-Ellis,West Big Creek 111,Attorney General,,R,Derek Schmidt,35
-Ellis,Wheatland,Attorney General,,R,Derek Schmidt,132
-Ellis,Victoria,Attorney General,,,Write-ins,2
-Ellis,Buckeye,U.S. House,1,D,James Sherow,35
-Ellis,Catherine,U.S. House,1,D,James Sherow,39
-Ellis,East Big Creek,U.S. House,1,D,James Sherow,77
-Ellis,Ellis twp,U.S. House,1,D,James Sherow,56
-Ellis,Ellis W1,U.S. House,1,D,James Sherow,64
-Ellis,Ellis W2,U.S. House,1,D,James Sherow,106
-Ellis,Ellis W3,U.S. House,1,D,James Sherow,55
-Ellis,Freedom,U.S. House,1,D,James Sherow,9
-Ellis,Herzog 110,U.S. House,1,D,James Sherow,29
-Ellis,Herzog 111,U.S. House,1,D,James Sherow,62
-Ellis,North Big Creek 110,U.S. House,1,D,James Sherow,28
-Ellis,North Big Creek 111,U.S. House,1,D,James Sherow,70
-Ellis,North Lookout 110,U.S. House,1,D,James Sherow,20
-Ellis,North Lookout 111,U.S. House,1,D,James Sherow,21
-Ellis,South Lookout 110,U.S. House,1,D,James Sherow,33
-Ellis,Victoria,U.S. House,1,D,James Sherow,104
-Ellis,West Big Creek 110,U.S. House,1,D,James Sherow,5
-Ellis,West Big Creek 111,U.S. House,1,D,James Sherow,11
-Ellis,Wheatland,U.S. House,1,D,James Sherow,37
-Ellis,Buckeye,U.S. House,1,R,Tim Huelskamp,136
-Ellis,Catherine,U.S. House,1,R,Tim Huelskamp,95
-Ellis,East Big Creek,U.S. House,1,R,Tim Huelskamp,228
-Ellis,Ellis twp,U.S. House,1,R,Tim Huelskamp,144
-Ellis,Ellis W1,U.S. House,1,R,Tim Huelskamp,187
-Ellis,Ellis W2,U.S. House,1,R,Tim Huelskamp,264
-Ellis,Ellis W3,U.S. House,1,R,Tim Huelskamp,141
-Ellis,Freedom,U.S. House,1,R,Tim Huelskamp,32
-Ellis,Herzog 110,U.S. House,1,R,Tim Huelskamp,76
-Ellis,Herzog 111,U.S. House,1,R,Tim Huelskamp,133
-Ellis,North Big Creek 110,U.S. House,1,R,Tim Huelskamp,53
-Ellis,North Big Creek 111,U.S. House,1,R,Tim Huelskamp,149
-Ellis,North Lookout 110,U.S. House,1,R,Tim Huelskamp,38
-Ellis,North Lookout 111,U.S. House,1,R,Tim Huelskamp,37
-Ellis,South Lookout 110,U.S. House,1,R,Tim Huelskamp,78
-Ellis,Victoria,U.S. House,1,R,Tim Huelskamp,248
-Ellis,West Big Creek 110,U.S. House,1,R,Tim Huelskamp,27
-Ellis,West Big Creek 111,U.S. House,1,R,Tim Huelskamp,26
-Ellis,Wheatland,U.S. House,1,R,Tim Huelskamp,120
-Ellis,East Big Creek,U.S. House,1,,Write-ins,1
-Ellis,North Big Creek 111,U.S. House,1,,Write-ins,1
-Ellis,North Lookout 110,U.S. House,1,,Write-ins,1
-Ellis,West Big Creek 110,U.S. House,1,,Write-ins,1
-Ellis,Buckeye,Governor,,L,Keen Umbehr,4
-Ellis,Catherine,Governor,,L,Keen Umbehr,6
-Ellis,East Big Creek,Governor,,L,Keen Umbehr,10
-Ellis,Ellis twp,Governor,,L,Keen Umbehr,7
-Ellis,Ellis W1,Governor,,L,Keen Umbehr,11
-Ellis,Ellis W2,Governor,,L,Keen Umbehr,18
-Ellis,Ellis W3,Governor,,L,Keen Umbehr,13
-Ellis,Freedom,Governor,,L,Keen Umbehr,0
-Ellis,Herzog 110,Governor,,L,Keen Umbehr,5
-Ellis,Herzog 111,Governor,,L,Keen Umbehr,10
-Ellis,North Big Creek 110,Governor,,L,Keen Umbehr,3
-Ellis,North Big Creek 111,Governor,,L,Keen Umbehr,6
-Ellis,North Lookout 110,Governor,,L,Keen Umbehr,4
-Ellis,North Lookout 111,Governor,,L,Keen Umbehr,2
-Ellis,South Lookout 110,Governor,,L,Keen Umbehr,4
-Ellis,Victoria,Governor,,L,Keen Umbehr,18
-Ellis,West Big Creek 110,Governor,,L,Keen Umbehr,0
-Ellis,West Big Creek 111,Governor,,L,Keen Umbehr,2
-Ellis,Wheatland,Governor,,L,Keen Umbehr,4
-Ellis,Buckeye,Governor,,D,Paul Davis,50
-Ellis,Catherine,Governor,,D,Paul Davis,45
-Ellis,East Big Creek,Governor,,D,Paul Davis,110
-Ellis,Ellis twp,Governor,,D,Paul Davis,64
-Ellis,Ellis W1,Governor,,D,Paul Davis,95
-Ellis,Ellis W2,Governor,,D,Paul Davis,168
-Ellis,Ellis W3,Governor,,D,Paul Davis,81
-Ellis,Freedom,Governor,,D,Paul Davis,14
-Ellis,Herzog 110,Governor,,D,Paul Davis,36
-Ellis,Herzog 111,Governor,,D,Paul Davis,76
-Ellis,North Big Creek 110,Governor,,D,Paul Davis,34
-Ellis,North Big Creek 111,Governor,,D,Paul Davis,73
-Ellis,North Lookout 110,Governor,,D,Paul Davis,18
-Ellis,North Lookout 111,Governor,,D,Paul Davis,18
-Ellis,South Lookout 110,Governor,,D,Paul Davis,36
-Ellis,Victoria,Governor,,D,Paul Davis,137
-Ellis,West Big Creek 110,Governor,,D,Paul Davis,8
-Ellis,West Big Creek 111,Governor,,D,Paul Davis,11
-Ellis,Wheatland,Governor,,D,Paul Davis,48
-Ellis,Buckeye,Governor,,R,Sam Brownback,119
-Ellis,Catherine,Governor,,R,Sam Brownback,84
-Ellis,East Big Creek,Governor,,R,Sam Brownback,191
-Ellis,Ellis twp,Governor,,R,Sam Brownback,130
-Ellis,Ellis W1,Governor,,R,Sam Brownback,149
-Ellis,Ellis W2,Governor,,R,Sam Brownback,189
-Ellis,Ellis W3,Governor,,R,Sam Brownback,105
-Ellis,Freedom,Governor,,R,Sam Brownback,27
-Ellis,Herzog 110,Governor,,R,Sam Brownback,62
-Ellis,Herzog 111,Governor,,R,Sam Brownback,108
-Ellis,North Big Creek 110,Governor,,R,Sam Brownback,44
-Ellis,North Big Creek 111,Governor,,R,Sam Brownback,146
-Ellis,North Lookout 110,Governor,,R,Sam Brownback,40
-Ellis,North Lookout 111,Governor,,R,Sam Brownback,38
-Ellis,South Lookout 110,Governor,,R,Sam Brownback,73
-Ellis,Victoria,Governor,,R,Sam Brownback,205
-Ellis,West Big Creek 110,Governor,,R,Sam Brownback,25
-Ellis,West Big Creek 111,Governor,,R,Sam Brownback,25
-Ellis,Wheatland,Governor,,R,Sam Brownback,107
-Ellis,Ellis W2,Governor,,,writiens,1
-Ellis,Herzog 110,Governor,,,writiens,1
-Ellis,Buckeye,Insurance Commissioner,,D,Dennis Anderson,29
-Ellis,Catherine,Insurance Commissioner,,D,Dennis Anderson,33
-Ellis,East Big Creek,Insurance Commissioner,,D,Dennis Anderson,80
-Ellis,Ellis twp,Insurance Commissioner,,D,Dennis Anderson,54
-Ellis,Ellis W1,Insurance Commissioner,,D,Dennis Anderson,78
-Ellis,Ellis W2,Insurance Commissioner,,D,Dennis Anderson,123
-Ellis,Ellis W3,Insurance Commissioner,,D,Dennis Anderson,63
-Ellis,Freedom,Insurance Commissioner,,D,Dennis Anderson,15
-Ellis,Herzog 110,Insurance Commissioner,,D,Dennis Anderson,36
-Ellis,Herzog 111,Insurance Commissioner,,D,Dennis Anderson,65
-Ellis,North Big Creek 110,Insurance Commissioner,,D,Dennis Anderson,26
-Ellis,North Big Creek 111,Insurance Commissioner,,D,Dennis Anderson,53
-Ellis,North Lookout 110,Insurance Commissioner,,D,Dennis Anderson,18
-Ellis,North Lookout 111,Insurance Commissioner,,D,Dennis Anderson,17
-Ellis,South Lookout 110,Insurance Commissioner,,D,Dennis Anderson,29
-Ellis,Victoria,Insurance Commissioner,,D,Dennis Anderson,104
-Ellis,West Big Creek 110,Insurance Commissioner,,D,Dennis Anderson,8
-Ellis,West Big Creek 111,Insurance Commissioner,,D,Dennis Anderson,11
-Ellis,Wheatland,Insurance Commissioner,,D,Dennis Anderson,39
-Ellis,Buckeye,Insurance Commissioner,,R,Ken Selzer,135
-Ellis,Catherine,Insurance Commissioner,,R,Ken Selzer,91
-Ellis,East Big Creek,Insurance Commissioner,,R,Ken Selzer,213
-Ellis,Ellis twp,Insurance Commissioner,,R,Ken Selzer,137
-Ellis,Ellis W1,Insurance Commissioner,,R,Ken Selzer,162
-Ellis,Ellis W2,Insurance Commissioner,,R,Ken Selzer,229
-Ellis,Ellis W3,Insurance Commissioner,,R,Ken Selzer,127
-Ellis,Freedom,Insurance Commissioner,,R,Ken Selzer,23
-Ellis,Herzog 110,Insurance Commissioner,,R,Ken Selzer,65
-Ellis,Herzog 111,Insurance Commissioner,,R,Ken Selzer,117
-Ellis,North Big Creek 110,Insurance Commissioner,,R,Ken Selzer,53
-Ellis,North Big Creek 111,Insurance Commissioner,,R,Ken Selzer,155
-Ellis,North Lookout 110,Insurance Commissioner,,R,Ken Selzer,42
-Ellis,North Lookout 111,Insurance Commissioner,,R,Ken Selzer,40
-Ellis,South Lookout 110,Insurance Commissioner,,R,Ken Selzer,73
-Ellis,Victoria,Insurance Commissioner,,R,Ken Selzer,224
-Ellis,West Big Creek 110,Insurance Commissioner,,R,Ken Selzer,22
-Ellis,West Big Creek 111,Insurance Commissioner,,R,Ken Selzer,26
-Ellis,Wheatland,Insurance Commissioner,,R,Ken Selzer,109
-Ellis,Victoria,Insurance Commissioner,,,Write-ins,1
-Ellis,Buckeye,State House,110,R,Travis Couture-Lovelady,152
-Ellis,Catherine,State House,110,R,Travis Couture-Lovelady,105
-Ellis,Ellis twp,State House,110,R,Travis Couture-Lovelady,178
-Ellis,Ellis W1,State House,110,R,Travis Couture-Lovelady,212
-Ellis,Ellis W2,State House,110,R,Travis Couture-Lovelady,318
-Ellis,Ellis W3,State House,110,R,Travis Couture-Lovelady,173
-Ellis,Herzog 110,State House,110,R,Travis Couture-Lovelady,94
-Ellis,North Big Creek 110,State House,110,R,Travis Couture-Lovelady,65
-Ellis,North Lookout 110,State House,110,R,Travis Couture-Lovelady,53
-Ellis,South Lookout 110,State House,110,R,Travis Couture-Lovelady,94
-Ellis,West Big Creek 110,State House,110,R,Travis Couture-Lovelady,28
-Ellis,Buckeye,State House,110,,Write-ins,3
-Ellis,Catherine,State House,110,,Write-ins,1
-Ellis,Ellis twp,State House,110,,Write-ins,2
-Ellis,Ellis W1,State House,110,,Write-ins,5
-Ellis,Ellis W2,State House,110,,Write-ins,8
-Ellis,Ellis W3,State House,110,,Write-ins,2
-Ellis,Herzog 110,State House,110,,Write-ins,2
-Ellis,North Big Creek 110,State House,110,,Write-ins,5
-Ellis,North Lookout 110,State House,110,,Write-ins,2
-Ellis,East Big Creek,State House,111,D,James Leiker,111
-Ellis,Freedom,State House,111,D,James Leiker,13
-Ellis,Herzog 111,State House,111,D,James Leiker,88
-Ellis,North Big Creek 111,State House,111,D,James Leiker,78
-Ellis,North Lookout 111,State House,111,D,James Leiker,25
-Ellis,Victoria,State House,111,D,James Leiker,145
-Ellis,West Big Creek 111,State House,111,D,James Leiker,13
-Ellis,Wheatland,State House,111,D,James Leiker,57
-Ellis,East Big Creek,State House,111,R,Sue Boldra,200
-Ellis,Freedom,State House,111,R,Sue Boldra,28
-Ellis,Herzog 111,State House,111,R,Sue Boldra,109
-Ellis,North Big Creek 111,State House,111,R,Sue Boldra,147
-Ellis,North Lookout 111,State House,111,R,Sue Boldra,35
-Ellis,Victoria,State House,111,R,Sue Boldra,215
-Ellis,West Big Creek 111,State House,111,R,Sue Boldra,25
-Ellis,Wheatland,State House,111,R,Sue Boldra,101
-Ellis,Buckeye,Secretary of State,,D,Jean Schodorf,35
-Ellis,Catherine,Secretary of State,,D,Jean Schodorf,34
-Ellis,East Big Creek,Secretary of State,,D,Jean Schodorf,75
-Ellis,Ellis twp,Secretary of State,,D,Jean Schodorf,59
-Ellis,Ellis W1,Secretary of State,,D,Jean Schodorf,73
-Ellis,Ellis W2,Secretary of State,,D,Jean Schodorf,128
-Ellis,Ellis W3,Secretary of State,,D,Jean Schodorf,56
-Ellis,Freedom,Secretary of State,,D,Jean Schodorf,10
-Ellis,Herzog 110,Secretary of State,,D,Jean Schodorf,30
-Ellis,Herzog 111,Secretary of State,,D,Jean Schodorf,66
-Ellis,North Big Creek 110,Secretary of State,,D,Jean Schodorf,25
-Ellis,North Big Creek 111,Secretary of State,,D,Jean Schodorf,62
-Ellis,North Lookout 110,Secretary of State,,D,Jean Schodorf,15
-Ellis,North Lookout 111,Secretary of State,,D,Jean Schodorf,15
-Ellis,South Lookout 110,Secretary of State,,D,Jean Schodorf,30
-Ellis,Victoria,Secretary of State,,D,Jean Schodorf,107
-Ellis,West Big Creek 110,Secretary of State,,D,Jean Schodorf,10
-Ellis,West Big Creek 111,Secretary of State,,D,Jean Schodorf,10
-Ellis,Wheatland,Secretary of State,,D,Jean Schodorf,39
-Ellis,Buckeye,Secretary of State,,R,Kris Kobach,135
-Ellis,Catherine,Secretary of State,,R,Kris Kobach,98
-Ellis,East Big Creek,Secretary of State,,R,Kris Kobach,231
-Ellis,Ellis twp,Secretary of State,,R,Kris Kobach,141
-Ellis,Ellis W1,Secretary of State,,R,Kris Kobach,175
-Ellis,Ellis W2,Secretary of State,,R,Kris Kobach,240
-Ellis,Ellis W3,Secretary of State,,R,Kris Kobach,136
-Ellis,Freedom,Secretary of State,,R,Kris Kobach,30
-Ellis,Herzog 110,Secretary of State,,R,Kris Kobach,74
-Ellis,Herzog 111,Secretary of State,,R,Kris Kobach,119
-Ellis,North Big Creek 110,Secretary of State,,R,Kris Kobach,55
-Ellis,North Big Creek 111,Secretary of State,,R,Kris Kobach,153
-Ellis,North Lookout 110,Secretary of State,,R,Kris Kobach,46
-Ellis,North Lookout 111,Secretary of State,,R,Kris Kobach,44
-Ellis,South Lookout 110,Secretary of State,,R,Kris Kobach,79
-Ellis,Victoria,Secretary of State,,R,Kris Kobach,239
-Ellis,West Big Creek 110,Secretary of State,,R,Kris Kobach,23
-Ellis,West Big Creek 111,Secretary of State,,R,Kris Kobach,26
-Ellis,Wheatland,Secretary of State,,R,Kris Kobach,116
-Ellis,Buckeye,Secretary of State,,,Write-ins,1
-Ellis,Victoria,Secretary of State,,,Write-ins,2
-Ellis,Buckeye,State Treasurer,,D,Carmen Alldritt,24
-Ellis,Catherine,State Treasurer,,D,Carmen Alldritt,22
-Ellis,East Big Creek,State Treasurer,,D,Carmen Alldritt,59
-Ellis,Ellis twp,State Treasurer,,D,Carmen Alldritt,39
-Ellis,Ellis W1,State Treasurer,,D,Carmen Alldritt,61
-Ellis,Ellis W2,State Treasurer,,D,Carmen Alldritt,102
-Ellis,Ellis W3,State Treasurer,,D,Carmen Alldritt,49
-Ellis,Freedom,State Treasurer,,D,Carmen Alldritt,8
-Ellis,Herzog 110,State Treasurer,,D,Carmen Alldritt,28
-Ellis,Herzog 111,State Treasurer,,D,Carmen Alldritt,57
-Ellis,North Big Creek 110,State Treasurer,,D,Carmen Alldritt,26
-Ellis,North Big Creek 111,State Treasurer,,D,Carmen Alldritt,41
-Ellis,North Lookout 110,State Treasurer,,D,Carmen Alldritt,12
-Ellis,North Lookout 111,State Treasurer,,D,Carmen Alldritt,11
-Ellis,South Lookout 110,State Treasurer,,D,Carmen Alldritt,25
-Ellis,Victoria,State Treasurer,,D,Carmen Alldritt,79
-Ellis,West Big Creek 110,State Treasurer,,D,Carmen Alldritt,6
-Ellis,West Big Creek 111,State Treasurer,,D,Carmen Alldritt,5
-Ellis,Wheatland,State Treasurer,,D,Carmen Alldritt,28
-Ellis,Buckeye,State Treasurer,,R,Ron Estes,145
-Ellis,Catherine,State Treasurer,,R,Ron Estes,105
-Ellis,East Big Creek,State Treasurer,,R,Ron Estes,240
-Ellis,Ellis twp,State Treasurer,,R,Ron Estes,155
-Ellis,Ellis W1,State Treasurer,,R,Ron Estes,181
-Ellis,Ellis W2,State Treasurer,,R,Ron Estes,253
-Ellis,Ellis W3,State Treasurer,,R,Ron Estes,141
-Ellis,Freedom,State Treasurer,,R,Ron Estes,31
-Ellis,Herzog 110,State Treasurer,,R,Ron Estes,74
-Ellis,Herzog 111,State Treasurer,,R,Ron Estes,129
-Ellis,North Big Creek 110,State Treasurer,,R,Ron Estes,53
-Ellis,North Big Creek 111,State Treasurer,,R,Ron Estes,172
-Ellis,North Lookout 110,State Treasurer,,R,Ron Estes,47
-Ellis,North Lookout 111,State Treasurer,,R,Ron Estes,47
-Ellis,South Lookout 110,State Treasurer,,R,Ron Estes,83
-Ellis,Victoria,State Treasurer,,R,Ron Estes,255
-Ellis,West Big Creek 110,State Treasurer,,R,Ron Estes,27
-Ellis,West Big Creek 111,State Treasurer,,R,Ron Estes,33
-Ellis,Wheatland,State Treasurer,,R,Ron Estes,122
-Ellis,Victoria,State Treasurer,,,writiens,1
-Ellis,Buckeye,U.S. Senate,,I,Greg Orman,41
-Ellis,Catherine,U.S. Senate,,I,Greg Orman,38
-Ellis,East Big Creek,U.S. Senate,,I,Greg Orman,88
-Ellis,Ellis twp,U.S. Senate,,I,Greg Orman,55
-Ellis,Ellis W1,U.S. Senate,,I,Greg Orman,75
-Ellis,Ellis W2,U.S. Senate,,I,Greg Orman,138
-Ellis,Ellis W3,U.S. Senate,,I,Greg Orman,69
-Ellis,Freedom,U.S. Senate,,I,Greg Orman,13
-Ellis,Herzog 110,U.S. Senate,,I,Greg Orman,26
-Ellis,Herzog 111,U.S. Senate,,I,Greg Orman,70
-Ellis,North Big Creek 110,U.S. Senate,,I,Greg Orman,30
-Ellis,North Big Creek 111,U.S. Senate,,I,Greg Orman,69
-Ellis,North Lookout 110,U.S. Senate,,I,Greg Orman,12
-Ellis,North Lookout 111,U.S. Senate,,I,Greg Orman,21
-Ellis,South Lookout 110,U.S. Senate,,I,Greg Orman,24
-Ellis,Victoria,U.S. Senate,,I,Greg Orman,105
-Ellis,West Big Creek 110,U.S. Senate,,I,Greg Orman,8
-Ellis,West Big Creek 111,U.S. Senate,,I,Greg Orman,5
-Ellis,Wheatland,U.S. Senate,,I,Greg Orman,39
-Ellis,Buckeye,U.S. Senate,,R,Pat Roberts,125
-Ellis,Catherine,U.S. Senate,,R,Pat Roberts,89
-Ellis,East Big Creek,U.S. Senate,,R,Pat Roberts,213
-Ellis,Ellis twp,U.S. Senate,,R,Pat Roberts,143
-Ellis,Ellis W1,U.S. Senate,,R,Pat Roberts,166
-Ellis,Ellis W2,U.S. Senate,,R,Pat Roberts,225
-Ellis,Ellis W3,U.S. Senate,,R,Pat Roberts,114
-Ellis,Freedom,U.S. Senate,,R,Pat Roberts,29
-Ellis,Herzog 110,U.S. Senate,,R,Pat Roberts,71
-Ellis,Herzog 111,U.S. Senate,,R,Pat Roberts,116
-Ellis,North Big Creek 110,U.S. Senate,,R,Pat Roberts,49
-Ellis,North Big Creek 111,U.S. Senate,,R,Pat Roberts,150
-Ellis,North Lookout 110,U.S. Senate,,R,Pat Roberts,45
-Ellis,North Lookout 111,U.S. Senate,,R,Pat Roberts,36
-Ellis,South Lookout 110,U.S. Senate,,R,Pat Roberts,82
-Ellis,Victoria,U.S. Senate,,R,Pat Roberts,229
-Ellis,West Big Creek 110,U.S. Senate,,R,Pat Roberts,25
-Ellis,West Big Creek 111,U.S. Senate,,R,Pat Roberts,31
-Ellis,Wheatland,U.S. Senate,,R,Pat Roberts,113
-Ellis,Buckeye,U.S. Senate,,L,Randall Batson,6
-Ellis,Catherine,U.S. Senate,,L,Randall Batson,8
-Ellis,East Big Creek,U.S. Senate,,L,Randall Batson,10
-Ellis,Ellis twp,U.S. Senate,,L,Randall Batson,5
-Ellis,Ellis W1,U.S. Senate,,L,Randall Batson,10
-Ellis,Ellis W2,U.S. Senate,,L,Randall Batson,13
-Ellis,Ellis W3,U.S. Senate,,L,Randall Batson,17
-Ellis,Freedom,U.S. Senate,,L,Randall Batson,0
-Ellis,Herzog 110,U.S. Senate,,L,Randall Batson,7
-Ellis,Herzog 111,U.S. Senate,,L,Randall Batson,9
-Ellis,North Big Creek 110,U.S. Senate,,L,Randall Batson,2
-Ellis,North Big Creek 111,U.S. Senate,,L,Randall Batson,4
-Ellis,North Lookout 110,U.S. Senate,,L,Randall Batson,5
-Ellis,North Lookout 111,U.S. Senate,,L,Randall Batson,3
-Ellis,South Lookout 110,U.S. Senate,,L,Randall Batson,7
-Ellis,Victoria,U.S. Senate,,L,Randall Batson,22
-Ellis,West Big Creek 110,U.S. Senate,,L,Randall Batson,0
-Ellis,West Big Creek 111,U.S. Senate,,L,Randall Batson,2
-Ellis,Wheatland,U.S. Senate,,L,Randall Batson,6
+county,precinct,office,district,party,candidate,votes,vtd
+ELLIS,Buckeye Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000010
+ELLIS,Buckeye Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+ELLIS,Buckeye Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000010
+ELLIS,Catherine Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000020
+ELLIS,Catherine Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000020
+ELLIS,Catherine Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",84,000020
+ELLIS,East Big Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",110,000030
+ELLIS,East Big Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000030
+ELLIS,East Big Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",191,000030
+ELLIS,Ellis Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",64,000040
+ELLIS,Ellis Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000040
+ELLIS,Ellis Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000040
+ELLIS,Ellis Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",95,000050
+ELLIS,Ellis Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000050
+ELLIS,Ellis Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",149,000050
+ELLIS,Ellis Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",168,000060
+ELLIS,Ellis Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000060
+ELLIS,Ellis Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",189,000060
+ELLIS,Ellis Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000070
+ELLIS,Ellis Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000070
+ELLIS,Ellis Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",105,000070
+ELLIS,Freedom Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000080
+ELLIS,Freedom Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+ELLIS,Freedom Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000080
+ELLIS,Hays Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000090
+ELLIS,Hays Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000090
+ELLIS,Hays Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000090
+ELLIS,Hays Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,00010A
+ELLIS,Hays Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00010A
+ELLIS,Hays Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,00010A
+ELLIS,Hays Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",154,000110
+ELLIS,Hays Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000110
+ELLIS,Hays Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",162,000110
+ELLIS,Hays Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",169,000120
+ELLIS,Hays Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000120
+ELLIS,Hays Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",127,000120
+ELLIS,Hays Ward 2 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000130
+ELLIS,Hays Ward 2 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000130
+ELLIS,Hays Ward 2 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",111,000130
+ELLIS,Hays Ward 2 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",136,000140
+ELLIS,Hays Ward 2 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000140
+ELLIS,Hays Ward 2 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",116,000140
+ELLIS,Hays Ward 2 Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",87,000150
+ELLIS,Hays Ward 2 Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000150
+ELLIS,Hays Ward 2 Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000150
+ELLIS,Hays Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",146,00016A
+ELLIS,Hays Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,00016A
+ELLIS,Hays Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",149,00016A
+ELLIS,Hays Ward 3 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",214,000170
+ELLIS,Hays Ward 3 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000170
+ELLIS,Hays Ward 3 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",260,000170
+ELLIS,Hays Ward 3 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",276,000180
+ELLIS,Hays Ward 3 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000180
+ELLIS,Hays Ward 3 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",297,000180
+ELLIS,Hays Ward 3 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",410,00019A
+ELLIS,Hays Ward 3 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,00019A
+ELLIS,Hays Ward 3 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",558,00019A
+ELLIS,Hays Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",165,000200
+ELLIS,Hays Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000200
+ELLIS,Hays Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",190,000200
+ELLIS,Hays Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",197,00021A
+ELLIS,Hays Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,00021A
+ELLIS,Hays Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",210,00021A
+ELLIS,Hays Ward 4 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",180,000220
+ELLIS,Hays Ward 4 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000220
+ELLIS,Hays Ward 4 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",198,000220
+ELLIS,Hays Ward 4 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",336,000230
+ELLIS,Hays Ward 4 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",27,000230
+ELLIS,Hays Ward 4 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",373,000230
+ELLIS,Hays Ward 4 Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",254,000240
+ELLIS,Hays Ward 4 Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000240
+ELLIS,Hays Ward 4 Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",261,000240
+ELLIS,South Lookout Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000280
+ELLIS,South Lookout Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000280
+ELLIS,South Lookout Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000280
+ELLIS,Victoria Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",137,000290
+ELLIS,Victoria Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000290
+ELLIS,Victoria Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",205,000290
+ELLIS,Wheatland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000310
+ELLIS,Wheatland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000310
+ELLIS,Wheatland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000310
+ELLIS,Herzog Township H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,120020
+ELLIS,Herzog Township H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120020
+ELLIS,Herzog Township H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",62,120020
+ELLIS,Herzog Township H111,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,120030
+ELLIS,Herzog Township H111,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,120030
+ELLIS,Herzog Township H111,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,120030
+ELLIS,North Big Creek Township H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,120040
+ELLIS,North Big Creek Township H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,120040
+ELLIS,North Big Creek Township H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,120040
+ELLIS,North Big Creek Township H111,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,120050
+ELLIS,North Big Creek Township H111,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120050
+ELLIS,North Big Creek Township H111,Governor / Lt. Governor,,Republican,"Brownback, Sam",146,120050
+ELLIS,North Lookout Township H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,120060
+ELLIS,North Lookout Township H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,120060
+ELLIS,North Lookout Township H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,120060
+ELLIS,North Lookout Township H111,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,120070
+ELLIS,North Lookout Township H111,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120070
+ELLIS,North Lookout Township H111,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,120070
+ELLIS,West Big Creek Township H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,120080
+ELLIS,West Big Creek Township H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120080
+ELLIS,West Big Creek Township H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,120080
+ELLIS,West Big Creek Township H111,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,120090
+ELLIS,West Big Creek Township H111,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120090
+ELLIS,West Big Creek Township H111,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+ELLIS,North Big Creek Township Enclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+ELLIS,North Big Creek Township Enclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+ELLIS,North Big Creek Township Enclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+ELLIS,North Big Creek Township Enclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900060
+ELLIS,North Big Creek Township Enclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+ELLIS,North Big Creek Township Enclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900060
+ELLIS,North Big Creek Township Enclave 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900070
+ELLIS,North Big Creek Township Enclave 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900070
+ELLIS,North Big Creek Township Enclave 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900070
+ELLIS,North Big Creek Township Enclave 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900080
+ELLIS,North Big Creek Township Enclave 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900080
+ELLIS,North Big Creek Township Enclave 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900080
+ELLIS,Buckeye Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",152,000010
+ELLIS,Catherine Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",105,000020
+ELLIS,East Big Creek Township,Kansas House of Representatives,111,Democratic,"Leiker, James A.",111,000030
+ELLIS,East Big Creek Township,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",200,000030
+ELLIS,Ellis Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",178,000040
+ELLIS,Ellis Ward 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",212,000050
+ELLIS,Ellis Ward 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",318,000060
+ELLIS,Ellis Ward 3,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",173,000070
+ELLIS,Freedom Township,Kansas House of Representatives,111,Democratic,"Leiker, James A.",13,000080
+ELLIS,Freedom Township,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",28,000080
+ELLIS,Hays Ward 1 Precinct 1,Kansas House of Representatives,111,Democratic,"Leiker, James A.",36,000090
+ELLIS,Hays Ward 1 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",33,000090
+ELLIS,Hays Ward 1 Precinct 2,Kansas House of Representatives,111,Democratic,"Leiker, James A.",78,00010A
+ELLIS,Hays Ward 1 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",95,00010A
+ELLIS,Hays Ward 2 Precinct 1,Kansas House of Representatives,111,Democratic,"Leiker, James A.",156,000110
+ELLIS,Hays Ward 2 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",187,000110
+ELLIS,Hays Ward 2 Precinct 2,Kansas House of Representatives,111,Democratic,"Leiker, James A.",159,000120
+ELLIS,Hays Ward 2 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",152,000120
+ELLIS,Hays Ward 2 Precinct 3,Kansas House of Representatives,111,Democratic,"Leiker, James A.",124,000130
+ELLIS,Hays Ward 2 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",113,000130
+ELLIS,Hays Ward 2 Precinct 4,Kansas House of Representatives,111,Democratic,"Leiker, James A.",141,000140
+ELLIS,Hays Ward 2 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",125,000140
+ELLIS,Hays Ward 2 Precinct 5,Kansas House of Representatives,111,Democratic,"Leiker, James A.",86,000150
+ELLIS,Hays Ward 2 Precinct 5,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",98,000150
+ELLIS,Hays Ward 3 Precinct 1,Kansas House of Representatives,111,Democratic,"Leiker, James A.",132,00016A
+ELLIS,Hays Ward 3 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",170,00016A
+ELLIS,Hays Ward 3 Precinct 2,Kansas House of Representatives,111,Democratic,"Leiker, James A.",198,000170
+ELLIS,Hays Ward 3 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",305,000170
+ELLIS,Hays Ward 3 Precinct 3,Kansas House of Representatives,111,Democratic,"Leiker, James A.",254,000180
+ELLIS,Hays Ward 3 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",321,000180
+ELLIS,Hays Ward 3 Precinct 4,Kansas House of Representatives,111,Democratic,"Leiker, James A.",364,00019A
+ELLIS,Hays Ward 3 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",628,00019A
+ELLIS,Hays Ward 4 Precinct 1,Kansas House of Representatives,111,Democratic,"Leiker, James A.",164,000200
+ELLIS,Hays Ward 4 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",216,000200
+ELLIS,Hays Ward 4 Precinct 2,Kansas House of Representatives,111,Democratic,"Leiker, James A.",194,00021A
+ELLIS,Hays Ward 4 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",233,00021A
+ELLIS,Hays Ward 4 Precinct 3,Kansas House of Representatives,111,Democratic,"Leiker, James A.",174,000220
+ELLIS,Hays Ward 4 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",220,000220
+ELLIS,Hays Ward 4 Precinct 4,Kansas House of Representatives,111,Democratic,"Leiker, James A.",323,000230
+ELLIS,Hays Ward 4 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",409,000230
+ELLIS,Hays Ward 4 Precinct 5,Kansas House of Representatives,111,Democratic,"Leiker, James A.",217,000240
+ELLIS,Hays Ward 4 Precinct 5,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",307,000240
+ELLIS,South Lookout Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",94,000280
+ELLIS,Victoria Township,Kansas House of Representatives,111,Democratic,"Leiker, James A.",145,000290
+ELLIS,Victoria Township,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",215,000290
+ELLIS,Wheatland Township,Kansas House of Representatives,111,Democratic,"Leiker, James A.",57,000310
+ELLIS,Wheatland Township,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",101,000310
+ELLIS,Herzog Township H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",94,120020
+ELLIS,Herzog Township H111,Kansas House of Representatives,111,Democratic,"Leiker, James A.",88,120030
+ELLIS,Herzog Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",109,120030
+ELLIS,North Big Creek Township H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",65,120040
+ELLIS,North Big Creek Township H111,Kansas House of Representatives,111,Democratic,"Leiker, James A.",78,120050
+ELLIS,North Big Creek Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",147,120050
+ELLIS,North Lookout Township H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",53,120060
+ELLIS,North Lookout Township H111,Kansas House of Representatives,111,Democratic,"Leiker, James A.",25,120070
+ELLIS,North Lookout Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",35,120070
+ELLIS,West Big Creek Township H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",28,120080
+ELLIS,West Big Creek Township H111,Kansas House of Representatives,111,Democratic,"Leiker, James A.",13,120090
+ELLIS,West Big Creek Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",25,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas House of Representatives,111,Democratic,"Leiker, James A.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas House of Representatives,111,Democratic,"Leiker, James A.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas House of Representatives,111,Democratic,"Leiker, James A.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas House of Representatives,111,Democratic,"Leiker, James A.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900040
+ELLIS,North Big Creek Township Enclave 1,Kansas House of Representatives,111,Democratic,"Leiker, James A.",0,900050
+ELLIS,North Big Creek Township Enclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900050
+ELLIS,North Big Creek Township Enclave 2,Kansas House of Representatives,111,Democratic,"Leiker, James A.",0,900060
+ELLIS,North Big Creek Township Enclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900060
+ELLIS,North Big Creek Township Enclave 3,Kansas House of Representatives,111,Democratic,"Leiker, James A.",0,900070
+ELLIS,North Big Creek Township Enclave 3,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900070
+ELLIS,North Big Creek Township Enclave 4,Kansas House of Representatives,111,Democratic,"Leiker, James A.",0,900080
+ELLIS,North Big Creek Township Enclave 4,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900080
+ELLIS,Buckeye Township,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000010
+ELLIS,Buckeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",136,000010
+ELLIS,Catherine Township,United States House of Representatives,1,Democratic,"Sherow, James E.",39,000020
+ELLIS,Catherine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000020
+ELLIS,East Big Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",77,000030
+ELLIS,East Big Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",228,000030
+ELLIS,Ellis Township,United States House of Representatives,1,Democratic,"Sherow, James E.",56,000040
+ELLIS,Ellis Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",144,000040
+ELLIS,Ellis Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",64,000050
+ELLIS,Ellis Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",187,000050
+ELLIS,Ellis Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",106,000060
+ELLIS,Ellis Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",264,000060
+ELLIS,Ellis Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",55,000070
+ELLIS,Ellis Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",141,000070
+ELLIS,Freedom Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000080
+ELLIS,Freedom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000080
+ELLIS,Hays Ward 1 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",38,000090
+ELLIS,Hays Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000090
+ELLIS,Hays Ward 1 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",65,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,00010A
+ELLIS,Hays Ward 2 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",135,000110
+ELLIS,Hays Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",208,000110
+ELLIS,Hays Ward 2 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",153,000120
+ELLIS,Hays Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",152,000120
+ELLIS,Hays Ward 2 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",100,000130
+ELLIS,Hays Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",135,000130
+ELLIS,Hays Ward 2 Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",115,000140
+ELLIS,Hays Ward 2 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",149,000140
+ELLIS,Hays Ward 2 Precinct 5,United States House of Representatives,1,Democratic,"Sherow, James E.",80,000150
+ELLIS,Hays Ward 2 Precinct 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,000150
+ELLIS,Hays Ward 3 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",121,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",179,00016A
+ELLIS,Hays Ward 3 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",171,000170
+ELLIS,Hays Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",326,000170
+ELLIS,Hays Ward 3 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",210,000180
+ELLIS,Hays Ward 3 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",359,000180
+ELLIS,Hays Ward 3 Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",334,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",640,00019A
+ELLIS,Hays Ward 4 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",143,000200
+ELLIS,Hays Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",230,000200
+ELLIS,Hays Ward 4 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",160,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",256,00021A
+ELLIS,Hays Ward 4 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",143,000220
+ELLIS,Hays Ward 4 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",243,000220
+ELLIS,Hays Ward 4 Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",278,000230
+ELLIS,Hays Ward 4 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",451,000230
+ELLIS,Hays Ward 4 Precinct 5,United States House of Representatives,1,Democratic,"Sherow, James E.",181,000240
+ELLIS,Hays Ward 4 Precinct 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",329,000240
+ELLIS,South Lookout Township,United States House of Representatives,1,Democratic,"Sherow, James E.",33,000280
+ELLIS,South Lookout Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000280
+ELLIS,Victoria Township,United States House of Representatives,1,Democratic,"Sherow, James E.",104,000290
+ELLIS,Victoria Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",248,000290
+ELLIS,Wheatland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",37,000310
+ELLIS,Wheatland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",120,000310
+ELLIS,Herzog Township H110,United States House of Representatives,1,Democratic,"Sherow, James E.",29,120020
+ELLIS,Herzog Township H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,120020
+ELLIS,Herzog Township H111,United States House of Representatives,1,Democratic,"Sherow, James E.",62,120030
+ELLIS,Herzog Township H111,United States House of Representatives,1,Republican,"Huelskamp, Tim",133,120030
+ELLIS,North Big Creek Township H110,United States House of Representatives,1,Democratic,"Sherow, James E.",28,120040
+ELLIS,North Big Creek Township H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,120040
+ELLIS,North Big Creek Township H111,United States House of Representatives,1,Democratic,"Sherow, James E.",70,120050
+ELLIS,North Big Creek Township H111,United States House of Representatives,1,Republican,"Huelskamp, Tim",149,120050
+ELLIS,North Lookout Township H110,United States House of Representatives,1,Democratic,"Sherow, James E.",20,120060
+ELLIS,North Lookout Township H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,120060
+ELLIS,North Lookout Township H111,United States House of Representatives,1,Democratic,"Sherow, James E.",21,120070
+ELLIS,North Lookout Township H111,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,120070
+ELLIS,West Big Creek Township H110,United States House of Representatives,1,Democratic,"Sherow, James E.",5,120080
+ELLIS,West Big Creek Township H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,120080
+ELLIS,West Big Creek Township H111,United States House of Representatives,1,Democratic,"Sherow, James E.",11,120090
+ELLIS,West Big Creek Township H111,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+ELLIS,North Big Creek Township Enclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050
+ELLIS,North Big Creek Township Enclave 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900060
+ELLIS,North Big Creek Township Enclave 3,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900070
+ELLIS,North Big Creek Township Enclave 4,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900080
+ELLIS,Buckeye Township,Attorney General,,Democratic,"Kotich, A.J.",22,000010
+ELLIS,Buckeye Township,Attorney General,,Republican,"Schmidt, Derek",147,000010
+ELLIS,Catherine Township,Attorney General,,Democratic,"Kotich, A.J.",22,000020
+ELLIS,Catherine Township,Attorney General,,Republican,"Schmidt, Derek",112,000020
+ELLIS,East Big Creek Township,Attorney General,,Democratic,"Kotich, A.J.",54,000030
+ELLIS,East Big Creek Township,Attorney General,,Republican,"Schmidt, Derek",248,000030
+ELLIS,Ellis Township,Attorney General,,Democratic,"Kotich, A.J.",32,000040
+ELLIS,Ellis Township,Attorney General,,Republican,"Schmidt, Derek",165,000040
+ELLIS,Ellis Ward 1,Attorney General,,Democratic,"Kotich, A.J.",58,000050
+ELLIS,Ellis Ward 1,Attorney General,,Republican,"Schmidt, Derek",186,000050
+ELLIS,Ellis Ward 2,Attorney General,,Democratic,"Kotich, A.J.",102,000060
+ELLIS,Ellis Ward 2,Attorney General,,Republican,"Schmidt, Derek",258,000060
+ELLIS,Ellis Ward 3,Attorney General,,Democratic,"Kotich, A.J.",51,000070
+ELLIS,Ellis Ward 3,Attorney General,,Republican,"Schmidt, Derek",140,000070
+ELLIS,Freedom Township,Attorney General,,Democratic,"Kotich, A.J.",6,000080
+ELLIS,Freedom Township,Attorney General,,Republican,"Schmidt, Derek",34,000080
+ELLIS,Hays Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",27,000090
+ELLIS,Hays Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",40,000090
+ELLIS,Hays Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",50,00010A
+ELLIS,Hays Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",118,00010A
+ELLIS,Hays Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",101,000110
+ELLIS,Hays Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",230,000110
+ELLIS,Hays Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",117,000120
+ELLIS,Hays Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",186,000120
+ELLIS,Hays Ward 2 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",82,000130
+ELLIS,Hays Ward 2 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",154,000130
+ELLIS,Hays Ward 2 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",93,000140
+ELLIS,Hays Ward 2 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",171,000140
+ELLIS,Hays Ward 2 Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",55,000150
+ELLIS,Hays Ward 2 Precinct 5,Attorney General,,Republican,"Schmidt, Derek",131,000150
+ELLIS,Hays Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",91,00016A
+ELLIS,Hays Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",211,00016A
+ELLIS,Hays Ward 3 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",110,000170
+ELLIS,Hays Ward 3 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",386,000170
+ELLIS,Hays Ward 3 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",106,000180
+ELLIS,Hays Ward 3 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",462,000180
+ELLIS,Hays Ward 3 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",191,00019A
+ELLIS,Hays Ward 3 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",766,00019A
+ELLIS,Hays Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",90,000200
+ELLIS,Hays Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",281,000200
+ELLIS,Hays Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",114,00021A
+ELLIS,Hays Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",302,00021A
+ELLIS,Hays Ward 4 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",92,000220
+ELLIS,Hays Ward 4 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",295,000220
+ELLIS,Hays Ward 4 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",169,000230
+ELLIS,Hays Ward 4 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",539,000230
+ELLIS,Hays Ward 4 Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",121,000240
+ELLIS,Hays Ward 4 Precinct 5,Attorney General,,Republican,"Schmidt, Derek",384,000240
+ELLIS,South Lookout Township,Attorney General,,Democratic,"Kotich, A.J.",16,000280
+ELLIS,South Lookout Township,Attorney General,,Republican,"Schmidt, Derek",94,000280
+ELLIS,Victoria Township,Attorney General,,Democratic,"Kotich, A.J.",64,000290
+ELLIS,Victoria Township,Attorney General,,Republican,"Schmidt, Derek",280,000290
+ELLIS,Wheatland Township,Attorney General,,Democratic,"Kotich, A.J.",23,000310
+ELLIS,Wheatland Township,Attorney General,,Republican,"Schmidt, Derek",132,000310
+ELLIS,Herzog Township H110,Attorney General,,Democratic,"Kotich, A.J.",16,120020
+ELLIS,Herzog Township H110,Attorney General,,Republican,"Schmidt, Derek",87,120020
+ELLIS,Herzog Township H111,Attorney General,,Democratic,"Kotich, A.J.",45,120030
+ELLIS,Herzog Township H111,Attorney General,,Republican,"Schmidt, Derek",144,120030
+ELLIS,North Big Creek Township H110,Attorney General,,Democratic,"Kotich, A.J.",22,120040
+ELLIS,North Big Creek Township H110,Attorney General,,Republican,"Schmidt, Derek",57,120040
+ELLIS,North Big Creek Township H111,Attorney General,,Democratic,"Kotich, A.J.",38,120050
+ELLIS,North Big Creek Township H111,Attorney General,,Republican,"Schmidt, Derek",178,120050
+ELLIS,North Lookout Township H110,Attorney General,,Democratic,"Kotich, A.J.",9,120060
+ELLIS,North Lookout Township H110,Attorney General,,Republican,"Schmidt, Derek",51,120060
+ELLIS,North Lookout Township H111,Attorney General,,Democratic,"Kotich, A.J.",9,120070
+ELLIS,North Lookout Township H111,Attorney General,,Republican,"Schmidt, Derek",51,120070
+ELLIS,West Big Creek Township H110,Attorney General,,Democratic,"Kotich, A.J.",6,120080
+ELLIS,West Big Creek Township H110,Attorney General,,Republican,"Schmidt, Derek",26,120080
+ELLIS,West Big Creek Township H111,Attorney General,,Democratic,"Kotich, A.J.",3,120090
+ELLIS,West Big Creek Township H111,Attorney General,,Republican,"Schmidt, Derek",35,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900040
+ELLIS,North Big Creek Township Enclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+ELLIS,North Big Creek Township Enclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900050
+ELLIS,North Big Creek Township Enclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900060
+ELLIS,North Big Creek Township Enclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900060
+ELLIS,North Big Creek Township Enclave 3,Attorney General,,Democratic,"Kotich, A.J.",0,900070
+ELLIS,North Big Creek Township Enclave 3,Attorney General,,Republican,"Schmidt, Derek",0,900070
+ELLIS,North Big Creek Township Enclave 4,Attorney General,,Democratic,"Kotich, A.J.",0,900080
+ELLIS,North Big Creek Township Enclave 4,Attorney General,,Republican,"Schmidt, Derek",0,900080
+ELLIS,Buckeye Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000010
+ELLIS,Buckeye Township,Commissioner of Insurance,,Republican,"Selzer, Ken",135,000010
+ELLIS,Catherine Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000020
+ELLIS,Catherine Township,Commissioner of Insurance,,Republican,"Selzer, Ken",91,000020
+ELLIS,East Big Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000030
+ELLIS,East Big Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",213,000030
+ELLIS,Ellis Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000040
+ELLIS,Ellis Township,Commissioner of Insurance,,Republican,"Selzer, Ken",137,000040
+ELLIS,Ellis Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",78,000050
+ELLIS,Ellis Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",162,000050
+ELLIS,Ellis Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",123,000060
+ELLIS,Ellis Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",229,000060
+ELLIS,Ellis Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,000070
+ELLIS,Ellis Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",127,000070
+ELLIS,Freedom Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000080
+ELLIS,Freedom Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000080
+ELLIS,Hays Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000090
+ELLIS,Hays Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000090
+ELLIS,Hays Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,00010A
+ELLIS,Hays Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",104,00010A
+ELLIS,Hays Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",128,000110
+ELLIS,Hays Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",194,000110
+ELLIS,Hays Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",144,000120
+ELLIS,Hays Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",151,000120
+ELLIS,Hays Ward 2 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",107,000130
+ELLIS,Hays Ward 2 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",122,000130
+ELLIS,Hays Ward 2 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",110,000140
+ELLIS,Hays Ward 2 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",144,000140
+ELLIS,Hays Ward 2 Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000150
+ELLIS,Hays Ward 2 Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",107,000150
+ELLIS,Hays Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",103,00016A
+ELLIS,Hays Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",187,00016A
+ELLIS,Hays Ward 3 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",155,000170
+ELLIS,Hays Ward 3 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",320,000170
+ELLIS,Hays Ward 3 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",175,000180
+ELLIS,Hays Ward 3 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",372,000180
+ELLIS,Hays Ward 3 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",265,00019A
+ELLIS,Hays Ward 3 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",664,00019A
+ELLIS,Hays Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",126,000200
+ELLIS,Hays Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",233,000200
+ELLIS,Hays Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",164,00021A
+ELLIS,Hays Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",238,00021A
+ELLIS,Hays Ward 4 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",132,000220
+ELLIS,Hays Ward 4 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",248,000220
+ELLIS,Hays Ward 4 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",246,000230
+ELLIS,Hays Ward 4 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",442,000230
+ELLIS,Hays Ward 4 Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",161,000240
+ELLIS,Hays Ward 4 Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",326,000240
+ELLIS,South Lookout Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000280
+ELLIS,South Lookout Township,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000280
+ELLIS,Victoria Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",104,000290
+ELLIS,Victoria Township,Commissioner of Insurance,,Republican,"Selzer, Ken",224,000290
+ELLIS,Wheatland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000310
+ELLIS,Wheatland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",109,000310
+ELLIS,Herzog Township H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,120020
+ELLIS,Herzog Township H110,Commissioner of Insurance,,Republican,"Selzer, Ken",65,120020
+ELLIS,Herzog Township H111,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,120030
+ELLIS,Herzog Township H111,Commissioner of Insurance,,Republican,"Selzer, Ken",117,120030
+ELLIS,North Big Creek Township H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,120040
+ELLIS,North Big Creek Township H110,Commissioner of Insurance,,Republican,"Selzer, Ken",53,120040
+ELLIS,North Big Creek Township H111,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,120050
+ELLIS,North Big Creek Township H111,Commissioner of Insurance,,Republican,"Selzer, Ken",155,120050
+ELLIS,North Lookout Township H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,120060
+ELLIS,North Lookout Township H110,Commissioner of Insurance,,Republican,"Selzer, Ken",42,120060
+ELLIS,North Lookout Township H111,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,120070
+ELLIS,North Lookout Township H111,Commissioner of Insurance,,Republican,"Selzer, Ken",40,120070
+ELLIS,West Big Creek Township H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,120080
+ELLIS,West Big Creek Township H110,Commissioner of Insurance,,Republican,"Selzer, Ken",22,120080
+ELLIS,West Big Creek Township H111,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,120090
+ELLIS,West Big Creek Township H111,Commissioner of Insurance,,Republican,"Selzer, Ken",26,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+ELLIS,North Big Creek Township Enclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+ELLIS,North Big Creek Township Enclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+ELLIS,North Big Creek Township Enclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900060
+ELLIS,North Big Creek Township Enclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900060
+ELLIS,North Big Creek Township Enclave 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900070
+ELLIS,North Big Creek Township Enclave 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900070
+ELLIS,North Big Creek Township Enclave 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900080
+ELLIS,North Big Creek Township Enclave 4,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900080
+ELLIS,Buckeye Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000010
+ELLIS,Buckeye Township,Secretary of State,,Republican,"Kobach, Kris",135,000010
+ELLIS,Catherine Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000020
+ELLIS,Catherine Township,Secretary of State,,Republican,"Kobach, Kris",98,000020
+ELLIS,East Big Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000030
+ELLIS,East Big Creek Township,Secretary of State,,Republican,"Kobach, Kris",231,000030
+ELLIS,Ellis Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000040
+ELLIS,Ellis Township,Secretary of State,,Republican,"Kobach, Kris",141,000040
+ELLIS,Ellis Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,000050
+ELLIS,Ellis Ward 1,Secretary of State,,Republican,"Kobach, Kris",175,000050
+ELLIS,Ellis Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",128,000060
+ELLIS,Ellis Ward 2,Secretary of State,,Republican,"Kobach, Kris",240,000060
+ELLIS,Ellis Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,000070
+ELLIS,Ellis Ward 3,Secretary of State,,Republican,"Kobach, Kris",136,000070
+ELLIS,Freedom Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000080
+ELLIS,Freedom Township,Secretary of State,,Republican,"Kobach, Kris",30,000080
+ELLIS,Hays Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000090
+ELLIS,Hays Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",30,000090
+ELLIS,Hays Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,00010A
+ELLIS,Hays Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",104,00010A
+ELLIS,Hays Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",128,000110
+ELLIS,Hays Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",207,000110
+ELLIS,Hays Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,000120
+ELLIS,Hays Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",157,000120
+ELLIS,Hays Ward 2 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000130
+ELLIS,Hays Ward 2 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",142,000130
+ELLIS,Hays Ward 2 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",122,000140
+ELLIS,Hays Ward 2 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",139,000140
+ELLIS,Hays Ward 2 Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",80,000150
+ELLIS,Hays Ward 2 Precinct 5,Secretary of State,,Republican,"Kobach, Kris",106,000150
+ELLIS,Hays Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",113,00016A
+ELLIS,Hays Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",188,00016A
+ELLIS,Hays Ward 3 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",162,000170
+ELLIS,Hays Ward 3 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",332,000170
+ELLIS,Hays Ward 3 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",186,000180
+ELLIS,Hays Ward 3 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",381,000180
+ELLIS,Hays Ward 3 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",299,00019A
+ELLIS,Hays Ward 3 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",664,00019A
+ELLIS,Hays Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",132,000200
+ELLIS,Hays Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",238,000200
+ELLIS,Hays Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",150,00021A
+ELLIS,Hays Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",263,00021A
+ELLIS,Hays Ward 4 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",126,000220
+ELLIS,Hays Ward 4 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",255,000220
+ELLIS,Hays Ward 4 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",257,000230
+ELLIS,Hays Ward 4 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",460,000230
+ELLIS,Hays Ward 4 Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",169,000240
+ELLIS,Hays Ward 4 Precinct 5,Secretary of State,,Republican,"Kobach, Kris",340,000240
+ELLIS,South Lookout Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000280
+ELLIS,South Lookout Township,Secretary of State,,Republican,"Kobach, Kris",79,000280
+ELLIS,Victoria Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",107,000290
+ELLIS,Victoria Township,Secretary of State,,Republican,"Kobach, Kris",239,000290
+ELLIS,Wheatland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000310
+ELLIS,Wheatland Township,Secretary of State,,Republican,"Kobach, Kris",116,000310
+ELLIS,Herzog Township H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,120020
+ELLIS,Herzog Township H110,Secretary of State,,Republican,"Kobach, Kris",74,120020
+ELLIS,Herzog Township H111,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,120030
+ELLIS,Herzog Township H111,Secretary of State,,Republican,"Kobach, Kris",119,120030
+ELLIS,North Big Creek Township H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,120040
+ELLIS,North Big Creek Township H110,Secretary of State,,Republican,"Kobach, Kris",55,120040
+ELLIS,North Big Creek Township H111,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,120050
+ELLIS,North Big Creek Township H111,Secretary of State,,Republican,"Kobach, Kris",153,120050
+ELLIS,North Lookout Township H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,120060
+ELLIS,North Lookout Township H110,Secretary of State,,Republican,"Kobach, Kris",46,120060
+ELLIS,North Lookout Township H111,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,120070
+ELLIS,North Lookout Township H111,Secretary of State,,Republican,"Kobach, Kris",44,120070
+ELLIS,West Big Creek Township H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,120080
+ELLIS,West Big Creek Township H110,Secretary of State,,Republican,"Kobach, Kris",23,120080
+ELLIS,West Big Creek Township H111,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,120090
+ELLIS,West Big Creek Township H111,Secretary of State,,Republican,"Kobach, Kris",26,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900040
+ELLIS,North Big Creek Township Enclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+ELLIS,North Big Creek Township Enclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900050
+ELLIS,North Big Creek Township Enclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900060
+ELLIS,North Big Creek Township Enclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900060
+ELLIS,North Big Creek Township Enclave 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900070
+ELLIS,North Big Creek Township Enclave 3,Secretary of State,,Republican,"Kobach, Kris",0,900070
+ELLIS,North Big Creek Township Enclave 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900080
+ELLIS,North Big Creek Township Enclave 4,Secretary of State,,Republican,"Kobach, Kris",0,900080
+ELLIS,Buckeye Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000010
+ELLIS,Buckeye Township,State Treasurer,,Republican,"Estes, Ron",145,000010
+ELLIS,Catherine Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000020
+ELLIS,Catherine Township,State Treasurer,,Republican,"Estes, Ron",105,000020
+ELLIS,East Big Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",59,000030
+ELLIS,East Big Creek Township,State Treasurer,,Republican,"Estes, Ron",240,000030
+ELLIS,Ellis Township,State Treasurer,,Democratic,"Alldritt, Carmen",39,000040
+ELLIS,Ellis Township,State Treasurer,,Republican,"Estes, Ron",155,000040
+ELLIS,Ellis Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",61,000050
+ELLIS,Ellis Ward 1,State Treasurer,,Republican,"Estes, Ron",181,000050
+ELLIS,Ellis Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",102,000060
+ELLIS,Ellis Ward 2,State Treasurer,,Republican,"Estes, Ron",253,000060
+ELLIS,Ellis Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",49,000070
+ELLIS,Ellis Ward 3,State Treasurer,,Republican,"Estes, Ron",141,000070
+ELLIS,Freedom Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000080
+ELLIS,Freedom Township,State Treasurer,,Republican,"Estes, Ron",31,000080
+ELLIS,Hays Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",29,000090
+ELLIS,Hays Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",37,000090
+ELLIS,Hays Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",56,00010A
+ELLIS,Hays Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",113,00010A
+ELLIS,Hays Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",105,000110
+ELLIS,Hays Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",223,000110
+ELLIS,Hays Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",111,000120
+ELLIS,Hays Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",194,000120
+ELLIS,Hays Ward 2 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",85,000130
+ELLIS,Hays Ward 2 Precinct 3,State Treasurer,,Republican,"Estes, Ron",147,000130
+ELLIS,Hays Ward 2 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",92,000140
+ELLIS,Hays Ward 2 Precinct 4,State Treasurer,,Republican,"Estes, Ron",165,000140
+ELLIS,Hays Ward 2 Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",67,000150
+ELLIS,Hays Ward 2 Precinct 5,State Treasurer,,Republican,"Estes, Ron",113,000150
+ELLIS,Hays Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",87,00016A
+ELLIS,Hays Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",206,00016A
+ELLIS,Hays Ward 3 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",118,000170
+ELLIS,Hays Ward 3 Precinct 2,State Treasurer,,Republican,"Estes, Ron",368,000170
+ELLIS,Hays Ward 3 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",118,000180
+ELLIS,Hays Ward 3 Precinct 3,State Treasurer,,Republican,"Estes, Ron",440,000180
+ELLIS,Hays Ward 3 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",198,00019A
+ELLIS,Hays Ward 3 Precinct 4,State Treasurer,,Republican,"Estes, Ron",746,00019A
+ELLIS,Hays Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",104,000200
+ELLIS,Hays Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",263,000200
+ELLIS,Hays Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",131,00021A
+ELLIS,Hays Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",278,00021A
+ELLIS,Hays Ward 4 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",103,000220
+ELLIS,Hays Ward 4 Precinct 3,State Treasurer,,Republican,"Estes, Ron",278,000220
+ELLIS,Hays Ward 4 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",196,000230
+ELLIS,Hays Ward 4 Precinct 4,State Treasurer,,Republican,"Estes, Ron",508,000230
+ELLIS,Hays Ward 4 Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",130,000240
+ELLIS,Hays Ward 4 Precinct 5,State Treasurer,,Republican,"Estes, Ron",367,000240
+ELLIS,South Lookout Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000280
+ELLIS,South Lookout Township,State Treasurer,,Republican,"Estes, Ron",83,000280
+ELLIS,Victoria Township,State Treasurer,,Democratic,"Alldritt, Carmen",79,000290
+ELLIS,Victoria Township,State Treasurer,,Republican,"Estes, Ron",255,000290
+ELLIS,Wheatland Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000310
+ELLIS,Wheatland Township,State Treasurer,,Republican,"Estes, Ron",122,000310
+ELLIS,Herzog Township H110,State Treasurer,,Democratic,"Alldritt, Carmen",28,120020
+ELLIS,Herzog Township H110,State Treasurer,,Republican,"Estes, Ron",74,120020
+ELLIS,Herzog Township H111,State Treasurer,,Democratic,"Alldritt, Carmen",57,120030
+ELLIS,Herzog Township H111,State Treasurer,,Republican,"Estes, Ron",129,120030
+ELLIS,North Big Creek Township H110,State Treasurer,,Democratic,"Alldritt, Carmen",26,120040
+ELLIS,North Big Creek Township H110,State Treasurer,,Republican,"Estes, Ron",53,120040
+ELLIS,North Big Creek Township H111,State Treasurer,,Democratic,"Alldritt, Carmen",41,120050
+ELLIS,North Big Creek Township H111,State Treasurer,,Republican,"Estes, Ron",172,120050
+ELLIS,North Lookout Township H110,State Treasurer,,Democratic,"Alldritt, Carmen",12,120060
+ELLIS,North Lookout Township H110,State Treasurer,,Republican,"Estes, Ron",47,120060
+ELLIS,North Lookout Township H111,State Treasurer,,Democratic,"Alldritt, Carmen",11,120070
+ELLIS,North Lookout Township H111,State Treasurer,,Republican,"Estes, Ron",47,120070
+ELLIS,West Big Creek Township H110,State Treasurer,,Democratic,"Alldritt, Carmen",6,120080
+ELLIS,West Big Creek Township H110,State Treasurer,,Republican,"Estes, Ron",27,120080
+ELLIS,West Big Creek Township H111,State Treasurer,,Democratic,"Alldritt, Carmen",5,120090
+ELLIS,West Big Creek Township H111,State Treasurer,,Republican,"Estes, Ron",33,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900040
+ELLIS,North Big Creek Township Enclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+ELLIS,North Big Creek Township Enclave 1,State Treasurer,,Republican,"Estes, Ron",0,900050
+ELLIS,North Big Creek Township Enclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900060
+ELLIS,North Big Creek Township Enclave 2,State Treasurer,,Republican,"Estes, Ron",0,900060
+ELLIS,North Big Creek Township Enclave 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,900070
+ELLIS,North Big Creek Township Enclave 3,State Treasurer,,Republican,"Estes, Ron",0,900070
+ELLIS,North Big Creek Township Enclave 4,State Treasurer,,Democratic,"Alldritt, Carmen",0,900080
+ELLIS,North Big Creek Township Enclave 4,State Treasurer,,Republican,"Estes, Ron",0,900080
+ELLIS,Buckeye Township,United States Senate,,independent,"Orman, Greg",41,000010
+ELLIS,Buckeye Township,United States Senate,,Libertarian,"Batson, Randall",6,000010
+ELLIS,Buckeye Township,United States Senate,,Republican,"Roberts, Pat",125,000010
+ELLIS,Catherine Township,United States Senate,,independent,"Orman, Greg",38,000020
+ELLIS,Catherine Township,United States Senate,,Libertarian,"Batson, Randall",8,000020
+ELLIS,Catherine Township,United States Senate,,Republican,"Roberts, Pat",89,000020
+ELLIS,East Big Creek Township,United States Senate,,independent,"Orman, Greg",88,000030
+ELLIS,East Big Creek Township,United States Senate,,Libertarian,"Batson, Randall",10,000030
+ELLIS,East Big Creek Township,United States Senate,,Republican,"Roberts, Pat",213,000030
+ELLIS,Ellis Township,United States Senate,,independent,"Orman, Greg",55,000040
+ELLIS,Ellis Township,United States Senate,,Libertarian,"Batson, Randall",5,000040
+ELLIS,Ellis Township,United States Senate,,Republican,"Roberts, Pat",143,000040
+ELLIS,Ellis Ward 1,United States Senate,,independent,"Orman, Greg",75,000050
+ELLIS,Ellis Ward 1,United States Senate,,Libertarian,"Batson, Randall",10,000050
+ELLIS,Ellis Ward 1,United States Senate,,Republican,"Roberts, Pat",166,000050
+ELLIS,Ellis Ward 2,United States Senate,,independent,"Orman, Greg",138,000060
+ELLIS,Ellis Ward 2,United States Senate,,Libertarian,"Batson, Randall",13,000060
+ELLIS,Ellis Ward 2,United States Senate,,Republican,"Roberts, Pat",225,000060
+ELLIS,Ellis Ward 3,United States Senate,,independent,"Orman, Greg",69,000070
+ELLIS,Ellis Ward 3,United States Senate,,Libertarian,"Batson, Randall",17,000070
+ELLIS,Ellis Ward 3,United States Senate,,Republican,"Roberts, Pat",114,000070
+ELLIS,Freedom Township,United States Senate,,independent,"Orman, Greg",13,000080
+ELLIS,Freedom Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+ELLIS,Freedom Township,United States Senate,,Republican,"Roberts, Pat",29,000080
+ELLIS,Hays Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",38,000090
+ELLIS,Hays Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",4,000090
+ELLIS,Hays Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",28,000090
+ELLIS,Hays Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",64,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",13,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",97,00010A
+ELLIS,Hays Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",132,000110
+ELLIS,Hays Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",22,000110
+ELLIS,Hays Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",189,000110
+ELLIS,Hays Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",157,000120
+ELLIS,Hays Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",11,000120
+ELLIS,Hays Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",142,000120
+ELLIS,Hays Ward 2 Precinct 3,United States Senate,,independent,"Orman, Greg",102,000130
+ELLIS,Hays Ward 2 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",13,000130
+ELLIS,Hays Ward 2 Precinct 3,United States Senate,,Republican,"Roberts, Pat",123,000130
+ELLIS,Hays Ward 2 Precinct 4,United States Senate,,independent,"Orman, Greg",125,000140
+ELLIS,Hays Ward 2 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",14,000140
+ELLIS,Hays Ward 2 Precinct 4,United States Senate,,Republican,"Roberts, Pat",124,000140
+ELLIS,Hays Ward 2 Precinct 5,United States Senate,,independent,"Orman, Greg",75,000150
+ELLIS,Hays Ward 2 Precinct 5,United States Senate,,Libertarian,"Batson, Randall",17,000150
+ELLIS,Hays Ward 2 Precinct 5,United States Senate,,Republican,"Roberts, Pat",95,000150
+ELLIS,Hays Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",125,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",11,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",170,00016A
+ELLIS,Hays Ward 3 Precinct 2,United States Senate,,independent,"Orman, Greg",173,000170
+ELLIS,Hays Ward 3 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",22,000170
+ELLIS,Hays Ward 3 Precinct 2,United States Senate,,Republican,"Roberts, Pat",308,000170
+ELLIS,Hays Ward 3 Precinct 3,United States Senate,,independent,"Orman, Greg",196,000180
+ELLIS,Hays Ward 3 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",16,000180
+ELLIS,Hays Ward 3 Precinct 3,United States Senate,,Republican,"Roberts, Pat",361,000180
+ELLIS,Hays Ward 3 Precinct 4,United States Senate,,independent,"Orman, Greg",332,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",25,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States Senate,,Republican,"Roberts, Pat",625,00019A
+ELLIS,Hays Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",146,000200
+ELLIS,Hays Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",19,000200
+ELLIS,Hays Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",214,000200
+ELLIS,Hays Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",162,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",22,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",241,00021A
+ELLIS,Hays Ward 4 Precinct 3,United States Senate,,independent,"Orman, Greg",143,000220
+ELLIS,Hays Ward 4 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",17,000220
+ELLIS,Hays Ward 4 Precinct 3,United States Senate,,Republican,"Roberts, Pat",234,000220
+ELLIS,Hays Ward 4 Precinct 4,United States Senate,,independent,"Orman, Greg",282,000230
+ELLIS,Hays Ward 4 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",32,000230
+ELLIS,Hays Ward 4 Precinct 4,United States Senate,,Republican,"Roberts, Pat",418,000230
+ELLIS,Hays Ward 4 Precinct 5,United States Senate,,independent,"Orman, Greg",190,000240
+ELLIS,Hays Ward 4 Precinct 5,United States Senate,,Libertarian,"Batson, Randall",21,000240
+ELLIS,Hays Ward 4 Precinct 5,United States Senate,,Republican,"Roberts, Pat",310,000240
+ELLIS,South Lookout Township,United States Senate,,independent,"Orman, Greg",24,000280
+ELLIS,South Lookout Township,United States Senate,,Libertarian,"Batson, Randall",7,000280
+ELLIS,South Lookout Township,United States Senate,,Republican,"Roberts, Pat",82,000280
+ELLIS,Victoria Township,United States Senate,,independent,"Orman, Greg",105,000290
+ELLIS,Victoria Township,United States Senate,,Libertarian,"Batson, Randall",22,000290
+ELLIS,Victoria Township,United States Senate,,Republican,"Roberts, Pat",229,000290
+ELLIS,Wheatland Township,United States Senate,,independent,"Orman, Greg",39,000310
+ELLIS,Wheatland Township,United States Senate,,Libertarian,"Batson, Randall",6,000310
+ELLIS,Wheatland Township,United States Senate,,Republican,"Roberts, Pat",113,000310
+ELLIS,Herzog Township H110,United States Senate,,independent,"Orman, Greg",26,120020
+ELLIS,Herzog Township H110,United States Senate,,Libertarian,"Batson, Randall",7,120020
+ELLIS,Herzog Township H110,United States Senate,,Republican,"Roberts, Pat",71,120020
+ELLIS,Herzog Township H111,United States Senate,,independent,"Orman, Greg",70,120030
+ELLIS,Herzog Township H111,United States Senate,,Libertarian,"Batson, Randall",9,120030
+ELLIS,Herzog Township H111,United States Senate,,Republican,"Roberts, Pat",116,120030
+ELLIS,North Big Creek Township H110,United States Senate,,independent,"Orman, Greg",30,120040
+ELLIS,North Big Creek Township H110,United States Senate,,Libertarian,"Batson, Randall",2,120040
+ELLIS,North Big Creek Township H110,United States Senate,,Republican,"Roberts, Pat",49,120040
+ELLIS,North Big Creek Township H111,United States Senate,,independent,"Orman, Greg",69,120050
+ELLIS,North Big Creek Township H111,United States Senate,,Libertarian,"Batson, Randall",4,120050
+ELLIS,North Big Creek Township H111,United States Senate,,Republican,"Roberts, Pat",150,120050
+ELLIS,North Lookout Township H110,United States Senate,,independent,"Orman, Greg",12,120060
+ELLIS,North Lookout Township H110,United States Senate,,Libertarian,"Batson, Randall",5,120060
+ELLIS,North Lookout Township H110,United States Senate,,Republican,"Roberts, Pat",45,120060
+ELLIS,North Lookout Township H111,United States Senate,,independent,"Orman, Greg",21,120070
+ELLIS,North Lookout Township H111,United States Senate,,Libertarian,"Batson, Randall",3,120070
+ELLIS,North Lookout Township H111,United States Senate,,Republican,"Roberts, Pat",36,120070
+ELLIS,West Big Creek Township H110,United States Senate,,independent,"Orman, Greg",8,120080
+ELLIS,West Big Creek Township H110,United States Senate,,Libertarian,"Batson, Randall",0,120080
+ELLIS,West Big Creek Township H110,United States Senate,,Republican,"Roberts, Pat",25,120080
+ELLIS,West Big Creek Township H111,United States Senate,,independent,"Orman, Greg",5,120090
+ELLIS,West Big Creek Township H111,United States Senate,,Libertarian,"Batson, Randall",2,120090
+ELLIS,West Big Creek Township H111,United States Senate,,Republican,"Roberts, Pat",31,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States Senate,,independent,"Orman, Greg",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States Senate,,independent,"Orman, Greg",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States Senate,,independent,"Orman, Greg",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States Senate,,independent,"Orman, Greg",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900040
+ELLIS,North Big Creek Township Enclave 1,United States Senate,,independent,"Orman, Greg",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States Senate,,Republican,"Roberts, Pat",0,900050
+ELLIS,North Big Creek Township Enclave 2,United States Senate,,independent,"Orman, Greg",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States Senate,,Republican,"Roberts, Pat",0,900060
+ELLIS,North Big Creek Township Enclave 3,United States Senate,,independent,"Orman, Greg",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States Senate,,Libertarian,"Batson, Randall",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States Senate,,Republican,"Roberts, Pat",0,900070
+ELLIS,North Big Creek Township Enclave 4,United States Senate,,independent,"Orman, Greg",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States Senate,,Libertarian,"Batson, Randall",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States Senate,,Republican,"Roberts, Pat",0,900080

--- a/2014/20141104__ks__general__ellsworth__precinct.csv
+++ b/2014/20141104__ks__general__ellsworth__precinct.csv
@@ -1,518 +1,451 @@
-county,precinct,office,district,party,candidate,votes
-Ellsworth,Ash Creek Township,,,,Votes Cast,33
-Ellsworth,Black Wolf Township,,,,Votes Cast,44
-Ellsworth,Buckeye Township,,,,Votes Cast,32
-Ellsworth,Carneiro Township,,,,Votes Cast,26
-Ellsworth,Clear Creek Township,,,,Votes Cast,60
-Ellsworth,Columbia Township,,,,Votes Cast,27
-Ellsworth,Ellsworth City East Ward 1,,,,Votes Cast,251
-Ellsworth,Ellsworth City East Ward 2,,,,Votes Cast,295
-Ellsworth,Ellsworth City West,,,,Votes Cast,302
-Ellsworth,Canren Township,,,,Votes Cast,33
-Ellsworth,Ellsworth Township,,,,Votes Cast,81
-Ellsworth,Garfield Township,,,,Votes Cast,30
-Ellsworth,Lorraine Green Garden,,,,Votes Cast,69
-Ellsworth,Kanopolis Township,,,,Votes Cast,213
-Ellsworth,Langley Township,,,,Votes Cast,34
-Ellsworth,Lincoln Township,,,,Votes Cast,30
-Ellsworth,Mulberry Township,,,,Votes Cast,17
-Ellsworth,Noble Township,,,,Votes Cast,34
-Ellsworth,Palacky Township,,,,Votes Cast,28
-Ellsworth,Sherman Township,,,,Votes Cast,36
-Ellsworth,Thomas Township,,,,Votes Cast,32
-Ellsworth,Trivoli Township,,,,Votes Cast,26
-Ellsworth,Holyrood Valley,,,,Votes Cast,205
-Ellsworth,Venango Township,,,,Votes Cast,62
-Ellsworth,Wilson Township,,,,Votes Cast,323
-Ellsworth,Ash Creek Township,U.S. Senate,,R,Pat Roberts,28
-Ellsworth,Black Wolf Township,U.S. Senate,,R,Pat Roberts,28
-Ellsworth,Buckeye Township,U.S. Senate,,R,Pat Roberts,21
-Ellsworth,Carneiro Township,U.S. Senate,,R,Pat Roberts,18
-Ellsworth,Clear Creek Township,U.S. Senate,,R,Pat Roberts,35
-Ellsworth,Columbia Township,U.S. Senate,,R,Pat Roberts,18
-Ellsworth,Ellsworth City East Ward 1,U.S. Senate,,R,Pat Roberts,143
-Ellsworth,Ellsworth City East Ward 2,U.S. Senate,,R,Pat Roberts,171
-Ellsworth,Ellsworth City West,U.S. Senate,,R,Pat Roberts,166
-Ellsworth,Canren Township,U.S. Senate,,R,Pat Roberts,13
-Ellsworth,Ellsworth Township,U.S. Senate,,R,Pat Roberts,52
-Ellsworth,Garfield Township,U.S. Senate,,R,Pat Roberts,25
-Ellsworth,Lorraine Green Garden,U.S. Senate,,R,Pat Roberts,50
-Ellsworth,Kanopolis Township,U.S. Senate,,R,Pat Roberts,103
-Ellsworth,Langley Township,U.S. Senate,,R,Pat Roberts,29
-Ellsworth,Lincoln Township,U.S. Senate,,R,Pat Roberts,18
-Ellsworth,Mulberry Township,U.S. Senate,,R,Pat Roberts,15
-Ellsworth,Noble Township,U.S. Senate,,R,Pat Roberts,24
-Ellsworth,Palacky Township,U.S. Senate,,R,Pat Roberts,16
-Ellsworth,Sherman Township,U.S. Senate,,R,Pat Roberts,23
-Ellsworth,Thomas Township,U.S. Senate,,R,Pat Roberts,27
-Ellsworth,Trivoli Township,U.S. Senate,,R,Pat Roberts,19
-Ellsworth,Holyrood Valley,U.S. Senate,,R,Pat Roberts,131
-Ellsworth,Venango Township,U.S. Senate,,R,Pat Roberts,43
-Ellsworth,Wilson Township,U.S. Senate,,R,Pat Roberts,194
-Ellsworth,Ash Creek Township,U.S. Senate,,I,Greg Orman,5
-Ellsworth,Black Wolf Township,U.S. Senate,,I,Greg Orman,15
-Ellsworth,Buckeye Township,U.S. Senate,,I,Greg Orman,9
-Ellsworth,Carneiro Township,U.S. Senate,,I,Greg Orman,4
-Ellsworth,Clear Creek Township,U.S. Senate,,I,Greg Orman,17
-Ellsworth,Columbia Township,U.S. Senate,,I,Greg Orman,7
-Ellsworth,Ellsworth City East Ward 1,U.S. Senate,,I,Greg Orman,96
-Ellsworth,Ellsworth City East Ward 2,U.S. Senate,,I,Greg Orman,110
-Ellsworth,Ellsworth City West,U.S. Senate,,I,Greg Orman,109
-Ellsworth,Canren Township,U.S. Senate,,I,Greg Orman,19
-Ellsworth,Ellsworth Township,U.S. Senate,,I,Greg Orman,23
-Ellsworth,Garfield Township,U.S. Senate,,I,Greg Orman,4
-Ellsworth,Lorraine Green Garden,U.S. Senate,,I,Greg Orman,15
-Ellsworth,Kanopolis Township,U.S. Senate,,I,Greg Orman,89
-Ellsworth,Langley Township,U.S. Senate,,I,Greg Orman,3
-Ellsworth,Lincoln Township,U.S. Senate,,I,Greg Orman,11
-Ellsworth,Mulberry Township,U.S. Senate,,I,Greg Orman,1
-Ellsworth,Noble Township,U.S. Senate,,I,Greg Orman,7
-Ellsworth,Palacky Township,U.S. Senate,,I,Greg Orman,11
-Ellsworth,Sherman Township,U.S. Senate,,I,Greg Orman,6
-Ellsworth,Thomas Township,U.S. Senate,,I,Greg Orman,5
-Ellsworth,Trivoli Township,U.S. Senate,,I,Greg Orman,4
-Ellsworth,Holyrood Valley,U.S. Senate,,I,Greg Orman,56
-Ellsworth,Venango Township,U.S. Senate,,I,Greg Orman,16
-Ellsworth,Wilson Township,U.S. Senate,,I,Greg Orman,108
-Ellsworth,Ash Creek Township,U.S. Senate,,L,Nathan Batson,0
-Ellsworth,Black Wolf Township,U.S. Senate,,L,Nathan Batson,1
-Ellsworth,Buckeye Township,U.S. Senate,,L,Nathan Batson,1
-Ellsworth,Carneiro Township,U.S. Senate,,L,Nathan Batson,2
-Ellsworth,Clear Creek Township,U.S. Senate,,L,Nathan Batson,4
-Ellsworth,Columbia Township,U.S. Senate,,L,Nathan Batson,2
-Ellsworth,Ellsworth City East Ward 1,U.S. Senate,,L,Nathan Batson,9
-Ellsworth,Ellsworth City East Ward 2,U.S. Senate,,L,Nathan Batson,7
-Ellsworth,Ellsworth City West,U.S. Senate,,L,Nathan Batson,16
-Ellsworth,Canren Township,U.S. Senate,,L,Nathan Batson,0
-Ellsworth,Ellsworth Township,U.S. Senate,,L,Nathan Batson,2
-Ellsworth,Garfield Township,U.S. Senate,,L,Nathan Batson,0
-Ellsworth,Lorraine Green Garden,U.S. Senate,,L,Nathan Batson,2
-Ellsworth,Kanopolis Township,U.S. Senate,,L,Nathan Batson,16
-Ellsworth,Langley Township,U.S. Senate,,L,Nathan Batson,2
-Ellsworth,Lincoln Township,U.S. Senate,,L,Nathan Batson,1
-Ellsworth,Mulberry Township,U.S. Senate,,L,Nathan Batson,1
-Ellsworth,Noble Township,U.S. Senate,,L,Nathan Batson,3
-Ellsworth,Palacky Township,U.S. Senate,,L,Nathan Batson,0
-Ellsworth,Sherman Township,U.S. Senate,,L,Nathan Batson,4
-Ellsworth,Thomas Township,U.S. Senate,,L,Nathan Batson,0
-Ellsworth,Trivoli Township,U.S. Senate,,L,Nathan Batson,3
-Ellsworth,Holyrood Valley,U.S. Senate,,L,Nathan Batson,15
-Ellsworth,Venango Township,U.S. Senate,,L,Nathan Batson,3
-Ellsworth,Wilson Township,U.S. Senate,,L,Nathan Batson,19
-Ellsworth,Ash Creek Township,U.S. House,1,R,Tim Huelskamp,27
-Ellsworth,Black Wolf Township,U.S. House,1,R,Tim Huelskamp,29
-Ellsworth,Buckeye Township,U.S. House,1,R,Tim Huelskamp,22
-Ellsworth,Carneiro Township,U.S. House,1,R,Tim Huelskamp,22
-Ellsworth,Clear Creek Township,U.S. House,1,R,Tim Huelskamp,39
-Ellsworth,Columbia Township,U.S. House,1,R,Tim Huelskamp,18
-Ellsworth,Ellsworth City East Ward 1,U.S. House,1,R,Tim Huelskamp,152
-Ellsworth,Ellsworth City East Ward 2,U.S. House,1,R,Tim Huelskamp,161
-Ellsworth,Ellsworth City West,U.S. House,1,R,Tim Huelskamp,206
-Ellsworth,Canren Township,U.S. House,1,R,Tim Huelskamp,16
-Ellsworth,Ellsworth Township,U.S. House,1,R,Tim Huelskamp,55
-Ellsworth,Garfield Township,U.S. House,1,R,Tim Huelskamp,23
-Ellsworth,Lorraine Green Garden,U.S. House,1,R,Tim Huelskamp,45
-Ellsworth,Kanopolis Township,U.S. House,1,R,Tim Huelskamp,117
-Ellsworth,Langley Township,U.S. House,1,R,Tim Huelskamp,30
-Ellsworth,Lincoln Township,U.S. House,1,R,Tim Huelskamp,22
-Ellsworth,Mulberry Township,U.S. House,1,R,Tim Huelskamp,15
-Ellsworth,Noble Township,U.S. House,1,R,Tim Huelskamp,24
-Ellsworth,Palacky Township,U.S. House,1,R,Tim Huelskamp,20
-Ellsworth,Sherman Township,U.S. House,1,R,Tim Huelskamp,26
-Ellsworth,Thomas Township,U.S. House,1,R,Tim Huelskamp,28
-Ellsworth,Trivoli Township,U.S. House,1,R,Tim Huelskamp,21
-Ellsworth,Holyrood Valley,U.S. House,1,R,Tim Huelskamp,146
-Ellsworth,Venango Township,U.S. House,1,R,Tim Huelskamp,47
-Ellsworth,Wilson Township,U.S. House,1,R,Tim Huelskamp,213
-Ellsworth,Ash Creek Township,U.S. House,1,D,James Sherow,5
-Ellsworth,Black Wolf Township,U.S. House,1,D,James Sherow,13
-Ellsworth,Buckeye Township,U.S. House,1,D,James Sherow,8
-Ellsworth,Carneiro Township,U.S. House,1,D,James Sherow,2
-Ellsworth,Clear Creek Township,U.S. House,1,D,James Sherow,15
-Ellsworth,Columbia Township,U.S. House,1,D,James Sherow,8
-Ellsworth,Ellsworth City East Ward 1,U.S. House,1,D,James Sherow,90
-Ellsworth,Ellsworth City East Ward 2,U.S. House,1,D,James Sherow,122
-Ellsworth,Ellsworth City West,U.S. House,1,D,James Sherow,79
-Ellsworth,Canren Township,U.S. House,1,D,James Sherow,17
-Ellsworth,Ellsworth Township,U.S. House,1,D,James Sherow,21
-Ellsworth,Garfield Township,U.S. House,1,D,James Sherow,6
-Ellsworth,Lorraine Green Garden,U.S. House,1,D,James Sherow,19
-Ellsworth,Kanopolis Township,U.S. House,1,D,James Sherow,86
-Ellsworth,Langley Township,U.S. House,1,D,James Sherow,3
-Ellsworth,Lincoln Township,U.S. House,1,D,James Sherow,8
-Ellsworth,Mulberry Township,U.S. House,1,D,James Sherow,2
-Ellsworth,Noble Township,U.S. House,1,D,James Sherow,9
-Ellsworth,Palacky Township,U.S. House,1,D,James Sherow,7
-Ellsworth,Sherman Township,U.S. House,1,D,James Sherow,6
-Ellsworth,Thomas Township,U.S. House,1,D,James Sherow,4
-Ellsworth,Trivoli Township,U.S. House,1,D,James Sherow,4
-Ellsworth,Holyrood Valley,U.S. House,1,D,James Sherow,57
-Ellsworth,Venango Township,U.S. House,1,D,James Sherow,14
-Ellsworth,Wilson Township,U.S. House,1,D,James Sherow,101
-Ellsworth,Ash Creek Township,Governor,,R,Sam Brownback,27
-Ellsworth,Black Wolf Township,Governor,,R,Sam Brownback,26
-Ellsworth,Buckeye Township,Governor,,R,Sam Brownback,19
-Ellsworth,Carneiro Township,Governor,,R,Sam Brownback,21
-Ellsworth,Clear Creek Township,Governor,,R,Sam Brownback,31
-Ellsworth,Columbia Township,Governor,,R,Sam Brownback,20
-Ellsworth,Ellsworth City East Ward 1,Governor,,R,Sam Brownback,119
-Ellsworth,Ellsworth City East Ward 2,Governor,,R,Sam Brownback,137
-Ellsworth,Ellsworth City West,Governor,,R,Sam Brownback,150
-Ellsworth,Canren Township,Governor,,R,Sam Brownback,12
-Ellsworth,Ellsworth Township,Governor,,R,Sam Brownback,48
-Ellsworth,Garfield Township,Governor,,R,Sam Brownback,24
-Ellsworth,Lorraine Green Garden,Governor,,R,Sam Brownback,44
-Ellsworth,Kanopolis Township,Governor,,R,Sam Brownback,90
-Ellsworth,Langley Township,Governor,,R,Sam Brownback,21
-Ellsworth,Lincoln Township,Governor,,R,Sam Brownback,20
-Ellsworth,Mulberry Township,Governor,,R,Sam Brownback,13
-Ellsworth,Noble Township,Governor,,R,Sam Brownback,24
-Ellsworth,Palacky Township,Governor,,R,Sam Brownback,17
-Ellsworth,Sherman Township,Governor,,R,Sam Brownback,24
-Ellsworth,Thomas Township,Governor,,R,Sam Brownback,27
-Ellsworth,Trivoli Township,Governor,,R,Sam Brownback,19
-Ellsworth,Holyrood Valley,Governor,,R,Sam Brownback,115
-Ellsworth,Venango Township,Governor,,R,Sam Brownback,39
-Ellsworth,Wilson Township,Governor,,R,Sam Brownback,171
-Ellsworth,Ash Creek Township,Governor,,D,Paul Davis,6
-Ellsworth,Black Wolf Township,Governor,,D,Paul Davis,16
-Ellsworth,Buckeye Township,Governor,,D,Paul Davis,9
-Ellsworth,Carneiro Township,Governor,,D,Paul Davis,2
-Ellsworth,Clear Creek Township,Governor,,D,Paul Davis,23
-Ellsworth,Columbia Township,Governor,,D,Paul Davis,3
-Ellsworth,Ellsworth City East Ward 1,Governor,,D,Paul Davis,121
-Ellsworth,Ellsworth City East Ward 2,Governor,,D,Paul Davis,139
-Ellsworth,Ellsworth City West,Governor,,D,Paul Davis,130
-Ellsworth,Canren Township,Governor,,D,Paul Davis,21
-Ellsworth,Ellsworth Township,Governor,,D,Paul Davis,28
-Ellsworth,Garfield Township,Governor,,D,Paul Davis,6
-Ellsworth,Lorraine Green Garden,Governor,,D,Paul Davis,18
-Ellsworth,Kanopolis Township,Governor,,D,Paul Davis,111
-Ellsworth,Langley Township,Governor,,D,Paul Davis,9
-Ellsworth,Lincoln Township,Governor,,D,Paul Davis,9
-Ellsworth,Mulberry Township,Governor,,D,Paul Davis,1
-Ellsworth,Noble Township,Governor,,D,Paul Davis,8
-Ellsworth,Palacky Township,Governor,,D,Paul Davis,10
-Ellsworth,Sherman Township,Governor,,D,Paul Davis,10
-Ellsworth,Thomas Township,Governor,,D,Paul Davis,4
-Ellsworth,Trivoli Township,Governor,,D,Paul Davis,4
-Ellsworth,Holyrood Valley,Governor,,D,Paul Davis,81
-Ellsworth,Venango Township,Governor,,D,Paul Davis,22
-Ellsworth,Wilson Township,Governor,,D,Paul Davis,134
-Ellsworth,Ash Creek Township,Governor,,L,Keen Umbehr,0
-Ellsworth,Black Wolf Township,Governor,,L,Keen Umbehr,2
-Ellsworth,Buckeye Township,Governor,,L,Keen Umbehr,3
-Ellsworth,Carneiro Township,Governor,,L,Keen Umbehr,2
-Ellsworth,Clear Creek Township,Governor,,L,Keen Umbehr,4
-Ellsworth,Columbia Township,Governor,,L,Keen Umbehr,4
-Ellsworth,Ellsworth City East Ward 1,Governor,,L,Keen Umbehr,10
-Ellsworth,Ellsworth City East Ward 2,Governor,,L,Keen Umbehr,12
-Ellsworth,Ellsworth City West,Governor,,L,Keen Umbehr,14
-Ellsworth,Canren Township,Governor,,L,Keen Umbehr,0
-Ellsworth,Ellsworth Township,Governor,,L,Keen Umbehr,2
-Ellsworth,Garfield Township,Governor,,L,Keen Umbehr,0
-Ellsworth,Lorraine Green Garden,Governor,,L,Keen Umbehr,5
-Ellsworth,Kanopolis Township,Governor,,L,Keen Umbehr,10
-Ellsworth,Langley Township,Governor,,L,Keen Umbehr,3
-Ellsworth,Lincoln Township,Governor,,L,Keen Umbehr,1
-Ellsworth,Mulberry Township,Governor,,L,Keen Umbehr,3
-Ellsworth,Noble Township,Governor,,L,Keen Umbehr,2
-Ellsworth,Palacky Township,Governor,,L,Keen Umbehr,1
-Ellsworth,Sherman Township,Governor,,L,Keen Umbehr,2
-Ellsworth,Thomas Township,Governor,,L,Keen Umbehr,1
-Ellsworth,Trivoli Township,Governor,,L,Keen Umbehr,2
-Ellsworth,Holyrood Valley,Governor,,L,Keen Umbehr,8
-Ellsworth,Venango Township,Governor,,L,Keen Umbehr,1
-Ellsworth,Wilson Township,Governor,,L,Keen Umbehr,18
-Ellsworth,Ash Creek Township,Secretary of State,,R,Kris Kobach,28
-Ellsworth,Black Wolf Township,Secretary of State,,R,Kris Kobach,26
-Ellsworth,Buckeye Township,Secretary of State,,R,Kris Kobach,26
-Ellsworth,Carneiro Township,Secretary of State,,R,Kris Kobach,20
-Ellsworth,Clear Creek Township,Secretary of State,,R,Kris Kobach,35
-Ellsworth,Columbia Township,Secretary of State,,R,Kris Kobach,20
-Ellsworth,Ellsworth City East Ward 1,Secretary of State,,R,Kris Kobach,146
-Ellsworth,Ellsworth City East Ward 2,Secretary of State,,R,Kris Kobach,180
-Ellsworth,Ellsworth City West,Secretary of State,,R,Kris Kobach,199
-Ellsworth,Canren Township,Secretary of State,,R,Kris Kobach,15
-Ellsworth,Ellsworth Township,Secretary of State,,R,Kris Kobach,50
-Ellsworth,Garfield Township,Secretary of State,,R,Kris Kobach,22
-Ellsworth,Lorraine Green Garden,Secretary of State,,R,Kris Kobach,47
-Ellsworth,Kanopolis Township,Secretary of State,,R,Kris Kobach,119
-Ellsworth,Langley Township,Secretary of State,,R,Kris Kobach,26
-Ellsworth,Lincoln Township,Secretary of State,,R,Kris Kobach,21
-Ellsworth,Mulberry Township,Secretary of State,,R,Kris Kobach,15
-Ellsworth,Noble Township,Secretary of State,,R,Kris Kobach,25
-Ellsworth,Palacky Township,Secretary of State,,R,Kris Kobach,22
-Ellsworth,Sherman Township,Secretary of State,,R,Kris Kobach,25
-Ellsworth,Thomas Township,Secretary of State,,R,Kris Kobach,24
-Ellsworth,Trivoli Township,Secretary of State,,R,Kris Kobach,20
-Ellsworth,Holyrood Valley,Secretary of State,,R,Kris Kobach,145
-Ellsworth,Venango Township,Secretary of State,,R,Kris Kobach,50
-Ellsworth,Wilson Township,Secretary of State,,R,Kris Kobach,214
-Ellsworth,Ash Creek Township,Secretary of State,,D,Jean Schodorf,5
-Ellsworth,Black Wolf Township,Secretary of State,,D,Jean Schodorf,15
-Ellsworth,Buckeye Township,Secretary of State,,D,Jean Schodorf,5
-Ellsworth,Carneiro Township,Secretary of State,,D,Jean Schodorf,1
-Ellsworth,Clear Creek Township,Secretary of State,,D,Jean Schodorf,21
-Ellsworth,Columbia Township,Secretary of State,,D,Jean Schodorf,4
-Ellsworth,Ellsworth City East Ward 1,Secretary of State,,D,Jean Schodorf,99
-Ellsworth,Ellsworth City East Ward 2,Secretary of State,,D,Jean Schodorf,106
-Ellsworth,Ellsworth City West,Secretary of State,,D,Jean Schodorf,90
-Ellsworth,Canren Township,Secretary of State,,D,Jean Schodorf,18
-Ellsworth,Ellsworth Township,Secretary of State,,D,Jean Schodorf,25
-Ellsworth,Garfield Township,Secretary of State,,D,Jean Schodorf,7
-Ellsworth,Lorraine Green Garden,Secretary of State,,D,Jean Schodorf,17
-Ellsworth,Kanopolis Township,Secretary of State,,D,Jean Schodorf,87
-Ellsworth,Langley Township,Secretary of State,,D,Jean Schodorf,8
-Ellsworth,Lincoln Township,Secretary of State,,D,Jean Schodorf,8
-Ellsworth,Mulberry Township,Secretary of State,,D,Jean Schodorf,2
-Ellsworth,Noble Township,Secretary of State,,D,Jean Schodorf,9
-Ellsworth,Palacky Township,Secretary of State,,D,Jean Schodorf,6
-Ellsworth,Sherman Township,Secretary of State,,D,Jean Schodorf,8
-Ellsworth,Thomas Township,Secretary of State,,D,Jean Schodorf,8
-Ellsworth,Trivoli Township,Secretary of State,,D,Jean Schodorf,5
-Ellsworth,Holyrood Valley,Secretary of State,,D,Jean Schodorf,55
-Ellsworth,Venango Township,Secretary of State,,D,Jean Schodorf,12
-Ellsworth,Wilson Township,Secretary of State,,D,Jean Schodorf,103
-Ellsworth,Ash Creek Township,Attorney General,,R,Derek Schmidt,28
-Ellsworth,Black Wolf Township,Attorney General,,R,Derek Schmidt,31
-Ellsworth,Buckeye Township,Attorney General,,R,Derek Schmidt,26
-Ellsworth,Carneiro Township,Attorney General,,R,Derek Schmidt,21
-Ellsworth,Clear Creek Township,Attorney General,,R,Derek Schmidt,39
-Ellsworth,Columbia Township,Attorney General,,R,Derek Schmidt,22
-Ellsworth,Ellsworth City East Ward 1,Attorney General,,R,Derek Schmidt,182
-Ellsworth,Ellsworth City East Ward 2,Attorney General,,R,Derek Schmidt,220
-Ellsworth,Ellsworth City West,Attorney General,,R,Derek Schmidt,218
-Ellsworth,Canren Township,Attorney General,,R,Derek Schmidt,21
-Ellsworth,Ellsworth Township,Attorney General,,R,Derek Schmidt,59
-Ellsworth,Garfield Township,Attorney General,,R,Derek Schmidt,26
-Ellsworth,Lorraine Green Garden,Attorney General,,R,Derek Schmidt,49
-Ellsworth,Kanopolis Township,Attorney General,,R,Derek Schmidt,127
-Ellsworth,Langley Township,Attorney General,,R,Derek Schmidt,27
-Ellsworth,Lincoln Township,Attorney General,,R,Derek Schmidt,22
-Ellsworth,Mulberry Township,Attorney General,,R,Derek Schmidt,15
-Ellsworth,Noble Township,Attorney General,,R,Derek Schmidt,24
-Ellsworth,Palacky Township,Attorney General,,R,Derek Schmidt,22
-Ellsworth,Sherman Township,Attorney General,,R,Derek Schmidt,30
-Ellsworth,Thomas Township,Attorney General,,R,Derek Schmidt,28
-Ellsworth,Trivoli Township,Attorney General,,R,Derek Schmidt,22
-Ellsworth,Holyrood Valley,Attorney General,,R,Derek Schmidt,150
-Ellsworth,Venango Township,Attorney General,,R,Derek Schmidt,50
-Ellsworth,Wilson Township,Attorney General,,R,Derek Schmidt,225
-Ellsworth,Ash Creek Township,Attorney General,,D,AJ Kotich,4
-Ellsworth,Black Wolf Township,Attorney General,,D,AJ Kotich,10
-Ellsworth,Buckeye Township,Attorney General,,D,AJ Kotich,5
-Ellsworth,Carneiro Township,Attorney General,,D,AJ Kotich,2
-Ellsworth,Clear Creek Township,Attorney General,,D,AJ Kotich,13
-Ellsworth,Columbia Township,Attorney General,,D,AJ Kotich,3
-Ellsworth,Ellsworth City East Ward 1,Attorney General,,D,AJ Kotich,57
-Ellsworth,Ellsworth City East Ward 2,Attorney General,,D,AJ Kotich,58
-Ellsworth,Ellsworth City West,Attorney General,,D,AJ Kotich,65
-Ellsworth,Canren Township,Attorney General,,D,AJ Kotich,11
-Ellsworth,Ellsworth Township,Attorney General,,D,AJ Kotich,13
-Ellsworth,Garfield Township,Attorney General,,D,AJ Kotich,3
-Ellsworth,Lorraine Green Garden,Attorney General,,D,AJ Kotich,16
-Ellsworth,Kanopolis Township,Attorney General,,D,AJ Kotich,70
-Ellsworth,Langley Township,Attorney General,,D,AJ Kotich,5
-Ellsworth,Lincoln Township,Attorney General,,D,AJ Kotich,4
-Ellsworth,Mulberry Township,Attorney General,,D,AJ Kotich,1
-Ellsworth,Noble Township,Attorney General,,D,AJ Kotich,7
-Ellsworth,Palacky Township,Attorney General,,D,AJ Kotich,5
-Ellsworth,Sherman Township,Attorney General,,D,AJ Kotich,3
-Ellsworth,Thomas Township,Attorney General,,D,AJ Kotich,3
-Ellsworth,Trivoli Township,Attorney General,,D,AJ Kotich,3
-Ellsworth,Holyrood Valley,Attorney General,,D,AJ Kotich,52
-Ellsworth,Venango Township,Attorney General,,D,AJ Kotich,11
-Ellsworth,Wilson Township,Attorney General,,D,AJ Kotich,86
-Ellsworth,Ash Creek Township,State Treasurer,,R,Ron Estes,29
-Ellsworth,Black Wolf Township,State Treasurer,,R,Ron Estes,32
-Ellsworth,Buckeye Township,State Treasurer,,R,Ron Estes,25
-Ellsworth,Carneiro Township,State Treasurer,,R,Ron Estes,21
-Ellsworth,Clear Creek Township,State Treasurer,,R,Ron Estes,40
-Ellsworth,Columbia Township,State Treasurer,,R,Ron Estes,21
-Ellsworth,Ellsworth City East Ward 1,State Treasurer,,R,Ron Estes,173
-Ellsworth,Ellsworth City East Ward 2,State Treasurer,,R,Ron Estes,218
-Ellsworth,Ellsworth City West,State Treasurer,,R,Ron Estes,227
-Ellsworth,Canren Township,State Treasurer,,R,Ron Estes,22
-Ellsworth,Ellsworth Township,State Treasurer,,R,Ron Estes,60
-Ellsworth,Garfield Township,State Treasurer,,R,Ron Estes,25
-Ellsworth,Lorraine Green Garden,State Treasurer,,R,Ron Estes,55
-Ellsworth,Kanopolis Township,State Treasurer,,R,Ron Estes,133
-Ellsworth,Langley Township,State Treasurer,,R,Ron Estes,26
-Ellsworth,Lincoln Township,State Treasurer,,R,Ron Estes,24
-Ellsworth,Mulberry Township,State Treasurer,,R,Ron Estes,16
-Ellsworth,Noble Township,State Treasurer,,R,Ron Estes,25
-Ellsworth,Palacky Township,State Treasurer,,R,Ron Estes,24
-Ellsworth,Sherman Township,State Treasurer,,R,Ron Estes,33
-Ellsworth,Thomas Township,State Treasurer,,R,Ron Estes,27
-Ellsworth,Trivoli Township,State Treasurer,,R,Ron Estes,20
-Ellsworth,Holyrood Valley,State Treasurer,,R,Ron Estes,155
-Ellsworth,Venango Township,State Treasurer,,R,Ron Estes,53
-Ellsworth,Wilson Township,State Treasurer,,R,Ron Estes,230
-Ellsworth,Ash Creek Township,State Treasurer,,D,Carmen Alldritt,3
-Ellsworth,Black Wolf Township,State Treasurer,,D,Carmen Alldritt,9
-Ellsworth,Buckeye Township,State Treasurer,,D,Carmen Alldritt,6
-Ellsworth,Carneiro Township,State Treasurer,,D,Carmen Alldritt,1
-Ellsworth,Clear Creek Township,State Treasurer,,D,Carmen Alldritt,10
-Ellsworth,Columbia Township,State Treasurer,,D,Carmen Alldritt,3
-Ellsworth,Ellsworth City East Ward 1,State Treasurer,,D,Carmen Alldritt,68
-Ellsworth,Ellsworth City East Ward 2,State Treasurer,,D,Carmen Alldritt,58
-Ellsworth,Ellsworth City West,State Treasurer,,D,Carmen Alldritt,63
-Ellsworth,Canren Township,State Treasurer,,D,Carmen Alldritt,10
-Ellsworth,Ellsworth Township,State Treasurer,,D,Carmen Alldritt,13
-Ellsworth,Garfield Township,State Treasurer,,D,Carmen Alldritt,3
-Ellsworth,Lorraine Green Garden,State Treasurer,,D,Carmen Alldritt,10
-Ellsworth,Kanopolis Township,State Treasurer,,D,Carmen Alldritt,63
-Ellsworth,Langley Township,State Treasurer,,D,Carmen Alldritt,6
-Ellsworth,Lincoln Township,State Treasurer,,D,Carmen Alldritt,5
-Ellsworth,Mulberry Township,State Treasurer,,D,Carmen Alldritt,1
-Ellsworth,Noble Township,State Treasurer,,D,Carmen Alldritt,7
-Ellsworth,Palacky Township,State Treasurer,,D,Carmen Alldritt,4
-Ellsworth,Sherman Township,State Treasurer,,D,Carmen Alldritt,1
-Ellsworth,Thomas Township,State Treasurer,,D,Carmen Alldritt,4
-Ellsworth,Trivoli Township,State Treasurer,,D,Carmen Alldritt,5
-Ellsworth,Holyrood Valley,State Treasurer,,D,Carmen Alldritt,46
-Ellsworth,Venango Township,State Treasurer,,D,Carmen Alldritt,7
-Ellsworth,Wilson Township,State Treasurer,,D,Carmen Alldritt,81
-Ellsworth,Ash Creek Township,Insurance Commissioner,,R,Ken Selzer,26
-Ellsworth,Black Wolf Township,Insurance Commissioner,,R,Ken Selzer,28
-Ellsworth,Buckeye Township,Insurance Commissioner,,R,Ken Selzer,22
-Ellsworth,Carneiro Township,Insurance Commissioner,,R,Ken Selzer,20
-Ellsworth,Clear Creek Township,Insurance Commissioner,,R,Ken Selzer,31
-Ellsworth,Columbia Township,Insurance Commissioner,,R,Ken Selzer,20
-Ellsworth,Ellsworth City East Ward 1,Insurance Commissioner,,R,Ken Selzer,157
-Ellsworth,Ellsworth City East Ward 2,Insurance Commissioner,,R,Ken Selzer,181
-Ellsworth,Ellsworth City West,Insurance Commissioner,,R,Ken Selzer,202
-Ellsworth,Canren Township,Insurance Commissioner,,R,Ken Selzer,16
-Ellsworth,Ellsworth Township,Insurance Commissioner,,R,Ken Selzer,53
-Ellsworth,Garfield Township,Insurance Commissioner,,R,Ken Selzer,23
-Ellsworth,Lorraine Green Garden,Insurance Commissioner,,R,Ken Selzer,52
-Ellsworth,Kanopolis Township,Insurance Commissioner,,R,Ken Selzer,113
-Ellsworth,Langley Township,Insurance Commissioner,,R,Ken Selzer,30
-Ellsworth,Lincoln Township,Insurance Commissioner,,R,Ken Selzer,21
-Ellsworth,Mulberry Township,Insurance Commissioner,,R,Ken Selzer,17
-Ellsworth,Noble Township,Insurance Commissioner,,R,Ken Selzer,23
-Ellsworth,Palacky Township,Insurance Commissioner,,R,Ken Selzer,21
-Ellsworth,Sherman Township,Insurance Commissioner,,R,Ken Selzer,28
-Ellsworth,Thomas Township,Insurance Commissioner,,R,Ken Selzer,26
-Ellsworth,Trivoli Township,Insurance Commissioner,,R,Ken Selzer,19
-Ellsworth,Holyrood Valley,Insurance Commissioner,,R,Ken Selzer,141
-Ellsworth,Venango Township,Insurance Commissioner,,R,Ken Selzer,45
-Ellsworth,Wilson Township,Insurance Commissioner,,R,Ken Selzer,205
-Ellsworth,Ash Creek Township,Insurance Commissioner,,D,Dennis Anderson,4
-Ellsworth,Black Wolf Township,Insurance Commissioner,,D,Dennis Anderson,10
-Ellsworth,Buckeye Township,Insurance Commissioner,,D,Dennis Anderson,5
-Ellsworth,Carneiro Township,Insurance Commissioner,,D,Dennis Anderson,1
-Ellsworth,Clear Creek Township,Insurance Commissioner,,D,Dennis Anderson,15
-Ellsworth,Columbia Township,Insurance Commissioner,,D,Dennis Anderson,3
-Ellsworth,Ellsworth City East Ward 1,Insurance Commissioner,,D,Dennis Anderson,72
-Ellsworth,Ellsworth City East Ward 2,Insurance Commissioner,,D,Dennis Anderson,83
-Ellsworth,Ellsworth City West,Insurance Commissioner,,D,Dennis Anderson,76
-Ellsworth,Canren Township,Insurance Commissioner,,D,Dennis Anderson,17
-Ellsworth,Ellsworth Township,Insurance Commissioner,,D,Dennis Anderson,18
-Ellsworth,Garfield Township,Insurance Commissioner,,D,Dennis Anderson,3
-Ellsworth,Lorraine Green Garden,Insurance Commissioner,,D,Dennis Anderson,12
-Ellsworth,Kanopolis Township,Insurance Commissioner,,D,Dennis Anderson,81
-Ellsworth,Langley Township,Insurance Commissioner,,D,Dennis Anderson,3
-Ellsworth,Lincoln Township,Insurance Commissioner,,D,Dennis Anderson,7
-Ellsworth,Mulberry Township,Insurance Commissioner,,D,Dennis Anderson,0
-Ellsworth,Noble Township,Insurance Commissioner,,D,Dennis Anderson,9
-Ellsworth,Palacky Township,Insurance Commissioner,,D,Dennis Anderson,6
-Ellsworth,Sherman Township,Insurance Commissioner,,D,Dennis Anderson,6
-Ellsworth,Thomas Township,Insurance Commissioner,,D,Dennis Anderson,4
-Ellsworth,Trivoli Township,Insurance Commissioner,,D,Dennis Anderson,5
-Ellsworth,Holyrood Valley,Insurance Commissioner,,D,Dennis Anderson,56
-Ellsworth,Venango Township,Insurance Commissioner,,D,Dennis Anderson,13
-Ellsworth,Wilson Township,Insurance Commissioner,,D,Dennis Anderson,101
-Ellsworth,Ash Creek Township,State Senate,35,R,Richard Wilborn,29
-Ellsworth,Black Wolf Township,State Senate,35,R,Richard Wilborn,28
-Ellsworth,Buckeye Township,State Senate,35,R,Richard Wilborn,26
-Ellsworth,Carniero Twp,State Senate,35,R,Richard Wilborn,20
-Ellsworth,Clear Creek Township,State Senate,35,R,Richard Wilborn,40
-Ellsworth,Columbia Township,State Senate,35,R,Richard Wilborn,20
-Ellsworth,Ellsworth City East Ward 1,State Senate,35,R,Richard Wilborn,190
-Ellsworth,Ellsworth City East Ward 2,State Senate,35,R,Richard Wilborn,253
-Ellsworth,Ellsworth City West,State Senate,35,R,Richard Wilborn,236
-Ellsworth,Canren Township,State Senate,35,R,Richard Wilborn,21
-Ellsworth,Ellsworth Township,State Senate,35,R,Richard Wilborn,67
-Ellsworth,Garfield Township,State Senate,35,R,Richard Wilborn,25
-Ellsworth,Green Garden Township,State Senate,35,R,Richard Wilborn,51
-Ellsworth,Kanopolis Township,State Senate,35,R,Richard Wilborn,150
-Ellsworth,Langley Township,State Senate,35,R,Richard Wilborn,31
-Ellsworth,Lincoln Township,State Senate,35,R,Richard Wilborn,26
-Ellsworth,Mulberry Township,State Senate,35,R,Richard Wilborn,16
-Ellsworth,Noble Township,State Senate,35,R,Richard Wilborn,25
-Ellsworth,Palacky Township,State Senate,35,R,Richard Wilborn,21
-Ellsworth,Sherman Township,State Senate,35,R,Richard Wilborn,29
-Ellsworth,Thomas Township,State Senate,35,R,Richard Wilborn,30
-Ellsworth,Trivoli Township,State Senate,35,R,Richard Wilborn,19
-Ellsworth,Valley Township,State Senate,35,R,Richard Wilborn,178
-Ellsworth,Venango Township,State Senate,35,R,Richard Wilborn,57
-Ellsworth,Wilson Township,State Senate,35,R,Richard Wilborn,260
-Ellsworth,Ash Creek Township,State House,108,R,Steven Johnson,29
-Ellsworth,Black Wolf Township,State House,108,R,Steven Johnson,33
-Ellsworth,Buckeye Township,State House,108,R,Steven Johnson,28
-Ellsworth,Carneiro Township,State House,108,R,Steven Johnson,19
-Ellsworth,Clear Creek Township,State House,108,R,Steven Johnson,45
-Ellsworth,Columbia Township,State House,108,R,Steven Johnson,23
-Ellsworth,Ellsworth City East Ward 1,State House,108,R,Steven Johnson,195
-Ellsworth,Ellsworth City East Ward 2,State House,108,R,Steven Johnson,260
-Ellsworth,Ellsworth City West,State House,108,R,Steven Johnson,237
-Ellsworth,Canren Township,State House,108,R,Steven Johnson,22
-Ellsworth,Ellsworth Township,State House,108,R,Steven Johnson,67
-Ellsworth,Garfield Township,State House,108,R,Steven Johnson,29
-Ellsworth,Lorraine Green Garden,State House,108,R,Steven Johnson,54
-Ellsworth,Kanopolis Township,State House,108,R,Steven Johnson,170
-Ellsworth,Langley Township,State House,108,R,Steven Johnson,31
-Ellsworth,Lincoln Township,State House,108,R,Steven Johnson,26
-Ellsworth,Mulberry Township,State House,108,R,Steven Johnson,15
-Ellsworth,Noble Township,State House,108,R,Steven Johnson,24
-Ellsworth,Palacky Township,State House,108,R,Steven Johnson,22
-Ellsworth,Sherman Township,State House,108,R,Steven Johnson,32
-Ellsworth,Thomas Township,State House,108,R,Steven Johnson,31
-Ellsworth,Trivoli Township,State House,108,R,Steven Johnson,19
-Ellsworth,Holyrood Valley,State House,108,R,Steven Johnson,174
-Ellsworth,Venango Township,State House,108,R,Steven Johnson,56
-Ellsworth,Wilson Township,State House,108,R,Steven Johnson,264
-Ellsworth,Carneiro Township,State House,108,,Write-ins,1
-Ellsworth,Clear Creek Township,Attorney General,,,Write-ins,1
-Ellsworth,Clear Creek Township,State Treasurer,,,Write-ins,1
-Ellsworth,Clear Creek Township,Insurance Commissioner,,,Write-ins,1
-Ellsworth,Clear Creek Township,State Senate,35,,Write-ins,1
-Ellsworth,Clear Creek Township,State House,108,,Write-ins,1
-Ellsworth,Columbia Township,U.S. House,1,,Write-ins,1
-Ellsworth,Columbia Township,Secretary of State,,,Write-ins,1
-Ellsworth,Columbia Township,Insurance Commissioner,,,Write-ins,1
-Ellsworth,Venango Township,State Senate,35,,Write-ins,1
-Ellsworth,Venango Township,State House,108,,Write-ins,2
-Ellsworth,Sherman Township,U.S. Senate,,,Write-ins,1
-Ellsworth,Sherman Township,Secretary of State,,,Write-ins,1
-Ellsworth,Trivoli Township,State Senate,35,,Write-ins,1
-Ellsworth,Trivoli Township,State House,108,,Write-ins,1
-Ellsworth,Ellsworth City East Ward 1,U.S. House,1,,Write-ins,2
-Ellsworth,Ellsworth City East Ward 1,Attorney General,,,Write-ins,1
-Ellsworth,Ellsworth City East Ward 1,State Senate,35,,Write-ins,6
-Ellsworth,Ellsworth City East Ward 1,State House,108,,Write-ins,5
-Ellsworth,Ellsworth City East Ward 2,U.S. Senate,,,Write-ins,1
-Ellsworth,Ellsworth City East Ward 2,U.S. House,1,,Write-ins,1
-Ellsworth,Ellsworth City East Ward 2,Governor,,,Write-ins,1
-Ellsworth,Ellsworth City East Ward 2,Secretary of State,,,Write-ins,2
-Ellsworth,Ellsworth City East Ward 2,Attorney General,,,Write-ins,1
-Ellsworth,Ellsworth City East Ward 2,State Treasurer,,,Write-ins,1
-Ellsworth,Ellsworth City East Ward 2,State House,108,,Write-ins,1
-Ellsworth,Ellsworth City West,U.S. Senate,,,Write-ins,2
-Ellsworth,Ellsworth City West,U.S. House,1,,Write-ins,1
-Ellsworth,Ellsworth City West,Governor,,,Write-ins,2
-Ellsworth,Ellsworth City West,Attorney General,,,Write-ins,1
-Ellsworth,Ellsworth City West,State Senate,35,,Write-ins,2
-Ellsworth,Ellsworth City West,State House,108,,Write-ins,2
-Ellsworth,Kanopolis Township,State Senate,35,,Write-ins,1
-Ellsworth,Lorraine Twp,State Senate,35,,Write-ins,2
-Ellsworth,Lorraine Twp,State House,108,,Write-ins,1
-Ellsworth,Holyrood,Insurance Commissioner,,,Write-ins,1
-Ellsworth,Holyrood,State Senate,35,,Write-ins,1
-Ellsworth,Holyrood,State House,108,,Write-ins,2
-Ellsworth,Wilson Township,State House,108,,Write-ins,1
-Ellsworth,Canren Township,State Treasurer,,,Write-ins,1
-Ellsworth,Canren Township,State Senate,35,,Write-ins,1
-Ellsworth,Canren Township,State House,108,,Write-ins,1
+county,precinct,office,district,party,candidate,votes,vtd
+ELLSWORTH,Ash Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000010
+ELLSWORTH,Ash Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+ELLSWORTH,Ash Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000010
+ELLSWORTH,Black Wolf Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000020
+ELLSWORTH,Black Wolf Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+ELLSWORTH,Black Wolf Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000020
+ELLSWORTH,Buckeye Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000030
+ELLSWORTH,Buckeye Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000030
+ELLSWORTH,Buckeye Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000030
+ELLSWORTH,Carneiro Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000040
+ELLSWORTH,Carneiro Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+ELLSWORTH,Carneiro Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000040
+ELLSWORTH,Clear Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000050
+ELLSWORTH,Clear Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000050
+ELLSWORTH,Clear Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000050
+ELLSWORTH,Columbia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000060
+ELLSWORTH,Columbia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000060
+ELLSWORTH,Columbia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000060
+ELLSWORTH,Ellsworth City East Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",121,000070
+ELLSWORTH,Ellsworth City East Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000070
+ELLSWORTH,Ellsworth City East Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000070
+ELLSWORTH,Ellsworth City East Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",139,000080
+ELLSWORTH,Ellsworth City East Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000080
+ELLSWORTH,Ellsworth City East Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",137,000080
+ELLSWORTH,Ellsworth City West,Governor / Lt. Governor,,Democratic,"Davis, Paul",130,00009A
+ELLSWORTH,Ellsworth City West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00009A
+ELLSWORTH,Ellsworth City West,Governor / Lt. Governor,,Republican,"Brownback, Sam",150,00009A
+ELLSWORTH,Canren Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,00009B
+ELLSWORTH,Canren Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00009B
+ELLSWORTH,Canren Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,00009B
+ELLSWORTH,Ellsworth Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000100
+ELLSWORTH,Ellsworth Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000100
+ELLSWORTH,Ellsworth Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000100
+ELLSWORTH,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000110
+ELLSWORTH,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+ELLSWORTH,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000110
+ELLSWORTH,Green Garden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000120
+ELLSWORTH,Green Garden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000120
+ELLSWORTH,Green Garden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000120
+ELLSWORTH,Kanopolis Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,000130
+ELLSWORTH,Kanopolis Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000130
+ELLSWORTH,Kanopolis Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",90,000130
+ELLSWORTH,Langley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000140
+ELLSWORTH,Langley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000140
+ELLSWORTH,Langley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000140
+ELLSWORTH,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000150
+ELLSWORTH,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+ELLSWORTH,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000150
+ELLSWORTH,Mulberry Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000160
+ELLSWORTH,Mulberry Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000160
+ELLSWORTH,Mulberry Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000160
+ELLSWORTH,Noble Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000170
+ELLSWORTH,Noble Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000170
+ELLSWORTH,Noble Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000170
+ELLSWORTH,Palacky Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000180
+ELLSWORTH,Palacky Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000180
+ELLSWORTH,Palacky Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000180
+ELLSWORTH,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000190
+ELLSWORTH,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000190
+ELLSWORTH,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000190
+ELLSWORTH,Thomas Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000200
+ELLSWORTH,Thomas Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000200
+ELLSWORTH,Thomas Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000200
+ELLSWORTH,Trivoli Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000210
+ELLSWORTH,Trivoli Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000210
+ELLSWORTH,Trivoli Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000210
+ELLSWORTH,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000220
+ELLSWORTH,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000220
+ELLSWORTH,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000220
+ELLSWORTH,Venango Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000230
+ELLSWORTH,Venango Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000230
+ELLSWORTH,Venango Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000230
+ELLSWORTH,Wilson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",134,000240
+ELLSWORTH,Wilson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000240
+ELLSWORTH,Wilson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",171,000240
+ELLSWORTH,Ash Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",29,000010
+ELLSWORTH,Black Wolf Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",33,000020
+ELLSWORTH,Buckeye Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",28,000030
+ELLSWORTH,Carneiro Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",19,000040
+ELLSWORTH,Clear Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",45,000050
+ELLSWORTH,Columbia Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",23,000060
+ELLSWORTH,Ellsworth City East Ward 1,Kansas House of Representatives,108,Republican,"Johnson, Steven",195,000070
+ELLSWORTH,Ellsworth City East Ward 2,Kansas House of Representatives,108,Republican,"Johnson, Steven",260,000080
+ELLSWORTH,Ellsworth City West,Kansas House of Representatives,108,Republican,"Johnson, Steven",237,00009A
+ELLSWORTH,Canren Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",22,00009B
+ELLSWORTH,Ellsworth Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",67,000100
+ELLSWORTH,Garfield Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",29,000110
+ELLSWORTH,Green Garden Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",54,000120
+ELLSWORTH,Kanopolis Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",170,000130
+ELLSWORTH,Langley Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",31,000140
+ELLSWORTH,Lincoln Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",26,000150
+ELLSWORTH,Mulberry Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",15,000160
+ELLSWORTH,Noble Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",24,000170
+ELLSWORTH,Palacky Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",22,000180
+ELLSWORTH,Sherman Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",32,000190
+ELLSWORTH,Thomas Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",31,000200
+ELLSWORTH,Trivoli Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",19,000210
+ELLSWORTH,Valley Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",174,000220
+ELLSWORTH,Venango Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",56,000230
+ELLSWORTH,Wilson Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",264,000240
+ELLSWORTH,Ash Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000010
+ELLSWORTH,Ash Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000010
+ELLSWORTH,Black Wolf Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000020
+ELLSWORTH,Black Wolf Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000020
+ELLSWORTH,Buckeye Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000030
+ELLSWORTH,Buckeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000030
+ELLSWORTH,Carneiro Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000040
+ELLSWORTH,Carneiro Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000040
+ELLSWORTH,Clear Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000050
+ELLSWORTH,Clear Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000050
+ELLSWORTH,Columbia Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000060
+ELLSWORTH,Columbia Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000060
+ELLSWORTH,Ellsworth City East Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",90,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",152,000070
+ELLSWORTH,Ellsworth City East Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",122,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",161,000080
+ELLSWORTH,Ellsworth City West,United States House of Representatives,1,Democratic,"Sherow, James E.",79,00009A
+ELLSWORTH,Ellsworth City West,United States House of Representatives,1,Republican,"Huelskamp, Tim",206,00009A
+ELLSWORTH,Canren Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,00009B
+ELLSWORTH,Canren Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,00009B
+ELLSWORTH,Ellsworth Township,United States House of Representatives,1,Democratic,"Sherow, James E.",21,000100
+ELLSWORTH,Ellsworth Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000100
+ELLSWORTH,Garfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000110
+ELLSWORTH,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000110
+ELLSWORTH,Green Garden Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000120
+ELLSWORTH,Green Garden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000120
+ELLSWORTH,Kanopolis Township,United States House of Representatives,1,Democratic,"Sherow, James E.",86,000130
+ELLSWORTH,Kanopolis Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",117,000130
+ELLSWORTH,Langley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000140
+ELLSWORTH,Langley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000140
+ELLSWORTH,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000150
+ELLSWORTH,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000150
+ELLSWORTH,Mulberry Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000160
+ELLSWORTH,Mulberry Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000160
+ELLSWORTH,Noble Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000170
+ELLSWORTH,Noble Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000170
+ELLSWORTH,Palacky Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000180
+ELLSWORTH,Palacky Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000180
+ELLSWORTH,Sherman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000190
+ELLSWORTH,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000190
+ELLSWORTH,Thomas Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000200
+ELLSWORTH,Thomas Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000200
+ELLSWORTH,Trivoli Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000210
+ELLSWORTH,Trivoli Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000210
+ELLSWORTH,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",57,000220
+ELLSWORTH,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",146,000220
+ELLSWORTH,Venango Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000230
+ELLSWORTH,Venango Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000230
+ELLSWORTH,Wilson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",101,000240
+ELLSWORTH,Wilson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",213,000240
+ELLSWORTH,Ash Creek Township,Attorney General,,Democratic,"Kotich, A.J.",4,000010
+ELLSWORTH,Ash Creek Township,Attorney General,,Republican,"Schmidt, Derek",28,000010
+ELLSWORTH,Black Wolf Township,Attorney General,,Democratic,"Kotich, A.J.",10,000020
+ELLSWORTH,Black Wolf Township,Attorney General,,Republican,"Schmidt, Derek",31,000020
+ELLSWORTH,Buckeye Township,Attorney General,,Democratic,"Kotich, A.J.",5,000030
+ELLSWORTH,Buckeye Township,Attorney General,,Republican,"Schmidt, Derek",26,000030
+ELLSWORTH,Carneiro Township,Attorney General,,Democratic,"Kotich, A.J.",2,000040
+ELLSWORTH,Carneiro Township,Attorney General,,Republican,"Schmidt, Derek",21,000040
+ELLSWORTH,Clear Creek Township,Attorney General,,Democratic,"Kotich, A.J.",13,000050
+ELLSWORTH,Clear Creek Township,Attorney General,,Republican,"Schmidt, Derek",39,000050
+ELLSWORTH,Columbia Township,Attorney General,,Democratic,"Kotich, A.J.",3,000060
+ELLSWORTH,Columbia Township,Attorney General,,Republican,"Schmidt, Derek",22,000060
+ELLSWORTH,Ellsworth City East Ward 1,Attorney General,,Democratic,"Kotich, A.J.",57,000070
+ELLSWORTH,Ellsworth City East Ward 1,Attorney General,,Republican,"Schmidt, Derek",182,000070
+ELLSWORTH,Ellsworth City East Ward 2,Attorney General,,Democratic,"Kotich, A.J.",58,000080
+ELLSWORTH,Ellsworth City East Ward 2,Attorney General,,Republican,"Schmidt, Derek",220,000080
+ELLSWORTH,Ellsworth City West,Attorney General,,Democratic,"Kotich, A.J.",65,00009A
+ELLSWORTH,Ellsworth City West,Attorney General,,Republican,"Schmidt, Derek",218,00009A
+ELLSWORTH,Canren Township,Attorney General,,Democratic,"Kotich, A.J.",11,00009B
+ELLSWORTH,Canren Township,Attorney General,,Republican,"Schmidt, Derek",21,00009B
+ELLSWORTH,Ellsworth Township,Attorney General,,Democratic,"Kotich, A.J.",13,000100
+ELLSWORTH,Ellsworth Township,Attorney General,,Republican,"Schmidt, Derek",59,000100
+ELLSWORTH,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",3,000110
+ELLSWORTH,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",26,000110
+ELLSWORTH,Green Garden Township,Attorney General,,Democratic,"Kotich, A.J.",16,000120
+ELLSWORTH,Green Garden Township,Attorney General,,Republican,"Schmidt, Derek",49,000120
+ELLSWORTH,Kanopolis Township,Attorney General,,Democratic,"Kotich, A.J.",70,000130
+ELLSWORTH,Kanopolis Township,Attorney General,,Republican,"Schmidt, Derek",127,000130
+ELLSWORTH,Langley Township,Attorney General,,Democratic,"Kotich, A.J.",5,000140
+ELLSWORTH,Langley Township,Attorney General,,Republican,"Schmidt, Derek",27,000140
+ELLSWORTH,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",4,000150
+ELLSWORTH,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",22,000150
+ELLSWORTH,Mulberry Township,Attorney General,,Democratic,"Kotich, A.J.",1,000160
+ELLSWORTH,Mulberry Township,Attorney General,,Republican,"Schmidt, Derek",15,000160
+ELLSWORTH,Noble Township,Attorney General,,Democratic,"Kotich, A.J.",7,000170
+ELLSWORTH,Noble Township,Attorney General,,Republican,"Schmidt, Derek",24,000170
+ELLSWORTH,Palacky Township,Attorney General,,Democratic,"Kotich, A.J.",5,000180
+ELLSWORTH,Palacky Township,Attorney General,,Republican,"Schmidt, Derek",22,000180
+ELLSWORTH,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",3,000190
+ELLSWORTH,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",30,000190
+ELLSWORTH,Thomas Township,Attorney General,,Democratic,"Kotich, A.J.",3,000200
+ELLSWORTH,Thomas Township,Attorney General,,Republican,"Schmidt, Derek",28,000200
+ELLSWORTH,Trivoli Township,Attorney General,,Democratic,"Kotich, A.J.",3,000210
+ELLSWORTH,Trivoli Township,Attorney General,,Republican,"Schmidt, Derek",22,000210
+ELLSWORTH,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",52,000220
+ELLSWORTH,Valley Township,Attorney General,,Republican,"Schmidt, Derek",150,000220
+ELLSWORTH,Venango Township,Attorney General,,Democratic,"Kotich, A.J.",11,000230
+ELLSWORTH,Venango Township,Attorney General,,Republican,"Schmidt, Derek",50,000230
+ELLSWORTH,Wilson Township,Attorney General,,Democratic,"Kotich, A.J.",86,000240
+ELLSWORTH,Wilson Township,Attorney General,,Republican,"Schmidt, Derek",225,000240
+ELLSWORTH,Ash Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000010
+ELLSWORTH,Ash Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000010
+ELLSWORTH,Black Wolf Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000020
+ELLSWORTH,Black Wolf Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000020
+ELLSWORTH,Buckeye Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000030
+ELLSWORTH,Buckeye Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000030
+ELLSWORTH,Carneiro Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000040
+ELLSWORTH,Carneiro Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000040
+ELLSWORTH,Clear Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000050
+ELLSWORTH,Clear Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000050
+ELLSWORTH,Columbia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000060
+ELLSWORTH,Columbia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000060
+ELLSWORTH,Ellsworth City East Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000070
+ELLSWORTH,Ellsworth City East Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",157,000070
+ELLSWORTH,Ellsworth City East Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",83,000080
+ELLSWORTH,Ellsworth City East Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",181,000080
+ELLSWORTH,Ellsworth City West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,00009A
+ELLSWORTH,Ellsworth City West,Commissioner of Insurance,,Republican,"Selzer, Ken",202,00009A
+ELLSWORTH,Canren Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,00009B
+ELLSWORTH,Canren Township,Commissioner of Insurance,,Republican,"Selzer, Ken",16,00009B
+ELLSWORTH,Ellsworth Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000100
+ELLSWORTH,Ellsworth Township,Commissioner of Insurance,,Republican,"Selzer, Ken",53,000100
+ELLSWORTH,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000110
+ELLSWORTH,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000110
+ELLSWORTH,Green Garden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000120
+ELLSWORTH,Green Garden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",52,000120
+ELLSWORTH,Kanopolis Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000130
+ELLSWORTH,Kanopolis Township,Commissioner of Insurance,,Republican,"Selzer, Ken",113,000130
+ELLSWORTH,Langley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000140
+ELLSWORTH,Langley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000140
+ELLSWORTH,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000150
+ELLSWORTH,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000150
+ELLSWORTH,Mulberry Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000160
+ELLSWORTH,Mulberry Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000160
+ELLSWORTH,Noble Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000170
+ELLSWORTH,Noble Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000170
+ELLSWORTH,Palacky Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000180
+ELLSWORTH,Palacky Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000180
+ELLSWORTH,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000190
+ELLSWORTH,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000190
+ELLSWORTH,Thomas Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000200
+ELLSWORTH,Thomas Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000200
+ELLSWORTH,Trivoli Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000210
+ELLSWORTH,Trivoli Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000210
+ELLSWORTH,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,000220
+ELLSWORTH,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",141,000220
+ELLSWORTH,Venango Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000230
+ELLSWORTH,Venango Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000230
+ELLSWORTH,Wilson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",101,000240
+ELLSWORTH,Wilson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",205,000240
+ELLSWORTH,Ash Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",29,000010
+ELLSWORTH,Black Wolf Township,Kansas Senate,35,Republican,"Wilborn, Richard",28,000020
+ELLSWORTH,Buckeye Township,Kansas Senate,35,Republican,"Wilborn, Richard",26,000030
+ELLSWORTH,Carneiro Township,Kansas Senate,35,Republican,"Wilborn, Richard",20,000040
+ELLSWORTH,Clear Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",40,000050
+ELLSWORTH,Columbia Township,Kansas Senate,35,Republican,"Wilborn, Richard",20,000060
+ELLSWORTH,Ellsworth City East Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",190,000070
+ELLSWORTH,Ellsworth City East Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",253,000080
+ELLSWORTH,Ellsworth City West,Kansas Senate,35,Republican,"Wilborn, Richard",236,00009A
+ELLSWORTH,Canren Township,Kansas Senate,35,Republican,"Wilborn, Richard",21,00009B
+ELLSWORTH,Ellsworth Township,Kansas Senate,35,Republican,"Wilborn, Richard",67,000100
+ELLSWORTH,Garfield Township,Kansas Senate,35,Republican,"Wilborn, Richard",25,000110
+ELLSWORTH,Green Garden Township,Kansas Senate,35,Republican,"Wilborn, Richard",51,000120
+ELLSWORTH,Kanopolis Township,Kansas Senate,35,Republican,"Wilborn, Richard",150,000130
+ELLSWORTH,Langley Township,Kansas Senate,35,Republican,"Wilborn, Richard",31,000140
+ELLSWORTH,Lincoln Township,Kansas Senate,35,Republican,"Wilborn, Richard",26,000150
+ELLSWORTH,Mulberry Township,Kansas Senate,35,Republican,"Wilborn, Richard",16,000160
+ELLSWORTH,Noble Township,Kansas Senate,35,Republican,"Wilborn, Richard",25,000170
+ELLSWORTH,Palacky Township,Kansas Senate,35,Republican,"Wilborn, Richard",21,000180
+ELLSWORTH,Sherman Township,Kansas Senate,35,Republican,"Wilborn, Richard",29,000190
+ELLSWORTH,Thomas Township,Kansas Senate,35,Republican,"Wilborn, Richard",30,000200
+ELLSWORTH,Trivoli Township,Kansas Senate,35,Republican,"Wilborn, Richard",19,000210
+ELLSWORTH,Valley Township,Kansas Senate,35,Republican,"Wilborn, Richard",178,000220
+ELLSWORTH,Venango Township,Kansas Senate,35,Republican,"Wilborn, Richard",57,000230
+ELLSWORTH,Wilson Township,Kansas Senate,35,Republican,"Wilborn, Richard",260,000240
+ELLSWORTH,Ash Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000010
+ELLSWORTH,Ash Creek Township,Secretary of State,,Republican,"Kobach, Kris",28,000010
+ELLSWORTH,Black Wolf Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000020
+ELLSWORTH,Black Wolf Township,Secretary of State,,Republican,"Kobach, Kris",26,000020
+ELLSWORTH,Buckeye Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000030
+ELLSWORTH,Buckeye Township,Secretary of State,,Republican,"Kobach, Kris",26,000030
+ELLSWORTH,Carneiro Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000040
+ELLSWORTH,Carneiro Township,Secretary of State,,Republican,"Kobach, Kris",20,000040
+ELLSWORTH,Clear Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000050
+ELLSWORTH,Clear Creek Township,Secretary of State,,Republican,"Kobach, Kris",35,000050
+ELLSWORTH,Columbia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000060
+ELLSWORTH,Columbia Township,Secretary of State,,Republican,"Kobach, Kris",20,000060
+ELLSWORTH,Ellsworth City East Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",99,000070
+ELLSWORTH,Ellsworth City East Ward 1,Secretary of State,,Republican,"Kobach, Kris",146,000070
+ELLSWORTH,Ellsworth City East Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",106,000080
+ELLSWORTH,Ellsworth City East Ward 2,Secretary of State,,Republican,"Kobach, Kris",180,000080
+ELLSWORTH,Ellsworth City West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,00009A
+ELLSWORTH,Ellsworth City West,Secretary of State,,Republican,"Kobach, Kris",199,00009A
+ELLSWORTH,Canren Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,00009B
+ELLSWORTH,Canren Township,Secretary of State,,Republican,"Kobach, Kris",15,00009B
+ELLSWORTH,Ellsworth Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000100
+ELLSWORTH,Ellsworth Township,Secretary of State,,Republican,"Kobach, Kris",50,000100
+ELLSWORTH,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000110
+ELLSWORTH,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",22,000110
+ELLSWORTH,Green Garden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000120
+ELLSWORTH,Green Garden Township,Secretary of State,,Republican,"Kobach, Kris",47,000120
+ELLSWORTH,Kanopolis Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",87,000130
+ELLSWORTH,Kanopolis Township,Secretary of State,,Republican,"Kobach, Kris",119,000130
+ELLSWORTH,Langley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000140
+ELLSWORTH,Langley Township,Secretary of State,,Republican,"Kobach, Kris",26,000140
+ELLSWORTH,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000150
+ELLSWORTH,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",21,000150
+ELLSWORTH,Mulberry Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000160
+ELLSWORTH,Mulberry Township,Secretary of State,,Republican,"Kobach, Kris",15,000160
+ELLSWORTH,Noble Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000170
+ELLSWORTH,Noble Township,Secretary of State,,Republican,"Kobach, Kris",25,000170
+ELLSWORTH,Palacky Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000180
+ELLSWORTH,Palacky Township,Secretary of State,,Republican,"Kobach, Kris",22,000180
+ELLSWORTH,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000190
+ELLSWORTH,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",25,000190
+ELLSWORTH,Thomas Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000200
+ELLSWORTH,Thomas Township,Secretary of State,,Republican,"Kobach, Kris",24,000200
+ELLSWORTH,Trivoli Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000210
+ELLSWORTH,Trivoli Township,Secretary of State,,Republican,"Kobach, Kris",20,000210
+ELLSWORTH,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000220
+ELLSWORTH,Valley Township,Secretary of State,,Republican,"Kobach, Kris",145,000220
+ELLSWORTH,Venango Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000230
+ELLSWORTH,Venango Township,Secretary of State,,Republican,"Kobach, Kris",50,000230
+ELLSWORTH,Wilson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,000240
+ELLSWORTH,Wilson Township,Secretary of State,,Republican,"Kobach, Kris",214,000240
+ELLSWORTH,Ash Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000010
+ELLSWORTH,Ash Creek Township,State Treasurer,,Republican,"Estes, Ron",29,000010
+ELLSWORTH,Black Wolf Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000020
+ELLSWORTH,Black Wolf Township,State Treasurer,,Republican,"Estes, Ron",32,000020
+ELLSWORTH,Buckeye Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000030
+ELLSWORTH,Buckeye Township,State Treasurer,,Republican,"Estes, Ron",25,000030
+ELLSWORTH,Carneiro Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000040
+ELLSWORTH,Carneiro Township,State Treasurer,,Republican,"Estes, Ron",21,000040
+ELLSWORTH,Clear Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000050
+ELLSWORTH,Clear Creek Township,State Treasurer,,Republican,"Estes, Ron",40,000050
+ELLSWORTH,Columbia Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000060
+ELLSWORTH,Columbia Township,State Treasurer,,Republican,"Estes, Ron",21,000060
+ELLSWORTH,Ellsworth City East Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",68,000070
+ELLSWORTH,Ellsworth City East Ward 1,State Treasurer,,Republican,"Estes, Ron",173,000070
+ELLSWORTH,Ellsworth City East Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",58,000080
+ELLSWORTH,Ellsworth City East Ward 2,State Treasurer,,Republican,"Estes, Ron",218,000080
+ELLSWORTH,Ellsworth City West,State Treasurer,,Democratic,"Alldritt, Carmen",63,00009A
+ELLSWORTH,Ellsworth City West,State Treasurer,,Republican,"Estes, Ron",227,00009A
+ELLSWORTH,Canren Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,00009B
+ELLSWORTH,Canren Township,State Treasurer,,Republican,"Estes, Ron",22,00009B
+ELLSWORTH,Ellsworth Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000100
+ELLSWORTH,Ellsworth Township,State Treasurer,,Republican,"Estes, Ron",60,000100
+ELLSWORTH,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000110
+ELLSWORTH,Garfield Township,State Treasurer,,Republican,"Estes, Ron",25,000110
+ELLSWORTH,Green Garden Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000120
+ELLSWORTH,Green Garden Township,State Treasurer,,Republican,"Estes, Ron",55,000120
+ELLSWORTH,Kanopolis Township,State Treasurer,,Democratic,"Alldritt, Carmen",63,000130
+ELLSWORTH,Kanopolis Township,State Treasurer,,Republican,"Estes, Ron",133,000130
+ELLSWORTH,Langley Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000140
+ELLSWORTH,Langley Township,State Treasurer,,Republican,"Estes, Ron",26,000140
+ELLSWORTH,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000150
+ELLSWORTH,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",24,000150
+ELLSWORTH,Mulberry Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000160
+ELLSWORTH,Mulberry Township,State Treasurer,,Republican,"Estes, Ron",16,000160
+ELLSWORTH,Noble Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000170
+ELLSWORTH,Noble Township,State Treasurer,,Republican,"Estes, Ron",25,000170
+ELLSWORTH,Palacky Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000180
+ELLSWORTH,Palacky Township,State Treasurer,,Republican,"Estes, Ron",24,000180
+ELLSWORTH,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000190
+ELLSWORTH,Sherman Township,State Treasurer,,Republican,"Estes, Ron",33,000190
+ELLSWORTH,Thomas Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000200
+ELLSWORTH,Thomas Township,State Treasurer,,Republican,"Estes, Ron",27,000200
+ELLSWORTH,Trivoli Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000210
+ELLSWORTH,Trivoli Township,State Treasurer,,Republican,"Estes, Ron",20,000210
+ELLSWORTH,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",46,000220
+ELLSWORTH,Valley Township,State Treasurer,,Republican,"Estes, Ron",155,000220
+ELLSWORTH,Venango Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000230
+ELLSWORTH,Venango Township,State Treasurer,,Republican,"Estes, Ron",53,000230
+ELLSWORTH,Wilson Township,State Treasurer,,Democratic,"Alldritt, Carmen",81,000240
+ELLSWORTH,Wilson Township,State Treasurer,,Republican,"Estes, Ron",230,000240
+ELLSWORTH,Ash Creek Township,United States Senate,,independent,"Orman, Greg",5,000010
+ELLSWORTH,Ash Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+ELLSWORTH,Ash Creek Township,United States Senate,,Republican,"Roberts, Pat",28,000010
+ELLSWORTH,Black Wolf Township,United States Senate,,independent,"Orman, Greg",15,000020
+ELLSWORTH,Black Wolf Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+ELLSWORTH,Black Wolf Township,United States Senate,,Republican,"Roberts, Pat",28,000020
+ELLSWORTH,Buckeye Township,United States Senate,,independent,"Orman, Greg",9,000030
+ELLSWORTH,Buckeye Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+ELLSWORTH,Buckeye Township,United States Senate,,Republican,"Roberts, Pat",21,000030
+ELLSWORTH,Carneiro Township,United States Senate,,independent,"Orman, Greg",4,000040
+ELLSWORTH,Carneiro Township,United States Senate,,Libertarian,"Batson, Randall",2,000040
+ELLSWORTH,Carneiro Township,United States Senate,,Republican,"Roberts, Pat",18,000040
+ELLSWORTH,Clear Creek Township,United States Senate,,independent,"Orman, Greg",17,000050
+ELLSWORTH,Clear Creek Township,United States Senate,,Libertarian,"Batson, Randall",4,000050
+ELLSWORTH,Clear Creek Township,United States Senate,,Republican,"Roberts, Pat",35,000050
+ELLSWORTH,Columbia Township,United States Senate,,independent,"Orman, Greg",7,000060
+ELLSWORTH,Columbia Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+ELLSWORTH,Columbia Township,United States Senate,,Republican,"Roberts, Pat",18,000060
+ELLSWORTH,Ellsworth City East Ward 1,United States Senate,,independent,"Orman, Greg",96,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States Senate,,Libertarian,"Batson, Randall",9,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States Senate,,Republican,"Roberts, Pat",143,000070
+ELLSWORTH,Ellsworth City East Ward 2,United States Senate,,independent,"Orman, Greg",110,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States Senate,,Libertarian,"Batson, Randall",7,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States Senate,,Republican,"Roberts, Pat",171,000080
+ELLSWORTH,Ellsworth City West,United States Senate,,independent,"Orman, Greg",109,00009A
+ELLSWORTH,Ellsworth City West,United States Senate,,Libertarian,"Batson, Randall",16,00009A
+ELLSWORTH,Ellsworth City West,United States Senate,,Republican,"Roberts, Pat",166,00009A
+ELLSWORTH,Canren Township,United States Senate,,independent,"Orman, Greg",19,00009B
+ELLSWORTH,Canren Township,United States Senate,,Libertarian,"Batson, Randall",0,00009B
+ELLSWORTH,Canren Township,United States Senate,,Republican,"Roberts, Pat",13,00009B
+ELLSWORTH,Ellsworth Township,United States Senate,,independent,"Orman, Greg",23,000100
+ELLSWORTH,Ellsworth Township,United States Senate,,Libertarian,"Batson, Randall",2,000100
+ELLSWORTH,Ellsworth Township,United States Senate,,Republican,"Roberts, Pat",52,000100
+ELLSWORTH,Garfield Township,United States Senate,,independent,"Orman, Greg",4,000110
+ELLSWORTH,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+ELLSWORTH,Garfield Township,United States Senate,,Republican,"Roberts, Pat",25,000110
+ELLSWORTH,Green Garden Township,United States Senate,,independent,"Orman, Greg",15,000120
+ELLSWORTH,Green Garden Township,United States Senate,,Libertarian,"Batson, Randall",2,000120
+ELLSWORTH,Green Garden Township,United States Senate,,Republican,"Roberts, Pat",50,000120
+ELLSWORTH,Kanopolis Township,United States Senate,,independent,"Orman, Greg",89,000130
+ELLSWORTH,Kanopolis Township,United States Senate,,Libertarian,"Batson, Randall",16,000130
+ELLSWORTH,Kanopolis Township,United States Senate,,Republican,"Roberts, Pat",103,000130
+ELLSWORTH,Langley Township,United States Senate,,independent,"Orman, Greg",3,000140
+ELLSWORTH,Langley Township,United States Senate,,Libertarian,"Batson, Randall",2,000140
+ELLSWORTH,Langley Township,United States Senate,,Republican,"Roberts, Pat",29,000140
+ELLSWORTH,Lincoln Township,United States Senate,,independent,"Orman, Greg",11,000150
+ELLSWORTH,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",1,000150
+ELLSWORTH,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",18,000150
+ELLSWORTH,Mulberry Township,United States Senate,,independent,"Orman, Greg",1,000160
+ELLSWORTH,Mulberry Township,United States Senate,,Libertarian,"Batson, Randall",1,000160
+ELLSWORTH,Mulberry Township,United States Senate,,Republican,"Roberts, Pat",15,000160
+ELLSWORTH,Noble Township,United States Senate,,independent,"Orman, Greg",7,000170
+ELLSWORTH,Noble Township,United States Senate,,Libertarian,"Batson, Randall",3,000170
+ELLSWORTH,Noble Township,United States Senate,,Republican,"Roberts, Pat",24,000170
+ELLSWORTH,Palacky Township,United States Senate,,independent,"Orman, Greg",11,000180
+ELLSWORTH,Palacky Township,United States Senate,,Libertarian,"Batson, Randall",0,000180
+ELLSWORTH,Palacky Township,United States Senate,,Republican,"Roberts, Pat",16,000180
+ELLSWORTH,Sherman Township,United States Senate,,independent,"Orman, Greg",6,000190
+ELLSWORTH,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",4,000190
+ELLSWORTH,Sherman Township,United States Senate,,Republican,"Roberts, Pat",23,000190
+ELLSWORTH,Thomas Township,United States Senate,,independent,"Orman, Greg",5,000200
+ELLSWORTH,Thomas Township,United States Senate,,Libertarian,"Batson, Randall",0,000200
+ELLSWORTH,Thomas Township,United States Senate,,Republican,"Roberts, Pat",27,000200
+ELLSWORTH,Trivoli Township,United States Senate,,independent,"Orman, Greg",4,000210
+ELLSWORTH,Trivoli Township,United States Senate,,Libertarian,"Batson, Randall",3,000210
+ELLSWORTH,Trivoli Township,United States Senate,,Republican,"Roberts, Pat",19,000210
+ELLSWORTH,Valley Township,United States Senate,,independent,"Orman, Greg",56,000220
+ELLSWORTH,Valley Township,United States Senate,,Libertarian,"Batson, Randall",15,000220
+ELLSWORTH,Valley Township,United States Senate,,Republican,"Roberts, Pat",131,000220
+ELLSWORTH,Venango Township,United States Senate,,independent,"Orman, Greg",16,000230
+ELLSWORTH,Venango Township,United States Senate,,Libertarian,"Batson, Randall",3,000230
+ELLSWORTH,Venango Township,United States Senate,,Republican,"Roberts, Pat",43,000230
+ELLSWORTH,Wilson Township,United States Senate,,independent,"Orman, Greg",108,000240
+ELLSWORTH,Wilson Township,United States Senate,,Libertarian,"Batson, Randall",19,000240
+ELLSWORTH,Wilson Township,United States Senate,,Republican,"Roberts, Pat",194,000240

--- a/2014/20141104__ks__general__finney__precinct.csv
+++ b/2014/20141104__ks__general__finney__precinct.csv
@@ -1,680 +1,596 @@
-county,precinct,office,district,party,candidate,total
-Finney,1ST WARD,U.S. Senate,,R,Pat Roberts,56
-Finney,2ND WARD,U.S. Senate,,R,Pat Roberts,114
-Finney,3RD WARD,U.S. Senate,,R,Pat Roberts,186
-Finney,4TH WARD,U.S. Senate,,R,Pat Roberts,166
-Finney,5TH WARD,U.S. Senate,,R,Pat Roberts,147
-Finney,6TH WARD,U.S. Senate,,R,Pat Roberts,129
-Finney,7TH WARD,U.S. Senate,,R,Pat Roberts,123
-Finney,8TH WARD,U.S. Senate,,R,Pat Roberts,165
-Finney,9TH WARD,U.S. Senate,,R,Pat Roberts,106
-Finney,10TH WARD,U.S. Senate,,R,Pat Roberts,136
-Finney,11TH WARD,U.S. Senate,,R,Pat Roberts,238
-Finney,12TH WARD,U.S. Senate,,R,Pat Roberts,299
-Finney,13TH WARD,U.S. Senate,,R,Pat Roberts,257
-Finney,14TH WARD,U.S. Senate,,R,Pat Roberts,190
-Finney,15TH WARD,U.S. Senate,,R,Pat Roberts,277
-Finney,16TH WARD,U.S. Senate,,R,Pat Roberts,297
-Finney,0017 HUFFMAN,U.S. Senate,,R,Pat Roberts,108
-Finney,0018 JENNIE BARKER,U.S. Senate,,R,Pat Roberts,246
-Finney,0019 MACK,U.S. Senate,,R,Pat Roberts,67
-Finney,0020 RIVERSIDE,U.S. Senate,,R,Pat Roberts,308
-Finney,0021 KALVESTA,U.S. Senate,,R,Pat Roberts,46
-Finney,0022 THEONI,U.S. Senate,,R,Pat Roberts,47
-Finney,0023 PLYMELL,U.S. Senate,,R,Pat Roberts,106
-Finney,0024 PIERCEVILLE,U.S. Senate,,R,Pat Roberts,97
-Finney,0025 PL VALLEY,U.S. Senate,,R,Pat Roberts,57
-Finney,0026 HOLCOMB,U.S. Senate,,R,Pat Roberts,444
-Finney,0027 FRIEND,U.S. Senate,,R,Pat Roberts,34
-Finney,1ST WARD,U.S. Senate,,I,Greg Orman,64
-Finney,2ND WARD,U.S. Senate,,I,Greg Orman,87
-Finney,3RD WARD,U.S. Senate,,I,Greg Orman,125
-Finney,4TH WARD,U.S. Senate,,I,Greg Orman,80
-Finney,5TH WARD,U.S. Senate,,I,Greg Orman,80
-Finney,6TH WARD,U.S. Senate,,I,Greg Orman,84
-Finney,7TH WARD,U.S. Senate,,I,Greg Orman,66
-Finney,8TH WARD,U.S. Senate,,I,Greg Orman,107
-Finney,9TH WARD,U.S. Senate,,I,Greg Orman,78
-Finney,10TH WARD,U.S. Senate,,I,Greg Orman,83
-Finney,11TH WARD,U.S. Senate,,I,Greg Orman,114
-Finney,12TH WARD,U.S. Senate,,I,Greg Orman,139
-Finney,13TH WARD,U.S. Senate,,I,Greg Orman,99
-Finney,14TH WARD,U.S. Senate,,I,Greg Orman,120
-Finney,15TH WARD,U.S. Senate,,I,Greg Orman,112
-Finney,16TH WARD,U.S. Senate,,I,Greg Orman,141
-Finney,0017 HUFFMAN,U.S. Senate,,I,Greg Orman,38
-Finney,0018 JENNIE BARKER,U.S. Senate,,I,Greg Orman,88
-Finney,0019 MACK,U.S. Senate,,I,Greg Orman,28
-Finney,0020 RIVERSIDE,U.S. Senate,,I,Greg Orman,104
-Finney,0021 KALVESTA,U.S. Senate,,I,Greg Orman,5
-Finney,0022 THEONI,U.S. Senate,,I,Greg Orman,6
-Finney,0023 PLYMELL,U.S. Senate,,I,Greg Orman,20
-Finney,0024 PIERCEVILLE,U.S. Senate,,I,Greg Orman,28
-Finney,0025 PL VALLEY,U.S. Senate,,I,Greg Orman,4
-Finney,0026 HOLCOMB,U.S. Senate,,I,Greg Orman,121
-Finney,0027 FRIEND,U.S. Senate,,I,Greg Orman,7
-Finney,1ST WARD,U.S. Senate,,L,Randall Batson,12
-Finney,2ND WARD,U.S. Senate,,L,Randall Batson,14
-Finney,3RD WARD,U.S. Senate,,L,Randall Batson,20
-Finney,4TH WARD,U.S. Senate,,L,Randall Batson,8
-Finney,5TH WARD,U.S. Senate,,L,Randall Batson,10
-Finney,6TH WARD,U.S. Senate,,L,Randall Batson,15
-Finney,7TH WARD,U.S. Senate,,L,Randall Batson,10
-Finney,8TH WARD,U.S. Senate,,L,Randall Batson,27
-Finney,9TH WARD,U.S. Senate,,L,Randall Batson,18
-Finney,10TH WARD,U.S. Senate,,L,Randall Batson,14
-Finney,11TH WARD,U.S. Senate,,L,Randall Batson,14
-Finney,12TH WARD,U.S. Senate,,L,Randall Batson,10
-Finney,13TH WARD,U.S. Senate,,L,Randall Batson,13
-Finney,14TH WARD,U.S. Senate,,L,Randall Batson,12
-Finney,15TH WARD,U.S. Senate,,L,Randall Batson,16
-Finney,16TH WARD,U.S. Senate,,L,Randall Batson,20
-Finney,0017 HUFFMAN,U.S. Senate,,L,Randall Batson,8
-Finney,0018 JENNIE BARKER,U.S. Senate,,L,Randall Batson,13
-Finney,0019 MACK,U.S. Senate,,L,Randall Batson,7
-Finney,0020 RIVERSIDE,U.S. Senate,,L,Randall Batson,9
-Finney,0021 KALVESTA,U.S. Senate,,L,Randall Batson,1
-Finney,0022 THEONI,U.S. Senate,,L,Randall Batson,2
-Finney,0023 PLYMELL,U.S. Senate,,L,Randall Batson,3
-Finney,0024 PIERCEVILLE,U.S. Senate,,L,Randall Batson,4
-Finney,0025 PL VALLEY,U.S. Senate,,L,Randall Batson,0
-Finney,0026 HOLCOMB,U.S. Senate,,L,Randall Batson,18
-Finney,0027 FRIEND,U.S. Senate,,L,Randall Batson,4
-Finney,1ST WARD,U.S. Senate,,,Write-ins,1
-Finney,2ND WARD,U.S. Senate,,,Write-ins,2
-Finney,3RD WARD,U.S. Senate,,,Write-ins,2
-Finney,4TH WARD,U.S. Senate,,,Write-ins,0
-Finney,5TH WARD,U.S. Senate,,,Write-ins,2
-Finney,6TH WARD,U.S. Senate,,,Write-ins,0
-Finney,7TH WARD,U.S. Senate,,,Write-ins,0
-Finney,8TH WARD,U.S. Senate,,,Write-ins,2
-Finney,9TH WARD,U.S. Senate,,,Write-ins,0
-Finney,10TH WARD,U.S. Senate,,,Write-ins,2
-Finney,11TH WARD,U.S. Senate,,,Write-ins,2
-Finney,12TH WARD,U.S. Senate,,,Write-ins,0
-Finney,13TH WARD,U.S. Senate,,,Write-ins,1
-Finney,14TH WARD,U.S. Senate,,,Write-ins,0
-Finney,15TH WARD,U.S. Senate,,,Write-ins,0
-Finney,16TH WARD,U.S. Senate,,,Write-ins,0
-Finney,0017 HUFFMAN,U.S. Senate,,,Write-ins,0
-Finney,0018 JENNIE BARKER,U.S. Senate,,,Write-ins,0
-Finney,0019 MACK,U.S. Senate,,,Write-ins,0
-Finney,0020 RIVERSIDE,U.S. Senate,,,Write-ins,0
-Finney,0021 KALVESTA,U.S. Senate,,,Write-ins,0
-Finney,0022 THEONI,U.S. Senate,,,Write-ins,0
-Finney,0023 PLYMELL,U.S. Senate,,,Write-ins,1
-Finney,0024 PIERCEVILLE,U.S. Senate,,,Write-ins,2
-Finney,0025 PL VALLEY,U.S. Senate,,,Write-ins,0
-Finney,0026 HOLCOMB,U.S. Senate,,,Write-ins,0
-Finney,0027 FRIEND,U.S. Senate,,,Write-ins,0
-Finney,1ST WARD,U.S. House,1,R,Tim Huelskamp,60
-Finney,2ND WARD,U.S. House,1,R,Tim Huelskamp,109
-Finney,3RD WARD,U.S. House,1,R,Tim Huelskamp,195
-Finney,4TH WARD,U.S. House,1,R,Tim Huelskamp,152
-Finney,5TH WARD,U.S. House,1,R,Tim Huelskamp,137
-Finney,6TH WARD,U.S. House,1,R,Tim Huelskamp,129
-Finney,7TH WARD,U.S. House,1,R,Tim Huelskamp,115
-Finney,8TH WARD,U.S. House,1,R,Tim Huelskamp,167
-Finney,9TH WARD,U.S. House,1,R,Tim Huelskamp,113
-Finney,10TH WARD,U.S. House,1,R,Tim Huelskamp,132
-Finney,11TH WARD,U.S. House,1,R,Tim Huelskamp,226
-Finney,12TH WARD,U.S. House,1,R,Tim Huelskamp,251
-Finney,13TH WARD,U.S. House,1,R,Tim Huelskamp,230
-Finney,14TH WARD,U.S. House,1,R,Tim Huelskamp,178
-Finney,15TH WARD,U.S. House,1,R,Tim Huelskamp,259
-Finney,16TH WARD,U.S. House,1,R,Tim Huelskamp,283
-Finney,0017 HUFFMAN,U.S. House,1,R,Tim Huelskamp,109
-Finney,0018 JENNIE BARKER,U.S. House,1,R,Tim Huelskamp,242
-Finney,0019 MACK,U.S. House,1,R,Tim Huelskamp,72
-Finney,0020 RIVERSIDE,U.S. House,1,R,Tim Huelskamp,279
-Finney,0021 KALVESTA,U.S. House,1,R,Tim Huelskamp,40
-Finney,0022 THEONI,U.S. House,1,R,Tim Huelskamp,36
-Finney,0023 PLYMELL,U.S. House,1,R,Tim Huelskamp,92
-Finney,0024 PIERCEVILLE,U.S. House,1,R,Tim Huelskamp,96
-Finney,0025 PL VALLEY,U.S. House,1,R,Tim Huelskamp,53
-Finney,0026 HOLCOMB,U.S. House,1,R,Tim Huelskamp,410
-Finney,0027 FRIEND,U.S. House,1,R,Tim Huelskamp,34
-Finney,1ST WARD,U.S. House,1,D,James Sherow,68
-Finney,2ND WARD,U.S. House,1,D,James Sherow,99
-Finney,3RD WARD,U.S. House,1,D,James Sherow,130
-Finney,4TH WARD,U.S. House,1,D,James Sherow,99
-Finney,5TH WARD,U.S. House,1,D,James Sherow,100
-Finney,6TH WARD,U.S. House,1,D,James Sherow,94
-Finney,7TH WARD,U.S. House,1,D,James Sherow,80
-Finney,8TH WARD,U.S. House,1,D,James Sherow,130
-Finney,9TH WARD,U.S. House,1,D,James Sherow,85
-Finney,10TH WARD,U.S. House,1,D,James Sherow,100
-Finney,11TH WARD,U.S. House,1,D,James Sherow,133
-Finney,12TH WARD,U.S. House,1,D,James Sherow,188
-Finney,13TH WARD,U.S. House,1,D,James Sherow,134
-Finney,14TH WARD,U.S. House,1,D,James Sherow,144
-Finney,15TH WARD,U.S. House,1,D,James Sherow,140
-Finney,16TH WARD,U.S. House,1,D,James Sherow,165
-Finney,0017 HUFFMAN,U.S. House,1,D,James Sherow,40
-Finney,0018 JENNIE BARKER,U.S. House,1,D,James Sherow,104
-Finney,0019 MACK,U.S. House,1,D,James Sherow,30
-Finney,0020 RIVERSIDE,U.S. House,1,D,James Sherow,139
-Finney,0021 KALVESTA,U.S. House,1,D,James Sherow,12
-Finney,0022 THEONI,U.S. House,1,D,James Sherow,16
-Finney,0023 PLYMELL,U.S. House,1,D,James Sherow,34
-Finney,0024 PIERCEVILLE,U.S. House,1,D,James Sherow,34
-Finney,0025 PL VALLEY,U.S. House,1,D,James Sherow,7
-Finney,0026 HOLCOMB,U.S. House,1,D,James Sherow,165
-Finney,0027 FRIEND,U.S. House,1,D,James Sherow,8
-Finney,1ST WARD,U.S. House,1,,Write-ins,1
-Finney,2ND WARD,U.S. House,1,,Write-ins,3
-Finney,3RD WARD,U.S. House,1,,Write-ins,0
-Finney,4TH WARD,U.S. House,1,,Write-ins,0
-Finney,5TH WARD,U.S. House,1,,Write-ins,1
-Finney,6TH WARD,U.S. House,1,,Write-ins,0
-Finney,7TH WARD,U.S. House,1,,Write-ins,0
-Finney,8TH WARD,U.S. House,1,,Write-ins,1
-Finney,9TH WARD,U.S. House,1,,Write-ins,1
-Finney,10TH WARD,U.S. House,1,,Write-ins,0
-Finney,11TH WARD,U.S. House,1,,Write-ins,4
-Finney,12TH WARD,U.S. House,1,,Write-ins,1
-Finney,13TH WARD,U.S. House,1,,Write-ins,1
-Finney,14TH WARD,U.S. House,1,,Write-ins,0
-Finney,15TH WARD,U.S. House,1,,Write-ins,1
-Finney,16TH WARD,U.S. House,1,,Write-ins,2
-Finney,0017 HUFFMAN,U.S. House,1,,Write-ins,0
-Finney,0018 JENNIE BARKER,U.S. House,1,,Write-ins,0
-Finney,0019 MACK,U.S. House,1,,Write-ins,3
-Finney,0020 RIVERSIDE,U.S. House,1,,Write-ins,1
-Finney,0021 KALVESTA,U.S. House,1,,Write-ins,0
-Finney,0022 THEONI,U.S. House,1,,Write-ins,0
-Finney,0023 PLYMELL,U.S. House,1,,Write-ins,0
-Finney,0024 PIERCEVILLE,U.S. House,1,,Write-ins,0
-Finney,0025 PL VALLEY,U.S. House,1,,Write-ins,0
-Finney,0026 HOLCOMB,U.S. House,1,,Write-ins,1
-Finney,0027 FRIEND,U.S. House,1,,Write-ins,2
-Finney,1ST WARD,Governor,,R,Sam Brownback,50
-Finney,2ND WARD,Governor,,R,Sam Brownback,97
-Finney,3RD WARD,Governor,,R,Sam Brownback,181
-Finney,4TH WARD,Governor,,R,Sam Brownback,163
-Finney,5TH WARD,Governor,,R,Sam Brownback,133
-Finney,6TH WARD,Governor,,R,Sam Brownback,123
-Finney,7TH WARD,Governor,,R,Sam Brownback,105
-Finney,8TH WARD,Governor,,R,Sam Brownback,156
-Finney,9TH WARD,Governor,,R,Sam Brownback,89
-Finney,10TH WARD,Governor,,R,Sam Brownback,123
-Finney,11TH WARD,Governor,,R,Sam Brownback,236
-Finney,12TH WARD,Governor,,R,Sam Brownback,285
-Finney,13TH WARD,Governor,,R,Sam Brownback,238
-Finney,14TH WARD,Governor,,R,Sam Brownback,174
-Finney,15TH WARD,Governor,,R,Sam Brownback,256
-Finney,16TH WARD,Governor,,R,Sam Brownback,262
-Finney,0017 HUFFMAN,Governor,,R,Sam Brownback,107
-Finney,0018 JENNIE BARKER,Governor,,R,Sam Brownback,226
-Finney,0019 MACK,Governor,,R,Sam Brownback,60
-Finney,0020 RIVERSIDE,Governor,,R,Sam Brownback,287
-Finney,0021 KALVESTA,Governor,,R,Sam Brownback,40
-Finney,0022 THEONI,Governor,,R,Sam Brownback,46
-Finney,0023 PLYMELL,Governor,,R,Sam Brownback,102
-Finney,0024 PIERCEVILLE,Governor,,R,Sam Brownback,92
-Finney,0025 PL VALLEY,Governor,,R,Sam Brownback,56
-Finney,0026 HOLCOMB,Governor,,R,Sam Brownback,422
-Finney,0027 FRIEND,Governor,,R,Sam Brownback,35
-Finney,1ST WARD,Governor,,D,Paul Davis,71
-Finney,2ND WARD,Governor,,D,Paul Davis,107
-Finney,3RD WARD,Governor,,D,Paul Davis,139
-Finney,4TH WARD,Governor,,D,Paul Davis,83
-Finney,5TH WARD,Governor,,D,Paul Davis,97
-Finney,6TH WARD,Governor,,D,Paul Davis,90
-Finney,7TH WARD,Governor,,D,Paul Davis,86
-Finney,8TH WARD,Governor,,D,Paul Davis,132
-Finney,9TH WARD,Governor,,D,Paul Davis,97
-Finney,10TH WARD,Governor,,D,Paul Davis,99
-Finney,11TH WARD,Governor,,D,Paul Davis,122
-Finney,12TH WARD,Governor,,D,Paul Davis,151
-Finney,13TH WARD,Governor,,D,Paul Davis,125
-Finney,14TH WARD,Governor,,D,Paul Davis,140
-Finney,15TH WARD,Governor,,D,Paul Davis,140
-Finney,16TH WARD,Governor,,D,Paul Davis,181
-Finney,0017 HUFFMAN,Governor,,D,Paul Davis,40
-Finney,0018 JENNIE BARKER,Governor,,D,Paul Davis,108
-Finney,0019 MACK,Governor,,D,Paul Davis,37
-Finney,0020 RIVERSIDE,Governor,,D,Paul Davis,126
-Finney,0021 KALVESTA,Governor,,D,Paul Davis,11
-Finney,0022 THEONI,Governor,,D,Paul Davis,6
-Finney,0023 PLYMELL,Governor,,D,Paul Davis,23
-Finney,0024 PIERCEVILLE,Governor,,D,Paul Davis,33
-Finney,0025 PL VALLEY,Governor,,D,Paul Davis,6
-Finney,0026 HOLCOMB,Governor,,D,Paul Davis,150
-Finney,0027 FRIEND,Governor,,L,Keen Umbehr,6
-Finney,1ST WARD,Governor,,L,Keen Umbehr,11
-Finney,2ND WARD,Governor,,L,Keen Umbehr,10
-Finney,3RD WARD,Governor,,L,Keen Umbehr,11
-Finney,4TH WARD,Governor,,L,Keen Umbehr,6
-Finney,5TH WARD,Governor,,L,Keen Umbehr,11
-Finney,6TH WARD,Governor,,L,Keen Umbehr,10
-Finney,7TH WARD,Governor,,L,Keen Umbehr,7
-Finney,8TH WARD,Governor,,L,Keen Umbehr,17
-Finney,9TH WARD,Governor,,L,Keen Umbehr,18
-Finney,10TH WARD,Governor,,L,Keen Umbehr,14
-Finney,11TH WARD,Governor,,L,Keen Umbehr,9
-Finney,12TH WARD,Governor,,L,Keen Umbehr,10
-Finney,13TH WARD,Governor,,L,Keen Umbehr,7
-Finney,14TH WARD,Governor,,L,Keen Umbehr,9
-Finney,15TH WARD,Governor,,L,Keen Umbehr,11
-Finney,16TH WARD,Governor,,L,Keen Umbehr,16
-Finney,0017 HUFFMAN,Governor,,L,Keen Umbehr,6
-Finney,0018 JENNIE BARKER,Governor,,L,Keen Umbehr,13
-Finney,0019 MACK,Governor,,L,Keen Umbehr,7
-Finney,0020 RIVERSIDE,Governor,,L,Keen Umbehr,8
-Finney,0021 KALVESTA,Governor,,L,Keen Umbehr,1
-Finney,0022 THEONI,Governor,,L,Keen Umbehr,1
-Finney,0023 PLYMELL,Governor,,L,Keen Umbehr,4
-Finney,0024 PIERCEVILLE,Governor,,L,Keen Umbehr,4
-Finney,0025 PL VALLEY,Governor,,L,Keen Umbehr,0
-Finney,0026 HOLCOMB,Governor,,L,Keen Umbehr,13
-Finney,0027 FRIEND,Governor,,L,Keen Umbehr,4
-Finney,1ST WARD,Governor,,,Write-ins,1
-Finney,2ND WARD,Governor,,,Write-ins,1
-Finney,3RD WARD,Governor,,,Write-ins,1
-Finney,4TH WARD,Governor,,,Write-ins,0
-Finney,5TH WARD,Governor,,,Write-ins,0
-Finney,6TH WARD,Governor,,,Write-ins,0
-Finney,7TH WARD,Governor,,,Write-ins,0
-Finney,8TH WARD,Governor,,,Write-ins,0
-Finney,9TH WARD,Governor,,,Write-ins,1
-Finney,10TH WARD,Governor,,,Write-ins,0
-Finney,11TH WARD,Governor,,,Write-ins,3
-Finney,12TH WARD,Governor,,,Write-ins,0
-Finney,13TH WARD,Governor,,,Write-ins,0
-Finney,14TH WARD,Governor,,,Write-ins,1
-Finney,15TH WARD,Governor,,,Write-ins,0
-Finney,16TH WARD,Governor,,,Write-ins,1
-Finney,0017 HUFFMAN,Governor,,,Write-ins,0
-Finney,0018 JENNIE BARKER,Governor,,,Write-ins,0
-Finney,0019 MACK,Governor,,,Write-ins,0
-Finney,0020 RIVERSIDE,Governor,,,Write-ins,1
-Finney,0021 KALVESTA,Governor,,,Write-ins,0
-Finney,0022 THEONI,Governor,,,Write-ins,0
-Finney,0023 PLYMELL,Governor,,,Write-ins,0
-Finney,0024 PIERCEVILLE,Governor,,,Write-ins,1
-Finney,0025 PL VALLEY,Governor,,,Write-ins,0
-Finney,0026 HOLCOMB,Governor,,,Write-ins,0
-Finney,0027 FRIEND,Governor,,,Write-ins,0
-Finney,1ST WARD,Secretary of State,,R,Kris Kobach,57
-Finney,2ND WARD,Secretary of State,,R,Kris Kobach,118
-Finney,3RD WARD,Secretary of State,,R,Kris Kobach,211
-Finney,4TH WARD,Secretary of State,,R,Kris Kobach,172
-Finney,5TH WARD,Secretary of State,,R,Kris Kobach,157
-Finney,6TH WARD,Secretary of State,,R,Kris Kobach,148
-Finney,7TH WARD,Secretary of State,,R,Kris Kobach,124
-Finney,8TH WARD,Secretary of State,,R,Kris Kobach,183
-Finney,9TH WARD,Secretary of State,,R,Kris Kobach,122
-Finney,10TH WARD,Secretary of State,,R,Kris Kobach,156
-Finney,11TH WARD,Secretary of State,,R,Kris Kobach,262
-Finney,12TH WARD,Secretary of State,,R,Kris Kobach,316
-Finney,13TH WARD,Secretary of State,,R,Kris Kobach,273
-Finney,14TH WARD,Secretary of State,,R,Kris Kobach,206
-Finney,15TH WARD,Secretary of State,,R,Kris Kobach,295
-Finney,16TH WARD,Secretary of State,,R,Kris Kobach,326
-Finney,0017 HUFFMAN,Secretary of State,,R,Kris Kobach,106
-Finney,0018 JENNIE BARKER,Secretary of State,,R,Kris Kobach,258
-Finney,0019 MACK,Secretary of State,,R,Kris Kobach,72
-Finney,0020 RIVERSIDE,Secretary of State,,R,Kris Kobach,323
-Finney,0021 KALVESTA,Secretary of State,,R,Kris Kobach,44
-Finney,0022 THEONI,Secretary of State,,R,Kris Kobach,49
-Finney,0023 PLYMELL,Secretary of State,,R,Kris Kobach,107
-Finney,0024 PIERCEVILLE,Secretary of State,,R,Kris Kobach,98
-Finney,0025 PL VALLEY,Secretary of State,,R,Kris Kobach,57
-Finney,0026 HOLCOMB,Secretary of State,,R,Kris Kobach,462
-Finney,0027 FRIEND,Secretary of State,,R,Kris Kobach,38
-Finney,1ST WARD,Secretary of State,,D,Jean Schodorf,76
-Finney,2ND WARD,Secretary of State,,D,Jean Schodorf,95
-Finney,3RD WARD,Secretary of State,,D,Jean Schodorf,120
-Finney,4TH WARD,Secretary of State,,D,Jean Schodorf,77
-Finney,5TH WARD,Secretary of State,,D,Jean Schodorf,80
-Finney,6TH WARD,Secretary of State,,D,Jean Schodorf,79
-Finney,7TH WARD,Secretary of State,,D,Jean Schodorf,72
-Finney,8TH WARD,Secretary of State,,D,Jean Schodorf,114
-Finney,9TH WARD,Secretary of State,,D,Jean Schodorf,82
-Finney,10TH WARD,Secretary of State,,D,Jean Schodorf,78
-Finney,11TH WARD,Secretary of State,,D,Jean Schodorf,103
-Finney,12TH WARD,Secretary of State,,D,Jean Schodorf,127
-Finney,13TH WARD,Secretary of State,,D,Jean Schodorf,96
-Finney,14TH WARD,Secretary of State,,D,Jean Schodorf,114
-Finney,15TH WARD,Secretary of State,,D,Jean Schodorf,106
-Finney,16TH WARD,Secretary of State,,D,Jean Schodorf,126
-Finney,0017 HUFFMAN,Secretary of State,,D,Jean Schodorf,47
-Finney,0018 JENNIE BARKER,Secretary of State,,D,Jean Schodorf,88
-Finney,0019 MACK,Secretary of State,,D,Jean Schodorf,31
-Finney,0020 RIVERSIDE,Secretary of State,,D,Jean Schodorf,96
-Finney,0021 KALVESTA,Secretary of State,,D,Jean Schodorf,7
-Finney,0022 THEONI,Secretary of State,,D,Jean Schodorf,5
-Finney,0023 PLYMELL,Secretary of State,,D,Jean Schodorf,22
-Finney,0024 PIERCEVILLE,Secretary of State,,D,Jean Schodorf,31
-Finney,0025 PL VALLEY,Secretary of State,,D,Jean Schodorf,4
-Finney,0026 HOLCOMB,Secretary of State,,D,Jean Schodorf,115
-Finney,0027 FRIEND,Secretary of State,,D,Jean Schodorf,7
-Finney,1ST WARD,Secretary of State,,,Write-ins,0
-Finney,2ND WARD,Secretary of State,,,Write-ins,4
-Finney,3RD WARD,Secretary of State,,,Write-ins,0
-Finney,4TH WARD,Secretary of State,,,Write-ins,0
-Finney,5TH WARD,Secretary of State,,,Write-ins,2
-Finney,6TH WARD,Secretary of State,,,Write-ins,0
-Finney,7TH WARD,Secretary of State,,,Write-ins,0
-Finney,8TH WARD,Secretary of State,,,Write-ins,1
-Finney,9TH WARD,Secretary of State,,,Write-ins,0
-Finney,10TH WARD,Secretary of State,,,Write-ins,0
-Finney,11TH WARD,Secretary of State,,,Write-ins,1
-Finney,12TH WARD,Secretary of State,,,Write-ins,0
-Finney,13TH WARD,Secretary of State,,,Write-ins,0
-Finney,14TH WARD,Secretary of State,,,Write-ins,0
-Finney,15TH WARD,Secretary of State,,,Write-ins,0
-Finney,16TH WARD,Secretary of State,,,Write-ins,0
-Finney,0017 HUFFMAN,Secretary of State,,,Write-ins,0
-Finney,0018 JENNIE BARKER,Secretary of State,,,Write-ins,2
-Finney,0019 MACK,Secretary of State,,,Write-ins,1
-Finney,0020 RIVERSIDE,Secretary of State,,,Write-ins,0
-Finney,0021 KALVESTA,Secretary of State,,,Write-ins,0
-Finney,0022 THEONI,Secretary of State,,,Write-ins,0
-Finney,0023 PLYMELL,Secretary of State,,,Write-ins,0
-Finney,0024 PIERCEVILLE,Secretary of State,,,Write-ins,0
-Finney,0025 PL VALLEY,Secretary of State,,,Write-ins,0
-Finney,0026 HOLCOMB,Secretary of State,,,Write-ins,0
-Finney,0027 FRIEND,Secretary of State,,,Write-ins,0
-Finney,1ST WARD,Attorney General,,R,Derek Schmidt,66
-Finney,2ND WARD,Attorney General,,R,Derek Schmidt,136
-Finney,3RD WARD,Attorney General,,R,Derek Schmidt,234
-Finney,4TH WARD,Attorney General,,R,Derek Schmidt,197
-Finney,5TH WARD,Attorney General,,R,Derek Schmidt,173
-Finney,6TH WARD,Attorney General,,R,Derek Schmidt,157
-Finney,7TH WARD,Attorney General,,R,Derek Schmidt,135
-Finney,8TH WARD,Attorney General,,R,Derek Schmidt,192
-Finney,9TH WARD,Attorney General,,R,Derek Schmidt,128
-Finney,10TH WARD,Attorney General,,R,Derek Schmidt,168
-Finney,11TH WARD,Attorney General,,R,Derek Schmidt,269
-Finney,12TH WARD,Attorney General,,R,Derek Schmidt,362
-Finney,13TH WARD,Attorney General,,R,Derek Schmidt,295
-Finney,14TH WARD,Attorney General,,R,Derek Schmidt,221
-Finney,15TH WARD,Attorney General,,R,Derek Schmidt,313
-Finney,16TH WARD,Attorney General,,R,Derek Schmidt,346
-Finney,0017 HUFFMAN,Attorney General,,R,Derek Schmidt,125
-Finney,0018 JENNIE BARKER,Attorney General,,R,Derek Schmidt,276
-Finney,0019 MACK,Attorney General,,R,Derek Schmidt,77
-Finney,0020 RIVERSIDE,Attorney General,,R,Derek Schmidt,371
-Finney,0021 KALVESTA,Attorney General,,R,Derek Schmidt,44
-Finney,0022 THEONI,Attorney General,,R,Derek Schmidt,46
-Finney,0023 PLYMELL,Attorney General,,R,Derek Schmidt,115
-Finney,0024 PIERCEVILLE,Attorney General,,R,Derek Schmidt,102
-Finney,0025 PL VALLEY,Attorney General,,R,Derek Schmidt,57
-Finney,0026 HOLCOMB,Attorney General,,R,Derek Schmidt,489
-Finney,0027 FRIEND,Attorney General,,R,Derek Schmidt,41
-Finney,1ST WARD,Attorney General,,D,A J Kotich,63
-Finney,2ND WARD,Attorney General,,D,A J Kotich,79
-Finney,3RD WARD,Attorney General,,D,A J Kotich,94
-Finney,4TH WARD,Attorney General,,D,A J Kotich,52
-Finney,5TH WARD,Attorney General,,D,A J Kotich,58
-Finney,6TH WARD,Attorney General,,D,A J Kotich,62
-Finney,7TH WARD,Attorney General,,D,A J Kotich,58
-Finney,8TH WARD,Attorney General,,D,A J Kotich,102
-Finney,9TH WARD,Attorney General,,D,A J Kotich,67
-Finney,10TH WARD,Attorney General,,D,A J Kotich,64
-Finney,11TH WARD,Attorney General,,D,A J Kotich,92
-Finney,12TH WARD,Attorney General,,D,A J Kotich,81
-Finney,13TH WARD,Attorney General,,D,A J Kotich,65
-Finney,14TH WARD,Attorney General,,D,A J Kotich,94
-Finney,15TH WARD,Attorney General,,D,A J Kotich,80
-Finney,16TH WARD,Attorney General,,D,A J Kotich,99
-Finney,0017 HUFFMAN,Attorney General,,D,A J Kotich,27
-Finney,0018 JENNIE BARKER,Attorney General,,D,A J Kotich,69
-Finney,0019 MACK,Attorney General,,D,A J Kotich,27
-Finney,0020 RIVERSIDE,Attorney General,,D,A J Kotich,40
-Finney,0021 KALVESTA,Attorney General,,D,A J Kotich,5
-Finney,0022 THEONI,Attorney General,,D,A J Kotich,5
-Finney,0023 PLYMELL,Attorney General,,D,A J Kotich,13
-Finney,0024 PIERCEVILLE,Attorney General,,D,A J Kotich,24
-Finney,0025 PL VALLEY,Attorney General,,D,A J Kotich,4
-Finney,0026 HOLCOMB,Attorney General,,D,A J Kotich,78
-Finney,0027 FRIEND,Attorney General,,D,A J Kotich,3
-Finney,1ST WARD,Attorney General,,,Write-ins,0
-Finney,2ND WARD,Attorney General,,,Write-ins,1
-Finney,3RD WARD,Attorney General,,,Write-ins,0
-Finney,4TH WARD,Attorney General,,,Write-ins,0
-Finney,5TH WARD,Attorney General,,,Write-ins,0
-Finney,6TH WARD,Attorney General,,,Write-ins,1
-Finney,7TH WARD,Attorney General,,,Write-ins,0
-Finney,8TH WARD,Attorney General,,,Write-ins,0
-Finney,9TH WARD,Attorney General,,,Write-ins,3
-Finney,10TH WARD,Attorney General,,,Write-ins,0
-Finney,11TH WARD,Attorney General,,,Write-ins,1
-Finney,12TH WARD,Attorney General,,,Write-ins,0
-Finney,13TH WARD,Attorney General,,,Write-ins,0
-Finney,14TH WARD,Attorney General,,,Write-ins,0
-Finney,15TH WARD,Attorney General,,,Write-ins,2
-Finney,16TH WARD,Attorney General,,,Write-ins,1
-Finney,0017 HUFFMAN,Attorney General,,,Write-ins,0
-Finney,0018 JENNIE BARKER,Attorney General,,,Write-ins,1
-Finney,0019 MACK,Attorney General,,,Write-ins,0
-Finney,0020 RIVERSIDE,Attorney General,,,Write-ins,0
-Finney,0021 KALVESTA,Attorney General,,,Write-ins,0
-Finney,0022 THEONI,Attorney General,,,Write-ins,0
-Finney,0023 PLYMELL,Attorney General,,,Write-ins,1
-Finney,0024 PIERCEVILLE,Attorney General,,,Write-ins,0
-Finney,0025 PL VALLEY,Attorney General,,,Write-ins,0
-Finney,0026 HOLCOMB,Attorney General,,,Write-ins,0
-Finney,0027 FRIEND,Attorney General,,,Write-ins,0
-Finney,1ST WARD,State Treasurer,,R,Ron Estes,60
-Finney,2ND WARD,State Treasurer,,R,Ron Estes,127
-Finney,3RD WARD,State Treasurer,,R,Ron Estes,232
-Finney,4TH WARD,State Treasurer,,R,Ron Estes,192
-Finney,5TH WARD,State Treasurer,,R,Ron Estes,178
-Finney,6TH WARD,State Treasurer,,R,Ron Estes,155
-Finney,7TH WARD,State Treasurer,,R,Ron Estes,130
-Finney,8TH WARD,State Treasurer,,R,Ron Estes,185
-Finney,9TH WARD,State Treasurer,,R,Ron Estes,136
-Finney,10TH WARD,State Treasurer,,R,Ron Estes,173
-Finney,11TH WARD,State Treasurer,,R,Ron Estes,277
-Finney,12TH WARD,State Treasurer,,R,Ron Estes,355
-Finney,13TH WARD,State Treasurer,,R,Ron Estes,295
-Finney,14TH WARD,State Treasurer,,R,Ron Estes,214
-Finney,15TH WARD,State Treasurer,,R,Ron Estes,328
-Finney,16TH WARD,State Treasurer,,R,Ron Estes,347
-Finney,0017 HUFFMAN,State Treasurer,,R,Ron Estes,121
-Finney,0018 JENNIE BARKER,State Treasurer,,R,Ron Estes,281
-Finney,0019 MACK,State Treasurer,,R,Ron Estes,76
-Finney,0020 RIVERSIDE,State Treasurer,,R,Ron Estes,371
-Finney,0021 KALVESTA,State Treasurer,,R,Ron Estes,42
-Finney,0022 THEONI,State Treasurer,,R,Ron Estes,47
-Finney,0023 PLYMELL,State Treasurer,,R,Ron Estes,108
-Finney,0024 PIERCEVILLE,State Treasurer,,R,Ron Estes,111
-Finney,0025 PL VALLEY,State Treasurer,,R,Ron Estes,57
-Finney,0026 HOLCOMB,State Treasurer,,R,Ron Estes,491
-Finney,0027 FRIEND,State Treasurer,,R,Ron Estes,41
-Finney,1ST WARD,State Treasurer,,D,Carmen Alldritt,66
-Finney,2ND WARD,State Treasurer,,D,Carmen Alldritt,87
-Finney,3RD WARD,State Treasurer,,D,Carmen Alldritt,94
-Finney,4TH WARD,State Treasurer,,D,Carmen Alldritt,53
-Finney,5TH WARD,State Treasurer,,D,Carmen Alldritt,53
-Finney,6TH WARD,State Treasurer,,D,Carmen Alldritt,66
-Finney,7TH WARD,State Treasurer,,D,Carmen Alldritt,62
-Finney,8TH WARD,State Treasurer,,D,Carmen Alldritt,106
-Finney,9TH WARD,State Treasurer,,D,Carmen Alldritt,62
-Finney,10TH WARD,State Treasurer,,D,Carmen Alldritt,58
-Finney,11TH WARD,State Treasurer,,D,Carmen Alldritt,79
-Finney,12TH WARD,State Treasurer,,D,Carmen Alldritt,82
-Finney,13TH WARD,State Treasurer,,D,Carmen Alldritt,63
-Finney,14TH WARD,State Treasurer,,D,Carmen Alldritt,95
-Finney,15TH WARD,State Treasurer,,D,Carmen Alldritt,68
-Finney,16TH WARD,State Treasurer,,D,Carmen Alldritt,95
-Finney,0017 HUFFMAN,State Treasurer,,D,Carmen Alldritt,29
-Finney,0018 JENNIE BARKER,State Treasurer,,D,Carmen Alldritt,57
-Finney,0019 MACK,State Treasurer,,D,Carmen Alldritt,27
-Finney,0020 RIVERSIDE,State Treasurer,,D,Carmen Alldritt,39
-Finney,0021 KALVESTA,State Treasurer,,D,Carmen Alldritt,9
-Finney,0022 THEONI,State Treasurer,,D,Carmen Alldritt,5
-Finney,0023 PLYMELL,State Treasurer,,D,Carmen Alldritt,19
-Finney,0024 PIERCEVILLE,State Treasurer,,D,Carmen Alldritt,16
-Finney,0025 PL VALLEY,State Treasurer,,D,Carmen Alldritt,4
-Finney,0026 HOLCOMB,State Treasurer,,D,Carmen Alldritt,74
-Finney,0027 FRIEND,State Treasurer,,D,Carmen Alldritt,3
-Finney,1ST WARD,State Treasurer,,,Write-ins,0
-Finney,2ND WARD,State Treasurer,,,Write-ins,1
-Finney,3RD WARD,State Treasurer,,,Write-ins,0
-Finney,4TH WARD,State Treasurer,,,Write-ins,0
-Finney,5TH WARD,State Treasurer,,,Write-ins,0
-Finney,6TH WARD,State Treasurer,,,Write-ins,0
-Finney,7TH WARD,State Treasurer,,,Write-ins,0
-Finney,8TH WARD,State Treasurer,,,Write-ins,0
-Finney,9TH WARD,State Treasurer,,,Write-ins,1
-Finney,10TH WARD,State Treasurer,,,Write-ins,0
-Finney,11TH WARD,State Treasurer,,,Write-ins,1
-Finney,12TH WARD,State Treasurer,,,Write-ins,0
-Finney,13TH WARD,State Treasurer,,,Write-ins,0
-Finney,14TH WARD,State Treasurer,,,Write-ins,0
-Finney,15TH WARD,State Treasurer,,,Write-ins,1
-Finney,16TH WARD,State Treasurer,,,Write-ins,1
-Finney,0017 HUFFMAN,State Treasurer,,,Write-ins,0
-Finney,0018 JENNIE BARKER,State Treasurer,,,Write-ins,1
-Finney,0019 MACK,State Treasurer,,,Write-ins,0
-Finney,0020 RIVERSIDE,State Treasurer,,,Write-ins,0
-Finney,0021 KALVESTA,State Treasurer,,,Write-ins,0
-Finney,0022 THEONI,State Treasurer,,,Write-ins,0
-Finney,0023 PLYMELL,State Treasurer,,,Write-ins,0
-Finney,0024 PIERCEVILLE,State Treasurer,,,Write-ins,0
-Finney,0025 PL VALLEY,State Treasurer,,,Write-ins,0
-Finney,0026 HOLCOMB,State Treasurer,,,Write-ins,0
-Finney,0027 FRIEND,State Treasurer,,,Write-ins,0
-Finney,1ST WARD,Insurance Commissioner,,R,Ken Selzer,61
-Finney,2ND WARD,Insurance Commissioner,,R,Ken Selzer,117
-Finney,3RD WARD,Insurance Commissioner,,R,Ken Selzer,218
-Finney,4TH WARD,Insurance Commissioner,,R,Ken Selzer,186
-Finney,5TH WARD,Insurance Commissioner,,R,Ken Selzer,160
-Finney,6TH WARD,Insurance Commissioner,,R,Ken Selzer,151
-Finney,7TH WARD,Insurance Commissioner,,R,Ken Selzer,113
-Finney,8TH WARD,Insurance Commissioner,,R,Ken Selzer,173
-Finney,9TH WARD,Insurance Commissioner,,R,Ken Selzer,128
-Finney,10TH WARD,Insurance Commissioner,,R,Ken Selzer,153
-Finney,11TH WARD,Insurance Commissioner,,R,Ken Selzer,251
-Finney,12TH WARD,Insurance Commissioner,,R,Ken Selzer,331
-Finney,13TH WARD,Insurance Commissioner,,R,Ken Selzer,273
-Finney,14TH WARD,Insurance Commissioner,,R,Ken Selzer,192
-Finney,15TH WARD,Insurance Commissioner,,R,Ken Selzer,300
-Finney,16TH WARD,Insurance Commissioner,,R,Ken Selzer,328
-Finney,0017 HUFFMAN,Insurance Commissioner,,R,Ken Selzer,113
-Finney,0018 JENNIE BARKER,Insurance Commissioner,,R,Ken Selzer,270
-Finney,0019 MACK,Insurance Commissioner,,R,Ken Selzer,76
-Finney,0020 RIVERSIDE,Insurance Commissioner,,R,Ken Selzer,363
-Finney,0021 KALVESTA,Insurance Commissioner,,R,Ken Selzer,41
-Finney,0022 THEONI,Insurance Commissioner,,R,Ken Selzer,47
-Finney,0023 PLYMELL,Insurance Commissioner,,R,Ken Selzer,103
-Finney,0024 PIERCEVILLE,Insurance Commissioner,,R,Ken Selzer,103
-Finney,0025 PL VALLEY,Insurance Commissioner,,R,Ken Selzer,56
-Finney,0026 HOLCOMB,Insurance Commissioner,,R,Ken Selzer,458
-Finney,0027 FRIEND,Insurance Commissioner,,R,Ken Selzer,37
-Finney,1ST WARD,Insurance Commissioner,,D,Dennis Anderson,67
-Finney,2ND WARD,Insurance Commissioner,,D,Dennis Anderson,91
-Finney,3RD WARD,Insurance Commissioner,,D,Dennis Anderson,100
-Finney,4TH WARD,Insurance Commissioner,,D,Dennis Anderson,59
-Finney,5TH WARD,Insurance Commissioner,,D,Dennis Anderson,71
-Finney,6TH WARD,Insurance Commissioner,,D,Dennis Anderson,67
-Finney,7TH WARD,Insurance Commissioner,,D,Dennis Anderson,73
-Finney,8TH WARD,Insurance Commissioner,,D,Dennis Anderson,118
-Finney,9TH WARD,Insurance Commissioner,,D,Dennis Anderson,67
-Finney,10TH WARD,Insurance Commissioner,,D,Dennis Anderson,69
-Finney,11TH WARD,Insurance Commissioner,,D,Dennis Anderson,96
-Finney,12TH WARD,Insurance Commissioner,,D,Dennis Anderson,101
-Finney,13TH WARD,Insurance Commissioner,,D,Dennis Anderson,80
-Finney,14TH WARD,Insurance Commissioner,,D,Dennis Anderson,112
-Finney,15TH WARD,Insurance Commissioner,,D,Dennis Anderson,86
-Finney,16TH WARD,Insurance Commissioner,,D,Dennis Anderson,108
-Finney,0017 HUFFMAN,Insurance Commissioner,,D,Dennis Anderson,36
-Finney,0018 JENNIE BARKER,Insurance Commissioner,,D,Dennis Anderson,68
-Finney,0019 MACK,Insurance Commissioner,,D,Dennis Anderson,27
-Finney,0020 RIVERSIDE,Insurance Commissioner,,D,Dennis Anderson,52
-Finney,0021 KALVESTA,Insurance Commissioner,,D,Dennis Anderson,8
-Finney,0022 THEONI,Insurance Commissioner,,D,Dennis Anderson,4
-Finney,0023 PLYMELL,Insurance Commissioner,,D,Dennis Anderson,21
-Finney,0024 PIERCEVILLE,Insurance Commissioner,,D,Dennis Anderson,23
-Finney,0025 PL VALLEY,Insurance Commissioner,,D,Dennis Anderson,5
-Finney,0026 HOLCOMB,Insurance Commissioner,,D,Dennis Anderson,104
-Finney,0027 FRIEND,Insurance Commissioner,,D,Dennis Anderson,4
-Finney,1ST WARD,Insurance Commissioner,,,Write-ins,0
-Finney,2ND WARD,Insurance Commissioner,,,Write-ins,1
-Finney,3RD WARD,Insurance Commissioner,,,Write-ins,0
-Finney,4TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,5TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,6TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,7TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,8TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,9TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,10TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,11TH WARD,Insurance Commissioner,,,Write-ins,2
-Finney,12TH WARD,Insurance Commissioner,,,Write-ins,1
-Finney,13TH WARD,Insurance Commissioner,,,Write-ins,1
-Finney,14TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,15TH WARD,Insurance Commissioner,,,Write-ins,1
-Finney,16TH WARD,Insurance Commissioner,,,Write-ins,0
-Finney,0017 HUFFMAN,Insurance Commissioner,,,Write-ins,0
-Finney,0018 JENNIE BARKER,Insurance Commissioner,,,Write-ins,1
-Finney,0019 MACK,Insurance Commissioner,,,Write-ins,0
-Finney,0020 RIVERSIDE,Insurance Commissioner,,,Write-ins,0
-Finney,0021 KALVESTA,Insurance Commissioner,,,Write-ins,0
-Finney,0022 THEONI,Insurance Commissioner,,,Write-ins,0
-Finney,0023 PLYMELL,Insurance Commissioner,,,Write-ins,0
-Finney,0024 PIERCEVILLE,Insurance Commissioner,,,Write-ins,1
-Finney,0025 PL VALLEY,Insurance Commissioner,,,Write-ins,0
-Finney,0026 HOLCOMB,Insurance Commissioner,,,Write-ins,0
-Finney,0027 FRIEND,Insurance Commissioner,,,Write-ins,0
-Finney,0021 KALVESTA,State House,117,,Write-ins,1
-Finney,2ND WARD,State House,122,,Write-ins,12
-Finney,14TH WARD,State House,122,,Write-ins,2
-Finney,15TH WARD,State House,122,,Write-ins,1
-Finney,0017 HUFFMAN,State House,122,,Write-ins,2
-Finney,0018 JENNIE BARKER,State House,122,,Write-ins,7
-Finney,0019 MACK,State House,122,,Write-ins,7
-Finney,0020 RIVERSIDE,State House,122,,Write-ins,5
-Finney,0022 THEONI,State House,122,,Write-ins,1
-Finney,0023 PLYMELL,State House,122,,Write-ins,2
-Finney,0024 PIERCEVILLE,State House,122,,Write-ins,0
-Finney,0025 PL VALLEY,State House,122,,Write-ins,1
-Finney,0026 HOLCOMB,State House,122,,Write-ins,8
-Finney,0027 FRIEND,State House,122,,Write-ins,2
-Finney,1ST WARD,State House,123,,Write-ins,10
-Finney,3RD WARD,State House,123,,Write-ins,7
-Finney,4TH WARD,State House,123,,Write-ins,0
-Finney,5TH WARD,State House,123,,Write-ins,6
-Finney,6TH WARD,State House,123,,Write-ins,3
-Finney,7TH WARD,State House,123,,Write-ins,2
-Finney,8TH WARD,State House,123,,Write-ins,10
-Finney,9TH WARD,State House,123,,Write-ins,9
-Finney,10TH WARD,State House,123,,Write-ins,5
-Finney,11TH WARD,State House,123,,Write-ins,8
-Finney,12TH WARD,State House,123,,Write-ins,7
-Finney,13TH WARD,State House,123,,Write-ins,3
-Finney,14TH WARD,State House,123,,Write-ins,2
-Finney,15TH WARD,State House,123,,Write-ins,8
-Finney,16TH WARD,State House,123,,Write-ins,3
-Finney,0021 KALVESTA,State House,117,R,John Ewy,51
-Finney,2ND WARD,State House,122,R,Russell Jennings,176
-Finney,14TH WARD,State House,122,R,Russell Jennings,84
-Finney,15TH WARD,State House,122,R,Russell Jennings,145
-Finney,0017 HUFFMAN,State House,122,R,Russell Jennings,139
-Finney,0018 JENNIE BARKER,State House,122,R,Russell Jennings,312
-Finney,0019 MACK,State House,122,R,Russell Jennings,85
-Finney,0020 RIVERSIDE,State House,122,R,Russell Jennings,379
-Finney,0022 THEONI,State House,122,R,Russell Jennings,47
-Finney,0023 PLYMELL,State House,122,R,Russell Jennings,119
-Finney,0024 PIERCEVILLE,State House,122,R,Russell Jennings,124
-Finney,0025 PL VALLEY,State House,122,R,Russell Jennings,58
-Finney,0026 HOLCOMB,State House,122,R,Russell Jennings,539
-Finney,0027 FRIEND,State House,122,R,Russell Jennings,39
-Finney,1ST WARD,State House,123,R,John Doll,111
-Finney,3RD WARD,State House,123,R,John Doll,299
-Finney,4TH WARD,State House,123,R,John Doll,231
-Finney,5TH WARD,State House,123,R,John Doll,205
-Finney,6TH WARD,State House,123,R,John Doll,204
-Finney,7TH WARD,State House,123,R,John Doll,173
-Finney,8TH WARD,State House,123,R,John Doll,266
-Finney,9TH WARD,State House,123,R,John Doll,180
-Finney,10TH WARD,State House,123,R,John Doll,211
-Finney,11TH WARD,State House,123,R,John Doll,323
-Finney,12TH WARD,State House,123,R,John Doll,395
-Finney,13TH WARD,State House,123,R,John Doll,335
-Finney,14TH WARD,State House,123,R,John Doll,205
-Finney,15TH WARD,State House,123,R,John Doll,218
-Finney,16TH WARD,State House,123,R,John Doll,434
+county,precinct,office,district,party,candidate,votes,vtd
+FINNEY,Friend Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000010
+FINNEY,Friend Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+FINNEY,Friend Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000010
+FINNEY,Garden City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",139,000040
+FINNEY,Garden City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000040
+FINNEY,Garden City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",181,000040
+FINNEY,Garden City Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",97,000060
+FINNEY,Garden City Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000060
+FINNEY,Garden City Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000060
+FINNEY,Garden City Ward 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000070
+FINNEY,Garden City Ward 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000070
+FINNEY,Garden City Ward 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",123,000070
+FINNEY,Garden City Ward 7,Governor / Lt. Governor,,Democratic,"Davis, Paul",86,000080
+FINNEY,Garden City Ward 7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000080
+FINNEY,Garden City Ward 7,Governor / Lt. Governor,,Republican,"Brownback, Sam",105,000080
+FINNEY,Garden City Ward 8,Governor / Lt. Governor,,Democratic,"Davis, Paul",132,00009A
+FINNEY,Garden City Ward 8,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,00009A
+FINNEY,Garden City Ward 8,Governor / Lt. Governor,,Republican,"Brownback, Sam",156,00009A
+FINNEY,Garden City Ward 8 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00009B
+FINNEY,Garden City Ward 8 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00009B
+FINNEY,Garden City Ward 8 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00009B
+FINNEY,Garden City Ward 9,Governor / Lt. Governor,,Democratic,"Davis, Paul",97,000100
+FINNEY,Garden City Ward 9,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000100
+FINNEY,Garden City Ward 9,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000100
+FINNEY,Garden City Ward 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",99,000110
+FINNEY,Garden City Ward 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000110
+FINNEY,Garden City Ward 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",123,000110
+FINNEY,Garden City Ward 11,Governor / Lt. Governor,,Democratic,"Davis, Paul",122,000120
+FINNEY,Garden City Ward 11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000120
+FINNEY,Garden City Ward 11,Governor / Lt. Governor,,Republican,"Brownback, Sam",236,000120
+FINNEY,Garden City Ward 12,Governor / Lt. Governor,,Democratic,"Davis, Paul",151,000130
+FINNEY,Garden City Ward 12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000130
+FINNEY,Garden City Ward 12,Governor / Lt. Governor,,Republican,"Brownback, Sam",285,000130
+FINNEY,Garden City Ward 13,Governor / Lt. Governor,,Democratic,"Davis, Paul",125,000140
+FINNEY,Garden City Ward 13,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000140
+FINNEY,Garden City Ward 13,Governor / Lt. Governor,,Republican,"Brownback, Sam",238,000140
+FINNEY,Garden City Ward 16,Governor / Lt. Governor,,Democratic,"Davis, Paul",181,000170
+FINNEY,Garden City Ward 16,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000170
+FINNEY,Garden City Ward 16,Governor / Lt. Governor,,Republican,"Brownback, Sam",262,000170
+FINNEY,Garden City Ward 17,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018A
+FINNEY,Garden City Ward 17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018A
+FINNEY,Garden City Ward 17,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018A
+FINNEY,Holcomb Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",150,000190
+FINNEY,Holcomb Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000190
+FINNEY,Holcomb Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",422,000190
+FINNEY,Huffman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000200
+FINNEY,Huffman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000200
+FINNEY,Huffman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000200
+FINNEY,Jennie Barker Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",108,00021A
+FINNEY,Jennie Barker Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,00021A
+FINNEY,Jennie Barker Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",226,00021A
+FINNEY,Kalvesta Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000220
+FINNEY,Kalvesta Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000220
+FINNEY,Kalvesta Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000220
+FINNEY,Mack Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000230
+FINNEY,Mack Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000230
+FINNEY,Mack Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,000230
+FINNEY,Pleasant Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000250
+FINNEY,Pleasant Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000250
+FINNEY,Pleasant Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,000250
+FINNEY,Plymell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000260
+FINNEY,Plymell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000260
+FINNEY,Plymell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000260
+FINNEY,Theoni Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000280
+FINNEY,Theoni Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000280
+FINNEY,Theoni Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000280
+FINNEY,Garden City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,120030
+FINNEY,Garden City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,120030
+FINNEY,Garden City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,120030
+FINNEY,Garden City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,140010
+FINNEY,Garden City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,140010
+FINNEY,Garden City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",97,140010
+FINNEY,Garden City Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",83,140020
+FINNEY,Garden City Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,140020
+FINNEY,Garden City Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",163,140020
+FINNEY,Garden City Ward 14 H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,140030
+FINNEY,Garden City Ward 14 H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,140030
+FINNEY,Garden City Ward 14 H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,140030
+FINNEY,Garden City ward 14 H123,Governor / Lt. Governor,,Democratic,"Davis, Paul",140,140040
+FINNEY,Garden City ward 14 H123,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,140040
+FINNEY,Garden City ward 14 H123,Governor / Lt. Governor,,Republican,"Brownback, Sam",174,140040
+FINNEY,Garden City Ward 15 H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,140050
+FINNEY,Garden City Ward 15 H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,140050
+FINNEY,Garden City Ward 15 H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,140050
+FINNEY,Garden City ward 15 H123,Governor / Lt. Governor,,Democratic,"Davis, Paul",140,140060
+FINNEY,Garden City ward 15 H123,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,140060
+FINNEY,Garden City ward 15 H123,Governor / Lt. Governor,,Republican,"Brownback, Sam",256,140060
+FINNEY,Pierceville Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,140070
+FINNEY,Pierceville Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,140070
+FINNEY,Pierceville Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,140070
+FINNEY,Garden City Ward 4 H123,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,200020
+FINNEY,Garden City Ward 4 H123,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,200020
+FINNEY,Garden City Ward 4 H123,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,200020
+FINNEY,Pierceville Precinct H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,200040
+FINNEY,Pierceville Precinct H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,200040
+FINNEY,Pierceville Precinct H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,200040
+FINNEY,Riverside Precinct H117,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,200050
+FINNEY,Riverside Precinct H117,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,200050
+FINNEY,Riverside Precinct H117,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,200050
+FINNEY,Riverside Precinct H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",126,200060
+FINNEY,Riverside Precinct H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,200060
+FINNEY,Riverside Precinct H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",287,200060
+FINNEY,Garden City Ward 1 H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,990020
+FINNEY,Garden City Ward 1 H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,990020
+FINNEY,Garden City Ward 1 H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,990020
+FINNEY,Friend Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",39,000010
+FINNEY,Garden City Ward 3,Kansas House of Representatives,123,Republican,"Doll, John",299,000040
+FINNEY,Garden City Ward 5,Kansas House of Representatives,123,Republican,"Doll, John",205,000060
+FINNEY,Garden City Ward 6,Kansas House of Representatives,123,Republican,"Doll, John",204,000070
+FINNEY,Garden City Ward 7,Kansas House of Representatives,123,Republican,"Doll, John",173,000080
+FINNEY,Garden City Ward 8,Kansas House of Representatives,123,Republican,"Doll, John",266,00009A
+FINNEY,Garden City Ward 8 Exclave,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,00009B
+FINNEY,Garden City Ward 9,Kansas House of Representatives,123,Republican,"Doll, John",180,000100
+FINNEY,Garden City Ward 10,Kansas House of Representatives,123,Republican,"Doll, John",211,000110
+FINNEY,Garden City Ward 11,Kansas House of Representatives,123,Republican,"Doll, John",323,000120
+FINNEY,Garden City Ward 12,Kansas House of Representatives,123,Republican,"Doll, John",395,000130
+FINNEY,Garden City Ward 13,Kansas House of Representatives,123,Republican,"Doll, John",335,000140
+FINNEY,Garden City Ward 16,Kansas House of Representatives,123,Republican,"Doll, John",434,000170
+FINNEY,Garden City Ward 17,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,00018A
+FINNEY,Holcomb Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",539,000190
+FINNEY,Huffman Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",139,000200
+FINNEY,Jennie Barker Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",312,00021A
+FINNEY,Kalvesta Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",51,000220
+FINNEY,Mack Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",85,000230
+FINNEY,Pleasant Valley Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",58,000250
+FINNEY,Plymell Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",119,000260
+FINNEY,Theoni Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",47,000280
+FINNEY,Garden City Ward 1,Kansas House of Representatives,123,Republican,"Doll, John",111,120030
+FINNEY,Garden City Ward 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",176,140010
+FINNEY,Garden City Ward 4,Kansas House of Representatives,123,Republican,"Doll, John",231,140020
+FINNEY,Garden City Ward 14 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",84,140030
+FINNEY,Garden City ward 14 H123,Kansas House of Representatives,123,Republican,"Doll, John",205,140040
+FINNEY,Garden City Ward 15 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",145,140050
+FINNEY,Garden City ward 15 H123,Kansas House of Representatives,123,Republican,"Doll, John",218,140060
+FINNEY,Pierceville Precinct,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,140070
+FINNEY,Garden City Ward 4 H123,Kansas House of Representatives,123,Republican,"Doll, John",0,200020
+FINNEY,Pierceville Precinct H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",124,200040
+FINNEY,Riverside Precinct H117,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,200050
+FINNEY,Riverside Precinct H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",379,200060
+FINNEY,Garden City Ward 1 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,990020
+FINNEY,Friend Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000010
+FINNEY,Friend Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000010
+FINNEY,Garden City Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",130,000040
+FINNEY,Garden City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",195,000040
+FINNEY,Garden City Ward 5,United States House of Representatives,1,Democratic,"Sherow, James E.",100,000060
+FINNEY,Garden City Ward 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",137,000060
+FINNEY,Garden City Ward 6,United States House of Representatives,1,Democratic,"Sherow, James E.",94,000070
+FINNEY,Garden City Ward 6,United States House of Representatives,1,Republican,"Huelskamp, Tim",129,000070
+FINNEY,Garden City Ward 7,United States House of Representatives,1,Democratic,"Sherow, James E.",80,000080
+FINNEY,Garden City Ward 7,United States House of Representatives,1,Republican,"Huelskamp, Tim",115,000080
+FINNEY,Garden City Ward 8,United States House of Representatives,1,Democratic,"Sherow, James E.",130,00009A
+FINNEY,Garden City Ward 8,United States House of Representatives,1,Republican,"Huelskamp, Tim",167,00009A
+FINNEY,Garden City Ward 8 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00009B
+FINNEY,Garden City Ward 8 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00009B
+FINNEY,Garden City Ward 9,United States House of Representatives,1,Democratic,"Sherow, James E.",85,000100
+FINNEY,Garden City Ward 9,United States House of Representatives,1,Republican,"Huelskamp, Tim",113,000100
+FINNEY,Garden City Ward 10,United States House of Representatives,1,Democratic,"Sherow, James E.",100,000110
+FINNEY,Garden City Ward 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",132,000110
+FINNEY,Garden City Ward 11,United States House of Representatives,1,Democratic,"Sherow, James E.",133,000120
+FINNEY,Garden City Ward 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",226,000120
+FINNEY,Garden City Ward 12,United States House of Representatives,1,Democratic,"Sherow, James E.",188,000130
+FINNEY,Garden City Ward 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",251,000130
+FINNEY,Garden City Ward 13,United States House of Representatives,1,Democratic,"Sherow, James E.",134,000140
+FINNEY,Garden City Ward 13,United States House of Representatives,1,Republican,"Huelskamp, Tim",230,000140
+FINNEY,Garden City Ward 16,United States House of Representatives,1,Democratic,"Sherow, James E.",165,000170
+FINNEY,Garden City Ward 16,United States House of Representatives,1,Republican,"Huelskamp, Tim",283,000170
+FINNEY,Garden City Ward 17,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00018A
+FINNEY,Garden City Ward 17,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00018A
+FINNEY,Holcomb Township,United States House of Representatives,1,Democratic,"Sherow, James E.",165,000190
+FINNEY,Holcomb Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",410,000190
+FINNEY,Huffman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000200
+FINNEY,Huffman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",109,000200
+FINNEY,Jennie Barker Township,United States House of Representatives,1,Democratic,"Sherow, James E.",104,00021A
+FINNEY,Jennie Barker Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",242,00021A
+FINNEY,Kalvesta Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000220
+FINNEY,Kalvesta Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000220
+FINNEY,Mack Township,United States House of Representatives,1,Democratic,"Sherow, James E.",30,000230
+FINNEY,Mack Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000230
+FINNEY,Pleasant Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000250
+FINNEY,Pleasant Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000250
+FINNEY,Plymell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",34,000260
+FINNEY,Plymell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,000260
+FINNEY,Theoni Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000280
+FINNEY,Theoni Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000280
+FINNEY,Garden City Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",68,120030
+FINNEY,Garden City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,120030
+FINNEY,Garden City Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",99,140010
+FINNEY,Garden City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",109,140010
+FINNEY,Garden City Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",99,140020
+FINNEY,Garden City Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",152,140020
+FINNEY,Garden City Ward 14 H122,United States House of Representatives,1,Democratic,"Sherow, James E.",0,140030
+FINNEY,Garden City Ward 14 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,140030
+FINNEY,Garden City ward 14 H123,United States House of Representatives,1,Democratic,"Sherow, James E.",144,140040
+FINNEY,Garden City ward 14 H123,United States House of Representatives,1,Republican,"Huelskamp, Tim",178,140040
+FINNEY,Garden City Ward 15 H122,United States House of Representatives,1,Democratic,"Sherow, James E.",0,140050
+FINNEY,Garden City Ward 15 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,140050
+FINNEY,Garden City ward 15 H123,United States House of Representatives,1,Democratic,"Sherow, James E.",140,140060
+FINNEY,Garden City ward 15 H123,United States House of Representatives,1,Republican,"Huelskamp, Tim",259,140060
+FINNEY,Pierceville Precinct,United States House of Representatives,1,Democratic,"Sherow, James E.",0,140070
+FINNEY,Pierceville Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,140070
+FINNEY,Garden City Ward 4 H123,United States House of Representatives,1,Democratic,"Sherow, James E.",0,200020
+FINNEY,Garden City Ward 4 H123,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,200020
+FINNEY,Pierceville Precinct H122,United States House of Representatives,1,Democratic,"Sherow, James E.",34,200040
+FINNEY,Pierceville Precinct H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",96,200040
+FINNEY,Riverside Precinct H117,United States House of Representatives,1,Democratic,"Sherow, James E.",0,200050
+FINNEY,Riverside Precinct H117,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,200050
+FINNEY,Riverside Precinct H122,United States House of Representatives,1,Democratic,"Sherow, James E.",139,200060
+FINNEY,Riverside Precinct H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",279,200060
+FINNEY,Garden City Ward 1 H122,United States House of Representatives,1,Democratic,"Sherow, James E.",0,990020
+FINNEY,Garden City Ward 1 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,990020
+FINNEY,Friend Township,Attorney General,,Democratic,"Kotich, A.J.",3,000010
+FINNEY,Friend Township,Attorney General,,Republican,"Schmidt, Derek",41,000010
+FINNEY,Garden City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",94,000040
+FINNEY,Garden City Ward 3,Attorney General,,Republican,"Schmidt, Derek",234,000040
+FINNEY,Garden City Ward 5,Attorney General,,Democratic,"Kotich, A.J.",58,000060
+FINNEY,Garden City Ward 5,Attorney General,,Republican,"Schmidt, Derek",173,000060
+FINNEY,Garden City Ward 6,Attorney General,,Democratic,"Kotich, A.J.",62,000070
+FINNEY,Garden City Ward 6,Attorney General,,Republican,"Schmidt, Derek",157,000070
+FINNEY,Garden City Ward 7,Attorney General,,Democratic,"Kotich, A.J.",58,000080
+FINNEY,Garden City Ward 7,Attorney General,,Republican,"Schmidt, Derek",135,000080
+FINNEY,Garden City Ward 8,Attorney General,,Democratic,"Kotich, A.J.",102,00009A
+FINNEY,Garden City Ward 8,Attorney General,,Republican,"Schmidt, Derek",192,00009A
+FINNEY,Garden City Ward 8 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00009B
+FINNEY,Garden City Ward 8 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00009B
+FINNEY,Garden City Ward 9,Attorney General,,Democratic,"Kotich, A.J.",67,000100
+FINNEY,Garden City Ward 9,Attorney General,,Republican,"Schmidt, Derek",128,000100
+FINNEY,Garden City Ward 10,Attorney General,,Democratic,"Kotich, A.J.",64,000110
+FINNEY,Garden City Ward 10,Attorney General,,Republican,"Schmidt, Derek",168,000110
+FINNEY,Garden City Ward 11,Attorney General,,Democratic,"Kotich, A.J.",92,000120
+FINNEY,Garden City Ward 11,Attorney General,,Republican,"Schmidt, Derek",269,000120
+FINNEY,Garden City Ward 12,Attorney General,,Democratic,"Kotich, A.J.",81,000130
+FINNEY,Garden City Ward 12,Attorney General,,Republican,"Schmidt, Derek",362,000130
+FINNEY,Garden City Ward 13,Attorney General,,Democratic,"Kotich, A.J.",65,000140
+FINNEY,Garden City Ward 13,Attorney General,,Republican,"Schmidt, Derek",295,000140
+FINNEY,Garden City Ward 16,Attorney General,,Democratic,"Kotich, A.J.",99,000170
+FINNEY,Garden City Ward 16,Attorney General,,Republican,"Schmidt, Derek",346,000170
+FINNEY,Garden City Ward 17,Attorney General,,Democratic,"Kotich, A.J.",0,00018A
+FINNEY,Garden City Ward 17,Attorney General,,Republican,"Schmidt, Derek",0,00018A
+FINNEY,Holcomb Township,Attorney General,,Democratic,"Kotich, A.J.",78,000190
+FINNEY,Holcomb Township,Attorney General,,Republican,"Schmidt, Derek",489,000190
+FINNEY,Huffman Township,Attorney General,,Democratic,"Kotich, A.J.",27,000200
+FINNEY,Huffman Township,Attorney General,,Republican,"Schmidt, Derek",125,000200
+FINNEY,Jennie Barker Township,Attorney General,,Democratic,"Kotich, A.J.",69,00021A
+FINNEY,Jennie Barker Township,Attorney General,,Republican,"Schmidt, Derek",276,00021A
+FINNEY,Kalvesta Township,Attorney General,,Democratic,"Kotich, A.J.",5,000220
+FINNEY,Kalvesta Township,Attorney General,,Republican,"Schmidt, Derek",44,000220
+FINNEY,Mack Township,Attorney General,,Democratic,"Kotich, A.J.",27,000230
+FINNEY,Mack Township,Attorney General,,Republican,"Schmidt, Derek",77,000230
+FINNEY,Pleasant Valley Township,Attorney General,,Democratic,"Kotich, A.J.",4,000250
+FINNEY,Pleasant Valley Township,Attorney General,,Republican,"Schmidt, Derek",57,000250
+FINNEY,Plymell Township,Attorney General,,Democratic,"Kotich, A.J.",13,000260
+FINNEY,Plymell Township,Attorney General,,Republican,"Schmidt, Derek",115,000260
+FINNEY,Theoni Township,Attorney General,,Democratic,"Kotich, A.J.",5,000280
+FINNEY,Theoni Township,Attorney General,,Republican,"Schmidt, Derek",46,000280
+FINNEY,Garden City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",63,120030
+FINNEY,Garden City Ward 1,Attorney General,,Republican,"Schmidt, Derek",66,120030
+FINNEY,Garden City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",79,140010
+FINNEY,Garden City Ward 2,Attorney General,,Republican,"Schmidt, Derek",136,140010
+FINNEY,Garden City Ward 4,Attorney General,,Democratic,"Kotich, A.J.",52,140020
+FINNEY,Garden City Ward 4,Attorney General,,Republican,"Schmidt, Derek",197,140020
+FINNEY,Garden City Ward 14 H122,Attorney General,,Democratic,"Kotich, A.J.",0,140030
+FINNEY,Garden City Ward 14 H122,Attorney General,,Republican,"Schmidt, Derek",0,140030
+FINNEY,Garden City ward 14 H123,Attorney General,,Democratic,"Kotich, A.J.",94,140040
+FINNEY,Garden City ward 14 H123,Attorney General,,Republican,"Schmidt, Derek",221,140040
+FINNEY,Garden City Ward 15 H122,Attorney General,,Democratic,"Kotich, A.J.",0,140050
+FINNEY,Garden City Ward 15 H122,Attorney General,,Republican,"Schmidt, Derek",0,140050
+FINNEY,Garden City ward 15 H123,Attorney General,,Democratic,"Kotich, A.J.",80,140060
+FINNEY,Garden City ward 15 H123,Attorney General,,Republican,"Schmidt, Derek",313,140060
+FINNEY,Pierceville Precinct,Attorney General,,Democratic,"Kotich, A.J.",0,140070
+FINNEY,Pierceville Precinct,Attorney General,,Republican,"Schmidt, Derek",0,140070
+FINNEY,Garden City Ward 4 H123,Attorney General,,Democratic,"Kotich, A.J.",0,200020
+FINNEY,Garden City Ward 4 H123,Attorney General,,Republican,"Schmidt, Derek",0,200020
+FINNEY,Pierceville Precinct H122,Attorney General,,Democratic,"Kotich, A.J.",24,200040
+FINNEY,Pierceville Precinct H122,Attorney General,,Republican,"Schmidt, Derek",102,200040
+FINNEY,Riverside Precinct H117,Attorney General,,Democratic,"Kotich, A.J.",0,200050
+FINNEY,Riverside Precinct H117,Attorney General,,Republican,"Schmidt, Derek",0,200050
+FINNEY,Riverside Precinct H122,Attorney General,,Democratic,"Kotich, A.J.",40,200060
+FINNEY,Riverside Precinct H122,Attorney General,,Republican,"Schmidt, Derek",371,200060
+FINNEY,Garden City Ward 1 H122,Attorney General,,Democratic,"Kotich, A.J.",0,990020
+FINNEY,Garden City Ward 1 H122,Attorney General,,Republican,"Schmidt, Derek",0,990020
+FINNEY,Friend Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000010
+FINNEY,Friend Township,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000010
+FINNEY,Garden City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",100,000040
+FINNEY,Garden City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",218,000040
+FINNEY,Garden City Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000060
+FINNEY,Garden City Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",160,000060
+FINNEY,Garden City Ward 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,000070
+FINNEY,Garden City Ward 6,Commissioner of Insurance,,Republican,"Selzer, Ken",151,000070
+FINNEY,Garden City Ward 7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000080
+FINNEY,Garden City Ward 7,Commissioner of Insurance,,Republican,"Selzer, Ken",113,000080
+FINNEY,Garden City Ward 8,Commissioner of Insurance,,Democratic,"Anderson, Dennis",118,00009A
+FINNEY,Garden City Ward 8,Commissioner of Insurance,,Republican,"Selzer, Ken",173,00009A
+FINNEY,Garden City Ward 8 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00009B
+FINNEY,Garden City Ward 8 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00009B
+FINNEY,Garden City Ward 9,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,000100
+FINNEY,Garden City Ward 9,Commissioner of Insurance,,Republican,"Selzer, Ken",128,000100
+FINNEY,Garden City Ward 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000110
+FINNEY,Garden City Ward 10,Commissioner of Insurance,,Republican,"Selzer, Ken",153,000110
+FINNEY,Garden City Ward 11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",96,000120
+FINNEY,Garden City Ward 11,Commissioner of Insurance,,Republican,"Selzer, Ken",251,000120
+FINNEY,Garden City Ward 12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",101,000130
+FINNEY,Garden City Ward 12,Commissioner of Insurance,,Republican,"Selzer, Ken",331,000130
+FINNEY,Garden City Ward 13,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000140
+FINNEY,Garden City Ward 13,Commissioner of Insurance,,Republican,"Selzer, Ken",273,000140
+FINNEY,Garden City Ward 16,Commissioner of Insurance,,Democratic,"Anderson, Dennis",108,000170
+FINNEY,Garden City Ward 16,Commissioner of Insurance,,Republican,"Selzer, Ken",328,000170
+FINNEY,Garden City Ward 17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018A
+FINNEY,Garden City Ward 17,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018A
+FINNEY,Holcomb Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",104,000190
+FINNEY,Holcomb Township,Commissioner of Insurance,,Republican,"Selzer, Ken",458,000190
+FINNEY,Huffman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000200
+FINNEY,Huffman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",113,000200
+FINNEY,Jennie Barker Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",68,00021A
+FINNEY,Jennie Barker Township,Commissioner of Insurance,,Republican,"Selzer, Ken",270,00021A
+FINNEY,Kalvesta Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000220
+FINNEY,Kalvesta Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000220
+FINNEY,Mack Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000230
+FINNEY,Mack Township,Commissioner of Insurance,,Republican,"Selzer, Ken",76,000230
+FINNEY,Pleasant Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000250
+FINNEY,Pleasant Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",56,000250
+FINNEY,Plymell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000260
+FINNEY,Plymell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000260
+FINNEY,Theoni Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000280
+FINNEY,Theoni Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000280
+FINNEY,Garden City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,120030
+FINNEY,Garden City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",61,120030
+FINNEY,Garden City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,140010
+FINNEY,Garden City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",117,140010
+FINNEY,Garden City Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,140020
+FINNEY,Garden City Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",186,140020
+FINNEY,Garden City Ward 14 H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,140030
+FINNEY,Garden City Ward 14 H122,Commissioner of Insurance,,Republican,"Selzer, Ken",0,140030
+FINNEY,Garden City ward 14 H123,Commissioner of Insurance,,Democratic,"Anderson, Dennis",112,140040
+FINNEY,Garden City ward 14 H123,Commissioner of Insurance,,Republican,"Selzer, Ken",192,140040
+FINNEY,Garden City Ward 15 H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,140050
+FINNEY,Garden City Ward 15 H122,Commissioner of Insurance,,Republican,"Selzer, Ken",0,140050
+FINNEY,Garden City ward 15 H123,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,140060
+FINNEY,Garden City ward 15 H123,Commissioner of Insurance,,Republican,"Selzer, Ken",300,140060
+FINNEY,Pierceville Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,140070
+FINNEY,Pierceville Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",0,140070
+FINNEY,Garden City Ward 4 H123,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,200020
+FINNEY,Garden City Ward 4 H123,Commissioner of Insurance,,Republican,"Selzer, Ken",0,200020
+FINNEY,Pierceville Precinct H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,200040
+FINNEY,Pierceville Precinct H122,Commissioner of Insurance,,Republican,"Selzer, Ken",103,200040
+FINNEY,Riverside Precinct H117,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,200050
+FINNEY,Riverside Precinct H117,Commissioner of Insurance,,Republican,"Selzer, Ken",0,200050
+FINNEY,Riverside Precinct H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,200060
+FINNEY,Riverside Precinct H122,Commissioner of Insurance,,Republican,"Selzer, Ken",363,200060
+FINNEY,Garden City Ward 1 H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,990020
+FINNEY,Garden City Ward 1 H122,Commissioner of Insurance,,Republican,"Selzer, Ken",0,990020
+FINNEY,Friend Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000010
+FINNEY,Friend Township,Secretary of State,,Republican,"Kobach, Kris",38,000010
+FINNEY,Garden City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",120,000040
+FINNEY,Garden City Ward 3,Secretary of State,,Republican,"Kobach, Kris",211,000040
+FINNEY,Garden City Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",80,000060
+FINNEY,Garden City Ward 5,Secretary of State,,Republican,"Kobach, Kris",157,000060
+FINNEY,Garden City Ward 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",79,000070
+FINNEY,Garden City Ward 6,Secretary of State,,Republican,"Kobach, Kris",148,000070
+FINNEY,Garden City Ward 7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,000080
+FINNEY,Garden City Ward 7,Secretary of State,,Republican,"Kobach, Kris",124,000080
+FINNEY,Garden City Ward 8,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",114,00009A
+FINNEY,Garden City Ward 8,Secretary of State,,Republican,"Kobach, Kris",183,00009A
+FINNEY,Garden City Ward 8 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00009B
+FINNEY,Garden City Ward 8 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00009B
+FINNEY,Garden City Ward 9,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",82,000100
+FINNEY,Garden City Ward 9,Secretary of State,,Republican,"Kobach, Kris",122,000100
+FINNEY,Garden City Ward 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,000110
+FINNEY,Garden City Ward 10,Secretary of State,,Republican,"Kobach, Kris",156,000110
+FINNEY,Garden City Ward 11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,000120
+FINNEY,Garden City Ward 11,Secretary of State,,Republican,"Kobach, Kris",262,000120
+FINNEY,Garden City Ward 12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",127,000130
+FINNEY,Garden City Ward 12,Secretary of State,,Republican,"Kobach, Kris",316,000130
+FINNEY,Garden City Ward 13,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",96,000140
+FINNEY,Garden City Ward 13,Secretary of State,,Republican,"Kobach, Kris",273,000140
+FINNEY,Garden City Ward 16,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",126,000170
+FINNEY,Garden City Ward 16,Secretary of State,,Republican,"Kobach, Kris",326,000170
+FINNEY,Garden City Ward 17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018A
+FINNEY,Garden City Ward 17,Secretary of State,,Republican,"Kobach, Kris",0,00018A
+FINNEY,Holcomb Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",115,000190
+FINNEY,Holcomb Township,Secretary of State,,Republican,"Kobach, Kris",462,000190
+FINNEY,Huffman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000200
+FINNEY,Huffman Township,Secretary of State,,Republican,"Kobach, Kris",106,000200
+FINNEY,Jennie Barker Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",88,00021A
+FINNEY,Jennie Barker Township,Secretary of State,,Republican,"Kobach, Kris",258,00021A
+FINNEY,Kalvesta Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000220
+FINNEY,Kalvesta Township,Secretary of State,,Republican,"Kobach, Kris",44,000220
+FINNEY,Mack Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000230
+FINNEY,Mack Township,Secretary of State,,Republican,"Kobach, Kris",72,000230
+FINNEY,Pleasant Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000250
+FINNEY,Pleasant Valley Township,Secretary of State,,Republican,"Kobach, Kris",57,000250
+FINNEY,Plymell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000260
+FINNEY,Plymell Township,Secretary of State,,Republican,"Kobach, Kris",107,000260
+FINNEY,Theoni Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000280
+FINNEY,Theoni Township,Secretary of State,,Republican,"Kobach, Kris",49,000280
+FINNEY,Garden City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",76,120030
+FINNEY,Garden City Ward 1,Secretary of State,,Republican,"Kobach, Kris",57,120030
+FINNEY,Garden City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",95,140010
+FINNEY,Garden City Ward 2,Secretary of State,,Republican,"Kobach, Kris",118,140010
+FINNEY,Garden City Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,140020
+FINNEY,Garden City Ward 4,Secretary of State,,Republican,"Kobach, Kris",172,140020
+FINNEY,Garden City Ward 14 H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,140030
+FINNEY,Garden City Ward 14 H122,Secretary of State,,Republican,"Kobach, Kris",0,140030
+FINNEY,Garden City ward 14 H123,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",114,140040
+FINNEY,Garden City ward 14 H123,Secretary of State,,Republican,"Kobach, Kris",206,140040
+FINNEY,Garden City Ward 15 H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,140050
+FINNEY,Garden City Ward 15 H122,Secretary of State,,Republican,"Kobach, Kris",0,140050
+FINNEY,Garden City ward 15 H123,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",106,140060
+FINNEY,Garden City ward 15 H123,Secretary of State,,Republican,"Kobach, Kris",295,140060
+FINNEY,Pierceville Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,140070
+FINNEY,Pierceville Precinct,Secretary of State,,Republican,"Kobach, Kris",0,140070
+FINNEY,Garden City Ward 4 H123,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,200020
+FINNEY,Garden City Ward 4 H123,Secretary of State,,Republican,"Kobach, Kris",0,200020
+FINNEY,Pierceville Precinct H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,200040
+FINNEY,Pierceville Precinct H122,Secretary of State,,Republican,"Kobach, Kris",98,200040
+FINNEY,Riverside Precinct H117,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,200050
+FINNEY,Riverside Precinct H117,Secretary of State,,Republican,"Kobach, Kris",0,200050
+FINNEY,Riverside Precinct H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",96,200060
+FINNEY,Riverside Precinct H122,Secretary of State,,Republican,"Kobach, Kris",323,200060
+FINNEY,Garden City Ward 1 H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,990020
+FINNEY,Garden City Ward 1 H122,Secretary of State,,Republican,"Kobach, Kris",0,990020
+FINNEY,Friend Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000010
+FINNEY,Friend Township,State Treasurer,,Republican,"Estes, Ron",41,000010
+FINNEY,Garden City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",94,000040
+FINNEY,Garden City Ward 3,State Treasurer,,Republican,"Estes, Ron",232,000040
+FINNEY,Garden City Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",53,000060
+FINNEY,Garden City Ward 5,State Treasurer,,Republican,"Estes, Ron",178,000060
+FINNEY,Garden City Ward 6,State Treasurer,,Democratic,"Alldritt, Carmen",66,000070
+FINNEY,Garden City Ward 6,State Treasurer,,Republican,"Estes, Ron",155,000070
+FINNEY,Garden City Ward 7,State Treasurer,,Democratic,"Alldritt, Carmen",62,000080
+FINNEY,Garden City Ward 7,State Treasurer,,Republican,"Estes, Ron",130,000080
+FINNEY,Garden City Ward 8,State Treasurer,,Democratic,"Alldritt, Carmen",106,00009A
+FINNEY,Garden City Ward 8,State Treasurer,,Republican,"Estes, Ron",185,00009A
+FINNEY,Garden City Ward 8 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00009B
+FINNEY,Garden City Ward 8 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00009B
+FINNEY,Garden City Ward 9,State Treasurer,,Democratic,"Alldritt, Carmen",62,000100
+FINNEY,Garden City Ward 9,State Treasurer,,Republican,"Estes, Ron",136,000100
+FINNEY,Garden City Ward 10,State Treasurer,,Democratic,"Alldritt, Carmen",58,000110
+FINNEY,Garden City Ward 10,State Treasurer,,Republican,"Estes, Ron",173,000110
+FINNEY,Garden City Ward 11,State Treasurer,,Democratic,"Alldritt, Carmen",79,000120
+FINNEY,Garden City Ward 11,State Treasurer,,Republican,"Estes, Ron",277,000120
+FINNEY,Garden City Ward 12,State Treasurer,,Democratic,"Alldritt, Carmen",82,000130
+FINNEY,Garden City Ward 12,State Treasurer,,Republican,"Estes, Ron",355,000130
+FINNEY,Garden City Ward 13,State Treasurer,,Democratic,"Alldritt, Carmen",63,000140
+FINNEY,Garden City Ward 13,State Treasurer,,Republican,"Estes, Ron",295,000140
+FINNEY,Garden City Ward 16,State Treasurer,,Democratic,"Alldritt, Carmen",95,000170
+FINNEY,Garden City Ward 16,State Treasurer,,Republican,"Estes, Ron",347,000170
+FINNEY,Garden City Ward 17,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018A
+FINNEY,Garden City Ward 17,State Treasurer,,Republican,"Estes, Ron",0,00018A
+FINNEY,Holcomb Township,State Treasurer,,Democratic,"Alldritt, Carmen",74,000190
+FINNEY,Holcomb Township,State Treasurer,,Republican,"Estes, Ron",491,000190
+FINNEY,Huffman Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000200
+FINNEY,Huffman Township,State Treasurer,,Republican,"Estes, Ron",121,000200
+FINNEY,Jennie Barker Township,State Treasurer,,Democratic,"Alldritt, Carmen",57,00021A
+FINNEY,Jennie Barker Township,State Treasurer,,Republican,"Estes, Ron",281,00021A
+FINNEY,Kalvesta Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000220
+FINNEY,Kalvesta Township,State Treasurer,,Republican,"Estes, Ron",42,000220
+FINNEY,Mack Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000230
+FINNEY,Mack Township,State Treasurer,,Republican,"Estes, Ron",76,000230
+FINNEY,Pleasant Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000250
+FINNEY,Pleasant Valley Township,State Treasurer,,Republican,"Estes, Ron",57,000250
+FINNEY,Plymell Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000260
+FINNEY,Plymell Township,State Treasurer,,Republican,"Estes, Ron",108,000260
+FINNEY,Theoni Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000280
+FINNEY,Theoni Township,State Treasurer,,Republican,"Estes, Ron",47,000280
+FINNEY,Garden City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",66,120030
+FINNEY,Garden City Ward 1,State Treasurer,,Republican,"Estes, Ron",60,120030
+FINNEY,Garden City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",87,140010
+FINNEY,Garden City Ward 2,State Treasurer,,Republican,"Estes, Ron",127,140010
+FINNEY,Garden City Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",53,140020
+FINNEY,Garden City Ward 4,State Treasurer,,Republican,"Estes, Ron",192,140020
+FINNEY,Garden City Ward 14 H122,State Treasurer,,Democratic,"Alldritt, Carmen",0,140030
+FINNEY,Garden City Ward 14 H122,State Treasurer,,Republican,"Estes, Ron",0,140030
+FINNEY,Garden City ward 14 H123,State Treasurer,,Democratic,"Alldritt, Carmen",95,140040
+FINNEY,Garden City ward 14 H123,State Treasurer,,Republican,"Estes, Ron",214,140040
+FINNEY,Garden City Ward 15 H122,State Treasurer,,Democratic,"Alldritt, Carmen",0,140050
+FINNEY,Garden City Ward 15 H122,State Treasurer,,Republican,"Estes, Ron",0,140050
+FINNEY,Garden City ward 15 H123,State Treasurer,,Democratic,"Alldritt, Carmen",68,140060
+FINNEY,Garden City ward 15 H123,State Treasurer,,Republican,"Estes, Ron",328,140060
+FINNEY,Pierceville Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",0,140070
+FINNEY,Pierceville Precinct,State Treasurer,,Republican,"Estes, Ron",0,140070
+FINNEY,Garden City Ward 4 H123,State Treasurer,,Democratic,"Alldritt, Carmen",0,200020
+FINNEY,Garden City Ward 4 H123,State Treasurer,,Republican,"Estes, Ron",0,200020
+FINNEY,Pierceville Precinct H122,State Treasurer,,Democratic,"Alldritt, Carmen",16,200040
+FINNEY,Pierceville Precinct H122,State Treasurer,,Republican,"Estes, Ron",111,200040
+FINNEY,Riverside Precinct H117,State Treasurer,,Democratic,"Alldritt, Carmen",0,200050
+FINNEY,Riverside Precinct H117,State Treasurer,,Republican,"Estes, Ron",0,200050
+FINNEY,Riverside Precinct H122,State Treasurer,,Democratic,"Alldritt, Carmen",39,200060
+FINNEY,Riverside Precinct H122,State Treasurer,,Republican,"Estes, Ron",371,200060
+FINNEY,Garden City Ward 1 H122,State Treasurer,,Democratic,"Alldritt, Carmen",0,990020
+FINNEY,Garden City Ward 1 H122,State Treasurer,,Republican,"Estes, Ron",0,990020
+FINNEY,Friend Township,United States Senate,,independent,"Orman, Greg",7,000010
+FINNEY,Friend Township,United States Senate,,Libertarian,"Batson, Randall",4,000010
+FINNEY,Friend Township,United States Senate,,Republican,"Roberts, Pat",34,000010
+FINNEY,Garden City Ward 3,United States Senate,,independent,"Orman, Greg",125,000040
+FINNEY,Garden City Ward 3,United States Senate,,Libertarian,"Batson, Randall",20,000040
+FINNEY,Garden City Ward 3,United States Senate,,Republican,"Roberts, Pat",186,000040
+FINNEY,Garden City Ward 5,United States Senate,,independent,"Orman, Greg",80,000060
+FINNEY,Garden City Ward 5,United States Senate,,Libertarian,"Batson, Randall",10,000060
+FINNEY,Garden City Ward 5,United States Senate,,Republican,"Roberts, Pat",147,000060
+FINNEY,Garden City Ward 6,United States Senate,,independent,"Orman, Greg",84,000070
+FINNEY,Garden City Ward 6,United States Senate,,Libertarian,"Batson, Randall",15,000070
+FINNEY,Garden City Ward 6,United States Senate,,Republican,"Roberts, Pat",129,000070
+FINNEY,Garden City Ward 7,United States Senate,,independent,"Orman, Greg",66,000080
+FINNEY,Garden City Ward 7,United States Senate,,Libertarian,"Batson, Randall",10,000080
+FINNEY,Garden City Ward 7,United States Senate,,Republican,"Roberts, Pat",123,000080
+FINNEY,Garden City Ward 8,United States Senate,,independent,"Orman, Greg",107,00009A
+FINNEY,Garden City Ward 8,United States Senate,,Libertarian,"Batson, Randall",27,00009A
+FINNEY,Garden City Ward 8,United States Senate,,Republican,"Roberts, Pat",165,00009A
+FINNEY,Garden City Ward 8 Exclave,United States Senate,,independent,"Orman, Greg",0,00009B
+FINNEY,Garden City Ward 8 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00009B
+FINNEY,Garden City Ward 8 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00009B
+FINNEY,Garden City Ward 9,United States Senate,,independent,"Orman, Greg",78,000100
+FINNEY,Garden City Ward 9,United States Senate,,Libertarian,"Batson, Randall",18,000100
+FINNEY,Garden City Ward 9,United States Senate,,Republican,"Roberts, Pat",106,000100
+FINNEY,Garden City Ward 10,United States Senate,,independent,"Orman, Greg",83,000110
+FINNEY,Garden City Ward 10,United States Senate,,Libertarian,"Batson, Randall",14,000110
+FINNEY,Garden City Ward 10,United States Senate,,Republican,"Roberts, Pat",136,000110
+FINNEY,Garden City Ward 11,United States Senate,,independent,"Orman, Greg",114,000120
+FINNEY,Garden City Ward 11,United States Senate,,Libertarian,"Batson, Randall",14,000120
+FINNEY,Garden City Ward 11,United States Senate,,Republican,"Roberts, Pat",238,000120
+FINNEY,Garden City Ward 12,United States Senate,,independent,"Orman, Greg",139,000130
+FINNEY,Garden City Ward 12,United States Senate,,Libertarian,"Batson, Randall",10,000130
+FINNEY,Garden City Ward 12,United States Senate,,Republican,"Roberts, Pat",299,000130
+FINNEY,Garden City Ward 13,United States Senate,,independent,"Orman, Greg",99,000140
+FINNEY,Garden City Ward 13,United States Senate,,Libertarian,"Batson, Randall",13,000140
+FINNEY,Garden City Ward 13,United States Senate,,Republican,"Roberts, Pat",257,000140
+FINNEY,Garden City Ward 16,United States Senate,,independent,"Orman, Greg",141,000170
+FINNEY,Garden City Ward 16,United States Senate,,Libertarian,"Batson, Randall",20,000170
+FINNEY,Garden City Ward 16,United States Senate,,Republican,"Roberts, Pat",297,000170
+FINNEY,Garden City Ward 17,United States Senate,,independent,"Orman, Greg",0,00018A
+FINNEY,Garden City Ward 17,United States Senate,,Libertarian,"Batson, Randall",0,00018A
+FINNEY,Garden City Ward 17,United States Senate,,Republican,"Roberts, Pat",0,00018A
+FINNEY,Holcomb Township,United States Senate,,independent,"Orman, Greg",121,000190
+FINNEY,Holcomb Township,United States Senate,,Libertarian,"Batson, Randall",18,000190
+FINNEY,Holcomb Township,United States Senate,,Republican,"Roberts, Pat",444,000190
+FINNEY,Huffman Township,United States Senate,,independent,"Orman, Greg",38,000200
+FINNEY,Huffman Township,United States Senate,,Libertarian,"Batson, Randall",8,000200
+FINNEY,Huffman Township,United States Senate,,Republican,"Roberts, Pat",108,000200
+FINNEY,Jennie Barker Township,United States Senate,,independent,"Orman, Greg",88,00021A
+FINNEY,Jennie Barker Township,United States Senate,,Libertarian,"Batson, Randall",13,00021A
+FINNEY,Jennie Barker Township,United States Senate,,Republican,"Roberts, Pat",246,00021A
+FINNEY,Kalvesta Township,United States Senate,,independent,"Orman, Greg",5,000220
+FINNEY,Kalvesta Township,United States Senate,,Libertarian,"Batson, Randall",1,000220
+FINNEY,Kalvesta Township,United States Senate,,Republican,"Roberts, Pat",46,000220
+FINNEY,Mack Township,United States Senate,,independent,"Orman, Greg",28,000230
+FINNEY,Mack Township,United States Senate,,Libertarian,"Batson, Randall",7,000230
+FINNEY,Mack Township,United States Senate,,Republican,"Roberts, Pat",67,000230
+FINNEY,Pleasant Valley Township,United States Senate,,independent,"Orman, Greg",4,000250
+FINNEY,Pleasant Valley Township,United States Senate,,Libertarian,"Batson, Randall",0,000250
+FINNEY,Pleasant Valley Township,United States Senate,,Republican,"Roberts, Pat",57,000250
+FINNEY,Plymell Township,United States Senate,,independent,"Orman, Greg",20,000260
+FINNEY,Plymell Township,United States Senate,,Libertarian,"Batson, Randall",3,000260
+FINNEY,Plymell Township,United States Senate,,Republican,"Roberts, Pat",106,000260
+FINNEY,Theoni Township,United States Senate,,independent,"Orman, Greg",6,000280
+FINNEY,Theoni Township,United States Senate,,Libertarian,"Batson, Randall",2,000280
+FINNEY,Theoni Township,United States Senate,,Republican,"Roberts, Pat",47,000280
+FINNEY,Garden City Ward 1,United States Senate,,independent,"Orman, Greg",64,120030
+FINNEY,Garden City Ward 1,United States Senate,,Libertarian,"Batson, Randall",12,120030
+FINNEY,Garden City Ward 1,United States Senate,,Republican,"Roberts, Pat",56,120030
+FINNEY,Garden City Ward 2,United States Senate,,independent,"Orman, Greg",87,140010
+FINNEY,Garden City Ward 2,United States Senate,,Libertarian,"Batson, Randall",14,140010
+FINNEY,Garden City Ward 2,United States Senate,,Republican,"Roberts, Pat",114,140010
+FINNEY,Garden City Ward 4,United States Senate,,independent,"Orman, Greg",80,140020
+FINNEY,Garden City Ward 4,United States Senate,,Libertarian,"Batson, Randall",8,140020
+FINNEY,Garden City Ward 4,United States Senate,,Republican,"Roberts, Pat",166,140020
+FINNEY,Garden City Ward 14 H122,United States Senate,,independent,"Orman, Greg",0,140030
+FINNEY,Garden City Ward 14 H122,United States Senate,,Libertarian,"Batson, Randall",0,140030
+FINNEY,Garden City Ward 14 H122,United States Senate,,Republican,"Roberts, Pat",0,140030
+FINNEY,Garden City ward 14 H123,United States Senate,,independent,"Orman, Greg",120,140040
+FINNEY,Garden City ward 14 H123,United States Senate,,Libertarian,"Batson, Randall",12,140040
+FINNEY,Garden City ward 14 H123,United States Senate,,Republican,"Roberts, Pat",190,140040
+FINNEY,Garden City Ward 15 H122,United States Senate,,independent,"Orman, Greg",0,140050
+FINNEY,Garden City Ward 15 H122,United States Senate,,Libertarian,"Batson, Randall",0,140050
+FINNEY,Garden City Ward 15 H122,United States Senate,,Republican,"Roberts, Pat",0,140050
+FINNEY,Garden City ward 15 H123,United States Senate,,independent,"Orman, Greg",112,140060
+FINNEY,Garden City ward 15 H123,United States Senate,,Libertarian,"Batson, Randall",16,140060
+FINNEY,Garden City ward 15 H123,United States Senate,,Republican,"Roberts, Pat",277,140060
+FINNEY,Pierceville Precinct,United States Senate,,independent,"Orman, Greg",0,140070
+FINNEY,Pierceville Precinct,United States Senate,,Libertarian,"Batson, Randall",0,140070
+FINNEY,Pierceville Precinct,United States Senate,,Republican,"Roberts, Pat",0,140070
+FINNEY,Garden City Ward 4 H123,United States Senate,,independent,"Orman, Greg",0,200020
+FINNEY,Garden City Ward 4 H123,United States Senate,,Libertarian,"Batson, Randall",0,200020
+FINNEY,Garden City Ward 4 H123,United States Senate,,Republican,"Roberts, Pat",0,200020
+FINNEY,Pierceville Precinct H122,United States Senate,,independent,"Orman, Greg",28,200040
+FINNEY,Pierceville Precinct H122,United States Senate,,Libertarian,"Batson, Randall",4,200040
+FINNEY,Pierceville Precinct H122,United States Senate,,Republican,"Roberts, Pat",97,200040
+FINNEY,Riverside Precinct H117,United States Senate,,independent,"Orman, Greg",0,200050
+FINNEY,Riverside Precinct H117,United States Senate,,Libertarian,"Batson, Randall",0,200050
+FINNEY,Riverside Precinct H117,United States Senate,,Republican,"Roberts, Pat",0,200050
+FINNEY,Riverside Precinct H122,United States Senate,,independent,"Orman, Greg",104,200060
+FINNEY,Riverside Precinct H122,United States Senate,,Libertarian,"Batson, Randall",9,200060
+FINNEY,Riverside Precinct H122,United States Senate,,Republican,"Roberts, Pat",308,200060
+FINNEY,Garden City Ward 1 H122,United States Senate,,independent,"Orman, Greg",0,990020
+FINNEY,Garden City Ward 1 H122,United States Senate,,Libertarian,"Batson, Randall",0,990020
+FINNEY,Garden City Ward 1 H122,United States Senate,,Republican,"Roberts, Pat",0,990020

--- a/2014/20141104__ks__general__ford__precinct.csv
+++ b/2014/20141104__ks__general__ford__precinct.csv
@@ -1,515 +1,766 @@
-county,precinct,office,district,party,candidate,votes
-Ford,Bloom twp,Attorney General,,D,Kotich,3
-Ford,Bucklin city,Attorney General,,D,Kotich,30
-Ford,Bucklin twp,Attorney General,,D,Kotich,4
-Ford,Concord twp,Attorney General,,D,Kotich,6
-Ford,Dodge City 1,Attorney General,,D,Kotich,123
-Ford,Dodge City 2,Attorney General,,D,Kotich,83
-Ford,Dodge City 3,Attorney General,,D,Kotich,128
-Ford,Dodge City 4,Attorney General,,D,Kotich,193
-Ford,Dodge City 5,Attorney General,,D,Kotich,246
-Ford,Dodge City 6,Attorney General,,D,Kotich,316
-Ford,Dodge City 7,Attorney General,,D,Kotich,4
-Ford,Dodge City 9,Attorney General,,D,Kotich,1
-Ford,Dodge twp 115,Attorney General,,D,Kotich,33
-Ford,Dodge twp 119,Attorney General,,D,Kotich,2
-Ford,Enterprise twp 115,Attorney General,,D,Kotich,41
-Ford,Enterprise twp 119,Attorney General,,D,Kotich,2
-Ford,Fairview twp,Attorney General,,D,Kotich,15
-Ford,Ford City,Attorney General,,D,Kotich,8
-Ford,Ford twp,Attorney General,,D,Kotich,7
-Ford,Grandview twp 115,Attorney General,,D,Kotich,25
-Ford,Grandview twp 2 115,Attorney General,,D,Kotich,13
-Ford,Richland twp,Attorney General,,D,Kotich,37
-Ford,Royal twp,Attorney General,,D,Kotich,14
-Ford,Sodville twp,Attorney General,,D,Kotich,1
-Ford,Spearville city,Attorney General,,D,Kotich,56
-Ford,Spearville twp,Attorney General,,D,Kotich,24
-Ford,Wheatland twp,Attorney General,,D,Kotich,2
-Ford,Wilburn twp,Attorney General,,D,Kotich,2
-Ford,Bloom twp,Attorney General,,R,Schmidt,27
-Ford,Bucklin city,Attorney General,,R,Schmidt,208
-Ford,Bucklin twp,Attorney General,,R,Schmidt,48
-Ford,Concord twp,Attorney General,,R,Schmidt,40
-Ford,Dodge City 1,Attorney General,,R,Schmidt,241
-Ford,Dodge City 2,Attorney General,,R,Schmidt,142
-Ford,Dodge City 3,Attorney General,,R,Schmidt,140
-Ford,Dodge City 4,Attorney General,,R,Schmidt,424
-Ford,Dodge City 5,Attorney General,,R,Schmidt,834
-Ford,Dodge City 6,Attorney General,,R,Schmidt,1090
-Ford,Dodge City 7,Attorney General,,R,Schmidt,49
-Ford,Dodge City 9,Attorney General,,R,Schmidt,4
-Ford,Dodge twp 115,Attorney General,,R,Schmidt,142
-Ford,Dodge twp 119,Attorney General,,R,Schmidt,31
-Ford,Enterprise twp 115,Attorney General,,R,Schmidt,102
-Ford,Enterprise twp 119,Attorney General,,R,Schmidt,0
-Ford,Fairview twp,Attorney General,,R,Schmidt,80
-Ford,Ford City,Attorney General,,R,Schmidt,66
-Ford,Ford twp,Attorney General,,R,Schmidt,58
-Ford,Grandview twp 115,Attorney General,,R,Schmidt,132
-Ford,Grandview twp 2 115,Attorney General,,R,Schmidt,26
-Ford,Richland twp,Attorney General,,R,Schmidt,135
-Ford,Royal twp,Attorney General,,R,Schmidt,90
-Ford,Sodville twp,Attorney General,,R,Schmidt,37
-Ford,Spearville city,Attorney General,,R,Schmidt,236
-Ford,Spearville twp,Attorney General,,R,Schmidt,117
-Ford,Wheatland twp,Attorney General,,R,Schmidt,59
-Ford,Wilburn twp,Attorney General,,R,Schmidt,29
-Ford,Bloom twp,Comm of Ins,,D,Anderson,6
-Ford,Bucklin city,Comm of Ins,,D,Anderson,35
-Ford,Bucklin twp,Comm of Ins,,D,Anderson,6
-Ford,Concord twp,Comm of Ins,,D,Anderson,11
-Ford,Dodge City 1,Comm of Ins,,D,Anderson,138
-Ford,Dodge City 2,Comm of Ins,,D,Anderson,95
-Ford,Dodge City 3,Comm of Ins,,D,Anderson,139
-Ford,Dodge City 4,Comm of Ins,,D,Anderson,209
-Ford,Dodge City 5,Comm of Ins,,D,Anderson,301
-Ford,Dodge City 6,Comm of Ins,,D,Anderson,389
-Ford,Dodge City 7,Comm of Ins,,D,Anderson,7
-Ford,Dodge City 9,Comm of Ins,,D,Anderson,1
-Ford,Dodge twp 115,Comm of Ins,,D,Anderson,48
-Ford,Dodge twp 119,Comm of Ins,,D,Anderson,3
-Ford,Enterprise twp 115,Comm of Ins,,D,Anderson,44
-Ford,Enterprise twp 119,Comm of Ins,,D,Anderson,2
-Ford,Fairview twp,Comm of Ins,,D,Anderson,16
-Ford,Ford City,Comm of Ins,,D,Anderson,6
-Ford,Ford twp,Comm of Ins,,D,Anderson,7
-Ford,Grandview twp 115,Comm of Ins,,D,Anderson,30
-Ford,Grandview twp 2 115,Comm of Ins,,D,Anderson,13
-Ford,Richland twp,Comm of Ins,,D,Anderson,38
-Ford,Royal twp,Comm of Ins,,D,Anderson,14
-Ford,Sodville twp,Comm of Ins,,D,Anderson,1
-Ford,Spearville city,Comm of Ins,,D,Anderson,73
-Ford,Spearville twp,Comm of Ins,,D,Anderson,20
-Ford,Wheatland twp,Comm of Ins,,D,Anderson,9
-Ford,Wilburn twp,Comm of Ins,,D,Anderson,4
-Ford,Bloom twp,Comm of Ins,,R,Selzer,23
-Ford,Bucklin city,Comm of Ins,,R,Selzer,198
-Ford,Bucklin twp,Comm of Ins,,R,Selzer,49
-Ford,Concord twp,Comm of Ins,,R,Selzer,35
-Ford,Dodge City 1,Comm of Ins,,R,Selzer,224
-Ford,Dodge City 2,Comm of Ins,,R,Selzer,127
-Ford,Dodge City 3,Comm of Ins,,R,Selzer,127
-Ford,Dodge City 4,Comm of Ins,,R,Selzer,388
-Ford,Dodge City 5,Comm of Ins,,R,Selzer,751
-Ford,Dodge City 6,Comm of Ins,,R,Selzer,977
-Ford,Dodge City 7,Comm of Ins,,R,Selzer,44
-Ford,Dodge City 9,Comm of Ins,,R,Selzer,3
-Ford,Dodge twp 115,Comm of Ins,,R,Selzer,124
-Ford,Dodge twp 119,Comm of Ins,,R,Selzer,30
-Ford,Enterprise twp 115,Comm of Ins,,R,Selzer,96
-Ford,Enterprise twp 119,Comm of Ins,,R,Selzer,0
-Ford,Fairview twp,Comm of Ins,,R,Selzer,78
-Ford,Ford City,Comm of Ins,,R,Selzer,65
-Ford,Ford twp,Comm of Ins,,R,Selzer,58
-Ford,Grandview twp 115,Comm of Ins,,R,Selzer,125
-Ford,Grandview twp 2 115,Comm of Ins,,R,Selzer,29
-Ford,Richland twp,Comm of Ins,,R,Selzer,131
-Ford,Royal twp,Comm of Ins,,R,Selzer,88
-Ford,Sodville twp,Comm of Ins,,R,Selzer,34
-Ford,Spearville city,Comm of Ins,,R,Selzer,206
-Ford,Spearville twp,Comm of Ins,,R,Selzer,118
-Ford,Wheatland twp,Comm of Ins,,R,Selzer,50
-Ford,Wilburn twp,Comm of Ins,,R,Selzer,26
-Ford,Bloom twp,Governor,,R,Brownback,28
-Ford,Bucklin city,Governor,,R,Brownback,185
-Ford,Bucklin twp,Governor,,R,Brownback,38
-Ford,Concord twp,Governor,,R,Brownback,34
-Ford,Dodge City 1,Governor,,R,Brownback,211
-Ford,Dodge City 2,Governor,,R,Brownback,116
-Ford,Dodge City 3,Governor,,R,Brownback,122
-Ford,Dodge City 4,Governor,,R,Brownback,343
-Ford,Dodge City 5,Governor,,R,Brownback,647
-Ford,Dodge City 6,Governor,,R,Brownback,855
-Ford,Dodge City 7,Governor,,R,Brownback,36
-Ford,Dodge City 9,Governor,,R,Brownback,3
-Ford,Dodge twp 115,Governor,,R,Brownback,124
-Ford,Dodge twp 119,Governor,,R,Brownback,24
-Ford,Enterprise twp 115,Governor,,R,Brownback,99
-Ford,Enterprise twp 119,Governor,,R,Brownback,0
-Ford,Fairview twp,Governor,,R,Brownback,66
-Ford,Ford City,Governor,,R,Brownback,62
-Ford,Ford twp,Governor,,R,Brownback,56
-Ford,Grandview twp 115,Governor,,R,Brownback,118
-Ford,Grandview twp 2 115,Governor,,R,Brownback,30
-Ford,Richland twp,Governor,,R,Brownback,116
-Ford,Royal twp,Governor,,R,Brownback,73
-Ford,Sodville twp,Governor,,R,Brownback,35
-Ford,Spearville city,Governor,,R,Brownback,189
-Ford,Spearville twp,Governor,,R,Brownback,117
-Ford,Wheatland twp,Governor,,R,Brownback,54
-Ford,Wilburn twp,Governor,,R,Brownback,25
-Ford,Bloom twp,Governor,,D,Davis,1
-Ford,Bucklin city,Governor,,D,Davis,58
-Ford,Bucklin twp,Governor,,D,Davis,16
-Ford,Concord twp,Governor,,D,Davis,11
-Ford,Dodge City 1,Governor,,D,Davis,143
-Ford,Dodge City 2,Governor,,D,Davis,94
-Ford,Dodge City 3,Governor,,D,Davis,137
-Ford,Dodge City 4,Governor,,D,Davis,252
-Ford,Dodge City 5,Governor,,D,Davis,414
-Ford,Dodge City 6,Governor,,D,Davis,534
-Ford,Dodge City 7,Governor,,D,Davis,17
-Ford,Dodge City 9,Governor,,D,Davis,2
-Ford,Dodge twp 115,Governor,,D,Davis,49
-Ford,Dodge twp 119,Governor,,D,Davis,10
-Ford,Enterprise twp 115,Governor,,D,Davis,41
-Ford,Enterprise twp 119,Governor,,D,Davis,1
-Ford,Fairview twp,Governor,,D,Davis,25
-Ford,Ford City,Governor,,D,Davis,9
-Ford,Ford twp,Governor,,D,Davis,8
-Ford,Grandview twp 115,Governor,,D,Davis,36
-Ford,Grandview twp 2 115,Governor,,D,Davis,13
-Ford,Richland twp,Governor,,D,Davis,46
-Ford,Royal twp,Governor,,D,Davis,30
-Ford,Sodville twp,Governor,,D,Davis,3
-Ford,Spearville city,Governor,,D,Davis,100
-Ford,Spearville twp,Governor,,D,Davis,20
-Ford,Wheatland twp,Governor,,D,Davis,8
-Ford,Wilburn twp,Governor,,D,Davis,5
-Ford,Bloom twp,Governor,,L,Umbehr,1
-Ford,Bucklin city,Governor,,L,Umbehr,11
-Ford,Bucklin twp,Governor,,L,Umbehr,2
-Ford,Concord twp,Governor,,L,Umbehr,1
-Ford,Dodge City 1,Governor,,L,Umbehr,21
-Ford,Dodge City 2,Governor,,L,Umbehr,19
-Ford,Dodge City 3,Governor,,L,Umbehr,12
-Ford,Dodge City 4,Governor,,L,Umbehr,38
-Ford,Dodge City 5,Governor,,L,Umbehr,42
-Ford,Dodge City 6,Governor,,L,Umbehr,49
-Ford,Dodge City 7,Governor,,L,Umbehr,2
-Ford,Dodge City 9,Governor,,L,Umbehr,0
-Ford,Dodge twp 115,Governor,,L,Umbehr,9
-Ford,Dodge twp 119,Governor,,L,Umbehr,1
-Ford,Enterprise twp 115,Governor,,L,Umbehr,7
-Ford,Enterprise twp 119,Governor,,L,Umbehr,1
-Ford,Fairview twp,Governor,,L,Umbehr,7
-Ford,Ford City,Governor,,L,Umbehr,4
-Ford,Ford twp,Governor,,L,Umbehr,2
-Ford,Grandview twp 115,Governor,,L,Umbehr,5
-Ford,Grandview twp 2 115,Governor,,L,Umbehr,1
-Ford,Richland twp,Governor,,L,Umbehr,12
-Ford,Royal twp,Governor,,L,Umbehr,1
-Ford,Sodville twp,Governor,,L,Umbehr,1
-Ford,Spearville city,Governor,,L,Umbehr,14
-Ford,Spearville twp,Governor,,L,Umbehr,7
-Ford,Wheatland twp,Governor,,L,Umbehr,3
-Ford,Wilburn twp,Governor,,L,Umbehr,0
-Ford,Bloom twp,Secretary of State,,R,Kobach,27
-Ford,Bucklin city,Secretary of State,,R,Kobach,211
-Ford,Bucklin twp,Secretary of State,,R,Kobach,46
-Ford,Concord twp,Secretary of State,,R,Kobach,37
-Ford,Dodge City 1,Secretary of State,,R,Kobach,234
-Ford,Dodge City 2,Secretary of State,,R,Kobach,134
-Ford,Dodge City 3,Secretary of State,,R,Kobach,131
-Ford,Dodge City 4,Secretary of State,,R,Kobach,406
-Ford,Dodge City 5,Secretary of State,,R,Kobach,764
-Ford,Dodge City 6,Secretary of State,,R,Kobach,991
-Ford,Dodge City 7,Secretary of State,,R,Kobach,40
-Ford,Dodge City 9,Secretary of State,,R,Kobach,2
-Ford,Dodge twp 115,Secretary of State,,R,Kobach,129
-Ford,Dodge twp 119,Secretary of State,,R,Kobach,26
-Ford,Enterprise twp 115,Secretary of State,,R,Kobach,102
-Ford,Enterprise twp 119,Secretary of State,,R,Kobach,0
-Ford,Fairview twp,Secretary of State,,R,Kobach,81
-Ford,Ford City,Secretary of State,,R,Kobach,66
-Ford,Ford twp,Secretary of State,,R,Kobach,55
-Ford,Grandview twp 115,Secretary of State,,R,Kobach,129
-Ford,Grandview twp 2 115,Secretary of State,,R,Kobach,29
-Ford,Richland twp,Secretary of State,,R,Kobach,134
-Ford,Royal twp,Secretary of State,,R,Kobach,85
-Ford,Sodville twp,Secretary of State,,R,Kobach,33
-Ford,Spearville city,Secretary of State,,R,Kobach,222
-Ford,Spearville twp,Secretary of State,,R,Kobach,119
-Ford,Wheatland twp,Secretary of State,,R,Kobach,57
-Ford,Wilburn twp,Secretary of State,,R,Kobach,27
-Ford,Bloom twp,Secretary of State,,D,Schodorf,3
-Ford,Bucklin city,Secretary of State,,D,Schodorf,35
-Ford,Bucklin twp,Secretary of State,,D,Schodorf,9
-Ford,Concord twp,Secretary of State,,D,Schodorf,9
-Ford,Dodge City 1,Secretary of State,,D,Schodorf,135
-Ford,Dodge City 2,Secretary of State,,D,Schodorf,90
-Ford,Dodge City 3,Secretary of State,,D,Schodorf,139
-Ford,Dodge City 4,Secretary of State,,D,Schodorf,216
-Ford,Dodge City 5,Secretary of State,,D,Schodorf,328
-Ford,Dodge City 6,Secretary of State,,D,Schodorf,436
-Ford,Dodge City 7,Secretary of State,,D,Schodorf,12
-Ford,Dodge City 9,Secretary of State,,D,Schodorf,3
-Ford,Dodge twp 115,Secretary of State,,D,Schodorf,48
-Ford,Dodge twp 119,Secretary of State,,D,Schodorf,7
-Ford,Enterprise twp 115,Secretary of State,,D,Schodorf,45
-Ford,Enterprise twp 119,Secretary of State,,D,Schodorf,2
-Ford,Fairview twp,Secretary of State,,D,Schodorf,14
-Ford,Ford City,Secretary of State,,D,Schodorf,10
-Ford,Ford twp,Secretary of State,,D,Schodorf,10
-Ford,Grandview twp 115,Secretary of State,,D,Schodorf,28
-Ford,Grandview twp 2 115,Secretary of State,,D,Schodorf,13
-Ford,Richland twp,Secretary of State,,D,Schodorf,39
-Ford,Royal twp,Secretary of State,,D,Schodorf,19
-Ford,Sodville twp,Secretary of State,,D,Schodorf,6
-Ford,Spearville city,Secretary of State,,D,Schodorf,78
-Ford,Spearville twp,Secretary of State,,D,Schodorf,23
-Ford,Wheatland twp,Secretary of State,,D,Schodorf,5
-Ford,Wilburn twp,Secretary of State,,D,Schodorf,4
-Ford,Bloom twp,State Treasurer,,D,Aldritt,3
-Ford,Bucklin city,State Treasurer,,D,Aldritt,19
-Ford,Bucklin twp,State Treasurer,,D,Aldritt,4
-Ford,Concord twp,State Treasurer,,D,Aldritt,6
-Ford,Dodge City 1,State Treasurer,,D,Aldritt,115
-Ford,Dodge City 2,State Treasurer,,D,Aldritt,79
-Ford,Dodge City 3,State Treasurer,,D,Aldritt,122
-Ford,Dodge City 4,State Treasurer,,D,Aldritt,156
-Ford,Dodge City 5,State Treasurer,,D,Aldritt,221
-Ford,Dodge City 6,State Treasurer,,D,Aldritt,286
-Ford,Dodge City 7,State Treasurer,,D,Aldritt,4
-Ford,Dodge City 9,State Treasurer,,D,Aldritt,1
-Ford,Dodge twp 115,State Treasurer,,D,Aldritt,27
-Ford,Dodge twp 119,State Treasurer,,D,Aldritt,3
-Ford,Enterprise twp 115,State Treasurer,,D,Aldritt,28
-Ford,Enterprise twp 119,State Treasurer,,D,Aldritt,2
-Ford,Fairview twp,State Treasurer,,D,Aldritt,9
-Ford,Ford City,State Treasurer,,D,Aldritt,3
-Ford,Ford twp,State Treasurer,,D,Aldritt,5
-Ford,Grandview twp 115,State Treasurer,,D,Aldritt,17
-Ford,Grandview twp 2 115,State Treasurer,,D,Aldritt,7
-Ford,Richland twp,State Treasurer,,D,Aldritt,28
-Ford,Royal twp,State Treasurer,,D,Aldritt,13
-Ford,Sodville twp,State Treasurer,,D,Aldritt,0
-Ford,Spearville city,State Treasurer,,D,Aldritt,44
-Ford,Spearville twp,State Treasurer,,D,Aldritt,12
-Ford,Wheatland twp,State Treasurer,,D,Aldritt,2
-Ford,Wilburn twp,State Treasurer,,D,Aldritt,1
-Ford,Bloom twp,State Treasurer,,R,Estes,25
-Ford,Bucklin city,State Treasurer,,R,Estes,224
-Ford,Bucklin twp,State Treasurer,,R,Estes,52
-Ford,Concord twp,State Treasurer,,R,Estes,40
-Ford,Dodge City 1,State Treasurer,,R,Estes,253
-Ford,Dodge City 2,State Treasurer,,R,Estes,147
-Ford,Dodge City 3,State Treasurer,,R,Estes,147
-Ford,Dodge City 4,State Treasurer,,R,Estes,464
-Ford,Dodge City 5,State Treasurer,,R,Estes,857
-Ford,Dodge City 6,State Treasurer,,R,Estes,1126
-Ford,Dodge City 7,State Treasurer,,R,Estes,50
-Ford,Dodge City 9,State Treasurer,,R,Estes,4
-Ford,Dodge twp 115,State Treasurer,,R,Estes,150
-Ford,Dodge twp 119,State Treasurer,,R,Estes,30
-Ford,Enterprise twp 115,State Treasurer,,R,Estes,115
-Ford,Enterprise twp 119,State Treasurer,,R,Estes,0
-Ford,Fairview twp,State Treasurer,,R,Estes,86
-Ford,Ford City,State Treasurer,,R,Estes,73
-Ford,Ford twp,State Treasurer,,R,Estes,61
-Ford,Grandview twp 115,State Treasurer,,R,Estes,142
-Ford,Grandview twp 2 115,State Treasurer,,R,Estes,36
-Ford,Richland twp,State Treasurer,,R,Estes,144
-Ford,Royal twp,State Treasurer,,R,Estes,92
-Ford,Sodville twp,State Treasurer,,R,Estes,38
-Ford,Spearville city,State Treasurer,,R,Estes,247
-Ford,Spearville twp,State Treasurer,,R,Estes,131
-Ford,Wheatland twp,State Treasurer,,R,Estes,58
-Ford,Wilburn twp,State Treasurer,,R,Estes,31
-Ford,Concord twp,State House,State House,D,Mark Low,11
-Ford,Dodge City 1,State House,State House,D,Mark Low,141
-Ford,Dodge City 9,State House,State House,D,Mark Low,1
-Ford,Dodge twp 115,State House,State House,D,Mark Low,40
-Ford,Enterprise twp 115,State House,State House,D,Mark Low,45
-Ford,Fairview twp,State House,State House,D,Mark Low,15
-Ford,Grandview twp 115,State House,State House,D,Mark Low,35
-Ford,Grandview twp 2 115,State House,State House,D,Mark Low,12
-Ford,Richland twp,State House,State House,D,Mark Low,40
-Ford,Royal twp,State House,State House,D,Mark Low,12
-Ford,Wilburn twp,State House,State House,D,Mark Low,7
-Ford,Concord twp,State House,State House,R,Ron Ryckman,36
-Ford,Dodge City 1,State House,State House,R,Ron Ryckman,226
-Ford,Dodge City 9,State House,State House,R,Ron Ryckman,4
-Ford,Dodge twp 115,State House,State House,R,Ron Ryckman,136
-Ford,Enterprise twp 115,State House,State House,R,Ron Ryckman,97
-Ford,Fairview twp,State House,State House,R,Ron Ryckman,80
-Ford,Grandview twp 115,State House,State House,R,Ron Ryckman,119
-Ford,Grandview twp 2 115,State House,State House,R,Ron Ryckman,27
-Ford,Richland twp,State House,State House,R,Ron Ryckman,129
-Ford,Royal twp,State House,State House,R,Ron Ryckman,90
-Ford,Wilburn twp,State House,State House,R,Ron Ryckman,25
-Ford,Bloom twp,State House,117,R,John Ewy,26
-Ford,Bucklin city,State House,117,R,John Ewy,234
-Ford,Bucklin twp,State House,117,R,John Ewy,55
-Ford,Ford City,State House,117,R,John Ewy,73
-Ford,Ford twp,State House,117,R,John Ewy,62
-Ford,Sodville twp,State House,117,R,John Ewy,38
-Ford,Spearville city,State House,117,R,John Ewy,291
-Ford,Spearville twp,State House,117,R,John Ewy,141
-Ford,Wheatland twp,State House,117,R,John Ewy,63
-Ford,Dodge City 2,State House,119,R,Bud Estes,134
-Ford,Dodge City 3,State House,119,R,Bud Estes,137
-Ford,Dodge City 4,State House,119,R,Bud Estes,437
-Ford,Dodge City 5,State House,119,R,Bud Estes,822
-Ford,Dodge City 6,State House,119,R,Bud Estes,1031
-Ford,Dodge City 7,State House,119,R,Bud Estes,49
-Ford,Dodge twp 119,State House,119,R,Bud Estes,30
-Ford,Enterprise twp 119,State House,119,R,Bud Estes,0
-Ford,Grandview twp 119,State House,119,R,Bud Estes,4
-Ford,Grandview twp 2 119,State House,119,R,Bud Estes,4
-Ford,Dodge City 2,State House,119,D,John Thomas,92
-Ford,Dodge City 3,State House,119,D,John Thomas,134
-Ford,Dodge City 4,State House,119,D,John Thomas,196
-Ford,Dodge City 5,State House,119,D,John Thomas,275
-Ford,Dodge City 6,State House,119,D,John Thomas,389
-Ford,Dodge City 7,State House,119,D,John Thomas,5
-Ford,Dodge twp 119,State House,119,D,John Thomas,4
-Ford,Enterprise twp 119,State House,119,D,John Thomas,2
-Ford,Grandview twp 119,State House,119,D,John Thomas,1
-Ford,Grandview twp 2 119,State House,119,D,John Thomas,0
-Ford,Bloom twp,U.S. House,1,R,Huelskamp,29
-Ford,Bucklin city,U.S. House,1,R,Huelskamp,189
-Ford,Bucklin twp,U.S. House,1,R,Huelskamp,40
-Ford,Concord twp,U.S. House,1,R,Huelskamp,33
-Ford,Dodge City 1,U.S. House,1,R,Huelskamp,232
-Ford,Dodge City 2,U.S. House,1,R,Huelskamp,132
-Ford,Dodge City 3,U.S. House,1,R,Huelskamp,145
-Ford,Dodge City 4,U.S. House,1,R,Huelskamp,384
-Ford,Dodge City 5,U.S. House,1,R,Huelskamp,732
-Ford,Dodge City 6,U.S. House,1,R,Huelskamp,921
-Ford,Dodge City 7,U.S. House,1,R,Huelskamp,42
-Ford,Dodge City 9,U.S. House,1,R,Huelskamp,3
-Ford,Dodge twp 115,U.S. House,1,R,Huelskamp,130
-Ford,Dodge twp 119,U.S. House,1,R,Huelskamp,27
-Ford,Enterprise twp 115,U.S. House,1,R,Huelskamp,102
-Ford,Enterprise twp 119,U.S. House,1,R,Huelskamp,0
-Ford,Fairview twp,U.S. House,1,R,Huelskamp,72
-Ford,Ford City,U.S. House,1,R,Huelskamp,70
-Ford,Ford twp,U.S. House,1,R,Huelskamp,57
-Ford,Grandview twp 115,U.S. House,1,R,Huelskamp,116
-Ford,Grandview twp 2 115,U.S. House,1,R,Huelskamp,35
-Ford,Richland twp,U.S. House,1,R,Huelskamp,129
-Ford,Royal twp,U.S. House,1,R,Huelskamp,79
-Ford,Sodville twp,U.S. House,1,R,Huelskamp,34
-Ford,Spearville city,U.S. House,1,R,Huelskamp,205
-Ford,Spearville twp,U.S. House,1,R,Huelskamp,122
-Ford,Wheatland twp,U.S. House,1,R,Huelskamp,53
-Ford,Wilburn twp,U.S. House,1,R,Huelskamp,24
-Ford,Bloom twp,U.S. House,1,D,Sherow,1
-Ford,Bucklin city,U.S. House,1,D,Sherow,61
-Ford,Bucklin twp,U.S. House,1,D,Sherow,14
-Ford,Concord twp,U.S. House,1,D,Sherow,13
-Ford,Dodge City 1,U.S. House,1,D,Sherow,139
-Ford,Dodge City 2,U.S. House,1,D,Sherow,92
-Ford,Dodge City 3,U.S. House,1,D,Sherow,123
-Ford,Dodge City 4,U.S. House,1,D,Sherow,246
-Ford,Dodge City 5,U.S. House,1,D,Sherow,366
-Ford,Dodge City 6,U.S. House,1,D,Sherow,497
-Ford,Dodge City 7,U.S. House,1,D,Sherow,11
-Ford,Dodge City 9,U.S. House,1,D,Sherow,2
-Ford,Dodge twp 115,U.S. House,1,D,Sherow,53
-Ford,Dodge twp 119,U.S. House,1,D,Sherow,7
-Ford,Enterprise twp 115,U.S. House,1,D,Sherow,45
-Ford,Enterprise twp 119,U.S. House,1,D,Sherow,2
-Ford,Fairview twp,U.S. House,1,D,Sherow,24
-Ford,Ford City,U.S. House,1,D,Sherow,5
-Ford,Ford twp,U.S. House,1,D,Sherow,9
-Ford,Grandview twp 115,U.S. House,1,D,Sherow,40
-Ford,Grandview twp 2 115,U.S. House,1,D,Sherow,11
-Ford,Richland twp,U.S. House,1,D,Sherow,44
-Ford,Royal twp,U.S. House,1,D,Sherow,25
-Ford,Sodville twp,U.S. House,1,D,Sherow,5
-Ford,Spearville city,U.S. House,1,D,Sherow,98
-Ford,Spearville twp,U.S. House,1,D,Sherow,24
-Ford,Wheatland twp,U.S. House,1,D,Sherow,10
-Ford,Wilburn twp,U.S. House,1,D,Sherow,6
-Ford,Bloom twp,U.S. Senate,,L,Batson,2
-Ford,Bucklin city,U.S. Senate,,L,Batson,9
-Ford,Bucklin twp,U.S. Senate,,L,Batson,1
-Ford,Concord twp,U.S. Senate,,L,Batson,1
-Ford,Dodge City 1,U.S. Senate,,L,Batson,20
-Ford,Dodge City 2,U.S. Senate,,L,Batson,14
-Ford,Dodge City 3,U.S. Senate,,L,Batson,13
-Ford,Dodge City 4,U.S. Senate,,L,Batson,38
-Ford,Dodge City 5,U.S. Senate,,L,Batson,39
-Ford,Dodge City 6,U.S. Senate,,L,Batson,30
-Ford,Dodge City 7,U.S. Senate,,L,Batson,1
-Ford,Dodge City 9,U.S. Senate,,L,Batson,0
-Ford,Dodge twp 115,U.S. Senate,,L,Batson,6
-Ford,Dodge twp 119,U.S. Senate,,L,Batson,0
-Ford,Enterprise twp 115,U.S. Senate,,L,Batson,9
-Ford,Enterprise twp 119,U.S. Senate,,L,Batson,2
-Ford,Fairview twp,U.S. Senate,,L,Batson,6
-Ford,Ford City,U.S. Senate,,L,Batson,4
-Ford,Ford twp,U.S. Senate,,L,Batson,4
-Ford,Grandview twp 115,U.S. Senate,,L,Batson,4
-Ford,Grandview twp 2 115,U.S. Senate,,L,Batson,3
-Ford,Richland twp,U.S. Senate,,L,Batson,8
-Ford,Royal twp,U.S. Senate,,L,Batson,2
-Ford,Sodville twp,U.S. Senate,,L,Batson,0
-Ford,Spearville city,U.S. Senate,,L,Batson,16
-Ford,Spearville twp,U.S. Senate,,L,Batson,5
-Ford,Wheatland twp,U.S. Senate,,L,Batson,2
-Ford,Wilburn twp,U.S. Senate,,L,Batson,0
-Ford,Bloom twp,U.S. Senate,,I,Orman,0
-Ford,Bucklin city,U.S. Senate,,I,Orman,47
-Ford,Bucklin twp,U.S. Senate,,I,Orman,10
-Ford,Concord twp,U.S. Senate,,I,Orman,10
-Ford,Dodge City 1,U.S. Senate,,I,Orman,117
-Ford,Dodge City 2,U.S. Senate,,I,Orman,83
-Ford,Dodge City 3,U.S. Senate,,I,Orman,118
-Ford,Dodge City 4,U.S. Senate,,I,Orman,220
-Ford,Dodge City 5,U.S. Senate,,I,Orman,352
-Ford,Dodge City 6,U.S. Senate,,I,Orman,456
-Ford,Dodge City 7,U.S. Senate,,I,Orman,17
-Ford,Dodge City 9,U.S. Senate,,I,Orman,2
-Ford,Dodge twp 115,U.S. Senate,,I,Orman,50
-Ford,Dodge twp 119,U.S. Senate,,I,Orman,5
-Ford,Enterprise twp 115,U.S. Senate,,I,Orman,36
-Ford,Enterprise twp 119,U.S. Senate,,I,Orman,0
-Ford,Fairview twp,U.S. Senate,,I,Orman,29
-Ford,Ford City,U.S. Senate,,I,Orman,6
-Ford,Ford twp,U.S. Senate,,I,Orman,7
-Ford,Grandview twp 115,U.S. Senate,,I,Orman,35
-Ford,Grandview twp 2 115,U.S. Senate,,I,Orman,11
-Ford,Richland twp,U.S. Senate,,I,Orman,47
-Ford,Royal twp,U.S. Senate,,I,Orman,26
-Ford,Sodville twp,U.S. Senate,,I,Orman,2
-Ford,Spearville city,U.S. Senate,,I,Orman,88
-Ford,Spearville twp,U.S. Senate,,I,Orman,19
-Ford,Wheatland twp,U.S. Senate,,I,Orman,8
-Ford,Wilburn twp,U.S. Senate,,I,Orman,7
-Ford,Bloom twp,U.S. Senate,,R,Roberts,28
-Ford,Bucklin city,U.S. Senate,,R,Roberts,199
-Ford,Bucklin twp,U.S. Senate,,R,Roberts,45
-Ford,Concord twp,U.S. Senate,,R,Roberts,36
-Ford,Dodge City 1,U.S. Senate,,R,Roberts,234
-Ford,Dodge City 2,U.S. Senate,,R,Roberts,133
-Ford,Dodge City 3,U.S. Senate,,R,Roberts,139
-Ford,Dodge City 4,U.S. Senate,,R,Roberts,374
-Ford,Dodge City 5,U.S. Senate,,R,Roberts,714
-Ford,Dodge City 6,U.S. Senate,,R,Roberts,947
-Ford,Dodge City 7,U.S. Senate,,R,Roberts,37
-Ford,Dodge City 9,U.S. Senate,,R,Roberts,3
-Ford,Dodge twp 115,U.S. Senate,,R,Roberts,127
-Ford,Dodge twp 119,U.S. Senate,,R,Roberts,30
-Ford,Enterprise twp 115,U.S. Senate,,R,Roberts,101
-Ford,Enterprise twp 119,U.S. Senate,,R,Roberts,0
-Ford,Fairview twp,U.S. Senate,,R,Roberts,63
-Ford,Ford City,U.S. Senate,,R,Roberts,66
-Ford,Ford twp,U.S. Senate,,R,Roberts,55
-Ford,Grandview twp 115,U.S. Senate,,R,Roberts,121
-Ford,Grandview twp 2 115,U.S. Senate,,R,Roberts,30
-Ford,Richland twp,U.S. Senate,,R,Roberts,116
-Ford,Royal twp,U.S. Senate,,R,Roberts,76
-Ford,Sodville twp,U.S. Senate,,R,Roberts,37
-Ford,Spearville city,U.S. Senate,,R,Roberts,199
-Ford,Spearville twp,U.S. Senate,,R,Roberts,120
-Ford,Wheatland twp,U.S. Senate,,R,Roberts,54
-Ford,Wilburn twp,U.S. Senate,,R,Roberts,25
-Ford,Dodge City 5,U.S. Senate,,,Chad Taylor,1
-Ford,Dodge City 4,U.S. Senate,,,N/A,1
-Ford,Dodge City 1,U.S. Senate,,,Brender Rodriguez,1
-Ford,Concord twp,U.S. House,,,Lee Kolbeck,1
-Ford,Dodge City 5,U.S. House,,,Ralph Thomas,1
-Ford,Wheatland twp,Secretary of State,,,Chrisgullick,1
-Ford,Dodge twp 119,Secretary of State,,,Linda Harris,1
-Ford,Dodge City 3,Attorney General,,,John,1
-Ford,Dodge twp 115,Attorney General,,,John Sauer,1
-Ford,Dodge City 4,Attorney General,,,David Rebein,1
-Ford,Dodge City 4,State Treasurer,,,Benny Rojas,1
-Ford,Spearville city,State House,,,M.T. Liggett,1
-Ford,Ford City,State House,,,Bud Estes,1
-Ford,Dodge City 6,State House,,,Brent Haskell,1
-Ford,Dodge City 4,State House,,,Benny Rojas,1
+county,precinct,office,district,party,candidate,votes,vtd
+FORD,Bloom Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000010
+FORD,Bloom Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+FORD,Bloom Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000010
+FORD,Bucklin City,Governor / Lt. Governor,,Democratic,"Davis, Paul",58,000020
+FORD,Bucklin City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000020
+FORD,Bucklin City,Governor / Lt. Governor,,Republican,"Brownback, Sam",185,000020
+FORD,Bucklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000030
+FORD,Bucklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000030
+FORD,Bucklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000030
+FORD,Concord Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000040
+FORD,Concord Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+FORD,Concord Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000040
+FORD,Dodge City Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",143,00005A
+FORD,Dodge City Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,00005A
+FORD,Dodge City Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",211,00005A
+FORD,Dodge City Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+FORD,Dodge City Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+FORD,Dodge City Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+FORD,Dodge City Industrial Park,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005C
+FORD,Dodge City Industrial Park,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005C
+FORD,Dodge City Industrial Park,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005C
+FORD,Dodge City Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",137,000070
+FORD,Dodge City Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000070
+FORD,Dodge City Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",122,000070
+FORD,Dodge City Precinct 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",252,00008A
+FORD,Dodge City Precinct 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",38,00008A
+FORD,Dodge City Precinct 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",343,00008A
+FORD,Dodge City Excel #1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008B
+FORD,Dodge City Excel #1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008B
+FORD,Dodge City Excel #1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008B
+FORD,Dodge City Excel #2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008C
+FORD,Dodge City Excel #2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008C
+FORD,Dodge City Excel #2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008C
+FORD,Dodge City Millard,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008D
+FORD,Dodge City Millard,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008D
+FORD,Dodge City Millard,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008D
+FORD,Dodge City Precinct 06,Governor / Lt. Governor,,Democratic,"Davis, Paul",534,000100
+FORD,Dodge City Precinct 06,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",49,000100
+FORD,Dodge City Precinct 06,Governor / Lt. Governor,,Republican,"Brownback, Sam",855,000100
+FORD,Dodge Township Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000200
+FORD,Dodge Township Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000200
+FORD,Dodge Township Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000200
+FORD,Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000220
+FORD,Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000220
+FORD,Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,000220
+FORD,Ford City,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000230
+FORD,Ford City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000230
+FORD,Ford City,Governor / Lt. Governor,,Republican,"Brownback, Sam",62,000230
+FORD,Ford Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000240
+FORD,Ford Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000240
+FORD,Ford Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,000240
+FORD,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000260
+FORD,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000260
+FORD,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",116,000260
+FORD,Royal Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000270
+FORD,Royal Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000270
+FORD,Royal Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000270
+FORD,Sodville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000280
+FORD,Sodville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000280
+FORD,Sodville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000280
+FORD,Spearville City,Governor / Lt. Governor,,Democratic,"Davis, Paul",100,000300
+FORD,Spearville City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000300
+FORD,Spearville City,Governor / Lt. Governor,,Republican,"Brownback, Sam",189,000300
+FORD,Spearville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000310
+FORD,Spearville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000310
+FORD,Spearville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,000310
+FORD,Wheatland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000320
+FORD,Wheatland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000320
+FORD,Wheatland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000320
+FORD,Wilburn Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000330
+FORD,Wilburn Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000330
+FORD,Wilburn Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000330
+FORD,Dodge Township H115,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,120020
+FORD,Dodge Township H115,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,120020
+FORD,Dodge Township H115,Governor / Lt. Governor,,Republican,"Brownback, Sam",124,120020
+FORD,Dodge Township H119 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12003A
+FORD,Dodge Township H119 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12003A
+FORD,Dodge Township H119 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",1,12003A
+FORD,Dodge Township H119,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,120030
+FORD,Dodge Township H119,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120030
+FORD,Dodge Township H119,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,120030
+FORD,Enterprise Township H115,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,120040
+FORD,Enterprise Township H115,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,120040
+FORD,Enterprise Township H115,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,120040
+FORD,Enterprise Township H119,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120050
+FORD,Enterprise Township H119,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120050
+FORD,Enterprise Township H119,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120050
+FORD,Grandview Township H115,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,120060
+FORD,Grandview Township H115,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120060
+FORD,Grandview Township H115,Governor / Lt. Governor,,Republican,"Brownback, Sam",118,120060
+FORD,Grandview Township East H119,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12007A
+FORD,Grandview Township East H119,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12007A
+FORD,Grandview Township East H119,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12007A
+FORD,Grandview Township H119,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120070
+FORD,Grandview Township H119,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120070
+FORD,Grandview Township H119,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120070
+FORD,Grandview Township Ward 2 H115,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,120080
+FORD,Grandview Township Ward 2 H115,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120080
+FORD,Grandview Township Ward 2 H115,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,120080
+FORD,Grandview Township Ward 2 H119,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120090
+FORD,Grandview Township Ward 2 H119,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120090
+FORD,Grandview Township Ward 2 H119,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120090
+FORD,Dodge City Precinct 03 H115,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120100
+FORD,Dodge City Precinct 03 H115,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120100
+FORD,Dodge City Precinct 03 H115,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120100
+FORD,Dodge City Township C H115,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120110
+FORD,Dodge City Township C H115,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120110
+FORD,Dodge City Township C H115,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120110
+FORD,Dodge City Township W H119,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120120
+FORD,Dodge City Township W H119,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120120
+FORD,Dodge City Township W H119,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120120
+FORD,Dodge City Precinct 09,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,120130
+FORD,Dodge City Precinct 09,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120130
+FORD,Dodge City Precinct 09,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,120130
+FORD,Dodge City Precinct 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120140
+FORD,Dodge City Precinct 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120140
+FORD,Dodge City Precinct 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120140
+FORD,Dodge City Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",94,130010
+FORD,Dodge City Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,130010
+FORD,Dodge City Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",116,130010
+FORD,Dodge City Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",414,130020
+FORD,Dodge City Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",42,130020
+FORD,Dodge City Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",647,130020
+FORD,Dodge City Precinct 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,600010
+FORD,Dodge City Precinct 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,600010
+FORD,Dodge City Precinct 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,600010
+FORD,Dodge City Precinct 08,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,800010
+FORD,Dodge City Precinct 08,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,800010
+FORD,Dodge City Precinct 08,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,800010
+FORD,Bloom Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",26,000010
+FORD,Bucklin City,Kansas House of Representatives,117,Republican,"Ewy, John L.",234,000020
+FORD,Bucklin Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",55,000030
+FORD,Concord Township,Kansas House of Representatives,115,Democratic,"Low, Mark",11,000040
+FORD,Concord Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",36,000040
+FORD,Dodge City Precinct 01,Kansas House of Representatives,115,Democratic,"Low, Mark",141,00005A
+FORD,Dodge City Precinct 01,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",226,00005A
+FORD,Dodge City Airport,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,00005B
+FORD,Dodge City Airport,Kansas House of Representatives,119,Republican,"Estes, Bud",0,00005B
+FORD,Dodge City Industrial Park,Kansas House of Representatives,115,Democratic,"Low, Mark",0,00005C
+FORD,Dodge City Industrial Park,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",0,00005C
+FORD,Dodge City Precinct 03,Kansas House of Representatives,119,Democratic,"Thomas, John E.",134,000070
+FORD,Dodge City Precinct 03,Kansas House of Representatives,119,Republican,"Estes, Bud",137,000070
+FORD,Dodge City Precinct 04,Kansas House of Representatives,119,Democratic,"Thomas, John E.",196,00008A
+FORD,Dodge City Precinct 04,Kansas House of Representatives,119,Republican,"Estes, Bud",437,00008A
+FORD,Dodge City Excel #1,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,00008B
+FORD,Dodge City Excel #1,Kansas House of Representatives,119,Republican,"Estes, Bud",0,00008B
+FORD,Dodge City Excel #2,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,00008C
+FORD,Dodge City Excel #2,Kansas House of Representatives,119,Republican,"Estes, Bud",0,00008C
+FORD,Dodge City Millard,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,00008D
+FORD,Dodge City Millard,Kansas House of Representatives,119,Republican,"Estes, Bud",0,00008D
+FORD,Dodge City Precinct 06,Kansas House of Representatives,119,Democratic,"Thomas, John E.",389,000100
+FORD,Dodge City Precinct 06,Kansas House of Representatives,119,Republican,"Estes, Bud",1031,000100
+FORD,Dodge Township Ward 3,Kansas House of Representatives,119,Democratic,"Thomas, John E.",7,000200
+FORD,Dodge Township Ward 3,Kansas House of Representatives,119,Republican,"Estes, Bud",15,000200
+FORD,Fairview Township,Kansas House of Representatives,115,Democratic,"Low, Mark",15,000220
+FORD,Fairview Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",80,000220
+FORD,Ford City,Kansas House of Representatives,117,Republican,"Ewy, John L.",73,000230
+FORD,Ford Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",62,000240
+FORD,Richland Township,Kansas House of Representatives,115,Democratic,"Low, Mark",40,000260
+FORD,Richland Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",129,000260
+FORD,Royal Township,Kansas House of Representatives,115,Democratic,"Low, Mark",12,000270
+FORD,Royal Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",90,000270
+FORD,Sodville Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",38,000280
+FORD,Spearville City,Kansas House of Representatives,117,Republican,"Ewy, John L.",291,000300
+FORD,Spearville Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",141,000310
+FORD,Wheatland Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",63,000320
+FORD,Wilburn Township,Kansas House of Representatives,115,Democratic,"Low, Mark",7,000330
+FORD,Wilburn Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",25,000330
+FORD,Dodge Township H115,Kansas House of Representatives,115,Democratic,"Low, Mark",40,120020
+FORD,Dodge Township H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",136,120020
+FORD,Dodge Township H119 A,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,12003A
+FORD,Dodge Township H119 A,Kansas House of Representatives,119,Republican,"Estes, Bud",1,12003A
+FORD,Dodge Township H119,Kansas House of Representatives,119,Democratic,"Thomas, John E.",4,120030
+FORD,Dodge Township H119,Kansas House of Representatives,119,Republican,"Estes, Bud",30,120030
+FORD,Enterprise Township H115,Kansas House of Representatives,115,Democratic,"Low, Mark",45,120040
+FORD,Enterprise Township H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",97,120040
+FORD,Enterprise Township H119,Kansas House of Representatives,119,Democratic,"Thomas, John E.",2,120050
+FORD,Enterprise Township H119,Kansas House of Representatives,119,Republican,"Estes, Bud",0,120050
+FORD,Grandview Township H115,Kansas House of Representatives,115,Democratic,"Low, Mark",35,120060
+FORD,Grandview Township H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",119,120060
+FORD,Grandview Township East H119,Kansas House of Representatives,119,Democratic,"Thomas, John E.",1,12007A
+FORD,Grandview Township East H119,Kansas House of Representatives,119,Republican,"Estes, Bud",4,12007A
+FORD,Grandview Township H119,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,120070
+FORD,Grandview Township H119,Kansas House of Representatives,119,Republican,"Estes, Bud",0,120070
+FORD,Grandview Township Ward 2 H115,Kansas House of Representatives,115,Democratic,"Low, Mark",12,120080
+FORD,Grandview Township Ward 2 H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",27,120080
+FORD,Grandview Township Ward 2 H119,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,120090
+FORD,Grandview Township Ward 2 H119,Kansas House of Representatives,119,Republican,"Estes, Bud",4,120090
+FORD,Dodge City Precinct 03 H115,Kansas House of Representatives,115,Democratic,"Low, Mark",0,120100
+FORD,Dodge City Precinct 03 H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",0,120100
+FORD,Dodge City Township C H115,Kansas House of Representatives,115,Democratic,"Low, Mark",0,120110
+FORD,Dodge City Township C H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",0,120110
+FORD,Dodge City Township W H119,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,120120
+FORD,Dodge City Township W H119,Kansas House of Representatives,119,Republican,"Estes, Bud",0,120120
+FORD,Dodge City Precinct 09,Kansas House of Representatives,115,Democratic,"Low, Mark",1,120130
+FORD,Dodge City Precinct 09,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",4,120130
+FORD,Dodge City Precinct 10,Kansas House of Representatives,115,Democratic,"Low, Mark",0,120140
+FORD,Dodge City Precinct 10,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",0,120140
+FORD,Dodge City Precinct 02,Kansas House of Representatives,119,Democratic,"Thomas, John E.",92,130010
+FORD,Dodge City Precinct 02,Kansas House of Representatives,119,Republican,"Estes, Bud",134,130010
+FORD,Dodge City Precinct 05,Kansas House of Representatives,119,Democratic,"Thomas, John E.",275,130020
+FORD,Dodge City Precinct 05,Kansas House of Representatives,119,Republican,"Estes, Bud",822,130020
+FORD,Dodge City Precinct 07,Kansas House of Representatives,119,Democratic,"Thomas, John E.",5,600010
+FORD,Dodge City Precinct 07,Kansas House of Representatives,119,Republican,"Estes, Bud",49,600010
+FORD,Dodge City Precinct 08,Kansas House of Representatives,119,Democratic,"Thomas, John E.",0,800010
+FORD,Dodge City Precinct 08,Kansas House of Representatives,119,Republican,"Estes, Bud",0,800010
+FORD,Bloom Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000010
+FORD,Bloom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000010
+FORD,Bucklin City,United States House of Representatives,1,Democratic,"Sherow, James E.",61,000020
+FORD,Bucklin City,United States House of Representatives,1,Republican,"Huelskamp, Tim",189,000020
+FORD,Bucklin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000030
+FORD,Bucklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000030
+FORD,Concord Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000040
+FORD,Concord Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000040
+FORD,Dodge City Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",139,00005A
+FORD,Dodge City Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",232,00005A
+FORD,Dodge City Airport,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00005B
+FORD,Dodge City Airport,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+FORD,Dodge City Industrial Park,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00005C
+FORD,Dodge City Industrial Park,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005C
+FORD,Dodge City Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",123,000070
+FORD,Dodge City Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",145,000070
+FORD,Dodge City Precinct 04,United States House of Representatives,1,Democratic,"Sherow, James E.",246,00008A
+FORD,Dodge City Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",384,00008A
+FORD,Dodge City Excel #1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00008B
+FORD,Dodge City Excel #1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008B
+FORD,Dodge City Excel #2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00008C
+FORD,Dodge City Excel #2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008C
+FORD,Dodge City Millard,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00008D
+FORD,Dodge City Millard,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008D
+FORD,Dodge City Precinct 06,United States House of Representatives,1,Democratic,"Sherow, James E.",497,000100
+FORD,Dodge City Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",921,000100
+FORD,Dodge Township Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000200
+FORD,Dodge Township Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000200
+FORD,Fairview Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000220
+FORD,Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000220
+FORD,Ford City,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000230
+FORD,Ford City,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000230
+FORD,Ford Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000240
+FORD,Ford Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",57,000240
+FORD,Richland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",44,000260
+FORD,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",129,000260
+FORD,Royal Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,000270
+FORD,Royal Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",79,000270
+FORD,Sodville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000280
+FORD,Sodville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000280
+FORD,Spearville City,United States House of Representatives,1,Democratic,"Sherow, James E.",98,000300
+FORD,Spearville City,United States House of Representatives,1,Republican,"Huelskamp, Tim",205,000300
+FORD,Spearville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000310
+FORD,Spearville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",122,000310
+FORD,Wheatland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000320
+FORD,Wheatland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000320
+FORD,Wilburn Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000330
+FORD,Wilburn Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000330
+FORD,Dodge Township H115,United States House of Representatives,1,Democratic,"Sherow, James E.",53,120020
+FORD,Dodge Township H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",130,120020
+FORD,Dodge Township H119 A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,12003A
+FORD,Dodge Township H119 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,12003A
+FORD,Dodge Township H119,United States House of Representatives,1,Democratic,"Sherow, James E.",7,120030
+FORD,Dodge Township H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,120030
+FORD,Enterprise Township H115,United States House of Representatives,1,Democratic,"Sherow, James E.",45,120040
+FORD,Enterprise Township H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",102,120040
+FORD,Enterprise Township H119,United States House of Representatives,1,Democratic,"Sherow, James E.",2,120050
+FORD,Enterprise Township H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120050
+FORD,Grandview Township H115,United States House of Representatives,1,Democratic,"Sherow, James E.",40,120060
+FORD,Grandview Township H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",116,120060
+FORD,Grandview Township East H119,United States House of Representatives,1,Democratic,"Sherow, James E.",0,12007A
+FORD,Grandview Township East H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12007A
+FORD,Grandview Township H119,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120070
+FORD,Grandview Township H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120070
+FORD,Grandview Township Ward 2 H115,United States House of Representatives,1,Democratic,"Sherow, James E.",11,120080
+FORD,Grandview Township Ward 2 H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,120080
+FORD,Grandview Township Ward 2 H119,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120090
+FORD,Grandview Township Ward 2 H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120090
+FORD,Dodge City Precinct 03 H115,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120100
+FORD,Dodge City Precinct 03 H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120100
+FORD,Dodge City Township C H115,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120110
+FORD,Dodge City Township C H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120110
+FORD,Dodge City Township W H119,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120120
+FORD,Dodge City Township W H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120120
+FORD,Dodge City Precinct 09,United States House of Representatives,1,Democratic,"Sherow, James E.",2,120130
+FORD,Dodge City Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,120130
+FORD,Dodge City Precinct 10,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120140
+FORD,Dodge City Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120140
+FORD,Dodge City Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",92,130010
+FORD,Dodge City Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",132,130010
+FORD,Dodge City Precinct 05,United States House of Representatives,1,Democratic,"Sherow, James E.",366,130020
+FORD,Dodge City Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",732,130020
+FORD,Dodge City Precinct 07,United States House of Representatives,1,Democratic,"Sherow, James E.",11,600010
+FORD,Dodge City Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,600010
+FORD,Dodge City Precinct 08,United States House of Representatives,1,Democratic,"Sherow, James E.",0,800010
+FORD,Dodge City Precinct 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,800010
+FORD,Bloom Township,Attorney General,,Democratic,"Kotich, A.J.",3,000010
+FORD,Bloom Township,Attorney General,,Republican,"Schmidt, Derek",27,000010
+FORD,Bucklin City,Attorney General,,Democratic,"Kotich, A.J.",30,000020
+FORD,Bucklin City,Attorney General,,Republican,"Schmidt, Derek",208,000020
+FORD,Bucklin Township,Attorney General,,Democratic,"Kotich, A.J.",4,000030
+FORD,Bucklin Township,Attorney General,,Republican,"Schmidt, Derek",48,000030
+FORD,Concord Township,Attorney General,,Democratic,"Kotich, A.J.",6,000040
+FORD,Concord Township,Attorney General,,Republican,"Schmidt, Derek",40,000040
+FORD,Dodge City Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",123,00005A
+FORD,Dodge City Precinct 01,Attorney General,,Republican,"Schmidt, Derek",241,00005A
+FORD,Dodge City Airport,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+FORD,Dodge City Airport,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+FORD,Dodge City Industrial Park,Attorney General,,Democratic,"Kotich, A.J.",0,00005C
+FORD,Dodge City Industrial Park,Attorney General,,Republican,"Schmidt, Derek",0,00005C
+FORD,Dodge City Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",128,000070
+FORD,Dodge City Precinct 03,Attorney General,,Republican,"Schmidt, Derek",140,000070
+FORD,Dodge City Precinct 04,Attorney General,,Democratic,"Kotich, A.J.",193,00008A
+FORD,Dodge City Precinct 04,Attorney General,,Republican,"Schmidt, Derek",424,00008A
+FORD,Dodge City Excel #1,Attorney General,,Democratic,"Kotich, A.J.",0,00008B
+FORD,Dodge City Excel #1,Attorney General,,Republican,"Schmidt, Derek",0,00008B
+FORD,Dodge City Excel #2,Attorney General,,Democratic,"Kotich, A.J.",0,00008C
+FORD,Dodge City Excel #2,Attorney General,,Republican,"Schmidt, Derek",0,00008C
+FORD,Dodge City Millard,Attorney General,,Democratic,"Kotich, A.J.",0,00008D
+FORD,Dodge City Millard,Attorney General,,Republican,"Schmidt, Derek",0,00008D
+FORD,Dodge City Precinct 06,Attorney General,,Democratic,"Kotich, A.J.",316,000100
+FORD,Dodge City Precinct 06,Attorney General,,Republican,"Schmidt, Derek",1090,000100
+FORD,Dodge Township Ward 3,Attorney General,,Democratic,"Kotich, A.J.",4,000200
+FORD,Dodge Township Ward 3,Attorney General,,Republican,"Schmidt, Derek",18,000200
+FORD,Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",15,000220
+FORD,Fairview Township,Attorney General,,Republican,"Schmidt, Derek",80,000220
+FORD,Ford City,Attorney General,,Democratic,"Kotich, A.J.",8,000230
+FORD,Ford City,Attorney General,,Republican,"Schmidt, Derek",66,000230
+FORD,Ford Township,Attorney General,,Democratic,"Kotich, A.J.",7,000240
+FORD,Ford Township,Attorney General,,Republican,"Schmidt, Derek",58,000240
+FORD,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",37,000260
+FORD,Richland Township,Attorney General,,Republican,"Schmidt, Derek",135,000260
+FORD,Royal Township,Attorney General,,Democratic,"Kotich, A.J.",14,000270
+FORD,Royal Township,Attorney General,,Republican,"Schmidt, Derek",90,000270
+FORD,Sodville Township,Attorney General,,Democratic,"Kotich, A.J.",1,000280
+FORD,Sodville Township,Attorney General,,Republican,"Schmidt, Derek",37,000280
+FORD,Spearville City,Attorney General,,Democratic,"Kotich, A.J.",56,000300
+FORD,Spearville City,Attorney General,,Republican,"Schmidt, Derek",236,000300
+FORD,Spearville Township,Attorney General,,Democratic,"Kotich, A.J.",24,000310
+FORD,Spearville Township,Attorney General,,Republican,"Schmidt, Derek",117,000310
+FORD,Wheatland Township,Attorney General,,Democratic,"Kotich, A.J.",2,000320
+FORD,Wheatland Township,Attorney General,,Republican,"Schmidt, Derek",59,000320
+FORD,Wilburn Township,Attorney General,,Democratic,"Kotich, A.J.",2,000330
+FORD,Wilburn Township,Attorney General,,Republican,"Schmidt, Derek",29,000330
+FORD,Dodge Township H115,Attorney General,,Democratic,"Kotich, A.J.",33,120020
+FORD,Dodge Township H115,Attorney General,,Republican,"Schmidt, Derek",142,120020
+FORD,Dodge Township H119 A,Attorney General,,Democratic,"Kotich, A.J.",0,12003A
+FORD,Dodge Township H119 A,Attorney General,,Republican,"Schmidt, Derek",1,12003A
+FORD,Dodge Township H119,Attorney General,,Democratic,"Kotich, A.J.",2,120030
+FORD,Dodge Township H119,Attorney General,,Republican,"Schmidt, Derek",31,120030
+FORD,Enterprise Township H115,Attorney General,,Democratic,"Kotich, A.J.",41,120040
+FORD,Enterprise Township H115,Attorney General,,Republican,"Schmidt, Derek",102,120040
+FORD,Enterprise Township H119,Attorney General,,Democratic,"Kotich, A.J.",2,120050
+FORD,Enterprise Township H119,Attorney General,,Republican,"Schmidt, Derek",0,120050
+FORD,Grandview Township H115,Attorney General,,Democratic,"Kotich, A.J.",25,120060
+FORD,Grandview Township H115,Attorney General,,Republican,"Schmidt, Derek",132,120060
+FORD,Grandview Township East H119,Attorney General,,Democratic,"Kotich, A.J.",0,12007A
+FORD,Grandview Township East H119,Attorney General,,Republican,"Schmidt, Derek",0,12007A
+FORD,Grandview Township H119,Attorney General,,Democratic,"Kotich, A.J.",0,120070
+FORD,Grandview Township H119,Attorney General,,Republican,"Schmidt, Derek",0,120070
+FORD,Grandview Township Ward 2 H115,Attorney General,,Democratic,"Kotich, A.J.",13,120080
+FORD,Grandview Township Ward 2 H115,Attorney General,,Republican,"Schmidt, Derek",26,120080
+FORD,Grandview Township Ward 2 H119,Attorney General,,Democratic,"Kotich, A.J.",0,120090
+FORD,Grandview Township Ward 2 H119,Attorney General,,Republican,"Schmidt, Derek",0,120090
+FORD,Dodge City Precinct 03 H115,Attorney General,,Democratic,"Kotich, A.J.",0,120100
+FORD,Dodge City Precinct 03 H115,Attorney General,,Republican,"Schmidt, Derek",0,120100
+FORD,Dodge City Township C H115,Attorney General,,Democratic,"Kotich, A.J.",0,120110
+FORD,Dodge City Township C H115,Attorney General,,Republican,"Schmidt, Derek",0,120110
+FORD,Dodge City Township W H119,Attorney General,,Democratic,"Kotich, A.J.",0,120120
+FORD,Dodge City Township W H119,Attorney General,,Republican,"Schmidt, Derek",0,120120
+FORD,Dodge City Precinct 09,Attorney General,,Democratic,"Kotich, A.J.",1,120130
+FORD,Dodge City Precinct 09,Attorney General,,Republican,"Schmidt, Derek",4,120130
+FORD,Dodge City Precinct 10,Attorney General,,Democratic,"Kotich, A.J.",0,120140
+FORD,Dodge City Precinct 10,Attorney General,,Republican,"Schmidt, Derek",0,120140
+FORD,Dodge City Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",83,130010
+FORD,Dodge City Precinct 02,Attorney General,,Republican,"Schmidt, Derek",142,130010
+FORD,Dodge City Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",246,130020
+FORD,Dodge City Precinct 05,Attorney General,,Republican,"Schmidt, Derek",834,130020
+FORD,Dodge City Precinct 07,Attorney General,,Democratic,"Kotich, A.J.",4,600010
+FORD,Dodge City Precinct 07,Attorney General,,Republican,"Schmidt, Derek",49,600010
+FORD,Dodge City Precinct 08,Attorney General,,Democratic,"Kotich, A.J.",0,800010
+FORD,Dodge City Precinct 08,Attorney General,,Republican,"Schmidt, Derek",0,800010
+FORD,Bloom Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000010
+FORD,Bloom Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000010
+FORD,Bucklin City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",35,000020
+FORD,Bucklin City,Commissioner of Insurance,,Republican,"Selzer, Ken",198,000020
+FORD,Bucklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000030
+FORD,Bucklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000030
+FORD,Concord Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000040
+FORD,Concord Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000040
+FORD,Dodge City Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",138,00005A
+FORD,Dodge City Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",224,00005A
+FORD,Dodge City Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+FORD,Dodge City Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+FORD,Dodge City Industrial Park,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005C
+FORD,Dodge City Industrial Park,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005C
+FORD,Dodge City Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",139,000070
+FORD,Dodge City Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",127,000070
+FORD,Dodge City Precinct 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",209,00008A
+FORD,Dodge City Precinct 04,Commissioner of Insurance,,Republican,"Selzer, Ken",388,00008A
+FORD,Dodge City Excel #1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00008B
+FORD,Dodge City Excel #1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00008B
+FORD,Dodge City Excel #2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00008C
+FORD,Dodge City Excel #2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00008C
+FORD,Dodge City Millard,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00008D
+FORD,Dodge City Millard,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00008D
+FORD,Dodge City Precinct 06,Commissioner of Insurance,,Democratic,"Anderson, Dennis",389,000100
+FORD,Dodge City Precinct 06,Commissioner of Insurance,,Republican,"Selzer, Ken",977,000100
+FORD,Dodge Township Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000200
+FORD,Dodge Township Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000200
+FORD,Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000220
+FORD,Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",78,000220
+FORD,Ford City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000230
+FORD,Ford City,Commissioner of Insurance,,Republican,"Selzer, Ken",65,000230
+FORD,Ford Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000240
+FORD,Ford Township,Commissioner of Insurance,,Republican,"Selzer, Ken",58,000240
+FORD,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000260
+FORD,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",131,000260
+FORD,Royal Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000270
+FORD,Royal Township,Commissioner of Insurance,,Republican,"Selzer, Ken",88,000270
+FORD,Sodville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000280
+FORD,Sodville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000280
+FORD,Spearville City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000300
+FORD,Spearville City,Commissioner of Insurance,,Republican,"Selzer, Ken",206,000300
+FORD,Spearville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000310
+FORD,Spearville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",118,000310
+FORD,Wheatland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000320
+FORD,Wheatland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000320
+FORD,Wilburn Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000330
+FORD,Wilburn Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000330
+FORD,Dodge Township H115,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,120020
+FORD,Dodge Township H115,Commissioner of Insurance,,Republican,"Selzer, Ken",124,120020
+FORD,Dodge Township H119 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12003A
+FORD,Dodge Township H119 A,Commissioner of Insurance,,Republican,"Selzer, Ken",1,12003A
+FORD,Dodge Township H119,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,120030
+FORD,Dodge Township H119,Commissioner of Insurance,,Republican,"Selzer, Ken",30,120030
+FORD,Enterprise Township H115,Commissioner of Insurance,,Democratic,"Anderson, Dennis",44,120040
+FORD,Enterprise Township H115,Commissioner of Insurance,,Republican,"Selzer, Ken",96,120040
+FORD,Enterprise Township H119,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,120050
+FORD,Enterprise Township H119,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120050
+FORD,Grandview Township H115,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,120060
+FORD,Grandview Township H115,Commissioner of Insurance,,Republican,"Selzer, Ken",125,120060
+FORD,Grandview Township East H119,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12007A
+FORD,Grandview Township East H119,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12007A
+FORD,Grandview Township H119,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120070
+FORD,Grandview Township H119,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120070
+FORD,Grandview Township Ward 2 H115,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,120080
+FORD,Grandview Township Ward 2 H115,Commissioner of Insurance,,Republican,"Selzer, Ken",29,120080
+FORD,Grandview Township Ward 2 H119,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120090
+FORD,Grandview Township Ward 2 H119,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120090
+FORD,Dodge City Precinct 03 H115,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120100
+FORD,Dodge City Precinct 03 H115,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120100
+FORD,Dodge City Township C H115,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120110
+FORD,Dodge City Township C H115,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120110
+FORD,Dodge City Township W H119,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120120
+FORD,Dodge City Township W H119,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120120
+FORD,Dodge City Precinct 09,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,120130
+FORD,Dodge City Precinct 09,Commissioner of Insurance,,Republican,"Selzer, Ken",3,120130
+FORD,Dodge City Precinct 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120140
+FORD,Dodge City Precinct 10,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120140
+FORD,Dodge City Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",95,130010
+FORD,Dodge City Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",127,130010
+FORD,Dodge City Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",301,130020
+FORD,Dodge City Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",751,130020
+FORD,Dodge City Precinct 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,600010
+FORD,Dodge City Precinct 07,Commissioner of Insurance,,Republican,"Selzer, Ken",44,600010
+FORD,Dodge City Precinct 08,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,800010
+FORD,Dodge City Precinct 08,Commissioner of Insurance,,Republican,"Selzer, Ken",0,800010
+FORD,Bloom Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+FORD,Bloom Township,Secretary of State,,Republican,"Kobach, Kris",27,000010
+FORD,Bucklin City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000020
+FORD,Bucklin City,Secretary of State,,Republican,"Kobach, Kris",211,000020
+FORD,Bucklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000030
+FORD,Bucklin Township,Secretary of State,,Republican,"Kobach, Kris",46,000030
+FORD,Concord Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000040
+FORD,Concord Township,Secretary of State,,Republican,"Kobach, Kris",37,000040
+FORD,Dodge City Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",135,00005A
+FORD,Dodge City Precinct 01,Secretary of State,,Republican,"Kobach, Kris",234,00005A
+FORD,Dodge City Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+FORD,Dodge City Airport,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+FORD,Dodge City Industrial Park,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005C
+FORD,Dodge City Industrial Park,Secretary of State,,Republican,"Kobach, Kris",0,00005C
+FORD,Dodge City Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",139,000070
+FORD,Dodge City Precinct 03,Secretary of State,,Republican,"Kobach, Kris",131,000070
+FORD,Dodge City Precinct 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",216,00008A
+FORD,Dodge City Precinct 04,Secretary of State,,Republican,"Kobach, Kris",406,00008A
+FORD,Dodge City Excel #1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008B
+FORD,Dodge City Excel #1,Secretary of State,,Republican,"Kobach, Kris",0,00008B
+FORD,Dodge City Excel #2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008C
+FORD,Dodge City Excel #2,Secretary of State,,Republican,"Kobach, Kris",0,00008C
+FORD,Dodge City Millard,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008D
+FORD,Dodge City Millard,Secretary of State,,Republican,"Kobach, Kris",0,00008D
+FORD,Dodge City Precinct 06,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",436,000100
+FORD,Dodge City Precinct 06,Secretary of State,,Republican,"Kobach, Kris",991,000100
+FORD,Dodge Township Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000200
+FORD,Dodge Township Ward 3,Secretary of State,,Republican,"Kobach, Kris",18,000200
+FORD,Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000220
+FORD,Fairview Township,Secretary of State,,Republican,"Kobach, Kris",81,000220
+FORD,Ford City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000230
+FORD,Ford City,Secretary of State,,Republican,"Kobach, Kris",66,000230
+FORD,Ford Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000240
+FORD,Ford Township,Secretary of State,,Republican,"Kobach, Kris",55,000240
+FORD,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000260
+FORD,Richland Township,Secretary of State,,Republican,"Kobach, Kris",134,000260
+FORD,Royal Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000270
+FORD,Royal Township,Secretary of State,,Republican,"Kobach, Kris",85,000270
+FORD,Sodville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000280
+FORD,Sodville Township,Secretary of State,,Republican,"Kobach, Kris",33,000280
+FORD,Spearville City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,000300
+FORD,Spearville City,Secretary of State,,Republican,"Kobach, Kris",222,000300
+FORD,Spearville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000310
+FORD,Spearville Township,Secretary of State,,Republican,"Kobach, Kris",119,000310
+FORD,Wheatland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000320
+FORD,Wheatland Township,Secretary of State,,Republican,"Kobach, Kris",57,000320
+FORD,Wilburn Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000330
+FORD,Wilburn Township,Secretary of State,,Republican,"Kobach, Kris",27,000330
+FORD,Dodge Township H115,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,120020
+FORD,Dodge Township H115,Secretary of State,,Republican,"Kobach, Kris",129,120020
+FORD,Dodge Township H119 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12003A
+FORD,Dodge Township H119 A,Secretary of State,,Republican,"Kobach, Kris",1,12003A
+FORD,Dodge Township H119,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,120030
+FORD,Dodge Township H119,Secretary of State,,Republican,"Kobach, Kris",26,120030
+FORD,Enterprise Township H115,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,120040
+FORD,Enterprise Township H115,Secretary of State,,Republican,"Kobach, Kris",102,120040
+FORD,Enterprise Township H119,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,120050
+FORD,Enterprise Township H119,Secretary of State,,Republican,"Kobach, Kris",0,120050
+FORD,Grandview Township H115,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,120060
+FORD,Grandview Township H115,Secretary of State,,Republican,"Kobach, Kris",129,120060
+FORD,Grandview Township East H119,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12007A
+FORD,Grandview Township East H119,Secretary of State,,Republican,"Kobach, Kris",0,12007A
+FORD,Grandview Township H119,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120070
+FORD,Grandview Township H119,Secretary of State,,Republican,"Kobach, Kris",0,120070
+FORD,Grandview Township Ward 2 H115,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,120080
+FORD,Grandview Township Ward 2 H115,Secretary of State,,Republican,"Kobach, Kris",29,120080
+FORD,Grandview Township Ward 2 H119,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120090
+FORD,Grandview Township Ward 2 H119,Secretary of State,,Republican,"Kobach, Kris",0,120090
+FORD,Dodge City Precinct 03 H115,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120100
+FORD,Dodge City Precinct 03 H115,Secretary of State,,Republican,"Kobach, Kris",0,120100
+FORD,Dodge City Township C H115,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120110
+FORD,Dodge City Township C H115,Secretary of State,,Republican,"Kobach, Kris",0,120110
+FORD,Dodge City Township W H119,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120120
+FORD,Dodge City Township W H119,Secretary of State,,Republican,"Kobach, Kris",0,120120
+FORD,Dodge City Precinct 09,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,120130
+FORD,Dodge City Precinct 09,Secretary of State,,Republican,"Kobach, Kris",2,120130
+FORD,Dodge City Precinct 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120140
+FORD,Dodge City Precinct 10,Secretary of State,,Republican,"Kobach, Kris",0,120140
+FORD,Dodge City Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,130010
+FORD,Dodge City Precinct 02,Secretary of State,,Republican,"Kobach, Kris",134,130010
+FORD,Dodge City Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",328,130020
+FORD,Dodge City Precinct 05,Secretary of State,,Republican,"Kobach, Kris",764,130020
+FORD,Dodge City Precinct 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,600010
+FORD,Dodge City Precinct 07,Secretary of State,,Republican,"Kobach, Kris",40,600010
+FORD,Dodge City Precinct 08,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,800010
+FORD,Dodge City Precinct 08,Secretary of State,,Republican,"Kobach, Kris",0,800010
+FORD,Bloom Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000010
+FORD,Bloom Township,State Treasurer,,Republican,"Estes, Ron",25,000010
+FORD,Bucklin City,State Treasurer,,Democratic,"Alldritt, Carmen",19,000020
+FORD,Bucklin City,State Treasurer,,Republican,"Estes, Ron",224,000020
+FORD,Bucklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+FORD,Bucklin Township,State Treasurer,,Republican,"Estes, Ron",52,000030
+FORD,Concord Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000040
+FORD,Concord Township,State Treasurer,,Republican,"Estes, Ron",40,000040
+FORD,Dodge City Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",115,00005A
+FORD,Dodge City Precinct 01,State Treasurer,,Republican,"Estes, Ron",253,00005A
+FORD,Dodge City Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+FORD,Dodge City Airport,State Treasurer,,Republican,"Estes, Ron",0,00005B
+FORD,Dodge City Industrial Park,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005C
+FORD,Dodge City Industrial Park,State Treasurer,,Republican,"Estes, Ron",0,00005C
+FORD,Dodge City Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",122,000070
+FORD,Dodge City Precinct 03,State Treasurer,,Republican,"Estes, Ron",147,000070
+FORD,Dodge City Precinct 04,State Treasurer,,Democratic,"Alldritt, Carmen",156,00008A
+FORD,Dodge City Precinct 04,State Treasurer,,Republican,"Estes, Ron",464,00008A
+FORD,Dodge City Excel #1,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008B
+FORD,Dodge City Excel #1,State Treasurer,,Republican,"Estes, Ron",0,00008B
+FORD,Dodge City Excel #2,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008C
+FORD,Dodge City Excel #2,State Treasurer,,Republican,"Estes, Ron",0,00008C
+FORD,Dodge City Millard,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008D
+FORD,Dodge City Millard,State Treasurer,,Republican,"Estes, Ron",0,00008D
+FORD,Dodge City Precinct 06,State Treasurer,,Democratic,"Alldritt, Carmen",286,000100
+FORD,Dodge City Precinct 06,State Treasurer,,Republican,"Estes, Ron",1126,000100
+FORD,Dodge Township Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",3,000200
+FORD,Dodge Township Ward 3,State Treasurer,,Republican,"Estes, Ron",20,000200
+FORD,Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000220
+FORD,Fairview Township,State Treasurer,,Republican,"Estes, Ron",86,000220
+FORD,Ford City,State Treasurer,,Democratic,"Alldritt, Carmen",3,000230
+FORD,Ford City,State Treasurer,,Republican,"Estes, Ron",73,000230
+FORD,Ford Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000240
+FORD,Ford Township,State Treasurer,,Republican,"Estes, Ron",61,000240
+FORD,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000260
+FORD,Richland Township,State Treasurer,,Republican,"Estes, Ron",144,000260
+FORD,Royal Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000270
+FORD,Royal Township,State Treasurer,,Republican,"Estes, Ron",92,000270
+FORD,Sodville Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000280
+FORD,Sodville Township,State Treasurer,,Republican,"Estes, Ron",38,000280
+FORD,Spearville City,State Treasurer,,Democratic,"Alldritt, Carmen",44,000300
+FORD,Spearville City,State Treasurer,,Republican,"Estes, Ron",247,000300
+FORD,Spearville Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000310
+FORD,Spearville Township,State Treasurer,,Republican,"Estes, Ron",131,000310
+FORD,Wheatland Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000320
+FORD,Wheatland Township,State Treasurer,,Republican,"Estes, Ron",58,000320
+FORD,Wilburn Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000330
+FORD,Wilburn Township,State Treasurer,,Republican,"Estes, Ron",31,000330
+FORD,Dodge Township H115,State Treasurer,,Democratic,"Alldritt, Carmen",27,120020
+FORD,Dodge Township H115,State Treasurer,,Republican,"Estes, Ron",150,120020
+FORD,Dodge Township H119 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,12003A
+FORD,Dodge Township H119 A,State Treasurer,,Republican,"Estes, Ron",1,12003A
+FORD,Dodge Township H119,State Treasurer,,Democratic,"Alldritt, Carmen",3,120030
+FORD,Dodge Township H119,State Treasurer,,Republican,"Estes, Ron",30,120030
+FORD,Enterprise Township H115,State Treasurer,,Democratic,"Alldritt, Carmen",28,120040
+FORD,Enterprise Township H115,State Treasurer,,Republican,"Estes, Ron",115,120040
+FORD,Enterprise Township H119,State Treasurer,,Democratic,"Alldritt, Carmen",2,120050
+FORD,Enterprise Township H119,State Treasurer,,Republican,"Estes, Ron",0,120050
+FORD,Grandview Township H115,State Treasurer,,Democratic,"Alldritt, Carmen",17,120060
+FORD,Grandview Township H115,State Treasurer,,Republican,"Estes, Ron",142,120060
+FORD,Grandview Township East H119,State Treasurer,,Democratic,"Alldritt, Carmen",0,12007A
+FORD,Grandview Township East H119,State Treasurer,,Republican,"Estes, Ron",0,12007A
+FORD,Grandview Township H119,State Treasurer,,Democratic,"Alldritt, Carmen",0,120070
+FORD,Grandview Township H119,State Treasurer,,Republican,"Estes, Ron",0,120070
+FORD,Grandview Township Ward 2 H115,State Treasurer,,Democratic,"Alldritt, Carmen",7,120080
+FORD,Grandview Township Ward 2 H115,State Treasurer,,Republican,"Estes, Ron",36,120080
+FORD,Grandview Township Ward 2 H119,State Treasurer,,Democratic,"Alldritt, Carmen",0,120090
+FORD,Grandview Township Ward 2 H119,State Treasurer,,Republican,"Estes, Ron",0,120090
+FORD,Dodge City Precinct 03 H115,State Treasurer,,Democratic,"Alldritt, Carmen",0,120100
+FORD,Dodge City Precinct 03 H115,State Treasurer,,Republican,"Estes, Ron",0,120100
+FORD,Dodge City Township C H115,State Treasurer,,Democratic,"Alldritt, Carmen",0,120110
+FORD,Dodge City Township C H115,State Treasurer,,Republican,"Estes, Ron",0,120110
+FORD,Dodge City Township W H119,State Treasurer,,Democratic,"Alldritt, Carmen",0,120120
+FORD,Dodge City Township W H119,State Treasurer,,Republican,"Estes, Ron",0,120120
+FORD,Dodge City Precinct 09,State Treasurer,,Democratic,"Alldritt, Carmen",1,120130
+FORD,Dodge City Precinct 09,State Treasurer,,Republican,"Estes, Ron",4,120130
+FORD,Dodge City Precinct 10,State Treasurer,,Democratic,"Alldritt, Carmen",0,120140
+FORD,Dodge City Precinct 10,State Treasurer,,Republican,"Estes, Ron",0,120140
+FORD,Dodge City Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",79,130010
+FORD,Dodge City Precinct 02,State Treasurer,,Republican,"Estes, Ron",147,130010
+FORD,Dodge City Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",221,130020
+FORD,Dodge City Precinct 05,State Treasurer,,Republican,"Estes, Ron",857,130020
+FORD,Dodge City Precinct 07,State Treasurer,,Democratic,"Alldritt, Carmen",4,600010
+FORD,Dodge City Precinct 07,State Treasurer,,Republican,"Estes, Ron",50,600010
+FORD,Dodge City Precinct 08,State Treasurer,,Democratic,"Alldritt, Carmen",0,800010
+FORD,Dodge City Precinct 08,State Treasurer,,Republican,"Estes, Ron",0,800010
+FORD,Bloom Township,United States Senate,,independent,"Orman, Greg",0,000010
+FORD,Bloom Township,United States Senate,,Libertarian,"Batson, Randall",2,000010
+FORD,Bloom Township,United States Senate,,Republican,"Roberts, Pat",28,000010
+FORD,Bucklin City,United States Senate,,independent,"Orman, Greg",47,000020
+FORD,Bucklin City,United States Senate,,Libertarian,"Batson, Randall",9,000020
+FORD,Bucklin City,United States Senate,,Republican,"Roberts, Pat",199,000020
+FORD,Bucklin Township,United States Senate,,independent,"Orman, Greg",10,000030
+FORD,Bucklin Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+FORD,Bucklin Township,United States Senate,,Republican,"Roberts, Pat",45,000030
+FORD,Concord Township,United States Senate,,independent,"Orman, Greg",10,000040
+FORD,Concord Township,United States Senate,,Libertarian,"Batson, Randall",1,000040
+FORD,Concord Township,United States Senate,,Republican,"Roberts, Pat",36,000040
+FORD,Dodge City Precinct 01,United States Senate,,independent,"Orman, Greg",117,00005A
+FORD,Dodge City Precinct 01,United States Senate,,Libertarian,"Batson, Randall",20,00005A
+FORD,Dodge City Precinct 01,United States Senate,,Republican,"Roberts, Pat",234,00005A
+FORD,Dodge City Airport,United States Senate,,independent,"Orman, Greg",0,00005B
+FORD,Dodge City Airport,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+FORD,Dodge City Airport,United States Senate,,Republican,"Roberts, Pat",0,00005B
+FORD,Dodge City Industrial Park,United States Senate,,independent,"Orman, Greg",0,00005C
+FORD,Dodge City Industrial Park,United States Senate,,Libertarian,"Batson, Randall",0,00005C
+FORD,Dodge City Industrial Park,United States Senate,,Republican,"Roberts, Pat",0,00005C
+FORD,Dodge City Precinct 03,United States Senate,,independent,"Orman, Greg",118,000070
+FORD,Dodge City Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,000070
+FORD,Dodge City Precinct 03,United States Senate,,Republican,"Roberts, Pat",139,000070
+FORD,Dodge City Precinct 04,United States Senate,,independent,"Orman, Greg",220,00008A
+FORD,Dodge City Precinct 04,United States Senate,,Libertarian,"Batson, Randall",38,00008A
+FORD,Dodge City Precinct 04,United States Senate,,Republican,"Roberts, Pat",374,00008A
+FORD,Dodge City Excel #1,United States Senate,,independent,"Orman, Greg",0,00008B
+FORD,Dodge City Excel #1,United States Senate,,Libertarian,"Batson, Randall",0,00008B
+FORD,Dodge City Excel #1,United States Senate,,Republican,"Roberts, Pat",0,00008B
+FORD,Dodge City Excel #2,United States Senate,,independent,"Orman, Greg",0,00008C
+FORD,Dodge City Excel #2,United States Senate,,Libertarian,"Batson, Randall",0,00008C
+FORD,Dodge City Excel #2,United States Senate,,Republican,"Roberts, Pat",0,00008C
+FORD,Dodge City Millard,United States Senate,,independent,"Orman, Greg",0,00008D
+FORD,Dodge City Millard,United States Senate,,Libertarian,"Batson, Randall",0,00008D
+FORD,Dodge City Millard,United States Senate,,Republican,"Roberts, Pat",0,00008D
+FORD,Dodge City Precinct 06,United States Senate,,independent,"Orman, Greg",456,000100
+FORD,Dodge City Precinct 06,United States Senate,,Libertarian,"Batson, Randall",30,000100
+FORD,Dodge City Precinct 06,United States Senate,,Republican,"Roberts, Pat",947,000100
+FORD,Dodge Township Ward 3,United States Senate,,independent,"Orman, Greg",6,000200
+FORD,Dodge Township Ward 3,United States Senate,,Libertarian,"Batson, Randall",0,000200
+FORD,Dodge Township Ward 3,United States Senate,,Republican,"Roberts, Pat",16,000200
+FORD,Fairview Township,United States Senate,,independent,"Orman, Greg",29,000220
+FORD,Fairview Township,United States Senate,,Libertarian,"Batson, Randall",6,000220
+FORD,Fairview Township,United States Senate,,Republican,"Roberts, Pat",63,000220
+FORD,Ford City,United States Senate,,independent,"Orman, Greg",6,000230
+FORD,Ford City,United States Senate,,Libertarian,"Batson, Randall",4,000230
+FORD,Ford City,United States Senate,,Republican,"Roberts, Pat",66,000230
+FORD,Ford Township,United States Senate,,independent,"Orman, Greg",7,000240
+FORD,Ford Township,United States Senate,,Libertarian,"Batson, Randall",4,000240
+FORD,Ford Township,United States Senate,,Republican,"Roberts, Pat",55,000240
+FORD,Richland Township,United States Senate,,independent,"Orman, Greg",47,000260
+FORD,Richland Township,United States Senate,,Libertarian,"Batson, Randall",8,000260
+FORD,Richland Township,United States Senate,,Republican,"Roberts, Pat",116,000260
+FORD,Royal Township,United States Senate,,independent,"Orman, Greg",26,000270
+FORD,Royal Township,United States Senate,,Libertarian,"Batson, Randall",2,000270
+FORD,Royal Township,United States Senate,,Republican,"Roberts, Pat",76,000270
+FORD,Sodville Township,United States Senate,,independent,"Orman, Greg",2,000280
+FORD,Sodville Township,United States Senate,,Libertarian,"Batson, Randall",0,000280
+FORD,Sodville Township,United States Senate,,Republican,"Roberts, Pat",37,000280
+FORD,Spearville City,United States Senate,,independent,"Orman, Greg",88,000300
+FORD,Spearville City,United States Senate,,Libertarian,"Batson, Randall",16,000300
+FORD,Spearville City,United States Senate,,Republican,"Roberts, Pat",199,000300
+FORD,Spearville Township,United States Senate,,independent,"Orman, Greg",19,000310
+FORD,Spearville Township,United States Senate,,Libertarian,"Batson, Randall",5,000310
+FORD,Spearville Township,United States Senate,,Republican,"Roberts, Pat",120,000310
+FORD,Wheatland Township,United States Senate,,independent,"Orman, Greg",8,000320
+FORD,Wheatland Township,United States Senate,,Libertarian,"Batson, Randall",2,000320
+FORD,Wheatland Township,United States Senate,,Republican,"Roberts, Pat",54,000320
+FORD,Wilburn Township,United States Senate,,independent,"Orman, Greg",7,000330
+FORD,Wilburn Township,United States Senate,,Libertarian,"Batson, Randall",0,000330
+FORD,Wilburn Township,United States Senate,,Republican,"Roberts, Pat",25,000330
+FORD,Dodge Township H115,United States Senate,,independent,"Orman, Greg",50,120020
+FORD,Dodge Township H115,United States Senate,,Libertarian,"Batson, Randall",6,120020
+FORD,Dodge Township H115,United States Senate,,Republican,"Roberts, Pat",127,120020
+FORD,Dodge Township H119 A,United States Senate,,independent,"Orman, Greg",0,12003A
+FORD,Dodge Township H119 A,United States Senate,,Libertarian,"Batson, Randall",0,12003A
+FORD,Dodge Township H119 A,United States Senate,,Republican,"Roberts, Pat",1,12003A
+FORD,Dodge Township H119,United States Senate,,independent,"Orman, Greg",5,120030
+FORD,Dodge Township H119,United States Senate,,Libertarian,"Batson, Randall",0,120030
+FORD,Dodge Township H119,United States Senate,,Republican,"Roberts, Pat",30,120030
+FORD,Enterprise Township H115,United States Senate,,independent,"Orman, Greg",36,120040
+FORD,Enterprise Township H115,United States Senate,,Libertarian,"Batson, Randall",9,120040
+FORD,Enterprise Township H115,United States Senate,,Republican,"Roberts, Pat",101,120040
+FORD,Enterprise Township H119,United States Senate,,independent,"Orman, Greg",0,120050
+FORD,Enterprise Township H119,United States Senate,,Libertarian,"Batson, Randall",2,120050
+FORD,Enterprise Township H119,United States Senate,,Republican,"Roberts, Pat",0,120050
+FORD,Grandview Township H115,United States Senate,,independent,"Orman, Greg",35,120060
+FORD,Grandview Township H115,United States Senate,,Libertarian,"Batson, Randall",4,120060
+FORD,Grandview Township H115,United States Senate,,Republican,"Roberts, Pat",121,120060
+FORD,Grandview Township East H119,United States Senate,,independent,"Orman, Greg",0,12007A
+FORD,Grandview Township East H119,United States Senate,,Libertarian,"Batson, Randall",0,12007A
+FORD,Grandview Township East H119,United States Senate,,Republican,"Roberts, Pat",0,12007A
+FORD,Grandview Township H119,United States Senate,,independent,"Orman, Greg",0,120070
+FORD,Grandview Township H119,United States Senate,,Libertarian,"Batson, Randall",0,120070
+FORD,Grandview Township H119,United States Senate,,Republican,"Roberts, Pat",0,120070
+FORD,Grandview Township Ward 2 H115,United States Senate,,independent,"Orman, Greg",11,120080
+FORD,Grandview Township Ward 2 H115,United States Senate,,Libertarian,"Batson, Randall",3,120080
+FORD,Grandview Township Ward 2 H115,United States Senate,,Republican,"Roberts, Pat",30,120080
+FORD,Grandview Township Ward 2 H119,United States Senate,,independent,"Orman, Greg",0,120090
+FORD,Grandview Township Ward 2 H119,United States Senate,,Libertarian,"Batson, Randall",0,120090
+FORD,Grandview Township Ward 2 H119,United States Senate,,Republican,"Roberts, Pat",0,120090
+FORD,Dodge City Precinct 03 H115,United States Senate,,independent,"Orman, Greg",0,120100
+FORD,Dodge City Precinct 03 H115,United States Senate,,Libertarian,"Batson, Randall",0,120100
+FORD,Dodge City Precinct 03 H115,United States Senate,,Republican,"Roberts, Pat",0,120100
+FORD,Dodge City Township C H115,United States Senate,,independent,"Orman, Greg",0,120110
+FORD,Dodge City Township C H115,United States Senate,,Libertarian,"Batson, Randall",0,120110
+FORD,Dodge City Township C H115,United States Senate,,Republican,"Roberts, Pat",0,120110
+FORD,Dodge City Township W H119,United States Senate,,independent,"Orman, Greg",0,120120
+FORD,Dodge City Township W H119,United States Senate,,Libertarian,"Batson, Randall",0,120120
+FORD,Dodge City Township W H119,United States Senate,,Republican,"Roberts, Pat",0,120120
+FORD,Dodge City Precinct 09,United States Senate,,independent,"Orman, Greg",2,120130
+FORD,Dodge City Precinct 09,United States Senate,,Libertarian,"Batson, Randall",0,120130
+FORD,Dodge City Precinct 09,United States Senate,,Republican,"Roberts, Pat",3,120130
+FORD,Dodge City Precinct 10,United States Senate,,independent,"Orman, Greg",0,120140
+FORD,Dodge City Precinct 10,United States Senate,,Libertarian,"Batson, Randall",0,120140
+FORD,Dodge City Precinct 10,United States Senate,,Republican,"Roberts, Pat",0,120140
+FORD,Dodge City Precinct 02,United States Senate,,independent,"Orman, Greg",83,130010
+FORD,Dodge City Precinct 02,United States Senate,,Libertarian,"Batson, Randall",14,130010
+FORD,Dodge City Precinct 02,United States Senate,,Republican,"Roberts, Pat",133,130010
+FORD,Dodge City Precinct 05,United States Senate,,independent,"Orman, Greg",352,130020
+FORD,Dodge City Precinct 05,United States Senate,,Libertarian,"Batson, Randall",39,130020
+FORD,Dodge City Precinct 05,United States Senate,,Republican,"Roberts, Pat",714,130020
+FORD,Dodge City Precinct 07,United States Senate,,independent,"Orman, Greg",17,600010
+FORD,Dodge City Precinct 07,United States Senate,,Libertarian,"Batson, Randall",1,600010
+FORD,Dodge City Precinct 07,United States Senate,,Republican,"Roberts, Pat",37,600010
+FORD,Dodge City Precinct 08,United States Senate,,independent,"Orman, Greg",0,800010
+FORD,Dodge City Precinct 08,United States Senate,,Libertarian,"Batson, Randall",0,800010
+FORD,Dodge City Precinct 08,United States Senate,,Republican,"Roberts, Pat",0,800010

--- a/2014/20141104__ks__general__franklin__precinct.csv
+++ b/2014/20141104__ks__general__franklin__precinct.csv
@@ -1,520 +1,514 @@
-county,precinct,office,district,party,candidate,votes
-Franklin,Appanoose,U.S. Senate,,R,Pat Roberts,61
-Franklin,N. Centropolis,U.S. Senate,,R,Pat Roberts,100
-Franklin,S. Centropolis,U.S. Senate,,R,Pat Roberts,100
-Franklin,Cutler,U.S. Senate,,R,Pat Roberts,146
-Franklin,Franklin,U.S. Senate,,R,Pat Roberts,468
-Franklin,Greenwood,U.S. Senate,,R,Pat Roberts,110
-Franklin,Harrison,U.S. Senate,,R,Pat Roberts,147
-Franklin,Hayes,U.S. Senate,,R,Pat Roberts,82
-Franklin,Homewood,U.S. Senate,,R,Pat Roberts,109
-Franklin,Lincoln,U.S. Senate,,R,Pat Roberts,170
-Franklin,Ohio,U.S. Senate,,R,Pat Roberts,149
-Franklin,Ottawa,U.S. Senate,,R,Pat Roberts,195
-Franklin,Peoria,U.S. Senate,,R,Pat Roberts,153
-Franklin,Pomona,U.S. Senate,,R,Pat Roberts,129
-Franklin,Pottawatomie,U.S. Senate,,R,Pat Roberts,113
-Franklin,Richmond,U.S. Senate,,R,Pat Roberts,127
-Franklin,Williamsburg,U.S. Senate,,R,Pat Roberts,90
-Franklin,1st Precinct,U.S. Senate,,R,Pat Roberts,131
-Franklin,2nd Precinct,U.S. Senate,,R,Pat Roberts,154
-Franklin,3rd Precinct,U.S. Senate,,R,Pat Roberts,53
-Franklin,4th Precinct,U.S. Senate,,R,Pat Roberts,327
-Franklin,6th Precinct,U.S. Senate,,R,Pat Roberts,122
-Franklin,7th Precinct,U.S. Senate,,R,Pat Roberts,246
-Franklin,8th Precinct,U.S. Senate,,R,Pat Roberts,334
-Franklin,Advance,U.S. Senate,,R,Pat Roberts,168
-Franklin,Early,U.S. Senate,,R,Pat Roberts,338
-Franklin,Provisional,U.S. Senate,,R,Pat Roberts,52
-Franklin,Appanoose,U.S. Senate,,I,Greg Orman,46
-Franklin,N. Centropolis,U.S. Senate,,I,Greg Orman,45
-Franklin,S. Centropolis,U.S. Senate,,I,Greg Orman,59
-Franklin,Cutler,U.S. Senate,,I,Greg Orman,79
-Franklin,Franklin,U.S. Senate,,I,Greg Orman,307
-Franklin,Greenwood,U.S. Senate,,I,Greg Orman,47
-Franklin,Harrison,U.S. Senate,,I,Greg Orman,50
-Franklin,Hayes,U.S. Senate,,I,Greg Orman,51
-Franklin,Homewood,U.S. Senate,,I,Greg Orman,70
-Franklin,Lincoln,U.S. Senate,,I,Greg Orman,111
-Franklin,Ohio,U.S. Senate,,I,Greg Orman,93
-Franklin,Ottawa,U.S. Senate,,I,Greg Orman,108
-Franklin,Peoria,U.S. Senate,,I,Greg Orman,80
-Franklin,Pomona,U.S. Senate,,I,Greg Orman,113
-Franklin,Pottawatomie,U.S. Senate,,I,Greg Orman,65
-Franklin,Richmond,U.S. Senate,,I,Greg Orman,79
-Franklin,Williamsburg,U.S. Senate,,I,Greg Orman,85
-Franklin,1st Precinct,U.S. Senate,,I,Greg Orman,79
-Franklin,2nd Precinct,U.S. Senate,,I,Greg Orman,101
-Franklin,3rd Precinct,U.S. Senate,,I,Greg Orman,50
-Franklin,4th Precinct,U.S. Senate,,I,Greg Orman,236
-Franklin,6th Precinct,U.S. Senate,,I,Greg Orman,88
-Franklin,7th Precinct,U.S. Senate,,I,Greg Orman,198
-Franklin,8th Precinct,U.S. Senate,,I,Greg Orman,259
-Franklin,Advance,U.S. Senate,,I,Greg Orman,187
-Franklin,Early,U.S. Senate,,I,Greg Orman,281
-Franklin,Provisional,U.S. Senate,,I,Greg Orman,57
-Franklin,Appanoose,U.S. Senate,,L,Randall Batson,4
-Franklin,N. Centropolis,U.S. Senate,,L,Randall Batson,12
-Franklin,S. Centropolis,U.S. Senate,,L,Randall Batson,6
-Franklin,Cutler,U.S. Senate,,L,Randall Batson,18
-Franklin,Franklin,U.S. Senate,,L,Randall Batson,54
-Franklin,Greenwood,U.S. Senate,,L,Randall Batson,7
-Franklin,Harrison,U.S. Senate,,L,Randall Batson,6
-Franklin,Hayes,U.S. Senate,,L,Randall Batson,7
-Franklin,Homewood,U.S. Senate,,L,Randall Batson,7
-Franklin,Lincoln,U.S. Senate,,L,Randall Batson,14
-Franklin,Ohio,U.S. Senate,,L,Randall Batson,18
-Franklin,Ottawa,U.S. Senate,,L,Randall Batson,8
-Franklin,Peoria,U.S. Senate,,L,Randall Batson,14
-Franklin,Pomona,U.S. Senate,,L,Randall Batson,26
-Franklin,Pottawatomie,U.S. Senate,,L,Randall Batson,19
-Franklin,Richmond,U.S. Senate,,L,Randall Batson,25
-Franklin,Williamsburg,U.S. Senate,,L,Randall Batson,17
-Franklin,1st Precinct,U.S. Senate,,L,Randall Batson,19
-Franklin,2nd Precinct,U.S. Senate,,L,Randall Batson,20
-Franklin,3rd Precinct,U.S. Senate,,L,Randall Batson,12
-Franklin,4th Precinct,U.S. Senate,,L,Randall Batson,27
-Franklin,6th Precinct,U.S. Senate,,L,Randall Batson,12
-Franklin,7th Precinct,U.S. Senate,,L,Randall Batson,26
-Franklin,8th Precinct,U.S. Senate,,L,Randall Batson,26
-Franklin,Advance,U.S. Senate,,L,Randall Batson,29
-Franklin,Early,U.S. Senate,,L,Randall Batson,19
-Franklin,Provisional,U.S. Senate,,L,Randall Batson,10
-Franklin,Appanoose,U.S. House,2,R,Lynn Jenkins,76
-Franklin,N. Centropolis,U.S. House,2,R,Lynn Jenkins,120
-Franklin,S. Centropolis,U.S. House,2,R,Lynn Jenkins,117
-Franklin,Cutler,U.S. House,2,R,Lynn Jenkins,184
-Franklin,Franklin,U.S. House,2,R,Lynn Jenkins,588
-Franklin,Greenwood,U.S. House,2,R,Lynn Jenkins,132
-Franklin,Harrison,U.S. House,2,R,Lynn Jenkins,171
-Franklin,Hayes,U.S. House,2,R,Lynn Jenkins,100
-Franklin,Homewood,U.S. House,2,R,Lynn Jenkins,128
-Franklin,Lincoln,U.S. House,2,R,Lynn Jenkins,228
-Franklin,Ohio,U.S. House,2,R,Lynn Jenkins,183
-Franklin,Ottawa,U.S. House,2,R,Lynn Jenkins,241
-Franklin,Peoria,U.S. House,2,R,Lynn Jenkins,191
-Franklin,Pomona,U.S. House,2,R,Lynn Jenkins,185
-Franklin,Pottawatomie,U.S. House,2,R,Lynn Jenkins,143
-Franklin,Richmond,U.S. House,2,R,Lynn Jenkins,178
-Franklin,Williamsburg,U.S. House,2,R,Lynn Jenkins,114
-Franklin,1st Precinct,U.S. House,2,R,Lynn Jenkins,158
-Franklin,2nd Precinct,U.S. House,2,R,Lynn Jenkins,188
-Franklin,3rd Precinct,U.S. House,2,R,Lynn Jenkins,71
-Franklin,4th Precinct,U.S. House,2,R,Lynn Jenkins,388
-Franklin,6th Precinct,U.S. House,2,R,Lynn Jenkins,149
-Franklin,7th Precinct,U.S. House,2,R,Lynn Jenkins,312
-Franklin,8th Precinct,U.S. House,2,R,Lynn Jenkins,416
-Franklin,Advance,U.S. House,2,R,Lynn Jenkins,217
-Franklin,Early,U.S. House,2,R,Lynn Jenkins,399
-Franklin,Provisional,U.S. House,2,R,Lynn Jenkins,69
-Franklin,Appanoose,U.S. House,2,D,Margie Wakefield,31
-Franklin,N. Centropolis,U.S. House,2,D,Margie Wakefield,34
-Franklin,S. Centropolis,U.S. House,2,D,Margie Wakefield,40
-Franklin,Cutler,U.S. House,2,D,Margie Wakefield,50
-Franklin,Franklin,U.S. House,2,D,Margie Wakefield,188
-Franklin,Greenwood,U.S. House,2,D,Margie Wakefield,29
-Franklin,Harrison,U.S. House,2,D,Margie Wakefield,27
-Franklin,Hayes,U.S. House,2,D,Margie Wakefield,36
-Franklin,Homewood,U.S. House,2,D,Margie Wakefield,45
-Franklin,Lincoln,U.S. House,2,D,Margie Wakefield,59
-Franklin,Ohio,U.S. House,2,D,Margie Wakefield,65
-Franklin,Ottawa,U.S. House,2,D,Margie Wakefield,58
-Franklin,Peoria,U.S. House,2,D,Margie Wakefield,47
-Franklin,Pomona,U.S. House,2,D,Margie Wakefield,70
-Franklin,Pottawatomie,U.S. House,2,D,Margie Wakefield,42
-Franklin,Richmond,U.S. House,2,D,Margie Wakefield,42
-Franklin,Williamsburg,U.S. House,2,D,Margie Wakefield,66
-Franklin,1st Precinct,U.S. House,2,D,Margie Wakefield,58
-Franklin,2nd Precinct,U.S. House,2,D,Margie Wakefield,73
-Franklin,3rd Precinct,U.S. House,2,D,Margie Wakefield,36
-Franklin,4th Precinct,U.S. House,2,D,Margie Wakefield,171
-Franklin,6th Precinct,U.S. House,2,D,Margie Wakefield,66
-Franklin,7th Precinct,U.S. House,2,D,Margie Wakefield,135
-Franklin,8th Precinct,U.S. House,2,D,Margie Wakefield,180
-Franklin,Advance,U.S. House,2,D,Margie Wakefield,156
-Franklin,Early,U.S. House,2,D,Margie Wakefield,225
-Franklin,Provisional,U.S. House,2,D,Margie Wakefield,41
-Franklin,Appanoose,U.S. House,2,L,Christopher Clemmons,4
-Franklin,N. Centropolis,U.S. House,2,L,Christopher Clemmons,7
-Franklin,S. Centropolis,U.S. House,2,L,Christopher Clemmons,6
-Franklin,Cutler,U.S. House,2,L,Christopher Clemmons,11
-Franklin,Franklin,U.S. House,2,L,Christopher Clemmons,50
-Franklin,Greenwood,U.S. House,2,L,Christopher Clemmons,3
-Franklin,Harrison,U.S. House,2,L,Christopher Clemmons,5
-Franklin,Hayes,U.S. House,2,L,Christopher Clemmons,5
-Franklin,Homewood,U.S. House,2,L,Christopher Clemmons,13
-Franklin,Lincoln,U.S. House,2,L,Christopher Clemmons,11
-Franklin,Ohio,U.S. House,2,L,Christopher Clemmons,10
-Franklin,Ottawa,U.S. House,2,L,Christopher Clemmons,14
-Franklin,Peoria,U.S. House,2,L,Christopher Clemmons,8
-Franklin,Pomona,U.S. House,2,L,Christopher Clemmons,15
-Franklin,Pottawatomie,U.S. House,2,L,Christopher Clemmons,11
-Franklin,Richmond,U.S. House,2,L,Christopher Clemmons,12
-Franklin,Williamsburg,U.S. House,2,L,Christopher Clemmons,13
-Franklin,1st Precinct,U.S. House,2,L,Christopher Clemmons,14
-Franklin,2nd Precinct,U.S. House,2,L,Christopher Clemmons,13
-Franklin,3rd Precinct,U.S. House,2,L,Christopher Clemmons,6
-Franklin,4th Precinct,U.S. House,2,L,Christopher Clemmons,29
-Franklin,6th Precinct,U.S. House,2,L,Christopher Clemmons,6
-Franklin,7th Precinct,U.S. House,2,L,Christopher Clemmons,22
-Franklin,8th Precinct,U.S. House,2,L,Christopher Clemmons,23
-Franklin,Advance,U.S. House,2,L,Christopher Clemmons,15
-Franklin,Early,U.S. House,2,L,Christopher Clemmons,12
-Franklin,Provisional,U.S. House,2,L,Christopher Clemmons,8
-Franklin,Appanoose,Governor,,R,Sam Brownback,53
-Franklin,N. Centropolis,Governor,,R,Sam Brownback,108
-Franklin,S. Centropolis,Governor,,R,Sam Brownback,91
-Franklin,Cutler,Governor,,R,Sam Brownback,141
-Franklin,Franklin,Governor,,R,Sam Brownback,484
-Franklin,Greenwood,Governor,,R,Sam Brownback,105
-Franklin,Harrison,Governor,,R,Sam Brownback,137
-Franklin,Hayes,Governor,,R,Sam Brownback,76
-Franklin,Homewood,Governor,,R,Sam Brownback,95
-Franklin,Lincoln,Governor,,R,Sam Brownback,164
-Franklin,Ohio,Governor,,R,Sam Brownback,137
-Franklin,Ottawa,Governor,,R,Sam Brownback,179
-Franklin,Peoria,Governor,,R,Sam Brownback,161
-Franklin,Pomona,Governor,,R,Sam Brownback,137
-Franklin,Pottawatomie,Governor,,R,Sam Brownback,116
-Franklin,Richmond,Governor,,R,Sam Brownback,138
-Franklin,Williamsburg,Governor,,R,Sam Brownback,80
-Franklin,1st Precinct,Governor,,R,Sam Brownback,120
-Franklin,2nd Precinct,Governor,,R,Sam Brownback,142
-Franklin,3rd Precinct,Governor,,R,Sam Brownback,48
-Franklin,4th Precinct,Governor,,R,Sam Brownback,300
-Franklin,6th Precinct,Governor,,R,Sam Brownback,113
-Franklin,7th Precinct,Governor,,R,Sam Brownback,211
-Franklin,8th Precinct,Governor,,R,Sam Brownback,304
-Franklin,Advance,Governor,,R,Sam Brownback,158
-Franklin,Early,Governor,,R,Sam Brownback,318
-Franklin,Provisional,Governor,,R,Sam Brownback,50
-Franklin,Appanoose,Governor,,D,Paul Davis,50
-Franklin,N. Centropolis,Governor,,D,Paul Davis,44
-Franklin,S. Centropolis,Governor,,D,Paul Davis,65
-Franklin,Cutler,Governor,,D,Paul Davis,86
-Franklin,Franklin,Governor,,D,Paul Davis,299
-Franklin,Greenwood,Governor,,D,Paul Davis,54
-Franklin,Harrison,Governor,,D,Paul Davis,57
-Franklin,Hayes,Governor,,D,Paul Davis,60
-Franklin,Homewood,Governor,,D,Paul Davis,80
-Franklin,Lincoln,Governor,,D,Paul Davis,116
-Franklin,Ohio,Governor,,D,Paul Davis,105
-Franklin,Ottawa,Governor,,D,Paul Davis,117
-Franklin,Peoria,Governor,,D,Paul Davis,75
-Franklin,Pomona,Governor,,D,Paul Davis,115
-Franklin,Pottawatomie,Governor,,D,Paul Davis,66
-Franklin,Richmond,Governor,,D,Paul Davis,82
-Franklin,Williamsburg,Governor,,D,Paul Davis,98
-Franklin,1st Precinct,Governor,,D,Paul Davis,98
-Franklin,2nd Precinct,Governor,,D,Paul Davis,124
-Franklin,3rd Precinct,Governor,,D,Paul Davis,58
-Franklin,4th Precinct,Governor,,D,Paul Davis,267
-Franklin,6th Precinct,Governor,,D,Paul Davis,99
-Franklin,7th Precinct,Governor,,D,Paul Davis,223
-Franklin,8th Precinct,Governor,,D,Paul Davis,288
-Franklin,Advance,Governor,,D,Paul Davis,198
-Franklin,Early,Governor,,D,Paul Davis,300
-Franklin,Provisional,Governor,,D,Paul Davis,61
-Franklin,Appanoose,Governor,,L,Keen Umbehr,7
-Franklin,N. Centropolis,Governor,,L,Keen Umbehr,9
-Franklin,S. Centropolis,Governor,,L,Keen Umbehr,8
-Franklin,Cutler,Governor,,L,Keen Umbehr,15
-Franklin,Franklin,Governor,,L,Keen Umbehr,46
-Franklin,Greenwood,Governor,,L,Keen Umbehr,4
-Franklin,Harrison,Governor,,L,Keen Umbehr,8
-Franklin,Hayes,Governor,,L,Keen Umbehr,5
-Franklin,Homewood,Governor,,L,Keen Umbehr,10
-Franklin,Lincoln,Governor,,L,Keen Umbehr,15
-Franklin,Ohio,Governor,,L,Keen Umbehr,18
-Franklin,Ottawa,Governor,,L,Keen Umbehr,17
-Franklin,Peoria,Governor,,L,Keen Umbehr,13
-Franklin,Pomona,Governor,,L,Keen Umbehr,19
-Franklin,Pottawatomie,Governor,,L,Keen Umbehr,14
-Franklin,Richmond,Governor,,L,Keen Umbehr,13
-Franklin,Williamsburg,Governor,,L,Keen Umbehr,16
-Franklin,1st Precinct,Governor,,L,Keen Umbehr,13
-Franklin,2nd Precinct,Governor,,L,Keen Umbehr,8
-Franklin,3rd Precinct,Governor,,L,Keen Umbehr,9
-Franklin,4th Precinct,Governor,,L,Keen Umbehr,24
-Franklin,6th Precinct,Governor,,L,Keen Umbehr,8
-Franklin,7th Precinct,Governor,,L,Keen Umbehr,36
-Franklin,8th Precinct,Governor,,L,Keen Umbehr,28
-Franklin,Advance,Governor,,L,Keen Umbehr,28
-Franklin,Early,Governor,,L,Keen Umbehr,20
-Franklin,Provisional,Governor,,L,Keen Umbehr,9
-Franklin,Appanoose,Secretary of State,,R,Kris Kobach,68
-Franklin,N. Centropolis,Secretary of State,,R,Kris Kobach,117
-Franklin,S. Centropolis,Secretary of State,,R,Kris Kobach,117
-Franklin,Cutler,Secretary of State,,R,Kris Kobach,171
-Franklin,Franklin,Secretary of State,,R,Kris Kobach,579
-Franklin,Greenwood,Secretary of State,,R,Kris Kobach,121
-Franklin,Harrison,Secretary of State,,R,Kris Kobach,149
-Franklin,Hayes,Secretary of State,,R,Kris Kobach,100
-Franklin,Homewood,Secretary of State,,R,Kris Kobach,124
-Franklin,Lincoln,Secretary of State,,R,Kris Kobach,210
-Franklin,Ohio,Secretary of State,,R,Kris Kobach,176
-Franklin,Ottawa,Secretary of State,,R,Kris Kobach,231
-Franklin,Peoria,Secretary of State,,R,Kris Kobach,191
-Franklin,Pomona,Secretary of State,,R,Kris Kobach,182
-Franklin,Pottawatomie,Secretary of State,,R,Kris Kobach,136
-Franklin,Richmond,Secretary of State,,R,Kris Kobach,166
-Franklin,Williamsburg,Secretary of State,,R,Kris Kobach,119
-Franklin,1st Precinct,Secretary of State,,R,Kris Kobach,153
-Franklin,2nd Precinct,Secretary of State,,R,Kris Kobach,185
-Franklin,3rd Precinct,Secretary of State,,R,Kris Kobach,64
-Franklin,4th Precinct,Secretary of State,,R,Kris Kobach,368
-Franklin,6th Precinct,Secretary of State,,R,Kris Kobach,145
-Franklin,7th Precinct,Secretary of State,,R,Kris Kobach,291
-Franklin,8th Precinct,Secretary of State,,R,Kris Kobach,403
-Franklin,Advance,Secretary of State,,R,Kris Kobach,184
-Franklin,Early,Secretary of State,,R,Kris Kobach,372
-Franklin,Provisional,Secretary of State,,R,Kris Kobach,63
-Franklin,Appanoose,Secretary of State,,D,Jean Schodorf,36
-Franklin,N. Centropolis,Secretary of State,,D,Jean Schodorf,43
-Franklin,S. Centropolis,Secretary of State,,D,Jean Schodorf,45
-Franklin,Cutler,Secretary of State,,D,Jean Schodorf,67
-Franklin,Franklin,Secretary of State,,D,Jean Schodorf,242
-Franklin,Greenwood,Secretary of State,,D,Jean Schodorf,41
-Franklin,Harrison,Secretary of State,,D,Jean Schodorf,45
-Franklin,Hayes,Secretary of State,,D,Jean Schodorf,38
-Franklin,Homewood,Secretary of State,,D,Jean Schodorf,61
-Franklin,Lincoln,Secretary of State,,D,Jean Schodorf,82
-Franklin,Ohio,Secretary of State,,D,Jean Schodorf,78
-Franklin,Ottawa,Secretary of State,,D,Jean Schodorf,76
-Franklin,Peoria,Secretary of State,,D,Jean Schodorf,58
-Franklin,Pomona,Secretary of State,,D,Jean Schodorf,84
-Franklin,Pottawatomie,Secretary of State,,D,Jean Schodorf,61
-Franklin,Richmond,Secretary of State,,D,Jean Schodorf,63
-Franklin,Williamsburg,Secretary of State,,D,Jean Schodorf,73
-Franklin,1st Precinct,Secretary of State,,D,Jean Schodorf,72
-Franklin,2nd Precinct,Secretary of State,,D,Jean Schodorf,84
-Franklin,3rd Precinct,Secretary of State,,D,Jean Schodorf,47
-Franklin,4th Precinct,Secretary of State,,D,Jean Schodorf,214
-Franklin,6th Precinct,Secretary of State,,D,Jean Schodorf,73
-Franklin,7th Precinct,Secretary of State,,D,Jean Schodorf,174
-Franklin,8th Precinct,Secretary of State,,D,Jean Schodorf,204
-Franklin,Advance,Secretary of State,,D,Jean Schodorf,195
-Franklin,Early,Secretary of State,,D,Jean Schodorf,261
-Franklin,Provisional,Secretary of State,,D,Jean Schodorf,52
-Franklin,Appanoose,Attorney General,,D,AJ Kotich,30
-Franklin,N. Centropolis,Attorney General,,D,AJ Kotich,44
-Franklin,S. Centropolis,Attorney General,,D,AJ Kotich,38
-Franklin,Cutler,Attorney General,,D,AJ Kotich,67
-Franklin,Franklin,Attorney General,,D,AJ Kotich,238
-Franklin,Greenwood,Attorney General,,D,AJ Kotich,33
-Franklin,Harrison,Attorney General,,D,AJ Kotich,37
-Franklin,Hayes,Attorney General,,D,AJ Kotich,34
-Franklin,Homewood,Attorney General,,D,AJ Kotich,48
-Franklin,Lincoln,Attorney General,,D,AJ Kotich,69
-Franklin,Ohio,Attorney General,,D,AJ Kotich,71
-Franklin,Ottawa,Attorney General,,D,AJ Kotich,66
-Franklin,Peoria,Attorney General,,D,AJ Kotich,50
-Franklin,Pomona,Attorney General,,D,AJ Kotich,78
-Franklin,Pottawatomie,Attorney General,,D,AJ Kotich,56
-Franklin,Richmond,Attorney General,,D,AJ Kotich,54
-Franklin,Williamsburg,Attorney General,,D,AJ Kotich,56
-Franklin,1st Precinct,Attorney General,,D,AJ Kotich,63
-Franklin,2nd Precinct,Attorney General,,D,AJ Kotich,80
-Franklin,3rd Precinct,Attorney General,,D,AJ Kotich,37
-Franklin,4th Precinct,Attorney General,,D,AJ Kotich,164
-Franklin,6th Precinct,Attorney General,,D,AJ Kotich,59
-Franklin,7th Precinct,Attorney General,,D,AJ Kotich,154
-Franklin,8th Precinct,Attorney General,,D,AJ Kotich,177
-Franklin,Advance,Attorney General,,D,AJ Kotich,166
-Franklin,Early,Attorney General,,D,AJ Kotich,185
-Franklin,Provisional,Attorney General,,D,AJ Kotich,48
-Franklin,Appanoose,Attorney General,,R,Derek Schmidt,75
-Franklin,N. Centropolis,Attorney General,,R,Derek Schmidt,113
-Franklin,S. Centropolis,Attorney General,,R,Derek Schmidt,121
-Franklin,Cutler,Attorney General,,R,Derek Schmidt,168
-Franklin,Franklin,Attorney General,,R,Derek Schmidt,570
-Franklin,Greenwood,Attorney General,,R,Derek Schmidt,127
-Franklin,Harrison,Attorney General,,R,Derek Schmidt,157
-Franklin,Hayes,Attorney General,,R,Derek Schmidt,102
-Franklin,Homewood,Attorney General,,R,Derek Schmidt,135
-Franklin,Lincoln,Attorney General,,R,Derek Schmidt,224
-Franklin,Ohio,Attorney General,,R,Derek Schmidt,178
-Franklin,Ottawa,Attorney General,,R,Derek Schmidt,239
-Franklin,Peoria,Attorney General,,R,Derek Schmidt,193
-Franklin,Pomona,Attorney General,,R,Derek Schmidt,186
-Franklin,Pottawatomie,Attorney General,,R,Derek Schmidt,135
-Franklin,Richmond,Attorney General,,R,Derek Schmidt,172
-Franklin,Williamsburg,Attorney General,,R,Derek Schmidt,135
-Franklin,1st Precinct,Attorney General,,R,Derek Schmidt,162
-Franklin,2nd Precinct,Attorney General,,R,Derek Schmidt,190
-Franklin,3rd Precinct,Attorney General,,R,Derek Schmidt,75
-Franklin,4th Precinct,Attorney General,,R,Derek Schmidt,411
-Franklin,6th Precinct,Attorney General,,R,Derek Schmidt,154
-Franklin,7th Precinct,Attorney General,,R,Derek Schmidt,306
-Franklin,8th Precinct,Attorney General,,R,Derek Schmidt,425
-Franklin,Advance,Attorney General,,R,Derek Schmidt,206
-Franklin,Early,Attorney General,,R,Derek Schmidt,438
-Franklin,Provisional,Attorney General,,R,Derek Schmidt,66
-Franklin,Appanoose,State Treasurer,,R,Ron Estes,70
-Franklin,N. Centropolis,State Treasurer,,R,Ron Estes,120
-Franklin,S. Centropolis,State Treasurer,,R,Ron Estes,117
-Franklin,Cutler,State Treasurer,,R,Ron Estes,167
-Franklin,Franklin,State Treasurer,,R,Ron Estes,582
-Franklin,Greenwood,State Treasurer,,R,Ron Estes,128
-Franklin,Harrison,State Treasurer,,R,Ron Estes,163
-Franklin,Hayes,State Treasurer,,R,Ron Estes,98
-Franklin,Homewood,State Treasurer,,R,Ron Estes,127
-Franklin,Lincoln,State Treasurer,,R,Ron Estes,214
-Franklin,Ohio,State Treasurer,,R,Ron Estes,175
-Franklin,Ottawa,State Treasurer,,R,Ron Estes,246
-Franklin,Peoria,State Treasurer,,R,Ron Estes,190
-Franklin,Pomona,State Treasurer,,R,Ron Estes,172
-Franklin,Pottawatomie,State Treasurer,,R,Ron Estes,132
-Franklin,Richmond,State Treasurer,,R,Ron Estes,165
-Franklin,Williamsburg,State Treasurer,,R,Ron Estes,130
-Franklin,1st Precinct,State Treasurer,,R,Ron Estes,161
-Franklin,2nd Precinct,State Treasurer,,R,Ron Estes,196
-Franklin,3rd Precinct,State Treasurer,,R,Ron Estes,67
-Franklin,4th Precinct,State Treasurer,,R,Ron Estes,394
-Franklin,6th Precinct,State Treasurer,,R,Ron Estes,148
-Franklin,7th Precinct,State Treasurer,,R,Ron Estes,295
-Franklin,8th Precinct,State Treasurer,,R,Ron Estes,415
-Franklin,Advance,State Treasurer,,R,Ron Estes,202
-Franklin,Early,State Treasurer,,R,Ron Estes,429
-Franklin,Provisional,State Treasurer,,R,Ron Estes,66
-Franklin,Appanoose,State Treasurer,,D,Carmen Alldritt,33
-Franklin,N. Centropolis,State Treasurer,,D,Carmen Alldritt,38
-Franklin,S. Centropolis,State Treasurer,,D,Carmen Alldritt,40
-Franklin,Cutler,State Treasurer,,D,Carmen Alldritt,66
-Franklin,Franklin,State Treasurer,,D,Carmen Alldritt,221
-Franklin,Greenwood,State Treasurer,,D,Carmen Alldritt,31
-Franklin,Harrison,State Treasurer,,D,Carmen Alldritt,32
-Franklin,Hayes,State Treasurer,,D,Carmen Alldritt,39
-Franklin,Homewood,State Treasurer,,D,Carmen Alldritt,55
-Franklin,Lincoln,State Treasurer,,D,Carmen Alldritt,72
-Franklin,Ohio,State Treasurer,,D,Carmen Alldritt,74
-Franklin,Ottawa,State Treasurer,,D,Carmen Alldritt,61
-Franklin,Peoria,State Treasurer,,D,Carmen Alldritt,51
-Franklin,Pomona,State Treasurer,,D,Carmen Alldritt,88
-Franklin,Pottawatomie,State Treasurer,,D,Carmen Alldritt,63
-Franklin,Richmond,State Treasurer,,D,Carmen Alldritt,64
-Franklin,Williamsburg,State Treasurer,,D,Carmen Alldritt,61
-Franklin,1st Precinct,State Treasurer,,D,Carmen Alldritt,63
-Franklin,2nd Precinct,State Treasurer,,D,Carmen Alldritt,74
-Franklin,3rd Precinct,State Treasurer,,D,Carmen Alldritt,45
-Franklin,4th Precinct,State Treasurer,,D,Carmen Alldritt,176
-Franklin,6th Precinct,State Treasurer,,D,Carmen Alldritt,65
-Franklin,7th Precinct,State Treasurer,,D,Carmen Alldritt,161
-Franklin,8th Precinct,State Treasurer,,D,Carmen Alldritt,183
-Franklin,Advance,State Treasurer,,D,Carmen Alldritt,170
-Franklin,Early,State Treasurer,,D,Carmen Alldritt,193
-Franklin,Provisional,State Treasurer,,D,Carmen Alldritt,49
-Franklin,Appanoose,Insurance Commissioner,,R,Ken Selzer,66
-Franklin,N. Centropolis,Insurance Commissioner,,R,Ken Selzer,119
-Franklin,S. Centropolis,Insurance Commissioner,,R,Ken Selzer,103
-Franklin,Cutler,Insurance Commissioner,,R,Ken Selzer,160
-Franklin,Franklin,Insurance Commissioner,,R,Ken Selzer,544
-Franklin,Greenwood,Insurance Commissioner,,R,Ken Selzer,120
-Franklin,Harrison,Insurance Commissioner,,R,Ken Selzer,157
-Franklin,Hayes,Insurance Commissioner,,R,Ken Selzer,92
-Franklin,Homewood,Insurance Commissioner,,R,Ken Selzer,123
-Franklin,Lincoln,Insurance Commissioner,,R,Ken Selzer,207
-Franklin,Ohio,Insurance Commissioner,,R,Ken Selzer,159
-Franklin,Ottawa,Insurance Commissioner,,R,Ken Selzer,230
-Franklin,Peoria,Insurance Commissioner,,R,Ken Selzer,184
-Franklin,Pomona,Insurance Commissioner,,R,Ken Selzer,159
-Franklin,Pottawatomie,Insurance Commissioner,,R,Ken Selzer,126
-Franklin,Richmond,Insurance Commissioner,,R,Ken Selzer,158
-Franklin,Williamsburg,Insurance Commissioner,,R,Ken Selzer,113
-Franklin,1st Precinct,Insurance Commissioner,,R,Ken Selzer,148
-Franklin,2nd Precinct,Insurance Commissioner,,R,Ken Selzer,173
-Franklin,3rd Precinct,Insurance Commissioner,,R,Ken Selzer,64
-Franklin,4th Precinct,Insurance Commissioner,,R,Ken Selzer,374
-Franklin,6th Precinct,Insurance Commissioner,,R,Ken Selzer,138
-Franklin,7th Precinct,Insurance Commissioner,,R,Ken Selzer,290
-Franklin,8th Precinct,Insurance Commissioner,,R,Ken Selzer,376
-Franklin,Advance,Insurance Commissioner,,R,Ken Selzer,182
-Franklin,Early,Insurance Commissioner,,R,Ken Selzer,384
-Franklin,Provisional,Insurance Commissioner,,R,Ken Selzer,63
-Franklin,Appanoose,Insurance Commissioner,,D,Dennis Anderson,38
-Franklin,N. Centropolis,Insurance Commissioner,,D,Dennis Anderson,36
-Franklin,S. Centropolis,Insurance Commissioner,,D,Dennis Anderson,48
-Franklin,Cutler,Insurance Commissioner,,D,Dennis Anderson,71
-Franklin,Franklin,Insurance Commissioner,,D,Dennis Anderson,248
-Franklin,Greenwood,Insurance Commissioner,,D,Dennis Anderson,37
-Franklin,Harrison,Insurance Commissioner,,D,Dennis Anderson,35
-Franklin,Hayes,Insurance Commissioner,,D,Dennis Anderson,40
-Franklin,Homewood,Insurance Commissioner,,D,Dennis Anderson,58
-Franklin,Lincoln,Insurance Commissioner,,D,Dennis Anderson,74
-Franklin,Ohio,Insurance Commissioner,,D,Dennis Anderson,83
-Franklin,Ottawa,Insurance Commissioner,,D,Dennis Anderson,71
-Franklin,Peoria,Insurance Commissioner,,D,Dennis Anderson,53
-Franklin,Pomona,Insurance Commissioner,,D,Dennis Anderson,97
-Franklin,Pottawatomie,Insurance Commissioner,,D,Dennis Anderson,66
-Franklin,Richmond,Insurance Commissioner,,D,Dennis Anderson,68
-Franklin,Williamsburg,Insurance Commissioner,,D,Dennis Anderson,72
-Franklin,1st Precinct,Insurance Commissioner,,D,Dennis Anderson,79
-Franklin,2nd Precinct,Insurance Commissioner,,D,Dennis Anderson,93
-Franklin,3rd Precinct,Insurance Commissioner,,D,Dennis Anderson,48
-Franklin,4th Precinct,Insurance Commissioner,,D,Dennis Anderson,192
-Franklin,6th Precinct,Insurance Commissioner,,D,Dennis Anderson,71
-Franklin,7th Precinct,Insurance Commissioner,,D,Dennis Anderson,166
-Franklin,8th Precinct,Insurance Commissioner,,D,Dennis Anderson,214
-Franklin,Advance,Insurance Commissioner,,D,Dennis Anderson,187
-Franklin,Early,Insurance Commissioner,,D,Dennis Anderson,230
-Franklin,Provisional,Insurance Commissioner,,D,Dennis Anderson,50
-Franklin,Appanoose,State House,59,R,Blaine Finch,78
-Franklin,N. Centropolis,State House,59,R,Blaine Finch,116
-Franklin,S. Centropolis,State House,59,R,Blaine Finch,122
-Franklin,Cutler,State House 005,5,R,Kevin Jones,174
-Franklin,Franklin,State House 005,5,R,Kevin Jones,656
-Franklin,Greenwood,State House,59,R,Blaine Finch,117
-Franklin,Harrison,State House,59,R,Blaine Finch,158
-Franklin,Hayes,State House,59,R,Blaine Finch,110
-Franklin,Homewood,State House,59,R,Blaine Finch,138
-Franklin,Lincoln,State House,59,R,Blaine Finch,239
-Franklin,Ohio,State House 005,5,R,Kevin Jones,177
-Franklin,Ottawa,State House,59,R,Blaine Finch,234
-Franklin,Peoria,State House 005,5,R,Kevin Jones,193
-Franklin,Pomona,State House,59,R,Blaine Finch,216
-Franklin,Pottawatomie,State House 005,5,R,Kevin Jones,134
-Franklin,Richmond,State House 005,5,R,Kevin Jones,164
-Franklin,Williamsburg,State House,59,R,Blaine Finch,136
-Franklin,1st Precinct,State House,59,R,Blaine Finch,157
-Franklin,2nd Precinct,State House,59,R,Blaine Finch,213
-Franklin,3rd Precinct,State House,59,R,Blaine Finch,78
-Franklin,4th Precinct,State House,59,R,Blaine Finch,452
-Franklin,6th Precinct,State House,59,R,Blaine Finch,178
-Franklin,7th Precinct,State House,59,R,Blaine Finch,350
-Franklin,8th Precinct,State House,59,R,Blaine Finch,473
-Franklin,Advance,State House 005,5,R,Kevin Jones,61
-Franklin,Early,State House 005,5,R,Kevin Jones,87
-Franklin,Provisional,State House 005,5,R,Kevin Jones,13
-Franklin,Advance 59,State House,59,R,Blaine Finch,173
-Franklin,Early 59,State House,59,R,Blaine Finch,385
-Franklin,Provisional 59,State House,59,R,Blaine Finch,64
-Franklin,Appanoose,State House,59,D,Scott Barnhardt D,30
-Franklin,N. Centropolis,State House,59,D,Scott Barnhardt D,39
-Franklin,S. Centropolis,State House,59,D,Scott Barnhardt D,40
-Franklin,Cutler,State House 005,5,D,Cleon Rickel D,65
-Franklin,Franklin,State House 005,5,D,Cleon Rickel D,167
-Franklin,Greenwood,State House,59,D,Scott Barnhardt D,43
-Franklin,Harrison,State House,59,D,Scott Barnhardt D,40
-Franklin,Hayes,State House,59,D,Scott Barnhardt D,24
-Franklin,Homewood,State House,59,D,Scott Barnhardt D,42
-Franklin,Lincoln,State House,59,D,Scott Barnhardt D,52
-Franklin,Ohio,State House 005,5,D,Cleon Rickel D,81
-Franklin,Ottawa,State House,59,D,Scott Barnhardt D,71
-Franklin,Peoria,State House 005,5,D,Cleon Rickel D,54
-Franklin,Pomona,State House,59,D,Scott Barnhardt D,52
-Franklin,Pottawatomie,State House 005,5,D,Cleon Rickel D,62
-Franklin,Richmond,State House 005,5,D,Cleon Rickel D,65
-Franklin,Williamsburg,State House,59,D,Scott Barnhardt D,53
-Franklin,1st Precinct,State House,59,D,Scott Barnhardt D,71
-Franklin,2nd Precinct,State House,59,D,Scott Barnhardt D,57
-Franklin,3rd Precinct,State House,59,D,Scott Barnhardt D,34
-Franklin,4th Precinct,State House,59,D,Scott Barnhardt D,133
-Franklin,6th Precinct,State House,59,D,Scott Barnhardt D,44
-Franklin,7th Precinct,State House,59,D,Scott Barnhardt D,121
-Franklin,8th Precinct,State House,59,D,Scott Barnhardt D,126
-Franklin,Advance,State House 005,5,D,Cleon Rickel D,33
-Franklin,Early,State House 005,5,D,Cleon Rickel D,38
-Franklin,Provisional,State House 005,5,D,Cleon Rickel D,11
-Franklin,Advance 59,State House,59,D,Scott Barnhardt D,111
-Franklin,Early 59,State House,59,D,Scott Barnhardt D,112
-Franklin,Provisional 59,State House,59,D,Scott Barnhardt D,30
+county,precinct,office,district,party,candidate,votes,vtd
+FRANKLIN,Appanoose Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000010
+FRANKLIN,Appanoose Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000010
+FRANKLIN,Appanoose Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",61,000010
+FRANKLIN,Centropolis North Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000020
+FRANKLIN,Centropolis North Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000020
+FRANKLIN,Centropolis North Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000020
+FRANKLIN,Centropolis South Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",69,000030
+FRANKLIN,Centropolis South Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000030
+FRANKLIN,Centropolis South Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",106,000030
+FRANKLIN,Cutler Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",102,000040
+FRANKLIN,Cutler Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000040
+FRANKLIN,Cutler Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",159,000040
+FRANKLIN,Franklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",349,000050
+FRANKLIN,Franklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",53,000050
+FRANKLIN,Franklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",528,000050
+FRANKLIN,Greenwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",60,000060
+FRANKLIN,Greenwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000060
+FRANKLIN,Greenwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",112,000060
+FRANKLIN,Harrison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000070
+FRANKLIN,Harrison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000070
+FRANKLIN,Harrison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",149,000070
+FRANKLIN,Hayes Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,000080
+FRANKLIN,Hayes Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000080
+FRANKLIN,Hayes Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,000080
+FRANKLIN,Homewood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,000090
+FRANKLIN,Homewood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000090
+FRANKLIN,Homewood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",105,000090
+FRANKLIN,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",159,000100
+FRANKLIN,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000100
+FRANKLIN,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",201,000100
+FRANKLIN,Ohio Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",120,000110
+FRANKLIN,Ohio Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000110
+FRANKLIN,Ohio Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",156,000110
+FRANKLIN,Ottawa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",134,00012A
+FRANKLIN,Ottawa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,00012A
+FRANKLIN,Ottawa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",205,00012A
+FRANKLIN,Ottawa Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",117,00013A
+FRANKLIN,Ottawa Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00013A
+FRANKLIN,Ottawa Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013C
+FRANKLIN,Ottawa Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",153,000140
+FRANKLIN,Ottawa Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000140
+FRANKLIN,Ottawa Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",168,000140
+FRANKLIN,Ottawa Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",70,000150
+FRANKLIN,Ottawa Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000150
+FRANKLIN,Ottawa Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",62,000150
+FRANKLIN,Ottawa Precinct 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",127,000180
+FRANKLIN,Ottawa Precinct 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000180
+FRANKLIN,Ottawa Precinct 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",134,000180
+FRANKLIN,Ottawa Precinct 7,Governor / Lt. Governor,,Democratic,"Davis, Paul",287,000190
+FRANKLIN,Ottawa Precinct 7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",42,000190
+FRANKLIN,Ottawa Precinct 7,Governor / Lt. Governor,,Republican,"Brownback, Sam",264,000190
+FRANKLIN,Ottawa Precinct 8,Governor / Lt. Governor,,Democratic,"Davis, Paul",377,00020A
+FRANKLIN,Ottawa Precinct 8,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",39,00020A
+FRANKLIN,Ottawa Precinct 8,Governor / Lt. Governor,,Republican,"Brownback, Sam",359,00020A
+FRANKLIN,Peoria Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,000210
+FRANKLIN,Peoria Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000210
+FRANKLIN,Peoria Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",173,000210
+FRANKLIN,Pomona Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",133,000220
+FRANKLIN,Pomona Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000220
+FRANKLIN,Pomona Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",150,000220
+FRANKLIN,Pottawatomie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000230
+FRANKLIN,Pottawatomie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000230
+FRANKLIN,Pottawatomie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000230
+FRANKLIN,Richmond Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",91,000240
+FRANKLIN,Richmond Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000240
+FRANKLIN,Richmond Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",153,000240
+FRANKLIN,Williamsburg Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",103,000250
+FRANKLIN,Williamsburg Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000250
+FRANKLIN,Williamsburg Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,000250
+FRANKLIN,Ottawa Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",334,140010
+FRANKLIN,Ottawa Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",32,140010
+FRANKLIN,Ottawa Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",352,140010
+FRANKLIN,Ottawa Exclave Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+FRANKLIN,Ottawa Exclave Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+FRANKLIN,Ottawa Exclave Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+FRANKLIN,Appanoose Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",32,000010
+FRANKLIN,Appanoose Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",87,000010
+FRANKLIN,Centropolis North Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",46,000020
+FRANKLIN,Centropolis North Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",127,000020
+FRANKLIN,Centropolis South Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",42,000030
+FRANKLIN,Centropolis South Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",139,000030
+FRANKLIN,Cutler Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",77,000040
+FRANKLIN,Cutler Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",198,000040
+FRANKLIN,Franklin Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",203,000050
+FRANKLIN,Franklin Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",721,000050
+FRANKLIN,Greenwood Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",48,000060
+FRANKLIN,Greenwood Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",126,000060
+FRANKLIN,Harrison Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",45,000070
+FRANKLIN,Harrison Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",177,000070
+FRANKLIN,Hayes Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",34,000080
+FRANKLIN,Hayes Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",126,000080
+FRANKLIN,Homewood Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",55,000090
+FRANKLIN,Homewood Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",146,000090
+FRANKLIN,Lincoln Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",71,000100
+FRANKLIN,Lincoln Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",299,000100
+FRANKLIN,Ohio Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",93,000110
+FRANKLIN,Ohio Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",200,000110
+FRANKLIN,Ottawa Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",84,00012A
+FRANKLIN,Ottawa Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",266,00012A
+FRANKLIN,Ottawa Precinct 1,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",85,00013A
+FRANKLIN,Ottawa Precinct 1,Kansas House of Representatives,59,Republican,"Finch, Blaine",187,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas House of Representatives,59,Republican,"Finch, Blaine",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas House of Representatives,59,Republican,"Finch, Blaine",0,00013C
+FRANKLIN,Ottawa Precinct 2,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",78,000140
+FRANKLIN,Ottawa Precinct 2,Kansas House of Representatives,59,Republican,"Finch, Blaine",244,000140
+FRANKLIN,Ottawa Precinct 3,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",44,000150
+FRANKLIN,Ottawa Precinct 3,Kansas House of Representatives,59,Republican,"Finch, Blaine",99,000150
+FRANKLIN,Ottawa Precinct 6,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",55,000180
+FRANKLIN,Ottawa Precinct 6,Kansas House of Representatives,59,Republican,"Finch, Blaine",214,000180
+FRANKLIN,Ottawa Precinct 7,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",154,000190
+FRANKLIN,Ottawa Precinct 7,Kansas House of Representatives,59,Republican,"Finch, Blaine",434,000190
+FRANKLIN,Ottawa Precinct 8,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",168,00020A
+FRANKLIN,Ottawa Precinct 8,Kansas House of Representatives,59,Republican,"Finch, Blaine",582,00020A
+FRANKLIN,Peoria Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",65,000210
+FRANKLIN,Peoria Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",208,000210
+FRANKLIN,Pomona Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",65,000220
+FRANKLIN,Pomona Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",232,000220
+FRANKLIN,Pottawatomie Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",67,000230
+FRANKLIN,Pottawatomie Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",149,000230
+FRANKLIN,Richmond Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",71,000240
+FRANKLIN,Richmond Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",183,000240
+FRANKLIN,Williamsburg Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",56,000250
+FRANKLIN,Williamsburg Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",150,000250
+FRANKLIN,Ottawa Precinct 4,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",163,140010
+FRANKLIN,Ottawa Precinct 4,Kansas House of Representatives,59,Republican,"Finch, Blaine",552,140010
+FRANKLIN,Ottawa Exclave Airport,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",0,900010
+FRANKLIN,Ottawa Exclave Airport,Kansas House of Representatives,59,Republican,"Finch, Blaine",0,900010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",34,000010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,000010
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",40,000020
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000020
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,000020
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",43,000030
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000030
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",133,000030
+FRANKLIN,Cutler Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",61,000040
+FRANKLIN,Cutler Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000040
+FRANKLIN,Cutler Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,000040
+FRANKLIN,Franklin Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",228,000050
+FRANKLIN,Franklin Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",55,000050
+FRANKLIN,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",642,000050
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",33,000060
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000060
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",142,000060
+FRANKLIN,Harrison Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",33,000070
+FRANKLIN,Harrison Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000070
+FRANKLIN,Harrison Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,000070
+FRANKLIN,Hayes Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",45,000080
+FRANKLIN,Hayes Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000080
+FRANKLIN,Hayes Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",116,000080
+FRANKLIN,Homewood Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",58,000090
+FRANKLIN,Homewood Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000090
+FRANKLIN,Homewood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",139,000090
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",90,000100
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000100
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",278,000100
+FRANKLIN,Ohio Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",76,000110
+FRANKLIN,Ohio Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000110
+FRANKLIN,Ohio Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,000110
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",70,00012A
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,00012A
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",273,00012A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",69,00013A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,00013A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",189,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013C
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",95,000140
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000140
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",220,000140
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,000150
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000150
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,000150
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Democratic,"Wakefield, Margie",85,000180
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000180
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,000180
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Democratic,"Wakefield, Margie",190,000190
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000190
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Republican,"Jenkins, Lynn",376,000190
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Democratic,"Wakefield, Margie",245,00020A
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,00020A
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Republican,"Jenkins, Lynn",501,00020A
+FRANKLIN,Peoria Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",57,000210
+FRANKLIN,Peoria Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000210
+FRANKLIN,Peoria Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",206,000210
+FRANKLIN,Pomona Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,000220
+FRANKLIN,Pomona Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000220
+FRANKLIN,Pomona Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",201,000220
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",50,000230
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000230
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",157,000230
+FRANKLIN,Richmond Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",50,000240
+FRANKLIN,Richmond Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000240
+FRANKLIN,Richmond Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",194,000240
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",71,000250
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000250
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",127,000250
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",218,140010
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",39,140010
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",462,140010
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+FRANKLIN,Appanoose Township,Attorney General,,Democratic,"Kotich, A.J.",31,000010
+FRANKLIN,Appanoose Township,Attorney General,,Republican,"Schmidt, Derek",84,000010
+FRANKLIN,Centropolis North Township,Attorney General,,Democratic,"Kotich, A.J.",50,000020
+FRANKLIN,Centropolis North Township,Attorney General,,Republican,"Schmidt, Derek",127,000020
+FRANKLIN,Centropolis South Township,Attorney General,,Democratic,"Kotich, A.J.",42,000030
+FRANKLIN,Centropolis South Township,Attorney General,,Republican,"Schmidt, Derek",135,000030
+FRANKLIN,Cutler Township,Attorney General,,Democratic,"Kotich, A.J.",81,000040
+FRANKLIN,Cutler Township,Attorney General,,Republican,"Schmidt, Derek",190,000040
+FRANKLIN,Franklin Township,Attorney General,,Democratic,"Kotich, A.J.",281,000050
+FRANKLIN,Franklin Township,Attorney General,,Republican,"Schmidt, Derek",625,000050
+FRANKLIN,Greenwood Township,Attorney General,,Democratic,"Kotich, A.J.",38,000060
+FRANKLIN,Greenwood Township,Attorney General,,Republican,"Schmidt, Derek",136,000060
+FRANKLIN,Harrison Township,Attorney General,,Democratic,"Kotich, A.J.",43,000070
+FRANKLIN,Harrison Township,Attorney General,,Republican,"Schmidt, Derek",175,000070
+FRANKLIN,Hayes Township,Attorney General,,Democratic,"Kotich, A.J.",41,000080
+FRANKLIN,Hayes Township,Attorney General,,Republican,"Schmidt, Derek",122,000080
+FRANKLIN,Homewood Township,Attorney General,,Democratic,"Kotich, A.J.",60,000090
+FRANKLIN,Homewood Township,Attorney General,,Republican,"Schmidt, Derek",146,000090
+FRANKLIN,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",97,000100
+FRANKLIN,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",277,000100
+FRANKLIN,Ohio Township,Attorney General,,Democratic,"Kotich, A.J.",83,000110
+FRANKLIN,Ohio Township,Attorney General,,Republican,"Schmidt, Derek",201,000110
+FRANKLIN,Ottawa Township,Attorney General,,Democratic,"Kotich, A.J.",77,00012A
+FRANKLIN,Ottawa Township,Attorney General,,Republican,"Schmidt, Derek",272,00012A
+FRANKLIN,Ottawa Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",78,00013A
+FRANKLIN,Ottawa Precinct 1,Attorney General,,Republican,"Schmidt, Derek",190,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Attorney General,,Democratic,"Kotich, A.J.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Attorney General,,Republican,"Schmidt, Derek",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Attorney General,,Democratic,"Kotich, A.J.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Attorney General,,Republican,"Schmidt, Derek",0,00013C
+FRANKLIN,Ottawa Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",104,000140
+FRANKLIN,Ottawa Precinct 2,Attorney General,,Republican,"Schmidt, Derek",220,000140
+FRANKLIN,Ottawa Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",47,000150
+FRANKLIN,Ottawa Precinct 3,Attorney General,,Republican,"Schmidt, Derek",95,000150
+FRANKLIN,Ottawa Precinct 6,Attorney General,,Democratic,"Kotich, A.J.",75,000180
+FRANKLIN,Ottawa Precinct 6,Attorney General,,Republican,"Schmidt, Derek",185,000180
+FRANKLIN,Ottawa Precinct 7,Attorney General,,Democratic,"Kotich, A.J.",203,000190
+FRANKLIN,Ottawa Precinct 7,Attorney General,,Republican,"Schmidt, Derek",377,000190
+FRANKLIN,Ottawa Precinct 8,Attorney General,,Democratic,"Kotich, A.J.",228,00020A
+FRANKLIN,Ottawa Precinct 8,Attorney General,,Republican,"Schmidt, Derek",518,00020A
+FRANKLIN,Peoria Township,Attorney General,,Democratic,"Kotich, A.J.",62,000210
+FRANKLIN,Peoria Township,Attorney General,,Republican,"Schmidt, Derek",206,000210
+FRANKLIN,Pomona Township,Attorney General,,Democratic,"Kotich, A.J.",94,000220
+FRANKLIN,Pomona Township,Attorney General,,Republican,"Schmidt, Derek",200,000220
+FRANKLIN,Pottawatomie Township,Attorney General,,Democratic,"Kotich, A.J.",63,000230
+FRANKLIN,Pottawatomie Township,Attorney General,,Republican,"Schmidt, Derek",147,000230
+FRANKLIN,Richmond Township,Attorney General,,Democratic,"Kotich, A.J.",58,000240
+FRANKLIN,Richmond Township,Attorney General,,Republican,"Schmidt, Derek",193,000240
+FRANKLIN,Williamsburg Township,Attorney General,,Democratic,"Kotich, A.J.",59,000250
+FRANKLIN,Williamsburg Township,Attorney General,,Republican,"Schmidt, Derek",150,000250
+FRANKLIN,Ottawa Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",207,140010
+FRANKLIN,Ottawa Precinct 4,Attorney General,,Republican,"Schmidt, Derek",492,140010
+FRANKLIN,Ottawa Exclave Airport,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+FRANKLIN,Ottawa Exclave Airport,Attorney General,,Republican,"Schmidt, Derek",0,900010
+FRANKLIN,Appanoose Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000010
+FRANKLIN,Appanoose Township,Commissioner of Insurance,,Republican,"Selzer, Ken",75,000010
+FRANKLIN,Centropolis North Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000020
+FRANKLIN,Centropolis North Township,Commissioner of Insurance,,Republican,"Selzer, Ken",131,000020
+FRANKLIN,Centropolis South Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,000030
+FRANKLIN,Centropolis South Township,Commissioner of Insurance,,Republican,"Selzer, Ken",118,000030
+FRANKLIN,Cutler Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,000040
+FRANKLIN,Cutler Township,Commissioner of Insurance,,Republican,"Selzer, Ken",181,000040
+FRANKLIN,Franklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",300,000050
+FRANKLIN,Franklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",589,000050
+FRANKLIN,Greenwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000060
+FRANKLIN,Greenwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000060
+FRANKLIN,Harrison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000070
+FRANKLIN,Harrison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000070
+FRANKLIN,Hayes Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",49,000080
+FRANKLIN,Hayes Township,Commissioner of Insurance,,Republican,"Selzer, Ken",109,000080
+FRANKLIN,Homewood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000090
+FRANKLIN,Homewood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000090
+FRANKLIN,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",103,000100
+FRANKLIN,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",258,000100
+FRANKLIN,Ohio Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",96,000110
+FRANKLIN,Ohio Township,Commissioner of Insurance,,Republican,"Selzer, Ken",180,000110
+FRANKLIN,Ottawa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",84,00012A
+FRANKLIN,Ottawa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",261,00012A
+FRANKLIN,Ottawa Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,00013A
+FRANKLIN,Ottawa Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",174,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013C
+FRANKLIN,Ottawa Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",118,000140
+FRANKLIN,Ottawa Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",202,000140
+FRANKLIN,Ottawa Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000150
+FRANKLIN,Ottawa Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",83,000150
+FRANKLIN,Ottawa Precinct 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,000180
+FRANKLIN,Ottawa Precinct 6,Commissioner of Insurance,,Republican,"Selzer, Ken",164,000180
+FRANKLIN,Ottawa Precinct 7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",222,000190
+FRANKLIN,Ottawa Precinct 7,Commissioner of Insurance,,Republican,"Selzer, Ken",352,000190
+FRANKLIN,Ottawa Precinct 8,Commissioner of Insurance,,Democratic,"Anderson, Dennis",277,00020A
+FRANKLIN,Ottawa Precinct 8,Commissioner of Insurance,,Republican,"Selzer, Ken",459,00020A
+FRANKLIN,Peoria Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,000210
+FRANKLIN,Peoria Township,Commissioner of Insurance,,Republican,"Selzer, Ken",196,000210
+FRANKLIN,Pomona Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,000220
+FRANKLIN,Pomona Township,Commissioner of Insurance,,Republican,"Selzer, Ken",170,000220
+FRANKLIN,Pottawatomie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",74,000230
+FRANKLIN,Pottawatomie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000230
+FRANKLIN,Richmond Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",75,000240
+FRANKLIN,Richmond Township,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000240
+FRANKLIN,Williamsburg Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",75,000250
+FRANKLIN,Williamsburg Township,Commissioner of Insurance,,Republican,"Selzer, Ken",125,000250
+FRANKLIN,Ottawa Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",247,140010
+FRANKLIN,Ottawa Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",439,140010
+FRANKLIN,Ottawa Exclave Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+FRANKLIN,Ottawa Exclave Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+FRANKLIN,Appanoose Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000010
+FRANKLIN,Appanoose Township,Secretary of State,,Republican,"Kobach, Kris",77,000010
+FRANKLIN,Centropolis North Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,000020
+FRANKLIN,Centropolis North Township,Secretary of State,,Republican,"Kobach, Kris",127,000020
+FRANKLIN,Centropolis South Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000030
+FRANKLIN,Centropolis South Township,Secretary of State,,Republican,"Kobach, Kris",133,000030
+FRANKLIN,Cutler Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",79,000040
+FRANKLIN,Cutler Township,Secretary of State,,Republican,"Kobach, Kris",195,000040
+FRANKLIN,Franklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",292,000050
+FRANKLIN,Franklin Township,Secretary of State,,Republican,"Kobach, Kris",629,000050
+FRANKLIN,Greenwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000060
+FRANKLIN,Greenwood Township,Secretary of State,,Republican,"Kobach, Kris",129,000060
+FRANKLIN,Harrison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,000070
+FRANKLIN,Harrison Township,Secretary of State,,Republican,"Kobach, Kris",165,000070
+FRANKLIN,Hayes Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,000080
+FRANKLIN,Hayes Township,Secretary of State,,Republican,"Kobach, Kris",115,000080
+FRANKLIN,Homewood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000090
+FRANKLIN,Homewood Township,Secretary of State,,Republican,"Kobach, Kris",134,000090
+FRANKLIN,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",116,000100
+FRANKLIN,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",256,000100
+FRANKLIN,Ohio Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",91,000110
+FRANKLIN,Ohio Township,Secretary of State,,Republican,"Kobach, Kris",198,000110
+FRANKLIN,Ottawa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,00012A
+FRANKLIN,Ottawa Township,Secretary of State,,Republican,"Kobach, Kris",261,00012A
+FRANKLIN,Ottawa Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,00013A
+FRANKLIN,Ottawa Precinct 1,Secretary of State,,Republican,"Kobach, Kris",180,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Secretary of State,,Republican,"Kobach, Kris",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Secretary of State,,Republican,"Kobach, Kris",0,00013C
+FRANKLIN,Ottawa Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,000140
+FRANKLIN,Ottawa Precinct 2,Secretary of State,,Republican,"Kobach, Kris",211,000140
+FRANKLIN,Ottawa Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,000150
+FRANKLIN,Ottawa Precinct 3,Secretary of State,,Republican,"Kobach, Kris",82,000150
+FRANKLIN,Ottawa Precinct 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000180
+FRANKLIN,Ottawa Precinct 6,Secretary of State,,Republican,"Kobach, Kris",172,000180
+FRANKLIN,Ottawa Precinct 7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",234,000190
+FRANKLIN,Ottawa Precinct 7,Secretary of State,,Republican,"Kobach, Kris",351,000190
+FRANKLIN,Ottawa Precinct 8,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",280,00020A
+FRANKLIN,Ottawa Precinct 8,Secretary of State,,Republican,"Kobach, Kris",477,00020A
+FRANKLIN,Peoria Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,000210
+FRANKLIN,Peoria Township,Secretary of State,,Republican,"Kobach, Kris",204,000210
+FRANKLIN,Pomona Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,000220
+FRANKLIN,Pomona Township,Secretary of State,,Republican,"Kobach, Kris",193,000220
+FRANKLIN,Pottawatomie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,000230
+FRANKLIN,Pottawatomie Township,Secretary of State,,Republican,"Kobach, Kris",149,000230
+FRANKLIN,Richmond Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,000240
+FRANKLIN,Richmond Township,Secretary of State,,Republican,"Kobach, Kris",181,000240
+FRANKLIN,Williamsburg Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",80,000250
+FRANKLIN,Williamsburg Township,Secretary of State,,Republican,"Kobach, Kris",130,000250
+FRANKLIN,Ottawa Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",274,140010
+FRANKLIN,Ottawa Precinct 4,Secretary of State,,Republican,"Kobach, Kris",436,140010
+FRANKLIN,Ottawa Exclave Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+FRANKLIN,Ottawa Exclave Airport,Secretary of State,,Republican,"Kobach, Kris",0,900010
+FRANKLIN,Appanoose Township,State Treasurer,,Democratic,"Alldritt, Carmen",36,000010
+FRANKLIN,Appanoose Township,State Treasurer,,Republican,"Estes, Ron",78,000010
+FRANKLIN,Centropolis North Township,State Treasurer,,Democratic,"Alldritt, Carmen",45,000020
+FRANKLIN,Centropolis North Township,State Treasurer,,Republican,"Estes, Ron",133,000020
+FRANKLIN,Centropolis South Township,State Treasurer,,Democratic,"Alldritt, Carmen",44,000030
+FRANKLIN,Centropolis South Township,State Treasurer,,Republican,"Estes, Ron",131,000030
+FRANKLIN,Cutler Township,State Treasurer,,Democratic,"Alldritt, Carmen",80,000040
+FRANKLIN,Cutler Township,State Treasurer,,Republican,"Estes, Ron",188,000040
+FRANKLIN,Franklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",269,000050
+FRANKLIN,Franklin Township,State Treasurer,,Republican,"Estes, Ron",631,000050
+FRANKLIN,Greenwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",34,000060
+FRANKLIN,Greenwood Township,State Treasurer,,Republican,"Estes, Ron",139,000060
+FRANKLIN,Harrison Township,State Treasurer,,Democratic,"Alldritt, Carmen",37,000070
+FRANKLIN,Harrison Township,State Treasurer,,Republican,"Estes, Ron",182,000070
+FRANKLIN,Hayes Township,State Treasurer,,Democratic,"Alldritt, Carmen",47,000080
+FRANKLIN,Hayes Township,State Treasurer,,Republican,"Estes, Ron",117,000080
+FRANKLIN,Homewood Township,State Treasurer,,Democratic,"Alldritt, Carmen",66,000090
+FRANKLIN,Homewood Township,State Treasurer,,Republican,"Estes, Ron",139,000090
+FRANKLIN,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",96,000100
+FRANKLIN,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",270,000100
+FRANKLIN,Ohio Township,State Treasurer,,Democratic,"Alldritt, Carmen",86,000110
+FRANKLIN,Ohio Township,State Treasurer,,Republican,"Estes, Ron",197,000110
+FRANKLIN,Ottawa Township,State Treasurer,,Democratic,"Alldritt, Carmen",71,00012A
+FRANKLIN,Ottawa Township,State Treasurer,,Republican,"Estes, Ron",281,00012A
+FRANKLIN,Ottawa Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",78,00013A
+FRANKLIN,Ottawa Precinct 1,State Treasurer,,Republican,"Estes, Ron",189,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),State Treasurer,,Democratic,"Alldritt, Carmen",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),State Treasurer,,Republican,"Estes, Ron",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),State Treasurer,,Democratic,"Alldritt, Carmen",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),State Treasurer,,Republican,"Estes, Ron",0,00013C
+FRANKLIN,Ottawa Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",99,000140
+FRANKLIN,Ottawa Precinct 2,State Treasurer,,Republican,"Estes, Ron",225,000140
+FRANKLIN,Ottawa Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",56,000150
+FRANKLIN,Ottawa Precinct 3,State Treasurer,,Republican,"Estes, Ron",86,000150
+FRANKLIN,Ottawa Precinct 6,State Treasurer,,Democratic,"Alldritt, Carmen",78,000180
+FRANKLIN,Ottawa Precinct 6,State Treasurer,,Republican,"Estes, Ron",182,000180
+FRANKLIN,Ottawa Precinct 7,State Treasurer,,Democratic,"Alldritt, Carmen",210,000190
+FRANKLIN,Ottawa Precinct 7,State Treasurer,,Republican,"Estes, Ron",364,000190
+FRANKLIN,Ottawa Precinct 8,State Treasurer,,Democratic,"Alldritt, Carmen",242,00020A
+FRANKLIN,Ottawa Precinct 8,State Treasurer,,Republican,"Estes, Ron",505,00020A
+FRANKLIN,Peoria Township,State Treasurer,,Democratic,"Alldritt, Carmen",63,000210
+FRANKLIN,Peoria Township,State Treasurer,,Republican,"Estes, Ron",203,000210
+FRANKLIN,Pomona Township,State Treasurer,,Democratic,"Alldritt, Carmen",103,000220
+FRANKLIN,Pomona Township,State Treasurer,,Republican,"Estes, Ron",186,000220
+FRANKLIN,Pottawatomie Township,State Treasurer,,Democratic,"Alldritt, Carmen",71,000230
+FRANKLIN,Pottawatomie Township,State Treasurer,,Republican,"Estes, Ron",144,000230
+FRANKLIN,Richmond Township,State Treasurer,,Democratic,"Alldritt, Carmen",71,000240
+FRANKLIN,Richmond Township,State Treasurer,,Republican,"Estes, Ron",181,000240
+FRANKLIN,Williamsburg Township,State Treasurer,,Democratic,"Alldritt, Carmen",64,000250
+FRANKLIN,Williamsburg Township,State Treasurer,,Republican,"Estes, Ron",145,000250
+FRANKLIN,Ottawa Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",222,140010
+FRANKLIN,Ottawa Precinct 4,State Treasurer,,Republican,"Estes, Ron",473,140010
+FRANKLIN,Ottawa Exclave Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+FRANKLIN,Ottawa Exclave Airport,State Treasurer,,Republican,"Estes, Ron",0,900010
+FRANKLIN,Appanoose Township,United States Senate,,independent,"Orman, Greg",49,000010
+FRANKLIN,Appanoose Township,United States Senate,,Libertarian,"Batson, Randall",5,000010
+FRANKLIN,Appanoose Township,United States Senate,,Republican,"Roberts, Pat",69,000010
+FRANKLIN,Centropolis North Township,United States Senate,,independent,"Orman, Greg",54,000020
+FRANKLIN,Centropolis North Township,United States Senate,,Libertarian,"Batson, Randall",12,000020
+FRANKLIN,Centropolis North Township,United States Senate,,Republican,"Roberts, Pat",111,000020
+FRANKLIN,Centropolis South Township,United States Senate,,independent,"Orman, Greg",63,000030
+FRANKLIN,Centropolis South Township,United States Senate,,Libertarian,"Batson, Randall",6,000030
+FRANKLIN,Centropolis South Township,United States Senate,,Republican,"Roberts, Pat",116,000030
+FRANKLIN,Cutler Township,United States Senate,,independent,"Orman, Greg",92,000040
+FRANKLIN,Cutler Township,United States Senate,,Libertarian,"Batson, Randall",21,000040
+FRANKLIN,Cutler Township,United States Senate,,Republican,"Roberts, Pat",166,000040
+FRANKLIN,Franklin Township,United States Senate,,independent,"Orman, Greg",359,000050
+FRANKLIN,Franklin Township,United States Senate,,Libertarian,"Batson, Randall",59,000050
+FRANKLIN,Franklin Township,United States Senate,,Republican,"Roberts, Pat",511,000050
+FRANKLIN,Greenwood Township,United States Senate,,independent,"Orman, Greg",53,000060
+FRANKLIN,Greenwood Township,United States Senate,,Libertarian,"Batson, Randall",7,000060
+FRANKLIN,Greenwood Township,United States Senate,,Republican,"Roberts, Pat",118,000060
+FRANKLIN,Harrison Township,United States Senate,,independent,"Orman, Greg",59,000070
+FRANKLIN,Harrison Township,United States Senate,,Libertarian,"Batson, Randall",7,000070
+FRANKLIN,Harrison Township,United States Senate,,Republican,"Roberts, Pat",160,000070
+FRANKLIN,Hayes Township,United States Senate,,independent,"Orman, Greg",59,000080
+FRANKLIN,Hayes Township,United States Senate,,Libertarian,"Batson, Randall",11,000080
+FRANKLIN,Hayes Township,United States Senate,,Republican,"Roberts, Pat",97,000080
+FRANKLIN,Homewood Township,United States Senate,,independent,"Orman, Greg",84,000090
+FRANKLIN,Homewood Township,United States Senate,,Libertarian,"Batson, Randall",8,000090
+FRANKLIN,Homewood Township,United States Senate,,Republican,"Roberts, Pat",118,000090
+FRANKLIN,Lincoln Township,United States Senate,,independent,"Orman, Greg",151,000100
+FRANKLIN,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",14,000100
+FRANKLIN,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",211,000100
+FRANKLIN,Ohio Township,United States Senate,,independent,"Orman, Greg",108,000110
+FRANKLIN,Ohio Township,United States Senate,,Libertarian,"Batson, Randall",19,000110
+FRANKLIN,Ohio Township,United States Senate,,Republican,"Roberts, Pat",168,000110
+FRANKLIN,Ottawa Township,United States Senate,,independent,"Orman, Greg",120,00012A
+FRANKLIN,Ottawa Township,United States Senate,,Libertarian,"Batson, Randall",11,00012A
+FRANKLIN,Ottawa Township,United States Senate,,Republican,"Roberts, Pat",225,00012A
+FRANKLIN,Ottawa Precinct 1,United States Senate,,independent,"Orman, Greg",98,00013A
+FRANKLIN,Ottawa Precinct 1,United States Senate,,Libertarian,"Batson, Randall",22,00013A
+FRANKLIN,Ottawa Precinct 1,United States Senate,,Republican,"Roberts, Pat",153,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States Senate,,independent,"Orman, Greg",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States Senate,,Libertarian,"Batson, Randall",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States Senate,,Republican,"Roberts, Pat",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States Senate,,independent,"Orman, Greg",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States Senate,,Libertarian,"Batson, Randall",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States Senate,,Republican,"Roberts, Pat",0,00013C
+FRANKLIN,Ottawa Precinct 2,United States Senate,,independent,"Orman, Greg",128,000140
+FRANKLIN,Ottawa Precinct 2,United States Senate,,Libertarian,"Batson, Randall",21,000140
+FRANKLIN,Ottawa Precinct 2,United States Senate,,Republican,"Roberts, Pat",182,000140
+FRANKLIN,Ottawa Precinct 3,United States Senate,,independent,"Orman, Greg",63,000150
+FRANKLIN,Ottawa Precinct 3,United States Senate,,Libertarian,"Batson, Randall",16,000150
+FRANKLIN,Ottawa Precinct 3,United States Senate,,Republican,"Roberts, Pat",67,000150
+FRANKLIN,Ottawa Precinct 6,United States Senate,,independent,"Orman, Greg",113,000180
+FRANKLIN,Ottawa Precinct 6,United States Senate,,Libertarian,"Batson, Randall",16,000180
+FRANKLIN,Ottawa Precinct 6,United States Senate,,Republican,"Roberts, Pat",142,000180
+FRANKLIN,Ottawa Precinct 7,United States Senate,,independent,"Orman, Greg",259,000190
+FRANKLIN,Ottawa Precinct 7,United States Senate,,Libertarian,"Batson, Randall",30,000190
+FRANKLIN,Ottawa Precinct 7,United States Senate,,Republican,"Roberts, Pat",302,000190
+FRANKLIN,Ottawa Precinct 8,United States Senate,,independent,"Orman, Greg",340,00020A
+FRANKLIN,Ottawa Precinct 8,United States Senate,,Libertarian,"Batson, Randall",36,00020A
+FRANKLIN,Ottawa Precinct 8,United States Senate,,Republican,"Roberts, Pat",397,00020A
+FRANKLIN,Peoria Township,United States Senate,,independent,"Orman, Greg",94,000210
+FRANKLIN,Peoria Township,United States Senate,,Libertarian,"Batson, Randall",14,000210
+FRANKLIN,Peoria Township,United States Senate,,Republican,"Roberts, Pat",165,000210
+FRANKLIN,Pomona Township,United States Senate,,independent,"Orman, Greg",129,000220
+FRANKLIN,Pomona Township,United States Senate,,Libertarian,"Batson, Randall",28,000220
+FRANKLIN,Pomona Township,United States Senate,,Republican,"Roberts, Pat",140,000220
+FRANKLIN,Pottawatomie Township,United States Senate,,independent,"Orman, Greg",72,000230
+FRANKLIN,Pottawatomie Township,United States Senate,,Libertarian,"Batson, Randall",19,000230
+FRANKLIN,Pottawatomie Township,United States Senate,,Republican,"Roberts, Pat",127,000230
+FRANKLIN,Richmond Township,United States Senate,,independent,"Orman, Greg",85,000240
+FRANKLIN,Richmond Township,United States Senate,,Libertarian,"Batson, Randall",28,000240
+FRANKLIN,Richmond Township,United States Senate,,Republican,"Roberts, Pat",143,000240
+FRANKLIN,Williamsburg Township,United States Senate,,independent,"Orman, Greg",92,000250
+FRANKLIN,Williamsburg Township,United States Senate,,Libertarian,"Batson, Randall",17,000250
+FRANKLIN,Williamsburg Township,United States Senate,,Republican,"Roberts, Pat",101,000250
+FRANKLIN,Ottawa Precinct 4,United States Senate,,independent,"Orman, Greg",300,140010
+FRANKLIN,Ottawa Precinct 4,United States Senate,,Libertarian,"Batson, Randall",35,140010
+FRANKLIN,Ottawa Precinct 4,United States Senate,,Republican,"Roberts, Pat",385,140010
+FRANKLIN,Ottawa Exclave Airport,United States Senate,,independent,"Orman, Greg",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States Senate,,Libertarian,"Batson, Randall",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States Senate,,Republican,"Roberts, Pat",0,900010

--- a/2014/20141104__ks__general__geary__precinct.csv
+++ b/2014/20141104__ks__general__geary__precinct.csv
@@ -1,686 +1,1404 @@
-county,precinct,office,district,party,candidate,votes
-Geary,W1P1,U.S. Senate,,IND,Greg Orman,61
-Geary,W1P2,U.S. Senate,,IND,Greg Orman,50
-Geary,W1P3,U.S. Senate,,IND,Greg Orman,68
-Geary,W1P4,U.S. Senate,,IND,Greg Orman,168
-Geary,W1P5,U.S. Senate,,IND,Greg Orman,93
-Geary,W1P6,U.S. Senate,,IND,Greg Orman,120
-Geary,W1P7,U.S. Senate,,IND,Greg Orman,151
-Geary,W2P1,U.S. Senate,,IND,Greg Orman,25
-Geary,W2P2,U.S. Senate,,IND,Greg Orman,82
-Geary,W2P3,U.S. Senate,,IND,Greg Orman,17
-Geary,W2P4,U.S. Senate,,IND,Greg Orman,9
-Geary,W2P5,U.S. Senate,,IND,Greg Orman,81
-Geary,W2P6,U.S. Senate,,IND,Greg Orman,57
-Geary,W2P7,U.S. Senate,,IND,Greg Orman,50
-Geary,W2P8,U.S. Senate,,IND,Greg Orman,11
-Geary,W3P1,U.S. Senate,,IND,Greg Orman,35
-Geary,W3P2,U.S. Senate,,IND,Greg Orman,88
-Geary,W3P3,U.S. Senate,,IND,Greg Orman,33
-Geary,W3P4,U.S. Senate,,IND,Greg Orman,14
-Geary,W4P1,U.S. Senate,,IND,Greg Orman,35
-Geary,W4P2,U.S. Senate,,IND,Greg Orman,27
-Geary,W4P3,U.S. Senate,,IND,Greg Orman,75
-Geary,W4P4,U.S. Senate,,IND,Greg Orman,141
-Geary,Blakely  Twp,U.S. Senate,,IND,Greg Orman,10
-Geary,Grandview  Plaza  Pct,U.S. Senate,,IND,Greg Orman,53
-Geary,Jefferson  Precinct,U.S. Senate,,IND,Greg Orman,42
-Geary,Jackson  Twp,U.S. Senate,,IND,Greg Orman,13
-Geary,Liberty  Twp,U.S. Senate,,IND,Greg Orman,25
-Geary,Lyon  Twp,U.S. Senate,,IND,Greg Orman,27
-Geary,Milford  City,U.S. Senate,,IND,Greg Orman,26
-Geary,Milford  Twp,U.S. Senate,,IND,Greg Orman,154
-Geary,Ft.  Riley  B,U.S. Senate,,IND,Greg Orman,14
-Geary,Ft.  Riley  A,U.S. Senate,,IND,Greg Orman,2
-Geary,Smoky Hill Twp Pct 2,U.S. Senate,,IND,Greg Orman,1
-Geary,Smoky Hill Twp Pct 3,U.S. Senate,,IND,Greg Orman,19
-Geary,Smoky Hill Twp Pct 4,U.S. Senate,,IND,Greg Orman,24
-Geary,Smoky Hill Twp Pct 5,U.S. Senate,,IND,Greg Orman,39
-Geary,Smoky Hill Twp Pct 6,U.S. Senate,,IND,Greg Orman,9
-Geary,Wingfield Twp,U.S. Senate,,IND,Greg Orman,25
-Geary,W1P1,U.S. Senate,,R,Pat Roberts,52
-Geary,W1P2,U.S. Senate,,R,Pat Roberts,66
-Geary,W1P3,U.S. Senate,,R,Pat Roberts,124
-Geary,W1P4,U.S. Senate,,R,Pat Roberts,187
-Geary,W1P5,U.S. Senate,,R,Pat Roberts,104
-Geary,W1P6,U.S. Senate,,R,Pat Roberts,138
-Geary,W1P7,U.S. Senate,,R,Pat Roberts,166
-Geary,W2P1,U.S. Senate,,R,Pat Roberts,30
-Geary,W2P2,U.S. Senate,,R,Pat Roberts,96
-Geary,W2P3,U.S. Senate,,R,Pat Roberts,20
-Geary,W2P4,U.S. Senate,,R,Pat Roberts,23
-Geary,W2P5,U.S. Senate,,R,Pat Roberts,113
-Geary,W2P6,U.S. Senate,,R,Pat Roberts,61
-Geary,W2P7,U.S. Senate,,R,Pat Roberts,79
-Geary,W2P8,U.S. Senate,,R,Pat Roberts,23
-Geary,W3P1,U.S. Senate,,R,Pat Roberts,38
-Geary,W3P2,U.S. Senate,,R,Pat Roberts,114
-Geary,W3P3,U.S. Senate,,R,Pat Roberts,38
-Geary,W3P4,U.S. Senate,,R,Pat Roberts,19
-Geary,W4P1,U.S. Senate,,R,Pat Roberts,31
-Geary,W4P2,U.S. Senate,,R,Pat Roberts,25
-Geary,W4P3,U.S. Senate,,R,Pat Roberts,65
-Geary,W4P4,U.S. Senate,,R,Pat Roberts,104
-Geary,Blakely  Twp,U.S. Senate,,R,Pat Roberts,40
-Geary,Grandview  Plaza  Pct,U.S. Senate,,R,Pat Roberts,107
-Geary,Jefferson  Precinct,U.S. Senate,,R,Pat Roberts,104
-Geary,Jackson  Twp,U.S. Senate,,R,Pat Roberts,26
-Geary,Liberty  Twp,U.S. Senate,,R,Pat Roberts,48
-Geary,Lyon  Twp,U.S. Senate,,R,Pat Roberts,99
-Geary,Milford  City,U.S. Senate,,R,Pat Roberts,75
-Geary,Milford  Twp,U.S. Senate,,R,Pat Roberts,280
-Geary,Ft.  Riley  B,U.S. Senate,,R,Pat Roberts,25
-Geary,Ft.  Riley  A,U.S. Senate,,R,Pat Roberts,4
-Geary,Smoky Hill Twp Pct 2,U.S. Senate,,R,Pat Roberts,3
-Geary,Smoky Hill Twp Pct 3,U.S. Senate,,R,Pat Roberts,43
-Geary,Smoky Hill Twp Pct 4,U.S. Senate,,R,Pat Roberts,49
-Geary,Smoky Hill Twp Pct 5,U.S. Senate,,R,Pat Roberts,109
-Geary,Smoky Hill Twp Pct 6,U.S. Senate,,R,Pat Roberts,14
-Geary,Wingfield Twp,U.S. Senate,,R,Pat Roberts,37
-Geary,W1P1,U.S. Senate,,LBT,Randall Batson,9
-Geary,W1P2,U.S. Senate,,LBT,Randall Batson,5
-Geary,W1P3,U.S. Senate,,LBT,Randall Batson,12
-Geary,W1P4,U.S. Senate,,LBT,Randall Batson,10
-Geary,W1P5,U.S. Senate,,LBT,Randall Batson,13
-Geary,W1P6,U.S. Senate,,LBT,Randall Batson,14
-Geary,W1P7,U.S. Senate,,LBT,Randall Batson,14
-Geary,W2P1,U.S. Senate,,LBT,Randall Batson,8
-Geary,W2P2,U.S. Senate,,LBT,Randall Batson,11
-Geary,W2P3,U.S. Senate,,LBT,Randall Batson,0
-Geary,W2P4,U.S. Senate,,LBT,Randall Batson,1
-Geary,W2P5,U.S. Senate,,LBT,Randall Batson,5
-Geary,W2P6,U.S. Senate,,LBT,Randall Batson,5
-Geary,W2P7,U.S. Senate,,LBT,Randall Batson,3
-Geary,W2P8,U.S. Senate,,LBT,Randall Batson,1
-Geary,W3P1,U.S. Senate,,LBT,Randall Batson,6
-Geary,W3P2,U.S. Senate,,LBT,Randall Batson,16
-Geary,W3P3,U.S. Senate,,LBT,Randall Batson,1
-Geary,W3P4,U.S. Senate,,LBT,Randall Batson,1
-Geary,W4P1,U.S. Senate,,LBT,Randall Batson,7
-Geary,W4P2,U.S. Senate,,LBT,Randall Batson,4
-Geary,W4P3,U.S. Senate,,LBT,Randall Batson,8
-Geary,W4P4,U.S. Senate,,LBT,Randall Batson,12
-Geary,Blakely  Twp,U.S. Senate,,LBT,Randall Batson,1
-Geary,Grandview  Plaza  Pct,U.S. Senate,,LBT,Randall Batson,14
-Geary,Jefferson  Precinct,U.S. Senate,,LBT,Randall Batson,5
-Geary,Jackson  Twp,U.S. Senate,,LBT,Randall Batson,1
-Geary,Liberty  Twp,U.S. Senate,,LBT,Randall Batson,3
-Geary,Lyon  Twp,U.S. Senate,,LBT,Randall Batson,5
-Geary,Milford  City,U.S. Senate,,LBT,Randall Batson,2
-Geary,Milford  Twp,U.S. Senate,,LBT,Randall Batson,17
-Geary,Ft.  Riley  B,U.S. Senate,,LBT,Randall Batson,2
-Geary,Ft.  Riley  A,U.S. Senate,,LBT,Randall Batson,2
-Geary,Smoky Hill Twp Pct 2,U.S. Senate,,LBT,Randall Batson,0
-Geary,Smoky Hill Twp Pct 3,U.S. Senate,,LBT,Randall Batson,2
-Geary,Smoky Hill Twp Pct 4,U.S. Senate,,LBT,Randall Batson,4
-Geary,Smoky Hill Twp Pct 5,U.S. Senate,,LBT,Randall Batson,6
-Geary,Smoky Hill Twp Pct 6,U.S. Senate,,LBT,Randall Batson,0
-Geary,Wingfield Twp,U.S. Senate,,LBT,Randall Batson,0
-Geary,W1P1,U.S. House,1,R,Tim Huelskamp,61
-Geary,W1P2,U.S. House,1,R,Tim Huelskamp,70
-Geary,W1P3,U.S. House,1,R,Tim Huelskamp,134
-Geary,W1P4,U.S. House,1,R,Tim Huelskamp,217
-Geary,W1P5,U.S. House,1,R,Tim Huelskamp,116
-Geary,W1P6,U.S. House,1,R,Tim Huelskamp,152
-Geary,W1P7,U.S. House,1,R,Tim Huelskamp,180
-Geary,W2P1,U.S. House,1,R,Tim Huelskamp,31
-Geary,W2P2,U.S. House,1,R,Tim Huelskamp,118
-Geary,W2P3,U.S. House,1,R,Tim Huelskamp,29
-Geary,W2P4,U.S. House,1,R,Tim Huelskamp,24
-Geary,W2P5,U.S. House,1,R,Tim Huelskamp,112
-Geary,W2P6,U.S. House,1,R,Tim Huelskamp,66
-Geary,W2P7,U.S. House,1,R,Tim Huelskamp,84
-Geary,W2P8,U.S. House,1,R,Tim Huelskamp,23
-Geary,W3P1,U.S. House,1,R,Tim Huelskamp,49
-Geary,W3P2,U.S. House,1,R,Tim Huelskamp,132
-Geary,W3P3,U.S. House,1,R,Tim Huelskamp,40
-Geary,W3P4,U.S. House,1,R,Tim Huelskamp,22
-Geary,W4P1,U.S. House,1,R,Tim Huelskamp,38
-Geary,W4P2,U.S. House,1,R,Tim Huelskamp,26
-Geary,W4P3,U.S. House,1,R,Tim Huelskamp,64
-Geary,W4P4,U.S. House,1,R,Tim Huelskamp,104
-Geary,Blakely  Twp,U.S. House,1,R,Tim Huelskamp,38
-Geary,Grandview  Plaza  Pct,U.S. House,1,R,Tim Huelskamp,126
-Geary,Jefferson  Precinct,U.S. House,1,R,Tim Huelskamp,108
-Geary,Jackson  Twp,U.S. House,1,R,Tim Huelskamp,26
-Geary,Liberty  Twp,U.S. House,1,R,Tim Huelskamp,53
-Geary,Lyon  Twp,U.S. House,1,R,Tim Huelskamp,108
-Geary,Milford  City,U.S. House,1,R,Tim Huelskamp,83
-Geary,Milford  Twp,U.S. House,1,R,Tim Huelskamp,322
-Geary,Ft.  Riley  B,U.S. House,1,R,Tim Huelskamp,28
-Geary,Ft.  Riley  A,U.S. House,1,R,Tim Huelskamp,6
-Geary,Smoky Hill Twp Pct 2,U.S. House,1,R,Tim Huelskamp,3
-Geary,Smoky Hill Twp Pct 3,U.S. House,1,R,Tim Huelskamp,44
-Geary,Smoky Hill Twp Pct 4,U.S. House,1,R,Tim Huelskamp,51
-Geary,Smoky Hill Twp Pct 5,U.S. House,1,R,Tim Huelskamp,117
-Geary,Smoky Hill Twp Pct 6,U.S. House,1,R,Tim Huelskamp,17
-Geary,Wingfield Twp,U.S. House,1,R,Tim Huelskamp,35
-Geary,W1P1,U.S. House,1,D,James Sherow,62
-Geary,W1P2,U.S. House,1,D,James Sherow,48
-Geary,W1P3,U.S. House,1,D,James Sherow,70
-Geary,W1P4,U.S. House,1,D,James Sherow,148
-Geary,W1P5,U.S. House,1,D,James Sherow,97
-Geary,W1P6,U.S. House,1,D,James Sherow,115
-Geary,W1P7,U.S. House,1,D,James Sherow,149
-Geary,W2P1,U.S. House,1,D,James Sherow,30
-Geary,W2P2,U.S. House,1,D,James Sherow,71
-Geary,W2P3,U.S. House,1,D,James Sherow,8
-Geary,W2P4,U.S. House,1,D,James Sherow,9
-Geary,W2P5,U.S. House,1,D,James Sherow,83
-Geary,W2P6,U.S. House,1,D,James Sherow,55
-Geary,W2P7,U.S. House,1,D,James Sherow,45
-Geary,W2P8,U.S. House,1,D,James Sherow,13
-Geary,W3P1,U.S. House,1,D,James Sherow,31
-Geary,W3P2,U.S. House,1,D,James Sherow,85
-Geary,W3P3,U.S. House,1,D,James Sherow,33
-Geary,W3P4,U.S. House,1,D,James Sherow,12
-Geary,W4P1,U.S. House,1,D,James Sherow,37
-Geary,W4P2,U.S. House,1,D,James Sherow,28
-Geary,W4P3,U.S. House,1,D,James Sherow,86
-Geary,W4P4,U.S. House,1,D,James Sherow,151
-Geary,Blakely  Twp,U.S. House,1,D,James Sherow,12
-Geary,Grandview  Plaza  Pct,U.S. House,1,D,James Sherow,46
-Geary,Jefferson  Precinct,U.S. House,1,D,James Sherow,37
-Geary,Jackson  Twp,U.S. House,1,D,James Sherow,13
-Geary,Liberty  Twp,U.S. House,1,D,James Sherow,24
-Geary,Lyon  Twp,U.S. House,1,D,James Sherow,22
-Geary,Milford  City,U.S. House,1,D,James Sherow,20
-Geary,Milford  Twp,U.S. House,1,D,James Sherow,129
-Geary,Ft.  Riley  B,U.S. House,1,D,James Sherow,13
-Geary,Ft.  Riley  A,U.S. House,1,D,James Sherow,2
-Geary,Smoky Hill Twp Pct 2,U.S. House,1,D,James Sherow,1
-Geary,Smoky Hill Twp Pct 3,U.S. House,1,D,James Sherow,18
-Geary,Smoky Hill Twp Pct 4,U.S. House,1,D,James Sherow,25
-Geary,Smoky Hill Twp Pct 5,U.S. House,1,D,James Sherow,33
-Geary,Smoky Hill Twp Pct 6,U.S. House,1,D,James Sherow,6
-Geary,Wingfield Twp,U.S. House,1,D,James Sherow,27
-Geary,W1P1,Governor,,D,Paul Davis,67
-Geary,W1P2,Governor,,D,Paul Davis,61
-Geary,W1P3,Governor,,D,Paul Davis,82
-Geary,W1P4,Governor,,D,Paul Davis,190
-Geary,W1P5,Governor,,D,Paul Davis,104
-Geary,W1P6,Governor,,D,Paul Davis,137
-Geary,W1P7,Governor,,D,Paul Davis,157
-Geary,W2P1,Governor,,D,Paul Davis,31
-Geary,W2P2,Governor,,D,Paul Davis,107
-Geary,W2P3,Governor,,D,Paul Davis,17
-Geary,W2P4,Governor,,D,Paul Davis,12
-Geary,W2P5,Governor,,D,Paul Davis,93
-Geary,W2P6,Governor,,D,Paul Davis,61
-Geary,W2P7,Governor,,D,Paul Davis,48
-Geary,W2P8,Governor,,D,Paul Davis,14
-Geary,W3P1,Governor,,D,Paul Davis,40
-Geary,W3P2,Governor,,D,Paul Davis,96
-Geary,W3P3,Governor,,D,Paul Davis,32
-Geary,W3P4,Governor,,D,Paul Davis,14
-Geary,W4P1,Governor,,D,Paul Davis,33
-Geary,W4P2,Governor,,D,Paul Davis,33
-Geary,W4P3,Governor,,D,Paul Davis,84
-Geary,W4P4,Governor,,D,Paul Davis,159
-Geary,Blakely  Twp,Governor,,D,Paul Davis,17
-Geary,Grandview  Plaza  Pct,Governor,,D,Paul Davis,56
-Geary,Jefferson  Precinct,Governor,,D,Paul Davis,48
-Geary,Jackson  Twp,Governor,,D,Paul Davis,12
-Geary,Liberty  Twp,Governor,,D,Paul Davis,29
-Geary,Lyon  Twp,Governor,,D,Paul Davis,30
-Geary,Milford  City,Governor,,D,Paul Davis,27
-Geary,Milford  Twp,Governor,,D,Paul Davis,164
-Geary,Ft.  Riley  B,Governor,,D,Paul Davis,14
-Geary,Ft.  Riley  A,Governor,,D,Paul Davis,2
-Geary,Smoky Hill Twp Pct 2,Governor,,D,Paul Davis,1
-Geary,Smoky Hill Twp Pct 3,Governor,,D,Paul Davis,22
-Geary,Smoky Hill Twp Pct 4,Governor,,D,Paul Davis,35
-Geary,Smoky Hill Twp Pct 5,Governor,,D,Paul Davis,38
-Geary,Smoky Hill Twp Pct 6,Governor,,D,Paul Davis,9
-Geary,Wingfield Twp,Governor,,D,Paul Davis,24
-Geary,W1P1,Governor,,LBT,Keen Umbehr,9
-Geary,W1P2,Governor,,LBT,Keen Umbehr,6
-Geary,W1P3,Governor,,LBT,Keen Umbehr,13
-Geary,W1P4,Governor,,LBT,Keen Umbehr,11
-Geary,W1P5,Governor,,LBT,Keen Umbehr,12
-Geary,W1P6,Governor,,LBT,Keen Umbehr,12
-Geary,W1P7,Governor,,LBT,Keen Umbehr,14
-Geary,W2P1,Governor,,LBT,Keen Umbehr,2
-Geary,W2P2,Governor,,LBT,Keen Umbehr,9
-Geary,W2P3,Governor,,LBT,Keen Umbehr,0
-Geary,W2P4,Governor,,LBT,Keen Umbehr,1
-Geary,W2P5,Governor,,LBT,Keen Umbehr,8
-Geary,W2P6,Governor,,LBT,Keen Umbehr,6
-Geary,W2P7,Governor,,LBT,Keen Umbehr,9
-Geary,W2P8,Governor,,LBT,Keen Umbehr,3
-Geary,W3P1,Governor,,LBT,Keen Umbehr,3
-Geary,W3P2,Governor,,LBT,Keen Umbehr,16
-Geary,W3P3,Governor,,LBT,Keen Umbehr,7
-Geary,W3P4,Governor,,LBT,Keen Umbehr,0
-Geary,W4P1,Governor,,LBT,Keen Umbehr,10
-Geary,W4P2,Governor,,LBT,Keen Umbehr,0
-Geary,W4P3,Governor,,LBT,Keen Umbehr,10
-Geary,W4P4,Governor,,LBT,Keen Umbehr,12
-Geary,Blakely  Twp,Governor,,LBT,Keen Umbehr,2
-Geary,Grandview  Plaza  Pct,Governor,,LBT,Keen Umbehr,17
-Geary,Jefferson  Precinct,Governor,,LBT,Keen Umbehr,10
-Geary,Jackson  Twp,Governor,,LBT,Keen Umbehr,2
-Geary,Liberty  Twp,Governor,,LBT,Keen Umbehr,6
-Geary,Lyon  Twp,Governor,,LBT,Keen Umbehr,3
-Geary,Milford  City,Governor,,LBT,Keen Umbehr,5
-Geary,Milford  Twp,Governor,,LBT,Keen Umbehr,17
-Geary,Ft.  Riley  B,Governor,,LBT,Keen Umbehr,2
-Geary,Ft.  Riley  A,Governor,,LBT,Keen Umbehr,1
-Geary,Smoky Hill Twp Pct 2,Governor,,LBT,Keen Umbehr,0
-Geary,Smoky Hill Twp Pct 3,Governor,,LBT,Keen Umbehr,3
-Geary,Smoky Hill Twp Pct 4,Governor,,LBT,Keen Umbehr,6
-Geary,Smoky Hill Twp Pct 5,Governor,,LBT,Keen Umbehr,3
-Geary,Smoky Hill Twp Pct 6,Governor,,LBT,Keen Umbehr,2
-Geary,Wingfield Twp,Governor,,LBT,Keen Umbehr,2
-Geary,W1P1,Governor,,R,Sam Brownback,49
-Geary,W1P2,Governor,,R,Sam Brownback,55
-Geary,W1P3,Governor,,R,Sam Brownback,115
-Geary,W1P4,Governor,,R,Sam Brownback,171
-Geary,W1P5,Governor,,R,Sam Brownback,99
-Geary,W1P6,Governor,,R,Sam Brownback,128
-Geary,W1P7,Governor,,R,Sam Brownback,161
-Geary,W2P1,Governor,,R,Sam Brownback,31
-Geary,W2P2,Governor,,R,Sam Brownback,73
-Geary,W2P3,Governor,,R,Sam Brownback,21
-Geary,W2P4,Governor,,R,Sam Brownback,20
-Geary,W2P5,Governor,,R,Sam Brownback,98
-Geary,W2P6,Governor,,R,Sam Brownback,57
-Geary,W2P7,Governor,,R,Sam Brownback,73
-Geary,W2P8,Governor,,R,Sam Brownback,19
-Geary,W3P1,Governor,,R,Sam Brownback,38
-Geary,W3P2,Governor,,R,Sam Brownback,107
-Geary,W3P3,Governor,,R,Sam Brownback,36
-Geary,W3P4,Governor,,R,Sam Brownback,20
-Geary,W4P1,Governor,,R,Sam Brownback,33
-Geary,W4P2,Governor,,R,Sam Brownback,21
-Geary,W4P3,Governor,,R,Sam Brownback,56
-Geary,W4P4,Governor,,R,Sam Brownback,91
-Geary,Blakely  Twp,Governor,,R,Sam Brownback,32
-Geary,Grandview  Plaza  Pct,Governor,,R,Sam Brownback,102
-Geary,Jefferson  Precinct,Governor,,R,Sam Brownback,92
-Geary,Jackson  Twp,Governor,,R,Sam Brownback,27
-Geary,Liberty  Twp,Governor,,R,Sam Brownback,42
-Geary,Lyon  Twp,Governor,,R,Sam Brownback,98
-Geary,Milford  City,Governor,,R,Sam Brownback,71
-Geary,Milford  Twp,Governor,,R,Sam Brownback,271
-Geary,Ft.  Riley  B,Governor,,R,Sam Brownback,25
-Geary,Ft.  Riley  A,Governor,,R,Sam Brownback,5
-Geary,Smoky Hill Twp Pct 2,Governor,,R,Sam Brownback,3
-Geary,Smoky Hill Twp Pct 3,Governor,,R,Sam Brownback,38
-Geary,Smoky Hill Twp Pct 4,Governor,,R,Sam Brownback,34
-Geary,Smoky Hill Twp Pct 5,Governor,,R,Sam Brownback,113
-Geary,Smoky Hill Twp Pct 6,Governor,,R,Sam Brownback,13
-Geary,Wingfield Twp,Governor,,R,Sam Brownback,36
-Geary,W1P1,Secretary of State,,R,Kris Kobach,59
-Geary,W1P2,Secretary of State,,R,Kris Kobach,76
-Geary,W1P3,Secretary of State,,R,Kris Kobach,139
-Geary,W1P4,Secretary of State,,R,Kris Kobach,219
-Geary,W1P5,Secretary of State,,R,Kris Kobach,120
-Geary,W1P6,Secretary of State,,R,Kris Kobach,152
-Geary,W1P7,Secretary of State,,R,Kris Kobach,184
-Geary,W2P1,Secretary of State,,R,Kris Kobach,30
-Geary,W2P2,Secretary of State,,R,Kris Kobach,105
-Geary,W2P3,Secretary of State,,R,Kris Kobach,26
-Geary,W2P4,Secretary of State,,R,Kris Kobach,24
-Geary,W2P5,Secretary of State,,R,Kris Kobach,121
-Geary,W2P6,Secretary of State,,R,Kris Kobach,69
-Geary,W2P7,Secretary of State,,R,Kris Kobach,84
-Geary,W2P8,Secretary of State,,R,Kris Kobach,25
-Geary,W3P1,Secretary of State,,R,Kris Kobach,44
-Geary,W3P2,Secretary of State,,R,Kris Kobach,122
-Geary,W3P3,Secretary of State,,R,Kris Kobach,46
-Geary,W3P4,Secretary of State,,R,Kris Kobach,22
-Geary,W4P1,Secretary of State,,R,Kris Kobach,37
-Geary,W4P2,Secretary of State,,R,Kris Kobach,27
-Geary,W4P3,Secretary of State,,R,Kris Kobach,62
-Geary,W4P4,Secretary of State,,R,Kris Kobach,107
-Geary,Blakely  Twp,Secretary of State,,R,Kris Kobach,38
-Geary,Grandview  Plaza  Pct,Secretary of State,,R,Kris Kobach,123
-Geary,Jefferson  Precinct,Secretary of State,,R,Kris Kobach,117
-Geary,Jackson  Twp,Secretary of State,,R,Kris Kobach,29
-Geary,Liberty  Twp,Secretary of State,,R,Kris Kobach,58
-Geary,Lyon  Twp,Secretary of State,,R,Kris Kobach,108
-Geary,Milford  City,Secretary of State,,R,Kris Kobach,80
-Geary,Milford  Twp,Secretary of State,,R,Kris Kobach,318
-Geary,Ft.  Riley  B,Secretary of State,,R,Kris Kobach,28
-Geary,Ft.  Riley  A,Secretary of State,,R,Kris Kobach,6
-Geary,Smoky Hill Twp Pct 2,Secretary of State,,R,Kris Kobach,3
-Geary,Smoky Hill Twp Pct 3,Secretary of State,,R,Kris Kobach,41
-Geary,Smoky Hill Twp Pct 4,Secretary of State,,R,Kris Kobach,52
-Geary,Smoky Hill Twp Pct 5,Secretary of State,,R,Kris Kobach,115
-Geary,Smoky Hill Twp Pct 6,Secretary of State,,R,Kris Kobach,17
-Geary,Wingfield Twp,Secretary of State,,R,Kris Kobach,37
-Geary,W1P1,Secretary of State,,D,Jean Schodorf,62
-Geary,W1P2,Secretary of State,,D,Jean Schodorf,45
-Geary,W1P3,Secretary of State,,D,Jean Schodorf,65
-Geary,W1P4,Secretary of State,,D,Jean Schodorf,150
-Geary,W1P5,Secretary of State,,D,Jean Schodorf,93
-Geary,W1P6,Secretary of State,,D,Jean Schodorf,113
-Geary,W1P7,Secretary of State,,D,Jean Schodorf,144
-Geary,W2P1,Secretary of State,,D,Jean Schodorf,31
-Geary,W2P2,Secretary of State,,D,Jean Schodorf,79
-Geary,W2P3,Secretary of State,,D,Jean Schodorf,12
-Geary,W2P4,Secretary of State,,D,Jean Schodorf,9
-Geary,W2P5,Secretary of State,,D,Jean Schodorf,77
-Geary,W2P6,Secretary of State,,D,Jean Schodorf,53
-Geary,W2P7,Secretary of State,,D,Jean Schodorf,46
-Geary,W2P8,Secretary of State,,D,Jean Schodorf,11
-Geary,W3P1,Secretary of State,,D,Jean Schodorf,37
-Geary,W3P2,Secretary of State,,D,Jean Schodorf,95
-Geary,W3P3,Secretary of State,,D,Jean Schodorf,27
-Geary,W3P4,Secretary of State,,D,Jean Schodorf,12
-Geary,W4P1,Secretary of State,,D,Jean Schodorf,39
-Geary,W4P2,Secretary of State,,D,Jean Schodorf,28
-Geary,W4P3,Secretary of State,,D,Jean Schodorf,86
-Geary,W4P4,Secretary of State,,D,Jean Schodorf,148
-Geary,Blakely  Twp,Secretary of State,,D,Jean Schodorf,13
-Geary,Grandview  Plaza  Pct,Secretary of State,,D,Jean Schodorf,49
-Geary,Jefferson  Precinct,Secretary of State,,D,Jean Schodorf,33
-Geary,Jackson  Twp,Secretary of State,,D,Jean Schodorf,9
-Geary,Liberty  Twp,Secretary of State,,D,Jean Schodorf,21
-Geary,Lyon  Twp,Secretary of State,,D,Jean Schodorf,21
-Geary,Milford  City,Secretary of State,,D,Jean Schodorf,21
-Geary,Milford  Twp,Secretary of State,,D,Jean Schodorf,133
-Geary,Ft.  Riley  B,Secretary of State,,D,Jean Schodorf,13
-Geary,Ft.  Riley  A,Secretary of State,,D,Jean Schodorf,2
-Geary,Smoky Hill Twp Pct 2,Secretary of State,,D,Jean Schodorf,1
-Geary,Smoky Hill Twp Pct 3,Secretary of State,,D,Jean Schodorf,22
-Geary,Smoky Hill Twp Pct 4,Secretary of State,,D,Jean Schodorf,24
-Geary,Smoky Hill Twp Pct 5,Secretary of State,,D,Jean Schodorf,37
-Geary,Smoky Hill Twp Pct 6,Secretary of State,,D,Jean Schodorf,6
-Geary,Wingfield Twp,Secretary of State,,D,Jean Schodorf,25
-Geary,W1P1,Attorney General,,D,A.J. Kotich,60
-Geary,W1P2,Attorney General,,D,A.J. Kotich,46
-Geary,W1P3,Attorney General,,D,A.J. Kotich,49
-Geary,W1P4,Attorney General,,D,A.J. Kotich,129
-Geary,W1P5,Attorney General,,D,A.J. Kotich,82
-Geary,W1P6,Attorney General,,D,A.J. Kotich,102
-Geary,W1P7,Attorney General,,D,A.J. Kotich,132
-Geary,W2P1,Attorney General,,D,A.J. Kotich,26
-Geary,W2P2,Attorney General,,D,A.J. Kotich,65
-Geary,W2P3,Attorney General,,D,A.J. Kotich,8
-Geary,W2P4,Attorney General,,D,A.J. Kotich,9
-Geary,W2P5,Attorney General,,D,A.J. Kotich,70
-Geary,W2P6,Attorney General,,D,A.J. Kotich,47
-Geary,W2P7,Attorney General,,D,A.J. Kotich,46
-Geary,W2P8,Attorney General,,D,A.J. Kotich,10
-Geary,W3P1,Attorney General,,D,A.J. Kotich,32
-Geary,W3P2,Attorney General,,D,A.J. Kotich,85
-Geary,W3P3,Attorney General,,D,A.J. Kotich,28
-Geary,W3P4,Attorney General,,D,A.J. Kotich,11
-Geary,W4P1,Attorney General,,D,A.J. Kotich,34
-Geary,W4P2,Attorney General,,D,A.J. Kotich,30
-Geary,W4P3,Attorney General,,D,A.J. Kotich,79
-Geary,W4P4,Attorney General,,D,A.J. Kotich,136
-Geary,Blakely  Twp,Attorney General,,D,A.J. Kotich,7
-Geary,Grandview  Plaza  Pct,Attorney General,,D,A.J. Kotich,47
-Geary,Jefferson  Precinct,Attorney General,,D,A.J. Kotich,25
-Geary,Jackson  Twp,Attorney General,,D,A.J. Kotich,8
-Geary,Liberty  Twp,Attorney General,,D,A.J. Kotich,22
-Geary,Lyon  Twp,Attorney General,,D,A.J. Kotich,15
-Geary,Milford  City,Attorney General,,D,A.J. Kotich,21
-Geary,Milford  Twp,Attorney General,,D,A.J. Kotich,119
-Geary,Ft.  Riley  B,Attorney General,,D,A.J. Kotich,12
-Geary,Ft.  Riley  A,Attorney General,,D,A.J. Kotich,2
-Geary,Smoky Hill Twp Pct 2,Attorney General,,D,A.J. Kotich,1
-Geary,Smoky Hill Twp Pct 3,Attorney General,,D,A.J. Kotich,17
-Geary,Smoky Hill Twp Pct 4,Attorney General,,D,A.J. Kotich,21
-Geary,Smoky Hill Twp Pct 5,Attorney General,,D,A.J. Kotich,31
-Geary,Smoky Hill Twp Pct 6,Attorney General,,D,A.J. Kotich,4
-Geary,Wingfield Twp,Attorney General,,D,A.J. Kotich,21
-Geary,W1P1,Attorney General,,R,Derek Schmidt,61
-Geary,W1P2,Attorney General,,R,Derek Schmidt,76
-Geary,W1P3,Attorney General,,R,Derek Schmidt,151
-Geary,W1P4,Attorney General,,R,Derek Schmidt,240
-Geary,W1P5,Attorney General,,R,Derek Schmidt,131
-Geary,W1P6,Attorney General,,R,Derek Schmidt,159
-Geary,W1P7,Attorney General,,R,Derek Schmidt,192
-Geary,W2P1,Attorney General,,R,Derek Schmidt,35
-Geary,W2P2,Attorney General,,R,Derek Schmidt,120
-Geary,W2P3,Attorney General,,R,Derek Schmidt,29
-Geary,W2P4,Attorney General,,R,Derek Schmidt,24
-Geary,W2P5,Attorney General,,R,Derek Schmidt,125
-Geary,W2P6,Attorney General,,R,Derek Schmidt,74
-Geary,W2P7,Attorney General,,R,Derek Schmidt,82
-Geary,W2P8,Attorney General,,R,Derek Schmidt,26
-Geary,W3P1,Attorney General,,R,Derek Schmidt,48
-Geary,W3P2,Attorney General,,R,Derek Schmidt,127
-Geary,W3P3,Attorney General,,R,Derek Schmidt,46
-Geary,W3P4,Attorney General,,R,Derek Schmidt,23
-Geary,W4P1,Attorney General,,R,Derek Schmidt,39
-Geary,W4P2,Attorney General,,R,Derek Schmidt,22
-Geary,W4P3,Attorney General,,R,Derek Schmidt,68
-Geary,W4P4,Attorney General,,R,Derek Schmidt,118
-Geary,Blakely  Twp,Attorney General,,R,Derek Schmidt,44
-Geary,Grandview  Plaza  Pct,Attorney General,,R,Derek Schmidt,125
-Geary,Jefferson  Precinct,Attorney General,,R,Derek Schmidt,120
-Geary,Jackson  Twp,Attorney General,,R,Derek Schmidt,30
-Geary,Liberty  Twp,Attorney General,,R,Derek Schmidt,57
-Geary,Lyon  Twp,Attorney General,,R,Derek Schmidt,114
-Geary,Milford  City,Attorney General,,R,Derek Schmidt,78
-Geary,Milford  Twp,Attorney General,,R,Derek Schmidt,327
-Geary,Ft.  Riley  B,Attorney General,,R,Derek Schmidt,29
-Geary,Ft.  Riley  A,Attorney General,,R,Derek Schmidt,6
-Geary,Smoky Hill Twp Pct 2,Attorney General,,R,Derek Schmidt,3
-Geary,Smoky Hill Twp Pct 3,Attorney General,,R,Derek Schmidt,47
-Geary,Smoky Hill Twp Pct 4,Attorney General,,R,Derek Schmidt,53
-Geary,Smoky Hill Twp Pct 5,Attorney General,,R,Derek Schmidt,121
-Geary,Smoky Hill Twp Pct 6,Attorney General,,R,Derek Schmidt,18
-Geary,Wingfield Twp,Attorney General,,R,Derek Schmidt,40
-Geary,W1P1,State Treasurer,,D,Carmen Alldritt,52
-Geary,W1P2,State Treasurer,,D,Carmen Alldritt,43
-Geary,W1P3,State Treasurer,,D,Carmen Alldritt,59
-Geary,W1P4,State Treasurer,,D,Carmen Alldritt,132
-Geary,W1P5,State Treasurer,,D,Carmen Alldritt,89
-Geary,W1P6,State Treasurer,,D,Carmen Alldritt,99
-Geary,W1P7,State Treasurer,,D,Carmen Alldritt,132
-Geary,W2P1,State Treasurer,,D,Carmen Alldritt,28
-Geary,W2P2,State Treasurer,,D,Carmen Alldritt,72
-Geary,W2P3,State Treasurer,,D,Carmen Alldritt,7
-Geary,W2P4,State Treasurer,,D,Carmen Alldritt,10
-Geary,W2P5,State Treasurer,,D,Carmen Alldritt,69
-Geary,W2P6,State Treasurer,,D,Carmen Alldritt,56
-Geary,W2P7,State Treasurer,,D,Carmen Alldritt,44
-Geary,W2P8,State Treasurer,,D,Carmen Alldritt,9
-Geary,W3P1,State Treasurer,,D,Carmen Alldritt,31
-Geary,W3P2,State Treasurer,,D,Carmen Alldritt,82
-Geary,W3P3,State Treasurer,,D,Carmen Alldritt,27
-Geary,W3P4,State Treasurer,,D,Carmen Alldritt,11
-Geary,W4P1,State Treasurer,,D,Carmen Alldritt,37
-Geary,W4P2,State Treasurer,,D,Carmen Alldritt,30
-Geary,W4P3,State Treasurer,,D,Carmen Alldritt,88
-Geary,W4P4,State Treasurer,,D,Carmen Alldritt,142
-Geary,Blakely  Twp,State Treasurer,,D,Carmen Alldritt,13
-Geary,Grandview  Plaza  Pct,State Treasurer,,D,Carmen Alldritt,49
-Geary,Jefferson  Precinct,State Treasurer,,D,Carmen Alldritt,31
-Geary,Jackson  Twp,State Treasurer,,D,Carmen Alldritt,7
-Geary,Liberty  Twp,State Treasurer,,D,Carmen Alldritt,17
-Geary,Lyon  Twp,State Treasurer,,D,Carmen Alldritt,20
-Geary,Milford  City,State Treasurer,,D,Carmen Alldritt,23
-Geary,Milford  Twp,State Treasurer,,D,Carmen Alldritt,112
-Geary,Ft.  Riley  B,State Treasurer,,D,Carmen Alldritt,12
-Geary,Ft.  Riley  A,State Treasurer,,D,Carmen Alldritt,2
-Geary,Smoky Hill Twp Pct 2,State Treasurer,,D,Carmen Alldritt,1
-Geary,Smoky Hill Twp Pct 3,State Treasurer,,D,Carmen Alldritt,19
-Geary,Smoky Hill Twp Pct 4,State Treasurer,,D,Carmen Alldritt,23
-Geary,Smoky Hill Twp Pct 5,State Treasurer,,D,Carmen Alldritt,22
-Geary,Smoky Hill Twp Pct 6,State Treasurer,,D,Carmen Alldritt,5
-Geary,Wingfield Twp,State Treasurer,,D,Carmen Alldritt,25
-Geary,W1P1,State Treasurer,,R,Ron Estes,68
-Geary,W1P2,State Treasurer,,R,Ron Estes,78
-Geary,W1P3,State Treasurer,,R,Ron Estes,142
-Geary,W1P4,State Treasurer,,R,Ron Estes,229
-Geary,W1P5,State Treasurer,,R,Ron Estes,124
-Geary,W1P6,State Treasurer,,R,Ron Estes,164
-Geary,W1P7,State Treasurer,,R,Ron Estes,192
-Geary,W2P1,State Treasurer,,R,Ron Estes,32
-Geary,W2P2,State Treasurer,,R,Ron Estes,112
-Geary,W2P3,State Treasurer,,R,Ron Estes,31
-Geary,W2P4,State Treasurer,,R,Ron Estes,23
-Geary,W2P5,State Treasurer,,R,Ron Estes,126
-Geary,W2P6,State Treasurer,,R,Ron Estes,64
-Geary,W2P7,State Treasurer,,R,Ron Estes,84
-Geary,W2P8,State Treasurer,,R,Ron Estes,27
-Geary,W3P1,State Treasurer,,R,Ron Estes,50
-Geary,W3P2,State Treasurer,,R,Ron Estes,128
-Geary,W3P3,State Treasurer,,R,Ron Estes,46
-Geary,W3P4,State Treasurer,,R,Ron Estes,23
-Geary,W4P1,State Treasurer,,R,Ron Estes,37
-Geary,W4P2,State Treasurer,,R,Ron Estes,22
-Geary,W4P3,State Treasurer,,R,Ron Estes,60
-Geary,W4P4,State Treasurer,,R,Ron Estes,114
-Geary,Blakely  Twp,State Treasurer,,R,Ron Estes,38
-Geary,Grandview  Plaza  Pct,State Treasurer,,R,Ron Estes,123
-Geary,Jefferson  Precinct,State Treasurer,,R,Ron Estes,112
-Geary,Jackson  Twp,State Treasurer,,R,Ron Estes,31
-Geary,Liberty  Twp,State Treasurer,,R,Ron Estes,60
-Geary,Lyon  Twp,State Treasurer,,R,Ron Estes,107
-Geary,Milford  City,State Treasurer,,R,Ron Estes,78
-Geary,Milford  Twp,State Treasurer,,R,Ron Estes,330
-Geary,Ft.  Riley  B,State Treasurer,,R,Ron Estes,28
-Geary,Ft.  Riley  A,State Treasurer,,R,Ron Estes,6
-Geary,Smoky Hill Twp Pct 2,State Treasurer,,R,Ron Estes,3
-Geary,Smoky Hill Twp Pct 3,State Treasurer,,R,Ron Estes,44
-Geary,Smoky Hill Twp Pct 4,State Treasurer,,R,Ron Estes,54
-Geary,Smoky Hill Twp Pct 5,State Treasurer,,R,Ron Estes,126
-Geary,Smoky Hill Twp Pct 6,State Treasurer,,R,Ron Estes,17
-Geary,Wingfield Twp,State Treasurer,,R,Ron Estes,37
-Geary,W1P1,Insurance Commissioner,,D,Dennis Anderson,56
-Geary,W1P2,Insurance Commissioner,,D,Dennis Anderson,47
-Geary,W1P3,Insurance Commissioner,,D,Dennis Anderson,66
-Geary,W1P4,Insurance Commissioner,,D,Dennis Anderson,141
-Geary,W1P5,Insurance Commissioner,,D,Dennis Anderson,95
-Geary,W1P6,Insurance Commissioner,,D,Dennis Anderson,112
-Geary,W1P7,Insurance Commissioner,,D,Dennis Anderson,138
-Geary,W2P1,Insurance Commissioner,,D,Dennis Anderson,29
-Geary,W2P2,Insurance Commissioner,,D,Dennis Anderson,76
-Geary,W2P3,Insurance Commissioner,,D,Dennis Anderson,9
-Geary,W2P4,Insurance Commissioner,,D,Dennis Anderson,10
-Geary,W2P5,Insurance Commissioner,,D,Dennis Anderson,77
-Geary,W2P6,Insurance Commissioner,,D,Dennis Anderson,55
-Geary,W2P7,Insurance Commissioner,,D,Dennis Anderson,42
-Geary,W2P8,Insurance Commissioner,,D,Dennis Anderson,11
-Geary,W3P1,Insurance Commissioner,,D,Dennis Anderson,34
-Geary,W3P2,Insurance Commissioner,,D,Dennis Anderson,87
-Geary,W3P3,Insurance Commissioner,,D,Dennis Anderson,31
-Geary,W3P4,Insurance Commissioner,,D,Dennis Anderson,15
-Geary,W4P1,Insurance Commissioner,,D,Dennis Anderson,34
-Geary,W4P2,Insurance Commissioner,,D,Dennis Anderson,29
-Geary,W4P3,Insurance Commissioner,,D,Dennis Anderson,82
-Geary,W4P4,Insurance Commissioner,,D,Dennis Anderson,152
-Geary,Blakely  Twp,Insurance Commissioner,,D,Dennis Anderson,9
-Geary,Grandview  Plaza  Pct,Insurance Commissioner,,D,Dennis Anderson,51
-Geary,Jefferson  Precinct,Insurance Commissioner,,D,Dennis Anderson,31
-Geary,Jackson  Twp,Insurance Commissioner,,D,Dennis Anderson,12
-Geary,Liberty  Twp,Insurance Commissioner,,D,Dennis Anderson,21
-Geary,Lyon  Twp,Insurance Commissioner,,D,Dennis Anderson,17
-Geary,Milford  City,Insurance Commissioner,,D,Dennis Anderson,27
-Geary,Milford  Twp,Insurance Commissioner,,D,Dennis Anderson,122
-Geary,Ft.  Riley  B,Insurance Commissioner,,D,Dennis Anderson,14
-Geary,Ft.  Riley  A,Insurance Commissioner,,D,Dennis Anderson,2
-Geary,Smoky Hill Twp Pct 2,Insurance Commissioner,,D,Dennis Anderson,1
-Geary,Smoky Hill Twp Pct 3,Insurance Commissioner,,D,Dennis Anderson,19
-Geary,Smoky Hill Twp Pct 4,Insurance Commissioner,,D,Dennis Anderson,28
-Geary,Smoky Hill Twp Pct 5,Insurance Commissioner,,D,Dennis Anderson,28
-Geary,Smoky Hill Twp Pct 6,Insurance Commissioner,,D,Dennis Anderson,4
-Geary,Wingfield Twp,Insurance Commissioner,,D,Dennis Anderson,26
-Geary,W1P1,Insurance Commissioner,,R,Ken Selzer,61
-Geary,W1P2,Insurance Commissioner,,R,Ken Selzer,71
-Geary,W1P3,Insurance Commissioner,,R,Ken Selzer,134
-Geary,W1P4,Insurance Commissioner,,R,Ken Selzer,222
-Geary,W1P5,Insurance Commissioner,,R,Ken Selzer,115
-Geary,W1P6,Insurance Commissioner,,R,Ken Selzer,150
-Geary,W1P7,Insurance Commissioner,,R,Ken Selzer,179
-Geary,W2P1,Insurance Commissioner,,R,Ken Selzer,29
-Geary,W2P2,Insurance Commissioner,,R,Ken Selzer,104
-Geary,W2P3,Insurance Commissioner,,R,Ken Selzer,28
-Geary,W2P4,Insurance Commissioner,,R,Ken Selzer,23
-Geary,W2P5,Insurance Commissioner,,R,Ken Selzer,117
-Geary,W2P6,Insurance Commissioner,,R,Ken Selzer,65
-Geary,W2P7,Insurance Commissioner,,R,Ken Selzer,86
-Geary,W2P8,Insurance Commissioner,,R,Ken Selzer,25
-Geary,W3P1,Insurance Commissioner,,R,Ken Selzer,46
-Geary,W3P2,Insurance Commissioner,,R,Ken Selzer,121
-Geary,W3P3,Insurance Commissioner,,R,Ken Selzer,41
-Geary,W3P4,Insurance Commissioner,,R,Ken Selzer,19
-Geary,W4P1,Insurance Commissioner,,R,Ken Selzer,40
-Geary,W4P2,Insurance Commissioner,,R,Ken Selzer,22
-Geary,W4P3,Insurance Commissioner,,R,Ken Selzer,64
-Geary,W4P4,Insurance Commissioner,,R,Ken Selzer,100
-Geary,Blakely  Twp,Insurance Commissioner,,R,Ken Selzer,41
-Geary,Grandview  Plaza  Pct,Insurance Commissioner,,R,Ken Selzer,119
-Geary,Jefferson  Precinct,Insurance Commissioner,,R,Ken Selzer,111
-Geary,Jackson  Twp,Insurance Commissioner,,R,Ken Selzer,25
-Geary,Liberty  Twp,Insurance Commissioner,,R,Ken Selzer,56
-Geary,Lyon  Twp,Insurance Commissioner,,R,Ken Selzer,110
-Geary,Milford  City,Insurance Commissioner,,R,Ken Selzer,72
-Geary,Milford  Twp,Insurance Commissioner,,R,Ken Selzer,317
-Geary,Ft.  Riley  B,Insurance Commissioner,,R,Ken Selzer,25
-Geary,Ft.  Riley  A,Insurance Commissioner,,R,Ken Selzer,6
-Geary,Smoky Hill Twp Pct 2,Insurance Commissioner,,R,Ken Selzer,3
-Geary,Smoky Hill Twp Pct 3,Insurance Commissioner,,R,Ken Selzer,43
-Geary,Smoky Hill Twp Pct 4,Insurance Commissioner,,R,Ken Selzer,48
-Geary,Smoky Hill Twp Pct 5,Insurance Commissioner,,R,Ken Selzer,120
-Geary,Smoky Hill Twp Pct 6,Insurance Commissioner,,R,Ken Selzer,18
-Geary,Wingfield Twp,Insurance Commissioner,,R,Ken Selzer,36
-Geary,W1P1,State House,65,D,Tom Brungardt,50
-Geary,W1P2,State House,65,D,Tom Brungardt,56
-Geary,W1P3,State House,65,D,Tom Brungardt,65
-Geary,W1P4,State House,68,R,Tom Moxley,302
-Geary,W1P5,State House,68,R,Tom Moxley,153
-Geary,W1P6,State House,68,R,Tom Moxley,220
-Geary,W1P7,State House,68,R,Tom Moxley,262
-Geary,W2P1,State House,65,D,Tom Brungardt,33
-Geary,W2P2,State House,65,D,Tom Brungardt,81
-Geary,W2P3,State House,68,R,Tom Moxley,33
-Geary,W2P4,State House,68,R,Tom Moxley,29
-Geary,W2P5,State House,68,R,Tom Moxley,153
-Geary,W2P6,State House,68,R,Tom Moxley,102
-Geary,W2P7,State House,68,R,Tom Moxley,106
-Geary,W2P8,State House,68,R,Tom Moxley,33
-Geary,W3P1,State House,65,D,Tom Brungardt,33
-Geary,W3P2,State House,65,D,Tom Brungardt,88
-Geary,W3P3,State House,68,R,Tom Moxley,57
-Geary,W3P4,State House,68,R,Tom Moxley,30
-Geary,W4P1,State House,65,D,Tom Brungardt,36
-Geary,W4P2,State House,65,D,Tom Brungardt,29
-Geary,W4P3,State House,65,D,Tom Brungardt,88
-Geary,W4P4,State House,65,D,Tom Brungardt,154
-Geary,Blakely  Twp,State House,65,D,Tom Brungardt,13
-Geary,Grandview  Plaza  Pct,State House,65,D,Tom Brungardt,53
-Geary,Jefferson  Precinct,State House,65,D,Tom Brungardt,36
-Geary,Jackson  Twp,State House,65,D,Tom Brungardt,9
-Geary,Liberty  Twp,State House,65,D,Tom Brungardt,22
-Geary,Lyon  Twp,State House,68,R,Tom Moxley,119
-Geary,Milford  City,State House,65,D,Tom Brungardt,32
-Geary,Milford  Twp,State House,65,D,Tom Brungardt,146
-Geary,Ft.  Riley  B,State House,65,D,Tom Brungardt,11
-Geary,Ft.  Riley  A,State House,65,D,Tom Brungardt,2,,,_,
-Geary,Smoky Hill Twp Pct 2,State House,68,R,Tom Moxley,4
-Geary,Smoky Hill Twp Pct 3,State House,65,D,Tom Brungardt,23
-Geary,Smoky Hill Twp Pct 4,State House,68,R,Tom Moxley,69
-Geary,Smoky Hill Twp Pct 5,State House,68,R,Tom Moxley,139
-Geary,Smoky Hill Twp Pct 6,State House,68,R,Tom Moxley,20
-Geary,Wingfield Twp,State House,65,D,Tom Brungardt,25
-Geary,W1P1,State House,65,R,Lonnie Clark,73
-Geary,W1P2,State House,65,R,Lonnie Clark,64
-Geary,W1P3,State House,65,R,Lonnie Clark,145
-Geary,W2P1,State House,65,R,Lonnie Clark,29
-Geary,W2P2,State House,65,R,Lonnie Clark,109
-Geary,W3P1,State House,65,R,Lonnie Clark,48
-Geary,W3P2,State House,65,R,Lonnie Clark,130
-Geary,W4P1,State House,65,R,Lonnie Clark,39
-Geary,W4P2,State House,65,R,Lonnie Clark,26
-Geary,W4P3,State House,65,R,Lonnie Clark,61
-Geary,W4P4,State House,65,R,Lonnie Clark,105
-Geary,Blakely  Twp,State House,65,R,Lonnie Clark,37
-Geary,Grandview  Plaza  Pct,State House,65,R,Lonnie Clark,116
-Geary,Jefferson  Precinct,State House,65,R,Lonnie Clark,115
-Geary,Jackson  Twp,State House,65,R,Lonnie Clark,29
-Geary,Liberty  Twp,State House,65,R,Lonnie Clark,56
-Geary,Milford  City,State House,65,R,Lonnie Clark,72
-Geary,Milford  Twp,State House,65,R,Lonnie Clark,300
-Geary,Ft.  Riley  B,State House,65,R,Lonnie Clark,29
-Geary,Ft.  Riley  A,State House,65,R,Lonnie Clark,6
-Geary,Smoky Hill Twp Pct 3,State House,65,R,Lonnie Clark,41
-Geary,Wingfield Twp,State House,65,R,Lonnie Clark,37
+county,precinct,office,district,party,candidate,votes,vtd
+GEARY,Blakely Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000010
+GEARY,Blakely Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+GEARY,Blakely Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000010
+GEARY,Fort Riley Milford Township Block 401,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002O
+GEARY,Fort Riley Milford Township Block 401,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002P
+GEARY,Fort Riley Milford Township Block 501,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002R
+GEARY,Fort Riley Milford Township Block 701,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002R
+GEARY,Wingfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000040
+GEARY,Wingfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+GEARY,Wingfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000040
+GEARY,Jackson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000050
+GEARY,Jackson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000050
+GEARY,Jackson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000050
+GEARY,Jefferson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000060
+GEARY,Jefferson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000060
+GEARY,Jefferson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,000060
+GEARY,Junction City Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,00007A
+GEARY,Junction City Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,00007A
+GEARY,Junction City Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,00007A
+GEARY,Junction City Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",61,000080
+GEARY,Junction City Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000080
+GEARY,Junction City Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000080
+GEARY,Junction City Ward 1 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",82,000090
+GEARY,Junction City Ward 1 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000090
+GEARY,Junction City Ward 1 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000090
+GEARY,Junction City Ward 1 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",190,000100
+GEARY,Junction City Ward 1 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000100
+GEARY,Junction City Ward 1 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",171,000100
+GEARY,Junction City Ward 1 Precinct 7,Governor / Lt. Governor,,Democratic,"Davis, Paul",157,00013A
+GEARY,Junction City Ward 1 Precinct 7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00013A
+GEARY,Junction City Ward 1 Precinct 7,Governor / Lt. Governor,,Republican,"Brownback, Sam",161,00013A
+GEARY,Junction City Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000140
+GEARY,Junction City Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000140
+GEARY,Junction City Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000140
+GEARY,Junction City Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,000150
+GEARY,Junction City Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000150
+GEARY,Junction City Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000150
+GEARY,Junction City Ward 2 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,00016A
+GEARY,Junction City Ward 2 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,00016A
+GEARY,Junction City Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000180
+GEARY,Junction City Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000180
+GEARY,Junction City Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000180
+GEARY,Junction City Ward 3 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",96,000190
+GEARY,Junction City Ward 3 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000190
+GEARY,Junction City Ward 3 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",159,000230
+GEARY,Junction City Ward 4 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000230
+GEARY,Junction City Ward 4 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000230
+GEARY,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000240
+GEARY,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000240
+GEARY,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000240
+GEARY,Lyon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000250
+GEARY,Lyon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000250
+GEARY,Lyon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",98,000250
+GEARY,Marshall Field,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000260
+GEARY,Marshall Field,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000260
+GEARY,Marshall Field,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000260
+GEARY,Milford Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",164,000270
+GEARY,Milford Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000270
+GEARY,Milford Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",271,000270
+GEARY,Fort Riley Precinct A,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,140010
+GEARY,Fort Riley Precinct A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,140010
+GEARY,Fort Riley Precinct A,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,140010
+GEARY,Fort Riley Precinct B,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,140020
+GEARY,Fort Riley Precinct B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,140020
+GEARY,Fort Riley Precinct B,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,140020
+GEARY,Grandview Plaza,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,140030
+GEARY,Grandview Plaza,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,140030
+GEARY,Grandview Plaza,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,140030
+GEARY,Junction City Ward 1 Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",104,140040
+GEARY,Junction City Ward 1 Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,140040
+GEARY,Junction City Ward 1 Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,140040
+GEARY,Junction City Ward 1 Precinct 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",137,140050
+GEARY,Junction City Ward 1 Precinct 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,140050
+GEARY,Junction City Ward 1 Precinct 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,140050
+GEARY,Junction City Ward 2 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,140060
+GEARY,Junction City Ward 2 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,140060
+GEARY,Junction City Ward 2 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,140060
+GEARY,Junction City Ward 2 Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,140070
+GEARY,Junction City Ward 2 Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,140070
+GEARY,Junction City Ward 2 Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",98,140070
+GEARY,Junction City Ward 2 Precinct 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",61,140080
+GEARY,Junction City Ward 2 Precinct 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,140080
+GEARY,Junction City Ward 2 Precinct 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,140080
+GEARY,Junction City Ward 2 Precinct 7,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,140090
+GEARY,Junction City Ward 2 Precinct 7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,140090
+GEARY,Junction City Ward 2 Precinct 7,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,140090
+GEARY,Junction City Ward 2 Precinct 8,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,140100
+GEARY,Junction City Ward 2 Precinct 8,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,140100
+GEARY,Junction City Ward 2 Precinct 8,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,140100
+GEARY,Junction City Ward 3 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,140110
+GEARY,Junction City Ward 3 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,140110
+GEARY,Junction City Ward 3 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,140110
+GEARY,Junction City Ward 3 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,140120
+GEARY,Junction City Ward 3 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,140120
+GEARY,Junction City Ward 3 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,140120
+GEARY,Milford City Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,140130
+GEARY,Milford City Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,140130
+GEARY,Milford City Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,140130
+GEARY,Smokey Hill Township Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,140140
+GEARY,Smokey Hill Township Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,140140
+GEARY,Smokey Hill Township Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,140140
+GEARY,Smokey Hill Township Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,140150
+GEARY,Smokey Hill Township Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,140150
+GEARY,Smokey Hill Township Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,140150
+GEARY,Smokey Hill Township Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,140160
+GEARY,Smokey Hill Township Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,140160
+GEARY,Smokey Hill Township Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,140160
+GEARY,Smokey Hill Township Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,140170
+GEARY,Smokey Hill Township Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,140170
+GEARY,Smokey Hill Township Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,140170
+GEARY,Smokey  Hill Township Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,140180
+GEARY,Smokey  Hill Township Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,140180
+GEARY,Smokey  Hill Township Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,140180
+GEARY,Smokey Hill Township Precinct 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,140190
+GEARY,Smokey Hill Township Precinct 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,140190
+GEARY,Smokey Hill Township Precinct 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,140190
+GEARY,Smokey Hill Township Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+GEARY,Smokey Hill Township Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+GEARY,Smokey Hill Township Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+GEARY,Smokey Hill Township Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+GEARY,Smokey Hill Township Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+GEARY,Smokey Hill Township Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+GEARY,Smokey Hill Township Enclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+GEARY,Smokey Hill Township Enclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+GEARY,Smokey Hill Township Enclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+GEARY,Grandview Township Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900100
+GEARY,Grandview Township Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900100
+GEARY,Grandview Township Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900100
+GEARY,Junction City Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,900190
+GEARY,Junction City Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,900190
+GEARY,Junction City Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900200
+GEARY,Junction City Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,900210
+GEARY,Junction City Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900210
+GEARY,Junction City Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900220
+GEARY,Fort Riley Precinct A S17 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002A
+GEARY,Fort Riley Precinct A S17 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002A
+GEARY,Fort Riley Precinct A S17 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002A
+GEARY,Fort Riley Precinct C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002C
+GEARY,Fort Riley Precinct C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002C
+GEARY,Fort Riley Precinct C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002C
+GEARY,Fort Riley Precinct D,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002D
+GEARY,Fort Riley Precinct D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002D
+GEARY,Fort Riley Precinct D,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002D
+GEARY,Fort Riley Precinct E,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002E
+GEARY,Fort Riley Precinct E,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002E
+GEARY,Fort Riley Precinct E,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002E
+GEARY,Fort Riley Precinct F,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002F
+GEARY,Fort Riley Precinct F,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002F
+GEARY,Fort Riley Precinct F,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002F
+GEARY,Fort Riley Precinct G,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002G
+GEARY,Fort Riley Precinct G,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002G
+GEARY,Fort Riley Precinct G,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002G
+GEARY,Fort Riley Precinct H,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002H
+GEARY,Fort Riley Precinct H,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002H
+GEARY,Fort Riley Precinct H,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002H
+GEARY,Fort Riley Precinct I,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002I
+GEARY,Fort Riley Precinct I,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002I
+GEARY,Fort Riley Precinct I,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002I
+GEARY,Fort Riley Precinct J,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002J
+GEARY,Fort Riley Precinct J,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002J
+GEARY,Fort Riley Precinct J,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002J
+GEARY,Fort Riley Precinct K,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002K
+GEARY,Fort Riley Precinct K,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002K
+GEARY,Fort Riley Precinct K,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002K
+GEARY,Fort Riley Precinct M,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002M
+GEARY,Fort Riley Precinct M,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002M
+GEARY,Fort Riley Precinct M,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002M
+GEARY,Fort Riley Precinct N,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,99002N
+GEARY,Fort Riley Precinct N,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,99002N
+GEARY,Fort Riley Precinct N,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,99002N
+GEARY,Fort Riley Precinct A S22,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,990030
+GEARY,Fort Riley Precinct A S22,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,990030
+GEARY,Fort Riley Precinct A S22,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,990030
+GEARY,Fort Riley Precinct L S17,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,990040
+GEARY,Fort Riley Precinct L S17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,990040
+GEARY,Fort Riley Precinct L S17,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,990040
+GEARY,Fort Riley Precinct L S22,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,990050
+GEARY,Fort Riley Precinct L S22,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,990050
+GEARY,Fort Riley Precinct L S22,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,990050
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,990110
+GEARY,Junction City Ward 4 Precinct 3 H65,Governor / Lt. Governor,,Democratic,"Davis, Paul",84,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,990120
+GEARY,Junction City Ward 4 Precinct 3 H68,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,990130
+GEARY,Smokey Hill Township S22 H68,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,990170
+GEARY,Smokey Hill Township S22 H68,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,990170
+GEARY,Smokey Hill Township S22 H68,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,990170
+GEARY,Smokey Hill Township Enclave D,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999050
+GEARY,Smokey Hill Township Enclave D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999050
+GEARY,Smokey Hill Township Enclave D,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999050
+GEARY,Smokey Hill Township Enclave E,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999060
+GEARY,Smokey Hill Township Enclave E,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999060
+GEARY,Smokey Hill Township Enclave E,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999060
+GEARY,Smokey Hill Township Enclave F,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999070
+GEARY,Smokey Hill Township Enclave F,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999070
+GEARY,Smokey Hill Township Enclave F,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999070
+GEARY,Smokey Hill Township Enclave G,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999080
+GEARY,Smokey Hill Township Enclave G,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999080
+GEARY,Smokey Hill Township Enclave G,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999080
+GEARY,Grandview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999090
+GEARY,Grandview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999090
+GEARY,Grandview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999090
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,999160
+GEARY,Blakely Township,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",13,000010
+GEARY,Blakely Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",37,000010
+GEARY,Fort Riley Milford Township Block 401,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,00002O
+GEARY,Fort Riley Milford Township Block 401,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,00002P
+GEARY,Fort Riley Milford Township Block 501,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,00002R
+GEARY,Fort Riley Milford Township Block 701,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00002R
+GEARY,Wingfield Township,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",25,000040
+GEARY,Wingfield Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",37,000040
+GEARY,Jackson Township,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",9,000050
+GEARY,Jackson Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",29,000050
+GEARY,Jefferson Township,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",36,000060
+GEARY,Jefferson Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",115,000060
+GEARY,Junction City Ward 1 Precinct 1,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",50,00007A
+GEARY,Junction City Ward 1 Precinct 1,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",73,00007A
+GEARY,Junction City Ward 1 Precinct 2,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",56,000080
+GEARY,Junction City Ward 1 Precinct 2,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",64,000080
+GEARY,Junction City Ward 1 Precinct 3,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",65,000090
+GEARY,Junction City Ward 1 Precinct 3,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",145,000090
+GEARY,Junction City Ward 1 Precinct 4,Kansas House of Representatives,68,Republican,"Moxley, Tom",302,000100
+GEARY,Junction City Ward 1 Precinct 7,Kansas House of Representatives,68,Republican,"Moxley, Tom",262,00013A
+GEARY,Junction City Ward 2 Precinct 1,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",33,000140
+GEARY,Junction City Ward 2 Precinct 1,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",29,000140
+GEARY,Junction City Ward 2 Precinct 2,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",81,000150
+GEARY,Junction City Ward 2 Precinct 2,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",109,000150
+GEARY,Junction City Ward 2 Precinct 3,Kansas House of Representatives,68,Republican,"Moxley, Tom",33,00016A
+GEARY,Junction City Ward 3 Precinct 1,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",33,000180
+GEARY,Junction City Ward 3 Precinct 1,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",48,000180
+GEARY,Junction City Ward 3 Precinct 2,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",88,000190
+GEARY,Junction City Ward 3 Precinct 2,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",130,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",154,000230
+GEARY,Junction City Ward 4 Precinct 4,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",105,000230
+GEARY,Liberty Township,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",22,000240
+GEARY,Liberty Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",56,000240
+GEARY,Lyon Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",119,000250
+GEARY,Marshall Field,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,000260
+GEARY,Marshall Field,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,000260
+GEARY,Milford Township,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",146,000270
+GEARY,Milford Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",300,000270
+GEARY,Fort Riley Precinct A,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",2,140010
+GEARY,Fort Riley Precinct A,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",6,140010
+GEARY,Fort Riley Precinct B,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",11,140020
+GEARY,Fort Riley Precinct B,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",29,140020
+GEARY,Junction City Ward 1 Precinct 5,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,140040
+GEARY,Junction City Ward 1 Precinct 5,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,140040
+GEARY,Junction City Ward 1 Precinct 6,Kansas House of Representatives,68,Republican,"Moxley, Tom",220,140050
+GEARY,Junction City Ward 2 Precinct 4,Kansas House of Representatives,68,Republican,"Moxley, Tom",29,140060
+GEARY,Junction City Ward 2 Precinct 5,Kansas House of Representatives,68,Republican,"Moxley, Tom",153,140070
+GEARY,Junction City Ward 2 Precinct 6,Kansas House of Representatives,68,Republican,"Moxley, Tom",102,140080
+GEARY,Junction City Ward 2 Precinct 7,Kansas House of Representatives,68,Republican,"Moxley, Tom",106,140090
+GEARY,Junction City Ward 2 Precinct 8,Kansas House of Representatives,68,Republican,"Moxley, Tom",33,140100
+GEARY,Smokey Hill Township Precinct 01,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",32,140140
+GEARY,Smokey Hill Township Precinct 01,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",72,140140
+GEARY,Smokey Hill Township Precinct 2,Kansas House of Representatives,68,Republican,"Moxley, Tom",4,140150
+GEARY,Smokey Hill Township Precinct 3,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,140160
+GEARY,Smokey Hill Township Precinct 4,Kansas House of Representatives,68,Republican,"Moxley, Tom",69,140170
+GEARY,Smokey  Hill Township Precinct 05,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,140180
+GEARY,Smokey  Hill Township Precinct 05,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,140180
+GEARY,Smokey Hill Township Precinct 6,Kansas House of Representatives,68,Republican,"Moxley, Tom",20,140190
+GEARY,Smokey Hill Township Enclave A,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",23,900020
+GEARY,Smokey Hill Township Enclave A,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",41,900020
+GEARY,Smokey Hill Township Enclave B,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,900030
+GEARY,Smokey Hill Township Enclave C,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,900040
+GEARY,Grandview Township Enclave A,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,900100
+GEARY,Grandview Township Enclave A,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,900100
+GEARY,Junction City Ward 4 Precinct 1,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",36,900190
+GEARY,Junction City Ward 4 Precinct 1,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",39,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,900200
+GEARY,Junction City Ward 4 Precinct 2,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",29,900210
+GEARY,Junction City Ward 4 Precinct 2,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",26,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,900220
+GEARY,Fort Riley Precinct A S17 A,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002A
+GEARY,Fort Riley Precinct A S17 A,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002A
+GEARY,Fort Riley Precinct C,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002C
+GEARY,Fort Riley Precinct C,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002C
+GEARY,Fort Riley Precinct D,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002D
+GEARY,Fort Riley Precinct D,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002D
+GEARY,Fort Riley Precinct E,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002E
+GEARY,Fort Riley Precinct E,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002E
+GEARY,Fort Riley Precinct F,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002F
+GEARY,Fort Riley Precinct F,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002F
+GEARY,Fort Riley Precinct G,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002G
+GEARY,Fort Riley Precinct G,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002G
+GEARY,Fort Riley Precinct H,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002H
+GEARY,Fort Riley Precinct H,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002H
+GEARY,Fort Riley Precinct I,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002I
+GEARY,Fort Riley Precinct I,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002I
+GEARY,Fort Riley Precinct J,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002J
+GEARY,Fort Riley Precinct J,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002J
+GEARY,Fort Riley Precinct K,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002K
+GEARY,Fort Riley Precinct K,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002K
+GEARY,Fort Riley Precinct M,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002M
+GEARY,Fort Riley Precinct M,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002M
+GEARY,Fort Riley Precinct N,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,99002N
+GEARY,Fort Riley Precinct N,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,99002N
+GEARY,Fort Riley Precinct A S22,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,990030
+GEARY,Fort Riley Precinct A S22,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,990030
+GEARY,Fort Riley Precinct L S17,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,990040
+GEARY,Fort Riley Precinct L S17,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,990040
+GEARY,Fort Riley Precinct L S22,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",0,990050
+GEARY,Fort Riley Precinct L S22,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,990050
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,990110
+GEARY,Junction City Ward 4 Precinct 3 H65,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",88,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",61,990120
+GEARY,Junction City Ward 4 Precinct 3 H68,Kansas House of Representatives,68,Republican,"Moxley, Tom",57,990130
+GEARY,Smokey Hill Township S22 H68,Kansas House of Representatives,68,Republican,"Moxley, Tom",139,990170
+GEARY,Smokey Hill Township Enclave D,Kansas House of Representatives,68,Republican,"Moxley, Tom",153,999050
+GEARY,Smokey Hill Township Enclave E,Kansas House of Representatives,68,Republican,"Moxley, Tom",30,999060
+GEARY,Smokey Hill Township Enclave F,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,999070
+GEARY,Smokey Hill Township Enclave G,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,999080
+GEARY,Grandview Township,Kansas House of Representatives,65,Democratic,"Brungardt, Tom",53,999090
+GEARY,Grandview Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",116,999090
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,999130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,999160
+GEARY,Blakely Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000010
+GEARY,Blakely Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000010
+GEARY,Fort Riley Milford Township Block 401,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002O
+GEARY,Fort Riley Milford Township Block 501,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002P
+GEARY,Fort Riley Milford Township Block 601,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002R
+GEARY,Wingfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000040
+GEARY,Wingfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000040
+GEARY,Jackson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000050
+GEARY,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000050
+GEARY,Jefferson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",37,000060
+GEARY,Jefferson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",108,000060
+GEARY,Junction City Ward 1 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",62,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",61,00007A
+GEARY,Junction City Ward 1 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",48,000080
+GEARY,Junction City Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000080
+GEARY,Junction City Ward 1 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",70,000090
+GEARY,Junction City Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,000090
+GEARY,Junction City Ward 1 Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",148,000100
+GEARY,Junction City Ward 1 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",217,000100
+GEARY,Junction City Ward 1 Precinct 7,United States House of Representatives,1,Democratic,"Sherow, James E.",149,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States House of Representatives,1,Republican,"Huelskamp, Tim",180,00013A
+GEARY,Junction City Ward 2 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",30,000140
+GEARY,Junction City Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000140
+GEARY,Junction City Ward 2 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",71,000150
+GEARY,Junction City Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",118,000150
+GEARY,Junction City Ward 2 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",8,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,00016A
+GEARY,Junction City Ward 3 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",31,000180
+GEARY,Junction City Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000180
+GEARY,Junction City Ward 3 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",85,000190
+GEARY,Junction City Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",132,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",151,000230
+GEARY,Junction City Ward 4 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,000230
+GEARY,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000240
+GEARY,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000240
+GEARY,Lyon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000250
+GEARY,Lyon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",108,000250
+GEARY,Marshall Field,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000260
+GEARY,Marshall Field,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000260
+GEARY,Milford Township,United States House of Representatives,1,Democratic,"Sherow, James E.",129,000270
+GEARY,Milford Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",322,000270
+GEARY,Fort Riley Precinct A,United States House of Representatives,1,Democratic,"Sherow, James E.",2,140010
+GEARY,Fort Riley Precinct A,United States House of Representatives,1,Republican,"Huelskamp, Tim",6,140010
+GEARY,Fort Riley Precinct B,United States House of Representatives,1,Democratic,"Sherow, James E.",13,140020
+GEARY,Fort Riley Precinct B,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,140020
+GEARY,Grandview Plaza,United States House of Representatives,1,Democratic,"Sherow, James E.",46,140030
+GEARY,Grandview Plaza,United States House of Representatives,1,Republican,"Huelskamp, Tim",126,140030
+GEARY,Junction City Ward 1 Precinct 5,United States House of Representatives,1,Democratic,"Sherow, James E.",97,140040
+GEARY,Junction City Ward 1 Precinct 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",116,140040
+GEARY,Junction City Ward 1 Precinct 6,United States House of Representatives,1,Democratic,"Sherow, James E.",115,140050
+GEARY,Junction City Ward 1 Precinct 6,United States House of Representatives,1,Republican,"Huelskamp, Tim",152,140050
+GEARY,Junction City Ward 2 Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",9,140060
+GEARY,Junction City Ward 2 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,140060
+GEARY,Junction City Ward 2 Precinct 5,United States House of Representatives,1,Democratic,"Sherow, James E.",83,140070
+GEARY,Junction City Ward 2 Precinct 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",112,140070
+GEARY,Junction City Ward 2 Precinct 6,United States House of Representatives,1,Democratic,"Sherow, James E.",55,140080
+GEARY,Junction City Ward 2 Precinct 6,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,140080
+GEARY,Junction City Ward 2 Precinct 7,United States House of Representatives,1,Democratic,"Sherow, James E.",45,140090
+GEARY,Junction City Ward 2 Precinct 7,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,140090
+GEARY,Junction City Ward 2 Precinct 8,United States House of Representatives,1,Democratic,"Sherow, James E.",13,140100
+GEARY,Junction City Ward 2 Precinct 8,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,140100
+GEARY,Junction City Ward 3 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",33,140110
+GEARY,Junction City Ward 3 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,140110
+GEARY,Junction City Ward 3 Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",12,140120
+GEARY,Junction City Ward 3 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,140120
+GEARY,Milford City Precinct,United States House of Representatives,1,Democratic,"Sherow, James E.",20,140130
+GEARY,Milford City Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",83,140130
+GEARY,Smokey Hill Township Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",0,140140
+GEARY,Smokey Hill Township Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,140140
+GEARY,Smokey Hill Township Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",1,140150
+GEARY,Smokey Hill Township Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,140150
+GEARY,Smokey Hill Township Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",18,140160
+GEARY,Smokey Hill Township Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,140160
+GEARY,Smokey Hill Township Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",25,140170
+GEARY,Smokey Hill Township Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,140170
+GEARY,Smokey  Hill Township Precinct 05,United States House of Representatives,1,Democratic,"Sherow, James E.",33,140180
+GEARY,Smokey  Hill Township Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",117,140180
+GEARY,Smokey Hill Township Precinct 6,United States House of Representatives,1,Democratic,"Sherow, James E.",6,140190
+GEARY,Smokey Hill Township Precinct 6,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,140190
+GEARY,Smokey Hill Township Enclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+GEARY,Smokey Hill Township Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+GEARY,Smokey Hill Township Enclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900030
+GEARY,Smokey Hill Township Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+GEARY,Smokey Hill Township Enclave C,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900040
+GEARY,Smokey Hill Township Enclave C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+GEARY,Grandview Township Enclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900100
+GEARY,Grandview Township Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900100
+GEARY,Junction City Ward 4 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",37,900190
+GEARY,Junction City Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900200
+GEARY,Junction City Ward 4 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",28,900210
+GEARY,Junction City Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900220
+GEARY,Fort Riley Precinct A S17 A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002A
+GEARY,Fort Riley Precinct A S17 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002A
+GEARY,Fort Riley Precinct C,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002C
+GEARY,Fort Riley Precinct C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002C
+GEARY,Fort Riley Precinct D,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002D
+GEARY,Fort Riley Precinct D,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002D
+GEARY,Fort Riley Precinct E,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002E
+GEARY,Fort Riley Precinct E,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002E
+GEARY,Fort Riley Precinct F,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002F
+GEARY,Fort Riley Precinct F,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002F
+GEARY,Fort Riley Precinct G,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002G
+GEARY,Fort Riley Precinct G,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002G
+GEARY,Fort Riley Precinct H,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002H
+GEARY,Fort Riley Precinct H,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002H
+GEARY,Fort Riley Precinct I,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002I
+GEARY,Fort Riley Precinct I,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002I
+GEARY,Fort Riley Precinct J,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002J
+GEARY,Fort Riley Precinct J,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002J
+GEARY,Fort Riley Precinct K,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002K
+GEARY,Fort Riley Precinct K,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002K
+GEARY,Fort Riley Precinct M,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002M
+GEARY,Fort Riley Precinct M,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002M
+GEARY,Fort Riley Precinct N,United States House of Representatives,1,Democratic,"Sherow, James E.",0,99002N
+GEARY,Fort Riley Precinct N,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,99002N
+GEARY,Fort Riley Precinct A S22,United States House of Representatives,1,Democratic,"Sherow, James E.",0,990030
+GEARY,Fort Riley Precinct A S22,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,990030
+GEARY,Fort Riley Precinct L S17,United States House of Representatives,1,Democratic,"Sherow, James E.",0,990040
+GEARY,Fort Riley Precinct L S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,990040
+GEARY,Fort Riley Precinct L S22,United States House of Representatives,1,Democratic,"Sherow, James E.",0,990050
+GEARY,Fort Riley Precinct L S22,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,990050
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,United States House of Representatives,1,Democratic,"Sherow, James E.",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,990110
+GEARY,Junction City Ward 4 Precinct 3 H65,United States House of Representatives,1,Democratic,"Sherow, James E.",86,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,990120
+GEARY,Junction City Ward 4 Precinct 3 H68,United States House of Representatives,1,Democratic,"Sherow, James E.",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,990130
+GEARY,Smokey Hill Township S22 H68,United States House of Representatives,1,Democratic,"Sherow, James E.",0,990170
+GEARY,Smokey Hill Township S22 H68,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,990170
+GEARY,Smokey Hill Township Enclave D,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999050
+GEARY,Smokey Hill Township Enclave D,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999050
+GEARY,Smokey Hill Township Enclave E,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999060
+GEARY,Smokey Hill Township Enclave E,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999060
+GEARY,Smokey Hill Township Enclave F,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999070
+GEARY,Smokey Hill Township Enclave F,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999070
+GEARY,Smokey Hill Township Enclave G,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999080
+GEARY,Smokey Hill Township Enclave G,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999080
+GEARY,Grandview Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999090
+GEARY,Grandview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999090
+GEARY,Junction City Ward 1 Precinct 6 Part 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,United States House of Representatives,1,Democratic,"Sherow, James E.",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999160
+GEARY,Blakely Township,Attorney General,,Democratic,"Kotich, A.J.",7,000010
+GEARY,Blakely Township,Attorney General,,Republican,"Schmidt, Derek",44,000010
+GEARY,Fort Riley Milford Township Block 401,Attorney General,,Democratic,"Kotich, A.J.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,Attorney General,,Republican,"Schmidt, Derek",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Attorney General,,Democratic,"Kotich, A.J.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,Attorney General,,Republican,"Schmidt, Derek",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Attorney General,,Democratic,"Kotich, A.J.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,Attorney General,,Republican,"Schmidt, Derek",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Attorney General,,Democratic,"Kotich, A.J.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,Attorney General,,Republican,"Schmidt, Derek",0,00002R
+GEARY,Wingfield Township,Attorney General,,Democratic,"Kotich, A.J.",21,000040
+GEARY,Wingfield Township,Attorney General,,Republican,"Schmidt, Derek",40,000040
+GEARY,Jackson Township,Attorney General,,Democratic,"Kotich, A.J.",8,000050
+GEARY,Jackson Township,Attorney General,,Republican,"Schmidt, Derek",30,000050
+GEARY,Jefferson Township,Attorney General,,Democratic,"Kotich, A.J.",25,000060
+GEARY,Jefferson Township,Attorney General,,Republican,"Schmidt, Derek",120,000060
+GEARY,Junction City Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",60,00007A
+GEARY,Junction City Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",61,00007A
+GEARY,Junction City Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",46,000080
+GEARY,Junction City Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",76,000080
+GEARY,Junction City Ward 1 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",49,000090
+GEARY,Junction City Ward 1 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",151,000090
+GEARY,Junction City Ward 1 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",129,000100
+GEARY,Junction City Ward 1 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",240,000100
+GEARY,Junction City Ward 1 Precinct 7,Attorney General,,Democratic,"Kotich, A.J.",132,00013A
+GEARY,Junction City Ward 1 Precinct 7,Attorney General,,Republican,"Schmidt, Derek",192,00013A
+GEARY,Junction City Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",26,000140
+GEARY,Junction City Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",35,000140
+GEARY,Junction City Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",65,000150
+GEARY,Junction City Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",120,000150
+GEARY,Junction City Ward 2 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",8,00016A
+GEARY,Junction City Ward 2 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",29,00016A
+GEARY,Junction City Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",32,000180
+GEARY,Junction City Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",48,000180
+GEARY,Junction City Ward 3 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",85,000190
+GEARY,Junction City Ward 3 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",127,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Attorney General,,Democratic,"Kotich, A.J.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Attorney General,,Republican,"Schmidt, Derek",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",136,000230
+GEARY,Junction City Ward 4 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",118,000230
+GEARY,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",22,000240
+GEARY,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",57,000240
+GEARY,Lyon Township,Attorney General,,Democratic,"Kotich, A.J.",15,000250
+GEARY,Lyon Township,Attorney General,,Republican,"Schmidt, Derek",114,000250
+GEARY,Marshall Field,Attorney General,,Democratic,"Kotich, A.J.",0,000260
+GEARY,Marshall Field,Attorney General,,Republican,"Schmidt, Derek",0,000260
+GEARY,Milford Township,Attorney General,,Democratic,"Kotich, A.J.",119,000270
+GEARY,Milford Township,Attorney General,,Republican,"Schmidt, Derek",327,000270
+GEARY,Fort Riley Precinct A,Attorney General,,Democratic,"Kotich, A.J.",2,140010
+GEARY,Fort Riley Precinct A,Attorney General,,Republican,"Schmidt, Derek",6,140010
+GEARY,Fort Riley Precinct B,Attorney General,,Democratic,"Kotich, A.J.",12,140020
+GEARY,Fort Riley Precinct B,Attorney General,,Republican,"Schmidt, Derek",29,140020
+GEARY,Grandview Plaza,Attorney General,,Democratic,"Kotich, A.J.",47,140030
+GEARY,Grandview Plaza,Attorney General,,Republican,"Schmidt, Derek",125,140030
+GEARY,Junction City Ward 1 Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",82,140040
+GEARY,Junction City Ward 1 Precinct 5,Attorney General,,Republican,"Schmidt, Derek",131,140040
+GEARY,Junction City Ward 1 Precinct 6,Attorney General,,Democratic,"Kotich, A.J.",102,140050
+GEARY,Junction City Ward 1 Precinct 6,Attorney General,,Republican,"Schmidt, Derek",159,140050
+GEARY,Junction City Ward 2 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",9,140060
+GEARY,Junction City Ward 2 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",24,140060
+GEARY,Junction City Ward 2 Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",70,140070
+GEARY,Junction City Ward 2 Precinct 5,Attorney General,,Republican,"Schmidt, Derek",125,140070
+GEARY,Junction City Ward 2 Precinct 6,Attorney General,,Democratic,"Kotich, A.J.",47,140080
+GEARY,Junction City Ward 2 Precinct 6,Attorney General,,Republican,"Schmidt, Derek",74,140080
+GEARY,Junction City Ward 2 Precinct 7,Attorney General,,Democratic,"Kotich, A.J.",46,140090
+GEARY,Junction City Ward 2 Precinct 7,Attorney General,,Republican,"Schmidt, Derek",82,140090
+GEARY,Junction City Ward 2 Precinct 8,Attorney General,,Democratic,"Kotich, A.J.",10,140100
+GEARY,Junction City Ward 2 Precinct 8,Attorney General,,Republican,"Schmidt, Derek",26,140100
+GEARY,Junction City Ward 3 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",28,140110
+GEARY,Junction City Ward 3 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",46,140110
+GEARY,Junction City Ward 3 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",11,140120
+GEARY,Junction City Ward 3 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",23,140120
+GEARY,Milford City Precinct,Attorney General,,Democratic,"Kotich, A.J.",21,140130
+GEARY,Milford City Precinct,Attorney General,,Republican,"Schmidt, Derek",78,140130
+GEARY,Smokey Hill Township Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",0,140140
+GEARY,Smokey Hill Township Precinct 01,Attorney General,,Republican,"Schmidt, Derek",0,140140
+GEARY,Smokey Hill Township Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",1,140150
+GEARY,Smokey Hill Township Precinct 2,Attorney General,,Republican,"Schmidt, Derek",3,140150
+GEARY,Smokey Hill Township Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",17,140160
+GEARY,Smokey Hill Township Precinct 3,Attorney General,,Republican,"Schmidt, Derek",47,140160
+GEARY,Smokey Hill Township Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",21,140170
+GEARY,Smokey Hill Township Precinct 4,Attorney General,,Republican,"Schmidt, Derek",53,140170
+GEARY,Smokey  Hill Township Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",31,140180
+GEARY,Smokey  Hill Township Precinct 05,Attorney General,,Republican,"Schmidt, Derek",121,140180
+GEARY,Smokey Hill Township Precinct 6,Attorney General,,Democratic,"Kotich, A.J.",4,140190
+GEARY,Smokey Hill Township Precinct 6,Attorney General,,Republican,"Schmidt, Derek",18,140190
+GEARY,Smokey Hill Township Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+GEARY,Smokey Hill Township Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,900020
+GEARY,Smokey Hill Township Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+GEARY,Smokey Hill Township Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,900030
+GEARY,Smokey Hill Township Enclave C,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+GEARY,Smokey Hill Township Enclave C,Attorney General,,Republican,"Schmidt, Derek",0,900040
+GEARY,Grandview Township Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900100
+GEARY,Grandview Township Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,900100
+GEARY,Junction City Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",34,900190
+GEARY,Junction City Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",39,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900200
+GEARY,Junction City Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",30,900210
+GEARY,Junction City Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",22,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900220
+GEARY,Fort Riley Precinct A S17 A,Attorney General,,Democratic,"Kotich, A.J.",0,99002A
+GEARY,Fort Riley Precinct A S17 A,Attorney General,,Republican,"Schmidt, Derek",0,99002A
+GEARY,Fort Riley Precinct C,Attorney General,,Democratic,"Kotich, A.J.",0,99002C
+GEARY,Fort Riley Precinct C,Attorney General,,Republican,"Schmidt, Derek",0,99002C
+GEARY,Fort Riley Precinct D,Attorney General,,Democratic,"Kotich, A.J.",0,99002D
+GEARY,Fort Riley Precinct D,Attorney General,,Republican,"Schmidt, Derek",0,99002D
+GEARY,Fort Riley Precinct E,Attorney General,,Democratic,"Kotich, A.J.",0,99002E
+GEARY,Fort Riley Precinct E,Attorney General,,Republican,"Schmidt, Derek",0,99002E
+GEARY,Fort Riley Precinct F,Attorney General,,Democratic,"Kotich, A.J.",0,99002F
+GEARY,Fort Riley Precinct F,Attorney General,,Republican,"Schmidt, Derek",0,99002F
+GEARY,Fort Riley Precinct G,Attorney General,,Democratic,"Kotich, A.J.",0,99002G
+GEARY,Fort Riley Precinct G,Attorney General,,Republican,"Schmidt, Derek",0,99002G
+GEARY,Fort Riley Precinct H,Attorney General,,Democratic,"Kotich, A.J.",0,99002H
+GEARY,Fort Riley Precinct H,Attorney General,,Republican,"Schmidt, Derek",0,99002H
+GEARY,Fort Riley Precinct I,Attorney General,,Democratic,"Kotich, A.J.",0,99002I
+GEARY,Fort Riley Precinct I,Attorney General,,Republican,"Schmidt, Derek",0,99002I
+GEARY,Fort Riley Precinct J,Attorney General,,Democratic,"Kotich, A.J.",0,99002J
+GEARY,Fort Riley Precinct J,Attorney General,,Republican,"Schmidt, Derek",0,99002J
+GEARY,Fort Riley Precinct K,Attorney General,,Democratic,"Kotich, A.J.",0,99002K
+GEARY,Fort Riley Precinct K,Attorney General,,Republican,"Schmidt, Derek",0,99002K
+GEARY,Fort Riley Precinct M,Attorney General,,Democratic,"Kotich, A.J.",0,99002M
+GEARY,Fort Riley Precinct M,Attorney General,,Republican,"Schmidt, Derek",0,99002M
+GEARY,Fort Riley Precinct N,Attorney General,,Democratic,"Kotich, A.J.",0,99002N
+GEARY,Fort Riley Precinct N,Attorney General,,Republican,"Schmidt, Derek",0,99002N
+GEARY,Fort Riley Precinct A S22,Attorney General,,Democratic,"Kotich, A.J.",0,990030
+GEARY,Fort Riley Precinct A S22,Attorney General,,Republican,"Schmidt, Derek",0,990030
+GEARY,Fort Riley Precinct L S17,Attorney General,,Democratic,"Kotich, A.J.",0,990040
+GEARY,Fort Riley Precinct L S17,Attorney General,,Republican,"Schmidt, Derek",0,990040
+GEARY,Fort Riley Precinct L S22,Attorney General,,Democratic,"Kotich, A.J.",0,990050
+GEARY,Fort Riley Precinct L S22,Attorney General,,Republican,"Schmidt, Derek",0,990050
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Attorney General,,Democratic,"Kotich, A.J.",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Attorney General,,Republican,"Schmidt, Derek",0,990110
+GEARY,Junction City Ward 4 Precinct 3 H65,Attorney General,,Democratic,"Kotich, A.J.",79,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,Attorney General,,Republican,"Schmidt, Derek",68,990120
+GEARY,Junction City Ward 4 Precinct 3 H68,Attorney General,,Democratic,"Kotich, A.J.",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,Attorney General,,Republican,"Schmidt, Derek",0,990130
+GEARY,Smokey Hill Township S22 H68,Attorney General,,Democratic,"Kotich, A.J.",0,990170
+GEARY,Smokey Hill Township S22 H68,Attorney General,,Republican,"Schmidt, Derek",0,990170
+GEARY,Smokey Hill Township Enclave D,Attorney General,,Democratic,"Kotich, A.J.",0,999050
+GEARY,Smokey Hill Township Enclave D,Attorney General,,Republican,"Schmidt, Derek",0,999050
+GEARY,Smokey Hill Township Enclave E,Attorney General,,Democratic,"Kotich, A.J.",0,999060
+GEARY,Smokey Hill Township Enclave E,Attorney General,,Republican,"Schmidt, Derek",0,999060
+GEARY,Smokey Hill Township Enclave F,Attorney General,,Democratic,"Kotich, A.J.",0,999070
+GEARY,Smokey Hill Township Enclave F,Attorney General,,Republican,"Schmidt, Derek",0,999070
+GEARY,Smokey Hill Township Enclave G,Attorney General,,Democratic,"Kotich, A.J.",0,999080
+GEARY,Smokey Hill Township Enclave G,Attorney General,,Republican,"Schmidt, Derek",0,999080
+GEARY,Grandview Township,Attorney General,,Democratic,"Kotich, A.J.",0,999090
+GEARY,Grandview Township,Attorney General,,Republican,"Schmidt, Derek",0,999090
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Attorney General,,Democratic,"Kotich, A.J.",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Attorney General,,Republican,"Schmidt, Derek",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Attorney General,,Democratic,"Kotich, A.J.",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Attorney General,,Republican,"Schmidt, Derek",0,999130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Attorney General,,Democratic,"Kotich, A.J.",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Attorney General,,Republican,"Schmidt, Derek",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Attorney General,,Democratic,"Kotich, A.J.",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Attorney General,,Republican,"Schmidt, Derek",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Attorney General,,Democratic,"Kotich, A.J.",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Attorney General,,Republican,"Schmidt, Derek",0,999160
+GEARY,Blakely Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000010
+GEARY,Blakely Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000010
+GEARY,Fort Riley Milford Township Block 401,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002O
+GEARY,Fort Riley Milford Township Block 401,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002P
+GEARY,Fort Riley Milford Township Block 501,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002R
+GEARY,Fort Riley Milford Township Block 701,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002R
+GEARY,Wingfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000040
+GEARY,Wingfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000040
+GEARY,Jackson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000050
+GEARY,Jackson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000050
+GEARY,Jefferson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000060
+GEARY,Jefferson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000060
+GEARY,Junction City Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,00007A
+GEARY,Junction City Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",61,00007A
+GEARY,Junction City Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000080
+GEARY,Junction City Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",71,000080
+GEARY,Junction City Ward 1 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,000090
+GEARY,Junction City Ward 1 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",134,000090
+GEARY,Junction City Ward 1 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",141,000100
+GEARY,Junction City Ward 1 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",222,000100
+GEARY,Junction City Ward 1 Precinct 7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",138,00013A
+GEARY,Junction City Ward 1 Precinct 7,Commissioner of Insurance,,Republican,"Selzer, Ken",179,00013A
+GEARY,Junction City Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000140
+GEARY,Junction City Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000140
+GEARY,Junction City Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,000150
+GEARY,Junction City Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",104,000150
+GEARY,Junction City Ward 2 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,00016A
+GEARY,Junction City Ward 2 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",28,00016A
+GEARY,Junction City Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000180
+GEARY,Junction City Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000180
+GEARY,Junction City Ward 3 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",87,000190
+GEARY,Junction City Ward 3 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",152,000230
+GEARY,Junction City Ward 4 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",100,000230
+GEARY,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000240
+GEARY,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",56,000240
+GEARY,Lyon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000250
+GEARY,Lyon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000250
+GEARY,Marshall Field,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000260
+GEARY,Marshall Field,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000260
+GEARY,Milford Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",122,000270
+GEARY,Milford Township,Commissioner of Insurance,,Republican,"Selzer, Ken",317,000270
+GEARY,Fort Riley Precinct A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,140010
+GEARY,Fort Riley Precinct A,Commissioner of Insurance,,Republican,"Selzer, Ken",6,140010
+GEARY,Fort Riley Precinct B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,140020
+GEARY,Fort Riley Precinct B,Commissioner of Insurance,,Republican,"Selzer, Ken",25,140020
+GEARY,Grandview Plaza,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,140030
+GEARY,Grandview Plaza,Commissioner of Insurance,,Republican,"Selzer, Ken",119,140030
+GEARY,Junction City Ward 1 Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",95,140040
+GEARY,Junction City Ward 1 Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",115,140040
+GEARY,Junction City Ward 1 Precinct 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",112,140050
+GEARY,Junction City Ward 1 Precinct 6,Commissioner of Insurance,,Republican,"Selzer, Ken",150,140050
+GEARY,Junction City Ward 2 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,140060
+GEARY,Junction City Ward 2 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",23,140060
+GEARY,Junction City Ward 2 Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,140070
+GEARY,Junction City Ward 2 Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",117,140070
+GEARY,Junction City Ward 2 Precinct 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",55,140080
+GEARY,Junction City Ward 2 Precinct 6,Commissioner of Insurance,,Republican,"Selzer, Ken",65,140080
+GEARY,Junction City Ward 2 Precinct 7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,140090
+GEARY,Junction City Ward 2 Precinct 7,Commissioner of Insurance,,Republican,"Selzer, Ken",86,140090
+GEARY,Junction City Ward 2 Precinct 8,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,140100
+GEARY,Junction City Ward 2 Precinct 8,Commissioner of Insurance,,Republican,"Selzer, Ken",25,140100
+GEARY,Junction City Ward 3 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,140110
+GEARY,Junction City Ward 3 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",41,140110
+GEARY,Junction City Ward 3 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,140120
+GEARY,Junction City Ward 3 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",19,140120
+GEARY,Milford City Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,140130
+GEARY,Milford City Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",72,140130
+GEARY,Smokey Hill Township Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,140140
+GEARY,Smokey Hill Township Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",0,140140
+GEARY,Smokey Hill Township Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,140150
+GEARY,Smokey Hill Township Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",3,140150
+GEARY,Smokey Hill Township Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,140160
+GEARY,Smokey Hill Township Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",43,140160
+GEARY,Smokey Hill Township Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,140170
+GEARY,Smokey Hill Township Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",48,140170
+GEARY,Smokey  Hill Township Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,140180
+GEARY,Smokey  Hill Township Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",120,140180
+GEARY,Smokey Hill Township Precinct 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,140190
+GEARY,Smokey Hill Township Precinct 6,Commissioner of Insurance,,Republican,"Selzer, Ken",18,140190
+GEARY,Smokey Hill Township Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+GEARY,Smokey Hill Township Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+GEARY,Smokey Hill Township Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+GEARY,Smokey Hill Township Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+GEARY,Smokey Hill Township Enclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+GEARY,Smokey Hill Township Enclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+GEARY,Grandview Township Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900100
+GEARY,Grandview Township Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900100
+GEARY,Junction City Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,900190
+GEARY,Junction City Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",40,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900200
+GEARY,Junction City Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,900210
+GEARY,Junction City Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",22,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900220
+GEARY,Fort Riley Precinct A S17 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002A
+GEARY,Fort Riley Precinct A S17 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002A
+GEARY,Fort Riley Precinct C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002C
+GEARY,Fort Riley Precinct C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002C
+GEARY,Fort Riley Precinct D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002D
+GEARY,Fort Riley Precinct D,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002D
+GEARY,Fort Riley Precinct E,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002E
+GEARY,Fort Riley Precinct E,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002E
+GEARY,Fort Riley Precinct F,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002F
+GEARY,Fort Riley Precinct F,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002F
+GEARY,Fort Riley Precinct G,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002G
+GEARY,Fort Riley Precinct G,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002G
+GEARY,Fort Riley Precinct H,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002H
+GEARY,Fort Riley Precinct H,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002H
+GEARY,Fort Riley Precinct I,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002I
+GEARY,Fort Riley Precinct I,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002I
+GEARY,Fort Riley Precinct J,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002J
+GEARY,Fort Riley Precinct J,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002J
+GEARY,Fort Riley Precinct K,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002K
+GEARY,Fort Riley Precinct K,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002K
+GEARY,Fort Riley Precinct M,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002M
+GEARY,Fort Riley Precinct M,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002M
+GEARY,Fort Riley Precinct N,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,99002N
+GEARY,Fort Riley Precinct N,Commissioner of Insurance,,Republican,"Selzer, Ken",0,99002N
+GEARY,Fort Riley Precinct A S22,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,990030
+GEARY,Fort Riley Precinct A S22,Commissioner of Insurance,,Republican,"Selzer, Ken",0,990030
+GEARY,Fort Riley Precinct L S17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,990040
+GEARY,Fort Riley Precinct L S17,Commissioner of Insurance,,Republican,"Selzer, Ken",0,990040
+GEARY,Fort Riley Precinct L S22,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,990050
+GEARY,Fort Riley Precinct L S22,Commissioner of Insurance,,Republican,"Selzer, Ken",0,990050
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Commissioner of Insurance,,Republican,"Selzer, Ken",0,990110
+GEARY,Junction City Ward 4 Precinct 3 H65,Commissioner of Insurance,,Democratic,"Anderson, Dennis",82,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,Commissioner of Insurance,,Republican,"Selzer, Ken",64,990120
+GEARY,Junction City Ward 4 Precinct 3 H68,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,Commissioner of Insurance,,Republican,"Selzer, Ken",0,990130
+GEARY,Smokey Hill Township S22 H68,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,990170
+GEARY,Smokey Hill Township S22 H68,Commissioner of Insurance,,Republican,"Selzer, Ken",0,990170
+GEARY,Smokey Hill Township Enclave D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999050
+GEARY,Smokey Hill Township Enclave D,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999050
+GEARY,Smokey Hill Township Enclave E,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999060
+GEARY,Smokey Hill Township Enclave E,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999060
+GEARY,Smokey Hill Township Enclave F,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999070
+GEARY,Smokey Hill Township Enclave F,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999070
+GEARY,Smokey Hill Township Enclave G,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999080
+GEARY,Smokey Hill Township Enclave G,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999080
+GEARY,Grandview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999090
+GEARY,Grandview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999090
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,999160
+GEARY,Blakely Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000010
+GEARY,Blakely Township,Secretary of State,,Republican,"Kobach, Kris",38,000010
+GEARY,Fort Riley Milford Township Block 401,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002O
+GEARY,Fort Riley Milford Township Block 401,Secretary of State,,Republican,"Kobach, Kris",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002P
+GEARY,Fort Riley Milford Township Block 501,Secretary of State,,Republican,"Kobach, Kris",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,Secretary of State,,Republican,"Kobach, Kris",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002R
+GEARY,Fort Riley Milford Township Block 701,Secretary of State,,Republican,"Kobach, Kris",0,00002R
+GEARY,Wingfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000040
+GEARY,Wingfield Township,Secretary of State,,Republican,"Kobach, Kris",37,000040
+GEARY,Jackson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000050
+GEARY,Jackson Township,Secretary of State,,Republican,"Kobach, Kris",29,000050
+GEARY,Jefferson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000060
+GEARY,Jefferson Township,Secretary of State,,Republican,"Kobach, Kris",117,000060
+GEARY,Junction City Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,00007A
+GEARY,Junction City Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",59,00007A
+GEARY,Junction City Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000080
+GEARY,Junction City Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",76,000080
+GEARY,Junction City Ward 1 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000090
+GEARY,Junction City Ward 1 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",139,000090
+GEARY,Junction City Ward 1 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",150,000100
+GEARY,Junction City Ward 1 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",219,000100
+GEARY,Junction City Ward 1 Precinct 7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",144,00013A
+GEARY,Junction City Ward 1 Precinct 7,Secretary of State,,Republican,"Kobach, Kris",184,00013A
+GEARY,Junction City Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000140
+GEARY,Junction City Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",30,000140
+GEARY,Junction City Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",79,000150
+GEARY,Junction City Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",105,000150
+GEARY,Junction City Ward 2 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,00016A
+GEARY,Junction City Ward 2 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",26,00016A
+GEARY,Junction City Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000180
+GEARY,Junction City Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",44,000180
+GEARY,Junction City Ward 3 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",95,000190
+GEARY,Junction City Ward 3 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",122,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Secretary of State,,Republican,"Kobach, Kris",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",148,000230
+GEARY,Junction City Ward 4 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",107,000230
+GEARY,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000240
+GEARY,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",58,000240
+GEARY,Lyon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000250
+GEARY,Lyon Township,Secretary of State,,Republican,"Kobach, Kris",108,000250
+GEARY,Marshall Field,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000260
+GEARY,Marshall Field,Secretary of State,,Republican,"Kobach, Kris",0,000260
+GEARY,Milford Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",133,000270
+GEARY,Milford Township,Secretary of State,,Republican,"Kobach, Kris",318,000270
+GEARY,Fort Riley Precinct A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,140010
+GEARY,Fort Riley Precinct A,Secretary of State,,Republican,"Kobach, Kris",6,140010
+GEARY,Fort Riley Precinct B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,140020
+GEARY,Fort Riley Precinct B,Secretary of State,,Republican,"Kobach, Kris",28,140020
+GEARY,Grandview Plaza,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,140030
+GEARY,Grandview Plaza,Secretary of State,,Republican,"Kobach, Kris",123,140030
+GEARY,Junction City Ward 1 Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",93,140040
+GEARY,Junction City Ward 1 Precinct 5,Secretary of State,,Republican,"Kobach, Kris",120,140040
+GEARY,Junction City Ward 1 Precinct 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",113,140050
+GEARY,Junction City Ward 1 Precinct 6,Secretary of State,,Republican,"Kobach, Kris",152,140050
+GEARY,Junction City Ward 2 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,140060
+GEARY,Junction City Ward 2 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",24,140060
+GEARY,Junction City Ward 2 Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,140070
+GEARY,Junction City Ward 2 Precinct 5,Secretary of State,,Republican,"Kobach, Kris",121,140070
+GEARY,Junction City Ward 2 Precinct 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,140080
+GEARY,Junction City Ward 2 Precinct 6,Secretary of State,,Republican,"Kobach, Kris",69,140080
+GEARY,Junction City Ward 2 Precinct 7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,140090
+GEARY,Junction City Ward 2 Precinct 7,Secretary of State,,Republican,"Kobach, Kris",84,140090
+GEARY,Junction City Ward 2 Precinct 8,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,140100
+GEARY,Junction City Ward 2 Precinct 8,Secretary of State,,Republican,"Kobach, Kris",25,140100
+GEARY,Junction City Ward 3 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,140110
+GEARY,Junction City Ward 3 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",46,140110
+GEARY,Junction City Ward 3 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,140120
+GEARY,Junction City Ward 3 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",22,140120
+GEARY,Milford City Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,140130
+GEARY,Milford City Precinct,Secretary of State,,Republican,"Kobach, Kris",80,140130
+GEARY,Smokey Hill Township Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,140140
+GEARY,Smokey Hill Township Precinct 01,Secretary of State,,Republican,"Kobach, Kris",0,140140
+GEARY,Smokey Hill Township Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,140150
+GEARY,Smokey Hill Township Precinct 2,Secretary of State,,Republican,"Kobach, Kris",3,140150
+GEARY,Smokey Hill Township Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,140160
+GEARY,Smokey Hill Township Precinct 3,Secretary of State,,Republican,"Kobach, Kris",41,140160
+GEARY,Smokey Hill Township Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,140170
+GEARY,Smokey Hill Township Precinct 4,Secretary of State,,Republican,"Kobach, Kris",52,140170
+GEARY,Smokey  Hill Township Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,140180
+GEARY,Smokey  Hill Township Precinct 05,Secretary of State,,Republican,"Kobach, Kris",115,140180
+GEARY,Smokey Hill Township Precinct 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,140190
+GEARY,Smokey Hill Township Precinct 6,Secretary of State,,Republican,"Kobach, Kris",17,140190
+GEARY,Smokey Hill Township Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+GEARY,Smokey Hill Township Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,900020
+GEARY,Smokey Hill Township Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+GEARY,Smokey Hill Township Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,900030
+GEARY,Smokey Hill Township Enclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+GEARY,Smokey Hill Township Enclave C,Secretary of State,,Republican,"Kobach, Kris",0,900040
+GEARY,Grandview Township Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900100
+GEARY,Grandview Township Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,900100
+GEARY,Junction City Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,900190
+GEARY,Junction City Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",37,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900200
+GEARY,Junction City Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,900210
+GEARY,Junction City Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",27,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900220
+GEARY,Fort Riley Precinct A S17 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002A
+GEARY,Fort Riley Precinct A S17 A,Secretary of State,,Republican,"Kobach, Kris",0,99002A
+GEARY,Fort Riley Precinct C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002C
+GEARY,Fort Riley Precinct C,Secretary of State,,Republican,"Kobach, Kris",0,99002C
+GEARY,Fort Riley Precinct D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002D
+GEARY,Fort Riley Precinct D,Secretary of State,,Republican,"Kobach, Kris",0,99002D
+GEARY,Fort Riley Precinct E,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002E
+GEARY,Fort Riley Precinct E,Secretary of State,,Republican,"Kobach, Kris",0,99002E
+GEARY,Fort Riley Precinct F,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002F
+GEARY,Fort Riley Precinct F,Secretary of State,,Republican,"Kobach, Kris",0,99002F
+GEARY,Fort Riley Precinct G,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002G
+GEARY,Fort Riley Precinct G,Secretary of State,,Republican,"Kobach, Kris",0,99002G
+GEARY,Fort Riley Precinct H,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002H
+GEARY,Fort Riley Precinct H,Secretary of State,,Republican,"Kobach, Kris",0,99002H
+GEARY,Fort Riley Precinct I,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002I
+GEARY,Fort Riley Precinct I,Secretary of State,,Republican,"Kobach, Kris",0,99002I
+GEARY,Fort Riley Precinct J,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002J
+GEARY,Fort Riley Precinct J,Secretary of State,,Republican,"Kobach, Kris",0,99002J
+GEARY,Fort Riley Precinct K,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002K
+GEARY,Fort Riley Precinct K,Secretary of State,,Republican,"Kobach, Kris",0,99002K
+GEARY,Fort Riley Precinct M,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002M
+GEARY,Fort Riley Precinct M,Secretary of State,,Republican,"Kobach, Kris",0,99002M
+GEARY,Fort Riley Precinct N,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,99002N
+GEARY,Fort Riley Precinct N,Secretary of State,,Republican,"Kobach, Kris",0,99002N
+GEARY,Fort Riley Precinct A S22,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,990030
+GEARY,Fort Riley Precinct A S22,Secretary of State,,Republican,"Kobach, Kris",0,990030
+GEARY,Fort Riley Precinct L S17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,990040
+GEARY,Fort Riley Precinct L S17,Secretary of State,,Republican,"Kobach, Kris",0,990040
+GEARY,Fort Riley Precinct L S22,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,990050
+GEARY,Fort Riley Precinct L S22,Secretary of State,,Republican,"Kobach, Kris",0,990050
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Secretary of State,,Republican,"Kobach, Kris",0,990110
+GEARY,Junction City Ward 4 Precinct 3 H65,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,Secretary of State,,Republican,"Kobach, Kris",62,990120
+GEARY,Junction City Ward 4 Precinct 3 H68,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,Secretary of State,,Republican,"Kobach, Kris",0,990130
+GEARY,Smokey Hill Township S22 H68,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,990170
+GEARY,Smokey Hill Township S22 H68,Secretary of State,,Republican,"Kobach, Kris",0,990170
+GEARY,Smokey Hill Township Enclave D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999050
+GEARY,Smokey Hill Township Enclave D,Secretary of State,,Republican,"Kobach, Kris",0,999050
+GEARY,Smokey Hill Township Enclave E,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999060
+GEARY,Smokey Hill Township Enclave E,Secretary of State,,Republican,"Kobach, Kris",0,999060
+GEARY,Smokey Hill Township Enclave F,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999070
+GEARY,Smokey Hill Township Enclave F,Secretary of State,,Republican,"Kobach, Kris",0,999070
+GEARY,Smokey Hill Township Enclave G,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999080
+GEARY,Smokey Hill Township Enclave G,Secretary of State,,Republican,"Kobach, Kris",0,999080
+GEARY,Grandview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999090
+GEARY,Grandview Township,Secretary of State,,Republican,"Kobach, Kris",0,999090
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Secretary of State,,Republican,"Kobach, Kris",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Secretary of State,,Republican,"Kobach, Kris",0,999130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Secretary of State,,Republican,"Kobach, Kris",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Secretary of State,,Republican,"Kobach, Kris",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Secretary of State,,Republican,"Kobach, Kris",0,999160
+GEARY,Blakely Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000010
+GEARY,Blakely Township,State Treasurer,,Republican,"Estes, Ron",38,000010
+GEARY,Fort Riley Milford Township Block 401,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002O
+GEARY,Fort Riley Milford Township Block 401,State Treasurer,,Republican,"Estes, Ron",0,00002O
+GEARY,Fort Riley Milford Township Block 501,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002P
+GEARY,Fort Riley Milford Township Block 501,State Treasurer,,Republican,"Estes, Ron",0,00002P
+GEARY,Fort Riley Milford Township Block 601,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,State Treasurer,,Republican,"Estes, Ron",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002R
+GEARY,Fort Riley Milford Township Block 701,State Treasurer,,Republican,"Estes, Ron",0,00002R
+GEARY,Wingfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000040
+GEARY,Wingfield Township,State Treasurer,,Republican,"Estes, Ron",37,000040
+GEARY,Jackson Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000050
+GEARY,Jackson Township,State Treasurer,,Republican,"Estes, Ron",31,000050
+GEARY,Jefferson Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000060
+GEARY,Jefferson Township,State Treasurer,,Republican,"Estes, Ron",112,000060
+GEARY,Junction City Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",52,00007A
+GEARY,Junction City Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",68,00007A
+GEARY,Junction City Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",43,000080
+GEARY,Junction City Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",78,000080
+GEARY,Junction City Ward 1 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",59,000090
+GEARY,Junction City Ward 1 Precinct 3,State Treasurer,,Republican,"Estes, Ron",142,000090
+GEARY,Junction City Ward 1 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",132,000100
+GEARY,Junction City Ward 1 Precinct 4,State Treasurer,,Republican,"Estes, Ron",229,000100
+GEARY,Junction City Ward 1 Precinct 7,State Treasurer,,Democratic,"Alldritt, Carmen",132,00013A
+GEARY,Junction City Ward 1 Precinct 7,State Treasurer,,Republican,"Estes, Ron",192,00013A
+GEARY,Junction City Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",28,000140
+GEARY,Junction City Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",32,000140
+GEARY,Junction City Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",72,000150
+GEARY,Junction City Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",112,000150
+GEARY,Junction City Ward 2 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",7,00016A
+GEARY,Junction City Ward 2 Precinct 3,State Treasurer,,Republican,"Estes, Ron",31,00016A
+GEARY,Junction City Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",31,000180
+GEARY,Junction City Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",50,000180
+GEARY,Junction City Ward 3 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",82,000190
+GEARY,Junction City Ward 3 Precinct 2,State Treasurer,,Republican,"Estes, Ron",128,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,State Treasurer,,Republican,"Estes, Ron",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",142,000230
+GEARY,Junction City Ward 4 Precinct 4,State Treasurer,,Republican,"Estes, Ron",114,000230
+GEARY,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000240
+GEARY,Liberty Township,State Treasurer,,Republican,"Estes, Ron",60,000240
+GEARY,Lyon Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000250
+GEARY,Lyon Township,State Treasurer,,Republican,"Estes, Ron",107,000250
+GEARY,Marshall Field,State Treasurer,,Democratic,"Alldritt, Carmen",0,000260
+GEARY,Marshall Field,State Treasurer,,Republican,"Estes, Ron",0,000260
+GEARY,Milford Township,State Treasurer,,Democratic,"Alldritt, Carmen",112,000270
+GEARY,Milford Township,State Treasurer,,Republican,"Estes, Ron",330,000270
+GEARY,Fort Riley Precinct A,State Treasurer,,Democratic,"Alldritt, Carmen",2,140010
+GEARY,Fort Riley Precinct A,State Treasurer,,Republican,"Estes, Ron",6,140010
+GEARY,Fort Riley Precinct B,State Treasurer,,Democratic,"Alldritt, Carmen",12,140020
+GEARY,Fort Riley Precinct B,State Treasurer,,Republican,"Estes, Ron",28,140020
+GEARY,Grandview Plaza,State Treasurer,,Democratic,"Alldritt, Carmen",49,140030
+GEARY,Grandview Plaza,State Treasurer,,Republican,"Estes, Ron",123,140030
+GEARY,Junction City Ward 1 Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",89,140040
+GEARY,Junction City Ward 1 Precinct 5,State Treasurer,,Republican,"Estes, Ron",124,140040
+GEARY,Junction City Ward 1 Precinct 6,State Treasurer,,Democratic,"Alldritt, Carmen",99,140050
+GEARY,Junction City Ward 1 Precinct 6,State Treasurer,,Republican,"Estes, Ron",164,140050
+GEARY,Junction City Ward 2 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",10,140060
+GEARY,Junction City Ward 2 Precinct 4,State Treasurer,,Republican,"Estes, Ron",23,140060
+GEARY,Junction City Ward 2 Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",69,140070
+GEARY,Junction City Ward 2 Precinct 5,State Treasurer,,Republican,"Estes, Ron",126,140070
+GEARY,Junction City Ward 2 Precinct 6,State Treasurer,,Democratic,"Alldritt, Carmen",56,140080
+GEARY,Junction City Ward 2 Precinct 6,State Treasurer,,Republican,"Estes, Ron",64,140080
+GEARY,Junction City Ward 2 Precinct 7,State Treasurer,,Democratic,"Alldritt, Carmen",44,140090
+GEARY,Junction City Ward 2 Precinct 7,State Treasurer,,Republican,"Estes, Ron",84,140090
+GEARY,Junction City Ward 2 Precinct 8,State Treasurer,,Democratic,"Alldritt, Carmen",9,140100
+GEARY,Junction City Ward 2 Precinct 8,State Treasurer,,Republican,"Estes, Ron",27,140100
+GEARY,Junction City Ward 3 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",27,140110
+GEARY,Junction City Ward 3 Precinct 3,State Treasurer,,Republican,"Estes, Ron",46,140110
+GEARY,Junction City Ward 3 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",11,140120
+GEARY,Junction City Ward 3 Precinct 4,State Treasurer,,Republican,"Estes, Ron",23,140120
+GEARY,Milford City Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",23,140130
+GEARY,Milford City Precinct,State Treasurer,,Republican,"Estes, Ron",78,140130
+GEARY,Smokey Hill Township Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",0,140140
+GEARY,Smokey Hill Township Precinct 01,State Treasurer,,Republican,"Estes, Ron",0,140140
+GEARY,Smokey Hill Township Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",1,140150
+GEARY,Smokey Hill Township Precinct 2,State Treasurer,,Republican,"Estes, Ron",3,140150
+GEARY,Smokey Hill Township Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",19,140160
+GEARY,Smokey Hill Township Precinct 3,State Treasurer,,Republican,"Estes, Ron",44,140160
+GEARY,Smokey Hill Township Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",23,140170
+GEARY,Smokey Hill Township Precinct 4,State Treasurer,,Republican,"Estes, Ron",54,140170
+GEARY,Smokey  Hill Township Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",22,140180
+GEARY,Smokey  Hill Township Precinct 05,State Treasurer,,Republican,"Estes, Ron",126,140180
+GEARY,Smokey Hill Township Precinct 6,State Treasurer,,Democratic,"Alldritt, Carmen",5,140190
+GEARY,Smokey Hill Township Precinct 6,State Treasurer,,Republican,"Estes, Ron",17,140190
+GEARY,Smokey Hill Township Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+GEARY,Smokey Hill Township Enclave A,State Treasurer,,Republican,"Estes, Ron",0,900020
+GEARY,Smokey Hill Township Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+GEARY,Smokey Hill Township Enclave B,State Treasurer,,Republican,"Estes, Ron",0,900030
+GEARY,Smokey Hill Township Enclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+GEARY,Smokey Hill Township Enclave C,State Treasurer,,Republican,"Estes, Ron",0,900040
+GEARY,Grandview Township Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900100
+GEARY,Grandview Township Enclave A,State Treasurer,,Republican,"Estes, Ron",0,900100
+GEARY,Junction City Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",37,900190
+GEARY,Junction City Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",37,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900200
+GEARY,Junction City Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",30,900210
+GEARY,Junction City Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",22,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900220
+GEARY,Fort Riley Precinct A S17 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002A
+GEARY,Fort Riley Precinct A S17 A,State Treasurer,,Republican,"Estes, Ron",0,99002A
+GEARY,Fort Riley Precinct C,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002C
+GEARY,Fort Riley Precinct C,State Treasurer,,Republican,"Estes, Ron",0,99002C
+GEARY,Fort Riley Precinct D,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002D
+GEARY,Fort Riley Precinct D,State Treasurer,,Republican,"Estes, Ron",0,99002D
+GEARY,Fort Riley Precinct E,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002E
+GEARY,Fort Riley Precinct E,State Treasurer,,Republican,"Estes, Ron",0,99002E
+GEARY,Fort Riley Precinct F,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002F
+GEARY,Fort Riley Precinct F,State Treasurer,,Republican,"Estes, Ron",0,99002F
+GEARY,Fort Riley Precinct G,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002G
+GEARY,Fort Riley Precinct G,State Treasurer,,Republican,"Estes, Ron",0,99002G
+GEARY,Fort Riley Precinct H,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002H
+GEARY,Fort Riley Precinct H,State Treasurer,,Republican,"Estes, Ron",0,99002H
+GEARY,Fort Riley Precinct I,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002I
+GEARY,Fort Riley Precinct I,State Treasurer,,Republican,"Estes, Ron",0,99002I
+GEARY,Fort Riley Precinct J,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002J
+GEARY,Fort Riley Precinct J,State Treasurer,,Republican,"Estes, Ron",0,99002J
+GEARY,Fort Riley Precinct K,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002K
+GEARY,Fort Riley Precinct K,State Treasurer,,Republican,"Estes, Ron",0,99002K
+GEARY,Fort Riley Precinct M,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002M
+GEARY,Fort Riley Precinct M,State Treasurer,,Republican,"Estes, Ron",0,99002M
+GEARY,Fort Riley Precinct N,State Treasurer,,Democratic,"Alldritt, Carmen",0,99002N
+GEARY,Fort Riley Precinct N,State Treasurer,,Republican,"Estes, Ron",0,99002N
+GEARY,Fort Riley Precinct A S22,State Treasurer,,Democratic,"Alldritt, Carmen",0,990030
+GEARY,Fort Riley Precinct A S22,State Treasurer,,Republican,"Estes, Ron",0,990030
+GEARY,Fort Riley Precinct L S17,State Treasurer,,Democratic,"Alldritt, Carmen",0,990040
+GEARY,Fort Riley Precinct L S17,State Treasurer,,Republican,"Estes, Ron",0,990040
+GEARY,Fort Riley Precinct L S22,State Treasurer,,Democratic,"Alldritt, Carmen",0,990050
+GEARY,Fort Riley Precinct L S22,State Treasurer,,Republican,"Estes, Ron",0,990050
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,State Treasurer,,Democratic,"Alldritt, Carmen",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,State Treasurer,,Republican,"Estes, Ron",0,990110
+GEARY,Junction City Ward 4 Precinct 3 H65,State Treasurer,,Democratic,"Alldritt, Carmen",88,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,State Treasurer,,Republican,"Estes, Ron",60,990120
+GEARY,Junction City Ward 4 Precinct 3 H68,State Treasurer,,Democratic,"Alldritt, Carmen",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,State Treasurer,,Republican,"Estes, Ron",0,990130
+GEARY,Smokey Hill Township S22 H68,State Treasurer,,Democratic,"Alldritt, Carmen",0,990170
+GEARY,Smokey Hill Township S22 H68,State Treasurer,,Republican,"Estes, Ron",0,990170
+GEARY,Smokey Hill Township Enclave D,State Treasurer,,Democratic,"Alldritt, Carmen",0,999050
+GEARY,Smokey Hill Township Enclave D,State Treasurer,,Republican,"Estes, Ron",0,999050
+GEARY,Smokey Hill Township Enclave E,State Treasurer,,Democratic,"Alldritt, Carmen",0,999060
+GEARY,Smokey Hill Township Enclave E,State Treasurer,,Republican,"Estes, Ron",0,999060
+GEARY,Smokey Hill Township Enclave F,State Treasurer,,Democratic,"Alldritt, Carmen",0,999070
+GEARY,Smokey Hill Township Enclave F,State Treasurer,,Republican,"Estes, Ron",0,999070
+GEARY,Smokey Hill Township Enclave G,State Treasurer,,Democratic,"Alldritt, Carmen",0,999080
+GEARY,Smokey Hill Township Enclave G,State Treasurer,,Republican,"Estes, Ron",0,999080
+GEARY,Grandview Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,999090
+GEARY,Grandview Township,State Treasurer,,Republican,"Estes, Ron",0,999090
+GEARY,Junction City Ward 1 Precinct 6 Part 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,State Treasurer,,Republican,"Estes, Ron",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,State Treasurer,,Republican,"Estes, Ron",0,999130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,State Treasurer,,Republican,"Estes, Ron",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,State Treasurer,,Republican,"Estes, Ron",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,State Treasurer,,Republican,"Estes, Ron",0,999160
+GEARY,Blakely Township,United States Senate,,independent,"Orman, Greg",10,000010
+GEARY,Blakely Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+GEARY,Blakely Township,United States Senate,,Republican,"Roberts, Pat",40,000010
+GEARY,Fort Riley Milford Township Block 401,United States Senate,,independent,"Orman, Greg",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States Senate,,Libertarian,"Batson, Randall",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States Senate,,Republican,"Roberts, Pat",0,00002O
+GEARY,Fort Riley Milford Township Block 501,United States Senate,,independent,"Orman, Greg",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States Senate,,Libertarian,"Batson, Randall",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States Senate,,Republican,"Roberts, Pat",0,00002P
+GEARY,Fort Riley Milford Township Block 601,United States Senate,,independent,"Orman, Greg",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States Senate,,Libertarian,"Batson, Randall",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States Senate,,Republican,"Roberts, Pat",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,United States Senate,,independent,"Orman, Greg",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States Senate,,Libertarian,"Batson, Randall",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States Senate,,Republican,"Roberts, Pat",0,00002R
+GEARY,Wingfield Township,United States Senate,,independent,"Orman, Greg",25,000040
+GEARY,Wingfield Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+GEARY,Wingfield Township,United States Senate,,Republican,"Roberts, Pat",37,000040
+GEARY,Jackson Township,United States Senate,,independent,"Orman, Greg",13,000050
+GEARY,Jackson Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+GEARY,Jackson Township,United States Senate,,Republican,"Roberts, Pat",26,000050
+GEARY,Jefferson Township,United States Senate,,independent,"Orman, Greg",42,000060
+GEARY,Jefferson Township,United States Senate,,Libertarian,"Batson, Randall",5,000060
+GEARY,Jefferson Township,United States Senate,,Republican,"Roberts, Pat",104,000060
+GEARY,Junction City Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",61,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",9,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",52,00007A
+GEARY,Junction City Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",50,000080
+GEARY,Junction City Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",5,000080
+GEARY,Junction City Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",66,000080
+GEARY,Junction City Ward 1 Precinct 3,United States Senate,,independent,"Orman, Greg",68,000090
+GEARY,Junction City Ward 1 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",12,000090
+GEARY,Junction City Ward 1 Precinct 3,United States Senate,,Republican,"Roberts, Pat",124,000090
+GEARY,Junction City Ward 1 Precinct 4,United States Senate,,independent,"Orman, Greg",168,000100
+GEARY,Junction City Ward 1 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",10,000100
+GEARY,Junction City Ward 1 Precinct 4,United States Senate,,Republican,"Roberts, Pat",187,000100
+GEARY,Junction City Ward 1 Precinct 7,United States Senate,,independent,"Orman, Greg",151,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States Senate,,Libertarian,"Batson, Randall",14,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States Senate,,Republican,"Roberts, Pat",166,00013A
+GEARY,Junction City Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",25,000140
+GEARY,Junction City Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",8,000140
+GEARY,Junction City Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",30,000140
+GEARY,Junction City Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",82,000150
+GEARY,Junction City Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",11,000150
+GEARY,Junction City Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",96,000150
+GEARY,Junction City Ward 2 Precinct 3,United States Senate,,independent,"Orman, Greg",17,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States Senate,,Republican,"Roberts, Pat",20,00016A
+GEARY,Junction City Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",35,000180
+GEARY,Junction City Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",6,000180
+GEARY,Junction City Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",38,000180
+GEARY,Junction City Ward 3 Precinct 2,United States Senate,,independent,"Orman, Greg",88,000190
+GEARY,Junction City Ward 3 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",16,000190
+GEARY,Junction City Ward 3 Precinct 2,United States Senate,,Republican,"Roberts, Pat",114,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States Senate,,independent,"Orman, Greg",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States Senate,,Libertarian,"Batson, Randall",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States Senate,,Republican,"Roberts, Pat",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,United States Senate,,independent,"Orman, Greg",141,000230
+GEARY,Junction City Ward 4 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",12,000230
+GEARY,Junction City Ward 4 Precinct 4,United States Senate,,Republican,"Roberts, Pat",104,000230
+GEARY,Liberty Township,United States Senate,,independent,"Orman, Greg",25,000240
+GEARY,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",3,000240
+GEARY,Liberty Township,United States Senate,,Republican,"Roberts, Pat",48,000240
+GEARY,Lyon Township,United States Senate,,independent,"Orman, Greg",27,000250
+GEARY,Lyon Township,United States Senate,,Libertarian,"Batson, Randall",5,000250
+GEARY,Lyon Township,United States Senate,,Republican,"Roberts, Pat",99,000250
+GEARY,Marshall Field,United States Senate,,independent,"Orman, Greg",0,000260
+GEARY,Marshall Field,United States Senate,,Libertarian,"Batson, Randall",0,000260
+GEARY,Marshall Field,United States Senate,,Republican,"Roberts, Pat",0,000260
+GEARY,Milford Township,United States Senate,,independent,"Orman, Greg",154,000270
+GEARY,Milford Township,United States Senate,,Libertarian,"Batson, Randall",17,000270
+GEARY,Milford Township,United States Senate,,Republican,"Roberts, Pat",280,000270
+GEARY,Fort Riley Precinct A,United States Senate,,independent,"Orman, Greg",2,140010
+GEARY,Fort Riley Precinct A,United States Senate,,Libertarian,"Batson, Randall",2,140010
+GEARY,Fort Riley Precinct A,United States Senate,,Republican,"Roberts, Pat",4,140010
+GEARY,Fort Riley Precinct B,United States Senate,,independent,"Orman, Greg",14,140020
+GEARY,Fort Riley Precinct B,United States Senate,,Libertarian,"Batson, Randall",2,140020
+GEARY,Fort Riley Precinct B,United States Senate,,Republican,"Roberts, Pat",25,140020
+GEARY,Grandview Plaza,United States Senate,,independent,"Orman, Greg",53,140030
+GEARY,Grandview Plaza,United States Senate,,Libertarian,"Batson, Randall",14,140030
+GEARY,Grandview Plaza,United States Senate,,Republican,"Roberts, Pat",107,140030
+GEARY,Junction City Ward 1 Precinct 5,United States Senate,,independent,"Orman, Greg",93,140040
+GEARY,Junction City Ward 1 Precinct 5,United States Senate,,Libertarian,"Batson, Randall",13,140040
+GEARY,Junction City Ward 1 Precinct 5,United States Senate,,Republican,"Roberts, Pat",104,140040
+GEARY,Junction City Ward 1 Precinct 6,United States Senate,,independent,"Orman, Greg",120,140050
+GEARY,Junction City Ward 1 Precinct 6,United States Senate,,Libertarian,"Batson, Randall",14,140050
+GEARY,Junction City Ward 1 Precinct 6,United States Senate,,Republican,"Roberts, Pat",138,140050
+GEARY,Junction City Ward 2 Precinct 4,United States Senate,,independent,"Orman, Greg",9,140060
+GEARY,Junction City Ward 2 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",1,140060
+GEARY,Junction City Ward 2 Precinct 4,United States Senate,,Republican,"Roberts, Pat",23,140060
+GEARY,Junction City Ward 2 Precinct 5,United States Senate,,independent,"Orman, Greg",81,140070
+GEARY,Junction City Ward 2 Precinct 5,United States Senate,,Libertarian,"Batson, Randall",5,140070
+GEARY,Junction City Ward 2 Precinct 5,United States Senate,,Republican,"Roberts, Pat",113,140070
+GEARY,Junction City Ward 2 Precinct 6,United States Senate,,independent,"Orman, Greg",57,140080
+GEARY,Junction City Ward 2 Precinct 6,United States Senate,,Libertarian,"Batson, Randall",5,140080
+GEARY,Junction City Ward 2 Precinct 6,United States Senate,,Republican,"Roberts, Pat",61,140080
+GEARY,Junction City Ward 2 Precinct 7,United States Senate,,independent,"Orman, Greg",50,140090
+GEARY,Junction City Ward 2 Precinct 7,United States Senate,,Libertarian,"Batson, Randall",3,140090
+GEARY,Junction City Ward 2 Precinct 7,United States Senate,,Republican,"Roberts, Pat",79,140090
+GEARY,Junction City Ward 2 Precinct 8,United States Senate,,independent,"Orman, Greg",11,140100
+GEARY,Junction City Ward 2 Precinct 8,United States Senate,,Libertarian,"Batson, Randall",1,140100
+GEARY,Junction City Ward 2 Precinct 8,United States Senate,,Republican,"Roberts, Pat",23,140100
+GEARY,Junction City Ward 3 Precinct 3,United States Senate,,independent,"Orman, Greg",33,140110
+GEARY,Junction City Ward 3 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",1,140110
+GEARY,Junction City Ward 3 Precinct 3,United States Senate,,Republican,"Roberts, Pat",38,140110
+GEARY,Junction City Ward 3 Precinct 4,United States Senate,,independent,"Orman, Greg",14,140120
+GEARY,Junction City Ward 3 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",1,140120
+GEARY,Junction City Ward 3 Precinct 4,United States Senate,,Republican,"Roberts, Pat",19,140120
+GEARY,Milford City Precinct,United States Senate,,independent,"Orman, Greg",26,140130
+GEARY,Milford City Precinct,United States Senate,,Libertarian,"Batson, Randall",2,140130
+GEARY,Milford City Precinct,United States Senate,,Republican,"Roberts, Pat",75,140130
+GEARY,Smokey Hill Township Precinct 01,United States Senate,,independent,"Orman, Greg",0,140140
+GEARY,Smokey Hill Township Precinct 01,United States Senate,,Libertarian,"Batson, Randall",0,140140
+GEARY,Smokey Hill Township Precinct 01,United States Senate,,Republican,"Roberts, Pat",0,140140
+GEARY,Smokey Hill Township Precinct 2,United States Senate,,independent,"Orman, Greg",1,140150
+GEARY,Smokey Hill Township Precinct 2,United States Senate,,Libertarian,"Batson, Randall",0,140150
+GEARY,Smokey Hill Township Precinct 2,United States Senate,,Republican,"Roberts, Pat",3,140150
+GEARY,Smokey Hill Township Precinct 3,United States Senate,,independent,"Orman, Greg",19,140160
+GEARY,Smokey Hill Township Precinct 3,United States Senate,,Libertarian,"Batson, Randall",2,140160
+GEARY,Smokey Hill Township Precinct 3,United States Senate,,Republican,"Roberts, Pat",43,140160
+GEARY,Smokey Hill Township Precinct 4,United States Senate,,independent,"Orman, Greg",24,140170
+GEARY,Smokey Hill Township Precinct 4,United States Senate,,Libertarian,"Batson, Randall",4,140170
+GEARY,Smokey Hill Township Precinct 4,United States Senate,,Republican,"Roberts, Pat",49,140170
+GEARY,Smokey  Hill Township Precinct 05,United States Senate,,independent,"Orman, Greg",39,140180
+GEARY,Smokey  Hill Township Precinct 05,United States Senate,,Libertarian,"Batson, Randall",6,140180
+GEARY,Smokey  Hill Township Precinct 05,United States Senate,,Republican,"Roberts, Pat",109,140180
+GEARY,Smokey Hill Township Precinct 6,United States Senate,,independent,"Orman, Greg",9,140190
+GEARY,Smokey Hill Township Precinct 6,United States Senate,,Libertarian,"Batson, Randall",0,140190
+GEARY,Smokey Hill Township Precinct 6,United States Senate,,Republican,"Roberts, Pat",14,140190
+GEARY,Smokey Hill Township Enclave A,United States Senate,,independent,"Orman, Greg",0,900020
+GEARY,Smokey Hill Township Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,900020
+GEARY,Smokey Hill Township Enclave A,United States Senate,,Republican,"Roberts, Pat",0,900020
+GEARY,Smokey Hill Township Enclave B,United States Senate,,independent,"Orman, Greg",0,900030
+GEARY,Smokey Hill Township Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,900030
+GEARY,Smokey Hill Township Enclave B,United States Senate,,Republican,"Roberts, Pat",0,900030
+GEARY,Smokey Hill Township Enclave C,United States Senate,,independent,"Orman, Greg",0,900040
+GEARY,Smokey Hill Township Enclave C,United States Senate,,Libertarian,"Batson, Randall",0,900040
+GEARY,Smokey Hill Township Enclave C,United States Senate,,Republican,"Roberts, Pat",0,900040
+GEARY,Grandview Township Enclave A,United States Senate,,independent,"Orman, Greg",0,900100
+GEARY,Grandview Township Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,900100
+GEARY,Grandview Township Enclave A,United States Senate,,Republican,"Roberts, Pat",0,900100
+GEARY,Junction City Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",35,900190
+GEARY,Junction City Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",7,900190
+GEARY,Junction City Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",31,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,United States Senate,,independent,"Orman, Greg",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900200
+GEARY,Junction City Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",27,900210
+GEARY,Junction City Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",4,900210
+GEARY,Junction City Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",25,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,United States Senate,,independent,"Orman, Greg",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900220
+GEARY,Fort Riley Precinct A S17 A,United States Senate,,independent,"Orman, Greg",0,99002A
+GEARY,Fort Riley Precinct A S17 A,United States Senate,,Libertarian,"Batson, Randall",0,99002A
+GEARY,Fort Riley Precinct A S17 A,United States Senate,,Republican,"Roberts, Pat",0,99002A
+GEARY,Fort Riley Precinct C,United States Senate,,independent,"Orman, Greg",0,99002C
+GEARY,Fort Riley Precinct C,United States Senate,,Libertarian,"Batson, Randall",0,99002C
+GEARY,Fort Riley Precinct C,United States Senate,,Republican,"Roberts, Pat",0,99002C
+GEARY,Fort Riley Precinct D,United States Senate,,independent,"Orman, Greg",0,99002D
+GEARY,Fort Riley Precinct D,United States Senate,,Libertarian,"Batson, Randall",0,99002D
+GEARY,Fort Riley Precinct D,United States Senate,,Republican,"Roberts, Pat",0,99002D
+GEARY,Fort Riley Precinct E,United States Senate,,independent,"Orman, Greg",0,99002E
+GEARY,Fort Riley Precinct E,United States Senate,,Libertarian,"Batson, Randall",0,99002E
+GEARY,Fort Riley Precinct E,United States Senate,,Republican,"Roberts, Pat",0,99002E
+GEARY,Fort Riley Precinct F,United States Senate,,independent,"Orman, Greg",0,99002F
+GEARY,Fort Riley Precinct F,United States Senate,,Libertarian,"Batson, Randall",0,99002F
+GEARY,Fort Riley Precinct F,United States Senate,,Republican,"Roberts, Pat",0,99002F
+GEARY,Fort Riley Precinct G,United States Senate,,independent,"Orman, Greg",0,99002G
+GEARY,Fort Riley Precinct G,United States Senate,,Libertarian,"Batson, Randall",0,99002G
+GEARY,Fort Riley Precinct G,United States Senate,,Republican,"Roberts, Pat",0,99002G
+GEARY,Fort Riley Precinct H,United States Senate,,independent,"Orman, Greg",0,99002H
+GEARY,Fort Riley Precinct H,United States Senate,,Libertarian,"Batson, Randall",0,99002H
+GEARY,Fort Riley Precinct H,United States Senate,,Republican,"Roberts, Pat",0,99002H
+GEARY,Fort Riley Precinct I,United States Senate,,independent,"Orman, Greg",0,99002I
+GEARY,Fort Riley Precinct I,United States Senate,,Libertarian,"Batson, Randall",0,99002I
+GEARY,Fort Riley Precinct I,United States Senate,,Republican,"Roberts, Pat",0,99002I
+GEARY,Fort Riley Precinct J,United States Senate,,independent,"Orman, Greg",0,99002J
+GEARY,Fort Riley Precinct J,United States Senate,,Libertarian,"Batson, Randall",0,99002J
+GEARY,Fort Riley Precinct J,United States Senate,,Republican,"Roberts, Pat",0,99002J
+GEARY,Fort Riley Precinct K,United States Senate,,independent,"Orman, Greg",0,99002K
+GEARY,Fort Riley Precinct K,United States Senate,,Libertarian,"Batson, Randall",0,99002K
+GEARY,Fort Riley Precinct K,United States Senate,,Republican,"Roberts, Pat",0,99002K
+GEARY,Fort Riley Precinct M,United States Senate,,independent,"Orman, Greg",0,99002M
+GEARY,Fort Riley Precinct M,United States Senate,,Libertarian,"Batson, Randall",0,99002M
+GEARY,Fort Riley Precinct M,United States Senate,,Republican,"Roberts, Pat",0,99002M
+GEARY,Fort Riley Precinct N,United States Senate,,independent,"Orman, Greg",0,99002N
+GEARY,Fort Riley Precinct N,United States Senate,,Libertarian,"Batson, Randall",0,99002N
+GEARY,Fort Riley Precinct N,United States Senate,,Republican,"Roberts, Pat",0,99002N
+GEARY,Fort Riley Precinct A S22,United States Senate,,independent,"Orman, Greg",0,990030
+GEARY,Fort Riley Precinct A S22,United States Senate,,Libertarian,"Batson, Randall",0,990030
+GEARY,Fort Riley Precinct A S22,United States Senate,,Republican,"Roberts, Pat",0,990030
+GEARY,Fort Riley Precinct L S17,United States Senate,,independent,"Orman, Greg",0,990040
+GEARY,Fort Riley Precinct L S17,United States Senate,,Libertarian,"Batson, Randall",0,990040
+GEARY,Fort Riley Precinct L S17,United States Senate,,Republican,"Roberts, Pat",0,990040
+GEARY,Fort Riley Precinct L S22,United States Senate,,independent,"Orman, Greg",0,990050
+GEARY,Fort Riley Precinct L S22,United States Senate,,Libertarian,"Batson, Randall",0,990050
+GEARY,Fort Riley Precinct L S22,United States Senate,,Republican,"Roberts, Pat",0,990050
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,United States Senate,,independent,"Orman, Greg",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,United States Senate,,Libertarian,"Batson, Randall",0,990110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,United States Senate,,Republican,"Roberts, Pat",0,990110
+GEARY,Junction City Ward 4 Precinct 3 H65,United States Senate,,independent,"Orman, Greg",75,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,United States Senate,,Libertarian,"Batson, Randall",8,990120
+GEARY,Junction City Ward 4 Precinct 3 H65,United States Senate,,Republican,"Roberts, Pat",65,990120
+GEARY,Junction City Ward 4 Precinct 3 H68,United States Senate,,independent,"Orman, Greg",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,United States Senate,,Libertarian,"Batson, Randall",0,990130
+GEARY,Junction City Ward 4 Precinct 3 H68,United States Senate,,Republican,"Roberts, Pat",0,990130
+GEARY,Smokey Hill Township S22 H68,United States Senate,,independent,"Orman, Greg",0,990170
+GEARY,Smokey Hill Township S22 H68,United States Senate,,Libertarian,"Batson, Randall",0,990170
+GEARY,Smokey Hill Township S22 H68,United States Senate,,Republican,"Roberts, Pat",0,990170
+GEARY,Smokey Hill Township Enclave D,United States Senate,,independent,"Orman, Greg",0,999050
+GEARY,Smokey Hill Township Enclave D,United States Senate,,Libertarian,"Batson, Randall",0,999050
+GEARY,Smokey Hill Township Enclave D,United States Senate,,Republican,"Roberts, Pat",0,999050
+GEARY,Smokey Hill Township Enclave E,United States Senate,,independent,"Orman, Greg",0,999060
+GEARY,Smokey Hill Township Enclave E,United States Senate,,Libertarian,"Batson, Randall",0,999060
+GEARY,Smokey Hill Township Enclave E,United States Senate,,Republican,"Roberts, Pat",0,999060
+GEARY,Smokey Hill Township Enclave F,United States Senate,,independent,"Orman, Greg",0,999070
+GEARY,Smokey Hill Township Enclave F,United States Senate,,Libertarian,"Batson, Randall",0,999070
+GEARY,Smokey Hill Township Enclave F,United States Senate,,Republican,"Roberts, Pat",0,999070
+GEARY,Smokey Hill Township Enclave G,United States Senate,,independent,"Orman, Greg",0,999080
+GEARY,Smokey Hill Township Enclave G,United States Senate,,Libertarian,"Batson, Randall",0,999080
+GEARY,Smokey Hill Township Enclave G,United States Senate,,Republican,"Roberts, Pat",0,999080
+GEARY,Grandview Township,United States Senate,,independent,"Orman, Greg",0,999090
+GEARY,Grandview Township,United States Senate,,Libertarian,"Batson, Randall",0,999090
+GEARY,Grandview Township,United States Senate,,Republican,"Roberts, Pat",0,999090
+GEARY,Junction City Ward 1 Precinct 6 Part 1,United States Senate,,independent,"Orman, Greg",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,United States Senate,,Libertarian,"Batson, Randall",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,United States Senate,,Republican,"Roberts, Pat",0,999120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,United States Senate,,independent,"Orman, Greg",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,United States Senate,,Libertarian,"Batson, Randall",0,999130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,United States Senate,,Republican,"Roberts, Pat",0,999130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,United States Senate,,independent,"Orman, Greg",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,United States Senate,,Libertarian,"Batson, Randall",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,United States Senate,,Republican,"Roberts, Pat",0,999140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,United States Senate,,independent,"Orman, Greg",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,United States Senate,,Libertarian,"Batson, Randall",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,United States Senate,,Republican,"Roberts, Pat",0,999150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,United States Senate,,independent,"Orman, Greg",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,United States Senate,,Libertarian,"Batson, Randall",0,999160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,United States Senate,,Republican,"Roberts, Pat",0,999160

--- a/2014/20141104__ks__general__gove__precinct.csv
+++ b/2014/20141104__ks__general__gove__precinct.csv
@@ -1,120 +1,154 @@
-county,precinct,office,district,party,candidate,votes
-Gove,Baker,Attorney General,,D,A J Kotich,73
-Gove,Grainfield,Attorney General,,D,A J Kotich,37
-Gove,Grinnell,Attorney General,,D,A J Kotich,30
-Gove,Gove,Attorney General,,D,A J Kotich,12
-Gove,Lewis,Attorney General,,D,A J Kotich,0
-Gove,Jerome,Attorney General,,D,A J Kotich,5
-Gove,Larrabee,Attorney General,,D,A J Kotich,1
-Gove,Baker,Attorney General,,R,Derek Schmidt,388
-Gove,Grainfield,Attorney General,,R,Derek Schmidt,178
-Gove,Grinnell,Attorney General,,R,Derek Schmidt,145
-Gove,Gove,Attorney General,,R,Derek Schmidt,63
-Gove,Lewis,Attorney General,,R,Derek Schmidt,2
-Gove,Jerome,Attorney General,,R,Derek Schmidt,41
-Gove,Larrabee,Attorney General,,R,Derek Schmidt,19
-Gove,Baker,U.S. House,1,D,James Sherow,103
-Gove,Grainfield,U.S. House,1,D,James Sherow,35
-Gove,Grinnell,U.S. House,1,D,James Sherow,31
-Gove,Gove,U.S. House,1,D,James Sherow,21
-Gove,Lewis,U.S. House,1,D,James Sherow,0
-Gove,Jerome,U.S. House,1,D,James Sherow,10
-Gove,Larrabee,U.S. House,1,D,James Sherow,1
-Gove,Baker,U.S. House,1,R,Tim Huelskamp,366
-Gove,Grainfield,U.S. House,1,R,Tim Huelskamp,187
-Gove,Grinnell,U.S. House,1,R,Tim Huelskamp,146
-Gove,Gove,U.S. House,1,R,Tim Huelskamp,54
-Gove,Lewis,U.S. House,1,R,Tim Huelskamp,2
-Gove,Jerome,U.S. House,1,R,Tim Huelskamp,35
-Gove,Larrabee,U.S. House,1,R,Tim Huelskamp,20
-Gove,Baker,Governor,,L,Keen Umbehr,17
-Gove,Grainfield,Governor,,L,Keen Umbehr,4
-Gove,Grinnell,Governor,,L,Keen Umbehr,6
-Gove,Gove,Governor,,L,Keen Umbehr,4
-Gove,Lewis,Governor,,L,Keen Umbehr,0
-Gove,Jerome,Governor,,L,Keen Umbehr,0
-Gove,Larrabee,Governor,,L,Keen Umbehr,1
-Gove,Baker,Governor,,D,Paul Davis,138
-Gove,Grainfield,Governor,,D,Paul Davis,57
-Gove,Grinnell,Governor,,D,Paul Davis,41
-Gove,Gove,Governor,,D,Paul Davis,22
-Gove,Lewis,Governor,,D,Paul Davis,0
-Gove,Jerome,Governor,,D,Paul Davis,8
-Gove,Larrabee,Governor,,D,Paul Davis,1
-Gove,Baker,Governor,,R,Sam Brownback,320
-Gove,Grainfield,Governor,,R,Sam Brownback,169
-Gove,Grinnell,Governor,,R,Sam Brownback,132
-Gove,Gove,Governor,,R,Sam Brownback,50
-Gove,Lewis,Governor,,R,Sam Brownback,2
-Gove,Jerome,Governor,,R,Sam Brownback,38
-Gove,Larrabee,Governor,,R,Sam Brownback,19
-Gove,Baker,Insurance Commissioner,,D,Dennis Anderson,87
-Gove,Grainfield,Insurance Commissioner,,D,Dennis Anderson,50
-Gove,Grinnell,Insurance Commissioner,,D,Dennis Anderson,37
-Gove,Gove,Insurance Commissioner,,D,Dennis Anderson,14
-Gove,Lewis,Insurance Commissioner,,D,Dennis Anderson,0
-Gove,Jerome,Insurance Commissioner,,D,Dennis Anderson,3
-Gove,Larrabee,Insurance Commissioner,,D,Dennis Anderson,0
-Gove,Baker,Insurance Commissioner,,R,Ken Selzer,362
-Gove,Grainfield,Insurance Commissioner,,R,Ken Selzer,154
-Gove,Grinnell,Insurance Commissioner,,R,Ken Selzer,134
-Gove,Gove,Insurance Commissioner,,R,Ken Selzer,56
-Gove,Lewis,Insurance Commissioner,,R,Ken Selzer,2
-Gove,Jerome,Insurance Commissioner,,R,Ken Selzer,39
-Gove,Larrabee,Insurance Commissioner,,R,Ken Selzer,18
-Gove,Baker,State House,118,R,Don Hineman,442
-Gove,Grainfield,State House,118,R,Don Hineman,205
-Gove,Grinnell,State House,118,R,Don Hineman,168
-Gove,Gove,State House,118,R,Don Hineman,71
-Gove,Lewis,State House,118,R,Don Hineman,2
-Gove,Jerome,State House,118,R,Don Hineman,45
-Gove,Larrabee,State House,118,R,Don Hineman,18
-Gove,Baker,Secretary of State,,D,Jean Schodorf,97
-Gove,Grainfield,Secretary of State,,D,Jean Schodorf,51
-Gove,Grinnell,Secretary of State,,D,Jean Schodorf,34
-Gove,Gove,Secretary of State,,D,Jean Schodorf,21
-Gove,Lewis,Secretary of State,,D,Jean Schodorf,0
-Gove,Jerome,Secretary of State,,D,Jean Schodorf,9
-Gove,Larrabee,Secretary of State,,D,Jean Schodorf,1
-Gove,Baker,Secretary of State,,R,Kris Kobach,369
-Gove,Grainfield,Secretary of State,,R,Kris Kobach,167
-Gove,Grinnell,Secretary of State,,R,Kris Kobach,141
-Gove,Gove,Secretary of State,,R,Kris Kobach,54
-Gove,Lewis,Secretary of State,,R,Kris Kobach,2
-Gove,Jerome,Secretary of State,,R,Kris Kobach,37
-Gove,Larrabee,Secretary of State,,R,Kris Kobach,20
-Gove,Baker,State Treasurer,,D,Carmen Alldritt,68
-Gove,Grainfield,State Treasurer,,D,Carmen Alldritt,34
-Gove,Grinnell,State Treasurer,,D,Carmen Alldritt,22
-Gove,Gove,State Treasurer,,D,Carmen Alldritt,10
-Gove,Lewis,State Treasurer,,D,Carmen Alldritt,0
-Gove,Jerome,State Treasurer,,D,Carmen Alldritt,3
-Gove,Larrabee,State Treasurer,,D,Carmen Alldritt,0
-Gove,Baker,State Treasurer,,R,Ron Estes,388
-Gove,Grainfield,State Treasurer,,R,Ron Estes,175
-Gove,Grinnell,State Treasurer,,R,Ron Estes,151
-Gove,Gove,State Treasurer,,R,Ron Estes,64
-Gove,Lewis,State Treasurer,,R,Ron Estes,2
-Gove,Jerome,State Treasurer,,R,Ron Estes,43
-Gove,Larrabee,State Treasurer,,R,Ron Estes,20
-Gove,Baker,U.S. Senate,,I,Greg Orman,110
-Gove,Grainfield,U.S. Senate,,I,Greg Orman,47
-Gove,Grinnell,U.S. Senate,,I,Greg Orman,33
-Gove,Gove,U.S. Senate,,I,Greg Orman,14
-Gove,Lewis,U.S. Senate,,I,Greg Orman,0
-Gove,Jerome,U.S. Senate,,I,Greg Orman,6
-Gove,Larrabee,U.S. Senate,,I,Greg Orman,2
-Gove,Baker,U.S. Senate,,R,Pat Roberts,344
-Gove,Grainfield,U.S. Senate,,R,Pat Roberts,172
-Gove,Grinnell,U.S. Senate,,R,Pat Roberts,135
-Gove,Gove,U.S. Senate,,R,Pat Roberts,55
-Gove,Lewis,U.S. Senate,,R,Pat Roberts,2
-Gove,Jerome,U.S. Senate,,R,Pat Roberts,40
-Gove,Larrabee,U.S. Senate,,R,Pat Roberts,18
-Gove,Baker,U.S. Senate,,L,Randall Batson,20
-Gove,Grainfield,U.S. Senate,,L,Randall Batson,7
-Gove,Grinnell,U.S. Senate,,L,Randall Batson,10
-Gove,Gove,U.S. Senate,,L,Randall Batson,4
-Gove,Lewis,U.S. Senate,,L,Randall Batson,0
-Gove,Jerome,U.S. Senate,,L,Randall Batson,0
-Gove,Larrabee,U.S. Senate,,L,Randall Batson,1
+county,precinct,office,district,party,candidate,votes,vtd
+GOVE,Baker Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",149,000010
+GOVE,Baker Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000010
+GOVE,Baker Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",351,000010
+GOVE,Gaeland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000020
+GOVE,Gaeland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+GOVE,Gaeland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000020
+GOVE,Gove Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000030
+GOVE,Gove Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000030
+GOVE,Gove Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000030
+GOVE,Grainfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",60,000040
+GOVE,Grainfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000040
+GOVE,Grainfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",196,000040
+GOVE,Grinnell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000050
+GOVE,Grinnell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000050
+GOVE,Grinnell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",142,000050
+GOVE,Jerome Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000060
+GOVE,Jerome Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+GOVE,Jerome Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000060
+GOVE,Larrabee Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000070
+GOVE,Larrabee Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+GOVE,Larrabee Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000070
+GOVE,Lewis Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000080
+GOVE,Lewis Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+GOVE,Lewis Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000080
+GOVE,Payne Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000090
+GOVE,Payne Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+GOVE,Payne Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000090
+GOVE,Baker Township,Kansas House of Representatives,118,Republican,"Hineman, Don",484,000010
+GOVE,Gaeland Township,Kansas House of Representatives,118,Republican,"Hineman, Don",0,000020
+GOVE,Gove Township,Kansas House of Representatives,118,Republican,"Hineman, Don",77,000030
+GOVE,Grainfield Township,Kansas House of Representatives,118,Republican,"Hineman, Don",238,000040
+GOVE,Grinnell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",179,000050
+GOVE,Jerome Township,Kansas House of Representatives,118,Republican,"Hineman, Don",55,000060
+GOVE,Larrabee Township,Kansas House of Representatives,118,Republican,"Hineman, Don",23,000070
+GOVE,Lewis Township,Kansas House of Representatives,118,Republican,"Hineman, Don",3,000080
+GOVE,Payne Township,Kansas House of Representatives,118,Republican,"Hineman, Don",0,000090
+GOVE,Baker Township,United States House of Representatives,1,Democratic,"Sherow, James E.",110,000010
+GOVE,Baker Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",402,000010
+GOVE,Gaeland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000020
+GOVE,Gaeland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000020
+GOVE,Gove Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000030
+GOVE,Gove Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000030
+GOVE,Grainfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",38,000040
+GOVE,Grainfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",205,000040
+GOVE,Grinnell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000050
+GOVE,Grinnell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000050
+GOVE,Jerome Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000060
+GOVE,Jerome Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000060
+GOVE,Larrabee Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000070
+GOVE,Larrabee Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000070
+GOVE,Lewis Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000080
+GOVE,Lewis Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000080
+GOVE,Payne Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000090
+GOVE,Payne Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000090
+GOVE,Baker Township,Attorney General,,Democratic,"Kotich, A.J.",85,000010
+GOVE,Baker Township,Attorney General,,Republican,"Schmidt, Derek",428,000010
+GOVE,Gaeland Township,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+GOVE,Gaeland Township,Attorney General,,Republican,"Schmidt, Derek",0,000020
+GOVE,Gove Township,Attorney General,,Democratic,"Kotich, A.J.",12,000030
+GOVE,Gove Township,Attorney General,,Republican,"Schmidt, Derek",69,000030
+GOVE,Grainfield Township,Attorney General,,Democratic,"Kotich, A.J.",37,000040
+GOVE,Grainfield Township,Attorney General,,Republican,"Schmidt, Derek",204,000040
+GOVE,Grinnell Township,Attorney General,,Democratic,"Kotich, A.J.",30,000050
+GOVE,Grinnell Township,Attorney General,,Republican,"Schmidt, Derek",155,000050
+GOVE,Jerome Township,Attorney General,,Democratic,"Kotich, A.J.",5,000060
+GOVE,Jerome Township,Attorney General,,Republican,"Schmidt, Derek",48,000060
+GOVE,Larrabee Township,Attorney General,,Democratic,"Kotich, A.J.",1,000070
+GOVE,Larrabee Township,Attorney General,,Republican,"Schmidt, Derek",28,000070
+GOVE,Lewis Township,Attorney General,,Democratic,"Kotich, A.J.",0,000080
+GOVE,Lewis Township,Attorney General,,Republican,"Schmidt, Derek",2,000080
+GOVE,Payne Township,Attorney General,,Democratic,"Kotich, A.J.",0,000090
+GOVE,Payne Township,Attorney General,,Republican,"Schmidt, Derek",0,000090
+GOVE,Baker Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,000010
+GOVE,Baker Township,Commissioner of Insurance,,Republican,"Selzer, Ken",398,000010
+GOVE,Gaeland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000020
+GOVE,Gaeland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000020
+GOVE,Gove Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000030
+GOVE,Gove Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000030
+GOVE,Grainfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,000040
+GOVE,Grainfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",168,000040
+GOVE,Grinnell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000050
+GOVE,Grinnell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",146,000050
+GOVE,Jerome Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000060
+GOVE,Jerome Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000060
+GOVE,Larrabee Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000070
+GOVE,Larrabee Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000070
+GOVE,Lewis Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000080
+GOVE,Lewis Township,Commissioner of Insurance,,Republican,"Selzer, Ken",3,000080
+GOVE,Payne Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000090
+GOVE,Payne Township,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000090
+GOVE,Baker Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,000010
+GOVE,Baker Township,Secretary of State,,Republican,"Kobach, Kris",404,000010
+GOVE,Gaeland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+GOVE,Gaeland Township,Secretary of State,,Republican,"Kobach, Kris",0,000020
+GOVE,Gove Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000030
+GOVE,Gove Township,Secretary of State,,Republican,"Kobach, Kris",60,000030
+GOVE,Grainfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000040
+GOVE,Grainfield Township,Secretary of State,,Republican,"Kobach, Kris",200,000040
+GOVE,Grinnell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000050
+GOVE,Grinnell Township,Secretary of State,,Republican,"Kobach, Kris",145,000050
+GOVE,Jerome Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000060
+GOVE,Jerome Township,Secretary of State,,Republican,"Kobach, Kris",41,000060
+GOVE,Larrabee Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000070
+GOVE,Larrabee Township,Secretary of State,,Republican,"Kobach, Kris",27,000070
+GOVE,Lewis Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000080
+GOVE,Lewis Township,Secretary of State,,Republican,"Kobach, Kris",2,000080
+GOVE,Payne Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000090
+GOVE,Payne Township,Secretary of State,,Republican,"Kobach, Kris",0,000090
+GOVE,Baker Township,State Treasurer,,Democratic,"Alldritt, Carmen",72,000010
+GOVE,Baker Township,State Treasurer,,Republican,"Estes, Ron",426,000010
+GOVE,Gaeland Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+GOVE,Gaeland Township,State Treasurer,,Republican,"Estes, Ron",0,000020
+GOVE,Gove Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000030
+GOVE,Gove Township,State Treasurer,,Republican,"Estes, Ron",70,000030
+GOVE,Grainfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",42,000040
+GOVE,Grainfield Township,State Treasurer,,Republican,"Estes, Ron",200,000040
+GOVE,Grinnell Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000050
+GOVE,Grinnell Township,State Treasurer,,Republican,"Estes, Ron",160,000050
+GOVE,Jerome Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000060
+GOVE,Jerome Township,State Treasurer,,Republican,"Estes, Ron",49,000060
+GOVE,Larrabee Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000070
+GOVE,Larrabee Township,State Treasurer,,Republican,"Estes, Ron",28,000070
+GOVE,Lewis Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000080
+GOVE,Lewis Township,State Treasurer,,Republican,"Estes, Ron",3,000080
+GOVE,Payne Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000090
+GOVE,Payne Township,State Treasurer,,Republican,"Estes, Ron",0,000090
+GOVE,Baker Township,United States Senate,,independent,"Orman, Greg",119,000010
+GOVE,Baker Township,United States Senate,,Libertarian,"Batson, Randall",20,000010
+GOVE,Baker Township,United States Senate,,Republican,"Roberts, Pat",378,000010
+GOVE,Gaeland Township,United States Senate,,independent,"Orman, Greg",0,000020
+GOVE,Gaeland Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+GOVE,Gaeland Township,United States Senate,,Republican,"Roberts, Pat",0,000020
+GOVE,Gove Township,United States Senate,,independent,"Orman, Greg",14,000030
+GOVE,Gove Township,United States Senate,,Libertarian,"Batson, Randall",4,000030
+GOVE,Gove Township,United States Senate,,Republican,"Roberts, Pat",64,000030
+GOVE,Grainfield Township,United States Senate,,independent,"Orman, Greg",50,000040
+GOVE,Grainfield Township,United States Senate,,Libertarian,"Batson, Randall",10,000040
+GOVE,Grainfield Township,United States Senate,,Republican,"Roberts, Pat",197,000040
+GOVE,Grinnell Township,United States Senate,,independent,"Orman, Greg",34,000050
+GOVE,Grinnell Township,United States Senate,,Libertarian,"Batson, Randall",10,000050
+GOVE,Grinnell Township,United States Senate,,Republican,"Roberts, Pat",144,000050
+GOVE,Jerome Township,United States Senate,,independent,"Orman, Greg",9,000060
+GOVE,Jerome Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+GOVE,Jerome Township,United States Senate,,Republican,"Roberts, Pat",47,000060
+GOVE,Larrabee Township,United States Senate,,independent,"Orman, Greg",2,000070
+GOVE,Larrabee Township,United States Senate,,Libertarian,"Batson, Randall",1,000070
+GOVE,Larrabee Township,United States Senate,,Republican,"Roberts, Pat",24,000070
+GOVE,Lewis Township,United States Senate,,independent,"Orman, Greg",0,000080
+GOVE,Lewis Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+GOVE,Lewis Township,United States Senate,,Republican,"Roberts, Pat",3,000080
+GOVE,Payne Township,United States Senate,,independent,"Orman, Greg",0,000090
+GOVE,Payne Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+GOVE,Payne Township,United States Senate,,Republican,"Roberts, Pat",0,000090

--- a/2014/20141104__ks__general__graham__precinct.csv
+++ b/2014/20141104__ks__general__graham__precinct.csv
@@ -1,333 +1,358 @@
-county,precinct,office,district,party,candidate,votes,,
-Graham,Allodium Township,U.S. Senate,,R,Pat Roberts,15,,
-Graham,Bryant Township,U.S. Senate,,R,Pat Roberts,27,,
-Graham,Gettysburg Township,U.S. Senate,,R,Pat Roberts,34,,
-Graham,Graham Township,U.S. Senate,,R,Pat Roberts,20,,
-Graham,Happy Township,U.S. Senate,,R,Pat Roberts,25,,
-Graham,Hill City Precinct 1 110,U.S. Senate,,R,Pat Roberts,53,,
-Graham,Hill City twp 71 118,U.S. Senate,,R,Pat Roberts,7,,
-Graham,Hill City Precinct 2 110,U.S. Senate,,R,Pat Roberts,259,,
-Graham,Hill City twp 72 118,U.S. Senate,,R,Pat Roberts,5,,
-Graham,Hill City Precinct 3 110,U.S. Senate,,R,Pat Roberts,96,,
-Graham,Hill City twp 73 118,U.S. Senate,,R,Pat Roberts,17,,
-Graham,Indiana Township,U.S. Senate,,R,Pat Roberts,11,,
-Graham,Millbrook Township,U.S. Senate,,R,Pat Roberts,52,,
-Graham,Morlan Township,U.S. Senate,,R,Pat Roberts,28,,
-Graham,Nicodemus Township  110,U.S. Senate,,R,Pat Roberts,4,,
-Graham,Nicodemus Township 118,U.S. Senate,,R,Pat Roberts,4,,
-Graham,Pioneer Township,U.S. Senate,,R,Pat Roberts,16,,
-Graham,Solomon Township,U.S. Senate,,R,Pat Roberts,72,,
-Graham,Wildhorse Township,U.S. Senate,,R,Pat Roberts,54,,
-Graham,Allodium Township,U.S. Senate,,I,Greg Orman,0,,
-Graham,Bryant Township,U.S. Senate,,I,Greg Orman,5,,
-Graham,Gettysburg Township,U.S. Senate,,I,Greg Orman,5,,
-Graham,Graham Township,U.S. Senate,,I,Greg Orman,6,,
-Graham,Happy Township,U.S. Senate,,I,Greg Orman,6,,
-Graham,Hill City Precinct 1 110,U.S. Senate,,I,Greg Orman,27,,
-Graham,Hill City twp 71 118,U.S. Senate,,I,Greg Orman,0,,
-Graham,Hill City Precinct 2 110,U.S. Senate,,I,Greg Orman,130,,
-Graham,Hill City twp 72 118,U.S. Senate,,I,Greg Orman,2,,
-Graham,Hill City Precinct 3 110,U.S. Senate,,I,Greg Orman,36,,
-Graham,Hill City twp 73 118,U.S. Senate,,I,Greg Orman,7,,
-Graham,Indiana Township,U.S. Senate,,I,Greg Orman,4,,
-Graham,Millbrook Township,U.S. Senate,,I,Greg Orman,14,,
-Graham,Morlan Township,U.S. Senate,,I,Greg Orman,0,,
-Graham,Nicodemus Township  110,U.S. Senate,,I,Greg Orman,2,,
-Graham,Nicodemus Township 118,U.S. Senate,,I,Greg Orman,4,,
-Graham,Pioneer Township,U.S. Senate,,I,Greg Orman,3,,
-Graham,Solomon Township,U.S. Senate,,I,Greg Orman,14,,
-Graham,Wildhorse Township,U.S. Senate,,I,Greg Orman,33,,
-Graham,Allodium Township,U.S. Senate,,L,Randall Batson,1,,
-Graham,Bryant Township,U.S. Senate,,L,Randall Batson,1,,
-Graham,Gettysburg Township,U.S. Senate,,L,Randall Batson,0,,
-Graham,Graham Township,U.S. Senate,,L,Randall Batson,0,,
-Graham,Happy Township,U.S. Senate,,L,Randall Batson,0,,
-Graham,Hill City Precinct 1 110,U.S. Senate,,L,Randall Batson,6,,
-Graham,Hill City twp 71 118,U.S. Senate,,L,Randall Batson,0,,
-Graham,Hill City Precinct 2 110,U.S. Senate,,L,Randall Batson,11,,
-Graham,Hill City twp 72 118,U.S. Senate,,L,Randall Batson,2,,
-Graham,Hill City Precinct 3 110,U.S. Senate,,L,Randall Batson,7,,
-Graham,Hill City twp 73 118,U.S. Senate,,L,Randall Batson,1,,
-Graham,Indiana Township,U.S. Senate,,L,Randall Batson,1,,
-Graham,Millbrook Township,U.S. Senate,,L,Randall Batson,1,,
-Graham,Morlan Township,U.S. Senate,,L,Randall Batson,1,,
-Graham,Nicodemus Township  110,U.S. Senate,,L,Randall Batson,0,,
-Graham,Nicodemus Township 118,U.S. Senate,,L,Randall Batson,1,,
-Graham,Pioneer Township,U.S. Senate,,L,Randall Batson,0,,
-Graham,Solomon Township,U.S. Senate,,L,Randall Batson,5,,
-Graham,Wildhorse Township,U.S. Senate,,L,Randall Batson,8,,
-Graham,Allodium Township,U.S. House,1,R,Tim Huelskamp,15,,
-Graham,Bryant Township,U.S. House,1,R,Tim Huelskamp,29,,
-Graham,Gettysburg Township,U.S. House,1,R,Tim Huelskamp,35,,
-Graham,Graham Township,U.S. House,1,R,Tim Huelskamp,20,,
-Graham,Happy Township,U.S. House,1,R,Tim Huelskamp,27,,
-Graham,Hill City Precinct 1 110,U.S. House,1,R,Tim Huelskamp,58,,
-Graham,Hill City twp 71 118,U.S. House,1,R,Tim Huelskamp,7,,
-Graham,Hill City Precinct 2 110,U.S. House,1,R,Tim Huelskamp,281,,
-Graham,Hill City twp 72 118,U.S. House,1,R,Tim Huelskamp,5,,
-Graham,Hill City Precinct 3 110,U.S. House,1,R,Tim Huelskamp,99,,
-Graham,Hill City twp 73 118,U.S. House,1,R,Tim Huelskamp,18,,
-Graham,Indiana Township,U.S. House,1,R,Tim Huelskamp,14,,
-Graham,Millbrook Township,U.S. House,1,R,Tim Huelskamp,58,,
-Graham,Morlan Township,U.S. House,1,R,Tim Huelskamp,28,,
-Graham,Nicodemus Township  110,U.S. House,1,R,Tim Huelskamp,3,,
-Graham,Nicodemus Township 118,U.S. House,1,R,Tim Huelskamp,3,,
-Graham,Pioneer Township,U.S. House,1,R,Tim Huelskamp,17,,
-Graham,Solomon Township,U.S. House,1,R,Tim Huelskamp,79,,
-Graham,Wildhorse Township,U.S. House,1,R,Tim Huelskamp,58,,
-Graham,Allodium Township,U.S. House,1,D,James Sherow,2,,
-Graham,Bryant Township,U.S. House,1,D,James Sherow,4,,
-Graham,Gettysburg Township,U.S. House,1,D,James Sherow,4,,
-Graham,Graham Township,U.S. House,1,D,James Sherow,6,,
-Graham,Happy Township,U.S. House,1,D,James Sherow,4,,
-Graham,Hill City Precinct 1 110,U.S. House,1,D,James Sherow,28,,
-Graham,Hill City twp 71 118,U.S. House,1,D,James Sherow,0,,
-Graham,Hill City Precinct 2 110,U.S. House,1,D,James Sherow,114,,
-Graham,Hill City twp 72 118,U.S. House,1,D,James Sherow,3,,
-Graham,Hill City Precinct 3 110,U.S. House,1,D,James Sherow,40,,
-Graham,Hill City twp 73 118,U.S. House,1,D,James Sherow,6,,
-Graham,Indiana Township,U.S. House,1,D,James Sherow,2,,
-Graham,Millbrook Township,U.S. House,1,D,James Sherow,8,,
-Graham,Morlan Township,U.S. House,1,D,James Sherow,1,,
-Graham,Nicodemus Township  110,U.S. House,1,D,James Sherow,3,,
-Graham,Nicodemus Township 118,U.S. House,1,D,James Sherow,8,,
-Graham,Pioneer Township,U.S. House,1,D,James Sherow,1,,
-Graham,Solomon Township,U.S. House,1,D,James Sherow,11,,
-Graham,Wildhorse Township,U.S. House,1,D,James Sherow,36,,
-Graham,Allodium Township,Governor,,R ,Sam Brownback,15,,
-Graham,Bryant Township,Governor,,R ,Sam Brownback,29,,
-Graham,Gettysburg Township,Governor,,R ,Sam Brownback,26,,
-Graham,Graham Township,Governor,,R ,Sam Brownback,17,,
-Graham,Happy Township,Governor,,R ,Sam Brownback,24,,
-Graham,Hill City Precinct 1 110,Governor,,R ,Sam Brownback,46,,
-Graham,Hill City twp 71 118,Governor,,R ,Sam Brownback,7,,
-Graham,Hill City Precinct 2 110,Governor,,R ,Sam Brownback,244,,
-Graham,Hill City twp 72 118,Governor,,R ,Sam Brownback,3,,
-Graham,Hill City Precinct 3 110,Governor,,R ,Sam Brownback,92,,
-Graham,Hill City twp 73 118,Governor,,R ,Sam Brownback,15,,
-Graham,Indiana Township,Governor,,R ,Sam Brownback,10,,
-Graham,Millbrook Township,Governor,,R ,Sam Brownback,51,,
-Graham,Morlan Township,Governor,,R ,Sam Brownback,28,,
-Graham,Nicodemus Township  110,Governor,,R ,Sam Brownback,6,,
-Graham,Nicodemus Township 118,Governor,,R ,Sam Brownback,3,,
-Graham,Pioneer Township,Governor,,R ,Sam Brownback,13,,
-Graham,Solomon Township,Governor,,R ,Sam Brownback,71,,
-Graham,Wildhorse Township,Governor,,R ,Sam Brownback,43,,
-Graham,Allodium Township,Governor,,D,Paul Davis,0,,
-Graham,Bryant Township,Governor,,D,Paul Davis,4,,
-Graham,Gettysburg Township,Governor,,D,Paul Davis,10,,
-Graham,Graham Township,Governor,,D,Paul Davis,8,,
-Graham,Happy Township,Governor,,D,Paul Davis,7,,
-Graham,Hill City Precinct 1 110,Governor,,D,Paul Davis,34,,
-Graham,Hill City twp 71 118,Governor,,D,Paul Davis,0,,
-Graham,Hill City Precinct 2 110,Governor,,D,Paul Davis,155,,
-Graham,Hill City twp 72 118,Governor,,D,Paul Davis,4,,
-Graham,Hill City Precinct 3 110,Governor,,D,Paul Davis,44,,
-Graham,Hill City twp 73 118,Governor,,D,Paul Davis,10,,
-Graham,Indiana Township,Governor,,D,Paul Davis,5,,
-Graham,Millbrook Township,Governor,,D,Paul Davis,12,,
-Graham,Morlan Township,Governor,,D,Paul Davis,1,,
-Graham,Nicodemus Township  110,Governor,,D,Paul Davis,1,,
-Graham,Nicodemus Township 118,Governor,,D,Paul Davis,6,,
-Graham,Pioneer Township,Governor,,D,Paul Davis,4,,
-Graham,Solomon Township,Governor,,D,Paul Davis,20,,
-Graham,Wildhorse Township,Governor,,D,Paul Davis,40,,
-Graham,Allodium Township,Governor,,L,Keen Umbehr,1,,
-Graham,Bryant Township,Governor,,L,Keen Umbehr,0,,
-Graham,Gettysburg Township,Governor,,L,Keen Umbehr,3,,
-Graham,Graham Township,Governor,,L,Keen Umbehr,1,,
-Graham,Happy Township,Governor,,L,Keen Umbehr,0,,
-Graham,Hill City Precinct 1 110,Governor,,L,Keen Umbehr,5,,
-Graham,Hill City twp 71 118,Governor,,L,Keen Umbehr,0,,
-Graham,Hill City Precinct 2 110,Governor,,L,Keen Umbehr,10,,
-Graham,Hill City twp 72 118,Governor,,L,Keen Umbehr,2,,
-Graham,Hill City Precinct 3 110,Governor,,L,Keen Umbehr,8,,
-Graham,Hill City twp 73 118,Governor,,L,Keen Umbehr,1,,
-Graham,Indiana Township,Governor,,L,Keen Umbehr,1,,
-Graham,Millbrook Township,Governor,,L,Keen Umbehr,4,,
-Graham,Morlan Township,Governor,,L,Keen Umbehr,0,,
-Graham,Nicodemus Township  110,Governor,,L,Keen Umbehr,0,,
-Graham,Nicodemus Township 118,Governor,,L,Keen Umbehr,2,,
-Graham,Pioneer Township,Governor,,L,Keen Umbehr,2,,
-Graham,Solomon Township,Governor,,L,Keen Umbehr,4,,
-Graham,Wildhorse Township,Governor,,L,Keen Umbehr,13,,
-Graham,Allodium Township,Secretary of State,,R,Kris Kobach,14,,
-Graham,Bryant Township,Secretary of State,,R,Kris Kobach,27,,
-Graham,Gettysburg Township,Secretary of State,,R,Kris Kobach,28,,
-Graham,Graham Township,Secretary of State,,R,Kris Kobach,19,,
-Graham,Happy Township,Secretary of State,,R,Kris Kobach,26,,
-Graham,Hill City Precinct 1 110,Secretary of State,,R,Kris Kobach,61,,
-Graham,Hill City twp 71 118,Secretary of State,,R,Kris Kobach,7,,
-Graham,Hill City Precinct 2 110,Secretary of State,,R,Kris Kobach,287,,
-Graham,Hill City twp 72 118,Secretary of State,,R,Kris Kobach,8,,
-Graham,Hill City Precinct 3 110,Secretary of State,,R,Kris Kobach,104,,
-Graham,Hill City twp 73 118,Secretary of State,,R,Kris Kobach,16,,
-Graham,Indiana Township,Secretary of State,,R,Kris Kobach,13,,
-Graham,Millbrook Township,Secretary of State,,R,Kris Kobach,55,,
-Graham,Morlan Township,Secretary of State,,R,Kris Kobach,27,,
-Graham,Nicodemus Township  110,Secretary of State,,R,Kris Kobach,6,,
-Graham,Nicodemus Township 118,Secretary of State,,R,Kris Kobach,3,,
-Graham,Pioneer Township,Secretary of State,,R,Kris Kobach,16,,
-Graham,Solomon Township,Secretary of State,,R,Kris Kobach,77,,
-Graham,Wildhorse Township,Secretary of State,,R,Kris Kobach,61,,
-Graham,Allodium Township,Secretary of State,,D,Jean Schodorf,3,,
-Graham,Bryant Township,Secretary of State,,D,Jean Schodorf,5,,
-Graham,Gettysburg Township,Secretary of State,,D,Jean Schodorf,10,,
-Graham,Graham Township,Secretary of State,,D,Jean Schodorf,7,,
-Graham,Happy Township,Secretary of State,,D,Jean Schodorf,4,,
-Graham,Hill City Precinct 1 110,Secretary of State,,D,Jean Schodorf,23,,
-Graham,Hill City twp 71 118,Secretary of State,,D,Jean Schodorf,0,,
-Graham,Hill City Precinct 2 110,Secretary of State,,D,Jean Schodorf,112,,
-Graham,Hill City twp 72 118,Secretary of State,,D,Jean Schodorf,1,,
-Graham,Hill City Precinct 3 110,Secretary of State,,D,Jean Schodorf,36,,
-Graham,Hill City twp 73 118,Secretary of State,,D,Jean Schodorf,10,,
-Graham,Indiana Township,Secretary of State,,D,Jean Schodorf,3,,
-Graham,Millbrook Township,Secretary of State,,D,Jean Schodorf,12,,
-Graham,Morlan Township,Secretary of State,,D,Jean Schodorf,1,,
-Graham,Nicodemus Township  110,Secretary of State,,D,Jean Schodorf,1,,
-Graham,Nicodemus Township 118,Secretary of State,,D,Jean Schodorf,7,,
-Graham,Pioneer Township,Secretary of State,,D,Jean Schodorf,2,,
-Graham,Solomon Township,Secretary of State,,D,Jean Schodorf,13,,
-Graham,Wildhorse Township,Secretary of State,,D,Jean Schodorf,37,,
-Graham,Allodium Township,Attorney General,,R,Derek Schmidt,17,,
-Graham,Bryant Township,Attorney General,,R,Derek Schmidt,28,,
-Graham,Gettysburg Township,Attorney General,,R,Derek Schmidt,35,,
-Graham,Graham Township,Attorney General,,R,Derek Schmidt,23,,
-Graham,Happy Township,Attorney General,,R,Derek Schmidt,26,,
-Graham,Hill City Precinct 1 110,Attorney General,,R,Derek Schmidt,65,,
-Graham,Hill City twp 71 118,Attorney General,,R,Derek Schmidt,6,,
-Graham,Hill City Precinct 2 110,Attorney General,,R,Derek Schmidt,313,,
-Graham,Hill City twp 72 118,Attorney General,,R,Derek Schmidt,8,,
-Graham,Hill City Precinct 3 110,Attorney General,,R,Derek Schmidt,112,,
-Graham,Hill City twp 73 118,Attorney General,,R,Derek Schmidt,19,,
-Graham,Indiana Township,Attorney General,,R,Derek Schmidt,13,,
-Graham,Millbrook Township,Attorney General,,R,Derek Schmidt,58,,
-Graham,Morlan Township,Attorney General,,R,Derek Schmidt,26,,
-Graham,Nicodemus Township  110,Attorney General,,R,Derek Schmidt,4,,
-Graham,Nicodemus Township 118,Attorney General,,R,Derek Schmidt,5,,
-Graham,Pioneer Township,Attorney General,,R,Derek Schmidt,15,,
-Graham,Solomon Township,Attorney General,,R,Derek Schmidt,79,,
-Graham,Wildhorse Township,Attorney General,,R,Derek Schmidt,71,,
-Graham,Allodium Township,Attorney General,,D,AJ Kotich,0,,
-Graham,Bryant Township,Attorney General,,D,AJ Kotich,4,,
-Graham,Gettysburg Township,Attorney General,,D,AJ Kotich,3,,
-Graham,Graham Township,Attorney General,,D,AJ Kotich,3,,
-Graham,Happy Township,Attorney General,,D,AJ Kotich,4,,
-Graham,Hill City Precinct 1 110,Attorney General,,D,AJ Kotich,19,,
-Graham,Hill City twp 71 118,Attorney General,,D,AJ Kotich,0,,
-Graham,Hill City Precinct 2 110,Attorney General,,D,AJ Kotich,76,,
-Graham,Hill City twp 72 118,Attorney General,,D,AJ Kotich,1,,
-Graham,Hill City Precinct 3 110,Attorney General,,D,AJ Kotich,26,,
-Graham,Hill City twp 73 118,Attorney General,,D,AJ Kotich,8,,
-Graham,Indiana Township,Attorney General,,D,AJ Kotich,3,,
-Graham,Millbrook Township,Attorney General,,D,AJ Kotich,8,,
-Graham,Morlan Township,Attorney General,,D,AJ Kotich,2,,
-Graham,Nicodemus Township  110,Attorney General,,D,AJ Kotich,3,,
-Graham,Nicodemus Township 118,Attorney General,,D,AJ Kotich,5,,
-Graham,Pioneer Township,Attorney General,,D,AJ Kotich,1,,
-Graham,Solomon Township,Attorney General,,D,AJ Kotich,9,,
-Graham,Wildhorse Township,Attorney General,,D,AJ Kotich,25,,
-Graham,Allodium Township,State Treasurer,,R,Ron Estes,14,,
-Graham,Bryant Township,State Treasurer,,R,Ron Estes,28,,
-Graham,Gettysburg Township,State Treasurer,,R,Ron Estes,34,,
-Graham,Graham Township,State Treasurer,,R,Ron Estes,21,,
-Graham,Happy Township,State Treasurer,,R,Ron Estes,26,,
-Graham,Hill City Precinct 1 110,State Treasurer,,R,Ron Estes,66,,
-Graham,Hill City twp 71 118,State Treasurer,,R,Ron Estes,7,,
-Graham,Hill City Precinct 2 110,State Treasurer,,R,Ron Estes,310,,
-Graham,Hill City twp 72 118,State Treasurer,,R,Ron Estes,8,,
-Graham,Hill City Precinct 3 110,State Treasurer,,R,Ron Estes,109,,
-Graham,Hill City twp 73 118,State Treasurer,,R,Ron Estes,20,,
-Graham,Indiana Township,State Treasurer,,R,Ron Estes,12,,
-Graham,Millbrook Township,State Treasurer,,R,Ron Estes,57,,
-Graham,Morlan Township,State Treasurer,,R,Ron Estes,28,,
-Graham,Nicodemus Township  110,State Treasurer,,R,Ron Estes,6,,
-Graham,Nicodemus Township 118,State Treasurer,,R,Ron Estes,3,,
-Graham,Pioneer Township,State Treasurer,,R,Ron Estes,16,,
-Graham,Solomon Township,State Treasurer,,R,Ron Estes,79,,
-Graham,Wildhorse Township,State Treasurer,,R,Ron Estes,72,,
-Graham,Allodium Township,State Treasurer,,D,Carmen Alldritt,2,,
-Graham,Bryant Township,State Treasurer,,D,Carmen Alldritt,4,,
-Graham,Gettysburg Township,State Treasurer,,D,Carmen Alldritt,4,,
-Graham,Graham Township,State Treasurer,,D,Carmen Alldritt,4,,
-Graham,Happy Township,State Treasurer,,D,Carmen Alldritt,5,,
-Graham,Hill City Precinct 1 110,State Treasurer,,D,Carmen Alldritt,18,,
-Graham,Hill City twp 71 118,State Treasurer,,D,Carmen Alldritt,0,,
-Graham,Hill City Precinct 2 110,State Treasurer,,D,Carmen Alldritt,84,,
-Graham,Hill City twp 72 118,State Treasurer,,D,Carmen Alldritt,1,,
-Graham,Hill City Precinct 3 110,State Treasurer,,D,Carmen Alldritt,30,,
-Graham,Hill City twp 73 118,State Treasurer,,D,Carmen Alldritt,5,,
-Graham,Indiana Township,State Treasurer,,D,Carmen Alldritt,4,,
-Graham,Millbrook Township,State Treasurer,,D,Carmen Alldritt,9,,
-Graham,Morlan Township,State Treasurer,,D,Carmen Alldritt,0,,
-Graham,Nicodemus Township  110,State Treasurer,,D,Carmen Alldritt,1,,
-Graham,Nicodemus Township 118,State Treasurer,,D,Carmen Alldritt,7,,
-Graham,Pioneer Township,State Treasurer,,D,Carmen Alldritt,1,,
-Graham,Solomon Township,State Treasurer,,D,Carmen Alldritt,10,,
-Graham,Wildhorse Township,State Treasurer,,D,Carmen Alldritt,25,,
-Graham,Allodium Township,Insurance Commissioner,,R,Ken Selzer,13,,
-Graham,Bryant Township,Insurance Commissioner,,R,Ken Selzer,25,,
-Graham,Gettysburg Township,Insurance Commissioner,,R,Ken Selzer,35,,
-Graham,Graham Township,Insurance Commissioner,,R,Ken Selzer,22,,
-Graham,Happy Township,Insurance Commissioner,,R,Ken Selzer,25,,
-Graham,Hill City Precinct 1 110,Insurance Commissioner,,R,Ken Selzer,56,,
-Graham,Hill City twp 71 118,Insurance Commissioner,,R,Ken Selzer,6,,
-Graham,Hill City Precinct 2 110,Insurance Commissioner,,R,Ken Selzer,276,,
-Graham,Hill City twp 72 118,Insurance Commissioner,,R,Ken Selzer,5,,
-Graham,Hill City Precinct 3 110,Insurance Commissioner,,R,Ken Selzer,99,,
-Graham,Hill City twp 73 118,Insurance Commissioner,,R,Ken Selzer,17,,
-Graham,Indiana Township,Insurance Commissioner,,R,Ken Selzer,11,,
-Graham,Millbrook Township,Insurance Commissioner,,R,Ken Selzer,55,,
-Graham,Morlan Township,Insurance Commissioner,,R,Ken Selzer,27,,
-Graham,Nicodemus Township  110,Insurance Commissioner,,R,Ken Selzer,3,,
-Graham,Nicodemus Township 118,Insurance Commissioner,,R,Ken Selzer,5,,
-Graham,Pioneer Township,Insurance Commissioner,,R,Ken Selzer,14,,
-Graham,Solomon Township,Insurance Commissioner,,R,Ken Selzer,76,,
-Graham,Wildhorse Township,Insurance Commissioner,,R,Ken Selzer,63,,
-Graham,Allodium Township,Insurance Commissioner,,D,Dennis Anderson,3,,
-Graham,Bryant Township,Insurance Commissioner,,D,Dennis Anderson,5,,
-Graham,Gettysburg Township,Insurance Commissioner,,D,Dennis Anderson,4,,
-Graham,Graham Township,Insurance Commissioner,,D,Dennis Anderson,3,,
-Graham,Happy Township,Insurance Commissioner,,D,Dennis Anderson,4,,
-Graham,Hill City Precinct 1 110,Insurance Commissioner,,D,Dennis Anderson,23,,
-Graham,Hill City twp 71 118,Insurance Commissioner,,D,Dennis Anderson,0,,
-Graham,Hill City Precinct 2 110,Insurance Commissioner,,D,Dennis Anderson,104,,
-Graham,Hill City twp 72 118,Insurance Commissioner,,D,Dennis Anderson,3,,
-Graham,Hill City Precinct 3 110,Insurance Commissioner,,D,Dennis Anderson,35,,
-Graham,Hill City twp 73 118,Insurance Commissioner,,D,Dennis Anderson,8,,
-Graham,Indiana Township,Insurance Commissioner,,D,Dennis Anderson,5,,
-Graham,Millbrook Township,Insurance Commissioner,,D,Dennis Anderson,9,,
-Graham,Morlan Township,Insurance Commissioner,,D,Dennis Anderson,1,,
-Graham,Nicodemus Township  110,Insurance Commissioner,,D,Dennis Anderson,4,,
-Graham,Nicodemus Township 118,Insurance Commissioner,,D,Dennis Anderson,6,,
-Graham,Pioneer Township,Insurance Commissioner,,D,Dennis Anderson,2,,
-Graham,Solomon Township,Insurance Commissioner,,D,Dennis Anderson,11,,
-Graham,Wildhorse Township,Insurance Commissioner,,D,Dennis Anderson,30,,
-Graham,Allodium Township,State House,118,R,Don Hineman,13,,
-Graham,Bryant Township,State House,118,R,Don Hineman,30,,
-Graham,Gettysburg Township,State House,118,R,Don Hineman,37,,
-Graham,Graham Township,State House,118,R,Don Hineman,22,,
-Graham,Happy Township,State House,118,R,Don Hineman,30,,
-Graham,Hill City Precinct 1 110,State House,110,R,Travis Couture-Lovelady,74,,
-Graham,Hill City twp 71 118,State House,118,R,Don Hineman,5,,
-Graham,Hill City Precinct 2 110,State House,110,R,Travis Couture-Lovelady,351,,
-Graham,Hill City twp 72 118,State House,118,R,Don Hineman,7,,
-Graham,Hill City Precinct 3 110,State House,110,R,Travis Couture-Lovelady,126,,
-Graham,Hill City twp 73 118,State House,118,R,Don Hineman,21,,
-Graham,Indiana Township,State House,118,R,Don Hineman,15,,
-Graham,Millbrook Township,State House,118,R,Don Hineman,61,,
-Graham,Morlan Township,State House,118,R,Don Hineman,29,,
-Graham,Nicodemus Township  110,State House,110,R,Travis Couture-Lovelady,6,,
-Graham,Nicodemus Township 118,State House,118,R,Don Hineman,10,,
-Graham,Pioneer Township,State House,118,R,Don Hineman,17,,
-Graham,Solomon Township,State House,118,R,Don Hineman,85,,
-Graham,Wildhorse Township,State House,118,R,Don Hineman,81,,
-Graham,Hill City 2 H 110,U.S. House,1,wri,Brad Eckols,2,,
-Graham,Hill City 2 H 110,Attorney General,,wri,Fred Pratt,1,,
-Graham,Hill City 1 H 110,Insurance Commissioner,,wri,Clark Schultz,1,,
-Graham,Hill City 3 H 110,State House,110,wri,Bob Hooper,1,,
-Graham,Hill City 2 H 110,State House,110,wri,Fred Pratt,1,,
-Graham,Hill City 2 H 110,State House,110,wri,Sue Boldra,1,,
-Graham,Hill City 2 H 110,State House,110,wri,Diana Parker,1,,
-Graham,Hill City 2 H 110,State House,110,wri,Jay Nickelson,1,,
-Graham,Hill City twp 73 H 118,State House,118,wri,Travis Couture-Lovelady,1,,
+county,precinct,office,district,party,candidate,votes,vtd
+GRAHAM,Allodium Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000010
+GRAHAM,Allodium Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+GRAHAM,Allodium Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000010
+GRAHAM,Bogue City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000020
+GRAHAM,Bogue City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+GRAHAM,Bogue City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000020
+GRAHAM,Bryant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000030
+GRAHAM,Bryant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+GRAHAM,Bryant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000030
+GRAHAM,Gettysburg Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000040
+GRAHAM,Gettysburg Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+GRAHAM,Gettysburg Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000040
+GRAHAM,Graham Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000050
+GRAHAM,Graham Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+GRAHAM,Graham Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000050
+GRAHAM,Happy Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000060
+GRAHAM,Happy Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+GRAHAM,Happy Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000060
+GRAHAM,Indiana Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000100
+GRAHAM,Indiana Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+GRAHAM,Indiana Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000100
+GRAHAM,Millbrook Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000110
+GRAHAM,Millbrook Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000110
+GRAHAM,Millbrook Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,000110
+GRAHAM,Morlan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000120
+GRAHAM,Morlan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+GRAHAM,Morlan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000120
+GRAHAM,Morland City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000130
+GRAHAM,Morland City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000130
+GRAHAM,Morland City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000130
+GRAHAM,Pioneer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000150
+GRAHAM,Pioneer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000150
+GRAHAM,Pioneer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000150
+GRAHAM,Solomon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000160
+GRAHAM,Solomon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000160
+GRAHAM,Solomon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000160
+GRAHAM,Wildhorse Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000170
+GRAHAM,Wildhorse Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000170
+GRAHAM,Wildhorse Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000170
+GRAHAM,Hill City Precinct 1 H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,120020
+GRAHAM,Hill City Precinct 1 H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120020
+GRAHAM,Hill City Precinct 1 H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,120020
+GRAHAM,Hill City Precinct 1 H118,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120030
+GRAHAM,Hill City Precinct 1 H118,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+GRAHAM,Hill City Precinct 1 H118,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,120030
+GRAHAM,Hill City Precinct 2 H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",155,120040
+GRAHAM,Hill City Precinct 2 H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,120040
+GRAHAM,Hill City Precinct 2 H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",244,120040
+GRAHAM,Hill City Precinct 2 H118,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,120050
+GRAHAM,Hill City Precinct 2 H118,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120050
+GRAHAM,Hill City Precinct 2 H118,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,120050
+GRAHAM,Hill City Precinct 3 H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",44,120060
+GRAHAM,Hill City Precinct 3 H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,120060
+GRAHAM,Hill City Precinct 3 H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,120060
+GRAHAM,Hill City Precinct 3 H118,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,120070
+GRAHAM,Hill City Precinct 3 H118,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120070
+GRAHAM,Hill City Precinct 3 H118,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,120070
+GRAHAM,Nicodemus Township  H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120080
+GRAHAM,Nicodemus Township  H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120080
+GRAHAM,Nicodemus Township  H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",6,120080
+GRAHAM,Nicodemus Township H118,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,120090
+GRAHAM,Nicodemus Township H118,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120090
+GRAHAM,Nicodemus Township H118,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,120090
+GRAHAM,Allodium Township,Kansas House of Representatives,118,Republican,"Hineman, Don",13,000010
+GRAHAM,Bogue City,Kansas House of Representatives,118,Republican,"Hineman, Don",0,000020
+GRAHAM,Bryant Township,Kansas House of Representatives,118,Republican,"Hineman, Don",30,000030
+GRAHAM,Gettysburg Township,Kansas House of Representatives,118,Republican,"Hineman, Don",37,000040
+GRAHAM,Graham Township,Kansas House of Representatives,118,Republican,"Hineman, Don",22,000050
+GRAHAM,Happy Township,Kansas House of Representatives,118,Republican,"Hineman, Don",30,000060
+GRAHAM,Indiana Township,Kansas House of Representatives,118,Republican,"Hineman, Don",15,000100
+GRAHAM,Millbrook Township,Kansas House of Representatives,118,Republican,"Hineman, Don",61,000110
+GRAHAM,Morlan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",29,000120
+GRAHAM,Morland City,Kansas House of Representatives,118,Republican,"Hineman, Don",0,000130
+GRAHAM,Pioneer Township,Kansas House of Representatives,118,Republican,"Hineman, Don",17,000150
+GRAHAM,Solomon Township,Kansas House of Representatives,118,Republican,"Hineman, Don",85,000160
+GRAHAM,Wildhorse Township,Kansas House of Representatives,118,Republican,"Hineman, Don",81,000170
+GRAHAM,Hill City Precinct 1 H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",74,120020
+GRAHAM,Hill City Precinct 1 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",5,120030
+GRAHAM,Hill City Precinct 2 H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",351,120040
+GRAHAM,Hill City Precinct 2 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",7,120050
+GRAHAM,Hill City Precinct 3 H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",126,120060
+GRAHAM,Hill City Precinct 3 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",21,120070
+GRAHAM,Nicodemus Township  H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",6,120080
+GRAHAM,Nicodemus Township H118,Kansas House of Representatives,118,Republican,"Hineman, Don",10,120090
+GRAHAM,Allodium Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000010
+GRAHAM,Allodium Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000010
+GRAHAM,Bogue City,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000020
+GRAHAM,Bogue City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000020
+GRAHAM,Bryant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000030
+GRAHAM,Bryant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000030
+GRAHAM,Gettysburg Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000040
+GRAHAM,Gettysburg Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000040
+GRAHAM,Graham Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000050
+GRAHAM,Graham Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000050
+GRAHAM,Happy Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000060
+GRAHAM,Happy Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000060
+GRAHAM,Indiana Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000100
+GRAHAM,Indiana Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000100
+GRAHAM,Millbrook Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000110
+GRAHAM,Millbrook Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000110
+GRAHAM,Morlan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000120
+GRAHAM,Morlan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000120
+GRAHAM,Morland City,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000130
+GRAHAM,Morland City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000130
+GRAHAM,Pioneer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000150
+GRAHAM,Pioneer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000150
+GRAHAM,Solomon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000160
+GRAHAM,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",79,000160
+GRAHAM,Wildhorse Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000170
+GRAHAM,Wildhorse Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000170
+GRAHAM,Hill City Precinct 1 H110,United States House of Representatives,1,Democratic,"Sherow, James E.",28,120020
+GRAHAM,Hill City Precinct 1 H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,120020
+GRAHAM,Hill City Precinct 1 H118,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120030
+GRAHAM,Hill City Precinct 1 H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,120030
+GRAHAM,Hill City Precinct 2 H110,United States House of Representatives,1,Democratic,"Sherow, James E.",114,120040
+GRAHAM,Hill City Precinct 2 H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",281,120040
+GRAHAM,Hill City Precinct 2 H118,United States House of Representatives,1,Democratic,"Sherow, James E.",3,120050
+GRAHAM,Hill City Precinct 2 H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,120050
+GRAHAM,Hill City Precinct 3 H110,United States House of Representatives,1,Democratic,"Sherow, James E.",40,120060
+GRAHAM,Hill City Precinct 3 H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",99,120060
+GRAHAM,Hill City Precinct 3 H118,United States House of Representatives,1,Democratic,"Sherow, James E.",6,120070
+GRAHAM,Hill City Precinct 3 H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,120070
+GRAHAM,Nicodemus Township  H110,United States House of Representatives,1,Democratic,"Sherow, James E.",3,120080
+GRAHAM,Nicodemus Township  H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,120080
+GRAHAM,Nicodemus Township H118,United States House of Representatives,1,Democratic,"Sherow, James E.",8,120090
+GRAHAM,Nicodemus Township H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,120090
+GRAHAM,Allodium Township,Attorney General,,Democratic,"Kotich, A.J.",0,000010
+GRAHAM,Allodium Township,Attorney General,,Republican,"Schmidt, Derek",17,000010
+GRAHAM,Bogue City,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+GRAHAM,Bogue City,Attorney General,,Republican,"Schmidt, Derek",0,000020
+GRAHAM,Bryant Township,Attorney General,,Democratic,"Kotich, A.J.",4,000030
+GRAHAM,Bryant Township,Attorney General,,Republican,"Schmidt, Derek",28,000030
+GRAHAM,Gettysburg Township,Attorney General,,Democratic,"Kotich, A.J.",3,000040
+GRAHAM,Gettysburg Township,Attorney General,,Republican,"Schmidt, Derek",35,000040
+GRAHAM,Graham Township,Attorney General,,Democratic,"Kotich, A.J.",3,000050
+GRAHAM,Graham Township,Attorney General,,Republican,"Schmidt, Derek",23,000050
+GRAHAM,Happy Township,Attorney General,,Democratic,"Kotich, A.J.",4,000060
+GRAHAM,Happy Township,Attorney General,,Republican,"Schmidt, Derek",26,000060
+GRAHAM,Indiana Township,Attorney General,,Democratic,"Kotich, A.J.",3,000100
+GRAHAM,Indiana Township,Attorney General,,Republican,"Schmidt, Derek",13,000100
+GRAHAM,Millbrook Township,Attorney General,,Democratic,"Kotich, A.J.",8,000110
+GRAHAM,Millbrook Township,Attorney General,,Republican,"Schmidt, Derek",58,000110
+GRAHAM,Morlan Township,Attorney General,,Democratic,"Kotich, A.J.",2,000120
+GRAHAM,Morlan Township,Attorney General,,Republican,"Schmidt, Derek",26,000120
+GRAHAM,Morland City,Attorney General,,Democratic,"Kotich, A.J.",0,000130
+GRAHAM,Morland City,Attorney General,,Republican,"Schmidt, Derek",0,000130
+GRAHAM,Pioneer Township,Attorney General,,Democratic,"Kotich, A.J.",1,000150
+GRAHAM,Pioneer Township,Attorney General,,Republican,"Schmidt, Derek",15,000150
+GRAHAM,Solomon Township,Attorney General,,Democratic,"Kotich, A.J.",9,000160
+GRAHAM,Solomon Township,Attorney General,,Republican,"Schmidt, Derek",79,000160
+GRAHAM,Wildhorse Township,Attorney General,,Democratic,"Kotich, A.J.",25,000170
+GRAHAM,Wildhorse Township,Attorney General,,Republican,"Schmidt, Derek",71,000170
+GRAHAM,Hill City Precinct 1 H110,Attorney General,,Democratic,"Kotich, A.J.",19,120020
+GRAHAM,Hill City Precinct 1 H110,Attorney General,,Republican,"Schmidt, Derek",65,120020
+GRAHAM,Hill City Precinct 1 H118,Attorney General,,Democratic,"Kotich, A.J.",0,120030
+GRAHAM,Hill City Precinct 1 H118,Attorney General,,Republican,"Schmidt, Derek",6,120030
+GRAHAM,Hill City Precinct 2 H110,Attorney General,,Democratic,"Kotich, A.J.",76,120040
+GRAHAM,Hill City Precinct 2 H110,Attorney General,,Republican,"Schmidt, Derek",313,120040
+GRAHAM,Hill City Precinct 2 H118,Attorney General,,Democratic,"Kotich, A.J.",1,120050
+GRAHAM,Hill City Precinct 2 H118,Attorney General,,Republican,"Schmidt, Derek",8,120050
+GRAHAM,Hill City Precinct 3 H110,Attorney General,,Democratic,"Kotich, A.J.",26,120060
+GRAHAM,Hill City Precinct 3 H110,Attorney General,,Republican,"Schmidt, Derek",112,120060
+GRAHAM,Hill City Precinct 3 H118,Attorney General,,Democratic,"Kotich, A.J.",8,120070
+GRAHAM,Hill City Precinct 3 H118,Attorney General,,Republican,"Schmidt, Derek",19,120070
+GRAHAM,Nicodemus Township  H110,Attorney General,,Democratic,"Kotich, A.J.",3,120080
+GRAHAM,Nicodemus Township  H110,Attorney General,,Republican,"Schmidt, Derek",4,120080
+GRAHAM,Nicodemus Township H118,Attorney General,,Democratic,"Kotich, A.J.",5,120090
+GRAHAM,Nicodemus Township H118,Attorney General,,Republican,"Schmidt, Derek",5,120090
+GRAHAM,Allodium Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000010
+GRAHAM,Allodium Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000010
+GRAHAM,Bogue City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000020
+GRAHAM,Bogue City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000020
+GRAHAM,Bryant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000030
+GRAHAM,Bryant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000030
+GRAHAM,Gettysburg Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000040
+GRAHAM,Gettysburg Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000040
+GRAHAM,Graham Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000050
+GRAHAM,Graham Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000050
+GRAHAM,Happy Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000060
+GRAHAM,Happy Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000060
+GRAHAM,Indiana Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000100
+GRAHAM,Indiana Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000100
+GRAHAM,Millbrook Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000110
+GRAHAM,Millbrook Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000110
+GRAHAM,Morlan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000120
+GRAHAM,Morlan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000120
+GRAHAM,Morland City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000130
+GRAHAM,Morland City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000130
+GRAHAM,Pioneer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000150
+GRAHAM,Pioneer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000150
+GRAHAM,Solomon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000160
+GRAHAM,Solomon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",76,000160
+GRAHAM,Wildhorse Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000170
+GRAHAM,Wildhorse Township,Commissioner of Insurance,,Republican,"Selzer, Ken",63,000170
+GRAHAM,Hill City Precinct 1 H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,120020
+GRAHAM,Hill City Precinct 1 H110,Commissioner of Insurance,,Republican,"Selzer, Ken",56,120020
+GRAHAM,Hill City Precinct 1 H118,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120030
+GRAHAM,Hill City Precinct 1 H118,Commissioner of Insurance,,Republican,"Selzer, Ken",6,120030
+GRAHAM,Hill City Precinct 2 H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",104,120040
+GRAHAM,Hill City Precinct 2 H110,Commissioner of Insurance,,Republican,"Selzer, Ken",276,120040
+GRAHAM,Hill City Precinct 2 H118,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,120050
+GRAHAM,Hill City Precinct 2 H118,Commissioner of Insurance,,Republican,"Selzer, Ken",5,120050
+GRAHAM,Hill City Precinct 3 H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",35,120060
+GRAHAM,Hill City Precinct 3 H110,Commissioner of Insurance,,Republican,"Selzer, Ken",99,120060
+GRAHAM,Hill City Precinct 3 H118,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,120070
+GRAHAM,Hill City Precinct 3 H118,Commissioner of Insurance,,Republican,"Selzer, Ken",17,120070
+GRAHAM,Nicodemus Township  H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,120080
+GRAHAM,Nicodemus Township  H110,Commissioner of Insurance,,Republican,"Selzer, Ken",3,120080
+GRAHAM,Nicodemus Township H118,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,120090
+GRAHAM,Nicodemus Township H118,Commissioner of Insurance,,Republican,"Selzer, Ken",5,120090
+GRAHAM,Allodium Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+GRAHAM,Allodium Township,Secretary of State,,Republican,"Kobach, Kris",14,000010
+GRAHAM,Bogue City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+GRAHAM,Bogue City,Secretary of State,,Republican,"Kobach, Kris",0,000020
+GRAHAM,Bryant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000030
+GRAHAM,Bryant Township,Secretary of State,,Republican,"Kobach, Kris",27,000030
+GRAHAM,Gettysburg Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000040
+GRAHAM,Gettysburg Township,Secretary of State,,Republican,"Kobach, Kris",28,000040
+GRAHAM,Graham Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000050
+GRAHAM,Graham Township,Secretary of State,,Republican,"Kobach, Kris",19,000050
+GRAHAM,Happy Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000060
+GRAHAM,Happy Township,Secretary of State,,Republican,"Kobach, Kris",26,000060
+GRAHAM,Indiana Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000100
+GRAHAM,Indiana Township,Secretary of State,,Republican,"Kobach, Kris",13,000100
+GRAHAM,Millbrook Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000110
+GRAHAM,Millbrook Township,Secretary of State,,Republican,"Kobach, Kris",55,000110
+GRAHAM,Morlan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000120
+GRAHAM,Morlan Township,Secretary of State,,Republican,"Kobach, Kris",27,000120
+GRAHAM,Morland City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000130
+GRAHAM,Morland City,Secretary of State,,Republican,"Kobach, Kris",0,000130
+GRAHAM,Pioneer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000150
+GRAHAM,Pioneer Township,Secretary of State,,Republican,"Kobach, Kris",16,000150
+GRAHAM,Solomon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000160
+GRAHAM,Solomon Township,Secretary of State,,Republican,"Kobach, Kris",77,000160
+GRAHAM,Wildhorse Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000170
+GRAHAM,Wildhorse Township,Secretary of State,,Republican,"Kobach, Kris",61,000170
+GRAHAM,Hill City Precinct 1 H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,120020
+GRAHAM,Hill City Precinct 1 H110,Secretary of State,,Republican,"Kobach, Kris",61,120020
+GRAHAM,Hill City Precinct 1 H118,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120030
+GRAHAM,Hill City Precinct 1 H118,Secretary of State,,Republican,"Kobach, Kris",7,120030
+GRAHAM,Hill City Precinct 2 H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",112,120040
+GRAHAM,Hill City Precinct 2 H110,Secretary of State,,Republican,"Kobach, Kris",287,120040
+GRAHAM,Hill City Precinct 2 H118,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,120050
+GRAHAM,Hill City Precinct 2 H118,Secretary of State,,Republican,"Kobach, Kris",8,120050
+GRAHAM,Hill City Precinct 3 H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,120060
+GRAHAM,Hill City Precinct 3 H110,Secretary of State,,Republican,"Kobach, Kris",104,120060
+GRAHAM,Hill City Precinct 3 H118,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,120070
+GRAHAM,Hill City Precinct 3 H118,Secretary of State,,Republican,"Kobach, Kris",16,120070
+GRAHAM,Nicodemus Township  H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,120080
+GRAHAM,Nicodemus Township  H110,Secretary of State,,Republican,"Kobach, Kris",6,120080
+GRAHAM,Nicodemus Township H118,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,120090
+GRAHAM,Nicodemus Township H118,Secretary of State,,Republican,"Kobach, Kris",3,120090
+GRAHAM,Allodium Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+GRAHAM,Allodium Township,State Treasurer,,Republican,"Estes, Ron",14,000010
+GRAHAM,Bogue City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+GRAHAM,Bogue City,State Treasurer,,Republican,"Estes, Ron",0,000020
+GRAHAM,Bryant Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+GRAHAM,Bryant Township,State Treasurer,,Republican,"Estes, Ron",28,000030
+GRAHAM,Gettysburg Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000040
+GRAHAM,Gettysburg Township,State Treasurer,,Republican,"Estes, Ron",34,000040
+GRAHAM,Graham Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000050
+GRAHAM,Graham Township,State Treasurer,,Republican,"Estes, Ron",21,000050
+GRAHAM,Happy Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000060
+GRAHAM,Happy Township,State Treasurer,,Republican,"Estes, Ron",26,000060
+GRAHAM,Indiana Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000100
+GRAHAM,Indiana Township,State Treasurer,,Republican,"Estes, Ron",12,000100
+GRAHAM,Millbrook Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000110
+GRAHAM,Millbrook Township,State Treasurer,,Republican,"Estes, Ron",57,000110
+GRAHAM,Morlan Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000120
+GRAHAM,Morlan Township,State Treasurer,,Republican,"Estes, Ron",28,000120
+GRAHAM,Morland City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000130
+GRAHAM,Morland City,State Treasurer,,Republican,"Estes, Ron",0,000130
+GRAHAM,Pioneer Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000150
+GRAHAM,Pioneer Township,State Treasurer,,Republican,"Estes, Ron",16,000150
+GRAHAM,Solomon Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000160
+GRAHAM,Solomon Township,State Treasurer,,Republican,"Estes, Ron",79,000160
+GRAHAM,Wildhorse Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000170
+GRAHAM,Wildhorse Township,State Treasurer,,Republican,"Estes, Ron",72,000170
+GRAHAM,Hill City Precinct 1 H110,State Treasurer,,Democratic,"Alldritt, Carmen",18,120020
+GRAHAM,Hill City Precinct 1 H110,State Treasurer,,Republican,"Estes, Ron",66,120020
+GRAHAM,Hill City Precinct 1 H118,State Treasurer,,Democratic,"Alldritt, Carmen",0,120030
+GRAHAM,Hill City Precinct 1 H118,State Treasurer,,Republican,"Estes, Ron",7,120030
+GRAHAM,Hill City Precinct 2 H110,State Treasurer,,Democratic,"Alldritt, Carmen",84,120040
+GRAHAM,Hill City Precinct 2 H110,State Treasurer,,Republican,"Estes, Ron",310,120040
+GRAHAM,Hill City Precinct 2 H118,State Treasurer,,Democratic,"Alldritt, Carmen",1,120050
+GRAHAM,Hill City Precinct 2 H118,State Treasurer,,Republican,"Estes, Ron",8,120050
+GRAHAM,Hill City Precinct 3 H110,State Treasurer,,Democratic,"Alldritt, Carmen",30,120060
+GRAHAM,Hill City Precinct 3 H110,State Treasurer,,Republican,"Estes, Ron",109,120060
+GRAHAM,Hill City Precinct 3 H118,State Treasurer,,Democratic,"Alldritt, Carmen",5,120070
+GRAHAM,Hill City Precinct 3 H118,State Treasurer,,Republican,"Estes, Ron",20,120070
+GRAHAM,Nicodemus Township  H110,State Treasurer,,Democratic,"Alldritt, Carmen",1,120080
+GRAHAM,Nicodemus Township  H110,State Treasurer,,Republican,"Estes, Ron",6,120080
+GRAHAM,Nicodemus Township H118,State Treasurer,,Democratic,"Alldritt, Carmen",7,120090
+GRAHAM,Nicodemus Township H118,State Treasurer,,Republican,"Estes, Ron",3,120090
+GRAHAM,Allodium Township,United States Senate,,independent,"Orman, Greg",0,000010
+GRAHAM,Allodium Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+GRAHAM,Allodium Township,United States Senate,,Republican,"Roberts, Pat",15,000010
+GRAHAM,Bogue City,United States Senate,,independent,"Orman, Greg",0,000020
+GRAHAM,Bogue City,United States Senate,,Libertarian,"Batson, Randall",0,000020
+GRAHAM,Bogue City,United States Senate,,Republican,"Roberts, Pat",0,000020
+GRAHAM,Bryant Township,United States Senate,,independent,"Orman, Greg",5,000030
+GRAHAM,Bryant Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+GRAHAM,Bryant Township,United States Senate,,Republican,"Roberts, Pat",27,000030
+GRAHAM,Gettysburg Township,United States Senate,,independent,"Orman, Greg",5,000040
+GRAHAM,Gettysburg Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+GRAHAM,Gettysburg Township,United States Senate,,Republican,"Roberts, Pat",34,000040
+GRAHAM,Graham Township,United States Senate,,independent,"Orman, Greg",6,000050
+GRAHAM,Graham Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+GRAHAM,Graham Township,United States Senate,,Republican,"Roberts, Pat",20,000050
+GRAHAM,Happy Township,United States Senate,,independent,"Orman, Greg",6,000060
+GRAHAM,Happy Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+GRAHAM,Happy Township,United States Senate,,Republican,"Roberts, Pat",25,000060
+GRAHAM,Indiana Township,United States Senate,,independent,"Orman, Greg",4,000100
+GRAHAM,Indiana Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+GRAHAM,Indiana Township,United States Senate,,Republican,"Roberts, Pat",11,000100
+GRAHAM,Millbrook Township,United States Senate,,independent,"Orman, Greg",14,000110
+GRAHAM,Millbrook Township,United States Senate,,Libertarian,"Batson, Randall",1,000110
+GRAHAM,Millbrook Township,United States Senate,,Republican,"Roberts, Pat",52,000110
+GRAHAM,Morlan Township,United States Senate,,independent,"Orman, Greg",0,000120
+GRAHAM,Morlan Township,United States Senate,,Libertarian,"Batson, Randall",1,000120
+GRAHAM,Morlan Township,United States Senate,,Republican,"Roberts, Pat",28,000120
+GRAHAM,Morland City,United States Senate,,independent,"Orman, Greg",0,000130
+GRAHAM,Morland City,United States Senate,,Libertarian,"Batson, Randall",0,000130
+GRAHAM,Morland City,United States Senate,,Republican,"Roberts, Pat",0,000130
+GRAHAM,Pioneer Township,United States Senate,,independent,"Orman, Greg",3,000150
+GRAHAM,Pioneer Township,United States Senate,,Libertarian,"Batson, Randall",0,000150
+GRAHAM,Pioneer Township,United States Senate,,Republican,"Roberts, Pat",16,000150
+GRAHAM,Solomon Township,United States Senate,,independent,"Orman, Greg",14,000160
+GRAHAM,Solomon Township,United States Senate,,Libertarian,"Batson, Randall",5,000160
+GRAHAM,Solomon Township,United States Senate,,Republican,"Roberts, Pat",72,000160
+GRAHAM,Wildhorse Township,United States Senate,,independent,"Orman, Greg",33,000170
+GRAHAM,Wildhorse Township,United States Senate,,Libertarian,"Batson, Randall",8,000170
+GRAHAM,Wildhorse Township,United States Senate,,Republican,"Roberts, Pat",54,000170
+GRAHAM,Hill City Precinct 1 H110,United States Senate,,independent,"Orman, Greg",27,120020
+GRAHAM,Hill City Precinct 1 H110,United States Senate,,Libertarian,"Batson, Randall",6,120020
+GRAHAM,Hill City Precinct 1 H110,United States Senate,,Republican,"Roberts, Pat",53,120020
+GRAHAM,Hill City Precinct 1 H118,United States Senate,,independent,"Orman, Greg",0,120030
+GRAHAM,Hill City Precinct 1 H118,United States Senate,,Libertarian,"Batson, Randall",0,120030
+GRAHAM,Hill City Precinct 1 H118,United States Senate,,Republican,"Roberts, Pat",7,120030
+GRAHAM,Hill City Precinct 2 H110,United States Senate,,independent,"Orman, Greg",130,120040
+GRAHAM,Hill City Precinct 2 H110,United States Senate,,Libertarian,"Batson, Randall",11,120040
+GRAHAM,Hill City Precinct 2 H110,United States Senate,,Republican,"Roberts, Pat",259,120040
+GRAHAM,Hill City Precinct 2 H118,United States Senate,,independent,"Orman, Greg",2,120050
+GRAHAM,Hill City Precinct 2 H118,United States Senate,,Libertarian,"Batson, Randall",2,120050
+GRAHAM,Hill City Precinct 2 H118,United States Senate,,Republican,"Roberts, Pat",5,120050
+GRAHAM,Hill City Precinct 3 H110,United States Senate,,independent,"Orman, Greg",36,120060
+GRAHAM,Hill City Precinct 3 H110,United States Senate,,Libertarian,"Batson, Randall",7,120060
+GRAHAM,Hill City Precinct 3 H110,United States Senate,,Republican,"Roberts, Pat",96,120060
+GRAHAM,Hill City Precinct 3 H118,United States Senate,,independent,"Orman, Greg",7,120070
+GRAHAM,Hill City Precinct 3 H118,United States Senate,,Libertarian,"Batson, Randall",1,120070
+GRAHAM,Hill City Precinct 3 H118,United States Senate,,Republican,"Roberts, Pat",17,120070
+GRAHAM,Nicodemus Township  H110,United States Senate,,independent,"Orman, Greg",2,120080
+GRAHAM,Nicodemus Township  H110,United States Senate,,Libertarian,"Batson, Randall",0,120080
+GRAHAM,Nicodemus Township  H110,United States Senate,,Republican,"Roberts, Pat",4,120080
+GRAHAM,Nicodemus Township H118,United States Senate,,independent,"Orman, Greg",4,120090
+GRAHAM,Nicodemus Township H118,United States Senate,,Libertarian,"Batson, Randall",1,120090
+GRAHAM,Nicodemus Township H118,United States Senate,,Republican,"Roberts, Pat",4,120090

--- a/2014/20141104__ks__general__grant__precinct.csv
+++ b/2014/20141104__ks__general__grant__precinct.csv
@@ -1,119 +1,103 @@
-county,precinct,office,district,party,candidate,total
-Grant,Ward 1,Attorney General,,,A.J. Kotich,34
-Grant,Ward 2,Attorney General,,,A.J. Kotich,77
-Grant,Ward 3,Attorney General,,,A.J. Kotich,79
-Grant,Prec 4,Attorney General,,,A.J. Kotich,37
-Grant,Ward 1,Attorney General,,,Derek Schmidt,148
-Grant,Ward 2,Attorney General,,,Derek Schmidt,347
-Grant,Ward 3,Attorney General,,,Derek Schmidt,322
-Grant,Prec 4,Attorney General,,,Derek Schmidt,269
-Grant,Ward 1,U.S. House,1,,James E. Sherow,42
-Grant,Ward 2,U.S. House,1,,James E. Sherow,88
-Grant,Ward 3,U.S. House,1,,James E. Sherow,91
-Grant,Prec 4,U.S. House,1,,James E. Sherow,45
-Grant,Ward 1,U.S. House,1,,Tim Huelskamp,140
-Grant,Ward 2,U.S. House,1,,Tim Huelskamp,338
-Grant,Ward 3,U.S. House,1,,Tim Huelskamp,312
-Grant,Prec 4,U.S. House,1,,Tim Huelskamp,262
-Grant,Ward 1,Governor,,,Keen Umbehr,10
-Grant,Ward 2,Governor,,,Keen Umbehr,17
-Grant,Ward 3,Governor,,,Keen Umbehr,40
-Grant,Prec 4,Governor,,,Keen Umbehr,25
-Grant,Ward 1,Governor,,,Paul Davis,52
-Grant,Ward 2,Governor,,,Paul Davis,134
-Grant,Ward 3,Governor,,,Paul Davis,115
-Grant,Prec 4,Governor,,,Paul Davis,66
-Grant,Ward 1,Governor,,,Sam Brownback,125
-Grant,Ward 2,Governor,,,Sam Brownback,282
-Grant,Ward 3,Governor,,,Sam Brownback,254
-Grant,Prec 4,Governor,,,Sam Brownback,217
-Grant,Ward 1,Insurance Commissioner,,,Dennis Anderson,40
-Grant,Ward 2,Insurance Commissioner,,,Dennis Anderson,81
-Grant,Ward 3,Insurance Commissioner,,,Dennis Anderson,87
-Grant,Prec 4,Insurance Commissioner,,,Dennis Anderson,42
-Grant,Ward 1,Insurance Commissioner,,,Ken Selzer,140
-Grant,Ward 2,Insurance Commissioner,,,Ken Selzer,346
-Grant,Ward 3,Insurance Commissioner,,,Ken Selzer,307
-Grant,Prec 4,Insurance Commissioner,,,Ken Selzer,257
-Grant,Ward 1,Secretary of State,,,Jean Kurtis Schodorf,55
-Grant,Ward 2,Secretary of State,,,Jean Kurtis Schodorf,86
-Grant,Ward 3,Secretary of State,,,Jean Kurtis Schodorf,97
-Grant,Prec 4,Secretary of State,,,Jean Kurtis Schodorf,54
-Grant,Ward 1,Secretary of State,,,Kris Kobach,128
-Grant,Ward 2,Secretary of State,,,Kris Kobach,346
-Grant,Ward 3,Secretary of State,,,Kris Kobach,307
-Grant,Prec 4,Secretary of State,,,Kris Kobach,254
-Grant,Ward 1,State House,124,,Stephen Alford,162
-Grant,Ward 2,State House,124,,Stephen Alford,399
-Grant,Ward 3,State House,124,,Stephen Alford,362
-Grant,Prec 4,State House,124,,Stephen Alford,282
-Grant,Ward 1,State Treasurer,,,Carmen Alldritt,29
-Grant,Ward 2,State Treasurer,,,Carmen Alldritt,65
-Grant,Ward 3,State Treasurer,,,Carmen Alldritt,69
-Grant,Prec 4,State Treasurer,,,Carmen Alldritt,31
-Grant,Ward 1,State Treasurer,,,Ron Estes,153
-Grant,Ward 2,State Treasurer,,,Ron Estes,363
-Grant,Ward 3,State Treasurer,,,Ron Estes,328
-Grant,Prec 4,State Treasurer,,,Ron Estes,272
-Grant,Ward 1,U.S. Senate,,,Greg Orman [I],45
-Grant,Ward 2,U.S. Senate,,,Greg Orman [I],117
-Grant,Ward 3,U.S. Senate,,,Greg Orman [I],101
-Grant,Prec 4,U.S. Senate,,,Greg Orman [I],37
-Grant,Ward 1,U.S. Senate,,,Pat Roberts,133
-Grant,Ward 2,U.S. Senate,,,Pat Roberts,294
-Grant,Ward 3,U.S. Senate,,,Pat Roberts,286
-Grant,Prec 4,U.S. Senate,,,Pat Roberts,250
-Grant,Ward 1,U.S. Senate,,,Randall Batson,6
-Grant,Ward 2,U.S. Senate,,,Randall Batson,18
-Grant,Ward 3,U.S. Senate,,,Randall Batson,21
-Grant,Prec 4,U.S. Senate,,,Randall Batson,21
-Grant,Ward 1,Voters,,,Provisional,5
-Grant,Ward 2,Voters,,,Provisional,10
-Grant,Ward 3,Voters,,,Provisional,22
-Grant,Prec 4,Voters,,,Provisional,14
-Grant,Ward 1,Voters,,,Registered voters,574
-Grant,Ward 2,Voters,,,Registered voters,978
-Grant,Ward 3,Voters,,,Registered voters,1129
-Grant,Prec 4,Voters,,,Registered voters,724
-Grant,Ward 1,Voters,,,Total Votes Cast,192
-Grant,Ward 2,Voters,,,Total Votes Cast,447
-Grant,Ward 3,Voters,,,Total Votes Cast,436
-Grant,Prec 4,Voters,,,Total Votes Cast,325
-Grant,Ward 1,Voters,,,Votes cast at polls,187
-Grant,Ward 2,Voters,,,Votes cast at polls,437
-Grant,Ward 3,Voters,,,Votes cast at polls,414
-Grant,Prec 4,Voters,,,Votes cast at polls,311
-Grant,Advance,U.S. Senate,,R,Pat Roberts,289
-Grant,Prov,U.S. Senate,,R,Pat Roberts,23
-Grant,Advance,U.S. Senate,,I,Greg Orman [I],99
-Grant,Prov,U.S. Senate,,I,Greg Orman [I],14
-Grant,Advance,U.S. Senate,,L,Randall Batson,15
-Grant,Prov,U.S. Senate,,L,Randall Batson,3
-Grant,Advance,U.S. House,1,R,Tim Huelskamp,298
-Grant,Prov,U.S. House,1,R,Tim Huelskamp,28
-Grant,Advance,U.S. House,1,D,James E. Sherow,98
-Grant,Prov,U.S. House,1,D,James E. Sherow,11
-Grant,Advance,Governor,,R,Sam Brownback,259
-Grant,Prov,Governor,,R,Sam Brownback,20
-Grant,Advance,Governor,,D,Paul Davis,127
-Grant,Prov,Governor,,D,Paul Davis,13
-Grant,Advance,Governor,,L,Keen Umbehr,15
-Grant,Prov,Governor,,L,Keen Umbehr,6
-Grant,Advance,Secretary of State,,R,Kris Kobach,297
-Grant,Prov,Secretary of State,,R,Kris Kobach,28
-Grant,Advance,Secretary of State,,D,Jean Kurtis Schodorf,96
-Grant,Prov,Secretary of State,,D,Jean Kurtis Schodorf,10
-Grant,Advance,Attorney General,,R,Derek Schmidt,316
-Grant,Prov,Attorney General,,R,Derek Schmidt,27
-Grant,Advance,Attorney General,,D,A J Kotich,73
-Grant,Prov,Attorney General,,D,A J Kotich,11
-Grant,Advance,State Treasurer,,R,Ron Estes,320
-Grant,Prov,State Treasurer,,R,Ron Estes,27
-Grant,Advance,State Treasurer,,D,Carmen Alldritt,67
-Grant,Prov,State Treasurer,,D,Carmen Alldritt,11
-Grant,Advance,Insurance Commissioner,,R,Ken Selzer,302
-Grant,Prov,Insurance Commissioner,,R,Ken Selzer,27
-Grant,Advance,Insurance Commissioner,,D,Dennis Anderson,78
-Grant,Prov,Insurance Commissioner,,D,Dennis Anderson,11
-Grant,Advance,State House,124,R,Stephen Alford,342
-Grant,Prov,State House,124,R,Stephen Alford,35
+county,precinct,office,district,party,candidate,votes,vtd
+GRANT,Ulysses Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,000020
+GRANT,Ulysses Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000020
+GRANT,Ulysses Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",145,000020
+GRANT,Ulysses Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",182,00003A
+GRANT,Ulysses Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,00003A
+GRANT,Ulysses Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",371,00003A
+GRANT,Ulysses Ward 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00003B
+GRANT,Ulysses Ward 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00003B
+GRANT,Ulysses Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",178,000040
+GRANT,Ulysses Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",50,000040
+GRANT,Ulysses Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",354,000040
+GRANT,Precinct 4 H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120020
+GRANT,Precinct 4 H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120020
+GRANT,Precinct 4 H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120020
+GRANT,Precinct 4 H124,Governor / Lt. Governor,,Democratic,"Davis, Paul",85,120030
+GRANT,Precinct 4 H124,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",32,120030
+GRANT,Precinct 4 H124,Governor / Lt. Governor,,Republican,"Brownback, Sam",287,120030
+GRANT,Ulysses Ward 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",191,000020
+GRANT,Ulysses Ward 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",514,00003A
+GRANT,Ulysses Ward 2 Exclave,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",0,00003B
+GRANT,Ulysses Ward 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",513,000040
+GRANT,Precinct 4 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,120020
+GRANT,Precinct 4 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",364,120030
+GRANT,Ulysses Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",50,000020
+GRANT,Ulysses Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000020
+GRANT,Ulysses Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",124,00003A
+GRANT,Ulysses Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",439,00003A
+GRANT,Ulysses Ward 2 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00003B
+GRANT,Ulysses Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",139,000040
+GRANT,Ulysses Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",434,000040
+GRANT,Precinct 4 H122,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120020
+GRANT,Precinct 4 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120020
+GRANT,Precinct 4 H124,United States House of Representatives,1,Democratic,"Sherow, James E.",62,120030
+GRANT,Precinct 4 H124,United States House of Representatives,1,Republican,"Huelskamp, Tim",341,120030
+GRANT,Ulysses Ward 1,Attorney General,,Democratic,"Kotich, A.J.",39,000020
+GRANT,Ulysses Ward 1,Attorney General,,Republican,"Schmidt, Derek",175,000020
+GRANT,Ulysses Ward 2,Attorney General,,Democratic,"Kotich, A.J.",107,00003A
+GRANT,Ulysses Ward 2,Attorney General,,Republican,"Schmidt, Derek",450,00003A
+GRANT,Ulysses Ward 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00003B
+GRANT,Ulysses Ward 3,Attorney General,,Democratic,"Kotich, A.J.",118,000040
+GRANT,Ulysses Ward 3,Attorney General,,Republican,"Schmidt, Derek",449,000040
+GRANT,Precinct 4 H122,Attorney General,,Democratic,"Kotich, A.J.",0,120020
+GRANT,Precinct 4 H122,Attorney General,,Republican,"Schmidt, Derek",0,120020
+GRANT,Precinct 4 H124,Attorney General,,Democratic,"Kotich, A.J.",47,120030
+GRANT,Precinct 4 H124,Attorney General,,Republican,"Schmidt, Derek",355,120030
+GRANT,Ulysses Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000020
+GRANT,Ulysses Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",166,000020
+GRANT,Ulysses Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",111,00003A
+GRANT,Ulysses Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",446,00003A
+GRANT,Ulysses Ward 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00003B
+GRANT,Ulysses Ward 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00003B
+GRANT,Ulysses Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",126,000040
+GRANT,Ulysses Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",430,000040
+GRANT,Precinct 4 H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120020
+GRANT,Precinct 4 H122,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120020
+GRANT,Precinct 4 H124,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,120030
+GRANT,Precinct 4 H124,Commissioner of Insurance,,Republican,"Selzer, Ken",337,120030
+GRANT,Ulysses Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",64,000020
+GRANT,Ulysses Ward 1,Secretary of State,,Republican,"Kobach, Kris",152,000020
+GRANT,Ulysses Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",114,00003A
+GRANT,Ulysses Ward 2,Secretary of State,,Republican,"Kobach, Kris",451,00003A
+GRANT,Ulysses Ward 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00003B
+GRANT,Ulysses Ward 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00003B
+GRANT,Ulysses Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,000040
+GRANT,Ulysses Ward 3,Secretary of State,,Republican,"Kobach, Kris",428,000040
+GRANT,Precinct 4 H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120020
+GRANT,Precinct 4 H122,Secretary of State,,Republican,"Kobach, Kris",0,120020
+GRANT,Precinct 4 H124,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,120030
+GRANT,Precinct 4 H124,Secretary of State,,Republican,"Kobach, Kris",329,120030
+GRANT,Ulysses Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",33,000020
+GRANT,Ulysses Ward 1,State Treasurer,,Republican,"Estes, Ron",181,000020
+GRANT,Ulysses Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",93,00003A
+GRANT,Ulysses Ward 2,State Treasurer,,Republican,"Estes, Ron",468,00003A
+GRANT,Ulysses Ward 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00003B
+GRANT,Ulysses Ward 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00003B
+GRANT,Ulysses Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",103,000040
+GRANT,Ulysses Ward 3,State Treasurer,,Republican,"Estes, Ron",459,000040
+GRANT,Precinct 4 H122,State Treasurer,,Democratic,"Alldritt, Carmen",0,120020
+GRANT,Precinct 4 H122,State Treasurer,,Republican,"Estes, Ron",0,120020
+GRANT,Precinct 4 H124,State Treasurer,,Democratic,"Alldritt, Carmen",43,120030
+GRANT,Precinct 4 H124,State Treasurer,,Republican,"Estes, Ron",355,120030
+GRANT,Ulysses Ward 1,United States Senate,,independent,"Orman, Greg",51,000020
+GRANT,Ulysses Ward 1,United States Senate,,Libertarian,"Batson, Randall",8,000020
+GRANT,Ulysses Ward 1,United States Senate,,Republican,"Roberts, Pat",158,000020
+GRANT,Ulysses Ward 2,United States Senate,,independent,"Orman, Greg",155,00003A
+GRANT,Ulysses Ward 2,United States Senate,,Libertarian,"Batson, Randall",20,00003A
+GRANT,Ulysses Ward 2,United States Senate,,Republican,"Roberts, Pat",394,00003A
+GRANT,Ulysses Ward 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00003B
+GRANT,Ulysses Ward 3,United States Senate,,independent,"Orman, Greg",149,000040
+GRANT,Ulysses Ward 3,United States Senate,,Libertarian,"Batson, Randall",30,000040
+GRANT,Ulysses Ward 3,United States Senate,,Republican,"Roberts, Pat",403,000040
+GRANT,Precinct 4 H122,United States Senate,,independent,"Orman, Greg",0,120020
+GRANT,Precinct 4 H122,United States Senate,,Libertarian,"Batson, Randall",0,120020
+GRANT,Precinct 4 H122,United States Senate,,Republican,"Roberts, Pat",0,120020
+GRANT,Precinct 4 H124,United States Senate,,independent,"Orman, Greg",58,120030
+GRANT,Precinct 4 H124,United States Senate,,Libertarian,"Batson, Randall",26,120030
+GRANT,Precinct 4 H124,United States Senate,,Republican,"Roberts, Pat",320,120030

--- a/2014/20141104__ks__general__gray__precinct.csv
+++ b/2014/20141104__ks__general__gray__precinct.csv
@@ -1,137 +1,145 @@
-county,precinct,office,district,party,candidate,votes
-Gray,Cimarron#1,U.S. Senate,,R,Pat Roberts,158
-Gray,Cimarron#2,U.S. Senate,,R,Pat Roberts,424
-Gray,Copeland,U.S. Senate,,R,Pat Roberts,94
-Gray,East  Hess,U.S. Senate,,R,Pat Roberts,85
-Gray,Foote,U.S. Senate,,R,Pat Roberts,35
-Gray,Ingalls,U.S. Senate,,R,Pat Roberts,126
-Gray,Logan,U.S. Senate,,R,Pat Roberts,61
-Gray,Montezuma,U.S. Senate,,R,Pat Roberts,227
-Gray,Cimarron#1,U.S. Senate,,I ,Greg Orman,60
-Gray,Cimarron#2,U.S. Senate,,I ,Greg Orman,135
-Gray,Copeland,U.S. Senate,,I ,Greg Orman,17
-Gray,East  Hess,U.S. Senate,,I ,Greg Orman,19
-Gray,Foote,U.S. Senate,,I ,Greg Orman,8
-Gray,Ingalls,U.S. Senate,,I ,Greg Orman,35
-Gray,Logan,U.S. Senate,,I ,Greg Orman,21
-Gray,Montezuma,U.S. Senate,,I ,Greg Orman,65
-Gray,Cimarron#1,U.S. Senate,,L,Randall Batson,5
-Gray,Cimarron#2,U.S. Senate,,L,Randall Batson,32
-Gray,Copeland,U.S. Senate,,L,Randall Batson,4
-Gray,East  Hess,U.S. Senate,,L,Randall Batson,3
-Gray,Foote,U.S. Senate,,L,Randall Batson,0
-Gray,Ingalls,U.S. Senate,,L,Randall Batson,11
-Gray,Logan,U.S. Senate,,L,Randall Batson,1
-Gray,Montezuma,U.S. Senate,,L,Randall Batson,13
-Gray,Cimarron#1,U.S. House,1,R,Tim Huelskamp,166
-Gray,Cimarron#2,U.S. House,1,R,Tim Huelskamp,419
-Gray,Copeland,U.S. House,1,R,Tim Huelskamp,84
-Gray,East  Hess,U.S. House,1,R,Tim Huelskamp,90
-Gray,Foote,U.S. House,1,R,Tim Huelskamp,34
-Gray,Ingalls,U.S. House,1,R,Tim Huelskamp,122
-Gray,Logan,U.S. House,1,R,Tim Huelskamp,56
-Gray,Montezuma,U.S. House,1,R,Tim Huelskamp,223
-Gray,Cimarron#1,U.S. House,1,D,James Therow,55
-Gray,Cimarron#2,U.S. House,1,D,James Therow,164
-Gray,Copeland,U.S. House,1,D,James Therow,29
-Gray,East  Hess,U.S. House,1,D,James Therow,18
-Gray,Foote,U.S. House,1,D,James Therow,8
-Gray,Ingalls,U.S. House,1,D,James Therow,49
-Gray,Logan,U.S. House,1,D,James Therow,26
-Gray,Montezuma,U.S. House,1,D,James Therow,77
-Gray,Cimarron#1,Governor,,R,Sam Brownback,148
-Gray,Cimarron#2,Governor,,R,Sam Brownback,384
-Gray,Copeland,Governor,,R,Sam Brownback,80
-Gray,East  Hess,Governor,,R,Sam Brownback,81
-Gray,Foote,Governor,,R,Sam Brownback,35
-Gray,Ingalls,Governor,,R,Sam Brownback,115
-Gray,Logan,Governor,,R,Sam Brownback,63
-Gray,Montezuma,Governor,,R,Sam Brownback,207
-Gray,Cimarron#1,Governor,,D,Paul Davis,65
-Gray,Cimarron#2,Governor,,D,Paul Davis,177
-Gray,Copeland,Governor,,D,Paul Davis,26
-Gray,East  Hess,Governor,,D,Paul Davis,23
-Gray,Foote,Governor,,D,Paul Davis,7
-Gray,Ingalls,Governor,,D,Paul Davis,50
-Gray,Logan,Governor,,D,Paul Davis,19
-Gray,Montezuma,Governor,,D,Paul Davis,65
-Gray,Cimarron#1,Governor,,L,Keen Umbehr,7
-Gray,Cimarron#2,Governor,,L,Keen Umbehr,30
-Gray,Copeland,Governor,,L,Keen Umbehr,8
-Gray,East  Hess,Governor,,L,Keen Umbehr,2
-Gray,Foote,Governor,,L,Keen Umbehr,1
-Gray,Ingalls,Governor,,L,Keen Umbehr,8
-Gray,Logan,Governor,,L,Keen Umbehr,1
-Gray,Montezuma,Governor,,L,Keen Umbehr,17
-Gray,Cimarron#1,Secretary of State,,R,Kris Kobach,173
-Gray,Cimarron#2,Secretary of State,,R,Kris Kobach,468
-Gray,Copeland,Secretary of State,,R,Kris Kobach,99
-Gray,East  Hess,Secretary of State,,R,Kris Kobach,81
-Gray,Foote,Secretary of State,,R,Kris Kobach,37
-Gray,Ingalls,Secretary of State,,R,Kris Kobach,135
-Gray,Logan,Secretary of State,,R,Kris Kobach,66
-Gray,Montezuma,Secretary of State,,R,Kris Kobach,246
-Gray,Cimarron#1,Secretary of State,,D,Jean Schodorf,48
-Gray,Cimarron#2,Secretary of State,,D,Jean Schodorf,116
-Gray,Copeland,Secretary of State,,D,Jean Schodorf,15
-Gray,East  Hess,Secretary of State,,D,Jean Schodorf,24
-Gray,Foote,Secretary of State,,D,Jean Schodorf,6
-Gray,Ingalls,Secretary of State,,D,Jean Schodorf,38
-Gray,Logan,Secretary of State,,D,Jean Schodorf,14
-Gray,Montezuma,Secretary of State,,D,Jean Schodorf,57
-Gray,Cimarron#1,Attorney General,,D,A J Kotich,32
-Gray,Cimarron#2,Attorney General,,D,A J Kotich,98
-Gray,Copeland,Attorney General,,D,A J Kotich,15
-Gray,East  Hess,Attorney General,,D,A J Kotich,18
-Gray,Foote,Attorney General,,D,A J Kotich,4
-Gray,Ingalls,Attorney General,,D,A J Kotich,29
-Gray,Logan,Attorney General,,D,A J Kotich,8
-Gray,Montezuma,Attorney General,,D,A J Kotich,39
-Gray,Cimarron#1,Attorney General,,R,Derek Schmidt,187
-Gray,Cimarron#2,Attorney General,,R,Derek Schmidt,483
-Gray,Copeland,Attorney General,,R,Derek Schmidt,96
-Gray,East  Hess,Attorney General,,R,Derek Schmidt,85
-Gray,Foote,Attorney General,,R,Derek Schmidt,39
-Gray,Ingalls,Attorney General,,R,Derek Schmidt,143
-Gray,Logan,Attorney General,,R,Derek Schmidt,74
-Gray,Montezuma,Attorney General,,R,Derek Schmidt,263
-Gray,Cimarron#1,State Treasurer,,R,Ron Estes,188
-Gray,Cimarron#2,State Treasurer,,R,Ron Estes,508
-Gray,Copeland,State Treasurer,,R,Ron Estes,101
-Gray,East  Hess,State Treasurer,,R,Ron Estes,94
-Gray,Foote,State Treasurer,,R,Ron Estes,40
-Gray,Ingalls,State Treasurer,,R,Ron Estes,149
-Gray,Logan,State Treasurer,,R,Ron Estes,71
-Gray,Montezuma,State Treasurer,,R,Ron Estes,264
-Gray,Cimarron#1,State Treasurer,,D,Carmen Alldritt,32
-Gray,Cimarron#2,State Treasurer,,D,Carmen Alldritt,69
-Gray,Copeland,State Treasurer,,D,Carmen Alldritt,11
-Gray,East  Hess,State Treasurer,,D,Carmen Alldritt,9
-Gray,Foote,State Treasurer,,D,Carmen Alldritt,3
-Gray,Ingalls,State Treasurer,,D,Carmen Alldritt,23
-Gray,Logan,State Treasurer,,D,Carmen Alldritt,10
-Gray,Montezuma,State Treasurer,,D,Carmen Alldritt,36
-Gray,Cimarron#1,Insurance Commissioner,,R,Ken Selzer,160
-Gray,Cimarron#2,Insurance Commissioner,,R,Ken Selzer,451
-Gray,Copeland,Insurance Commissioner,,R,Ken Selzer,87
-Gray,East  Hess,Insurance Commissioner,,R,Ken Selzer,77
-Gray,Foote,Insurance Commissioner,,R,Ken Selzer,37
-Gray,Ingalls,Insurance Commissioner,,R,Ken Selzer,132
-Gray,Logan,Insurance Commissioner,,R,Ken Selzer,62
-Gray,Montezuma,Insurance Commissioner,,R,Ken Selzer,241
-Gray,Cimarron#1,Insurance Commissioner,,D,Dennis Anderson,45
-Gray,Cimarron#2,Insurance Commissioner,,D,Dennis Anderson,114
-Gray,Copeland,Insurance Commissioner,,D,Dennis Anderson,22
-Gray,East  Hess,Insurance Commissioner,,D,Dennis Anderson,24
-Gray,Foote,Insurance Commissioner,,D,Dennis Anderson,6
-Gray,Ingalls,Insurance Commissioner,,D,Dennis Anderson,35
-Gray,Logan,Insurance Commissioner,,D,Dennis Anderson,20
-Gray,Montezuma,Insurance Commissioner,,D,Dennis Anderson,48
-Gray,Cimarron#1,State House,115,R,Ronald Ryckman,170
-Gray,Cimarron#2,State House,115,R,Ronald Ryckman,455
-Gray,Copeland,State House,115,R,Ronald Ryckman,78
-Gray,East  Hess,State House,115,R,Ronald Ryckman,77
-Gray,Foote,State House,115,R,Ronald Ryckman,34
-Gray,Ingalls,State House,115,R,Ronald Ryckman,136
-Gray,Logan,State House,115,R,Ronald Ryckman,63
-Gray,Montezuma,State House,115,R,Ronald Ryckman,223
+county,precinct,office,district,party,candidate,votes,vtd
+GRAY,Copeland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000020
+GRAY,Copeland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000020
+GRAY,Copeland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000020
+GRAY,East Hess Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000030
+GRAY,East Hess Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000030
+GRAY,East Hess Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,000030
+GRAY,Foote Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000040
+GRAY,Foote Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+GRAY,Foote Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000040
+GRAY,Ingalls Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000050
+GRAY,Ingalls Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000050
+GRAY,Ingalls Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000050
+GRAY,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000060
+GRAY,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+GRAY,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000060
+GRAY,Montezuma Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",85,000070
+GRAY,Montezuma Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000070
+GRAY,Montezuma Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",207,000070
+GRAY,Cimarron Township Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,500010
+GRAY,Cimarron Township Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,500010
+GRAY,Cimarron Township Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",148,500010
+GRAY,Cimarron Township Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",177,500020
+GRAY,Cimarron Township Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,500020
+GRAY,Cimarron Township Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",384,500020
+GRAY,Copeland Township,Kansas House of Representatives,115,Democratic,"Low, Mark",34,000020
+GRAY,Copeland Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",78,000020
+GRAY,East Hess Township,Kansas House of Representatives,115,Democratic,"Low, Mark",30,000030
+GRAY,East Hess Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",77,000030
+GRAY,Foote Township,Kansas House of Representatives,115,Democratic,"Low, Mark",9,000040
+GRAY,Foote Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",34,000040
+GRAY,Ingalls Township,Kansas House of Representatives,115,Democratic,"Low, Mark",36,000050
+GRAY,Ingalls Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",136,000050
+GRAY,Logan Township,Kansas House of Representatives,115,Democratic,"Low, Mark",18,000060
+GRAY,Logan Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",63,000060
+GRAY,Montezuma Township,Kansas House of Representatives,115,Democratic,"Low, Mark",81,000070
+GRAY,Montezuma Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",223,000070
+GRAY,Cimarron Township Precinct 1,Kansas House of Representatives,115,Democratic,"Low, Mark",50,500010
+GRAY,Cimarron Township Precinct 1,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",170,500010
+GRAY,Cimarron Township Precinct 2,Kansas House of Representatives,115,Democratic,"Low, Mark",124,500020
+GRAY,Cimarron Township Precinct 2,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",455,500020
+GRAY,Copeland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000020
+GRAY,Copeland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000020
+GRAY,East Hess Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000030
+GRAY,East Hess Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",90,000030
+GRAY,Foote Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000040
+GRAY,Foote Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000040
+GRAY,Ingalls Township,United States House of Representatives,1,Democratic,"Sherow, James E.",49,000050
+GRAY,Ingalls Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",122,000050
+GRAY,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",26,000060
+GRAY,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000060
+GRAY,Montezuma Township,United States House of Representatives,1,Democratic,"Sherow, James E.",77,000070
+GRAY,Montezuma Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",223,000070
+GRAY,Cimarron Township Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",55,500010
+GRAY,Cimarron Township Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",166,500010
+GRAY,Cimarron Township Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",164,500020
+GRAY,Cimarron Township Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",419,500020
+GRAY,Copeland Township,Attorney General,,Democratic,"Kotich, A.J.",15,000020
+GRAY,Copeland Township,Attorney General,,Republican,"Schmidt, Derek",96,000020
+GRAY,East Hess Township,Attorney General,,Democratic,"Kotich, A.J.",18,000030
+GRAY,East Hess Township,Attorney General,,Republican,"Schmidt, Derek",85,000030
+GRAY,Foote Township,Attorney General,,Democratic,"Kotich, A.J.",4,000040
+GRAY,Foote Township,Attorney General,,Republican,"Schmidt, Derek",39,000040
+GRAY,Ingalls Township,Attorney General,,Democratic,"Kotich, A.J.",29,000050
+GRAY,Ingalls Township,Attorney General,,Republican,"Schmidt, Derek",143,000050
+GRAY,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",8,000060
+GRAY,Logan Township,Attorney General,,Republican,"Schmidt, Derek",74,000060
+GRAY,Montezuma Township,Attorney General,,Democratic,"Kotich, A.J.",39,000070
+GRAY,Montezuma Township,Attorney General,,Republican,"Schmidt, Derek",263,000070
+GRAY,Cimarron Township Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",32,500010
+GRAY,Cimarron Township Precinct 1,Attorney General,,Republican,"Schmidt, Derek",187,500010
+GRAY,Cimarron Township Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",98,500020
+GRAY,Cimarron Township Precinct 2,Attorney General,,Republican,"Schmidt, Derek",483,500020
+GRAY,Copeland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000020
+GRAY,Copeland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000020
+GRAY,East Hess Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000030
+GRAY,East Hess Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000030
+GRAY,Foote Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000040
+GRAY,Foote Township,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000040
+GRAY,Ingalls Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",35,000050
+GRAY,Ingalls Township,Commissioner of Insurance,,Republican,"Selzer, Ken",132,000050
+GRAY,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000060
+GRAY,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000060
+GRAY,Montezuma Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000070
+GRAY,Montezuma Township,Commissioner of Insurance,,Republican,"Selzer, Ken",241,000070
+GRAY,Cimarron Township Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,500010
+GRAY,Cimarron Township Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",160,500010
+GRAY,Cimarron Township Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",114,500020
+GRAY,Cimarron Township Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",451,500020
+GRAY,Copeland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000020
+GRAY,Copeland Township,Secretary of State,,Republican,"Kobach, Kris",99,000020
+GRAY,East Hess Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000030
+GRAY,East Hess Township,Secretary of State,,Republican,"Kobach, Kris",81,000030
+GRAY,Foote Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000040
+GRAY,Foote Township,Secretary of State,,Republican,"Kobach, Kris",37,000040
+GRAY,Ingalls Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000050
+GRAY,Ingalls Township,Secretary of State,,Republican,"Kobach, Kris",135,000050
+GRAY,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000060
+GRAY,Logan Township,Secretary of State,,Republican,"Kobach, Kris",66,000060
+GRAY,Montezuma Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000070
+GRAY,Montezuma Township,Secretary of State,,Republican,"Kobach, Kris",246,000070
+GRAY,Cimarron Township Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,500010
+GRAY,Cimarron Township Precinct 1,Secretary of State,,Republican,"Kobach, Kris",173,500010
+GRAY,Cimarron Township Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",116,500020
+GRAY,Cimarron Township Precinct 2,Secretary of State,,Republican,"Kobach, Kris",468,500020
+GRAY,Copeland Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000020
+GRAY,Copeland Township,State Treasurer,,Republican,"Estes, Ron",101,000020
+GRAY,East Hess Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000030
+GRAY,East Hess Township,State Treasurer,,Republican,"Estes, Ron",94,000030
+GRAY,Foote Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000040
+GRAY,Foote Township,State Treasurer,,Republican,"Estes, Ron",40,000040
+GRAY,Ingalls Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000050
+GRAY,Ingalls Township,State Treasurer,,Republican,"Estes, Ron",149,000050
+GRAY,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000060
+GRAY,Logan Township,State Treasurer,,Republican,"Estes, Ron",71,000060
+GRAY,Montezuma Township,State Treasurer,,Democratic,"Alldritt, Carmen",36,000070
+GRAY,Montezuma Township,State Treasurer,,Republican,"Estes, Ron",264,000070
+GRAY,Cimarron Township Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",32,500010
+GRAY,Cimarron Township Precinct 1,State Treasurer,,Republican,"Estes, Ron",188,500010
+GRAY,Cimarron Township Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",69,500020
+GRAY,Cimarron Township Precinct 2,State Treasurer,,Republican,"Estes, Ron",508,500020
+GRAY,Copeland Township,United States Senate,,independent,"Orman, Greg",17,000020
+GRAY,Copeland Township,United States Senate,,Libertarian,"Batson, Randall",4,000020
+GRAY,Copeland Township,United States Senate,,Republican,"Roberts, Pat",94,000020
+GRAY,East Hess Township,United States Senate,,independent,"Orman, Greg",19,000030
+GRAY,East Hess Township,United States Senate,,Libertarian,"Batson, Randall",3,000030
+GRAY,East Hess Township,United States Senate,,Republican,"Roberts, Pat",85,000030
+GRAY,Foote Township,United States Senate,,independent,"Orman, Greg",8,000040
+GRAY,Foote Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+GRAY,Foote Township,United States Senate,,Republican,"Roberts, Pat",35,000040
+GRAY,Ingalls Township,United States Senate,,independent,"Orman, Greg",35,000050
+GRAY,Ingalls Township,United States Senate,,Libertarian,"Batson, Randall",11,000050
+GRAY,Ingalls Township,United States Senate,,Republican,"Roberts, Pat",126,000050
+GRAY,Logan Township,United States Senate,,independent,"Orman, Greg",21,000060
+GRAY,Logan Township,United States Senate,,Libertarian,"Batson, Randall",1,000060
+GRAY,Logan Township,United States Senate,,Republican,"Roberts, Pat",61,000060
+GRAY,Montezuma Township,United States Senate,,independent,"Orman, Greg",65,000070
+GRAY,Montezuma Township,United States Senate,,Libertarian,"Batson, Randall",13,000070
+GRAY,Montezuma Township,United States Senate,,Republican,"Roberts, Pat",227,000070
+GRAY,Cimarron Township Precinct 1,United States Senate,,independent,"Orman, Greg",60,500010
+GRAY,Cimarron Township Precinct 1,United States Senate,,Libertarian,"Batson, Randall",5,500010
+GRAY,Cimarron Township Precinct 1,United States Senate,,Republican,"Roberts, Pat",158,500010
+GRAY,Cimarron Township Precinct 2,United States Senate,,independent,"Orman, Greg",135,500020
+GRAY,Cimarron Township Precinct 2,United States Senate,,Libertarian,"Batson, Randall",32,500020
+GRAY,Cimarron Township Precinct 2,United States Senate,,Republican,"Roberts, Pat",424,500020

--- a/2014/20141104__ks__general__greeley__precinct.csv
+++ b/2014/20141104__ks__general__greeley__precinct.csv
@@ -1,58 +1,52 @@
-county,precinct,office,district,party,candidate,votes,,
-Greeley,MSD,Voters,,,Registered,566,,
-Greeley,GSD,Voters,,,Registered,287,,
-Greeley,HC,Voters,,,Registered,73,,
-Greeley,MSD,Voters,,,Cast,346,,
-Greeley,GSD,Voters,,,Cast,174,,
-Greeley,HC,Voters,,,Cast,56,,
-Greeley,MSD,U.S. Senate,,R,Pat Roberts,250,,
-Greeley,GSD,U.S. Senate,,R,Pat Roberts,138,,
-Greeley,HC,U.S. Senate,,R,Pat Roberts,38,,
-Greeley,MSD,U.S. Senate,,I,Greg Orman,72,,
-Greeley,GSD,U.S. Senate,,I,Greg Orman,28,,
-Greeley,HC,U.S. Senate,,I,Greg Orman,13,,
-Greeley,MSD,U.S. Senate,,L,Randall Batson,16,,
-Greeley,GSD,U.S. Senate,,L,Randall Batson,7,,
-Greeley,HC,U.S. Senate,,L,Randall Batson,4,,
-Greeley,MSD,U.S. House,1,R,Tim Huelskamp,261,,
-Greeley,GSD,U.S. House,1,R,Tim Huelskamp,138,,
-Greeley,HC,U.S. House,1,R,Tim Huelskamp,45,,
-Greeley,MSD,U.S. House,1,D,James Sherow,72,,
-Greeley,GSD,U.S. House,1,D,James Sherow,28,,
-Greeley,HC,U.S. House,1,D,James Sherow,8,,
-Greeley,MSD,Governor,,R,Sam Brownback,219,,
-Greeley,GSD,Governor,,R,Sam Brownback,127,,
-Greeley,HC,Governor,,R,Sam Brownback,37,,
-Greeley,MSD,Governor,,D,Paul Davis,100,,
-Greeley,GSD,Governor,,D,Paul Davis,38,,
-Greeley,HC,Governor,,D,Paul Davis,16,,
-Greeley,MSD,Governor,,L,Keen Umbehr,17,,
-Greeley,GSD,Governor,,L,Keen Umbehr,3,,
-Greeley,HC,Governor,,L,Keen Umbehr,3,,
-Greeley,MSD,Secretary of State,,R,Kris Kobach,268,,
-Greeley,GSD,Secretary of State,,R,Kris Kobach,139,,
-Greeley,HC,Secretary of State,,R,Kris Kobach,42,,
-Greeley,MSD,Secretary of State,,D,Jean Schodorf,64,,
-Greeley,GSD,Secretary of State,,D,Jean Schodorf,26,,
-Greeley,HC,Secretary of State,,D,Jean Schodorf,12,,
-Greeley,MSD,Attorney General,,R,Derek Schmidt,277,,
-Greeley,GSD,Attorney General,,R,Derek Schmidt,143,,
-Greeley,HC,Attorney General,,R,Derek Schmidt,45,,
-Greeley,MSD,Attorney General,,D,AJ Kotich,52,,
-Greeley,GSD,Attorney General,,D,AJ Kotich,20,,
-Greeley,HC,Attorney General,,D,AJ Kotich,10,,
-Greeley,MSD,State Treasurer,,R,Ron Estes,293,,
-Greeley,GSD,State Treasurer,,R,Ron Estes,143,,
-Greeley,HC,State Treasurer,,R,Ron Estes,47,,
-Greeley,MSD,State Treasurer,,D,Carmen Alldritt,36,,
-Greeley,GSD,State Treasurer,,D,Carmen Alldritt,21,,
-Greeley,HC,State Treasurer,,D,Carmen Alldritt,7,,
-Greeley,MSD,Insurance Commissioner,,R,Ken Selzer,255,,
-Greeley,GSD,Insurance Commissioner,,R,Ken Selzer,135,,
-Greeley,HC,Insurance Commissioner,,R,Ken Selzer,46,,
-Greeley,MSD,Insurance Commissioner,,D,Dennis Anderson,62,,
-Greeley,GSD,Insurance Commissioner,,D,Dennis Anderson,22,,
-Greeley,HC,Insurance Commissioner,,D,Dennis Anderson,8,,
-Greeley,MSD,State House,122,R,Russ Jennings,319,,
-Greeley,GSD,State House,122,R,Russ Jennings,143,,
-Greeley,HC,State House,122,R,Russ Jennings,56,,
+county,precinct,office,district,party,candidate,votes,vtd
+GREELEY,Tribune Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",100,000010
+GREELEY,Tribune Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000010
+GREELEY,Tribune Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",219,000010
+GREELEY,Tribune Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,000020
+GREELEY,Tribune Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000020
+GREELEY,Tribune Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",127,000020
+GREELEY,Tribune Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000030
+GREELEY,Tribune Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000030
+GREELEY,Tribune Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000030
+GREELEY,Tribune Precinct 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",319,000010
+GREELEY,Tribune Precinct 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",146,000020
+GREELEY,Tribune Precinct 3,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",53,000030
+GREELEY,Tribune Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",72,000010
+GREELEY,Tribune Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",261,000010
+GREELEY,Tribune Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",28,000020
+GREELEY,Tribune Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",138,000020
+GREELEY,Tribune Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000030
+GREELEY,Tribune Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000030
+GREELEY,Tribune Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",52,000010
+GREELEY,Tribune Precinct 1,Attorney General,,Republican,"Schmidt, Derek",277,000010
+GREELEY,Tribune Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",20,000020
+GREELEY,Tribune Precinct 2,Attorney General,,Republican,"Schmidt, Derek",143,000020
+GREELEY,Tribune Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",10,000030
+GREELEY,Tribune Precinct 3,Attorney General,,Republican,"Schmidt, Derek",45,000030
+GREELEY,Tribune Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,000010
+GREELEY,Tribune Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",255,000010
+GREELEY,Tribune Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000020
+GREELEY,Tribune Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",135,000020
+GREELEY,Tribune Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000030
+GREELEY,Tribune Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000030
+GREELEY,Tribune Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",64,000010
+GREELEY,Tribune Precinct 1,Secretary of State,,Republican,"Kobach, Kris",268,000010
+GREELEY,Tribune Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000020
+GREELEY,Tribune Precinct 2,Secretary of State,,Republican,"Kobach, Kris",139,000020
+GREELEY,Tribune Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000030
+GREELEY,Tribune Precinct 3,Secretary of State,,Republican,"Kobach, Kris",42,000030
+GREELEY,Tribune Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",36,000010
+GREELEY,Tribune Precinct 1,State Treasurer,,Republican,"Estes, Ron",293,000010
+GREELEY,Tribune Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",21,000020
+GREELEY,Tribune Precinct 2,State Treasurer,,Republican,"Estes, Ron",143,000020
+GREELEY,Tribune Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",7,000030
+GREELEY,Tribune Precinct 3,State Treasurer,,Republican,"Estes, Ron",47,000030
+GREELEY,Tribune Precinct 1,United States Senate,,independent,"Orman, Greg",72,000010
+GREELEY,Tribune Precinct 1,United States Senate,,Libertarian,"Batson, Randall",16,000010
+GREELEY,Tribune Precinct 1,United States Senate,,Republican,"Roberts, Pat",250,000010
+GREELEY,Tribune Precinct 2,United States Senate,,independent,"Orman, Greg",28,000020
+GREELEY,Tribune Precinct 2,United States Senate,,Libertarian,"Batson, Randall",7,000020
+GREELEY,Tribune Precinct 2,United States Senate,,Republican,"Roberts, Pat",138,000020
+GREELEY,Tribune Precinct 3,United States Senate,,independent,"Orman, Greg",13,000030
+GREELEY,Tribune Precinct 3,United States Senate,,Libertarian,"Batson, Randall",4,000030
+GREELEY,Tribune Precinct 3,United States Senate,,Republican,"Roberts, Pat",38,000030

--- a/2014/20141104__ks__general__greenwood__precinct.csv
+++ b/2014/20141104__ks__general__greenwood__precinct.csv
@@ -1,341 +1,358 @@
-county,precinct,office,district,party,candidate,votes
-Greenwood,Bachelor,Attorney General,,D,A.J. Kotich,13
-Greenwood,Eureka twp,Attorney General,,D,A.J. Kotich,31
-Greenwood,Fall River,Attorney General,,D,A.J. Kotich,21
-Greenwood,Janesville,Attorney General,,D,A.J. Kotich,19
-Greenwood,Lane,Attorney General,,D,A.J. Kotich,6
-Greenwood,Madison,Attorney General,,D,A.J. Kotich,72
-Greenwood,Otter Creek,Attorney General,,D,A.J. Kotich,23
-Greenwood,Pleasant Grv,Attorney General,,D,A.J. Kotich,3
-Greenwood,Quincy,Attorney General,,D,A.J. Kotich,6
-Greenwood,S Salem,Attorney General,,D,A.J. Kotich,4
-Greenwood,Saith Sprs,Attorney General,,D,A.J. Kotich,23
-Greenwood,Salem,Attorney General,,D,A.J. Kotich,2
-Greenwood,Shell Rock,Attorney General,,D,A.J. Kotich,6
-Greenwood,Spg Creek,Attorney General,,D,A.J. Kotich,5
-Greenwood,Twin Grove,Attorney General,,D,A.J. Kotich,33
-Greenwood,W1,Attorney General,,D,A.J. Kotich,56
-Greenwood,W2,Attorney General,,D,A.J. Kotich,39
-Greenwood,W3,Attorney General,,D,A.J. Kotich,42
-Greenwood,Bachelor,Attorney General,,R,Derek Schmidt,65
-Greenwood,Eureka twp,Attorney General,,R,Derek Schmidt,126
-Greenwood,Fall River,Attorney General,,R,Derek Schmidt,61
-Greenwood,Janesville,Attorney General,,R,Derek Schmidt,140
-Greenwood,Lane,Attorney General,,R,Derek Schmidt,33
-Greenwood,Madison,Attorney General,,R,Derek Schmidt,268
-Greenwood,Otter Creek,Attorney General,,R,Derek Schmidt,56
-Greenwood,Pleasant Grv,Attorney General,,R,Derek Schmidt,21
-Greenwood,Quincy,Attorney General,,R,Derek Schmidt,44
-Greenwood,S Salem,Attorney General,,R,Derek Schmidt,31
-Greenwood,Saith Sprs,Attorney General,,R,Derek Schmidt,96
-Greenwood,Salem,Attorney General,,R,Derek Schmidt,9
-Greenwood,Shell Rock,Attorney General,,R,Derek Schmidt,67
-Greenwood,Spg Creek,Attorney General,,R,Derek Schmidt,31
-Greenwood,Twin Grove,Attorney General,,R,Derek Schmidt,130
-Greenwood,W1,Attorney General,,R,Derek Schmidt,213
-Greenwood,W2,Attorney General,,R,Derek Schmidt,154
-Greenwood,W3,Attorney General,,R,Derek Schmidt,192
-Greenwood,Bachelor,U.S. House,,R,Mike Pompeo,65
-Greenwood,Eureka twp,U.S. House,,R,Mike Pompeo,122
-Greenwood,Fall River,U.S. House,,R,Mike Pompeo,58
-Greenwood,Janesville,U.S. House,,R,Mike Pompeo,138
-Greenwood,Lane,U.S. House,,R,Mike Pompeo,27
-Greenwood,Madison,U.S. House,,R,Mike Pompeo,266
-Greenwood,Otter Creek,U.S. House,,R,Mike Pompeo,54
-Greenwood,Pleasant Grv,U.S. House,,R,Mike Pompeo,15
-Greenwood,Quincy,U.S. House,,R,Mike Pompeo,43
-Greenwood,S Salem,U.S. House,,R,Mike Pompeo,31
-Greenwood,Saith Sprs,U.S. House,,R,Mike Pompeo,83
-Greenwood,Salem,U.S. House,,R,Mike Pompeo,9
-Greenwood,Shell Rock,U.S. House,,R,Mike Pompeo,64
-Greenwood,Spg Creek,U.S. House,,R,Mike Pompeo,29
-Greenwood,Twin Grove,U.S. House,,R,Mike Pompeo,120
-Greenwood,W1,U.S. House,,R,Mike Pompeo,201
-Greenwood,W2,U.S. House,,R,Mike Pompeo,147
-Greenwood,W3,U.S. House,,R,Mike Pompeo,186
-Greenwood,Bachelor,U.S. House,,D,Perry Schuckman,15
-Greenwood,Eureka twp,U.S. House,,D,Perry Schuckman,40
-Greenwood,Fall River,U.S. House,,D,Perry Schuckman,23
-Greenwood,Janesville,U.S. House,,D,Perry Schuckman,20
-Greenwood,Lane,U.S. House,,D,Perry Schuckman,12
-Greenwood,Madison,U.S. House,,D,Perry Schuckman,82
-Greenwood,Otter Creek,U.S. House,,D,Perry Schuckman,23
-Greenwood,Pleasant Grv,U.S. House,,D,Perry Schuckman,8
-Greenwood,Quincy,U.S. House,,D,Perry Schuckman,7
-Greenwood,S Salem,U.S. House,,D,Perry Schuckman,5
-Greenwood,Saith Sprs,U.S. House,,D,Perry Schuckman,35
-Greenwood,Salem,U.S. House,,D,Perry Schuckman,1
-Greenwood,Shell Rock,U.S. House,,D,Perry Schuckman,8
-Greenwood,Spg Creek,U.S. House,,D,Perry Schuckman,8
-Greenwood,Twin Grove,U.S. House,,D,Perry Schuckman,43
-Greenwood,W1,U.S. House,,D,Perry Schuckman,71
-Greenwood,W2,U.S. House,,D,Perry Schuckman,43
-Greenwood,W3,U.S. House,,D,Perry Schuckman,47
-Greenwood,Bachelor,Governor,,L,Keen Unbehr,4
-Greenwood,Eureka twp,Governor,,L,Keen Unbehr,7
-Greenwood,Fall River,Governor,,L,Keen Unbehr,5
-Greenwood,Janesville,Governor,,L,Keen Unbehr,7
-Greenwood,Lane,Governor,,L,Keen Unbehr,3
-Greenwood,Madison,Governor,,L,Keen Unbehr,22
-Greenwood,Otter Creek,Governor,,L,Keen Unbehr,2
-Greenwood,Pleasant Grv,Governor,,L,Keen Unbehr,0
-Greenwood,Quincy,Governor,,L,Keen Unbehr,1
-Greenwood,S Salem,Governor,,L,Keen Unbehr,3
-Greenwood,Saith Sprs,Governor,,L,Keen Unbehr,8
-Greenwood,Salem,Governor,,L,Keen Unbehr,1
-Greenwood,Shell Rock,Governor,,L,Keen Unbehr,3
-Greenwood,Spg Creek,Governor,,L,Keen Unbehr,5
-Greenwood,Twin Grove,Governor,,L,Keen Unbehr,6
-Greenwood,W1,Governor,,L,Keen Unbehr,15
-Greenwood,W2,Governor,,L,Keen Unbehr,10
-Greenwood,W3,Governor,,L,Keen Unbehr,20
-Greenwood,Bachelor,Governor,,D,Paul Davis,31
-Greenwood,Eureka twp,Governor,,D,Paul Davis,68
-Greenwood,Fall River,Governor,,D,Paul Davis,33
-Greenwood,Janesville,Governor,,D,Paul Davis,41
-Greenwood,Lane,Governor,,D,Paul Davis,13
-Greenwood,Madison,Governor,,D,Paul Davis,116
-Greenwood,Otter Creek,Governor,,D,Paul Davis,34
-Greenwood,Pleasant Grv,Governor,,D,Paul Davis,10
-Greenwood,Quincy,Governor,,D,Paul Davis,13
-Greenwood,S Salem,Governor,,D,Paul Davis,7
-Greenwood,Saith Sprs,Governor,,D,Paul Davis,42
-Greenwood,Salem,Governor,,D,Paul Davis,1
-Greenwood,Shell Rock,Governor,,D,Paul Davis,9
-Greenwood,Spg Creek,Governor,,D,Paul Davis,10
-Greenwood,Twin Grove,Governor,,D,Paul Davis,57
-Greenwood,W1,Governor,,D,Paul Davis,95
-Greenwood,W2,Governor,,D,Paul Davis,64
-Greenwood,W3,Governor,,D,Paul Davis,89
-Greenwood,Bachelor,Governor,,R,Sam Brownback,46
-Greenwood,Eureka twp,Governor,,R,Sam Brownback,86
-Greenwood,Fall River,Governor,,R,Sam Brownback,45
-Greenwood,Janesville,Governor,,R,Sam Brownback,112
-Greenwood,Lane,Governor,,R,Sam Brownback,24
-Greenwood,Madison,Governor,,R,Sam Brownback,215
-Greenwood,Otter Creek,Governor,,R,Sam Brownback,43
-Greenwood,Pleasant Grv,Governor,,R,Sam Brownback,15
-Greenwood,Quincy,Governor,,R,Sam Brownback,35
-Greenwood,S Salem,Governor,,R,Sam Brownback,26
-Greenwood,Saith Sprs,Governor,,R,Sam Brownback,72
-Greenwood,Salem,Governor,,R,Sam Brownback,10
-Greenwood,Shell Rock,Governor,,R,Sam Brownback,60
-Greenwood,Spg Creek,Governor,,R,Sam Brownback,24
-Greenwood,Twin Grove,Governor,,R,Sam Brownback,101
-Greenwood,W1,Governor,,R,Sam Brownback,162
-Greenwood,W2,Governor,,R,Sam Brownback,119
-Greenwood,W3,Governor,,R,Sam Brownback,131
-Greenwood,Bachelor,Insurance Commissioner,,D,Dennis Anderson,20
-Greenwood,Eureka twp,Insurance Commissioner,,D,Dennis Anderson,49
-Greenwood,Fall River,Insurance Commissioner,,D,Dennis Anderson,22
-Greenwood,Janesville,Insurance Commissioner,,D,Dennis Anderson,32
-Greenwood,Lane,Insurance Commissioner,,D,Dennis Anderson,13
-Greenwood,Madison,Insurance Commissioner,,D,Dennis Anderson,97
-Greenwood,Otter Creek,Insurance Commissioner,,D,Dennis Anderson,26
-Greenwood,Pleasant Grv,Insurance Commissioner,,D,Dennis Anderson,7
-Greenwood,Quincy,Insurance Commissioner,,D,Dennis Anderson,11
-Greenwood,S Salem,Insurance Commissioner,,D,Dennis Anderson,4
-Greenwood,Saith Sprs,Insurance Commissioner,,D,Dennis Anderson,36
-Greenwood,Salem,Insurance Commissioner,,D,Dennis Anderson,2
-Greenwood,Shell Rock,Insurance Commissioner,,D,Dennis Anderson,8
-Greenwood,Spg Creek,Insurance Commissioner,,D,Dennis Anderson,8
-Greenwood,Twin Grove,Insurance Commissioner,,D,Dennis Anderson,39
-Greenwood,W1,Insurance Commissioner,,D,Dennis Anderson,71
-Greenwood,W2,Insurance Commissioner,,D,Dennis Anderson,52
-Greenwood,W3,Insurance Commissioner,,D,Dennis Anderson,52
-Greenwood,Bachelor,Insurance Commissioner,,R,Ken Selzer,56
-Greenwood,Eureka twp,Insurance Commissioner,,R,Ken Selzer,108
-Greenwood,Fall River,Insurance Commissioner,,R,Ken Selzer,55
-Greenwood,Janesville,Insurance Commissioner,,R,Ken Selzer,126
-Greenwood,Lane,Insurance Commissioner,,R,Ken Selzer,25
-Greenwood,Madison,Insurance Commissioner,,R,Ken Selzer,239
-Greenwood,Otter Creek,Insurance Commissioner,,R,Ken Selzer,48
-Greenwood,Pleasant Grv,Insurance Commissioner,,R,Ken Selzer,17
-Greenwood,Quincy,Insurance Commissioner,,R,Ken Selzer,37
-Greenwood,S Salem,Insurance Commissioner,,R,Ken Selzer,29
-Greenwood,Saith Sprs,Insurance Commissioner,,R,Ken Selzer,79
-Greenwood,Salem,Insurance Commissioner,,R,Ken Selzer,10
-Greenwood,Shell Rock,Insurance Commissioner,,R,Ken Selzer,62
-Greenwood,Spg Creek,Insurance Commissioner,,R,Ken Selzer,28
-Greenwood,Twin Grove,Insurance Commissioner,,R,Ken Selzer,120
-Greenwood,W1,Insurance Commissioner,,R,Ken Selzer,189
-Greenwood,W2,Insurance Commissioner,,R,Ken Selzer,133
-Greenwood,W3,Insurance Commissioner,,R,Ken Selzer,173
-Greenwood,Bachelor,Secretary of State,,D,Jean Kurtis Schodorf,26
-Greenwood,Eureka twp,Secretary of State,,D,Jean Kurtis Schodorf,58
-Greenwood,Fall River,Secretary of State,,D,Jean Kurtis Schodorf,35
-Greenwood,Janesville,Secretary of State,,D,Jean Kurtis Schodorf,34
-Greenwood,Lane,Secretary of State,,D,Jean Kurtis Schodorf,16
-Greenwood,Madison,Secretary of State,,D,Jean Kurtis Schodorf,104
-Greenwood,Otter Creek,Secretary of State,,D,Jean Kurtis Schodorf,30
-Greenwood,Pleasant Grv,Secretary of State,,D,Jean Kurtis Schodorf,8
-Greenwood,Quincy,Secretary of State,,D,Jean Kurtis Schodorf,12
-Greenwood,S Salem,Secretary of State,,D,Jean Kurtis Schodorf,9
-Greenwood,Saith Sprs,Secretary of State,,D,Jean Kurtis Schodorf,42
-Greenwood,Salem,Secretary of State,,D,Jean Kurtis Schodorf,3
-Greenwood,Shell Rock,Secretary of State,,D,Jean Kurtis Schodorf,7
-Greenwood,Spg Creek,Secretary of State,,D,Jean Kurtis Schodorf,7
-Greenwood,Twin Grove,Secretary of State,,D,Jean Kurtis Schodorf,50
-Greenwood,W1,Secretary of State,,D,Jean Kurtis Schodorf,88
-Greenwood,W2,Secretary of State,,D,Jean Kurtis Schodorf,67
-Greenwood,W3,Secretary of State,,D,Jean Kurtis Schodorf,80
-Greenwood,Bachelor,Secretary of State,,R,Kris Kobach,53
-Greenwood,Eureka twp,Secretary of State,,R,Kris Kobach,104
-Greenwood,Fall River,Secretary of State,,R,Kris Kobach,48
-Greenwood,Janesville,Secretary of State,,R,Kris Kobach,129
-Greenwood,Lane,Secretary of State,,R,Kris Kobach,24
-Greenwood,Madison,Secretary of State,,R,Kris Kobach,247
-Greenwood,Otter Creek,Secretary of State,,R,Kris Kobach,48
-Greenwood,Pleasant Grv,Secretary of State,,R,Kris Kobach,16
-Greenwood,Quincy,Secretary of State,,R,Kris Kobach,38
-Greenwood,S Salem,Secretary of State,,R,Kris Kobach,26
-Greenwood,Saith Sprs,Secretary of State,,R,Kris Kobach,77
-Greenwood,Salem,Secretary of State,,R,Kris Kobach,9
-Greenwood,Shell Rock,Secretary of State,,R,Kris Kobach,65
-Greenwood,Spg Creek,Secretary of State,,R,Kris Kobach,31
-Greenwood,Twin Grove,Secretary of State,,R,Kris Kobach,113
-Greenwood,W1,Secretary of State,,R,Kris Kobach,187
-Greenwood,W2,Secretary of State,,R,Kris Kobach,126
-Greenwood,W3,Secretary of State,,R,Kris Kobach,157
-Greenwood,Bachelor,State House,13,R,Larry P Hibbard,68
-Greenwood,Eureka twp,State House,13,R,Larry P Hibbard,142
-Greenwood,Fall River,State House,13,R,Larry P Hibbard,71
-Greenwood,Janesville,State House,13,R,Larry P Hibbard,134
-Greenwood,Lane,State House,13,R,Larry P Hibbard,28
-Greenwood,Madison,State House,13,R,Larry P Hibbard,300
-Greenwood,Otter Creek,State House,13,R,Larry P Hibbard,63
-Greenwood,Pleasant Grv,State House,13,R,Larry P Hibbard,21
-Greenwood,Quincy,State House,13,R,Larry P Hibbard,43
-Greenwood,S Salem,State House,13,R,Larry P Hibbard,28
-Greenwood,Saith Sprs,State House,13,R,Larry P Hibbard,99
-Greenwood,Salem,State House,13,R,Larry P Hibbard,9
-Greenwood,Shell Rock,State House,13,R,Larry P Hibbard,63
-Greenwood,Spg Creek,State House,13,R,Larry P Hibbard,35
-Greenwood,Twin Grove,State House,13,R,Larry P Hibbard,141
-Greenwood,W1,State House,13,R,Larry P Hibbard,240
-Greenwood,W2,State House,13,R,Larry P Hibbard,167
-Greenwood,W3,State House,13,R,Larry P Hibbard,218
-Greenwood,Bachelor,State Treasurer,,D,Carmen Alldritt,14
-Greenwood,Eureka twp,State Treasurer,,D,Carmen Alldritt,28
-Greenwood,Fall River,State Treasurer,,D,Carmen Alldritt,21
-Greenwood,Janesville,State Treasurer,,D,Carmen Alldritt,17
-Greenwood,Lane,State Treasurer,,D,Carmen Alldritt,12
-Greenwood,Madison,State Treasurer,,D,Carmen Alldritt,74
-Greenwood,Otter Creek,State Treasurer,,D,Carmen Alldritt,26
-Greenwood,Pleasant Grv,State Treasurer,,D,Carmen Alldritt,2
-Greenwood,Quincy,State Treasurer,,D,Carmen Alldritt,5
-Greenwood,S Salem,State Treasurer,,D,Carmen Alldritt,5
-Greenwood,Saith Sprs,State Treasurer,,D,Carmen Alldritt,23
-Greenwood,Salem,State Treasurer,,D,Carmen Alldritt,0
-Greenwood,Shell Rock,State Treasurer,,D,Carmen Alldritt,6
-Greenwood,Spg Creek,State Treasurer,,D,Carmen Alldritt,4
-Greenwood,Twin Grove,State Treasurer,,D,Carmen Alldritt,30
-Greenwood,W1,State Treasurer,,D,Carmen Alldritt,69
-Greenwood,W2,State Treasurer,,D,Carmen Alldritt,37
-Greenwood,W3,State Treasurer,,D,Carmen Alldritt,36
-Greenwood,Bachelor,State Treasurer,,R,Ron Estes,65
-Greenwood,Eureka twp,State Treasurer,,R,Ron Estes,130
-Greenwood,Fall River,State Treasurer,,R,Ron Estes,58
-Greenwood,Janesville,State Treasurer,,R,Ron Estes,139
-Greenwood,Lane,State Treasurer,,R,Ron Estes,28
-Greenwood,Madison,State Treasurer,,R,Ron Estes,266
-Greenwood,Otter Creek,State Treasurer,,R,Ron Estes,50
-Greenwood,Pleasant Grv,State Treasurer,,R,Ron Estes,22
-Greenwood,Quincy,State Treasurer,,R,Ron Estes,43
-Greenwood,S Salem,State Treasurer,,R,Ron Estes,29
-Greenwood,Saith Sprs,State Treasurer,,R,Ron Estes,95
-Greenwood,Salem,State Treasurer,,R,Ron Estes,12
-Greenwood,Shell Rock,State Treasurer,,R,Ron Estes,66
-Greenwood,Spg Creek,State Treasurer,,R,Ron Estes,32
-Greenwood,Twin Grove,State Treasurer,,R,Ron Estes,133
-Greenwood,W1,State Treasurer,,R,Ron Estes,199
-Greenwood,W2,State Treasurer,,R,Ron Estes,151
-Greenwood,W3,State Treasurer,,R,Ron Estes,196
-Greenwood,Bachelor,U.S. Senate,,I,Greg Orman,29
-Greenwood,Eureka twp,U.S. Senate,,I,Greg Orman,54
-Greenwood,Fall River,U.S. Senate,,I,Greg Orman,32
-Greenwood,Janesville,U.S. Senate,,I,Greg Orman,31
-Greenwood,Lane,U.S. Senate,,I,Greg Orman,13
-Greenwood,Madison,U.S. Senate,,I,Greg Orman,97
-Greenwood,Otter Creek,U.S. Senate,,I,Greg Orman,29
-Greenwood,Pleasant Grv,U.S. Senate,,I,Greg Orman,9
-Greenwood,Quincy,U.S. Senate,,I,Greg Orman,12
-Greenwood,S Salem,U.S. Senate,,I,Greg Orman,6
-Greenwood,Saith Sprs,U.S. Senate,,I,Greg Orman,44
-Greenwood,Salem,U.S. Senate,,I,Greg Orman,2
-Greenwood,Shell Rock,U.S. Senate,,I,Greg Orman,9
-Greenwood,Spg Creek,U.S. Senate,,I,Greg Orman,9
-Greenwood,Twin Grove,U.S. Senate,,I,Greg Orman,44
-Greenwood,W1,U.S. Senate,,I,Greg Orman,82
-Greenwood,W2,U.S. Senate,,I,Greg Orman,53
-Greenwood,W3,U.S. Senate,,I,Greg Orman,81
-Greenwood,Bachelor,U.S. Senate,,R,Pat Roberts,48
-Greenwood,Eureka twp,U.S. Senate,,R,Pat Roberts,99
-Greenwood,Fall River,U.S. Senate,,R,Pat Roberts,44
-Greenwood,Janesville,U.S. Senate,,R,Pat Roberts,125
-Greenwood,Lane,U.S. Senate,,R,Pat Roberts,24
-Greenwood,Madison,U.S. Senate,,R,Pat Roberts,230
-Greenwood,Otter Creek,U.S. Senate,,R,Pat Roberts,41
-Greenwood,Pleasant Grv,U.S. Senate,,R,Pat Roberts,13
-Greenwood,Quincy,U.S. Senate,,R,Pat Roberts,34
-Greenwood,S Salem,U.S. Senate,,R,Pat Roberts,29
-Greenwood,Saith Sprs,U.S. Senate,,R,Pat Roberts,68
-Greenwood,Salem,U.S. Senate,,R,Pat Roberts,10
-Greenwood,Shell Rock,U.S. Senate,,R,Pat Roberts,63
-Greenwood,Spg Creek,U.S. Senate,,R,Pat Roberts,28
-Greenwood,Twin Grove,U.S. Senate,,R,Pat Roberts,102
-Greenwood,W1,U.S. Senate,,R,Pat Roberts,174
-Greenwood,W2,U.S. Senate,,R,Pat Roberts,119
-Greenwood,W3,U.S. Senate,,R,Pat Roberts,139
-Greenwood,Bachelor,U.S. Senate,,L,Randall Batson,4
-Greenwood,Eureka twp,U.S. Senate,,L,Randall Batson,7
-Greenwood,Fall River,U.S. Senate,,L,Randall Batson,5
-Greenwood,Janesville,U.S. Senate,,L,Randall Batson,5
-Greenwood,Lane,U.S. Senate,,L,Randall Batson,3
-Greenwood,Madison,U.S. Senate,,L,Randall Batson,26
-Greenwood,Otter Creek,U.S. Senate,,L,Randall Batson,9
-Greenwood,Pleasant Grv,U.S. Senate,,L,Randall Batson,2
-Greenwood,Quincy,U.S. Senate,,L,Randall Batson,4
-Greenwood,S Salem,U.S. Senate,,L,Randall Batson,1
-Greenwood,Saith Sprs,U.S. Senate,,L,Randall Batson,8
-Greenwood,Salem,U.S. Senate,,L,Randall Batson,0
-Greenwood,Shell Rock,U.S. Senate,,L,Randall Batson,1
-Greenwood,Spg Creek,U.S. Senate,,L,Randall Batson,1
-Greenwood,Twin Grove,U.S. Senate,,L,Randall Batson,19
-Greenwood,W1,U.S. Senate,,L,Randall Batson,15
-Greenwood,W2,U.S. Senate,,L,Randall Batson,20
-Greenwood,W3,U.S. Senate,,L,Randall Batson,21
-Greenwood,Advance,Attorney General,,D,A.J. Kotich,81
-Greenwood,Prov,Attorney General,,D,A.J. Kotich,5
-Greenwood,Advance,Attorney General,,R,Derek Schmidt,310
-Greenwood,Prov,Attorney General,,R,Derek Schmidt,49
-Greenwood,Advance,U.S. House,,R,Mike Pompeo,300
-Greenwood,Prov,U.S. House,,R,Mike Pompeo,51
-Greenwood,Advance,U.S. House,,D,Perry Schuckman,90
-Greenwood,Prov,U.S. House,,D,Perry Schuckman,5
-Greenwood,Advance,Governor,,L,Keen Unbehr,13
-Greenwood,Prov,Governor,,L,Keen Unbehr,5
-Greenwood,Advance,Governor,,D,Paul Davis,142
-Greenwood,Prov,Governor,,D,Paul Davis,12
-Greenwood,Advance,Governor,,R,Sam Brownback,240
-Greenwood,Prov,Governor,,R,Sam Brownback,39
-Greenwood,Advance,Insurance Commissioner,,D,Dennis Anderson,107
-Greenwood,Prov,Insurance Commissioner,,D,Dennis Anderson,8
-Greenwood,Advance,Insurance Commissioner,,R,Ken Selzer,270
-Greenwood,Prov,Insurance Commissioner,,R,Ken Selzer,43
-Greenwood,Advance,Secretary of State,,D,Jean Kurtis Schodorf,135
-Greenwood,Prov,Secretary of State,,D,Jean Kurtis Schodorf,10
-Greenwood,Advance,Secretary of State,,R,Kris Kobach,259
-Greenwood,Prov,Secretary of State,,R,Kris Kobach,44
-Greenwood,Advance,State House,13,R,Larry P Hibbard,345
-Greenwood,Prov,State House,13,R,Larry P Hibbard,49
-Greenwood,Advance,State Treasurer,,D,Carmen Alldritt,77
-Greenwood,Prov,State Treasurer,,D,Carmen Alldritt,9
-Greenwood,Advance,State Treasurer,,R,Ron Estes,307
-Greenwood,Prov,State Treasurer,,R,Ron Estes,43
-Greenwood,Advance,U.S. Senate,,I,Greg Orman,126
-Greenwood,Prov,U.S. Senate,,I,Greg Orman,8
-Greenwood,Advance,U.S. Senate,,R,Pat Roberts,245
-Greenwood,Prov,U.S. Senate,,R,Pat Roberts,42
-Greenwood,Advance,U.S. Senate,,L,Randall Batson,26
-Greenwood,Prov,U.S. Senate,,L,Randall Batson,6
+county,precinct,office,district,party,candidate,votes,vtd
+GREENWOOD,Bachelor Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000010
+GREENWOOD,Bachelor Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+GREENWOOD,Bachelor Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000010
+GREENWOOD,Eureka Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",68,000020
+GREENWOOD,Eureka Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000020
+GREENWOOD,Eureka Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000020
+GREENWOOD,Eureka Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",96,000030
+GREENWOOD,Eureka Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000030
+GREENWOOD,Eureka Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",165,000030
+GREENWOOD,Eureka Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000040
+GREENWOOD,Eureka Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000040
+GREENWOOD,Eureka Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",126,000040
+GREENWOOD,Eureka Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000050
+GREENWOOD,Eureka Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000050
+GREENWOOD,Eureka Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,000050
+GREENWOOD,Fall River Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000060
+GREENWOOD,Fall River Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000060
+GREENWOOD,Fall River Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,000060
+GREENWOOD,Janesville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000070
+GREENWOOD,Janesville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000070
+GREENWOOD,Janesville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",118,000070
+GREENWOOD,Lane Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000080
+GREENWOOD,Lane Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000080
+GREENWOOD,Lane Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000080
+GREENWOOD,Madison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",121,000090
+GREENWOOD,Madison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000090
+GREENWOOD,Madison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",223,000090
+GREENWOOD,Otter Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000100
+GREENWOOD,Otter Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000100
+GREENWOOD,Otter Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000100
+GREENWOOD,Pleasant Grove Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000110
+GREENWOOD,Pleasant Grove Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+GREENWOOD,Pleasant Grove Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000110
+GREENWOOD,Quincy Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000120
+GREENWOOD,Quincy Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000120
+GREENWOOD,Quincy Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000120
+GREENWOOD,Salem Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000130
+GREENWOOD,Salem Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000130
+GREENWOOD,Salem Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000130
+GREENWOOD,Salt Springs Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000140
+GREENWOOD,Salt Springs Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000140
+GREENWOOD,Salt Springs Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000140
+GREENWOOD,Shell Rock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000150
+GREENWOOD,Shell Rock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000150
+GREENWOOD,Shell Rock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,000150
+GREENWOOD,Spring Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000170
+GREENWOOD,Spring Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000170
+GREENWOOD,Spring Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000170
+GREENWOOD,Twin Grove Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",57,000180
+GREENWOOD,Twin Grove Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000180
+GREENWOOD,Twin Grove Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,000180
+GREENWOOD,South Salem Township C01,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,200010
+GREENWOOD,South Salem Township C01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,200010
+GREENWOOD,South Salem Township C01,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,200010
+GREENWOOD,South Salem Township C04,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,200020
+GREENWOOD,South Salem Township C04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,200020
+GREENWOOD,South Salem Township C04,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,200020
+GREENWOOD,Eureka Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+GREENWOOD,Eureka Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+GREENWOOD,Eureka Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+GREENWOOD,Bachelor Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",73,000010
+GREENWOOD,Eureka Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",144,000020
+GREENWOOD,Eureka Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",246,000030
+GREENWOOD,Eureka Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",173,000040
+GREENWOOD,Eureka Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",224,000050
+GREENWOOD,Fall River Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",71,000060
+GREENWOOD,Janesville Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",141,000070
+GREENWOOD,Lane Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",28,000080
+GREENWOOD,Madison Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",310,000090
+GREENWOOD,Otter Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",65,000100
+GREENWOOD,Pleasant Grove Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",23,000110
+GREENWOOD,Quincy Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",44,000120
+GREENWOOD,Salem Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",9,000130
+GREENWOOD,Salt Springs Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",99,000140
+GREENWOOD,Shell Rock Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",63,000150
+GREENWOOD,Spring Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",37,000170
+GREENWOOD,Twin Grove Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",141,000180
+GREENWOOD,South Salem Township C01,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",28,200010
+GREENWOOD,South Salem Township C04,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,200020
+GREENWOOD,Eureka Airport,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900020
+GREENWOOD,Bachelor Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",15,000010
+GREENWOOD,Bachelor Township,United States House of Representatives,4,Republican,"Pompeo, Mike",70,000010
+GREENWOOD,Eureka Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",40,000020
+GREENWOOD,Eureka Township,United States House of Representatives,4,Republican,"Pompeo, Mike",125,000020
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",72,000030
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",206,000030
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",44,000040
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",154,000040
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",48,000050
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",191,000050
+GREENWOOD,Fall River Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",23,000060
+GREENWOOD,Fall River Township,United States House of Representatives,4,Republican,"Pompeo, Mike",58,000060
+GREENWOOD,Janesville Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",20,000070
+GREENWOOD,Janesville Township,United States House of Representatives,4,Republican,"Pompeo, Mike",146,000070
+GREENWOOD,Lane Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",12,000080
+GREENWOOD,Lane Township,United States House of Representatives,4,Republican,"Pompeo, Mike",27,000080
+GREENWOOD,Madison Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",84,000090
+GREENWOOD,Madison Township,United States House of Representatives,4,Republican,"Pompeo, Mike",277,000090
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",23,000100
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",56,000100
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000110
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,Republican,"Pompeo, Mike",17,000110
+GREENWOOD,Quincy Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",7,000120
+GREENWOOD,Quincy Township,United States House of Representatives,4,Republican,"Pompeo, Mike",44,000120
+GREENWOOD,Salem Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,000130
+GREENWOOD,Salem Township,United States House of Representatives,4,Republican,"Pompeo, Mike",9,000130
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",35,000140
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,Republican,"Pompeo, Mike",83,000140
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000150
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,Republican,"Pompeo, Mike",64,000150
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000170
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",31,000170
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",43,000180
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,Republican,"Pompeo, Mike",120,000180
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,200010
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,Republican,"Pompeo, Mike",31,200010
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,200020
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,Republican,"Pompeo, Mike",0,200020
+GREENWOOD,Eureka Airport,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900010
+GREENWOOD,Eureka Airport,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900020
+GREENWOOD,Bachelor Township,Attorney General,,Democratic,"Kotich, A.J.",13,000010
+GREENWOOD,Bachelor Township,Attorney General,,Republican,"Schmidt, Derek",70,000010
+GREENWOOD,Eureka Township,Attorney General,,Democratic,"Kotich, A.J.",31,000020
+GREENWOOD,Eureka Township,Attorney General,,Republican,"Schmidt, Derek",129,000020
+GREENWOOD,Eureka Ward 1,Attorney General,,Democratic,"Kotich, A.J.",56,000030
+GREENWOOD,Eureka Ward 1,Attorney General,,Republican,"Schmidt, Derek",218,000030
+GREENWOOD,Eureka Ward 2,Attorney General,,Democratic,"Kotich, A.J.",40,000040
+GREENWOOD,Eureka Ward 2,Attorney General,,Republican,"Schmidt, Derek",161,000040
+GREENWOOD,Eureka Ward 3,Attorney General,,Democratic,"Kotich, A.J.",43,000050
+GREENWOOD,Eureka Ward 3,Attorney General,,Republican,"Schmidt, Derek",197,000050
+GREENWOOD,Fall River Township,Attorney General,,Democratic,"Kotich, A.J.",21,000060
+GREENWOOD,Fall River Township,Attorney General,,Republican,"Schmidt, Derek",61,000060
+GREENWOOD,Janesville Township,Attorney General,,Democratic,"Kotich, A.J.",20,000070
+GREENWOOD,Janesville Township,Attorney General,,Republican,"Schmidt, Derek",146,000070
+GREENWOOD,Lane Township,Attorney General,,Democratic,"Kotich, A.J.",6,000080
+GREENWOOD,Lane Township,Attorney General,,Republican,"Schmidt, Derek",33,000080
+GREENWOOD,Madison Township,Attorney General,,Democratic,"Kotich, A.J.",74,000090
+GREENWOOD,Madison Township,Attorney General,,Republican,"Schmidt, Derek",279,000090
+GREENWOOD,Otter Creek Township,Attorney General,,Democratic,"Kotich, A.J.",23,000100
+GREENWOOD,Otter Creek Township,Attorney General,,Republican,"Schmidt, Derek",58,000100
+GREENWOOD,Pleasant Grove Township,Attorney General,,Democratic,"Kotich, A.J.",3,000110
+GREENWOOD,Pleasant Grove Township,Attorney General,,Republican,"Schmidt, Derek",23,000110
+GREENWOOD,Quincy Township,Attorney General,,Democratic,"Kotich, A.J.",6,000120
+GREENWOOD,Quincy Township,Attorney General,,Republican,"Schmidt, Derek",45,000120
+GREENWOOD,Salem Township,Attorney General,,Democratic,"Kotich, A.J.",2,000130
+GREENWOOD,Salem Township,Attorney General,,Republican,"Schmidt, Derek",9,000130
+GREENWOOD,Salt Springs Township,Attorney General,,Democratic,"Kotich, A.J.",23,000140
+GREENWOOD,Salt Springs Township,Attorney General,,Republican,"Schmidt, Derek",96,000140
+GREENWOOD,Shell Rock Township,Attorney General,,Democratic,"Kotich, A.J.",6,000150
+GREENWOOD,Shell Rock Township,Attorney General,,Republican,"Schmidt, Derek",67,000150
+GREENWOOD,Spring Creek Township,Attorney General,,Democratic,"Kotich, A.J.",5,000170
+GREENWOOD,Spring Creek Township,Attorney General,,Republican,"Schmidt, Derek",33,000170
+GREENWOOD,Twin Grove Township,Attorney General,,Democratic,"Kotich, A.J.",33,000180
+GREENWOOD,Twin Grove Township,Attorney General,,Republican,"Schmidt, Derek",130,000180
+GREENWOOD,South Salem Township C01,Attorney General,,Democratic,"Kotich, A.J.",4,200010
+GREENWOOD,South Salem Township C01,Attorney General,,Republican,"Schmidt, Derek",31,200010
+GREENWOOD,South Salem Township C04,Attorney General,,Democratic,"Kotich, A.J.",0,200020
+GREENWOOD,South Salem Township C04,Attorney General,,Republican,"Schmidt, Derek",0,200020
+GREENWOOD,Eureka Airport,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+GREENWOOD,Eureka Airport,Attorney General,,Republican,"Schmidt, Derek",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900020
+GREENWOOD,Bachelor Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000010
+GREENWOOD,Bachelor Township,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000010
+GREENWOOD,Eureka Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",49,000020
+GREENWOOD,Eureka Township,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000020
+GREENWOOD,Eureka Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000030
+GREENWOOD,Eureka Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",193,000030
+GREENWOOD,Eureka Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000040
+GREENWOOD,Eureka Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000040
+GREENWOOD,Eureka Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000050
+GREENWOOD,Eureka Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",178,000050
+GREENWOOD,Fall River Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000060
+GREENWOOD,Fall River Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000060
+GREENWOOD,Janesville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000070
+GREENWOOD,Janesville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",131,000070
+GREENWOOD,Lane Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000080
+GREENWOOD,Lane Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000080
+GREENWOOD,Madison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",99,000090
+GREENWOOD,Madison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",249,000090
+GREENWOOD,Otter Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000100
+GREENWOOD,Otter Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000100
+GREENWOOD,Pleasant Grove Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000110
+GREENWOOD,Pleasant Grove Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000110
+GREENWOOD,Quincy Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000120
+GREENWOOD,Quincy Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000120
+GREENWOOD,Salem Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000130
+GREENWOOD,Salem Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000130
+GREENWOOD,Salt Springs Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000140
+GREENWOOD,Salt Springs Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000140
+GREENWOOD,Shell Rock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000150
+GREENWOOD,Shell Rock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000150
+GREENWOOD,Spring Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000170
+GREENWOOD,Spring Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000170
+GREENWOOD,Twin Grove Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000180
+GREENWOOD,Twin Grove Township,Commissioner of Insurance,,Republican,"Selzer, Ken",120,000180
+GREENWOOD,South Salem Township C01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,200010
+GREENWOOD,South Salem Township C01,Commissioner of Insurance,,Republican,"Selzer, Ken",29,200010
+GREENWOOD,South Salem Township C04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,200020
+GREENWOOD,South Salem Township C04,Commissioner of Insurance,,Republican,"Selzer, Ken",0,200020
+GREENWOOD,Eureka Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+GREENWOOD,Eureka Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+GREENWOOD,Bachelor Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000010
+GREENWOOD,Bachelor Township,Secretary of State,,Republican,"Kobach, Kris",58,000010
+GREENWOOD,Eureka Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000020
+GREENWOOD,Eureka Township,Secretary of State,,Republican,"Kobach, Kris",107,000020
+GREENWOOD,Eureka Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,000030
+GREENWOOD,Eureka Ward 1,Secretary of State,,Republican,"Kobach, Kris",192,000030
+GREENWOOD,Eureka Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",69,000040
+GREENWOOD,Eureka Ward 2,Secretary of State,,Republican,"Kobach, Kris",132,000040
+GREENWOOD,Eureka Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",82,000050
+GREENWOOD,Eureka Ward 3,Secretary of State,,Republican,"Kobach, Kris",161,000050
+GREENWOOD,Fall River Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000060
+GREENWOOD,Fall River Township,Secretary of State,,Republican,"Kobach, Kris",48,000060
+GREENWOOD,Janesville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000070
+GREENWOOD,Janesville Township,Secretary of State,,Republican,"Kobach, Kris",135,000070
+GREENWOOD,Lane Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000080
+GREENWOOD,Lane Township,Secretary of State,,Republican,"Kobach, Kris",24,000080
+GREENWOOD,Madison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",107,000090
+GREENWOOD,Madison Township,Secretary of State,,Republican,"Kobach, Kris",257,000090
+GREENWOOD,Otter Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000100
+GREENWOOD,Otter Creek Township,Secretary of State,,Republican,"Kobach, Kris",50,000100
+GREENWOOD,Pleasant Grove Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000110
+GREENWOOD,Pleasant Grove Township,Secretary of State,,Republican,"Kobach, Kris",18,000110
+GREENWOOD,Quincy Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000120
+GREENWOOD,Quincy Township,Secretary of State,,Republican,"Kobach, Kris",39,000120
+GREENWOOD,Salem Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000130
+GREENWOOD,Salem Township,Secretary of State,,Republican,"Kobach, Kris",9,000130
+GREENWOOD,Salt Springs Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000140
+GREENWOOD,Salt Springs Township,Secretary of State,,Republican,"Kobach, Kris",77,000140
+GREENWOOD,Shell Rock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000150
+GREENWOOD,Shell Rock Township,Secretary of State,,Republican,"Kobach, Kris",65,000150
+GREENWOOD,Spring Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000170
+GREENWOOD,Spring Creek Township,Secretary of State,,Republican,"Kobach, Kris",31,000170
+GREENWOOD,Twin Grove Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,000180
+GREENWOOD,Twin Grove Township,Secretary of State,,Republican,"Kobach, Kris",113,000180
+GREENWOOD,South Salem Township C01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,200010
+GREENWOOD,South Salem Township C01,Secretary of State,,Republican,"Kobach, Kris",26,200010
+GREENWOOD,South Salem Township C04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,200020
+GREENWOOD,South Salem Township C04,Secretary of State,,Republican,"Kobach, Kris",0,200020
+GREENWOOD,Eureka Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+GREENWOOD,Eureka Airport,Secretary of State,,Republican,"Kobach, Kris",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900020
+GREENWOOD,Bachelor Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000010
+GREENWOOD,Bachelor Township,State Treasurer,,Republican,"Estes, Ron",70,000010
+GREENWOOD,Eureka Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000020
+GREENWOOD,Eureka Township,State Treasurer,,Republican,"Estes, Ron",133,000020
+GREENWOOD,Eureka Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",70,000030
+GREENWOOD,Eureka Ward 1,State Treasurer,,Republican,"Estes, Ron",203,000030
+GREENWOOD,Eureka Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",39,000040
+GREENWOOD,Eureka Ward 2,State Treasurer,,Republican,"Estes, Ron",157,000040
+GREENWOOD,Eureka Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",38,000050
+GREENWOOD,Eureka Ward 3,State Treasurer,,Republican,"Estes, Ron",200,000050
+GREENWOOD,Fall River Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000060
+GREENWOOD,Fall River Township,State Treasurer,,Republican,"Estes, Ron",58,000060
+GREENWOOD,Janesville Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000070
+GREENWOOD,Janesville Township,State Treasurer,,Republican,"Estes, Ron",144,000070
+GREENWOOD,Lane Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000080
+GREENWOOD,Lane Township,State Treasurer,,Republican,"Estes, Ron",28,000080
+GREENWOOD,Madison Township,State Treasurer,,Democratic,"Alldritt, Carmen",76,000090
+GREENWOOD,Madison Township,State Treasurer,,Republican,"Estes, Ron",276,000090
+GREENWOOD,Otter Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000100
+GREENWOOD,Otter Creek Township,State Treasurer,,Republican,"Estes, Ron",52,000100
+GREENWOOD,Pleasant Grove Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000110
+GREENWOOD,Pleasant Grove Township,State Treasurer,,Republican,"Estes, Ron",24,000110
+GREENWOOD,Quincy Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000120
+GREENWOOD,Quincy Township,State Treasurer,,Republican,"Estes, Ron",44,000120
+GREENWOOD,Salem Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000130
+GREENWOOD,Salem Township,State Treasurer,,Republican,"Estes, Ron",12,000130
+GREENWOOD,Salt Springs Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000140
+GREENWOOD,Salt Springs Township,State Treasurer,,Republican,"Estes, Ron",95,000140
+GREENWOOD,Shell Rock Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000150
+GREENWOOD,Shell Rock Township,State Treasurer,,Republican,"Estes, Ron",66,000150
+GREENWOOD,Spring Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000170
+GREENWOOD,Spring Creek Township,State Treasurer,,Republican,"Estes, Ron",33,000170
+GREENWOOD,Twin Grove Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000180
+GREENWOOD,Twin Grove Township,State Treasurer,,Republican,"Estes, Ron",133,000180
+GREENWOOD,South Salem Township C01,State Treasurer,,Democratic,"Alldritt, Carmen",5,200010
+GREENWOOD,South Salem Township C01,State Treasurer,,Republican,"Estes, Ron",29,200010
+GREENWOOD,South Salem Township C04,State Treasurer,,Democratic,"Alldritt, Carmen",0,200020
+GREENWOOD,South Salem Township C04,State Treasurer,,Republican,"Estes, Ron",0,200020
+GREENWOOD,Eureka Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+GREENWOOD,Eureka Airport,State Treasurer,,Republican,"Estes, Ron",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900020
+GREENWOOD,Bachelor Township,United States Senate,,independent,"Orman, Greg",30,000010
+GREENWOOD,Bachelor Township,United States Senate,,Libertarian,"Batson, Randall",4,000010
+GREENWOOD,Bachelor Township,United States Senate,,Republican,"Roberts, Pat",52,000010
+GREENWOOD,Eureka Township,United States Senate,,independent,"Orman, Greg",54,000020
+GREENWOOD,Eureka Township,United States Senate,,Libertarian,"Batson, Randall",7,000020
+GREENWOOD,Eureka Township,United States Senate,,Republican,"Roberts, Pat",102,000020
+GREENWOOD,Eureka Ward 1,United States Senate,,independent,"Orman, Greg",83,000030
+GREENWOOD,Eureka Ward 1,United States Senate,,Libertarian,"Batson, Randall",17,000030
+GREENWOOD,Eureka Ward 1,United States Senate,,Republican,"Roberts, Pat",177,000030
+GREENWOOD,Eureka Ward 2,United States Senate,,independent,"Orman, Greg",54,000040
+GREENWOOD,Eureka Ward 2,United States Senate,,Libertarian,"Batson, Randall",21,000040
+GREENWOOD,Eureka Ward 2,United States Senate,,Republican,"Roberts, Pat",125,000040
+GREENWOOD,Eureka Ward 3,United States Senate,,independent,"Orman, Greg",83,000050
+GREENWOOD,Eureka Ward 3,United States Senate,,Libertarian,"Batson, Randall",22,000050
+GREENWOOD,Eureka Ward 3,United States Senate,,Republican,"Roberts, Pat",142,000050
+GREENWOOD,Fall River Township,United States Senate,,independent,"Orman, Greg",32,000060
+GREENWOOD,Fall River Township,United States Senate,,Libertarian,"Batson, Randall",5,000060
+GREENWOOD,Fall River Township,United States Senate,,Republican,"Roberts, Pat",44,000060
+GREENWOOD,Janesville Township,United States Senate,,independent,"Orman, Greg",31,000070
+GREENWOOD,Janesville Township,United States Senate,,Libertarian,"Batson, Randall",7,000070
+GREENWOOD,Janesville Township,United States Senate,,Republican,"Roberts, Pat",131,000070
+GREENWOOD,Lane Township,United States Senate,,independent,"Orman, Greg",13,000080
+GREENWOOD,Lane Township,United States Senate,,Libertarian,"Batson, Randall",3,000080
+GREENWOOD,Lane Township,United States Senate,,Republican,"Roberts, Pat",24,000080
+GREENWOOD,Madison Township,United States Senate,,independent,"Orman, Greg",99,000090
+GREENWOOD,Madison Township,United States Senate,,Libertarian,"Batson, Randall",26,000090
+GREENWOOD,Madison Township,United States Senate,,Republican,"Roberts, Pat",241,000090
+GREENWOOD,Otter Creek Township,United States Senate,,independent,"Orman, Greg",30,000100
+GREENWOOD,Otter Creek Township,United States Senate,,Libertarian,"Batson, Randall",9,000100
+GREENWOOD,Otter Creek Township,United States Senate,,Republican,"Roberts, Pat",42,000100
+GREENWOOD,Pleasant Grove Township,United States Senate,,independent,"Orman, Greg",9,000110
+GREENWOOD,Pleasant Grove Township,United States Senate,,Libertarian,"Batson, Randall",2,000110
+GREENWOOD,Pleasant Grove Township,United States Senate,,Republican,"Roberts, Pat",15,000110
+GREENWOOD,Quincy Township,United States Senate,,independent,"Orman, Greg",12,000120
+GREENWOOD,Quincy Township,United States Senate,,Libertarian,"Batson, Randall",4,000120
+GREENWOOD,Quincy Township,United States Senate,,Republican,"Roberts, Pat",35,000120
+GREENWOOD,Salem Township,United States Senate,,independent,"Orman, Greg",2,000130
+GREENWOOD,Salem Township,United States Senate,,Libertarian,"Batson, Randall",0,000130
+GREENWOOD,Salem Township,United States Senate,,Republican,"Roberts, Pat",10,000130
+GREENWOOD,Salt Springs Township,United States Senate,,independent,"Orman, Greg",44,000140
+GREENWOOD,Salt Springs Township,United States Senate,,Libertarian,"Batson, Randall",8,000140
+GREENWOOD,Salt Springs Township,United States Senate,,Republican,"Roberts, Pat",68,000140
+GREENWOOD,Shell Rock Township,United States Senate,,independent,"Orman, Greg",9,000150
+GREENWOOD,Shell Rock Township,United States Senate,,Libertarian,"Batson, Randall",1,000150
+GREENWOOD,Shell Rock Township,United States Senate,,Republican,"Roberts, Pat",63,000150
+GREENWOOD,Spring Creek Township,United States Senate,,independent,"Orman, Greg",9,000170
+GREENWOOD,Spring Creek Township,United States Senate,,Libertarian,"Batson, Randall",1,000170
+GREENWOOD,Spring Creek Township,United States Senate,,Republican,"Roberts, Pat",30,000170
+GREENWOOD,Twin Grove Township,United States Senate,,independent,"Orman, Greg",44,000180
+GREENWOOD,Twin Grove Township,United States Senate,,Libertarian,"Batson, Randall",19,000180
+GREENWOOD,Twin Grove Township,United States Senate,,Republican,"Roberts, Pat",102,000180
+GREENWOOD,South Salem Township C01,United States Senate,,independent,"Orman, Greg",6,200010
+GREENWOOD,South Salem Township C01,United States Senate,,Libertarian,"Batson, Randall",1,200010
+GREENWOOD,South Salem Township C01,United States Senate,,Republican,"Roberts, Pat",29,200010
+GREENWOOD,South Salem Township C04,United States Senate,,independent,"Orman, Greg",0,200020
+GREENWOOD,South Salem Township C04,United States Senate,,Libertarian,"Batson, Randall",0,200020
+GREENWOOD,South Salem Township C04,United States Senate,,Republican,"Roberts, Pat",0,200020
+GREENWOOD,Eureka Airport,United States Senate,,independent,"Orman, Greg",0,900010
+GREENWOOD,Eureka Airport,United States Senate,,Libertarian,"Batson, Randall",0,900010
+GREENWOOD,Eureka Airport,United States Senate,,Republican,"Roberts, Pat",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900020

--- a/2014/20141104__ks__general__hamilton__precinct.csv
+++ b/2014/20141104__ks__general__hamilton__precinct.csv
@@ -1,205 +1,205 @@
-county,precinct,office,district,party,candidate,votes
-Hamilton,Bear Creek,U.S. Senate,,R,Pat Roberts,15
-Hamilton,Coolidge,U.S. Senate,,R,Pat Roberts,20
-Hamilton,Kendall,U.S. Senate,,R,Pat Roberts,20
-Hamilton,Lamont,U.S. Senate,,R,Pat Roberts,38
-Hamilton,Liberty,U.S. Senate,,R,Pat Roberts,15
-Hamilton,Medway,U.S. Senate,,R,Pat Roberts,22
-Hamilton,Richland,U.S. Senate,,R,Pat Roberts,9
-Hamilton,Syracuse 1,U.S. Senate,,R,Pat Roberts,106
-Hamilton,Syracuse 2,U.S. Senate,,R,Pat Roberts,82
-Hamilton,Syracuse 3,U.S. Senate,,R,Pat Roberts,84
-Hamilton,Syracuse 4,U.S. Senate,,R,Pat Roberts,37
-Hamilton,Syracuse 5,U.S. Senate,,R,Pat Roberts,98
-Hamilton,Bear Creek,U.S. Senate,,I,Greg Orman,2
-Hamilton,Coolidge,U.S. Senate,,I,Greg Orman,5
-Hamilton,Kendall,U.S. Senate,,I,Greg Orman,9
-Hamilton,Lamont,U.S. Senate,,I,Greg Orman,5
-Hamilton,Liberty,U.S. Senate,,I,Greg Orman,2
-Hamilton,Medway,U.S. Senate,,I,Greg Orman,3
-Hamilton,Richland,U.S. Senate,,I,Greg Orman,1
-Hamilton,Syracuse 1,U.S. Senate,,I,Greg Orman,41
-Hamilton,Syracuse 2,U.S. Senate,,I,Greg Orman,13
-Hamilton,Syracuse 3,U.S. Senate,,I,Greg Orman,26
-Hamilton,Syracuse 4,U.S. Senate,,I,Greg Orman,12
-Hamilton,Syracuse 5,U.S. Senate,,I,Greg Orman,31
-Hamilton,Bear Creek,U.S. Senate,,L,Randall Batson,0
-Hamilton,Coolidge,U.S. Senate,,L,Randall Batson,3
-Hamilton,Kendall,U.S. Senate,,L,Randall Batson,2
-Hamilton,Lamont,U.S. Senate,,L,Randall Batson,0
-Hamilton,Liberty,U.S. Senate,,L,Randall Batson,0
-Hamilton,Medway,U.S. Senate,,L,Randall Batson,0
-Hamilton,Richland,U.S. Senate,,L,Randall Batson,1
-Hamilton,Syracuse 1,U.S. Senate,,L,Randall Batson,8
-Hamilton,Syracuse 2,U.S. Senate,,L,Randall Batson,2
-Hamilton,Syracuse 3,U.S. Senate,,L,Randall Batson,0
-Hamilton,Syracuse 4,U.S. Senate,,L,Randall Batson,4
-Hamilton,Syracuse 5,U.S. Senate,,L,Randall Batson,1
-Hamilton,Bear Creek,U.S. House,1,R,Tim Huelskamp,14
-Hamilton,Coolidge,U.S. House,1,R,Tim Huelskamp,23
-Hamilton,Kendall,U.S. House,1,R,Tim Huelskamp,21
-Hamilton,Lamont,U.S. House,1,R,Tim Huelskamp,34
-Hamilton,Liberty,U.S. House,1,R,Tim Huelskamp,13
-Hamilton,Medway,U.S. House,1,R,Tim Huelskamp,20
-Hamilton,Richland,U.S. House,1,R,Tim Huelskamp,9
-Hamilton,Syracuse 1,U.S. House,1,R,Tim Huelskamp,116
-Hamilton,Syracuse 2,U.S. House,1,R,Tim Huelskamp,78
-Hamilton,Syracuse 3,U.S. House,1,R,Tim Huelskamp,80
-Hamilton,Syracuse 4,U.S. House,1,R,Tim Huelskamp,40
-Hamilton,Syracuse 5,U.S. House,1,R,Tim Huelskamp,96
-Hamilton,Bear Creek,U.S. House,1,D,James Sherow,1
-Hamilton,Coolidge,U.S. House,1,D,James Sherow,6
-Hamilton,Kendall,U.S. House,1,D,James Sherow,8
-Hamilton,Lamont,U.S. House,1,D,James Sherow,9
-Hamilton,Liberty,U.S. House,1,D,James Sherow,1
-Hamilton,Medway,U.S. House,1,D,James Sherow,5
-Hamilton,Richland,U.S. House,1,D,James Sherow,2
-Hamilton,Syracuse 1,U.S. House,1,D,James Sherow,40
-Hamilton,Syracuse 2,U.S. House,1,D,James Sherow,15
-Hamilton,Syracuse 3,U.S. House,1,D,James Sherow,27
-Hamilton,Syracuse 4,U.S. House,1,D,James Sherow,12
-Hamilton,Syracuse 5,U.S. House,1,D,James Sherow,32
-Hamilton,Bear Creek,Governor,,R,Sam Brownback,14
-Hamilton,Coolidge,Governor,,R,Sam Brownback,18
-Hamilton,Kendall,Governor,,R,Sam Brownback,21
-Hamilton,Lamont,Governor,,R,Sam Brownback,35
-Hamilton,Liberty,Governor,,R,Sam Brownback,14
-Hamilton,Medway,Governor,,R,Sam Brownback,21
-Hamilton,Richland,Governor,,R,Sam Brownback,8
-Hamilton,Syracuse 1,Governor,,R,Sam Brownback,82
-Hamilton,Syracuse 2,Governor,,R,Sam Brownback,68
-Hamilton,Syracuse 3,Governor,,R,Sam Brownback,75
-Hamilton,Syracuse 4,Governor,,R,Sam Brownback,32
-Hamilton,Syracuse 5,Governor,,R,Sam Brownback,74
-Hamilton,Bear Creek,Governor,,D,Paul Davis,3
-Hamilton,Coolidge,Governor,,D,Paul Davis,6
-Hamilton,Kendall,Governor,,D,Paul Davis,8
-Hamilton,Lamont,Governor,,D,Paul Davis,7
-Hamilton,Liberty,Governor,,D,Paul Davis,3
-Hamilton,Medway,Governor,,D,Paul Davis,5
-Hamilton,Richland,Governor,,D,Paul Davis,1
-Hamilton,Syracuse 1,Governor,,D,Paul Davis,67
-Hamilton,Syracuse 2,Governor,,D,Paul Davis,22
-Hamilton,Syracuse 3,Governor,,D,Paul Davis,33
-Hamilton,Syracuse 4,Governor,,D,Paul Davis,22
-Hamilton,Syracuse 5,Governor,,D,Paul Davis,49
-Hamilton,Bear Creek,Governor,,L,Keen Umbehr,0
-Hamilton,Coolidge,Governor,,L,Keen Umbehr,3
-Hamilton,Kendall,Governor,,L,Keen Umbehr,1
-Hamilton,Lamont,Governor,,L,Keen Umbehr,0
-Hamilton,Liberty,Governor,,L,Keen Umbehr,0
-Hamilton,Medway,Governor,,L,Keen Umbehr,0
-Hamilton,Richland,Governor,,L,Keen Umbehr,1
-Hamilton,Syracuse 1,Governor,,L,Keen Umbehr,9
-Hamilton,Syracuse 2,Governor,,L,Keen Umbehr,4
-Hamilton,Syracuse 3,Governor,,L,Keen Umbehr,3
-Hamilton,Syracuse 4,Governor,,L,Keen Umbehr,0
-Hamilton,Syracuse 5,Governor,,L,Keen Umbehr,2
-Hamilton,Bear Creek,Secretary of State,,R,Kris Kobach,13
-Hamilton,Coolidge,Secretary of State,,R,Kris Kobach,21
-Hamilton,Kendall,Secretary of State,,R,Kris Kobach,21
-Hamilton,Lamont,Secretary of State,,R,Kris Kobach,38
-Hamilton,Liberty,Secretary of State,,R,Kris Kobach,14
-Hamilton,Medway,Secretary of State,,R,Kris Kobach,22
-Hamilton,Richland,Secretary of State,,R,Kris Kobach,8
-Hamilton,Syracuse 1,Secretary of State,,R,Kris Kobach,123
-Hamilton,Syracuse 2,Secretary of State,,R,Kris Kobach,79
-Hamilton,Syracuse 3,Secretary of State,,R,Kris Kobach,84
-Hamilton,Syracuse 4,Secretary of State,,R,Kris Kobach,40
-Hamilton,Syracuse 5,Secretary of State,,R,Kris Kobach,98
-Hamilton,Bear Creek,Secretary of State,,D,Jean Schodorf,1
-Hamilton,Coolidge,Secretary of State,,D,Jean Schodorf,6
-Hamilton,Kendall,Secretary of State,,D,Jean Schodorf,7
-Hamilton,Lamont,Secretary of State,,D,Jean Schodorf,5
-Hamilton,Liberty,Secretary of State,,D,Jean Schodorf,2
-Hamilton,Medway,Secretary of State,,D,Jean Schodorf,2
-Hamilton,Richland,Secretary of State,,D,Jean Schodorf,3
-Hamilton,Syracuse 1,Secretary of State,,D,Jean Schodorf,34
-Hamilton,Syracuse 2,Secretary of State,,D,Jean Schodorf,15
-Hamilton,Syracuse 3,Secretary of State,,D,Jean Schodorf,29
-Hamilton,Syracuse 4,Secretary of State,,D,Jean Schodorf,14
-Hamilton,Syracuse 5,Secretary of State,,D,Jean Schodorf,31
-Hamilton,Bear Creek,Attorney General,,R,Derek Schmidt,12
-Hamilton,Coolidge,Attorney General,,R,Derek Schmidt,21
-Hamilton,Kendall,Attorney General,,R,Derek Schmidt,21
-Hamilton,Lamont,Attorney General,,R,Derek Schmidt,41
-Hamilton,Liberty,Attorney General,,R,Derek Schmidt,14
-Hamilton,Medway,Attorney General,,R,Derek Schmidt,22
-Hamilton,Richland,Attorney General,,R,Derek Schmidt,10
-Hamilton,Syracuse 1,Attorney General,,R,Derek Schmidt,125
-Hamilton,Syracuse 2,Attorney General,,R,Derek Schmidt,80
-Hamilton,Syracuse 3,Attorney General,,R,Derek Schmidt,88
-Hamilton,Syracuse 4,Attorney General,,R,Derek Schmidt,38
-Hamilton,Syracuse 5,Attorney General,,R,Derek Schmidt,109
-Hamilton,Bear Creek,Attorney General,,D,A J Kotich,2
-Hamilton,Coolidge,Attorney General,,D,A J Kotich,6
-Hamilton,Kendall,Attorney General,,D,A J Kotich,6
-Hamilton,Lamont,Attorney General,,D,A J Kotich,1
-Hamilton,Liberty,Attorney General,,D,A J Kotich,2
-Hamilton,Medway,Attorney General,,D,A J Kotich,2
-Hamilton,Richland,Attorney General,,D,A J Kotich,1
-Hamilton,Syracuse 1,Attorney General,,D,A J Kotich,28
-Hamilton,Syracuse 2,Attorney General,,D,A J Kotich,12
-Hamilton,Syracuse 3,Attorney General,,D,A J Kotich,23
-Hamilton,Syracuse 4,Attorney General,,D,A J Kotich,15
-Hamilton,Syracuse 5,Attorney General,,D,A J Kotich,18
-Hamilton,Bear Creek,State Treasurer,,R,Ron Estes,15
-Hamilton,Coolidge,State Treasurer,,R,Ron Estes,23
-Hamilton,Kendall,State Treasurer,,R,Ron Estes,23
-Hamilton,Lamont,State Treasurer,,R,Ron Estes,41
-Hamilton,Liberty,State Treasurer,,R,Ron Estes,15
-Hamilton,Medway,State Treasurer,,R,Ron Estes,22
-Hamilton,Richland,State Treasurer,,R,Ron Estes,10
-Hamilton,Syracuse 1,State Treasurer,,R,Ron Estes,119
-Hamilton,Syracuse 2,State Treasurer,,R,Ron Estes,83
-Hamilton,Syracuse 3,State Treasurer,,R,Ron Estes,90
-Hamilton,Syracuse 4,State Treasurer,,R,Ron Estes,39
-Hamilton,Syracuse 5,State Treasurer,,R,Ron Estes,110
-Hamilton,Bear Creek,State Treasurer,,D,Carmen Alldritt,0
-Hamilton,Coolidge,State Treasurer,,D,Carmen Alldritt,3
-Hamilton,Kendall,State Treasurer,,D,Carmen Alldritt,4
-Hamilton,Lamont,State Treasurer,,D,Carmen Alldritt,2
-Hamilton,Liberty,State Treasurer,,D,Carmen Alldritt,1
-Hamilton,Medway,State Treasurer,,D,Carmen Alldritt,2
-Hamilton,Richland,State Treasurer,,D,Carmen Alldritt,1
-Hamilton,Syracuse 1,State Treasurer,,D,Carmen Alldritt,37
-Hamilton,Syracuse 2,State Treasurer,,D,Carmen Alldritt,11
-Hamilton,Syracuse 3,State Treasurer,,D,Carmen Alldritt,21
-Hamilton,Syracuse 4,State Treasurer,,D,Carmen Alldritt,13
-Hamilton,Syracuse 5,State Treasurer,,D,Carmen Alldritt,13
-Hamilton,Bear Creek,Insurance Commissioner,,R,Ken Selzer,12
-Hamilton,Coolidge,Insurance Commissioner,,R,Ken Selzer,21
-Hamilton,Kendall,Insurance Commissioner,,R,Ken Selzer,24
-Hamilton,Lamont,Insurance Commissioner,,R,Ken Selzer,39
-Hamilton,Liberty,Insurance Commissioner,,R,Ken Selzer,13
-Hamilton,Medway,Insurance Commissioner,,R,Ken Selzer,20
-Hamilton,Richland,Insurance Commissioner,,R,Ken Selzer,10
-Hamilton,Syracuse 1,Insurance Commissioner,,R,Ken Selzer,115
-Hamilton,Syracuse 2,Insurance Commissioner,,R,Ken Selzer,70
-Hamilton,Syracuse 3,Insurance Commissioner,,R,Ken Selzer,87
-Hamilton,Syracuse 4,Insurance Commissioner,,R,Ken Selzer,37
-Hamilton,Syracuse 5,Insurance Commissioner,,R,Ken Selzer,90
-Hamilton,Bear Creek,Insurance Commissioner,,D,Dennis Anderson,2
-Hamilton,Coolidge,Insurance Commissioner,,D,Dennis Anderson,6
-Hamilton,Kendall,Insurance Commissioner,,D,Dennis Anderson,4
-Hamilton,Lamont,Insurance Commissioner,,D,Dennis Anderson,4
-Hamilton,Liberty,Insurance Commissioner,,D,Dennis Anderson,3
-Hamilton,Medway,Insurance Commissioner,,D,Dennis Anderson,6
-Hamilton,Richland,Insurance Commissioner,,D,Dennis Anderson,1
-Hamilton,Syracuse 1,Insurance Commissioner,,D,Dennis Anderson,38
-Hamilton,Syracuse 2,Insurance Commissioner,,D,Dennis Anderson,21
-Hamilton,Syracuse 3,Insurance Commissioner,,D,Dennis Anderson,25
-Hamilton,Syracuse 4,Insurance Commissioner,,D,Dennis Anderson,14
-Hamilton,Syracuse 5,Insurance Commissioner,,D,Dennis Anderson,32
-Hamilton,Bear Creek,State House,122,R,Russ Jennings,16
-Hamilton,Coolidge,State House,122,R,Russ Jennings,24
-Hamilton,Kendall,State House,122,R,Russ Jennings,25
-Hamilton,Lamont,State House,122,R,Russ Jennings,41
-Hamilton,Liberty,State House,122,R,Russ Jennings,14
-Hamilton,Medway,State House,122,R,Russ Jennings,24
-Hamilton,Richland,State House,122,R,Russ Jennings,11
-Hamilton,Syracuse 1,State House,122,R,Russ Jennings,148
-Hamilton,Syracuse 2,State House,122,R,Russ Jennings,88
-Hamilton,Syracuse 3,State House,122,R,Russ Jennings,106
-Hamilton,Syracuse 4,State House,122,R,Russ Jennings,51
-Hamilton,Syracuse 5,State House,122,R,Russ Jennings,122
+county,precinct,office,district,party,candidate,votes,vtd
+HAMILTON,Bear Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000010
+HAMILTON,Bear Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+HAMILTON,Bear Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000010
+HAMILTON,Coolidge Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000020
+HAMILTON,Coolidge Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000020
+HAMILTON,Coolidge Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000020
+HAMILTON,Kendall Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+HAMILTON,Kendall Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+HAMILTON,Kendall Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000030
+HAMILTON,Lamont Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000040
+HAMILTON,Lamont Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+HAMILTON,Lamont Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000040
+HAMILTON,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000050
+HAMILTON,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+HAMILTON,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000050
+HAMILTON,Medway Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000060
+HAMILTON,Medway Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+HAMILTON,Medway Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000060
+HAMILTON,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000070
+HAMILTON,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+HAMILTON,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000070
+HAMILTON,Syracuse 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000080
+HAMILTON,Syracuse 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000080
+HAMILTON,Syracuse 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",82,000080
+HAMILTON,Syracuse 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000090
+HAMILTON,Syracuse 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000090
+HAMILTON,Syracuse 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000090
+HAMILTON,Syracuse 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000100
+HAMILTON,Syracuse 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000100
+HAMILTON,Syracuse 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000100
+HAMILTON,Syracuse 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,120010
+HAMILTON,Syracuse 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120010
+HAMILTON,Syracuse 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,120010
+HAMILTON,Syracuse 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,120020
+HAMILTON,Syracuse 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120020
+HAMILTON,Syracuse 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",74,120020
+HAMILTON,Bear Creek Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",16,000010
+HAMILTON,Coolidge Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",24,000020
+HAMILTON,Kendall Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",25,000030
+HAMILTON,Lamont Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",41,000040
+HAMILTON,Liberty Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",14,000050
+HAMILTON,Medway Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",24,000060
+HAMILTON,Richland Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",11,000070
+HAMILTON,Syracuse 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",148,000080
+HAMILTON,Syracuse 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",88,000090
+HAMILTON,Syracuse 3,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",106,000100
+HAMILTON,Syracuse 4,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",51,120010
+HAMILTON,Syracuse 5,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",122,120020
+HAMILTON,Bear Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000010
+HAMILTON,Bear Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000010
+HAMILTON,Coolidge Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000020
+HAMILTON,Coolidge Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000020
+HAMILTON,Kendall Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000030
+HAMILTON,Kendall Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000030
+HAMILTON,Lamont Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000040
+HAMILTON,Lamont Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000040
+HAMILTON,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000050
+HAMILTON,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000050
+HAMILTON,Medway Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000060
+HAMILTON,Medway Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000060
+HAMILTON,Richland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000070
+HAMILTON,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000070
+HAMILTON,Syracuse 1,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000080
+HAMILTON,Syracuse 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",116,000080
+HAMILTON,Syracuse 2,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000090
+HAMILTON,Syracuse 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000090
+HAMILTON,Syracuse 3,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000100
+HAMILTON,Syracuse 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000100
+HAMILTON,Syracuse 4,United States House of Representatives,1,Democratic,"Sherow, James E.",12,120010
+HAMILTON,Syracuse 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,120010
+HAMILTON,Syracuse 5,United States House of Representatives,1,Democratic,"Sherow, James E.",32,120020
+HAMILTON,Syracuse 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",96,120020
+HAMILTON,Bear Creek Township,Attorney General,,Democratic,"Kotich, A.J.",1,000010
+HAMILTON,Bear Creek Township,Attorney General,,Republican,"Schmidt, Derek",13,000010
+HAMILTON,Coolidge Township,Attorney General,,Democratic,"Kotich, A.J.",6,000020
+HAMILTON,Coolidge Township,Attorney General,,Republican,"Schmidt, Derek",21,000020
+HAMILTON,Kendall Township,Attorney General,,Democratic,"Kotich, A.J.",6,000030
+HAMILTON,Kendall Township,Attorney General,,Republican,"Schmidt, Derek",21,000030
+HAMILTON,Lamont Township,Attorney General,,Democratic,"Kotich, A.J.",1,000040
+HAMILTON,Lamont Township,Attorney General,,Republican,"Schmidt, Derek",41,000040
+HAMILTON,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",2,000050
+HAMILTON,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",14,000050
+HAMILTON,Medway Township,Attorney General,,Democratic,"Kotich, A.J.",2,000060
+HAMILTON,Medway Township,Attorney General,,Republican,"Schmidt, Derek",22,000060
+HAMILTON,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",1,000070
+HAMILTON,Richland Township,Attorney General,,Republican,"Schmidt, Derek",10,000070
+HAMILTON,Syracuse 1,Attorney General,,Democratic,"Kotich, A.J.",28,000080
+HAMILTON,Syracuse 1,Attorney General,,Republican,"Schmidt, Derek",125,000080
+HAMILTON,Syracuse 2,Attorney General,,Democratic,"Kotich, A.J.",12,000090
+HAMILTON,Syracuse 2,Attorney General,,Republican,"Schmidt, Derek",80,000090
+HAMILTON,Syracuse 3,Attorney General,,Democratic,"Kotich, A.J.",23,000100
+HAMILTON,Syracuse 3,Attorney General,,Republican,"Schmidt, Derek",88,000100
+HAMILTON,Syracuse 4,Attorney General,,Democratic,"Kotich, A.J.",15,120010
+HAMILTON,Syracuse 4,Attorney General,,Republican,"Schmidt, Derek",38,120010
+HAMILTON,Syracuse 5,Attorney General,,Democratic,"Kotich, A.J.",18,120020
+HAMILTON,Syracuse 5,Attorney General,,Republican,"Schmidt, Derek",109,120020
+HAMILTON,Bear Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000010
+HAMILTON,Bear Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000010
+HAMILTON,Coolidge Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000020
+HAMILTON,Coolidge Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000020
+HAMILTON,Kendall Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000030
+HAMILTON,Kendall Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000030
+HAMILTON,Lamont Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000040
+HAMILTON,Lamont Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000040
+HAMILTON,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000050
+HAMILTON,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000050
+HAMILTON,Medway Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000060
+HAMILTON,Medway Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000060
+HAMILTON,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000070
+HAMILTON,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000070
+HAMILTON,Syracuse 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000080
+HAMILTON,Syracuse 1,Commissioner of Insurance,,Republican,"Selzer, Ken",115,000080
+HAMILTON,Syracuse 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000090
+HAMILTON,Syracuse 2,Commissioner of Insurance,,Republican,"Selzer, Ken",70,000090
+HAMILTON,Syracuse 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000100
+HAMILTON,Syracuse 3,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000100
+HAMILTON,Syracuse 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,120010
+HAMILTON,Syracuse 4,Commissioner of Insurance,,Republican,"Selzer, Ken",37,120010
+HAMILTON,Syracuse 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,120020
+HAMILTON,Syracuse 5,Commissioner of Insurance,,Republican,"Selzer, Ken",90,120020
+HAMILTON,Bear Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000010
+HAMILTON,Bear Creek Township,Secretary of State,,Republican,"Kobach, Kris",13,000010
+HAMILTON,Coolidge Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000020
+HAMILTON,Coolidge Township,Secretary of State,,Republican,"Kobach, Kris",21,000020
+HAMILTON,Kendall Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000030
+HAMILTON,Kendall Township,Secretary of State,,Republican,"Kobach, Kris",21,000030
+HAMILTON,Lamont Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000040
+HAMILTON,Lamont Township,Secretary of State,,Republican,"Kobach, Kris",38,000040
+HAMILTON,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000050
+HAMILTON,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",14,000050
+HAMILTON,Medway Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000060
+HAMILTON,Medway Township,Secretary of State,,Republican,"Kobach, Kris",22,000060
+HAMILTON,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000070
+HAMILTON,Richland Township,Secretary of State,,Republican,"Kobach, Kris",8,000070
+HAMILTON,Syracuse 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000080
+HAMILTON,Syracuse 1,Secretary of State,,Republican,"Kobach, Kris",123,000080
+HAMILTON,Syracuse 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000090
+HAMILTON,Syracuse 2,Secretary of State,,Republican,"Kobach, Kris",79,000090
+HAMILTON,Syracuse 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000100
+HAMILTON,Syracuse 3,Secretary of State,,Republican,"Kobach, Kris",84,000100
+HAMILTON,Syracuse 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,120010
+HAMILTON,Syracuse 4,Secretary of State,,Republican,"Kobach, Kris",40,120010
+HAMILTON,Syracuse 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,120020
+HAMILTON,Syracuse 5,Secretary of State,,Republican,"Kobach, Kris",98,120020
+HAMILTON,Bear Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000010
+HAMILTON,Bear Creek Township,State Treasurer,,Republican,"Estes, Ron",15,000010
+HAMILTON,Coolidge Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000020
+HAMILTON,Coolidge Township,State Treasurer,,Republican,"Estes, Ron",23,000020
+HAMILTON,Kendall Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+HAMILTON,Kendall Township,State Treasurer,,Republican,"Estes, Ron",23,000030
+HAMILTON,Lamont Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000040
+HAMILTON,Lamont Township,State Treasurer,,Republican,"Estes, Ron",41,000040
+HAMILTON,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000050
+HAMILTON,Liberty Township,State Treasurer,,Republican,"Estes, Ron",15,000050
+HAMILTON,Medway Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000060
+HAMILTON,Medway Township,State Treasurer,,Republican,"Estes, Ron",22,000060
+HAMILTON,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000070
+HAMILTON,Richland Township,State Treasurer,,Republican,"Estes, Ron",10,000070
+HAMILTON,Syracuse 1,State Treasurer,,Democratic,"Alldritt, Carmen",37,000080
+HAMILTON,Syracuse 1,State Treasurer,,Republican,"Estes, Ron",119,000080
+HAMILTON,Syracuse 2,State Treasurer,,Democratic,"Alldritt, Carmen",11,000090
+HAMILTON,Syracuse 2,State Treasurer,,Republican,"Estes, Ron",83,000090
+HAMILTON,Syracuse 3,State Treasurer,,Democratic,"Alldritt, Carmen",21,000100
+HAMILTON,Syracuse 3,State Treasurer,,Republican,"Estes, Ron",90,000100
+HAMILTON,Syracuse 4,State Treasurer,,Democratic,"Alldritt, Carmen",13,120010
+HAMILTON,Syracuse 4,State Treasurer,,Republican,"Estes, Ron",39,120010
+HAMILTON,Syracuse 5,State Treasurer,,Democratic,"Alldritt, Carmen",13,120020
+HAMILTON,Syracuse 5,State Treasurer,,Republican,"Estes, Ron",110,120020
+HAMILTON,Bear Creek Township,United States Senate,,independent,"Orman, Greg",2,000010
+HAMILTON,Bear Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+HAMILTON,Bear Creek Township,United States Senate,,Republican,"Roberts, Pat",15,000010
+HAMILTON,Coolidge Township,United States Senate,,independent,"Orman, Greg",5,000020
+HAMILTON,Coolidge Township,United States Senate,,Libertarian,"Batson, Randall",3,000020
+HAMILTON,Coolidge Township,United States Senate,,Republican,"Roberts, Pat",20,000020
+HAMILTON,Kendall Township,United States Senate,,independent,"Orman, Greg",9,000030
+HAMILTON,Kendall Township,United States Senate,,Libertarian,"Batson, Randall",2,000030
+HAMILTON,Kendall Township,United States Senate,,Republican,"Roberts, Pat",20,000030
+HAMILTON,Lamont Township,United States Senate,,independent,"Orman, Greg",5,000040
+HAMILTON,Lamont Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+HAMILTON,Lamont Township,United States Senate,,Republican,"Roberts, Pat",38,000040
+HAMILTON,Liberty Township,United States Senate,,independent,"Orman, Greg",2,000050
+HAMILTON,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+HAMILTON,Liberty Township,United States Senate,,Republican,"Roberts, Pat",15,000050
+HAMILTON,Medway Township,United States Senate,,independent,"Orman, Greg",3,000060
+HAMILTON,Medway Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+HAMILTON,Medway Township,United States Senate,,Republican,"Roberts, Pat",22,000060
+HAMILTON,Richland Township,United States Senate,,independent,"Orman, Greg",1,000070
+HAMILTON,Richland Township,United States Senate,,Libertarian,"Batson, Randall",1,000070
+HAMILTON,Richland Township,United States Senate,,Republican,"Roberts, Pat",9,000070
+HAMILTON,Syracuse 1,United States Senate,,independent,"Orman, Greg",41,000080
+HAMILTON,Syracuse 1,United States Senate,,Libertarian,"Batson, Randall",8,000080
+HAMILTON,Syracuse 1,United States Senate,,Republican,"Roberts, Pat",106,000080
+HAMILTON,Syracuse 2,United States Senate,,independent,"Orman, Greg",13,000090
+HAMILTON,Syracuse 2,United States Senate,,Libertarian,"Batson, Randall",2,000090
+HAMILTON,Syracuse 2,United States Senate,,Republican,"Roberts, Pat",82,000090
+HAMILTON,Syracuse 3,United States Senate,,independent,"Orman, Greg",26,000100
+HAMILTON,Syracuse 3,United States Senate,,Libertarian,"Batson, Randall",0,000100
+HAMILTON,Syracuse 3,United States Senate,,Republican,"Roberts, Pat",84,000100
+HAMILTON,Syracuse 4,United States Senate,,independent,"Orman, Greg",12,120010
+HAMILTON,Syracuse 4,United States Senate,,Libertarian,"Batson, Randall",4,120010
+HAMILTON,Syracuse 4,United States Senate,,Republican,"Roberts, Pat",37,120010
+HAMILTON,Syracuse 5,United States Senate,,independent,"Orman, Greg",31,120020
+HAMILTON,Syracuse 5,United States Senate,,Libertarian,"Batson, Randall",1,120020
+HAMILTON,Syracuse 5,United States Senate,,Republican,"Roberts, Pat",98,120020

--- a/2014/20141104__ks__general__harper__precinct.csv
+++ b/2014/20141104__ks__general__harper__precinct.csv
@@ -1,286 +1,375 @@
-county,precinct,office,district,party,candidate,votes
-Harper,Anthony 1,Attorney General,,D,AJ Kotich - D,80
-Harper,Anthony 2,Attorney General,,D,AJ Kotich - D,32
-Harper,Anthony 3,Attorney General,,D,AJ Kotich - D,8
-Harper,Anthony 4,Attorney General,,D,AJ Kotich - D,14
-Harper,Harper 1,Attorney General,,D,AJ Kotich - D,55
-Harper,Harper 2,Attorney General,,D,AJ Kotich - D,54
-Harper,Township 1,Attorney General,,D,AJ Kotich - D,54
-Harper,Township 2,Attorney General,,D,AJ Kotich - D,5
-Harper,Township 3 East,Attorney General,,D,AJ Kotich - D,10
-Harper,Township 3 West,Attorney General,,D,AJ Kotich - D,14
-Harper,Township 4,Attorney General,,D,AJ Kotich - D,20
-Harper,Township 5 East,Attorney General,,D,AJ Kotich - D,15
-Harper,Township 5 West,Attorney General,,D,AJ Kotich - D,3
-Harper,Township 6 East,Attorney General,,D,AJ Kotich - D,13
-Harper,Township 6 West,Attorney General,,D,AJ Kotich - D,4
-Harper,Anthony 1,Attorney General,,R,Derek Schmidt - R,303
-Harper,Anthony 2,Attorney General,,R,Derek Schmidt - R,146
-Harper,Anthony 3,Attorney General,,R,Derek Schmidt - R,43
-Harper,Anthony 4,Attorney General,,R,Derek Schmidt - R,102
-Harper,Harper 1,Attorney General,,R,Derek Schmidt - R,164
-Harper,Harper 2,Attorney General,,R,Derek Schmidt - R,145
-Harper,Township 1,Attorney General,,R,Derek Schmidt - R,239
-Harper,Township 2,Attorney General,,R,Derek Schmidt - R,36
-Harper,Township 3 East,Attorney General,,R,Derek Schmidt - R,40
-Harper,Township 3 West,Attorney General,,R,Derek Schmidt - R,59
-Harper,Township 4,Attorney General,,R,Derek Schmidt - R,55
-Harper,Township 5 East,Attorney General,,R,Derek Schmidt - R,64
-Harper,Township 5 West,Attorney General,,R,Derek Schmidt - R,82
-Harper,Township 6 East,Attorney General,,R,Derek Schmidt - R,67
-Harper,Township 6 West,Attorney General,,R,Derek Schmidt - R,28
-Harper,Anthony 1,Commissioner of Insurance,,D,Dennis Anderson - D,103
-Harper,Anthony 2,Commissioner of Insurance,,D,Dennis Anderson - D,47
-Harper,Anthony 3,Commissioner of Insurance,,D,Dennis Anderson - D,10
-Harper,Anthony 4,Commissioner of Insurance,,D,Dennis Anderson - D,25
-Harper,Harper 1,Commissioner of Insurance,,D,Dennis Anderson - D,68
-Harper,Harper 2,Commissioner of Insurance,,D,Dennis Anderson - D,69
-Harper,Township 1,Commissioner of Insurance,,D,Dennis Anderson - D,80
-Harper,Township 2,Commissioner of Insurance,,D,Dennis Anderson - D,5
-Harper,Township 3 East,Commissioner of Insurance,,D,Dennis Anderson - D,14
-Harper,Township 3 West,Commissioner of Insurance,,D,Dennis Anderson - D,16
-Harper,Township 4,Commissioner of Insurance,,D,Dennis Anderson - D,26
-Harper,Township 5 East,Commissioner of Insurance,,D,Dennis Anderson - D,16
-Harper,Township 5 West,Commissioner of Insurance,,D,Dennis Anderson - D,11
-Harper,Township 6 East,Commissioner of Insurance,,D,Dennis Anderson - D,13
-Harper,Township 6 West,Commissioner of Insurance,,D,Dennis Anderson - D,8
-Harper,Anthony 1,Commissioner of Insurance,,R,Ken Selzer - R,278
-Harper,Anthony 2,Commissioner of Insurance,,R,Ken Selzer - R,130
-Harper,Anthony 3,Commissioner of Insurance,,R,Ken Selzer - R,41
-Harper,Anthony 4,Commissioner of Insurance,,R,Ken Selzer - R,90
-Harper,Harper 1,Commissioner of Insurance,,R,Ken Selzer - R,143
-Harper,Harper 2,Commissioner of Insurance,,R,Ken Selzer - R,129
-Harper,Township 1,Commissioner of Insurance,,R,Ken Selzer - R,212
-Harper,Township 2,Commissioner of Insurance,,R,Ken Selzer - R,33
-Harper,Township 3 East,Commissioner of Insurance,,R,Ken Selzer - R,36
-Harper,Township 3 West,Commissioner of Insurance,,R,Ken Selzer - R,58
-Harper,Township 4,Commissioner of Insurance,,R,Ken Selzer - R,46
-Harper,Township 5 East,Commissioner of Insurance,,R,Ken Selzer - R,59
-Harper,Township 5 West,Commissioner of Insurance,,R,Ken Selzer - R,76
-Harper,Township 6 East,Commissioner of Insurance,,R,Ken Selzer - R,65
-Harper,Township 6 West,Commissioner of Insurance,,R,Ken Selzer - R,24
-Harper,Anthony 1,U.S. House,4,R,Mike Pompeo - R,304
-Harper,Anthony 2,U.S. House,4,R,Mike Pompeo - R,142
-Harper,Anthony 3,U.S. House,4,R,Mike Pompeo - R,45
-Harper,Anthony 4,U.S. House,4,R,Mike Pompeo - R,99
-Harper,Harper 1,U.S. House,4,R,Mike Pompeo - R,162
-Harper,Harper 2,U.S. House,4,R,Mike Pompeo - R,145
-Harper,Township 1,U.S. House,4,R,Mike Pompeo - R,245
-Harper,Township 2,U.S. House,4,R,Mike Pompeo - R,37
-Harper,Township 3 East,U.S. House,4,R,Mike Pompeo - R,40
-Harper,Township 3 West,U.S. House,4,R,Mike Pompeo - R,65
-Harper,Township 4,U.S. House,4,R,Mike Pompeo - R,47
-Harper,Township 5 East,U.S. House,4,R,Mike Pompeo - R,66
-Harper,Township 5 West,U.S. House,4,R,Mike Pompeo - R,84
-Harper,Township 6 East,U.S. House,4,R,Mike Pompeo - R,70
-Harper,Township 6 West,U.S. House,4,R,Mike Pompeo - R,27
-Harper,Anthony 1,U.S. House,4,D,Perry L Schuckman - D,88
-Harper,Anthony 2,U.S. House,4,D,Perry L Schuckman - D,39
-Harper,Anthony 3,U.S. House,4,D,Perry L Schuckman - D,6
-Harper,Anthony 4,U.S. House,4,D,Perry L Schuckman - D,19
-Harper,Harper 1,U.S. House,4,D,Perry L Schuckman - D,59
-Harper,Harper 2,U.S. House,4,D,Perry L Schuckman - D,58
-Harper,Township 1,U.S. House,4,D,Perry L Schuckman - D,58
-Harper,Township 2,U.S. House,4,D,Perry L Schuckman - D,5
-Harper,Township 3 East,U.S. House,4,D,Perry L Schuckman - D,11
-Harper,Township 3 West,U.S. House,4,D,Perry L Schuckman - D,11
-Harper,Township 4,U.S. House,4,D,Perry L Schuckman - D,26
-Harper,Township 5 East,U.S. House,4,D,Perry L Schuckman - D,14
-Harper,Township 5 West,U.S. House,4,D,Perry L Schuckman - D,7
-Harper,Township 6 East,U.S. House,4,D,Perry L Schuckman - D,12
-Harper,Township 6 West,U.S. House,4,D,Perry L Schuckman - D,5
-Harper,Anthony 1,Governor,,L,Keen Umbehr,21
-Harper,Anthony 2,Governor,,L,Keen Umbehr,12
-Harper,Anthony 3,Governor,,L,Keen Umbehr,5
-Harper,Anthony 4,Governor,,L,Keen Umbehr,8
-Harper,Harper 1,Governor,,L,Keen Umbehr,7
-Harper,Harper 2,Governor,,L,Keen Umbehr,10
-Harper,Township 1,Governor,,L,Keen Umbehr,15
-Harper,Township 2,Governor,,L,Keen Umbehr,1
-Harper,Township 3 East,Governor,,L,Keen Umbehr,2
-Harper,Township 3 West,Governor,,L,Keen Umbehr,6
-Harper,Township 4,Governor,,L,Keen Umbehr,3
-Harper,Township 5 East,Governor,,L,Keen Umbehr,4
-Harper,Township 5 West,Governor,,L,Keen Umbehr,2
-Harper,Township 6 East,Governor,,L,Keen Umbehr,2
-Harper,Township 6 West,Governor,,L,Keen Umbehr,0
-Harper,Anthony 1,Governor,,D,Paul Davis - D,132
-Harper,Anthony 2,Governor,,D,Paul Davis - D,68
-Harper,Anthony 3,Governor,,D,Paul Davis - D,15
-Harper,Anthony 4,Governor,,D,Paul Davis - D,30
-Harper,Harper 1,Governor,,D,Paul Davis - D,92
-Harper,Harper 2,Governor,,D,Paul Davis - D,78
-Harper,Township 1,Governor,,D,Paul Davis - D,98
-Harper,Township 2,Governor,,D,Paul Davis - D,6
-Harper,Township 3 East,Governor,,D,Paul Davis - D,19
-Harper,Township 3 West,Governor,,D,Paul Davis - D,23
-Harper,Township 4,Governor,,D,Paul Davis - D,32
-Harper,Township 5 East,Governor,,D,Paul Davis - D,24
-Harper,Township 5 West,Governor,,D,Paul Davis - D,16
-Harper,Township 6 East,Governor,,D,Paul Davis - D,27
-Harper,Township 6 West,Governor,,D,Paul Davis - D,11
-Harper,Anthony 1,Governor,,R,Sam Brownback - R,240
-Harper,Anthony 2,Governor,,R,Sam Brownback - R,103
-Harper,Anthony 3,Governor,,R,Sam Brownback - R,31
-Harper,Anthony 4,Governor,,R,Sam Brownback - R,79
-Harper,Harper 1,Governor,,R,Sam Brownback - R,120
-Harper,Harper 2,Governor,,R,Sam Brownback - R,115
-Harper,Township 1,Governor,,R,Sam Brownback - R,195
-Harper,Township 2,Governor,,R,Sam Brownback - R,35
-Harper,Township 3 East,Governor,,R,Sam Brownback - R,30
-Harper,Township 3 West,Governor,,R,Sam Brownback - R,47
-Harper,Township 4,Governor,,R,Sam Brownback - R,41
-Harper,Township 5 East,Governor,,R,Sam Brownback - R,53
-Harper,Township 5 West,Governor,,R,Sam Brownback - R,72
-Harper,Township 6 East,Governor,,R,Sam Brownback - R,52
-Harper,Township 6 West,Governor,,R,Sam Brownback - R,21
-Harper,Anthony 1,State House,116,R,Kyle D Hoffman - R,348
-Harper,Anthony 2,State House,116,R,Kyle D Hoffman - R,155
-Harper,Anthony 3,State House,116,R,Kyle D Hoffman - R,47
-Harper,Anthony 4,State House,116,R,Kyle D Hoffman - R,106
-Harper,Harper 1,State House,116,R,Kyle D Hoffman - R,194
-Harper,Harper 2,State House,116,R,Kyle D Hoffman - R,181
-Harper,Township 1,State House,116,R,Kyle D Hoffman - R,270
-Harper,Township 2,State House,116,R,Kyle D Hoffman - R,41
-Harper,Township 3 East,State House,116,R,Kyle D Hoffman - R,45
-Harper,Township 3 West,State House,116,R,Kyle D Hoffman - R,67
-Harper,Township 4,State House,116,R,Kyle D Hoffman - R,60
-Harper,Township 5 East,State House,116,R,Kyle D Hoffman - R,72
-Harper,Township 5 West,State House,116,R,Kyle D Hoffman - R,85
-Harper,Township 6 East,State House,116,R,Kyle D Hoffman - R,73
-Harper,Township 6 West,State House,116,R,Kyle D Hoffman - R,25
-Harper,Anthony 1,Secretary of State,,D,Jean Kurtis Schodorf - D,110
-Harper,Anthony 2,Secretary of State,,D,Jean Kurtis Schodorf - D,51
-Harper,Anthony 3,Secretary of State,,D,Jean Kurtis Schodorf - D,10
-Harper,Anthony 4,Secretary of State,,D,Jean Kurtis Schodorf - D,31
-Harper,Harper 1,Secretary of State,,D,Jean Kurtis Schodorf - D,71
-Harper,Harper 2,Secretary of State,,D,Jean Kurtis Schodorf - D,69
-Harper,Township 1,Secretary of State,,D,Jean Kurtis Schodorf - D,85
-Harper,Township 2,Secretary of State,,D,Jean Kurtis Schodorf - D,9
-Harper,Township 3 East,Secretary of State,,D,Jean Kurtis Schodorf - D,16
-Harper,Township 3 West,Secretary of State,,D,Jean Kurtis Schodorf - D,22
-Harper,Township 4,Secretary of State,,D,Jean Kurtis Schodorf - D,35
-Harper,Township 5 East,Secretary of State,,D,Jean Kurtis Schodorf - D,18
-Harper,Township 5 West,Secretary of State,,D,Jean Kurtis Schodorf - D,10
-Harper,Township 6 East,Secretary of State,,D,Jean Kurtis Schodorf - D,18
-Harper,Township 6 West,Secretary of State,,D,Jean Kurtis Schodorf - D,5
-Harper,Anthony 1,Secretary of State,,R,Kris Kobach - R,274
-Harper,Anthony 2,Secretary of State,,R,Kris Kobach - R,129
-Harper,Anthony 3,Secretary of State,,R,Kris Kobach - R,41
-Harper,Anthony 4,Secretary of State,,R,Kris Kobach - R,87
-Harper,Harper 1,Secretary of State,,R,Kris Kobach - R,149
-Harper,Harper 2,Secretary of State,,R,Kris Kobach - R,132
-Harper,Township 1,Secretary of State,,R,Kris Kobach - R,218
-Harper,Township 2,Secretary of State,,R,Kris Kobach - R,33
-Harper,Township 3 East,Secretary of State,,R,Kris Kobach - R,34
-Harper,Township 3 West,Secretary of State,,R,Kris Kobach - R,55
-Harper,Township 4,Secretary of State,,R,Kris Kobach - R,42
-Harper,Township 5 East,Secretary of State,,R,Kris Kobach - R,58
-Harper,Township 5 West,Secretary of State,,R,Kris Kobach - R,79
-Harper,Township 6 East,Secretary of State,,R,Kris Kobach - R,64
-Harper,Township 6 West,Secretary of State,,R,Kris Kobach - R,27
-Harper,Anthony 1,State Treasurer,,D,Carmen Alldritt - D,165
-Harper,Anthony 2,State Treasurer,,D,Carmen Alldritt - D,64
-Harper,Anthony 3,State Treasurer,,D,Carmen Alldritt - D,18
-Harper,Anthony 4,State Treasurer,,D,Carmen Alldritt - D,45
-Harper,Harper 1,State Treasurer,,D,Carmen Alldritt - D,110
-Harper,Harper 2,State Treasurer,,D,Carmen Alldritt - D,101
-Harper,Township 1,State Treasurer,,D,Carmen Alldritt - D,121
-Harper,Township 2,State Treasurer,,D,Carmen Alldritt - D,12
-Harper,Township 3 East,State Treasurer,,D,Carmen Alldritt - D,22
-Harper,Township 3 West,State Treasurer,,D,Carmen Alldritt - D,34
-Harper,Township 4,State Treasurer,,D,Carmen Alldritt - D,37
-Harper,Township 5 East,State Treasurer,,D,Carmen Alldritt - D,40
-Harper,Township 5 West,State Treasurer,,D,Carmen Alldritt - D,31
-Harper,Township 6 East,State Treasurer,,D,Carmen Alldritt - D,31
-Harper,Township 6 West,State Treasurer,,D,Carmen Alldritt - D,13
-Harper,Anthony 1,State Treasurer,,R,Ron Estes - R,226
-Harper,Anthony 2,State Treasurer,,R,Ron Estes - R,115
-Harper,Anthony 3,State Treasurer,,R,Ron Estes - R,33
-Harper,Anthony 4,State Treasurer,,R,Ron Estes - R,71
-Harper,Harper 1,State Treasurer,,R,Ron Estes - R,109
-Harper,Harper 2,State Treasurer,,R,Ron Estes - R,102
-Harper,Township 1,State Treasurer,,R,Ron Estes - R,184
-Harper,Township 2,State Treasurer,,R,Ron Estes - R,30
-Harper,Township 3 East,State Treasurer,,R,Ron Estes - R,29
-Harper,Township 3 West,State Treasurer,,R,Ron Estes - R,43
-Harper,Township 4,State Treasurer,,R,Ron Estes - R,40
-Harper,Township 5 East,State Treasurer,,R,Ron Estes - R,39
-Harper,Township 5 West,State Treasurer,,R,Ron Estes - R,60
-Harper,Township 6 East,State Treasurer,,R,Ron Estes - R,48
-Harper,Township 6 West,State Treasurer,,R,Ron Estes - R,19
-Harper,Anthony 1,U.S. Senate,,I,Greg Orman - I,115
-Harper,Anthony 2,U.S. Senate,,I,Greg Orman - I,53
-Harper,Anthony 3,U.S. Senate,,I,Greg Orman - I,16
-Harper,Anthony 4,U.S. Senate,,I,Greg Orman - I,24
-Harper,Harper 1,U.S. Senate,,I,Greg Orman - I,67
-Harper,Harper 2,U.S. Senate,,I,Greg Orman - I,68
-Harper,Township 1,U.S. Senate,,I,Greg Orman - I,72
-Harper,Township 2,U.S. Senate,,I,Greg Orman - I,2
-Harper,Township 3 East,U.S. Senate,,I,Greg Orman - I,12
-Harper,Township 3 West,U.S. Senate,,I,Greg Orman - I,19
-Harper,Township 4,U.S. Senate,,I,Greg Orman - I,28
-Harper,Township 5 East,U.S. Senate,,I,Greg Orman - I,21
-Harper,Township 5 West,U.S. Senate,,I,Greg Orman - I,13
-Harper,Township 6 East,U.S. Senate,,I,Greg Orman - I,19
-Harper,Township 6 West,U.S. Senate,,I,Greg Orman - I,9
-Harper,Anthony 1,U.S. Senate,,R,Pat Roberts - R,262
-Harper,Anthony 2,U.S. Senate,,R,Pat Roberts - R,122
-Harper,Anthony 3,U.S. Senate,,R,Pat Roberts - R,30
-Harper,Anthony 4,U.S. Senate,,R,Pat Roberts - R,82
-Harper,Harper 1,U.S. Senate,,R,Pat Roberts - R,140
-Harper,Harper 2,U.S. Senate,,R,Pat Roberts - R,119
-Harper,Township 1,U.S. Senate,,R,Pat Roberts - R,211
-Harper,Township 2,U.S. Senate,,R,Pat Roberts - R,37
-Harper,Township 3 East,U.S. Senate,,R,Pat Roberts - R,38
-Harper,Township 3 West,U.S. Senate,,R,Pat Roberts - R,54
-Harper,Township 4,U.S. Senate,,R,Pat Roberts - R,46
-Harper,Township 5 East,U.S. Senate,,R,Pat Roberts - R,57
-Harper,Township 5 West,U.S. Senate,,R,Pat Roberts - R,71
-Harper,Township 6 East,U.S. Senate,,R,Pat Roberts - R,61
-Harper,Township 6 West,U.S. Senate,,R,Pat Roberts - R,22
-Harper,Anthony 1,U.S. Senate,,L,Randall Batson - L,19
-Harper,Anthony 2,U.S. Senate,,L,Randall Batson - L,10
-Harper,Anthony 3,U.S. Senate,,L,Randall Batson - L,6
-Harper,Anthony 4,U.S. Senate,,L,Randall Batson - L,11
-Harper,Harper 1,U.S. Senate,,L,Randall Batson - L,12
-Harper,Harper 2,U.S. Senate,,L,Randall Batson - L,16
-Harper,Township 1,U.S. Senate,,L,Randall Batson - L,22
-Harper,Township 2,U.S. Senate,,L,Randall Batson - L,3
-Harper,Township 3 East,U.S. Senate,,L,Randall Batson - L,2
-Harper,Township 3 West,U.S. Senate,,L,Randall Batson - L,5
-Harper,Township 4,U.S. Senate,,L,Randall Batson - L,4
-Harper,Township 5 East,U.S. Senate,,L,Randall Batson - L,2
-Harper,Township 5 West,U.S. Senate,,L,Randall Batson - L,6
-Harper,Township 6 East,U.S. Senate,,L,Randall Batson - L,2
-Harper,Township 6 West,U.S. Senate,,L,Randall Batson - L,1
-Harper,Anthony 1,Voter,,,# registered voters,756
-Harper,Anthony 2,Voter,,,# registered voters,386
-Harper,Anthony 3,Voter,,,# registered voters,147
-Harper,Anthony 4,Voter,,,# registered voters,293
-Harper,Harper 1,Voter,,,# registered voters,448
-Harper,Harper 2,Voter,,,# registered voters,459
-Harper,Township 1,Voter,,,# registered voters,677
-Harper,Township 2,Voter,,,# registered voters,80
-Harper,Township 3 East,Voter,,,# registered voters,108
-Harper,Township 3 West,Voter,,,# registered voters,130
-Harper,Township 4,Voter,,,# registered voters,165
-Harper,Township 5 East,Voter,,,# registered voters,242
-Harper,Township 5 West,Voter,,,# registered voters,91
-Harper,Township 6 East,Voter,,,# registered voters,141
-Harper,Township 6 West,Voter,,,# registered voters,58
-Harper,Anthony 1,Voter,,,persons voting,396
-Harper,Anthony 2,Voter,,,persons voting,186
-Harper,Anthony 3,Voter,,,persons voting,52
-Harper,Anthony 4,Voter,,,persons voting,119
-Harper,Harper 1,Voter,,,persons voting,225
-Harper,Harper 2,Voter,,,persons voting,207
-Harper,Township 1,Voter,,,persons voting,314
-Harper,Township 2,Voter,,,persons voting,43
-Harper,Township 3 East,Voter,,,persons voting,52
-Harper,Township 3 West,Voter,,,persons voting,78
-Harper,Township 4,Voter,,,persons voting,79
-Harper,Township 5 East,Voter,,,persons voting,173
-Harper,Township 5 West,Voter,,,persons voting,0
-Harper,Township 6 East,Voter,,,persons voting,82
-Harper,Township 6 West,Voter,,,persons voting,33
+county,precinct,office,district,party,candidate,votes,vtd
+HARPER,Anthony Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",132,000010
+HARPER,Anthony Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000010
+HARPER,Anthony Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",240,000010
+HARPER,Anthony Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",68,000020
+HARPER,Anthony Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000020
+HARPER,Anthony Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000020
+HARPER,Anthony Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000030
+HARPER,Anthony Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000030
+HARPER,Anthony Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000030
+HARPER,Anthony Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000040
+HARPER,Anthony Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000040
+HARPER,Anthony Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000040
+HARPER,Harper Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000050
+HARPER,Harper Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000050
+HARPER,Harper Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",120,000050
+HARPER,Harper Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,000060
+HARPER,Harper Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000060
+HARPER,Harper Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000060
+HARPER,Township 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",98,000070
+HARPER,Township 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000070
+HARPER,Township 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",195,000070
+HARPER,Township 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000080
+HARPER,Township 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+HARPER,Township 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000080
+HARPER,Township 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000100
+HARPER,Township 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000100
+HARPER,Township 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000100
+HARPER,Township 3 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,800010
+HARPER,Township 3 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,800010
+HARPER,Township 3 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,800010
+HARPER,Township 3 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,800020
+HARPER,Township 3 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,800020
+HARPER,Township 3 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,800020
+HARPER,Township 5 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,800030
+HARPER,Township 5 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,800030
+HARPER,Township 5 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,800030
+HARPER,Township 5 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,800040
+HARPER,Township 5 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,800040
+HARPER,Township 5 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,800040
+HARPER,Township 6 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,800050
+HARPER,Township 6 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,800050
+HARPER,Township 6 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,800050
+HARPER,Township 6 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,800060
+HARPER,Township 6 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,800060
+HARPER,Township 6 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,800060
+HARPER,Anthony Ward 2 Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+HARPER,Anthony Ward 2 Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+HARPER,Anthony Ward 2 Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+HARPER,Anthony Ward 2 Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+HARPER,Anthony Ward 2 Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+HARPER,Anthony Ward 2 Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+HARPER,Anthony Ward 3 Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+HARPER,Anthony Ward 3 Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+HARPER,Anthony Ward 3 Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+HARPER,Anthony Ward 3 Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+HARPER,Anthony Ward 3 Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+HARPER,Anthony Ward 3 Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+HARPER,Anthony Ward 4 Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+HARPER,Anthony Ward 4 Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+HARPER,Anthony Ward 4 Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+HARPER,Harper Ward 1 Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900060
+HARPER,Harper Ward 1 Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+HARPER,Harper Ward 1 Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900060
+HARPER,Township 5 West Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900070
+HARPER,Township 5 West Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900070
+HARPER,Township 5 West Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900070
+HARPER,Anthony Ward 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",348,000010
+HARPER,Anthony Ward 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",155,000020
+HARPER,Anthony Ward 3,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",47,000030
+HARPER,Anthony Ward 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",106,000040
+HARPER,Harper Ward 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",194,000050
+HARPER,Harper Ward 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",181,000060
+HARPER,Township 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",270,000070
+HARPER,Township 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",41,000080
+HARPER,Township 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",60,000100
+HARPER,Township 3 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",45,800010
+HARPER,Township 3 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",67,800020
+HARPER,Township 5 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",72,800030
+HARPER,Township 5 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",85,800040
+HARPER,Township 6 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",73,800050
+HARPER,Township 6 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",25,800060
+HARPER,Anthony Ward 2 Exclave 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900010
+HARPER,Anthony Ward 2 Exclave 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900020
+HARPER,Anthony Ward 3 Exclave 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900030
+HARPER,Anthony Ward 3 Exclave 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900040
+HARPER,Anthony Ward 4 Exclave 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900050
+HARPER,Harper Ward 1 Exclave 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900060
+HARPER,Township 5 West Enclave,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900070
+HARPER,Anthony Ward 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",88,000010
+HARPER,Anthony Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",304,000010
+HARPER,Anthony Ward 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",39,000020
+HARPER,Anthony Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",142,000020
+HARPER,Anthony Ward 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",6,000030
+HARPER,Anthony Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",45,000030
+HARPER,Anthony Ward 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,000040
+HARPER,Anthony Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",99,000040
+HARPER,Harper Ward 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",59,000050
+HARPER,Harper Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",162,000050
+HARPER,Harper Ward 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",58,000060
+HARPER,Harper Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",145,000060
+HARPER,Township 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",58,000070
+HARPER,Township 1,United States House of Representatives,4,Republican,"Pompeo, Mike",245,000070
+HARPER,Township 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000080
+HARPER,Township 2,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000080
+HARPER,Township 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",26,000100
+HARPER,Township 4,United States House of Representatives,4,Republican,"Pompeo, Mike",47,000100
+HARPER,Township 3 East,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,800010
+HARPER,Township 3 East,United States House of Representatives,4,Republican,"Pompeo, Mike",40,800010
+HARPER,Township 3 West,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,800020
+HARPER,Township 3 West,United States House of Representatives,4,Republican,"Pompeo, Mike",65,800020
+HARPER,Township 5 East,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",14,800030
+HARPER,Township 5 East,United States House of Representatives,4,Republican,"Pompeo, Mike",66,800030
+HARPER,Township 5 West,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",7,800040
+HARPER,Township 5 West,United States House of Representatives,4,Republican,"Pompeo, Mike",84,800040
+HARPER,Township 6 East,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",12,800050
+HARPER,Township 6 East,United States House of Representatives,4,Republican,"Pompeo, Mike",70,800050
+HARPER,Township 6 West,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,800060
+HARPER,Township 6 West,United States House of Representatives,4,Republican,"Pompeo, Mike",27,800060
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900010
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900010
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900020
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900020
+HARPER,Anthony Ward 3 Exclave 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900030
+HARPER,Anthony Ward 3 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900030
+HARPER,Anthony Ward 3 Exclave 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900040
+HARPER,Anthony Ward 3 Exclave 2,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900040
+HARPER,Anthony Ward 4 Exclave 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900050
+HARPER,Anthony Ward 4 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900050
+HARPER,Harper Ward 1 Exclave 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900060
+HARPER,Harper Ward 1 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900060
+HARPER,Township 5 West Enclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900070
+HARPER,Township 5 West Enclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900070
+HARPER,Anthony Ward 1,Attorney General,,Democratic,"Kotich, A.J.",80,000010
+HARPER,Anthony Ward 1,Attorney General,,Republican,"Schmidt, Derek",303,000010
+HARPER,Anthony Ward 2,Attorney General,,Democratic,"Kotich, A.J.",32,000020
+HARPER,Anthony Ward 2,Attorney General,,Republican,"Schmidt, Derek",146,000020
+HARPER,Anthony Ward 3,Attorney General,,Democratic,"Kotich, A.J.",8,000030
+HARPER,Anthony Ward 3,Attorney General,,Republican,"Schmidt, Derek",43,000030
+HARPER,Anthony Ward 4,Attorney General,,Democratic,"Kotich, A.J.",14,000040
+HARPER,Anthony Ward 4,Attorney General,,Republican,"Schmidt, Derek",102,000040
+HARPER,Harper Ward 1,Attorney General,,Democratic,"Kotich, A.J.",55,000050
+HARPER,Harper Ward 1,Attorney General,,Republican,"Schmidt, Derek",164,000050
+HARPER,Harper Ward 2,Attorney General,,Democratic,"Kotich, A.J.",54,000060
+HARPER,Harper Ward 2,Attorney General,,Republican,"Schmidt, Derek",145,000060
+HARPER,Township 1,Attorney General,,Democratic,"Kotich, A.J.",54,000070
+HARPER,Township 1,Attorney General,,Republican,"Schmidt, Derek",239,000070
+HARPER,Township 2,Attorney General,,Democratic,"Kotich, A.J.",5,000080
+HARPER,Township 2,Attorney General,,Republican,"Schmidt, Derek",36,000080
+HARPER,Township 4,Attorney General,,Democratic,"Kotich, A.J.",20,000100
+HARPER,Township 4,Attorney General,,Republican,"Schmidt, Derek",55,000100
+HARPER,Township 3 East,Attorney General,,Democratic,"Kotich, A.J.",10,800010
+HARPER,Township 3 East,Attorney General,,Republican,"Schmidt, Derek",40,800010
+HARPER,Township 3 West,Attorney General,,Democratic,"Kotich, A.J.",14,800020
+HARPER,Township 3 West,Attorney General,,Republican,"Schmidt, Derek",59,800020
+HARPER,Township 5 East,Attorney General,,Democratic,"Kotich, A.J.",15,800030
+HARPER,Township 5 East,Attorney General,,Republican,"Schmidt, Derek",64,800030
+HARPER,Township 5 West,Attorney General,,Democratic,"Kotich, A.J.",3,800040
+HARPER,Township 5 West,Attorney General,,Republican,"Schmidt, Derek",82,800040
+HARPER,Township 6 East,Attorney General,,Democratic,"Kotich, A.J.",13,800050
+HARPER,Township 6 East,Attorney General,,Republican,"Schmidt, Derek",67,800050
+HARPER,Township 6 West,Attorney General,,Democratic,"Kotich, A.J.",4,800060
+HARPER,Township 6 West,Attorney General,,Republican,"Schmidt, Derek",28,800060
+HARPER,Anthony Ward 2 Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+HARPER,Anthony Ward 2 Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900010
+HARPER,Anthony Ward 2 Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+HARPER,Anthony Ward 2 Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900020
+HARPER,Anthony Ward 3 Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+HARPER,Anthony Ward 3 Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900030
+HARPER,Anthony Ward 3 Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+HARPER,Anthony Ward 3 Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900040
+HARPER,Anthony Ward 4 Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+HARPER,Anthony Ward 4 Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900050
+HARPER,Harper Ward 1 Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900060
+HARPER,Harper Ward 1 Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900060
+HARPER,Township 5 West Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900070
+HARPER,Township 5 West Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900070
+HARPER,Anthony Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",103,000010
+HARPER,Anthony Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",278,000010
+HARPER,Anthony Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000020
+HARPER,Anthony Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",130,000020
+HARPER,Anthony Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000030
+HARPER,Anthony Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000030
+HARPER,Anthony Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000040
+HARPER,Anthony Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",90,000040
+HARPER,Harper Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",68,000050
+HARPER,Harper Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",143,000050
+HARPER,Harper Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000060
+HARPER,Harper Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000060
+HARPER,Township 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000070
+HARPER,Township 1,Commissioner of Insurance,,Republican,"Selzer, Ken",212,000070
+HARPER,Township 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000080
+HARPER,Township 2,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000080
+HARPER,Township 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000100
+HARPER,Township 4,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000100
+HARPER,Township 3 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,800010
+HARPER,Township 3 East,Commissioner of Insurance,,Republican,"Selzer, Ken",36,800010
+HARPER,Township 3 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,800020
+HARPER,Township 3 West,Commissioner of Insurance,,Republican,"Selzer, Ken",58,800020
+HARPER,Township 5 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,800030
+HARPER,Township 5 East,Commissioner of Insurance,,Republican,"Selzer, Ken",59,800030
+HARPER,Township 5 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,800040
+HARPER,Township 5 West,Commissioner of Insurance,,Republican,"Selzer, Ken",76,800040
+HARPER,Township 6 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,800050
+HARPER,Township 6 East,Commissioner of Insurance,,Republican,"Selzer, Ken",65,800050
+HARPER,Township 6 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,800060
+HARPER,Township 6 West,Commissioner of Insurance,,Republican,"Selzer, Ken",24,800060
+HARPER,Anthony Ward 2 Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+HARPER,Anthony Ward 2 Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+HARPER,Anthony Ward 2 Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+HARPER,Anthony Ward 2 Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+HARPER,Anthony Ward 3 Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+HARPER,Anthony Ward 3 Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+HARPER,Anthony Ward 3 Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+HARPER,Anthony Ward 3 Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+HARPER,Anthony Ward 4 Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+HARPER,Anthony Ward 4 Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+HARPER,Harper Ward 1 Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900060
+HARPER,Harper Ward 1 Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900060
+HARPER,Township 5 West Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900070
+HARPER,Township 5 West Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900070
+HARPER,Anthony Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,000010
+HARPER,Anthony Ward 1,Secretary of State,,Republican,"Kobach, Kris",274,000010
+HARPER,Anthony Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000020
+HARPER,Anthony Ward 2,Secretary of State,,Republican,"Kobach, Kris",129,000020
+HARPER,Anthony Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000030
+HARPER,Anthony Ward 3,Secretary of State,,Republican,"Kobach, Kris",41,000030
+HARPER,Anthony Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000040
+HARPER,Anthony Ward 4,Secretary of State,,Republican,"Kobach, Kris",87,000040
+HARPER,Harper Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,000050
+HARPER,Harper Ward 1,Secretary of State,,Republican,"Kobach, Kris",149,000050
+HARPER,Harper Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",69,000060
+HARPER,Harper Ward 2,Secretary of State,,Republican,"Kobach, Kris",132,000060
+HARPER,Township 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",85,000070
+HARPER,Township 1,Secretary of State,,Republican,"Kobach, Kris",218,000070
+HARPER,Township 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000080
+HARPER,Township 2,Secretary of State,,Republican,"Kobach, Kris",33,000080
+HARPER,Township 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000100
+HARPER,Township 4,Secretary of State,,Republican,"Kobach, Kris",42,000100
+HARPER,Township 3 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,800010
+HARPER,Township 3 East,Secretary of State,,Republican,"Kobach, Kris",34,800010
+HARPER,Township 3 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,800020
+HARPER,Township 3 West,Secretary of State,,Republican,"Kobach, Kris",55,800020
+HARPER,Township 5 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,800030
+HARPER,Township 5 East,Secretary of State,,Republican,"Kobach, Kris",58,800030
+HARPER,Township 5 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,800040
+HARPER,Township 5 West,Secretary of State,,Republican,"Kobach, Kris",79,800040
+HARPER,Township 6 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,800050
+HARPER,Township 6 East,Secretary of State,,Republican,"Kobach, Kris",64,800050
+HARPER,Township 6 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,800060
+HARPER,Township 6 West,Secretary of State,,Republican,"Kobach, Kris",27,800060
+HARPER,Anthony Ward 2 Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+HARPER,Anthony Ward 2 Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900010
+HARPER,Anthony Ward 2 Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+HARPER,Anthony Ward 2 Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900020
+HARPER,Anthony Ward 3 Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+HARPER,Anthony Ward 3 Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900030
+HARPER,Anthony Ward 3 Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+HARPER,Anthony Ward 3 Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900040
+HARPER,Anthony Ward 4 Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+HARPER,Anthony Ward 4 Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900050
+HARPER,Harper Ward 1 Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900060
+HARPER,Harper Ward 1 Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900060
+HARPER,Township 5 West Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900070
+HARPER,Township 5 West Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900070
+HARPER,Anthony Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",165,000010
+HARPER,Anthony Ward 1,State Treasurer,,Republican,"Estes, Ron",226,000010
+HARPER,Anthony Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",64,000020
+HARPER,Anthony Ward 2,State Treasurer,,Republican,"Estes, Ron",115,000020
+HARPER,Anthony Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",18,000030
+HARPER,Anthony Ward 3,State Treasurer,,Republican,"Estes, Ron",33,000030
+HARPER,Anthony Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",45,000040
+HARPER,Anthony Ward 4,State Treasurer,,Republican,"Estes, Ron",71,000040
+HARPER,Harper Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",110,000050
+HARPER,Harper Ward 1,State Treasurer,,Republican,"Estes, Ron",109,000050
+HARPER,Harper Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",101,000060
+HARPER,Harper Ward 2,State Treasurer,,Republican,"Estes, Ron",102,000060
+HARPER,Township 1,State Treasurer,,Democratic,"Alldritt, Carmen",121,000070
+HARPER,Township 1,State Treasurer,,Republican,"Estes, Ron",184,000070
+HARPER,Township 2,State Treasurer,,Democratic,"Alldritt, Carmen",12,000080
+HARPER,Township 2,State Treasurer,,Republican,"Estes, Ron",30,000080
+HARPER,Township 4,State Treasurer,,Democratic,"Alldritt, Carmen",37,000100
+HARPER,Township 4,State Treasurer,,Republican,"Estes, Ron",40,000100
+HARPER,Township 3 East,State Treasurer,,Democratic,"Alldritt, Carmen",22,800010
+HARPER,Township 3 East,State Treasurer,,Republican,"Estes, Ron",29,800010
+HARPER,Township 3 West,State Treasurer,,Democratic,"Alldritt, Carmen",34,800020
+HARPER,Township 3 West,State Treasurer,,Republican,"Estes, Ron",43,800020
+HARPER,Township 5 East,State Treasurer,,Democratic,"Alldritt, Carmen",40,800030
+HARPER,Township 5 East,State Treasurer,,Republican,"Estes, Ron",39,800030
+HARPER,Township 5 West,State Treasurer,,Democratic,"Alldritt, Carmen",31,800040
+HARPER,Township 5 West,State Treasurer,,Republican,"Estes, Ron",60,800040
+HARPER,Township 6 East,State Treasurer,,Democratic,"Alldritt, Carmen",31,800050
+HARPER,Township 6 East,State Treasurer,,Republican,"Estes, Ron",48,800050
+HARPER,Township 6 West,State Treasurer,,Democratic,"Alldritt, Carmen",13,800060
+HARPER,Township 6 West,State Treasurer,,Republican,"Estes, Ron",19,800060
+HARPER,Anthony Ward 2 Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+HARPER,Anthony Ward 2 Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900010
+HARPER,Anthony Ward 2 Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+HARPER,Anthony Ward 2 Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900020
+HARPER,Anthony Ward 3 Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+HARPER,Anthony Ward 3 Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900030
+HARPER,Anthony Ward 3 Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+HARPER,Anthony Ward 3 Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900040
+HARPER,Anthony Ward 4 Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+HARPER,Anthony Ward 4 Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900050
+HARPER,Harper Ward 1 Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900060
+HARPER,Harper Ward 1 Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900060
+HARPER,Township 5 West Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900070
+HARPER,Township 5 West Enclave,State Treasurer,,Republican,"Estes, Ron",0,900070
+HARPER,Anthony Ward 1,United States Senate,,independent,"Orman, Greg",115,000010
+HARPER,Anthony Ward 1,United States Senate,,Libertarian,"Batson, Randall",19,000010
+HARPER,Anthony Ward 1,United States Senate,,Republican,"Roberts, Pat",262,000010
+HARPER,Anthony Ward 2,United States Senate,,independent,"Orman, Greg",53,000020
+HARPER,Anthony Ward 2,United States Senate,,Libertarian,"Batson, Randall",10,000020
+HARPER,Anthony Ward 2,United States Senate,,Republican,"Roberts, Pat",122,000020
+HARPER,Anthony Ward 3,United States Senate,,independent,"Orman, Greg",16,000030
+HARPER,Anthony Ward 3,United States Senate,,Libertarian,"Batson, Randall",6,000030
+HARPER,Anthony Ward 3,United States Senate,,Republican,"Roberts, Pat",30,000030
+HARPER,Anthony Ward 4,United States Senate,,independent,"Orman, Greg",24,000040
+HARPER,Anthony Ward 4,United States Senate,,Libertarian,"Batson, Randall",11,000040
+HARPER,Anthony Ward 4,United States Senate,,Republican,"Roberts, Pat",82,000040
+HARPER,Harper Ward 1,United States Senate,,independent,"Orman, Greg",67,000050
+HARPER,Harper Ward 1,United States Senate,,Libertarian,"Batson, Randall",12,000050
+HARPER,Harper Ward 1,United States Senate,,Republican,"Roberts, Pat",140,000050
+HARPER,Harper Ward 2,United States Senate,,independent,"Orman, Greg",68,000060
+HARPER,Harper Ward 2,United States Senate,,Libertarian,"Batson, Randall",16,000060
+HARPER,Harper Ward 2,United States Senate,,Republican,"Roberts, Pat",119,000060
+HARPER,Township 1,United States Senate,,independent,"Orman, Greg",72,000070
+HARPER,Township 1,United States Senate,,Libertarian,"Batson, Randall",22,000070
+HARPER,Township 1,United States Senate,,Republican,"Roberts, Pat",211,000070
+HARPER,Township 2,United States Senate,,independent,"Orman, Greg",2,000080
+HARPER,Township 2,United States Senate,,Libertarian,"Batson, Randall",3,000080
+HARPER,Township 2,United States Senate,,Republican,"Roberts, Pat",37,000080
+HARPER,Township 4,United States Senate,,independent,"Orman, Greg",28,000100
+HARPER,Township 4,United States Senate,,Libertarian,"Batson, Randall",4,000100
+HARPER,Township 4,United States Senate,,Republican,"Roberts, Pat",46,000100
+HARPER,Township 3 East,United States Senate,,independent,"Orman, Greg",12,800010
+HARPER,Township 3 East,United States Senate,,Libertarian,"Batson, Randall",2,800010
+HARPER,Township 3 East,United States Senate,,Republican,"Roberts, Pat",38,800010
+HARPER,Township 3 West,United States Senate,,independent,"Orman, Greg",19,800020
+HARPER,Township 3 West,United States Senate,,Libertarian,"Batson, Randall",5,800020
+HARPER,Township 3 West,United States Senate,,Republican,"Roberts, Pat",54,800020
+HARPER,Township 5 East,United States Senate,,independent,"Orman, Greg",21,800030
+HARPER,Township 5 East,United States Senate,,Libertarian,"Batson, Randall",2,800030
+HARPER,Township 5 East,United States Senate,,Republican,"Roberts, Pat",57,800030
+HARPER,Township 5 West,United States Senate,,independent,"Orman, Greg",13,800040
+HARPER,Township 5 West,United States Senate,,Libertarian,"Batson, Randall",6,800040
+HARPER,Township 5 West,United States Senate,,Republican,"Roberts, Pat",71,800040
+HARPER,Township 6 East,United States Senate,,independent,"Orman, Greg",19,800050
+HARPER,Township 6 East,United States Senate,,Libertarian,"Batson, Randall",2,800050
+HARPER,Township 6 East,United States Senate,,Republican,"Roberts, Pat",61,800050
+HARPER,Township 6 West,United States Senate,,independent,"Orman, Greg",9,800060
+HARPER,Township 6 West,United States Senate,,Libertarian,"Batson, Randall",1,800060
+HARPER,Township 6 West,United States Senate,,Republican,"Roberts, Pat",22,800060
+HARPER,Anthony Ward 2 Exclave 1,United States Senate,,independent,"Orman, Greg",0,900010
+HARPER,Anthony Ward 2 Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900010
+HARPER,Anthony Ward 2 Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900010
+HARPER,Anthony Ward 2 Exclave 2,United States Senate,,independent,"Orman, Greg",0,900020
+HARPER,Anthony Ward 2 Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900020
+HARPER,Anthony Ward 2 Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900020
+HARPER,Anthony Ward 3 Exclave 1,United States Senate,,independent,"Orman, Greg",0,900030
+HARPER,Anthony Ward 3 Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900030
+HARPER,Anthony Ward 3 Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900030
+HARPER,Anthony Ward 3 Exclave 2,United States Senate,,independent,"Orman, Greg",0,900040
+HARPER,Anthony Ward 3 Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900040
+HARPER,Anthony Ward 3 Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900040
+HARPER,Anthony Ward 4 Exclave 1,United States Senate,,independent,"Orman, Greg",0,900050
+HARPER,Anthony Ward 4 Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900050
+HARPER,Anthony Ward 4 Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900050
+HARPER,Harper Ward 1 Exclave 1,United States Senate,,independent,"Orman, Greg",0,900060
+HARPER,Harper Ward 1 Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900060
+HARPER,Harper Ward 1 Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900060
+HARPER,Township 5 West Enclave,United States Senate,,independent,"Orman, Greg",0,900070
+HARPER,Township 5 West Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900070
+HARPER,Township 5 West Enclave,United States Senate,,Republican,"Roberts, Pat",0,900070

--- a/2014/20141104__ks__general__harvey__precinct.csv
+++ b/2014/20141104__ks__general__harvey__precinct.csv
@@ -1,883 +1,766 @@
-county,precinct,office,district,party,candidate,votes
-Harvey,1-Halstead  City W1P1,,,,Registration,536
-Harvey,2-Halstead  City W2P1,,,,Registration,719
-Harvey,3-Hesston  City W1P1,,,,Registration,1170
-Harvey,4-Hesston  City W2P1,,,,Registration,1154
-Harvey,5-Newton City W1P1,,,,Registration,725
-Harvey,6-Newton City W1P2,,,,Registration,576
-Harvey,7-Newton City W1P3,,,,Registration,424
-Harvey,8-Newton City W2P1,,,,Registration,683
-Harvey,9-Newton City W2P2,,,,Registration,1469
-Harvey,10-Newton City W3P1,,,,Registration,635
-Harvey,11-Newton City W3P2,,,,Registration,947
-Harvey,12-Newton City W3P3,,,,Registration,790
-Harvey,13-Newton City W3P4,,,,Registration,1611
-Harvey,14-Newton City W4P1,,,,Registration,759
-Harvey,15-Newton City W4P2,,,,Registration,1329
-Harvey,16-Newton City W4P3,,,,Registration,974
-Harvey,17-Newton City W4P4,,,,Registration,420
-Harvey,18-North  Newton,,,,Registration,1355
-Harvey,19-Alta  Township,,,,Registration,170
-Harvey,20-Burrton  City/Twp,,,,Registration,640
-Harvey,21-Darlington  Township,,,,Registration,311
-Harvey,22-Darlington  Twp  North,,,,Registration,93
-Harvey,23-Emma  Township,,,,Registration,369
-Harvey,24-Garden  Township,,,,Registration,201
-Harvey,25-Halstead  Township,,,,Registration,181
-Harvey,26-Highland  Twp FD1,,,,Registration,169
-Harvey,27-Lake  Township,,,,Registration,100
-Harvey,28-Lakin  Township,,,,Registration,188
-Harvey,29-Macon  Township,,,,Registration,315
-Harvey,30-Newton  Township  AB,,,,Registration,232
-Harvey,31-Newton  Township  CDE,,,,Registration,77
-Harvey,32-Pleasant  Twp,,,,Registration,185
-Harvey,33-Richland  Township,,,,Registration,266
-Harvey,34-Sedgwick  City/Twp,,,,Registration,1125
-Harvey,35-Walton  City/Twp FD,,,,Registration,316
-Harvey,36-Walton  Township,,,,Registration,27
-Harvey,37-Highland  Township,,,,Registration,101
-Harvey,38-Pleasant  Township,,,,Registration,156
-Harvey,1-Halstead  City W1P1,,,,Ballots,270
-Harvey,2-Halstead  City W2P1,,,,Ballots,360
-Harvey,3-Hesston  City W1P1,,,,Ballots,697
-Harvey,4-Hesston  City W2P1,,,,Ballots,688
-Harvey,5-Newton City W1P1,,,,Ballots,320
-Harvey,6-Newton City W1P2,,,,Ballots,259
-Harvey,7-Newton City W1P3,,,,Ballots,177
-Harvey,8-Newton City W2P1,,,,Ballots,271
-Harvey,9-Newton City W2P2,,,,Ballots,742
-Harvey,10-Newton City W3P1,,,,Ballots,323
-Harvey,11-Newton City W3P2,,,,Ballots,497
-Harvey,12-Newton City W3P3,,,,Ballots,418
-Harvey,13-Newton City W3P4,,,,Ballots,893
-Harvey,14-Newton City W4P1,,,,Ballots,394
-Harvey,15-Newton City W4P2,,,,Ballots,752
-Harvey,16-Newton City W4P3,,,,Ballots,535
-Harvey,17-Newton City W4P4,,,,Ballots,225
-Harvey,18-North  Newton,,,,Ballots,851
-Harvey,19-Alta  Township,,,,Ballots,105
-Harvey,20-Burrton  City/Twp,,,,Ballots,328
-Harvey,21-Darlington  Township,,,,Ballots,173
-Harvey,22-Darlington  Twp  North,,,,Ballots,60
-Harvey,23-Emma  Township,,,,Ballots,222
-Harvey,24-Garden  Township,,,,Ballots,134
-Harvey,25-Halstead  Township,,,,Ballots,109
-Harvey,26-Highland  Twp FD1,,,,Ballots,99
-Harvey,27-Lake  Township,,,,Ballots,67
-Harvey,28-Lakin  Township,,,,Ballots,104
-Harvey,29-Macon  Township,,,,Ballots,213
-Harvey,30-Newton  Township  AB,,,,Ballots,147
-Harvey,31-Newton  Township  CDE,,,,Ballots,41
-Harvey,32-Pleasant  Twp,,,,Ballots,130
-Harvey,33-Richland  Township,,,,Ballots,183
-Harvey,34-Sedgwick  City/Twp,,,,Ballots,602
-Harvey,35-Walton  City/Twp FD,,,,Ballots,178
-Harvey,36-Walton  Township,,,,Ballots,15
-Harvey,37-Highland  Township,,,,Ballots,61
-Harvey,38-Pleasant  Township,,,,Ballots,118
-Harvey,1-Halstead  City W1P1,U.S. Senate,,R,Pat Roberts,163
-Harvey,2-Halstead  City W2P1,U.S. Senate,,R,Pat Roberts,204
-Harvey,3-Hesston  City W1P1,U.S. Senate,,R,Pat Roberts,344
-Harvey,4-Hesston  City W2P1,U.S. Senate,,R,Pat Roberts,396
-Harvey,5-Newton City W1P1,U.S. Senate,,R,Pat Roberts,131
-Harvey,6-Newton City W1P2,U.S. Senate,,R,Pat Roberts,117
-Harvey,7-Newton City W1P3,U.S. Senate,,R,Pat Roberts,82
-Harvey,8-Newton City W2P1,U.S. Senate,,R,Pat Roberts,110
-Harvey,9-Newton City W2P2,U.S. Senate,,R,Pat Roberts,348
-Harvey,10-Newton City W3P1,U.S. Senate,,R,Pat Roberts,152
-Harvey,11-Newton City W3P2,U.S. Senate,,R,Pat Roberts,261
-Harvey,12-Newton City W3P3,U.S. Senate,,R,Pat Roberts,227
-Harvey,13-Newton City W3P4,U.S. Senate,,R,Pat Roberts,514
-Harvey,14-Newton City W4P1,U.S. Senate,,R,Pat Roberts,185
-Harvey,15-Newton City W4P2,U.S. Senate,,R,Pat Roberts,350
-Harvey,16-Newton City W4P3,U.S. Senate,,R,Pat Roberts,253
-Harvey,17-Newton City W4P4,U.S. Senate,,R,Pat Roberts,111
-Harvey,18-North  Newton,U.S. Senate,,R,Pat Roberts,289
-Harvey,19-Alta  Township,U.S. Senate,,R,Pat Roberts,63
-Harvey,20-Burrton  City/Twp,U.S. Senate,,R,Pat Roberts,190
-Harvey,21-Darlington  Township,U.S. Senate,,R,Pat Roberts,116
-Harvey,22-Darlington  Twp  North,U.S. Senate,,R,Pat Roberts,34
-Harvey,23-Emma  Township,U.S. Senate,,R,Pat Roberts,155
-Harvey,24-Garden  Township,U.S. Senate,,R,Pat Roberts,82
-Harvey,25-Halstead  Township,U.S. Senate,,R,Pat Roberts,55
-Harvey,26-Highland  Twp FD1,U.S. Senate,,R,Pat Roberts,56
-Harvey,27-Lake  Township,U.S. Senate,,R,Pat Roberts,41
-Harvey,28-Lakin  Township,U.S. Senate,,R,Pat Roberts,79
-Harvey,29-Macon  Township,U.S. Senate,,R,Pat Roberts,110
-Harvey,30-Newton  Township  AB,U.S. Senate,,R,Pat Roberts,100
-Harvey,31-Newton  Township  CDE,U.S. Senate,,R,Pat Roberts,32
-Harvey,32-Pleasant  Twp,U.S. Senate,,R,Pat Roberts,81
-Harvey,33-Richland  Township,U.S. Senate,,R,Pat Roberts,135
-Harvey,34-Sedgwick  City/Twp,U.S. Senate,,R,Pat Roberts,375
-Harvey,35-Walton  City/Twp FD,U.S. Senate,,R,Pat Roberts,107
-Harvey,36-Walton  Township,U.S. Senate,,R,Pat Roberts,7
-Harvey,37-Highland  Township,U.S. Senate,,R,Pat Roberts,34
-Harvey,38-Pleasant  Township,U.S. Senate,,R,Pat Roberts,80
-Harvey,1-Halstead  City W1P1,U.S. Senate,,I ,Greg Orman,90
-Harvey,2-Halstead  City W2P1,U.S. Senate,,I ,Greg Orman,140
-Harvey,3-Hesston  City W1P1,U.S. Senate,,I ,Greg Orman,328
-Harvey,4-Hesston  City W2P1,U.S. Senate,,I ,Greg Orman,271
-Harvey,5-Newton City W1P1,U.S. Senate,,I ,Greg Orman,166
-Harvey,6-Newton City W1P2,U.S. Senate,,I ,Greg Orman,120
-Harvey,7-Newton City W1P3,U.S. Senate,,I ,Greg Orman,77
-Harvey,8-Newton City W2P1,U.S. Senate,,I ,Greg Orman,137
-Harvey,9-Newton City W2P2,U.S. Senate,,I ,Greg Orman,365
-Harvey,10-Newton City W3P1,U.S. Senate,,I ,Greg Orman,148
-Harvey,11-Newton City W3P2,U.S. Senate,,I ,Greg Orman,215
-Harvey,12-Newton City W3P3,U.S. Senate,,I ,Greg Orman,170
-Harvey,13-Newton City W3P4,U.S. Senate,,I ,Greg Orman,355
-Harvey,14-Newton City W4P1,U.S. Senate,,I ,Greg Orman,187
-Harvey,15-Newton City W4P2,U.S. Senate,,I ,Greg Orman,369
-Harvey,16-Newton City W4P3,U.S. Senate,,I ,Greg Orman,244
-Harvey,17-Newton City W4P4,U.S. Senate,,I ,Greg Orman,109
-Harvey,18-North  Newton,U.S. Senate,,I ,Greg Orman,539
-Harvey,19-Alta  Township,U.S. Senate,,I ,Greg Orman,40
-Harvey,20-Burrton  City/Twp,U.S. Senate,,I ,Greg Orman,112
-Harvey,21-Darlington  Township,U.S. Senate,,I ,Greg Orman,57
-Harvey,22-Darlington  Twp  North,U.S. Senate,,I ,Greg Orman,20
-Harvey,23-Emma  Township,U.S. Senate,,I ,Greg Orman,59
-Harvey,24-Garden  Township,U.S. Senate,,I ,Greg Orman,48
-Harvey,25-Halstead  Township,U.S. Senate,,I ,Greg Orman,49
-Harvey,26-Highland  Twp FD1,U.S. Senate,,I ,Greg Orman,39
-Harvey,27-Lake  Township,U.S. Senate,,I ,Greg Orman,22
-Harvey,28-Lakin  Township,U.S. Senate,,I ,Greg Orman,22
-Harvey,29-Macon  Township,U.S. Senate,,I ,Greg Orman,90
-Harvey,30-Newton  Township  AB,U.S. Senate,,I ,Greg Orman,43
-Harvey,31-Newton  Township  CDE,U.S. Senate,,I ,Greg Orman,7
-Harvey,32-Pleasant  Twp,U.S. Senate,,I ,Greg Orman,48
-Harvey,33-Richland  Township,U.S. Senate,,I ,Greg Orman,43
-Harvey,34-Sedgwick  City/Twp,U.S. Senate,,I ,Greg Orman,190
-Harvey,35-Walton  City/Twp FD,U.S. Senate,,I ,Greg Orman,61
-Harvey,36-Walton  Township,U.S. Senate,,I ,Greg Orman,8
-Harvey,37-Highland  Township,U.S. Senate,,I ,Greg Orman,27
-Harvey,38-Pleasant  Township,U.S. Senate,,I ,Greg Orman,36
-Harvey,1-Halstead  City W1P1,U.S. Senate,,L,Randall Batson,12
-Harvey,2-Halstead  City W2P1,U.S. Senate,,L,Randall Batson,11
-Harvey,3-Hesston  City W1P1,U.S. Senate,,L,Randall Batson,18
-Harvey,4-Hesston  City W2P1,U.S. Senate,,L,Randall Batson,18
-Harvey,5-Newton City W1P1,U.S. Senate,,L,Randall Batson,17
-Harvey,6-Newton City W1P2,U.S. Senate,,L,Randall Batson,16
-Harvey,7-Newton City W1P3,U.S. Senate,,L,Randall Batson,14
-Harvey,8-Newton City W2P1,U.S. Senate,,L,Randall Batson,18
-Harvey,9-Newton City W2P2,U.S. Senate,,L,Randall Batson,20
-Harvey,10-Newton City W3P1,U.S. Senate,,L,Randall Batson,23
-Harvey,11-Newton City W3P2,U.S. Senate,,L,Randall Batson,15
-Harvey,12-Newton City W3P3,U.S. Senate,,L,Randall Batson,19
-Harvey,13-Newton City W3P4,U.S. Senate,,L,Randall Batson,18
-Harvey,14-Newton City W4P1,U.S. Senate,,L,Randall Batson,16
-Harvey,15-Newton City W4P2,U.S. Senate,,L,Randall Batson,30
-Harvey,16-Newton City W4P3,U.S. Senate,,L,Randall Batson,33
-Harvey,17-Newton City W4P4,U.S. Senate,,L,Randall Batson,3
-Harvey,18-North  Newton,U.S. Senate,,L,Randall Batson,14
-Harvey,19-Alta  Township,U.S. Senate,,L,Randall Batson,1
-Harvey,20-Burrton  City/Twp,U.S. Senate,,L,Randall Batson,20
-Harvey,21-Darlington  Township,U.S. Senate,,L,Randall Batson,0
-Harvey,22-Darlington  Twp  North,U.S. Senate,,L,Randall Batson,6
-Harvey,23-Emma  Township,U.S. Senate,,L,Randall Batson,7
-Harvey,24-Garden  Township,U.S. Senate,,L,Randall Batson,2
-Harvey,25-Halstead  Township,U.S. Senate,,L,Randall Batson,5
-Harvey,26-Highland  Twp FD1,U.S. Senate,,L,Randall Batson,4
-Harvey,27-Lake  Township,U.S. Senate,,L,Randall Batson,2
-Harvey,28-Lakin  Township,U.S. Senate,,L,Randall Batson,3
-Harvey,29-Macon  Township,U.S. Senate,,L,Randall Batson,11
-Harvey,30-Newton  Township  AB,U.S. Senate,,L,Randall Batson,4
-Harvey,31-Newton  Township  CDE,U.S. Senate,,L,Randall Batson,1
-Harvey,32-Pleasant  Twp,U.S. Senate,,L,Randall Batson,1
-Harvey,33-Richland  Township,U.S. Senate,,L,Randall Batson,2
-Harvey,34-Sedgwick  City/Twp,U.S. Senate,,L,Randall Batson,31
-Harvey,35-Walton  City/Twp FD,U.S. Senate,,L,Randall Batson,8
-Harvey,36-Walton  Township,U.S. Senate,,L,Randall Batson,0
-Harvey,37-Highland  Township,U.S. Senate,,L,Randall Batson,0
-Harvey,38-Pleasant  Township,U.S. Senate,,L,Randall Batson,1
-Harvey,1-Halstead  City W1P1,U.S. Senate,,,Write-ins,0
-Harvey,2-Halstead  City W2P1,U.S. Senate,,,Write-ins,2
-Harvey,3-Hesston  City W1P1,U.S. Senate,,,Write-ins,1
-Harvey,4-Hesston  City W2P1,U.S. Senate,,,Write-ins,0
-Harvey,5-Newton City W1P1,U.S. Senate,,,Write-ins,0
-Harvey,6-Newton City W1P2,U.S. Senate,,,Write-ins,2
-Harvey,7-Newton City W1P3,U.S. Senate,,,Write-ins,2
-Harvey,8-Newton City W2P1,U.S. Senate,,,Write-ins,0
-Harvey,9-Newton City W2P2,U.S. Senate,,,Write-ins,1
-Harvey,10-Newton City W3P1,U.S. Senate,,,Write-ins,0
-Harvey,11-Newton City W3P2,U.S. Senate,,,Write-ins,0
-Harvey,12-Newton City W3P3,U.S. Senate,,,Write-ins,0
-Harvey,13-Newton City W3P4,U.S. Senate,,,Write-ins,1
-Harvey,14-Newton City W4P1,U.S. Senate,,,Write-ins,2
-Harvey,15-Newton City W4P2,U.S. Senate,,,Write-ins,0
-Harvey,16-Newton City W4P3,U.S. Senate,,,Write-ins,3
-Harvey,17-Newton City W4P4,U.S. Senate,,,Write-ins,0
-Harvey,18-North  Newton,U.S. Senate,,,Write-ins,1
-Harvey,19-Alta  Township,U.S. Senate,,,Write-ins,0
-Harvey,20-Burrton  City/Twp,U.S. Senate,,,Write-ins,0
-Harvey,21-Darlington  Township,U.S. Senate,,,Write-ins,0
-Harvey,22-Darlington  Twp  North,U.S. Senate,,,Write-ins,0
-Harvey,23-Emma  Township,U.S. Senate,,,Write-ins,0
-Harvey,24-Garden  Township,U.S. Senate,,,Write-ins,0
-Harvey,25-Halstead  Township,U.S. Senate,,,Write-ins,0
-Harvey,26-Highland  Twp FD1,U.S. Senate,,,Write-ins,0
-Harvey,27-Lake  Township,U.S. Senate,,,Write-ins,1
-Harvey,28-Lakin  Township,U.S. Senate,,,Write-ins,0
-Harvey,29-Macon  Township,U.S. Senate,,,Write-ins,0
-Harvey,30-Newton  Township  AB,U.S. Senate,,,Write-ins,0
-Harvey,31-Newton  Township  CDE,U.S. Senate,,,Write-ins,0
-Harvey,32-Pleasant  Twp,U.S. Senate,,,Write-ins,0
-Harvey,33-Richland  Township,U.S. Senate,,,Write-ins,0
-Harvey,34-Sedgwick  City/Twp,U.S. Senate,,,Write-ins,0
-Harvey,35-Walton  City/Twp FD,U.S. Senate,,,Write-ins,1
-Harvey,36-Walton  Township,U.S. Senate,,,Write-ins,0
-Harvey,37-Highland  Township,U.S. Senate,,,Write-ins,0
-Harvey,38-Pleasant  Township,U.S. Senate,,,Write-ins,0
-Harvey,1-Halstead  City W1P1,U.S. House,4,R,Mike Pompeo,191
-Harvey,2-Halstead  City W2P1,U.S. House,4,R,Mike Pompeo,245
-Harvey,3-Hesston  City W1P1,U.S. House,4,R,Mike Pompeo,434
-Harvey,4-Hesston  City W2P1,U.S. House,4,R,Mike Pompeo,487
-Harvey,5-Newton City W1P1,U.S. House,4,R,Mike Pompeo,173
-Harvey,6-Newton City W1P2,U.S. House,4,R,Mike Pompeo,135
-Harvey,7-Newton City W1P3,U.S. House,4,R,Mike Pompeo,103
-Harvey,8-Newton City W2P1,U.S. House,4,R,Mike Pompeo,135
-Harvey,9-Newton City W2P2,U.S. House,4,R,Mike Pompeo,441
-Harvey,10-Newton City W3P1,U.S. House,4,R,Mike Pompeo,189
-Harvey,11-Newton City W3P2,U.S. House,4,R,Mike Pompeo,328
-Harvey,12-Newton City W3P3,U.S. House,4,R,Mike Pompeo,281
-Harvey,13-Newton City W3P4,U.S. House,4,R,Mike Pompeo,617
-Harvey,14-Newton City W4P1,U.S. House,4,R,Mike Pompeo,217
-Harvey,15-Newton City W4P2,U.S. House,4,R,Mike Pompeo,444
-Harvey,16-Newton City W4P3,U.S. House,4,R,Mike Pompeo,324
-Harvey,17-Newton City W4P4,U.S. House,4,R,Mike Pompeo,126
-Harvey,18-North  Newton,U.S. House,4,R,Mike Pompeo,348
-Harvey,19-Alta  Township,U.S. House,4,R,Mike Pompeo,76
-Harvey,20-Burrton  City/Twp,U.S. House,4,R,Mike Pompeo,244
-Harvey,21-Darlington  Township,U.S. House,4,R,Mike Pompeo,121
-Harvey,22-Darlington  Twp  North,U.S. House,4,R,Mike Pompeo,41
-Harvey,23-Emma  Township,U.S. House,4,R,Mike Pompeo,169
-Harvey,24-Garden  Township,U.S. House,4,R,Mike Pompeo,93
-Harvey,25-Halstead  Township,U.S. House,4,R,Mike Pompeo,66
-Harvey,26-Highland  Twp FD1,U.S. House,4,R,Mike Pompeo,63
-Harvey,27-Lake  Township,U.S. House,4,R,Mike Pompeo,50
-Harvey,28-Lakin  Township,U.S. House,4,R,Mike Pompeo,81
-Harvey,29-Macon  Township,U.S. House,4,R,Mike Pompeo,137
-Harvey,30-Newton  Township  AB,U.S. House,4,R,Mike Pompeo,112
-Harvey,31-Newton  Township  CDE,U.S. House,4,R,Mike Pompeo,36
-Harvey,32-Pleasant  Twp,U.S. House,4,R,Mike Pompeo,86
-Harvey,33-Richland  Township,U.S. House,4,R,Mike Pompeo,149
-Harvey,34-Sedgwick  City/Twp,U.S. House,4,R,Mike Pompeo,450
-Harvey,35-Walton  City/Twp FD,U.S. House,4,R,Mike Pompeo,125
-Harvey,36-Walton  Township,U.S. House,4,R,Mike Pompeo,8
-Harvey,37-Highland  Township,U.S. House,4,R,Mike Pompeo,38
-Harvey,38-Pleasant  Township,U.S. House,4,R,Mike Pompeo,87
-Harvey,1-Halstead  City W1P1,U.S. House,4,D,Perry Schuckman,75
-Harvey,2-Halstead  City W2P1,U.S. House,4,D,Perry Schuckman,107
-Harvey,3-Hesston  City W1P1,U.S. House,4,D,Perry Schuckman,243
-Harvey,4-Hesston  City W2P1,U.S. House,4,D,Perry Schuckman,187
-Harvey,5-Newton City W1P1,U.S. House,4,D,Perry Schuckman,140
-Harvey,6-Newton City W1P2,U.S. House,4,D,Perry Schuckman,116
-Harvey,7-Newton City W1P3,U.S. House,4,D,Perry Schuckman,67
-Harvey,8-Newton City W2P1,U.S. House,4,D,Perry Schuckman,131
-Harvey,9-Newton City W2P2,U.S. House,4,D,Perry Schuckman,289
-Harvey,10-Newton City W3P1,U.S. House,4,D,Perry Schuckman,130
-Harvey,11-Newton City W3P2,U.S. House,4,D,Perry Schuckman,160
-Harvey,12-Newton City W3P3,U.S. House,4,D,Perry Schuckman,128
-Harvey,13-Newton City W3P4,U.S. House,4,D,Perry Schuckman,258
-Harvey,14-Newton City W4P1,U.S. House,4,D,Perry Schuckman,169
-Harvey,15-Newton City W4P2,U.S. House,4,D,Perry Schuckman,292
-Harvey,16-Newton City W4P3,U.S. House,4,D,Perry Schuckman,200
-Harvey,17-Newton City W4P4,U.S. House,4,D,Perry Schuckman,93
-Harvey,18-North  Newton,U.S. House,4,D,Perry Schuckman,479
-Harvey,19-Alta  Township,U.S. House,4,D,Perry Schuckman,25
-Harvey,20-Burrton  City/Twp,U.S. House,4,D,Perry Schuckman,79
-Harvey,21-Darlington  Township,U.S. House,4,D,Perry Schuckman,48
-Harvey,22-Darlington  Twp  North,U.S. House,4,D,Perry Schuckman,19
-Harvey,23-Emma  Township,U.S. House,4,D,Perry Schuckman,48
-Harvey,24-Garden  Township,U.S. House,4,D,Perry Schuckman,38
-Harvey,25-Halstead  Township,U.S. House,4,D,Perry Schuckman,39
-Harvey,26-Highland  Twp FD1,U.S. House,4,D,Perry Schuckman,31
-Harvey,27-Lake  Township,U.S. House,4,D,Perry Schuckman,15
-Harvey,28-Lakin  Township,U.S. House,4,D,Perry Schuckman,21
-Harvey,29-Macon  Township,U.S. House,4,D,Perry Schuckman,71
-Harvey,30-Newton  Township  AB,U.S. House,4,D,Perry Schuckman,31
-Harvey,31-Newton  Township  CDE,U.S. House,4,D,Perry Schuckman,3
-Harvey,32-Pleasant  Twp,U.S. House,4,D,Perry Schuckman,44
-Harvey,33-Richland  Township,U.S. House,4,D,Perry Schuckman,34
-Harvey,34-Sedgwick  City/Twp,U.S. House,4,D,Perry Schuckman,137
-Harvey,35-Walton  City/Twp FD,U.S. House,4,D,Perry Schuckman,50
-Harvey,36-Walton  Township,U.S. House,4,D,Perry Schuckman,6
-Harvey,37-Highland  Township,U.S. House,4,D,Perry Schuckman,23
-Harvey,38-Pleasant  Township,U.S. House,4,D,Perry Schuckman,30
-Harvey,1-Halstead  City W1P1,U.S. House,4,,Write-ins,0
-Harvey,2-Halstead  City W2P1,U.S. House,4,,Write-ins,1
-Harvey,3-Hesston  City W1P1,U.S. House,4,,Write-ins,0
-Harvey,4-Hesston  City W2P1,U.S. House,4,,Write-ins,1
-Harvey,5-Newton City W1P1,U.S. House,4,,Write-ins,2
-Harvey,6-Newton City W1P2,U.S. House,4,,Write-ins,3
-Harvey,7-Newton City W1P3,U.S. House,4,,Write-ins,1
-Harvey,8-Newton City W2P1,U.S. House,4,,Write-ins,1
-Harvey,9-Newton City W2P2,U.S. House,4,,Write-ins,1
-Harvey,10-Newton City W3P1,U.S. House,4,,Write-ins,0
-Harvey,11-Newton City W3P2,U.S. House,4,,Write-ins,0
-Harvey,12-Newton City W3P3,U.S. House,4,,Write-ins,0
-Harvey,13-Newton City W3P4,U.S. House,4,,Write-ins,3
-Harvey,14-Newton City W4P1,U.S. House,4,,Write-ins,0
-Harvey,15-Newton City W4P2,U.S. House,4,,Write-ins,3
-Harvey,16-Newton City W4P3,U.S. House,4,,Write-ins,2
-Harvey,17-Newton City W4P4,U.S. House,4,,Write-ins,2
-Harvey,18-North  Newton,U.S. House,4,,Write-ins,1
-Harvey,19-Alta  Township,U.S. House,4,,Write-ins,0
-Harvey,20-Burrton  City/Twp,U.S. House,4,,Write-ins,0
-Harvey,21-Darlington  Township,U.S. House,4,,Write-ins,0
-Harvey,22-Darlington  Twp  North,U.S. House,4,,Write-ins,0
-Harvey,23-Emma  Township,U.S. House,4,,Write-ins,1
-Harvey,24-Garden  Township,U.S. House,4,,Write-ins,0
-Harvey,25-Halstead  Township,U.S. House,4,,Write-ins,0
-Harvey,26-Highland  Twp FD1,U.S. House,4,,Write-ins,2
-Harvey,27-Lake  Township,U.S. House,4,,Write-ins,0
-Harvey,28-Lakin  Township,U.S. House,4,,Write-ins,1
-Harvey,29-Macon  Township,U.S. House,4,,Write-ins,0
-Harvey,30-Newton  Township  AB,U.S. House,4,,Write-ins,0
-Harvey,31-Newton  Township  CDE,U.S. House,4,,Write-ins,0
-Harvey,32-Pleasant  Twp,U.S. House,4,,Write-ins,0
-Harvey,33-Richland  Township,U.S. House,4,,Write-ins,0
-Harvey,34-Sedgwick  City/Twp,U.S. House,4,,Write-ins,1
-Harvey,35-Walton  City/Twp FD,U.S. House,4,,Write-ins,0
-Harvey,36-Walton  Township,U.S. House,4,,Write-ins,0
-Harvey,37-Highland  Township,U.S. House,4,,Write-ins,0
-Harvey,38-Pleasant  Township,U.S. House,4,,Write-ins,0
-Harvey,1-Halstead  City W1P1,Governor,,R,Sam Brownback,144
-Harvey,2-Halstead  City W2P1,Governor,,R,Sam Brownback,178
-Harvey,3-Hesston  City W1P1,Governor,,R,Sam Brownback,326
-Harvey,4-Hesston  City W2P1,Governor,,R,Sam Brownback,370
-Harvey,5-Newton City W1P1,Governor,,R,Sam Brownback,135
-Harvey,6-Newton City W1P2,Governor,,R,Sam Brownback,115
-Harvey,7-Newton City W1P3,Governor,,R,Sam Brownback,85
-Harvey,8-Newton City W2P1,Governor,,R,Sam Brownback,105
-Harvey,9-Newton City W2P2,Governor,,R,Sam Brownback,336
-Harvey,10-Newton City W3P1,Governor,,R,Sam Brownback,154
-Harvey,11-Newton City W3P2,Governor,,R,Sam Brownback,254
-Harvey,12-Newton City W3P3,Governor,,R,Sam Brownback,220
-Harvey,13-Newton City W3P4,Governor,,R,Sam Brownback,478
-Harvey,14-Newton City W4P1,Governor,,R,Sam Brownback,171
-Harvey,15-Newton City W4P2,Governor,,R,Sam Brownback,315
-Harvey,16-Newton City W4P3,Governor,,R,Sam Brownback,234
-Harvey,17-Newton City W4P4,Governor,,R,Sam Brownback,101
-Harvey,18-North  Newton,Governor,,R,Sam Brownback,273
-Harvey,19-Alta  Township,Governor,,R,Sam Brownback,68
-Harvey,20-Burrton  City/Twp,Governor,,R,Sam Brownback,188
-Harvey,21-Darlington  Township,Governor,,R,Sam Brownback,117
-Harvey,22-Darlington  Twp  North,Governor,,R,Sam Brownback,40
-Harvey,23-Emma  Township,Governor,,R,Sam Brownback,148
-Harvey,24-Garden  Township,Governor,,R,Sam Brownback,81
-Harvey,25-Halstead  Township,Governor,,R,Sam Brownback,53
-Harvey,26-Highland  Twp FD1,Governor,,R,Sam Brownback,55
-Harvey,27-Lake  Township,Governor,,R,Sam Brownback,41
-Harvey,28-Lakin  Township,Governor,,R,Sam Brownback,74
-Harvey,29-Macon  Township,Governor,,R,Sam Brownback,103
-Harvey,30-Newton  Township  AB,Governor,,R,Sam Brownback,98
-Harvey,31-Newton  Township  CDE,Governor,,R,Sam Brownback,31
-Harvey,32-Pleasant  Twp,Governor,,R,Sam Brownback,78
-Harvey,33-Richland  Township,Governor,,R,Sam Brownback,132
-Harvey,34-Sedgwick  City/Twp,Governor,,R,Sam Brownback,328
-Harvey,35-Walton  City/Twp FD,Governor,,R,Sam Brownback,99
-Harvey,36-Walton  Township,Governor,,R,Sam Brownback,6
-Harvey,37-Highland  Township,Governor,,R,Sam Brownback,27
-Harvey,38-Pleasant  Township,Governor,,R,Sam Brownback,79
-Harvey,1-Halstead  City W1P1,Governor,,D,Paul Davis,110
-Harvey,2-Halstead  City W2P1,Governor,,D,Paul Davis,165
-Harvey,3-Hesston  City W1P1,Governor,,D,Paul Davis,349
-Harvey,4-Hesston  City W2P1,Governor,,D,Paul Davis,302
-Harvey,5-Newton City W1P1,Governor,,D,Paul Davis,169
-Harvey,6-Newton City W1P2,Governor,,D,Paul Davis,126
-Harvey,7-Newton City W1P3,Governor,,D,Paul Davis,82
-Harvey,8-Newton City W2P1,Governor,,D,Paul Davis,151
-Harvey,9-Newton City W2P2,Governor,,D,Paul Davis,383
-Harvey,10-Newton City W3P1,Governor,,D,Paul Davis,151
-Harvey,11-Newton City W3P2,Governor,,D,Paul Davis,226
-Harvey,12-Newton City W3P3,Governor,,D,Paul Davis,180
-Harvey,13-Newton City W3P4,Governor,,D,Paul Davis,396
-Harvey,14-Newton City W4P1,Governor,,D,Paul Davis,204
-Harvey,15-Newton City W4P2,Governor,,D,Paul Davis,405
-Harvey,16-Newton City W4P3,Governor,,D,Paul Davis,268
-Harvey,17-Newton City W4P4,Governor,,D,Paul Davis,117
-Harvey,18-North  Newton,Governor,,D,Paul Davis,558
-Harvey,19-Alta  Township,Governor,,D,Paul Davis,33
-Harvey,20-Burrton  City/Twp,Governor,,D,Paul Davis,119
-Harvey,21-Darlington  Township,Governor,,D,Paul Davis,56
-Harvey,22-Darlington  Twp  North,Governor,,D,Paul Davis,16
-Harvey,23-Emma  Township,Governor,,D,Paul Davis,65
-Harvey,24-Garden  Township,Governor,,D,Paul Davis,50
-Harvey,25-Halstead  Township,Governor,,D,Paul Davis,49
-Harvey,26-Highland  Twp FD1,Governor,,D,Paul Davis,41
-Harvey,27-Lake  Township,Governor,,D,Paul Davis,19
-Harvey,28-Lakin  Township,Governor,,D,Paul Davis,29
-Harvey,29-Macon  Township,Governor,,D,Paul Davis,95
-Harvey,30-Newton  Township  AB,Governor,,D,Paul Davis,43
-Harvey,31-Newton  Township  CDE,Governor,,D,Paul Davis,8
-Harvey,32-Pleasant  Twp,Governor,,D,Paul Davis,51
-Harvey,33-Richland  Township,Governor,,D,Paul Davis,45
-Harvey,34-Sedgwick  City/Twp,Governor,,D,Paul Davis,241
-Harvey,35-Walton  City/Twp FD,Governor,,D,Paul Davis,73
-Harvey,36-Walton  Township,Governor,,D,Paul Davis,9
-Harvey,37-Highland  Township,Governor,,D,Paul Davis,32
-Harvey,38-Pleasant  Township,Governor,,D,Paul Davis,38
-Harvey,1-Halstead  City W1P1,Governor,,L,Keen Umbehr,14
-Harvey,2-Halstead  City W2P1,Governor,,L,Keen Umbehr,14
-Harvey,3-Hesston  City W1P1,Governor,,L,Keen Umbehr,16
-Harvey,4-Hesston  City W2P1,Governor,,L,Keen Umbehr,14
-Harvey,5-Newton City W1P1,Governor,,L,Keen Umbehr,11
-Harvey,6-Newton City W1P2,Governor,,L,Keen Umbehr,16
-Harvey,7-Newton City W1P3,Governor,,L,Keen Umbehr,6
-Harvey,8-Newton City W2P1,Governor,,L,Keen Umbehr,13
-Harvey,9-Newton City W2P2,Governor,,L,Keen Umbehr,14
-Harvey,10-Newton City W3P1,Governor,,L,Keen Umbehr,17
-Harvey,11-Newton City W3P2,Governor,,L,Keen Umbehr,17
-Harvey,12-Newton City W3P3,Governor,,L,Keen Umbehr,16
-Harvey,13-Newton City W3P4,Governor,,L,Keen Umbehr,11
-Harvey,14-Newton City W4P1,Governor,,L,Keen Umbehr,13
-Harvey,15-Newton City W4P2,Governor,,L,Keen Umbehr,25
-Harvey,16-Newton City W4P3,Governor,,L,Keen Umbehr,30
-Harvey,17-Newton City W4P4,Governor,,L,Keen Umbehr,7
-Harvey,18-North  Newton,Governor,,L,Keen Umbehr,13
-Harvey,19-Alta  Township,Governor,,L,Keen Umbehr,3
-Harvey,20-Burrton  City/Twp,Governor,,L,Keen Umbehr,18
-Harvey,21-Darlington  Township,Governor,,L,Keen Umbehr,0
-Harvey,22-Darlington  Twp  North,Governor,,L,Keen Umbehr,4
-Harvey,23-Emma  Township,Governor,,L,Keen Umbehr,7
-Harvey,24-Garden  Township,Governor,,L,Keen Umbehr,3
-Harvey,25-Halstead  Township,Governor,,L,Keen Umbehr,5
-Harvey,26-Highland  Twp FD1,Governor,,L,Keen Umbehr,2
-Harvey,27-Lake  Township,Governor,,L,Keen Umbehr,6
-Harvey,28-Lakin  Township,Governor,,L,Keen Umbehr,1
-Harvey,29-Macon  Township,Governor,,L,Keen Umbehr,11
-Harvey,30-Newton  Township  AB,Governor,,L,Keen Umbehr,6
-Harvey,31-Newton  Township  CDE,Governor,,L,Keen Umbehr,2
-Harvey,32-Pleasant  Twp,Governor,,L,Keen Umbehr,1
-Harvey,33-Richland  Township,Governor,,L,Keen Umbehr,4
-Harvey,34-Sedgwick  City/Twp,Governor,,L,Keen Umbehr,30
-Harvey,35-Walton  City/Twp FD,Governor,,L,Keen Umbehr,6
-Harvey,36-Walton  Township,Governor,,L,Keen Umbehr,0
-Harvey,37-Highland  Township,Governor,,L,Keen Umbehr,1
-Harvey,38-Pleasant  Township,Governor,,L,Keen Umbehr,1
-Harvey,1-Halstead  City W1P1,Governor,,,Write-ins,0
-Harvey,2-Halstead  City W2P1,Governor,,,Write-ins,2
-Harvey,3-Hesston  City W1P1,Governor,,,Write-ins,2
-Harvey,4-Hesston  City W2P1,Governor,,,Write-ins,1
-Harvey,5-Newton City W1P1,Governor,,,Write-ins,1
-Harvey,6-Newton City W1P2,Governor,,,Write-ins,0
-Harvey,7-Newton City W1P3,Governor,,,Write-ins,2
-Harvey,8-Newton City W2P1,Governor,,,Write-ins,0
-Harvey,9-Newton City W2P2,Governor,,,Write-ins,0
-Harvey,10-Newton City W3P1,Governor,,,Write-ins,0
-Harvey,11-Newton City W3P2,Governor,,,Write-ins,0
-Harvey,12-Newton City W3P3,Governor,,,Write-ins,0
-Harvey,13-Newton City W3P4,Governor,,,Write-ins,2
-Harvey,14-Newton City W4P1,Governor,,,Write-ins,0
-Harvey,15-Newton City W4P2,Governor,,,Write-ins,0
-Harvey,16-Newton City W4P3,Governor,,,Write-ins,1
-Harvey,17-Newton City W4P4,Governor,,,Write-ins,0
-Harvey,18-North  Newton,Governor,,,Write-ins,0
-Harvey,19-Alta  Township,Governor,,,Write-ins,0
-Harvey,20-Burrton  City/Twp,Governor,,,Write-ins,0
-Harvey,21-Darlington  Township,Governor,,,Write-ins,0
-Harvey,22-Darlington  Twp  North,Governor,,,Write-ins,0
-Harvey,23-Emma  Township,Governor,,,Write-ins,0
-Harvey,24-Garden  Township,Governor,,,Write-ins,0
-Harvey,25-Halstead  Township,Governor,,,Write-ins,0
-Harvey,26-Highland  Twp FD1,Governor,,,Write-ins,0
-Harvey,27-Lake  Township,Governor,,,Write-ins,0
-Harvey,28-Lakin  Township,Governor,,,Write-ins,0
-Harvey,29-Macon  Township,Governor,,,Write-ins,0
-Harvey,30-Newton  Township  AB,Governor,,,Write-ins,0
-Harvey,31-Newton  Township  CDE,Governor,,,Write-ins,0
-Harvey,32-Pleasant  Twp,Governor,,,Write-ins,0
-Harvey,33-Richland  Township,Governor,,,Write-ins,0
-Harvey,34-Sedgwick  City/Twp,Governor,,,Write-ins,0
-Harvey,35-Walton  City/Twp FD,Governor,,,Write-ins,0
-Harvey,36-Walton  Township,Governor,,,Write-ins,0
-Harvey,37-Highland  Township,Governor,,,Write-ins,0
-Harvey,38-Pleasant  Township,Governor,,,Write-ins,0
-Harvey,5-Newton City W1P1,Secretary of State,,R,Kris Kobach,153
-Harvey,6-Newton City W1P2,Secretary of State,,R,Kris Kobach,125
-Harvey,7-Newton City W1P3,Secretary of State,,R,Kris Kobach,100
-Harvey,8-Newton City W2P1,Secretary of State,,R,Kris Kobach,126
-Harvey,9-Newton City W2P2,Secretary of State,,R,Kris Kobach,389
-Harvey,10-Newton City W3P1,Secretary of State,,R,Kris Kobach,175
-Harvey,11-Newton City W3P2,Secretary of State,,R,Kris Kobach,290
-Harvey,12-Newton City W3P3,Secretary of State,,R,Kris Kobach,251
-Harvey,13-Newton City W3P4,Secretary of State,,R,Kris Kobach,543
-Harvey,14-Newton City W4P1,Secretary of State,,R,Kris Kobach,195
-Harvey,15-Newton City W4P2,Secretary of State,,R,Kris Kobach,380
-Harvey,16-Newton City W4P3,Secretary of State,,R,Kris Kobach,291
-Harvey,17-Newton City W4P4,Secretary of State,,R,Kris Kobach,115
-Harvey,Newton City,Secretary of State,,R,Kris Kobach,3133
-Harvey,1-Halstead  City W1P1,Secretary of State,,R,Kris Kobach,173
-Harvey,2-Halstead  City W2P1,Secretary of State,,R,Kris Kobach,208
-Harvey,3-Hesston  City W1P1,Secretary of State,,R,Kris Kobach,364
-Harvey,4-Hesston  City W2P1,Secretary of State,,R,Kris Kobach,427
-Harvey,18-North  Newton,Secretary of State,,R,Kris Kobach,318
-Harvey,19-Alta  Township,Secretary of State,,R,Kris Kobach,72
-Harvey,20-Burrton  City/Twp,Secretary of State,,R,Kris Kobach,224
-Harvey,21-Darlington  Township,Secretary of State,,R,Kris Kobach,124
-Harvey,22-Darlington  Twp  North,Secretary of State,,R,Kris Kobach,41
-Harvey,23-Emma  Township,Secretary of State,,R,Kris Kobach,164
-Harvey,24-Garden  Township,Secretary of State,,R,Kris Kobach,85
-Harvey,25-Halstead  Township,Secretary of State,,R,Kris Kobach,61
-Harvey,26-Highland  Twp FD1,Secretary of State,,R,Kris Kobach,59
-Harvey,27-Lake  Township,Secretary of State,,R,Kris Kobach,53
-Harvey,28-Lakin  Township,Secretary of State,,R,Kris Kobach,77
-Harvey,29-Macon  Township,Secretary of State,,R,Kris Kobach,113
-Harvey,30-Newton  Township  AB,Secretary of State,,R,Kris Kobach,102
-Harvey,31-Newton  Township  CDE,Secretary of State,,R,Kris Kobach,33
-Harvey,32-Pleasant  Twp,Secretary of State,,R,Kris Kobach,81
-Harvey,33-Richland  Township,Secretary of State,,R,Kris Kobach,139
-Harvey,34-Sedgwick  City/Twp,Secretary of State,,R,Kris Kobach,384
-Harvey,35-Walton  City/Twp FD,Secretary of State,,R,Kris Kobach,113
-Harvey,36-Walton  Township,Secretary of State,,R,Kris Kobach,6
-Harvey,37-Highland  Township,Secretary of State,,R,Kris Kobach,31
-Harvey,38-Pleasant  Township,Secretary of State,,R,Kris Kobach,82
-Harvey,5-Newton City W1P1,Secretary of State,,D,Jean Schodorf,160
-Harvey,6-Newton City W1P2,Secretary of State,,D,Jean Schodorf,123
-Harvey,7-Newton City W1P3,Secretary of State,,D,Jean Schodorf,73
-Harvey,8-Newton City W2P1,Secretary of State,,D,Jean Schodorf,143
-Harvey,9-Newton City W2P2,Secretary of State,,D,Jean Schodorf,349
-Harvey,10-Newton City W3P1,Secretary of State,,D,Jean Schodorf,146
-Harvey,11-Newton City W3P2,Secretary of State,,D,Jean Schodorf,198
-Harvey,12-Newton City W3P3,Secretary of State,,D,Jean Schodorf,162
-Harvey,13-Newton City W3P4,Secretary of State,,D,Jean Schodorf,341
-Harvey,14-Newton City W4P1,Secretary of State,,D,Jean Schodorf,193
-Harvey,15-Newton City W4P2,Secretary of State,,D,Jean Schodorf,367
-Harvey,16-Newton City W4P3,Secretary of State,,D,Jean Schodorf,239
-Harvey,17-Newton City W4P4,Secretary of State,,D,Jean Schodorf,103
-Harvey,Newton City,Secretary of State,,D,Jean Schodorf,2597
-Harvey,1-Halstead  City W1P1,Secretary of State,,D,Jean Schodorf,94
-Harvey,2-Halstead  City W2P1,Secretary of State,,D,Jean Schodorf,146
-Harvey,3-Hesston  City W1P1,Secretary of State,,D,Jean Schodorf,320
-Harvey,4-Hesston  City W2P1,Secretary of State,,D,Jean Schodorf,256
-Harvey,18-North  Newton,Secretary of State,,D,Jean Schodorf,521
-Harvey,19-Alta  Township,Secretary of State,,D,Jean Schodorf,31
-Harvey,20-Burrton  City/Twp,Secretary of State,,D,Jean Schodorf,99
-Harvey,21-Darlington  Township,Secretary of State,,D,Jean Schodorf,49
-Harvey,22-Darlington  Twp  North,Secretary of State,,D,Jean Schodorf,18
-Harvey,23-Emma  Township,Secretary of State,,D,Jean Schodorf,53
-Harvey,24-Garden  Township,Secretary of State,,D,Jean Schodorf,48
-Harvey,25-Halstead  Township,Secretary of State,,D,Jean Schodorf,47
-Harvey,26-Highland  Twp FD1,Secretary of State,,D,Jean Schodorf,40
-Harvey,27-Lake  Township,Secretary of State,,D,Jean Schodorf,12
-Harvey,28-Lakin  Township,Secretary of State,,D,Jean Schodorf,25
-Harvey,29-Macon  Township,Secretary of State,,D,Jean Schodorf,96
-Harvey,30-Newton  Township  AB,Secretary of State,,D,Jean Schodorf,40
-Harvey,31-Newton  Township  CDE,Secretary of State,,D,Jean Schodorf,7
-Harvey,32-Pleasant  Twp,Secretary of State,,D,Jean Schodorf,49
-Harvey,33-Richland  Township,Secretary of State,,D,Jean Schodorf,44
-Harvey,34-Sedgwick  City/Twp,Secretary of State,,D,Jean Schodorf,209
-Harvey,35-Walton  City/Twp FD,Secretary of State,,D,Jean Schodorf,63
-Harvey,36-Walton  Township,Secretary of State,,D,Jean Schodorf,8
-Harvey,37-Highland  Township,Secretary of State,,D,Jean Schodorf,30
-Harvey,38-Pleasant  Township,Secretary of State,,D,Jean Schodorf,36
-Harvey,5-Newton City W1P1,Attorney General,,R,Derek Schmidt,184
-Harvey,6-Newton City W1P2,Attorney General,,R,Derek Schmidt,152
-Harvey,7-Newton City W1P3,Attorney General,,R,Derek Schmidt,101
-Harvey,8-Newton City W2P1,Attorney General,,R,Derek Schmidt,153
-Harvey,9-Newton City W2P2,Attorney General,,R,Derek Schmidt,454
-Harvey,10-Newton City W3P1,Attorney General,,R,Derek Schmidt,198
-Harvey,11-Newton City W3P2,Attorney General,,R,Derek Schmidt,339
-Harvey,12-Newton City W3P3,Attorney General,,R,Derek Schmidt,292
-Harvey,13-Newton City W3P4,Attorney General,,R,Derek Schmidt,626
-Harvey,14-Newton City W4P1,Attorney General,,R,Derek Schmidt,250
-Harvey,15-Newton City W4P2,Attorney General,,R,Derek Schmidt,479
-Harvey,16-Newton City W4P3,Attorney General,,R,Derek Schmidt,348
-Harvey,17-Newton City W4P4,Attorney General,,R,Derek Schmidt,142
-Harvey,Newton City,Attorney General,,R,Derek Schmidt,3718
-Harvey,1-Halstead  City W1P1,Attorney General,,R,Derek Schmidt,194
-Harvey,2-Halstead  City W2P1,Attorney General,,R,Derek Schmidt,254
-Harvey,3-Hesston  City W1P1,Attorney General,,R,Derek Schmidt,478
-Harvey,4-Hesston  City W2P1,Attorney General,,R,Derek Schmidt,499
-Harvey,18-North  Newton,Attorney General,,R,Derek Schmidt,420
-Harvey,19-Alta  Township,Attorney General,,R,Derek Schmidt,81
-Harvey,20-Burrton  City/Twp,Attorney General,,R,Derek Schmidt,252
-Harvey,21-Darlington  Township,Attorney General,,R,Derek Schmidt,130
-Harvey,22-Darlington  Twp  North,Attorney General,,R,Derek Schmidt,44
-Harvey,23-Emma  Township,Attorney General,,R,Derek Schmidt,181
-Harvey,24-Garden  Township,Attorney General,,R,Derek Schmidt,100
-Harvey,25-Halstead  Township,Attorney General,,R,Derek Schmidt,69
-Harvey,26-Highland  Twp FD1,Attorney General,,R,Derek Schmidt,74
-Harvey,27-Lake  Township,Attorney General,,R,Derek Schmidt,56
-Harvey,28-Lakin  Township,Attorney General,,R,Derek Schmidt,87
-Harvey,29-Macon  Township,Attorney General,,R,Derek Schmidt,148
-Harvey,30-Newton  Township  AB,Attorney General,,R,Derek Schmidt,115
-Harvey,31-Newton  Township  CDE,Attorney General,,R,Derek Schmidt,35
-Harvey,32-Pleasant  Twp,Attorney General,,R,Derek Schmidt,95
-Harvey,33-Richland  Township,Attorney General,,R,Derek Schmidt,153
-Harvey,34-Sedgwick  City/Twp,Attorney General,,R,Derek Schmidt,470
-Harvey,35-Walton  City/Twp FD,Attorney General,,R,Derek Schmidt,133
-Harvey,36-Walton  Township,Attorney General,,R,Derek Schmidt,8
-Harvey,37-Highland  Township,Attorney General,,R,Derek Schmidt,39
-Harvey,38-Pleasant  Township,Attorney General,,R,Derek Schmidt,91
-Harvey,5-Newton City W1P1,Attorney General,,D,A J Kotich,129
-Harvey,6-Newton City W1P2,Attorney General,,D,A J Kotich,94
-Harvey,7-Newton City W1P3,Attorney General,,D,A J Kotich,67
-Harvey,8-Newton City W2P1,Attorney General,,D,A J Kotich,112
-Harvey,9-Newton City W2P2,Attorney General,,D,A J Kotich,267
-Harvey,10-Newton City W3P1,Attorney General,,D,A J Kotich,115
-Harvey,11-Newton City W3P2,Attorney General,,D,A J Kotich,140
-Harvey,12-Newton City W3P3,Attorney General,,D,A J Kotich,111
-Harvey,13-Newton City W3P4,Attorney General,,D,A J Kotich,246
-Harvey,14-Newton City W4P1,Attorney General,,D,A J Kotich,134
-Harvey,15-Newton City W4P2,Attorney General,,D,A J Kotich,255
-Harvey,16-Newton City W4P3,Attorney General,,D,A J Kotich,175
-Harvey,17-Newton City W4P4,Attorney General,,D,A J Kotich,76
-Harvey,Newton City,Attorney General,,D,A J Kotich,1921
-Harvey,1-Halstead  City W1P1,Attorney General,,D,A J Kotich,72
-Harvey,2-Halstead  City W2P1,Attorney General,,D,A J Kotich,94
-Harvey,3-Hesston  City W1P1,Attorney General,,D,A J Kotich,187
-Harvey,4-Hesston  City W2P1,Attorney General,,D,A J Kotich,168
-Harvey,18-North  Newton,Attorney General,,D,A J Kotich,398
-Harvey,19-Alta  Township,Attorney General,,D,A J Kotich,19
-Harvey,20-Burrton  City/Twp,Attorney General,,D,A J Kotich,69
-Harvey,21-Darlington  Township,Attorney General,,D,A J Kotich,39
-Harvey,22-Darlington  Twp  North,Attorney General,,D,A J Kotich,15
-Harvey,23-Emma  Township,Attorney General,,D,A J Kotich,36
-Harvey,24-Garden  Township,Attorney General,,D,A J Kotich,31
-Harvey,25-Halstead  Township,Attorney General,,D,A J Kotich,37
-Harvey,26-Highland  Twp FD1,Attorney General,,D,A J Kotich,23
-Harvey,27-Lake  Township,Attorney General,,D,A J Kotich,8
-Harvey,28-Lakin  Township,Attorney General,,D,A J Kotich,14
-Harvey,29-Macon  Township,Attorney General,,D,A J Kotich,59
-Harvey,30-Newton  Township  AB,Attorney General,,D,A J Kotich,29
-Harvey,31-Newton  Township  CDE,Attorney General,,D,A J Kotich,4
-Harvey,32-Pleasant  Twp,Attorney General,,D,A J Kotich,29
-Harvey,33-Richland  Township,Attorney General,,D,A J Kotich,26
-Harvey,34-Sedgwick  City/Twp,Attorney General,,D,A J Kotich,117
-Harvey,35-Walton  City/Twp FD,Attorney General,,D,A J Kotich,42
-Harvey,36-Walton  Township,Attorney General,,D,A J Kotich,6
-Harvey,37-Highland  Township,Attorney General,,D,A J Kotich,22
-Harvey,38-Pleasant  Township,Attorney General,,D,A J Kotich,26
-Harvey,5-Newton City W1P1,State Treasurer,,R,Ron Estes,185
-Harvey,6-Newton City W1P2,State Treasurer,,R,Ron Estes,156
-Harvey,7-Newton City W1P3,State Treasurer,,R,Ron Estes,100
-Harvey,8-Newton City W2P1,State Treasurer,,R,Ron Estes,155
-Harvey,9-Newton City W2P2,State Treasurer,,R,Ron Estes,458
-Harvey,10-Newton City W3P1,State Treasurer,,R,Ron Estes,206
-Harvey,11-Newton City W3P2,State Treasurer,,R,Ron Estes,340
-Harvey,12-Newton City W3P3,State Treasurer,,R,Ron Estes,301
-Harvey,13-Newton City W3P4,State Treasurer,,R,Ron Estes,630
-Harvey,14-Newton City W4P1,State Treasurer,,R,Ron Estes,248
-Harvey,15-Newton City W4P2,State Treasurer,,R,Ron Estes,484
-Harvey,16-Newton City W4P3,State Treasurer,,R,Ron Estes,348
-Harvey,17-Newton City W4P4,State Treasurer,,R,Ron Estes,139
-Harvey,Newton City,State Treasurer,,R,Ron Estes,3750
-Harvey,1-Halstead  City W1P1,State Treasurer,,R,Ron Estes,204
-Harvey,2-Halstead  City W2P1,State Treasurer,,R,Ron Estes,249
-Harvey,3-Hesston  City W1P1,State Treasurer,,R,Ron Estes,479
-Harvey,4-Hesston  City W2P1,State Treasurer,,R,Ron Estes,509
-Harvey,18-North  Newton,State Treasurer,,R,Ron Estes,410
-Harvey,19-Alta  Township,State Treasurer,,R,Ron Estes,79
-Harvey,20-Burrton  City/Twp,State Treasurer,,R,Ron Estes,249
-Harvey,21-Darlington  Township,State Treasurer,,R,Ron Estes,136
-Harvey,22-Darlington  Twp  North,State Treasurer,,R,Ron Estes,45
-Harvey,23-Emma  Township,State Treasurer,,R,Ron Estes,185
-Harvey,24-Garden  Township,State Treasurer,,R,Ron Estes,98
-Harvey,25-Halstead  Township,State Treasurer,,R,Ron Estes,73
-Harvey,26-Highland  Twp FD1,State Treasurer,,R,Ron Estes,70
-Harvey,27-Lake  Township,State Treasurer,,R,Ron Estes,58
-Harvey,28-Lakin  Township,State Treasurer,,R,Ron Estes,85
-Harvey,29-Macon  Township,State Treasurer,,R,Ron Estes,146
-Harvey,30-Newton  Township  AB,State Treasurer,,R,Ron Estes,114
-Harvey,31-Newton  Township  CDE,State Treasurer,,R,Ron Estes,39
-Harvey,32-Pleasant  Twp,State Treasurer,,R,Ron Estes,94
-Harvey,33-Richland  Township,State Treasurer,,R,Ron Estes,157
-Harvey,34-Sedgwick  City/Twp,State Treasurer,,R,Ron Estes,475
-Harvey,35-Walton  City/Twp FD,State Treasurer,,R,Ron Estes,134
-Harvey,36-Walton  Township,State Treasurer,,R,Ron Estes,9
-Harvey,37-Highland  Township,State Treasurer,,R,Ron Estes,37
-Harvey,38-Pleasant  Township,State Treasurer,,R,Ron Estes,93
-Harvey,5-Newton City W1P1,State Treasurer,,D,Carmen Alldritt,125
-Harvey,6-Newton City W1P2,State Treasurer,,D,Carmen Alldritt,92
-Harvey,7-Newton City W1P3,State Treasurer,,D,Carmen Alldritt,66
-Harvey,8-Newton City W2P1,State Treasurer,,D,Carmen Alldritt,109
-Harvey,9-Newton City W2P2,State Treasurer,,D,Carmen Alldritt,266
-Harvey,10-Newton City W3P1,State Treasurer,,D,Carmen Alldritt,112
-Harvey,11-Newton City W3P2,State Treasurer,,D,Carmen Alldritt,140
-Harvey,12-Newton City W3P3,State Treasurer,,D,Carmen Alldritt,99
-Harvey,13-Newton City W3P4,State Treasurer,,D,Carmen Alldritt,238
-Harvey,14-Newton City W4P1,State Treasurer,,D,Carmen Alldritt,135
-Harvey,15-Newton City W4P2,State Treasurer,,D,Carmen Alldritt,246
-Harvey,16-Newton City W4P3,State Treasurer,,D,Carmen Alldritt,174
-Harvey,17-Newton City W4P4,State Treasurer,,D,Carmen Alldritt,76
-Harvey,Newton City,State Treasurer,,D,Carmen Alldritt,1878
-Harvey,1-Halstead  City W1P1,State Treasurer,,D,Carmen Alldritt,60
-Harvey,2-Halstead  City W2P1,State Treasurer,,D,Carmen Alldritt,100
-Harvey,3-Hesston  City W1P1,State Treasurer,,D,Carmen Alldritt,183
-Harvey,4-Hesston  City W2P1,State Treasurer,,D,Carmen Alldritt,158
-Harvey,18-North  Newton,State Treasurer,,D,Carmen Alldritt,400
-Harvey,19-Alta  Township,State Treasurer,,D,Carmen Alldritt,19
-Harvey,20-Burrton  City/Twp,State Treasurer,,D,Carmen Alldritt,73
-Harvey,21-Darlington  Township,State Treasurer,,D,Carmen Alldritt,36
-Harvey,22-Darlington  Twp  North,State Treasurer,,D,Carmen Alldritt,13
-Harvey,23-Emma  Township,State Treasurer,,D,Carmen Alldritt,33
-Harvey,24-Garden  Township,State Treasurer,,D,Carmen Alldritt,31
-Harvey,25-Halstead  Township,State Treasurer,,D,Carmen Alldritt,31
-Harvey,26-Highland  Twp FD1,State Treasurer,,D,Carmen Alldritt,25
-Harvey,27-Lake  Township,State Treasurer,,D,Carmen Alldritt,7
-Harvey,28-Lakin  Township,State Treasurer,,D,Carmen Alldritt,17
-Harvey,29-Macon  Township,State Treasurer,,D,Carmen Alldritt,59
-Harvey,30-Newton  Township  AB,State Treasurer,,D,Carmen Alldritt,25
-Harvey,31-Newton  Township  CDE,State Treasurer,,D,Carmen Alldritt,1
-Harvey,32-Pleasant  Twp,State Treasurer,,D,Carmen Alldritt,30
-Harvey,33-Richland  Township,State Treasurer,,D,Carmen Alldritt,24
-Harvey,34-Sedgwick  City/Twp,State Treasurer,,D,Carmen Alldritt,109
-Harvey,35-Walton  City/Twp FD,State Treasurer,,D,Carmen Alldritt,41
-Harvey,36-Walton  Township,State Treasurer,,D,Carmen Alldritt,5
-Harvey,37-Highland  Township,State Treasurer,,D,Carmen Alldritt,24
-Harvey,38-Pleasant  Township,State Treasurer,,D,Carmen Alldritt,24
-Harvey,5-Newton City W1P1,Insurance Commissioner,,R,Ken Selzer,164
-Harvey,6-Newton City W1P2,Insurance Commissioner,,R,Ken Selzer,144
-Harvey,7-Newton City W1P3,Insurance Commissioner,,R,Ken Selzer,99
-Harvey,8-Newton City W2P1,Insurance Commissioner,,R,Ken Selzer,135
-Harvey,9-Newton City W2P2,Insurance Commissioner,,R,Ken Selzer,423
-Harvey,10-Newton City W3P1,Insurance Commissioner,,R,Ken Selzer,192
-Harvey,11-Newton City W3P2,Insurance Commissioner,,R,Ken Selzer,320
-Harvey,12-Newton City W3P3,Insurance Commissioner,,R,Ken Selzer,275
-Harvey,13-Newton City W3P4,Insurance Commissioner,,R,Ken Selzer,600
-Harvey,14-Newton City W4P1,Insurance Commissioner,,R,Ken Selzer,229
-Harvey,15-Newton City W4P2,Insurance Commissioner,,R,Ken Selzer,446
-Harvey,16-Newton City W4P3,Insurance Commissioner,,R,Ken Selzer,323
-Harvey,17-Newton City W4P4,Insurance Commissioner,,R,Ken Selzer,125
-Harvey,Newton City,Insurance Commissioner,,R,Ken Selzer,3475
-Harvey,1-Halstead  City W1P1,Insurance Commissioner,,R,Ken Selzer,189
-Harvey,2-Halstead  City W2P1,Insurance Commissioner,,R,Ken Selzer,228
-Harvey,3-Hesston  City W1P1,Insurance Commissioner,,R,Ken Selzer,456
-Harvey,4-Hesston  City W2P1,Insurance Commissioner,,R,Ken Selzer,492
-Harvey,18-North  Newton,Insurance Commissioner,,R,Ken Selzer,374
-Harvey,19-Alta  Township,Insurance Commissioner,,R,Ken Selzer,82
-Harvey,20-Burrton  City/Twp,Insurance Commissioner,,R,Ken Selzer,231
-Harvey,21-Darlington  Township,Insurance Commissioner,,R,Ken Selzer,126
-Harvey,22-Darlington  Twp  North,Insurance Commissioner,,R,Ken Selzer,42
-Harvey,23-Emma  Township,Insurance Commissioner,,R,Ken Selzer,172
-Harvey,24-Garden  Township,Insurance Commissioner,,R,Ken Selzer,97
-Harvey,25-Halstead  Township,Insurance Commissioner,,R,Ken Selzer,65
-Harvey,26-Highland  Twp FD1,Insurance Commissioner,,R,Ken Selzer,69
-Harvey,27-Lake  Township,Insurance Commissioner,,R,Ken Selzer,47
-Harvey,28-Lakin  Township,Insurance Commissioner,,R,Ken Selzer,81
-Harvey,29-Macon  Township,Insurance Commissioner,,R,Ken Selzer,139
-Harvey,30-Newton  Township  AB,Insurance Commissioner,,R,Ken Selzer,106
-Harvey,31-Newton  Township  CDE,Insurance Commissioner,,R,Ken Selzer,35
-Harvey,32-Pleasant  Twp,Insurance Commissioner,,R,Ken Selzer,86
-Harvey,33-Richland  Township,Insurance Commissioner,,R,Ken Selzer,143
-Harvey,34-Sedgwick  City/Twp,Insurance Commissioner,,R,Ken Selzer,432
-Harvey,35-Walton  City/Twp FD,Insurance Commissioner,,R,Ken Selzer,128
-Harvey,36-Walton  Township,Insurance Commissioner,,R,Ken Selzer,9
-Harvey,37-Highland  Township,Insurance Commissioner,,R,Ken Selzer,33
-Harvey,38-Pleasant  Township,Insurance Commissioner,,R,Ken Selzer,87
-Harvey,5-Newton City W1P1,Insurance Commissioner,,D,Dennis Anderson,144
-Harvey,6-Newton City W1P2,Insurance Commissioner,,D,Dennis Anderson,100
-Harvey,7-Newton City W1P3,Insurance Commissioner,,D,Dennis Anderson,69
-Harvey,8-Newton City W2P1,Insurance Commissioner,,D,Dennis Anderson,123
-Harvey,9-Newton City W2P2,Insurance Commissioner,,D,Dennis Anderson,294
-Harvey,10-Newton City W3P1,Insurance Commissioner,,D,Dennis Anderson,123
-Harvey,11-Newton City W3P2,Insurance Commissioner,,D,Dennis Anderson,159
-Harvey,12-Newton City W3P3,Insurance Commissioner,,D,Dennis Anderson,124
-Harvey,13-Newton City W3P4,Insurance Commissioner,,D,Dennis Anderson,271
-Harvey,14-Newton City W4P1,Insurance Commissioner,,D,Dennis Anderson,157
-Harvey,15-Newton City W4P2,Insurance Commissioner,,D,Dennis Anderson,286
-Harvey,16-Newton City W4P3,Insurance Commissioner,,D,Dennis Anderson,191
-Harvey,17-Newton City W4P4,Insurance Commissioner,,D,Dennis Anderson,86
-Harvey,Newton City,Insurance Commissioner,,D,Dennis Anderson,2127
-Harvey,1-Halstead  City W1P1,Insurance Commissioner,,D,Dennis Anderson,73
-Harvey,2-Halstead  City W2P1,Insurance Commissioner,,D,Dennis Anderson,124
-Harvey,3-Hesston  City W1P1,Insurance Commissioner,,D,Dennis Anderson,213
-Harvey,4-Hesston  City W2P1,Insurance Commissioner,,D,Dennis Anderson,174
-Harvey,18-North  Newton,Insurance Commissioner,,D,Dennis Anderson,444
-Harvey,19-Alta  Township,Insurance Commissioner,,D,Dennis Anderson,17
-Harvey,20-Burrton  City/Twp,Insurance Commissioner,,D,Dennis Anderson,85
-Harvey,21-Darlington  Township,Insurance Commissioner,,D,Dennis Anderson,42
-Harvey,22-Darlington  Twp  North,Insurance Commissioner,,D,Dennis Anderson,16
-Harvey,23-Emma  Township,Insurance Commissioner,,D,Dennis Anderson,46
-Harvey,24-Garden  Township,Insurance Commissioner,,D,Dennis Anderson,34
-Harvey,25-Halstead  Township,Insurance Commissioner,,D,Dennis Anderson,40
-Harvey,26-Highland  Twp FD1,Insurance Commissioner,,D,Dennis Anderson,25
-Harvey,27-Lake  Township,Insurance Commissioner,,D,Dennis Anderson,16
-Harvey,28-Lakin  Township,Insurance Commissioner,,D,Dennis Anderson,20
-Harvey,29-Macon  Township,Insurance Commissioner,,D,Dennis Anderson,64
-Harvey,30-Newton  Township  AB,Insurance Commissioner,,D,Dennis Anderson,35
-Harvey,31-Newton  Township  CDE,Insurance Commissioner,,D,Dennis Anderson,3
-Harvey,32-Pleasant  Twp,Insurance Commissioner,,D,Dennis Anderson,41
-Harvey,33-Richland  Township,Insurance Commissioner,,D,Dennis Anderson,34
-Harvey,34-Sedgwick  City/Twp,Insurance Commissioner,,D,Dennis Anderson,149
-Harvey,35-Walton  City/Twp FD,Insurance Commissioner,,D,Dennis Anderson,43
-Harvey,36-Walton  Township,Insurance Commissioner,,D,Dennis Anderson,5
-Harvey,37-Highland  Township,Insurance Commissioner,,D,Dennis Anderson,27
-Harvey,38-Pleasant  Township,Insurance Commissioner,,D,Dennis Anderson,28
-Harvey,5-Newton City W1P1,State House,72,R,Marc Rhoades,228
-Harvey,6-Newton City W1P2,State House,72,R,Marc Rhoades,186
-Harvey,7-Newton City W1P3,State House,72,R,Marc Rhoades,135
-Harvey,8-Newton City W2P1,State House,72,R,Marc Rhoades,197
-Harvey,9-Newton City W2P2,State House,72,R,Marc Rhoades,524
-Harvey,10-Newton City W3P1,State House,72,R,Marc Rhoades,231
-Harvey,11-Newton City W3P2,State House,72,R,Marc Rhoades,379
-Harvey,12-Newton City W3P3,State House,72,R,Marc Rhoades,335
-Harvey,13-Newton City W3P4,State House,72,R,Marc Rhoades,708
-Harvey,14-Newton City W4P1,State House,72,R,Marc Rhoades,277
-Harvey,15-Newton City W4P2,State House,72,R,Marc Rhoades,520
-Harvey,16-Newton City W4P3,State House,72,R,Marc Rhoades,395
-Harvey,17-Newton City W4P4,State House,72,R,Marc Rhoades,157
-Harvey,1-Halstead  City W1P1,State House,74,R,Don Schroeder,246
-Harvey,2-Halstead  City W2P1,State House,74,R,Don Schroeder,311
-Harvey,3-Hesston  City W1P1,State House,74,R,Don Schroeder,593
-Harvey,4-Hesston  City W2P1,State House,74,R,Don Schroeder,600
-Harvey,18-North  Newton,State House,72,R,Marc Rhoades,441
-Harvey,19-Alta  Township,State House,74,R,Don Schroeder,87
-Harvey,20-Burrton  City/Twp,State House,74,R,Don Schroeder,295
-Harvey,21-Darlington  Township,State House,74,R,Don Schroeder,143
-Harvey,22-Darlington  Twp  North,State House,72,R,Marc Rhoades,51
-Harvey,23-Emma  Township,State House,74,R,Don Schroeder,198
-Harvey,24-Garden  Township,State House,74,R,Don Schroeder,117
-Harvey,25-Halstead  Township,State House,74,R,Don Schroeder,96
-Harvey,26-Highland  Twp FD1,State House,74,R,Don Schroeder,85
-Harvey,27-Lake  Township,State House,74,R,Don Schroeder,59
-Harvey,28-Lakin  Township,State House,74,R,Don Schroeder,94
-Harvey,29-Macon  Township,State House,74,R,Don Schroeder,175
-Harvey,30-Newton  Township  AB,State House,72,R,Marc Rhoades,119
-Harvey,31-Newton  Township  CDE,State House,72,R,Marc Rhoades,36
-Harvey,32-Pleasant  Twp,State House,72,R,Marc Rhoades,100
-Harvey,33-Richland  Township,State House,72,R,Marc Rhoades,159
-Harvey,34-Sedgwick  City/Twp,State House,74,R,Don Schroeder,537
-Harvey,35-Walton  City/Twp FD,State House,74,R,Don Schroeder,157
-Harvey,36-Walton  Township,State House,74,R,Don Schroeder,14
-Harvey,37-Highland  Township,State House,74,R,Don Schroeder,47
-Harvey,38-Pleasant  Township,State House,72,R,Marc Rhoades,89
-Harvey,1-Halstead  City W1P1,State House,74,,Write-ins,5
-Harvey,2-Halstead  City W2P1,State House,74,,Write-ins,7
-Harvey,3-Hesston  City W1P1,State House,74,,Write-ins,6
-Harvey,4-Hesston  City W2P1,State House,74,,Write-ins,5
-Harvey,5-Newton City W1P1,State House,72,,Write-ins,19
-Harvey,6-Newton City W1P2,State House,72,,Write-ins,19
-Harvey,7-Newton City W1P3,State House,72,,Write-ins,15
-Harvey,8-Newton City W2P1,State House,72,,Write-ins,23
-Harvey,9-Newton City W2P2,State House,72,,Write-ins,68
-Harvey,10-Newton City W3P1,State House,72,,Write-ins,28
-Harvey,11-Newton City W3P2,State House,72,,Write-ins,35
-Harvey,12-Newton City W3P3,State House,72,,Write-ins,18
-Harvey,13-Newton City W3P4,State House,72,,Write-ins,56
-Harvey,14-Newton City W4P1,State House,72,,Write-ins,38
-Harvey,15-Newton City W4P2,State House,72,,Write-ins,84
-Harvey,16-Newton City W4P3,State House,72,,Write-ins,41
-Harvey,17-Newton City W4P4,State House,72,,Write-ins,19
-Harvey,18-North  Newton,State House,72,,Write-ins,141
-Harvey,19-Alta  Township,State House,74,,Write-ins,3
-Harvey,20-Burrton  City/Twp,State House,74,,Write-ins,1
-Harvey,21-Darlington  Township,State House,74,,Write-ins,2
-Harvey,22-Darlington  Twp  North,State House,72,,Write-ins,1
-Harvey,23-Emma  Township,State House,74,,Write-ins,1
-Harvey,24-Garden  Township,State House,74,,Write-ins,2
-Harvey,25-Halstead  Township,State House,74,,Write-ins,0
-Harvey,26-Highland  Twp FD1,State House,74,,Write-ins,0
-Harvey,27-Lake  Township,State House,74,,Write-ins,0
-Harvey,28-Lakin  Township,State House,74,,Write-ins,0
-Harvey,29-Macon  Township,State House,74,,Write-ins,3
-Harvey,30-Newton  Township  AB,State House,72,,Write-ins,11
-Harvey,31-Newton  Township  CDE,State House,72,,Write-ins,1
-Harvey,32-Pleasant  Twp,State House,72,,Write-ins,8
-Harvey,33-Richland  Township,State House,72,,Write-ins,4
-Harvey,34-Sedgwick  City/Twp,State House,74,,Write-ins,6
-Harvey,35-Walton  City/Twp FD,State House,74,,Write-ins,2
-Harvey,36-Walton  Township,State House,74,,Write-ins,0
-Harvey,37-Highland  Township,State House,74,,Write-ins,3
-Harvey,38-Pleasant  Township,State House,72,,Write-ins,6
+county,precinct,office,district,party,candidate,votes,vtd
+HARVEY,Alta Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000010
+HARVEY,Alta Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000010
+HARVEY,Alta Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000010
+HARVEY,Burrton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000020
+HARVEY,Burrton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000020
+HARVEY,Burrton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,000020
+HARVEY,Emma Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000040
+HARVEY,Emma Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000040
+HARVEY,Emma Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",148,000040
+HARVEY,Garden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000050
+HARVEY,Garden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000050
+HARVEY,Garden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",110,000060
+HARVEY,Halstead City Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000060
+HARVEY,Halstead City Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",144,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",165,000070
+HARVEY,Halstead City Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000070
+HARVEY,Halstead City Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",178,000070
+HARVEY,Halstead Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000080
+HARVEY,Halstead Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000080
+HARVEY,Halstead Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000080
+HARVEY,Hesston Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",349,000090
+HARVEY,Hesston Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000090
+HARVEY,Hesston Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",326,000090
+HARVEY,Hesston Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",302,00010A
+HARVEY,Hesston Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00010A
+HARVEY,Hesston Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",370,00010A
+HARVEY,Highland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000110
+HARVEY,Highland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000110
+HARVEY,Highland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",82,000110
+HARVEY,Lake Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000120
+HARVEY,Lake Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000120
+HARVEY,Lake Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000120
+HARVEY,Lakin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000130
+HARVEY,Lakin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000130
+HARVEY,Lakin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",74,000130
+HARVEY,Macon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",95,000140
+HARVEY,Macon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000140
+HARVEY,Macon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000140
+HARVEY,Newton City Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",169,000150
+HARVEY,Newton City Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000150
+HARVEY,Newton City Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,000150
+HARVEY,Newton City Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",126,000160
+HARVEY,Newton City Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000160
+HARVEY,Newton City Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000160
+HARVEY,Newton City Ward 1 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",82,000170
+HARVEY,Newton City Ward 1 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000170
+HARVEY,Newton City Ward 1 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",85,000170
+HARVEY,Newton City Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",151,000180
+HARVEY,Newton City Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000180
+HARVEY,Newton City Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",105,000180
+HARVEY,Newton City Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",383,00019A
+HARVEY,Newton City Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00019A
+HARVEY,Newton City Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",336,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",151,000200
+HARVEY,Newton City Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000200
+HARVEY,Newton City Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",154,000200
+HARVEY,Newton City Ward 3 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",226,000210
+HARVEY,Newton City Ward 3 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000210
+HARVEY,Newton City Ward 3 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",254,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",180,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",220,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",204,000230
+HARVEY,Newton City Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000230
+HARVEY,Newton City Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",171,000230
+HARVEY,Newton City Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",405,000240
+HARVEY,Newton City Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000240
+HARVEY,Newton City Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",315,000240
+HARVEY,Newton City Ward 4 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",268,000250
+HARVEY,Newton City Ward 4 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000250
+HARVEY,Newton City Ward 4 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",234,000250
+HARVEY,Newton City Ward 4 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",117,000260
+HARVEY,Newton City Ward 4 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000260
+HARVEY,Newton City Ward 4 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,000260
+HARVEY,Newton Township Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,00027A
+HARVEY,Newton Township Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00027A
+HARVEY,Newton Township Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,00027A
+HARVEY,Newton Township Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,00027B
+HARVEY,Newton Township Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00027B
+HARVEY,Newton Township Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",95,00027B
+HARVEY,Newton Township Part B Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00027C
+HARVEY,Newton Township Part B Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00027C
+HARVEY,Newton Township Part B Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00027C
+HARVEY,Newton Township Part C,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,00027D
+HARVEY,Newton Township Part C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00027D
+HARVEY,Newton Township Part C,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,00027D
+HARVEY,North Newton City,Governor / Lt. Governor,,Democratic,"Davis, Paul",558,000280
+HARVEY,North Newton City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000280
+HARVEY,North Newton City,Governor / Lt. Governor,,Republican,"Brownback, Sam",273,000280
+HARVEY,Pleasant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,000290
+HARVEY,Pleasant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000290
+HARVEY,Pleasant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",157,000290
+HARVEY,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000300
+HARVEY,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000300
+HARVEY,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000300
+HARVEY,Sedgwick Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",51,000310
+HARVEY,Sedgwick Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000310
+HARVEY,Sedgwick Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000310
+HARVEY,Walton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000320
+HARVEY,Walton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000320
+HARVEY,Walton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000320
+HARVEY,Darlington Township H72,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,120020
+HARVEY,Darlington Township H72,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,120020
+HARVEY,Darlington Township H72,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,120020
+HARVEY,Darlington Township H74,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,120030
+HARVEY,Darlington Township H74,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+HARVEY,Darlington Township H74,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,120030
+HARVEY,Newton City Ward 3 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",396,800010
+HARVEY,Newton City Ward 3 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,800010
+HARVEY,Newton City Ward 3 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",478,800010
+HARVEY,Burrton City,Governor / Lt. Governor,,Democratic,"Davis, Paul",87,900010
+HARVEY,Burrton City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,900010
+HARVEY,Burrton City,Governor / Lt. Governor,,Republican,"Brownback, Sam",137,900010
+HARVEY,Sedgwick City,Governor / Lt. Governor,,Democratic,"Davis, Paul",190,900020
+HARVEY,Sedgwick City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,900020
+HARVEY,Sedgwick City,Governor / Lt. Governor,,Republican,"Brownback, Sam",259,900020
+HARVEY,Walton City,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,900030
+HARVEY,Walton City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,900030
+HARVEY,Walton City,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,900030
+HARVEY,Burrton City Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+HARVEY,Burrton City Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+HARVEY,Burrton City Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+HARVEY,Newton Township Part D,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,900050
+HARVEY,Newton Township Part D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,900050
+HARVEY,Newton Township Part D,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,900050
+HARVEY,Newton Township Part E,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900060
+HARVEY,Newton Township Part E,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+HARVEY,Newton Township Part E,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,900060
+HARVEY,Newton Township Part F,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900070
+HARVEY,Newton Township Part F,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900070
+HARVEY,Newton Township Part F,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900070
+HARVEY,Newton Township Part G,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900080
+HARVEY,Newton Township Part G,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900080
+HARVEY,Newton Township Part G,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900080
+HARVEY,Alta Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",87,000010
+HARVEY,Burrton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",80,000020
+HARVEY,Emma Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",198,000040
+HARVEY,Garden Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",117,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",246,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",311,000070
+HARVEY,Halstead Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",96,000080
+HARVEY,Hesston Precinct 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",593,000090
+HARVEY,Hesston Precinct 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",600,00010A
+HARVEY,Highland Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",132,000110
+HARVEY,Lake Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",59,000120
+HARVEY,Lakin Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",94,000130
+HARVEY,Macon Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",175,000140
+HARVEY,Newton City Ward 1 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",228,000150
+HARVEY,Newton City Ward 1 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",186,000160
+HARVEY,Newton City Ward 1 Precinct 3,Kansas House of Representatives,72,Republican,"Rhoades, Marc",135,000170
+HARVEY,Newton City Ward 2 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",197,000180
+HARVEY,Newton City Ward 2 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",524,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",231,000200
+HARVEY,Newton City Ward 3 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",379,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Kansas House of Representatives,72,Republican,"Rhoades, Marc",335,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",277,000230
+HARVEY,Newton City Ward 4 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",520,000240
+HARVEY,Newton City Ward 4 Precinct 3,Kansas House of Representatives,72,Republican,"Rhoades, Marc",395,000250
+HARVEY,Newton City Ward 4 Precinct 4,Kansas House of Representatives,72,Republican,"Rhoades, Marc",157,000260
+HARVEY,Newton Township Part A,Kansas House of Representatives,72,Republican,"Rhoades, Marc",4,00027A
+HARVEY,Newton Township Part B,Kansas House of Representatives,72,Republican,"Rhoades, Marc",115,00027B
+HARVEY,Newton Township Part B Exclave,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,00027C
+HARVEY,Newton Township Part C,Kansas House of Representatives,72,Republican,"Rhoades, Marc",3,00027D
+HARVEY,North Newton City,Kansas House of Representatives,72,Republican,"Rhoades, Marc",441,000280
+HARVEY,Pleasant Township,Kansas House of Representatives,72,Republican,"Rhoades, Marc",189,000290
+HARVEY,Richland Township,Kansas House of Representatives,72,Republican,"Rhoades, Marc",159,000300
+HARVEY,Sedgwick Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",113,000310
+HARVEY,Walton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",97,000320
+HARVEY,Darlington Township H72,Kansas House of Representatives,72,Republican,"Rhoades, Marc",51,120020
+HARVEY,Darlington Township H74,Kansas House of Representatives,74,Republican,"Schroeder, Don",143,120030
+HARVEY,Newton City Ward 3 Precinct 4,Kansas House of Representatives,72,Republican,"Rhoades, Marc",708,800010
+HARVEY,Burrton City,Kansas House of Representatives,74,Republican,"Schroeder, Don",215,900010
+HARVEY,Sedgwick City,Kansas House of Representatives,74,Republican,"Schroeder, Don",424,900020
+HARVEY,Walton City,Kansas House of Representatives,74,Republican,"Schroeder, Don",74,900030
+HARVEY,Burrton City Exclave,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,900040
+HARVEY,Newton Township Part D,Kansas House of Representatives,72,Republican,"Rhoades, Marc",32,900050
+HARVEY,Newton Township Part E,Kansas House of Representatives,72,Republican,"Rhoades, Marc",1,900060
+HARVEY,Newton Township Part F,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,900070
+HARVEY,Newton Township Part G,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,900080
+HARVEY,Alta Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",25,000010
+HARVEY,Alta Township,United States House of Representatives,4,Republican,"Pompeo, Mike",76,000010
+HARVEY,Burrton Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",21,000020
+HARVEY,Burrton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",66,000020
+HARVEY,Emma Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",48,000040
+HARVEY,Emma Township,United States House of Representatives,4,Republican,"Pompeo, Mike",169,000040
+HARVEY,Garden Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",38,000050
+HARVEY,Garden Township,United States House of Representatives,4,Republican,"Pompeo, Mike",93,000050
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",75,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",191,000060
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",107,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",245,000070
+HARVEY,Halstead Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",39,000080
+HARVEY,Halstead Township,United States House of Representatives,4,Republican,"Pompeo, Mike",66,000080
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",243,000090
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",434,000090
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",187,00010A
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",487,00010A
+HARVEY,Highland Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",54,000110
+HARVEY,Highland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",101,000110
+HARVEY,Lake Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",15,000120
+HARVEY,Lake Township,United States House of Representatives,4,Republican,"Pompeo, Mike",50,000120
+HARVEY,Lakin Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",21,000130
+HARVEY,Lakin Township,United States House of Representatives,4,Republican,"Pompeo, Mike",81,000130
+HARVEY,Macon Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",71,000140
+HARVEY,Macon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",137,000140
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",140,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",173,000150
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",116,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",135,000160
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",67,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",103,000170
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",131,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",135,000180
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",289,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",441,00019A
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",130,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",189,000200
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",160,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",328,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",128,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,Republican,"Pompeo, Mike",281,00022A
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",169,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",217,000230
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",292,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",444,000240
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",200,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",324,000250
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",93,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Mike",126,000260
+HARVEY,Newton Township Part A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,00027A
+HARVEY,Newton Township Part A,United States House of Representatives,4,Republican,"Pompeo, Mike",3,00027A
+HARVEY,Newton Township Part B,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",30,00027B
+HARVEY,Newton Township Part B,United States House of Representatives,4,Republican,"Pompeo, Mike",109,00027B
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00027C
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00027C
+HARVEY,Newton Township Part C,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00027D
+HARVEY,Newton Township Part C,United States House of Representatives,4,Republican,"Pompeo, Mike",3,00027D
+HARVEY,North Newton City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",479,000280
+HARVEY,North Newton City,United States House of Representatives,4,Republican,"Pompeo, Mike",348,000280
+HARVEY,Pleasant Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",74,000290
+HARVEY,Pleasant Township,United States House of Representatives,4,Republican,"Pompeo, Mike",173,000290
+HARVEY,Richland Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",34,000300
+HARVEY,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",149,000300
+HARVEY,Sedgwick Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",29,000310
+HARVEY,Sedgwick Township,United States House of Representatives,4,Republican,"Pompeo, Mike",94,000310
+HARVEY,Walton Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",32,000320
+HARVEY,Walton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",74,000320
+HARVEY,Darlington Township H72,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,120020
+HARVEY,Darlington Township H72,United States House of Representatives,4,Republican,"Pompeo, Mike",41,120020
+HARVEY,Darlington Township H74,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",48,120030
+HARVEY,Darlington Township H74,United States House of Representatives,4,Republican,"Pompeo, Mike",121,120030
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",258,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Mike",617,800010
+HARVEY,Burrton City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",58,900010
+HARVEY,Burrton City,United States House of Representatives,4,Republican,"Pompeo, Mike",178,900010
+HARVEY,Sedgwick City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",108,900020
+HARVEY,Sedgwick City,United States House of Representatives,4,Republican,"Pompeo, Mike",356,900020
+HARVEY,Walton City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",24,900030
+HARVEY,Walton City,United States House of Representatives,4,Republican,"Pompeo, Mike",59,900030
+HARVEY,Burrton City Exclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900040
+HARVEY,Burrton City Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900040
+HARVEY,Newton Township Part D,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,900050
+HARVEY,Newton Township Part D,United States House of Representatives,4,Republican,"Pompeo, Mike",32,900050
+HARVEY,Newton Township Part E,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900060
+HARVEY,Newton Township Part E,United States House of Representatives,4,Republican,"Pompeo, Mike",1,900060
+HARVEY,Newton Township Part F,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900070
+HARVEY,Newton Township Part F,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900070
+HARVEY,Newton Township Part G,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900080
+HARVEY,Newton Township Part G,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900080
+HARVEY,Alta Township,Attorney General,,Democratic,"Kotich, A.J.",19,000010
+HARVEY,Alta Township,Attorney General,,Republican,"Schmidt, Derek",81,000010
+HARVEY,Burrton Township,Attorney General,,Democratic,"Kotich, A.J.",19,000020
+HARVEY,Burrton Township,Attorney General,,Republican,"Schmidt, Derek",68,000020
+HARVEY,Emma Township,Attorney General,,Democratic,"Kotich, A.J.",36,000040
+HARVEY,Emma Township,Attorney General,,Republican,"Schmidt, Derek",181,000040
+HARVEY,Garden Township,Attorney General,,Democratic,"Kotich, A.J.",31,000050
+HARVEY,Garden Township,Attorney General,,Republican,"Schmidt, Derek",100,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",72,000060
+HARVEY,Halstead City Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",194,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",94,000070
+HARVEY,Halstead City Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",254,000070
+HARVEY,Halstead Township,Attorney General,,Democratic,"Kotich, A.J.",37,000080
+HARVEY,Halstead Township,Attorney General,,Republican,"Schmidt, Derek",69,000080
+HARVEY,Hesston Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",187,000090
+HARVEY,Hesston Precinct 1,Attorney General,,Republican,"Schmidt, Derek",478,000090
+HARVEY,Hesston Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",168,00010A
+HARVEY,Hesston Precinct 2,Attorney General,,Republican,"Schmidt, Derek",499,00010A
+HARVEY,Highland Township,Attorney General,,Democratic,"Kotich, A.J.",45,000110
+HARVEY,Highland Township,Attorney General,,Republican,"Schmidt, Derek",113,000110
+HARVEY,Lake Township,Attorney General,,Democratic,"Kotich, A.J.",8,000120
+HARVEY,Lake Township,Attorney General,,Republican,"Schmidt, Derek",56,000120
+HARVEY,Lakin Township,Attorney General,,Democratic,"Kotich, A.J.",14,000130
+HARVEY,Lakin Township,Attorney General,,Republican,"Schmidt, Derek",87,000130
+HARVEY,Macon Township,Attorney General,,Democratic,"Kotich, A.J.",59,000140
+HARVEY,Macon Township,Attorney General,,Republican,"Schmidt, Derek",148,000140
+HARVEY,Newton City Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",129,000150
+HARVEY,Newton City Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",184,000150
+HARVEY,Newton City Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",94,000160
+HARVEY,Newton City Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",152,000160
+HARVEY,Newton City Ward 1 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",67,000170
+HARVEY,Newton City Ward 1 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",101,000170
+HARVEY,Newton City Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",112,000180
+HARVEY,Newton City Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",153,000180
+HARVEY,Newton City Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",267,00019A
+HARVEY,Newton City Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",454,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",115,000200
+HARVEY,Newton City Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",198,000200
+HARVEY,Newton City Ward 3 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",140,000210
+HARVEY,Newton City Ward 3 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",339,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Attorney General,,Democratic,"Kotich, A.J.",111,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Attorney General,,Republican,"Schmidt, Derek",292,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",134,000230
+HARVEY,Newton City Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",250,000230
+HARVEY,Newton City Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",255,000240
+HARVEY,Newton City Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",479,000240
+HARVEY,Newton City Ward 4 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",175,000250
+HARVEY,Newton City Ward 4 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",348,000250
+HARVEY,Newton City Ward 4 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",76,000260
+HARVEY,Newton City Ward 4 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",142,000260
+HARVEY,Newton Township Part A,Attorney General,,Democratic,"Kotich, A.J.",1,00027A
+HARVEY,Newton Township Part A,Attorney General,,Republican,"Schmidt, Derek",3,00027A
+HARVEY,Newton Township Part B,Attorney General,,Democratic,"Kotich, A.J.",28,00027B
+HARVEY,Newton Township Part B,Attorney General,,Republican,"Schmidt, Derek",112,00027B
+HARVEY,Newton Township Part B Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00027C
+HARVEY,Newton Township Part B Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00027C
+HARVEY,Newton Township Part C,Attorney General,,Democratic,"Kotich, A.J.",0,00027D
+HARVEY,Newton Township Part C,Attorney General,,Republican,"Schmidt, Derek",3,00027D
+HARVEY,North Newton City,Attorney General,,Democratic,"Kotich, A.J.",398,000280
+HARVEY,North Newton City,Attorney General,,Republican,"Schmidt, Derek",420,000280
+HARVEY,Pleasant Township,Attorney General,,Democratic,"Kotich, A.J.",55,000290
+HARVEY,Pleasant Township,Attorney General,,Republican,"Schmidt, Derek",186,000290
+HARVEY,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",26,000300
+HARVEY,Richland Township,Attorney General,,Republican,"Schmidt, Derek",153,000300
+HARVEY,Sedgwick Township,Attorney General,,Democratic,"Kotich, A.J.",25,000310
+HARVEY,Sedgwick Township,Attorney General,,Republican,"Schmidt, Derek",99,000310
+HARVEY,Walton Township,Attorney General,,Democratic,"Kotich, A.J.",28,000320
+HARVEY,Walton Township,Attorney General,,Republican,"Schmidt, Derek",78,000320
+HARVEY,Darlington Township H72,Attorney General,,Democratic,"Kotich, A.J.",15,120020
+HARVEY,Darlington Township H72,Attorney General,,Republican,"Schmidt, Derek",44,120020
+HARVEY,Darlington Township H74,Attorney General,,Democratic,"Kotich, A.J.",39,120030
+HARVEY,Darlington Township H74,Attorney General,,Republican,"Schmidt, Derek",130,120030
+HARVEY,Newton City Ward 3 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",246,800010
+HARVEY,Newton City Ward 3 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",626,800010
+HARVEY,Burrton City,Attorney General,,Democratic,"Kotich, A.J.",50,900010
+HARVEY,Burrton City,Attorney General,,Republican,"Schmidt, Derek",184,900010
+HARVEY,Sedgwick City,Attorney General,,Democratic,"Kotich, A.J.",92,900020
+HARVEY,Sedgwick City,Attorney General,,Republican,"Schmidt, Derek",371,900020
+HARVEY,Walton City,Attorney General,,Democratic,"Kotich, A.J.",20,900030
+HARVEY,Walton City,Attorney General,,Republican,"Schmidt, Derek",63,900030
+HARVEY,Burrton City Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+HARVEY,Burrton City Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900040
+HARVEY,Newton Township Part D,Attorney General,,Democratic,"Kotich, A.J.",4,900050
+HARVEY,Newton Township Part D,Attorney General,,Republican,"Schmidt, Derek",31,900050
+HARVEY,Newton Township Part E,Attorney General,,Democratic,"Kotich, A.J.",0,900060
+HARVEY,Newton Township Part E,Attorney General,,Republican,"Schmidt, Derek",1,900060
+HARVEY,Newton Township Part F,Attorney General,,Democratic,"Kotich, A.J.",0,900070
+HARVEY,Newton Township Part F,Attorney General,,Republican,"Schmidt, Derek",0,900070
+HARVEY,Newton Township Part G,Attorney General,,Democratic,"Kotich, A.J.",0,900080
+HARVEY,Newton Township Part G,Attorney General,,Republican,"Schmidt, Derek",0,900080
+HARVEY,Alta Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000010
+HARVEY,Alta Township,Commissioner of Insurance,,Republican,"Selzer, Ken",82,000010
+HARVEY,Burrton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000020
+HARVEY,Burrton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000020
+HARVEY,Emma Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000040
+HARVEY,Emma Township,Commissioner of Insurance,,Republican,"Selzer, Ken",172,000040
+HARVEY,Garden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000050
+HARVEY,Garden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000060
+HARVEY,Halstead City Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",189,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",124,000070
+HARVEY,Halstead City Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",228,000070
+HARVEY,Halstead Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000080
+HARVEY,Halstead Township,Commissioner of Insurance,,Republican,"Selzer, Ken",65,000080
+HARVEY,Hesston Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",213,000090
+HARVEY,Hesston Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",456,000090
+HARVEY,Hesston Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",174,00010A
+HARVEY,Hesston Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",492,00010A
+HARVEY,Highland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000110
+HARVEY,Highland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",102,000110
+HARVEY,Lake Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000120
+HARVEY,Lake Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000120
+HARVEY,Lakin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000130
+HARVEY,Lakin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",81,000130
+HARVEY,Macon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",64,000140
+HARVEY,Macon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000140
+HARVEY,Newton City Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",144,000150
+HARVEY,Newton City Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",164,000150
+HARVEY,Newton City Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",100,000160
+HARVEY,Newton City Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",144,000160
+HARVEY,Newton City Ward 1 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000170
+HARVEY,Newton City Ward 1 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",99,000170
+HARVEY,Newton City Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",123,000180
+HARVEY,Newton City Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",135,000180
+HARVEY,Newton City Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",294,00019A
+HARVEY,Newton City Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",423,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",123,000200
+HARVEY,Newton City Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",192,000200
+HARVEY,Newton City Ward 3 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",159,000210
+HARVEY,Newton City Ward 3 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",320,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",124,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",275,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",157,000230
+HARVEY,Newton City Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",229,000230
+HARVEY,Newton City Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",286,000240
+HARVEY,Newton City Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",446,000240
+HARVEY,Newton City Ward 4 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",191,000250
+HARVEY,Newton City Ward 4 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",323,000250
+HARVEY,Newton City Ward 4 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,000260
+HARVEY,Newton City Ward 4 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",125,000260
+HARVEY,Newton Township Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,00027A
+HARVEY,Newton Township Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",3,00027A
+HARVEY,Newton Township Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,00027B
+HARVEY,Newton Township Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",103,00027B
+HARVEY,Newton Township Part B Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00027C
+HARVEY,Newton Township Part B Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00027C
+HARVEY,Newton Township Part C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00027D
+HARVEY,Newton Township Part C,Commissioner of Insurance,,Republican,"Selzer, Ken",3,00027D
+HARVEY,North Newton City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",444,000280
+HARVEY,North Newton City,Commissioner of Insurance,,Republican,"Selzer, Ken",374,000280
+HARVEY,Pleasant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000290
+HARVEY,Pleasant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000290
+HARVEY,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000300
+HARVEY,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",143,000300
+HARVEY,Sedgwick Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000310
+HARVEY,Sedgwick Township,Commissioner of Insurance,,Republican,"Selzer, Ken",91,000310
+HARVEY,Walton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000320
+HARVEY,Walton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000320
+HARVEY,Darlington Township H72,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,120020
+HARVEY,Darlington Township H72,Commissioner of Insurance,,Republican,"Selzer, Ken",42,120020
+HARVEY,Darlington Township H74,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,120030
+HARVEY,Darlington Township H74,Commissioner of Insurance,,Republican,"Selzer, Ken",126,120030
+HARVEY,Newton City Ward 3 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",271,800010
+HARVEY,Newton City Ward 3 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",600,800010
+HARVEY,Burrton City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,900010
+HARVEY,Burrton City,Commissioner of Insurance,,Republican,"Selzer, Ken",169,900010
+HARVEY,Sedgwick City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",118,900020
+HARVEY,Sedgwick City,Commissioner of Insurance,,Republican,"Selzer, Ken",341,900020
+HARVEY,Walton City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,900030
+HARVEY,Walton City,Commissioner of Insurance,,Republican,"Selzer, Ken",60,900030
+HARVEY,Burrton City Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+HARVEY,Burrton City Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+HARVEY,Newton Township Part D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,900050
+HARVEY,Newton Township Part D,Commissioner of Insurance,,Republican,"Selzer, Ken",31,900050
+HARVEY,Newton Township Part E,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900060
+HARVEY,Newton Township Part E,Commissioner of Insurance,,Republican,"Selzer, Ken",1,900060
+HARVEY,Newton Township Part F,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900070
+HARVEY,Newton Township Part F,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900070
+HARVEY,Newton Township Part G,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900080
+HARVEY,Newton Township Part G,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900080
+HARVEY,Alta Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000010
+HARVEY,Alta Township,Secretary of State,,Republican,"Kobach, Kris",72,000010
+HARVEY,Burrton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000020
+HARVEY,Burrton Township,Secretary of State,,Republican,"Kobach, Kris",60,000020
+HARVEY,Emma Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,000040
+HARVEY,Emma Township,Secretary of State,,Republican,"Kobach, Kris",164,000040
+HARVEY,Garden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000050
+HARVEY,Garden Township,Secretary of State,,Republican,"Kobach, Kris",85,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000060
+HARVEY,Halstead City Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",173,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,000070
+HARVEY,Halstead City Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",208,000070
+HARVEY,Halstead Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000080
+HARVEY,Halstead Township,Secretary of State,,Republican,"Kobach, Kris",61,000080
+HARVEY,Hesston Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",320,000090
+HARVEY,Hesston Precinct 1,Secretary of State,,Republican,"Kobach, Kris",364,000090
+HARVEY,Hesston Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",256,00010A
+HARVEY,Hesston Precinct 2,Secretary of State,,Republican,"Kobach, Kris",427,00010A
+HARVEY,Highland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,000110
+HARVEY,Highland Township,Secretary of State,,Republican,"Kobach, Kris",90,000110
+HARVEY,Lake Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000120
+HARVEY,Lake Township,Secretary of State,,Republican,"Kobach, Kris",53,000120
+HARVEY,Lakin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000130
+HARVEY,Lakin Township,Secretary of State,,Republican,"Kobach, Kris",77,000130
+HARVEY,Macon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",96,000140
+HARVEY,Macon Township,Secretary of State,,Republican,"Kobach, Kris",113,000140
+HARVEY,Newton City Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",160,000150
+HARVEY,Newton City Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",153,000150
+HARVEY,Newton City Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",123,000160
+HARVEY,Newton City Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",125,000160
+HARVEY,Newton City Ward 1 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,000170
+HARVEY,Newton City Ward 1 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",100,000170
+HARVEY,Newton City Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",143,000180
+HARVEY,Newton City Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",126,000180
+HARVEY,Newton City Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",349,00019A
+HARVEY,Newton City Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",389,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,000200
+HARVEY,Newton City Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",175,000200
+HARVEY,Newton City Ward 3 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",198,000210
+HARVEY,Newton City Ward 3 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",290,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",162,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Secretary of State,,Republican,"Kobach, Kris",251,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",193,000230
+HARVEY,Newton City Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",195,000230
+HARVEY,Newton City Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",367,000240
+HARVEY,Newton City Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",380,000240
+HARVEY,Newton City Ward 4 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",239,000250
+HARVEY,Newton City Ward 4 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",291,000250
+HARVEY,Newton City Ward 4 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,000260
+HARVEY,Newton City Ward 4 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",115,000260
+HARVEY,Newton Township Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,00027A
+HARVEY,Newton Township Part A,Secretary of State,,Republican,"Kobach, Kris",3,00027A
+HARVEY,Newton Township Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,00027B
+HARVEY,Newton Township Part B,Secretary of State,,Republican,"Kobach, Kris",99,00027B
+HARVEY,Newton Township Part B Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00027C
+HARVEY,Newton Township Part B Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00027C
+HARVEY,Newton Township Part C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,00027D
+HARVEY,Newton Township Part C,Secretary of State,,Republican,"Kobach, Kris",3,00027D
+HARVEY,North Newton City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",521,000280
+HARVEY,North Newton City,Secretary of State,,Republican,"Kobach, Kris",318,000280
+HARVEY,Pleasant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",85,000290
+HARVEY,Pleasant Township,Secretary of State,,Republican,"Kobach, Kris",163,000290
+HARVEY,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000300
+HARVEY,Richland Township,Secretary of State,,Republican,"Kobach, Kris",139,000300
+HARVEY,Sedgwick Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000310
+HARVEY,Sedgwick Township,Secretary of State,,Republican,"Kobach, Kris",81,000310
+HARVEY,Walton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000320
+HARVEY,Walton Township,Secretary of State,,Republican,"Kobach, Kris",66,000320
+HARVEY,Darlington Township H72,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,120020
+HARVEY,Darlington Township H72,Secretary of State,,Republican,"Kobach, Kris",41,120020
+HARVEY,Darlington Township H74,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,120030
+HARVEY,Darlington Township H74,Secretary of State,,Republican,"Kobach, Kris",124,120030
+HARVEY,Newton City Ward 3 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",341,800010
+HARVEY,Newton City Ward 3 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",543,800010
+HARVEY,Burrton City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,900010
+HARVEY,Burrton City,Secretary of State,,Republican,"Kobach, Kris",164,900010
+HARVEY,Sedgwick City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",165,900020
+HARVEY,Sedgwick City,Secretary of State,,Republican,"Kobach, Kris",303,900020
+HARVEY,Walton City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,900030
+HARVEY,Walton City,Secretary of State,,Republican,"Kobach, Kris",53,900030
+HARVEY,Burrton City Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+HARVEY,Burrton City Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900040
+HARVEY,Newton Township Part D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,900050
+HARVEY,Newton Township Part D,Secretary of State,,Republican,"Kobach, Kris",29,900050
+HARVEY,Newton Township Part E,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900060
+HARVEY,Newton Township Part E,Secretary of State,,Republican,"Kobach, Kris",1,900060
+HARVEY,Newton Township Part F,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900070
+HARVEY,Newton Township Part F,Secretary of State,,Republican,"Kobach, Kris",0,900070
+HARVEY,Newton Township Part G,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900080
+HARVEY,Newton Township Part G,Secretary of State,,Republican,"Kobach, Kris",0,900080
+HARVEY,Alta Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000010
+HARVEY,Alta Township,State Treasurer,,Republican,"Estes, Ron",79,000010
+HARVEY,Burrton Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000020
+HARVEY,Burrton Township,State Treasurer,,Republican,"Estes, Ron",67,000020
+HARVEY,Emma Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,000040
+HARVEY,Emma Township,State Treasurer,,Republican,"Estes, Ron",185,000040
+HARVEY,Garden Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000050
+HARVEY,Garden Township,State Treasurer,,Republican,"Estes, Ron",98,000050
+HARVEY,Halstead City Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",60,000060
+HARVEY,Halstead City Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",204,000060
+HARVEY,Halstead City Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",100,000070
+HARVEY,Halstead City Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",249,000070
+HARVEY,Halstead Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000080
+HARVEY,Halstead Township,State Treasurer,,Republican,"Estes, Ron",73,000080
+HARVEY,Hesston Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",183,000090
+HARVEY,Hesston Precinct 1,State Treasurer,,Republican,"Estes, Ron",479,000090
+HARVEY,Hesston Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",158,00010A
+HARVEY,Hesston Precinct 2,State Treasurer,,Republican,"Estes, Ron",509,00010A
+HARVEY,Highland Township,State Treasurer,,Democratic,"Alldritt, Carmen",49,000110
+HARVEY,Highland Township,State Treasurer,,Republican,"Estes, Ron",107,000110
+HARVEY,Lake Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000120
+HARVEY,Lake Township,State Treasurer,,Republican,"Estes, Ron",58,000120
+HARVEY,Lakin Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000130
+HARVEY,Lakin Township,State Treasurer,,Republican,"Estes, Ron",85,000130
+HARVEY,Macon Township,State Treasurer,,Democratic,"Alldritt, Carmen",59,000140
+HARVEY,Macon Township,State Treasurer,,Republican,"Estes, Ron",146,000140
+HARVEY,Newton City Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",125,000150
+HARVEY,Newton City Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",185,000150
+HARVEY,Newton City Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",92,000160
+HARVEY,Newton City Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",156,000160
+HARVEY,Newton City Ward 1 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",66,000170
+HARVEY,Newton City Ward 1 Precinct 3,State Treasurer,,Republican,"Estes, Ron",100,000170
+HARVEY,Newton City Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",109,000180
+HARVEY,Newton City Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",155,000180
+HARVEY,Newton City Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",266,00019A
+HARVEY,Newton City Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",458,00019A
+HARVEY,Newton City Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",112,000200
+HARVEY,Newton City Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",206,000200
+HARVEY,Newton City Ward 3 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",140,000210
+HARVEY,Newton City Ward 3 Precinct 2,State Treasurer,,Republican,"Estes, Ron",340,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",99,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,State Treasurer,,Republican,"Estes, Ron",301,00022A
+HARVEY,Newton City Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",135,000230
+HARVEY,Newton City Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",248,000230
+HARVEY,Newton City Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",246,000240
+HARVEY,Newton City Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",484,000240
+HARVEY,Newton City Ward 4 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",174,000250
+HARVEY,Newton City Ward 4 Precinct 3,State Treasurer,,Republican,"Estes, Ron",348,000250
+HARVEY,Newton City Ward 4 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",76,000260
+HARVEY,Newton City Ward 4 Precinct 4,State Treasurer,,Republican,"Estes, Ron",139,000260
+HARVEY,Newton Township Part A,State Treasurer,,Democratic,"Alldritt, Carmen",1,00027A
+HARVEY,Newton Township Part A,State Treasurer,,Republican,"Estes, Ron",3,00027A
+HARVEY,Newton Township Part B,State Treasurer,,Democratic,"Alldritt, Carmen",24,00027B
+HARVEY,Newton Township Part B,State Treasurer,,Republican,"Estes, Ron",111,00027B
+HARVEY,Newton Township Part B Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00027C
+HARVEY,Newton Township Part B Exclave,State Treasurer,,Republican,"Estes, Ron",0,00027C
+HARVEY,Newton Township Part C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00027D
+HARVEY,Newton Township Part C,State Treasurer,,Republican,"Estes, Ron",3,00027D
+HARVEY,North Newton City,State Treasurer,,Democratic,"Alldritt, Carmen",400,000280
+HARVEY,North Newton City,State Treasurer,,Republican,"Estes, Ron",410,000280
+HARVEY,Pleasant Township,State Treasurer,,Democratic,"Alldritt, Carmen",54,000290
+HARVEY,Pleasant Township,State Treasurer,,Republican,"Estes, Ron",187,000290
+HARVEY,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000300
+HARVEY,Richland Township,State Treasurer,,Republican,"Estes, Ron",157,000300
+HARVEY,Sedgwick Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000310
+HARVEY,Sedgwick Township,State Treasurer,,Republican,"Estes, Ron",100,000310
+HARVEY,Walton Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000320
+HARVEY,Walton Township,State Treasurer,,Republican,"Estes, Ron",80,000320
+HARVEY,Darlington Township H72,State Treasurer,,Democratic,"Alldritt, Carmen",13,120020
+HARVEY,Darlington Township H72,State Treasurer,,Republican,"Estes, Ron",45,120020
+HARVEY,Darlington Township H74,State Treasurer,,Democratic,"Alldritt, Carmen",36,120030
+HARVEY,Darlington Township H74,State Treasurer,,Republican,"Estes, Ron",136,120030
+HARVEY,Newton City Ward 3 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",238,800010
+HARVEY,Newton City Ward 3 Precinct 4,State Treasurer,,Republican,"Estes, Ron",630,800010
+HARVEY,Burrton City,State Treasurer,,Democratic,"Alldritt, Carmen",53,900010
+HARVEY,Burrton City,State Treasurer,,Republican,"Estes, Ron",182,900010
+HARVEY,Sedgwick City,State Treasurer,,Democratic,"Alldritt, Carmen",86,900020
+HARVEY,Sedgwick City,State Treasurer,,Republican,"Estes, Ron",375,900020
+HARVEY,Walton City,State Treasurer,,Democratic,"Alldritt, Carmen",19,900030
+HARVEY,Walton City,State Treasurer,,Republican,"Estes, Ron",63,900030
+HARVEY,Burrton City Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+HARVEY,Burrton City Exclave,State Treasurer,,Republican,"Estes, Ron",0,900040
+HARVEY,Newton Township Part D,State Treasurer,,Democratic,"Alldritt, Carmen",1,900050
+HARVEY,Newton Township Part D,State Treasurer,,Republican,"Estes, Ron",34,900050
+HARVEY,Newton Township Part E,State Treasurer,,Democratic,"Alldritt, Carmen",0,900060
+HARVEY,Newton Township Part E,State Treasurer,,Republican,"Estes, Ron",2,900060
+HARVEY,Newton Township Part F,State Treasurer,,Democratic,"Alldritt, Carmen",0,900070
+HARVEY,Newton Township Part F,State Treasurer,,Republican,"Estes, Ron",0,900070
+HARVEY,Newton Township Part G,State Treasurer,,Democratic,"Alldritt, Carmen",0,900080
+HARVEY,Newton Township Part G,State Treasurer,,Republican,"Estes, Ron",0,900080
+HARVEY,Alta Township,United States Senate,,independent,"Orman, Greg",40,000010
+HARVEY,Alta Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+HARVEY,Alta Township,United States Senate,,Republican,"Roberts, Pat",63,000010
+HARVEY,Burrton Township,United States Senate,,independent,"Orman, Greg",30,000020
+HARVEY,Burrton Township,United States Senate,,Libertarian,"Batson, Randall",5,000020
+HARVEY,Burrton Township,United States Senate,,Republican,"Roberts, Pat",51,000020
+HARVEY,Emma Township,United States Senate,,independent,"Orman, Greg",59,000040
+HARVEY,Emma Township,United States Senate,,Libertarian,"Batson, Randall",7,000040
+HARVEY,Emma Township,United States Senate,,Republican,"Roberts, Pat",155,000040
+HARVEY,Garden Township,United States Senate,,independent,"Orman, Greg",48,000050
+HARVEY,Garden Township,United States Senate,,Libertarian,"Batson, Randall",2,000050
+HARVEY,Garden Township,United States Senate,,Republican,"Roberts, Pat",82,000050
+HARVEY,Halstead City Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",90,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",12,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",163,000060
+HARVEY,Halstead City Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",140,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",11,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",204,000070
+HARVEY,Halstead Township,United States Senate,,independent,"Orman, Greg",49,000080
+HARVEY,Halstead Township,United States Senate,,Libertarian,"Batson, Randall",5,000080
+HARVEY,Halstead Township,United States Senate,,Republican,"Roberts, Pat",55,000080
+HARVEY,Hesston Precinct 1,United States Senate,,independent,"Orman, Greg",328,000090
+HARVEY,Hesston Precinct 1,United States Senate,,Libertarian,"Batson, Randall",18,000090
+HARVEY,Hesston Precinct 1,United States Senate,,Republican,"Roberts, Pat",344,000090
+HARVEY,Hesston Precinct 2,United States Senate,,independent,"Orman, Greg",271,00010A
+HARVEY,Hesston Precinct 2,United States Senate,,Libertarian,"Batson, Randall",18,00010A
+HARVEY,Hesston Precinct 2,United States Senate,,Republican,"Roberts, Pat",396,00010A
+HARVEY,Highland Township,United States Senate,,independent,"Orman, Greg",66,000110
+HARVEY,Highland Township,United States Senate,,Libertarian,"Batson, Randall",4,000110
+HARVEY,Highland Township,United States Senate,,Republican,"Roberts, Pat",90,000110
+HARVEY,Lake Township,United States Senate,,independent,"Orman, Greg",22,000120
+HARVEY,Lake Township,United States Senate,,Libertarian,"Batson, Randall",2,000120
+HARVEY,Lake Township,United States Senate,,Republican,"Roberts, Pat",41,000120
+HARVEY,Lakin Township,United States Senate,,independent,"Orman, Greg",22,000130
+HARVEY,Lakin Township,United States Senate,,Libertarian,"Batson, Randall",3,000130
+HARVEY,Lakin Township,United States Senate,,Republican,"Roberts, Pat",79,000130
+HARVEY,Macon Township,United States Senate,,independent,"Orman, Greg",90,000140
+HARVEY,Macon Township,United States Senate,,Libertarian,"Batson, Randall",11,000140
+HARVEY,Macon Township,United States Senate,,Republican,"Roberts, Pat",110,000140
+HARVEY,Newton City Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",166,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",17,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",131,000150
+HARVEY,Newton City Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",120,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",16,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",117,000160
+HARVEY,Newton City Ward 1 Precinct 3,United States Senate,,independent,"Orman, Greg",77,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",14,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States Senate,,Republican,"Roberts, Pat",82,000170
+HARVEY,Newton City Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",137,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",18,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",110,000180
+HARVEY,Newton City Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",365,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",20,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",348,00019A
+HARVEY,Newton City Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",148,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",23,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",152,000200
+HARVEY,Newton City Ward 3 Precinct 2,United States Senate,,independent,"Orman, Greg",215,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",15,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States Senate,,Republican,"Roberts, Pat",261,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States Senate,,independent,"Orman, Greg",170,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States Senate,,Libertarian,"Batson, Randall",19,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States Senate,,Republican,"Roberts, Pat",227,00022A
+HARVEY,Newton City Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",187,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",16,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",185,000230
+HARVEY,Newton City Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",369,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",30,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",350,000240
+HARVEY,Newton City Ward 4 Precinct 3,United States Senate,,independent,"Orman, Greg",244,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",33,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States Senate,,Republican,"Roberts, Pat",253,000250
+HARVEY,Newton City Ward 4 Precinct 4,United States Senate,,independent,"Orman, Greg",109,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",3,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States Senate,,Republican,"Roberts, Pat",111,000260
+HARVEY,Newton Township Part A,United States Senate,,independent,"Orman, Greg",42,00027A
+HARVEY,Newton Township Part A,United States Senate,,Libertarian,"Batson, Randall",4,00027A
+HARVEY,Newton Township Part A,United States Senate,,Republican,"Roberts, Pat",97,00027A
+HARVEY,Newton Township Part B,United States Senate,,independent,"Orman, Greg",1,00027B
+HARVEY,Newton Township Part B,United States Senate,,Libertarian,"Batson, Randall",0,00027B
+HARVEY,Newton Township Part B,United States Senate,,Republican,"Roberts, Pat",3,00027B
+HARVEY,Newton Township Part B Exclave,United States Senate,,independent,"Orman, Greg",0,00027C
+HARVEY,Newton Township Part B Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00027C
+HARVEY,Newton Township Part B Exclave,United States Senate,,Republican,"Roberts, Pat",0,00027C
+HARVEY,Newton Township Part C,United States Senate,,independent,"Orman, Greg",1,00027D
+HARVEY,Newton Township Part C,United States Senate,,Libertarian,"Batson, Randall",0,00027D
+HARVEY,Newton Township Part C,United States Senate,,Republican,"Roberts, Pat",3,00027D
+HARVEY,North Newton City,United States Senate,,independent,"Orman, Greg",539,000280
+HARVEY,North Newton City,United States Senate,,Libertarian,"Batson, Randall",14,000280
+HARVEY,North Newton City,United States Senate,,Republican,"Roberts, Pat",289,000280
+HARVEY,Pleasant Township,United States Senate,,independent,"Orman, Greg",84,000290
+HARVEY,Pleasant Township,United States Senate,,Libertarian,"Batson, Randall",2,000290
+HARVEY,Pleasant Township,United States Senate,,Republican,"Roberts, Pat",161,000290
+HARVEY,Richland Township,United States Senate,,independent,"Orman, Greg",43,000300
+HARVEY,Richland Township,United States Senate,,Libertarian,"Batson, Randall",2,000300
+HARVEY,Richland Township,United States Senate,,Republican,"Roberts, Pat",135,000300
+HARVEY,Sedgwick Township,United States Senate,,independent,"Orman, Greg",40,000310
+HARVEY,Sedgwick Township,United States Senate,,Libertarian,"Batson, Randall",7,000310
+HARVEY,Sedgwick Township,United States Senate,,Republican,"Roberts, Pat",79,000310
+HARVEY,Walton Township,United States Senate,,independent,"Orman, Greg",40,000320
+HARVEY,Walton Township,United States Senate,,Libertarian,"Batson, Randall",4,000320
+HARVEY,Walton Township,United States Senate,,Republican,"Roberts, Pat",64,000320
+HARVEY,Darlington Township H72,United States Senate,,independent,"Orman, Greg",20,120020
+HARVEY,Darlington Township H72,United States Senate,,Libertarian,"Batson, Randall",6,120020
+HARVEY,Darlington Township H72,United States Senate,,Republican,"Roberts, Pat",34,120020
+HARVEY,Darlington Township H74,United States Senate,,independent,"Orman, Greg",57,120030
+HARVEY,Darlington Township H74,United States Senate,,Libertarian,"Batson, Randall",0,120030
+HARVEY,Darlington Township H74,United States Senate,,Republican,"Roberts, Pat",116,120030
+HARVEY,Newton City Ward 3 Precinct 4,United States Senate,,independent,"Orman, Greg",355,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",18,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States Senate,,Republican,"Roberts, Pat",514,800010
+HARVEY,Burrton City,United States Senate,,independent,"Orman, Greg",82,900010
+HARVEY,Burrton City,United States Senate,,Libertarian,"Batson, Randall",15,900010
+HARVEY,Burrton City,United States Senate,,Republican,"Roberts, Pat",139,900010
+HARVEY,Sedgwick City,United States Senate,,independent,"Orman, Greg",150,900020
+HARVEY,Sedgwick City,United States Senate,,Libertarian,"Batson, Randall",24,900020
+HARVEY,Sedgwick City,United States Senate,,Republican,"Roberts, Pat",296,900020
+HARVEY,Walton City,United States Senate,,independent,"Orman, Greg",29,900030
+HARVEY,Walton City,United States Senate,,Libertarian,"Batson, Randall",4,900030
+HARVEY,Walton City,United States Senate,,Republican,"Roberts, Pat",50,900030
+HARVEY,Burrton City Exclave,United States Senate,,independent,"Orman, Greg",0,900040
+HARVEY,Burrton City Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900040
+HARVEY,Burrton City Exclave,United States Senate,,Republican,"Roberts, Pat",0,900040
+HARVEY,Newton Township Part D,United States Senate,,independent,"Orman, Greg",6,900050
+HARVEY,Newton Township Part D,United States Senate,,Libertarian,"Batson, Randall",1,900050
+HARVEY,Newton Township Part D,United States Senate,,Republican,"Roberts, Pat",28,900050
+HARVEY,Newton Township Part E,United States Senate,,independent,"Orman, Greg",0,900060
+HARVEY,Newton Township Part E,United States Senate,,Libertarian,"Batson, Randall",0,900060
+HARVEY,Newton Township Part E,United States Senate,,Republican,"Roberts, Pat",1,900060
+HARVEY,Newton Township Part F,United States Senate,,independent,"Orman, Greg",0,900070
+HARVEY,Newton Township Part F,United States Senate,,Libertarian,"Batson, Randall",0,900070
+HARVEY,Newton Township Part F,United States Senate,,Republican,"Roberts, Pat",0,900070
+HARVEY,Newton Township Part G,United States Senate,,independent,"Orman, Greg",0,900080
+HARVEY,Newton Township Part G,United States Senate,,Libertarian,"Batson, Randall",0,900080
+HARVEY,Newton Township Part G,United States Senate,,Republican,"Roberts, Pat",0,900080

--- a/2014/20141104__ks__general__haskell__precinct.csv
+++ b/2014/20141104__ks__general__haskell__precinct.csv
@@ -1,190 +1,190 @@
-county,precinct,office,district,party,candidate,total,polls,advance,hand,provisional
-Haskell,N Lockport,Attorney General,,D,A.J. Kotich,3,1,1,1,0
-Haskell,Sub 3 H124,Attorney General,,D,A.J. Kotich,20,14,3,1,2
-Haskell,Sat 2 H124,Attorney General,,D,A.J. Kotich,52,49,2,0,1
-Haskell,S Lockport,Attorney General,,D,A.J. Kotich,6,5,1,0,0
-Haskell,Ivanhoe,Attorney General,,D,A.J. Kotich,6,5,1,0,0
-Haskell,Sub 1 122,Attorney General,,D,A.J. Kotich,2,2,0,0,0
-Haskell,N Dudley,Attorney General,,D,A.J. Kotich,2,2,0,0,0
-Haskell,Sub 1 H124,Attorney General,,D,A.J. Kotich,31,20,9,1,1
-Haskell,Sat 1 124,Attorney General,,D,A.J. Kotich,11,9,0,0,2
-Haskell,Sub 3 122,Attorney General,,D,A.J. Kotich,0,0,0,0,0
-Haskell,Sat 2 122,Attorney General,,D,A.J. Kotich,2,1,1,0,0
-Haskell,N Lockport,Attorney General,,R,Derek Schmidt,48,31,9,4,4
-Haskell,Sub 3 H124,Attorney General,,R,Derek Schmidt,166,122,39,0,5
-Haskell,Sat 2 H124,Attorney General,,R,Derek Schmidt,206,175,20,0,11
-Haskell,S Lockport,Attorney General,,R,Derek Schmidt,33,31,2,0,0
-Haskell,Ivanhoe,Attorney General,,R,Derek Schmidt,41,32,9,0,0
-Haskell,Sub 1 122,Attorney General,,R,Derek Schmidt,17,17,0,0,0
-Haskell,N Dudley,Attorney General,,R,Derek Schmidt,45,38,7,0,0
-Haskell,Sub 1 H124,Attorney General,,R,Derek Schmidt,259,186,48,11,14
-Haskell,Sat 1 124,Attorney General,,R,Derek Schmidt,46,38,3,2,3
-Haskell,Sub 3 122,Attorney General,,R,Derek Schmidt,5,3,2,0,0
-Haskell,Sat 2 122,Attorney General,,R,Derek Schmidt,17,10,7,0,0
-Haskell,N Lockport,GOVERNOR,,L,Keen Umbehr,2,1,0,1,0
-Haskell,Sub 3 H124,GOVERNOR,,L,Keen Umbehr,6,6,0,0,0
-Haskell,Sat 2 H124,GOVERNOR,,L,Keen Umbehr,10,9,1,0,0
-Haskell,S Lockport,GOVERNOR,,L,Keen Umbehr,1,0,1,0,0
-Haskell,Ivanhoe,GOVERNOR,,L,Keen Umbehr,1,1,0,0,0
-Haskell,Sub 1 122,GOVERNOR,,L,Keen Umbehr,2,2,0,0,0
-Haskell,N Dudley,GOVERNOR,,L,Keen Umbehr,1,1,0,0,0
-Haskell,Sub 1 H124,GOVERNOR,,L,Keen Umbehr,12,8,3,0,1
-Haskell,Sat 1 124,GOVERNOR,,L,Keen Umbehr,1,0,0,0,1
-Haskell,Sub 3 122,GOVERNOR,,L,Keen Umbehr,0,0,0,0,0
-Haskell,Sat 2 122,GOVERNOR,,L,Keen Umbehr,0,0,0,0,0
-Haskell,N Lockport,GOVERNOR,,D,Paul Davis,8,3,4,1,0
-Haskell,Sub 3 H124,GOVERNOR,,D,Paul Davis,39,30,6,0,3
-Haskell,Sat 2 H124,GOVERNOR,,D,Paul Davis,93,85,6,0,2
-Haskell,S Lockport,GOVERNOR,,D,Paul Davis,9,8,1,0,0
-Haskell,Ivanhoe,GOVERNOR,,D,Paul Davis,7,4,3,0,0
-Haskell,Sub 1 122,GOVERNOR,,D,Paul Davis,2,2,0,0,0
-Haskell,N Dudley,GOVERNOR,,D,Paul Davis,6,6,0,0,0
-Haskell,Sub 1 H124,GOVERNOR,,D,Paul Davis,61,47,11,1,2
-Haskell,Sat 1 124,GOVERNOR,,D,Paul Davis,11,10,0,0,1
-Haskell,Sub 3 122,GOVERNOR,,D,Paul Davis,3,1,2,0,0
-Haskell,Sat 2 122,GOVERNOR,,D,Paul Davis,3,2,1,0,0
-Haskell,N Lockport,GOVERNOR,,R,Sam Brownback,43,29,7,3,4
-Haskell,Sub 3 H124,GOVERNOR,,R,Sam Brownback,147,105,37,1,4
-Haskell,Sat 2 H124,GOVERNOR,,R,Sam Brownback,160,135,15,0,10
-Haskell,S Lockport,GOVERNOR,,R,Sam Brownback,34,33,1,0,0
-Haskell,Ivanhoe,GOVERNOR,,R,Sam Brownback,41,34,7,0,0
-Haskell,Sub 1 122,GOVERNOR,,R,Sam Brownback,15,15,0,0,0
-Haskell,N Dudley,GOVERNOR,,R,Sam Brownback,40,33,7,0,0
-Haskell,Sub 1 H124,GOVERNOR,,R,Sam Brownback,229,160,46,11,12
-Haskell,Sat 1 124,GOVERNOR,,R,Sam Brownback,47,39,3,2,3
-Haskell,Sub 3 122,GOVERNOR,,R,Sam Brownback,2,2,0,0,0
-Haskell,Sat 2 122,GOVERNOR,,R,Sam Brownback,16,9,7,0,0
-Haskell,N Lockport,State House,115,D,Mark Low,2,1,0,1,0
-Haskell,S Lockport,State House,115,D,Mark Low,8,7,1,0,0
-Haskell,N Lockport,State House,115,R,Ron Ryckman,50,31,11,4,4
-Haskell,S Lockport,State House,115,R,Ron Ryckman,35,33,2,0,0
-Haskell,Ivanhoe,State House,122,R,Russell Jennings,46,37,9,0,0
-Haskell,Sub 1 122,State House,122,R,Russell Jennings,15,15,0,0,0
-Haskell,N Dudley,State House,122,R,Russell Jennings,42,38,4,0,0
-Haskell,Sub 3 122,State House,122,R,Russell Jennings,4,2,2,0,0
-Haskell,Sat 2 122,State House,122,R,Russell Jennings,15,8,7,0,0
-Haskell,Sub 3 H124,State House,124,R,Stephen Alford,167,123,36,1,7
-Haskell,Sat 2 H124,State House,124,R,Stephen Alford,243,211,20,0,12
-Haskell,Sub 1 H124,State House,124,R,Stephen Alford,250,187,48,2,13
-Haskell,Sat 1 124,State House,124,R,Stephen Alford,49,41,3,0,5
-Haskell,N Lockport,Insurance Commissioner,,D,Dennis Anderson,3,0,1,2,0
-Haskell,Sub 3 H124,Insurance Commissioner,,D,Dennis Anderson,20,15,4,0,1
-Haskell,Sat 2 H124,Insurance Commissioner,,D,Dennis Anderson,61,58,2,0,1
-Haskell,S Lockport,Insurance Commissioner,,D,Dennis Anderson,10,9,1,0,0
-Haskell,Ivanhoe,Insurance Commissioner,,D,Dennis Anderson,9,6,3,0,0
-Haskell,Sub 1 122,Insurance Commissioner,,D,Dennis Anderson,2,2,0,0,0
-Haskell,N Dudley,Insurance Commissioner,,D,Dennis Anderson,3,3,0,0,0
-Haskell,Sub 1 H124,Insurance Commissioner,,D,Dennis Anderson,34,21,11,1,1
-Haskell,Sat 1 124,Insurance Commissioner,,D,Dennis Anderson,11,9,1,0,1
-Haskell,Sub 3 122,Insurance Commissioner,,D,Dennis Anderson,0,0,0,0,0
-Haskell,Sat 2 122,Insurance Commissioner,,D,Dennis Anderson,1,1,0,0,0
-Haskell,N Lockport,Insurance Commissioner,,R,Ken Selzer,48,32,9,3,4
-Haskell,Sub 3 H124,Insurance Commissioner,,R,Ken Selzer,160,116,37,1,6
-Haskell,Sat 2 H124,Insurance Commissioner,,R,Ken Selzer,190,160,19,0,11
-Haskell,S Lockport,Insurance Commissioner,,R,Ken Selzer,29,27,2,0,0
-Haskell,Ivanhoe,Insurance Commissioner,,R,Ken Selzer,38,32,6,0,0
-Haskell,Sub 1 122,Insurance Commissioner,,R,Ken Selzer,17,17,0,0,0
-Haskell,N Dudley,Insurance Commissioner,,R,Ken Selzer,41,34,7,0,0
-Haskell,Sub 1 H124,Insurance Commissioner,,R,Ken Selzer,251,180,45,12,14
-Haskell,Sat 1 124,Insurance Commissioner,,R,Ken Selzer,45,37,2,2,4
-Haskell,Sub 3 122,Insurance Commissioner,,R,Ken Selzer,4,2,2,0,0
-Haskell,Sat 2 122,Insurance Commissioner,,R,Ken Selzer,18,10,8,0,0
-Haskell,N Lockport,Secretary of State,,D,Jean Kurtis Schodorf,5,2,2,1,0
-Haskell,Sub 3 H124,Secretary of State,,D,Jean Kurtis Schodorf,25,20,4,0,1
-Haskell,Sat 2 H124,Secretary of State,,D,Jean Kurtis Schodorf,70,65,2,0,3
-Haskell,S Lockport,Secretary of State,,D,Jean Kurtis Schodorf,7,6,1,0,0
-Haskell,Ivanhoe,Secretary of State,,D,Jean Kurtis Schodorf,8,5,3,0,0
-Haskell,Sub 1 122,Secretary of State,,D,Jean Kurtis Schodorf,5,5,0,0,0
-Haskell,N Dudley,Secretary of State,,D,Jean Kurtis Schodorf,6,6,0,0,0
-Haskell,Sub 1 H124,Secretary of State,,D,Jean Kurtis Schodorf,52,37,11,2,2
-Haskell,Sat 1 124,Secretary of State,,D,Jean Kurtis Schodorf,9,7,0,0,2
-Haskell,Sub 3 122,Secretary of State,,D,Jean Kurtis Schodorf,1,1,0,0,0
-Haskell,Sat 2 122,Secretary of State,,D,Jean Kurtis Schodorf,2,2,0,0,0
-Haskell,N Lockport,Secretary of State,,R,Kris Kobach,46,31,7,4,4
-Haskell,Sub 3 H124,Secretary of State,,R,Kris Kobach,163,118,38,1,6
-Haskell,Sat 2 H124,Secretary of State,,R,Kris Kobach,191,161,21,0,9
-Haskell,S Lockport,Secretary of State,,R,Kris Kobach,37,35,2,0,0
-Haskell,Ivanhoe,Secretary of State,,R,Kris Kobach,41,34,7,0,0
-Haskell,Sub 1 122,Secretary of State,,R,Kris Kobach,14,14,0,0,0
-Haskell,N Dudley,Secretary of State,,R,Kris Kobach,41,34,7,0,0
-Haskell,Sub 1 H124,Secretary of State,,R,Kris Kobach,246,173,49,11,13
-Haskell,Sat 1 124,Secretary of State,,R,Kris Kobach,46,39,3,1,3
-Haskell,Sub 3 122,Secretary of State,,R,Kris Kobach,4,2,2,0,0
-Haskell,Sat 2 122,Secretary of State,,R,Kris Kobach,17,9,8,0,0
-Haskell,N Lockport,State Treasurer,,D,Carmen Alldritt,3,1,1,1,0
-Haskell,Sub 3 H124,State Treasurer,,D,Carmen Alldritt,12,8,3,0,1
-Haskell,Sat 2 H124,State Treasurer,,D,Carmen Alldritt,39,37,1,0,1
-Haskell,S Lockport,State Treasurer,,D,Carmen Alldritt,6,5,1,0,0
-Haskell,Ivanhoe,State Treasurer,,D,Carmen Alldritt,7,5,2,0,0
-Haskell,Sub 1 122,State Treasurer,,D,Carmen Alldritt,2,2,0,0,0
-Haskell,N Dudley,State Treasurer,,D,Carmen Alldritt,3,3,0,0,0
-Haskell,Sub 1 H124,State Treasurer,,D,Carmen Alldritt,27,17,5,3,2
-Haskell,Sat 1 124,State Treasurer,,D,Carmen Alldritt,8,7,0,0,1
-Haskell,Sub 3 122,State Treasurer,,D,Carmen Alldritt,2,0,2,0,0
-Haskell,Sat 2 122,State Treasurer,,D,Carmen Alldritt,1,1,0,0,0
-Haskell,N Lockport,State Treasurer,,R,Ron Estes,47,31,8,4,4
-Haskell,Sub 3 H124,State Treasurer,,R,Ron Estes,171,124,40,1,6
-Haskell,Sat 2 H124,State Treasurer,,R,Ron Estes,220,188,21,0,11
-Haskell,S Lockport,State Treasurer,,R,Ron Estes,36,34,2,0,0
-Haskell,Ivanhoe,State Treasurer,,R,Ron Estes,42,34,8,0,0
-Haskell,Sub 1 122,State Treasurer,,R,Ron Estes,17,17,0,0,0
-Haskell,N Dudley,State Treasurer,,R,Ron Estes,44,37,7,0,0
-Haskell,Sub 1 H124,State Treasurer,,R,Ron Estes,271,193,55,10,13
-Haskell,Sat 1 124,State Treasurer,,R,Ron Estes,50,41,3,2,4
-Haskell,Sub 3 122,State Treasurer,,R,Ron Estes,3,3,0,0,0
-Haskell,Sat 2 122,State Treasurer,,R,Ron Estes,18,10,8,0,0
-Haskell,N Lockport,U.S. House,1,D,James E Sherow,7,1,4,2,0
-Haskell,Sub 3 H124,U.S. House,1,D,James E Sherow,33,26,6,0,1
-Haskell,Sat 2 H124,U.S. House,1,D,James E Sherow,77,73,2,0,2
-Haskell,S Lockport,U.S. House,1,D,James E Sherow,5,4,1,0,0
-Haskell,Ivanhoe,U.S. House,1,D,James E Sherow,13,9,4,0,0
-Haskell,Sub 1 122,U.S. House,1,D,James E Sherow,3,3,0,0,0
-Haskell,N Dudley,U.S. House,1,D,James E Sherow,7,7,0,0,0
-Haskell,Sub 1 H124,U.S. House,1,D,James E Sherow,53,39,12,1,1
-Haskell,Sat 1 124,U.S. House,1,D,James E Sherow,10,8,0,0,2
-Haskell,Sub 3 122,U.S. House,1,D,James E Sherow,1,1,0,0,0
-Haskell,Sat 2 122,U.S. House,1,D,James E Sherow,1,1,0,0,0
-Haskell,N Lockport,U.S. House,1,R,Tim Huelskamp,45,31,7,3,4
-Haskell,Sub 3 H124,U.S. House,1,R,Tim Huelskamp,156,112,37,1,6
-Haskell,Sat 2 H124,U.S. House,1,R,Tim Huelskamp,184,154,20,0,10
-Haskell,S Lockport,U.S. House,1,R,Tim Huelskamp,39,37,2,0,0
-Haskell,Ivanhoe,U.S. House,1,R,Tim Huelskamp,36,30,6,0,0
-Haskell,Sub 1 122,U.S. House,1,R,Tim Huelskamp,16,16,0,0,0
-Haskell,N Dudley,U.S. House,1,R,Tim Huelskamp,39,32,7,0,0
-Haskell,Sub 1 H124,U.S. House,1,R,Tim Huelskamp,247,172,50,11,14
-Haskell,Sat 1 124,U.S. House,1,R,Tim Huelskamp,49,41,3,2,3
-Haskell,Sub 3 122,U.S. House,1,R,Tim Huelskamp,4,2,2,0,0
-Haskell,Sat 2 122,U.S. House,1,R,Tim Huelskamp,18,10,8,0,0
-Haskell,N Lockport,U.S. Senate,,I,Greg Orman,4,0,3,1,0
-Haskell,Sub 3 H124,U.S. Senate,,I,Greg Orman,33,24,6,0,3
-Haskell,Sat 2 H124,U.S. Senate,,I,Greg Orman,67,60,6,0,1
-Haskell,S Lockport,U.S. Senate,,I,Greg Orman,8,7,1,0,0
-Haskell,Ivanhoe,U.S. Senate,,I,Greg Orman,7,4,3,0,0
-Haskell,Sub 1 122,U.S. Senate,,I,Greg Orman,2,2,0,0,0
-Haskell,N Dudley,U.S. Senate,,I,Greg Orman,5,4,1,0,0
-Haskell,Sub 1 H124,U.S. Senate,,I,Greg Orman,50,34,13,2,1
-Haskell,Sat 1 124,U.S. Senate,,I,Greg Orman,7,6,0,0,1
-Haskell,Sub 3 122,U.S. Senate,,I,Greg Orman,3,1,2,0,0
-Haskell,Sat 2 122,U.S. Senate,,I,Greg Orman,1,1,0,0,0
-Haskell,N Lockport,U.S. Senate,,R,Pat Roberts,49,33,8,4,4
-Haskell,Sub 3 H124,U.S. Senate,,R,Pat Roberts,154,113,36,1,4
-Haskell,Sat 2 H124,U.S. Senate,,R,Pat Roberts,186,161,17,0,8
-Haskell,S Lockport,U.S. Senate,,R,Pat Roberts,34,33,1,0,0
-Haskell,Ivanhoe,U.S. Senate,,R,Pat Roberts,41,34,7,0,0
-Haskell,Sub 1 122,U.S. Senate,,R,Pat Roberts,16,16,0,0,0
-Haskell,N Dudley,U.S. Senate,,R,Pat Roberts,41,35,6,0,0
-Haskell,Sub 1 H124,U.S. Senate,,R,Pat Roberts,243,175,45,10,13
-Haskell,Sat 1 124,U.S. Senate,,R,Pat Roberts,47,39,3,2,3
-Haskell,Sub 3 122,U.S. Senate,,R,Pat Roberts,1,1,0,0,0
-Haskell,Sat 2 122,U.S. Senate,,R,Pat Roberts,17,9,8,0,0
-Haskell,N Lockport,U.S. Senate,,L,Randall Batson,0,0,0,0,0
-Haskell,Sub 3 H124,U.S. Senate,,L,Randall Batson,5,4,1,0,0
-Haskell,Sat 2 H124,U.S. Senate,,L,Randall Batson,11,8,0,0,3
-Haskell,S Lockport,U.S. Senate,,L,Randall Batson,3,2,1,0,0
-Haskell,Ivanhoe,U.S. Senate,,L,Randall Batson,0,0,0,0,0
-Haskell,Sub 1 122,U.S. Senate,,L,Randall Batson,2,2,0,0,0
-Haskell,N Dudley,U.S. Senate,,L,Randall Batson,0,0,0,0,0
-Haskell,Sub 1 H124,U.S. Senate,,L,Randall Batson,8,5,1,1,1
-Haskell,Sat 1 124,U.S. Senate,,L,Randall Batson,4,3,0,0,1
-Haskell,Sub 3 122,U.S. Senate,,L,Randall Batson,1,1,0,0,0
-Haskell,Sat 2 122,U.S. Senate,,L,Randall Batson,1,1,0,0,0
+county,precinct,office,district,party,candidate,votes,vtd
+HASKELL,Ivanhoe Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000010
+HASKELL,Ivanhoe Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+HASKELL,Ivanhoe Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000010
+HASKELL,North Dudley,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000020
+HASKELL,North Dudley,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+HASKELL,North Dudley,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000020
+HASKELL,North Lockport,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+HASKELL,North Lockport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000030
+HASKELL,North Lockport,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000030
+HASKELL,Satanta 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000040
+HASKELL,Satanta 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+HASKELL,Satanta 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,000040
+HASKELL,South Lockport,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000060
+HASKELL,South Lockport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+HASKELL,South Lockport,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000060
+HASKELL,Satanta 2 H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,120020
+HASKELL,Satanta 2 H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120020
+HASKELL,Satanta 2 H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,120020
+HASKELL,Satanta 2 H124,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,120030
+HASKELL,Satanta 2 H124,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,120030
+HASKELL,Satanta 2 H124,Governor / Lt. Governor,,Republican,"Brownback, Sam",160,120030
+HASKELL,Sublette 1 H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,120040
+HASKELL,Sublette 1 H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120040
+HASKELL,Sublette 1 H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,120040
+HASKELL,Sublette 1 H124,Governor / Lt. Governor,,Democratic,"Davis, Paul",61,120050
+HASKELL,Sublette 1 H124,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,120050
+HASKELL,Sublette 1 H124,Governor / Lt. Governor,,Republican,"Brownback, Sam",229,120050
+HASKELL,Sublette 3 H122,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,120060
+HASKELL,Sublette 3 H122,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120060
+HASKELL,Sublette 3 H122,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,120060
+HASKELL,Sublette 3 H124,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,120070
+HASKELL,Sublette 3 H124,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120070
+HASKELL,Sublette 3 H124,Governor / Lt. Governor,,Republican,"Brownback, Sam",147,120070
+HASKELL,Ivanhoe Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",46,000010
+HASKELL,North Dudley,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",42,000020
+HASKELL,North Lockport,Kansas House of Representatives,115,Democratic,"Low, Mark",2,000030
+HASKELL,North Lockport,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",50,000030
+HASKELL,Satanta 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",49,000040
+HASKELL,South Lockport,Kansas House of Representatives,115,Democratic,"Low, Mark",8,000060
+HASKELL,South Lockport,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",35,000060
+HASKELL,Satanta 2 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",15,120020
+HASKELL,Satanta 2 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",243,120030
+HASKELL,Sublette 1 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",15,120040
+HASKELL,Sublette 1 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",250,120050
+HASKELL,Sublette 3 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",4,120060
+HASKELL,Sublette 3 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",167,120070
+HASKELL,Ivanhoe Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000010
+HASKELL,Ivanhoe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000010
+HASKELL,North Dudley,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000020
+HASKELL,North Dudley,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000020
+HASKELL,North Lockport,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000030
+HASKELL,North Lockport,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000030
+HASKELL,Satanta 1,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000040
+HASKELL,Satanta 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000040
+HASKELL,South Lockport,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000060
+HASKELL,South Lockport,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000060
+HASKELL,Satanta 2 H122,United States House of Representatives,1,Democratic,"Sherow, James E.",1,120020
+HASKELL,Satanta 2 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,120020
+HASKELL,Satanta 2 H124,United States House of Representatives,1,Democratic,"Sherow, James E.",77,120030
+HASKELL,Satanta 2 H124,United States House of Representatives,1,Republican,"Huelskamp, Tim",184,120030
+HASKELL,Sublette 1 H122,United States House of Representatives,1,Democratic,"Sherow, James E.",3,120040
+HASKELL,Sublette 1 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,120040
+HASKELL,Sublette 1 H124,United States House of Representatives,1,Democratic,"Sherow, James E.",53,120050
+HASKELL,Sublette 1 H124,United States House of Representatives,1,Republican,"Huelskamp, Tim",247,120050
+HASKELL,Sublette 3 H122,United States House of Representatives,1,Democratic,"Sherow, James E.",1,120060
+HASKELL,Sublette 3 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,120060
+HASKELL,Sublette 3 H124,United States House of Representatives,1,Democratic,"Sherow, James E.",33,120070
+HASKELL,Sublette 3 H124,United States House of Representatives,1,Republican,"Huelskamp, Tim",156,120070
+HASKELL,Ivanhoe Township,Attorney General,,Democratic,"Kotich, A.J.",6,000010
+HASKELL,Ivanhoe Township,Attorney General,,Republican,"Schmidt, Derek",41,000010
+HASKELL,North Dudley,Attorney General,,Democratic,"Kotich, A.J.",2,000020
+HASKELL,North Dudley,Attorney General,,Republican,"Schmidt, Derek",45,000020
+HASKELL,North Lockport,Attorney General,,Democratic,"Kotich, A.J.",3,000030
+HASKELL,North Lockport,Attorney General,,Republican,"Schmidt, Derek",48,000030
+HASKELL,Satanta 1,Attorney General,,Democratic,"Kotich, A.J.",11,000040
+HASKELL,Satanta 1,Attorney General,,Republican,"Schmidt, Derek",46,000040
+HASKELL,South Lockport,Attorney General,,Democratic,"Kotich, A.J.",6,000060
+HASKELL,South Lockport,Attorney General,,Republican,"Schmidt, Derek",33,000060
+HASKELL,Satanta 2 H122,Attorney General,,Democratic,"Kotich, A.J.",2,120020
+HASKELL,Satanta 2 H122,Attorney General,,Republican,"Schmidt, Derek",17,120020
+HASKELL,Satanta 2 H124,Attorney General,,Democratic,"Kotich, A.J.",52,120030
+HASKELL,Satanta 2 H124,Attorney General,,Republican,"Schmidt, Derek",206,120030
+HASKELL,Sublette 1 H122,Attorney General,,Democratic,"Kotich, A.J.",2,120040
+HASKELL,Sublette 1 H122,Attorney General,,Republican,"Schmidt, Derek",17,120040
+HASKELL,Sublette 1 H124,Attorney General,,Democratic,"Kotich, A.J.",31,120050
+HASKELL,Sublette 1 H124,Attorney General,,Republican,"Schmidt, Derek",259,120050
+HASKELL,Sublette 3 H122,Attorney General,,Democratic,"Kotich, A.J.",0,120060
+HASKELL,Sublette 3 H122,Attorney General,,Republican,"Schmidt, Derek",5,120060
+HASKELL,Sublette 3 H124,Attorney General,,Democratic,"Kotich, A.J.",20,120070
+HASKELL,Sublette 3 H124,Attorney General,,Republican,"Schmidt, Derek",166,120070
+HASKELL,Ivanhoe Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000010
+HASKELL,Ivanhoe Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000010
+HASKELL,North Dudley,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000020
+HASKELL,North Dudley,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000020
+HASKELL,North Lockport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000030
+HASKELL,North Lockport,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000030
+HASKELL,Satanta 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000040
+HASKELL,Satanta 1,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000040
+HASKELL,South Lockport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000060
+HASKELL,South Lockport,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000060
+HASKELL,Satanta 2 H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,120020
+HASKELL,Satanta 2 H122,Commissioner of Insurance,,Republican,"Selzer, Ken",18,120020
+HASKELL,Satanta 2 H124,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,120030
+HASKELL,Satanta 2 H124,Commissioner of Insurance,,Republican,"Selzer, Ken",190,120030
+HASKELL,Sublette 1 H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,120040
+HASKELL,Sublette 1 H122,Commissioner of Insurance,,Republican,"Selzer, Ken",17,120040
+HASKELL,Sublette 1 H124,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,120050
+HASKELL,Sublette 1 H124,Commissioner of Insurance,,Republican,"Selzer, Ken",251,120050
+HASKELL,Sublette 3 H122,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120060
+HASKELL,Sublette 3 H122,Commissioner of Insurance,,Republican,"Selzer, Ken",4,120060
+HASKELL,Sublette 3 H124,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,120070
+HASKELL,Sublette 3 H124,Commissioner of Insurance,,Republican,"Selzer, Ken",160,120070
+HASKELL,Ivanhoe Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000010
+HASKELL,Ivanhoe Township,Secretary of State,,Republican,"Kobach, Kris",41,000010
+HASKELL,North Dudley,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000020
+HASKELL,North Dudley,Secretary of State,,Republican,"Kobach, Kris",41,000020
+HASKELL,North Lockport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000030
+HASKELL,North Lockport,Secretary of State,,Republican,"Kobach, Kris",46,000030
+HASKELL,Satanta 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000040
+HASKELL,Satanta 1,Secretary of State,,Republican,"Kobach, Kris",46,000040
+HASKELL,South Lockport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000060
+HASKELL,South Lockport,Secretary of State,,Republican,"Kobach, Kris",37,000060
+HASKELL,Satanta 2 H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,120020
+HASKELL,Satanta 2 H122,Secretary of State,,Republican,"Kobach, Kris",17,120020
+HASKELL,Satanta 2 H124,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,120030
+HASKELL,Satanta 2 H124,Secretary of State,,Republican,"Kobach, Kris",191,120030
+HASKELL,Sublette 1 H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,120040
+HASKELL,Sublette 1 H122,Secretary of State,,Republican,"Kobach, Kris",14,120040
+HASKELL,Sublette 1 H124,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,120050
+HASKELL,Sublette 1 H124,Secretary of State,,Republican,"Kobach, Kris",246,120050
+HASKELL,Sublette 3 H122,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,120060
+HASKELL,Sublette 3 H122,Secretary of State,,Republican,"Kobach, Kris",4,120060
+HASKELL,Sublette 3 H124,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,120070
+HASKELL,Sublette 3 H124,Secretary of State,,Republican,"Kobach, Kris",163,120070
+HASKELL,Ivanhoe Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000010
+HASKELL,Ivanhoe Township,State Treasurer,,Republican,"Estes, Ron",42,000010
+HASKELL,North Dudley,State Treasurer,,Democratic,"Alldritt, Carmen",3,000020
+HASKELL,North Dudley,State Treasurer,,Republican,"Estes, Ron",44,000020
+HASKELL,North Lockport,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+HASKELL,North Lockport,State Treasurer,,Republican,"Estes, Ron",47,000030
+HASKELL,Satanta 1,State Treasurer,,Democratic,"Alldritt, Carmen",8,000040
+HASKELL,Satanta 1,State Treasurer,,Republican,"Estes, Ron",50,000040
+HASKELL,South Lockport,State Treasurer,,Democratic,"Alldritt, Carmen",6,000060
+HASKELL,South Lockport,State Treasurer,,Republican,"Estes, Ron",36,000060
+HASKELL,Satanta 2 H122,State Treasurer,,Democratic,"Alldritt, Carmen",1,120020
+HASKELL,Satanta 2 H122,State Treasurer,,Republican,"Estes, Ron",18,120020
+HASKELL,Satanta 2 H124,State Treasurer,,Democratic,"Alldritt, Carmen",39,120030
+HASKELL,Satanta 2 H124,State Treasurer,,Republican,"Estes, Ron",220,120030
+HASKELL,Sublette 1 H122,State Treasurer,,Democratic,"Alldritt, Carmen",2,120040
+HASKELL,Sublette 1 H122,State Treasurer,,Republican,"Estes, Ron",17,120040
+HASKELL,Sublette 1 H124,State Treasurer,,Democratic,"Alldritt, Carmen",27,120050
+HASKELL,Sublette 1 H124,State Treasurer,,Republican,"Estes, Ron",271,120050
+HASKELL,Sublette 3 H122,State Treasurer,,Democratic,"Alldritt, Carmen",2,120060
+HASKELL,Sublette 3 H122,State Treasurer,,Republican,"Estes, Ron",3,120060
+HASKELL,Sublette 3 H124,State Treasurer,,Democratic,"Alldritt, Carmen",12,120070
+HASKELL,Sublette 3 H124,State Treasurer,,Republican,"Estes, Ron",171,120070
+HASKELL,Ivanhoe Township,United States Senate,,independent,"Orman, Greg",7,000010
+HASKELL,Ivanhoe Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+HASKELL,Ivanhoe Township,United States Senate,,Republican,"Roberts, Pat",41,000010
+HASKELL,North Dudley,United States Senate,,independent,"Orman, Greg",5,000020
+HASKELL,North Dudley,United States Senate,,Libertarian,"Batson, Randall",0,000020
+HASKELL,North Dudley,United States Senate,,Republican,"Roberts, Pat",41,000020
+HASKELL,North Lockport,United States Senate,,independent,"Orman, Greg",4,000030
+HASKELL,North Lockport,United States Senate,,Libertarian,"Batson, Randall",0,000030
+HASKELL,North Lockport,United States Senate,,Republican,"Roberts, Pat",49,000030
+HASKELL,Satanta 1,United States Senate,,independent,"Orman, Greg",7,000040
+HASKELL,Satanta 1,United States Senate,,Libertarian,"Batson, Randall",4,000040
+HASKELL,Satanta 1,United States Senate,,Republican,"Roberts, Pat",47,000040
+HASKELL,South Lockport,United States Senate,,independent,"Orman, Greg",8,000060
+HASKELL,South Lockport,United States Senate,,Libertarian,"Batson, Randall",3,000060
+HASKELL,South Lockport,United States Senate,,Republican,"Roberts, Pat",34,000060
+HASKELL,Satanta 2 H122,United States Senate,,independent,"Orman, Greg",1,120020
+HASKELL,Satanta 2 H122,United States Senate,,Libertarian,"Batson, Randall",1,120020
+HASKELL,Satanta 2 H122,United States Senate,,Republican,"Roberts, Pat",17,120020
+HASKELL,Satanta 2 H124,United States Senate,,independent,"Orman, Greg",67,120030
+HASKELL,Satanta 2 H124,United States Senate,,Libertarian,"Batson, Randall",11,120030
+HASKELL,Satanta 2 H124,United States Senate,,Republican,"Roberts, Pat",186,120030
+HASKELL,Sublette 1 H122,United States Senate,,independent,"Orman, Greg",2,120040
+HASKELL,Sublette 1 H122,United States Senate,,Libertarian,"Batson, Randall",2,120040
+HASKELL,Sublette 1 H122,United States Senate,,Republican,"Roberts, Pat",16,120040
+HASKELL,Sublette 1 H124,United States Senate,,independent,"Orman, Greg",50,120050
+HASKELL,Sublette 1 H124,United States Senate,,Libertarian,"Batson, Randall",8,120050
+HASKELL,Sublette 1 H124,United States Senate,,Republican,"Roberts, Pat",243,120050
+HASKELL,Sublette 3 H122,United States Senate,,independent,"Orman, Greg",3,120060
+HASKELL,Sublette 3 H122,United States Senate,,Libertarian,"Batson, Randall",1,120060
+HASKELL,Sublette 3 H122,United States Senate,,Republican,"Roberts, Pat",1,120060
+HASKELL,Sublette 3 H124,United States Senate,,independent,"Orman, Greg",33,120070
+HASKELL,Sublette 3 H124,United States Senate,,Libertarian,"Batson, Randall",5,120070
+HASKELL,Sublette 3 H124,United States Senate,,Republican,"Roberts, Pat",154,120070

--- a/2014/20141104__ks__general__hodgeman__precinct.csv
+++ b/2014/20141104__ks__general__hodgeman__precinct.csv
@@ -1,191 +1,188 @@
-county,precinct,office,district,party,candidate,total
-Hodgeman,Benton,U.S. Senate,,R,Pat Roberts,27
-Hodgeman,N Center,U.S. Senate,,R,Pat Roberts,156
-Hodgeman,S Center,U.S. Senate,,R,Pat Roberts,136
-Hodgeman,Marena,U.S. Senate,,R,Pat Roberts,101
-Hodgeman,N Hallet,U.S. Senate,,R,Pat Roberts,3
-Hodgeman,N Roscoe,U.S. Senate,,R,Pat Roberts,24
-Hodgeman,Sawlog,U.S. Senate,,R,Pat Roberts,31
-Hodgeman,S Hallet,U.S. Senate,,R,Pat Roberts,15
-Hodgeman,S Roscoe,U.S. Senate,,R,Pat Roberts,25
-Hodgeman,Sterling,U.S. Senate,,R,Pat Roberts,46
-Hodgeman,Valley,U.S. Senate,,R,Pat Roberts,17
-Hodgeman,Benton,U.S. Senate,,I,Greg Orman,2
-Hodgeman,N Center,U.S. Senate,,I,Greg Orman,62
-Hodgeman,S Center,U.S. Senate,,I,Greg Orman,48
-Hodgeman,Marena,U.S. Senate,,I,Greg Orman,31
-Hodgeman,N Hallet,U.S. Senate,,I,Greg Orman,1
-Hodgeman,N Roscoe,U.S. Senate,,I,Greg Orman,0
-Hodgeman,Sawlog,U.S. Senate,,I,Greg Orman,7
-Hodgeman,S Hallet,U.S. Senate,,I,Greg Orman,1
-Hodgeman,S Roscoe,U.S. Senate,,I,Greg Orman,3
-Hodgeman,Sterling,U.S. Senate,,I,Greg Orman,10
-Hodgeman,Valley,U.S. Senate,,I,Greg Orman,4
-Hodgeman,Benton,U.S. Senate,,L,Randall Batson,0
-Hodgeman,N Center,U.S. Senate,,L,Randall Batson,7
-Hodgeman,S Center,U.S. Senate,,L,Randall Batson,6
-Hodgeman,Marena,U.S. Senate,,L,Randall Batson,6
-Hodgeman,N Hallet,U.S. Senate,,L,Randall Batson,0
-Hodgeman,N Roscoe,U.S. Senate,,L,Randall Batson,0
-Hodgeman,Sawlog,U.S. Senate,,L,Randall Batson,1
-Hodgeman,S Hallet,U.S. Senate,,L,Randall Batson,0
-Hodgeman,S Roscoe,U.S. Senate,,L,Randall Batson,0
-Hodgeman,Sterling,U.S. Senate,,L,Randall Batson,0
-Hodgeman,Valley,U.S. Senate,,L,Randall Batson,0
-Hodgeman,Benton,U.S. House,1,R,Tim Huelskamp,27
-Hodgeman,N Center,U.S. House,1,R,Tim Huelskamp,173
-Hodgeman,S Center,U.S. House,1,R,Tim Huelskamp,142
-Hodgeman,Marena,U.S. House,1,R,Tim Huelskamp,174
-Hodgeman,N Hallet,U.S. House,1,R,Tim Huelskamp,2
-Hodgeman,N Roscoe,U.S. House,1,R,Tim Huelskamp,23
-Hodgeman,Sawlog,U.S. House,1,R,Tim Huelskamp,32
-Hodgeman,S Hallet,U.S. House,1,R,Tim Huelskamp,13
-Hodgeman,S Roscoe,U.S. House,1,R,Tim Huelskamp,25
-Hodgeman,Sterling,U.S. House,1,R,Tim Huelskamp,44
-Hodgeman,Valley,U.S. House,1,R,Tim Huelskamp,16
-Hodgeman,Benton,U.S. House,1,D,James Sherow,2
-Hodgeman,N Center,U.S. House,1,D,James Sherow,50
-Hodgeman,S Center,U.S. House,1,D,James Sherow,48
-Hodgeman,Marena,U.S. House,1,D,James Sherow,33
-Hodgeman,N Hallet,U.S. House,1,D,James Sherow,2
-Hodgeman,N Roscoe,U.S. House,1,D,James Sherow,0
-Hodgeman,Sawlog,U.S. House,1,D,James Sherow,6
-Hodgeman,S Hallet,U.S. House,1,D,James Sherow,3
-Hodgeman,S Roscoe,U.S. House,1,D,James Sherow,3
-Hodgeman,Sterling,U.S. House,1,D,James Sherow,12
-Hodgeman,Valley,U.S. House,1,D,James Sherow,4
-Hodgeman,Benton,Governor,,R,Sam Brownback,27
-Hodgeman,N Center,Governor,,R,Sam Brownback,149
-Hodgeman,S Center,Governor,,R,Sam Brownback,134
-Hodgeman,Marena,Governor,,R,Sam Brownback,173
-Hodgeman,N Hallet,Governor,,R,Sam Brownback,3
-Hodgeman,N Roscoe,Governor,,R,Sam Brownback,22
-Hodgeman,Sawlog,Governor,,R,Sam Brownback,33
-Hodgeman,S Hallet,Governor,,R,Sam Brownback,13
-Hodgeman,S Roscoe,Governor,,R,Sam Brownback,23
-Hodgeman,Sterling,Governor,,R,Sam Brownback,43
-Hodgeman,Valley,Governor,,R,Sam Brownback,16
-Hodgeman,Benton,Governor,,D,Paul Davis,2
-Hodgeman,N Center,Governor,,D,Paul Davis,74
-Hodgeman,S Center,Governor,,D,Paul Davis,51
-Hodgeman,Marena,Governor,,D,Paul Davis,34
-Hodgeman,N Hallet,Governor,,D,Paul Davis,1
-Hodgeman,N Roscoe,Governor,,D,Paul Davis,0
-Hodgeman,Sawlog,Governor,,D,Paul Davis,8
-Hodgeman,S Hallet,Governor,,D,Paul Davis,2
-Hodgeman,S Roscoe,Governor,,D,Paul Davis,5
-Hodgeman,Sterling,Governor,,D,Paul Davis,14
-Hodgeman,Valley,Governor,,D,Paul Davis,4
-Hodgeman,Benton,Governor,,L,Keen Umbehr,0
-Hodgeman,N Center,Governor,,L,Keen Umbehr,7
-Hodgeman,S Center,Governor,,L,Keen Umbehr,7
-Hodgeman,Marena,Governor,,L,Keen Umbehr,5
-Hodgeman,N Hallet,Governor,,L,Keen Umbehr,0
-Hodgeman,N Roscoe,Governor,,L,Keen Umbehr,0
-Hodgeman,Sawlog,Governor,,L,Keen Umbehr,2
-Hodgeman,S Hallet,Governor,,L,Keen Umbehr,1
-Hodgeman,S Roscoe,Governor,,L,Keen Umbehr,0
-Hodgeman,Sterling,Governor,,L,Keen Umbehr,0
-Hodgeman,Valley,Governor,,L,Keen Umbehr,0
-Hodgeman,Benton,Secretary of State,,R,Kris Kobach,26
-Hodgeman,N Center,Secretary of State,,R,Kris Kobach,172
-Hodgeman,S Center,Secretary of State,,R,Kris Kobach,144
-Hodgeman,Marena,Secretary of State,,R,Kris Kobach,179
-Hodgeman,N Hallet,Secretary of State,,R,Kris Kobach,4
-Hodgeman,N Roscoe,Secretary of State,,R,Kris Kobach,23
-Hodgeman,Sawlog,Secretary of State,,R,Kris Kobach,34
-Hodgeman,S Hallet,Secretary of State,,R,Kris Kobach,14
-Hodgeman,S Roscoe,Secretary of State,,R,Kris Kobach,23
-Hodgeman,Sterling,Secretary of State,,R,Kris Kobach,47
-Hodgeman,Valley,Secretary of State,,R,Kris Kobach,18
-Hodgeman,Benton,Secretary of State,,D,Jean Schodorf,2
-Hodgeman,N Center,Secretary of State,,D,Jean Schodorf,53
-Hodgeman,S Center,Secretary of State,,D,Jean Schodorf,40
-Hodgeman,Marena,Secretary of State,,D,Jean Schodorf,58
-Hodgeman,N Hallet,Secretary of State,,D,Jean Schodorf,0
-Hodgeman,N Roscoe,Secretary of State,,D,Jean Schodorf,0
-Hodgeman,Sawlog,Secretary of State,,D,Jean Schodorf,8
-Hodgeman,S Hallet,Secretary of State,,D,Jean Schodorf,1
-Hodgeman,S Roscoe,Secretary of State,,D,Jean Schodorf,6
-Hodgeman,Sterling,Secretary of State,,D,Jean Schodorf,9
-Hodgeman,Valley,Secretary of State,,D,Jean Schodorf,3
-Hodgeman,Benton,Attorney General,,R,Derek Schmidt,26
-Hodgeman,N Center,Attorney General,,R,Derek Schmidt,188
-Hodgeman,S Center,Attorney General,,R,Derek Schmidt,161
-Hodgeman,Marena,Attorney General,,R,Derek Schmidt,186
-Hodgeman,N Hallet,Attorney General,,R,Derek Schmidt,4
-Hodgeman,N Roscoe,Attorney General,,R,Derek Schmidt,21
-Hodgeman,Sawlog,Attorney General,,R,Derek Schmidt,36
-Hodgeman,S Hallet,Attorney General,,R,Derek Schmidt,15
-Hodgeman,S Roscoe,Attorney General,,R,Derek Schmidt,25
-Hodgeman,Sterling,Attorney General,,R,Derek Schmidt,50
-Hodgeman,Valley,Attorney General,,R,Derek Schmidt,19
-Hodgeman,Benton,Attorney General,,D,A J Kotich,2
-Hodgeman,N Center,Attorney General,,D,A J Kotich,34
-Hodgeman,S Center,Attorney General,,D,A J Kotich,19
-Hodgeman,Marena,Attorney General,,D,A J Kotich,22
-Hodgeman,N Hallet,Attorney General,,D,A J Kotich,0
-Hodgeman,N Roscoe,Attorney General,,D,A J Kotich,0
-Hodgeman,Sawlog,Attorney General,,D,A J Kotich,5
-Hodgeman,S Hallet,Attorney General,,D,A J Kotich,0
-Hodgeman,S Roscoe,Attorney General,,D,A J Kotich,4
-Hodgeman,Sterling,Attorney General,,D,A J Kotich,5
-Hodgeman,Valley,Attorney General,,D,A J Kotich,2
-Hodgeman,Benton,State Treasurer,,R,Ron Estes,26
-Hodgeman,N Center,State Treasurer,,R,Ron Estes,188
-Hodgeman,S Center,State Treasurer,,R,Ron Estes,157
-Hodgeman,Marena,State Treasurer,,R,Ron Estes,193
-Hodgeman,N Hallet,State Treasurer,,R,Ron Estes,4
-Hodgeman,N Roscoe,State Treasurer,,R,Ron Estes,23
-Hodgeman,Sawlog,State Treasurer,,R,Ron Estes,37
-Hodgeman,S Hallet,State Treasurer,,R,Ron Estes,15
-Hodgeman,S Roscoe,State Treasurer,,R,Ron Estes,24
-Hodgeman,Sterling,State Treasurer,,R,Ron Estes,46
-Hodgeman,Valley,State Treasurer,,R,Ron Estes,17
-Hodgeman,Benton,State Treasurer,,D,Carmen Alldritt,2
-Hodgeman,N Center,State Treasurer,,D,Carmen Alldritt,31
-Hodgeman,S Center,State Treasurer,,D,Carmen Alldritt,27
-Hodgeman,Marena,State Treasurer,,D,Carmen Alldritt,16
-Hodgeman,N Hallet,State Treasurer,,D,Carmen Alldritt,0
-Hodgeman,N Roscoe,State Treasurer,,D,Carmen Alldritt,0
-Hodgeman,Sawlog,State Treasurer,,D,Carmen Alldritt,5
-Hodgeman,S Hallet,State Treasurer,,D,Carmen Alldritt,0
-Hodgeman,S Roscoe,State Treasurer,,D,Carmen Alldritt,5
-Hodgeman,Sterling,State Treasurer,,D,Carmen Alldritt,10
-Hodgeman,Valley,State Treasurer,,D,Carmen Alldritt,4
-Hodgeman,Benton,Insurance Commissioner,,R,Ken Selzer,23
-Hodgeman,N Center,Insurance Commissioner,,R,Ken Selzer,162
-Hodgeman,S Center,Insurance Commissioner,,R,Ken Selzer,138
-Hodgeman,Marena,Insurance Commissioner,,R,Ken Selzer,175
-Hodgeman,N Hallet,Insurance Commissioner,,R,Ken Selzer,4
-Hodgeman,N Roscoe,Insurance Commissioner,,R,Ken Selzer,18
-Hodgeman,Sawlog,Insurance Commissioner,,R,Ken Selzer,33
-Hodgeman,S Hallet,Insurance Commissioner,,R,Ken Selzer,13
-Hodgeman,S Roscoe,Insurance Commissioner,,R,Ken Selzer,23
-Hodgeman,Sterling,Insurance Commissioner,,R,Ken Selzer,41
-Hodgeman,Valley,Insurance Commissioner,,R,Ken Selzer,17
-Hodgeman,Benton,Insurance Commissioner,,D,Dennis Anderson,2
-Hodgeman,N Center,Insurance Commissioner,,D,Dennis Anderson,53
-Hodgeman,S Center,Insurance Commissioner,,D,Dennis Anderson,42
-Hodgeman,Marena,Insurance Commissioner,,D,Dennis Anderson,31
-Hodgeman,N Hallet,Insurance Commissioner,,D,Dennis Anderson,0
-Hodgeman,N Roscoe,Insurance Commissioner,,D,Dennis Anderson,2
-Hodgeman,Sawlog,Insurance Commissioner,,D,Dennis Anderson,6
-Hodgeman,S Hallet,Insurance Commissioner,,D,Dennis Anderson,2
-Hodgeman,S Roscoe,Insurance Commissioner,,D,Dennis Anderson,6
-Hodgeman,Sterling,Insurance Commissioner,,D,Dennis Anderson,14
-Hodgeman,Valley,Insurance Commissioner,,D,Dennis Anderson,4
-Hodgeman,Benton,State House,117,R,John Ewy,26
-Hodgeman,N Center,State House,117,R,John Ewy,203
-Hodgeman,S Center,State House,117,R,John Ewy,181
-Hodgeman,Marena,State House,117,R,John Ewy,197
-Hodgeman,N Hallet,State House,117,R,John Ewy,4
-Hodgeman,N Roscoe,State House,117,R,John Ewy,23
-Hodgeman,Sawlog,State House,117,R,John Ewy,40
-Hodgeman,S Hallet,State House,117,R,John Ewy,16
-Hodgeman,S Roscoe,State House,117,R,John Ewy,29
-Hodgeman,Sterling,State House,117,R,John Ewy,52
-Hodgeman,Valley,State House,117,R,John Ewy,19
-Hodgeman,Marena,U.S. Senate,,wri,Chad Jones [wri],1
-Hodgeman,N Center,State House,117,wri,Emmett Alstrup [wri],1
-Hodgeman,N Center,State House,117,wri,Joanne Clarke [wri],1
+county,precinct,office,district,party,candidate,votes,vtd
+HODGEMAN,Benton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000010
+HODGEMAN,Benton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+HODGEMAN,Benton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000010
+HODGEMAN,Marena Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000020
+HODGEMAN,Marena Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000020
+HODGEMAN,Marena Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",173,000020
+HODGEMAN,North Center,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000030
+HODGEMAN,North Center,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000030
+HODGEMAN,North Center,Governor / Lt. Governor,,Republican,"Brownback, Sam",149,000030
+HODGEMAN,North Hallet,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000040
+HODGEMAN,North Hallet,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+HODGEMAN,North Hallet,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000040
+HODGEMAN,North Roscoe,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000050
+HODGEMAN,North Roscoe,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+HODGEMAN,North Roscoe,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000050
+HODGEMAN,Sawlog Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000060
+HODGEMAN,Sawlog Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000060
+HODGEMAN,Sawlog Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000060
+HODGEMAN,South Center,Governor / Lt. Governor,,Democratic,"Davis, Paul",51,000070
+HODGEMAN,South Center,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000070
+HODGEMAN,South Center,Governor / Lt. Governor,,Republican,"Brownback, Sam",134,000070
+HODGEMAN,South Hallet,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000080
+HODGEMAN,South Hallet,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+HODGEMAN,South Hallet,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000080
+HODGEMAN,South Roscoe,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000090
+HODGEMAN,South Roscoe,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+HODGEMAN,South Roscoe,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000090
+HODGEMAN,Sterling Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000100
+HODGEMAN,Sterling Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+HODGEMAN,Sterling Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000100
+HODGEMAN,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000110
+HODGEMAN,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+HODGEMAN,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000110
+HODGEMAN,Benton Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",26,000010
+HODGEMAN,Marena Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",197,000020
+HODGEMAN,North Center,Kansas House of Representatives,117,Republican,"Ewy, John L.",203,000030
+HODGEMAN,North Hallet,Kansas House of Representatives,117,Republican,"Ewy, John L.",4,000040
+HODGEMAN,North Roscoe,Kansas House of Representatives,117,Republican,"Ewy, John L.",23,000050
+HODGEMAN,Sawlog Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",40,000060
+HODGEMAN,South Center,Kansas House of Representatives,117,Republican,"Ewy, John L.",181,000070
+HODGEMAN,South Hallet,Kansas House of Representatives,117,Republican,"Ewy, John L.",16,000080
+HODGEMAN,South Roscoe,Kansas House of Representatives,117,Republican,"Ewy, John L.",29,000090
+HODGEMAN,Sterling Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",52,000100
+HODGEMAN,Valley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",19,000110
+HODGEMAN,Benton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000010
+HODGEMAN,Benton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000010
+HODGEMAN,Marena Township,United States House of Representatives,1,Democratic,"Sherow, James E.",33,000020
+HODGEMAN,Marena Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",174,000020
+HODGEMAN,North Center,United States House of Representatives,1,Democratic,"Sherow, James E.",50,000030
+HODGEMAN,North Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",173,000030
+HODGEMAN,North Hallet,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000040
+HODGEMAN,North Hallet,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,000040
+HODGEMAN,North Roscoe,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000050
+HODGEMAN,North Roscoe,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000050
+HODGEMAN,Sawlog Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000060
+HODGEMAN,Sawlog Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000060
+HODGEMAN,South Center,United States House of Representatives,1,Democratic,"Sherow, James E.",48,000070
+HODGEMAN,South Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",142,000070
+HODGEMAN,South Hallet,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000080
+HODGEMAN,South Hallet,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000080
+HODGEMAN,South Roscoe,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000090
+HODGEMAN,South Roscoe,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000090
+HODGEMAN,Sterling Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000100
+HODGEMAN,Sterling Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000100
+HODGEMAN,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000110
+HODGEMAN,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000110
+HODGEMAN,Benton Township,Attorney General,,Democratic,"Kotich, A.J.",2,000010
+HODGEMAN,Benton Township,Attorney General,,Republican,"Schmidt, Derek",26,000010
+HODGEMAN,Marena Township,Attorney General,,Democratic,"Kotich, A.J.",22,000020
+HODGEMAN,Marena Township,Attorney General,,Republican,"Schmidt, Derek",186,000020
+HODGEMAN,North Center,Attorney General,,Democratic,"Kotich, A.J.",34,000030
+HODGEMAN,North Center,Attorney General,,Republican,"Schmidt, Derek",188,000030
+HODGEMAN,North Hallet,Attorney General,,Democratic,"Kotich, A.J.",0,000040
+HODGEMAN,North Hallet,Attorney General,,Republican,"Schmidt, Derek",4,000040
+HODGEMAN,North Roscoe,Attorney General,,Democratic,"Kotich, A.J.",0,000050
+HODGEMAN,North Roscoe,Attorney General,,Republican,"Schmidt, Derek",21,000050
+HODGEMAN,Sawlog Township,Attorney General,,Democratic,"Kotich, A.J.",5,000060
+HODGEMAN,Sawlog Township,Attorney General,,Republican,"Schmidt, Derek",36,000060
+HODGEMAN,South Center,Attorney General,,Democratic,"Kotich, A.J.",19,000070
+HODGEMAN,South Center,Attorney General,,Republican,"Schmidt, Derek",161,000070
+HODGEMAN,South Hallet,Attorney General,,Democratic,"Kotich, A.J.",0,000080
+HODGEMAN,South Hallet,Attorney General,,Republican,"Schmidt, Derek",15,000080
+HODGEMAN,South Roscoe,Attorney General,,Democratic,"Kotich, A.J.",4,000090
+HODGEMAN,South Roscoe,Attorney General,,Republican,"Schmidt, Derek",25,000090
+HODGEMAN,Sterling Township,Attorney General,,Democratic,"Kotich, A.J.",5,000100
+HODGEMAN,Sterling Township,Attorney General,,Republican,"Schmidt, Derek",50,000100
+HODGEMAN,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",2,000110
+HODGEMAN,Valley Township,Attorney General,,Republican,"Schmidt, Derek",19,000110
+HODGEMAN,Benton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000010
+HODGEMAN,Benton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000010
+HODGEMAN,Marena Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000020
+HODGEMAN,Marena Township,Commissioner of Insurance,,Republican,"Selzer, Ken",175,000020
+HODGEMAN,North Center,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000030
+HODGEMAN,North Center,Commissioner of Insurance,,Republican,"Selzer, Ken",162,000030
+HODGEMAN,North Hallet,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000040
+HODGEMAN,North Hallet,Commissioner of Insurance,,Republican,"Selzer, Ken",4,000040
+HODGEMAN,North Roscoe,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000050
+HODGEMAN,North Roscoe,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000050
+HODGEMAN,Sawlog Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000060
+HODGEMAN,Sawlog Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000060
+HODGEMAN,South Center,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000070
+HODGEMAN,South Center,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000070
+HODGEMAN,South Hallet,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000080
+HODGEMAN,South Hallet,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000080
+HODGEMAN,South Roscoe,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000090
+HODGEMAN,South Roscoe,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000090
+HODGEMAN,Sterling Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000100
+HODGEMAN,Sterling Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000100
+HODGEMAN,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000110
+HODGEMAN,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000110
+HODGEMAN,Benton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000010
+HODGEMAN,Benton Township,Secretary of State,,Republican,"Kobach, Kris",26,000010
+HODGEMAN,Marena Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000020
+HODGEMAN,Marena Township,Secretary of State,,Republican,"Kobach, Kris",179,000020
+HODGEMAN,North Center,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,000030
+HODGEMAN,North Center,Secretary of State,,Republican,"Kobach, Kris",172,000030
+HODGEMAN,North Hallet,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000040
+HODGEMAN,North Hallet,Secretary of State,,Republican,"Kobach, Kris",4,000040
+HODGEMAN,North Roscoe,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000050
+HODGEMAN,North Roscoe,Secretary of State,,Republican,"Kobach, Kris",23,000050
+HODGEMAN,Sawlog Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000060
+HODGEMAN,Sawlog Township,Secretary of State,,Republican,"Kobach, Kris",34,000060
+HODGEMAN,South Center,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000070
+HODGEMAN,South Center,Secretary of State,,Republican,"Kobach, Kris",144,000070
+HODGEMAN,South Hallet,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000080
+HODGEMAN,South Hallet,Secretary of State,,Republican,"Kobach, Kris",14,000080
+HODGEMAN,South Roscoe,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000090
+HODGEMAN,South Roscoe,Secretary of State,,Republican,"Kobach, Kris",23,000090
+HODGEMAN,Sterling Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000100
+HODGEMAN,Sterling Township,Secretary of State,,Republican,"Kobach, Kris",47,000100
+HODGEMAN,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000110
+HODGEMAN,Valley Township,Secretary of State,,Republican,"Kobach, Kris",18,000110
+HODGEMAN,Benton Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+HODGEMAN,Benton Township,State Treasurer,,Republican,"Estes, Ron",26,000010
+HODGEMAN,Marena Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000020
+HODGEMAN,Marena Township,State Treasurer,,Republican,"Estes, Ron",193,000020
+HODGEMAN,North Center,State Treasurer,,Democratic,"Alldritt, Carmen",31,000030
+HODGEMAN,North Center,State Treasurer,,Republican,"Estes, Ron",188,000030
+HODGEMAN,North Hallet,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+HODGEMAN,North Hallet,State Treasurer,,Republican,"Estes, Ron",4,000040
+HODGEMAN,North Roscoe,State Treasurer,,Democratic,"Alldritt, Carmen",0,000050
+HODGEMAN,North Roscoe,State Treasurer,,Republican,"Estes, Ron",21,000050
+HODGEMAN,Sawlog Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000060
+HODGEMAN,Sawlog Township,State Treasurer,,Republican,"Estes, Ron",36,000060
+HODGEMAN,South Center,State Treasurer,,Democratic,"Alldritt, Carmen",27,000070
+HODGEMAN,South Center,State Treasurer,,Republican,"Estes, Ron",157,000070
+HODGEMAN,South Hallet,State Treasurer,,Democratic,"Alldritt, Carmen",0,000080
+HODGEMAN,South Hallet,State Treasurer,,Republican,"Estes, Ron",15,000080
+HODGEMAN,South Roscoe,State Treasurer,,Democratic,"Alldritt, Carmen",5,000090
+HODGEMAN,South Roscoe,State Treasurer,,Republican,"Estes, Ron",25,000090
+HODGEMAN,Sterling Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000100
+HODGEMAN,Sterling Township,State Treasurer,,Republican,"Estes, Ron",50,000100
+HODGEMAN,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000110
+HODGEMAN,Valley Township,State Treasurer,,Republican,"Estes, Ron",19,000110
+HODGEMAN,Benton Township,United States Senate,,independent,"Orman, Greg",2,000010
+HODGEMAN,Benton Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+HODGEMAN,Benton Township,United States Senate,,Republican,"Roberts, Pat",27,000010
+HODGEMAN,Marena Township,United States Senate,,independent,"Orman, Greg",31,000020
+HODGEMAN,Marena Township,United States Senate,,Libertarian,"Batson, Randall",6,000020
+HODGEMAN,Marena Township,United States Senate,,Republican,"Roberts, Pat",101,000020
+HODGEMAN,North Center,United States Senate,,independent,"Orman, Greg",62,000030
+HODGEMAN,North Center,United States Senate,,Libertarian,"Batson, Randall",7,000030
+HODGEMAN,North Center,United States Senate,,Republican,"Roberts, Pat",156,000030
+HODGEMAN,North Hallet,United States Senate,,independent,"Orman, Greg",1,000040
+HODGEMAN,North Hallet,United States Senate,,Libertarian,"Batson, Randall",0,000040
+HODGEMAN,North Hallet,United States Senate,,Republican,"Roberts, Pat",3,000040
+HODGEMAN,North Roscoe,United States Senate,,independent,"Orman, Greg",0,000050
+HODGEMAN,North Roscoe,United States Senate,,Libertarian,"Batson, Randall",0,000050
+HODGEMAN,North Roscoe,United States Senate,,Republican,"Roberts, Pat",24,000050
+HODGEMAN,Sawlog Township,United States Senate,,independent,"Orman, Greg",7,000060
+HODGEMAN,Sawlog Township,United States Senate,,Libertarian,"Batson, Randall",1,000060
+HODGEMAN,Sawlog Township,United States Senate,,Republican,"Roberts, Pat",31,000060
+HODGEMAN,South Center,United States Senate,,independent,"Orman, Greg",48,000070
+HODGEMAN,South Center,United States Senate,,Libertarian,"Batson, Randall",6,000070
+HODGEMAN,South Center,United States Senate,,Republican,"Roberts, Pat",136,000070
+HODGEMAN,South Hallet,United States Senate,,independent,"Orman, Greg",1,000080
+HODGEMAN,South Hallet,United States Senate,,Libertarian,"Batson, Randall",0,000080
+HODGEMAN,South Hallet,United States Senate,,Republican,"Roberts, Pat",15,000080
+HODGEMAN,South Roscoe,United States Senate,,independent,"Orman, Greg",3,000090
+HODGEMAN,South Roscoe,United States Senate,,Libertarian,"Batson, Randall",0,000090
+HODGEMAN,South Roscoe,United States Senate,,Republican,"Roberts, Pat",25,000090
+HODGEMAN,Sterling Township,United States Senate,,independent,"Orman, Greg",10,000100
+HODGEMAN,Sterling Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+HODGEMAN,Sterling Township,United States Senate,,Republican,"Roberts, Pat",46,000100
+HODGEMAN,Valley Township,United States Senate,,independent,"Orman, Greg",4,000110
+HODGEMAN,Valley Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+HODGEMAN,Valley Township,United States Senate,,Republican,"Roberts, Pat",17,000110

--- a/2014/20141104__ks__general__jackson__precinct.csv
+++ b/2014/20141104__ks__general__jackson__precinct.csv
@@ -1,381 +1,381 @@
-county,precinct,office,district,party,candidate,total,polls,advance,provisional
-Jackson,Wd 1,Attorney General,,D,A J Kotich,93,72,19,2
-Jackson,Wd 2,Attorney General,,D,A J Kotich,118,90,27,1
-Jackson,Wd 3,Attorney General,,D,A J Kotich,88,67,21,0
-Jackson,Wd 1,Attorney General,,R,Derek Schmidt,248,174,72,2
-Jackson,Wd 2,Attorney General,,R,Derek Schmidt,260,188,68,4
-Jackson,Wd 3,Attorney General,,R,Derek Schmidt,213,170,39,4
-Jackson,Wd 1,U.S. House,2,L,Chris Clemmons,19,16,3,0
-Jackson,Wd 2,U.S. House,2,L,Chris Clemmons,22,20,2,0
-Jackson,Wd 3,U.S. House,2,L,Chris Clemmons,16,15,1,0
-Jackson,Wd 1,U.S. House,2,R,Lynn Jenkins,211,151,58,2
-Jackson,Wd 2,U.S. House,2,R,Lynn Jenkins,231,167,60,4
-Jackson,Wd 3,U.S. House,2,R,Lynn Jenkins,170,135,33,2
-Jackson,Wd 1,U.S. House,2,D,Margie Wakefield,117,85,30,2
-Jackson,Wd 2,U.S. House,2,D,Margie Wakefield,134,97,36,1
-Jackson,Wd 3,U.S. House,2,D,Margie Wakefield,119,88,29,2
-Jackson,Wd 1,Governor,,L,Keen Umbehr,17,12,4,1
-Jackson,Wd 2,Governor,,L,Keen Umbehr,14,8,6,0
-Jackson,Wd 3,Governor,,L,Keen Umbehr,17,14,3,0
-Jackson,Wd 1,Governor,,D,Paul Davis,179,134,43,2
-Jackson,Wd 2,Governor,,D,Paul Davis,216,172,42,2
-Jackson,Wd 3,Governor,,D,Paul Davis,153,118,34,1
-Jackson,Wd 1,Governor,,R,Sam Brownback,151,105,45,1
-Jackson,Wd 2,Governor,,R,Sam Brownback,156,104,49,3
-Jackson,Wd 3,Governor,,R,Sam Brownback,137,109,25,3
-Jackson,Wd 1,Insurance Commissioner,,D,Dennis Anderson,126,89,36,1
-Jackson,Wd 2,Insurance Commissioner,,D,Dennis Anderson,154,122,31,1
-Jackson,Wd 3,Insurance Commissioner,,D,Dennis Anderson,119,90,26,3
-Jackson,Wd 1,Insurance Commissioner,,R,Ken Selzer,211,156,52,3
-Jackson,Wd 2,Insurance Commissioner,,R,Ken Selzer,201,141,56,4
-Jackson,Wd 3,Insurance Commissioner,,R,Ken Selzer,167,134,32,1
-Jackson,Wd 1,Secretary of State,,D,Jean Schodorf,125,89,34,2
-Jackson,Wd 2,Secretary of State,,D,Jean Schodorf,136,99,36,1
-Jackson,Wd 3,Secretary of State,,D,Jean Schodorf,104,73,31,0
-Jackson,Wd 1,Secretary of State,,R,Kris Kobach,222,162,58,2
-Jackson,Wd 2,Secretary of State,,R,Kris Kobach,245,181,60,4
-Jackson,Wd 3,Secretary of State,,R,Kris Kobach,200,166,30,4
-Jackson,Wd 1,State House,61,R,Becky Hutchins,220,156,62,2
-Jackson,Wd 2,State House,61,R,Becky Hutchins,253,188,61,4
-Jackson,Wd 3,State House,61,R,Becky Hutchins,196,162,31,3
-Jackson,Wd 1,State House,61,D,Vivian Olsen,126,95,29,2
-Jackson,Wd 2,State House,61,D,Vivian Olsen,133,95,37,1
-Jackson,Wd 3,State House,61,D,Vivian Olsen,111,80,30,1
-Jackson,Wd 1,State Treasurer,,D,Carmen Alldritt,105,80,23,2
-Jackson,Wd 2,State Treasurer,,D,Carmen Alldritt,126,94,30,2
-Jackson,Wd 3,State Treasurer,,D,Carmen Alldritt,86,65,20,1
-Jackson,Wd 1,State Treasurer,,R,Ron Estes,234,166,66,2
-Jackson,Wd 2,State Treasurer,,R,Ron Estes,248,183,62,3
-Jackson,Wd 3,State Treasurer,,R,Ron Estes,210,168,39,3
-Jackson,Wd 1,U.S. Senate,,I,Greg Orman,162,121,39,2
-Jackson,Wd 2,U.S. Senate,,I,Greg Orman,181,140,39,2
-Jackson,Wd 3,U.S. Senate,,I,Greg Orman,141,108,32,1
-Jackson,Wd 1,U.S. Senate,,R,Pat Roberts,160,115,43,2
-Jackson,Wd 2,U.S. Senate,,R,Pat Roberts,192,134,55,3
-Jackson,Wd 3,U.S. Senate,,R,Pat Roberts,151,119,30,2
-Jackson,Wd 1,U.S. Senate,,L,Randall Batson,25,16,9,0
-Jackson,Wd 2,U.S. Senate,,L,Randall Batson,11,7,4,0
-Jackson,Wd 3,U.S. Senate,,L,Randall Batson,11,11,0,0
-Jackson,Wd 1,Voters,,,Cast,262,,,
-Jackson,Wd 2,Voters,,,Cast,293,,,
-Jackson,Wd 3,Voters,,,Cast,249,,,
-Jackson,Wd 1,Voters,,,Registered,760,,,
-Jackson,Wd 2,Voters,,,Registered,821,,,
-Jackson,Wd 3,Voters,,,Registered,596,,,
-Jackson,precinct,office,,,candidate,Total,Polls,Advance,Provisional
-Jackson,Adrian,Attorney General,,D,A J Kotich,5,3,2,0
-Jackson,Banner,Attorney General,,D,A J Kotich,28,21,7,0
-Jackson,Cedar,Attorney General,,D,A J Kotich,129,106,17,6
-Jackson,Douglas,Attorney General,,D,A J Kotich,260,224,35,1
-Jackson,Franklin,Attorney General,,D,A J Kotich,103,79,24,0
-Jackson,Garfield,Attorney General,,D,A J Kotich,62,51,10,1
-Jackson,Grant,Attorney General,,D,A J Kotich,23,18,5,0
-Jackson,Jefferson,Attorney General,,D,A J Kotich,53,44,9,0
-Jackson,Liberty,Attorney General,,D,A J Kotich,66,52,13,1
-Jackson,Lincoln,Attorney General,,D,A J Kotich,185,155,24,6
-Jackson,Netawaka,Attorney General,,D,A J Kotich,34,34,0,0
-Jackson,Soldier,Attorney General,,D,A J Kotich,44,36,8,0
-Jackson,St. Creek,Attorney General,,D,A J Kotich,15,6,9,0
-Jackson,Washington,Attorney General,,D,A J Kotich,36,30,4,2
-Jackson,Whiting,Attorney General,,D,A J Kotich,25,22,3,0
-Jackson,Adrian,Attorney General,,R,Derek Schmidt,49,40,9,0
-Jackson,Banner,Attorney General,,R,Derek Schmidt,111,93,17,1
-Jackson,Cedar,Attorney General,,R,Derek Schmidt,320,263,50,7
-Jackson,Douglas,Attorney General,,R,Derek Schmidt,598,517,72,9
-Jackson,Franklin,Attorney General,,R,Derek Schmidt,323,241,76,6
-Jackson,Garfield,Attorney General,,R,Derek Schmidt,181,160,21,0
-Jackson,Grant,Attorney General,,R,Derek Schmidt,55,42,12,1
-Jackson,Jefferson,Attorney General,,R,Derek Schmidt,171,138,33,0
-Jackson,Liberty,Attorney General,,R,Derek Schmidt,160,131,29,0
-Jackson,Lincoln,Attorney General,,R,Derek Schmidt,159,128,25,6
-Jackson,Netawaka,Attorney General,,R,Derek Schmidt,85,80,5,0
-Jackson,Soldier,Attorney General,,R,Derek Schmidt,113,95,16,2
-Jackson,St. Creek,Attorney General,,R,Derek Schmidt,58,36,20,2
-Jackson,Washington,Attorney General,,R,Derek Schmidt,153,147,4,2
-Jackson,Whiting,Attorney General,,R,Derek Schmidt,108,100,5,3
-Jackson,Adrian,U.S. House,2,L,Chris Clemmons,4,4,0,0
-Jackson,Banner,U.S. House,2,L,Chris Clemmons,6,5,0,1
-Jackson,Cedar,U.S. House,2,L,Chris Clemmons,20,18,2,0
-Jackson,Douglas,U.S. House,2,L,Chris Clemmons,53,47,6,0
-Jackson,Franklin,U.S. House,2,L,Chris Clemmons,14,12,2,0
-Jackson,Garfield,U.S. House,2,L,Chris Clemmons,16,13,2,1
-Jackson,Grant,U.S. House,2,L,Chris Clemmons,1,1,0,0
-Jackson,Jefferson,U.S. House,2,L,Chris Clemmons,8,8,0,0
-Jackson,Liberty,U.S. House,2,L,Chris Clemmons,5,4,1,0
-Jackson,Lincoln,U.S. House,2,L,Chris Clemmons,21,17,3,1
-Jackson,Netawaka,U.S. House,2,L,Chris Clemmons,8,8,0,0
-Jackson,Soldier,U.S. House,2,L,Chris Clemmons,8,7,1,0
-Jackson,St. Creek,U.S. House,2,L,Chris Clemmons,4,2,2,0
-Jackson,Washington,U.S. House,2,L,Chris Clemmons,10,9,0,1
-Jackson,Whiting,U.S. House,2,L,Chris Clemmons,7,7,0,0
-Jackson,Adrian,U.S. House,2,R,Lynn Jenkins,44,36,8,0
-Jackson,Banner,U.S. House,2,R,Lynn Jenkins,102,84,18,0
-Jackson,Cedar,U.S. House,2,R,Lynn Jenkins,298,247,43,8
-Jackson,Douglas,U.S. House,2,R,Lynn Jenkins,506,438,60,8
-Jackson,Franklin,U.S. House,2,R,Lynn Jenkins,290,214,70,6
-Jackson,Garfield,U.S. House,2,R,Lynn Jenkins,167,145,21,1
-Jackson,Grant,U.S. House,2,R,Lynn Jenkins,54,40,13,1
-Jackson,Jefferson,U.S. House,2,R,Lynn Jenkins,152,121,31,0
-Jackson,Liberty,U.S. House,2,R,Lynn Jenkins,154,131,22,1
-Jackson,Lincoln,U.S. House,2,R,Lynn Jenkins,129,105,20,4
-Jackson,Netawaka,U.S. House,2,R,Lynn Jenkins,74,69,5,0
-Jackson,Soldier,U.S. House,2,R,Lynn Jenkins,111,92,17,2
-Jackson,St. Creek,U.S. House,2,R,Lynn Jenkins,51,30,19,2
-Jackson,Washington,U.S. House,2,R,Lynn Jenkins,133,127,5,1
-Jackson,Whiting,U.S. House,2,R,Lynn Jenkins,92,85,4,3
-Jackson,Adrian,U.S. House,2,D,Margie Wakefield,7,4,3,0
-Jackson,Banner,U.S. House,2,D,Margie Wakefield,36,27,9,0
-Jackson,Cedar,U.S. House,2,D,Margie Wakefield,134,107,22,5
-Jackson,Douglas,U.S. House,2,D,Margie Wakefield,313,269,41,3
-Jackson,Franklin,U.S. House,2,D,Margie Wakefield,129,101,28,0
-Jackson,Garfield,U.S. House,2,D,Margie Wakefield,66,57,9,0
-Jackson,Grant,U.S. House,2,D,Margie Wakefield,25,21,4,0
-Jackson,Jefferson,U.S. House,2,D,Margie Wakefield,66,54,12,0
-Jackson,Liberty,U.S. House,2,D,Margie Wakefield,74,53,20,1
-Jackson,Lincoln,U.S. House,2,D,Margie Wakefield,195,162,26,7
-Jackson,Netawaka,U.S. House,2,D,Margie Wakefield,38,38,0,0
-Jackson,Soldier,U.S. House,2,D,Margie Wakefield,40,33,7,0
-Jackson,St. Creek,U.S. House,2,D,Margie Wakefield,22,11,11,0
-Jackson,Washington,U.S. House,2,D,Margie Wakefield,41,36,3,2
-Jackson,Whiting,U.S. House,2,D,Margie Wakefield,36,32,4,0
-Jackson,Adrian,Governor,,L,Keen Umbehr,6,5,1,0
-Jackson,Banner,Governor,,L,Keen Umbehr,6,6,0,0
-Jackson,Cedar,Governor,,L,Keen Umbehr,19,14,5,0
-Jackson,Douglas,Governor,,L,Keen Umbehr,41,37,4,0
-Jackson,Franklin,Governor,,L,Keen Umbehr,16,12,4,0
-Jackson,Garfield,Governor,,L,Keen Umbehr,8,7,1,0
-Jackson,Grant,Governor,,L,Keen Umbehr,5,4,1,0
-Jackson,Jefferson,Governor,,L,Keen Umbehr,9,8,1,0
-Jackson,Liberty,Governor,,L,Keen Umbehr,13,11,2,0
-Jackson,Lincoln,Governor,,L,Keen Umbehr,17,17,0,0
-Jackson,Netawaka,Governor,,L,Keen Umbehr,7,7,0,0
-Jackson,Soldier,Governor,,L,Keen Umbehr,4,3,1,0
-Jackson,St. Creek,Governor,,L,Keen Umbehr,1,1,0,0
-Jackson,Washington,Governor,,L,Keen Umbehr,7,6,1,0
-Jackson,Whiting,Governor,,L,Keen Umbehr,13,11,1,0
-Jackson,Adrian,Governor,,D,Paul Davis,12,9,3,0
-Jackson,Banner,Governor,,D,Paul Davis,60,46,14,0
-Jackson,Cedar,Governor,,D,Paul Davis,202,169,27,6
-Jackson,Douglas,Governor,,D,Paul Davis,415,356,55,4
-Jackson,Franklin,Governor,,D,Paul Davis,214,170,44,0
-Jackson,Garfield,Governor,,D,Paul Davis,101,85,14,2
-Jackson,Grant,Governor,,D,Paul Davis,40,33,7,0
-Jackson,Jefferson,Governor,,D,Paul Davis,91,75,16,0
-Jackson,Liberty,Governor,,D,Paul Davis,118,90,26,2
-Jackson,Lincoln,Governor,,D,Paul Davis,220,183,31,6
-Jackson,Netawaka,Governor,,D,Paul Davis,61,59,2,0
-Jackson,Soldier,Governor,,D,Paul Davis,62,53,9,0
-Jackson,St. Creek,Governor,,D,Paul Davis,37,18,19,0
-Jackson,Washington,Governor,,D,Paul Davis,63,56,4,3
-Jackson,Whiting,Governor,,D,Paul Davis,52,49,3,0
-Jackson,Adrian,Governor,,R,Sam Brownback,39,32,7,0
-Jackson,Banner,Governor,,R,Sam Brownback,80,66,13,1
-Jackson,Cedar,Governor,,R,Sam Brownback,238,194,37,7
-Jackson,Douglas,Governor,,R,Sam Brownback,416,361,48,7
-Jackson,Franklin,Governor,,R,Sam Brownback,207,148,53,6
-Jackson,Garfield,Governor,,R,Sam Brownback,139,122,17,0
-Jackson,Grant,Governor,,R,Sam Brownback,35,25,9,1
-Jackson,Jefferson,Governor,,R,Sam Brownback,127,100,27,0
-Jackson,Liberty,Governor,,R,Sam Brownback,104,89,15,0
-Jackson,Lincoln,Governor,,R,Sam Brownback,108,84,18,6
-Jackson,Netawaka,Governor,,R,Sam Brownback,51,48,3,0
-Jackson,Soldier,Governor,,R,Sam Brownback,95,78,15,2
-Jackson,St. Creek,Governor,,R,Sam Brownback,38,24,12,2
-Jackson,Washington,Governor,,R,Sam Brownback,124,120,3,1
-Jackson,Whiting,Governor,,R,Sam Brownback,70,64,4,2
-Jackson,Adrian,Insurance Commissioner,,D,Dennis Anderson,13,9,4,0
-Jackson,Banner,Insurance Commissioner,,D,Dennis Anderson,34,25,9,0
-Jackson,Cedar,Insurance Commissioner,,D,Dennis Anderson,153,124,23,6
-Jackson,Douglas,Insurance Commissioner,,D,Dennis Anderson,342,293,47,2
-Jackson,Franklin,Insurance Commissioner,,D,Dennis Anderson,122,94,28,0
-Jackson,Garfield,Insurance Commissioner,,D,Dennis Anderson,81,68,11,2
-Jackson,Grant,Insurance Commissioner,,D,Dennis Anderson,29,22,7,0
-Jackson,Jefferson,Insurance Commissioner,,D,Dennis Anderson,62,48,14,0
-Jackson,Liberty,Insurance Commissioner,,D,Dennis Anderson,79,61,17,1
-Jackson,Lincoln,Insurance Commissioner,,D,Dennis Anderson,208,176,27,5
-Jackson,Netawaka,Insurance Commissioner,,D,Dennis Anderson,46,44,2,0
-Jackson,Soldier,Insurance Commissioner,,D,Dennis Anderson,52,43,9,0
-Jackson,St. Creek,Insurance Commissioner,,D,Dennis Anderson,20,8,12,0
-Jackson,Washington,Insurance Commissioner,,D,Dennis Anderson,47,42,3,2
-Jackson,Whiting,Insurance Commissioner,,D,Dennis Anderson,42,37,4,1
-Jackson,Adrian,Insurance Commissioner,,R,Ken Selzer,39,33,6,0
-Jackson,Banner,Insurance Commissioner,,R,Ken Selzer,99,84,14,1
-Jackson,Cedar,Insurance Commissioner,,R,Ken Selzer,278,234,38,6
-Jackson,Douglas,Insurance Commissioner,,R,Ken Selzer,490,423,59,8
-Jackson,Franklin,Insurance Commissioner,,R,Ken Selzer,282,209,68,5
-Jackson,Garfield,Insurance Commissioner,,R,Ken Selzer,155,134,21,0
-Jackson,Grant,Insurance Commissioner,,R,Ken Selzer,49,38,10,1
-Jackson,Jefferson,Insurance Commissioner,,R,Ken Selzer,157,131,26,0
-Jackson,Liberty,Insurance Commissioner,,R,Ken Selzer,147,123,24,0
-Jackson,Lincoln,Insurance Commissioner,,R,Ken Selzer,132,105,20,7
-Jackson,Netawaka,Insurance Commissioner,,R,Ken Selzer,71,69,2,0
-Jackson,Soldier,Insurance Commissioner,,R,Ken Selzer,101,84,15,2
-Jackson,St. Creek,Insurance Commissioner,,R,Ken Selzer,46,27,17,2
-Jackson,Washington,Insurance Commissioner,,R,Ken Selzer,137,130,5,2
-Jackson,Whiting,Insurance Commissioner,,R,Ken Selzer,87,81,4,2
-Jackson,Adrian,Secretary of State,,D,Jean Schodorf,14,10,4,0
-Jackson,Banner,Secretary of State,,D,Jean Schodorf,41,31,10,0
-Jackson,Cedar,Secretary of State,,D,Jean Schodorf,143,117,21,5
-Jackson,Douglas,Secretary of State,,D,Jean Schodorf,301,250,50,1
-Jackson,Franklin,Secretary of State,,D,Jean Schodorf,135,103,31,1
-Jackson,Garfield,Secretary of State,,D,Jean Schodorf,75,64,9,2
-Jackson,Grant,Secretary of State,,D,Jean Schodorf,25,19,5,1
-Jackson,Jefferson,Secretary of State,,D,Jean Schodorf,58,49,9,0
-Jackson,Liberty,Secretary of State,,D,Jean Schodorf,80,61,18,1
-Jackson,Lincoln,Secretary of State,,D,Jean Schodorf,193,165,24,4
-Jackson,Netawaka,Secretary of State,,D,Jean Schodorf,38,37,1,0
-Jackson,Soldier,Secretary of State,,D,Jean Schodorf,42,35,7,0
-Jackson,St. Creek,Secretary of State,,D,Jean Schodorf,23,13,10,0
-Jackson,Washington,Secretary of State,,D,Jean Schodorf,51,45,4,2
-Jackson,Whiting,Secretary of State,,D,Jean Schodorf,37,33,4,0
-Jackson,Adrian,Secretary of State,,R,Kris Kobach,42,35,7,0
-Jackson,Banner,Secretary of State,,R,Kris Kobach,104,86,17,1
-Jackson,Cedar,Secretary of State,,R,Kris Kobach,316,260,48,8
-Jackson,Douglas,Secretary of State,,R,Kris Kobach,558,493,56,9
-Jackson,Franklin,Secretary of State,,R,Kris Kobach,296,224,67,5
-Jackson,Garfield,Secretary of State,,R,Kris Kobach,170,148,22,0
-Jackson,Grant,Secretary of State,,R,Kris Kobach,53,42,11,0
-Jackson,Jefferson,Secretary of State,,R,Kris Kobach,169,134,35,0
-Jackson,Liberty,Secretary of State,,R,Kris Kobach,152,127,25,0
-Jackson,Lincoln,Secretary of State,,R,Kris Kobach,150,118,25,7
-Jackson,Netawaka,Secretary of State,,R,Kris Kobach,82,78,4,0
-Jackson,Soldier,Secretary of State,,R,Kris Kobach,116,97,17,2
-Jackson,St. Creek,Secretary of State,,R,Kris Kobach,51,28,21,2
-Jackson,Washington,Secretary of State,,R,Kris Kobach,141,135,4,2
-Jackson,Whiting,Secretary of State,,R,Kris Kobach,98,91,4,3
-Jackson,Adrian,State House,61,R,Becky Hutchins,42,35,7,0
-Jackson,Banner,State House,61,R,Becky Hutchins,102,87,14,1
-Jackson,Cedar,State House,61,R,Becky Hutchins,312,260,45,7
-Jackson,Douglas,State House,61,R,Becky Hutchins,571,495,68,8
-Jackson,Franklin,State House,61,R,Becky Hutchins,322,241,75,6
-Jackson,Garfield,State House,61,R,Becky Hutchins,189,165,22,2
-Jackson,Grant,State House,61,R,Becky Hutchins,51,38,12,1
-Jackson,Jefferson,State House,61,R,Becky Hutchins,148,121,27,0
-Jackson,Liberty,State House,61,R,Becky Hutchins,157,130,26,1
-Jackson,Lincoln,State House,61,R,Becky Hutchins,137,108,24,5
-Jackson,Soldier,State House,61,R,Becky Hutchins,102,86,14,2
-Jackson,St. Creek,State House,61,R,Becky Hutchins,62,37,23,2
-Jackson,Washington,State House,61,R,Becky Hutchins,143,135,5,3
-Jackson,Adrian,State House,61,D,Vivian Olsen,14,10,4,0
-Jackson,Banner,State House,61,D,Vivian Olsen,43,30,13,0
-Jackson,Cedar,State House,61,D,Vivian Olsen,138,110,22,6
-Jackson,Douglas,State House,61,D,Vivian Olsen,294,252,39,3
-Jackson,Franklin,State House,61,D,Vivian Olsen,114,88,26,0
-Jackson,Garfield,State House,61,D,Vivian Olsen,62,52,10,0
-Jackson,Grant,State House,61,D,Vivian Olsen,29,24,5,0
-Jackson,Jefferson,State House,61,D,Vivian Olsen,79,63,16,0
-Jackson,Liberty,State House,61,D,Vivian Olsen,73,55,17,1
-Jackson,Lincoln,State House,61,D,Vivian Olsen,209,178,24,7
-Jackson,Soldier,State House,61,D,Vivian Olsen,57,46,11,0
-Jackson,St. Creek,State House,61,D,Vivian Olsen,15,6,9,0
-Jackson,Washington,State House,61,D,Vivian Olsen,48,44,3,1
-Jackson,Netawaka,State House,62,R,Randy Garber,65,63,2,0
-Jackson,Whiting,State House,62,R,Randy Garber,67,60,4,3
-Jackson,Netawaka,State House,62,D,Steve Lukert,57,54,3,0
-Jackson,Whiting,State House,62,D,Steve Lukert,68,64,4,0
-Jackson,Adrian,State Treasurer,,D,Carmen Alldritt,9,6,3,0
-Jackson,Banner,State Treasurer,,D,Carmen Alldritt,29,22,7,0
-Jackson,Cedar,State Treasurer,,D,Carmen Alldritt,134,111,17,6
-Jackson,Douglas,State Treasurer,,D,Carmen Alldritt,282,243,37,2
-Jackson,Franklin,State Treasurer,,D,Carmen Alldritt,105,80,25,0
-Jackson,Garfield,State Treasurer,,D,Carmen Alldritt,63,55,7,1
-Jackson,Grant,State Treasurer,,D,Carmen Alldritt,28,21,7,0
-Jackson,Jefferson,State Treasurer,,D,Carmen Alldritt,55,47,8,0
-Jackson,Liberty,State Treasurer,,D,Carmen Alldritt,62,49,12,1
-Jackson,Lincoln,State Treasurer,,D,Carmen Alldritt,186,158,22,6
-Jackson,Netawaka,State Treasurer,,D,Carmen Alldritt,25,25,0,0
-Jackson,Soldier,State Treasurer,,D,Carmen Alldritt,50,42,8,0
-Jackson,St. Creek,State Treasurer,,D,Carmen Alldritt,15,5,10,0
-Jackson,Washington,State Treasurer,,D,Carmen Alldritt,38,32,4,2
-Jackson,Whiting,State Treasurer,,D,Carmen Alldritt,25,23,2,0
-Jackson,Adrian,State Treasurer,,R,Ron Estes,46,38,8,0
-Jackson,Banner,State Treasurer,,R,Ron Estes,109,91,17,1
-Jackson,Cedar,State Treasurer,,R,Ron Estes,320,262,52,6
-Jackson,Douglas,State Treasurer,,R,Ron Estes,563,486,69,8
-Jackson,Franklin,State Treasurer,,R,Ron Estes,318,240,73,5
-Jackson,Garfield,State Treasurer,,R,Ron Estes,181,155,25,1
-Jackson,Grant,State Treasurer,,R,Ron Estes,50,40,9,1
-Jackson,Jefferson,State Treasurer,,R,Ron Estes,171,136,35,0
-Jackson,Liberty,State Treasurer,,R,Ron Estes,166,137,29,0
-Jackson,Lincoln,State Treasurer,,R,Ron Estes,157,125,26,6
-Jackson,Netawaka,State Treasurer,,R,Ron Estes,94,89,5,0
-Jackson,Soldier,State Treasurer,,R,Ron Estes,107,89,16,2
-Jackson,St. Creek,State Treasurer,,R,Ron Estes,58,35,21,2
-Jackson,Washington,State Treasurer,,R,Ron Estes,148,142,4,2
-Jackson,Whiting,State Treasurer,,R,Ron Estes,105,96,6,3
-Jackson,Adrian,U.S. Senate,,I,Greg Orman,10,7,3,0
-Jackson,Banner,U.S. Senate,,I,Greg Orman,46,34,12,0
-Jackson,Cedar,U.S. Senate,,I,Greg Orman,177,146,27,4
-Jackson,Douglas,U.S. Senate,,I,Greg Orman,379,322,55,2
-Jackson,Franklin,U.S. Senate,,I,Greg Orman,167,129,38,0
-Jackson,Garfield,U.S. Senate,,I,Greg Orman,90,77,11,2
-Jackson,Grant,U.S. Senate,,I,Greg Orman,33,26,6,1
-Jackson,Jefferson,U.S. Senate,,I,Greg Orman,84,68,16,0
-Jackson,Liberty,U.S. Senate,,I,Greg Orman,101,75,24,2
-Jackson,Lincoln,U.S. Senate,,I,Greg Orman,215,174,33,8
-Jackson,Netawaka,U.S. Senate,,I,Greg Orman,46,45,1,0
-Jackson,Soldier,U.S. Senate,,I,Greg Orman,52,43,9,0
-Jackson,St. Creek,U.S. Senate,,I,Greg Orman,30,15,15,0
-Jackson,Washington,U.S. Senate,,I,Greg Orman,57,52,3,2
-Jackson,Whiting,U.S. Senate,,I,Greg Orman,43,39,4,0
-Jackson,Adrian,U.S. Senate,,R,Pat Roberts,45,37,8,0
-Jackson,Banner,U.S. Senate,,R,Pat Roberts,92,77,15,0
-Jackson,Cedar,U.S. Senate,,R,Pat Roberts,250,204,38,8
-Jackson,Douglas,U.S. Senate,,R,Pat Roberts,446,392,46,8
-Jackson,Franklin,U.S. Senate,,R,Pat Roberts,243,182,55,6
-Jackson,Garfield,U.S. Senate,,R,Pat Roberts,149,130,19,0
-Jackson,Grant,U.S. Senate,,R,Pat Roberts,45,34,11,0
-Jackson,Jefferson,U.S. Senate,,R,Pat Roberts,128,102,26,0
-Jackson,Liberty,U.S. Senate,,R,Pat Roberts,121,103,18,0
-Jackson,Lincoln,U.S. Senate,,R,Pat Roberts,111,90,17,4
-Jackson,Netawaka,U.S. Senate,,R,Pat Roberts,71,67,4,0
-Jackson,Soldier,U.S. Senate,,R,Pat Roberts,101,85,14,2
-Jackson,St. Creek,U.S. Senate,,R,Pat Roberts,43,27,14,2
-Jackson,Washington,U.S. Senate,,R,Pat Roberts,130,125,4,1
-Jackson,Whiting,U.S. Senate,,R,Pat Roberts,75,69,4,2
-Jackson,Adrian,U.S. Senate,,L,Randall Batson,1,1,0,0
-Jackson,Banner,U.S. Senate,,L,Randall Batson,6,5,0,1
-Jackson,Cedar,U.S. Senate,,L,Randall Batson,29,24,4,1
-Jackson,Douglas,U.S. Senate,,L,Randall Batson,44,38,5,1
-Jackson,Franklin,U.S. Senate,,L,Randall Batson,20,15,5,0
-Jackson,Garfield,U.S. Senate,,L,Randall Batson,8,7,1,0
-Jackson,Grant,U.S. Senate,,L,Randall Batson,2,2,0,0
-Jackson,Jefferson,U.S. Senate,,L,Randall Batson,13,12,1,0
-Jackson,Liberty,U.S. Senate,,L,Randall Batson,12,11,1,0
-Jackson,Lincoln,U.S. Senate,,L,Randall Batson,20,20,0,0
-Jackson,Netawaka,U.S. Senate,,L,Randall Batson,3,3,0,0
-Jackson,Soldier,U.S. Senate,,L,Randall Batson,5,3,2,0
-Jackson,St. Creek,U.S. Senate,,L,Randall Batson,4,1,3,0
-Jackson,Washington,U.S. Senate,,L,Randall Batson,5,3,1,1
-Jackson,Whiting,U.S. Senate,,L,Randall Batson,15,14,0,1
-Jackson,Adrian,Voters,,,Cast,47,,,
-Jackson,Banner,Voters,,,Cast,120,,,
-Jackson,Cedar,Voters,,,Cast,393,,,
-Jackson,Douglas,Voters,,,Cast,765,,,
-Jackson,Franklin,Voters,,,Cast,333,,,
-Jackson,Garfield,Voters,,,Cast,221,,,
-Jackson,Grant,Voters,,,Cast,63,,,
-Jackson,Jefferson,Voters,,,Cast,186,,,
-Jackson,Liberty,Voters,,,Cast,192,,,
-Jackson,Lincoln,Voters,,,Cast,300,,,
-Jackson,Netawaka,Voters,,,Cast,117,,,
-Jackson,Soldier,Voters,,,Cast,138,,,
-Jackson,St. Creek,Voters,,,Cast,44,,,
-Jackson,Washington,Voters,,,Cast,186,,,
-Jackson,Whiting,Voters,,,Cast,129,,,
-Jackson,Advance,Voters,,,Cast,852,,,
-Jackson,Adrian,Voters,,,Registered,106,,,
-Jackson,Banner,Voters,,,Registered,216,,,
-Jackson,Cedar,Voters,,,Registered,900,,,
-Jackson,Douglas,Voters,,,Registered,1580,,,
-Jackson,Franklin,Voters,,,Registered,689,,,
-Jackson,Garfield,Voters,,,Registered,400,,,
-Jackson,Grant,Voters,,,Registered,114,,,
-Jackson,Jefferson,Voters,,,Registered,365,,,
-Jackson,Liberty,Voters,,,Registered,382,,,
-Jackson,Lincoln,Voters,,,Registered,762,,,
-Jackson,Netawaka,Voters,,,Registered,223,,,
-Jackson,Soldier,Voters,,,Registered,263,,,
-Jackson,St. Creek,Voters,,,Registered,116,,,
-Jackson,Washington,Voters,,,Registered,348,,,
-Jackson,Whiting,Voters,,,Registered,257,,,
+county,precinct,office,district,party,candidate,votes,vtd
+JACKSON,Adrian Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000010
+JACKSON,Adrian Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000010
+JACKSON,Adrian Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000010
+JACKSON,Banner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",60,000020
+JACKSON,Banner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000020
+JACKSON,Banner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000020
+JACKSON,Cedar Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",202,000030
+JACKSON,Cedar Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000030
+JACKSON,Cedar Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",238,000030
+JACKSON,Douglas Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",415,000040
+JACKSON,Douglas Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",41,000040
+JACKSON,Douglas Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",416,000040
+JACKSON,Franklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",214,000050
+JACKSON,Franklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000050
+JACKSON,Franklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",207,000050
+JACKSON,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",101,000060
+JACKSON,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000060
+JACKSON,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",139,000060
+JACKSON,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000070
+JACKSON,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000070
+JACKSON,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000070
+JACKSON,Holton Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",179,00008A
+JACKSON,Holton Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,00008A
+JACKSON,Holton Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",151,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008B
+JACKSON,Holton Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",216,000090
+JACKSON,Holton Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000090
+JACKSON,Holton Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",156,000090
+JACKSON,Holton Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",153,00010A
+JACKSON,Holton Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,00010A
+JACKSON,Holton Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",137,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00010B
+JACKSON,Jefferson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",91,000110
+JACKSON,Jefferson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000110
+JACKSON,Jefferson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",127,000110
+JACKSON,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",118,000120
+JACKSON,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000120
+JACKSON,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",104,000120
+JACKSON,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",220,000130
+JACKSON,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000130
+JACKSON,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,000130
+JACKSON,Netawaka Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",61,000140
+JACKSON,Netawaka Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000140
+JACKSON,Netawaka Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,000140
+JACKSON,Soldier Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,000150
+JACKSON,Soldier Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000150
+JACKSON,Soldier Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",95,000150
+JACKSON,Straight Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000160
+JACKSON,Straight Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000160
+JACKSON,Straight Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000160
+JACKSON,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",63,000170
+JACKSON,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000170
+JACKSON,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",124,000170
+JACKSON,Whiting Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",52,000180
+JACKSON,Whiting Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000180
+JACKSON,Whiting Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000180
+JACKSON,Adrian Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",14,000010
+JACKSON,Adrian Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",42,000010
+JACKSON,Banner Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",43,000020
+JACKSON,Banner Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",102,000020
+JACKSON,Cedar Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",138,000030
+JACKSON,Cedar Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",312,000030
+JACKSON,Douglas Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",294,000040
+JACKSON,Douglas Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",571,000040
+JACKSON,Franklin Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",114,000050
+JACKSON,Franklin Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",322,000050
+JACKSON,Garfield Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",62,000060
+JACKSON,Garfield Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",189,000060
+JACKSON,Grant Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",29,000070
+JACKSON,Grant Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",51,000070
+JACKSON,Holton Ward 1,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",126,00008A
+JACKSON,Holton Ward 1,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",220,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",0,00008B
+JACKSON,Holton Ward 2,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",133,000090
+JACKSON,Holton Ward 2,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",253,000090
+JACKSON,Holton Ward 3,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",111,00010A
+JACKSON,Holton Ward 3,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",196,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",0,00010B
+JACKSON,Jefferson Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",79,000110
+JACKSON,Jefferson Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",148,000110
+JACKSON,Liberty Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",73,000120
+JACKSON,Liberty Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",157,000120
+JACKSON,Lincoln Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",209,000130
+JACKSON,Lincoln Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",137,000130
+JACKSON,Netawaka Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",57,000140
+JACKSON,Netawaka Township,Kansas House of Representatives,62,Republican,"Garber, Randy",65,000140
+JACKSON,Soldier Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",57,000150
+JACKSON,Soldier Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",102,000150
+JACKSON,Straight Creek Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",15,000160
+JACKSON,Straight Creek Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",62,000160
+JACKSON,Washington Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",48,000170
+JACKSON,Washington Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",143,000170
+JACKSON,Whiting Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",68,000180
+JACKSON,Whiting Township,Kansas House of Representatives,62,Republican,"Garber, Randy",67,000180
+JACKSON,Adrian Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",7,000010
+JACKSON,Adrian Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000010
+JACKSON,Adrian Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,000010
+JACKSON,Banner Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",36,000020
+JACKSON,Banner Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000020
+JACKSON,Banner Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000020
+JACKSON,Cedar Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",134,000030
+JACKSON,Cedar Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,000030
+JACKSON,Cedar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",298,000030
+JACKSON,Douglas Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",313,000040
+JACKSON,Douglas Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",53,000040
+JACKSON,Douglas Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",506,000040
+JACKSON,Franklin Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",129,000050
+JACKSON,Franklin Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000050
+JACKSON,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",290,000050
+JACKSON,Garfield Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",66,000060
+JACKSON,Garfield Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,000060
+JACKSON,Garfield Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000060
+JACKSON,Grant Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000070
+JACKSON,Grant Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000070
+JACKSON,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000070
+JACKSON,Holton Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",117,00008A
+JACKSON,Holton Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,00008A
+JACKSON,Holton Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008B
+JACKSON,Holton Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",134,000090
+JACKSON,Holton Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,000090
+JACKSON,Holton Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",231,000090
+JACKSON,Holton Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",119,00010A
+JACKSON,Holton Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,00010A
+JACKSON,Holton Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",170,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+JACKSON,Jefferson Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",66,000110
+JACKSON,Jefferson Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000110
+JACKSON,Jefferson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",152,000110
+JACKSON,Liberty Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",74,000120
+JACKSON,Liberty Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000120
+JACKSON,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",154,000120
+JACKSON,Lincoln Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",195,000130
+JACKSON,Lincoln Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,000130
+JACKSON,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",129,000130
+JACKSON,Netawaka Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,000140
+JACKSON,Netawaka Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000140
+JACKSON,Netawaka Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",74,000140
+JACKSON,Soldier Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",40,000150
+JACKSON,Soldier Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000150
+JACKSON,Soldier Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",111,000150
+JACKSON,Straight Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",22,000160
+JACKSON,Straight Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000160
+JACKSON,Straight Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,000160
+JACKSON,Washington Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",41,000170
+JACKSON,Washington Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000170
+JACKSON,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",133,000170
+JACKSON,Whiting Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",36,000180
+JACKSON,Whiting Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000180
+JACKSON,Whiting Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,000180
+JACKSON,Adrian Township,Attorney General,,Democratic,"Kotich, A.J.",5,000010
+JACKSON,Adrian Township,Attorney General,,Republican,"Schmidt, Derek",49,000010
+JACKSON,Banner Township,Attorney General,,Democratic,"Kotich, A.J.",28,000020
+JACKSON,Banner Township,Attorney General,,Republican,"Schmidt, Derek",111,000020
+JACKSON,Cedar Township,Attorney General,,Democratic,"Kotich, A.J.",129,000030
+JACKSON,Cedar Township,Attorney General,,Republican,"Schmidt, Derek",320,000030
+JACKSON,Douglas Township,Attorney General,,Democratic,"Kotich, A.J.",260,000040
+JACKSON,Douglas Township,Attorney General,,Republican,"Schmidt, Derek",598,000040
+JACKSON,Franklin Township,Attorney General,,Democratic,"Kotich, A.J.",103,000050
+JACKSON,Franklin Township,Attorney General,,Republican,"Schmidt, Derek",323,000050
+JACKSON,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",62,000060
+JACKSON,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",181,000060
+JACKSON,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",23,000070
+JACKSON,Grant Township,Attorney General,,Republican,"Schmidt, Derek",55,000070
+JACKSON,Holton Ward 1,Attorney General,,Democratic,"Kotich, A.J.",93,00008A
+JACKSON,Holton Ward 1,Attorney General,,Republican,"Schmidt, Derek",248,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Attorney General,,Democratic,"Kotich, A.J.",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Attorney General,,Republican,"Schmidt, Derek",0,00008B
+JACKSON,Holton Ward 2,Attorney General,,Democratic,"Kotich, A.J.",118,000090
+JACKSON,Holton Ward 2,Attorney General,,Republican,"Schmidt, Derek",260,000090
+JACKSON,Holton Ward 3,Attorney General,,Democratic,"Kotich, A.J.",88,00010A
+JACKSON,Holton Ward 3,Attorney General,,Republican,"Schmidt, Derek",213,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Attorney General,,Democratic,"Kotich, A.J.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Attorney General,,Republican,"Schmidt, Derek",0,00010B
+JACKSON,Jefferson Township,Attorney General,,Democratic,"Kotich, A.J.",53,000110
+JACKSON,Jefferson Township,Attorney General,,Republican,"Schmidt, Derek",171,000110
+JACKSON,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",66,000120
+JACKSON,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",160,000120
+JACKSON,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",185,000130
+JACKSON,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",159,000130
+JACKSON,Netawaka Township,Attorney General,,Democratic,"Kotich, A.J.",34,000140
+JACKSON,Netawaka Township,Attorney General,,Republican,"Schmidt, Derek",85,000140
+JACKSON,Soldier Township,Attorney General,,Democratic,"Kotich, A.J.",44,000150
+JACKSON,Soldier Township,Attorney General,,Republican,"Schmidt, Derek",113,000150
+JACKSON,Straight Creek Township,Attorney General,,Democratic,"Kotich, A.J.",15,000160
+JACKSON,Straight Creek Township,Attorney General,,Republican,"Schmidt, Derek",58,000160
+JACKSON,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",36,000170
+JACKSON,Washington Township,Attorney General,,Republican,"Schmidt, Derek",153,000170
+JACKSON,Whiting Township,Attorney General,,Democratic,"Kotich, A.J.",25,000180
+JACKSON,Whiting Township,Attorney General,,Republican,"Schmidt, Derek",108,000180
+JACKSON,Adrian Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000010
+JACKSON,Adrian Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000010
+JACKSON,Banner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000020
+JACKSON,Banner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",99,000020
+JACKSON,Cedar Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",153,000030
+JACKSON,Cedar Township,Commissioner of Insurance,,Republican,"Selzer, Ken",278,000030
+JACKSON,Douglas Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",342,000040
+JACKSON,Douglas Township,Commissioner of Insurance,,Republican,"Selzer, Ken",490,000040
+JACKSON,Franklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",122,000050
+JACKSON,Franklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",282,000050
+JACKSON,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000060
+JACKSON,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",155,000060
+JACKSON,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000070
+JACKSON,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000070
+JACKSON,Holton Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",126,00008A
+JACKSON,Holton Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",211,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00008B
+JACKSON,Holton Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",154,000090
+JACKSON,Holton Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",201,000090
+JACKSON,Holton Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",119,00010A
+JACKSON,Holton Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",167,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00010B
+JACKSON,Jefferson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,000110
+JACKSON,Jefferson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",157,000110
+JACKSON,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",79,000120
+JACKSON,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",147,000120
+JACKSON,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",208,000130
+JACKSON,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",132,000130
+JACKSON,Netawaka Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000140
+JACKSON,Netawaka Township,Commissioner of Insurance,,Republican,"Selzer, Ken",71,000140
+JACKSON,Soldier Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000150
+JACKSON,Soldier Township,Commissioner of Insurance,,Republican,"Selzer, Ken",101,000150
+JACKSON,Straight Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000160
+JACKSON,Straight Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000160
+JACKSON,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000170
+JACKSON,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",137,000170
+JACKSON,Whiting Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000180
+JACKSON,Whiting Township,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000180
+JACKSON,Adrian Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000010
+JACKSON,Adrian Township,Secretary of State,,Republican,"Kobach, Kris",42,000010
+JACKSON,Banner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000020
+JACKSON,Banner Township,Secretary of State,,Republican,"Kobach, Kris",104,000020
+JACKSON,Cedar Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",143,000030
+JACKSON,Cedar Township,Secretary of State,,Republican,"Kobach, Kris",316,000030
+JACKSON,Douglas Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",301,000040
+JACKSON,Douglas Township,Secretary of State,,Republican,"Kobach, Kris",558,000040
+JACKSON,Franklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",135,000050
+JACKSON,Franklin Township,Secretary of State,,Republican,"Kobach, Kris",296,000050
+JACKSON,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000060
+JACKSON,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",170,000060
+JACKSON,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000070
+JACKSON,Grant Township,Secretary of State,,Republican,"Kobach, Kris",53,000070
+JACKSON,Holton Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",125,00008A
+JACKSON,Holton Ward 1,Secretary of State,,Republican,"Kobach, Kris",222,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Secretary of State,,Republican,"Kobach, Kris",0,00008B
+JACKSON,Holton Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",136,000090
+JACKSON,Holton Ward 2,Secretary of State,,Republican,"Kobach, Kris",245,000090
+JACKSON,Holton Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",104,00010A
+JACKSON,Holton Ward 3,Secretary of State,,Republican,"Kobach, Kris",200,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Secretary of State,,Republican,"Kobach, Kris",0,00010B
+JACKSON,Jefferson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000110
+JACKSON,Jefferson Township,Secretary of State,,Republican,"Kobach, Kris",169,000110
+JACKSON,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",80,000120
+JACKSON,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",152,000120
+JACKSON,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",193,000130
+JACKSON,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",150,000130
+JACKSON,Netawaka Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000140
+JACKSON,Netawaka Township,Secretary of State,,Republican,"Kobach, Kris",82,000140
+JACKSON,Soldier Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000150
+JACKSON,Soldier Township,Secretary of State,,Republican,"Kobach, Kris",116,000150
+JACKSON,Straight Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000160
+JACKSON,Straight Creek Township,Secretary of State,,Republican,"Kobach, Kris",51,000160
+JACKSON,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000170
+JACKSON,Washington Township,Secretary of State,,Republican,"Kobach, Kris",141,000170
+JACKSON,Whiting Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000180
+JACKSON,Whiting Township,Secretary of State,,Republican,"Kobach, Kris",98,000180
+JACKSON,Adrian Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000010
+JACKSON,Adrian Township,State Treasurer,,Republican,"Estes, Ron",46,000010
+JACKSON,Banner Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000020
+JACKSON,Banner Township,State Treasurer,,Republican,"Estes, Ron",109,000020
+JACKSON,Cedar Township,State Treasurer,,Democratic,"Alldritt, Carmen",134,000030
+JACKSON,Cedar Township,State Treasurer,,Republican,"Estes, Ron",320,000030
+JACKSON,Douglas Township,State Treasurer,,Democratic,"Alldritt, Carmen",282,000040
+JACKSON,Douglas Township,State Treasurer,,Republican,"Estes, Ron",563,000040
+JACKSON,Franklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",105,000050
+JACKSON,Franklin Township,State Treasurer,,Republican,"Estes, Ron",318,000050
+JACKSON,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",63,000060
+JACKSON,Garfield Township,State Treasurer,,Republican,"Estes, Ron",181,000060
+JACKSON,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000070
+JACKSON,Grant Township,State Treasurer,,Republican,"Estes, Ron",50,000070
+JACKSON,Holton Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",105,00008A
+JACKSON,Holton Ward 1,State Treasurer,,Republican,"Estes, Ron",234,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,State Treasurer,,Republican,"Estes, Ron",0,00008B
+JACKSON,Holton Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",126,000090
+JACKSON,Holton Ward 2,State Treasurer,,Republican,"Estes, Ron",248,000090
+JACKSON,Holton Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",86,00010A
+JACKSON,Holton Ward 3,State Treasurer,,Republican,"Estes, Ron",210,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,State Treasurer,,Democratic,"Alldritt, Carmen",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,State Treasurer,,Republican,"Estes, Ron",0,00010B
+JACKSON,Jefferson Township,State Treasurer,,Democratic,"Alldritt, Carmen",55,000110
+JACKSON,Jefferson Township,State Treasurer,,Republican,"Estes, Ron",171,000110
+JACKSON,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",62,000120
+JACKSON,Liberty Township,State Treasurer,,Republican,"Estes, Ron",166,000120
+JACKSON,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",186,000130
+JACKSON,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",157,000130
+JACKSON,Netawaka Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000140
+JACKSON,Netawaka Township,State Treasurer,,Republican,"Estes, Ron",94,000140
+JACKSON,Soldier Township,State Treasurer,,Democratic,"Alldritt, Carmen",50,000150
+JACKSON,Soldier Township,State Treasurer,,Republican,"Estes, Ron",107,000150
+JACKSON,Straight Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000160
+JACKSON,Straight Creek Township,State Treasurer,,Republican,"Estes, Ron",58,000160
+JACKSON,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000170
+JACKSON,Washington Township,State Treasurer,,Republican,"Estes, Ron",148,000170
+JACKSON,Whiting Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000180
+JACKSON,Whiting Township,State Treasurer,,Republican,"Estes, Ron",105,000180
+JACKSON,Adrian Township,United States Senate,,independent,"Orman, Greg",10,000010
+JACKSON,Adrian Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+JACKSON,Adrian Township,United States Senate,,Republican,"Roberts, Pat",45,000010
+JACKSON,Banner Township,United States Senate,,independent,"Orman, Greg",46,000020
+JACKSON,Banner Township,United States Senate,,Libertarian,"Batson, Randall",6,000020
+JACKSON,Banner Township,United States Senate,,Republican,"Roberts, Pat",92,000020
+JACKSON,Cedar Township,United States Senate,,independent,"Orman, Greg",177,000030
+JACKSON,Cedar Township,United States Senate,,Libertarian,"Batson, Randall",29,000030
+JACKSON,Cedar Township,United States Senate,,Republican,"Roberts, Pat",250,000030
+JACKSON,Douglas Township,United States Senate,,independent,"Orman, Greg",379,000040
+JACKSON,Douglas Township,United States Senate,,Libertarian,"Batson, Randall",44,000040
+JACKSON,Douglas Township,United States Senate,,Republican,"Roberts, Pat",446,000040
+JACKSON,Franklin Township,United States Senate,,independent,"Orman, Greg",167,000050
+JACKSON,Franklin Township,United States Senate,,Libertarian,"Batson, Randall",20,000050
+JACKSON,Franklin Township,United States Senate,,Republican,"Roberts, Pat",243,000050
+JACKSON,Garfield Township,United States Senate,,independent,"Orman, Greg",90,000060
+JACKSON,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",8,000060
+JACKSON,Garfield Township,United States Senate,,Republican,"Roberts, Pat",149,000060
+JACKSON,Grant Township,United States Senate,,independent,"Orman, Greg",33,000070
+JACKSON,Grant Township,United States Senate,,Libertarian,"Batson, Randall",2,000070
+JACKSON,Grant Township,United States Senate,,Republican,"Roberts, Pat",45,000070
+JACKSON,Holton Ward 1,United States Senate,,independent,"Orman, Greg",162,00008A
+JACKSON,Holton Ward 1,United States Senate,,Libertarian,"Batson, Randall",25,00008A
+JACKSON,Holton Ward 1,United States Senate,,Republican,"Roberts, Pat",160,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,United States Senate,,independent,"Orman, Greg",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States Senate,,Libertarian,"Batson, Randall",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States Senate,,Republican,"Roberts, Pat",0,00008B
+JACKSON,Holton Ward 2,United States Senate,,independent,"Orman, Greg",181,000090
+JACKSON,Holton Ward 2,United States Senate,,Libertarian,"Batson, Randall",11,000090
+JACKSON,Holton Ward 2,United States Senate,,Republican,"Roberts, Pat",192,000090
+JACKSON,Holton Ward 3,United States Senate,,independent,"Orman, Greg",141,00010A
+JACKSON,Holton Ward 3,United States Senate,,Libertarian,"Batson, Randall",11,00010A
+JACKSON,Holton Ward 3,United States Senate,,Republican,"Roberts, Pat",151,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States Senate,,independent,"Orman, Greg",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States Senate,,Libertarian,"Batson, Randall",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States Senate,,Republican,"Roberts, Pat",0,00010B
+JACKSON,Jefferson Township,United States Senate,,independent,"Orman, Greg",84,000110
+JACKSON,Jefferson Township,United States Senate,,Libertarian,"Batson, Randall",13,000110
+JACKSON,Jefferson Township,United States Senate,,Republican,"Roberts, Pat",128,000110
+JACKSON,Liberty Township,United States Senate,,independent,"Orman, Greg",101,000120
+JACKSON,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",12,000120
+JACKSON,Liberty Township,United States Senate,,Republican,"Roberts, Pat",121,000120
+JACKSON,Lincoln Township,United States Senate,,independent,"Orman, Greg",215,000130
+JACKSON,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",20,000130
+JACKSON,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",111,000130
+JACKSON,Netawaka Township,United States Senate,,independent,"Orman, Greg",46,000140
+JACKSON,Netawaka Township,United States Senate,,Libertarian,"Batson, Randall",3,000140
+JACKSON,Netawaka Township,United States Senate,,Republican,"Roberts, Pat",71,000140
+JACKSON,Soldier Township,United States Senate,,independent,"Orman, Greg",52,000150
+JACKSON,Soldier Township,United States Senate,,Libertarian,"Batson, Randall",5,000150
+JACKSON,Soldier Township,United States Senate,,Republican,"Roberts, Pat",101,000150
+JACKSON,Straight Creek Township,United States Senate,,independent,"Orman, Greg",30,000160
+JACKSON,Straight Creek Township,United States Senate,,Libertarian,"Batson, Randall",4,000160
+JACKSON,Straight Creek Township,United States Senate,,Republican,"Roberts, Pat",43,000160
+JACKSON,Washington Township,United States Senate,,independent,"Orman, Greg",57,000170
+JACKSON,Washington Township,United States Senate,,Libertarian,"Batson, Randall",5,000170
+JACKSON,Washington Township,United States Senate,,Republican,"Roberts, Pat",130,000170
+JACKSON,Whiting Township,United States Senate,,independent,"Orman, Greg",43,000180
+JACKSON,Whiting Township,United States Senate,,Libertarian,"Batson, Randall",15,000180
+JACKSON,Whiting Township,United States Senate,,Republican,"Roberts, Pat",75,000180

--- a/2014/20141104__ks__general__jefferson__precinct.csv
+++ b/2014/20141104__ks__general__jefferson__precinct.csv
@@ -1,337 +1,248 @@
-county,precinct,office,district,party,candidate,votes,advance,polling
-Jefferson,Delaware,Voters,,,Registered,1302,,
-Jefferson,East Fairview,Voters,,,Registered,745,,
-Jefferson,Jefferson,Voters,,,Registered,774,,
-Jefferson,Kaw,Voters,,,Registered,944,,
-Jefferson,Kentucky,Voters,,,Registered,1116,,
-Jefferson,Norton,Voters,,,Registered,543,,
-Jefferson,Oskaloosa,Voters,,,Registered,1459,,
-Jefferson,Ozawkie,Voters,,,Registered,1171,,
-Jefferson,Rock Creek,Voters,,,Registered,1848,,
-Jefferson,Rural,Voters,,,Registered,524,,
-Jefferson,Sarcoxie,Voters,,,Registered,800,,
-Jefferson,Union,Voters,,,Registered,1182,,
-Jefferson,West Fairview,Voters,,,Registered,480,,
-Jefferson,JEFFERSON KS,Voters,,,Registered,12888,,
-Jefferson,Delaware,Voters,,,Cast,634,55,579
-Jefferson,East Fairview,Voters,,,Cast,321,38,283
-Jefferson,Jefferson,Voters,,,Cast,348,29,319
-Jefferson,Kaw,Voters,,,Cast,578,51,527
-Jefferson,Kentucky,Voters,,,Cast,605,52,553
-Jefferson,Norton,Voters,,,Cast,290,16,274
-Jefferson,Oskaloosa,Voters,,,Cast,707,96,611
-Jefferson,Ozawkie,Voters,,,Cast,596,68,528
-Jefferson,Rock Creek,Voters,,,Cast,974,78,896
-Jefferson,Rural,Voters,,,Cast,294,48,246
-Jefferson,Sarcoxie,Voters,,,Cast,457,50,407
-Jefferson,Union,Voters,,,Cast,538,46,492
-Jefferson,West Fairview,Voters,,,Cast,282,39,243
-Jefferson,JEFFERSON KS,Voters,,,Cast,6624,666,5958
-Jefferson,Delaware,U.S. Senate,,R,Pat Roberts,326,28,298
-Jefferson,East Fairview,U.S. Senate,,R,Pat Roberts,145,13,132
-Jefferson,Jefferson,U.S. Senate,,R,Pat Roberts,211,17,194
-Jefferson,Kaw,U.S. Senate,,R,Pat Roberts,296,22,274
-Jefferson,Kentucky,U.S. Senate,,R,Pat Roberts,277,23,254
-Jefferson,Norton,U.S. Senate,,R,Pat Roberts,164,7,157
-Jefferson,Oskaloosa,U.S. Senate,,R,Pat Roberts,387,47,340
-Jefferson,Ozawkie,U.S. Senate,,R,Pat Roberts,315,33,282
-Jefferson,Rock Creek,U.S. Senate,,R,Pat Roberts,529,52,477
-Jefferson,Rural,U.S. Senate,,R,Pat Roberts,135,13,122
-Jefferson,Sarcoxie,U.S. Senate,,R,Pat Roberts,181,21,160
-Jefferson,Union,U.S. Senate,,R,Pat Roberts,293,30,263
-Jefferson,West Fairview,U.S. Senate,,R,Pat Roberts,162,18,144
-Jefferson,JEFFERSON KS,U.S. Senate,,R,Pat Roberts,3421,324,3097
-Jefferson,Delaware,U.S. Senate,,I,Greg Orman,272,25,247
-Jefferson,East Fairview,U.S. Senate,,I,Greg Orman,154,25,129
-Jefferson,Jefferson,U.S. Senate,,I,Greg Orman,119,12,107
-Jefferson,Kaw,U.S. Senate,,I,Greg Orman,249,24,225
-Jefferson,Kentucky,U.S. Senate,,I,Greg Orman,295,29,266
-Jefferson,Norton,U.S. Senate,,I,Greg Orman,111,9,102
-Jefferson,Oskaloosa,U.S. Senate,,I,Greg Orman,287,44,243
-Jefferson,Ozawkie,U.S. Senate,,I,Greg Orman,253,32,221
-Jefferson,Rock Creek,U.S. Senate,,I,Greg Orman,400,26,374
-Jefferson,Rural,U.S. Senate,,I,Greg Orman,154,32,122
-Jefferson,Sarcoxie,U.S. Senate,,I,Greg Orman,259,27,232
-Jefferson,Union,U.S. Senate,,I,Greg Orman,212,11,201
-Jefferson,West Fairview,U.S. Senate,,I,Greg Orman,113,20,93
-Jefferson,JEFFERSON KS,U.S. Senate,,I,Greg Orman,2878,316,2562
-Jefferson,Delaware,U.S. Senate,,L,Randall Batson,28,2,26
-Jefferson,East Fairview,U.S. Senate,,L,Randall Batson,18,0,18
-Jefferson,Jefferson,U.S. Senate,,L,Randall Batson,17,0,17
-Jefferson,Kaw,U.S. Senate,,L,Randall Batson,27,4,23
-Jefferson,Kentucky,U.S. Senate,,L,Randall Batson,28,0,28
-Jefferson,Norton,U.S. Senate,,L,Randall Batson,12,0,12
-Jefferson,Oskaloosa,U.S. Senate,,L,Randall Batson,27,2,25
-Jefferson,Ozawkie,U.S. Senate,,L,Randall Batson,24,2,22
-Jefferson,Rock Creek,U.S. Senate,,L,Randall Batson,37,0,37
-Jefferson,Rural,U.S. Senate,,L,Randall Batson,4,2,2
-Jefferson,Sarcoxie,U.S. Senate,,L,Randall Batson,11,2,9
-Jefferson,Union,U.S. Senate,,L,Randall Batson,29,5,24
-Jefferson,West Fairview,U.S. Senate,,L,Randall Batson,5,0,5
-Jefferson,JEFFERSON KS,U.S. Senate,,L,Randall Batson,267,19,248
-Jefferson,East Fairview,U.S. Senate,,,Write-ins,1,0,1
-Jefferson,Kaw,U.S. Senate,,,Write-ins,2,0,2
-Jefferson,Kentucky,U.S. Senate,,,Write-ins,1,0,1
-Jefferson,Oskaloosa,U.S. Senate,,,Write-ins,1,0,1
-Jefferson,Union,U.S. Senate,,,Write-ins,1,0,1
-Jefferson,JEFFERSON KS,U.S. Senate,,,Write-ins,7,1,6
-Jefferson,Delaware,U.S. House,2,R,Lynn Jenkins,363,30,333
-Jefferson,East Fairview,U.S. House,2,R,Lynn Jenkins,173,13,160
-Jefferson,Jefferson,U.S. House,2,R,Lynn Jenkins,236,16,220
-Jefferson,Kaw,U.S. House,2,R,Lynn Jenkins,333,25,308
-Jefferson,Kentucky,U.S. House,2,R,Lynn Jenkins,327,27,300
-Jefferson,Norton,U.S. House,2,R,Lynn Jenkins,199,11,188
-Jefferson,Oskaloosa,U.S. House,2,R,Lynn Jenkins,442,53,389
-Jefferson,Ozawkie,U.S. House,2,R,Lynn Jenkins,356,38,318
-Jefferson,Rock Creek,U.S. House,2,R,Lynn Jenkins,598,57,541
-Jefferson,Rural,U.S. House,2,R,Lynn Jenkins,143,14,129
-Jefferson,Sarcoxie,U.S. House,2,R,Lynn Jenkins,200,21,179
-Jefferson,Union,U.S. House,2,R,Lynn Jenkins,347,31,316
-Jefferson,West Fairview,U.S. House,2,R,Lynn Jenkins,185,22,163
-Jefferson,JEFFERSON KS,U.S. House,2,R,Lynn Jenkins,3902,358,3544
-Jefferson,Delaware,U.S. House,2,D,Margie Wakefield,227,21,206
-Jefferson,East Fairview,U.S. House,2,D,Margie Wakefield,128,24,104
-Jefferson,Jefferson,U.S. House,2,D,Margie Wakefield,99,13,86
-Jefferson,Kaw,U.S. House,2,D,Margie Wakefield,220,24,196
-Jefferson,Kentucky,U.S. House,2,D,Margie Wakefield,243,24,219
-Jefferson,Norton,U.S. House,2,D,Margie Wakefield,80,4,76
-Jefferson,Oskaloosa,U.S. House,2,D,Margie Wakefield,228,35,193
-Jefferson,Ozawkie,U.S. House,2,D,Margie Wakefield,217,27,190
-Jefferson,Rock Creek,U.S. House,2,D,Margie Wakefield,321,20,301
-Jefferson,Rural,U.S. House,2,D,Margie Wakefield,143,32,111
-Jefferson,Sarcoxie,U.S. House,2,D,Margie Wakefield,237,27,210
-Jefferson,Union,U.S. House,2,D,Margie Wakefield,166,11,155
-Jefferson,West Fairview,U.S. House,2,D,Margie Wakefield,87,17,70
-Jefferson,JEFFERSON KS,U.S. House,2,D,Margie Wakefield,2396,279,2117
-Jefferson,Delaware,U.S. House,2,L,Chris Clemmons,37,4,33
-Jefferson,East Fairview,U.S. House,2,L,Chris Clemmons,14,1,13
-Jefferson,Jefferson,U.S. House,2,L,Chris Clemmons,11,0,11
-Jefferson,Kaw,U.S. House,2,L,Chris Clemmons,21,2,19
-Jefferson,Kentucky,U.S. House,2,L,Chris Clemmons,32,1,31
-Jefferson,Norton,U.S. House,2,L,Chris Clemmons,8,1,7
-Jefferson,Oskaloosa,U.S. House,2,L,Chris Clemmons,33,4,29
-Jefferson,Ozawkie,U.S. House,2,L,Chris Clemmons,21,2,19
-Jefferson,Rock Creek,U.S. House,2,L,Chris Clemmons,49,1,48
-Jefferson,Rural,U.S. House,2,L,Chris Clemmons,7,1,6
-Jefferson,Sarcoxie,U.S. House,2,L,Chris Clemmons,13,2,11
-Jefferson,Union,U.S. House,2,L,Chris Clemmons,21,4,17
-Jefferson,West Fairview,U.S. House,2,L,Chris Clemmons,9,0,9
-Jefferson,JEFFERSON KS,U.S. House,2,L,Chris Clemmons,276,23,253
-Jefferson,Kaw,U.S. House,2,,Write-ins,1,,1
-Jefferson,Union,U.S. House,2,,Write-ins,1,,1
-Jefferson,JEFFERSON KS,U.S. House,2,,Write-ins,2,0,2
-Jefferson,Delaware,Governor,,R,Sam Brownback,273,23,250
-Jefferson,East Fairview,Governor,,R,Sam Brownback,145,12,133
-Jefferson,Jefferson,Governor,,R,Sam Brownback,185,13,172
-Jefferson,Kaw,Governor,,R,Sam Brownback,274,24,250
-Jefferson,Kentucky,Governor,,R,Sam Brownback,239,22,217
-Jefferson,Norton,Governor,,R,Sam Brownback,155,9,146
-Jefferson,Oskaloosa,Governor,,R,Sam Brownback,342,47,295
-Jefferson,Ozawkie,Governor,,R,Sam Brownback,291,32,259
-Jefferson,Rock Creek,Governor,,R,Sam Brownback,473,50,423
-Jefferson,Rural,Governor,,R,Sam Brownback,124,12,112
-Jefferson,Sarcoxie,Governor,,R,Sam Brownback,163,20,143
-Jefferson,Union,Governor,,R,Sam Brownback,260,27,233
-Jefferson,West Fairview,Governor,,R,Sam Brownback,149,17,132
-Jefferson,JEFFERSON KS,Governor,,R,Sam Brownback,3073,308,2765
-Jefferson,Delaware,Governor,,D,Paul Davis,325,27,298
-Jefferson,East Fairview,Governor,,D,Paul Davis,160,26,134
-Jefferson,Jefferson,Governor,,D,Paul Davis,144,16,128
-Jefferson,Kaw,Governor,,D,Paul Davis,275,25,250
-Jefferson,Kentucky,Governor,,D,Paul Davis,330,30,300
-Jefferson,Norton,Governor,,D,Paul Davis,115,4,111
-Jefferson,Oskaloosa,Governor,,D,Paul Davis,336,48,288
-Jefferson,Ozawkie,Governor,,D,Paul Davis,286,33,253
-Jefferson,Rock Creek,Governor,,D,Paul Davis,454,27,427
-Jefferson,Rural,Governor,,D,Paul Davis,163,34,129
-Jefferson,Sarcoxie,Governor,,D,Paul Davis,281,28,253
-Jefferson,Union,Governor,,D,Paul Davis,252,17,235
-Jefferson,West Fairview,Governor,,D,Paul Davis,125,21,104
-Jefferson,JEFFERSON KS,Governor,,D,Paul Davis,3246,336,2910
-Jefferson,Delaware,Governor,,L,Keen Umbehr,28,2,26
-Jefferson,East Fairview,Governor,,L,Keen Umbehr,12,0,12
-Jefferson,Jefferson,Governor,,L,Keen Umbehr,19,0,19
-Jefferson,Kaw,Governor,,L,Keen Umbehr,22,1,21
-Jefferson,Kentucky,Governor,,L,Keen Umbehr,24,0,24
-Jefferson,Norton,Governor,,L,Keen Umbehr,16,2,14
-Jefferson,Oskaloosa,Governor,,L,Keen Umbehr,26,1,25
-Jefferson,Ozawkie,Governor,,L,Keen Umbehr,17,3,14
-Jefferson,Rock Creek,Governor,,L,Keen Umbehr,46,1,45
-Jefferson,Rural,Governor,,L,Keen Umbehr,5,2,3
-Jefferson,Sarcoxie,Governor,,L,Keen Umbehr,7,2,5
-Jefferson,Union,Governor,,L,Keen Umbehr,20,2,18
-Jefferson,West Fairview,Governor,,L,Keen Umbehr,6,0,6
-Jefferson,JEFFERSON KS,Governor,,L,Keen Umbehr,248,16,232
-Jefferson,Kaw,Governor,,,Write-ins,2,,2
-Jefferson,Kentucky,Governor,,,Write-ins,10,,10
-Jefferson,Oskaloosa,Governor,,,Write-ins,1,,1
-Jefferson,Rock Creek,Governor,,,Write-ins,1,,1
-Jefferson,Sarcoxie,Governor,,,Write-ins,2,,2
-Jefferson,Union,Governor,,,Write-ins,1,,1
-Jefferson,JEFFERSON KS,Governor,,,Write-ins,17,0,17
-Jefferson,Delaware,Secretary of State,,R,Kris Kobach,386,31,355
-Jefferson,East Fairview,Secretary of State,,R,Kris Kobach,187,16,171
-Jefferson,Jefferson,Secretary of State,,R,Kris Kobach,237,15,222
-Jefferson,Kaw,Secretary of State,,R,Kris Kobach,344,27,317
-Jefferson,Kentucky,Secretary of State,,R,Kris Kobach,346,23,323
-Jefferson,Norton,Secretary of State,,R,Kris Kobach,202,12,190
-Jefferson,Oskaloosa,Secretary of State,,R,Kris Kobach,433,56,377
-Jefferson,Ozawkie,Secretary of State,,R,Kris Kobach,368,35,333
-Jefferson,Rock Creek,Secretary of State,,R,Kris Kobach,634,55,579
-Jefferson,Rural,Secretary of State,,R,Kris Kobach,150,17,133
-Jefferson,Sarcoxie,Secretary of State,,R,Kris Kobach,205,24,181
-Jefferson,Union,Secretary of State,,R,Kris Kobach,343,32,311
-Jefferson,West Fairview,Secretary of State,,R,Kris Kobach,194,24,170
-Jefferson,JEFFERSON KS,Secretary of State,,R,Kris Kobach,4029,367,3662
-Jefferson,Delaware,Secretary of State,,D,Jean Schodorf,232,24,208
-Jefferson,East Fairview,Secretary of State,,D,Jean Schodorf,126,21,105
-Jefferson,Jefferson,Secretary of State,,D,Jean Schodorf,107,14,93
-Jefferson,Kaw,Secretary of State,,D,Jean Schodorf,227,22,205
-Jefferson,Kentucky,Secretary of State,,D,Jean Schodorf,251,29,222
-Jefferson,Norton,Secretary of State,,D,Jean Schodorf,82,4,78
-Jefferson,Oskaloosa,Secretary of State,,D,Jean Schodorf,258,37,221
-Jefferson,Ozawkie,Secretary of State,,D,Jean Schodorf,221,32,189
-Jefferson,Rock Creek,Secretary of State,,D,Jean Schodorf,330,23,307
-Jefferson,Rural,Secretary of State,,D,Jean Schodorf,141,31,110
-Jefferson,Sarcoxie,Secretary of State,,D,Jean Schodorf,246,26,220
-Jefferson,Union,Secretary of State,,D,Jean Schodorf,184,14,170
-Jefferson,West Fairview,Secretary of State,,D,Jean Schodorf,86,15,71
-Jefferson,JEFFERSON KS,Secretary of State,,D,Jean Schodorf,2491,292,2199
-Jefferson,Kaw,Secretary of State,,,Write-ins,1,,1
-Jefferson,Kentucky,Secretary of State,,,Write-ins,2,,2
-Jefferson,Oskaloosa,Secretary of State,,,Write-ins,3,,3
-Jefferson,JEFFERSON KS,Secretary of State,,,Write-ins,6,0,6
-Jefferson,Delaware,Attorney General,,R,Derek Schmidt,398,36,362
-Jefferson,East Fairview,Attorney General,,R,Derek Schmidt,187,14,173
-Jefferson,Jefferson,Attorney General,,R,Derek Schmidt,237,17,220
-Jefferson,Kaw,Attorney General,,R,Derek Schmidt,377,29,348
-Jefferson,Kentucky,Attorney General,,R,Derek Schmidt,367,29,338
-Jefferson,Norton,Attorney General,,R,Derek Schmidt,209,14,195
-Jefferson,Oskaloosa,Attorney General,,R,Derek Schmidt,474,63,411
-Jefferson,Ozawkie,Attorney General,,R,Derek Schmidt,389,39,350
-Jefferson,Rock Creek,Attorney General,,R,Derek Schmidt,670,58,612
-Jefferson,Rural,Attorney General,,R,Derek Schmidt,157,16,141
-Jefferson,Sarcoxie,Attorney General,,R,Derek Schmidt,220,28,192
-Jefferson,Union,Attorney General,,R,Derek Schmidt,350,33,317
-Jefferson,West Fairview,Attorney General,,R,Derek Schmidt,199,23,176
-Jefferson,JEFFERSON KS,Attorney General,,R,Derek Schmidt,4324,399,3835
-Jefferson,Delaware,Attorney General,,D,A J Kotich,223,19,204
-Jefferson,East Fairview,Attorney General,,D,A J Kotich,124,24,100
-Jefferson,Jefferson,Attorney General,,D,A J Kotich,108,12,96
-Jefferson,Kaw,Attorney General,,D,A J Kotich,183,20,163
-Jefferson,Kentucky,Attorney General,,D,A J Kotich,228,23,205
-Jefferson,Norton,Attorney General,,D,A J Kotich,75,2,73
-Jefferson,Oskaloosa,Attorney General,,D,A J Kotich,217,31,186
-Jefferson,Ozawkie,Attorney General,,D,A J Kotich,198,27,171
-Jefferson,Rock Creek,Attorney General,,D,A J Kotich,290,20,270
-Jefferson,Rural,Attorney General,,D,A J Kotich,133,31,102
-Jefferson,Sarcoxie,Attorney General,,D,A J Kotich,224,22,202
-Jefferson,Union,Attorney General,,D,A J Kotich,173,13,160
-Jefferson,West Fairview,Attorney General,,D,A J Kotich,77,13,64
-Jefferson,JEFFERSON KS,Attorney General,,D,A J Kotich,2253,257,1996
-Jefferson,East Fairview,Attorney General,,,Write-ins,1,,1
-Jefferson,Kaw,Attorney General,,,Write-ins,1,,1
-Jefferson,Kentucky,Attorney General,,,Write-ins,2,,2
-Jefferson,Oskaloosa,Attorney General,,,Write-ins,1,,1
-Jefferson,Sarcoxie,Attorney General,,,Write-ins,1,,1
-Jefferson,JEFFERSON KS,Attorney General,,,Write-ins,6,0,6
-Jefferson,Delaware,State Treasurer,,R,Ron Estes,412,32,380
-Jefferson,East Fairview,State Treasurer,,R,Ron Estes,178,14,164
-Jefferson,Jefferson,State Treasurer,,R,Ron Estes,238,15,223
-Jefferson,Kaw,State Treasurer,,R,Ron Estes,358,30,328
-Jefferson,Kentucky,State Treasurer,,R,Ron Estes,372,30,342
-Jefferson,Norton,State Treasurer,,R,Ron Estes,210,13,197
-Jefferson,Oskaloosa,State Treasurer,,R,Ron Estes,480,64,416
-Jefferson,Ozawkie,State Treasurer,,R,Ron Estes,397,45,352
-Jefferson,Rock Creek,State Treasurer,,R,Ron Estes,665,56,609
-Jefferson,Rural,State Treasurer,,R,Ron Estes,153,18,135
-Jefferson,Sarcoxie,State Treasurer,,R,Ron Estes,221,29,192
-Jefferson,Union,State Treasurer,,R,Ron Estes,361,33,328
-Jefferson,West Fairview,State Treasurer,,R,Ron Estes,200,23,177
-Jefferson,JEFFERSON KS,State Treasurer,,R,Ron Estes,4245,402,3843
-Jefferson,Delaware,State Treasurer,,D,Carmen Alldritt,206,22,184
-Jefferson,East Fairview,State Treasurer,,D,Carmen Alldritt,132,23,109
-Jefferson,Jefferson,State Treasurer,,D,Carmen Alldritt,107,14,93
-Jefferson,Kaw,State Treasurer,,D,Carmen Alldritt,202,20,182
-Jefferson,Kentucky,State Treasurer,,D,Carmen Alldritt,223,22,201
-Jefferson,Norton,State Treasurer,,D,Carmen Alldritt,73,2,71
-Jefferson,Oskaloosa,State Treasurer,,D,Carmen Alldritt,210,30,180
-Jefferson,Ozawkie,State Treasurer,,D,Carmen Alldritt,185,20,165
-Jefferson,Rock Creek,State Treasurer,,D,Carmen Alldritt,288,22,266
-Jefferson,Rural,State Treasurer,,D,Carmen Alldritt,137,29,108
-Jefferson,Sarcoxie,State Treasurer,,D,Carmen Alldritt,220,20,200
-Jefferson,Union,State Treasurer,,D,Carmen Alldritt,163,13,150
-Jefferson,West Fairview,State Treasurer,,D,Carmen Alldritt,74,15,59
-Jefferson,JEFFERSON KS,State Treasurer,,D,Carmen Alldritt,2220,252,1968
-Jefferson,Kaw,State Treasurer,,,Write-ins,1,0,1
-Jefferson,Kentucky,State Treasurer,,,Write-ins,1,0,1
-Jefferson,Oskaloosa,State Treasurer,,,Write-ins,1,0,1
-Jefferson,Ozawkie,State Treasurer,,,Write-ins,1,0,1
-Jefferson,JEFFERSON KS,State Treasurer,,,Write-ins,4,0,4
-Jefferson,Delaware,Insurance Commissioner,,R,Ken Selzer,365,31,334
-Jefferson,East Fairview,Insurance Commissioner,,R,Ken Selzer,158,12,146
-Jefferson,Jefferson,Insurance Commissioner,,R,Ken Selzer,225,15,210
-Jefferson,Kaw,Insurance Commissioner,,R,Ken Selzer,331,26,305
-Jefferson,Kentucky,Insurance Commissioner,,R,Ken Selzer,329,24,305
-Jefferson,Norton,Insurance Commissioner,,R,Ken Selzer,188,12,176
-Jefferson,Oskaloosa,Insurance Commissioner,,R,Ken Selzer,438,56,382
-Jefferson,Ozawkie,Insurance Commissioner,,R,Ken Selzer,358,37,321
-Jefferson,Rock Creek,Insurance Commissioner,,R,Ken Selzer,579,52,527
-Jefferson,Rural,Insurance Commissioner,,R,Ken Selzer,143,15,128
-Jefferson,Sarcoxie,Insurance Commissioner,,R,Ken Selzer,200,25,175
-Jefferson,Union,Insurance Commissioner,,R,Ken Selzer,334,30,304
-Jefferson,West Fairview,Insurance Commissioner,,R,Ken Selzer,181,17,164
-Jefferson,JEFFERSON KS,Insurance Commissioner,,R,Ken Selzer,3829,352,3477
-Jefferson,Delaware,Insurance Commissioner,,D,Dennis Anderson,240,23,217
-Jefferson,East Fairview,Insurance Commissioner,,D,Dennis Anderson,148,26,122
-Jefferson,Jefferson,Insurance Commissioner,,D,Dennis Anderson,113,13,100
-Jefferson,Kaw,Insurance Commissioner,,D,Dennis Anderson,224,24,200
-Jefferson,Kentucky,Insurance Commissioner,,D,Dennis Anderson,263,28,235
-Jefferson,Norton,Insurance Commissioner,,D,Dennis Anderson,86,4,82
-Jefferson,Oskaloosa,Insurance Commissioner,,D,Dennis Anderson,246,37,209
-Jefferson,Ozawkie,Insurance Commissioner,,D,Dennis Anderson,220,28,192
-Jefferson,Rock Creek,Insurance Commissioner,,D,Dennis Anderson,357,24,333
-Jefferson,Rural,Insurance Commissioner,,D,Dennis Anderson,145,31,114
-Jefferson,Sarcoxie,Insurance Commissioner,,D,Dennis Anderson,236,23,213
-Jefferson,Union,Insurance Commissioner,,D,Dennis Anderson,187,16,171
-Jefferson,West Fairview,Insurance Commissioner,,D,Dennis Anderson,90,20,70
-Jefferson,JEFFERSON KS,Insurance Commissioner,,D,Dennis Anderson,2555,297,2258
-Jefferson,Kaw,Insurance Commissioner,,,Write-ins,1,0,1
-Jefferson,Oskaloosa,Insurance Commissioner,,,Write-ins,1,0,1
-Jefferson,Ozawkie,Insurance Commissioner,,,Write-ins,1,0,1
-Jefferson,Rock Creek,Insurance Commissioner,,,Write-ins,1,0,1
-Jefferson,Sarcoxie,Insurance Commissioner,,,Write-ins,1,0,1
-Jefferson,JEFFERSON KS,Insurance Commissioner,,,Write-ins,6,1,5
-Jefferson,Delaware,State House,47,R,R Gonzalez,355,31,324
-Jefferson,East Fairview,State House,47,R,R Gonzalez,202,16,186
-Jefferson,Jefferson,State House,47,R,R Gonzalez,229,19,210
-Jefferson,Kaw,State House,47,R,R Gonzalez,406,34,372
-Jefferson,Kentucky,State House,47,R,R Gonzalez,469,39,430
-Jefferson,Norton,State House,47,R,R Gonzalez,183,12,171
-Jefferson,Oskaloosa,State House,47,R,R Gonzalez,494,65,429
-Jefferson,Ozawkie,State House,47,R,R Gonzalez,369,37,332
-Jefferson,Rock Creek,State House,47,R,R Gonzalez,624,56,568
-Jefferson,Rural,State House,47,R,R Gonzalez,179,21,158
-Jefferson,Sarcoxie,State House,47,R,R Gonzalez,231,26,205
-Jefferson,Union,State House,47,R,R Gonzalez,356,34,322
-Jefferson,West Fairview,State House,47,R,R Gonzalez,195,19,176
-Jefferson,JEFFERSON KS,State House,47,R,R Gonzalez,4292,409,3883
-Jefferson,Delaware,State House,47,D,B Sirridege,257,24,233
-Jefferson,East Fairview,State House,47,D,B Sirridege,110,21,89
-Jefferson,Jefferson,State House,47,D,B Sirridege,107,10,97
-Jefferson,Kaw,State House,47,D,B Sirridege,158,17,141
-Jefferson,Kentucky,State House,47,D,B Sirridege,125,13,112
-Jefferson,Norton,State House,47,D,B Sirridege,90,3,87
-Jefferson,Oskaloosa,State House,47,D,B Sirridege,194,29,165
-Jefferson,Ozawkie,State House,47,D,B Sirridege,219,30,189
-Jefferson,Rock Creek,State House,47,D,B Sirridege,321,21,300
-Jefferson,Rural,State House,47,D,B Sirridege,110,26,84
-Jefferson,Sarcoxie,State House,47,D,B Sirridege,214,23,191
-Jefferson,Union,State House,47,D,B Sirridege,164,12,152
-Jefferson,West Fairview,State House,47,D,B Sirridege,74,18,56
-Jefferson,JEFFERSON KS,State House,47,D,B Sirridege,2143,247,1896
-Jefferson,Delaware,State House,47,,Write-ins,1,0,1
-Jefferson,Jefferson,State House,47,,Write-ins,1,0,1
-Jefferson,Kaw,State House,47,,Write-ins,2,0,2
-Jefferson,West Fairview,State House,47,,Write-ins,1,0,1
-Jefferson,JEFFERSON KS,State House,47,,Write-ins,5,0,5
+county,precinct,office,district,party,candidate,votes,vtd
+JEFFERSON,Delaware Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",325,000010
+JEFFERSON,Delaware Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000010
+JEFFERSON,Delaware Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",273,000010
+JEFFERSON,East Fairview,Governor / Lt. Governor,,Democratic,"Davis, Paul",160,000020
+JEFFERSON,East Fairview,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000020
+JEFFERSON,East Fairview,Governor / Lt. Governor,,Republican,"Brownback, Sam",145,000020
+JEFFERSON,Jefferson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,000030
+JEFFERSON,Jefferson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000030
+JEFFERSON,Jefferson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",185,000030
+JEFFERSON,Kaw Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",275,000040
+JEFFERSON,Kaw Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000040
+JEFFERSON,Kaw Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",274,000040
+JEFFERSON,Kentucky Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",330,000050
+JEFFERSON,Kentucky Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000050
+JEFFERSON,Kentucky Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",239,000050
+JEFFERSON,Norton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",115,000060
+JEFFERSON,Norton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000060
+JEFFERSON,Norton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",155,000060
+JEFFERSON,Oskaloosa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",336,000070
+JEFFERSON,Oskaloosa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000070
+JEFFERSON,Oskaloosa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",342,000070
+JEFFERSON,Ozawkie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",286,000080
+JEFFERSON,Ozawkie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000080
+JEFFERSON,Ozawkie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",291,000080
+JEFFERSON,Rock Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",454,000090
+JEFFERSON,Rock Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",46,000090
+JEFFERSON,Rock Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",473,000090
+JEFFERSON,Rural Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",163,000100
+JEFFERSON,Rural Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000100
+JEFFERSON,Rural Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",124,000100
+JEFFERSON,Sarcoxie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",281,000110
+JEFFERSON,Sarcoxie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000110
+JEFFERSON,Sarcoxie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",163,000110
+JEFFERSON,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",252,000120
+JEFFERSON,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000120
+JEFFERSON,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",260,000120
+JEFFERSON,West Fairview,Governor / Lt. Governor,,Democratic,"Davis, Paul",125,000130
+JEFFERSON,West Fairview,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000130
+JEFFERSON,West Fairview,Governor / Lt. Governor,,Republican,"Brownback, Sam",149,000130
+JEFFERSON,Delaware Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",257,000010
+JEFFERSON,Delaware Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",355,000010
+JEFFERSON,East Fairview,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",110,000020
+JEFFERSON,East Fairview,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",202,000020
+JEFFERSON,Jefferson Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",107,000030
+JEFFERSON,Jefferson Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",229,000030
+JEFFERSON,Kaw Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",158,000040
+JEFFERSON,Kaw Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",406,000040
+JEFFERSON,Kentucky Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",126,000050
+JEFFERSON,Kentucky Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",469,000050
+JEFFERSON,Norton Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",90,000060
+JEFFERSON,Norton Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",183,000060
+JEFFERSON,Oskaloosa Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",194,000070
+JEFFERSON,Oskaloosa Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",494,000070
+JEFFERSON,Ozawkie Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",219,000080
+JEFFERSON,Ozawkie Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",369,000080
+JEFFERSON,Rock Creek Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",321,000090
+JEFFERSON,Rock Creek Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",624,000090
+JEFFERSON,Rural Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",110,000100
+JEFFERSON,Rural Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",179,000100
+JEFFERSON,Sarcoxie Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",214,000110
+JEFFERSON,Sarcoxie Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",231,000110
+JEFFERSON,Union Township,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",164,000120
+JEFFERSON,Union Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",356,000120
+JEFFERSON,West Fairview,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",74,000130
+JEFFERSON,West Fairview,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",195,000130
+JEFFERSON,Delaware Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",227,000010
+JEFFERSON,Delaware Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",37,000010
+JEFFERSON,Delaware Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",363,000010
+JEFFERSON,East Fairview,United States House of Representatives,2,Democratic,"Wakefield, Margie",128,000020
+JEFFERSON,East Fairview,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000020
+JEFFERSON,East Fairview,United States House of Representatives,2,Republican,"Jenkins, Lynn",173,000020
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",99,000030
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000030
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",236,000030
+JEFFERSON,Kaw Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",220,000040
+JEFFERSON,Kaw Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,000040
+JEFFERSON,Kaw Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",333,000040
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",243,000050
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",32,000050
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",327,000050
+JEFFERSON,Norton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",80,000060
+JEFFERSON,Norton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000060
+JEFFERSON,Norton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,000060
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",228,000070
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",33,000070
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",442,000070
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",217,000080
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,000080
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",356,000080
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",321,000090
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",49,000090
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",598,000090
+JEFFERSON,Rural Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",143,000100
+JEFFERSON,Rural Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000100
+JEFFERSON,Rural Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000100
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",237,000110
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000110
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,000110
+JEFFERSON,Union Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",166,000120
+JEFFERSON,Union Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,000120
+JEFFERSON,Union Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",347,000120
+JEFFERSON,West Fairview,United States House of Representatives,2,Democratic,"Wakefield, Margie",87,000130
+JEFFERSON,West Fairview,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000130
+JEFFERSON,West Fairview,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,000130
+JEFFERSON,Delaware Township,Attorney General,,Democratic,"Kotich, A.J.",223,000010
+JEFFERSON,Delaware Township,Attorney General,,Republican,"Schmidt, Derek",398,000010
+JEFFERSON,East Fairview,Attorney General,,Democratic,"Kotich, A.J.",124,000020
+JEFFERSON,East Fairview,Attorney General,,Republican,"Schmidt, Derek",187,000020
+JEFFERSON,Jefferson Township,Attorney General,,Democratic,"Kotich, A.J.",108,000030
+JEFFERSON,Jefferson Township,Attorney General,,Republican,"Schmidt, Derek",237,000030
+JEFFERSON,Kaw Township,Attorney General,,Democratic,"Kotich, A.J.",183,000040
+JEFFERSON,Kaw Township,Attorney General,,Republican,"Schmidt, Derek",377,000040
+JEFFERSON,Kentucky Township,Attorney General,,Democratic,"Kotich, A.J.",228,000050
+JEFFERSON,Kentucky Township,Attorney General,,Republican,"Schmidt, Derek",367,000050
+JEFFERSON,Norton Township,Attorney General,,Democratic,"Kotich, A.J.",75,000060
+JEFFERSON,Norton Township,Attorney General,,Republican,"Schmidt, Derek",209,000060
+JEFFERSON,Oskaloosa Township,Attorney General,,Democratic,"Kotich, A.J.",217,000070
+JEFFERSON,Oskaloosa Township,Attorney General,,Republican,"Schmidt, Derek",474,000070
+JEFFERSON,Ozawkie Township,Attorney General,,Democratic,"Kotich, A.J.",198,000080
+JEFFERSON,Ozawkie Township,Attorney General,,Republican,"Schmidt, Derek",389,000080
+JEFFERSON,Rock Creek Township,Attorney General,,Democratic,"Kotich, A.J.",290,000090
+JEFFERSON,Rock Creek Township,Attorney General,,Republican,"Schmidt, Derek",670,000090
+JEFFERSON,Rural Township,Attorney General,,Democratic,"Kotich, A.J.",133,000100
+JEFFERSON,Rural Township,Attorney General,,Republican,"Schmidt, Derek",157,000100
+JEFFERSON,Sarcoxie Township,Attorney General,,Democratic,"Kotich, A.J.",224,000110
+JEFFERSON,Sarcoxie Township,Attorney General,,Republican,"Schmidt, Derek",220,000110
+JEFFERSON,Union Township,Attorney General,,Democratic,"Kotich, A.J.",173,000120
+JEFFERSON,Union Township,Attorney General,,Republican,"Schmidt, Derek",350,000120
+JEFFERSON,West Fairview,Attorney General,,Democratic,"Kotich, A.J.",77,000130
+JEFFERSON,West Fairview,Attorney General,,Republican,"Schmidt, Derek",199,000130
+JEFFERSON,Delaware Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",240,000010
+JEFFERSON,Delaware Township,Commissioner of Insurance,,Republican,"Selzer, Ken",365,000010
+JEFFERSON,East Fairview,Commissioner of Insurance,,Democratic,"Anderson, Dennis",148,000020
+JEFFERSON,East Fairview,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000020
+JEFFERSON,Jefferson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",113,000030
+JEFFERSON,Jefferson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",225,000030
+JEFFERSON,Kaw Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",224,000040
+JEFFERSON,Kaw Township,Commissioner of Insurance,,Republican,"Selzer, Ken",331,000040
+JEFFERSON,Kentucky Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",263,000050
+JEFFERSON,Kentucky Township,Commissioner of Insurance,,Republican,"Selzer, Ken",329,000050
+JEFFERSON,Norton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,000060
+JEFFERSON,Norton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",188,000060
+JEFFERSON,Oskaloosa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",246,000070
+JEFFERSON,Oskaloosa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",438,000070
+JEFFERSON,Ozawkie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",220,000080
+JEFFERSON,Ozawkie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",358,000080
+JEFFERSON,Rock Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",357,000090
+JEFFERSON,Rock Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",579,000090
+JEFFERSON,Rural Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",145,000100
+JEFFERSON,Rural Township,Commissioner of Insurance,,Republican,"Selzer, Ken",143,000100
+JEFFERSON,Sarcoxie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",236,000110
+JEFFERSON,Sarcoxie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",200,000110
+JEFFERSON,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",187,000120
+JEFFERSON,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",334,000120
+JEFFERSON,West Fairview,Commissioner of Insurance,,Democratic,"Anderson, Dennis",90,000130
+JEFFERSON,West Fairview,Commissioner of Insurance,,Republican,"Selzer, Ken",181,000130
+JEFFERSON,Delaware Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",232,000010
+JEFFERSON,Delaware Township,Secretary of State,,Republican,"Kobach, Kris",386,000010
+JEFFERSON,East Fairview,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",126,000020
+JEFFERSON,East Fairview,Secretary of State,,Republican,"Kobach, Kris",187,000020
+JEFFERSON,Jefferson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",107,000030
+JEFFERSON,Jefferson Township,Secretary of State,,Republican,"Kobach, Kris",237,000030
+JEFFERSON,Kaw Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",227,000040
+JEFFERSON,Kaw Township,Secretary of State,,Republican,"Kobach, Kris",344,000040
+JEFFERSON,Kentucky Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",251,000050
+JEFFERSON,Kentucky Township,Secretary of State,,Republican,"Kobach, Kris",346,000050
+JEFFERSON,Norton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",82,000060
+JEFFERSON,Norton Township,Secretary of State,,Republican,"Kobach, Kris",202,000060
+JEFFERSON,Oskaloosa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",258,000070
+JEFFERSON,Oskaloosa Township,Secretary of State,,Republican,"Kobach, Kris",433,000070
+JEFFERSON,Ozawkie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",221,000080
+JEFFERSON,Ozawkie Township,Secretary of State,,Republican,"Kobach, Kris",368,000080
+JEFFERSON,Rock Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",330,000090
+JEFFERSON,Rock Creek Township,Secretary of State,,Republican,"Kobach, Kris",634,000090
+JEFFERSON,Rural Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",141,000100
+JEFFERSON,Rural Township,Secretary of State,,Republican,"Kobach, Kris",150,000100
+JEFFERSON,Sarcoxie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",246,000110
+JEFFERSON,Sarcoxie Township,Secretary of State,,Republican,"Kobach, Kris",205,000110
+JEFFERSON,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",184,000120
+JEFFERSON,Union Township,Secretary of State,,Republican,"Kobach, Kris",343,000120
+JEFFERSON,West Fairview,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,000130
+JEFFERSON,West Fairview,Secretary of State,,Republican,"Kobach, Kris",194,000130
+JEFFERSON,Delaware Township,State Treasurer,,Democratic,"Alldritt, Carmen",206,000010
+JEFFERSON,Delaware Township,State Treasurer,,Republican,"Estes, Ron",412,000010
+JEFFERSON,East Fairview,State Treasurer,,Democratic,"Alldritt, Carmen",132,000020
+JEFFERSON,East Fairview,State Treasurer,,Republican,"Estes, Ron",178,000020
+JEFFERSON,Jefferson Township,State Treasurer,,Democratic,"Alldritt, Carmen",107,000030
+JEFFERSON,Jefferson Township,State Treasurer,,Republican,"Estes, Ron",238,000030
+JEFFERSON,Kaw Township,State Treasurer,,Democratic,"Alldritt, Carmen",202,000040
+JEFFERSON,Kaw Township,State Treasurer,,Republican,"Estes, Ron",358,000040
+JEFFERSON,Kentucky Township,State Treasurer,,Democratic,"Alldritt, Carmen",223,000050
+JEFFERSON,Kentucky Township,State Treasurer,,Republican,"Estes, Ron",372,000050
+JEFFERSON,Norton Township,State Treasurer,,Democratic,"Alldritt, Carmen",73,000060
+JEFFERSON,Norton Township,State Treasurer,,Republican,"Estes, Ron",210,000060
+JEFFERSON,Oskaloosa Township,State Treasurer,,Democratic,"Alldritt, Carmen",210,000070
+JEFFERSON,Oskaloosa Township,State Treasurer,,Republican,"Estes, Ron",480,000070
+JEFFERSON,Ozawkie Township,State Treasurer,,Democratic,"Alldritt, Carmen",185,000080
+JEFFERSON,Ozawkie Township,State Treasurer,,Republican,"Estes, Ron",397,000080
+JEFFERSON,Rock Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",288,000090
+JEFFERSON,Rock Creek Township,State Treasurer,,Republican,"Estes, Ron",665,000090
+JEFFERSON,Rural Township,State Treasurer,,Democratic,"Alldritt, Carmen",137,000100
+JEFFERSON,Rural Township,State Treasurer,,Republican,"Estes, Ron",153,000100
+JEFFERSON,Sarcoxie Township,State Treasurer,,Democratic,"Alldritt, Carmen",220,000110
+JEFFERSON,Sarcoxie Township,State Treasurer,,Republican,"Estes, Ron",221,000110
+JEFFERSON,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",163,000120
+JEFFERSON,Union Township,State Treasurer,,Republican,"Estes, Ron",361,000120
+JEFFERSON,West Fairview,State Treasurer,,Democratic,"Alldritt, Carmen",74,000130
+JEFFERSON,West Fairview,State Treasurer,,Republican,"Estes, Ron",200,000130
+JEFFERSON,Delaware Township,United States Senate,,independent,"Orman, Greg",272,000010
+JEFFERSON,Delaware Township,United States Senate,,Libertarian,"Batson, Randall",28,000010
+JEFFERSON,Delaware Township,United States Senate,,Republican,"Roberts, Pat",326,000010
+JEFFERSON,East Fairview,United States Senate,,independent,"Orman, Greg",154,000020
+JEFFERSON,East Fairview,United States Senate,,Libertarian,"Batson, Randall",18,000020
+JEFFERSON,East Fairview,United States Senate,,Republican,"Roberts, Pat",145,000020
+JEFFERSON,Jefferson Township,United States Senate,,independent,"Orman, Greg",119,000030
+JEFFERSON,Jefferson Township,United States Senate,,Libertarian,"Batson, Randall",17,000030
+JEFFERSON,Jefferson Township,United States Senate,,Republican,"Roberts, Pat",211,000030
+JEFFERSON,Kaw Township,United States Senate,,independent,"Orman, Greg",249,000040
+JEFFERSON,Kaw Township,United States Senate,,Libertarian,"Batson, Randall",27,000040
+JEFFERSON,Kaw Township,United States Senate,,Republican,"Roberts, Pat",296,000040
+JEFFERSON,Kentucky Township,United States Senate,,independent,"Orman, Greg",295,000050
+JEFFERSON,Kentucky Township,United States Senate,,Libertarian,"Batson, Randall",28,000050
+JEFFERSON,Kentucky Township,United States Senate,,Republican,"Roberts, Pat",277,000050
+JEFFERSON,Norton Township,United States Senate,,independent,"Orman, Greg",111,000060
+JEFFERSON,Norton Township,United States Senate,,Libertarian,"Batson, Randall",12,000060
+JEFFERSON,Norton Township,United States Senate,,Republican,"Roberts, Pat",164,000060
+JEFFERSON,Oskaloosa Township,United States Senate,,independent,"Orman, Greg",287,000070
+JEFFERSON,Oskaloosa Township,United States Senate,,Libertarian,"Batson, Randall",27,000070
+JEFFERSON,Oskaloosa Township,United States Senate,,Republican,"Roberts, Pat",387,000070
+JEFFERSON,Ozawkie Township,United States Senate,,independent,"Orman, Greg",253,000080
+JEFFERSON,Ozawkie Township,United States Senate,,Libertarian,"Batson, Randall",24,000080
+JEFFERSON,Ozawkie Township,United States Senate,,Republican,"Roberts, Pat",315,000080
+JEFFERSON,Rock Creek Township,United States Senate,,independent,"Orman, Greg",400,000090
+JEFFERSON,Rock Creek Township,United States Senate,,Libertarian,"Batson, Randall",37,000090
+JEFFERSON,Rock Creek Township,United States Senate,,Republican,"Roberts, Pat",529,000090
+JEFFERSON,Rural Township,United States Senate,,independent,"Orman, Greg",154,000100
+JEFFERSON,Rural Township,United States Senate,,Libertarian,"Batson, Randall",4,000100
+JEFFERSON,Rural Township,United States Senate,,Republican,"Roberts, Pat",135,000100
+JEFFERSON,Sarcoxie Township,United States Senate,,independent,"Orman, Greg",259,000110
+JEFFERSON,Sarcoxie Township,United States Senate,,Libertarian,"Batson, Randall",11,000110
+JEFFERSON,Sarcoxie Township,United States Senate,,Republican,"Roberts, Pat",181,000110
+JEFFERSON,Union Township,United States Senate,,independent,"Orman, Greg",212,000120
+JEFFERSON,Union Township,United States Senate,,Libertarian,"Batson, Randall",29,000120
+JEFFERSON,Union Township,United States Senate,,Republican,"Roberts, Pat",293,000120
+JEFFERSON,West Fairview,United States Senate,,independent,"Orman, Greg",113,000130
+JEFFERSON,West Fairview,United States Senate,,Libertarian,"Batson, Randall",5,000130
+JEFFERSON,West Fairview,United States Senate,,Republican,"Roberts, Pat",162,000130

--- a/2014/20141104__ks__general__jewell__precinct.csv
+++ b/2014/20141104__ks__general__jewell__precinct.csv
@@ -1,470 +1,426 @@
-county,precinct,office,district,party,candidate,votes
-Jewell,Allen,,,,Ballots,9
-Jewell,Athens,,,,Ballots,14
-Jewell,Browncreek,,,,Ballots,25
-Jewell,Buffalo,,,,Ballots,170
-Jewell,Burroak,,,,Ballots,80
-Jewell,Calvin,,,,Ballots,27
-Jewell,Center,,,,Ballots,359
-Jewell,Erving,,,,Ballots,11
-Jewell,Esbon,,,,Ballots,62
-Jewell,Grant,,,,Ballots,68
-Jewell,Harrison,,,,Ballots,11
-Jewell,Highland,,,,Ballots,19
-Jewell,Homwood,,,,Ballots,11
-Jewell,Ionia,,,,Ballots,33
-Jewell,Jackson,,,,Ballots,34
-Jewell,Limestone,,,,Ballots,28
-Jewell,Montana,,,,Ballots,27
-Jewell,Odessa,,,,Ballots,4
-Jewell,Prairie,,,,Ballots,50
-Jewell,Richland,,,,Ballots,12
-Jewell,Sinclair,,,,Ballots,14
-Jewell,Vicksburg,,,,Ballots,9
-Jewell,Walnut,,,,Ballots,28
-Jewell,Washington,,,,Ballots,20
-Jewell,Whitemound,,,,Ballots,16
-JEWELL,JEWELL KS,,,,Ballots,1141
-Jewell,Allen,U.S. Senate,,R,Pat Roberts,8
-Jewell,Athens,U.S. Senate,,R,Pat Roberts,9
-Jewell,Browncreek,U.S. Senate,,R,Pat Roberts,23
-Jewell,Buffalo,U.S. Senate,,R,Pat Roberts,128
-Jewell,Burroak,U.S. Senate,,R,Pat Roberts,58
-Jewell,Calvin,U.S. Senate,,R,Pat Roberts,24
-Jewell,Center,U.S. Senate,,R,Pat Roberts,235
-Jewell,Erving,U.S. Senate,,R,Pat Roberts,8
-Jewell,Esbon,U.S. Senate,,R,Pat Roberts,37
-Jewell,Grant,U.S. Senate,,R,Pat Roberts,57
-Jewell,Harrison,U.S. Senate,,R,Pat Roberts,9
-Jewell,Highland,U.S. Senate,,R,Pat Roberts,11
-Jewell,Homwood,U.S. Senate,,R,Pat Roberts,7
-Jewell,Ionia,U.S. Senate,,R,Pat Roberts,27
-Jewell,Jackson,U.S. Senate,,R,Pat Roberts,26
-Jewell,Limestone,U.S. Senate,,R,Pat Roberts,18
-Jewell,Montana,U.S. Senate,,R,Pat Roberts,20
-Jewell,Odessa,U.S. Senate,,R,Pat Roberts,3
-Jewell,Prairie,U.S. Senate,,R,Pat Roberts,45
-Jewell,Richland,U.S. Senate,,R,Pat Roberts,9
-Jewell,Sinclair,U.S. Senate,,R,Pat Roberts,13
-Jewell,Vicksburg,U.S. Senate,,R,Pat Roberts,9
-Jewell,Walnut,U.S. Senate,,R,Pat Roberts,23
-Jewell,Washington,U.S. Senate,,R,Pat Roberts,19
-Jewell,Whitemound,U.S. Senate,,R,Pat Roberts,18
-JEWELL,JEWELL KS,,0,R,Pat Roberts,844
-Jewell,Allen,U.S. Senate,,I,Greg Orman,1
-Jewell,Athens,U.S. Senate,,I,Greg Orman,4
-Jewell,Browncreek,U.S. Senate,,I,Greg Orman,2
-Jewell,Buffalo,U.S. Senate,,I,Greg Orman,22
-Jewell,Burroak,U.S. Senate,,I,Greg Orman,12
-Jewell,Calvin,U.S. Senate,,I,Greg Orman,2
-Jewell,Center,U.S. Senate,,I,Greg Orman,102
-Jewell,Erving,U.S. Senate,,I,Greg Orman,2
-Jewell,Esbon,U.S. Senate,,I,Greg Orman,18
-Jewell,Grant,U.S. Senate,,I,Greg Orman,4
-Jewell,Harrison,U.S. Senate,,I,Greg Orman,1
-Jewell,Highland,U.S. Senate,,I,Greg Orman,7
-Jewell,Homwood,U.S. Senate,,I,Greg Orman,2
-Jewell,Ionia,U.S. Senate,,I,Greg Orman,4
-Jewell,Jackson,U.S. Senate,,I,Greg Orman,7
-Jewell,Limestone,U.S. Senate,,I,Greg Orman,8
-Jewell,Montana,U.S. Senate,,I,Greg Orman,7
-Jewell,Odessa,U.S. Senate,,I,Greg Orman,0
-Jewell,Prairie,U.S. Senate,,I,Greg Orman,4
-Jewell,Richland,U.S. Senate,,I,Greg Orman,3
-Jewell,Sinclair,U.S. Senate,,I,Greg Orman,1
-Jewell,Vicksburg,U.S. Senate,,I,Greg Orman,0
-Jewell,Walnut,U.S. Senate,,I,Greg Orman,3
-Jewell,Washington,U.S. Senate,,I,Greg Orman,1
-Jewell,Whitemound,U.S. Senate,,I,Greg Orman,1
-JEWELL,JEWELL KS,,,I,Greg Orman,218
-Jewell,Allen,U.S. Senate,,L,Randall Batson,0
-Jewell,Athens,U.S. Senate,,L,Randall Batson,1
-Jewell,Browncreek,U.S. Senate,,L,Randall Batson,0
-Jewell,Buffalo,U.S. Senate,,L,Randall Batson,10
-Jewell,Burroak,U.S. Senate,,L,Randall Batson,8
-Jewell,Calvin,U.S. Senate,,L,Randall Batson,0
-Jewell,Center,U.S. Senate,,L,Randall Batson,16
-Jewell,Erving,U.S. Senate,,L,Randall Batson,0
-Jewell,Esbon,U.S. Senate,,L,Randall Batson,3
-Jewell,Grant,U.S. Senate,,L,Randall Batson,4
-Jewell,Harrison,U.S. Senate,,L,Randall Batson,0
-Jewell,Highland,U.S. Senate,,L,Randall Batson,1
-Jewell,Homwood,U.S. Senate,,L,Randall Batson,1
-Jewell,Ionia,U.S. Senate,,L,Randall Batson,0
-Jewell,Jackson,U.S. Senate,,L,Randall Batson,1
-Jewell,Limestone,U.S. Senate,,L,Randall Batson,0
-Jewell,Montana,U.S. Senate,,L,Randall Batson,0
-Jewell,Odessa,U.S. Senate,,L,Randall Batson,1
-Jewell,Prairie,U.S. Senate,,L,Randall Batson,1
-Jewell,Richland,U.S. Senate,,L,Randall Batson,2
-Jewell,Sinclair,U.S. Senate,,L,Randall Batson,0
-Jewell,Vicksburg,U.S. Senate,,L,Randall Batson,0
-Jewell,Walnut,U.S. Senate,,L,Randall Batson,0
-Jewell,Washington,U.S. Senate,,L,Randall Batson,0
-Jewell,Whitemound,U.S. Senate,,L,Randall Batson,0
-JEWELL,JEWELL KS,U.S. Senate,,L,Randall Batson,49
-Jewell,Allen,U.S. House,1,R,Tim Huelskamp,8
-Jewell,Athens,U.S. House,1,R,Tim Huelskamp,10
-Jewell,Browncreek,U.S. House,1,R,Tim Huelskamp,18
-Jewell,Buffalo,U.S. House,1,R,Tim Huelskamp,124
-Jewell,Burroak,U.S. House,1,R,Tim Huelskamp,69
-Jewell,Calvin,U.S. House,1,R,Tim Huelskamp,23
-Jewell,Center,U.S. House,1,R,Tim Huelskamp,240
-Jewell,Erving,U.S. House,1,R,Tim Huelskamp,9
-Jewell,Esbon,U.S. House,1,R,Tim Huelskamp,40
-Jewell,Grant,U.S. House,1,R,Tim Huelskamp,56
-Jewell,Harrison,U.S. House,1,R,Tim Huelskamp,9
-Jewell,Highland,U.S. House,1,R,Tim Huelskamp,13
-Jewell,Homwood,U.S. House,1,R,Tim Huelskamp,5
-Jewell,Ionia,U.S. House,1,R,Tim Huelskamp,27
-Jewell,Jackson,U.S. House,1,R,Tim Huelskamp,28
-Jewell,Limestone,U.S. House,1,R,Tim Huelskamp,20
-Jewell,Montana,U.S. House,1,R,Tim Huelskamp,20
-Jewell,Odessa,U.S. House,1,R,Tim Huelskamp,4
-Jewell,Prairie,U.S. House,1,R,Tim Huelskamp,44
-Jewell,Richland,U.S. House,1,R,Tim Huelskamp,11
-Jewell,Sinclair,U.S. House,1,R,Tim Huelskamp,12
-Jewell,Vicksburg,U.S. House,1,R,Tim Huelskamp,9
-Jewell,Walnut,U.S. House,1,R,Tim Huelskamp,23
-Jewell,Washington,U.S. House,1,R,Tim Huelskamp,15
-Jewell,Whitemound,U.S. House,1,R,Tim Huelskamp,16
-JEWELL,JEWELL KS,U.S. House,1,R,Tim Huelskamp,853
-Jewell,Allen,U.S. House,1,D,Tim Sherow,0
-Jewell,Athens,U.S. House,1,D,Tim Sherow,4
-Jewell,Browncreek,U.S. House,1,D,Tim Sherow,7
-Jewell,Buffalo,U.S. House,1,D,Tim Sherow,34
-Jewell,Burroak,U.S. House,1,D,Tim Sherow,11
-Jewell,Calvin,U.S. House,1,D,Tim Sherow,3
-Jewell,Center,U.S. House,1,D,Tim Sherow,106
-Jewell,Erving,U.S. House,1,D,Tim Sherow,1
-Jewell,Esbon,U.S. House,1,D,Tim Sherow,16
-Jewell,Grant,U.S. House,1,D,Tim Sherow,9
-Jewell,Harrison,U.S. House,1,D,Tim Sherow,1
-Jewell,Highland,U.S. House,1,D,Tim Sherow,5
-Jewell,Homwood,U.S. House,1,D,Tim Sherow,4
-Jewell,Ionia,U.S. House,1,D,Tim Sherow,4
-Jewell,Jackson,U.S. House,1,D,Tim Sherow,6
-Jewell,Limestone,U.S. House,1,D,Tim Sherow,6
-Jewell,Montana,U.S. House,1,D,Tim Sherow,7
-Jewell,Odessa,U.S. House,1,D,Tim Sherow,0
-Jewell,Prairie,U.S. House,1,D,Tim Sherow,4
-Jewell,Richland,U.S. House,1,D,Tim Sherow,1
-Jewell,Sinclair,U.S. House,1,D,Tim Sherow,1
-Jewell,Vicksburg,U.S. House,1,D,Tim Sherow,0
-Jewell,Walnut,U.S. House,1,D,Tim Sherow,3
-Jewell,Washington,U.S. House,1,D,Tim Sherow,6
-Jewell,Whitemound,U.S. House,1,D,Tim Sherow,1
-JEWELL,JEWELL KS,U.S. House,1,D,Tim Sherow,240
-Jewell,Allen,Governor,,R,Sam Brownback,7
-Jewell,Athens,Governor,,R,Sam Brownback,10
-Jewell,Browncreek,Governor,,R,Sam Brownback,18
-Jewell,Buffalo,Governor,,R,Sam Brownback,112
-Jewell,Burroak,Governor,,R,Sam Brownback,48
-Jewell,Calvin,Governor,,R,Sam Brownback,22
-Jewell,Center,Governor,,R,Sam Brownback,204
-Jewell,Erving,Governor,,R,Sam Brownback,8
-Jewell,Esbon,Governor,,R,Sam Brownback,31
-Jewell,Grant,Governor,,R,Sam Brownback,49
-Jewell,Harrison,Governor,,R,Sam Brownback,9
-Jewell,Highland,Governor,,R,Sam Brownback,9
-Jewell,Homwood,Governor,,R,Sam Brownback,4
-Jewell,Ionia,Governor,,R,Sam Brownback,28
-Jewell,Jackson,Governor,,R,Sam Brownback,25
-Jewell,Limestone,Governor,,R,Sam Brownback,17
-Jewell,Montana,Governor,,R,Sam Brownback,18
-Jewell,Odessa,Governor,,R,Sam Brownback,3
-Jewell,Prairie,Governor,,R,Sam Brownback,40
-Jewell,Richland,Governor,,R,Sam Brownback,8
-Jewell,Sinclair,Governor,,R,Sam Brownback,10
-Jewell,Vicksburg,Governor,,R,Sam Brownback,9
-Jewell,Walnut,Governor,,R,Sam Brownback,22
-Jewell,Washington,Governor,,R,Sam Brownback,14
-Jewell,Whitemound,Governor,,R,Sam Brownback,13
-JEWELL,JEWELL KS,Governor,,R,Sam Brownback,738
-Jewell,Allen,Governor,,D,Paul Davis,2
-Jewell,Athens,Governor,,D,Paul Davis,5
-Jewell,Browncreek,Governor,,D,Paul Davis,4
-Jewell,Buffalo,Governor,,D,Paul Davis,38
-Jewell,Burroak,Governor,,D,Paul Davis,16
-Jewell,Calvin,Governor,,D,Paul Davis,3
-Jewell,Center,Governor,,D,Paul Davis,128
-Jewell,Erving,Governor,,D,Paul Davis,2
-Jewell,Esbon,Governor,,D,Paul Davis,21
-Jewell,Grant,Governor,,D,Paul Davis,14
-Jewell,Harrison,Governor,,D,Paul Davis,1
-Jewell,Highland,Governor,,D,Paul Davis,8
-Jewell,Homwood,Governor,,D,Paul Davis,4
-Jewell,Ionia,Governor,,D,Paul Davis,2
-Jewell,Jackson,Governor,,D,Paul Davis,8
-Jewell,Limestone,Governor,,D,Paul Davis,7
-Jewell,Montana,Governor,,D,Paul Davis,5
-Jewell,Odessa,Governor,,D,Paul Davis,1
-Jewell,Prairie,Governor,,D,Paul Davis,7
-Jewell,Richland,Governor,,D,Paul Davis,1
-Jewell,Sinclair,Governor,,D,Paul Davis,1
-Jewell,Vicksburg,Governor,,D,Paul Davis,0
-Jewell,Walnut,Governor,,D,Paul Davis,3
-Jewell,Washington,Governor,,D,Paul Davis,7
-Jewell,Whitemound,Governor,,D,Paul Davis,5
-JEWELL,JEWELL KS,Governor,,D,Paul Davis,293
-Jewell,Allen,Governor,,L,Keen Umbehr,0
-Jewell,Athens,Governor,,L,Keen Umbehr,0
-Jewell,Browncreek,Governor,,L,Keen Umbehr,0
-Jewell,Buffalo,Governor,,L,Keen Umbehr,11
-Jewell,Burroak,Governor,,L,Keen Umbehr,16
-Jewell,Calvin,Governor,,L,Keen Umbehr,0
-Jewell,Center,Governor,,L,Keen Umbehr,20
-Jewell,Erving,Governor,,L,Keen Umbehr,0
-Jewell,Esbon,Governor,,L,Keen Umbehr,7
-Jewell,Grant,Governor,,L,Keen Umbehr,1
-Jewell,Harrison,Governor,,L,Keen Umbehr,0
-Jewell,Highland,Governor,,L,Keen Umbehr,1
-Jewell,Homwood,Governor,,L,Keen Umbehr,1
-Jewell,Ionia,Governor,,L,Keen Umbehr,1
-Jewell,Jackson,Governor,,L,Keen Umbehr,1
-Jewell,Limestone,Governor,,L,Keen Umbehr,2
-Jewell,Montana,Governor,,L,Keen Umbehr,3
-Jewell,Odessa,Governor,,L,Keen Umbehr,0
-Jewell,Prairie,Governor,,L,Keen Umbehr,3
-Jewell,Richland,Governor,,L,Keen Umbehr,2
-Jewell,Sinclair,Governor,,L,Keen Umbehr,3
-Jewell,Vicksburg,Governor,,L,Keen Umbehr,0
-Jewell,Walnut,Governor,,L,Keen Umbehr,1
-Jewell,Washington,Governor,,L,Keen Umbehr,0
-Jewell,Whitemound,Governor,,L,Keen Umbehr,1
-JEWELL,JEWELL KS,Governor,,L,Keen Umbehr,74
-Jewell,Allen,Secretary of State,,R,Kris Kobach,9
-Jewell,Athens,Secretary of State,,R,Kris Kobach,11
-Jewell,Browncreek,Secretary of State,,R,Kris Kobach,23
-Jewell,Buffalo,Secretary of State,,R,Kris Kobach,136
-Jewell,Burroak,Secretary of State,,R,Kris Kobach,72
-Jewell,Calvin,Secretary of State,,R,Kris Kobach,22
-Jewell,Center,Secretary of State,,R,Kris Kobach,246
-Jewell,Erving,Secretary of State,,R,Kris Kobach,8
-Jewell,Esbon,Secretary of State,,R,Kris Kobach,40
-Jewell,Grant,Secretary of State,,R,Kris Kobach,56
-Jewell,Harrison,Secretary of State,,R,Kris Kobach,9
-Jewell,Highland,Secretary of State,,R,Kris Kobach,10
-Jewell,Homwood,Secretary of State,,R,Kris Kobach,7
-Jewell,Ionia,Secretary of State,,R,Kris Kobach,25
-Jewell,Jackson,Secretary of State,,R,Kris Kobach,28
-Jewell,Limestone,Secretary of State,,R,Kris Kobach,20
-Jewell,Montana,Secretary of State,,R,Kris Kobach,22
-Jewell,Odessa,Secretary of State,,R,Kris Kobach,4
-Jewell,Prairie,Secretary of State,,R,Kris Kobach,44
-Jewell,Richland,Secretary of State,,R,Kris Kobach,10
-Jewell,Sinclair,Secretary of State,,R,Kris Kobach,9
-Jewell,Vicksburg,Secretary of State,,R,Kris Kobach,9
-Jewell,Walnut,Secretary of State,,R,Kris Kobach,22
-Jewell,Washington,Secretary of State,,R,Kris Kobach,15
-Jewell,Whitemound,Secretary of State,,R,Kris Kobach,15
-JEWELL,JEWELL KS,Secretary of State,,R,Kris Kobach,872
-Jewell,Allen,Secretary of State,,D,Jean Schodorf,0
-Jewell,Athens,Secretary of State,,D,Jean Schodorf,4
-Jewell,Browncreek,Secretary of State,,D,Jean Schodorf,2
-Jewell,Buffalo,Secretary of State,,D,Jean Schodorf,25
-Jewell,Burroak,Secretary of State,,D,Jean Schodorf,5
-Jewell,Calvin,Secretary of State,,D,Jean Schodorf,4
-Jewell,Center,Secretary of State,,D,Jean Schodorf,100
-Jewell,Erving,Secretary of State,,D,Jean Schodorf,2
-Jewell,Esbon,Secretary of State,,D,Jean Schodorf,15
-Jewell,Grant,Secretary of State,,D,Jean Schodorf,9
-Jewell,Harrison,Secretary of State,,D,Jean Schodorf,1
-Jewell,Highland,Secretary of State,,D,Jean Schodorf,9
-Jewell,Homwood,Secretary of State,,D,Jean Schodorf,3
-Jewell,Ionia,Secretary of State,,D,Jean Schodorf,5
-Jewell,Jackson,Secretary of State,,D,Jean Schodorf,6
-Jewell,Limestone,Secretary of State,,D,Jean Schodorf,6
-Jewell,Montana,Secretary of State,,D,Jean Schodorf,4
-Jewell,Odessa,Secretary of State,,D,Jean Schodorf,0
-Jewell,Prairie,Secretary of State,,D,Jean Schodorf,3
-Jewell,Richland,Secretary of State,,D,Jean Schodorf,2
-Jewell,Sinclair,Secretary of State,,D,Jean Schodorf,5
-Jewell,Vicksburg,Secretary of State,,D,Jean Schodorf,0
-Jewell,Walnut,Secretary of State,,D,Jean Schodorf,4
-Jewell,Washington,Secretary of State,,D,Jean Schodorf,4
-Jewell,Whitemound,Secretary of State,,D,Jean Schodorf,3
-JEWELL,JEWELL KS,Secretary of State,,D,Jean Schodorf,221
-Jewell,Allen,Attorney General,,R,Derek Schmidt,8
-Jewell,Athens,Attorney General,,R,Derek Schmidt,12
-Jewell,Browncreek,Attorney General,,R,Derek Schmidt,21
-Jewell,Buffalo,Attorney General,,R,Derek Schmidt,138
-Jewell,Burroak,Attorney General,,R,Derek Schmidt,68
-Jewell,Calvin,Attorney General,,R,Derek Schmidt,23
-Jewell,Center,Attorney General,,R,Derek Schmidt,283
-Jewell,Erving,Attorney General,,R,Derek Schmidt,9
-Jewell,Esbon,Attorney General,,R,Derek Schmidt,41
-Jewell,Grant,Attorney General,,R,Derek Schmidt,59
-Jewell,Harrison,Attorney General,,R,Derek Schmidt,9
-Jewell,Highland,Attorney General,,R,Derek Schmidt,11
-Jewell,Homwood,Attorney General,,R,Derek Schmidt,8
-Jewell,Ionia,Attorney General,,R,Derek Schmidt,28
-Jewell,Jackson,Attorney General,,R,Derek Schmidt,28
-Jewell,Limestone,Attorney General,,R,Derek Schmidt,20
-Jewell,Montana,Attorney General,,R,Derek Schmidt,24
-Jewell,Odessa,Attorney General,,R,Derek Schmidt,4
-Jewell,Prairie,Attorney General,,R,Derek Schmidt,44
-Jewell,Richland,Attorney General,,R,Derek Schmidt,11
-Jewell,Sinclair,Attorney General,,R,Derek Schmidt,12
-Jewell,Vicksburg,Attorney General,,R,Derek Schmidt,8
-Jewell,Walnut,Attorney General,,R,Derek Schmidt,21
-Jewell,Washington,Attorney General,,R,Derek Schmidt,19
-Jewell,Whitemound,Attorney General,,R,Derek Schmidt,15
-JEWELL,JEWELL KS,Attorney General,,R,Derek Schmidt,924
-Jewell,Allen,Attorney General,,D,A J Kotich,1
-Jewell,Athens,Attorney General,,D,A J Kotich,3
-Jewell,Browncreek,Attorney General,,D,A J Kotich,4
-Jewell,Buffalo,Attorney General,,D,A J Kotich,20
-Jewell,Burroak,Attorney General,,D,A J Kotich,9
-Jewell,Calvin,Attorney General,,D,A J Kotich,3
-Jewell,Center,Attorney General,,D,A J Kotich,58
-Jewell,Erving,Attorney General,,D,A J Kotich,1
-Jewell,Esbon,Attorney General,,D,A J Kotich,12
-Jewell,Grant,Attorney General,,D,A J Kotich,3
-Jewell,Harrison,Attorney General,,D,A J Kotich,1
-Jewell,Highland,Attorney General,,D,A J Kotich,7
-Jewell,Homwood,Attorney General,,D,A J Kotich,1
-Jewell,Ionia,Attorney General,,D,A J Kotich,3
-Jewell,Jackson,Attorney General,,D,A J Kotich,6
-Jewell,Limestone,Attorney General,,D,A J Kotich,6
-Jewell,Montana,Attorney General,,D,A J Kotich,3
-Jewell,Odessa,Attorney General,,D,A J Kotich,0
-Jewell,Prairie,Attorney General,,D,A J Kotich,4
-Jewell,Richland,Attorney General,,D,A J Kotich,5
-Jewell,Sinclair,Attorney General,,D,A J Kotich,2
-Jewell,Vicksburg,Attorney General,,D,A J Kotich,1
-Jewell,Walnut,Attorney General,,D,A J Kotich,4
-Jewell,Washington,Attorney General,,D,A J Kotich,2
-Jewell,Whitemound,Attorney General,,D,A J Kotich,2
-JEWELL,JEWELL KS,Attorney General,,D,A J Kotich,161
-Jewell,Allen,State Treasurer,,R,Ron Estes,8
-Jewell,Athens,State Treasurer,,R,Ron Estes,11
-Jewell,Browncreek,State Treasurer,,R,Ron Estes,21
-Jewell,Buffalo,State Treasurer,,R,Ron Estes,137
-Jewell,Burroak,State Treasurer,,R,Ron Estes,68
-Jewell,Calvin,State Treasurer,,R,Ron Estes,24
-Jewell,Center,State Treasurer,,R,Ron Estes,266
-Jewell,Erving,State Treasurer,,R,Ron Estes,8
-Jewell,Esbon,State Treasurer,,R,Ron Estes,43
-Jewell,Grant,State Treasurer,,R,Ron Estes,58
-Jewell,Harrison,State Treasurer,,R,Ron Estes,9
-Jewell,Highland,State Treasurer,,R,Ron Estes,10
-Jewell,Homwood,State Treasurer,,R,Ron Estes,7
-Jewell,Ionia,State Treasurer,,R,Ron Estes,29
-Jewell,Jackson,State Treasurer,,R,Ron Estes,27
-Jewell,Limestone,State Treasurer,,R,Ron Estes,19
-Jewell,Montana,State Treasurer,,R,Ron Estes,22
-Jewell,Odessa,State Treasurer,,R,Ron Estes,4
-Jewell,Prairie,State Treasurer,,R,Ron Estes,44
-Jewell,Richland,State Treasurer,,R,Ron Estes,11
-Jewell,Sinclair,State Treasurer,,R,Ron Estes,12
-Jewell,Vicksburg,State Treasurer,,R,Ron Estes,8
-Jewell,Walnut,State Treasurer,,R,Ron Estes,22
-Jewell,Washington,State Treasurer,,R,Ron Estes,17
-Jewell,Whitemound,State Treasurer,,R,Ron Estes,16
-JEWELL,JEWELL KS,State Treasurer,,R,Ron Estes,901
-Jewell,Allen,State Treasurer,,D,Carmen Alldritt,1
-Jewell,Athens,State Treasurer,,D,Carmen Alldritt,4
-Jewell,Browncreek,State Treasurer,,D,Carmen Alldritt,3
-Jewell,Buffalo,State Treasurer,,D,Carmen Alldritt,20
-Jewell,Burroak,State Treasurer,,D,Carmen Alldritt,8
-Jewell,Calvin,State Treasurer,,D,Carmen Alldritt,2
-Jewell,Center,State Treasurer,,D,Carmen Alldritt,71
-Jewell,Erving,State Treasurer,,D,Carmen Alldritt,2
-Jewell,Esbon,State Treasurer,,D,Carmen Alldritt,12
-Jewell,Grant,State Treasurer,,D,Carmen Alldritt,7
-Jewell,Harrison,State Treasurer,,D,Carmen Alldritt,1
-Jewell,Highland,State Treasurer,,D,Carmen Alldritt,7
-Jewell,Homwood,State Treasurer,,D,Carmen Alldritt,2
-Jewell,Ionia,State Treasurer,,D,Carmen Alldritt,2
-Jewell,Jackson,State Treasurer,,D,Carmen Alldritt,7
-Jewell,Limestone,State Treasurer,,D,Carmen Alldritt,7
-Jewell,Montana,State Treasurer,,D,Carmen Alldritt,5
-Jewell,Odessa,State Treasurer,,D,Carmen Alldritt,0
-Jewell,Prairie,State Treasurer,,D,Carmen Alldritt,3
-Jewell,Richland,State Treasurer,,D,Carmen Alldritt,1
-Jewell,Sinclair,State Treasurer,,D,Carmen Alldritt,2
-Jewell,Vicksburg,State Treasurer,,D,Carmen Alldritt,1
-Jewell,Walnut,State Treasurer,,D,Carmen Alldritt,3
-Jewell,Washington,State Treasurer,,D,Carmen Alldritt,4
-Jewell,Whitemound,State Treasurer,,D,Carmen Alldritt,1
-JEWELL,JEWELL KS,State Treasurer,,D,Carmen Alldritt,176
-Jewell,Allen,Insurance Commissioner,,R,Ken Selzer,7
-Jewell,Athens,Insurance Commissioner,,R,Ken Selzer,11
-Jewell,Browncreek,Insurance Commissioner,,R,Ken Selzer,18
-Jewell,Buffalo,Insurance Commissioner,,R,Ken Selzer,137
-Jewell,Burroak,Insurance Commissioner,,R,Ken Selzer,67
-Jewell,Calvin,Insurance Commissioner,,R,Ken Selzer,25
-Jewell,Center,Insurance Commissioner,,R,Ken Selzer,260
-Jewell,Erving,Insurance Commissioner,,R,Ken Selzer,7
-Jewell,Esbon,Insurance Commissioner,,R,Ken Selzer,38
-Jewell,Grant,Insurance Commissioner,,R,Ken Selzer,55
-Jewell,Harrison,Insurance Commissioner,,R,Ken Selzer,9
-Jewell,Highland,Insurance Commissioner,,R,Ken Selzer,11
-Jewell,Homwood,Insurance Commissioner,,R,Ken Selzer,8
-Jewell,Ionia,Insurance Commissioner,,R,Ken Selzer,29
-Jewell,Jackson,Insurance Commissioner,,R,Ken Selzer,27
-Jewell,Limestone,Insurance Commissioner,,R,Ken Selzer,20
-Jewell,Montana,Insurance Commissioner,,R,Ken Selzer,22
-Jewell,Odessa,Insurance Commissioner,,R,Ken Selzer,4
-Jewell,Prairie,Insurance Commissioner,,R,Ken Selzer,45
-Jewell,Richland,Insurance Commissioner,,R,Ken Selzer,11
-Jewell,Sinclair,Insurance Commissioner,,R,Ken Selzer,11
-Jewell,Vicksburg,Insurance Commissioner,,R,Ken Selzer,9
-Jewell,Walnut,Insurance Commissioner,,R,Ken Selzer,23
-Jewell,Washington,Insurance Commissioner,,R,Ken Selzer,18
-Jewell,Whitemound,Insurance Commissioner,,R,Ken Selzer,12
-JEWELL,JEWELL KS,Insurance Commissioner,,R,Ken Selzer,884
-Jewell,Allen,Insurance Commissioner,,D,Dennis Anderson,1
-Jewell,Athens,Insurance Commissioner,,D,Dennis Anderson,4
-Jewell,Browncreek,Insurance Commissioner,,D,Dennis Anderson,5
-Jewell,Buffalo,Insurance Commissioner,,D,Dennis Anderson,20
-Jewell,Burroak,Insurance Commissioner,,D,Dennis Anderson,8
-Jewell,Calvin,Insurance Commissioner,,D,Dennis Anderson,1
-Jewell,Center,Insurance Commissioner,,D,Dennis Anderson,78
-Jewell,Erving,Insurance Commissioner,,D,Dennis Anderson,3
-Jewell,Esbon,Insurance Commissioner,,D,Dennis Anderson,13
-Jewell,Grant,Insurance Commissioner,,D,Dennis Anderson,7
-Jewell,Harrison,Insurance Commissioner,,D,Dennis Anderson,1
-Jewell,Highland,Insurance Commissioner,,D,Dennis Anderson,7
-Jewell,Homwood,Insurance Commissioner,,D,Dennis Anderson,1
-Jewell,Ionia,Insurance Commissioner,,D,Dennis Anderson,2
-Jewell,Jackson,Insurance Commissioner,,D,Dennis Anderson,7
-Jewell,Limestone,Insurance Commissioner,,D,Dennis Anderson,6
-Jewell,Montana,Insurance Commissioner,,D,Dennis Anderson,5
-Jewell,Odessa,Insurance Commissioner,,D,Dennis Anderson,0
-Jewell,Prairie,Insurance Commissioner,,D,Dennis Anderson,2
-Jewell,Richland,Insurance Commissioner,,D,Dennis Anderson,1
-Jewell,Sinclair,Insurance Commissioner,,D,Dennis Anderson,2
-Jewell,Vicksburg,Insurance Commissioner,,D,Dennis Anderson,0
-Jewell,Walnut,Insurance Commissioner,,D,Dennis Anderson,3
-Jewell,Washington,Insurance Commissioner,,D,Dennis Anderson,3
-Jewell,Whitemound,Insurance Commissioner,,D,Dennis Anderson,4
-JEWELL,JEWELL KS,Insurance Commissioner,,D,Dennis Anderson,184
-Jewell,Allen,106,106,R,Sharon Schwartz,8
-Jewell,Athens,109,109,R,Troy Waymaster,14
-Jewell,Browncreek,109,109,R,Troy Waymaster,24
-Jewell,Buffalo,106,106,R,Sharon Schwartz,147
-Jewell,Burroak,109,109,R,Troy Waymaster,70
-Jewell,Calvin,109,109,R,Troy Waymaster,26
-Jewell,Center,109,109,R,Troy Waymaster,302
-Jewell,Erving,109,109,R,Troy Waymaster,10
-Jewell,Esbon,109,109,R,Troy Waymaster,50
-Jewell,Grant,106,106,R,Sharon Schwartz,59
-Jewell,Harrison,109,109,R,Troy Waymaster,9
-Jewell,Highland,109,109,R,Troy Waymaster,15
-Jewell,Homwood,109,109,R,Troy Waymaster,9
-Jewell,Ionia,109,109,R,Troy Waymaster,29
-Jewell,Jackson,106,106,R,Sharon Schwartz,27
-Jewell,Limestone,109,109,R,Troy Waymaster,22
-Jewell,Montana,106,106,R,Sharon Schwartz,27
-Jewell,Odessa,109,109,R,Troy Waymaster,4
-Jewell,Prairie,106,106,R,Sharon Schwartz,46
-Jewell,Richland,106,106,R,Sharon Schwartz,11
-Jewell,Sinclair,106,106,R,Sharon Schwartz,12
-Jewell,Vicksburg,106,106,R,Sharon Schwartz,8
-Jewell,Walnut,109,109,R,Troy Waymaster,23
-Jewell,Washington,109,109,R,Troy Waymaster,5
-Jewell,Whitemound,109,109,R,Troy Waymaster,17
-Jewell,Walnut,106,106,R,Sharon Schwartz,2
-Jewell,Washington,106,106,R,Sharon Schwartz,13
+county,precinct,office,district,party,candidate,votes,vtd
+JEWELL,Allen Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000010
+JEWELL,Allen Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+JEWELL,Allen Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,000010
+JEWELL,Athens Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000020
+JEWELL,Athens Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+JEWELL,Athens Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000020
+JEWELL,Browns Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000030
+JEWELL,Browns Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+JEWELL,Browns Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000030
+JEWELL,Buffalo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000040
+JEWELL,Buffalo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000040
+JEWELL,Buffalo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,000040
+JEWELL,Burr Oak Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000050
+JEWELL,Burr Oak Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000050
+JEWELL,Burr Oak Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000050
+JEWELL,Calvin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000060
+JEWELL,Calvin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+JEWELL,Calvin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000060
+JEWELL,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",130,000070
+JEWELL,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000070
+JEWELL,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",204,000070
+JEWELL,Erving Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000080
+JEWELL,Erving Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+JEWELL,Erving Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000080
+JEWELL,Esbon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000090
+JEWELL,Esbon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000090
+JEWELL,Esbon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000090
+JEWELL,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000100
+JEWELL,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+JEWELL,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000100
+JEWELL,Harrison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000110
+JEWELL,Harrison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+JEWELL,Harrison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000110
+JEWELL,Highland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000120
+JEWELL,Highland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000120
+JEWELL,Highland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000120
+JEWELL,Holmwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000130
+JEWELL,Holmwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000130
+JEWELL,Holmwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,000130
+JEWELL,Ionia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000140
+JEWELL,Ionia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+JEWELL,Ionia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000140
+JEWELL,Jackson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000150
+JEWELL,Jackson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+JEWELL,Jackson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000150
+JEWELL,Limestone Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000160
+JEWELL,Limestone Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000160
+JEWELL,Limestone Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000160
+JEWELL,Montana Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000170
+JEWELL,Montana Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000170
+JEWELL,Montana Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000170
+JEWELL,Odessa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000180
+JEWELL,Odessa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000180
+JEWELL,Odessa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000180
+JEWELL,Prairie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000190
+JEWELL,Prairie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000190
+JEWELL,Prairie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000190
+JEWELL,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000200
+JEWELL,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000200
+JEWELL,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000200
+JEWELL,Sinclair Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000210
+JEWELL,Sinclair Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000210
+JEWELL,Sinclair Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000210
+JEWELL,Vicksburg Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000220
+JEWELL,Vicksburg Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000220
+JEWELL,Vicksburg Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000220
+JEWELL,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000230
+JEWELL,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000230
+JEWELL,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000230
+JEWELL,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000240
+JEWELL,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000240
+JEWELL,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000240
+JEWELL,White Mound Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000250
+JEWELL,White Mound Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000250
+JEWELL,White Mound Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000250
+JEWELL,Allen Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",8,000010
+JEWELL,Athens Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000020
+JEWELL,Browns Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000030
+JEWELL,Buffalo Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",150,000040
+JEWELL,Burr Oak Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",70,000050
+JEWELL,Calvin Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",26,000060
+JEWELL,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",304,000070
+JEWELL,Erving Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000080
+JEWELL,Esbon Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",53,000090
+JEWELL,Grant Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",59,000100
+JEWELL,Harrison Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",9,000110
+JEWELL,Highland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",15,000120
+JEWELL,Holmwood Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",9,000130
+JEWELL,Ionia Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",30,000140
+JEWELL,Jackson Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",27,000150
+JEWELL,Limestone Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",22,000160
+JEWELL,Montana Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",27,000170
+JEWELL,Odessa Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",4,000180
+JEWELL,Prairie Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",46,000190
+JEWELL,Richland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",11,000200
+JEWELL,Sinclair Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",12,000210
+JEWELL,Vicksburg Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",8,000220
+JEWELL,Walnut Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",28,000230
+JEWELL,Washington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",16,000240
+JEWELL,White Mound Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",17,000250
+JEWELL,Allen Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000010
+JEWELL,Allen Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000010
+JEWELL,Athens Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000020
+JEWELL,Athens Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000020
+JEWELL,Browns Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000030
+JEWELL,Browns Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000030
+JEWELL,Buffalo Township,United States House of Representatives,1,Democratic,"Sherow, James E.",37,000040
+JEWELL,Buffalo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",125,000040
+JEWELL,Burr Oak Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000050
+JEWELL,Burr Oak Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,000050
+JEWELL,Calvin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000060
+JEWELL,Calvin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000060
+JEWELL,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",107,000070
+JEWELL,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",241,000070
+JEWELL,Erving Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000080
+JEWELL,Erving Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000080
+JEWELL,Esbon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000090
+JEWELL,Esbon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000090
+JEWELL,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000100
+JEWELL,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000100
+JEWELL,Harrison Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000110
+JEWELL,Harrison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000110
+JEWELL,Highland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000120
+JEWELL,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000120
+JEWELL,Holmwood Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000130
+JEWELL,Holmwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,000130
+JEWELL,Ionia Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000140
+JEWELL,Ionia Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000140
+JEWELL,Jackson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000150
+JEWELL,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000150
+JEWELL,Limestone Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000160
+JEWELL,Limestone Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000160
+JEWELL,Montana Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000170
+JEWELL,Montana Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000170
+JEWELL,Odessa Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000180
+JEWELL,Odessa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,000180
+JEWELL,Prairie Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000190
+JEWELL,Prairie Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000190
+JEWELL,Richland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000200
+JEWELL,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000200
+JEWELL,Sinclair Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000210
+JEWELL,Sinclair Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000210
+JEWELL,Vicksburg Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000220
+JEWELL,Vicksburg Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000220
+JEWELL,Walnut Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000230
+JEWELL,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000230
+JEWELL,Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000240
+JEWELL,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000240
+JEWELL,White Mound Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000250
+JEWELL,White Mound Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000250
+JEWELL,Allen Township,Attorney General,,Democratic,"Kotich, A.J.",1,000010
+JEWELL,Allen Township,Attorney General,,Republican,"Schmidt, Derek",8,000010
+JEWELL,Athens Township,Attorney General,,Democratic,"Kotich, A.J.",3,000020
+JEWELL,Athens Township,Attorney General,,Republican,"Schmidt, Derek",12,000020
+JEWELL,Browns Creek Township,Attorney General,,Democratic,"Kotich, A.J.",4,000030
+JEWELL,Browns Creek Township,Attorney General,,Republican,"Schmidt, Derek",19,000030
+JEWELL,Buffalo Township,Attorney General,,Democratic,"Kotich, A.J.",22,000040
+JEWELL,Buffalo Township,Attorney General,,Republican,"Schmidt, Derek",140,000040
+JEWELL,Burr Oak Township,Attorney General,,Democratic,"Kotich, A.J.",9,000050
+JEWELL,Burr Oak Township,Attorney General,,Republican,"Schmidt, Derek",68,000050
+JEWELL,Calvin Township,Attorney General,,Democratic,"Kotich, A.J.",3,000060
+JEWELL,Calvin Township,Attorney General,,Republican,"Schmidt, Derek",23,000060
+JEWELL,Center Township,Attorney General,,Democratic,"Kotich, A.J.",59,000070
+JEWELL,Center Township,Attorney General,,Republican,"Schmidt, Derek",284,000070
+JEWELL,Erving Township,Attorney General,,Democratic,"Kotich, A.J.",1,000080
+JEWELL,Erving Township,Attorney General,,Republican,"Schmidt, Derek",9,000080
+JEWELL,Esbon Township,Attorney General,,Democratic,"Kotich, A.J.",12,000090
+JEWELL,Esbon Township,Attorney General,,Republican,"Schmidt, Derek",44,000090
+JEWELL,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",3,000100
+JEWELL,Grant Township,Attorney General,,Republican,"Schmidt, Derek",59,000100
+JEWELL,Harrison Township,Attorney General,,Democratic,"Kotich, A.J.",1,000110
+JEWELL,Harrison Township,Attorney General,,Republican,"Schmidt, Derek",9,000110
+JEWELL,Highland Township,Attorney General,,Democratic,"Kotich, A.J.",7,000120
+JEWELL,Highland Township,Attorney General,,Republican,"Schmidt, Derek",11,000120
+JEWELL,Holmwood Township,Attorney General,,Democratic,"Kotich, A.J.",1,000130
+JEWELL,Holmwood Township,Attorney General,,Republican,"Schmidt, Derek",8,000130
+JEWELL,Ionia Township,Attorney General,,Democratic,"Kotich, A.J.",3,000140
+JEWELL,Ionia Township,Attorney General,,Republican,"Schmidt, Derek",29,000140
+JEWELL,Jackson Township,Attorney General,,Democratic,"Kotich, A.J.",6,000150
+JEWELL,Jackson Township,Attorney General,,Republican,"Schmidt, Derek",28,000150
+JEWELL,Limestone Township,Attorney General,,Democratic,"Kotich, A.J.",6,000160
+JEWELL,Limestone Township,Attorney General,,Republican,"Schmidt, Derek",20,000160
+JEWELL,Montana Township,Attorney General,,Democratic,"Kotich, A.J.",3,000170
+JEWELL,Montana Township,Attorney General,,Republican,"Schmidt, Derek",24,000170
+JEWELL,Odessa Township,Attorney General,,Democratic,"Kotich, A.J.",0,000180
+JEWELL,Odessa Township,Attorney General,,Republican,"Schmidt, Derek",4,000180
+JEWELL,Prairie Township,Attorney General,,Democratic,"Kotich, A.J.",4,000190
+JEWELL,Prairie Township,Attorney General,,Republican,"Schmidt, Derek",44,000190
+JEWELL,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",1,000200
+JEWELL,Richland Township,Attorney General,,Republican,"Schmidt, Derek",11,000200
+JEWELL,Sinclair Township,Attorney General,,Democratic,"Kotich, A.J.",2,000210
+JEWELL,Sinclair Township,Attorney General,,Republican,"Schmidt, Derek",12,000210
+JEWELL,Vicksburg Township,Attorney General,,Democratic,"Kotich, A.J.",1,000220
+JEWELL,Vicksburg Township,Attorney General,,Republican,"Schmidt, Derek",8,000220
+JEWELL,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",3,000230
+JEWELL,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",24,000230
+JEWELL,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",3,000240
+JEWELL,Washington Township,Attorney General,,Republican,"Schmidt, Derek",17,000240
+JEWELL,White Mound Township,Attorney General,,Democratic,"Kotich, A.J.",2,000250
+JEWELL,White Mound Township,Attorney General,,Republican,"Schmidt, Derek",15,000250
+JEWELL,Allen Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000010
+JEWELL,Allen Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000010
+JEWELL,Athens Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000020
+JEWELL,Athens Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000020
+JEWELL,Browns Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000030
+JEWELL,Browns Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000030
+JEWELL,Buffalo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000040
+JEWELL,Buffalo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000040
+JEWELL,Burr Oak Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000050
+JEWELL,Burr Oak Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000050
+JEWELL,Calvin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000060
+JEWELL,Calvin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000060
+JEWELL,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000070
+JEWELL,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",260,000070
+JEWELL,Erving Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000080
+JEWELL,Erving Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000080
+JEWELL,Esbon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000090
+JEWELL,Esbon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000090
+JEWELL,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000100
+JEWELL,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000100
+JEWELL,Harrison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000110
+JEWELL,Harrison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000110
+JEWELL,Highland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000120
+JEWELL,Highland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000120
+JEWELL,Holmwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000130
+JEWELL,Holmwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000130
+JEWELL,Ionia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000140
+JEWELL,Ionia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000140
+JEWELL,Jackson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000150
+JEWELL,Jackson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000150
+JEWELL,Limestone Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000160
+JEWELL,Limestone Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000160
+JEWELL,Montana Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000170
+JEWELL,Montana Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000170
+JEWELL,Odessa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000180
+JEWELL,Odessa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",4,000180
+JEWELL,Prairie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000190
+JEWELL,Prairie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000190
+JEWELL,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000200
+JEWELL,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000200
+JEWELL,Sinclair Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000210
+JEWELL,Sinclair Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000210
+JEWELL,Vicksburg Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000220
+JEWELL,Vicksburg Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000220
+JEWELL,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000230
+JEWELL,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000230
+JEWELL,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000240
+JEWELL,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000240
+JEWELL,White Mound Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000250
+JEWELL,White Mound Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000250
+JEWELL,Allen Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000010
+JEWELL,Allen Township,Secretary of State,,Republican,"Kobach, Kris",9,000010
+JEWELL,Athens Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000020
+JEWELL,Athens Township,Secretary of State,,Republican,"Kobach, Kris",11,000020
+JEWELL,Browns Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000030
+JEWELL,Browns Creek Township,Secretary of State,,Republican,"Kobach, Kris",24,000030
+JEWELL,Buffalo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000040
+JEWELL,Buffalo Township,Secretary of State,,Republican,"Kobach, Kris",137,000040
+JEWELL,Burr Oak Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000050
+JEWELL,Burr Oak Township,Secretary of State,,Republican,"Kobach, Kris",72,000050
+JEWELL,Calvin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000060
+JEWELL,Calvin Township,Secretary of State,,Republican,"Kobach, Kris",22,000060
+JEWELL,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",101,000070
+JEWELL,Center Township,Secretary of State,,Republican,"Kobach, Kris",247,000070
+JEWELL,Erving Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000080
+JEWELL,Erving Township,Secretary of State,,Republican,"Kobach, Kris",8,000080
+JEWELL,Esbon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000090
+JEWELL,Esbon Township,Secretary of State,,Republican,"Kobach, Kris",43,000090
+JEWELL,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000100
+JEWELL,Grant Township,Secretary of State,,Republican,"Kobach, Kris",56,000100
+JEWELL,Harrison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000110
+JEWELL,Harrison Township,Secretary of State,,Republican,"Kobach, Kris",9,000110
+JEWELL,Highland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000120
+JEWELL,Highland Township,Secretary of State,,Republican,"Kobach, Kris",10,000120
+JEWELL,Holmwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000130
+JEWELL,Holmwood Township,Secretary of State,,Republican,"Kobach, Kris",7,000130
+JEWELL,Ionia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000140
+JEWELL,Ionia Township,Secretary of State,,Republican,"Kobach, Kris",26,000140
+JEWELL,Jackson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000150
+JEWELL,Jackson Township,Secretary of State,,Republican,"Kobach, Kris",28,000150
+JEWELL,Limestone Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000160
+JEWELL,Limestone Township,Secretary of State,,Republican,"Kobach, Kris",20,000160
+JEWELL,Montana Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000170
+JEWELL,Montana Township,Secretary of State,,Republican,"Kobach, Kris",22,000170
+JEWELL,Odessa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000180
+JEWELL,Odessa Township,Secretary of State,,Republican,"Kobach, Kris",4,000180
+JEWELL,Prairie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000190
+JEWELL,Prairie Township,Secretary of State,,Republican,"Kobach, Kris",44,000190
+JEWELL,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000200
+JEWELL,Richland Township,Secretary of State,,Republican,"Kobach, Kris",10,000200
+JEWELL,Sinclair Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000210
+JEWELL,Sinclair Township,Secretary of State,,Republican,"Kobach, Kris",9,000210
+JEWELL,Vicksburg Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000220
+JEWELL,Vicksburg Township,Secretary of State,,Republican,"Kobach, Kris",9,000220
+JEWELL,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000230
+JEWELL,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",25,000230
+JEWELL,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000240
+JEWELL,Washington Township,Secretary of State,,Republican,"Kobach, Kris",13,000240
+JEWELL,White Mound Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000250
+JEWELL,White Mound Township,Secretary of State,,Republican,"Kobach, Kris",15,000250
+JEWELL,Allen Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000010
+JEWELL,Allen Township,State Treasurer,,Republican,"Estes, Ron",8,000010
+JEWELL,Athens Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000020
+JEWELL,Athens Township,State Treasurer,,Republican,"Estes, Ron",11,000020
+JEWELL,Browns Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+JEWELL,Browns Creek Township,State Treasurer,,Republican,"Estes, Ron",22,000030
+JEWELL,Buffalo Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000040
+JEWELL,Buffalo Township,State Treasurer,,Republican,"Estes, Ron",140,000040
+JEWELL,Burr Oak Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000050
+JEWELL,Burr Oak Township,State Treasurer,,Republican,"Estes, Ron",68,000050
+JEWELL,Calvin Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000060
+JEWELL,Calvin Township,State Treasurer,,Republican,"Estes, Ron",24,000060
+JEWELL,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",72,000070
+JEWELL,Center Township,State Treasurer,,Republican,"Estes, Ron",267,000070
+JEWELL,Erving Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000080
+JEWELL,Erving Township,State Treasurer,,Republican,"Estes, Ron",8,000080
+JEWELL,Esbon Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000090
+JEWELL,Esbon Township,State Treasurer,,Republican,"Estes, Ron",46,000090
+JEWELL,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000100
+JEWELL,Grant Township,State Treasurer,,Republican,"Estes, Ron",58,000100
+JEWELL,Harrison Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000110
+JEWELL,Harrison Township,State Treasurer,,Republican,"Estes, Ron",9,000110
+JEWELL,Highland Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000120
+JEWELL,Highland Township,State Treasurer,,Republican,"Estes, Ron",10,000120
+JEWELL,Holmwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000130
+JEWELL,Holmwood Township,State Treasurer,,Republican,"Estes, Ron",7,000130
+JEWELL,Ionia Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000140
+JEWELL,Ionia Township,State Treasurer,,Republican,"Estes, Ron",30,000140
+JEWELL,Jackson Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000150
+JEWELL,Jackson Township,State Treasurer,,Republican,"Estes, Ron",27,000150
+JEWELL,Limestone Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000160
+JEWELL,Limestone Township,State Treasurer,,Republican,"Estes, Ron",19,000160
+JEWELL,Montana Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000170
+JEWELL,Montana Township,State Treasurer,,Republican,"Estes, Ron",22,000170
+JEWELL,Odessa Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000180
+JEWELL,Odessa Township,State Treasurer,,Republican,"Estes, Ron",4,000180
+JEWELL,Prairie Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000190
+JEWELL,Prairie Township,State Treasurer,,Republican,"Estes, Ron",44,000190
+JEWELL,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000200
+JEWELL,Richland Township,State Treasurer,,Republican,"Estes, Ron",11,000200
+JEWELL,Sinclair Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000210
+JEWELL,Sinclair Township,State Treasurer,,Republican,"Estes, Ron",12,000210
+JEWELL,Vicksburg Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000220
+JEWELL,Vicksburg Township,State Treasurer,,Republican,"Estes, Ron",8,000220
+JEWELL,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000230
+JEWELL,Walnut Township,State Treasurer,,Republican,"Estes, Ron",25,000230
+JEWELL,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000240
+JEWELL,Washington Township,State Treasurer,,Republican,"Estes, Ron",15,000240
+JEWELL,White Mound Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000250
+JEWELL,White Mound Township,State Treasurer,,Republican,"Estes, Ron",16,000250
+JEWELL,Allen Township,United States Senate,,independent,"Orman, Greg",1,000010
+JEWELL,Allen Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+JEWELL,Allen Township,United States Senate,,Republican,"Roberts, Pat",8,000010
+JEWELL,Athens Township,United States Senate,,independent,"Orman, Greg",4,000020
+JEWELL,Athens Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+JEWELL,Athens Township,United States Senate,,Republican,"Roberts, Pat",9,000020
+JEWELL,Browns Creek Township,United States Senate,,independent,"Orman, Greg",2,000030
+JEWELL,Browns Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+JEWELL,Browns Creek Township,United States Senate,,Republican,"Roberts, Pat",24,000030
+JEWELL,Buffalo Township,United States Senate,,independent,"Orman, Greg",22,000040
+JEWELL,Buffalo Township,United States Senate,,Libertarian,"Batson, Randall",13,000040
+JEWELL,Buffalo Township,United States Senate,,Republican,"Roberts, Pat",129,000040
+JEWELL,Burr Oak Township,United States Senate,,independent,"Orman, Greg",12,000050
+JEWELL,Burr Oak Township,United States Senate,,Libertarian,"Batson, Randall",8,000050
+JEWELL,Burr Oak Township,United States Senate,,Republican,"Roberts, Pat",58,000050
+JEWELL,Calvin Township,United States Senate,,independent,"Orman, Greg",2,000060
+JEWELL,Calvin Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+JEWELL,Calvin Township,United States Senate,,Republican,"Roberts, Pat",24,000060
+JEWELL,Center Township,United States Senate,,independent,"Orman, Greg",103,000070
+JEWELL,Center Township,United States Senate,,Libertarian,"Batson, Randall",17,000070
+JEWELL,Center Township,United States Senate,,Republican,"Roberts, Pat",235,000070
+JEWELL,Erving Township,United States Senate,,independent,"Orman, Greg",2,000080
+JEWELL,Erving Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+JEWELL,Erving Township,United States Senate,,Republican,"Roberts, Pat",8,000080
+JEWELL,Esbon Township,United States Senate,,independent,"Orman, Greg",18,000090
+JEWELL,Esbon Township,United States Senate,,Libertarian,"Batson, Randall",4,000090
+JEWELL,Esbon Township,United States Senate,,Republican,"Roberts, Pat",39,000090
+JEWELL,Grant Township,United States Senate,,independent,"Orman, Greg",4,000100
+JEWELL,Grant Township,United States Senate,,Libertarian,"Batson, Randall",4,000100
+JEWELL,Grant Township,United States Senate,,Republican,"Roberts, Pat",57,000100
+JEWELL,Harrison Township,United States Senate,,independent,"Orman, Greg",1,000110
+JEWELL,Harrison Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+JEWELL,Harrison Township,United States Senate,,Republican,"Roberts, Pat",9,000110
+JEWELL,Highland Township,United States Senate,,independent,"Orman, Greg",7,000120
+JEWELL,Highland Township,United States Senate,,Libertarian,"Batson, Randall",1,000120
+JEWELL,Highland Township,United States Senate,,Republican,"Roberts, Pat",11,000120
+JEWELL,Holmwood Township,United States Senate,,independent,"Orman, Greg",2,000130
+JEWELL,Holmwood Township,United States Senate,,Libertarian,"Batson, Randall",1,000130
+JEWELL,Holmwood Township,United States Senate,,Republican,"Roberts, Pat",7,000130
+JEWELL,Ionia Township,United States Senate,,independent,"Orman, Greg",4,000140
+JEWELL,Ionia Township,United States Senate,,Libertarian,"Batson, Randall",0,000140
+JEWELL,Ionia Township,United States Senate,,Republican,"Roberts, Pat",28,000140
+JEWELL,Jackson Township,United States Senate,,independent,"Orman, Greg",7,000150
+JEWELL,Jackson Township,United States Senate,,Libertarian,"Batson, Randall",1,000150
+JEWELL,Jackson Township,United States Senate,,Republican,"Roberts, Pat",26,000150
+JEWELL,Limestone Township,United States Senate,,independent,"Orman, Greg",8,000160
+JEWELL,Limestone Township,United States Senate,,Libertarian,"Batson, Randall",0,000160
+JEWELL,Limestone Township,United States Senate,,Republican,"Roberts, Pat",18,000160
+JEWELL,Montana Township,United States Senate,,independent,"Orman, Greg",7,000170
+JEWELL,Montana Township,United States Senate,,Libertarian,"Batson, Randall",0,000170
+JEWELL,Montana Township,United States Senate,,Republican,"Roberts, Pat",20,000170
+JEWELL,Odessa Township,United States Senate,,independent,"Orman, Greg",0,000180
+JEWELL,Odessa Township,United States Senate,,Libertarian,"Batson, Randall",1,000180
+JEWELL,Odessa Township,United States Senate,,Republican,"Roberts, Pat",3,000180
+JEWELL,Prairie Township,United States Senate,,independent,"Orman, Greg",4,000190
+JEWELL,Prairie Township,United States Senate,,Libertarian,"Batson, Randall",1,000190
+JEWELL,Prairie Township,United States Senate,,Republican,"Roberts, Pat",45,000190
+JEWELL,Richland Township,United States Senate,,independent,"Orman, Greg",0,000200
+JEWELL,Richland Township,United States Senate,,Libertarian,"Batson, Randall",2,000200
+JEWELL,Richland Township,United States Senate,,Republican,"Roberts, Pat",9,000200
+JEWELL,Sinclair Township,United States Senate,,independent,"Orman, Greg",1,000210
+JEWELL,Sinclair Township,United States Senate,,Libertarian,"Batson, Randall",0,000210
+JEWELL,Sinclair Township,United States Senate,,Republican,"Roberts, Pat",13,000210
+JEWELL,Vicksburg Township,United States Senate,,independent,"Orman, Greg",0,000220
+JEWELL,Vicksburg Township,United States Senate,,Libertarian,"Batson, Randall",0,000220
+JEWELL,Vicksburg Township,United States Senate,,Republican,"Roberts, Pat",9,000220
+JEWELL,Walnut Township,United States Senate,,independent,"Orman, Greg",2,000230
+JEWELL,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+JEWELL,Walnut Township,United States Senate,,Republican,"Roberts, Pat",25,000230
+JEWELL,Washington Township,United States Senate,,independent,"Orman, Greg",2,000240
+JEWELL,Washington Township,United States Senate,,Libertarian,"Batson, Randall",0,000240
+JEWELL,Washington Township,United States Senate,,Republican,"Roberts, Pat",18,000240
+JEWELL,White Mound Township,United States Senate,,independent,"Orman, Greg",1,000250
+JEWELL,White Mound Township,United States Senate,,Libertarian,"Batson, Randall",0,000250
+JEWELL,White Mound Township,United States Senate,,Republican,"Roberts, Pat",18,000250

--- a/2014/20141104__ks__general__johnson__precinct.csv
+++ b/2014/20141104__ks__general__johnson__precinct.csv
@@ -1,11679 +1,2310 @@
-county,precinct,office,district,party,candidate,votes
-Johnson,Aubry Twp 0-01,,,,Registration,166
-Johnson,Aubry Twp 0-02,,,,Registration,1021
-Johnson,Aubry Twp 0-03,,,,Registration,607
-Johnson,Aubry Twp 0-04,,,,Registration,1377
-Johnson,Aubry Twp 0-05,,,,Registration,27
-Johnson,Aubry Twp 0-06,,,,Registration,140
-Johnson,De Soto 0-01,,,,Registration,1352
-Johnson,De Soto 0-02,,,,Registration,831
-Johnson,De Soto 0-03,,,,Registration,1110
-Johnson,De Soto 0-06,,,,Registration,147
-Johnson,De Soto 0-07,,,,Registration,2
-Johnson,Edgerton 0-01,,,,Registration,1020
-Johnson,Edgerton 0-02,,,,Registration,2
-Johnson,Edgerton 0-05,,,,Registration,5
-Johnson,Edgerton 0-06,,,,Registration,2
-Johnson,Edgerton 0-09,,,,Registration,3
-Johnson,Fairway 1-01,,,,Registration,468
-Johnson,Fairway 1-02,,,,Registration,345
-Johnson,Fairway 2-01,,,,Registration,354
-Johnson,Fairway 2-02,,,,Registration,355
-Johnson,Fairway 3-01,,,,Registration,454
-Johnson,Fairway 3-02,,,,Registration,389
-Johnson,Fairway 4-01,,,,Registration,194
-Johnson,Fairway 4-02,,,,Registration,245
-Johnson,Fairway 4-03,,,,Registration,160
-Johnson,Fairway 4-04,,,,Registration,234
-Johnson,Gardner 0-01,,,,Registration,1723
-Johnson,Gardner 0-02,,,,Registration,409
-Johnson,Gardner 0-03,,,,Registration,1532
-Johnson,Gardner 0-04,,,,Registration,1064
-Johnson,Gardner 0-06,,,,Registration,1324
-Johnson,Gardner 0-07,,,,Registration,28
-Johnson,Gardner 0-08,,,,Registration,96
-Johnson,Gardner 0-09,,,,Registration,1787
-Johnson,Gardner 0-10,,,,Registration,1048
-Johnson,Gardner 0-12,,,,Registration,24
-Johnson,Gardner 0-13,,,,Registration,1223
-Johnson,Gardner 0-14,,,,Registration,970
-Johnson,Gardner Twp 0-01,,,,Registration,541
-Johnson,Gardner Twp 0-02,,,,Registration,666
-Johnson,Gardner Twp 0-04,,,,Registration,2
-Johnson,Gardner Twp 0-05,,,,Registration,7
-Johnson,Gardner Twp 0-07,,,,Registration,4
-Johnson,Gardner Twp 0-08,,,,Registration,8
-Johnson,Gardner Twp 0-09,,,,Registration,4
-Johnson,Gardner Twp 0-10,,,,Registration,5
-Johnson,Gardner Twp 0-11,,,,Registration,159
-Johnson,Gardner Twp 0-13,,,,Registration,2
-Johnson,Lake Quivira 0-01,,,,Registration,797
-Johnson,Leawood 1-01,,,,Registration,766
-Johnson,Leawood 1-02,,,,Registration,1216
-Johnson,Leawood 1-03,,,,Registration,1057
-Johnson,Leawood 1-04,,,,Registration,875
-Johnson,Leawood 1-05,,,,Registration,832
-Johnson,Leawood 1-06,,,,Registration,231
-Johnson,Leawood 2-01,,,,Registration,980
-Johnson,Leawood 2-02,,,,Registration,1243
-Johnson,Leawood 2-03,,,,Registration,1233
-Johnson,Leawood 2-04,,,,Registration,1311
-Johnson,Leawood 2-05,,,,Registration,721
-Johnson,Leawood 2-06,,,,Registration,519
-Johnson,Leawood 3-01,,,,Registration,639
-Johnson,Leawood 3-02,,,,Registration,1223
-Johnson,Leawood 3-03,,,,Registration,728
-Johnson,Leawood 3-04,,,,Registration,385
-Johnson,Leawood 3-05,,,,Registration,1584
-Johnson,Leawood 3-06,,,,Registration,1551
-Johnson,Leawood 3-07,,,,Registration,1105
-Johnson,Leawood 4-01,,,,Registration,344
-Johnson,Leawood 4-02,,,,Registration,937
-Johnson,Leawood 4-03,,,,Registration,979
-Johnson,Leawood 4-04,,,,Registration,1192
-Johnson,Leawood 4-05,,,,Registration,1181
-Johnson,Leawood 4-06,,,,Registration,890
-Johnson,Leawood 4-07,,,,Registration,1603
-Johnson,Leawood 4-08,,,,Registration,667
-Johnson,Lenexa 1-01,,,,Registration,633
-Johnson,Lenexa 1-02,,,,Registration,1398
-Johnson,Lenexa 1-03,,,,Registration,1528
-Johnson,Lenexa 1-04,,,,Registration,1158
-Johnson,Lenexa 1-05,,,,Registration,1048
-Johnson,Lenexa 1-06,,,,Registration,1384
-Johnson,Lenexa 1-07,,,,Registration,804
-Johnson,Lenexa 1-08,,,,Registration,381
-Johnson,Lenexa 1-09,,,,Registration,18
-Johnson,Lenexa 2-01,,,,Registration,1772
-Johnson,Lenexa 2-02,,,,Registration,585
-Johnson,Lenexa 2-03,,,,Registration,1408
-Johnson,Lenexa 2-04,,,,Registration,1454
-Johnson,Lenexa 2-05,,,,Registration,1447
-Johnson,Lenexa 2-06,,,,Registration,901
-Johnson,Lenexa 2-07,,,,Registration,1642
-Johnson,Lenexa 3-01,,,,Registration,1193
-Johnson,Lenexa 3-02,,,,Registration,1244
-Johnson,Lenexa 3-03,,,,Registration,1437
-Johnson,Lenexa 3-04,,,,Registration,942
-Johnson,Lenexa 3-05,,,,Registration,1124
-Johnson,Lenexa 3-06,,,,Registration,861
-Johnson,Lenexa 3-07,,,,Registration,1073
-Johnson,Lenexa 3-08,,,,Registration,1117
-Johnson,Lenexa 4-01,,,,Registration,616
-Johnson,Lenexa 4-02,,,,Registration,1061
-Johnson,Lenexa 4-03,,,,Registration,994
-Johnson,Lenexa 4-04,,,,Registration,674
-Johnson,Lenexa 4-05,,,,Registration,540
-Johnson,Lenexa 4-06,,,,Registration,1073
-Johnson,Lenexa 4-07,,,,Registration,898
-Johnson,Lenexa 4-08,,,,Registration,800
-Johnson,Lenexa 4-09,,,,Registration,908
-Johnson,Lenexa 4-10,,,,Registration,591
-Johnson,Lenexa 4-11,,,,Registration,151
-Johnson,Lexington Twp 0-01,,,,Registration,1058
-Johnson,Lexington Twp 0-02,,,,Registration,4
-Johnson,Lexington Twp 0-03,,,,Registration,6
-Johnson,McCamish Twp 0-01,,,,Registration,251
-Johnson,McCamish Twp 0-02,,,,Registration,513
-Johnson,Merriam 1-01,,,,Registration,686
-Johnson,Merriam 1-02,,,,Registration,940
-Johnson,Merriam 2-01,,,,Registration,1094
-Johnson,Merriam 2-02,,,,Registration,3
-Johnson,Merriam 2-03,,,,Registration,648
-Johnson,Merriam 3-01,,,,Registration,1024
-Johnson,Merriam 3-02,,,,Registration,828
-Johnson,Merriam 4-01,,,,Registration,1052
-Johnson,Merriam 4-02,,,,Registration,444
-Johnson,Merriam 4-03,,,,Registration,605
-Johnson,Mission 1-01,,,,Registration,981
-Johnson,Mission 1-02,,,,Registration,787
-Johnson,Mission 2-01,,,,Registration,645
-Johnson,Mission 2-02,,,,Registration,822
-Johnson,Mission 3-01,,,,Registration,1200
-Johnson,Mission 3-02,,,,Registration,528
-Johnson,Mission 4-01,,,,Registration,581
-Johnson,Mission 4-02,,,,Registration,731
-Johnson,Mission 4-03,,,,Registration,480
-Johnson,Mission Hills 0-01,,,,Registration,704
-Johnson,Mission Hills 0-02,,,,Registration,842
-Johnson,Mission Hills 0-03,,,,Registration,577
-Johnson,Mission Hills 0-04,,,,Registration,900
-Johnson,Mission Woods 0-01,,,,Registration,151
-Johnson,Olathe 1-01,,,,Registration,1278
-Johnson,Olathe 1-02,,,,Registration,904
-Johnson,Olathe 1-03,,,,Registration,722
-Johnson,Olathe 1-04,,,,Registration,1177
-Johnson,Olathe 1-05,,,,Registration,1097
-Johnson,Olathe 1-06,,,,Registration,736
-Johnson,Olathe 1-08,,,,Registration,1571
-Johnson,Olathe 1-09,,,,Registration,1191
-Johnson,Olathe 1-11,,,,Registration,238
-Johnson,Olathe 1-14,,,,Registration,990
-Johnson,Olathe 1-15,,,,Registration,1042
-Johnson,Olathe 1-16,,,,Registration,1381
-Johnson,Olathe 1-17,,,,Registration,303
-Johnson,Olathe 1-18,,,,Registration,379
-Johnson,Olathe 1-19,,,,Registration,594
-Johnson,Olathe 1-20,,,,Registration,884
-Johnson,Olathe 1-21,,,,Registration,1416
-Johnson,Olathe 1-22,,,,Registration,1729
-Johnson,Olathe 1-23,,,,Registration,0
-Johnson,Olathe 1-24,,,,Registration,181
-Johnson,Olathe 1-24,,,,Registration,316
-Johnson,Olathe 1-26,,,,Registration,6
-Johnson,Olathe 1-27,,,,Registration,862
-Johnson,Olathe 2-01,,,,Registration,612
-Johnson,Olathe 2-02,,,,Registration,655
-Johnson,Olathe 2-03,,,,Registration,954
-Johnson,Olathe 2-04,,,,Registration,1153
-Johnson,Olathe 2-05,,,,Registration,1951
-Johnson,Olathe 2-06,,,,Registration,1100
-Johnson,Olathe 2-07,,,,Registration,1665
-Johnson,Olathe 2-08,,,,Registration,1474
-Johnson,Olathe 2-09,,,,Registration,467
-Johnson,Olathe 2-10,,,,Registration,2077
-Johnson,Olathe 2-11,,,,Registration,1563
-Johnson,Olathe 2-12,,,,Registration,940
-Johnson,Olathe 2-13,,,,Registration,987
-Johnson,Olathe 2-14,,,,Registration,941
-Johnson,Olathe 2-15,,,,Registration,795
-Johnson,Olathe 2-16,,,,Registration,392
-Johnson,Olathe 2-17,,,,Registration,0
-Johnson,Olathe 2-19,,,,Registration,13
-Johnson,Olathe 2-22,,,,Registration,1563
-Johnson,Olathe 2-23,,,,Registration,1087
-Johnson,Olathe 3-01,,,,Registration,726
-Johnson,Olathe 3-02,,,,Registration,1517
-Johnson,Olathe 3-03,,,,Registration,711
-Johnson,Olathe 3-04,,,,Registration,1228
-Johnson,Olathe 3-05,,,,Registration,1016
-Johnson,Olathe 3-06,,,,Registration,828
-Johnson,Olathe 3-07,,,,Registration,850
-Johnson,Olathe 3-08,,,,Registration,1238
-Johnson,Olathe 3-09,,,,Registration,798
-Johnson,Olathe 3-10,,,,Registration,1360
-Johnson,Olathe 3-11,,,,Registration,919
-Johnson,Olathe 3-12,,,,Registration,1268
-Johnson,Olathe 3-13,,,,Registration,1237
-Johnson,Olathe 3-15,,,,Registration,1021
-Johnson,Olathe 3-16,,,,Registration,1033
-Johnson,Olathe 3-17,,,,Registration,1290
-Johnson,Olathe 3-18,,,,Registration,1284
-Johnson,Olathe 3-19,,,,Registration,717
-Johnson,Olathe 3-20,,,,Registration,870
-Johnson,Olathe 3-21,,,,Registration,793
-Johnson,Olathe 3-22,,,,Registration,1146
-Johnson,Olathe 3-23,,,,Registration,1120
-Johnson,Olathe 3-24,,,,Registration,538
-Johnson,Olathe 3-26,,,,Registration,142
-Johnson,Olathe 4-01,,,,Registration,1197
-Johnson,Olathe 4-02,,,,Registration,1459
-Johnson,Olathe 4-03,,,,Registration,928
-Johnson,Olathe 4-04,,,,Registration,678
-Johnson,Olathe 4-05,,,,Registration,1042
-Johnson,Olathe 4-06,,,,Registration,1720
-Johnson,Olathe 4-07,,,,Registration,1505
-Johnson,Olathe 4-08,,,,Registration,937
-Johnson,Olathe 4-09,,,,Registration,1511
-Johnson,Olathe 4-10,,,,Registration,778
-Johnson,Olathe 4-11,,,,Registration,687
-Johnson,Olathe 4-12,,,,Registration,1402
-Johnson,Olathe 4-13,,,,Registration,819
-Johnson,Olathe 4-14,,,,Registration,1661
-Johnson,Olathe 4-15,,,,Registration,174
-Johnson,Olathe 4-16,,,,Registration,540
-Johnson,Olathe 4-17,,,,Registration,7
-Johnson,Olathe Twp 0-01,,,,Registration,447
-Johnson,Olathe Twp 0-02,,,,Registration,102
-Johnson,Olathe Twp 0-03,,,,Registration,74
-Johnson,Olathe Twp 0-04,,,,Registration,3
-Johnson,Olathe Twp 0-05,,,,Registration,3
-Johnson,Olathe Twp 0-06,,,,Registration,2
-Johnson,Olathe Twp 0-07,,,,Registration,1
-Johnson,Olathe Twp 0-08,,,,Registration,18
-Johnson,Olathe Twp 0-09,,,,Registration,0
-Johnson,Olathe Twp 0-10,,,,Registration,15
-Johnson,Olathe Twp 0-11,,,,Registration,11
-Johnson,Olathe Twp 0-14,,,,Registration,3
-Johnson,Olathe Twp 0-24,,,,Registration,4
-Johnson,Olathe Twp 0-25,,,,Registration,11
-Johnson,Olathe Twp 0-26,,,,Registration,5
-Johnson,Olathe Twp 0-32,,,,Registration,44
-Johnson,Overland Park 1-01,,,,Registration,1045
-Johnson,Overland Park 1-02,,,,Registration,1186
-Johnson,Overland Park 1-03,,,,Registration,1029
-Johnson,Overland Park 1-04,,,,Registration,375
-Johnson,Overland Park 1-05,,,,Registration,699
-Johnson,Overland Park 1-06,,,,Registration,1164
-Johnson,Overland Park 1-07,,,,Registration,1331
-Johnson,Overland Park 1-08,,,,Registration,1170
-Johnson,Overland Park 1-09,,,,Registration,588
-Johnson,Overland Park 1-10,,,,Registration,1143
-Johnson,Overland Park 1-11,,,,Registration,603
-Johnson,Overland Park 1-12,,,,Registration,1397
-Johnson,Overland Park 1-13,,,,Registration,883
-Johnson,Overland Park 1-14,,,,Registration,1047
-Johnson,Overland Park 1-15,,,,Registration,507
-Johnson,Overland Park 1-16,,,,Registration,1215
-Johnson,Overland Park 1-17,,,,Registration,590
-Johnson,Overland Park 1-18,,,,Registration,795
-Johnson,Overland Park 1-19,,,,Registration,1114
-Johnson,Overland Park 1-20,,,,Registration,523
-Johnson,Overland Park 1-21,,,,Registration,333
-Johnson,Overland Park 1-22,,,,Registration,326
-Johnson,Overland Park 2-01,,,,Registration,776
-Johnson,Overland Park 2-02,,,,Registration,789
-Johnson,Overland Park 2-03,,,,Registration,754
-Johnson,Overland Park 2-04,,,,Registration,916
-Johnson,Overland Park 2-05,,,,Registration,1019
-Johnson,Overland Park 2-06,,,,Registration,818
-Johnson,Overland Park 2-07,,,,Registration,687
-Johnson,Overland Park 2-08,,,,Registration,783
-Johnson,Overland Park 2-09,,,,Registration,865
-Johnson,Overland Park 2-10,,,,Registration,645
-Johnson,Overland Park 2-11,,,,Registration,817
-Johnson,Overland Park 2-12,,,,Registration,674
-Johnson,Overland Park 2-13,,,,Registration,666
-Johnson,Overland Park 2-14,,,,Registration,632
-Johnson,Overland Park 2-15,,,,Registration,1063
-Johnson,Overland Park 2-16,,,,Registration,657
-Johnson,Overland Park 2-17,,,,Registration,996
-Johnson,Overland Park 2-18,,,,Registration,1159
-Johnson,Overland Park 2-19,,,,Registration,685
-Johnson,Overland Park 2-20,,,,Registration,609
-Johnson,Overland Park 2-21,,,,Registration,708
-Johnson,Overland Park 2-22,,,,Registration,876
-Johnson,Overland Park 2-23,,,,Registration,739
-Johnson,Overland Park 2-24,,,,Registration,1443
-Johnson,Overland Park 2-25,,,,Registration,992
-Johnson,Overland Park 2-26,,,,Registration,453
-Johnson,Overland Park 3-01,,,,Registration,1422
-Johnson,Overland Park 3-02,,,,Registration,918
-Johnson,Overland Park 3-03,,,,Registration,785
-Johnson,Overland Park 3-04,,,,Registration,1132
-Johnson,Overland Park 3-05,,,,Registration,1098
-Johnson,Overland Park 3-06,,,,Registration,1167
-Johnson,Overland Park 3-07,,,,Registration,1058
-Johnson,Overland Park 3-08,,,,Registration,872
-Johnson,Overland Park 3-09,,,,Registration,1309
-Johnson,Overland Park 3-10,,,,Registration,715
-Johnson,Overland Park 3-11,,,,Registration,1034
-Johnson,Overland Park 3-12,,,,Registration,997
-Johnson,Overland Park 3-13,,,,Registration,1717
-Johnson,Overland Park 3-14,,,,Registration,1277
-Johnson,Overland Park 3-15,,,,Registration,812
-Johnson,Overland Park 3-16,,,,Registration,849
-Johnson,Overland Park 3-17,,,,Registration,679
-Johnson,Overland Park 3-18,,,,Registration,1259
-Johnson,Overland Park 3-19,,,,Registration,1137
-Johnson,Overland Park 3-20,,,,Registration,1202
-Johnson,Overland Park 3-21,,,,Registration,893
-Johnson,Overland Park 4-01,,,,Registration,950
-Johnson,Overland Park 4-02,,,,Registration,1544
-Johnson,Overland Park 4-03,,,,Registration,1515
-Johnson,Overland Park 4-04,,,,Registration,1497
-Johnson,Overland Park 4-05,,,,Registration,1150
-Johnson,Overland Park 4-06,,,,Registration,984
-Johnson,Overland Park 4-07,,,,Registration,822
-Johnson,Overland Park 4-08,,,,Registration,1042
-Johnson,Overland Park 4-09,,,,Registration,926
-Johnson,Overland Park 4-10,,,,Registration,748
-Johnson,Overland Park 4-11,,,,Registration,1353
-Johnson,Overland Park 4-12,,,,Registration,1685
-Johnson,Overland Park 4-13,,,,Registration,783
-Johnson,Overland Park 4-14,,,,Registration,635
-Johnson,Overland Park 4-15,,,,Registration,1431
-Johnson,Overland Park 4-16,,,,Registration,1086
-Johnson,Overland Park 4-17,,,,Registration,1442
-Johnson,Overland Park 4-18,,,,Registration,404
-Johnson,Overland Park 5-01,,,,Registration,1080
-Johnson,Overland Park 5-02,,,,Registration,658
-Johnson,Overland Park 5-03,,,,Registration,1127
-Johnson,Overland Park 5-04,,,,Registration,1045
-Johnson,Overland Park 5-05,,,,Registration,1011
-Johnson,Overland Park 5-06,,,,Registration,1214
-Johnson,Overland Park 5-07,,,,Registration,1358
-Johnson,Overland Park 5-08,,,,Registration,2001
-Johnson,Overland Park 5-09,,,,Registration,1560
-Johnson,Overland Park 5-10,,,,Registration,1186
-Johnson,Overland Park 5-11,,,,Registration,1534
-Johnson,Overland Park 5-12,,,,Registration,355
-Johnson,Overland Park 5-13,,,,Registration,1483
-Johnson,Overland Park 5-14,,,,Registration,1187
-Johnson,Overland Park 5-15,,,,Registration,1227
-Johnson,Overland Park 5-16,,,,Registration,749
-Johnson,Overland Park 5-17,,,,Registration,527
-Johnson,Overland Park 5-18,,,,Registration,1235
-Johnson,Overland Park 5-19,,,,Registration,97
-Johnson,Overland Park 6-01,,,,Registration,1323
-Johnson,Overland Park 6-02,,,,Registration,1068
-Johnson,Overland Park 6-03,,,,Registration,1218
-Johnson,Overland Park 6-04,,,,Registration,1226
-Johnson,Overland Park 6-05,,,,Registration,1436
-Johnson,Overland Park 6-06,,,,Registration,0
-Johnson,Overland Park 6-07,,,,Registration,331
-Johnson,Overland Park 6-08,,,,Registration,1980
-Johnson,Overland Park 6-09,,,,Registration,1550
-Johnson,Overland Park 6-10,,,,Registration,1241
-Johnson,Overland Park 6-11,,,,Registration,1126
-Johnson,Overland Park 6-12,,,,Registration,522
-Johnson,Overland Park 6-13,,,,Registration,1487
-Johnson,Overland Park 6-15,,,,Registration,1435
-Johnson,Overland Park 6-16,,,,Registration,774
-Johnson,Overland Park 6-17,,,,Registration,239
-Johnson,Overland Park 6-18,,,,Registration,3
-Johnson,Overland Park 6-19,,,,Registration,1354
-Johnson,Overland Park 6-20,,,,Registration,547
-Johnson,Overland Park 6-21,,,,Registration,1756
-Johnson,Overland Park 6-22,,,,Registration,606
-Johnson,Oxford Twp 0-01,,,,Registration,1
-Johnson,Oxford Twp 0-02,,,,Registration,728
-Johnson,Oxford Twp 0-04,,,,Registration,680
-Johnson,Oxford Twp 0-05,,,,Registration,24
-Johnson,Oxford Twp 0-09,,,,Registration,49
-Johnson,Oxford Twp 0-10,,,,Registration,2
-Johnson,Oxford Twp 0-11,,,,Registration,157
-Johnson,Prairie Village 1-01,,,,Registration,1119
-Johnson,Prairie Village 1-02,,,,Registration,860
-Johnson,Prairie Village 1-03,,,,Registration,1175
-Johnson,Prairie Village 2-01,,,,Registration,1000
-Johnson,Prairie Village 2-02,,,,Registration,619
-Johnson,Prairie Village 2-03,,,,Registration,936
-Johnson,Prairie Village 3-01,,,,Registration,705
-Johnson,Prairie Village 3-02,,,,Registration,1092
-Johnson,Prairie Village 3-03,,,,Registration,941
-Johnson,Prairie Village 4-01,,,,Registration,992
-Johnson,Prairie Village 4-02,,,,Registration,758
-Johnson,Prairie Village 4-03,,,,Registration,1105
-Johnson,Prairie Village 5-01,,,,Registration,1074
-Johnson,Prairie Village 5-02,,,,Registration,1065
-Johnson,Prairie Village 5-03,,,,Registration,828
-Johnson,Prairie Village 6-01,,,,Registration,1116
-Johnson,Prairie Village 6-02,,,,Registration,942
-Johnson,Prairie Village 6-03,,,,Registration,797
-Johnson,Roeland Park 1-01,,,,Registration,720
-Johnson,Roeland Park 1-02,,,,Registration,439
-Johnson,Roeland Park 2-01,,,,Registration,579
-Johnson,Roeland Park 2-02,,,,Registration,705
-Johnson,Roeland Park 3-01,,,,Registration,459
-Johnson,Roeland Park 3-02,,,,Registration,816
-Johnson,Roeland Park 4-01,,,,Registration,374
-Johnson,Roeland Park 4-02,,,,Registration,1051
-Johnson,Shawnee 1-01,,,,Registration,1190
-Johnson,Shawnee 1-02,,,,Registration,829
-Johnson,Shawnee 1-03,,,,Registration,844
-Johnson,Shawnee 1-04,,,,Registration,1379
-Johnson,Shawnee 1-05,,,,Registration,1377
-Johnson,Shawnee 1-06,,,,Registration,1083
-Johnson,Shawnee 1-07,,,,Registration,1239
-Johnson,Shawnee 1-08,,,,Registration,1424
-Johnson,Shawnee 1-09,,,,Registration,313
-Johnson,Shawnee 1-10,,,,Registration,404
-Johnson,Shawnee 1-11,,,,Registration,970
-Johnson,Shawnee 1-12,,,,Registration,12
-Johnson,Shawnee 2-01,,,,Registration,625
-Johnson,Shawnee 2-02,,,,Registration,1015
-Johnson,Shawnee 2-03,,,,Registration,1109
-Johnson,Shawnee 2-04,,,,Registration,1239
-Johnson,Shawnee 2-05,,,,Registration,622
-Johnson,Shawnee 2-06,,,,Registration,793
-Johnson,Shawnee 2-07,,,,Registration,755
-Johnson,Shawnee 2-08,,,,Registration,704
-Johnson,Shawnee 2-09,,,,Registration,674
-Johnson,Shawnee 2-10,,,,Registration,624
-Johnson,Shawnee 2-11,,,,Registration,802
-Johnson,Shawnee 2-12,,,,Registration,422
-Johnson,Shawnee 2-13,,,,Registration,477
-Johnson,Shawnee 3-01,,,,Registration,807
-Johnson,Shawnee 3-02,,,,Registration,1591
-Johnson,Shawnee 3-03,,,,Registration,1186
-Johnson,Shawnee 3-04,,,,Registration,1027
-Johnson,Shawnee 3-05,,,,Registration,1314
-Johnson,Shawnee 3-06,,,,Registration,1278
-Johnson,Shawnee 3-07,,,,Registration,1572
-Johnson,Shawnee 3-08,,,,Registration,1256
-Johnson,Shawnee 3-09,,,,Registration,763
-Johnson,Shawnee 4-01,,,,Registration,1358
-Johnson,Shawnee 4-02,,,,Registration,820
-Johnson,Shawnee 4-03,,,,Registration,385
-Johnson,Shawnee 4-04,,,,Registration,754
-Johnson,Shawnee 4-05,,,,Registration,1283
-Johnson,Shawnee 4-06,,,,Registration,1022
-Johnson,Shawnee 4-07,,,,Registration,1356
-Johnson,Shawnee 4-08,,,,Registration,486
-Johnson,Shawnee 4-09,,,,Registration,1750
-Johnson,Shawnee 4-11,,,,Registration,1023
-Johnson,Shawnee 4-12,,,,Registration,138
-Johnson,Spring Hill 0-01,,,,Registration,2071
-Johnson,Spring Hill 0-03,,,,Registration,88
-Johnson,Spring Hill 0-04,,,,Registration,2
-Johnson,Spring Hill Twp 0-01,,,,Registration,1299
-Johnson,Spring Hill Twp 0-02,,,,Registration,2
-Johnson,Spring Hill Twp 0-03,,,,Registration,130
-Johnson,Spring Hill Twp 0-04,,,,Registration,29
-Johnson,Spring Hill Twp 0-05,,,,Registration,15
-Johnson,Westwood 0-01,,,,Registration,641
-Johnson,Westwood 0-02,,,,Registration,564
-Johnson,Westwood Hills 0-01,,,,Registration,320
-Johnson,Aubry Twp 0-01,,,,Votes cast,110
-Johnson,Aubry Twp 0-02,,,,Votes cast,582
-Johnson,Aubry Twp 0-03,,,,Votes cast,328
-Johnson,Aubry Twp 0-04,,,,Votes cast,732
-Johnson,Aubry Twp 0-05,,,,Votes cast,14
-Johnson,Aubry Twp 0-06,,,,Votes cast,88
-Johnson,De Soto 0-01,,,,Votes cast,641
-Johnson,De Soto 0-02,,,,Votes cast,391
-Johnson,De Soto 0-03,,,,Votes cast,642
-Johnson,De Soto 0-06,,,,Votes cast,49
-Johnson,De Soto 0-07,,,,Votes cast,2
-Johnson,Edgerton 0-01,,,,Votes cast,406
-Johnson,Edgerton 0-02,,,,Votes cast,0
-Johnson,Edgerton 0-05,,,,Votes cast,0
-Johnson,Edgerton 0-06,,,,Votes cast,0
-Johnson,Edgerton 0-09,,,,Votes cast,0
-Johnson,Fairway 1-01,,,,Votes cast,288
-Johnson,Fairway 1-02,,,,Votes cast,211
-Johnson,Fairway 2-01,,,,Votes cast,225
-Johnson,Fairway 2-02,,,,Votes cast,228
-Johnson,Fairway 3-01,,,,Votes cast,317
-Johnson,Fairway 3-02,,,,Votes cast,244
-Johnson,Fairway 4-01,,,,Votes cast,93
-Johnson,Fairway 4-02,,,,Votes cast,122
-Johnson,Fairway 4-03,,,,Votes cast,86
-Johnson,Fairway 4-04,,,,Votes cast,123
-Johnson,Gardner 0-01,,,,Votes cast,794
-Johnson,Gardner 0-02,,,,Votes cast,115
-Johnson,Gardner 0-03,,,,Votes cast,488
-Johnson,Gardner 0-04,,,,Votes cast,492
-Johnson,Gardner 0-06,,,,Votes cast,579
-Johnson,Gardner 0-07,,,,Votes cast,14
-Johnson,Gardner 0-08,,,,Votes cast,47
-Johnson,Gardner 0-09,,,,Votes cast,670
-Johnson,Gardner 0-10,,,,Votes cast,429
-Johnson,Gardner 0-12,,,,Votes cast,14
-Johnson,Gardner 0-13,,,,Votes cast,480
-Johnson,Gardner 0-14,,,,Votes cast,406
-Johnson,Gardner Twp 0-01,,,,Votes cast,312
-Johnson,Gardner Twp 0-02,,,,Votes cast,353
-Johnson,Gardner Twp 0-04,,,,Votes cast,2
-Johnson,Gardner Twp 0-05,,,,Votes cast,6
-Johnson,Gardner Twp 0-07,,,,Votes cast,4
-Johnson,Gardner Twp 0-08,,,,Votes cast,5
-Johnson,Gardner Twp 0-09,,,,Votes cast,0
-Johnson,Gardner Twp 0-10,,,,Votes cast,0
-Johnson,Gardner Twp 0-11,,,,Votes cast,87
-Johnson,Gardner Twp 0-13,,,,Votes cast,2
-Johnson,Lake Quivira 0-01,,,,Votes cast,540
-Johnson,Leawood 1-01,,,,Votes cast,508
-Johnson,Leawood 1-02,,,,Votes cast,818
-Johnson,Leawood 1-03,,,,Votes cast,679
-Johnson,Leawood 1-04,,,,Votes cast,546
-Johnson,Leawood 1-05,,,,Votes cast,478
-Johnson,Leawood 1-06,,,,Votes cast,129
-Johnson,Leawood 2-01,,,,Votes cast,629
-Johnson,Leawood 2-02,,,,Votes cast,746
-Johnson,Leawood 2-03,,,,Votes cast,739
-Johnson,Leawood 2-04,,,,Votes cast,762
-Johnson,Leawood 2-05,,,,Votes cast,425
-Johnson,Leawood 2-06,,,,Votes cast,319
-Johnson,Leawood 3-01,,,,Votes cast,419
-Johnson,Leawood 3-02,,,,Votes cast,702
-Johnson,Leawood 3-03,,,,Votes cast,439
-Johnson,Leawood 3-04,,,,Votes cast,189
-Johnson,Leawood 3-05,,,,Votes cast,810
-Johnson,Leawood 3-06,,,,Votes cast,815
-Johnson,Leawood 3-07,,,,Votes cast,619
-Johnson,Leawood 4-01,,,,Votes cast,209
-Johnson,Leawood 4-02,,,,Votes cast,615
-Johnson,Leawood 4-03,,,,Votes cast,584
-Johnson,Leawood 4-04,,,,Votes cast,687
-Johnson,Leawood 4-05,,,,Votes cast,694
-Johnson,Leawood 4-06,,,,Votes cast,514
-Johnson,Leawood 4-07,,,,Votes cast,864
-Johnson,Leawood 4-08,,,,Votes cast,406
-Johnson,Lenexa 1-01,,,,Votes cast,370
-Johnson,Lenexa 1-02,,,,Votes cast,754
-Johnson,Lenexa 1-03,,,,Votes cast,878
-Johnson,Lenexa 1-04,,,,Votes cast,553
-Johnson,Lenexa 1-05,,,,Votes cast,613
-Johnson,Lenexa 1-06,,,,Votes cast,738
-Johnson,Lenexa 1-07,,,,Votes cast,394
-Johnson,Lenexa 1-08,,,,Votes cast,170
-Johnson,Lenexa 1-09,,,,Votes cast,12
-Johnson,Lenexa 2-01,,,,Votes cast,952
-Johnson,Lenexa 2-02,,,,Votes cast,345
-Johnson,Lenexa 2-03,,,,Votes cast,780
-Johnson,Lenexa 2-04,,,,Votes cast,780
-Johnson,Lenexa 2-05,,,,Votes cast,518
-Johnson,Lenexa 2-06,,,,Votes cast,545
-Johnson,Lenexa 2-07,,,,Votes cast,901
-Johnson,Lenexa 3-01,,,,Votes cast,451
-Johnson,Lenexa 3-02,,,,Votes cast,755
-Johnson,Lenexa 3-03,,,,Votes cast,892
-Johnson,Lenexa 3-04,,,,Votes cast,562
-Johnson,Lenexa 3-05,,,,Votes cast,340
-Johnson,Lenexa 3-06,,,,Votes cast,506
-Johnson,Lenexa 3-07,,,,Votes cast,682
-Johnson,Lenexa 3-08,,,,Votes cast,705
-Johnson,Lenexa 4-01,,,,Votes cast,304
-Johnson,Lenexa 4-02,,,,Votes cast,604
-Johnson,Lenexa 4-03,,,,Votes cast,248
-Johnson,Lenexa 4-04,,,,Votes cast,287
-Johnson,Lenexa 4-05,,,,Votes cast,257
-Johnson,Lenexa 4-06,,,,Votes cast,400
-Johnson,Lenexa 4-07,,,,Votes cast,508
-Johnson,Lenexa 4-08,,,,Votes cast,612
-Johnson,Lenexa 4-09,,,,Votes cast,526
-Johnson,Lenexa 4-10,,,,Votes cast,275
-Johnson,Lenexa 4-11,,,,Votes cast,78
-Johnson,Lexington Twp 0-01,,,,Votes cast,614
-Johnson,Lexington Twp 0-02,,,,Votes cast,3
-Johnson,Lexington Twp 0-03,,,,Votes cast,2
-Johnson,McCamish Twp 0-01,,,,Votes cast,147
-Johnson,McCamish Twp 0-02,,,,Votes cast,291
-Johnson,Merriam 1-01,,,,Votes cast,329
-Johnson,Merriam 1-02,,,,Votes cast,400
-Johnson,Merriam 2-01,,,,Votes cast,531
-Johnson,Merriam 2-02,,,,Votes cast,2
-Johnson,Merriam 2-03,,,,Votes cast,274
-Johnson,Merriam 3-01,,,,Votes cast,427
-Johnson,Merriam 3-02,,,,Votes cast,417
-Johnson,Merriam 4-01,,,,Votes cast,553
-Johnson,Merriam 4-02,,,,Votes cast,243
-Johnson,Merriam 4-03,,,,Votes cast,320
-Johnson,Mission 1-01,,,,Votes cast,502
-Johnson,Mission 1-02,,,,Votes cast,247
-Johnson,Mission 2-01,,,,Votes cast,297
-Johnson,Mission 2-02,,,,Votes cast,430
-Johnson,Mission 3-01,,,,Votes cast,432
-Johnson,Mission 3-02,,,,Votes cast,257
-Johnson,Mission 4-01,,,,Votes cast,326
-Johnson,Mission 4-02,,,,Votes cast,501
-Johnson,Mission 4-03,,,,Votes cast,255
-Johnson,Mission Hills 0-01,,,,Votes cast,418
-Johnson,Mission Hills 0-02,,,,Votes cast,559
-Johnson,Mission Hills 0-03,,,,Votes cast,343
-Johnson,Mission Hills 0-04,,,,Votes cast,592
-Johnson,Mission Woods 0-01,,,,Votes cast,99
-Johnson,Olathe 1-01,,,,Votes cast,558
-Johnson,Olathe 1-02,,,,Votes cast,371
-Johnson,Olathe 1-03,,,,Votes cast,282
-Johnson,Olathe 1-04,,,,Votes cast,539
-Johnson,Olathe 1-05,,,,Votes cast,580
-Johnson,Olathe 1-06,,,,Votes cast,362
-Johnson,Olathe 1-08,,,,Votes cast,623
-Johnson,Olathe 1-09,,,,Votes cast,576
-Johnson,Olathe 1-11,,,,Votes cast,106
-Johnson,Olathe 1-14,,,,Votes cast,516
-Johnson,Olathe 1-15,,,,Votes cast,493
-Johnson,Olathe 1-16,,,,Votes cast,635
-Johnson,Olathe 1-17,,,,Votes cast,158
-Johnson,Olathe 1-18,,,,Votes cast,176
-Johnson,Olathe 1-19,,,,Votes cast,246
-Johnson,Olathe 1-20,,,,Votes cast,395
-Johnson,Olathe 1-21,,,,Votes cast,649
-Johnson,Olathe 1-22,,,,Votes cast,936
-Johnson,Olathe 1-23,,,,Votes cast,1
-Johnson,Olathe 1-24,,,,Votes cast,79
-Johnson,Olathe 1-24,,,,Votes cast,157
-Johnson,Olathe 1-26,,,,Votes cast,2
-Johnson,Olathe 1-27,,,,Votes cast,402
-Johnson,Olathe 2-01,,,,Votes cast,233
-Johnson,Olathe 2-02,,,,Votes cast,369
-Johnson,Olathe 2-03,,,,Votes cast,408
-Johnson,Olathe 2-04,,,,Votes cast,455
-Johnson,Olathe 2-05,,,,Votes cast,1286
-Johnson,Olathe 2-06,,,,Votes cast,651
-Johnson,Olathe 2-07,,,,Votes cast,800
-Johnson,Olathe 2-08,,,,Votes cast,569
-Johnson,Olathe 2-09,,,,Votes cast,260
-Johnson,Olathe 2-10,,,,Votes cast,1056
-Johnson,Olathe 2-11,,,,Votes cast,753
-Johnson,Olathe 2-12,,,,Votes cast,440
-Johnson,Olathe 2-13,,,,Votes cast,443
-Johnson,Olathe 2-14,,,,Votes cast,424
-Johnson,Olathe 2-15,,,,Votes cast,431
-Johnson,Olathe 2-16,,,,Votes cast,153
-Johnson,Olathe 2-17,,,,Votes cast,1
-Johnson,Olathe 2-19,,,,Votes cast,6
-Johnson,Olathe 2-22,,,,Votes cast,883
-Johnson,Olathe 2-23,,,,Votes cast,566
-Johnson,Olathe 3-01,,,,Votes cast,229
-Johnson,Olathe 3-02,,,,Votes cast,694
-Johnson,Olathe 3-03,,,,Votes cast,347
-Johnson,Olathe 3-04,,,,Votes cast,589
-Johnson,Olathe 3-05,,,,Votes cast,620
-Johnson,Olathe 3-06,,,,Votes cast,447
-Johnson,Olathe 3-07,,,,Votes cast,442
-Johnson,Olathe 3-08,,,,Votes cast,665
-Johnson,Olathe 3-09,,,,Votes cast,326
-Johnson,Olathe 3-10,,,,Votes cast,648
-Johnson,Olathe 3-11,,,,Votes cast,425
-Johnson,Olathe 3-12,,,,Votes cast,581
-Johnson,Olathe 3-13,,,,Votes cast,644
-Johnson,Olathe 3-15,,,,Votes cast,429
-Johnson,Olathe 3-16,,,,Votes cast,466
-Johnson,Olathe 3-17,,,,Votes cast,638
-Johnson,Olathe 3-18,,,,Votes cast,582
-Johnson,Olathe 3-19,,,,Votes cast,374
-Johnson,Olathe 3-20,,,,Votes cast,412
-Johnson,Olathe 3-21,,,,Votes cast,406
-Johnson,Olathe 3-22,,,,Votes cast,541
-Johnson,Olathe 3-23,,,,Votes cast,488
-Johnson,Olathe 3-24,,,,Votes cast,288
-Johnson,Olathe 3-26,,,,Votes cast,53
-Johnson,Olathe 4-01,,,,Votes cast,449
-Johnson,Olathe 4-02,,,,Votes cast,837
-Johnson,Olathe 4-03,,,,Votes cast,263
-Johnson,Olathe 4-04,,,,Votes cast,296
-Johnson,Olathe 4-05,,,,Votes cast,595
-Johnson,Olathe 4-06,,,,Votes cast,729
-Johnson,Olathe 4-07,,,,Votes cast,616
-Johnson,Olathe 4-08,,,,Votes cast,525
-Johnson,Olathe 4-09,,,,Votes cast,734
-Johnson,Olathe 4-10,,,,Votes cast,396
-Johnson,Olathe 4-11,,,,Votes cast,253
-Johnson,Olathe 4-12,,,,Votes cast,669
-Johnson,Olathe 4-13,,,,Votes cast,321
-Johnson,Olathe 4-14,,,,Votes cast,709
-Johnson,Olathe 4-15,,,,Votes cast,35
-Johnson,Olathe 4-16,,,,Votes cast,201
-Johnson,Olathe 4-17,,,,Votes cast,3
-Johnson,Olathe Twp 0-01,,,,Votes cast,273
-Johnson,Olathe Twp 0-02,,,,Votes cast,54
-Johnson,Olathe Twp 0-03,,,,Votes cast,40
-Johnson,Olathe Twp 0-04,,,,Votes cast,2
-Johnson,Olathe Twp 0-05,,,,Votes cast,2
-Johnson,Olathe Twp 0-06,,,,Votes cast,0
-Johnson,Olathe Twp 0-07,,,,Votes cast,1
-Johnson,Olathe Twp 0-08,,,,Votes cast,6
-Johnson,Olathe Twp 0-09,,,,Votes cast,0
-Johnson,Olathe Twp 0-10,,,,Votes cast,11
-Johnson,Olathe Twp 0-11,,,,Votes cast,4
-Johnson,Olathe Twp 0-14,,,,Votes cast,1
-Johnson,Olathe Twp 0-24,,,,Votes cast,3
-Johnson,Olathe Twp 0-25,,,,Votes cast,8
-Johnson,Olathe Twp 0-26,,,,Votes cast,3
-Johnson,Olathe Twp 0-32,,,,Votes cast,23
-Johnson,Overland Park 1-01,,,,Votes cast,489
-Johnson,Overland Park 1-02,,,,Votes cast,504
-Johnson,Overland Park 1-03,,,,Votes cast,492
-Johnson,Overland Park 1-04,,,,Votes cast,170
-Johnson,Overland Park 1-05,,,,Votes cast,340
-Johnson,Overland Park 1-06,,,,Votes cast,655
-Johnson,Overland Park 1-07,,,,Votes cast,614
-Johnson,Overland Park 1-08,,,,Votes cast,405
-Johnson,Overland Park 1-09,,,,Votes cast,278
-Johnson,Overland Park 1-10,,,,Votes cast,549
-Johnson,Overland Park 1-11,,,,Votes cast,142
-Johnson,Overland Park 1-12,,,,Votes cast,444
-Johnson,Overland Park 1-13,,,,Votes cast,352
-Johnson,Overland Park 1-14,,,,Votes cast,506
-Johnson,Overland Park 1-15,,,,Votes cast,242
-Johnson,Overland Park 1-16,,,,Votes cast,588
-Johnson,Overland Park 1-17,,,,Votes cast,264
-Johnson,Overland Park 1-18,,,,Votes cast,510
-Johnson,Overland Park 1-19,,,,Votes cast,382
-Johnson,Overland Park 1-20,,,,Votes cast,307
-Johnson,Overland Park 1-21,,,,Votes cast,154
-Johnson,Overland Park 1-22,,,,Votes cast,115
-Johnson,Overland Park 2-01,,,,Votes cast,451
-Johnson,Overland Park 2-02,,,,Votes cast,498
-Johnson,Overland Park 2-03,,,,Votes cast,439
-Johnson,Overland Park 2-04,,,,Votes cast,525
-Johnson,Overland Park 2-05,,,,Votes cast,445
-Johnson,Overland Park 2-06,,,,Votes cast,461
-Johnson,Overland Park 2-07,,,,Votes cast,384
-Johnson,Overland Park 2-08,,,,Votes cast,253
-Johnson,Overland Park 2-09,,,,Votes cast,393
-Johnson,Overland Park 2-10,,,,Votes cast,318
-Johnson,Overland Park 2-11,,,,Votes cast,458
-Johnson,Overland Park 2-12,,,,Votes cast,344
-Johnson,Overland Park 2-13,,,,Votes cast,215
-Johnson,Overland Park 2-14,,,,Votes cast,339
-Johnson,Overland Park 2-15,,,,Votes cast,688
-Johnson,Overland Park 2-16,,,,Votes cast,402
-Johnson,Overland Park 2-17,,,,Votes cast,590
-Johnson,Overland Park 2-18,,,,Votes cast,599
-Johnson,Overland Park 2-19,,,,Votes cast,400
-Johnson,Overland Park 2-20,,,,Votes cast,387
-Johnson,Overland Park 2-21,,,,Votes cast,413
-Johnson,Overland Park 2-22,,,,Votes cast,447
-Johnson,Overland Park 2-23,,,,Votes cast,490
-Johnson,Overland Park 2-24,,,,Votes cast,741
-Johnson,Overland Park 2-25,,,,Votes cast,597
-Johnson,Overland Park 2-26,,,,Votes cast,219
-Johnson,Overland Park 3-01,,,,Votes cast,789
-Johnson,Overland Park 3-02,,,,Votes cast,498
-Johnson,Overland Park 3-03,,,,Votes cast,518
-Johnson,Overland Park 3-04,,,,Votes cast,631
-Johnson,Overland Park 3-05,,,,Votes cast,589
-Johnson,Overland Park 3-06,,,,Votes cast,682
-Johnson,Overland Park 3-07,,,,Votes cast,412
-Johnson,Overland Park 3-08,,,,Votes cast,548
-Johnson,Overland Park 3-09,,,,Votes cast,751
-Johnson,Overland Park 3-10,,,,Votes cast,422
-Johnson,Overland Park 3-11,,,,Votes cast,524
-Johnson,Overland Park 3-12,,,,Votes cast,350
-Johnson,Overland Park 3-13,,,,Votes cast,841
-Johnson,Overland Park 3-14,,,,Votes cast,610
-Johnson,Overland Park 3-15,,,,Votes cast,384
-Johnson,Overland Park 3-16,,,,Votes cast,534
-Johnson,Overland Park 3-17,,,,Votes cast,445
-Johnson,Overland Park 3-18,,,,Votes cast,453
-Johnson,Overland Park 3-19,,,,Votes cast,521
-Johnson,Overland Park 3-20,,,,Votes cast,676
-Johnson,Overland Park 3-21,,,,Votes cast,532
-Johnson,Overland Park 4-01,,,,Votes cast,391
-Johnson,Overland Park 4-02,,,,Votes cast,610
-Johnson,Overland Park 4-03,,,,Votes cast,733
-Johnson,Overland Park 4-04,,,,Votes cast,839
-Johnson,Overland Park 4-05,,,,Votes cast,601
-Johnson,Overland Park 4-06,,,,Votes cast,510
-Johnson,Overland Park 4-07,,,,Votes cast,411
-Johnson,Overland Park 4-08,,,,Votes cast,604
-Johnson,Overland Park 4-09,,,,Votes cast,582
-Johnson,Overland Park 4-10,,,,Votes cast,411
-Johnson,Overland Park 4-11,,,,Votes cast,710
-Johnson,Overland Park 4-12,,,,Votes cast,923
-Johnson,Overland Park 4-13,,,,Votes cast,442
-Johnson,Overland Park 4-14,,,,Votes cast,374
-Johnson,Overland Park 4-15,,,,Votes cast,771
-Johnson,Overland Park 4-16,,,,Votes cast,553
-Johnson,Overland Park 4-17,,,,Votes cast,712
-Johnson,Overland Park 4-18,,,,Votes cast,103
-Johnson,Overland Park 5-01,,,,Votes cast,631
-Johnson,Overland Park 5-02,,,,Votes cast,305
-Johnson,Overland Park 5-03,,,,Votes cast,593
-Johnson,Overland Park 5-04,,,,Votes cast,553
-Johnson,Overland Park 5-05,,,,Votes cast,430
-Johnson,Overland Park 5-06,,,,Votes cast,478
-Johnson,Overland Park 5-07,,,,Votes cast,741
-Johnson,Overland Park 5-08,,,,Votes cast,847
-Johnson,Overland Park 5-09,,,,Votes cast,827
-Johnson,Overland Park 5-10,,,,Votes cast,614
-Johnson,Overland Park 5-11,,,,Votes cast,738
-Johnson,Overland Park 5-12,,,,Votes cast,158
-Johnson,Overland Park 5-13,,,,Votes cast,821
-Johnson,Overland Park 5-14,,,,Votes cast,632
-Johnson,Overland Park 5-15,,,,Votes cast,440
-Johnson,Overland Park 5-16,,,,Votes cast,378
-Johnson,Overland Park 5-17,,,,Votes cast,230
-Johnson,Overland Park 5-18,,,,Votes cast,487
-Johnson,Overland Park 5-19,,,,Votes cast,52
-Johnson,Overland Park 6-01,,,,Votes cast,708
-Johnson,Overland Park 6-02,,,,Votes cast,557
-Johnson,Overland Park 6-03,,,,Votes cast,626
-Johnson,Overland Park 6-04,,,,Votes cast,596
-Johnson,Overland Park 6-05,,,,Votes cast,698
-Johnson,Overland Park 6-06,,,,Votes cast,1
-Johnson,Overland Park 6-07,,,,Votes cast,191
-Johnson,Overland Park 6-08,,,,Votes cast,948
-Johnson,Overland Park 6-09,,,,Votes cast,832
-Johnson,Overland Park 6-10,,,,Votes cast,542
-Johnson,Overland Park 6-11,,,,Votes cast,551
-Johnson,Overland Park 6-12,,,,Votes cast,258
-Johnson,Overland Park 6-13,,,,Votes cast,733
-Johnson,Overland Park 6-15,,,,Votes cast,717
-Johnson,Overland Park 6-16,,,,Votes cast,414
-Johnson,Overland Park 6-17,,,,Votes cast,138
-Johnson,Overland Park 6-18,,,,Votes cast,3
-Johnson,Overland Park 6-19,,,,Votes cast,724
-Johnson,Overland Park 6-20,,,,Votes cast,331
-Johnson,Overland Park 6-21,,,,Votes cast,909
-Johnson,Overland Park 6-22,,,,Votes cast,340
-Johnson,Oxford Twp 0-01,,,,Votes cast,3
-Johnson,Oxford Twp 0-02,,,,Votes cast,457
-Johnson,Oxford Twp 0-04,,,,Votes cast,353
-Johnson,Oxford Twp 0-05,,,,Votes cast,10
-Johnson,Oxford Twp 0-09,,,,Votes cast,20
-Johnson,Oxford Twp 0-10,,,,Votes cast,2
-Johnson,Oxford Twp 0-11,,,,Votes cast,91
-Johnson,Prairie Village 1-01,,,,Votes cast,719
-Johnson,Prairie Village 1-02,,,,Votes cast,496
-Johnson,Prairie Village 1-03,,,,Votes cast,704
-Johnson,Prairie Village 2-01,,,,Votes cast,570
-Johnson,Prairie Village 2-02,,,,Votes cast,271
-Johnson,Prairie Village 2-03,,,,Votes cast,501
-Johnson,Prairie Village 3-01,,,,Votes cast,405
-Johnson,Prairie Village 3-02,,,,Votes cast,601
-Johnson,Prairie Village 3-03,,,,Votes cast,546
-Johnson,Prairie Village 4-01,,,,Votes cast,694
-Johnson,Prairie Village 4-02,,,,Votes cast,421
-Johnson,Prairie Village 4-03,,,,Votes cast,679
-Johnson,Prairie Village 5-01,,,,Votes cast,657
-Johnson,Prairie Village 5-02,,,,Votes cast,692
-Johnson,Prairie Village 5-03,,,,Votes cast,541
-Johnson,Prairie Village 6-01,,,,Votes cast,680
-Johnson,Prairie Village 6-02,,,,Votes cast,546
-Johnson,Prairie Village 6-03,,,,Votes cast,342
-Johnson,Roeland Park 1-01,,,,Votes cast,235
-Johnson,Roeland Park 1-02,,,,Votes cast,187
-Johnson,Roeland Park 2-01,,,,Votes cast,270
-Johnson,Roeland Park 2-02,,,,Votes cast,373
-Johnson,Roeland Park 3-01,,,,Votes cast,228
-Johnson,Roeland Park 3-02,,,,Votes cast,460
-Johnson,Roeland Park 4-01,,,,Votes cast,208
-Johnson,Roeland Park 4-02,,,,Votes cast,638
-Johnson,Shawnee 1-01,,,,Votes cast,647
-Johnson,Shawnee 1-02,,,,Votes cast,487
-Johnson,Shawnee 1-03,,,,Votes cast,456
-Johnson,Shawnee 1-04,,,,Votes cast,769
-Johnson,Shawnee 1-05,,,,Votes cast,826
-Johnson,Shawnee 1-06,,,,Votes cast,662
-Johnson,Shawnee 1-07,,,,Votes cast,657
-Johnson,Shawnee 1-08,,,,Votes cast,676
-Johnson,Shawnee 1-09,,,,Votes cast,114
-Johnson,Shawnee 1-10,,,,Votes cast,242
-Johnson,Shawnee 1-11,,,,Votes cast,425
-Johnson,Shawnee 1-12,,,,Votes cast,7
-Johnson,Shawnee 2-01,,,,Votes cast,282
-Johnson,Shawnee 2-02,,,,Votes cast,536
-Johnson,Shawnee 2-03,,,,Votes cast,404
-Johnson,Shawnee 2-04,,,,Votes cast,644
-Johnson,Shawnee 2-05,,,,Votes cast,306
-Johnson,Shawnee 2-06,,,,Votes cast,444
-Johnson,Shawnee 2-07,,,,Votes cast,351
-Johnson,Shawnee 2-08,,,,Votes cast,343
-Johnson,Shawnee 2-09,,,,Votes cast,330
-Johnson,Shawnee 2-10,,,,Votes cast,296
-Johnson,Shawnee 2-11,,,,Votes cast,472
-Johnson,Shawnee 2-12,,,,Votes cast,124
-Johnson,Shawnee 2-13,,,,Votes cast,246
-Johnson,Shawnee 3-01,,,,Votes cast,408
-Johnson,Shawnee 3-02,,,,Votes cast,776
-Johnson,Shawnee 3-03,,,,Votes cast,593
-Johnson,Shawnee 3-04,,,,Votes cast,552
-Johnson,Shawnee 3-05,,,,Votes cast,790
-Johnson,Shawnee 3-06,,,,Votes cast,544
-Johnson,Shawnee 3-07,,,,Votes cast,717
-Johnson,Shawnee 3-08,,,,Votes cast,660
-Johnson,Shawnee 3-09,,,,Votes cast,385
-Johnson,Shawnee 4-01,,,,Votes cast,783
-Johnson,Shawnee 4-02,,,,Votes cast,434
-Johnson,Shawnee 4-03,,,,Votes cast,187
-Johnson,Shawnee 4-04,,,,Votes cast,211
-Johnson,Shawnee 4-05,,,,Votes cast,621
-Johnson,Shawnee 4-06,,,,Votes cast,545
-Johnson,Shawnee 4-07,,,,Votes cast,749
-Johnson,Shawnee 4-08,,,,Votes cast,297
-Johnson,Shawnee 4-09,,,,Votes cast,883
-Johnson,Shawnee 4-11,,,,Votes cast,447
-Johnson,Shawnee 4-12,,,,Votes cast,89
-Johnson,Spring Hill 0-01,,,,Votes cast,896
-Johnson,Spring Hill 0-03,,,,Votes cast,60
-Johnson,Spring Hill 0-04,,,,Votes cast,0
-Johnson,Spring Hill Twp 0-01,,,,Votes cast,676
-Johnson,Spring Hill Twp 0-02,,,,Votes cast,2
-Johnson,Spring Hill Twp 0-03,,,,Votes cast,69
-Johnson,Spring Hill Twp 0-04,,,,Votes cast,14
-Johnson,Spring Hill Twp 0-05,,,,Votes cast,8
-Johnson,Westwood 0-01,,,,Votes cast,353
-Johnson,Westwood 0-02,,,,Votes cast,355
-Johnson,Westwood Hills 0-01,,,,Votes cast,206
-Johnson,Aubry Twp 0-01,U.S. Senate,,L,Randall Batson,0
-Johnson,Aubry Twp 0-02,U.S. Senate,,L,Randall Batson,14
-Johnson,Aubry Twp 0-03,U.S. Senate,,L,Randall Batson,8
-Johnson,Aubry Twp 0-04,U.S. Senate,,L,Randall Batson,22
-Johnson,Aubry Twp 0-05,U.S. Senate,,L,Randall Batson,2
-Johnson,Aubry Twp 0-06,U.S. Senate,,L,Randall Batson,2
-Johnson,De Soto 0-01,U.S. Senate,,L,Randall Batson,32
-Johnson,De Soto 0-02,U.S. Senate,,L,Randall Batson,14
-Johnson,De Soto 0-03,U.S. Senate,,L,Randall Batson,20
-Johnson,De Soto 0-06,U.S. Senate,,L,Randall Batson,1
-Johnson,De Soto 0-07,U.S. Senate,,L,Randall Batson,0
-Johnson,Edgerton 0-01,U.S. Senate,,L,Randall Batson,31
-Johnson,Edgerton 0-02,U.S. Senate,,L,Randall Batson,0
-Johnson,Edgerton 0-05,U.S. Senate,,L,Randall Batson,0
-Johnson,Edgerton 0-06,U.S. Senate,,L,Randall Batson,0
-Johnson,Edgerton 0-09,U.S. Senate,,L,Randall Batson,0
-Johnson,Fairway 1-01,U.S. Senate,,L,Randall Batson,3
-Johnson,Fairway 1-02,U.S. Senate,,L,Randall Batson,2
-Johnson,Fairway 2-01,U.S. Senate,,L,Randall Batson,3
-Johnson,Fairway 2-02,U.S. Senate,,L,Randall Batson,4
-Johnson,Fairway 3-01,U.S. Senate,,L,Randall Batson,1
-Johnson,Fairway 3-02,U.S. Senate,,L,Randall Batson,2
-Johnson,Fairway 4-01,U.S. Senate,,L,Randall Batson,3
-Johnson,Fairway 4-02,U.S. Senate,,L,Randall Batson,1
-Johnson,Fairway 4-03,U.S. Senate,,L,Randall Batson,1
-Johnson,Fairway 4-04,U.S. Senate,,L,Randall Batson,3
-Johnson,Gardner 0-01,U.S. Senate,,L,Randall Batson,34
-Johnson,Gardner 0-02,U.S. Senate,,L,Randall Batson,7
-Johnson,Gardner 0-03,U.S. Senate,,L,Randall Batson,28
-Johnson,Gardner 0-04,U.S. Senate,,L,Randall Batson,25
-Johnson,Gardner 0-06,U.S. Senate,,L,Randall Batson,27
-Johnson,Gardner 0-07,U.S. Senate,,L,Randall Batson,0
-Johnson,Gardner 0-08,U.S. Senate,,L,Randall Batson,1
-Johnson,Gardner 0-09,U.S. Senate,,L,Randall Batson,30
-Johnson,Gardner 0-10,U.S. Senate,,L,Randall Batson,23
-Johnson,Gardner 0-12,U.S. Senate,,L,Randall Batson,2
-Johnson,Gardner 0-13,U.S. Senate,,L,Randall Batson,19
-Johnson,Gardner 0-14,U.S. Senate,,L,Randall Batson,12
-Johnson,Gardner Twp 0-01,U.S. Senate,,L,Randall Batson,7
-Johnson,Gardner Twp 0-02,U.S. Senate,,L,Randall Batson,11
-Johnson,Gardner Twp 0-04,U.S. Senate,,L,Randall Batson,0
-Johnson,Gardner Twp 0-05,U.S. Senate,,L,Randall Batson,1
-Johnson,Gardner Twp 0-07,U.S. Senate,,L,Randall Batson,0
-Johnson,Gardner Twp 0-08,U.S. Senate,,L,Randall Batson,0
-Johnson,Gardner Twp 0-09,U.S. Senate,,L,Randall Batson,0
-Johnson,Gardner Twp 0-10,U.S. Senate,,L,Randall Batson,0
-Johnson,Gardner Twp 0-11,U.S. Senate,,L,Randall Batson,6
-Johnson,Gardner Twp 0-13,U.S. Senate,,L,Randall Batson,1
-Johnson,Lake Quivira 0-01,U.S. Senate,,L,Randall Batson,5
-Johnson,Leawood 1-01,U.S. Senate,,L,Randall Batson,9
-Johnson,Leawood 1-02,U.S. Senate,,L,Randall Batson,10
-Johnson,Leawood 1-03,U.S. Senate,,L,Randall Batson,11
-Johnson,Leawood 1-04,U.S. Senate,,L,Randall Batson,7
-Johnson,Leawood 1-05,U.S. Senate,,L,Randall Batson,9
-Johnson,Leawood 1-06,U.S. Senate,,L,Randall Batson,0
-Johnson,Leawood 2-01,U.S. Senate,,L,Randall Batson,5
-Johnson,Leawood 2-02,U.S. Senate,,L,Randall Batson,15
-Johnson,Leawood 2-03,U.S. Senate,,L,Randall Batson,12
-Johnson,Leawood 2-04,U.S. Senate,,L,Randall Batson,1
-Johnson,Leawood 2-05,U.S. Senate,,L,Randall Batson,6
-Johnson,Leawood 2-06,U.S. Senate,,L,Randall Batson,3
-Johnson,Leawood 3-01,U.S. Senate,,L,Randall Batson,2
-Johnson,Leawood 3-02,U.S. Senate,,L,Randall Batson,18
-Johnson,Leawood 3-03,U.S. Senate,,L,Randall Batson,3
-Johnson,Leawood 3-04,U.S. Senate,,L,Randall Batson,4
-Johnson,Leawood 3-05,U.S. Senate,,L,Randall Batson,12
-Johnson,Leawood 3-06,U.S. Senate,,L,Randall Batson,16
-Johnson,Leawood 3-07,U.S. Senate,,L,Randall Batson,13
-Johnson,Leawood 4-01,U.S. Senate,,L,Randall Batson,1
-Johnson,Leawood 4-02,U.S. Senate,,L,Randall Batson,7
-Johnson,Leawood 4-03,U.S. Senate,,L,Randall Batson,4
-Johnson,Leawood 4-04,U.S. Senate,,L,Randall Batson,6
-Johnson,Leawood 4-05,U.S. Senate,,L,Randall Batson,12
-Johnson,Leawood 4-06,U.S. Senate,,L,Randall Batson,3
-Johnson,Leawood 4-07,U.S. Senate,,L,Randall Batson,7
-Johnson,Leawood 4-08,U.S. Senate,,L,Randall Batson,6
-Johnson,Lenexa 1-01,U.S. Senate,,L,Randall Batson,13
-Johnson,Lenexa 1-02,U.S. Senate,,L,Randall Batson,15
-Johnson,Lenexa 1-03,U.S. Senate,,L,Randall Batson,24
-Johnson,Lenexa 1-04,U.S. Senate,,L,Randall Batson,18
-Johnson,Lenexa 1-05,U.S. Senate,,L,Randall Batson,18
-Johnson,Lenexa 1-06,U.S. Senate,,L,Randall Batson,15
-Johnson,Lenexa 1-07,U.S. Senate,,L,Randall Batson,13
-Johnson,Lenexa 1-08,U.S. Senate,,L,Randall Batson,5
-Johnson,Lenexa 1-09,U.S. Senate,,L,Randall Batson,0
-Johnson,Lenexa 2-01,U.S. Senate,,L,Randall Batson,25
-Johnson,Lenexa 2-02,U.S. Senate,,L,Randall Batson,4
-Johnson,Lenexa 2-03,U.S. Senate,,L,Randall Batson,7
-Johnson,Lenexa 2-04,U.S. Senate,,L,Randall Batson,9
-Johnson,Lenexa 2-05,U.S. Senate,,L,Randall Batson,13
-Johnson,Lenexa 2-06,U.S. Senate,,L,Randall Batson,7
-Johnson,Lenexa 2-07,U.S. Senate,,L,Randall Batson,26
-Johnson,Lenexa 3-01,U.S. Senate,,L,Randall Batson,8
-Johnson,Lenexa 3-02,U.S. Senate,,L,Randall Batson,22
-Johnson,Lenexa 3-03,U.S. Senate,,L,Randall Batson,23
-Johnson,Lenexa 3-04,U.S. Senate,,L,Randall Batson,11
-Johnson,Lenexa 3-05,U.S. Senate,,L,Randall Batson,16
-Johnson,Lenexa 3-06,U.S. Senate,,L,Randall Batson,16
-Johnson,Lenexa 3-07,U.S. Senate,,L,Randall Batson,21
-Johnson,Lenexa 3-08,U.S. Senate,,L,Randall Batson,11
-Johnson,Lenexa 4-01,U.S. Senate,,L,Randall Batson,4
-Johnson,Lenexa 4-02,U.S. Senate,,L,Randall Batson,13
-Johnson,Lenexa 4-03,U.S. Senate,,L,Randall Batson,11
-Johnson,Lenexa 4-04,U.S. Senate,,L,Randall Batson,10
-Johnson,Lenexa 4-05,U.S. Senate,,L,Randall Batson,8
-Johnson,Lenexa 4-06,U.S. Senate,,L,Randall Batson,18
-Johnson,Lenexa 4-07,U.S. Senate,,L,Randall Batson,20
-Johnson,Lenexa 4-08,U.S. Senate,,L,Randall Batson,15
-Johnson,Lenexa 4-09,U.S. Senate,,L,Randall Batson,25
-Johnson,Lenexa 4-10,U.S. Senate,,L,Randall Batson,8
-Johnson,Lenexa 4-11,U.S. Senate,,L,Randall Batson,3
-Johnson,Lexington Twp 0-01,U.S. Senate,,L,Randall Batson,12
-Johnson,Lexington Twp 0-02,U.S. Senate,,L,Randall Batson,0
-Johnson,Lexington Twp 0-03,U.S. Senate,,L,Randall Batson,0
-Johnson,McCamish Twp 0-01,U.S. Senate,,L,Randall Batson,6
-Johnson,McCamish Twp 0-02,U.S. Senate,,L,Randall Batson,9
-Johnson,Merriam 1-01,U.S. Senate,,L,Randall Batson,17
-Johnson,Merriam 1-02,U.S. Senate,,L,Randall Batson,17
-Johnson,Merriam 2-01,U.S. Senate,,L,Randall Batson,24
-Johnson,Merriam 2-02,U.S. Senate,,L,Randall Batson,0
-Johnson,Merriam 2-03,U.S. Senate,,L,Randall Batson,13
-Johnson,Merriam 3-01,U.S. Senate,,L,Randall Batson,19
-Johnson,Merriam 3-02,U.S. Senate,,L,Randall Batson,14
-Johnson,Merriam 4-01,U.S. Senate,,L,Randall Batson,22
-Johnson,Merriam 4-02,U.S. Senate,,L,Randall Batson,7
-Johnson,Merriam 4-03,U.S. Senate,,L,Randall Batson,13
-Johnson,Mission 1-01,U.S. Senate,,L,Randall Batson,22
-Johnson,Mission 1-02,U.S. Senate,,L,Randall Batson,10
-Johnson,Mission 2-01,U.S. Senate,,L,Randall Batson,16
-Johnson,Mission 2-02,U.S. Senate,,L,Randall Batson,17
-Johnson,Mission 3-01,U.S. Senate,,L,Randall Batson,21
-Johnson,Mission 3-02,U.S. Senate,,L,Randall Batson,13
-Johnson,Mission 4-01,U.S. Senate,,L,Randall Batson,9
-Johnson,Mission 4-02,U.S. Senate,,L,Randall Batson,14
-Johnson,Mission 4-03,U.S. Senate,,L,Randall Batson,10
-Johnson,Mission Hills 0-01,U.S. Senate,,L,Randall Batson,3
-Johnson,Mission Hills 0-02,U.S. Senate,,L,Randall Batson,3
-Johnson,Mission Hills 0-03,U.S. Senate,,L,Randall Batson,2
-Johnson,Mission Hills 0-04,U.S. Senate,,L,Randall Batson,3
-Johnson,Mission Woods 0-01,U.S. Senate,,L,Randall Batson,1
-Johnson,Olathe 1-01,U.S. Senate,,L,Randall Batson,26
-Johnson,Olathe 1-02,U.S. Senate,,L,Randall Batson,26
-Johnson,Olathe 1-03,U.S. Senate,,L,Randall Batson,10
-Johnson,Olathe 1-04,U.S. Senate,,L,Randall Batson,24
-Johnson,Olathe 1-05,U.S. Senate,,L,Randall Batson,22
-Johnson,Olathe 1-06,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 1-08,U.S. Senate,,L,Randall Batson,17
-Johnson,Olathe 1-09,U.S. Senate,,L,Randall Batson,17
-Johnson,Olathe 1-11,U.S. Senate,,L,Randall Batson,10
-Johnson,Olathe 1-14,U.S. Senate,,L,Randall Batson,5
-Johnson,Olathe 1-15,U.S. Senate,,L,Randall Batson,15
-Johnson,Olathe 1-16,U.S. Senate,,L,Randall Batson,13
-Johnson,Olathe 1-17,U.S. Senate,,L,Randall Batson,2
-Johnson,Olathe 1-18,U.S. Senate,,L,Randall Batson,6
-Johnson,Olathe 1-19,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 1-20,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 1-21,U.S. Senate,,L,Randall Batson,25
-Johnson,Olathe 1-22,U.S. Senate,,L,Randall Batson,25
-Johnson,Olathe 1-23,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe 1-24,U.S. Senate,,L,Randall Batson,2
-Johnson,Olathe 1-24,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 1-26,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe 1-27,U.S. Senate,,L,Randall Batson,19
-Johnson,Olathe 2-01,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 2-02,U.S. Senate,,L,Randall Batson,8
-Johnson,Olathe 2-03,U.S. Senate,,L,Randall Batson,18
-Johnson,Olathe 2-04,U.S. Senate,,L,Randall Batson,31
-Johnson,Olathe 2-05,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 2-06,U.S. Senate,,L,Randall Batson,8
-Johnson,Olathe 2-07,U.S. Senate,,L,Randall Batson,18
-Johnson,Olathe 2-08,U.S. Senate,,L,Randall Batson,25
-Johnson,Olathe 2-09,U.S. Senate,,L,Randall Batson,6
-Johnson,Olathe 2-10,U.S. Senate,,L,Randall Batson,25
-Johnson,Olathe 2-11,U.S. Senate,,L,Randall Batson,31
-Johnson,Olathe 2-12,U.S. Senate,,L,Randall Batson,9
-Johnson,Olathe 2-13,U.S. Senate,,L,Randall Batson,12
-Johnson,Olathe 2-14,U.S. Senate,,L,Randall Batson,20
-Johnson,Olathe 2-15,U.S. Senate,,L,Randall Batson,17
-Johnson,Olathe 2-16,U.S. Senate,,L,Randall Batson,6
-Johnson,Olathe 2-17,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe 2-19,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe 2-22,U.S. Senate,,L,Randall Batson,24
-Johnson,Olathe 2-23,U.S. Senate,,L,Randall Batson,8
-Johnson,Olathe 3-01,U.S. Senate,,L,Randall Batson,6
-Johnson,Olathe 3-02,U.S. Senate,,L,Randall Batson,27
-Johnson,Olathe 3-03,U.S. Senate,,L,Randall Batson,4
-Johnson,Olathe 3-04,U.S. Senate,,L,Randall Batson,22
-Johnson,Olathe 3-05,U.S. Senate,,L,Randall Batson,16
-Johnson,Olathe 3-06,U.S. Senate,,L,Randall Batson,4
-Johnson,Olathe 3-07,U.S. Senate,,L,Randall Batson,13
-Johnson,Olathe 3-08,U.S. Senate,,L,Randall Batson,15
-Johnson,Olathe 3-09,U.S. Senate,,L,Randall Batson,9
-Johnson,Olathe 3-10,U.S. Senate,,L,Randall Batson,13
-Johnson,Olathe 3-11,U.S. Senate,,L,Randall Batson,13
-Johnson,Olathe 3-12,U.S. Senate,,L,Randall Batson,15
-Johnson,Olathe 3-13,U.S. Senate,,L,Randall Batson,12
-Johnson,Olathe 3-15,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 3-16,U.S. Senate,,L,Randall Batson,8
-Johnson,Olathe 3-17,U.S. Senate,,L,Randall Batson,18
-Johnson,Olathe 3-18,U.S. Senate,,L,Randall Batson,9
-Johnson,Olathe 3-19,U.S. Senate,,L,Randall Batson,8
-Johnson,Olathe 3-20,U.S. Senate,,L,Randall Batson,4
-Johnson,Olathe 3-21,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 3-22,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 3-23,U.S. Senate,,L,Randall Batson,18
-Johnson,Olathe 3-24,U.S. Senate,,L,Randall Batson,5
-Johnson,Olathe 3-26,U.S. Senate,,L,Randall Batson,3
-Johnson,Olathe 4-01,U.S. Senate,,L,Randall Batson,17
-Johnson,Olathe 4-02,U.S. Senate,,L,Randall Batson,18
-Johnson,Olathe 4-03,U.S. Senate,,L,Randall Batson,21
-Johnson,Olathe 4-04,U.S. Senate,,L,Randall Batson,8
-Johnson,Olathe 4-05,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 4-06,U.S. Senate,,L,Randall Batson,27
-Johnson,Olathe 4-07,U.S. Senate,,L,Randall Batson,21
-Johnson,Olathe 4-08,U.S. Senate,,L,Randall Batson,12
-Johnson,Olathe 4-09,U.S. Senate,,L,Randall Batson,13
-Johnson,Olathe 4-10,U.S. Senate,,L,Randall Batson,5
-Johnson,Olathe 4-11,U.S. Senate,,L,Randall Batson,12
-Johnson,Olathe 4-12,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 4-13,U.S. Senate,,L,Randall Batson,11
-Johnson,Olathe 4-14,U.S. Senate,,L,Randall Batson,16
-Johnson,Olathe 4-15,U.S. Senate,,L,Randall Batson,2
-Johnson,Olathe 4-16,U.S. Senate,,L,Randall Batson,5
-Johnson,Olathe 4-17,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-01,U.S. Senate,,L,Randall Batson,7
-Johnson,Olathe Twp 0-02,U.S. Senate,,L,Randall Batson,2
-Johnson,Olathe Twp 0-03,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-04,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-05,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-06,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-07,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-08,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-09,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-10,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-11,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-14,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-24,U.S. Senate,,L,Randall Batson,1
-Johnson,Olathe Twp 0-25,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-26,U.S. Senate,,L,Randall Batson,0
-Johnson,Olathe Twp 0-32,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 1-01,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 1-02,U.S. Senate,,L,Randall Batson,20
-Johnson,Overland Park 1-03,U.S. Senate,,L,Randall Batson,10
-Johnson,Overland Park 1-04,U.S. Senate,,L,Randall Batson,6
-Johnson,Overland Park 1-05,U.S. Senate,,L,Randall Batson,17
-Johnson,Overland Park 1-06,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 1-07,U.S. Senate,,L,Randall Batson,27
-Johnson,Overland Park 1-08,U.S. Senate,,L,Randall Batson,15
-Johnson,Overland Park 1-09,U.S. Senate,,L,Randall Batson,18
-Johnson,Overland Park 1-10,U.S. Senate,,L,Randall Batson,25
-Johnson,Overland Park 1-11,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 1-12,U.S. Senate,,L,Randall Batson,8
-Johnson,Overland Park 1-13,U.S. Senate,,L,Randall Batson,18
-Johnson,Overland Park 1-14,U.S. Senate,,L,Randall Batson,25
-Johnson,Overland Park 1-15,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 1-16,U.S. Senate,,L,Randall Batson,26
-Johnson,Overland Park 1-17,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 1-18,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 1-19,U.S. Senate,,L,Randall Batson,19
-Johnson,Overland Park 1-20,U.S. Senate,,L,Randall Batson,6
-Johnson,Overland Park 1-21,U.S. Senate,,L,Randall Batson,4
-Johnson,Overland Park 1-22,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 2-01,U.S. Senate,,L,Randall Batson,17
-Johnson,Overland Park 2-02,U.S. Senate,,L,Randall Batson,9
-Johnson,Overland Park 2-03,U.S. Senate,,L,Randall Batson,10
-Johnson,Overland Park 2-04,U.S. Senate,,L,Randall Batson,14
-Johnson,Overland Park 2-05,U.S. Senate,,L,Randall Batson,17
-Johnson,Overland Park 2-06,U.S. Senate,,L,Randall Batson,19
-Johnson,Overland Park 2-07,U.S. Senate,,L,Randall Batson,11
-Johnson,Overland Park 2-08,U.S. Senate,,L,Randall Batson,11
-Johnson,Overland Park 2-09,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 2-10,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 2-11,U.S. Senate,,L,Randall Batson,9
-Johnson,Overland Park 2-12,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 2-13,U.S. Senate,,L,Randall Batson,5
-Johnson,Overland Park 2-14,U.S. Senate,,L,Randall Batson,4
-Johnson,Overland Park 2-15,U.S. Senate,,L,Randall Batson,30
-Johnson,Overland Park 2-16,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 2-17,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 2-18,U.S. Senate,,L,Randall Batson,23
-Johnson,Overland Park 2-19,U.S. Senate,,L,Randall Batson,10
-Johnson,Overland Park 2-20,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 2-21,U.S. Senate,,L,Randall Batson,10
-Johnson,Overland Park 2-22,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 2-23,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 2-24,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 2-25,U.S. Senate,,L,Randall Batson,4
-Johnson,Overland Park 2-26,U.S. Senate,,L,Randall Batson,4
-Johnson,Overland Park 3-01,U.S. Senate,,L,Randall Batson,14
-Johnson,Overland Park 3-02,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 3-03,U.S. Senate,,L,Randall Batson,5
-Johnson,Overland Park 3-04,U.S. Senate,,L,Randall Batson,17
-Johnson,Overland Park 3-05,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 3-06,U.S. Senate,,L,Randall Batson,15
-Johnson,Overland Park 3-07,U.S. Senate,,L,Randall Batson,17
-Johnson,Overland Park 3-08,U.S. Senate,,L,Randall Batson,8
-Johnson,Overland Park 3-09,U.S. Senate,,L,Randall Batson,13
-Johnson,Overland Park 3-10,U.S. Senate,,L,Randall Batson,9
-Johnson,Overland Park 3-11,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 3-12,U.S. Senate,,L,Randall Batson,9
-Johnson,Overland Park 3-13,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 3-14,U.S. Senate,,L,Randall Batson,21
-Johnson,Overland Park 3-15,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 3-16,U.S. Senate,,L,Randall Batson,11
-Johnson,Overland Park 3-17,U.S. Senate,,L,Randall Batson,3
-Johnson,Overland Park 3-18,U.S. Senate,,L,Randall Batson,14
-Johnson,Overland Park 3-19,U.S. Senate,,L,Randall Batson,22
-Johnson,Overland Park 3-20,U.S. Senate,,L,Randall Batson,25
-Johnson,Overland Park 3-21,U.S. Senate,,L,Randall Batson,8
-Johnson,Overland Park 4-01,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 4-02,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 4-03,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 4-04,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 4-05,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 4-06,U.S. Senate,,L,Randall Batson,8
-Johnson,Overland Park 4-07,U.S. Senate,,L,Randall Batson,9
-Johnson,Overland Park 4-08,U.S. Senate,,L,Randall Batson,6
-Johnson,Overland Park 4-09,U.S. Senate,,L,Randall Batson,4
-Johnson,Overland Park 4-10,U.S. Senate,,L,Randall Batson,6
-Johnson,Overland Park 4-11,U.S. Senate,,L,Randall Batson,13
-Johnson,Overland Park 4-12,U.S. Senate,,L,Randall Batson,13
-Johnson,Overland Park 4-13,U.S. Senate,,L,Randall Batson,10
-Johnson,Overland Park 4-14,U.S. Senate,,L,Randall Batson,8
-Johnson,Overland Park 4-15,U.S. Senate,,L,Randall Batson,17
-Johnson,Overland Park 4-16,U.S. Senate,,L,Randall Batson,11
-Johnson,Overland Park 4-17,U.S. Senate,,L,Randall Batson,14
-Johnson,Overland Park 4-18,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 5-01,U.S. Senate,,L,Randall Batson,13
-Johnson,Overland Park 5-02,U.S. Senate,,L,Randall Batson,13
-Johnson,Overland Park 5-03,U.S. Senate,,L,Randall Batson,11
-Johnson,Overland Park 5-04,U.S. Senate,,L,Randall Batson,14
-Johnson,Overland Park 5-05,U.S. Senate,,L,Randall Batson,14
-Johnson,Overland Park 5-06,U.S. Senate,,L,Randall Batson,10
-Johnson,Overland Park 5-07,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 5-08,U.S. Senate,,L,Randall Batson,21
-Johnson,Overland Park 5-09,U.S. Senate,,L,Randall Batson,10
-Johnson,Overland Park 5-10,U.S. Senate,,L,Randall Batson,11
-Johnson,Overland Park 5-11,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 5-12,U.S. Senate,,L,Randall Batson,5
-Johnson,Overland Park 5-13,U.S. Senate,,L,Randall Batson,18
-Johnson,Overland Park 5-14,U.S. Senate,,L,Randall Batson,7
-Johnson,Overland Park 5-15,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 5-16,U.S. Senate,,L,Randall Batson,6
-Johnson,Overland Park 5-17,U.S. Senate,,L,Randall Batson,4
-Johnson,Overland Park 5-18,U.S. Senate,,L,Randall Batson,15
-Johnson,Overland Park 5-19,U.S. Senate,,L,Randall Batson,0
-Johnson,Overland Park 6-01,U.S. Senate,,L,Randall Batson,10
-Johnson,Overland Park 6-02,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 6-03,U.S. Senate,,L,Randall Batson,6
-Johnson,Overland Park 6-04,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 6-05,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 6-06,U.S. Senate,,L,Randall Batson,0
-Johnson,Overland Park 6-07,U.S. Senate,,L,Randall Batson,4
-Johnson,Overland Park 6-08,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 6-09,U.S. Senate,,L,Randall Batson,11
-Johnson,Overland Park 6-10,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 6-11,U.S. Senate,,L,Randall Batson,14
-Johnson,Overland Park 6-12,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 6-13,U.S. Senate,,L,Randall Batson,12
-Johnson,Overland Park 6-15,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 6-16,U.S. Senate,,L,Randall Batson,9
-Johnson,Overland Park 6-17,U.S. Senate,,L,Randall Batson,2
-Johnson,Overland Park 6-18,U.S. Senate,,L,Randall Batson,0
-Johnson,Overland Park 6-19,U.S. Senate,,L,Randall Batson,18
-Johnson,Overland Park 6-20,U.S. Senate,,L,Randall Batson,6
-Johnson,Overland Park 6-21,U.S. Senate,,L,Randall Batson,16
-Johnson,Overland Park 6-22,U.S. Senate,,L,Randall Batson,5
-Johnson,Oxford Twp 0-01,U.S. Senate,,L,Randall Batson,0
-Johnson,Oxford Twp 0-02,U.S. Senate,,L,Randall Batson,9
-Johnson,Oxford Twp 0-04,U.S. Senate,,L,Randall Batson,5
-Johnson,Oxford Twp 0-05,U.S. Senate,,L,Randall Batson,0
-Johnson,Oxford Twp 0-09,U.S. Senate,,L,Randall Batson,0
-Johnson,Oxford Twp 0-10,U.S. Senate,,L,Randall Batson,0
-Johnson,Oxford Twp 0-11,U.S. Senate,,L,Randall Batson,1
-Johnson,Prairie Village 1-01,U.S. Senate,,L,Randall Batson,9
-Johnson,Prairie Village 1-02,U.S. Senate,,L,Randall Batson,7
-Johnson,Prairie Village 1-03,U.S. Senate,,L,Randall Batson,8
-Johnson,Prairie Village 2-01,U.S. Senate,,L,Randall Batson,7
-Johnson,Prairie Village 2-02,U.S. Senate,,L,Randall Batson,10
-Johnson,Prairie Village 2-03,U.S. Senate,,L,Randall Batson,16
-Johnson,Prairie Village 3-01,U.S. Senate,,L,Randall Batson,12
-Johnson,Prairie Village 3-02,U.S. Senate,,L,Randall Batson,9
-Johnson,Prairie Village 3-03,U.S. Senate,,L,Randall Batson,6
-Johnson,Prairie Village 4-01,U.S. Senate,,L,Randall Batson,6
-Johnson,Prairie Village 4-02,U.S. Senate,,L,Randall Batson,13
-Johnson,Prairie Village 4-03,U.S. Senate,,L,Randall Batson,12
-Johnson,Prairie Village 5-01,U.S. Senate,,L,Randall Batson,8
-Johnson,Prairie Village 5-02,U.S. Senate,,L,Randall Batson,12
-Johnson,Prairie Village 5-03,U.S. Senate,,L,Randall Batson,15
-Johnson,Prairie Village 6-01,U.S. Senate,,L,Randall Batson,13
-Johnson,Prairie Village 6-02,U.S. Senate,,L,Randall Batson,20
-Johnson,Prairie Village 6-03,U.S. Senate,,L,Randall Batson,13
-Johnson,Roeland Park 1-01,U.S. Senate,,L,Randall Batson,14
-Johnson,Roeland Park 1-02,U.S. Senate,,L,Randall Batson,5
-Johnson,Roeland Park 2-01,U.S. Senate,,L,Randall Batson,9
-Johnson,Roeland Park 2-02,U.S. Senate,,L,Randall Batson,9
-Johnson,Roeland Park 3-01,U.S. Senate,,L,Randall Batson,10
-Johnson,Roeland Park 3-02,U.S. Senate,,L,Randall Batson,9
-Johnson,Roeland Park 4-01,U.S. Senate,,L,Randall Batson,5
-Johnson,Roeland Park 4-02,U.S. Senate,,L,Randall Batson,23
-Johnson,Shawnee 1-01,U.S. Senate,,L,Randall Batson,17
-Johnson,Shawnee 1-02,U.S. Senate,,L,Randall Batson,17
-Johnson,Shawnee 1-03,U.S. Senate,,L,Randall Batson,17
-Johnson,Shawnee 1-04,U.S. Senate,,L,Randall Batson,12
-Johnson,Shawnee 1-05,U.S. Senate,,L,Randall Batson,14
-Johnson,Shawnee 1-06,U.S. Senate,,L,Randall Batson,11
-Johnson,Shawnee 1-07,U.S. Senate,,L,Randall Batson,20
-Johnson,Shawnee 1-08,U.S. Senate,,L,Randall Batson,19
-Johnson,Shawnee 1-09,U.S. Senate,,L,Randall Batson,4
-Johnson,Shawnee 1-10,U.S. Senate,,L,Randall Batson,7
-Johnson,Shawnee 1-11,U.S. Senate,,L,Randall Batson,12
-Johnson,Shawnee 1-12,U.S. Senate,,L,Randall Batson,0
-Johnson,Shawnee 2-01,U.S. Senate,,L,Randall Batson,26
-Johnson,Shawnee 2-02,U.S. Senate,,L,Randall Batson,27
-Johnson,Shawnee 2-03,U.S. Senate,,L,Randall Batson,20
-Johnson,Shawnee 2-04,U.S. Senate,,L,Randall Batson,19
-Johnson,Shawnee 2-05,U.S. Senate,,L,Randall Batson,15
-Johnson,Shawnee 2-06,U.S. Senate,,L,Randall Batson,12
-Johnson,Shawnee 2-07,U.S. Senate,,L,Randall Batson,22
-Johnson,Shawnee 2-08,U.S. Senate,,L,Randall Batson,11
-Johnson,Shawnee 2-09,U.S. Senate,,L,Randall Batson,17
-Johnson,Shawnee 2-10,U.S. Senate,,L,Randall Batson,14
-Johnson,Shawnee 2-11,U.S. Senate,,L,Randall Batson,21
-Johnson,Shawnee 2-12,U.S. Senate,,L,Randall Batson,6
-Johnson,Shawnee 2-13,U.S. Senate,,L,Randall Batson,19
-Johnson,Shawnee 3-01,U.S. Senate,,L,Randall Batson,9
-Johnson,Shawnee 3-02,U.S. Senate,,L,Randall Batson,17
-Johnson,Shawnee 3-03,U.S. Senate,,L,Randall Batson,13
-Johnson,Shawnee 3-04,U.S. Senate,,L,Randall Batson,10
-Johnson,Shawnee 3-05,U.S. Senate,,L,Randall Batson,14
-Johnson,Shawnee 3-06,U.S. Senate,,L,Randall Batson,20
-Johnson,Shawnee 3-07,U.S. Senate,,L,Randall Batson,27
-Johnson,Shawnee 3-08,U.S. Senate,,L,Randall Batson,11
-Johnson,Shawnee 3-09,U.S. Senate,,L,Randall Batson,11
-Johnson,Shawnee 4-01,U.S. Senate,,L,Randall Batson,21
-Johnson,Shawnee 4-02,U.S. Senate,,L,Randall Batson,10
-Johnson,Shawnee 4-03,U.S. Senate,,L,Randall Batson,6
-Johnson,Shawnee 4-04,U.S. Senate,,L,Randall Batson,12
-Johnson,Shawnee 4-05,U.S. Senate,,L,Randall Batson,17
-Johnson,Shawnee 4-06,U.S. Senate,,L,Randall Batson,22
-Johnson,Shawnee 4-07,U.S. Senate,,L,Randall Batson,22
-Johnson,Shawnee 4-08,U.S. Senate,,L,Randall Batson,3
-Johnson,Shawnee 4-09,U.S. Senate,,L,Randall Batson,27
-Johnson,Shawnee 4-11,U.S. Senate,,L,Randall Batson,16
-Johnson,Shawnee 4-12,U.S. Senate,,L,Randall Batson,5
-Johnson,Spring Hill 0-01,U.S. Senate,,L,Randall Batson,43
-Johnson,Spring Hill 0-03,U.S. Senate,,L,Randall Batson,3
-Johnson,Spring Hill 0-04,U.S. Senate,,L,Randall Batson,0
-Johnson,Spring Hill Twp 0-01,U.S. Senate,,L,Randall Batson,27
-Johnson,Spring Hill Twp 0-02,U.S. Senate,,L,Randall Batson,0
-Johnson,Spring Hill Twp 0-03,U.S. Senate,,L,Randall Batson,1
-Johnson,Spring Hill Twp 0-04,U.S. Senate,,L,Randall Batson,1
-Johnson,Spring Hill Twp 0-05,U.S. Senate,,L,Randall Batson,0
-Johnson,Westwood 0-01,U.S. Senate,,L,Randall Batson,13
-Johnson,Westwood 0-02,U.S. Senate,,L,Randall Batson,4
-Johnson,Westwood Hills 0-01,U.S. Senate,,L,Randall Batson,4
-Johnson,Aubry Twp 0-01,U.S. Senate,,I,Greg Orman,40
-Johnson,Aubry Twp 0-02,U.S. Senate,,I,Greg Orman,200
-Johnson,Aubry Twp 0-03,U.S. Senate,,I,Greg Orman,120
-Johnson,Aubry Twp 0-04,U.S. Senate,,I,Greg Orman,263
-Johnson,Aubry Twp 0-05,U.S. Senate,,I,Greg Orman,6
-Johnson,Aubry Twp 0-06,U.S. Senate,,I,Greg Orman,26
-Johnson,De Soto 0-01,U.S. Senate,,I,Greg Orman,238
-Johnson,De Soto 0-02,U.S. Senate,,I,Greg Orman,184
-Johnson,De Soto 0-03,U.S. Senate,,I,Greg Orman,263
-Johnson,De Soto 0-06,U.S. Senate,,I,Greg Orman,23
-Johnson,De Soto 0-07,U.S. Senate,,I,Greg Orman,0
-Johnson,Edgerton 0-01,U.S. Senate,,I,Greg Orman,150
-Johnson,Edgerton 0-02,U.S. Senate,,I,Greg Orman,0
-Johnson,Edgerton 0-05,U.S. Senate,,I,Greg Orman,0
-Johnson,Edgerton 0-06,U.S. Senate,,I,Greg Orman,0
-Johnson,Edgerton 0-09,U.S. Senate,,I,Greg Orman,0
-Johnson,Fairway 1-01,U.S. Senate,,I,Greg Orman,176
-Johnson,Fairway 1-02,U.S. Senate,,I,Greg Orman,130
-Johnson,Fairway 2-01,U.S. Senate,,I,Greg Orman,133
-Johnson,Fairway 2-02,U.S. Senate,,I,Greg Orman,131
-Johnson,Fairway 3-01,U.S. Senate,,I,Greg Orman,164
-Johnson,Fairway 3-02,U.S. Senate,,I,Greg Orman,145
-Johnson,Fairway 4-01,U.S. Senate,,I,Greg Orman,69
-Johnson,Fairway 4-02,U.S. Senate,,I,Greg Orman,86
-Johnson,Fairway 4-03,U.S. Senate,,I,Greg Orman,55
-Johnson,Fairway 4-04,U.S. Senate,,I,Greg Orman,82
-Johnson,Gardner 0-01,U.S. Senate,,I,Greg Orman,306
-Johnson,Gardner 0-02,U.S. Senate,,I,Greg Orman,54
-Johnson,Gardner 0-03,U.S. Senate,,I,Greg Orman,220
-Johnson,Gardner 0-04,U.S. Senate,,I,Greg Orman,217
-Johnson,Gardner 0-06,U.S. Senate,,I,Greg Orman,220
-Johnson,Gardner 0-07,U.S. Senate,,I,Greg Orman,9
-Johnson,Gardner 0-08,U.S. Senate,,I,Greg Orman,17
-Johnson,Gardner 0-09,U.S. Senate,,I,Greg Orman,279
-Johnson,Gardner 0-10,U.S. Senate,,I,Greg Orman,158
-Johnson,Gardner 0-12,U.S. Senate,,I,Greg Orman,7
-Johnson,Gardner 0-13,U.S. Senate,,I,Greg Orman,220
-Johnson,Gardner 0-14,U.S. Senate,,I,Greg Orman,169
-Johnson,Gardner Twp 0-01,U.S. Senate,,I,Greg Orman,130
-Johnson,Gardner Twp 0-02,U.S. Senate,,I,Greg Orman,118
-Johnson,Gardner Twp 0-04,U.S. Senate,,I,Greg Orman,0
-Johnson,Gardner Twp 0-05,U.S. Senate,,I,Greg Orman,0
-Johnson,Gardner Twp 0-07,U.S. Senate,,I,Greg Orman,2
-Johnson,Gardner Twp 0-08,U.S. Senate,,I,Greg Orman,3
-Johnson,Gardner Twp 0-09,U.S. Senate,,I,Greg Orman,0
-Johnson,Gardner Twp 0-10,U.S. Senate,,I,Greg Orman,0
-Johnson,Gardner Twp 0-11,U.S. Senate,,I,Greg Orman,31
-Johnson,Gardner Twp 0-13,U.S. Senate,,I,Greg Orman,0
-Johnson,Lake Quivira 0-01,U.S. Senate,,I,Greg Orman,232
-Johnson,Leawood 1-01,U.S. Senate,,I,Greg Orman,311
-Johnson,Leawood 1-02,U.S. Senate,,I,Greg Orman,407
-Johnson,Leawood 1-03,U.S. Senate,,I,Greg Orman,347
-Johnson,Leawood 1-04,U.S. Senate,,I,Greg Orman,280
-Johnson,Leawood 1-05,U.S. Senate,,I,Greg Orman,232
-Johnson,Leawood 1-06,U.S. Senate,,I,Greg Orman,79
-Johnson,Leawood 2-01,U.S. Senate,,I,Greg Orman,323
-Johnson,Leawood 2-02,U.S. Senate,,I,Greg Orman,390
-Johnson,Leawood 2-03,U.S. Senate,,I,Greg Orman,359
-Johnson,Leawood 2-04,U.S. Senate,,I,Greg Orman,259
-Johnson,Leawood 2-05,U.S. Senate,,I,Greg Orman,196
-Johnson,Leawood 2-06,U.S. Senate,,I,Greg Orman,142
-Johnson,Leawood 3-01,U.S. Senate,,I,Greg Orman,216
-Johnson,Leawood 3-02,U.S. Senate,,I,Greg Orman,327
-Johnson,Leawood 3-03,U.S. Senate,,I,Greg Orman,185
-Johnson,Leawood 3-04,U.S. Senate,,I,Greg Orman,84
-Johnson,Leawood 3-05,U.S. Senate,,I,Greg Orman,326
-Johnson,Leawood 3-06,U.S. Senate,,I,Greg Orman,311
-Johnson,Leawood 3-07,U.S. Senate,,I,Greg Orman,273
-Johnson,Leawood 4-01,U.S. Senate,,I,Greg Orman,78
-Johnson,Leawood 4-02,U.S. Senate,,I,Greg Orman,235
-Johnson,Leawood 4-03,U.S. Senate,,I,Greg Orman,283
-Johnson,Leawood 4-04,U.S. Senate,,I,Greg Orman,303
-Johnson,Leawood 4-05,U.S. Senate,,I,Greg Orman,316
-Johnson,Leawood 4-06,U.S. Senate,,I,Greg Orman,161
-Johnson,Leawood 4-07,U.S. Senate,,I,Greg Orman,312
-Johnson,Leawood 4-08,U.S. Senate,,I,Greg Orman,156
-Johnson,Lenexa 1-01,U.S. Senate,,I,Greg Orman,169
-Johnson,Lenexa 1-02,U.S. Senate,,I,Greg Orman,396
-Johnson,Lenexa 1-03,U.S. Senate,,I,Greg Orman,445
-Johnson,Lenexa 1-04,U.S. Senate,,I,Greg Orman,267
-Johnson,Lenexa 1-05,U.S. Senate,,I,Greg Orman,305
-Johnson,Lenexa 1-06,U.S. Senate,,I,Greg Orman,333
-Johnson,Lenexa 1-07,U.S. Senate,,I,Greg Orman,197
-Johnson,Lenexa 1-08,U.S. Senate,,I,Greg Orman,82
-Johnson,Lenexa 1-09,U.S. Senate,,I,Greg Orman,5
-Johnson,Lenexa 2-01,U.S. Senate,,I,Greg Orman,400
-Johnson,Lenexa 2-02,U.S. Senate,,I,Greg Orman,129
-Johnson,Lenexa 2-03,U.S. Senate,,I,Greg Orman,307
-Johnson,Lenexa 2-04,U.S. Senate,,I,Greg Orman,246
-Johnson,Lenexa 2-05,U.S. Senate,,I,Greg Orman,305
-Johnson,Lenexa 2-06,U.S. Senate,,I,Greg Orman,208
-Johnson,Lenexa 2-07,U.S. Senate,,I,Greg Orman,407
-Johnson,Lenexa 3-01,U.S. Senate,,I,Greg Orman,262
-Johnson,Lenexa 3-02,U.S. Senate,,I,Greg Orman,444
-Johnson,Lenexa 3-03,U.S. Senate,,I,Greg Orman,441
-Johnson,Lenexa 3-04,U.S. Senate,,I,Greg Orman,243
-Johnson,Lenexa 3-05,U.S. Senate,,I,Greg Orman,196
-Johnson,Lenexa 3-06,U.S. Senate,,I,Greg Orman,271
-Johnson,Lenexa 3-07,U.S. Senate,,I,Greg Orman,333
-Johnson,Lenexa 3-08,U.S. Senate,,I,Greg Orman,334
-Johnson,Lenexa 4-01,U.S. Senate,,I,Greg Orman,167
-Johnson,Lenexa 4-02,U.S. Senate,,I,Greg Orman,301
-Johnson,Lenexa 4-03,U.S. Senate,,I,Greg Orman,145
-Johnson,Lenexa 4-04,U.S. Senate,,I,Greg Orman,131
-Johnson,Lenexa 4-05,U.S. Senate,,I,Greg Orman,145
-Johnson,Lenexa 4-06,U.S. Senate,,I,Greg Orman,189
-Johnson,Lenexa 4-07,U.S. Senate,,I,Greg Orman,237
-Johnson,Lenexa 4-08,U.S. Senate,,I,Greg Orman,335
-Johnson,Lenexa 4-09,U.S. Senate,,I,Greg Orman,254
-Johnson,Lenexa 4-10,U.S. Senate,,I,Greg Orman,152
-Johnson,Lenexa 4-11,U.S. Senate,,I,Greg Orman,42
-Johnson,Lexington Twp 0-01,U.S. Senate,,I,Greg Orman,220
-Johnson,Lexington Twp 0-02,U.S. Senate,,I,Greg Orman,2
-Johnson,Lexington Twp 0-03,U.S. Senate,,I,Greg Orman,2
-Johnson,McCamish Twp 0-01,U.S. Senate,,I,Greg Orman,36
-Johnson,McCamish Twp 0-02,U.S. Senate,,I,Greg Orman,95
-Johnson,Merriam 1-01,U.S. Senate,,I,Greg Orman,176
-Johnson,Merriam 1-02,U.S. Senate,,I,Greg Orman,241
-Johnson,Merriam 2-01,U.S. Senate,,I,Greg Orman,285
-Johnson,Merriam 2-02,U.S. Senate,,I,Greg Orman,1
-Johnson,Merriam 2-03,U.S. Senate,,I,Greg Orman,160
-Johnson,Merriam 3-01,U.S. Senate,,I,Greg Orman,246
-Johnson,Merriam 3-02,U.S. Senate,,I,Greg Orman,242
-Johnson,Merriam 4-01,U.S. Senate,,I,Greg Orman,312
-Johnson,Merriam 4-02,U.S. Senate,,I,Greg Orman,139
-Johnson,Merriam 4-03,U.S. Senate,,I,Greg Orman,193
-Johnson,Mission 1-01,U.S. Senate,,I,Greg Orman,299
-Johnson,Mission 1-02,U.S. Senate,,I,Greg Orman,163
-Johnson,Mission 2-01,U.S. Senate,,I,Greg Orman,193
-Johnson,Mission 2-02,U.S. Senate,,I,Greg Orman,262
-Johnson,Mission 3-01,U.S. Senate,,I,Greg Orman,267
-Johnson,Mission 3-02,U.S. Senate,,I,Greg Orman,156
-Johnson,Mission 4-01,U.S. Senate,,I,Greg Orman,218
-Johnson,Mission 4-02,U.S. Senate,,I,Greg Orman,298
-Johnson,Mission 4-03,U.S. Senate,,I,Greg Orman,147
-Johnson,Mission Hills 0-01,U.S. Senate,,I,Greg Orman,161
-Johnson,Mission Hills 0-02,U.S. Senate,,I,Greg Orman,273
-Johnson,Mission Hills 0-03,U.S. Senate,,I,Greg Orman,140
-Johnson,Mission Hills 0-04,U.S. Senate,,I,Greg Orman,280
-Johnson,Mission Woods 0-01,U.S. Senate,,I,Greg Orman,57
-Johnson,Olathe 1-01,U.S. Senate,,I,Greg Orman,254
-Johnson,Olathe 1-02,U.S. Senate,,I,Greg Orman,177
-Johnson,Olathe 1-03,U.S. Senate,,I,Greg Orman,132
-Johnson,Olathe 1-04,U.S. Senate,,I,Greg Orman,246
-Johnson,Olathe 1-05,U.S. Senate,,I,Greg Orman,238
-Johnson,Olathe 1-06,U.S. Senate,,I,Greg Orman,141
-Johnson,Olathe 1-08,U.S. Senate,,I,Greg Orman,290
-Johnson,Olathe 1-09,U.S. Senate,,I,Greg Orman,218
-Johnson,Olathe 1-11,U.S. Senate,,I,Greg Orman,49
-Johnson,Olathe 1-14,U.S. Senate,,I,Greg Orman,216
-Johnson,Olathe 1-15,U.S. Senate,,I,Greg Orman,214
-Johnson,Olathe 1-16,U.S. Senate,,I,Greg Orman,265
-Johnson,Olathe 1-17,U.S. Senate,,I,Greg Orman,58
-Johnson,Olathe 1-18,U.S. Senate,,I,Greg Orman,83
-Johnson,Olathe 1-19,U.S. Senate,,I,Greg Orman,113
-Johnson,Olathe 1-20,U.S. Senate,,I,Greg Orman,198
-Johnson,Olathe 1-21,U.S. Senate,,I,Greg Orman,297
-Johnson,Olathe 1-22,U.S. Senate,,I,Greg Orman,364
-Johnson,Olathe 1-23,U.S. Senate,,I,Greg Orman,0
-Johnson,Olathe 1-24,U.S. Senate,,I,Greg Orman,30
-Johnson,Olathe 1-24,U.S. Senate,,I,Greg Orman,66
-Johnson,Olathe 1-26,U.S. Senate,,I,Greg Orman,2
-Johnson,Olathe 1-27,U.S. Senate,,I,Greg Orman,193
-Johnson,Olathe 2-01,U.S. Senate,,I,Greg Orman,99
-Johnson,Olathe 2-02,U.S. Senate,,I,Greg Orman,190
-Johnson,Olathe 2-03,U.S. Senate,,I,Greg Orman,177
-Johnson,Olathe 2-04,U.S. Senate,,I,Greg Orman,218
-Johnson,Olathe 2-05,U.S. Senate,,I,Greg Orman,535
-Johnson,Olathe 2-06,U.S. Senate,,I,Greg Orman,274
-Johnson,Olathe 2-07,U.S. Senate,,I,Greg Orman,362
-Johnson,Olathe 2-08,U.S. Senate,,I,Greg Orman,260
-Johnson,Olathe 2-09,U.S. Senate,,I,Greg Orman,121
-Johnson,Olathe 2-10,U.S. Senate,,I,Greg Orman,524
-Johnson,Olathe 2-11,U.S. Senate,,I,Greg Orman,356
-Johnson,Olathe 2-12,U.S. Senate,,I,Greg Orman,209
-Johnson,Olathe 2-13,U.S. Senate,,I,Greg Orman,228
-Johnson,Olathe 2-14,U.S. Senate,,I,Greg Orman,188
-Johnson,Olathe 2-15,U.S. Senate,,I,Greg Orman,169
-Johnson,Olathe 2-16,U.S. Senate,,I,Greg Orman,90
-Johnson,Olathe 2-17,U.S. Senate,,I,Greg Orman,1
-Johnson,Olathe 2-19,U.S. Senate,,I,Greg Orman,1
-Johnson,Olathe 2-22,U.S. Senate,,I,Greg Orman,398
-Johnson,Olathe 2-23,U.S. Senate,,I,Greg Orman,264
-Johnson,Olathe 3-01,U.S. Senate,,I,Greg Orman,106
-Johnson,Olathe 3-02,U.S. Senate,,I,Greg Orman,300
-Johnson,Olathe 3-03,U.S. Senate,,I,Greg Orman,137
-Johnson,Olathe 3-04,U.S. Senate,,I,Greg Orman,243
-Johnson,Olathe 3-05,U.S. Senate,,I,Greg Orman,222
-Johnson,Olathe 3-06,U.S. Senate,,I,Greg Orman,187
-Johnson,Olathe 3-07,U.S. Senate,,I,Greg Orman,189
-Johnson,Olathe 3-08,U.S. Senate,,I,Greg Orman,279
-Johnson,Olathe 3-09,U.S. Senate,,I,Greg Orman,122
-Johnson,Olathe 3-10,U.S. Senate,,I,Greg Orman,266
-Johnson,Olathe 3-11,U.S. Senate,,I,Greg Orman,192
-Johnson,Olathe 3-12,U.S. Senate,,I,Greg Orman,270
-Johnson,Olathe 3-13,U.S. Senate,,I,Greg Orman,277
-Johnson,Olathe 3-15,U.S. Senate,,I,Greg Orman,181
-Johnson,Olathe 3-16,U.S. Senate,,I,Greg Orman,203
-Johnson,Olathe 3-17,U.S. Senate,,I,Greg Orman,257
-Johnson,Olathe 3-18,U.S. Senate,,I,Greg Orman,255
-Johnson,Olathe 3-19,U.S. Senate,,I,Greg Orman,134
-Johnson,Olathe 3-20,U.S. Senate,,I,Greg Orman,181
-Johnson,Olathe 3-21,U.S. Senate,,I,Greg Orman,135
-Johnson,Olathe 3-22,U.S. Senate,,I,Greg Orman,216
-Johnson,Olathe 3-23,U.S. Senate,,I,Greg Orman,224
-Johnson,Olathe 3-24,U.S. Senate,,I,Greg Orman,131
-Johnson,Olathe 3-26,U.S. Senate,,I,Greg Orman,28
-Johnson,Olathe 4-01,U.S. Senate,,I,Greg Orman,218
-Johnson,Olathe 4-02,U.S. Senate,,I,Greg Orman,398
-Johnson,Olathe 4-03,U.S. Senate,,I,Greg Orman,140
-Johnson,Olathe 4-04,U.S. Senate,,I,Greg Orman,155
-Johnson,Olathe 4-05,U.S. Senate,,I,Greg Orman,297
-Johnson,Olathe 4-06,U.S. Senate,,I,Greg Orman,348
-Johnson,Olathe 4-07,U.S. Senate,,I,Greg Orman,302
-Johnson,Olathe 4-08,U.S. Senate,,I,Greg Orman,227
-Johnson,Olathe 4-09,U.S. Senate,,I,Greg Orman,337
-Johnson,Olathe 4-10,U.S. Senate,,I,Greg Orman,198
-Johnson,Olathe 4-11,U.S. Senate,,I,Greg Orman,143
-Johnson,Olathe 4-12,U.S. Senate,,I,Greg Orman,283
-Johnson,Olathe 4-13,U.S. Senate,,I,Greg Orman,165
-Johnson,Olathe 4-14,U.S. Senate,,I,Greg Orman,332
-Johnson,Olathe 4-15,U.S. Senate,,I,Greg Orman,14
-Johnson,Olathe 4-16,U.S. Senate,,I,Greg Orman,108
-Johnson,Olathe 4-17,U.S. Senate,,I,Greg Orman,2
-Johnson,Olathe Twp 0-01,U.S. Senate,,I,Greg Orman,122
-Johnson,Olathe Twp 0-02,U.S. Senate,,I,Greg Orman,18
-Johnson,Olathe Twp 0-03,U.S. Senate,,I,Greg Orman,23
-Johnson,Olathe Twp 0-04,U.S. Senate,,I,Greg Orman,0
-Johnson,Olathe Twp 0-05,U.S. Senate,,I,Greg Orman,0
-Johnson,Olathe Twp 0-06,U.S. Senate,,I,Greg Orman,0
-Johnson,Olathe Twp 0-07,U.S. Senate,,I,Greg Orman,0
-Johnson,Olathe Twp 0-08,U.S. Senate,,I,Greg Orman,2
-Johnson,Olathe Twp 0-09,U.S. Senate,,I,Greg Orman,0
-Johnson,Olathe Twp 0-10,U.S. Senate,,I,Greg Orman,5
-Johnson,Olathe Twp 0-11,U.S. Senate,,I,Greg Orman,3
-Johnson,Olathe Twp 0-14,U.S. Senate,,I,Greg Orman,0
-Johnson,Olathe Twp 0-24,U.S. Senate,,I,Greg Orman,1
-Johnson,Olathe Twp 0-25,U.S. Senate,,I,Greg Orman,1
-Johnson,Olathe Twp 0-26,U.S. Senate,,I,Greg Orman,0
-Johnson,Olathe Twp 0-32,U.S. Senate,,I,Greg Orman,11
-Johnson,Overland Park 1-01,U.S. Senate,,I,Greg Orman,296
-Johnson,Overland Park 1-02,U.S. Senate,,I,Greg Orman,294
-Johnson,Overland Park 1-03,U.S. Senate,,I,Greg Orman,269
-Johnson,Overland Park 1-04,U.S. Senate,,I,Greg Orman,92
-Johnson,Overland Park 1-05,U.S. Senate,,I,Greg Orman,212
-Johnson,Overland Park 1-06,U.S. Senate,,I,Greg Orman,372
-Johnson,Overland Park 1-07,U.S. Senate,,I,Greg Orman,330
-Johnson,Overland Park 1-08,U.S. Senate,,I,Greg Orman,229
-Johnson,Overland Park 1-09,U.S. Senate,,I,Greg Orman,160
-Johnson,Overland Park 1-10,U.S. Senate,,I,Greg Orman,306
-Johnson,Overland Park 1-11,U.S. Senate,,I,Greg Orman,83
-Johnson,Overland Park 1-12,U.S. Senate,,I,Greg Orman,268
-Johnson,Overland Park 1-13,U.S. Senate,,I,Greg Orman,193
-Johnson,Overland Park 1-14,U.S. Senate,,I,Greg Orman,306
-Johnson,Overland Park 1-15,U.S. Senate,,I,Greg Orman,137
-Johnson,Overland Park 1-16,U.S. Senate,,I,Greg Orman,381
-Johnson,Overland Park 1-17,U.S. Senate,,I,Greg Orman,154
-Johnson,Overland Park 1-18,U.S. Senate,,I,Greg Orman,308
-Johnson,Overland Park 1-19,U.S. Senate,,I,Greg Orman,206
-Johnson,Overland Park 1-20,U.S. Senate,,I,Greg Orman,190
-Johnson,Overland Park 1-21,U.S. Senate,,I,Greg Orman,80
-Johnson,Overland Park 1-22,U.S. Senate,,I,Greg Orman,65
-Johnson,Overland Park 2-01,U.S. Senate,,I,Greg Orman,245
-Johnson,Overland Park 2-02,U.S. Senate,,I,Greg Orman,300
-Johnson,Overland Park 2-03,U.S. Senate,,I,Greg Orman,247
-Johnson,Overland Park 2-04,U.S. Senate,,I,Greg Orman,285
-Johnson,Overland Park 2-05,U.S. Senate,,I,Greg Orman,263
-Johnson,Overland Park 2-06,U.S. Senate,,I,Greg Orman,244
-Johnson,Overland Park 2-07,U.S. Senate,,I,Greg Orman,203
-Johnson,Overland Park 2-08,U.S. Senate,,I,Greg Orman,154
-Johnson,Overland Park 2-09,U.S. Senate,,I,Greg Orman,203
-Johnson,Overland Park 2-10,U.S. Senate,,I,Greg Orman,118
-Johnson,Overland Park 2-11,U.S. Senate,,I,Greg Orman,253
-Johnson,Overland Park 2-12,U.S. Senate,,I,Greg Orman,182
-Johnson,Overland Park 2-13,U.S. Senate,,I,Greg Orman,126
-Johnson,Overland Park 2-14,U.S. Senate,,I,Greg Orman,203
-Johnson,Overland Park 2-15,U.S. Senate,,I,Greg Orman,369
-Johnson,Overland Park 2-16,U.S. Senate,,I,Greg Orman,219
-Johnson,Overland Park 2-17,U.S. Senate,,I,Greg Orman,284
-Johnson,Overland Park 2-18,U.S. Senate,,I,Greg Orman,341
-Johnson,Overland Park 2-19,U.S. Senate,,I,Greg Orman,227
-Johnson,Overland Park 2-20,U.S. Senate,,I,Greg Orman,200
-Johnson,Overland Park 2-21,U.S. Senate,,I,Greg Orman,245
-Johnson,Overland Park 2-22,U.S. Senate,,I,Greg Orman,266
-Johnson,Overland Park 2-23,U.S. Senate,,I,Greg Orman,240
-Johnson,Overland Park 2-24,U.S. Senate,,I,Greg Orman,379
-Johnson,Overland Park 2-25,U.S. Senate,,I,Greg Orman,317
-Johnson,Overland Park 2-26,U.S. Senate,,I,Greg Orman,130
-Johnson,Overland Park 3-01,U.S. Senate,,I,Greg Orman,366
-Johnson,Overland Park 3-02,U.S. Senate,,I,Greg Orman,268
-Johnson,Overland Park 3-03,U.S. Senate,,I,Greg Orman,251
-Johnson,Overland Park 3-04,U.S. Senate,,I,Greg Orman,341
-Johnson,Overland Park 3-05,U.S. Senate,,I,Greg Orman,316
-Johnson,Overland Park 3-06,U.S. Senate,,I,Greg Orman,352
-Johnson,Overland Park 3-07,U.S. Senate,,I,Greg Orman,236
-Johnson,Overland Park 3-08,U.S. Senate,,I,Greg Orman,258
-Johnson,Overland Park 3-09,U.S. Senate,,I,Greg Orman,392
-Johnson,Overland Park 3-10,U.S. Senate,,I,Greg Orman,203
-Johnson,Overland Park 3-11,U.S. Senate,,I,Greg Orman,241
-Johnson,Overland Park 3-12,U.S. Senate,,I,Greg Orman,200
-Johnson,Overland Park 3-13,U.S. Senate,,I,Greg Orman,409
-Johnson,Overland Park 3-14,U.S. Senate,,I,Greg Orman,344
-Johnson,Overland Park 3-15,U.S. Senate,,I,Greg Orman,166
-Johnson,Overland Park 3-16,U.S. Senate,,I,Greg Orman,298
-Johnson,Overland Park 3-17,U.S. Senate,,I,Greg Orman,243
-Johnson,Overland Park 3-18,U.S. Senate,,I,Greg Orman,252
-Johnson,Overland Park 3-19,U.S. Senate,,I,Greg Orman,259
-Johnson,Overland Park 3-20,U.S. Senate,,I,Greg Orman,351
-Johnson,Overland Park 3-21,U.S. Senate,,I,Greg Orman,244
-Johnson,Overland Park 4-01,U.S. Senate,,I,Greg Orman,179
-Johnson,Overland Park 4-02,U.S. Senate,,I,Greg Orman,239
-Johnson,Overland Park 4-03,U.S. Senate,,I,Greg Orman,245
-Johnson,Overland Park 4-04,U.S. Senate,,I,Greg Orman,378
-Johnson,Overland Park 4-05,U.S. Senate,,I,Greg Orman,273
-Johnson,Overland Park 4-06,U.S. Senate,,I,Greg Orman,229
-Johnson,Overland Park 4-07,U.S. Senate,,I,Greg Orman,221
-Johnson,Overland Park 4-08,U.S. Senate,,I,Greg Orman,276
-Johnson,Overland Park 4-09,U.S. Senate,,I,Greg Orman,196
-Johnson,Overland Park 4-10,U.S. Senate,,I,Greg Orman,158
-Johnson,Overland Park 4-11,U.S. Senate,,I,Greg Orman,329
-Johnson,Overland Park 4-12,U.S. Senate,,I,Greg Orman,427
-Johnson,Overland Park 4-13,U.S. Senate,,I,Greg Orman,148
-Johnson,Overland Park 4-14,U.S. Senate,,I,Greg Orman,139
-Johnson,Overland Park 4-15,U.S. Senate,,I,Greg Orman,348
-Johnson,Overland Park 4-16,U.S. Senate,,I,Greg Orman,202
-Johnson,Overland Park 4-17,U.S. Senate,,I,Greg Orman,317
-Johnson,Overland Park 4-18,U.S. Senate,,I,Greg Orman,55
-Johnson,Overland Park 5-01,U.S. Senate,,I,Greg Orman,300
-Johnson,Overland Park 5-02,U.S. Senate,,I,Greg Orman,150
-Johnson,Overland Park 5-03,U.S. Senate,,I,Greg Orman,268
-Johnson,Overland Park 5-04,U.S. Senate,,I,Greg Orman,269
-Johnson,Overland Park 5-05,U.S. Senate,,I,Greg Orman,245
-Johnson,Overland Park 5-06,U.S. Senate,,I,Greg Orman,224
-Johnson,Overland Park 5-07,U.S. Senate,,I,Greg Orman,246
-Johnson,Overland Park 5-08,U.S. Senate,,I,Greg Orman,368
-Johnson,Overland Park 5-09,U.S. Senate,,I,Greg Orman,386
-Johnson,Overland Park 5-10,U.S. Senate,,I,Greg Orman,287
-Johnson,Overland Park 5-11,U.S. Senate,,I,Greg Orman,387
-Johnson,Overland Park 5-12,U.S. Senate,,I,Greg Orman,73
-Johnson,Overland Park 5-13,U.S. Senate,,I,Greg Orman,425
-Johnson,Overland Park 5-14,U.S. Senate,,I,Greg Orman,303
-Johnson,Overland Park 5-15,U.S. Senate,,I,Greg Orman,231
-Johnson,Overland Park 5-16,U.S. Senate,,I,Greg Orman,175
-Johnson,Overland Park 5-17,U.S. Senate,,I,Greg Orman,110
-Johnson,Overland Park 5-18,U.S. Senate,,I,Greg Orman,235
-Johnson,Overland Park 5-19,U.S. Senate,,I,Greg Orman,22
-Johnson,Overland Park 6-01,U.S. Senate,,I,Greg Orman,289
-Johnson,Overland Park 6-02,U.S. Senate,,I,Greg Orman,229
-Johnson,Overland Park 6-03,U.S. Senate,,I,Greg Orman,266
-Johnson,Overland Park 6-04,U.S. Senate,,I,Greg Orman,241
-Johnson,Overland Park 6-05,U.S. Senate,,I,Greg Orman,315
-Johnson,Overland Park 6-06,U.S. Senate,,I,Greg Orman,0
-Johnson,Overland Park 6-07,U.S. Senate,,I,Greg Orman,63
-Johnson,Overland Park 6-08,U.S. Senate,,I,Greg Orman,283
-Johnson,Overland Park 6-09,U.S. Senate,,I,Greg Orman,357
-Johnson,Overland Park 6-10,U.S. Senate,,I,Greg Orman,224
-Johnson,Overland Park 6-11,U.S. Senate,,I,Greg Orman,233
-Johnson,Overland Park 6-12,U.S. Senate,,I,Greg Orman,116
-Johnson,Overland Park 6-13,U.S. Senate,,I,Greg Orman,299
-Johnson,Overland Park 6-15,U.S. Senate,,I,Greg Orman,282
-Johnson,Overland Park 6-16,U.S. Senate,,I,Greg Orman,159
-Johnson,Overland Park 6-17,U.S. Senate,,I,Greg Orman,53
-Johnson,Overland Park 6-18,U.S. Senate,,I,Greg Orman,0
-Johnson,Overland Park 6-19,U.S. Senate,,I,Greg Orman,343
-Johnson,Overland Park 6-20,U.S. Senate,,I,Greg Orman,90
-Johnson,Overland Park 6-21,U.S. Senate,,I,Greg Orman,275
-Johnson,Overland Park 6-22,U.S. Senate,,I,Greg Orman,135
-Johnson,Oxford Twp 0-01,U.S. Senate,,I,Greg Orman,1
-Johnson,Oxford Twp 0-02,U.S. Senate,,I,Greg Orman,184
-Johnson,Oxford Twp 0-04,U.S. Senate,,I,Greg Orman,153
-Johnson,Oxford Twp 0-05,U.S. Senate,,I,Greg Orman,0
-Johnson,Oxford Twp 0-09,U.S. Senate,,I,Greg Orman,7
-Johnson,Oxford Twp 0-10,U.S. Senate,,I,Greg Orman,0
-Johnson,Oxford Twp 0-11,U.S. Senate,,I,Greg Orman,28
-Johnson,Prairie Village 1-01,U.S. Senate,,I,Greg Orman,434
-Johnson,Prairie Village 1-02,U.S. Senate,,I,Greg Orman,308
-Johnson,Prairie Village 1-03,U.S. Senate,,I,Greg Orman,430
-Johnson,Prairie Village 2-01,U.S. Senate,,I,Greg Orman,374
-Johnson,Prairie Village 2-02,U.S. Senate,,I,Greg Orman,155
-Johnson,Prairie Village 2-03,U.S. Senate,,I,Greg Orman,316
-Johnson,Prairie Village 3-01,U.S. Senate,,I,Greg Orman,231
-Johnson,Prairie Village 3-02,U.S. Senate,,I,Greg Orman,358
-Johnson,Prairie Village 3-03,U.S. Senate,,I,Greg Orman,343
-Johnson,Prairie Village 4-01,U.S. Senate,,I,Greg Orman,351
-Johnson,Prairie Village 4-02,U.S. Senate,,I,Greg Orman,244
-Johnson,Prairie Village 4-03,U.S. Senate,,I,Greg Orman,408
-Johnson,Prairie Village 5-01,U.S. Senate,,I,Greg Orman,394
-Johnson,Prairie Village 5-02,U.S. Senate,,I,Greg Orman,364
-Johnson,Prairie Village 5-03,U.S. Senate,,I,Greg Orman,266
-Johnson,Prairie Village 6-01,U.S. Senate,,I,Greg Orman,399
-Johnson,Prairie Village 6-02,U.S. Senate,,I,Greg Orman,355
-Johnson,Prairie Village 6-03,U.S. Senate,,I,Greg Orman,198
-Johnson,Roeland Park 1-01,U.S. Senate,,I,Greg Orman,143
-Johnson,Roeland Park 1-02,U.S. Senate,,I,Greg Orman,128
-Johnson,Roeland Park 2-01,U.S. Senate,,I,Greg Orman,176
-Johnson,Roeland Park 2-02,U.S. Senate,,I,Greg Orman,220
-Johnson,Roeland Park 3-01,U.S. Senate,,I,Greg Orman,170
-Johnson,Roeland Park 3-02,U.S. Senate,,I,Greg Orman,321
-Johnson,Roeland Park 4-01,U.S. Senate,,I,Greg Orman,122
-Johnson,Roeland Park 4-02,U.S. Senate,,I,Greg Orman,383
-Johnson,Shawnee 1-01,U.S. Senate,,I,Greg Orman,339
-Johnson,Shawnee 1-02,U.S. Senate,,I,Greg Orman,247
-Johnson,Shawnee 1-03,U.S. Senate,,I,Greg Orman,226
-Johnson,Shawnee 1-04,U.S. Senate,,I,Greg Orman,351
-Johnson,Shawnee 1-05,U.S. Senate,,I,Greg Orman,414
-Johnson,Shawnee 1-06,U.S. Senate,,I,Greg Orman,284
-Johnson,Shawnee 1-07,U.S. Senate,,I,Greg Orman,316
-Johnson,Shawnee 1-08,U.S. Senate,,I,Greg Orman,303
-Johnson,Shawnee 1-09,U.S. Senate,,I,Greg Orman,53
-Johnson,Shawnee 1-10,U.S. Senate,,I,Greg Orman,109
-Johnson,Shawnee 1-11,U.S. Senate,,I,Greg Orman,198
-Johnson,Shawnee 1-12,U.S. Senate,,I,Greg Orman,4
-Johnson,Shawnee 2-01,U.S. Senate,,I,Greg Orman,133
-Johnson,Shawnee 2-02,U.S. Senate,,I,Greg Orman,255
-Johnson,Shawnee 2-03,U.S. Senate,,I,Greg Orman,213
-Johnson,Shawnee 2-04,U.S. Senate,,I,Greg Orman,350
-Johnson,Shawnee 2-05,U.S. Senate,,I,Greg Orman,148
-Johnson,Shawnee 2-06,U.S. Senate,,I,Greg Orman,193
-Johnson,Shawnee 2-07,U.S. Senate,,I,Greg Orman,177
-Johnson,Shawnee 2-08,U.S. Senate,,I,Greg Orman,165
-Johnson,Shawnee 2-09,U.S. Senate,,I,Greg Orman,172
-Johnson,Shawnee 2-10,U.S. Senate,,I,Greg Orman,138
-Johnson,Shawnee 2-11,U.S. Senate,,I,Greg Orman,222
-Johnson,Shawnee 2-12,U.S. Senate,,I,Greg Orman,72
-Johnson,Shawnee 2-13,U.S. Senate,,I,Greg Orman,125
-Johnson,Shawnee 3-01,U.S. Senate,,I,Greg Orman,156
-Johnson,Shawnee 3-02,U.S. Senate,,I,Greg Orman,342
-Johnson,Shawnee 3-03,U.S. Senate,,I,Greg Orman,294
-Johnson,Shawnee 3-04,U.S. Senate,,I,Greg Orman,224
-Johnson,Shawnee 3-05,U.S. Senate,,I,Greg Orman,298
-Johnson,Shawnee 3-06,U.S. Senate,,I,Greg Orman,248
-Johnson,Shawnee 3-07,U.S. Senate,,I,Greg Orman,301
-Johnson,Shawnee 3-08,U.S. Senate,,I,Greg Orman,290
-Johnson,Shawnee 3-09,U.S. Senate,,I,Greg Orman,141
-Johnson,Shawnee 4-01,U.S. Senate,,I,Greg Orman,376
-Johnson,Shawnee 4-02,U.S. Senate,,I,Greg Orman,201
-Johnson,Shawnee 4-03,U.S. Senate,,I,Greg Orman,86
-Johnson,Shawnee 4-04,U.S. Senate,,I,Greg Orman,122
-Johnson,Shawnee 4-05,U.S. Senate,,I,Greg Orman,313
-Johnson,Shawnee 4-06,U.S. Senate,,I,Greg Orman,240
-Johnson,Shawnee 4-07,U.S. Senate,,I,Greg Orman,366
-Johnson,Shawnee 4-08,U.S. Senate,,I,Greg Orman,133
-Johnson,Shawnee 4-09,U.S. Senate,,I,Greg Orman,421
-Johnson,Shawnee 4-11,U.S. Senate,,I,Greg Orman,221
-Johnson,Shawnee 4-12,U.S. Senate,,I,Greg Orman,44
-Johnson,Spring Hill 0-01,U.S. Senate,,I,Greg Orman,322
-Johnson,Spring Hill 0-03,U.S. Senate,,I,Greg Orman,23
-Johnson,Spring Hill 0-04,U.S. Senate,,I,Greg Orman,0
-Johnson,Spring Hill Twp 0-01,U.S. Senate,,I,Greg Orman,237
-Johnson,Spring Hill Twp 0-02,U.S. Senate,,I,Greg Orman,1
-Johnson,Spring Hill Twp 0-03,U.S. Senate,,I,Greg Orman,25
-Johnson,Spring Hill Twp 0-04,U.S. Senate,,I,Greg Orman,3
-Johnson,Spring Hill Twp 0-05,U.S. Senate,,I,Greg Orman,7
-Johnson,Westwood 0-01,U.S. Senate,,I,Greg Orman,240
-Johnson,Westwood 0-02,U.S. Senate,,I,Greg Orman,230
-Johnson,Westwood Hills 0-01,U.S. Senate,,I,Greg Orman,144
-Johnson,Aubry Twp 0-01,U.S. Senate,,R,Pat Roberts,70
-Johnson,Aubry Twp 0-02,U.S. Senate,,R,Pat Roberts,366
-Johnson,Aubry Twp 0-03,U.S. Senate,,R,Pat Roberts,196
-Johnson,Aubry Twp 0-04,U.S. Senate,,R,Pat Roberts,445
-Johnson,Aubry Twp 0-05,U.S. Senate,,R,Pat Roberts,6
-Johnson,Aubry Twp 0-06,U.S. Senate,,R,Pat Roberts,60
-Johnson,De Soto 0-01,U.S. Senate,,R,Pat Roberts,360
-Johnson,De Soto 0-02,U.S. Senate,,R,Pat Roberts,190
-Johnson,De Soto 0-03,U.S. Senate,,R,Pat Roberts,356
-Johnson,De Soto 0-06,U.S. Senate,,R,Pat Roberts,24
-Johnson,De Soto 0-07,U.S. Senate,,R,Pat Roberts,2
-Johnson,Edgerton 0-01,U.S. Senate,,R,Pat Roberts,222
-Johnson,Edgerton 0-02,U.S. Senate,,R,Pat Roberts,0
-Johnson,Edgerton 0-05,U.S. Senate,,R,Pat Roberts,0
-Johnson,Edgerton 0-06,U.S. Senate,,R,Pat Roberts,0
-Johnson,Edgerton 0-09,U.S. Senate,,R,Pat Roberts,0
-Johnson,Fairway 1-01,U.S. Senate,,R,Pat Roberts,108
-Johnson,Fairway 1-02,U.S. Senate,,R,Pat Roberts,78
-Johnson,Fairway 2-01,U.S. Senate,,R,Pat Roberts,87
-Johnson,Fairway 2-02,U.S. Senate,,R,Pat Roberts,91
-Johnson,Fairway 3-01,U.S. Senate,,R,Pat Roberts,150
-Johnson,Fairway 3-02,U.S. Senate,,R,Pat Roberts,97
-Johnson,Fairway 4-01,U.S. Senate,,R,Pat Roberts,21
-Johnson,Fairway 4-02,U.S. Senate,,R,Pat Roberts,35
-Johnson,Fairway 4-03,U.S. Senate,,R,Pat Roberts,30
-Johnson,Fairway 4-04,U.S. Senate,,R,Pat Roberts,35
-Johnson,Gardner 0-01,U.S. Senate,,R,Pat Roberts,446
-Johnson,Gardner 0-02,U.S. Senate,,R,Pat Roberts,54
-Johnson,Gardner 0-03,U.S. Senate,,R,Pat Roberts,238
-Johnson,Gardner 0-04,U.S. Senate,,R,Pat Roberts,245
-Johnson,Gardner 0-06,U.S. Senate,,R,Pat Roberts,329
-Johnson,Gardner 0-07,U.S. Senate,,R,Pat Roberts,5
-Johnson,Gardner 0-08,U.S. Senate,,R,Pat Roberts,29
-Johnson,Gardner 0-09,U.S. Senate,,R,Pat Roberts,354
-Johnson,Gardner 0-10,U.S. Senate,,R,Pat Roberts,245
-Johnson,Gardner 0-12,U.S. Senate,,R,Pat Roberts,5
-Johnson,Gardner 0-13,U.S. Senate,,R,Pat Roberts,235
-Johnson,Gardner 0-14,U.S. Senate,,R,Pat Roberts,222
-Johnson,Gardner Twp 0-01,U.S. Senate,,R,Pat Roberts,172
-Johnson,Gardner Twp 0-02,U.S. Senate,,R,Pat Roberts,221
-Johnson,Gardner Twp 0-04,U.S. Senate,,R,Pat Roberts,2
-Johnson,Gardner Twp 0-05,U.S. Senate,,R,Pat Roberts,5
-Johnson,Gardner Twp 0-07,U.S. Senate,,R,Pat Roberts,2
-Johnson,Gardner Twp 0-08,U.S. Senate,,R,Pat Roberts,2
-Johnson,Gardner Twp 0-09,U.S. Senate,,R,Pat Roberts,0
-Johnson,Gardner Twp 0-10,U.S. Senate,,R,Pat Roberts,0
-Johnson,Gardner Twp 0-11,U.S. Senate,,R,Pat Roberts,49
-Johnson,Gardner Twp 0-13,U.S. Senate,,R,Pat Roberts,1
-Johnson,Lake Quivira 0-01,U.S. Senate,,R,Pat Roberts,302
-Johnson,Leawood 1-01,U.S. Senate,,R,Pat Roberts,185
-Johnson,Leawood 1-02,U.S. Senate,,R,Pat Roberts,395
-Johnson,Leawood 1-03,U.S. Senate,,R,Pat Roberts,319
-Johnson,Leawood 1-04,U.S. Senate,,R,Pat Roberts,254
-Johnson,Leawood 1-05,U.S. Senate,,R,Pat Roberts,230
-Johnson,Leawood 1-06,U.S. Senate,,R,Pat Roberts,50
-Johnson,Leawood 2-01,U.S. Senate,,R,Pat Roberts,296
-Johnson,Leawood 2-02,U.S. Senate,,R,Pat Roberts,336
-Johnson,Leawood 2-03,U.S. Senate,,R,Pat Roberts,356
-Johnson,Leawood 2-04,U.S. Senate,,R,Pat Roberts,500
-Johnson,Leawood 2-05,U.S. Senate,,R,Pat Roberts,222
-Johnson,Leawood 2-06,U.S. Senate,,R,Pat Roberts,172
-Johnson,Leawood 3-01,U.S. Senate,,R,Pat Roberts,201
-Johnson,Leawood 3-02,U.S. Senate,,R,Pat Roberts,355
-Johnson,Leawood 3-03,U.S. Senate,,R,Pat Roberts,249
-Johnson,Leawood 3-04,U.S. Senate,,R,Pat Roberts,100
-Johnson,Leawood 3-05,U.S. Senate,,R,Pat Roberts,464
-Johnson,Leawood 3-06,U.S. Senate,,R,Pat Roberts,485
-Johnson,Leawood 3-07,U.S. Senate,,R,Pat Roberts,328
-Johnson,Leawood 4-01,U.S. Senate,,R,Pat Roberts,130
-Johnson,Leawood 4-02,U.S. Senate,,R,Pat Roberts,372
-Johnson,Leawood 4-03,U.S. Senate,,R,Pat Roberts,294
-Johnson,Leawood 4-04,U.S. Senate,,R,Pat Roberts,374
-Johnson,Leawood 4-05,U.S. Senate,,R,Pat Roberts,365
-Johnson,Leawood 4-06,U.S. Senate,,R,Pat Roberts,347
-Johnson,Leawood 4-07,U.S. Senate,,R,Pat Roberts,539
-Johnson,Leawood 4-08,U.S. Senate,,R,Pat Roberts,241
-Johnson,Lenexa 1-01,U.S. Senate,,R,Pat Roberts,182
-Johnson,Lenexa 1-02,U.S. Senate,,R,Pat Roberts,339
-Johnson,Lenexa 1-03,U.S. Senate,,R,Pat Roberts,402
-Johnson,Lenexa 1-04,U.S. Senate,,R,Pat Roberts,263
-Johnson,Lenexa 1-05,U.S. Senate,,R,Pat Roberts,285
-Johnson,Lenexa 1-06,U.S. Senate,,R,Pat Roberts,378
-Johnson,Lenexa 1-07,U.S. Senate,,R,Pat Roberts,181
-Johnson,Lenexa 1-08,U.S. Senate,,R,Pat Roberts,78
-Johnson,Lenexa 1-09,U.S. Senate,,R,Pat Roberts,7
-Johnson,Lenexa 2-01,U.S. Senate,,R,Pat Roberts,522
-Johnson,Lenexa 2-02,U.S. Senate,,R,Pat Roberts,212
-Johnson,Lenexa 2-03,U.S. Senate,,R,Pat Roberts,462
-Johnson,Lenexa 2-04,U.S. Senate,,R,Pat Roberts,525
-Johnson,Lenexa 2-05,U.S. Senate,,R,Pat Roberts,197
-Johnson,Lenexa 2-06,U.S. Senate,,R,Pat Roberts,330
-Johnson,Lenexa 2-07,U.S. Senate,,R,Pat Roberts,460
-Johnson,Lenexa 3-01,U.S. Senate,,R,Pat Roberts,178
-Johnson,Lenexa 3-02,U.S. Senate,,R,Pat Roberts,286
-Johnson,Lenexa 3-03,U.S. Senate,,R,Pat Roberts,421
-Johnson,Lenexa 3-04,U.S. Senate,,R,Pat Roberts,304
-Johnson,Lenexa 3-05,U.S. Senate,,R,Pat Roberts,124
-Johnson,Lenexa 3-06,U.S. Senate,,R,Pat Roberts,217
-Johnson,Lenexa 3-07,U.S. Senate,,R,Pat Roberts,325
-Johnson,Lenexa 3-08,U.S. Senate,,R,Pat Roberts,356
-Johnson,Lenexa 4-01,U.S. Senate,,R,Pat Roberts,129
-Johnson,Lenexa 4-02,U.S. Senate,,R,Pat Roberts,288
-Johnson,Lenexa 4-03,U.S. Senate,,R,Pat Roberts,91
-Johnson,Lenexa 4-04,U.S. Senate,,R,Pat Roberts,141
-Johnson,Lenexa 4-05,U.S. Senate,,R,Pat Roberts,103
-Johnson,Lenexa 4-06,U.S. Senate,,R,Pat Roberts,191
-Johnson,Lenexa 4-07,U.S. Senate,,R,Pat Roberts,246
-Johnson,Lenexa 4-08,U.S. Senate,,R,Pat Roberts,254
-Johnson,Lenexa 4-09,U.S. Senate,,R,Pat Roberts,241
-Johnson,Lenexa 4-10,U.S. Senate,,R,Pat Roberts,113
-Johnson,Lenexa 4-11,U.S. Senate,,R,Pat Roberts,31
-Johnson,Lexington Twp 0-01,U.S. Senate,,R,Pat Roberts,380
-Johnson,Lexington Twp 0-02,U.S. Senate,,R,Pat Roberts,1
-Johnson,Lexington Twp 0-03,U.S. Senate,,R,Pat Roberts,0
-Johnson,McCamish Twp 0-01,U.S. Senate,,R,Pat Roberts,103
-Johnson,McCamish Twp 0-02,U.S. Senate,,R,Pat Roberts,186
-Johnson,Merriam 1-01,U.S. Senate,,R,Pat Roberts,128
-Johnson,Merriam 1-02,U.S. Senate,,R,Pat Roberts,138
-Johnson,Merriam 2-01,U.S. Senate,,R,Pat Roberts,220
-Johnson,Merriam 2-02,U.S. Senate,,R,Pat Roberts,0
-Johnson,Merriam 2-03,U.S. Senate,,R,Pat Roberts,96
-Johnson,Merriam 3-01,U.S. Senate,,R,Pat Roberts,156
-Johnson,Merriam 3-02,U.S. Senate,,R,Pat Roberts,157
-Johnson,Merriam 4-01,U.S. Senate,,R,Pat Roberts,215
-Johnson,Merriam 4-02,U.S. Senate,,R,Pat Roberts,96
-Johnson,Merriam 4-03,U.S. Senate,,R,Pat Roberts,111
-Johnson,Mission 1-01,U.S. Senate,,R,Pat Roberts,177
-Johnson,Mission 1-02,U.S. Senate,,R,Pat Roberts,73
-Johnson,Mission 2-01,U.S. Senate,,R,Pat Roberts,86
-Johnson,Mission 2-02,U.S. Senate,,R,Pat Roberts,144
-Johnson,Mission 3-01,U.S. Senate,,R,Pat Roberts,140
-Johnson,Mission 3-02,U.S. Senate,,R,Pat Roberts,85
-Johnson,Mission 4-01,U.S. Senate,,R,Pat Roberts,95
-Johnson,Mission 4-02,U.S. Senate,,R,Pat Roberts,186
-Johnson,Mission 4-03,U.S. Senate,,R,Pat Roberts,96
-Johnson,Mission Hills 0-01,U.S. Senate,,R,Pat Roberts,253
-Johnson,Mission Hills 0-02,U.S. Senate,,R,Pat Roberts,280
-Johnson,Mission Hills 0-03,U.S. Senate,,R,Pat Roberts,200
-Johnson,Mission Hills 0-04,U.S. Senate,,R,Pat Roberts,306
-Johnson,Mission Woods 0-01,U.S. Senate,,R,Pat Roberts,41
-Johnson,Olathe 1-01,U.S. Senate,,R,Pat Roberts,272
-Johnson,Olathe 1-02,U.S. Senate,,R,Pat Roberts,166
-Johnson,Olathe 1-03,U.S. Senate,,R,Pat Roberts,137
-Johnson,Olathe 1-04,U.S. Senate,,R,Pat Roberts,263
-Johnson,Olathe 1-05,U.S. Senate,,R,Pat Roberts,312
-Johnson,Olathe 1-06,U.S. Senate,,R,Pat Roberts,209
-Johnson,Olathe 1-08,U.S. Senate,,R,Pat Roberts,313
-Johnson,Olathe 1-09,U.S. Senate,,R,Pat Roberts,340
-Johnson,Olathe 1-11,U.S. Senate,,R,Pat Roberts,45
-Johnson,Olathe 1-14,U.S. Senate,,R,Pat Roberts,292
-Johnson,Olathe 1-15,U.S. Senate,,R,Pat Roberts,260
-Johnson,Olathe 1-16,U.S. Senate,,R,Pat Roberts,354
-Johnson,Olathe 1-17,U.S. Senate,,R,Pat Roberts,98
-Johnson,Olathe 1-18,U.S. Senate,,R,Pat Roberts,86
-Johnson,Olathe 1-19,U.S. Senate,,R,Pat Roberts,121
-Johnson,Olathe 1-20,U.S. Senate,,R,Pat Roberts,183
-Johnson,Olathe 1-21,U.S. Senate,,R,Pat Roberts,319
-Johnson,Olathe 1-22,U.S. Senate,,R,Pat Roberts,537
-Johnson,Olathe 1-23,U.S. Senate,,R,Pat Roberts,1
-Johnson,Olathe 1-24,U.S. Senate,,R,Pat Roberts,47
-Johnson,Olathe 1-24,U.S. Senate,,R,Pat Roberts,79
-Johnson,Olathe 1-26,U.S. Senate,,R,Pat Roberts,0
-Johnson,Olathe 1-27,U.S. Senate,,R,Pat Roberts,186
-Johnson,Olathe 2-01,U.S. Senate,,R,Pat Roberts,122
-Johnson,Olathe 2-02,U.S. Senate,,R,Pat Roberts,169
-Johnson,Olathe 2-03,U.S. Senate,,R,Pat Roberts,206
-Johnson,Olathe 2-04,U.S. Senate,,R,Pat Roberts,202
-Johnson,Olathe 2-05,U.S. Senate,,R,Pat Roberts,732
-Johnson,Olathe 2-06,U.S. Senate,,R,Pat Roberts,368
-Johnson,Olathe 2-07,U.S. Senate,,R,Pat Roberts,415
-Johnson,Olathe 2-08,U.S. Senate,,R,Pat Roberts,276
-Johnson,Olathe 2-09,U.S. Senate,,R,Pat Roberts,131
-Johnson,Olathe 2-10,U.S. Senate,,R,Pat Roberts,500
-Johnson,Olathe 2-11,U.S. Senate,,R,Pat Roberts,364
-Johnson,Olathe 2-12,U.S. Senate,,R,Pat Roberts,220
-Johnson,Olathe 2-13,U.S. Senate,,R,Pat Roberts,200
-Johnson,Olathe 2-14,U.S. Senate,,R,Pat Roberts,215
-Johnson,Olathe 2-15,U.S. Senate,,R,Pat Roberts,244
-Johnson,Olathe 2-16,U.S. Senate,,R,Pat Roberts,56
-Johnson,Olathe 2-17,U.S. Senate,,R,Pat Roberts,0
-Johnson,Olathe 2-19,U.S. Senate,,R,Pat Roberts,5
-Johnson,Olathe 2-22,U.S. Senate,,R,Pat Roberts,456
-Johnson,Olathe 2-23,U.S. Senate,,R,Pat Roberts,289
-Johnson,Olathe 3-01,U.S. Senate,,R,Pat Roberts,114
-Johnson,Olathe 3-02,U.S. Senate,,R,Pat Roberts,361
-Johnson,Olathe 3-03,U.S. Senate,,R,Pat Roberts,205
-Johnson,Olathe 3-04,U.S. Senate,,R,Pat Roberts,323
-Johnson,Olathe 3-05,U.S. Senate,,R,Pat Roberts,377
-Johnson,Olathe 3-06,U.S. Senate,,R,Pat Roberts,255
-Johnson,Olathe 3-07,U.S. Senate,,R,Pat Roberts,237
-Johnson,Olathe 3-08,U.S. Senate,,R,Pat Roberts,368
-Johnson,Olathe 3-09,U.S. Senate,,R,Pat Roberts,191
-Johnson,Olathe 3-10,U.S. Senate,,R,Pat Roberts,366
-Johnson,Olathe 3-11,U.S. Senate,,R,Pat Roberts,219
-Johnson,Olathe 3-12,U.S. Senate,,R,Pat Roberts,294
-Johnson,Olathe 3-13,U.S. Senate,,R,Pat Roberts,351
-Johnson,Olathe 3-15,U.S. Senate,,R,Pat Roberts,229
-Johnson,Olathe 3-16,U.S. Senate,,R,Pat Roberts,252
-Johnson,Olathe 3-17,U.S. Senate,,R,Pat Roberts,358
-Johnson,Olathe 3-18,U.S. Senate,,R,Pat Roberts,316
-Johnson,Olathe 3-19,U.S. Senate,,R,Pat Roberts,228
-Johnson,Olathe 3-20,U.S. Senate,,R,Pat Roberts,227
-Johnson,Olathe 3-21,U.S. Senate,,R,Pat Roberts,259
-Johnson,Olathe 3-22,U.S. Senate,,R,Pat Roberts,313
-Johnson,Olathe 3-23,U.S. Senate,,R,Pat Roberts,243
-Johnson,Olathe 3-24,U.S. Senate,,R,Pat Roberts,151
-Johnson,Olathe 3-26,U.S. Senate,,R,Pat Roberts,22
-Johnson,Olathe 4-01,U.S. Senate,,R,Pat Roberts,211
-Johnson,Olathe 4-02,U.S. Senate,,R,Pat Roberts,417
-Johnson,Olathe 4-03,U.S. Senate,,R,Pat Roberts,101
-Johnson,Olathe 4-04,U.S. Senate,,R,Pat Roberts,129
-Johnson,Olathe 4-05,U.S. Senate,,R,Pat Roberts,280
-Johnson,Olathe 4-06,U.S. Senate,,R,Pat Roberts,347
-Johnson,Olathe 4-07,U.S. Senate,,R,Pat Roberts,291
-Johnson,Olathe 4-08,U.S. Senate,,R,Pat Roberts,285
-Johnson,Olathe 4-09,U.S. Senate,,R,Pat Roberts,378
-Johnson,Olathe 4-10,U.S. Senate,,R,Pat Roberts,193
-Johnson,Olathe 4-11,U.S. Senate,,R,Pat Roberts,96
-Johnson,Olathe 4-12,U.S. Senate,,R,Pat Roberts,371
-Johnson,Olathe 4-13,U.S. Senate,,R,Pat Roberts,143
-Johnson,Olathe 4-14,U.S. Senate,,R,Pat Roberts,353
-Johnson,Olathe 4-15,U.S. Senate,,R,Pat Roberts,17
-Johnson,Olathe 4-16,U.S. Senate,,R,Pat Roberts,87
-Johnson,Olathe 4-17,U.S. Senate,,R,Pat Roberts,1
-Johnson,Olathe Twp 0-01,U.S. Senate,,R,Pat Roberts,144
-Johnson,Olathe Twp 0-02,U.S. Senate,,R,Pat Roberts,34
-Johnson,Olathe Twp 0-03,U.S. Senate,,R,Pat Roberts,17
-Johnson,Olathe Twp 0-04,U.S. Senate,,R,Pat Roberts,2
-Johnson,Olathe Twp 0-05,U.S. Senate,,R,Pat Roberts,2
-Johnson,Olathe Twp 0-06,U.S. Senate,,R,Pat Roberts,0
-Johnson,Olathe Twp 0-07,U.S. Senate,,R,Pat Roberts,1
-Johnson,Olathe Twp 0-08,U.S. Senate,,R,Pat Roberts,4
-Johnson,Olathe Twp 0-09,U.S. Senate,,R,Pat Roberts,0
-Johnson,Olathe Twp 0-10,U.S. Senate,,R,Pat Roberts,6
-Johnson,Olathe Twp 0-11,U.S. Senate,,R,Pat Roberts,1
-Johnson,Olathe Twp 0-14,U.S. Senate,,R,Pat Roberts,1
-Johnson,Olathe Twp 0-24,U.S. Senate,,R,Pat Roberts,1
-Johnson,Olathe Twp 0-25,U.S. Senate,,R,Pat Roberts,7
-Johnson,Olathe Twp 0-26,U.S. Senate,,R,Pat Roberts,3
-Johnson,Olathe Twp 0-32,U.S. Senate,,R,Pat Roberts,10
-Johnson,Overland Park 1-01,U.S. Senate,,R,Pat Roberts,173
-Johnson,Overland Park 1-02,U.S. Senate,,R,Pat Roberts,185
-Johnson,Overland Park 1-03,U.S. Senate,,R,Pat Roberts,206
-Johnson,Overland Park 1-04,U.S. Senate,,R,Pat Roberts,72
-Johnson,Overland Park 1-05,U.S. Senate,,R,Pat Roberts,109
-Johnson,Overland Park 1-06,U.S. Senate,,R,Pat Roberts,259
-Johnson,Overland Park 1-07,U.S. Senate,,R,Pat Roberts,256
-Johnson,Overland Park 1-08,U.S. Senate,,R,Pat Roberts,159
-Johnson,Overland Park 1-09,U.S. Senate,,R,Pat Roberts,97
-Johnson,Overland Park 1-10,U.S. Senate,,R,Pat Roberts,212
-Johnson,Overland Park 1-11,U.S. Senate,,R,Pat Roberts,56
-Johnson,Overland Park 1-12,U.S. Senate,,R,Pat Roberts,167
-Johnson,Overland Park 1-13,U.S. Senate,,R,Pat Roberts,138
-Johnson,Overland Park 1-14,U.S. Senate,,R,Pat Roberts,164
-Johnson,Overland Park 1-15,U.S. Senate,,R,Pat Roberts,93
-Johnson,Overland Park 1-16,U.S. Senate,,R,Pat Roberts,177
-Johnson,Overland Park 1-17,U.S. Senate,,R,Pat Roberts,88
-Johnson,Overland Park 1-18,U.S. Senate,,R,Pat Roberts,197
-Johnson,Overland Park 1-19,U.S. Senate,,R,Pat Roberts,150
-Johnson,Overland Park 1-20,U.S. Senate,,R,Pat Roberts,108
-Johnson,Overland Park 1-21,U.S. Senate,,R,Pat Roberts,65
-Johnson,Overland Park 1-22,U.S. Senate,,R,Pat Roberts,43
-Johnson,Overland Park 2-01,U.S. Senate,,R,Pat Roberts,186
-Johnson,Overland Park 2-02,U.S. Senate,,R,Pat Roberts,186
-Johnson,Overland Park 2-03,U.S. Senate,,R,Pat Roberts,181
-Johnson,Overland Park 2-04,U.S. Senate,,R,Pat Roberts,222
-Johnson,Overland Park 2-05,U.S. Senate,,R,Pat Roberts,162
-Johnson,Overland Park 2-06,U.S. Senate,,R,Pat Roberts,194
-Johnson,Overland Park 2-07,U.S. Senate,,R,Pat Roberts,168
-Johnson,Overland Park 2-08,U.S. Senate,,R,Pat Roberts,86
-Johnson,Overland Park 2-09,U.S. Senate,,R,Pat Roberts,179
-Johnson,Overland Park 2-10,U.S. Senate,,R,Pat Roberts,183
-Johnson,Overland Park 2-11,U.S. Senate,,R,Pat Roberts,192
-Johnson,Overland Park 2-12,U.S. Senate,,R,Pat Roberts,146
-Johnson,Overland Park 2-13,U.S. Senate,,R,Pat Roberts,83
-Johnson,Overland Park 2-14,U.S. Senate,,R,Pat Roberts,131
-Johnson,Overland Park 2-15,U.S. Senate,,R,Pat Roberts,284
-Johnson,Overland Park 2-16,U.S. Senate,,R,Pat Roberts,168
-Johnson,Overland Park 2-17,U.S. Senate,,R,Pat Roberts,277
-Johnson,Overland Park 2-18,U.S. Senate,,R,Pat Roberts,231
-Johnson,Overland Park 2-19,U.S. Senate,,R,Pat Roberts,161
-Johnson,Overland Park 2-20,U.S. Senate,,R,Pat Roberts,182
-Johnson,Overland Park 2-21,U.S. Senate,,R,Pat Roberts,154
-Johnson,Overland Park 2-22,U.S. Senate,,R,Pat Roberts,170
-Johnson,Overland Park 2-23,U.S. Senate,,R,Pat Roberts,237
-Johnson,Overland Park 2-24,U.S. Senate,,R,Pat Roberts,342
-Johnson,Overland Park 2-25,U.S. Senate,,R,Pat Roberts,270
-Johnson,Overland Park 2-26,U.S. Senate,,R,Pat Roberts,84
-Johnson,Overland Park 3-01,U.S. Senate,,R,Pat Roberts,403
-Johnson,Overland Park 3-02,U.S. Senate,,R,Pat Roberts,214
-Johnson,Overland Park 3-03,U.S. Senate,,R,Pat Roberts,259
-Johnson,Overland Park 3-04,U.S. Senate,,R,Pat Roberts,272
-Johnson,Overland Park 3-05,U.S. Senate,,R,Pat Roberts,257
-Johnson,Overland Park 3-06,U.S. Senate,,R,Pat Roberts,314
-Johnson,Overland Park 3-07,U.S. Senate,,R,Pat Roberts,153
-Johnson,Overland Park 3-08,U.S. Senate,,R,Pat Roberts,278
-Johnson,Overland Park 3-09,U.S. Senate,,R,Pat Roberts,341
-Johnson,Overland Park 3-10,U.S. Senate,,R,Pat Roberts,204
-Johnson,Overland Park 3-11,U.S. Senate,,R,Pat Roberts,270
-Johnson,Overland Park 3-12,U.S. Senate,,R,Pat Roberts,131
-Johnson,Overland Park 3-13,U.S. Senate,,R,Pat Roberts,410
-Johnson,Overland Park 3-14,U.S. Senate,,R,Pat Roberts,240
-Johnson,Overland Park 3-15,U.S. Senate,,R,Pat Roberts,210
-Johnson,Overland Park 3-16,U.S. Senate,,R,Pat Roberts,221
-Johnson,Overland Park 3-17,U.S. Senate,,R,Pat Roberts,196
-Johnson,Overland Park 3-18,U.S. Senate,,R,Pat Roberts,183
-Johnson,Overland Park 3-19,U.S. Senate,,R,Pat Roberts,235
-Johnson,Overland Park 3-20,U.S. Senate,,R,Pat Roberts,298
-Johnson,Overland Park 3-21,U.S. Senate,,R,Pat Roberts,275
-Johnson,Overland Park 4-01,U.S. Senate,,R,Pat Roberts,205
-Johnson,Overland Park 4-02,U.S. Senate,,R,Pat Roberts,357
-Johnson,Overland Park 4-03,U.S. Senate,,R,Pat Roberts,473
-Johnson,Overland Park 4-04,U.S. Senate,,R,Pat Roberts,445
-Johnson,Overland Park 4-05,U.S. Senate,,R,Pat Roberts,315
-Johnson,Overland Park 4-06,U.S. Senate,,R,Pat Roberts,269
-Johnson,Overland Park 4-07,U.S. Senate,,R,Pat Roberts,178
-Johnson,Overland Park 4-08,U.S. Senate,,R,Pat Roberts,317
-Johnson,Overland Park 4-09,U.S. Senate,,R,Pat Roberts,380
-Johnson,Overland Park 4-10,U.S. Senate,,R,Pat Roberts,246
-Johnson,Overland Park 4-11,U.S. Senate,,R,Pat Roberts,362
-Johnson,Overland Park 4-12,U.S. Senate,,R,Pat Roberts,479
-Johnson,Overland Park 4-13,U.S. Senate,,R,Pat Roberts,282
-Johnson,Overland Park 4-14,U.S. Senate,,R,Pat Roberts,227
-Johnson,Overland Park 4-15,U.S. Senate,,R,Pat Roberts,400
-Johnson,Overland Park 4-16,U.S. Senate,,R,Pat Roberts,336
-Johnson,Overland Park 4-17,U.S. Senate,,R,Pat Roberts,376
-Johnson,Overland Park 4-18,U.S. Senate,,R,Pat Roberts,46
-Johnson,Overland Park 5-01,U.S. Senate,,R,Pat Roberts,316
-Johnson,Overland Park 5-02,U.S. Senate,,R,Pat Roberts,140
-Johnson,Overland Park 5-03,U.S. Senate,,R,Pat Roberts,309
-Johnson,Overland Park 5-04,U.S. Senate,,R,Pat Roberts,264
-Johnson,Overland Park 5-05,U.S. Senate,,R,Pat Roberts,169
-Johnson,Overland Park 5-06,U.S. Senate,,R,Pat Roberts,240
-Johnson,Overland Park 5-07,U.S. Senate,,R,Pat Roberts,480
-Johnson,Overland Park 5-08,U.S. Senate,,R,Pat Roberts,454
-Johnson,Overland Park 5-09,U.S. Senate,,R,Pat Roberts,427
-Johnson,Overland Park 5-10,U.S. Senate,,R,Pat Roberts,312
-Johnson,Overland Park 5-11,U.S. Senate,,R,Pat Roberts,330
-Johnson,Overland Park 5-12,U.S. Senate,,R,Pat Roberts,78
-Johnson,Overland Park 5-13,U.S. Senate,,R,Pat Roberts,368
-Johnson,Overland Park 5-14,U.S. Senate,,R,Pat Roberts,319
-Johnson,Overland Park 5-15,U.S. Senate,,R,Pat Roberts,192
-Johnson,Overland Park 5-16,U.S. Senate,,R,Pat Roberts,194
-Johnson,Overland Park 5-17,U.S. Senate,,R,Pat Roberts,113
-Johnson,Overland Park 5-18,U.S. Senate,,R,Pat Roberts,232
-Johnson,Overland Park 5-19,U.S. Senate,,R,Pat Roberts,30
-Johnson,Overland Park 6-01,U.S. Senate,,R,Pat Roberts,406
-Johnson,Overland Park 6-02,U.S. Senate,,R,Pat Roberts,319
-Johnson,Overland Park 6-03,U.S. Senate,,R,Pat Roberts,351
-Johnson,Overland Park 6-04,U.S. Senate,,R,Pat Roberts,351
-Johnson,Overland Park 6-05,U.S. Senate,,R,Pat Roberts,369
-Johnson,Overland Park 6-06,U.S. Senate,,R,Pat Roberts,1
-Johnson,Overland Park 6-07,U.S. Senate,,R,Pat Roberts,123
-Johnson,Overland Park 6-08,U.S. Senate,,R,Pat Roberts,646
-Johnson,Overland Park 6-09,U.S. Senate,,R,Pat Roberts,461
-Johnson,Overland Park 6-10,U.S. Senate,,R,Pat Roberts,301
-Johnson,Overland Park 6-11,U.S. Senate,,R,Pat Roberts,302
-Johnson,Overland Park 6-12,U.S. Senate,,R,Pat Roberts,138
-Johnson,Overland Park 6-13,U.S. Senate,,R,Pat Roberts,418
-Johnson,Overland Park 6-15,U.S. Senate,,R,Pat Roberts,414
-Johnson,Overland Park 6-16,U.S. Senate,,R,Pat Roberts,243
-Johnson,Overland Park 6-17,U.S. Senate,,R,Pat Roberts,82
-Johnson,Overland Park 6-18,U.S. Senate,,R,Pat Roberts,3
-Johnson,Overland Park 6-19,U.S. Senate,,R,Pat Roberts,362
-Johnson,Overland Park 6-20,U.S. Senate,,R,Pat Roberts,232
-Johnson,Overland Park 6-21,U.S. Senate,,R,Pat Roberts,616
-Johnson,Overland Park 6-22,U.S. Senate,,R,Pat Roberts,199
-Johnson,Oxford Twp 0-01,U.S. Senate,,R,Pat Roberts,2
-Johnson,Oxford Twp 0-02,U.S. Senate,,R,Pat Roberts,263
-Johnson,Oxford Twp 0-04,U.S. Senate,,R,Pat Roberts,194
-Johnson,Oxford Twp 0-05,U.S. Senate,,R,Pat Roberts,10
-Johnson,Oxford Twp 0-09,U.S. Senate,,R,Pat Roberts,13
-Johnson,Oxford Twp 0-10,U.S. Senate,,R,Pat Roberts,2
-Johnson,Oxford Twp 0-11,U.S. Senate,,R,Pat Roberts,62
-Johnson,Prairie Village 1-01,U.S. Senate,,R,Pat Roberts,269
-Johnson,Prairie Village 1-02,U.S. Senate,,R,Pat Roberts,178
-Johnson,Prairie Village 1-03,U.S. Senate,,R,Pat Roberts,256
-Johnson,Prairie Village 2-01,U.S. Senate,,R,Pat Roberts,187
-Johnson,Prairie Village 2-02,U.S. Senate,,R,Pat Roberts,104
-Johnson,Prairie Village 2-03,U.S. Senate,,R,Pat Roberts,169
-Johnson,Prairie Village 3-01,U.S. Senate,,R,Pat Roberts,162
-Johnson,Prairie Village 3-02,U.S. Senate,,R,Pat Roberts,224
-Johnson,Prairie Village 3-03,U.S. Senate,,R,Pat Roberts,193
-Johnson,Prairie Village 4-01,U.S. Senate,,R,Pat Roberts,327
-Johnson,Prairie Village 4-02,U.S. Senate,,R,Pat Roberts,164
-Johnson,Prairie Village 4-03,U.S. Senate,,R,Pat Roberts,255
-Johnson,Prairie Village 5-01,U.S. Senate,,R,Pat Roberts,251
-Johnson,Prairie Village 5-02,U.S. Senate,,R,Pat Roberts,314
-Johnson,Prairie Village 5-03,U.S. Senate,,R,Pat Roberts,255
-Johnson,Prairie Village 6-01,U.S. Senate,,R,Pat Roberts,264
-Johnson,Prairie Village 6-02,U.S. Senate,,R,Pat Roberts,168
-Johnson,Prairie Village 6-03,U.S. Senate,,R,Pat Roberts,128
-Johnson,Roeland Park 1-01,U.S. Senate,,R,Pat Roberts,76
-Johnson,Roeland Park 1-02,U.S. Senate,,R,Pat Roberts,53
-Johnson,Roeland Park 2-01,U.S. Senate,,R,Pat Roberts,84
-Johnson,Roeland Park 2-02,U.S. Senate,,R,Pat Roberts,140
-Johnson,Roeland Park 3-01,U.S. Senate,,R,Pat Roberts,47
-Johnson,Roeland Park 3-02,U.S. Senate,,R,Pat Roberts,127
-Johnson,Roeland Park 4-01,U.S. Senate,,R,Pat Roberts,79
-Johnson,Roeland Park 4-02,U.S. Senate,,R,Pat Roberts,229
-Johnson,Shawnee 1-01,U.S. Senate,,R,Pat Roberts,283
-Johnson,Shawnee 1-02,U.S. Senate,,R,Pat Roberts,220
-Johnson,Shawnee 1-03,U.S. Senate,,R,Pat Roberts,208
-Johnson,Shawnee 1-04,U.S. Senate,,R,Pat Roberts,402
-Johnson,Shawnee 1-05,U.S. Senate,,R,Pat Roberts,393
-Johnson,Shawnee 1-06,U.S. Senate,,R,Pat Roberts,363
-Johnson,Shawnee 1-07,U.S. Senate,,R,Pat Roberts,314
-Johnson,Shawnee 1-08,U.S. Senate,,R,Pat Roberts,349
-Johnson,Shawnee 1-09,U.S. Senate,,R,Pat Roberts,56
-Johnson,Shawnee 1-10,U.S. Senate,,R,Pat Roberts,126
-Johnson,Shawnee 1-11,U.S. Senate,,R,Pat Roberts,213
-Johnson,Shawnee 1-12,U.S. Senate,,R,Pat Roberts,3
-Johnson,Shawnee 2-01,U.S. Senate,,R,Pat Roberts,118
-Johnson,Shawnee 2-02,U.S. Senate,,R,Pat Roberts,252
-Johnson,Shawnee 2-03,U.S. Senate,,R,Pat Roberts,168
-Johnson,Shawnee 2-04,U.S. Senate,,R,Pat Roberts,269
-Johnson,Shawnee 2-05,U.S. Senate,,R,Pat Roberts,139
-Johnson,Shawnee 2-06,U.S. Senate,,R,Pat Roberts,235
-Johnson,Shawnee 2-07,U.S. Senate,,R,Pat Roberts,149
-Johnson,Shawnee 2-08,U.S. Senate,,R,Pat Roberts,163
-Johnson,Shawnee 2-09,U.S. Senate,,R,Pat Roberts,137
-Johnson,Shawnee 2-10,U.S. Senate,,R,Pat Roberts,141
-Johnson,Shawnee 2-11,U.S. Senate,,R,Pat Roberts,222
-Johnson,Shawnee 2-12,U.S. Senate,,R,Pat Roberts,45
-Johnson,Shawnee 2-13,U.S. Senate,,R,Pat Roberts,101
-Johnson,Shawnee 3-01,U.S. Senate,,R,Pat Roberts,242
-Johnson,Shawnee 3-02,U.S. Senate,,R,Pat Roberts,415
-Johnson,Shawnee 3-03,U.S. Senate,,R,Pat Roberts,279
-Johnson,Shawnee 3-04,U.S. Senate,,R,Pat Roberts,314
-Johnson,Shawnee 3-05,U.S. Senate,,R,Pat Roberts,475
-Johnson,Shawnee 3-06,U.S. Senate,,R,Pat Roberts,274
-Johnson,Shawnee 3-07,U.S. Senate,,R,Pat Roberts,387
-Johnson,Shawnee 3-08,U.S. Senate,,R,Pat Roberts,357
-Johnson,Shawnee 3-09,U.S. Senate,,R,Pat Roberts,232
-Johnson,Shawnee 4-01,U.S. Senate,,R,Pat Roberts,384
-Johnson,Shawnee 4-02,U.S. Senate,,R,Pat Roberts,222
-Johnson,Shawnee 4-03,U.S. Senate,,R,Pat Roberts,93
-Johnson,Shawnee 4-04,U.S. Senate,,R,Pat Roberts,71
-Johnson,Shawnee 4-05,U.S. Senate,,R,Pat Roberts,287
-Johnson,Shawnee 4-06,U.S. Senate,,R,Pat Roberts,277
-Johnson,Shawnee 4-07,U.S. Senate,,R,Pat Roberts,358
-Johnson,Shawnee 4-08,U.S. Senate,,R,Pat Roberts,160
-Johnson,Shawnee 4-09,U.S. Senate,,R,Pat Roberts,428
-Johnson,Shawnee 4-11,U.S. Senate,,R,Pat Roberts,205
-Johnson,Shawnee 4-12,U.S. Senate,,R,Pat Roberts,40
-Johnson,Spring Hill 0-01,U.S. Senate,,R,Pat Roberts,522
-Johnson,Spring Hill 0-03,U.S. Senate,,R,Pat Roberts,34
-Johnson,Spring Hill 0-04,U.S. Senate,,R,Pat Roberts,0
-Johnson,Spring Hill Twp 0-01,U.S. Senate,,R,Pat Roberts,407
-Johnson,Spring Hill Twp 0-02,U.S. Senate,,R,Pat Roberts,1
-Johnson,Spring Hill Twp 0-03,U.S. Senate,,R,Pat Roberts,43
-Johnson,Spring Hill Twp 0-04,U.S. Senate,,R,Pat Roberts,10
-Johnson,Spring Hill Twp 0-05,U.S. Senate,,R,Pat Roberts,1
-Johnson,Westwood 0-01,U.S. Senate,,R,Pat Roberts,92
-Johnson,Westwood 0-02,U.S. Senate,,R,Pat Roberts,120
-Johnson,Westwood Hills 0-01,U.S. Senate,,R,Pat Roberts,57
-Johnson,Aubry Twp 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Aubry Twp 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Aubry Twp 0-03,U.S. Senate,,,Write-ins,0
-Johnson,Aubry Twp 0-04,U.S. Senate,,,Write-ins,0
-Johnson,Aubry Twp 0-05,U.S. Senate,,,Write-ins,0
-Johnson,Aubry Twp 0-06,U.S. Senate,,,Write-ins,0
-Johnson,De Soto 0-01,U.S. Senate,,,Write-ins,2
-Johnson,De Soto 0-02,U.S. Senate,,,Write-ins,0
-Johnson,De Soto 0-03,U.S. Senate,,,Write-ins,0
-Johnson,De Soto 0-06,U.S. Senate,,,Write-ins,0
-Johnson,De Soto 0-07,U.S. Senate,,,Write-ins,0
-Johnson,Edgerton 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Edgerton 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Edgerton 0-05,U.S. Senate,,,Write-ins,0
-Johnson,Edgerton 0-06,U.S. Senate,,,Write-ins,0
-Johnson,Edgerton 0-09,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 1-01,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 1-02,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 2-01,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 3-02,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 4-01,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 4-02,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 4-03,U.S. Senate,,,Write-ins,0
-Johnson,Fairway 4-04,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-01,U.S. Senate,,,Write-ins,2
-Johnson,Gardner 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-03,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-04,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-06,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-07,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-08,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-09,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-10,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-12,U.S. Senate,,,Write-ins,0
-Johnson,Gardner 0-13,U.S. Senate,,,Write-ins,3
-Johnson,Gardner 0-14,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-01,U.S. Senate,,,Write-ins,1
-Johnson,Gardner Twp 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-04,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-05,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-07,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-08,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-09,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-10,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-11,U.S. Senate,,,Write-ins,0
-Johnson,Gardner Twp 0-13,U.S. Senate,,,Write-ins,0
-Johnson,Lake Quivira 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 1-01,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 1-02,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 1-03,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 1-04,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 1-05,U.S. Senate,,,Write-ins,3
-Johnson,Leawood 1-06,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 2-01,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 2-03,U.S. Senate,,,Write-ins,1
-Johnson,Leawood 2-04,U.S. Senate,,,Write-ins,1
-Johnson,Leawood 2-05,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 2-06,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 3-02,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 3-03,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 3-04,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 3-05,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 3-06,U.S. Senate,,,Write-ins,1
-Johnson,Leawood 3-07,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 4-01,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 4-02,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 4-03,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 4-04,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 4-05,U.S. Senate,,,Write-ins,1
-Johnson,Leawood 4-06,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 4-07,U.S. Senate,,,Write-ins,0
-Johnson,Leawood 4-08,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 1-01,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 1-02,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 1-03,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 1-04,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 1-05,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 1-06,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 1-07,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 1-08,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 1-09,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 2-01,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 2-03,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 2-04,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 2-05,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 2-06,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 2-07,U.S. Senate,,,Write-ins,2
-Johnson,Lenexa 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 3-02,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 3-03,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 3-04,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 3-05,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 3-06,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 3-07,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 3-08,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 4-01,U.S. Senate,,,Write-ins,3
-Johnson,Lenexa 4-02,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 4-03,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 4-04,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 4-05,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 4-06,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 4-07,U.S. Senate,,,Write-ins,1
-Johnson,Lenexa 4-08,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 4-09,U.S. Senate,,,Write-ins,0
-Johnson,Lenexa 4-10,U.S. Senate,,,Write-ins,2
-Johnson,Lenexa 4-11,U.S. Senate,,,Write-ins,0
-Johnson,Lexington Twp 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Lexington Twp 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Lexington Twp 0-03,U.S. Senate,,,Write-ins,0
-Johnson,McCamish Twp 0-01,U.S. Senate,,,Write-ins,0
-Johnson,McCamish Twp 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Merriam 1-01,U.S. Senate,,,Write-ins,1
-Johnson,Merriam 1-02,U.S. Senate,,,Write-ins,0
-Johnson,Merriam 2-01,U.S. Senate,,,Write-ins,0
-Johnson,Merriam 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Merriam 2-03,U.S. Senate,,,Write-ins,0
-Johnson,Merriam 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Merriam 3-02,U.S. Senate,,,Write-ins,0
-Johnson,Merriam 4-01,U.S. Senate,,,Write-ins,1
-Johnson,Merriam 4-02,U.S. Senate,,,Write-ins,1
-Johnson,Merriam 4-03,U.S. Senate,,,Write-ins,0
-Johnson,Mission 1-01,U.S. Senate,,,Write-ins,0
-Johnson,Mission 1-02,U.S. Senate,,,Write-ins,1
-Johnson,Mission 2-01,U.S. Senate,,,Write-ins,0
-Johnson,Mission 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Mission 3-01,U.S. Senate,,,Write-ins,2
-Johnson,Mission 3-02,U.S. Senate,,,Write-ins,0
-Johnson,Mission 4-01,U.S. Senate,,,Write-ins,0
-Johnson,Mission 4-02,U.S. Senate,,,Write-ins,0
-Johnson,Mission 4-03,U.S. Senate,,,Write-ins,0
-Johnson,Mission Hills 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Mission Hills 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Mission Hills 0-03,U.S. Senate,,,Write-ins,0
-Johnson,Mission Hills 0-04,U.S. Senate,,,Write-ins,2
-Johnson,Mission Woods 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-01,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-02,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-03,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-04,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-05,U.S. Senate,,,Write-ins,2
-Johnson,Olathe 1-06,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-08,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-09,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-11,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-14,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-15,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 1-16,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 1-17,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-18,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-19,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-20,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-21,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 1-22,U.S. Senate,,,Write-ins,2
-Johnson,Olathe 1-23,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-24,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-24,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 1-26,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 1-27,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-01,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-03,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-04,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-05,U.S. Senate,,,Write-ins,2
-Johnson,Olathe 2-06,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-07,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-08,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 2-09,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-10,U.S. Senate,,,Write-ins,2
-Johnson,Olathe 2-11,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-12,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 2-13,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-14,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-15,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 2-16,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-17,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-19,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-22,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 2-23,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-02,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-03,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-04,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-05,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 3-06,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-07,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 3-08,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-09,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-10,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-11,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-12,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-13,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 3-15,U.S. Senate,,,Write-ins,2
-Johnson,Olathe 3-16,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-17,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 3-18,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-19,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 3-20,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-21,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 3-22,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-23,U.S. Senate,,,Write-ins,2
-Johnson,Olathe 3-24,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 3-26,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-01,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-02,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 4-03,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-04,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-05,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 4-06,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 4-07,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-08,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-09,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 4-10,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-11,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 4-12,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-13,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-14,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-15,U.S. Senate,,,Write-ins,0
-Johnson,Olathe 4-16,U.S. Senate,,,Write-ins,1
-Johnson,Olathe 4-17,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-03,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-04,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-05,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-06,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-07,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-08,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-09,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-10,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-11,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-14,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-24,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-25,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-26,U.S. Senate,,,Write-ins,0
-Johnson,Olathe Twp 0-32,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-01,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-02,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-03,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-04,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-05,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-06,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-07,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-08,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 1-09,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-10,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-11,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-12,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-13,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-14,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-15,U.S. Senate,,,Write-ins,2
-Johnson,Overland Park 1-16,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-17,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-18,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 1-19,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-20,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 1-21,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 1-22,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-01,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-03,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-04,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-05,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-06,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 2-07,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-08,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-09,U.S. Senate,,,Write-ins,2
-Johnson,Overland Park 2-10,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-11,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 2-12,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-13,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 2-14,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-15,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-16,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 2-17,U.S. Senate,,,Write-ins,3
-Johnson,Overland Park 2-18,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-19,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-20,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-21,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-22,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-23,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-24,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-25,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 2-26,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-02,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-03,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-04,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-05,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-06,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-07,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 3-08,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-09,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-10,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-11,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 3-12,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-13,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-14,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-15,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-16,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-17,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 3-18,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-19,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 3-20,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 3-21,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-01,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-02,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-03,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 4-04,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-05,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-06,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-07,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-08,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-09,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-10,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-11,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-12,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-13,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-14,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-15,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-16,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 4-17,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 4-18,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-01,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 5-02,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-03,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-04,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-05,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-06,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 5-07,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-08,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-09,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 5-10,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-11,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 5-12,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 5-13,U.S. Senate,,,Write-ins,2
-Johnson,Overland Park 5-14,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-15,U.S. Senate,,,Write-ins,2
-Johnson,Overland Park 5-16,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-17,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-18,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 5-19,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-01,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 6-02,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-03,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-04,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-05,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-06,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-07,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-08,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-09,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-10,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-11,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-12,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-13,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 6-15,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 6-16,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-17,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-18,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-19,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-20,U.S. Senate,,,Write-ins,1
-Johnson,Overland Park 6-21,U.S. Senate,,,Write-ins,0
-Johnson,Overland Park 6-22,U.S. Senate,,,Write-ins,0
-Johnson,Oxford Twp 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Oxford Twp 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Oxford Twp 0-04,U.S. Senate,,,Write-ins,0
-Johnson,Oxford Twp 0-05,U.S. Senate,,,Write-ins,0
-Johnson,Oxford Twp 0-09,U.S. Senate,,,Write-ins,0
-Johnson,Oxford Twp 0-10,U.S. Senate,,,Write-ins,0
-Johnson,Oxford Twp 0-11,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 1-01,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 1-02,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 1-03,U.S. Senate,,,Write-ins,2
-Johnson,Prairie Village 2-01,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 2-03,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 3-02,U.S. Senate,,,Write-ins,2
-Johnson,Prairie Village 3-03,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 4-01,U.S. Senate,,,Write-ins,1
-Johnson,Prairie Village 4-02,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 4-03,U.S. Senate,,,Write-ins,1
-Johnson,Prairie Village 5-01,U.S. Senate,,,Write-ins,1
-Johnson,Prairie Village 5-02,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 5-03,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 6-01,U.S. Senate,,,Write-ins,1
-Johnson,Prairie Village 6-02,U.S. Senate,,,Write-ins,0
-Johnson,Prairie Village 6-03,U.S. Senate,,,Write-ins,0
-Johnson,Roeland Park 1-01,U.S. Senate,,,Write-ins,0
-Johnson,Roeland Park 1-02,U.S. Senate,,,Write-ins,0
-Johnson,Roeland Park 2-01,U.S. Senate,,,Write-ins,1
-Johnson,Roeland Park 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Roeland Park 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Roeland Park 3-02,U.S. Senate,,,Write-ins,0
-Johnson,Roeland Park 4-01,U.S. Senate,,,Write-ins,0
-Johnson,Roeland Park 4-02,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 1-01,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 1-02,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 1-03,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 1-04,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 1-05,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 1-06,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 1-07,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 1-08,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 1-09,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 1-10,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 1-11,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 1-12,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-01,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-02,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-03,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-04,U.S. Senate,,,Write-ins,2
-Johnson,Shawnee 2-05,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-06,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-07,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 2-08,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-09,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 2-10,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-11,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-12,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 2-13,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 3-01,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 3-02,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 3-03,U.S. Senate,,,Write-ins,2
-Johnson,Shawnee 3-04,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 3-05,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 3-06,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 3-07,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 3-08,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 3-09,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 4-01,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 4-02,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 4-03,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 4-04,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 4-05,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 4-06,U.S. Senate,,,Write-ins,2
-Johnson,Shawnee 4-07,U.S. Senate,,,Write-ins,1
-Johnson,Shawnee 4-08,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 4-09,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 4-11,U.S. Senate,,,Write-ins,0
-Johnson,Shawnee 4-12,U.S. Senate,,,Write-ins,0
-Johnson,Spring Hill 0-01,U.S. Senate,,,Write-ins,1
-Johnson,Spring Hill 0-03,U.S. Senate,,,Write-ins,0
-Johnson,Spring Hill 0-04,U.S. Senate,,,Write-ins,0
-Johnson,Spring Hill Twp 0-01,U.S. Senate,,,Write-ins,0
-Johnson,Spring Hill Twp 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Spring Hill Twp 0-03,U.S. Senate,,,Write-ins,0
-Johnson,Spring Hill Twp 0-04,U.S. Senate,,,Write-ins,0
-Johnson,Spring Hill Twp 0-05,U.S. Senate,,,Write-ins,0
-Johnson,Westwood 0-01,U.S. Senate,,,Write-ins,1
-Johnson,Westwood 0-02,U.S. Senate,,,Write-ins,0
-Johnson,Westwood Hills 0-01,U.S. Senate,,,Write-ins,1
-Johnson,Aubry Twp 0-01,U.S. House,3,D,Kelly Kultala,33
-Johnson,Aubry Twp 0-02,U.S. House,3,D,Kelly Kultala,127
-Johnson,Aubry Twp 0-03,U.S. House,3,D,Kelly Kultala,86
-Johnson,Aubry Twp 0-04,U.S. House,3,D,Kelly Kultala,195
-Johnson,Aubry Twp 0-05,U.S. House,3,D,Kelly Kultala,4
-Johnson,Aubry Twp 0-06,U.S. House,3,D,Kelly Kultala,18
-Johnson,De Soto 0-01,U.S. House,3,D,Kelly Kultala,179
-Johnson,De Soto 0-02,U.S. House,3,D,Kelly Kultala,145
-Johnson,De Soto 0-03,U.S. House,3,D,Kelly Kultala,189
-Johnson,De Soto 0-06,U.S. House,3,D,Kelly Kultala,16
-Johnson,De Soto 0-07,U.S. House,3,D,Kelly Kultala,0
-Johnson,Edgerton 0-01,U.S. House,3,D,Kelly Kultala,123
-Johnson,Edgerton 0-02,U.S. House,3,D,Kelly Kultala,0
-Johnson,Edgerton 0-05,U.S. House,3,D,Kelly Kultala,0
-Johnson,Edgerton 0-06,U.S. House,3,D,Kelly Kultala,0
-Johnson,Edgerton 0-09,U.S. House,3,D,Kelly Kultala,0
-Johnson,Fairway 1-01,U.S. House,3,D,Kelly Kultala,141
-Johnson,Fairway 1-02,U.S. House,3,D,Kelly Kultala,103
-Johnson,Fairway 2-01,U.S. House,3,D,Kelly Kultala,105
-Johnson,Fairway 2-02,U.S. House,3,D,Kelly Kultala,108
-Johnson,Fairway 3-01,U.S. House,3,D,Kelly Kultala,141
-Johnson,Fairway 3-02,U.S. House,3,D,Kelly Kultala,111
-Johnson,Fairway 4-01,U.S. House,3,D,Kelly Kultala,56
-Johnson,Fairway 4-02,U.S. House,3,D,Kelly Kultala,67
-Johnson,Fairway 4-03,U.S. House,3,D,Kelly Kultala,42
-Johnson,Fairway 4-04,U.S. House,3,D,Kelly Kultala,71
-Johnson,Gardner 0-01,U.S. House,3,D,Kelly Kultala,227
-Johnson,Gardner 0-02,U.S. House,3,D,Kelly Kultala,41
-Johnson,Gardner 0-03,U.S. House,3,D,Kelly Kultala,163
-Johnson,Gardner 0-04,U.S. House,3,D,Kelly Kultala,168
-Johnson,Gardner 0-06,U.S. House,3,D,Kelly Kultala,158
-Johnson,Gardner 0-07,U.S. House,3,D,Kelly Kultala,8
-Johnson,Gardner 0-08,U.S. House,3,D,Kelly Kultala,9
-Johnson,Gardner 0-09,U.S. House,3,D,Kelly Kultala,206
-Johnson,Gardner 0-10,U.S. House,3,D,Kelly Kultala,125
-Johnson,Gardner 0-12,U.S. House,3,D,Kelly Kultala,6
-Johnson,Gardner 0-13,U.S. House,3,D,Kelly Kultala,166
-Johnson,Gardner 0-14,U.S. House,3,D,Kelly Kultala,131
-Johnson,Gardner Twp 0-01,U.S. House,3,D,Kelly Kultala,83
-Johnson,Gardner Twp 0-02,U.S. House,3,D,Kelly Kultala,87
-Johnson,Gardner Twp 0-04,U.S. House,3,D,Kelly Kultala,0
-Johnson,Gardner Twp 0-05,U.S. House,3,D,Kelly Kultala,1
-Johnson,Gardner Twp 0-07,U.S. House,3,D,Kelly Kultala,2
-Johnson,Gardner Twp 0-08,U.S. House,3,D,Kelly Kultala,3
-Johnson,Gardner Twp 0-09,U.S. House,3,D,Kelly Kultala,0
-Johnson,Gardner Twp 0-10,U.S. House,3,D,Kelly Kultala,0
-Johnson,Gardner Twp 0-11,U.S. House,3,D,Kelly Kultala,32
-Johnson,Gardner Twp 0-13,U.S. House,3,D,Kelly Kultala,1
-Johnson,Lake Quivira 0-01,U.S. House,3,D,Kelly Kultala,173
-Johnson,Leawood 1-01,U.S. House,3,D,Kelly Kultala,251
-Johnson,Leawood 1-02,U.S. House,3,D,Kelly Kultala,326
-Johnson,Leawood 1-03,U.S. House,3,D,Kelly Kultala,266
-Johnson,Leawood 1-04,U.S. House,3,D,Kelly Kultala,223
-Johnson,Leawood 1-05,U.S. House,3,D,Kelly Kultala,178
-Johnson,Leawood 1-06,U.S. House,3,D,Kelly Kultala,61
-Johnson,Leawood 2-01,U.S. House,3,D,Kelly Kultala,259
-Johnson,Leawood 2-02,U.S. House,3,D,Kelly Kultala,293
-Johnson,Leawood 2-03,U.S. House,3,D,Kelly Kultala,284
-Johnson,Leawood 2-04,U.S. House,3,D,Kelly Kultala,171
-Johnson,Leawood 2-05,U.S. House,3,D,Kelly Kultala,151
-Johnson,Leawood 2-06,U.S. House,3,D,Kelly Kultala,103
-Johnson,Leawood 3-01,U.S. House,3,D,Kelly Kultala,171
-Johnson,Leawood 3-02,U.S. House,3,D,Kelly Kultala,263
-Johnson,Leawood 3-03,U.S. House,3,D,Kelly Kultala,138
-Johnson,Leawood 3-04,U.S. House,3,D,Kelly Kultala,72
-Johnson,Leawood 3-05,U.S. House,3,D,Kelly Kultala,241
-Johnson,Leawood 3-06,U.S. House,3,D,Kelly Kultala,208
-Johnson,Leawood 3-07,U.S. House,3,D,Kelly Kultala,203
-Johnson,Leawood 4-01,U.S. House,3,D,Kelly Kultala,61
-Johnson,Leawood 4-02,U.S. House,3,D,Kelly Kultala,191
-Johnson,Leawood 4-03,U.S. House,3,D,Kelly Kultala,213
-Johnson,Leawood 4-04,U.S. House,3,D,Kelly Kultala,235
-Johnson,Leawood 4-05,U.S. House,3,D,Kelly Kultala,220
-Johnson,Leawood 4-06,U.S. House,3,D,Kelly Kultala,103
-Johnson,Leawood 4-07,U.S. House,3,D,Kelly Kultala,227
-Johnson,Leawood 4-08,U.S. House,3,D,Kelly Kultala,106
-Johnson,Lenexa 1-01,U.S. House,3,D,Kelly Kultala,127
-Johnson,Lenexa 1-02,U.S. House,3,D,Kelly Kultala,302
-Johnson,Lenexa 1-03,U.S. House,3,D,Kelly Kultala,348
-Johnson,Lenexa 1-04,U.S. House,3,D,Kelly Kultala,236
-Johnson,Lenexa 1-05,U.S. House,3,D,Kelly Kultala,241
-Johnson,Lenexa 1-06,U.S. House,3,D,Kelly Kultala,234
-Johnson,Lenexa 1-07,U.S. House,3,D,Kelly Kultala,170
-Johnson,Lenexa 1-08,U.S. House,3,D,Kelly Kultala,74
-Johnson,Lenexa 1-09,U.S. House,3,D,Kelly Kultala,5
-Johnson,Lenexa 2-01,U.S. House,3,D,Kelly Kultala,296
-Johnson,Lenexa 2-02,U.S. House,3,D,Kelly Kultala,86
-Johnson,Lenexa 2-03,U.S. House,3,D,Kelly Kultala,217
-Johnson,Lenexa 2-04,U.S. House,3,D,Kelly Kultala,150
-Johnson,Lenexa 2-05,U.S. House,3,D,Kelly Kultala,237
-Johnson,Lenexa 2-06,U.S. House,3,D,Kelly Kultala,152
-Johnson,Lenexa 2-07,U.S. House,3,D,Kelly Kultala,303
-Johnson,Lenexa 3-01,U.S. House,3,D,Kelly Kultala,220
-Johnson,Lenexa 3-02,U.S. House,3,D,Kelly Kultala,379
-Johnson,Lenexa 3-03,U.S. House,3,D,Kelly Kultala,353
-Johnson,Lenexa 3-04,U.S. House,3,D,Kelly Kultala,201
-Johnson,Lenexa 3-05,U.S. House,3,D,Kelly Kultala,169
-Johnson,Lenexa 3-06,U.S. House,3,D,Kelly Kultala,221
-Johnson,Lenexa 3-07,U.S. House,3,D,Kelly Kultala,263
-Johnson,Lenexa 3-08,U.S. House,3,D,Kelly Kultala,254
-Johnson,Lenexa 4-01,U.S. House,3,D,Kelly Kultala,135
-Johnson,Lenexa 4-02,U.S. House,3,D,Kelly Kultala,231
-Johnson,Lenexa 4-03,U.S. House,3,D,Kelly Kultala,119
-Johnson,Lenexa 4-04,U.S. House,3,D,Kelly Kultala,109
-Johnson,Lenexa 4-05,U.S. House,3,D,Kelly Kultala,113
-Johnson,Lenexa 4-06,U.S. House,3,D,Kelly Kultala,158
-Johnson,Lenexa 4-07,U.S. House,3,D,Kelly Kultala,210
-Johnson,Lenexa 4-08,U.S. House,3,D,Kelly Kultala,271
-Johnson,Lenexa 4-09,U.S. House,3,D,Kelly Kultala,197
-Johnson,Lenexa 4-10,U.S. House,3,D,Kelly Kultala,105
-Johnson,Lenexa 4-11,U.S. House,3,D,Kelly Kultala,37
-Johnson,Lexington Twp 0-01,U.S. House,3,D,Kelly Kultala,159
-Johnson,Lexington Twp 0-02,U.S. House,3,D,Kelly Kultala,2
-Johnson,Lexington Twp 0-03,U.S. House,3,D,Kelly Kultala,1
-Johnson,McCamish Twp 0-01,U.S. House,3,D,Kelly Kultala,29
-Johnson,McCamish Twp 0-02,U.S. House,3,D,Kelly Kultala,63
-Johnson,Merriam 1-01,U.S. House,3,D,Kelly Kultala,157
-Johnson,Merriam 1-02,U.S. House,3,D,Kelly Kultala,199
-Johnson,Merriam 2-01,U.S. House,3,D,Kelly Kultala,239
-Johnson,Merriam 2-02,U.S. House,3,D,Kelly Kultala,1
-Johnson,Merriam 2-03,U.S. House,3,D,Kelly Kultala,130
-Johnson,Merriam 3-01,U.S. House,3,D,Kelly Kultala,223
-Johnson,Merriam 3-02,U.S. House,3,D,Kelly Kultala,200
-Johnson,Merriam 4-01,U.S. House,3,D,Kelly Kultala,255
-Johnson,Merriam 4-02,U.S. House,3,D,Kelly Kultala,122
-Johnson,Merriam 4-03,U.S. House,3,D,Kelly Kultala,177
-Johnson,Mission 1-01,U.S. House,3,D,Kelly Kultala,241
-Johnson,Mission 1-02,U.S. House,3,D,Kelly Kultala,154
-Johnson,Mission 2-01,U.S. House,3,D,Kelly Kultala,169
-Johnson,Mission 2-02,U.S. House,3,D,Kelly Kultala,238
-Johnson,Mission 3-01,U.S. House,3,D,Kelly Kultala,221
-Johnson,Mission 3-02,U.S. House,3,D,Kelly Kultala,136
-Johnson,Mission 4-01,U.S. House,3,D,Kelly Kultala,188
-Johnson,Mission 4-02,U.S. House,3,D,Kelly Kultala,249
-Johnson,Mission 4-03,U.S. House,3,D,Kelly Kultala,122
-Johnson,Mission Hills 0-01,U.S. House,3,D,Kelly Kultala,126
-Johnson,Mission Hills 0-02,U.S. House,3,D,Kelly Kultala,189
-Johnson,Mission Hills 0-03,U.S. House,3,D,Kelly Kultala,95
-Johnson,Mission Hills 0-04,U.S. House,3,D,Kelly Kultala,206
-Johnson,Mission Woods 0-01,U.S. House,3,D,Kelly Kultala,47
-Johnson,Olathe 1-01,U.S. House,3,D,Kelly Kultala,179
-Johnson,Olathe 1-02,U.S. House,3,D,Kelly Kultala,145
-Johnson,Olathe 1-03,U.S. House,3,D,Kelly Kultala,105
-Johnson,Olathe 1-04,U.S. House,3,D,Kelly Kultala,174
-Johnson,Olathe 1-05,U.S. House,3,D,Kelly Kultala,200
-Johnson,Olathe 1-06,U.S. House,3,D,Kelly Kultala,102
-Johnson,Olathe 1-08,U.S. House,3,D,Kelly Kultala,219
-Johnson,Olathe 1-09,U.S. House,3,D,Kelly Kultala,164
-Johnson,Olathe 1-11,U.S. House,3,D,Kelly Kultala,39
-Johnson,Olathe 1-14,U.S. House,3,D,Kelly Kultala,163
-Johnson,Olathe 1-15,U.S. House,3,D,Kelly Kultala,168
-Johnson,Olathe 1-16,U.S. House,3,D,Kelly Kultala,182
-Johnson,Olathe 1-17,U.S. House,3,D,Kelly Kultala,41
-Johnson,Olathe 1-18,U.S. House,3,D,Kelly Kultala,52
-Johnson,Olathe 1-19,U.S. House,3,D,Kelly Kultala,89
-Johnson,Olathe 1-20,U.S. House,3,D,Kelly Kultala,164
-Johnson,Olathe 1-21,U.S. House,3,D,Kelly Kultala,214
-Johnson,Olathe 1-22,U.S. House,3,D,Kelly Kultala,252
-Johnson,Olathe 1-23,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe 1-24,U.S. House,3,D,Kelly Kultala,18
-Johnson,Olathe 1-24,U.S. House,3,D,Kelly Kultala,56
-Johnson,Olathe 1-26,U.S. House,3,D,Kelly Kultala,2
-Johnson,Olathe 1-27,U.S. House,3,D,Kelly Kultala,159
-Johnson,Olathe 2-01,U.S. House,3,D,Kelly Kultala,73
-Johnson,Olathe 2-02,U.S. House,3,D,Kelly Kultala,134
-Johnson,Olathe 2-03,U.S. House,3,D,Kelly Kultala,137
-Johnson,Olathe 2-04,U.S. House,3,D,Kelly Kultala,174
-Johnson,Olathe 2-05,U.S. House,3,D,Kelly Kultala,332
-Johnson,Olathe 2-06,U.S. House,3,D,Kelly Kultala,155
-Johnson,Olathe 2-07,U.S. House,3,D,Kelly Kultala,253
-Johnson,Olathe 2-08,U.S. House,3,D,Kelly Kultala,192
-Johnson,Olathe 2-09,U.S. House,3,D,Kelly Kultala,88
-Johnson,Olathe 2-10,U.S. House,3,D,Kelly Kultala,374
-Johnson,Olathe 2-11,U.S. House,3,D,Kelly Kultala,259
-Johnson,Olathe 2-12,U.S. House,3,D,Kelly Kultala,149
-Johnson,Olathe 2-13,U.S. House,3,D,Kelly Kultala,174
-Johnson,Olathe 2-14,U.S. House,3,D,Kelly Kultala,134
-Johnson,Olathe 2-15,U.S. House,3,D,Kelly Kultala,121
-Johnson,Olathe 2-16,U.S. House,3,D,Kelly Kultala,72
-Johnson,Olathe 2-17,U.S. House,3,D,Kelly Kultala,1
-Johnson,Olathe 2-19,U.S. House,3,D,Kelly Kultala,2
-Johnson,Olathe 2-22,U.S. House,3,D,Kelly Kultala,311
-Johnson,Olathe 2-23,U.S. House,3,D,Kelly Kultala,190
-Johnson,Olathe 3-01,U.S. House,3,D,Kelly Kultala,91
-Johnson,Olathe 3-02,U.S. House,3,D,Kelly Kultala,238
-Johnson,Olathe 3-03,U.S. House,3,D,Kelly Kultala,101
-Johnson,Olathe 3-04,U.S. House,3,D,Kelly Kultala,175
-Johnson,Olathe 3-05,U.S. House,3,D,Kelly Kultala,172
-Johnson,Olathe 3-06,U.S. House,3,D,Kelly Kultala,126
-Johnson,Olathe 3-07,U.S. House,3,D,Kelly Kultala,154
-Johnson,Olathe 3-08,U.S. House,3,D,Kelly Kultala,206
-Johnson,Olathe 3-09,U.S. House,3,D,Kelly Kultala,84
-Johnson,Olathe 3-10,U.S. House,3,D,Kelly Kultala,188
-Johnson,Olathe 3-11,U.S. House,3,D,Kelly Kultala,129
-Johnson,Olathe 3-12,U.S. House,3,D,Kelly Kultala,189
-Johnson,Olathe 3-13,U.S. House,3,D,Kelly Kultala,200
-Johnson,Olathe 3-15,U.S. House,3,D,Kelly Kultala,136
-Johnson,Olathe 3-16,U.S. House,3,D,Kelly Kultala,146
-Johnson,Olathe 3-17,U.S. House,3,D,Kelly Kultala,188
-Johnson,Olathe 3-18,U.S. House,3,D,Kelly Kultala,173
-Johnson,Olathe 3-19,U.S. House,3,D,Kelly Kultala,81
-Johnson,Olathe 3-20,U.S. House,3,D,Kelly Kultala,113
-Johnson,Olathe 3-21,U.S. House,3,D,Kelly Kultala,84
-Johnson,Olathe 3-22,U.S. House,3,D,Kelly Kultala,176
-Johnson,Olathe 3-23,U.S. House,3,D,Kelly Kultala,166
-Johnson,Olathe 3-24,U.S. House,3,D,Kelly Kultala,89
-Johnson,Olathe 3-26,U.S. House,3,D,Kelly Kultala,21
-Johnson,Olathe 4-01,U.S. House,3,D,Kelly Kultala,163
-Johnson,Olathe 4-02,U.S. House,3,D,Kelly Kultala,314
-Johnson,Olathe 4-03,U.S. House,3,D,Kelly Kultala,115
-Johnson,Olathe 4-04,U.S. House,3,D,Kelly Kultala,126
-Johnson,Olathe 4-05,U.S. House,3,D,Kelly Kultala,226
-Johnson,Olathe 4-06,U.S. House,3,D,Kelly Kultala,272
-Johnson,Olathe 4-07,U.S. House,3,D,Kelly Kultala,241
-Johnson,Olathe 4-08,U.S. House,3,D,Kelly Kultala,167
-Johnson,Olathe 4-09,U.S. House,3,D,Kelly Kultala,265
-Johnson,Olathe 4-10,U.S. House,3,D,Kelly Kultala,142
-Johnson,Olathe 4-11,U.S. House,3,D,Kelly Kultala,108
-Johnson,Olathe 4-12,U.S. House,3,D,Kelly Kultala,207
-Johnson,Olathe 4-13,U.S. House,3,D,Kelly Kultala,121
-Johnson,Olathe 4-14,U.S. House,3,D,Kelly Kultala,253
-Johnson,Olathe 4-15,U.S. House,3,D,Kelly Kultala,15
-Johnson,Olathe 4-16,U.S. House,3,D,Kelly Kultala,92
-Johnson,Olathe 4-17,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe Twp 0-01,U.S. House,3,D,Kelly Kultala,92
-Johnson,Olathe Twp 0-02,U.S. House,3,D,Kelly Kultala,10
-Johnson,Olathe Twp 0-03,U.S. House,3,D,Kelly Kultala,16
-Johnson,Olathe Twp 0-04,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe Twp 0-05,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe Twp 0-06,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe Twp 0-07,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe Twp 0-08,U.S. House,3,D,Kelly Kultala,2
-Johnson,Olathe Twp 0-09,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe Twp 0-10,U.S. House,3,D,Kelly Kultala,4
-Johnson,Olathe Twp 0-11,U.S. House,3,D,Kelly Kultala,1
-Johnson,Olathe Twp 0-14,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe Twp 0-24,U.S. House,3,D,Kelly Kultala,1
-Johnson,Olathe Twp 0-25,U.S. House,3,D,Kelly Kultala,1
-Johnson,Olathe Twp 0-26,U.S. House,3,D,Kelly Kultala,0
-Johnson,Olathe Twp 0-32,U.S. House,3,D,Kelly Kultala,4
-Johnson,Overland Park 1-01,U.S. House,3,D,Kelly Kultala,241
-Johnson,Overland Park 1-02,U.S. House,3,D,Kelly Kultala,267
-Johnson,Overland Park 1-03,U.S. House,3,D,Kelly Kultala,225
-Johnson,Overland Park 1-04,U.S. House,3,D,Kelly Kultala,71
-Johnson,Overland Park 1-05,U.S. House,3,D,Kelly Kultala,170
-Johnson,Overland Park 1-06,U.S. House,3,D,Kelly Kultala,327
-Johnson,Overland Park 1-07,U.S. House,3,D,Kelly Kultala,262
-Johnson,Overland Park 1-08,U.S. House,3,D,Kelly Kultala,194
-Johnson,Overland Park 1-09,U.S. House,3,D,Kelly Kultala,125
-Johnson,Overland Park 1-10,U.S. House,3,D,Kelly Kultala,243
-Johnson,Overland Park 1-11,U.S. House,3,D,Kelly Kultala,70
-Johnson,Overland Park 1-12,U.S. House,3,D,Kelly Kultala,213
-Johnson,Overland Park 1-13,U.S. House,3,D,Kelly Kultala,154
-Johnson,Overland Park 1-14,U.S. House,3,D,Kelly Kultala,264
-Johnson,Overland Park 1-15,U.S. House,3,D,Kelly Kultala,123
-Johnson,Overland Park 1-16,U.S. House,3,D,Kelly Kultala,322
-Johnson,Overland Park 1-17,U.S. House,3,D,Kelly Kultala,106
-Johnson,Overland Park 1-18,U.S. House,3,D,Kelly Kultala,244
-Johnson,Overland Park 1-19,U.S. House,3,D,Kelly Kultala,177
-Johnson,Overland Park 1-20,U.S. House,3,D,Kelly Kultala,158
-Johnson,Overland Park 1-21,U.S. House,3,D,Kelly Kultala,57
-Johnson,Overland Park 1-22,U.S. House,3,D,Kelly Kultala,58
-Johnson,Overland Park 2-01,U.S. House,3,D,Kelly Kultala,158
-Johnson,Overland Park 2-02,U.S. House,3,D,Kelly Kultala,255
-Johnson,Overland Park 2-03,U.S. House,3,D,Kelly Kultala,204
-Johnson,Overland Park 2-04,U.S. House,3,D,Kelly Kultala,226
-Johnson,Overland Park 2-05,U.S. House,3,D,Kelly Kultala,208
-Johnson,Overland Park 2-06,U.S. House,3,D,Kelly Kultala,189
-Johnson,Overland Park 2-07,U.S. House,3,D,Kelly Kultala,168
-Johnson,Overland Park 2-08,U.S. House,3,D,Kelly Kultala,134
-Johnson,Overland Park 2-09,U.S. House,3,D,Kelly Kultala,165
-Johnson,Overland Park 2-10,U.S. House,3,D,Kelly Kultala,82
-Johnson,Overland Park 2-11,U.S. House,3,D,Kelly Kultala,201
-Johnson,Overland Park 2-12,U.S. House,3,D,Kelly Kultala,139
-Johnson,Overland Park 2-13,U.S. House,3,D,Kelly Kultala,93
-Johnson,Overland Park 2-14,U.S. House,3,D,Kelly Kultala,167
-Johnson,Overland Park 2-15,U.S. House,3,D,Kelly Kultala,294
-Johnson,Overland Park 2-16,U.S. House,3,D,Kelly Kultala,180
-Johnson,Overland Park 2-17,U.S. House,3,D,Kelly Kultala,234
-Johnson,Overland Park 2-18,U.S. House,3,D,Kelly Kultala,270
-Johnson,Overland Park 2-19,U.S. House,3,D,Kelly Kultala,178
-Johnson,Overland Park 2-20,U.S. House,3,D,Kelly Kultala,150
-Johnson,Overland Park 2-21,U.S. House,3,D,Kelly Kultala,191
-Johnson,Overland Park 2-22,U.S. House,3,D,Kelly Kultala,207
-Johnson,Overland Park 2-23,U.S. House,3,D,Kelly Kultala,156
-Johnson,Overland Park 2-24,U.S. House,3,D,Kelly Kultala,284
-Johnson,Overland Park 2-25,U.S. House,3,D,Kelly Kultala,248
-Johnson,Overland Park 2-26,U.S. House,3,D,Kelly Kultala,100
-Johnson,Overland Park 3-01,U.S. House,3,D,Kelly Kultala,261
-Johnson,Overland Park 3-02,U.S. House,3,D,Kelly Kultala,214
-Johnson,Overland Park 3-03,U.S. House,3,D,Kelly Kultala,180
-Johnson,Overland Park 3-04,U.S. House,3,D,Kelly Kultala,264
-Johnson,Overland Park 3-05,U.S. House,3,D,Kelly Kultala,229
-Johnson,Overland Park 3-06,U.S. House,3,D,Kelly Kultala,276
-Johnson,Overland Park 3-07,U.S. House,3,D,Kelly Kultala,199
-Johnson,Overland Park 3-08,U.S. House,3,D,Kelly Kultala,205
-Johnson,Overland Park 3-09,U.S. House,3,D,Kelly Kultala,314
-Johnson,Overland Park 3-10,U.S. House,3,D,Kelly Kultala,153
-Johnson,Overland Park 3-11,U.S. House,3,D,Kelly Kultala,163
-Johnson,Overland Park 3-12,U.S. House,3,D,Kelly Kultala,163
-Johnson,Overland Park 3-13,U.S. House,3,D,Kelly Kultala,313
-Johnson,Overland Park 3-14,U.S. House,3,D,Kelly Kultala,258
-Johnson,Overland Park 3-15,U.S. House,3,D,Kelly Kultala,124
-Johnson,Overland Park 3-16,U.S. House,3,D,Kelly Kultala,221
-Johnson,Overland Park 3-17,U.S. House,3,D,Kelly Kultala,200
-Johnson,Overland Park 3-18,U.S. House,3,D,Kelly Kultala,196
-Johnson,Overland Park 3-19,U.S. House,3,D,Kelly Kultala,195
-Johnson,Overland Park 3-20,U.S. House,3,D,Kelly Kultala,258
-Johnson,Overland Park 3-21,U.S. House,3,D,Kelly Kultala,193
-Johnson,Overland Park 4-01,U.S. House,3,D,Kelly Kultala,109
-Johnson,Overland Park 4-02,U.S. House,3,D,Kelly Kultala,146
-Johnson,Overland Park 4-03,U.S. House,3,D,Kelly Kultala,170
-Johnson,Overland Park 4-04,U.S. House,3,D,Kelly Kultala,246
-Johnson,Overland Park 4-05,U.S. House,3,D,Kelly Kultala,192
-Johnson,Overland Park 4-06,U.S. House,3,D,Kelly Kultala,175
-Johnson,Overland Park 4-07,U.S. House,3,D,Kelly Kultala,162
-Johnson,Overland Park 4-08,U.S. House,3,D,Kelly Kultala,201
-Johnson,Overland Park 4-09,U.S. House,3,D,Kelly Kultala,129
-Johnson,Overland Park 4-10,U.S. House,3,D,Kelly Kultala,120
-Johnson,Overland Park 4-11,U.S. House,3,D,Kelly Kultala,239
-Johnson,Overland Park 4-12,U.S. House,3,D,Kelly Kultala,317
-Johnson,Overland Park 4-13,U.S. House,3,D,Kelly Kultala,93
-Johnson,Overland Park 4-14,U.S. House,3,D,Kelly Kultala,101
-Johnson,Overland Park 4-15,U.S. House,3,D,Kelly Kultala,258
-Johnson,Overland Park 4-16,U.S. House,3,D,Kelly Kultala,147
-Johnson,Overland Park 4-17,U.S. House,3,D,Kelly Kultala,226
-Johnson,Overland Park 4-18,U.S. House,3,D,Kelly Kultala,40
-Johnson,Overland Park 5-01,U.S. House,3,D,Kelly Kultala,233
-Johnson,Overland Park 5-02,U.S. House,3,D,Kelly Kultala,119
-Johnson,Overland Park 5-03,U.S. House,3,D,Kelly Kultala,187
-Johnson,Overland Park 5-04,U.S. House,3,D,Kelly Kultala,209
-Johnson,Overland Park 5-05,U.S. House,3,D,Kelly Kultala,198
-Johnson,Overland Park 5-06,U.S. House,3,D,Kelly Kultala,167
-Johnson,Overland Park 5-07,U.S. House,3,D,Kelly Kultala,161
-Johnson,Overland Park 5-08,U.S. House,3,D,Kelly Kultala,250
-Johnson,Overland Park 5-09,U.S. House,3,D,Kelly Kultala,300
-Johnson,Overland Park 5-10,U.S. House,3,D,Kelly Kultala,215
-Johnson,Overland Park 5-11,U.S. House,3,D,Kelly Kultala,280
-Johnson,Overland Park 5-12,U.S. House,3,D,Kelly Kultala,59
-Johnson,Overland Park 5-13,U.S. House,3,D,Kelly Kultala,336
-Johnson,Overland Park 5-14,U.S. House,3,D,Kelly Kultala,234
-Johnson,Overland Park 5-15,U.S. House,3,D,Kelly Kultala,181
-Johnson,Overland Park 5-16,U.S. House,3,D,Kelly Kultala,131
-Johnson,Overland Park 5-17,U.S. House,3,D,Kelly Kultala,88
-Johnson,Overland Park 5-18,U.S. House,3,D,Kelly Kultala,178
-Johnson,Overland Park 5-19,U.S. House,3,D,Kelly Kultala,12
-Johnson,Overland Park 6-01,U.S. House,3,D,Kelly Kultala,199
-Johnson,Overland Park 6-02,U.S. House,3,D,Kelly Kultala,151
-Johnson,Overland Park 6-03,U.S. House,3,D,Kelly Kultala,170
-Johnson,Overland Park 6-04,U.S. House,3,D,Kelly Kultala,153
-Johnson,Overland Park 6-05,U.S. House,3,D,Kelly Kultala,238
-Johnson,Overland Park 6-06,U.S. House,3,D,Kelly Kultala,0
-Johnson,Overland Park 6-07,U.S. House,3,D,Kelly Kultala,36
-Johnson,Overland Park 6-08,U.S. House,3,D,Kelly Kultala,200
-Johnson,Overland Park 6-09,U.S. House,3,D,Kelly Kultala,246
-Johnson,Overland Park 6-10,U.S. House,3,D,Kelly Kultala,159
-Johnson,Overland Park 6-11,U.S. House,3,D,Kelly Kultala,182
-Johnson,Overland Park 6-12,U.S. House,3,D,Kelly Kultala,81
-Johnson,Overland Park 6-13,U.S. House,3,D,Kelly Kultala,215
-Johnson,Overland Park 6-15,U.S. House,3,D,Kelly Kultala,182
-Johnson,Overland Park 6-16,U.S. House,3,D,Kelly Kultala,102
-Johnson,Overland Park 6-17,U.S. House,3,D,Kelly Kultala,35
-Johnson,Overland Park 6-18,U.S. House,3,D,Kelly Kultala,0
-Johnson,Overland Park 6-19,U.S. House,3,D,Kelly Kultala,252
-Johnson,Overland Park 6-20,U.S. House,3,D,Kelly Kultala,59
-Johnson,Overland Park 6-21,U.S. House,3,D,Kelly Kultala,183
-Johnson,Overland Park 6-22,U.S. House,3,D,Kelly Kultala,92
-Johnson,Oxford Twp 0-01,U.S. House,3,D,Kelly Kultala,2
-Johnson,Oxford Twp 0-02,U.S. House,3,D,Kelly Kultala,120
-Johnson,Oxford Twp 0-04,U.S. House,3,D,Kelly Kultala,113
-Johnson,Oxford Twp 0-05,U.S. House,3,D,Kelly Kultala,0
-Johnson,Oxford Twp 0-09,U.S. House,3,D,Kelly Kultala,4
-Johnson,Oxford Twp 0-10,U.S. House,3,D,Kelly Kultala,0
-Johnson,Oxford Twp 0-11,U.S. House,3,D,Kelly Kultala,17
-Johnson,Prairie Village 1-01,U.S. House,3,D,Kelly Kultala,363
-Johnson,Prairie Village 1-02,U.S. House,3,D,Kelly Kultala,266
-Johnson,Prairie Village 1-03,U.S. House,3,D,Kelly Kultala,365
-Johnson,Prairie Village 2-01,U.S. House,3,D,Kelly Kultala,300
-Johnson,Prairie Village 2-02,U.S. House,3,D,Kelly Kultala,120
-Johnson,Prairie Village 2-03,U.S. House,3,D,Kelly Kultala,261
-Johnson,Prairie Village 3-01,U.S. House,3,D,Kelly Kultala,189
-Johnson,Prairie Village 3-02,U.S. House,3,D,Kelly Kultala,289
-Johnson,Prairie Village 3-03,U.S. House,3,D,Kelly Kultala,280
-Johnson,Prairie Village 4-01,U.S. House,3,D,Kelly Kultala,280
-Johnson,Prairie Village 4-02,U.S. House,3,D,Kelly Kultala,206
-Johnson,Prairie Village 4-03,U.S. House,3,D,Kelly Kultala,321
-Johnson,Prairie Village 5-01,U.S. House,3,D,Kelly Kultala,305
-Johnson,Prairie Village 5-02,U.S. House,3,D,Kelly Kultala,278
-Johnson,Prairie Village 5-03,U.S. House,3,D,Kelly Kultala,221
-Johnson,Prairie Village 6-01,U.S. House,3,D,Kelly Kultala,318
-Johnson,Prairie Village 6-02,U.S. House,3,D,Kelly Kultala,309
-Johnson,Prairie Village 6-03,U.S. House,3,D,Kelly Kultala,174
-Johnson,Roeland Park 1-01,U.S. House,3,D,Kelly Kultala,138
-Johnson,Roeland Park 1-02,U.S. House,3,D,Kelly Kultala,122
-Johnson,Roeland Park 2-01,U.S. House,3,D,Kelly Kultala,156
-Johnson,Roeland Park 2-02,U.S. House,3,D,Kelly Kultala,193
-Johnson,Roeland Park 3-01,U.S. House,3,D,Kelly Kultala,150
-Johnson,Roeland Park 3-02,U.S. House,3,D,Kelly Kultala,259
-Johnson,Roeland Park 4-01,U.S. House,3,D,Kelly Kultala,106
-Johnson,Roeland Park 4-02,U.S. House,3,D,Kelly Kultala,331
-Johnson,Shawnee 1-01,U.S. House,3,D,Kelly Kultala,275
-Johnson,Shawnee 1-02,U.S. House,3,D,Kelly Kultala,194
-Johnson,Shawnee 1-03,U.S. House,3,D,Kelly Kultala,185
-Johnson,Shawnee 1-04,U.S. House,3,D,Kelly Kultala,256
-Johnson,Shawnee 1-05,U.S. House,3,D,Kelly Kultala,320
-Johnson,Shawnee 1-06,U.S. House,3,D,Kelly Kultala,221
-Johnson,Shawnee 1-07,U.S. House,3,D,Kelly Kultala,256
-Johnson,Shawnee 1-08,U.S. House,3,D,Kelly Kultala,222
-Johnson,Shawnee 1-09,U.S. House,3,D,Kelly Kultala,40
-Johnson,Shawnee 1-10,U.S. House,3,D,Kelly Kultala,71
-Johnson,Shawnee 1-11,U.S. House,3,D,Kelly Kultala,149
-Johnson,Shawnee 1-12,U.S. House,3,D,Kelly Kultala,3
-Johnson,Shawnee 2-01,U.S. House,3,D,Kelly Kultala,105
-Johnson,Shawnee 2-02,U.S. House,3,D,Kelly Kultala,216
-Johnson,Shawnee 2-03,U.S. House,3,D,Kelly Kultala,182
-Johnson,Shawnee 2-04,U.S. House,3,D,Kelly Kultala,279
-Johnson,Shawnee 2-05,U.S. House,3,D,Kelly Kultala,115
-Johnson,Shawnee 2-06,U.S. House,3,D,Kelly Kultala,158
-Johnson,Shawnee 2-07,U.S. House,3,D,Kelly Kultala,151
-Johnson,Shawnee 2-08,U.S. House,3,D,Kelly Kultala,131
-Johnson,Shawnee 2-09,U.S. House,3,D,Kelly Kultala,143
-Johnson,Shawnee 2-10,U.S. House,3,D,Kelly Kultala,122
-Johnson,Shawnee 2-11,U.S. House,3,D,Kelly Kultala,195
-Johnson,Shawnee 2-12,U.S. House,3,D,Kelly Kultala,71
-Johnson,Shawnee 2-13,U.S. House,3,D,Kelly Kultala,104
-Johnson,Shawnee 3-01,U.S. House,3,D,Kelly Kultala,129
-Johnson,Shawnee 3-02,U.S. House,3,D,Kelly Kultala,234
-Johnson,Shawnee 3-03,U.S. House,3,D,Kelly Kultala,221
-Johnson,Shawnee 3-04,U.S. House,3,D,Kelly Kultala,163
-Johnson,Shawnee 3-05,U.S. House,3,D,Kelly Kultala,214
-Johnson,Shawnee 3-06,U.S. House,3,D,Kelly Kultala,213
-Johnson,Shawnee 3-07,U.S. House,3,D,Kelly Kultala,217
-Johnson,Shawnee 3-08,U.S. House,3,D,Kelly Kultala,225
-Johnson,Shawnee 3-09,U.S. House,3,D,Kelly Kultala,103
-Johnson,Shawnee 4-01,U.S. House,3,D,Kelly Kultala,302
-Johnson,Shawnee 4-02,U.S. House,3,D,Kelly Kultala,156
-Johnson,Shawnee 4-03,U.S. House,3,D,Kelly Kultala,60
-Johnson,Shawnee 4-04,U.S. House,3,D,Kelly Kultala,106
-Johnson,Shawnee 4-05,U.S. House,3,D,Kelly Kultala,255
-Johnson,Shawnee 4-06,U.S. House,3,D,Kelly Kultala,192
-Johnson,Shawnee 4-07,U.S. House,3,D,Kelly Kultala,252
-Johnson,Shawnee 4-08,U.S. House,3,D,Kelly Kultala,111
-Johnson,Shawnee 4-09,U.S. House,3,D,Kelly Kultala,346
-Johnson,Shawnee 4-11,U.S. House,3,D,Kelly Kultala,184
-Johnson,Shawnee 4-12,U.S. House,3,D,Kelly Kultala,36
-Johnson,Spring Hill 0-01,U.S. House,3,D,Kelly Kultala,252
-Johnson,Spring Hill 0-03,U.S. House,3,D,Kelly Kultala,22
-Johnson,Spring Hill 0-04,U.S. House,3,D,Kelly Kultala,0
-Johnson,Spring Hill Twp 0-01,U.S. House,3,D,Kelly Kultala,195
-Johnson,Spring Hill Twp 0-02,U.S. House,3,D,Kelly Kultala,0
-Johnson,Spring Hill Twp 0-03,U.S. House,3,D,Kelly Kultala,16
-Johnson,Spring Hill Twp 0-04,U.S. House,3,D,Kelly Kultala,2
-Johnson,Spring Hill Twp 0-05,U.S. House,3,D,Kelly Kultala,4
-Johnson,Westwood 0-01,U.S. House,3,D,Kelly Kultala,205
-Johnson,Westwood 0-02,U.S. House,3,D,Kelly Kultala,189
-Johnson,Westwood Hills 0-01,U.S. House,3,D,Kelly Kultala,118
-Johnson,Aubry Twp 0-01,U.S. House,3,R,Kevin Yoder,77
-Johnson,Aubry Twp 0-02,U.S. House,3,R,Kevin Yoder,452
-Johnson,Aubry Twp 0-03,U.S. House,3,R,Kevin Yoder,238
-Johnson,Aubry Twp 0-04,U.S. House,3,R,Kevin Yoder,534
-Johnson,Aubry Twp 0-05,U.S. House,3,R,Kevin Yoder,10
-Johnson,Aubry Twp 0-06,U.S. House,3,R,Kevin Yoder,70
-Johnson,De Soto 0-01,U.S. House,3,R,Kevin Yoder,457
-Johnson,De Soto 0-02,U.S. House,3,R,Kevin Yoder,242
-Johnson,De Soto 0-03,U.S. House,3,R,Kevin Yoder,448
-Johnson,De Soto 0-06,U.S. House,3,R,Kevin Yoder,31
-Johnson,De Soto 0-07,U.S. House,3,R,Kevin Yoder,2
-Johnson,Edgerton 0-01,U.S. House,3,R,Kevin Yoder,276
-Johnson,Edgerton 0-02,U.S. House,3,R,Kevin Yoder,0
-Johnson,Edgerton 0-05,U.S. House,3,R,Kevin Yoder,0
-Johnson,Edgerton 0-06,U.S. House,3,R,Kevin Yoder,0
-Johnson,Edgerton 0-09,U.S. House,3,R,Kevin Yoder,0
-Johnson,Fairway 1-01,U.S. House,3,R,Kevin Yoder,145
-Johnson,Fairway 1-02,U.S. House,3,R,Kevin Yoder,104
-Johnson,Fairway 2-01,U.S. House,3,R,Kevin Yoder,116
-Johnson,Fairway 2-02,U.S. House,3,R,Kevin Yoder,113
-Johnson,Fairway 3-01,U.S. House,3,R,Kevin Yoder,173
-Johnson,Fairway 3-02,U.S. House,3,R,Kevin Yoder,129
-Johnson,Fairway 4-01,U.S. House,3,R,Kevin Yoder,31
-Johnson,Fairway 4-02,U.S. House,3,R,Kevin Yoder,53
-Johnson,Fairway 4-03,U.S. House,3,R,Kevin Yoder,40
-Johnson,Fairway 4-04,U.S. House,3,R,Kevin Yoder,50
-Johnson,Gardner 0-01,U.S. House,3,R,Kevin Yoder,554
-Johnson,Gardner 0-02,U.S. House,3,R,Kevin Yoder,72
-Johnson,Gardner 0-03,U.S. House,3,R,Kevin Yoder,323
-Johnson,Gardner 0-04,U.S. House,3,R,Kevin Yoder,318
-Johnson,Gardner 0-06,U.S. House,3,R,Kevin Yoder,417
-Johnson,Gardner 0-07,U.S. House,3,R,Kevin Yoder,6
-Johnson,Gardner 0-08,U.S. House,3,R,Kevin Yoder,38
-Johnson,Gardner 0-09,U.S. House,3,R,Kevin Yoder,455
-Johnson,Gardner 0-10,U.S. House,3,R,Kevin Yoder,300
-Johnson,Gardner 0-12,U.S. House,3,R,Kevin Yoder,8
-Johnson,Gardner 0-13,U.S. House,3,R,Kevin Yoder,311
-Johnson,Gardner 0-14,U.S. House,3,R,Kevin Yoder,272
-Johnson,Gardner Twp 0-01,U.S. House,3,R,Kevin Yoder,229
-Johnson,Gardner Twp 0-02,U.S. House,3,R,Kevin Yoder,257
-Johnson,Gardner Twp 0-04,U.S. House,3,R,Kevin Yoder,2
-Johnson,Gardner Twp 0-05,U.S. House,3,R,Kevin Yoder,5
-Johnson,Gardner Twp 0-07,U.S. House,3,R,Kevin Yoder,2
-Johnson,Gardner Twp 0-08,U.S. House,3,R,Kevin Yoder,2
-Johnson,Gardner Twp 0-09,U.S. House,3,R,Kevin Yoder,0
-Johnson,Gardner Twp 0-10,U.S. House,3,R,Kevin Yoder,0
-Johnson,Gardner Twp 0-11,U.S. House,3,R,Kevin Yoder,55
-Johnson,Gardner Twp 0-13,U.S. House,3,R,Kevin Yoder,1
-Johnson,Lake Quivira 0-01,U.S. House,3,R,Kevin Yoder,363
-Johnson,Leawood 1-01,U.S. House,3,R,Kevin Yoder,248
-Johnson,Leawood 1-02,U.S. House,3,R,Kevin Yoder,486
-Johnson,Leawood 1-03,U.S. House,3,R,Kevin Yoder,404
-Johnson,Leawood 1-04,U.S. House,3,R,Kevin Yoder,322
-Johnson,Leawood 1-05,U.S. House,3,R,Kevin Yoder,295
-Johnson,Leawood 1-06,U.S. House,3,R,Kevin Yoder,63
-Johnson,Leawood 2-01,U.S. House,3,R,Kevin Yoder,367
-Johnson,Leawood 2-02,U.S. House,3,R,Kevin Yoder,445
-Johnson,Leawood 2-03,U.S. House,3,R,Kevin Yoder,446
-Johnson,Leawood 2-04,U.S. House,3,R,Kevin Yoder,590
-Johnson,Leawood 2-05,U.S. House,3,R,Kevin Yoder,269
-Johnson,Leawood 2-06,U.S. House,3,R,Kevin Yoder,212
-Johnson,Leawood 3-01,U.S. House,3,R,Kevin Yoder,246
-Johnson,Leawood 3-02,U.S. House,3,R,Kevin Yoder,433
-Johnson,Leawood 3-03,U.S. House,3,R,Kevin Yoder,297
-Johnson,Leawood 3-04,U.S. House,3,R,Kevin Yoder,115
-Johnson,Leawood 3-05,U.S. House,3,R,Kevin Yoder,562
-Johnson,Leawood 3-06,U.S. House,3,R,Kevin Yoder,600
-Johnson,Leawood 3-07,U.S. House,3,R,Kevin Yoder,408
-Johnson,Leawood 4-01,U.S. House,3,R,Kevin Yoder,146
-Johnson,Leawood 4-02,U.S. House,3,R,Kevin Yoder,419
-Johnson,Leawood 4-03,U.S. House,3,R,Kevin Yoder,361
-Johnson,Leawood 4-04,U.S. House,3,R,Kevin Yoder,446
-Johnson,Leawood 4-05,U.S. House,3,R,Kevin Yoder,466
-Johnson,Leawood 4-06,U.S. House,3,R,Kevin Yoder,409
-Johnson,Leawood 4-07,U.S. House,3,R,Kevin Yoder,625
-Johnson,Leawood 4-08,U.S. House,3,R,Kevin Yoder,295
-Johnson,Lenexa 1-01,U.S. House,3,R,Kevin Yoder,242
-Johnson,Lenexa 1-02,U.S. House,3,R,Kevin Yoder,443
-Johnson,Lenexa 1-03,U.S. House,3,R,Kevin Yoder,520
-Johnson,Lenexa 1-04,U.S. House,3,R,Kevin Yoder,310
-Johnson,Lenexa 1-05,U.S. House,3,R,Kevin Yoder,361
-Johnson,Lenexa 1-06,U.S. House,3,R,Kevin Yoder,494
-Johnson,Lenexa 1-07,U.S. House,3,R,Kevin Yoder,217
-Johnson,Lenexa 1-08,U.S. House,3,R,Kevin Yoder,92
-Johnson,Lenexa 1-09,U.S. House,3,R,Kevin Yoder,7
-Johnson,Lenexa 2-01,U.S. House,3,R,Kevin Yoder,643
-Johnson,Lenexa 2-02,U.S. House,3,R,Kevin Yoder,255
-Johnson,Lenexa 2-03,U.S. House,3,R,Kevin Yoder,557
-Johnson,Lenexa 2-04,U.S. House,3,R,Kevin Yoder,622
-Johnson,Lenexa 2-05,U.S. House,3,R,Kevin Yoder,277
-Johnson,Lenexa 2-06,U.S. House,3,R,Kevin Yoder,388
-Johnson,Lenexa 2-07,U.S. House,3,R,Kevin Yoder,592
-Johnson,Lenexa 3-01,U.S. House,3,R,Kevin Yoder,229
-Johnson,Lenexa 3-02,U.S. House,3,R,Kevin Yoder,362
-Johnson,Lenexa 3-03,U.S. House,3,R,Kevin Yoder,530
-Johnson,Lenexa 3-04,U.S. House,3,R,Kevin Yoder,354
-Johnson,Lenexa 3-05,U.S. House,3,R,Kevin Yoder,167
-Johnson,Lenexa 3-06,U.S. House,3,R,Kevin Yoder,283
-Johnson,Lenexa 3-07,U.S. House,3,R,Kevin Yoder,414
-Johnson,Lenexa 3-08,U.S. House,3,R,Kevin Yoder,444
-Johnson,Lenexa 4-01,U.S. House,3,R,Kevin Yoder,164
-Johnson,Lenexa 4-02,U.S. House,3,R,Kevin Yoder,368
-Johnson,Lenexa 4-03,U.S. House,3,R,Kevin Yoder,122
-Johnson,Lenexa 4-04,U.S. House,3,R,Kevin Yoder,174
-Johnson,Lenexa 4-05,U.S. House,3,R,Kevin Yoder,136
-Johnson,Lenexa 4-06,U.S. House,3,R,Kevin Yoder,236
-Johnson,Lenexa 4-07,U.S. House,3,R,Kevin Yoder,294
-Johnson,Lenexa 4-08,U.S. House,3,R,Kevin Yoder,326
-Johnson,Lenexa 4-09,U.S. House,3,R,Kevin Yoder,322
-Johnson,Lenexa 4-10,U.S. House,3,R,Kevin Yoder,164
-Johnson,Lenexa 4-11,U.S. House,3,R,Kevin Yoder,41
-Johnson,Lexington Twp 0-01,U.S. House,3,R,Kevin Yoder,449
-Johnson,Lexington Twp 0-02,U.S. House,3,R,Kevin Yoder,1
-Johnson,Lexington Twp 0-03,U.S. House,3,R,Kevin Yoder,1
-Johnson,McCamish Twp 0-01,U.S. House,3,R,Kevin Yoder,118
-Johnson,McCamish Twp 0-02,U.S. House,3,R,Kevin Yoder,224
-Johnson,Merriam 1-01,U.S. House,3,R,Kevin Yoder,167
-Johnson,Merriam 1-02,U.S. House,3,R,Kevin Yoder,201
-Johnson,Merriam 2-01,U.S. House,3,R,Kevin Yoder,288
-Johnson,Merriam 2-02,U.S. House,3,R,Kevin Yoder,0
-Johnson,Merriam 2-03,U.S. House,3,R,Kevin Yoder,140
-Johnson,Merriam 3-01,U.S. House,3,R,Kevin Yoder,198
-Johnson,Merriam 3-02,U.S. House,3,R,Kevin Yoder,207
-Johnson,Merriam 4-01,U.S. House,3,R,Kevin Yoder,290
-Johnson,Merriam 4-02,U.S. House,3,R,Kevin Yoder,120
-Johnson,Merriam 4-03,U.S. House,3,R,Kevin Yoder,143
-Johnson,Mission 1-01,U.S. House,3,R,Kevin Yoder,256
-Johnson,Mission 1-02,U.S. House,3,R,Kevin Yoder,88
-Johnson,Mission 2-01,U.S. House,3,R,Kevin Yoder,123
-Johnson,Mission 2-02,U.S. House,3,R,Kevin Yoder,186
-Johnson,Mission 3-01,U.S. House,3,R,Kevin Yoder,208
-Johnson,Mission 3-02,U.S. House,3,R,Kevin Yoder,116
-Johnson,Mission 4-01,U.S. House,3,R,Kevin Yoder,131
-Johnson,Mission 4-02,U.S. House,3,R,Kevin Yoder,248
-Johnson,Mission 4-03,U.S. House,3,R,Kevin Yoder,127
-Johnson,Mission Hills 0-01,U.S. House,3,R,Kevin Yoder,292
-Johnson,Mission Hills 0-02,U.S. House,3,R,Kevin Yoder,361
-Johnson,Mission Hills 0-03,U.S. House,3,R,Kevin Yoder,243
-Johnson,Mission Hills 0-04,U.S. House,3,R,Kevin Yoder,380
-Johnson,Mission Woods 0-01,U.S. House,3,R,Kevin Yoder,51
-Johnson,Olathe 1-01,U.S. House,3,R,Kevin Yoder,369
-Johnson,Olathe 1-02,U.S. House,3,R,Kevin Yoder,222
-Johnson,Olathe 1-03,U.S. House,3,R,Kevin Yoder,173
-Johnson,Olathe 1-04,U.S. House,3,R,Kevin Yoder,357
-Johnson,Olathe 1-05,U.S. House,3,R,Kevin Yoder,372
-Johnson,Olathe 1-06,U.S. House,3,R,Kevin Yoder,258
-Johnson,Olathe 1-08,U.S. House,3,R,Kevin Yoder,397
-Johnson,Olathe 1-09,U.S. House,3,R,Kevin Yoder,406
-Johnson,Olathe 1-11,U.S. House,3,R,Kevin Yoder,66
-Johnson,Olathe 1-14,U.S. House,3,R,Kevin Yoder,351
-Johnson,Olathe 1-15,U.S. House,3,R,Kevin Yoder,319
-Johnson,Olathe 1-16,U.S. House,3,R,Kevin Yoder,445
-Johnson,Olathe 1-17,U.S. House,3,R,Kevin Yoder,116
-Johnson,Olathe 1-18,U.S. House,3,R,Kevin Yoder,123
-Johnson,Olathe 1-19,U.S. House,3,R,Kevin Yoder,155
-Johnson,Olathe 1-20,U.S. House,3,R,Kevin Yoder,227
-Johnson,Olathe 1-21,U.S. House,3,R,Kevin Yoder,424
-Johnson,Olathe 1-22,U.S. House,3,R,Kevin Yoder,668
-Johnson,Olathe 1-23,U.S. House,3,R,Kevin Yoder,1
-Johnson,Olathe 1-24,U.S. House,3,R,Kevin Yoder,60
-Johnson,Olathe 1-24,U.S. House,3,R,Kevin Yoder,98
-Johnson,Olathe 1-26,U.S. House,3,R,Kevin Yoder,0
-Johnson,Olathe 1-27,U.S. House,3,R,Kevin Yoder,240
-Johnson,Olathe 2-01,U.S. House,3,R,Kevin Yoder,156
-Johnson,Olathe 2-02,U.S. House,3,R,Kevin Yoder,231
-Johnson,Olathe 2-03,U.S. House,3,R,Kevin Yoder,266
-Johnson,Olathe 2-04,U.S. House,3,R,Kevin Yoder,269
-Johnson,Olathe 2-05,U.S. House,3,R,Kevin Yoder,940
-Johnson,Olathe 2-06,U.S. House,3,R,Kevin Yoder,490
-Johnson,Olathe 2-07,U.S. House,3,R,Kevin Yoder,534
-Johnson,Olathe 2-08,U.S. House,3,R,Kevin Yoder,368
-Johnson,Olathe 2-09,U.S. House,3,R,Kevin Yoder,169
-Johnson,Olathe 2-10,U.S. House,3,R,Kevin Yoder,674
-Johnson,Olathe 2-11,U.S. House,3,R,Kevin Yoder,482
-Johnson,Olathe 2-12,U.S. House,3,R,Kevin Yoder,288
-Johnson,Olathe 2-13,U.S. House,3,R,Kevin Yoder,261
-Johnson,Olathe 2-14,U.S. House,3,R,Kevin Yoder,282
-Johnson,Olathe 2-15,U.S. House,3,R,Kevin Yoder,304
-Johnson,Olathe 2-16,U.S. House,3,R,Kevin Yoder,77
-Johnson,Olathe 2-17,U.S. House,3,R,Kevin Yoder,0
-Johnson,Olathe 2-19,U.S. House,3,R,Kevin Yoder,4
-Johnson,Olathe 2-22,U.S. House,3,R,Kevin Yoder,557
-Johnson,Olathe 2-23,U.S. House,3,R,Kevin Yoder,372
-Johnson,Olathe 3-01,U.S. House,3,R,Kevin Yoder,137
-Johnson,Olathe 3-02,U.S. House,3,R,Kevin Yoder,448
-Johnson,Olathe 3-03,U.S. House,3,R,Kevin Yoder,242
-Johnson,Olathe 3-04,U.S. House,3,R,Kevin Yoder,407
-Johnson,Olathe 3-05,U.S. House,3,R,Kevin Yoder,441
-Johnson,Olathe 3-06,U.S. House,3,R,Kevin Yoder,318
-Johnson,Olathe 3-07,U.S. House,3,R,Kevin Yoder,285
-Johnson,Olathe 3-08,U.S. House,3,R,Kevin Yoder,449
-Johnson,Olathe 3-09,U.S. House,3,R,Kevin Yoder,236
-Johnson,Olathe 3-10,U.S. House,3,R,Kevin Yoder,454
-Johnson,Olathe 3-11,U.S. House,3,R,Kevin Yoder,292
-Johnson,Olathe 3-12,U.S. House,3,R,Kevin Yoder,381
-Johnson,Olathe 3-13,U.S. House,3,R,Kevin Yoder,435
-Johnson,Olathe 3-15,U.S. House,3,R,Kevin Yoder,292
-Johnson,Olathe 3-16,U.S. House,3,R,Kevin Yoder,314
-Johnson,Olathe 3-17,U.S. House,3,R,Kevin Yoder,441
-Johnson,Olathe 3-18,U.S. House,3,R,Kevin Yoder,404
-Johnson,Olathe 3-19,U.S. House,3,R,Kevin Yoder,292
-Johnson,Olathe 3-20,U.S. House,3,R,Kevin Yoder,294
-Johnson,Olathe 3-21,U.S. House,3,R,Kevin Yoder,322
-Johnson,Olathe 3-22,U.S. House,3,R,Kevin Yoder,363
-Johnson,Olathe 3-23,U.S. House,3,R,Kevin Yoder,311
-Johnson,Olathe 3-24,U.S. House,3,R,Kevin Yoder,194
-Johnson,Olathe 3-26,U.S. House,3,R,Kevin Yoder,32
-Johnson,Olathe 4-01,U.S. House,3,R,Kevin Yoder,279
-Johnson,Olathe 4-02,U.S. House,3,R,Kevin Yoder,505
-Johnson,Olathe 4-03,U.S. House,3,R,Kevin Yoder,144
-Johnson,Olathe 4-04,U.S. House,3,R,Kevin Yoder,167
-Johnson,Olathe 4-05,U.S. House,3,R,Kevin Yoder,361
-Johnson,Olathe 4-06,U.S. House,3,R,Kevin Yoder,443
-Johnson,Olathe 4-07,U.S. House,3,R,Kevin Yoder,370
-Johnson,Olathe 4-08,U.S. House,3,R,Kevin Yoder,353
-Johnson,Olathe 4-09,U.S. House,3,R,Kevin Yoder,465
-Johnson,Olathe 4-10,U.S. House,3,R,Kevin Yoder,253
-Johnson,Olathe 4-11,U.S. House,3,R,Kevin Yoder,140
-Johnson,Olathe 4-12,U.S. House,3,R,Kevin Yoder,455
-Johnson,Olathe 4-13,U.S. House,3,R,Kevin Yoder,195
-Johnson,Olathe 4-14,U.S. House,3,R,Kevin Yoder,444
-Johnson,Olathe 4-15,U.S. House,3,R,Kevin Yoder,20
-Johnson,Olathe 4-16,U.S. House,3,R,Kevin Yoder,108
-Johnson,Olathe 4-17,U.S. House,3,R,Kevin Yoder,3
-Johnson,Olathe Twp 0-01,U.S. House,3,R,Kevin Yoder,178
-Johnson,Olathe Twp 0-02,U.S. House,3,R,Kevin Yoder,44
-Johnson,Olathe Twp 0-03,U.S. House,3,R,Kevin Yoder,24
-Johnson,Olathe Twp 0-04,U.S. House,3,R,Kevin Yoder,2
-Johnson,Olathe Twp 0-05,U.S. House,3,R,Kevin Yoder,2
-Johnson,Olathe Twp 0-06,U.S. House,3,R,Kevin Yoder,0
-Johnson,Olathe Twp 0-07,U.S. House,3,R,Kevin Yoder,1
-Johnson,Olathe Twp 0-08,U.S. House,3,R,Kevin Yoder,4
-Johnson,Olathe Twp 0-09,U.S. House,3,R,Kevin Yoder,0
-Johnson,Olathe Twp 0-10,U.S. House,3,R,Kevin Yoder,7
-Johnson,Olathe Twp 0-11,U.S. House,3,R,Kevin Yoder,3
-Johnson,Olathe Twp 0-14,U.S. House,3,R,Kevin Yoder,1
-Johnson,Olathe Twp 0-24,U.S. House,3,R,Kevin Yoder,2
-Johnson,Olathe Twp 0-25,U.S. House,3,R,Kevin Yoder,7
-Johnson,Olathe Twp 0-26,U.S. House,3,R,Kevin Yoder,3
-Johnson,Olathe Twp 0-32,U.S. House,3,R,Kevin Yoder,19
-Johnson,Overland Park 1-01,U.S. House,3,R,Kevin Yoder,241
-Johnson,Overland Park 1-02,U.S. House,3,R,Kevin Yoder,230
-Johnson,Overland Park 1-03,U.S. House,3,R,Kevin Yoder,253
-Johnson,Overland Park 1-04,U.S. House,3,R,Kevin Yoder,99
-Johnson,Overland Park 1-05,U.S. House,3,R,Kevin Yoder,162
-Johnson,Overland Park 1-06,U.S. House,3,R,Kevin Yoder,317
-Johnson,Overland Park 1-07,U.S. House,3,R,Kevin Yoder,347
-Johnson,Overland Park 1-08,U.S. House,3,R,Kevin Yoder,207
-Johnson,Overland Park 1-09,U.S. House,3,R,Kevin Yoder,150
-Johnson,Overland Park 1-10,U.S. House,3,R,Kevin Yoder,295
-Johnson,Overland Park 1-11,U.S. House,3,R,Kevin Yoder,71
-Johnson,Overland Park 1-12,U.S. House,3,R,Kevin Yoder,231
-Johnson,Overland Park 1-13,U.S. House,3,R,Kevin Yoder,192
-Johnson,Overland Park 1-14,U.S. House,3,R,Kevin Yoder,238
-Johnson,Overland Park 1-15,U.S. House,3,R,Kevin Yoder,116
-Johnson,Overland Park 1-16,U.S. House,3,R,Kevin Yoder,261
-Johnson,Overland Park 1-17,U.S. House,3,R,Kevin Yoder,151
-Johnson,Overland Park 1-18,U.S. House,3,R,Kevin Yoder,258
-Johnson,Overland Park 1-19,U.S. House,3,R,Kevin Yoder,200
-Johnson,Overland Park 1-20,U.S. House,3,R,Kevin Yoder,145
-Johnson,Overland Park 1-21,U.S. House,3,R,Kevin Yoder,96
-Johnson,Overland Park 1-22,U.S. House,3,R,Kevin Yoder,56
-Johnson,Overland Park 2-01,U.S. House,3,R,Kevin Yoder,286
-Johnson,Overland Park 2-02,U.S. House,3,R,Kevin Yoder,238
-Johnson,Overland Park 2-03,U.S. House,3,R,Kevin Yoder,230
-Johnson,Overland Park 2-04,U.S. House,3,R,Kevin Yoder,294
-Johnson,Overland Park 2-05,U.S. House,3,R,Kevin Yoder,230
-Johnson,Overland Park 2-06,U.S. House,3,R,Kevin Yoder,264
-Johnson,Overland Park 2-07,U.S. House,3,R,Kevin Yoder,215
-Johnson,Overland Park 2-08,U.S. House,3,R,Kevin Yoder,117
-Johnson,Overland Park 2-09,U.S. House,3,R,Kevin Yoder,226
-Johnson,Overland Park 2-10,U.S. House,3,R,Kevin Yoder,232
-Johnson,Overland Park 2-11,U.S. House,3,R,Kevin Yoder,251
-Johnson,Overland Park 2-12,U.S. House,3,R,Kevin Yoder,201
-Johnson,Overland Park 2-13,U.S. House,3,R,Kevin Yoder,119
-Johnson,Overland Park 2-14,U.S. House,3,R,Kevin Yoder,170
-Johnson,Overland Park 2-15,U.S. House,3,R,Kevin Yoder,388
-Johnson,Overland Park 2-16,U.S. House,3,R,Kevin Yoder,216
-Johnson,Overland Park 2-17,U.S. House,3,R,Kevin Yoder,350
-Johnson,Overland Park 2-18,U.S. House,3,R,Kevin Yoder,321
-Johnson,Overland Park 2-19,U.S. House,3,R,Kevin Yoder,218
-Johnson,Overland Park 2-20,U.S. House,3,R,Kevin Yoder,235
-Johnson,Overland Park 2-21,U.S. House,3,R,Kevin Yoder,216
-Johnson,Overland Park 2-22,U.S. House,3,R,Kevin Yoder,228
-Johnson,Overland Park 2-23,U.S. House,3,R,Kevin Yoder,329
-Johnson,Overland Park 2-24,U.S. House,3,R,Kevin Yoder,449
-Johnson,Overland Park 2-25,U.S. House,3,R,Kevin Yoder,345
-Johnson,Overland Park 2-26,U.S. House,3,R,Kevin Yoder,117
-Johnson,Overland Park 3-01,U.S. House,3,R,Kevin Yoder,518
-Johnson,Overland Park 3-02,U.S. House,3,R,Kevin Yoder,279
-Johnson,Overland Park 3-03,U.S. House,3,R,Kevin Yoder,337
-Johnson,Overland Park 3-04,U.S. House,3,R,Kevin Yoder,358
-Johnson,Overland Park 3-05,U.S. House,3,R,Kevin Yoder,348
-Johnson,Overland Park 3-06,U.S. House,3,R,Kevin Yoder,403
-Johnson,Overland Park 3-07,U.S. House,3,R,Kevin Yoder,209
-Johnson,Overland Park 3-08,U.S. House,3,R,Kevin Yoder,333
-Johnson,Overland Park 3-09,U.S. House,3,R,Kevin Yoder,427
-Johnson,Overland Park 3-10,U.S. House,3,R,Kevin Yoder,259
-Johnson,Overland Park 3-11,U.S. House,3,R,Kevin Yoder,357
-Johnson,Overland Park 3-12,U.S. House,3,R,Kevin Yoder,173
-Johnson,Overland Park 3-13,U.S. House,3,R,Kevin Yoder,522
-Johnson,Overland Park 3-14,U.S. House,3,R,Kevin Yoder,340
-Johnson,Overland Park 3-15,U.S. House,3,R,Kevin Yoder,255
-Johnson,Overland Park 3-16,U.S. House,3,R,Kevin Yoder,308
-Johnson,Overland Park 3-17,U.S. House,3,R,Kevin Yoder,239
-Johnson,Overland Park 3-18,U.S. House,3,R,Kevin Yoder,249
-Johnson,Overland Park 3-19,U.S. House,3,R,Kevin Yoder,318
-Johnson,Overland Park 3-20,U.S. House,3,R,Kevin Yoder,414
-Johnson,Overland Park 3-21,U.S. House,3,R,Kevin Yoder,332
-Johnson,Overland Park 4-01,U.S. House,3,R,Kevin Yoder,278
-Johnson,Overland Park 4-02,U.S. House,3,R,Kevin Yoder,461
-Johnson,Overland Park 4-03,U.S. House,3,R,Kevin Yoder,560
-Johnson,Overland Park 4-04,U.S. House,3,R,Kevin Yoder,581
-Johnson,Overland Park 4-05,U.S. House,3,R,Kevin Yoder,401
-Johnson,Overland Park 4-06,U.S. House,3,R,Kevin Yoder,328
-Johnson,Overland Park 4-07,U.S. House,3,R,Kevin Yoder,242
-Johnson,Overland Park 4-08,U.S. House,3,R,Kevin Yoder,397
-Johnson,Overland Park 4-09,U.S. House,3,R,Kevin Yoder,448
-Johnson,Overland Park 4-10,U.S. House,3,R,Kevin Yoder,289
-Johnson,Overland Park 4-11,U.S. House,3,R,Kevin Yoder,462
-Johnson,Overland Park 4-12,U.S. House,3,R,Kevin Yoder,597
-Johnson,Overland Park 4-13,U.S. House,3,R,Kevin Yoder,343
-Johnson,Overland Park 4-14,U.S. House,3,R,Kevin Yoder,269
-Johnson,Overland Park 4-15,U.S. House,3,R,Kevin Yoder,505
-Johnson,Overland Park 4-16,U.S. House,3,R,Kevin Yoder,403
-Johnson,Overland Park 4-17,U.S. House,3,R,Kevin Yoder,478
-Johnson,Overland Park 4-18,U.S. House,3,R,Kevin Yoder,62
-Johnson,Overland Park 5-01,U.S. House,3,R,Kevin Yoder,394
-Johnson,Overland Park 5-02,U.S. House,3,R,Kevin Yoder,184
-Johnson,Overland Park 5-03,U.S. House,3,R,Kevin Yoder,399
-Johnson,Overland Park 5-04,U.S. House,3,R,Kevin Yoder,340
-Johnson,Overland Park 5-05,U.S. House,3,R,Kevin Yoder,222
-Johnson,Overland Park 5-06,U.S. House,3,R,Kevin Yoder,303
-Johnson,Overland Park 5-07,U.S. House,3,R,Kevin Yoder,573
-Johnson,Overland Park 5-08,U.S. House,3,R,Kevin Yoder,585
-Johnson,Overland Park 5-09,U.S. House,3,R,Kevin Yoder,517
-Johnson,Overland Park 5-10,U.S. House,3,R,Kevin Yoder,394
-Johnson,Overland Park 5-11,U.S. House,3,R,Kevin Yoder,450
-Johnson,Overland Park 5-12,U.S. House,3,R,Kevin Yoder,96
-Johnson,Overland Park 5-13,U.S. House,3,R,Kevin Yoder,471
-Johnson,Overland Park 5-14,U.S. House,3,R,Kevin Yoder,390
-Johnson,Overland Park 5-15,U.S. House,3,R,Kevin Yoder,252
-Johnson,Overland Park 5-16,U.S. House,3,R,Kevin Yoder,244
-Johnson,Overland Park 5-17,U.S. House,3,R,Kevin Yoder,141
-Johnson,Overland Park 5-18,U.S. House,3,R,Kevin Yoder,307
-Johnson,Overland Park 5-19,U.S. House,3,R,Kevin Yoder,38
-Johnson,Overland Park 6-01,U.S. House,3,R,Kevin Yoder,500
-Johnson,Overland Park 6-02,U.S. House,3,R,Kevin Yoder,401
-Johnson,Overland Park 6-03,U.S. House,3,R,Kevin Yoder,450
-Johnson,Overland Park 6-04,U.S. House,3,R,Kevin Yoder,440
-Johnson,Overland Park 6-05,U.S. House,3,R,Kevin Yoder,454
-Johnson,Overland Park 6-06,U.S. House,3,R,Kevin Yoder,1
-Johnson,Overland Park 6-07,U.S. House,3,R,Kevin Yoder,151
-Johnson,Overland Park 6-08,U.S. House,3,R,Kevin Yoder,739
-Johnson,Overland Park 6-09,U.S. House,3,R,Kevin Yoder,578
-Johnson,Overland Park 6-10,U.S. House,3,R,Kevin Yoder,377
-Johnson,Overland Park 6-11,U.S. House,3,R,Kevin Yoder,366
-Johnson,Overland Park 6-12,U.S. House,3,R,Kevin Yoder,175
-Johnson,Overland Park 6-13,U.S. House,3,R,Kevin Yoder,514
-Johnson,Overland Park 6-15,U.S. House,3,R,Kevin Yoder,532
-Johnson,Overland Park 6-16,U.S. House,3,R,Kevin Yoder,308
-Johnson,Overland Park 6-17,U.S. House,3,R,Kevin Yoder,101
-Johnson,Overland Park 6-18,U.S. House,3,R,Kevin Yoder,3
-Johnson,Overland Park 6-19,U.S. House,3,R,Kevin Yoder,465
-Johnson,Overland Park 6-20,U.S. House,3,R,Kevin Yoder,272
-Johnson,Overland Park 6-21,U.S. House,3,R,Kevin Yoder,721
-Johnson,Overland Park 6-22,U.S. House,3,R,Kevin Yoder,244
-Johnson,Oxford Twp 0-01,U.S. House,3,R,Kevin Yoder,1
-Johnson,Oxford Twp 0-02,U.S. House,3,R,Kevin Yoder,329
-Johnson,Oxford Twp 0-04,U.S. House,3,R,Kevin Yoder,235
-Johnson,Oxford Twp 0-05,U.S. House,3,R,Kevin Yoder,10
-Johnson,Oxford Twp 0-09,U.S. House,3,R,Kevin Yoder,16
-Johnson,Oxford Twp 0-10,U.S. House,3,R,Kevin Yoder,2
-Johnson,Oxford Twp 0-11,U.S. House,3,R,Kevin Yoder,74
-Johnson,Prairie Village 1-01,U.S. House,3,R,Kevin Yoder,342
-Johnson,Prairie Village 1-02,U.S. House,3,R,Kevin Yoder,225
-Johnson,Prairie Village 1-03,U.S. House,3,R,Kevin Yoder,332
-Johnson,Prairie Village 2-01,U.S. House,3,R,Kevin Yoder,263
-Johnson,Prairie Village 2-02,U.S. House,3,R,Kevin Yoder,148
-Johnson,Prairie Village 2-03,U.S. House,3,R,Kevin Yoder,230
-Johnson,Prairie Village 3-01,U.S. House,3,R,Kevin Yoder,212
-Johnson,Prairie Village 3-02,U.S. House,3,R,Kevin Yoder,298
-Johnson,Prairie Village 3-03,U.S. House,3,R,Kevin Yoder,259
-Johnson,Prairie Village 4-01,U.S. House,3,R,Kevin Yoder,399
-Johnson,Prairie Village 4-02,U.S. House,3,R,Kevin Yoder,206
-Johnson,Prairie Village 4-03,U.S. House,3,R,Kevin Yoder,353
-Johnson,Prairie Village 5-01,U.S. House,3,R,Kevin Yoder,342
-Johnson,Prairie Village 5-02,U.S. House,3,R,Kevin Yoder,405
-Johnson,Prairie Village 5-03,U.S. House,3,R,Kevin Yoder,310
-Johnson,Prairie Village 6-01,U.S. House,3,R,Kevin Yoder,350
-Johnson,Prairie Village 6-02,U.S. House,3,R,Kevin Yoder,231
-Johnson,Prairie Village 6-03,U.S. House,3,R,Kevin Yoder,163
-Johnson,Roeland Park 1-01,U.S. House,3,R,Kevin Yoder,96
-Johnson,Roeland Park 1-02,U.S. House,3,R,Kevin Yoder,65
-Johnson,Roeland Park 2-01,U.S. House,3,R,Kevin Yoder,113
-Johnson,Roeland Park 2-02,U.S. House,3,R,Kevin Yoder,170
-Johnson,Roeland Park 3-01,U.S. House,3,R,Kevin Yoder,75
-Johnson,Roeland Park 3-02,U.S. House,3,R,Kevin Yoder,189
-Johnson,Roeland Park 4-01,U.S. House,3,R,Kevin Yoder,99
-Johnson,Roeland Park 4-02,U.S. House,3,R,Kevin Yoder,298
-Johnson,Shawnee 1-01,U.S. House,3,R,Kevin Yoder,361
-Johnson,Shawnee 1-02,U.S. House,3,R,Kevin Yoder,290
-Johnson,Shawnee 1-03,U.S. House,3,R,Kevin Yoder,263
-Johnson,Shawnee 1-04,U.S. House,3,R,Kevin Yoder,504
-Johnson,Shawnee 1-05,U.S. House,3,R,Kevin Yoder,499
-Johnson,Shawnee 1-06,U.S. House,3,R,Kevin Yoder,436
-Johnson,Shawnee 1-07,U.S. House,3,R,Kevin Yoder,395
-Johnson,Shawnee 1-08,U.S. House,3,R,Kevin Yoder,448
-Johnson,Shawnee 1-09,U.S. House,3,R,Kevin Yoder,72
-Johnson,Shawnee 1-10,U.S. House,3,R,Kevin Yoder,170
-Johnson,Shawnee 1-11,U.S. House,3,R,Kevin Yoder,270
-Johnson,Shawnee 1-12,U.S. House,3,R,Kevin Yoder,4
-Johnson,Shawnee 2-01,U.S. House,3,R,Kevin Yoder,171
-Johnson,Shawnee 2-02,U.S. House,3,R,Kevin Yoder,315
-Johnson,Shawnee 2-03,U.S. House,3,R,Kevin Yoder,217
-Johnson,Shawnee 2-04,U.S. House,3,R,Kevin Yoder,353
-Johnson,Shawnee 2-05,U.S. House,3,R,Kevin Yoder,186
-Johnson,Shawnee 2-06,U.S. House,3,R,Kevin Yoder,281
-Johnson,Shawnee 2-07,U.S. House,3,R,Kevin Yoder,200
-Johnson,Shawnee 2-08,U.S. House,3,R,Kevin Yoder,204
-Johnson,Shawnee 2-09,U.S. House,3,R,Kevin Yoder,184
-Johnson,Shawnee 2-10,U.S. House,3,R,Kevin Yoder,168
-Johnson,Shawnee 2-11,U.S. House,3,R,Kevin Yoder,273
-Johnson,Shawnee 2-12,U.S. House,3,R,Kevin Yoder,53
-Johnson,Shawnee 2-13,U.S. House,3,R,Kevin Yoder,135
-Johnson,Shawnee 3-01,U.S. House,3,R,Kevin Yoder,277
-Johnson,Shawnee 3-02,U.S. House,3,R,Kevin Yoder,538
-Johnson,Shawnee 3-03,U.S. House,3,R,Kevin Yoder,368
-Johnson,Shawnee 3-04,U.S. House,3,R,Kevin Yoder,380
-Johnson,Shawnee 3-05,U.S. House,3,R,Kevin Yoder,569
-Johnson,Shawnee 3-06,U.S. House,3,R,Kevin Yoder,328
-Johnson,Shawnee 3-07,U.S. House,3,R,Kevin Yoder,487
-Johnson,Shawnee 3-08,U.S. House,3,R,Kevin Yoder,428
-Johnson,Shawnee 3-09,U.S. House,3,R,Kevin Yoder,280
-Johnson,Shawnee 4-01,U.S. House,3,R,Kevin Yoder,474
-Johnson,Shawnee 4-02,U.S. House,3,R,Kevin Yoder,275
-Johnson,Shawnee 4-03,U.S. House,3,R,Kevin Yoder,125
-Johnson,Shawnee 4-04,U.S. House,3,R,Kevin Yoder,102
-Johnson,Shawnee 4-05,U.S. House,3,R,Kevin Yoder,360
-Johnson,Shawnee 4-06,U.S. House,3,R,Kevin Yoder,347
-Johnson,Shawnee 4-07,U.S. House,3,R,Kevin Yoder,487
-Johnson,Shawnee 4-08,U.S. House,3,R,Kevin Yoder,181
-Johnson,Shawnee 4-09,U.S. House,3,R,Kevin Yoder,531
-Johnson,Shawnee 4-11,U.S. House,3,R,Kevin Yoder,259
-Johnson,Shawnee 4-12,U.S. House,3,R,Kevin Yoder,52
-Johnson,Spring Hill 0-01,U.S. House,3,R,Kevin Yoder,629
-Johnson,Spring Hill 0-03,U.S. House,3,R,Kevin Yoder,38
-Johnson,Spring Hill 0-04,U.S. House,3,R,Kevin Yoder,0
-Johnson,Spring Hill Twp 0-01,U.S. House,3,R,Kevin Yoder,479
-Johnson,Spring Hill Twp 0-02,U.S. House,3,R,Kevin Yoder,2
-Johnson,Spring Hill Twp 0-03,U.S. House,3,R,Kevin Yoder,53
-Johnson,Spring Hill Twp 0-04,U.S. House,3,R,Kevin Yoder,12
-Johnson,Spring Hill Twp 0-05,U.S. House,3,R,Kevin Yoder,4
-Johnson,Westwood 0-01,U.S. House,3,R,Kevin Yoder,139
-Johnson,Westwood 0-02,U.S. House,3,R,Kevin Yoder,163
-Johnson,Westwood Hills 0-01,U.S. House,3,R,Kevin Yoder,86
-Johnson,Aubry Twp 0-01,U.S. House,3,,Write-ins,0
-Johnson,Aubry Twp 0-02,U.S. House,3,,Write-ins,0
-Johnson,Aubry Twp 0-03,U.S. House,3,,Write-ins,0
-Johnson,Aubry Twp 0-04,U.S. House,3,,Write-ins,0
-Johnson,Aubry Twp 0-05,U.S. House,3,,Write-ins,0
-Johnson,Aubry Twp 0-06,U.S. House,3,,Write-ins,0
-Johnson,De Soto 0-01,U.S. House,3,,Write-ins,0
-Johnson,De Soto 0-02,U.S. House,3,,Write-ins,0
-Johnson,De Soto 0-03,U.S. House,3,,Write-ins,1
-Johnson,De Soto 0-06,U.S. House,3,,Write-ins,0
-Johnson,De Soto 0-07,U.S. House,3,,Write-ins,0
-Johnson,Edgerton 0-01,U.S. House,3,,Write-ins,1
-Johnson,Edgerton 0-02,U.S. House,3,,Write-ins,0
-Johnson,Edgerton 0-05,U.S. House,3,,Write-ins,0
-Johnson,Edgerton 0-06,U.S. House,3,,Write-ins,0
-Johnson,Edgerton 0-09,U.S. House,3,,Write-ins,0
-Johnson,Fairway 1-01,U.S. House,3,,Write-ins,0
-Johnson,Fairway 1-02,U.S. House,3,,Write-ins,0
-Johnson,Fairway 2-01,U.S. House,3,,Write-ins,2
-Johnson,Fairway 2-02,U.S. House,3,,Write-ins,2
-Johnson,Fairway 3-01,U.S. House,3,,Write-ins,0
-Johnson,Fairway 3-02,U.S. House,3,,Write-ins,0
-Johnson,Fairway 4-01,U.S. House,3,,Write-ins,1
-Johnson,Fairway 4-02,U.S. House,3,,Write-ins,0
-Johnson,Fairway 4-03,U.S. House,3,,Write-ins,0
-Johnson,Fairway 4-04,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-01,U.S. House,3,,Write-ins,1
-Johnson,Gardner 0-02,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-03,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-04,U.S. House,3,,Write-ins,1
-Johnson,Gardner 0-06,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-07,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-08,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-09,U.S. House,3,,Write-ins,1
-Johnson,Gardner 0-10,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-12,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-13,U.S. House,3,,Write-ins,0
-Johnson,Gardner 0-14,U.S. House,3,,Write-ins,1
-Johnson,Gardner Twp 0-01,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-02,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-04,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-05,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-07,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-08,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-09,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-10,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-11,U.S. House,3,,Write-ins,0
-Johnson,Gardner Twp 0-13,U.S. House,3,,Write-ins,0
-Johnson,Lake Quivira 0-01,U.S. House,3,,Write-ins,0
-Johnson,Leawood 1-01,U.S. House,3,,Write-ins,0
-Johnson,Leawood 1-02,U.S. House,3,,Write-ins,1
-Johnson,Leawood 1-03,U.S. House,3,,Write-ins,0
-Johnson,Leawood 1-04,U.S. House,3,,Write-ins,0
-Johnson,Leawood 1-05,U.S. House,3,,Write-ins,0
-Johnson,Leawood 1-06,U.S. House,3,,Write-ins,0
-Johnson,Leawood 2-01,U.S. House,3,,Write-ins,0
-Johnson,Leawood 2-02,U.S. House,3,,Write-ins,1
-Johnson,Leawood 2-03,U.S. House,3,,Write-ins,2
-Johnson,Leawood 2-04,U.S. House,3,,Write-ins,0
-Johnson,Leawood 2-05,U.S. House,3,,Write-ins,1
-Johnson,Leawood 2-06,U.S. House,3,,Write-ins,0
-Johnson,Leawood 3-01,U.S. House,3,,Write-ins,0
-Johnson,Leawood 3-02,U.S. House,3,,Write-ins,0
-Johnson,Leawood 3-03,U.S. House,3,,Write-ins,0
-Johnson,Leawood 3-04,U.S. House,3,,Write-ins,0
-Johnson,Leawood 3-05,U.S. House,3,,Write-ins,0
-Johnson,Leawood 3-06,U.S. House,3,,Write-ins,2
-Johnson,Leawood 3-07,U.S. House,3,,Write-ins,0
-Johnson,Leawood 4-01,U.S. House,3,,Write-ins,0
-Johnson,Leawood 4-02,U.S. House,3,,Write-ins,0
-Johnson,Leawood 4-03,U.S. House,3,,Write-ins,0
-Johnson,Leawood 4-04,U.S. House,3,,Write-ins,0
-Johnson,Leawood 4-05,U.S. House,3,,Write-ins,0
-Johnson,Leawood 4-06,U.S. House,3,,Write-ins,0
-Johnson,Leawood 4-07,U.S. House,3,,Write-ins,0
-Johnson,Leawood 4-08,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 1-01,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 1-02,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 1-03,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 1-04,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 1-05,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 1-06,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 1-07,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 1-08,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 1-09,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 2-01,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 2-02,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 2-03,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 2-04,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 2-05,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 2-06,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 2-07,U.S. House,3,,Write-ins,2
-Johnson,Lenexa 3-01,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 3-02,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 3-03,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 3-04,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 3-05,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 3-06,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 3-07,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 3-08,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 4-01,U.S. House,3,,Write-ins,2
-Johnson,Lenexa 4-02,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 4-03,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 4-04,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 4-05,U.S. House,3,,Write-ins,1
-Johnson,Lenexa 4-06,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 4-07,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 4-08,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 4-09,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 4-10,U.S. House,3,,Write-ins,0
-Johnson,Lenexa 4-11,U.S. House,3,,Write-ins,0
-Johnson,Lexington Twp 0-01,U.S. House,3,,Write-ins,0
-Johnson,Lexington Twp 0-02,U.S. House,3,,Write-ins,0
-Johnson,Lexington Twp 0-03,U.S. House,3,,Write-ins,0
-Johnson,McCamish Twp 0-01,U.S. House,3,,Write-ins,0
-Johnson,McCamish Twp 0-02,U.S. House,3,,Write-ins,0
-Johnson,Merriam 1-01,U.S. House,3,,Write-ins,0
-Johnson,Merriam 1-02,U.S. House,3,,Write-ins,0
-Johnson,Merriam 2-01,U.S. House,3,,Write-ins,0
-Johnson,Merriam 2-02,U.S. House,3,,Write-ins,0
-Johnson,Merriam 2-03,U.S. House,3,,Write-ins,0
-Johnson,Merriam 3-01,U.S. House,3,,Write-ins,1
-Johnson,Merriam 3-02,U.S. House,3,,Write-ins,0
-Johnson,Merriam 4-01,U.S. House,3,,Write-ins,0
-Johnson,Merriam 4-02,U.S. House,3,,Write-ins,0
-Johnson,Merriam 4-03,U.S. House,3,,Write-ins,0
-Johnson,Mission 1-01,U.S. House,3,,Write-ins,0
-Johnson,Mission 1-02,U.S. House,3,,Write-ins,0
-Johnson,Mission 2-01,U.S. House,3,,Write-ins,1
-Johnson,Mission 2-02,U.S. House,3,,Write-ins,0
-Johnson,Mission 3-01,U.S. House,3,,Write-ins,0
-Johnson,Mission 3-02,U.S. House,3,,Write-ins,0
-Johnson,Mission 4-01,U.S. House,3,,Write-ins,1
-Johnson,Mission 4-02,U.S. House,3,,Write-ins,0
-Johnson,Mission 4-03,U.S. House,3,,Write-ins,0
-Johnson,Mission Hills 0-01,U.S. House,3,,Write-ins,0
-Johnson,Mission Hills 0-02,U.S. House,3,,Write-ins,1
-Johnson,Mission Hills 0-03,U.S. House,3,,Write-ins,0
-Johnson,Mission Hills 0-04,U.S. House,3,,Write-ins,2
-Johnson,Mission Woods 0-01,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-01,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-02,U.S. House,3,,Write-ins,1
-Johnson,Olathe 1-03,U.S. House,3,,Write-ins,1
-Johnson,Olathe 1-04,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-05,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-06,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-08,U.S. House,3,,Write-ins,1
-Johnson,Olathe 1-09,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-11,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-14,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-15,U.S. House,3,,Write-ins,1
-Johnson,Olathe 1-16,U.S. House,3,,Write-ins,2
-Johnson,Olathe 1-17,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-18,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-19,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-20,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-21,U.S. House,3,,Write-ins,1
-Johnson,Olathe 1-22,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-23,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-24,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-24,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-26,U.S. House,3,,Write-ins,0
-Johnson,Olathe 1-27,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-01,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-02,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-03,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-04,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-05,U.S. House,3,,Write-ins,2
-Johnson,Olathe 2-06,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-07,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-08,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-09,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-10,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-11,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-12,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-13,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-14,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-15,U.S. House,3,,Write-ins,1
-Johnson,Olathe 2-16,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-17,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-19,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-22,U.S. House,3,,Write-ins,0
-Johnson,Olathe 2-23,U.S. House,3,,Write-ins,1
-Johnson,Olathe 3-01,U.S. House,3,,Write-ins,1
-Johnson,Olathe 3-02,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-03,U.S. House,3,,Write-ins,1
-Johnson,Olathe 3-04,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-05,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-06,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-07,U.S. House,3,,Write-ins,1
-Johnson,Olathe 3-08,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-09,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-10,U.S. House,3,,Write-ins,1
-Johnson,Olathe 3-11,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-12,U.S. House,3,,Write-ins,2
-Johnson,Olathe 3-13,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-15,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-16,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-17,U.S. House,3,,Write-ins,1
-Johnson,Olathe 3-18,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-19,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-20,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-21,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-22,U.S. House,3,,Write-ins,0
-Johnson,Olathe 3-23,U.S. House,3,,Write-ins,2
-Johnson,Olathe 3-24,U.S. House,3,,Write-ins,1
-Johnson,Olathe 3-26,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-01,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-02,U.S. House,3,,Write-ins,1
-Johnson,Olathe 4-03,U.S. House,3,,Write-ins,2
-Johnson,Olathe 4-04,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-05,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-06,U.S. House,3,,Write-ins,3
-Johnson,Olathe 4-07,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-08,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-09,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-10,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-11,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-12,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-13,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-14,U.S. House,3,,Write-ins,1
-Johnson,Olathe 4-15,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-16,U.S. House,3,,Write-ins,0
-Johnson,Olathe 4-17,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-01,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-02,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-03,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-04,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-05,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-06,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-07,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-08,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-09,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-10,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-11,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-14,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-24,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-25,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-26,U.S. House,3,,Write-ins,0
-Johnson,Olathe Twp 0-32,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-01,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-02,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-03,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-04,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-05,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-06,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-07,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-08,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-09,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-10,U.S. House,3,,Write-ins,2
-Johnson,Overland Park 1-11,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-12,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-13,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-14,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-15,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-16,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-17,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-18,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-19,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-20,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 1-21,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 1-22,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-01,U.S. House,3,,Write-ins,2
-Johnson,Overland Park 2-02,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-03,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 2-04,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-05,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-06,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 2-07,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-08,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-09,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-10,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 2-11,U.S. House,3,,Write-ins,2
-Johnson,Overland Park 2-12,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 2-13,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-14,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-15,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-16,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 2-17,U.S. House,3,,Write-ins,2
-Johnson,Overland Park 2-18,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 2-19,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-20,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 2-21,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-22,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-23,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-24,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 2-25,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 2-26,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-01,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-02,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 3-03,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-04,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-05,U.S. House,3,,Write-ins,2
-Johnson,Overland Park 3-06,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-07,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-08,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-09,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-10,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-11,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-12,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-13,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 3-14,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 3-15,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 3-16,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 3-17,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-18,U.S. House,3,,Write-ins,2
-Johnson,Overland Park 3-19,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 3-20,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 3-21,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-01,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-02,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-03,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-04,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-05,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 4-06,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 4-07,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-08,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 4-09,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-10,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 4-11,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-12,U.S. House,3,,Write-ins,5
-Johnson,Overland Park 4-13,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 4-14,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-15,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-16,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-17,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 4-18,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-01,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 5-02,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-03,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-04,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-05,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-06,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-07,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-08,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-09,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-10,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-11,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-12,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-13,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 5-14,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-15,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-16,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-17,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-18,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 5-19,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-01,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-02,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-03,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-04,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-05,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-06,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-07,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 6-08,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-09,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 6-10,U.S. House,3,,Write-ins,1
-Johnson,Overland Park 6-11,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-12,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-13,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-15,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-16,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-17,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-18,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-19,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-20,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-21,U.S. House,3,,Write-ins,0
-Johnson,Overland Park 6-22,U.S. House,3,,Write-ins,0
-Johnson,Oxford Twp 0-01,U.S. House,3,,Write-ins,0
-Johnson,Oxford Twp 0-02,U.S. House,3,,Write-ins,0
-Johnson,Oxford Twp 0-04,U.S. House,3,,Write-ins,0
-Johnson,Oxford Twp 0-05,U.S. House,3,,Write-ins,0
-Johnson,Oxford Twp 0-09,U.S. House,3,,Write-ins,0
-Johnson,Oxford Twp 0-10,U.S. House,3,,Write-ins,0
-Johnson,Oxford Twp 0-11,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 1-01,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 1-02,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 1-03,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 2-01,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 2-02,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 2-03,U.S. House,3,,Write-ins,1
-Johnson,Prairie Village 3-01,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 3-02,U.S. House,3,,Write-ins,1
-Johnson,Prairie Village 3-03,U.S. House,3,,Write-ins,1
-Johnson,Prairie Village 4-01,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 4-02,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 4-03,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 5-01,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 5-02,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 5-03,U.S. House,3,,Write-ins,1
-Johnson,Prairie Village 6-01,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 6-02,U.S. House,3,,Write-ins,0
-Johnson,Prairie Village 6-03,U.S. House,3,,Write-ins,1
-Johnson,Roeland Park 1-01,U.S. House,3,,Write-ins,0
-Johnson,Roeland Park 1-02,U.S. House,3,,Write-ins,0
-Johnson,Roeland Park 2-01,U.S. House,3,,Write-ins,0
-Johnson,Roeland Park 2-02,U.S. House,3,,Write-ins,2
-Johnson,Roeland Park 3-01,U.S. House,3,,Write-ins,0
-Johnson,Roeland Park 3-02,U.S. House,3,,Write-ins,1
-Johnson,Roeland Park 4-01,U.S. House,3,,Write-ins,0
-Johnson,Roeland Park 4-02,U.S. House,3,,Write-ins,1
-Johnson,Shawnee 1-01,U.S. House,3,,Write-ins,1
-Johnson,Shawnee 1-02,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 1-03,U.S. House,3,,Write-ins,2
-Johnson,Shawnee 1-04,U.S. House,3,,Write-ins,1
-Johnson,Shawnee 1-05,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 1-06,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 1-07,U.S. House,3,,Write-ins,1
-Johnson,Shawnee 1-08,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 1-09,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 1-10,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 1-11,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 1-12,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-01,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-02,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-03,U.S. House,3,,Write-ins,1
-Johnson,Shawnee 2-04,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-05,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-06,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-07,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-08,U.S. House,3,,Write-ins,2
-Johnson,Shawnee 2-09,U.S. House,3,,Write-ins,1
-Johnson,Shawnee 2-10,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-11,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-12,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 2-13,U.S. House,3,,Write-ins,4
-Johnson,Shawnee 3-01,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 3-02,U.S. House,3,,Write-ins,2
-Johnson,Shawnee 3-03,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 3-04,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 3-05,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 3-06,U.S. House,3,,Write-ins,1
-Johnson,Shawnee 3-07,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 3-08,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 3-09,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-01,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-02,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-03,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-04,U.S. House,3,,Write-ins,1
-Johnson,Shawnee 4-05,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-06,U.S. House,3,,Write-ins,2
-Johnson,Shawnee 4-07,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-08,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-09,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-11,U.S. House,3,,Write-ins,0
-Johnson,Shawnee 4-12,U.S. House,3,,Write-ins,0
-Johnson,Spring Hill 0-01,U.S. House,3,,Write-ins,0
-Johnson,Spring Hill 0-03,U.S. House,3,,Write-ins,0
-Johnson,Spring Hill 0-04,U.S. House,3,,Write-ins,0
-Johnson,Spring Hill Twp 0-01,U.S. House,3,,Write-ins,0
-Johnson,Spring Hill Twp 0-02,U.S. House,3,,Write-ins,0
-Johnson,Spring Hill Twp 0-03,U.S. House,3,,Write-ins,0
-Johnson,Spring Hill Twp 0-04,U.S. House,3,,Write-ins,0
-Johnson,Spring Hill Twp 0-05,U.S. House,3,,Write-ins,0
-Johnson,Westwood 0-01,U.S. House,3,,Write-ins,0
-Johnson,Westwood 0-02,U.S. House,3,,Write-ins,0
-Johnson,Westwood Hills 0-01,U.S. House,3,,Write-ins,0
-Johnson,Aubry Twp 0-01,Governor,,D,Paul Davis,40
-Johnson,Aubry Twp 0-02,Governor,,D,Paul Davis,174
-Johnson,Aubry Twp 0-03,Governor,,D,Paul Davis,115
-Johnson,Aubry Twp 0-04,Governor,,D,Paul Davis,254
-Johnson,Aubry Twp 0-05,Governor,,D,Paul Davis,4
-Johnson,Aubry Twp 0-06,Governor,,D,Paul Davis,24
-Johnson,De Soto 0-01,Governor,,D,Paul Davis,245
-Johnson,De Soto 0-02,Governor,,D,Paul Davis,195
-Johnson,De Soto 0-03,Governor,,D,Paul Davis,255
-Johnson,De Soto 0-06,Governor,,D,Paul Davis,17
-Johnson,De Soto 0-07,Governor,,D,Paul Davis,2
-Johnson,Edgerton 0-01,Governor,,D,Paul Davis,142
-Johnson,Edgerton 0-02,Governor,,D,Paul Davis,0
-Johnson,Edgerton 0-05,Governor,,D,Paul Davis,0
-Johnson,Edgerton 0-06,Governor,,D,Paul Davis,0
-Johnson,Edgerton 0-09,Governor,,D,Paul Davis,0
-Johnson,Fairway 1-01,Governor,,D,Paul Davis,181
-Johnson,Fairway 1-02,Governor,,D,Paul Davis,126
-Johnson,Fairway 2-01,Governor,,D,Paul Davis,137
-Johnson,Fairway 2-02,Governor,,D,Paul Davis,131
-Johnson,Fairway 3-01,Governor,,D,Paul Davis,191
-Johnson,Fairway 3-02,Governor,,D,Paul Davis,134
-Johnson,Fairway 4-01,Governor,,D,Paul Davis,65
-Johnson,Fairway 4-02,Governor,,D,Paul Davis,87
-Johnson,Fairway 4-03,Governor,,D,Paul Davis,51
-Johnson,Fairway 4-04,Governor,,D,Paul Davis,84
-Johnson,Gardner 0-01,Governor,,D,Paul Davis,318
-Johnson,Gardner 0-02,Governor,,D,Paul Davis,57
-Johnson,Gardner 0-03,Governor,,D,Paul Davis,201
-Johnson,Gardner 0-04,Governor,,D,Paul Davis,216
-Johnson,Gardner 0-06,Governor,,D,Paul Davis,217
-Johnson,Gardner 0-07,Governor,,D,Paul Davis,8
-Johnson,Gardner 0-08,Governor,,D,Paul Davis,14
-Johnson,Gardner 0-09,Governor,,D,Paul Davis,289
-Johnson,Gardner 0-10,Governor,,D,Paul Davis,168
-Johnson,Gardner 0-12,Governor,,D,Paul Davis,8
-Johnson,Gardner 0-13,Governor,,D,Paul Davis,225
-Johnson,Gardner 0-14,Governor,,D,Paul Davis,170
-Johnson,Gardner Twp 0-01,Governor,,D,Paul Davis,123
-Johnson,Gardner Twp 0-02,Governor,,D,Paul Davis,124
-Johnson,Gardner Twp 0-04,Governor,,D,Paul Davis,0
-Johnson,Gardner Twp 0-05,Governor,,D,Paul Davis,1
-Johnson,Gardner Twp 0-07,Governor,,D,Paul Davis,1
-Johnson,Gardner Twp 0-08,Governor,,D,Paul Davis,4
-Johnson,Gardner Twp 0-09,Governor,,D,Paul Davis,0
-Johnson,Gardner Twp 0-10,Governor,,D,Paul Davis,0
-Johnson,Gardner Twp 0-11,Governor,,D,Paul Davis,33
-Johnson,Gardner Twp 0-13,Governor,,D,Paul Davis,0
-Johnson,Lake Quivira 0-01,Governor,,D,Paul Davis,245
-Johnson,Leawood 1-01,Governor,,D,Paul Davis,324
-Johnson,Leawood 1-02,Governor,,D,Paul Davis,441
-Johnson,Leawood 1-03,Governor,,D,Paul Davis,342
-Johnson,Leawood 1-04,Governor,,D,Paul Davis,294
-Johnson,Leawood 1-05,Governor,,D,Paul Davis,243
-Johnson,Leawood 1-06,Governor,,D,Paul Davis,78
-Johnson,Leawood 2-01,Governor,,D,Paul Davis,347
-Johnson,Leawood 2-02,Governor,,D,Paul Davis,402
-Johnson,Leawood 2-03,Governor,,D,Paul Davis,352
-Johnson,Leawood 2-04,Governor,,D,Paul Davis,270
-Johnson,Leawood 2-05,Governor,,D,Paul Davis,198
-Johnson,Leawood 2-06,Governor,,D,Paul Davis,135
-Johnson,Leawood 3-01,Governor,,D,Paul Davis,218
-Johnson,Leawood 3-02,Governor,,D,Paul Davis,332
-Johnson,Leawood 3-03,Governor,,D,Paul Davis,187
-Johnson,Leawood 3-04,Governor,,D,Paul Davis,91
-Johnson,Leawood 3-05,Governor,,D,Paul Davis,318
-Johnson,Leawood 3-06,Governor,,D,Paul Davis,284
-Johnson,Leawood 3-07,Governor,,D,Paul Davis,271
-Johnson,Leawood 4-01,Governor,,D,Paul Davis,74
-Johnson,Leawood 4-02,Governor,,D,Paul Davis,256
-Johnson,Leawood 4-03,Governor,,D,Paul Davis,275
-Johnson,Leawood 4-04,Governor,,D,Paul Davis,306
-Johnson,Leawood 4-05,Governor,,D,Paul Davis,358
-Johnson,Leawood 4-06,Governor,,D,Paul Davis,355
-Johnson,Leawood 4-07,Governor,,D,Paul Davis,551
-Johnson,Leawood 4-08,Governor,,D,Paul Davis,247
-Johnson,Lenexa 1-01,Governor,,D,Paul Davis,181
-Johnson,Lenexa 1-02,Governor,,D,Paul Davis,335
-Johnson,Lenexa 1-03,Governor,,D,Paul Davis,381
-Johnson,Lenexa 1-04,Governor,,D,Paul Davis,262
-Johnson,Lenexa 1-05,Governor,,D,Paul Davis,287
-Johnson,Lenexa 1-06,Governor,,D,Paul Davis,380
-Johnson,Lenexa 1-07,Governor,,D,Paul Davis,169
-Johnson,Lenexa 1-08,Governor,,D,Paul Davis,78
-Johnson,Lenexa 1-09,Governor,,D,Paul Davis,6
-Johnson,Lenexa 2-01,Governor,,D,Paul Davis,535
-Johnson,Lenexa 2-02,Governor,,D,Paul Davis,222
-Johnson,Lenexa 2-03,Governor,,D,Paul Davis,471
-Johnson,Lenexa 2-04,Governor,,D,Paul Davis,528
-Johnson,Lenexa 2-05,Governor,,D,Paul Davis,211
-Johnson,Lenexa 2-06,Governor,,D,Paul Davis,343
-Johnson,Lenexa 2-07,Governor,,D,Paul Davis,472
-Johnson,Lenexa 3-01,Governor,,D,Paul Davis,185
-Johnson,Lenexa 3-02,Governor,,D,Paul Davis,270
-Johnson,Lenexa 3-03,Governor,,D,Paul Davis,415
-Johnson,Lenexa 3-04,Governor,,D,Paul Davis,296
-Johnson,Lenexa 3-05,Governor,,D,Paul Davis,125
-Johnson,Lenexa 3-06,Governor,,D,Paul Davis,228
-Johnson,Lenexa 3-07,Governor,,D,Paul Davis,321
-Johnson,Lenexa 3-08,Governor,,D,Paul Davis,329
-Johnson,Lenexa 4-01,Governor,,D,Paul Davis,130
-Johnson,Lenexa 4-02,Governor,,D,Paul Davis,285
-Johnson,Lenexa 4-03,Governor,,D,Paul Davis,93
-Johnson,Lenexa 4-04,Governor,,D,Paul Davis,140
-Johnson,Lenexa 4-05,Governor,,D,Paul Davis,104
-Johnson,Lenexa 4-06,Governor,,D,Paul Davis,186
-Johnson,Lenexa 4-07,Governor,,D,Paul Davis,244
-Johnson,Lenexa 4-08,Governor,,D,Paul Davis,248
-Johnson,Lenexa 4-09,Governor,,D,Paul Davis,231
-Johnson,Lenexa 4-10,Governor,,D,Paul Davis,118
-Johnson,Lenexa 4-11,Governor,,D,Paul Davis,30
-Johnson,Lexington Twp 0-01,Governor,,D,Paul Davis,378
-Johnson,Lexington Twp 0-02,Governor,,D,Paul Davis,1
-Johnson,Lexington Twp 0-03,Governor,,D,Paul Davis,1
-Johnson,McCamish Twp 0-01,Governor,,D,Paul Davis,36
-Johnson,McCamish Twp 0-02,Governor,,D,Paul Davis,89
-Johnson,Merriam 1-01,Governor,,D,Paul Davis,185
-Johnson,Merriam 1-02,Governor,,D,Paul Davis,233
-Johnson,Merriam 2-01,Governor,,D,Paul Davis,292
-Johnson,Merriam 2-02,Governor,,D,Paul Davis,1
-Johnson,Merriam 2-03,Governor,,D,Paul Davis,159
-Johnson,Merriam 3-01,Governor,,D,Paul Davis,257
-Johnson,Merriam 3-02,Governor,,D,Paul Davis,245
-Johnson,Merriam 4-01,Governor,,D,Paul Davis,299
-Johnson,Merriam 4-02,Governor,,D,Paul Davis,141
-Johnson,Merriam 4-03,Governor,,D,Paul Davis,196
-Johnson,Mission 1-01,Governor,,D,Paul Davis,301
-Johnson,Mission 1-02,Governor,,D,Paul Davis,171
-Johnson,Mission 2-01,Governor,,D,Paul Davis,187
-Johnson,Mission 2-02,Governor,,D,Paul Davis,270
-Johnson,Mission 3-01,Governor,,D,Paul Davis,266
-Johnson,Mission 3-02,Governor,,D,Paul Davis,157
-Johnson,Mission 4-01,Governor,,D,Paul Davis,217
-Johnson,Mission 4-02,Governor,,D,Paul Davis,316
-Johnson,Mission 4-03,Governor,,D,Paul Davis,149
-Johnson,Mission Hills 0-01,Governor,,D,Paul Davis,177
-Johnson,Mission Hills 0-02,Governor,,D,Paul Davis,300
-Johnson,Mission Hills 0-03,Governor,,D,Paul Davis,156
-Johnson,Mission Hills 0-04,Governor,,D,Paul Davis,294
-Johnson,Mission Woods 0-01,Governor,,D,Paul Davis,60
-Johnson,Olathe 1-01,Governor,,D,Paul Davis,249
-Johnson,Olathe 1-02,Governor,,D,Paul Davis,167
-Johnson,Olathe 1-03,Governor,,D,Paul Davis,125
-Johnson,Olathe 1-04,Governor,,D,Paul Davis,241
-Johnson,Olathe 1-05,Governor,,D,Paul Davis,238
-Johnson,Olathe 1-06,Governor,,D,Paul Davis,135
-Johnson,Olathe 1-08,Governor,,D,Paul Davis,281
-Johnson,Olathe 1-09,Governor,,D,Paul Davis,223
-Johnson,Olathe 1-11,Governor,,D,Paul Davis,44
-Johnson,Olathe 1-14,Governor,,D,Paul Davis,204
-Johnson,Olathe 1-15,Governor,,D,Paul Davis,207
-Johnson,Olathe 1-16,Governor,,D,Paul Davis,248
-Johnson,Olathe 1-17,Governor,,D,Paul Davis,55
-Johnson,Olathe 1-18,Governor,,D,Paul Davis,75
-Johnson,Olathe 1-19,Governor,,D,Paul Davis,104
-Johnson,Olathe 1-20,Governor,,D,Paul Davis,187
-Johnson,Olathe 1-21,Governor,,D,Paul Davis,290
-Johnson,Olathe 1-22,Governor,,D,Paul Davis,354
-Johnson,Olathe 1-23,Governor,,D,Paul Davis,0
-Johnson,Olathe 1-24,Governor,,D,Paul Davis,28
-Johnson,Olathe 1-24,Governor,,D,Paul Davis,67
-Johnson,Olathe 1-26,Governor,,D,Paul Davis,2
-Johnson,Olathe 1-27,Governor,,D,Paul Davis,181
-Johnson,Olathe 2-01,Governor,,D,Paul Davis,102
-Johnson,Olathe 2-02,Governor,,D,Paul Davis,181
-Johnson,Olathe 2-03,Governor,,D,Paul Davis,172
-Johnson,Olathe 2-04,Governor,,D,Paul Davis,216
-Johnson,Olathe 2-05,Governor,,D,Paul Davis,458
-Johnson,Olathe 2-06,Governor,,D,Paul Davis,244
-Johnson,Olathe 2-07,Governor,,D,Paul Davis,337
-Johnson,Olathe 2-08,Governor,,D,Paul Davis,250
-Johnson,Olathe 2-09,Governor,,D,Paul Davis,114
-Johnson,Olathe 2-10,Governor,,D,Paul Davis,498
-Johnson,Olathe 2-11,Governor,,D,Paul Davis,339
-Johnson,Olathe 2-12,Governor,,D,Paul Davis,192
-Johnson,Olathe 2-13,Governor,,D,Paul Davis,222
-Johnson,Olathe 2-14,Governor,,D,Paul Davis,177
-Johnson,Olathe 2-15,Governor,,D,Paul Davis,158
-Johnson,Olathe 2-16,Governor,,D,Paul Davis,92
-Johnson,Olathe 2-17,Governor,,D,Paul Davis,1
-Johnson,Olathe 2-19,Governor,,D,Paul Davis,1
-Johnson,Olathe 2-22,Governor,,D,Paul Davis,391
-Johnson,Olathe 2-23,Governor,,D,Paul Davis,261
-Johnson,Olathe 3-01,Governor,,D,Paul Davis,109
-Johnson,Olathe 3-02,Governor,,D,Paul Davis,295
-Johnson,Olathe 3-03,Governor,,D,Paul Davis,129
-Johnson,Olathe 3-04,Governor,,D,Paul Davis,237
-Johnson,Olathe 3-05,Governor,,D,Paul Davis,220
-Johnson,Olathe 3-06,Governor,,D,Paul Davis,176
-Johnson,Olathe 3-07,Governor,,D,Paul Davis,188
-Johnson,Olathe 3-08,Governor,,D,Paul Davis,273
-Johnson,Olathe 3-09,Governor,,D,Paul Davis,118
-Johnson,Olathe 3-10,Governor,,D,Paul Davis,262
-Johnson,Olathe 3-11,Governor,,D,Paul Davis,194
-Johnson,Olathe 3-12,Governor,,D,Paul Davis,255
-Johnson,Olathe 3-13,Governor,,D,Paul Davis,270
-Johnson,Olathe 3-15,Governor,,D,Paul Davis,186
-Johnson,Olathe 3-16,Governor,,D,Paul Davis,198
-Johnson,Olathe 3-17,Governor,,D,Paul Davis,241
-Johnson,Olathe 3-18,Governor,,D,Paul Davis,225
-Johnson,Olathe 3-19,Governor,,D,Paul Davis,128
-Johnson,Olathe 3-20,Governor,,D,Paul Davis,169
-Johnson,Olathe 3-21,Governor,,D,Paul Davis,135
-Johnson,Olathe 3-22,Governor,,D,Paul Davis,213
-Johnson,Olathe 3-23,Governor,,D,Paul Davis,218
-Johnson,Olathe 3-24,Governor,,D,Paul Davis,132
-Johnson,Olathe 3-26,Governor,,D,Paul Davis,23
-Johnson,Olathe 4-01,Governor,,D,Paul Davis,205
-Johnson,Olathe 4-02,Governor,,D,Paul Davis,373
-Johnson,Olathe 4-03,Governor,,D,Paul Davis,136
-Johnson,Olathe 4-04,Governor,,D,Paul Davis,146
-Johnson,Olathe 4-05,Governor,,D,Paul Davis,272
-Johnson,Olathe 4-06,Governor,,D,Paul Davis,331
-Johnson,Olathe 4-07,Governor,,D,Paul Davis,279
-Johnson,Olathe 4-08,Governor,,D,Paul Davis,233
-Johnson,Olathe 4-09,Governor,,D,Paul Davis,318
-Johnson,Olathe 4-10,Governor,,D,Paul Davis,197
-Johnson,Olathe 4-11,Governor,,D,Paul Davis,134
-Johnson,Olathe 4-12,Governor,,D,Paul Davis,284
-Johnson,Olathe 4-13,Governor,,D,Paul Davis,153
-Johnson,Olathe 4-14,Governor,,D,Paul Davis,339
-Johnson,Olathe 4-15,Governor,,D,Paul Davis,17
-Johnson,Olathe 4-16,Governor,,D,Paul Davis,97
-Johnson,Olathe 4-17,Governor,,D,Paul Davis,2
-Johnson,Olathe Twp 0-01,Governor,,D,Paul Davis,115
-Johnson,Olathe Twp 0-02,Governor,,D,Paul Davis,17
-Johnson,Olathe Twp 0-03,Governor,,D,Paul Davis,20
-Johnson,Olathe Twp 0-04,Governor,,D,Paul Davis,1
-Johnson,Olathe Twp 0-05,Governor,,D,Paul Davis,0
-Johnson,Olathe Twp 0-06,Governor,,D,Paul Davis,0
-Johnson,Olathe Twp 0-07,Governor,,D,Paul Davis,0
-Johnson,Olathe Twp 0-08,Governor,,D,Paul Davis,2
-Johnson,Olathe Twp 0-09,Governor,,D,Paul Davis,0
-Johnson,Olathe Twp 0-10,Governor,,D,Paul Davis,6
-Johnson,Olathe Twp 0-11,Governor,,D,Paul Davis,1
-Johnson,Olathe Twp 0-14,Governor,,D,Paul Davis,0
-Johnson,Olathe Twp 0-24,Governor,,D,Paul Davis,1
-Johnson,Olathe Twp 0-25,Governor,,D,Paul Davis,1
-Johnson,Olathe Twp 0-26,Governor,,D,Paul Davis,0
-Johnson,Olathe Twp 0-32,Governor,,D,Paul Davis,5
-Johnson,Overland Park 1-01,Governor,,D,Paul Davis,296
-Johnson,Overland Park 1-02,Governor,,D,Paul Davis,302
-Johnson,Overland Park 1-03,Governor,,D,Paul Davis,279
-Johnson,Overland Park 1-04,Governor,,D,Paul Davis,87
-Johnson,Overland Park 1-05,Governor,,D,Paul Davis,205
-Johnson,Overland Park 1-06,Governor,,D,Paul Davis,378
-Johnson,Overland Park 1-07,Governor,,D,Paul Davis,334
-Johnson,Overland Park 1-08,Governor,,D,Paul Davis,223
-Johnson,Overland Park 1-09,Governor,,D,Paul Davis,157
-Johnson,Overland Park 1-10,Governor,,D,Paul Davis,307
-Johnson,Overland Park 1-11,Governor,,D,Paul Davis,79
-Johnson,Overland Park 1-12,Governor,,D,Paul Davis,255
-Johnson,Overland Park 1-13,Governor,,D,Paul Davis,186
-Johnson,Overland Park 1-14,Governor,,D,Paul Davis,311
-Johnson,Overland Park 1-15,Governor,,D,Paul Davis,139
-Johnson,Overland Park 1-16,Governor,,D,Paul Davis,368
-Johnson,Overland Park 1-17,Governor,,D,Paul Davis,156
-Johnson,Overland Park 1-18,Governor,,D,Paul Davis,318
-Johnson,Overland Park 1-19,Governor,,D,Paul Davis,211
-Johnson,Overland Park 1-20,Governor,,D,Paul Davis,179
-Johnson,Overland Park 1-21,Governor,,D,Paul Davis,75
-Johnson,Overland Park 1-22,Governor,,D,Paul Davis,70
-Johnson,Overland Park 2-01,Governor,,D,Paul Davis,245
-Johnson,Overland Park 2-02,Governor,,D,Paul Davis,312
-Johnson,Overland Park 2-03,Governor,,D,Paul Davis,257
-Johnson,Overland Park 2-04,Governor,,D,Paul Davis,282
-Johnson,Overland Park 2-05,Governor,,D,Paul Davis,256
-Johnson,Overland Park 2-06,Governor,,D,Paul Davis,245
-Johnson,Overland Park 2-07,Governor,,D,Paul Davis,203
-Johnson,Overland Park 2-08,Governor,,D,Paul Davis,157
-Johnson,Overland Park 2-09,Governor,,D,Paul Davis,209
-Johnson,Overland Park 2-10,Governor,,D,Paul Davis,127
-Johnson,Overland Park 2-11,Governor,,D,Paul Davis,255
-Johnson,Overland Park 2-12,Governor,,D,Paul Davis,183
-Johnson,Overland Park 2-13,Governor,,D,Paul Davis,113
-Johnson,Overland Park 2-14,Governor,,D,Paul Davis,195
-Johnson,Overland Park 2-15,Governor,,D,Paul Davis,378
-Johnson,Overland Park 2-16,Governor,,D,Paul Davis,226
-Johnson,Overland Park 2-17,Governor,,D,Paul Davis,295
-Johnson,Overland Park 2-18,Governor,,D,Paul Davis,338
-Johnson,Overland Park 2-19,Governor,,D,Paul Davis,227
-Johnson,Overland Park 2-20,Governor,,D,Paul Davis,207
-Johnson,Overland Park 2-21,Governor,,D,Paul Davis,242
-Johnson,Overland Park 2-22,Governor,,D,Paul Davis,269
-Johnson,Overland Park 2-23,Governor,,D,Paul Davis,252
-Johnson,Overland Park 2-24,Governor,,D,Paul Davis,398
-Johnson,Overland Park 2-25,Governor,,D,Paul Davis,318
-Johnson,Overland Park 2-26,Governor,,D,Paul Davis,120
-Johnson,Overland Park 3-01,Governor,,D,Paul Davis,352
-Johnson,Overland Park 3-02,Governor,,D,Paul Davis,269
-Johnson,Overland Park 3-03,Governor,,D,Paul Davis,251
-Johnson,Overland Park 3-04,Governor,,D,Paul Davis,341
-Johnson,Overland Park 3-05,Governor,,D,Paul Davis,312
-Johnson,Overland Park 3-06,Governor,,D,Paul Davis,359
-Johnson,Overland Park 3-07,Governor,,D,Paul Davis,242
-Johnson,Overland Park 3-08,Governor,,D,Paul Davis,263
-Johnson,Overland Park 3-09,Governor,,D,Paul Davis,397
-Johnson,Overland Park 3-10,Governor,,D,Paul Davis,198
-Johnson,Overland Park 3-11,Governor,,D,Paul Davis,241
-Johnson,Overland Park 3-12,Governor,,D,Paul Davis,198
-Johnson,Overland Park 3-13,Governor,,D,Paul Davis,417
-Johnson,Overland Park 3-14,Governor,,D,Paul Davis,325
-Johnson,Overland Park 3-15,Governor,,D,Paul Davis,172
-Johnson,Overland Park 3-16,Governor,,D,Paul Davis,300
-Johnson,Overland Park 3-17,Governor,,D,Paul Davis,241
-Johnson,Overland Park 3-18,Governor,,D,Paul Davis,248
-Johnson,Overland Park 3-19,Governor,,D,Paul Davis,250
-Johnson,Overland Park 3-20,Governor,,D,Paul Davis,339
-Johnson,Overland Park 3-21,Governor,,D,Paul Davis,260
-Johnson,Overland Park 4-01,Governor,,D,Paul Davis,162
-Johnson,Overland Park 4-02,Governor,,D,Paul Davis,226
-Johnson,Overland Park 4-03,Governor,,D,Paul Davis,248
-Johnson,Overland Park 4-04,Governor,,D,Paul Davis,351
-Johnson,Overland Park 4-05,Governor,,D,Paul Davis,283
-Johnson,Overland Park 4-06,Governor,,D,Paul Davis,240
-Johnson,Overland Park 4-07,Governor,,D,Paul Davis,229
-Johnson,Overland Park 4-08,Governor,,D,Paul Davis,276
-Johnson,Overland Park 4-09,Governor,,D,Paul Davis,193
-Johnson,Overland Park 4-10,Governor,,D,Paul Davis,164
-Johnson,Overland Park 4-11,Governor,,D,Paul Davis,336
-Johnson,Overland Park 4-12,Governor,,D,Paul Davis,415
-Johnson,Overland Park 4-13,Governor,,D,Paul Davis,143
-Johnson,Overland Park 4-14,Governor,,D,Paul Davis,137
-Johnson,Overland Park 4-15,Governor,,D,Paul Davis,346
-Johnson,Overland Park 4-16,Governor,,D,Paul Davis,200
-Johnson,Overland Park 4-17,Governor,,D,Paul Davis,322
-Johnson,Overland Park 4-18,Governor,,D,Paul Davis,53
-Johnson,Overland Park 5-01,Governor,,D,Paul Davis,301
-Johnson,Overland Park 5-02,Governor,,D,Paul Davis,154
-Johnson,Overland Park 5-03,Governor,,D,Paul Davis,263
-Johnson,Overland Park 5-04,Governor,,D,Paul Davis,277
-Johnson,Overland Park 5-05,Governor,,D,Paul Davis,246
-Johnson,Overland Park 5-06,Governor,,D,Paul Davis,215
-Johnson,Overland Park 5-07,Governor,,D,Paul Davis,234
-Johnson,Overland Park 5-08,Governor,,D,Paul Davis,350
-Johnson,Overland Park 5-09,Governor,,D,Paul Davis,395
-Johnson,Overland Park 5-10,Governor,,D,Paul Davis,276
-Johnson,Overland Park 5-11,Governor,,D,Paul Davis,383
-Johnson,Overland Park 5-12,Governor,,D,Paul Davis,75
-Johnson,Overland Park 5-13,Governor,,D,Paul Davis,418
-Johnson,Overland Park 5-14,Governor,,D,Paul Davis,296
-Johnson,Overland Park 5-15,Governor,,D,Paul Davis,231
-Johnson,Overland Park 5-16,Governor,,D,Paul Davis,173
-Johnson,Overland Park 5-17,Governor,,D,Paul Davis,123
-Johnson,Overland Park 5-18,Governor,,D,Paul Davis,240
-Johnson,Overland Park 5-19,Governor,,D,Paul Davis,22
-Johnson,Overland Park 6-01,Governor,,D,Paul Davis,297
-Johnson,Overland Park 6-02,Governor,,D,Paul Davis,224
-Johnson,Overland Park 6-03,Governor,,D,Paul Davis,247
-Johnson,Overland Park 6-04,Governor,,D,Paul Davis,230
-Johnson,Overland Park 6-05,Governor,,D,Paul Davis,304
-Johnson,Overland Park 6-06,Governor,,D,Paul Davis,0
-Johnson,Overland Park 6-07,Governor,,D,Paul Davis,68
-Johnson,Overland Park 6-08,Governor,,D,Paul Davis,289
-Johnson,Overland Park 6-09,Governor,,D,Paul Davis,354
-Johnson,Overland Park 6-10,Governor,,D,Paul Davis,219
-Johnson,Overland Park 6-11,Governor,,D,Paul Davis,227
-Johnson,Overland Park 6-12,Governor,,D,Paul Davis,111
-Johnson,Overland Park 6-13,Governor,,D,Paul Davis,286
-Johnson,Overland Park 6-15,Governor,,D,Paul Davis,279
-Johnson,Overland Park 6-16,Governor,,D,Paul Davis,150
-Johnson,Overland Park 6-17,Governor,,D,Paul Davis,53
-Johnson,Overland Park 6-18,Governor,,D,Paul Davis,1
-Johnson,Overland Park 6-19,Governor,,D,Paul Davis,333
-Johnson,Overland Park 6-20,Governor,,D,Paul Davis,90
-Johnson,Overland Park 6-21,Governor,,D,Paul Davis,271
-Johnson,Overland Park 6-22,Governor,,D,Paul Davis,118
-Johnson,Oxford Twp 0-01,Governor,,D,Paul Davis,2
-Johnson,Oxford Twp 0-02,Governor,,D,Paul Davis,146
-Johnson,Oxford Twp 0-04,Governor,,D,Paul Davis,143
-Johnson,Oxford Twp 0-05,Governor,,D,Paul Davis,0
-Johnson,Oxford Twp 0-09,Governor,,D,Paul Davis,6
-Johnson,Oxford Twp 0-10,Governor,,D,Paul Davis,0
-Johnson,Oxford Twp 0-11,Governor,,D,Paul Davis,23
-Johnson,Prairie Village 1-01,Governor,,D,Paul Davis,457
-Johnson,Prairie Village 1-02,Governor,,D,Paul Davis,326
-Johnson,Prairie Village 1-03,Governor,,D,Paul Davis,463
-Johnson,Prairie Village 2-01,Governor,,D,Paul Davis,376
-Johnson,Prairie Village 2-02,Governor,,D,Paul Davis,159
-Johnson,Prairie Village 2-03,Governor,,D,Paul Davis,327
-Johnson,Prairie Village 3-01,Governor,,D,Paul Davis,243
-Johnson,Prairie Village 3-02,Governor,,D,Paul Davis,361
-Johnson,Prairie Village 3-03,Governor,,D,Paul Davis,341
-Johnson,Prairie Village 4-01,Governor,,D,Paul Davis,365
-Johnson,Prairie Village 4-02,Governor,,D,Paul Davis,254
-Johnson,Prairie Village 4-03,Governor,,D,Paul Davis,422
-Johnson,Prairie Village 5-01,Governor,,D,Paul Davis,417
-Johnson,Prairie Village 5-02,Governor,,D,Paul Davis,378
-Johnson,Prairie Village 5-03,Governor,,D,Paul Davis,279
-Johnson,Prairie Village 6-01,Governor,,D,Paul Davis,394
-Johnson,Prairie Village 6-02,Governor,,D,Paul Davis,361
-Johnson,Prairie Village 6-03,Governor,,D,Paul Davis,198
-Johnson,Roeland Park 1-01,Governor,,D,Paul Davis,149
-Johnson,Roeland Park 1-02,Governor,,D,Paul Davis,130
-Johnson,Roeland Park 2-01,Governor,,D,Paul Davis,177
-Johnson,Roeland Park 2-02,Governor,,D,Paul Davis,227
-Johnson,Roeland Park 3-01,Governor,,D,Paul Davis,169
-Johnson,Roeland Park 3-02,Governor,,D,Paul Davis,318
-Johnson,Roeland Park 4-01,Governor,,D,Paul Davis,120
-Johnson,Roeland Park 4-02,Governor,,D,Paul Davis,383
-Johnson,Shawnee 1-01,Governor,,D,Paul Davis,339
-Johnson,Shawnee 1-02,Governor,,D,Paul Davis,255
-Johnson,Shawnee 1-03,Governor,,D,Paul Davis,241
-Johnson,Shawnee 1-04,Governor,,D,Paul Davis,356
-Johnson,Shawnee 1-05,Governor,,D,Paul Davis,416
-Johnson,Shawnee 1-06,Governor,,D,Paul Davis,270
-Johnson,Shawnee 1-07,Governor,,D,Paul Davis,322
-Johnson,Shawnee 1-08,Governor,,D,Paul Davis,304
-Johnson,Shawnee 1-09,Governor,,D,Paul Davis,56
-Johnson,Shawnee 1-10,Governor,,D,Paul Davis,105
-Johnson,Shawnee 1-11,Governor,,D,Paul Davis,196
-Johnson,Shawnee 1-12,Governor,,D,Paul Davis,3
-Johnson,Shawnee 2-01,Governor,,D,Paul Davis,123
-Johnson,Shawnee 2-02,Governor,,D,Paul Davis,257
-Johnson,Shawnee 2-03,Governor,,D,Paul Davis,221
-Johnson,Shawnee 2-04,Governor,,D,Paul Davis,344
-Johnson,Shawnee 2-05,Governor,,D,Paul Davis,149
-Johnson,Shawnee 2-06,Governor,,D,Paul Davis,195
-Johnson,Shawnee 2-07,Governor,,D,Paul Davis,182
-Johnson,Shawnee 2-08,Governor,,D,Paul Davis,162
-Johnson,Shawnee 2-09,Governor,,D,Paul Davis,174
-Johnson,Shawnee 2-10,Governor,,D,Paul Davis,141
-Johnson,Shawnee 2-11,Governor,,D,Paul Davis,231
-Johnson,Shawnee 2-12,Governor,,D,Paul Davis,73
-Johnson,Shawnee 2-13,Governor,,D,Paul Davis,130
-Johnson,Shawnee 3-01,Governor,,D,Paul Davis,155
-Johnson,Shawnee 3-02,Governor,,D,Paul Davis,334
-Johnson,Shawnee 3-03,Governor,,D,Paul Davis,283
-Johnson,Shawnee 3-04,Governor,,D,Paul Davis,223
-Johnson,Shawnee 3-05,Governor,,D,Paul Davis,292
-Johnson,Shawnee 3-06,Governor,,D,Paul Davis,253
-Johnson,Shawnee 3-07,Governor,,D,Paul Davis,303
-Johnson,Shawnee 3-08,Governor,,D,Paul Davis,289
-Johnson,Shawnee 3-09,Governor,,D,Paul Davis,136
-Johnson,Shawnee 4-01,Governor,,D,Paul Davis,364
-Johnson,Shawnee 4-02,Governor,,D,Paul Davis,200
-Johnson,Shawnee 4-03,Governor,,D,Paul Davis,82
-Johnson,Shawnee 4-04,Governor,,D,Paul Davis,125
-Johnson,Shawnee 4-05,Governor,,D,Paul Davis,311
-Johnson,Shawnee 4-06,Governor,,D,Paul Davis,237
-Johnson,Shawnee 4-07,Governor,,D,Paul Davis,365
-Johnson,Shawnee 4-08,Governor,,D,Paul Davis,138
-Johnson,Shawnee 4-09,Governor,,D,Paul Davis,419
-Johnson,Shawnee 4-11,Governor,,D,Paul Davis,235
-Johnson,Shawnee 4-12,Governor,,D,Paul Davis,42
-Johnson,Spring Hill 0-01,Governor,,D,Paul Davis,322
-Johnson,Spring Hill 0-03,Governor,,D,Paul Davis,24
-Johnson,Spring Hill 0-04,Governor,,D,Paul Davis,0
-Johnson,Spring Hill Twp 0-01,Governor,,D,Paul Davis,243
-Johnson,Spring Hill Twp 0-02,Governor,,D,Paul Davis,2
-Johnson,Spring Hill Twp 0-03,Governor,,D,Paul Davis,24
-Johnson,Spring Hill Twp 0-04,Governor,,D,Paul Davis,3
-Johnson,Spring Hill Twp 0-05,Governor,,D,Paul Davis,6
-Johnson,Westwood 0-01,Governor,,D,Paul Davis,245
-Johnson,Westwood 0-02,Governor,,D,Paul Davis,236
-Johnson,Westwood Hills 0-01,Governor,,D,Paul Davis,149
-Johnson,Aubry Twp 0-01,Governor,,R,Sam Brownback,68
-Johnson,Aubry Twp 0-02,Governor,,R,Sam Brownback,386
-Johnson,Aubry Twp 0-03,Governor,,R,Sam Brownback,194
-Johnson,Aubry Twp 0-04,Governor,,R,Sam Brownback,453
-Johnson,Aubry Twp 0-05,Governor,,R,Sam Brownback,7
-Johnson,Aubry Twp 0-06,Governor,,R,Sam Brownback,58
-Johnson,De Soto 0-01,Governor,,R,Sam Brownback,352
-Johnson,De Soto 0-02,Governor,,R,Sam Brownback,178
-Johnson,De Soto 0-03,Governor,,R,Sam Brownback,367
-Johnson,De Soto 0-06,Governor,,R,Sam Brownback,26
-Johnson,De Soto 0-07,Governor,,R,Sam Brownback,0
-Johnson,Edgerton 0-01,Governor,,R,Sam Brownback,240
-Johnson,Edgerton 0-02,Governor,,R,Sam Brownback,0
-Johnson,Edgerton 0-05,Governor,,R,Sam Brownback,0
-Johnson,Edgerton 0-06,Governor,,R,Sam Brownback,0
-Johnson,Edgerton 0-09,Governor,,R,Sam Brownback,0
-Johnson,Fairway 1-01,Governor,,R,Sam Brownback,102
-Johnson,Fairway 1-02,Governor,,R,Sam Brownback,81
-Johnson,Fairway 2-01,Governor,,R,Sam Brownback,85
-Johnson,Fairway 2-02,Governor,,R,Sam Brownback,93
-Johnson,Fairway 3-01,Governor,,R,Sam Brownback,121
-Johnson,Fairway 3-02,Governor,,R,Sam Brownback,107
-Johnson,Fairway 4-01,Governor,,R,Sam Brownback,20
-Johnson,Fairway 4-02,Governor,,R,Sam Brownback,33
-Johnson,Fairway 4-03,Governor,,R,Sam Brownback,32
-Johnson,Fairway 4-04,Governor,,R,Sam Brownback,35
-Johnson,Gardner 0-01,Governor,,R,Sam Brownback,441
-Johnson,Gardner 0-02,Governor,,R,Sam Brownback,52
-Johnson,Gardner 0-03,Governor,,R,Sam Brownback,245
-Johnson,Gardner 0-04,Governor,,R,Sam Brownback,248
-Johnson,Gardner 0-06,Governor,,R,Sam Brownback,333
-Johnson,Gardner 0-07,Governor,,R,Sam Brownback,5
-Johnson,Gardner 0-08,Governor,,R,Sam Brownback,33
-Johnson,Gardner 0-09,Governor,,R,Sam Brownback,351
-Johnson,Gardner 0-10,Governor,,R,Sam Brownback,239
-Johnson,Gardner 0-12,Governor,,R,Sam Brownback,4
-Johnson,Gardner 0-13,Governor,,R,Sam Brownback,235
-Johnson,Gardner 0-14,Governor,,R,Sam Brownback,215
-Johnson,Gardner Twp 0-01,Governor,,R,Sam Brownback,177
-Johnson,Gardner Twp 0-02,Governor,,R,Sam Brownback,208
-Johnson,Gardner Twp 0-04,Governor,,R,Sam Brownback,2
-Johnson,Gardner Twp 0-05,Governor,,R,Sam Brownback,5
-Johnson,Gardner Twp 0-07,Governor,,R,Sam Brownback,2
-Johnson,Gardner Twp 0-08,Governor,,R,Sam Brownback,1
-Johnson,Gardner Twp 0-09,Governor,,R,Sam Brownback,0
-Johnson,Gardner Twp 0-10,Governor,,R,Sam Brownback,0
-Johnson,Gardner Twp 0-11,Governor,,R,Sam Brownback,50
-Johnson,Gardner Twp 0-13,Governor,,R,Sam Brownback,1
-Johnson,Lake Quivira 0-01,Governor,,R,Sam Brownback,284
-Johnson,Leawood 1-01,Governor,,R,Sam Brownback,169
-Johnson,Leawood 1-02,Governor,,R,Sam Brownback,359
-Johnson,Leawood 1-03,Governor,,R,Sam Brownback,319
-Johnson,Leawood 1-04,Governor,,R,Sam Brownback,244
-Johnson,Leawood 1-05,Governor,,R,Sam Brownback,219
-Johnson,Leawood 1-06,Governor,,R,Sam Brownback,46
-Johnson,Leawood 2-01,Governor,,R,Sam Brownback,273
-Johnson,Leawood 2-02,Governor,,R,Sam Brownback,313
-Johnson,Leawood 2-03,Governor,,R,Sam Brownback,366
-Johnson,Leawood 2-04,Governor,,R,Sam Brownback,486
-Johnson,Leawood 2-05,Governor,,R,Sam Brownback,220
-Johnson,Leawood 2-06,Governor,,R,Sam Brownback,175
-Johnson,Leawood 3-01,Governor,,R,Sam Brownback,198
-Johnson,Leawood 3-02,Governor,,R,Sam Brownback,353
-Johnson,Leawood 3-03,Governor,,R,Sam Brownback,241
-Johnson,Leawood 3-04,Governor,,R,Sam Brownback,98
-Johnson,Leawood 3-05,Governor,,R,Sam Brownback,479
-Johnson,Leawood 3-06,Governor,,R,Sam Brownback,512
-Johnson,Leawood 3-07,Governor,,R,Sam Brownback,331
-Johnson,Leawood 4-01,Governor,,R,Sam Brownback,133
-Johnson,Leawood 4-02,Governor,,R,Sam Brownback,347
-Johnson,Leawood 4-03,Governor,,R,Sam Brownback,301
-Johnson,Leawood 4-04,Governor,,R,Sam Brownback,369
-Johnson,Leawood 4-05,Governor,,R,Sam Brownback,3
-Johnson,Leawood 4-06,Governor,,R,Sam Brownback,0
-Johnson,Leawood 4-07,Governor,,R,Sam Brownback,3
-Johnson,Leawood 4-08,Governor,,R,Sam Brownback,1
-Johnson,Lenexa 1-01,Governor,,R,Sam Brownback,0
-Johnson,Lenexa 1-02,Governor,,R,Sam Brownback,3
-Johnson,Lenexa 1-03,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 1-04,Governor,,R,Sam Brownback,5
-Johnson,Lenexa 1-05,Governor,,R,Sam Brownback,1
-Johnson,Lenexa 1-06,Governor,,R,Sam Brownback,7
-Johnson,Lenexa 1-07,Governor,,R,Sam Brownback,3
-Johnson,Lenexa 1-08,Governor,,R,Sam Brownback,1
-Johnson,Lenexa 1-09,Governor,,R,Sam Brownback,0
-Johnson,Lenexa 2-01,Governor,,R,Sam Brownback,10
-Johnson,Lenexa 2-02,Governor,,R,Sam Brownback,0
-Johnson,Lenexa 2-03,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 2-04,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 2-05,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 2-06,Governor,,R,Sam Brownback,4
-Johnson,Lenexa 2-07,Governor,,R,Sam Brownback,6
-Johnson,Lenexa 3-01,Governor,,R,Sam Brownback,0
-Johnson,Lenexa 3-02,Governor,,R,Sam Brownback,3
-Johnson,Lenexa 3-03,Governor,,R,Sam Brownback,4
-Johnson,Lenexa 3-04,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 3-05,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 3-06,Governor,,R,Sam Brownback,0
-Johnson,Lenexa 3-07,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 3-08,Governor,,R,Sam Brownback,6
-Johnson,Lenexa 4-01,Governor,,R,Sam Brownback,0
-Johnson,Lenexa 4-02,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 4-03,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 4-04,Governor,,R,Sam Brownback,3
-Johnson,Lenexa 4-05,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 4-06,Governor,,R,Sam Brownback,1
-Johnson,Lenexa 4-07,Governor,,R,Sam Brownback,2
-Johnson,Lenexa 4-08,Governor,,R,Sam Brownback,7
-Johnson,Lenexa 4-09,Governor,,R,Sam Brownback,4
-Johnson,Lenexa 4-10,Governor,,R,Sam Brownback,1
-Johnson,Lenexa 4-11,Governor,,R,Sam Brownback,0
-Johnson,Lexington Twp 0-01,Governor,,R,Sam Brownback,2
-Johnson,Lexington Twp 0-02,Governor,,R,Sam Brownback,0
-Johnson,Lexington Twp 0-03,Governor,,R,Sam Brownback,0
-Johnson,McCamish Twp 0-01,Governor,,R,Sam Brownback,107
-Johnson,McCamish Twp 0-02,Governor,,R,Sam Brownback,196
-Johnson,Merriam 1-01,Governor,,R,Sam Brownback,134
-Johnson,Merriam 1-02,Governor,,R,Sam Brownback,147
-Johnson,Merriam 2-01,Governor,,R,Sam Brownback,216
-Johnson,Merriam 2-02,Governor,,R,Sam Brownback,0
-Johnson,Merriam 2-03,Governor,,R,Sam Brownback,101
-Johnson,Merriam 3-01,Governor,,R,Sam Brownback,156
-Johnson,Merriam 3-02,Governor,,R,Sam Brownback,154
-Johnson,Merriam 4-01,Governor,,R,Sam Brownback,223
-Johnson,Merriam 4-02,Governor,,R,Sam Brownback,94
-Johnson,Merriam 4-03,Governor,,R,Sam Brownback,108
-Johnson,Mission 1-01,Governor,,R,Sam Brownback,179
-Johnson,Mission 1-02,Governor,,R,Sam Brownback,63
-Johnson,Mission 2-01,Governor,,R,Sam Brownback,95
-Johnson,Mission 2-02,Governor,,R,Sam Brownback,146
-Johnson,Mission 3-01,Governor,,R,Sam Brownback,148
-Johnson,Mission 3-02,Governor,,R,Sam Brownback,85
-Johnson,Mission 4-01,Governor,,R,Sam Brownback,98
-Johnson,Mission 4-02,Governor,,R,Sam Brownback,168
-Johnson,Mission 4-03,Governor,,R,Sam Brownback,87
-Johnson,Mission Hills 0-01,Governor,,R,Sam Brownback,241
-Johnson,Mission Hills 0-02,Governor,,R,Sam Brownback,248
-Johnson,Mission Hills 0-03,Governor,,R,Sam Brownback,182
-Johnson,Mission Hills 0-04,Governor,,R,Sam Brownback,292
-Johnson,Mission Woods 0-01,Governor,,R,Sam Brownback,36
-Johnson,Olathe 1-01,Governor,,R,Sam Brownback,279
-Johnson,Olathe 1-02,Governor,,R,Sam Brownback,177
-Johnson,Olathe 1-03,Governor,,R,Sam Brownback,149
-Johnson,Olathe 1-04,Governor,,R,Sam Brownback,266
-Johnson,Olathe 1-05,Governor,,R,Sam Brownback,322
-Johnson,Olathe 1-06,Governor,,R,Sam Brownback,213
-Johnson,Olathe 1-08,Governor,,R,Sam Brownback,305
-Johnson,Olathe 1-09,Governor,,R,Sam Brownback,332
-Johnson,Olathe 1-11,Governor,,R,Sam Brownback,55
-Johnson,Olathe 1-14,Governor,,R,Sam Brownback,300
-Johnson,Olathe 1-15,Governor,,R,Sam Brownback,266
-Johnson,Olathe 1-16,Governor,,R,Sam Brownback,366
-Johnson,Olathe 1-17,Governor,,R,Sam Brownback,100
-Johnson,Olathe 1-18,Governor,,R,Sam Brownback,90
-Johnson,Olathe 1-19,Governor,,R,Sam Brownback,129
-Johnson,Olathe 1-20,Governor,,R,Sam Brownback,184
-Johnson,Olathe 1-21,Governor,,R,Sam Brownback,325
-Johnson,Olathe 1-22,Governor,,R,Sam Brownback,548
-Johnson,Olathe 1-23,Governor,,R,Sam Brownback,1
-Johnson,Olathe 1-24,Governor,,R,Sam Brownback,48
-Johnson,Olathe 1-24,Governor,,R,Sam Brownback,80
-Johnson,Olathe 1-26,Governor,,R,Sam Brownback,0
-Johnson,Olathe 1-27,Governor,,R,Sam Brownback,194
-Johnson,Olathe 2-01,Governor,,R,Sam Brownback,122
-Johnson,Olathe 2-02,Governor,,R,Sam Brownback,173
-Johnson,Olathe 2-03,Governor,,R,Sam Brownback,217
-Johnson,Olathe 2-04,Governor,,R,Sam Brownback,213
-Johnson,Olathe 2-05,Governor,,R,Sam Brownback,802
-Johnson,Olathe 2-06,Governor,,R,Sam Brownback,392
-Johnson,Olathe 2-07,Governor,,R,Sam Brownback,430
-Johnson,Olathe 2-08,Governor,,R,Sam Brownback,279
-Johnson,Olathe 2-09,Governor,,R,Sam Brownback,134
-Johnson,Olathe 2-10,Governor,,R,Sam Brownback,523
-Johnson,Olathe 2-11,Governor,,R,Sam Brownback,377
-Johnson,Olathe 2-12,Governor,,R,Sam Brownback,233
-Johnson,Olathe 2-13,Governor,,R,Sam Brownback,195
-Johnson,Olathe 2-14,Governor,,R,Sam Brownback,230
-Johnson,Olathe 2-15,Governor,,R,Sam Brownback,252
-Johnson,Olathe 2-16,Governor,,R,Sam Brownback,51
-Johnson,Olathe 2-17,Governor,,R,Sam Brownback,0
-Johnson,Olathe 2-19,Governor,,R,Sam Brownback,5
-Johnson,Olathe 2-22,Governor,,R,Sam Brownback,461
-Johnson,Olathe 2-23,Governor,,R,Sam Brownback,284
-Johnson,Olathe 3-01,Governor,,R,Sam Brownback,110
-Johnson,Olathe 3-02,Governor,,R,Sam Brownback,365
-Johnson,Olathe 3-03,Governor,,R,Sam Brownback,210
-Johnson,Olathe 3-04,Governor,,R,Sam Brownback,327
-Johnson,Olathe 3-05,Governor,,R,Sam Brownback,382
-Johnson,Olathe 3-06,Governor,,R,Sam Brownback,265
-Johnson,Olathe 3-07,Governor,,R,Sam Brownback,235
-Johnson,Olathe 3-08,Governor,,R,Sam Brownback,361
-Johnson,Olathe 3-09,Governor,,R,Sam Brownback,199
-Johnson,Olathe 3-10,Governor,,R,Sam Brownback,362
-Johnson,Olathe 3-11,Governor,,R,Sam Brownback,215
-Johnson,Olathe 3-12,Governor,,R,Sam Brownback,307
-Johnson,Olathe 3-13,Governor,,R,Sam Brownback,356
-Johnson,Olathe 3-15,Governor,,R,Sam Brownback,226
-Johnson,Olathe 3-16,Governor,,R,Sam Brownback,257
-Johnson,Olathe 3-17,Governor,,R,Sam Brownback,371
-Johnson,Olathe 3-18,Governor,,R,Sam Brownback,344
-Johnson,Olathe 3-19,Governor,,R,Sam Brownback,235
-Johnson,Olathe 3-20,Governor,,R,Sam Brownback,225
-Johnson,Olathe 3-21,Governor,,R,Sam Brownback,258
-Johnson,Olathe 3-22,Governor,,R,Sam Brownback,309
-Johnson,Olathe 3-23,Governor,,R,Sam Brownback,247
-Johnson,Olathe 3-24,Governor,,R,Sam Brownback,151
-Johnson,Olathe 3-26,Governor,,R,Sam Brownback,27
-Johnson,Olathe 4-01,Governor,,R,Sam Brownback,208
-Johnson,Olathe 4-02,Governor,,R,Sam Brownback,428
-Johnson,Olathe 4-03,Governor,,R,Sam Brownback,110
-Johnson,Olathe 4-04,Governor,,R,Sam Brownback,134
-Johnson,Olathe 4-05,Governor,,R,Sam Brownback,302
-Johnson,Olathe 4-06,Governor,,R,Sam Brownback,359
-Johnson,Olathe 4-07,Governor,,R,Sam Brownback,305
-Johnson,Olathe 4-08,Governor,,R,Sam Brownback,282
-Johnson,Olathe 4-09,Governor,,R,Sam Brownback,389
-Johnson,Olathe 4-10,Governor,,R,Sam Brownback,192
-Johnson,Olathe 4-11,Governor,,R,Sam Brownback,102
-Johnson,Olathe 4-12,Governor,,R,Sam Brownback,364
-Johnson,Olathe 4-13,Governor,,R,Sam Brownback,155
-Johnson,Olathe 4-14,Governor,,R,Sam Brownback,349
-Johnson,Olathe 4-15,Governor,,R,Sam Brownback,14
-Johnson,Olathe 4-16,Governor,,R,Sam Brownback,91
-Johnson,Olathe 4-17,Governor,,R,Sam Brownback,1
-Johnson,Olathe Twp 0-01,Governor,,R,Sam Brownback,148
-Johnson,Olathe Twp 0-02,Governor,,R,Sam Brownback,34
-Johnson,Olathe Twp 0-03,Governor,,R,Sam Brownback,19
-Johnson,Olathe Twp 0-04,Governor,,R,Sam Brownback,1
-Johnson,Olathe Twp 0-05,Governor,,R,Sam Brownback,2
-Johnson,Olathe Twp 0-06,Governor,,R,Sam Brownback,0
-Johnson,Olathe Twp 0-07,Governor,,R,Sam Brownback,1
-Johnson,Olathe Twp 0-08,Governor,,R,Sam Brownback,4
-Johnson,Olathe Twp 0-09,Governor,,R,Sam Brownback,0
-Johnson,Olathe Twp 0-10,Governor,,R,Sam Brownback,5
-Johnson,Olathe Twp 0-11,Governor,,R,Sam Brownback,3
-Johnson,Olathe Twp 0-14,Governor,,R,Sam Brownback,1
-Johnson,Olathe Twp 0-24,Governor,,R,Sam Brownback,1
-Johnson,Olathe Twp 0-25,Governor,,R,Sam Brownback,6
-Johnson,Olathe Twp 0-26,Governor,,R,Sam Brownback,3
-Johnson,Olathe Twp 0-32,Governor,,R,Sam Brownback,18
-Johnson,Overland Park 1-01,Governor,,R,Sam Brownback,175
-Johnson,Overland Park 1-02,Governor,,R,Sam Brownback,181
-Johnson,Overland Park 1-03,Governor,,R,Sam Brownback,195
-Johnson,Overland Park 1-04,Governor,,R,Sam Brownback,75
-Johnson,Overland Park 1-05,Governor,,R,Sam Brownback,118
-Johnson,Overland Park 1-06,Governor,,R,Sam Brownback,252
-Johnson,Overland Park 1-07,Governor,,R,Sam Brownback,251
-Johnson,Overland Park 1-08,Governor,,R,Sam Brownback,161
-Johnson,Overland Park 1-09,Governor,,R,Sam Brownback,105
-Johnson,Overland Park 1-10,Governor,,R,Sam Brownback,213
-Johnson,Overland Park 1-11,Governor,,R,Sam Brownback,58
-Johnson,Overland Park 1-12,Governor,,R,Sam Brownback,170
-Johnson,Overland Park 1-13,Governor,,R,Sam Brownback,149
-Johnson,Overland Park 1-14,Governor,,R,Sam Brownback,169
-Johnson,Overland Park 1-15,Governor,,R,Sam Brownback,94
-Johnson,Overland Park 1-16,Governor,,R,Sam Brownback,184
-Johnson,Overland Park 1-17,Governor,,R,Sam Brownback,88
-Johnson,Overland Park 1-18,Governor,,R,Sam Brownback,170
-Johnson,Overland Park 1-19,Governor,,R,Sam Brownback,149
-Johnson,Overland Park 1-20,Governor,,R,Sam Brownback,112
-Johnson,Overland Park 1-21,Governor,,R,Sam Brownback,74
-Johnson,Overland Park 1-22,Governor,,R,Sam Brownback,37
-Johnson,Overland Park 2-01,Governor,,R,Sam Brownback,180
-Johnson,Overland Park 2-02,Governor,,R,Sam Brownback,175
-Johnson,Overland Park 2-03,Governor,,R,Sam Brownback,166
-Johnson,Overland Park 2-04,Governor,,R,Sam Brownback,220
-Johnson,Overland Park 2-05,Governor,,R,Sam Brownback,167
-Johnson,Overland Park 2-06,Governor,,R,Sam Brownback,200
-Johnson,Overland Park 2-07,Governor,,R,Sam Brownback,172
-Johnson,Overland Park 2-08,Governor,,R,Sam Brownback,90
-Johnson,Overland Park 2-09,Governor,,R,Sam Brownback,173
-Johnson,Overland Park 2-10,Governor,,R,Sam Brownback,177
-Johnson,Overland Park 2-11,Governor,,R,Sam Brownback,186
-Johnson,Overland Park 2-12,Governor,,R,Sam Brownback,144
-Johnson,Overland Park 2-13,Governor,,R,Sam Brownback,87
-Johnson,Overland Park 2-14,Governor,,R,Sam Brownback,135
-Johnson,Overland Park 2-15,Governor,,R,Sam Brownback,282
-Johnson,Overland Park 2-16,Governor,,R,Sam Brownback,161
-Johnson,Overland Park 2-17,Governor,,R,Sam Brownback,276
-Johnson,Overland Park 2-18,Governor,,R,Sam Brownback,233
-Johnson,Overland Park 2-19,Governor,,R,Sam Brownback,158
-Johnson,Overland Park 2-20,Governor,,R,Sam Brownback,172
-Johnson,Overland Park 2-21,Governor,,R,Sam Brownback,162
-Johnson,Overland Park 2-22,Governor,,R,Sam Brownback,165
-Johnson,Overland Park 2-23,Governor,,R,Sam Brownback,225
-Johnson,Overland Park 2-24,Governor,,R,Sam Brownback,319
-Johnson,Overland Park 2-25,Governor,,R,Sam Brownback,264
-Johnson,Overland Park 2-26,Governor,,R,Sam Brownback,92
-Johnson,Overland Park 3-01,Governor,,R,Sam Brownback,415
-Johnson,Overland Park 3-02,Governor,,R,Sam Brownback,204
-Johnson,Overland Park 3-03,Governor,,R,Sam Brownback,251
-Johnson,Overland Park 3-04,Governor,,R,Sam Brownback,264
-Johnson,Overland Park 3-05,Governor,,R,Sam Brownback,256
-Johnson,Overland Park 3-06,Governor,,R,Sam Brownback,304
-Johnson,Overland Park 3-07,Governor,,R,Sam Brownback,150
-Johnson,Overland Park 3-08,Governor,,R,Sam Brownback,258
-Johnson,Overland Park 3-09,Governor,,R,Sam Brownback,326
-Johnson,Overland Park 3-10,Governor,,R,Sam Brownback,211
-Johnson,Overland Park 3-11,Governor,,R,Sam Brownback,268
-Johnson,Overland Park 3-12,Governor,,R,Sam Brownback,125
-Johnson,Overland Park 3-13,Governor,,R,Sam Brownback,404
-Johnson,Overland Park 3-14,Governor,,R,Sam Brownback,260
-Johnson,Overland Park 3-15,Governor,,R,Sam Brownback,201
-Johnson,Overland Park 3-16,Governor,,R,Sam Brownback,213
-Johnson,Overland Park 3-17,Governor,,R,Sam Brownback,195
-Johnson,Overland Park 3-18,Governor,,R,Sam Brownback,183
-Johnson,Overland Park 3-19,Governor,,R,Sam Brownback,245
-Johnson,Overland Park 3-20,Governor,,R,Sam Brownback,307
-Johnson,Overland Park 3-21,Governor,,R,Sam Brownback,257
-Johnson,Overland Park 4-01,Governor,,R,Sam Brownback,222
-Johnson,Overland Park 4-02,Governor,,R,Sam Brownback,367
-Johnson,Overland Park 4-03,Governor,,R,Sam Brownback,477
-Johnson,Overland Park 4-04,Governor,,R,Sam Brownback,466
-Johnson,Overland Park 4-05,Governor,,R,Sam Brownback,302
-Johnson,Overland Park 4-06,Governor,,R,Sam Brownback,253
-Johnson,Overland Park 4-07,Governor,,R,Sam Brownback,170
-Johnson,Overland Park 4-08,Governor,,R,Sam Brownback,309
-Johnson,Overland Park 4-09,Governor,,R,Sam Brownback,376
-Johnson,Overland Park 4-10,Governor,,R,Sam Brownback,237
-Johnson,Overland Park 4-11,Governor,,R,Sam Brownback,359
-Johnson,Overland Park 4-12,Governor,,R,Sam Brownback,488
-Johnson,Overland Park 4-13,Governor,,R,Sam Brownback,280
-Johnson,Overland Park 4-14,Governor,,R,Sam Brownback,228
-Johnson,Overland Park 4-15,Governor,,R,Sam Brownback,403
-Johnson,Overland Park 4-16,Governor,,R,Sam Brownback,336
-Johnson,Overland Park 4-17,Governor,,R,Sam Brownback,373
-Johnson,Overland Park 4-18,Governor,,R,Sam Brownback,45
-Johnson,Overland Park 5-01,Governor,,R,Sam Brownback,318
-Johnson,Overland Park 5-02,Governor,,R,Sam Brownback,141
-Johnson,Overland Park 5-03,Governor,,R,Sam Brownback,318
-Johnson,Overland Park 5-04,Governor,,R,Sam Brownback,249
-Johnson,Overland Park 5-05,Governor,,R,Sam Brownback,174
-Johnson,Overland Park 5-06,Governor,,R,Sam Brownback,249
-Johnson,Overland Park 5-07,Governor,,R,Sam Brownback,494
-Johnson,Overland Park 5-08,Governor,,R,Sam Brownback,466
-Johnson,Overland Park 5-09,Governor,,R,Sam Brownback,416
-Johnson,Overland Park 5-10,Governor,,R,Sam Brownback,310
-Johnson,Overland Park 5-11,Governor,,R,Sam Brownback,343
-Johnson,Overland Park 5-12,Governor,,R,Sam Brownback,80
-Johnson,Overland Park 5-13,Governor,,R,Sam Brownback,378
-Johnson,Overland Park 5-14,Governor,,R,Sam Brownback,320
-Johnson,Overland Park 5-15,Governor,,R,Sam Brownback,195
-Johnson,Overland Park 5-16,Governor,,R,Sam Brownback,199
-Johnson,Overland Park 5-17,Governor,,R,Sam Brownback,101
-Johnson,Overland Park 5-18,Governor,,R,Sam Brownback,227
-Johnson,Overland Park 5-19,Governor,,R,Sam Brownback,30
-Johnson,Overland Park 6-01,Governor,,R,Sam Brownback,397
-Johnson,Overland Park 6-02,Governor,,R,Sam Brownback,328
-Johnson,Overland Park 6-03,Governor,,R,Sam Brownback,366
-Johnson,Overland Park 6-04,Governor,,R,Sam Brownback,352
-Johnson,Overland Park 6-05,Governor,,R,Sam Brownback,374
-Johnson,Overland Park 6-06,Governor,,R,Sam Brownback,1
-Johnson,Overland Park 6-07,Governor,,R,Sam Brownback,119
-Johnson,Overland Park 6-08,Governor,,R,Sam Brownback,640
-Johnson,Overland Park 6-09,Governor,,R,Sam Brownback,459
-Johnson,Overland Park 6-10,Governor,,R,Sam Brownback,299
-Johnson,Overland Park 6-11,Governor,,R,Sam Brownback,311
-Johnson,Overland Park 6-12,Governor,,R,Sam Brownback,136
-Johnson,Overland Park 6-13,Governor,,R,Sam Brownback,415
-Johnson,Overland Park 6-15,Governor,,R,Sam Brownback,414
-Johnson,Overland Park 6-16,Governor,,R,Sam Brownback,252
-Johnson,Overland Park 6-17,Governor,,R,Sam Brownback,79
-Johnson,Overland Park 6-18,Governor,,R,Sam Brownback,2
-Johnson,Overland Park 6-19,Governor,,R,Sam Brownback,364
-Johnson,Overland Park 6-20,Governor,,R,Sam Brownback,238
-Johnson,Overland Park 6-21,Governor,,R,Sam Brownback,607
-Johnson,Overland Park 6-22,Governor,,R,Sam Brownback,209
-Johnson,Oxford Twp 0-01,Governor,,R,Sam Brownback,1
-Johnson,Oxford Twp 0-02,Governor,,R,Sam Brownback,292
-Johnson,Oxford Twp 0-04,Governor,,R,Sam Brownback,194
-Johnson,Oxford Twp 0-05,Governor,,R,Sam Brownback,10
-Johnson,Oxford Twp 0-09,Governor,,R,Sam Brownback,14
-Johnson,Oxford Twp 0-10,Governor,,R,Sam Brownback,2
-Johnson,Oxford Twp 0-11,Governor,,R,Sam Brownback,66
-Johnson,Prairie Village 1-01,Governor,,R,Sam Brownback,251
-Johnson,Prairie Village 1-02,Governor,,R,Sam Brownback,158
-Johnson,Prairie Village 1-03,Governor,,R,Sam Brownback,227
-Johnson,Prairie Village 2-01,Governor,,R,Sam Brownback,181
-Johnson,Prairie Village 2-02,Governor,,R,Sam Brownback,97
-Johnson,Prairie Village 2-03,Governor,,R,Sam Brownback,157
-Johnson,Prairie Village 3-01,Governor,,R,Sam Brownback,150
-Johnson,Prairie Village 3-02,Governor,,R,Sam Brownback,215
-Johnson,Prairie Village 3-03,Governor,,R,Sam Brownback,194
-Johnson,Prairie Village 4-01,Governor,,R,Sam Brownback,302
-Johnson,Prairie Village 4-02,Governor,,R,Sam Brownback,152
-Johnson,Prairie Village 4-03,Governor,,R,Sam Brownback,240
-Johnson,Prairie Village 5-01,Governor,,R,Sam Brownback,228
-Johnson,Prairie Village 5-02,Governor,,R,Sam Brownback,299
-Johnson,Prairie Village 5-03,Governor,,R,Sam Brownback,247
-Johnson,Prairie Village 6-01,Governor,,R,Sam Brownback,263
-Johnson,Prairie Village 6-02,Governor,,R,Sam Brownback,161
-Johnson,Prairie Village 6-03,Governor,,R,Sam Brownback,127
-Johnson,Roeland Park 1-01,Governor,,R,Sam Brownback,75
-Johnson,Roeland Park 1-02,Governor,,R,Sam Brownback,49
-Johnson,Roeland Park 2-01,Governor,,R,Sam Brownback,82
-Johnson,Roeland Park 2-02,Governor,,R,Sam Brownback,138
-Johnson,Roeland Park 3-01,Governor,,R,Sam Brownback,45
-Johnson,Roeland Park 3-02,Governor,,R,Sam Brownback,125
-Johnson,Roeland Park 4-01,Governor,,R,Sam Brownback,81
-Johnson,Roeland Park 4-02,Governor,,R,Sam Brownback,229
-Johnson,Shawnee 1-01,Governor,,R,Sam Brownback,279
-Johnson,Shawnee 1-02,Governor,,R,Sam Brownback,220
-Johnson,Shawnee 1-03,Governor,,R,Sam Brownback,189
-Johnson,Shawnee 1-04,Governor,,R,Sam Brownback,397
-Johnson,Shawnee 1-05,Governor,,R,Sam Brownback,383
-Johnson,Shawnee 1-06,Governor,,R,Sam Brownback,374
-Johnson,Shawnee 1-07,Governor,,R,Sam Brownback,311
-Johnson,Shawnee 1-08,Governor,,R,Sam Brownback,347
-Johnson,Shawnee 1-09,Governor,,R,Sam Brownback,56
-Johnson,Shawnee 1-10,Governor,,R,Sam Brownback,126
-Johnson,Shawnee 1-11,Governor,,R,Sam Brownback,209
-Johnson,Shawnee 1-12,Governor,,R,Sam Brownback,4
-Johnson,Shawnee 2-01,Governor,,R,Sam Brownback,135
-Johnson,Shawnee 2-02,Governor,,R,Sam Brownback,258
-Johnson,Shawnee 2-03,Governor,,R,Sam Brownback,164
-Johnson,Shawnee 2-04,Governor,,R,Sam Brownback,271
-Johnson,Shawnee 2-05,Governor,,R,Sam Brownback,143
-Johnson,Shawnee 2-06,Governor,,R,Sam Brownback,231
-Johnson,Shawnee 2-07,Governor,,R,Sam Brownback,150
-Johnson,Shawnee 2-08,Governor,,R,Sam Brownback,164
-Johnson,Shawnee 2-09,Governor,,R,Sam Brownback,137
-Johnson,Shawnee 2-10,Governor,,R,Sam Brownback,137
-Johnson,Shawnee 2-11,Governor,,R,Sam Brownback,221
-Johnson,Shawnee 2-12,Governor,,R,Sam Brownback,42
-Johnson,Shawnee 2-13,Governor,,R,Sam Brownback,101
-Johnson,Shawnee 3-01,Governor,,R,Sam Brownback,242
-Johnson,Shawnee 3-02,Governor,,R,Sam Brownback,422
-Johnson,Shawnee 3-03,Governor,,R,Sam Brownback,279
-Johnson,Shawnee 3-04,Governor,,R,Sam Brownback,310
-Johnson,Shawnee 3-05,Governor,,R,Sam Brownback,468
-Johnson,Shawnee 3-06,Governor,,R,Sam Brownback,270
-Johnson,Shawnee 3-07,Governor,,R,Sam Brownback,380
-Johnson,Shawnee 3-08,Governor,,R,Sam Brownback,354
-Johnson,Shawnee 3-09,Governor,,R,Sam Brownback,228
-Johnson,Shawnee 4-01,Governor,,R,Sam Brownback,386
-Johnson,Shawnee 4-02,Governor,,R,Sam Brownback,218
-Johnson,Shawnee 4-03,Governor,,R,Sam Brownback,92
-Johnson,Shawnee 4-04,Governor,,R,Sam Brownback,73
-Johnson,Shawnee 4-05,Governor,,R,Sam Brownback,286
-Johnson,Shawnee 4-06,Governor,,R,Sam Brownback,284
-Johnson,Shawnee 4-07,Governor,,R,Sam Brownback,359
-Johnson,Shawnee 4-08,Governor,,R,Sam Brownback,151
-Johnson,Shawnee 4-09,Governor,,R,Sam Brownback,431
-Johnson,Shawnee 4-11,Governor,,R,Sam Brownback,197
-Johnson,Shawnee 4-12,Governor,,R,Sam Brownback,42
-Johnson,Spring Hill 0-01,Governor,,R,Sam Brownback,515
-Johnson,Spring Hill 0-03,Governor,,R,Sam Brownback,33
-Johnson,Spring Hill 0-04,Governor,,R,Sam Brownback,0
-Johnson,Spring Hill Twp 0-01,Governor,,R,Sam Brownback,400
-Johnson,Spring Hill Twp 0-02,Governor,,R,Sam Brownback,0
-Johnson,Spring Hill Twp 0-03,Governor,,R,Sam Brownback,43
-Johnson,Spring Hill Twp 0-04,Governor,,R,Sam Brownback,10
-Johnson,Spring Hill Twp 0-05,Governor,,R,Sam Brownback,2
-Johnson,Westwood 0-01,Governor,,R,Sam Brownback,92
-Johnson,Westwood 0-02,Governor,,R,Sam Brownback,114
-Johnson,Westwood Hills 0-01,Governor,,R,Sam Brownback,55
-Johnson,Aubry Twp 0-01,Governor,,L,Keen Umbehr,2
-Johnson,Aubry Twp 0-02,Governor,,L,Keen Umbehr,19
-Johnson,Aubry Twp 0-03,Governor,,L,Keen Umbehr,16
-Johnson,Aubry Twp 0-04,Governor,,L,Keen Umbehr,20
-Johnson,Aubry Twp 0-05,Governor,,L,Keen Umbehr,2
-Johnson,Aubry Twp 0-06,Governor,,L,Keen Umbehr,6
-Johnson,De Soto 0-01,Governor,,L,Keen Umbehr,38
-Johnson,De Soto 0-02,Governor,,L,Keen Umbehr,15
-Johnson,De Soto 0-03,Governor,,L,Keen Umbehr,17
-Johnson,De Soto 0-06,Governor,,L,Keen Umbehr,5
-Johnson,De Soto 0-07,Governor,,L,Keen Umbehr,0
-Johnson,Edgerton 0-01,Governor,,L,Keen Umbehr,17
-Johnson,Edgerton 0-02,Governor,,L,Keen Umbehr,0
-Johnson,Edgerton 0-05,Governor,,L,Keen Umbehr,0
-Johnson,Edgerton 0-06,Governor,,L,Keen Umbehr,0
-Johnson,Edgerton 0-09,Governor,,L,Keen Umbehr,0
-Johnson,Fairway 1-01,Governor,,L,Keen Umbehr,4
-Johnson,Fairway 1-02,Governor,,L,Keen Umbehr,3
-Johnson,Fairway 2-01,Governor,,L,Keen Umbehr,2
-Johnson,Fairway 2-02,Governor,,L,Keen Umbehr,3
-Johnson,Fairway 3-01,Governor,,L,Keen Umbehr,2
-Johnson,Fairway 3-02,Governor,,L,Keen Umbehr,2
-Johnson,Fairway 4-01,Governor,,L,Keen Umbehr,7
-Johnson,Fairway 4-02,Governor,,L,Keen Umbehr,2
-Johnson,Fairway 4-03,Governor,,L,Keen Umbehr,2
-Johnson,Fairway 4-04,Governor,,L,Keen Umbehr,3
-Johnson,Gardner 0-01,Governor,,L,Keen Umbehr,28
-Johnson,Gardner 0-02,Governor,,L,Keen Umbehr,6
-Johnson,Gardner 0-03,Governor,,L,Keen Umbehr,40
-Johnson,Gardner 0-04,Governor,,L,Keen Umbehr,23
-Johnson,Gardner 0-06,Governor,,L,Keen Umbehr,27
-Johnson,Gardner 0-07,Governor,,L,Keen Umbehr,1
-Johnson,Gardner 0-08,Governor,,L,Keen Umbehr,0
-Johnson,Gardner 0-09,Governor,,L,Keen Umbehr,25
-Johnson,Gardner 0-10,Governor,,L,Keen Umbehr,19
-Johnson,Gardner 0-12,Governor,,L,Keen Umbehr,2
-Johnson,Gardner 0-13,Governor,,L,Keen Umbehr,18
-Johnson,Gardner 0-14,Governor,,L,Keen Umbehr,18
-Johnson,Gardner Twp 0-01,Governor,,L,Keen Umbehr,11
-Johnson,Gardner Twp 0-02,Governor,,L,Keen Umbehr,15
-Johnson,Gardner Twp 0-04,Governor,,L,Keen Umbehr,0
-Johnson,Gardner Twp 0-05,Governor,,L,Keen Umbehr,0
-Johnson,Gardner Twp 0-07,Governor,,L,Keen Umbehr,1
-Johnson,Gardner Twp 0-08,Governor,,L,Keen Umbehr,0
-Johnson,Gardner Twp 0-09,Governor,,L,Keen Umbehr,0
-Johnson,Gardner Twp 0-10,Governor,,L,Keen Umbehr,0
-Johnson,Gardner Twp 0-11,Governor,,L,Keen Umbehr,3
-Johnson,Gardner Twp 0-13,Governor,,L,Keen Umbehr,1
-Johnson,Lake Quivira 0-01,Governor,,L,Keen Umbehr,10
-Johnson,Leawood 1-01,Governor,,L,Keen Umbehr,9
-Johnson,Leawood 1-02,Governor,,L,Keen Umbehr,17
-Johnson,Leawood 1-03,Governor,,L,Keen Umbehr,11
-Johnson,Leawood 1-04,Governor,,L,Keen Umbehr,7
-Johnson,Leawood 1-05,Governor,,L,Keen Umbehr,11
-Johnson,Leawood 1-06,Governor,,L,Keen Umbehr,4
-Johnson,Leawood 2-01,Governor,,L,Keen Umbehr,7
-Johnson,Leawood 2-02,Governor,,L,Keen Umbehr,25
-Johnson,Leawood 2-03,Governor,,L,Keen Umbehr,15
-Johnson,Leawood 2-04,Governor,,L,Keen Umbehr,3
-Johnson,Leawood 2-05,Governor,,L,Keen Umbehr,7
-Johnson,Leawood 2-06,Governor,,L,Keen Umbehr,7
-Johnson,Leawood 3-01,Governor,,L,Keen Umbehr,2
-Johnson,Leawood 3-02,Governor,,L,Keen Umbehr,14
-Johnson,Leawood 3-03,Governor,,L,Keen Umbehr,9
-Johnson,Leawood 3-04,Governor,,L,Keen Umbehr,0
-Johnson,Leawood 3-05,Governor,,L,Keen Umbehr,10
-Johnson,Leawood 3-06,Governor,,L,Keen Umbehr,15
-Johnson,Leawood 3-07,Governor,,L,Keen Umbehr,11
-Johnson,Leawood 4-01,Governor,,L,Keen Umbehr,2
-Johnson,Leawood 4-02,Governor,,L,Keen Umbehr,10
-Johnson,Leawood 4-03,Governor,,L,Keen Umbehr,7
-Johnson,Leawood 4-04,Governor,,L,Keen Umbehr,6
-Johnson,Leawood 4-05,Governor,,L,Keen Umbehr,321
-Johnson,Leawood 4-06,Governor,,L,Keen Umbehr,156
-Johnson,Leawood 4-07,Governor,,L,Keen Umbehr,305
-Johnson,Leawood 4-08,Governor,,L,Keen Umbehr,149
-Johnson,Lenexa 1-01,Governor,,L,Keen Umbehr,174
-Johnson,Lenexa 1-02,Governor,,L,Keen Umbehr,403
-Johnson,Lenexa 1-03,Governor,,L,Keen Umbehr,474
-Johnson,Lenexa 1-04,Governor,,L,Keen Umbehr,273
-Johnson,Lenexa 1-05,Governor,,L,Keen Umbehr,300
-Johnson,Lenexa 1-06,Governor,,L,Keen Umbehr,341
-Johnson,Lenexa 1-07,Governor,,L,Keen Umbehr,202
-Johnson,Lenexa 1-08,Governor,,L,Keen Umbehr,84
-Johnson,Lenexa 1-09,Governor,,L,Keen Umbehr,6
-Johnson,Lenexa 2-01,Governor,,L,Keen Umbehr,381
-Johnson,Lenexa 2-02,Governor,,L,Keen Umbehr,116
-Johnson,Lenexa 2-03,Governor,,L,Keen Umbehr,295
-Johnson,Lenexa 2-04,Governor,,L,Keen Umbehr,241
-Johnson,Lenexa 2-05,Governor,,L,Keen Umbehr,285
-Johnson,Lenexa 2-06,Governor,,L,Keen Umbehr,193
-Johnson,Lenexa 2-07,Governor,,L,Keen Umbehr,396
-Johnson,Lenexa 3-01,Governor,,L,Keen Umbehr,246
-Johnson,Lenexa 3-02,Governor,,L,Keen Umbehr,459
-Johnson,Lenexa 3-03,Governor,,L,Keen Umbehr,456
-Johnson,Lenexa 3-04,Governor,,L,Keen Umbehr,257
-Johnson,Lenexa 3-05,Governor,,L,Keen Umbehr,198
-Johnson,Lenexa 3-06,Governor,,L,Keen Umbehr,270
-Johnson,Lenexa 3-07,Governor,,L,Keen Umbehr,340
-Johnson,Lenexa 3-08,Governor,,L,Keen Umbehr,355
-Johnson,Lenexa 4-01,Governor,,L,Keen Umbehr,166
-Johnson,Lenexa 4-02,Governor,,L,Keen Umbehr,300
-Johnson,Lenexa 4-03,Governor,,L,Keen Umbehr,140
-Johnson,Lenexa 4-04,Governor,,L,Keen Umbehr,133
-Johnson,Lenexa 4-05,Governor,,L,Keen Umbehr,141
-Johnson,Lenexa 4-06,Governor,,L,Keen Umbehr,190
-Johnson,Lenexa 4-07,Governor,,L,Keen Umbehr,241
-Johnson,Lenexa 4-08,Governor,,L,Keen Umbehr,346
-Johnson,Lenexa 4-09,Governor,,L,Keen Umbehr,266
-Johnson,Lenexa 4-10,Governor,,L,Keen Umbehr,148
-Johnson,Lenexa 4-11,Governor,,L,Keen Umbehr,45
-Johnson,Lexington Twp 0-01,Governor,,L,Keen Umbehr,221
-Johnson,Lexington Twp 0-02,Governor,,L,Keen Umbehr,0
-Johnson,Lexington Twp 0-03,Governor,,L,Keen Umbehr,0
-Johnson,McCamish Twp 0-01,Governor,,L,Keen Umbehr,4
-Johnson,McCamish Twp 0-02,Governor,,L,Keen Umbehr,5
-Johnson,Merriam 1-01,Governor,,L,Keen Umbehr,10
-Johnson,Merriam 1-02,Governor,,L,Keen Umbehr,18
-Johnson,Merriam 2-01,Governor,,L,Keen Umbehr,23
-Johnson,Merriam 2-02,Governor,,L,Keen Umbehr,0
-Johnson,Merriam 2-03,Governor,,L,Keen Umbehr,11
-Johnson,Merriam 3-01,Governor,,L,Keen Umbehr,10
-Johnson,Merriam 3-02,Governor,,L,Keen Umbehr,18
-Johnson,Merriam 4-01,Governor,,L,Keen Umbehr,25
-Johnson,Merriam 4-02,Governor,,L,Keen Umbehr,5
-Johnson,Merriam 4-03,Governor,,L,Keen Umbehr,13
-Johnson,Mission 1-01,Governor,,L,Keen Umbehr,20
-Johnson,Mission 1-02,Governor,,L,Keen Umbehr,12
-Johnson,Mission 2-01,Governor,,L,Keen Umbehr,12
-Johnson,Mission 2-02,Governor,,L,Keen Umbehr,9
-Johnson,Mission 3-01,Governor,,L,Keen Umbehr,16
-Johnson,Mission 3-02,Governor,,L,Keen Umbehr,13
-Johnson,Mission 4-01,Governor,,L,Keen Umbehr,8
-Johnson,Mission 4-02,Governor,,L,Keen Umbehr,12
-Johnson,Mission 4-03,Governor,,L,Keen Umbehr,15
-Johnson,Mission Hills 0-01,Governor,,L,Keen Umbehr,0
-Johnson,Mission Hills 0-02,Governor,,L,Keen Umbehr,6
-Johnson,Mission Hills 0-03,Governor,,L,Keen Umbehr,2
-Johnson,Mission Hills 0-04,Governor,,L,Keen Umbehr,3
-Johnson,Mission Woods 0-01,Governor,,L,Keen Umbehr,1
-Johnson,Olathe 1-01,Governor,,L,Keen Umbehr,25
-Johnson,Olathe 1-02,Governor,,L,Keen Umbehr,24
-Johnson,Olathe 1-03,Governor,,L,Keen Umbehr,6
-Johnson,Olathe 1-04,Governor,,L,Keen Umbehr,27
-Johnson,Olathe 1-05,Governor,,L,Keen Umbehr,17
-Johnson,Olathe 1-06,Governor,,L,Keen Umbehr,13
-Johnson,Olathe 1-08,Governor,,L,Keen Umbehr,34
-Johnson,Olathe 1-09,Governor,,L,Keen Umbehr,17
-Johnson,Olathe 1-11,Governor,,L,Keen Umbehr,6
-Johnson,Olathe 1-14,Governor,,L,Keen Umbehr,11
-Johnson,Olathe 1-15,Governor,,L,Keen Umbehr,17
-Johnson,Olathe 1-16,Governor,,L,Keen Umbehr,20
-Johnson,Olathe 1-17,Governor,,L,Keen Umbehr,3
-Johnson,Olathe 1-18,Governor,,L,Keen Umbehr,9
-Johnson,Olathe 1-19,Governor,,L,Keen Umbehr,10
-Johnson,Olathe 1-20,Governor,,L,Keen Umbehr,23
-Johnson,Olathe 1-21,Governor,,L,Keen Umbehr,26
-Johnson,Olathe 1-22,Governor,,L,Keen Umbehr,27
-Johnson,Olathe 1-23,Governor,,L,Keen Umbehr,0
-Johnson,Olathe 1-24,Governor,,L,Keen Umbehr,3
-Johnson,Olathe 1-24,Governor,,L,Keen Umbehr,8
-Johnson,Olathe 1-26,Governor,,L,Keen Umbehr,0
-Johnson,Olathe 1-27,Governor,,L,Keen Umbehr,25
-Johnson,Olathe 2-01,Governor,,L,Keen Umbehr,6
-Johnson,Olathe 2-02,Governor,,L,Keen Umbehr,12
-Johnson,Olathe 2-03,Governor,,L,Keen Umbehr,16
-Johnson,Olathe 2-04,Governor,,L,Keen Umbehr,22
-Johnson,Olathe 2-05,Governor,,L,Keen Umbehr,19
-Johnson,Olathe 2-06,Governor,,L,Keen Umbehr,14
-Johnson,Olathe 2-07,Governor,,L,Keen Umbehr,25
-Johnson,Olathe 2-08,Governor,,L,Keen Umbehr,35
-Johnson,Olathe 2-09,Governor,,L,Keen Umbehr,7
-Johnson,Olathe 2-10,Governor,,L,Keen Umbehr,31
-Johnson,Olathe 2-11,Governor,,L,Keen Umbehr,33
-Johnson,Olathe 2-12,Governor,,L,Keen Umbehr,10
-Johnson,Olathe 2-13,Governor,,L,Keen Umbehr,25
-Johnson,Olathe 2-14,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 2-15,Governor,,L,Keen Umbehr,18
-Johnson,Olathe 2-16,Governor,,L,Keen Umbehr,8
-Johnson,Olathe 2-17,Governor,,L,Keen Umbehr,0
-Johnson,Olathe 2-19,Governor,,L,Keen Umbehr,0
-Johnson,Olathe 2-22,Governor,,L,Keen Umbehr,28
-Johnson,Olathe 2-23,Governor,,L,Keen Umbehr,17
-Johnson,Olathe 3-01,Governor,,L,Keen Umbehr,9
-Johnson,Olathe 3-02,Governor,,L,Keen Umbehr,33
-Johnson,Olathe 3-03,Governor,,L,Keen Umbehr,7
-Johnson,Olathe 3-04,Governor,,L,Keen Umbehr,22
-Johnson,Olathe 3-05,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 3-06,Governor,,L,Keen Umbehr,5
-Johnson,Olathe 3-07,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 3-08,Governor,,L,Keen Umbehr,24
-Johnson,Olathe 3-09,Governor,,L,Keen Umbehr,6
-Johnson,Olathe 3-10,Governor,,L,Keen Umbehr,17
-Johnson,Olathe 3-11,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 3-12,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 3-13,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 3-15,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 3-16,Governor,,L,Keen Umbehr,8
-Johnson,Olathe 3-17,Governor,,L,Keen Umbehr,21
-Johnson,Olathe 3-18,Governor,,L,Keen Umbehr,8
-Johnson,Olathe 3-19,Governor,,L,Keen Umbehr,9
-Johnson,Olathe 3-20,Governor,,L,Keen Umbehr,18
-Johnson,Olathe 3-21,Governor,,L,Keen Umbehr,11
-Johnson,Olathe 3-22,Governor,,L,Keen Umbehr,16
-Johnson,Olathe 3-23,Governor,,L,Keen Umbehr,21
-Johnson,Olathe 3-24,Governor,,L,Keen Umbehr,3
-Johnson,Olathe 3-26,Governor,,L,Keen Umbehr,2
-Johnson,Olathe 4-01,Governor,,L,Keen Umbehr,28
-Johnson,Olathe 4-02,Governor,,L,Keen Umbehr,30
-Johnson,Olathe 4-03,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 4-04,Governor,,L,Keen Umbehr,13
-Johnson,Olathe 4-05,Governor,,L,Keen Umbehr,14
-Johnson,Olathe 4-06,Governor,,L,Keen Umbehr,26
-Johnson,Olathe 4-07,Governor,,L,Keen Umbehr,29
-Johnson,Olathe 4-08,Governor,,L,Keen Umbehr,8
-Johnson,Olathe 4-09,Governor,,L,Keen Umbehr,21
-Johnson,Olathe 4-10,Governor,,L,Keen Umbehr,6
-Johnson,Olathe 4-11,Governor,,L,Keen Umbehr,16
-Johnson,Olathe 4-12,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 4-13,Governor,,L,Keen Umbehr,12
-Johnson,Olathe 4-14,Governor,,L,Keen Umbehr,15
-Johnson,Olathe 4-15,Governor,,L,Keen Umbehr,4
-Johnson,Olathe 4-16,Governor,,L,Keen Umbehr,12
-Johnson,Olathe 4-17,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-01,Governor,,L,Keen Umbehr,9
-Johnson,Olathe Twp 0-02,Governor,,L,Keen Umbehr,1
-Johnson,Olathe Twp 0-03,Governor,,L,Keen Umbehr,1
-Johnson,Olathe Twp 0-04,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-05,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-06,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-07,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-08,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-09,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-10,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-11,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-14,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-24,Governor,,L,Keen Umbehr,1
-Johnson,Olathe Twp 0-25,Governor,,L,Keen Umbehr,1
-Johnson,Olathe Twp 0-26,Governor,,L,Keen Umbehr,0
-Johnson,Olathe Twp 0-32,Governor,,L,Keen Umbehr,0
-Johnson,Overland Park 1-01,Governor,,L,Keen Umbehr,17
-Johnson,Overland Park 1-02,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 1-03,Governor,,L,Keen Umbehr,16
-Johnson,Overland Park 1-04,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 1-05,Governor,,L,Keen Umbehr,14
-Johnson,Overland Park 1-06,Governor,,L,Keen Umbehr,20
-Johnson,Overland Park 1-07,Governor,,L,Keen Umbehr,26
-Johnson,Overland Park 1-08,Governor,,L,Keen Umbehr,21
-Johnson,Overland Park 1-09,Governor,,L,Keen Umbehr,15
-Johnson,Overland Park 1-10,Governor,,L,Keen Umbehr,25
-Johnson,Overland Park 1-11,Governor,,L,Keen Umbehr,3
-Johnson,Overland Park 1-12,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 1-13,Governor,,L,Keen Umbehr,14
-Johnson,Overland Park 1-14,Governor,,L,Keen Umbehr,22
-Johnson,Overland Park 1-15,Governor,,L,Keen Umbehr,7
-Johnson,Overland Park 1-16,Governor,,L,Keen Umbehr,33
-Johnson,Overland Park 1-17,Governor,,L,Keen Umbehr,14
-Johnson,Overland Park 1-18,Governor,,L,Keen Umbehr,14
-Johnson,Overland Park 1-19,Governor,,L,Keen Umbehr,15
-Johnson,Overland Park 1-20,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 1-21,Governor,,L,Keen Umbehr,4
-Johnson,Overland Park 1-22,Governor,,L,Keen Umbehr,7
-Johnson,Overland Park 2-01,Governor,,L,Keen Umbehr,20
-Johnson,Overland Park 2-02,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 2-03,Governor,,L,Keen Umbehr,14
-Johnson,Overland Park 2-04,Governor,,L,Keen Umbehr,20
-Johnson,Overland Park 2-05,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 2-06,Governor,,L,Keen Umbehr,14
-Johnson,Overland Park 2-07,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 2-08,Governor,,L,Keen Umbehr,6
-Johnson,Overland Park 2-09,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 2-10,Governor,,L,Keen Umbehr,12
-Johnson,Overland Park 2-11,Governor,,L,Keen Umbehr,15
-Johnson,Overland Park 2-12,Governor,,L,Keen Umbehr,11
-Johnson,Overland Park 2-13,Governor,,L,Keen Umbehr,13
-Johnson,Overland Park 2-14,Governor,,L,Keen Umbehr,6
-Johnson,Overland Park 2-15,Governor,,L,Keen Umbehr,20
-Johnson,Overland Park 2-16,Governor,,L,Keen Umbehr,15
-Johnson,Overland Park 2-17,Governor,,L,Keen Umbehr,14
-Johnson,Overland Park 2-18,Governor,,L,Keen Umbehr,25
-Johnson,Overland Park 2-19,Governor,,L,Keen Umbehr,10
-Johnson,Overland Park 2-20,Governor,,L,Keen Umbehr,5
-Johnson,Overland Park 2-21,Governor,,L,Keen Umbehr,3
-Johnson,Overland Park 2-22,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 2-23,Governor,,L,Keen Umbehr,7
-Johnson,Overland Park 2-24,Governor,,L,Keen Umbehr,15
-Johnson,Overland Park 2-25,Governor,,L,Keen Umbehr,10
-Johnson,Overland Park 2-26,Governor,,L,Keen Umbehr,7
-Johnson,Overland Park 3-01,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 3-02,Governor,,L,Keen Umbehr,17
-Johnson,Overland Park 3-03,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 3-04,Governor,,L,Keen Umbehr,21
-Johnson,Overland Park 3-05,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 3-06,Governor,,L,Keen Umbehr,19
-Johnson,Overland Park 3-07,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 3-08,Governor,,L,Keen Umbehr,24
-Johnson,Overland Park 3-09,Governor,,L,Keen Umbehr,20
-Johnson,Overland Park 3-10,Governor,,L,Keen Umbehr,7
-Johnson,Overland Park 3-11,Governor,,L,Keen Umbehr,13
-Johnson,Overland Park 3-12,Governor,,L,Keen Umbehr,17
-Johnson,Overland Park 3-13,Governor,,L,Keen Umbehr,17
-Johnson,Overland Park 3-14,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 3-15,Governor,,L,Keen Umbehr,10
-Johnson,Overland Park 3-16,Governor,,L,Keen Umbehr,21
-Johnson,Overland Park 3-17,Governor,,L,Keen Umbehr,6
-Johnson,Overland Park 3-18,Governor,,L,Keen Umbehr,19
-Johnson,Overland Park 3-19,Governor,,L,Keen Umbehr,23
-Johnson,Overland Park 3-20,Governor,,L,Keen Umbehr,19
-Johnson,Overland Park 3-21,Governor,,L,Keen Umbehr,13
-Johnson,Overland Park 4-01,Governor,,L,Keen Umbehr,6
-Johnson,Overland Park 4-02,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 4-03,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 4-04,Governor,,L,Keen Umbehr,21
-Johnson,Overland Park 4-05,Governor,,L,Keen Umbehr,12
-Johnson,Overland Park 4-06,Governor,,L,Keen Umbehr,14
-Johnson,Overland Park 4-07,Governor,,L,Keen Umbehr,6
-Johnson,Overland Park 4-08,Governor,,L,Keen Umbehr,17
-Johnson,Overland Park 4-09,Governor,,L,Keen Umbehr,10
-Johnson,Overland Park 4-10,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 4-11,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 4-12,Governor,,L,Keen Umbehr,17
-Johnson,Overland Park 4-13,Governor,,L,Keen Umbehr,13
-Johnson,Overland Park 4-14,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 4-15,Governor,,L,Keen Umbehr,20
-Johnson,Overland Park 4-16,Governor,,L,Keen Umbehr,13
-Johnson,Overland Park 4-17,Governor,,L,Keen Umbehr,16
-Johnson,Overland Park 4-18,Governor,,L,Keen Umbehr,4
-Johnson,Overland Park 5-01,Governor,,L,Keen Umbehr,11
-Johnson,Overland Park 5-02,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 5-03,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 5-04,Governor,,L,Keen Umbehr,24
-Johnson,Overland Park 5-05,Governor,,L,Keen Umbehr,6
-Johnson,Overland Park 5-06,Governor,,L,Keen Umbehr,13
-Johnson,Overland Park 5-07,Governor,,L,Keen Umbehr,12
-Johnson,Overland Park 5-08,Governor,,L,Keen Umbehr,22
-Johnson,Overland Park 5-09,Governor,,L,Keen Umbehr,11
-Johnson,Overland Park 5-10,Governor,,L,Keen Umbehr,22
-Johnson,Overland Park 5-11,Governor,,L,Keen Umbehr,10
-Johnson,Overland Park 5-12,Governor,,L,Keen Umbehr,2
-Johnson,Overland Park 5-13,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 5-14,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 5-15,Governor,,L,Keen Umbehr,12
-Johnson,Overland Park 5-16,Governor,,L,Keen Umbehr,4
-Johnson,Overland Park 5-17,Governor,,L,Keen Umbehr,4
-Johnson,Overland Park 5-18,Governor,,L,Keen Umbehr,16
-Johnson,Overland Park 5-19,Governor,,L,Keen Umbehr,0
-Johnson,Overland Park 6-01,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 6-02,Governor,,L,Keen Umbehr,5
-Johnson,Overland Park 6-03,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 6-04,Governor,,L,Keen Umbehr,9
-Johnson,Overland Park 6-05,Governor,,L,Keen Umbehr,18
-Johnson,Overland Park 6-06,Governor,,L,Keen Umbehr,0
-Johnson,Overland Park 6-07,Governor,,L,Keen Umbehr,4
-Johnson,Overland Park 6-08,Governor,,L,Keen Umbehr,17
-Johnson,Overland Park 6-09,Governor,,L,Keen Umbehr,15
-Johnson,Overland Park 6-10,Governor,,L,Keen Umbehr,20
-Johnson,Overland Park 6-11,Governor,,L,Keen Umbehr,10
-Johnson,Overland Park 6-12,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 6-13,Governor,,L,Keen Umbehr,27
-Johnson,Overland Park 6-15,Governor,,L,Keen Umbehr,22
-Johnson,Overland Park 6-16,Governor,,L,Keen Umbehr,8
-Johnson,Overland Park 6-17,Governor,,L,Keen Umbehr,5
-Johnson,Overland Park 6-18,Governor,,L,Keen Umbehr,0
-Johnson,Overland Park 6-19,Governor,,L,Keen Umbehr,25
-Johnson,Overland Park 6-20,Governor,,L,Keen Umbehr,3
-Johnson,Overland Park 6-21,Governor,,L,Keen Umbehr,25
-Johnson,Overland Park 6-22,Governor,,L,Keen Umbehr,10
-Johnson,Oxford Twp 0-01,Governor,,L,Keen Umbehr,0
-Johnson,Oxford Twp 0-02,Governor,,L,Keen Umbehr,15
-Johnson,Oxford Twp 0-04,Governor,,L,Keen Umbehr,12
-Johnson,Oxford Twp 0-05,Governor,,L,Keen Umbehr,0
-Johnson,Oxford Twp 0-09,Governor,,L,Keen Umbehr,0
-Johnson,Oxford Twp 0-10,Governor,,L,Keen Umbehr,0
-Johnson,Oxford Twp 0-11,Governor,,L,Keen Umbehr,2
-Johnson,Prairie Village 1-01,Governor,,L,Keen Umbehr,7
-Johnson,Prairie Village 1-02,Governor,,L,Keen Umbehr,7
-Johnson,Prairie Village 1-03,Governor,,L,Keen Umbehr,9
-Johnson,Prairie Village 2-01,Governor,,L,Keen Umbehr,11
-Johnson,Prairie Village 2-02,Governor,,L,Keen Umbehr,10
-Johnson,Prairie Village 2-03,Governor,,L,Keen Umbehr,13
-Johnson,Prairie Village 3-01,Governor,,L,Keen Umbehr,10
-Johnson,Prairie Village 3-02,Governor,,L,Keen Umbehr,13
-Johnson,Prairie Village 3-03,Governor,,L,Keen Umbehr,8
-Johnson,Prairie Village 4-01,Governor,,L,Keen Umbehr,16
-Johnson,Prairie Village 4-02,Governor,,L,Keen Umbehr,12
-Johnson,Prairie Village 4-03,Governor,,L,Keen Umbehr,12
-Johnson,Prairie Village 5-01,Governor,,L,Keen Umbehr,5
-Johnson,Prairie Village 5-02,Governor,,L,Keen Umbehr,11
-Johnson,Prairie Village 5-03,Governor,,L,Keen Umbehr,13
-Johnson,Prairie Village 6-01,Governor,,L,Keen Umbehr,14
-Johnson,Prairie Village 6-02,Governor,,L,Keen Umbehr,21
-Johnson,Prairie Village 6-03,Governor,,L,Keen Umbehr,16
-Johnson,Roeland Park 1-01,Governor,,L,Keen Umbehr,6
-Johnson,Roeland Park 1-02,Governor,,L,Keen Umbehr,7
-Johnson,Roeland Park 2-01,Governor,,L,Keen Umbehr,10
-Johnson,Roeland Park 2-02,Governor,,L,Keen Umbehr,6
-Johnson,Roeland Park 3-01,Governor,,L,Keen Umbehr,11
-Johnson,Roeland Park 3-02,Governor,,L,Keen Umbehr,16
-Johnson,Roeland Park 4-01,Governor,,L,Keen Umbehr,5
-Johnson,Roeland Park 4-02,Governor,,L,Keen Umbehr,20
-Johnson,Shawnee 1-01,Governor,,L,Keen Umbehr,22
-Johnson,Shawnee 1-02,Governor,,L,Keen Umbehr,10
-Johnson,Shawnee 1-03,Governor,,L,Keen Umbehr,19
-Johnson,Shawnee 1-04,Governor,,L,Keen Umbehr,12
-Johnson,Shawnee 1-05,Governor,,L,Keen Umbehr,23
-Johnson,Shawnee 1-06,Governor,,L,Keen Umbehr,15
-Johnson,Shawnee 1-07,Governor,,L,Keen Umbehr,20
-Johnson,Shawnee 1-08,Governor,,L,Keen Umbehr,22
-Johnson,Shawnee 1-09,Governor,,L,Keen Umbehr,1
-Johnson,Shawnee 1-10,Governor,,L,Keen Umbehr,8
-Johnson,Shawnee 1-11,Governor,,L,Keen Umbehr,16
-Johnson,Shawnee 1-12,Governor,,L,Keen Umbehr,0
-Johnson,Shawnee 2-01,Governor,,L,Keen Umbehr,19
-Johnson,Shawnee 2-02,Governor,,L,Keen Umbehr,20
-Johnson,Shawnee 2-03,Governor,,L,Keen Umbehr,16
-Johnson,Shawnee 2-04,Governor,,L,Keen Umbehr,25
-Johnson,Shawnee 2-05,Governor,,L,Keen Umbehr,10
-Johnson,Shawnee 2-06,Governor,,L,Keen Umbehr,11
-Johnson,Shawnee 2-07,Governor,,L,Keen Umbehr,17
-Johnson,Shawnee 2-08,Governor,,L,Keen Umbehr,13
-Johnson,Shawnee 2-09,Governor,,L,Keen Umbehr,15
-Johnson,Shawnee 2-10,Governor,,L,Keen Umbehr,13
-Johnson,Shawnee 2-11,Governor,,L,Keen Umbehr,18
-Johnson,Shawnee 2-12,Governor,,L,Keen Umbehr,9
-Johnson,Shawnee 2-13,Governor,,L,Keen Umbehr,13
-Johnson,Shawnee 3-01,Governor,,L,Keen Umbehr,8
-Johnson,Shawnee 3-02,Governor,,L,Keen Umbehr,18
-Johnson,Shawnee 3-03,Governor,,L,Keen Umbehr,27
-Johnson,Shawnee 3-04,Governor,,L,Keen Umbehr,17
-Johnson,Shawnee 3-05,Governor,,L,Keen Umbehr,23
-Johnson,Shawnee 3-06,Governor,,L,Keen Umbehr,18
-Johnson,Shawnee 3-07,Governor,,L,Keen Umbehr,30
-Johnson,Shawnee 3-08,Governor,,L,Keen Umbehr,16
-Johnson,Shawnee 3-09,Governor,,L,Keen Umbehr,17
-Johnson,Shawnee 4-01,Governor,,L,Keen Umbehr,27
-Johnson,Shawnee 4-02,Governor,,L,Keen Umbehr,14
-Johnson,Shawnee 4-03,Governor,,L,Keen Umbehr,11
-Johnson,Shawnee 4-04,Governor,,L,Keen Umbehr,12
-Johnson,Shawnee 4-05,Governor,,L,Keen Umbehr,22
-Johnson,Shawnee 4-06,Governor,,L,Keen Umbehr,18
-Johnson,Shawnee 4-07,Governor,,L,Keen Umbehr,20
-Johnson,Shawnee 4-08,Governor,,L,Keen Umbehr,6
-Johnson,Shawnee 4-09,Governor,,L,Keen Umbehr,26
-Johnson,Shawnee 4-11,Governor,,L,Keen Umbehr,13
-Johnson,Shawnee 4-12,Governor,,L,Keen Umbehr,4
-Johnson,Spring Hill 0-01,Governor,,L,Keen Umbehr,50
-Johnson,Spring Hill 0-03,Governor,,L,Keen Umbehr,3
-Johnson,Spring Hill 0-04,Governor,,L,Keen Umbehr,0
-Johnson,Spring Hill Twp 0-01,Governor,,L,Keen Umbehr,27
-Johnson,Spring Hill Twp 0-02,Governor,,L,Keen Umbehr,0
-Johnson,Spring Hill Twp 0-03,Governor,,L,Keen Umbehr,2
-Johnson,Spring Hill Twp 0-04,Governor,,L,Keen Umbehr,1
-Johnson,Spring Hill Twp 0-05,Governor,,L,Keen Umbehr,0
-Johnson,Westwood 0-01,Governor,,L,Keen Umbehr,12
-Johnson,Westwood 0-02,Governor,,L,Keen Umbehr,2
-Johnson,Westwood Hills 0-01,Governor,,L,Keen Umbehr,2
-Johnson,Aubry Twp 0-01,Governor,,,Write-ins,0
-Johnson,Aubry Twp 0-02,Governor,,,Write-ins,0
-Johnson,Aubry Twp 0-03,Governor,,,Write-ins,0
-Johnson,Aubry Twp 0-04,Governor,,,Write-ins,0
-Johnson,Aubry Twp 0-05,Governor,,,Write-ins,0
-Johnson,Aubry Twp 0-06,Governor,,,Write-ins,0
-Johnson,De Soto 0-01,Governor,,,Write-ins,1
-Johnson,De Soto 0-02,Governor,,,Write-ins,0
-Johnson,De Soto 0-03,Governor,,,Write-ins,0
-Johnson,De Soto 0-06,Governor,,,Write-ins,0
-Johnson,De Soto 0-07,Governor,,,Write-ins,0
-Johnson,Edgerton 0-01,Governor,,,Write-ins,0
-Johnson,Edgerton 0-02,Governor,,,Write-ins,0
-Johnson,Edgerton 0-05,Governor,,,Write-ins,0
-Johnson,Edgerton 0-06,Governor,,,Write-ins,0
-Johnson,Edgerton 0-09,Governor,,,Write-ins,0
-Johnson,Fairway 1-01,Governor,,,Write-ins,0
-Johnson,Fairway 1-02,Governor,,,Write-ins,0
-Johnson,Fairway 2-01,Governor,,,Write-ins,0
-Johnson,Fairway 2-02,Governor,,,Write-ins,0
-Johnson,Fairway 3-01,Governor,,,Write-ins,0
-Johnson,Fairway 3-02,Governor,,,Write-ins,0
-Johnson,Fairway 4-01,Governor,,,Write-ins,0
-Johnson,Fairway 4-02,Governor,,,Write-ins,0
-Johnson,Fairway 4-03,Governor,,,Write-ins,0
-Johnson,Fairway 4-04,Governor,,,Write-ins,0
-Johnson,Gardner 0-01,Governor,,,Write-ins,1
-Johnson,Gardner 0-02,Governor,,,Write-ins,0
-Johnson,Gardner 0-03,Governor,,,Write-ins,0
-Johnson,Gardner 0-04,Governor,,,Write-ins,0
-Johnson,Gardner 0-06,Governor,,,Write-ins,0
-Johnson,Gardner 0-07,Governor,,,Write-ins,0
-Johnson,Gardner 0-08,Governor,,,Write-ins,0
-Johnson,Gardner 0-09,Governor,,,Write-ins,1
-Johnson,Gardner 0-10,Governor,,,Write-ins,0
-Johnson,Gardner 0-12,Governor,,,Write-ins,0
-Johnson,Gardner 0-13,Governor,,,Write-ins,0
-Johnson,Gardner 0-14,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-01,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-02,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-04,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-05,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-07,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-08,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-09,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-10,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-11,Governor,,,Write-ins,0
-Johnson,Gardner Twp 0-13,Governor,,,Write-ins,0
-Johnson,Lake Quivira 0-01,Governor,,,Write-ins,0
-Johnson,Leawood 1-01,Governor,,,Write-ins,1
-Johnson,Leawood 1-02,Governor,,,Write-ins,0
-Johnson,Leawood 1-03,Governor,,,Write-ins,0
-Johnson,Leawood 1-04,Governor,,,Write-ins,0
-Johnson,Leawood 1-05,Governor,,,Write-ins,0
-Johnson,Leawood 1-06,Governor,,,Write-ins,0
-Johnson,Leawood 2-01,Governor,,,Write-ins,0
-Johnson,Leawood 2-02,Governor,,,Write-ins,0
-Johnson,Leawood 2-03,Governor,,,Write-ins,1
-Johnson,Leawood 2-04,Governor,,,Write-ins,0
-Johnson,Leawood 2-05,Governor,,,Write-ins,0
-Johnson,Leawood 2-06,Governor,,,Write-ins,0
-Johnson,Leawood 3-01,Governor,,,Write-ins,0
-Johnson,Leawood 3-02,Governor,,,Write-ins,0
-Johnson,Leawood 3-03,Governor,,,Write-ins,0
-Johnson,Leawood 3-04,Governor,,,Write-ins,0
-Johnson,Leawood 3-05,Governor,,,Write-ins,0
-Johnson,Leawood 3-06,Governor,,,Write-ins,0
-Johnson,Leawood 3-07,Governor,,,Write-ins,0
-Johnson,Leawood 4-01,Governor,,,Write-ins,0
-Johnson,Leawood 4-02,Governor,,,Write-ins,0
-Johnson,Leawood 4-03,Governor,,,Write-ins,0
-Johnson,Leawood 4-04,Governor,,,Write-ins,0
-Johnson,Leawood 4-05,Governor,,,Write-ins,11
-Johnson,Leawood 4-06,Governor,,,Write-ins,3
-Johnson,Leawood 4-07,Governor,,,Write-ins,5
-Johnson,Leawood 4-08,Governor,,,Write-ins,8
-Johnson,Lenexa 1-01,Governor,,,Write-ins,14
-Johnson,Lenexa 1-02,Governor,,,Write-ins,13
-Johnson,Lenexa 1-03,Governor,,,Write-ins,21
-Johnson,Lenexa 1-04,Governor,,,Write-ins,12
-Johnson,Lenexa 1-05,Governor,,,Write-ins,25
-Johnson,Lenexa 1-06,Governor,,,Write-ins,10
-Johnson,Lenexa 1-07,Governor,,,Write-ins,18
-Johnson,Lenexa 1-08,Governor,,,Write-ins,7
-Johnson,Lenexa 1-09,Governor,,,Write-ins,0
-Johnson,Lenexa 2-01,Governor,,,Write-ins,25
-Johnson,Lenexa 2-02,Governor,,,Write-ins,7
-Johnson,Lenexa 2-03,Governor,,,Write-ins,10
-Johnson,Lenexa 2-04,Governor,,,Write-ins,9
-Johnson,Lenexa 2-05,Governor,,,Write-ins,20
-Johnson,Lenexa 2-06,Governor,,,Write-ins,5
-Johnson,Lenexa 2-07,Governor,,,Write-ins,24
-Johnson,Lenexa 3-01,Governor,,,Write-ins,20
-Johnson,Lenexa 3-02,Governor,,,Write-ins,23
-Johnson,Lenexa 3-03,Governor,,,Write-ins,17
-Johnson,Lenexa 3-04,Governor,,,Write-ins,7
-Johnson,Lenexa 3-05,Governor,,,Write-ins,15
-Johnson,Lenexa 3-06,Governor,,,Write-ins,7
-Johnson,Lenexa 3-07,Governor,,,Write-ins,19
-Johnson,Lenexa 3-08,Governor,,,Write-ins,15
-Johnson,Lenexa 4-01,Governor,,,Write-ins,8
-Johnson,Lenexa 4-02,Governor,,,Write-ins,16
-Johnson,Lenexa 4-03,Governor,,,Write-ins,11
-Johnson,Lenexa 4-04,Governor,,,Write-ins,10
-Johnson,Lenexa 4-05,Governor,,,Write-ins,10
-Johnson,Lenexa 4-06,Governor,,,Write-ins,23
-Johnson,Lenexa 4-07,Governor,,,Write-ins,21
-Johnson,Lenexa 4-08,Governor,,,Write-ins,11
-Johnson,Lenexa 4-09,Governor,,,Write-ins,25
-Johnson,Lenexa 4-10,Governor,,,Write-ins,8
-Johnson,Lenexa 4-11,Governor,,,Write-ins,3
-Johnson,Lexington Twp 0-01,Governor,,,Write-ins,13
-Johnson,Lexington Twp 0-02,Governor,,,Write-ins,2
-Johnson,Lexington Twp 0-03,Governor,,,Write-ins,1
-Johnson,McCamish Twp 0-01,Governor,,,Write-ins,0
-Johnson,McCamish Twp 0-02,Governor,,,Write-ins,0
-Johnson,Merriam 1-01,Governor,,,Write-ins,0
-Johnson,Merriam 1-02,Governor,,,Write-ins,0
-Johnson,Merriam 2-01,Governor,,,Write-ins,0
-Johnson,Merriam 2-02,Governor,,,Write-ins,0
-Johnson,Merriam 2-03,Governor,,,Write-ins,0
-Johnson,Merriam 3-01,Governor,,,Write-ins,1
-Johnson,Merriam 3-02,Governor,,,Write-ins,0
-Johnson,Merriam 4-01,Governor,,,Write-ins,0
-Johnson,Merriam 4-02,Governor,,,Write-ins,1
-Johnson,Merriam 4-03,Governor,,,Write-ins,0
-Johnson,Mission 1-01,Governor,,,Write-ins,0
-Johnson,Mission 1-02,Governor,,,Write-ins,0
-Johnson,Mission 2-01,Governor,,,Write-ins,0
-Johnson,Mission 2-02,Governor,,,Write-ins,1
-Johnson,Mission 3-01,Governor,,,Write-ins,1
-Johnson,Mission 3-02,Governor,,,Write-ins,0
-Johnson,Mission 4-01,Governor,,,Write-ins,0
-Johnson,Mission 4-02,Governor,,,Write-ins,0
-Johnson,Mission 4-03,Governor,,,Write-ins,0
-Johnson,Mission Hills 0-01,Governor,,,Write-ins,0
-Johnson,Mission Hills 0-02,Governor,,,Write-ins,0
-Johnson,Mission Hills 0-03,Governor,,,Write-ins,0
-Johnson,Mission Hills 0-04,Governor,,,Write-ins,0
-Johnson,Mission Woods 0-01,Governor,,,Write-ins,0
-Johnson,Olathe 1-01,Governor,,,Write-ins,0
-Johnson,Olathe 1-02,Governor,,,Write-ins,1
-Johnson,Olathe 1-03,Governor,,,Write-ins,0
-Johnson,Olathe 1-04,Governor,,,Write-ins,1
-Johnson,Olathe 1-05,Governor,,,Write-ins,0
-Johnson,Olathe 1-06,Governor,,,Write-ins,0
-Johnson,Olathe 1-08,Governor,,,Write-ins,1
-Johnson,Olathe 1-09,Governor,,,Write-ins,0
-Johnson,Olathe 1-11,Governor,,,Write-ins,0
-Johnson,Olathe 1-14,Governor,,,Write-ins,0
-Johnson,Olathe 1-15,Governor,,,Write-ins,0
-Johnson,Olathe 1-16,Governor,,,Write-ins,0
-Johnson,Olathe 1-17,Governor,,,Write-ins,0
-Johnson,Olathe 1-18,Governor,,,Write-ins,0
-Johnson,Olathe 1-19,Governor,,,Write-ins,0
-Johnson,Olathe 1-20,Governor,,,Write-ins,0
-Johnson,Olathe 1-21,Governor,,,Write-ins,1
-Johnson,Olathe 1-22,Governor,,,Write-ins,0
-Johnson,Olathe 1-23,Governor,,,Write-ins,0
-Johnson,Olathe 1-24,Governor,,,Write-ins,0
-Johnson,Olathe 1-24,Governor,,,Write-ins,0
-Johnson,Olathe 1-26,Governor,,,Write-ins,0
-Johnson,Olathe 1-27,Governor,,,Write-ins,0
-Johnson,Olathe 2-01,Governor,,,Write-ins,0
-Johnson,Olathe 2-02,Governor,,,Write-ins,2
-Johnson,Olathe 2-03,Governor,,,Write-ins,0
-Johnson,Olathe 2-04,Governor,,,Write-ins,0
-Johnson,Olathe 2-05,Governor,,,Write-ins,0
-Johnson,Olathe 2-06,Governor,,,Write-ins,0
-Johnson,Olathe 2-07,Governor,,,Write-ins,1
-Johnson,Olathe 2-08,Governor,,,Write-ins,1
-Johnson,Olathe 2-09,Governor,,,Write-ins,0
-Johnson,Olathe 2-10,Governor,,,Write-ins,0
-Johnson,Olathe 2-11,Governor,,,Write-ins,1
-Johnson,Olathe 2-12,Governor,,,Write-ins,1
-Johnson,Olathe 2-13,Governor,,,Write-ins,0
-Johnson,Olathe 2-14,Governor,,,Write-ins,0
-Johnson,Olathe 2-15,Governor,,,Write-ins,2
-Johnson,Olathe 2-16,Governor,,,Write-ins,0
-Johnson,Olathe 2-17,Governor,,,Write-ins,0
-Johnson,Olathe 2-19,Governor,,,Write-ins,0
-Johnson,Olathe 2-22,Governor,,,Write-ins,0
-Johnson,Olathe 2-23,Governor,,,Write-ins,1
-Johnson,Olathe 3-01,Governor,,,Write-ins,1
-Johnson,Olathe 3-02,Governor,,,Write-ins,0
-Johnson,Olathe 3-03,Governor,,,Write-ins,0
-Johnson,Olathe 3-04,Governor,,,Write-ins,0
-Johnson,Olathe 3-05,Governor,,,Write-ins,0
-Johnson,Olathe 3-06,Governor,,,Write-ins,0
-Johnson,Olathe 3-07,Governor,,,Write-ins,2
-Johnson,Olathe 3-08,Governor,,,Write-ins,0
-Johnson,Olathe 3-09,Governor,,,Write-ins,1
-Johnson,Olathe 3-10,Governor,,,Write-ins,0
-Johnson,Olathe 3-11,Governor,,,Write-ins,1
-Johnson,Olathe 3-12,Governor,,,Write-ins,1
-Johnson,Olathe 3-13,Governor,,,Write-ins,0
-Johnson,Olathe 3-15,Governor,,,Write-ins,2
-Johnson,Olathe 3-16,Governor,,,Write-ins,0
-Johnson,Olathe 3-17,Governor,,,Write-ins,0
-Johnson,Olathe 3-18,Governor,,,Write-ins,0
-Johnson,Olathe 3-19,Governor,,,Write-ins,0
-Johnson,Olathe 3-20,Governor,,,Write-ins,0
-Johnson,Olathe 3-21,Governor,,,Write-ins,0
-Johnson,Olathe 3-22,Governor,,,Write-ins,0
-Johnson,Olathe 3-23,Governor,,,Write-ins,0
-Johnson,Olathe 3-24,Governor,,,Write-ins,0
-Johnson,Olathe 3-26,Governor,,,Write-ins,0
-Johnson,Olathe 4-01,Governor,,,Write-ins,3
-Johnson,Olathe 4-02,Governor,,,Write-ins,2
-Johnson,Olathe 4-03,Governor,,,Write-ins,1
-Johnson,Olathe 4-04,Governor,,,Write-ins,1
-Johnson,Olathe 4-05,Governor,,,Write-ins,0
-Johnson,Olathe 4-06,Governor,,,Write-ins,2
-Johnson,Olathe 4-07,Governor,,,Write-ins,0
-Johnson,Olathe 4-08,Governor,,,Write-ins,0
-Johnson,Olathe 4-09,Governor,,,Write-ins,0
-Johnson,Olathe 4-10,Governor,,,Write-ins,0
-Johnson,Olathe 4-11,Governor,,,Write-ins,0
-Johnson,Olathe 4-12,Governor,,,Write-ins,0
-Johnson,Olathe 4-13,Governor,,,Write-ins,0
-Johnson,Olathe 4-14,Governor,,,Write-ins,1
-Johnson,Olathe 4-15,Governor,,,Write-ins,0
-Johnson,Olathe 4-16,Governor,,,Write-ins,1
-Johnson,Olathe 4-17,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-01,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-02,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-03,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-04,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-05,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-06,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-07,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-08,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-09,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-10,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-11,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-14,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-24,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-25,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-26,Governor,,,Write-ins,0
-Johnson,Olathe Twp 0-32,Governor,,,Write-ins,0
-Johnson,Overland Park 1-01,Governor,,,Write-ins,0
-Johnson,Overland Park 1-02,Governor,,,Write-ins,0
-Johnson,Overland Park 1-03,Governor,,,Write-ins,0
-Johnson,Overland Park 1-04,Governor,,,Write-ins,0
-Johnson,Overland Park 1-05,Governor,,,Write-ins,0
-Johnson,Overland Park 1-06,Governor,,,Write-ins,0
-Johnson,Overland Park 1-07,Governor,,,Write-ins,0
-Johnson,Overland Park 1-08,Governor,,,Write-ins,0
-Johnson,Overland Park 1-09,Governor,,,Write-ins,0
-Johnson,Overland Park 1-10,Governor,,,Write-ins,0
-Johnson,Overland Park 1-11,Governor,,,Write-ins,1
-Johnson,Overland Park 1-12,Governor,,,Write-ins,0
-Johnson,Overland Park 1-13,Governor,,,Write-ins,1
-Johnson,Overland Park 1-14,Governor,,,Write-ins,1
-Johnson,Overland Park 1-15,Governor,,,Write-ins,0
-Johnson,Overland Park 1-16,Governor,,,Write-ins,0
-Johnson,Overland Park 1-17,Governor,,,Write-ins,1
-Johnson,Overland Park 1-18,Governor,,,Write-ins,1
-Johnson,Overland Park 1-19,Governor,,,Write-ins,0
-Johnson,Overland Park 1-20,Governor,,,Write-ins,0
-Johnson,Overland Park 1-21,Governor,,,Write-ins,0
-Johnson,Overland Park 1-22,Governor,,,Write-ins,0
-Johnson,Overland Park 2-01,Governor,,,Write-ins,0
-Johnson,Overland Park 2-02,Governor,,,Write-ins,0
-Johnson,Overland Park 2-03,Governor,,,Write-ins,0
-Johnson,Overland Park 2-04,Governor,,,Write-ins,0
-Johnson,Overland Park 2-05,Governor,,,Write-ins,0
-Johnson,Overland Park 2-06,Governor,,,Write-ins,0
-Johnson,Overland Park 2-07,Governor,,,Write-ins,0
-Johnson,Overland Park 2-08,Governor,,,Write-ins,0
-Johnson,Overland Park 2-09,Governor,,,Write-ins,0
-Johnson,Overland Park 2-10,Governor,,,Write-ins,0
-Johnson,Overland Park 2-11,Governor,,,Write-ins,0
-Johnson,Overland Park 2-12,Governor,,,Write-ins,0
-Johnson,Overland Park 2-13,Governor,,,Write-ins,1
-Johnson,Overland Park 2-14,Governor,,,Write-ins,1
-Johnson,Overland Park 2-15,Governor,,,Write-ins,1
-Johnson,Overland Park 2-16,Governor,,,Write-ins,0
-Johnson,Overland Park 2-17,Governor,,,Write-ins,0
-Johnson,Overland Park 2-18,Governor,,,Write-ins,0
-Johnson,Overland Park 2-19,Governor,,,Write-ins,0
-Johnson,Overland Park 2-20,Governor,,,Write-ins,0
-Johnson,Overland Park 2-21,Governor,,,Write-ins,1
-Johnson,Overland Park 2-22,Governor,,,Write-ins,0
-Johnson,Overland Park 2-23,Governor,,,Write-ins,0
-Johnson,Overland Park 2-24,Governor,,,Write-ins,1
-Johnson,Overland Park 2-25,Governor,,,Write-ins,0
-Johnson,Overland Park 2-26,Governor,,,Write-ins,0
-Johnson,Overland Park 3-01,Governor,,,Write-ins,0
-Johnson,Overland Park 3-02,Governor,,,Write-ins,0
-Johnson,Overland Park 3-03,Governor,,,Write-ins,0
-Johnson,Overland Park 3-04,Governor,,,Write-ins,0
-Johnson,Overland Park 3-05,Governor,,,Write-ins,0
-Johnson,Overland Park 3-06,Governor,,,Write-ins,0
-Johnson,Overland Park 3-07,Governor,,,Write-ins,0
-Johnson,Overland Park 3-08,Governor,,,Write-ins,0
-Johnson,Overland Park 3-09,Governor,,,Write-ins,0
-Johnson,Overland Park 3-10,Governor,,,Write-ins,0
-Johnson,Overland Park 3-11,Governor,,,Write-ins,0
-Johnson,Overland Park 3-12,Governor,,,Write-ins,0
-Johnson,Overland Park 3-13,Governor,,,Write-ins,1
-Johnson,Overland Park 3-14,Governor,,,Write-ins,2
-Johnson,Overland Park 3-15,Governor,,,Write-ins,0
-Johnson,Overland Park 3-16,Governor,,,Write-ins,0
-Johnson,Overland Park 3-17,Governor,,,Write-ins,0
-Johnson,Overland Park 3-18,Governor,,,Write-ins,0
-Johnson,Overland Park 3-19,Governor,,,Write-ins,0
-Johnson,Overland Park 3-20,Governor,,,Write-ins,0
-Johnson,Overland Park 3-21,Governor,,,Write-ins,0
-Johnson,Overland Park 4-01,Governor,,,Write-ins,0
-Johnson,Overland Park 4-02,Governor,,,Write-ins,0
-Johnson,Overland Park 4-03,Governor,,,Write-ins,0
-Johnson,Overland Park 4-04,Governor,,,Write-ins,0
-Johnson,Overland Park 4-05,Governor,,,Write-ins,0
-Johnson,Overland Park 4-06,Governor,,,Write-ins,0
-Johnson,Overland Park 4-07,Governor,,,Write-ins,0
-Johnson,Overland Park 4-08,Governor,,,Write-ins,0
-Johnson,Overland Park 4-09,Governor,,,Write-ins,0
-Johnson,Overland Park 4-10,Governor,,,Write-ins,0
-Johnson,Overland Park 4-11,Governor,,,Write-ins,0
-Johnson,Overland Park 4-12,Governor,,,Write-ins,0
-Johnson,Overland Park 4-13,Governor,,,Write-ins,0
-Johnson,Overland Park 4-14,Governor,,,Write-ins,0
-Johnson,Overland Park 4-15,Governor,,,Write-ins,0
-Johnson,Overland Park 4-16,Governor,,,Write-ins,0
-Johnson,Overland Park 4-17,Governor,,,Write-ins,0
-Johnson,Overland Park 4-18,Governor,,,Write-ins,0
-Johnson,Overland Park 5-01,Governor,,,Write-ins,0
-Johnson,Overland Park 5-02,Governor,,,Write-ins,0
-Johnson,Overland Park 5-03,Governor,,,Write-ins,0
-Johnson,Overland Park 5-04,Governor,,,Write-ins,0
-Johnson,Overland Park 5-05,Governor,,,Write-ins,1
-Johnson,Overland Park 5-06,Governor,,,Write-ins,0
-Johnson,Overland Park 5-07,Governor,,,Write-ins,0
-Johnson,Overland Park 5-08,Governor,,,Write-ins,0
-Johnson,Overland Park 5-09,Governor,,,Write-ins,0
-Johnson,Overland Park 5-10,Governor,,,Write-ins,0
-Johnson,Overland Park 5-11,Governor,,,Write-ins,0
-Johnson,Overland Park 5-12,Governor,,,Write-ins,0
-Johnson,Overland Park 5-13,Governor,,,Write-ins,1
-Johnson,Overland Park 5-14,Governor,,,Write-ins,0
-Johnson,Overland Park 5-15,Governor,,,Write-ins,0
-Johnson,Overland Park 5-16,Governor,,,Write-ins,0
-Johnson,Overland Park 5-17,Governor,,,Write-ins,0
-Johnson,Overland Park 5-18,Governor,,,Write-ins,0
-Johnson,Overland Park 5-19,Governor,,,Write-ins,0
-Johnson,Overland Park 6-01,Governor,,,Write-ins,0
-Johnson,Overland Park 6-02,Governor,,,Write-ins,0
-Johnson,Overland Park 6-03,Governor,,,Write-ins,0
-Johnson,Overland Park 6-04,Governor,,,Write-ins,0
-Johnson,Overland Park 6-05,Governor,,,Write-ins,0
-Johnson,Overland Park 6-06,Governor,,,Write-ins,0
-Johnson,Overland Park 6-07,Governor,,,Write-ins,0
-Johnson,Overland Park 6-08,Governor,,,Write-ins,0
-Johnson,Overland Park 6-09,Governor,,,Write-ins,0
-Johnson,Overland Park 6-10,Governor,,,Write-ins,0
-Johnson,Overland Park 6-11,Governor,,,Write-ins,0
-Johnson,Overland Park 6-12,Governor,,,Write-ins,0
-Johnson,Overland Park 6-13,Governor,,,Write-ins,0
-Johnson,Overland Park 6-15,Governor,,,Write-ins,0
-Johnson,Overland Park 6-16,Governor,,,Write-ins,0
-Johnson,Overland Park 6-17,Governor,,,Write-ins,0
-Johnson,Overland Park 6-18,Governor,,,Write-ins,0
-Johnson,Overland Park 6-19,Governor,,,Write-ins,0
-Johnson,Overland Park 6-20,Governor,,,Write-ins,0
-Johnson,Overland Park 6-21,Governor,,,Write-ins,0
-Johnson,Overland Park 6-22,Governor,,,Write-ins,0
-Johnson,Oxford Twp 0-01,Governor,,,Write-ins,0
-Johnson,Oxford Twp 0-02,Governor,,,Write-ins,1
-Johnson,Oxford Twp 0-04,Governor,,,Write-ins,0
-Johnson,Oxford Twp 0-05,Governor,,,Write-ins,0
-Johnson,Oxford Twp 0-09,Governor,,,Write-ins,0
-Johnson,Oxford Twp 0-10,Governor,,,Write-ins,0
-Johnson,Oxford Twp 0-11,Governor,,,Write-ins,0
-Johnson,Prairie Village 1-01,Governor,,,Write-ins,0
-Johnson,Prairie Village 1-02,Governor,,,Write-ins,0
-Johnson,Prairie Village 1-03,Governor,,,Write-ins,0
-Johnson,Prairie Village 2-01,Governor,,,Write-ins,0
-Johnson,Prairie Village 2-02,Governor,,,Write-ins,1
-Johnson,Prairie Village 2-03,Governor,,,Write-ins,1
-Johnson,Prairie Village 3-01,Governor,,,Write-ins,0
-Johnson,Prairie Village 3-02,Governor,,,Write-ins,2
-Johnson,Prairie Village 3-03,Governor,,,Write-ins,0
-Johnson,Prairie Village 4-01,Governor,,,Write-ins,1
-Johnson,Prairie Village 4-02,Governor,,,Write-ins,0
-Johnson,Prairie Village 4-03,Governor,,,Write-ins,0
-Johnson,Prairie Village 5-01,Governor,,,Write-ins,1
-Johnson,Prairie Village 5-02,Governor,,,Write-ins,0
-Johnson,Prairie Village 5-03,Governor,,,Write-ins,0
-Johnson,Prairie Village 6-01,Governor,,,Write-ins,2
-Johnson,Prairie Village 6-02,Governor,,,Write-ins,0
-Johnson,Prairie Village 6-03,Governor,,,Write-ins,0
-Johnson,Roeland Park 1-01,Governor,,,Write-ins,0
-Johnson,Roeland Park 1-02,Governor,,,Write-ins,0
-Johnson,Roeland Park 2-01,Governor,,,Write-ins,0
-Johnson,Roeland Park 2-02,Governor,,,Write-ins,0
-Johnson,Roeland Park 3-01,Governor,,,Write-ins,0
-Johnson,Roeland Park 3-02,Governor,,,Write-ins,0
-Johnson,Roeland Park 4-01,Governor,,,Write-ins,0
-Johnson,Roeland Park 4-02,Governor,,,Write-ins,1
-Johnson,Shawnee 1-01,Governor,,,Write-ins,0
-Johnson,Shawnee 1-02,Governor,,,Write-ins,0
-Johnson,Shawnee 1-03,Governor,,,Write-ins,1
-Johnson,Shawnee 1-04,Governor,,,Write-ins,1
-Johnson,Shawnee 1-05,Governor,,,Write-ins,0
-Johnson,Shawnee 1-06,Governor,,,Write-ins,0
-Johnson,Shawnee 1-07,Governor,,,Write-ins,1
-Johnson,Shawnee 1-08,Governor,,,Write-ins,0
-Johnson,Shawnee 1-09,Governor,,,Write-ins,0
-Johnson,Shawnee 1-10,Governor,,,Write-ins,0
-Johnson,Shawnee 1-11,Governor,,,Write-ins,0
-Johnson,Shawnee 1-12,Governor,,,Write-ins,0
-Johnson,Shawnee 2-01,Governor,,,Write-ins,0
-Johnson,Shawnee 2-02,Governor,,,Write-ins,0
-Johnson,Shawnee 2-03,Governor,,,Write-ins,0
-Johnson,Shawnee 2-04,Governor,,,Write-ins,0
-Johnson,Shawnee 2-05,Governor,,,Write-ins,0
-Johnson,Shawnee 2-06,Governor,,,Write-ins,0
-Johnson,Shawnee 2-07,Governor,,,Write-ins,0
-Johnson,Shawnee 2-08,Governor,,,Write-ins,0
-Johnson,Shawnee 2-09,Governor,,,Write-ins,1
-Johnson,Shawnee 2-10,Governor,,,Write-ins,1
-Johnson,Shawnee 2-11,Governor,,,Write-ins,0
-Johnson,Shawnee 2-12,Governor,,,Write-ins,0
-Johnson,Shawnee 2-13,Governor,,,Write-ins,0
-Johnson,Shawnee 3-01,Governor,,,Write-ins,0
-Johnson,Shawnee 3-02,Governor,,,Write-ins,0
-Johnson,Shawnee 3-03,Governor,,,Write-ins,1
-Johnson,Shawnee 3-04,Governor,,,Write-ins,0
-Johnson,Shawnee 3-05,Governor,,,Write-ins,0
-Johnson,Shawnee 3-06,Governor,,,Write-ins,0
-Johnson,Shawnee 3-07,Governor,,,Write-ins,1
-Johnson,Shawnee 3-08,Governor,,,Write-ins,0
-Johnson,Shawnee 3-09,Governor,,,Write-ins,1
-Johnson,Shawnee 4-01,Governor,,,Write-ins,0
-Johnson,Shawnee 4-02,Governor,,,Write-ins,0
-Johnson,Shawnee 4-03,Governor,,,Write-ins,0
-Johnson,Shawnee 4-04,Governor,,,Write-ins,0
-Johnson,Shawnee 4-05,Governor,,,Write-ins,0
-Johnson,Shawnee 4-06,Governor,,,Write-ins,0
-Johnson,Shawnee 4-07,Governor,,,Write-ins,2
-Johnson,Shawnee 4-08,Governor,,,Write-ins,0
-Johnson,Shawnee 4-09,Governor,,,Write-ins,0
-Johnson,Shawnee 4-11,Governor,,,Write-ins,0
-Johnson,Shawnee 4-12,Governor,,,Write-ins,0
-Johnson,Spring Hill 0-01,Governor,,,Write-ins,3
-Johnson,Spring Hill 0-03,Governor,,,Write-ins,0
-Johnson,Spring Hill 0-04,Governor,,,Write-ins,0
-Johnson,Spring Hill Twp 0-01,Governor,,,Write-ins,0
-Johnson,Spring Hill Twp 0-02,Governor,,,Write-ins,0
-Johnson,Spring Hill Twp 0-03,Governor,,,Write-ins,0
-Johnson,Spring Hill Twp 0-04,Governor,,,Write-ins,0
-Johnson,Spring Hill Twp 0-05,Governor,,,Write-ins,0
-Johnson,Westwood 0-01,Governor,,,Write-ins,1
-Johnson,Westwood 0-02,Governor,,,Write-ins,0
-Johnson,Westwood Hills 0-01,Governor,,,Write-ins,0
-Johnson,Aubry Twp 0-01,Secretary of State,,R,Kris Kobach,73
-Johnson,Aubry Twp 0-02,Secretary of State,,R,Kris Kobach,416
-Johnson,Aubry Twp 0-03,Secretary of State,,R,Kris Kobach,229
-Johnson,Aubry Twp 0-04,Secretary of State,,R,Kris Kobach,505
-Johnson,Aubry Twp 0-05,Secretary of State,,R,Kris Kobach,9
-Johnson,Aubry Twp 0-06,Secretary of State,,R,Kris Kobach,67
-Johnson,De Soto 0-01,Secretary of State,,R,Kris Kobach,426
-Johnson,De Soto 0-02,Secretary of State,,R,Kris Kobach,237
-Johnson,De Soto 0-03,Secretary of State,,R,Kris Kobach,426
-Johnson,De Soto 0-06,Secretary of State,,R,Kris Kobach,29
-Johnson,Edgerton,Secretary of State,,R,Kris Kobach,273
-Johnson,Fairway 1-01,Secretary of State,,R,Kris Kobach,106
-Johnson,Fairway 1-02,Secretary of State,,R,Kris Kobach,89
-Johnson,Fairway 2-01,Secretary of State,,R,Kris Kobach,96
-Johnson,Fairway 2-02,Secretary of State,,R,Kris Kobach,97
-Johnson,Fairway 3-01,Secretary of State,,R,Kris Kobach,148
-Johnson,Fairway 3-02,Secretary of State,,R,Kris Kobach,115
-Johnson,Fairway 4-01,Secretary of State,,R,Kris Kobach,26
-Johnson,Fairway 4-02,Secretary of State,,R,Kris Kobach,39
-Johnson,Fairway 4-03,Secretary of State,,R,Kris Kobach,33
-Johnson,Fairway 4-04,Secretary of State,,R,Kris Kobach,43
-Johnson,Gardner 0-01,Secretary of State,,R,Kris Kobach,534
-Johnson,Gardner 0-02,Secretary of State,,R,Kris Kobach,60
-Johnson,Gardner 0-03,Secretary of State,,R,Kris Kobach,307
-Johnson,Gardner 0-04,Secretary of State,,R,Kris Kobach,313
-Johnson,Gardner 0-06,Secretary of State,,R,Kris Kobach,401
-Johnson,Gardner 0-07,Secretary of State,,R,Kris Kobach,5
-Johnson,Gardner 0-08,Secretary of State,,R,Kris Kobach,38
-Johnson,Gardner 0-09,Secretary of State,,R,Kris Kobach,430
-Johnson,Gardner 0-10,Secretary of State,,R,Kris Kobach,290
-Johnson,Gardner 0-12,Secretary of State,,R,Kris Kobach,9
-Johnson,Gardner 0-13,Secretary of State,,R,Kris Kobach,291
-Johnson,Gardner 0-14,Secretary of State,,R,Kris Kobach,264
-Johnson,Gardner Twp 0-01,Secretary of State,,R,Kris Kobach,218
-Johnson,Gardner Twp 0-02,Secretary of State,,R,Kris Kobach,250
-Johnson,Gardner Twp 0-07,Secretary of State,,R,Kris Kobach,2
-Johnson,Gardner Twp 0-08,Secretary of State,,R,Kris Kobach,2
-Johnson,Gardner Twp 0-11,Secretary of State,,R,Kris Kobach,61
-Johnson,Gardner Twp 0-13,Secretary of State,,R,Kris Kobach,1
-Johnson,Lake Quivira,Secretary of State,,R,Kris Kobach,321
-Johnson,Leawood 1-01,Secretary of State,,R,Kris Kobach,206
-Johnson,Leawood 1-02,Secretary of State,,R,Kris Kobach,402
-Johnson,Leawood 1-03,Secretary of State,,R,Kris Kobach,363
-Johnson,Leawood 1-04,Secretary of State,,R,Kris Kobach,278
-Johnson,Leawood 1-05,Secretary of State,,R,Kris Kobach,260
-Johnson,Leawood 1-06,Secretary of State,,R,Kris Kobach,52
-Johnson,Leawood 2-01,Secretary of State,,R,Kris Kobach,313
-Johnson,Leawood 2-02,Secretary of State,,R,Kris Kobach,371
-Johnson,Leawood 2-03,Secretary of State,,R,Kris Kobach,384
-Johnson,Leawood 2-04,Secretary of State,,R,Kris Kobach,506
-Johnson,Leawood 2-05,Secretary of State,,R,Kris Kobach,245
-Johnson,Leawood 2-06,Secretary of State,,R,Kris Kobach,192
-Johnson,Leawood 3-01,Secretary of State,,R,Kris Kobach,218
-Johnson,Leawood 3-02,Secretary of State,,R,Kris Kobach,379
-Johnson,Leawood 3-03,Secretary of State,,R,Kris Kobach,252
-Johnson,Leawood 3-04,Secretary of State,,R,Kris Kobach,107
-Johnson,Leawood 3-05,Secretary of State,,R,Kris Kobach,521
-Johnson,Leawood 3-06,Secretary of State,,R,Kris Kobach,539
-Johnson,Leawood 3-07,Secretary of State,,R,Kris Kobach,364
-Johnson,Leawood 4-01,Secretary of State,,R,Kris Kobach,137
-Johnson,Leawood 4-02,Secretary of State,,R,Kris Kobach,381
-Johnson,Leawood 4-03,Secretary of State,,R,Kris Kobach,324
-Johnson,Leawood 4-04,Secretary of State,,R,Kris Kobach,393
-Johnson,Leawood 4-05,Secretary of State,,R,Kris Kobach,397
-Johnson,Leawood 4-06,Secretary of State,,R,Kris Kobach,384
-Johnson,Leawood 4-07,Secretary of State,,R,Kris Kobach,571
-Johnson,Leawood 4-08,Secretary of State,,R,Kris Kobach,278
-Johnson,Lenexa 1-01,Secretary of State,,R,Kris Kobach,209
-Johnson,Lenexa 1-02,Secretary of State,,R,Kris Kobach,392
-Johnson,Lenexa 1-03,Secretary of State,,R,Kris Kobach,445
-Johnson,Lenexa 1-04,Secretary of State,,R,Kris Kobach,306
-Johnson,Lenexa 1-05,Secretary of State,,R,Kris Kobach,328
-Johnson,Lenexa 1-06,Secretary of State,,R,Kris Kobach,440
-Johnson,Lenexa 1-07,Secretary of State,,R,Kris Kobach,200
-Johnson,Lenexa 1-08,Secretary of State,,R,Kris Kobach,89
-Johnson,Lenexa 1-09,Secretary of State,,R,Kris Kobach,5
-Johnson,Lenexa 2-01,Secretary of State,,R,Kris Kobach,621
-Johnson,Lenexa 2-02,Secretary of State,,R,Kris Kobach,244
-Johnson,Lenexa 2-03,Secretary of State,,R,Kris Kobach,526
-Johnson,Lenexa 2-04,Secretary of State,,R,Kris Kobach,572
-Johnson,Lenexa 2-05,Secretary of State,,R,Kris Kobach,247
-Johnson,Lenexa 2-06,Secretary of State,,R,Kris Kobach,369
-Johnson,Lenexa 2-07,Secretary of State,,R,Kris Kobach,556
-Johnson,Lenexa 3-01,Secretary of State,,R,Kris Kobach,204
-Johnson,Lenexa 3-02,Secretary of State,,R,Kris Kobach,331
-Johnson,Lenexa 3-03,Secretary of State,,R,Kris Kobach,464
-Johnson,Lenexa 3-04,Secretary of State,,R,Kris Kobach,332
-Johnson,Lenexa 3-05,Secretary of State,,R,Kris Kobach,155
-Johnson,Lenexa 3-06,Secretary of State,,R,Kris Kobach,250
-Johnson,Lenexa 3-07,Secretary of State,,R,Kris Kobach,384
-Johnson,Lenexa 3-08,Secretary of State,,R,Kris Kobach,366
-Johnson,Lenexa 4-01,Secretary of State,,R,Kris Kobach,151
-Johnson,Lenexa 4-02,Secretary of State,,R,Kris Kobach,326
-Johnson,Lenexa 4-03,Secretary of State,,R,Kris Kobach,116
-Johnson,Lenexa 4-04,Secretary of State,,R,Kris Kobach,163
-Johnson,Lenexa 4-05,Secretary of State,,R,Kris Kobach,132
-Johnson,Lenexa 4-06,Secretary of State,,R,Kris Kobach,224
-Johnson,Lenexa 4-07,Secretary of State,,R,Kris Kobach,281
-Johnson,Lenexa 4-08,Secretary of State,,R,Kris Kobach,285
-Johnson,Lenexa 4-09,Secretary of State,,R,Kris Kobach,282
-Johnson,Lenexa 4-10,Secretary of State,,R,Kris Kobach,143
-Johnson,Lenexa 4-11,Secretary of State,,R,Kris Kobach,38
-Johnson,Lexington Twp 0-01,Secretary of State,,R,Kris Kobach,423
-Johnson,Lexington Twp 0-02,Secretary of State,,R,Kris Kobach,1
-Johnson,Lexington Twp 0-03,Secretary of State,,R,Kris Kobach,1
-Johnson,McCamish Twp 0-01,Secretary of State,,R,Kris Kobach,115
-Johnson,McCamish Twp 0-02,Secretary of State,,R,Kris Kobach,213
-Johnson,Merriam 1-01,Secretary of State,,R,Kris Kobach,150
-Johnson,Merriam 1-02,Secretary of State,,R,Kris Kobach,182
-Johnson,Merriam 2-01,Secretary of State,,R,Kris Kobach,270
-Johnson,Merriam 2-02,Secretary of State,,R,Kris Kobach,0
-Johnson,Merriam 2-03,Secretary of State,,R,Kris Kobach,125
-Johnson,Merriam 3-01,Secretary of State,,R,Kris Kobach,188
-Johnson,Merriam 3-02,Secretary of State,,R,Kris Kobach,195
-Johnson,Merriam 4-01,Secretary of State,,R,Kris Kobach,261
-Johnson,Merriam 4-02,Secretary of State,,R,Kris Kobach,115
-Johnson,Merriam 4-03,Secretary of State,,R,Kris Kobach,137
-Johnson,Mission 1-01,Secretary of State,,R,Kris Kobach,239
-Johnson,Mission 1-02,Secretary of State,,R,Kris Kobach,86
-Johnson,Mission 2-01,Secretary of State,,R,Kris Kobach,116
-Johnson,Mission 2-02,Secretary of State,,R,Kris Kobach,173
-Johnson,Mission 3-01,Secretary of State,,R,Kris Kobach,193
-Johnson,Mission 3-02,Secretary of State,,R,Kris Kobach,106
-Johnson,Mission 4-01,Secretary of State,,R,Kris Kobach,122
-Johnson,Mission 4-02,Secretary of State,,R,Kris Kobach,209
-Johnson,Mission 4-03,Secretary of State,,R,Kris Kobach,109
-Johnson,Mission Hills 0-01,Secretary of State,,R,Kris Kobach,248
-Johnson,Mission Hills 0-02,Secretary of State,,R,Kris Kobach,290
-Johnson,Mission Hills 0-03,Secretary of State,,R,Kris Kobach,196
-Johnson,Mission Hills 0-04,Secretary of State,,R,Kris Kobach,314
-Johnson,Mission Woods,Secretary of State,,R,Kris Kobach,40
-Johnson,Olathe 1-01,Secretary of State,,R,Kris Kobach,325
-Johnson,Olathe 1-02,Secretary of State,,R,Kris Kobach,203
-Johnson,Olathe 1-03,Secretary of State,,R,Kris Kobach,168
-Johnson,Olathe 1-04,Secretary of State,,R,Kris Kobach,320
-Johnson,Olathe 1-05,Secretary of State,,R,Kris Kobach,369
-Johnson,Olathe 1-06,Secretary of State,,R,Kris Kobach,232
-Johnson,Olathe 1-08,Secretary of State,,R,Kris Kobach,375
-Johnson,Olathe 1-09,Secretary of State,,R,Kris Kobach,384
-Johnson,Olathe 1-11,Secretary of State,,R,Kris Kobach,58
-Johnson,Olathe 1-14,Secretary of State,,R,Kris Kobach,340
-Johnson,Olathe 1-15,Secretary of State,,R,Kris Kobach,306
-Johnson,Olathe 1-16,Secretary of State,,R,Kris Kobach,424
-Johnson,Olathe 1-17,Secretary of State,,R,Kris Kobach,109
-Johnson,Olathe 1-18,Secretary of State,,R,Kris Kobach,110
-Johnson,Olathe 1-19,Secretary of State,,R,Kris Kobach,141
-Johnson,Olathe 1-20,Secretary of State,,R,Kris Kobach,222
-Johnson,Olathe 1-21,Secretary of State,,R,Kris Kobach,402
-Johnson,Olathe 1-22,Secretary of State,,R,Kris Kobach,618
-Johnson,Olathe 1-24,Secretary of State,,R,Kris Kobach,55
-Johnson,Olathe 1-24,Secretary of State,,R,Kris Kobach,92
-Johnson,Olathe 1-26,Secretary of State,,R,Kris Kobach,0
-Johnson,Olathe 1-27,Secretary of State,,R,Kris Kobach,240
-Johnson,Olathe 2-01,Secretary of State,,R,Kris Kobach,148
-Johnson,Olathe 2-02,Secretary of State,,R,Kris Kobach,207
-Johnson,Olathe 2-03,Secretary of State,,R,Kris Kobach,254
-Johnson,Olathe 2-04,Secretary of State,,R,Kris Kobach,243
-Johnson,Olathe 2-05,Secretary of State,,R,Kris Kobach,863
-Johnson,Olathe 2-06,Secretary of State,,R,Kris Kobach,448
-Johnson,Olathe 2-07,Secretary of State,,R,Kris Kobach,501
-Johnson,Olathe 2-08,Secretary of State,,R,Kris Kobach,338
-Johnson,Olathe 2-09,Secretary of State,,R,Kris Kobach,157
-Johnson,Olathe 2-10,Secretary of State,,R,Kris Kobach,619
-Johnson,Olathe 2-11,Secretary of State,,R,Kris Kobach,439
-Johnson,Olathe 2-12,Secretary of State,,R,Kris Kobach,259
-Johnson,Olathe 2-13,Secretary of State,,R,Kris Kobach,240
-Johnson,Olathe 2-14,Secretary of State,,R,Kris Kobach,261
-Johnson,Olathe 2-15,Secretary of State,,R,Kris Kobach,295
-Johnson,Olathe 2-16,Secretary of State,,R,Kris Kobach,74
-Johnson,Olathe 2-17,Secretary of State,,R,Kris Kobach,0
-Johnson,Olathe 2-19,Secretary of State,,R,Kris Kobach,5
-Johnson,Olathe 2-22,Secretary of State,,R,Kris Kobach,528
-Johnson,Olathe 2-23,Secretary of State,,R,Kris Kobach,345
-Johnson,Olathe 3-01,Secretary of State,,R,Kris Kobach,130
-Johnson,Olathe 3-02,Secretary of State,,R,Kris Kobach,421
-Johnson,Olathe 3-03,Secretary of State,,R,Kris Kobach,233
-Johnson,Olathe 3-04,Secretary of State,,R,Kris Kobach,387
-Johnson,Olathe 3-05,Secretary of State,,R,Kris Kobach,408
-Johnson,Olathe 3-06,Secretary of State,,R,Kris Kobach,291
-Johnson,Olathe 3-07,Secretary of State,,R,Kris Kobach,276
-Johnson,Olathe 3-08,Secretary of State,,R,Kris Kobach,430
-Johnson,Olathe 3-09,Secretary of State,,R,Kris Kobach,217
-Johnson,Olathe 3-10,Secretary of State,,R,Kris Kobach,425
-Johnson,Olathe 3-11,Secretary of State,,R,Kris Kobach,264
-Johnson,Olathe 3-12,Secretary of State,,R,Kris Kobach,353
-Johnson,Olathe 3-13,Secretary of State,,R,Kris Kobach,416
-Johnson,Olathe 3-15,Secretary of State,,R,Kris Kobach,269
-Johnson,Olathe 3-16,Secretary of State,,R,Kris Kobach,295
-Johnson,Olathe 3-17,Secretary of State,,R,Kris Kobach,414
-Johnson,Olathe 3-18,Secretary of State,,R,Kris Kobach,382
-Johnson,Olathe 3-19,Secretary of State,,R,Kris Kobach,271
-Johnson,Olathe 3-20,Secretary of State,,R,Kris Kobach,267
-Johnson,Olathe 3-21,Secretary of State,,R,Kris Kobach,297
-Johnson,Olathe 3-22,Secretary of State,,R,Kris Kobach,350
-Johnson,Olathe 3-23,Secretary of State,,R,Kris Kobach,295
-Johnson,Olathe 3-24,Secretary of State,,R,Kris Kobach,184
-Johnson,Olathe 3-26,Secretary of State,,R,Kris Kobach,31
-Johnson,Olathe 4-01,Secretary of State,,R,Kris Kobach,257
-Johnson,Olathe 4-02,Secretary of State,,R,Kris Kobach,478
-Johnson,Olathe 4-03,Secretary of State,,R,Kris Kobach,135
-Johnson,Olathe 4-04,Secretary of State,,R,Kris Kobach,169
-Johnson,Olathe 4-05,Secretary of State,,R,Kris Kobach,330
-Johnson,Olathe 4-06,Secretary of State,,R,Kris Kobach,425
-Johnson,Olathe 4-07,Secretary of State,,R,Kris Kobach,343
-Johnson,Olathe 4-08,Secretary of State,,R,Kris Kobach,320
-Johnson,Olathe 4-09,Secretary of State,,R,Kris Kobach,437
-Johnson,Olathe 4-10,Secretary of State,,R,Kris Kobach,231
-Johnson,Olathe 4-11,Secretary of State,,R,Kris Kobach,136
-Johnson,Olathe 4-12,Secretary of State,,R,Kris Kobach,415
-Johnson,Olathe 4-13,Secretary of State,,R,Kris Kobach,178
-Johnson,Olathe 4-14,Secretary of State,,R,Kris Kobach,395
-Johnson,Olathe 4-15,Secretary of State,,R,Kris Kobach,20
-Johnson,Olathe 4-16,Secretary of State,,R,Kris Kobach,110
-Johnson,Olathe 4-17,Secretary of State,,R,Kris Kobach,1
-Johnson,Olathe Twp 0-01,Secretary of State,,R,Kris Kobach,165
-Johnson,Olathe Twp 0-02,Secretary of State,,R,Kris Kobach,42
-Johnson,Olathe Twp 0-03,Secretary of State,,R,Kris Kobach,22
-Johnson,Olathe Twp 0-04,Secretary of State,,R,Kris Kobach,1
-Johnson,Olathe Twp 0-08,Secretary of State,,R,Kris Kobach,4
-Johnson,Olathe Twp 0-10,Secretary of State,,R,Kris Kobach,7
-Johnson,Olathe Twp 0-11,Secretary of State,,R,Kris Kobach,3
-Johnson,Olathe Twp 0-24,Secretary of State,,R,Kris Kobach,2
-Johnson,Olathe Twp 0-25,Secretary of State,,R,Kris Kobach,7
-Johnson,Olathe Twp 0-32,Secretary of State,,R,Kris Kobach,19
-Johnson,Overland Park 1-01,Secretary of State,,R,Kris Kobach,224
-Johnson,Overland Park 1-02,Secretary of State,,R,Kris Kobach,215
-Johnson,Overland Park 1-03,Secretary of State,,R,Kris Kobach,233
-Johnson,Overland Park 1-04,Secretary of State,,R,Kris Kobach,88
-Johnson,Overland Park 1-05,Secretary of State,,R,Kris Kobach,157
-Johnson,Overland Park 1-06,Secretary of State,,R,Kris Kobach,288
-Johnson,Overland Park 1-07,Secretary of State,,R,Kris Kobach,304
-Johnson,Overland Park 1-08,Secretary of State,,R,Kris Kobach,176
-Johnson,Overland Park 1-09,Secretary of State,,R,Kris Kobach,133
-Johnson,Overland Park 1-10,Secretary of State,,R,Kris Kobach,256
-Johnson,Overland Park 1-11,Secretary of State,,R,Kris Kobach,66
-Johnson,Overland Park 1-12,Secretary of State,,R,Kris Kobach,195
-Johnson,Overland Park 1-13,Secretary of State,,R,Kris Kobach,170
-Johnson,Overland Park 1-14,Secretary of State,,R,Kris Kobach,217
-Johnson,Overland Park 1-15,Secretary of State,,R,Kris Kobach,104
-Johnson,Overland Park 1-16,Secretary of State,,R,Kris Kobach,226
-Johnson,Overland Park 1-17,Secretary of State,,R,Kris Kobach,119
-Johnson,Overland Park 1-18,Secretary of State,,R,Kris Kobach,201
-Johnson,Overland Park 1-19,Secretary of State,,R,Kris Kobach,178
-Johnson,Overland Park 1-20,Secretary of State,,R,Kris Kobach,141
-Johnson,Overland Park 1-21,Secretary of State,,R,Kris Kobach,84
-Johnson,Overland Park 1-22,Secretary of State,,R,Kris Kobach,50
-Johnson,Overland Park 2-01,Secretary of State,,R,Kris Kobach,224
-Johnson,Overland Park 2-02,Secretary of State,,R,Kris Kobach,202
-Johnson,Overland Park 2-03,Secretary of State,,R,Kris Kobach,190
-Johnson,Overland Park 2-04,Secretary of State,,R,Kris Kobach,259
-Johnson,Overland Park 2-05,Secretary of State,,R,Kris Kobach,198
-Johnson,Overland Park 2-06,Secretary of State,,R,Kris Kobach,224
-Johnson,Overland Park 2-07,Secretary of State,,R,Kris Kobach,190
-Johnson,Overland Park 2-08,Secretary of State,,R,Kris Kobach,94
-Johnson,Overland Park 2-09,Secretary of State,,R,Kris Kobach,198
-Johnson,Overland Park 2-10,Secretary of State,,R,Kris Kobach,201
-Johnson,Overland Park 2-11,Secretary of State,,R,Kris Kobach,218
-Johnson,Overland Park 2-12,Secretary of State,,R,Kris Kobach,167
-Johnson,Overland Park 2-13,Secretary of State,,R,Kris Kobach,95
-Johnson,Overland Park 2-14,Secretary of State,,R,Kris Kobach,140
-Johnson,Overland Park 2-15,Secretary of State,,R,Kris Kobach,323
-Johnson,Overland Park 2-16,Secretary of State,,R,Kris Kobach,181
-Johnson,Overland Park 2-17,Secretary of State,,R,Kris Kobach,308
-Johnson,Overland Park 2-18,Secretary of State,,R,Kris Kobach,275
-Johnson,Overland Park 2-19,Secretary of State,,R,Kris Kobach,185
-Johnson,Overland Park 2-20,Secretary of State,,R,Kris Kobach,201
-Johnson,Overland Park 2-21,Secretary of State,,R,Kris Kobach,174
-Johnson,Overland Park 2-22,Secretary of State,,R,Kris Kobach,197
-Johnson,Overland Park 2-23,Secretary of State,,R,Kris Kobach,263
-Johnson,Overland Park 2-24,Secretary of State,,R,Kris Kobach,364
-Johnson,Overland Park 2-25,Secretary of State,,R,Kris Kobach,273
-Johnson,Overland Park 2-26,Secretary of State,,R,Kris Kobach,97
-Johnson,Overland Park 3-01,Secretary of State,,R,Kris Kobach,458
-Johnson,Overland Park 3-02,Secretary of State,,R,Kris Kobach,248
-Johnson,Overland Park 3-03,Secretary of State,,R,Kris Kobach,279
-Johnson,Overland Park 3-04,Secretary of State,,R,Kris Kobach,306
-Johnson,Overland Park 3-05,Secretary of State,,R,Kris Kobach,297
-Johnson,Overland Park 3-06,Secretary of State,,R,Kris Kobach,345
-Johnson,Overland Park 3-07,Secretary of State,,R,Kris Kobach,183
-Johnson,Overland Park 3-08,Secretary of State,,R,Kris Kobach,304
-Johnson,Overland Park 3-09,Secretary of State,,R,Kris Kobach,377
-Johnson,Overland Park 3-10,Secretary of State,,R,Kris Kobach,236
-Johnson,Overland Park 3-11,Secretary of State,,R,Kris Kobach,298
-Johnson,Overland Park 3-12,Secretary of State,,R,Kris Kobach,150
-Johnson,Overland Park 3-13,Secretary of State,,R,Kris Kobach,455
-Johnson,Overland Park 3-14,Secretary of State,,R,Kris Kobach,288
-Johnson,Overland Park 3-15,Secretary of State,,R,Kris Kobach,222
-Johnson,Overland Park 3-16,Secretary of State,,R,Kris Kobach,251
-Johnson,Overland Park 3-17,Secretary of State,,R,Kris Kobach,215
-Johnson,Overland Park 3-18,Secretary of State,,R,Kris Kobach,225
-Johnson,Overland Park 3-19,Secretary of State,,R,Kris Kobach,285
-Johnson,Overland Park 3-20,Secretary of State,,R,Kris Kobach,347
-Johnson,Overland Park 3-21,Secretary of State,,R,Kris Kobach,291
-Johnson,Overland Park 4-01,Secretary of State,,R,Kris Kobach,248
-Johnson,Overland Park 4-02,Secretary of State,,R,Kris Kobach,418
-Johnson,Overland Park 4-03,Secretary of State,,R,Kris Kobach,512
-Johnson,Overland Park 4-04,Secretary of State,,R,Kris Kobach,502
-Johnson,Overland Park 4-05,Secretary of State,,R,Kris Kobach,338
-Johnson,Overland Park 4-06,Secretary of State,,R,Kris Kobach,281
-Johnson,Overland Park 4-07,Secretary of State,,R,Kris Kobach,197
-Johnson,Overland Park 4-08,Secretary of State,,R,Kris Kobach,356
-Johnson,Overland Park 4-09,Secretary of State,,R,Kris Kobach,392
-Johnson,Overland Park 4-10,Secretary of State,,R,Kris Kobach,258
-Johnson,Overland Park 4-11,Secretary of State,,R,Kris Kobach,386
-Johnson,Overland Park 4-12,Secretary of State,,R,Kris Kobach,516
-Johnson,Overland Park 4-13,Secretary of State,,R,Kris Kobach,312
-Johnson,Overland Park 4-14,Secretary of State,,R,Kris Kobach,241
-Johnson,Overland Park 4-15,Secretary of State,,R,Kris Kobach,458
-Johnson,Overland Park 4-16,Secretary of State,,R,Kris Kobach,371
-Johnson,Overland Park 4-17,Secretary of State,,R,Kris Kobach,403
-Johnson,Overland Park 4-18,Secretary of State,,R,Kris Kobach,52
-Johnson,Overland Park 5-01,Secretary of State,,R,Kris Kobach,344
-Johnson,Overland Park 5-02,Secretary of State,,R,Kris Kobach,169
-Johnson,Overland Park 5-03,Secretary of State,,R,Kris Kobach,353
-Johnson,Overland Park 5-04,Secretary of State,,R,Kris Kobach,293
-Johnson,Overland Park 5-05,Secretary of State,,R,Kris Kobach,198
-Johnson,Overland Park 5-06,Secretary of State,,R,Kris Kobach,269
-Johnson,Overland Park 5-07,Secretary of State,,R,Kris Kobach,512
-Johnson,Overland Park 5-08,Secretary of State,,R,Kris Kobach,505
-Johnson,Overland Park 5-09,Secretary of State,,R,Kris Kobach,454
-Johnson,Overland Park 5-10,Secretary of State,,R,Kris Kobach,344
-Johnson,Overland Park 5-11,Secretary of State,,R,Kris Kobach,379
-Johnson,Overland Park 5-12,Secretary of State,,R,Kris Kobach,84
-Johnson,Overland Park 5-13,Secretary of State,,R,Kris Kobach,398
-Johnson,Overland Park 5-14,Secretary of State,,R,Kris Kobach,340
-Johnson,Overland Park 5-15,Secretary of State,,R,Kris Kobach,225
-Johnson,Overland Park 5-16,Secretary of State,,R,Kris Kobach,219
-Johnson,Overland Park 5-17,Secretary of State,,R,Kris Kobach,126
-Johnson,Overland Park 5-18,Secretary of State,,R,Kris Kobach,252
-Johnson,Overland Park 5-19,Secretary of State,,R,Kris Kobach,31
-Johnson,Overland Park 6-01,Secretary of State,,R,Kris Kobach,435
-Johnson,Overland Park 6-02,Secretary of State,,R,Kris Kobach,346
-Johnson,Overland Park 6-03,Secretary of State,,R,Kris Kobach,384
-Johnson,Overland Park 6-04,Secretary of State,,R,Kris Kobach,385
-Johnson,Overland Park 6-05,Secretary of State,,R,Kris Kobach,421
-Johnson,Overland Park 6-07,Secretary of State,,R,Kris Kobach,132
-Johnson,Overland Park 6-08,Secretary of State,,R,Kris Kobach,689
-Johnson,Overland Park 6-09,Secretary of State,,R,Kris Kobach,505
-Johnson,Overland Park 6-10,Secretary of State,,R,Kris Kobach,332
-Johnson,Overland Park 6-11,Secretary of State,,R,Kris Kobach,348
-Johnson,Overland Park 6-12,Secretary of State,,R,Kris Kobach,152
-Johnson,Overland Park 6-13,Secretary of State,,R,Kris Kobach,468
-Johnson,Overland Park 6-15,Secretary of State,,R,Kris Kobach,477
-Johnson,Overland Park 6-16,Secretary of State,,R,Kris Kobach,277
-Johnson,Overland Park 6-17,Secretary of State,,R,Kris Kobach,88
-Johnson,Overland Park 6-18,Secretary of State,,R,Kris Kobach,2
-Johnson,Overland Park 6-19,Secretary of State,,R,Kris Kobach,416
-Johnson,Overland Park 6-20,Secretary of State,,R,Kris Kobach,254
-Johnson,Overland Park 6-21,Secretary of State,,R,Kris Kobach,650
-Johnson,Overland Park 6-22,Secretary of State,,R,Kris Kobach,223
-Johnson,Oxford Twp 0-02,Secretary of State,,R,Kris Kobach,302
-Johnson,Oxford Twp 0-04,Secretary of State,,R,Kris Kobach,224
-Johnson,Oxford Twp 0-09,Secretary of State,,R,Kris Kobach,14
-Johnson,Oxford Twp 0-11,Secretary of State,,R,Kris Kobach,69
-Johnson,Prairie Village 1-01,Secretary of State,,R,Kris Kobach,300
-Johnson,Prairie Village 1-02,Secretary of State,,R,Kris Kobach,194
-Johnson,Prairie Village 1-03,Secretary of State,,R,Kris Kobach,281
-Johnson,Prairie Village 2-01,Secretary of State,,R,Kris Kobach,215
-Johnson,Prairie Village 2-02,Secretary of State,,R,Kris Kobach,121
-Johnson,Prairie Village 2-03,Secretary of State,,R,Kris Kobach,193
-Johnson,Prairie Village 3-01,Secretary of State,,R,Kris Kobach,168
-Johnson,Prairie Village 3-02,Secretary of State,,R,Kris Kobach,250
-Johnson,Prairie Village 3-03,Secretary of State,,R,Kris Kobach,222
-Johnson,Prairie Village 4-01,Secretary of State,,R,Kris Kobach,336
-Johnson,Prairie Village 4-02,Secretary of State,,R,Kris Kobach,167
-Johnson,Prairie Village 4-03,Secretary of State,,R,Kris Kobach,288
-Johnson,Prairie Village 5-01,Secretary of State,,R,Kris Kobach,273
-Johnson,Prairie Village 5-02,Secretary of State,,R,Kris Kobach,339
-Johnson,Prairie Village 5-03,Secretary of State,,R,Kris Kobach,265
-Johnson,Prairie Village 6-01,Secretary of State,,R,Kris Kobach,304
-Johnson,Prairie Village 6-02,Secretary of State,,R,Kris Kobach,200
-Johnson,Prairie Village 6-03,Secretary of State,,R,Kris Kobach,141
-Johnson,Roeland Park 1-01,Secretary of State,,R,Kris Kobach,88
-Johnson,Roeland Park 1-02,Secretary of State,,R,Kris Kobach,59
-Johnson,Roeland Park 2-01,Secretary of State,,R,Kris Kobach,100
-Johnson,Roeland Park 2-02,Secretary of State,,R,Kris Kobach,154
-Johnson,Roeland Park 3-01,Secretary of State,,R,Kris Kobach,61
-Johnson,Roeland Park 3-02,Secretary of State,,R,Kris Kobach,157
-Johnson,Roeland Park 4-01,Secretary of State,,R,Kris Kobach,93
-Johnson,Roeland Park 4-02,Secretary of State,,R,Kris Kobach,248
-Johnson,Shawnee 1-01,Secretary of State,,R,Kris Kobach,331
-Johnson,Shawnee 1-02,Secretary of State,,R,Kris Kobach,259
-Johnson,Shawnee 1-03,Secretary of State,,R,Kris Kobach,244
-Johnson,Shawnee 1-04,Secretary of State,,R,Kris Kobach,446
-Johnson,Shawnee 1-05,Secretary of State,,R,Kris Kobach,448
-Johnson,Shawnee 1-06,Secretary of State,,R,Kris Kobach,411
-Johnson,Shawnee 1-07,Secretary of State,,R,Kris Kobach,366
-Johnson,Shawnee 1-08,Secretary of State,,R,Kris Kobach,412
-Johnson,Shawnee 1-09,Secretary of State,,R,Kris Kobach,62
-Johnson,Shawnee 1-10,Secretary of State,,R,Kris Kobach,160
-Johnson,Shawnee 1-11,Secretary of State,,R,Kris Kobach,257
-Johnson,Shawnee 1-12,Secretary of State,,R,Kris Kobach,4
-Johnson,Shawnee 2-01,Secretary of State,,R,Kris Kobach,157
-Johnson,Shawnee 2-02,Secretary of State,,R,Kris Kobach,296
-Johnson,Shawnee 2-03,Secretary of State,,R,Kris Kobach,207
-Johnson,Shawnee 2-04,Secretary of State,,R,Kris Kobach,307
-Johnson,Shawnee 2-05,Secretary of State,,R,Kris Kobach,169
-Johnson,Shawnee 2-06,Secretary of State,,R,Kris Kobach,252
-Johnson,Shawnee 2-07,Secretary of State,,R,Kris Kobach,186
-Johnson,Shawnee 2-08,Secretary of State,,R,Kris Kobach,194
-Johnson,Shawnee 2-09,Secretary of State,,R,Kris Kobach,174
-Johnson,Shawnee 2-10,Secretary of State,,R,Kris Kobach,159
-Johnson,Shawnee 2-11,Secretary of State,,R,Kris Kobach,258
-Johnson,Shawnee 2-12,Secretary of State,,R,Kris Kobach,49
-Johnson,Shawnee 2-13,Secretary of State,,R,Kris Kobach,124
-Johnson,Shawnee 3-01,Secretary of State,,R,Kris Kobach,267
-Johnson,Shawnee 3-02,Secretary of State,,R,Kris Kobach,503
-Johnson,Shawnee 3-03,Secretary of State,,R,Kris Kobach,351
-Johnson,Shawnee 3-04,Secretary of State,,R,Kris Kobach,353
-Johnson,Shawnee 3-05,Secretary of State,,R,Kris Kobach,535
-Johnson,Shawnee 3-06,Secretary of State,,R,Kris Kobach,315
-Johnson,Shawnee 3-07,Secretary of State,,R,Kris Kobach,457
-Johnson,Shawnee 3-08,Secretary of State,,R,Kris Kobach,399
-Johnson,Shawnee 3-09,Secretary of State,,R,Kris Kobach,263
-Johnson,Shawnee 4-01,Secretary of State,,R,Kris Kobach,431
-Johnson,Shawnee 4-02,Secretary of State,,R,Kris Kobach,251
-Johnson,Shawnee 4-03,Secretary of State,,R,Kris Kobach,115
-Johnson,Shawnee 4-04,Secretary of State,,R,Kris Kobach,92
-Johnson,Shawnee 4-05,Secretary of State,,R,Kris Kobach,327
-Johnson,Shawnee 4-06,Secretary of State,,R,Kris Kobach,318
-Johnson,Shawnee 4-07,Secretary of State,,R,Kris Kobach,438
-Johnson,Shawnee 4-08,Secretary of State,,R,Kris Kobach,159
-Johnson,Shawnee 4-09,Secretary of State,,R,Kris Kobach,499
-Johnson,Shawnee 4-11,Secretary of State,,R,Kris Kobach,239
-Johnson,Shawnee 4-12,Secretary of State,,R,Kris Kobach,49
-Johnson,Spring Hill 0-01,Secretary of State,,R,Kris Kobach,585
-Johnson,Spring Hill 0-03,Secretary of State,,R,Kris Kobach,36
-Johnson,Spring Hill Twp 0-01,Secretary of State,,R,Kris Kobach,448
-Johnson,Spring Hill Twp 0-02,Secretary of State,,R,Kris Kobach,1
-Johnson,Spring Hill Twp 0-03,Secretary of State,,R,Kris Kobach,51
-Johnson,Spring Hill Twp 0-04,Secretary of State,,R,Kris Kobach,12
-Johnson,Spring Hill Twp 0-05,Secretary of State,,R,Kris Kobach,3
-Johnson,Westwood 0-01,Secretary of State,,R,Kris Kobach,112
-Johnson,Westwood 0-02,Secretary of State,,R,Kris Kobach,133
-Johnson,Westwood Hills 0-01,Secretary of State,,R,Kris Kobach,65
-Johnson,Aubry Twp 0-01,Secretary of State,,D,Jean Schodorf,37
-Johnson,Aubry Twp 0-02,Secretary of State,,D,Jean Schodorf,154
-Johnson,Aubry Twp 0-03,Secretary of State,,D,Jean Schodorf,96
-Johnson,Aubry Twp 0-04,Secretary of State,,D,Jean Schodorf,222
-Johnson,Aubry Twp 0-05,Secretary of State,,D,Jean Schodorf,5
-Johnson,Aubry Twp 0-06,Secretary of State,,D,Jean Schodorf,21
-Johnson,De Soto 0-01,Secretary of State,,D,Jean Schodorf,201
-Johnson,De Soto 0-02,Secretary of State,,D,Jean Schodorf,146
-Johnson,De Soto 0-03,Secretary of State,,D,Jean Schodorf,210
-Johnson,De Soto 0-06,Secretary of State,,D,Jean Schodorf,18
-Johnson,Edgerton,Secretary of State,,D,Jean Schodorf,126
-Johnson,Fairway 1-01,Secretary of State,,D,Jean Schodorf,176
-Johnson,Fairway 1-02,Secretary of State,,D,Jean Schodorf,119
-Johnson,Fairway 2-01,Secretary of State,,D,Jean Schodorf,125
-Johnson,Fairway 2-02,Secretary of State,,D,Jean Schodorf,127
-Johnson,Fairway 3-01,Secretary of State,,D,Jean Schodorf,163
-Johnson,Fairway 3-02,Secretary of State,,D,Jean Schodorf,125
-Johnson,Fairway 4-01,Secretary of State,,D,Jean Schodorf,62
-Johnson,Fairway 4-02,Secretary of State,,D,Jean Schodorf,77
-Johnson,Fairway 4-03,Secretary of State,,D,Jean Schodorf,49
-Johnson,Fairway 4-04,Secretary of State,,D,Jean Schodorf,79
-Johnson,Gardner 0-01,Secretary of State,,D,Jean Schodorf,247
-Johnson,Gardner 0-02,Secretary of State,,D,Jean Schodorf,53
-Johnson,Gardner 0-03,Secretary of State,,D,Jean Schodorf,170
-Johnson,Gardner 0-04,Secretary of State,,D,Jean Schodorf,170
-Johnson,Gardner 0-06,Secretary of State,,D,Jean Schodorf,172
-Johnson,Gardner 0-07,Secretary of State,,D,Jean Schodorf,9
-Johnson,Gardner 0-08,Secretary of State,,D,Jean Schodorf,9
-Johnson,Gardner 0-09,Secretary of State,,D,Jean Schodorf,236
-Johnson,Gardner 0-10,Secretary of State,,D,Jean Schodorf,132
-Johnson,Gardner 0-12,Secretary of State,,D,Jean Schodorf,5
-Johnson,Gardner 0-13,Secretary of State,,D,Jean Schodorf,184
-Johnson,Gardner 0-14,Secretary of State,,D,Jean Schodorf,134
-Johnson,Gardner Twp 0-01,Secretary of State,,D,Jean Schodorf,93
-Johnson,Gardner Twp 0-02,Secretary of State,,D,Jean Schodorf,94
-Johnson,Gardner Twp 0-07,Secretary of State,,D,Jean Schodorf,2
-Johnson,Gardner Twp 0-08,Secretary of State,,D,Jean Schodorf,3
-Johnson,Gardner Twp 0-11,Secretary of State,,D,Jean Schodorf,26
-Johnson,Gardner Twp 0-13,Secretary of State,,D,Jean Schodorf,1
-Johnson,Lake Quivira,Secretary of State,,D,Jean Schodorf,211
-Johnson,Leawood 1-01,Secretary of State,,D,Jean Schodorf,298
-Johnson,Leawood 1-02,Secretary of State,,D,Jean Schodorf,398
-Johnson,Leawood 1-03,Secretary of State,,D,Jean Schodorf,308
-Johnson,Leawood 1-04,Secretary of State,,D,Jean Schodorf,260
-Johnson,Leawood 1-05,Secretary of State,,D,Jean Schodorf,211
-Johnson,Leawood 1-06,Secretary of State,,D,Jean Schodorf,73
-Johnson,Leawood 2-01,Secretary of State,,D,Jean Schodorf,301
-Johnson,Leawood 2-02,Secretary of State,,D,Jean Schodorf,365
-Johnson,Leawood 2-03,Secretary of State,,D,Jean Schodorf,336
-Johnson,Leawood 2-04,Secretary of State,,D,Jean Schodorf,243
-Johnson,Leawood 2-05,Secretary of State,,D,Jean Schodorf,174
-Johnson,Leawood 2-06,Secretary of State,,D,Jean Schodorf,122
-Johnson,Leawood 3-01,Secretary of State,,D,Jean Schodorf,199
-Johnson,Leawood 3-02,Secretary of State,,D,Jean Schodorf,312
-Johnson,Leawood 3-03,Secretary of State,,D,Jean Schodorf,175
-Johnson,Leawood 3-04,Secretary of State,,D,Jean Schodorf,78
-Johnson,Leawood 3-05,Secretary of State,,D,Jean Schodorf,280
-Johnson,Leawood 3-06,Secretary of State,,D,Jean Schodorf,264
-Johnson,Leawood 3-07,Secretary of State,,D,Jean Schodorf,244
-Johnson,Leawood 4-01,Secretary of State,,D,Jean Schodorf,71
-Johnson,Leawood 4-02,Secretary of State,,D,Jean Schodorf,230
-Johnson,Leawood 4-03,Secretary of State,,D,Jean Schodorf,252
-Johnson,Leawood 4-04,Secretary of State,,D,Jean Schodorf,283
-Johnson,Leawood 4-05,Secretary of State,,D,Jean Schodorf,288
-Johnson,Leawood 4-06,Secretary of State,,D,Jean Schodorf,123
-Johnson,Leawood 4-07,Secretary of State,,D,Jean Schodorf,276
-Johnson,Leawood 4-08,Secretary of State,,D,Jean Schodorf,126
-Johnson,Lenexa 1-01,Secretary of State,,D,Jean Schodorf,155
-Johnson,Lenexa 1-02,Secretary of State,,D,Jean Schodorf,353
-Johnson,Lenexa 1-03,Secretary of State,,D,Jean Schodorf,420
-Johnson,Lenexa 1-04,Secretary of State,,D,Jean Schodorf,235
-Johnson,Lenexa 1-05,Secretary of State,,D,Jean Schodorf,273
-Johnson,Lenexa 1-06,Secretary of State,,D,Jean Schodorf,284
-Johnson,Lenexa 1-07,Secretary of State,,D,Jean Schodorf,191
-Johnson,Lenexa 1-08,Secretary of State,,D,Jean Schodorf,73
-Johnson,Lenexa 1-09,Secretary of State,,D,Jean Schodorf,7
-Johnson,Lenexa 2-01,Secretary of State,,D,Jean Schodorf,312
-Johnson,Lenexa 2-02,Secretary of State,,D,Jean Schodorf,98
-Johnson,Lenexa 2-03,Secretary of State,,D,Jean Schodorf,251
-Johnson,Lenexa 2-04,Secretary of State,,D,Jean Schodorf,201
-Johnson,Lenexa 2-05,Secretary of State,,D,Jean Schodorf,266
-Johnson,Lenexa 2-06,Secretary of State,,D,Jean Schodorf,169
-Johnson,Lenexa 2-07,Secretary of State,,D,Jean Schodorf,334
-Johnson,Lenexa 3-01,Secretary of State,,D,Jean Schodorf,243
-Johnson,Lenexa 3-02,Secretary of State,,D,Jean Schodorf,409
-Johnson,Lenexa 3-03,Secretary of State,,D,Jean Schodorf,418
-Johnson,Lenexa 3-04,Secretary of State,,D,Jean Schodorf,228
-Johnson,Lenexa 3-05,Secretary of State,,D,Jean Schodorf,178
-Johnson,Lenexa 3-06,Secretary of State,,D,Jean Schodorf,247
-Johnson,Lenexa 3-07,Secretary of State,,D,Jean Schodorf,291
-Johnson,Lenexa 3-08,Secretary of State,,D,Jean Schodorf,329
-Johnson,Lenexa 4-01,Secretary of State,,D,Jean Schodorf,148
-Johnson,Lenexa 4-02,Secretary of State,,D,Jean Schodorf,269
-Johnson,Lenexa 4-03,Secretary of State,,D,Jean Schodorf,127
-Johnson,Lenexa 4-04,Secretary of State,,D,Jean Schodorf,119
-Johnson,Lenexa 4-05,Secretary of State,,D,Jean Schodorf,120
-Johnson,Lenexa 4-06,Secretary of State,,D,Jean Schodorf,171
-Johnson,Lenexa 4-07,Secretary of State,,D,Jean Schodorf,220
-Johnson,Lenexa 4-08,Secretary of State,,D,Jean Schodorf,308
-Johnson,Lenexa 4-09,Secretary of State,,D,Jean Schodorf,238
-Johnson,Lenexa 4-10,Secretary of State,,D,Jean Schodorf,126
-Johnson,Lenexa 4-11,Secretary of State,,D,Jean Schodorf,38
-Johnson,Lexington Twp 0-01,Secretary of State,,D,Jean Schodorf,181
-Johnson,Lexington Twp 0-02,Secretary of State,,D,Jean Schodorf,2
-Johnson,Lexington Twp 0-03,Secretary of State,,D,Jean Schodorf,1
-Johnson,McCamish Twp 0-01,Secretary of State,,D,Jean Schodorf,31
-Johnson,McCamish Twp 0-02,Secretary of State,,D,Jean Schodorf,75
-Johnson,Merriam 1-01,Secretary of State,,D,Jean Schodorf,175
-Johnson,Merriam 1-02,Secretary of State,,D,Jean Schodorf,216
-Johnson,Merriam 2-01,Secretary of State,,D,Jean Schodorf,255
-Johnson,Merriam 2-02,Secretary of State,,D,Jean Schodorf,1
-Johnson,Merriam 2-03,Secretary of State,,D,Jean Schodorf,145
-Johnson,Merriam 3-01,Secretary of State,,D,Jean Schodorf,231
-Johnson,Merriam 3-02,Secretary of State,,D,Jean Schodorf,213
-Johnson,Merriam 4-01,Secretary of State,,D,Jean Schodorf,282
-Johnson,Merriam 4-02,Secretary of State,,D,Jean Schodorf,127
-Johnson,Merriam 4-03,Secretary of State,,D,Jean Schodorf,178
-Johnson,Mission 1-01,Secretary of State,,D,Jean Schodorf,258
-Johnson,Mission 1-02,Secretary of State,,D,Jean Schodorf,156
-Johnson,Mission 2-01,Secretary of State,,D,Jean Schodorf,174
-Johnson,Mission 2-02,Secretary of State,,D,Jean Schodorf,251
-Johnson,Mission 3-01,Secretary of State,,D,Jean Schodorf,233
-Johnson,Mission 3-02,Secretary of State,,D,Jean Schodorf,143
-Johnson,Mission 4-01,Secretary of State,,D,Jean Schodorf,199
-Johnson,Mission 4-02,Secretary of State,,D,Jean Schodorf,288
-Johnson,Mission 4-03,Secretary of State,,D,Jean Schodorf,138
-Johnson,Mission Hills 0-01,Secretary of State,,D,Jean Schodorf,164
-Johnson,Mission Hills 0-02,Secretary of State,,D,Jean Schodorf,261
-Johnson,Mission Hills 0-03,Secretary of State,,D,Jean Schodorf,141
-Johnson,Mission Hills 0-04,Secretary of State,,D,Jean Schodorf,266
-Johnson,Mission Woods,Secretary of State,,D,Jean Schodorf,57
-Johnson,Olathe 1-01,Secretary of State,,D,Jean Schodorf,218
-Johnson,Olathe 1-02,Secretary of State,,D,Jean Schodorf,163
-Johnson,Olathe 1-03,Secretary of State,,D,Jean Schodorf,110
-Johnson,Olathe 1-04,Secretary of State,,D,Jean Schodorf,205
-Johnson,Olathe 1-05,Secretary of State,,D,Jean Schodorf,206
-Johnson,Olathe 1-06,Secretary of State,,D,Jean Schodorf,126
-Johnson,Olathe 1-08,Secretary of State,,D,Jean Schodorf,240
-Johnson,Olathe 1-09,Secretary of State,,D,Jean Schodorf,188
-Johnson,Olathe 1-11,Secretary of State,,D,Jean Schodorf,46
-Johnson,Olathe 1-14,Secretary of State,,D,Jean Schodorf,172
-Johnson,Olathe 1-15,Secretary of State,,D,Jean Schodorf,178
-Johnson,Olathe 1-16,Secretary of State,,D,Jean Schodorf,199
-Johnson,Olathe 1-17,Secretary of State,,D,Jean Schodorf,47
-Johnson,Olathe 1-18,Secretary of State,,D,Jean Schodorf,62
-Johnson,Olathe 1-19,Secretary of State,,D,Jean Schodorf,101
-Johnson,Olathe 1-20,Secretary of State,,D,Jean Schodorf,165
-Johnson,Olathe 1-21,Secretary of State,,D,Jean Schodorf,231
-Johnson,Olathe 1-22,Secretary of State,,D,Jean Schodorf,301
-Johnson,Olathe 1-24,Secretary of State,,D,Jean Schodorf,22
-Johnson,Olathe 1-24,Secretary of State,,D,Jean Schodorf,61
-Johnson,Olathe 1-26,Secretary of State,,D,Jean Schodorf,2
-Johnson,Olathe 1-27,Secretary of State,,D,Jean Schodorf,160
-Johnson,Olathe 2-01,Secretary of State,,D,Jean Schodorf,79
-Johnson,Olathe 2-02,Secretary of State,,D,Jean Schodorf,154
-Johnson,Olathe 2-03,Secretary of State,,D,Jean Schodorf,147
-Johnson,Olathe 2-04,Secretary of State,,D,Jean Schodorf,193
-Johnson,Olathe 2-05,Secretary of State,,D,Jean Schodorf,408
-Johnson,Olathe 2-06,Secretary of State,,D,Jean Schodorf,194
-Johnson,Olathe 2-07,Secretary of State,,D,Jean Schodorf,279
-Johnson,Olathe 2-08,Secretary of State,,D,Jean Schodorf,219
-Johnson,Olathe 2-09,Secretary of State,,D,Jean Schodorf,96
-Johnson,Olathe 2-10,Secretary of State,,D,Jean Schodorf,418
-Johnson,Olathe 2-11,Secretary of State,,D,Jean Schodorf,303
-Johnson,Olathe 2-12,Secretary of State,,D,Jean Schodorf,174
-Johnson,Olathe 2-13,Secretary of State,,D,Jean Schodorf,195
-Johnson,Olathe 2-14,Secretary of State,,D,Jean Schodorf,148
-Johnson,Olathe 2-15,Secretary of State,,D,Jean Schodorf,124
-Johnson,Olathe 2-16,Secretary of State,,D,Jean Schodorf,77
-Johnson,Olathe 2-17,Secretary of State,,D,Jean Schodorf,1
-Johnson,Olathe 2-19,Secretary of State,,D,Jean Schodorf,1
-Johnson,Olathe 2-22,Secretary of State,,D,Jean Schodorf,337
-Johnson,Olathe 2-23,Secretary of State,,D,Jean Schodorf,209
-Johnson,Olathe 3-01,Secretary of State,,D,Jean Schodorf,95
-Johnson,Olathe 3-02,Secretary of State,,D,Jean Schodorf,262
-Johnson,Olathe 3-03,Secretary of State,,D,Jean Schodorf,111
-Johnson,Olathe 3-04,Secretary of State,,D,Jean Schodorf,196
-Johnson,Olathe 3-05,Secretary of State,,D,Jean Schodorf,203
-Johnson,Olathe 3-06,Secretary of State,,D,Jean Schodorf,151
-Johnson,Olathe 3-07,Secretary of State,,D,Jean Schodorf,160
-Johnson,Olathe 3-08,Secretary of State,,D,Jean Schodorf,226
-Johnson,Olathe 3-09,Secretary of State,,D,Jean Schodorf,102
-Johnson,Olathe 3-10,Secretary of State,,D,Jean Schodorf,213
-Johnson,Olathe 3-11,Secretary of State,,D,Jean Schodorf,155
-Johnson,Olathe 3-12,Secretary of State,,D,Jean Schodorf,218
-Johnson,Olathe 3-13,Secretary of State,,D,Jean Schodorf,220
-Johnson,Olathe 3-15,Secretary of State,,D,Jean Schodorf,150
-Johnson,Olathe 3-16,Secretary of State,,D,Jean Schodorf,161
-Johnson,Olathe 3-17,Secretary of State,,D,Jean Schodorf,215
-Johnson,Olathe 3-18,Secretary of State,,D,Jean Schodorf,192
-Johnson,Olathe 3-19,Secretary of State,,D,Jean Schodorf,99
-Johnson,Olathe 3-20,Secretary of State,,D,Jean Schodorf,135
-Johnson,Olathe 3-21,Secretary of State,,D,Jean Schodorf,103
-Johnson,Olathe 3-22,Secretary of State,,D,Jean Schodorf,186
-Johnson,Olathe 3-23,Secretary of State,,D,Jean Schodorf,185
-Johnson,Olathe 3-24,Secretary of State,,D,Jean Schodorf,101
-Johnson,Olathe 3-26,Secretary of State,,D,Jean Schodorf,22
-Johnson,Olathe 4-01,Secretary of State,,D,Jean Schodorf,175
-Johnson,Olathe 4-02,Secretary of State,,D,Jean Schodorf,342
-Johnson,Olathe 4-03,Secretary of State,,D,Jean Schodorf,124
-Johnson,Olathe 4-04,Secretary of State,,D,Jean Schodorf,126
-Johnson,Olathe 4-05,Secretary of State,,D,Jean Schodorf,252
-Johnson,Olathe 4-06,Secretary of State,,D,Jean Schodorf,287
-Johnson,Olathe 4-07,Secretary of State,,D,Jean Schodorf,263
-Johnson,Olathe 4-08,Secretary of State,,D,Jean Schodorf,195
-Johnson,Olathe 4-09,Secretary of State,,D,Jean Schodorf,286
-Johnson,Olathe 4-10,Secretary of State,,D,Jean Schodorf,164
-Johnson,Olathe 4-11,Secretary of State,,D,Jean Schodorf,111
-Johnson,Olathe 4-12,Secretary of State,,D,Jean Schodorf,242
-Johnson,Olathe 4-13,Secretary of State,,D,Jean Schodorf,139
-Johnson,Olathe 4-14,Secretary of State,,D,Jean Schodorf,293
-Johnson,Olathe 4-15,Secretary of State,,D,Jean Schodorf,14
-Johnson,Olathe 4-16,Secretary of State,,D,Jean Schodorf,91
-Johnson,Olathe 4-17,Secretary of State,,D,Jean Schodorf,2
-Johnson,Olathe Twp 0-01,Secretary of State,,D,Jean Schodorf,106
-Johnson,Olathe Twp 0-02,Secretary of State,,D,Jean Schodorf,12
-Johnson,Olathe Twp 0-03,Secretary of State,,D,Jean Schodorf,17
-Johnson,Olathe Twp 0-04,Secretary of State,,D,Jean Schodorf,1
-Johnson,Olathe Twp 0-08,Secretary of State,,D,Jean Schodorf,2
-Johnson,Olathe Twp 0-10,Secretary of State,,D,Jean Schodorf,4
-Johnson,Olathe Twp 0-11,Secretary of State,,D,Jean Schodorf,1
-Johnson,Olathe Twp 0-24,Secretary of State,,D,Jean Schodorf,1
-Johnson,Olathe Twp 0-25,Secretary of State,,D,Jean Schodorf,1
-Johnson,Olathe Twp 0-32,Secretary of State,,D,Jean Schodorf,4
-Johnson,Overland Park 1-01,Secretary of State,,D,Jean Schodorf,258
-Johnson,Overland Park 1-02,Secretary of State,,D,Jean Schodorf,285
-Johnson,Overland Park 1-03,Secretary of State,,D,Jean Schodorf,238
-Johnson,Overland Park 1-04,Secretary of State,,D,Jean Schodorf,81
-Johnson,Overland Park 1-05,Secretary of State,,D,Jean Schodorf,175
-Johnson,Overland Park 1-06,Secretary of State,,D,Jean Schodorf,355
-Johnson,Overland Park 1-07,Secretary of State,,D,Jean Schodorf,297
-Johnson,Overland Park 1-08,Secretary of State,,D,Jean Schodorf,224
-Johnson,Overland Park 1-09,Secretary of State,,D,Jean Schodorf,140
-Johnson,Overland Park 1-10,Secretary of State,,D,Jean Schodorf,282
-Johnson,Overland Park 1-11,Secretary of State,,D,Jean Schodorf,74
-Johnson,Overland Park 1-12,Secretary of State,,D,Jean Schodorf,244
-Johnson,Overland Park 1-13,Secretary of State,,D,Jean Schodorf,176
-Johnson,Overland Park 1-14,Secretary of State,,D,Jean Schodorf,280
-Johnson,Overland Park 1-15,Secretary of State,,D,Jean Schodorf,136
-Johnson,Overland Park 1-16,Secretary of State,,D,Jean Schodorf,356
-Johnson,Overland Park 1-17,Secretary of State,,D,Jean Schodorf,137
-Johnson,Overland Park 1-18,Secretary of State,,D,Jean Schodorf,295
-Johnson,Overland Park 1-19,Secretary of State,,D,Jean Schodorf,199
-Johnson,Overland Park 1-20,Secretary of State,,D,Jean Schodorf,161
-Johnson,Overland Park 1-21,Secretary of State,,D,Jean Schodorf,68
-Johnson,Overland Park 1-22,Secretary of State,,D,Jean Schodorf,64
-Johnson,Overland Park 2-01,Secretary of State,,D,Jean Schodorf,212
-Johnson,Overland Park 2-02,Secretary of State,,D,Jean Schodorf,291
-Johnson,Overland Park 2-03,Secretary of State,,D,Jean Schodorf,242
-Johnson,Overland Park 2-04,Secretary of State,,D,Jean Schodorf,260
-Johnson,Overland Park 2-05,Secretary of State,,D,Jean Schodorf,237
-Johnson,Overland Park 2-06,Secretary of State,,D,Jean Schodorf,227
-Johnson,Overland Park 2-07,Secretary of State,,D,Jean Schodorf,189
-Johnson,Overland Park 2-08,Secretary of State,,D,Jean Schodorf,156
-Johnson,Overland Park 2-09,Secretary of State,,D,Jean Schodorf,192
-Johnson,Overland Park 2-10,Secretary of State,,D,Jean Schodorf,112
-Johnson,Overland Park 2-11,Secretary of State,,D,Jean Schodorf,232
-Johnson,Overland Park 2-12,Secretary of State,,D,Jean Schodorf,168
-Johnson,Overland Park 2-13,Secretary of State,,D,Jean Schodorf,113
-Johnson,Overland Park 2-14,Secretary of State,,D,Jean Schodorf,195
-Johnson,Overland Park 2-15,Secretary of State,,D,Jean Schodorf,354
-Johnson,Overland Park 2-16,Secretary of State,,D,Jean Schodorf,215
-Johnson,Overland Park 2-17,Secretary of State,,D,Jean Schodorf,274
-Johnson,Overland Park 2-18,Secretary of State,,D,Jean Schodorf,317
-Johnson,Overland Park 2-19,Secretary of State,,D,Jean Schodorf,205
-Johnson,Overland Park 2-20,Secretary of State,,D,Jean Schodorf,181
-Johnson,Overland Park 2-21,Secretary of State,,D,Jean Schodorf,223
-Johnson,Overland Park 2-22,Secretary of State,,D,Jean Schodorf,241
-Johnson,Overland Park 2-23,Secretary of State,,D,Jean Schodorf,215
-Johnson,Overland Park 2-24,Secretary of State,,D,Jean Schodorf,356
-Johnson,Overland Park 2-25,Secretary of State,,D,Jean Schodorf,314
-Johnson,Overland Park 2-26,Secretary of State,,D,Jean Schodorf,119
-Johnson,Overland Park 3-01,Secretary of State,,D,Jean Schodorf,321
-Johnson,Overland Park 3-02,Secretary of State,,D,Jean Schodorf,238
-Johnson,Overland Park 3-03,Secretary of State,,D,Jean Schodorf,228
-Johnson,Overland Park 3-04,Secretary of State,,D,Jean Schodorf,315
-Johnson,Overland Park 3-05,Secretary of State,,D,Jean Schodorf,282
-Johnson,Overland Park 3-06,Secretary of State,,D,Jean Schodorf,332
-Johnson,Overland Park 3-07,Secretary of State,,D,Jean Schodorf,222
-Johnson,Overland Park 3-08,Secretary of State,,D,Jean Schodorf,235
-Johnson,Overland Park 3-09,Secretary of State,,D,Jean Schodorf,358
-Johnson,Overland Park 3-10,Secretary of State,,D,Jean Schodorf,174
-Johnson,Overland Park 3-11,Secretary of State,,D,Jean Schodorf,215
-Johnson,Overland Park 3-12,Secretary of State,,D,Jean Schodorf,180
-Johnson,Overland Park 3-13,Secretary of State,,D,Jean Schodorf,377
-Johnson,Overland Park 3-14,Secretary of State,,D,Jean Schodorf,307
-Johnson,Overland Park 3-15,Secretary of State,,D,Jean Schodorf,157
-Johnson,Overland Park 3-16,Secretary of State,,D,Jean Schodorf,279
-Johnson,Overland Park 3-17,Secretary of State,,D,Jean Schodorf,225
-Johnson,Overland Park 3-18,Secretary of State,,D,Jean Schodorf,219
-Johnson,Overland Park 3-19,Secretary of State,,D,Jean Schodorf,233
-Johnson,Overland Park 3-20,Secretary of State,,D,Jean Schodorf,317
-Johnson,Overland Park 3-21,Secretary of State,,D,Jean Schodorf,229
-Johnson,Overland Park 4-01,Secretary of State,,D,Jean Schodorf,140
-Johnson,Overland Park 4-02,Secretary of State,,D,Jean Schodorf,182
-Johnson,Overland Park 4-03,Secretary of State,,D,Jean Schodorf,216
-Johnson,Overland Park 4-04,Secretary of State,,D,Jean Schodorf,319
-Johnson,Overland Park 4-05,Secretary of State,,D,Jean Schodorf,256
-Johnson,Overland Park 4-06,Secretary of State,,D,Jean Schodorf,219
-Johnson,Overland Park 4-07,Secretary of State,,D,Jean Schodorf,206
-Johnson,Overland Park 4-08,Secretary of State,,D,Jean Schodorf,241
-Johnson,Overland Park 4-09,Secretary of State,,D,Jean Schodorf,187
-Johnson,Overland Park 4-10,Secretary of State,,D,Jean Schodorf,150
-Johnson,Overland Park 4-11,Secretary of State,,D,Jean Schodorf,313
-Johnson,Overland Park 4-12,Secretary of State,,D,Jean Schodorf,392
-Johnson,Overland Park 4-13,Secretary of State,,D,Jean Schodorf,123
-Johnson,Overland Park 4-14,Secretary of State,,D,Jean Schodorf,124
-Johnson,Overland Park 4-15,Secretary of State,,D,Jean Schodorf,299
-Johnson,Overland Park 4-16,Secretary of State,,D,Jean Schodorf,172
-Johnson,Overland Park 4-17,Secretary of State,,D,Jean Schodorf,303
-Johnson,Overland Park 4-18,Secretary of State,,D,Jean Schodorf,48
-Johnson,Overland Park 5-01,Secretary of State,,D,Jean Schodorf,281
-Johnson,Overland Park 5-02,Secretary of State,,D,Jean Schodorf,134
-Johnson,Overland Park 5-03,Secretary of State,,D,Jean Schodorf,227
-Johnson,Overland Park 5-04,Secretary of State,,D,Jean Schodorf,250
-Johnson,Overland Park 5-05,Secretary of State,,D,Jean Schodorf,222
-Johnson,Overland Park 5-06,Secretary of State,,D,Jean Schodorf,200
-Johnson,Overland Park 5-07,Secretary of State,,D,Jean Schodorf,217
-Johnson,Overland Park 5-08,Secretary of State,,D,Jean Schodorf,320
-Johnson,Overland Park 5-09,Secretary of State,,D,Jean Schodorf,356
-Johnson,Overland Park 5-10,Secretary of State,,D,Jean Schodorf,256
-Johnson,Overland Park 5-11,Secretary of State,,D,Jean Schodorf,351
-Johnson,Overland Park 5-12,Secretary of State,,D,Jean Schodorf,69
-Johnson,Overland Park 5-13,Secretary of State,,D,Jean Schodorf,403
-Johnson,Overland Park 5-14,Secretary of State,,D,Jean Schodorf,282
-Johnson,Overland Park 5-15,Secretary of State,,D,Jean Schodorf,207
-Johnson,Overland Park 5-16,Secretary of State,,D,Jean Schodorf,154
-Johnson,Overland Park 5-17,Secretary of State,,D,Jean Schodorf,103
-Johnson,Overland Park 5-18,Secretary of State,,D,Jean Schodorf,225
-Johnson,Overland Park 5-19,Secretary of State,,D,Jean Schodorf,18
-Johnson,Overland Park 6-01,Secretary of State,,D,Jean Schodorf,265
-Johnson,Overland Park 6-02,Secretary of State,,D,Jean Schodorf,201
-Johnson,Overland Park 6-03,Secretary of State,,D,Jean Schodorf,228
-Johnson,Overland Park 6-04,Secretary of State,,D,Jean Schodorf,201
-Johnson,Overland Park 6-05,Secretary of State,,D,Jean Schodorf,270
-Johnson,Overland Park 6-07,Secretary of State,,D,Jean Schodorf,54
-Johnson,Overland Park 6-08,Secretary of State,,D,Jean Schodorf,243
-Johnson,Overland Park 6-09,Secretary of State,,D,Jean Schodorf,313
-Johnson,Overland Park 6-10,Secretary of State,,D,Jean Schodorf,198
-Johnson,Overland Park 6-11,Secretary of State,,D,Jean Schodorf,194
-Johnson,Overland Park 6-12,Secretary of State,,D,Jean Schodorf,102
-Johnson,Overland Park 6-13,Secretary of State,,D,Jean Schodorf,259
-Johnson,Overland Park 6-15,Secretary of State,,D,Jean Schodorf,232
-Johnson,Overland Park 6-16,Secretary of State,,D,Jean Schodorf,128
-Johnson,Overland Park 6-17,Secretary of State,,D,Jean Schodorf,47
-Johnson,Overland Park 6-18,Secretary of State,,D,Jean Schodorf,1
-Johnson,Overland Park 6-19,Secretary of State,,D,Jean Schodorf,300
-Johnson,Overland Park 6-20,Secretary of State,,D,Jean Schodorf,75
-Johnson,Overland Park 6-21,Secretary of State,,D,Jean Schodorf,241
-Johnson,Overland Park 6-22,Secretary of State,,D,Jean Schodorf,108
-Johnson,Oxford Twp 0-02,Secretary of State,,D,Jean Schodorf,144
-Johnson,Oxford Twp 0-04,Secretary of State,,D,Jean Schodorf,125
-Johnson,Oxford Twp 0-09,Secretary of State,,D,Jean Schodorf,6
-Johnson,Oxford Twp 0-11,Secretary of State,,D,Jean Schodorf,21
-Johnson,Prairie Village 1-01,Secretary of State,,D,Jean Schodorf,406
-Johnson,Prairie Village 1-02,Secretary of State,,D,Jean Schodorf,293
-Johnson,Prairie Village 1-03,Secretary of State,,D,Jean Schodorf,407
-Johnson,Prairie Village 2-01,Secretary of State,,D,Jean Schodorf,347
-Johnson,Prairie Village 2-02,Secretary of State,,D,Jean Schodorf,143
-Johnson,Prairie Village 2-03,Secretary of State,,D,Jean Schodorf,297
-Johnson,Prairie Village 3-01,Secretary of State,,D,Jean Schodorf,225
-Johnson,Prairie Village 3-02,Secretary of State,,D,Jean Schodorf,329
-Johnson,Prairie Village 3-03,Secretary of State,,D,Jean Schodorf,314
-Johnson,Prairie Village 4-01,Secretary of State,,D,Jean Schodorf,339
-Johnson,Prairie Village 4-02,Secretary of State,,D,Jean Schodorf,246
-Johnson,Prairie Village 4-03,Secretary of State,,D,Jean Schodorf,383
-Johnson,Prairie Village 5-01,Secretary of State,,D,Jean Schodorf,370
-Johnson,Prairie Village 5-02,Secretary of State,,D,Jean Schodorf,342
-Johnson,Prairie Village 5-03,Secretary of State,,D,Jean Schodorf,263
-Johnson,Prairie Village 6-01,Secretary of State,,D,Jean Schodorf,364
-Johnson,Prairie Village 6-02,Secretary of State,,D,Jean Schodorf,338
-Johnson,Prairie Village 6-03,Secretary of State,,D,Jean Schodorf,194
-Johnson,Roeland Park 1-01,Secretary of State,,D,Jean Schodorf,140
-Johnson,Roeland Park 1-02,Secretary of State,,D,Jean Schodorf,125
-Johnson,Roeland Park 2-01,Secretary of State,,D,Jean Schodorf,166
-Johnson,Roeland Park 2-02,Secretary of State,,D,Jean Schodorf,212
-Johnson,Roeland Park 3-01,Secretary of State,,D,Jean Schodorf,160
-Johnson,Roeland Park 3-02,Secretary of State,,D,Jean Schodorf,289
-Johnson,Roeland Park 4-01,Secretary of State,,D,Jean Schodorf,113
-Johnson,Roeland Park 4-02,Secretary of State,,D,Jean Schodorf,376
-Johnson,Shawnee 1-01,Secretary of State,,D,Jean Schodorf,305
-Johnson,Shawnee 1-02,Secretary of State,,D,Jean Schodorf,217
-Johnson,Shawnee 1-03,Secretary of State,,D,Jean Schodorf,200
-Johnson,Shawnee 1-04,Secretary of State,,D,Jean Schodorf,310
-Johnson,Shawnee 1-05,Secretary of State,,D,Jean Schodorf,368
-Johnson,Shawnee 1-06,Secretary of State,,D,Jean Schodorf,240
-Johnson,Shawnee 1-07,Secretary of State,,D,Jean Schodorf,284
-Johnson,Shawnee 1-08,Secretary of State,,D,Jean Schodorf,250
-Johnson,Shawnee 1-09,Secretary of State,,D,Jean Schodorf,48
-Johnson,Shawnee 1-10,Secretary of State,,D,Jean Schodorf,79
-Johnson,Shawnee 1-11,Secretary of State,,D,Jean Schodorf,157
-Johnson,Shawnee 1-12,Secretary of State,,D,Jean Schodorf,3
-Johnson,Shawnee 2-01,Secretary of State,,D,Jean Schodorf,117
-Johnson,Shawnee 2-02,Secretary of State,,D,Jean Schodorf,229
-Johnson,Shawnee 2-03,Secretary of State,,D,Jean Schodorf,191
-Johnson,Shawnee 2-04,Secretary of State,,D,Jean Schodorf,324
-Johnson,Shawnee 2-05,Secretary of State,,D,Jean Schodorf,130
-Johnson,Shawnee 2-06,Secretary of State,,D,Jean Schodorf,185
-Johnson,Shawnee 2-07,Secretary of State,,D,Jean Schodorf,157
-Johnson,Shawnee 2-08,Secretary of State,,D,Jean Schodorf,140
-Johnson,Shawnee 2-09,Secretary of State,,D,Jean Schodorf,152
-Johnson,Shawnee 2-10,Secretary of State,,D,Jean Schodorf,128
-Johnson,Shawnee 2-11,Secretary of State,,D,Jean Schodorf,209
-Johnson,Shawnee 2-12,Secretary of State,,D,Jean Schodorf,74
-Johnson,Shawnee 2-13,Secretary of State,,D,Jean Schodorf,118
-Johnson,Shawnee 3-01,Secretary of State,,D,Jean Schodorf,134
-Johnson,Shawnee 3-02,Secretary of State,,D,Jean Schodorf,260
-Johnson,Shawnee 3-03,Secretary of State,,D,Jean Schodorf,230
-Johnson,Shawnee 3-04,Secretary of State,,D,Jean Schodorf,186
-Johnson,Shawnee 3-05,Secretary of State,,D,Jean Schodorf,247
-Johnson,Shawnee 3-06,Secretary of State,,D,Jean Schodorf,220
-Johnson,Shawnee 3-07,Secretary of State,,D,Jean Schodorf,244
-Johnson,Shawnee 3-08,Secretary of State,,D,Jean Schodorf,252
-Johnson,Shawnee 3-09,Secretary of State,,D,Jean Schodorf,114
-Johnson,Shawnee 4-01,Secretary of State,,D,Jean Schodorf,341
-Johnson,Shawnee 4-02,Secretary of State,,D,Jean Schodorf,173
-Johnson,Shawnee 4-03,Secretary of State,,D,Jean Schodorf,70
-Johnson,Shawnee 4-04,Secretary of State,,D,Jean Schodorf,115
-Johnson,Shawnee 4-05,Secretary of State,,D,Jean Schodorf,288
-Johnson,Shawnee 4-06,Secretary of State,,D,Jean Schodorf,217
-Johnson,Shawnee 4-07,Secretary of State,,D,Jean Schodorf,305
-Johnson,Shawnee 4-08,Secretary of State,,D,Jean Schodorf,134
-Johnson,Shawnee 4-09,Secretary of State,,D,Jean Schodorf,369
-Johnson,Shawnee 4-11,Secretary of State,,D,Jean Schodorf,204
-Johnson,Shawnee 4-12,Secretary of State,,D,Jean Schodorf,39
-Johnson,Spring Hill 0-01,Secretary of State,,D,Jean Schodorf,298
-Johnson,Spring Hill 0-03,Secretary of State,,D,Jean Schodorf,24
-Johnson,Spring Hill Twp 0-01,Secretary of State,,D,Jean Schodorf,220
-Johnson,Spring Hill Twp 0-02,Secretary of State,,D,Jean Schodorf,1
-Johnson,Spring Hill Twp 0-03,Secretary of State,,D,Jean Schodorf,17
-Johnson,Spring Hill Twp 0-04,Secretary of State,,D,Jean Schodorf,2
-Johnson,Spring Hill Twp 0-05,Secretary of State,,D,Jean Schodorf,5
-Johnson,Westwood 0-01,Secretary of State,,D,Jean Schodorf,232
-Johnson,Westwood 0-02,Secretary of State,,D,Jean Schodorf,217
-Johnson,Westwood Hills 0-01,Secretary of State,,D,Jean Schodorf,138
-Johnson,Shawnee 4-07,Secretary of State,,D,Jean Schodorf,305
-Johnson,Shawnee 4-08,Secretary of State,,D,Jean Schodorf,134
-Johnson,Shawnee 4-09,Secretary of State,,D,Jean Schodorf,369
-Johnson,Shawnee 4-11,Secretary of State,,D,Jean Schodorf,204
-Johnson,Shawnee 4-12,Secretary of State,,D,Jean Schodorf,39
-Johnson,Spring Hill 0-01,Secretary of State,,D,Jean Schodorf,298
-Johnson,Spring Hill 0-03,Secretary of State,,D,Jean Schodorf,24
-Johnson,Spring Hill 0-04,Secretary of State,,D,Jean Schodorf,0
-Johnson,Spring Hill Twp 0-01,Secretary of State,,D,Jean Schodorf,220
-Johnson,Spring Hill Twp 0-02,Secretary of State,,D,Jean Schodorf,1
-Johnson,Spring Hill Twp 0-03,Secretary of State,,D,Jean Schodorf,17
-Johnson,Spring Hill Twp 0-04,Secretary of State,,D,Jean Schodorf,2
-Johnson,Spring Hill Twp 0-05,Secretary of State,,D,Jean Schodorf,5
-Johnson,Westwood 0-01,Secretary of State,,D,Jean Schodorf,232
-Johnson,Westwood 0-02,Secretary of State,,D,Jean Schodorf,217
-Johnson,Westwood Hills 0-01,Secretary of State,,D,Jean Schodorf,138
-COUNTY,PRECINCT,Secretary of State,,,,Write-ins
-Johnson,Aubry Twp 0-02,Secretary of State,,,Write-ins,1
-Johnson,De Soto 0-01,Secretary of State,,,Write-ins,1
-Johnson,De Soto 0-03,Secretary of State,,,Write-ins,1
-Johnson,Edgerton,Secretary of State,,,Write-ins,1
-Johnson,Fairway 4-01,Secretary of State,,,Write-ins,1
-Johnson,Gardner 0-01,Secretary of State,,,Write-ins,1
-Johnson,Gardner 0-03,Secretary of State,,,Write-ins,1
-Johnson,Gardner 0-04,Secretary of State,,,Write-ins,1
-Johnson,Leawood 1-02,Secretary of State,,,Write-ins,1
-Johnson,Leawood 2-01,Secretary of State,,,Write-ins,1
-Johnson,Leawood 3-02,Secretary of State,,,Write-ins,1
-Johnson,Leawood 3-03,Secretary of State,,,Write-ins,1
-Johnson,Leawood 3-04,Secretary of State,,,Write-ins,1
-Johnson,Leawood 4-06,Secretary of State,,,Write-ins,1
-Johnson,Leawood 4-07,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 2-01,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 3-01,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 3-06,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 3-07,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 4-01,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 4-04,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 4-06,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 4-08,Secretary of State,,,Write-ins,1
-Johnson,Merriam 3-01,Secretary of State,,,Write-ins,1
-Johnson,Mission 2-01,Secretary of State,,,Write-ins,1
-Johnson,Mission 4-03,Secretary of State,,,Write-ins,1
-Johnson,Olathe 1-03,Secretary of State,,,Write-ins,1
-Johnson,Olathe 1-08,Secretary of State,,,Write-ins,1
-Johnson,Olathe 1-18,Secretary of State,,,Write-ins,1
-Johnson,Olathe 2-04,Secretary of State,,,Write-ins,1
-Johnson,Olathe 2-05,Secretary of State,,,Write-ins,1
-Johnson,Olathe 2-15,Secretary of State,,,Write-ins,1
-Johnson,Olathe 2-23,Secretary of State,,,Write-ins,1
-Johnson,Olathe 3-01,Secretary of State,,,Write-ins,1
-Johnson,Olathe 3-03,Secretary of State,,,Write-ins,1
-Johnson,Olathe 3-15,Secretary of State,,,Write-ins,1
-Johnson,Olathe 4-03,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 1-08,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 1-10,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 1-21,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 2-03,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 2-04,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 2-06,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 2-12,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 2-13,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 2-25,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 3-05,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 3-07,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 3-14,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 3-16,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 4-04,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 4-08,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 4-13,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 5-13,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 6-03,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 6-07,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 6-09,Secretary of State,,,Write-ins,1
-Johnson,Overland Park 6-17,Secretary of State,,,Write-ins,1
-Johnson,Prairie Village 2-03,Secretary of State,,,Write-ins,1
-Johnson,Prairie Village 3-02,Secretary of State,,,Write-ins,1
-Johnson,Prairie Village 3-03,Secretary of State,,,Write-ins,1
-Johnson,Prairie Village 6-03,Secretary of State,,,Write-ins,1
-Johnson,Shawnee 1-07,Secretary of State,,,Write-ins,1
-Johnson,Shawnee 1-08,Secretary of State,,,Write-ins,1
-Johnson,Shawnee 2-07,Secretary of State,,,Write-ins,1
-Johnson,Shawnee 2-08,Secretary of State,,,Write-ins,1
-Johnson,Shawnee 4-01,Secretary of State,,,Write-ins,1
-Johnson,Shawnee 4-04,Secretary of State,,,Write-ins,1
-Johnson,Shawnee 4-06,Secretary of State,,,Write-ins,1
-Johnson,Shawnee 4-09,Secretary of State,,,Write-ins,1
-Johnson,Spring Hill 0-01,Secretary of State,,,Write-ins,1
-Johnson,Westwood 0-02,Secretary of State,,,Write-ins,1
-Johnson,Lenexa 2-07,Secretary of State,,,Write-ins,2
-Johnson,Lenexa 3-08,Secretary of State,,,Write-ins,2
-Johnson,Lenexa 4-05,Secretary of State,,,Write-ins,2
-Johnson,Olathe 1-21,Secretary of State,,,Write-ins,2
-Johnson,Olathe 3-07,Secretary of State,,,Write-ins,2
-Johnson,Olathe 4-06,Secretary of State,,,Write-ins,2
-Johnson,Olathe 4-14,Secretary of State,,,Write-ins,2
-Johnson,Overland Park 2-17,Secretary of State,,,Write-ins,2
-Johnson,Overland Park 2-23,Secretary of State,,,Write-ins,2
-Johnson,Overland Park 3-18,Secretary of State,,,Write-ins,2
-Johnson,Overland Park 6-10,Secretary of State,,,Write-ins,2
-Johnson,Overland Park 6-21,Secretary of State,,,Write-ins,2
-Johnson,Shawnee 1-03,Secretary of State,,,Write-ins,2
-Johnson,Lenexa 4-02,Secretary of State,,,Write-ins,3
-Johnson,Aubry Twp 0-01,Attorney General,,R,Derek Schmidt,73
-Johnson,Aubry Twp 0-02,Attorney General,,R,Derek Schmidt,429
-Johnson,Aubry Twp 0-03,Attorney General,,R,Derek Schmidt,222
-Johnson,Aubry Twp 0-04,Attorney General,,R,Derek Schmidt,522
-Johnson,Aubry Twp 0-05,Attorney General,,R,Derek Schmidt,9
-Johnson,Aubry Twp 0-06,Attorney General,,R,Derek Schmidt,72
-Johnson,De Soto 0-01,Attorney General,,R,Derek Schmidt,428
-Johnson,De Soto 0-02,Attorney General,,R,Derek Schmidt,237
-Johnson,De Soto 0-03,Attorney General,,R,Derek Schmidt,445
-Johnson,De Soto 0-06,Attorney General,,R,Derek Schmidt,30
-Johnson,De Soto 0-07,Attorney General,,R,Derek Schmidt,2
-Johnson,Edgerton,Attorney General,,R,Derek Schmidt,262
-Johnson,Fairway 1-01,Attorney General,,R,Derek Schmidt,147
-Johnson,Fairway 1-02,Attorney General,,R,Derek Schmidt,104
-Johnson,Fairway 2-01,Attorney General,,R,Derek Schmidt,110
-Johnson,Fairway 2-02,Attorney General,,R,Derek Schmidt,116
-Johnson,Fairway 3-01,Attorney General,,R,Derek Schmidt,173
-Johnson,Fairway 3-02,Attorney General,,R,Derek Schmidt,141
-Johnson,Fairway 4-01,Attorney General,,R,Derek Schmidt,31
-Johnson,Fairway 4-02,Attorney General,,R,Derek Schmidt,46
-Johnson,Fairway 4-03,Attorney General,,R,Derek Schmidt,33
-Johnson,Fairway 4-04,Attorney General,,R,Derek Schmidt,51
-Johnson,Gardner 0-01,Attorney General,,R,Derek Schmidt,517
-Johnson,Gardner 0-02,Attorney General,,R,Derek Schmidt,71
-Johnson,Gardner 0-03,Attorney General,,R,Derek Schmidt,302
-Johnson,Gardner 0-04,Attorney General,,R,Derek Schmidt,311
-Johnson,Gardner 0-06,Attorney General,,R,Derek Schmidt,392
-Johnson,Gardner 0-07,Attorney General,,R,Derek Schmidt,5
-Johnson,Gardner 0-08,Attorney General,,R,Derek Schmidt,39
-Johnson,Gardner 0-09,Attorney General,,R,Derek Schmidt,412
-Johnson,Gardner 0-10,Attorney General,,R,Derek Schmidt,287
-Johnson,Gardner 0-12,Attorney General,,R,Derek Schmidt,7
-Johnson,Gardner 0-13,Attorney General,,R,Derek Schmidt,299
-Johnson,Gardner 0-14,Attorney General,,R,Derek Schmidt,257
-Johnson,Gardner Twp 0-01,Attorney General,,R,Derek Schmidt,209
-Johnson,Gardner Twp 0-02,Attorney General,,R,Derek Schmidt,251
-Johnson,Gardner Twp 0-04,Attorney General,,R,Derek Schmidt,2
-Johnson,Gardner Twp 0-05,Attorney General,,R,Derek Schmidt,6
-Johnson,Gardner Twp 0-07,Attorney General,,R,Derek Schmidt,2
-Johnson,Gardner Twp 0-08,Attorney General,,R,Derek Schmidt,2
-Johnson,Gardner Twp 0-09,Attorney General,,R,Derek Schmidt,0
-Johnson,Gardner Twp 0-10,Attorney General,,R,Derek Schmidt,0
-Johnson,Gardner Twp 0-11,Attorney General,,R,Derek Schmidt,56
-Johnson,Gardner Twp 0-13,Attorney General,,R,Derek Schmidt,1
-Johnson,Lake Quivira,Attorney General,,R,Derek Schmidt,358
-Johnson,Leawood 1-01,Attorney General,,R,Derek Schmidt,232
-Johnson,Leawood 1-02,Attorney General,,R,Derek Schmidt,474
-Johnson,Leawood 1-03,Attorney General,,R,Derek Schmidt,386
-Johnson,Leawood 1-04,Attorney General,,R,Derek Schmidt,305
-Johnson,Leawood 1-05,Attorney General,,R,Derek Schmidt,279
-Johnson,Leawood 1-06,Attorney General,,R,Derek Schmidt,64
-Johnson,Leawood 2-01,Attorney General,,R,Derek Schmidt,375
-Johnson,Leawood 2-02,Attorney General,,R,Derek Schmidt,430
-Johnson,Leawood 2-03,Attorney General,,R,Derek Schmidt,445
-Johnson,Leawood 2-04,Attorney General,,R,Derek Schmidt,567
-Johnson,Leawood 2-05,Attorney General,,R,Derek Schmidt,263
-Johnson,Leawood 2-06,Attorney General,,R,Derek Schmidt,193
-Johnson,Leawood 3-01,Attorney General,,R,Derek Schmidt,229
-Johnson,Leawood 3-02,Attorney General,,R,Derek Schmidt,410
-Johnson,Leawood 3-03,Attorney General,,R,Derek Schmidt,293
-Johnson,Leawood 3-04,Attorney General,,R,Derek Schmidt,117
-Johnson,Leawood 3-05,Attorney General,,R,Derek Schmidt,541
-Johnson,Leawood 3-06,Attorney General,,R,Derek Schmidt,576
-Johnson,Leawood 3-07,Attorney General,,R,Derek Schmidt,403
-Johnson,Leawood 4-01,Attorney General,,R,Derek Schmidt,149
-Johnson,Leawood 4-02,Attorney General,,R,Derek Schmidt,420
-Johnson,Leawood 4-03,Attorney General,,R,Derek Schmidt,350
-Johnson,Leawood 4-04,Attorney General,,R,Derek Schmidt,439
-Johnson,Leawood 4-05,Attorney General,,R,Derek Schmidt,445
-Johnson,Leawood 4-06,Attorney General,,R,Derek Schmidt,386
-Johnson,Leawood 4-07,Attorney General,,R,Derek Schmidt,623
-Johnson,Leawood 4-08,Attorney General,,R,Derek Schmidt,283
-Johnson,Lenexa 1-01,Attorney General,,R,Derek Schmidt,231
-Johnson,Lenexa 1-02,Attorney General,,R,Derek Schmidt,431
-Johnson,Lenexa 1-03,Attorney General,,R,Derek Schmidt,502
-Johnson,Lenexa 1-04,Attorney General,,R,Derek Schmidt,300
-Johnson,Lenexa 1-05,Attorney General,,R,Derek Schmidt,351
-Johnson,Lenexa 1-06,Attorney General,,R,Derek Schmidt,473
-Johnson,Lenexa 1-07,Attorney General,,R,Derek Schmidt,222
-Johnson,Lenexa 1-08,Attorney General,,R,Derek Schmidt,87
-Johnson,Lenexa 1-09,Attorney General,,R,Derek Schmidt,7
-Johnson,Lenexa 2-01,Attorney General,,R,Derek Schmidt,630
-Johnson,Lenexa 2-02,Attorney General,,R,Derek Schmidt,245
-Johnson,Lenexa 2-03,Attorney General,,R,Derek Schmidt,546
-Johnson,Lenexa 2-04,Attorney General,,R,Derek Schmidt,607
-Johnson,Lenexa 2-05,Attorney General,,R,Derek Schmidt,263
-Johnson,Lenexa 2-06,Attorney General,,R,Derek Schmidt,402
-Johnson,Lenexa 2-07,Attorney General,,R,Derek Schmidt,551
-Johnson,Lenexa 3-01,Attorney General,,R,Derek Schmidt,226
-Johnson,Lenexa 3-02,Attorney General,,R,Derek Schmidt,375
-Johnson,Lenexa 3-03,Attorney General,,R,Derek Schmidt,527
-Johnson,Lenexa 3-04,Attorney General,,R,Derek Schmidt,340
-Johnson,Lenexa 3-05,Attorney General,,R,Derek Schmidt,155
-Johnson,Lenexa 3-06,Attorney General,,R,Derek Schmidt,265
-Johnson,Lenexa 3-07,Attorney General,,R,Derek Schmidt,399
-Johnson,Lenexa 3-08,Attorney General,,R,Derek Schmidt,414
-Johnson,Lenexa 4-01,Attorney General,,R,Derek Schmidt,159
-Johnson,Lenexa 4-02,Attorney General,,R,Derek Schmidt,356
-Johnson,Lenexa 4-03,Attorney General,,R,Derek Schmidt,108
-Johnson,Lenexa 4-04,Attorney General,,R,Derek Schmidt,162
-Johnson,Lenexa 4-05,Attorney General,,R,Derek Schmidt,121
-Johnson,Lenexa 4-06,Attorney General,,R,Derek Schmidt,220
-Johnson,Lenexa 4-07,Attorney General,,R,Derek Schmidt,292
-Johnson,Lenexa 4-08,Attorney General,,R,Derek Schmidt,353
-Johnson,Lenexa 4-09,Attorney General,,R,Derek Schmidt,299
-Johnson,Lenexa 4-10,Attorney General,,R,Derek Schmidt,149
-Johnson,Lenexa 4-11,Attorney General,,R,Derek Schmidt,39
-Johnson,Lexington Twp 0-01,Attorney General,,R,Derek Schmidt,434
-Johnson,Lexington Twp 0-02,Attorney General,,R,Derek Schmidt,1
-Johnson,Lexington Twp 0-03,Attorney General,,R,Derek Schmidt,1
-Johnson,McCamish Twp 0-01,Attorney General,,R,Derek Schmidt,112
-Johnson,McCamish Twp 0-02,Attorney General,,R,Derek Schmidt,216
-Johnson,Merriam 1-01,Attorney General,,R,Derek Schmidt,159
-Johnson,Merriam 1-02,Attorney General,,R,Derek Schmidt,181
-Johnson,Merriam 2-01,Attorney General,,R,Derek Schmidt,279
-Johnson,Merriam 2-02,Attorney General,,R,Derek Schmidt,0
-Johnson,Merriam 2-03,Attorney General,,R,Derek Schmidt,126
-Johnson,Merriam 3-01,Attorney General,,R,Derek Schmidt,191
-Johnson,Merriam 3-02,Attorney General,,R,Derek Schmidt,188
-Johnson,Merriam 4-01,Attorney General,,R,Derek Schmidt,276
-Johnson,Merriam 4-02,Attorney General,,R,Derek Schmidt,110
-Johnson,Merriam 4-03,Attorney General,,R,Derek Schmidt,144
-Johnson,Mission 1-01,Attorney General,,R,Derek Schmidt,235
-Johnson,Mission 1-02,Attorney General,,R,Derek Schmidt,91
-Johnson,Mission 2-01,Attorney General,,R,Derek Schmidt,124
-Johnson,Mission 2-02,Attorney General,,R,Derek Schmidt,186
-Johnson,Mission 3-01,Attorney General,,R,Derek Schmidt,195
-Johnson,Mission 3-02,Attorney General,,R,Derek Schmidt,109
-Johnson,Mission 4-01,Attorney General,,R,Derek Schmidt,133
-Johnson,Mission 4-02,Attorney General,,R,Derek Schmidt,248
-Johnson,Mission 4-03,Attorney General,,R,Derek Schmidt,120
-Johnson,Mission Hills 0-01,Attorney General,,R,Derek Schmidt,299
-Johnson,Mission Hills 0-02,Attorney General,,R,Derek Schmidt,362
-Johnson,Mission Hills 0-03,Attorney General,,R,Derek Schmidt,248
-Johnson,Mission Hills 0-04,Attorney General,,R,Derek Schmidt,380
-Johnson,Mission Woods,Attorney General,,R,Derek Schmidt,52
-Johnson,Olathe 1-01,Attorney General,,R,Derek Schmidt,341
-Johnson,Olathe 1-02,Attorney General,,R,Derek Schmidt,202
-Johnson,Olathe 1-03,Attorney General,,R,Derek Schmidt,174
-Johnson,Olathe 1-04,Attorney General,,R,Derek Schmidt,326
-Johnson,Olathe 1-05,Attorney General,,R,Derek Schmidt,374
-Johnson,Olathe 1-06,Attorney General,,R,Derek Schmidt,238
-Johnson,Olathe 1-08,Attorney General,,R,Derek Schmidt,375
-Johnson,Olathe 1-09,Attorney General,,R,Derek Schmidt,382
-Johnson,Olathe 1-11,Attorney General,,R,Derek Schmidt,60
-Johnson,Olathe 1-14,Attorney General,,R,Derek Schmidt,339
-Johnson,Olathe 1-15,Attorney General,,R,Derek Schmidt,296
-Johnson,Olathe 1-16,Attorney General,,R,Derek Schmidt,418
-Johnson,Olathe 1-17,Attorney General,,R,Derek Schmidt,114
-Johnson,Olathe 1-18,Attorney General,,R,Derek Schmidt,112
-Johnson,Olathe 1-19,Attorney General,,R,Derek Schmidt,149
-Johnson,Olathe 1-20,Attorney General,,R,Derek Schmidt,218
-Johnson,Olathe 1-21,Attorney General,,R,Derek Schmidt,399
-Johnson,Olathe 1-22,Attorney General,,R,Derek Schmidt,620
-Johnson,Olathe 1-23,Attorney General,,R,Derek Schmidt,1
-Johnson,Olathe 1-24,Attorney General,,R,Derek Schmidt,56
-Johnson,Olathe 1-24,Attorney General,,R,Derek Schmidt,93
-Johnson,Olathe 1-26,Attorney General,,R,Derek Schmidt,1
-Johnson,Olathe 1-27,Attorney General,,R,Derek Schmidt,219
-Johnson,Olathe 2-01,Attorney General,,R,Derek Schmidt,146
-Johnson,Olathe 2-02,Attorney General,,R,Derek Schmidt,212
-Johnson,Olathe 2-03,Attorney General,,R,Derek Schmidt,254
-Johnson,Olathe 2-04,Attorney General,,R,Derek Schmidt,240
-Johnson,Olathe 2-05,Attorney General,,R,Derek Schmidt,930
-Johnson,Olathe 2-06,Attorney General,,R,Derek Schmidt,463
-Johnson,Olathe 2-07,Attorney General,,R,Derek Schmidt,506
-Johnson,Olathe 2-08,Attorney General,,R,Derek Schmidt,324
-Johnson,Olathe 2-09,Attorney General,,R,Derek Schmidt,156
-Johnson,Olathe 2-10,Attorney General,,R,Derek Schmidt,632
-Johnson,Olathe 2-11,Attorney General,,R,Derek Schmidt,457
-Johnson,Olathe 2-12,Attorney General,,R,Derek Schmidt,270
-Johnson,Olathe 2-13,Attorney General,,R,Derek Schmidt,249
-Johnson,Olathe 2-14,Attorney General,,R,Derek Schmidt,264
-Johnson,Olathe 2-15,Attorney General,,R,Derek Schmidt,298
-Johnson,Olathe 2-16,Attorney General,,R,Derek Schmidt,68
-Johnson,Olathe 2-17,Attorney General,,R,Derek Schmidt,0
-Johnson,Olathe 2-19,Attorney General,,R,Derek Schmidt,2
-Johnson,Olathe 2-22,Attorney General,,R,Derek Schmidt,540
-Johnson,Olathe 2-23,Attorney General,,R,Derek Schmidt,350
-Johnson,Olathe 3-01,Attorney General,,R,Derek Schmidt,129
-Johnson,Olathe 3-02,Attorney General,,R,Derek Schmidt,429
-Johnson,Olathe 3-03,Attorney General,,R,Derek Schmidt,233
-Johnson,Olathe 3-04,Attorney General,,R,Derek Schmidt,392
-Johnson,Olathe 3-05,Attorney General,,R,Derek Schmidt,449
-Johnson,Olathe 3-06,Attorney General,,R,Derek Schmidt,306
-Johnson,Olathe 3-07,Attorney General,,R,Derek Schmidt,278
-Johnson,Olathe 3-08,Attorney General,,R,Derek Schmidt,425
-Johnson,Olathe 3-09,Attorney General,,R,Derek Schmidt,218
-Johnson,Olathe 3-10,Attorney General,,R,Derek Schmidt,435
-Johnson,Olathe 3-11,Attorney General,,R,Derek Schmidt,259
-Johnson,Olathe 3-12,Attorney General,,R,Derek Schmidt,366
-Johnson,Olathe 3-13,Attorney General,,R,Derek Schmidt,425
-Johnson,Olathe 3-15,Attorney General,,R,Derek Schmidt,274
-Johnson,Olathe 3-16,Attorney General,,R,Derek Schmidt,287
-Johnson,Olathe 3-17,Attorney General,,R,Derek Schmidt,423
-Johnson,Olathe 3-18,Attorney General,,R,Derek Schmidt,390
-Johnson,Olathe 3-19,Attorney General,,R,Derek Schmidt,284
-Johnson,Olathe 3-20,Attorney General,,R,Derek Schmidt,279
-Johnson,Olathe 3-21,Attorney General,,R,Derek Schmidt,301
-Johnson,Olathe 3-22,Attorney General,,R,Derek Schmidt,352
-Johnson,Olathe 3-23,Attorney General,,R,Derek Schmidt,300
-Johnson,Olathe 3-24,Attorney General,,R,Derek Schmidt,182
-Johnson,Olathe 3-26,Attorney General,,R,Derek Schmidt,28
-Johnson,Olathe 4-01,Attorney General,,R,Derek Schmidt,252
-Johnson,Olathe 4-02,Attorney General,,R,Derek Schmidt,507
-Johnson,Olathe 4-03,Attorney General,,R,Derek Schmidt,125
-Johnson,Olathe 4-04,Attorney General,,R,Derek Schmidt,166
-Johnson,Olathe 4-05,Attorney General,,R,Derek Schmidt,333
-Johnson,Olathe 4-06,Attorney General,,R,Derek Schmidt,422
-Johnson,Olathe 4-07,Attorney General,,R,Derek Schmidt,354
-Johnson,Olathe 4-08,Attorney General,,R,Derek Schmidt,332
-Johnson,Olathe 4-09,Attorney General,,R,Derek Schmidt,453
-Johnson,Olathe 4-10,Attorney General,,R,Derek Schmidt,241
-Johnson,Olathe 4-11,Attorney General,,R,Derek Schmidt,125
-Johnson,Olathe 4-12,Attorney General,,R,Derek Schmidt,424
-Johnson,Olathe 4-13,Attorney General,,R,Derek Schmidt,186
-Johnson,Olathe 4-14,Attorney General,,R,Derek Schmidt,433
-Johnson,Olathe 4-15,Attorney General,,R,Derek Schmidt,19
-Johnson,Olathe 4-16,Attorney General,,R,Derek Schmidt,102
-Johnson,Olathe 4-17,Attorney General,,R,Derek Schmidt,3
-Johnson,Olathe Twp 0-01,Attorney General,,R,Derek Schmidt,179
-Johnson,Olathe Twp 0-02,Attorney General,,R,Derek Schmidt,42
-Johnson,Olathe Twp 0-03,Attorney General,,R,Derek Schmidt,25
-Johnson,Olathe Twp 0-04,Attorney General,,R,Derek Schmidt,2
-Johnson,Olathe Twp 0-05,Attorney General,,R,Derek Schmidt,2
-Johnson,Olathe Twp 0-06,Attorney General,,R,Derek Schmidt,0
-Johnson,Olathe Twp 0-07,Attorney General,,R,Derek Schmidt,1
-Johnson,Olathe Twp 0-08,Attorney General,,R,Derek Schmidt,4
-Johnson,Olathe Twp 0-10,Attorney General,,R,Derek Schmidt,8
-Johnson,Olathe Twp 0-11,Attorney General,,R,Derek Schmidt,3
-Johnson,Olathe Twp 0-14,Attorney General,,R,Derek Schmidt,1
-Johnson,Olathe Twp 0-24,Attorney General,,R,Derek Schmidt,2
-Johnson,Olathe Twp 0-25,Attorney General,,R,Derek Schmidt,7
-Johnson,Olathe Twp 0-26,Attorney General,,R,Derek Schmidt,3
-Johnson,Olathe Twp 0-32,Attorney General,,R,Derek Schmidt,15
-Johnson,Overland Park 1-01,Attorney General,,R,Derek Schmidt,223
-Johnson,Overland Park 1-02,Attorney General,,R,Derek Schmidt,218
-Johnson,Overland Park 1-03,Attorney General,,R,Derek Schmidt,242
-Johnson,Overland Park 1-04,Attorney General,,R,Derek Schmidt,94
-Johnson,Overland Park 1-05,Attorney General,,R,Derek Schmidt,151
-Johnson,Overland Park 1-06,Attorney General,,R,Derek Schmidt,299
-Johnson,Overland Park 1-07,Attorney General,,R,Derek Schmidt,324
-Johnson,Overland Park 1-08,Attorney General,,R,Derek Schmidt,199
-Johnson,Overland Park 1-09,Attorney General,,R,Derek Schmidt,138
-Johnson,Overland Park 1-10,Attorney General,,R,Derek Schmidt,275
-Johnson,Overland Park 1-11,Attorney General,,R,Derek Schmidt,69
-Johnson,Overland Park 1-12,Attorney General,,R,Derek Schmidt,214
-Johnson,Overland Park 1-13,Attorney General,,R,Derek Schmidt,183
-Johnson,Overland Park 1-14,Attorney General,,R,Derek Schmidt,246
-Johnson,Overland Park 1-15,Attorney General,,R,Derek Schmidt,108
-Johnson,Overland Park 1-16,Attorney General,,R,Derek Schmidt,262
-Johnson,Overland Park 1-17,Attorney General,,R,Derek Schmidt,127
-Johnson,Overland Park 1-18,Attorney General,,R,Derek Schmidt,250
-Johnson,Overland Park 1-19,Attorney General,,R,Derek Schmidt,191
-Johnson,Overland Park 1-20,Attorney General,,R,Derek Schmidt,145
-Johnson,Overland Park 1-21,Attorney General,,R,Derek Schmidt,91
-Johnson,Overland Park 1-22,Attorney General,,R,Derek Schmidt,43
-Johnson,Overland Park 2-01,Attorney General,,R,Derek Schmidt,238
-Johnson,Overland Park 2-02,Attorney General,,R,Derek Schmidt,253
-Johnson,Overland Park 2-03,Attorney General,,R,Derek Schmidt,221
-Johnson,Overland Park 2-04,Attorney General,,R,Derek Schmidt,280
-Johnson,Overland Park 2-05,Attorney General,,R,Derek Schmidt,225
-Johnson,Overland Park 2-06,Attorney General,,R,Derek Schmidt,258
-Johnson,Overland Park 2-07,Attorney General,,R,Derek Schmidt,198
-Johnson,Overland Park 2-08,Attorney General,,R,Derek Schmidt,104
-Johnson,Overland Park 2-09,Attorney General,,R,Derek Schmidt,216
-Johnson,Overland Park 2-10,Attorney General,,R,Derek Schmidt,214
-Johnson,Overland Park 2-11,Attorney General,,R,Derek Schmidt,245
-Johnson,Overland Park 2-12,Attorney General,,R,Derek Schmidt,195
-Johnson,Overland Park 2-13,Attorney General,,R,Derek Schmidt,104
-Johnson,Overland Park 2-14,Attorney General,,R,Derek Schmidt,172
-Johnson,Overland Park 2-15,Attorney General,,R,Derek Schmidt,361
-Johnson,Overland Park 2-16,Attorney General,,R,Derek Schmidt,212
-Johnson,Overland Park 2-17,Attorney General,,R,Derek Schmidt,343
-Johnson,Overland Park 2-18,Attorney General,,R,Derek Schmidt,316
-Johnson,Overland Park 2-19,Attorney General,,R,Derek Schmidt,210
-Johnson,Overland Park 2-20,Attorney General,,R,Derek Schmidt,224
-Johnson,Overland Park 2-21,Attorney General,,R,Derek Schmidt,214
-Johnson,Overland Park 2-22,Attorney General,,R,Derek Schmidt,220
-Johnson,Overland Park 2-23,Attorney General,,R,Derek Schmidt,304
-Johnson,Overland Park 2-24,Attorney General,,R,Derek Schmidt,432
-Johnson,Overland Park 2-25,Attorney General,,R,Derek Schmidt,318
-Johnson,Overland Park 2-26,Attorney General,,R,Derek Schmidt,109
-Johnson,Overland Park 3-01,Attorney General,,R,Derek Schmidt,500
-Johnson,Overland Park 3-02,Attorney General,,R,Derek Schmidt,264
-Johnson,Overland Park 3-03,Attorney General,,R,Derek Schmidt,311
-Johnson,Overland Park 3-04,Attorney General,,R,Derek Schmidt,346
-Johnson,Overland Park 3-05,Attorney General,,R,Derek Schmidt,329
-Johnson,Overland Park 3-06,Attorney General,,R,Derek Schmidt,398
-Johnson,Overland Park 3-07,Attorney General,,R,Derek Schmidt,196
-Johnson,Overland Park 3-08,Attorney General,,R,Derek Schmidt,348
-Johnson,Overland Park 3-09,Attorney General,,R,Derek Schmidt,412
-Johnson,Overland Park 3-10,Attorney General,,R,Derek Schmidt,259
-Johnson,Overland Park 3-11,Attorney General,,R,Derek Schmidt,327
-Johnson,Overland Park 3-12,Attorney General,,R,Derek Schmidt,159
-Johnson,Overland Park 3-13,Attorney General,,R,Derek Schmidt,492
-Johnson,Overland Park 3-14,Attorney General,,R,Derek Schmidt,332
-Johnson,Overland Park 3-15,Attorney General,,R,Derek Schmidt,249
-Johnson,Overland Park 3-16,Attorney General,,R,Derek Schmidt,294
-Johnson,Overland Park 3-17,Attorney General,,R,Derek Schmidt,256
-Johnson,Overland Park 3-18,Attorney General,,R,Derek Schmidt,244
-Johnson,Overland Park 3-19,Attorney General,,R,Derek Schmidt,297
-Johnson,Overland Park 3-20,Attorney General,,R,Derek Schmidt,391
-Johnson,Overland Park 3-21,Attorney General,,R,Derek Schmidt,338
-Johnson,Overland Park 4-01,Attorney General,,R,Derek Schmidt,262
-Johnson,Overland Park 4-02,Attorney General,,R,Derek Schmidt,422
-Johnson,Overland Park 4-03,Attorney General,,R,Derek Schmidt,549
-Johnson,Overland Park 4-04,Attorney General,,R,Derek Schmidt,536
-Johnson,Overland Park 4-05,Attorney General,,R,Derek Schmidt,386
-Johnson,Overland Park 4-06,Attorney General,,R,Derek Schmidt,311
-Johnson,Overland Park 4-07,Attorney General,,R,Derek Schmidt,228
-Johnson,Overland Park 4-08,Attorney General,,R,Derek Schmidt,407
-Johnson,Overland Park 4-09,Attorney General,,R,Derek Schmidt,441
-Johnson,Overland Park 4-10,Attorney General,,R,Derek Schmidt,299
-Johnson,Overland Park 4-11,Attorney General,,R,Derek Schmidt,449
-Johnson,Overland Park 4-12,Attorney General,,R,Derek Schmidt,574
-Johnson,Overland Park 4-13,Attorney General,,R,Derek Schmidt,332
-Johnson,Overland Park 4-14,Attorney General,,R,Derek Schmidt,248
-Johnson,Overland Park 4-15,Attorney General,,R,Derek Schmidt,479
-Johnson,Overland Park 4-16,Attorney General,,R,Derek Schmidt,397
-Johnson,Overland Park 4-17,Attorney General,,R,Derek Schmidt,444
-Johnson,Overland Park 4-18,Attorney General,,R,Derek Schmidt,58
-Johnson,Overland Park 5-01,Attorney General,,R,Derek Schmidt,380
-Johnson,Overland Park 5-02,Attorney General,,R,Derek Schmidt,183
-Johnson,Overland Park 5-03,Attorney General,,R,Derek Schmidt,374
-Johnson,Overland Park 5-04,Attorney General,,R,Derek Schmidt,320
-Johnson,Overland Park 5-05,Attorney General,,R,Derek Schmidt,215
-Johnson,Overland Park 5-06,Attorney General,,R,Derek Schmidt,294
-Johnson,Overland Park 5-07,Attorney General,,R,Derek Schmidt,550
-Johnson,Overland Park 5-08,Attorney General,,R,Derek Schmidt,552
-Johnson,Overland Park 5-09,Attorney General,,R,Derek Schmidt,478
-Johnson,Overland Park 5-10,Attorney General,,R,Derek Schmidt,374
-Johnson,Overland Park 5-11,Attorney General,,R,Derek Schmidt,413
-Johnson,Overland Park 5-12,Attorney General,,R,Derek Schmidt,89
-Johnson,Overland Park 5-13,Attorney General,,R,Derek Schmidt,443
-Johnson,Overland Park 5-14,Attorney General,,R,Derek Schmidt,384
-Johnson,Overland Park 5-15,Attorney General,,R,Derek Schmidt,233
-Johnson,Overland Park 5-16,Attorney General,,R,Derek Schmidt,236
-Johnson,Overland Park 5-17,Attorney General,,R,Derek Schmidt,136
-Johnson,Overland Park 5-18,Attorney General,,R,Derek Schmidt,299
-Johnson,Overland Park 5-19,Attorney General,,R,Derek Schmidt,31
-Johnson,Overland Park 6-01,Attorney General,,R,Derek Schmidt,483
-Johnson,Overland Park 6-02,Attorney General,,R,Derek Schmidt,374
-Johnson,Overland Park 6-03,Attorney General,,R,Derek Schmidt,429
-Johnson,Overland Park 6-04,Attorney General,,R,Derek Schmidt,419
-Johnson,Overland Park 6-05,Attorney General,,R,Derek Schmidt,436
-Johnson,Overland Park 6-06,Attorney General,,R,Derek Schmidt,1
-Johnson,Overland Park 6-07,Attorney General,,R,Derek Schmidt,141
-Johnson,Overland Park 6-08,Attorney General,,R,Derek Schmidt,721
-Johnson,Overland Park 6-09,Attorney General,,R,Derek Schmidt,554
-Johnson,Overland Park 6-10,Attorney General,,R,Derek Schmidt,355
-Johnson,Overland Park 6-11,Attorney General,,R,Derek Schmidt,361
-Johnson,Overland Park 6-12,Attorney General,,R,Derek Schmidt,181
-Johnson,Overland Park 6-13,Attorney General,,R,Derek Schmidt,492
-Johnson,Overland Park 6-15,Attorney General,,R,Derek Schmidt,487
-Johnson,Overland Park 6-16,Attorney General,,R,Derek Schmidt,294
-Johnson,Overland Park 6-17,Attorney General,,R,Derek Schmidt,94
-Johnson,Overland Park 6-18,Attorney General,,R,Derek Schmidt,3
-Johnson,Overland Park 6-19,Attorney General,,R,Derek Schmidt,444
-Johnson,Overland Park 6-20,Attorney General,,R,Derek Schmidt,256
-Johnson,Overland Park 6-21,Attorney General,,R,Derek Schmidt,695
-Johnson,Overland Park 6-22,Attorney General,,R,Derek Schmidt,245
-Johnson,Oxford Twp 0-01,Attorney General,,R,Derek Schmidt,1
-Johnson,Oxford Twp 0-02,Attorney General,,R,Derek Schmidt,320
-Johnson,Oxford Twp 0-04,Attorney General,,R,Derek Schmidt,238
-Johnson,Oxford Twp 0-05,Attorney General,,R,Derek Schmidt,10
-Johnson,Oxford Twp 0-09,Attorney General,,R,Derek Schmidt,17
-Johnson,Oxford Twp 0-10,Attorney General,,R,Derek Schmidt,2
-Johnson,Oxford Twp 0-11,Attorney General,,R,Derek Schmidt,68
-Johnson,Prairie Village 1-01,Attorney General,,R,Derek Schmidt,340
-Johnson,Prairie Village 1-02,Attorney General,,R,Derek Schmidt,233
-Johnson,Prairie Village 1-03,Attorney General,,R,Derek Schmidt,309
-Johnson,Prairie Village 2-01,Attorney General,,R,Derek Schmidt,262
-Johnson,Prairie Village 2-02,Attorney General,,R,Derek Schmidt,137
-Johnson,Prairie Village 2-03,Attorney General,,R,Derek Schmidt,224
-Johnson,Prairie Village 3-01,Attorney General,,R,Derek Schmidt,200
-Johnson,Prairie Village 3-02,Attorney General,,R,Derek Schmidt,281
-Johnson,Prairie Village 3-03,Attorney General,,R,Derek Schmidt,260
-Johnson,Prairie Village 4-01,Attorney General,,R,Derek Schmidt,407
-Johnson,Prairie Village 4-02,Attorney General,,R,Derek Schmidt,210
-Johnson,Prairie Village 4-03,Attorney General,,R,Derek Schmidt,343
-Johnson,Prairie Village 5-01,Attorney General,,R,Derek Schmidt,339
-Johnson,Prairie Village 5-02,Attorney General,,R,Derek Schmidt,397
-Johnson,Prairie Village 5-03,Attorney General,,R,Derek Schmidt,314
-Johnson,Prairie Village 6-01,Attorney General,,R,Derek Schmidt,331
-Johnson,Prairie Village 6-02,Attorney General,,R,Derek Schmidt,218
-Johnson,Prairie Village 6-03,Attorney General,,R,Derek Schmidt,155
-Johnson,Roeland Park 1-01,Attorney General,,R,Derek Schmidt,88
-Johnson,Roeland Park 1-02,Attorney General,,R,Derek Schmidt,63
-Johnson,Roeland Park 2-01,Attorney General,,R,Derek Schmidt,105
-Johnson,Roeland Park 2-02,Attorney General,,R,Derek Schmidt,166
-Johnson,Roeland Park 3-01,Attorney General,,R,Derek Schmidt,73
-Johnson,Roeland Park 3-02,Attorney General,,R,Derek Schmidt,169
-Johnson,Roeland Park 4-01,Attorney General,,R,Derek Schmidt,96
-Johnson,Roeland Park 4-02,Attorney General,,R,Derek Schmidt,287
-Johnson,Shawnee 1-01,Attorney General,,R,Derek Schmidt,336
-Johnson,Shawnee 1-02,Attorney General,,R,Derek Schmidt,261
-Johnson,Shawnee 1-03,Attorney General,,R,Derek Schmidt,239
-Johnson,Shawnee 1-04,Attorney General,,R,Derek Schmidt,473
-Johnson,Shawnee 1-05,Attorney General,,R,Derek Schmidt,461
-Johnson,Shawnee 1-06,Attorney General,,R,Derek Schmidt,442
-Johnson,Shawnee 1-07,Attorney General,,R,Derek Schmidt,381
-Johnson,Shawnee 1-08,Attorney General,,R,Derek Schmidt,424
-Johnson,Shawnee 1-09,Attorney General,,R,Derek Schmidt,56
-Johnson,Shawnee 1-10,Attorney General,,R,Derek Schmidt,161
-Johnson,Shawnee 1-11,Attorney General,,R,Derek Schmidt,266
-Johnson,Shawnee 1-12,Attorney General,,R,Derek Schmidt,5
-Johnson,Shawnee 2-01,Attorney General,,R,Derek Schmidt,162
-Johnson,Shawnee 2-02,Attorney General,,R,Derek Schmidt,291
-Johnson,Shawnee 2-03,Attorney General,,R,Derek Schmidt,208
-Johnson,Shawnee 2-04,Attorney General,,R,Derek Schmidt,337
-Johnson,Shawnee 2-05,Attorney General,,R,Derek Schmidt,173
-Johnson,Shawnee 2-06,Attorney General,,R,Derek Schmidt,263
-Johnson,Shawnee 2-07,Attorney General,,R,Derek Schmidt,194
-Johnson,Shawnee 2-08,Attorney General,,R,Derek Schmidt,203
-Johnson,Shawnee 2-09,Attorney General,,R,Derek Schmidt,178
-Johnson,Shawnee 2-10,Attorney General,,R,Derek Schmidt,152
-Johnson,Shawnee 2-11,Attorney General,,R,Derek Schmidt,267
-Johnson,Shawnee 2-12,Attorney General,,R,Derek Schmidt,51
-Johnson,Shawnee 2-13,Attorney General,,R,Derek Schmidt,137
-Johnson,Shawnee 3-01,Attorney General,,R,Derek Schmidt,280
-Johnson,Shawnee 3-02,Attorney General,,R,Derek Schmidt,512
-Johnson,Shawnee 3-03,Attorney General,,R,Derek Schmidt,353
-Johnson,Shawnee 3-04,Attorney General,,R,Derek Schmidt,362
-Johnson,Shawnee 3-05,Attorney General,,R,Derek Schmidt,549
-Johnson,Shawnee 3-06,Attorney General,,R,Derek Schmidt,319
-Johnson,Shawnee 3-07,Attorney General,,R,Derek Schmidt,474
-Johnson,Shawnee 3-08,Attorney General,,R,Derek Schmidt,425
-Johnson,Shawnee 3-09,Attorney General,,R,Derek Schmidt,278
-Johnson,Shawnee 4-01,Attorney General,,R,Derek Schmidt,469
-Johnson,Shawnee 4-02,Attorney General,,R,Derek Schmidt,264
-Johnson,Shawnee 4-03,Attorney General,,R,Derek Schmidt,114
-Johnson,Shawnee 4-04,Attorney General,,R,Derek Schmidt,92
-Johnson,Shawnee 4-05,Attorney General,,R,Derek Schmidt,346
-Johnson,Shawnee 4-06,Attorney General,,R,Derek Schmidt,342
-Johnson,Shawnee 4-07,Attorney General,,R,Derek Schmidt,476
-Johnson,Shawnee 4-08,Attorney General,,R,Derek Schmidt,199
-Johnson,Shawnee 4-09,Attorney General,,R,Derek Schmidt,508
-Johnson,Shawnee 4-11,Attorney General,,R,Derek Schmidt,249
-Johnson,Shawnee 4-12,Attorney General,,R,Derek Schmidt,56
-Johnson,Spring Hill 0-01,Attorney General,,R,Derek Schmidt,580
-Johnson,Spring Hill 0-03,Attorney General,,R,Derek Schmidt,42
-Johnson,Spring Hill 0-04,Attorney General,,R,Derek Schmidt,0
-Johnson,Spring Hill Twp 0-01,Attorney General,,R,Derek Schmidt,470
-Johnson,Spring Hill Twp 0-02,Attorney General,,R,Derek Schmidt,1
-Johnson,Spring Hill Twp 0-03,Attorney General,,R,Derek Schmidt,51
-Johnson,Spring Hill Twp 0-04,Attorney General,,R,Derek Schmidt,10
-Johnson,Spring Hill Twp 0-05,Attorney General,,R,Derek Schmidt,3
-Johnson,Westwood 0-01,Attorney General,,R,Derek Schmidt,142
-Johnson,Westwood 0-02,Attorney General,,R,Derek Schmidt,163
-Johnson,Westwood Hills 0-01,Attorney General,,R,Derek Schmidt,90
-Johnson,Aubry Twp 0-02,Attorney General,,,Write-ins,1
-Johnson,De Soto 0-01,Attorney General,,,Write-ins,1
-Johnson,Fairway 2-01,Attorney General,,,Write-ins,1
-Johnson,Fairway 4-01,Attorney General,,,Write-ins,1
-Johnson,Gardner 0-01,Attorney General,,,Write-ins,1
-Johnson,Gardner 0-03,Attorney General,,,Write-ins,1
-Johnson,Gardner 0-04,Attorney General,,,Write-ins,1
-Johnson,Leawood 1-02,Attorney General,,,Write-ins,1
-Johnson,Leawood 3-02,Attorney General,,,Write-ins,1
-Johnson,Leawood 3-04,Attorney General,,,Write-ins,1
-Johnson,Leawood 4-07,Attorney General,,,Write-ins,1
-Johnson,Lenexa 1-05,Attorney General,,,Write-ins,1
-Johnson,Lenexa 2-01,Attorney General,,,Write-ins,1
-Johnson,Lenexa 2-07,Attorney General,,,Write-ins,1
-Johnson,Lenexa 3-07,Attorney General,,,Write-ins,1
-Johnson,Lenexa 4-02,Attorney General,,,Write-ins,1
-Johnson,Lenexa 4-03,Attorney General,,,Write-ins,1
-Johnson,Lenexa 4-04,Attorney General,,,Write-ins,1
-Johnson,Lenexa 4-05,Attorney General,,,Write-ins,1
-Johnson,Lenexa 4-06,Attorney General,,,Write-ins,1
-Johnson,Merriam 3-01,Attorney General,,,Write-ins,1
-Johnson,Olathe 1-02,Attorney General,,,Write-ins,1
-Johnson,Olathe 1-08,Attorney General,,,Write-ins,1
-Johnson,Olathe 1-21,Attorney General,,,Write-ins,1
-Johnson,Olathe 2-05,Attorney General,,,Write-ins,1
-Johnson,Olathe 2-08,Attorney General,,,Write-ins,1
-Johnson,Olathe 3-03,Attorney General,,,Write-ins,1
-Johnson,Olathe 3-05,Attorney General,,,Write-ins,1
-Johnson,Olathe 3-12,Attorney General,,,Write-ins,1
-Johnson,Olathe 3-13,Attorney General,,,Write-ins,1
-Johnson,Olathe 3-17,Attorney General,,,Write-ins,1
-Johnson,Olathe 4-03,Attorney General,,,Write-ins,1
-Johnson,Olathe 4-05,Attorney General,,,Write-ins,1
-Johnson,Olathe 4-14,Attorney General,,,Write-ins,1
-Johnson,Overland Park 1-08,Attorney General,,,Write-ins,1
-Johnson,Overland Park 1-10,Attorney General,,,Write-ins,1
-Johnson,Overland Park 1-21,Attorney General,,,Write-ins,1
-Johnson,Overland Park 2-01,Attorney General,,,Write-ins,1
-Johnson,Overland Park 2-03,Attorney General,,,Write-ins,1
-Johnson,Overland Park 2-06,Attorney General,,,Write-ins,1
-Johnson,Overland Park 2-09,Attorney General,,,Write-ins,1
-Johnson,Overland Park 2-12,Attorney General,,,Write-ins,1
-Johnson,Overland Park 2-13,Attorney General,,,Write-ins,1
-Johnson,Overland Park 2-25,Attorney General,,,Write-ins,1
-Johnson,Overland Park 3-07,Attorney General,,,Write-ins,1
-Johnson,Overland Park 3-14,Attorney General,,,Write-ins,1
-Johnson,Overland Park 3-18,Attorney General,,,Write-ins,1
-Johnson,Overland Park 4-08,Attorney General,,,Write-ins,1
-Johnson,Overland Park 5-04,Attorney General,,,Write-ins,1
-Johnson,Overland Park 6-01,Attorney General,,,Write-ins,1
-Johnson,Overland Park 6-07,Attorney General,,,Write-ins,1
-Johnson,Overland Park 6-09,Attorney General,,,Write-ins,1
-Johnson,Overland Park 6-10,Attorney General,,,Write-ins,1
-Johnson,Overland Park 6-19,Attorney General,,,Write-ins,1
-Johnson,Prairie Village 1-01,Attorney General,,,Write-ins,1
-Johnson,Prairie Village 3-02,Attorney General,,,Write-ins,1
-Johnson,Prairie Village 5-03,Attorney General,,,Write-ins,1
-Johnson,Roeland Park 3-02,Attorney General,,,Write-ins,1
-Johnson,Roeland Park 4-02,Attorney General,,,Write-ins,1
-Johnson,Shawnee 1-04,Attorney General,,,Write-ins,1
-Johnson,Shawnee 1-07,Attorney General,,,Write-ins,1
-Johnson,Shawnee 2-13,Attorney General,,,Write-ins,1
-Johnson,Shawnee 3-02,Attorney General,,,Write-ins,1
-Johnson,Shawnee 4-04,Attorney General,,,Write-ins,1
-Johnson,Shawnee 4-05,Attorney General,,,Write-ins,1
-Johnson,Shawnee 4-06,Attorney General,,,Write-ins,1
-Johnson,Shawnee 4-07,Attorney General,,,Write-ins,1
-Johnson,Shawnee 4-11,Attorney General,,,Write-ins,1
-Johnson,Spring Hill 0-01,Attorney General,,,Write-ins,1
-Johnson,Lenexa 3-03,Attorney General,,,Write-ins,2
-Johnson,Lenexa 4-01,Attorney General,,,Write-ins,2
-Johnson,Olathe 2-22,Attorney General,,,Write-ins,2
-Johnson,Olathe 3-10,Attorney General,,,Write-ins,2
-Johnson,Olathe 4-06,Attorney General,,,Write-ins,2
-Johnson,Overland Park 2-15,Attorney General,,,Write-ins,2
-Johnson,Shawnee 1-03,Attorney General,,,Write-ins,2
-Johnson,Olathe 3-07,Attorney General,,,Write-ins,3
-Johnson,Overland Park 2-22,Attorney General,,,Write-ins,3
-Johnson,Overland Park 6-08,Attorney General,,,Write-ins,3
-Johnson,Aubry Twp 0-01,Attorney General,,D,AJ Kotich,35
-Johnson,Aubry Twp 0-02,Attorney General,,D,AJ Kotich,130
-Johnson,Aubry Twp 0-03,Attorney General,,D,AJ Kotich,97
-Johnson,Aubry Twp 0-04,Attorney General,,D,AJ Kotich,189
-Johnson,Aubry Twp 0-05,Attorney General,,D,AJ Kotich,4
-Johnson,Aubry Twp 0-06,Attorney General,,D,AJ Kotich,16
-Johnson,De Soto 0-01,Attorney General,,D,AJ Kotich,188
-Johnson,De Soto 0-02,Attorney General,,D,AJ Kotich,142
-Johnson,De Soto 0-03,Attorney General,,D,AJ Kotich,183
-Johnson,De Soto 0-06,Attorney General,,D,AJ Kotich,17
-Johnson,De Soto 0-07,Attorney General,,D,AJ Kotich,0
-Johnson,Edgerton,Attorney General,,D,AJ Kotich,127
-Johnson,Fairway 1-01,Attorney General,,D,AJ Kotich,129
-Johnson,Fairway 1-02,Attorney General,,D,AJ Kotich,96
-Johnson,Fairway 2-01,Attorney General,,D,AJ Kotich,103
-Johnson,Fairway 2-02,Attorney General,,D,AJ Kotich,98
-Johnson,Fairway 3-01,Attorney General,,D,AJ Kotich,130
-Johnson,Fairway 3-02,Attorney General,,D,AJ Kotich,92
-Johnson,Fairway 4-01,Attorney General,,D,AJ Kotich,57
-Johnson,Fairway 4-02,Attorney General,,D,AJ Kotich,68
-Johnson,Fairway 4-03,Attorney General,,D,AJ Kotich,42
-Johnson,Fairway 4-04,Attorney General,,D,AJ Kotich,68
-Johnson,Gardner 0-01,Attorney General,,D,AJ Kotich,250
-Johnson,Gardner 0-02,Attorney General,,D,AJ Kotich,42
-Johnson,Gardner 0-03,Attorney General,,D,AJ Kotich,171
-Johnson,Gardner 0-04,Attorney General,,D,AJ Kotich,162
-Johnson,Gardner 0-06,Attorney General,,D,AJ Kotich,177
-Johnson,Gardner 0-07,Attorney General,,D,AJ Kotich,9
-Johnson,Gardner 0-08,Attorney General,,D,AJ Kotich,8
-Johnson,Gardner 0-09,Attorney General,,D,AJ Kotich,236
-Johnson,Gardner 0-10,Attorney General,,D,AJ Kotich,132
-Johnson,Gardner 0-12,Attorney General,,D,AJ Kotich,7
-Johnson,Gardner 0-13,Attorney General,,D,AJ Kotich,171
-Johnson,Gardner 0-14,Attorney General,,D,AJ Kotich,134
-Johnson,Gardner Twp 0-01,Attorney General,,D,AJ Kotich,88
-Johnson,Gardner Twp 0-02,Attorney General,,D,AJ Kotich,79
-Johnson,Gardner Twp 0-04,Attorney General,,D,AJ Kotich,0
-Johnson,Gardner Twp 0-05,Attorney General,,D,AJ Kotich,0
-Johnson,Gardner Twp 0-07,Attorney General,,D,AJ Kotich,2
-Johnson,Gardner Twp 0-08,Attorney General,,D,AJ Kotich,3
-Johnson,Gardner Twp 0-09,Attorney General,,D,AJ Kotich,0
-Johnson,Gardner Twp 0-10,Attorney General,,D,AJ Kotich,0
-Johnson,Gardner Twp 0-11,Attorney General,,D,AJ Kotich,28
-Johnson,Gardner Twp 0-13,Attorney General,,D,AJ Kotich,1
-Johnson,Lake Quivira,Attorney General,,D,AJ Kotich,151
-Johnson,Leawood 1-01,Attorney General,,D,AJ Kotich,258
-Johnson,Leawood 1-02,Attorney General,,D,AJ Kotich,310
-Johnson,Leawood 1-03,Attorney General,,D,AJ Kotich,258
-Johnson,Leawood 1-04,Attorney General,,D,AJ Kotich,226
-Johnson,Leawood 1-05,Attorney General,,D,AJ Kotich,180
-Johnson,Leawood 1-06,Attorney General,,D,AJ Kotich,59
-Johnson,Leawood 2-01,Attorney General,,D,AJ Kotich,237
-Johnson,Leawood 2-02,Attorney General,,D,AJ Kotich,291
-Johnson,Leawood 2-03,Attorney General,,D,AJ Kotich,263
-Johnson,Leawood 2-04,Attorney General,,D,AJ Kotich,174
-Johnson,Leawood 2-05,Attorney General,,D,AJ Kotich,147
-Johnson,Leawood 2-06,Attorney General,,D,AJ Kotich,116
-Johnson,Leawood 3-01,Attorney General,,D,AJ Kotich,177
-Johnson,Leawood 3-02,Attorney General,,D,AJ Kotich,256
-Johnson,Leawood 3-03,Attorney General,,D,AJ Kotich,130
-Johnson,Leawood 3-04,Attorney General,,D,AJ Kotich,63
-Johnson,Leawood 3-05,Attorney General,,D,AJ Kotich,248
-Johnson,Leawood 3-06,Attorney General,,D,AJ Kotich,217
-Johnson,Leawood 3-07,Attorney General,,D,AJ Kotich,195
-Johnson,Leawood 4-01,Attorney General,,D,AJ Kotich,57
-Johnson,Leawood 4-02,Attorney General,,D,AJ Kotich,178
-Johnson,Leawood 4-03,Attorney General,,D,AJ Kotich,210
-Johnson,Leawood 4-04,Attorney General,,D,AJ Kotich,221
-Johnson,Leawood 4-05,Attorney General,,D,AJ Kotich,231
-Johnson,Leawood 4-06,Attorney General,,D,AJ Kotich,110
-Johnson,Leawood 4-07,Attorney General,,D,AJ Kotich,214
-Johnson,Leawood 4-08,Attorney General,,D,AJ Kotich,110
-Johnson,Lenexa 1-01,Attorney General,,D,AJ Kotich,127
-Johnson,Lenexa 1-02,Attorney General,,D,AJ Kotich,293
-Johnson,Lenexa 1-03,Attorney General,,D,AJ Kotich,340
-Johnson,Lenexa 1-04,Attorney General,,D,AJ Kotich,236
-Johnson,Lenexa 1-05,Attorney General,,D,AJ Kotich,236
-Johnson,Lenexa 1-06,Attorney General,,D,AJ Kotich,232
-Johnson,Lenexa 1-07,Attorney General,,D,AJ Kotich,163
-Johnson,Lenexa 1-08,Attorney General,,D,AJ Kotich,74
-Johnson,Lenexa 1-09,Attorney General,,D,AJ Kotich,5
-Johnson,Lenexa 2-01,Attorney General,,D,AJ Kotich,289
-Johnson,Lenexa 2-02,Attorney General,,D,AJ Kotich,91
-Johnson,Lenexa 2-03,Attorney General,,D,AJ Kotich,215
-Johnson,Lenexa 2-04,Attorney General,,D,AJ Kotich,152
-Johnson,Lenexa 2-05,Attorney General,,D,AJ Kotich,233
-Johnson,Lenexa 2-06,Attorney General,,D,AJ Kotich,123
-Johnson,Lenexa 2-07,Attorney General,,D,AJ Kotich,318
-Johnson,Lenexa 3-01,Attorney General,,D,AJ Kotich,211
-Johnson,Lenexa 3-02,Attorney General,,D,AJ Kotich,356
-Johnson,Lenexa 3-03,Attorney General,,D,AJ Kotich,336
-Johnson,Lenexa 3-04,Attorney General,,D,AJ Kotich,206
-Johnson,Lenexa 3-05,Attorney General,,D,AJ Kotich,172
-Johnson,Lenexa 3-06,Attorney General,,D,AJ Kotich,216
-Johnson,Lenexa 3-07,Attorney General,,D,AJ Kotich,261
-Johnson,Lenexa 3-08,Attorney General,,D,AJ Kotich,264
-Johnson,Lenexa 4-01,Attorney General,,D,AJ Kotich,131
-Johnson,Lenexa 4-02,Attorney General,,D,AJ Kotich,233
-Johnson,Lenexa 4-03,Attorney General,,D,AJ Kotich,135
-Johnson,Lenexa 4-04,Attorney General,,D,AJ Kotich,111
-Johnson,Lenexa 4-05,Attorney General,,D,AJ Kotich,127
-Johnson,Lenexa 4-06,Attorney General,,D,AJ Kotich,165
-Johnson,Lenexa 4-07,Attorney General,,D,AJ Kotich,202
-Johnson,Lenexa 4-08,Attorney General,,D,AJ Kotich,220
-Johnson,Lenexa 4-09,Attorney General,,D,AJ Kotich,210
-Johnson,Lenexa 4-10,Attorney General,,D,AJ Kotich,116
-Johnson,Lenexa 4-11,Attorney General,,D,AJ Kotich,34
-Johnson,Lexington Twp 0-01,Attorney General,,D,AJ Kotich,159
-Johnson,Lexington Twp 0-02,Attorney General,,D,AJ Kotich,2
-Johnson,Lexington Twp 0-03,Attorney General,,D,AJ Kotich,1
-Johnson,McCamish Twp 0-01,Attorney General,,D,AJ Kotich,30
-Johnson,McCamish Twp 0-02,Attorney General,,D,AJ Kotich,66
-Johnson,Merriam 1-01,Attorney General,,D,AJ Kotich,163
-Johnson,Merriam 1-02,Attorney General,,D,AJ Kotich,210
-Johnson,Merriam 2-01,Attorney General,,D,AJ Kotich,236
-Johnson,Merriam 2-02,Attorney General,,D,AJ Kotich,2
-Johnson,Merriam 2-03,Attorney General,,D,AJ Kotich,132
-Johnson,Merriam 3-01,Attorney General,,D,AJ Kotich,224
-Johnson,Merriam 3-02,Attorney General,,D,AJ Kotich,209
-Johnson,Merriam 4-01,Attorney General,,D,AJ Kotich,253
-Johnson,Merriam 4-02,Attorney General,,D,AJ Kotich,129
-Johnson,Merriam 4-03,Attorney General,,D,AJ Kotich,167
-Johnson,Mission 1-01,Attorney General,,D,AJ Kotich,246
-Johnson,Mission 1-02,Attorney General,,D,AJ Kotich,144
-Johnson,Mission 2-01,Attorney General,,D,AJ Kotich,157
-Johnson,Mission 2-02,Attorney General,,D,AJ Kotich,227
-Johnson,Mission 3-01,Attorney General,,D,AJ Kotich,226
-Johnson,Mission 3-02,Attorney General,,D,AJ Kotich,138
-Johnson,Mission 4-01,Attorney General,,D,AJ Kotich,184
-Johnson,Mission 4-02,Attorney General,,D,AJ Kotich,236
-Johnson,Mission 4-03,Attorney General,,D,AJ Kotich,122
-Johnson,Mission Hills 0-01,Attorney General,,D,AJ Kotich,104
-Johnson,Mission Hills 0-02,Attorney General,,D,AJ Kotich,171
-Johnson,Mission Hills 0-03,Attorney General,,D,AJ Kotich,84
-Johnson,Mission Hills 0-04,Attorney General,,D,AJ Kotich,189
-Johnson,Mission Woods,Attorney General,,D,AJ Kotich,39
-Johnson,Olathe 1-01,Attorney General,,D,AJ Kotich,189
-Johnson,Olathe 1-02,Attorney General,,D,AJ Kotich,158
-Johnson,Olathe 1-03,Attorney General,,D,AJ Kotich,100
-Johnson,Olathe 1-04,Attorney General,,D,AJ Kotich,197
-Johnson,Olathe 1-05,Attorney General,,D,AJ Kotich,187
-Johnson,Olathe 1-06,Attorney General,,D,AJ Kotich,116
-Johnson,Olathe 1-08,Attorney General,,D,AJ Kotich,232
-Johnson,Olathe 1-09,Attorney General,,D,AJ Kotich,177
-Johnson,Olathe 1-11,Attorney General,,D,AJ Kotich,44
-Johnson,Olathe 1-14,Attorney General,,D,AJ Kotich,164
-Johnson,Olathe 1-15,Attorney General,,D,AJ Kotich,183
-Johnson,Olathe 1-16,Attorney General,,D,AJ Kotich,193
-Johnson,Olathe 1-17,Attorney General,,D,AJ Kotich,40
-Johnson,Olathe 1-18,Attorney General,,D,AJ Kotich,57
-Johnson,Olathe 1-19,Attorney General,,D,AJ Kotich,88
-Johnson,Olathe 1-20,Attorney General,,D,AJ Kotich,164
-Johnson,Olathe 1-21,Attorney General,,D,AJ Kotich,218
-Johnson,Olathe 1-22,Attorney General,,D,AJ Kotich,282
-Johnson,Olathe 1-23,Attorney General,,D,AJ Kotich,0
-Johnson,Olathe 1-24,Attorney General,,D,AJ Kotich,22
-Johnson,Olathe 1-24,Attorney General,,D,AJ Kotich,57
-Johnson,Olathe 1-26,Attorney General,,D,AJ Kotich,1
-Johnson,Olathe 1-27,Attorney General,,D,AJ Kotich,169
-Johnson,Olathe 2-01,Attorney General,,D,AJ Kotich,78
-Johnson,Olathe 2-02,Attorney General,,D,AJ Kotich,141
-Johnson,Olathe 2-03,Attorney General,,D,AJ Kotich,137
-Johnson,Olathe 2-04,Attorney General,,D,AJ Kotich,195
-Johnson,Olathe 2-05,Attorney General,,D,AJ Kotich,306
-Johnson,Olathe 2-06,Attorney General,,D,AJ Kotich,169
-Johnson,Olathe 2-07,Attorney General,,D,AJ Kotich,260
-Johnson,Olathe 2-08,Attorney General,,D,AJ Kotich,228
-Johnson,Olathe 2-09,Attorney General,,D,AJ Kotich,92
-Johnson,Olathe 2-10,Attorney General,,D,AJ Kotich,385
-Johnson,Olathe 2-11,Attorney General,,D,AJ Kotich,266
-Johnson,Olathe 2-12,Attorney General,,D,AJ Kotich,157
-Johnson,Olathe 2-13,Attorney General,,D,AJ Kotich,183
-Johnson,Olathe 2-14,Attorney General,,D,AJ Kotich,143
-Johnson,Olathe 2-15,Attorney General,,D,AJ Kotich,113
-Johnson,Olathe 2-16,Attorney General,,D,AJ Kotich,75
-Johnson,Olathe 2-17,Attorney General,,D,AJ Kotich,1
-Johnson,Olathe 2-19,Attorney General,,D,AJ Kotich,4
-Johnson,Olathe 2-22,Attorney General,,D,AJ Kotich,312
-Johnson,Olathe 2-23,Attorney General,,D,AJ Kotich,193
-Johnson,Olathe 3-01,Attorney General,,D,AJ Kotich,96
-Johnson,Olathe 3-02,Attorney General,,D,AJ Kotich,238
-Johnson,Olathe 3-03,Attorney General,,D,AJ Kotich,100
-Johnson,Olathe 3-04,Attorney General,,D,AJ Kotich,179
-Johnson,Olathe 3-05,Attorney General,,D,AJ Kotich,147
-Johnson,Olathe 3-06,Attorney General,,D,AJ Kotich,128
-Johnson,Olathe 3-07,Attorney General,,D,AJ Kotich,150
-Johnson,Olathe 3-08,Attorney General,,D,AJ Kotich,217
-Johnson,Olathe 3-09,Attorney General,,D,AJ Kotich,99
-Johnson,Olathe 3-10,Attorney General,,D,AJ Kotich,193
-Johnson,Olathe 3-11,Attorney General,,D,AJ Kotich,144
-Johnson,Olathe 3-12,Attorney General,,D,AJ Kotich,196
-Johnson,Olathe 3-13,Attorney General,,D,AJ Kotich,201
-Johnson,Olathe 3-15,Attorney General,,D,AJ Kotich,145
-Johnson,Olathe 3-16,Attorney General,,D,AJ Kotich,164
-Johnson,Olathe 3-17,Attorney General,,D,AJ Kotich,187
-Johnson,Olathe 3-18,Attorney General,,D,AJ Kotich,172
-Johnson,Olathe 3-19,Attorney General,,D,AJ Kotich,84
-Johnson,Olathe 3-20,Attorney General,,D,AJ Kotich,119
-Johnson,Olathe 3-21,Attorney General,,D,AJ Kotich,91
-Johnson,Olathe 3-22,Attorney General,,D,AJ Kotich,176
-Johnson,Olathe 3-23,Attorney General,,D,AJ Kotich,175
-Johnson,Olathe 3-24,Attorney General,,D,AJ Kotich,97
-Johnson,Olathe 3-26,Attorney General,,D,AJ Kotich,24
-Johnson,Olathe 4-01,Attorney General,,D,AJ Kotich,175
-Johnson,Olathe 4-02,Attorney General,,D,AJ Kotich,302
-Johnson,Olathe 4-03,Attorney General,,D,AJ Kotich,133
-Johnson,Olathe 4-04,Attorney General,,D,AJ Kotich,117
-Johnson,Olathe 4-05,Attorney General,,D,AJ Kotich,230
-Johnson,Olathe 4-06,Attorney General,,D,AJ Kotich,270
-Johnson,Olathe 4-07,Attorney General,,D,AJ Kotich,242
-Johnson,Olathe 4-08,Attorney General,,D,AJ Kotich,171
-Johnson,Olathe 4-09,Attorney General,,D,AJ Kotich,258
-Johnson,Olathe 4-10,Attorney General,,D,AJ Kotich,139
-Johnson,Olathe 4-11,Attorney General,,D,AJ Kotich,123
-Johnson,Olathe 4-12,Attorney General,,D,AJ Kotich,216
-Johnson,Olathe 4-13,Attorney General,,D,AJ Kotich,126
-Johnson,Olathe 4-14,Attorney General,,D,AJ Kotich,242
-Johnson,Olathe 4-15,Attorney General,,D,AJ Kotich,14
-Johnson,Olathe 4-16,Attorney General,,D,AJ Kotich,90
-Johnson,Olathe 4-17,Attorney General,,D,AJ Kotich,0
-Johnson,Olathe Twp 0-01,Attorney General,,D,AJ Kotich,89
-Johnson,Olathe Twp 0-02,Attorney General,,D,AJ Kotich,11
-Johnson,Olathe Twp 0-03,Attorney General,,D,AJ Kotich,14
-Johnson,Olathe Twp 0-04,Attorney General,,D,AJ Kotich,0
-Johnson,Olathe Twp 0-05,Attorney General,,D,AJ Kotich,0
-Johnson,Olathe Twp 0-06,Attorney General,,D,AJ Kotich,0
-Johnson,Olathe Twp 0-07,Attorney General,,D,AJ Kotich,0
-Johnson,Olathe Twp 0-08,Attorney General,,D,AJ Kotich,2
-Johnson,Olathe Twp 0-10,Attorney General,,D,AJ Kotich,2
-Johnson,Olathe Twp 0-11,Attorney General,,D,AJ Kotich,1
-Johnson,Olathe Twp 0-14,Attorney General,,D,AJ Kotich,0
-Johnson,Olathe Twp 0-24,Attorney General,,D,AJ Kotich,1
-Johnson,Olathe Twp 0-25,Attorney General,,D,AJ Kotich,1
-Johnson,Olathe Twp 0-26,Attorney General,,D,AJ Kotich,0
-Johnson,Olathe Twp 0-32,Attorney General,,D,AJ Kotich,8
-Johnson,Overland Park 1-01,Attorney General,,D,AJ Kotich,247
-Johnson,Overland Park 1-02,Attorney General,,D,AJ Kotich,273
-Johnson,Overland Park 1-03,Attorney General,,D,AJ Kotich,223
-Johnson,Overland Park 1-04,Attorney General,,D,AJ Kotich,73
-Johnson,Overland Park 1-05,Attorney General,,D,AJ Kotich,171
-Johnson,Overland Park 1-06,Attorney General,,D,AJ Kotich,331
-Johnson,Overland Park 1-07,Attorney General,,D,AJ Kotich,267
-Johnson,Overland Park 1-08,Attorney General,,D,AJ Kotich,193
-Johnson,Overland Park 1-09,Attorney General,,D,AJ Kotich,130
-Johnson,Overland Park 1-10,Attorney General,,D,AJ Kotich,251
-Johnson,Overland Park 1-11,Attorney General,,D,AJ Kotich,71
-Johnson,Overland Park 1-12,Attorney General,,D,AJ Kotich,215
-Johnson,Overland Park 1-13,Attorney General,,D,AJ Kotich,156
-Johnson,Overland Park 1-14,Attorney General,,D,AJ Kotich,232
-Johnson,Overland Park 1-15,Attorney General,,D,AJ Kotich,127
-Johnson,Overland Park 1-16,Attorney General,,D,AJ Kotich,305
-Johnson,Overland Park 1-17,Attorney General,,D,AJ Kotich,119
-Johnson,Overland Park 1-18,Attorney General,,D,AJ Kotich,237
-Johnson,Overland Park 1-19,Attorney General,,D,AJ Kotich,181
-Johnson,Overland Park 1-20,Attorney General,,D,AJ Kotich,150
-Johnson,Overland Park 1-21,Attorney General,,D,AJ Kotich,55
-Johnson,Overland Park 1-22,Attorney General,,D,AJ Kotich,68
-Johnson,Overland Park 2-01,Attorney General,,D,AJ Kotich,180
-Johnson,Overland Park 2-02,Attorney General,,D,AJ Kotich,231
-Johnson,Overland Park 2-03,Attorney General,,D,AJ Kotich,199
-Johnson,Overland Park 2-04,Attorney General,,D,AJ Kotich,236
-Johnson,Overland Park 2-05,Attorney General,,D,AJ Kotich,203
-Johnson,Overland Park 2-06,Attorney General,,D,AJ Kotich,184
-Johnson,Overland Park 2-07,Attorney General,,D,AJ Kotich,168
-Johnson,Overland Park 2-08,Attorney General,,D,AJ Kotich,142
-Johnson,Overland Park 2-09,Attorney General,,D,AJ Kotich,161
-Johnson,Overland Park 2-10,Attorney General,,D,AJ Kotich,92
-Johnson,Overland Park 2-11,Attorney General,,D,AJ Kotich,194
-Johnson,Overland Park 2-12,Attorney General,,D,AJ Kotich,135
-Johnson,Overland Park 2-13,Attorney General,,D,AJ Kotich,95
-Johnson,Overland Park 2-14,Attorney General,,D,AJ Kotich,158
-Johnson,Overland Park 2-15,Attorney General,,D,AJ Kotich,301
-Johnson,Overland Park 2-16,Attorney General,,D,AJ Kotich,178
-Johnson,Overland Park 2-17,Attorney General,,D,AJ Kotich,221
-Johnson,Overland Park 2-18,Attorney General,,D,AJ Kotich,263
-Johnson,Overland Park 2-19,Attorney General,,D,AJ Kotich,169
-Johnson,Overland Park 2-20,Attorney General,,D,AJ Kotich,156
-Johnson,Overland Park 2-21,Attorney General,,D,AJ Kotich,181
-Johnson,Overland Park 2-22,Attorney General,,D,AJ Kotich,199
-Johnson,Overland Park 2-23,Attorney General,,D,AJ Kotich,164
-Johnson,Overland Park 2-24,Attorney General,,D,AJ Kotich,273
-Johnson,Overland Park 2-25,Attorney General,,D,AJ Kotich,258
-Johnson,Overland Park 2-26,Attorney General,,D,AJ Kotich,101
-Johnson,Overland Park 3-01,Attorney General,,D,AJ Kotich,263
-Johnson,Overland Park 3-02,Attorney General,,D,AJ Kotich,210
-Johnson,Overland Park 3-03,Attorney General,,D,AJ Kotich,181
-Johnson,Overland Park 3-04,Attorney General,,D,AJ Kotich,261
-Johnson,Overland Park 3-05,Attorney General,,D,AJ Kotich,235
-Johnson,Overland Park 3-06,Attorney General,,D,AJ Kotich,262
-Johnson,Overland Park 3-07,Attorney General,,D,AJ Kotich,203
-Johnson,Overland Park 3-08,Attorney General,,D,AJ Kotich,177
-Johnson,Overland Park 3-09,Attorney General,,D,AJ Kotich,306
-Johnson,Overland Park 3-10,Attorney General,,D,AJ Kotich,144
-Johnson,Overland Park 3-11,Attorney General,,D,AJ Kotich,180
-Johnson,Overland Park 3-12,Attorney General,,D,AJ Kotich,161
-Johnson,Overland Park 3-13,Attorney General,,D,AJ Kotich,316
-Johnson,Overland Park 3-14,Attorney General,,D,AJ Kotich,252
-Johnson,Overland Park 3-15,Attorney General,,D,AJ Kotich,127
-Johnson,Overland Park 3-16,Attorney General,,D,AJ Kotich,216
-Johnson,Overland Park 3-17,Attorney General,,D,AJ Kotich,171
-Johnson,Overland Park 3-18,Attorney General,,D,AJ Kotich,194
-Johnson,Overland Park 3-19,Attorney General,,D,AJ Kotich,206
-Johnson,Overland Park 3-20,Attorney General,,D,AJ Kotich,258
-Johnson,Overland Park 3-21,Attorney General,,D,AJ Kotich,171
-Johnson,Overland Park 4-01,Attorney General,,D,AJ Kotich,115
-Johnson,Overland Park 4-02,Attorney General,,D,AJ Kotich,169
-Johnson,Overland Park 4-03,Attorney General,,D,AJ Kotich,166
-Johnson,Overland Park 4-04,Attorney General,,D,AJ Kotich,266
-Johnson,Overland Park 4-05,Attorney General,,D,AJ Kotich,189
-Johnson,Overland Park 4-06,Attorney General,,D,AJ Kotich,177
-Johnson,Overland Park 4-07,Attorney General,,D,AJ Kotich,166
-Johnson,Overland Park 4-08,Attorney General,,D,AJ Kotich,181
-Johnson,Overland Park 4-09,Attorney General,,D,AJ Kotich,115
-Johnson,Overland Park 4-10,Attorney General,,D,AJ Kotich,106
-Johnson,Overland Park 4-11,Attorney General,,D,AJ Kotich,236
-Johnson,Overland Park 4-12,Attorney General,,D,AJ Kotich,327
-Johnson,Overland Park 4-13,Attorney General,,D,AJ Kotich,101
-Johnson,Overland Park 4-14,Attorney General,,D,AJ Kotich,110
-Johnson,Overland Park 4-15,Attorney General,,D,AJ Kotich,261
-Johnson,Overland Park 4-16,Attorney General,,D,AJ Kotich,138
-Johnson,Overland Park 4-17,Attorney General,,D,AJ Kotich,253
-Johnson,Overland Park 4-18,Attorney General,,D,AJ Kotich,40
-Johnson,Overland Park 5-01,Attorney General,,D,AJ Kotich,232
-Johnson,Overland Park 5-02,Attorney General,,D,AJ Kotich,116
-Johnson,Overland Park 5-03,Attorney General,,D,AJ Kotich,192
-Johnson,Overland Park 5-04,Attorney General,,D,AJ Kotich,208
-Johnson,Overland Park 5-05,Attorney General,,D,AJ Kotich,193
-Johnson,Overland Park 5-06,Attorney General,,D,AJ Kotich,171
-Johnson,Overland Park 5-07,Attorney General,,D,AJ Kotich,172
-Johnson,Overland Park 5-08,Attorney General,,D,AJ Kotich,264
-Johnson,Overland Park 5-09,Attorney General,,D,AJ Kotich,309
-Johnson,Overland Park 5-10,Attorney General,,D,AJ Kotich,213
-Johnson,Overland Park 5-11,Attorney General,,D,AJ Kotich,298
-Johnson,Overland Park 5-12,Attorney General,,D,AJ Kotich,63
-Johnson,Overland Park 5-13,Attorney General,,D,AJ Kotich,334
-Johnson,Overland Park 5-14,Attorney General,,D,AJ Kotich,228
-Johnson,Overland Park 5-15,Attorney General,,D,AJ Kotich,186
-Johnson,Overland Park 5-16,Attorney General,,D,AJ Kotich,117
-Johnson,Overland Park 5-17,Attorney General,,D,AJ Kotich,90
-Johnson,Overland Park 5-18,Attorney General,,D,AJ Kotich,169
-Johnson,Overland Park 5-19,Attorney General,,D,AJ Kotich,18
-Johnson,Overland Park 6-01,Attorney General,,D,AJ Kotich,203
-Johnson,Overland Park 6-02,Attorney General,,D,AJ Kotich,167
-Johnson,Overland Park 6-03,Attorney General,,D,AJ Kotich,177
-Johnson,Overland Park 6-04,Attorney General,,D,AJ Kotich,160
-Johnson,Overland Park 6-05,Attorney General,,D,AJ Kotich,246
-Johnson,Overland Park 6-06,Attorney General,,D,AJ Kotich,0
-Johnson,Overland Park 6-07,Attorney General,,D,AJ Kotich,38
-Johnson,Overland Park 6-08,Attorney General,,D,AJ Kotich,192
-Johnson,Overland Park 6-09,Attorney General,,D,AJ Kotich,250
-Johnson,Overland Park 6-10,Attorney General,,D,AJ Kotich,172
-Johnson,Overland Park 6-11,Attorney General,,D,AJ Kotich,175
-Johnson,Overland Park 6-12,Attorney General,,D,AJ Kotich,69
-Johnson,Overland Park 6-13,Attorney General,,D,AJ Kotich,221
-Johnson,Overland Park 6-15,Attorney General,,D,AJ Kotich,205
-Johnson,Overland Park 6-16,Attorney General,,D,AJ Kotich,107
-Johnson,Overland Park 6-17,Attorney General,,D,AJ Kotich,41
-Johnson,Overland Park 6-18,Attorney General,,D,AJ Kotich,0
-Johnson,Overland Park 6-19,Attorney General,,D,AJ Kotich,252
-Johnson,Overland Park 6-20,Attorney General,,D,AJ Kotich,66
-Johnson,Overland Park 6-21,Attorney General,,D,AJ Kotich,174
-Johnson,Overland Park 6-22,Attorney General,,D,AJ Kotich,79
-Johnson,Oxford Twp 0-01,Attorney General,,D,AJ Kotich,2
-Johnson,Oxford Twp 0-02,Attorney General,,D,AJ Kotich,112
-Johnson,Oxford Twp 0-04,Attorney General,,D,AJ Kotich,107
-Johnson,Oxford Twp 0-05,Attorney General,,D,AJ Kotich,0
-Johnson,Oxford Twp 0-09,Attorney General,,D,AJ Kotich,3
-Johnson,Oxford Twp 0-10,Attorney General,,D,AJ Kotich,0
-Johnson,Oxford Twp 0-11,Attorney General,,D,AJ Kotich,19
-Johnson,Prairie Village 1-01,Attorney General,,D,AJ Kotich,344
-Johnson,Prairie Village 1-02,Attorney General,,D,AJ Kotich,248
-Johnson,Prairie Village 1-03,Attorney General,,D,AJ Kotich,355
-Johnson,Prairie Village 2-01,Attorney General,,D,AJ Kotich,286
-Johnson,Prairie Village 2-02,Attorney General,,D,AJ Kotich,124
-Johnson,Prairie Village 2-03,Attorney General,,D,AJ Kotich,256
-Johnson,Prairie Village 3-01,Attorney General,,D,AJ Kotich,186
-Johnson,Prairie Village 3-02,Attorney General,,D,AJ Kotich,274
-Johnson,Prairie Village 3-03,Attorney General,,D,AJ Kotich,261
-Johnson,Prairie Village 4-01,Attorney General,,D,AJ Kotich,257
-Johnson,Prairie Village 4-02,Attorney General,,D,AJ Kotich,196
-Johnson,Prairie Village 4-03,Attorney General,,D,AJ Kotich,308
-Johnson,Prairie Village 5-01,Attorney General,,D,AJ Kotich,286
-Johnson,Prairie Village 5-02,Attorney General,,D,AJ Kotich,271
-Johnson,Prairie Village 5-03,Attorney General,,D,AJ Kotich,196
-Johnson,Prairie Village 6-01,Attorney General,,D,AJ Kotich,314
-Johnson,Prairie Village 6-02,Attorney General,,D,AJ Kotich,309
-Johnson,Prairie Village 6-03,Attorney General,,D,AJ Kotich,174
-Johnson,Roeland Park 1-01,Attorney General,,D,AJ Kotich,136
-Johnson,Roeland Park 1-02,Attorney General,,D,AJ Kotich,116
-Johnson,Roeland Park 2-01,Attorney General,,D,AJ Kotich,157
-Johnson,Roeland Park 2-02,Attorney General,,D,AJ Kotich,190
-Johnson,Roeland Park 3-01,Attorney General,,D,AJ Kotich,143
-Johnson,Roeland Park 3-02,Attorney General,,D,AJ Kotich,267
-Johnson,Roeland Park 4-01,Attorney General,,D,AJ Kotich,98
-Johnson,Roeland Park 4-02,Attorney General,,D,AJ Kotich,320
-Johnson,Shawnee 1-01,Attorney General,,D,AJ Kotich,290
-Johnson,Shawnee 1-02,Attorney General,,D,AJ Kotich,204
-Johnson,Shawnee 1-03,Attorney General,,D,AJ Kotich,198
-Johnson,Shawnee 1-04,Attorney General,,D,AJ Kotich,265
-Johnson,Shawnee 1-05,Attorney General,,D,AJ Kotich,334
-Johnson,Shawnee 1-06,Attorney General,,D,AJ Kotich,204
-Johnson,Shawnee 1-07,Attorney General,,D,AJ Kotich,249
-Johnson,Shawnee 1-08,Attorney General,,D,AJ Kotich,227
-Johnson,Shawnee 1-09,Attorney General,,D,AJ Kotich,51
-Johnson,Shawnee 1-10,Attorney General,,D,AJ Kotich,68
-Johnson,Shawnee 1-11,Attorney General,,D,AJ Kotich,136
-Johnson,Shawnee 1-12,Attorney General,,D,AJ Kotich,2
-Johnson,Shawnee 2-01,Attorney General,,D,AJ Kotich,101
-Johnson,Shawnee 2-02,Attorney General,,D,AJ Kotich,225
-Johnson,Shawnee 2-03,Attorney General,,D,AJ Kotich,182
-Johnson,Shawnee 2-04,Attorney General,,D,AJ Kotich,283
-Johnson,Shawnee 2-05,Attorney General,,D,AJ Kotich,123
-Johnson,Shawnee 2-06,Attorney General,,D,AJ Kotich,168
-Johnson,Shawnee 2-07,Attorney General,,D,AJ Kotich,144
-Johnson,Shawnee 2-08,Attorney General,,D,AJ Kotich,134
-Johnson,Shawnee 2-09,Attorney General,,D,AJ Kotich,140
-Johnson,Shawnee 2-10,Attorney General,,D,AJ Kotich,133
-Johnson,Shawnee 2-11,Attorney General,,D,AJ Kotich,190
-Johnson,Shawnee 2-12,Attorney General,,D,AJ Kotich,73
-Johnson,Shawnee 2-13,Attorney General,,D,AJ Kotich,104
-Johnson,Shawnee 3-01,Attorney General,,D,AJ Kotich,115
-Johnson,Shawnee 3-02,Attorney General,,D,AJ Kotich,235
-Johnson,Shawnee 3-03,Attorney General,,D,AJ Kotich,211
-Johnson,Shawnee 3-04,Attorney General,,D,AJ Kotich,163
-Johnson,Shawnee 3-05,Attorney General,,D,AJ Kotich,216
-Johnson,Shawnee 3-06,Attorney General,,D,AJ Kotich,207
-Johnson,Shawnee 3-07,Attorney General,,D,AJ Kotich,221
-Johnson,Shawnee 3-08,Attorney General,,D,AJ Kotich,212
-Johnson,Shawnee 3-09,Attorney General,,D,AJ Kotich,99
-Johnson,Shawnee 4-01,Attorney General,,D,AJ Kotich,283
-Johnson,Shawnee 4-02,Attorney General,,D,AJ Kotich,159
-Johnson,Shawnee 4-03,Attorney General,,D,AJ Kotich,70
-Johnson,Shawnee 4-04,Attorney General,,D,AJ Kotich,114
-Johnson,Shawnee 4-05,Attorney General,,D,AJ Kotich,257
-Johnson,Shawnee 4-06,Attorney General,,D,AJ Kotich,183
-Johnson,Shawnee 4-07,Attorney General,,D,AJ Kotich,246
-Johnson,Shawnee 4-08,Attorney General,,D,AJ Kotich,90
-Johnson,Shawnee 4-09,Attorney General,,D,AJ Kotich,337
-Johnson,Shawnee 4-11,Attorney General,,D,AJ Kotich,178
-Johnson,Shawnee 4-12,Attorney General,,D,AJ Kotich,31
-Johnson,Spring Hill 0-01,Attorney General,,D,AJ Kotich,280
-Johnson,Spring Hill 0-03,Attorney General,,D,AJ Kotich,17
-Johnson,Spring Hill 0-04,Attorney General,,D,AJ Kotich,0
-Johnson,Spring Hill Twp 0-01,Attorney General,,D,AJ Kotich,191
-Johnson,Spring Hill Twp 0-02,Attorney General,,D,AJ Kotich,1
-Johnson,Spring Hill Twp 0-03,Attorney General,,D,AJ Kotich,16
-Johnson,Spring Hill Twp 0-04,Attorney General,,D,AJ Kotich,2
-Johnson,Spring Hill Twp 0-05,Attorney General,,D,AJ Kotich,5
-Johnson,Westwood 0-01,Attorney General,,D,AJ Kotich,195
-Johnson,Westwood 0-02,Attorney General,,D,AJ Kotich,177
-Johnson,Westwood Hills 0-01,Attorney General,,D,AJ Kotich,104
-COUNTY,PRECINCT,State Treasurer,,,,ESTES R
-Johnson,Aubry Twp 0-01,State Treasurer,,R,Ron Estes,76
-Johnson,Aubry Twp 0-02,State Treasurer,,R,Ron Estes,438
-Johnson,Aubry Twp 0-03,State Treasurer,,R,Ron Estes,221
-Johnson,Aubry Twp 0-04,State Treasurer,,R,Ron Estes,522
-Johnson,Aubry Twp 0-05,State Treasurer,,R,Ron Estes,9
-Johnson,Aubry Twp 0-06,State Treasurer,,R,Ron Estes,69
-Johnson,De Soto 0-01,State Treasurer,,R,Ron Estes,428
-Johnson,De Soto 0-02,State Treasurer,,R,Ron Estes,240
-Johnson,De Soto 0-03,State Treasurer,,R,Ron Estes,444
-Johnson,De Soto 0-06,State Treasurer,,R,Ron Estes,31
-Johnson,De Soto 0-07,State Treasurer,,R,Ron Estes,2
-Johnson,Edgerton,State Treasurer,,R,Ron Estes,267
-Johnson,Fairway 1-01,State Treasurer,,R,Ron Estes,146
-Johnson,Fairway 1-02,State Treasurer,,R,Ron Estes,102
-Johnson,Fairway 2-01,State Treasurer,,R,Ron Estes,106
-Johnson,Fairway 2-02,State Treasurer,,R,Ron Estes,118
-Johnson,Fairway 3-01,State Treasurer,,R,Ron Estes,176
-Johnson,Fairway 3-02,State Treasurer,,R,Ron Estes,152
-Johnson,Fairway 4-01,State Treasurer,,R,Ron Estes,36
-Johnson,Fairway 4-02,State Treasurer,,R,Ron Estes,55
-Johnson,Fairway 4-03,State Treasurer,,R,Ron Estes,36
-Johnson,Fairway 4-04,State Treasurer,,R,Ron Estes,51
-Johnson,Gardner 0-01,State Treasurer,,R,Ron Estes,524
-Johnson,Gardner 0-02,State Treasurer,,R,Ron Estes,70
-Johnson,Gardner 0-03,State Treasurer,,R,Ron Estes,305
-Johnson,Gardner 0-04,State Treasurer,,R,Ron Estes,302
-Johnson,Gardner 0-06,State Treasurer,,R,Ron Estes,399
-Johnson,Gardner 0-07,State Treasurer,,R,Ron Estes,6
-Johnson,Gardner 0-08,State Treasurer,,R,Ron Estes,38
-Johnson,Gardner 0-09,State Treasurer,,R,Ron Estes,421
-Johnson,Gardner 0-10,State Treasurer,,R,Ron Estes,285
-Johnson,Gardner 0-12,State Treasurer,,R,Ron Estes,7
-Johnson,Gardner 0-13,State Treasurer,,R,Ron Estes,296
-Johnson,Gardner 0-14,State Treasurer,,R,Ron Estes,257
-Johnson,Gardner Twp 0-01,State Treasurer,,R,Ron Estes,217
-Johnson,Gardner Twp 0-02,State Treasurer,,R,Ron Estes,254
-Johnson,Gardner Twp 0-04,State Treasurer,,R,Ron Estes,2
-Johnson,Gardner Twp 0-05,State Treasurer,,R,Ron Estes,5
-Johnson,Gardner Twp 0-07,State Treasurer,,R,Ron Estes,2
-Johnson,Gardner Twp 0-08,State Treasurer,,R,Ron Estes,2
-Johnson,Gardner Twp 0-09,State Treasurer,,R,Ron Estes,0
-Johnson,Gardner Twp 0-10,State Treasurer,,R,Ron Estes,0
-Johnson,Gardner Twp 0-11,State Treasurer,,R,Ron Estes,57
-Johnson,Gardner Twp 0-13,State Treasurer,,R,Ron Estes,2
-Johnson,Lake Quivira,State Treasurer,,R,Ron Estes,371
-Johnson,Leawood 1-01,State Treasurer,,R,Ron Estes,258
-Johnson,Leawood 1-02,State Treasurer,,R,Ron Estes,501
-Johnson,Leawood 1-03,State Treasurer,,R,Ron Estes,416
-Johnson,Leawood 1-04,State Treasurer,,R,Ron Estes,319
-Johnson,Leawood 1-05,State Treasurer,,R,Ron Estes,292
-Johnson,Leawood 1-06,State Treasurer,,R,Ron Estes,62
-Johnson,Leawood 2-01,State Treasurer,,R,Ron Estes,387
-Johnson,Leawood 2-02,State Treasurer,,R,Ron Estes,438
-Johnson,Leawood 2-03,State Treasurer,,R,Ron Estes,466
-Johnson,Leawood 2-04,State Treasurer,,R,Ron Estes,573
-Johnson,Leawood 2-05,State Treasurer,,R,Ron Estes,272
-Johnson,Leawood 2-06,State Treasurer,,R,Ron Estes,209
-Johnson,Leawood 3-01,State Treasurer,,R,Ron Estes,256
-Johnson,Leawood 3-02,State Treasurer,,R,Ron Estes,427
-Johnson,Leawood 3-03,State Treasurer,,R,Ron Estes,292
-Johnson,Leawood 3-04,State Treasurer,,R,Ron Estes,118
-Johnson,Leawood 3-05,State Treasurer,,R,Ron Estes,556
-Johnson,Leawood 3-06,State Treasurer,,R,Ron Estes,604
-Johnson,Leawood 3-07,State Treasurer,,R,Ron Estes,409
-Johnson,Leawood 4-01,State Treasurer,,R,Ron Estes,149
-Johnson,Leawood 4-02,State Treasurer,,R,Ron Estes,426
-Johnson,Leawood 4-03,State Treasurer,,R,Ron Estes,354
-Johnson,Leawood 4-04,State Treasurer,,R,Ron Estes,460
-Johnson,Leawood 4-05,State Treasurer,,R,Ron Estes,472
-Johnson,Leawood 4-06,State Treasurer,,R,Ron Estes,409
-Johnson,Leawood 4-07,State Treasurer,,R,Ron Estes,626
-Johnson,Leawood 4-08,State Treasurer,,R,Ron Estes,293
-Johnson,Lenexa 1-01,State Treasurer,,R,Ron Estes,245
-Johnson,Lenexa 1-02,State Treasurer,,R,Ron Estes,443
-Johnson,Lenexa 1-03,State Treasurer,,R,Ron Estes,512
-Johnson,Lenexa 1-04,State Treasurer,,R,Ron Estes,314
-Johnson,Lenexa 1-05,State Treasurer,,R,Ron Estes,354
-Johnson,Lenexa 1-06,State Treasurer,,R,Ron Estes,474
-Johnson,Lenexa 1-07,State Treasurer,,R,Ron Estes,220
-Johnson,Lenexa 1-08,State Treasurer,,R,Ron Estes,94
-Johnson,Lenexa 1-09,State Treasurer,,R,Ron Estes,7
-Johnson,Lenexa 2-01,State Treasurer,,R,Ron Estes,652
-Johnson,Lenexa 2-02,State Treasurer,,R,Ron Estes,256
-Johnson,Lenexa 2-03,State Treasurer,,R,Ron Estes,552
-Johnson,Lenexa 2-04,State Treasurer,,R,Ron Estes,617
-Johnson,Lenexa 2-05,State Treasurer,,R,Ron Estes,268
-Johnson,Lenexa 2-06,State Treasurer,,R,Ron Estes,391
-Johnson,Lenexa 2-07,State Treasurer,,R,Ron Estes,566
-Johnson,Lenexa 3-01,State Treasurer,,R,Ron Estes,224
-Johnson,Lenexa 3-02,State Treasurer,,R,Ron Estes,379
-Johnson,Lenexa 3-03,State Treasurer,,R,Ron Estes,533
-Johnson,Lenexa 3-04,State Treasurer,,R,Ron Estes,356
-Johnson,Lenexa 3-05,State Treasurer,,R,Ron Estes,156
-Johnson,Lenexa 3-06,State Treasurer,,R,Ron Estes,273
-Johnson,Lenexa 3-07,State Treasurer,,R,Ron Estes,413
-Johnson,Lenexa 3-08,State Treasurer,,R,Ron Estes,447
-Johnson,Lenexa 4-01,State Treasurer,,R,Ron Estes,157
-Johnson,Lenexa 4-02,State Treasurer,,R,Ron Estes,363
-Johnson,Lenexa 4-03,State Treasurer,,R,Ron Estes,110
-Johnson,Lenexa 4-04,State Treasurer,,R,Ron Estes,168
-Johnson,Lenexa 4-05,State Treasurer,,R,Ron Estes,130
-Johnson,Lenexa 4-06,State Treasurer,,R,Ron Estes,226
-Johnson,Lenexa 4-07,State Treasurer,,R,Ron Estes,297
-Johnson,Lenexa 4-08,State Treasurer,,R,Ron Estes,377
-Johnson,Lenexa 4-09,State Treasurer,,R,Ron Estes,323
-Johnson,Lenexa 4-10,State Treasurer,,R,Ron Estes,152
-Johnson,Lenexa 4-11,State Treasurer,,R,Ron Estes,36
-Johnson,Lexington Twp 0-01,State Treasurer,,R,Ron Estes,430
-Johnson,Lexington Twp 0-02,State Treasurer,,R,Ron Estes,2
-Johnson,Lexington Twp 0-03,State Treasurer,,R,Ron Estes,1
-Johnson,McCamish Twp 0-01,State Treasurer,,R,Ron Estes,110
-Johnson,McCamish Twp 0-02,State Treasurer,,R,Ron Estes,221
-Johnson,Merriam 1-01,State Treasurer,,R,Ron Estes,158
-Johnson,Merriam 1-02,State Treasurer,,R,Ron Estes,186
-Johnson,Merriam 2-01,State Treasurer,,R,Ron Estes,278
-Johnson,Merriam 2-02,State Treasurer,,R,Ron Estes,0
-Johnson,Merriam 2-03,State Treasurer,,R,Ron Estes,119
-Johnson,Merriam 3-01,State Treasurer,,R,Ron Estes,194
-Johnson,Merriam 3-02,State Treasurer,,R,Ron Estes,205
-Johnson,Merriam 4-01,State Treasurer,,R,Ron Estes,294
-Johnson,Merriam 4-02,State Treasurer,,R,Ron Estes,111
-Johnson,Merriam 4-03,State Treasurer,,R,Ron Estes,146
-Johnson,Mission 1-01,State Treasurer,,R,Ron Estes,238
-Johnson,Mission 1-02,State Treasurer,,R,Ron Estes,95
-Johnson,Mission 2-01,State Treasurer,,R,Ron Estes,131
-Johnson,Mission 2-02,State Treasurer,,R,Ron Estes,188
-Johnson,Mission 3-01,State Treasurer,,R,Ron Estes,186
-Johnson,Mission 3-02,State Treasurer,,R,Ron Estes,112
-Johnson,Mission 4-01,State Treasurer,,R,Ron Estes,139
-Johnson,Mission 4-02,State Treasurer,,R,Ron Estes,273
-Johnson,Mission 4-03,State Treasurer,,R,Ron Estes,116
-Johnson,Mission Hills 0-01,State Treasurer,,R,Ron Estes,307
-Johnson,Mission Hills 0-02,State Treasurer,,R,Ron Estes,374
-Johnson,Mission Hills 0-03,State Treasurer,,R,Ron Estes,255
-Johnson,Mission Hills 0-04,State Treasurer,,R,Ron Estes,384
-Johnson,Mission Woods,State Treasurer,,R,Ron Estes,56
-Johnson,Olathe 1-01,State Treasurer,,R,Ron Estes,352
-Johnson,Olathe 1-02,State Treasurer,,R,Ron Estes,209
-Johnson,Olathe 1-03,State Treasurer,,R,Ron Estes,178
-Johnson,Olathe 1-04,State Treasurer,,R,Ron Estes,333
-Johnson,Olathe 1-05,State Treasurer,,R,Ron Estes,379
-Johnson,Olathe 1-06,State Treasurer,,R,Ron Estes,245
-Johnson,Olathe 1-08,State Treasurer,,R,Ron Estes,384
-Johnson,Olathe 1-09,State Treasurer,,R,Ron Estes,394
-Johnson,Olathe 1-11,State Treasurer,,R,Ron Estes,60
-Johnson,Olathe 1-14,State Treasurer,,R,Ron Estes,349
-Johnson,Olathe 1-15,State Treasurer,,R,Ron Estes,299
-Johnson,Olathe 1-16,State Treasurer,,R,Ron Estes,442
-Johnson,Olathe 1-17,State Treasurer,,R,Ron Estes,114
-Johnson,Olathe 1-18,State Treasurer,,R,Ron Estes,117
-Johnson,Olathe 1-19,State Treasurer,,R,Ron Estes,152
-Johnson,Olathe 1-20,State Treasurer,,R,Ron Estes,214
-Johnson,Olathe 1-21,State Treasurer,,R,Ron Estes,413
-Johnson,Olathe 1-22,State Treasurer,,R,Ron Estes,644
-Johnson,Olathe 1-23,State Treasurer,,R,Ron Estes,1
-Johnson,Olathe 1-24,State Treasurer,,R,Ron Estes,60
-Johnson,Olathe 1-24,State Treasurer,,R,Ron Estes,97
-Johnson,Olathe 1-26,State Treasurer,,R,Ron Estes,0
-Johnson,Olathe 1-27,State Treasurer,,R,Ron Estes,220
-Johnson,Olathe 2-01,State Treasurer,,R,Ron Estes,143
-Johnson,Olathe 2-02,State Treasurer,,R,Ron Estes,214
-Johnson,Olathe 2-03,State Treasurer,,R,Ron Estes,260
-Johnson,Olathe 2-04,State Treasurer,,R,Ron Estes,244
-Johnson,Olathe 2-05,State Treasurer,,R,Ron Estes,938
-Johnson,Olathe 2-06,State Treasurer,,R,Ron Estes,472
-Johnson,Olathe 2-07,State Treasurer,,R,Ron Estes,520
-Johnson,Olathe 2-08,State Treasurer,,R,Ron Estes,339
-Johnson,Olathe 2-09,State Treasurer,,R,Ron Estes,157
-Johnson,Olathe 2-10,State Treasurer,,R,Ron Estes,651
-Johnson,Olathe 2-11,State Treasurer,,R,Ron Estes,460
-Johnson,Olathe 2-12,State Treasurer,,R,Ron Estes,273
-Johnson,Olathe 2-13,State Treasurer,,R,Ron Estes,246
-Johnson,Olathe 2-14,State Treasurer,,R,Ron Estes,262
-Johnson,Olathe 2-15,State Treasurer,,R,Ron Estes,305
-Johnson,Olathe 2-16,State Treasurer,,R,Ron Estes,75
-Johnson,Olathe 2-17,State Treasurer,,R,Ron Estes,1
-Johnson,Olathe 2-19,State Treasurer,,R,Ron Estes,4
-Johnson,Olathe 2-22,State Treasurer,,R,Ron Estes,569
-Johnson,Olathe 2-23,State Treasurer,,R,Ron Estes,351
-Johnson,Olathe 3-01,State Treasurer,,R,Ron Estes,129
-Johnson,Olathe 3-02,State Treasurer,,R,Ron Estes,434
-Johnson,Olathe 3-03,State Treasurer,,R,Ron Estes,239
-Johnson,Olathe 3-04,State Treasurer,,R,Ron Estes,397
-Johnson,Olathe 3-05,State Treasurer,,R,Ron Estes,452
-Johnson,Olathe 3-06,State Treasurer,,R,Ron Estes,312
-Johnson,Olathe 3-07,State Treasurer,,R,Ron Estes,287
-Johnson,Olathe 3-08,State Treasurer,,R,Ron Estes,452
-Johnson,Olathe 3-09,State Treasurer,,R,Ron Estes,215
-Johnson,Olathe 3-10,State Treasurer,,R,Ron Estes,444
-Johnson,Olathe 3-11,State Treasurer,,R,Ron Estes,276
-Johnson,Olathe 3-12,State Treasurer,,R,Ron Estes,375
-Johnson,Olathe 3-13,State Treasurer,,R,Ron Estes,429
-Johnson,Olathe 3-15,State Treasurer,,R,Ron Estes,278
-Johnson,Olathe 3-16,State Treasurer,,R,Ron Estes,295
-Johnson,Olathe 3-17,State Treasurer,,R,Ron Estes,420
-Johnson,Olathe 3-18,State Treasurer,,R,Ron Estes,394
-Johnson,Olathe 3-19,State Treasurer,,R,Ron Estes,277
-Johnson,Olathe 3-20,State Treasurer,,R,Ron Estes,293
-Johnson,Olathe 3-21,State Treasurer,,R,Ron Estes,312
-Johnson,Olathe 3-22,State Treasurer,,R,Ron Estes,359
-Johnson,Olathe 3-23,State Treasurer,,R,Ron Estes,302
-Johnson,Olathe 3-24,State Treasurer,,R,Ron Estes,197
-Johnson,Olathe 3-26,State Treasurer,,R,Ron Estes,29
-Johnson,Olathe 4-01,State Treasurer,,R,Ron Estes,256
-Johnson,Olathe 4-02,State Treasurer,,R,Ron Estes,520
-Johnson,Olathe 4-03,State Treasurer,,R,Ron Estes,132
-Johnson,Olathe 4-04,State Treasurer,,R,Ron Estes,169
-Johnson,Olathe 4-05,State Treasurer,,R,Ron Estes,347
-Johnson,Olathe 4-06,State Treasurer,,R,Ron Estes,422
-Johnson,Olathe 4-07,State Treasurer,,R,Ron Estes,347
-Johnson,Olathe 4-08,State Treasurer,,R,Ron Estes,352
-Johnson,Olathe 4-09,State Treasurer,,R,Ron Estes,463
-Johnson,Olathe 4-10,State Treasurer,,R,Ron Estes,240
-Johnson,Olathe 4-11,State Treasurer,,R,Ron Estes,133
-Johnson,Olathe 4-12,State Treasurer,,R,Ron Estes,427
-Johnson,Olathe 4-13,State Treasurer,,R,Ron Estes,188
-Johnson,Olathe 4-14,State Treasurer,,R,Ron Estes,440
-Johnson,Olathe 4-15,State Treasurer,,R,Ron Estes,17
-Johnson,Olathe 4-16,State Treasurer,,R,Ron Estes,99
-Johnson,Olathe 4-17,State Treasurer,,R,Ron Estes,3
-Johnson,Olathe Twp 0-01,State Treasurer,,R,Ron Estes,171
-Johnson,Olathe Twp 0-02,State Treasurer,,R,Ron Estes,40
-Johnson,Olathe Twp 0-03,State Treasurer,,R,Ron Estes,24
-Johnson,Olathe Twp 0-04,State Treasurer,,R,Ron Estes,2
-Johnson,Olathe Twp 0-05,State Treasurer,,R,Ron Estes,2
-Johnson,Olathe Twp 0-06,State Treasurer,,R,Ron Estes,0
-Johnson,Olathe Twp 0-07,State Treasurer,,R,Ron Estes,1
-Johnson,Olathe Twp 0-08,State Treasurer,,R,Ron Estes,4
-Johnson,Olathe Twp 0-10,State Treasurer,,R,Ron Estes,9
-Johnson,Olathe Twp 0-11,State Treasurer,,R,Ron Estes,3
-Johnson,Olathe Twp 0-14,State Treasurer,,R,Ron Estes,1
-Johnson,Olathe Twp 0-24,State Treasurer,,R,Ron Estes,2
-Johnson,Olathe Twp 0-25,State Treasurer,,R,Ron Estes,7
-Johnson,Olathe Twp 0-26,State Treasurer,,R,Ron Estes,3
-Johnson,Olathe Twp 0-32,State Treasurer,,R,Ron Estes,17
-Johnson,Overland Park 1-01,State Treasurer,,R,Ron Estes,223
-Johnson,Overland Park 1-02,State Treasurer,,R,Ron Estes,217
-Johnson,Overland Park 1-03,State Treasurer,,R,Ron Estes,244
-Johnson,Overland Park 1-04,State Treasurer,,R,Ron Estes,92
-Johnson,Overland Park 1-05,State Treasurer,,R,Ron Estes,156
-Johnson,Overland Park 1-06,State Treasurer,,R,Ron Estes,308
-Johnson,Overland Park 1-07,State Treasurer,,R,Ron Estes,328
-Johnson,Overland Park 1-08,State Treasurer,,R,Ron Estes,200
-Johnson,Overland Park 1-09,State Treasurer,,R,Ron Estes,139
-Johnson,Overland Park 1-10,State Treasurer,,R,Ron Estes,281
-Johnson,Overland Park 1-11,State Treasurer,,R,Ron Estes,75
-Johnson,Overland Park 1-12,State Treasurer,,R,Ron Estes,217
-Johnson,Overland Park 1-13,State Treasurer,,R,Ron Estes,193
-Johnson,Overland Park 1-14,State Treasurer,,R,Ron Estes,245
-Johnson,Overland Park 1-15,State Treasurer,,R,Ron Estes,117
-Johnson,Overland Park 1-16,State Treasurer,,R,Ron Estes,275
-Johnson,Overland Park 1-17,State Treasurer,,R,Ron Estes,133
-Johnson,Overland Park 1-18,State Treasurer,,R,Ron Estes,268
-Johnson,Overland Park 1-19,State Treasurer,,R,Ron Estes,194
-Johnson,Overland Park 1-20,State Treasurer,,R,Ron Estes,153
-Johnson,Overland Park 1-21,State Treasurer,,R,Ron Estes,91
-Johnson,Overland Park 1-22,State Treasurer,,R,Ron Estes,47
-Johnson,Overland Park 2-01,State Treasurer,,R,Ron Estes,263
-Johnson,Overland Park 2-02,State Treasurer,,R,Ron Estes,254
-Johnson,Overland Park 2-03,State Treasurer,,R,Ron Estes,231
-Johnson,Overland Park 2-04,State Treasurer,,R,Ron Estes,289
-Johnson,Overland Park 2-05,State Treasurer,,R,Ron Estes,223
-Johnson,Overland Park 2-06,State Treasurer,,R,Ron Estes,256
-Johnson,Overland Park 2-07,State Treasurer,,R,Ron Estes,213
-Johnson,Overland Park 2-08,State Treasurer,,R,Ron Estes,105
-Johnson,Overland Park 2-09,State Treasurer,,R,Ron Estes,216
-Johnson,Overland Park 2-10,State Treasurer,,R,Ron Estes,213
-Johnson,Overland Park 2-11,State Treasurer,,R,Ron Estes,256
-Johnson,Overland Park 2-12,State Treasurer,,R,Ron Estes,196
-Johnson,Overland Park 2-13,State Treasurer,,R,Ron Estes,106
-Johnson,Overland Park 2-14,State Treasurer,,R,Ron Estes,170
-Johnson,Overland Park 2-15,State Treasurer,,R,Ron Estes,375
-Johnson,Overland Park 2-16,State Treasurer,,R,Ron Estes,219
-Johnson,Overland Park 2-17,State Treasurer,,R,Ron Estes,350
-Johnson,Overland Park 2-18,State Treasurer,,R,Ron Estes,326
-Johnson,Overland Park 2-19,State Treasurer,,R,Ron Estes,219
-Johnson,Overland Park 2-20,State Treasurer,,R,Ron Estes,239
-Johnson,Overland Park 2-21,State Treasurer,,R,Ron Estes,216
-Johnson,Overland Park 2-22,State Treasurer,,R,Ron Estes,224
-Johnson,Overland Park 2-23,State Treasurer,,R,Ron Estes,312
-Johnson,Overland Park 2-24,State Treasurer,,R,Ron Estes,446
-Johnson,Overland Park 2-25,State Treasurer,,R,Ron Estes,334
-Johnson,Overland Park 2-26,State Treasurer,,R,Ron Estes,115
-Johnson,Overland Park 3-01,State Treasurer,,R,Ron Estes,502
-Johnson,Overland Park 3-02,State Treasurer,,R,Ron Estes,265
-Johnson,Overland Park 3-03,State Treasurer,,R,Ron Estes,329
-Johnson,Overland Park 3-04,State Treasurer,,R,Ron Estes,350
-Johnson,Overland Park 3-05,State Treasurer,,R,Ron Estes,331
-Johnson,Overland Park 3-06,State Treasurer,,R,Ron Estes,412
-Johnson,Overland Park 3-07,State Treasurer,,R,Ron Estes,201
-Johnson,Overland Park 3-08,State Treasurer,,R,Ron Estes,342
-Johnson,Overland Park 3-09,State Treasurer,,R,Ron Estes,428
-Johnson,Overland Park 3-10,State Treasurer,,R,Ron Estes,258
-Johnson,Overland Park 3-11,State Treasurer,,R,Ron Estes,347
-Johnson,Overland Park 3-12,State Treasurer,,R,Ron Estes,165
-Johnson,Overland Park 3-13,State Treasurer,,R,Ron Estes,497
-Johnson,Overland Park 3-14,State Treasurer,,R,Ron Estes,336
-Johnson,Overland Park 3-15,State Treasurer,,R,Ron Estes,255
-Johnson,Overland Park 3-16,State Treasurer,,R,Ron Estes,293
-Johnson,Overland Park 3-17,State Treasurer,,R,Ron Estes,257
-Johnson,Overland Park 3-18,State Treasurer,,R,Ron Estes,250
-Johnson,Overland Park 3-19,State Treasurer,,R,Ron Estes,312
-Johnson,Overland Park 3-20,State Treasurer,,R,Ron Estes,401
-Johnson,Overland Park 3-21,State Treasurer,,R,Ron Estes,346
-Johnson,Overland Park 4-01,State Treasurer,,R,Ron Estes,279
-Johnson,Overland Park 4-02,State Treasurer,,R,Ron Estes,429
-Johnson,Overland Park 4-03,State Treasurer,,R,Ron Estes,554
-Johnson,Overland Park 4-04,State Treasurer,,R,Ron Estes,568
-Johnson,Overland Park 4-05,State Treasurer,,R,Ron Estes,396
-Johnson,Overland Park 4-06,State Treasurer,,R,Ron Estes,316
-Johnson,Overland Park 4-07,State Treasurer,,R,Ron Estes,244
-Johnson,Overland Park 4-08,State Treasurer,,R,Ron Estes,406
-Johnson,Overland Park 4-09,State Treasurer,,R,Ron Estes,456
-Johnson,Overland Park 4-10,State Treasurer,,R,Ron Estes,304
-Johnson,Overland Park 4-11,State Treasurer,,R,Ron Estes,462
-Johnson,Overland Park 4-12,State Treasurer,,R,Ron Estes,592
-Johnson,Overland Park 4-13,State Treasurer,,R,Ron Estes,338
-Johnson,Overland Park 4-14,State Treasurer,,R,Ron Estes,262
-Johnson,Overland Park 4-15,State Treasurer,,R,Ron Estes,502
-Johnson,Overland Park 4-16,State Treasurer,,R,Ron Estes,400
-Johnson,Overland Park 4-17,State Treasurer,,R,Ron Estes,470
-Johnson,Overland Park 4-18,State Treasurer,,R,Ron Estes,60
-Johnson,Overland Park 5-01,State Treasurer,,R,Ron Estes,394
-Johnson,Overland Park 5-02,State Treasurer,,R,Ron Estes,181
-Johnson,Overland Park 5-03,State Treasurer,,R,Ron Estes,390
-Johnson,Overland Park 5-04,State Treasurer,,R,Ron Estes,330
-Johnson,Overland Park 5-05,State Treasurer,,R,Ron Estes,227
-Johnson,Overland Park 5-06,State Treasurer,,R,Ron Estes,292
-Johnson,Overland Park 5-07,State Treasurer,,R,Ron Estes,557
-Johnson,Overland Park 5-08,State Treasurer,,R,Ron Estes,566
-Johnson,Overland Park 5-09,State Treasurer,,R,Ron Estes,516
-Johnson,Overland Park 5-10,State Treasurer,,R,Ron Estes,397
-Johnson,Overland Park 5-11,State Treasurer,,R,Ron Estes,421
-Johnson,Overland Park 5-12,State Treasurer,,R,Ron Estes,92
-Johnson,Overland Park 5-13,State Treasurer,,R,Ron Estes,456
-Johnson,Overland Park 5-14,State Treasurer,,R,Ron Estes,400
-Johnson,Overland Park 5-15,State Treasurer,,R,Ron Estes,249
-Johnson,Overland Park 5-16,State Treasurer,,R,Ron Estes,242
-Johnson,Overland Park 5-17,State Treasurer,,R,Ron Estes,146
-Johnson,Overland Park 5-18,State Treasurer,,R,Ron Estes,300
-Johnson,Overland Park 5-19,State Treasurer,,R,Ron Estes,37
-Johnson,Overland Park 6-01,State Treasurer,,R,Ron Estes,494
-Johnson,Overland Park 6-02,State Treasurer,,R,Ron Estes,392
-Johnson,Overland Park 6-03,State Treasurer,,R,Ron Estes,438
-Johnson,Overland Park 6-04,State Treasurer,,R,Ron Estes,430
-Johnson,Overland Park 6-05,State Treasurer,,R,Ron Estes,454
-Johnson,Overland Park 6-06,State Treasurer,,R,Ron Estes,1
-Johnson,Overland Park 6-07,State Treasurer,,R,Ron Estes,144
-Johnson,Overland Park 6-08,State Treasurer,,R,Ron Estes,729
-Johnson,Overland Park 6-09,State Treasurer,,R,Ron Estes,556
-Johnson,Overland Park 6-10,State Treasurer,,R,Ron Estes,361
-Johnson,Overland Park 6-11,State Treasurer,,R,Ron Estes,370
-Johnson,Overland Park 6-12,State Treasurer,,R,Ron Estes,178
-Johnson,Overland Park 6-13,State Treasurer,,R,Ron Estes,501
-Johnson,Overland Park 6-15,State Treasurer,,R,Ron Estes,493
-Johnson,Overland Park 6-16,State Treasurer,,R,Ron Estes,303
-Johnson,Overland Park 6-17,State Treasurer,,R,Ron Estes,97
-Johnson,Overland Park 6-18,State Treasurer,,R,Ron Estes,3
-Johnson,Overland Park 6-19,State Treasurer,,R,Ron Estes,463
-Johnson,Overland Park 6-20,State Treasurer,,R,Ron Estes,267
-Johnson,Overland Park 6-21,State Treasurer,,R,Ron Estes,701
-Johnson,Overland Park 6-22,State Treasurer,,R,Ron Estes,242
-Johnson,Oxford Twp 0-01,State Treasurer,,R,Ron Estes,1
-Johnson,Oxford Twp 0-02,State Treasurer,,R,Ron Estes,342
-Johnson,Oxford Twp 0-04,State Treasurer,,R,Ron Estes,238
-Johnson,Oxford Twp 0-05,State Treasurer,,R,Ron Estes,10
-Johnson,Oxford Twp 0-09,State Treasurer,,R,Ron Estes,18
-Johnson,Oxford Twp 0-10,State Treasurer,,R,Ron Estes,2
-Johnson,Oxford Twp 0-11,State Treasurer,,R,Ron Estes,67
-Johnson,Prairie Village 1-01,State Treasurer,,R,Ron Estes,351
-Johnson,Prairie Village 1-02,State Treasurer,,R,Ron Estes,243
-Johnson,Prairie Village 1-03,State Treasurer,,R,Ron Estes,332
-Johnson,Prairie Village 2-01,State Treasurer,,R,Ron Estes,264
-Johnson,Prairie Village 2-02,State Treasurer,,R,Ron Estes,139
-Johnson,Prairie Village 2-03,State Treasurer,,R,Ron Estes,228
-Johnson,Prairie Village 3-01,State Treasurer,,R,Ron Estes,214
-Johnson,Prairie Village 3-02,State Treasurer,,R,Ron Estes,292
-Johnson,Prairie Village 3-03,State Treasurer,,R,Ron Estes,263
-Johnson,Prairie Village 4-01,State Treasurer,,R,Ron Estes,420
-Johnson,Prairie Village 4-02,State Treasurer,,R,Ron Estes,213
-Johnson,Prairie Village 4-03,State Treasurer,,R,Ron Estes,357
-Johnson,Prairie Village 5-01,State Treasurer,,R,Ron Estes,367
-Johnson,Prairie Village 5-02,State Treasurer,,R,Ron Estes,415
-Johnson,Prairie Village 5-03,State Treasurer,,R,Ron Estes,330
-Johnson,Prairie Village 6-01,State Treasurer,,R,Ron Estes,356
-Johnson,Prairie Village 6-02,State Treasurer,,R,Ron Estes,231
-Johnson,Prairie Village 6-03,State Treasurer,,R,Ron Estes,160
-Johnson,Roeland Park 1-01,State Treasurer,,R,Ron Estes,89
-Johnson,Roeland Park 1-02,State Treasurer,,R,Ron Estes,66
-Johnson,Roeland Park 2-01,State Treasurer,,R,Ron Estes,114
-Johnson,Roeland Park 2-02,State Treasurer,,R,Ron Estes,174
-Johnson,Roeland Park 3-01,State Treasurer,,R,Ron Estes,79
-Johnson,Roeland Park 3-02,State Treasurer,,R,Ron Estes,174
-Johnson,Roeland Park 4-01,State Treasurer,,R,Ron Estes,108
-Johnson,Roeland Park 4-02,State Treasurer,,R,Ron Estes,299
-Johnson,Shawnee 1-01,State Treasurer,,R,Ron Estes,339
-Johnson,Shawnee 1-02,State Treasurer,,R,Ron Estes,275
-Johnson,Shawnee 1-03,State Treasurer,,R,Ron Estes,253
-Johnson,Shawnee 1-04,State Treasurer,,R,Ron Estes,480
-Johnson,Shawnee 1-05,State Treasurer,,R,Ron Estes,499
-Johnson,Shawnee 1-06,State Treasurer,,R,Ron Estes,459
-Johnson,Shawnee 1-07,State Treasurer,,R,Ron Estes,401
-Johnson,Shawnee 1-08,State Treasurer,,R,Ron Estes,434
-Johnson,Shawnee 1-09,State Treasurer,,R,Ron Estes,63
-Johnson,Shawnee 1-10,State Treasurer,,R,Ron Estes,155
-Johnson,Shawnee 1-11,State Treasurer,,R,Ron Estes,263
-Johnson,Shawnee 1-12,State Treasurer,,R,Ron Estes,6
-Johnson,Shawnee 2-01,State Treasurer,,R,Ron Estes,168
-Johnson,Shawnee 2-02,State Treasurer,,R,Ron Estes,302
-Johnson,Shawnee 2-03,State Treasurer,,R,Ron Estes,208
-Johnson,Shawnee 2-04,State Treasurer,,R,Ron Estes,342
-Johnson,Shawnee 2-05,State Treasurer,,R,Ron Estes,172
-Johnson,Shawnee 2-06,State Treasurer,,R,Ron Estes,272
-Johnson,Shawnee 2-07,State Treasurer,,R,Ron Estes,193
-Johnson,Shawnee 2-08,State Treasurer,,R,Ron Estes,199
-Johnson,Shawnee 2-09,State Treasurer,,R,Ron Estes,175
-Johnson,Shawnee 2-10,State Treasurer,,R,Ron Estes,152
-Johnson,Shawnee 2-11,State Treasurer,,R,Ron Estes,259
-Johnson,Shawnee 2-12,State Treasurer,,R,Ron Estes,49
-Johnson,Shawnee 2-13,State Treasurer,,R,Ron Estes,138
-Johnson,Shawnee 3-01,State Treasurer,,R,Ron Estes,282
-Johnson,Shawnee 3-02,State Treasurer,,R,Ron Estes,520
-Johnson,Shawnee 3-03,State Treasurer,,R,Ron Estes,368
-Johnson,Shawnee 3-04,State Treasurer,,R,Ron Estes,365
-Johnson,Shawnee 3-05,State Treasurer,,R,Ron Estes,561
-Johnson,Shawnee 3-06,State Treasurer,,R,Ron Estes,322
-Johnson,Shawnee 3-07,State Treasurer,,R,Ron Estes,478
-Johnson,Shawnee 3-08,State Treasurer,,R,Ron Estes,432
-Johnson,Shawnee 3-09,State Treasurer,,R,Ron Estes,277
-Johnson,Shawnee 4-01,State Treasurer,,R,Ron Estes,497
-Johnson,Shawnee 4-02,State Treasurer,,R,Ron Estes,276
-Johnson,Shawnee 4-03,State Treasurer,,R,Ron Estes,112
-Johnson,Shawnee 4-04,State Treasurer,,R,Ron Estes,100
-Johnson,Shawnee 4-05,State Treasurer,,R,Ron Estes,352
-Johnson,Shawnee 4-06,State Treasurer,,R,Ron Estes,338
-Johnson,Shawnee 4-07,State Treasurer,,R,Ron Estes,492
-Johnson,Shawnee 4-08,State Treasurer,,R,Ron Estes,200
-Johnson,Shawnee 4-09,State Treasurer,,R,Ron Estes,509
-Johnson,Shawnee 4-11,State Treasurer,,R,Ron Estes,252
-Johnson,Shawnee 4-12,State Treasurer,,R,Ron Estes,56
-Johnson,Spring Hill 0-01,State Treasurer,,R,Ron Estes,595
-Johnson,Spring Hill 0-03,State Treasurer,,R,Ron Estes,41
-Johnson,Spring Hill 0-04,State Treasurer,,R,Ron Estes,0
-Johnson,Spring Hill Twp 0-01,State Treasurer,,R,Ron Estes,486
-Johnson,Spring Hill Twp 0-02,State Treasurer,,R,Ron Estes,1
-Johnson,Spring Hill Twp 0-03,State Treasurer,,R,Ron Estes,51
-Johnson,Spring Hill Twp 0-04,State Treasurer,,R,Ron Estes,9
-Johnson,Spring Hill Twp 0-05,State Treasurer,,R,Ron Estes,3
-Johnson,Westwood 0-01,State Treasurer,,R,Ron Estes,145
-Johnson,Westwood 0-02,State Treasurer,,R,Ron Estes,163
-Johnson,Westwood Hills 0-01,State Treasurer,,R,Ron Estes,79
-Johnson,Aubry Twp 0-01,State Treasurer,,D,Carmen Alldritt,33
-Johnson,Aubry Twp 0-02,State Treasurer,,D,Carmen Alldritt,122
-Johnson,Aubry Twp 0-03,State Treasurer,,D,Carmen Alldritt,96
-Johnson,Aubry Twp 0-04,State Treasurer,,D,Carmen Alldritt,182
-Johnson,Aubry Twp 0-05,State Treasurer,,D,Carmen Alldritt,4
-Johnson,Aubry Twp 0-06,State Treasurer,,D,Carmen Alldritt,18
-Johnson,De Soto 0-01,State Treasurer,,D,Carmen Alldritt,188
-Johnson,De Soto 0-02,State Treasurer,,D,Carmen Alldritt,141
-Johnson,De Soto 0-03,State Treasurer,,D,Carmen Alldritt,179
-Johnson,De Soto 0-06,State Treasurer,,D,Carmen Alldritt,16
-Johnson,De Soto 0-07,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Edgerton,State Treasurer,,D,Carmen Alldritt,122
-Johnson,Fairway 1-01,State Treasurer,,D,Carmen Alldritt,125
-Johnson,Fairway 1-02,State Treasurer,,D,Carmen Alldritt,97
-Johnson,Fairway 2-01,State Treasurer,,D,Carmen Alldritt,106
-Johnson,Fairway 2-02,State Treasurer,,D,Carmen Alldritt,97
-Johnson,Fairway 3-01,State Treasurer,,D,Carmen Alldritt,127
-Johnson,Fairway 3-02,State Treasurer,,D,Carmen Alldritt,82
-Johnson,Fairway 4-01,State Treasurer,,D,Carmen Alldritt,49
-Johnson,Fairway 4-02,State Treasurer,,D,Carmen Alldritt,59
-Johnson,Fairway 4-03,State Treasurer,,D,Carmen Alldritt,40
-Johnson,Fairway 4-04,State Treasurer,,D,Carmen Alldritt,67
-Johnson,Gardner 0-01,State Treasurer,,D,Carmen Alldritt,236
-Johnson,Gardner 0-02,State Treasurer,,D,Carmen Alldritt,40
-Johnson,Gardner 0-03,State Treasurer,,D,Carmen Alldritt,165
-Johnson,Gardner 0-04,State Treasurer,,D,Carmen Alldritt,169
-Johnson,Gardner 0-06,State Treasurer,,D,Carmen Alldritt,167
-Johnson,Gardner 0-07,State Treasurer,,D,Carmen Alldritt,8
-Johnson,Gardner 0-08,State Treasurer,,D,Carmen Alldritt,9
-Johnson,Gardner 0-09,State Treasurer,,D,Carmen Alldritt,225
-Johnson,Gardner 0-10,State Treasurer,,D,Carmen Alldritt,132
-Johnson,Gardner 0-12,State Treasurer,,D,Carmen Alldritt,7
-Johnson,Gardner 0-13,State Treasurer,,D,Carmen Alldritt,173
-Johnson,Gardner 0-14,State Treasurer,,D,Carmen Alldritt,132
-Johnson,Gardner Twp 0-01,State Treasurer,,D,Carmen Alldritt,79
-Johnson,Gardner Twp 0-02,State Treasurer,,D,Carmen Alldritt,80
-Johnson,Gardner Twp 0-04,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Gardner Twp 0-05,State Treasurer,,D,Carmen Alldritt,1
-Johnson,Gardner Twp 0-07,State Treasurer,,D,Carmen Alldritt,2
-Johnson,Gardner Twp 0-08,State Treasurer,,D,Carmen Alldritt,3
-Johnson,Gardner Twp 0-09,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Gardner Twp 0-10,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Gardner Twp 0-11,State Treasurer,,D,Carmen Alldritt,27
-Johnson,Gardner Twp 0-13,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Lake Quivira,State Treasurer,,D,Carmen Alldritt,139
-Johnson,Leawood 1-01,State Treasurer,,D,Carmen Alldritt,230
-Johnson,Leawood 1-02,State Treasurer,,D,Carmen Alldritt,279
-Johnson,Leawood 1-03,State Treasurer,,D,Carmen Alldritt,236
-Johnson,Leawood 1-04,State Treasurer,,D,Carmen Alldritt,207
-Johnson,Leawood 1-05,State Treasurer,,D,Carmen Alldritt,164
-Johnson,Leawood 1-06,State Treasurer,,D,Carmen Alldritt,59
-Johnson,Leawood 2-01,State Treasurer,,D,Carmen Alldritt,226
-Johnson,Leawood 2-02,State Treasurer,,D,Carmen Alldritt,276
-Johnson,Leawood 2-03,State Treasurer,,D,Carmen Alldritt,245
-Johnson,Leawood 2-04,State Treasurer,,D,Carmen Alldritt,164
-Johnson,Leawood 2-05,State Treasurer,,D,Carmen Alldritt,138
-Johnson,Leawood 2-06,State Treasurer,,D,Carmen Alldritt,100
-Johnson,Leawood 3-01,State Treasurer,,D,Carmen Alldritt,151
-Johnson,Leawood 3-02,State Treasurer,,D,Carmen Alldritt,243
-Johnson,Leawood 3-03,State Treasurer,,D,Carmen Alldritt,130
-Johnson,Leawood 3-04,State Treasurer,,D,Carmen Alldritt,61
-Johnson,Leawood 3-05,State Treasurer,,D,Carmen Alldritt,234
-Johnson,Leawood 3-06,State Treasurer,,D,Carmen Alldritt,187
-Johnson,Leawood 3-07,State Treasurer,,D,Carmen Alldritt,187
-Johnson,Leawood 4-01,State Treasurer,,D,Carmen Alldritt,54
-Johnson,Leawood 4-02,State Treasurer,,D,Carmen Alldritt,172
-Johnson,Leawood 4-03,State Treasurer,,D,Carmen Alldritt,211
-Johnson,Leawood 4-04,State Treasurer,,D,Carmen Alldritt,204
-Johnson,Leawood 4-05,State Treasurer,,D,Carmen Alldritt,197
-Johnson,Leawood 4-06,State Treasurer,,D,Carmen Alldritt,88
-Johnson,Leawood 4-07,State Treasurer,,D,Carmen Alldritt,211
-Johnson,Leawood 4-08,State Treasurer,,D,Carmen Alldritt,101
-Johnson,Lenexa 1-01,State Treasurer,,D,Carmen Alldritt,114
-Johnson,Lenexa 1-02,State Treasurer,,D,Carmen Alldritt,273
-Johnson,Lenexa 1-03,State Treasurer,,D,Carmen Alldritt,328
-Johnson,Lenexa 1-04,State Treasurer,,D,Carmen Alldritt,221
-Johnson,Lenexa 1-05,State Treasurer,,D,Carmen Alldritt,231
-Johnson,Lenexa 1-06,State Treasurer,,D,Carmen Alldritt,225
-Johnson,Lenexa 1-07,State Treasurer,,D,Carmen Alldritt,159
-Johnson,Lenexa 1-08,State Treasurer,,D,Carmen Alldritt,68
-Johnson,Lenexa 1-09,State Treasurer,,D,Carmen Alldritt,5
-Johnson,Lenexa 2-01,State Treasurer,,D,Carmen Alldritt,268
-Johnson,Lenexa 2-02,State Treasurer,,D,Carmen Alldritt,80
-Johnson,Lenexa 2-03,State Treasurer,,D,Carmen Alldritt,209
-Johnson,Lenexa 2-04,State Treasurer,,D,Carmen Alldritt,143
-Johnson,Lenexa 2-05,State Treasurer,,D,Carmen Alldritt,224
-Johnson,Lenexa 2-06,State Treasurer,,D,Carmen Alldritt,134
-Johnson,Lenexa 2-07,State Treasurer,,D,Carmen Alldritt,301
-Johnson,Lenexa 3-01,State Treasurer,,D,Carmen Alldritt,209
-Johnson,Lenexa 3-02,State Treasurer,,D,Carmen Alldritt,355
-Johnson,Lenexa 3-03,State Treasurer,,D,Carmen Alldritt,329
-Johnson,Lenexa 3-04,State Treasurer,,D,Carmen Alldritt,184
-Johnson,Lenexa 3-05,State Treasurer,,D,Carmen Alldritt,169
-Johnson,Lenexa 3-06,State Treasurer,,D,Carmen Alldritt,210
-Johnson,Lenexa 3-07,State Treasurer,,D,Carmen Alldritt,249
-Johnson,Lenexa 3-08,State Treasurer,,D,Carmen Alldritt,232
-Johnson,Lenexa 4-01,State Treasurer,,D,Carmen Alldritt,133
-Johnson,Lenexa 4-02,State Treasurer,,D,Carmen Alldritt,223
-Johnson,Lenexa 4-03,State Treasurer,,D,Carmen Alldritt,131
-Johnson,Lenexa 4-04,State Treasurer,,D,Carmen Alldritt,106
-Johnson,Lenexa 4-05,State Treasurer,,D,Carmen Alldritt,114
-Johnson,Lenexa 4-06,State Treasurer,,D,Carmen Alldritt,165
-Johnson,Lenexa 4-07,State Treasurer,,D,Carmen Alldritt,194
-Johnson,Lenexa 4-08,State Treasurer,,D,Carmen Alldritt,201
-Johnson,Lenexa 4-09,State Treasurer,,D,Carmen Alldritt,185
-Johnson,Lenexa 4-10,State Treasurer,,D,Carmen Alldritt,112
-Johnson,Lenexa 4-11,State Treasurer,,D,Carmen Alldritt,39
-Johnson,Lexington Twp 0-01,State Treasurer,,D,Carmen Alldritt,161
-Johnson,Lexington Twp 0-02,State Treasurer,,D,Carmen Alldritt,1
-Johnson,Lexington Twp 0-03,State Treasurer,,D,Carmen Alldritt,1
-Johnson,McCamish Twp 0-01,State Treasurer,,D,Carmen Alldritt,30
-Johnson,McCamish Twp 0-02,State Treasurer,,D,Carmen Alldritt,62
-Johnson,Merriam 1-01,State Treasurer,,D,Carmen Alldritt,160
-Johnson,Merriam 1-02,State Treasurer,,D,Carmen Alldritt,201
-Johnson,Merriam 2-01,State Treasurer,,D,Carmen Alldritt,238
-Johnson,Merriam 2-02,State Treasurer,,D,Carmen Alldritt,2
-Johnson,Merriam 2-03,State Treasurer,,D,Carmen Alldritt,141
-Johnson,Merriam 3-01,State Treasurer,,D,Carmen Alldritt,219
-Johnson,Merriam 3-02,State Treasurer,,D,Carmen Alldritt,194
-Johnson,Merriam 4-01,State Treasurer,,D,Carmen Alldritt,235
-Johnson,Merriam 4-02,State Treasurer,,D,Carmen Alldritt,124
-Johnson,Merriam 4-03,State Treasurer,,D,Carmen Alldritt,166
-Johnson,Mission 1-01,State Treasurer,,D,Carmen Alldritt,239
-Johnson,Mission 1-02,State Treasurer,,D,Carmen Alldritt,138
-Johnson,Mission 2-01,State Treasurer,,D,Carmen Alldritt,152
-Johnson,Mission 2-02,State Treasurer,,D,Carmen Alldritt,221
-Johnson,Mission 3-01,State Treasurer,,D,Carmen Alldritt,231
-Johnson,Mission 3-02,State Treasurer,,D,Carmen Alldritt,132
-Johnson,Mission 4-01,State Treasurer,,D,Carmen Alldritt,180
-Johnson,Mission 4-02,State Treasurer,,D,Carmen Alldritt,207
-Johnson,Mission 4-03,State Treasurer,,D,Carmen Alldritt,123
-Johnson,Mission Hills 0-01,State Treasurer,,D,Carmen Alldritt,96
-Johnson,Mission Hills 0-02,State Treasurer,,D,Carmen Alldritt,161
-Johnson,Mission Hills 0-03,State Treasurer,,D,Carmen Alldritt,73
-Johnson,Mission Hills 0-04,State Treasurer,,D,Carmen Alldritt,182
-Johnson,Mission Woods,State Treasurer,,D,Carmen Alldritt,36
-Johnson,Olathe 1-01,State Treasurer,,D,Carmen Alldritt,175
-Johnson,Olathe 1-02,State Treasurer,,D,Carmen Alldritt,150
-Johnson,Olathe 1-03,State Treasurer,,D,Carmen Alldritt,96
-Johnson,Olathe 1-04,State Treasurer,,D,Carmen Alldritt,192
-Johnson,Olathe 1-05,State Treasurer,,D,Carmen Alldritt,182
-Johnson,Olathe 1-06,State Treasurer,,D,Carmen Alldritt,110
-Johnson,Olathe 1-08,State Treasurer,,D,Carmen Alldritt,220
-Johnson,Olathe 1-09,State Treasurer,,D,Carmen Alldritt,166
-Johnson,Olathe 1-11,State Treasurer,,D,Carmen Alldritt,42
-Johnson,Olathe 1-14,State Treasurer,,D,Carmen Alldritt,153
-Johnson,Olathe 1-15,State Treasurer,,D,Carmen Alldritt,180
-Johnson,Olathe 1-16,State Treasurer,,D,Carmen Alldritt,170
-Johnson,Olathe 1-17,State Treasurer,,D,Carmen Alldritt,39
-Johnson,Olathe 1-18,State Treasurer,,D,Carmen Alldritt,55
-Johnson,Olathe 1-19,State Treasurer,,D,Carmen Alldritt,87
-Johnson,Olathe 1-20,State Treasurer,,D,Carmen Alldritt,168
-Johnson,Olathe 1-21,State Treasurer,,D,Carmen Alldritt,202
-Johnson,Olathe 1-22,State Treasurer,,D,Carmen Alldritt,259
-Johnson,Olathe 1-23,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe 1-24,State Treasurer,,D,Carmen Alldritt,17
-Johnson,Olathe 1-24,State Treasurer,,D,Carmen Alldritt,53
-Johnson,Olathe 1-26,State Treasurer,,D,Carmen Alldritt,2
-Johnson,Olathe 1-27,State Treasurer,,D,Carmen Alldritt,166
-Johnson,Olathe 2-01,State Treasurer,,D,Carmen Alldritt,80
-Johnson,Olathe 2-02,State Treasurer,,D,Carmen Alldritt,137
-Johnson,Olathe 2-03,State Treasurer,,D,Carmen Alldritt,132
-Johnson,Olathe 2-04,State Treasurer,,D,Carmen Alldritt,188
-Johnson,Olathe 2-05,State Treasurer,,D,Carmen Alldritt,303
-Johnson,Olathe 2-06,State Treasurer,,D,Carmen Alldritt,157
-Johnson,Olathe 2-07,State Treasurer,,D,Carmen Alldritt,243
-Johnson,Olathe 2-08,State Treasurer,,D,Carmen Alldritt,215
-Johnson,Olathe 2-09,State Treasurer,,D,Carmen Alldritt,91
-Johnson,Olathe 2-10,State Treasurer,,D,Carmen Alldritt,370
-Johnson,Olathe 2-11,State Treasurer,,D,Carmen Alldritt,257
-Johnson,Olathe 2-12,State Treasurer,,D,Carmen Alldritt,153
-Johnson,Olathe 2-13,State Treasurer,,D,Carmen Alldritt,185
-Johnson,Olathe 2-14,State Treasurer,,D,Carmen Alldritt,142
-Johnson,Olathe 2-15,State Treasurer,,D,Carmen Alldritt,107
-Johnson,Olathe 2-16,State Treasurer,,D,Carmen Alldritt,71
-Johnson,Olathe 2-17,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe 2-19,State Treasurer,,D,Carmen Alldritt,2
-Johnson,Olathe 2-22,State Treasurer,,D,Carmen Alldritt,288
-Johnson,Olathe 2-23,State Treasurer,,D,Carmen Alldritt,193
-Johnson,Olathe 3-01,State Treasurer,,D,Carmen Alldritt,95
-Johnson,Olathe 3-02,State Treasurer,,D,Carmen Alldritt,231
-Johnson,Olathe 3-03,State Treasurer,,D,Carmen Alldritt,92
-Johnson,Olathe 3-04,State Treasurer,,D,Carmen Alldritt,174
-Johnson,Olathe 3-05,State Treasurer,,D,Carmen Alldritt,148
-Johnson,Olathe 3-06,State Treasurer,,D,Carmen Alldritt,120
-Johnson,Olathe 3-07,State Treasurer,,D,Carmen Alldritt,135
-Johnson,Olathe 3-08,State Treasurer,,D,Carmen Alldritt,184
-Johnson,Olathe 3-09,State Treasurer,,D,Carmen Alldritt,100
-Johnson,Olathe 3-10,State Treasurer,,D,Carmen Alldritt,182
-Johnson,Olathe 3-11,State Treasurer,,D,Carmen Alldritt,130
-Johnson,Olathe 3-12,State Treasurer,,D,Carmen Alldritt,182
-Johnson,Olathe 3-13,State Treasurer,,D,Carmen Alldritt,192
-Johnson,Olathe 3-15,State Treasurer,,D,Carmen Alldritt,139
-Johnson,Olathe 3-16,State Treasurer,,D,Carmen Alldritt,151
-Johnson,Olathe 3-17,State Treasurer,,D,Carmen Alldritt,191
-Johnson,Olathe 3-18,State Treasurer,,D,Carmen Alldritt,167
-Johnson,Olathe 3-19,State Treasurer,,D,Carmen Alldritt,91
-Johnson,Olathe 3-20,State Treasurer,,D,Carmen Alldritt,103
-Johnson,Olathe 3-21,State Treasurer,,D,Carmen Alldritt,81
-Johnson,Olathe 3-22,State Treasurer,,D,Carmen Alldritt,168
-Johnson,Olathe 3-23,State Treasurer,,D,Carmen Alldritt,170
-Johnson,Olathe 3-24,State Treasurer,,D,Carmen Alldritt,78
-Johnson,Olathe 3-26,State Treasurer,,D,Carmen Alldritt,23
-Johnson,Olathe 4-01,State Treasurer,,D,Carmen Alldritt,167
-Johnson,Olathe 4-02,State Treasurer,,D,Carmen Alldritt,279
-Johnson,Olathe 4-03,State Treasurer,,D,Carmen Alldritt,123
-Johnson,Olathe 4-04,State Treasurer,,D,Carmen Alldritt,116
-Johnson,Olathe 4-05,State Treasurer,,D,Carmen Alldritt,219
-Johnson,Olathe 4-06,State Treasurer,,D,Carmen Alldritt,267
-Johnson,Olathe 4-07,State Treasurer,,D,Carmen Alldritt,247
-Johnson,Olathe 4-08,State Treasurer,,D,Carmen Alldritt,151
-Johnson,Olathe 4-09,State Treasurer,,D,Carmen Alldritt,248
-Johnson,Olathe 4-10,State Treasurer,,D,Carmen Alldritt,138
-Johnson,Olathe 4-11,State Treasurer,,D,Carmen Alldritt,114
-Johnson,Olathe 4-12,State Treasurer,,D,Carmen Alldritt,208
-Johnson,Olathe 4-13,State Treasurer,,D,Carmen Alldritt,125
-Johnson,Olathe 4-14,State Treasurer,,D,Carmen Alldritt,236
-Johnson,Olathe 4-15,State Treasurer,,D,Carmen Alldritt,16
-Johnson,Olathe 4-16,State Treasurer,,D,Carmen Alldritt,93
-Johnson,Olathe 4-17,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe Twp 0-01,State Treasurer,,D,Carmen Alldritt,94
-Johnson,Olathe Twp 0-02,State Treasurer,,D,Carmen Alldritt,11
-Johnson,Olathe Twp 0-03,State Treasurer,,D,Carmen Alldritt,13
-Johnson,Olathe Twp 0-04,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe Twp 0-05,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe Twp 0-06,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe Twp 0-07,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe Twp 0-08,State Treasurer,,D,Carmen Alldritt,2
-Johnson,Olathe Twp 0-10,State Treasurer,,D,Carmen Alldritt,2
-Johnson,Olathe Twp 0-11,State Treasurer,,D,Carmen Alldritt,1
-Johnson,Olathe Twp 0-14,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe Twp 0-24,State Treasurer,,D,Carmen Alldritt,1
-Johnson,Olathe Twp 0-25,State Treasurer,,D,Carmen Alldritt,1
-Johnson,Olathe Twp 0-26,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Olathe Twp 0-32,State Treasurer,,D,Carmen Alldritt,6
-Johnson,Overland Park 1-01,State Treasurer,,D,Carmen Alldritt,245
-Johnson,Overland Park 1-02,State Treasurer,,D,Carmen Alldritt,265
-Johnson,Overland Park 1-03,State Treasurer,,D,Carmen Alldritt,212
-Johnson,Overland Park 1-04,State Treasurer,,D,Carmen Alldritt,75
-Johnson,Overland Park 1-05,State Treasurer,,D,Carmen Alldritt,163
-Johnson,Overland Park 1-06,State Treasurer,,D,Carmen Alldritt,322
-Johnson,Overland Park 1-07,State Treasurer,,D,Carmen Alldritt,260
-Johnson,Overland Park 1-08,State Treasurer,,D,Carmen Alldritt,185
-Johnson,Overland Park 1-09,State Treasurer,,D,Carmen Alldritt,123
-Johnson,Overland Park 1-10,State Treasurer,,D,Carmen Alldritt,245
-Johnson,Overland Park 1-11,State Treasurer,,D,Carmen Alldritt,65
-Johnson,Overland Park 1-12,State Treasurer,,D,Carmen Alldritt,207
-Johnson,Overland Park 1-13,State Treasurer,,D,Carmen Alldritt,148
-Johnson,Overland Park 1-14,State Treasurer,,D,Carmen Alldritt,235
-Johnson,Overland Park 1-15,State Treasurer,,D,Carmen Alldritt,119
-Johnson,Overland Park 1-16,State Treasurer,,D,Carmen Alldritt,289
-Johnson,Overland Park 1-17,State Treasurer,,D,Carmen Alldritt,113
-Johnson,Overland Park 1-18,State Treasurer,,D,Carmen Alldritt,220
-Johnson,Overland Park 1-19,State Treasurer,,D,Carmen Alldritt,177
-Johnson,Overland Park 1-20,State Treasurer,,D,Carmen Alldritt,140
-Johnson,Overland Park 1-21,State Treasurer,,D,Carmen Alldritt,56
-Johnson,Overland Park 1-22,State Treasurer,,D,Carmen Alldritt,65
-Johnson,Overland Park 2-01,State Treasurer,,D,Carmen Alldritt,159
-Johnson,Overland Park 2-02,State Treasurer,,D,Carmen Alldritt,228
-Johnson,Overland Park 2-03,State Treasurer,,D,Carmen Alldritt,191
-Johnson,Overland Park 2-04,State Treasurer,,D,Carmen Alldritt,224
-Johnson,Overland Park 2-05,State Treasurer,,D,Carmen Alldritt,202
-Johnson,Overland Park 2-06,State Treasurer,,D,Carmen Alldritt,180
-Johnson,Overland Park 2-07,State Treasurer,,D,Carmen Alldritt,153
-Johnson,Overland Park 2-08,State Treasurer,,D,Carmen Alldritt,139
-Johnson,Overland Park 2-09,State Treasurer,,D,Carmen Alldritt,157
-Johnson,Overland Park 2-10,State Treasurer,,D,Carmen Alldritt,92
-Johnson,Overland Park 2-11,State Treasurer,,D,Carmen Alldritt,184
-Johnson,Overland Park 2-12,State Treasurer,,D,Carmen Alldritt,132
-Johnson,Overland Park 2-13,State Treasurer,,D,Carmen Alldritt,94
-Johnson,Overland Park 2-14,State Treasurer,,D,Carmen Alldritt,160
-Johnson,Overland Park 2-15,State Treasurer,,D,Carmen Alldritt,278
-Johnson,Overland Park 2-16,State Treasurer,,D,Carmen Alldritt,169
-Johnson,Overland Park 2-17,State Treasurer,,D,Carmen Alldritt,216
-Johnson,Overland Park 2-18,State Treasurer,,D,Carmen Alldritt,251
-Johnson,Overland Park 2-19,State Treasurer,,D,Carmen Alldritt,156
-Johnson,Overland Park 2-20,State Treasurer,,D,Carmen Alldritt,141
-Johnson,Overland Park 2-21,State Treasurer,,D,Carmen Alldritt,177
-Johnson,Overland Park 2-22,State Treasurer,,D,Carmen Alldritt,199
-Johnson,Overland Park 2-23,State Treasurer,,D,Carmen Alldritt,155
-Johnson,Overland Park 2-24,State Treasurer,,D,Carmen Alldritt,257
-Johnson,Overland Park 2-25,State Treasurer,,D,Carmen Alldritt,240
-Johnson,Overland Park 2-26,State Treasurer,,D,Carmen Alldritt,92
-Johnson,Overland Park 3-01,State Treasurer,,D,Carmen Alldritt,260
-Johnson,Overland Park 3-02,State Treasurer,,D,Carmen Alldritt,209
-Johnson,Overland Park 3-03,State Treasurer,,D,Carmen Alldritt,162
-Johnson,Overland Park 3-04,State Treasurer,,D,Carmen Alldritt,261
-Johnson,Overland Park 3-05,State Treasurer,,D,Carmen Alldritt,233
-Johnson,Overland Park 3-06,State Treasurer,,D,Carmen Alldritt,248
-Johnson,Overland Park 3-07,State Treasurer,,D,Carmen Alldritt,198
-Johnson,Overland Park 3-08,State Treasurer,,D,Carmen Alldritt,177
-Johnson,Overland Park 3-09,State Treasurer,,D,Carmen Alldritt,292
-Johnson,Overland Park 3-10,State Treasurer,,D,Carmen Alldritt,142
-Johnson,Overland Park 3-11,State Treasurer,,D,Carmen Alldritt,162
-Johnson,Overland Park 3-12,State Treasurer,,D,Carmen Alldritt,154
-Johnson,Overland Park 3-13,State Treasurer,,D,Carmen Alldritt,309
-Johnson,Overland Park 3-14,State Treasurer,,D,Carmen Alldritt,250
-Johnson,Overland Park 3-15,State Treasurer,,D,Carmen Alldritt,120
-Johnson,Overland Park 3-16,State Treasurer,,D,Carmen Alldritt,213
-Johnson,Overland Park 3-17,State Treasurer,,D,Carmen Alldritt,169
-Johnson,Overland Park 3-18,State Treasurer,,D,Carmen Alldritt,189
-Johnson,Overland Park 3-19,State Treasurer,,D,Carmen Alldritt,189
-Johnson,Overland Park 3-20,State Treasurer,,D,Carmen Alldritt,250
-Johnson,Overland Park 3-21,State Treasurer,,D,Carmen Alldritt,160
-Johnson,Overland Park 4-01,State Treasurer,,D,Carmen Alldritt,95
-Johnson,Overland Park 4-02,State Treasurer,,D,Carmen Alldritt,158
-Johnson,Overland Park 4-03,State Treasurer,,D,Carmen Alldritt,158
-Johnson,Overland Park 4-04,State Treasurer,,D,Carmen Alldritt,230
-Johnson,Overland Park 4-05,State Treasurer,,D,Carmen Alldritt,173
-Johnson,Overland Park 4-06,State Treasurer,,D,Carmen Alldritt,172
-Johnson,Overland Park 4-07,State Treasurer,,D,Carmen Alldritt,158
-Johnson,Overland Park 4-08,State Treasurer,,D,Carmen Alldritt,178
-Johnson,Overland Park 4-09,State Treasurer,,D,Carmen Alldritt,101
-Johnson,Overland Park 4-10,State Treasurer,,D,Carmen Alldritt,102
-Johnson,Overland Park 4-11,State Treasurer,,D,Carmen Alldritt,220
-Johnson,Overland Park 4-12,State Treasurer,,D,Carmen Alldritt,304
-Johnson,Overland Park 4-13,State Treasurer,,D,Carmen Alldritt,90
-Johnson,Overland Park 4-14,State Treasurer,,D,Carmen Alldritt,95
-Johnson,Overland Park 4-15,State Treasurer,,D,Carmen Alldritt,236
-Johnson,Overland Park 4-16,State Treasurer,,D,Carmen Alldritt,133
-Johnson,Overland Park 4-17,State Treasurer,,D,Carmen Alldritt,223
-Johnson,Overland Park 4-18,State Treasurer,,D,Carmen Alldritt,38
-Johnson,Overland Park 5-01,State Treasurer,,D,Carmen Alldritt,219
-Johnson,Overland Park 5-02,State Treasurer,,D,Carmen Alldritt,117
-Johnson,Overland Park 5-03,State Treasurer,,D,Carmen Alldritt,176
-Johnson,Overland Park 5-04,State Treasurer,,D,Carmen Alldritt,201
-Johnson,Overland Park 5-05,State Treasurer,,D,Carmen Alldritt,178
-Johnson,Overland Park 5-06,State Treasurer,,D,Carmen Alldritt,173
-Johnson,Overland Park 5-07,State Treasurer,,D,Carmen Alldritt,158
-Johnson,Overland Park 5-08,State Treasurer,,D,Carmen Alldritt,250
-Johnson,Overland Park 5-09,State Treasurer,,D,Carmen Alldritt,272
-Johnson,Overland Park 5-10,State Treasurer,,D,Carmen Alldritt,196
-Johnson,Overland Park 5-11,State Treasurer,,D,Carmen Alldritt,291
-Johnson,Overland Park 5-12,State Treasurer,,D,Carmen Alldritt,60
-Johnson,Overland Park 5-13,State Treasurer,,D,Carmen Alldritt,324
-Johnson,Overland Park 5-14,State Treasurer,,D,Carmen Alldritt,210
-Johnson,Overland Park 5-15,State Treasurer,,D,Carmen Alldritt,171
-Johnson,Overland Park 5-16,State Treasurer,,D,Carmen Alldritt,115
-Johnson,Overland Park 5-17,State Treasurer,,D,Carmen Alldritt,80
-Johnson,Overland Park 5-18,State Treasurer,,D,Carmen Alldritt,168
-Johnson,Overland Park 5-19,State Treasurer,,D,Carmen Alldritt,12
-Johnson,Overland Park 6-01,State Treasurer,,D,Carmen Alldritt,190
-Johnson,Overland Park 6-02,State Treasurer,,D,Carmen Alldritt,149
-Johnson,Overland Park 6-03,State Treasurer,,D,Carmen Alldritt,164
-Johnson,Overland Park 6-04,State Treasurer,,D,Carmen Alldritt,147
-Johnson,Overland Park 6-05,State Treasurer,,D,Carmen Alldritt,226
-Johnson,Overland Park 6-06,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Overland Park 6-07,State Treasurer,,D,Carmen Alldritt,36
-Johnson,Overland Park 6-08,State Treasurer,,D,Carmen Alldritt,186
-Johnson,Overland Park 6-09,State Treasurer,,D,Carmen Alldritt,248
-Johnson,Overland Park 6-10,State Treasurer,,D,Carmen Alldritt,164
-Johnson,Overland Park 6-11,State Treasurer,,D,Carmen Alldritt,164
-Johnson,Overland Park 6-12,State Treasurer,,D,Carmen Alldritt,70
-Johnson,Overland Park 6-13,State Treasurer,,D,Carmen Alldritt,210
-Johnson,Overland Park 6-15,State Treasurer,,D,Carmen Alldritt,191
-Johnson,Overland Park 6-16,State Treasurer,,D,Carmen Alldritt,95
-Johnson,Overland Park 6-17,State Treasurer,,D,Carmen Alldritt,34
-Johnson,Overland Park 6-18,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Overland Park 6-19,State Treasurer,,D,Carmen Alldritt,230
-Johnson,Overland Park 6-20,State Treasurer,,D,Carmen Alldritt,56
-Johnson,Overland Park 6-21,State Treasurer,,D,Carmen Alldritt,168
-Johnson,Overland Park 6-22,State Treasurer,,D,Carmen Alldritt,80
-Johnson,Oxford Twp 0-01,State Treasurer,,D,Carmen Alldritt,1
-Johnson,Oxford Twp 0-02,State Treasurer,,D,Carmen Alldritt,96
-Johnson,Oxford Twp 0-04,State Treasurer,,D,Carmen Alldritt,103
-Johnson,Oxford Twp 0-05,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Oxford Twp 0-09,State Treasurer,,D,Carmen Alldritt,2
-Johnson,Oxford Twp 0-10,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Oxford Twp 0-11,State Treasurer,,D,Carmen Alldritt,17
-Johnson,Prairie Village 1-01,State Treasurer,,D,Carmen Alldritt,331
-Johnson,Prairie Village 1-02,State Treasurer,,D,Carmen Alldritt,229
-Johnson,Prairie Village 1-03,State Treasurer,,D,Carmen Alldritt,332
-Johnson,Prairie Village 2-01,State Treasurer,,D,Carmen Alldritt,280
-Johnson,Prairie Village 2-02,State Treasurer,,D,Carmen Alldritt,123
-Johnson,Prairie Village 2-03,State Treasurer,,D,Carmen Alldritt,253
-Johnson,Prairie Village 3-01,State Treasurer,,D,Carmen Alldritt,171
-Johnson,Prairie Village 3-02,State Treasurer,,D,Carmen Alldritt,267
-Johnson,Prairie Village 3-03,State Treasurer,,D,Carmen Alldritt,258
-Johnson,Prairie Village 4-01,State Treasurer,,D,Carmen Alldritt,247
-Johnson,Prairie Village 4-02,State Treasurer,,D,Carmen Alldritt,190
-Johnson,Prairie Village 4-03,State Treasurer,,D,Carmen Alldritt,296
-Johnson,Prairie Village 5-01,State Treasurer,,D,Carmen Alldritt,261
-Johnson,Prairie Village 5-02,State Treasurer,,D,Carmen Alldritt,247
-Johnson,Prairie Village 5-03,State Treasurer,,D,Carmen Alldritt,189
-Johnson,Prairie Village 6-01,State Treasurer,,D,Carmen Alldritt,293
-Johnson,Prairie Village 6-02,State Treasurer,,D,Carmen Alldritt,291
-Johnson,Prairie Village 6-03,State Treasurer,,D,Carmen Alldritt,165
-Johnson,Roeland Park 1-01,State Treasurer,,D,Carmen Alldritt,133
-Johnson,Roeland Park 1-02,State Treasurer,,D,Carmen Alldritt,112
-Johnson,Roeland Park 2-01,State Treasurer,,D,Carmen Alldritt,147
-Johnson,Roeland Park 2-02,State Treasurer,,D,Carmen Alldritt,182
-Johnson,Roeland Park 3-01,State Treasurer,,D,Carmen Alldritt,137
-Johnson,Roeland Park 3-02,State Treasurer,,D,Carmen Alldritt,258
-Johnson,Roeland Park 4-01,State Treasurer,,D,Carmen Alldritt,86
-Johnson,Roeland Park 4-02,State Treasurer,,D,Carmen Alldritt,312
-Johnson,Shawnee 1-01,State Treasurer,,D,Carmen Alldritt,285
-Johnson,Shawnee 1-02,State Treasurer,,D,Carmen Alldritt,192
-Johnson,Shawnee 1-03,State Treasurer,,D,Carmen Alldritt,181
-Johnson,Shawnee 1-04,State Treasurer,,D,Carmen Alldritt,257
-Johnson,Shawnee 1-05,State Treasurer,,D,Carmen Alldritt,299
-Johnson,Shawnee 1-06,State Treasurer,,D,Carmen Alldritt,191
-Johnson,Shawnee 1-07,State Treasurer,,D,Carmen Alldritt,231
-Johnson,Shawnee 1-08,State Treasurer,,D,Carmen Alldritt,217
-Johnson,Shawnee 1-09,State Treasurer,,D,Carmen Alldritt,45
-Johnson,Shawnee 1-10,State Treasurer,,D,Carmen Alldritt,74
-Johnson,Shawnee 1-11,State Treasurer,,D,Carmen Alldritt,132
-Johnson,Shawnee 1-12,State Treasurer,,D,Carmen Alldritt,1
-Johnson,Shawnee 2-01,State Treasurer,,D,Carmen Alldritt,98
-Johnson,Shawnee 2-02,State Treasurer,,D,Carmen Alldritt,212
-Johnson,Shawnee 2-03,State Treasurer,,D,Carmen Alldritt,184
-Johnson,Shawnee 2-04,State Treasurer,,D,Carmen Alldritt,281
-Johnson,Shawnee 2-05,State Treasurer,,D,Carmen Alldritt,124
-Johnson,Shawnee 2-06,State Treasurer,,D,Carmen Alldritt,159
-Johnson,Shawnee 2-07,State Treasurer,,D,Carmen Alldritt,145
-Johnson,Shawnee 2-08,State Treasurer,,D,Carmen Alldritt,134
-Johnson,Shawnee 2-09,State Treasurer,,D,Carmen Alldritt,147
-Johnson,Shawnee 2-10,State Treasurer,,D,Carmen Alldritt,129
-Johnson,Shawnee 2-11,State Treasurer,,D,Carmen Alldritt,192
-Johnson,Shawnee 2-12,State Treasurer,,D,Carmen Alldritt,72
-Johnson,Shawnee 2-13,State Treasurer,,D,Carmen Alldritt,101
-Johnson,Shawnee 3-01,State Treasurer,,D,Carmen Alldritt,115
-Johnson,Shawnee 3-02,State Treasurer,,D,Carmen Alldritt,221
-Johnson,Shawnee 3-03,State Treasurer,,D,Carmen Alldritt,199
-Johnson,Shawnee 3-04,State Treasurer,,D,Carmen Alldritt,158
-Johnson,Shawnee 3-05,State Treasurer,,D,Carmen Alldritt,204
-Johnson,Shawnee 3-06,State Treasurer,,D,Carmen Alldritt,196
-Johnson,Shawnee 3-07,State Treasurer,,D,Carmen Alldritt,217
-Johnson,Shawnee 3-08,State Treasurer,,D,Carmen Alldritt,202
-Johnson,Shawnee 3-09,State Treasurer,,D,Carmen Alldritt,94
-Johnson,Shawnee 4-01,State Treasurer,,D,Carmen Alldritt,258
-Johnson,Shawnee 4-02,State Treasurer,,D,Carmen Alldritt,143
-Johnson,Shawnee 4-03,State Treasurer,,D,Carmen Alldritt,71
-Johnson,Shawnee 4-04,State Treasurer,,D,Carmen Alldritt,103
-Johnson,Shawnee 4-05,State Treasurer,,D,Carmen Alldritt,252
-Johnson,Shawnee 4-06,State Treasurer,,D,Carmen Alldritt,186
-Johnson,Shawnee 4-07,State Treasurer,,D,Carmen Alldritt,226
-Johnson,Shawnee 4-08,State Treasurer,,D,Carmen Alldritt,85
-Johnson,Shawnee 4-09,State Treasurer,,D,Carmen Alldritt,335
-Johnson,Shawnee 4-11,State Treasurer,,D,Carmen Alldritt,170
-Johnson,Shawnee 4-12,State Treasurer,,D,Carmen Alldritt,31
-Johnson,Spring Hill 0-01,State Treasurer,,D,Carmen Alldritt,273
-Johnson,Spring Hill 0-03,State Treasurer,,D,Carmen Alldritt,18
-Johnson,Spring Hill 0-04,State Treasurer,,D,Carmen Alldritt,0
-Johnson,Spring Hill Twp 0-01,State Treasurer,,D,Carmen Alldritt,167
-Johnson,Spring Hill Twp 0-02,State Treasurer,,D,Carmen Alldritt,1
-Johnson,Spring Hill Twp 0-03,State Treasurer,,D,Carmen Alldritt,16
-Johnson,Spring Hill Twp 0-04,State Treasurer,,D,Carmen Alldritt,2
-Johnson,Spring Hill Twp 0-05,State Treasurer,,D,Carmen Alldritt,5
-Johnson,Westwood 0-01,State Treasurer,,D,Carmen Alldritt,191
-Johnson,Westwood 0-02,State Treasurer,,D,Carmen Alldritt,176
-Johnson,Westwood Hills 0-01,State Treasurer,,D,Carmen Alldritt,115
-Johnson,Aubry Twp 0-01,State Treasurer,,,Write-ins,0
-Johnson,Aubry Twp 0-02,State Treasurer,,,Write-ins,1
-Johnson,Aubry Twp 0-03,State Treasurer,,,Write-ins,0
-Johnson,Aubry Twp 0-04,State Treasurer,,,Write-ins,0
-Johnson,Aubry Twp 0-05,State Treasurer,,,Write-ins,0
-Johnson,Aubry Twp 0-06,State Treasurer,,,Write-ins,0
-Johnson,De Soto 0-01,State Treasurer,,,Write-ins,1
-Johnson,De Soto 0-02,State Treasurer,,,Write-ins,0
-Johnson,De Soto 0-03,State Treasurer,,,Write-ins,0
-Johnson,De Soto 0-06,State Treasurer,,,Write-ins,0
-Johnson,De Soto 0-07,State Treasurer,,,Write-ins,0
-Johnson,Edgerton,State Treasurer,,,Write-ins,0
-Johnson,Fairway 1-01,State Treasurer,,,Write-ins,0
-Johnson,Fairway 1-02,State Treasurer,,,Write-ins,0
-Johnson,Fairway 2-01,State Treasurer,,,Write-ins,0
-Johnson,Fairway 2-02,State Treasurer,,,Write-ins,0
-Johnson,Fairway 3-01,State Treasurer,,,Write-ins,0
-Johnson,Fairway 3-02,State Treasurer,,,Write-ins,0
-Johnson,Fairway 4-01,State Treasurer,,,Write-ins,1
-Johnson,Fairway 4-02,State Treasurer,,,Write-ins,0
-Johnson,Fairway 4-03,State Treasurer,,,Write-ins,0
-Johnson,Fairway 4-04,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-01,State Treasurer,,,Write-ins,2
-Johnson,Gardner 0-02,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-03,State Treasurer,,,Write-ins,1
-Johnson,Gardner 0-04,State Treasurer,,,Write-ins,1
-Johnson,Gardner 0-06,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-07,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-08,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-09,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-10,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-12,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-13,State Treasurer,,,Write-ins,0
-Johnson,Gardner 0-14,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-01,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-02,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-04,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-05,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-07,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-08,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-09,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-10,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-11,State Treasurer,,,Write-ins,0
-Johnson,Gardner Twp 0-13,State Treasurer,,,Write-ins,0
-Johnson,Lake Quivira,State Treasurer,,,Write-ins,0
-Johnson,Leawood 1-01,State Treasurer,,,Write-ins,0
-Johnson,Leawood 1-02,State Treasurer,,,Write-ins,0
-Johnson,Leawood 1-03,State Treasurer,,,Write-ins,0
-Johnson,Leawood 1-04,State Treasurer,,,Write-ins,1
-Johnson,Leawood 1-05,State Treasurer,,,Write-ins,0
-Johnson,Leawood 1-06,State Treasurer,,,Write-ins,0
-Johnson,Leawood 2-01,State Treasurer,,,Write-ins,0
-Johnson,Leawood 2-02,State Treasurer,,,Write-ins,1
-Johnson,Leawood 2-03,State Treasurer,,,Write-ins,0
-Johnson,Leawood 2-04,State Treasurer,,,Write-ins,0
-Johnson,Leawood 2-05,State Treasurer,,,Write-ins,1
-Johnson,Leawood 2-06,State Treasurer,,,Write-ins,0
-Johnson,Leawood 3-01,State Treasurer,,,Write-ins,0
-Johnson,Leawood 3-02,State Treasurer,,,Write-ins,1
-Johnson,Leawood 3-03,State Treasurer,,,Write-ins,0
-Johnson,Leawood 3-04,State Treasurer,,,Write-ins,1
-Johnson,Leawood 3-05,State Treasurer,,,Write-ins,0
-Johnson,Leawood 3-06,State Treasurer,,,Write-ins,0
-Johnson,Leawood 3-07,State Treasurer,,,Write-ins,0
-Johnson,Leawood 4-01,State Treasurer,,,Write-ins,0
-Johnson,Leawood 4-02,State Treasurer,,,Write-ins,1
-Johnson,Leawood 4-03,State Treasurer,,,Write-ins,0
-Johnson,Leawood 4-04,State Treasurer,,,Write-ins,0
-Johnson,Leawood 4-05,State Treasurer,,,Write-ins,0
-Johnson,Leawood 4-06,State Treasurer,,,Write-ins,0
-Johnson,Leawood 4-07,State Treasurer,,,Write-ins,1
-Johnson,Leawood 4-08,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-01,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-02,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-03,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-04,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-05,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-06,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-07,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-08,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 1-09,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 2-01,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 2-02,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 2-03,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 2-04,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 2-05,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 2-06,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 2-07,State Treasurer,,,Write-ins,2
-Johnson,Lenexa 3-01,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 3-02,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 3-03,State Treasurer,,,Write-ins,1
-Johnson,Lenexa 3-04,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 3-05,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 3-06,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 3-07,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 3-08,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 4-01,State Treasurer,,,Write-ins,2
-Johnson,Lenexa 4-02,State Treasurer,,,Write-ins,1
-Johnson,Lenexa 4-03,State Treasurer,,,Write-ins,1
-Johnson,Lenexa 4-04,State Treasurer,,,Write-ins,1
-Johnson,Lenexa 4-05,State Treasurer,,,Write-ins,1
-Johnson,Lenexa 4-06,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 4-07,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 4-08,State Treasurer,,,Write-ins,1
-Johnson,Lenexa 4-09,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 4-10,State Treasurer,,,Write-ins,0
-Johnson,Lenexa 4-11,State Treasurer,,,Write-ins,0
-Johnson,Lexington Twp 0-01,State Treasurer,,,Write-ins,0
-Johnson,Lexington Twp 0-02,State Treasurer,,,Write-ins,0
-Johnson,Lexington Twp 0-03,State Treasurer,,,Write-ins,0
-Johnson,McCamish Twp 0-01,State Treasurer,,,Write-ins,0
-Johnson,McCamish Twp 0-02,State Treasurer,,,Write-ins,0
-Johnson,Merriam 1-01,State Treasurer,,,Write-ins,1
-Johnson,Merriam 1-02,State Treasurer,,,Write-ins,1
-Johnson,Merriam 2-01,State Treasurer,,,Write-ins,0
-Johnson,Merriam 2-02,State Treasurer,,,Write-ins,0
-Johnson,Merriam 2-03,State Treasurer,,,Write-ins,0
-Johnson,Merriam 3-01,State Treasurer,,,Write-ins,1
-Johnson,Merriam 3-02,State Treasurer,,,Write-ins,0
-Johnson,Merriam 4-01,State Treasurer,,,Write-ins,0
-Johnson,Merriam 4-02,State Treasurer,,,Write-ins,1
-Johnson,Merriam 4-03,State Treasurer,,,Write-ins,0
-Johnson,Mission 1-01,State Treasurer,,,Write-ins,0
-Johnson,Mission 1-02,State Treasurer,,,Write-ins,0
-Johnson,Mission 2-01,State Treasurer,,,Write-ins,0
-Johnson,Mission 2-02,State Treasurer,,,Write-ins,0
-Johnson,Mission 3-01,State Treasurer,,,Write-ins,0
-Johnson,Mission 3-02,State Treasurer,,,Write-ins,0
-Johnson,Mission 4-01,State Treasurer,,,Write-ins,0
-Johnson,Mission 4-02,State Treasurer,,,Write-ins,0
-Johnson,Mission 4-03,State Treasurer,,,Write-ins,0
-Johnson,Mission Hills 0-01,State Treasurer,,,Write-ins,0
-Johnson,Mission Hills 0-02,State Treasurer,,,Write-ins,0
-Johnson,Mission Hills 0-03,State Treasurer,,,Write-ins,0
-Johnson,Mission Hills 0-04,State Treasurer,,,Write-ins,0
-Johnson,Mission Woods,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-01,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-02,State Treasurer,,,Write-ins,1
-Johnson,Olathe 1-03,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-04,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-05,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-06,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-08,State Treasurer,,,Write-ins,1
-Johnson,Olathe 1-09,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-11,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-14,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-15,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-16,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-17,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-18,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-19,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-20,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-21,State Treasurer,,,Write-ins,2
-Johnson,Olathe 1-22,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-23,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-24,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-24,State Treasurer,,,Write-ins,1
-Johnson,Olathe 1-26,State Treasurer,,,Write-ins,0
-Johnson,Olathe 1-27,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-01,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-02,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-03,State Treasurer,,,Write-ins,1
-Johnson,Olathe 2-04,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-05,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-06,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-07,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-08,State Treasurer,,,Write-ins,1
-Johnson,Olathe 2-09,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-10,State Treasurer,,,Write-ins,1
-Johnson,Olathe 2-11,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-12,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-13,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-14,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-15,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-16,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-17,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-19,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-22,State Treasurer,,,Write-ins,0
-Johnson,Olathe 2-23,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-01,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-02,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-03,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-04,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-05,State Treasurer,,,Write-ins,1
-Johnson,Olathe 3-06,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-07,State Treasurer,,,Write-ins,3
-Johnson,Olathe 3-08,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-09,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-10,State Treasurer,,,Write-ins,1
-Johnson,Olathe 3-11,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-12,State Treasurer,,,Write-ins,1
-Johnson,Olathe 3-13,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-15,State Treasurer,,,Write-ins,1
-Johnson,Olathe 3-16,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-17,State Treasurer,,,Write-ins,1
-Johnson,Olathe 3-18,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-19,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-20,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-21,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-22,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-23,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-24,State Treasurer,,,Write-ins,0
-Johnson,Olathe 3-26,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-01,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-02,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-03,State Treasurer,,,Write-ins,1
-Johnson,Olathe 4-04,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-05,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-06,State Treasurer,,,Write-ins,1
-Johnson,Olathe 4-07,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-08,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-09,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-10,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-11,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-12,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-13,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-14,State Treasurer,,,Write-ins,1
-Johnson,Olathe 4-15,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-16,State Treasurer,,,Write-ins,0
-Johnson,Olathe 4-17,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-01,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-02,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-03,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-04,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-05,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-06,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-07,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-08,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-10,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-11,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-14,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-24,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-25,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-26,State Treasurer,,,Write-ins,0
-Johnson,Olathe Twp 0-32,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-01,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-02,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 1-03,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-04,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 1-05,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-06,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-07,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-08,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 1-09,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-10,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 1-11,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-12,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-13,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-14,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-15,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-16,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-17,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-18,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-19,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 1-20,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-21,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 1-22,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-01,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-02,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-03,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 2-04,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-05,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 2-06,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 2-07,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-08,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-09,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 2-10,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-11,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-12,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 2-13,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-14,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-15,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 2-16,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-17,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-18,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-19,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-20,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-21,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-22,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-23,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-24,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-25,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 2-26,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-01,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-02,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-03,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-04,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-05,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-06,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-07,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-08,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-09,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-10,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-11,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-12,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-13,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-14,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-15,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-16,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-17,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-18,State Treasurer,,,Write-ins,2
-Johnson,Overland Park 3-19,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-20,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 3-21,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-01,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-02,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-03,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-04,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-05,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-06,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-07,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-08,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 4-09,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-10,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-11,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-12,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 4-13,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-14,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-15,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-16,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-17,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 4-18,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-01,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-02,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-03,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-04,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-05,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-06,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-07,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-08,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-09,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-10,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-11,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-12,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-13,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-14,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-15,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-16,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-17,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-18,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 5-19,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-01,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-02,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-03,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-04,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-05,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-06,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-07,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 6-08,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-09,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 6-10,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-11,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-12,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-13,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 6-15,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-16,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-17,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 6-18,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-19,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-20,State Treasurer,,,Write-ins,0
-Johnson,Overland Park 6-21,State Treasurer,,,Write-ins,1
-Johnson,Overland Park 6-22,State Treasurer,,,Write-ins,0
-Johnson,Oxford Twp 0-01,State Treasurer,,,Write-ins,0
-Johnson,Oxford Twp 0-02,State Treasurer,,,Write-ins,0
-Johnson,Oxford Twp 0-04,State Treasurer,,,Write-ins,0
-Johnson,Oxford Twp 0-05,State Treasurer,,,Write-ins,0
-Johnson,Oxford Twp 0-09,State Treasurer,,,Write-ins,0
-Johnson,Oxford Twp 0-10,State Treasurer,,,Write-ins,0
-Johnson,Oxford Twp 0-11,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 1-01,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 1-02,State Treasurer,,,Write-ins,1
-Johnson,Prairie Village 1-03,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 2-01,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 2-02,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 2-03,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 3-01,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 3-02,State Treasurer,,,Write-ins,1
-Johnson,Prairie Village 3-03,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 4-01,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 4-02,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 4-03,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 5-01,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 5-02,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 5-03,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 6-01,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 6-02,State Treasurer,,,Write-ins,0
-Johnson,Prairie Village 6-03,State Treasurer,,,Write-ins,0
-Johnson,Roeland Park 1-01,State Treasurer,,,Write-ins,0
-Johnson,Roeland Park 1-02,State Treasurer,,,Write-ins,0
-Johnson,Roeland Park 2-01,State Treasurer,,,Write-ins,0
-Johnson,Roeland Park 2-02,State Treasurer,,,Write-ins,1
-Johnson,Roeland Park 3-01,State Treasurer,,,Write-ins,0
-Johnson,Roeland Park 3-02,State Treasurer,,,Write-ins,0
-Johnson,Roeland Park 4-01,State Treasurer,,,Write-ins,0
-Johnson,Roeland Park 4-02,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 1-01,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 1-02,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 1-03,State Treasurer,,,Write-ins,2
-Johnson,Shawnee 1-04,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 1-05,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 1-06,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 1-07,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 1-08,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 1-09,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 1-10,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 1-11,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 1-12,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-01,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-02,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-03,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-04,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-05,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-06,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-07,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-08,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 2-09,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-10,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 2-11,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-12,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 2-13,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 3-01,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 3-02,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 3-03,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 3-04,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 3-05,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 3-06,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 3-07,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 3-08,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 3-09,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-01,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-02,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-03,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-04,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 4-05,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-06,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-07,State Treasurer,,,Write-ins,1
-Johnson,Shawnee 4-08,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-09,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-11,State Treasurer,,,Write-ins,0
-Johnson,Shawnee 4-12,State Treasurer,,,Write-ins,0
-Johnson,Spring Hill 0-01,State Treasurer,,,Write-ins,1
-Johnson,Spring Hill 0-03,State Treasurer,,,Write-ins,0
-Johnson,Spring Hill 0-04,State Treasurer,,,Write-ins,0
-Johnson,Spring Hill Twp 0-01,State Treasurer,,,Write-ins,2
-Johnson,Spring Hill Twp 0-02,State Treasurer,,,Write-ins,0
-Johnson,Spring Hill Twp 0-03,State Treasurer,,,Write-ins,0
-Johnson,Spring Hill Twp 0-04,State Treasurer,,,Write-ins,0
-Johnson,Spring Hill Twp 0-05,State Treasurer,,,Write-ins,0
-Johnson,Westwood 0-01,State Treasurer,,,Write-ins,0
-Johnson,Westwood 0-02,State Treasurer,,,Write-ins,0
-Johnson,Westwood Hills 0-01,State Treasurer,,,Write-ins,0
-Johnson,Aubry Twp 0-01,Insurance Commissioner,,R,Ken Selzer,70
-Johnson,Aubry Twp 0-02,Insurance Commissioner,,R,Ken Selzer,415
-Johnson,Aubry Twp 0-03,Insurance Commissioner,,R,Ken Selzer,222
-Johnson,Aubry Twp 0-04,Insurance Commissioner,,R,Ken Selzer,502
-Johnson,Aubry Twp 0-05,Insurance Commissioner,,R,Ken Selzer,10
-Johnson,Aubry Twp 0-06,Insurance Commissioner,,R,Ken Selzer,67
-Johnson,De Soto 0-01,Insurance Commissioner,,R,Ken Selzer,383
-Johnson,De Soto 0-02,Insurance Commissioner,,R,Ken Selzer,215
-Johnson,De Soto 0-03,Insurance Commissioner,,R,Ken Selzer,415
-Johnson,De Soto 0-06,Insurance Commissioner,,R,Ken Selzer,31
-Johnson,De Soto 0-07,Insurance Commissioner,,R,Ken Selzer,1
-Johnson,Edgerton,Insurance Commissioner,,R,Ken Selzer,262
-Johnson,Fairway 1-01,Insurance Commissioner,,R,Ken Selzer,136
-Johnson,Fairway 1-02,Insurance Commissioner,,R,Ken Selzer,103
-Johnson,Fairway 2-01,Insurance Commissioner,,R,Ken Selzer,101
-Johnson,Fairway 2-02,Insurance Commissioner,,R,Ken Selzer,102
-Johnson,Fairway 3-01,Insurance Commissioner,,R,Ken Selzer,154
-Johnson,Fairway 3-02,Insurance Commissioner,,R,Ken Selzer,131
-Johnson,Fairway 4-01,Insurance Commissioner,,R,Ken Selzer,29
-Johnson,Fairway 4-02,Insurance Commissioner,,R,Ken Selzer,38
-Johnson,Fairway 4-03,Insurance Commissioner,,R,Ken Selzer,32
-Johnson,Fairway 4-04,Insurance Commissioner,,R,Ken Selzer,48
-Johnson,Gardner 0-01,Insurance Commissioner,,R,Ken Selzer,496
-Johnson,Gardner 0-02,Insurance Commissioner,,R,Ken Selzer,65
-Johnson,Gardner 0-03,Insurance Commissioner,,R,Ken Selzer,296
-Johnson,Gardner 0-04,Insurance Commissioner,,R,Ken Selzer,284
-Johnson,Gardner 0-06,Insurance Commissioner,,R,Ken Selzer,388
-Johnson,Gardner 0-07,Insurance Commissioner,,R,Ken Selzer,6
-Johnson,Gardner 0-08,Insurance Commissioner,,R,Ken Selzer,36
-Johnson,Gardner 0-09,Insurance Commissioner,,R,Ken Selzer,406
-Johnson,Gardner 0-10,Insurance Commissioner,,R,Ken Selzer,281
-Johnson,Gardner 0-12,Insurance Commissioner,,R,Ken Selzer,8
-Johnson,Gardner 0-13,Insurance Commissioner,,R,Ken Selzer,282
-Johnson,Gardner 0-14,Insurance Commissioner,,R,Ken Selzer,243
-Johnson,Gardner Twp 0-01,Insurance Commissioner,,R,Ken Selzer,198
-Johnson,Gardner Twp 0-02,Insurance Commissioner,,R,Ken Selzer,236
-Johnson,Gardner Twp 0-04,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Gardner Twp 0-05,Insurance Commissioner,,R,Ken Selzer,5
-Johnson,Gardner Twp 0-07,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Gardner Twp 0-08,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Gardner Twp 0-09,Insurance Commissioner,,R,Ken Selzer,0
-Johnson,Gardner Twp 0-10,Insurance Commissioner,,R,Ken Selzer,0
-Johnson,Gardner Twp 0-11,Insurance Commissioner,,R,Ken Selzer,52
-Johnson,Gardner Twp 0-13,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Lake Quivira,Insurance Commissioner,,R,Ken Selzer,338
-Johnson,Leawood 1-01,Insurance Commissioner,,R,Ken Selzer,261
-Johnson,Leawood 1-02,Insurance Commissioner,,R,Ken Selzer,484
-Johnson,Leawood 1-03,Insurance Commissioner,,R,Ken Selzer,423
-Johnson,Leawood 1-04,Insurance Commissioner,,R,Ken Selzer,325
-Johnson,Leawood 1-05,Insurance Commissioner,,R,Ken Selzer,290
-Johnson,Leawood 1-06,Insurance Commissioner,,R,Ken Selzer,65
-Johnson,Leawood 2-01,Insurance Commissioner,,R,Ken Selzer,381
-Johnson,Leawood 2-02,Insurance Commissioner,,R,Ken Selzer,437
-Johnson,Leawood 2-03,Insurance Commissioner,,R,Ken Selzer,444
-Johnson,Leawood 2-04,Insurance Commissioner,,R,Ken Selzer,585
-Johnson,Leawood 2-05,Insurance Commissioner,,R,Ken Selzer,268
-Johnson,Leawood 2-06,Insurance Commissioner,,R,Ken Selzer,207
-Johnson,Leawood 3-01,Insurance Commissioner,,R,Ken Selzer,251
-Johnson,Leawood 3-02,Insurance Commissioner,,R,Ken Selzer,430
-Johnson,Leawood 3-03,Insurance Commissioner,,R,Ken Selzer,296
-Johnson,Leawood 3-04,Insurance Commissioner,,R,Ken Selzer,120
-Johnson,Leawood 3-05,Insurance Commissioner,,R,Ken Selzer,568
-Johnson,Leawood 3-06,Insurance Commissioner,,R,Ken Selzer,597
-Johnson,Leawood 3-07,Insurance Commissioner,,R,Ken Selzer,418
-Johnson,Leawood 4-01,Insurance Commissioner,,R,Ken Selzer,148
-Johnson,Leawood 4-02,Insurance Commissioner,,R,Ken Selzer,420
-Johnson,Leawood 4-03,Insurance Commissioner,,R,Ken Selzer,372
-Johnson,Leawood 4-04,Insurance Commissioner,,R,Ken Selzer,466
-Johnson,Leawood 4-05,Insurance Commissioner,,R,Ken Selzer,472
-Johnson,Leawood 4-06,Insurance Commissioner,,R,Ken Selzer,405
-Johnson,Leawood 4-07,Insurance Commissioner,,R,Ken Selzer,633
-Johnson,Leawood 4-08,Insurance Commissioner,,R,Ken Selzer,302
-Johnson,Lenexa 1-01,Insurance Commissioner,,R,Ken Selzer,226
-Johnson,Lenexa 1-02,Insurance Commissioner,,R,Ken Selzer,393
-Johnson,Lenexa 1-03,Insurance Commissioner,,R,Ken Selzer,472
-Johnson,Lenexa 1-04,Insurance Commissioner,,R,Ken Selzer,280
-Johnson,Lenexa 1-05,Insurance Commissioner,,R,Ken Selzer,325
-Johnson,Lenexa 1-06,Insurance Commissioner,,R,Ken Selzer,429
-Johnson,Lenexa 1-07,Insurance Commissioner,,R,Ken Selzer,195
-Johnson,Lenexa 1-08,Insurance Commissioner,,R,Ken Selzer,84
-Johnson,Lenexa 1-09,Insurance Commissioner,,R,Ken Selzer,4
-Johnson,Lenexa 2-01,Insurance Commissioner,,R,Ken Selzer,618
-Johnson,Lenexa 2-02,Insurance Commissioner,,R,Ken Selzer,233
-Johnson,Lenexa 2-03,Insurance Commissioner,,R,Ken Selzer,521
-Johnson,Lenexa 2-04,Insurance Commissioner,,R,Ken Selzer,595
-Johnson,Lenexa 2-05,Insurance Commissioner,,R,Ken Selzer,239
-Johnson,Lenexa 2-06,Insurance Commissioner,,R,Ken Selzer,374
-Johnson,Lenexa 2-07,Insurance Commissioner,,R,Ken Selzer,550
-Johnson,Lenexa 3-01,Insurance Commissioner,,R,Ken Selzer,204
-Johnson,Lenexa 3-02,Insurance Commissioner,,R,Ken Selzer,338
-Johnson,Lenexa 3-03,Insurance Commissioner,,R,Ken Selzer,479
-Johnson,Lenexa 3-04,Insurance Commissioner,,R,Ken Selzer,331
-Johnson,Lenexa 3-05,Insurance Commissioner,,R,Ken Selzer,146
-Johnson,Lenexa 3-06,Insurance Commissioner,,R,Ken Selzer,246
-Johnson,Lenexa 3-07,Insurance Commissioner,,R,Ken Selzer,372
-Johnson,Lenexa 3-08,Insurance Commissioner,,R,Ken Selzer,400
-Johnson,Lenexa 4-01,Insurance Commissioner,,R,Ken Selzer,139
-Johnson,Lenexa 4-02,Insurance Commissioner,,R,Ken Selzer,324
-Johnson,Lenexa 4-03,Insurance Commissioner,,R,Ken Selzer,100
-Johnson,Lenexa 4-04,Insurance Commissioner,,R,Ken Selzer,154
-Johnson,Lenexa 4-05,Insurance Commissioner,,R,Ken Selzer,118
-Johnson,Lenexa 4-06,Insurance Commissioner,,R,Ken Selzer,218
-Johnson,Lenexa 4-07,Insurance Commissioner,,R,Ken Selzer,279
-Johnson,Lenexa 4-08,Insurance Commissioner,,R,Ken Selzer,305
-Johnson,Lenexa 4-09,Insurance Commissioner,,R,Ken Selzer,288
-Johnson,Lenexa 4-10,Insurance Commissioner,,R,Ken Selzer,146
-Johnson,Lenexa 4-11,Insurance Commissioner,,R,Ken Selzer,35
-Johnson,Lexington Twp 0-01,Insurance Commissioner,,R,Ken Selzer,413
-Johnson,Lexington Twp 0-02,Insurance Commissioner,,R,Ken Selzer,1
-Johnson,Lexington Twp 0-03,Insurance Commissioner,,R,Ken Selzer,1
-Johnson,McCamish Twp 0-01,Insurance Commissioner,,R,Ken Selzer,107
-Johnson,McCamish Twp 0-02,Insurance Commissioner,,R,Ken Selzer,210
-Johnson,Merriam 1-01,Insurance Commissioner,,R,Ken Selzer,151
-Johnson,Merriam 1-02,Insurance Commissioner,,R,Ken Selzer,172
-Johnson,Merriam 2-01,Insurance Commissioner,,R,Ken Selzer,264
-Johnson,Merriam 2-02,Insurance Commissioner,,R,Ken Selzer,0
-Johnson,Merriam 2-03,Insurance Commissioner,,R,Ken Selzer,119
-Johnson,Merriam 3-01,Insurance Commissioner,,R,Ken Selzer,170
-Johnson,Merriam 3-02,Insurance Commissioner,,R,Ken Selzer,187
-Johnson,Merriam 4-01,Insurance Commissioner,,R,Ken Selzer,266
-Johnson,Merriam 4-02,Insurance Commissioner,,R,Ken Selzer,103
-Johnson,Merriam 4-03,Insurance Commissioner,,R,Ken Selzer,129
-Johnson,Mission 1-01,Insurance Commissioner,,R,Ken Selzer,221
-Johnson,Mission 1-02,Insurance Commissioner,,R,Ken Selzer,79
-Johnson,Mission 2-01,Insurance Commissioner,,R,Ken Selzer,120
-Johnson,Mission 2-02,Insurance Commissioner,,R,Ken Selzer,151
-Johnson,Mission 3-01,Insurance Commissioner,,R,Ken Selzer,167
-Johnson,Mission 3-02,Insurance Commissioner,,R,Ken Selzer,100
-Johnson,Mission 4-01,Insurance Commissioner,,R,Ken Selzer,121
-Johnson,Mission 4-02,Insurance Commissioner,,R,Ken Selzer,212
-Johnson,Mission 4-03,Insurance Commissioner,,R,Ken Selzer,112
-Johnson,Mission Hills 0-01,Insurance Commissioner,,R,Ken Selzer,279
-Johnson,Mission Hills 0-02,Insurance Commissioner,,R,Ken Selzer,347
-Johnson,Mission Hills 0-03,Insurance Commissioner,,R,Ken Selzer,232
-Johnson,Mission Hills 0-04,Insurance Commissioner,,R,Ken Selzer,368
-Johnson,Mission Woods,Insurance Commissioner,,R,Ken Selzer,53
-Johnson,Olathe 1-01,Insurance Commissioner,,R,Ken Selzer,311
-Johnson,Olathe 1-02,Insurance Commissioner,,R,Ken Selzer,194
-Johnson,Olathe 1-03,Insurance Commissioner,,R,Ken Selzer,165
-Johnson,Olathe 1-04,Insurance Commissioner,,R,Ken Selzer,300
-Johnson,Olathe 1-05,Insurance Commissioner,,R,Ken Selzer,358
-Johnson,Olathe 1-06,Insurance Commissioner,,R,Ken Selzer,224
-Johnson,Olathe 1-08,Insurance Commissioner,,R,Ken Selzer,353
-Johnson,Olathe 1-09,Insurance Commissioner,,R,Ken Selzer,368
-Johnson,Olathe 1-11,Insurance Commissioner,,R,Ken Selzer,58
-Johnson,Olathe 1-14,Insurance Commissioner,,R,Ken Selzer,328
-Johnson,Olathe 1-15,Insurance Commissioner,,R,Ken Selzer,294
-Johnson,Olathe 1-16,Insurance Commissioner,,R,Ken Selzer,409
-Johnson,Olathe 1-17,Insurance Commissioner,,R,Ken Selzer,107
-Johnson,Olathe 1-18,Insurance Commissioner,,R,Ken Selzer,112
-Johnson,Olathe 1-19,Insurance Commissioner,,R,Ken Selzer,140
-Johnson,Olathe 1-20,Insurance Commissioner,,R,Ken Selzer,198
-Johnson,Olathe 1-21,Insurance Commissioner,,R,Ken Selzer,380
-Johnson,Olathe 1-22,Insurance Commissioner,,R,Ken Selzer,593
-Johnson,Olathe 1-23,Insurance Commissioner,,R,Ken Selzer,1
-Johnson,Olathe 1-24,Insurance Commissioner,,R,Ken Selzer,52
-Johnson,Olathe 1-24,Insurance Commissioner,,R,Ken Selzer,88
-Johnson,Olathe 1-26,Insurance Commissioner,,R,Ken Selzer,0
-Johnson,Olathe 1-27,Insurance Commissioner,,R,Ken Selzer,206
-Johnson,Olathe 2-01,Insurance Commissioner,,R,Ken Selzer,140
-Johnson,Olathe 2-02,Insurance Commissioner,,R,Ken Selzer,208
-Johnson,Olathe 2-03,Insurance Commissioner,,R,Ken Selzer,237
-Johnson,Olathe 2-04,Insurance Commissioner,,R,Ken Selzer,226
-Johnson,Olathe 2-05,Insurance Commissioner,,R,Ken Selzer,881
-Johnson,Olathe 2-06,Insurance Commissioner,,R,Ken Selzer,460
-Johnson,Olathe 2-07,Insurance Commissioner,,R,Ken Selzer,487
-Johnson,Olathe 2-08,Insurance Commissioner,,R,Ken Selzer,322
-Johnson,Olathe 2-09,Insurance Commissioner,,R,Ken Selzer,147
-Johnson,Olathe 2-10,Insurance Commissioner,,R,Ken Selzer,602
-Johnson,Olathe 2-11,Insurance Commissioner,,R,Ken Selzer,423
-Johnson,Olathe 2-12,Insurance Commissioner,,R,Ken Selzer,243
-Johnson,Olathe 2-13,Insurance Commissioner,,R,Ken Selzer,236
-Johnson,Olathe 2-14,Insurance Commissioner,,R,Ken Selzer,257
-Johnson,Olathe 2-15,Insurance Commissioner,,R,Ken Selzer,297
-Johnson,Olathe 2-16,Insurance Commissioner,,R,Ken Selzer,71
-Johnson,Olathe 2-17,Insurance Commissioner,,R,Ken Selzer,0
-Johnson,Olathe 2-19,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Olathe 2-22,Insurance Commissioner,,R,Ken Selzer,528
-Johnson,Olathe 2-23,Insurance Commissioner,,R,Ken Selzer,329
-Johnson,Olathe 3-01,Insurance Commissioner,,R,Ken Selzer,131
-Johnson,Olathe 3-02,Insurance Commissioner,,R,Ken Selzer,405
-Johnson,Olathe 3-03,Insurance Commissioner,,R,Ken Selzer,223
-Johnson,Olathe 3-04,Insurance Commissioner,,R,Ken Selzer,383
-Johnson,Olathe 3-05,Insurance Commissioner,,R,Ken Selzer,419
-Johnson,Olathe 3-06,Insurance Commissioner,,R,Ken Selzer,291
-Johnson,Olathe 3-07,Insurance Commissioner,,R,Ken Selzer,268
-Johnson,Olathe 3-08,Insurance Commissioner,,R,Ken Selzer,411
-Johnson,Olathe 3-09,Insurance Commissioner,,R,Ken Selzer,203
-Johnson,Olathe 3-10,Insurance Commissioner,,R,Ken Selzer,417
-Johnson,Olathe 3-11,Insurance Commissioner,,R,Ken Selzer,261
-Johnson,Olathe 3-12,Insurance Commissioner,,R,Ken Selzer,342
-Johnson,Olathe 3-13,Insurance Commissioner,,R,Ken Selzer,406
-Johnson,Olathe 3-15,Insurance Commissioner,,R,Ken Selzer,262
-Johnson,Olathe 3-16,Insurance Commissioner,,R,Ken Selzer,289
-Johnson,Olathe 3-17,Insurance Commissioner,,R,Ken Selzer,401
-Johnson,Olathe 3-18,Insurance Commissioner,,R,Ken Selzer,377
-Johnson,Olathe 3-19,Insurance Commissioner,,R,Ken Selzer,275
-Johnson,Olathe 3-20,Insurance Commissioner,,R,Ken Selzer,262
-Johnson,Olathe 3-21,Insurance Commissioner,,R,Ken Selzer,294
-Johnson,Olathe 3-22,Insurance Commissioner,,R,Ken Selzer,340
-Johnson,Olathe 3-23,Insurance Commissioner,,R,Ken Selzer,288
-Johnson,Olathe 3-24,Insurance Commissioner,,R,Ken Selzer,174
-Johnson,Olathe 3-26,Insurance Commissioner,,R,Ken Selzer,29
-Johnson,Olathe 4-01,Insurance Commissioner,,R,Ken Selzer,250
-Johnson,Olathe 4-02,Insurance Commissioner,,R,Ken Selzer,477
-Johnson,Olathe 4-03,Insurance Commissioner,,R,Ken Selzer,120
-Johnson,Olathe 4-04,Insurance Commissioner,,R,Ken Selzer,158
-Johnson,Olathe 4-05,Insurance Commissioner,,R,Ken Selzer,324
-Johnson,Olathe 4-06,Insurance Commissioner,,R,Ken Selzer,403
-Johnson,Olathe 4-07,Insurance Commissioner,,R,Ken Selzer,326
-Johnson,Olathe 4-08,Insurance Commissioner,,R,Ken Selzer,332
-Johnson,Olathe 4-09,Insurance Commissioner,,R,Ken Selzer,424
-Johnson,Olathe 4-10,Insurance Commissioner,,R,Ken Selzer,223
-Johnson,Olathe 4-11,Insurance Commissioner,,R,Ken Selzer,121
-Johnson,Olathe 4-12,Insurance Commissioner,,R,Ken Selzer,412
-Johnson,Olathe 4-13,Insurance Commissioner,,R,Ken Selzer,168
-Johnson,Olathe 4-14,Insurance Commissioner,,R,Ken Selzer,394
-Johnson,Olathe 4-15,Insurance Commissioner,,R,Ken Selzer,21
-Johnson,Olathe 4-16,Insurance Commissioner,,R,Ken Selzer,99
-Johnson,Olathe 4-17,Insurance Commissioner,,R,Ken Selzer,3
-Johnson,Olathe Twp 0-01,Insurance Commissioner,,R,Ken Selzer,169
-Johnson,Olathe Twp 0-02,Insurance Commissioner,,R,Ken Selzer,39
-Johnson,Olathe Twp 0-03,Insurance Commissioner,,R,Ken Selzer,20
-Johnson,Olathe Twp 0-04,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Olathe Twp 0-05,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Olathe Twp 0-06,Insurance Commissioner,,R,Ken Selzer,0
-Johnson,Olathe Twp 0-07,Insurance Commissioner,,R,Ken Selzer,1
-Johnson,Olathe Twp 0-08,Insurance Commissioner,,R,Ken Selzer,4
-Johnson,Olathe Twp 0-10,Insurance Commissioner,,R,Ken Selzer,10
-Johnson,Olathe Twp 0-11,Insurance Commissioner,,R,Ken Selzer,3
-Johnson,Olathe Twp 0-14,Insurance Commissioner,,R,Ken Selzer,1
-Johnson,Olathe Twp 0-24,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Olathe Twp 0-25,Insurance Commissioner,,R,Ken Selzer,8
-Johnson,Olathe Twp 0-26,Insurance Commissioner,,R,Ken Selzer,3
-Johnson,Olathe Twp 0-32,Insurance Commissioner,,R,Ken Selzer,15
-Johnson,Overland Park 1-01,Insurance Commissioner,,R,Ken Selzer,196
-Johnson,Overland Park 1-02,Insurance Commissioner,,R,Ken Selzer,202
-Johnson,Overland Park 1-03,Insurance Commissioner,,R,Ken Selzer,217
-Johnson,Overland Park 1-04,Insurance Commissioner,,R,Ken Selzer,87
-Johnson,Overland Park 1-05,Insurance Commissioner,,R,Ken Selzer,134
-Johnson,Overland Park 1-06,Insurance Commissioner,,R,Ken Selzer,280
-Johnson,Overland Park 1-07,Insurance Commissioner,,R,Ken Selzer,280
-Johnson,Overland Park 1-08,Insurance Commissioner,,R,Ken Selzer,171
-Johnson,Overland Park 1-09,Insurance Commissioner,,R,Ken Selzer,123
-Johnson,Overland Park 1-10,Insurance Commissioner,,R,Ken Selzer,236
-Johnson,Overland Park 1-11,Insurance Commissioner,,R,Ken Selzer,62
-Johnson,Overland Park 1-12,Insurance Commissioner,,R,Ken Selzer,189
-Johnson,Overland Park 1-13,Insurance Commissioner,,R,Ken Selzer,159
-Johnson,Overland Park 1-14,Insurance Commissioner,,R,Ken Selzer,200
-Johnson,Overland Park 1-15,Insurance Commissioner,,R,Ken Selzer,97
-Johnson,Overland Park 1-16,Insurance Commissioner,,R,Ken Selzer,231
-Johnson,Overland Park 1-17,Insurance Commissioner,,R,Ken Selzer,105
-Johnson,Overland Park 1-18,Insurance Commissioner,,R,Ken Selzer,207
-Johnson,Overland Park 1-19,Insurance Commissioner,,R,Ken Selzer,166
-Johnson,Overland Park 1-20,Insurance Commissioner,,R,Ken Selzer,123
-Johnson,Overland Park 1-21,Insurance Commissioner,,R,Ken Selzer,85
-Johnson,Overland Park 1-22,Insurance Commissioner,,R,Ken Selzer,40
-Johnson,Overland Park 2-01,Insurance Commissioner,,R,Ken Selzer,225
-Johnson,Overland Park 2-02,Insurance Commissioner,,R,Ken Selzer,226
-Johnson,Overland Park 2-03,Insurance Commissioner,,R,Ken Selzer,216
-Johnson,Overland Park 2-04,Insurance Commissioner,,R,Ken Selzer,239
-Johnson,Overland Park 2-05,Insurance Commissioner,,R,Ken Selzer,197
-Johnson,Overland Park 2-06,Insurance Commissioner,,R,Ken Selzer,218
-Johnson,Overland Park 2-07,Insurance Commissioner,,R,Ken Selzer,183
-Johnson,Overland Park 2-08,Insurance Commissioner,,R,Ken Selzer,92
-Johnson,Overland Park 2-09,Insurance Commissioner,,R,Ken Selzer,201
-Johnson,Overland Park 2-10,Insurance Commissioner,,R,Ken Selzer,197
-Johnson,Overland Park 2-11,Insurance Commissioner,,R,Ken Selzer,224
-Johnson,Overland Park 2-12,Insurance Commissioner,,R,Ken Selzer,166
-Johnson,Overland Park 2-13,Insurance Commissioner,,R,Ken Selzer,95
-Johnson,Overland Park 2-14,Insurance Commissioner,,R,Ken Selzer,150
-Johnson,Overland Park 2-15,Insurance Commissioner,,R,Ken Selzer,317
-Johnson,Overland Park 2-16,Insurance Commissioner,,R,Ken Selzer,190
-Johnson,Overland Park 2-17,Insurance Commissioner,,R,Ken Selzer,310
-Johnson,Overland Park 2-18,Insurance Commissioner,,R,Ken Selzer,276
-Johnson,Overland Park 2-19,Insurance Commissioner,,R,Ken Selzer,201
-Johnson,Overland Park 2-20,Insurance Commissioner,,R,Ken Selzer,204
-Johnson,Overland Park 2-21,Insurance Commissioner,,R,Ken Selzer,194
-Johnson,Overland Park 2-22,Insurance Commissioner,,R,Ken Selzer,199
-Johnson,Overland Park 2-23,Insurance Commissioner,,R,Ken Selzer,284
-Johnson,Overland Park 2-24,Insurance Commissioner,,R,Ken Selzer,398
-Johnson,Overland Park 2-25,Insurance Commissioner,,R,Ken Selzer,317
-Johnson,Overland Park 2-26,Insurance Commissioner,,R,Ken Selzer,97
-Johnson,Overland Park 3-01,Insurance Commissioner,,R,Ken Selzer,461
-Johnson,Overland Park 3-02,Insurance Commissioner,,R,Ken Selzer,234
-Johnson,Overland Park 3-03,Insurance Commissioner,,R,Ken Selzer,297
-Johnson,Overland Park 3-04,Insurance Commissioner,,R,Ken Selzer,316
-Johnson,Overland Park 3-05,Insurance Commissioner,,R,Ken Selzer,299
-Johnson,Overland Park 3-06,Insurance Commissioner,,R,Ken Selzer,366
-Johnson,Overland Park 3-07,Insurance Commissioner,,R,Ken Selzer,182
-Johnson,Overland Park 3-08,Insurance Commissioner,,R,Ken Selzer,314
-Johnson,Overland Park 3-09,Insurance Commissioner,,R,Ken Selzer,366
-Johnson,Overland Park 3-10,Insurance Commissioner,,R,Ken Selzer,234
-Johnson,Overland Park 3-11,Insurance Commissioner,,R,Ken Selzer,303
-Johnson,Overland Park 3-12,Insurance Commissioner,,R,Ken Selzer,146
-Johnson,Overland Park 3-13,Insurance Commissioner,,R,Ken Selzer,453
-Johnson,Overland Park 3-14,Insurance Commissioner,,R,Ken Selzer,295
-Johnson,Overland Park 3-15,Insurance Commissioner,,R,Ken Selzer,233
-Johnson,Overland Park 3-16,Insurance Commissioner,,R,Ken Selzer,262
-Johnson,Overland Park 3-17,Insurance Commissioner,,R,Ken Selzer,229
-Johnson,Overland Park 3-18,Insurance Commissioner,,R,Ken Selzer,218
-Johnson,Overland Park 3-19,Insurance Commissioner,,R,Ken Selzer,284
-Johnson,Overland Park 3-20,Insurance Commissioner,,R,Ken Selzer,365
-Johnson,Overland Park 3-21,Insurance Commissioner,,R,Ken Selzer,306
-Johnson,Overland Park 4-01,Insurance Commissioner,,R,Ken Selzer,247
-Johnson,Overland Park 4-02,Insurance Commissioner,,R,Ken Selzer,418
-Johnson,Overland Park 4-03,Insurance Commissioner,,R,Ken Selzer,529
-Johnson,Overland Park 4-04,Insurance Commissioner,,R,Ken Selzer,506
-Johnson,Overland Park 4-05,Insurance Commissioner,,R,Ken Selzer,349
-Johnson,Overland Park 4-06,Insurance Commissioner,,R,Ken Selzer,294
-Johnson,Overland Park 4-07,Insurance Commissioner,,R,Ken Selzer,201
-Johnson,Overland Park 4-08,Insurance Commissioner,,R,Ken Selzer,367
-Johnson,Overland Park 4-09,Insurance Commissioner,,R,Ken Selzer,414
-Johnson,Overland Park 4-10,Insurance Commissioner,,R,Ken Selzer,273
-Johnson,Overland Park 4-11,Insurance Commissioner,,R,Ken Selzer,417
-Johnson,Overland Park 4-12,Insurance Commissioner,,R,Ken Selzer,540
-Johnson,Overland Park 4-13,Insurance Commissioner,,R,Ken Selzer,313
-Johnson,Overland Park 4-14,Insurance Commissioner,,R,Ken Selzer,246
-Johnson,Overland Park 4-15,Insurance Commissioner,,R,Ken Selzer,450
-Johnson,Overland Park 4-16,Insurance Commissioner,,R,Ken Selzer,383
-Johnson,Overland Park 4-17,Insurance Commissioner,,R,Ken Selzer,419
-Johnson,Overland Park 4-18,Insurance Commissioner,,R,Ken Selzer,52
-Johnson,Overland Park 5-01,Insurance Commissioner,,R,Ken Selzer,348
-Johnson,Overland Park 5-02,Insurance Commissioner,,R,Ken Selzer,170
-Johnson,Overland Park 5-03,Insurance Commissioner,,R,Ken Selzer,361
-Johnson,Overland Park 5-04,Insurance Commissioner,,R,Ken Selzer,302
-Johnson,Overland Park 5-05,Insurance Commissioner,,R,Ken Selzer,201
-Johnson,Overland Park 5-06,Insurance Commissioner,,R,Ken Selzer,272
-Johnson,Overland Park 5-07,Insurance Commissioner,,R,Ken Selzer,533
-Johnson,Overland Park 5-08,Insurance Commissioner,,R,Ken Selzer,542
-Johnson,Overland Park 5-09,Insurance Commissioner,,R,Ken Selzer,496
-Johnson,Overland Park 5-10,Insurance Commissioner,,R,Ken Selzer,358
-Johnson,Overland Park 5-11,Insurance Commissioner,,R,Ken Selzer,392
-Johnson,Overland Park 5-12,Insurance Commissioner,,R,Ken Selzer,86
-Johnson,Overland Park 5-13,Insurance Commissioner,,R,Ken Selzer,419
-Johnson,Overland Park 5-14,Insurance Commissioner,,R,Ken Selzer,364
-Johnson,Overland Park 5-15,Insurance Commissioner,,R,Ken Selzer,216
-Johnson,Overland Park 5-16,Insurance Commissioner,,R,Ken Selzer,231
-Johnson,Overland Park 5-17,Insurance Commissioner,,R,Ken Selzer,133
-Johnson,Overland Park 5-18,Insurance Commissioner,,R,Ken Selzer,271
-Johnson,Overland Park 5-19,Insurance Commissioner,,R,Ken Selzer,30
-Johnson,Overland Park 6-01,Insurance Commissioner,,R,Ken Selzer,464
-Johnson,Overland Park 6-02,Insurance Commissioner,,R,Ken Selzer,369
-Johnson,Overland Park 6-03,Insurance Commissioner,,R,Ken Selzer,403
-Johnson,Overland Park 6-04,Insurance Commissioner,,R,Ken Selzer,395
-Johnson,Overland Park 6-05,Insurance Commissioner,,R,Ken Selzer,417
-Johnson,Overland Park 6-06,Insurance Commissioner,,R,Ken Selzer,1
-Johnson,Overland Park 6-07,Insurance Commissioner,,R,Ken Selzer,133
-Johnson,Overland Park 6-08,Insurance Commissioner,,R,Ken Selzer,698
-Johnson,Overland Park 6-09,Insurance Commissioner,,R,Ken Selzer,505
-Johnson,Overland Park 6-10,Insurance Commissioner,,R,Ken Selzer,328
-Johnson,Overland Park 6-11,Insurance Commissioner,,R,Ken Selzer,340
-Johnson,Overland Park 6-12,Insurance Commissioner,,R,Ken Selzer,165
-Johnson,Overland Park 6-13,Insurance Commissioner,,R,Ken Selzer,489
-Johnson,Overland Park 6-15,Insurance Commissioner,,R,Ken Selzer,469
-Johnson,Overland Park 6-16,Insurance Commissioner,,R,Ken Selzer,278
-Johnson,Overland Park 6-17,Insurance Commissioner,,R,Ken Selzer,86
-Johnson,Overland Park 6-18,Insurance Commissioner,,R,Ken Selzer,3
-Johnson,Overland Park 6-19,Insurance Commissioner,,R,Ken Selzer,434
-Johnson,Overland Park 6-20,Insurance Commissioner,,R,Ken Selzer,258
-Johnson,Overland Park 6-21,Insurance Commissioner,,R,Ken Selzer,678
-Johnson,Overland Park 6-22,Insurance Commissioner,,R,Ken Selzer,232
-Johnson,Oxford Twp 0-01,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Oxford Twp 0-02,Insurance Commissioner,,R,Ken Selzer,313
-Johnson,Oxford Twp 0-04,Insurance Commissioner,,R,Ken Selzer,230
-Johnson,Oxford Twp 0-05,Insurance Commissioner,,R,Ken Selzer,10
-Johnson,Oxford Twp 0-09,Insurance Commissioner,,R,Ken Selzer,18
-Johnson,Oxford Twp 0-10,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Oxford Twp 0-11,Insurance Commissioner,,R,Ken Selzer,66
-Johnson,Prairie Village 1-01,Insurance Commissioner,,R,Ken Selzer,335
-Johnson,Prairie Village 1-02,Insurance Commissioner,,R,Ken Selzer,211
-Johnson,Prairie Village 1-03,Insurance Commissioner,,R,Ken Selzer,294
-Johnson,Prairie Village 2-01,Insurance Commissioner,,R,Ken Selzer,234
-Johnson,Prairie Village 2-02,Insurance Commissioner,,R,Ken Selzer,133
-Johnson,Prairie Village 2-03,Insurance Commissioner,,R,Ken Selzer,200
-Johnson,Prairie Village 3-01,Insurance Commissioner,,R,Ken Selzer,188
-Johnson,Prairie Village 3-02,Insurance Commissioner,,R,Ken Selzer,268
-Johnson,Prairie Village 3-03,Insurance Commissioner,,R,Ken Selzer,246
-Johnson,Prairie Village 4-01,Insurance Commissioner,,R,Ken Selzer,388
-Johnson,Prairie Village 4-02,Insurance Commissioner,,R,Ken Selzer,194
-Johnson,Prairie Village 4-03,Insurance Commissioner,,R,Ken Selzer,324
-Johnson,Prairie Village 5-01,Insurance Commissioner,,R,Ken Selzer,336
-Johnson,Prairie Village 5-02,Insurance Commissioner,,R,Ken Selzer,387
-Johnson,Prairie Village 5-03,Insurance Commissioner,,R,Ken Selzer,302
-Johnson,Prairie Village 6-01,Insurance Commissioner,,R,Ken Selzer,337
-Johnson,Prairie Village 6-02,Insurance Commissioner,,R,Ken Selzer,214
-Johnson,Prairie Village 6-03,Insurance Commissioner,,R,Ken Selzer,147
-Johnson,Roeland Park 1-01,Insurance Commissioner,,R,Ken Selzer,81
-Johnson,Roeland Park 1-02,Insurance Commissioner,,R,Ken Selzer,58
-Johnson,Roeland Park 2-01,Insurance Commissioner,,R,Ken Selzer,100
-Johnson,Roeland Park 2-02,Insurance Commissioner,,R,Ken Selzer,159
-Johnson,Roeland Park 3-01,Insurance Commissioner,,R,Ken Selzer,65
-Johnson,Roeland Park 3-02,Insurance Commissioner,,R,Ken Selzer,156
-Johnson,Roeland Park 4-01,Insurance Commissioner,,R,Ken Selzer,97
-Johnson,Roeland Park 4-02,Insurance Commissioner,,R,Ken Selzer,272
-Johnson,Shawnee 1-01,Insurance Commissioner,,R,Ken Selzer,318
-Johnson,Shawnee 1-02,Insurance Commissioner,,R,Ken Selzer,254
-Johnson,Shawnee 1-03,Insurance Commissioner,,R,Ken Selzer,228
-Johnson,Shawnee 1-04,Insurance Commissioner,,R,Ken Selzer,458
-Johnson,Shawnee 1-05,Insurance Commissioner,,R,Ken Selzer,443
-Johnson,Shawnee 1-06,Insurance Commissioner,,R,Ken Selzer,421
-Johnson,Shawnee 1-07,Insurance Commissioner,,R,Ken Selzer,363
-Johnson,Shawnee 1-08,Insurance Commissioner,,R,Ken Selzer,406
-Johnson,Shawnee 1-09,Insurance Commissioner,,R,Ken Selzer,50
-Johnson,Shawnee 1-10,Insurance Commissioner,,R,Ken Selzer,156
-Johnson,Shawnee 1-11,Insurance Commissioner,,R,Ken Selzer,253
-Johnson,Shawnee 1-12,Insurance Commissioner,,R,Ken Selzer,4
-Johnson,Shawnee 2-01,Insurance Commissioner,,R,Ken Selzer,143
-Johnson,Shawnee 2-02,Insurance Commissioner,,R,Ken Selzer,278
-Johnson,Shawnee 2-03,Insurance Commissioner,,R,Ken Selzer,192
-Johnson,Shawnee 2-04,Insurance Commissioner,,R,Ken Selzer,313
-Johnson,Shawnee 2-05,Insurance Commissioner,,R,Ken Selzer,163
-Johnson,Shawnee 2-06,Insurance Commissioner,,R,Ken Selzer,248
-Johnson,Shawnee 2-07,Insurance Commissioner,,R,Ken Selzer,170
-Johnson,Shawnee 2-08,Insurance Commissioner,,R,Ken Selzer,181
-Johnson,Shawnee 2-09,Insurance Commissioner,,R,Ken Selzer,155
-Johnson,Shawnee 2-10,Insurance Commissioner,,R,Ken Selzer,144
-Johnson,Shawnee 2-11,Insurance Commissioner,,R,Ken Selzer,250
-Johnson,Shawnee 2-12,Insurance Commissioner,,R,Ken Selzer,45
-Johnson,Shawnee 2-13,Insurance Commissioner,,R,Ken Selzer,127
-Johnson,Shawnee 3-01,Insurance Commissioner,,R,Ken Selzer,270
-Johnson,Shawnee 3-02,Insurance Commissioner,,R,Ken Selzer,482
-Johnson,Shawnee 3-03,Insurance Commissioner,,R,Ken Selzer,337
-Johnson,Shawnee 3-04,Insurance Commissioner,,R,Ken Selzer,354
-Johnson,Shawnee 3-05,Insurance Commissioner,,R,Ken Selzer,527
-Johnson,Shawnee 3-06,Insurance Commissioner,,R,Ken Selzer,314
-Johnson,Shawnee 3-07,Insurance Commissioner,,R,Ken Selzer,440
-Johnson,Shawnee 3-08,Insurance Commissioner,,R,Ken Selzer,399
-Johnson,Shawnee 3-09,Insurance Commissioner,,R,Ken Selzer,257
-Johnson,Shawnee 4-01,Insurance Commissioner,,R,Ken Selzer,440
-Johnson,Shawnee 4-02,Insurance Commissioner,,R,Ken Selzer,247
-Johnson,Shawnee 4-03,Insurance Commissioner,,R,Ken Selzer,101
-Johnson,Shawnee 4-04,Insurance Commissioner,,R,Ken Selzer,84
-Johnson,Shawnee 4-05,Insurance Commissioner,,R,Ken Selzer,325
-Johnson,Shawnee 4-06,Insurance Commissioner,,R,Ken Selzer,318
-Johnson,Shawnee 4-07,Insurance Commissioner,,R,Ken Selzer,440
-Johnson,Shawnee 4-08,Insurance Commissioner,,R,Ken Selzer,175
-Johnson,Shawnee 4-09,Insurance Commissioner,,R,Ken Selzer,477
-Johnson,Shawnee 4-11,Insurance Commissioner,,R,Ken Selzer,224
-Johnson,Shawnee 4-12,Insurance Commissioner,,R,Ken Selzer,49
-Johnson,Spring Hill 0-01,Insurance Commissioner,,R,Ken Selzer,555
-Johnson,Spring Hill 0-03,Insurance Commissioner,,R,Ken Selzer,41
-Johnson,Spring Hill 0-04,Insurance Commissioner,,R,Ken Selzer,0
-Johnson,Spring Hill Twp 0-01,Insurance Commissioner,,R,Ken Selzer,452
-Johnson,Spring Hill Twp 0-02,Insurance Commissioner,,R,Ken Selzer,2
-Johnson,Spring Hill Twp 0-03,Insurance Commissioner,,R,Ken Selzer,51
-Johnson,Spring Hill Twp 0-04,Insurance Commissioner,,R,Ken Selzer,9
-Johnson,Spring Hill Twp 0-05,Insurance Commissioner,,R,Ken Selzer,1
-Johnson,Westwood 0-01,Insurance Commissioner,,R,Ken Selzer,124
-Johnson,Westwood 0-02,Insurance Commissioner,,R,Ken Selzer,149
-Johnson,Westwood Hills 0-01,Insurance Commissioner,,R,Ken Selzer,74
-Johnson,Aubry Twp 0-01,Insurance Commissioner,,D,Dennis Anderson,40
-Johnson,Aubry Twp 0-02,Insurance Commissioner,,D,Dennis Anderson,146
-Johnson,Aubry Twp 0-03,Insurance Commissioner,,D,Dennis Anderson,97
-Johnson,Aubry Twp 0-04,Insurance Commissioner,,D,Dennis Anderson,206
-Johnson,Aubry Twp 0-05,Insurance Commissioner,,D,Dennis Anderson,3
-Johnson,Aubry Twp 0-06,Insurance Commissioner,,D,Dennis Anderson,20
-Johnson,De Soto 0-01,Insurance Commissioner,,D,Dennis Anderson,230
-Johnson,De Soto 0-02,Insurance Commissioner,,D,Dennis Anderson,164
-Johnson,De Soto 0-03,Insurance Commissioner,,D,Dennis Anderson,212
-Johnson,De Soto 0-06,Insurance Commissioner,,D,Dennis Anderson,17
-Johnson,De Soto 0-07,Insurance Commissioner,,D,Dennis Anderson,1
-Johnson,Edgerton,Insurance Commissioner,,D,Dennis Anderson,130
-Johnson,Fairway 1-01,Insurance Commissioner,,D,Dennis Anderson,141
-Johnson,Fairway 1-02,Insurance Commissioner,,D,Dennis Anderson,99
-Johnson,Fairway 2-01,Insurance Commissioner,,D,Dennis Anderson,112
-Johnson,Fairway 2-02,Insurance Commissioner,,D,Dennis Anderson,113
-Johnson,Fairway 3-01,Insurance Commissioner,,D,Dennis Anderson,150
-Johnson,Fairway 3-02,Insurance Commissioner,,D,Dennis Anderson,106
-Johnson,Fairway 4-01,Insurance Commissioner,,D,Dennis Anderson,57
-Johnson,Fairway 4-02,Insurance Commissioner,,D,Dennis Anderson,73
-Johnson,Fairway 4-03,Insurance Commissioner,,D,Dennis Anderson,45
-Johnson,Fairway 4-04,Insurance Commissioner,,D,Dennis Anderson,71
-Johnson,Gardner 0-01,Insurance Commissioner,,D,Dennis Anderson,266
-Johnson,Gardner 0-02,Insurance Commissioner,,D,Dennis Anderson,48
-Johnson,Gardner 0-03,Insurance Commissioner,,D,Dennis Anderson,174
-Johnson,Gardner 0-04,Insurance Commissioner,,D,Dennis Anderson,182
-Johnson,Gardner 0-06,Insurance Commissioner,,D,Dennis Anderson,179
-Johnson,Gardner 0-07,Insurance Commissioner,,D,Dennis Anderson,8
-Johnson,Gardner 0-08,Insurance Commissioner,,D,Dennis Anderson,11
-Johnson,Gardner 0-09,Insurance Commissioner,,D,Dennis Anderson,238
-Johnson,Gardner 0-10,Insurance Commissioner,,D,Dennis Anderson,134
-Johnson,Gardner 0-12,Insurance Commissioner,,D,Dennis Anderson,6
-Johnson,Gardner 0-13,Insurance Commissioner,,D,Dennis Anderson,186
-Johnson,Gardner 0-14,Insurance Commissioner,,D,Dennis Anderson,150
-Johnson,Gardner Twp 0-01,Insurance Commissioner,,D,Dennis Anderson,105
-Johnson,Gardner Twp 0-02,Insurance Commissioner,,D,Dennis Anderson,99
-Johnson,Gardner Twp 0-04,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Gardner Twp 0-05,Insurance Commissioner,,D,Dennis Anderson,1
-Johnson,Gardner Twp 0-07,Insurance Commissioner,,D,Dennis Anderson,2
-Johnson,Gardner Twp 0-08,Insurance Commissioner,,D,Dennis Anderson,3
-Johnson,Gardner Twp 0-09,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Gardner Twp 0-10,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Gardner Twp 0-11,Insurance Commissioner,,D,Dennis Anderson,31
-Johnson,Gardner Twp 0-13,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Lake Quivira,Insurance Commissioner,,D,Dennis Anderson,175
-Johnson,Leawood 1-01,Insurance Commissioner,,D,Dennis Anderson,230
-Johnson,Leawood 1-02,Insurance Commissioner,,D,Dennis Anderson,299
-Johnson,Leawood 1-03,Insurance Commissioner,,D,Dennis Anderson,234
-Johnson,Leawood 1-04,Insurance Commissioner,,D,Dennis Anderson,204
-Johnson,Leawood 1-05,Insurance Commissioner,,D,Dennis Anderson,170
-Johnson,Leawood 1-06,Insurance Commissioner,,D,Dennis Anderson,55
-Johnson,Leawood 2-01,Insurance Commissioner,,D,Dennis Anderson,234
-Johnson,Leawood 2-02,Insurance Commissioner,,D,Dennis Anderson,286
-Johnson,Leawood 2-03,Insurance Commissioner,,D,Dennis Anderson,269
-Johnson,Leawood 2-04,Insurance Commissioner,,D,Dennis Anderson,163
-Johnson,Leawood 2-05,Insurance Commissioner,,D,Dennis Anderson,146
-Johnson,Leawood 2-06,Insurance Commissioner,,D,Dennis Anderson,105
-Johnson,Leawood 3-01,Insurance Commissioner,,D,Dennis Anderson,158
-Johnson,Leawood 3-02,Insurance Commissioner,,D,Dennis Anderson,250
-Johnson,Leawood 3-03,Insurance Commissioner,,D,Dennis Anderson,129
-Johnson,Leawood 3-04,Insurance Commissioner,,D,Dennis Anderson,61
-Johnson,Leawood 3-05,Insurance Commissioner,,D,Dennis Anderson,226
-Johnson,Leawood 3-06,Insurance Commissioner,,D,Dennis Anderson,200
-Johnson,Leawood 3-07,Insurance Commissioner,,D,Dennis Anderson,187
-Johnson,Leawood 4-01,Insurance Commissioner,,D,Dennis Anderson,57
-Johnson,Leawood 4-02,Insurance Commissioner,,D,Dennis Anderson,185
-Johnson,Leawood 4-03,Insurance Commissioner,,D,Dennis Anderson,197
-Johnson,Leawood 4-04,Insurance Commissioner,,D,Dennis Anderson,207
-Johnson,Leawood 4-05,Insurance Commissioner,,D,Dennis Anderson,206
-Johnson,Leawood 4-06,Insurance Commissioner,,D,Dennis Anderson,96
-Johnson,Leawood 4-07,Insurance Commissioner,,D,Dennis Anderson,206
-Johnson,Leawood 4-08,Insurance Commissioner,,D,Dennis Anderson,97
-Johnson,Lenexa 1-01,Insurance Commissioner,,D,Dennis Anderson,134
-Johnson,Lenexa 1-02,Insurance Commissioner,,D,Dennis Anderson,329
-Johnson,Lenexa 1-03,Insurance Commissioner,,D,Dennis Anderson,373
-Johnson,Lenexa 1-04,Insurance Commissioner,,D,Dennis Anderson,252
-Johnson,Lenexa 1-05,Insurance Commissioner,,D,Dennis Anderson,262
-Johnson,Lenexa 1-06,Insurance Commissioner,,D,Dennis Anderson,273
-Johnson,Lenexa 1-07,Insurance Commissioner,,D,Dennis Anderson,185
-Johnson,Lenexa 1-08,Insurance Commissioner,,D,Dennis Anderson,75
-Johnson,Lenexa 1-09,Insurance Commissioner,,D,Dennis Anderson,8
-Johnson,Lenexa 2-01,Insurance Commissioner,,D,Dennis Anderson,304
-Johnson,Lenexa 2-02,Insurance Commissioner,,D,Dennis Anderson,100
-Johnson,Lenexa 2-03,Insurance Commissioner,,D,Dennis Anderson,237
-Johnson,Lenexa 2-04,Insurance Commissioner,,D,Dennis Anderson,164
-Johnson,Lenexa 2-05,Insurance Commissioner,,D,Dennis Anderson,259
-Johnson,Lenexa 2-06,Insurance Commissioner,,D,Dennis Anderson,152
-Johnson,Lenexa 2-07,Insurance Commissioner,,D,Dennis Anderson,317
-Johnson,Lenexa 3-01,Insurance Commissioner,,D,Dennis Anderson,234
-Johnson,Lenexa 3-02,Insurance Commissioner,,D,Dennis Anderson,393
-Johnson,Lenexa 3-03,Insurance Commissioner,,D,Dennis Anderson,391
-Johnson,Lenexa 3-04,Insurance Commissioner,,D,Dennis Anderson,214
-Johnson,Lenexa 3-05,Insurance Commissioner,,D,Dennis Anderson,181
-Johnson,Lenexa 3-06,Insurance Commissioner,,D,Dennis Anderson,234
-Johnson,Lenexa 3-07,Insurance Commissioner,,D,Dennis Anderson,289
-Johnson,Lenexa 3-08,Insurance Commissioner,,D,Dennis Anderson,281
-Johnson,Lenexa 4-01,Insurance Commissioner,,D,Dennis Anderson,153
-Johnson,Lenexa 4-02,Insurance Commissioner,,D,Dennis Anderson,262
-Johnson,Lenexa 4-03,Insurance Commissioner,,D,Dennis Anderson,140
-Johnson,Lenexa 4-04,Insurance Commissioner,,D,Dennis Anderson,118
-Johnson,Lenexa 4-05,Insurance Commissioner,,D,Dennis Anderson,127
-Johnson,Lenexa 4-06,Insurance Commissioner,,D,Dennis Anderson,169
-Johnson,Lenexa 4-07,Insurance Commissioner,,D,Dennis Anderson,217
-Johnson,Lenexa 4-08,Insurance Commissioner,,D,Dennis Anderson,282
-Johnson,Lenexa 4-09,Insurance Commissioner,,D,Dennis Anderson,222
-Johnson,Lenexa 4-10,Insurance Commissioner,,D,Dennis Anderson,121
-Johnson,Lenexa 4-11,Insurance Commissioner,,D,Dennis Anderson,41
-Johnson,Lexington Twp 0-01,Insurance Commissioner,,D,Dennis Anderson,186
-Johnson,Lexington Twp 0-02,Insurance Commissioner,,D,Dennis Anderson,2
-Johnson,Lexington Twp 0-03,Insurance Commissioner,,D,Dennis Anderson,1
-Johnson,McCamish Twp 0-01,Insurance Commissioner,,D,Dennis Anderson,34
-Johnson,McCamish Twp 0-02,Insurance Commissioner,,D,Dennis Anderson,73
-Johnson,Merriam 1-01,Insurance Commissioner,,D,Dennis Anderson,168
-Johnson,Merriam 1-02,Insurance Commissioner,,D,Dennis Anderson,218
-Johnson,Merriam 2-01,Insurance Commissioner,,D,Dennis Anderson,253
-Johnson,Merriam 2-02,Insurance Commissioner,,D,Dennis Anderson,2
-Johnson,Merriam 2-03,Insurance Commissioner,,D,Dennis Anderson,140
-Johnson,Merriam 3-01,Insurance Commissioner,,D,Dennis Anderson,245
-Johnson,Merriam 3-02,Insurance Commissioner,,D,Dennis Anderson,216
-Johnson,Merriam 4-01,Insurance Commissioner,,D,Dennis Anderson,266
-Johnson,Merriam 4-02,Insurance Commissioner,,D,Dennis Anderson,132
-Johnson,Merriam 4-03,Insurance Commissioner,,D,Dennis Anderson,182
-Johnson,Mission 1-01,Insurance Commissioner,,D,Dennis Anderson,261
-Johnson,Mission 1-02,Insurance Commissioner,,D,Dennis Anderson,155
-Johnson,Mission 2-01,Insurance Commissioner,,D,Dennis Anderson,166
-Johnson,Mission 2-02,Insurance Commissioner,,D,Dennis Anderson,263
-Johnson,Mission 3-01,Insurance Commissioner,,D,Dennis Anderson,250
-Johnson,Mission 3-02,Insurance Commissioner,,D,Dennis Anderson,145
-Johnson,Mission 4-01,Insurance Commissioner,,D,Dennis Anderson,197
-Johnson,Mission 4-02,Insurance Commissioner,,D,Dennis Anderson,271
-Johnson,Mission 4-03,Insurance Commissioner,,D,Dennis Anderson,127
-Johnson,Mission Hills 0-01,Insurance Commissioner,,D,Dennis Anderson,127
-Johnson,Mission Hills 0-02,Insurance Commissioner,,D,Dennis Anderson,191
-Johnson,Mission Hills 0-03,Insurance Commissioner,,D,Dennis Anderson,93
-Johnson,Mission Hills 0-04,Insurance Commissioner,,D,Dennis Anderson,200
-Johnson,Mission Woods,Insurance Commissioner,,D,Dennis Anderson,41
-Johnson,Olathe 1-01,Insurance Commissioner,,D,Dennis Anderson,211
-Johnson,Olathe 1-02,Insurance Commissioner,,D,Dennis Anderson,168
-Johnson,Olathe 1-03,Insurance Commissioner,,D,Dennis Anderson,112
-Johnson,Olathe 1-04,Insurance Commissioner,,D,Dennis Anderson,223
-Johnson,Olathe 1-05,Insurance Commissioner,,D,Dennis Anderson,206
-Johnson,Olathe 1-06,Insurance Commissioner,,D,Dennis Anderson,132
-Johnson,Olathe 1-08,Insurance Commissioner,,D,Dennis Anderson,252
-Johnson,Olathe 1-09,Insurance Commissioner,,D,Dennis Anderson,187
-Johnson,Olathe 1-11,Insurance Commissioner,,D,Dennis Anderson,46
-Johnson,Olathe 1-14,Insurance Commissioner,,D,Dennis Anderson,172
-Johnson,Olathe 1-15,Insurance Commissioner,,D,Dennis Anderson,181
-Johnson,Olathe 1-16,Insurance Commissioner,,D,Dennis Anderson,196
-Johnson,Olathe 1-17,Insurance Commissioner,,D,Dennis Anderson,46
-Johnson,Olathe 1-18,Insurance Commissioner,,D,Dennis Anderson,59
-Johnson,Olathe 1-19,Insurance Commissioner,,D,Dennis Anderson,98
-Johnson,Olathe 1-20,Insurance Commissioner,,D,Dennis Anderson,184
-Johnson,Olathe 1-21,Insurance Commissioner,,D,Dennis Anderson,236
-Johnson,Olathe 1-22,Insurance Commissioner,,D,Dennis Anderson,307
-Johnson,Olathe 1-23,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe 1-24,Insurance Commissioner,,D,Dennis Anderson,26
-Johnson,Olathe 1-24,Insurance Commissioner,,D,Dennis Anderson,63
-Johnson,Olathe 1-26,Insurance Commissioner,,D,Dennis Anderson,2
-Johnson,Olathe 1-27,Insurance Commissioner,,D,Dennis Anderson,178
-Johnson,Olathe 2-01,Insurance Commissioner,,D,Dennis Anderson,85
-Johnson,Olathe 2-02,Insurance Commissioner,,D,Dennis Anderson,145
-Johnson,Olathe 2-03,Insurance Commissioner,,D,Dennis Anderson,156
-Johnson,Olathe 2-04,Insurance Commissioner,,D,Dennis Anderson,207
-Johnson,Olathe 2-05,Insurance Commissioner,,D,Dennis Anderson,362
-Johnson,Olathe 2-06,Insurance Commissioner,,D,Dennis Anderson,170
-Johnson,Olathe 2-07,Insurance Commissioner,,D,Dennis Anderson,275
-Johnson,Olathe 2-08,Insurance Commissioner,,D,Dennis Anderson,229
-Johnson,Olathe 2-09,Insurance Commissioner,,D,Dennis Anderson,105
-Johnson,Olathe 2-10,Insurance Commissioner,,D,Dennis Anderson,410
-Johnson,Olathe 2-11,Insurance Commissioner,,D,Dennis Anderson,297
-Johnson,Olathe 2-12,Insurance Commissioner,,D,Dennis Anderson,181
-Johnson,Olathe 2-13,Insurance Commissioner,,D,Dennis Anderson,194
-Johnson,Olathe 2-14,Insurance Commissioner,,D,Dennis Anderson,149
-Johnson,Olathe 2-15,Insurance Commissioner,,D,Dennis Anderson,116
-Johnson,Olathe 2-16,Insurance Commissioner,,D,Dennis Anderson,73
-Johnson,Olathe 2-17,Insurance Commissioner,,D,Dennis Anderson,1
-Johnson,Olathe 2-19,Insurance Commissioner,,D,Dennis Anderson,4
-Johnson,Olathe 2-22,Insurance Commissioner,,D,Dennis Anderson,324
-Johnson,Olathe 2-23,Insurance Commissioner,,D,Dennis Anderson,214
-Johnson,Olathe 3-01,Insurance Commissioner,,D,Dennis Anderson,95
-Johnson,Olathe 3-02,Insurance Commissioner,,D,Dennis Anderson,263
-Johnson,Olathe 3-03,Insurance Commissioner,,D,Dennis Anderson,108
-Johnson,Olathe 3-04,Insurance Commissioner,,D,Dennis Anderson,190
-Johnson,Olathe 3-05,Insurance Commissioner,,D,Dennis Anderson,181
-Johnson,Olathe 3-06,Insurance Commissioner,,D,Dennis Anderson,144
-Johnson,Olathe 3-07,Insurance Commissioner,,D,Dennis Anderson,154
-Johnson,Olathe 3-08,Insurance Commissioner,,D,Dennis Anderson,223
-Johnson,Olathe 3-09,Insurance Commissioner,,D,Dennis Anderson,111
-Johnson,Olathe 3-10,Insurance Commissioner,,D,Dennis Anderson,208
-Johnson,Olathe 3-11,Insurance Commissioner,,D,Dennis Anderson,138
-Johnson,Olathe 3-12,Insurance Commissioner,,D,Dennis Anderson,211
-Johnson,Olathe 3-13,Insurance Commissioner,,D,Dennis Anderson,223
-Johnson,Olathe 3-15,Insurance Commissioner,,D,Dennis Anderson,154
-Johnson,Olathe 3-16,Insurance Commissioner,,D,Dennis Anderson,159
-Johnson,Olathe 3-17,Insurance Commissioner,,D,Dennis Anderson,199
-Johnson,Olathe 3-18,Insurance Commissioner,,D,Dennis Anderson,188
-Johnson,Olathe 3-19,Insurance Commissioner,,D,Dennis Anderson,92
-Johnson,Olathe 3-20,Insurance Commissioner,,D,Dennis Anderson,137
-Johnson,Olathe 3-21,Insurance Commissioner,,D,Dennis Anderson,102
-Johnson,Olathe 3-22,Insurance Commissioner,,D,Dennis Anderson,187
-Johnson,Olathe 3-23,Insurance Commissioner,,D,Dennis Anderson,186
-Johnson,Olathe 3-24,Insurance Commissioner,,D,Dennis Anderson,102
-Johnson,Olathe 3-26,Insurance Commissioner,,D,Dennis Anderson,23
-Johnson,Olathe 4-01,Insurance Commissioner,,D,Dennis Anderson,176
-Johnson,Olathe 4-02,Insurance Commissioner,,D,Dennis Anderson,322
-Johnson,Olathe 4-03,Insurance Commissioner,,D,Dennis Anderson,134
-Johnson,Olathe 4-04,Insurance Commissioner,,D,Dennis Anderson,124
-Johnson,Olathe 4-05,Insurance Commissioner,,D,Dennis Anderson,245
-Johnson,Olathe 4-06,Insurance Commissioner,,D,Dennis Anderson,292
-Johnson,Olathe 4-07,Insurance Commissioner,,D,Dennis Anderson,270
-Johnson,Olathe 4-08,Insurance Commissioner,,D,Dennis Anderson,175
-Johnson,Olathe 4-09,Insurance Commissioner,,D,Dennis Anderson,279
-Johnson,Olathe 4-10,Insurance Commissioner,,D,Dennis Anderson,155
-Johnson,Olathe 4-11,Insurance Commissioner,,D,Dennis Anderson,123
-Johnson,Olathe 4-12,Insurance Commissioner,,D,Dennis Anderson,227
-Johnson,Olathe 4-13,Insurance Commissioner,,D,Dennis Anderson,143
-Johnson,Olathe 4-14,Insurance Commissioner,,D,Dennis Anderson,278
-Johnson,Olathe 4-15,Insurance Commissioner,,D,Dennis Anderson,12
-Johnson,Olathe 4-16,Insurance Commissioner,,D,Dennis Anderson,92
-Johnson,Olathe 4-17,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe Twp 0-01,Insurance Commissioner,,D,Dennis Anderson,97
-Johnson,Olathe Twp 0-02,Insurance Commissioner,,D,Dennis Anderson,14
-Johnson,Olathe Twp 0-03,Insurance Commissioner,,D,Dennis Anderson,18
-Johnson,Olathe Twp 0-04,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe Twp 0-05,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe Twp 0-06,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe Twp 0-07,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe Twp 0-08,Insurance Commissioner,,D,Dennis Anderson,2
-Johnson,Olathe Twp 0-10,Insurance Commissioner,,D,Dennis Anderson,1
-Johnson,Olathe Twp 0-11,Insurance Commissioner,,D,Dennis Anderson,1
-Johnson,Olathe Twp 0-14,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe Twp 0-24,Insurance Commissioner,,D,Dennis Anderson,1
-Johnson,Olathe Twp 0-25,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe Twp 0-26,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Olathe Twp 0-32,Insurance Commissioner,,D,Dennis Anderson,8
-Johnson,Overland Park 1-01,Insurance Commissioner,,D,Dennis Anderson,276
-Johnson,Overland Park 1-02,Insurance Commissioner,,D,Dennis Anderson,282
-Johnson,Overland Park 1-03,Insurance Commissioner,,D,Dennis Anderson,244
-Johnson,Overland Park 1-04,Insurance Commissioner,,D,Dennis Anderson,80
-Johnson,Overland Park 1-05,Insurance Commissioner,,D,Dennis Anderson,190
-Johnson,Overland Park 1-06,Insurance Commissioner,,D,Dennis Anderson,356
-Johnson,Overland Park 1-07,Insurance Commissioner,,D,Dennis Anderson,311
-Johnson,Overland Park 1-08,Insurance Commissioner,,D,Dennis Anderson,218
-Johnson,Overland Park 1-09,Insurance Commissioner,,D,Dennis Anderson,144
-Johnson,Overland Park 1-10,Insurance Commissioner,,D,Dennis Anderson,293
-Johnson,Overland Park 1-11,Insurance Commissioner,,D,Dennis Anderson,76
-Johnson,Overland Park 1-12,Insurance Commissioner,,D,Dennis Anderson,242
-Johnson,Overland Park 1-13,Insurance Commissioner,,D,Dennis Anderson,179
-Johnson,Overland Park 1-14,Insurance Commissioner,,D,Dennis Anderson,279
-Johnson,Overland Park 1-15,Insurance Commissioner,,D,Dennis Anderson,138
-Johnson,Overland Park 1-16,Insurance Commissioner,,D,Dennis Anderson,337
-Johnson,Overland Park 1-17,Insurance Commissioner,,D,Dennis Anderson,145
-Johnson,Overland Park 1-18,Insurance Commissioner,,D,Dennis Anderson,285
-Johnson,Overland Park 1-19,Insurance Commissioner,,D,Dennis Anderson,205
-Johnson,Overland Park 1-20,Insurance Commissioner,,D,Dennis Anderson,172
-Johnson,Overland Park 1-21,Insurance Commissioner,,D,Dennis Anderson,64
-Johnson,Overland Park 1-22,Insurance Commissioner,,D,Dennis Anderson,70
-Johnson,Overland Park 2-01,Insurance Commissioner,,D,Dennis Anderson,195
-Johnson,Overland Park 2-02,Insurance Commissioner,,D,Dennis Anderson,260
-Johnson,Overland Park 2-03,Insurance Commissioner,,D,Dennis Anderson,207
-Johnson,Overland Park 2-04,Insurance Commissioner,,D,Dennis Anderson,277
-Johnson,Overland Park 2-05,Insurance Commissioner,,D,Dennis Anderson,233
-Johnson,Overland Park 2-06,Insurance Commissioner,,D,Dennis Anderson,220
-Johnson,Overland Park 2-07,Insurance Commissioner,,D,Dennis Anderson,186
-Johnson,Overland Park 2-08,Insurance Commissioner,,D,Dennis Anderson,151
-Johnson,Overland Park 2-09,Insurance Commissioner,,D,Dennis Anderson,175
-Johnson,Overland Park 2-10,Insurance Commissioner,,D,Dennis Anderson,108
-Johnson,Overland Park 2-11,Insurance Commissioner,,D,Dennis Anderson,213
-Johnson,Overland Park 2-12,Insurance Commissioner,,D,Dennis Anderson,162
-Johnson,Overland Park 2-13,Insurance Commissioner,,D,Dennis Anderson,109
-Johnson,Overland Park 2-14,Insurance Commissioner,,D,Dennis Anderson,181
-Johnson,Overland Park 2-15,Insurance Commissioner,,D,Dennis Anderson,345
-Johnson,Overland Park 2-16,Insurance Commissioner,,D,Dennis Anderson,199
-Johnson,Overland Park 2-17,Insurance Commissioner,,D,Dennis Anderson,259
-Johnson,Overland Park 2-18,Insurance Commissioner,,D,Dennis Anderson,303
-Johnson,Overland Park 2-19,Insurance Commissioner,,D,Dennis Anderson,184
-Johnson,Overland Park 2-20,Insurance Commissioner,,D,Dennis Anderson,174
-Johnson,Overland Park 2-21,Insurance Commissioner,,D,Dennis Anderson,203
-Johnson,Overland Park 2-22,Insurance Commissioner,,D,Dennis Anderson,228
-Johnson,Overland Park 2-23,Insurance Commissioner,,D,Dennis Anderson,187
-Johnson,Overland Park 2-24,Insurance Commissioner,,D,Dennis Anderson,306
-Johnson,Overland Park 2-25,Insurance Commissioner,,D,Dennis Anderson,262
-Johnson,Overland Park 2-26,Insurance Commissioner,,D,Dennis Anderson,114
-Johnson,Overland Park 3-01,Insurance Commissioner,,D,Dennis Anderson,304
-Johnson,Overland Park 3-02,Insurance Commissioner,,D,Dennis Anderson,243
-Johnson,Overland Park 3-03,Insurance Commissioner,,D,Dennis Anderson,199
-Johnson,Overland Park 3-04,Insurance Commissioner,,D,Dennis Anderson,297
-Johnson,Overland Park 3-05,Insurance Commissioner,,D,Dennis Anderson,262
-Johnson,Overland Park 3-06,Insurance Commissioner,,D,Dennis Anderson,299
-Johnson,Overland Park 3-07,Insurance Commissioner,,D,Dennis Anderson,220
-Johnson,Overland Park 3-08,Insurance Commissioner,,D,Dennis Anderson,212
-Johnson,Overland Park 3-09,Insurance Commissioner,,D,Dennis Anderson,359
-Johnson,Overland Park 3-10,Insurance Commissioner,,D,Dennis Anderson,168
-Johnson,Overland Park 3-11,Insurance Commissioner,,D,Dennis Anderson,204
-Johnson,Overland Park 3-12,Insurance Commissioner,,D,Dennis Anderson,181
-Johnson,Overland Park 3-13,Insurance Commissioner,,D,Dennis Anderson,356
-Johnson,Overland Park 3-14,Insurance Commissioner,,D,Dennis Anderson,292
-Johnson,Overland Park 3-15,Insurance Commissioner,,D,Dennis Anderson,142
-Johnson,Overland Park 3-16,Insurance Commissioner,,D,Dennis Anderson,246
-Johnson,Overland Park 3-17,Insurance Commissioner,,D,Dennis Anderson,201
-Johnson,Overland Park 3-18,Insurance Commissioner,,D,Dennis Anderson,220
-Johnson,Overland Park 3-19,Insurance Commissioner,,D,Dennis Anderson,217
-Johnson,Overland Park 3-20,Insurance Commissioner,,D,Dennis Anderson,287
-Johnson,Overland Park 3-21,Insurance Commissioner,,D,Dennis Anderson,209
-Johnson,Overland Park 4-01,Insurance Commissioner,,D,Dennis Anderson,130
-Johnson,Overland Park 4-02,Insurance Commissioner,,D,Dennis Anderson,173
-Johnson,Overland Park 4-03,Insurance Commissioner,,D,Dennis Anderson,188
-Johnson,Overland Park 4-04,Insurance Commissioner,,D,Dennis Anderson,302
-Johnson,Overland Park 4-05,Insurance Commissioner,,D,Dennis Anderson,225
-Johnson,Overland Park 4-06,Insurance Commissioner,,D,Dennis Anderson,198
-Johnson,Overland Park 4-07,Insurance Commissioner,,D,Dennis Anderson,194
-Johnson,Overland Park 4-08,Insurance Commissioner,,D,Dennis Anderson,223
-Johnson,Overland Park 4-09,Insurance Commissioner,,D,Dennis Anderson,147
-Johnson,Overland Park 4-10,Insurance Commissioner,,D,Dennis Anderson,130
-Johnson,Overland Park 4-11,Insurance Commissioner,,D,Dennis Anderson,266
-Johnson,Overland Park 4-12,Insurance Commissioner,,D,Dennis Anderson,361
-Johnson,Overland Park 4-13,Insurance Commissioner,,D,Dennis Anderson,117
-Johnson,Overland Park 4-14,Insurance Commissioner,,D,Dennis Anderson,113
-Johnson,Overland Park 4-15,Insurance Commissioner,,D,Dennis Anderson,285
-Johnson,Overland Park 4-16,Insurance Commissioner,,D,Dennis Anderson,150
-Johnson,Overland Park 4-17,Insurance Commissioner,,D,Dennis Anderson,275
-Johnson,Overland Park 4-18,Insurance Commissioner,,D,Dennis Anderson,46
-Johnson,Overland Park 5-01,Insurance Commissioner,,D,Dennis Anderson,262
-Johnson,Overland Park 5-02,Insurance Commissioner,,D,Dennis Anderson,131
-Johnson,Overland Park 5-03,Insurance Commissioner,,D,Dennis Anderson,214
-Johnson,Overland Park 5-04,Insurance Commissioner,,D,Dennis Anderson,233
-Johnson,Overland Park 5-05,Insurance Commissioner,,D,Dennis Anderson,209
-Johnson,Overland Park 5-06,Insurance Commissioner,,D,Dennis Anderson,197
-Johnson,Overland Park 5-07,Insurance Commissioner,,D,Dennis Anderson,188
-Johnson,Overland Park 5-08,Insurance Commissioner,,D,Dennis Anderson,280
-Johnson,Overland Park 5-09,Insurance Commissioner,,D,Dennis Anderson,299
-Johnson,Overland Park 5-10,Insurance Commissioner,,D,Dennis Anderson,237
-Johnson,Overland Park 5-11,Insurance Commissioner,,D,Dennis Anderson,324
-Johnson,Overland Park 5-12,Insurance Commissioner,,D,Dennis Anderson,65
-Johnson,Overland Park 5-13,Insurance Commissioner,,D,Dennis Anderson,367
-Johnson,Overland Park 5-14,Insurance Commissioner,,D,Dennis Anderson,246
-Johnson,Overland Park 5-15,Insurance Commissioner,,D,Dennis Anderson,209
-Johnson,Overland Park 5-16,Insurance Commissioner,,D,Dennis Anderson,130
-Johnson,Overland Park 5-17,Insurance Commissioner,,D,Dennis Anderson,91
-Johnson,Overland Park 5-18,Insurance Commissioner,,D,Dennis Anderson,193
-Johnson,Overland Park 5-19,Insurance Commissioner,,D,Dennis Anderson,18
-Johnson,Overland Park 6-01,Insurance Commissioner,,D,Dennis Anderson,225
-Johnson,Overland Park 6-02,Insurance Commissioner,,D,Dennis Anderson,169
-Johnson,Overland Park 6-03,Insurance Commissioner,,D,Dennis Anderson,198
-Johnson,Overland Park 6-04,Insurance Commissioner,,D,Dennis Anderson,180
-Johnson,Overland Park 6-05,Insurance Commissioner,,D,Dennis Anderson,268
-Johnson,Overland Park 6-06,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Overland Park 6-07,Insurance Commissioner,,D,Dennis Anderson,48
-Johnson,Overland Park 6-08,Insurance Commissioner,,D,Dennis Anderson,220
-Johnson,Overland Park 6-09,Insurance Commissioner,,D,Dennis Anderson,302
-Johnson,Overland Park 6-10,Insurance Commissioner,,D,Dennis Anderson,198
-Johnson,Overland Park 6-11,Insurance Commissioner,,D,Dennis Anderson,192
-Johnson,Overland Park 6-12,Insurance Commissioner,,D,Dennis Anderson,84
-Johnson,Overland Park 6-13,Insurance Commissioner,,D,Dennis Anderson,225
-Johnson,Overland Park 6-15,Insurance Commissioner,,D,Dennis Anderson,221
-Johnson,Overland Park 6-16,Insurance Commissioner,,D,Dennis Anderson,120
-Johnson,Overland Park 6-17,Insurance Commissioner,,D,Dennis Anderson,46
-Johnson,Overland Park 6-18,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Overland Park 6-19,Insurance Commissioner,,D,Dennis Anderson,268
-Johnson,Overland Park 6-20,Insurance Commissioner,,D,Dennis Anderson,65
-Johnson,Overland Park 6-21,Insurance Commissioner,,D,Dennis Anderson,195
-Johnson,Overland Park 6-22,Insurance Commissioner,,D,Dennis Anderson,91
-Johnson,Oxford Twp 0-01,Insurance Commissioner,,D,Dennis Anderson,1
-Johnson,Oxford Twp 0-02,Insurance Commissioner,,D,Dennis Anderson,128
-Johnson,Oxford Twp 0-04,Insurance Commissioner,,D,Dennis Anderson,115
-Johnson,Oxford Twp 0-05,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Oxford Twp 0-09,Insurance Commissioner,,D,Dennis Anderson,2
-Johnson,Oxford Twp 0-10,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Oxford Twp 0-11,Insurance Commissioner,,D,Dennis Anderson,21
-Johnson,Prairie Village 1-01,Insurance Commissioner,,D,Dennis Anderson,349
-Johnson,Prairie Village 1-02,Insurance Commissioner,,D,Dennis Anderson,261
-Johnson,Prairie Village 1-03,Insurance Commissioner,,D,Dennis Anderson,370
-Johnson,Prairie Village 2-01,Insurance Commissioner,,D,Dennis Anderson,311
-Johnson,Prairie Village 2-02,Insurance Commissioner,,D,Dennis Anderson,130
-Johnson,Prairie Village 2-03,Insurance Commissioner,,D,Dennis Anderson,277
-Johnson,Prairie Village 3-01,Insurance Commissioner,,D,Dennis Anderson,197
-Johnson,Prairie Village 3-02,Insurance Commissioner,,D,Dennis Anderson,294
-Johnson,Prairie Village 3-03,Insurance Commissioner,,D,Dennis Anderson,276
-Johnson,Prairie Village 4-01,Insurance Commissioner,,D,Dennis Anderson,276
-Johnson,Prairie Village 4-02,Insurance Commissioner,,D,Dennis Anderson,215
-Johnson,Prairie Village 4-03,Insurance Commissioner,,D,Dennis Anderson,330
-Johnson,Prairie Village 5-01,Insurance Commissioner,,D,Dennis Anderson,289
-Johnson,Prairie Village 5-02,Insurance Commissioner,,D,Dennis Anderson,284
-Johnson,Prairie Village 5-03,Insurance Commissioner,,D,Dennis Anderson,219
-Johnson,Prairie Village 6-01,Insurance Commissioner,,D,Dennis Anderson,308
-Johnson,Prairie Village 6-02,Insurance Commissioner,,D,Dennis Anderson,312
-Johnson,Prairie Village 6-03,Insurance Commissioner,,D,Dennis Anderson,179
-Johnson,Roeland Park 1-01,Insurance Commissioner,,D,Dennis Anderson,139
-Johnson,Roeland Park 1-02,Insurance Commissioner,,D,Dennis Anderson,119
-Johnson,Roeland Park 2-01,Insurance Commissioner,,D,Dennis Anderson,161
-Johnson,Roeland Park 2-02,Insurance Commissioner,,D,Dennis Anderson,194
-Johnson,Roeland Park 3-01,Insurance Commissioner,,D,Dennis Anderson,150
-Johnson,Roeland Park 3-02,Insurance Commissioner,,D,Dennis Anderson,273
-Johnson,Roeland Park 4-01,Insurance Commissioner,,D,Dennis Anderson,97
-Johnson,Roeland Park 4-02,Insurance Commissioner,,D,Dennis Anderson,336
-Johnson,Shawnee 1-01,Insurance Commissioner,,D,Dennis Anderson,311
-Johnson,Shawnee 1-02,Insurance Commissioner,,D,Dennis Anderson,211
-Johnson,Shawnee 1-03,Insurance Commissioner,,D,Dennis Anderson,211
-Johnson,Shawnee 1-04,Insurance Commissioner,,D,Dennis Anderson,280
-Johnson,Shawnee 1-05,Insurance Commissioner,,D,Dennis Anderson,352
-Johnson,Shawnee 1-06,Insurance Commissioner,,D,Dennis Anderson,229
-Johnson,Shawnee 1-07,Insurance Commissioner,,D,Dennis Anderson,270
-Johnson,Shawnee 1-08,Insurance Commissioner,,D,Dennis Anderson,242
-Johnson,Shawnee 1-09,Insurance Commissioner,,D,Dennis Anderson,54
-Johnson,Shawnee 1-10,Insurance Commissioner,,D,Dennis Anderson,72
-Johnson,Shawnee 1-11,Insurance Commissioner,,D,Dennis Anderson,147
-Johnson,Shawnee 1-12,Insurance Commissioner,,D,Dennis Anderson,3
-Johnson,Shawnee 2-01,Insurance Commissioner,,D,Dennis Anderson,121
-Johnson,Shawnee 2-02,Insurance Commissioner,,D,Dennis Anderson,238
-Johnson,Shawnee 2-03,Insurance Commissioner,,D,Dennis Anderson,197
-Johnson,Shawnee 2-04,Insurance Commissioner,,D,Dennis Anderson,307
-Johnson,Shawnee 2-05,Insurance Commissioner,,D,Dennis Anderson,133
-Johnson,Shawnee 2-06,Insurance Commissioner,,D,Dennis Anderson,184
-Johnson,Shawnee 2-07,Insurance Commissioner,,D,Dennis Anderson,167
-Johnson,Shawnee 2-08,Insurance Commissioner,,D,Dennis Anderson,154
-Johnson,Shawnee 2-09,Insurance Commissioner,,D,Dennis Anderson,166
-Johnson,Shawnee 2-10,Insurance Commissioner,,D,Dennis Anderson,142
-Johnson,Shawnee 2-11,Insurance Commissioner,,D,Dennis Anderson,204
-Johnson,Shawnee 2-12,Insurance Commissioner,,D,Dennis Anderson,77
-Johnson,Shawnee 2-13,Insurance Commissioner,,D,Dennis Anderson,114
-Johnson,Shawnee 3-01,Insurance Commissioner,,D,Dennis Anderson,123
-Johnson,Shawnee 3-02,Insurance Commissioner,,D,Dennis Anderson,257
-Johnson,Shawnee 3-03,Insurance Commissioner,,D,Dennis Anderson,230
-Johnson,Shawnee 3-04,Insurance Commissioner,,D,Dennis Anderson,169
-Johnson,Shawnee 3-05,Insurance Commissioner,,D,Dennis Anderson,241
-Johnson,Shawnee 3-06,Insurance Commissioner,,D,Dennis Anderson,204
-Johnson,Shawnee 3-07,Insurance Commissioner,,D,Dennis Anderson,253
-Johnson,Shawnee 3-08,Insurance Commissioner,,D,Dennis Anderson,233
-Johnson,Shawnee 3-09,Insurance Commissioner,,D,Dennis Anderson,114
-Johnson,Shawnee 4-01,Insurance Commissioner,,D,Dennis Anderson,315
-Johnson,Shawnee 4-02,Insurance Commissioner,,D,Dennis Anderson,170
-Johnson,Shawnee 4-03,Insurance Commissioner,,D,Dennis Anderson,80
-Johnson,Shawnee 4-04,Insurance Commissioner,,D,Dennis Anderson,120
-Johnson,Shawnee 4-05,Insurance Commissioner,,D,Dennis Anderson,285
-Johnson,Shawnee 4-06,Insurance Commissioner,,D,Dennis Anderson,207
-Johnson,Shawnee 4-07,Insurance Commissioner,,D,Dennis Anderson,281
-Johnson,Shawnee 4-08,Insurance Commissioner,,D,Dennis Anderson,112
-Johnson,Shawnee 4-09,Insurance Commissioner,,D,Dennis Anderson,372
-Johnson,Shawnee 4-11,Insurance Commissioner,,D,Dennis Anderson,202
-Johnson,Shawnee 4-12,Insurance Commissioner,,D,Dennis Anderson,39
-Johnson,Spring Hill 0-01,Insurance Commissioner,,D,Dennis Anderson,308
-Johnson,Spring Hill 0-03,Insurance Commissioner,,D,Dennis Anderson,18
-Johnson,Spring Hill 0-04,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Spring Hill Twp 0-01,Insurance Commissioner,,D,Dennis Anderson,203
-Johnson,Spring Hill Twp 0-02,Insurance Commissioner,,D,Dennis Anderson,0
-Johnson,Spring Hill Twp 0-03,Insurance Commissioner,,D,Dennis Anderson,16
-Johnson,Spring Hill Twp 0-04,Insurance Commissioner,,D,Dennis Anderson,2
-Johnson,Spring Hill Twp 0-05,Insurance Commissioner,,D,Dennis Anderson,7
-Johnson,Westwood 0-01,Insurance Commissioner,,D,Dennis Anderson,213
-Johnson,Westwood 0-02,Insurance Commissioner,,D,Dennis Anderson,194
-Johnson,Westwood Hills 0-01,Insurance Commissioner,,D,Dennis Anderson,119
-Johnson,Aubry Twp 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Aubry Twp 0-02,Insurance Commissioner,,,Write-ins,1
-Johnson,Aubry Twp 0-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Aubry Twp 0-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Aubry Twp 0-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Aubry Twp 0-06,Insurance Commissioner,,,Write-ins,0
-Johnson,De Soto 0-01,Insurance Commissioner,,,Write-ins,1
-Johnson,De Soto 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,De Soto 0-03,Insurance Commissioner,,,Write-ins,0
-Johnson,De Soto 0-06,Insurance Commissioner,,,Write-ins,0
-Johnson,De Soto 0-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Edgerton,Insurance Commissioner,,,Write-ins,0
-Johnson,Fairway 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Fairway 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Fairway 2-01,Insurance Commissioner,,,Write-ins,1
-Johnson,Fairway 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Fairway 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Fairway 3-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Fairway 4-01,Insurance Commissioner,,,Write-ins,1
-Johnson,Fairway 4-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Fairway 4-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Fairway 4-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-03,Insurance Commissioner,,,Write-ins,1
-Johnson,Gardner 0-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner 0-14,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Gardner Twp 0-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Lake Quivira,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 1-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 1-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 1-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 1-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 2-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 2-04,Insurance Commissioner,,,Write-ins,1
-Johnson,Leawood 2-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 2-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 3-02,Insurance Commissioner,,,Write-ins,2
-Johnson,Leawood 3-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 3-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 3-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 3-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 3-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 4-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 4-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 4-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 4-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 4-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Leawood 4-07,Insurance Commissioner,,,Write-ins,1
-Johnson,Leawood 4-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 1-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 2-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 2-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 2-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 2-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 2-07,Insurance Commissioner,,,Write-ins,1
-Johnson,Lenexa 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 3-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 3-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 3-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 3-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 3-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 3-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 3-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 4-02,Insurance Commissioner,,,Write-ins,1
-Johnson,Lenexa 4-03,Insurance Commissioner,,,Write-ins,1
-Johnson,Lenexa 4-04,Insurance Commissioner,,,Write-ins,1
-Johnson,Lenexa 4-05,Insurance Commissioner,,,Write-ins,1
-Johnson,Lenexa 4-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 4-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 4-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 4-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 4-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Lenexa 4-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Lexington Twp 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Lexington Twp 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Lexington Twp 0-03,Insurance Commissioner,,,Write-ins,0
-Johnson,McCamish Twp 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,McCamish Twp 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 2-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 3-01,Insurance Commissioner,,,Write-ins,1
-Johnson,Merriam 3-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 4-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Merriam 4-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 3-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 4-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission 4-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission Hills 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission Hills 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission Hills 0-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission Hills 0-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Mission Woods,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-01,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 1-02,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 1-03,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 1-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-08,Insurance Commissioner,,,Write-ins,2
-Johnson,Olathe 1-09,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 1-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-14,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-15,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 1-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-17,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-18,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-19,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-20,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-21,Insurance Commissioner,,,Write-ins,2
-Johnson,Olathe 1-22,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-23,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-24,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-24,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-26,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 1-27,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-04,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 2-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-08,Insurance Commissioner,,,Write-ins,2
-Johnson,Olathe 2-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-10,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 2-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-14,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-15,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-17,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-19,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-22,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 2-23,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-05,Insurance Commissioner,,,Write-ins,2
-Johnson,Olathe 3-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-07,Insurance Commissioner,,,Write-ins,3
-Johnson,Olathe 3-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-10,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 3-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-12,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 3-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-15,Insurance Commissioner,,,Write-ins,2
-Johnson,Olathe 3-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-17,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 3-18,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 3-19,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-20,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-21,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-22,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-23,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-24,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 3-26,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-03,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 4-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-06,Insurance Commissioner,,,Write-ins,2
-Johnson,Olathe 4-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-08,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 4-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-14,Insurance Commissioner,,,Write-ins,1
-Johnson,Olathe 4-15,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe 4-17,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-14,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-24,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-25,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-26,Insurance Commissioner,,,Write-ins,0
-Johnson,Olathe Twp 0-32,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-06,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 1-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-08,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 1-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-10,Insurance Commissioner,,,Write-ins,2
-Johnson,Overland Park 1-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-14,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-15,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-17,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 1-18,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-19,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-20,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 1-21,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 1-22,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-03,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 2-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-06,Insurance Commissioner,,,Write-ins,2
-Johnson,Overland Park 2-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-11,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 2-12,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 2-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-14,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 2-15,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-17,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-18,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-19,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-20,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-21,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 2-22,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-23,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-24,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 2-25,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 2-26,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-04,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 3-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-14,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-15,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-17,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-18,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 3-19,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-20,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 3-21,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-14,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-15,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-17,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 4-18,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-09,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 5-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-14,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-15,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-17,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-18,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 5-19,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-07,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 6-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-09,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 6-10,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 6-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-15,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-16,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-17,Insurance Commissioner,,,Write-ins,1
-Johnson,Overland Park 6-18,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-19,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-20,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-21,Insurance Commissioner,,,Write-ins,0
-Johnson,Overland Park 6-22,Insurance Commissioner,,,Write-ins,0
-Johnson,Oxford Twp 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Oxford Twp 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Oxford Twp 0-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Oxford Twp 0-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Oxford Twp 0-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Oxford Twp 0-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Oxford Twp 0-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 1-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 2-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 3-02,Insurance Commissioner,,,Write-ins,1
-Johnson,Prairie Village 3-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 4-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 4-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 5-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 5-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 5-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 6-01,Insurance Commissioner,,,Write-ins,1
-Johnson,Prairie Village 6-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Prairie Village 6-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Roeland Park 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Roeland Park 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Roeland Park 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Roeland Park 2-02,Insurance Commissioner,,,Write-ins,2
-Johnson,Roeland Park 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Roeland Park 3-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Roeland Park 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Roeland Park 4-02,Insurance Commissioner,,,Write-ins,1
-Johnson,Shawnee 1-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 1-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 1-03,Insurance Commissioner,,,Write-ins,2
-Johnson,Shawnee 1-04,Insurance Commissioner,,,Write-ins,1
-Johnson,Shawnee 1-05,Insurance Commissioner,,,Write-ins,2
-Johnson,Shawnee 1-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 1-07,Insurance Commissioner,,,Write-ins,1
-Johnson,Shawnee 1-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 1-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 1-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 1-11,Insurance Commissioner,,,Write-ins,1
-Johnson,Shawnee 1-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-10,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 2-13,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-06,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 3-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 4-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 4-02,Insurance Commissioner,,,Write-ins,1
-Johnson,Shawnee 4-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 4-04,Insurance Commissioner,,,Write-ins,1
-Johnson,Shawnee 4-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 4-06,Insurance Commissioner,,,Write-ins,1
-Johnson,Shawnee 4-07,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 4-08,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 4-09,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 4-11,Insurance Commissioner,,,Write-ins,0
-Johnson,Shawnee 4-12,Insurance Commissioner,,,Write-ins,0
-Johnson,Spring Hill 0-01,Insurance Commissioner,,,Write-ins,1
-Johnson,Spring Hill 0-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Spring Hill 0-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Spring Hill Twp 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Spring Hill Twp 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Spring Hill Twp 0-03,Insurance Commissioner,,,Write-ins,0
-Johnson,Spring Hill Twp 0-04,Insurance Commissioner,,,Write-ins,0
-Johnson,Spring Hill Twp 0-05,Insurance Commissioner,,,Write-ins,0
-Johnson,Westwood 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Westwood 0-02,Insurance Commissioner,,,Write-ins,0
-Johnson,Westwood Hills 0-01,Insurance Commissioner,,,Write-ins,0
-Johnson,Aubry Twp 0-01,State House,27,D,Theresa Hohl,32
-Johnson,Aubry Twp 0-02,State House,27,D,Theresa Hohl,131
-Johnson,Aubry Twp 0-03,State House,27,D,Theresa Hohl,98
-Johnson,Aubry Twp 0-04,State House,27,D,Theresa Hohl,202
-Johnson,Aubry Twp 0-05,State House,26,D,Cheron Tiffany,4
-Johnson,Aubry Twp 0-06,State House,27,D,Theresa Hohl,16
-Johnson,De Soto 0-01,State House,38,D,Jan Pringle,184
-Johnson,De Soto 0-02,State House,38,D,Jan Pringle,140
-Johnson,De Soto 0-03,State House,38,D,Jan Pringle,183
-Johnson,De Soto 0-04,State House,38,D,Jan Pringle,0
-Johnson,De Soto 0-05,State House,38,D,Jan Pringle,0
-Johnson,De Soto 0-06,State House,38,D,Jan Pringle,13
-Johnson,De Soto 0-07,State House,38,D,Jan Pringle,0
-Johnson,De Soto 0-08,State House,38,D,Jan Pringle,0
-Johnson,Edgerton 0-01,State House,43,D,Caitlin Trujillo,110
-Johnson,Edgerton 0-02,State House,43,D,Caitlin Trujillo,0
-Johnson,Edgerton 0-03,State House,43,D,Caitlin Trujillo,0
-Johnson,Edgerton 0-04,State House,43,D,Caitlin Trujillo,0
-Johnson,Edgerton 0-05,State House,43,D,Caitlin Trujillo,0
-Johnson,Edgerton 0-06,State House,43,D,Caitlin Trujillo,0
-Johnson,Edgerton 0-07,State House,43,D,Caitlin Trujillo,0
-Johnson,Edgerton 0-08,State House,43,D,Caitlin Trujillo,0
-Johnson,Edgerton 0-09,State House,43,D,Caitlin Trujillo,0
-Johnson,Fairway 1-01,State House,25,D,Jennifer Robinson,105
-Johnson,Fairway 1-02,State House,25,D,Jennifer Robinson,83
-Johnson,Fairway 2-01,State House,25,D,Jennifer Robinson,78
-Johnson,Fairway 2-02,State House,25,D,Jennifer Robinson,60
-Johnson,Fairway 3-01,State House,25,D,Jennifer Robinson,65
-Johnson,Fairway 3-02,State House,25,D,Jennifer Robinson,61
-Johnson,Fairway 4-01,State House,25,D,Jennifer Robinson,46
-Johnson,Fairway 4-02,State House,25,D,Jennifer Robinson,50
-Johnson,Fairway 4-03,State House,25,D,Jennifer Robinson,39
-Johnson,Fairway 4-04,State House,25,D,Jennifer Robinson,59
-Johnson,Gardner 0-01,State House,43,D,Caitlin Trujillo,254
-Johnson,Gardner 0-02,State House,43,D,Caitlin Trujillo,49
-Johnson,Gardner 0-03,State House,43,D,Caitlin Trujillo,182
-Johnson,Gardner 0-04,State House,43,D,Caitlin Trujillo,183
-Johnson,Gardner 0-05,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner 0-06,State House,43,D,Caitlin Trujillo,177
-Johnson,Gardner 0-07,State House,38,D,Jan Pringle,11
-Johnson,Gardner 0-08,State House,43,D,Caitlin Trujillo,9
-Johnson,Gardner 0-09,State House,43,D,Caitlin Trujillo,244
-Johnson,Gardner 0-10,State House,43,D,Caitlin Trujillo,127
-Johnson,Gardner 0-11,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner 0-12,State House,43,D,Caitlin Trujillo,7
-Johnson,Gardner 0-13,State House,43,D,Caitlin Trujillo,185
-Johnson,Gardner 0-14,State House,43,D,Caitlin Trujillo,147
-Johnson,Gardner 0-15,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner 0-16,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner Twp 0-01,State House,38,D,Jan Pringle,117
-Johnson,Gardner Twp 0-02,State House,43,D,Caitlin Trujillo,95
-Johnson,Gardner Twp 0-03,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner Twp 0-04,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner Twp 0-05,State House,43,D,Caitlin Trujillo,1
-Johnson,Gardner Twp 0-06,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner Twp 0-07,State House,43,D,Caitlin Trujillo,2
-Johnson,Gardner Twp 0-08,State House,43,D,Caitlin Trujillo,3
-Johnson,Gardner Twp 0-09,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner Twp 0-10,State House,121,D,Gary Smith,0
-Johnson,Gardner Twp 0-11,State House,121,D,Gary Smith,24
-Johnson,Gardner Twp 0-12,State House,43,D,Caitlin Trujillo,0
-Johnson,Gardner Twp 0-13,State House,43,D,Caitlin Trujillo,0
-Johnson,Lake Quivira,State House,17,D,Larry Meeker,257
-Johnson,Leawood 1-01,State House,21,D,Amy Bell,171
-Johnson,Leawood 1-02,State House,19,D,Patricia Stratton,224
-Johnson,Leawood 1-03,State House,19,D,Patricia Stratton,186
-Johnson,Leawood 1-04,State House,19,D,Patricia Stratton,169
-Johnson,Leawood 1-05,State House,19,D,Patricia Stratton,143
-Johnson,Leawood 1-06,State House,19,D,Patricia Stratton,52
-Johnson,Leawood 2-01,State House,19,D,Patricia Stratton,194
-Johnson,Leawood 2-02,State House,19,D,Patricia Stratton,223
-Johnson,Leawood 2-03,State House,20,D,Elizabeth Arnold,314
-Johnson,Leawood 2-04,State House,20,D,Elizabeth Arnold,237
-Johnson,Leawood 2-05,State House,20,D,Elizabeth Arnold,185
-Johnson,Leawood 2-06,State House,20,D,Elizabeth Arnold,124
-Johnson,Leawood 3-01,State House,20,D,Elizabeth Arnold,203
-Johnson,Leawood 3-02,State House,20,D,Elizabeth Arnold,309
-Johnson,Leawood 3-03,State House,20,D,Elizabeth Arnold,165
-Johnson,Leawood 3-07,State House,20,D,Elizabeth Arnold,256
-Johnson,Leawood 4-01,State House,20,D,Elizabeth Arnold,68
-Johnson,Leawood 4-02,State House,20,D,Elizabeth Arnold,217
-Johnson,Leawood 4-03,State House,20,D,Elizabeth Arnold,255
-Johnson,Leawood 4-08,State House,27,D,Theresa Hohl,112
-Johnson,Lenexa 1-01,State House,30,D,Liz Dickinson,162
-Johnson,Lenexa 1-02,State House,17,D,Larry Meeker,319
-Johnson,Lenexa 1-03,State House,17,D,Larry Meeker,355
-Johnson,Lenexa 1-04,State House,17,D,Larry Meeker,242
-Johnson,Lenexa 1-05,State House,17,D,Larry Meeker,260
-Johnson,Lenexa 1-06,State House,14,D,Merlin Ring,252
-Johnson,Lenexa 1-07,State House,30,D,Liz Dickinson,200
-Johnson,Lenexa 1-08,State House,14,D,Merlin Ring,68
-Johnson,Lenexa 1-09,State House,17,D,Larry Meeker,6
-Johnson,Lenexa 2-01,State House,14,D,Merlin Ring,267
-Johnson,Lenexa 2-02,State House,121,D,Gary Smith,95
-Johnson,Lenexa 2-03,State House,14,D,Merlin Ring,213
-Johnson,Lenexa 2-04,State House,14,D,Merlin Ring,157
-Johnson,Lenexa 2-05,State House,30,D,Liz Dickinson,267
-Johnson,Lenexa 2-06,State House,14,D,Merlin Ring,157
-Johnson,Lenexa 2-07,State House,121,D,Gary Smith,338
-Johnson,Lenexa 3-01,State House,23,D,Amber Versola,191
-Johnson,Lenexa 3-02,State House,23,D,Amber Versola,377
-Johnson,Lenexa 3-03,State House,23,D,Amber Versola,341
-Johnson,Lenexa 3-04,State House,23,D,Amber Versola,167
-Johnson,Lenexa 3-05,State House,23,D,Amber Versola,174
-Johnson,Lenexa 3-06,State House,17,D,Larry Meeker,248
-Johnson,Lenexa 3-07,State House,17,D,Larry Meeker,296
-Johnson,Lenexa 3-08,State House,17,D,Larry Meeker,316
-Johnson,Lenexa 4-01,State House,16,D,Don McGuire,151
-Johnson,Lenexa 4-02,State House,16,D,Don McGuire,255
-Johnson,Lenexa 4-03,State House,23,D,Amber Versola,132
-Johnson,Lenexa 4-04,State House,23,D,Amber Versola,107
-Johnson,Lenexa 4-05,State House,30,D,Liz Dickinson,132
-Johnson,Lenexa 4-06,State House,30,D,Liz Dickinson,171
-Johnson,Lenexa 4-07,State House,30,D,Liz Dickinson,231
-Johnson,Lenexa 4-08,State House,30,D,Liz Dickinson,284
-Johnson,Lenexa 4-09,State House,30,D,Liz Dickinson,246
-Johnson,Lenexa 4-10,State House,30,D,Liz Dickinson,134
-Johnson,Lenexa 4-11,State House,16,D,Don McGuire,38
-Johnson,Lexington Twp 0-01,State House,38,D,Jan Pringle,174
-Johnson,Lexington Twp 0-02,State House,38,D,Jan Pringle,0
-Johnson,Lexington Twp 0-03,State House,38,D,Jan Pringle,0
-Johnson,Lexington Twp 0-04,State House,38,D,Jan Pringle,0
-Johnson,Lexington Twp 0-05,State House,38,D,Jan Pringle,0
-Johnson,McCamish Twp 0-01,State House,43,D,Caitlin Trujillo,31
-Johnson,McCamish Twp 0-02,State House,43,D,Caitlin Trujillo,69
-Johnson,McCamish Twp 0-03,State House,43,D,Caitlin Trujillo,0
-Johnson,Merriam 1-01,State House,24,D,Jarrod Ousley,198
-Johnson,Merriam 1-02,State House,24,D,Jarrod Ousley,256
-Johnson,Merriam 2-01,State House,24,D,Jarrod Ousley,308
-Johnson,Merriam 2-02,State House,24,D,Jarrod Ousley,2
-Johnson,Merriam 2-03,State House,24,D,Jarrod Ousley,166
-Johnson,Merriam 3-01,State House,24,D,Jarrod Ousley,260
-Johnson,Merriam 3-02,State House,24,D,Jarrod Ousley,252
-Johnson,Merriam 4-01,State House,24,D,Jarrod Ousley,328
-Johnson,Merriam 4-02,State House,24,D,Jarrod Ousley,150
-Johnson,Merriam 4-03,State House,24,D,Jarrod Ousley,195
-Johnson,Mission 1-01,State House,25,D,Jennifer Robinson,247
-Johnson,Mission 1-02,State House,24,D,Jarrod Ousley,161
-Johnson,Mission 2-01,State House,25,D,Jennifer Robinson,149
-Johnson,Mission 2-02,State House,25,D,Jennifer Robinson,229
-Johnson,Mission 3-01,State House,24,D,Jarrod Ousley,261
-Johnson,Mission 3-02,State House,25,D,Jennifer Robinson,132
-Johnson,Mission 4-01,State House,25,D,Jennifer Robinson,172
-Johnson,Mission 4-02,State House,25,D,Jennifer Robinson,185
-Johnson,Mission 4-03,State House,25,D,Jennifer Robinson,108
-Johnson,Mission Hills 0-01,State House,25,D,Jennifer Robinson,82
-Johnson,Mission Hills 0-02,State House,25,D,Jennifer Robinson,109
-Johnson,Mission Hills 0-03,State House,25,D,Jennifer Robinson,42
-Johnson,Mission Hills 0-04,State House,21,D,Amy Bell,67
-Johnson,Mission Woods,State House,25,D,Jennifer Robinson,34
-Johnson,Olathe 1-01,State House,15,D,Steve Wright,195
-Johnson,Olathe 1-02,State House,15,D,Steve Wright,152
-Johnson,Olathe 1-03,State House,15,D,Steve Wright,106
-Johnson,Olathe 1-04,State House,26,D,Cheron Tiffany,193
-Johnson,Olathe 1-05,State House,78,D,Jim Poe,195
-Johnson,Olathe 1-06,State House,26,D,Cheron Tiffany,99
-Johnson,Olathe 1-07,State House,26,D,Cheron Tiffany,0
-Johnson,Olathe 1-08,State House,26,D,Cheron Tiffany,222
-Johnson,Olathe 1-09,State House,78,D,Jim Poe,176
-Johnson,Olathe 1-11,State House,15,D,Steve Wright,44
-Johnson,Olathe 1-12,State House,26,D,Cheron Tiffany,0
-Johnson,Olathe 1-13,State House,26,D,Cheron Tiffany,0
-Johnson,Olathe 1-14,State House,26,D,Cheron Tiffany,150
-Johnson,Olathe 1-15,State House,26,D,Cheron Tiffany,165
-Johnson,Olathe 1-16,State House,26,D,Cheron Tiffany,170
-Johnson,Olathe 1-17,State House,26,D,Cheron Tiffany,38
-Johnson,Olathe 1-18,State House,26,D,Cheron Tiffany,54
-Johnson,Olathe 1-19,State House,121,D,Gary Smith,92
-Johnson,Olathe 1-20,State House,121,D,Gary Smith,175
-Johnson,Olathe 1-21,State House,121,D,Gary Smith,236
-Johnson,Olathe 1-22,State House,121,D,Gary Smith,295
-Johnson,Olathe 1-23,State House,26,D,Cheron Tiffany,0
-Johnson,Olathe 1-24,State House,78,D,Jim Poe,20
-Johnson,Olathe 1-24,State House,78,D,Jim Poe,57
-Johnson,Olathe 1-26,State House,26,D,Cheron Tiffany,1
-Johnson,Olathe 1-27,State House,121,D,Gary Smith,174
-Johnson,Olathe 2-01,State House,15,D,Steve Wright,78
-Johnson,Olathe 2-02,State House,15,D,Steve Wright,136
-Johnson,Olathe 2-03,State House,15,D,Steve Wright,148
-Johnson,Olathe 2-04,State House,15,D,Steve Wright,204
-Johnson,Olathe 2-05,State House,121,D,Gary Smith,362
-Johnson,Olathe 2-06,State House,121,D,Gary Smith,181
-Johnson,Olathe 2-07,State House,121,D,Gary Smith,288
-Johnson,Olathe 2-08,State House,15,D,Steve Wright,221
-Johnson,Olathe 2-09,State House,14,D,Merlin Ring,95
-Johnson,Olathe 2-10,State House,121,D,Gary Smith,415
-Johnson,Olathe 2-11,State House,15,D,Steve Wright,277
-Johnson,Olathe 2-12,State House,14,D,Merlin Ring,167
-Johnson,Olathe 2-13,State House,15,D,Steve Wright,182
-Johnson,Olathe 2-14,State House,15,D,Steve Wright,136
-Johnson,Olathe 2-15,State House,14,D,Merlin Ring,112
-Johnson,Olathe 2-16,State House,14,D,Merlin Ring,69
-Johnson,Olathe 2-17,State House,38,D,Jan Pringle,1
-Johnson,Olathe 2-18,State House,121,D,Gary Smith,0
-Johnson,Olathe 2-19,State House,121,D,Gary Smith,2
-Johnson,Olathe 2-21,State House,121,D,Gary Smith,0
-Johnson,Olathe 2-22,State House,14,D,Merlin Ring,310
-Johnson,Olathe 2-23,State House,15,D,Steve Wright,197
-Johnson,Olathe 3-01,State House,49,D,Darnell Hunt,95
-Johnson,Olathe 3-02,State House,49,D,Darnell Hunt,256
-Johnson,Olathe 3-03,State House,78,D,Jim Poe,95
-Johnson,Olathe 3-04,State House,78,D,Jim Poe,186
-Johnson,Olathe 3-05,State House,8,D,Jodie Dietz,191
-Johnson,Olathe 3-06,State House,78,D,Jim Poe,137
-Johnson,Olathe 3-07,State House,78,D,Jim Poe,154
-Johnson,Olathe 3-08,State House,49,D,Darnell Hunt,214
-Johnson,Olathe 3-09,State House,49,D,Darnell Hunt,100
-Johnson,Olathe 3-10,State House,78,D,Jim Poe,206
-Johnson,Olathe 3-11,State House,78,D,Jim Poe,139
-Johnson,Olathe 3-12,State House,49,D,Darnell Hunt,207
-Johnson,Olathe 3-13,State House,78,D,Jim Poe,189
-Johnson,Olathe 3-15,State House,78,D,Jim Poe,146
-Johnson,Olathe 3-16,State House,49,D,Darnell Hunt,158
-Johnson,Olathe 3-17,State House,78,D,Jim Poe,187
-Johnson,Olathe 3-18,State House,49,D,Darnell Hunt,192
-Johnson,Olathe 3-19,State House,78,D,Jim Poe,87
-Johnson,Olathe 3-20,State House,26,D,Cheron Tiffany,116
-Johnson,Olathe 3-21,State House,26,D,Cheron Tiffany,79
-Johnson,Olathe 3-22,State House,78,D,Jim Poe,186
-Johnson,Olathe 3-23,State House,78,D,Jim Poe,173
-Johnson,Olathe 3-24,State House,49,D,Darnell Hunt,81
-Johnson,Olathe 3-25,State House,78,D,Jim Poe,0
-Johnson,Olathe 3-26,State House,78,D,Jim Poe,24
-Johnson,Olathe 4-01,State House,30,D,Liz Dickinson,157
-Johnson,Olathe 4-02,State House,14,D,Merlin Ring,300
-Johnson,Olathe 4-03,State House,14,D,Merlin Ring,111
-Johnson,Olathe 4-04,State House,30,D,Liz Dickinson,116
-Johnson,Olathe 4-05,State House,14,D,Merlin Ring,230
-Johnson,Olathe 4-06,State House,49,D,Darnell Hunt,278
-Johnson,Olathe 4-07,State House,49,D,Darnell Hunt,249
-Johnson,Olathe 4-08,State House,30,D,Liz Dickinson,184
-Johnson,Olathe 4-09,State House,30,D,Liz Dickinson,247
-Johnson,Olathe 4-10,State House,30,D,Liz Dickinson,148
-Johnson,Olathe 4-11,State House,14,D,Merlin Ring,112
-Johnson,Olathe 4-12,State House,49,D,Darnell Hunt,216
-Johnson,Olathe 4-13,State House,30,D,Liz Dickinson,127
-Johnson,Olathe 4-14,State House,30,D,Liz Dickinson,253
-Johnson,Olathe 4-15,State House,14,D,Merlin Ring,12
-Johnson,Olathe 4-16,State House,49,D,Darnell Hunt,91
-Johnson,Olathe 4-17,State House,30,D,Liz Dickinson,0
-Johnson,Olathe Twp 0-01,State House,121,D,Gary Smith,94
-Johnson,Olathe Twp 0-02,State House,26,D,Cheron Tiffany,10
-Johnson,Olathe Twp 0-03,State House,121,D,Gary Smith,15
-Johnson,Olathe Twp 0-04,State House,121,D,Gary Smith,0
-Johnson,Olathe Twp 0-05,State House,26,D,Cheron Tiffany,0
-Johnson,Olathe Twp 0-06,State House,26,D,Cheron Tiffany,0
-Johnson,Olathe Twp 0-07,State House,26,D,Cheron Tiffany,0
-Johnson,Olathe Twp 0-08,State House,121,D,Gary Smith,2
-Johnson,Olathe Twp 0-09,State House,121,D,Gary Smith,0
-Johnson,Olathe Twp 0-10,State House,26,D,Cheron Tiffany,1
-Johnson,Olathe Twp 0-11,State House,121,D,Gary Smith,1
-Johnson,Olathe Twp 0-14,State House,78,D,Jim Poe,0
-Johnson,Olathe Twp 0-25,State House,26,D,Cheron Tiffany,1
-Johnson,Olathe Twp 0-32,State House,26,D,Cheron Tiffany,3
-Johnson,Overland Park 1-01,State House,24,D,Jarrod Ousley,286
-Johnson,Overland Park 1-02,State House,24,D,Jarrod Ousley,289
-Johnson,Overland Park 1-03,State House,24,D,Jarrod Ousley,255
-Johnson,Overland Park 1-04,State House,24,D,Jarrod Ousley,87
-Johnson,Overland Park 1-05,State House,24,D,Jarrod Ousley,194
-Johnson,Overland Park 1-06,State House,21,D,Amy Bell,284
-Johnson,Overland Park 1-07,State House,21,D,Amy Bell,248
-Johnson,Overland Park 1-08,State House,22,D,Nancy Lusk,211
-Johnson,Overland Park 1-09,State House,22,D,Nancy Lusk,144
-Johnson,Overland Park 1-10,State House,22,D,Nancy Lusk,269
-Johnson,Overland Park 1-11,State House,22,D,Nancy Lusk,76
-Johnson,Overland Park 1-12,State House,22,D,Nancy Lusk,237
-Johnson,Overland Park 1-13,State House,22,D,Nancy Lusk,183
-Johnson,Overland Park 1-14,State House,22,D,Nancy Lusk,281
-Johnson,Overland Park 1-15,State House,22,D,Nancy Lusk,134
-Johnson,Overland Park 1-16,State House,19,D,Patricia Stratton,250
-Johnson,Overland Park 1-17,State House,21,D,Amy Bell,132
-Johnson,Overland Park 1-18,State House,19,D,Patricia Stratton,195
-Johnson,Overland Park 1-19,State House,22,D,Nancy Lusk,201
-Johnson,Overland Park 1-20,State House,24,D,Jarrod Ousley,187
-Johnson,Overland Park 1-21,State House,24,D,Jarrod Ousley,60
-Johnson,Overland Park 1-22,State House,24,D,Jarrod Ousley,68
-Johnson,Overland Park 2-01,State House,20,D,Elizabeth Arnold,253
-Johnson,Overland Park 2-02,State House,19,D,Patricia Stratton,198
-Johnson,Overland Park 2-03,State House,19,D,Patricia Stratton,168
-Johnson,Overland Park 2-04,State House,29,D,Heather Meyer,262
-Johnson,Overland Park 2-05,State House,23,D,Amber Versola,229
-Johnson,Overland Park 2-06,State House,22,D,Nancy Lusk,237
-Johnson,Overland Park 2-07,State House,22,D,Nancy Lusk,190
-Johnson,Overland Park 2-08,State House,19,D,Patricia Stratton,125
-Johnson,Overland Park 2-09,State House,23,D,Amber Versola,154
-Johnson,Overland Park 2-10,State House,22,D,Nancy Lusk,115
-Johnson,Overland Park 2-11,State House,22,D,Nancy Lusk,238
-Johnson,Overland Park 2-12,State House,22,D,Nancy Lusk,160
-Johnson,Overland Park 2-13,State House,22,D,Nancy Lusk,113
-Johnson,Overland Park 2-14,State House,19,D,Patricia Stratton,141
-Johnson,Overland Park 2-15,State House,16,D,Don McGuire,348
-Johnson,Overland Park 2-16,State House,19,D,Patricia Stratton,122
-Johnson,Overland Park 2-17,State House,16,D,Don McGuire,268
-Johnson,Overland Park 2-18,State House,22,D,Nancy Lusk,320
-Johnson,Overland Park 2-19,State House,19,D,Patricia Stratton,138
-Johnson,Overland Park 2-20,State House,16,D,Don McGuire,182
-Johnson,Overland Park 2-21,State House,19,D,Patricia Stratton,146
-Johnson,Overland Park 2-22,State House,19,D,Patricia Stratton,160
-Johnson,Overland Park 2-23,State House,19,D,Patricia Stratton,121
-Johnson,Overland Park 2-24,State House,20,D,Elizabeth Arnold,412
-Johnson,Overland Park 2-25,State House,20,D,Elizabeth Arnold,311
-Johnson,Overland Park 2-26,State House,23,D,Amber Versola,107
-Johnson,Overland Park 3-01,State House,16,D,Don McGuire,313
-Johnson,Overland Park 3-02,State House,29,D,Heather Meyer,238
-Johnson,Overland Park 3-03,State House,29,D,Heather Meyer,212
-Johnson,Overland Park 3-04,State House,29,D,Heather Meyer,295
-Johnson,Overland Park 3-05,State House,29,D,Heather Meyer,264
-Johnson,Overland Park 3-06,State House,29,D,Heather Meyer,293
-Johnson,Overland Park 3-07,State House,29,D,Heather Meyer,231
-Johnson,Overland Park 3-08,State House,29,D,Heather Meyer,211
-Johnson,Overland Park 3-09,State House,16,D,Don McGuire,361
-Johnson,Overland Park 3-10,State House,16,D,Don McGuire,173
-Johnson,Overland Park 3-11,State House,16,D,Don McGuire,223
-Johnson,Overland Park 3-12,State House,29,D,Heather Meyer,176
-Johnson,Overland Park 3-13,State House,16,D,Don McGuire,374
-Johnson,Overland Park 3-14,State House,16,D,Don McGuire,303
-Johnson,Overland Park 3-15,State House,16,D,Don McGuire,153
-Johnson,Overland Park 3-16,State House,20,D,Elizabeth Arnold,278
-Johnson,Overland Park 3-17,State House,29,D,Heather Meyer,198
-Johnson,Overland Park 3-18,State House,16,D,Don McGuire,227
-Johnson,Overland Park 3-19,State House,29,D,Heather Meyer,215
-Johnson,Overland Park 3-20,State House,20,D,Elizabeth Arnold,363
-Johnson,Overland Park 3-21,State House,29,D,Heather Meyer,206
-Johnson,Overland Park 4-01,State House,8,D,Jody Dietz,129
-Johnson,Overland Park 4-02,State House,8,D,Jody Dietz,176
-Johnson,Overland Park 4-03,State House,8,D,Jody Dietz,215
-Johnson,Overland Park 4-04,State House,48,D,Sandy Ackerson,304
-Johnson,Overland Park 4-05,State House,48,D,Sandy Ackerson,212
-Johnson,Overland Park 4-06,State House,16,D,Don McGuire,231
-Johnson,Overland Park 4-07,State House,16,D,Don McGuire,198
-Johnson,Overland Park 4-08,State House,16,D,Don McGuire,250
-Johnson,Overland Park 4-09,State House,8,D,Jody Dietz,179
-Johnson,Overland Park 4-10,State House,8,D,Jody Dietz,145
-Johnson,Overland Park 4-11,State House,48,D,Sandy Ackerson,261
-Johnson,Overland Park 4-12,State House,48,D,Sandy Ackerson,366
-Johnson,Overland Park 4-13,State House,8,D,Jody Dietz,113
-Johnson,Overland Park 4-14,State House,8,D,Jody Dietz,122
-Johnson,Overland Park 4-15,State House,8,D,Jody Dietz,294
-Johnson,Overland Park 4-16,State House,8,D,Jody Dietz,150
-Johnson,Overland Park 4-17,State House,8,D,Jody Dietz,289
-Johnson,Overland Park 4-18,State House,8,D,Jody Dietz,48
-Johnson,Overland Park 5-01,State House,29,D,Heather Meyer,245
-Johnson,Overland Park 5-02,State House,29,D,Heather Meyer,132
-Johnson,Overland Park 5-03,State House,48,D,Sandy Ackerson,212
-Johnson,Overland Park 5-04,State House,29,D,Heather Meyer,233
-Johnson,Overland Park 5-05,State House,48,D,Sandy Ackerson,218
-Johnson,Overland Park 5-10,State House,20,D,Elizabeth Arnold,364
-Johnson,Overland Park 5-11,State House,29,D,Heather Meyer,324
-Johnson,Overland Park 5-12,State House,29,D,Heather Meyer,68
-Johnson,Overland Park 5-13,State House,20,D,Elizabeth Arnold,406
-Johnson,Overland Park 5-14,State House,20,D,Elizabeth Arnold,364
-Johnson,Overland Park 5-15,State House,48,D,Sandy Ackerson,193
-Johnson,Overland Park 5-18,State House,48,D,Sandy Ackerson,197
-Johnson,Overland Park 5-19,State House,48,D,Sandy Ackerson,17
-Johnson,Overland Park 6-01,State House,48,D,Sandy Ackerson,200
-Johnson,Overland Park 6-02,State House,48,D,Sandy Ackerson,156
-Johnson,Overland Park 6-03,State House,8,D,Jody Dietz,237
-Johnson,Overland Park 6-04,State House,48,D,Sandy Ackerson,169
-Johnson,Overland Park 6-05,State House,48,D,Sandy Ackerson,243
-Johnson,Overland Park 6-06,State House,27,D,Theresa Hohl,0
-Johnson,Overland Park 6-07,State House,8,D,Jody Dietz,81
-Johnson,Overland Park 6-09,State House,27,D,Theresa Hohl,215
-Johnson,Overland Park 6-10,State House,27,D,Theresa Hohl,274
-Johnson,Overland Park 6-11,State House,27,D,Theresa Hohl,189
-Johnson,Overland Park 6-12,State House,27,D,Theresa Hohl,183
-Johnson,Overland Park 6-13,State House,27,D,Theresa Hohl,88
-Johnson,Overland Park 6-14,State House,27,D,Theresa Hohl,248
-Johnson,Overland Park 6-15,State House,27,D,Theresa Hohl,0
-Johnson,Overland Park 6-16,State House,8,D,Jody Dietz,222
-Johnson,Overland Park 6-17,State House,48,D,Sandy Ackerson,44
-Johnson,Overland Park 6-18,State House,27,D,Theresa Hohl,0
-Johnson,Overland Park 6-19,State House,27,D,Theresa Hohl,276
-Johnson,Overland Park 6-20,State House,27,D,Theresa Hohl,62
-Johnson,Overland Park 6-21,State House,8,D,Jody Dietz,232
-Johnson,Overland Park 6-22,State House,27,D,Theresa Hohl,89
-Johnson,Oxford Twp 0-01,State House,26,D,Cheron Tiffany,0
-Johnson,Oxford Twp 0-02,State House,27,D,Theresa Hohl,119
-Johnson,Oxford Twp 0-04,State House,27,D,Theresa Hohl,121
-Johnson,Oxford Twp 0-08,State House,27,D,Theresa Hohl,0
-Johnson,Oxford Twp 0-09,State House,27,D,Theresa Hohl,4
-Johnson,Oxford Twp 0-10,State House,27,D,Theresa Hohl,0
-Johnson,Oxford Twp 0-11,State House,78,D,Jim Poe,18
-Johnson,Prairie Village 1-01,State House,25,D,Jennifer Robinson,235
-Johnson,Prairie Village 1-02,State House,21,D,Amy Bell,192
-Johnson,Prairie Village 1-03,State House,21,D,Amy Bell,218
-Johnson,Prairie Village 2-01,State House,21,D,Amy Bell,233
-Johnson,Prairie Village 2-02,State House,21,D,Amy Bell,125
-Johnson,Prairie Village 2-03,State House,21,D,Amy Bell,240
-Johnson,Prairie Village 3-01,State House,21,D,Amy Bell,136
-Johnson,Prairie Village 3-02,State House,21,D,Amy Bell,218
-Johnson,Prairie Village 3-03,State House,21,D,Amy Bell,195
-Johnson,Prairie Village 4-01,State House,21,D,Amy Bell,187
-Johnson,Prairie Village 4-02,State House,21,D,Amy Bell,150
-Johnson,Prairie Village 4-03,State House,21,D,Amy Bell,220
-Johnson,Prairie Village 5-01,State House,19,D,Patricia Stratton,225
-Johnson,Prairie Village 5-02,State House,19,D,Patricia Stratton,199
-Johnson,Prairie Village 5-03,State House,19,D,Patricia Stratton,186
-Johnson,Prairie Village 6-01,State House,21,D,Amy Bell,246
-Johnson,Prairie Village 6-02,State House,21,D,Amy Bell,259
-Johnson,Prairie Village 6-03,State House,21,D,Amy Bell,156
-Johnson,Roeland Park 1-01,State House,25,D,Jennifer Robinson,137
-Johnson,Roeland Park 1-02,State House,25,D,Jennifer Robinson,113
-Johnson,Roeland Park 2-01,State House,25,D,Jennifer Robinson,152
-Johnson,Roeland Park 2-02,State House,25,D,Jennifer Robinson,194
-Johnson,Roeland Park 3-01,State House,25,D,Jennifer Robinson,132
-Johnson,Roeland Park 3-02,State House,25,D,Jennifer Robinson,249
-Johnson,Roeland Park 4-01,State House,25,D,Jennifer Robinson,95
-Johnson,Roeland Park 4-02,State House,25,D,Jennifer Robinson,289
-Johnson,Shawnee 1-01,State House,18,D,Cindy Neighbor,318
-Johnson,Shawnee 1-02,State House,18,D,Cindy Neighbor,256
-Johnson,Shawnee 1-03,State House,18,D,Cindy Neighbor,226
-Johnson,Shawnee 1-04,State House,18,D,Cindy Neighbor,328
-Johnson,Shawnee 1-05,State House,18,D,Cindy Neighbor,392
-Johnson,Shawnee 1-06,State House,18,D,Cindy Neighbor,273
-Johnson,Shawnee 1-07,State House,17,D,Larry Meeker,288
-Johnson,Shawnee 1-08,State House,39,D,Vicki Hiatt,268
-Johnson,Shawnee 1-09,State House,17,D,Larry Meeker,47
-Johnson,Shawnee 1-10,State House,39,D,Vicki Hiatt,78
-Johnson,Shawnee 1-11,State House,39,D,Vicki Hiatt,173
-Johnson,Shawnee 1-12,State House,17,D,Larry Meeker,3
-Johnson,Shawnee 2-01,State House,18,D,Cindy Neighbor,131
-Johnson,Shawnee 2-02,State House,18,D,Cindy Neighbor,249
-Johnson,Shawnee 2-03,State House,18,D,Cindy Neighbor,204
-Johnson,Shawnee 2-04,State House,18,D,Cindy Neighbor,338
-Johnson,Shawnee 2-05,State House,18,D,Cindy Neighbor,137
-Johnson,Shawnee 2-06,State House,18,D,Cindy Neighbor,193
-Johnson,Shawnee 2-07,State House,18,D,Cindy Neighbor,184
-Johnson,Shawnee 2-08,State House,18,D,Cindy Neighbor,152
-Johnson,Shawnee 2-09,State House,18,D,Cindy Neighbor,170
-Johnson,Shawnee 2-10,State House,18,D,Cindy Neighbor,139
-Johnson,Shawnee 2-11,State House,18,D,Cindy Neighbor,224
-Johnson,Shawnee 2-12,State House,23,D,Amber Versola,72
-Johnson,Shawnee 2-13,State House,23,D,Amber Versola,103
-Johnson,Shawnee 3-01,State House,39,D,Vicki Hiatt,142
-Johnson,Shawnee 3-02,State House,39,D,Vicki Hiatt,285
-Johnson,Shawnee 3-03,State House,39,D,Vicki Hiatt,256
-Johnson,Shawnee 3-04,State House,39,D,Vicki Hiatt,189
-Johnson,Shawnee 3-05,State House,39,D,Vicki Hiatt,245
-Johnson,Shawnee 3-06,State House,39,D,Vicki Hiatt,227
-Johnson,Shawnee 3-07,State House,39,D,Vicki Hiatt,248
-Johnson,Shawnee 3-08,State House,39,D,Vicki Hiatt,260
-Johnson,Shawnee 3-09,State House,39,D,Vicki Hiatt,118
-Johnson,Shawnee 4-01,State House,23,D,Amber Versola,259
-Johnson,Shawnee 4-02,State House,17,D,Larry Meeker,186
-Johnson,Shawnee 4-03,State House,23,D,Amber Versola,65
-Johnson,Shawnee 4-04,State House,23,D,Amber Versola,110
-Johnson,Shawnee 4-05,State House,17,D,Larry Meeker,273
-Johnson,Shawnee 4-06,State House,17,D,Larry Meeker,220
-Johnson,Shawnee 4-07,State House,17,D,Larry Meeker,306
-Johnson,Shawnee 4-08,State House,17,D,Larry Meeker,127
-Johnson,Shawnee 4-09,State House,39,D,Vicki Hiatt,378
-Johnson,Shawnee 4-11,State House,17,D,Larry Meeker,203
-Johnson,Shawnee 4-12,State House,18,D,Cindy Neighbor,45
-Johnson,Spring Hill 0-01,State House,26,D,Cheron Tiffany,257
-Johnson,Spring Hill 0-02,State House,26,D,Cheron Tiffany,0
-Johnson,Spring Hill 0-03,State House,26,D,Cheron Tiffany,15
-Johnson,Spring Hill 0-04,State House,26,D,Cheron Tiffany,0
-Johnson,Spring Hill Twp 0-01,State House,26,D,Cheron Tiffany,175
-Johnson,Spring Hill Twp 0-02,State House,26,D,Cheron Tiffany,0
-Johnson,Spring Hill Twp 0-03,State House,26,D,Cheron Tiffany,16
-Johnson,Spring Hill Twp 0-04,State House,26,D,Cheron Tiffany,2
-Johnson,Spring Hill Twp 0-05,State House,26,D,Cheron Tiffany,4
-Johnson,Westwood 0-01,State House,25,D,Jennifer Robinson,227
-Johnson,Westwood 0-02,State House,25,D,Jennifer Robinson,177
-Johnson,Westwood Hills 0-01,State House,25,D,Jennifer Robinson,117
-Johnson,Aubry Twp 0-01,State House,27,R,Ray Merrick,78
-Johnson,Aubry Twp 0-02,State House,27,R,Ray Merrick,436
-Johnson,Aubry Twp 0-03,State House,27,R,Ray Merrick,223
-Johnson,Aubry Twp 0-04,State House,27,R,Ray Merrick,518
-Johnson,Aubry Twp 0-05,State House,26,R,Larry Campbell,9
-Johnson,Aubry Twp 0-06,State House,27,R,Ray Merrick,68
-Johnson,De Soto 0-01,State House,38,R,Willie Dove,396
-Johnson,De Soto 0-02,State House,38,R,Willie Dove,216
-Johnson,De Soto 0-03,State House,38,R,Willie Dove,411
-Johnson,De Soto 0-04,State House,38,R,Willie Dove,0
-Johnson,De Soto 0-05,State House,38,R,Willie Dove,0
-Johnson,De Soto 0-06,State House,38,R,Willie Dove,32
-Johnson,De Soto 0-07,State House,38,R,Willie Dove,2
-Johnson,De Soto 0-08,State House,38,R,Willie Dove,0
-Johnson,Edgerton 0-01,State House,43,R,Bill Sutton,286
-Johnson,Edgerton 0-02,State House,43,R,Bill Sutton,0
-Johnson,Edgerton 0-03,State House,43,R,Bill Sutton,0
-Johnson,Edgerton 0-04,State House,43,R,Bill Sutton,0
-Johnson,Edgerton 0-05,State House,43,R,Bill Sutton,0
-Johnson,Edgerton 0-06,State House,43,R,Bill Sutton,0
-Johnson,Edgerton 0-07,State House,43,R,Bill Sutton,0
-Johnson,Edgerton 0-08,State House,43,R,Bill Sutton,0
-Johnson,Edgerton 0-09,State House,43,R,Bill Sutton,0
-Johnson,Fairway 1-01,State House,25,R,Melissa Rooker,177
-Johnson,Fairway 1-02,State House,25,R,Melissa Rooker,119
-Johnson,Fairway 2-01,State House,25,R,Melissa Rooker,140
-Johnson,Fairway 2-02,State House,25,R,Melissa Rooker,157
-Johnson,Fairway 3-01,State House,25,R,Melissa Rooker,242
-Johnson,Fairway 3-02,State House,25,R,Melissa Rooker,178
-Johnson,Fairway 4-01,State House,25,R,Melissa Rooker,44
-Johnson,Fairway 4-02,State House,25,R,Melissa Rooker,69
-Johnson,Fairway 4-03,State House,25,R,Melissa Rooker,39
-Johnson,Fairway 4-04,State House,25,R,Melissa Rooker,61
-Johnson,Gardner 0-01,State House,43,R,Bill Sutton,524
-Johnson,Gardner 0-02,State House,43,R,Bill Sutton,61
-Johnson,Gardner 0-03,State House,43,R,Bill Sutton,295
-Johnson,Gardner 0-04,State House,43,R,Bill Sutton,296
-Johnson,Gardner 0-05,State House,43,R,Bill Sutton,0
-Johnson,Gardner 0-06,State House,43,R,Bill Sutton,396
-Johnson,Gardner 0-07,State House,38,R,Willie Dove,3
-Johnson,Gardner 0-08,State House,43,R,Bill Sutton,38
-Johnson,Gardner 0-09,State House,43,R,Bill Sutton,414
-Johnson,Gardner 0-10,State House,43,R,Bill Sutton,292
-Johnson,Gardner 0-11,State House,43,R,Bill Sutton,0
-Johnson,Gardner 0-12,State House,43,R,Bill Sutton,7
-Johnson,Gardner 0-13,State House,43,R,Bill Sutton,290
-Johnson,Gardner 0-14,State House,43,R,Bill Sutton,256
-Johnson,Gardner 0-15,State House,43,R,Bill Sutton,0
-Johnson,Gardner 0-16,State House,43,R,Bill Sutton,0
-Johnson,Gardner Twp 0-01,State House,38,R,Willie Dove,175
-Johnson,Gardner Twp 0-02,State House,43,R,Bill Sutton,242
-Johnson,Gardner Twp 0-03,State House,43,R,Bill Sutton,0
-Johnson,Gardner Twp 0-04,State House,43,R,Bill Sutton,2
-Johnson,Gardner Twp 0-05,State House,43,R,Bill Sutton,5
-Johnson,Gardner Twp 0-06,State House,43,R,Bill Sutton,0
-Johnson,Gardner Twp 0-07,State House,43,R,Bill Sutton,2
-Johnson,Gardner Twp 0-08,State House,43,R,Bill Sutton,2
-Johnson,Gardner Twp 0-09,State House,43,R,Bill Sutton,0
-Johnson,Gardner Twp 0-10,State House,121,R,Mike Kiegirl,0
-Johnson,Gardner Twp 0-11,State House,121,R,Mike Kiegirl,63
-Johnson,Gardner Twp 0-12,State House,43,R,Bill Sutton,0
-Johnson,Gardner Twp 0-13,State House,43,R,Bill Sutton,2
-Johnson,Lake Quivira,State House,17,R,Brett Hildabrand,267
-Johnson,Leawood 1-01,State House,21,R,Barbara Bollier,319
-Johnson,Leawood 1-02,State House,19,R,Stephanie Clayton,562
-Johnson,Leawood 1-03,State House,19,R,Stephanie Clayton,468
-Johnson,Leawood 1-04,State House,19,R,Stephanie Clayton,359
-Johnson,Leawood 1-05,State House,19,R,Stephanie Clayton,314
-Johnson,Leawood 1-06,State House,19,R,Stephanie Clayton,70
-Johnson,Leawood 2-01,State House,19,R,Stephanie Clayton,415
-Johnson,Leawood 2-02,State House,19,R,Stephanie Clayton,485
-Johnson,Leawood 2-03,State House,20,R,Rob Bruchman,400
-Johnson,Leawood 2-04,State House,20,R,Rob Bruchman,506
-Johnson,Leawood 2-05,State House,20,R,Rob Bruchman,231
-Johnson,Leawood 2-06,State House,20,R,Rob Bruchman,189
-Johnson,Leawood 3-01,State House,20,R,Rob Bruchman,203
-Johnson,Leawood 3-02,State House,20,R,Rob Bruchman,365
-Johnson,Leawood 3-03,State House,20,R,Rob Bruchman,259
-Johnson,Leawood 3-04,State House,28,R,Jerry Lunn,137
-Johnson,Leawood 3-05,State House,28,R,Jerry Lunn,634
-Johnson,Leawood 3-06,State House,28,R,Jerry Lunn,662
-Johnson,Leawood 3-07,State House,20,R,Rob Bruchman,344
-Johnson,Leawood 4-01,State House,20,R,Rob Bruchman,138
-Johnson,Leawood 4-02,State House,20,R,Rob Bruchman,375
-Johnson,Leawood 4-03,State House,20,R,Rob Bruchman,314
-Johnson,Leawood 4-04,State House,28,R,Jerry Lunn,529
-Johnson,Leawood 4-05,State House,28,R,Jerry Lunn,536
-Johnson,Leawood 4-06,State House,28,R,Jerry Lunn,444
-Johnson,Leawood 4-07,State House,28,R,Jerry Lunn,701
-Johnson,Leawood 4-08,State House,27,R,Ray Merrick,277
-Johnson,Lenexa 1-01,State House,30,R,Randy Powell,199
-Johnson,Lenexa 1-02,State House,17,R,Brett Hildabrand,357
-Johnson,Lenexa 1-03,State House,17,R,Brett Hildabrand,416
-Johnson,Lenexa 1-04,State House,17,R,Brett Hildabrand,264
-Johnson,Lenexa 1-05,State House,17,R,Brett Hildabrand,290
-Johnson,Lenexa 1-06,State House,14,R,Keith Esau,416
-Johnson,Lenexa 1-07,State House,30,R,Randy Powell,185
-Johnson,Lenexa 1-08,State House,14,R,Keith Esau,78
-Johnson,Lexexa 1-09,State House,17,R,Brett Hildabrand,6
-Johnson,Lenexa 2-01,State House,14,R,Keith Esau,606
-Johnson,Lenexa 2-02,State House,121,R,Mike Kiegirl,231
-Johnson,Lenexa 2-03,State House,14,R,Keith Esau,504
-Johnson,Lenexa 2-04,State House,14,R,Keith Esau,565
-Johnson,Lenexa 2-05,State House,30,R,Randy Powell,228
-Johnson,Lenexa 2-06,State House,14,R,Keith Esau,347
-Johnson,Lenexa 2-07,State House,121,R,Mike Kiegirl,526
-Johnson,Lenexa 3-01,State House,23,R,Linda Gallagher,243
-Johnson,Lenexa 3-02,State House,23,R,Linda Gallagher,361
-Johnson,Lenexa 3-03,State House,23,R,Linda Gallagher,517
-Johnson,Lenexa 3-04,State House,23,R,Linda Gallagher,359
-Johnson,Lenexa 3-05,State House,23,R,Linda Gallagher,151
-Johnson,Lenexa 3-06,State House,17,R,Brett Hildabrand,204
-Johnson,Lenexa 3-07,State House,17,R,Brett Hildabrand,329
-Johnson,Lenexa 3-08,State House,17,R,Brett Hildabrand,329
-Johnson,Lenexa 4-01,State House,16,R,Amanda Grosserode,146
-Johnson,Lenexa 4-02,State House,16,R,Amanda Grosserode,357
-Johnson,Lenexa 4-03,State House,23,R,Linda Gallagher,106
-Johnson,Lenexa 4-04,State House,23,R,Linda Gallagher,164
-Johnson,Lenexa 4-05,State House,30,R,Randy Powell,119
-Johnson,Lenexa 4-06,State House,30,R,Randy Powell,215
-Johnson,Lenexa 4-07,State House,30,R,Randy Powell,265
-Johnson,Lenexa 4-08,State House,30,R,Randy Powell,301
-Johnson,Lenexa 4-09,State House,30,R,Randy Powell,263
-Johnson,Lenexa 4-10,State House,30,R,Randy Powell,131
-Johnson,Lenexa 4-11,State House,16,R,Amanda Grosserode,39
-Johnson,Lexington Twp 0-01,State House,38,R,Willie Dove,397
-Johnson,Lexington Twp 0-02,State House,38,R,Willie Dove,1
-Johnson,Lexington Twp 0-03,State House,38,R,Willie Dove,1
-Johnson,Lexington Twp 0-04,State House,38,R,Willie Dove,0
-Johnson,McCamish Twp 0-01,State House,43,R,Bill Sutton,113
-Johnson,McCamish Twp 0-02,State House,43,R,Bill Sutton,215
-Johnson,McCamish Twp 0-03,State House,43,R,Bill Sutton,0
-Johnson,Merriam 1-01,State House,24,R,Brandon Hermreck,125
-Johnson,Merriam 1-02,State House,24,R,Brandon Hermreck,140
-Johnson,Merriam 2-01,State House,24,R,Brandon Hermreck,212
-Johnson,Merriam 2-02,State House,24,R,Brandon Hermreck,0
-Johnson,Merriam 2-03,State House,24,R,Brandon Hermreck,97
-Johnson,Merriam 3-01,State House,24,R,Brandon Hermreck,151
-Johnson,Merriam 3-02,State House,24,R,Brandon Hermreck,146
-Johnson,Merriam 4-01,State House,24,R,Brandon Hermreck,205
-Johnson,Merriam 4-02,State House,24,R,Brandon Hermreck,87
-Johnson,Merriam 4-03,State House,24,R,Brandon Hermreck,116
-Johnson,Mission 1-01,State House,25,R,Melissa Rooker,239
-Johnson,Mission 1-02,State House,24,R,Brandon Hermreck,70
-Johnson,Mission 2-01,State House,25,R,Melissa Rooker,137
-Johnson,Mission 2-02,State House,25,R,Melissa Rooker,183
-Johnson,Mission 3-01,State House,24,R,Brandon Hermreck,154
-Johnson,Mission 3-02,State House,25,R,Melissa Rooker,113
-Johnson,Mission 4-01,State House,25,R,Melissa Rooker,147
-Johnson,Mission 4-02,State House,25,R,Melissa Rooker,302
-Johnson,Mission 4-03,State House,25,R,Melissa Rooker,134
-Johnson,Mission Hills 0-01,State House,25,R,Melissa Rooker,321
-Johnson,Mission Hills 0-02,State House,25,R,Melissa Rooker,432
-Johnson,Mission Hills 0-03,State House,25,R,Melissa Rooker,292
-Johnson,Mission Hills 0-04,State House,21,R,Barbara Bollier,507
-Johnson,Mission Woods 0-01,State House,25,R,Melissa Rooker,63
-Johnson,Olathe 1-01,State House,15,R,Erin Davis,337
-Johnson,Olathe 1-02,State House,15,R,Erin Davis,211
-Johnson,Olathe 1-03,State House,15,R,Erin Davis,170
-Johnson,Olathe 1-04,State House,26,R,Larry Campbell,334
-Johnson,Olathe 1-05,State House,78,R,Ron Ryckman,364
-Johnson,Olathe 1-06,State House,26,R,Larry Campbell,258
-Johnson,Olathe 1-07,State House,26,R,Larry Campbell,0
-Johnson,Olathe 1-08,State House,26,R,Larry Campbell,382
-Johnson,Olathe 1-09,State House,78,R,Ron Ryckman,381
-Johnson,Olathe 1-11,State House,15,R,Erin Davis,60
-Johnson,Olathe 1-12,State House,26,R,Larry Campbell,0
-Johnson,Olathe 1-13,State House,26,R,Larry Campbell,0
-Johnson,Olathe 1-14,State House,26,R,Larry Campbell,355
-Johnson,Olathe 1-15,State House,26,R,Larry Campbell,316
-Johnson,Olathe 1-16,State House,26,R,Larry Campbell,444
-Johnson,Olathe 1-17,State House,26,R,Larry Campbell,117
-Johnson,Olathe 1-18,State House,26,R,Larry Campbell,116
-Johnson,Olathe 1-19,State House,121,R,Mike Kiegirl,148
-Johnson,Olathe 1-20,State House,121,R,Mike Kiegirl,208
-Johnson,Olathe 1-21,State House,121,R,Mike Kiegirl,383
-Johnson,Olathe 1-22,State House,121,R,Mike Kiegirl,617
-Johnson,Olathe 1-23,State House,26,R,Larry Campbell,1
-Johnson,Olathe 1-24,State House,78,R,Ron Ryckman,55
-Johnson,Olathe 1-24,State House,78,R,Ron Ryckman,92
-Johnson,Olathe 1-26,State House,26,R,Larry Campbell,1
-Johnson,Olathe 1-27,State House,121,R,Mike Kiegirl,205
-Johnson,Olathe 2-01,State House,15,R,Erin Davis,145
-Johnson,Olathe 2-02,State House,15,R,Erin Davis,219
-Johnson,Olathe 2-03,State House,15,R,Erin Davis,253
-Johnson,Olathe 2-04,State House,15,R,Erin Davis,230
-Johnson,Olathe 2-05,State House,121,R,Ron Ryckman,873
-Johnson,Olathe 2-06,State House,121,R,Ron Ryckman,443
-Johnson,Olathe 2-07,State House,121,R,Ron Ryckman,475
-Johnson,Olathe 2-08,State House,15,R,Erin Davis,331
-Johnson,Olathe 2-09,State House,14,R,Keith Esau,142
-Johnson,Olathe 2-10,State House,121,R,Ron Ryckman,600
-Johnson,Olathe 2-11,State House,15,R,Erin Davis,455
-Johnson,Olathe 2-12,State House,14,R,Keith Esau,239
-Johnson,Olathe 2-13,State House,15,R,Erin Davis,249
-Johnson,Olathe 2-14,State House,15,R,Erin Davis,275
-Johnson,Olathe 2-15,State House,14,R,Keith Esau,282
-Johnson,Olathe 2-16,State House,14,R,Keith Esau,64
-Johnson,Olathe 2-17,State House,38,R,Willie Dove,0
-Johnson,Olathe 2-18,State House,121,R,Ron Ryckman,0
-Johnson,Olathe 2-19,State House,121,R,Ron Ryckman,4
-Johnson,Olathe 2-21,State House,121,R,Ron Ryckman,0
-Johnson,Olathe 2-22,State House,14,R,Keith Esau,509
-Johnson,Olathe 2-23,State House,15,R,Erin Davis,354
-Johnson,Olathe 3-01,State House,49,R,Scott Schwab,128
-Johnson,Olathe 3-02,State House,49,R,Scott Schwab,412
-Johnson,Olathe 3-03,State House,78,R,Ron Ryckman,237
-Johnson,Olathe 3-04,State House,78,R,Ron Ryckman,389
-Johnson,Olathe 3-05,State House,8,R,Craig McPherson,410
-Johnson,Olathe 3-06,State House,78,R,Ron Ryckman,298
-Johnson,Olathe 3-07,State House,78,R,Ron Ryckman,275
-Johnson,Olathe 3-08,State House,49,R,Scott Schwab,426
-Johnson,Olathe 3-09,State House,49,R,Scott Schwab,214
-Johnson,Olathe 3-10,State House,78,R,Ron Ryckman,427
-Johnson,Olathe 3-11,State House,78,R,Ron Ryckman,269
-Johnson,Olathe 3-12,State House,49,R,Scott Schwab,355
-Johnson,Olathe 3-13,State House,78,R,Ron Ryckman,434
-Johnson,Olathe 3-15,State House,78,R,Ron Ryckman,270
-Johnson,Olathe 3-16,State House,49,R,Scott Schwab,289
-Johnson,Olathe 3-17,State House,78,R,Ron Ryckman,423
-Johnson,Olathe 3-18,State House,49,R,Scott Schwab,371
-Johnson,Olathe 3-19,State House,78,R,Ron Ryckman,284
-Johnson,Olathe 3-20,State House,26,R,Larry Campbell,285
-Johnson,Olathe 3-21,State House,26,R,Larry Campbell,316
-Johnson,Olathe 3-22,State House,78,R,Ron Ryckman,339
-Johnson,Olathe 3-23,State House,78,R,Ron Ryckman,303
-Johnson,Olathe 3-24,State House,49,R,Scott Schwab,195
-Johnson,Olathe 3-25,State House,78,R,Ron Ryckman,0
-Johnson,Olathe 3-26,State House,78,R,Ron Ryckman,27
-Johnson,Olathe 4-01,State House,30,R,Randy Powell,271
-Johnson,Olathe 4-02,State House,14,R,Keith Esau,458
-Johnson,Olathe 4-03,State House,14,R,Keith Esau,107
-Johnson,Olathe 4-04,State House,30,R,Randy Powell,172
-Johnson,Olathe 4-05,State House,14,R,Keith Esau,313
-Johnson,Olathe 4-06,State House,49,R,Scott Schwab,423
-Johnson,Olathe 4-07,State House,49,R,Scott Schwab,352
-Johnson,Olathe 4-08,State House,30,R,Randy Powell,322
-Johnson,Olathe 4-09,State House,30,R,Randy Powell,460
-Johnson,Olathe 4-10,State House,30,R,Randy Powell,239
-Johnson,Olathe 4-11,State House,14,R,Keith Esau,115
-Johnson,Olathe 4-12,State House,49,R,Scott Schwab,418
-Johnson,Olathe 4-13,State House,30,R,Randy Powell,184
-Johnson,Olathe 4-14,State House,30,R,Randy Powell,421
-Johnson,Olathe 4-15,State House,14,R,Keith Esau,19
-Johnson,Olathe 4-16,State House,49,R,Scott Schwab,105
-Johnson,Olathe 4-17,State House,30,R,Randy Powell,3
-Johnson,Olathe Twp 0-01,State House,121,R,Mike Kiegirl,171
-Johnson,Olathe Twp 0-02,State House,26,R,Larry Campbell,42
-Johnson,Olathe Twp 0-03,State House,121,R,Mike Kiegirl,22
-Johnson,Olathe Twp 0-04,State House,121,R,Mike Kiegirl,0
-Johnson,Olathe Twp 0-05,State House,26,R,Larry Campbell,0
-Johnson,Olathe Twp 0-06,State House,26,R,Larry Campbell,0
-Johnson,Olathe Twp 0-07,State House,26,R,Larry Campbell,0
-Johnson,Olathe Twp 0-08,State House,121,R,Mike Kiegirl,4
-Johnson,Olathe Twp 0-09,State House,121,R,Mike Kiegirl,0
-Johnson,Olathe Twp 0-10,State House,26,R,Larry Campbell,10
-Johnson,Olathe Twp 0-11,State House,121,R,Mike Kiegirl,3
-Johnson,Olathe Twp 0-14,State House,78,R,Ron Ryckman,1
-Johnson,Olathe Twp 0-25,State House,26,R,Larry Campbell,7
-Johnson,Olathe Twp 0-32,State House,26,R,Larry Campbell,20
-Johnson,Overland Park 1-01,State House,24,R,Brandon Hermreck,190
-Johnson,Overland Park 1-02,State House,24,R,Brandon Hermreck,200
-Johnson,Overland Park 1-03,State House,24,R,Brandon Hermreck,215
-Johnson,Overland Park 1-04,State House,24,R,Brandon Hermreck,81
-Johnson,Overland Park 1-05,State House,24,R,Brandon Hermreck,128
-Johnson,Overland Park 1-06,State House,21,R,Barbara Bollier,337
-Johnson,Overland Park 1-07,State House,21,R,Barbara Bollier,334
-Johnson,Overland Park 1-08,State House,22,R,Mike Jones,185
-Johnson,Overland Park 1-09,State House,22,R,Mike Jones,128
-Johnson,Overland Park 1-10,State House,22,R,Mike Jones,272
-Johnson,Overland Park 1-11,State House,22,R,Mike Jones,64
-Johnson,Overland Park 1-12,State House,22,R,Mike Jones,194
-Johnson,Overland Park 1-13,State House,22,R,Mike Jones,163
-Johnson,Overland Park 1-14,State House,22,R,Mike Jones,211
-Johnson,Overland Park 1-15,State House,22,R,Mike Jones,105
-Johnson,Overland Park 1-16,State House,19,R,Stephanie Clayton,307
-Johnson,Overland Park 1-17,State House,21,R,Barbara Bollier,118
-Johnson,Overland Park 1-18,State House,19,R,Stephanie Clayton,291
-Johnson,Overland Park 1-19,State House,22,R,Mike Jones,171
-Johnson,Overland Park 1-20,State House,24,R,Brandon Hermreck,110
-Johnson,Overland Park 1-21,State House,24,R,Brandon Hermreck,90
-Johnson,Overland Park 1-22,State House,24,R,Brandon Hermreck,42
-Johnson,Overland Park 2-01,State House,20,R,Rob Bruchman,179
-Johnson,Overland Park 2-02,State House,19,R,Stephanie Clayton,285
-Johnson,Overland Park 2-03,State House,19,R,Stephanie Clayton,253
-Johnson,Overland Park 2-04,State House,29,R,James Eric Todd,256
-Johnson,Overland Park 2-05,State House,23,R,Linda Gallagher,198
-Johnson,Overland Park 2-06,State House,22,R,Mike Jones,212
-Johnson,Overland Park 2-07,State House,22,R,Mike Jones,183
-Johnson,Overland Park 2-08,State House,19,R,Stephanie Clayton,117
-Johnson,Overland Park 2-09,State House,23,R,Linda Gallagher,223
-Johnson,Overland Park 2-10,State House,22,R,Mike Jones,198
-Johnson,Overland Park 2-11,State House,22,R,Mike Jones,211
-Johnson,Overland Park 2-12,State House,22,R,Mike Jones,178
-Johnson,Overland Park 2-13,State House,22,R,Mike Jones,90
-Johnson,Overland Park 2-14,State House,19,R,Stephanie Clayton,182
-Johnson,Overland Park 2-15,State House,16,R,Amanda Grosserode,323
-Johnson,Overland Park 2-16,State House,19,R,Stephanie Clayton,250
-Johnson,Overland Park 2-17,State House,16,R,Amanda Grosserode,310
-Johnson,Overland Park 2-18,State House,22,R,Mike Jones,269
-Johnson,Overland Park 2-19,State House,19,R,Stephanie Clayton,241
-Johnson,Overland Park 2-20,State House,16,R,Amanda Grosserode,200
-Johnson,Overland Park 2-21,State House,19,R,Stephanie Clayton,237
-Johnson,Overland Park 2-22,State House,19,R,Stephanie Clayton,270
-Johnson,Overland Park 2-23,State House,19,R,Stephanie Clayton,342
-Johnson,Overland Park 2-24,State House,20,R,Rob Bruchman,308
-Johnson,Overland Park 2-25,State House,20,R,Rob Bruchman,266
-Johnson,Overland Park 2-26,State House,23,R,Linda Gallagher,101
-Johnson,Overland Park 3-01,State House,16,R,Amanda Grosserode,463
-Johnson,Overland Park 3-02,State House,29,R,James Eric Todd,242
-Johnson,Overland Park 3-03,State House,29,R,James Eric Todd,288
-Johnson,Overland Park 3-04,State House,29,R,James Eric Todd,310
-Johnson,Overland Park 3-05,State House,29,R,James Eric Todd,303
-Johnson,Overland Park 3-06,State House,29,R,James Eric Todd,370
-Johnson,Overland Park 3-07,State House,29,R,James Eric Todd,171
-Johnson,Overland Park 3-08,State House,29,R,James Eric Todd,310
-Johnson,Overland Park 3-09,State House,16,R,Amanda Grosserode,369
-Johnson,Overland Park 3-10,State House,16,R,Amanda Grosserode,235
-Johnson,Overland Park 3-11,State House,16,R,Amanda Grosserode,290
-Johnson,Overland Park 3-12,State House,29,R,James Eric Todd,148
-Johnson,Overland Park 3-13,State House,16,R,Amanda Grosserode,444
-Johnson,Overland Park 3-14,State House,16,R,Amanda Grosserode,287
-Johnson,Overland Park 3-15,State House,16,R,Amanda Grosserode,226
-Johnson,Overland Park 3-16,State House,20,R,Rob Bruchman,239
-Johnson,Overland Park 3-17,State House,29,R,James Eric Todd,226
-Johnson,Overland Park 3-18,State House,16,R,Amanda Grosserode,212
-Johnson,Overland Park 3-19,State House,29,R,James Eric Todd,284
-Johnson,Overland Park 3-20,State House,20,R,Rob Bruchman,281
-Johnson,Overland Park 3-21,State House,29,R,James Eric Todd,307
-Johnson,Overland Park 4-01,State House,8,R,Craig McPherson,245
-Johnson,Overland Park 4-02,State House,8,R,Craig McPherson,417
-Johnson,Overland Park 4-03,State House,8,R,Craig McPherson,497
-Johnson,Overland Park 4-04,State House,48,R,Marvin Kleeb,507
-Johnson,Overland Park 4-05,State House,48,R,Marvin Kleeb,365
-Johnson,Overland Park 4-06,State House,16,R,Amanda Grosserode,259
-Johnson,Overland Park 4-07,State House,16,R,Amanda Grosserode,198
-Johnson,Overland Park 4-08,State House,16,R,Amanda Grosserode,342
-Johnson,Overland Park 4-09,State House,8,R,Craig McPherson,377
-Johnson,Overland Park 4-10,State House,8,R,Craig McPherson,253
-Johnson,Overland Park 4-11,State House,48,R,Marvin Kleeb,415
-Johnson,Overland Park 4-12,State House,48,R,Marvin Kleeb,533
-Johnson,Overland Park 4-13,State House,8,R,Craig McPherson,313
-Johnson,Overland Park 4-14,State House,8,R,Craig McPherson,235
-Johnson,Overland Park 4-15,State House,8,R,Craig McPherson,449
-Johnson,Overland Park 4-16,State House,8,R,Craig McPherson,385
-Johnson,Overland Park 4-17,State House,8,R,Craig McPherson,405
-Johnson,Overland Park 4-18,State House,8,R,Craig McPherson,51
-Johnson,Overland Park 5-01,State House,29,R,James Eric Todd,364
-Johnson,Overland Park 5-02,State House,29,R,James Eric Todd,169
-Johnson,Overland Park 5-03,State House,48,R,Marvin Kleeb,361
-Johnson,Overland Park 5-04,State House,29,R,James Eric Todd,302
-Johnson,Overland Park 5-05,State House,48,R,Marvin Kleeb,195
-Johnson,Overland Park 5-06,State House,28,R,Jerry Lunn,355
-Johnson,Overland Park 5-07,State House,28,R,Jerry Lunn,613
-Johnson,Overland Park 5-08,State House,28,R,Jerry Lunn,682
-Johnson,Overland Park 5-09,State House,28,R,Jerry Lunn,593
-Johnson,Overland Park 5-10,State House,20,R,Rob Bruchman,229
-Johnson,Overland Park 5-11,State House,29,R,James Eric Todd,394
-Johnson,Overland Park 5-12,State House,29,R,James Eric Todd,82
-Johnson,Overland Park 5-13,State House,20,R,Rob Bruchman,376
-Johnson,Overland Park 5-14,State House,20,R,Rob Bruchman,247
-Johnson,Overland Park 5-15,State House,48,R,Marvin Kleeb,229
-Johnson,Overland Park 5-16,State House,28,R,Jerry Lunn,278
-Johnson,Overland Park 5-17,State House,28,R,Jerry Lunn,169
-Johnson,Overland Park 5-18,State House,48,R,Marvin Kleeb,271
-Johnson,Overland Park 5-19,State House,48,R,Marvin Kleeb,31
-Johnson,Overland Park 6-01,State House,48,R,Marvin Kleeb,497
-Johnson,Overland Park 6-02,State House,48,R,Marvin Kleeb,389
-Johnson,Overland Park 6-03,State House,8,R,Craig McPherson,370
-Johnson,Overland Park 6-04,State House,48,R,Marvin Kleeb,406
-Johnson,Overland Park 6-05,State House,48,R,Marvin Kleeb,447
-Johnson,Overland Park 6-06,State House,27,R,Ray Merrick,1
-Johnson,Overland Park 6-07,State House,8,R,Craig McPherson,107
-Johnson,Overland Park 6-08,State House,27,R,Ray Merrick,696
-Johnson,Overland Park 6-09,State House,27,R,Ray Merrick,530
-Johnson,Overland Park 6-10,State House,27,R,Ray Merrick,335
-Johnson,Overland Park 6-11,State House,27,R,Ray Merrick,353
-Johnson,Overland Park 6-12,State House,27,R,Ray Merrick,162
-Johnson,Overland Park 6-13,State House,27,R,Ray Merrick,473
-Johnson,Overland Park 6-14,State House,27,R,Ray Merrick,0
-Johnson,Overland Park 6-15,State House,27,R,Ray Merrick,476
-Johnson,Overland Park 6-16,State House,8,R,Craig McPherson,277
-Johnson,Overland Park 6-17,State House,48,R,Marvin Kleeb,90
-Johnson,Overland Park 6-18,State House,27,R,Ray Merrick,3
-Johnson,Overland Park 6-19,State House,27,R,Ray Merrick,421
-Johnson,Overland Park 6-20,State House,27,R,Ray Merrick,265
-Johnson,Overland Park 6-21,State House,8,R,Craig McPherson,644
-Johnson,Overland Park 6-22,State House,27,R,Ray Merrick,235
-Johnson,Oxford Twp 0-01,State House,26,R,Larry Campbell,2
-Johnson,Oxford Twp 0-02,State House,27,R,Ray Merrick,324
-Johnson,Oxford Twp 0-04,State House,27,R,Ray Merrick,229
-Johnson,Oxford Twp 0-05,State House,28,R,Jerry Lunn,10
-Johnson,Oxford Twp 0-08,State House,27,R,Ray Merrick,0
-Johnson,Oxford Twp 0-09,State House,27,R,Ray Merrick,16
-Johnson,Oxford Twp 0-10,State House,27,R,Ray Merrick,2
-Johnson,Oxford Twp 0-11,State House,78,R,Ron Ryckman,68
-Johnson,Prairie Village 1-01,State House,25,R,Melissa Rooker,455
-Johnson,Prairie Village 1-02,State House,21,R,Barbara Bollier,290
-Johnson,Prairie Village 1-03,State House,21,R,Barbara Bollier,459
-Johnson,Prairie Village 2-01,State House,21,R,Barbara Bollier,319
-Johnson,Prairie Village 2-02,State House,21,R,Barbara Bollier,136
-Johnson,Prairie Village 2-03,State House,21,R,Barbara Bollier,241
-Johnson,Prairie Village 3-01,State House,21,R,Barbara Bollier,259
-Johnson,Prairie Village 3-02,State House,21,R,Barbara Bollier,353
-Johnson,Prairie Village 3-03,State House,21,R,Barbara Bollier,325
-Johnson,Prairie Village 4-01,State House,21,R,Barbara Bollier,478
-Johnson,Prairie Village 4-02,State House,21,R,Barbara Bollier,253
-Johnson,Prairie Village 4-03,State House,21,R,Barbara Bollier,427
-Johnson,Prairie Village 5-01,State House,19,R,Stephanie Clayton,408
-Johnson,Prairie Village 5-02,State House,19,R,Stephanie Clayton,462
-Johnson,Prairie Village 5-03,State House,19,R,Stephanie Clayton,319
-Johnson,Prairie Village 6-01,State House,21,R,Barbara Bollier,410
-Johnson,Prairie Village 6-02,State House,21,R,Barbara Bollier,273
-Johnson,Prairie Village 6-03,State House,21,R,Barbara Bollier,176
-Johnson,Roeland Park 1-01,State House,25,R,Melissa Rooker,87
-Johnson,Roeland Park 1-02,State House,25,R,Melissa Rooker,69
-Johnson,Roeland Park 2-01,State House,25,R,Melissa Rooker,109
-Johnson,Roeland Park 2-02,State House,25,R,Melissa Rooker,165
-Johnson,Roeland Park 3-01,State House,25,R,Melissa Rooker,92
-Johnson,Roeland Park 3-02,State House,25,R,Melissa Rooker,188
-Johnson,Roeland Park 4-01,State House,25,R,Melissa Rooker,102
-Johnson,Roeland Park 4-02,State House,25,R,Melissa Rooker,311
-Johnson,Shawnee 1-01,State House,18,R,John Rubin,322
-Johnson,Shawnee 1-02,State House,18,R,John Rubin,228
-Johnson,Shawnee 1-03,State House,18,R,John Rubin,222
-Johnson,Shawnee 1-04,State House,18,R,John Rubin,431
-Johnson,Shawnee 1-05,State House,18,R,John Rubin,422
-Johnson,Shawnee 1-06,State House,18,R,John Rubin,384
-Johnson,Shawnee 1-07,State House,17,R,Brett Hildabrand,337
-Johnson,Shawnee 1-08,State House,39,R,Charles Macheers,388
-Johnson,Shawnee 1-09,State House,17,R,Brett Hildabrand,56
-Johnson,Shawnee 1-10,State House,39,R,Charles Macheers,153
-Johnson,Shawnee 1-11,State House,39,R,Charles Macheers,235
-Johnson,Shawnee 1-12,State House,17,R,Brett Hildabrand,4
-Johnson,Shawnee 2-01,State House,18,R,John Rubin,143
-Johnson,Shawnee 2-02,State House,18,R,John Rubin,277
-Johnson,Shawnee 2-03,State House,18,R,John Rubin,192
-Johnson,Shawnee 2-04,State House,18,R,John Rubin,292
-Johnson,Shawnee 2-05,State House,18,R,John Rubin,164
-Johnson,Shawnee 2-06,State House,18,R,John Rubin,240
-Johnson,Shawnee 2-07,State House,18,R,John Rubin,163
-Johnson,Shawnee 2-08,State House,18,R,John Rubin,188
-Johnson,Shawnee 2-09,State House,18,R,John Rubin,151
-Johnson,Shawnee 2-10,State House,18,R,John Rubin,152
-Johnson,Shawnee 2-11,State House,18,R,John Rubin,241
-Johnson,Shawnee 2-12,State House,23,R,Linda Gallagher,51
-Johnson,Shawnee 2-13,State House,23,R,Linda Gallagher,121
-Johnson,Shawnee 3-01,State House,39,R,Charles Macheers,261
-Johnson,Shawnee 3-02,State House,39,R,Charles Macheers,471
-Johnson,Shawnee 3-03,State House,39,R,Charles Macheers,319
-Johnson,Shawnee 3-04,State House,39,R,Charles Macheers,340
-Johnson,Shawnee 3-05,State House,39,R,Charles Macheers,526
-Johnson,Shawnee 3-06,State House,39,R,Charles Macheers,304
-Johnson,Shawnee 3-07,State House,39,R,Charles Macheers,451
-Johnson,Shawnee 3-08,State House,39,R,Charles Macheers,382
-Johnson,Shawnee 3-09,State House,39,R,Charles Macheers,260
-Johnson,Shawnee 4-01,State House,23,R,Linda Gallagher,489
-Johnson,Shawnee 4-02,State House,17,R,Brett Hildabrand,230
-Johnson,Shawnee 4-03,State House,23,R,Linda Gallagher,109
-Johnson,Shawnee 4-04,State House,23,R,Linda Gallagher,92
-Johnson,Shawnee 4-05,State House,17,R,Brett Hildabrand,309
-Johnson,Shawnee 4-06,State House,17,R,Brett Hildabrand,295
-Johnson,Shawnee 4-07,State House,17,R,Brett Hildabrand,405
-Johnson,Shawnee 4-08,State House,17,R,Brett Hildabrand,158
-Johnson,Shawnee 4-09,State House,39,R,Charles Macheers,482
-Johnson,Shawnee 4-11,State House,17,R,Brett Hildabrand,210
-Johnson,Shawnee 4-12,State House,18,R,John Rubin,44
-Johnson,Spring Hill 0-01,State House,26,R,Larry Campbell,605
-Johnson,Spring Hill 0-02,State House,26,R,Larry Campbell,0
-Johnson,Spring Hill 0-03,State House,26,R,Larry Campbell,45
-Johnson,Spring Hill 0-04,State House,26,R,Larry Campbell,0
-Johnson,Spring Hill Twp 0-01,State House,26,R,Larry Campbell,476
-Johnson,Spring Hill Twp 0-03,State House,26,R,Larry Campbell,53
-Johnson,Spring Hill Twp 0-04,State House,26,R,Larry Campbell,11
-Johnson,Spring Hill Twp 0-05,State House,26,R,Larry Campbell,4
-Johnson,Westwood 0-01,State House,25,R,Melissa Rooker,121
-Johnson,Westwood 0-02,State House,25,R,Melissa Rooker,169
-Johnson,Westwood Hills 0-01,State House,25,R,Melissa Rooker,85
-Johnson,De Soto 0-01,State House,38,L,Caleb Christopher,42
-Johnson,De Soto 0-02,State House,38,L,Caleb Christopher,27
-Johnson,De Soto 0-03,State House,38,L,Caleb Christopher,39
-Johnson,De Soto 0-04,State House,38,L,Caleb Christopher,0
-Johnson,De Soto 0-05,State House,38,L,Caleb Christopher,0
-Johnson,De Soto 0-06,State House,38,L,Caleb Christopher,3
-Johnson,De Soto 0-07,State House,38,L,Caleb Christopher,0
-Johnson,De Soto 0-08,State House,38,L,Caleb Christopher,0
-Johnson,Gardner 7,State House,38,L,Caleb Christopher,0
-Johnson,Gardner Twp 0-01,State House,38,L,Caleb Christopher,12
-Johnson,Lake Quivira,State House,17,L,Michael Kerner,9
-Johnson,Lenexa 1-02,State House,17,L,Michael Kerner,64
-Johnson,Lenexa 1-03,State House,17,L,Michael Kerner,91
-Johnson,Lenexa 1-04,State House,17,L,Michael Kerner,43
-Johnson,Lenexa 1-05,State House,17,L,Michael Kerner,54
-Johnson,Lenexa 1-06,State House,14,L,Brent Stackhouse,36
-Johnson,Lenexa 1-08,State House,14,L,Brent Stackhouse,16
-Johnson,Lenexa 1-09,State House,17,L,Michael Kerner,0
-Johnson,Lenexa 2-01,State House,14,L,Brent Stackhouse,50
-Johnson,Lenexa 2-03,State House,14,L,Brent Stackhouse,43
-Johnson,Lenexa 2-04,State House,14,L,Brent Stackhouse,28
-Johnson,Lenexa 2-06,State House,14,L,Brent Stackhouse,26
-Johnson,Lenexa 3-06,State House,17,L,Michael Kerner,43
-Johnson,Lenexa 3-07,State House,17,L,Michael Kerner,53
-Johnson,Lenexa 3-08,State House,17,L,Michael Kerner,53
-Johnson,Lexington Twp 0-01,State House,38,L,Caleb Christopher,24
-Johnson,Lexington Twp 0-02,State House,38,L,Caleb Christopher,2
-Johnson,Lexington Twp 0-03,State House,38,L,Caleb Christopher,1
-Johnson,Lexington Twp 0-04,State House,38,L,Caleb Christopher,0
-Johnson,Lexington Twp 0-05,State House,38,L,Caleb Christopher,0
-Johnson,Olathe 2-09,State House,14,L,Brent Stackhouse,10
-Johnson,Olathe 2-12,State House,14,L,Brent Stackhouse,23
-Johnson,Olathe 2-15,State House,14,L,Brent Stackhouse,24
-Johnson,Olathe 2-16,State House,14,L,Brent Stackhouse,15
-Johnson,Olathe 2-17,State House,38,L,Caleb Christopher,0
-Johnson,Olathe 2-22,State House,14,L,Brent Stackhouse,47
-Johnson,Olathe 4-02,State House,14,L,Brent Stackhouse,59
-Johnson,Olathe 4-03,State House,14,L,Brent Stackhouse,39
-Johnson,Olathe 4-05,State House,14,L,Brent Stackhouse,29
-Johnson,Olathe 4-11,State House,14,L,Brent Stackhouse,24
-Johnson,Olathe 4-15,State House,14,L,Brent Stackhouse,3
-Johnson,Shawnee 1-07,State House,17,L,Michael Kerner,20
-Johnson,Shawnee 1-09,State House,17,L,Michael Kerner,4
-Johnson,Shawnee 1-12,State House,17,L,Michael Kerner,0
-Johnson,Shawnee 4-02,State House,17,L,Michael Kerner,13
-Johnson,Shawnee 4-05,State House,17,L,Michael Kerner,32
-Johnson,Shawnee 4-06,State House,17,L,Michael Kerner,23
-Johnson,Shawnee 4-07,State House,17,L,Michael Kerner,26
-Johnson,Shawnee 4-08,State House,17,L,Michael Kerner,12
-Johnson,Shawnee 4-11,State House,17,L,Michael Kerner,26
-Johnson,Overland Park 4-01,State Senate,37,R,Molly Baumgardner,312
-Johnson,Overland Park 4-02,State Senate,37,R,Molly Baumgardner,501
-Johnson,Overland Park 6-03,State Senate,37,R,Molly Baumgardner,501
-Johnson,Overland Park 6-04,State Senate,37,R,Molly Baumgardner,484
-Johnson,Overland Park 6-06,State Senate,37,R,Molly Baumgardner,1
-Johnson,Overland Park 6-07,State Senate,37,R,Molly Baumgardner,158
-Johnson,Overland Park 6-08,State Senate,37,R,Molly Baumgardner,793
-Johnson,Overland Park 6-09,State Senate,37,R,Molly Baumgardner,649
-Johnson,Overland Park 6-10,State Senate,37,R,Molly Baumgardner,426
-Johnson,Overland Park 6-16,State Senate,37,R,Molly Baumgardner,344
-Johnson,Aubry Twp 0-01,State Senate,37,R,Molly Baumgardner,89
-Johnson,Aubry Twp 0-02,State Senate,37,R,Molly Baumgardner,483
-Johnson,Aubry Twp 0-03,State Senate,37,R,Molly Baumgardner,271
-Johnson,Aubry Twp 0-04,State Senate,37,R,Molly Baumgardner,603
-Johnson,Aubry Twp 0-05,State Senate,37,R,Molly Baumgardner,11
-Johnson,Aubry Twp 0-06,State Senate,37,R,Molly Baumgardner,77
-Johnson,Edgerton 0-01,State Senate,37,R,Molly Baumgardner,338
-Johnson,Gardner 0-02,State Senate,37,R,Molly Baumgardner,85
-Johnson,Gardner 0-03,State Senate,37,R,Molly Baumgardner,395
-Johnson,Gardner 0-04,State Senate,37,R,Molly Baumgardner,387
-Johnson,Gardner 0-09,State Senate,37,R,Molly Baumgardner,548
-Johnson,Gardner 0-10,State Senate,37,R,Molly Baumgardner,343
-Johnson,Gardner 0-13,State Senate,37,R,Molly Baumgardner,385
-Johnson,Gardner Twp 0-02,State Senate,37,R,Molly Baumgardner,286
-Johnson,Gardner Twp 0-09,State Senate,37,R,Molly Baumgardner,0
-Johnson,Gardner Twp 0-10,State Senate,37,R,Molly Baumgardner,0
-Johnson,Gardner Twp 0-13,State Senate,37,R,Molly Baumgardner,2
-Johnson,McCamish Twp 0-02,State Senate,37,R,Molly Baumgardner,126
-Johnson,Olathe 1-11,State Senate,37,R,Molly Baumgardner,0
-Johnson,Olathe 1-17,State Senate,37,R,Molly Baumgardner,143
-Johnson,Olathe 3-05,State Senate,37,R,Molly Baumgardner,498
-Johnson,Olathe Twp 0-06,State Senate,37,R,Molly Baumgardner,0
-Johnson,Overland Park 6-17,State Senate,37,R,Molly Baumgardner,109
-Johnson,Overland Park 6-18,State Senate,37,R,Molly Baumgardner,3
-Johnson,Overland Park 6-20,State Senate,37,R,Molly Baumgardner,292
-Johnson,Overland Park 6-21,State Senate,37,R,Molly Baumgardner,753
-Johnson,Overland Park 6-22,State Senate,37,R,Molly Baumgardner,270
-Johnson,Oxford Twp 0-01,State Senate,37,R,Molly Baumgardner,1
-Johnson,Oxford Twp 0-02,State Senate,37,R,Molly Baumgardner,366
-Johnson,Oxford Twp 0-11,State Senate,37,R,Molly Baumgardner,77
-Johnson,Spring Hill 0-01,State Senate,37,R,Molly Baumgardner,708
-Johnson,Spring Hill 0-03,State Senate,37,R,Molly Baumgardner,47
-Johnson,Spring Hill 0-04,State Senate,37,R,Molly Baumgardner,0
-Johnson,Spring Hill Twp 0-01,State Senate,37,R,Molly Baumgardner,556
-Johnson,Spring Hill Twp 0-02,State Senate,37,R,Molly Baumgardner,2
-Johnson,Spring Hill Twp 0-03,State Senate,37,R,Molly Baumgardner,57
-Johnson,Spring Hill Twp 0-04,State Senate,37,R,Molly Baumgardner,12
-Johnson,Spring Hill Twp 0-05,State Senate,37,R,Molly Baumgardner,6
-Johnson,Overland Park 4-01,State Senate,37,,Write-ins,5
-Johnson,Overland Park 4-02,State Senate,37,,Write-ins,1
-Johnson,Overland Park 6-03,State Senate,37,,Write-ins,7
-Johnson,Overland Park 6-04,State Senate,37,,Write-ins,4
-Johnson,Overland Park 6-06,State Senate,37,,Write-ins,0
-Johnson,Overland Park 6-07,State Senate,37,,Write-ins,1
-Johnson,Overland Park 6-08,State Senate,37,,Write-ins,10
-Johnson,Overland Park 6-09,State Senate,37,,Write-ins,7
-Johnson,Overland Park 6-10,State Senate,37,,Write-ins,5
-Johnson,Overland Park 6-16,State Senate,37,,Write-ins,1
-Johnson,Aubry Twp 0-01,State Senate,37,,Write-ins,0
-Johnson,Aubry Twp 0-02,State Senate,37,,Write-ins,2
-Johnson,Aubry Twp 0-03,State Senate,37,,Write-ins,1
-Johnson,Aubry Twp 0-04,State Senate,37,,Write-ins,8
-Johnson,Aubry Twp 0-05,State Senate,37,,Write-ins,0
-Johnson,Aubry Twp 0-06,State Senate,37,,Write-ins,0
-Johnson,Edgerton 0-01,State Senate,37,,Write-ins,7
-Johnson,Gardner 0-02,State Senate,37,,Write-ins,2
-Johnson,Gardner 0-03,State Senate,37,,Write-ins,7
-Johnson,Gardner 0-04,State Senate,37,,Write-ins,6
-Johnson,Gardner 0-09,State Senate,37,,Write-ins,5
-Johnson,Gardner 0-10,State Senate,37,,Write-ins,6
-Johnson,Gardner 0-13,State Senate,37,,Write-ins,9
-Johnson,Gardner Twp 0-02,State Senate,37,,Write-ins,0
-Johnson,Gardner Twp 0-09,State Senate,37,,Write-ins,0
-Johnson,Gardner Twp 0-10,State Senate,37,,Write-ins,0
-Johnson,Gardner Twp 0-13,State Senate,37,,Write-ins,0
-Johnson,McCamish Twp 0-02,State Senate,37,,Write-ins,1
-Johnson,Olathe 1-11,State Senate,37,,Write-ins,0
-Johnson,Olathe 1-17,State Senate,37,,Write-ins,0
-Johnson,Olathe 3-05,State Senate,37,,Write-ins,12
-Johnson,Olathe Twp 0-06,State Senate,37,,Write-ins,0
-Johnson,Overland Park 6-17,State Senate,37,,Write-ins,2
-Johnson,Overland Park 6-18,State Senate,37,,Write-ins,0
-Johnson,Overland Park 6-20,State Senate,37,,Write-ins,2
-Johnson,Overland Park 6-21,State Senate,37,,Write-ins,10
-Johnson,Overland Park 6-22,State Senate,37,,Write-ins,4
-Johnson,Oxford Twp 0-01,State Senate,37,,Write-ins,0
-Johnson,Oxford Twp 0-02,State Senate,37,,Write-ins,3
-Johnson,Oxford Twp 0-11,State Senate,37,,Write-ins,2
-Johnson,Spring Hill 0-01,State Senate,37,,Write-ins,15
-Johnson,Spring Hill 0-03,State Senate,37,,Write-ins,2
-Johnson,Spring Hill 0-04,State Senate,37,,Write-ins,0
-Johnson,Spring Hill Twp 0-01,State Senate,37,,Write-ins,8
-Johnson,Spring Hill Twp 0-02,State Senate,37,,Write-ins,0
-Johnson,Spring Hill Twp 0-03,State Senate,37,,Write-ins,0
-Johnson,Spring Hill Twp 0-04,State Senate,37,,Write-ins,0
-Johnson,Spring Hill Twp 0-05,State Senate,37,,Write-ins,0
+county,precinct,office,district,party,candidate,votes,vtd
+JOHNSON,ADVANCED,Kansas House of Representatives,8,Democratic,"Dietz, Jodie",2723,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,8,Republican,"McPherson, Craig",5435,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,14,Democratic,"Ring, Merlin",2632,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,14,Libertarian,"Stackhouse, Brent",472,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,14,Republican,"Esau, Keith",4764,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,15,Democratic,"Wright, Steve",2076,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,15,Republican,"Davis, Erin L.",3289,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,16,Democratic,"McGuire, Don",4048,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,16,Republican,"Grosserode, Amanda",4680,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,17,Democratic,"Meeker, Larry",3952,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,17,Libertarian,"Kerner, Michael",566,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,17,Republican,"Hildabrand, Brett M.",4466,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,18,Democratic,"Neighbor, Cindy",3959,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,18,Republican,"Rubin, John",4256,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,19,Democratic,"Stratton, Patricia",3565,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,19,Republican,"Clayton, Stephanie",6637,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,20,Democratic,"Arnold, Elizabeth",4458,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,20,Republican,"Bruchman, Rob",6075,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,21,Democratic,"Bell, Amy",3677,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,21,Republican,"Bollier, Barbara",6014,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,22,Democratic,"Lusk, Nancy",3109,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,22,Republican,"Jones, Mike",2834,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,23,Democratic,"Versola, Amber",2588,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,23,Republican,"Gallagher, Linda",3285,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,24,Democratic,"Ousley, Jarrod",3963,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,24,Republican,"Hermreck, Brandon",2559,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,25,Democratic,"Robinson, Jennifer",4252,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,25,Republican,"Rooker, Melissa",5542,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",1775,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",4220,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,27,Democratic,"Hohl, Theresa",2684,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,27,Republican,"Merrick, Ray",6121,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,28,Republican,"Lunn, Jerry",6343,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,29,Democratic,"Meyer, Heather",3803,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,29,Republican,"Todd, James Eric",4526,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,30,Democratic,"Dickinson, Liz",3059,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,30,Republican,"Powell, Randy",3978,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,38,Democratic,"Pringle, Jan",823,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",150,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,38,Republican,"Dove, Willie",1634,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,39,Democratic,"Hiatt, Vicki",2867,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,39,Republican,"Macheers, Charles",4572,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,43,Democratic,"Trujillo, Caitlin",1875,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,43,Republican,"Sutton, Bill",3738,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,48,Democratic,"Ackerson, Sandy",2792,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,48,Republican,"Kleeb, Marvin",4736,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,49,Democratic,"Hunt, Darnell",2137,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,49,Republican,"Schwab, Scott",3688,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,78,Democratic,"Poe, Jim",2375,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,78,Republican,"Ryckman, Ron",4936,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,121,Democratic,"Smith, Gary",2789,999998
+JOHNSON,ADVANCED,Kansas House of Representatives,121,Republican,"Kiegerl, S. Mike",4978,999998
+JOHNSON,Aubry Township 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",33,000010
+JOHNSON,Aubry Township 01,United States House of Representatives,3,Republican,"Yoder, Kevin",77,000010
+JOHNSON,Aubry Township 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",127,000020
+JOHNSON,Aubry Township 02,United States House of Representatives,3,Republican,"Yoder, Kevin",452,000020
+JOHNSON,Aubry Township 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",86,000030
+JOHNSON,Aubry Township 03,United States House of Representatives,3,Republican,"Yoder, Kevin",238,000030
+JOHNSON,Aubry Township 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",195,000040
+JOHNSON,Aubry Township 04,United States House of Representatives,3,Republican,"Yoder, Kevin",534,000040
+JOHNSON,DeSoto Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",179,000070
+JOHNSON,DeSoto Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",457,000070
+JOHNSON,DeSoto Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",145,000080
+JOHNSON,DeSoto Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",242,000080
+JOHNSON,Edgerton Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",123,000090
+JOHNSON,Edgerton Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",276,000090
+JOHNSON,Fairway Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",141,000100
+JOHNSON,Fairway Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",145,000100
+JOHNSON,Fairway Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",103,000105
+JOHNSON,Fairway Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",104,000105
+JOHNSON,Fairway Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",105,000110
+JOHNSON,Fairway Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",116,000110
+JOHNSON,Fairway Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",108,000115
+JOHNSON,Fairway Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",113,000115
+JOHNSON,Fairway Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",141,000120
+JOHNSON,Fairway Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",173,000120
+JOHNSON,Fairway Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",111,000125
+JOHNSON,Fairway Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",129,000125
+JOHNSON,Fairway Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",56,000130
+JOHNSON,Fairway Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",31,000130
+JOHNSON,Fairway Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",67,000132
+JOHNSON,Fairway Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",53,000132
+JOHNSON,Fairway Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",42,000135
+JOHNSON,Fairway Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",40,000135
+JOHNSON,Fairway Ward 04 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",71,000137
+JOHNSON,Fairway Ward 04 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",50,000137
+JOHNSON,Gardner City Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",227,00014A
+JOHNSON,Gardner City Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",554,00014A
+JOHNSON,Gardner City Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",163,000160
+JOHNSON,Gardner City Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",323,000160
+JOHNSON,Lake Quivira Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",173,000190
+JOHNSON,Lake Quivira Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",363,000190
+JOHNSON,Leawood Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",326,000210
+JOHNSON,Leawood Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",486,000210
+JOHNSON,Leawood Ward 01 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",266,000220
+JOHNSON,Leawood Ward 01 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",404,000220
+JOHNSON,Leawood Ward 01 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",223,000230
+JOHNSON,Leawood Ward 01 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",322,000230
+JOHNSON,Leawood Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",259,000240
+JOHNSON,Leawood Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",367,000240
+JOHNSON,Leawood Ward 02 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",171,000270
+JOHNSON,Leawood Ward 02 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",590,000270
+JOHNSON,Leawood Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",191,000350
+JOHNSON,Leawood Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",419,000350
+JOHNSON,Leawood Ward 04 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",235,000370
+JOHNSON,Leawood Ward 04 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",446,000370
+JOHNSON,Lenexa Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",302,000430
+JOHNSON,Lenexa Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",443,000430
+JOHNSON,Lenexa Ward 01 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",348,000440
+JOHNSON,Lenexa Ward 01 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",520,000440
+JOHNSON,Lenexa Ward 01 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",241,000460
+JOHNSON,Lenexa Ward 01 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",361,000460
+JOHNSON,Lenexa Ward 04 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",197,000510
+JOHNSON,Lenexa Ward 04 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",322,000510
+JOHNSON,Lenexa Ward 02 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",150,000520
+JOHNSON,Lenexa Ward 02 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",622,000520
+JOHNSON,Lenexa Ward 02 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",237,000530
+JOHNSON,Lenexa Ward 02 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",277,000530
+JOHNSON,Lenexa Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",127,000540
+JOHNSON,Lenexa Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",242,000540
+JOHNSON,Lenexa Ward 01 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",170,000550
+JOHNSON,Lenexa Ward 01 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",217,000550
+JOHNSON,Lenexa Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",220,000580
+JOHNSON,Lenexa Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",229,000580
+JOHNSON,Lenexa Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",379,000590
+JOHNSON,Lenexa Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",362,000590
+JOHNSON,Lenexa Ward 03 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",353,000600
+JOHNSON,Lenexa Ward 03 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",530,000600
+JOHNSON,Lenexa Ward 03 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",201,000610
+JOHNSON,Lenexa Ward 03 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",354,000610
+JOHNSON,Lenexa Ward 03 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",169,000620
+JOHNSON,Lenexa Ward 03 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",167,000620
+JOHNSON,Lenexa Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",231,000640
+JOHNSON,Lenexa Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",368,000640
+JOHNSON,Lenexa Ward 04 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",109,000660
+JOHNSON,Lenexa Ward 04 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",174,000660
+JOHNSON,Mission Hills Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",126,000840
+JOHNSON,Mission Hills Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",292,000840
+JOHNSON,Mission Hills Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",189,000850
+JOHNSON,Mission Hills Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",361,000850
+JOHNSON,Mission Hills Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",95,000860
+JOHNSON,Mission Hills Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",243,000860
+JOHNSON,Mission Hills Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",206,000870
+JOHNSON,Mission Hills Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",380,000870
+JOHNSON,Mission Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",241,000880
+JOHNSON,Mission Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",256,000880
+JOHNSON,Mission Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",154,000890
+JOHNSON,Mission Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",88,000890
+JOHNSON,Mission Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",169,000900
+JOHNSON,Mission Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",123,000900
+JOHNSON,Mission Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",238,000910
+JOHNSON,Mission Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",186,000910
+JOHNSON,Mission Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",221,000920
+JOHNSON,Mission Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",208,000920
+JOHNSON,Mission Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",136,000930
+JOHNSON,Mission Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",116,000930
+JOHNSON,Mission Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",188,000940
+JOHNSON,Mission Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",131,000940
+JOHNSON,Mission Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",249,000950
+JOHNSON,Mission Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",248,000950
+JOHNSON,Mission Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",122,000960
+JOHNSON,Mission Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",127,000960
+JOHNSON,Mission Woods Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",47,000970
+JOHNSON,Mission Woods Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",51,000970
+JOHNSON,Olathe City Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",145,001000
+JOHNSON,Olathe City Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",222,001000
+JOHNSON,Olathe City Ward 01 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",105,001010
+JOHNSON,Olathe City Ward 01 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",173,001010
+JOHNSON,Olathe City Ward 01 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",200,001030
+JOHNSON,Olathe City Ward 01 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",372,001030
+JOHNSON,Olathe City Ward 03 Precinct 23,United States House of Representatives,3,Democratic,"Kultala, Kelly",166,001050
+JOHNSON,Olathe City Ward 03 Precinct 23,United States House of Representatives,3,Republican,"Yoder, Kevin",311,001050
+JOHNSON,Olathe City Ward 01 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",219,001060
+JOHNSON,Olathe City Ward 01 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",397,001060
+JOHNSON,Olathe City Ward 01 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",164,001070
+JOHNSON,Olathe City Ward 01 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",406,001070
+JOHNSON,Olathe City Ward 03 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",154,001100
+JOHNSON,Olathe City Ward 03 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",285,001100
+JOHNSON,Olathe City Ward 01 Precinct 20,United States House of Representatives,3,Democratic,"Kultala, Kelly",164,001130
+JOHNSON,Olathe City Ward 01 Precinct 20,United States House of Representatives,3,Republican,"Yoder, Kevin",227,001130
+JOHNSON,Olathe City Ward 02 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",137,001150
+JOHNSON,Olathe City Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",266,001150
+JOHNSON,Olathe City Ward 02 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",174,001160
+JOHNSON,Olathe City Ward 02 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",269,001160
+JOHNSON,Olathe City Ward 02 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",332,00117A
+JOHNSON,Olathe City Ward 02 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",940,00117A
+JOHNSON,Olathe City Ward 02 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",192,001200
+JOHNSON,Olathe City Ward 02 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",368,001200
+JOHNSON,Olathe City Ward 01 Precinct 19,United States House of Representatives,3,Democratic,"Kultala, Kelly",89,001210
+JOHNSON,Olathe City Ward 01 Precinct 19,United States House of Representatives,3,Republican,"Yoder, Kevin",155,001210
+JOHNSON,Olathe City Ward 02 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",374,001220
+JOHNSON,Olathe City Ward 02 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",674,001220
+JOHNSON,Olathe City Ward 02 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",149,001240
+JOHNSON,Olathe City Ward 02 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",288,001240
+JOHNSON,Olathe City Ward 02 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",134,001260
+JOHNSON,Olathe City Ward 02 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",282,001260
+JOHNSON,Olathe City Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",73,001280
+JOHNSON,Olathe City Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",156,001280
+JOHNSON,Olathe City Ward 02 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",1,001290
+JOHNSON,Olathe City Ward 02 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",0,001290
+JOHNSON,Olathe City Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",91,001300
+JOHNSON,Olathe City Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",137,001300
+JOHNSON,Olathe City Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",238,001310
+JOHNSON,Olathe City Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",448,001310
+JOHNSON,Olathe City Ward 03 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",101,001320
+JOHNSON,Olathe City Ward 03 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",242,001320
+JOHNSON,Olathe City Ward 03 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",175,001330
+JOHNSON,Olathe City Ward 03 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",407,001330
+JOHNSON,Olathe City Ward 03 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",172,001340
+JOHNSON,Olathe City Ward 03 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",441,001340
+JOHNSON,Olathe City Ward 03 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",126,001350
+JOHNSON,Olathe City Ward 03 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",318,001350
+JOHNSON,Olathe City Ward 03 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",84,001360
+JOHNSON,Olathe City Ward 03 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",236,001360
+JOHNSON,Olathe City Ward 03 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",206,001370
+JOHNSON,Olathe City Ward 03 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",449,001370
+JOHNSON,Olathe City Ward 03 Precinct 22,United States House of Representatives,3,Democratic,"Kultala, Kelly",176,001380
+JOHNSON,Olathe City Ward 03 Precinct 22,United States House of Representatives,3,Republican,"Yoder, Kevin",363,001380
+JOHNSON,Olathe City Ward 03 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",188,001390
+JOHNSON,Olathe City Ward 03 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",454,001390
+JOHNSON,Olathe City Ward 03 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",189,001410
+JOHNSON,Olathe City Ward 03 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",381,001410
+JOHNSON,Olathe City Ward 04 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",272,00147A
+JOHNSON,Olathe City Ward 04 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",443,00147A
+JOHNSON,Olathe City Ward 04 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",207,00147B
+JOHNSON,Olathe City Ward 04 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",455,00147B
+JOHNSON,Olathe City Ward 04 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",241,001480
+JOHNSON,Olathe City Ward 04 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",370,001480
+JOHNSON,Olathe City Ward 04 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",167,001490
+JOHNSON,Olathe City Ward 04 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",353,001490
+JOHNSON,Olathe City Ward 04 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",265,001500
+JOHNSON,Olathe City Ward 04 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",465,001500
+JOHNSON,Olathe City Ward 04 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",142,001510
+JOHNSON,Olathe City Ward 04 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",253,001510
+JOHNSON,Olathe Township Part 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",16,00153J
+JOHNSON,Olathe Township Part 03,United States House of Representatives,3,Republican,"Yoder, Kevin",24,00153J
+JOHNSON,Olathe Township Part 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00153K
+JOHNSON,Olathe Township Part 04,United States House of Representatives,3,Republican,"Yoder, Kevin",2,00153K
+JOHNSON,Overland Park Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",241,001540
+JOHNSON,Overland Park Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",241,001540
+JOHNSON,Overland Park Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",267,001550
+JOHNSON,Overland Park Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",230,001550
+JOHNSON,Overland Park Ward 01 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",225,001560
+JOHNSON,Overland Park Ward 01 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",253,001560
+JOHNSON,Overland Park Ward 01 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",327,001590
+JOHNSON,Overland Park Ward 01 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",317,001590
+JOHNSON,Overland Park Ward 01 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",262,001600
+JOHNSON,Overland Park Ward 01 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",347,001600
+JOHNSON,Overland Park Ward 01 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",194,001610
+JOHNSON,Overland Park Ward 01 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",207,001610
+JOHNSON,Overland Park Ward 01 Precinct 19,United States House of Representatives,3,Democratic,"Kultala, Kelly",177,001630
+JOHNSON,Overland Park Ward 01 Precinct 19,United States House of Representatives,3,Republican,"Yoder, Kevin",200,001630
+JOHNSON,Overland Park Ward 01 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",70,001640
+JOHNSON,Overland Park Ward 01 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",71,001640
+JOHNSON,Overland Park Ward 01 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",213,001650
+JOHNSON,Overland Park Ward 01 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",231,001650
+JOHNSON,Overland Park Ward 01 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",154,001660
+JOHNSON,Overland Park Ward 01 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",192,001660
+JOHNSON,Overland Park Ward 01 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",264,001670
+JOHNSON,Overland Park Ward 01 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",238,001670
+JOHNSON,Overland Park Ward 01 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",123,001680
+JOHNSON,Overland Park Ward 01 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",116,001680
+JOHNSON,Overland Park Ward 02 Precinct 18,United States House of Representatives,3,Democratic,"Kultala, Kelly",270,001690
+JOHNSON,Overland Park Ward 02 Precinct 18,United States House of Representatives,3,Republican,"Yoder, Kevin",321,001690
+JOHNSON,Overland Park Ward 01 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",106,001700
+JOHNSON,Overland Park Ward 01 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",151,001700
+JOHNSON,Overland Park Ward 01 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",243,001710
+JOHNSON,Overland Park Ward 01 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",295,001710
+JOHNSON,Overland Park Ward 01 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",322,001720
+JOHNSON,Overland Park Ward 01 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",261,001720
+JOHNSON,Overland Park Ward 02 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",226,001730
+JOHNSON,Overland Park Ward 02 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",294,001730
+JOHNSON,Overland Park Ward 02 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",208,001740
+JOHNSON,Overland Park Ward 02 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",230,001740
+JOHNSON,Overland Park Ward 02 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",189,001750
+JOHNSON,Overland Park Ward 02 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",264,001750
+JOHNSON,Overland Park Ward 02 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",168,001760
+JOHNSON,Overland Park Ward 02 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",215,001760
+JOHNSON,Overland Park Ward 02 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",134,001770
+JOHNSON,Overland Park Ward 02 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",117,001770
+JOHNSON,Overland Park Ward 02 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",165,001780
+JOHNSON,Overland Park Ward 02 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",226,001780
+JOHNSON,Overland Park Ward 02 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",201,001800
+JOHNSON,Overland Park Ward 02 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",251,001800
+JOHNSON,Overland Park Ward 02 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",139,001810
+JOHNSON,Overland Park Ward 02 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",201,001810
+JOHNSON,Overland Park Ward 02 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",93,001820
+JOHNSON,Overland Park Ward 02 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",119,001820
+JOHNSON,Overland Park Ward 02 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",167,001830
+JOHNSON,Overland Park Ward 02 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",170,001830
+JOHNSON,Overland Park Ward 02 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",294,001840
+JOHNSON,Overland Park Ward 02 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",388,001840
+JOHNSON,Overland Park Ward 02 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",180,001850
+JOHNSON,Overland Park Ward 02 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",216,001850
+JOHNSON,Overland Park Ward 02 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",234,001860
+JOHNSON,Overland Park Ward 02 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",350,001860
+JOHNSON,Overland Park Ward 03 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",221,001870
+JOHNSON,Overland Park Ward 03 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",308,001870
+JOHNSON,Overland Park Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",158,001880
+JOHNSON,Overland Park Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",286,001880
+JOHNSON,Overland Park Ward 02 Precinct 20,United States House of Representatives,3,Democratic,"Kultala, Kelly",150,001890
+JOHNSON,Overland Park Ward 02 Precinct 20,United States House of Representatives,3,Republican,"Yoder, Kevin",235,001890
+JOHNSON,Overland Park Ward 03 Precinct 20,United States House of Representatives,3,Democratic,"Kultala, Kelly",258,001900
+JOHNSON,Overland Park Ward 03 Precinct 20,United States House of Representatives,3,Republican,"Yoder, Kevin",414,001900
+JOHNSON,Overland Park Ward 03 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",229,001910
+JOHNSON,Overland Park Ward 03 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",348,001910
+JOHNSON,Overland Park Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",214,001920
+JOHNSON,Overland Park Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",279,001920
+JOHNSON,Overland Park Ward 03 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",180,001930
+JOHNSON,Overland Park Ward 03 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",337,001930
+JOHNSON,Overland Park Ward 03 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",264,001940
+JOHNSON,Overland Park Ward 03 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",358,001940
+JOHNSON,Overland Park Ward 03 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",200,001950
+JOHNSON,Overland Park Ward 03 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",239,001950
+JOHNSON,Overland Park Ward 03 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",276,001960
+JOHNSON,Overland Park Ward 03 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",403,001960
+JOHNSON,Overland Park Ward 03 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",199,001970
+JOHNSON,Overland Park Ward 03 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",209,001970
+JOHNSON,Overland Park Ward 03 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",205,001980
+JOHNSON,Overland Park Ward 03 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",333,001980
+JOHNSON,Overland Park Ward 03 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",314,001990
+JOHNSON,Overland Park Ward 03 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",427,001990
+JOHNSON,Overland Park Ward 03 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",153,002000
+JOHNSON,Overland Park Ward 03 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",259,002000
+JOHNSON,Overland Park Ward 03 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",163,002010
+JOHNSON,Overland Park Ward 03 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",357,002010
+JOHNSON,Overland Park Ward 03 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",163,002020
+JOHNSON,Overland Park Ward 03 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",173,002020
+JOHNSON,Overland Park Ward 05 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",233,002030
+JOHNSON,Overland Park Ward 05 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",394,002030
+JOHNSON,Overland Park Ward 03 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",258,002040
+JOHNSON,Overland Park Ward 03 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",340,002040
+JOHNSON,Overland Park Ward 03 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",124,002050
+JOHNSON,Overland Park Ward 03 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",255,002050
+JOHNSON,Overland Park Ward 05 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",119,002060
+JOHNSON,Overland Park Ward 05 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",184,002060
+JOHNSON,Overland Park Ward 05 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",187,002070
+JOHNSON,Overland Park Ward 05 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",399,002070
+JOHNSON,Overland Park Ward 05 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",209,002080
+JOHNSON,Overland Park Ward 05 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",340,002080
+JOHNSON,Overland Park Ward 05 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",198,002090
+JOHNSON,Overland Park Ward 05 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",222,002090
+JOHNSON,Overland Park Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",261,002120
+JOHNSON,Overland Park Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",518,002120
+JOHNSON,Overland Park Ward 03 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",313,002130
+JOHNSON,Overland Park Ward 03 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",522,002130
+JOHNSON,Overland Park Ward 03 Precinct 18,United States House of Representatives,3,Democratic,"Kultala, Kelly",196,002140
+JOHNSON,Overland Park Ward 03 Precinct 18,United States House of Representatives,3,Republican,"Yoder, Kevin",249,002140
+JOHNSON,Overland Park Ward 03 Precinct 19,United States House of Representatives,3,Democratic,"Kultala, Kelly",195,002150
+JOHNSON,Overland Park Ward 03 Precinct 19,United States House of Representatives,3,Republican,"Yoder, Kevin",318,002150
+JOHNSON,Overland Park Ward 04 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",246,002160
+JOHNSON,Overland Park Ward 04 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",581,002160
+JOHNSON,Overland Park Ward 04 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",162,00217B
+JOHNSON,Overland Park Ward 04 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",242,00217B
+JOHNSON,Overland Park Ward 04 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",129,002180
+JOHNSON,Overland Park Ward 04 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",448,002180
+JOHNSON,Overland Park Ward 04 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",120,002190
+JOHNSON,Overland Park Ward 04 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",289,002190
+JOHNSON,Overland Park Ward 04 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",239,002200
+JOHNSON,Overland Park Ward 04 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",462,002200
+JOHNSON,Overland Park Ward 04 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",317,002210
+JOHNSON,Overland Park Ward 04 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",597,002210
+JOHNSON,Overland Park Ward 04 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",93,00222A
+JOHNSON,Overland Park Ward 04 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",343,00222A
+JOHNSON,Overland Park Ward 04 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",258,00222B
+JOHNSON,Overland Park Ward 04 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",505,00222B
+JOHNSON,Overland Park Ward 04 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",101,002230
+JOHNSON,Overland Park Ward 04 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",269,002230
+JOHNSON,Overland Park Ward 04 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",192,002240
+JOHNSON,Overland Park Ward 04 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",401,002240
+JOHNSON,Overland Park Ward 06 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",170,00226A
+JOHNSON,Overland Park Ward 06 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",450,00226A
+JOHNSON,Overland Park Ward 06 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",153,00226B
+JOHNSON,Overland Park Ward 06 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",440,00226B
+JOHNSON,Overland Park Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",255,002280
+JOHNSON,Overland Park Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",238,002280
+JOHNSON,Overland Park Ward 02 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",204,002290
+JOHNSON,Overland Park Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",230,002290
+JOHNSON,Overland Park Ward 02 Precinct 22,United States House of Representatives,3,Democratic,"Kultala, Kelly",207,002300
+JOHNSON,Overland Park Ward 02 Precinct 22,United States House of Representatives,3,Republican,"Yoder, Kevin",228,002300
+JOHNSON,Overland Park Ward 02 Precinct 19,United States House of Representatives,3,Democratic,"Kultala, Kelly",178,002320
+JOHNSON,Overland Park Ward 02 Precinct 19,United States House of Representatives,3,Republican,"Yoder, Kevin",218,002320
+JOHNSON,Overland Park Ward 02 Precinct 21,United States House of Representatives,3,Democratic,"Kultala, Kelly",191,002330
+JOHNSON,Overland Park Ward 02 Precinct 21,United States House of Representatives,3,Republican,"Yoder, Kevin",216,002330
+JOHNSON,Overland Park Ward 02 Precinct 24,United States House of Representatives,3,Democratic,"Kultala, Kelly",284,002340
+JOHNSON,Overland Park Ward 02 Precinct 24,United States House of Representatives,3,Republican,"Yoder, Kevin",449,002340
+JOHNSON,Overland Park Ward 02 Precinct 25,United States House of Representatives,3,Democratic,"Kultala, Kelly",248,002350
+JOHNSON,Overland Park Ward 02 Precinct 25,United States House of Representatives,3,Republican,"Yoder, Kevin",345,002350
+JOHNSON,Overland Park Ward 06 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,002360
+JOHNSON,Overland Park Ward 06 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",0,002360
+JOHNSON,Overland Park Ward 05 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",215,002370
+JOHNSON,Overland Park Ward 05 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",394,002370
+JOHNSON,Overland Park Ward 05 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",280,002380
+JOHNSON,Overland Park Ward 05 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",450,002380
+JOHNSON,Overland Park Ward 05 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",336,002400
+JOHNSON,Overland Park Ward 05 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",471,002400
+JOHNSON,Overland Park Ward 05 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",234,002410
+JOHNSON,Overland Park Ward 05 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",390,002410
+JOHNSON,Overland Park Ward 05 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",300,00242B
+JOHNSON,Overland Park Ward 05 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",517,00242B
+JOHNSON,Overland Park Ward 06 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",238,00244A
+JOHNSON,Overland Park Ward 06 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",454,00244A
+JOHNSON,Overland Park Ward 05 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",167,00244B
+JOHNSON,Overland Park Ward 05 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",303,00244B
+JOHNSON,Overland Park Ward 06 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",182,002460
+JOHNSON,Overland Park Ward 06 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",366,002460
+JOHNSON,Overland Park Ward 06 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",81,002470
+JOHNSON,Overland Park Ward 06 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",175,002470
+JOHNSON,Oxford Township Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00249C
+JOHNSON,Oxford Township Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",10,00249C
+JOHNSON,Oxford Township Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",113,00249E
+JOHNSON,Oxford Township Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",235,00249E
+JOHNSON,Oxford Township Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",120,00249F
+JOHNSON,Oxford Township Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",329,00249F
+JOHNSON,Prairie Village Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",363,002500
+JOHNSON,Prairie Village Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",342,002500
+JOHNSON,Prairie Village Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",266,002510
+JOHNSON,Prairie Village Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",225,002510
+JOHNSON,Prairie Village Ward 01 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",365,002520
+JOHNSON,Prairie Village Ward 01 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",332,002520
+JOHNSON,Prairie Village Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",300,002530
+JOHNSON,Prairie Village Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",263,002530
+JOHNSON,Prairie Village Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",120,002540
+JOHNSON,Prairie Village Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",148,002540
+JOHNSON,Prairie Village Ward 02 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",261,002550
+JOHNSON,Prairie Village Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",230,002550
+JOHNSON,Prairie Village Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",189,002560
+JOHNSON,Prairie Village Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",212,002560
+JOHNSON,Prairie Village Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",289,002570
+JOHNSON,Prairie Village Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",298,002570
+JOHNSON,Prairie Village Ward 03 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",280,002580
+JOHNSON,Prairie Village Ward 03 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",259,002580
+JOHNSON,Prairie Village Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",280,002590
+JOHNSON,Prairie Village Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",399,002590
+JOHNSON,Prairie Village Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",206,002600
+JOHNSON,Prairie Village Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",206,002600
+JOHNSON,Prairie Village Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",321,002610
+JOHNSON,Prairie Village Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",353,002610
+JOHNSON,Prairie Village Ward 05 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",305,002620
+JOHNSON,Prairie Village Ward 05 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",342,002620
+JOHNSON,Prairie Village Ward 05 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",278,002630
+JOHNSON,Prairie Village Ward 05 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",405,002630
+JOHNSON,Prairie Village Ward 05 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",221,002640
+JOHNSON,Prairie Village Ward 05 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",310,002640
+JOHNSON,Prairie Village Ward 06 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",318,002650
+JOHNSON,Prairie Village Ward 06 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",350,002650
+JOHNSON,Prairie Village Ward 06 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",309,002660
+JOHNSON,Prairie Village Ward 06 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",231,002660
+JOHNSON,Prairie Village Ward 06 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",174,002670
+JOHNSON,Prairie Village Ward 06 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",163,002670
+JOHNSON,Roeland Park Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",138,002680
+JOHNSON,Roeland Park Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",96,002680
+JOHNSON,Roeland Park Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",122,002690
+JOHNSON,Roeland Park Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",65,002690
+JOHNSON,Roeland Park Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",156,002700
+JOHNSON,Roeland Park Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",113,002700
+JOHNSON,Roeland Park Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",193,002710
+JOHNSON,Roeland Park Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",170,002710
+JOHNSON,Roeland Park Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",150,002720
+JOHNSON,Roeland Park Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",75,002720
+JOHNSON,Roeland Park Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",259,002730
+JOHNSON,Roeland Park Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",189,002730
+JOHNSON,Roeland Park Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",106,002740
+JOHNSON,Roeland Park Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",99,002740
+JOHNSON,Roeland Park Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",331,002750
+JOHNSON,Roeland Park Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",298,002750
+JOHNSON,Shawnee City Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",275,002760
+JOHNSON,Shawnee City Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",361,002760
+JOHNSON,Shawnee City Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",194,002770
+JOHNSON,Shawnee City Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",290,002770
+JOHNSON,Shawnee City Ward 01 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",185,002780
+JOHNSON,Shawnee City Ward 01 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",263,002780
+JOHNSON,Shawnee City Ward 01 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",256,002790
+JOHNSON,Shawnee City Ward 01 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",504,002790
+JOHNSON,Shawnee City Ward 01 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",320,002800
+JOHNSON,Shawnee City Ward 01 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",499,002800
+JOHNSON,Shawnee City Ward 01 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",221,002810
+JOHNSON,Shawnee City Ward 01 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",436,002810
+JOHNSON,Shawnee City Ward 01 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",256,002820
+JOHNSON,Shawnee City Ward 01 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",395,002820
+JOHNSON,Shawnee City Ward 01 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",222,002830
+JOHNSON,Shawnee City Ward 01 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",448,002830
+JOHNSON,Shawnee City Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",105,002850
+JOHNSON,Shawnee City Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",171,002850
+JOHNSON,Shawnee City Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",216,002860
+JOHNSON,Shawnee City Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",315,002860
+JOHNSON,Shawnee City Ward 02 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",182,002870
+JOHNSON,Shawnee City Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",217,002870
+JOHNSON,Shawnee City Ward 02 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",279,002880
+JOHNSON,Shawnee City Ward 02 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",353,002880
+JOHNSON,Shawnee City Ward 02 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",115,002890
+JOHNSON,Shawnee City Ward 02 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",186,002890
+JOHNSON,Shawnee City Ward 02 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",158,002900
+JOHNSON,Shawnee City Ward 02 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",281,002900
+JOHNSON,Shawnee City Ward 02 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",151,002910
+JOHNSON,Shawnee City Ward 02 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",200,002910
+JOHNSON,Shawnee City Ward 02 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",131,002920
+JOHNSON,Shawnee City Ward 02 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",204,002920
+JOHNSON,Shawnee City Ward 04 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",255,002930
+JOHNSON,Shawnee City Ward 04 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",360,002930
+JOHNSON,Shawnee City Ward 04 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",192,002940
+JOHNSON,Shawnee City Ward 04 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",347,002940
+JOHNSON,Shawnee City Ward 03 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",163,002960
+JOHNSON,Shawnee City Ward 03 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",380,002960
+JOHNSON,Shawnee City Ward 03 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",213,002980
+JOHNSON,Shawnee City Ward 03 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",328,002980
+JOHNSON,Shawnee City Ward 03 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",217,002990
+JOHNSON,Shawnee City Ward 03 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",487,002990
+JOHNSON,Shawnee City Ward 03 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",225,003000
+JOHNSON,Shawnee City Ward 03 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",428,003000
+JOHNSON,Shawnee City Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",234,003010
+JOHNSON,Shawnee City Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",538,003010
+JOHNSON,Shawnee City Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",129,003020
+JOHNSON,Shawnee City Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",277,003020
+JOHNSON,Shawnee City Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",156,003040
+JOHNSON,Shawnee City Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",275,003040
+JOHNSON,Shawnee City Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",60,003050
+JOHNSON,Shawnee City Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",125,003050
+JOHNSON,Shawnee City Ward 04 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",106,003060
+JOHNSON,Shawnee City Ward 04 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",102,003060
+JOHNSON,Shawnee City Ward 02 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",143,003070
+JOHNSON,Shawnee City Ward 02 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",184,003070
+JOHNSON,Shawnee City Ward 04 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",252,003090
+JOHNSON,Shawnee City Ward 04 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",487,003090
+JOHNSON,Spring Hill City Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",252,00311A
+JOHNSON,Spring Hill City Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",629,00311A
+JOHNSON,Spring Hill City Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00311B
+JOHNSON,Spring Hill City Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00311B
+JOHNSON,Spring Hill City Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",22,00311D
+JOHNSON,Spring Hill City Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",38,00311D
+JOHNSON,Spring Hill Township Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",195,003120
+JOHNSON,Spring Hill Township Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",479,003120
+JOHNSON,Westwood Hills Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",118,003130
+JOHNSON,Westwood Hills Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",86,003130
+JOHNSON,Westwood Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",205,003140
+JOHNSON,Westwood Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",139,003140
+JOHNSON,Westwood Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",189,003150
+JOHNSON,Westwood Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",163,003150
+JOHNSON,Lexington Township Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",2,004070
+JOHNSON,Lexington Township Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",1,004070
+JOHNSON,Lexington Township Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",1,004080
+JOHNSON,Lexington Township Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",1,004080
+JOHNSON,Olathe City Ward 02 Precinct 19,United States House of Representatives,3,Democratic,"Kultala, Kelly",2,004140
+JOHNSON,Olathe City Ward 02 Precinct 19,United States House of Representatives,3,Republican,"Yoder, Kevin",4,004140
+JOHNSON,Olathe Township Part 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",2,004180
+JOHNSON,Olathe Township Part 08,United States House of Representatives,3,Republican,"Yoder, Kevin",4,004180
+JOHNSON,Olathe Township Part 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",4,004190
+JOHNSON,Olathe Township Part 10,United States House of Representatives,3,Republican,"Yoder, Kevin",7,004190
+JOHNSON,Oxford Township Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,004300
+JOHNSON,Oxford Township Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",0,004300
+JOHNSON,McCamish Township Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",63,100030
+JOHNSON,McCamish Township Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",224,100030
+JOHNSON,Leawood Ward 01 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",61,120130
+JOHNSON,Leawood Ward 01 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",63,120130
+JOHNSON,Leawood Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",251,120140
+JOHNSON,Leawood Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",248,120140
+JOHNSON,Merriam Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",1,120260
+JOHNSON,Merriam Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",0,120260
+JOHNSON,Merriam Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",177,120280
+JOHNSON,Merriam Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",143,120280
+JOHNSON,Overland Park Ward 02 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",82,120660
+JOHNSON,Overland Park Ward 02 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",232,120660
+JOHNSON,Overland Park Ward 02 Precinct 26,United States House of Representatives,3,Democratic,"Kultala, Kelly",100,120670
+JOHNSON,Overland Park Ward 02 Precinct 26,United States House of Representatives,3,Republican,"Yoder, Kevin",117,120670
+JOHNSON,Overland Park Ward 04 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",201,120680
+JOHNSON,Overland Park Ward 04 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",397,120680
+JOHNSON,Overland Park Ward 04 Precinct 18,United States House of Representatives,3,Democratic,"Kultala, Kelly",40,120690
+JOHNSON,Overland Park Ward 04 Precinct 18,United States House of Representatives,3,Republican,"Yoder, Kevin",62,120690
+JOHNSON,Overland Park Ward 05 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",59,120700
+JOHNSON,Overland Park Ward 05 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",96,120700
+JOHNSON,Overland Park Ward 05 Precinct 19,United States House of Representatives,3,Democratic,"Kultala, Kelly",12,120710
+JOHNSON,Overland Park Ward 05 Precinct 19,United States House of Representatives,3,Republican,"Yoder, Kevin",38,120710
+JOHNSON,Overland Park Ward 05 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",181,120730
+JOHNSON,Overland Park Ward 05 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",252,120730
+JOHNSON,Lenexa Ward 01 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",74,140010
+JOHNSON,Lenexa Ward 01 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",92,140010
+JOHNSON,Lenexa Ward 01 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",5,140020
+JOHNSON,Lenexa Ward 01 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",7,140020
+JOHNSON,Lenexa Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",135,140030
+JOHNSON,Lenexa Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",164,140030
+JOHNSON,Lenexa Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",119,140040
+JOHNSON,Lenexa Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",122,140040
+JOHNSON,Lenexa Ward 04 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",105,140050
+JOHNSON,Lenexa Ward 04 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",164,140050
+JOHNSON,Lenexa Ward 04 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",37,140060
+JOHNSON,Lenexa Ward 04 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",41,140060
+JOHNSON,McCamish Township Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",29,140070
+JOHNSON,McCamish Township Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",118,140070
+JOHNSON,Merriam Ward 02 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",130,140080
+JOHNSON,Merriam Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",140,140080
+JOHNSON,Merriam Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",122,140090
+JOHNSON,Merriam Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",120,140090
+JOHNSON,Olathe City Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",179,140100
+JOHNSON,Olathe City Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",369,140100
+JOHNSON,Olathe City Ward 01 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",174,140110
+JOHNSON,Olathe City Ward 01 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",357,140110
+JOHNSON,Olathe City Ward 01 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",102,140120
+JOHNSON,Olathe City Ward 01 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",258,140120
+JOHNSON,Olathe City Ward 01 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",39,140130
+JOHNSON,Olathe City Ward 01 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",66,140130
+JOHNSON,Olathe City Ward 01 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",168,140140
+JOHNSON,Olathe City Ward 01 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",319,140140
+JOHNSON,Olathe City Ward 01 Precinct 25,United States House of Representatives,3,Democratic,"Kultala, Kelly",56,140150
+JOHNSON,Olathe City Ward 01 Precinct 25,United States House of Representatives,3,Republican,"Yoder, Kevin",98,140150
+JOHNSON,Olathe City Ward 01 Precinct 26,United States House of Representatives,3,Democratic,"Kultala, Kelly",2,140160
+JOHNSON,Olathe City Ward 01 Precinct 26,United States House of Representatives,3,Republican,"Yoder, Kevin",0,140160
+JOHNSON,Olathe City Ward 01 Precinct 27,United States House of Representatives,3,Democratic,"Kultala, Kelly",159,140170
+JOHNSON,Olathe City Ward 01 Precinct 27,United States House of Representatives,3,Republican,"Yoder, Kevin",240,140170
+JOHNSON,Olathe City Ward 02 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",174,140180
+JOHNSON,Olathe City Ward 02 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",261,140180
+JOHNSON,Olathe City Ward 02 Precinct 23,United States House of Representatives,3,Democratic,"Kultala, Kelly",190,140190
+JOHNSON,Olathe City Ward 02 Precinct 23,United States House of Representatives,3,Republican,"Yoder, Kevin",372,140190
+JOHNSON,Olathe City Ward 03 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",129,140200
+JOHNSON,Olathe City Ward 03 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",292,140200
+JOHNSON,Olathe City Ward 03 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",146,140210
+JOHNSON,Olathe City Ward 03 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",314,140210
+JOHNSON,Olathe City Ward 03 Precinct 26,United States House of Representatives,3,Democratic,"Kultala, Kelly",21,140220
+JOHNSON,Olathe City Ward 03 Precinct 26,United States House of Representatives,3,Republican,"Yoder, Kevin",32,140220
+JOHNSON,Olathe City Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",115,140230
+JOHNSON,Olathe City Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",144,140230
+JOHNSON,Olathe City Ward 04 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",126,140240
+JOHNSON,Olathe City Ward 04 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",167,140240
+JOHNSON,Olathe City Ward 04 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",108,140250
+JOHNSON,Olathe City Ward 04 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",140,140250
+JOHNSON,Olathe City Ward 04 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",15,140260
+JOHNSON,Olathe City Ward 04 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",20,140260
+JOHNSON,Olathe City Ward 04 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",92,140270
+JOHNSON,Olathe City Ward 04 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",108,140270
+JOHNSON,Olathe City Ward 04 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,140280
+JOHNSON,Olathe City Ward 04 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",3,140280
+JOHNSON,Olathe Township Part 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",10,140290
+JOHNSON,Olathe Township Part 02,United States House of Representatives,3,Republican,"Yoder, Kevin",44,140290
+JOHNSON,Olathe Township Part 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,140300
+JOHNSON,Olathe Township Part 14,United States House of Representatives,3,Republican,"Yoder, Kevin",1,140300
+JOHNSON,Olathe Township Part 25,United States House of Representatives,3,Democratic,"Kultala, Kelly",1,140310
+JOHNSON,Olathe Township Part 25,United States House of Representatives,3,Republican,"Yoder, Kevin",7,140310
+JOHNSON,Overland Park Ward 01 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",71,140320
+JOHNSON,Overland Park Ward 01 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",99,140320
+JOHNSON,Overland Park Ward 01 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",170,140330
+JOHNSON,Overland Park Ward 01 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",162,140330
+JOHNSON,Overland Park Ward 01 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",125,140340
+JOHNSON,Overland Park Ward 01 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",150,140340
+JOHNSON,Overland Park Ward 01 Precinct 20,United States House of Representatives,3,Democratic,"Kultala, Kelly",158,140350
+JOHNSON,Overland Park Ward 01 Precinct 20,United States House of Representatives,3,Republican,"Yoder, Kevin",145,140350
+JOHNSON,Overland Park Ward 01 Precinct 21,United States House of Representatives,3,Democratic,"Kultala, Kelly",57,140360
+JOHNSON,Overland Park Ward 01 Precinct 21,United States House of Representatives,3,Republican,"Yoder, Kevin",96,140360
+JOHNSON,Overland Park Ward 01 Precinct 22,United States House of Representatives,3,Democratic,"Kultala, Kelly",58,140370
+JOHNSON,Overland Park Ward 01 Precinct 22,United States House of Representatives,3,Republican,"Yoder, Kevin",56,140370
+JOHNSON,Overland Park Ward 03 Precinct 21,United States House of Representatives,3,Democratic,"Kultala, Kelly",193,140380
+JOHNSON,Overland Park Ward 03 Precinct 21,United States House of Representatives,3,Republican,"Yoder, Kevin",332,140380
+JOHNSON,Overland Park Ward 06 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",200,140390
+JOHNSON,Overland Park Ward 06 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",739,140390
+JOHNSON,Overland Park Ward 06 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",102,140400
+JOHNSON,Overland Park Ward 06 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",308,140400
+JOHNSON,Oxford Township Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",2,140410
+JOHNSON,Oxford Township Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",1,140410
+JOHNSON,Oxford Township Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",17,140420
+JOHNSON,Oxford Township Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",74,140420
+JOHNSON,Shawnee City Ward 01 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",71,140430
+JOHNSON,Shawnee City Ward 01 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",170,140430
+JOHNSON,Shawnee City Ward 01 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",3,140440
+JOHNSON,Shawnee City Ward 01 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",4,140440
+JOHNSON,Shawnee City Ward 02 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",122,140450
+JOHNSON,Shawnee City Ward 02 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",168,140450
+JOHNSON,Shawnee City Ward 02 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",195,140460
+JOHNSON,Shawnee City Ward 02 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",273,140460
+JOHNSON,Shawnee City Ward 02 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",71,140470
+JOHNSON,Shawnee City Ward 02 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",53,140470
+JOHNSON,Shawnee City Ward 02 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",104,140480
+JOHNSON,Shawnee City Ward 02 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",135,140480
+JOHNSON,Shawnee City Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",302,140490
+JOHNSON,Shawnee City Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",474,140490
+JOHNSON,Shawnee City Ward 04 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",346,140500
+JOHNSON,Shawnee City Ward 04 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",531,140500
+JOHNSON,Shawnee City Ward 04 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",184,140510
+JOHNSON,Shawnee City Ward 04 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",259,140510
+JOHNSON,Shawnee City Ward 04 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",36,140520
+JOHNSON,Shawnee City Ward 04 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",52,140520
+JOHNSON,Gardner Township Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",1,140530
+JOHNSON,Gardner Township Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",1,140530
+JOHNSON,Aubry Township 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",4,900010
+JOHNSON,Aubry Township 05,United States House of Representatives,3,Republican,"Yoder, Kevin",10,900010
+JOHNSON,Aubry Township 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",18,900020
+JOHNSON,Aubry Township 06,United States House of Representatives,3,Republican,"Yoder, Kevin",70,900020
+JOHNSON,DeSoto Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",189,900040
+JOHNSON,DeSoto Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",448,900040
+JOHNSON,DeSoto Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",16,900060
+JOHNSON,DeSoto Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",31,900060
+JOHNSON,Gardner City Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",158,900090
+JOHNSON,Gardner City Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",417,900090
+JOHNSON,Gardner City Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",8,900100
+JOHNSON,Gardner City Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",6,900100
+JOHNSON,Gardner City Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",206,900120
+JOHNSON,Gardner City Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",455,900120
+JOHNSON,Gardner City Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",125,900130
+JOHNSON,Gardner City Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",300,900130
+JOHNSON,Gardner Township 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,900160
+JOHNSON,Gardner Township 04,United States House of Representatives,3,Republican,"Yoder, Kevin",2,900160
+JOHNSON,Gardner Township 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",2,900170
+JOHNSON,Gardner Township 07,United States House of Representatives,3,Republican,"Yoder, Kevin",2,900170
+JOHNSON,Gardner Township 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",3,900180
+JOHNSON,Gardner Township 08,United States House of Representatives,3,Republican,"Yoder, Kevin",2,900180
+JOHNSON,Leawood Ward 01 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",178,900190
+JOHNSON,Leawood Ward 01 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",295,900190
+JOHNSON,Leawood Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",293,900200
+JOHNSON,Leawood Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",445,900200
+JOHNSON,Leawood Ward 02 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",284,900210
+JOHNSON,Leawood Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",446,900210
+JOHNSON,Leawood Ward 02 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",151,900220
+JOHNSON,Leawood Ward 02 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",269,900220
+JOHNSON,Leawood Ward 02 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",103,900230
+JOHNSON,Leawood Ward 02 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",212,900230
+JOHNSON,Leawood Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",171,900240
+JOHNSON,Leawood Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",246,900240
+JOHNSON,Leawood Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",263,900250
+JOHNSON,Leawood Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",433,900250
+JOHNSON,Leawood Ward 03 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",138,900260
+JOHNSON,Leawood Ward 03 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",297,900260
+JOHNSON,Leawood Ward 03 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",241,900280
+JOHNSON,Leawood Ward 03 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",562,900280
+JOHNSON,Leawood Ward 03 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",208,900290
+JOHNSON,Leawood Ward 03 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",600,900290
+JOHNSON,Leawood Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",61,900300
+JOHNSON,Leawood Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",146,900300
+JOHNSON,Leawood Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",213,900310
+JOHNSON,Leawood Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",361,900310
+JOHNSON,Leawood Ward 04 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",220,900320
+JOHNSON,Leawood Ward 04 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",466,900320
+JOHNSON,Leawood Ward 04 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",103,900330
+JOHNSON,Leawood Ward 04 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",409,900330
+JOHNSON,Leawood Ward 04 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",227,900340
+JOHNSON,Leawood Ward 04 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",625,900340
+JOHNSON,Leawood Ward 04 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",106,900350
+JOHNSON,Leawood Ward 04 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",295,900350
+JOHNSON,Lenexa Ward 03 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",254,900360
+JOHNSON,Lenexa Ward 03 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",444,900360
+JOHNSON,Lenexa Ward 01 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",234,900370
+JOHNSON,Lenexa Ward 01 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",494,900370
+JOHNSON,Lenexa Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",296,900380
+JOHNSON,Lenexa Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",643,900380
+JOHNSON,Lenexa Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",86,900390
+JOHNSON,Lenexa Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",255,900390
+JOHNSON,Lenexa Ward 02 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",217,900400
+JOHNSON,Lenexa Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",557,900400
+JOHNSON,Lenexa Ward 02 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",152,900410
+JOHNSON,Lenexa Ward 02 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",388,900410
+JOHNSON,Lenexa Ward 02 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",303,900420
+JOHNSON,Lenexa Ward 02 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",592,900420
+JOHNSON,Lenexa Ward 03 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",221,900430
+JOHNSON,Lenexa Ward 03 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",283,900430
+JOHNSON,Lenexa Ward 03 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",263,900440
+JOHNSON,Lenexa Ward 03 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",414,900440
+JOHNSON,Lenexa Ward 04 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",113,900450
+JOHNSON,Lenexa Ward 04 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",136,900450
+JOHNSON,Lenexa Ward 04 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",158,900460
+JOHNSON,Lenexa Ward 04 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",236,900460
+JOHNSON,Lenexa Ward 04 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",210,900470
+JOHNSON,Lenexa Ward 04 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",294,900470
+JOHNSON,Lenexa Ward 04 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",271,900480
+JOHNSON,Lenexa Ward 04 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",326,900480
+JOHNSON,Merriam Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",157,900490
+JOHNSON,Merriam Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",167,900490
+JOHNSON,Merriam Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",199,900500
+JOHNSON,Merriam Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",201,900500
+JOHNSON,Merriam Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",239,900510
+JOHNSON,Merriam Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",288,900510
+JOHNSON,Merriam Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",223,900530
+JOHNSON,Merriam Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",198,900530
+JOHNSON,Merriam Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",200,900540
+JOHNSON,Merriam Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",207,900540
+JOHNSON,Merriam Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",255,900550
+JOHNSON,Merriam Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",290,900550
+JOHNSON,Olathe City Ward 01 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",182,900610
+JOHNSON,Olathe City Ward 01 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",445,900610
+JOHNSON,Olathe City Ward 01 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",41,900620
+JOHNSON,Olathe City Ward 01 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",116,900620
+JOHNSON,Olathe City Ward 01 Precinct 21,United States House of Representatives,3,Democratic,"Kultala, Kelly",214,900640
+JOHNSON,Olathe City Ward 01 Precinct 21,United States House of Representatives,3,Republican,"Yoder, Kevin",424,900640
+JOHNSON,Olathe City Ward 01 Precinct 23,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,900650
+JOHNSON,Olathe City Ward 01 Precinct 23,United States House of Representatives,3,Republican,"Yoder, Kevin",1,900650
+JOHNSON,Olathe City Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",134,900660
+JOHNSON,Olathe City Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",231,900660
+JOHNSON,Olathe City Ward 02 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",155,900670
+JOHNSON,Olathe City Ward 02 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",490,900670
+JOHNSON,Olathe City Ward 02 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",253,900680
+JOHNSON,Olathe City Ward 02 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",534,900680
+JOHNSON,Olathe City Ward 02 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",259,900700
+JOHNSON,Olathe City Ward 02 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",482,900700
+JOHNSON,Olathe City Ward 02 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",121,900710
+JOHNSON,Olathe City Ward 02 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",304,900710
+JOHNSON,Olathe City Ward 02 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",72,900720
+JOHNSON,Olathe City Ward 02 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",77,900720
+JOHNSON,Olathe City Ward 02 Precinct 22,United States House of Representatives,3,Democratic,"Kultala, Kelly",311,900750
+JOHNSON,Olathe City Ward 02 Precinct 22,United States House of Representatives,3,Republican,"Yoder, Kevin",557,900750
+JOHNSON,Olathe City Ward 03 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",200,900800
+JOHNSON,Olathe City Ward 03 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",435,900800
+JOHNSON,Olathe City Ward 03 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",188,900820
+JOHNSON,Olathe City Ward 03 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",441,900820
+JOHNSON,Olathe City Ward 03 Precinct 18,United States House of Representatives,3,Democratic,"Kultala, Kelly",173,900830
+JOHNSON,Olathe City Ward 03 Precinct 18,United States House of Representatives,3,Republican,"Yoder, Kevin",404,900830
+JOHNSON,Olathe City Ward 03 Precinct 19,United States House of Representatives,3,Democratic,"Kultala, Kelly",81,900840
+JOHNSON,Olathe City Ward 03 Precinct 19,United States House of Representatives,3,Republican,"Yoder, Kevin",292,900840
+JOHNSON,Olathe City Ward 03 Precinct 20,United States House of Representatives,3,Democratic,"Kultala, Kelly",113,900850
+JOHNSON,Olathe City Ward 03 Precinct 20,United States House of Representatives,3,Republican,"Yoder, Kevin",294,900850
+JOHNSON,Olathe City Ward 03 Precinct 21,United States House of Representatives,3,Democratic,"Kultala, Kelly",84,900860
+JOHNSON,Olathe City Ward 03 Precinct 21,United States House of Representatives,3,Republican,"Yoder, Kevin",322,900860
+JOHNSON,Olathe City Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",314,900870
+JOHNSON,Olathe City Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",505,900870
+JOHNSON,Olathe City Ward 04 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",121,900880
+JOHNSON,Olathe City Ward 04 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",195,900880
+JOHNSON,Olathe City Ward 04 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",253,900890
+JOHNSON,Olathe City Ward 04 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",444,900890
+JOHNSON,Olathe Township Part 24,United States House of Representatives,3,Democratic,"Kultala, Kelly",1,900910
+JOHNSON,Olathe Township Part 24,United States House of Representatives,3,Republican,"Yoder, Kevin",2,900910
+JOHNSON,Olathe Township Part 26,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,900930
+JOHNSON,Olathe Township Part 26,United States House of Representatives,3,Republican,"Yoder, Kevin",3,900930
+JOHNSON,Olathe Township Part 32,United States House of Representatives,3,Democratic,"Kultala, Kelly",4,900980
+JOHNSON,Olathe Township Part 32,United States House of Representatives,3,Republican,"Yoder, Kevin",19,900980
+JOHNSON,Overland Park Ward 01 Precinct 18,United States House of Representatives,3,Democratic,"Kultala, Kelly",244,900990
+JOHNSON,Overland Park Ward 01 Precinct 18,United States House of Representatives,3,Republican,"Yoder, Kevin",258,900990
+JOHNSON,Overland Park Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",109,901000
+JOHNSON,Overland Park Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",278,901000
+JOHNSON,Overland Park Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",146,901010
+JOHNSON,Overland Park Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",461,901010
+JOHNSON,Overland Park Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",170,901020
+JOHNSON,Overland Park Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",560,901020
+JOHNSON,Overland Park Ward 04 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",147,901030
+JOHNSON,Overland Park Ward 04 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",403,901030
+JOHNSON,Overland Park Ward 04 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",226,901040
+JOHNSON,Overland Park Ward 04 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",478,901040
+JOHNSON,Overland Park Ward 04 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",175,901050
+JOHNSON,Overland Park Ward 04 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",328,901050
+JOHNSON,Overland Park Ward 05 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",250,901060
+JOHNSON,Overland Park Ward 05 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",585,901060
+JOHNSON,Overland Park Ward 05 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",131,901070
+JOHNSON,Overland Park Ward 05 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",244,901070
+JOHNSON,Overland Park Ward 05 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",88,901080
+JOHNSON,Overland Park Ward 05 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",141,901080
+JOHNSON,Overland Park Ward 05 Precinct 18,United States House of Representatives,3,Democratic,"Kultala, Kelly",178,901090
+JOHNSON,Overland Park Ward 05 Precinct 18,United States House of Representatives,3,Republican,"Yoder, Kevin",307,901090
+JOHNSON,Overland Park Ward 06 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",199,901100
+JOHNSON,Overland Park Ward 06 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",500,901100
+JOHNSON,Overland Park Ward 06 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",151,901110
+JOHNSON,Overland Park Ward 06 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",401,901110
+JOHNSON,Overland Park Ward 06 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",36,901120
+JOHNSON,Overland Park Ward 06 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",151,901120
+JOHNSON,Overland Park Ward 06 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",246,901140
+JOHNSON,Overland Park Ward 06 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",578,901140
+JOHNSON,Overland Park Ward 06 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",159,901150
+JOHNSON,Overland Park Ward 06 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",377,901150
+JOHNSON,Overland Park Ward 06 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",215,901160
+JOHNSON,Overland Park Ward 06 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",514,901160
+JOHNSON,Overland Park Ward 06 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",182,901170
+JOHNSON,Overland Park Ward 06 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",532,901170
+JOHNSON,Overland Park Ward 06 Precinct 17,United States House of Representatives,3,Democratic,"Kultala, Kelly",35,901190
+JOHNSON,Overland Park Ward 06 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",101,901190
+JOHNSON,Overland Park Ward 05 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",161,901200
+JOHNSON,Overland Park Ward 05 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",573,901200
+JOHNSON,Overland Park Ward 06 Precinct 19,United States House of Representatives,3,Democratic,"Kultala, Kelly",252,901210
+JOHNSON,Overland Park Ward 06 Precinct 19,United States House of Representatives,3,Republican,"Yoder, Kevin",465,901210
+JOHNSON,Overland Park Ward 06 Precinct 20,United States House of Representatives,3,Democratic,"Kultala, Kelly",59,901220
+JOHNSON,Overland Park Ward 06 Precinct 20,United States House of Representatives,3,Republican,"Yoder, Kevin",272,901220
+JOHNSON,Overland Park Ward 06 Precinct 21,United States House of Representatives,3,Democratic,"Kultala, Kelly",183,901230
+JOHNSON,Overland Park Ward 06 Precinct 21,United States House of Representatives,3,Republican,"Yoder, Kevin",721,901230
+JOHNSON,Overland Park Ward 06 Precinct 22,United States House of Representatives,3,Democratic,"Kultala, Kelly",92,901240
+JOHNSON,Overland Park Ward 06 Precinct 22,United States House of Representatives,3,Republican,"Yoder, Kevin",244,901240
+JOHNSON,Overland Park Ward 02 Precinct 23,United States House of Representatives,3,Democratic,"Kultala, Kelly",156,901250
+JOHNSON,Overland Park Ward 02 Precinct 23,United States House of Representatives,3,Republican,"Yoder, Kevin",329,901250
+JOHNSON,Overland Park Ward 06 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,901260
+JOHNSON,Overland Park Ward 06 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",1,901260
+JOHNSON,Overland Park Ward 06 Precinct 18,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,901270
+JOHNSON,Overland Park Ward 06 Precinct 18,United States House of Representatives,3,Republican,"Yoder, Kevin",3,901270
+JOHNSON,Oxford Township Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",4,901300
+JOHNSON,Oxford Township Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",16,901300
+JOHNSON,Oxford Township Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,901310
+JOHNSON,Oxford Township Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",2,901310
+JOHNSON,Shawnee City Ward 01 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",40,901330
+JOHNSON,Shawnee City Ward 01 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",72,901330
+JOHNSON,Shawnee City Ward 01 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",149,901350
+JOHNSON,Shawnee City Ward 01 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",270,901350
+JOHNSON,Shawnee City Ward 03 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",221,901360
+JOHNSON,Shawnee City Ward 03 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",368,901360
+JOHNSON,Shawnee City Ward 03 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",214,901370
+JOHNSON,Shawnee City Ward 03 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",569,901370
+JOHNSON,Shawnee City Ward 03 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",103,901380
+JOHNSON,Shawnee City Ward 03 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",280,901380
+JOHNSON,Shawnee City Ward 04 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",111,901410
+JOHNSON,Shawnee City Ward 04 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",181,901410
+JOHNSON,Shawnee City Ward 04 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,901430
+JOHNSON,Shawnee City Ward 04 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",0,901430
+JOHNSON,Spring Hill Township Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,901440
+JOHNSON,Spring Hill Township Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",2,901440
+JOHNSON,Spring Hill Township Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",2,901460
+JOHNSON,Spring Hill Township Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",12,901460
+JOHNSON,Spring Hill Township Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",4,901470
+JOHNSON,Spring Hill Township Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",4,901470
+JOHNSON,Olathe Township Part 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",1,901560
+JOHNSON,Olathe Township Part 11,United States House of Representatives,3,Republican,"Yoder, Kevin",3,901560
+JOHNSON,Spring Hill Township Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",16,901620
+JOHNSON,Spring Hill Township Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",53,901620
+JOHNSON,Olathe City Ward 01 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",163,901630
+JOHNSON,Olathe City Ward 01 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",351,901630
+JOHNSON,Olathe City Ward 02 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",88,901650
+JOHNSON,Olathe City Ward 02 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",169,901650
+JOHNSON,Olathe City Ward 03 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",136,901680
+JOHNSON,Olathe City Ward 03 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",292,901680
+JOHNSON,Olathe City Ward 03 Precinct 24,United States House of Representatives,3,Democratic,"Kultala, Kelly",89,901690
+JOHNSON,Olathe City Ward 03 Precinct 24,United States House of Representatives,3,Republican,"Yoder, Kevin",194,901690
+JOHNSON,Olathe City Ward 04 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",226,901710
+JOHNSON,Olathe City Ward 04 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",361,901710
+JOHNSON,Olathe Township Part 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,901780
+JOHNSON,Olathe Township Part 05,United States House of Representatives,3,Republican,"Yoder, Kevin",2,901780
+JOHNSON,Olathe City Ward 01 Precinct 24,United States House of Representatives,3,Democratic,"Kultala, Kelly",18,901800
+JOHNSON,Olathe City Ward 01 Precinct 24,United States House of Representatives,3,Republican,"Yoder, Kevin",60,901800
+JOHNSON,Olathe City Ward 01 Precinct 22,United States House of Representatives,3,Democratic,"Kultala, Kelly",252,901810
+JOHNSON,Olathe City Ward 01 Precinct 22,United States House of Representatives,3,Republican,"Yoder, Kevin",668,901810
+JOHNSON,DeSoto Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,901850
+JOHNSON,DeSoto Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",2,901850
+JOHNSON,Olathe City Ward 01 Precinct 18,United States House of Representatives,3,Democratic,"Kultala, Kelly",52,901880
+JOHNSON,Olathe City Ward 01 Precinct 18,United States House of Representatives,3,Republican,"Yoder, Kevin",123,901880
+JOHNSON,Olathe Township Part 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,901890
+JOHNSON,Olathe Township Part 07,United States House of Representatives,3,Republican,"Yoder, Kevin",1,901890
+JOHNSON,Lexington Township Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",159,901940
+JOHNSON,Lexington Township Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",449,901940
+JOHNSON,Gardner City Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",41,990010
+JOHNSON,Gardner City Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",72,990010
+JOHNSON,Gardner City Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",168,990020
+JOHNSON,Gardner City Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",318,990020
+JOHNSON,Gardner City Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",9,990030
+JOHNSON,Gardner City Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",38,990030
+JOHNSON,Gardner City Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",6,990040
+JOHNSON,Gardner City Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",8,990040
+JOHNSON,Gardner City Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",166,990050
+JOHNSON,Gardner City Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",311,990050
+JOHNSON,Gardner City Precicnt 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",131,990060
+JOHNSON,Gardner City Precicnt 14,United States House of Representatives,3,Republican,"Yoder, Kevin",272,990060
+JOHNSON,Gardner Township 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",83,990070
+JOHNSON,Gardner Township 01,United States House of Representatives,3,Republican,"Yoder, Kevin",229,990070
+JOHNSON,Gardner Township 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",87,990080
+JOHNSON,Gardner Township 02,United States House of Representatives,3,Republican,"Yoder, Kevin",257,990080
+JOHNSON,Gardner Township 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",32,990100
+JOHNSON,Gardner Township 11,United States House of Representatives,3,Republican,"Yoder, Kevin",55,990100
+JOHNSON,Leawood Ward 03 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",72,990110
+JOHNSON,Leawood Ward 03 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",115,990110
+JOHNSON,Leawood Ward 03 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",203,990120
+JOHNSON,Leawood Ward 03 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",408,990120
+JOHNSON,Lenexa Ward 01 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",236,999987
+JOHNSON,Lenexa Ward 01 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",310,999987
+JOHNSON,Olathe Township Part 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",92,999992
+JOHNSON,Olathe Township Part 01,United States House of Representatives,3,Republican,"Yoder, Kevin",178,999992
+JOHNSON,Olathe City Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",163,999993
+JOHNSON,Olathe City Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",279,999993
+JOHNSON,Gardner Township 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",1,999997
+JOHNSON,Gardner Township 05,United States House of Representatives,3,Republican,"Yoder, Kevin",5,999997
+JOHNSON,ADVANCED,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,999998
+JOHNSON,ADVANCED,United States House of Representatives,3,Republican,"Yoder, Kevin",0,999998
+JOHNSON,ADVANCED,Attorney General,,Democratic,"Kotich, A.J.",71308,999998
+JOHNSON,ADVANCED,Attorney General,,Republican,"Schmidt, Derek",115530,999998
+JOHNSON,ADVANCED,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77297,999998
+JOHNSON,ADVANCED,Commissioner of Insurance,,Republican,"Selzer, Ken",109703,999998
+JOHNSON,ADVANCED,Kansas Senate,37,Republican,"Baumgardner, Molly",12498,999998
+JOHNSON,ADVANCED,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",82366,999998
+JOHNSON,ADVANCED,Secretary of State,,Republican,"Kobach, Kris",108409,999998
+JOHNSON,ADVANCED,State Treasurer,,Democratic,"Alldritt, Carmen",67998,999998
+JOHNSON,ADVANCED,State Treasurer,,Republican,"Estes, Ron",118424,999998
+JOHNSON,Aubry Township 01,United States Senate,,independent,"Orman, Greg",40,000010
+JOHNSON,Aubry Township 01,United States Senate,,Libertarian,"Batson, Randall",0,000010
+JOHNSON,Aubry Township 01,United States Senate,,Republican,"Roberts, Pat",70,000010
+JOHNSON,Aubry Township 02,United States Senate,,independent,"Orman, Greg",200,000020
+JOHNSON,Aubry Township 02,United States Senate,,Libertarian,"Batson, Randall",14,000020
+JOHNSON,Aubry Township 02,United States Senate,,Republican,"Roberts, Pat",366,000020
+JOHNSON,Aubry Township 03,United States Senate,,independent,"Orman, Greg",120,000030
+JOHNSON,Aubry Township 03,United States Senate,,Libertarian,"Batson, Randall",8,000030
+JOHNSON,Aubry Township 03,United States Senate,,Republican,"Roberts, Pat",196,000030
+JOHNSON,Aubry Township 04,United States Senate,,independent,"Orman, Greg",263,000040
+JOHNSON,Aubry Township 04,United States Senate,,Libertarian,"Batson, Randall",22,000040
+JOHNSON,Aubry Township 04,United States Senate,,Republican,"Roberts, Pat",445,000040
+JOHNSON,DeSoto Precinct 01,United States Senate,,independent,"Orman, Greg",238,000070
+JOHNSON,DeSoto Precinct 01,United States Senate,,Libertarian,"Batson, Randall",32,000070
+JOHNSON,DeSoto Precinct 01,United States Senate,,Republican,"Roberts, Pat",360,000070
+JOHNSON,DeSoto Precinct 02,United States Senate,,independent,"Orman, Greg",184,000080
+JOHNSON,DeSoto Precinct 02,United States Senate,,Libertarian,"Batson, Randall",14,000080
+JOHNSON,DeSoto Precinct 02,United States Senate,,Republican,"Roberts, Pat",190,000080
+JOHNSON,Edgerton Precinct 01,United States Senate,,independent,"Orman, Greg",150,000090
+JOHNSON,Edgerton Precinct 01,United States Senate,,Libertarian,"Batson, Randall",31,000090
+JOHNSON,Edgerton Precinct 01,United States Senate,,Republican,"Roberts, Pat",222,000090
+JOHNSON,Fairway Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",176,000100
+JOHNSON,Fairway Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",3,000100
+JOHNSON,Fairway Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",108,000100
+JOHNSON,Fairway Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",130,000105
+JOHNSON,Fairway Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",2,000105
+JOHNSON,Fairway Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",78,000105
+JOHNSON,Fairway Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",133,000110
+JOHNSON,Fairway Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",3,000110
+JOHNSON,Fairway Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",87,000110
+JOHNSON,Fairway Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",131,000115
+JOHNSON,Fairway Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",4,000115
+JOHNSON,Fairway Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",91,000115
+JOHNSON,Fairway Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",164,000120
+JOHNSON,Fairway Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",1,000120
+JOHNSON,Fairway Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",150,000120
+JOHNSON,Fairway Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",145,000125
+JOHNSON,Fairway Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",2,000125
+JOHNSON,Fairway Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",97,000125
+JOHNSON,Fairway Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",69,000130
+JOHNSON,Fairway Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",3,000130
+JOHNSON,Fairway Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",21,000130
+JOHNSON,Fairway Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",86,000132
+JOHNSON,Fairway Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",1,000132
+JOHNSON,Fairway Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",35,000132
+JOHNSON,Fairway Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",55,000135
+JOHNSON,Fairway Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",1,000135
+JOHNSON,Fairway Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",30,000135
+JOHNSON,Fairway Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",82,000137
+JOHNSON,Fairway Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",3,000137
+JOHNSON,Fairway Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",35,000137
+JOHNSON,Gardner City Precinct 01,United States Senate,,independent,"Orman, Greg",306,00014A
+JOHNSON,Gardner City Precinct 01,United States Senate,,Libertarian,"Batson, Randall",34,00014A
+JOHNSON,Gardner City Precinct 01,United States Senate,,Republican,"Roberts, Pat",446,00014A
+JOHNSON,Gardner City Precinct 03,United States Senate,,independent,"Orman, Greg",220,000160
+JOHNSON,Gardner City Precinct 03,United States Senate,,Libertarian,"Batson, Randall",28,000160
+JOHNSON,Gardner City Precinct 03,United States Senate,,Republican,"Roberts, Pat",238,000160
+JOHNSON,Lake Quivira Precinct 01,United States Senate,,independent,"Orman, Greg",232,000190
+JOHNSON,Lake Quivira Precinct 01,United States Senate,,Libertarian,"Batson, Randall",5,000190
+JOHNSON,Lake Quivira Precinct 01,United States Senate,,Republican,"Roberts, Pat",302,000190
+JOHNSON,Leawood Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",407,000210
+JOHNSON,Leawood Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",10,000210
+JOHNSON,Leawood Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",395,000210
+JOHNSON,Leawood Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",347,000220
+JOHNSON,Leawood Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",11,000220
+JOHNSON,Leawood Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",319,000220
+JOHNSON,Leawood Ward 01 Precinct 04,United States Senate,,independent,"Orman, Greg",280,000230
+JOHNSON,Leawood Ward 01 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",7,000230
+JOHNSON,Leawood Ward 01 Precinct 04,United States Senate,,Republican,"Roberts, Pat",254,000230
+JOHNSON,Leawood Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",323,000240
+JOHNSON,Leawood Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",5,000240
+JOHNSON,Leawood Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",296,000240
+JOHNSON,Leawood Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",259,000270
+JOHNSON,Leawood Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",1,000270
+JOHNSON,Leawood Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",500,000270
+JOHNSON,Leawood Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",235,000350
+JOHNSON,Leawood Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",7,000350
+JOHNSON,Leawood Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",372,000350
+JOHNSON,Leawood Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",303,000370
+JOHNSON,Leawood Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",6,000370
+JOHNSON,Leawood Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",374,000370
+JOHNSON,Lenexa Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",396,000430
+JOHNSON,Lenexa Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",15,000430
+JOHNSON,Lenexa Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",339,000430
+JOHNSON,Lenexa Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",445,000440
+JOHNSON,Lenexa Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",24,000440
+JOHNSON,Lenexa Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",402,000440
+JOHNSON,Lenexa Ward 01 Precinct 05,United States Senate,,independent,"Orman, Greg",305,000460
+JOHNSON,Lenexa Ward 01 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",18,000460
+JOHNSON,Lenexa Ward 01 Precinct 05,United States Senate,,Republican,"Roberts, Pat",285,000460
+JOHNSON,Lenexa Ward 04 Precinct 09,United States Senate,,independent,"Orman, Greg",254,000510
+JOHNSON,Lenexa Ward 04 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",25,000510
+JOHNSON,Lenexa Ward 04 Precinct 09,United States Senate,,Republican,"Roberts, Pat",241,000510
+JOHNSON,Lenexa Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",246,000520
+JOHNSON,Lenexa Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",9,000520
+JOHNSON,Lenexa Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",525,000520
+JOHNSON,Lenexa Ward 02 Precinct 05,United States Senate,,independent,"Orman, Greg",305,000530
+JOHNSON,Lenexa Ward 02 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",13,000530
+JOHNSON,Lenexa Ward 02 Precinct 05,United States Senate,,Republican,"Roberts, Pat",197,000530
+JOHNSON,Lenexa Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",169,000540
+JOHNSON,Lenexa Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",13,000540
+JOHNSON,Lenexa Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",182,000540
+JOHNSON,Lenexa Ward 01 Precinct 07,United States Senate,,independent,"Orman, Greg",197,000550
+JOHNSON,Lenexa Ward 01 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",13,000550
+JOHNSON,Lenexa Ward 01 Precinct 07,United States Senate,,Republican,"Roberts, Pat",181,000550
+JOHNSON,Lenexa Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",262,000580
+JOHNSON,Lenexa Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",8,000580
+JOHNSON,Lenexa Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",178,000580
+JOHNSON,Lenexa Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",444,000590
+JOHNSON,Lenexa Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",22,000590
+JOHNSON,Lenexa Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",286,000590
+JOHNSON,Lenexa Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",441,000600
+JOHNSON,Lenexa Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",23,000600
+JOHNSON,Lenexa Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",421,000600
+JOHNSON,Lenexa Ward 03 Precinct 04,United States Senate,,independent,"Orman, Greg",243,000610
+JOHNSON,Lenexa Ward 03 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",11,000610
+JOHNSON,Lenexa Ward 03 Precinct 04,United States Senate,,Republican,"Roberts, Pat",304,000610
+JOHNSON,Lenexa Ward 03 Precinct 05,United States Senate,,independent,"Orman, Greg",196,000620
+JOHNSON,Lenexa Ward 03 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",16,000620
+JOHNSON,Lenexa Ward 03 Precinct 05,United States Senate,,Republican,"Roberts, Pat",124,000620
+JOHNSON,Lenexa Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",301,000640
+JOHNSON,Lenexa Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",13,000640
+JOHNSON,Lenexa Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",288,000640
+JOHNSON,Lenexa Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",131,000660
+JOHNSON,Lenexa Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",10,000660
+JOHNSON,Lenexa Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",141,000660
+JOHNSON,Mission Hills Precinct 01,United States Senate,,independent,"Orman, Greg",161,000840
+JOHNSON,Mission Hills Precinct 01,United States Senate,,Libertarian,"Batson, Randall",3,000840
+JOHNSON,Mission Hills Precinct 01,United States Senate,,Republican,"Roberts, Pat",253,000840
+JOHNSON,Mission Hills Precinct 02,United States Senate,,independent,"Orman, Greg",273,000850
+JOHNSON,Mission Hills Precinct 02,United States Senate,,Libertarian,"Batson, Randall",3,000850
+JOHNSON,Mission Hills Precinct 02,United States Senate,,Republican,"Roberts, Pat",280,000850
+JOHNSON,Mission Hills Precinct 03,United States Senate,,independent,"Orman, Greg",140,000860
+JOHNSON,Mission Hills Precinct 03,United States Senate,,Libertarian,"Batson, Randall",2,000860
+JOHNSON,Mission Hills Precinct 03,United States Senate,,Republican,"Roberts, Pat",200,000860
+JOHNSON,Mission Hills Precinct 04,United States Senate,,independent,"Orman, Greg",280,000870
+JOHNSON,Mission Hills Precinct 04,United States Senate,,Libertarian,"Batson, Randall",3,000870
+JOHNSON,Mission Hills Precinct 04,United States Senate,,Republican,"Roberts, Pat",306,000870
+JOHNSON,Mission Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",299,000880
+JOHNSON,Mission Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",22,000880
+JOHNSON,Mission Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",177,000880
+JOHNSON,Mission Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",163,000890
+JOHNSON,Mission Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",10,000890
+JOHNSON,Mission Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",73,000890
+JOHNSON,Mission Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",193,000900
+JOHNSON,Mission Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",16,000900
+JOHNSON,Mission Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",86,000900
+JOHNSON,Mission Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",262,000910
+JOHNSON,Mission Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",17,000910
+JOHNSON,Mission Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",144,000910
+JOHNSON,Mission Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",267,000920
+JOHNSON,Mission Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",21,000920
+JOHNSON,Mission Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",140,000920
+JOHNSON,Mission Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",156,000930
+JOHNSON,Mission Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",13,000930
+JOHNSON,Mission Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",85,000930
+JOHNSON,Mission Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",218,000940
+JOHNSON,Mission Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",9,000940
+JOHNSON,Mission Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",95,000940
+JOHNSON,Mission Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",298,000950
+JOHNSON,Mission Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",14,000950
+JOHNSON,Mission Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",186,000950
+JOHNSON,Mission Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",147,000960
+JOHNSON,Mission Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",10,000960
+JOHNSON,Mission Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",96,000960
+JOHNSON,Mission Woods Precinct 01,United States Senate,,independent,"Orman, Greg",57,000970
+JOHNSON,Mission Woods Precinct 01,United States Senate,,Libertarian,"Batson, Randall",1,000970
+JOHNSON,Mission Woods Precinct 01,United States Senate,,Republican,"Roberts, Pat",41,000970
+JOHNSON,Olathe City Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",177,001000
+JOHNSON,Olathe City Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",26,001000
+JOHNSON,Olathe City Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",166,001000
+JOHNSON,Olathe City Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",132,001010
+JOHNSON,Olathe City Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",10,001010
+JOHNSON,Olathe City Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",137,001010
+JOHNSON,Olathe City Ward 01 Precinct 05,United States Senate,,independent,"Orman, Greg",238,001030
+JOHNSON,Olathe City Ward 01 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",22,001030
+JOHNSON,Olathe City Ward 01 Precinct 05,United States Senate,,Republican,"Roberts, Pat",312,001030
+JOHNSON,Olathe City Ward 03 Precinct 23,United States Senate,,independent,"Orman, Greg",224,001050
+JOHNSON,Olathe City Ward 03 Precinct 23,United States Senate,,Libertarian,"Batson, Randall",18,001050
+JOHNSON,Olathe City Ward 03 Precinct 23,United States Senate,,Republican,"Roberts, Pat",243,001050
+JOHNSON,Olathe City Ward 01 Precinct 08,United States Senate,,independent,"Orman, Greg",290,001060
+JOHNSON,Olathe City Ward 01 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",17,001060
+JOHNSON,Olathe City Ward 01 Precinct 08,United States Senate,,Republican,"Roberts, Pat",313,001060
+JOHNSON,Olathe City Ward 01 Precinct 09,United States Senate,,independent,"Orman, Greg",218,001070
+JOHNSON,Olathe City Ward 01 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",17,001070
+JOHNSON,Olathe City Ward 01 Precinct 09,United States Senate,,Republican,"Roberts, Pat",340,001070
+JOHNSON,Olathe City Ward 03 Precinct 07,United States Senate,,independent,"Orman, Greg",189,001100
+JOHNSON,Olathe City Ward 03 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",13,001100
+JOHNSON,Olathe City Ward 03 Precinct 07,United States Senate,,Republican,"Roberts, Pat",237,001100
+JOHNSON,Olathe City Ward 01 Precinct 20,United States Senate,,independent,"Orman, Greg",198,001130
+JOHNSON,Olathe City Ward 01 Precinct 20,United States Senate,,Libertarian,"Batson, Randall",11,001130
+JOHNSON,Olathe City Ward 01 Precinct 20,United States Senate,,Republican,"Roberts, Pat",183,001130
+JOHNSON,Olathe City Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",177,001150
+JOHNSON,Olathe City Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",18,001150
+JOHNSON,Olathe City Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",206,001150
+JOHNSON,Olathe City Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",218,001160
+JOHNSON,Olathe City Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",31,001160
+JOHNSON,Olathe City Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",202,001160
+JOHNSON,Olathe City Ward 02 Precinct 05,United States Senate,,independent,"Orman, Greg",535,00117A
+JOHNSON,Olathe City Ward 02 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",11,00117A
+JOHNSON,Olathe City Ward 02 Precinct 05,United States Senate,,Republican,"Roberts, Pat",732,00117A
+JOHNSON,Olathe City Ward 02 Precinct 08,United States Senate,,independent,"Orman, Greg",260,001200
+JOHNSON,Olathe City Ward 02 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",25,001200
+JOHNSON,Olathe City Ward 02 Precinct 08,United States Senate,,Republican,"Roberts, Pat",276,001200
+JOHNSON,Olathe City Ward 01 Precinct 19,United States Senate,,independent,"Orman, Greg",113,001210
+JOHNSON,Olathe City Ward 01 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",11,001210
+JOHNSON,Olathe City Ward 01 Precinct 19,United States Senate,,Republican,"Roberts, Pat",121,001210
+JOHNSON,Olathe City Ward 02 Precinct 10,United States Senate,,independent,"Orman, Greg",524,001220
+JOHNSON,Olathe City Ward 02 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",25,001220
+JOHNSON,Olathe City Ward 02 Precinct 10,United States Senate,,Republican,"Roberts, Pat",500,001220
+JOHNSON,Olathe City Ward 02 Precinct 12,United States Senate,,independent,"Orman, Greg",209,001240
+JOHNSON,Olathe City Ward 02 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",9,001240
+JOHNSON,Olathe City Ward 02 Precinct 12,United States Senate,,Republican,"Roberts, Pat",220,001240
+JOHNSON,Olathe City Ward 02 Precinct 14,United States Senate,,independent,"Orman, Greg",188,001260
+JOHNSON,Olathe City Ward 02 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",20,001260
+JOHNSON,Olathe City Ward 02 Precinct 14,United States Senate,,Republican,"Roberts, Pat",215,001260
+JOHNSON,Olathe City Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",99,001280
+JOHNSON,Olathe City Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",11,001280
+JOHNSON,Olathe City Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",122,001280
+JOHNSON,Olathe City Ward 02 Precinct 17,United States Senate,,independent,"Orman, Greg",1,001290
+JOHNSON,Olathe City Ward 02 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",0,001290
+JOHNSON,Olathe City Ward 02 Precinct 17,United States Senate,,Republican,"Roberts, Pat",0,001290
+JOHNSON,Olathe City Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",106,001300
+JOHNSON,Olathe City Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",6,001300
+JOHNSON,Olathe City Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",114,001300
+JOHNSON,Olathe City Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",300,001310
+JOHNSON,Olathe City Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",27,001310
+JOHNSON,Olathe City Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",361,001310
+JOHNSON,Olathe City Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",137,001320
+JOHNSON,Olathe City Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",4,001320
+JOHNSON,Olathe City Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",205,001320
+JOHNSON,Olathe City Ward 03 Precinct 04,United States Senate,,independent,"Orman, Greg",243,001330
+JOHNSON,Olathe City Ward 03 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",22,001330
+JOHNSON,Olathe City Ward 03 Precinct 04,United States Senate,,Republican,"Roberts, Pat",323,001330
+JOHNSON,Olathe City Ward 03 Precinct 05,United States Senate,,independent,"Orman, Greg",222,001340
+JOHNSON,Olathe City Ward 03 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",16,001340
+JOHNSON,Olathe City Ward 03 Precinct 05,United States Senate,,Republican,"Roberts, Pat",377,001340
+JOHNSON,Olathe City Ward 03 Precinct 06,United States Senate,,independent,"Orman, Greg",187,001350
+JOHNSON,Olathe City Ward 03 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",4,001350
+JOHNSON,Olathe City Ward 03 Precinct 06,United States Senate,,Republican,"Roberts, Pat",255,001350
+JOHNSON,Olathe City Ward 03 Precinct 09,United States Senate,,independent,"Orman, Greg",122,001360
+JOHNSON,Olathe City Ward 03 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",9,001360
+JOHNSON,Olathe City Ward 03 Precinct 09,United States Senate,,Republican,"Roberts, Pat",191,001360
+JOHNSON,Olathe City Ward 03 Precinct 08,United States Senate,,independent,"Orman, Greg",279,001370
+JOHNSON,Olathe City Ward 03 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",15,001370
+JOHNSON,Olathe City Ward 03 Precinct 08,United States Senate,,Republican,"Roberts, Pat",368,001370
+JOHNSON,Olathe City Ward 03 Precinct 22,United States Senate,,independent,"Orman, Greg",216,001380
+JOHNSON,Olathe City Ward 03 Precinct 22,United States Senate,,Libertarian,"Batson, Randall",11,001380
+JOHNSON,Olathe City Ward 03 Precinct 22,United States Senate,,Republican,"Roberts, Pat",313,001380
+JOHNSON,Olathe City Ward 03 Precinct 10,United States Senate,,independent,"Orman, Greg",266,001390
+JOHNSON,Olathe City Ward 03 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",13,001390
+JOHNSON,Olathe City Ward 03 Precinct 10,United States Senate,,Republican,"Roberts, Pat",366,001390
+JOHNSON,Olathe City Ward 03 Precinct 12,United States Senate,,independent,"Orman, Greg",270,001410
+JOHNSON,Olathe City Ward 03 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",15,001410
+JOHNSON,Olathe City Ward 03 Precinct 12,United States Senate,,Republican,"Roberts, Pat",294,001410
+JOHNSON,Olathe City Ward 04 Precinct 06,United States Senate,,independent,"Orman, Greg",348,00147A
+JOHNSON,Olathe City Ward 04 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",27,00147A
+JOHNSON,Olathe City Ward 04 Precinct 06,United States Senate,,Republican,"Roberts, Pat",347,00147A
+JOHNSON,Olathe City Ward 04 Precinct 12,United States Senate,,independent,"Orman, Greg",283,00147B
+JOHNSON,Olathe City Ward 04 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",11,00147B
+JOHNSON,Olathe City Ward 04 Precinct 12,United States Senate,,Republican,"Roberts, Pat",371,00147B
+JOHNSON,Olathe City Ward 04 Precinct 07,United States Senate,,independent,"Orman, Greg",302,001480
+JOHNSON,Olathe City Ward 04 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",21,001480
+JOHNSON,Olathe City Ward 04 Precinct 07,United States Senate,,Republican,"Roberts, Pat",291,001480
+JOHNSON,Olathe City Ward 04 Precinct 08,United States Senate,,independent,"Orman, Greg",227,001490
+JOHNSON,Olathe City Ward 04 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",12,001490
+JOHNSON,Olathe City Ward 04 Precinct 08,United States Senate,,Republican,"Roberts, Pat",285,001490
+JOHNSON,Olathe City Ward 04 Precinct 09,United States Senate,,independent,"Orman, Greg",337,001500
+JOHNSON,Olathe City Ward 04 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",13,001500
+JOHNSON,Olathe City Ward 04 Precinct 09,United States Senate,,Republican,"Roberts, Pat",378,001500
+JOHNSON,Olathe City Ward 04 Precinct 10,United States Senate,,independent,"Orman, Greg",198,001510
+JOHNSON,Olathe City Ward 04 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",5,001510
+JOHNSON,Olathe City Ward 04 Precinct 10,United States Senate,,Republican,"Roberts, Pat",193,001510
+JOHNSON,Olathe Township Part 03,United States Senate,,independent,"Orman, Greg",23,00153J
+JOHNSON,Olathe Township Part 03,United States Senate,,Libertarian,"Batson, Randall",0,00153J
+JOHNSON,Olathe Township Part 03,United States Senate,,Republican,"Roberts, Pat",17,00153J
+JOHNSON,Olathe Township Part 04,United States Senate,,independent,"Orman, Greg",0,00153K
+JOHNSON,Olathe Township Part 04,United States Senate,,Libertarian,"Batson, Randall",0,00153K
+JOHNSON,Olathe Township Part 04,United States Senate,,Republican,"Roberts, Pat",2,00153K
+JOHNSON,Overland Park Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",296,001540
+JOHNSON,Overland Park Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",16,001540
+JOHNSON,Overland Park Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",173,001540
+JOHNSON,Overland Park Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",294,001550
+JOHNSON,Overland Park Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",20,001550
+JOHNSON,Overland Park Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",185,001550
+JOHNSON,Overland Park Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",269,001560
+JOHNSON,Overland Park Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",10,001560
+JOHNSON,Overland Park Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",206,001560
+JOHNSON,Overland Park Ward 01 Precinct 06,United States Senate,,independent,"Orman, Greg",372,001590
+JOHNSON,Overland Park Ward 01 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",16,001590
+JOHNSON,Overland Park Ward 01 Precinct 06,United States Senate,,Republican,"Roberts, Pat",259,001590
+JOHNSON,Overland Park Ward 01 Precinct 07,United States Senate,,independent,"Orman, Greg",330,001600
+JOHNSON,Overland Park Ward 01 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",27,001600
+JOHNSON,Overland Park Ward 01 Precinct 07,United States Senate,,Republican,"Roberts, Pat",256,001600
+JOHNSON,Overland Park Ward 01 Precinct 08,United States Senate,,independent,"Orman, Greg",229,001610
+JOHNSON,Overland Park Ward 01 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",15,001610
+JOHNSON,Overland Park Ward 01 Precinct 08,United States Senate,,Republican,"Roberts, Pat",159,001610
+JOHNSON,Overland Park Ward 01 Precinct 19,United States Senate,,independent,"Orman, Greg",206,001630
+JOHNSON,Overland Park Ward 01 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",19,001630
+JOHNSON,Overland Park Ward 01 Precinct 19,United States Senate,,Republican,"Roberts, Pat",150,001630
+JOHNSON,Overland Park Ward 01 Precinct 11,United States Senate,,independent,"Orman, Greg",83,001640
+JOHNSON,Overland Park Ward 01 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",2,001640
+JOHNSON,Overland Park Ward 01 Precinct 11,United States Senate,,Republican,"Roberts, Pat",56,001640
+JOHNSON,Overland Park Ward 01 Precinct 12,United States Senate,,independent,"Orman, Greg",268,001650
+JOHNSON,Overland Park Ward 01 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",8,001650
+JOHNSON,Overland Park Ward 01 Precinct 12,United States Senate,,Republican,"Roberts, Pat",167,001650
+JOHNSON,Overland Park Ward 01 Precinct 13,United States Senate,,independent,"Orman, Greg",193,001660
+JOHNSON,Overland Park Ward 01 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",18,001660
+JOHNSON,Overland Park Ward 01 Precinct 13,United States Senate,,Republican,"Roberts, Pat",138,001660
+JOHNSON,Overland Park Ward 01 Precinct 14,United States Senate,,independent,"Orman, Greg",306,001670
+JOHNSON,Overland Park Ward 01 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",25,001670
+JOHNSON,Overland Park Ward 01 Precinct 14,United States Senate,,Republican,"Roberts, Pat",164,001670
+JOHNSON,Overland Park Ward 01 Precinct 15,United States Senate,,independent,"Orman, Greg",137,001680
+JOHNSON,Overland Park Ward 01 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",7,001680
+JOHNSON,Overland Park Ward 01 Precinct 15,United States Senate,,Republican,"Roberts, Pat",93,001680
+JOHNSON,Overland Park Ward 02 Precinct 18,United States Senate,,independent,"Orman, Greg",341,001690
+JOHNSON,Overland Park Ward 02 Precinct 18,United States Senate,,Libertarian,"Batson, Randall",23,001690
+JOHNSON,Overland Park Ward 02 Precinct 18,United States Senate,,Republican,"Roberts, Pat",231,001690
+JOHNSON,Overland Park Ward 01 Precinct 17,United States Senate,,independent,"Orman, Greg",154,001700
+JOHNSON,Overland Park Ward 01 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",12,001700
+JOHNSON,Overland Park Ward 01 Precinct 17,United States Senate,,Republican,"Roberts, Pat",88,001700
+JOHNSON,Overland Park Ward 01 Precinct 10,United States Senate,,independent,"Orman, Greg",306,001710
+JOHNSON,Overland Park Ward 01 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",25,001710
+JOHNSON,Overland Park Ward 01 Precinct 10,United States Senate,,Republican,"Roberts, Pat",212,001710
+JOHNSON,Overland Park Ward 01 Precinct 16,United States Senate,,independent,"Orman, Greg",381,001720
+JOHNSON,Overland Park Ward 01 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",26,001720
+JOHNSON,Overland Park Ward 01 Precinct 16,United States Senate,,Republican,"Roberts, Pat",177,001720
+JOHNSON,Overland Park Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",285,001730
+JOHNSON,Overland Park Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",14,001730
+JOHNSON,Overland Park Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",222,001730
+JOHNSON,Overland Park Ward 02 Precinct 05,United States Senate,,independent,"Orman, Greg",263,001740
+JOHNSON,Overland Park Ward 02 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",17,001740
+JOHNSON,Overland Park Ward 02 Precinct 05,United States Senate,,Republican,"Roberts, Pat",162,001740
+JOHNSON,Overland Park Ward 02 Precinct 06,United States Senate,,independent,"Orman, Greg",244,001750
+JOHNSON,Overland Park Ward 02 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",19,001750
+JOHNSON,Overland Park Ward 02 Precinct 06,United States Senate,,Republican,"Roberts, Pat",194,001750
+JOHNSON,Overland Park Ward 02 Precinct 07,United States Senate,,independent,"Orman, Greg",203,001760
+JOHNSON,Overland Park Ward 02 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",11,001760
+JOHNSON,Overland Park Ward 02 Precinct 07,United States Senate,,Republican,"Roberts, Pat",168,001760
+JOHNSON,Overland Park Ward 02 Precinct 08,United States Senate,,independent,"Orman, Greg",154,001770
+JOHNSON,Overland Park Ward 02 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",11,001770
+JOHNSON,Overland Park Ward 02 Precinct 08,United States Senate,,Republican,"Roberts, Pat",86,001770
+JOHNSON,Overland Park Ward 02 Precinct 09,United States Senate,,independent,"Orman, Greg",203,001780
+JOHNSON,Overland Park Ward 02 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",7,001780
+JOHNSON,Overland Park Ward 02 Precinct 09,United States Senate,,Republican,"Roberts, Pat",179,001780
+JOHNSON,Overland Park Ward 02 Precinct 11,United States Senate,,independent,"Orman, Greg",253,001800
+JOHNSON,Overland Park Ward 02 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",9,001800
+JOHNSON,Overland Park Ward 02 Precinct 11,United States Senate,,Republican,"Roberts, Pat",192,001800
+JOHNSON,Overland Park Ward 02 Precinct 12,United States Senate,,independent,"Orman, Greg",182,001810
+JOHNSON,Overland Park Ward 02 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",12,001810
+JOHNSON,Overland Park Ward 02 Precinct 12,United States Senate,,Republican,"Roberts, Pat",146,001810
+JOHNSON,Overland Park Ward 02 Precinct 13,United States Senate,,independent,"Orman, Greg",126,001820
+JOHNSON,Overland Park Ward 02 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",5,001820
+JOHNSON,Overland Park Ward 02 Precinct 13,United States Senate,,Republican,"Roberts, Pat",83,001820
+JOHNSON,Overland Park Ward 02 Precinct 14,United States Senate,,independent,"Orman, Greg",203,001830
+JOHNSON,Overland Park Ward 02 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",4,001830
+JOHNSON,Overland Park Ward 02 Precinct 14,United States Senate,,Republican,"Roberts, Pat",131,001830
+JOHNSON,Overland Park Ward 02 Precinct 15,United States Senate,,independent,"Orman, Greg",369,001840
+JOHNSON,Overland Park Ward 02 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",30,001840
+JOHNSON,Overland Park Ward 02 Precinct 15,United States Senate,,Republican,"Roberts, Pat",284,001840
+JOHNSON,Overland Park Ward 02 Precinct 16,United States Senate,,independent,"Orman, Greg",219,001850
+JOHNSON,Overland Park Ward 02 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",12,001850
+JOHNSON,Overland Park Ward 02 Precinct 16,United States Senate,,Republican,"Roberts, Pat",168,001850
+JOHNSON,Overland Park Ward 02 Precinct 17,United States Senate,,independent,"Orman, Greg",284,001860
+JOHNSON,Overland Park Ward 02 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",16,001860
+JOHNSON,Overland Park Ward 02 Precinct 17,United States Senate,,Republican,"Roberts, Pat",277,001860
+JOHNSON,Overland Park Ward 03 Precinct 16,United States Senate,,independent,"Orman, Greg",298,001870
+JOHNSON,Overland Park Ward 03 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",11,001870
+JOHNSON,Overland Park Ward 03 Precinct 16,United States Senate,,Republican,"Roberts, Pat",221,001870
+JOHNSON,Overland Park Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",245,001880
+JOHNSON,Overland Park Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",17,001880
+JOHNSON,Overland Park Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",186,001880
+JOHNSON,Overland Park Ward 02 Precinct 20,United States Senate,,independent,"Orman, Greg",200,001890
+JOHNSON,Overland Park Ward 02 Precinct 20,United States Senate,,Libertarian,"Batson, Randall",2,001890
+JOHNSON,Overland Park Ward 02 Precinct 20,United States Senate,,Republican,"Roberts, Pat",182,001890
+JOHNSON,Overland Park Ward 03 Precinct 20,United States Senate,,independent,"Orman, Greg",351,001900
+JOHNSON,Overland Park Ward 03 Precinct 20,United States Senate,,Libertarian,"Batson, Randall",25,001900
+JOHNSON,Overland Park Ward 03 Precinct 20,United States Senate,,Republican,"Roberts, Pat",298,001900
+JOHNSON,Overland Park Ward 03 Precinct 05,United States Senate,,independent,"Orman, Greg",316,001910
+JOHNSON,Overland Park Ward 03 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",12,001910
+JOHNSON,Overland Park Ward 03 Precinct 05,United States Senate,,Republican,"Roberts, Pat",257,001910
+JOHNSON,Overland Park Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",268,001920
+JOHNSON,Overland Park Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",12,001920
+JOHNSON,Overland Park Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",214,001920
+JOHNSON,Overland Park Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",251,001930
+JOHNSON,Overland Park Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",5,001930
+JOHNSON,Overland Park Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",259,001930
+JOHNSON,Overland Park Ward 03 Precinct 04,United States Senate,,independent,"Orman, Greg",341,001940
+JOHNSON,Overland Park Ward 03 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",17,001940
+JOHNSON,Overland Park Ward 03 Precinct 04,United States Senate,,Republican,"Roberts, Pat",272,001940
+JOHNSON,Overland Park Ward 03 Precinct 17,United States Senate,,independent,"Orman, Greg",243,001950
+JOHNSON,Overland Park Ward 03 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",3,001950
+JOHNSON,Overland Park Ward 03 Precinct 17,United States Senate,,Republican,"Roberts, Pat",196,001950
+JOHNSON,Overland Park Ward 03 Precinct 06,United States Senate,,independent,"Orman, Greg",352,001960
+JOHNSON,Overland Park Ward 03 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",15,001960
+JOHNSON,Overland Park Ward 03 Precinct 06,United States Senate,,Republican,"Roberts, Pat",314,001960
+JOHNSON,Overland Park Ward 03 Precinct 07,United States Senate,,independent,"Orman, Greg",236,001970
+JOHNSON,Overland Park Ward 03 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",17,001970
+JOHNSON,Overland Park Ward 03 Precinct 07,United States Senate,,Republican,"Roberts, Pat",153,001970
+JOHNSON,Overland Park Ward 03 Precinct 08,United States Senate,,independent,"Orman, Greg",258,001980
+JOHNSON,Overland Park Ward 03 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",8,001980
+JOHNSON,Overland Park Ward 03 Precinct 08,United States Senate,,Republican,"Roberts, Pat",278,001980
+JOHNSON,Overland Park Ward 03 Precinct 09,United States Senate,,independent,"Orman, Greg",392,001990
+JOHNSON,Overland Park Ward 03 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",13,001990
+JOHNSON,Overland Park Ward 03 Precinct 09,United States Senate,,Republican,"Roberts, Pat",341,001990
+JOHNSON,Overland Park Ward 03 Precinct 10,United States Senate,,independent,"Orman, Greg",203,002000
+JOHNSON,Overland Park Ward 03 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",9,002000
+JOHNSON,Overland Park Ward 03 Precinct 10,United States Senate,,Republican,"Roberts, Pat",204,002000
+JOHNSON,Overland Park Ward 03 Precinct 11,United States Senate,,independent,"Orman, Greg",241,002010
+JOHNSON,Overland Park Ward 03 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",7,002010
+JOHNSON,Overland Park Ward 03 Precinct 11,United States Senate,,Republican,"Roberts, Pat",270,002010
+JOHNSON,Overland Park Ward 03 Precinct 12,United States Senate,,independent,"Orman, Greg",200,002020
+JOHNSON,Overland Park Ward 03 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",9,002020
+JOHNSON,Overland Park Ward 03 Precinct 12,United States Senate,,Republican,"Roberts, Pat",131,002020
+JOHNSON,Overland Park Ward 05 Precinct 01,United States Senate,,independent,"Orman, Greg",300,002030
+JOHNSON,Overland Park Ward 05 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",13,002030
+JOHNSON,Overland Park Ward 05 Precinct 01,United States Senate,,Republican,"Roberts, Pat",316,002030
+JOHNSON,Overland Park Ward 03 Precinct 14,United States Senate,,independent,"Orman, Greg",344,002040
+JOHNSON,Overland Park Ward 03 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",21,002040
+JOHNSON,Overland Park Ward 03 Precinct 14,United States Senate,,Republican,"Roberts, Pat",240,002040
+JOHNSON,Overland Park Ward 03 Precinct 15,United States Senate,,independent,"Orman, Greg",166,002050
+JOHNSON,Overland Park Ward 03 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",7,002050
+JOHNSON,Overland Park Ward 03 Precinct 15,United States Senate,,Republican,"Roberts, Pat",210,002050
+JOHNSON,Overland Park Ward 05 Precinct 02,United States Senate,,independent,"Orman, Greg",150,002060
+JOHNSON,Overland Park Ward 05 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",13,002060
+JOHNSON,Overland Park Ward 05 Precinct 02,United States Senate,,Republican,"Roberts, Pat",140,002060
+JOHNSON,Overland Park Ward 05 Precinct 03,United States Senate,,independent,"Orman, Greg",268,002070
+JOHNSON,Overland Park Ward 05 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",11,002070
+JOHNSON,Overland Park Ward 05 Precinct 03,United States Senate,,Republican,"Roberts, Pat",309,002070
+JOHNSON,Overland Park Ward 05 Precinct 04,United States Senate,,independent,"Orman, Greg",269,002080
+JOHNSON,Overland Park Ward 05 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",14,002080
+JOHNSON,Overland Park Ward 05 Precinct 04,United States Senate,,Republican,"Roberts, Pat",264,002080
+JOHNSON,Overland Park Ward 05 Precinct 05,United States Senate,,independent,"Orman, Greg",245,002090
+JOHNSON,Overland Park Ward 05 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",14,002090
+JOHNSON,Overland Park Ward 05 Precinct 05,United States Senate,,Republican,"Roberts, Pat",169,002090
+JOHNSON,Overland Park Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",366,002120
+JOHNSON,Overland Park Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",14,002120
+JOHNSON,Overland Park Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",403,002120
+JOHNSON,Overland Park Ward 03 Precinct 13,United States Senate,,independent,"Orman, Greg",409,002130
+JOHNSON,Overland Park Ward 03 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",16,002130
+JOHNSON,Overland Park Ward 03 Precinct 13,United States Senate,,Republican,"Roberts, Pat",410,002130
+JOHNSON,Overland Park Ward 03 Precinct 18,United States Senate,,independent,"Orman, Greg",252,002140
+JOHNSON,Overland Park Ward 03 Precinct 18,United States Senate,,Libertarian,"Batson, Randall",14,002140
+JOHNSON,Overland Park Ward 03 Precinct 18,United States Senate,,Republican,"Roberts, Pat",183,002140
+JOHNSON,Overland Park Ward 03 Precinct 19,United States Senate,,independent,"Orman, Greg",259,002150
+JOHNSON,Overland Park Ward 03 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",22,002150
+JOHNSON,Overland Park Ward 03 Precinct 19,United States Senate,,Republican,"Roberts, Pat",235,002150
+JOHNSON,Overland Park Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",378,002160
+JOHNSON,Overland Park Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",12,002160
+JOHNSON,Overland Park Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",445,002160
+JOHNSON,Overland Park Ward 04 Precinct 07,United States Senate,,independent,"Orman, Greg",221,00217B
+JOHNSON,Overland Park Ward 04 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",9,00217B
+JOHNSON,Overland Park Ward 04 Precinct 07,United States Senate,,Republican,"Roberts, Pat",178,00217B
+JOHNSON,Overland Park Ward 04 Precinct 09,United States Senate,,independent,"Orman, Greg",196,002180
+JOHNSON,Overland Park Ward 04 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",4,002180
+JOHNSON,Overland Park Ward 04 Precinct 09,United States Senate,,Republican,"Roberts, Pat",380,002180
+JOHNSON,Overland Park Ward 04 Precinct 10,United States Senate,,independent,"Orman, Greg",158,002190
+JOHNSON,Overland Park Ward 04 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",6,002190
+JOHNSON,Overland Park Ward 04 Precinct 10,United States Senate,,Republican,"Roberts, Pat",246,002190
+JOHNSON,Overland Park Ward 04 Precinct 11,United States Senate,,independent,"Orman, Greg",329,002200
+JOHNSON,Overland Park Ward 04 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",13,002200
+JOHNSON,Overland Park Ward 04 Precinct 11,United States Senate,,Republican,"Roberts, Pat",362,002200
+JOHNSON,Overland Park Ward 04 Precinct 12,United States Senate,,independent,"Orman, Greg",427,002210
+JOHNSON,Overland Park Ward 04 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",13,002210
+JOHNSON,Overland Park Ward 04 Precinct 12,United States Senate,,Republican,"Roberts, Pat",479,002210
+JOHNSON,Overland Park Ward 04 Precinct 13,United States Senate,,independent,"Orman, Greg",148,00222A
+JOHNSON,Overland Park Ward 04 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",10,00222A
+JOHNSON,Overland Park Ward 04 Precinct 13,United States Senate,,Republican,"Roberts, Pat",282,00222A
+JOHNSON,Overland Park Ward 04 Precinct 15,United States Senate,,independent,"Orman, Greg",348,00222B
+JOHNSON,Overland Park Ward 04 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",17,00222B
+JOHNSON,Overland Park Ward 04 Precinct 15,United States Senate,,Republican,"Roberts, Pat",400,00222B
+JOHNSON,Overland Park Ward 04 Precinct 14,United States Senate,,independent,"Orman, Greg",139,002230
+JOHNSON,Overland Park Ward 04 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",8,002230
+JOHNSON,Overland Park Ward 04 Precinct 14,United States Senate,,Republican,"Roberts, Pat",227,002230
+JOHNSON,Overland Park Ward 04 Precinct 05,United States Senate,,independent,"Orman, Greg",273,002240
+JOHNSON,Overland Park Ward 04 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",12,002240
+JOHNSON,Overland Park Ward 04 Precinct 05,United States Senate,,Republican,"Roberts, Pat",315,002240
+JOHNSON,Overland Park Ward 06 Precinct 03,United States Senate,,independent,"Orman, Greg",266,00226A
+JOHNSON,Overland Park Ward 06 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",6,00226A
+JOHNSON,Overland Park Ward 06 Precinct 03,United States Senate,,Republican,"Roberts, Pat",351,00226A
+JOHNSON,Overland Park Ward 06 Precinct 04,United States Senate,,independent,"Orman, Greg",241,00226B
+JOHNSON,Overland Park Ward 06 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",2,00226B
+JOHNSON,Overland Park Ward 06 Precinct 04,United States Senate,,Republican,"Roberts, Pat",351,00226B
+JOHNSON,Overland Park Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",300,002280
+JOHNSON,Overland Park Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",9,002280
+JOHNSON,Overland Park Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",186,002280
+JOHNSON,Overland Park Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",247,002290
+JOHNSON,Overland Park Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",10,002290
+JOHNSON,Overland Park Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",181,002290
+JOHNSON,Overland Park Ward 02 Precinct 22,United States Senate,,independent,"Orman, Greg",266,002300
+JOHNSON,Overland Park Ward 02 Precinct 22,United States Senate,,Libertarian,"Batson, Randall",7,002300
+JOHNSON,Overland Park Ward 02 Precinct 22,United States Senate,,Republican,"Roberts, Pat",170,002300
+JOHNSON,Overland Park Ward 02 Precinct 19,United States Senate,,independent,"Orman, Greg",227,002320
+JOHNSON,Overland Park Ward 02 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",10,002320
+JOHNSON,Overland Park Ward 02 Precinct 19,United States Senate,,Republican,"Roberts, Pat",161,002320
+JOHNSON,Overland Park Ward 02 Precinct 21,United States Senate,,independent,"Orman, Greg",245,002330
+JOHNSON,Overland Park Ward 02 Precinct 21,United States Senate,,Libertarian,"Batson, Randall",10,002330
+JOHNSON,Overland Park Ward 02 Precinct 21,United States Senate,,Republican,"Roberts, Pat",154,002330
+JOHNSON,Overland Park Ward 02 Precinct 24,United States Senate,,independent,"Orman, Greg",379,002340
+JOHNSON,Overland Park Ward 02 Precinct 24,United States Senate,,Libertarian,"Batson, Randall",12,002340
+JOHNSON,Overland Park Ward 02 Precinct 24,United States Senate,,Republican,"Roberts, Pat",342,002340
+JOHNSON,Overland Park Ward 02 Precinct 25,United States Senate,,independent,"Orman, Greg",317,002350
+JOHNSON,Overland Park Ward 02 Precinct 25,United States Senate,,Libertarian,"Batson, Randall",4,002350
+JOHNSON,Overland Park Ward 02 Precinct 25,United States Senate,,Republican,"Roberts, Pat",270,002350
+JOHNSON,Overland Park Ward 05 Precinct 10,United States Senate,,independent,"Orman, Greg",287,002370
+JOHNSON,Overland Park Ward 05 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",11,002370
+JOHNSON,Overland Park Ward 05 Precinct 10,United States Senate,,Republican,"Roberts, Pat",312,002370
+JOHNSON,Overland Park Ward 05 Precinct 11,United States Senate,,independent,"Orman, Greg",387,002380
+JOHNSON,Overland Park Ward 05 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",16,002380
+JOHNSON,Overland Park Ward 05 Precinct 11,United States Senate,,Republican,"Roberts, Pat",330,002380
+JOHNSON,Overland Park Ward 05 Precinct 13,United States Senate,,independent,"Orman, Greg",425,002400
+JOHNSON,Overland Park Ward 05 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",18,002400
+JOHNSON,Overland Park Ward 05 Precinct 13,United States Senate,,Republican,"Roberts, Pat",368,002400
+JOHNSON,Overland Park Ward 05 Precinct 14,United States Senate,,independent,"Orman, Greg",303,002410
+JOHNSON,Overland Park Ward 05 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",7,002410
+JOHNSON,Overland Park Ward 05 Precinct 14,United States Senate,,Republican,"Roberts, Pat",319,002410
+JOHNSON,Overland Park Ward 05 Precinct 09,United States Senate,,independent,"Orman, Greg",386,00242B
+JOHNSON,Overland Park Ward 05 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",10,00242B
+JOHNSON,Overland Park Ward 05 Precinct 09,United States Senate,,Republican,"Roberts, Pat",427,00242B
+JOHNSON,Overland Park Ward 06 Precinct 05,United States Senate,,independent,"Orman, Greg",315,00244A
+JOHNSON,Overland Park Ward 06 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",12,00244A
+JOHNSON,Overland Park Ward 06 Precinct 05,United States Senate,,Republican,"Roberts, Pat",369,00244A
+JOHNSON,Overland Park Ward 05 Precinct 06,United States Senate,,independent,"Orman, Greg",224,00244B
+JOHNSON,Overland Park Ward 05 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",10,00244B
+JOHNSON,Overland Park Ward 05 Precinct 06,United States Senate,,Republican,"Roberts, Pat",240,00244B
+JOHNSON,Overland Park Ward 06 Precinct 11,United States Senate,,independent,"Orman, Greg",233,002460
+JOHNSON,Overland Park Ward 06 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",14,002460
+JOHNSON,Overland Park Ward 06 Precinct 11,United States Senate,,Republican,"Roberts, Pat",302,002460
+JOHNSON,Overland Park Ward 06 Precinct 12,United States Senate,,independent,"Orman, Greg",116,002470
+JOHNSON,Overland Park Ward 06 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",2,002470
+JOHNSON,Overland Park Ward 06 Precinct 12,United States Senate,,Republican,"Roberts, Pat",138,002470
+JOHNSON,Oxford Township Precinct 05,United States Senate,,independent,"Orman, Greg",0,00249C
+JOHNSON,Oxford Township Precinct 05,United States Senate,,Libertarian,"Batson, Randall",0,00249C
+JOHNSON,Oxford Township Precinct 05,United States Senate,,Republican,"Roberts, Pat",10,00249C
+JOHNSON,Oxford Township Precinct 04,United States Senate,,independent,"Orman, Greg",153,00249E
+JOHNSON,Oxford Township Precinct 04,United States Senate,,Libertarian,"Batson, Randall",5,00249E
+JOHNSON,Oxford Township Precinct 04,United States Senate,,Republican,"Roberts, Pat",194,00249E
+JOHNSON,Oxford Township Precinct 02,United States Senate,,independent,"Orman, Greg",184,00249F
+JOHNSON,Oxford Township Precinct 02,United States Senate,,Libertarian,"Batson, Randall",9,00249F
+JOHNSON,Oxford Township Precinct 02,United States Senate,,Republican,"Roberts, Pat",263,00249F
+JOHNSON,Prairie Village Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",434,002500
+JOHNSON,Prairie Village Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",9,002500
+JOHNSON,Prairie Village Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",269,002500
+JOHNSON,Prairie Village Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",308,002510
+JOHNSON,Prairie Village Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",7,002510
+JOHNSON,Prairie Village Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",178,002510
+JOHNSON,Prairie Village Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",430,002520
+JOHNSON,Prairie Village Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",8,002520
+JOHNSON,Prairie Village Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",256,002520
+JOHNSON,Prairie Village Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",374,002530
+JOHNSON,Prairie Village Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",7,002530
+JOHNSON,Prairie Village Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",187,002530
+JOHNSON,Prairie Village Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",155,002540
+JOHNSON,Prairie Village Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",10,002540
+JOHNSON,Prairie Village Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",104,002540
+JOHNSON,Prairie Village Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",316,002550
+JOHNSON,Prairie Village Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",16,002550
+JOHNSON,Prairie Village Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",169,002550
+JOHNSON,Prairie Village Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",231,002560
+JOHNSON,Prairie Village Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",12,002560
+JOHNSON,Prairie Village Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",162,002560
+JOHNSON,Prairie Village Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",358,002570
+JOHNSON,Prairie Village Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",9,002570
+JOHNSON,Prairie Village Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",224,002570
+JOHNSON,Prairie Village Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",343,002580
+JOHNSON,Prairie Village Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",6,002580
+JOHNSON,Prairie Village Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",193,002580
+JOHNSON,Prairie Village Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",351,002590
+JOHNSON,Prairie Village Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",6,002590
+JOHNSON,Prairie Village Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",327,002590
+JOHNSON,Prairie Village Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",244,002600
+JOHNSON,Prairie Village Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",13,002600
+JOHNSON,Prairie Village Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",164,002600
+JOHNSON,Prairie Village Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",408,002610
+JOHNSON,Prairie Village Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",12,002610
+JOHNSON,Prairie Village Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",255,002610
+JOHNSON,Prairie Village Ward 05 Precinct 01,United States Senate,,independent,"Orman, Greg",394,002620
+JOHNSON,Prairie Village Ward 05 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",8,002620
+JOHNSON,Prairie Village Ward 05 Precinct 01,United States Senate,,Republican,"Roberts, Pat",251,002620
+JOHNSON,Prairie Village Ward 05 Precinct 02,United States Senate,,independent,"Orman, Greg",364,002630
+JOHNSON,Prairie Village Ward 05 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",12,002630
+JOHNSON,Prairie Village Ward 05 Precinct 02,United States Senate,,Republican,"Roberts, Pat",314,002630
+JOHNSON,Prairie Village Ward 05 Precinct 03,United States Senate,,independent,"Orman, Greg",266,002640
+JOHNSON,Prairie Village Ward 05 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",15,002640
+JOHNSON,Prairie Village Ward 05 Precinct 03,United States Senate,,Republican,"Roberts, Pat",255,002640
+JOHNSON,Prairie Village Ward 06 Precinct 01,United States Senate,,independent,"Orman, Greg",399,002650
+JOHNSON,Prairie Village Ward 06 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",13,002650
+JOHNSON,Prairie Village Ward 06 Precinct 01,United States Senate,,Republican,"Roberts, Pat",264,002650
+JOHNSON,Prairie Village Ward 06 Precinct 02,United States Senate,,independent,"Orman, Greg",355,002660
+JOHNSON,Prairie Village Ward 06 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",20,002660
+JOHNSON,Prairie Village Ward 06 Precinct 02,United States Senate,,Republican,"Roberts, Pat",168,002660
+JOHNSON,Prairie Village Ward 06 Precinct 03,United States Senate,,independent,"Orman, Greg",198,002670
+JOHNSON,Prairie Village Ward 06 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,002670
+JOHNSON,Prairie Village Ward 06 Precinct 03,United States Senate,,Republican,"Roberts, Pat",128,002670
+JOHNSON,Roeland Park Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",143,002680
+JOHNSON,Roeland Park Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",14,002680
+JOHNSON,Roeland Park Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",76,002680
+JOHNSON,Roeland Park Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",128,002690
+JOHNSON,Roeland Park Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",5,002690
+JOHNSON,Roeland Park Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",53,002690
+JOHNSON,Roeland Park Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",176,002700
+JOHNSON,Roeland Park Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",9,002700
+JOHNSON,Roeland Park Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",84,002700
+JOHNSON,Roeland Park Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",220,002710
+JOHNSON,Roeland Park Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",9,002710
+JOHNSON,Roeland Park Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",140,002710
+JOHNSON,Roeland Park Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",170,002720
+JOHNSON,Roeland Park Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",10,002720
+JOHNSON,Roeland Park Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",47,002720
+JOHNSON,Roeland Park Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",321,002730
+JOHNSON,Roeland Park Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",9,002730
+JOHNSON,Roeland Park Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",127,002730
+JOHNSON,Roeland Park Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",122,002740
+JOHNSON,Roeland Park Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",5,002740
+JOHNSON,Roeland Park Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",79,002740
+JOHNSON,Roeland Park Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",383,002750
+JOHNSON,Roeland Park Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",23,002750
+JOHNSON,Roeland Park Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",229,002750
+JOHNSON,Shawnee City Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",339,002760
+JOHNSON,Shawnee City Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",17,002760
+JOHNSON,Shawnee City Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",283,002760
+JOHNSON,Shawnee City Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",247,002770
+JOHNSON,Shawnee City Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",17,002770
+JOHNSON,Shawnee City Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",220,002770
+JOHNSON,Shawnee City Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",226,002780
+JOHNSON,Shawnee City Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",17,002780
+JOHNSON,Shawnee City Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",208,002780
+JOHNSON,Shawnee City Ward 01 Precinct 04,United States Senate,,independent,"Orman, Greg",351,002790
+JOHNSON,Shawnee City Ward 01 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",12,002790
+JOHNSON,Shawnee City Ward 01 Precinct 04,United States Senate,,Republican,"Roberts, Pat",402,002790
+JOHNSON,Shawnee City Ward 01 Precinct 05,United States Senate,,independent,"Orman, Greg",414,002800
+JOHNSON,Shawnee City Ward 01 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",14,002800
+JOHNSON,Shawnee City Ward 01 Precinct 05,United States Senate,,Republican,"Roberts, Pat",393,002800
+JOHNSON,Shawnee City Ward 01 Precinct 06,United States Senate,,independent,"Orman, Greg",284,002810
+JOHNSON,Shawnee City Ward 01 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",11,002810
+JOHNSON,Shawnee City Ward 01 Precinct 06,United States Senate,,Republican,"Roberts, Pat",363,002810
+JOHNSON,Shawnee City Ward 01 Precinct 07,United States Senate,,independent,"Orman, Greg",316,002820
+JOHNSON,Shawnee City Ward 01 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",20,002820
+JOHNSON,Shawnee City Ward 01 Precinct 07,United States Senate,,Republican,"Roberts, Pat",314,002820
+JOHNSON,Shawnee City Ward 01 Precinct 08,United States Senate,,independent,"Orman, Greg",303,002830
+JOHNSON,Shawnee City Ward 01 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",19,002830
+JOHNSON,Shawnee City Ward 01 Precinct 08,United States Senate,,Republican,"Roberts, Pat",349,002830
+JOHNSON,Shawnee City Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",133,002850
+JOHNSON,Shawnee City Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",26,002850
+JOHNSON,Shawnee City Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",118,002850
+JOHNSON,Shawnee City Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",255,002860
+JOHNSON,Shawnee City Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",27,002860
+JOHNSON,Shawnee City Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",252,002860
+JOHNSON,Shawnee City Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",213,002870
+JOHNSON,Shawnee City Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",20,002870
+JOHNSON,Shawnee City Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",168,002870
+JOHNSON,Shawnee City Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",350,002880
+JOHNSON,Shawnee City Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",19,002880
+JOHNSON,Shawnee City Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",269,002880
+JOHNSON,Shawnee City Ward 02 Precinct 05,United States Senate,,independent,"Orman, Greg",148,002890
+JOHNSON,Shawnee City Ward 02 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",15,002890
+JOHNSON,Shawnee City Ward 02 Precinct 05,United States Senate,,Republican,"Roberts, Pat",139,002890
+JOHNSON,Shawnee City Ward 02 Precinct 06,United States Senate,,independent,"Orman, Greg",193,002900
+JOHNSON,Shawnee City Ward 02 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",12,002900
+JOHNSON,Shawnee City Ward 02 Precinct 06,United States Senate,,Republican,"Roberts, Pat",235,002900
+JOHNSON,Shawnee City Ward 02 Precinct 07,United States Senate,,independent,"Orman, Greg",177,002910
+JOHNSON,Shawnee City Ward 02 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",22,002910
+JOHNSON,Shawnee City Ward 02 Precinct 07,United States Senate,,Republican,"Roberts, Pat",149,002910
+JOHNSON,Shawnee City Ward 02 Precinct 08,United States Senate,,independent,"Orman, Greg",165,002920
+JOHNSON,Shawnee City Ward 02 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",11,002920
+JOHNSON,Shawnee City Ward 02 Precinct 08,United States Senate,,Republican,"Roberts, Pat",163,002920
+JOHNSON,Shawnee City Ward 04 Precinct 05,United States Senate,,independent,"Orman, Greg",313,002930
+JOHNSON,Shawnee City Ward 04 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",17,002930
+JOHNSON,Shawnee City Ward 04 Precinct 05,United States Senate,,Republican,"Roberts, Pat",287,002930
+JOHNSON,Shawnee City Ward 04 Precinct 06,United States Senate,,independent,"Orman, Greg",240,002940
+JOHNSON,Shawnee City Ward 04 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",22,002940
+JOHNSON,Shawnee City Ward 04 Precinct 06,United States Senate,,Republican,"Roberts, Pat",277,002940
+JOHNSON,Shawnee City Ward 03 Precinct 04,United States Senate,,independent,"Orman, Greg",224,002960
+JOHNSON,Shawnee City Ward 03 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",10,002960
+JOHNSON,Shawnee City Ward 03 Precinct 04,United States Senate,,Republican,"Roberts, Pat",314,002960
+JOHNSON,Shawnee City Ward 03 Precinct 06,United States Senate,,independent,"Orman, Greg",248,002980
+JOHNSON,Shawnee City Ward 03 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",20,002980
+JOHNSON,Shawnee City Ward 03 Precinct 06,United States Senate,,Republican,"Roberts, Pat",274,002980
+JOHNSON,Shawnee City Ward 03 Precinct 07,United States Senate,,independent,"Orman, Greg",301,002990
+JOHNSON,Shawnee City Ward 03 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",27,002990
+JOHNSON,Shawnee City Ward 03 Precinct 07,United States Senate,,Republican,"Roberts, Pat",387,002990
+JOHNSON,Shawnee City Ward 03 Precinct 08,United States Senate,,independent,"Orman, Greg",290,003000
+JOHNSON,Shawnee City Ward 03 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",11,003000
+JOHNSON,Shawnee City Ward 03 Precinct 08,United States Senate,,Republican,"Roberts, Pat",357,003000
+JOHNSON,Shawnee City Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",342,003010
+JOHNSON,Shawnee City Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",17,003010
+JOHNSON,Shawnee City Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",415,003010
+JOHNSON,Shawnee City Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",156,003020
+JOHNSON,Shawnee City Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",9,003020
+JOHNSON,Shawnee City Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",242,003020
+JOHNSON,Shawnee City Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",201,003040
+JOHNSON,Shawnee City Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",10,003040
+JOHNSON,Shawnee City Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",222,003040
+JOHNSON,Shawnee City Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",86,003050
+JOHNSON,Shawnee City Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",6,003050
+JOHNSON,Shawnee City Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",93,003050
+JOHNSON,Shawnee City Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",122,003060
+JOHNSON,Shawnee City Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",12,003060
+JOHNSON,Shawnee City Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",71,003060
+JOHNSON,Shawnee City Ward 02 Precinct 09,United States Senate,,independent,"Orman, Greg",172,003070
+JOHNSON,Shawnee City Ward 02 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",17,003070
+JOHNSON,Shawnee City Ward 02 Precinct 09,United States Senate,,Republican,"Roberts, Pat",137,003070
+JOHNSON,Shawnee City Ward 04 Precinct 07,United States Senate,,independent,"Orman, Greg",366,003090
+JOHNSON,Shawnee City Ward 04 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",22,003090
+JOHNSON,Shawnee City Ward 04 Precinct 07,United States Senate,,Republican,"Roberts, Pat",358,003090
+JOHNSON,Spring Hill City Precinct 01,United States Senate,,independent,"Orman, Greg",322,00311A
+JOHNSON,Spring Hill City Precinct 01,United States Senate,,Libertarian,"Batson, Randall",43,00311A
+JOHNSON,Spring Hill City Precinct 01,United States Senate,,Republican,"Roberts, Pat",522,00311A
+JOHNSON,Spring Hill City Precinct 03,United States Senate,,independent,"Orman, Greg",23,00311D
+JOHNSON,Spring Hill City Precinct 03,United States Senate,,Libertarian,"Batson, Randall",3,00311D
+JOHNSON,Spring Hill City Precinct 03,United States Senate,,Republican,"Roberts, Pat",34,00311D
+JOHNSON,Spring Hill Township Precinct 01,United States Senate,,independent,"Orman, Greg",237,003120
+JOHNSON,Spring Hill Township Precinct 01,United States Senate,,Libertarian,"Batson, Randall",27,003120
+JOHNSON,Spring Hill Township Precinct 01,United States Senate,,Republican,"Roberts, Pat",407,003120
+JOHNSON,Westwood Hills Precinct 01,United States Senate,,independent,"Orman, Greg",144,003130
+JOHNSON,Westwood Hills Precinct 01,United States Senate,,Libertarian,"Batson, Randall",4,003130
+JOHNSON,Westwood Hills Precinct 01,United States Senate,,Republican,"Roberts, Pat",57,003130
+JOHNSON,Westwood Precinct 01,United States Senate,,independent,"Orman, Greg",240,003140
+JOHNSON,Westwood Precinct 01,United States Senate,,Libertarian,"Batson, Randall",13,003140
+JOHNSON,Westwood Precinct 01,United States Senate,,Republican,"Roberts, Pat",92,003140
+JOHNSON,Westwood Precinct 02,United States Senate,,independent,"Orman, Greg",230,003150
+JOHNSON,Westwood Precinct 02,United States Senate,,Libertarian,"Batson, Randall",4,003150
+JOHNSON,Westwood Precinct 02,United States Senate,,Republican,"Roberts, Pat",120,003150
+JOHNSON,Lexington Township Precinct 02,United States Senate,,independent,"Orman, Greg",2,004070
+JOHNSON,Lexington Township Precinct 02,United States Senate,,Libertarian,"Batson, Randall",0,004070
+JOHNSON,Lexington Township Precinct 02,United States Senate,,Republican,"Roberts, Pat",1,004070
+JOHNSON,Lexington Township Precinct 03,United States Senate,,independent,"Orman, Greg",2,004080
+JOHNSON,Lexington Township Precinct 03,United States Senate,,Libertarian,"Batson, Randall",0,004080
+JOHNSON,Lexington Township Precinct 03,United States Senate,,Republican,"Roberts, Pat",0,004080
+JOHNSON,Olathe City Ward 02 Precinct 19,United States Senate,,independent,"Orman, Greg",1,004140
+JOHNSON,Olathe City Ward 02 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",0,004140
+JOHNSON,Olathe City Ward 02 Precinct 19,United States Senate,,Republican,"Roberts, Pat",5,004140
+JOHNSON,Olathe Township Part 08,United States Senate,,independent,"Orman, Greg",2,004180
+JOHNSON,Olathe Township Part 08,United States Senate,,Libertarian,"Batson, Randall",0,004180
+JOHNSON,Olathe Township Part 08,United States Senate,,Republican,"Roberts, Pat",4,004180
+JOHNSON,Olathe Township Part 10,United States Senate,,independent,"Orman, Greg",5,004190
+JOHNSON,Olathe Township Part 10,United States Senate,,Libertarian,"Batson, Randall",0,004190
+JOHNSON,Olathe Township Part 10,United States Senate,,Republican,"Roberts, Pat",6,004190
+JOHNSON,McCamish Township Precinct 02,United States Senate,,independent,"Orman, Greg",95,100030
+JOHNSON,McCamish Township Precinct 02,United States Senate,,Libertarian,"Batson, Randall",9,100030
+JOHNSON,McCamish Township Precinct 02,United States Senate,,Republican,"Roberts, Pat",186,100030
+JOHNSON,Leawood Ward 01 Precinct 06,United States Senate,,independent,"Orman, Greg",79,120130
+JOHNSON,Leawood Ward 01 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",0,120130
+JOHNSON,Leawood Ward 01 Precinct 06,United States Senate,,Republican,"Roberts, Pat",50,120130
+JOHNSON,Leawood Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",311,120140
+JOHNSON,Leawood Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",9,120140
+JOHNSON,Leawood Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",185,120140
+JOHNSON,Merriam Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",1,120260
+JOHNSON,Merriam Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",0,120260
+JOHNSON,Merriam Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",0,120260
+JOHNSON,Merriam Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",193,120280
+JOHNSON,Merriam Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,120280
+JOHNSON,Merriam Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",111,120280
+JOHNSON,Overland Park Ward 02 Precinct 10,United States Senate,,independent,"Orman, Greg",118,120660
+JOHNSON,Overland Park Ward 02 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",12,120660
+JOHNSON,Overland Park Ward 02 Precinct 10,United States Senate,,Republican,"Roberts, Pat",183,120660
+JOHNSON,Overland Park Ward 02 Precinct 26,United States Senate,,independent,"Orman, Greg",130,120670
+JOHNSON,Overland Park Ward 02 Precinct 26,United States Senate,,Libertarian,"Batson, Randall",4,120670
+JOHNSON,Overland Park Ward 02 Precinct 26,United States Senate,,Republican,"Roberts, Pat",84,120670
+JOHNSON,Overland Park Ward 04 Precinct 08,United States Senate,,independent,"Orman, Greg",276,120680
+JOHNSON,Overland Park Ward 04 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",6,120680
+JOHNSON,Overland Park Ward 04 Precinct 08,United States Senate,,Republican,"Roberts, Pat",317,120680
+JOHNSON,Overland Park Ward 04 Precinct 18,United States Senate,,independent,"Orman, Greg",55,120690
+JOHNSON,Overland Park Ward 04 Precinct 18,United States Senate,,Libertarian,"Batson, Randall",2,120690
+JOHNSON,Overland Park Ward 04 Precinct 18,United States Senate,,Republican,"Roberts, Pat",46,120690
+JOHNSON,Overland Park Ward 05 Precinct 12,United States Senate,,independent,"Orman, Greg",73,120700
+JOHNSON,Overland Park Ward 05 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",5,120700
+JOHNSON,Overland Park Ward 05 Precinct 12,United States Senate,,Republican,"Roberts, Pat",78,120700
+JOHNSON,Overland Park Ward 05 Precinct 19,United States Senate,,independent,"Orman, Greg",22,120710
+JOHNSON,Overland Park Ward 05 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",0,120710
+JOHNSON,Overland Park Ward 05 Precinct 19,United States Senate,,Republican,"Roberts, Pat",30,120710
+JOHNSON,Overland Park Ward 05 Precinct 15,United States Senate,,independent,"Orman, Greg",231,120730
+JOHNSON,Overland Park Ward 05 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",12,120730
+JOHNSON,Overland Park Ward 05 Precinct 15,United States Senate,,Republican,"Roberts, Pat",192,120730
+JOHNSON,Lenexa Ward 01 Precinct 08,United States Senate,,independent,"Orman, Greg",82,140010
+JOHNSON,Lenexa Ward 01 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",5,140010
+JOHNSON,Lenexa Ward 01 Precinct 08,United States Senate,,Republican,"Roberts, Pat",78,140010
+JOHNSON,Lenexa Ward 01 Precinct 09,United States Senate,,independent,"Orman, Greg",5,140020
+JOHNSON,Lenexa Ward 01 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",0,140020
+JOHNSON,Lenexa Ward 01 Precinct 09,United States Senate,,Republican,"Roberts, Pat",7,140020
+JOHNSON,Lenexa Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",167,140030
+JOHNSON,Lenexa Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",4,140030
+JOHNSON,Lenexa Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",129,140030
+JOHNSON,Lenexa Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",145,140040
+JOHNSON,Lenexa Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",11,140040
+JOHNSON,Lenexa Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",91,140040
+JOHNSON,Lenexa Ward 04 Precinct 10,United States Senate,,independent,"Orman, Greg",152,140050
+JOHNSON,Lenexa Ward 04 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",8,140050
+JOHNSON,Lenexa Ward 04 Precinct 10,United States Senate,,Republican,"Roberts, Pat",113,140050
+JOHNSON,Lenexa Ward 04 Precinct 11,United States Senate,,independent,"Orman, Greg",42,140060
+JOHNSON,Lenexa Ward 04 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",3,140060
+JOHNSON,Lenexa Ward 04 Precinct 11,United States Senate,,Republican,"Roberts, Pat",31,140060
+JOHNSON,McCamish Township Precinct 01,United States Senate,,independent,"Orman, Greg",36,140070
+JOHNSON,McCamish Township Precinct 01,United States Senate,,Libertarian,"Batson, Randall",6,140070
+JOHNSON,McCamish Township Precinct 01,United States Senate,,Republican,"Roberts, Pat",103,140070
+JOHNSON,Merriam Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",160,140080
+JOHNSON,Merriam Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,140080
+JOHNSON,Merriam Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",96,140080
+JOHNSON,Merriam Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",139,140090
+JOHNSON,Merriam Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",7,140090
+JOHNSON,Merriam Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",96,140090
+JOHNSON,Olathe City Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",254,140100
+JOHNSON,Olathe City Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",26,140100
+JOHNSON,Olathe City Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",272,140100
+JOHNSON,Olathe City Ward 01 Precinct 04,United States Senate,,independent,"Orman, Greg",246,140110
+JOHNSON,Olathe City Ward 01 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",24,140110
+JOHNSON,Olathe City Ward 01 Precinct 04,United States Senate,,Republican,"Roberts, Pat",263,140110
+JOHNSON,Olathe City Ward 01 Precinct 06,United States Senate,,independent,"Orman, Greg",141,140120
+JOHNSON,Olathe City Ward 01 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",11,140120
+JOHNSON,Olathe City Ward 01 Precinct 06,United States Senate,,Republican,"Roberts, Pat",209,140120
+JOHNSON,Olathe City Ward 01 Precinct 11,United States Senate,,independent,"Orman, Greg",49,140130
+JOHNSON,Olathe City Ward 01 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",10,140130
+JOHNSON,Olathe City Ward 01 Precinct 11,United States Senate,,Republican,"Roberts, Pat",45,140130
+JOHNSON,Olathe City Ward 01 Precinct 15,United States Senate,,independent,"Orman, Greg",214,140140
+JOHNSON,Olathe City Ward 01 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",15,140140
+JOHNSON,Olathe City Ward 01 Precinct 15,United States Senate,,Republican,"Roberts, Pat",260,140140
+JOHNSON,Olathe City Ward 01 Precinct 25,United States Senate,,independent,"Orman, Greg",66,140150
+JOHNSON,Olathe City Ward 01 Precinct 25,United States Senate,,Libertarian,"Batson, Randall",11,140150
+JOHNSON,Olathe City Ward 01 Precinct 25,United States Senate,,Republican,"Roberts, Pat",79,140150
+JOHNSON,Olathe City Ward 01 Precinct 26,United States Senate,,independent,"Orman, Greg",2,140160
+JOHNSON,Olathe City Ward 01 Precinct 26,United States Senate,,Libertarian,"Batson, Randall",0,140160
+JOHNSON,Olathe City Ward 01 Precinct 26,United States Senate,,Republican,"Roberts, Pat",0,140160
+JOHNSON,Olathe City Ward 01 Precinct 27,United States Senate,,independent,"Orman, Greg",193,140170
+JOHNSON,Olathe City Ward 01 Precinct 27,United States Senate,,Libertarian,"Batson, Randall",19,140170
+JOHNSON,Olathe City Ward 01 Precinct 27,United States Senate,,Republican,"Roberts, Pat",186,140170
+JOHNSON,Olathe City Ward 02 Precinct 13,United States Senate,,independent,"Orman, Greg",228,140180
+JOHNSON,Olathe City Ward 02 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",12,140180
+JOHNSON,Olathe City Ward 02 Precinct 13,United States Senate,,Republican,"Roberts, Pat",200,140180
+JOHNSON,Olathe City Ward 02 Precinct 23,United States Senate,,independent,"Orman, Greg",264,140190
+JOHNSON,Olathe City Ward 02 Precinct 23,United States Senate,,Libertarian,"Batson, Randall",8,140190
+JOHNSON,Olathe City Ward 02 Precinct 23,United States Senate,,Republican,"Roberts, Pat",289,140190
+JOHNSON,Olathe City Ward 03 Precinct 11,United States Senate,,independent,"Orman, Greg",192,140200
+JOHNSON,Olathe City Ward 03 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",13,140200
+JOHNSON,Olathe City Ward 03 Precinct 11,United States Senate,,Republican,"Roberts, Pat",219,140200
+JOHNSON,Olathe City Ward 03 Precinct 16,United States Senate,,independent,"Orman, Greg",203,140210
+JOHNSON,Olathe City Ward 03 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",8,140210
+JOHNSON,Olathe City Ward 03 Precinct 16,United States Senate,,Republican,"Roberts, Pat",252,140210
+JOHNSON,Olathe City Ward 03 Precinct 26,United States Senate,,independent,"Orman, Greg",28,140220
+JOHNSON,Olathe City Ward 03 Precinct 26,United States Senate,,Libertarian,"Batson, Randall",3,140220
+JOHNSON,Olathe City Ward 03 Precinct 26,United States Senate,,Republican,"Roberts, Pat",22,140220
+JOHNSON,Olathe City Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",140,140230
+JOHNSON,Olathe City Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",21,140230
+JOHNSON,Olathe City Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",101,140230
+JOHNSON,Olathe City Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",155,140240
+JOHNSON,Olathe City Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",8,140240
+JOHNSON,Olathe City Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",129,140240
+JOHNSON,Olathe City Ward 04 Precinct 11,United States Senate,,independent,"Orman, Greg",143,140250
+JOHNSON,Olathe City Ward 04 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",12,140250
+JOHNSON,Olathe City Ward 04 Precinct 11,United States Senate,,Republican,"Roberts, Pat",96,140250
+JOHNSON,Olathe City Ward 04 Precinct 15,United States Senate,,independent,"Orman, Greg",14,140260
+JOHNSON,Olathe City Ward 04 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",2,140260
+JOHNSON,Olathe City Ward 04 Precinct 15,United States Senate,,Republican,"Roberts, Pat",17,140260
+JOHNSON,Olathe City Ward 04 Precinct 16,United States Senate,,independent,"Orman, Greg",108,140270
+JOHNSON,Olathe City Ward 04 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",5,140270
+JOHNSON,Olathe City Ward 04 Precinct 16,United States Senate,,Republican,"Roberts, Pat",87,140270
+JOHNSON,Olathe City Ward 04 Precinct 17,United States Senate,,independent,"Orman, Greg",2,140280
+JOHNSON,Olathe City Ward 04 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",0,140280
+JOHNSON,Olathe City Ward 04 Precinct 17,United States Senate,,Republican,"Roberts, Pat",1,140280
+JOHNSON,Olathe Township Part 02,United States Senate,,independent,"Orman, Greg",18,140290
+JOHNSON,Olathe Township Part 02,United States Senate,,Libertarian,"Batson, Randall",2,140290
+JOHNSON,Olathe Township Part 02,United States Senate,,Republican,"Roberts, Pat",34,140290
+JOHNSON,Olathe Township Part 14,United States Senate,,independent,"Orman, Greg",0,140300
+JOHNSON,Olathe Township Part 14,United States Senate,,Libertarian,"Batson, Randall",0,140300
+JOHNSON,Olathe Township Part 14,United States Senate,,Republican,"Roberts, Pat",1,140300
+JOHNSON,Olathe Township Part 25,United States Senate,,independent,"Orman, Greg",1,140310
+JOHNSON,Olathe Township Part 25,United States Senate,,Libertarian,"Batson, Randall",0,140310
+JOHNSON,Olathe Township Part 25,United States Senate,,Republican,"Roberts, Pat",7,140310
+JOHNSON,Overland Park Ward 01 Precinct 04,United States Senate,,independent,"Orman, Greg",92,140320
+JOHNSON,Overland Park Ward 01 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",6,140320
+JOHNSON,Overland Park Ward 01 Precinct 04,United States Senate,,Republican,"Roberts, Pat",72,140320
+JOHNSON,Overland Park Ward 01 Precinct 05,United States Senate,,independent,"Orman, Greg",212,140330
+JOHNSON,Overland Park Ward 01 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",17,140330
+JOHNSON,Overland Park Ward 01 Precinct 05,United States Senate,,Republican,"Roberts, Pat",109,140330
+JOHNSON,Overland Park Ward 01 Precinct 09,United States Senate,,independent,"Orman, Greg",160,140340
+JOHNSON,Overland Park Ward 01 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",18,140340
+JOHNSON,Overland Park Ward 01 Precinct 09,United States Senate,,Republican,"Roberts, Pat",97,140340
+JOHNSON,Overland Park Ward 01 Precinct 20,United States Senate,,independent,"Orman, Greg",190,140350
+JOHNSON,Overland Park Ward 01 Precinct 20,United States Senate,,Libertarian,"Batson, Randall",6,140350
+JOHNSON,Overland Park Ward 01 Precinct 20,United States Senate,,Republican,"Roberts, Pat",108,140350
+JOHNSON,Overland Park Ward 01 Precinct 21,United States Senate,,independent,"Orman, Greg",80,140360
+JOHNSON,Overland Park Ward 01 Precinct 21,United States Senate,,Libertarian,"Batson, Randall",4,140360
+JOHNSON,Overland Park Ward 01 Precinct 21,United States Senate,,Republican,"Roberts, Pat",65,140360
+JOHNSON,Overland Park Ward 01 Precinct 22,United States Senate,,independent,"Orman, Greg",65,140370
+JOHNSON,Overland Park Ward 01 Precinct 22,United States Senate,,Libertarian,"Batson, Randall",7,140370
+JOHNSON,Overland Park Ward 01 Precinct 22,United States Senate,,Republican,"Roberts, Pat",43,140370
+JOHNSON,Overland Park Ward 03 Precinct 21,United States Senate,,independent,"Orman, Greg",244,140380
+JOHNSON,Overland Park Ward 03 Precinct 21,United States Senate,,Libertarian,"Batson, Randall",8,140380
+JOHNSON,Overland Park Ward 03 Precinct 21,United States Senate,,Republican,"Roberts, Pat",275,140380
+JOHNSON,Overland Park Ward 06 Precinct 08,United States Senate,,independent,"Orman, Greg",283,140390
+JOHNSON,Overland Park Ward 06 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",16,140390
+JOHNSON,Overland Park Ward 06 Precinct 08,United States Senate,,Republican,"Roberts, Pat",646,140390
+JOHNSON,Overland Park Ward 06 Precinct 16,United States Senate,,independent,"Orman, Greg",159,140400
+JOHNSON,Overland Park Ward 06 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",9,140400
+JOHNSON,Overland Park Ward 06 Precinct 16,United States Senate,,Republican,"Roberts, Pat",243,140400
+JOHNSON,Oxford Township Precinct 01,United States Senate,,independent,"Orman, Greg",1,140410
+JOHNSON,Oxford Township Precinct 01,United States Senate,,Libertarian,"Batson, Randall",0,140410
+JOHNSON,Oxford Township Precinct 01,United States Senate,,Republican,"Roberts, Pat",2,140410
+JOHNSON,Oxford Township Precinct 11,United States Senate,,independent,"Orman, Greg",28,140420
+JOHNSON,Oxford Township Precinct 11,United States Senate,,Libertarian,"Batson, Randall",1,140420
+JOHNSON,Oxford Township Precinct 11,United States Senate,,Republican,"Roberts, Pat",62,140420
+JOHNSON,Shawnee City Ward 01 Precinct 10,United States Senate,,independent,"Orman, Greg",109,140430
+JOHNSON,Shawnee City Ward 01 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",7,140430
+JOHNSON,Shawnee City Ward 01 Precinct 10,United States Senate,,Republican,"Roberts, Pat",126,140430
+JOHNSON,Shawnee City Ward 01 Precinct 12,United States Senate,,independent,"Orman, Greg",4,140440
+JOHNSON,Shawnee City Ward 01 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",0,140440
+JOHNSON,Shawnee City Ward 01 Precinct 12,United States Senate,,Republican,"Roberts, Pat",3,140440
+JOHNSON,Shawnee City Ward 02 Precinct 10,United States Senate,,independent,"Orman, Greg",138,140450
+JOHNSON,Shawnee City Ward 02 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",14,140450
+JOHNSON,Shawnee City Ward 02 Precinct 10,United States Senate,,Republican,"Roberts, Pat",141,140450
+JOHNSON,Shawnee City Ward 02 Precinct 11,United States Senate,,independent,"Orman, Greg",222,140460
+JOHNSON,Shawnee City Ward 02 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",21,140460
+JOHNSON,Shawnee City Ward 02 Precinct 11,United States Senate,,Republican,"Roberts, Pat",222,140460
+JOHNSON,Shawnee City Ward 02 Precinct 12,United States Senate,,independent,"Orman, Greg",72,140470
+JOHNSON,Shawnee City Ward 02 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",6,140470
+JOHNSON,Shawnee City Ward 02 Precinct 12,United States Senate,,Republican,"Roberts, Pat",45,140470
+JOHNSON,Shawnee City Ward 02 Precinct 13,United States Senate,,independent,"Orman, Greg",125,140480
+JOHNSON,Shawnee City Ward 02 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",19,140480
+JOHNSON,Shawnee City Ward 02 Precinct 13,United States Senate,,Republican,"Roberts, Pat",101,140480
+JOHNSON,Shawnee City Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",376,140490
+JOHNSON,Shawnee City Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",21,140490
+JOHNSON,Shawnee City Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",384,140490
+JOHNSON,Shawnee City Ward 04 Precinct 09,United States Senate,,independent,"Orman, Greg",421,140500
+JOHNSON,Shawnee City Ward 04 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",27,140500
+JOHNSON,Shawnee City Ward 04 Precinct 09,United States Senate,,Republican,"Roberts, Pat",428,140500
+JOHNSON,Shawnee City Ward 04 Precinct 11,United States Senate,,independent,"Orman, Greg",221,140510
+JOHNSON,Shawnee City Ward 04 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",16,140510
+JOHNSON,Shawnee City Ward 04 Precinct 11,United States Senate,,Republican,"Roberts, Pat",205,140510
+JOHNSON,Shawnee City Ward 04 Precinct 12,United States Senate,,independent,"Orman, Greg",44,140520
+JOHNSON,Shawnee City Ward 04 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",5,140520
+JOHNSON,Shawnee City Ward 04 Precinct 12,United States Senate,,Republican,"Roberts, Pat",40,140520
+JOHNSON,Gardner Township Precinct 13,United States Senate,,independent,"Orman, Greg",0,140530
+JOHNSON,Gardner Township Precinct 13,United States Senate,,Libertarian,"Batson, Randall",1,140530
+JOHNSON,Gardner Township Precinct 13,United States Senate,,Republican,"Roberts, Pat",1,140530
+JOHNSON,Aubry Township 05,United States Senate,,independent,"Orman, Greg",6,900010
+JOHNSON,Aubry Township 05,United States Senate,,Libertarian,"Batson, Randall",2,900010
+JOHNSON,Aubry Township 05,United States Senate,,Republican,"Roberts, Pat",6,900010
+JOHNSON,Aubry Township 06,United States Senate,,independent,"Orman, Greg",26,900020
+JOHNSON,Aubry Township 06,United States Senate,,Libertarian,"Batson, Randall",2,900020
+JOHNSON,Aubry Township 06,United States Senate,,Republican,"Roberts, Pat",60,900020
+JOHNSON,DeSoto Precinct 03,United States Senate,,independent,"Orman, Greg",263,900040
+JOHNSON,DeSoto Precinct 03,United States Senate,,Libertarian,"Batson, Randall",20,900040
+JOHNSON,DeSoto Precinct 03,United States Senate,,Republican,"Roberts, Pat",356,900040
+JOHNSON,DeSoto Precinct 06,United States Senate,,independent,"Orman, Greg",23,900060
+JOHNSON,DeSoto Precinct 06,United States Senate,,Libertarian,"Batson, Randall",1,900060
+JOHNSON,DeSoto Precinct 06,United States Senate,,Republican,"Roberts, Pat",24,900060
+JOHNSON,Gardner City Precinct 06,United States Senate,,independent,"Orman, Greg",220,900090
+JOHNSON,Gardner City Precinct 06,United States Senate,,Libertarian,"Batson, Randall",27,900090
+JOHNSON,Gardner City Precinct 06,United States Senate,,Republican,"Roberts, Pat",329,900090
+JOHNSON,Gardner City Precinct 07,United States Senate,,independent,"Orman, Greg",9,900100
+JOHNSON,Gardner City Precinct 07,United States Senate,,Libertarian,"Batson, Randall",0,900100
+JOHNSON,Gardner City Precinct 07,United States Senate,,Republican,"Roberts, Pat",5,900100
+JOHNSON,Gardner City Precinct 09,United States Senate,,independent,"Orman, Greg",279,900120
+JOHNSON,Gardner City Precinct 09,United States Senate,,Libertarian,"Batson, Randall",30,900120
+JOHNSON,Gardner City Precinct 09,United States Senate,,Republican,"Roberts, Pat",354,900120
+JOHNSON,Gardner City Precinct 10,United States Senate,,independent,"Orman, Greg",158,900130
+JOHNSON,Gardner City Precinct 10,United States Senate,,Libertarian,"Batson, Randall",23,900130
+JOHNSON,Gardner City Precinct 10,United States Senate,,Republican,"Roberts, Pat",245,900130
+JOHNSON,Gardner Township 04,United States Senate,,independent,"Orman, Greg",0,900160
+JOHNSON,Gardner Township 04,United States Senate,,Libertarian,"Batson, Randall",0,900160
+JOHNSON,Gardner Township 04,United States Senate,,Republican,"Roberts, Pat",2,900160
+JOHNSON,Gardner Township 07,United States Senate,,independent,"Orman, Greg",2,900170
+JOHNSON,Gardner Township 07,United States Senate,,Libertarian,"Batson, Randall",0,900170
+JOHNSON,Gardner Township 07,United States Senate,,Republican,"Roberts, Pat",2,900170
+JOHNSON,Gardner Township 08,United States Senate,,independent,"Orman, Greg",3,900180
+JOHNSON,Gardner Township 08,United States Senate,,Libertarian,"Batson, Randall",0,900180
+JOHNSON,Gardner Township 08,United States Senate,,Republican,"Roberts, Pat",2,900180
+JOHNSON,Leawood Ward 01 Precinct 05,United States Senate,,independent,"Orman, Greg",232,900190
+JOHNSON,Leawood Ward 01 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",9,900190
+JOHNSON,Leawood Ward 01 Precinct 05,United States Senate,,Republican,"Roberts, Pat",230,900190
+JOHNSON,Leawood Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",390,900200
+JOHNSON,Leawood Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",15,900200
+JOHNSON,Leawood Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",336,900200
+JOHNSON,Leawood Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",359,900210
+JOHNSON,Leawood Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",12,900210
+JOHNSON,Leawood Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",356,900210
+JOHNSON,Leawood Ward 02 Precinct 05,United States Senate,,independent,"Orman, Greg",196,900220
+JOHNSON,Leawood Ward 02 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",6,900220
+JOHNSON,Leawood Ward 02 Precinct 05,United States Senate,,Republican,"Roberts, Pat",222,900220
+JOHNSON,Leawood Ward 02 Precinct 06,United States Senate,,independent,"Orman, Greg",142,900230
+JOHNSON,Leawood Ward 02 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",3,900230
+JOHNSON,Leawood Ward 02 Precinct 06,United States Senate,,Republican,"Roberts, Pat",172,900230
+JOHNSON,Leawood Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",216,900240
+JOHNSON,Leawood Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",2,900240
+JOHNSON,Leawood Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",201,900240
+JOHNSON,Leawood Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",327,900250
+JOHNSON,Leawood Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",18,900250
+JOHNSON,Leawood Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",355,900250
+JOHNSON,Leawood Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",185,900260
+JOHNSON,Leawood Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",3,900260
+JOHNSON,Leawood Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",249,900260
+JOHNSON,Leawood Ward 03 Precinct 05,United States Senate,,independent,"Orman, Greg",326,900280
+JOHNSON,Leawood Ward 03 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",12,900280
+JOHNSON,Leawood Ward 03 Precinct 05,United States Senate,,Republican,"Roberts, Pat",464,900280
+JOHNSON,Leawood Ward 03 Precinct 06,United States Senate,,independent,"Orman, Greg",311,900290
+JOHNSON,Leawood Ward 03 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",16,900290
+JOHNSON,Leawood Ward 03 Precinct 06,United States Senate,,Republican,"Roberts, Pat",485,900290
+JOHNSON,Leawood Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",78,900300
+JOHNSON,Leawood Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",1,900300
+JOHNSON,Leawood Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",130,900300
+JOHNSON,Leawood Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",283,900310
+JOHNSON,Leawood Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",4,900310
+JOHNSON,Leawood Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",294,900310
+JOHNSON,Leawood Ward 04 Precinct 05,United States Senate,,independent,"Orman, Greg",316,900320
+JOHNSON,Leawood Ward 04 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",12,900320
+JOHNSON,Leawood Ward 04 Precinct 05,United States Senate,,Republican,"Roberts, Pat",365,900320
+JOHNSON,Leawood Ward 04 Precinct 06,United States Senate,,independent,"Orman, Greg",161,900330
+JOHNSON,Leawood Ward 04 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",3,900330
+JOHNSON,Leawood Ward 04 Precinct 06,United States Senate,,Republican,"Roberts, Pat",347,900330
+JOHNSON,Leawood Ward 04 Precinct 07,United States Senate,,independent,"Orman, Greg",312,900340
+JOHNSON,Leawood Ward 04 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",7,900340
+JOHNSON,Leawood Ward 04 Precinct 07,United States Senate,,Republican,"Roberts, Pat",539,900340
+JOHNSON,Leawood Ward 04 Precinct 08,United States Senate,,independent,"Orman, Greg",156,900350
+JOHNSON,Leawood Ward 04 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",6,900350
+JOHNSON,Leawood Ward 04 Precinct 08,United States Senate,,Republican,"Roberts, Pat",241,900350
+JOHNSON,Lenexa Ward 03 Precinct 08,United States Senate,,independent,"Orman, Greg",334,900360
+JOHNSON,Lenexa Ward 03 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",11,900360
+JOHNSON,Lenexa Ward 03 Precinct 08,United States Senate,,Republican,"Roberts, Pat",356,900360
+JOHNSON,Lenexa Ward 01 Precinct 06,United States Senate,,independent,"Orman, Greg",333,900370
+JOHNSON,Lenexa Ward 01 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",15,900370
+JOHNSON,Lenexa Ward 01 Precinct 06,United States Senate,,Republican,"Roberts, Pat",378,900370
+JOHNSON,Lenexa Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",400,900380
+JOHNSON,Lenexa Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",25,900380
+JOHNSON,Lenexa Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",522,900380
+JOHNSON,Lenexa Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",129,900390
+JOHNSON,Lenexa Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",4,900390
+JOHNSON,Lenexa Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",212,900390
+JOHNSON,Lenexa Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",307,900400
+JOHNSON,Lenexa Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",7,900400
+JOHNSON,Lenexa Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",462,900400
+JOHNSON,Lenexa Ward 02 Precinct 06,United States Senate,,independent,"Orman, Greg",208,900410
+JOHNSON,Lenexa Ward 02 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",7,900410
+JOHNSON,Lenexa Ward 02 Precinct 06,United States Senate,,Republican,"Roberts, Pat",330,900410
+JOHNSON,Lenexa Ward 02 Precinct 07,United States Senate,,independent,"Orman, Greg",407,900420
+JOHNSON,Lenexa Ward 02 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",26,900420
+JOHNSON,Lenexa Ward 02 Precinct 07,United States Senate,,Republican,"Roberts, Pat",460,900420
+JOHNSON,Lenexa Ward 03 Precinct 06,United States Senate,,independent,"Orman, Greg",271,900430
+JOHNSON,Lenexa Ward 03 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",16,900430
+JOHNSON,Lenexa Ward 03 Precinct 06,United States Senate,,Republican,"Roberts, Pat",217,900430
+JOHNSON,Lenexa Ward 03 Precinct 07,United States Senate,,independent,"Orman, Greg",333,900440
+JOHNSON,Lenexa Ward 03 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",21,900440
+JOHNSON,Lenexa Ward 03 Precinct 07,United States Senate,,Republican,"Roberts, Pat",325,900440
+JOHNSON,Lenexa Ward 04 Precinct 05,United States Senate,,independent,"Orman, Greg",145,900450
+JOHNSON,Lenexa Ward 04 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",8,900450
+JOHNSON,Lenexa Ward 04 Precinct 05,United States Senate,,Republican,"Roberts, Pat",103,900450
+JOHNSON,Lenexa Ward 04 Precinct 06,United States Senate,,independent,"Orman, Greg",189,900460
+JOHNSON,Lenexa Ward 04 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",18,900460
+JOHNSON,Lenexa Ward 04 Precinct 06,United States Senate,,Republican,"Roberts, Pat",191,900460
+JOHNSON,Lenexa Ward 04 Precinct 07,United States Senate,,independent,"Orman, Greg",237,900470
+JOHNSON,Lenexa Ward 04 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",20,900470
+JOHNSON,Lenexa Ward 04 Precinct 07,United States Senate,,Republican,"Roberts, Pat",246,900470
+JOHNSON,Lenexa Ward 04 Precinct 08,United States Senate,,independent,"Orman, Greg",335,900480
+JOHNSON,Lenexa Ward 04 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",15,900480
+JOHNSON,Lenexa Ward 04 Precinct 08,United States Senate,,Republican,"Roberts, Pat",254,900480
+JOHNSON,Merriam Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",176,900490
+JOHNSON,Merriam Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",17,900490
+JOHNSON,Merriam Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",128,900490
+JOHNSON,Merriam Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",241,900500
+JOHNSON,Merriam Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",17,900500
+JOHNSON,Merriam Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",138,900500
+JOHNSON,Merriam Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",285,900510
+JOHNSON,Merriam Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",24,900510
+JOHNSON,Merriam Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",220,900510
+JOHNSON,Merriam Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",246,900530
+JOHNSON,Merriam Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",19,900530
+JOHNSON,Merriam Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",156,900530
+JOHNSON,Merriam Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",242,900540
+JOHNSON,Merriam Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",14,900540
+JOHNSON,Merriam Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",157,900540
+JOHNSON,Merriam Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",312,900550
+JOHNSON,Merriam Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",22,900550
+JOHNSON,Merriam Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",215,900550
+JOHNSON,Olathe City Ward 01 Precinct 16,United States Senate,,independent,"Orman, Greg",265,900610
+JOHNSON,Olathe City Ward 01 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",13,900610
+JOHNSON,Olathe City Ward 01 Precinct 16,United States Senate,,Republican,"Roberts, Pat",354,900610
+JOHNSON,Olathe City Ward 01 Precinct 17,United States Senate,,independent,"Orman, Greg",58,900620
+JOHNSON,Olathe City Ward 01 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",2,900620
+JOHNSON,Olathe City Ward 01 Precinct 17,United States Senate,,Republican,"Roberts, Pat",98,900620
+JOHNSON,Olathe City Ward 01 Precinct 21,United States Senate,,independent,"Orman, Greg",297,900640
+JOHNSON,Olathe City Ward 01 Precinct 21,United States Senate,,Libertarian,"Batson, Randall",25,900640
+JOHNSON,Olathe City Ward 01 Precinct 21,United States Senate,,Republican,"Roberts, Pat",319,900640
+JOHNSON,Olathe City Ward 01 Precinct 23,United States Senate,,independent,"Orman, Greg",0,900650
+JOHNSON,Olathe City Ward 01 Precinct 23,United States Senate,,Libertarian,"Batson, Randall",0,900650
+JOHNSON,Olathe City Ward 01 Precinct 23,United States Senate,,Republican,"Roberts, Pat",1,900650
+JOHNSON,Olathe City Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",190,900660
+JOHNSON,Olathe City Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",8,900660
+JOHNSON,Olathe City Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",169,900660
+JOHNSON,Olathe City Ward 02 Precinct 06,United States Senate,,independent,"Orman, Greg",274,900670
+JOHNSON,Olathe City Ward 02 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",8,900670
+JOHNSON,Olathe City Ward 02 Precinct 06,United States Senate,,Republican,"Roberts, Pat",368,900670
+JOHNSON,Olathe City Ward 02 Precinct 07,United States Senate,,independent,"Orman, Greg",362,900680
+JOHNSON,Olathe City Ward 02 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",18,900680
+JOHNSON,Olathe City Ward 02 Precinct 07,United States Senate,,Republican,"Roberts, Pat",415,900680
+JOHNSON,Olathe City Ward 02 Precinct 11,United States Senate,,independent,"Orman, Greg",356,900700
+JOHNSON,Olathe City Ward 02 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",31,900700
+JOHNSON,Olathe City Ward 02 Precinct 11,United States Senate,,Republican,"Roberts, Pat",364,900700
+JOHNSON,Olathe City Ward 02 Precinct 15,United States Senate,,independent,"Orman, Greg",169,900710
+JOHNSON,Olathe City Ward 02 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",17,900710
+JOHNSON,Olathe City Ward 02 Precinct 15,United States Senate,,Republican,"Roberts, Pat",244,900710
+JOHNSON,Olathe City Ward 02 Precinct 16,United States Senate,,independent,"Orman, Greg",90,900720
+JOHNSON,Olathe City Ward 02 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",6,900720
+JOHNSON,Olathe City Ward 02 Precinct 16,United States Senate,,Republican,"Roberts, Pat",56,900720
+JOHNSON,Olathe City Ward 02 Precinct 22,United States Senate,,independent,"Orman, Greg",398,900750
+JOHNSON,Olathe City Ward 02 Precinct 22,United States Senate,,Libertarian,"Batson, Randall",24,900750
+JOHNSON,Olathe City Ward 02 Precinct 22,United States Senate,,Republican,"Roberts, Pat",456,900750
+JOHNSON,Olathe City Ward 03 Precinct 13,United States Senate,,independent,"Orman, Greg",277,900800
+JOHNSON,Olathe City Ward 03 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",12,900800
+JOHNSON,Olathe City Ward 03 Precinct 13,United States Senate,,Republican,"Roberts, Pat",351,900800
+JOHNSON,Olathe City Ward 03 Precinct 17,United States Senate,,independent,"Orman, Greg",257,900820
+JOHNSON,Olathe City Ward 03 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",18,900820
+JOHNSON,Olathe City Ward 03 Precinct 17,United States Senate,,Republican,"Roberts, Pat",358,900820
+JOHNSON,Olathe City Ward 03 Precinct 18,United States Senate,,independent,"Orman, Greg",255,900830
+JOHNSON,Olathe City Ward 03 Precinct 18,United States Senate,,Libertarian,"Batson, Randall",9,900830
+JOHNSON,Olathe City Ward 03 Precinct 18,United States Senate,,Republican,"Roberts, Pat",316,900830
+JOHNSON,Olathe City Ward 03 Precinct 19,United States Senate,,independent,"Orman, Greg",134,900840
+JOHNSON,Olathe City Ward 03 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",8,900840
+JOHNSON,Olathe City Ward 03 Precinct 19,United States Senate,,Republican,"Roberts, Pat",228,900840
+JOHNSON,Olathe City Ward 03 Precinct 20,United States Senate,,independent,"Orman, Greg",181,900850
+JOHNSON,Olathe City Ward 03 Precinct 20,United States Senate,,Libertarian,"Batson, Randall",4,900850
+JOHNSON,Olathe City Ward 03 Precinct 20,United States Senate,,Republican,"Roberts, Pat",227,900850
+JOHNSON,Olathe City Ward 03 Precinct 21,United States Senate,,independent,"Orman, Greg",135,900860
+JOHNSON,Olathe City Ward 03 Precinct 21,United States Senate,,Libertarian,"Batson, Randall",11,900860
+JOHNSON,Olathe City Ward 03 Precinct 21,United States Senate,,Republican,"Roberts, Pat",259,900860
+JOHNSON,Olathe City Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",398,900870
+JOHNSON,Olathe City Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",18,900870
+JOHNSON,Olathe City Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",417,900870
+JOHNSON,Olathe City Ward 04 Precinct 13,United States Senate,,independent,"Orman, Greg",165,900880
+JOHNSON,Olathe City Ward 04 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",11,900880
+JOHNSON,Olathe City Ward 04 Precinct 13,United States Senate,,Republican,"Roberts, Pat",143,900880
+JOHNSON,Olathe City Ward 04 Precinct 14,United States Senate,,independent,"Orman, Greg",332,900890
+JOHNSON,Olathe City Ward 04 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",16,900890
+JOHNSON,Olathe City Ward 04 Precinct 14,United States Senate,,Republican,"Roberts, Pat",353,900890
+JOHNSON,Olathe Township Part 24,United States Senate,,independent,"Orman, Greg",1,900910
+JOHNSON,Olathe Township Part 24,United States Senate,,Libertarian,"Batson, Randall",1,900910
+JOHNSON,Olathe Township Part 24,United States Senate,,Republican,"Roberts, Pat",1,900910
+JOHNSON,Olathe Township Part 26,United States Senate,,independent,"Orman, Greg",0,900930
+JOHNSON,Olathe Township Part 26,United States Senate,,Libertarian,"Batson, Randall",0,900930
+JOHNSON,Olathe Township Part 26,United States Senate,,Republican,"Roberts, Pat",3,900930
+JOHNSON,Olathe Township Part 32,United States Senate,,independent,"Orman, Greg",11,900980
+JOHNSON,Olathe Township Part 32,United States Senate,,Libertarian,"Batson, Randall",2,900980
+JOHNSON,Olathe Township Part 32,United States Senate,,Republican,"Roberts, Pat",10,900980
+JOHNSON,Overland Park Ward 01 Precinct 18,United States Senate,,independent,"Orman, Greg",308,900990
+JOHNSON,Overland Park Ward 01 Precinct 18,United States Senate,,Libertarian,"Batson, Randall",2,900990
+JOHNSON,Overland Park Ward 01 Precinct 18,United States Senate,,Republican,"Roberts, Pat",197,900990
+JOHNSON,Overland Park Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",179,901000
+JOHNSON,Overland Park Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",7,901000
+JOHNSON,Overland Park Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",205,901000
+JOHNSON,Overland Park Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",239,901010
+JOHNSON,Overland Park Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",12,901010
+JOHNSON,Overland Park Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",357,901010
+JOHNSON,Overland Park Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",245,901020
+JOHNSON,Overland Park Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",7,901020
+JOHNSON,Overland Park Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",473,901020
+JOHNSON,Overland Park Ward 04 Precinct 16,United States Senate,,independent,"Orman, Greg",202,901030
+JOHNSON,Overland Park Ward 04 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",11,901030
+JOHNSON,Overland Park Ward 04 Precinct 16,United States Senate,,Republican,"Roberts, Pat",336,901030
+JOHNSON,Overland Park Ward 04 Precinct 17,United States Senate,,independent,"Orman, Greg",317,901040
+JOHNSON,Overland Park Ward 04 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",14,901040
+JOHNSON,Overland Park Ward 04 Precinct 17,United States Senate,,Republican,"Roberts, Pat",376,901040
+JOHNSON,Overland Park Ward 04 Precinct 06,United States Senate,,independent,"Orman, Greg",229,901050
+JOHNSON,Overland Park Ward 04 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",8,901050
+JOHNSON,Overland Park Ward 04 Precinct 06,United States Senate,,Republican,"Roberts, Pat",269,901050
+JOHNSON,Overland Park Ward 05 Precinct 08,United States Senate,,independent,"Orman, Greg",368,901060
+JOHNSON,Overland Park Ward 05 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",21,901060
+JOHNSON,Overland Park Ward 05 Precinct 08,United States Senate,,Republican,"Roberts, Pat",454,901060
+JOHNSON,Overland Park Ward 05 Precinct 16,United States Senate,,independent,"Orman, Greg",175,901070
+JOHNSON,Overland Park Ward 05 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",6,901070
+JOHNSON,Overland Park Ward 05 Precinct 16,United States Senate,,Republican,"Roberts, Pat",194,901070
+JOHNSON,Overland Park Ward 05 Precinct 17,United States Senate,,independent,"Orman, Greg",110,901080
+JOHNSON,Overland Park Ward 05 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",4,901080
+JOHNSON,Overland Park Ward 05 Precinct 17,United States Senate,,Republican,"Roberts, Pat",113,901080
+JOHNSON,Overland Park Ward 05 Precinct 18,United States Senate,,independent,"Orman, Greg",235,901090
+JOHNSON,Overland Park Ward 05 Precinct 18,United States Senate,,Libertarian,"Batson, Randall",15,901090
+JOHNSON,Overland Park Ward 05 Precinct 18,United States Senate,,Republican,"Roberts, Pat",232,901090
+JOHNSON,Overland Park Ward 06 Precinct 01,United States Senate,,independent,"Orman, Greg",289,901100
+JOHNSON,Overland Park Ward 06 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",10,901100
+JOHNSON,Overland Park Ward 06 Precinct 01,United States Senate,,Republican,"Roberts, Pat",406,901100
+JOHNSON,Overland Park Ward 06 Precinct 02,United States Senate,,independent,"Orman, Greg",229,901110
+JOHNSON,Overland Park Ward 06 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",2,901110
+JOHNSON,Overland Park Ward 06 Precinct 02,United States Senate,,Republican,"Roberts, Pat",319,901110
+JOHNSON,Overland Park Ward 06 Precinct 07,United States Senate,,independent,"Orman, Greg",63,901120
+JOHNSON,Overland Park Ward 06 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",4,901120
+JOHNSON,Overland Park Ward 06 Precinct 07,United States Senate,,Republican,"Roberts, Pat",123,901120
+JOHNSON,Overland Park Ward 06 Precinct 09,United States Senate,,independent,"Orman, Greg",357,901140
+JOHNSON,Overland Park Ward 06 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",11,901140
+JOHNSON,Overland Park Ward 06 Precinct 09,United States Senate,,Republican,"Roberts, Pat",461,901140
+JOHNSON,Overland Park Ward 06 Precinct 10,United States Senate,,independent,"Orman, Greg",224,901150
+JOHNSON,Overland Park Ward 06 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",16,901150
+JOHNSON,Overland Park Ward 06 Precinct 10,United States Senate,,Republican,"Roberts, Pat",301,901150
+JOHNSON,Overland Park Ward 06 Precinct 13,United States Senate,,independent,"Orman, Greg",299,901160
+JOHNSON,Overland Park Ward 06 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",12,901160
+JOHNSON,Overland Park Ward 06 Precinct 13,United States Senate,,Republican,"Roberts, Pat",418,901160
+JOHNSON,Overland Park Ward 06 Precinct 15,United States Senate,,independent,"Orman, Greg",282,901170
+JOHNSON,Overland Park Ward 06 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",16,901170
+JOHNSON,Overland Park Ward 06 Precinct 15,United States Senate,,Republican,"Roberts, Pat",414,901170
+JOHNSON,Overland Park Ward 06 Precinct 17,United States Senate,,independent,"Orman, Greg",53,901190
+JOHNSON,Overland Park Ward 06 Precinct 17,United States Senate,,Libertarian,"Batson, Randall",2,901190
+JOHNSON,Overland Park Ward 06 Precinct 17,United States Senate,,Republican,"Roberts, Pat",82,901190
+JOHNSON,Overland Park Ward 05 Precinct 07,United States Senate,,independent,"Orman, Greg",246,901200
+JOHNSON,Overland Park Ward 05 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",12,901200
+JOHNSON,Overland Park Ward 05 Precinct 07,United States Senate,,Republican,"Roberts, Pat",480,901200
+JOHNSON,Overland Park Ward 06 Precinct 19,United States Senate,,independent,"Orman, Greg",343,901210
+JOHNSON,Overland Park Ward 06 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",18,901210
+JOHNSON,Overland Park Ward 06 Precinct 19,United States Senate,,Republican,"Roberts, Pat",362,901210
+JOHNSON,Overland Park Ward 06 Precinct 20,United States Senate,,independent,"Orman, Greg",90,901220
+JOHNSON,Overland Park Ward 06 Precinct 20,United States Senate,,Libertarian,"Batson, Randall",6,901220
+JOHNSON,Overland Park Ward 06 Precinct 20,United States Senate,,Republican,"Roberts, Pat",232,901220
+JOHNSON,Overland Park Ward 06 Precinct 21,United States Senate,,independent,"Orman, Greg",275,901230
+JOHNSON,Overland Park Ward 06 Precinct 21,United States Senate,,Libertarian,"Batson, Randall",16,901230
+JOHNSON,Overland Park Ward 06 Precinct 21,United States Senate,,Republican,"Roberts, Pat",616,901230
+JOHNSON,Overland Park Ward 06 Precinct 22,United States Senate,,independent,"Orman, Greg",135,901240
+JOHNSON,Overland Park Ward 06 Precinct 22,United States Senate,,Libertarian,"Batson, Randall",5,901240
+JOHNSON,Overland Park Ward 06 Precinct 22,United States Senate,,Republican,"Roberts, Pat",199,901240
+JOHNSON,Overland Park Ward 02 Precinct 23,United States Senate,,independent,"Orman, Greg",240,901250
+JOHNSON,Overland Park Ward 02 Precinct 23,United States Senate,,Libertarian,"Batson, Randall",7,901250
+JOHNSON,Overland Park Ward 02 Precinct 23,United States Senate,,Republican,"Roberts, Pat",237,901250
+JOHNSON,Overland Park Ward 06 Precinct 06,United States Senate,,independent,"Orman, Greg",0,901260
+JOHNSON,Overland Park Ward 06 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",0,901260
+JOHNSON,Overland Park Ward 06 Precinct 06,United States Senate,,Republican,"Roberts, Pat",1,901260
+JOHNSON,Overland Park Ward 06 Precinct 18,United States Senate,,independent,"Orman, Greg",0,901270
+JOHNSON,Overland Park Ward 06 Precinct 18,United States Senate,,Libertarian,"Batson, Randall",0,901270
+JOHNSON,Overland Park Ward 06 Precinct 18,United States Senate,,Republican,"Roberts, Pat",3,901270
+JOHNSON,Oxford Township Precinct 09,United States Senate,,independent,"Orman, Greg",7,901300
+JOHNSON,Oxford Township Precinct 09,United States Senate,,Libertarian,"Batson, Randall",0,901300
+JOHNSON,Oxford Township Precinct 09,United States Senate,,Republican,"Roberts, Pat",13,901300
+JOHNSON,Oxford Township Precinct 10,United States Senate,,independent,"Orman, Greg",0,901310
+JOHNSON,Oxford Township Precinct 10,United States Senate,,Libertarian,"Batson, Randall",0,901310
+JOHNSON,Oxford Township Precinct 10,United States Senate,,Republican,"Roberts, Pat",2,901310
+JOHNSON,Shawnee City Ward 01 Precinct 09,United States Senate,,independent,"Orman, Greg",53,901330
+JOHNSON,Shawnee City Ward 01 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",4,901330
+JOHNSON,Shawnee City Ward 01 Precinct 09,United States Senate,,Republican,"Roberts, Pat",56,901330
+JOHNSON,Shawnee City Ward 01 Precinct 11,United States Senate,,independent,"Orman, Greg",198,901350
+JOHNSON,Shawnee City Ward 01 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",12,901350
+JOHNSON,Shawnee City Ward 01 Precinct 11,United States Senate,,Republican,"Roberts, Pat",213,901350
+JOHNSON,Shawnee City Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",294,901360
+JOHNSON,Shawnee City Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,901360
+JOHNSON,Shawnee City Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",279,901360
+JOHNSON,Shawnee City Ward 03 Precinct 05,United States Senate,,independent,"Orman, Greg",298,901370
+JOHNSON,Shawnee City Ward 03 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",14,901370
+JOHNSON,Shawnee City Ward 03 Precinct 05,United States Senate,,Republican,"Roberts, Pat",475,901370
+JOHNSON,Shawnee City Ward 03 Precinct 09,United States Senate,,independent,"Orman, Greg",141,901380
+JOHNSON,Shawnee City Ward 03 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",11,901380
+JOHNSON,Shawnee City Ward 03 Precinct 09,United States Senate,,Republican,"Roberts, Pat",232,901380
+JOHNSON,Shawnee City Ward 04 Precinct 08,United States Senate,,independent,"Orman, Greg",133,901410
+JOHNSON,Shawnee City Ward 04 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",3,901410
+JOHNSON,Shawnee City Ward 04 Precinct 08,United States Senate,,Republican,"Roberts, Pat",160,901410
+JOHNSON,Spring Hill Township Precinct 02,United States Senate,,independent,"Orman, Greg",1,901440
+JOHNSON,Spring Hill Township Precinct 02,United States Senate,,Libertarian,"Batson, Randall",0,901440
+JOHNSON,Spring Hill Township Precinct 02,United States Senate,,Republican,"Roberts, Pat",1,901440
+JOHNSON,Spring Hill Township Precinct 04,United States Senate,,independent,"Orman, Greg",3,901460
+JOHNSON,Spring Hill Township Precinct 04,United States Senate,,Libertarian,"Batson, Randall",1,901460
+JOHNSON,Spring Hill Township Precinct 04,United States Senate,,Republican,"Roberts, Pat",10,901460
+JOHNSON,Spring Hill Township Precinct 05,United States Senate,,independent,"Orman, Greg",7,901470
+JOHNSON,Spring Hill Township Precinct 05,United States Senate,,Libertarian,"Batson, Randall",0,901470
+JOHNSON,Spring Hill Township Precinct 05,United States Senate,,Republican,"Roberts, Pat",1,901470
+JOHNSON,Olathe Township Part 11,United States Senate,,independent,"Orman, Greg",3,901560
+JOHNSON,Olathe Township Part 11,United States Senate,,Libertarian,"Batson, Randall",0,901560
+JOHNSON,Olathe Township Part 11,United States Senate,,Republican,"Roberts, Pat",1,901560
+JOHNSON,Spring Hill Township Precinct 03,United States Senate,,independent,"Orman, Greg",25,901620
+JOHNSON,Spring Hill Township Precinct 03,United States Senate,,Libertarian,"Batson, Randall",1,901620
+JOHNSON,Spring Hill Township Precinct 03,United States Senate,,Republican,"Roberts, Pat",43,901620
+JOHNSON,Olathe City Ward 01 Precinct 14,United States Senate,,independent,"Orman, Greg",216,901630
+JOHNSON,Olathe City Ward 01 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",5,901630
+JOHNSON,Olathe City Ward 01 Precinct 14,United States Senate,,Republican,"Roberts, Pat",292,901630
+JOHNSON,Olathe City Ward 02 Precinct 09,United States Senate,,independent,"Orman, Greg",121,901650
+JOHNSON,Olathe City Ward 02 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",6,901650
+JOHNSON,Olathe City Ward 02 Precinct 09,United States Senate,,Republican,"Roberts, Pat",131,901650
+JOHNSON,Olathe City Ward 03 Precinct 15,United States Senate,,independent,"Orman, Greg",181,901680
+JOHNSON,Olathe City Ward 03 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",11,901680
+JOHNSON,Olathe City Ward 03 Precinct 15,United States Senate,,Republican,"Roberts, Pat",229,901680
+JOHNSON,Olathe City Ward 03 Precinct 24,United States Senate,,independent,"Orman, Greg",131,901690
+JOHNSON,Olathe City Ward 03 Precinct 24,United States Senate,,Libertarian,"Batson, Randall",5,901690
+JOHNSON,Olathe City Ward 03 Precinct 24,United States Senate,,Republican,"Roberts, Pat",151,901690
+JOHNSON,Olathe City Ward 04 Precinct 05,United States Senate,,independent,"Orman, Greg",297,901710
+JOHNSON,Olathe City Ward 04 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",11,901710
+JOHNSON,Olathe City Ward 04 Precinct 05,United States Senate,,Republican,"Roberts, Pat",280,901710
+JOHNSON,Olathe Township Part 05,United States Senate,,independent,"Orman, Greg",0,901780
+JOHNSON,Olathe Township Part 05,United States Senate,,Libertarian,"Batson, Randall",0,901780
+JOHNSON,Olathe Township Part 05,United States Senate,,Republican,"Roberts, Pat",2,901780
+JOHNSON,Olathe City Ward 01 Precinct 24,United States Senate,,independent,"Orman, Greg",30,901800
+JOHNSON,Olathe City Ward 01 Precinct 24,United States Senate,,Libertarian,"Batson, Randall",2,901800
+JOHNSON,Olathe City Ward 01 Precinct 24,United States Senate,,Republican,"Roberts, Pat",47,901800
+JOHNSON,Olathe City Ward 01 Precinct 22,United States Senate,,independent,"Orman, Greg",364,901810
+JOHNSON,Olathe City Ward 01 Precinct 22,United States Senate,,Libertarian,"Batson, Randall",25,901810
+JOHNSON,Olathe City Ward 01 Precinct 22,United States Senate,,Republican,"Roberts, Pat",537,901810
+JOHNSON,DeSoto Precinct 07,United States Senate,,independent,"Orman, Greg",0,901850
+JOHNSON,DeSoto Precinct 07,United States Senate,,Libertarian,"Batson, Randall",0,901850
+JOHNSON,DeSoto Precinct 07,United States Senate,,Republican,"Roberts, Pat",2,901850
+JOHNSON,Olathe City Ward 01 Precinct 18,United States Senate,,independent,"Orman, Greg",83,901880
+JOHNSON,Olathe City Ward 01 Precinct 18,United States Senate,,Libertarian,"Batson, Randall",6,901880
+JOHNSON,Olathe City Ward 01 Precinct 18,United States Senate,,Republican,"Roberts, Pat",86,901880
+JOHNSON,Olathe Township Part 07,United States Senate,,independent,"Orman, Greg",0,901890
+JOHNSON,Olathe Township Part 07,United States Senate,,Libertarian,"Batson, Randall",0,901890
+JOHNSON,Olathe Township Part 07,United States Senate,,Republican,"Roberts, Pat",1,901890
+JOHNSON,Lexington Township Precinct 01,United States Senate,,independent,"Orman, Greg",220,901940
+JOHNSON,Lexington Township Precinct 01,United States Senate,,Libertarian,"Batson, Randall",12,901940
+JOHNSON,Lexington Township Precinct 01,United States Senate,,Republican,"Roberts, Pat",380,901940
+JOHNSON,Gardner City Precinct 02,United States Senate,,independent,"Orman, Greg",54,990010
+JOHNSON,Gardner City Precinct 02,United States Senate,,Libertarian,"Batson, Randall",7,990010
+JOHNSON,Gardner City Precinct 02,United States Senate,,Republican,"Roberts, Pat",54,990010
+JOHNSON,Gardner City Precinct 04,United States Senate,,independent,"Orman, Greg",217,990020
+JOHNSON,Gardner City Precinct 04,United States Senate,,Libertarian,"Batson, Randall",25,990020
+JOHNSON,Gardner City Precinct 04,United States Senate,,Republican,"Roberts, Pat",245,990020
+JOHNSON,Gardner City Precinct 08,United States Senate,,independent,"Orman, Greg",17,990030
+JOHNSON,Gardner City Precinct 08,United States Senate,,Libertarian,"Batson, Randall",1,990030
+JOHNSON,Gardner City Precinct 08,United States Senate,,Republican,"Roberts, Pat",29,990030
+JOHNSON,Gardner City Precinct 12,United States Senate,,independent,"Orman, Greg",7,990040
+JOHNSON,Gardner City Precinct 12,United States Senate,,Libertarian,"Batson, Randall",2,990040
+JOHNSON,Gardner City Precinct 12,United States Senate,,Republican,"Roberts, Pat",5,990040
+JOHNSON,Gardner City Precinct 13,United States Senate,,independent,"Orman, Greg",220,990050
+JOHNSON,Gardner City Precinct 13,United States Senate,,Libertarian,"Batson, Randall",19,990050
+JOHNSON,Gardner City Precinct 13,United States Senate,,Republican,"Roberts, Pat",235,990050
+JOHNSON,Gardner City Precicnt 14,United States Senate,,independent,"Orman, Greg",169,990060
+JOHNSON,Gardner City Precicnt 14,United States Senate,,Libertarian,"Batson, Randall",12,990060
+JOHNSON,Gardner City Precicnt 14,United States Senate,,Republican,"Roberts, Pat",222,990060
+JOHNSON,Gardner Township 01,United States Senate,,independent,"Orman, Greg",130,990070
+JOHNSON,Gardner Township 01,United States Senate,,Libertarian,"Batson, Randall",7,990070
+JOHNSON,Gardner Township 01,United States Senate,,Republican,"Roberts, Pat",172,990070
+JOHNSON,Gardner Township 02,United States Senate,,independent,"Orman, Greg",118,990080
+JOHNSON,Gardner Township 02,United States Senate,,Libertarian,"Batson, Randall",11,990080
+JOHNSON,Gardner Township 02,United States Senate,,Republican,"Roberts, Pat",221,990080
+JOHNSON,Gardner Township 11,United States Senate,,independent,"Orman, Greg",31,990100
+JOHNSON,Gardner Township 11,United States Senate,,Libertarian,"Batson, Randall",6,990100
+JOHNSON,Gardner Township 11,United States Senate,,Republican,"Roberts, Pat",49,990100
+JOHNSON,Leawood Ward 03 Precinct 04,United States Senate,,independent,"Orman, Greg",84,990110
+JOHNSON,Leawood Ward 03 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",4,990110
+JOHNSON,Leawood Ward 03 Precinct 04,United States Senate,,Republican,"Roberts, Pat",100,990110
+JOHNSON,Leawood Ward 03 Precinct 07,United States Senate,,independent,"Orman, Greg",273,990120
+JOHNSON,Leawood Ward 03 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",13,990120
+JOHNSON,Leawood Ward 03 Precinct 07,United States Senate,,Republican,"Roberts, Pat",328,990120
+JOHNSON,Lenexa Ward 01 Precinct 04,United States Senate,,independent,"Orman, Greg",267,999987
+JOHNSON,Lenexa Ward 01 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",18,999987
+JOHNSON,Lenexa Ward 01 Precinct 04,United States Senate,,Republican,"Roberts, Pat",263,999987
+JOHNSON,Olathe Township Part 01,United States Senate,,independent,"Orman, Greg",122,999992
+JOHNSON,Olathe Township Part 01,United States Senate,,Libertarian,"Batson, Randall",7,999992
+JOHNSON,Olathe Township Part 01,United States Senate,,Republican,"Roberts, Pat",144,999992
+JOHNSON,Olathe City Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",218,999993
+JOHNSON,Olathe City Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",17,999993
+JOHNSON,Olathe City Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",211,999993
+JOHNSON,Gardner Township 05,United States Senate,,independent,"Orman, Greg",0,999997
+JOHNSON,Gardner Township 05,United States Senate,,Libertarian,"Batson, Randall",1,999997
+JOHNSON,Gardner Township 05,United States Senate,,Republican,"Roberts, Pat",5,999997
+JOHNSON,ADVANCED,United States Senate,,independent,"Orman, Greg",0,999998
+JOHNSON,ADVANCED,United States Senate,,Libertarian,"Batson, Randall",0,999998
+JOHNSON,ADVANCED,United States Senate,,Republican,"Roberts, Pat",0,999998

--- a/2014/20141104__ks__general__kearny__precinct.csv
+++ b/2014/20141104__ks__general__kearny__precinct.csv
@@ -1,178 +1,154 @@
-county,precinct,office,district,party,candidate,vote
-Kearny,Deerfield,U.S. Senate,,R,Pat Roberts,115
-Kearny,Hartland,U.S. Senate,,R,Pat Roberts,24
-Kearny,Hibbard E,U.S. Senate,,R,Pat Roberts,25
-Kearny,Hibbard W,U.S. Senate,,R,Pat Roberts,11
-Kearny,Kendall,U.S. Senate,,R,Pat Roberts,14
-Kearny,Lakin City 1,U.S. Senate,,R,Pat Roberts,194
-Kearny,Lakin twp 1,U.S. Senate,,R,Pat Roberts,57
-Kearny,Lakin City 2,U.S. Senate,,R,Pat Roberts,135
-Kearny,Southside,U.S. Senate,,R,Pat Roberts,51
-Kearny,Advance,U.S. Senate,,R,Pat Roberts,137
-Kearny,Deerfield,U.S. Senate,,I,Greg Orman,54
-Kearny,Hartland,U.S. Senate,,I,Greg Orman,1
-Kearny,Hibbard E,U.S. Senate,,I,Greg Orman,6
-Kearny,Hibbard W,U.S. Senate,,I,Greg Orman,2
-Kearny,Kendall,U.S. Senate,,I,Greg Orman,0
-Kearny,Lakin City 1,U.S. Senate,,I,Greg Orman,50
-Kearny,Lakin twp 1,U.S. Senate,,I,Greg Orman,11
-Kearny,Lakin City 2,U.S. Senate,,I,Greg Orman,45
-Kearny,Southside,U.S. Senate,,I,Greg Orman,3
-Kearny,Advance,U.S. Senate,,I,Greg Orman,42
-Kearny,Deerfield,U.S. Senate,,L,Randall Batson,4
-Kearny,Hartland,U.S. Senate,,L,Randall Batson,0
-Kearny,Hibbard E,U.S. Senate,,L,Randall Batson,1
-Kearny,Hibbard W,U.S. Senate,,L,Randall Batson,0
-Kearny,Kendall,U.S. Senate,,L,Randall Batson,0
-Kearny,Lakin City 1,U.S. Senate,,L,Randall Batson,6
-Kearny,Lakin twp 1,U.S. Senate,,L,Randall Batson,0
-Kearny,Lakin City 2,U.S. Senate,,L,Randall Batson,14
-Kearny,Southside,U.S. Senate,,L,Randall Batson,3
-Kearny,Advance,U.S. Senate,,L,Randall Batson,2
-Kearny,Deerfield,U.S. House 1,1,R,Tim Huelskamp,125
-Kearny,Hartland,U.S. House 1,1,R,Tim Huelskamp,26
-Kearny,Hibbard E,U.S. House 1,1,R,Tim Huelskamp,25
-Kearny,Hibbard W,U.S. House 1,1,R,Tim Huelskamp,11
-Kearny,Kendall,U.S. House 1,1,R,Tim Huelskamp,13
-Kearny,Lakin City 1,U.S. House 1,1,R,Tim Huelskamp,199
-Kearny,Lakin twp 1,U.S. House 1,1,R,Tim Huelskamp,55
-Kearny,Lakin City 2,U.S. House 1,1,R,Tim Huelskamp,143
-Kearny,Southside,U.S. House 1,1,R,Tim Huelskamp,50
-Kearny,Advance,U.S. House 1,1,R,Tim Huelskamp,147
-Kearny,Deerfield,U.S. House 1,1,D,James Sherow,43
-Kearny,Hartland,U.S. House 1,1,D,James Sherow,1
-Kearny,Hibbard E,U.S. House 1,1,D,James Sherow,7
-Kearny,Hibbard W,U.S. House 1,1,D,James Sherow,0
-Kearny,Kendall,U.S. House 1,1,D,James Sherow,1
-Kearny,Lakin City 1,U.S. House 1,1,D,James Sherow,48
-Kearny,Lakin twp 1,U.S. House 1,1,D,James Sherow,12
-Kearny,Lakin City 2,U.S. House 1,1,D,James Sherow,47
-Kearny,Southside,U.S. House 1,1,D,James Sherow,7
-Kearny,Advance,U.S. House 1,1,D,James Sherow,32
-Kearny,Deerfield,Governor,,R,Sam Brownback,104
-Kearny,Hartland,Governor,,R,Sam Brownback,26
-Kearny,Hibbard E,Governor,,R,Sam Brownback,25
-Kearny,Hibbard W,Governor,,R,Sam Brownback,12
-Kearny,Kendall,Governor,,R,Sam Brownback,14
-Kearny,Lakin City 1,Governor,,R,Sam Brownback,179
-Kearny,Lakin twp 1,Governor,,R,Sam Brownback,53
-Kearny,Lakin City 2,Governor,,R,Sam Brownback,124
-Kearny,Southside,Governor,,R,Sam Brownback,49
-Kearny,Advance,Governor,,R,Sam Brownback,130
-Kearny,Deerfield,Governor,,D,Paul Davis,61
-Kearny,Hartland,Governor,,D,Paul Davis,1
-Kearny,Hibbard E,Governor,,D,Paul Davis,6
-Kearny,Hibbard W,Governor,,D,Paul Davis,1
-Kearny,Kendall,Governor,,D,Paul Davis,0
-Kearny,Lakin City 1,Governor,,D,Paul Davis,65
-Kearny,Lakin twp 1,Governor,,D,Paul Davis,13
-Kearny,Lakin City 2,Governor,,D,Paul Davis,61
-Kearny,Southside,Governor,,D,Paul Davis,6
-Kearny,Advance,Governor,,D,Paul Davis,48
-Kearny,Deerfield,Governor,,L,Keen Umbehr,5
-Kearny,Hartland,Governor,,L,Keen Umbehr,0
-Kearny,Hibbard E,Governor,,L,Keen Umbehr,1
-Kearny,Hibbard W,Governor,,L,Keen Umbehr,0
-Kearny,Kendall,Governor,,L,Keen Umbehr,0
-Kearny,Lakin City 1,Governor,,L,Keen Umbehr,5
-Kearny,Lakin twp 1,Governor,,L,Keen Umbehr,1
-Kearny,Lakin City 2,Governor,,L,Keen Umbehr,9
-Kearny,Southside,Governor,,L,Keen Umbehr,1
-Kearny,Advance,Governor,,L,Keen Umbehr,4
-Kearny,Deerfield,Secretary of State,,R,Kris Kobach,127
-Kearny,Hartland,Secretary of State,,R,Kris Kobach,25
-Kearny,Hibbard E,Secretary of State,,R,Kris Kobach,28
-Kearny,Hibbard W,Secretary of State,,R,Kris Kobach,12
-Kearny,Kendall,Secretary of State,,R,Kris Kobach,14
-Kearny,Lakin City 1,Secretary of State,,R,Kris Kobach,198
-Kearny,Lakin twp 1,Secretary of State,,R,Kris Kobach,58
-Kearny,Lakin City 2,Secretary of State,,R,Kris Kobach,144
-Kearny,Southside,Secretary of State,,R,Kris Kobach,49
-Kearny,Advance,Secretary of State,,R,Kris Kobach,139
-Kearny,Deerfield,Secretary of State,,D,Jean Schodorf,42
-Kearny,Hartland,Secretary of State,,D,Jean Schodorf,2
-Kearny,Hibbard E,Secretary of State,,D,Jean Schodorf,4
-Kearny,Hibbard W,Secretary of State,,D,Jean Schodorf,1
-Kearny,Kendall,Secretary of State,,D,Jean Schodorf,0
-Kearny,Lakin City 1,Secretary of State,,D,Jean Schodorf,50
-Kearny,Lakin twp 1,Secretary of State,,D,Jean Schodorf,11
-Kearny,Lakin City 2,Secretary of State,,D,Jean Schodorf,47
-Kearny,Southside,Secretary of State,,D,Jean Schodorf,6
-Kearny,Advance,Secretary of State,,D,Jean Schodorf,36
-Kearny,Deerfield,Attorney General,,R,Derek Schmidt,125
-Kearny,Hartland,Attorney General,,R,Derek Schmidt,25
-Kearny,Hibbard E,Attorney General,,R,Derek Schmidt,27
-Kearny,Hibbard W,Attorney General,,R,Derek Schmidt,12
-Kearny,Kendall,Attorney General,,R,Derek Schmidt,13
-Kearny,Lakin City 1,Attorney General,,R,Derek Schmidt,205
-Kearny,Lakin twp 1,Attorney General,,R,Derek Schmidt,57
-Kearny,Lakin City 2,Attorney General,,R,Derek Schmidt,142
-Kearny,Southside,Attorney General,,R,Derek Schmidt,51
-Kearny,Advance,Attorney General,,R,Derek Schmidt,150
-Kearny,Deerfield,Attorney General,,D,AJ Kotich,38
-Kearny,Hartland,Attorney General,,D,AJ Kotich,0
-Kearny,Hibbard E,Attorney General,,D,AJ Kotich,3
-Kearny,Hibbard W,Attorney General,,D,AJ Kotich,0
-Kearny,Kendall,Attorney General,,D,AJ Kotich,1
-Kearny,Lakin City 1,Attorney General,,D,AJ Kotich,33
-Kearny,Lakin twp 1,Attorney General,,D,AJ Kotich,11
-Kearny,Lakin City 2,Attorney General,,D,AJ Kotich,48
-Kearny,Southside,Attorney General,,D,AJ Kotich,5
-Kearny,Advance,Attorney General,,D,AJ Kotich,24
-Kearny,Deerfield,State Treasurer,,R,Ron Estes,143
-Kearny,Hartland,State Treasurer,,R,Ron Estes,26
-Kearny,Hibbard E,State Treasurer,,R,Ron Estes,32
-Kearny,Hibbard W,State Treasurer,,R,Ron Estes,12
-Kearny,Kendall,State Treasurer,,R,Ron Estes,14
-Kearny,Lakin City 1,State Treasurer,,R,Ron Estes,211
-Kearny,Lakin twp 1,State Treasurer,,R,Ron Estes,62
-Kearny,Lakin City 2,State Treasurer,,R,Ron Estes,157
-Kearny,Southside,State Treasurer,,R,Ron Estes,54
-Kearny,Advance,State Treasurer,,R,Ron Estes,145
-Kearny,Deerfield,State Treasurer,,D,Carmen Alldritt,26
-Kearny,Hartland,State Treasurer,,D,Carmen Alldritt,1
-Kearny,Hibbard E,State Treasurer,,D,Carmen Alldritt,1
-Kearny,Hibbard W,State Treasurer,,D,Carmen Alldritt,0
-Kearny,Kendall,State Treasurer,,D,Carmen Alldritt,0
-Kearny,Lakin City 1,State Treasurer,,D,Carmen Alldritt,27
-Kearny,Lakin twp 1,State Treasurer,,D,Carmen Alldritt,6
-Kearny,Lakin City 2,State Treasurer,,D,Carmen Alldritt,34
-Kearny,Southside,State Treasurer,,D,Carmen Alldritt,2
-Kearny,Advance,State Treasurer,,D,Carmen Alldritt,25
-Kearny,Deerfield,Insurance Commissioner,,R,Ron Selzer,123
-Kearny,Hartland,Insurance Commissioner,,R,Ron Selzer,26
-Kearny,Hibbard E,Insurance Commissioner,,R,Ron Selzer,25
-Kearny,Hibbard W,Insurance Commissioner,,R,Ron Selzer,12
-Kearny,Kendall,Insurance Commissioner,,R,Ron Selzer,14
-Kearny,Lakin City 1,Insurance Commissioner,,R,Ron Selzer,185
-Kearny,Lakin twp 1,Insurance Commissioner,,R,Ron Selzer,58
-Kearny,Lakin City 2,Insurance Commissioner,,R,Ron Selzer,145
-Kearny,Southside,Insurance Commissioner,,R,Ron Selzer,51
-Kearny,Advance,Insurance Commissioner,,R,Ron Selzer,133
-Kearny,Deerfield,Insurance Commissioner,,D,Dennis Anderson,43
-Kearny,Hartland,Insurance Commissioner,,D,Dennis Anderson,0
-Kearny,Hibbard E,Insurance Commissioner,,D,Dennis Anderson,3
-Kearny,Hibbard W,Insurance Commissioner,,D,Dennis Anderson,0
-Kearny,Kendall,Insurance Commissioner,,D,Dennis Anderson,0
-Kearny,Lakin City 1,Insurance Commissioner,,D,Dennis Anderson,47
-Kearny,Lakin twp 1,Insurance Commissioner,,D,Dennis Anderson,9
-Kearny,Lakin City 2,Insurance Commissioner,,D,Dennis Anderson,41
-Kearny,Southside,Insurance Commissioner,,D,Dennis Anderson,5
-Kearny,Advance,Insurance Commissioner,,D,Dennis Anderson,34
-Kearny,Deerfield,State House 122,122,R,Russ Jennings,146
-Kearny,Hartland,State House 122,122,R,Russ Jennings,23
-Kearny,Hibbard E,State House 122,122,R,Russ Jennings,25
-Kearny,Hibbard W,State House 122,122,R,Russ Jennings,9
-Kearny,Kendall,State House 122,122,R,Russ Jennings,14
-Kearny,Lakin City 1,State House 122,122,R,Russ Jennings,224
-Kearny,Lakin twp 1,State House 122,122,R,Russ Jennings,64
-Kearny,Lakin City 2,State House 122,122,R,Russ Jennings,165
-Kearny,Southside,State House 122,122,R,Russ Jennings,46
-Kearny,Advance,State House 122,122,R,Russ Jennings,155
-Kearny,Hibbard W,State House 122,122,wri,Stan Rice,2
-Kearny,Deerfield,State House 122,122,wri,Randy Hazlett,1
-Kearny,Lakin City 1,State House 122,122,wri,Stan Rice,2
-Kearny,Lakin twp 1,State House 122,122,wri,Stan Rice,1
-Kearny,Southside,State House 122,122,wri,Stan Rice,4
-Kearny,Southside,State House 122,122,wri,Randy Hazlett,2
-Kearny,Advance,State House 122,122,wri,Randy Hazlett,2
+county,precinct,office,district,party,candidate,votes,vtd
+KEARNY,Deerfield Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000010
+KEARNY,Deerfield Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000010
+KEARNY,Deerfield Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,000010
+KEARNY,East Hibbard Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000020
+KEARNY,East Hibbard Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+KEARNY,East Hibbard Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000020
+KEARNY,Hartland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000030
+KEARNY,Hartland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+KEARNY,Hartland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000030
+KEARNY,Kendall Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000040
+KEARNY,Kendall Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+KEARNY,Kendall Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000040
+KEARNY,Lakin Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",83,000050
+KEARNY,Lakin Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000050
+KEARNY,Lakin Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",228,000050
+KEARNY,Lakin Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,000060
+KEARNY,Lakin Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000060
+KEARNY,Lakin Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",152,000060
+KEARNY,Lakin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000070
+KEARNY,Lakin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000070
+KEARNY,Lakin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",62,000070
+KEARNY,Southside Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000080
+KEARNY,Southside Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+KEARNY,Southside Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,000080
+KEARNY,West Hibbard Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000090
+KEARNY,West Hibbard Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+KEARNY,West Hibbard Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000090
+KEARNY,Deerfield Precinct,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",162,000010
+KEARNY,East Hibbard Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",37,000020
+KEARNY,Hartland Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",28,000030
+KEARNY,Kendall Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",19,000040
+KEARNY,Lakin Precinct 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",281,000050
+KEARNY,Lakin Precinct 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",206,000060
+KEARNY,Lakin Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",77,000070
+KEARNY,Southside Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",50,000080
+KEARNY,West Hibbard Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",11,000090
+KEARNY,Deerfield Precinct,United States House of Representatives,1,Democratic,"Sherow, James E.",46,000010
+KEARNY,Deerfield Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",138,000010
+KEARNY,East Hibbard Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000020
+KEARNY,East Hibbard Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000020
+KEARNY,Hartland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000030
+KEARNY,Hartland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000030
+KEARNY,Kendall Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000040
+KEARNY,Kendall Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000040
+KEARNY,Lakin Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",61,000050
+KEARNY,Lakin Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",253,000050
+KEARNY,Lakin Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",53,000060
+KEARNY,Lakin Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",184,000060
+KEARNY,Lakin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000070
+KEARNY,Lakin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000070
+KEARNY,Southside Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000080
+KEARNY,Southside Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000080
+KEARNY,West Hibbard Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000090
+KEARNY,West Hibbard Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000090
+KEARNY,Deerfield Precinct,Attorney General,,Democratic,"Kotich, A.J.",39,000010
+KEARNY,Deerfield Precinct,Attorney General,,Republican,"Schmidt, Derek",140,000010
+KEARNY,East Hibbard Township,Attorney General,,Democratic,"Kotich, A.J.",3,000020
+KEARNY,East Hibbard Township,Attorney General,,Republican,"Schmidt, Derek",41,000020
+KEARNY,Hartland Township,Attorney General,,Democratic,"Kotich, A.J.",0,000030
+KEARNY,Hartland Township,Attorney General,,Republican,"Schmidt, Derek",33,000030
+KEARNY,Kendall Township,Attorney General,,Democratic,"Kotich, A.J.",1,000040
+KEARNY,Kendall Township,Attorney General,,Republican,"Schmidt, Derek",18,000040
+KEARNY,Lakin Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",43,000050
+KEARNY,Lakin Precinct 1,Attorney General,,Republican,"Schmidt, Derek",259,000050
+KEARNY,Lakin Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",54,000060
+KEARNY,Lakin Precinct 2,Attorney General,,Republican,"Schmidt, Derek",181,000060
+KEARNY,Lakin Township,Attorney General,,Democratic,"Kotich, A.J.",16,000070
+KEARNY,Lakin Township,Attorney General,,Republican,"Schmidt, Derek",67,000070
+KEARNY,Southside Township,Attorney General,,Democratic,"Kotich, A.J.",6,000080
+KEARNY,Southside Township,Attorney General,,Republican,"Schmidt, Derek",54,000080
+KEARNY,West Hibbard Township,Attorney General,,Democratic,"Kotich, A.J.",1,000090
+KEARNY,West Hibbard Township,Attorney General,,Republican,"Schmidt, Derek",14,000090
+KEARNY,Deerfield Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000010
+KEARNY,Deerfield Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",134,000010
+KEARNY,East Hibbard Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000020
+KEARNY,East Hibbard Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000020
+KEARNY,Hartland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000030
+KEARNY,Hartland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000030
+KEARNY,Kendall Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000040
+KEARNY,Kendall Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000040
+KEARNY,Lakin Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000050
+KEARNY,Lakin Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",235,000050
+KEARNY,Lakin Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000060
+KEARNY,Lakin Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",177,000060
+KEARNY,Lakin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000070
+KEARNY,Lakin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",68,000070
+KEARNY,Southside Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000080
+KEARNY,Southside Township,Commissioner of Insurance,,Republican,"Selzer, Ken",53,000080
+KEARNY,West Hibbard Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000090
+KEARNY,West Hibbard Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000090
+KEARNY,Deerfield Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000010
+KEARNY,Deerfield Precinct,Secretary of State,,Republican,"Kobach, Kris",141,000010
+KEARNY,East Hibbard Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000020
+KEARNY,East Hibbard Township,Secretary of State,,Republican,"Kobach, Kris",42,000020
+KEARNY,Hartland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000030
+KEARNY,Hartland Township,Secretary of State,,Republican,"Kobach, Kris",32,000030
+KEARNY,Kendall Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000040
+KEARNY,Kendall Township,Secretary of State,,Republican,"Kobach, Kris",19,000040
+KEARNY,Lakin Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",64,000050
+KEARNY,Lakin Precinct 1,Secretary of State,,Republican,"Kobach, Kris",246,000050
+KEARNY,Lakin Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000060
+KEARNY,Lakin Precinct 2,Secretary of State,,Republican,"Kobach, Kris",181,000060
+KEARNY,Lakin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000070
+KEARNY,Lakin Township,Secretary of State,,Republican,"Kobach, Kris",67,000070
+KEARNY,Southside Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000080
+KEARNY,Southside Township,Secretary of State,,Republican,"Kobach, Kris",51,000080
+KEARNY,West Hibbard Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000090
+KEARNY,West Hibbard Township,Secretary of State,,Republican,"Kobach, Kris",15,000090
+KEARNY,Deerfield Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",29,000010
+KEARNY,Deerfield Precinct,State Treasurer,,Republican,"Estes, Ron",155,000010
+KEARNY,East Hibbard Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000020
+KEARNY,East Hibbard Township,State Treasurer,,Republican,"Estes, Ron",45,000020
+KEARNY,Hartland Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000030
+KEARNY,Hartland Township,State Treasurer,,Republican,"Estes, Ron",34,000030
+KEARNY,Kendall Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+KEARNY,Kendall Township,State Treasurer,,Republican,"Estes, Ron",19,000040
+KEARNY,Lakin Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",37,000050
+KEARNY,Lakin Precinct 1,State Treasurer,,Republican,"Estes, Ron",263,000050
+KEARNY,Lakin Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",41,000060
+KEARNY,Lakin Precinct 2,State Treasurer,,Republican,"Estes, Ron",195,000060
+KEARNY,Lakin Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000070
+KEARNY,Lakin Township,State Treasurer,,Republican,"Estes, Ron",73,000070
+KEARNY,Southside Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000080
+KEARNY,Southside Township,State Treasurer,,Republican,"Estes, Ron",57,000080
+KEARNY,West Hibbard Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000090
+KEARNY,West Hibbard Township,State Treasurer,,Republican,"Estes, Ron",15,000090
+KEARNY,Deerfield Precinct,United States Senate,,independent,"Orman, Greg",58,000010
+KEARNY,Deerfield Precinct,United States Senate,,Libertarian,"Batson, Randall",5,000010
+KEARNY,Deerfield Precinct,United States Senate,,Republican,"Roberts, Pat",127,000010
+KEARNY,East Hibbard Township,United States Senate,,independent,"Orman, Greg",6,000020
+KEARNY,East Hibbard Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+KEARNY,East Hibbard Township,United States Senate,,Republican,"Roberts, Pat",40,000020
+KEARNY,Hartland Township,United States Senate,,independent,"Orman, Greg",2,000030
+KEARNY,Hartland Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+KEARNY,Hartland Township,United States Senate,,Republican,"Roberts, Pat",31,000030
+KEARNY,Kendall Township,United States Senate,,independent,"Orman, Greg",1,000040
+KEARNY,Kendall Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+KEARNY,Kendall Township,United States Senate,,Republican,"Roberts, Pat",18,000040
+KEARNY,Lakin Precinct 1,United States Senate,,independent,"Orman, Greg",67,000050
+KEARNY,Lakin Precinct 1,United States Senate,,Libertarian,"Batson, Randall",7,000050
+KEARNY,Lakin Precinct 1,United States Senate,,Republican,"Roberts, Pat",243,000050
+KEARNY,Lakin Precinct 2,United States Senate,,independent,"Orman, Greg",58,000060
+KEARNY,Lakin Precinct 2,United States Senate,,Libertarian,"Batson, Randall",14,000060
+KEARNY,Lakin Precinct 2,United States Senate,,Republican,"Roberts, Pat",169,000060
+KEARNY,Lakin Township,United States Senate,,independent,"Orman, Greg",16,000070
+KEARNY,Lakin Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+KEARNY,Lakin Township,United States Senate,,Republican,"Roberts, Pat",67,000070
+KEARNY,Southside Township,United States Senate,,independent,"Orman, Greg",4,000080
+KEARNY,Southside Township,United States Senate,,Libertarian,"Batson, Randall",3,000080
+KEARNY,Southside Township,United States Senate,,Republican,"Roberts, Pat",54,000080
+KEARNY,West Hibbard Township,United States Senate,,independent,"Orman, Greg",2,000090
+KEARNY,West Hibbard Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+KEARNY,West Hibbard Township,United States Senate,,Republican,"Roberts, Pat",14,000090

--- a/2014/20141104__ks__general__kingman__precinct.csv
+++ b/2014/20141104__ks__general__kingman__precinct.csv
@@ -1,505 +1,541 @@
-county,precinct,office,district,party,candidate,vote
-Kingman,Allen Township,U.S. Senate,,D,Pat Roberts,30
-Kingman,Belmont Township,U.S. Senate,,D,Pat Roberts,15
-Kingman,Bennett Township,U.S. Senate,,D,Pat Roberts,126
-Kingman,Canton Township,U.S. Senate,,D,Pat Roberts,31
-Kingman,Chikaskia Township,U.S. Senate,,D,Pat Roberts,24
-Kingman,Dale Township,U.S. Senate,,D,Pat Roberts,40
-Kingman,Dresden Township,U.S. Senate,,D,Pat Roberts,93
-Kingman,Eagle Township,U.S. Senate,,D,Pat Roberts,35
-Kingman,Eureka Township,U.S. Senate,,D,Pat Roberts,33
-Kingman,Evan Township,U.S. Senate,,D,Pat Roberts,161
-Kingman,Galesburg Township,U.S. Senate,,D,Pat Roberts,67
-Kingman,Hoosier Township,U.S. Senate,,D,Pat Roberts,42
-Kingman,Kingman Township,U.S. Senate,,D,Pat Roberts,42
-Kingman,Liberty Township,U.S. Senate,,D,Pat Roberts,33
-Kingman,Ninnescah Township,U.S. Senate,,D,Pat Roberts,100
-Kingman,Peters Township,U.S. Senate,,D,Pat Roberts,32
-Kingman,Richland Township,U.S. Senate,,D,Pat Roberts,22
-Kingman,Rochester Township,U.S. Senate,,D,Pat Roberts,47
-Kingman,Rural Township,U.S. Senate,,D,Pat Roberts,66
-Kingman,Union Township,U.S. Senate,,D,Pat Roberts,27
-Kingman,Valley Township,U.S. Senate,,D,Pat Roberts,27
-Kingman,Vinita Township,U.S. Senate,,D,Pat Roberts,70
-Kingman,White Township,U.S. Senate,,D,Pat Roberts,96
-Kingman,Kingman Ward 1,U.S. Senate,,D,Pat Roberts,159
-Kingman,Kingman Ward 2,U.S. Senate,,D,Pat Roberts,229
-Kingman,Kingman Ward 3,U.S. Senate,,D,Pat Roberts,80
-Kingman,Kingman Ward 4,U.S. Senate,,D,Pat Roberts,114
-Kingman,Prov,U.S. Senate,,D,Pat Roberts,17
-Kingman,Allen Township,U.S. Senate,,I,Greg Orman,8
-Kingman,Belmont Township,U.S. Senate,,I,Greg Orman,8
-Kingman,Bennett Township,U.S. Senate,,I,Greg Orman,61
-Kingman,Canton Township,U.S. Senate,,I,Greg Orman,6
-Kingman,Chikaskia Township,U.S. Senate,,I,Greg Orman,17
-Kingman,Dale Township,U.S. Senate,,I,Greg Orman,24
-Kingman,Dresden Township,U.S. Senate,,I,Greg Orman,44
-Kingman,Eagle Township,U.S. Senate,,I,Greg Orman,14
-Kingman,Eureka Township,U.S. Senate,,I,Greg Orman,11
-Kingman,Evan Township,U.S. Senate,,I,Greg Orman,40
-Kingman,Galesburg Township,U.S. Senate,,I,Greg Orman,24
-Kingman,Hoosier Township,U.S. Senate,,I,Greg Orman,12
-Kingman,Kingman Township,U.S. Senate,,I,Greg Orman,10
-Kingman,Liberty Township,U.S. Senate,,I,Greg Orman,19
-Kingman,Ninnescah Township,U.S. Senate,,I,Greg Orman,22
-Kingman,Peters Township,U.S. Senate,,I,Greg Orman,11
-Kingman,Richland Township,U.S. Senate,,I,Greg Orman,9
-Kingman,Rochester Township,U.S. Senate,,I,Greg Orman,21
-Kingman,Rural Township,U.S. Senate,,I,Greg Orman,44
-Kingman,Union Township,U.S. Senate,,I,Greg Orman,7
-Kingman,Valley Township,U.S. Senate,,I,Greg Orman,14
-Kingman,Vinita Township,U.S. Senate,,I,Greg Orman,35
-Kingman,White Township,U.S. Senate,,I,Greg Orman,36
-Kingman,Kingman Ward 1,U.S. Senate,,I,Greg Orman,92
-Kingman,Kingman Ward 2,U.S. Senate,,I,Greg Orman,157
-Kingman,Kingman Ward 3,U.S. Senate,,I,Greg Orman,56
-Kingman,Kingman Ward 4,U.S. Senate,,I,Greg Orman,66
-Kingman,Prov,U.S. Senate,,I,Greg Orman,7
-Kingman,Allen Township,U.S. Senate,,L,Randall Batson,0
-Kingman,Belmont Township,U.S. Senate,,L,Randall Batson,1
-Kingman,Bennett Township,U.S. Senate,,L,Randall Batson,11
-Kingman,Canton Township,U.S. Senate,,L,Randall Batson,0
-Kingman,Chikaskia Township,U.S. Senate,,L,Randall Batson,3
-Kingman,Dale Township,U.S. Senate,,L,Randall Batson,2
-Kingman,Dresden Township,U.S. Senate,,L,Randall Batson,9
-Kingman,Eagle Township,U.S. Senate,,L,Randall Batson,0
-Kingman,Eureka Township,U.S. Senate,,L,Randall Batson,0
-Kingman,Evan Township,U.S. Senate,,L,Randall Batson,12
-Kingman,Galesburg Township,U.S. Senate,,L,Randall Batson,4
-Kingman,Hoosier Township,U.S. Senate,,L,Randall Batson,2
-Kingman,Kingman Township,U.S. Senate,,L,Randall Batson,1
-Kingman,Liberty Township,U.S. Senate,,L,Randall Batson,3
-Kingman,Ninnescah Township,U.S. Senate,,L,Randall Batson,7
-Kingman,Peters Township,U.S. Senate,,L,Randall Batson,3
-Kingman,Richland Township,U.S. Senate,,L,Randall Batson,1
-Kingman,Rochester Township,U.S. Senate,,L,Randall Batson,3
-Kingman,Rural Township,U.S. Senate,,L,Randall Batson,7
-Kingman,Union Township,U.S. Senate,,L,Randall Batson,1
-Kingman,Valley Township,U.S. Senate,,L,Randall Batson,0
-Kingman,Vinita Township,U.S. Senate,,L,Randall Batson,4
-Kingman,White Township,U.S. Senate,,L,Randall Batson,2
-Kingman,Kingman Ward 1,U.S. Senate,,L,Randall Batson,18
-Kingman,Kingman Ward 2,U.S. Senate,,L,Randall Batson,20
-Kingman,Kingman Ward 3,U.S. Senate,,L,Randall Batson,8
-Kingman,Kingman Ward 4,U.S. Senate,,L,Randall Batson,7
-Kingman,Prov,U.S. Senate,,L,Randall Batson,0
-Kingman,Allen Township,U.S. House,4,R,Mike Pompeo,32
-Kingman,Belmont Township,U.S. House,4,R,Mike Pompeo,17
-Kingman,Bennett Township,U.S. House,4,R,Mike Pompeo,149
-Kingman,Canton Township,U.S. House,4,R,Mike Pompeo,37
-Kingman,Chikaskia Township,U.S. House,4,R,Mike Pompeo,31
-Kingman,Dale Township,U.S. House,4,R,Mike Pompeo,48
-Kingman,Dresden Township,U.S. House,4,R,Mike Pompeo,112
-Kingman,Eagle Township,U.S. House,4,R,Mike Pompeo,39
-Kingman,Eureka Township,U.S. House,4,R,Mike Pompeo,37
-Kingman,Evan Township,U.S. House,4,R,Mike Pompeo,187
-Kingman,Galesburg Township,U.S. House,4,R,Mike Pompeo,71
-Kingman,Hoosier Township,U.S. House,4,R,Mike Pompeo,46
-Kingman,Kingman Township,U.S. House,4,R,Mike Pompeo,45
-Kingman,Liberty Township,U.S. House,4,R,Mike Pompeo,45
-Kingman,Ninnescah Township,U.S. House,4,R,Mike Pompeo,118
-Kingman,Peters Township,U.S. House,4,R,Mike Pompeo,35
-Kingman,Richland Township,U.S. House,4,R,Mike Pompeo,27
-Kingman,Rochester Township,U.S. House,4,R,Mike Pompeo,46
-Kingman,Rural Township,U.S. House,4,R,Mike Pompeo,81
-Kingman,Union Township,U.S. House,4,R,Mike Pompeo,27
-Kingman,Valley Township,U.S. House,4,R,Mike Pompeo,33
-Kingman,Vinita Township,U.S. House,4,R,Mike Pompeo,78
-Kingman,White Township,U.S. House,4,R,Mike Pompeo,104
-Kingman,Kingman Ward 1,U.S. House,4,R,Mike Pompeo,195
-Kingman,Kingman Ward 2,U.S. House,4,R,Mike Pompeo,294
-Kingman,Kingman Ward 3,U.S. House,4,R,Mike Pompeo,101
-Kingman,Kingman Ward 4,U.S. House,4,R,Mike Pompeo,133
-Kingman,Prov,U.S. House,4,R,Mike Pompeo,20
-Kingman,Allen Township,U.S. House,4,D,Perry Schuckman,6
-Kingman,Belmont Township,U.S. House,4,D,Perry Schuckman,6
-Kingman,Bennett Township,U.S. House,4,D,Perry Schuckman,45
-Kingman,Canton Township,U.S. House,4,D,Perry Schuckman,0
-Kingman,Chikaskia Township,U.S. House,4,D,Perry Schuckman,12
-Kingman,Dale Township,U.S. House,4,D,Perry Schuckman,17
-Kingman,Dresden Township,U.S. House,4,D,Perry Schuckman,36
-Kingman,Eagle Township,U.S. House,4,D,Perry Schuckman,9
-Kingman,Eureka Township,U.S. House,4,D,Perry Schuckman,6
-Kingman,Evan Township,U.S. House,4,D,Perry Schuckman,25
-Kingman,Galesburg Township,U.S. House,4,D,Perry Schuckman,19
-Kingman,Hoosier Township,U.S. House,4,D,Perry Schuckman,8
-Kingman,Kingman Township,U.S. House,4,D,Perry Schuckman,7
-Kingman,Liberty Township,U.S. House,4,D,Perry Schuckman,9
-Kingman,Ninnescah Township,U.S. House,4,D,Perry Schuckman,13
-Kingman,Peters Township,U.S. House,4,D,Perry Schuckman,7
-Kingman,Richland Township,U.S. House,4,D,Perry Schuckman,6
-Kingman,Rochester Township,U.S. House,4,D,Perry Schuckman,24
-Kingman,Rural Township,U.S. House,4,D,Perry Schuckman,32
-Kingman,Union Township,U.S. House,4,D,Perry Schuckman,5
-Kingman,Valley Township,U.S. House,4,D,Perry Schuckman,8
-Kingman,Vinita Township,U.S. House,4,D,Perry Schuckman,31
-Kingman,White Township,U.S. House,4,D,Perry Schuckman,28
-Kingman,Kingman Ward 1,U.S. House,4,D,Perry Schuckman,70
-Kingman,Kingman Ward 2,U.S. House,4,D,Perry Schuckman,103
-Kingman,Kingman Ward 3,U.S. House,4,D,Perry Schuckman,43
-Kingman,Kingman Ward 4,U.S. House,4,D,Perry Schuckman,52
-Kingman,Prov,U.S. House,4,D,Perry Schuckman,4
-Kingman,Allen Township,Governor,,R,Sam Brownback,28
-Kingman,Belmont Township,Governor,,R,Sam Brownback,16
-Kingman,Bennett Township,Governor,,R,Sam Brownback,112
-Kingman,Canton Township,Governor,,R,Sam Brownback,29
-Kingman,Chikaskia Township,Governor,,R,Sam Brownback,25
-Kingman,Dale Township,Governor,,R,Sam Brownback,34
-Kingman,Dresden Township,Governor,,R,Sam Brownback,84
-Kingman,Eagle Township,Governor,,R,Sam Brownback,34
-Kingman,Eureka Township,Governor,,R,Sam Brownback,30
-Kingman,Evan Township,Governor,,R,Sam Brownback,159
-Kingman,Galesburg Township,Governor,,R,Sam Brownback,67
-Kingman,Hoosier Township,Governor,,R,Sam Brownback,38
-Kingman,Kingman Township,Governor,,R,Sam Brownback,44
-Kingman,Liberty Township,Governor,,R,Sam Brownback,31
-Kingman,Ninnescah Township,Governor,,R,Sam Brownback,97
-Kingman,Peters Township,Governor,,R,Sam Brownback,31
-Kingman,Richland Township,Governor,,R,Sam Brownback,21
-Kingman,Rochester Township,Governor,,R,Sam Brownback,41
-Kingman,Rural Township,Governor,,R,Sam Brownback,70
-Kingman,Union Township,Governor,,R,Sam Brownback,27
-Kingman,Valley Township,Governor,,R,Sam Brownback,26
-Kingman,Vinita Township,Governor,,R,Sam Brownback,70
-Kingman,White Township,Governor,,R,Sam Brownback,78
-Kingman,Kingman Ward 1,Governor,,R,Sam Brownback,141
-Kingman,Kingman Ward 2,Governor,,R,Sam Brownback,203
-Kingman,Kingman Ward 3,Governor,,R,Sam Brownback,71
-Kingman,Kingman Ward 4,Governor,,R,Sam Brownback,103
-Kingman,Prov,Governor,,R,Sam Brownback,14
-Kingman,Allen Township,Governor,,D,Paul Davis,6
-Kingman,Belmont Township,Governor,,D,Paul Davis,8
-Kingman,Bennett Township,Governor,,D,Paul Davis,71
-Kingman,Canton Township,Governor,,D,Paul Davis,7
-Kingman,Chikaskia Township,Governor,,D,Paul Davis,16
-Kingman,Dale Township,Governor,,D,Paul Davis,29
-Kingman,Dresden Township,Governor,,D,Paul Davis,55
-Kingman,Eagle Township,Governor,,D,Paul Davis,14
-Kingman,Eureka Township,Governor,,D,Paul Davis,13
-Kingman,Evan Township,Governor,,D,Paul Davis,48
-Kingman,Galesburg Township,Governor,,D,Paul Davis,24
-Kingman,Hoosier Township,Governor,,D,Paul Davis,15
-Kingman,Kingman Township,Governor,,D,Paul Davis,8
-Kingman,Liberty Township,Governor,,D,Paul Davis,21
-Kingman,Ninnescah Township,Governor,,D,Paul Davis,28
-Kingman,Peters Township,Governor,,D,Paul Davis,11
-Kingman,Richland Township,Governor,,D,Paul Davis,9
-Kingman,Rochester Township,Governor,,D,Paul Davis,25
-Kingman,Rural Township,Governor,,D,Paul Davis,40
-Kingman,Union Township,Governor,,D,Paul Davis,8
-Kingman,Valley Township,Governor,,D,Paul Davis,11
-Kingman,Vinita Township,Governor,,D,Paul Davis,36
-Kingman,White Township,Governor,,D,Paul Davis,49
-Kingman,Kingman Ward 1,Governor,,D,Paul Davis,116
-Kingman,Kingman Ward 2,Governor,,D,Paul Davis,179
-Kingman,Kingman Ward 3,Governor,,D,Paul Davis,68
-Kingman,Kingman Ward 4,Governor,,D,Paul Davis,79
-Kingman,Prov,Governor,,D,Paul Davis,8
-Kingman,Allen Township,Governor,,L,Keen Umbehr,4
-Kingman,Belmont Township,Governor,,L,Keen Umbehr,0
-Kingman,Bennett Township,Governor,,L,Keen Umbehr,14
-Kingman,Canton Township,Governor,,L,Keen Umbehr,1
-Kingman,Chikaskia Township,Governor,,L,Keen Umbehr,2
-Kingman,Dale Township,Governor,,L,Keen Umbehr,3
-Kingman,Dresden Township,Governor,,L,Keen Umbehr,9
-Kingman,Eagle Township,Governor,,L,Keen Umbehr,2
-Kingman,Eureka Township,Governor,,L,Keen Umbehr,1
-Kingman,Evan Township,Governor,,L,Keen Umbehr,8
-Kingman,Galesburg Township,Governor,,L,Keen Umbehr,3
-Kingman,Hoosier Township,Governor,,L,Keen Umbehr,3
-Kingman,Kingman Township,Governor,,L,Keen Umbehr,0
-Kingman,Liberty Township,Governor,,L,Keen Umbehr,2
-Kingman,Ninnescah Township,Governor,,L,Keen Umbehr,4
-Kingman,Peters Township,Governor,,L,Keen Umbehr,2
-Kingman,Richland Township,Governor,,L,Keen Umbehr,2
-Kingman,Rochester Township,Governor,,L,Keen Umbehr,4
-Kingman,Rural Township,Governor,,L,Keen Umbehr,8
-Kingman,Union Township,Governor,,L,Keen Umbehr,0
-Kingman,Valley Township,Governor,,L,Keen Umbehr,4
-Kingman,Vinita Township,Governor,,L,Keen Umbehr,5
-Kingman,White Township,Governor,,L,Keen Umbehr,6
-Kingman,Kingman Ward 1,Governor,,L,Keen Umbehr,14
-Kingman,Kingman Ward 2,Governor,,L,Keen Umbehr,25
-Kingman,Kingman Ward 3,Governor,,L,Keen Umbehr,10
-Kingman,Kingman Ward 4,Governor,,L,Keen Umbehr,6
-Kingman,Prov,Governor,,L,Keen Umbehr,2
-Kingman,Allen Township,Secretary of State,,R,Kris Kobach,31
-Kingman,Belmont Township,Secretary of State,,R,Kris Kobach,15
-Kingman,Bennett Township,Secretary of State,,R,Kris Kobach,129
-Kingman,Canton Township,Secretary of State,,R,Kris Kobach,32
-Kingman,Chikaskia Township,Secretary of State,,R,Kris Kobach,28
-Kingman,Dale Township,Secretary of State,,R,Kris Kobach,42
-Kingman,Dresden Township,Secretary of State,,R,Kris Kobach,102
-Kingman,Eagle Township,Secretary of State,,R,Kris Kobach,35
-Kingman,Eureka Township,Secretary of State,,R,Kris Kobach,34
-Kingman,Evan Township,Secretary of State,,R,Kris Kobach,175
-Kingman,Galesburg Township,Secretary of State,,R,Kris Kobach,70
-Kingman,Hoosier Township,Secretary of State,,R,Kris Kobach,39
-Kingman,Kingman Township,Secretary of State,,R,Kris Kobach,40
-Kingman,Liberty Township,Secretary of State,,R,Kris Kobach,36
-Kingman,Ninnescah Township,Secretary of State,,R,Kris Kobach,108
-Kingman,Peters Township,Secretary of State,,R,Kris Kobach,27
-Kingman,Richland Township,Secretary of State,,R,Kris Kobach,23
-Kingman,Rochester Township,Secretary of State,,R,Kris Kobach,46
-Kingman,Rural Township,Secretary of State,,R,Kris Kobach,67
-Kingman,Union Township,Secretary of State,,R,Kris Kobach,25
-Kingman,Valley Township,Secretary of State,,R,Kris Kobach,27
-Kingman,Vinita Township,Secretary of State,,R,Kris Kobach,71
-Kingman,White Township,Secretary of State,,R,Kris Kobach,90
-Kingman,Kingman Ward 1,Secretary of State,,R,Kris Kobach,165
-Kingman,Kingman Ward 2,Secretary of State,,R,Kris Kobach,253
-Kingman,Kingman Ward 3,Secretary of State,,R,Kris Kobach,95
-Kingman,Kingman Ward 4,Secretary of State,,R,Kris Kobach,119
-Kingman,Prov,Secretary of State,,R,Kris Kobach,17
-Kingman,Allen Township,Secretary of State,,D,Jean Schodorf,7
-Kingman,Belmont Township,Secretary of State,,D,Jean Schodorf,9
-Kingman,Bennett Township,Secretary of State,,D,Jean Schodorf,68
-Kingman,Canton Township,Secretary of State,,D,Jean Schodorf,5
-Kingman,Chikaskia Township,Secretary of State,,D,Jean Schodorf,15
-Kingman,Dale Township,Secretary of State,,D,Jean Schodorf,24
-Kingman,Dresden Township,Secretary of State,,D,Jean Schodorf,43
-Kingman,Eagle Township,Secretary of State,,D,Jean Schodorf,13
-Kingman,Eureka Township,Secretary of State,,D,Jean Schodorf,9
-Kingman,Evan Township,Secretary of State,,D,Jean Schodorf,38
-Kingman,Galesburg Township,Secretary of State,,D,Jean Schodorf,21
-Kingman,Hoosier Township,Secretary of State,,D,Jean Schodorf,17
-Kingman,Kingman Township,Secretary of State,,D,Jean Schodorf,11
-Kingman,Liberty Township,Secretary of State,,D,Jean Schodorf,19
-Kingman,Ninnescah Township,Secretary of State,,D,Jean Schodorf,23
-Kingman,Peters Township,Secretary of State,,D,Jean Schodorf,16
-Kingman,Richland Township,Secretary of State,,D,Jean Schodorf,8
-Kingman,Rochester Township,Secretary of State,,D,Jean Schodorf,25
-Kingman,Rural Township,Secretary of State,,D,Jean Schodorf,49
-Kingman,Union Township,Secretary of State,,D,Jean Schodorf,10
-Kingman,Valley Township,Secretary of State,,D,Jean Schodorf,12
-Kingman,Vinita Township,Secretary of State,,D,Jean Schodorf,35
-Kingman,White Township,Secretary of State,,D,Jean Schodorf,44
-Kingman,Kingman Ward 1,Secretary of State,,D,Jean Schodorf,100
-Kingman,Kingman Ward 2,Secretary of State,,D,Jean Schodorf,147
-Kingman,Kingman Ward 3,Secretary of State,,D,Jean Schodorf,49
-Kingman,Kingman Ward 4,Secretary of State,,D,Jean Schodorf,66
-Kingman,Prov,Secretary of State,,D,Jean Schodorf,7
-Kingman,Allen Township,Attorney General,,R,Derek Schmidt,33
-Kingman,Belmont Township,Attorney General,,R,Derek Schmidt,17
-Kingman,Bennett Township,Attorney General,,R,Derek Schmidt,145
-Kingman,Canton Township,Attorney General,,R,Derek Schmidt,37
-Kingman,Chikaskia Township,Attorney General,,R,Derek Schmidt,32
-Kingman,Dale Township,Attorney General,,R,Derek Schmidt,52
-Kingman,Dresden Township,Attorney General,,R,Derek Schmidt,112
-Kingman,Eagle Township,Attorney General,,R,Derek Schmidt,40
-Kingman,Eureka Township,Attorney General,,R,Derek Schmidt,38
-Kingman,Evan Township,Attorney General,,R,Derek Schmidt,185
-Kingman,Galesburg Township,Attorney General,,R,Derek Schmidt,73
-Kingman,Hoosier Township,Attorney General,,R,Derek Schmidt,51
-Kingman,Kingman Township,Attorney General,,R,Derek Schmidt,37
-Kingman,Liberty Township,Attorney General,,R,Derek Schmidt,43
-Kingman,Ninnescah Township,Attorney General,,R,Derek Schmidt,121
-Kingman,Peters Township,Attorney General,,R,Derek Schmidt,30
-Kingman,Richland Township,Attorney General,,R,Derek Schmidt,27
-Kingman,Rochester Township,Attorney General,,R,Derek Schmidt,59
-Kingman,Rural Township,Attorney General,,R,Derek Schmidt,77
-Kingman,Union Township,Attorney General,,R,Derek Schmidt,30
-Kingman,Valley Township,Attorney General,,R,Derek Schmidt,33
-Kingman,Vinita Township,Attorney General,,R,Derek Schmidt,86
-Kingman,White Township,Attorney General,,R,Derek Schmidt,113
-Kingman,Kingman Ward 1,Attorney General,,R,Derek Schmidt,203
-Kingman,Kingman Ward 2,Attorney General,,R,Derek Schmidt,302
-Kingman,Kingman Ward 3,Attorney General,,R,Derek Schmidt,108
-Kingman,Kingman Ward 4,Attorney General,,R,Derek Schmidt,139
-Kingman,Prov,Attorney General,,R,Derek Schmidt,19
-Kingman,Allen Township,Attorney General,,D,AJ Kotich,4
-Kingman,Belmont Township,Attorney General,,D,AJ Kotich,7
-Kingman,Bennett Township,Attorney General,,D,AJ Kotich,47
-Kingman,Canton Township,Attorney General,,D,AJ Kotich,0
-Kingman,Chikaskia Township,Attorney General,,D,AJ Kotich,11
-Kingman,Dale Township,Attorney General,,D,AJ Kotich,14
-Kingman,Dresden Township,Attorney General,,D,AJ Kotich,29
-Kingman,Eagle Township,Attorney General,,D,AJ Kotich,8
-Kingman,Eureka Township,Attorney General,,D,AJ Kotich,5
-Kingman,Evan Township,Attorney General,,D,AJ Kotich,25
-Kingman,Galesburg Township,Attorney General,,D,AJ Kotich,17
-Kingman,Hoosier Township,Attorney General,,D,AJ Kotich,5
-Kingman,Kingman Township,Attorney General,,D,AJ Kotich,10
-Kingman,Liberty Township,Attorney General,,D,AJ Kotich,10
-Kingman,Ninnescah Township,Attorney General,,D,AJ Kotich,10
-Kingman,Peters Township,Attorney General,,D,AJ Kotich,8
-Kingman,Richland Township,Attorney General,,D,AJ Kotich,5
-Kingman,Rochester Township,Attorney General,,D,AJ Kotich,11
-Kingman,Rural Township,Attorney General,,D,AJ Kotich,34
-Kingman,Union Township,Attorney General,,D,AJ Kotich,3
-Kingman,Valley Township,Attorney General,,D,AJ Kotich,7
-Kingman,Vinita Township,Attorney General,,D,AJ Kotich,16
-Kingman,White Township,Attorney General,,D,AJ Kotich,20
-Kingman,Kingman Ward 1,Attorney General,,D,AJ Kotich,59
-Kingman,Kingman Ward 2,Attorney General,,D,AJ Kotich,90
-Kingman,Kingman Ward 3,Attorney General,,D,AJ Kotich,34
-Kingman,Kingman Ward 4,Attorney General,,D,AJ Kotich,44
-Kingman,Prov,Attorney General,,D,AJ Kotich,5
-Kingman,Allen Township,State Treasurer,,R,Ron Estes,33
-Kingman,Belmont Township,State Treasurer,,R,Ron Estes,18
-Kingman,Bennett Township,State Treasurer,,R,Ron Estes,145
-Kingman,Canton Township,State Treasurer,,R,Ron Estes,32
-Kingman,Chikaskia Township,State Treasurer,,R,Ron Estes,26
-Kingman,Dale Township,State Treasurer,,R,Ron Estes,54
-Kingman,Dresden Township,State Treasurer,,R,Ron Estes,113
-Kingman,Eagle Township,State Treasurer,,R,Ron Estes,39
-Kingman,Eureka Township,State Treasurer,,R,Ron Estes,37
-Kingman,Evan Township,State Treasurer,,R,Ron Estes,181
-Kingman,Galesburg Township,State Treasurer,,R,Ron Estes,75
-Kingman,Hoosier Township,State Treasurer,,R,Ron Estes,48
-Kingman,Kingman Township,State Treasurer,,R,Ron Estes,40
-Kingman,Liberty Township,State Treasurer,,R,Ron Estes,44
-Kingman,Ninnescah Township,State Treasurer,,R,Ron Estes,117
-Kingman,Peters Township,State Treasurer,,R,Ron Estes,30
-Kingman,Richland Township,State Treasurer,,R,Ron Estes,27
-Kingman,Rochester Township,State Treasurer,,R,Ron Estes,51
-Kingman,Rural Township,State Treasurer,,R,Ron Estes,89
-Kingman,Union Township,State Treasurer,,R,Ron Estes,29
-Kingman,Valley Township,State Treasurer,,R,Ron Estes,28
-Kingman,Vinita Township,State Treasurer,,R,Ron Estes,86
-Kingman,White Township,State Treasurer,,R,Ron Estes,110
-Kingman,Kingman Ward 1,State Treasurer,,R,Ron Estes,206
-Kingman,Kingman Ward 2,State Treasurer,,R,Ron Estes,300
-Kingman,Kingman Ward 3,State Treasurer,,R,Ron Estes,101
-Kingman,Kingman Ward 4,State Treasurer,,R,Ron Estes,130
-Kingman,Prov,State Treasurer,,R,Ron Estes,21
-Kingman,Allen Township,State Treasurer,,D,Carmen Alldritt,4
-Kingman,Belmont Township,State Treasurer,,D,Carmen Alldritt,6
-Kingman,Bennett Township,State Treasurer,,D,Carmen Alldritt,48
-Kingman,Canton Township,State Treasurer,,D,Carmen Alldritt,5
-Kingman,Chikaskia Township,State Treasurer,,D,Carmen Alldritt,15
-Kingman,Dale Township,State Treasurer,,D,Carmen Alldritt,12
-Kingman,Dresden Township,State Treasurer,,D,Carmen Alldritt,32
-Kingman,Eagle Township,State Treasurer,,D,Carmen Alldritt,9
-Kingman,Eureka Township,State Treasurer,,D,Carmen Alldritt,6
-Kingman,Evan Township,State Treasurer,,D,Carmen Alldritt,32
-Kingman,Galesburg Township,State Treasurer,,D,Carmen Alldritt,15
-Kingman,Hoosier Township,State Treasurer,,D,Carmen Alldritt,8
-Kingman,Kingman Township,State Treasurer,,D,Carmen Alldritt,9
-Kingman,Liberty Township,State Treasurer,,D,Carmen Alldritt,10
-Kingman,Ninnescah Township,State Treasurer,,D,Carmen Alldritt,14
-Kingman,Peters Township,State Treasurer,,D,Carmen Alldritt,7
-Kingman,Richland Township,State Treasurer,,D,Carmen Alldritt,5
-Kingman,Rochester Township,State Treasurer,,D,Carmen Alldritt,19
-Kingman,Rural Township,State Treasurer,,D,Carmen Alldritt,26
-Kingman,Union Township,State Treasurer,,D,Carmen Alldritt,4
-Kingman,Valley Township,State Treasurer,,D,Carmen Alldritt,13
-Kingman,Vinita Township,State Treasurer,,D,Carmen Alldritt,19
-Kingman,White Township,State Treasurer,,D,Carmen Alldritt,23
-Kingman,Kingman Ward 1,State Treasurer,,D,Carmen Alldritt,61
-Kingman,Kingman Ward 2,State Treasurer,,D,Carmen Alldritt,84
-Kingman,Kingman Ward 3,State Treasurer,,D,Carmen Alldritt,39
-Kingman,Kingman Ward 4,State Treasurer,,D,Carmen Alldritt,49
-Kingman,Prov,State Treasurer,,D,Carmen Alldritt,3
-Kingman,Allen Township,Insurance Commissioner,,R,Ken Selzer,29
-Kingman,Belmont Township,Insurance Commissioner,,R,Ken Selzer,12
-Kingman,Bennett Township,Insurance Commissioner,,R,Ken Selzer,136
-Kingman,Canton Township,Insurance Commissioner,,R,Ken Selzer,30
-Kingman,Chikaskia Township,Insurance Commissioner,,R,Ken Selzer,24
-Kingman,Dale Township,Insurance Commissioner,,R,Ken Selzer,47
-Kingman,Dresden Township,Insurance Commissioner,,R,Ken Selzer,96
-Kingman,Eagle Township,Insurance Commissioner,,R,Ken Selzer,35
-Kingman,Eureka Township,Insurance Commissioner,,R,Ken Selzer,36
-Kingman,Evan Township,Insurance Commissioner,,R,Ken Selzer,172
-Kingman,Galesburg Township,Insurance Commissioner,,R,Ken Selzer,65
-Kingman,Hoosier Township,Insurance Commissioner,,R,Ken Selzer,41
-Kingman,Kingman Township,Insurance Commissioner,,R,Ken Selzer,32
-Kingman,Liberty Township,Insurance Commissioner,,R,Ken Selzer,37
-Kingman,Ninnescah Township,Insurance Commissioner,,R,Ken Selzer,103
-Kingman,Peters Township,Insurance Commissioner,,R,Ken Selzer,24
-Kingman,Richland Township,Insurance Commissioner,,R,Ken Selzer,24
-Kingman,Rochester Township,Insurance Commissioner,,R,Ken Selzer,47
-Kingman,Rural Township,Insurance Commissioner,,R,Ken Selzer,68
-Kingman,Union Township,Insurance Commissioner,,R,Ken Selzer,25
-Kingman,Valley Township,Insurance Commissioner,,R,Ken Selzer,30
-Kingman,Vinita Township,Insurance Commissioner,,R,Ken Selzer,78
-Kingman,White Township,Insurance Commissioner,,R,Ken Selzer,101
-Kingman,Kingman Ward 1,Insurance Commissioner,,R,Ken Selzer,181
-Kingman,Kingman Ward 2,Insurance Commissioner,,R,Ken Selzer,266
-Kingman,Kingman Ward 3,Insurance Commissioner,,R,Ken Selzer,94
-Kingman,Kingman Ward 4,Insurance Commissioner,,R,Ken Selzer,116
-Kingman,Prov,Insurance Commissioner,,R,Ken Selzer,20
-Kingman,Allen Township,Insurance Commissioner,,D,Dennis Anderson,5
-Kingman,Belmont Township,Insurance Commissioner,,D,Dennis Anderson,11
-Kingman,Bennett Township,Insurance Commissioner,,D,Dennis Anderson,50
-Kingman,Canton Township,Insurance Commissioner,,D,Dennis Anderson,6
-Kingman,Chikaskia Township,Insurance Commissioner,,D,Dennis Anderson,12
-Kingman,Dale Township,Insurance Commissioner,,D,Dennis Anderson,18
-Kingman,Dresden Township,Insurance Commissioner,,D,Dennis Anderson,40
-Kingman,Eagle Township,Insurance Commissioner,,D,Dennis Anderson,9
-Kingman,Eureka Township,Insurance Commissioner,,D,Dennis Anderson,7
-Kingman,Evan Township,Insurance Commissioner,,D,Dennis Anderson,33
-Kingman,Galesburg Township,Insurance Commissioner,,D,Dennis Anderson,19
-Kingman,Hoosier Township,Insurance Commissioner,,D,Dennis Anderson,13
-Kingman,Kingman Township,Insurance Commissioner,,D,Dennis Anderson,13
-Kingman,Liberty Township,Insurance Commissioner,,D,Dennis Anderson,15
-Kingman,Ninnescah Township,Insurance Commissioner,,D,Dennis Anderson,22
-Kingman,Peters Township,Insurance Commissioner,,D,Dennis Anderson,12
-Kingman,Richland Township,Insurance Commissioner,,D,Dennis Anderson,8
-Kingman,Rochester Township,Insurance Commissioner,,D,Dennis Anderson,21
-Kingman,Rural Township,Insurance Commissioner,,D,Dennis Anderson,38
-Kingman,Union Township,Insurance Commissioner,,D,Dennis Anderson,7
-Kingman,Valley Township,Insurance Commissioner,,D,Dennis Anderson,9
-Kingman,Vinita Township,Insurance Commissioner,,D,Dennis Anderson,24
-Kingman,White Township,Insurance Commissioner,,D,Dennis Anderson,28
-Kingman,Kingman Ward 1,Insurance Commissioner,,D,Dennis Anderson,75
-Kingman,Kingman Ward 2,Insurance Commissioner,,D,Dennis Anderson,111
-Kingman,Kingman Ward 3,Insurance Commissioner,,D,Dennis Anderson,41
-Kingman,Kingman Ward 4,Insurance Commissioner,,D,Dennis Anderson,61
-Kingman,Prov,Insurance Commissioner,,D,Dennis Anderson,4
-Kingman,Allen Township,State House,114,R,Jack Thimesch,30
-Kingman,Belmont Township,State House,114,R,Jack Thimesch,19
-Kingman,Bennett Township,State House,114,R,Jack Thimesch,129
-Kingman,Canton Township,State House,114,R,Jack Thimesch,33
-Kingman,Chikaskia Township,State House,114,R,Jack Thimesch,35
-Kingman,Dale Township,State House,114,R,Jack Thimesch,49
-Kingman,Dresden Township,State House,114,R,Jack Thimesch,112
-Kingman,Eagle Township,State House,114,R,Jack Thimesch,37
-Kingman,Eureka Township,State House,114,R,Jack Thimesch,36
-Kingman,Evan Township,State House,114,R,Jack Thimesch,172
-Kingman,Galesburg Township,State House,114,R,Jack Thimesch,66
-Kingman,Hoosier Township,State House,114,R,Jack Thimesch,43
-Kingman,Kingman Township,State House,114,R,Jack Thimesch,43
-Kingman,Liberty Township,State House,114,R,Jack Thimesch,36
-Kingman,Ninnescah Township,State House,114,R,Jack Thimesch,101
-Kingman,Peters Township,State House,114,R,Jack Thimesch,36
-Kingman,Richland Township,State House,114,R,Jack Thimesch,21
-Kingman,Rochester Township,State House,114,R,Jack Thimesch,50
-Kingman,Rural Township,State House,114,R,Jack Thimesch,81
-Kingman,Union Township,State House,114,R,Jack Thimesch,25
-Kingman,Valley Township,State House,114,R,Jack Thimesch,34
-Kingman,Vinita Township,State House,114,R,Jack Thimesch,70
-Kingman,White Township,State House,114,R,Jack Thimesch,101
-Kingman,Kingman Ward 1,State House,114,R,Jack Thimesch,176
-Kingman,Kingman Ward 2,State House,114,R,Jack Thimesch,273
-Kingman,Kingman Ward 3,State House,114,R,Jack Thimesch,93
-Kingman,Kingman Ward 4,State House,114,R,Jack Thimesch,130
-Kingman,Prov,State House,114,R,Jack Thimesch,19
-Kingman,Allen Township,State House,114,D,Mark Schnitker,8
-Kingman,Belmont Township,State House,114,D,Mark Schnitker,4
-Kingman,Bennett Township,State House,114,D,Mark Schnitker,65
-Kingman,Canton Township,State House,114,D,Mark Schnitker,4
-Kingman,Chikaskia Township,State House,114,D,Mark Schnitker,8
-Kingman,Dale Township,State House,114,D,Mark Schnitker,18
-Kingman,Dresden Township,State House,114,D,Mark Schnitker,35
-Kingman,Eagle Township,State House,114,D,Mark Schnitker,11
-Kingman,Eureka Township,State House,114,D,Mark Schnitker,8
-Kingman,Evan Township,State House,114,D,Mark Schnitker,40
-Kingman,Galesburg Township,State House,114,D,Mark Schnitker,24
-Kingman,Hoosier Township,State House,114,D,Mark Schnitker,12
-Kingman,Kingman Township,State House,114,D,Mark Schnitker,11
-Kingman,Liberty Township,State House,114,D,Mark Schnitker,18
-Kingman,Ninnescah Township,State House,114,D,Mark Schnitker,29
-Kingman,Peters Township,State House,114,D,Mark Schnitker,9
-Kingman,Richland Township,State House,114,D,Mark Schnitker,12
-Kingman,Rochester Township,State House,114,D,Mark Schnitker,21
-Kingman,Rural Township,State House,114,D,Mark Schnitker,33
-Kingman,Union Township,State House,114,D,Mark Schnitker,9
-Kingman,Valley Township,State House,114,D,Mark Schnitker,6
-Kingman,Vinita Township,State House,114,D,Mark Schnitker,33
-Kingman,White Township,State House,114,D,Mark Schnitker,34
-Kingman,Kingman Ward 1,State House,114,D,Mark Schnitker,93
-Kingman,Kingman Ward 2,State House,114,D,Mark Schnitker,131
-Kingman,Kingman Ward 3,State House,114,D,Mark Schnitker,55
-Kingman,Kingman Ward 4,State House,114,D,Mark Schnitker,55
-Kingman,Prov,State House,114,D,Mark Schnitker,5
+county,precinct,office,district,party,candidate,votes,vtd
+KINGMAN,Allen Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000010
+KINGMAN,Allen Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+KINGMAN,Allen Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000010
+KINGMAN,Belmont Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000020
+KINGMAN,Belmont Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+KINGMAN,Belmont Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000020
+KINGMAN,Bennett Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,000030
+KINGMAN,Bennett Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000030
+KINGMAN,Bennett Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",112,000030
+KINGMAN,Canton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000040
+KINGMAN,Canton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+KINGMAN,Canton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000040
+KINGMAN,Chikaskia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000050
+KINGMAN,Chikaskia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000050
+KINGMAN,Chikaskia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000050
+KINGMAN,Dale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000060
+KINGMAN,Dale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000060
+KINGMAN,Dale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000060
+KINGMAN,Dresden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000070
+KINGMAN,Dresden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000070
+KINGMAN,Dresden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",84,000070
+KINGMAN,Eagle Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000080
+KINGMAN,Eagle Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+KINGMAN,Eagle Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000080
+KINGMAN,Eureka Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000090
+KINGMAN,Eureka Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+KINGMAN,Eureka Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000090
+KINGMAN,Evan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000100
+KINGMAN,Evan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000100
+KINGMAN,Evan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",159,000100
+KINGMAN,Galesburg Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000110
+KINGMAN,Galesburg Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000110
+KINGMAN,Galesburg Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",67,000110
+KINGMAN,Hoosier Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000120
+KINGMAN,Hoosier Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000120
+KINGMAN,Hoosier Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000120
+KINGMAN,Kingman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000130
+KINGMAN,Kingman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000130
+KINGMAN,Kingman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000130
+KINGMAN,Kingman Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,00014A
+KINGMAN,Kingman Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00014A
+KINGMAN,Kingman Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",155,00014A
+KINGMAN,Kingman Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00014B
+KINGMAN,Kingman Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",179,000150
+KINGMAN,Kingman Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000150
+KINGMAN,Kingman Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",203,000150
+KINGMAN,Kingman Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",68,000160
+KINGMAN,Kingman Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000160
+KINGMAN,Kingman Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000160
+KINGMAN,Kingman Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",79,000170
+KINGMAN,Kingman Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000170
+KINGMAN,Kingman Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000170
+KINGMAN,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000180
+KINGMAN,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000180
+KINGMAN,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000180
+KINGMAN,Ninnescah Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000190
+KINGMAN,Ninnescah Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000190
+KINGMAN,Ninnescah Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",97,000190
+KINGMAN,Peters Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000200
+KINGMAN,Peters Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000200
+KINGMAN,Peters Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000200
+KINGMAN,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000210
+KINGMAN,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000210
+KINGMAN,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000210
+KINGMAN,Rochester Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000220
+KINGMAN,Rochester Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000220
+KINGMAN,Rochester Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000220
+KINGMAN,Rural Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000230
+KINGMAN,Rural Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000230
+KINGMAN,Rural Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000230
+KINGMAN,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000240
+KINGMAN,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000240
+KINGMAN,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000240
+KINGMAN,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000250
+KINGMAN,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000250
+KINGMAN,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000250
+KINGMAN,Vinita Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000260
+KINGMAN,Vinita Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000260
+KINGMAN,Vinita Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000260
+KINGMAN,White Township Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,00027A
+KINGMAN,White Township Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00027A
+KINGMAN,White Township Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,00027A
+KINGMAN,White Township Part A Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00027B
+KINGMAN,White Township Part A Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00027B
+KINGMAN,White Township Part A Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00027B
+KINGMAN,White Township Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,00027C
+KINGMAN,White Township Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,00027C
+KINGMAN,White Township Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,00027C
+KINGMAN,Allen Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",8,000010
+KINGMAN,Allen Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",30,000010
+KINGMAN,Belmont Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",4,000020
+KINGMAN,Belmont Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",19,000020
+KINGMAN,Bennett Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",65,000030
+KINGMAN,Bennett Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",129,000030
+KINGMAN,Canton Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",4,000040
+KINGMAN,Canton Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",33,000040
+KINGMAN,Chikaskia Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",8,000050
+KINGMAN,Chikaskia Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",35,000050
+KINGMAN,Dale Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",18,000060
+KINGMAN,Dale Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",48,000060
+KINGMAN,Dresden Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",36,000070
+KINGMAN,Dresden Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",112,000070
+KINGMAN,Eagle Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",11,000080
+KINGMAN,Eagle Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",37,000080
+KINGMAN,Eureka Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",8,000090
+KINGMAN,Eureka Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",36,000090
+KINGMAN,Evan Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",40,000100
+KINGMAN,Evan Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",172,000100
+KINGMAN,Galesburg Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",24,000110
+KINGMAN,Galesburg Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",66,000110
+KINGMAN,Hoosier Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",12,000120
+KINGMAN,Hoosier Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",43,000120
+KINGMAN,Kingman Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",11,000130
+KINGMAN,Kingman Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",43,000130
+KINGMAN,Kingman Ward 1,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",98,00014A
+KINGMAN,Kingman Ward 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",195,00014A
+KINGMAN,Kingman Ward 1 Exclave,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00014B
+KINGMAN,Kingman Ward 2,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",131,000150
+KINGMAN,Kingman Ward 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",273,000150
+KINGMAN,Kingman Ward 3,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",55,000160
+KINGMAN,Kingman Ward 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",93,000160
+KINGMAN,Kingman Ward 4,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",55,000170
+KINGMAN,Kingman Ward 4,Kansas House of Representatives,114,Republican,"Thimesch, Jack",130,000170
+KINGMAN,Liberty Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",18,000180
+KINGMAN,Liberty Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",36,000180
+KINGMAN,Ninnescah Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",29,000190
+KINGMAN,Ninnescah Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",101,000190
+KINGMAN,Peters Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",9,000200
+KINGMAN,Peters Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",36,000200
+KINGMAN,Richland Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",12,000210
+KINGMAN,Richland Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",21,000210
+KINGMAN,Rochester Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",21,000220
+KINGMAN,Rochester Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",50,000220
+KINGMAN,Rural Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",33,000230
+KINGMAN,Rural Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",81,000230
+KINGMAN,Union Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",9,000240
+KINGMAN,Union Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",25,000240
+KINGMAN,Valley Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",6,000250
+KINGMAN,Valley Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",34,000250
+KINGMAN,Vinita Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",33,000260
+KINGMAN,Vinita Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",70,000260
+KINGMAN,White Township Part A,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",16,00027A
+KINGMAN,White Township Part A,Kansas House of Representatives,114,Republican,"Thimesch, Jack",59,00027A
+KINGMAN,White Township Part A Enclave,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",0,00027B
+KINGMAN,White Township Part A Enclave,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00027B
+KINGMAN,White Township Part B,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",18,00027C
+KINGMAN,White Township Part B,Kansas House of Representatives,114,Republican,"Thimesch, Jack",42,00027C
+KINGMAN,Allen Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",6,000010
+KINGMAN,Allen Township,United States House of Representatives,4,Republican,"Pompeo, Mike",32,000010
+KINGMAN,Belmont Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",6,000020
+KINGMAN,Belmont Township,United States House of Representatives,4,Republican,"Pompeo, Mike",17,000020
+KINGMAN,Bennett Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",45,000030
+KINGMAN,Bennett Township,United States House of Representatives,4,Republican,"Pompeo, Mike",149,000030
+KINGMAN,Canton Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000040
+KINGMAN,Canton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000040
+KINGMAN,Chikaskia Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",12,000050
+KINGMAN,Chikaskia Township,United States House of Representatives,4,Republican,"Pompeo, Mike",31,000050
+KINGMAN,Dale Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",17,000060
+KINGMAN,Dale Township,United States House of Representatives,4,Republican,"Pompeo, Mike",48,000060
+KINGMAN,Dresden Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",36,000070
+KINGMAN,Dresden Township,United States House of Representatives,4,Republican,"Pompeo, Mike",112,000070
+KINGMAN,Eagle Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,000080
+KINGMAN,Eagle Township,United States House of Representatives,4,Republican,"Pompeo, Mike",39,000080
+KINGMAN,Eureka Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",6,000090
+KINGMAN,Eureka Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000090
+KINGMAN,Evan Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",25,000100
+KINGMAN,Evan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",187,000100
+KINGMAN,Galesburg Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,000110
+KINGMAN,Galesburg Township,United States House of Representatives,4,Republican,"Pompeo, Mike",71,000110
+KINGMAN,Hoosier Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000120
+KINGMAN,Hoosier Township,United States House of Representatives,4,Republican,"Pompeo, Mike",46,000120
+KINGMAN,Kingman Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",7,000130
+KINGMAN,Kingman Township,United States House of Representatives,4,Republican,"Pompeo, Mike",45,000130
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",74,00014A
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",215,00014A
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00014B
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",103,000150
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",294,000150
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",43,000160
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",101,000160
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",52,000170
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",133,000170
+KINGMAN,Liberty Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,000180
+KINGMAN,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Mike",45,000180
+KINGMAN,Ninnescah Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",13,000190
+KINGMAN,Ninnescah Township,United States House of Representatives,4,Republican,"Pompeo, Mike",118,000190
+KINGMAN,Peters Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",7,000200
+KINGMAN,Peters Township,United States House of Representatives,4,Republican,"Pompeo, Mike",35,000200
+KINGMAN,Richland Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",6,000210
+KINGMAN,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",27,000210
+KINGMAN,Rochester Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",24,000220
+KINGMAN,Rochester Township,United States House of Representatives,4,Republican,"Pompeo, Mike",46,000220
+KINGMAN,Rural Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",32,000230
+KINGMAN,Rural Township,United States House of Representatives,4,Republican,"Pompeo, Mike",81,000230
+KINGMAN,Union Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000240
+KINGMAN,Union Township,United States House of Representatives,4,Republican,"Pompeo, Mike",27,000240
+KINGMAN,Valley Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000250
+KINGMAN,Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",33,000250
+KINGMAN,Vinita Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",31,000260
+KINGMAN,Vinita Township,United States House of Representatives,4,Republican,"Pompeo, Mike",78,000260
+KINGMAN,White Township Part A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",18,00027A
+KINGMAN,White Township Part A,United States House of Representatives,4,Republican,"Pompeo, Mike",56,00027A
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00027B
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00027B
+KINGMAN,White Township Part B,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",10,00027C
+KINGMAN,White Township Part B,United States House of Representatives,4,Republican,"Pompeo, Mike",48,00027C
+KINGMAN,Allen Township,Attorney General,,Democratic,"Kotich, A.J.",4,000010
+KINGMAN,Allen Township,Attorney General,,Republican,"Schmidt, Derek",33,000010
+KINGMAN,Belmont Township,Attorney General,,Democratic,"Kotich, A.J.",7,000020
+KINGMAN,Belmont Township,Attorney General,,Republican,"Schmidt, Derek",17,000020
+KINGMAN,Bennett Township,Attorney General,,Democratic,"Kotich, A.J.",47,000030
+KINGMAN,Bennett Township,Attorney General,,Republican,"Schmidt, Derek",146,000030
+KINGMAN,Canton Township,Attorney General,,Democratic,"Kotich, A.J.",0,000040
+KINGMAN,Canton Township,Attorney General,,Republican,"Schmidt, Derek",37,000040
+KINGMAN,Chikaskia Township,Attorney General,,Democratic,"Kotich, A.J.",11,000050
+KINGMAN,Chikaskia Township,Attorney General,,Republican,"Schmidt, Derek",32,000050
+KINGMAN,Dale Township,Attorney General,,Democratic,"Kotich, A.J.",14,000060
+KINGMAN,Dale Township,Attorney General,,Republican,"Schmidt, Derek",52,000060
+KINGMAN,Dresden Township,Attorney General,,Democratic,"Kotich, A.J.",29,000070
+KINGMAN,Dresden Township,Attorney General,,Republican,"Schmidt, Derek",112,000070
+KINGMAN,Eagle Township,Attorney General,,Democratic,"Kotich, A.J.",8,000080
+KINGMAN,Eagle Township,Attorney General,,Republican,"Schmidt, Derek",40,000080
+KINGMAN,Eureka Township,Attorney General,,Democratic,"Kotich, A.J.",5,000090
+KINGMAN,Eureka Township,Attorney General,,Republican,"Schmidt, Derek",38,000090
+KINGMAN,Evan Township,Attorney General,,Democratic,"Kotich, A.J.",25,000100
+KINGMAN,Evan Township,Attorney General,,Republican,"Schmidt, Derek",185,000100
+KINGMAN,Galesburg Township,Attorney General,,Democratic,"Kotich, A.J.",17,000110
+KINGMAN,Galesburg Township,Attorney General,,Republican,"Schmidt, Derek",73,000110
+KINGMAN,Hoosier Township,Attorney General,,Democratic,"Kotich, A.J.",5,000120
+KINGMAN,Hoosier Township,Attorney General,,Republican,"Schmidt, Derek",51,000120
+KINGMAN,Kingman Township,Attorney General,,Democratic,"Kotich, A.J.",10,000130
+KINGMAN,Kingman Township,Attorney General,,Republican,"Schmidt, Derek",37,000130
+KINGMAN,Kingman Ward 1,Attorney General,,Democratic,"Kotich, A.J.",64,00014A
+KINGMAN,Kingman Ward 1,Attorney General,,Republican,"Schmidt, Derek",222,00014A
+KINGMAN,Kingman Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00014B
+KINGMAN,Kingman Ward 2,Attorney General,,Democratic,"Kotich, A.J.",90,000150
+KINGMAN,Kingman Ward 2,Attorney General,,Republican,"Schmidt, Derek",302,000150
+KINGMAN,Kingman Ward 3,Attorney General,,Democratic,"Kotich, A.J.",34,000160
+KINGMAN,Kingman Ward 3,Attorney General,,Republican,"Schmidt, Derek",108,000160
+KINGMAN,Kingman Ward 4,Attorney General,,Democratic,"Kotich, A.J.",44,000170
+KINGMAN,Kingman Ward 4,Attorney General,,Republican,"Schmidt, Derek",139,000170
+KINGMAN,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",10,000180
+KINGMAN,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",43,000180
+KINGMAN,Ninnescah Township,Attorney General,,Democratic,"Kotich, A.J.",10,000190
+KINGMAN,Ninnescah Township,Attorney General,,Republican,"Schmidt, Derek",121,000190
+KINGMAN,Peters Township,Attorney General,,Democratic,"Kotich, A.J.",8,000200
+KINGMAN,Peters Township,Attorney General,,Republican,"Schmidt, Derek",30,000200
+KINGMAN,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",5,000210
+KINGMAN,Richland Township,Attorney General,,Republican,"Schmidt, Derek",27,000210
+KINGMAN,Rochester Township,Attorney General,,Democratic,"Kotich, A.J.",11,000220
+KINGMAN,Rochester Township,Attorney General,,Republican,"Schmidt, Derek",59,000220
+KINGMAN,Rural Township,Attorney General,,Democratic,"Kotich, A.J.",34,000230
+KINGMAN,Rural Township,Attorney General,,Republican,"Schmidt, Derek",77,000230
+KINGMAN,Union Township,Attorney General,,Democratic,"Kotich, A.J.",3,000240
+KINGMAN,Union Township,Attorney General,,Republican,"Schmidt, Derek",30,000240
+KINGMAN,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",7,000250
+KINGMAN,Valley Township,Attorney General,,Republican,"Schmidt, Derek",33,000250
+KINGMAN,Vinita Township,Attorney General,,Democratic,"Kotich, A.J.",16,000260
+KINGMAN,Vinita Township,Attorney General,,Republican,"Schmidt, Derek",86,000260
+KINGMAN,White Township Part A,Attorney General,,Democratic,"Kotich, A.J.",11,00027A
+KINGMAN,White Township Part A,Attorney General,,Republican,"Schmidt, Derek",64,00027A
+KINGMAN,White Township Part A Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00027B
+KINGMAN,White Township Part A Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00027B
+KINGMAN,White Township Part B,Attorney General,,Democratic,"Kotich, A.J.",9,00027C
+KINGMAN,White Township Part B,Attorney General,,Republican,"Schmidt, Derek",49,00027C
+KINGMAN,Allen Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000010
+KINGMAN,Allen Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000010
+KINGMAN,Belmont Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000020
+KINGMAN,Belmont Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000020
+KINGMAN,Bennett Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000030
+KINGMAN,Bennett Township,Commissioner of Insurance,,Republican,"Selzer, Ken",136,000030
+KINGMAN,Canton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000040
+KINGMAN,Canton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000040
+KINGMAN,Chikaskia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000050
+KINGMAN,Chikaskia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000050
+KINGMAN,Dale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000060
+KINGMAN,Dale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000060
+KINGMAN,Dresden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000070
+KINGMAN,Dresden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",96,000070
+KINGMAN,Eagle Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000080
+KINGMAN,Eagle Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000080
+KINGMAN,Eureka Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000090
+KINGMAN,Eureka Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000090
+KINGMAN,Evan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000100
+KINGMAN,Evan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",172,000100
+KINGMAN,Galesburg Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000110
+KINGMAN,Galesburg Township,Commissioner of Insurance,,Republican,"Selzer, Ken",65,000110
+KINGMAN,Hoosier Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000120
+KINGMAN,Hoosier Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000120
+KINGMAN,Kingman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000130
+KINGMAN,Kingman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000130
+KINGMAN,Kingman Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",79,00014A
+KINGMAN,Kingman Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",201,00014A
+KINGMAN,Kingman Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00014B
+KINGMAN,Kingman Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",111,000150
+KINGMAN,Kingman Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",266,000150
+KINGMAN,Kingman Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000160
+KINGMAN,Kingman Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",94,000160
+KINGMAN,Kingman Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,000170
+KINGMAN,Kingman Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",116,000170
+KINGMAN,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000180
+KINGMAN,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000180
+KINGMAN,Ninnescah Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000190
+KINGMAN,Ninnescah Township,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000190
+KINGMAN,Peters Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000200
+KINGMAN,Peters Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000200
+KINGMAN,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000210
+KINGMAN,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000210
+KINGMAN,Rochester Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000220
+KINGMAN,Rochester Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000220
+KINGMAN,Rural Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000230
+KINGMAN,Rural Township,Commissioner of Insurance,,Republican,"Selzer, Ken",68,000230
+KINGMAN,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000240
+KINGMAN,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000240
+KINGMAN,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000250
+KINGMAN,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000250
+KINGMAN,Vinita Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000260
+KINGMAN,Vinita Township,Commissioner of Insurance,,Republican,"Selzer, Ken",78,000260
+KINGMAN,White Township Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,00027A
+KINGMAN,White Township Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",56,00027A
+KINGMAN,White Township Part A Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00027B
+KINGMAN,White Township Part A Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00027B
+KINGMAN,White Township Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,00027C
+KINGMAN,White Township Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",45,00027C
+KINGMAN,Allen Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000010
+KINGMAN,Allen Township,Secretary of State,,Republican,"Kobach, Kris",31,000010
+KINGMAN,Belmont Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000020
+KINGMAN,Belmont Township,Secretary of State,,Republican,"Kobach, Kris",15,000020
+KINGMAN,Bennett Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000030
+KINGMAN,Bennett Township,Secretary of State,,Republican,"Kobach, Kris",129,000030
+KINGMAN,Canton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000040
+KINGMAN,Canton Township,Secretary of State,,Republican,"Kobach, Kris",32,000040
+KINGMAN,Chikaskia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000050
+KINGMAN,Chikaskia Township,Secretary of State,,Republican,"Kobach, Kris",28,000050
+KINGMAN,Dale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000060
+KINGMAN,Dale Township,Secretary of State,,Republican,"Kobach, Kris",42,000060
+KINGMAN,Dresden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000070
+KINGMAN,Dresden Township,Secretary of State,,Republican,"Kobach, Kris",102,000070
+KINGMAN,Eagle Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000080
+KINGMAN,Eagle Township,Secretary of State,,Republican,"Kobach, Kris",35,000080
+KINGMAN,Eureka Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000090
+KINGMAN,Eureka Township,Secretary of State,,Republican,"Kobach, Kris",34,000090
+KINGMAN,Evan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000100
+KINGMAN,Evan Township,Secretary of State,,Republican,"Kobach, Kris",175,000100
+KINGMAN,Galesburg Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000110
+KINGMAN,Galesburg Township,Secretary of State,,Republican,"Kobach, Kris",70,000110
+KINGMAN,Hoosier Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000120
+KINGMAN,Hoosier Township,Secretary of State,,Republican,"Kobach, Kris",39,000120
+KINGMAN,Kingman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000130
+KINGMAN,Kingman Township,Secretary of State,,Republican,"Kobach, Kris",40,000130
+KINGMAN,Kingman Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",107,00014A
+KINGMAN,Kingman Ward 1,Secretary of State,,Republican,"Kobach, Kris",182,00014A
+KINGMAN,Kingman Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00014B
+KINGMAN,Kingman Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",147,000150
+KINGMAN,Kingman Ward 2,Secretary of State,,Republican,"Kobach, Kris",253,000150
+KINGMAN,Kingman Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000160
+KINGMAN,Kingman Ward 3,Secretary of State,,Republican,"Kobach, Kris",95,000160
+KINGMAN,Kingman Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,000170
+KINGMAN,Kingman Ward 4,Secretary of State,,Republican,"Kobach, Kris",119,000170
+KINGMAN,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000180
+KINGMAN,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",36,000180
+KINGMAN,Ninnescah Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000190
+KINGMAN,Ninnescah Township,Secretary of State,,Republican,"Kobach, Kris",108,000190
+KINGMAN,Peters Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000200
+KINGMAN,Peters Township,Secretary of State,,Republican,"Kobach, Kris",27,000200
+KINGMAN,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000210
+KINGMAN,Richland Township,Secretary of State,,Republican,"Kobach, Kris",23,000210
+KINGMAN,Rochester Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000220
+KINGMAN,Rochester Township,Secretary of State,,Republican,"Kobach, Kris",46,000220
+KINGMAN,Rural Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000230
+KINGMAN,Rural Township,Secretary of State,,Republican,"Kobach, Kris",67,000230
+KINGMAN,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000240
+KINGMAN,Union Township,Secretary of State,,Republican,"Kobach, Kris",25,000240
+KINGMAN,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000250
+KINGMAN,Valley Township,Secretary of State,,Republican,"Kobach, Kris",27,000250
+KINGMAN,Vinita Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000260
+KINGMAN,Vinita Township,Secretary of State,,Republican,"Kobach, Kris",71,000260
+KINGMAN,White Township Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,00027A
+KINGMAN,White Township Part A,Secretary of State,,Republican,"Kobach, Kris",53,00027A
+KINGMAN,White Township Part A Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00027B
+KINGMAN,White Township Part A Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00027B
+KINGMAN,White Township Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,00027C
+KINGMAN,White Township Part B,Secretary of State,,Republican,"Kobach, Kris",37,00027C
+KINGMAN,Allen Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000010
+KINGMAN,Allen Township,State Treasurer,,Republican,"Estes, Ron",33,000010
+KINGMAN,Belmont Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000020
+KINGMAN,Belmont Township,State Treasurer,,Republican,"Estes, Ron",18,000020
+KINGMAN,Bennett Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000030
+KINGMAN,Bennett Township,State Treasurer,,Republican,"Estes, Ron",145,000030
+KINGMAN,Canton Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000040
+KINGMAN,Canton Township,State Treasurer,,Republican,"Estes, Ron",32,000040
+KINGMAN,Chikaskia Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000050
+KINGMAN,Chikaskia Township,State Treasurer,,Republican,"Estes, Ron",26,000050
+KINGMAN,Dale Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000060
+KINGMAN,Dale Township,State Treasurer,,Republican,"Estes, Ron",54,000060
+KINGMAN,Dresden Township,State Treasurer,,Democratic,"Alldritt, Carmen",32,000070
+KINGMAN,Dresden Township,State Treasurer,,Republican,"Estes, Ron",113,000070
+KINGMAN,Eagle Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000080
+KINGMAN,Eagle Township,State Treasurer,,Republican,"Estes, Ron",39,000080
+KINGMAN,Eureka Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000090
+KINGMAN,Eureka Township,State Treasurer,,Republican,"Estes, Ron",37,000090
+KINGMAN,Evan Township,State Treasurer,,Democratic,"Alldritt, Carmen",32,000100
+KINGMAN,Evan Township,State Treasurer,,Republican,"Estes, Ron",181,000100
+KINGMAN,Galesburg Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000110
+KINGMAN,Galesburg Township,State Treasurer,,Republican,"Estes, Ron",75,000110
+KINGMAN,Hoosier Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000120
+KINGMAN,Hoosier Township,State Treasurer,,Republican,"Estes, Ron",48,000120
+KINGMAN,Kingman Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000130
+KINGMAN,Kingman Township,State Treasurer,,Republican,"Estes, Ron",40,000130
+KINGMAN,Kingman Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",64,00014A
+KINGMAN,Kingman Ward 1,State Treasurer,,Republican,"Estes, Ron",227,00014A
+KINGMAN,Kingman Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00014B
+KINGMAN,Kingman Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",84,000150
+KINGMAN,Kingman Ward 2,State Treasurer,,Republican,"Estes, Ron",300,000150
+KINGMAN,Kingman Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",39,000160
+KINGMAN,Kingman Ward 3,State Treasurer,,Republican,"Estes, Ron",101,000160
+KINGMAN,Kingman Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",49,000170
+KINGMAN,Kingman Ward 4,State Treasurer,,Republican,"Estes, Ron",130,000170
+KINGMAN,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000180
+KINGMAN,Liberty Township,State Treasurer,,Republican,"Estes, Ron",44,000180
+KINGMAN,Ninnescah Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000190
+KINGMAN,Ninnescah Township,State Treasurer,,Republican,"Estes, Ron",117,000190
+KINGMAN,Peters Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000200
+KINGMAN,Peters Township,State Treasurer,,Republican,"Estes, Ron",30,000200
+KINGMAN,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000210
+KINGMAN,Richland Township,State Treasurer,,Republican,"Estes, Ron",27,000210
+KINGMAN,Rochester Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000220
+KINGMAN,Rochester Township,State Treasurer,,Republican,"Estes, Ron",51,000220
+KINGMAN,Rural Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000230
+KINGMAN,Rural Township,State Treasurer,,Republican,"Estes, Ron",89,000230
+KINGMAN,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000240
+KINGMAN,Union Township,State Treasurer,,Republican,"Estes, Ron",29,000240
+KINGMAN,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000250
+KINGMAN,Valley Township,State Treasurer,,Republican,"Estes, Ron",28,000250
+KINGMAN,Vinita Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000260
+KINGMAN,Vinita Township,State Treasurer,,Republican,"Estes, Ron",86,000260
+KINGMAN,White Township Part A,State Treasurer,,Democratic,"Alldritt, Carmen",13,00027A
+KINGMAN,White Township Part A,State Treasurer,,Republican,"Estes, Ron",61,00027A
+KINGMAN,White Township Part A Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00027B
+KINGMAN,White Township Part A Enclave,State Treasurer,,Republican,"Estes, Ron",0,00027B
+KINGMAN,White Township Part B,State Treasurer,,Democratic,"Alldritt, Carmen",10,00027C
+KINGMAN,White Township Part B,State Treasurer,,Republican,"Estes, Ron",49,00027C
+KINGMAN,Allen Township,United States Senate,,independent,"Orman, Greg",8,000010
+KINGMAN,Allen Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+KINGMAN,Allen Township,United States Senate,,Republican,"Roberts, Pat",30,000010
+KINGMAN,Belmont Township,United States Senate,,independent,"Orman, Greg",8,000020
+KINGMAN,Belmont Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+KINGMAN,Belmont Township,United States Senate,,Republican,"Roberts, Pat",15,000020
+KINGMAN,Bennett Township,United States Senate,,independent,"Orman, Greg",61,000030
+KINGMAN,Bennett Township,United States Senate,,Libertarian,"Batson, Randall",11,000030
+KINGMAN,Bennett Township,United States Senate,,Republican,"Roberts, Pat",126,000030
+KINGMAN,Canton Township,United States Senate,,independent,"Orman, Greg",6,000040
+KINGMAN,Canton Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+KINGMAN,Canton Township,United States Senate,,Republican,"Roberts, Pat",31,000040
+KINGMAN,Chikaskia Township,United States Senate,,independent,"Orman, Greg",17,000050
+KINGMAN,Chikaskia Township,United States Senate,,Libertarian,"Batson, Randall",3,000050
+KINGMAN,Chikaskia Township,United States Senate,,Republican,"Roberts, Pat",24,000050
+KINGMAN,Dale Township,United States Senate,,independent,"Orman, Greg",24,000060
+KINGMAN,Dale Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+KINGMAN,Dale Township,United States Senate,,Republican,"Roberts, Pat",40,000060
+KINGMAN,Dresden Township,United States Senate,,independent,"Orman, Greg",44,000070
+KINGMAN,Dresden Township,United States Senate,,Libertarian,"Batson, Randall",9,000070
+KINGMAN,Dresden Township,United States Senate,,Republican,"Roberts, Pat",93,000070
+KINGMAN,Eagle Township,United States Senate,,independent,"Orman, Greg",14,000080
+KINGMAN,Eagle Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+KINGMAN,Eagle Township,United States Senate,,Republican,"Roberts, Pat",35,000080
+KINGMAN,Eureka Township,United States Senate,,independent,"Orman, Greg",11,000090
+KINGMAN,Eureka Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+KINGMAN,Eureka Township,United States Senate,,Republican,"Roberts, Pat",33,000090
+KINGMAN,Evan Township,United States Senate,,independent,"Orman, Greg",40,000100
+KINGMAN,Evan Township,United States Senate,,Libertarian,"Batson, Randall",12,000100
+KINGMAN,Evan Township,United States Senate,,Republican,"Roberts, Pat",161,000100
+KINGMAN,Galesburg Township,United States Senate,,independent,"Orman, Greg",24,000110
+KINGMAN,Galesburg Township,United States Senate,,Libertarian,"Batson, Randall",4,000110
+KINGMAN,Galesburg Township,United States Senate,,Republican,"Roberts, Pat",67,000110
+KINGMAN,Hoosier Township,United States Senate,,independent,"Orman, Greg",12,000120
+KINGMAN,Hoosier Township,United States Senate,,Libertarian,"Batson, Randall",2,000120
+KINGMAN,Hoosier Township,United States Senate,,Republican,"Roberts, Pat",42,000120
+KINGMAN,Kingman Township,United States Senate,,independent,"Orman, Greg",10,000130
+KINGMAN,Kingman Township,United States Senate,,Libertarian,"Batson, Randall",1,000130
+KINGMAN,Kingman Township,United States Senate,,Republican,"Roberts, Pat",42,000130
+KINGMAN,Kingman Ward 1,United States Senate,,independent,"Orman, Greg",99,00014A
+KINGMAN,Kingman Ward 1,United States Senate,,Libertarian,"Batson, Randall",18,00014A
+KINGMAN,Kingman Ward 1,United States Senate,,Republican,"Roberts, Pat",176,00014A
+KINGMAN,Kingman Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00014B
+KINGMAN,Kingman Ward 2,United States Senate,,independent,"Orman, Greg",157,000150
+KINGMAN,Kingman Ward 2,United States Senate,,Libertarian,"Batson, Randall",20,000150
+KINGMAN,Kingman Ward 2,United States Senate,,Republican,"Roberts, Pat",229,000150
+KINGMAN,Kingman Ward 3,United States Senate,,independent,"Orman, Greg",56,000160
+KINGMAN,Kingman Ward 3,United States Senate,,Libertarian,"Batson, Randall",8,000160
+KINGMAN,Kingman Ward 3,United States Senate,,Republican,"Roberts, Pat",80,000160
+KINGMAN,Kingman Ward 4,United States Senate,,independent,"Orman, Greg",66,000170
+KINGMAN,Kingman Ward 4,United States Senate,,Libertarian,"Batson, Randall",7,000170
+KINGMAN,Kingman Ward 4,United States Senate,,Republican,"Roberts, Pat",114,000170
+KINGMAN,Liberty Township,United States Senate,,independent,"Orman, Greg",19,000180
+KINGMAN,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",3,000180
+KINGMAN,Liberty Township,United States Senate,,Republican,"Roberts, Pat",33,000180
+KINGMAN,Ninnescah Township,United States Senate,,independent,"Orman, Greg",22,000190
+KINGMAN,Ninnescah Township,United States Senate,,Libertarian,"Batson, Randall",7,000190
+KINGMAN,Ninnescah Township,United States Senate,,Republican,"Roberts, Pat",100,000190
+KINGMAN,Peters Township,United States Senate,,independent,"Orman, Greg",11,000200
+KINGMAN,Peters Township,United States Senate,,Libertarian,"Batson, Randall",3,000200
+KINGMAN,Peters Township,United States Senate,,Republican,"Roberts, Pat",32,000200
+KINGMAN,Richland Township,United States Senate,,independent,"Orman, Greg",9,000210
+KINGMAN,Richland Township,United States Senate,,Libertarian,"Batson, Randall",1,000210
+KINGMAN,Richland Township,United States Senate,,Republican,"Roberts, Pat",22,000210
+KINGMAN,Rochester Township,United States Senate,,independent,"Orman, Greg",21,000220
+KINGMAN,Rochester Township,United States Senate,,Libertarian,"Batson, Randall",3,000220
+KINGMAN,Rochester Township,United States Senate,,Republican,"Roberts, Pat",47,000220
+KINGMAN,Rural Township,United States Senate,,independent,"Orman, Greg",44,000230
+KINGMAN,Rural Township,United States Senate,,Libertarian,"Batson, Randall",7,000230
+KINGMAN,Rural Township,United States Senate,,Republican,"Roberts, Pat",66,000230
+KINGMAN,Union Township,United States Senate,,independent,"Orman, Greg",7,000240
+KINGMAN,Union Township,United States Senate,,Libertarian,"Batson, Randall",1,000240
+KINGMAN,Union Township,United States Senate,,Republican,"Roberts, Pat",27,000240
+KINGMAN,Valley Township,United States Senate,,independent,"Orman, Greg",14,000250
+KINGMAN,Valley Township,United States Senate,,Libertarian,"Batson, Randall",0,000250
+KINGMAN,Valley Township,United States Senate,,Republican,"Roberts, Pat",27,000250
+KINGMAN,Vinita Township,United States Senate,,independent,"Orman, Greg",35,000260
+KINGMAN,Vinita Township,United States Senate,,Libertarian,"Batson, Randall",4,000260
+KINGMAN,Vinita Township,United States Senate,,Republican,"Roberts, Pat",70,000260
+KINGMAN,White Township Part A,United States Senate,,independent,"Orman, Greg",19,00027A
+KINGMAN,White Township Part A,United States Senate,,Libertarian,"Batson, Randall",0,00027A
+KINGMAN,White Township Part A,United States Senate,,Republican,"Roberts, Pat",55,00027A
+KINGMAN,White Township Part A Enclave,United States Senate,,independent,"Orman, Greg",0,00027B
+KINGMAN,White Township Part A Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00027B
+KINGMAN,White Township Part A Enclave,United States Senate,,Republican,"Roberts, Pat",0,00027B
+KINGMAN,White Township Part B,United States Senate,,independent,"Orman, Greg",17,00027C
+KINGMAN,White Township Part B,United States Senate,,Libertarian,"Batson, Randall",2,00027C
+KINGMAN,White Township Part B,United States Senate,,Republican,"Roberts, Pat",41,00027C

--- a/2014/20141104__ks__general__kiowa__precinct.csv
+++ b/2014/20141104__ks__general__kiowa__precinct.csv
@@ -1,219 +1,86 @@
-county,precinct,office,district,party,candidate,votes
-Kiowa,Center I,U.S. Senate,,R,Pat Roberts,87
-Kiowa,Center 1 twp,U.S. Senate,,R,Pat Roberts,85
-Kiowa,Center 1A twp,U.S. Senate,,R,Pat Roberts,15
-Kiowa,Center I I,U.S. Senate,,R,Pat Roberts,48
-Kiowa,Center IIA ,U.S. Senate,,R,Pat Roberts,64
-Kiowa,Haviland,U.S. Senate,,R,Pat Roberts,155
-Kiowa,Haviland twp,U.S. Senate,,R,Pat Roberts,51
-Kiowa,Haviland A twp,U.S. Senate,,R,Pat Roberts,17
-Kiowa,Mullinville,U.S. Senate,,R,Pat Roberts,65
-Kiowa,Mullinville twp,U.S. Senate,,R,Pat Roberts,79
-Kiowa,Belvidere twp,U.S. Senate,,R,Pat Roberts,11
-Kiowa,Prov,U.S. Senate,,R,Pat Roberts,10
-Kiowa,Center I,U.S. Senate,,I,Greg Orman,34
-Kiowa,Center 1 twp,U.S. Senate,,I,Greg Orman,11
-Kiowa,Center 1A twp,U.S. Senate,,I,Greg Orman,9
-Kiowa,Center I I,U.S. Senate,,I,Greg Orman,22
-Kiowa,Center IIA ,U.S. Senate,,I,Greg Orman,19
-Kiowa,Haviland,U.S. Senate,,I,Greg Orman,41
-Kiowa,Haviland twp,U.S. Senate,,I,Greg Orman,10
-Kiowa,Haviland A twp,U.S. Senate,,I,Greg Orman,9
-Kiowa,Mullinville,U.S. Senate,,I,Greg Orman,10
-Kiowa,Mullinville twp,U.S. Senate,,I,Greg Orman,16
-Kiowa,Belvidere twp,U.S. Senate,,I,Greg Orman,0
-Kiowa,Prov,U.S. Senate,,I,Greg Orman,4
-Kiowa,Center I,U.S. Senate,,L,Randall Batson,5
-Kiowa,Center 1 twp,U.S. Senate,,L,Randall Batson,1
-Kiowa,Center 1A twp,U.S. Senate,,L,Randall Batson,0
-Kiowa,Center I I,U.S. Senate,,L,Randall Batson,0
-Kiowa,Center IIA ,U.S. Senate,,L,Randall Batson,4
-Kiowa,Haviland,U.S. Senate,,L,Randall Batson,3
-Kiowa,Haviland twp,U.S. Senate,,L,Randall Batson,0
-Kiowa,Haviland A twp,U.S. Senate,,L,Randall Batson,2
-Kiowa,Mullinville,U.S. Senate,,L,Randall Batson,8
-Kiowa,Mullinville twp,U.S. Senate,,L,Randall Batson,1
-Kiowa,Belvidere twp,U.S. Senate,,L,Randall Batson,0
-Kiowa,Prov,U.S. Senate,,L,Randall Batson,2
-Kiowa,Center I,U.S. House,4,R,Mike Pompeo,101
-Kiowa,Center 1 twp,U.S. House,4,R,Mike Pompeo,82
-Kiowa,Center 1A twp,U.S. House,4,R,Mike Pompeo,17
-Kiowa,Center I I,U.S. House,4,R,Mike Pompeo,55
-Kiowa,Center IIA ,U.S. House,4,R,Mike Pompeo,71
-Kiowa,Haviland,U.S. House,4,R,Mike Pompeo,178
-Kiowa,Haviland twp,U.S. House,4,R,Mike Pompeo,50
-Kiowa,Haviland A twp,U.S. House,4,R,Mike Pompeo,24
-Kiowa,Mullinville,U.S. House,4,R,Mike Pompeo,75
-Kiowa,Mullinville twp,U.S. House,4,R,Mike Pompeo,88
-Kiowa,Belvidere twp,U.S. House,4,R,Mike Pompeo,12
-Kiowa,Prov,U.S. House,4,R,Mike Pompeo,13
-Kiowa,Center I,U.S. House,4,D,Perry Schuckman,22
-Kiowa,Center 1 twp,U.S. House,4,D,Perry Schuckman,11
-Kiowa,Center 1A twp,U.S. House,4,D,Perry Schuckman,6
-Kiowa,Center I I,U.S. House,4,D,Perry Schuckman,15
-Kiowa,Center IIA ,U.S. House,4,D,Perry Schuckman,15
-Kiowa,Haviland,U.S. House,4,D,Perry Schuckman,19
-Kiowa,Haviland twp,U.S. House,4,D,Perry Schuckman,9
-Kiowa,Haviland A twp,U.S. House,4,D,Perry Schuckman,2
-Kiowa,Mullinville,U.S. House,4,D,Perry Schuckman,10
-Kiowa,Mullinville twp,U.S. House,4,D,Perry Schuckman,8
-Kiowa,Belvidere twp,U.S. House,4,D,Perry Schuckman,0
-Kiowa,Prov,U.S. House,4,D,Perry Schuckman,3
-Kiowa,Center I,Governor,,R,Sam Brownback,73
-Kiowa,Center 1 twp,Governor,,R,Sam Brownback,72
-Kiowa,Center 1A twp,Governor,,R,Sam Brownback,13
-Kiowa,Center I I,Governor,,R,Sam Brownback,41
-Kiowa,Center IIA ,Governor,,R,Sam Brownback,49
-Kiowa,Haviland,Governor,,R,Sam Brownback,150
-Kiowa,Haviland twp,Governor,,R,Sam Brownback,46
-Kiowa,Haviland A twp,Governor,,R,Sam Brownback,14
-Kiowa,Mullinville,Governor,,R,Sam Brownback,59
-Kiowa,Mullinville twp,Governor,,R,Sam Brownback,72
-Kiowa,Belvidere twp,Governor,,R,Sam Brownback,8
-Kiowa,Prov,Governor,,R,Sam Brownback,11
-Kiowa,Center I,Governor,,D,Paul Davis,42
-Kiowa,Center 1 twp,Governor,,D,Paul Davis,21
-Kiowa,Center 1A twp,Governor,,D,Paul Davis,9
-Kiowa,Center I I,Governor,,D,Paul Davis,30
-Kiowa,Center IIA ,Governor,,D,Paul Davis,35
-Kiowa,Haviland,Governor,,D,Paul Davis,44
-Kiowa,Haviland twp,Governor,,D,Paul Davis,15
-Kiowa,Haviland A twp,Governor,,D,Paul Davis,13
-Kiowa,Mullinville,Governor,,D,Paul Davis,20
-Kiowa,Mullinville twp,Governor,,D,Paul Davis,23
-Kiowa,Belvidere twp,Governor,,D,Paul Davis,3
-Kiowa,Prov,Governor,,D,Paul Davis,4
-Kiowa,Center I,Governor,,L,Keen Umbehr,10
-Kiowa,Center 1 twp,Governor,,L,Keen Umbehr,4
-Kiowa,Center 1A twp,Governor,,L,Keen Umbehr,1
-Kiowa,Center I I,Governor,,L,Keen Umbehr,0
-Kiowa,Center IIA ,Governor,,L,Keen Umbehr,3
-Kiowa,Haviland,Governor,,L,Keen Umbehr,6
-Kiowa,Haviland twp,Governor,,L,Keen Umbehr,1
-Kiowa,Haviland A twp,Governor,,L,Keen Umbehr,1
-Kiowa,Mullinville,Governor,,L,Keen Umbehr,4
-Kiowa,Mullinville twp,Governor,,L,Keen Umbehr,2
-Kiowa,Belvidere twp,Governor,,L,Keen Umbehr,1
-Kiowa,Prov,Governor,,L,Keen Umbehr,2
-Kiowa,Center I,Secretary of State,,R,Kris Kobach,88
-Kiowa,Center 1 twp,Secretary of State,,R,Kris Kobach,77
-Kiowa,Center 1A twp,Secretary of State,,R,Kris Kobach,17
-Kiowa,Center I I,Secretary of State,,R,Kris Kobach,50
-Kiowa,Center IIA ,Secretary of State,,R,Kris Kobach,60
-Kiowa,Haviland,Secretary of State,,R,Kris Kobach,163
-Kiowa,Haviland twp,Secretary of State,,R,Kris Kobach,49
-Kiowa,Haviland A twp,Secretary of State,,R,Kris Kobach,21
-Kiowa,Mullinville,Secretary of State,,R,Kris Kobach,66
-Kiowa,Mullinville twp,Secretary of State,,R,Kris Kobach,81
-Kiowa,Belvidere twp,Secretary of State,,R,Kris Kobach,12
-Kiowa,Prov,Secretary of State,,R,Kris Kobach,12
-Kiowa,Center I,Secretary of State,,D,Jean Schodorf,32
-Kiowa,Center 1 twp,Secretary of State,,D,Jean Schodorf,19
-Kiowa,Center 1A twp,Secretary of State,,D,Jean Schodorf,7
-Kiowa,Center I I,Secretary of State,,D,Jean Schodorf,20
-Kiowa,Center IIA ,Secretary of State,,D,Jean Schodorf,28
-Kiowa,Haviland,Secretary of State,,D,Jean Schodorf,32
-Kiowa,Haviland twp,Secretary of State,,D,Jean Schodorf,13
-Kiowa,Haviland A twp,Secretary of State,,D,Jean Schodorf,6
-Kiowa,Mullinville,Secretary of State,,D,Jean Schodorf,18
-Kiowa,Mullinville twp,Secretary of State,,D,Jean Schodorf,14
-Kiowa,Belvidere twp,Secretary of State,,D,Jean Schodorf,1
-Kiowa,Prov,Secretary of State,,D,Jean Schodorf,3
-Kiowa,Center I,Attorney General,,R,Derek Schmidt,94
-Kiowa,Center 1 twp,Attorney General,,R,Derek Schmidt,86
-Kiowa,Center 1A twp,Attorney General,,R,Derek Schmidt,19
-Kiowa,Center I I,Attorney General,,R,Derek Schmidt,55
-Kiowa,Center IIA ,Attorney General,,R,Derek Schmidt,73
-Kiowa,Haviland,Attorney General,,R,Derek Schmidt,184
-Kiowa,Haviland twp,Attorney General,,R,Derek Schmidt,54
-Kiowa,Haviland A twp,Attorney General,,R,Derek Schmidt,26
-Kiowa,Mullinville,Attorney General,,R,Derek Schmidt,75
-Kiowa,Mullinville twp,Attorney General,,R,Derek Schmidt,86
-Kiowa,Belvidere twp,Attorney General,,R,Derek Schmidt,13
-Kiowa,Prov,Attorney General,,R,Derek Schmidt,10
-Kiowa,Center I,Attorney General,,D,AJ Kotich,25
-Kiowa,Center 1 twp,Attorney General,,D,AJ Kotich,8
-Kiowa,Center 1A twp,Attorney General,,D,AJ Kotich,4
-Kiowa,Center I I,Attorney General,,D,AJ Kotich,14
-Kiowa,Center IIA ,Attorney General,,D,AJ Kotich,14
-Kiowa,Haviland,Attorney General,,D,AJ Kotich,11
-Kiowa,Haviland twp,Attorney General,,D,AJ Kotich,7
-Kiowa,Haviland A twp,Attorney General,,D,AJ Kotich,1
-Kiowa,Mullinville,Attorney General,,D,AJ Kotich,6
-Kiowa,Mullinville twp,Attorney General,,D,AJ Kotich,9
-Kiowa,Belvidere twp,Attorney General,,D,AJ Kotich,0
-Kiowa,Prov,Attorney General,,D,AJ Kotich,5
-Kiowa,Center I,State Treasurer,,R,Ron Estes,101
-Kiowa,Center 1 twp,State Treasurer,,R,Ron Estes,80
-Kiowa,Center 1A twp,State Treasurer,,R,Ron Estes,17
-Kiowa,Center I I,State Treasurer,,R,Ron Estes,57
-Kiowa,Center IIA ,State Treasurer,,R,Ron Estes,69
-Kiowa,Haviland,State Treasurer,,R,Ron Estes,180
-Kiowa,Haviland twp,State Treasurer,,R,Ron Estes,52
-Kiowa,Haviland A twp,State Treasurer,,R,Ron Estes,25
-Kiowa,Mullinville,State Treasurer,,R,Ron Estes,81
-Kiowa,Mullinville twp,State Treasurer,,R,Ron Estes,85
-Kiowa,Belvidere twp,State Treasurer,,R,Ron Estes,13
-Kiowa,Prov,State Treasurer,,R,Ron Estes,14
-Kiowa,Center I,State Treasurer,,D,Carmen Alldritt,20
-Kiowa,Center 1 twp,State Treasurer,,D,Carmen Alldritt,11
-Kiowa,Center 1A twp,State Treasurer,,D,Carmen Alldritt,6
-Kiowa,Center I I,State Treasurer,,D,Carmen Alldritt,13
-Kiowa,Center IIA ,State Treasurer,,D,Carmen Alldritt,12
-Kiowa,Haviland,State Treasurer,,D,Carmen Alldritt,14
-Kiowa,Haviland twp,State Treasurer,,D,Carmen Alldritt,7
-Kiowa,Haviland A twp,State Treasurer,,D,Carmen Alldritt,2
-Kiowa,Mullinville,State Treasurer,,D,Carmen Alldritt,5
-Kiowa,Mullinville twp,State Treasurer,,D,Carmen Alldritt,8
-Kiowa,Belvidere twp,State Treasurer,,D,Carmen Alldritt,0
-Kiowa,Prov,State Treasurer,,D,Carmen Alldritt,1
-Kiowa,Center I,Insurance Commissioner,,R,Ken Selzer,91
-Kiowa,Center 1 twp,Insurance Commissioner,,R,Ken Selzer,75
-Kiowa,Center 1A twp,Insurance Commissioner,,R,Ken Selzer,15
-Kiowa,Center I I,Insurance Commissioner,,R,Ken Selzer,52
-Kiowa,Center IIA ,Insurance Commissioner,,R,Ken Selzer,61
-Kiowa,Haviland,Insurance Commissioner,,R,Ken Selzer,166
-Kiowa,Haviland twp,Insurance Commissioner,,R,Ken Selzer,50
-Kiowa,Haviland A twp,Insurance Commissioner,,R,Ken Selzer,19
-Kiowa,Mullinville,Insurance Commissioner,,R,Ken Selzer,66
-Kiowa,Mullinville twp,Insurance Commissioner,,R,Ken Selzer,80
-Kiowa,Belvidere twp,Insurance Commissioner,,R,Ken Selzer,12
-Kiowa,Prov,Insurance Commissioner,,R,Ken Selzer,12
-Kiowa,Center I,Insurance Commissioner,,D,Dennis Anderson,28
-Kiowa,Center 1 twp,Insurance Commissioner,,D,Dennis Anderson,15
-Kiowa,Center 1A twp,Insurance Commissioner,,D,Dennis Anderson,7
-Kiowa,Center I I,Insurance Commissioner,,D,Dennis Anderson,16
-Kiowa,Center IIA ,Insurance Commissioner,,D,Dennis Anderson,19
-Kiowa,Haviland,Insurance Commissioner,,D,Dennis Anderson,20
-Kiowa,Haviland twp,Insurance Commissioner,,D,Dennis Anderson,9
-Kiowa,Haviland A twp,Insurance Commissioner,,D,Dennis Anderson,5
-Kiowa,Mullinville,Insurance Commissioner,,D,Dennis Anderson,14
-Kiowa,Mullinville twp,Insurance Commissioner,,D,Dennis Anderson,10
-Kiowa,Belvidere twp,Insurance Commissioner,,D,Dennis Anderson,0
-Kiowa,Prov,Insurance Commissioner,,D,Dennis Anderson,3
-Kiowa,Center I,State House,117,R,John Ewy,113
-Kiowa,Center 1 twp,State House,117,R,John Ewy,82
-Kiowa,Center 1A twp,State House,117,R,John Ewy,18
-Kiowa,Center I I,State House,117,R,John Ewy,60
-Kiowa,Center IIA ,State House,117,R,John Ewy,71
-Kiowa,Haviland,State House,117,R,John Ewy,184
-Kiowa,Haviland twp,State House,117,R,John Ewy,49
-Kiowa,Haviland A twp,State House,117,R,John Ewy,25
-Kiowa,Mullinville,State House,117,R,John Ewy,81
-Kiowa,Mullinville twp,State House,117,R,John Ewy,85
-Kiowa,Belvidere twp,State House,117,R,John Ewy,11
-Kiowa,Prov,State House,117,R,John Ewy,16
-Kiowa,Haviland A twp,U.S. House,4,,Dennis McKinney,1
-Kiowa,Center 11A,Governor,,,Abby Hoffman,1
-Kiowa,Center I TWP,State Treasurer,,,Dennis McKinney,1
-Kiowa,Center IIA ,State Treasurer,,,Marsha Kline,1
-Kiowa,Center I,State House,117,,Stacey Barnes,1
-Kiowa,Center I,State House,117,,Dennis McKinney,1
-Kiowa,Center I TWP,State House,117,,Dennis McKinney,3
-Kiowa,Center 1A twp,State House,117,,Dennis McKinney,1
-Kiowa,Center I I,State House,117,,Dennis McKinney,1
-Kiowa,Center IIA ,State House,117,,Dennis McKinney,1
-Kiowa,Center II,State House,117,,Bob Dixon,1
-Kiowa,Haviland twp,State House,117,,Dennis McKinney,1
-Kiowa,Haviland A twp,State House,117,,Ruth Teichman,1
-Kiowa,Haviland A twp,State House,117,,Dennis McKinney,1
+county,precinct,office,district,party,candidate,votes,vtd
+KIOWA,Belvidere,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000010
+KIOWA,Belvidere,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+KIOWA,Belvidere,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000010
+KIOWA,Center I,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000020
+KIOWA,Center I,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000020
+KIOWA,Center I,Governor / Lt. Governor,,Republican,"Brownback, Sam",160,000020
+KIOWA,Center I I,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000030
+KIOWA,Center I I,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000030
+KIOWA,Center I I,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,000030
+KIOWA,Haviland,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,000040
+KIOWA,Haviland,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000040
+KIOWA,Haviland,Governor / Lt. Governor,,Republican,"Brownback, Sam",212,000040
+KIOWA,Mullinville,Governor / Lt. Governor,,Democratic,"Davis, Paul",44,000050
+KIOWA,Mullinville,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000050
+KIOWA,Mullinville,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000050
+KIOWA,Belvidere,Kansas House of Representatives,117,Republican,"Ewy, John L.",11,000010
+KIOWA,Center I,Kansas House of Representatives,117,Republican,"Ewy, John L.",215,000020
+KIOWA,Center I I,Kansas House of Representatives,117,Republican,"Ewy, John L.",140,000030
+KIOWA,Haviland,Kansas House of Representatives,117,Republican,"Ewy, John L.",260,000040
+KIOWA,Mullinville,Kansas House of Representatives,117,Republican,"Ewy, John L.",169,000050
+KIOWA,Belvidere,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000010
+KIOWA,Belvidere,United States House of Representatives,4,Republican,"Pompeo, Mike",12,000010
+KIOWA,Center I,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",39,000020
+KIOWA,Center I,United States House of Representatives,4,Republican,"Pompeo, Mike",202,000020
+KIOWA,Center I I,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",32,000030
+KIOWA,Center I I,United States House of Representatives,4,Republican,"Pompeo, Mike",133,000030
+KIOWA,Haviland,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",30,000040
+KIOWA,Haviland,United States House of Representatives,4,Republican,"Pompeo, Mike",254,000040
+KIOWA,Mullinville,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,000050
+KIOWA,Mullinville,United States House of Representatives,4,Republican,"Pompeo, Mike",165,000050
+KIOWA,Belvidere,Attorney General,,Democratic,"Kotich, A.J.",0,000010
+KIOWA,Belvidere,Attorney General,,Republican,"Schmidt, Derek",13,000010
+KIOWA,Center I,Attorney General,,Democratic,"Kotich, A.J.",38,000020
+KIOWA,Center I,Attorney General,,Republican,"Schmidt, Derek",199,000020
+KIOWA,Center I I,Attorney General,,Democratic,"Kotich, A.J.",30,000030
+KIOWA,Center I I,Attorney General,,Republican,"Schmidt, Derek",75,000030
+KIOWA,Haviland,Attorney General,,Democratic,"Kotich, A.J.",19,000040
+KIOWA,Haviland,Attorney General,,Republican,"Schmidt, Derek",266,000040
+KIOWA,Mullinville,Attorney General,,Democratic,"Kotich, A.J.",17,000050
+KIOWA,Mullinville,Attorney General,,Republican,"Schmidt, Derek",162,000050
+KIOWA,Belvidere,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000010
+KIOWA,Belvidere,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000010
+KIOWA,Center I,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000020
+KIOWA,Center I,Commissioner of Insurance,,Republican,"Selzer, Ken",182,000020
+KIOWA,Center I I,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000030
+KIOWA,Center I I,Commissioner of Insurance,,Republican,"Selzer, Ken",120,000030
+KIOWA,Haviland,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000040
+KIOWA,Haviland,Commissioner of Insurance,,Republican,"Selzer, Ken",237,000040
+KIOWA,Mullinville,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000050
+KIOWA,Mullinville,Commissioner of Insurance,,Republican,"Selzer, Ken",148,000050
+KIOWA,Belvidere,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000010
+KIOWA,Belvidere,Secretary of State,,Republican,"Kobach, Kris",12,000010
+KIOWA,Center I,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000020
+KIOWA,Center I,Secretary of State,,Republican,"Kobach, Kris",183,000020
+KIOWA,Center I I,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,000030
+KIOWA,Center I I,Secretary of State,,Republican,"Kobach, Kris",117,000030
+KIOWA,Haviland,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000040
+KIOWA,Haviland,Secretary of State,,Republican,"Kobach, Kris",235,000040
+KIOWA,Mullinville,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000050
+KIOWA,Mullinville,Secretary of State,,Republican,"Kobach, Kris",149,000050
+KIOWA,Belvidere,State Treasurer,,Democratic,"Alldritt, Carmen",0,000010
+KIOWA,Belvidere,State Treasurer,,Republican,"Estes, Ron",13,000010
+KIOWA,Center I,State Treasurer,,Democratic,"Alldritt, Carmen",37,000020
+KIOWA,Center I,State Treasurer,,Republican,"Estes, Ron",199,000020
+KIOWA,Center I I,State Treasurer,,Democratic,"Alldritt, Carmen",26,000030
+KIOWA,Center I I,State Treasurer,,Republican,"Estes, Ron",134,000030
+KIOWA,Haviland,State Treasurer,,Democratic,"Alldritt, Carmen",23,000040
+KIOWA,Haviland,State Treasurer,,Republican,"Estes, Ron",259,000040
+KIOWA,Mullinville,State Treasurer,,Democratic,"Alldritt, Carmen",13,000050
+KIOWA,Mullinville,State Treasurer,,Republican,"Estes, Ron",169,000050
+KIOWA,Belvidere,United States Senate,,independent,"Orman, Greg",0,000010
+KIOWA,Belvidere,United States Senate,,Libertarian,"Batson, Randall",0,000010
+KIOWA,Belvidere,United States Senate,,Republican,"Roberts, Pat",11,000010
+KIOWA,Center I,United States Senate,,independent,"Orman, Greg",55,000020
+KIOWA,Center I,United States Senate,,Libertarian,"Batson, Randall",6,000020
+KIOWA,Center I,United States Senate,,Republican,"Roberts, Pat",189,000020
+KIOWA,Center I I,United States Senate,,independent,"Orman, Greg",43,000030
+KIOWA,Center I I,United States Senate,,Libertarian,"Batson, Randall",6,000030
+KIOWA,Center I I,United States Senate,,Republican,"Roberts, Pat",117,000030
+KIOWA,Haviland,United States Senate,,independent,"Orman, Greg",60,000040
+KIOWA,Haviland,United States Senate,,Libertarian,"Batson, Randall",5,000040
+KIOWA,Haviland,United States Senate,,Republican,"Roberts, Pat",224,000040
+KIOWA,Mullinville,United States Senate,,independent,"Orman, Greg",27,000050
+KIOWA,Mullinville,United States Senate,,Libertarian,"Batson, Randall",9,000050
+KIOWA,Mullinville,United States Senate,,Republican,"Roberts, Pat",146,000050

--- a/2014/20141104__ks__general__labette__precinct.csv
+++ b/2014/20141104__ks__general__labette__precinct.csv
@@ -1,690 +1,835 @@
-county,precinct,office,district,party,candidate,votes
-Labette,Parsons W1P1,U.S. Senate,,R,Pat Roberts,121
-Labette,Parsons W1P2,U.S. Senate,,R,Pat Roberts,56
-Labette,Parsons W1P3,U.S. Senate,,R,Pat Roberts,36
-Labette,Parsons W2P1,U.S. Senate,,R,Pat Roberts,36
-Labette,Parsons W2P2,U.S. Senate,,R,Pat Roberts,96
-Labette,Parsons W2P3,U.S. Senate,,R,Pat Roberts,80
-Labette,Parsons W3P1,U.S. Senate,,R,Pat Roberts,46
-Labette,Parsons W3P2,U.S. Senate,,R,Pat Roberts,95
-Labette,Parsons W3P3,U.S. Senate,,R,Pat Roberts,94
-Labette,Parsons W3P4,U.S. Senate,,R,Pat Roberts,124
-Labette,Parsons W4P1,U.S. Senate,,R,Pat Roberts,61
-Labette,Parsons W4P2,U.S. Senate,,R,Pat Roberts,62
-Labette,Parsons W4P3,U.S. Senate,,R,Pat Roberts,55
-Labette,Parsons W4P4,U.S. Senate,,R,Pat Roberts,110
-Labette,City of Chetopa W1,U.S. Senate,,R,Pat Roberts,38
-Labette,City of Chetopa W2,U.S. Senate,,R,Pat Roberts,40
-Labette,City of Chetopa W3,U.S. Senate,,R,Pat Roberts,54
-Labette,City of Oswego W1,U.S. Senate,,R,Pat Roberts,104
-Labette,City of Oswego W2,U.S. Senate,,R,Pat Roberts,90
-Labette,City of Oswego W3,U.S. Senate,,R,Pat Roberts,58
-Labette,Canada,U.S. Senate,,R,Pat Roberts,74
-Labette,Elm Grove,U.S. Senate,,R,Pat Roberts,228
-Labette,Fairview,U.S. Senate,,R,Pat Roberts,58
-Labette,Hackberry,U.S. Senate,,R,Pat Roberts,74
-Labette,Howard,U.S. Senate,,R,Pat Roberts,86
-Labette,Labette,U.S. Senate,,R,Pat Roberts,107
-Labette,Liberty,U.S. Senate,,R,Pat Roberts,89
-Labette,Montana,U.S. Senate,,R,Pat Roberts,41
-Labette,Mound Valley,U.S. Senate,,R,Pat Roberts,167
-Labette,Mt Pleasant,U.S. Senate,,R,Pat Roberts,259
-Labette,Neosho,U.S. Senate,,R,Pat Roberts,39
-Labette,North,U.S. Senate,,R,Pat Roberts,127
-Labette,Osage,U.S. Senate,,R,Pat Roberts,148
-Labette,Oswego,U.S. Senate,,R,Pat Roberts,56
-Labette,Richland 1A,U.S. Senate,,R,Pat Roberts,12
-Labette,Richland 1B,U.S. Senate,,R,Pat Roberts,8
-Labette,Richland 7,U.S. Senate,,R,Pat Roberts,25
-Labette,Walton,U.S. Senate,,R,Pat Roberts,160
-Labette,W1P1,U.S. Senate,,I,Greg Orman,108
-Labette,W1P2,U.S. Senate,,I,Greg Orman,42
-Labette,W1P3,U.S. Senate,,I,Greg Orman,36
-Labette,W2P1,U.S. Senate,,I,Greg Orman,41
-Labette,W2P2,U.S. Senate,,I,Greg Orman,104
-Labette,W2P3,U.S. Senate,,I,Greg Orman,89
-Labette,W3P1,U.S. Senate,,I,Greg Orman,25
-Labette,W3P2,U.S. Senate,,I,Greg Orman,117
-Labette,W3P3,U.S. Senate,,I,Greg Orman,84
-Labette,W3P4,U.S. Senate,,I,Greg Orman,123
-Labette,W4P1,U.S. Senate,,I,Greg Orman,44
-Labette,W4P2,U.S. Senate,,I,Greg Orman,88
-Labette,W4P3,U.S. Senate,,I,Greg Orman,72
-Labette,W4P4,U.S. Senate,,I,Greg Orman,81
-Labette,City of Chetopa W1,U.S. Senate,,I,Greg Orman,26
-Labette,City of Chetopa W2,U.S. Senate,,I,Greg Orman,24
-Labette,City of Chetopa W3,U.S. Senate,,I,Greg Orman,31
-Labette,City of Oswego W1,U.S. Senate,,I,Greg Orman,52
-Labette,City of Oswego W2,U.S. Senate,,I,Greg Orman,64
-Labette,City of Oswego W3,U.S. Senate,,I,Greg Orman,45
-Labette,Canada,U.S. Senate,,I,Greg Orman,21
-Labette,Elm Grove,U.S. Senate,,I,Greg Orman,47
-Labette,Fairview,U.S. Senate,,I,Greg Orman,18
-Labette,Hackberry,U.S. Senate,,I,Greg Orman,26
-Labette,Howard,U.S. Senate,,I,Greg Orman,42
-Labette,Labette,U.S. Senate,,I,Greg Orman,32
-Labette,Liberty,U.S. Senate,,I,Greg Orman,47
-Labette,Montana,U.S. Senate,,I,Greg Orman,16
-Labette,Mound Valley,U.S. Senate,,I,Greg Orman,70
-Labette,Mt Pleasant,U.S. Senate,,I,Greg Orman,123
-Labette,Neosho,U.S. Senate,,I,Greg Orman,19
-Labette,North,U.S. Senate,,I,Greg Orman,91
-Labette,Osage,U.S. Senate,,I,Greg Orman,75
-Labette,Oswego,U.S. Senate,,I,Greg Orman,30
-Labette,Richland 1A,U.S. Senate,,I,Greg Orman,6
-Labette,Richland 1B,U.S. Senate,,I,Greg Orman,4
-Labette,Richland 7,U.S. Senate,,I,Greg Orman,18
-Labette,Walton,U.S. Senate,,I,Greg Orman,105
-Labette,W1P1,U.S. Senate,,L,Randall Batson,13
-Labette,W1P2,U.S. Senate,,L,Randall Batson,6
-Labette,W1P3,U.S. Senate,,L,Randall Batson,4
-Labette,W2P1,U.S. Senate,,L,Randall Batson,4
-Labette,W2P2,U.S. Senate,,L,Randall Batson,6
-Labette,W2P3,U.S. Senate,,L,Randall Batson,18
-Labette,W3P1,U.S. Senate,,L,Randall Batson,6
-Labette,W3P2,U.S. Senate,,L,Randall Batson,12
-Labette,W3P3,U.S. Senate,,L,Randall Batson,21
-Labette,W3P4,U.S. Senate,,L,Randall Batson,15
-Labette,W4P1,U.S. Senate,,L,Randall Batson,8
-Labette,W4P2,U.S. Senate,,L,Randall Batson,15
-Labette,W4P3,U.S. Senate,,L,Randall Batson,8
-Labette,W4P4,U.S. Senate,,L,Randall Batson,12
-Labette,City of Chetopa W1,U.S. Senate,,L,Randall Batson,7
-Labette,City of Chetopa W2,U.S. Senate,,L,Randall Batson,6
-Labette,City of Chetopa W3,U.S. Senate,,L,Randall Batson,7
-Labette,City of Oswego W1,U.S. Senate,,L,Randall Batson,18
-Labette,City of Oswego W2,U.S. Senate,,L,Randall Batson,12
-Labette,City of Oswego W3,U.S. Senate,,L,Randall Batson,14
-Labette,Canada,U.S. Senate,,L,Randall Batson,3
-Labette,Elm Grove,U.S. Senate,,L,Randall Batson,18
-Labette,Fairview,U.S. Senate,,L,Randall Batson,3
-Labette,Hackberry,U.S. Senate,,L,Randall Batson,9
-Labette,Howard,U.S. Senate,,L,Randall Batson,7
-Labette,Labette,U.S. Senate,,L,Randall Batson,8
-Labette,Liberty,U.S. Senate,,L,Randall Batson,6
-Labette,Montana,U.S. Senate,,L,Randall Batson,3
-Labette,Mound Valley,U.S. Senate,,L,Randall Batson,17
-Labette,Mt Pleasant,U.S. Senate,,L,Randall Batson,26
-Labette,Neosho,U.S. Senate,,L,Randall Batson,6
-Labette,North,U.S. Senate,,L,Randall Batson,15
-Labette,Osage,U.S. Senate,,L,Randall Batson,12
-Labette,Oswego,U.S. Senate,,L,Randall Batson,5
-Labette,Richland 1A,U.S. Senate,,L,Randall Batson,2
-Labette,Richland 1B,U.S. Senate,,L,Randall Batson,1
-Labette,Richland 7,U.S. Senate,,L,Randall Batson,5
-Labette,Walton,U.S. Senate,,L,Randall Batson,14
-Labette,W1P1,U.S. House,2,R,Lynn Jenkins,138
-Labette,W1P2,U.S. House,2,R,Lynn Jenkins,62
-Labette,W1P3,U.S. House,2,R,Lynn Jenkins,37
-Labette,W2P1,U.S. House,2,R,Lynn Jenkins,34
-Labette,W2P2,U.S. House,2,R,Lynn Jenkins,98
-Labette,W2P3,U.S. House,2,R,Lynn Jenkins,82
-Labette,W3P1,U.S. House,2,R,Lynn Jenkins,47
-Labette,W3P2,U.S. House,2,R,Lynn Jenkins,104
-Labette,W3P3,U.S. House,2,R,Lynn Jenkins,94
-Labette,W3P4,U.S. House,2,R,Lynn Jenkins,146
-Labette,W4P1,U.S. House,2,R,Lynn Jenkins,68
-Labette,W4P2,U.S. House,2,R,Lynn Jenkins,81
-Labette,W4P3,U.S. House,2,R,Lynn Jenkins,61
-Labette,W4P4,U.S. House,2,R,Lynn Jenkins,126
-Labette,City of Chetopa W1,U.S. House,2,R,Lynn Jenkins,41
-Labette,City of Chetopa W2,U.S. House,2,R,Lynn Jenkins,42
-Labette,City of Chetopa W3,U.S. House,2,R,Lynn Jenkins,56
-Labette,City of Oswego W1,U.S. House,2,R,Lynn Jenkins,132
-Labette,City of Oswego W2,U.S. House,2,R,Lynn Jenkins,99
-Labette,City of Oswego W3,U.S. House,2,R,Lynn Jenkins,69
-Labette,Canada,U.S. House,2,R,Lynn Jenkins,75
-Labette,Elm Grove,U.S. House,2,R,Lynn Jenkins,246
-Labette,Fairview,U.S. House,2,R,Lynn Jenkins,59
-Labette,Hackberry,U.S. House,2,R,Lynn Jenkins,79
-Labette,Howard,U.S. House,2,R,Lynn Jenkins,99
-Labette,Labette,U.S. House,2,R,Lynn Jenkins,108
-Labette,Liberty,U.S. House,2,R,Lynn Jenkins,94
-Labette,Montana,U.S. House,2,R,Lynn Jenkins,42
-Labette,Mound Valley,U.S. House,2,R,Lynn Jenkins,185
-Labette,Mt Pleasant,U.S. House,2,R,Lynn Jenkins,273
-Labette,Neosho,U.S. House,2,R,Lynn Jenkins,43
-Labette,North,U.S. House,2,R,Lynn Jenkins,145
-Labette,Osage,U.S. House,2,R,Lynn Jenkins,161
-Labette,Oswego,U.S. House,2,R,Lynn Jenkins,59
-Labette,Richland 1A,U.S. House,2,R,Lynn Jenkins,14
-Labette,Richland 1B,U.S. House,2,R,Lynn Jenkins,11
-Labette,Richland 7,U.S. House,2,R,Lynn Jenkins,33
-Labette,Walton,U.S. House,2,R,Lynn Jenkins,176
-Labette,W1P1,U.S. House,2,D,Margie Wakefield,99
-Labette,W1P2,U.S. House,2,D,Margie Wakefield,41
-Labette,W1P3,U.S. House,2,D,Margie Wakefield,42
-Labette,W2P1,U.S. House,2,D,Margie Wakefield,44
-Labette,W2P2,U.S. House,2,D,Margie Wakefield,103
-Labette,W2P3,U.S. House,2,D,Margie Wakefield,97
-Labette,W3P1,U.S. House,2,D,Margie Wakefield,25
-Labette,W3P2,U.S. House,2,D,Margie Wakefield,118
-Labette,W3P3,U.S. House,2,D,Margie Wakefield,98
-Labette,W3P4,U.S. House,2,D,Margie Wakefield,112
-Labette,W4P1,U.S. House,2,D,Margie Wakefield,38
-Labette,W4P2,U.S. House,2,D,Margie Wakefield,70
-Labette,W4P3,U.S. House,2,D,Margie Wakefield,70
-Labette,W4P4,U.S. House,2,D,Margie Wakefield,63
-Labette,City of Chetopa W1,U.S. House,2,D,Margie Wakefield,31
-Labette,City of Chetopa W2,U.S. House,2,D,Margie Wakefield,25
-Labette,City of Chetopa W3,U.S. House,2,D,Margie Wakefield,34
-Labette,City of Oswego W1,U.S. House,2,D,Margie Wakefield,36
-Labette,City of Oswego W2,U.S. House,2,D,Margie Wakefield,58
-Labette,City of Oswego W3,U.S. House,2,D,Margie Wakefield,37
-Labette,Canada,U.S. House,2,D,Margie Wakefield,16
-Labette,Elm Grove,U.S. House,2,D,Margie Wakefield,39
-Labette,Fairview,U.S. House,2,D,Margie Wakefield,17
-Labette,Hackberry,U.S. House,2,D,Margie Wakefield,26
-Labette,Howard,U.S. House,2,D,Margie Wakefield,28
-Labette,Labette,U.S. House,2,D,Margie Wakefield,26
-Labette,Liberty,U.S. House,2,D,Margie Wakefield,42
-Labette,Montana,U.S. House,2,D,Margie Wakefield,15
-Labette,Mound Valley,U.S. House,2,D,Margie Wakefield,58
-Labette,Mt Pleasant,U.S. House,2,D,Margie Wakefield,109
-Labette,Neosho,U.S. House,2,D,Margie Wakefield,18
-Labette,North,U.S. House,2,D,Margie Wakefield,77
-Labette,Osage,U.S. House,2,D,Margie Wakefield,62
-Labette,Oswego,U.S. House,2,D,Margie Wakefield,26
-Labette,Richland 1A,U.S. House,2,D,Margie Wakefield,5
-Labette,Richland 1B,U.S. House,2,D,Margie Wakefield,3
-Labette,Richland 7,U.S. House,2,D,Margie Wakefield,16
-Labette,Walton,U.S. House,2,D,Margie Wakefield,91
-Labette,W1P1,U.S. House,2,L,Chris Clemmons,10
-Labette,W1P2,U.S. House,2,L,Chris Clemmons,4
-Labette,W1P3,U.S. House,2,L,Chris Clemmons,1
-Labette,W2P1,U.S. House,2,L,Chris Clemmons,3
-Labette,W2P2,U.S. House,2,L,Chris Clemmons,8
-Labette,W2P3,U.S. House,2,L,Chris Clemmons,11
-Labette,W3P1,U.S. House,2,L,Chris Clemmons,5
-Labette,W3P2,U.S. House,2,L,Chris Clemmons,10
-Labette,W3P3,U.S. House,2,L,Chris Clemmons,13
-Labette,W3P4,U.S. House,2,L,Chris Clemmons,4
-Labette,W4P1,U.S. House,2,L,Chris Clemmons,7
-Labette,W4P2,U.S. House,2,L,Chris Clemmons,14
-Labette,W4P3,U.S. House,2,L,Chris Clemmons,6
-Labette,W4P4,U.S. House,2,L,Chris Clemmons,12
-Labette,City of Chetopa W1,U.S. House,2,L,Chris Clemmons,1
-Labette,City of Chetopa W2,U.S. House,2,L,Chris Clemmons,6
-Labette,City of Chetopa W3,U.S. House,2,L,Chris Clemmons,6
-Labette,City of Oswego W1,U.S. House,2,L,Chris Clemmons,11
-Labette,City of Oswego W2,U.S. House,2,L,Chris Clemmons,12
-Labette,City of Oswego W3,U.S. House,2,L,Chris Clemmons,12
-Labette,Canada,U.S. House,2,L,Chris Clemmons,6
-Labette,Elm Grove,U.S. House,2,L,Chris Clemmons,11
-Labette,Fairview,U.S. House,2,L,Chris Clemmons,3
-Labette,Hackberry,U.S. House,2,L,Chris Clemmons,6
-Labette,Howard,U.S. House,2,L,Chris Clemmons,6
-Labette,Labette,U.S. House,2,L,Chris Clemmons,9
-Labette,Liberty,U.S. House,2,L,Chris Clemmons,6
-Labette,Montana,U.S. House,2,L,Chris Clemmons,3
-Labette,Mound Valley,U.S. House,2,L,Chris Clemmons,13
-Labette,Mt Pleasant,U.S. House,2,L,Chris Clemmons,28
-Labette,Neosho,U.S. House,2,L,Chris Clemmons,5
-Labette,North,U.S. House,2,L,Chris Clemmons,11
-Labette,Osage,U.S. House,2,L,Chris Clemmons,13
-Labette,Oswego,U.S. House,2,L,Chris Clemmons,6
-Labette,Richland 1A,U.S. House,2,L,Chris Clemmons,1
-Labette,Richland 1B,U.S. House,2,L,Chris Clemmons,0
-Labette,Richland 7,U.S. House,2,L,Chris Clemmons,1
-Labette,Walton,U.S. House,2,L,Chris Clemmons,14
-Labette,W1P1,Governor,,R,Sam Brownback,113
-Labette,W1P2,Governor,,R,Sam Brownback,54
-Labette,W1P3,Governor,,R,Sam Brownback,31
-Labette,W2P1,Governor,,R,Sam Brownback,31
-Labette,W2P2,Governor,,R,Sam Brownback,86
-Labette,W2P3,Governor,,R,Sam Brownback,73
-Labette,W3P1,Governor,,R,Sam Brownback,42
-Labette,W3P2,Governor,,R,Sam Brownback,93
-Labette,W3P3,Governor,,R,Sam Brownback,79
-Labette,W3P4,Governor,,R,Sam Brownback,113
-Labette,W4P1,Governor,,R,Sam Brownback,56
-Labette,W4P2,Governor,,R,Sam Brownback,52
-Labette,W4P3,Governor,,R,Sam Brownback,49
-Labette,W4P4,Governor,,R,Sam Brownback,91
-Labette,City of Chetopa W1,Governor,,R,Sam Brownback,33
-Labette,City of Chetopa W2,Governor,,R,Sam Brownback,42
-Labette,City of Chetopa W3,Governor,,R,Sam Brownback,50
-Labette,City of Oswego W1,Governor,,R,Sam Brownback,99
-Labette,City of Oswego W2,Governor,,R,Sam Brownback,87
-Labette,City of Oswego W3,Governor,,R,Sam Brownback,52
-Labette,Canada,Governor,,R,Sam Brownback,69
-Labette,Elm Grove,Governor,,R,Sam Brownback,219
-Labette,Fairview,Governor,,R,Sam Brownback,58
-Labette,Hackberry,Governor,,R,Sam Brownback,73
-Labette,Howard,Governor,,R,Sam Brownback,92
-Labette,Labette,Governor,,R,Sam Brownback,96
-Labette,Liberty,Governor,,R,Sam Brownback,82
-Labette,Montana,Governor,,R,Sam Brownback,37
-Labette,Mound Valley,Governor,,R,Sam Brownback,162
-Labette,Mt Pleasant,Governor,,R,Sam Brownback,230
-Labette,Neosho,Governor,,R,Sam Brownback,39
-Labette,North,Governor,,R,Sam Brownback,127
-Labette,Osage,Governor,,R,Sam Brownback,147
-Labette,Oswego,Governor,,R,Sam Brownback,57
-Labette,Richland 1A,Governor,,R,Sam Brownback,10
-Labette,Richland 1B,Governor,,R,Sam Brownback,4
-Labette,Richland 7,Governor,,R,Sam Brownback,32
-Labette,Walton,Governor,,R,Sam Brownback,157
-Labette,W1P1,Governor,,D,Paul Davis,124
-Labette,W1P2,Governor,,D,Paul Davis,47
-Labette,W1P3,Governor,,D,Paul Davis,45
-Labette,W2P1,Governor,,D,Paul Davis,48
-Labette,W2P2,Governor,,D,Paul Davis,119
-Labette,W2P3,Governor,,D,Paul Davis,110
-Labette,W3P1,Governor,,D,Paul Davis,33
-Labette,W3P2,Governor,,D,Paul Davis,130
-Labette,W3P3,Governor,,D,Paul Davis,110
-Labette,W3P4,Governor,,D,Paul Davis,142
-Labette,W4P1,Governor,,D,Paul Davis,54
-Labette,W4P2,Governor,,D,Paul Davis,101
-Labette,W4P3,Governor,,D,Paul Davis,83
-Labette,W4P4,Governor,,D,Paul Davis,105
-Labette,City of Chetopa W1,Governor,,D,Paul Davis,38
-Labette,City of Chetopa W2,Governor,,D,Paul Davis,27
-Labette,City of Chetopa W3,Governor,,D,Paul Davis,42
-Labette,City of Oswego W1,Governor,,D,Paul Davis,67
-Labette,City of Oswego W2,Governor,,D,Paul Davis,71
-Labette,City of Oswego W3,Governor,,D,Paul Davis,56
-Labette,Canada,Governor,,D,Paul Davis,24
-Labette,Elm Grove,Governor,,D,Paul Davis,66
-Labette,Fairview,Governor,,D,Paul Davis,22
-Labette,Hackberry,Governor,,D,Paul Davis,34
-Labette,Howard,Governor,,D,Paul Davis,36
-Labette,Labette,Governor,,D,Paul Davis,43
-Labette,Liberty,Governor,,D,Paul Davis,56
-Labette,Montana,Governor,,D,Paul Davis,21
-Labette,Mound Valley,Governor,,D,Paul Davis,84
-Labette,Mt Pleasant,Governor,,D,Paul Davis,163
-Labette,Neosho,Governor,,D,Paul Davis,25
-Labette,North,Governor,,D,Paul Davis,103
-Labette,Osage,Governor,,D,Paul Davis,81
-Labette,Oswego,Governor,,D,Paul Davis,28
-Labette,Richland 1A,Governor,,D,Paul Davis,9
-Labette,Richland 1B,Governor,,D,Paul Davis,9
-Labette,Richland 7,Governor,,D,Paul Davis,16
-Labette,Walton,Governor,,D,Paul Davis,120
-Labette,W1P1,Governor,,L,Keen Umbehr,8
-Labette,W1P2,Governor,,L,Keen Umbehr,4
-Labette,W1P3,Governor,,L,Keen Umbehr,2
-Labette,W2P1,Governor,,L,Keen Umbehr,2
-Labette,W2P2,Governor,,L,Keen Umbehr,5
-Labette,W2P3,Governor,,L,Keen Umbehr,9
-Labette,W3P1,Governor,,L,Keen Umbehr,3
-Labette,W3P2,Governor,,L,Keen Umbehr,7
-Labette,W3P3,Governor,,L,Keen Umbehr,15
-Labette,W3P4,Governor,,L,Keen Umbehr,12
-Labette,W4P1,Governor,,L,Keen Umbehr,4
-Labette,W4P2,Governor,,L,Keen Umbehr,13
-Labette,W4P3,Governor,,L,Keen Umbehr,5
-Labette,W4P4,Governor,,L,Keen Umbehr,6
-Labette,City of Chetopa W1,Governor,,L,Keen Umbehr,1
-Labette,City of Chetopa W2,Governor,,L,Keen Umbehr,3
-Labette,City of Chetopa W3,Governor,,L,Keen Umbehr,5
-Labette,City of Oswego W1,Governor,,L,Keen Umbehr,14
-Labette,City of Oswego W2,Governor,,L,Keen Umbehr,8
-Labette,City of Oswego W3,Governor,,L,Keen Umbehr,8
-Labette,Canada,Governor,,L,Keen Umbehr,5
-Labette,Elm Grove,Governor,,L,Keen Umbehr,11
-Labette,Fairview,Governor,,L,Keen Umbehr,0
-Labette,Hackberry,Governor,,L,Keen Umbehr,3
-Labette,Howard,Governor,,L,Keen Umbehr,8
-Labette,Labette,Governor,,L,Keen Umbehr,6
-Labette,Liberty,Governor,,L,Keen Umbehr,4
-Labette,Montana,Governor,,L,Keen Umbehr,2
-Labette,Mound Valley,Governor,,L,Keen Umbehr,12
-Labette,Mt Pleasant,Governor,,L,Keen Umbehr,19
-Labette,Neosho,Governor,,L,Keen Umbehr,2
-Labette,North,Governor,,L,Keen Umbehr,8
-Labette,Osage,Governor,,L,Keen Umbehr,6
-Labette,Oswego,Governor,,L,Keen Umbehr,3
-Labette,Richland 1A,Governor,,L,Keen Umbehr,1
-Labette,Richland 1B,Governor,,L,Keen Umbehr,1
-Labette,Richland 7,Governor,,L,Keen Umbehr,2
-Labette,Walton,Governor,,L,Keen Umbehr,3
-Labette,Parsons W1P1,Secretary of State,,R,Kris Kobach,129
-Labette,Parsons W1P2,Secretary of State,,R,Kris Kobach,60
-Labette,Parsons W1P3,Secretary of State,,R,Kris Kobach,32
-Labette,Parsons W2P1,Secretary of State,,R,Kris Kobach,39
-Labette,Parsons W2P2,Secretary of State,,R,Kris Kobach,102
-Labette,Parsons W2P3,Secretary of State,,R,Kris Kobach,93
-Labette,Parsons W3P1,Secretary of State,,R,Kris Kobach,46
-Labette,Parsons W3P2,Secretary of State,,R,Kris Kobach,101
-Labette,Parsons W3P3,Secretary of State,,R,Kris Kobach,101
-Labette,Parsons W3P4,Secretary of State,,R,Kris Kobach,137
-Labette,Parsons W4P1,Secretary of State,,R,Kris Kobach,66
-Labette,Parsons W4P2,Secretary of State,,R,Kris Kobach,78
-Labette,Parsons W4P3,Secretary of State,,R,Kris Kobach,50
-Labette,Parsons W4P4,Secretary of State,,R,Kris Kobach,117
-Labette,City of Chetopa W1,Secretary of State,,R,Kris Kobach,38
-Labette,City of Chetopa W2,Secretary of State,,R,Kris Kobach,44
-Labette,City of Chetopa W3,Secretary of State,,R,Kris Kobach,50
-Labette,City of Oswego W1,Secretary of State,,R,Kris Kobach,117
-Labette,City of Oswego W2,Secretary of State,,R,Kris Kobach,100
-Labette,City of Oswego W3,Secretary of State,,R,Kris Kobach,67
-Labette,Canada,Secretary of State,,R,Kris Kobach,73
-Labette,Elm Grove,Secretary of State,,R,Kris Kobach,239
-Labette,Fairview,Secretary of State,,R,Kris Kobach,60
-Labette,Hackberry,Secretary of State,,R,Kris Kobach,77
-Labette,Howard,Secretary of State,,R,Kris Kobach,93
-Labette,Labette,Secretary of State,,R,Kris Kobach,112
-Labette,Liberty,Secretary of State,,R,Kris Kobach,92
-Labette,Montana,Secretary of State,,R,Kris Kobach,39
-Labette,Mound Valley,Secretary of State,,R,Kris Kobach,174
-Labette,Mt Pleasant,Secretary of State,,R,Kris Kobach,265
-Labette,Neosho,Secretary of State,,R,Kris Kobach,44
-Labette,North,Secretary of State,,R,Kris Kobach,147
-Labette,Osage,Secretary of State,,R,Kris Kobach,161
-Labette,Oswego,Secretary of State,,R,Kris Kobach,59
-Labette,Richland 1A,Secretary of State,,R,Kris Kobach,9
-Labette,Richland 1B,Secretary of State,,R,Kris Kobach,9
-Labette,Richland 7,Secretary of State,,R,Kris Kobach,29
-Labette,Walton,Secretary of State,,R,Kris Kobach,167
-Labette,W1P1,Secretary of State,,D,Jean Schodorf,110
-Labette,W1P2,Secretary of State,,D,Jean Schodorf,45
-Labette,W1P3,Secretary of State,,D,Jean Schodorf,46
-Labette,W2P1,Secretary of State,,D,Jean Schodorf,43
-Labette,W2P2,Secretary of State,,D,Jean Schodorf,103
-Labette,W2P3,Secretary of State,,D,Jean Schodorf,91
-Labette,W3P1,Secretary of State,,D,Jean Schodorf,29
-Labette,W3P2,Secretary of State,,D,Jean Schodorf,124
-Labette,W3P3,Secretary of State,,D,Jean Schodorf,101
-Labette,W3P4,Secretary of State,,D,Jean Schodorf,121
-Labette,W4P1,Secretary of State,,D,Jean Schodorf,46
-Labette,W4P2,Secretary of State,,D,Jean Schodorf,85
-Labette,W4P3,Secretary of State,,D,Jean Schodorf,85
-Labette,W4P4,Secretary of State,,D,Jean Schodorf,81
-Labette,City of Chetopa W1,Secretary of State,,D,Jean Schodorf,32
-Labette,City of Chetopa W2,Secretary of State,,D,Jean Schodorf,27
-Labette,City of Chetopa W3,Secretary of State,,D,Jean Schodorf,41
-Labette,City of Oswego W1,Secretary of State,,D,Jean Schodorf,55
-Labette,City of Oswego W2,Secretary of State,,D,Jean Schodorf,61
-Labette,City of Oswego W3,Secretary of State,,D,Jean Schodorf,43
-Labette,Canada,Secretary of State,,D,Jean Schodorf,23
-Labette,Elm Grove,Secretary of State,,D,Jean Schodorf,57
-Labette,Fairview,Secretary of State,,D,Jean Schodorf,19
-Labette,Hackberry,Secretary of State,,D,Jean Schodorf,27
-Labette,Howard,Secretary of State,,D,Jean Schodorf,41
-Labette,Labette,Secretary of State,,D,Jean Schodorf,34
-Labette,Liberty,Secretary of State,,D,Jean Schodorf,44
-Labette,Montana,Secretary of State,,D,Jean Schodorf,17
-Labette,Mound Valley,Secretary of State,,D,Jean Schodorf,80
-Labette,Mt Pleasant,Secretary of State,,D,Jean Schodorf,143
-Labette,Neosho,Secretary of State,,D,Jean Schodorf,21
-Labette,North,Secretary of State,,D,Jean Schodorf,86
-Labette,Osage,Secretary of State,,D,Jean Schodorf,71
-Labette,Oswego,Secretary of State,,D,Jean Schodorf,31
-Labette,Richland 1A,Secretary of State,,D,Jean Schodorf,9
-Labette,Richland 1B,Secretary of State,,D,Jean Schodorf,3
-Labette,Richland 7,Secretary of State,,D,Jean Schodorf,20
-Labette,Walton,Secretary of State,,D,Jean Schodorf,107
-Labette,W1P1,Attorney General,,R,Derek Schmidt,152
-Labette,W1P2,Attorney General,,R,Derek Schmidt,67
-Labette,W1P3,Attorney General,,R,Derek Schmidt,44
-Labette,W2P1,Attorney General,,R,Derek Schmidt,51
-Labette,W2P2,Attorney General,,R,Derek Schmidt,114
-Labette,W2P3,Attorney General,,R,Derek Schmidt,102
-Labette,W3P1,Attorney General,,R,Derek Schmidt,48
-Labette,W3P2,Attorney General,,R,Derek Schmidt,118
-Labette,W3P3,Attorney General,,R,Derek Schmidt,114
-Labette,W3P4,Attorney General,,R,Derek Schmidt,144
-Labette,W4P1,Attorney General,,R,Derek Schmidt,70
-Labette,W4P2,Attorney General,,R,Derek Schmidt,86
-Labette,W4P3,Attorney General,,R,Derek Schmidt,59
-Labette,W4P4,Attorney General,,R,Derek Schmidt,135
-Labette,City of Chetopa W1,Attorney General,,R,Derek Schmidt,45
-Labette,City of Chetopa W2,Attorney General,,R,Derek Schmidt,48
-Labette,City of Chetopa W3,Attorney General,,R,Derek Schmidt,59
-Labette,City of Oswego W1,Attorney General,,R,Derek Schmidt,129
-Labette,City of Oswego W2,Attorney General,,R,Derek Schmidt,113
-Labette,City of Oswego W3,Attorney General,,R,Derek Schmidt,74
-Labette,Canada,Attorney General,,R,Derek Schmidt,84
-Labette,Elm Grove,Attorney General,,R,Derek Schmidt,251
-Labette,Fairview,Attorney General,,R,Derek Schmidt,64
-Labette,Hackberry,Attorney General,,R,Derek Schmidt,82
-Labette,Howard,Attorney General,,R,Derek Schmidt,110
-Labette,Labette,Attorney General,,R,Derek Schmidt,120
-Labette,Liberty,Attorney General,,R,Derek Schmidt,102
-Labette,Montana,Attorney General,,R,Derek Schmidt,44
-Labette,Mound Valley,Attorney General,,R,Derek Schmidt,197
-Labette,Mt Pleasant,Attorney General,,R,Derek Schmidt,295
-Labette,Neosho,Attorney General,,R,Derek Schmidt,46
-Labette,North,Attorney General,,R,Derek Schmidt,171
-Labette,Osage,Attorney General,,R,Derek Schmidt,171
-Labette,Oswego,Attorney General,,R,Derek Schmidt,66
-Labette,Richland 1A,Attorney General,,R,Derek Schmidt,10
-Labette,Richland 1B,Attorney General,,R,Derek Schmidt,10
-Labette,Richland 7,Attorney General,,R,Derek Schmidt,35
-Labette,Walton,Attorney General,,R,Derek Schmidt,194
-Labette,W1P1,Attorney General,,D,A J Kotich,87
-Labette,W1P2,Attorney General,,D,A J Kotich,39
-Labette,W1P3,Attorney General,,D,A J Kotich,35
-Labette,W2P1,Attorney General,,D,A J Kotich,31
-Labette,W2P2,Attorney General,,D,A J Kotich,91
-Labette,W2P3,Attorney General,,D,A J Kotich,85
-Labette,W3P1,Attorney General,,D,A J Kotich,27
-Labette,W3P2,Attorney General,,D,A J Kotich,107
-Labette,W3P3,Attorney General,,D,A J Kotich,86
-Labette,W3P4,Attorney General,,D,A J Kotich,115
-Labette,W4P1,Attorney General,,D,A J Kotich,42
-Labette,W4P2,Attorney General,,D,A J Kotich,77
-Labette,W4P3,Attorney General,,D,A J Kotich,75
-Labette,W4P4,Attorney General,,D,A J Kotich,60
-Labette,City of Chetopa W1,Attorney General,,D,A J Kotich,28
-Labette,City of Chetopa W2,Attorney General,,D,A J Kotich,22
-Labette,City of Chetopa W3,Attorney General,,D,A J Kotich,31
-Labette,City of Oswego W1,Attorney General,,D,A J Kotich,45
-Labette,City of Oswego W2,Attorney General,,D,A J Kotich,46
-Labette,City of Oswego W3,Attorney General,,D,A J Kotich,37
-Labette,Canada,Attorney General,,D,A J Kotich,14
-Labette,Elm Grove,Attorney General,,D,A J Kotich,43
-Labette,Fairview,Attorney General,,D,A J Kotich,14
-Labette,Hackberry,Attorney General,,D,A J Kotich,25
-Labette,Howard,Attorney General,,D,A J Kotich,26
-Labette,Labette,Attorney General,,D,A J Kotich,25
-Labette,Liberty,Attorney General,,D,A J Kotich,31
-Labette,Montana,Attorney General,,D,A J Kotich,16
-Labette,Mound Valley,Attorney General,,D,A J Kotich,62
-Labette,Mt Pleasant,Attorney General,,D,A J Kotich,113
-Labette,Neosho,Attorney General,,D,A J Kotich,19
-Labette,North,Attorney General,,D,A J Kotich,57
-Labette,Osage,Attorney General,,D,A J Kotich,60
-Labette,Oswego,Attorney General,,D,A J Kotich,25
-Labette,Richland 1A,Attorney General,,D,A J Kotich,8
-Labette,Richland 1B,Attorney General,,D,A J Kotich,2
-Labette,Richland 7,Attorney General,,D,A J Kotich,13
-Labette,Walton,Attorney General,,D,A J Kotich,84
-Labette,W1P1,State Treasurer,,R,Ron Estes,149
-Labette,W1P2,State Treasurer,,R,Ron Estes,61
-Labette,W1P3,State Treasurer,,R,Ron Estes,33
-Labette,W2P1,State Treasurer,,R,Ron Estes,46
-Labette,W2P2,State Treasurer,,R,Ron Estes,115
-Labette,W2P3,State Treasurer,,R,Ron Estes,85
-Labette,W3P1,State Treasurer,,R,Ron Estes,48
-Labette,W3P2,State Treasurer,,R,Ron Estes,111
-Labette,W3P3,State Treasurer,,R,Ron Estes,106
-Labette,W3P4,State Treasurer,,R,Ron Estes,146
-Labette,W4P1,State Treasurer,,R,Ron Estes,70
-Labette,W4P2,State Treasurer,,R,Ron Estes,84
-Labette,W4P3,State Treasurer,,R,Ron Estes,58
-Labette,W4P4,State Treasurer,,R,Ron Estes,131
-Labette,City of Chetopa W1,State Treasurer,,R,Ron Estes,41
-Labette,City of Chetopa W2,State Treasurer,,R,Ron Estes,47
-Labette,City of Chetopa W3,State Treasurer,,R,Ron Estes,53
-Labette,City of Oswego W1,State Treasurer,,R,Ron Estes,127
-Labette,City of Oswego W2,State Treasurer,,R,Ron Estes,102
-Labette,City of Oswego W3,State Treasurer,,R,Ron Estes,72
-Labette,Canada,State Treasurer,,R,Ron Estes,75
-Labette,Elm Grove,State Treasurer,,R,Ron Estes,244
-Labette,Fairview,State Treasurer,,R,Ron Estes,62
-Labette,Hackberry,State Treasurer,,R,Ron Estes,80
-Labette,Howard,State Treasurer,,R,Ron Estes,96
-Labette,Labette,State Treasurer,,R,Ron Estes,114
-Labette,Liberty,State Treasurer,,R,Ron Estes,102
-Labette,Montana,State Treasurer,,R,Ron Estes,40
-Labette,Mound Valley,State Treasurer,,R,Ron Estes,185
-Labette,Mt Pleasant,State Treasurer,,R,Ron Estes,279
-Labette,Neosho,State Treasurer,,R,Ron Estes,44
-Labette,North,State Treasurer,,R,Ron Estes,160
-Labette,Osage,State Treasurer,,R,Ron Estes,166
-Labette,Oswego,State Treasurer,,R,Ron Estes,62
-Labette,Richland 1A,State Treasurer,,R,Ron Estes,12
-Labette,Richland 1B,State Treasurer,,R,Ron Estes,10
-Labette,Richland 7,State Treasurer,,R,Ron Estes,34
-Labette,Walton,State Treasurer,,R,Ron Estes,190
-Labette,W1P1,State Treasurer,,D,Carmen Alldritt,88
-Labette,W1P2,State Treasurer,,D,Carmen Alldritt,41
-Labette,W1P3,State Treasurer,,D,Carmen Alldritt,44
-Labette,W2P1,State Treasurer,,D,Carmen Alldritt,35
-Labette,W2P2,State Treasurer,,D,Carmen Alldritt,89
-Labette,W2P3,State Treasurer,,D,Carmen Alldritt,97
-Labette,W3P1,State Treasurer,,D,Carmen Alldritt,26
-Labette,W3P2,State Treasurer,,D,Carmen Alldritt,112
-Labette,W3P3,State Treasurer,,D,Carmen Alldritt,90
-Labette,W3P4,State Treasurer,,D,Carmen Alldritt,108
-Labette,W4P1,State Treasurer,,D,Carmen Alldritt,42
-Labette,W4P2,State Treasurer,,D,Carmen Alldritt,73
-Labette,W4P3,State Treasurer,,D,Carmen Alldritt,72
-Labette,W4P4,State Treasurer,,D,Carmen Alldritt,65
-Labette,City of Chetopa W1,State Treasurer,,D,Carmen Alldritt,30
-Labette,City of Chetopa W2,State Treasurer,,D,Carmen Alldritt,23
-Labette,City of Chetopa W3,State Treasurer,,D,Carmen Alldritt,33
-Labette,City of Oswego W1,State Treasurer,,D,Carmen Alldritt,48
-Labette,City of Oswego W2,State Treasurer,,D,Carmen Alldritt,55
-Labette,City of Oswego W3,State Treasurer,,D,Carmen Alldritt,38
-Labette,Canada,State Treasurer,,D,Carmen Alldritt,22
-Labette,Elm Grove,State Treasurer,,D,Carmen Alldritt,49
-Labette,Fairview,State Treasurer,,D,Carmen Alldritt,16
-Labette,Hackberry,State Treasurer,,D,Carmen Alldritt,24
-Labette,Howard,State Treasurer,,D,Carmen Alldritt,37
-Labette,Labette,State Treasurer,,D,Carmen Alldritt,32
-Labette,Liberty,State Treasurer,,D,Carmen Alldritt,34
-Labette,Montana,State Treasurer,,D,Carmen Alldritt,19
-Labette,Mound Valley,State Treasurer,,D,Carmen Alldritt,68
-Labette,Mt Pleasant,State Treasurer,,D,Carmen Alldritt,126
-Labette,Neosho,State Treasurer,,D,Carmen Alldritt,19
-Labette,North,State Treasurer,,D,Carmen Alldritt,64
-Labette,Osage,State Treasurer,,D,Carmen Alldritt,63
-Labette,Oswego,State Treasurer,,D,Carmen Alldritt,27
-Labette,Richland 1A,State Treasurer,,D,Carmen Alldritt,7
-Labette,Richland 1B,State Treasurer,,D,Carmen Alldritt,2
-Labette,Richland 7,State Treasurer,,D,Carmen Alldritt,15
-Labette,Walton,State Treasurer,,D,Carmen Alldritt,84
-Labette,W1P1,Insurance Commissioner,,R,Ken Selzer,134
-Labette,W1P2,Insurance Commissioner,,R,Ken Selzer,65
-Labette,W1P3,Insurance Commissioner,,R,Ken Selzer,38
-Labette,W2P1,Insurance Commissioner,,R,Ken Selzer,43
-Labette,W2P2,Insurance Commissioner,,R,Ken Selzer,113
-Labette,W2P3,Insurance Commissioner,,R,Ken Selzer,87
-Labette,W3P1,Insurance Commissioner,,R,Ken Selzer,45
-Labette,W3P2,Insurance Commissioner,,R,Ken Selzer,96
-Labette,W3P3,Insurance Commissioner,,R,Ken Selzer,99
-Labette,W3P4,Insurance Commissioner,,R,Ken Selzer,133
-Labette,W4P1,Insurance Commissioner,,R,Ken Selzer,69
-Labette,W4P2,Insurance Commissioner,,R,Ken Selzer,75
-Labette,W4P3,Insurance Commissioner,,R,Ken Selzer,54
-Labette,W4P4,Insurance Commissioner,,R,Ken Selzer,120
-Labette,City of Chetopa W1,Insurance Commissioner,,R,Ken Selzer,38
-Labette,City of Chetopa W2,Insurance Commissioner,,R,Ken Selzer,48
-Labette,City of Chetopa W3,Insurance Commissioner,,R,Ken Selzer,46
-Labette,City of Oswego W1,Insurance Commissioner,,R,Ken Selzer,119
-Labette,City of Oswego W2,Insurance Commissioner,,R,Ken Selzer,90
-Labette,City of Oswego W3,Insurance Commissioner,,R,Ken Selzer,62
-Labette,Canada,Insurance Commissioner,,R,Ken Selzer,73
-Labette,Elm Grove,Insurance Commissioner,,R,Ken Selzer,235
-Labette,Fairview,Insurance Commissioner,,R,Ken Selzer,60
-Labette,Hackberry,Insurance Commissioner,,R,Ken Selzer,78
-Labette,Howard,Insurance Commissioner,,R,Ken Selzer,96
-Labette,Labette,Insurance Commissioner,,R,Ken Selzer,113
-Labette,Liberty,Insurance Commissioner,,R,Ken Selzer,93
-Labette,Montana,Insurance Commissioner,,R,Ken Selzer,38
-Labette,Mound Valley,Insurance Commissioner,,R,Ken Selzer,174
-Labette,Mt Pleasant,Insurance Commissioner,,R,Ken Selzer,265
-Labette,Neosho,Insurance Commissioner,,R,Ken Selzer,41
-Labette,North,Insurance Commissioner,,R,Ken Selzer,142
-Labette,Osage,Insurance Commissioner,,R,Ken Selzer,156
-Labette,Oswego,Insurance Commissioner,,R,Ken Selzer,61
-Labette,Richland 1A,Insurance Commissioner,,R,Ken Selzer,9
-Labette,Richland 1B,Insurance Commissioner,,R,Ken Selzer,10
-Labette,Richland 7,Insurance Commissioner,,R,Ken Selzer,29
-Labette,Walton,Insurance Commissioner,,R,Ken Selzer,176
-Labette,W1P1,Insurance Commissioner,,D,Dennis Anderson,100
-Labette,W1P2,Insurance Commissioner,,D,Dennis Anderson,39
-Labette,W1P3,Insurance Commissioner,,D,Dennis Anderson,37
-Labette,W2P1,Insurance Commissioner,,D,Dennis Anderson,38
-Labette,W2P2,Insurance Commissioner,,D,Dennis Anderson,92
-Labette,W2P3,Insurance Commissioner,,D,Dennis Anderson,94
-Labette,W3P1,Insurance Commissioner,,D,Dennis Anderson,30
-Labette,W3P2,Insurance Commissioner,,D,Dennis Anderson,124
-Labette,W3P3,Insurance Commissioner,,D,Dennis Anderson,100
-Labette,W3P4,Insurance Commissioner,,D,Dennis Anderson,118
-Labette,W4P1,Insurance Commissioner,,D,Dennis Anderson,41
-Labette,W4P2,Insurance Commissioner,,D,Dennis Anderson,83
-Labette,W4P3,Insurance Commissioner,,D,Dennis Anderson,77
-Labette,W4P4,Insurance Commissioner,,D,Dennis Anderson,73
-Labette,City of Chetopa W1,Insurance Commissioner,,D,Dennis Anderson,34
-Labette,City of Chetopa W2,Insurance Commissioner,,D,Dennis Anderson,24
-Labette,City of Chetopa W3,Insurance Commissioner,,D,Dennis Anderson,41
-Labette,City of Oswego W1,Insurance Commissioner,,D,Dennis Anderson,53
-Labette,City of Oswego W2,Insurance Commissioner,,D,Dennis Anderson,63
-Labette,City of Oswego W3,Insurance Commissioner,,D,Dennis Anderson,41
-Labette,Canada,Insurance Commissioner,,D,Dennis Anderson,25
-Labette,Elm Grove,Insurance Commissioner,,D,Dennis Anderson,51
-Labette,Fairview,Insurance Commissioner,,D,Dennis Anderson,16
-Labette,Hackberry,Insurance Commissioner,,D,Dennis Anderson,25
-Labette,Howard,Insurance Commissioner,,D,Dennis Anderson,37
-Labette,Labette,Insurance Commissioner,,D,Dennis Anderson,31
-Labette,Liberty,Insurance Commissioner,,D,Dennis Anderson,43
-Labette,Montana,Insurance Commissioner,,D,Dennis Anderson,19
-Labette,Mound Valley,Insurance Commissioner,,D,Dennis Anderson,76
-Labette,Mt Pleasant,Insurance Commissioner,,D,Dennis Anderson,129
-Labette,Neosho,Insurance Commissioner,,D,Dennis Anderson,23
-Labette,North,Insurance Commissioner,,D,Dennis Anderson,74
-Labette,Osage,Insurance Commissioner,,D,Dennis Anderson,73
-Labette,Oswego,Insurance Commissioner,,D,Dennis Anderson,30
-Labette,Richland 1A,Insurance Commissioner,,D,Dennis Anderson,9
-Labette,Richland 1B,Insurance Commissioner,,D,Dennis Anderson,2
-Labette,Richland 7,Insurance Commissioner,,D,Dennis Anderson,20
-Labette,Walton,Insurance Commissioner,,D,Dennis Anderson,98
-Labette,W1P1,State House,7,R,Richard J Proehl,211
-Labette,W1P2,State House,7,R,Richard J Proehl,87
-Labette,W1P3,State House,7,R,Richard J Proehl,62
-Labette,W2P1,State House,7,R,Richard J Proehl,69
-Labette,W2P2,State House,7,R,Richard J Proehl,178
-Labette,W2P3,State House,7,R,Richard J Proehl,155
-Labette,W3P1,State House,7,R,Richard J Proehl,66
-Labette,W3P2,State House,7,R,Richard J Proehl,180
-Labette,W3P3,State House,7,R,Richard J Proehl,171
-Labette,W3P4,State House,7,R,Richard J Proehl,214
-Labette,W4P1,State House,7,R,Richard J Proehl,101
-Labette,W4P2,State House,7,R,Richard J Proehl,134
-Labette,W4P3,State House,7,R,Richard J Proehl,109
-Labette,W4P4,State House,7,R,Richard J Proehl,183
-Labette,City of Chetopa W1,State House,1,R,Michael Houser,41
-Labette,City of Chetopa W2,State House,1,R,Michael Houser,46
-Labette,City of Chetopa W3,State House,1,R,Michael Houser,57
-Labette,City of Oswego W1,State House,7,R,Richard J Proehl,152
-Labette,City of Oswego W2,State House,7,R,Richard J Proehl,146
-Labette,City of Oswego W3,State House,7,R,Richard J Proehl,95
-Labette,Canada,State House,7,R,Richard J Proehl,89
-Labette,Elm Grove,State House,7,R,Richard J Proehl,265
-Labette,Fairview,State House,7,R,Richard J Proehl,65
-Labette,Hackberry,State House,7,R,Richard J Proehl,81
-Labette,Howard,State House,7,R,Richard J Proehl,117
-Labette,Labette,State House,7,R,Richard J Proehl,132
-Labette,Liberty,State House,7,R,Richard J Proehl,121
-Labette,Montana,State House,7,R,Richard J Proehl,50
-Labette,Mound Valley,State House,7,R,Richard J Proehl,220
-Labette,Mt Pleasant,State House,7,R,Richard J Proehl,347
-Labette,Neosho,State House,7,R,Richard J Proehl,55
-Labette,Norton,State House,7,R,Richard J Proehl,204
-Labette,Osage,State House,7,R,Richard J Proehl,211
-Labette,Oswego,State House,7,R,Richard J Proehl,73
-Labette,Richland 1A,State House,1,R,Michael Houser,13
-Labette,Richland 1B,State House,1,R,Michael Houser,8
-Labette,Richland 7,State House,7,R,Richard J Proehl,43
-Labette,Walton,State House,7,R,Richard J Proehl,242
-Labette,City of Chetopa W1,State House,1,D,Brian Caswell,29
-Labette,City of Chetopa W2,State House,1,D,Brian Caswell,27
-Labette,City of Chetopa W3,State House,1,D,Brian Caswell,38
-Labette,Richland 1A,State House,1,D,Brian Caswell,6
-Labette,Richland 1B,State House,1,D,Brian Caswell,5
+county,precinct,office,district,party,candidate,votes,vtd
+LABETTE,Altamont City Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00001A
+LABETTE,Altamont City Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00001A
+LABETTE,Altamont City Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00001A
+LABETTE,Canada Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000020
+LABETTE,Canada Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000020
+LABETTE,Canada Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000020
+LABETTE,Chetopa Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,000030
+LABETTE,Chetopa Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+LABETTE,Chetopa Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000030
+LABETTE,Chetopa Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000040
+LABETTE,Chetopa Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+LABETTE,Chetopa Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000040
+LABETTE,Chetopa Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000050
+LABETTE,Chetopa Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000050
+LABETTE,Chetopa Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000050
+LABETTE,Elm Grove Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,000060
+LABETTE,Elm Grove Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000060
+LABETTE,Elm Grove Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",219,000060
+LABETTE,Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000070
+LABETTE,Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+LABETTE,Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000070
+LABETTE,Hackberry Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000080
+LABETTE,Hackberry Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000080
+LABETTE,Hackberry Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000080
+LABETTE,Howard Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000090
+LABETTE,Howard Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000090
+LABETTE,Howard Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,000090
+LABETTE,Labette Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000100
+LABETTE,Labette Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000100
+LABETTE,Labette Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,000100
+LABETTE,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,000110
+LABETTE,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000110
+LABETTE,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",82,000110
+LABETTE,Montana Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000120
+LABETTE,Montana Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000120
+LABETTE,Montana Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000120
+LABETTE,Mound Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",84,000130
+LABETTE,Mound Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000130
+LABETTE,Mound Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",162,000130
+LABETTE,Mount Pleasant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",163,000140
+LABETTE,Mount Pleasant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000140
+LABETTE,Mount Pleasant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",230,000140
+LABETTE,Neosho Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000150
+LABETTE,Neosho Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000150
+LABETTE,Neosho Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000150
+LABETTE,North Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",103,00016A
+LABETTE,North Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00016A
+LABETTE,North Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",127,00016A
+LABETTE,North Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00016B
+LABETTE,North Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00016B
+LABETTE,North Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00016B
+LABETTE,Oswego City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000180
+LABETTE,Oswego City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000180
+LABETTE,Oswego City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,000180
+LABETTE,Oswego City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,00019A
+LABETTE,Oswego City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00019A
+LABETTE,Oswego City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,00019A
+LABETTE,Oswego City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,000200
+LABETTE,Oswego City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000200
+LABETTE,Oswego City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000200
+LABETTE,Oswego Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000210
+LABETTE,Oswego Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000210
+LABETTE,Oswego Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000210
+LABETTE,Parsons Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000220
+LABETTE,Parsons Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000220
+LABETTE,Parsons Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,000220
+LABETTE,Parsons Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,000230
+LABETTE,Parsons Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000230
+LABETTE,Parsons Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000230
+LABETTE,Parsons Ward 1 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,00024A
+LABETTE,Parsons Ward 1 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00024A
+LABETTE,Parsons Ward 1 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000250
+LABETTE,Parsons Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000250
+LABETTE,Parsons Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000250
+LABETTE,Parsons Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000260
+LABETTE,Parsons Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000260
+LABETTE,Parsons Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,000260
+LABETTE,Parsons Ward 2 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",110,00027A
+LABETTE,Parsons Ward 2 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,00027A
+LABETTE,Parsons Ward 2 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000280
+LABETTE,Parsons Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000280
+LABETTE,Parsons Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000280
+LABETTE,Parsons Ward 3 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",130,00029A
+LABETTE,Parsons Ward 3 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00029A
+LABETTE,Parsons Ward 3 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",93,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",110,000300
+LABETTE,Parsons Ward 3 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000300
+LABETTE,Parsons Ward 3 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000300
+LABETTE,Parsons Ward 3 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",142,000310
+LABETTE,Parsons Ward 3 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000310
+LABETTE,Parsons Ward 3 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,000310
+LABETTE,Parsons Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",54,000320
+LABETTE,Parsons Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000320
+LABETTE,Parsons Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,000320
+LABETTE,Parsons Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",101,000330
+LABETTE,Parsons Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000330
+LABETTE,Parsons Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000330
+LABETTE,Parsons Ward 4 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",83,000340
+LABETTE,Parsons Ward 4 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000340
+LABETTE,Parsons Ward 4 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000340
+LABETTE,Parsons Ward 4 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",105,000350
+LABETTE,Parsons Ward 4 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000350
+LABETTE,Parsons Ward 4 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000350
+LABETTE,Walton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",120,000370
+LABETTE,Walton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000370
+LABETTE,Walton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",157,000370
+LABETTE,Osage Township S14,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120020
+LABETTE,Osage Township S14,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120020
+LABETTE,Osage Township S14,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120020
+LABETTE,Osage Township S15,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,120030
+LABETTE,Osage Township S15,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120030
+LABETTE,Osage Township S15,Governor / Lt. Governor,,Republican,"Brownback, Sam",147,120030
+LABETTE,Richland Township H1 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,12004A
+LABETTE,Richland Township H1 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,12004A
+LABETTE,Richland Township H1 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,12004A
+LABETTE,Richland Township H1 B,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,12004B
+LABETTE,Richland Township H1 B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,12004B
+LABETTE,Richland Township H1 B,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,12004B
+LABETTE,Richland Township H1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120040
+LABETTE,Richland Township H1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120040
+LABETTE,Richland Township H1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120040
+LABETTE,Richland Township H7,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,120050
+LABETTE,Richland Township H7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120050
+LABETTE,Richland Township H7,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,120050
+LABETTE,Oswego City Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+LABETTE,Oswego City Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+LABETTE,Altamont City Part A,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00001A
+LABETTE,Canada Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",89,000020
+LABETTE,Chetopa Ward 1,Kansas House of Representatives,1,Democratic,"Caswell, Brian",29,000030
+LABETTE,Chetopa Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",41,000030
+LABETTE,Chetopa Ward 2,Kansas House of Representatives,1,Democratic,"Caswell, Brian",27,000040
+LABETTE,Chetopa Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",46,000040
+LABETTE,Chetopa Ward 3,Kansas House of Representatives,1,Democratic,"Caswell, Brian",38,000050
+LABETTE,Chetopa Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",57,000050
+LABETTE,Elm Grove Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",265,000060
+LABETTE,Fairview Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",65,000070
+LABETTE,Hackberry Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",81,000080
+LABETTE,Howard Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",117,000090
+LABETTE,Labette Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",132,000100
+LABETTE,Liberty Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",121,000110
+LABETTE,Montana Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",50,000120
+LABETTE,Mound Valley Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",220,000130
+LABETTE,Mount Pleasant Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",347,000140
+LABETTE,Neosho Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",55,000150
+LABETTE,North Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",204,00016A
+LABETTE,North Township Enclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00016B
+LABETTE,Oswego City Ward 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",152,000180
+LABETTE,Oswego City Ward 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",146,00019A
+LABETTE,Oswego City Ward 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",95,000200
+LABETTE,Oswego Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",73,000210
+LABETTE,Parsons Ward 1 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",211,000220
+LABETTE,Parsons Ward 1 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",87,000230
+LABETTE,Parsons Ward 1 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",62,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",69,000250
+LABETTE,Parsons Ward 2 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",178,000260
+LABETTE,Parsons Ward 2 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",155,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",66,000280
+LABETTE,Parsons Ward 3 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",180,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",171,000300
+LABETTE,Parsons Ward 3 Precinct 4,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",214,000310
+LABETTE,Parsons Ward 4 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",101,000320
+LABETTE,Parsons Ward 4 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",134,000330
+LABETTE,Parsons Ward 4 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",109,000340
+LABETTE,Parsons Ward 4 Precinct 4,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",183,000350
+LABETTE,Walton Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",242,000370
+LABETTE,Osage Township S14,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,120020
+LABETTE,Osage Township S15,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",211,120030
+LABETTE,Richland Township H1 A,Kansas House of Representatives,1,Democratic,"Caswell, Brian",6,12004A
+LABETTE,Richland Township H1 A,Kansas House of Representatives,1,Republican,"Houser, Michael",13,12004A
+LABETTE,Richland Township H1 B,Kansas House of Representatives,1,Democratic,"Caswell, Brian",5,12004B
+LABETTE,Richland Township H1 B,Kansas House of Representatives,1,Republican,"Houser, Michael",8,12004B
+LABETTE,Richland Township H1,Kansas House of Representatives,1,Democratic,"Caswell, Brian",0,120040
+LABETTE,Richland Township H1,Kansas House of Representatives,1,Republican,"Houser, Michael",0,120040
+LABETTE,Richland Township H7,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",43,120050
+LABETTE,Oswego City Ward 1 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,900010
+LABETTE,Altamont City Part A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00001A
+LABETTE,Altamont City Part A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00001A
+LABETTE,Altamont City Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00001A
+LABETTE,Canada Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000020
+LABETTE,Canada Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000020
+LABETTE,Canada Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,000020
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,000030
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000030
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000030
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000040
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000040
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",42,000040
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",34,000050
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000050
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,000050
+LABETTE,Elm Grove Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",39,000060
+LABETTE,Elm Grove Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000060
+LABETTE,Elm Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",246,000060
+LABETTE,Fairview Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000070
+LABETTE,Fairview Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000070
+LABETTE,Fairview Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000070
+LABETTE,Hackberry Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000080
+LABETTE,Hackberry Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000080
+LABETTE,Hackberry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",79,000080
+LABETTE,Howard Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,000090
+LABETTE,Howard Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000090
+LABETTE,Howard Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000090
+LABETTE,Labette Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000100
+LABETTE,Labette Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000100
+LABETTE,Labette Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",108,000100
+LABETTE,Liberty Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",42,000110
+LABETTE,Liberty Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000110
+LABETTE,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000110
+LABETTE,Montana Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,000120
+LABETTE,Montana Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000120
+LABETTE,Montana Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",42,000120
+LABETTE,Mound Valley Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",58,000130
+LABETTE,Mound Valley Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000130
+LABETTE,Mound Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,000130
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",109,000140
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",28,000140
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",273,000140
+LABETTE,Neosho Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000150
+LABETTE,Neosho Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000150
+LABETTE,Neosho Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,000150
+LABETTE,North Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",77,00016A
+LABETTE,North Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,00016A
+LABETTE,North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",145,00016A
+LABETTE,North Township Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00016B
+LABETTE,North Township Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00016B
+LABETTE,North Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016B
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",36,000180
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000180
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,000180
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",58,00019A
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,00019A
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,00019A
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",37,000200
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000200
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",69,000200
+LABETTE,Oswego Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000210
+LABETTE,Oswego Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000210
+LABETTE,Oswego Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000210
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",99,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,000220
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",41,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000230
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",42,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",37,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",44,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",34,000250
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",103,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",98,000260
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",97,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000280
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",118,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",98,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000300
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",112,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",146,000310
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,000320
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",70,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",81,000330
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",70,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000340
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",63,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",126,000350
+LABETTE,Walton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",91,000370
+LABETTE,Walton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000370
+LABETTE,Walton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000370
+LABETTE,Osage Township S14,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120020
+LABETTE,Osage Township S14,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120020
+LABETTE,Osage Township S14,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120020
+LABETTE,Osage Township S15,United States House of Representatives,2,Democratic,"Wakefield, Margie",62,120030
+LABETTE,Osage Township S15,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,120030
+LABETTE,Osage Township S15,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,120030
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Democratic,"Wakefield, Margie",5,12004A
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,12004A
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",14,12004A
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Democratic,"Wakefield, Margie",3,12004B
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,12004B
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Republican,"Jenkins, Lynn",11,12004B
+LABETTE,Richland Township H1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120040
+LABETTE,Richland Township H1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120040
+LABETTE,Richland Township H1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120040
+LABETTE,Richland Township H7,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,120050
+LABETTE,Richland Township H7,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,120050
+LABETTE,Richland Township H7,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,120050
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+LABETTE,Altamont City Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00001A
+LABETTE,Altamont City Part A,Attorney General,,Republican,"Schmidt, Derek",0,00001A
+LABETTE,Canada Township,Attorney General,,Democratic,"Kotich, A.J.",14,000020
+LABETTE,Canada Township,Attorney General,,Republican,"Schmidt, Derek",84,000020
+LABETTE,Chetopa Ward 1,Attorney General,,Democratic,"Kotich, A.J.",28,000030
+LABETTE,Chetopa Ward 1,Attorney General,,Republican,"Schmidt, Derek",45,000030
+LABETTE,Chetopa Ward 2,Attorney General,,Democratic,"Kotich, A.J.",22,000040
+LABETTE,Chetopa Ward 2,Attorney General,,Republican,"Schmidt, Derek",48,000040
+LABETTE,Chetopa Ward 3,Attorney General,,Democratic,"Kotich, A.J.",31,000050
+LABETTE,Chetopa Ward 3,Attorney General,,Republican,"Schmidt, Derek",59,000050
+LABETTE,Elm Grove Township,Attorney General,,Democratic,"Kotich, A.J.",43,000060
+LABETTE,Elm Grove Township,Attorney General,,Republican,"Schmidt, Derek",251,000060
+LABETTE,Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",14,000070
+LABETTE,Fairview Township,Attorney General,,Republican,"Schmidt, Derek",64,000070
+LABETTE,Hackberry Township,Attorney General,,Democratic,"Kotich, A.J.",25,000080
+LABETTE,Hackberry Township,Attorney General,,Republican,"Schmidt, Derek",82,000080
+LABETTE,Howard Township,Attorney General,,Democratic,"Kotich, A.J.",26,000090
+LABETTE,Howard Township,Attorney General,,Republican,"Schmidt, Derek",110,000090
+LABETTE,Labette Township,Attorney General,,Democratic,"Kotich, A.J.",25,000100
+LABETTE,Labette Township,Attorney General,,Republican,"Schmidt, Derek",120,000100
+LABETTE,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",31,000110
+LABETTE,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",102,000110
+LABETTE,Montana Township,Attorney General,,Democratic,"Kotich, A.J.",16,000120
+LABETTE,Montana Township,Attorney General,,Republican,"Schmidt, Derek",44,000120
+LABETTE,Mound Valley Township,Attorney General,,Democratic,"Kotich, A.J.",62,000130
+LABETTE,Mound Valley Township,Attorney General,,Republican,"Schmidt, Derek",197,000130
+LABETTE,Mount Pleasant Township,Attorney General,,Democratic,"Kotich, A.J.",113,000140
+LABETTE,Mount Pleasant Township,Attorney General,,Republican,"Schmidt, Derek",295,000140
+LABETTE,Neosho Township,Attorney General,,Democratic,"Kotich, A.J.",19,000150
+LABETTE,Neosho Township,Attorney General,,Republican,"Schmidt, Derek",46,000150
+LABETTE,North Township,Attorney General,,Democratic,"Kotich, A.J.",57,00016A
+LABETTE,North Township,Attorney General,,Republican,"Schmidt, Derek",171,00016A
+LABETTE,North Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00016B
+LABETTE,North Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00016B
+LABETTE,Oswego City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",45,000180
+LABETTE,Oswego City Ward 1,Attorney General,,Republican,"Schmidt, Derek",129,000180
+LABETTE,Oswego City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",46,00019A
+LABETTE,Oswego City Ward 2,Attorney General,,Republican,"Schmidt, Derek",113,00019A
+LABETTE,Oswego City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",37,000200
+LABETTE,Oswego City Ward 3,Attorney General,,Republican,"Schmidt, Derek",74,000200
+LABETTE,Oswego Township,Attorney General,,Democratic,"Kotich, A.J.",25,000210
+LABETTE,Oswego Township,Attorney General,,Republican,"Schmidt, Derek",66,000210
+LABETTE,Parsons Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",87,000220
+LABETTE,Parsons Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",152,000220
+LABETTE,Parsons Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",39,000230
+LABETTE,Parsons Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",67,000230
+LABETTE,Parsons Ward 1 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",35,00024A
+LABETTE,Parsons Ward 1 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",44,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",31,000250
+LABETTE,Parsons Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",51,000250
+LABETTE,Parsons Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",91,000260
+LABETTE,Parsons Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",114,000260
+LABETTE,Parsons Ward 2 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",85,00027A
+LABETTE,Parsons Ward 2 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",102,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",27,000280
+LABETTE,Parsons Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",48,000280
+LABETTE,Parsons Ward 3 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",107,00029A
+LABETTE,Parsons Ward 3 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",118,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",86,000300
+LABETTE,Parsons Ward 3 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",114,000300
+LABETTE,Parsons Ward 3 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",115,000310
+LABETTE,Parsons Ward 3 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",144,000310
+LABETTE,Parsons Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",42,000320
+LABETTE,Parsons Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",70,000320
+LABETTE,Parsons Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",77,000330
+LABETTE,Parsons Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",86,000330
+LABETTE,Parsons Ward 4 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",75,000340
+LABETTE,Parsons Ward 4 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",59,000340
+LABETTE,Parsons Ward 4 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",60,000350
+LABETTE,Parsons Ward 4 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",135,000350
+LABETTE,Walton Township,Attorney General,,Democratic,"Kotich, A.J.",84,000370
+LABETTE,Walton Township,Attorney General,,Republican,"Schmidt, Derek",194,000370
+LABETTE,Osage Township S14,Attorney General,,Democratic,"Kotich, A.J.",0,120020
+LABETTE,Osage Township S14,Attorney General,,Republican,"Schmidt, Derek",0,120020
+LABETTE,Osage Township S15,Attorney General,,Democratic,"Kotich, A.J.",60,120030
+LABETTE,Osage Township S15,Attorney General,,Republican,"Schmidt, Derek",171,120030
+LABETTE,Richland Township H1 A,Attorney General,,Democratic,"Kotich, A.J.",8,12004A
+LABETTE,Richland Township H1 A,Attorney General,,Republican,"Schmidt, Derek",10,12004A
+LABETTE,Richland Township H1 B,Attorney General,,Democratic,"Kotich, A.J.",2,12004B
+LABETTE,Richland Township H1 B,Attorney General,,Republican,"Schmidt, Derek",10,12004B
+LABETTE,Richland Township H1,Attorney General,,Democratic,"Kotich, A.J.",0,120040
+LABETTE,Richland Township H1,Attorney General,,Republican,"Schmidt, Derek",0,120040
+LABETTE,Richland Township H7,Attorney General,,Democratic,"Kotich, A.J.",13,120050
+LABETTE,Richland Township H7,Attorney General,,Republican,"Schmidt, Derek",35,120050
+LABETTE,Oswego City Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+LABETTE,Altamont City Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00001A
+LABETTE,Altamont City Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00001A
+LABETTE,Canada Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000020
+LABETTE,Canada Township,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000020
+LABETTE,Chetopa Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000030
+LABETTE,Chetopa Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000030
+LABETTE,Chetopa Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000040
+LABETTE,Chetopa Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000040
+LABETTE,Chetopa Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000050
+LABETTE,Chetopa Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000050
+LABETTE,Elm Grove Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,000060
+LABETTE,Elm Grove Township,Commissioner of Insurance,,Republican,"Selzer, Ken",235,000060
+LABETTE,Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000070
+LABETTE,Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",60,000070
+LABETTE,Hackberry Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000080
+LABETTE,Hackberry Township,Commissioner of Insurance,,Republican,"Selzer, Ken",78,000080
+LABETTE,Howard Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000090
+LABETTE,Howard Township,Commissioner of Insurance,,Republican,"Selzer, Ken",96,000090
+LABETTE,Labette Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000100
+LABETTE,Labette Township,Commissioner of Insurance,,Republican,"Selzer, Ken",113,000100
+LABETTE,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000110
+LABETTE,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",93,000110
+LABETTE,Montana Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000120
+LABETTE,Montana Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000120
+LABETTE,Mound Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,000130
+LABETTE,Mound Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",174,000130
+LABETTE,Mount Pleasant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",129,000140
+LABETTE,Mount Pleasant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",265,000140
+LABETTE,Neosho Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000150
+LABETTE,Neosho Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000150
+LABETTE,North Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",74,00016A
+LABETTE,North Township,Commissioner of Insurance,,Republican,"Selzer, Ken",142,00016A
+LABETTE,North Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00016B
+LABETTE,North Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00016B
+LABETTE,Oswego City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000180
+LABETTE,Oswego City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",119,000180
+LABETTE,Oswego City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,00019A
+LABETTE,Oswego City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",90,00019A
+LABETTE,Oswego City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000200
+LABETTE,Oswego City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000200
+LABETTE,Oswego Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000210
+LABETTE,Oswego Township,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000210
+LABETTE,Parsons Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",100,000220
+LABETTE,Parsons Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",134,000220
+LABETTE,Parsons Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000230
+LABETTE,Parsons Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",65,000230
+LABETTE,Parsons Ward 1 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,00024A
+LABETTE,Parsons Ward 1 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",38,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000250
+LABETTE,Parsons Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",43,000250
+LABETTE,Parsons Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,000260
+LABETTE,Parsons Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",113,000260
+LABETTE,Parsons Ward 2 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",94,00027A
+LABETTE,Parsons Ward 2 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",87,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000280
+LABETTE,Parsons Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000280
+LABETTE,Parsons Ward 3 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",124,00029A
+LABETTE,Parsons Ward 3 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",96,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",100,000300
+LABETTE,Parsons Ward 3 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",99,000300
+LABETTE,Parsons Ward 3 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",118,000310
+LABETTE,Parsons Ward 3 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000310
+LABETTE,Parsons Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000320
+LABETTE,Parsons Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",69,000320
+LABETTE,Parsons Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",83,000330
+LABETTE,Parsons Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",75,000330
+LABETTE,Parsons Ward 4 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000340
+LABETTE,Parsons Ward 4 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",54,000340
+LABETTE,Parsons Ward 4 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000350
+LABETTE,Parsons Ward 4 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",120,000350
+LABETTE,Walton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",98,000370
+LABETTE,Walton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",176,000370
+LABETTE,Osage Township S14,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120020
+LABETTE,Osage Township S14,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120020
+LABETTE,Osage Township S15,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,120030
+LABETTE,Osage Township S15,Commissioner of Insurance,,Republican,"Selzer, Ken",156,120030
+LABETTE,Richland Township H1 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,12004A
+LABETTE,Richland Township H1 A,Commissioner of Insurance,,Republican,"Selzer, Ken",9,12004A
+LABETTE,Richland Township H1 B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,12004B
+LABETTE,Richland Township H1 B,Commissioner of Insurance,,Republican,"Selzer, Ken",10,12004B
+LABETTE,Richland Township H1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120040
+LABETTE,Richland Township H1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120040
+LABETTE,Richland Township H7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,120050
+LABETTE,Richland Township H7,Commissioner of Insurance,,Republican,"Selzer, Ken",29,120050
+LABETTE,Oswego City Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+LABETTE,Oswego City Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+LABETTE,Altamont City Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00001A
+LABETTE,Altamont City Part A,Secretary of State,,Republican,"Kobach, Kris",0,00001A
+LABETTE,Canada Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000020
+LABETTE,Canada Township,Secretary of State,,Republican,"Kobach, Kris",73,000020
+LABETTE,Chetopa Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",32,000030
+LABETTE,Chetopa Ward 1,Secretary of State,,Republican,"Kobach, Kris",38,000030
+LABETTE,Chetopa Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000040
+LABETTE,Chetopa Ward 2,Secretary of State,,Republican,"Kobach, Kris",44,000040
+LABETTE,Chetopa Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000050
+LABETTE,Chetopa Ward 3,Secretary of State,,Republican,"Kobach, Kris",50,000050
+LABETTE,Elm Grove Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000060
+LABETTE,Elm Grove Township,Secretary of State,,Republican,"Kobach, Kris",239,000060
+LABETTE,Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000070
+LABETTE,Fairview Township,Secretary of State,,Republican,"Kobach, Kris",60,000070
+LABETTE,Hackberry Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000080
+LABETTE,Hackberry Township,Secretary of State,,Republican,"Kobach, Kris",77,000080
+LABETTE,Howard Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000090
+LABETTE,Howard Township,Secretary of State,,Republican,"Kobach, Kris",93,000090
+LABETTE,Labette Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000100
+LABETTE,Labette Township,Secretary of State,,Republican,"Kobach, Kris",112,000100
+LABETTE,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000110
+LABETTE,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",92,000110
+LABETTE,Montana Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000120
+LABETTE,Montana Township,Secretary of State,,Republican,"Kobach, Kris",39,000120
+LABETTE,Mound Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",80,000130
+LABETTE,Mound Valley Township,Secretary of State,,Republican,"Kobach, Kris",174,000130
+LABETTE,Mount Pleasant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",143,000140
+LABETTE,Mount Pleasant Township,Secretary of State,,Republican,"Kobach, Kris",265,000140
+LABETTE,Neosho Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000150
+LABETTE,Neosho Township,Secretary of State,,Republican,"Kobach, Kris",44,000150
+LABETTE,North Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,00016A
+LABETTE,North Township,Secretary of State,,Republican,"Kobach, Kris",147,00016A
+LABETTE,North Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00016B
+LABETTE,North Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00016B
+LABETTE,Oswego City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000180
+LABETTE,Oswego City Ward 1,Secretary of State,,Republican,"Kobach, Kris",117,000180
+LABETTE,Oswego City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,00019A
+LABETTE,Oswego City Ward 2,Secretary of State,,Republican,"Kobach, Kris",100,00019A
+LABETTE,Oswego City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000200
+LABETTE,Oswego City Ward 3,Secretary of State,,Republican,"Kobach, Kris",67,000200
+LABETTE,Oswego Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000210
+LABETTE,Oswego Township,Secretary of State,,Republican,"Kobach, Kris",59,000210
+LABETTE,Parsons Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,000220
+LABETTE,Parsons Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",129,000220
+LABETTE,Parsons Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000230
+LABETTE,Parsons Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",60,000230
+LABETTE,Parsons Ward 1 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,00024A
+LABETTE,Parsons Ward 1 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",32,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000250
+LABETTE,Parsons Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",39,000250
+LABETTE,Parsons Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,000260
+LABETTE,Parsons Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",102,000260
+LABETTE,Parsons Ward 2 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",91,00027A
+LABETTE,Parsons Ward 2 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",93,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000280
+LABETTE,Parsons Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",46,000280
+LABETTE,Parsons Ward 3 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",124,00029A
+LABETTE,Parsons Ward 3 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",101,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",101,000300
+LABETTE,Parsons Ward 3 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",101,000300
+LABETTE,Parsons Ward 3 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",121,000310
+LABETTE,Parsons Ward 3 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",137,000310
+LABETTE,Parsons Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000320
+LABETTE,Parsons Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",66,000320
+LABETTE,Parsons Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",85,000330
+LABETTE,Parsons Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",78,000330
+LABETTE,Parsons Ward 4 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",85,000340
+LABETTE,Parsons Ward 4 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",50,000340
+LABETTE,Parsons Ward 4 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",81,000350
+LABETTE,Parsons Ward 4 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",117,000350
+LABETTE,Walton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",107,000370
+LABETTE,Walton Township,Secretary of State,,Republican,"Kobach, Kris",167,000370
+LABETTE,Osage Township S14,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120020
+LABETTE,Osage Township S14,Secretary of State,,Republican,"Kobach, Kris",0,120020
+LABETTE,Osage Township S15,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,120030
+LABETTE,Osage Township S15,Secretary of State,,Republican,"Kobach, Kris",161,120030
+LABETTE,Richland Township H1 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,12004A
+LABETTE,Richland Township H1 A,Secretary of State,,Republican,"Kobach, Kris",9,12004A
+LABETTE,Richland Township H1 B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,12004B
+LABETTE,Richland Township H1 B,Secretary of State,,Republican,"Kobach, Kris",9,12004B
+LABETTE,Richland Township H1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120040
+LABETTE,Richland Township H1,Secretary of State,,Republican,"Kobach, Kris",0,120040
+LABETTE,Richland Township H7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,120050
+LABETTE,Richland Township H7,Secretary of State,,Republican,"Kobach, Kris",29,120050
+LABETTE,Oswego City Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+LABETTE,Oswego City Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+LABETTE,Altamont City Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00001A
+LABETTE,Altamont City Part A,State Treasurer,,Republican,"Estes, Ron",0,00001A
+LABETTE,Canada Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000020
+LABETTE,Canada Township,State Treasurer,,Republican,"Estes, Ron",75,000020
+LABETTE,Chetopa Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",30,000030
+LABETTE,Chetopa Ward 1,State Treasurer,,Republican,"Estes, Ron",41,000030
+LABETTE,Chetopa Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",23,000040
+LABETTE,Chetopa Ward 2,State Treasurer,,Republican,"Estes, Ron",47,000040
+LABETTE,Chetopa Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",33,000050
+LABETTE,Chetopa Ward 3,State Treasurer,,Republican,"Estes, Ron",53,000050
+LABETTE,Elm Grove Township,State Treasurer,,Democratic,"Alldritt, Carmen",49,000060
+LABETTE,Elm Grove Township,State Treasurer,,Republican,"Estes, Ron",244,000060
+LABETTE,Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000070
+LABETTE,Fairview Township,State Treasurer,,Republican,"Estes, Ron",62,000070
+LABETTE,Hackberry Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000080
+LABETTE,Hackberry Township,State Treasurer,,Republican,"Estes, Ron",80,000080
+LABETTE,Howard Township,State Treasurer,,Democratic,"Alldritt, Carmen",37,000090
+LABETTE,Howard Township,State Treasurer,,Republican,"Estes, Ron",96,000090
+LABETTE,Labette Township,State Treasurer,,Democratic,"Alldritt, Carmen",32,000100
+LABETTE,Labette Township,State Treasurer,,Republican,"Estes, Ron",114,000100
+LABETTE,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",34,000110
+LABETTE,Liberty Township,State Treasurer,,Republican,"Estes, Ron",102,000110
+LABETTE,Montana Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000120
+LABETTE,Montana Township,State Treasurer,,Republican,"Estes, Ron",40,000120
+LABETTE,Mound Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",68,000130
+LABETTE,Mound Valley Township,State Treasurer,,Republican,"Estes, Ron",185,000130
+LABETTE,Mount Pleasant Township,State Treasurer,,Democratic,"Alldritt, Carmen",126,000140
+LABETTE,Mount Pleasant Township,State Treasurer,,Republican,"Estes, Ron",279,000140
+LABETTE,Neosho Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000150
+LABETTE,Neosho Township,State Treasurer,,Republican,"Estes, Ron",44,000150
+LABETTE,North Township,State Treasurer,,Democratic,"Alldritt, Carmen",64,00016A
+LABETTE,North Township,State Treasurer,,Republican,"Estes, Ron",160,00016A
+LABETTE,North Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00016B
+LABETTE,North Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,00016B
+LABETTE,Oswego City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",48,000180
+LABETTE,Oswego City Ward 1,State Treasurer,,Republican,"Estes, Ron",127,000180
+LABETTE,Oswego City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",55,00019A
+LABETTE,Oswego City Ward 2,State Treasurer,,Republican,"Estes, Ron",102,00019A
+LABETTE,Oswego City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",38,000200
+LABETTE,Oswego City Ward 3,State Treasurer,,Republican,"Estes, Ron",72,000200
+LABETTE,Oswego Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000210
+LABETTE,Oswego Township,State Treasurer,,Republican,"Estes, Ron",62,000210
+LABETTE,Parsons Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",88,000220
+LABETTE,Parsons Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",149,000220
+LABETTE,Parsons Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",41,000230
+LABETTE,Parsons Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",61,000230
+LABETTE,Parsons Ward 1 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",44,00024A
+LABETTE,Parsons Ward 1 Precinct 3,State Treasurer,,Republican,"Estes, Ron",33,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",35,000250
+LABETTE,Parsons Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",46,000250
+LABETTE,Parsons Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",89,000260
+LABETTE,Parsons Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",115,000260
+LABETTE,Parsons Ward 2 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",97,00027A
+LABETTE,Parsons Ward 2 Precinct 3,State Treasurer,,Republican,"Estes, Ron",85,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",26,000280
+LABETTE,Parsons Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",48,000280
+LABETTE,Parsons Ward 3 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",112,00029A
+LABETTE,Parsons Ward 3 Precinct 2,State Treasurer,,Republican,"Estes, Ron",111,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",90,000300
+LABETTE,Parsons Ward 3 Precinct 3,State Treasurer,,Republican,"Estes, Ron",106,000300
+LABETTE,Parsons Ward 3 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",108,000310
+LABETTE,Parsons Ward 3 Precinct 4,State Treasurer,,Republican,"Estes, Ron",146,000310
+LABETTE,Parsons Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",42,000320
+LABETTE,Parsons Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",70,000320
+LABETTE,Parsons Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",73,000330
+LABETTE,Parsons Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",84,000330
+LABETTE,Parsons Ward 4 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",72,000340
+LABETTE,Parsons Ward 4 Precinct 3,State Treasurer,,Republican,"Estes, Ron",58,000340
+LABETTE,Parsons Ward 4 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",65,000350
+LABETTE,Parsons Ward 4 Precinct 4,State Treasurer,,Republican,"Estes, Ron",131,000350
+LABETTE,Walton Township,State Treasurer,,Democratic,"Alldritt, Carmen",84,000370
+LABETTE,Walton Township,State Treasurer,,Republican,"Estes, Ron",190,000370
+LABETTE,Osage Township S14,State Treasurer,,Democratic,"Alldritt, Carmen",0,120020
+LABETTE,Osage Township S14,State Treasurer,,Republican,"Estes, Ron",0,120020
+LABETTE,Osage Township S15,State Treasurer,,Democratic,"Alldritt, Carmen",63,120030
+LABETTE,Osage Township S15,State Treasurer,,Republican,"Estes, Ron",166,120030
+LABETTE,Richland Township H1 A,State Treasurer,,Democratic,"Alldritt, Carmen",7,12004A
+LABETTE,Richland Township H1 A,State Treasurer,,Republican,"Estes, Ron",12,12004A
+LABETTE,Richland Township H1 B,State Treasurer,,Democratic,"Alldritt, Carmen",2,12004B
+LABETTE,Richland Township H1 B,State Treasurer,,Republican,"Estes, Ron",10,12004B
+LABETTE,Richland Township H1,State Treasurer,,Democratic,"Alldritt, Carmen",0,120040
+LABETTE,Richland Township H1,State Treasurer,,Republican,"Estes, Ron",0,120040
+LABETTE,Richland Township H7,State Treasurer,,Democratic,"Alldritt, Carmen",15,120050
+LABETTE,Richland Township H7,State Treasurer,,Republican,"Estes, Ron",34,120050
+LABETTE,Oswego City Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+LABETTE,Oswego City Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+LABETTE,Altamont City Part A,United States Senate,,independent,"Orman, Greg",0,00001A
+LABETTE,Altamont City Part A,United States Senate,,Libertarian,"Batson, Randall",0,00001A
+LABETTE,Altamont City Part A,United States Senate,,Republican,"Roberts, Pat",0,00001A
+LABETTE,Canada Township,United States Senate,,independent,"Orman, Greg",21,000020
+LABETTE,Canada Township,United States Senate,,Libertarian,"Batson, Randall",3,000020
+LABETTE,Canada Township,United States Senate,,Republican,"Roberts, Pat",74,000020
+LABETTE,Chetopa Ward 1,United States Senate,,independent,"Orman, Greg",26,000030
+LABETTE,Chetopa Ward 1,United States Senate,,Libertarian,"Batson, Randall",7,000030
+LABETTE,Chetopa Ward 1,United States Senate,,Republican,"Roberts, Pat",38,000030
+LABETTE,Chetopa Ward 2,United States Senate,,independent,"Orman, Greg",24,000040
+LABETTE,Chetopa Ward 2,United States Senate,,Libertarian,"Batson, Randall",6,000040
+LABETTE,Chetopa Ward 2,United States Senate,,Republican,"Roberts, Pat",40,000040
+LABETTE,Chetopa Ward 3,United States Senate,,independent,"Orman, Greg",31,000050
+LABETTE,Chetopa Ward 3,United States Senate,,Libertarian,"Batson, Randall",7,000050
+LABETTE,Chetopa Ward 3,United States Senate,,Republican,"Roberts, Pat",54,000050
+LABETTE,Elm Grove Township,United States Senate,,independent,"Orman, Greg",47,000060
+LABETTE,Elm Grove Township,United States Senate,,Libertarian,"Batson, Randall",18,000060
+LABETTE,Elm Grove Township,United States Senate,,Republican,"Roberts, Pat",228,000060
+LABETTE,Fairview Township,United States Senate,,independent,"Orman, Greg",18,000070
+LABETTE,Fairview Township,United States Senate,,Libertarian,"Batson, Randall",3,000070
+LABETTE,Fairview Township,United States Senate,,Republican,"Roberts, Pat",58,000070
+LABETTE,Hackberry Township,United States Senate,,independent,"Orman, Greg",26,000080
+LABETTE,Hackberry Township,United States Senate,,Libertarian,"Batson, Randall",9,000080
+LABETTE,Hackberry Township,United States Senate,,Republican,"Roberts, Pat",74,000080
+LABETTE,Howard Township,United States Senate,,independent,"Orman, Greg",42,000090
+LABETTE,Howard Township,United States Senate,,Libertarian,"Batson, Randall",7,000090
+LABETTE,Howard Township,United States Senate,,Republican,"Roberts, Pat",86,000090
+LABETTE,Labette Township,United States Senate,,independent,"Orman, Greg",32,000100
+LABETTE,Labette Township,United States Senate,,Libertarian,"Batson, Randall",8,000100
+LABETTE,Labette Township,United States Senate,,Republican,"Roberts, Pat",107,000100
+LABETTE,Liberty Township,United States Senate,,independent,"Orman, Greg",47,000110
+LABETTE,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",6,000110
+LABETTE,Liberty Township,United States Senate,,Republican,"Roberts, Pat",89,000110
+LABETTE,Montana Township,United States Senate,,independent,"Orman, Greg",16,000120
+LABETTE,Montana Township,United States Senate,,Libertarian,"Batson, Randall",3,000120
+LABETTE,Montana Township,United States Senate,,Republican,"Roberts, Pat",41,000120
+LABETTE,Mound Valley Township,United States Senate,,independent,"Orman, Greg",70,000130
+LABETTE,Mound Valley Township,United States Senate,,Libertarian,"Batson, Randall",17,000130
+LABETTE,Mound Valley Township,United States Senate,,Republican,"Roberts, Pat",167,000130
+LABETTE,Mount Pleasant Township,United States Senate,,independent,"Orman, Greg",123,000140
+LABETTE,Mount Pleasant Township,United States Senate,,Libertarian,"Batson, Randall",26,000140
+LABETTE,Mount Pleasant Township,United States Senate,,Republican,"Roberts, Pat",259,000140
+LABETTE,Neosho Township,United States Senate,,independent,"Orman, Greg",19,000150
+LABETTE,Neosho Township,United States Senate,,Libertarian,"Batson, Randall",6,000150
+LABETTE,Neosho Township,United States Senate,,Republican,"Roberts, Pat",39,000150
+LABETTE,North Township,United States Senate,,independent,"Orman, Greg",91,00016A
+LABETTE,North Township,United States Senate,,Libertarian,"Batson, Randall",15,00016A
+LABETTE,North Township,United States Senate,,Republican,"Roberts, Pat",127,00016A
+LABETTE,North Township Enclave,United States Senate,,independent,"Orman, Greg",0,00016B
+LABETTE,North Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00016B
+LABETTE,North Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,00016B
+LABETTE,Oswego City Ward 1,United States Senate,,independent,"Orman, Greg",52,000180
+LABETTE,Oswego City Ward 1,United States Senate,,Libertarian,"Batson, Randall",18,000180
+LABETTE,Oswego City Ward 1,United States Senate,,Republican,"Roberts, Pat",104,000180
+LABETTE,Oswego City Ward 2,United States Senate,,independent,"Orman, Greg",64,00019A
+LABETTE,Oswego City Ward 2,United States Senate,,Libertarian,"Batson, Randall",12,00019A
+LABETTE,Oswego City Ward 2,United States Senate,,Republican,"Roberts, Pat",90,00019A
+LABETTE,Oswego City Ward 3,United States Senate,,independent,"Orman, Greg",45,000200
+LABETTE,Oswego City Ward 3,United States Senate,,Libertarian,"Batson, Randall",14,000200
+LABETTE,Oswego City Ward 3,United States Senate,,Republican,"Roberts, Pat",58,000200
+LABETTE,Oswego Township,United States Senate,,independent,"Orman, Greg",30,000210
+LABETTE,Oswego Township,United States Senate,,Libertarian,"Batson, Randall",5,000210
+LABETTE,Oswego Township,United States Senate,,Republican,"Roberts, Pat",56,000210
+LABETTE,Parsons Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",108,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",13,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",121,000220
+LABETTE,Parsons Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",42,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",6,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",56,000230
+LABETTE,Parsons Ward 1 Precinct 3,United States Senate,,independent,"Orman, Greg",36,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",4,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States Senate,,Republican,"Roberts, Pat",36,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States Senate,,independent,"Orman, Greg",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",41,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",4,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",36,000250
+LABETTE,Parsons Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",104,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",6,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",96,000260
+LABETTE,Parsons Ward 2 Precinct 3,United States Senate,,independent,"Orman, Greg",89,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",18,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States Senate,,Republican,"Roberts, Pat",80,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States Senate,,independent,"Orman, Greg",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",25,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",6,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",46,000280
+LABETTE,Parsons Ward 3 Precinct 2,United States Senate,,independent,"Orman, Greg",117,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",12,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States Senate,,Republican,"Roberts, Pat",95,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,United States Senate,,independent,"Orman, Greg",84,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",21,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States Senate,,Republican,"Roberts, Pat",94,000300
+LABETTE,Parsons Ward 3 Precinct 4,United States Senate,,independent,"Orman, Greg",123,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",15,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States Senate,,Republican,"Roberts, Pat",124,000310
+LABETTE,Parsons Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",44,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",8,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",61,000320
+LABETTE,Parsons Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",88,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",15,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",62,000330
+LABETTE,Parsons Ward 4 Precinct 3,United States Senate,,independent,"Orman, Greg",72,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",8,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States Senate,,Republican,"Roberts, Pat",55,000340
+LABETTE,Parsons Ward 4 Precinct 4,United States Senate,,independent,"Orman, Greg",81,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",12,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States Senate,,Republican,"Roberts, Pat",110,000350
+LABETTE,Walton Township,United States Senate,,independent,"Orman, Greg",105,000370
+LABETTE,Walton Township,United States Senate,,Libertarian,"Batson, Randall",14,000370
+LABETTE,Walton Township,United States Senate,,Republican,"Roberts, Pat",160,000370
+LABETTE,Osage Township S14,United States Senate,,independent,"Orman, Greg",0,120020
+LABETTE,Osage Township S14,United States Senate,,Libertarian,"Batson, Randall",0,120020
+LABETTE,Osage Township S14,United States Senate,,Republican,"Roberts, Pat",0,120020
+LABETTE,Osage Township S15,United States Senate,,independent,"Orman, Greg",75,120030
+LABETTE,Osage Township S15,United States Senate,,Libertarian,"Batson, Randall",12,120030
+LABETTE,Osage Township S15,United States Senate,,Republican,"Roberts, Pat",148,120030
+LABETTE,Richland Township H1 A,United States Senate,,independent,"Orman, Greg",6,12004A
+LABETTE,Richland Township H1 A,United States Senate,,Libertarian,"Batson, Randall",2,12004A
+LABETTE,Richland Township H1 A,United States Senate,,Republican,"Roberts, Pat",12,12004A
+LABETTE,Richland Township H1 B,United States Senate,,independent,"Orman, Greg",4,12004B
+LABETTE,Richland Township H1 B,United States Senate,,Libertarian,"Batson, Randall",1,12004B
+LABETTE,Richland Township H1 B,United States Senate,,Republican,"Roberts, Pat",8,12004B
+LABETTE,Richland Township H1,United States Senate,,independent,"Orman, Greg",0,120040
+LABETTE,Richland Township H1,United States Senate,,Libertarian,"Batson, Randall",0,120040
+LABETTE,Richland Township H1,United States Senate,,Republican,"Roberts, Pat",0,120040
+LABETTE,Richland Township H7,United States Senate,,independent,"Orman, Greg",18,120050
+LABETTE,Richland Township H7,United States Senate,,Libertarian,"Batson, Randall",5,120050
+LABETTE,Richland Township H7,United States Senate,,Republican,"Roberts, Pat",25,120050
+LABETTE,Oswego City Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900010

--- a/2014/20141104__ks__general__lane__precinct.csv
+++ b/2014/20141104__ks__general__lane__precinct.csv
@@ -1,171 +1,171 @@
-county,precinct,office,district,party,candidate,votes,election night,advance,provisional
-Lane,Alamota Twp,Attorney General,,D,A J Kotich,7,5,2,0
-Lane,Cheyenne Twp,Attorney General,,D,A J Kotich,14,11,2,1
-Lane,Dighton City 1,Attorney General,,D,A J Kotich,32,21,11,0
-Lane,Dighton City 2,Attorney General,,D,A J Kotich,31,19,11,1
-Lane,Dighton City 3,Attorney General,,D,A J Kotich,10,6,2,2
-Lane,Dighton Twp 1,Attorney General,,D,A J Kotich,9,4,3,2
-Lane,Dighton Twp 2,Attorney General,,D,A J Kotich,4,1,3,0
-Lane,Dighton Twp 3,Attorney General,,D,A J Kotich,3,2,1,0
-Lane,White Rock Twp,Attorney General,,D,A J Kotich,1,1,0,0
-Lane,Wilson Twp,Attorney General,,D,A J Kotich,3,3,0,0
-Lane,Alamota Twp,Attorney General,,R,Derek Schmidt,28,21,6,1
-Lane,Cheyenne Twp,Attorney General,,R,Derek Schmidt,94,80,9,5
-Lane,Dighton City 1,Attorney General,,R,Derek Schmidt,133,91,33,9
-Lane,Dighton City 2,Attorney General,,R,Derek Schmidt,174,141,30,3
-Lane,Dighton City 3,Attorney General,,R,Derek Schmidt,53,45,6,2
-Lane,Dighton Twp 1,Attorney General,,R,Derek Schmidt,31,27,3,1
-Lane,Dighton Twp 2,Attorney General,,R,Derek Schmidt,50,37,13,0
-Lane,Dighton Twp 3,Attorney General,,R,Derek Schmidt,19,13,6,0
-Lane,White Rock Twp,Attorney General,,R,Derek Schmidt,11,9,2,0
-Lane,Wilson Twp,Attorney General,,R,Derek Schmidt,31,25,6,0
-Lane,Alamota Twp,U.S. House,1,D,James Sherow,8,6,2,0
-Lane,Cheyenne Twp,U.S. House,1,D,James Sherow,20,18,2,0
-Lane,Dighton City 1,U.S. House,1,D,James Sherow,44,31,13,0
-Lane,Dighton City 2,U.S. House,1,D,James Sherow,56,41,15,0
-Lane,Dighton City 3,U.S. House,1,D,James Sherow,15,8,5,2
-Lane,Dighton Twp 1,U.S. House,1,D,James Sherow,11,8,1,2
-Lane,Dighton Twp 2,U.S. House,1,D,James Sherow,8,4,4,0
-Lane,Dighton Twp 3,U.S. House,1,D,James Sherow,4,3,1,0
-Lane,White Rock Twp,U.S. House,1,D,James Sherow,3,2,1,0
-Lane,Wilson Twp,U.S. House,1,D,James Sherow,4,4,0,0
-Lane,Alamota Twp,U.S. House,1,R,Tim Huelskamp,28,20,7,1
-Lane,Cheyenne Twp,U.S. House,1,R,Tim Huelskamp,94,79,9,6
-Lane,Dighton City 1,U.S. House,1,R,Tim Huelskamp,126,85,32,9
-Lane,Dighton City 2,U.S. House,1,R,Tim Huelskamp,154,124,26,4
-Lane,Dighton City 3,U.S. House,1,R,Tim Huelskamp,51,44,5,2
-Lane,Dighton Twp 1,U.S. House,1,R,Tim Huelskamp,31,25,5,1
-Lane,Dighton Twp 2,U.S. House,1,R,Tim Huelskamp,45,34,11,0
-Lane,Dighton Twp 3,U.S. House,1,R,Tim Huelskamp,18,12,6,0
-Lane,White Rock Twp,U.S. House,1,R,Tim Huelskamp,9,8,1,0
-Lane,Wilson Twp,U.S. House,1,R,Tim Huelskamp,29,23,6,0
-Lane,Alamota Twp,Governor,,L,Keen Umbehr,1,0,1,0
-Lane,Cheyenne Twp,Governor,,L,Keen Umbehr,5,5,0,0
-Lane,Dighton City 1,Governor,,L,Keen Umbehr,9,6,2,1
-Lane,Dighton City 2,Governor,,L,Keen Umbehr,7,5,2,0
-Lane,Dighton City 3,Governor,,L,Keen Umbehr,5,5,0,0
-Lane,Dighton Twp 1,Governor,,L,Keen Umbehr,1,0,0,1
-Lane,Dighton Twp 2,Governor,,L,Keen Umbehr,2,1,1,0
-Lane,Dighton Twp 3,Governor,,L,Keen Umbehr,0,0,0,0
-Lane,White Rock Twp,Governor,,L,Keen Umbehr,1,1,0,0
-Lane,Wilson Twp,Governor,,L,Keen Umbehr,2,2,0,0
-Lane,Alamota Twp,Governor,,D,Paul Davis,8,6,2,0
-Lane,Cheyenne Twp,Governor,,D,Paul Davis,26,22,3,1
-Lane,Dighton City 1,Governor,,D,Paul Davis,58,41,15,2
-Lane,Dighton City 2,Governor,,D,Paul Davis,68,51,16,1
-Lane,Dighton City 3,Governor,,D,Paul Davis,15,9,4,2
-Lane,Dighton Twp 1,Governor,,D,Paul Davis,10,8,0,2
-Lane,Dighton Twp 2,Governor,,D,Paul Davis,15,8,7,0
-Lane,Dighton Twp 3,Governor,,D,Paul Davis,9,6,3,0
-Lane,White Rock Twp,Governor,,D,Paul Davis,6,4,2,0
-Lane,Wilson Twp,Governor,,D,Paul Davis,5,5,0,0
-Lane,Alamota Twp,Governor,,R,Sam Brownback,28,21,6,1
-Lane,Cheyenne Twp,Governor,,R,Sam Brownback,84,71,8,5
-Lane,Dighton City 1,Governor,,R,Sam Brownback,103,70,27,6
-Lane,Dighton City 2,Governor,,R,Sam Brownback,136,109,24,3
-Lane,Dighton City 3,Governor,,R,Sam Brownback,42,37,4,1
-Lane,Dighton Twp 1,Governor,,R,Sam Brownback,31,26,5,0
-Lane,Dighton Twp 2,Governor,,R,Sam Brownback,39,31,8,0
-Lane,Dighton Twp 3,Governor,,R,Sam Brownback,13,9,4,0
-Lane,White Rock Twp,Governor,,R,Sam Brownback,5,5,0,0
-Lane,Wilson Twp,Governor,,R,Sam Brownback,28,22,6,0
-Lane,Alamota Twp,Insurance Commissioner,,D,Dennis Anderson,8,6,2,0
-Lane,Cheyenne Twp,Insurance Commissioner,,D,Dennis Anderson,11,9,2,0
-Lane,Dighton City 1,Insurance Commissioner,,D,Dennis Anderson,33,24,9,0
-Lane,Dighton City 2,Insurance Commissioner,,D,Dennis Anderson,34,24,10,0
-Lane,Dighton City 3,Insurance Commissioner,,D,Dennis Anderson,6,3,1,2
-Lane,Dighton Twp 1,Insurance Commissioner,,D,Dennis Anderson,10,5,3,2
-Lane,Dighton Twp 2,Insurance Commissioner,,D,Dennis Anderson,6,2,4,0
-Lane,Dighton Twp 3,Insurance Commissioner,,D,Dennis Anderson,4,3,1,0
-Lane,White Rock Twp,Insurance Commissioner,,D,Dennis Anderson,3,2,1,0
-Lane,Wilson Twp,Insurance Commissioner,,D,Dennis Anderson,2,2,0,0
-Lane,Alamota Twp,Insurance Commissioner,,R,Ken Selzer,25,20,4,1
-Lane,Cheyenne Twp,Insurance Commissioner,,R,Ken Selzer,98,83,9,6
-Lane,Dighton City 1,Insurance Commissioner,,R,Ken Selzer,128,86,34,8
-Lane,Dighton City 2,Insurance Commissioner,,R,Ken Selzer,160,127,29,4
-Lane,Dighton City 3,Insurance Commissioner,,R,Ken Selzer,57,48,7,2
-Lane,Dighton Twp 1,Insurance Commissioner,,R,Ken Selzer,30,27,2,1
-Lane,Dighton Twp 2,Insurance Commissioner,,R,Ken Selzer,48,37,11,0
-Lane,Dighton Twp 3,Insurance Commissioner,,R,Ken Selzer,18,12,6,0
-Lane,White Rock Twp,Insurance Commissioner,,R,Ken Selzer,8,8,0,0
-Lane,Wilson Twp,Insurance Commissioner,,R,Ken Selzer,30,24,6,0
-Lane,Alamota Twp,Secretary of State,,D,Jean Schodorf,6,4,2,0
-Lane,Cheyenne Twp,Secretary of State,,D,Jean Schodorf,21,18,3,0
-Lane,Dighton City 1,Secretary of State,,D,Jean Schodorf,46,32,14,0
-Lane,Dighton City 2,Secretary of State,,D,Jean Schodorf,44,31,12,1
-Lane,Dighton City 3,Secretary of State,,D,Jean Schodorf,12,6,4,2
-Lane,Dighton Twp 1,Secretary of State,,D,Jean Schodorf,13,7,3,3
-Lane,Dighton Twp 2,Secretary of State,,D,Jean Schodorf,11,5,6,0
-Lane,Dighton Twp 3,Secretary of State,,D,Jean Schodorf,6,5,1,0
-Lane,White Rock Twp,Secretary of State,,D,Jean Schodorf,5,4,1,0
-Lane,Wilson Twp,Secretary of State,,D,Jean Schodorf,6,6,0,0
-Lane,Alamota Twp,Secretary of State,,R,Kris Kobach,29,22,6,1
-Lane,Cheyenne Twp,Secretary of State,,R,Kris Kobach,90,76,8,6
-Lane,Dighton City 1,Secretary of State,,R,Kris Kobach,125,85,31,9
-Lane,Dighton City 2,Secretary of State,,R,Kris Kobach,164,132,29,3
-Lane,Dighton City 3,Secretary of State,,R,Kris Kobach,54,46,6,2
-Lane,Dighton Twp 1,Secretary of State,,R,Kris Kobach,28,25,3,0
-Lane,Dighton Twp 2,Secretary of State,,R,Kris Kobach,44,34,10,0
-Lane,Dighton Twp 3,Secretary of State,,R,Kris Kobach,16,10,6,0
-Lane,White Rock Twp,Secretary of State,,R,Kris Kobach,7,6,1,0
-Lane,Wilson Twp,Secretary of State,,R,Kris Kobach,28,22,6,0
-Lane,Alamota Twp,State House,118,R,Don Hineman,25,19,5,1
-Lane,Cheyenne Twp,State House,118,R,Don Hineman,101,86,9,6
-Lane,Dighton City 1,State House,118,R,Don Hineman,156,105,42,9
-Lane,Dighton City 2,State House,118,R,Don Hineman,198,154,40,4
-Lane,Dighton City 3,State House,118,R,Don Hineman,61,47,10,4
-Lane,Dighton Twp 1,State House,118,R,Don Hineman,40,31,6,3
-Lane,Dighton Twp 2,State House,118,R,Don Hineman,55,40,15,0
-Lane,Dighton Twp 3,State House,118,R,Don Hineman,19,12,7,0
-Lane,White Rock Twp,State House,118,R,Don Hineman,10,9,1,0
-Lane,Wilson Twp,State House,118,R,Don Hineman,31,25,6,0
-Lane,Alamota Twp,State Treasurer,,D,Carmen Alldritt,6,4,2,0
-Lane,Cheyenne Twp,State Treasurer,,D,Carmen Alldritt,8,7,1,0
-Lane,Dighton City 1,State Treasurer,,D,Carmen Alldritt,26,17,9,0
-Lane,Dighton City 2,State Treasurer,,D,Carmen Alldritt,29,16,12,1
-Lane,Dighton City 3,State Treasurer,,D,Carmen Alldritt,5,2,1,2
-Lane,Dighton Twp 1,State Treasurer,,D,Carmen Alldritt,9,5,2,2
-Lane,Dighton Twp 2,State Treasurer,,D,Carmen Alldritt,5,1,4,0
-Lane,Dighton Twp 3,State Treasurer,,D,Carmen Alldritt,3,2,1,0
-Lane,White Rock Twp,State Treasurer,,D,Carmen Alldritt,1,1,0,0
-Lane,Wilson Twp,State Treasurer,,D,Carmen Alldritt,2,2,0,0
-Lane,Alamota Twp,State Treasurer,,R,Ron Estes,27,20,6,1
-Lane,Cheyenne Twp,State Treasurer,,R,Ron Estes,102,87,9,6
-Lane,Dighton City 1,State Treasurer,,R,Ron Estes,139,97,34,8
-Lane,Dighton City 2,State Treasurer,,R,Ron Estes,173,142,28,3
-Lane,Dighton City 3,State Treasurer,,R,Ron Estes,59,49,8,2
-Lane,Dighton Twp 1,State Treasurer,,R,Ron Estes,31,27,3,1
-Lane,Dighton Twp 2,State Treasurer,,R,Ron Estes,50,38,12,0
-Lane,Dighton Twp 3,State Treasurer,,R,Ron Estes,19,13,6,0
-Lane,White Rock Twp,State Treasurer,,R,Ron Estes,11,9,2,0
-Lane,Wilson Twp,State Treasurer,,R,Ron Estes,31,25,6,0
-Lane,Alamota Twp,U.S. Senate,,I,Greg Orman,7,6,1,0
-Lane,Cheyenne Twp,U.S. Senate,,I,Greg Orman,23,18,3,2
-Lane,Dighton City 1,U.S. Senate,,I,Greg Orman,47,32,14,1
-Lane,Dighton City 2,U.S. Senate,,I,Greg Orman,43,32,10,1
-Lane,Dighton City 3,U.S. Senate,,I,Greg Orman,12,8,2,2
-Lane,Dighton Twp 1,U.S. Senate,,I,Greg Orman,8,5,2,1
-Lane,Dighton Twp 2,U.S. Senate,,I,Greg Orman,8,2,6,0
-Lane,Dighton Twp 3,U.S. Senate,,I,Greg Orman,4,3,1,0
-Lane,White Rock Twp,U.S. Senate,,I,Greg Orman,3,2,1,0
-Lane,Wilson Twp,U.S. Senate,,I,Greg Orman,4,4,0,0
-Lane,Alamota Twp,U.S. Senate,,R,Pat Roberts,27,19,7,1
-Lane,Cheyenne Twp,U.S. Senate,,R,Pat Roberts,89,78,8,3
-Lane,Dighton City 1,U.S. Senate,,R,Pat Roberts,120,84,29,7
-Lane,Dighton City 2,U.S. Senate,,R,Pat Roberts,158,127,28,3
-Lane,Dighton City 3,U.S. Senate,,R,Pat Roberts,50,40,8,2
-Lane,Dighton Twp 1,U.S. Senate,,R,Pat Roberts,32,28,3,1
-Lane,Dighton Twp 2,U.S. Senate,,R,Pat Roberts,46,36,10,0
-Lane,Dighton Twp 3,U.S. Senate,,R,Pat Roberts,18,12,6,0
-Lane,White Rock Twp,U.S. Senate,,R,Pat Roberts,9,8,1,0
-Lane,Wilson Twp,U.S. Senate,,R,Pat Roberts,31,25,6,0
-Lane,Alamota Twp,U.S. Senate,,L,Randall Batson,1,0,1,0
-Lane,Cheyenne Twp,U.S. Senate,,L,Randall Batson,3,2,0,1
-Lane,Dighton City 1,U.S. Senate,,L,Randall Batson,5,4,1,0
-Lane,Dighton City 2,U.S. Senate,,L,Randall Batson,9,5,4,0
-Lane,Dighton City 3,U.S. Senate,,L,Randall Batson,3,3,0,0
-Lane,Dighton Twp 1,U.S. Senate,,L,Randall Batson,2,0,1,1
-Lane,Dighton Twp 2,U.S. Senate,,L,Randall Batson,1,1,0,0
-Lane,Dighton Twp 3,U.S. Senate,,L,Randall Batson,0,0,0,0
-Lane,White Rock Twp,U.S. Senate,,L,Randall Batson,0,0,0,0
-Lane,Wilson Twp,U.S. Senate,,L,Randall Batson,1,1,0,0
+county,precinct,office,district,party,candidate,votes,vtd
+LANE,Alamota Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000010
+LANE,Alamota Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+LANE,Alamota Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000010
+LANE,Dighton Township 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000020
+LANE,Dighton Township 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+LANE,Dighton Township 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000020
+LANE,Dighton Township 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000030
+LANE,Dighton Township 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+LANE,Dighton Township 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000030
+LANE,Cheyenne Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000040
+LANE,Cheyenne Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000040
+LANE,Cheyenne Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",84,000040
+LANE,Dighton Township 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000050
+LANE,Dighton Township 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+LANE,Dighton Township 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000050
+LANE,Dighton City Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",58,000060
+LANE,Dighton City Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000060
+LANE,Dighton City Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000060
+LANE,Dighton City Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",68,000070
+LANE,Dighton City Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000070
+LANE,Dighton City Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,000070
+LANE,Dighton City Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000080
+LANE,Dighton City Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000080
+LANE,Dighton City Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000080
+LANE,White Rock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000100
+LANE,White Rock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+LANE,White Rock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,000100
+LANE,Wilson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000110
+LANE,Wilson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000110
+LANE,Wilson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000110
+LANE,Alamota Township,Kansas House of Representatives,118,Republican,"Hineman, Don",25,000010
+LANE,Dighton Township 2,Kansas House of Representatives,118,Republican,"Hineman, Don",55,000020
+LANE,Dighton Township 3,Kansas House of Representatives,118,Republican,"Hineman, Don",19,000030
+LANE,Cheyenne Township,Kansas House of Representatives,118,Republican,"Hineman, Don",101,000040
+LANE,Dighton Township 1,Kansas House of Representatives,118,Republican,"Hineman, Don",40,000050
+LANE,Dighton City Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",156,000060
+LANE,Dighton City Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",198,000070
+LANE,Dighton City Precinct 3,Kansas House of Representatives,118,Republican,"Hineman, Don",61,000080
+LANE,White Rock Township,Kansas House of Representatives,118,Republican,"Hineman, Don",10,000100
+LANE,Wilson Township,Kansas House of Representatives,118,Republican,"Hineman, Don",31,000110
+LANE,Alamota Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000010
+LANE,Alamota Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000010
+LANE,Dighton Township 2,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000020
+LANE,Dighton Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000020
+LANE,Dighton Township 3,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000030
+LANE,Dighton Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000030
+LANE,Cheyenne Township,United States House of Representatives,1,Democratic,"Sherow, James E.",20,000040
+LANE,Cheyenne Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000040
+LANE,Dighton Township 1,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000050
+LANE,Dighton Township 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000050
+LANE,Dighton City Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",44,000060
+LANE,Dighton City Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",126,000060
+LANE,Dighton City Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",56,000070
+LANE,Dighton City Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",154,000070
+LANE,Dighton City Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000080
+LANE,Dighton City Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000080
+LANE,White Rock Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000100
+LANE,White Rock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000100
+LANE,Wilson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000110
+LANE,Wilson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000110
+LANE,Alamota Township,Attorney General,,Democratic,"Kotich, A.J.",7,000010
+LANE,Alamota Township,Attorney General,,Republican,"Schmidt, Derek",28,000010
+LANE,Dighton Township 2,Attorney General,,Democratic,"Kotich, A.J.",4,000020
+LANE,Dighton Township 2,Attorney General,,Republican,"Schmidt, Derek",50,000020
+LANE,Dighton Township 3,Attorney General,,Democratic,"Kotich, A.J.",3,000030
+LANE,Dighton Township 3,Attorney General,,Republican,"Schmidt, Derek",19,000030
+LANE,Cheyenne Township,Attorney General,,Democratic,"Kotich, A.J.",14,000040
+LANE,Cheyenne Township,Attorney General,,Republican,"Schmidt, Derek",94,000040
+LANE,Dighton Township 1,Attorney General,,Democratic,"Kotich, A.J.",9,000050
+LANE,Dighton Township 1,Attorney General,,Republican,"Schmidt, Derek",31,000050
+LANE,Dighton City Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",32,000060
+LANE,Dighton City Precinct 1,Attorney General,,Republican,"Schmidt, Derek",133,000060
+LANE,Dighton City Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",31,000070
+LANE,Dighton City Precinct 2,Attorney General,,Republican,"Schmidt, Derek",174,000070
+LANE,Dighton City Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",10,000080
+LANE,Dighton City Precinct 3,Attorney General,,Republican,"Schmidt, Derek",53,000080
+LANE,White Rock Township,Attorney General,,Democratic,"Kotich, A.J.",1,000100
+LANE,White Rock Township,Attorney General,,Republican,"Schmidt, Derek",11,000100
+LANE,Wilson Township,Attorney General,,Democratic,"Kotich, A.J.",3,000110
+LANE,Wilson Township,Attorney General,,Republican,"Schmidt, Derek",31,000110
+LANE,Alamota Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000010
+LANE,Alamota Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000010
+LANE,Dighton Township 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000020
+LANE,Dighton Township 2,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000020
+LANE,Dighton Township 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000030
+LANE,Dighton Township 3,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000030
+LANE,Cheyenne Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000040
+LANE,Cheyenne Township,Commissioner of Insurance,,Republican,"Selzer, Ken",98,000040
+LANE,Dighton Township 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000050
+LANE,Dighton Township 1,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000050
+LANE,Dighton City Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000060
+LANE,Dighton City Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",128,000060
+LANE,Dighton City Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000070
+LANE,Dighton City Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",160,000070
+LANE,Dighton City Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000080
+LANE,Dighton City Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000080
+LANE,White Rock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000100
+LANE,White Rock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000100
+LANE,Wilson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000110
+LANE,Wilson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000110
+LANE,Alamota Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000010
+LANE,Alamota Township,Secretary of State,,Republican,"Kobach, Kris",29,000010
+LANE,Dighton Township 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000020
+LANE,Dighton Township 2,Secretary of State,,Republican,"Kobach, Kris",44,000020
+LANE,Dighton Township 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000030
+LANE,Dighton Township 3,Secretary of State,,Republican,"Kobach, Kris",16,000030
+LANE,Cheyenne Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000040
+LANE,Cheyenne Township,Secretary of State,,Republican,"Kobach, Kris",90,000040
+LANE,Dighton Township 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000050
+LANE,Dighton Township 1,Secretary of State,,Republican,"Kobach, Kris",28,000050
+LANE,Dighton City Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000060
+LANE,Dighton City Precinct 1,Secretary of State,,Republican,"Kobach, Kris",125,000060
+LANE,Dighton City Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000070
+LANE,Dighton City Precinct 2,Secretary of State,,Republican,"Kobach, Kris",164,000070
+LANE,Dighton City Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000080
+LANE,Dighton City Precinct 3,Secretary of State,,Republican,"Kobach, Kris",54,000080
+LANE,White Rock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000100
+LANE,White Rock Township,Secretary of State,,Republican,"Kobach, Kris",7,000100
+LANE,Wilson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000110
+LANE,Wilson Township,Secretary of State,,Republican,"Kobach, Kris",28,000110
+LANE,Alamota Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000010
+LANE,Alamota Township,State Treasurer,,Republican,"Estes, Ron",27,000010
+LANE,Dighton Township 2,State Treasurer,,Democratic,"Alldritt, Carmen",5,000020
+LANE,Dighton Township 2,State Treasurer,,Republican,"Estes, Ron",50,000020
+LANE,Dighton Township 3,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+LANE,Dighton Township 3,State Treasurer,,Republican,"Estes, Ron",19,000030
+LANE,Cheyenne Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000040
+LANE,Cheyenne Township,State Treasurer,,Republican,"Estes, Ron",102,000040
+LANE,Dighton Township 1,State Treasurer,,Democratic,"Alldritt, Carmen",9,000050
+LANE,Dighton Township 1,State Treasurer,,Republican,"Estes, Ron",31,000050
+LANE,Dighton City Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",26,000060
+LANE,Dighton City Precinct 1,State Treasurer,,Republican,"Estes, Ron",139,000060
+LANE,Dighton City Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",29,000070
+LANE,Dighton City Precinct 2,State Treasurer,,Republican,"Estes, Ron",173,000070
+LANE,Dighton City Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",5,000080
+LANE,Dighton City Precinct 3,State Treasurer,,Republican,"Estes, Ron",59,000080
+LANE,White Rock Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000100
+LANE,White Rock Township,State Treasurer,,Republican,"Estes, Ron",11,000100
+LANE,Wilson Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000110
+LANE,Wilson Township,State Treasurer,,Republican,"Estes, Ron",31,000110
+LANE,Alamota Township,United States Senate,,independent,"Orman, Greg",7,000010
+LANE,Alamota Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+LANE,Alamota Township,United States Senate,,Republican,"Roberts, Pat",27,000010
+LANE,Dighton Township 2,United States Senate,,independent,"Orman, Greg",8,000020
+LANE,Dighton Township 2,United States Senate,,Libertarian,"Batson, Randall",1,000020
+LANE,Dighton Township 2,United States Senate,,Republican,"Roberts, Pat",46,000020
+LANE,Dighton Township 3,United States Senate,,independent,"Orman, Greg",4,000030
+LANE,Dighton Township 3,United States Senate,,Libertarian,"Batson, Randall",0,000030
+LANE,Dighton Township 3,United States Senate,,Republican,"Roberts, Pat",18,000030
+LANE,Cheyenne Township,United States Senate,,independent,"Orman, Greg",23,000040
+LANE,Cheyenne Township,United States Senate,,Libertarian,"Batson, Randall",3,000040
+LANE,Cheyenne Township,United States Senate,,Republican,"Roberts, Pat",89,000040
+LANE,Dighton Township 1,United States Senate,,independent,"Orman, Greg",8,000050
+LANE,Dighton Township 1,United States Senate,,Libertarian,"Batson, Randall",2,000050
+LANE,Dighton Township 1,United States Senate,,Republican,"Roberts, Pat",32,000050
+LANE,Dighton City Precinct 1,United States Senate,,independent,"Orman, Greg",47,000060
+LANE,Dighton City Precinct 1,United States Senate,,Libertarian,"Batson, Randall",5,000060
+LANE,Dighton City Precinct 1,United States Senate,,Republican,"Roberts, Pat",120,000060
+LANE,Dighton City Precinct 2,United States Senate,,independent,"Orman, Greg",43,000070
+LANE,Dighton City Precinct 2,United States Senate,,Libertarian,"Batson, Randall",9,000070
+LANE,Dighton City Precinct 2,United States Senate,,Republican,"Roberts, Pat",158,000070
+LANE,Dighton City Precinct 3,United States Senate,,independent,"Orman, Greg",12,000080
+LANE,Dighton City Precinct 3,United States Senate,,Libertarian,"Batson, Randall",3,000080
+LANE,Dighton City Precinct 3,United States Senate,,Republican,"Roberts, Pat",50,000080
+LANE,White Rock Township,United States Senate,,independent,"Orman, Greg",3,000100
+LANE,White Rock Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+LANE,White Rock Township,United States Senate,,Republican,"Roberts, Pat",9,000100
+LANE,Wilson Township,United States Senate,,independent,"Orman, Greg",4,000110
+LANE,Wilson Township,United States Senate,,Libertarian,"Batson, Randall",1,000110
+LANE,Wilson Township,United States Senate,,Republican,"Roberts, Pat",31,000110

--- a/2014/20141104__ks__general__leavenworth__precinct.csv
+++ b/2014/20141104__ks__general__leavenworth__precinct.csv
@@ -1,913 +1,963 @@
-county,precinct,office,district,party,candidate,votes
-Leavenworth,W1P1,,,,Registration,767
-Leavenworth,W2P1,,,,Registration,560
-Leavenworth,W2P2,,,,Registration,567
-Leavenworth,W2P3,,,,Registration,881
-Leavenworth,W3P1,,,,Registration,986
-Leavenworth,W4P1 ,,,,Registration,648
-Leavenworth,W5P1,,,,Registration,758
-Leavenworth,W5P2,,,,Registration,698
-Leavenworth,W5P3,,,,Registration,1148
-Leavenworth,W5P4,,,,Registration,680
-Leavenworth,W6P1,,,,Registration,905
-Leavenworth,W6P2,,,,Registration,766
-Leavenworth,W6P3,,,,Registration,743
-Leavenworth,W6P4,,,,Registration,1338
-Leavenworth,W6P5,,,,Registration,1186
-Leavenworth,W7P1,,,,Registration,527
-Leavenworth,W7P2,,,,Registration,2074
-Leavenworth,W7P3,,,,Registration,2336
-Leavenworth,W1P1,,,,Ballots,193
-Leavenworth,W2P1,,,,Ballots,159
-Leavenworth,W2P2,,,,Ballots,215
-Leavenworth,W2P3,,,,Ballots,285
-Leavenworth,W3P1,,,,Ballots,316
-Leavenworth,W4P1 ,,,,Ballots,148
-Leavenworth,W5P1,,,,Ballots,219
-Leavenworth,W5P2,,,,Ballots,225
-Leavenworth,W5P3,,,,Ballots,441
-Leavenworth,W5P4,,,,Ballots,286
-Leavenworth,W6P1,,,,Ballots,363
-Leavenworth,W6P2,,,,Ballots,252
-Leavenworth,W6P3,,,,Ballots,280
-Leavenworth,W6P4,,,,Ballots,525
-Leavenworth,W6P5,,,,Ballots,581
-Leavenworth,W7P1,,,,Ballots,116
-Leavenworth,W7P2,,,,Ballots,937
-Leavenworth,W7P3,,,,Ballots,1119
-Leavenworth,W1P1,U.S. Senate,,R,Pat Roberts,64
-Leavenworth,W2P1,U.S. Senate,,R,Pat Roberts,76
-Leavenworth,W2P2,U.S. Senate,,R,Pat Roberts,92
-Leavenworth,W2P3,U.S. Senate,,R,Pat Roberts,126
-Leavenworth,W3P1,U.S. Senate,,R,Pat Roberts,121
-Leavenworth,W4P1 ,U.S. Senate,,R,Pat Roberts,59
-Leavenworth,W5P1,U.S. Senate,,R,Pat Roberts,110
-Leavenworth,W5P2,U.S. Senate,,R,Pat Roberts,98
-Leavenworth,W5P3,U.S. Senate,,R,Pat Roberts,203
-Leavenworth,W5P4,U.S. Senate,,R,Pat Roberts,155
-Leavenworth,W6P1,U.S. Senate,,R,Pat Roberts,157
-Leavenworth,W6P2,U.S. Senate,,R,Pat Roberts,92
-Leavenworth,W6P3,U.S. Senate,,R,Pat Roberts,120
-Leavenworth,W6P4,U.S. Senate,,R,Pat Roberts,271
-Leavenworth,W6P5,U.S. Senate,,R,Pat Roberts,306
-Leavenworth,W7P1,U.S. Senate,,R,Pat Roberts,26
-Leavenworth,W7P2,U.S. Senate,,R,Pat Roberts,475
-Leavenworth,W7P3,U.S. Senate,,R,Pat Roberts,580
-Leavenworth,W1P1,U.S. Senate,,I,Greg Orman,114
-Leavenworth,W2P1,U.S. Senate,,I,Greg Orman,71
-Leavenworth,W2P2,U.S. Senate,,I,Greg Orman,107
-Leavenworth,W2P3,U.S. Senate,,I,Greg Orman,133
-Leavenworth,W3P1,U.S. Senate,,I,Greg Orman,163
-Leavenworth,W4P1 ,U.S. Senate,,I,Greg Orman,74
-Leavenworth,W5P1,U.S. Senate,,I,Greg Orman,95
-Leavenworth,W5P2,U.S. Senate,,I,Greg Orman,97
-Leavenworth,W5P3,U.S. Senate,,I,Greg Orman,196
-Leavenworth,W5P4,U.S. Senate,,I,Greg Orman,105
-Leavenworth,W6P1,U.S. Senate,,I,Greg Orman,180
-Leavenworth,W6P2,U.S. Senate,,I,Greg Orman,146
-Leavenworth,W6P3,U.S. Senate,,I,Greg Orman,136
-Leavenworth,W6P4,U.S. Senate,,I,Greg Orman,224
-Leavenworth,W6P5,U.S. Senate,,I,Greg Orman,250
-Leavenworth,W7P1,U.S. Senate,,I,Greg Orman,78
-Leavenworth,W7P2,U.S. Senate,,I,Greg Orman,401
-Leavenworth,W7P3,U.S. Senate,,I,Greg Orman,490
-Leavenworth,W1P1,U.S. Senate,,L,Randall Batson,9
-Leavenworth,W2P1,U.S. Senate,,L,Randall Batson,10
-Leavenworth,W2P2,U.S. Senate,,L,Randall Batson,14
-Leavenworth,W2P3,U.S. Senate,,L,Randall Batson,19
-Leavenworth,W3P1,U.S. Senate,,L,Randall Batson,27
-Leavenworth,W4P1 ,U.S. Senate,,L,Randall Batson,12
-Leavenworth,W5P1,U.S. Senate,,L,Randall Batson,11
-Leavenworth,W5P2,U.S. Senate,,L,Randall Batson,25
-Leavenworth,W5P3,U.S. Senate,,L,Randall Batson,38
-Leavenworth,W5P4,U.S. Senate,,L,Randall Batson,22
-Leavenworth,W6P1,U.S. Senate,,L,Randall Batson,15
-Leavenworth,W6P2,U.S. Senate,,L,Randall Batson,11
-Leavenworth,W6P3,U.S. Senate,,L,Randall Batson,17
-Leavenworth,W6P4,U.S. Senate,,L,Randall Batson,25
-Leavenworth,W6P5,U.S. Senate,,L,Randall Batson,19
-Leavenworth,W7P1,U.S. Senate,,L,Randall Batson,6
-Leavenworth,W7P2,U.S. Senate,,L,Randall Batson,36
-Leavenworth,W7P3,U.S. Senate,,L,Randall Batson,37
-Leavenworth,W1P1,U.S. House,2,R,Lynn Jenkins,85
-Leavenworth,W2P1,U.S. House,2,R,Lynn Jenkins,99
-Leavenworth,W2P2,U.S. House,2,R,Lynn Jenkins,131
-Leavenworth,W2P3,U.S. House,2,R,Lynn Jenkins,158
-Leavenworth,W3P1,U.S. House,2,R,Lynn Jenkins,160
-Leavenworth,W4P1 ,U.S. House,2,R,Lynn Jenkins,80
-Leavenworth,W5P1,U.S. House,2,R,Lynn Jenkins,128
-Leavenworth,W5P2,U.S. House,2,R,Lynn Jenkins,131
-Leavenworth,W5P3,U.S. House,2,R,Lynn Jenkins,277
-Leavenworth,W5P4,U.S. House,2,R,Lynn Jenkins,196
-Leavenworth,W6P1,U.S. House,2,R,Lynn Jenkins,201
-Leavenworth,W6P2,U.S. House,2,R,Lynn Jenkins,117
-Leavenworth,W6P3,U.S. House,2,R,Lynn Jenkins,161
-Leavenworth,W6P4,U.S. House,2,R,Lynn Jenkins,343
-Leavenworth,W6P5,U.S. House,2,R,Lynn Jenkins,391
-Leavenworth,W7P1,U.S. House,2,R,Lynn Jenkins,35
-Leavenworth,W7P2,U.S. House,2,R,Lynn Jenkins,600
-Leavenworth,W7P3,U.S. House,2,R,Lynn Jenkins,714
-Leavenworth,W1P1,U.S. House,2,D,Margie Wakefield,85
-Leavenworth,W2P1,U.S. House,2,D,Margie Wakefield,51
-Leavenworth,W2P2,U.S. House,2,D,Margie Wakefield,68
-Leavenworth,W2P3,U.S. House,2,D,Margie Wakefield,110
-Leavenworth,W3P1,U.S. House,2,D,Margie Wakefield,131
-Leavenworth,W4P1 ,U.S. House,2,D,Margie Wakefield,60
-Leavenworth,W5P1,U.S. House,2,D,Margie Wakefield,75
-Leavenworth,W5P2,U.S. House,2,D,Margie Wakefield,72
-Leavenworth,W5P3,U.S. House,2,D,Margie Wakefield,138
-Leavenworth,W5P4,U.S. House,2,D,Margie Wakefield,72
-Leavenworth,W6P1,U.S. House,2,D,Margie Wakefield,142
-Leavenworth,W6P2,U.S. House,2,D,Margie Wakefield,106
-Leavenworth,W6P3,U.S. House,2,D,Margie Wakefield,95
-Leavenworth,W6P4,U.S. House,2,D,Margie Wakefield,148
-Leavenworth,W6P5,U.S. House,2,D,Margie Wakefield,167
-Leavenworth,W7P1,U.S. House,2,D,Margie Wakefield,70
-Leavenworth,W7P2,U.S. House,2,D,Margie Wakefield,284
-Leavenworth,W7P3,U.S. House,2,D,Margie Wakefield,356
-Leavenworth,W1P1,U.S. House,2,L,Chris Clemmons,18
-Leavenworth,W2P1,U.S. House,2,L,Chris Clemmons,7
-Leavenworth,W2P2,U.S. House,2,L,Chris Clemmons,13
-Leavenworth,W2P3,U.S. House,2,L,Chris Clemmons,12
-Leavenworth,W3P1,U.S. House,2,L,Chris Clemmons,24
-Leavenworth,W4P1 ,U.S. House,2,L,Chris Clemmons,6
-Leavenworth,W5P1,U.S. House,2,L,Chris Clemmons,16
-Leavenworth,W5P2,U.S. House,2,L,Chris Clemmons,20
-Leavenworth,W5P3,U.S. House,2,L,Chris Clemmons,23
-Leavenworth,W5P4,U.S. House,2,L,Chris Clemmons,17
-Leavenworth,W6P1,U.S. House,2,L,Chris Clemmons,20
-Leavenworth,W6P2,U.S. House,2,L,Chris Clemmons,24
-Leavenworth,W6P3,U.S. House,2,L,Chris Clemmons,18
-Leavenworth,W6P4,U.S. House,2,L,Chris Clemmons,30
-Leavenworth,W6P5,U.S. House,2,L,Chris Clemmons,14
-Leavenworth,W7P1,U.S. House,2,L,Chris Clemmons,7
-Leavenworth,W7P2,U.S. House,2,L,Chris Clemmons,42
-Leavenworth,W7P3,U.S. House,2,L,Chris Clemmons,41
-Leavenworth,W1P1,Governor,,R,Sam Brownback,65
-Leavenworth,W2P1,Governor,,R,Sam Brownback,76
-Leavenworth,W2P2,Governor,,R,Sam Brownback,97
-Leavenworth,W2P3,Governor,,R,Sam Brownback,117
-Leavenworth,W3P1,Governor,,R,Sam Brownback,112
-Leavenworth,W4P1 ,Governor,,R,Sam Brownback,63
-Leavenworth,W5P1,Governor,,R,Sam Brownback,101
-Leavenworth,W5P2,Governor,,R,Sam Brownback,96
-Leavenworth,W5P3,Governor,,R,Sam Brownback,210
-Leavenworth,W5P4,Governor,,R,Sam Brownback,159
-Leavenworth,W6P1,Governor,,R,Sam Brownback,161
-Leavenworth,W6P2,Governor,,R,Sam Brownback,96
-Leavenworth,W6P3,Governor,,R,Sam Brownback,125
-Leavenworth,W6P4,Governor,,R,Sam Brownback,277
-Leavenworth,W6P5,Governor,,R,Sam Brownback,317
-Leavenworth,W7P1,Governor,,R,Sam Brownback,23
-Leavenworth,W7P2,Governor,,R,Sam Brownback,468
-Leavenworth,W7P3,Governor,,R,Sam Brownback,567
-Leavenworth,W1P1,Governor,,D,Paul Davis,107
-Leavenworth,W2P1,Governor,,D,Paul Davis,73
-Leavenworth,W2P2,Governor,,D,Paul Davis,107
-Leavenworth,W2P3,Governor,,D,Paul Davis,141
-Leavenworth,W3P1,Governor,,D,Paul Davis,166
-Leavenworth,W4P1 ,Governor,,D,Paul Davis,77
-Leavenworth,W5P1,Governor,,D,Paul Davis,104
-Leavenworth,W5P2,Governor,,D,Paul Davis,103
-Leavenworth,W5P3,Governor,,D,Paul Davis,198
-Leavenworth,W5P4,Governor,,D,Paul Davis,115
-Leavenworth,W6P1,Governor,,D,Paul Davis,183
-Leavenworth,W6P2,Governor,,D,Paul Davis,131
-Leavenworth,W6P3,Governor,,D,Paul Davis,134
-Leavenworth,W6P4,Governor,,D,Paul Davis,222
-Leavenworth,W6P5,Governor,,D,Paul Davis,242
-Leavenworth,W7P1,Governor,,D,Paul Davis,84
-Leavenworth,W7P2,Governor,,D,Paul Davis,409
-Leavenworth,W7P3,Governor,,D,Paul Davis,516
-Leavenworth,W1P1,Governor,,L,Keen Umbehr,19
-Leavenworth,W2P1,Governor,,L,Keen Umbehr,10
-Leavenworth,W2P2,Governor,,L,Keen Umbehr,11
-Leavenworth,W2P3,Governor,,L,Keen Umbehr,22
-Leavenworth,W3P1,Governor,,L,Keen Umbehr,35
-Leavenworth,W4P1 ,Governor,,L,Keen Umbehr,7
-Leavenworth,W5P1,Governor,,L,Keen Umbehr,12
-Leavenworth,W5P2,Governor,,L,Keen Umbehr,22
-Leavenworth,W5P3,Governor,,L,Keen Umbehr,28
-Leavenworth,W5P4,Governor,,L,Keen Umbehr,11
-Leavenworth,W6P1,Governor,,L,Keen Umbehr,16
-Leavenworth,W6P2,Governor,,L,Keen Umbehr,21
-Leavenworth,W6P3,Governor,,L,Keen Umbehr,17
-Leavenworth,W6P4,Governor,,L,Keen Umbehr,24
-Leavenworth,W6P5,Governor,,L,Keen Umbehr,21
-Leavenworth,W7P1,Governor,,L,Keen Umbehr,7
-Leavenworth,W7P2,Governor,,L,Keen Umbehr,47
-Leavenworth,W7P3,Governor,,L,Keen Umbehr,30
-Leavenworth,W1P1,Secretary of State,,R,Kris Kobach,86
-Leavenworth,W2P1,Secretary of State,,R,Kris Kobach,88
-Leavenworth,W2P2,Secretary of State,,R,Kris Kobach,127
-Leavenworth,W2P3,Secretary of State,,R,Kris Kobach,148
-Leavenworth,W3P1,Secretary of State,,R,Kris Kobach,165
-Leavenworth,W4P1 ,Secretary of State,,R,Kris Kobach,78
-Leavenworth,W5P1,Secretary of State,,R,Kris Kobach,123
-Leavenworth,W5P2,Secretary of State,,R,Kris Kobach,126
-Leavenworth,W5P3,Secretary of State,,R,Kris Kobach,266
-Leavenworth,W5P4,Secretary of State,,R,Kris Kobach,186
-Leavenworth,W6P1,Secretary of State,,R,Kris Kobach,193
-Leavenworth,W6P2,Secretary of State,,R,Kris Kobach,118
-Leavenworth,W6P3,Secretary of State,,R,Kris Kobach,144
-Leavenworth,W6P4,Secretary of State,,R,Kris Kobach,316
-Leavenworth,W6P5,Secretary of State,,R,Kris Kobach,369
-Leavenworth,W7P1,Secretary of State,,R,Kris Kobach,27
-Leavenworth,W7P2,Secretary of State,,R,Kris Kobach,546
-Leavenworth,W7P3,Secretary of State,,R,Kris Kobach,662
-Leavenworth,W1P1,Secretary of State,,D,Jean Schodorf,101
-Leavenworth,W2P1,Secretary of State,,D,Jean Schodorf,68
-Leavenworth,W2P2,Secretary of State,,D,Jean Schodorf,83
-Leavenworth,W2P3,Secretary of State,,D,Jean Schodorf,132
-Leavenworth,W3P1,Secretary of State,,D,Jean Schodorf,147
-Leavenworth,W4P1 ,Secretary of State,,D,Jean Schodorf,68
-Leavenworth,W5P1,Secretary of State,,D,Jean Schodorf,91
-Leavenworth,W5P2,Secretary of State,,D,Jean Schodorf,94
-Leavenworth,W5P3,Secretary of State,,D,Jean Schodorf,168
-Leavenworth,W5P4,Secretary of State,,D,Jean Schodorf,97
-Leavenworth,W6P1,Secretary of State,,D,Jean Schodorf,164
-Leavenworth,W6P2,Secretary of State,,D,Jean Schodorf,128
-Leavenworth,W6P3,Secretary of State,,D,Jean Schodorf,127
-Leavenworth,W6P4,Secretary of State,,D,Jean Schodorf,199
-Leavenworth,W6P5,Secretary of State,,D,Jean Schodorf,203
-Leavenworth,W7P1,Secretary of State,,D,Jean Schodorf,85
-Leavenworth,W7P2,Secretary of State,,D,Jean Schodorf,367
-Leavenworth,W7P3,Secretary of State,,D,Jean Schodorf,434
-Leavenworth,W1P1,Attorney General,,R,Derek Schmidt,93
-Leavenworth,W2P1,Attorney General,,R,Derek Schmidt,89
-Leavenworth,W2P2,Attorney General,,R,Derek Schmidt,129
-Leavenworth,W2P3,Attorney General,,R,Derek Schmidt,147
-Leavenworth,W3P1,Attorney General,,R,Derek Schmidt,163
-Leavenworth,W4P1 ,Attorney General,,R,Derek Schmidt,71
-Leavenworth,W5P1,Attorney General,,R,Derek Schmidt,130
-Leavenworth,W5P2,Attorney General,,R,Derek Schmidt,118
-Leavenworth,W5P3,Attorney General,,R,Derek Schmidt,285
-Leavenworth,W5P4,Attorney General,,R,Derek Schmidt,198
-Leavenworth,W6P1,Attorney General,,R,Derek Schmidt,200
-Leavenworth,W6P2,Attorney General,,R,Derek Schmidt,112
-Leavenworth,W6P3,Attorney General,,R,Derek Schmidt,151
-Leavenworth,W6P4,Attorney General,,R,Derek Schmidt,329
-Leavenworth,W6P5,Attorney General,,R,Derek Schmidt,370
-Leavenworth,W7P1,Attorney General,,R,Derek Schmidt,38
-Leavenworth,W7P2,Attorney General,,R,Derek Schmidt,574
-Leavenworth,W7P3,Attorney General,,R,Derek Schmidt,701
-Leavenworth,W1P1,Attorney General,,D,A J Kotich,95
-Leavenworth,W2P1,Attorney General,,D,A J Kotich,63
-Leavenworth,W2P2,Attorney General,,D,A J Kotich,77
-Leavenworth,W2P3,Attorney General,,D,A J Kotich,132
-Leavenworth,W3P1,Attorney General,,D,A J Kotich,146
-Leavenworth,W4P1 ,Attorney General,,D,A J Kotich,72
-Leavenworth,W5P1,Attorney General,,D,A J Kotich,85
-Leavenworth,W5P2,Attorney General,,D,A J Kotich,104
-Leavenworth,W5P3,Attorney General,,D,A J Kotich,145
-Leavenworth,W5P4,Attorney General,,D,A J Kotich,78
-Leavenworth,W6P1,Attorney General,,D,A J Kotich,156
-Leavenworth,W6P2,Attorney General,,D,A J Kotich,127
-Leavenworth,W6P3,Attorney General,,D,A J Kotich,119
-Leavenworth,W6P4,Attorney General,,D,A J Kotich,187
-Leavenworth,W6P5,Attorney General,,D,A J Kotich,196
-Leavenworth,W7P1,Attorney General,,D,A J Kotich,73
-Leavenworth,W7P2,Attorney General,,D,A J Kotich,326
-Leavenworth,W7P3,Attorney General,,D,A J Kotich,385
-Leavenworth,W1P1,State Treasurer,,R,Ron Estes,84
-Leavenworth,W2P1,State Treasurer,,R,Ron Estes,90
-Leavenworth,W2P2,State Treasurer,,R,Ron Estes,136
-Leavenworth,W2P3,State Treasurer,,R,Ron Estes,151
-Leavenworth,W3P1,State Treasurer,,R,Ron Estes,175
-Leavenworth,W4P1 ,State Treasurer,,R,Ron Estes,78
-Leavenworth,W5P1,State Treasurer,,R,Ron Estes,125
-Leavenworth,W5P2,State Treasurer,,R,Ron Estes,130
-Leavenworth,W5P3,State Treasurer,,R,Ron Estes,287
-Leavenworth,W5P4,State Treasurer,,R,Ron Estes,194
-Leavenworth,W6P1,State Treasurer,,R,Ron Estes,212
-Leavenworth,W6P2,State Treasurer,,R,Ron Estes,120
-Leavenworth,W6P3,State Treasurer,,R,Ron Estes,157
-Leavenworth,W6P4,State Treasurer,,R,Ron Estes,334
-Leavenworth,W6P5,State Treasurer,,R,Ron Estes,386
-Leavenworth,W7P1,State Treasurer,,R,Ron Estes,37
-Leavenworth,W7P2,State Treasurer,,R,Ron Estes,582
-Leavenworth,W7P3,State Treasurer,,R,Ron Estes,709
-Leavenworth,W1P1,State Treasurer,,D,Carmen Alldritt,105
-Leavenworth,W2P1,State Treasurer,,D,Carmen Alldritt,61
-Leavenworth,W2P2,State Treasurer,,D,Carmen Alldritt,73
-Leavenworth,W2P3,State Treasurer,,D,Carmen Alldritt,125
-Leavenworth,W3P1,State Treasurer,,D,Carmen Alldritt,134
-Leavenworth,W4P1 ,State Treasurer,,D,Carmen Alldritt,67
-Leavenworth,W5P1,State Treasurer,,D,Carmen Alldritt,87
-Leavenworth,W5P2,State Treasurer,,D,Carmen Alldritt,92
-Leavenworth,W5P3,State Treasurer,,D,Carmen Alldritt,149
-Leavenworth,W5P4,State Treasurer,,D,Carmen Alldritt,87
-Leavenworth,W6P1,State Treasurer,,D,Carmen Alldritt,145
-Leavenworth,W6P2,State Treasurer,,D,Carmen Alldritt,123
-Leavenworth,W6P3,State Treasurer,,D,Carmen Alldritt,110
-Leavenworth,W6P4,State Treasurer,,D,Carmen Alldritt,180
-Leavenworth,W6P5,State Treasurer,,D,Carmen Alldritt,179
-Leavenworth,W7P1,State Treasurer,,D,Carmen Alldritt,71
-Leavenworth,W7P2,State Treasurer,,D,Carmen Alldritt,319
-Leavenworth,W7P3,State Treasurer,,D,Carmen Alldritt,372
-Leavenworth,W1P1,Insurance Commissioner,,R,Ken Selzer,76
-Leavenworth,W2P1,Insurance Commissioner,,R,Ken Selzer,79
-Leavenworth,W2P2,Insurance Commissioner,,R,Ken Selzer,121
-Leavenworth,W2P3,Insurance Commissioner,,R,Ken Selzer,136
-Leavenworth,W3P1,Insurance Commissioner,,R,Ken Selzer,146
-Leavenworth,W4P1 ,Insurance Commissioner,,R,Ken Selzer,79
-Leavenworth,W5P1,Insurance Commissioner,,R,Ken Selzer,116
-Leavenworth,W5P2,Insurance Commissioner,,R,Ken Selzer,124
-Leavenworth,W5P3,Insurance Commissioner,,R,Ken Selzer,262
-Leavenworth,W5P4,Insurance Commissioner,,R,Ken Selzer,177
-Leavenworth,W6P1,Insurance Commissioner,,R,Ken Selzer,189
-Leavenworth,W6P2,Insurance Commissioner,,R,Ken Selzer,110
-Leavenworth,W6P3,Insurance Commissioner,,R,Ken Selzer,143
-Leavenworth,W6P4,Insurance Commissioner,,R,Ken Selzer,306
-Leavenworth,W6P5,Insurance Commissioner,,R,Ken Selzer,366
-Leavenworth,W7P1,Insurance Commissioner,,R,Ken Selzer,30
-Leavenworth,W7P2,Insurance Commissioner,,R,Ken Selzer,542
-Leavenworth,W7P3,Insurance Commissioner,,R,Ken Selzer,676
-Leavenworth,W1P1,Insurance Commissioner,,D,Dennis Anderson,112
-Leavenworth,W2P1,Insurance Commissioner,,D,Dennis Anderson,72
-Leavenworth,W2P2,Insurance Commissioner,,D,Dennis Anderson,89
-Leavenworth,W2P3,Insurance Commissioner,,D,Dennis Anderson,141
-Leavenworth,W3P1,Insurance Commissioner,,D,Dennis Anderson,158
-Leavenworth,W4P1 ,Insurance Commissioner,,D,Dennis Anderson,63
-Leavenworth,W5P1,Insurance Commissioner,,D,Dennis Anderson,92
-Leavenworth,W5P2,Insurance Commissioner,,D,Dennis Anderson,94
-Leavenworth,W5P3,Insurance Commissioner,,D,Dennis Anderson,168
-Leavenworth,W5P4,Insurance Commissioner,,D,Dennis Anderson,100
-Leavenworth,W6P1,Insurance Commissioner,,D,Dennis Anderson,163
-Leavenworth,W6P2,Insurance Commissioner,,D,Dennis Anderson,131
-Leavenworth,W6P3,Insurance Commissioner,,D,Dennis Anderson,124
-Leavenworth,W6P4,Insurance Commissioner,,D,Dennis Anderson,204
-Leavenworth,W6P5,Insurance Commissioner,,D,Dennis Anderson,197
-Leavenworth,W7P1,Insurance Commissioner,,D,Dennis Anderson,78
-Leavenworth,W7P2,Insurance Commissioner,,D,Dennis Anderson,354
-Leavenworth,W7P3,Insurance Commissioner,,D,Dennis Anderson,404
-Leavenworth,W1P1,State House,41,R,TONY BARTON,85
-Leavenworth,W2P1,State House,41,R,TONY BARTON,88
-Leavenworth,W2P2,State House,41,R,TONY BARTON,122
-Leavenworth,W2P3,State House,40,R,JOHN BRADFORD,126
-Leavenworth,W3P1,State House,41,R,TONY BARTON,156
-Leavenworth,W4P1 ,State House,41,R,TONY BARTON,71
-Leavenworth,W5P1,State House,41,R,TONY BARTON,125
-Leavenworth,W5P2,State House,41,R,TONY BARTON,124
-Leavenworth,W5P3,State House,41,R,TONY BARTON,252
-Leavenworth,W5P4,State House,41,R,TONY BARTON,174
-Leavenworth,W6P1,State House,41,R,TONY BARTON,193
-Leavenworth,W6P2,State House,41,R,TONY BARTON,114
-Leavenworth,W6P3,State House,40,R,JOHN BRADFORD,108
-Leavenworth,W6P4,State House,41,R,TONY BARTON,318
-Leavenworth,W6P5,State House,41,R,TONY BARTON,341
-Leavenworth,W7P1,State House,40,R,JOHN BRADFORD,30
-Leavenworth,W7P2,State House,40,R,JOHN BRADFORD,479
-Leavenworth,W7P3,State House,40,R,JOHN BRADFORD,588
-Leavenworth,W1P1,State House,41,D,NANCY D. BAUDER,107
-Leavenworth,W2P1,State House,41,D,NANCY D. BAUDER,69
-Leavenworth,W2P2,State House,41,D,NANCY D. BAUDER,89
-Leavenworth,W2P3,State House,40,D,LINDA JOHNSON,158
-Leavenworth,W3P1,State House,41,D,NANCY D. BAUDER,156
-Leavenworth,W4P1 ,State House,41,D,NANCY D. BAUDER,76
-Leavenworth,W5P1,State House,41,D,NANCY D. BAUDER,93
-Leavenworth,W5P2,State House,41,D,NANCY D. BAUDER,98
-Leavenworth,W5P3,State House,41,D,NANCY D. BAUDER,184
-Leavenworth,W5P4,State House,41,D,NANCY D. BAUDER,110
-Leavenworth,W6P1,State House,41,D,NANCY D. BAUDER,166
-Leavenworth,W6P2,State House,41,D,NANCY D. BAUDER,128
-Leavenworth,W6P3,State House,40,D,LINDA JOHNSON,167
-Leavenworth,W6P4,State House,41,D,NANCY D. BAUDER,204
-Leavenworth,W6P5,State House,41,D,NANCY D. BAUDER,240
-Leavenworth,W7P1,State House,40,D,LINDA JOHNSON,82
-Leavenworth,W7P2,State House,40,D,LINDA JOHNSON,444
-Leavenworth,W7P3,State House,40,D,LINDA JOHNSON,520
-Leavenworth,0019 Springdale/Alexandria,,,,Registration,601
-Leavenworth,0020 Lansing Ward 1,,,,Registration,1436
-Leavenworth,0021 Lansing Ward 2,,,,Registration,1473
-Leavenworth,0022 Lansing Ward 3,,,,Registration,1656
-Leavenworth,0023 Lansing Ward 4,,,,Registration,1600
-Leavenworth,0024 Delaware 1,,,,Registration,401
-Leavenworth,0025 Delaware 2,,,,Registration,142
-Leavenworth,0026 Delaware 3,,,,Registration,207
-Leavenworth,0027 Delaware 4,,,,Registration,3
-Leavenworth,0028 Easton/Easton,,,,Registration,777
-Leavenworth,0029 Basehor City/Fairmount,,,,Registration,3542
-Leavenworth,0030 Basehor Twp/Fairmount,,,,Registration,1393
-Leavenworth,0031 Glenwood/Fairmount,,,,Registration,1963
-Leavenworth,0032 Boling/High Prairie,,,,Registration,1510
-Leavenworth,0033 Kickapoo/Kickapoo,,,,Registration,1422
-Leavenworth,0034 Reno West 42,,,,Registration,908
-Leavenworth,0035 Reno East 38,,,,Registration,168
-Leavenworth,0036 Linwood/Sherman,,,,Registration,1982
-Leavenworth,0037 Stranger/Stranger,,,,Registration,1144
-Leavenworth,0038 Walnut/Stranger,,,,Registration,824
-Leavenworth,0039 Tonganoxie North,,,,Registration,2024
-Leavenworth,0040 Tonganoxie South,,,,Registration,1293
-Leavenworth,0041 Tonganoxie Rural,,,,Registration,1787
-Leavenworth,"0042 Ft Leavenworth, Pct 41",,,,Registration,616
-Leavenworth,"0043 Ft Leavenworth, Pct 42",,,,Registration,385
-Leavenworth,0019 Springdale/Alexandria,,,,Ballots,296
-Leavenworth,0020 Lansing Ward 1,,,,Ballots,527
-Leavenworth,0021 Lansing Ward 2,,,,Ballots,722
-Leavenworth,0022 Lansing Ward 3,,,,Ballots,707
-Leavenworth,0023 Lansing Ward 4,,,,Ballots,738
-Leavenworth,0024 Delaware 1,,,,Ballots,192
-Leavenworth,0025 Delaware 2,,,,Ballots,84
-Leavenworth,0026 Delaware 3,,,,Ballots,112
-Leavenworth,0027 Delaware 4,,,,Ballots,3
-Leavenworth,0028 Easton/Easton,,,,Ballots,371
-Leavenworth,0029 Basehor City/Fairmount,,,,Ballots,1646
-Leavenworth,0030 Basehor Twp/Fairmount,,,,Ballots,701
-Leavenworth,0031 Glenwood/Fairmount,,,,Ballots,997
-Leavenworth,0032 Boling/High Prairie,,,,Ballots,802
-Leavenworth,0033 Kickapoo/Kickapoo,,,,Ballots,725
-Leavenworth,0034 Reno West 42,,,,Ballots,501
-Leavenworth,0035 Reno East 38,,,,Ballots,101
-Leavenworth,0036 Linwood/Sherman,,,,Ballots,937
-Leavenworth,0037 Stranger/Stranger,,,,Ballots,581
-Leavenworth,0038 Walnut/Stranger,,,,Ballots,434
-Leavenworth,0039 Tonganoxie North,,,,Ballots,772
-Leavenworth,0040 Tonganoxie South,,,,Ballots,557
-Leavenworth,0041 Tonganoxie Rural,,,,Ballots,877
-Leavenworth,"0042 Ft Leavenworth, Pct 41",,,,Ballots,53
-Leavenworth,"0043 Ft Leavenworth, Pct 42",,,,Ballots,23
-Leavenworth,0019 Springdale/Alexandria,U.S. Senate,,R,Pat Roberts,187
-Leavenworth,0020 Lansing Ward 1,U.S. Senate,,R,Pat Roberts,270
-Leavenworth,0021 Lansing Ward 2,U.S. Senate,,R,Pat Roberts,428
-Leavenworth,0022 Lansing Ward 3,U.S. Senate,,R,Pat Roberts,360
-Leavenworth,0023 Lansing Ward 4,U.S. Senate,,R,Pat Roberts,382
-Leavenworth,0024 Delaware 1,U.S. Senate,,R,Pat Roberts,117
-Leavenworth,0025 Delaware 2,U.S. Senate,,R,Pat Roberts,49
-Leavenworth,0026 Delaware 3,U.S. Senate,,R,Pat Roberts,72
-Leavenworth,0027 Delaware 4,U.S. Senate,,R,Pat Roberts,2
-Leavenworth,0028 Easton/Easton,U.S. Senate,,R,Pat Roberts,204
-Leavenworth,0029 Basehor City/Fairmount,U.S. Senate,,R,Pat Roberts,842
-Leavenworth,0030 Basehor Twp/Fairmount,U.S. Senate,,R,Pat Roberts,419
-Leavenworth,0031 Glenwood/Fairmount,U.S. Senate,,R,Pat Roberts,558
-Leavenworth,0032 Boling/High Prairie,U.S. Senate,,R,Pat Roberts,476
-Leavenworth,0033 Kickapoo/Kickapoo,U.S. Senate,,R,Pat Roberts,438
-Leavenworth,0034 Reno West 42,U.S. Senate,,R,Pat Roberts,235
-Leavenworth,0035 Reno East 38,U.S. Senate,,R,Pat Roberts,47
-Leavenworth,0036 Linwood/Sherman,U.S. Senate,,R,Pat Roberts,479
-Leavenworth,0037 Stranger/Stranger,U.S. Senate,,R,Pat Roberts,330
-Leavenworth,0038 Walnut/Stranger,U.S. Senate,,R,Pat Roberts,219
-Leavenworth,0039 Tonganoxie North,U.S. Senate,,R,Pat Roberts,401
-Leavenworth,0040 Tonganoxie South,U.S. Senate,,R,Pat Roberts,259
-Leavenworth,0041 Tonganoxie Rural,U.S. Senate,,R,Pat Roberts,460
-Leavenworth,"0042 Ft Leavenworth, Pct 41",U.S. Senate,,R,Pat Roberts,27
-Leavenworth,"0043 Ft Leavenworth, Pct 42",U.S. Senate,,R,Pat Roberts,19
-Leavenworth,0019 Springdale/Alexandria,U.S. Senate,,I,Greg Orman,84
-Leavenworth,0020 Lansing Ward 1,U.S. Senate,,I,Greg Orman,215
-Leavenworth,0021 Lansing Ward 2,U.S. Senate,,I,Greg Orman,264
-Leavenworth,0022 Lansing Ward 3,U.S. Senate,,I,Greg Orman,299
-Leavenworth,0023 Lansing Ward 4,U.S. Senate,,I,Greg Orman,304
-Leavenworth,0024 Delaware 1,U.S. Senate,,I,Greg Orman,68
-Leavenworth,0025 Delaware 2,U.S. Senate,,I,Greg Orman,32
-Leavenworth,0026 Delaware 3,U.S. Senate,,I,Greg Orman,36
-Leavenworth,0027 Delaware 4,U.S. Senate,,I,Greg Orman,1
-Leavenworth,0028 Easton/Easton,U.S. Senate,,I,Greg Orman,140
-Leavenworth,0029 Basehor City/Fairmount,U.S. Senate,,I,Greg Orman,732
-Leavenworth,0030 Basehor Twp/Fairmount,U.S. Senate,,I,Greg Orman,237
-Leavenworth,0031 Glenwood/Fairmount,U.S. Senate,,I,Greg Orman,400
-Leavenworth,0032 Boling/High Prairie,U.S. Senate,,I,Greg Orman,291
-Leavenworth,0033 Kickapoo/Kickapoo,U.S. Senate,,I,Greg Orman,260
-Leavenworth,0034 Reno West 42,U.S. Senate,,I,Greg Orman,251
-Leavenworth,0035 Reno East 38,U.S. Senate,,I,Greg Orman,50
-Leavenworth,0036 Linwood/Sherman,U.S. Senate,,I,Greg Orman,413
-Leavenworth,0037 Stranger/Stranger,U.S. Senate,,I,Greg Orman,227
-Leavenworth,0038 Walnut/Stranger,U.S. Senate,,I,Greg Orman,201
-Leavenworth,0039 Tonganoxie North,U.S. Senate,,I,Greg Orman,329
-Leavenworth,0040 Tonganoxie South,U.S. Senate,,I,Greg Orman,271
-Leavenworth,0041 Tonganoxie Rural,U.S. Senate,,I,Greg Orman,370
-Leavenworth,"0042 Ft Leavenworth, Pct 41",U.S. Senate,,I,Greg Orman,22
-Leavenworth,"0043 Ft Leavenworth, Pct 42",U.S. Senate,,I,Greg Orman,4
-Leavenworth,0019 Springdale/Alexandria,U.S. Senate,,L,Randall Batson,20
-Leavenworth,0020 Lansing Ward 1,U.S. Senate,,L,Randall Batson,39
-Leavenworth,0021 Lansing Ward 2,U.S. Senate,,L,Randall Batson,25
-Leavenworth,0022 Lansing Ward 3,U.S. Senate,,L,Randall Batson,39
-Leavenworth,0023 Lansing Ward 4,U.S. Senate,,L,Randall Batson,40
-Leavenworth,0024 Delaware 1,U.S. Senate,,L,Randall Batson,7
-Leavenworth,0025 Delaware 2,U.S. Senate,,L,Randall Batson,1
-Leavenworth,0026 Delaware 3,U.S. Senate,,L,Randall Batson,4
-Leavenworth,0027 Delaware 4,U.S. Senate,,L,Randall Batson,0
-Leavenworth,0028 Easton/Easton,U.S. Senate,,L,Randall Batson,24
-Leavenworth,0029 Basehor City/Fairmount,U.S. Senate,,L,Randall Batson,57
-Leavenworth,0030 Basehor Twp/Fairmount,U.S. Senate,,L,Randall Batson,29
-Leavenworth,0031 Glenwood/Fairmount,U.S. Senate,,L,Randall Batson,34
-Leavenworth,0032 Boling/High Prairie,U.S. Senate,,L,Randall Batson,28
-Leavenworth,0033 Kickapoo/Kickapoo,U.S. Senate,,L,Randall Batson,18
-Leavenworth,0034 Reno West 42,U.S. Senate,,L,Randall Batson,12
-Leavenworth,0035 Reno East 38,U.S. Senate,,L,Randall Batson,4
-Leavenworth,0036 Linwood/Sherman,U.S. Senate,,L,Randall Batson,37
-Leavenworth,0037 Stranger/Stranger,U.S. Senate,,L,Randall Batson,21
-Leavenworth,0038 Walnut/Stranger,U.S. Senate,,L,Randall Batson,12
-Leavenworth,0039 Tonganoxie North,U.S. Senate,,L,Randall Batson,35
-Leavenworth,0040 Tonganoxie South,U.S. Senate,,L,Randall Batson,19
-Leavenworth,0041 Tonganoxie Rural,U.S. Senate,,L,Randall Batson,38
-Leavenworth,"0042 Ft Leavenworth, Pct 41",U.S. Senate,,L,Randall Batson,4
-Leavenworth,"0043 Ft Leavenworth, Pct 42",U.S. Senate,,L,Randall Batson,0
-Leavenworth,0019 Springdale/Alexandria,U.S. House,2,R,Lynn Jenkins,228
-Leavenworth,0020 Lansing Ward 1,U.S. House,2,R,Lynn Jenkins,353
-Leavenworth,0021 Lansing Ward 2,U.S. House,2,R,Lynn Jenkins,503
-Leavenworth,0022 Lansing Ward 3,U.S. House,2,R,Lynn Jenkins,447
-Leavenworth,0023 Lansing Ward 4,U.S. House,2,R,Lynn Jenkins,472
-Leavenworth,0024 Delaware 1,U.S. House,2,R,Lynn Jenkins,135
-Leavenworth,0025 Delaware 2,U.S. House,2,R,Lynn Jenkins,60
-Leavenworth,0026 Delaware 3,U.S. House,2,R,Lynn Jenkins,86
-Leavenworth,0027 Delaware 4,U.S. House,2,R,Lynn Jenkins,3
-Leavenworth,0028 Easton/Easton,U.S. House,2,R,Lynn Jenkins,267
-Leavenworth,0029 Basehor City/Fairmount,U.S. House,2,R,Lynn Jenkins,1056
-Leavenworth,0030 Basehor Twp/Fairmount,U.S. House,2,R,Lynn Jenkins,497
-Leavenworth,0031 Glenwood/Fairmount,U.S. House,2,R,Lynn Jenkins,671
-Leavenworth,0032 Boling/High Prairie,U.S. House,2,R,Lynn Jenkins,577
-Leavenworth,0033 Kickapoo/Kickapoo,U.S. House,2,R,Lynn Jenkins,505
-Leavenworth,0034 Reno West 42,U.S. House,2,R,Lynn Jenkins,286
-Leavenworth,0035 Reno East 38,U.S. House,2,R,Lynn Jenkins,59
-Leavenworth,0036 Linwood/Sherman,U.S. House,2,R,Lynn Jenkins,601
-Leavenworth,0037 Stranger/Stranger,U.S. House,2,R,Lynn Jenkins,396
-Leavenworth,0038 Walnut/Stranger,U.S. House,2,R,Lynn Jenkins,286
-Leavenworth,0039 Tonganoxie North,U.S. House,2,R,Lynn Jenkins,492
-Leavenworth,0040 Tonganoxie South,U.S. House,2,R,Lynn Jenkins,308
-Leavenworth,0041 Tonganoxie Rural,U.S. House,2,R,Lynn Jenkins,560
-Leavenworth,"0042 Ft Leavenworth, Pct 41",U.S. House,2,R,Lynn Jenkins,34
-Leavenworth,"0043 Ft Leavenworth, Pct 42",U.S. House,2,R,Lynn Jenkins,21
-Leavenworth,0019 Springdale/Alexandria,U.S. House,2,D,Margie Wakefield,51
-Leavenworth,0020 Lansing Ward 1,U.S. House,2,D,Margie Wakefield,136
-Leavenworth,0021 Lansing Ward 2,U.S. House,2,D,Margie Wakefield,185
-Leavenworth,0022 Lansing Ward 3,U.S. House,2,D,Margie Wakefield,215
-Leavenworth,0023 Lansing Ward 4,U.S. House,2,D,Margie Wakefield,213
-Leavenworth,0024 Delaware 1,U.S. House,2,D,Margie Wakefield,41
-Leavenworth,0025 Delaware 2,U.S. House,2,D,Margie Wakefield,20
-Leavenworth,0026 Delaware 3,U.S. House,2,D,Margie Wakefield,18
-Leavenworth,0027 Delaware 4,U.S. House,2,D,Margie Wakefield,0
-Leavenworth,0028 Easton/Easton,U.S. House,2,D,Margie Wakefield,76
-Leavenworth,0029 Basehor City/Fairmount,U.S. House,2,D,Margie Wakefield,517
-Leavenworth,0030 Basehor Twp/Fairmount,U.S. House,2,D,Margie Wakefield,160
-Leavenworth,0031 Glenwood/Fairmount,U.S. House,2,D,Margie Wakefield,281
-Leavenworth,0032 Boling/High Prairie,U.S. House,2,D,Margie Wakefield,186
-Leavenworth,0033 Kickapoo/Kickapoo,U.S. House,2,D,Margie Wakefield,176
-Leavenworth,0034 Reno West 42,U.S. House,2,D,Margie Wakefield,194
-Leavenworth,0035 Reno East 38,U.S. House,2,D,Margie Wakefield,39
-Leavenworth,0036 Linwood/Sherman,U.S. House,2,D,Margie Wakefield,291
-Leavenworth,0037 Stranger/Stranger,U.S. House,2,D,Margie Wakefield,160
-Leavenworth,0038 Walnut/Stranger,U.S. House,2,D,Margie Wakefield,140
-Leavenworth,0039 Tonganoxie North,U.S. House,2,D,Margie Wakefield,226
-Leavenworth,0040 Tonganoxie South,U.S. House,2,D,Margie Wakefield,206
-Leavenworth,0041 Tonganoxie Rural,U.S. House,2,D,Margie Wakefield,268
-Leavenworth,"0042 Ft Leavenworth, Pct 41",U.S. House,2,D,Margie Wakefield,14
-Leavenworth,"0043 Ft Leavenworth, Pct 42",U.S. House,2,D,Margie Wakefield,2
-Leavenworth,0019 Springdale/Alexandria,U.S. House,2,L,Chris Clemmons,15
-Leavenworth,0020 Lansing Ward 1,U.S. House,2,L,Chris Clemmons,34
-Leavenworth,0021 Lansing Ward 2,U.S. House,2,L,Chris Clemmons,28
-Leavenworth,0022 Lansing Ward 3,U.S. House,2,L,Chris Clemmons,33
-Leavenworth,0023 Lansing Ward 4,U.S. House,2,L,Chris Clemmons,43
-Leavenworth,0024 Delaware 1,U.S. House,2,L,Chris Clemmons,15
-Leavenworth,0025 Delaware 2,U.S. House,2,L,Chris Clemmons,2
-Leavenworth,0026 Delaware 3,U.S. House,2,L,Chris Clemmons,8
-Leavenworth,0027 Delaware 4,U.S. House,2,L,Chris Clemmons,0
-Leavenworth,0028 Easton/Easton,U.S. House,2,L,Chris Clemmons,26
-Leavenworth,0029 Basehor City/Fairmount,U.S. House,2,L,Chris Clemmons,60
-Leavenworth,0030 Basehor Twp/Fairmount,U.S. House,2,L,Chris Clemmons,31
-Leavenworth,0031 Glenwood/Fairmount,U.S. House,2,L,Chris Clemmons,42
-Leavenworth,0032 Boling/High Prairie,U.S. House,2,L,Chris Clemmons,37
-Leavenworth,0033 Kickapoo/Kickapoo,U.S. House,2,L,Chris Clemmons,38
-Leavenworth,0034 Reno West 42,U.S. House,2,L,Chris Clemmons,17
-Leavenworth,0035 Reno East 38,U.S. House,2,L,Chris Clemmons,2
-Leavenworth,0036 Linwood/Sherman,U.S. House,2,L,Chris Clemmons,36
-Leavenworth,0037 Stranger/Stranger,U.S. House,2,L,Chris Clemmons,23
-Leavenworth,0038 Walnut/Stranger,U.S. House,2,L,Chris Clemmons,7
-Leavenworth,0039 Tonganoxie North,U.S. House,2,L,Chris Clemmons,44
-Leavenworth,0040 Tonganoxie South,U.S. House,2,L,Chris Clemmons,34
-Leavenworth,0041 Tonganoxie Rural,U.S. House,2,L,Chris Clemmons,40
-Leavenworth,"0042 Ft Leavenworth, Pct 41",U.S. House,2,L,Chris Clemmons,5
-Leavenworth,"0043 Ft Leavenworth, Pct 42",U.S. House,2,L,Chris Clemmons,0
-Leavenworth,0019 Springdale/Alexandria,Governor,,R,Sam Brownback,181
-Leavenworth,0020 Lansing Ward 1,Governor,,R,Sam Brownback,257
-Leavenworth,0021 Lansing Ward 2,Governor,,R,Sam Brownback,414
-Leavenworth,0022 Lansing Ward 3,Governor,,R,Sam Brownback,370
-Leavenworth,0023 Lansing Ward 4,Governor,,R,Sam Brownback,361
-Leavenworth,0024 Delaware 1,Governor,,R,Sam Brownback,109
-Leavenworth,0025 Delaware 2,Governor,,R,Sam Brownback,42
-Leavenworth,0026 Delaware 3,Governor,,R,Sam Brownback,68
-Leavenworth,0027 Delaware 4,Governor,,R,Sam Brownback,3
-Leavenworth,0028 Easton/Easton,Governor,,R,Sam Brownback,208
-Leavenworth,0029 Basehor City/Fairmount,Governor,,R,Sam Brownback,822
-Leavenworth,0030 Basehor Twp/Fairmount,Governor,,R,Sam Brownback,403
-Leavenworth,0031 Glenwood/Fairmount,Governor,,R,Sam Brownback,539
-Leavenworth,0032 Boling/High Prairie,Governor,,R,Sam Brownback,471
-Leavenworth,0033 Kickapoo/Kickapoo,Governor,,R,Sam Brownback,435
-Leavenworth,0034 Reno West 42,Governor,,R,Sam Brownback,212
-Leavenworth,0035 Reno East 38,Governor,,R,Sam Brownback,46
-Leavenworth,0036 Linwood/Sherman,Governor,,R,Sam Brownback,473
-Leavenworth,0037 Stranger/Stranger,Governor,,R,Sam Brownback,317
-Leavenworth,0038 Walnut/Stranger,Governor,,R,Sam Brownback,210
-Leavenworth,0039 Tonganoxie North,Governor,,R,Sam Brownback,388
-Leavenworth,0040 Tonganoxie South,Governor,,R,Sam Brownback,243
-Leavenworth,0041 Tonganoxie Rural,Governor,,R,Sam Brownback,459
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Governor,,R,Sam Brownback,35
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Governor,,R,Sam Brownback,21
-Leavenworth,0019 Springdale/Alexandria,Governor,,D,Paul Davis,96
-Leavenworth,0020 Lansing Ward 1,Governor,,D,Paul Davis,231
-Leavenworth,0021 Lansing Ward 2,Governor,,D,Paul Davis,278
-Leavenworth,0022 Lansing Ward 3,Governor,,D,Paul Davis,304
-Leavenworth,0023 Lansing Ward 4,Governor,,D,Paul Davis,325
-Leavenworth,0024 Delaware 1,Governor,,D,Paul Davis,74
-Leavenworth,0025 Delaware 2,Governor,,D,Paul Davis,40
-Leavenworth,0026 Delaware 3,Governor,,D,Paul Davis,40
-Leavenworth,0027 Delaware 4,Governor,,D,Paul Davis,0
-Leavenworth,0028 Easton/Easton,Governor,,D,Paul Davis,149
-Leavenworth,0029 Basehor City/Fairmount,Governor,,D,Paul Davis,758
-Leavenworth,0030 Basehor Twp/Fairmount,Governor,,D,Paul Davis,265
-Leavenworth,0031 Glenwood/Fairmount,Governor,,D,Paul Davis,415
-Leavenworth,0032 Boling/High Prairie,Governor,,D,Paul Davis,292
-Leavenworth,0033 Kickapoo/Kickapoo,Governor,,D,Paul Davis,255
-Leavenworth,0034 Reno West 42,Governor,,D,Paul Davis,269
-Leavenworth,0035 Reno East 38,Governor,,D,Paul Davis,50
-Leavenworth,0036 Linwood/Sherman,Governor,,D,Paul Davis,430
-Leavenworth,0037 Stranger/Stranger,Governor,,D,Paul Davis,239
-Leavenworth,0038 Walnut/Stranger,Governor,,D,Paul Davis,219
-Leavenworth,0039 Tonganoxie North,Governor,,D,Paul Davis,356
-Leavenworth,0040 Tonganoxie South,Governor,,D,Paul Davis,290
-Leavenworth,0041 Tonganoxie Rural,Governor,,D,Paul Davis,368
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Governor,,D,Paul Davis,15
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Governor,,D,Paul Davis,2
-Leavenworth,0019 Springdale/Alexandria,Governor,,L,Keen Umbehr,17
-Leavenworth,0020 Lansing Ward 1,Governor,,L,Keen Umbehr,34
-Leavenworth,0021 Lansing Ward 2,Governor,,L,Keen Umbehr,30
-Leavenworth,0022 Lansing Ward 3,Governor,,L,Keen Umbehr,28
-Leavenworth,0023 Lansing Ward 4,Governor,,L,Keen Umbehr,45
-Leavenworth,0024 Delaware 1,Governor,,L,Keen Umbehr,9
-Leavenworth,0025 Delaware 2,Governor,,L,Keen Umbehr,0
-Leavenworth,0026 Delaware 3,Governor,,L,Keen Umbehr,3
-Leavenworth,0027 Delaware 4,Governor,,L,Keen Umbehr,0
-Leavenworth,0028 Easton/Easton,Governor,,L,Keen Umbehr,13
-Leavenworth,0029 Basehor City/Fairmount,Governor,,L,Keen Umbehr,52
-Leavenworth,0030 Basehor Twp/Fairmount,Governor,,L,Keen Umbehr,25
-Leavenworth,0031 Glenwood/Fairmount,Governor,,L,Keen Umbehr,39
-Leavenworth,0032 Boling/High Prairie,Governor,,L,Keen Umbehr,35
-Leavenworth,0033 Kickapoo/Kickapoo,Governor,,L,Keen Umbehr,30
-Leavenworth,0034 Reno West 42,Governor,,L,Keen Umbehr,17
-Leavenworth,0035 Reno East 38,Governor,,L,Keen Umbehr,5
-Leavenworth,0036 Linwood/Sherman,Governor,,L,Keen Umbehr,31
-Leavenworth,0037 Stranger/Stranger,Governor,,L,Keen Umbehr,22
-Leavenworth,0038 Walnut/Stranger,Governor,,L,Keen Umbehr,5
-Leavenworth,0039 Tonganoxie North,Governor,,L,Keen Umbehr,22
-Leavenworth,0040 Tonganoxie South,Governor,,L,Keen Umbehr,18
-Leavenworth,0041 Tonganoxie Rural,Governor,,L,Keen Umbehr,39
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Governor,,L,Keen Umbehr,3
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Governor,,L,Keen Umbehr,0
-Leavenworth,0019 Springdale/Alexandria,Secretary of State,,R,Kris Kobach,212
-Leavenworth,0020 Lansing Ward 1,Secretary of State,,R,Kris Kobach,338
-Leavenworth,0021 Lansing Ward 2,Secretary of State,,R,Kris Kobach,504
-Leavenworth,0022 Lansing Ward 3,Secretary of State,,R,Kris Kobach,435
-Leavenworth,0023 Lansing Ward 4,Secretary of State,,R,Kris Kobach,453
-Leavenworth,0024 Delaware 1,Secretary of State,,R,Kris Kobach,134
-Leavenworth,0025 Delaware 2,Secretary of State,,R,Kris Kobach,58
-Leavenworth,0026 Delaware 3,Secretary of State,,R,Kris Kobach,84
-Leavenworth,0027 Delaware 4,Secretary of State,,R,Kris Kobach,3
-Leavenworth,0028 Easton/Easton,Secretary of State,,R,Kris Kobach,248
-Leavenworth,0029 Basehor City/Fairmount,Secretary of State,,R,Kris Kobach,1035
-Leavenworth,0030 Basehor Twp/Fairmount,Secretary of State,,R,Kris Kobach,491
-Leavenworth,0031 Glenwood/Fairmount,Secretary of State,,R,Kris Kobach,658
-Leavenworth,0032 Boling/High Prairie,Secretary of State,,R,Kris Kobach,552
-Leavenworth,0033 Kickapoo/Kickapoo,Secretary of State,,R,Kris Kobach,490
-Leavenworth,0034 Reno West 42,Secretary of State,,R,Kris Kobach,265
-Leavenworth,0035 Reno East 38,Secretary of State,,R,Kris Kobach,59
-Leavenworth,0036 Linwood/Sherman,Secretary of State,,R,Kris Kobach,593
-Leavenworth,0037 Stranger/Stranger,Secretary of State,,R,Kris Kobach,386
-Leavenworth,0038 Walnut/Stranger,Secretary of State,,R,Kris Kobach,265
-Leavenworth,0039 Tonganoxie North,Secretary of State,,R,Kris Kobach,487
-Leavenworth,0040 Tonganoxie South,Secretary of State,,R,Kris Kobach,309
-Leavenworth,0041 Tonganoxie Rural,Secretary of State,,R,Kris Kobach,565
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Secretary of State,,R,Kris Kobach,35
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Secretary of State,,R,Kris Kobach,21
-Leavenworth,0019 Springdale/Alexandria,Secretary of State,,D,Jean Schodorf,75
-Leavenworth,0020 Lansing Ward 1,Secretary of State,,D,Jean Schodorf,178
-Leavenworth,0021 Lansing Ward 2,Secretary of State,,D,Jean Schodorf,208
-Leavenworth,0022 Lansing Ward 3,Secretary of State,,D,Jean Schodorf,268
-Leavenworth,0023 Lansing Ward 4,Secretary of State,,D,Jean Schodorf,269
-Leavenworth,0024 Delaware 1,Secretary of State,,D,Jean Schodorf,55
-Leavenworth,0025 Delaware 2,Secretary of State,,D,Jean Schodorf,23
-Leavenworth,0026 Delaware 3,Secretary of State,,D,Jean Schodorf,28
-Leavenworth,0027 Delaware 4,Secretary of State,,D,Jean Schodorf,0
-Leavenworth,0028 Easton/Easton,Secretary of State,,D,Jean Schodorf,116
-Leavenworth,0029 Basehor City/Fairmount,Secretary of State,,D,Jean Schodorf,587
-Leavenworth,0030 Basehor Twp/Fairmount,Secretary of State,,D,Jean Schodorf,192
-Leavenworth,0031 Glenwood/Fairmount,Secretary of State,,D,Jean Schodorf,332
-Leavenworth,0032 Boling/High Prairie,Secretary of State,,D,Jean Schodorf,240
-Leavenworth,0033 Kickapoo/Kickapoo,Secretary of State,,D,Jean Schodorf,222
-Leavenworth,0034 Reno West 42,Secretary of State,,D,Jean Schodorf,228
-Leavenworth,0035 Reno East 38,Secretary of State,,D,Jean Schodorf,41
-Leavenworth,0036 Linwood/Sherman,Secretary of State,,D,Jean Schodorf,333
-Leavenworth,0037 Stranger/Stranger,Secretary of State,,D,Jean Schodorf,188
-Leavenworth,0038 Walnut/Stranger,Secretary of State,,D,Jean Schodorf,164
-Leavenworth,0039 Tonganoxie North,Secretary of State,,D,Jean Schodorf,271
-Leavenworth,0040 Tonganoxie South,Secretary of State,,D,Jean Schodorf,239
-Leavenworth,0041 Tonganoxie Rural,Secretary of State,,D,Jean Schodorf,307
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Secretary of State,,D,Jean Schodorf,15
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Secretary of State,,D,Jean Schodorf,2
-Leavenworth,0019 Springdale/Alexandria,Attorney General,,R,Derek Schmidt,209
-Leavenworth,0020 Lansing Ward 1,Attorney General,,R,Derek Schmidt,324
-Leavenworth,0021 Lansing Ward 2,Attorney General,,R,Derek Schmidt,503
-Leavenworth,0022 Lansing Ward 3,Attorney General,,R,Derek Schmidt,445
-Leavenworth,0023 Lansing Ward 4,Attorney General,,R,Derek Schmidt,454
-Leavenworth,0024 Delaware 1,Attorney General,,R,Derek Schmidt,134
-Leavenworth,0025 Delaware 2,Attorney General,,R,Derek Schmidt,55
-Leavenworth,0026 Delaware 3,Attorney General,,R,Derek Schmidt,86
-Leavenworth,0027 Delaware 4,Attorney General,,R,Derek Schmidt,3
-Leavenworth,0028 Easton/Easton,Attorney General,,R,Derek Schmidt,237
-Leavenworth,0029 Basehor City/Fairmount,Attorney General,,R,Derek Schmidt,1013
-Leavenworth,0030 Basehor Twp/Fairmount,Attorney General,,R,Derek Schmidt,476
-Leavenworth,0031 Glenwood/Fairmount,Attorney General,,R,Derek Schmidt,638
-Leavenworth,0032 Boling/High Prairie,Attorney General,,R,Derek Schmidt,555
-Leavenworth,0033 Kickapoo/Kickapoo,Attorney General,,R,Derek Schmidt,496
-Leavenworth,0034 Reno West 42,Attorney General,,R,Derek Schmidt,272
-Leavenworth,0035 Reno East 38,Attorney General,,R,Derek Schmidt,60
-Leavenworth,0036 Linwood/Sherman,Attorney General,,R,Derek Schmidt,576
-Leavenworth,0037 Stranger/Stranger,Attorney General,,R,Derek Schmidt,382
-Leavenworth,0038 Walnut/Stranger,Attorney General,,R,Derek Schmidt,255
-Leavenworth,0039 Tonganoxie North,Attorney General,,R,Derek Schmidt,478
-Leavenworth,0040 Tonganoxie South,Attorney General,,R,Derek Schmidt,310
-Leavenworth,0041 Tonganoxie Rural,Attorney General,,R,Derek Schmidt,556
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Attorney General,,R,Derek Schmidt,38
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Attorney General,,R,Derek Schmidt,21
-Leavenworth,0019 Springdale/Alexandria,Attorney General,,D,A J Kotich,72
-Leavenworth,0020 Lansing Ward 1,Attorney General,,D,A J Kotich,185
-Leavenworth,0021 Lansing Ward 2,Attorney General,,D,A J Kotich,200
-Leavenworth,0022 Lansing Ward 3,Attorney General,,D,A J Kotich,251
-Leavenworth,0023 Lansing Ward 4,Attorney General,,D,A J Kotich,259
-Leavenworth,0024 Delaware 1,Attorney General,,D,A J Kotich,54
-Leavenworth,0025 Delaware 2,Attorney General,,D,A J Kotich,24
-Leavenworth,0026 Delaware 3,Attorney General,,D,A J Kotich,26
-Leavenworth,0027 Delaware 4,Attorney General,,D,A J Kotich,0
-Leavenworth,0028 Easton/Easton,Attorney General,,D,A J Kotich,115
-Leavenworth,0029 Basehor City/Fairmount,Attorney General,,D,A J Kotich,574
-Leavenworth,0030 Basehor Twp/Fairmount,Attorney General,,D,A J Kotich,198
-Leavenworth,0031 Glenwood/Fairmount,Attorney General,,D,A J Kotich,340
-Leavenworth,0032 Boling/High Prairie,Attorney General,,D,A J Kotich,228
-Leavenworth,0033 Kickapoo/Kickapoo,Attorney General,,D,A J Kotich,200
-Leavenworth,0034 Reno West 42,Attorney General,,D,A J Kotich,222
-Leavenworth,0035 Reno East 38,Attorney General,,D,A J Kotich,38
-Leavenworth,0036 Linwood/Sherman,Attorney General,,D,A J Kotich,336
-Leavenworth,0037 Stranger/Stranger,Attorney General,,D,A J Kotich,191
-Leavenworth,0038 Walnut/Stranger,Attorney General,,D,A J Kotich,162
-Leavenworth,0039 Tonganoxie North,Attorney General,,D,A J Kotich,270
-Leavenworth,0040 Tonganoxie South,Attorney General,,D,A J Kotich,225
-Leavenworth,0041 Tonganoxie Rural,Attorney General,,D,A J Kotich,303
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Attorney General,,D,A J Kotich,13
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Attorney General,,D,A J Kotich,1
-Leavenworth,0019 Springdale/Alexandria,State Treasurer,,R,Ron Estes,215
-Leavenworth,0020 Lansing Ward 1,State Treasurer,,R,Ron Estes,337
-Leavenworth,0021 Lansing Ward 2,State Treasurer,,R,Ron Estes,511
-Leavenworth,0022 Lansing Ward 3,State Treasurer,,R,Ron Estes,452
-Leavenworth,0023 Lansing Ward 4,State Treasurer,,R,Ron Estes,471
-Leavenworth,0024 Delaware 1,State Treasurer,,R,Ron Estes,135
-Leavenworth,0025 Delaware 2,State Treasurer,,R,Ron Estes,55
-Leavenworth,0026 Delaware 3,State Treasurer,,R,Ron Estes,90
-Leavenworth,0027 Delaware 4,State Treasurer,,R,Ron Estes,3
-Leavenworth,0028 Easton/Easton,State Treasurer,,R,Ron Estes,242
-Leavenworth,0029 Basehor City/Fairmount,State Treasurer,,R,Ron Estes,1049
-Leavenworth,0030 Basehor Twp/Fairmount,State Treasurer,,R,Ron Estes,485
-Leavenworth,0031 Glenwood/Fairmount,State Treasurer,,R,Ron Estes,667
-Leavenworth,0032 Boling/High Prairie,State Treasurer,,R,Ron Estes,568
-Leavenworth,0033 Kickapoo/Kickapoo,State Treasurer,,R,Ron Estes,501
-Leavenworth,0034 Reno West 42,State Treasurer,,R,Ron Estes,287
-Leavenworth,0035 Reno East 38,State Treasurer,,R,Ron Estes,58
-Leavenworth,0036 Linwood/Sherman,State Treasurer,,R,Ron Estes,574
-Leavenworth,0037 Stranger/Stranger,State Treasurer,,R,Ron Estes,392
-Leavenworth,0038 Walnut/Stranger,State Treasurer,,R,Ron Estes,265
-Leavenworth,0039 Tonganoxie North,State Treasurer,,R,Ron Estes,482
-Leavenworth,0040 Tonganoxie South,State Treasurer,,R,Ron Estes,315
-Leavenworth,0041 Tonganoxie Rural,State Treasurer,,R,Ron Estes,551
-Leavenworth,"0042 Ft Leavenworth, Pct 41",State Treasurer,,R,Ron Estes,38
-Leavenworth,"0043 Ft Leavenworth, Pct 42",State Treasurer,,R,Ron Estes,20
-Leavenworth,0019 Springdale/Alexandria,State Treasurer,,D,Carmen Alldritt,69
-Leavenworth,0020 Lansing Ward 1,State Treasurer,,D,Carmen Alldritt,177
-Leavenworth,0021 Lansing Ward 2,State Treasurer,,D,Carmen Alldritt,193
-Leavenworth,0022 Lansing Ward 3,State Treasurer,,D,Carmen Alldritt,240
-Leavenworth,0023 Lansing Ward 4,State Treasurer,,D,Carmen Alldritt,241
-Leavenworth,0024 Delaware 1,State Treasurer,,D,Carmen Alldritt,52
-Leavenworth,0025 Delaware 2,State Treasurer,,D,Carmen Alldritt,23
-Leavenworth,0026 Delaware 3,State Treasurer,,D,Carmen Alldritt,20
-Leavenworth,0027 Delaware 4,State Treasurer,,D,Carmen Alldritt,0
-Leavenworth,0028 Easton/Easton,State Treasurer,,D,Carmen Alldritt,116
-Leavenworth,0029 Basehor City/Fairmount,State Treasurer,,D,Carmen Alldritt,538
-Leavenworth,0030 Basehor Twp/Fairmount,State Treasurer,,D,Carmen Alldritt,196
-Leavenworth,0031 Glenwood/Fairmount,State Treasurer,,D,Carmen Alldritt,308
-Leavenworth,0032 Boling/High Prairie,State Treasurer,,D,Carmen Alldritt,214
-Leavenworth,0033 Kickapoo/Kickapoo,State Treasurer,,D,Carmen Alldritt,204
-Leavenworth,0034 Reno West 42,State Treasurer,,D,Carmen Alldritt,208
-Leavenworth,0035 Reno East 38,State Treasurer,,D,Carmen Alldritt,40
-Leavenworth,0036 Linwood/Sherman,State Treasurer,,D,Carmen Alldritt,336
-Leavenworth,0037 Stranger/Stranger,State Treasurer,,D,Carmen Alldritt,173
-Leavenworth,0038 Walnut/Stranger,State Treasurer,,D,Carmen Alldritt,155
-Leavenworth,0039 Tonganoxie North,State Treasurer,,D,Carmen Alldritt,261
-Leavenworth,0040 Tonganoxie South,State Treasurer,,D,Carmen Alldritt,222
-Leavenworth,0041 Tonganoxie Rural,State Treasurer,,D,Carmen Alldritt,309
-Leavenworth,"0042 Ft Leavenworth, Pct 41",State Treasurer,,D,Carmen Alldritt,13
-Leavenworth,"0043 Ft Leavenworth, Pct 42",State Treasurer,,D,Carmen Alldritt,2
-Leavenworth,0019 Springdale/Alexandria,Insurance Commissioner,,R,Ken Selzer,198
-Leavenworth,0020 Lansing Ward 1,Insurance Commissioner,,R,Ken Selzer,307
-Leavenworth,0021 Lansing Ward 2,Insurance Commissioner,,R,Ken Selzer,479
-Leavenworth,0022 Lansing Ward 3,Insurance Commissioner,,R,Ken Selzer,428
-Leavenworth,0023 Lansing Ward 4,Insurance Commissioner,,R,Ken Selzer,448
-Leavenworth,0024 Delaware 1,Insurance Commissioner,,R,Ken Selzer,128
-Leavenworth,0025 Delaware 2,Insurance Commissioner,,R,Ken Selzer,55
-Leavenworth,0026 Delaware 3,Insurance Commissioner,,R,Ken Selzer,83
-Leavenworth,0027 Delaware 4,Insurance Commissioner,,R,Ken Selzer,3
-Leavenworth,0028 Easton/Easton,Insurance Commissioner,,R,Ken Selzer,232
-Leavenworth,0029 Basehor City/Fairmount,Insurance Commissioner,,R,Ken Selzer,952
-Leavenworth,0030 Basehor Twp/Fairmount,Insurance Commissioner,,R,Ken Selzer,454
-Leavenworth,0031 Glenwood/Fairmount,Insurance Commissioner,,R,Ken Selzer,608
-Leavenworth,0032 Boling/High Prairie,Insurance Commissioner,,R,Ken Selzer,540
-Leavenworth,0033 Kickapoo/Kickapoo,Insurance Commissioner,,R,Ken Selzer,480
-Leavenworth,0034 Reno West 42,Insurance Commissioner,,R,Ken Selzer,271
-Leavenworth,0035 Reno East 38,Insurance Commissioner,,R,Ken Selzer,56
-Leavenworth,0036 Linwood/Sherman,Insurance Commissioner,,R,Ken Selzer,536
-Leavenworth,0037 Stranger/Stranger,Insurance Commissioner,,R,Ken Selzer,361
-Leavenworth,0038 Walnut/Stranger,Insurance Commissioner,,R,Ken Selzer,247
-Leavenworth,0039 Tonganoxie North,Insurance Commissioner,,R,Ken Selzer,454
-Leavenworth,0040 Tonganoxie South,Insurance Commissioner,,R,Ken Selzer,285
-Leavenworth,0041 Tonganoxie Rural,Insurance Commissioner,,R,Ken Selzer,533
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Insurance Commissioner,,R,Ken Selzer,36
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Insurance Commissioner,,R,Ken Selzer,20
-Leavenworth,0019 Springdale/Alexandria,Insurance Commissioner,,D,Dennis Anderson,81
-Leavenworth,0020 Lansing Ward 1,Insurance Commissioner,,D,Dennis Anderson,205
-Leavenworth,0021 Lansing Ward 2,Insurance Commissioner,,D,Dennis Anderson,225
-Leavenworth,0022 Lansing Ward 3,Insurance Commissioner,,D,Dennis Anderson,261
-Leavenworth,0023 Lansing Ward 4,Insurance Commissioner,,D,Dennis Anderson,258
-Leavenworth,0024 Delaware 1,Insurance Commissioner,,D,Dennis Anderson,59
-Leavenworth,0025 Delaware 2,Insurance Commissioner,,D,Dennis Anderson,26
-Leavenworth,0026 Delaware 3,Insurance Commissioner,,D,Dennis Anderson,27
-Leavenworth,0027 Delaware 4,Insurance Commissioner,,D,Dennis Anderson,0
-Leavenworth,0028 Easton/Easton,Insurance Commissioner,,D,Dennis Anderson,127
-Leavenworth,0029 Basehor City/Fairmount,Insurance Commissioner,,D,Dennis Anderson,627
-Leavenworth,0030 Basehor Twp/Fairmount,Insurance Commissioner,,D,Dennis Anderson,221
-Leavenworth,0031 Glenwood/Fairmount,Insurance Commissioner,,D,Dennis Anderson,358
-Leavenworth,0032 Boling/High Prairie,Insurance Commissioner,,D,Dennis Anderson,238
-Leavenworth,0033 Kickapoo/Kickapoo,Insurance Commissioner,,D,Dennis Anderson,220
-Leavenworth,0034 Reno West 42,Insurance Commissioner,,D,Dennis Anderson,220
-Leavenworth,0035 Reno East 38,Insurance Commissioner,,D,Dennis Anderson,41
-Leavenworth,0036 Linwood/Sherman,Insurance Commissioner,,D,Dennis Anderson,369
-Leavenworth,0037 Stranger/Stranger,Insurance Commissioner,,D,Dennis Anderson,209
-Leavenworth,0038 Walnut/Stranger,Insurance Commissioner,,D,Dennis Anderson,172
-Leavenworth,0039 Tonganoxie North,Insurance Commissioner,,D,Dennis Anderson,289
-Leavenworth,0040 Tonganoxie South,Insurance Commissioner,,D,Dennis Anderson,248
-Leavenworth,0041 Tonganoxie Rural,Insurance Commissioner,,D,Dennis Anderson,319
-Leavenworth,"0042 Ft Leavenworth, Pct 41",Insurance Commissioner,,D,Dennis Anderson,15
-Leavenworth,"0043 Ft Leavenworth, Pct 42",Insurance Commissioner,,D,Dennis Anderson,2
-Leavenworth,0019 Springdale/Alexandria,State House,42,R,Connie O'Brien,206
-Leavenworth,0020 Lansing Ward 1,State House,40,R,John Bradford,280
-Leavenworth,0021 Lansing Ward 2,State House,40,R,John Bradford,459
-Leavenworth,0022 Lansing Ward 3,State House,40,R,John Bradford,397
-Leavenworth,0023 Lansing Ward 4,State House,40,R,John Bradford,404
-Leavenworth,0024 Delaware 1,State House,40,R,John Bradford,119
-Leavenworth,0025 Delaware 2,State House,40,R,John Bradford,54
-Leavenworth,0026 Delaware 3,State House,38,R,Willie Dove,79
-Leavenworth,0027 Delaware 4,State House,38,R,Willie Dove,3
-Leavenworth,0028 Easton/Easton,State House,42,R,Connie O'Brien,234
-Leavenworth,0029 Basehor City/Fairmount,State House,38,R,Willie Dove,903
-Leavenworth,0030 Basehor Twp/Fairmount,State House,38,R,Willie Dove,432
-Leavenworth,0031 Glenwood/Fairmount,State House,38,R,Willie Dove,616
-Leavenworth,0032 Boling/High Prairie,State House,42,R,Connie O'Brien,550
-Leavenworth,0033 Kickapoo/Kickapoo,State House,42,R,Connie O'Brien,479
-Leavenworth,0034 Reno West 42,State House,42,R,Connie O'Brien,266
-Leavenworth,0035 Reno East 38,State House,38,R,Willie Dove,51
-Leavenworth,0036 Linwood/Sherman,State House,38,R,Willie Dove,568
-Leavenworth,0037 Stranger/Stranger,State House,38,R,Willie Dove,345
-Leavenworth,0038 Walnut/Stranger,State House,38,R,Willie Dove,243
-Leavenworth,0039 Tonganoxie North,State House,42,R,Connie O'Brien,410
-Leavenworth,0040 Tonganoxie South,State House,42,R,Connie O'Brien,254
-Leavenworth,0041 Tonganoxie Rural,State House,42,R,Connie O'Brien,507
-Leavenworth,"0042 Ft Leavenworth, Pct 41",State House,41,R,TONY BARTON,39
-Leavenworth,"0043 Ft Leavenworth, Pct 42",State House,42,R,Connie O'Brien,19
-Leavenworth,0019 Springdale/Alexandria,State House,42,D,Austin Harris,81
-Leavenworth,0020 Lansing Ward 1,State House,40,D,Linda Johnson,237
-Leavenworth,0021 Lansing Ward 2,State House,40,D,Linda Johnson,255
-Leavenworth,0022 Lansing Ward 3,State House,40,D,Linda Johnson,305
-Leavenworth,0023 Lansing Ward 4,State House,40,D,Linda Johnson,325
-Leavenworth,0024 Delaware 1,State House,40,D,Linda Johnson,69
-Leavenworth,0025 Delaware 2,State House,40,D,Linda Johnson,28
-Leavenworth,0026 Delaware 3,State House,38,D,Jan Pringle,19
-Leavenworth,0027 Delaware 4,State House,38,D,Jan Pringle,0
-Leavenworth,0028 Easton/Easton,State House,42,D,Austin Harris,130
-Leavenworth,0029 Basehor City/Fairmount,State House,38,D,Jan Pringle,469
-Leavenworth,0030 Basehor Twp/Fairmount,State House,38,D,Jan Pringle,160
-Leavenworth,0031 Glenwood/Fairmount,State House,38,D,Jan Pringle,263
-Leavenworth,0032 Boling/High Prairie,State House,42,D,Austin Harris,239
-Leavenworth,0033 Kickapoo/Kickapoo,State House,42,D,Austin Harris,229
-Leavenworth,0034 Reno West 42,State House,42,D,Austin Harris,231
-Leavenworth,0035 Reno East 38,State House,38,D,Jan Pringle,35
-Leavenworth,0036 Linwood/Sherman,State House,38,D,Jan Pringle,282
-Leavenworth,0037 Stranger/Stranger,State House,38,D,Jan Pringle,169
-Leavenworth,0038 Walnut/Stranger,State House,38,D,Jan Pringle,146
-Leavenworth,0039 Tonganoxie North,State House,42,D,Austin Harris,353
-Leavenworth,0040 Tonganoxie South,State House,42,D,Austin Harris,297
-Leavenworth,0041 Tonganoxie Rural,State House,42,D,Austin Harris,356
-Leavenworth,"0042 Ft Leavenworth, Pct 41",State House,41,D,Nancy Bauder,12
-Leavenworth,"0043 Ft Leavenworth, Pct 42",State House,42,D,Austin Harris,3
-Leavenworth,0026 Delaware 3,State House,38,L,Caleb Christopher,13
-Leavenworth,0027 Delaware 4,State House,38,L,Caleb Christopher,0
-Leavenworth,0029 Basehor City/Fairmount,State House,38,L,Caleb Christopher,242
-Leavenworth,0030 Basehor Twp/Fairmount,State House,38,L,Caleb Christopher,95
-Leavenworth,0031 Glenwood/Fairmount,State House,38,L,Caleb Christopher,104
-Leavenworth,0035 Reno East 38,State House,38,L,Caleb Christopher,12
-Leavenworth,0036 Linwood/Sherman,State House,38,L,Caleb Christopher,68
-Leavenworth,0037 Stranger/Stranger,State House,38,L,Caleb Christopher,55
-Leavenworth,0038 Walnut/Stranger,State House,38,L,Caleb Christopher,36
+county,precinct,office,district,party,candidate,votes,vtd
+LEAVENWORTH,Alexandria Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",96,000010
+LEAVENWORTH,Alexandria Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000010
+LEAVENWORTH,Alexandria Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",181,000010
+LEAVENWORTH,Basehor City,Governor / Lt. Governor,,Democratic,"Davis, Paul",758,000020
+LEAVENWORTH,Basehor City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",52,000020
+LEAVENWORTH,Basehor City,Governor / Lt. Governor,,Republican,"Brownback, Sam",822,000020
+LEAVENWORTH,Basehor Township Voting District,Governor / Lt. Governor,,Democratic,"Davis, Paul",265,000030
+LEAVENWORTH,Basehor Township Voting District,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000030
+LEAVENWORTH,Basehor Township Voting District,Governor / Lt. Governor,,Republican,"Brownback, Sam",403,000030
+LEAVENWORTH,Easton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",149,000040
+LEAVENWORTH,Easton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000040
+LEAVENWORTH,Easton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",208,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,Governor / Lt. Governor,,Democratic,"Davis, Paul",415,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",39,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Governor / Lt. Governor,,Republican,"Brownback, Sam",539,000050
+LEAVENWORTH,High Prairie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",292,000060
+LEAVENWORTH,High Prairie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",35,000060
+LEAVENWORTH,High Prairie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",471,000060
+LEAVENWORTH,Kickapoo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",255,000070
+LEAVENWORTH,Kickapoo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000070
+LEAVENWORTH,Kickapoo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",435,000070
+LEAVENWORTH,Lansing Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",231,000080
+LEAVENWORTH,Lansing Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",34,000080
+LEAVENWORTH,Lansing Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",257,000080
+LEAVENWORTH,Lansing Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",278,000090
+LEAVENWORTH,Lansing Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000090
+LEAVENWORTH,Lansing Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",414,000090
+LEAVENWORTH,Lansing Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",304,000100
+LEAVENWORTH,Lansing Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000100
+LEAVENWORTH,Lansing Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",370,000100
+LEAVENWORTH,Lansing Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",325,000110
+LEAVENWORTH,Lansing Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",45,000110
+LEAVENWORTH,Lansing Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",361,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",97,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",141,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",166,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",35,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",112,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",77,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",104,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",103,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",198,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",210,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",115,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",159,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",183,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",161,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",131,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",134,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",222,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",277,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",242,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",317,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",84,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",409,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",47,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",468,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",516,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",567,00029A
+LEAVENWORTH,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",430,000320
+LEAVENWORTH,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",31,000320
+LEAVENWORTH,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",473,000320
+LEAVENWORTH,South Delaware 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000340
+LEAVENWORTH,South Delaware 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000340
+LEAVENWORTH,South Delaware 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000340
+LEAVENWORTH,Stranger Township Voting District,Governor / Lt. Governor,,Democratic,"Davis, Paul",239,000350
+LEAVENWORTH,Stranger Township Voting District,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000350
+LEAVENWORTH,Stranger Township Voting District,Governor / Lt. Governor,,Republican,"Brownback, Sam",317,000350
+LEAVENWORTH,Tonganoxie North Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",356,000360
+LEAVENWORTH,Tonganoxie North Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000360
+LEAVENWORTH,Tonganoxie North Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",388,000360
+LEAVENWORTH,Tonganoxie South Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",290,000370
+LEAVENWORTH,Tonganoxie South Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000370
+LEAVENWORTH,Tonganoxie South Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",243,000370
+LEAVENWORTH,Tonganoxie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",368,000380
+LEAVENWORTH,Tonganoxie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",39,000380
+LEAVENWORTH,Tonganoxie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",459,000380
+LEAVENWORTH,Walnut Township Voting District,Governor / Lt. Governor,,Democratic,"Davis, Paul",219,000390
+LEAVENWORTH,Walnut Township Voting District,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000390
+LEAVENWORTH,Walnut Township Voting District,Governor / Lt. Governor,,Republican,"Brownback, Sam",210,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,120050
+LEAVENWORTH,Missouri River H41,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120060
+LEAVENWORTH,Missouri River H41,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120060
+LEAVENWORTH,Missouri River H41,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120060
+LEAVENWORTH,Missouri River H42,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120070
+LEAVENWORTH,Missouri River H42,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120070
+LEAVENWORTH,Missouri River H42,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120070
+LEAVENWORTH,Reno Township H38,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,120080
+LEAVENWORTH,Reno Township H38,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120080
+LEAVENWORTH,Reno Township H38,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,120080
+LEAVENWORTH,Reno Township H42,Governor / Lt. Governor,,Democratic,"Davis, Paul",269,120090
+LEAVENWORTH,Reno Township H42,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,120090
+LEAVENWORTH,Reno Township H42,Governor / Lt. Governor,,Republican,"Brownback, Sam",212,120090
+LEAVENWORTH,South Delaware 3 S3 H38,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,120100
+LEAVENWORTH,South Delaware 2 S3 H40,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,120110
+LEAVENWORTH,South Delaware 2 S3 H40,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,120110
+LEAVENWORTH,South Delaware 4 S5 H38,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,120120
+LEAVENWORTH,South Delaware 1 S5 H40,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Governor / Lt. Governor,,Republican,"Brownback, Sam",109,120130
+LEAVENWORTH,Basehor City Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900080
+LEAVENWORTH,Alexandria Township,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",81,000010
+LEAVENWORTH,Alexandria Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",206,000010
+LEAVENWORTH,Basehor City,Kansas House of Representatives,38,Democratic,"Pringle, Jan",469,000020
+LEAVENWORTH,Basehor City,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",242,000020
+LEAVENWORTH,Basehor City,Kansas House of Representatives,38,Republican,"Dove, Willie",903,000020
+LEAVENWORTH,Basehor Township Voting District,Kansas House of Representatives,38,Democratic,"Pringle, Jan",160,000030
+LEAVENWORTH,Basehor Township Voting District,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",95,000030
+LEAVENWORTH,Basehor Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",432,000030
+LEAVENWORTH,Easton Township,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",130,000040
+LEAVENWORTH,Easton Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",234,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,Kansas House of Representatives,38,Democratic,"Pringle, Jan",263,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",104,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",616,000050
+LEAVENWORTH,High Prairie Township,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",239,000060
+LEAVENWORTH,High Prairie Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",550,000060
+LEAVENWORTH,Kickapoo Township,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",229,000070
+LEAVENWORTH,Kickapoo Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",479,000070
+LEAVENWORTH,Lansing Ward 1,Kansas House of Representatives,40,Democratic,"Johnson, Linda",237,000080
+LEAVENWORTH,Lansing Ward 1,Kansas House of Representatives,40,Republican,"Bradford, John",280,000080
+LEAVENWORTH,Lansing Ward 2,Kansas House of Representatives,40,Democratic,"Johnson, Linda",255,000090
+LEAVENWORTH,Lansing Ward 2,Kansas House of Representatives,40,Republican,"Bradford, John",459,000090
+LEAVENWORTH,Lansing Ward 3,Kansas House of Representatives,40,Democratic,"Johnson, Linda",305,000100
+LEAVENWORTH,Lansing Ward 3,Kansas House of Representatives,40,Republican,"Bradford, John",397,000100
+LEAVENWORTH,Lansing Ward 4,Kansas House of Representatives,40,Democratic,"Johnson, Linda",325,000110
+LEAVENWORTH,Lansing Ward 4,Kansas House of Representatives,40,Republican,"Bradford, John",404,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",107,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",85,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",69,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",88,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",89,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas House of Representatives,41,Republican,"Barton, Tony",122,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas House of Representatives,40,Democratic,"Johnson, Linda",158,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",126,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",156,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",156,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",76,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",71,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",93,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",125,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",98,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas House of Representatives,41,Republican,"Barton, Tony",124,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",184,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas House of Representatives,41,Republican,"Barton, Tony",252,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",110,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas House of Representatives,41,Republican,"Barton, Tony",174,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",166,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",193,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",128,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas House of Representatives,41,Republican,"Barton, Tony",114,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas House of Representatives,40,Democratic,"Johnson, Linda",167,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",108,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",204,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas House of Representatives,41,Republican,"Barton, Tony",318,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",240,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas House of Representatives,41,Republican,"Barton, Tony",341,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas House of Representatives,40,Democratic,"Johnson, Linda",82,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas House of Representatives,40,Republican,"Bradford, John",30,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas House of Representatives,40,Democratic,"Johnson, Linda",444,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas House of Representatives,40,Republican,"Bradford, John",479,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas House of Representatives,40,Democratic,"Johnson, Linda",520,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",588,00029A
+LEAVENWORTH,Sherman Township,Kansas House of Representatives,38,Democratic,"Pringle, Jan",282,000320
+LEAVENWORTH,Sherman Township,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",68,000320
+LEAVENWORTH,Sherman Township,Kansas House of Representatives,38,Republican,"Dove, Willie",568,000320
+LEAVENWORTH,South Delaware 2,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,000340
+LEAVENWORTH,South Delaware 2,Kansas House of Representatives,40,Republican,"Bradford, John",0,000340
+LEAVENWORTH,Stranger Township Voting District,Kansas House of Representatives,38,Democratic,"Pringle, Jan",169,000350
+LEAVENWORTH,Stranger Township Voting District,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",55,000350
+LEAVENWORTH,Stranger Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",345,000350
+LEAVENWORTH,Tonganoxie North Precinct,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",353,000360
+LEAVENWORTH,Tonganoxie North Precinct,Kansas House of Representatives,42,Republican,"O'Brien, Connie",410,000360
+LEAVENWORTH,Tonganoxie South Precinct,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",297,000370
+LEAVENWORTH,Tonganoxie South Precinct,Kansas House of Representatives,42,Republican,"O'Brien, Connie",254,000370
+LEAVENWORTH,Tonganoxie Township,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",356,000380
+LEAVENWORTH,Tonganoxie Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",507,000380
+LEAVENWORTH,Walnut Township Voting District,Kansas House of Representatives,38,Democratic,"Pringle, Jan",146,000390
+LEAVENWORTH,Walnut Township Voting District,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",36,000390
+LEAVENWORTH,Walnut Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",243,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",12,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas House of Representatives,41,Republican,"Barton, Tony",39,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",3,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas House of Representatives,42,Republican,"O'Brien, Connie",19,120050
+LEAVENWORTH,Missouri River H41,Kansas House of Representatives,41,Democratic,"Bauder, Nancy D.",0,120060
+LEAVENWORTH,Missouri River H41,Kansas House of Representatives,41,Republican,"Barton, Tony",0,120060
+LEAVENWORTH,Missouri River H42,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",0,120070
+LEAVENWORTH,Missouri River H42,Kansas House of Representatives,42,Republican,"O'Brien, Connie",0,120070
+LEAVENWORTH,Reno Township H38,Kansas House of Representatives,38,Democratic,"Pringle, Jan",35,120080
+LEAVENWORTH,Reno Township H38,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",12,120080
+LEAVENWORTH,Reno Township H38,Kansas House of Representatives,38,Republican,"Dove, Willie",51,120080
+LEAVENWORTH,Reno Township H42,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",231,120090
+LEAVENWORTH,Reno Township H42,Kansas House of Representatives,42,Republican,"O'Brien, Connie",266,120090
+LEAVENWORTH,South Delaware 3 S3 H38,Kansas House of Representatives,38,Democratic,"Pringle, Jan",19,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",13,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Kansas House of Representatives,38,Republican,"Dove, Willie",79,120100
+LEAVENWORTH,South Delaware 2 S3 H40,Kansas House of Representatives,40,Democratic,"Johnson, Linda",28,120110
+LEAVENWORTH,South Delaware 2 S3 H40,Kansas House of Representatives,40,Republican,"Bradford, John",54,120110
+LEAVENWORTH,South Delaware 4 S5 H38,Kansas House of Representatives,38,Democratic,"Pringle, Jan",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Kansas House of Representatives,38,Republican,"Dove, Willie",3,120120
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas House of Representatives,40,Democratic,"Johnson, Linda",69,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas House of Representatives,40,Republican,"Bradford, John",119,120130
+LEAVENWORTH,Basehor City Exclave 1,Kansas House of Representatives,38,Democratic,"Pringle, Jan",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Kansas House of Representatives,38,Democratic,"Pringle, Jan",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Kansas House of Representatives,38,Democratic,"Pringle, Jan",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Kansas House of Representatives,38,Libertarian,"Christopher, F Caleb",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,Kansas House of Representatives,42,Democratic,"Harris, Austin Lee",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Kansas House of Representatives,42,Republican,"O'Brien, Connie",0,900080
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",51,000010
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000010
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",228,000010
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Democratic,"Wakefield, Margie",517,000020
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",60,000020
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Republican,"Jenkins, Lynn",1056,000020
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Democratic,"Wakefield, Margie",160,000030
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",31,000030
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",497,000030
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",76,000040
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",26,000040
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",267,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,United States House of Representatives,2,Democratic,"Wakefield, Margie",281,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",42,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",671,000050
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",186,000060
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",37,000060
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",577,000060
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",176,000070
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",38,000070
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",505,000070
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",136,000080
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",34,000080
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",353,000080
+LEAVENWORTH,Lansing Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",185,000090
+LEAVENWORTH,Lansing Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",28,000090
+LEAVENWORTH,Lansing Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",503,000090
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",215,000100
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",33,000100
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",447,000100
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",213,000110
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",43,000110
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",472,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",85,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",51,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",68,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",110,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",158,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",131,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",160,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",60,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",75,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",72,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",138,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",277,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",72,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",196,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",142,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",201,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",106,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",95,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",148,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",30,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",343,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",167,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",391,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",70,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",35,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",284,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",42,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",600,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",356,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",41,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",714,00029A
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",291,000320
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",36,000320
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",601,000320
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,000340
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000340
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000340
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Democratic,"Wakefield, Margie",160,000350
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,000350
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",396,000350
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Democratic,"Wakefield, Margie",226,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",44,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Republican,"Jenkins, Lynn",492,000360
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Democratic,"Wakefield, Margie",206,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",34,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Republican,"Jenkins, Lynn",308,000370
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",268,000380
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",40,000380
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",560,000380
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Democratic,"Wakefield, Margie",140,000390
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000390
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",286,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Republican,"Jenkins, Lynn",34,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Democratic,"Wakefield, Margie",2,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",21,120050
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120060
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120060
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120060
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120070
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120070
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120070
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Democratic,"Wakefield, Margie",39,120080
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120080
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,120080
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Democratic,"Wakefield, Margie",194,120090
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,120090
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",286,120090
+LEAVENWORTH,South Delaware 3 S3 H38,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,120100
+LEAVENWORTH,South Delaware 2 S3 H40,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,120110
+LEAVENWORTH,South Delaware 4 S5 H38,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",3,120120
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Democratic,"Wakefield, Margie",41,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,120130
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900080
+LEAVENWORTH,Alexandria Township,Attorney General,,Democratic,"Kotich, A.J.",72,000010
+LEAVENWORTH,Alexandria Township,Attorney General,,Republican,"Schmidt, Derek",209,000010
+LEAVENWORTH,Basehor City,Attorney General,,Democratic,"Kotich, A.J.",574,000020
+LEAVENWORTH,Basehor City,Attorney General,,Republican,"Schmidt, Derek",1013,000020
+LEAVENWORTH,Basehor Township Voting District,Attorney General,,Democratic,"Kotich, A.J.",198,000030
+LEAVENWORTH,Basehor Township Voting District,Attorney General,,Republican,"Schmidt, Derek",476,000030
+LEAVENWORTH,Easton Township,Attorney General,,Democratic,"Kotich, A.J.",115,000040
+LEAVENWORTH,Easton Township,Attorney General,,Republican,"Schmidt, Derek",237,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,Attorney General,,Democratic,"Kotich, A.J.",340,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Attorney General,,Republican,"Schmidt, Derek",638,000050
+LEAVENWORTH,High Prairie Township,Attorney General,,Democratic,"Kotich, A.J.",228,000060
+LEAVENWORTH,High Prairie Township,Attorney General,,Republican,"Schmidt, Derek",555,000060
+LEAVENWORTH,Kickapoo Township,Attorney General,,Democratic,"Kotich, A.J.",200,000070
+LEAVENWORTH,Kickapoo Township,Attorney General,,Republican,"Schmidt, Derek",496,000070
+LEAVENWORTH,Lansing Ward 1,Attorney General,,Democratic,"Kotich, A.J.",185,000080
+LEAVENWORTH,Lansing Ward 1,Attorney General,,Republican,"Schmidt, Derek",324,000080
+LEAVENWORTH,Lansing Ward 2,Attorney General,,Democratic,"Kotich, A.J.",200,000090
+LEAVENWORTH,Lansing Ward 2,Attorney General,,Republican,"Schmidt, Derek",503,000090
+LEAVENWORTH,Lansing Ward 3,Attorney General,,Democratic,"Kotich, A.J.",251,000100
+LEAVENWORTH,Lansing Ward 3,Attorney General,,Republican,"Schmidt, Derek",445,000100
+LEAVENWORTH,Lansing Ward 4,Attorney General,,Democratic,"Kotich, A.J.",259,000110
+LEAVENWORTH,Lansing Ward 4,Attorney General,,Republican,"Schmidt, Derek",454,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",95,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",93,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",63,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",89,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",77,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",129,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",132,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",147,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",146,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",163,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",72,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",71,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",85,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",130,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",104,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",118,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",145,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",285,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",78,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",198,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",156,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",200,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",127,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",112,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",119,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",151,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",187,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Attorney General,,Republican,"Schmidt, Derek",329,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",196,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Attorney General,,Republican,"Schmidt, Derek",370,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",73,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",38,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",326,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",574,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",385,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",701,00029A
+LEAVENWORTH,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",336,000320
+LEAVENWORTH,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",576,000320
+LEAVENWORTH,South Delaware 2,Attorney General,,Democratic,"Kotich, A.J.",0,000340
+LEAVENWORTH,South Delaware 2,Attorney General,,Republican,"Schmidt, Derek",0,000340
+LEAVENWORTH,Stranger Township Voting District,Attorney General,,Democratic,"Kotich, A.J.",191,000350
+LEAVENWORTH,Stranger Township Voting District,Attorney General,,Republican,"Schmidt, Derek",382,000350
+LEAVENWORTH,Tonganoxie North Precinct,Attorney General,,Democratic,"Kotich, A.J.",270,000360
+LEAVENWORTH,Tonganoxie North Precinct,Attorney General,,Republican,"Schmidt, Derek",478,000360
+LEAVENWORTH,Tonganoxie South Precinct,Attorney General,,Democratic,"Kotich, A.J.",225,000370
+LEAVENWORTH,Tonganoxie South Precinct,Attorney General,,Republican,"Schmidt, Derek",310,000370
+LEAVENWORTH,Tonganoxie Township,Attorney General,,Democratic,"Kotich, A.J.",303,000380
+LEAVENWORTH,Tonganoxie Township,Attorney General,,Republican,"Schmidt, Derek",556,000380
+LEAVENWORTH,Walnut Township Voting District,Attorney General,,Democratic,"Kotich, A.J.",162,000390
+LEAVENWORTH,Walnut Township Voting District,Attorney General,,Republican,"Schmidt, Derek",255,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Attorney General,,Democratic,"Kotich, A.J.",13,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Attorney General,,Republican,"Schmidt, Derek",38,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Attorney General,,Democratic,"Kotich, A.J.",1,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Attorney General,,Republican,"Schmidt, Derek",21,120050
+LEAVENWORTH,Missouri River H41,Attorney General,,Democratic,"Kotich, A.J.",0,120060
+LEAVENWORTH,Missouri River H41,Attorney General,,Republican,"Schmidt, Derek",0,120060
+LEAVENWORTH,Missouri River H42,Attorney General,,Democratic,"Kotich, A.J.",0,120070
+LEAVENWORTH,Missouri River H42,Attorney General,,Republican,"Schmidt, Derek",0,120070
+LEAVENWORTH,Reno Township H38,Attorney General,,Democratic,"Kotich, A.J.",38,120080
+LEAVENWORTH,Reno Township H38,Attorney General,,Republican,"Schmidt, Derek",60,120080
+LEAVENWORTH,Reno Township H42,Attorney General,,Democratic,"Kotich, A.J.",222,120090
+LEAVENWORTH,Reno Township H42,Attorney General,,Republican,"Schmidt, Derek",272,120090
+LEAVENWORTH,South Delaware 3 S3 H38,Attorney General,,Democratic,"Kotich, A.J.",26,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Attorney General,,Republican,"Schmidt, Derek",86,120100
+LEAVENWORTH,South Delaware 2 S3 H40,Attorney General,,Democratic,"Kotich, A.J.",24,120110
+LEAVENWORTH,South Delaware 2 S3 H40,Attorney General,,Republican,"Schmidt, Derek",55,120110
+LEAVENWORTH,South Delaware 4 S5 H38,Attorney General,,Democratic,"Kotich, A.J.",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Attorney General,,Republican,"Schmidt, Derek",3,120120
+LEAVENWORTH,South Delaware 1 S5 H40,Attorney General,,Democratic,"Kotich, A.J.",54,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Attorney General,,Republican,"Schmidt, Derek",134,120130
+LEAVENWORTH,Basehor City Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Attorney General,,Republican,"Schmidt, Derek",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900080
+LEAVENWORTH,Alexandria Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000010
+LEAVENWORTH,Alexandria Township,Commissioner of Insurance,,Republican,"Selzer, Ken",198,000010
+LEAVENWORTH,Basehor City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",627,000020
+LEAVENWORTH,Basehor City,Commissioner of Insurance,,Republican,"Selzer, Ken",952,000020
+LEAVENWORTH,Basehor Township Voting District,Commissioner of Insurance,,Democratic,"Anderson, Dennis",221,000030
+LEAVENWORTH,Basehor Township Voting District,Commissioner of Insurance,,Republican,"Selzer, Ken",454,000030
+LEAVENWORTH,Easton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",127,000040
+LEAVENWORTH,Easton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",232,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,Commissioner of Insurance,,Democratic,"Anderson, Dennis",358,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Commissioner of Insurance,,Republican,"Selzer, Ken",608,000050
+LEAVENWORTH,High Prairie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",238,000060
+LEAVENWORTH,High Prairie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",540,000060
+LEAVENWORTH,Kickapoo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",220,000070
+LEAVENWORTH,Kickapoo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",480,000070
+LEAVENWORTH,Lansing Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",205,000080
+LEAVENWORTH,Lansing Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",307,000080
+LEAVENWORTH,Lansing Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",225,000090
+LEAVENWORTH,Lansing Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",479,000090
+LEAVENWORTH,Lansing Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",261,000100
+LEAVENWORTH,Lansing Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",428,000100
+LEAVENWORTH,Lansing Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",258,000110
+LEAVENWORTH,Lansing Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",448,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",112,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",76,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",89,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",141,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",136,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",158,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",146,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",79,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",116,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",94,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",124,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",168,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",262,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",100,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",177,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",163,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",189,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",131,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",124,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",143,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",204,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",306,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",197,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",366,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",78,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",30,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",354,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",542,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",404,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",676,00029A
+LEAVENWORTH,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",369,000320
+LEAVENWORTH,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",536,000320
+LEAVENWORTH,South Delaware 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000340
+LEAVENWORTH,South Delaware 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000340
+LEAVENWORTH,Stranger Township Voting District,Commissioner of Insurance,,Democratic,"Anderson, Dennis",209,000350
+LEAVENWORTH,Stranger Township Voting District,Commissioner of Insurance,,Republican,"Selzer, Ken",361,000350
+LEAVENWORTH,Tonganoxie North Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",289,000360
+LEAVENWORTH,Tonganoxie North Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",454,000360
+LEAVENWORTH,Tonganoxie South Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",248,000370
+LEAVENWORTH,Tonganoxie South Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",285,000370
+LEAVENWORTH,Tonganoxie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",319,000380
+LEAVENWORTH,Tonganoxie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",533,000380
+LEAVENWORTH,Walnut Township Voting District,Commissioner of Insurance,,Democratic,"Anderson, Dennis",172,000390
+LEAVENWORTH,Walnut Township Voting District,Commissioner of Insurance,,Republican,"Selzer, Ken",247,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Commissioner of Insurance,,Republican,"Selzer, Ken",36,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Commissioner of Insurance,,Republican,"Selzer, Ken",20,120050
+LEAVENWORTH,Missouri River H41,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120060
+LEAVENWORTH,Missouri River H41,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120060
+LEAVENWORTH,Missouri River H42,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120070
+LEAVENWORTH,Missouri River H42,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120070
+LEAVENWORTH,Reno Township H38,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,120080
+LEAVENWORTH,Reno Township H38,Commissioner of Insurance,,Republican,"Selzer, Ken",56,120080
+LEAVENWORTH,Reno Township H42,Commissioner of Insurance,,Democratic,"Anderson, Dennis",220,120090
+LEAVENWORTH,Reno Township H42,Commissioner of Insurance,,Republican,"Selzer, Ken",271,120090
+LEAVENWORTH,South Delaware 3 S3 H38,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Commissioner of Insurance,,Republican,"Selzer, Ken",83,120100
+LEAVENWORTH,South Delaware 2 S3 H40,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,120110
+LEAVENWORTH,South Delaware 2 S3 H40,Commissioner of Insurance,,Republican,"Selzer, Ken",55,120110
+LEAVENWORTH,South Delaware 4 S5 H38,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Commissioner of Insurance,,Republican,"Selzer, Ken",3,120120
+LEAVENWORTH,South Delaware 1 S5 H40,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Commissioner of Insurance,,Republican,"Selzer, Ken",128,120130
+LEAVENWORTH,Basehor City Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900080
+LEAVENWORTH,Alexandria Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000010
+LEAVENWORTH,Alexandria Township,Secretary of State,,Republican,"Kobach, Kris",212,000010
+LEAVENWORTH,Basehor City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",587,000020
+LEAVENWORTH,Basehor City,Secretary of State,,Republican,"Kobach, Kris",1035,000020
+LEAVENWORTH,Basehor Township Voting District,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",192,000030
+LEAVENWORTH,Basehor Township Voting District,Secretary of State,,Republican,"Kobach, Kris",491,000030
+LEAVENWORTH,Easton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",116,000040
+LEAVENWORTH,Easton Township,Secretary of State,,Republican,"Kobach, Kris",248,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",332,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Secretary of State,,Republican,"Kobach, Kris",658,000050
+LEAVENWORTH,High Prairie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",240,000060
+LEAVENWORTH,High Prairie Township,Secretary of State,,Republican,"Kobach, Kris",552,000060
+LEAVENWORTH,Kickapoo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",222,000070
+LEAVENWORTH,Kickapoo Township,Secretary of State,,Republican,"Kobach, Kris",490,000070
+LEAVENWORTH,Lansing Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",178,000080
+LEAVENWORTH,Lansing Ward 1,Secretary of State,,Republican,"Kobach, Kris",338,000080
+LEAVENWORTH,Lansing Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",208,000090
+LEAVENWORTH,Lansing Ward 2,Secretary of State,,Republican,"Kobach, Kris",504,000090
+LEAVENWORTH,Lansing Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",268,000100
+LEAVENWORTH,Lansing Ward 3,Secretary of State,,Republican,"Kobach, Kris",435,000100
+LEAVENWORTH,Lansing Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",269,000110
+LEAVENWORTH,Lansing Ward 4,Secretary of State,,Republican,"Kobach, Kris",453,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",101,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",86,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",88,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",83,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",127,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",132,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",148,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",147,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",165,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",78,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",91,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",123,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",126,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",168,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",266,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",97,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",186,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",164,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",193,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",128,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",118,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",127,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",144,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",199,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Secretary of State,,Republican,"Kobach, Kris",316,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",203,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Secretary of State,,Republican,"Kobach, Kris",369,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",85,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",27,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",367,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",546,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",434,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",662,00029A
+LEAVENWORTH,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",333,000320
+LEAVENWORTH,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",593,000320
+LEAVENWORTH,South Delaware 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000340
+LEAVENWORTH,South Delaware 2,Secretary of State,,Republican,"Kobach, Kris",0,000340
+LEAVENWORTH,Stranger Township Voting District,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",188,000350
+LEAVENWORTH,Stranger Township Voting District,Secretary of State,,Republican,"Kobach, Kris",386,000350
+LEAVENWORTH,Tonganoxie North Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",271,000360
+LEAVENWORTH,Tonganoxie North Precinct,Secretary of State,,Republican,"Kobach, Kris",487,000360
+LEAVENWORTH,Tonganoxie South Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",239,000370
+LEAVENWORTH,Tonganoxie South Precinct,Secretary of State,,Republican,"Kobach, Kris",309,000370
+LEAVENWORTH,Tonganoxie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",307,000380
+LEAVENWORTH,Tonganoxie Township,Secretary of State,,Republican,"Kobach, Kris",565,000380
+LEAVENWORTH,Walnut Township Voting District,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",164,000390
+LEAVENWORTH,Walnut Township Voting District,Secretary of State,,Republican,"Kobach, Kris",265,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Secretary of State,,Republican,"Kobach, Kris",35,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Secretary of State,,Republican,"Kobach, Kris",21,120050
+LEAVENWORTH,Missouri River H41,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120060
+LEAVENWORTH,Missouri River H41,Secretary of State,,Republican,"Kobach, Kris",0,120060
+LEAVENWORTH,Missouri River H42,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120070
+LEAVENWORTH,Missouri River H42,Secretary of State,,Republican,"Kobach, Kris",0,120070
+LEAVENWORTH,Reno Township H38,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,120080
+LEAVENWORTH,Reno Township H38,Secretary of State,,Republican,"Kobach, Kris",59,120080
+LEAVENWORTH,Reno Township H42,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",228,120090
+LEAVENWORTH,Reno Township H42,Secretary of State,,Republican,"Kobach, Kris",265,120090
+LEAVENWORTH,South Delaware 3 S3 H38,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Secretary of State,,Republican,"Kobach, Kris",84,120100
+LEAVENWORTH,South Delaware 2 S3 H40,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,120110
+LEAVENWORTH,South Delaware 2 S3 H40,Secretary of State,,Republican,"Kobach, Kris",58,120110
+LEAVENWORTH,South Delaware 4 S5 H38,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Secretary of State,,Republican,"Kobach, Kris",3,120120
+LEAVENWORTH,South Delaware 1 S5 H40,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Secretary of State,,Republican,"Kobach, Kris",134,120130
+LEAVENWORTH,Basehor City Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Secretary of State,,Republican,"Kobach, Kris",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900080
+LEAVENWORTH,Alexandria Township,State Treasurer,,Democratic,"Alldritt, Carmen",69,000010
+LEAVENWORTH,Alexandria Township,State Treasurer,,Republican,"Estes, Ron",215,000010
+LEAVENWORTH,Basehor City,State Treasurer,,Democratic,"Alldritt, Carmen",538,000020
+LEAVENWORTH,Basehor City,State Treasurer,,Republican,"Estes, Ron",1049,000020
+LEAVENWORTH,Basehor Township Voting District,State Treasurer,,Democratic,"Alldritt, Carmen",196,000030
+LEAVENWORTH,Basehor Township Voting District,State Treasurer,,Republican,"Estes, Ron",485,000030
+LEAVENWORTH,Easton Township,State Treasurer,,Democratic,"Alldritt, Carmen",116,000040
+LEAVENWORTH,Easton Township,State Treasurer,,Republican,"Estes, Ron",242,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,State Treasurer,,Democratic,"Alldritt, Carmen",308,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,State Treasurer,,Republican,"Estes, Ron",667,000050
+LEAVENWORTH,High Prairie Township,State Treasurer,,Democratic,"Alldritt, Carmen",214,000060
+LEAVENWORTH,High Prairie Township,State Treasurer,,Republican,"Estes, Ron",568,000060
+LEAVENWORTH,Kickapoo Township,State Treasurer,,Democratic,"Alldritt, Carmen",204,000070
+LEAVENWORTH,Kickapoo Township,State Treasurer,,Republican,"Estes, Ron",501,000070
+LEAVENWORTH,Lansing Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",177,000080
+LEAVENWORTH,Lansing Ward 1,State Treasurer,,Republican,"Estes, Ron",337,000080
+LEAVENWORTH,Lansing Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",193,000090
+LEAVENWORTH,Lansing Ward 2,State Treasurer,,Republican,"Estes, Ron",511,000090
+LEAVENWORTH,Lansing Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",240,000100
+LEAVENWORTH,Lansing Ward 3,State Treasurer,,Republican,"Estes, Ron",452,000100
+LEAVENWORTH,Lansing Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",241,000110
+LEAVENWORTH,Lansing Ward 4,State Treasurer,,Republican,"Estes, Ron",471,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",105,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",84,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",61,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",90,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",73,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",136,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",125,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,State Treasurer,,Republican,"Estes, Ron",151,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",134,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",175,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",67,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",78,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",87,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,State Treasurer,,Republican,"Estes, Ron",125,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",92,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,State Treasurer,,Republican,"Estes, Ron",130,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",149,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,State Treasurer,,Republican,"Estes, Ron",287,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",87,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,State Treasurer,,Republican,"Estes, Ron",194,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",145,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,State Treasurer,,Republican,"Estes, Ron",212,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",123,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,State Treasurer,,Republican,"Estes, Ron",120,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",110,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,State Treasurer,,Republican,"Estes, Ron",157,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",180,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,State Treasurer,,Republican,"Estes, Ron",334,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",179,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,State Treasurer,,Republican,"Estes, Ron",386,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",71,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,State Treasurer,,Republican,"Estes, Ron",37,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",319,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,State Treasurer,,Republican,"Estes, Ron",582,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",372,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,State Treasurer,,Republican,"Estes, Ron",709,00029A
+LEAVENWORTH,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",336,000320
+LEAVENWORTH,Sherman Township,State Treasurer,,Republican,"Estes, Ron",574,000320
+LEAVENWORTH,South Delaware 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,000340
+LEAVENWORTH,South Delaware 2,State Treasurer,,Republican,"Estes, Ron",0,000340
+LEAVENWORTH,Stranger Township Voting District,State Treasurer,,Democratic,"Alldritt, Carmen",173,000350
+LEAVENWORTH,Stranger Township Voting District,State Treasurer,,Republican,"Estes, Ron",392,000350
+LEAVENWORTH,Tonganoxie North Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",261,000360
+LEAVENWORTH,Tonganoxie North Precinct,State Treasurer,,Republican,"Estes, Ron",482,000360
+LEAVENWORTH,Tonganoxie South Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",222,000370
+LEAVENWORTH,Tonganoxie South Precinct,State Treasurer,,Republican,"Estes, Ron",315,000370
+LEAVENWORTH,Tonganoxie Township,State Treasurer,,Democratic,"Alldritt, Carmen",309,000380
+LEAVENWORTH,Tonganoxie Township,State Treasurer,,Republican,"Estes, Ron",551,000380
+LEAVENWORTH,Walnut Township Voting District,State Treasurer,,Democratic,"Alldritt, Carmen",155,000390
+LEAVENWORTH,Walnut Township Voting District,State Treasurer,,Republican,"Estes, Ron",265,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,State Treasurer,,Democratic,"Alldritt, Carmen",13,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,State Treasurer,,Republican,"Estes, Ron",38,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,State Treasurer,,Democratic,"Alldritt, Carmen",2,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,State Treasurer,,Republican,"Estes, Ron",20,120050
+LEAVENWORTH,Missouri River H41,State Treasurer,,Democratic,"Alldritt, Carmen",0,120060
+LEAVENWORTH,Missouri River H41,State Treasurer,,Republican,"Estes, Ron",0,120060
+LEAVENWORTH,Missouri River H42,State Treasurer,,Democratic,"Alldritt, Carmen",0,120070
+LEAVENWORTH,Missouri River H42,State Treasurer,,Republican,"Estes, Ron",0,120070
+LEAVENWORTH,Reno Township H38,State Treasurer,,Democratic,"Alldritt, Carmen",40,120080
+LEAVENWORTH,Reno Township H38,State Treasurer,,Republican,"Estes, Ron",58,120080
+LEAVENWORTH,Reno Township H42,State Treasurer,,Democratic,"Alldritt, Carmen",208,120090
+LEAVENWORTH,Reno Township H42,State Treasurer,,Republican,"Estes, Ron",287,120090
+LEAVENWORTH,South Delaware 3 S3 H38,State Treasurer,,Democratic,"Alldritt, Carmen",20,120100
+LEAVENWORTH,South Delaware 3 S3 H38,State Treasurer,,Republican,"Estes, Ron",90,120100
+LEAVENWORTH,South Delaware 2 S3 H40,State Treasurer,,Democratic,"Alldritt, Carmen",23,120110
+LEAVENWORTH,South Delaware 2 S3 H40,State Treasurer,,Republican,"Estes, Ron",55,120110
+LEAVENWORTH,South Delaware 4 S5 H38,State Treasurer,,Democratic,"Alldritt, Carmen",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,State Treasurer,,Republican,"Estes, Ron",3,120120
+LEAVENWORTH,South Delaware 1 S5 H40,State Treasurer,,Democratic,"Alldritt, Carmen",52,120130
+LEAVENWORTH,South Delaware 1 S5 H40,State Treasurer,,Republican,"Estes, Ron",135,120130
+LEAVENWORTH,Basehor City Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+LEAVENWORTH,Basehor City Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900010
+LEAVENWORTH,Basehor City Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+LEAVENWORTH,Basehor City Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900020
+LEAVENWORTH,Basehor City Exclave 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+LEAVENWORTH,Basehor City Exclave 3,State Treasurer,,Republican,"Estes, Ron",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,State Treasurer,,Republican,"Estes, Ron",0,900080
+LEAVENWORTH,Alexandria Township,United States Senate,,independent,"Orman, Greg",84,000010
+LEAVENWORTH,Alexandria Township,United States Senate,,Libertarian,"Batson, Randall",20,000010
+LEAVENWORTH,Alexandria Township,United States Senate,,Republican,"Roberts, Pat",187,000010
+LEAVENWORTH,Basehor City,United States Senate,,independent,"Orman, Greg",732,000020
+LEAVENWORTH,Basehor City,United States Senate,,Libertarian,"Batson, Randall",57,000020
+LEAVENWORTH,Basehor City,United States Senate,,Republican,"Roberts, Pat",842,000020
+LEAVENWORTH,Basehor Township Voting District,United States Senate,,independent,"Orman, Greg",237,000030
+LEAVENWORTH,Basehor Township Voting District,United States Senate,,Libertarian,"Batson, Randall",29,000030
+LEAVENWORTH,Basehor Township Voting District,United States Senate,,Republican,"Roberts, Pat",419,000030
+LEAVENWORTH,Easton Township,United States Senate,,independent,"Orman, Greg",140,000040
+LEAVENWORTH,Easton Township,United States Senate,,Libertarian,"Batson, Randall",24,000040
+LEAVENWORTH,Easton Township,United States Senate,,Republican,"Roberts, Pat",204,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,United States Senate,,independent,"Orman, Greg",400,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States Senate,,Libertarian,"Batson, Randall",34,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States Senate,,Republican,"Roberts, Pat",558,000050
+LEAVENWORTH,High Prairie Township,United States Senate,,independent,"Orman, Greg",291,000060
+LEAVENWORTH,High Prairie Township,United States Senate,,Libertarian,"Batson, Randall",28,000060
+LEAVENWORTH,High Prairie Township,United States Senate,,Republican,"Roberts, Pat",476,000060
+LEAVENWORTH,Kickapoo Township,United States Senate,,independent,"Orman, Greg",260,000070
+LEAVENWORTH,Kickapoo Township,United States Senate,,Libertarian,"Batson, Randall",18,000070
+LEAVENWORTH,Kickapoo Township,United States Senate,,Republican,"Roberts, Pat",438,000070
+LEAVENWORTH,Lansing Ward 1,United States Senate,,independent,"Orman, Greg",215,000080
+LEAVENWORTH,Lansing Ward 1,United States Senate,,Libertarian,"Batson, Randall",39,000080
+LEAVENWORTH,Lansing Ward 1,United States Senate,,Republican,"Roberts, Pat",270,000080
+LEAVENWORTH,Lansing Ward 2,United States Senate,,independent,"Orman, Greg",264,000090
+LEAVENWORTH,Lansing Ward 2,United States Senate,,Libertarian,"Batson, Randall",25,000090
+LEAVENWORTH,Lansing Ward 2,United States Senate,,Republican,"Roberts, Pat",428,000090
+LEAVENWORTH,Lansing Ward 3,United States Senate,,independent,"Orman, Greg",299,000100
+LEAVENWORTH,Lansing Ward 3,United States Senate,,Libertarian,"Batson, Randall",39,000100
+LEAVENWORTH,Lansing Ward 3,United States Senate,,Republican,"Roberts, Pat",360,000100
+LEAVENWORTH,Lansing Ward 4,United States Senate,,independent,"Orman, Greg",304,000110
+LEAVENWORTH,Lansing Ward 4,United States Senate,,Libertarian,"Batson, Randall",40,000110
+LEAVENWORTH,Lansing Ward 4,United States Senate,,Republican,"Roberts, Pat",382,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",114,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",9,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",64,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",71,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",10,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",76,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",107,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",14,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",92,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States Senate,,independent,"Orman, Greg",133,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",19,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States Senate,,Republican,"Roberts, Pat",126,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",163,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",27,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",121,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",74,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",12,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",59,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States Senate,,independent,"Orman, Greg",95,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",11,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States Senate,,Republican,"Roberts, Pat",110,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States Senate,,independent,"Orman, Greg",97,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",25,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States Senate,,Republican,"Roberts, Pat",98,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States Senate,,independent,"Orman, Greg",196,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",38,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States Senate,,Republican,"Roberts, Pat",203,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States Senate,,independent,"Orman, Greg",105,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",22,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States Senate,,Republican,"Roberts, Pat",155,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States Senate,,independent,"Orman, Greg",180,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",15,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States Senate,,Republican,"Roberts, Pat",157,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States Senate,,independent,"Orman, Greg",146,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",11,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States Senate,,Republican,"Roberts, Pat",92,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States Senate,,independent,"Orman, Greg",136,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",17,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States Senate,,Republican,"Roberts, Pat",120,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States Senate,,independent,"Orman, Greg",224,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States Senate,,Libertarian,"Batson, Randall",25,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States Senate,,Republican,"Roberts, Pat",271,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States Senate,,independent,"Orman, Greg",250,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States Senate,,Libertarian,"Batson, Randall",19,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States Senate,,Republican,"Roberts, Pat",306,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States Senate,,independent,"Orman, Greg",78,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",6,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States Senate,,Republican,"Roberts, Pat",26,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States Senate,,independent,"Orman, Greg",401,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",36,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States Senate,,Republican,"Roberts, Pat",475,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States Senate,,independent,"Orman, Greg",490,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",37,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States Senate,,Republican,"Roberts, Pat",580,00029A
+LEAVENWORTH,Sherman Township,United States Senate,,independent,"Orman, Greg",413,000320
+LEAVENWORTH,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",37,000320
+LEAVENWORTH,Sherman Township,United States Senate,,Republican,"Roberts, Pat",479,000320
+LEAVENWORTH,South Delaware 2,United States Senate,,independent,"Orman, Greg",0,000340
+LEAVENWORTH,South Delaware 2,United States Senate,,Libertarian,"Batson, Randall",0,000340
+LEAVENWORTH,South Delaware 2,United States Senate,,Republican,"Roberts, Pat",0,000340
+LEAVENWORTH,Stranger Township Voting District,United States Senate,,independent,"Orman, Greg",227,000350
+LEAVENWORTH,Stranger Township Voting District,United States Senate,,Libertarian,"Batson, Randall",21,000350
+LEAVENWORTH,Stranger Township Voting District,United States Senate,,Republican,"Roberts, Pat",330,000350
+LEAVENWORTH,Tonganoxie North Precinct,United States Senate,,independent,"Orman, Greg",329,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States Senate,,Libertarian,"Batson, Randall",35,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States Senate,,Republican,"Roberts, Pat",401,000360
+LEAVENWORTH,Tonganoxie South Precinct,United States Senate,,independent,"Orman, Greg",271,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States Senate,,Libertarian,"Batson, Randall",19,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States Senate,,Republican,"Roberts, Pat",259,000370
+LEAVENWORTH,Tonganoxie Township,United States Senate,,independent,"Orman, Greg",370,000380
+LEAVENWORTH,Tonganoxie Township,United States Senate,,Libertarian,"Batson, Randall",38,000380
+LEAVENWORTH,Tonganoxie Township,United States Senate,,Republican,"Roberts, Pat",460,000380
+LEAVENWORTH,Walnut Township Voting District,United States Senate,,independent,"Orman, Greg",201,000390
+LEAVENWORTH,Walnut Township Voting District,United States Senate,,Libertarian,"Batson, Randall",12,000390
+LEAVENWORTH,Walnut Township Voting District,United States Senate,,Republican,"Roberts, Pat",219,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States Senate,,independent,"Orman, Greg",22,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States Senate,,Libertarian,"Batson, Randall",4,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States Senate,,Republican,"Roberts, Pat",27,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States Senate,,independent,"Orman, Greg",4,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States Senate,,Libertarian,"Batson, Randall",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States Senate,,Republican,"Roberts, Pat",19,120050
+LEAVENWORTH,Missouri River H41,United States Senate,,independent,"Orman, Greg",0,120060
+LEAVENWORTH,Missouri River H41,United States Senate,,Libertarian,"Batson, Randall",0,120060
+LEAVENWORTH,Missouri River H41,United States Senate,,Republican,"Roberts, Pat",0,120060
+LEAVENWORTH,Missouri River H42,United States Senate,,independent,"Orman, Greg",0,120070
+LEAVENWORTH,Missouri River H42,United States Senate,,Libertarian,"Batson, Randall",0,120070
+LEAVENWORTH,Missouri River H42,United States Senate,,Republican,"Roberts, Pat",0,120070
+LEAVENWORTH,Reno Township H38,United States Senate,,independent,"Orman, Greg",50,120080
+LEAVENWORTH,Reno Township H38,United States Senate,,Libertarian,"Batson, Randall",4,120080
+LEAVENWORTH,Reno Township H38,United States Senate,,Republican,"Roberts, Pat",47,120080
+LEAVENWORTH,Reno Township H42,United States Senate,,independent,"Orman, Greg",251,120090
+LEAVENWORTH,Reno Township H42,United States Senate,,Libertarian,"Batson, Randall",12,120090
+LEAVENWORTH,Reno Township H42,United States Senate,,Republican,"Roberts, Pat",235,120090
+LEAVENWORTH,South Delaware 3 S3 H38,United States Senate,,independent,"Orman, Greg",36,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States Senate,,Libertarian,"Batson, Randall",4,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States Senate,,Republican,"Roberts, Pat",72,120100
+LEAVENWORTH,South Delaware 2 S3 H40,United States Senate,,independent,"Orman, Greg",32,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States Senate,,Libertarian,"Batson, Randall",1,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States Senate,,Republican,"Roberts, Pat",49,120110
+LEAVENWORTH,South Delaware 4 S5 H38,United States Senate,,independent,"Orman, Greg",1,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States Senate,,Libertarian,"Batson, Randall",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States Senate,,Republican,"Roberts, Pat",2,120120
+LEAVENWORTH,South Delaware 1 S5 H40,United States Senate,,independent,"Orman, Greg",68,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States Senate,,Libertarian,"Batson, Randall",7,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States Senate,,Republican,"Roberts, Pat",117,120130
+LEAVENWORTH,Basehor City Exclave 1,United States Senate,,independent,"Orman, Greg",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900010
+LEAVENWORTH,Basehor City Exclave 2,United States Senate,,independent,"Orman, Greg",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900020
+LEAVENWORTH,Basehor City Exclave 3,United States Senate,,independent,"Orman, Greg",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States Senate,,Libertarian,"Batson, Randall",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States Senate,,Republican,"Roberts, Pat",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,United States Senate,,independent,"Orman, Greg",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States Senate,,Republican,"Roberts, Pat",0,900080

--- a/2014/20141104__ks__general__lincoln__precinct.csv
+++ b/2014/20141104__ks__general__lincoln__precinct.csv
@@ -1,383 +1,409 @@
-county,precinct,office,district,party,candidate,vote
-Lincoln,Battle Creek Township,U.S. Senate,,R,Pat Roberts,13
-Lincoln,Beaver Township,U.S. Senate,,R,Pat Roberts,18
-Lincoln,Cedron Township,U.S. Senate,,R,Pat Roberts,14
-Lincoln,Colorado Township,U.S. Senate,,R,Pat Roberts,65
-Lincoln,Elkhorn Township,U.S. Senate,,R,Pat Roberts,50
-Lincoln,Franklin Township,U.S. Senate,,R,Pat Roberts,32
-Lincoln,Golden Belt Township,U.S. Senate,,R,Pat Roberts,15
-Lincoln,Grant Township,U.S. Senate,,R,Pat Roberts,24
-Lincoln,Hanover Township,U.S. Senate,,R,Pat Roberts,13
-Lincoln,Highland Township,U.S. Senate,,R,Pat Roberts,22
-Lincoln,Indiana Township,U.S. Senate,,R,Pat Roberts,24
-Lincoln,Lincoln Precinct 1,U.S. Senate,,R,Pat Roberts,122
-Lincoln,Lincoln Precinct 2,U.S. Senate,,R,Pat Roberts,144
-Lincoln,Logan Township,U.S. Senate,,R,Pat Roberts,25
-Lincoln,Madison Township,U.S. Senate,,R,Pat Roberts,25
-Lincoln,Marion Township,U.S. Senate,,R,Pat Roberts,8
-Lincoln,Orange Township,U.S. Senate,,R,Pat Roberts,19
-Lincoln,Pleasant Township,U.S. Senate,,R,Pat Roberts,100
-Lincoln,Salt Creek Township,U.S. Senate,,R,Pat Roberts,18
-Lincoln,Scott Township,U.S. Senate,,R,Pat Roberts,30
-Lincoln,Valley Township,U.S. Senate,,R,Pat Roberts,14
-Lincoln,Vesper Township,U.S. Senate,,R,Pat Roberts,30
-Lincoln,Battle Creek Township,U.S. Senate,,I,Greg Orman,4
-Lincoln,Beaver Township,U.S. Senate,,I,Greg Orman,6
-Lincoln,Cedron Township,U.S. Senate,,I,Greg Orman,0
-Lincoln,Colorado Township,U.S. Senate,,I,Greg Orman,17
-Lincoln,Elkhorn Township,U.S. Senate,,I,Greg Orman,10
-Lincoln,Franklin Township,U.S. Senate,,I,Greg Orman,12
-Lincoln,Golden Belt Township,U.S. Senate,,I,Greg Orman,11
-Lincoln,Grant Township,U.S. Senate,,I,Greg Orman,7
-Lincoln,Hanover Township,U.S. Senate,,I,Greg Orman,4
-Lincoln,Highland Township,U.S. Senate,,I,Greg Orman,9
-Lincoln,Indiana Township,U.S. Senate,,I,Greg Orman,5
-Lincoln,Lincoln Precinct 1,U.S. Senate,,I,Greg Orman,61
-Lincoln,Lincoln Precinct 2,U.S. Senate,,I,Greg Orman,63
-Lincoln,Logan Township,U.S. Senate,,I,Greg Orman,4
-Lincoln,Madison Township,U.S. Senate,,I,Greg Orman,8
-Lincoln,Marion Township,U.S. Senate,,I,Greg Orman,2
-Lincoln,Orange Township,U.S. Senate,,I,Greg Orman,4
-Lincoln,Pleasant Township,U.S. Senate,,I,Greg Orman,42
-Lincoln,Salt Creek Township,U.S. Senate,,I,Greg Orman,7
-Lincoln,Scott Township,U.S. Senate,,I,Greg Orman,11
-Lincoln,Valley Township,U.S. Senate,,I,Greg Orman,3
-Lincoln,Vesper Township,U.S. Senate,,I,Greg Orman,9
-Lincoln,Battle Creek Township,U.S. Senate,,L,Randall Batson,1
-Lincoln,Beaver Township,U.S. Senate,,L,Randall Batson,0
-Lincoln,Cedron Township,U.S. Senate,,L,Randall Batson,0
-Lincoln,Colorado Township,U.S. Senate,,L,Randall Batson,3
-Lincoln,Elkhorn Township Part A,U.S. Senate,,L,Randall Batson,0
-Lincoln,Franklin Township,U.S. Senate,,L,Randall Batson,3
-Lincoln,Golden Belt Township,U.S. Senate,,L,Randall Batson,1
-Lincoln,Grant Township,U.S. Senate,,L,Randall Batson,1
-Lincoln,Hanover Township,U.S. Senate,,L,Randall Batson,1
-Lincoln,Highland Township,U.S. Senate,,L,Randall Batson,1
-Lincoln,Indiana Township,U.S. Senate,,L,Randall Batson,0
-Lincoln,Lincoln Precinct 1,U.S. Senate,,L,Randall Batson,10
-Lincoln,Lincoln Precinct 2,U.S. Senate,,L,Randall Batson,13
-Lincoln,Logan Township,U.S. Senate,,L,Randall Batson,1
-Lincoln,Madison Township,U.S. Senate,,L,Randall Batson,3
-Lincoln,Marion Township,U.S. Senate,,L,Randall Batson,0
-Lincoln,Orange Township,U.S. Senate,,L,Randall Batson,4
-Lincoln,Pleasant Township,U.S. Senate,,L,Randall Batson,5
-Lincoln,Salt Creek Township,U.S. Senate,,L,Randall Batson,2
-Lincoln,Scott Township,U.S. Senate,,L,Randall Batson,2
-Lincoln,Valley Township,U.S. Senate,,L,Randall Batson,0
-Lincoln,Vesper Township,U.S. Senate,,L,Randall Batson,1
-Lincoln,Battle Creek Township,U.S. House,1,R,Tim Huelskamp,13
-Lincoln,Beaver Township,U.S. House,1,R,Tim Huelskamp,18
-Lincoln,Cedron Township,U.S. House,1,R,Tim Huelskamp,11
-Lincoln,Colorado Township,U.S. House,1,R,Tim Huelskamp,70
-Lincoln,Elkhorn Township,U.S. House,1,R,Tim Huelskamp,50
-Lincoln,Franklin Township,U.S. House,1,R,Tim Huelskamp,34
-Lincoln,Golden Belt Township,U.S. House,1,R,Tim Huelskamp,15
-Lincoln,Grant Township,U.S. House,1,R,Tim Huelskamp,28
-Lincoln,Hanover Township,U.S. House,1,R,Tim Huelskamp,14
-Lincoln,Highland Township,U.S. House,1,R,Tim Huelskamp,23
-Lincoln,Indiana Township,U.S. House,1,R,Tim Huelskamp,24
-Lincoln,Lincoln Precinct 1,U.S. House,1,R,Tim Huelskamp,125
-Lincoln,Lincoln Precinct 2,U.S. House,1,R,Tim Huelskamp,149
-Lincoln,Logan Township,U.S. House,1,R,Tim Huelskamp,26
-Lincoln,Madison Township,U.S. House,1,R,Tim Huelskamp,26
-Lincoln,Marion Township,U.S. House,1,R,Tim Huelskamp,9
-Lincoln,Orange Township,U.S. House,1,R,Tim Huelskamp,22
-Lincoln,Pleasant Township,U.S. House,1,R,Tim Huelskamp,111
-Lincoln,Salt Creek Township,U.S. House,1,R,Tim Huelskamp,17
-Lincoln,Scott Township,U.S. House,1,R,Tim Huelskamp,35
-Lincoln,Valley Township,U.S. House,1,R,Tim Huelskamp,11
-Lincoln,Vesper Township,U.S. House,1,R,Tim Huelskamp,33
-Lincoln,Battle Creek Township,U.S. House,1,D,James Sherow,3
-Lincoln,Beaver Township,U.S. House,1,D,James Sherow,6
-Lincoln,Cedron Township,U.S. House,1,D,James Sherow,3
-Lincoln,Colorado Township,U.S. House,1,D,James Sherow,14
-Lincoln,Elkhorn Township Part A,U.S. House,1,D,James Sherow,8
-Lincoln,Franklin Township,U.S. House,1,D,James Sherow,12
-Lincoln,Golden Belt Township,U.S. House,1,D,James Sherow,11
-Lincoln,Grant Township,U.S. House,1,D,James Sherow,4
-Lincoln,Hanover Township,U.S. House,1,D,James Sherow,4
-Lincoln,Highland Township,U.S. House,1,D,James Sherow,9
-Lincoln,Indiana Township,U.S. House,1,D,James Sherow,6
-Lincoln,Lincoln Precinct 1,U.S. House,1,D,James Sherow,64
-Lincoln,Lincoln Precinct 2,U.S. House,1,D,James Sherow,67
-Lincoln,Logan Township,U.S. House,1,D,James Sherow,4
-Lincoln,Madison Township,U.S. House,1,D,James Sherow,13
-Lincoln,Marion Township,U.S. House,1,D,James Sherow,1
-Lincoln,Orange Township,U.S. House,1,D,James Sherow,4
-Lincoln,Pleasant Township,U.S. House,1,D,James Sherow,35
-Lincoln,Salt Creek Township,U.S. House,1,D,James Sherow,9
-Lincoln,Scott Township,U.S. House,1,D,James Sherow,9
-Lincoln,Valley Township,U.S. House,1,D,James Sherow,6
-Lincoln,Vesper Township,U.S. House,1,D,James Sherow,8
-Lincoln,Battle Creek Township,Governor,,R,Sam Brownback,11
-Lincoln,Beaver Township,Governor,,R,Sam Brownback,13
-Lincoln,Cedron Township,Governor,,R,Sam Brownback,9
-Lincoln,Colorado Township,Governor,,R,Sam Brownback,63
-Lincoln,Elkhorn Township Part A,Governor,,R,Sam Brownback,46
-Lincoln,Franklin Township,Governor,,R,Sam Brownback,32
-Lincoln,Golden Belt Township,Governor,,R,Sam Brownback,15
-Lincoln,Grant Township,Governor,,R,Sam Brownback,22
-Lincoln,Hanover Township,Governor,,R,Sam Brownback,14
-Lincoln,Highland Township,Governor,,R,Sam Brownback,19
-Lincoln,Indiana Township,Governor,,R,Sam Brownback,21
-Lincoln,Lincoln Precinct 1,Governor,,R,Sam Brownback,102
-Lincoln,Lincoln Precinct 2,Governor,,R,Sam Brownback,123
-Lincoln,Logan Township,Governor,,R,Sam Brownback,25
-Lincoln,Madison Township,Governor,,R,Sam Brownback,24
-Lincoln,Marion Township,Governor,,R,Sam Brownback,9
-Lincoln,Orange Township,Governor,,R,Sam Brownback,20
-Lincoln,Pleasant Township,Governor,,R,Sam Brownback,94
-Lincoln,Salt Creek Township,Governor,,R,Sam Brownback,12
-Lincoln,Scott Township,Governor,,R,Sam Brownback,29
-Lincoln,Valley Township,Governor,,R,Sam Brownback,9
-Lincoln,Vesper Township,Governor,,R,Sam Brownback,25
-Lincoln,Battle Creek Township,Governor,,D,Paul Davis,6
-Lincoln,Beaver Township,Governor,,D,Paul Davis,10
-Lincoln,Cedron Township,Governor,,D,Paul Davis,4
-Lincoln,Colorado Township,Governor,,D,Paul Davis,20
-Lincoln,Elkhorn Township Part A,Governor,,D,Paul Davis,12
-Lincoln,Franklin Township,Governor,,D,Paul Davis,13
-Lincoln,Golden Belt Township,Governor,,D,Paul Davis,10
-Lincoln,Grant Township,Governor,,D,Paul Davis,8
-Lincoln,Hanover Township,Governor,,D,Paul Davis,3
-Lincoln,Highland Township,Governor,,D,Paul Davis,12
-Lincoln,Indiana Township,Governor,,D,Paul Davis,6
-Lincoln,Lincoln Precinct 1,Governor,,D,Paul Davis,85
-Lincoln,Lincoln Precinct 2,Governor,,D,Paul Davis,88
-Lincoln,Logan Township,Governor,,D,Paul Davis,4
-Lincoln,Madison Township,Governor,,D,Paul Davis,13
-Lincoln,Marion Township,Governor,,D,Paul Davis,1
-Lincoln,Orange Township,Governor,,D,Paul Davis,5
-Lincoln,Pleasant Township,Governor,,D,Paul Davis,52
-Lincoln,Salt Creek Township,Governor,,D,Paul Davis,12
-Lincoln,Scott Township,Governor,,D,Paul Davis,14
-Lincoln,Valley Township,Governor,,D,Paul Davis,8
-Lincoln,Vesper Township,Governor,,D,Paul Davis,14
-Lincoln,Battle Creek Township,Governor,,L,Keen Umbehr,1
-Lincoln,Beaver Township,Governor,,L,Keen Umbehr,1
-Lincoln,Cedron Township,Governor,,L,Keen Umbehr,1
-Lincoln,Colorado Township,Governor,,L,Keen Umbehr,2
-Lincoln,Elkhorn Township Part A,Governor,,L,Keen Umbehr,2
-Lincoln,Franklin Township,Governor,,L,Keen Umbehr,2
-Lincoln,Golden Belt Township,Governor,,L,Keen Umbehr,0
-Lincoln,Grant Township,Governor,,L,Keen Umbehr,2
-Lincoln,Hanover Township,Governor,,L,Keen Umbehr,1
-Lincoln,Highland Township,Governor,,L,Keen Umbehr,1
-Lincoln,Indiana Township,Governor,,L,Keen Umbehr,2
-Lincoln,Lincoln Precinct 1,Governor,,L,Keen Umbehr,6
-Lincoln,Lincoln Precinct 2,Governor,,L,Keen Umbehr,8
-Lincoln,Logan Township,Governor,,L,Keen Umbehr,1
-Lincoln,Madison Township,Governor,,L,Keen Umbehr,3
-Lincoln,Marion Township,Governor,,L,Keen Umbehr,0
-Lincoln,Orange Township,Governor,,L,Keen Umbehr,2
-Lincoln,Pleasant Township,Governor,,L,Keen Umbehr,2
-Lincoln,Salt Creek Township,Governor,,L,Keen Umbehr,2
-Lincoln,Scott Township,Governor,,L,Keen Umbehr,2
-Lincoln,Valley Township,Governor,,L,Keen Umbehr,0
-Lincoln,Vesper Township,Governor,,L,Keen Umbehr,1
-Lincoln,Battle Creek Township,Secretary of State,,R,Kris Kobach,14
-Lincoln,Beaver Township,Secretary of State,,R,Kris Kobach,17
-Lincoln,Cedron Township,Secretary of State,,R,Kris Kobach,10
-Lincoln,Colorado Township,Secretary of State,,R,Kris Kobach,67
-Lincoln,Elkhorn Township Part A,Secretary of State,,R,Kris Kobach,47
-Lincoln,Franklin Township,Secretary of State,,R,Kris Kobach,35
-Lincoln,Golden Belt Township,Secretary of State,,R,Kris Kobach,16
-Lincoln,Grant Township,Secretary of State,,R,Kris Kobach,25
-Lincoln,Hanover Township,Secretary of State,,R,Kris Kobach,15
-Lincoln,Highland Township,Secretary of State,,R,Kris Kobach,22
-Lincoln,Indiana Township,Secretary of State,,R,Kris Kobach,21
-Lincoln,Lincoln Precinct 1,Secretary of State,,R,Kris Kobach,126
-Lincoln,Lincoln Precinct 2,Secretary of State,,R,Kris Kobach,143
-Lincoln,Logan Township,Secretary of State,,R,Kris Kobach,26
-Lincoln,Madison Township,Secretary of State,,R,Kris Kobach,28
-Lincoln,Marion Township,Secretary of State,,R,Kris Kobach,8
-Lincoln,Orange Township,Secretary of State,,R,Kris Kobach,23
-Lincoln,Pleasant Township,Secretary of State,,R,Kris Kobach,105
-Lincoln,Salt Creek Township,Secretary of State,,R,Kris Kobach,16
-Lincoln,Scott Township,Secretary of State,,R,Kris Kobach,33
-Lincoln,Valley Township,Secretary of State,,R,Kris Kobach,12
-Lincoln,Vesper Township,Secretary of State,,R,Kris Kobach,29
-Lincoln,Battle Creek Township,Secretary of State,,D,Jean Schodorf,3
-Lincoln,Beaver Township,Secretary of State,,D,Jean Schodorf,6
-Lincoln,Cedron Township,Secretary of State,,D,Jean Schodorf,4
-Lincoln,Colorado Township,Secretary of State,,D,Jean Schodorf,17
-Lincoln,Elkhorn Township Part A,Secretary of State,,D,Jean Schodorf,11
-Lincoln,Franklin Township,Secretary of State,,D,Jean Schodorf,12
-Lincoln,Golden Belt Township,Secretary of State,,D,Jean Schodorf,11
-Lincoln,Grant Township,Secretary of State,,D,Jean Schodorf,6
-Lincoln,Hanover Township,Secretary of State,,D,Jean Schodorf,3
-Lincoln,Highland Township,Secretary of State,,D,Jean Schodorf,10
-Lincoln,Indiana Township,Secretary of State,,D,Jean Schodorf,7
-Lincoln,Lincoln Precinct 1,Secretary of State,,D,Jean Schodorf,65
-Lincoln,Lincoln Precinct 2,Secretary of State,,D,Jean Schodorf,76
-Lincoln,Logan Township,Secretary of State,,D,Jean Schodorf,4
-Lincoln,Madison Township,Secretary of State,,D,Jean Schodorf,8
-Lincoln,Marion Township,Secretary of State,,D,Jean Schodorf,2
-Lincoln,Orange Township,Secretary of State,,D,Jean Schodorf,3
-Lincoln,Pleasant Township,Secretary of State,,D,Jean Schodorf,41
-Lincoln,Salt Creek Township,Secretary of State,,D,Jean Schodorf,11
-Lincoln,Scott Township,Secretary of State,,D,Jean Schodorf,10
-Lincoln,Valley Township,Secretary of State,,D,Jean Schodorf,5
-Lincoln,Vesper Township,Secretary of State,,D,Jean Schodorf,11
-Lincoln,Battle Creek Township,Attorney General,,R,Derek Schmidt,16
-Lincoln,Beaver Township,Attorney General,,R,Derek Schmidt,22
-Lincoln,Cedron Township,Attorney General,,R,Derek Schmidt,11
-Lincoln,Colorado Township,Attorney General,,R,Derek Schmidt,73
-Lincoln,Elkhorn Township Part A,Attorney General,,R,Derek Schmidt,51
-Lincoln,Franklin Township,Attorney General,,R,Derek Schmidt,37
-Lincoln,Golden Belt Township,Attorney General,,R,Derek Schmidt,18
-Lincoln,Grant Township,Attorney General,,R,Derek Schmidt,28
-Lincoln,Hanover Township,Attorney General,,R,Derek Schmidt,16
-Lincoln,Highland Township,Attorney General,,R,Derek Schmidt,23
-Lincoln,Indiana Township,Attorney General,,R,Derek Schmidt,27
-Lincoln,Lincoln Precinct 1,Attorney General,,R,Derek Schmidt,148
-Lincoln,Lincoln Precinct 2,Attorney General,,R,Derek Schmidt,172
-Lincoln,Logan Township,Attorney General,,R,Derek Schmidt,26
-Lincoln,Madison Township,Attorney General,,R,Derek Schmidt,30
-Lincoln,Marion Township,Attorney General,,R,Derek Schmidt,8
-Lincoln,Orange Township,Attorney General,,R,Derek Schmidt,24
-Lincoln,Pleasant Township,Attorney General,,R,Derek Schmidt,112
-Lincoln,Salt Creek Township,Attorney General,,R,Derek Schmidt,22
-Lincoln,Scott Township,Attorney General,,R,Derek Schmidt,36
-Lincoln,Valley Township,Attorney General,,R,Derek Schmidt,16
-Lincoln,Vesper Township,Attorney General,,R,Derek Schmidt,32
-Lincoln,Battle Creek Township,Attorney General,,D,AJ Kotich,1
-Lincoln,Beaver Township,Attorney General,,D,AJ Kotich,2
-Lincoln,Cedron Township,Attorney General,,D,AJ Kotich,3
-Lincoln,Colorado Township,Attorney General,,D,AJ Kotich,9
-Lincoln,Elkhorn Township Part A,Attorney General,,D,AJ Kotich,6
-Lincoln,Franklin Township,Attorney General,,D,AJ Kotich,7
-Lincoln,Golden Belt Township,Attorney General,,D,AJ Kotich,7
-Lincoln,Grant Township,Attorney General,,D,AJ Kotich,2
-Lincoln,Hanover Township,Attorney General,,D,AJ Kotich,2
-Lincoln,Highland Township,Attorney General,,D,AJ Kotich,8
-Lincoln,Indiana Township,Attorney General,,D,AJ Kotich,2
-Lincoln,Lincoln Precinct 1,Attorney General,,D,AJ Kotich,37
-Lincoln,Lincoln Precinct 2,Attorney General,,D,AJ Kotich,46
-Lincoln,Logan Township,Attorney General,,D,AJ Kotich,4
-Lincoln,Madison Township,Attorney General,,D,AJ Kotich,5
-Lincoln,Marion Township,Attorney General,,D,AJ Kotich,1
-Lincoln,Orange Township,Attorney General,,D,AJ Kotich,1
-Lincoln,Pleasant Township,Attorney General,,D,AJ Kotich,32
-Lincoln,Salt Creek Township,Attorney General,,D,AJ Kotich,2
-Lincoln,Scott Township,Attorney General,,D,AJ Kotich,5
-Lincoln,Valley Township,Attorney General,,D,AJ Kotich,1
-Lincoln,Vesper Township,Attorney General,,D,AJ Kotich,8
-Lincoln,Battle Creek Township,State Treasurer,,R,Ron Estes,14
-Lincoln,Beaver Township,State Treasurer,,R,Ron Estes,23
-Lincoln,Cedron Township,State Treasurer,,R,Ron Estes,11
-Lincoln,Colorado Township,State Treasurer,,R,Ron Estes,69
-Lincoln,Elkhorn Township,State Treasurer,,R,Ron Estes,53
-Lincoln,Franklin Township,State Treasurer,,R,Ron Estes,41
-Lincoln,Golden Belt Township,State Treasurer,,R,Ron Estes,19
-Lincoln,Grant Township,State Treasurer,,R,Ron Estes,28
-Lincoln,Hanover Township,State Treasurer,,R,Ron Estes,17
-Lincoln,Highland Township,State Treasurer,,R,Ron Estes,23
-Lincoln,Indiana Township,State Treasurer,,R,Ron Estes,23
-Lincoln,Lincoln Precinct 1,State Treasurer,,R,Ron Estes,151
-Lincoln,Lincoln Precinct 2,State Treasurer,,R,Ron Estes,170
-Lincoln,Logan Township,State Treasurer,,R,Ron Estes,26
-Lincoln,Madison Township,State Treasurer,,R,Ron Estes,27
-Lincoln,Marion Township,State Treasurer,,R,Ron Estes,10
-Lincoln,Orange Township,State Treasurer,,R,Ron Estes,23
-Lincoln,Pleasant Township,State Treasurer,,R,Ron Estes,113
-Lincoln,Salt Creek Township,State Treasurer,,R,Ron Estes,21
-Lincoln,Scott Township,State Treasurer,,R,Ron Estes,37
-Lincoln,Valley Township,State Treasurer,,R,Ron Estes,15
-Lincoln,Vesper Township,State Treasurer,,R,Ron Estes,34
-Lincoln,Battle Creek Township,State Treasurer,,D,Carmen Alldritt,3
-Lincoln,Beaver Township,State Treasurer,,D,Carmen Alldritt,1
-Lincoln,Cedron Township,State Treasurer,,D,Carmen Alldritt,3
-Lincoln,Colorado Township,State Treasurer,,D,Carmen Alldritt,13
-Lincoln,Elkhorn Township Part A,State Treasurer,,D,Carmen Alldritt,5
-Lincoln,Franklin Township,State Treasurer,,D,Carmen Alldritt,3
-Lincoln,Golden Belt Township,State Treasurer,,D,Carmen Alldritt,7
-Lincoln,Grant Township,State Treasurer,,D,Carmen Alldritt,2
-Lincoln,Hanover Township,State Treasurer,,D,Carmen Alldritt,1
-Lincoln,Highland Township,State Treasurer,,D,Carmen Alldritt,9
-Lincoln,Indiana Township,State Treasurer,,D,Carmen Alldritt,4
-Lincoln,Lincoln Precinct 1,State Treasurer,,D,Carmen Alldritt,38
-Lincoln,Lincoln Precinct 2,State Treasurer,,D,Carmen Alldritt,44
-Lincoln,Logan Township,State Treasurer,,D,Carmen Alldritt,4
-Lincoln,Madison Township,State Treasurer,,D,Carmen Alldritt,8
-Lincoln,Marion Township,State Treasurer,,D,Carmen Alldritt,0
-Lincoln,Orange Township,State Treasurer,,D,Carmen Alldritt,2
-Lincoln,Pleasant Township,State Treasurer,,D,Carmen Alldritt,31
-Lincoln,Salt Creek Township,State Treasurer,,D,Carmen Alldritt,5
-Lincoln,Scott Township,State Treasurer,,D,Carmen Alldritt,5
-Lincoln,Valley Township,State Treasurer,,D,Carmen Alldritt,2
-Lincoln,Vesper Township,State Treasurer,,D,Carmen Alldritt,7
-Lincoln,Battle Creek Township,Insurance Commissioner,,R,Ken Selzer,14
-Lincoln,Beaver Township,Insurance Commissioner,,R,Ken Selzer,20
-Lincoln,Cedron Township,Insurance Commissioner,,R,Ken Selzer,10
-Lincoln,Colorado Township,Insurance Commissioner,,R,Ken Selzer,62
-Lincoln,Elkhorn Township,Insurance Commissioner,,R,Ken Selzer,50
-Lincoln,Franklin Township,Insurance Commissioner,,R,Ken Selzer,36
-Lincoln,Golden Belt Township,Insurance Commissioner,,R,Ken Selzer,17
-Lincoln,Grant Township,Insurance Commissioner,,R,Ken Selzer,29
-Lincoln,Hanover Township,Insurance Commissioner,,R,Ken Selzer,13
-Lincoln,Highland Township,Insurance Commissioner,,R,Ken Selzer,18
-Lincoln,Indiana Township,Insurance Commissioner,,R,Ken Selzer,23
-Lincoln,Lincoln Precinct 1,Insurance Commissioner,,R,Ken Selzer,139
-Lincoln,Lincoln Precinct 2,Insurance Commissioner,,R,Ken Selzer,157
-Lincoln,Logan Township,Insurance Commissioner,,R,Ken Selzer,25
-Lincoln,Madison Township,Insurance Commissioner,,R,Ken Selzer,29
-Lincoln,Marion Township,Insurance Commissioner,,R,Ken Selzer,8
-Lincoln,Orange Township,Insurance Commissioner,,R,Ken Selzer,21
-Lincoln,Pleasant Township,Insurance Commissioner,,R,Ken Selzer,106
-Lincoln,Salt Creek Township,Insurance Commissioner,,R,Ken Selzer,18
-Lincoln,Scott Township,Insurance Commissioner,,R,Ken Selzer,35
-Lincoln,Valley Township,Insurance Commissioner,,R,Ken Selzer,13
-Lincoln,Vesper Township,Insurance Commissioner,,R,Ken Selzer,28
-Lincoln,Battle Creek Township,Insurance Commissioner,,D,Dennis Anderson,2
-Lincoln,Beaver Township,Insurance Commissioner,,D,Dennis Anderson,2
-Lincoln,Cedron Township,Insurance Commissioner,,D,Dennis Anderson,4
-Lincoln,Colorado Township,Insurance Commissioner,,D,Dennis Anderson,19
-Lincoln,Elkhorn Township Part A,Insurance Commissioner,,D,Dennis Anderson,6
-Lincoln,Franklin Township,Insurance Commissioner,,D,Dennis Anderson,6
-Lincoln,Golden Belt Township,Insurance Commissioner,,D,Dennis Anderson,9
-Lincoln,Grant Township,Insurance Commissioner,,D,Dennis Anderson,1
-Lincoln,Hanover Township,Insurance Commissioner,,D,Dennis Anderson,4
-Lincoln,Highland Township,Insurance Commissioner,,D,Dennis Anderson,13
-Lincoln,Indiana Township,Insurance Commissioner,,D,Dennis Anderson,3
-Lincoln,Lincoln Precinct 1,Insurance Commissioner,,D,Dennis Anderson,46
-Lincoln,Lincoln Precinct 2,Insurance Commissioner,,D,Dennis Anderson,55
-Lincoln,Logan Township,Insurance Commissioner,,D,Dennis Anderson,4
-Lincoln,Madison Township,Insurance Commissioner,,D,Dennis Anderson,9
-Lincoln,Marion Township,Insurance Commissioner,,D,Dennis Anderson,1
-Lincoln,Orange Township,Insurance Commissioner,,D,Dennis Anderson,3
-Lincoln,Pleasant Township,Insurance Commissioner,,D,Dennis Anderson,38
-Lincoln,Salt Creek Township,Insurance Commissioner,,D,Dennis Anderson,6
-Lincoln,Scott Township,Insurance Commissioner,,D,Dennis Anderson,7
-Lincoln,Valley Township,Insurance Commissioner,,D,Dennis Anderson,3
-Lincoln,Vesper Township,Insurance Commissioner,,D,Dennis Anderson,10
-Lincoln,Battle Creek Township,State House,109,R,Troy Waymaster,13
-Lincoln,Beaver Township,State House,107,R,Susan Concannon,22
-Lincoln,Cedron Township,State House,109,R,Troy Waymaster,14
-Lincoln,Colorado Township,State House,107,R,Susan Concannon,77
-Lincoln,Elkhorn Township Part A,State House,107,R,Susan Concannon,55
-Lincoln,Franklin Township,State House,107,R,Susan Concannon,45
-Lincoln,Golden Belt Township,State House,109,R,Troy Waymaster,26
-Lincoln,Grant Township,State House,109,R,Troy Waymaster,27
-Lincoln,Hanover Township,State House,109,R,Troy Waymaster,17
-Lincoln,Highland Township,State House,109,R,Troy Waymaster,25
-Lincoln,Indiana Township,State House,109,R,Troy Waymaster,26
-Lincoln,Lincoln Precinct 1,State House,109,R,Troy Waymaster,176
-Lincoln,Lincoln Precinct 2,State House,109,R,Troy Waymaster,202
-Lincoln,Logan Township,State House,107,R,Susan Concannon,24
-Lincoln,Madison Township,State House,107,R,Susan Concannon,31
-Lincoln,Marion Township,State House,109,R,Troy Waymaster,10
-Lincoln,Orange Township,State House,109,R,Troy Waymaster,25
-Lincoln,Pleasant Township,State House,109,R,Troy Waymaster,137
-Lincoln,Salt Creek Township,State House,107,R,Susan Concannon,24
-Lincoln,Scott Township,State House,107,R,Susan Concannon,43
-Lincoln,Valley Township,State House,109,R,Troy Waymaster,15
-Lincoln,Vesper Township,State House,109,R,Troy Waymaster,36
-Lincoln,Scott Township,U.S. House,1,,Tim Huelskamp,1
-Lincoln,Logan Township,State House,107,,Matt Olde,1
-Lincoln,Logan Township,State House,107,,Sherry Snyder,1
-Lincoln,Pleasant Township,State House,109,,Kerrick Kuder,2
-Lincoln,Lincoln 1,State House,109,,Jim Hedge,1
-Lincoln,Lincoln 2,State House,109,,Lowell Larson,1
-Lincoln,Lincoln 2,State House,109,,Jeffery Longberger,1
-Lincoln,Lincoln 2,State House,109,,Mark Kelly,1
+county,precinct,office,district,party,candidate,votes,vtd
+LINCOLN,Battle Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000010
+LINCOLN,Battle Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+LINCOLN,Battle Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000010
+LINCOLN,Beaver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,00002A
+LINCOLN,Beaver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,00002A
+LINCOLN,Beaver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,00002A
+LINCOLN,Cedron Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000030
+LINCOLN,Cedron Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+LINCOLN,Cedron Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000030
+LINCOLN,Colorado Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000040
+LINCOLN,Colorado Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+LINCOLN,Colorado Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000040
+LINCOLN,Elkhorn Township Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,00005A
+LINCOLN,Elkhorn Township Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00005A
+LINCOLN,Elkhorn Township Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,00005A
+LINCOLN,Franklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000060
+LINCOLN,Franklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000060
+LINCOLN,Franklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000060
+LINCOLN,Golden Belt Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000070
+LINCOLN,Golden Belt Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+LINCOLN,Golden Belt Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000070
+LINCOLN,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000080
+LINCOLN,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+LINCOLN,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000080
+LINCOLN,Hanover Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000090
+LINCOLN,Hanover Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+LINCOLN,Hanover Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000090
+LINCOLN,Highland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000100
+LINCOLN,Highland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+LINCOLN,Highland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000100
+LINCOLN,Indiana Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000110
+LINCOLN,Indiana Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000110
+LINCOLN,Indiana Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000110
+LINCOLN,Lincoln Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",85,000120
+LINCOLN,Lincoln Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000120
+LINCOLN,Lincoln Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000120
+LINCOLN,Lincoln Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",88,00013A
+LINCOLN,Lincoln Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00013A
+LINCOLN,Lincoln Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",123,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013B
+LINCOLN,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000140
+LINCOLN,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+LINCOLN,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000140
+LINCOLN,Madison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000150
+LINCOLN,Madison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000150
+LINCOLN,Madison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000150
+LINCOLN,Marion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000160
+LINCOLN,Marion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000160
+LINCOLN,Marion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000160
+LINCOLN,Orange Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000170
+LINCOLN,Orange Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000170
+LINCOLN,Orange Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000170
+LINCOLN,Pleasant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",52,000180
+LINCOLN,Pleasant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000180
+LINCOLN,Pleasant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,000180
+LINCOLN,Salt Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000190
+LINCOLN,Salt Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000190
+LINCOLN,Salt Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000190
+LINCOLN,Scott Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000200
+LINCOLN,Scott Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000200
+LINCOLN,Scott Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000200
+LINCOLN,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000210
+LINCOLN,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000210
+LINCOLN,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000210
+LINCOLN,Vesper Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000220
+LINCOLN,Vesper Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000220
+LINCOLN,Vesper Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000220
+LINCOLN,Marion Township Enclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+LINCOLN,Marion Township Enclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+LINCOLN,Marion Township Enclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+LINCOLN,Battle Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000010
+LINCOLN,Beaver Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",22,00002A
+LINCOLN,Cedron Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000030
+LINCOLN,Colorado Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",77,000040
+LINCOLN,Elkhorn Township Part A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",55,00005A
+LINCOLN,Franklin Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",45,000060
+LINCOLN,Golden Belt Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",26,000070
+LINCOLN,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",27,000080
+LINCOLN,Hanover Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",17,000090
+LINCOLN,Highland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000100
+LINCOLN,Indiana Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",26,000110
+LINCOLN,Lincoln Precinct 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",176,000120
+LINCOLN,Lincoln Precinct 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",202,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00013B
+LINCOLN,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",24,000140
+LINCOLN,Madison Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",31,000150
+LINCOLN,Marion Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000160
+LINCOLN,Orange Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000170
+LINCOLN,Pleasant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",137,000180
+LINCOLN,Salt Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",24,000190
+LINCOLN,Scott Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",43,000200
+LINCOLN,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",15,000210
+LINCOLN,Vesper Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",36,000220
+LINCOLN,Marion Township Enclave 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,900010
+LINCOLN,Battle Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000010
+LINCOLN,Battle Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000010
+LINCOLN,Beaver Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,00002A
+LINCOLN,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,00002A
+LINCOLN,Cedron Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000030
+LINCOLN,Cedron Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000030
+LINCOLN,Colorado Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000040
+LINCOLN,Colorado Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000040
+LINCOLN,Elkhorn Township Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",8,00005A
+LINCOLN,Elkhorn Township Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,00005A
+LINCOLN,Franklin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000060
+LINCOLN,Franklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000060
+LINCOLN,Golden Belt Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000070
+LINCOLN,Golden Belt Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000070
+LINCOLN,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000080
+LINCOLN,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000080
+LINCOLN,Hanover Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000090
+LINCOLN,Hanover Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000090
+LINCOLN,Highland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000100
+LINCOLN,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000100
+LINCOLN,Indiana Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000110
+LINCOLN,Indiana Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000110
+LINCOLN,Lincoln Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",64,000120
+LINCOLN,Lincoln Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",125,000120
+LINCOLN,Lincoln Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",67,00013A
+LINCOLN,Lincoln Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",149,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00013B
+LINCOLN,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000140
+LINCOLN,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000140
+LINCOLN,Madison Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000150
+LINCOLN,Madison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000150
+LINCOLN,Marion Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000160
+LINCOLN,Marion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000160
+LINCOLN,Orange Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000170
+LINCOLN,Orange Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000170
+LINCOLN,Pleasant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000180
+LINCOLN,Pleasant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",111,000180
+LINCOLN,Salt Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000190
+LINCOLN,Salt Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000190
+LINCOLN,Scott Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000200
+LINCOLN,Scott Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000200
+LINCOLN,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000210
+LINCOLN,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000210
+LINCOLN,Vesper Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000220
+LINCOLN,Vesper Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000220
+LINCOLN,Marion Township Enclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+LINCOLN,Marion Township Enclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+LINCOLN,Battle Creek Township,Attorney General,,Democratic,"Kotich, A.J.",1,000010
+LINCOLN,Battle Creek Township,Attorney General,,Republican,"Schmidt, Derek",16,000010
+LINCOLN,Beaver Township,Attorney General,,Democratic,"Kotich, A.J.",2,00002A
+LINCOLN,Beaver Township,Attorney General,,Republican,"Schmidt, Derek",22,00002A
+LINCOLN,Cedron Township,Attorney General,,Democratic,"Kotich, A.J.",3,000030
+LINCOLN,Cedron Township,Attorney General,,Republican,"Schmidt, Derek",11,000030
+LINCOLN,Colorado Township,Attorney General,,Democratic,"Kotich, A.J.",9,000040
+LINCOLN,Colorado Township,Attorney General,,Republican,"Schmidt, Derek",73,000040
+LINCOLN,Elkhorn Township Part A,Attorney General,,Democratic,"Kotich, A.J.",6,00005A
+LINCOLN,Elkhorn Township Part A,Attorney General,,Republican,"Schmidt, Derek",51,00005A
+LINCOLN,Franklin Township,Attorney General,,Democratic,"Kotich, A.J.",7,000060
+LINCOLN,Franklin Township,Attorney General,,Republican,"Schmidt, Derek",37,000060
+LINCOLN,Golden Belt Township,Attorney General,,Democratic,"Kotich, A.J.",7,000070
+LINCOLN,Golden Belt Township,Attorney General,,Republican,"Schmidt, Derek",18,000070
+LINCOLN,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",2,000080
+LINCOLN,Grant Township,Attorney General,,Republican,"Schmidt, Derek",28,000080
+LINCOLN,Hanover Township,Attorney General,,Democratic,"Kotich, A.J.",2,000090
+LINCOLN,Hanover Township,Attorney General,,Republican,"Schmidt, Derek",16,000090
+LINCOLN,Highland Township,Attorney General,,Democratic,"Kotich, A.J.",8,000100
+LINCOLN,Highland Township,Attorney General,,Republican,"Schmidt, Derek",23,000100
+LINCOLN,Indiana Township,Attorney General,,Democratic,"Kotich, A.J.",2,000110
+LINCOLN,Indiana Township,Attorney General,,Republican,"Schmidt, Derek",27,000110
+LINCOLN,Lincoln Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",37,000120
+LINCOLN,Lincoln Precinct 1,Attorney General,,Republican,"Schmidt, Derek",148,000120
+LINCOLN,Lincoln Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",46,00013A
+LINCOLN,Lincoln Precinct 2,Attorney General,,Republican,"Schmidt, Derek",172,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00013B
+LINCOLN,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",4,000140
+LINCOLN,Logan Township,Attorney General,,Republican,"Schmidt, Derek",26,000140
+LINCOLN,Madison Township,Attorney General,,Democratic,"Kotich, A.J.",5,000150
+LINCOLN,Madison Township,Attorney General,,Republican,"Schmidt, Derek",30,000150
+LINCOLN,Marion Township,Attorney General,,Democratic,"Kotich, A.J.",1,000160
+LINCOLN,Marion Township,Attorney General,,Republican,"Schmidt, Derek",8,000160
+LINCOLN,Orange Township,Attorney General,,Democratic,"Kotich, A.J.",1,000170
+LINCOLN,Orange Township,Attorney General,,Republican,"Schmidt, Derek",24,000170
+LINCOLN,Pleasant Township,Attorney General,,Democratic,"Kotich, A.J.",32,000180
+LINCOLN,Pleasant Township,Attorney General,,Republican,"Schmidt, Derek",112,000180
+LINCOLN,Salt Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000190
+LINCOLN,Salt Creek Township,Attorney General,,Republican,"Schmidt, Derek",22,000190
+LINCOLN,Scott Township,Attorney General,,Democratic,"Kotich, A.J.",5,000200
+LINCOLN,Scott Township,Attorney General,,Republican,"Schmidt, Derek",36,000200
+LINCOLN,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",1,000210
+LINCOLN,Valley Township,Attorney General,,Republican,"Schmidt, Derek",16,000210
+LINCOLN,Vesper Township,Attorney General,,Democratic,"Kotich, A.J.",8,000220
+LINCOLN,Vesper Township,Attorney General,,Republican,"Schmidt, Derek",32,000220
+LINCOLN,Marion Township Enclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+LINCOLN,Marion Township Enclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900010
+LINCOLN,Battle Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000010
+LINCOLN,Battle Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000010
+LINCOLN,Beaver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,00002A
+LINCOLN,Beaver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,00002A
+LINCOLN,Cedron Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000030
+LINCOLN,Cedron Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000030
+LINCOLN,Colorado Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000040
+LINCOLN,Colorado Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000040
+LINCOLN,Elkhorn Township Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,00005A
+LINCOLN,Elkhorn Township Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",50,00005A
+LINCOLN,Franklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000060
+LINCOLN,Franklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000060
+LINCOLN,Golden Belt Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000070
+LINCOLN,Golden Belt Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000070
+LINCOLN,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000080
+LINCOLN,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000080
+LINCOLN,Hanover Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000090
+LINCOLN,Hanover Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000090
+LINCOLN,Highland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000100
+LINCOLN,Highland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000100
+LINCOLN,Indiana Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000110
+LINCOLN,Indiana Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000110
+LINCOLN,Lincoln Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000120
+LINCOLN,Lincoln Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000120
+LINCOLN,Lincoln Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",55,00013A
+LINCOLN,Lincoln Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",157,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013B
+LINCOLN,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000140
+LINCOLN,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000140
+LINCOLN,Madison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000150
+LINCOLN,Madison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000150
+LINCOLN,Marion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000160
+LINCOLN,Marion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000160
+LINCOLN,Orange Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000170
+LINCOLN,Orange Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000170
+LINCOLN,Pleasant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000180
+LINCOLN,Pleasant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",106,000180
+LINCOLN,Salt Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000190
+LINCOLN,Salt Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000190
+LINCOLN,Scott Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000200
+LINCOLN,Scott Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000200
+LINCOLN,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000210
+LINCOLN,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000210
+LINCOLN,Vesper Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000220
+LINCOLN,Vesper Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000220
+LINCOLN,Marion Township Enclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+LINCOLN,Marion Township Enclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+LINCOLN,Battle Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+LINCOLN,Battle Creek Township,Secretary of State,,Republican,"Kobach, Kris",14,000010
+LINCOLN,Beaver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,00002A
+LINCOLN,Beaver Township,Secretary of State,,Republican,"Kobach, Kris",17,00002A
+LINCOLN,Cedron Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000030
+LINCOLN,Cedron Township,Secretary of State,,Republican,"Kobach, Kris",10,000030
+LINCOLN,Colorado Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000040
+LINCOLN,Colorado Township,Secretary of State,,Republican,"Kobach, Kris",67,000040
+LINCOLN,Elkhorn Township Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,00005A
+LINCOLN,Elkhorn Township Part A,Secretary of State,,Republican,"Kobach, Kris",47,00005A
+LINCOLN,Franklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000060
+LINCOLN,Franklin Township,Secretary of State,,Republican,"Kobach, Kris",35,000060
+LINCOLN,Golden Belt Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000070
+LINCOLN,Golden Belt Township,Secretary of State,,Republican,"Kobach, Kris",16,000070
+LINCOLN,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000080
+LINCOLN,Grant Township,Secretary of State,,Republican,"Kobach, Kris",25,000080
+LINCOLN,Hanover Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000090
+LINCOLN,Hanover Township,Secretary of State,,Republican,"Kobach, Kris",15,000090
+LINCOLN,Highland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000100
+LINCOLN,Highland Township,Secretary of State,,Republican,"Kobach, Kris",22,000100
+LINCOLN,Indiana Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000110
+LINCOLN,Indiana Township,Secretary of State,,Republican,"Kobach, Kris",21,000110
+LINCOLN,Lincoln Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000120
+LINCOLN,Lincoln Precinct 1,Secretary of State,,Republican,"Kobach, Kris",126,000120
+LINCOLN,Lincoln Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",76,00013A
+LINCOLN,Lincoln Precinct 2,Secretary of State,,Republican,"Kobach, Kris",143,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00013B
+LINCOLN,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000140
+LINCOLN,Logan Township,Secretary of State,,Republican,"Kobach, Kris",26,000140
+LINCOLN,Madison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000150
+LINCOLN,Madison Township,Secretary of State,,Republican,"Kobach, Kris",28,000150
+LINCOLN,Marion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000160
+LINCOLN,Marion Township,Secretary of State,,Republican,"Kobach, Kris",8,000160
+LINCOLN,Orange Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000170
+LINCOLN,Orange Township,Secretary of State,,Republican,"Kobach, Kris",23,000170
+LINCOLN,Pleasant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000180
+LINCOLN,Pleasant Township,Secretary of State,,Republican,"Kobach, Kris",105,000180
+LINCOLN,Salt Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000190
+LINCOLN,Salt Creek Township,Secretary of State,,Republican,"Kobach, Kris",16,000190
+LINCOLN,Scott Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000200
+LINCOLN,Scott Township,Secretary of State,,Republican,"Kobach, Kris",33,000200
+LINCOLN,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000210
+LINCOLN,Valley Township,Secretary of State,,Republican,"Kobach, Kris",12,000210
+LINCOLN,Vesper Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000220
+LINCOLN,Vesper Township,Secretary of State,,Republican,"Kobach, Kris",29,000220
+LINCOLN,Marion Township Enclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+LINCOLN,Marion Township Enclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900010
+LINCOLN,Battle Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000010
+LINCOLN,Battle Creek Township,State Treasurer,,Republican,"Estes, Ron",14,000010
+LINCOLN,Beaver Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,00002A
+LINCOLN,Beaver Township,State Treasurer,,Republican,"Estes, Ron",23,00002A
+LINCOLN,Cedron Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+LINCOLN,Cedron Township,State Treasurer,,Republican,"Estes, Ron",11,000030
+LINCOLN,Colorado Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000040
+LINCOLN,Colorado Township,State Treasurer,,Republican,"Estes, Ron",69,000040
+LINCOLN,Elkhorn Township Part A,State Treasurer,,Democratic,"Alldritt, Carmen",5,00005A
+LINCOLN,Elkhorn Township Part A,State Treasurer,,Republican,"Estes, Ron",53,00005A
+LINCOLN,Franklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000060
+LINCOLN,Franklin Township,State Treasurer,,Republican,"Estes, Ron",41,000060
+LINCOLN,Golden Belt Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000070
+LINCOLN,Golden Belt Township,State Treasurer,,Republican,"Estes, Ron",19,000070
+LINCOLN,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000080
+LINCOLN,Grant Township,State Treasurer,,Republican,"Estes, Ron",28,000080
+LINCOLN,Hanover Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000090
+LINCOLN,Hanover Township,State Treasurer,,Republican,"Estes, Ron",17,000090
+LINCOLN,Highland Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000100
+LINCOLN,Highland Township,State Treasurer,,Republican,"Estes, Ron",23,000100
+LINCOLN,Indiana Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000110
+LINCOLN,Indiana Township,State Treasurer,,Republican,"Estes, Ron",23,000110
+LINCOLN,Lincoln Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",38,000120
+LINCOLN,Lincoln Precinct 1,State Treasurer,,Republican,"Estes, Ron",151,000120
+LINCOLN,Lincoln Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",44,00013A
+LINCOLN,Lincoln Precinct 2,State Treasurer,,Republican,"Estes, Ron",170,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00013B
+LINCOLN,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000140
+LINCOLN,Logan Township,State Treasurer,,Republican,"Estes, Ron",26,000140
+LINCOLN,Madison Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000150
+LINCOLN,Madison Township,State Treasurer,,Republican,"Estes, Ron",27,000150
+LINCOLN,Marion Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000160
+LINCOLN,Marion Township,State Treasurer,,Republican,"Estes, Ron",10,000160
+LINCOLN,Orange Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000170
+LINCOLN,Orange Township,State Treasurer,,Republican,"Estes, Ron",23,000170
+LINCOLN,Pleasant Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000180
+LINCOLN,Pleasant Township,State Treasurer,,Republican,"Estes, Ron",113,000180
+LINCOLN,Salt Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000190
+LINCOLN,Salt Creek Township,State Treasurer,,Republican,"Estes, Ron",21,000190
+LINCOLN,Scott Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000200
+LINCOLN,Scott Township,State Treasurer,,Republican,"Estes, Ron",37,000200
+LINCOLN,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000210
+LINCOLN,Valley Township,State Treasurer,,Republican,"Estes, Ron",15,000210
+LINCOLN,Vesper Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000220
+LINCOLN,Vesper Township,State Treasurer,,Republican,"Estes, Ron",34,000220
+LINCOLN,Marion Township Enclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+LINCOLN,Marion Township Enclave 1,State Treasurer,,Republican,"Estes, Ron",0,900010
+LINCOLN,Battle Creek Township,United States Senate,,independent,"Orman, Greg",4,000010
+LINCOLN,Battle Creek Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+LINCOLN,Battle Creek Township,United States Senate,,Republican,"Roberts, Pat",13,000010
+LINCOLN,Beaver Township,United States Senate,,independent,"Orman, Greg",6,00002A
+LINCOLN,Beaver Township,United States Senate,,Libertarian,"Batson, Randall",0,00002A
+LINCOLN,Beaver Township,United States Senate,,Republican,"Roberts, Pat",18,00002A
+LINCOLN,Cedron Township,United States Senate,,independent,"Orman, Greg",0,000030
+LINCOLN,Cedron Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+LINCOLN,Cedron Township,United States Senate,,Republican,"Roberts, Pat",14,000030
+LINCOLN,Colorado Township,United States Senate,,independent,"Orman, Greg",17,000040
+LINCOLN,Colorado Township,United States Senate,,Libertarian,"Batson, Randall",3,000040
+LINCOLN,Colorado Township,United States Senate,,Republican,"Roberts, Pat",65,000040
+LINCOLN,Elkhorn Township Part A,United States Senate,,independent,"Orman, Greg",10,00005A
+LINCOLN,Elkhorn Township Part A,United States Senate,,Libertarian,"Batson, Randall",0,00005A
+LINCOLN,Elkhorn Township Part A,United States Senate,,Republican,"Roberts, Pat",50,00005A
+LINCOLN,Franklin Township,United States Senate,,independent,"Orman, Greg",12,000060
+LINCOLN,Franklin Township,United States Senate,,Libertarian,"Batson, Randall",3,000060
+LINCOLN,Franklin Township,United States Senate,,Republican,"Roberts, Pat",32,000060
+LINCOLN,Golden Belt Township,United States Senate,,independent,"Orman, Greg",11,000070
+LINCOLN,Golden Belt Township,United States Senate,,Libertarian,"Batson, Randall",1,000070
+LINCOLN,Golden Belt Township,United States Senate,,Republican,"Roberts, Pat",15,000070
+LINCOLN,Grant Township,United States Senate,,independent,"Orman, Greg",7,000080
+LINCOLN,Grant Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+LINCOLN,Grant Township,United States Senate,,Republican,"Roberts, Pat",24,000080
+LINCOLN,Hanover Township,United States Senate,,independent,"Orman, Greg",4,000090
+LINCOLN,Hanover Township,United States Senate,,Libertarian,"Batson, Randall",1,000090
+LINCOLN,Hanover Township,United States Senate,,Republican,"Roberts, Pat",13,000090
+LINCOLN,Highland Township,United States Senate,,independent,"Orman, Greg",9,000100
+LINCOLN,Highland Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+LINCOLN,Highland Township,United States Senate,,Republican,"Roberts, Pat",22,000100
+LINCOLN,Indiana Township,United States Senate,,independent,"Orman, Greg",5,000110
+LINCOLN,Indiana Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+LINCOLN,Indiana Township,United States Senate,,Republican,"Roberts, Pat",24,000110
+LINCOLN,Lincoln Precinct 1,United States Senate,,independent,"Orman, Greg",61,000120
+LINCOLN,Lincoln Precinct 1,United States Senate,,Libertarian,"Batson, Randall",10,000120
+LINCOLN,Lincoln Precinct 1,United States Senate,,Republican,"Roberts, Pat",222,000120
+LINCOLN,Lincoln Precinct 2,United States Senate,,independent,"Orman, Greg",63,00013A
+LINCOLN,Lincoln Precinct 2,United States Senate,,Libertarian,"Batson, Randall",13,00013A
+LINCOLN,Lincoln Precinct 2,United States Senate,,Republican,"Roberts, Pat",144,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00013B
+LINCOLN,Logan Township,United States Senate,,independent,"Orman, Greg",4,000140
+LINCOLN,Logan Township,United States Senate,,Libertarian,"Batson, Randall",1,000140
+LINCOLN,Logan Township,United States Senate,,Republican,"Roberts, Pat",25,000140
+LINCOLN,Madison Township,United States Senate,,independent,"Orman, Greg",8,000150
+LINCOLN,Madison Township,United States Senate,,Libertarian,"Batson, Randall",3,000150
+LINCOLN,Madison Township,United States Senate,,Republican,"Roberts, Pat",25,000150
+LINCOLN,Marion Township,United States Senate,,independent,"Orman, Greg",2,000160
+LINCOLN,Marion Township,United States Senate,,Libertarian,"Batson, Randall",0,000160
+LINCOLN,Marion Township,United States Senate,,Republican,"Roberts, Pat",8,000160
+LINCOLN,Orange Township,United States Senate,,independent,"Orman, Greg",4,000170
+LINCOLN,Orange Township,United States Senate,,Libertarian,"Batson, Randall",4,000170
+LINCOLN,Orange Township,United States Senate,,Republican,"Roberts, Pat",19,000170
+LINCOLN,Pleasant Township,United States Senate,,independent,"Orman, Greg",42,000180
+LINCOLN,Pleasant Township,United States Senate,,Libertarian,"Batson, Randall",5,000180
+LINCOLN,Pleasant Township,United States Senate,,Republican,"Roberts, Pat",100,000180
+LINCOLN,Salt Creek Township,United States Senate,,independent,"Orman, Greg",7,000190
+LINCOLN,Salt Creek Township,United States Senate,,Libertarian,"Batson, Randall",2,000190
+LINCOLN,Salt Creek Township,United States Senate,,Republican,"Roberts, Pat",18,000190
+LINCOLN,Scott Township,United States Senate,,independent,"Orman, Greg",11,000200
+LINCOLN,Scott Township,United States Senate,,Libertarian,"Batson, Randall",2,000200
+LINCOLN,Scott Township,United States Senate,,Republican,"Roberts, Pat",30,000200
+LINCOLN,Valley Township,United States Senate,,independent,"Orman, Greg",3,000210
+LINCOLN,Valley Township,United States Senate,,Libertarian,"Batson, Randall",0,000210
+LINCOLN,Valley Township,United States Senate,,Republican,"Roberts, Pat",14,000210
+LINCOLN,Vesper Township,United States Senate,,independent,"Orman, Greg",9,000220
+LINCOLN,Vesper Township,United States Senate,,Libertarian,"Batson, Randall",1,000220
+LINCOLN,Vesper Township,United States Senate,,Republican,"Roberts, Pat",30,000220
+LINCOLN,Marion Township Enclave 1,United States Senate,,independent,"Orman, Greg",0,900010
+LINCOLN,Marion Township Enclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900010
+LINCOLN,Marion Township Enclave 1,United States Senate,,Republican,"Roberts, Pat",0,900010

--- a/2014/20141104__ks__general__linn__precinct.csv
+++ b/2014/20141104__ks__general__linn__precinct.csv
@@ -1,267 +1,248 @@
-county,precinct,office,district,party,candidate,votes
-Linn,Blue Mound,Attorney General,,D,A.J. Kotich,41
-Linn,Centerville,Attorney General,,D,A.J. Kotich,45
-Linn,Liberty,Attorney General,,D,A.J. Kotich,85
-Linn,Lincoln N,Attorney General,,D,A.J. Kotich,75
-Linn,Lincoln S,Attorney General,,D,A.J. Kotich,52
-Linn,Linn Valley City,Attorney General,,D,A.J. Kotich,86
-Linn,Mound City twp,Attorney General,,D,A.J. Kotich,101
-Linn,Paris,Attorney General,,D,A.J. Kotich,43
-Linn,Potosi N,Attorney General,,D,A.J. Kotich,69
-Linn,Potosi S,Attorney General,,D,A.J. Kotich,37
-Linn,Scott,Attorney General,,D,A.J. Kotich,57
-Linn,Sheridan,Attorney General,,D,A.J. Kotich,31
-Linn,Stanton,Attorney General,,D,A.J. Kotich,17
-Linn,Valley,Attorney General,,D,A.J. Kotich,13
-Linn,Blue Mound,Attorney General,,R,Derek Schmidt,113
-Linn,Centerville,Attorney General,,R,Derek Schmidt,131
-Linn,Liberty,Attorney General,,R,Derek Schmidt,258
-Linn,Lincoln N,Attorney General,,R,Derek Schmidt,204
-Linn,Lincoln S,Attorney General,,R,Derek Schmidt,129
-Linn,Linn Valley City,Attorney General,,R,Derek Schmidt,194
-Linn,Mound City twp,Attorney General,,R,Derek Schmidt,361
-Linn,Paris,Attorney General,,R,Derek Schmidt,158
-Linn,Potosi N,Attorney General,,R,Derek Schmidt,204
-Linn,Potosi S,Attorney General,,R,Derek Schmidt,209
-Linn,Scott,Attorney General,,R,Derek Schmidt,196
-Linn,Sheridan,Attorney General,,R,Derek Schmidt,135
-Linn,Stanton,Attorney General,,R,Derek Schmidt,49
-Linn,Valley,Attorney General,,R,Derek Schmidt,31
-Linn,Blue Mound,Governor,,L,Keen A. Umbehr,9
-Linn,Centerville,Governor,,L,Keen A. Umbehr,0
-Linn,Liberty,Governor,,L,Keen A. Umbehr,13
-Linn,Lincoln N,Governor,,L,Keen A. Umbehr,10
-Linn,Lincoln S,Governor,,L,Keen A. Umbehr,10
-Linn,Linn Valley City,Governor,,L,Keen A. Umbehr,8
-Linn,Mound City twp,Governor,,L,Keen A. Umbehr,23
-Linn,Paris,Governor,,L,Keen A. Umbehr,5
-Linn,Potosi N,Governor,,L,Keen A. Umbehr,14
-Linn,Potosi S,Governor,,L,Keen A. Umbehr,13
-Linn,Scott,Governor,,L,Keen A. Umbehr,13
-Linn,Sheridan,Governor,,L,Keen A. Umbehr,8
-Linn,Stanton,Governor,,L,Keen A. Umbehr,2
-Linn,Valley,Governor,,L,Keen A. Umbehr,3
-Linn,Blue Mound,Governor,,D,Paul Davis,51
-Linn,Centerville,Governor,,D,Paul Davis,50
-Linn,Liberty,Governor,,D,Paul Davis,100
-Linn,Lincoln N,Governor,,D,Paul Davis,87
-Linn,Lincoln S,Governor,,D,Paul Davis,67
-Linn,Linn Valley City,Governor,,D,Paul Davis,105
-Linn,Mound City twp,Governor,,D,Paul Davis,153
-Linn,Paris,Governor,,D,Paul Davis,55
-Linn,Potosi N,Governor,,D,Paul Davis,87
-Linn,Potosi S,Governor,,D,Paul Davis,74
-Linn,Scott,Governor,,D,Paul Davis,74
-Linn,Sheridan,Governor,,D,Paul Davis,40
-Linn,Stanton,Governor,,D,Paul Davis,20
-Linn,Valley,Governor,,D,Paul Davis,14
-Linn,Blue Mound,Governor,,R,Sam Brownback,92
-Linn,Centerville,Governor,,R,Sam Brownback,127
-Linn,Liberty,Governor,,R,Sam Brownback,224
-Linn,Lincoln N,Governor,,R,Sam Brownback,184
-Linn,Lincoln S,Governor,,R,Sam Brownback,98
-Linn,Linn Valley City,Governor,,R,Sam Brownback,162
-Linn,Mound City twp,Governor,,R,Sam Brownback,295
-Linn,Paris,Governor,,R,Sam Brownback,125
-Linn,Potosi N,Governor,,R,Sam Brownback,169
-Linn,Potosi S,Governor,,R,Sam Brownback,155
-Linn,Scott,Governor,,R,Sam Brownback,161
-Linn,Sheridan,Governor,,R,Sam Brownback,117
-Linn,Stanton,Governor,,R,Sam Brownback,41
-Linn,Valley,Governor,,R,Sam Brownback,28
-Linn,Blue Mound,Insurance Commissioner,,D,Dennis Anderson,48
-Linn,Centerville,Insurance Commissioner,,D,Dennis Anderson,49
-Linn,Liberty,Insurance Commissioner,,D,Dennis Anderson,105
-Linn,Lincoln N,Insurance Commissioner,,D,Dennis Anderson,89
-Linn,Lincoln S,Insurance Commissioner,,D,Dennis Anderson,60
-Linn,Linn Valley City,Insurance Commissioner,,D,Dennis Anderson,91
-Linn,Mound City twp,Insurance Commissioner,,D,Dennis Anderson,113
-Linn,Paris,Insurance Commissioner,,D,Dennis Anderson,48
-Linn,Potosi N,Insurance Commissioner,,D,Dennis Anderson,86
-Linn,Potosi S,Insurance Commissioner,,D,Dennis Anderson,48
-Linn,Scott,Insurance Commissioner,,D,Dennis Anderson,66
-Linn,Sheridan,Insurance Commissioner,,D,Dennis Anderson,35
-Linn,Stanton,Insurance Commissioner,,D,Dennis Anderson,18
-Linn,Valley,Insurance Commissioner,,D,Dennis Anderson,17
-Linn,Blue Mound,Insurance Commissioner,,R,Ken Selzer,102
-Linn,Centerville,Insurance Commissioner,,R,Ken Selzer,129
-Linn,Liberty,Insurance Commissioner,,R,Ken Selzer,235
-Linn,Lincoln N,Insurance Commissioner,,R,Ken Selzer,188
-Linn,Lincoln S,Insurance Commissioner,,R,Ken Selzer,117
-Linn,Linn Valley City,Insurance Commissioner,,R,Ken Selzer,190
-Linn,Mound City twp,Insurance Commissioner,,R,Ken Selzer,343
-Linn,Paris,Insurance Commissioner,,R,Ken Selzer,146
-Linn,Potosi N,Insurance Commissioner,,R,Ken Selzer,188
-Linn,Potosi S,Insurance Commissioner,,R,Ken Selzer,194
-Linn,Scott,Insurance Commissioner,,R,Ken Selzer,186
-Linn,Sheridan,Insurance Commissioner,,R,Ken Selzer,129
-Linn,Stanton,Insurance Commissioner,,R,Ken Selzer,48
-Linn,Valley,Insurance Commissioner,,R,Ken Selzer,26
-Linn,Blue Mound,Secretary of State,,D,Jean Schodorf,44
-Linn,Centerville,Secretary of State,,D,Jean Schodorf,46
-Linn,Liberty,Secretary of State,,D,Jean Schodorf,92
-Linn,Lincoln N,Secretary of State,,D,Jean Schodorf,86
-Linn,Lincoln S,Secretary of State,,D,Jean Schodorf,55
-Linn,Linn Valley City,Secretary of State,,D,Jean Schodorf,95
-Linn,Mound City twp,Secretary of State,,D,Jean Schodorf,111
-Linn,Paris,Secretary of State,,D,Jean Schodorf,45
-Linn,Potosi N,Secretary of State,,D,Jean Schodorf,74
-Linn,Potosi S,Secretary of State,,D,Jean Schodorf,45
-Linn,Scott,Secretary of State,,D,Jean Schodorf,68
-Linn,Sheridan,Secretary of State,,D,Jean Schodorf,35
-Linn,Stanton,Secretary of State,,D,Jean Schodorf,17
-Linn,Valley,Secretary of State,,D,Jean Schodorf,13
-Linn,Blue Mound,Secretary of State,,R,Kris Kobach,109
-Linn,Centerville,Secretary of State,,R,Kris Kobach,134
-Linn,Liberty,Secretary of State,,R,Kris Kobach,258
-Linn,Lincoln N,Secretary of State,,R,Kris Kobach,204
-Linn,Lincoln S,Secretary of State,,R,Kris Kobach,126
-Linn,Linn Valley City,Secretary of State,,R,Kris Kobach,189
-Linn,Mound City twp,Secretary of State,,R,Kris Kobach,357
-Linn,Paris,Secretary of State,,R,Kris Kobach,156
-Linn,Potosi N,Secretary of State,,R,Kris Kobach,202
-Linn,Potosi S,Secretary of State,,R,Kris Kobach,205
-Linn,Scott,Secretary of State,,R,Kris Kobach,190
-Linn,Sheridan,Secretary of State,,R,Kris Kobach,134
-Linn,Stanton,Secretary of State,,R,Kris Kobach,49
-Linn,Valley,Secretary of State,,R,Kris Kobach,32
-Linn,Blue Mound,State House,4,D,Lucas B Cosens,33
-Linn,Lincoln N,State House,4,D,Lucas B Cosens,66
-Linn,Lincoln S,State House,4,D,Lucas B Cosens,41
-Linn,Linn Valley City,State House,4,D,Lucas B Cosens,75
-Linn,Mound City twp,State House,4,D,Lucas B Cosens,94
-Linn,Paris,State House,4,D,Lucas B Cosens,39
-Linn,Potosi N,State House,4,D,Lucas B Cosens,67
-Linn,Potosi S,State House,4,D,Lucas B Cosens,48
-Linn,Scott,State House,4,D,Lucas B Cosens,44
-Linn,Sheridan,State House,4,D,Lucas B Cosens,26
-Linn,Stanton,State House,4,D,Lucas B Cosens,16
-Linn,Valley,State House,4,D,Lucas B Cosens,9
-Linn,Blue Mound,State House,4,R,Marty Read,122
-Linn,Lincoln N,State House,4,R,Marty Read,225
-Linn,Lincoln S,State House,4,R,Marty Read,143
-Linn,Linn Valley City,State House,4,R,Marty Read,209
-Linn,Mound City twp,State House,4,R,Marty Read,390
-Linn,Paris,State House,4,R,Marty Read,167
-Linn,Potosi N,State House,4,R,Marty Read,215
-Linn,Potosi S,State House,4,R,Marty Read,204
-Linn,Scott,State House,4,R,Marty Read,214
-Linn,Sheridan,State House,4,R,Marty Read,150
-Linn,Stanton,State House,4,R,Marty Read,50
-Linn,Valley,State House,4,R,Marty Read,36
-Linn,Centerville,State House,5,D,Cleon Rickel,47
-Linn,Liberty,State House,5,D,Cleon Rickel,85
-Linn,Centerville,State House,5,R,Kevin Jones,133
-Linn,Liberty,State House,5,R,Kevin Jones,258
-Linn,Blue Mound,State Treasurer,,D,Carmen Alldritt,41
-Linn,Centerville,State Treasurer,,D,Carmen Alldritt,42
-Linn,Liberty,State Treasurer,,D,Carmen Alldritt,92
-Linn,Lincoln N,State Treasurer,,D,Carmen Alldritt,81
-Linn,Lincoln S,State Treasurer,,D,Carmen Alldritt,50
-Linn,Linn Valley City,State Treasurer,,D,Carmen Alldritt,87
-Linn,Mound City twp,State Treasurer,,D,Carmen Alldritt,105
-Linn,Paris,State Treasurer,,D,Carmen Alldritt,40
-Linn,Potosi N,State Treasurer,,D,Carmen Alldritt,72
-Linn,Potosi S,State Treasurer,,D,Carmen Alldritt,49
-Linn,Scott,State Treasurer,,D,Carmen Alldritt,60
-Linn,Sheridan,State Treasurer,,D,Carmen Alldritt,29
-Linn,Stanton,State Treasurer,,D,Carmen Alldritt,17
-Linn,Valley,State Treasurer,,D,Carmen Alldritt,12
-Linn,Blue Mound,State Treasurer,,R,Ron Estes,113
-Linn,Centerville,State Treasurer,,R,Ron Estes,134
-Linn,Liberty,State Treasurer,,R,Ron Estes,253
-Linn,Lincoln N,State Treasurer,,R,Ron Estes,202
-Linn,Lincoln S,State Treasurer,,R,Ron Estes,129
-Linn,Linn Valley City,State Treasurer,,R,Ron Estes,193
-Linn,Mound City twp,State Treasurer,,R,Ron Estes,357
-Linn,Paris,State Treasurer,,R,Ron Estes,159
-Linn,Potosi N,State Treasurer,,R,Ron Estes,201
-Linn,Potosi S,State Treasurer,,R,Ron Estes,192
-Linn,Scott,State Treasurer,,R,Ron Estes,193
-Linn,Sheridan,State Treasurer,,R,Ron Estes,136
-Linn,Stanton,State Treasurer,,R,Ron Estes,49
-Linn,Valley,State Treasurer,,R,Ron Estes,31
-Linn,Blue Mound,U.S. House,2,L,Chris Clemmons,11
-Linn,Centerville,U.S. House,2,L,Chris Clemmons,8
-Linn,Liberty,U.S. House,2,L,Chris Clemmons,13
-Linn,Lincoln N,U.S. House,2,L,Chris Clemmons,9
-Linn,Lincoln S,U.S. House,2,L,Chris Clemmons,10
-Linn,Linn Valley City,U.S. House,2,L,Chris Clemmons,9
-Linn,Mound City twp,U.S. House,2,L,Chris Clemmons,12
-Linn,Paris,U.S. House,2,L,Chris Clemmons,4
-Linn,Potosi N,U.S. House,2,L,Chris Clemmons,11
-Linn,Potosi S,U.S. House,2,L,Chris Clemmons,15
-Linn,Scott,U.S. House,2,L,Chris Clemmons,7
-Linn,Sheridan,U.S. House,2,L,Chris Clemmons,9
-Linn,Stanton,U.S. House,2,L,Chris Clemmons,5
-Linn,Valley,U.S. House,2,L,Chris Clemmons,3
-Linn,Blue Mound,U.S. House,2,R,Lynn Jenkins,115
-Linn,Centerville,U.S. House,2,R,Lynn Jenkins,140
-Linn,Liberty,U.S. House,2,R,Lynn Jenkins,277
-Linn,Lincoln N,U.S. House,2,R,Lynn Jenkins,213
-Linn,Lincoln S,U.S. House,2,R,Lynn Jenkins,139
-Linn,Linn Valley City,U.S. House,2,R,Lynn Jenkins,203
-Linn,Mound City twp,U.S. House,2,R,Lynn Jenkins,395
-Linn,Paris,U.S. House,2,R,Lynn Jenkins,167
-Linn,Potosi N,U.S. House,2,R,Lynn Jenkins,210
-Linn,Potosi S,U.S. House,2,R,Lynn Jenkins,211
-Linn,Scott,U.S. House,2,R,Lynn Jenkins,201
-Linn,Sheridan,U.S. House,2,R,Lynn Jenkins,140
-Linn,Stanton,U.S. House,2,R,Lynn Jenkins,47
-Linn,Valley,U.S. House,2,R,Lynn Jenkins,33
-Linn,Blue Mound,U.S. House,2,D,Margie Wakefield,30
-Linn,Centerville,U.S. House,2,D,Margie Wakefield,33
-Linn,Liberty,U.S. House,2,D,Margie Wakefield,64
-Linn,Lincoln N,U.S. House,2,D,Margie Wakefield,67
-Linn,Lincoln S,U.S. House,2,D,Margie Wakefield,34
-Linn,Linn Valley City,U.S. House,2,D,Margie Wakefield,73
-Linn,Mound City twp,U.S. House,2,D,Margie Wakefield,82
-Linn,Paris,U.S. House,2,D,Margie Wakefield,35
-Linn,Potosi N,U.S. House,2,D,Margie Wakefield,59
-Linn,Potosi S,U.S. House,2,D,Margie Wakefield,28
-Linn,Scott,U.S. House,2,D,Margie Wakefield,53
-Linn,Sheridan,U.S. House,2,D,Margie Wakefield,27
-Linn,Stanton,U.S. House,2,D,Margie Wakefield,13
-Linn,Valley,U.S. House,2,D,Margie Wakefield,9
-Linn,Blue Mound,U.S. Senate,,I,Greg Orman,55
-Linn,Centerville,U.S. Senate,,I,Greg Orman,58
-Linn,Liberty,U.S. Senate,,I,Greg Orman,103
-Linn,Lincoln N,U.S. Senate,,I,Greg Orman,96
-Linn,Lincoln S,U.S. Senate,,I,Greg Orman,53
-Linn,Linn Valley City,U.S. Senate,,I,Greg Orman,113
-Linn,Mound City twp,U.S. Senate,,I,Greg Orman,133
-Linn,Paris,U.S. Senate,,I,Greg Orman,55
-Linn,Potosi N,U.S. Senate,,I,Greg Orman,88
-Linn,Potosi S,U.S. Senate,,I,Greg Orman,69
-Linn,Scott,U.S. Senate,,I,Greg Orman,83
-Linn,Sheridan,U.S. Senate,,I,Greg Orman,38
-Linn,Stanton,U.S. Senate,,I,Greg Orman,14
-Linn,Valley,U.S. Senate,,I,Greg Orman,15
-Linn,Blue Mound,U.S. Senate,,R,Pat Roberts,87
-Linn,Centerville,U.S. Senate,,R,Pat Roberts,119
-Linn,Liberty,U.S. Senate,,R,Pat Roberts,220
-Linn,Lincoln N,U.S. Senate,,R,Pat Roberts,179
-Linn,Lincoln S,U.S. Senate,,R,Pat Roberts,112
-Linn,Linn Valley City,U.S. Senate,,R,Pat Roberts,160
-Linn,Mound City twp,U.S. Senate,,R,Pat Roberts,322
-Linn,Paris,U.S. Senate,,R,Pat Roberts,140
-Linn,Potosi N,U.S. Senate,,R,Pat Roberts,169
-Linn,Potosi S,U.S. Senate,,R,Pat Roberts,166
-Linn,Scott,U.S. Senate,,R,Pat Roberts,162
-Linn,Sheridan,U.S. Senate,,R,Pat Roberts,122
-Linn,Stanton,U.S. Senate,,R,Pat Roberts,48
-Linn,Valley,U.S. Senate,,R,Pat Roberts,26
-Linn,Blue Mound,U.S. Senate,,L,Randall Batson,11
-Linn,Centerville,U.S. Senate,,L,Randall Batson,4
-Linn,Liberty,U.S. Senate,,L,Randall Batson,25
-Linn,Lincoln N,U.S. Senate,,L,Randall Batson,15
-Linn,Lincoln S,U.S. Senate,,L,Randall Batson,16
-Linn,Linn Valley City,U.S. Senate,,L,Randall Batson,12
-Linn,Mound City twp,U.S. Senate,,L,Randall Batson,27
-Linn,Paris,U.S. Senate,,L,Randall Batson,11
-Linn,Potosi N,U.S. Senate,,L,Randall Batson,18
-Linn,Potosi S,U.S. Senate,,L,Randall Batson,19
-Linn,Scott,U.S. Senate,,L,Randall Batson,12
-Linn,Sheridan,U.S. Senate,,L,Randall Batson,12
-Linn,Stanton,U.S. Senate,,L,Randall Batson,2
-Linn,Valley,U.S. Senate,,L,Randall Batson,4
+county,precinct,office,district,party,candidate,votes,vtd
+LINN,Blue Mound Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",51,000010
+LINN,Blue Mound Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000010
+LINN,Blue Mound Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,000010
+LINN,Centerville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000020
+LINN,Centerville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+LINN,Centerville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",127,000020
+LINN,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",100,000030
+LINN,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000030
+LINN,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",224,000030
+LINN,Mound City Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",153,000040
+LINN,Mound City Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000040
+LINN,Mound City Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",295,000040
+LINN,North Lincoln,Governor / Lt. Governor,,Democratic,"Davis, Paul",192,000050
+LINN,North Lincoln,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000050
+LINN,North Lincoln,Governor / Lt. Governor,,Republican,"Brownback, Sam",346,000050
+LINN,North Potosi,Governor / Lt. Governor,,Democratic,"Davis, Paul",87,000060
+LINN,North Potosi,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000060
+LINN,North Potosi,Governor / Lt. Governor,,Republican,"Brownback, Sam",169,000060
+LINN,Paris Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000070
+LINN,Paris Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000070
+LINN,Paris Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000070
+LINN,Scott Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000080
+LINN,Scott Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000080
+LINN,Scott Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",161,000080
+LINN,Sheridan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000090
+LINN,Sheridan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000090
+LINN,Sheridan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,000090
+LINN,South Lincoln,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000100
+LINN,South Lincoln,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000100
+LINN,South Lincoln,Governor / Lt. Governor,,Republican,"Brownback, Sam",98,000100
+LINN,South Potosi,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000110
+LINN,South Potosi,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000110
+LINN,South Potosi,Governor / Lt. Governor,,Republican,"Brownback, Sam",155,000110
+LINN,Stanton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000120
+LINN,Stanton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000120
+LINN,Stanton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000120
+LINN,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000130
+LINN,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000130
+LINN,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000130
+LINN,Blue Mound Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",33,000010
+LINN,Blue Mound Township,Kansas House of Representatives,4,Republican,"Read, Marty",122,000010
+LINN,Centerville Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",47,000020
+LINN,Centerville Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",133,000020
+LINN,Liberty Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",85,000030
+LINN,Liberty Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",258,000030
+LINN,Mound City Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",94,000040
+LINN,Mound City Township,Kansas House of Representatives,4,Republican,"Read, Marty",390,000040
+LINN,North Lincoln,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",141,000050
+LINN,North Lincoln,Kansas House of Representatives,4,Republican,"Read, Marty",434,000050
+LINN,North Potosi,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",67,000060
+LINN,North Potosi,Kansas House of Representatives,4,Republican,"Read, Marty",215,000060
+LINN,Paris Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",39,000070
+LINN,Paris Township,Kansas House of Representatives,4,Republican,"Read, Marty",167,000070
+LINN,Scott Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",44,000080
+LINN,Scott Township,Kansas House of Representatives,4,Republican,"Read, Marty",214,000080
+LINN,Sheridan Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",26,000090
+LINN,Sheridan Township,Kansas House of Representatives,4,Republican,"Read, Marty",150,000090
+LINN,South Lincoln,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",41,000100
+LINN,South Lincoln,Kansas House of Representatives,4,Republican,"Read, Marty",143,000100
+LINN,South Potosi,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",48,000110
+LINN,South Potosi,Kansas House of Representatives,4,Republican,"Read, Marty",204,000110
+LINN,Stanton Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",16,000120
+LINN,Stanton Township,Kansas House of Representatives,4,Republican,"Read, Marty",50,000120
+LINN,Valley Township,Kansas House of Representatives,4,Democratic,"Cosens, Lucas B",9,000130
+LINN,Valley Township,Kansas House of Representatives,4,Republican,"Read, Marty",36,000130
+LINN,Blue Mound Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",30,000010
+LINN,Blue Mound Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000010
+LINN,Blue Mound Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",115,000010
+LINN,Centerville Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",33,000020
+LINN,Centerville Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000020
+LINN,Centerville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",140,000020
+LINN,Liberty Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",64,000030
+LINN,Liberty Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000030
+LINN,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",277,000030
+LINN,Mound City Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,000040
+LINN,Mound City Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000040
+LINN,Mound City Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",395,000040
+LINN,North Lincoln,United States House of Representatives,2,Democratic,"Wakefield, Margie",140,000050
+LINN,North Lincoln,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000050
+LINN,North Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",416,000050
+LINN,North Potosi,United States House of Representatives,2,Democratic,"Wakefield, Margie",59,000060
+LINN,North Potosi,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000060
+LINN,North Potosi,United States House of Representatives,2,Republican,"Jenkins, Lynn",210,000060
+LINN,Paris Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",35,000070
+LINN,Paris Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000070
+LINN,Paris Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000070
+LINN,Scott Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,000080
+LINN,Scott Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000080
+LINN,Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",201,000080
+LINN,Sheridan Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,000090
+LINN,Sheridan Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000090
+LINN,Sheridan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",140,000090
+LINN,South Lincoln,United States House of Representatives,2,Democratic,"Wakefield, Margie",34,000100
+LINN,South Lincoln,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000100
+LINN,South Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",139,000100
+LINN,South Potosi,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,000110
+LINN,South Potosi,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000110
+LINN,South Potosi,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,000110
+LINN,Stanton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",13,000120
+LINN,Stanton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000120
+LINN,Stanton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000120
+LINN,Valley Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000130
+LINN,Valley Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000130
+LINN,Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000130
+LINN,Blue Mound Township,Attorney General,,Democratic,"Kotich, A.J.",41,000010
+LINN,Blue Mound Township,Attorney General,,Republican,"Schmidt, Derek",113,000010
+LINN,Centerville Township,Attorney General,,Democratic,"Kotich, A.J.",45,000020
+LINN,Centerville Township,Attorney General,,Republican,"Schmidt, Derek",131,000020
+LINN,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",85,000030
+LINN,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",258,000030
+LINN,Mound City Township,Attorney General,,Democratic,"Kotich, A.J.",101,000040
+LINN,Mound City Township,Attorney General,,Republican,"Schmidt, Derek",361,000040
+LINN,North Lincoln,Attorney General,,Democratic,"Kotich, A.J.",161,000050
+LINN,North Lincoln,Attorney General,,Republican,"Schmidt, Derek",398,000050
+LINN,North Potosi,Attorney General,,Democratic,"Kotich, A.J.",69,000060
+LINN,North Potosi,Attorney General,,Republican,"Schmidt, Derek",204,000060
+LINN,Paris Township,Attorney General,,Democratic,"Kotich, A.J.",43,000070
+LINN,Paris Township,Attorney General,,Republican,"Schmidt, Derek",158,000070
+LINN,Scott Township,Attorney General,,Democratic,"Kotich, A.J.",57,000080
+LINN,Scott Township,Attorney General,,Republican,"Schmidt, Derek",196,000080
+LINN,Sheridan Township,Attorney General,,Democratic,"Kotich, A.J.",31,000090
+LINN,Sheridan Township,Attorney General,,Republican,"Schmidt, Derek",135,000090
+LINN,South Lincoln,Attorney General,,Democratic,"Kotich, A.J.",52,000100
+LINN,South Lincoln,Attorney General,,Republican,"Schmidt, Derek",129,000100
+LINN,South Potosi,Attorney General,,Democratic,"Kotich, A.J.",37,000110
+LINN,South Potosi,Attorney General,,Republican,"Schmidt, Derek",209,000110
+LINN,Stanton Township,Attorney General,,Democratic,"Kotich, A.J.",17,000120
+LINN,Stanton Township,Attorney General,,Republican,"Schmidt, Derek",49,000120
+LINN,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",13,000130
+LINN,Valley Township,Attorney General,,Republican,"Schmidt, Derek",31,000130
+LINN,Blue Mound Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000010
+LINN,Blue Mound Township,Commissioner of Insurance,,Republican,"Selzer, Ken",102,000010
+LINN,Centerville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",49,000020
+LINN,Centerville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000020
+LINN,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",105,000030
+LINN,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",235,000030
+LINN,Mound City Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",113,000040
+LINN,Mound City Township,Commissioner of Insurance,,Republican,"Selzer, Ken",343,000040
+LINN,North Lincoln,Commissioner of Insurance,,Democratic,"Anderson, Dennis",180,000050
+LINN,North Lincoln,Commissioner of Insurance,,Republican,"Selzer, Ken",378,000050
+LINN,North Potosi,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,000060
+LINN,North Potosi,Commissioner of Insurance,,Republican,"Selzer, Ken",188,000060
+LINN,Paris Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000070
+LINN,Paris Township,Commissioner of Insurance,,Republican,"Selzer, Ken",146,000070
+LINN,Scott Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,000080
+LINN,Scott Township,Commissioner of Insurance,,Republican,"Selzer, Ken",186,000080
+LINN,Sheridan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",35,000090
+LINN,Sheridan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000090
+LINN,South Lincoln,Commissioner of Insurance,,Democratic,"Anderson, Dennis",60,000100
+LINN,South Lincoln,Commissioner of Insurance,,Republican,"Selzer, Ken",117,000100
+LINN,South Potosi,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000110
+LINN,South Potosi,Commissioner of Insurance,,Republican,"Selzer, Ken",194,000110
+LINN,Stanton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000120
+LINN,Stanton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000120
+LINN,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000130
+LINN,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000130
+LINN,Blue Mound Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000010
+LINN,Blue Mound Township,Secretary of State,,Republican,"Kobach, Kris",109,000010
+LINN,Centerville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000020
+LINN,Centerville Township,Secretary of State,,Republican,"Kobach, Kris",134,000020
+LINN,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",92,000030
+LINN,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",258,000030
+LINN,Mound City Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",111,000040
+LINN,Mound City Township,Secretary of State,,Republican,"Kobach, Kris",357,000040
+LINN,North Lincoln,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",181,000050
+LINN,North Lincoln,Secretary of State,,Republican,"Kobach, Kris",393,000050
+LINN,North Potosi,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000060
+LINN,North Potosi,Secretary of State,,Republican,"Kobach, Kris",202,000060
+LINN,Paris Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000070
+LINN,Paris Township,Secretary of State,,Republican,"Kobach, Kris",156,000070
+LINN,Scott Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000080
+LINN,Scott Township,Secretary of State,,Republican,"Kobach, Kris",190,000080
+LINN,Sheridan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000090
+LINN,Sheridan Township,Secretary of State,,Republican,"Kobach, Kris",134,000090
+LINN,South Lincoln,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000100
+LINN,South Lincoln,Secretary of State,,Republican,"Kobach, Kris",126,000100
+LINN,South Potosi,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000110
+LINN,South Potosi,Secretary of State,,Republican,"Kobach, Kris",205,000110
+LINN,Stanton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000120
+LINN,Stanton Township,Secretary of State,,Republican,"Kobach, Kris",49,000120
+LINN,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000130
+LINN,Valley Township,Secretary of State,,Republican,"Kobach, Kris",32,000130
+LINN,Blue Mound Township,State Treasurer,,Democratic,"Alldritt, Carmen",41,000010
+LINN,Blue Mound Township,State Treasurer,,Republican,"Estes, Ron",113,000010
+LINN,Centerville Township,State Treasurer,,Democratic,"Alldritt, Carmen",42,000020
+LINN,Centerville Township,State Treasurer,,Republican,"Estes, Ron",134,000020
+LINN,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",92,000030
+LINN,Liberty Township,State Treasurer,,Republican,"Estes, Ron",253,000030
+LINN,Mound City Township,State Treasurer,,Democratic,"Alldritt, Carmen",105,000040
+LINN,Mound City Township,State Treasurer,,Republican,"Estes, Ron",357,000040
+LINN,North Lincoln,State Treasurer,,Democratic,"Alldritt, Carmen",168,000050
+LINN,North Lincoln,State Treasurer,,Republican,"Estes, Ron",395,000050
+LINN,North Potosi,State Treasurer,,Democratic,"Alldritt, Carmen",72,000060
+LINN,North Potosi,State Treasurer,,Republican,"Estes, Ron",201,000060
+LINN,Paris Township,State Treasurer,,Democratic,"Alldritt, Carmen",40,000070
+LINN,Paris Township,State Treasurer,,Republican,"Estes, Ron",159,000070
+LINN,Scott Township,State Treasurer,,Democratic,"Alldritt, Carmen",60,000080
+LINN,Scott Township,State Treasurer,,Republican,"Estes, Ron",193,000080
+LINN,Sheridan Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000090
+LINN,Sheridan Township,State Treasurer,,Republican,"Estes, Ron",136,000090
+LINN,South Lincoln,State Treasurer,,Democratic,"Alldritt, Carmen",50,000100
+LINN,South Lincoln,State Treasurer,,Republican,"Estes, Ron",129,000100
+LINN,South Potosi,State Treasurer,,Democratic,"Alldritt, Carmen",49,000110
+LINN,South Potosi,State Treasurer,,Republican,"Estes, Ron",192,000110
+LINN,Stanton Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000120
+LINN,Stanton Township,State Treasurer,,Republican,"Estes, Ron",49,000120
+LINN,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000130
+LINN,Valley Township,State Treasurer,,Republican,"Estes, Ron",31,000130
+LINN,Blue Mound Township,United States Senate,,independent,"Orman, Greg",55,000010
+LINN,Blue Mound Township,United States Senate,,Libertarian,"Batson, Randall",11,000010
+LINN,Blue Mound Township,United States Senate,,Republican,"Roberts, Pat",87,000010
+LINN,Centerville Township,United States Senate,,independent,"Orman, Greg",58,000020
+LINN,Centerville Township,United States Senate,,Libertarian,"Batson, Randall",4,000020
+LINN,Centerville Township,United States Senate,,Republican,"Roberts, Pat",119,000020
+LINN,Liberty Township,United States Senate,,independent,"Orman, Greg",103,000030
+LINN,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",25,000030
+LINN,Liberty Township,United States Senate,,Republican,"Roberts, Pat",220,000030
+LINN,Mound City Township,United States Senate,,independent,"Orman, Greg",133,000040
+LINN,Mound City Township,United States Senate,,Libertarian,"Batson, Randall",27,000040
+LINN,Mound City Township,United States Senate,,Republican,"Roberts, Pat",322,000040
+LINN,North Lincoln,United States Senate,,independent,"Orman, Greg",209,000050
+LINN,North Lincoln,United States Senate,,Libertarian,"Batson, Randall",27,000050
+LINN,North Lincoln,United States Senate,,Republican,"Roberts, Pat",339,000050
+LINN,North Potosi,United States Senate,,independent,"Orman, Greg",88,000060
+LINN,North Potosi,United States Senate,,Libertarian,"Batson, Randall",18,000060
+LINN,North Potosi,United States Senate,,Republican,"Roberts, Pat",169,000060
+LINN,Paris Township,United States Senate,,independent,"Orman, Greg",55,000070
+LINN,Paris Township,United States Senate,,Libertarian,"Batson, Randall",11,000070
+LINN,Paris Township,United States Senate,,Republican,"Roberts, Pat",140,000070
+LINN,Scott Township,United States Senate,,independent,"Orman, Greg",83,000080
+LINN,Scott Township,United States Senate,,Libertarian,"Batson, Randall",12,000080
+LINN,Scott Township,United States Senate,,Republican,"Roberts, Pat",162,000080
+LINN,Sheridan Township,United States Senate,,independent,"Orman, Greg",38,000090
+LINN,Sheridan Township,United States Senate,,Libertarian,"Batson, Randall",12,000090
+LINN,Sheridan Township,United States Senate,,Republican,"Roberts, Pat",122,000090
+LINN,South Lincoln,United States Senate,,independent,"Orman, Greg",53,000100
+LINN,South Lincoln,United States Senate,,Libertarian,"Batson, Randall",16,000100
+LINN,South Lincoln,United States Senate,,Republican,"Roberts, Pat",112,000100
+LINN,South Potosi,United States Senate,,independent,"Orman, Greg",69,000110
+LINN,South Potosi,United States Senate,,Libertarian,"Batson, Randall",19,000110
+LINN,South Potosi,United States Senate,,Republican,"Roberts, Pat",166,000110
+LINN,Stanton Township,United States Senate,,independent,"Orman, Greg",14,000120
+LINN,Stanton Township,United States Senate,,Libertarian,"Batson, Randall",2,000120
+LINN,Stanton Township,United States Senate,,Republican,"Roberts, Pat",48,000120
+LINN,Valley Township,United States Senate,,independent,"Orman, Greg",15,000130
+LINN,Valley Township,United States Senate,,Libertarian,"Batson, Randall",4,000130
+LINN,Valley Township,United States Senate,,Republican,"Roberts, Pat",26,000130

--- a/2014/20141104__ks__general__logan__precinct.csv
+++ b/2014/20141104__ks__general__logan__precinct.csv
@@ -1,225 +1,205 @@
-county,precinct,office,district,party,candidate,votes
-Logan,Augustine,U.S. Senate,,I,Greg Orman,0
-Logan,Elkander,U.S. Senate,,I,Greg Orman,0
-Logan,Lees,U.S. Senate,,I,Greg Orman,2
-Logan,Logansport,U.S. Senate,,I,Greg Orman,0
-Logan,Allender,U.S. Senate,,I,Greg Orman,0
-Logan,Monument,U.S. Senate,,I,Greg Orman,7
-Logan,Oakley 1,U.S. Senate,,I,Greg Orman,93
-Logan,Oakley 2,U.S. Senate,,I,Greg Orman,81
-Logan,Paxton,U.S. Senate,,I,Greg Orman,0
-Logan,Russell Sprs,U.S. Senate,,I,Greg Orman,4
-Logan,Western,U.S. Senate,,I,Greg Orman,1
-Logan,Winona,U.S. Senate,,I,Greg Orman,14
-Logan,Provisional,U.S. Senate,,I,Greg Orman,3
-Logan,Augustine,U.S. Senate,,R,Pat Roberts,11
-Logan,Elkander,U.S. Senate,,R,Pat Roberts,3
-Logan,Lees,U.S. Senate,,R,Pat Roberts,5
-Logan,Logansport,U.S. Senate,,R,Pat Roberts,2
-Logan,Allender,U.S. Senate,,R,Pat Roberts,11
-Logan,Monument,U.S. Senate,,R,Pat Roberts,47
-Logan,Oakley 1,U.S. Senate,,R,Pat Roberts,360
-Logan,Oakley 2,U.S. Senate,,R,Pat Roberts,226
-Logan,Paxton,U.S. Senate,,R,Pat Roberts,20
-Logan,Russell Sprs,U.S. Senate,,R,Pat Roberts,13
-Logan,Western,U.S. Senate,,R,Pat Roberts,20
-Logan,Winona,U.S. Senate,,R,Pat Roberts,80
-Logan,Provisional,U.S. Senate,,R,Pat Roberts,4
-Logan,Augustine,U.S. Senate,,LBT,Randall Batson,0
-Logan,Elkander,U.S. Senate,,LBT,Randall Batson,0
-Logan,Lees,U.S. Senate,,LBT,Randall Batson,0
-Logan,Logansport,U.S. Senate,,LBT,Randall Batson,0
-Logan,Allender,U.S. Senate,,LBT,Randall Batson,0
-Logan,Monument,U.S. Senate,,LBT,Randall Batson,1
-Logan,Oakley 1,U.S. Senate,,LBT,Randall Batson,18
-Logan,Oakley 2,U.S. Senate,,LBT,Randall Batson,25
-Logan,Paxton,U.S. Senate,,LBT,Randall Batson,0
-Logan,Russell Sprs,U.S. Senate,,LBT,Randall Batson,2
-Logan,Western,U.S. Senate,,LBT,Randall Batson,0
-Logan,Winona,U.S. Senate,,LBT,Randall Batson,3
-Logan,Provisional,U.S. Senate,,LBT,Randall Batson,0
-Logan,Augustine,U.S. House,1,R,Tim Huelskamp,11
-Logan,Elkander,U.S. House,1,R,Tim Huelskamp,3
-Logan,Lees,U.S. House,1,R,Tim Huelskamp,5
-Logan,Logansport,U.S. House,1,R,Tim Huelskamp,2
-Logan,Allender,U.S. House,1,R,Tim Huelskamp,11
-Logan,Monument,U.S. House,1,R,Tim Huelskamp,46
-Logan,Oakley 1,U.S. House,1,R,Tim Huelskamp,378
-Logan,Oakley 2,U.S. House,1,R,Tim Huelskamp,265
-Logan,Paxton,U.S. House,1,R,Tim Huelskamp,20
-Logan,Russell Sprs,U.S. House,1,R,Tim Huelskamp,16
-Logan,Western,U.S. House,1,R,Tim Huelskamp,19
-Logan,Winona,U.S. House,1,R,Tim Huelskamp,84
-Logan,Provisional,U.S. House,1,R,Tim Huelskamp,4
-Logan,Augustine,U.S. House,1,D,James Sherow,0
-Logan,Elkander,U.S. House,1,D,James Sherow,0
-Logan,Lees,U.S. House,1,D,James Sherow,2
-Logan,Logansport,U.S. House,1,D,James Sherow,0
-Logan,Allender,U.S. House,1,D,James Sherow,0
-Logan,Monument,U.S. House,1,D,James Sherow,9
-Logan,Oakley 1,U.S. House,1,D,James Sherow,88
-Logan,Oakley 2,U.S. House,1,D,James Sherow,66
-Logan,Paxton,U.S. House,1,D,James Sherow,0
-Logan,Russell Sprs,U.S. House,1,D,James Sherow,4
-Logan,Western,U.S. House,1,D,James Sherow,2
-Logan,Winona,U.S. House,1,D,James Sherow,13
-Logan,Provisional,U.S. House,1,D,James Sherow,3
-Logan,Augustine,Governor,,D,Paul Davis,1
-Logan,Elkander,Governor,,D,Paul Davis,0
-Logan,Lees,Governor,,D,Paul Davis,2
-Logan,Logansport,Governor,,D,Paul Davis,0
-Logan,Allender,Governor,,D,Paul Davis,2
-Logan,Monument,Governor,,D,Paul Davis,11
-Logan,Oakley 1,Governor,,D,Paul Davis,91
-Logan,Oakley 2,Governor,,D,Paul Davis,111
-Logan,Paxton,Governor,,D,Paul Davis,0
-Logan,Russell Sprs,Governor,,D,Paul Davis,3
-Logan,Western,Governor,,D,Paul Davis,1
-Logan,Winona,Governor,,D,Paul Davis,14
-Logan,Provisional,Governor,,D,Paul Davis,3
-Logan,Augustine,Governor,,LBT,Keen Umbehr,0
-Logan,Elkander,Governor,,LBT,Keen Umbehr,0
-Logan,Lees,Governor,,LBT,Keen Umbehr,0
-Logan,Logansport,Governor,,LBT,Keen Umbehr,0
-Logan,Allender,Governor,,LBT,Keen Umbehr,0
-Logan,Monument,Governor,,LBT,Keen Umbehr,1
-Logan,Oakley 1,Governor,,LBT,Keen Umbehr,24
-Logan,Oakley 2,Governor,,LBT,Keen Umbehr,18
-Logan,Paxton,Governor,,LBT,Keen Umbehr,0
-Logan,Russell Sprs,Governor,,LBT,Keen Umbehr,2
-Logan,Western,Governor,,LBT,Keen Umbehr,1
-Logan,Winona,Governor,,LBT,Keen Umbehr,5
-Logan,Provisional,Governor,,LBT,Keen Umbehr,0
-Logan,Augustine,Governor,,R,Sam Brownback,10
-Logan,Elkander,Governor,,R,Sam Brownback,3
-Logan,Lees,Governor,,R,Sam Brownback,5
-Logan,Logansport,Governor,,R,Sam Brownback,2
-Logan,Allender,Governor,,R,Sam Brownback,9
-Logan,Monument,Governor,,R,Sam Brownback,43
-Logan,Oakley 1,Governor,,R,Sam Brownback,218
-Logan,Oakley 2,Governor,,R,Sam Brownback,346
-Logan,Paxton,Governor,,R,Sam Brownback,20
-Logan,Russell Sprs,Governor,,R,Sam Brownback,15
-Logan,Western,Governor,,R,Sam Brownback,20
-Logan,Winona,Governor,,R,Sam Brownback,75
-Logan,Provisional,Governor,,R,Sam Brownback,4
-Logan,Augustine,Secretary of State,,D,Jean Schodorf,0
-Logan,Elkander,Secretary of State,,D,Jean Schodorf,0
-Logan,Lees,Secretary of State,,D,Jean Schodorf,5
-Logan,Logansport,Secretary of State,,D,Jean Schodorf,0
-Logan,Allender,Secretary of State,,D,Jean Schodorf,0
-Logan,Monument,Secretary of State,,D,Jean Schodorf,7
-Logan,Oakley 1,Secretary of State,,D,Jean Schodorf,98
-Logan,Oakley 2,Secretary of State,,D,Jean Schodorf,70
-Logan,Paxton,Secretary of State,,D,Jean Schodorf,0
-Logan,Russell Sprs,Secretary of State,,D,Jean Schodorf,4
-Logan,Western,Secretary of State,,D,Jean Schodorf,1
-Logan,Winona,Secretary of State,,D,Jean Schodorf,17
-Logan,Provisional,Secretary of State,,D,Jean Schodorf,3
-Logan,Augustine,Secretary of State,,R,Kris Kobach,11
-Logan,Elkander,Secretary of State,,R,Kris Kobach,3
-Logan,Lees,Secretary of State,,R,Kris Kobach,2
-Logan,Logansport,Secretary of State,,R,Kris Kobach,2
-Logan,Allender,Secretary of State,,R,Kris Kobach,11
-Logan,Monument,Secretary of State,,R,Kris Kobach,45
-Logan,Oakley 1,Secretary of State,,R,Kris Kobach,365
-Logan,Oakley 2,Secretary of State,,R,Kris Kobach,259
-Logan,Paxton,Secretary of State,,R,Kris Kobach,20
-Logan,Russell Sprs,Secretary of State,,R,Kris Kobach,15
-Logan,Western,Secretary of State,,R,Kris Kobach,20
-Logan,Winona,Secretary of State,,R,Kris Kobach,79
-Logan,Provisional,Secretary of State,,R,Kris Kobach,4
-Logan,Augustine,Attorney General,,R,Derek Schmidt,11
-Logan,Elkander,Attorney General,,R,Derek Schmidt,3
-Logan,Lees,Attorney General,,R,Derek Schmidt,5
-Logan,Logansport,Attorney General,,R,Derek Schmidt,2
-Logan,Allender,Attorney General,,R,Derek Schmidt,11
-Logan,Monument,Attorney General,,R,Derek Schmidt,50
-Logan,Oakley 1,Attorney General,,R,Derek Schmidt,400
-Logan,Oakley 2,Attorney General,,R,Derek Schmidt,282
-Logan,Paxton,Attorney General,,R,Derek Schmidt,20
-Logan,Russell Sprs,Attorney General,,R,Derek Schmidt,15
-Logan,Western,Attorney General,,R,Derek Schmidt,21
-Logan,Winona,Attorney General,,R,Derek Schmidt,85
-Logan,Provisional,Attorney General,,R,Derek Schmidt,4
-Logan,Augustine,Attorney General,,D,A.J. Kotich,0
-Logan,Elkander,Attorney General,,D,A.J. Kotich,0
-Logan,Lees,Attorney General,,D,A.J. Kotich,2
-Logan,Logansport,Attorney General,,D,A.J. Kotich,0
-Logan,Allender,Attorney General,,D,A.J. Kotich,0
-Logan,Monument,Attorney General,,D,A.J. Kotich,3
-Logan,Oakley 1,Attorney General,,D,A.J. Kotich,55
-Logan,Oakley 2,Attorney General,,D,A.J. Kotich,46
-Logan,Paxton,Attorney General,,D,A.J. Kotich,0
-Logan,Russell Sprs,Attorney General,,D,A.J. Kotich,3
-Logan,Western,Attorney General,,D,A.J. Kotich,0
-Logan,Winona,Attorney General,,D,A.J. Kotich,10
-Logan,Provisional,Attorney General,,D,A.J. Kotich,2
-Logan,Augustine,State Treasurer,,R,Ron Estes,11
-Logan,Elkander,State Treasurer,,R,Ron Estes,3
-Logan,Lees,State Treasurer,,R,Ron Estes,1
-Logan,Logansport,State Treasurer,,R,Ron Estes,6
-Logan,Allender,State Treasurer,,R,Ron Estes,11
-Logan,Monument,State Treasurer,,R,Ron Estes,51
-Logan,Oakley 1,State Treasurer,,R,Ron Estes,400
-Logan,Oakley 2,State Treasurer,,R,Ron Estes,286
-Logan,Paxton,State Treasurer,,R,Ron Estes,20
-Logan,Russell Sprs,State Treasurer,,R,Ron Estes,16
-Logan,Western,State Treasurer,,R,Ron Estes,20
-Logan,Winona,State Treasurer,,R,Ron Estes,87
-Logan,Provisional,State Treasurer,,R,Ron Estes,5
-Logan,Augustine,State Treasurer,,D,Carmen Alldritt,0
-Logan,Elkander,State Treasurer,,D,Carmen Alldritt,0
-Logan,Lees,State Treasurer,,D,Carmen Alldritt,2
-Logan,Logansport,State Treasurer,,D,Carmen Alldritt,0
-Logan,Allender,State Treasurer,,D,Carmen Alldritt,0
-Logan,Monument,State Treasurer,,D,Carmen Alldritt,3
-Logan,Oakley 1,State Treasurer,,D,Carmen Alldritt,56
-Logan,Oakley 2,State Treasurer,,D,Carmen Alldritt,40
-Logan,Paxton,State Treasurer,,D,Carmen Alldritt,0
-Logan,Russell Sprs,State Treasurer,,D,Carmen Alldritt,2
-Logan,Western,State Treasurer,,D,Carmen Alldritt,1
-Logan,Winona,State Treasurer,,D,Carmen Alldritt,9
-Logan,Provisional,State Treasurer,,D,Carmen Alldritt,2
-Logan,Augustine,Insurance Commissioner,,R,Ken Selzer,11
-Logan,Elkander,Insurance Commissioner,,R,Ken Selzer,3
-Logan,Lees,Insurance Commissioner,,R,Ken Selzer,5
-Logan,Logansport,Insurance Commissioner,,R,Ken Selzer,2
-Logan,Allender,Insurance Commissioner,,R,Ken Selzer,11
-Logan,Monument,Insurance Commissioner,,R,Ken Selzer,50
-Logan,Oakley 1,Insurance Commissioner,,R,Ken Selzer,388
-Logan,Oakley 2,Insurance Commissioner,,R,Ken Selzer,269
-Logan,Paxton,Insurance Commissioner,,R,Ken Selzer,20
-Logan,Russell Sprs,Insurance Commissioner,,R,Ken Selzer,15
-Logan,Western,Insurance Commissioner,,R,Ken Selzer,20
-Logan,Winona,Insurance Commissioner,,R,Ken Selzer,86
-Logan,Provisional,Insurance Commissioner,,R,Ken Selzer,2
-Logan,Augustine,Insurance Commissioner,,D,Dennis Anderson,0
-Logan,Elkander,Insurance Commissioner,,D,Dennis Anderson,0
-Logan,Lees,Insurance Commissioner,,D,Dennis Anderson,2
-Logan,Logansport,Insurance Commissioner,,D,Dennis Anderson,0
-Logan,Allender,Insurance Commissioner,,D,Dennis Anderson,0
-Logan,Monument,Insurance Commissioner,,D,Dennis Anderson,3
-Logan,Oakley 1,Insurance Commissioner,,D,Dennis Anderson,68
-Logan,Oakley 2,Insurance Commissioner,,D,Dennis Anderson,53
-Logan,Paxton,Insurance Commissioner,,D,Dennis Anderson,0
-Logan,Russell Sprs,Insurance Commissioner,,D,Dennis Anderson,3
-Logan,Western,Insurance Commissioner,,D,Dennis Anderson,1
-Logan,Winona,Insurance Commissioner,,D,Dennis Anderson,8
-Logan,Provisional,Insurance Commissioner,,D,Dennis Anderson,3
-Logan,Augustine,State House,118,R,Don Hineman,11
-Logan,Elkander,State House,118,R,Don Hineman,3
-Logan,Lees,State House,118,R,Don Hineman,6
-Logan,Logansport,State House,118,R,Don Hineman,2
-Logan,Allender,State House,118,R,Don Hineman,11
-Logan,Monument,State House,118,R,Don Hineman,49
-Logan,Oakley 1,State House,118,R,Don Hineman,408
-Logan,Oakley 2,State House,118,R,Don Hineman,293
-Logan,Paxton,State House,118,R,Don Hineman,20
-Logan,Russell Sprs,State House,118,R,Don Hineman,19
-Logan,Western,State House,118,R,Don Hineman,21
-Logan,Winona,State House,118,R,Don Hineman,88
-Logan,Provisional,State House,118,R,Don Hineman,6
-Logan,Monument,State House,118,,Write-ins,1
-Logan,Oakley 1,State House,118,,Write-ins,2
-Logan,Oakley 2,State House,118,,Write-ins,3
+county,precinct,office,district,party,candidate,votes,vtd
+LOGAN,Augustine Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000010
+LOGAN,Augustine Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+LOGAN,Augustine Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000010
+LOGAN,Elkader Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000020
+LOGAN,Elkader Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+LOGAN,Elkader Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000020
+LOGAN,Lees Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000030
+LOGAN,Lees Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+LOGAN,Lees Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,000030
+LOGAN,Logansport Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000040
+LOGAN,Logansport Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+LOGAN,Logansport Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,000040
+LOGAN,McAllaster Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000050
+LOGAN,McAllaster Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+LOGAN,McAllaster Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000050
+LOGAN,Monument Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000060
+LOGAN,Monument Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+LOGAN,Monument Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000060
+LOGAN,Oakley Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",91,000070
+LOGAN,Oakley Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000070
+LOGAN,Oakley Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",218,000070
+LOGAN,Oakley Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,000080
+LOGAN,Oakley Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000080
+LOGAN,Oakley Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",346,000080
+LOGAN,Paxton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000090
+LOGAN,Paxton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+LOGAN,Paxton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000090
+LOGAN,Russell Springs Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000100
+LOGAN,Russell Springs Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000100
+LOGAN,Russell Springs Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000100
+LOGAN,Western Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000110
+LOGAN,Western Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000110
+LOGAN,Western Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000110
+LOGAN,Winona Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000120
+LOGAN,Winona Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000120
+LOGAN,Winona Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000120
+LOGAN,Augustine Township,Kansas House of Representatives,118,Republican,"Hineman, Don",11,000010
+LOGAN,Elkader Township,Kansas House of Representatives,118,Republican,"Hineman, Don",3,000020
+LOGAN,Lees Township,Kansas House of Representatives,118,Republican,"Hineman, Don",6,000030
+LOGAN,Logansport Township,Kansas House of Representatives,118,Republican,"Hineman, Don",2,000040
+LOGAN,McAllaster Township,Kansas House of Representatives,118,Republican,"Hineman, Don",11,000050
+LOGAN,Monument Township,Kansas House of Representatives,118,Republican,"Hineman, Don",49,000060
+LOGAN,Oakley Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",408,000070
+LOGAN,Oakley Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",293,000080
+LOGAN,Paxton Township,Kansas House of Representatives,118,Republican,"Hineman, Don",20,000090
+LOGAN,Russell Springs Township,Kansas House of Representatives,118,Republican,"Hineman, Don",19,000100
+LOGAN,Western Township,Kansas House of Representatives,118,Republican,"Hineman, Don",21,000110
+LOGAN,Winona Township,Kansas House of Representatives,118,Republican,"Hineman, Don",88,000120
+LOGAN,Augustine Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000010
+LOGAN,Augustine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000010
+LOGAN,Elkader Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000020
+LOGAN,Elkader Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000020
+LOGAN,Lees Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000030
+LOGAN,Lees Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,000030
+LOGAN,Logansport Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000040
+LOGAN,Logansport Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,000040
+LOGAN,McAllaster Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000050
+LOGAN,McAllaster Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000050
+LOGAN,Monument Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000060
+LOGAN,Monument Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000060
+LOGAN,Oakley Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",88,000070
+LOGAN,Oakley Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",378,000070
+LOGAN,Oakley Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",66,000080
+LOGAN,Oakley Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",265,000080
+LOGAN,Paxton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000090
+LOGAN,Paxton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000090
+LOGAN,Russell Springs Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000100
+LOGAN,Russell Springs Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000100
+LOGAN,Western Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000110
+LOGAN,Western Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000110
+LOGAN,Winona Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000120
+LOGAN,Winona Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000120
+LOGAN,Augustine Township,Attorney General,,Democratic,"Kotich, A.J.",0,000010
+LOGAN,Augustine Township,Attorney General,,Republican,"Schmidt, Derek",11,000010
+LOGAN,Elkader Township,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+LOGAN,Elkader Township,Attorney General,,Republican,"Schmidt, Derek",3,000020
+LOGAN,Lees Township,Attorney General,,Democratic,"Kotich, A.J.",2,000030
+LOGAN,Lees Township,Attorney General,,Republican,"Schmidt, Derek",5,000030
+LOGAN,Logansport Township,Attorney General,,Democratic,"Kotich, A.J.",0,000040
+LOGAN,Logansport Township,Attorney General,,Republican,"Schmidt, Derek",2,000040
+LOGAN,McAllaster Township,Attorney General,,Democratic,"Kotich, A.J.",0,000050
+LOGAN,McAllaster Township,Attorney General,,Republican,"Schmidt, Derek",11,000050
+LOGAN,Monument Township,Attorney General,,Democratic,"Kotich, A.J.",3,000060
+LOGAN,Monument Township,Attorney General,,Republican,"Schmidt, Derek",50,000060
+LOGAN,Oakley Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",55,000070
+LOGAN,Oakley Precinct 1,Attorney General,,Republican,"Schmidt, Derek",400,000070
+LOGAN,Oakley Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",46,000080
+LOGAN,Oakley Precinct 2,Attorney General,,Republican,"Schmidt, Derek",282,000080
+LOGAN,Paxton Township,Attorney General,,Democratic,"Kotich, A.J.",0,000090
+LOGAN,Paxton Township,Attorney General,,Republican,"Schmidt, Derek",20,000090
+LOGAN,Russell Springs Township,Attorney General,,Democratic,"Kotich, A.J.",3,000100
+LOGAN,Russell Springs Township,Attorney General,,Republican,"Schmidt, Derek",15,000100
+LOGAN,Western Township,Attorney General,,Democratic,"Kotich, A.J.",0,000110
+LOGAN,Western Township,Attorney General,,Republican,"Schmidt, Derek",21,000110
+LOGAN,Winona Township,Attorney General,,Democratic,"Kotich, A.J.",10,000120
+LOGAN,Winona Township,Attorney General,,Republican,"Schmidt, Derek",85,000120
+LOGAN,Augustine Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000010
+LOGAN,Augustine Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000010
+LOGAN,Elkader Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000020
+LOGAN,Elkader Township,Commissioner of Insurance,,Republican,"Selzer, Ken",3,000020
+LOGAN,Lees Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000030
+LOGAN,Lees Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,000030
+LOGAN,Logansport Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000040
+LOGAN,Logansport Township,Commissioner of Insurance,,Republican,"Selzer, Ken",2,000040
+LOGAN,McAllaster Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000050
+LOGAN,McAllaster Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000050
+LOGAN,Monument Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000060
+LOGAN,Monument Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000060
+LOGAN,Oakley Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",68,000070
+LOGAN,Oakley Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",388,000070
+LOGAN,Oakley Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000080
+LOGAN,Oakley Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",269,000080
+LOGAN,Paxton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000090
+LOGAN,Paxton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000090
+LOGAN,Russell Springs Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000100
+LOGAN,Russell Springs Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000100
+LOGAN,Western Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000110
+LOGAN,Western Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000110
+LOGAN,Winona Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000120
+LOGAN,Winona Township,Commissioner of Insurance,,Republican,"Selzer, Ken",86,000120
+LOGAN,Augustine Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000010
+LOGAN,Augustine Township,Secretary of State,,Republican,"Kobach, Kris",11,000010
+LOGAN,Elkader Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+LOGAN,Elkader Township,Secretary of State,,Republican,"Kobach, Kris",3,000020
+LOGAN,Lees Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000030
+LOGAN,Lees Township,Secretary of State,,Republican,"Kobach, Kris",2,000030
+LOGAN,Logansport Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000040
+LOGAN,Logansport Township,Secretary of State,,Republican,"Kobach, Kris",2,000040
+LOGAN,McAllaster Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000050
+LOGAN,McAllaster Township,Secretary of State,,Republican,"Kobach, Kris",11,000050
+LOGAN,Monument Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000060
+LOGAN,Monument Township,Secretary of State,,Republican,"Kobach, Kris",45,000060
+LOGAN,Oakley Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",98,000070
+LOGAN,Oakley Precinct 1,Secretary of State,,Republican,"Kobach, Kris",365,000070
+LOGAN,Oakley Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,000080
+LOGAN,Oakley Precinct 2,Secretary of State,,Republican,"Kobach, Kris",259,000080
+LOGAN,Paxton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000090
+LOGAN,Paxton Township,Secretary of State,,Republican,"Kobach, Kris",20,000090
+LOGAN,Russell Springs Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000100
+LOGAN,Russell Springs Township,Secretary of State,,Republican,"Kobach, Kris",15,000100
+LOGAN,Western Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000110
+LOGAN,Western Township,Secretary of State,,Republican,"Kobach, Kris",20,000110
+LOGAN,Winona Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000120
+LOGAN,Winona Township,Secretary of State,,Republican,"Kobach, Kris",79,000120
+LOGAN,Augustine Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000010
+LOGAN,Augustine Township,State Treasurer,,Republican,"Estes, Ron",11,000010
+LOGAN,Elkader Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+LOGAN,Elkader Township,State Treasurer,,Republican,"Estes, Ron",3,000020
+LOGAN,Lees Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000030
+LOGAN,Lees Township,State Treasurer,,Republican,"Estes, Ron",1,000030
+LOGAN,Logansport Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+LOGAN,Logansport Township,State Treasurer,,Republican,"Estes, Ron",6,000040
+LOGAN,McAllaster Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000050
+LOGAN,McAllaster Township,State Treasurer,,Republican,"Estes, Ron",11,000050
+LOGAN,Monument Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000060
+LOGAN,Monument Township,State Treasurer,,Republican,"Estes, Ron",51,000060
+LOGAN,Oakley Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",56,000070
+LOGAN,Oakley Precinct 1,State Treasurer,,Republican,"Estes, Ron",400,000070
+LOGAN,Oakley Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",40,000080
+LOGAN,Oakley Precinct 2,State Treasurer,,Republican,"Estes, Ron",286,000080
+LOGAN,Paxton Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000090
+LOGAN,Paxton Township,State Treasurer,,Republican,"Estes, Ron",20,000090
+LOGAN,Russell Springs Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000100
+LOGAN,Russell Springs Township,State Treasurer,,Republican,"Estes, Ron",16,000100
+LOGAN,Western Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000110
+LOGAN,Western Township,State Treasurer,,Republican,"Estes, Ron",20,000110
+LOGAN,Winona Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000120
+LOGAN,Winona Township,State Treasurer,,Republican,"Estes, Ron",87,000120
+LOGAN,Augustine Township,United States Senate,,independent,"Orman, Greg",0,000010
+LOGAN,Augustine Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+LOGAN,Augustine Township,United States Senate,,Republican,"Roberts, Pat",11,000010
+LOGAN,Elkader Township,United States Senate,,independent,"Orman, Greg",0,000020
+LOGAN,Elkader Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+LOGAN,Elkader Township,United States Senate,,Republican,"Roberts, Pat",3,000020
+LOGAN,Lees Township,United States Senate,,independent,"Orman, Greg",2,000030
+LOGAN,Lees Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+LOGAN,Lees Township,United States Senate,,Republican,"Roberts, Pat",5,000030
+LOGAN,Logansport Township,United States Senate,,independent,"Orman, Greg",0,000040
+LOGAN,Logansport Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+LOGAN,Logansport Township,United States Senate,,Republican,"Roberts, Pat",2,000040
+LOGAN,McAllaster Township,United States Senate,,independent,"Orman, Greg",0,000050
+LOGAN,McAllaster Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+LOGAN,McAllaster Township,United States Senate,,Republican,"Roberts, Pat",11,000050
+LOGAN,Monument Township,United States Senate,,independent,"Orman, Greg",7,000060
+LOGAN,Monument Township,United States Senate,,Libertarian,"Batson, Randall",1,000060
+LOGAN,Monument Township,United States Senate,,Republican,"Roberts, Pat",47,000060
+LOGAN,Oakley Precinct 1,United States Senate,,independent,"Orman, Greg",93,000070
+LOGAN,Oakley Precinct 1,United States Senate,,Libertarian,"Batson, Randall",18,000070
+LOGAN,Oakley Precinct 1,United States Senate,,Republican,"Roberts, Pat",360,000070
+LOGAN,Oakley Precinct 2,United States Senate,,independent,"Orman, Greg",81,000080
+LOGAN,Oakley Precinct 2,United States Senate,,Libertarian,"Batson, Randall",25,000080
+LOGAN,Oakley Precinct 2,United States Senate,,Republican,"Roberts, Pat",226,000080
+LOGAN,Paxton Township,United States Senate,,independent,"Orman, Greg",0,000090
+LOGAN,Paxton Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+LOGAN,Paxton Township,United States Senate,,Republican,"Roberts, Pat",20,000090
+LOGAN,Russell Springs Township,United States Senate,,independent,"Orman, Greg",4,000100
+LOGAN,Russell Springs Township,United States Senate,,Libertarian,"Batson, Randall",2,000100
+LOGAN,Russell Springs Township,United States Senate,,Republican,"Roberts, Pat",13,000100
+LOGAN,Western Township,United States Senate,,independent,"Orman, Greg",1,000110
+LOGAN,Western Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+LOGAN,Western Township,United States Senate,,Republican,"Roberts, Pat",20,000110
+LOGAN,Winona Township,United States Senate,,independent,"Orman, Greg",14,000120
+LOGAN,Winona Township,United States Senate,,Libertarian,"Batson, Randall",3,000120
+LOGAN,Winona Township,United States Senate,,Republican,"Roberts, Pat",80,000120

--- a/2014/20141104__ks__general__lyon__precinct.csv
+++ b/2014/20141104__ks__general__lyon__precinct.csv
@@ -1,705 +1,973 @@
-county,precinct,office,district,party,candidate,votes
-Lyon,Emporia 01.01,Voters,,,Registration,800
-Lyon,Emporia 02.01,Voters,,,Registration,676
-Lyon,Emporia 03.01,Voters,,,Registration,808
-Lyon,Emporia 04.01,Voters,,,Registration,877
-Lyon,Emporia 4A.01,Voters,,,Registration,4
-Lyon,Emporia 4B.01,Voters,,,Registration,6
-Lyon,Emporia 4C.01,Voters,,,Registration,6
-Lyon,Emporia 05.01,Voters,,,Registration,668
-Lyon,Emporia 06.01,Voters,,,Registration,717
-Lyon,Emporia 07.01,Voters,,,Registration,434
-Lyon,Emporia 08.01,Voters,,,Registration,796
-Lyon,Emporia 09.01,Voters,,,Registration,553
-Lyon,Emporia 10.01,Voters,,,Registration,544
-Lyon,Emporia 11.01,Voters,,,Registration,539
-Lyon,Emporia 12.01,Voters,,,Registration,480
-Lyon,Emporia 13.01,Voters,,,Registration,755
-Lyon,Emporia 14.01,Voters,,,Registration,753
-Lyon,Emporia 15.01,Voters,,,Registration,426
-Lyon,Emporia 16.01,Voters,,,Registration,715
-Lyon,Emporia 17.01,Voters,,,Registration,698
-Lyon,Emporia 18.01,Voters,,,Registration,569
-Lyon,Emporia 19.01,Voters,,,Registration,952
-Lyon,Emporia 20.01,Voters,,,Registration,760
-Lyon,Precinct 21.01,Voters,,,Registration,298
-Lyon,Precinct 22.01,Voters,,,Registration,148
-Lyon,Precinct 23.01,Voters,,,Registration,197
-Lyon,Precinct 24.01,Voters,,,Registration,921
-Lyon,Precinct 25.01,Voters,,,Registration,641
-Lyon,Precinct 26.01,Voters,,,Registration,315
-Lyon,Precinct 27.01,Voters,,,Registration,571
-Lyon,Precinct 28.01,Voters,,,Registration,477
-Lyon,Precinct 29.01,Voters,,,Registration,220
-Lyon,Precinct 29D.01,Voters,,,Registration,8
-Lyon,Precinct 30.01,Voters,,,Registration,700
-Lyon,Precinct 31.01,Voters,,,Registration,827
-Lyon,Precinct 32.01,Voters,,,Registration,535
-Lyon,Emporia 01.01,Voters,,,Ballots Cast,326
-Lyon,Emporia 02.01,Voters,,,Ballots Cast,227
-Lyon,Emporia 03.01,Voters,,,Ballots Cast,274
-Lyon,Emporia 04.01,Voters,,,Ballots Cast,314
-Lyon,Emporia 4A.01,Voters,,,Ballots Cast,4
-Lyon,Emporia 4B.01,Voters,,,Ballots Cast,2
-Lyon,Emporia 4C.01,Voters,,,Ballots Cast,5
-Lyon,Emporia 05.01,Voters,,,Ballots Cast,181
-Lyon,Emporia 06.01,Voters,,,Ballots Cast,212
-Lyon,Emporia 07.01,Voters,,,Ballots Cast,91
-Lyon,Emporia 08.01,Voters,,,Ballots Cast,204
-Lyon,Emporia 09.01,Voters,,,Ballots Cast,207
-Lyon,Emporia 10.01,Voters,,,Ballots Cast,274
-Lyon,Emporia 11.01,Voters,,,Ballots Cast,205
-Lyon,Emporia 12.01,Voters,,,Ballots Cast,219
-Lyon,Emporia 13.01,Voters,,,Ballots Cast,310
-Lyon,Emporia 14.01,Voters,,,Ballots Cast,436
-Lyon,Emporia 15.01,Voters,,,Ballots Cast,236
-Lyon,Emporia 16.01,Voters,,,Ballots Cast,360
-Lyon,Emporia 17.01,Voters,,,Ballots Cast,359
-Lyon,Emporia 18.01,Voters,,,Ballots Cast,330
-Lyon,Emporia 19.01,Voters,,,Ballots Cast,541
-Lyon,Emporia 20.01,Voters,,,Ballots Cast,466
-Lyon,Precinct 21.01,Voters,,,Ballots Cast,155
-Lyon,Precinct 22.01,Voters,,,Ballots Cast,98
-Lyon,Precinct 23.01,Voters,,,Ballots Cast,110
-Lyon,Precinct 24.01,Voters,,,Ballots Cast,478
-Lyon,Precinct 25.01,Voters,,,Ballots Cast,400
-Lyon,Precinct 26.01,Voters,,,Ballots Cast,191
-Lyon,Precinct 27.01,Voters,,,Ballots Cast,282
-Lyon,Precinct 28.01,Voters,,,Ballots Cast,271
-Lyon,Precinct 29.01,Voters,,,Ballots Cast,139
-Lyon,Precinct 29D.01,Voters,,,Ballots Cast,3
-Lyon,Precinct 30.01,Voters,,,Ballots Cast,383
-Lyon,Precinct 31.01,Voters,,,Ballots Cast,502
-Lyon,Precinct 32.01,Voters,,,Ballots Cast,276
-Lyon,Emporia 01.01,U.S. Senate,,R,Pat Roberts,124
-Lyon,Emporia 02.01,U.S. Senate,,R,Pat Roberts,84
-Lyon,Emporia 03.01,U.S. Senate,,R,Pat Roberts,124
-Lyon,Emporia 04.01,U.S. Senate,,R,Pat Roberts,124
-Lyon,Emporia 4A.01,U.S. Senate,,R,Pat Roberts,4
-Lyon,Emporia 4B.01,U.S. Senate,,R,Pat Roberts,0
-Lyon,Emporia 4C.01,U.S. Senate,,R,Pat Roberts,2
-Lyon,Emporia 05.01,U.S. Senate,,R,Pat Roberts,76
-Lyon,Emporia 06.01,U.S. Senate,,R,Pat Roberts,88
-Lyon,Emporia 07.01,U.S. Senate,,R,Pat Roberts,33
-Lyon,Emporia 08.01,U.S. Senate,,R,Pat Roberts,79
-Lyon,Emporia 09.01,U.S. Senate,,R,Pat Roberts,89
-Lyon,Emporia 10.01,U.S. Senate,,R,Pat Roberts,108
-Lyon,Emporia 11.01,U.S. Senate,,R,Pat Roberts,87
-Lyon,Emporia 12.01,U.S. Senate,,R,Pat Roberts,91
-Lyon,Emporia 13.01,U.S. Senate,,R,Pat Roberts,135
-Lyon,Emporia 14.01,U.S. Senate,,R,Pat Roberts,184
-Lyon,Emporia 15.01,U.S. Senate,,R,Pat Roberts,109
-Lyon,Emporia 16.01,U.S. Senate,,R,Pat Roberts,145
-Lyon,Emporia 17.01,U.S. Senate,,R,Pat Roberts,160
-Lyon,Emporia 18.01,U.S. Senate,,R,Pat Roberts,154
-Lyon,Emporia 19.01,U.S. Senate,,R,Pat Roberts,234
-Lyon,Emporia 20.01,U.S. Senate,,R,Pat Roberts,239
-Lyon,Precinct 21.01,U.S. Senate,,R,Pat Roberts,80
-Lyon,Precinct 22.01,U.S. Senate,,R,Pat Roberts,60
-Lyon,Precinct 23.01,U.S. Senate,,R,Pat Roberts,66
-Lyon,Precinct 24.01,U.S. Senate,,R,Pat Roberts,263
-Lyon,Precinct 25.01,U.S. Senate,,R,Pat Roberts,236
-Lyon,Precinct 26.01,U.S. Senate,,R,Pat Roberts,97
-Lyon,Precinct 27.01,U.S. Senate,,R,Pat Roberts,157
-Lyon,Precinct 28.01,U.S. Senate,,R,Pat Roberts,138
-Lyon,Precinct 29.01,U.S. Senate,,R,Pat Roberts,79
-Lyon,Precinct 29D.01,U.S. Senate,,R,Pat Roberts,3
-Lyon,Precinct 30.01,U.S. Senate,,R,Pat Roberts,200
-Lyon,Precinct 31.01,U.S. Senate,,R,Pat Roberts,271
-Lyon,Precinct 32.01,U.S. Senate,,R,Pat Roberts,138
-Lyon,Emporia 01.01,U.S. Senate,,I,Greg Orman,188
-Lyon,Emporia 02.01,U.S. Senate,,I,Greg Orman,128
-Lyon,Emporia 03.01,U.S. Senate,,I,Greg Orman,124
-Lyon,Emporia 04.01,U.S. Senate,,I,Greg Orman,171
-Lyon,Emporia 4A.01,U.S. Senate,,I,Greg Orman,0
-Lyon,Emporia 4B.01,U.S. Senate,,I,Greg Orman,1
-Lyon,Emporia 4C.01,U.S. Senate,,I,Greg Orman,3
-Lyon,Emporia 05.01,U.S. Senate,,I,Greg Orman,86
-Lyon,Emporia 06.01,U.S. Senate,,I,Greg Orman,103
-Lyon,Emporia 07.01,U.S. Senate,,I,Greg Orman,53
-Lyon,Emporia 08.01,U.S. Senate,,I,Greg Orman,110
-Lyon,Emporia 09.01,U.S. Senate,,I,Greg Orman,107
-Lyon,Emporia 10.01,U.S. Senate,,I,Greg Orman,149
-Lyon,Emporia 11.01,U.S. Senate,,I,Greg Orman,107
-Lyon,Emporia 12.01,U.S. Senate,,I,Greg Orman,115
-Lyon,Emporia 13.01,U.S. Senate,,I,Greg Orman,142
-Lyon,Emporia 14.01,U.S. Senate,,I,Greg Orman,239
-Lyon,Emporia 15.01,U.S. Senate,,I,Greg Orman,116
-Lyon,Emporia 16.01,U.S. Senate,,I,Greg Orman,199
-Lyon,Emporia 17.01,U.S. Senate,,I,Greg Orman,172
-Lyon,Emporia 18.01,U.S. Senate,,I,Greg Orman,164
-Lyon,Emporia 19.01,U.S. Senate,,I,Greg Orman,279
-Lyon,Emporia 20.01,U.S. Senate,,I,Greg Orman,206
-Lyon,Precinct 21.01,U.S. Senate,,I,Greg Orman,65
-Lyon,Precinct 22.01,U.S. Senate,,I,Greg Orman,34
-Lyon,Precinct 23.01,U.S. Senate,,I,Greg Orman,34
-Lyon,Precinct 24.01,U.S. Senate,,I,Greg Orman,187
-Lyon,Precinct 25.01,U.S. Senate,,I,Greg Orman,142
-Lyon,Precinct 26.01,U.S. Senate,,I,Greg Orman,88
-Lyon,Precinct 27.01,U.S. Senate,,I,Greg Orman,107
-Lyon,Precinct 28.01,U.S. Senate,,I,Greg Orman,116
-Lyon,Precinct 29.01,U.S. Senate,,I,Greg Orman,54
-Lyon,Precinct 29D.01,U.S. Senate,,I,Greg Orman,0
-Lyon,Precinct 30.01,U.S. Senate,,I,Greg Orman,149
-Lyon,Precinct 31.01,U.S. Senate,,I,Greg Orman,198
-Lyon,Precinct 32.01,U.S. Senate,,I,Greg Orman,118
-Lyon,Emporia 01.01,U.S. Senate,,L,Randall Batson,7
-Lyon,Emporia 02.01,U.S. Senate,,L,Randall Batson,11
-Lyon,Emporia 03.01,U.S. Senate,,L,Randall Batson,17
-Lyon,Emporia 04.01,U.S. Senate,,L,Randall Batson,13
-Lyon,Emporia 4A.01,U.S. Senate,,L,Randall Batson,0
-Lyon,Emporia 4B.01,U.S. Senate,,L,Randall Batson,0
-Lyon,Emporia 4C.01,U.S. Senate,,L,Randall Batson,0
-Lyon,Emporia 05.01,U.S. Senate,,L,Randall Batson,13
-Lyon,Emporia 06.01,U.S. Senate,,L,Randall Batson,13
-Lyon,Emporia 07.01,U.S. Senate,,L,Randall Batson,5
-Lyon,Emporia 08.01,U.S. Senate,,L,Randall Batson,11
-Lyon,Emporia 09.01,U.S. Senate,,L,Randall Batson,6
-Lyon,Emporia 10.01,U.S. Senate,,L,Randall Batson,12
-Lyon,Emporia 11.01,U.S. Senate,,L,Randall Batson,7
-Lyon,Emporia 12.01,U.S. Senate,,L,Randall Batson,8
-Lyon,Emporia 13.01,U.S. Senate,,L,Randall Batson,22
-Lyon,Emporia 14.01,U.S. Senate,,L,Randall Batson,10
-Lyon,Emporia 15.01,U.S. Senate,,L,Randall Batson,7
-Lyon,Emporia 16.01,U.S. Senate,,L,Randall Batson,11
-Lyon,Emporia 17.01,U.S. Senate,,L,Randall Batson,22
-Lyon,Emporia 18.01,U.S. Senate,,L,Randall Batson,8
-Lyon,Emporia 19.01,U.S. Senate,,L,Randall Batson,16
-Lyon,Emporia 20.01,U.S. Senate,,L,Randall Batson,14
-Lyon,Precinct 21.01,U.S. Senate,,L,Randall Batson,5
-Lyon,Precinct 22.01,U.S. Senate,,L,Randall Batson,3
-Lyon,Precinct 23.01,U.S. Senate,,L,Randall Batson,7
-Lyon,Precinct 24.01,U.S. Senate,,L,Randall Batson,23
-Lyon,Precinct 25.01,U.S. Senate,,L,Randall Batson,19
-Lyon,Precinct 26.01,U.S. Senate,,L,Randall Batson,5
-Lyon,Precinct 27.01,U.S. Senate,,L,Randall Batson,18
-Lyon,Precinct 28.01,U.S. Senate,,L,Randall Batson,14
-Lyon,Precinct 29.01,U.S. Senate,,L,Randall Batson,5
-Lyon,Precinct 29D.01,U.S. Senate,,L,Randall Batson,0
-Lyon,Precinct 30.01,U.S. Senate,,L,Randall Batson,29
-Lyon,Precinct 31.01,U.S. Senate,,L,Randall Batson,25
-Lyon,Precinct 32.01,U.S. Senate,,L,Randall Batson,16
-Lyon,Emporia 01.01,U.S. House,1,R,Tim Huelskamp,124
-Lyon,Emporia 02.01,U.S. House,1,R,Tim Huelskamp,101
-Lyon,Emporia 03.01,U.S. House,1,R,Tim Huelskamp,131
-Lyon,Emporia 04.01,U.S. House,1,R,Tim Huelskamp,145
-Lyon,Emporia 4A.01,U.S. House,1,R,Tim Huelskamp,4
-Lyon,Emporia 4B.01,U.S. House,1,R,Tim Huelskamp,0
-Lyon,Emporia 4C.01,U.S. House,1,R,Tim Huelskamp,1
-Lyon,Emporia 05.01,U.S. House,1,R,Tim Huelskamp,90
-Lyon,Emporia 06.01,U.S. House,1,R,Tim Huelskamp,85
-Lyon,Emporia 07.01,U.S. House,1,R,Tim Huelskamp,37
-Lyon,Emporia 08.01,U.S. House,1,R,Tim Huelskamp,98
-Lyon,Emporia 09.01,U.S. House,1,R,Tim Huelskamp,94
-Lyon,Emporia 10.01,U.S. House,1,R,Tim Huelskamp,131
-Lyon,Emporia 11.01,U.S. House,1,R,Tim Huelskamp,99
-Lyon,Emporia 12.01,U.S. House,1,R,Tim Huelskamp,94
-Lyon,Emporia 13.01,U.S. House,1,R,Tim Huelskamp,149
-Lyon,Emporia 14.01,U.S. House,1,R,Tim Huelskamp,190
-Lyon,Emporia 15.01,U.S. House,1,R,Tim Huelskamp,109
-Lyon,Emporia 16.01,U.S. House,1,R,Tim Huelskamp,154
-Lyon,Emporia 17.01,U.S. House,1,R,Tim Huelskamp,168
-Lyon,Emporia 18.01,U.S. House,1,R,Tim Huelskamp,164
-Lyon,Emporia 19.01,U.S. House,1,R,Tim Huelskamp,269
-Lyon,Emporia 20.01,U.S. House,1,R,Tim Huelskamp,233
-Lyon,Precinct 21.01,U.S. House,1,R,Tim Huelskamp,95
-Lyon,Precinct 22.01,U.S. House,1,R,Tim Huelskamp,67
-Lyon,Precinct 23.01,U.S. House,1,R,Tim Huelskamp,67
-Lyon,Precinct 24.01,U.S. House,1,R,Tim Huelskamp,283
-Lyon,Precinct 25.01,U.S. House,1,R,Tim Huelskamp,259
-Lyon,Precinct 26.01,U.S. House,1,R,Tim Huelskamp,106
-Lyon,Precinct 27.01,U.S. House,1,R,Tim Huelskamp,176
-Lyon,Precinct 28.01,U.S. House,1,R,Tim Huelskamp,162
-Lyon,Precinct 29.01,U.S. House,1,R,Tim Huelskamp,81
-Lyon,Precinct 29D.01,U.S. House,1,R,Tim Huelskamp,3
-Lyon,Precinct 30.01,U.S. House,1,R,Tim Huelskamp,224
-Lyon,Precinct 31.01,U.S. House,1,R,Tim Huelskamp,306
-Lyon,Precinct 32.01,U.S. House,1,R,Tim Huelskamp,168
-Lyon,Emporia 01.01,U.S. House,1,D,James Sherow,193
-Lyon,Emporia 02.01,U.S. House,1,D,James Sherow,115
-Lyon,Emporia 03.01,U.S. House,1,D,James Sherow,126
-Lyon,Emporia 04.01,U.S. House,1,D,James Sherow,157
-Lyon,Emporia 4A.01,U.S. House,1,D,James Sherow,0
-Lyon,Emporia 4B.01,U.S. House,1,D,James Sherow,2
-Lyon,Emporia 4C.01,U.S. House,1,D,James Sherow,4
-Lyon,Emporia 05.01,U.S. House,1,D,James Sherow,86
-Lyon,Emporia 06.01,U.S. House,1,D,James Sherow,121
-Lyon,Emporia 07.01,U.S. House,1,D,James Sherow,51
-Lyon,Emporia 08.01,U.S. House,1,D,James Sherow,102
-Lyon,Emporia 09.01,U.S. House,1,D,James Sherow,104
-Lyon,Emporia 10.01,U.S. House,1,D,James Sherow,136
-Lyon,Emporia 11.01,U.S. House,1,D,James Sherow,101
-Lyon,Emporia 12.01,U.S. House,1,D,James Sherow,114
-Lyon,Emporia 13.01,U.S. House,1,D,James Sherow,145
-Lyon,Emporia 14.01,U.S. House,1,D,James Sherow,230
-Lyon,Emporia 15.01,U.S. House,1,D,James Sherow,122
-Lyon,Emporia 16.01,U.S. House,1,D,James Sherow,196
-Lyon,Emporia 17.01,U.S. House,1,D,James Sherow,181
-Lyon,Emporia 18.01,U.S. House,1,D,James Sherow,156
-Lyon,Emporia 19.01,U.S. House,1,D,James Sherow,252
-Lyon,Emporia 20.01,U.S. House,1,D,James Sherow,214
-Lyon,Precinct 21.01,U.S. House,1,D,James Sherow,50
-Lyon,Precinct 22.01,U.S. House,1,D,James Sherow,31
-Lyon,Precinct 23.01,U.S. House,1,D,James Sherow,40
-Lyon,Precinct 24.01,U.S. House,1,D,James Sherow,179
-Lyon,Precinct 25.01,U.S. House,1,D,James Sherow,135
-Lyon,Precinct 26.01,U.S. House,1,D,James Sherow,81
-Lyon,Precinct 27.01,U.S. House,1,D,James Sherow,98
-Lyon,Precinct 28.01,U.S. House,1,D,James Sherow,99
-Lyon,Precinct 29.01,U.S. House,1,D,James Sherow,54
-Lyon,Precinct 29D.01,U.S. House,1,D,James Sherow,0
-Lyon,Precinct 30.01,U.S. House,1,D,James Sherow,150
-Lyon,Precinct 31.01,U.S. House,1,D,James Sherow,173
-Lyon,Precinct 32.01,U.S. House,1,D,James Sherow,105
-Lyon,Emporia 01.01,Governor,,R,Sam Brownback,99
-Lyon,Emporia 02.01,Governor,,R,Sam Brownback,64
-Lyon,Emporia 03.01,Governor,,R,Sam Brownback,107
-Lyon,Emporia 04.01,Governor,,R,Sam Brownback,96
-Lyon,Emporia 4A.01,Governor,,R,Sam Brownback,4
-Lyon,Emporia 4B.01,Governor,,R,Sam Brownback,0
-Lyon,Emporia 4C.01,Governor,,R,Sam Brownback,1
-Lyon,Emporia 05.01,Governor,,R,Sam Brownback,61
-Lyon,Emporia 06.01,Governor,,R,Sam Brownback,71
-Lyon,Emporia 07.01,Governor,,R,Sam Brownback,23
-Lyon,Emporia 08.01,Governor,,R,Sam Brownback,65
-Lyon,Emporia 09.01,Governor,,R,Sam Brownback,71
-Lyon,Emporia 10.01,Governor,,R,Sam Brownback,93
-Lyon,Emporia 11.01,Governor,,R,Sam Brownback,64
-Lyon,Emporia 12.01,Governor,,R,Sam Brownback,60
-Lyon,Emporia 13.01,Governor,,R,Sam Brownback,108
-Lyon,Emporia 14.01,Governor,,R,Sam Brownback,142
-Lyon,Emporia 15.01,Governor,,R,Sam Brownback,84
-Lyon,Emporia 16.01,Governor,,R,Sam Brownback,110
-Lyon,Emporia 17.01,Governor,,R,Sam Brownback,126
-Lyon,Emporia 18.01,Governor,,R,Sam Brownback,128
-Lyon,Emporia 19.01,Governor,,R,Sam Brownback,192
-Lyon,Emporia 20.01,Governor,,R,Sam Brownback,171
-Lyon,Precinct 21.01,Governor,,R,Sam Brownback,77
-Lyon,Precinct 22.01,Governor,,R,Sam Brownback,55
-Lyon,Precinct 23.01,Governor,,R,Sam Brownback,57
-Lyon,Precinct 24.01,Governor,,R,Sam Brownback,234
-Lyon,Precinct 25.01,Governor,,R,Sam Brownback,205
-Lyon,Precinct 26.01,Governor,,R,Sam Brownback,82
-Lyon,Precinct 27.01,Governor,,R,Sam Brownback,148
-Lyon,Precinct 28.01,Governor,,R,Sam Brownback,130
-Lyon,Precinct 29.01,Governor,,R,Sam Brownback,63
-Lyon,Precinct 29D.01,Governor,,R,Sam Brownback,3
-Lyon,Precinct 30.01,Governor,,R,Sam Brownback,180
-Lyon,Precinct 31.01,Governor,,R,Sam Brownback,221
-Lyon,Precinct 32.01,Governor,,R,Sam Brownback,125
-Lyon,Emporia 01.01,Governor,,D,Paul Davis,213
-Lyon,Emporia 02.01,Governor,,D,Paul Davis,154
-Lyon,Emporia 03.01,Governor,,D,Paul Davis,154
-Lyon,Emporia 04.01,Governor,,D,Paul Davis,195
-Lyon,Emporia 4A.01,Governor,,D,Paul Davis,0
-Lyon,Emporia 4B.01,Governor,,D,Paul Davis,2
-Lyon,Emporia 4C.01,Governor,,D,Paul Davis,4
-Lyon,Emporia 05.01,Governor,,D,Paul Davis,99
-Lyon,Emporia 06.01,Governor,,D,Paul Davis,125
-Lyon,Emporia 07.01,Governor,,D,Paul Davis,60
-Lyon,Emporia 08.01,Governor,,D,Paul Davis,124
-Lyon,Emporia 09.01,Governor,,D,Paul Davis,121
-Lyon,Emporia 10.01,Governor,,D,Paul Davis,173
-Lyon,Emporia 11.01,Governor,,D,Paul Davis,126
-Lyon,Emporia 12.01,Governor,,D,Paul Davis,144
-Lyon,Emporia 13.01,Governor,,D,Paul Davis,175
-Lyon,Emporia 14.01,Governor,,D,Paul Davis,282
-Lyon,Emporia 15.01,Governor,,D,Paul Davis,146
-Lyon,Emporia 16.01,Governor,,D,Paul Davis,236
-Lyon,Emporia 17.01,Governor,,D,Paul Davis,211
-Lyon,Emporia 18.01,Governor,,D,Paul Davis,199
-Lyon,Emporia 19.01,Governor,,D,Paul Davis,327
-Lyon,Emporia 20.01,Governor,,D,Paul Davis,283
-Lyon,Precinct 21.01,Governor,,D,Paul Davis,65
-Lyon,Precinct 22.01,Governor,,D,Paul Davis,39
-Lyon,Precinct 23.01,Governor,,D,Paul Davis,46
-Lyon,Precinct 24.01,Governor,,D,Paul Davis,222
-Lyon,Precinct 25.01,Governor,,D,Paul Davis,164
-Lyon,Precinct 26.01,Governor,,D,Paul Davis,93
-Lyon,Precinct 27.01,Governor,,D,Paul Davis,124
-Lyon,Precinct 28.01,Governor,,D,Paul Davis,123
-Lyon,Precinct 29.01,Governor,,D,Paul Davis,72
-Lyon,Precinct 29D.01,Governor,,D,Paul Davis,0
-Lyon,Precinct 30.01,Governor,,D,Paul Davis,173
-Lyon,Precinct 31.01,Governor,,D,Paul Davis,259
-Lyon,Precinct 32.01,Governor,,D,Paul Davis,120
-Lyon,Emporia 01.01,Governor,,L,Keen Umbehr,13
-Lyon,Emporia 02.01,Governor,,L,Keen Umbehr,6
-Lyon,Emporia 03.01,Governor,,L,Keen Umbehr,10
-Lyon,Emporia 04.01,Governor,,L,Keen Umbehr,20
-Lyon,Emporia 4A.01,Governor,,L,Keen Umbehr,0
-Lyon,Emporia 4B.01,Governor,,L,Keen Umbehr,0
-Lyon,Emporia 4C.01,Governor,,L,Keen Umbehr,0
-Lyon,Emporia 05.01,Governor,,L,Keen Umbehr,20
-Lyon,Emporia 06.01,Governor,,L,Keen Umbehr,14
-Lyon,Emporia 07.01,Governor,,L,Keen Umbehr,8
-Lyon,Emporia 08.01,Governor,,L,Keen Umbehr,15
-Lyon,Emporia 09.01,Governor,,L,Keen Umbehr,10
-Lyon,Emporia 10.01,Governor,,L,Keen Umbehr,6
-Lyon,Emporia 11.01,Governor,,L,Keen Umbehr,12
-Lyon,Emporia 12.01,Governor,,L,Keen Umbehr,13
-Lyon,Emporia 13.01,Governor,,L,Keen Umbehr,24
-Lyon,Emporia 14.01,Governor,,L,Keen Umbehr,10
-Lyon,Emporia 15.01,Governor,,L,Keen Umbehr,6
-Lyon,Emporia 16.01,Governor,,L,Keen Umbehr,10
-Lyon,Emporia 17.01,Governor,,L,Keen Umbehr,16
-Lyon,Emporia 18.01,Governor,,L,Keen Umbehr,2
-Lyon,Emporia 19.01,Governor,,L,Keen Umbehr,17
-Lyon,Emporia 20.01,Governor,,L,Keen Umbehr,8
-Lyon,Precinct 21.01,Governor,,L,Keen Umbehr,12
-Lyon,Precinct 22.01,Governor,,L,Keen Umbehr,4
-Lyon,Precinct 23.01,Governor,,L,Keen Umbehr,7
-Lyon,Precinct 24.01,Governor,,L,Keen Umbehr,17
-Lyon,Precinct 25.01,Governor,,L,Keen Umbehr,26
-Lyon,Precinct 26.01,Governor,,L,Keen Umbehr,12
-Lyon,Precinct 27.01,Governor,,L,Keen Umbehr,10
-Lyon,Precinct 28.01,Governor,,L,Keen Umbehr,16
-Lyon,Precinct 29.01,Governor,,L,Keen Umbehr,4
-Lyon,Precinct 29D.01,Governor,,L,Keen Umbehr,0
-Lyon,Precinct 30.01,Governor,,L,Keen Umbehr,22
-Lyon,Precinct 31.01,Governor,,L,Keen Umbehr,20
-Lyon,Precinct 32.01,Governor,,L,Keen Umbehr,28
-Lyon,Emporia 01.01,Secretary of State,,R,Kris Kobach,121
-Lyon,Emporia 02.01,Secretary of State,,R,Kris Kobach,96
-Lyon,Emporia 03.01,Secretary of State,,R,Kris Kobach,133
-Lyon,Emporia 04.01,Secretary of State,,R,Kris Kobach,149
-Lyon,Emporia 4A.01,Secretary of State,,R,Kris Kobach,4
-Lyon,Emporia 4B.01,Secretary of State,,R,Kris Kobach,0
-Lyon,Emporia 4C.01,Secretary of State,,R,Kris Kobach,2
-Lyon,Emporia 05.01,Secretary of State,,R,Kris Kobach,90
-Lyon,Emporia 06.01,Secretary of State,,R,Kris Kobach,86
-Lyon,Emporia 07.01,Secretary of State,,R,Kris Kobach,36
-Lyon,Emporia 08.01,Secretary of State,,R,Kris Kobach,92
-Lyon,Emporia 09.01,Secretary of State,,R,Kris Kobach,99
-Lyon,Emporia 10.01,Secretary of State,,R,Kris Kobach,131
-Lyon,Emporia 11.01,Secretary of State,,R,Kris Kobach,100
-Lyon,Emporia 12.01,Secretary of State,,R,Kris Kobach,97
-Lyon,Emporia 13.01,Secretary of State,,R,Kris Kobach,160
-Lyon,Emporia 14.01,Secretary of State,,R,Kris Kobach,197
-Lyon,Emporia 15.01,Secretary of State,,R,Kris Kobach,115
-Lyon,Emporia 16.01,Secretary of State,,R,Kris Kobach,163
-Lyon,Emporia 17.01,Secretary of State,,R,Kris Kobach,184
-Lyon,Emporia 18.01,Secretary of State,,R,Kris Kobach,172
-Lyon,Emporia 19.01,Secretary of State,,R,Kris Kobach,284
-Lyon,Emporia 20.01,Secretary of State,,R,Kris Kobach,249
-Lyon,Precinct 21.01,Secretary of State,,R,Kris Kobach,102
-Lyon,Precinct 22.01,Secretary of State,,R,Kris Kobach,69
-Lyon,Precinct 23.01,Secretary of State,,R,Kris Kobach,70
-Lyon,Precinct 24.01,Secretary of State,,R,Kris Kobach,302
-Lyon,Precinct 25.01,Secretary of State,,R,Kris Kobach,259
-Lyon,Precinct 26.01,Secretary of State,,R,Kris Kobach,101
-Lyon,Precinct 27.01,Secretary of State,,R,Kris Kobach,179
-Lyon,Precinct 28.01,Secretary of State,,R,Kris Kobach,171
-Lyon,Precinct 29.01,Secretary of State,,R,Kris Kobach,87
-Lyon,Precinct 29D.01,Secretary of State,,R,Kris Kobach,2
-Lyon,Precinct 30.01,Secretary of State,,R,Kris Kobach,234
-Lyon,Precinct 31.01,Secretary of State,,R,Kris Kobach,314
-Lyon,Precinct 32.01,Secretary of State,,R,Kris Kobach,169
-Lyon,Emporia 01.01,Secretary of State,,D,Jean Schodorf,197
-Lyon,Emporia 02.01,Secretary of State,,D,Jean Schodorf,121
-Lyon,Emporia 03.01,Secretary of State,,D,Jean Schodorf,124
-Lyon,Emporia 04.01,Secretary of State,,D,Jean Schodorf,154
-Lyon,Emporia 4A.01,Secretary of State,,D,Jean Schodorf,0
-Lyon,Emporia 4B.01,Secretary of State,,D,Jean Schodorf,2
-Lyon,Emporia 4C.01,Secretary of State,,D,Jean Schodorf,3
-Lyon,Emporia 05.01,Secretary of State,,D,Jean Schodorf,85
-Lyon,Emporia 06.01,Secretary of State,,D,Jean Schodorf,122
-Lyon,Emporia 07.01,Secretary of State,,D,Jean Schodorf,49
-Lyon,Emporia 08.01,Secretary of State,,D,Jean Schodorf,108
-Lyon,Emporia 09.01,Secretary of State,,D,Jean Schodorf,98
-Lyon,Emporia 10.01,Secretary of State,,D,Jean Schodorf,136
-Lyon,Emporia 11.01,Secretary of State,,D,Jean Schodorf,100
-Lyon,Emporia 12.01,Secretary of State,,D,Jean Schodorf,114
-Lyon,Emporia 13.01,Secretary of State,,D,Jean Schodorf,138
-Lyon,Emporia 14.01,Secretary of State,,D,Jean Schodorf,232
-Lyon,Emporia 15.01,Secretary of State,,D,Jean Schodorf,117
-Lyon,Emporia 16.01,Secretary of State,,D,Jean Schodorf,188
-Lyon,Emporia 17.01,Secretary of State,,D,Jean Schodorf,163
-Lyon,Emporia 18.01,Secretary of State,,D,Jean Schodorf,150
-Lyon,Emporia 19.01,Secretary of State,,D,Jean Schodorf,238
-Lyon,Emporia 20.01,Secretary of State,,D,Jean Schodorf,203
-Lyon,Precinct 21.01,Secretary of State,,D,Jean Schodorf,47
-Lyon,Precinct 22.01,Secretary of State,,D,Jean Schodorf,29
-Lyon,Precinct 23.01,Secretary of State,,D,Jean Schodorf,40
-Lyon,Precinct 24.01,Secretary of State,,D,Jean Schodorf,161
-Lyon,Precinct 25.01,Secretary of State,,D,Jean Schodorf,133
-Lyon,Precinct 26.01,Secretary of State,,D,Jean Schodorf,84
-Lyon,Precinct 27.01,Secretary of State,,D,Jean Schodorf,96
-Lyon,Precinct 28.01,Secretary of State,,D,Jean Schodorf,89
-Lyon,Precinct 29.01,Secretary of State,,D,Jean Schodorf,49
-Lyon,Precinct 29D.01,Secretary of State,,D,Jean Schodorf,0
-Lyon,Precinct 30.01,Secretary of State,,D,Jean Schodorf,141
-Lyon,Precinct 31.01,Secretary of State,,D,Jean Schodorf,171
-Lyon,Precinct 32.01,Secretary of State,,D,Jean Schodorf,102
-Lyon,Emporia 01.01,Attorney General,,R,Derek Schmidt,157
-Lyon,Emporia 02.01,Attorney General,,R,Derek Schmidt,106
-Lyon,Emporia 03.01,Attorney General,,R,Derek Schmidt,147
-Lyon,Emporia 04.01,Attorney General,,R,Derek Schmidt,161
-Lyon,Emporia 4A.01,Attorney General,,R,Derek Schmidt,4
-Lyon,Emporia 4B.01,Attorney General,,R,Derek Schmidt,0
-Lyon,Emporia 4C.01,Attorney General,,R,Derek Schmidt,3
-Lyon,Emporia 05.01,Attorney General,,R,Derek Schmidt,100
-Lyon,Emporia 06.01,Attorney General,,R,Derek Schmidt,96
-Lyon,Emporia 07.01,Attorney General,,R,Derek Schmidt,42
-Lyon,Emporia 08.01,Attorney General,,R,Derek Schmidt,101
-Lyon,Emporia 09.01,Attorney General,,R,Derek Schmidt,111
-Lyon,Emporia 10.01,Attorney General,,R,Derek Schmidt,154
-Lyon,Emporia 11.01,Attorney General,,R,Derek Schmidt,114
-Lyon,Emporia 12.01,Attorney General,,R,Derek Schmidt,109
-Lyon,Emporia 13.01,Attorney General,,R,Derek Schmidt,175
-Lyon,Emporia 14.01,Attorney General,,R,Derek Schmidt,233
-Lyon,Emporia 15.01,Attorney General,,R,Derek Schmidt,131
-Lyon,Emporia 16.01,Attorney General,,R,Derek Schmidt,193
-Lyon,Emporia 17.01,Attorney General,,R,Derek Schmidt,219
-Lyon,Emporia 18.01,Attorney General,,R,Derek Schmidt,197
-Lyon,Emporia 19.01,Attorney General,,R,Derek Schmidt,333
-Lyon,Emporia 20.01,Attorney General,,R,Derek Schmidt,298
-Lyon,Precinct 21.01,Attorney General,,R,Derek Schmidt,110
-Lyon,Precinct 22.01,Attorney General,,R,Derek Schmidt,71
-Lyon,Precinct 23.01,Attorney General,,R,Derek Schmidt,81
-Lyon,Precinct 24.01,Attorney General,,R,Derek Schmidt,318
-Lyon,Precinct 25.01,Attorney General,,R,Derek Schmidt,302
-Lyon,Precinct 26.01,Attorney General,,R,Derek Schmidt,129
-Lyon,Precinct 27.01,Attorney General,,R,Derek Schmidt,200
-Lyon,Precinct 28.01,Attorney General,,R,Derek Schmidt,184
-Lyon,Precinct 29.01,Attorney General,,R,Derek Schmidt,99
-Lyon,Precinct 29D.01,Attorney General,,R,Derek Schmidt,3
-Lyon,Precinct 30.01,Attorney General,,R,Derek Schmidt,258
-Lyon,Precinct 31.01,Attorney General,,R,Derek Schmidt,367
-Lyon,Precinct 32.01,Attorney General,,R,Derek Schmidt,204
-Lyon,Emporia 01.01,Attorney General,,D,AJ Kotich,157
-Lyon,Emporia 02.01,Attorney General,,D,AJ Kotich,111
-Lyon,Emporia 03.01,Attorney General,,D,AJ Kotich,110
-Lyon,Emporia 04.01,Attorney General,,D,AJ Kotich,136
-Lyon,Emporia 4A.01,Attorney General,,D,AJ Kotich,0
-Lyon,Emporia 4B.01,Attorney General,,D,AJ Kotich,2
-Lyon,Emporia 4C.01,Attorney General,,D,AJ Kotich,2
-Lyon,Emporia 05.01,Attorney General,,D,AJ Kotich,74
-Lyon,Emporia 06.01,Attorney General,,D,AJ Kotich,107
-Lyon,Emporia 07.01,Attorney General,,D,AJ Kotich,43
-Lyon,Emporia 08.01,Attorney General,,D,AJ Kotich,94
-Lyon,Emporia 09.01,Attorney General,,D,AJ Kotich,87
-Lyon,Emporia 10.01,Attorney General,,D,AJ Kotich,113
-Lyon,Emporia 11.01,Attorney General,,D,AJ Kotich,85
-Lyon,Emporia 12.01,Attorney General,,D,AJ Kotich,97
-Lyon,Emporia 13.01,Attorney General,,D,AJ Kotich,119
-Lyon,Emporia 14.01,Attorney General,,D,AJ Kotich,190
-Lyon,Emporia 15.01,Attorney General,,D,AJ Kotich,99
-Lyon,Emporia 16.01,Attorney General,,D,AJ Kotich,147
-Lyon,Emporia 17.01,Attorney General,,D,AJ Kotich,126
-Lyon,Emporia 18.01,Attorney General,,D,AJ Kotich,117
-Lyon,Emporia 19.01,Attorney General,,D,AJ Kotich,182
-Lyon,Emporia 20.01,Attorney General,,D,AJ Kotich,152
-Lyon,Precinct 21.01,Attorney General,,D,AJ Kotich,39
-Lyon,Precinct 22.01,Attorney General,,D,AJ Kotich,27
-Lyon,Precinct 23.01,Attorney General,,D,AJ Kotich,28
-Lyon,Precinct 24.01,Attorney General,,D,AJ Kotich,140
-Lyon,Precinct 25.01,Attorney General,,D,AJ Kotich,89
-Lyon,Precinct 26.01,Attorney General,,D,AJ Kotich,54
-Lyon,Precinct 27.01,Attorney General,,D,AJ Kotich,69
-Lyon,Precinct 28.01,Attorney General,,D,AJ Kotich,77
-Lyon,Precinct 29.01,Attorney General,,D,AJ Kotich,33
-Lyon,Precinct 29D.01,Attorney General,,D,AJ Kotich,0
-Lyon,Precinct 30.01,Attorney General,,D,AJ Kotich,110
-Lyon,Precinct 31.01,Attorney General,,D,AJ Kotich,116
-Lyon,Precinct 32.01,Attorney General,,D,AJ Kotich,67
-Lyon,Emporia 01.01,State Treasurer,,R,Ron Estes,162
-Lyon,Emporia 02.01,State Treasurer,,R,Ron Estes,117
-Lyon,Emporia 03.01,State Treasurer,,R,Ron Estes,147
-Lyon,Emporia 04.01,State Treasurer,,R,Ron Estes,165
-Lyon,Emporia 4A.01,State Treasurer,,R,Ron Estes,4
-Lyon,Emporia 4B.01,State Treasurer,,R,Ron Estes,0
-Lyon,Emporia 4C.01,State Treasurer,,R,Ron Estes,2
-Lyon,Emporia 05.01,State Treasurer,,R,Ron Estes,97
-Lyon,Emporia 06.01,State Treasurer,,R,Ron Estes,103
-Lyon,Emporia 07.01,State Treasurer,,R,Ron Estes,44
-Lyon,Emporia 08.01,State Treasurer,,R,Ron Estes,108
-Lyon,Emporia 09.01,State Treasurer,,R,Ron Estes,118
-Lyon,Emporia 10.01,State Treasurer,,R,Ron Estes,156
-Lyon,Emporia 11.01,State Treasurer,,R,Ron Estes,108
-Lyon,Emporia 12.01,State Treasurer,,R,Ron Estes,121
-Lyon,Emporia 13.01,State Treasurer,,R,Ron Estes,180
-Lyon,Emporia 14.01,State Treasurer,,R,Ron Estes,248
-Lyon,Emporia 15.01,State Treasurer,,R,Ron Estes,135
-Lyon,Emporia 16.01,State Treasurer,,R,Ron Estes,195
-Lyon,Emporia 17.01,State Treasurer,,R,Ron Estes,210
-Lyon,Emporia 18.01,State Treasurer,,R,Ron Estes,196
-Lyon,Emporia 19.01,State Treasurer,,R,Ron Estes,339
-Lyon,Emporia 20.01,State Treasurer,,R,Ron Estes,297
-Lyon,Precinct 21.01,State Treasurer,,R,Ron Estes,109
-Lyon,Precinct 22.01,State Treasurer,,R,Ron Estes,75
-Lyon,Precinct 23.01,State Treasurer,,R,Ron Estes,84
-Lyon,Precinct 24.01,State Treasurer,,R,Ron Estes,339
-Lyon,Precinct 25.01,State Treasurer,,R,Ron Estes,293
-Lyon,Precinct 26.01,State Treasurer,,R,Ron Estes,124
-Lyon,Precinct 27.01,State Treasurer,,R,Ron Estes,198
-Lyon,Precinct 28.01,State Treasurer,,R,Ron Estes,178
-Lyon,Precinct 29.01,State Treasurer,,R,Ron Estes,99
-Lyon,Precinct 29D.01,State Treasurer,,R,Ron Estes,3
-Lyon,Precinct 30.01,State Treasurer,,R,Ron Estes,251
-Lyon,Precinct 31.01,State Treasurer,,R,Ron Estes,338
-Lyon,Precinct 32.01,State Treasurer,,R,Ron Estes,195
-Lyon,Emporia 01.01,State Treasurer,,D,Carmen Alldritt,151
-Lyon,Emporia 02.01,State Treasurer,,D,Carmen Alldritt,98
-Lyon,Emporia 03.01,State Treasurer,,D,Carmen Alldritt,109
-Lyon,Emporia 04.01,State Treasurer,,D,Carmen Alldritt,132
-Lyon,Emporia 4A.01,State Treasurer,,D,Carmen Alldritt,0
-Lyon,Emporia 4B.01,State Treasurer,,D,Carmen Alldritt,2
-Lyon,Emporia 4C.01,State Treasurer,,D,Carmen Alldritt,2
-Lyon,Emporia 05.01,State Treasurer,,D,Carmen Alldritt,77
-Lyon,Emporia 06.01,State Treasurer,,D,Carmen Alldritt,101
-Lyon,Emporia 07.01,State Treasurer,,D,Carmen Alldritt,38
-Lyon,Emporia 08.01,State Treasurer,,D,Carmen Alldritt,83
-Lyon,Emporia 09.01,State Treasurer,,D,Carmen Alldritt,84
-Lyon,Emporia 10.01,State Treasurer,,D,Carmen Alldritt,110
-Lyon,Emporia 11.01,State Treasurer,,D,Carmen Alldritt,87
-Lyon,Emporia 12.01,State Treasurer,,D,Carmen Alldritt,87
-Lyon,Emporia 13.01,State Treasurer,,D,Carmen Alldritt,108
-Lyon,Emporia 14.01,State Treasurer,,D,Carmen Alldritt,170
-Lyon,Emporia 15.01,State Treasurer,,D,Carmen Alldritt,86
-Lyon,Emporia 16.01,State Treasurer,,D,Carmen Alldritt,139
-Lyon,Emporia 17.01,State Treasurer,,D,Carmen Alldritt,133
-Lyon,Emporia 18.01,State Treasurer,,D,Carmen Alldritt,118
-Lyon,Emporia 19.01,State Treasurer,,D,Carmen Alldritt,175
-Lyon,Emporia 20.01,State Treasurer,,D,Carmen Alldritt,148
-Lyon,Precinct 21.01,State Treasurer,,D,Carmen Alldritt,38
-Lyon,Precinct 22.01,State Treasurer,,D,Carmen Alldritt,22
-Lyon,Precinct 23.01,State Treasurer,,D,Carmen Alldritt,24
-Lyon,Precinct 24.01,State Treasurer,,D,Carmen Alldritt,120
-Lyon,Precinct 25.01,State Treasurer,,D,Carmen Alldritt,91
-Lyon,Precinct 26.01,State Treasurer,,D,Carmen Alldritt,58
-Lyon,Precinct 27.01,State Treasurer,,D,Carmen Alldritt,66
-Lyon,Precinct 28.01,State Treasurer,,D,Carmen Alldritt,78
-Lyon,Precinct 29.01,State Treasurer,,D,Carmen Alldritt,34
-Lyon,Precinct 29D.01,State Treasurer,,D,Carmen Alldritt,0
-Lyon,Precinct 30.01,State Treasurer,,D,Carmen Alldritt,115
-Lyon,Precinct 31.01,State Treasurer,,D,Carmen Alldritt,128
-Lyon,Precinct 32.01,State Treasurer,,D,Carmen Alldritt,74
-Lyon,Emporia 01.01,Insurance Commissioner,,R,Ken Selzer,147
-Lyon,Emporia 02.01,Insurance Commissioner,,R,Ken Selzer,94
-Lyon,Emporia 03.01,Insurance Commissioner,,R,Ken Selzer,125
-Lyon,Emporia 04.01,Insurance Commissioner,,R,Ken Selzer,146
-Lyon,Emporia 4A.01,Insurance Commissioner,,R,Ken Selzer,4
-Lyon,Emporia 4B.01,Insurance Commissioner,,R,Ken Selzer,0
-Lyon,Emporia 4C.01,Insurance Commissioner,,R,Ken Selzer,2
-Lyon,Emporia 05.01,Insurance Commissioner,,R,Ken Selzer,79
-Lyon,Emporia 06.01,Insurance Commissioner,,R,Ken Selzer,86
-Lyon,Emporia 07.01,Insurance Commissioner,,R,Ken Selzer,41
-Lyon,Emporia 08.01,Insurance Commissioner,,R,Ken Selzer,87
-Lyon,Emporia 09.01,Insurance Commissioner,,R,Ken Selzer,100
-Lyon,Emporia 10.01,Insurance Commissioner,,R,Ken Selzer,118
-Lyon,Emporia 11.01,Insurance Commissioner,,R,Ken Selzer,98
-Lyon,Emporia 12.01,Insurance Commissioner,,R,Ken Selzer,102
-Lyon,Emporia 13.01,Insurance Commissioner,,R,Ken Selzer,160
-Lyon,Emporia 14.01,Insurance Commissioner,,R,Ken Selzer,212
-Lyon,Emporia 15.01,Insurance Commissioner,,R,Ken Selzer,124
-Lyon,Emporia 16.01,Insurance Commissioner,,R,Ken Selzer,167
-Lyon,Emporia 17.01,Insurance Commissioner,,R,Ken Selzer,181
-Lyon,Emporia 18.01,Insurance Commissioner,,R,Ken Selzer,180
-Lyon,Emporia 19.01,Insurance Commissioner,,R,Ken Selzer,289
-Lyon,Emporia 20.01,Insurance Commissioner,,R,Ken Selzer,258
-Lyon,Precinct 21.01,Insurance Commissioner,,R,Ken Selzer,88
-Lyon,Precinct 22.01,Insurance Commissioner,,R,Ken Selzer,64
-Lyon,Precinct 23.01,Insurance Commissioner,,R,Ken Selzer,67
-Lyon,Precinct 24.01,Insurance Commissioner,,R,Ken Selzer,292
-Lyon,Precinct 25.01,Insurance Commissioner,,R,Ken Selzer,256
-Lyon,Precinct 26.01,Insurance Commissioner,,R,Ken Selzer,109
-Lyon,Precinct 27.01,Insurance Commissioner,,R,Ken Selzer,172
-Lyon,Precinct 28.01,Insurance Commissioner,,R,Ken Selzer,160
-Lyon,Precinct 29.01,Insurance Commissioner,,R,Ken Selzer,88
-Lyon,Precinct 29D.01,Insurance Commissioner,,R,Ken Selzer,2
-Lyon,Precinct 30.01,Insurance Commissioner,,R,Ken Selzer,238
-Lyon,Precinct 31.01,Insurance Commissioner,,R,Ken Selzer,284
-Lyon,Precinct 32.01,Insurance Commissioner,,R,Ken Selzer,160
-Lyon,Emporia 01.01,Insurance Commissioner,,D,Dennis Anderson,167
-Lyon,Emporia 02.01,Insurance Commissioner,,D,Dennis Anderson,115
-Lyon,Emporia 03.01,Insurance Commissioner,,D,Dennis Anderson,124
-Lyon,Emporia 04.01,Insurance Commissioner,,D,Dennis Anderson,145
-Lyon,Emporia 4A.01,Insurance Commissioner,,D,Dennis Anderson,0
-Lyon,Emporia 4B.01,Insurance Commissioner,,D,Dennis Anderson,2
-Lyon,Emporia 4C.01,Insurance Commissioner,,D,Dennis Anderson,2
-Lyon,Emporia 05.01,Insurance Commissioner,,D,Dennis Anderson,92
-Lyon,Emporia 06.01,Insurance Commissioner,,D,Dennis Anderson,115
-Lyon,Emporia 07.01,Insurance Commissioner,,D,Dennis Anderson,42
-Lyon,Emporia 08.01,Insurance Commissioner,,D,Dennis Anderson,102
-Lyon,Emporia 09.01,Insurance Commissioner,,D,Dennis Anderson,99
-Lyon,Emporia 10.01,Insurance Commissioner,,D,Dennis Anderson,145
-Lyon,Emporia 11.01,Insurance Commissioner,,D,Dennis Anderson,92
-Lyon,Emporia 12.01,Insurance Commissioner,,D,Dennis Anderson,103
-Lyon,Emporia 13.01,Insurance Commissioner,,D,Dennis Anderson,127
-Lyon,Emporia 14.01,Insurance Commissioner,,D,Dennis Anderson,197
-Lyon,Emporia 15.01,Insurance Commissioner,,D,Dennis Anderson,97
-Lyon,Emporia 16.01,Insurance Commissioner,,D,Dennis Anderson,169
-Lyon,Emporia 17.01,Insurance Commissioner,,D,Dennis Anderson,154
-Lyon,Emporia 18.01,Insurance Commissioner,,D,Dennis Anderson,126
-Lyon,Emporia 19.01,Insurance Commissioner,,D,Dennis Anderson,217
-Lyon,Emporia 20.01,Insurance Commissioner,,D,Dennis Anderson,180
-Lyon,Precinct 21.01,Insurance Commissioner,,D,Dennis Anderson,53
-Lyon,Precinct 22.01,Insurance Commissioner,,D,Dennis Anderson,33
-Lyon,Precinct 23.01,Insurance Commissioner,,D,Dennis Anderson,41
-Lyon,Precinct 24.01,Insurance Commissioner,,D,Dennis Anderson,161
-Lyon,Precinct 25.01,Insurance Commissioner,,D,Dennis Anderson,123
-Lyon,Precinct 26.01,Insurance Commissioner,,D,Dennis Anderson,71
-Lyon,Precinct 27.01,Insurance Commissioner,,D,Dennis Anderson,90
-Lyon,Precinct 28.01,Insurance Commissioner,,D,Dennis Anderson,88
-Lyon,Precinct 29.01,Insurance Commissioner,,D,Dennis Anderson,40
-Lyon,Precinct 29D.01,Insurance Commissioner,,D,Dennis Anderson,0
-Lyon,Precinct 30.01,Insurance Commissioner,,D,Dennis Anderson,120
-Lyon,Precinct 31.01,Insurance Commissioner,,D,Dennis Anderson,172
-Lyon,Precinct 32.01,Insurance Commissioner,,D,Dennis Anderson,103
-Lyon,Emporia 01.01,State House,60,R,Don Hill,286
-Lyon,Emporia 02.01,State House,60,R,Don Hill,188
-Lyon,Emporia 03.01,State House,76,R,Peggy Mast,112
-Lyon,Emporia 04.01,State House,76,R,Peggy Mast,122
-Lyon,Emporia 4A.01,State House,76,R,Peggy Mast,2
-Lyon,Emporia 4B.01,State House,76,R,Peggy Mast,0
-Lyon,Emporia 4C.01,State House,76,R,Peggy Mast,0
-Lyon,Emporia 05.01,State House,60,R,Don Hill,156
-Lyon,Emporia 06.01,State House,60,R,Don Hill,166
-Lyon,Emporia 07.01,State House,60,R,Don Hill,76
-Lyon,Emporia 08.01,State House,60,R,Don Hill,162
-Lyon,Emporia 09.01,State House,60,R,Don Hill,177
-Lyon,Emporia 10.01,State House,76,R,Peggy Mast,132
-Lyon,Emporia 11.01,State House,60,R,Don Hill,170
-Lyon,Emporia 12.01,State House,60,R,Don Hill,180
-Lyon,Emporia 13.01,State House,60,R,Don Hill,255
-Lyon,Emporia 14.01,State House,60,R,Don Hill,397
-Lyon,Emporia 15.01,State House,60,R,Don Hill,214
-Lyon,Emporia 16.01,State House,60,R,Don Hill,317
-Lyon,Emporia 17.01,State House,60,R,Don Hill,309
-Lyon,Emporia 18.01,State House,60,R,Don Hill,280
-Lyon,Emporia 19.01,State House,60,R,Don Hill,484
-Lyon,Emporia 20.01,State House,60,R,Don Hill,415
-Lyon,Precinct 21.01,State House,51,R,Ron Highland,124
-Lyon,Precinct 22.01,State House,51,R,Ron Highland,86
-Lyon,Precinct 23.01,State House,51,R,Ron Highland,95
-Lyon,Precinct 24.01,State House,60,R,Don Hill,428
-Lyon,Precinct 25.01,State House,60,R,Don Hill,367
-Lyon,Precinct 26.01,State House,51,R,Ron Highland,140
-Lyon,Precinct 27.01,State House,60,R,Don Hill,262
-Lyon,Precinct 28.01,State House,76,R,Peggy Mast,110
-Lyon,Precinct 29.01,State House,60,R,Don Hill,121
-Lyon,Precinct 29D.01,State House,60,R,Don Hill,3
-Lyon,Precinct 30.01,State House,76,R,Peggy Mast,148
-Lyon,Precinct 31.01,State House,76,R,Peggy Mast,250
-Lyon,Precinct 32.01,State House,76,R,Peggy Mast,111
-Lyon,Emporia 03.01,State House,76,D,Teresa Briggs,117
-Lyon,Emporia 04.01,State House,76,D,Teresa Briggs,146
-Lyon,Emporia 4A.01,State House,76,D,Teresa Briggs,1
-Lyon,Emporia 4B.01,State House,76,D,Teresa Briggs,2
-Lyon,Emporia 4C.01,State House,76,D,Teresa Briggs,5
-Lyon,Emporia 10.01,State House,76,D,Teresa Briggs,104
-Lyon,Precinct 28.01,State House,76,D,Teresa Briggs,135
-Lyon,Precinct 30.01,State House,76,D,Teresa Briggs,186
-Lyon,Precinct 31.01,State House,76,D,Teresa Briggs,176
-Lyon,Precinct 32.01,State House,76,D,Teresa Briggs,112
-Lyon,Emporia 03.01,State House,76,I,Bill Otto,37
-Lyon,Emporia 04.01,State House,76,I,Bill Otto,38
-Lyon,Emporia 4A.01,State House,76,I,Bill Otto,1
-Lyon,Emporia 4B.01,State House,76,I,Bill Otto,0
-Lyon,Emporia 4C.01,State House,76,I,Bill Otto,0
-Lyon,Emporia 10.01,State House,76,I,Bill Otto,38
-Lyon,Precinct 28.01,State House,76,I,Bill Otto,23
-Lyon,Precinct 30.01,State House,76,I,Bill Otto,46
-Lyon,Precinct 31.01,State House,76,I,Bill Otto,72
-Lyon,Precinct 32.01,State House,76,I,Bill Otto,52
+county,precinct,office,district,party,candidate,votes,vtd
+LYON,Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",213,000010
+LYON,Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000010
+LYON,Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,000010
+LYON,Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",154,000020
+LYON,Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000020
+LYON,Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000020
+LYON,Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",154,000030
+LYON,Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000030
+LYON,Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000030
+LYON,Precinct 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",195,000040
+LYON,Precinct 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000040
+LYON,Precinct 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,000040
+LYON,Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",99,00005A
+LYON,Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,00005A
+LYON,Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",61,00005A
+LYON,Precinct 05 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+LYON,Precinct 05 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+LYON,Precinct 05 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+LYON,Precinct 05 Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005C
+LYON,Precinct 05 Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005C
+LYON,Precinct 05 Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005C
+LYON,Precinct 06 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",125,00006A
+LYON,Precinct 06 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00006A
+LYON,Precinct 06 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,00006A
+LYON,Precinct 06 Part A Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006B
+LYON,Precinct 06 Part A Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006B
+LYON,Precinct 06 Part A Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006B
+LYON,Precinct 06 Part B Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006C
+LYON,Precinct 06 Part B Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006C
+LYON,Precinct 06 Part B Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006C
+LYON,Precinct 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",60,000070
+LYON,Precinct 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000070
+LYON,Precinct 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000070
+LYON,Precinct 08,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000080
+LYON,Precinct 08,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000080
+LYON,Precinct 08,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,000080
+LYON,Precinct 09,Governor / Lt. Governor,,Democratic,"Davis, Paul",121,000090
+LYON,Precinct 09,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000090
+LYON,Precinct 09,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000090
+LYON,Precinct 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",173,000100
+LYON,Precinct 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000100
+LYON,Precinct 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",93,000100
+LYON,Precinct 11,Governor / Lt. Governor,,Democratic,"Davis, Paul",126,000110
+LYON,Precinct 11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000110
+LYON,Precinct 11,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000110
+LYON,Precinct 12,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,000120
+LYON,Precinct 12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000120
+LYON,Precinct 12,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,000120
+LYON,Precinct 13,Governor / Lt. Governor,,Democratic,"Davis, Paul",175,000130
+LYON,Precinct 13,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000130
+LYON,Precinct 13,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,000130
+LYON,Precinct 14,Governor / Lt. Governor,,Democratic,"Davis, Paul",282,000140
+LYON,Precinct 14,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000140
+LYON,Precinct 14,Governor / Lt. Governor,,Republican,"Brownback, Sam",142,000140
+LYON,Precinct 15,Governor / Lt. Governor,,Democratic,"Davis, Paul",146,000150
+LYON,Precinct 15,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000150
+LYON,Precinct 15,Governor / Lt. Governor,,Republican,"Brownback, Sam",84,000150
+LYON,Precinct 16,Governor / Lt. Governor,,Democratic,"Davis, Paul",236,000160
+LYON,Precinct 16,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000160
+LYON,Precinct 16,Governor / Lt. Governor,,Republican,"Brownback, Sam",110,000160
+LYON,Precinct 17 Exclave Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00017A
+LYON,Precinct 17 Exclave Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00017A
+LYON,Precinct 17 Exclave Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00017A
+LYON,Precinct 17 Enclave Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00017B
+LYON,Precinct 17 Enclave Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00017B
+LYON,Precinct 17 Enclave Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00017B
+LYON,Precinct 17,Governor / Lt. Governor,,Democratic,"Davis, Paul",211,000170
+LYON,Precinct 17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000170
+LYON,Precinct 17,Governor / Lt. Governor,,Republican,"Brownback, Sam",126,000170
+LYON,Precinct 18 Enclave Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018A
+LYON,Precinct 18 Enclave Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018A
+LYON,Precinct 18 Enclave Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018A
+LYON,Precinct 18,Governor / Lt. Governor,,Democratic,"Davis, Paul",199,000180
+LYON,Precinct 18,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000180
+LYON,Precinct 18,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000180
+LYON,Precinct 19,Governor / Lt. Governor,,Democratic,"Davis, Paul",327,000190
+LYON,Precinct 19,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000190
+LYON,Precinct 19,Governor / Lt. Governor,,Republican,"Brownback, Sam",192,000190
+LYON,Precinct 20 Exclave Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00020A
+LYON,Precinct 20 Exclave Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00020A
+LYON,Precinct 20 Exclave Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00020A
+LYON,Precinct 20,Governor / Lt. Governor,,Democratic,"Davis, Paul",283,000200
+LYON,Precinct 20,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000200
+LYON,Precinct 20,Governor / Lt. Governor,,Republican,"Brownback, Sam",171,000200
+LYON,Precinct 21,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000210
+LYON,Precinct 21,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000210
+LYON,Precinct 21,Governor / Lt. Governor,,Republican,"Brownback, Sam",77,000210
+LYON,Precinct 22,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000220
+LYON,Precinct 22,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000220
+LYON,Precinct 22,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000220
+LYON,Precinct 23,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000230
+LYON,Precinct 23,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000230
+LYON,Precinct 23,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000230
+LYON,Precinct 24,Governor / Lt. Governor,,Democratic,"Davis, Paul",222,000240
+LYON,Precinct 24,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000240
+LYON,Precinct 24,Governor / Lt. Governor,,Republican,"Brownback, Sam",234,000240
+LYON,Precinct 25,Governor / Lt. Governor,,Democratic,"Davis, Paul",164,000250
+LYON,Precinct 25,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000250
+LYON,Precinct 25,Governor / Lt. Governor,,Republican,"Brownback, Sam",205,000250
+LYON,Precinct 26,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,000260
+LYON,Precinct 26,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000260
+LYON,Precinct 26,Governor / Lt. Governor,,Republican,"Brownback, Sam",82,000260
+LYON,Precinct 27,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000270
+LYON,Precinct 27,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000270
+LYON,Precinct 27,Governor / Lt. Governor,,Republican,"Brownback, Sam",148,000270
+LYON,Precinct 28,Governor / Lt. Governor,,Democratic,"Davis, Paul",123,00028A
+LYON,Precinct 28,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00028A
+LYON,Precinct 28,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,00028A
+LYON,Precinct 28 Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00028B
+LYON,Precinct 28 Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00028B
+LYON,Precinct 28 Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00028B
+LYON,Precinct 28 Enclave Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00028C
+LYON,Precinct 28 Enclave Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00028C
+LYON,Precinct 28 Enclave Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00028C
+LYON,Precinct 29 Exclave Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00029A
+LYON,Precinct 29 Exclave Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00029A
+LYON,Precinct 29 Exclave Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00029A
+LYON,Precinct 29,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,000290
+LYON,Precinct 29,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000290
+LYON,Precinct 29,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000290
+LYON,Precinct 30,Governor / Lt. Governor,,Democratic,"Davis, Paul",173,000300
+LYON,Precinct 30,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000300
+LYON,Precinct 30,Governor / Lt. Governor,,Republican,"Brownback, Sam",180,000300
+LYON,Precinct 31,Governor / Lt. Governor,,Democratic,"Davis, Paul",259,000310
+LYON,Precinct 31,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000310
+LYON,Precinct 31,Governor / Lt. Governor,,Republican,"Brownback, Sam",221,000310
+LYON,Precinct 32,Governor / Lt. Governor,,Democratic,"Davis, Paul",120,000320
+LYON,Precinct 32,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000320
+LYON,Precinct 32,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000320
+LYON,Precinct 29 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120020
+LYON,Precinct 29 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120020
+LYON,Precinct 29 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120020
+LYON,Precinct 07 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,140010
+LYON,Precinct 07 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,140010
+LYON,Precinct 07 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,140010
+LYON,Precinct 17 Part C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,140020
+LYON,Precinct 17 Part C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,140020
+LYON,Precinct 17 Part C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,140020
+LYON,Precinct 19 Exclave Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,300010
+LYON,Precinct 19 Exclave Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,300010
+LYON,Precinct 19 Exclave Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,300010
+LYON,Precinct 19 Exclave Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,300020
+LYON,Precinct 19 Exclave Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,300020
+LYON,Precinct 19 Exclave Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,300020
+LYON,Precinct 04 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,400010
+LYON,Precinct 04 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,400010
+LYON,Precinct 04 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,400010
+LYON,Precinct 04 Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,400020
+LYON,Precinct 04 Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,400020
+LYON,Precinct 04 Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,400020
+LYON,Precinct 04 Part C,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,400030
+LYON,Precinct 04 Part C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,400030
+LYON,Precinct 04 Part C,Governor / Lt. Governor,,Republican,"Brownback, Sam",1,400030
+LYON,Precinct 04 Part D,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+LYON,Precinct 04 Part D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+LYON,Precinct 04 Part D,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+LYON,Precinct 09 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+LYON,Precinct 09 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+LYON,Precinct 09 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+LYON,Precinct 29 Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+LYON,Precinct 29 Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+LYON,Precinct 29 Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+LYON,Precinct 29 Enclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+LYON,Precinct 29 Enclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+LYON,Precinct 29 Enclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+LYON,Precinct 29 Enclave 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+LYON,Precinct 29 Enclave 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+LYON,Precinct 29 Enclave 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,900050
+LYON,Precinct 01,Kansas House of Representatives,60,Republican,"Hill, Don",286,000010
+LYON,Precinct 02,Kansas House of Representatives,60,Republican,"Hill, Don",188,000020
+LYON,Precinct 03,Kansas House of Representatives,76,independent,"Otto, Bill",37,000030
+LYON,Precinct 03,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",117,000030
+LYON,Precinct 03,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",112,000030
+LYON,Precinct 04,Kansas House of Representatives,76,independent,"Otto, Bill",38,000040
+LYON,Precinct 04,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",146,000040
+LYON,Precinct 04,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",122,000040
+LYON,Precinct 05,Kansas House of Representatives,60,Republican,"Hill, Don",156,00005A
+LYON,Precinct 05 Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00005B
+LYON,Precinct 05 Part B,Kansas House of Representatives,60,Republican,"Hill, Don",0,00005C
+LYON,Precinct 06 Part A,Kansas House of Representatives,60,Republican,"Hill, Don",166,00006A
+LYON,Precinct 06 Part A Exclave,Kansas House of Representatives,60,Republican,"Hill, Don",0,00006B
+LYON,Precinct 06 Part B Exclave,Kansas House of Representatives,60,Republican,"Hill, Don",0,00006C
+LYON,Precinct 07,Kansas House of Representatives,60,Republican,"Hill, Don",76,000070
+LYON,Precinct 08,Kansas House of Representatives,60,Republican,"Hill, Don",162,000080
+LYON,Precinct 09,Kansas House of Representatives,60,Republican,"Hill, Don",177,000090
+LYON,Precinct 10,Kansas House of Representatives,76,independent,"Otto, Bill",38,000100
+LYON,Precinct 10,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",132,000100
+LYON,Precinct 10,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",104,000100
+LYON,Precinct 11,Kansas House of Representatives,60,Republican,"Hill, Don",170,000110
+LYON,Precinct 12,Kansas House of Representatives,60,Republican,"Hill, Don",180,000120
+LYON,Precinct 13,Kansas House of Representatives,60,Republican,"Hill, Don",255,000130
+LYON,Precinct 14,Kansas House of Representatives,60,Republican,"Hill, Don",397,000140
+LYON,Precinct 15,Kansas House of Representatives,60,Republican,"Hill, Don",214,000150
+LYON,Precinct 16,Kansas House of Representatives,60,Republican,"Hill, Don",317,000160
+LYON,Precinct 17 Exclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00017A
+LYON,Precinct 17 Enclave Part B,Kansas House of Representatives,60,Republican,"Hill, Don",0,00017B
+LYON,Precinct 17,Kansas House of Representatives,60,Republican,"Hill, Don",309,000170
+LYON,Precinct 18 Enclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00018A
+LYON,Precinct 18,Kansas House of Representatives,60,Republican,"Hill, Don",280,000180
+LYON,Precinct 19,Kansas House of Representatives,60,Republican,"Hill, Don",484,000190
+LYON,Precinct 20 Exclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00020A
+LYON,Precinct 20,Kansas House of Representatives,60,Republican,"Hill, Don",415,000200
+LYON,Precinct 21,Kansas House of Representatives,51,Republican,"Highland, Ron",124,000210
+LYON,Precinct 22,Kansas House of Representatives,51,Republican,"Highland, Ron",86,000220
+LYON,Precinct 23,Kansas House of Representatives,51,Republican,"Highland, Ron",95,000230
+LYON,Precinct 24,Kansas House of Representatives,60,Republican,"Hill, Don",428,000240
+LYON,Precinct 25,Kansas House of Representatives,60,Republican,"Hill, Don",367,000250
+LYON,Precinct 26,Kansas House of Representatives,51,Republican,"Highland, Ron",140,000260
+LYON,Precinct 27,Kansas House of Representatives,60,Republican,"Hill, Don",262,000270
+LYON,Precinct 28,Kansas House of Representatives,76,independent,"Otto, Bill",23,00028A
+LYON,Precinct 28,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",110,00028A
+LYON,Precinct 28,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",135,00028A
+LYON,Precinct 28 Enclave A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00028B
+LYON,Precinct 28 Enclave Part B,Kansas House of Representatives,60,Republican,"Hill, Don",0,00028C
+LYON,Precinct 29 Exclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00029A
+LYON,Precinct 29,Kansas House of Representatives,60,Republican,"Hill, Don",121,000290
+LYON,Precinct 30,Kansas House of Representatives,76,independent,"Otto, Bill",46,000300
+LYON,Precinct 30,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",148,000300
+LYON,Precinct 30,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",186,000300
+LYON,Precinct 31,Kansas House of Representatives,76,independent,"Otto, Bill",72,000310
+LYON,Precinct 31,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",250,000310
+LYON,Precinct 31,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",176,000310
+LYON,Precinct 32,Kansas House of Representatives,76,independent,"Otto, Bill",52,000320
+LYON,Precinct 32,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",111,000320
+LYON,Precinct 32,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",112,000320
+LYON,Precinct 29 A,Kansas House of Representatives,60,Republican,"Hill, Don",0,120020
+LYON,Precinct 19 Exclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,300010
+LYON,Precinct 19 Exclave Part B,Kansas House of Representatives,60,Republican,"Hill, Don",0,300020
+LYON,Precinct 04 Part A,Kansas House of Representatives,76,independent,"Otto, Bill",1,400010
+LYON,Precinct 04 Part A,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",1,400010
+LYON,Precinct 04 Part A,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",2,400010
+LYON,Precinct 04 Part B,Kansas House of Representatives,76,independent,"Otto, Bill",0,400020
+LYON,Precinct 04 Part B,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",2,400020
+LYON,Precinct 04 Part B,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,400020
+LYON,Precinct 04 Part C,Kansas House of Representatives,76,independent,"Otto, Bill",0,400030
+LYON,Precinct 04 Part C,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",5,400030
+LYON,Precinct 04 Part C,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,400030
+LYON,Precinct 04 Part D,Kansas House of Representatives,76,independent,"Otto, Bill",0,900010
+LYON,Precinct 04 Part D,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900010
+LYON,Precinct 04 Part D,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,900010
+LYON,Precinct 09 Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,900020
+LYON,Precinct 29 Enclave,Kansas House of Representatives,60,Republican,"Hill, Don",0,900030
+LYON,Precinct 29 Enclave 2,Kansas House of Representatives,60,Republican,"Hill, Don",0,900040
+LYON,Precinct 29 Enclave 3,Kansas House of Representatives,60,Republican,"Hill, Don",3,900050
+LYON,Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",193,000010
+LYON,Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",124,000010
+LYON,Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",115,000020
+LYON,Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000020
+LYON,Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",126,000030
+LYON,Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",131,000030
+LYON,Precinct 04,United States House of Representatives,1,Democratic,"Sherow, James E.",157,000040
+LYON,Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",145,000040
+LYON,Precinct 05,United States House of Representatives,1,Democratic,"Sherow, James E.",86,00005A
+LYON,Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",90,00005A
+LYON,Precinct 05 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00005B
+LYON,Precinct 05 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+LYON,Precinct 05 Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00005C
+LYON,Precinct 05 Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005C
+LYON,Precinct 06 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",121,00006A
+LYON,Precinct 06 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,00006A
+LYON,Precinct 06 Part A Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00006B
+LYON,Precinct 06 Part A Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+LYON,Precinct 06 Part B Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00006C
+LYON,Precinct 06 Part B Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006C
+LYON,Precinct 07,United States House of Representatives,1,Democratic,"Sherow, James E.",51,000070
+LYON,Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000070
+LYON,Precinct 08,United States House of Representatives,1,Democratic,"Sherow, James E.",102,000080
+LYON,Precinct 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",98,000080
+LYON,Precinct 09,United States House of Representatives,1,Democratic,"Sherow, James E.",104,000090
+LYON,Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000090
+LYON,Precinct 10,United States House of Representatives,1,Democratic,"Sherow, James E.",136,000100
+LYON,Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",131,000100
+LYON,Precinct 11,United States House of Representatives,1,Democratic,"Sherow, James E.",101,000110
+LYON,Precinct 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",99,000110
+LYON,Precinct 12,United States House of Representatives,1,Democratic,"Sherow, James E.",114,000120
+LYON,Precinct 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000120
+LYON,Precinct 13,United States House of Representatives,1,Democratic,"Sherow, James E.",145,000130
+LYON,Precinct 13,United States House of Representatives,1,Republican,"Huelskamp, Tim",149,000130
+LYON,Precinct 14,United States House of Representatives,1,Democratic,"Sherow, James E.",230,000140
+LYON,Precinct 14,United States House of Representatives,1,Republican,"Huelskamp, Tim",190,000140
+LYON,Precinct 15,United States House of Representatives,1,Democratic,"Sherow, James E.",122,000150
+LYON,Precinct 15,United States House of Representatives,1,Republican,"Huelskamp, Tim",109,000150
+LYON,Precinct 16,United States House of Representatives,1,Democratic,"Sherow, James E.",196,000160
+LYON,Precinct 16,United States House of Representatives,1,Republican,"Huelskamp, Tim",154,000160
+LYON,Precinct 17 Exclave Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00017A
+LYON,Precinct 17 Exclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00017A
+LYON,Precinct 17 Enclave Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00017B
+LYON,Precinct 17 Enclave Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00017B
+LYON,Precinct 17,United States House of Representatives,1,Democratic,"Sherow, James E.",181,000170
+LYON,Precinct 17,United States House of Representatives,1,Republican,"Huelskamp, Tim",168,000170
+LYON,Precinct 18 Enclave Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00018A
+LYON,Precinct 18 Enclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00018A
+LYON,Precinct 18,United States House of Representatives,1,Democratic,"Sherow, James E.",156,000180
+LYON,Precinct 18,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000180
+LYON,Precinct 19,United States House of Representatives,1,Democratic,"Sherow, James E.",252,000190
+LYON,Precinct 19,United States House of Representatives,1,Republican,"Huelskamp, Tim",269,000190
+LYON,Precinct 20 Exclave Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00020A
+LYON,Precinct 20 Exclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00020A
+LYON,Precinct 20,United States House of Representatives,1,Democratic,"Sherow, James E.",214,000200
+LYON,Precinct 20,United States House of Representatives,1,Republican,"Huelskamp, Tim",233,000200
+LYON,Precinct 21,United States House of Representatives,1,Democratic,"Sherow, James E.",50,000210
+LYON,Precinct 21,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000210
+LYON,Precinct 22,United States House of Representatives,1,Democratic,"Sherow, James E.",31,000220
+LYON,Precinct 22,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000220
+LYON,Precinct 23,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000230
+LYON,Precinct 23,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000230
+LYON,Precinct 24,United States House of Representatives,1,Democratic,"Sherow, James E.",179,000240
+LYON,Precinct 24,United States House of Representatives,1,Republican,"Huelskamp, Tim",283,000240
+LYON,Precinct 25,United States House of Representatives,1,Democratic,"Sherow, James E.",135,000250
+LYON,Precinct 25,United States House of Representatives,1,Republican,"Huelskamp, Tim",259,000250
+LYON,Precinct 26,United States House of Representatives,1,Democratic,"Sherow, James E.",81,000260
+LYON,Precinct 26,United States House of Representatives,1,Republican,"Huelskamp, Tim",106,000260
+LYON,Precinct 27,United States House of Representatives,1,Democratic,"Sherow, James E.",98,000270
+LYON,Precinct 27,United States House of Representatives,1,Republican,"Huelskamp, Tim",176,000270
+LYON,Precinct 28,United States House of Representatives,1,Democratic,"Sherow, James E.",99,00028A
+LYON,Precinct 28,United States House of Representatives,1,Republican,"Huelskamp, Tim",162,00028A
+LYON,Precinct 28 Enclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00028B
+LYON,Precinct 28 Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00028B
+LYON,Precinct 28 Enclave Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00028C
+LYON,Precinct 28 Enclave Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00028C
+LYON,Precinct 29 Exclave Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00029A
+LYON,Precinct 29 Exclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00029A
+LYON,Precinct 29,United States House of Representatives,1,Democratic,"Sherow, James E.",54,000290
+LYON,Precinct 29,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000290
+LYON,Precinct 30,United States House of Representatives,1,Democratic,"Sherow, James E.",150,000300
+LYON,Precinct 30,United States House of Representatives,1,Republican,"Huelskamp, Tim",224,000300
+LYON,Precinct 31,United States House of Representatives,1,Democratic,"Sherow, James E.",173,000310
+LYON,Precinct 31,United States House of Representatives,1,Republican,"Huelskamp, Tim",306,000310
+LYON,Precinct 32,United States House of Representatives,1,Democratic,"Sherow, James E.",105,000320
+LYON,Precinct 32,United States House of Representatives,1,Republican,"Huelskamp, Tim",168,000320
+LYON,Precinct 29 A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120020
+LYON,Precinct 29 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120020
+LYON,Precinct 07 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,140010
+LYON,Precinct 07 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,140010
+LYON,Precinct 17 Part C,United States House of Representatives,1,Democratic,"Sherow, James E.",0,140020
+LYON,Precinct 17 Part C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,140020
+LYON,Precinct 19 Exclave Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,300010
+LYON,Precinct 19 Exclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300010
+LYON,Precinct 19 Exclave Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,300020
+LYON,Precinct 19 Exclave Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300020
+LYON,Precinct 04 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,400010
+LYON,Precinct 04 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,400010
+LYON,Precinct 04 Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",2,400020
+LYON,Precinct 04 Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,400020
+LYON,Precinct 04 Part C,United States House of Representatives,1,Democratic,"Sherow, James E.",4,400030
+LYON,Precinct 04 Part C,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,400030
+LYON,Precinct 04 Part D,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+LYON,Precinct 04 Part D,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+LYON,Precinct 09 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+LYON,Precinct 09 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+LYON,Precinct 29 Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900030
+LYON,Precinct 29 Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+LYON,Precinct 29 Enclave 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900040
+LYON,Precinct 29 Enclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+LYON,Precinct 29 Enclave 3,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900050
+LYON,Precinct 29 Enclave 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,900050
+LYON,Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",157,000010
+LYON,Precinct 01,Attorney General,,Republican,"Schmidt, Derek",157,000010
+LYON,Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",111,000020
+LYON,Precinct 02,Attorney General,,Republican,"Schmidt, Derek",106,000020
+LYON,Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",110,000030
+LYON,Precinct 03,Attorney General,,Republican,"Schmidt, Derek",147,000030
+LYON,Precinct 04,Attorney General,,Democratic,"Kotich, A.J.",136,000040
+LYON,Precinct 04,Attorney General,,Republican,"Schmidt, Derek",161,000040
+LYON,Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",74,00005A
+LYON,Precinct 05,Attorney General,,Republican,"Schmidt, Derek",100,00005A
+LYON,Precinct 05 Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+LYON,Precinct 05 Part A,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+LYON,Precinct 05 Part B,Attorney General,,Democratic,"Kotich, A.J.",0,00005C
+LYON,Precinct 05 Part B,Attorney General,,Republican,"Schmidt, Derek",0,00005C
+LYON,Precinct 06 Part A,Attorney General,,Democratic,"Kotich, A.J.",107,00006A
+LYON,Precinct 06 Part A,Attorney General,,Republican,"Schmidt, Derek",96,00006A
+LYON,Precinct 06 Part A Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00006B
+LYON,Precinct 06 Part A Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00006B
+LYON,Precinct 06 Part B Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00006C
+LYON,Precinct 06 Part B Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00006C
+LYON,Precinct 07,Attorney General,,Democratic,"Kotich, A.J.",43,000070
+LYON,Precinct 07,Attorney General,,Republican,"Schmidt, Derek",42,000070
+LYON,Precinct 08,Attorney General,,Democratic,"Kotich, A.J.",94,000080
+LYON,Precinct 08,Attorney General,,Republican,"Schmidt, Derek",101,000080
+LYON,Precinct 09,Attorney General,,Democratic,"Kotich, A.J.",87,000090
+LYON,Precinct 09,Attorney General,,Republican,"Schmidt, Derek",111,000090
+LYON,Precinct 10,Attorney General,,Democratic,"Kotich, A.J.",113,000100
+LYON,Precinct 10,Attorney General,,Republican,"Schmidt, Derek",154,000100
+LYON,Precinct 11,Attorney General,,Democratic,"Kotich, A.J.",85,000110
+LYON,Precinct 11,Attorney General,,Republican,"Schmidt, Derek",114,000110
+LYON,Precinct 12,Attorney General,,Democratic,"Kotich, A.J.",97,000120
+LYON,Precinct 12,Attorney General,,Republican,"Schmidt, Derek",109,000120
+LYON,Precinct 13,Attorney General,,Democratic,"Kotich, A.J.",119,000130
+LYON,Precinct 13,Attorney General,,Republican,"Schmidt, Derek",175,000130
+LYON,Precinct 14,Attorney General,,Democratic,"Kotich, A.J.",190,000140
+LYON,Precinct 14,Attorney General,,Republican,"Schmidt, Derek",233,000140
+LYON,Precinct 15,Attorney General,,Democratic,"Kotich, A.J.",99,000150
+LYON,Precinct 15,Attorney General,,Republican,"Schmidt, Derek",131,000150
+LYON,Precinct 16,Attorney General,,Democratic,"Kotich, A.J.",147,000160
+LYON,Precinct 16,Attorney General,,Republican,"Schmidt, Derek",193,000160
+LYON,Precinct 17 Exclave Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00017A
+LYON,Precinct 17 Exclave Part A,Attorney General,,Republican,"Schmidt, Derek",0,00017A
+LYON,Precinct 17 Enclave Part B,Attorney General,,Democratic,"Kotich, A.J.",0,00017B
+LYON,Precinct 17 Enclave Part B,Attorney General,,Republican,"Schmidt, Derek",0,00017B
+LYON,Precinct 17,Attorney General,,Democratic,"Kotich, A.J.",126,000170
+LYON,Precinct 17,Attorney General,,Republican,"Schmidt, Derek",219,000170
+LYON,Precinct 18 Enclave Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00018A
+LYON,Precinct 18 Enclave Part A,Attorney General,,Republican,"Schmidt, Derek",0,00018A
+LYON,Precinct 18,Attorney General,,Democratic,"Kotich, A.J.",117,000180
+LYON,Precinct 18,Attorney General,,Republican,"Schmidt, Derek",197,000180
+LYON,Precinct 19,Attorney General,,Democratic,"Kotich, A.J.",182,000190
+LYON,Precinct 19,Attorney General,,Republican,"Schmidt, Derek",333,000190
+LYON,Precinct 20 Exclave Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00020A
+LYON,Precinct 20 Exclave Part A,Attorney General,,Republican,"Schmidt, Derek",0,00020A
+LYON,Precinct 20,Attorney General,,Democratic,"Kotich, A.J.",152,000200
+LYON,Precinct 20,Attorney General,,Republican,"Schmidt, Derek",298,000200
+LYON,Precinct 21,Attorney General,,Democratic,"Kotich, A.J.",39,000210
+LYON,Precinct 21,Attorney General,,Republican,"Schmidt, Derek",110,000210
+LYON,Precinct 22,Attorney General,,Democratic,"Kotich, A.J.",27,000220
+LYON,Precinct 22,Attorney General,,Republican,"Schmidt, Derek",71,000220
+LYON,Precinct 23,Attorney General,,Democratic,"Kotich, A.J.",28,000230
+LYON,Precinct 23,Attorney General,,Republican,"Schmidt, Derek",81,000230
+LYON,Precinct 24,Attorney General,,Democratic,"Kotich, A.J.",140,000240
+LYON,Precinct 24,Attorney General,,Republican,"Schmidt, Derek",318,000240
+LYON,Precinct 25,Attorney General,,Democratic,"Kotich, A.J.",89,000250
+LYON,Precinct 25,Attorney General,,Republican,"Schmidt, Derek",302,000250
+LYON,Precinct 26,Attorney General,,Democratic,"Kotich, A.J.",54,000260
+LYON,Precinct 26,Attorney General,,Republican,"Schmidt, Derek",129,000260
+LYON,Precinct 27,Attorney General,,Democratic,"Kotich, A.J.",69,000270
+LYON,Precinct 27,Attorney General,,Republican,"Schmidt, Derek",200,000270
+LYON,Precinct 28,Attorney General,,Democratic,"Kotich, A.J.",77,00028A
+LYON,Precinct 28,Attorney General,,Republican,"Schmidt, Derek",184,00028A
+LYON,Precinct 28 Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00028B
+LYON,Precinct 28 Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,00028B
+LYON,Precinct 28 Enclave Part B,Attorney General,,Democratic,"Kotich, A.J.",0,00028C
+LYON,Precinct 28 Enclave Part B,Attorney General,,Republican,"Schmidt, Derek",0,00028C
+LYON,Precinct 29 Exclave Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00029A
+LYON,Precinct 29 Exclave Part A,Attorney General,,Republican,"Schmidt, Derek",0,00029A
+LYON,Precinct 29,Attorney General,,Democratic,"Kotich, A.J.",33,000290
+LYON,Precinct 29,Attorney General,,Republican,"Schmidt, Derek",99,000290
+LYON,Precinct 30,Attorney General,,Democratic,"Kotich, A.J.",110,000300
+LYON,Precinct 30,Attorney General,,Republican,"Schmidt, Derek",258,000300
+LYON,Precinct 31,Attorney General,,Democratic,"Kotich, A.J.",116,000310
+LYON,Precinct 31,Attorney General,,Republican,"Schmidt, Derek",367,000310
+LYON,Precinct 32,Attorney General,,Democratic,"Kotich, A.J.",67,000320
+LYON,Precinct 32,Attorney General,,Republican,"Schmidt, Derek",204,000320
+LYON,Precinct 29 A,Attorney General,,Democratic,"Kotich, A.J.",0,120020
+LYON,Precinct 29 A,Attorney General,,Republican,"Schmidt, Derek",0,120020
+LYON,Precinct 07 Part A,Attorney General,,Democratic,"Kotich, A.J.",0,140010
+LYON,Precinct 07 Part A,Attorney General,,Republican,"Schmidt, Derek",0,140010
+LYON,Precinct 17 Part C,Attorney General,,Democratic,"Kotich, A.J.",0,140020
+LYON,Precinct 17 Part C,Attorney General,,Republican,"Schmidt, Derek",0,140020
+LYON,Precinct 19 Exclave Part A,Attorney General,,Democratic,"Kotich, A.J.",0,300010
+LYON,Precinct 19 Exclave Part A,Attorney General,,Republican,"Schmidt, Derek",0,300010
+LYON,Precinct 19 Exclave Part B,Attorney General,,Democratic,"Kotich, A.J.",0,300020
+LYON,Precinct 19 Exclave Part B,Attorney General,,Republican,"Schmidt, Derek",0,300020
+LYON,Precinct 04 Part A,Attorney General,,Democratic,"Kotich, A.J.",0,400010
+LYON,Precinct 04 Part A,Attorney General,,Republican,"Schmidt, Derek",4,400010
+LYON,Precinct 04 Part B,Attorney General,,Democratic,"Kotich, A.J.",2,400020
+LYON,Precinct 04 Part B,Attorney General,,Republican,"Schmidt, Derek",0,400020
+LYON,Precinct 04 Part C,Attorney General,,Democratic,"Kotich, A.J.",2,400030
+LYON,Precinct 04 Part C,Attorney General,,Republican,"Schmidt, Derek",3,400030
+LYON,Precinct 04 Part D,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+LYON,Precinct 04 Part D,Attorney General,,Republican,"Schmidt, Derek",0,900010
+LYON,Precinct 09 Part A,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+LYON,Precinct 09 Part A,Attorney General,,Republican,"Schmidt, Derek",0,900020
+LYON,Precinct 29 Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+LYON,Precinct 29 Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900030
+LYON,Precinct 29 Enclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+LYON,Precinct 29 Enclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900040
+LYON,Precinct 29 Enclave 3,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+LYON,Precinct 29 Enclave 3,Attorney General,,Republican,"Schmidt, Derek",3,900050
+LYON,Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",167,000010
+LYON,Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",147,000010
+LYON,Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,000020
+LYON,Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",94,000020
+LYON,Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",124,000030
+LYON,Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",125,000030
+LYON,Precinct 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",145,000040
+LYON,Precinct 04,Commissioner of Insurance,,Republican,"Selzer, Ken",146,000040
+LYON,Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,00005A
+LYON,Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",79,00005A
+LYON,Precinct 05 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+LYON,Precinct 05 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+LYON,Precinct 05 Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005C
+LYON,Precinct 05 Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005C
+LYON,Precinct 06 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,00006A
+LYON,Precinct 06 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",86,00006A
+LYON,Precinct 06 Part A Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006B
+LYON,Precinct 06 Part A Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006B
+LYON,Precinct 06 Part B Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006C
+LYON,Precinct 06 Part B Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006C
+LYON,Precinct 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000070
+LYON,Precinct 07,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000070
+LYON,Precinct 08,Commissioner of Insurance,,Democratic,"Anderson, Dennis",102,000080
+LYON,Precinct 08,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000080
+LYON,Precinct 09,Commissioner of Insurance,,Democratic,"Anderson, Dennis",99,000090
+LYON,Precinct 09,Commissioner of Insurance,,Republican,"Selzer, Ken",100,000090
+LYON,Precinct 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",145,000100
+LYON,Precinct 10,Commissioner of Insurance,,Republican,"Selzer, Ken",118,000100
+LYON,Precinct 11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,000110
+LYON,Precinct 11,Commissioner of Insurance,,Republican,"Selzer, Ken",98,000110
+LYON,Precinct 12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",103,000120
+LYON,Precinct 12,Commissioner of Insurance,,Republican,"Selzer, Ken",102,000120
+LYON,Precinct 13,Commissioner of Insurance,,Democratic,"Anderson, Dennis",127,000130
+LYON,Precinct 13,Commissioner of Insurance,,Republican,"Selzer, Ken",160,000130
+LYON,Precinct 14,Commissioner of Insurance,,Democratic,"Anderson, Dennis",197,000140
+LYON,Precinct 14,Commissioner of Insurance,,Republican,"Selzer, Ken",212,000140
+LYON,Precinct 15,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,000150
+LYON,Precinct 15,Commissioner of Insurance,,Republican,"Selzer, Ken",124,000150
+LYON,Precinct 16,Commissioner of Insurance,,Democratic,"Anderson, Dennis",169,000160
+LYON,Precinct 16,Commissioner of Insurance,,Republican,"Selzer, Ken",167,000160
+LYON,Precinct 17 Exclave Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00017A
+LYON,Precinct 17 Exclave Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00017A
+LYON,Precinct 17 Enclave Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00017B
+LYON,Precinct 17 Enclave Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00017B
+LYON,Precinct 17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",154,000170
+LYON,Precinct 17,Commissioner of Insurance,,Republican,"Selzer, Ken",181,000170
+LYON,Precinct 18 Enclave Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018A
+LYON,Precinct 18 Enclave Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018A
+LYON,Precinct 18,Commissioner of Insurance,,Democratic,"Anderson, Dennis",126,000180
+LYON,Precinct 18,Commissioner of Insurance,,Republican,"Selzer, Ken",180,000180
+LYON,Precinct 19,Commissioner of Insurance,,Democratic,"Anderson, Dennis",217,000190
+LYON,Precinct 19,Commissioner of Insurance,,Republican,"Selzer, Ken",289,000190
+LYON,Precinct 20 Exclave Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00020A
+LYON,Precinct 20 Exclave Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00020A
+LYON,Precinct 20,Commissioner of Insurance,,Democratic,"Anderson, Dennis",180,000200
+LYON,Precinct 20,Commissioner of Insurance,,Republican,"Selzer, Ken",258,000200
+LYON,Precinct 21,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000210
+LYON,Precinct 21,Commissioner of Insurance,,Republican,"Selzer, Ken",88,000210
+LYON,Precinct 22,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000220
+LYON,Precinct 22,Commissioner of Insurance,,Republican,"Selzer, Ken",64,000220
+LYON,Precinct 23,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000230
+LYON,Precinct 23,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000230
+LYON,Precinct 24,Commissioner of Insurance,,Democratic,"Anderson, Dennis",161,000240
+LYON,Precinct 24,Commissioner of Insurance,,Republican,"Selzer, Ken",292,000240
+LYON,Precinct 25,Commissioner of Insurance,,Democratic,"Anderson, Dennis",123,000250
+LYON,Precinct 25,Commissioner of Insurance,,Republican,"Selzer, Ken",256,000250
+LYON,Precinct 26,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000260
+LYON,Precinct 26,Commissioner of Insurance,,Republican,"Selzer, Ken",109,000260
+LYON,Precinct 27,Commissioner of Insurance,,Democratic,"Anderson, Dennis",90,000270
+LYON,Precinct 27,Commissioner of Insurance,,Republican,"Selzer, Ken",172,000270
+LYON,Precinct 28,Commissioner of Insurance,,Democratic,"Anderson, Dennis",88,00028A
+LYON,Precinct 28,Commissioner of Insurance,,Republican,"Selzer, Ken",160,00028A
+LYON,Precinct 28 Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00028B
+LYON,Precinct 28 Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00028B
+LYON,Precinct 28 Enclave Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00028C
+LYON,Precinct 28 Enclave Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00028C
+LYON,Precinct 29 Exclave Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00029A
+LYON,Precinct 29 Exclave Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00029A
+LYON,Precinct 29,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000290
+LYON,Precinct 29,Commissioner of Insurance,,Republican,"Selzer, Ken",88,000290
+LYON,Precinct 30,Commissioner of Insurance,,Democratic,"Anderson, Dennis",120,000300
+LYON,Precinct 30,Commissioner of Insurance,,Republican,"Selzer, Ken",238,000300
+LYON,Precinct 31,Commissioner of Insurance,,Democratic,"Anderson, Dennis",172,000310
+LYON,Precinct 31,Commissioner of Insurance,,Republican,"Selzer, Ken",284,000310
+LYON,Precinct 32,Commissioner of Insurance,,Democratic,"Anderson, Dennis",103,000320
+LYON,Precinct 32,Commissioner of Insurance,,Republican,"Selzer, Ken",160,000320
+LYON,Precinct 29 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120020
+LYON,Precinct 29 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120020
+LYON,Precinct 07 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,140010
+LYON,Precinct 07 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,140010
+LYON,Precinct 17 Part C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,140020
+LYON,Precinct 17 Part C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,140020
+LYON,Precinct 19 Exclave Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,300010
+LYON,Precinct 19 Exclave Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,300010
+LYON,Precinct 19 Exclave Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,300020
+LYON,Precinct 19 Exclave Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,300020
+LYON,Precinct 04 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,400010
+LYON,Precinct 04 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",4,400010
+LYON,Precinct 04 Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,400020
+LYON,Precinct 04 Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,400020
+LYON,Precinct 04 Part C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,400030
+LYON,Precinct 04 Part C,Commissioner of Insurance,,Republican,"Selzer, Ken",2,400030
+LYON,Precinct 04 Part D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+LYON,Precinct 04 Part D,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+LYON,Precinct 09 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+LYON,Precinct 09 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+LYON,Precinct 29 Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+LYON,Precinct 29 Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+LYON,Precinct 29 Enclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+LYON,Precinct 29 Enclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+LYON,Precinct 29 Enclave 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+LYON,Precinct 29 Enclave 3,Commissioner of Insurance,,Republican,"Selzer, Ken",2,900050
+LYON,Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",197,000010
+LYON,Precinct 01,Secretary of State,,Republican,"Kobach, Kris",121,000010
+LYON,Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",121,000020
+LYON,Precinct 02,Secretary of State,,Republican,"Kobach, Kris",96,000020
+LYON,Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",124,000030
+LYON,Precinct 03,Secretary of State,,Republican,"Kobach, Kris",133,000030
+LYON,Precinct 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",154,000040
+LYON,Precinct 04,Secretary of State,,Republican,"Kobach, Kris",149,000040
+LYON,Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",85,00005A
+LYON,Precinct 05,Secretary of State,,Republican,"Kobach, Kris",90,00005A
+LYON,Precinct 05 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+LYON,Precinct 05 Part A,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+LYON,Precinct 05 Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005C
+LYON,Precinct 05 Part B,Secretary of State,,Republican,"Kobach, Kris",0,00005C
+LYON,Precinct 06 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",122,00006A
+LYON,Precinct 06 Part A,Secretary of State,,Republican,"Kobach, Kris",86,00006A
+LYON,Precinct 06 Part A Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006B
+LYON,Precinct 06 Part A Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00006B
+LYON,Precinct 06 Part B Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006C
+LYON,Precinct 06 Part B Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00006C
+LYON,Precinct 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000070
+LYON,Precinct 07,Secretary of State,,Republican,"Kobach, Kris",36,000070
+LYON,Precinct 08,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",108,000080
+LYON,Precinct 08,Secretary of State,,Republican,"Kobach, Kris",92,000080
+LYON,Precinct 09,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",98,000090
+LYON,Precinct 09,Secretary of State,,Republican,"Kobach, Kris",99,000090
+LYON,Precinct 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",136,000100
+LYON,Precinct 10,Secretary of State,,Republican,"Kobach, Kris",131,000100
+LYON,Precinct 11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",100,000110
+LYON,Precinct 11,Secretary of State,,Republican,"Kobach, Kris",100,000110
+LYON,Precinct 12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",114,000120
+LYON,Precinct 12,Secretary of State,,Republican,"Kobach, Kris",97,000120
+LYON,Precinct 13,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",138,000130
+LYON,Precinct 13,Secretary of State,,Republican,"Kobach, Kris",160,000130
+LYON,Precinct 14,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",232,000140
+LYON,Precinct 14,Secretary of State,,Republican,"Kobach, Kris",197,000140
+LYON,Precinct 15,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",117,000150
+LYON,Precinct 15,Secretary of State,,Republican,"Kobach, Kris",115,000150
+LYON,Precinct 16,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",188,000160
+LYON,Precinct 16,Secretary of State,,Republican,"Kobach, Kris",163,000160
+LYON,Precinct 17 Exclave Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00017A
+LYON,Precinct 17 Exclave Part A,Secretary of State,,Republican,"Kobach, Kris",0,00017A
+LYON,Precinct 17 Enclave Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00017B
+LYON,Precinct 17 Enclave Part B,Secretary of State,,Republican,"Kobach, Kris",0,00017B
+LYON,Precinct 17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",163,000170
+LYON,Precinct 17,Secretary of State,,Republican,"Kobach, Kris",184,000170
+LYON,Precinct 18 Enclave Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018A
+LYON,Precinct 18 Enclave Part A,Secretary of State,,Republican,"Kobach, Kris",0,00018A
+LYON,Precinct 18,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",150,000180
+LYON,Precinct 18,Secretary of State,,Republican,"Kobach, Kris",172,000180
+LYON,Precinct 19,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",238,000190
+LYON,Precinct 19,Secretary of State,,Republican,"Kobach, Kris",284,000190
+LYON,Precinct 20 Exclave Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00020A
+LYON,Precinct 20 Exclave Part A,Secretary of State,,Republican,"Kobach, Kris",0,00020A
+LYON,Precinct 20,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",203,000200
+LYON,Precinct 20,Secretary of State,,Republican,"Kobach, Kris",249,000200
+LYON,Precinct 21,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000210
+LYON,Precinct 21,Secretary of State,,Republican,"Kobach, Kris",102,000210
+LYON,Precinct 22,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000220
+LYON,Precinct 22,Secretary of State,,Republican,"Kobach, Kris",69,000220
+LYON,Precinct 23,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000230
+LYON,Precinct 23,Secretary of State,,Republican,"Kobach, Kris",70,000230
+LYON,Precinct 24,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",161,000240
+LYON,Precinct 24,Secretary of State,,Republican,"Kobach, Kris",302,000240
+LYON,Precinct 25,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",133,000250
+LYON,Precinct 25,Secretary of State,,Republican,"Kobach, Kris",259,000250
+LYON,Precinct 26,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",84,000260
+LYON,Precinct 26,Secretary of State,,Republican,"Kobach, Kris",101,000260
+LYON,Precinct 27,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",96,000270
+LYON,Precinct 27,Secretary of State,,Republican,"Kobach, Kris",179,000270
+LYON,Precinct 28,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,00028A
+LYON,Precinct 28,Secretary of State,,Republican,"Kobach, Kris",171,00028A
+LYON,Precinct 28 Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00028B
+LYON,Precinct 28 Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,00028B
+LYON,Precinct 28 Enclave Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00028C
+LYON,Precinct 28 Enclave Part B,Secretary of State,,Republican,"Kobach, Kris",0,00028C
+LYON,Precinct 29 Exclave Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00029A
+LYON,Precinct 29 Exclave Part A,Secretary of State,,Republican,"Kobach, Kris",0,00029A
+LYON,Precinct 29,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000290
+LYON,Precinct 29,Secretary of State,,Republican,"Kobach, Kris",87,000290
+LYON,Precinct 30,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",141,000300
+LYON,Precinct 30,Secretary of State,,Republican,"Kobach, Kris",234,000300
+LYON,Precinct 31,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",171,000310
+LYON,Precinct 31,Secretary of State,,Republican,"Kobach, Kris",314,000310
+LYON,Precinct 32,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",102,000320
+LYON,Precinct 32,Secretary of State,,Republican,"Kobach, Kris",169,000320
+LYON,Precinct 29 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120020
+LYON,Precinct 29 A,Secretary of State,,Republican,"Kobach, Kris",0,120020
+LYON,Precinct 07 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,140010
+LYON,Precinct 07 Part A,Secretary of State,,Republican,"Kobach, Kris",0,140010
+LYON,Precinct 17 Part C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,140020
+LYON,Precinct 17 Part C,Secretary of State,,Republican,"Kobach, Kris",0,140020
+LYON,Precinct 19 Exclave Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,300010
+LYON,Precinct 19 Exclave Part A,Secretary of State,,Republican,"Kobach, Kris",0,300010
+LYON,Precinct 19 Exclave Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,300020
+LYON,Precinct 19 Exclave Part B,Secretary of State,,Republican,"Kobach, Kris",0,300020
+LYON,Precinct 04 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,400010
+LYON,Precinct 04 Part A,Secretary of State,,Republican,"Kobach, Kris",4,400010
+LYON,Precinct 04 Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,400020
+LYON,Precinct 04 Part B,Secretary of State,,Republican,"Kobach, Kris",0,400020
+LYON,Precinct 04 Part C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,400030
+LYON,Precinct 04 Part C,Secretary of State,,Republican,"Kobach, Kris",2,400030
+LYON,Precinct 04 Part D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+LYON,Precinct 04 Part D,Secretary of State,,Republican,"Kobach, Kris",0,900010
+LYON,Precinct 09 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+LYON,Precinct 09 Part A,Secretary of State,,Republican,"Kobach, Kris",0,900020
+LYON,Precinct 29 Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+LYON,Precinct 29 Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900030
+LYON,Precinct 29 Enclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+LYON,Precinct 29 Enclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900040
+LYON,Precinct 29 Enclave 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+LYON,Precinct 29 Enclave 3,Secretary of State,,Republican,"Kobach, Kris",2,900050
+LYON,Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",151,000010
+LYON,Precinct 01,State Treasurer,,Republican,"Estes, Ron",162,000010
+LYON,Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",98,000020
+LYON,Precinct 02,State Treasurer,,Republican,"Estes, Ron",117,000020
+LYON,Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",109,000030
+LYON,Precinct 03,State Treasurer,,Republican,"Estes, Ron",147,000030
+LYON,Precinct 04,State Treasurer,,Democratic,"Alldritt, Carmen",132,000040
+LYON,Precinct 04,State Treasurer,,Republican,"Estes, Ron",165,000040
+LYON,Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",77,00005A
+LYON,Precinct 05,State Treasurer,,Republican,"Estes, Ron",97,00005A
+LYON,Precinct 05 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+LYON,Precinct 05 Part A,State Treasurer,,Republican,"Estes, Ron",0,00005B
+LYON,Precinct 05 Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005C
+LYON,Precinct 05 Part B,State Treasurer,,Republican,"Estes, Ron",0,00005C
+LYON,Precinct 06 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",101,00006A
+LYON,Precinct 06 Part A,State Treasurer,,Republican,"Estes, Ron",103,00006A
+LYON,Precinct 06 Part A Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006B
+LYON,Precinct 06 Part A Exclave,State Treasurer,,Republican,"Estes, Ron",0,00006B
+LYON,Precinct 06 Part B Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006C
+LYON,Precinct 06 Part B Exclave,State Treasurer,,Republican,"Estes, Ron",0,00006C
+LYON,Precinct 07,State Treasurer,,Democratic,"Alldritt, Carmen",38,000070
+LYON,Precinct 07,State Treasurer,,Republican,"Estes, Ron",44,000070
+LYON,Precinct 08,State Treasurer,,Democratic,"Alldritt, Carmen",83,000080
+LYON,Precinct 08,State Treasurer,,Republican,"Estes, Ron",108,000080
+LYON,Precinct 09,State Treasurer,,Democratic,"Alldritt, Carmen",84,000090
+LYON,Precinct 09,State Treasurer,,Republican,"Estes, Ron",118,000090
+LYON,Precinct 10,State Treasurer,,Democratic,"Alldritt, Carmen",110,000100
+LYON,Precinct 10,State Treasurer,,Republican,"Estes, Ron",156,000100
+LYON,Precinct 11,State Treasurer,,Democratic,"Alldritt, Carmen",87,000110
+LYON,Precinct 11,State Treasurer,,Republican,"Estes, Ron",108,000110
+LYON,Precinct 12,State Treasurer,,Democratic,"Alldritt, Carmen",87,000120
+LYON,Precinct 12,State Treasurer,,Republican,"Estes, Ron",121,000120
+LYON,Precinct 13,State Treasurer,,Democratic,"Alldritt, Carmen",108,000130
+LYON,Precinct 13,State Treasurer,,Republican,"Estes, Ron",180,000130
+LYON,Precinct 14,State Treasurer,,Democratic,"Alldritt, Carmen",170,000140
+LYON,Precinct 14,State Treasurer,,Republican,"Estes, Ron",248,000140
+LYON,Precinct 15,State Treasurer,,Democratic,"Alldritt, Carmen",86,000150
+LYON,Precinct 15,State Treasurer,,Republican,"Estes, Ron",135,000150
+LYON,Precinct 16,State Treasurer,,Democratic,"Alldritt, Carmen",139,000160
+LYON,Precinct 16,State Treasurer,,Republican,"Estes, Ron",195,000160
+LYON,Precinct 17 Exclave Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00017A
+LYON,Precinct 17 Exclave Part A,State Treasurer,,Republican,"Estes, Ron",0,00017A
+LYON,Precinct 17 Enclave Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00017B
+LYON,Precinct 17 Enclave Part B,State Treasurer,,Republican,"Estes, Ron",0,00017B
+LYON,Precinct 17,State Treasurer,,Democratic,"Alldritt, Carmen",133,000170
+LYON,Precinct 17,State Treasurer,,Republican,"Estes, Ron",210,000170
+LYON,Precinct 18 Enclave Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018A
+LYON,Precinct 18 Enclave Part A,State Treasurer,,Republican,"Estes, Ron",0,00018A
+LYON,Precinct 18,State Treasurer,,Democratic,"Alldritt, Carmen",118,000180
+LYON,Precinct 18,State Treasurer,,Republican,"Estes, Ron",196,000180
+LYON,Precinct 19,State Treasurer,,Democratic,"Alldritt, Carmen",175,000190
+LYON,Precinct 19,State Treasurer,,Republican,"Estes, Ron",339,000190
+LYON,Precinct 20 Exclave Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00020A
+LYON,Precinct 20 Exclave Part A,State Treasurer,,Republican,"Estes, Ron",0,00020A
+LYON,Precinct 20,State Treasurer,,Democratic,"Alldritt, Carmen",148,000200
+LYON,Precinct 20,State Treasurer,,Republican,"Estes, Ron",297,000200
+LYON,Precinct 21,State Treasurer,,Democratic,"Alldritt, Carmen",38,000210
+LYON,Precinct 21,State Treasurer,,Republican,"Estes, Ron",109,000210
+LYON,Precinct 22,State Treasurer,,Democratic,"Alldritt, Carmen",22,000220
+LYON,Precinct 22,State Treasurer,,Republican,"Estes, Ron",75,000220
+LYON,Precinct 23,State Treasurer,,Democratic,"Alldritt, Carmen",24,000230
+LYON,Precinct 23,State Treasurer,,Republican,"Estes, Ron",84,000230
+LYON,Precinct 24,State Treasurer,,Democratic,"Alldritt, Carmen",120,000240
+LYON,Precinct 24,State Treasurer,,Republican,"Estes, Ron",339,000240
+LYON,Precinct 25,State Treasurer,,Democratic,"Alldritt, Carmen",91,000250
+LYON,Precinct 25,State Treasurer,,Republican,"Estes, Ron",293,000250
+LYON,Precinct 26,State Treasurer,,Democratic,"Alldritt, Carmen",58,000260
+LYON,Precinct 26,State Treasurer,,Republican,"Estes, Ron",124,000260
+LYON,Precinct 27,State Treasurer,,Democratic,"Alldritt, Carmen",66,000270
+LYON,Precinct 27,State Treasurer,,Republican,"Estes, Ron",198,000270
+LYON,Precinct 28,State Treasurer,,Democratic,"Alldritt, Carmen",78,00028A
+LYON,Precinct 28,State Treasurer,,Republican,"Estes, Ron",178,00028A
+LYON,Precinct 28 Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00028B
+LYON,Precinct 28 Enclave A,State Treasurer,,Republican,"Estes, Ron",0,00028B
+LYON,Precinct 28 Enclave Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00028C
+LYON,Precinct 28 Enclave Part B,State Treasurer,,Republican,"Estes, Ron",0,00028C
+LYON,Precinct 29 Exclave Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00029A
+LYON,Precinct 29 Exclave Part A,State Treasurer,,Republican,"Estes, Ron",0,00029A
+LYON,Precinct 29,State Treasurer,,Democratic,"Alldritt, Carmen",34,000290
+LYON,Precinct 29,State Treasurer,,Republican,"Estes, Ron",99,000290
+LYON,Precinct 30,State Treasurer,,Democratic,"Alldritt, Carmen",115,000300
+LYON,Precinct 30,State Treasurer,,Republican,"Estes, Ron",251,000300
+LYON,Precinct 31,State Treasurer,,Democratic,"Alldritt, Carmen",128,000310
+LYON,Precinct 31,State Treasurer,,Republican,"Estes, Ron",338,000310
+LYON,Precinct 32,State Treasurer,,Democratic,"Alldritt, Carmen",74,000320
+LYON,Precinct 32,State Treasurer,,Republican,"Estes, Ron",195,000320
+LYON,Precinct 29 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,120020
+LYON,Precinct 29 A,State Treasurer,,Republican,"Estes, Ron",0,120020
+LYON,Precinct 07 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,140010
+LYON,Precinct 07 Part A,State Treasurer,,Republican,"Estes, Ron",0,140010
+LYON,Precinct 17 Part C,State Treasurer,,Democratic,"Alldritt, Carmen",0,140020
+LYON,Precinct 17 Part C,State Treasurer,,Republican,"Estes, Ron",0,140020
+LYON,Precinct 19 Exclave Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,300010
+LYON,Precinct 19 Exclave Part A,State Treasurer,,Republican,"Estes, Ron",0,300010
+LYON,Precinct 19 Exclave Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,300020
+LYON,Precinct 19 Exclave Part B,State Treasurer,,Republican,"Estes, Ron",0,300020
+LYON,Precinct 04 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,400010
+LYON,Precinct 04 Part A,State Treasurer,,Republican,"Estes, Ron",4,400010
+LYON,Precinct 04 Part B,State Treasurer,,Democratic,"Alldritt, Carmen",2,400020
+LYON,Precinct 04 Part B,State Treasurer,,Republican,"Estes, Ron",0,400020
+LYON,Precinct 04 Part C,State Treasurer,,Democratic,"Alldritt, Carmen",2,400030
+LYON,Precinct 04 Part C,State Treasurer,,Republican,"Estes, Ron",2,400030
+LYON,Precinct 04 Part D,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+LYON,Precinct 04 Part D,State Treasurer,,Republican,"Estes, Ron",0,900010
+LYON,Precinct 09 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+LYON,Precinct 09 Part A,State Treasurer,,Republican,"Estes, Ron",0,900020
+LYON,Precinct 29 Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+LYON,Precinct 29 Enclave,State Treasurer,,Republican,"Estes, Ron",0,900030
+LYON,Precinct 29 Enclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+LYON,Precinct 29 Enclave 2,State Treasurer,,Republican,"Estes, Ron",0,900040
+LYON,Precinct 29 Enclave 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+LYON,Precinct 29 Enclave 3,State Treasurer,,Republican,"Estes, Ron",3,900050
+LYON,Precinct 01,United States Senate,,independent,"Orman, Greg",188,000010
+LYON,Precinct 01,United States Senate,,Libertarian,"Batson, Randall",7,000010
+LYON,Precinct 01,United States Senate,,Republican,"Roberts, Pat",124,000010
+LYON,Precinct 02,United States Senate,,independent,"Orman, Greg",128,000020
+LYON,Precinct 02,United States Senate,,Libertarian,"Batson, Randall",11,000020
+LYON,Precinct 02,United States Senate,,Republican,"Roberts, Pat",84,000020
+LYON,Precinct 03,United States Senate,,independent,"Orman, Greg",124,000030
+LYON,Precinct 03,United States Senate,,Libertarian,"Batson, Randall",17,000030
+LYON,Precinct 03,United States Senate,,Republican,"Roberts, Pat",124,000030
+LYON,Precinct 04,United States Senate,,independent,"Orman, Greg",171,000040
+LYON,Precinct 04,United States Senate,,Libertarian,"Batson, Randall",13,000040
+LYON,Precinct 04,United States Senate,,Republican,"Roberts, Pat",124,000040
+LYON,Precinct 05,United States Senate,,independent,"Orman, Greg",86,00005A
+LYON,Precinct 05,United States Senate,,Libertarian,"Batson, Randall",13,00005A
+LYON,Precinct 05,United States Senate,,Republican,"Roberts, Pat",76,00005A
+LYON,Precinct 05 Part A,United States Senate,,independent,"Orman, Greg",0,00005B
+LYON,Precinct 05 Part A,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+LYON,Precinct 05 Part A,United States Senate,,Republican,"Roberts, Pat",0,00005B
+LYON,Precinct 05 Part B,United States Senate,,independent,"Orman, Greg",0,00005C
+LYON,Precinct 05 Part B,United States Senate,,Libertarian,"Batson, Randall",0,00005C
+LYON,Precinct 05 Part B,United States Senate,,Republican,"Roberts, Pat",0,00005C
+LYON,Precinct 06 Part A,United States Senate,,independent,"Orman, Greg",103,00006A
+LYON,Precinct 06 Part A,United States Senate,,Libertarian,"Batson, Randall",13,00006A
+LYON,Precinct 06 Part A,United States Senate,,Republican,"Roberts, Pat",88,00006A
+LYON,Precinct 06 Part A Exclave,United States Senate,,independent,"Orman, Greg",0,00006B
+LYON,Precinct 06 Part A Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00006B
+LYON,Precinct 06 Part A Exclave,United States Senate,,Republican,"Roberts, Pat",0,00006B
+LYON,Precinct 06 Part B Exclave,United States Senate,,independent,"Orman, Greg",0,00006C
+LYON,Precinct 06 Part B Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00006C
+LYON,Precinct 06 Part B Exclave,United States Senate,,Republican,"Roberts, Pat",0,00006C
+LYON,Precinct 07,United States Senate,,independent,"Orman, Greg",53,000070
+LYON,Precinct 07,United States Senate,,Libertarian,"Batson, Randall",5,000070
+LYON,Precinct 07,United States Senate,,Republican,"Roberts, Pat",33,000070
+LYON,Precinct 08,United States Senate,,independent,"Orman, Greg",110,000080
+LYON,Precinct 08,United States Senate,,Libertarian,"Batson, Randall",11,000080
+LYON,Precinct 08,United States Senate,,Republican,"Roberts, Pat",79,000080
+LYON,Precinct 09,United States Senate,,independent,"Orman, Greg",107,000090
+LYON,Precinct 09,United States Senate,,Libertarian,"Batson, Randall",6,000090
+LYON,Precinct 09,United States Senate,,Republican,"Roberts, Pat",89,000090
+LYON,Precinct 10,United States Senate,,independent,"Orman, Greg",149,000100
+LYON,Precinct 10,United States Senate,,Libertarian,"Batson, Randall",12,000100
+LYON,Precinct 10,United States Senate,,Republican,"Roberts, Pat",108,000100
+LYON,Precinct 11,United States Senate,,independent,"Orman, Greg",107,000110
+LYON,Precinct 11,United States Senate,,Libertarian,"Batson, Randall",7,000110
+LYON,Precinct 11,United States Senate,,Republican,"Roberts, Pat",87,000110
+LYON,Precinct 12,United States Senate,,independent,"Orman, Greg",115,000120
+LYON,Precinct 12,United States Senate,,Libertarian,"Batson, Randall",8,000120
+LYON,Precinct 12,United States Senate,,Republican,"Roberts, Pat",91,000120
+LYON,Precinct 13,United States Senate,,independent,"Orman, Greg",142,000130
+LYON,Precinct 13,United States Senate,,Libertarian,"Batson, Randall",22,000130
+LYON,Precinct 13,United States Senate,,Republican,"Roberts, Pat",135,000130
+LYON,Precinct 14,United States Senate,,independent,"Orman, Greg",239,000140
+LYON,Precinct 14,United States Senate,,Libertarian,"Batson, Randall",10,000140
+LYON,Precinct 14,United States Senate,,Republican,"Roberts, Pat",184,000140
+LYON,Precinct 15,United States Senate,,independent,"Orman, Greg",116,000150
+LYON,Precinct 15,United States Senate,,Libertarian,"Batson, Randall",7,000150
+LYON,Precinct 15,United States Senate,,Republican,"Roberts, Pat",109,000150
+LYON,Precinct 16,United States Senate,,independent,"Orman, Greg",199,000160
+LYON,Precinct 16,United States Senate,,Libertarian,"Batson, Randall",11,000160
+LYON,Precinct 16,United States Senate,,Republican,"Roberts, Pat",145,000160
+LYON,Precinct 17 Exclave Part A,United States Senate,,independent,"Orman, Greg",0,00017A
+LYON,Precinct 17 Exclave Part A,United States Senate,,Libertarian,"Batson, Randall",0,00017A
+LYON,Precinct 17 Exclave Part A,United States Senate,,Republican,"Roberts, Pat",0,00017A
+LYON,Precinct 17 Enclave Part B,United States Senate,,independent,"Orman, Greg",0,00017B
+LYON,Precinct 17 Enclave Part B,United States Senate,,Libertarian,"Batson, Randall",0,00017B
+LYON,Precinct 17 Enclave Part B,United States Senate,,Republican,"Roberts, Pat",0,00017B
+LYON,Precinct 17,United States Senate,,independent,"Orman, Greg",172,000170
+LYON,Precinct 17,United States Senate,,Libertarian,"Batson, Randall",22,000170
+LYON,Precinct 17,United States Senate,,Republican,"Roberts, Pat",160,000170
+LYON,Precinct 18 Enclave Part A,United States Senate,,independent,"Orman, Greg",0,00018A
+LYON,Precinct 18 Enclave Part A,United States Senate,,Libertarian,"Batson, Randall",0,00018A
+LYON,Precinct 18 Enclave Part A,United States Senate,,Republican,"Roberts, Pat",0,00018A
+LYON,Precinct 18,United States Senate,,independent,"Orman, Greg",164,000180
+LYON,Precinct 18,United States Senate,,Libertarian,"Batson, Randall",8,000180
+LYON,Precinct 18,United States Senate,,Republican,"Roberts, Pat",154,000180
+LYON,Precinct 19,United States Senate,,independent,"Orman, Greg",279,000190
+LYON,Precinct 19,United States Senate,,Libertarian,"Batson, Randall",16,000190
+LYON,Precinct 19,United States Senate,,Republican,"Roberts, Pat",234,000190
+LYON,Precinct 20 Exclave Part A,United States Senate,,independent,"Orman, Greg",0,00020A
+LYON,Precinct 20 Exclave Part A,United States Senate,,Libertarian,"Batson, Randall",0,00020A
+LYON,Precinct 20 Exclave Part A,United States Senate,,Republican,"Roberts, Pat",0,00020A
+LYON,Precinct 20,United States Senate,,independent,"Orman, Greg",206,000200
+LYON,Precinct 20,United States Senate,,Libertarian,"Batson, Randall",14,000200
+LYON,Precinct 20,United States Senate,,Republican,"Roberts, Pat",239,000200
+LYON,Precinct 21,United States Senate,,independent,"Orman, Greg",65,000210
+LYON,Precinct 21,United States Senate,,Libertarian,"Batson, Randall",5,000210
+LYON,Precinct 21,United States Senate,,Republican,"Roberts, Pat",80,000210
+LYON,Precinct 22,United States Senate,,independent,"Orman, Greg",34,000220
+LYON,Precinct 22,United States Senate,,Libertarian,"Batson, Randall",3,000220
+LYON,Precinct 22,United States Senate,,Republican,"Roberts, Pat",60,000220
+LYON,Precinct 23,United States Senate,,independent,"Orman, Greg",34,000230
+LYON,Precinct 23,United States Senate,,Libertarian,"Batson, Randall",7,000230
+LYON,Precinct 23,United States Senate,,Republican,"Roberts, Pat",66,000230
+LYON,Precinct 24,United States Senate,,independent,"Orman, Greg",187,000240
+LYON,Precinct 24,United States Senate,,Libertarian,"Batson, Randall",23,000240
+LYON,Precinct 24,United States Senate,,Republican,"Roberts, Pat",263,000240
+LYON,Precinct 25,United States Senate,,independent,"Orman, Greg",142,000250
+LYON,Precinct 25,United States Senate,,Libertarian,"Batson, Randall",19,000250
+LYON,Precinct 25,United States Senate,,Republican,"Roberts, Pat",236,000250
+LYON,Precinct 26,United States Senate,,independent,"Orman, Greg",88,000260
+LYON,Precinct 26,United States Senate,,Libertarian,"Batson, Randall",5,000260
+LYON,Precinct 26,United States Senate,,Republican,"Roberts, Pat",97,000260
+LYON,Precinct 27,United States Senate,,independent,"Orman, Greg",107,000270
+LYON,Precinct 27,United States Senate,,Libertarian,"Batson, Randall",18,000270
+LYON,Precinct 27,United States Senate,,Republican,"Roberts, Pat",157,000270
+LYON,Precinct 28,United States Senate,,independent,"Orman, Greg",116,00028A
+LYON,Precinct 28,United States Senate,,Libertarian,"Batson, Randall",14,00028A
+LYON,Precinct 28,United States Senate,,Republican,"Roberts, Pat",138,00028A
+LYON,Precinct 28 Enclave A,United States Senate,,independent,"Orman, Greg",0,00028B
+LYON,Precinct 28 Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,00028B
+LYON,Precinct 28 Enclave A,United States Senate,,Republican,"Roberts, Pat",0,00028B
+LYON,Precinct 28 Enclave Part B,United States Senate,,independent,"Orman, Greg",0,00028C
+LYON,Precinct 28 Enclave Part B,United States Senate,,Libertarian,"Batson, Randall",0,00028C
+LYON,Precinct 28 Enclave Part B,United States Senate,,Republican,"Roberts, Pat",0,00028C
+LYON,Precinct 29 Exclave Part A,United States Senate,,independent,"Orman, Greg",0,00029A
+LYON,Precinct 29 Exclave Part A,United States Senate,,Libertarian,"Batson, Randall",0,00029A
+LYON,Precinct 29 Exclave Part A,United States Senate,,Republican,"Roberts, Pat",0,00029A
+LYON,Precinct 29,United States Senate,,independent,"Orman, Greg",54,000290
+LYON,Precinct 29,United States Senate,,Libertarian,"Batson, Randall",5,000290
+LYON,Precinct 29,United States Senate,,Republican,"Roberts, Pat",79,000290
+LYON,Precinct 30,United States Senate,,independent,"Orman, Greg",149,000300
+LYON,Precinct 30,United States Senate,,Libertarian,"Batson, Randall",29,000300
+LYON,Precinct 30,United States Senate,,Republican,"Roberts, Pat",200,000300
+LYON,Precinct 31,United States Senate,,independent,"Orman, Greg",198,000310
+LYON,Precinct 31,United States Senate,,Libertarian,"Batson, Randall",25,000310
+LYON,Precinct 31,United States Senate,,Republican,"Roberts, Pat",271,000310
+LYON,Precinct 32,United States Senate,,independent,"Orman, Greg",118,000320
+LYON,Precinct 32,United States Senate,,Libertarian,"Batson, Randall",16,000320
+LYON,Precinct 32,United States Senate,,Republican,"Roberts, Pat",138,000320
+LYON,Precinct 29 A,United States Senate,,independent,"Orman, Greg",0,120020
+LYON,Precinct 29 A,United States Senate,,Libertarian,"Batson, Randall",0,120020
+LYON,Precinct 29 A,United States Senate,,Republican,"Roberts, Pat",0,120020
+LYON,Precinct 07 Part A,United States Senate,,independent,"Orman, Greg",0,140010
+LYON,Precinct 07 Part A,United States Senate,,Libertarian,"Batson, Randall",0,140010
+LYON,Precinct 07 Part A,United States Senate,,Republican,"Roberts, Pat",0,140010
+LYON,Precinct 17 Part C,United States Senate,,independent,"Orman, Greg",0,140020
+LYON,Precinct 17 Part C,United States Senate,,Libertarian,"Batson, Randall",0,140020
+LYON,Precinct 17 Part C,United States Senate,,Republican,"Roberts, Pat",0,140020
+LYON,Precinct 19 Exclave Part A,United States Senate,,independent,"Orman, Greg",0,300010
+LYON,Precinct 19 Exclave Part A,United States Senate,,Libertarian,"Batson, Randall",0,300010
+LYON,Precinct 19 Exclave Part A,United States Senate,,Republican,"Roberts, Pat",0,300010
+LYON,Precinct 19 Exclave Part B,United States Senate,,independent,"Orman, Greg",0,300020
+LYON,Precinct 19 Exclave Part B,United States Senate,,Libertarian,"Batson, Randall",0,300020
+LYON,Precinct 19 Exclave Part B,United States Senate,,Republican,"Roberts, Pat",0,300020
+LYON,Precinct 04 Part A,United States Senate,,independent,"Orman, Greg",0,400010
+LYON,Precinct 04 Part A,United States Senate,,Libertarian,"Batson, Randall",0,400010
+LYON,Precinct 04 Part A,United States Senate,,Republican,"Roberts, Pat",4,400010
+LYON,Precinct 04 Part B,United States Senate,,independent,"Orman, Greg",1,400020
+LYON,Precinct 04 Part B,United States Senate,,Libertarian,"Batson, Randall",0,400020
+LYON,Precinct 04 Part B,United States Senate,,Republican,"Roberts, Pat",0,400020
+LYON,Precinct 04 Part C,United States Senate,,independent,"Orman, Greg",3,400030
+LYON,Precinct 04 Part C,United States Senate,,Libertarian,"Batson, Randall",0,400030
+LYON,Precinct 04 Part C,United States Senate,,Republican,"Roberts, Pat",2,400030
+LYON,Precinct 04 Part D,United States Senate,,independent,"Orman, Greg",0,900010
+LYON,Precinct 04 Part D,United States Senate,,Libertarian,"Batson, Randall",0,900010
+LYON,Precinct 04 Part D,United States Senate,,Republican,"Roberts, Pat",0,900010
+LYON,Precinct 09 Part A,United States Senate,,independent,"Orman, Greg",0,900020
+LYON,Precinct 09 Part A,United States Senate,,Libertarian,"Batson, Randall",0,900020
+LYON,Precinct 09 Part A,United States Senate,,Republican,"Roberts, Pat",0,900020
+LYON,Precinct 29 Enclave,United States Senate,,independent,"Orman, Greg",0,900030
+LYON,Precinct 29 Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900030
+LYON,Precinct 29 Enclave,United States Senate,,Republican,"Roberts, Pat",0,900030
+LYON,Precinct 29 Enclave 2,United States Senate,,independent,"Orman, Greg",0,900040
+LYON,Precinct 29 Enclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900040
+LYON,Precinct 29 Enclave 2,United States Senate,,Republican,"Roberts, Pat",0,900040
+LYON,Precinct 29 Enclave 3,United States Senate,,independent,"Orman, Greg",0,900050
+LYON,Precinct 29 Enclave 3,United States Senate,,Libertarian,"Batson, Randall",0,900050
+LYON,Precinct 29 Enclave 3,United States Senate,,Republican,"Roberts, Pat",3,900050

--- a/2014/20141104__ks__general__marion__precinct.csv
+++ b/2014/20141104__ks__general__marion__precinct.csv
@@ -1,559 +1,631 @@
-county,precinct,office,district,party,candidate,votes
-Marion,Blaine Township,U.S. Senate,,R,Pat Roberts,48
-Marion,Catlin Township,U.S. Senate,,R,Pat Roberts,52
-Marion,Centre Township,U.S. Senate,,R,Pat Roberts,159
-Marion,Clark Township,U.S. Senate,,R,Pat Roberts,50
-Marion,Clear Creek Township,U.S. Senate,,R,Pat Roberts,129
-Marion,Colfax Township,U.S. Senate,,R,Pat Roberts,55
-Marion,Doyle Township,U.S. Senate,,R,Pat Roberts,15
-Marion,Durham Park Township,U.S. Senate,,R,Pat Roberts,60
-Marion,East Branch Township,U.S. Senate,,R,Pat Roberts,57
-Marion,Fairplay Township,U.S. Senate,,R,Pat Roberts,48
-Marion,Florence Ward 1,U.S. Senate,,R,Pat Roberts,28
-Marion,Florence Ward 2,U.S. Senate,,R,Pat Roberts,37
-Marion,Gale Township,U.S. Senate,,R,Pat Roberts,64
-Marion,Grant Township,U.S. Senate,,R,Pat Roberts,45
-Marion,Hillsboro Ward 1,U.S. Senate,,R,Pat Roberts,290
-Marion,Hillsboro Ward 2,U.S. Senate,,R,Pat Roberts,331
-Marion,Lehigh Township,U.S. Senate,,R,Pat Roberts,58
-Marion,Liberty Township,U.S. Senate,,R,Pat Roberts,96
-Marion,Logan Township,U.S. Senate,,R,Pat Roberts,19
-Marion,Lost Springs Township,U.S. Senate,,R,Pat Roberts,64
-Marion,Marion North Ward,U.S. Senate,,R,Pat Roberts,200
-Marion,Marion South Ward,U.S. Senate,,R,Pat Roberts,184
-Marion,Menno Township,U.S. Senate,,R,Pat Roberts,100
-Marion,Milton Township,U.S. Senate,,R,Pat Roberts,53
-Marion,Moore Township,U.S. Senate,,R,Pat Roberts,20
-Marion,Peabody East,U.S. Senate,,R,Pat Roberts,89
-Marion,Peabody West,U.S. Senate,,R,Pat Roberts,136
-Marion,Risley Township,U.S. Senate,,R,Pat Roberts,94
-Marion,Summit Township,U.S. Senate,,R,Pat Roberts,20
-Marion,West Branch Township,U.S. Senate,,R,Pat Roberts,185
-Marion,Wilson Township,U.S. Senate,,R,Pat Roberts,61
-Marion,Blaine Township,U.S. Senate,,I,Greg Orman,18
-Marion,Catlin Township,U.S. Senate,,I,Greg Orman,28
-Marion,Centre Township,U.S. Senate,,I,Greg Orman,76
-Marion,Clark Township,U.S. Senate,,I,Greg Orman,11
-Marion,Clear Creek Township,U.S. Senate,,I,Greg Orman,40
-Marion,Colfax Township,U.S. Senate,,I,Greg Orman,19
-Marion,Doyle Township,U.S. Senate,,I,Greg Orman,4
-Marion,Durham Park Township,U.S. Senate,,I,Greg Orman,27
-Marion,East Branch Township,U.S. Senate,,I,Greg Orman,36
-Marion,Fairplay Township,U.S. Senate,,I,Greg Orman,10
-Marion,Florence Ward 1,U.S. Senate,,I,Greg Orman,26
-Marion,Florence Ward 2,U.S. Senate,,I,Greg Orman,33
-Marion,Gale Township,U.S. Senate,,I,Greg Orman,33
-Marion,Grant Township,U.S. Senate,,I,Greg Orman,23
-Marion,Hillsboro Ward 1,U.S. Senate,,I,Greg Orman,105
-Marion,Hillsboro Ward 2,U.S. Senate,,I,Greg Orman,125
-Marion,Lehigh Township,U.S. Senate,,I,Greg Orman,18
-Marion,Liberty Township,U.S. Senate,,I,Greg Orman,39
-Marion,Logan Township,U.S. Senate,,I,Greg Orman,6
-Marion,Lost Springs Township,U.S. Senate,,I,Greg Orman,14
-Marion,Marion North Ward,U.S. Senate,,I,Greg Orman,125
-Marion,Marion South Ward,U.S. Senate,,I,Greg Orman,106
-Marion,Menno Township,U.S. Senate,,I,Greg Orman,49
-Marion,Milton Township,U.S. Senate,,I,Greg Orman,25
-Marion,Moore Township,U.S. Senate,,I,Greg Orman,7
-Marion,Peabody East,U.S. Senate,,I,Greg Orman,70
-Marion,Peabody West,U.S. Senate,,I,Greg Orman,75
-Marion,Risley Township,U.S. Senate,,I,Greg Orman,16
-Marion,Summit Township,U.S. Senate,,I,Greg Orman,11
-Marion,West Branch Township,U.S. Senate,,I,Greg Orman,173
-Marion,Wilson Township,U.S. Senate,,I,Greg Orman,15
-Marion,Blaine Township,U.S. Senate,,L,Randall Batson,2
-Marion,Catlin Township,U.S. Senate,,L,Randall Batson,3
-Marion,Centre Township,U.S. Senate,,L,Randall Batson,15
-Marion,Clark Township,U.S. Senate,,L,Randall Batson,0
-Marion,Clear Creek Township,U.S. Senate,,L,Randall Batson,11
-Marion,Colfax Township,U.S. Senate,,L,Randall Batson,1
-Marion,Doyle Township,U.S. Senate,,L,Randall Batson,0
-Marion,Durham Park Township,U.S. Senate,,L,Randall Batson,2
-Marion,East Branch Township,U.S. Senate,,L,Randall Batson,5
-Marion,Fairplay Township,U.S. Senate,,L,Randall Batson,2
-Marion,Florence Ward 1,U.S. Senate,,L,Randall Batson,9
-Marion,Florence Ward 2,U.S. Senate,,L,Randall Batson,6
-Marion,Gale Township,U.S. Senate,,L,Randall Batson,6
-Marion,Grant Township,U.S. Senate,,L,Randall Batson,1
-Marion,Hillsboro Ward 1,U.S. Senate,,L,Randall Batson,13
-Marion,Hillsboro Ward 2,U.S. Senate,,L,Randall Batson,22
-Marion,Lehigh Township,U.S. Senate,,L,Randall Batson,0
-Marion,Liberty Township,U.S. Senate,,L,Randall Batson,7
-Marion,Logan Township,U.S. Senate,,L,Randall Batson,0
-Marion,Lost Springs Township,U.S. Senate,,L,Randall Batson,0
-Marion,Marion North Ward,U.S. Senate,,L,Randall Batson,18
-Marion,Marion South Ward,U.S. Senate,,L,Randall Batson,17
-Marion,Menno Township,U.S. Senate,,L,Randall Batson,7
-Marion,Milton Township,U.S. Senate,,L,Randall Batson,5
-Marion,Moore Township,U.S. Senate,,L,Randall Batson,0
-Marion,Peabody East,U.S. Senate,,L,Randall Batson,9
-Marion,Peabody West,U.S. Senate,,L,Randall Batson,23
-Marion,Risley Township,U.S. Senate,,L,Randall Batson,1
-Marion,Summit Township,U.S. Senate,,L,Randall Batson,2
-Marion,West Branch Township,U.S. Senate,,L,Randall Batson,26
-Marion,Wilson Township,U.S. Senate,,L,Randall Batson,6
-Marion,Blaine Township,U.S. House,1,R,Tim Huelskamp,50
-Marion,Catlin Township,U.S. House,1,R,Tim Huelskamp,56
-Marion,Centre Township,U.S. House,1,R,Tim Huelskamp,176
-Marion,Clark Township,U.S. House,1,R,Tim Huelskamp,50
-Marion,Clear Creek Township,U.S. House,1,R,Tim Huelskamp,137
-Marion,Colfax Township,U.S. House,1,R,Tim Huelskamp,57
-Marion,Doyle Township,U.S. House,1,R,Tim Huelskamp,15
-Marion,Durham Park Township,U.S. House,1,R,Tim Huelskamp,60
-Marion,East Branch Township,U.S. House,1,R,Tim Huelskamp,60
-Marion,Fairplay Township,U.S. House,1,R,Tim Huelskamp,53
-Marion,Florence Ward 1,U.S. House,1,R,Tim Huelskamp,38
-Marion,Florence Ward 2,U.S. House,1,R,Tim Huelskamp,51
-Marion,Gale Township,U.S. House,1,R,Tim Huelskamp,70
-Marion,Grant Township,U.S. House,1,R,Tim Huelskamp,47
-Marion,Hillsboro Ward 1,U.S. House,1,R,Tim Huelskamp,297
-Marion,Hillsboro Ward 2,U.S. House,1,R,Tim Huelskamp,376
-Marion,Lehigh Township,U.S. House,1,R,Tim Huelskamp,64
-Marion,Liberty Township,U.S. House,1,R,Tim Huelskamp,102
-Marion,Logan Township,U.S. House,1,R,Tim Huelskamp,19
-Marion,Lost Springs Township,U.S. House,1,R,Tim Huelskamp,64
-Marion,Marion North Ward,U.S. House,1,R,Tim Huelskamp,229
-Marion,Marion South Ward,U.S. House,1,R,Tim Huelskamp,212
-Marion,Menno Township,U.S. House,1,R,Tim Huelskamp,109
-Marion,Milton Township,U.S. House,1,R,Tim Huelskamp,59
-Marion,Moore Township,U.S. House,1,R,Tim Huelskamp,21
-Marion,Peabody East,U.S. House,1,R,Tim Huelskamp,107
-Marion,Peabody West,U.S. House,1,R,Tim Huelskamp,160
-Marion,Risley Township,U.S. House,1,R,Tim Huelskamp,86
-Marion,Summit Township,U.S. House,1,R,Tim Huelskamp,24
-Marion,West Branch Township,U.S. House,1,R,Tim Huelskamp,232
-Marion,Wilson Township,U.S. House,1,R,Tim Huelskamp,72
-Marion,Blaine Township,U.S. House,1,D,James Sherow,16
-Marion,Catlin Township,U.S. House,1,D,James Sherow,26
-Marion,Centre Township,U.S. House,1,D,James Sherow,65
-Marion,Clark Township,U.S. House,1,D,James Sherow,10
-Marion,Clear Creek Township,U.S. House,1,D,James Sherow,42
-Marion,Colfax Township,U.S. House,1,D,James Sherow,18
-Marion,Doyle Township,U.S. House,1,D,James Sherow,4
-Marion,Durham Park Township,U.S. House,1,D,James Sherow,28
-Marion,East Branch Township,U.S. House,1,D,James Sherow,37
-Marion,Fairplay Township,U.S. House,1,D,James Sherow,7
-Marion,Florence Ward 1,U.S. House,1,D,James Sherow,24
-Marion,Florence Ward 2,U.S. House,1,D,James Sherow,27
-Marion,Gale Township,U.S. House,1,D,James Sherow,28
-Marion,Grant Township,U.S. House,1,D,James Sherow,24
-Marion,Hillsboro Ward 1,U.S. House,1,D,James Sherow,100
-Marion,Hillsboro Ward 2,U.S. House,1,D,James Sherow,103
-Marion,Lehigh Township,U.S. House,1,D,James Sherow,12
-Marion,Liberty Township,U.S. House,1,D,James Sherow,39
-Marion,Logan Township,U.S. House,1,D,James Sherow,6
-Marion,Lost Springs Township,U.S. House,1,D,James Sherow,12
-Marion,Marion North Ward,U.S. House,1,D,James Sherow,110
-Marion,Marion South Ward,U.S. House,1,D,James Sherow,94
-Marion,Menno Township,U.S. House,1,D,James Sherow,46
-Marion,Milton Township,U.S. House,1,D,James Sherow,25
-Marion,Moore Township,U.S. House,1,D,James Sherow,6
-Marion,Peabody East,U.S. House,1,D,James Sherow,57
-Marion,Peabody West,U.S. House,1,D,James Sherow,75
-Marion,Risley Township,U.S. House,1,D,James Sherow,25
-Marion,Summit Township,U.S. House,1,D,James Sherow,9
-Marion,West Branch Township,U.S. House,1,D,James Sherow,145
-Marion,Wilson Township,U.S. House,1,D,James Sherow,8
-Marion,Blaine Township,Governor,,R,Sam Brownback,39
-Marion,Catlin Township,Governor,,R,Sam Brownback,52
-Marion,Centre Township,Governor,,R,Sam Brownback,139
-Marion,Clark Township,Governor,,R,Sam Brownback,42
-Marion,Clear Creek Township,Governor,,R,Sam Brownback,115
-Marion,Colfax Township,Governor,,R,Sam Brownback,51
-Marion,Doyle Township,Governor,,R,Sam Brownback,15
-Marion,Durham Park Township,Governor,,R,Sam Brownback,54
-Marion,East Branch Township,Governor,,R,Sam Brownback,49
-Marion,Fairplay Township,Governor,,R,Sam Brownback,37
-Marion,Florence Ward 1,Governor,,R,Sam Brownback,26
-Marion,Florence Ward 2,Governor,,R,Sam Brownback,33
-Marion,Gale Township,Governor,,R,Sam Brownback,57
-Marion,Grant Township,Governor,,R,Sam Brownback,43
-Marion,Hillsboro Ward 1,Governor,,R,Sam Brownback,252
-Marion,Hillsboro Ward 2,Governor,,R,Sam Brownback,304
-Marion,Lehigh Township,Governor,,R,Sam Brownback,58
-Marion,Liberty Township,Governor,,R,Sam Brownback,89
-Marion,Logan Township,Governor,,R,Sam Brownback,19
-Marion,Lost Springs Township,Governor,,R,Sam Brownback,54
-Marion,Marion North Ward,Governor,,R,Sam Brownback,170
-Marion,Marion South Ward,Governor,,R,Sam Brownback,152
-Marion,Menno Township,Governor,,R,Sam Brownback,91
-Marion,Milton Township,Governor,,R,Sam Brownback,52
-Marion,Moore Township,Governor,,R,Sam Brownback,19
-Marion,Peabody East,Governor,,R,Sam Brownback,78
-Marion,Peabody West,Governor,,R,Sam Brownback,128
-Marion,Risley Township,Governor,,R,Sam Brownback,79
-Marion,Summit Township,Governor,,R,Sam Brownback,15
-Marion,West Branch Township,Governor,,R,Sam Brownback,177
-Marion,Wilson Township,Governor,,R,Sam Brownback,64
-Marion,Blaine Township,Governor,,D,Paul Davis,26
-Marion,Catlin Township,Governor,,D,Paul Davis,30
-Marion,Centre Township,Governor,,D,Paul Davis,95
-Marion,Clark Township,Governor,,D,Paul Davis,16
-Marion,Clear Creek Township,Governor,,D,Paul Davis,53
-Marion,Colfax Township,Governor,,D,Paul Davis,21
-Marion,Doyle Township,Governor,,D,Paul Davis,4
-Marion,Durham Park Township,Governor,,D,Paul Davis,32
-Marion,East Branch Township,Governor,,D,Paul Davis,46
-Marion,Fairplay Township,Governor,,D,Paul Davis,15
-Marion,Florence Ward 1,Governor,,D,Paul Davis,26
-Marion,Florence Ward 2,Governor,,D,Paul Davis,35
-Marion,Gale Township,Governor,,D,Paul Davis,40
-Marion,Grant Township,Governor,,D,Paul Davis,27
-Marion,Hillsboro Ward 1,Governor,,D,Paul Davis,135
-Marion,Hillsboro Ward 2,Governor,,D,Paul Davis,151
-Marion,Lehigh Township,Governor,,D,Paul Davis,17
-Marion,Liberty Township,Governor,,D,Paul Davis,46
-Marion,Logan Township,Governor,,D,Paul Davis,6
-Marion,Lost Springs Township,Governor,,D,Paul Davis,18
-Marion,Marion North Ward,Governor,,D,Paul Davis,148
-Marion,Marion South Ward,Governor,,D,Paul Davis,138
-Marion,Menno Township,Governor,,D,Paul Davis,62
-Marion,Milton Township,Governor,,D,Paul Davis,27
-Marion,Moore Township,Governor,,D,Paul Davis,8
-Marion,Peabody East,Governor,,D,Paul Davis,79
-Marion,Peabody West,Governor,,D,Paul Davis,87
-Marion,Risley Township,Governor,,D,Paul Davis,30
-Marion,Summit Township,Governor,,D,Paul Davis,15
-Marion,West Branch Township,Governor,,D,Paul Davis,187
-Marion,Wilson Township,Governor,,D,Paul Davis,14
-Marion,Blaine Township,Governor,,L,Keen Umbehr,1
-Marion,Catlin Township,Governor,,L,Keen Umbehr,1
-Marion,Centre Township,Governor,,L,Keen Umbehr,12
-Marion,Clark Township,Governor,,L,Keen Umbehr,2
-Marion,Clear Creek Township,Governor,,L,Keen Umbehr,10
-Marion,Colfax Township,Governor,,L,Keen Umbehr,4
-Marion,Doyle Township,Governor,,L,Keen Umbehr,0
-Marion,Durham Park Township,Governor,,L,Keen Umbehr,3
-Marion,East Branch Township,Governor,,L,Keen Umbehr,4
-Marion,Fairplay Township,Governor,,L,Keen Umbehr,8
-Marion,Florence Ward 1,Governor,,L,Keen Umbehr,11
-Marion,Florence Ward 2,Governor,,L,Keen Umbehr,10
-Marion,Gale Township,Governor,,L,Keen Umbehr,4
-Marion,Grant Township,Governor,,L,Keen Umbehr,0
-Marion,Hillsboro Ward 1,Governor,,L,Keen Umbehr,17
-Marion,Hillsboro Ward 2,Governor,,L,Keen Umbehr,18
-Marion,Lehigh Township,Governor,,L,Keen Umbehr,1
-Marion,Liberty Township,Governor,,L,Keen Umbehr,5
-Marion,Logan Township,Governor,,L,Keen Umbehr,0
-Marion,Lost Springs Township,Governor,,L,Keen Umbehr,4
-Marion,Marion North Ward,Governor,,L,Keen Umbehr,22
-Marion,Marion South Ward,Governor,,L,Keen Umbehr,22
-Marion,Menno Township,Governor,,L,Keen Umbehr,3
-Marion,Milton Township,Governor,,L,Keen Umbehr,5
-Marion,Moore Township,Governor,,L,Keen Umbehr,0
-Marion,Peabody East,Governor,,L,Keen Umbehr,12
-Marion,Peabody West,Governor,,L,Keen Umbehr,20
-Marion,Risley Township,Governor,,L,Keen Umbehr,2
-Marion,Summit Township,Governor,,L,Keen Umbehr,3
-Marion,West Branch Township,Governor,,L,Keen Umbehr,23
-Marion,Wilson Township,Governor,,L,Keen Umbehr,4
-Marion,Blaine Township,Secretary of State,,R,Kris Kobach,45
-Marion,Catlin Township,Secretary of State,,R,Kris Kobach,54
-Marion,Centre Township,Secretary of State,,R,Kris Kobach,171
-Marion,Clark Township,Secretary of State,,R,Kris Kobach,41
-Marion,Clear Creek Township,Secretary of State,,R,Kris Kobach,130
-Marion,Colfax Township,Secretary of State,,R,Kris Kobach,55
-Marion,Doyle Township,Secretary of State,,R,Kris Kobach,15
-Marion,Durham Park Township,Secretary of State,,R,Kris Kobach,61
-Marion,East Branch Township,Secretary of State,,R,Kris Kobach,59
-Marion,Fairplay Township,Secretary of State,,R,Kris Kobach,46
-Marion,Florence Ward 1,Secretary of State,,R,Kris Kobach,35
-Marion,Florence Ward 2,Secretary of State,,R,Kris Kobach,47
-Marion,Gale Township,Secretary of State,,R,Kris Kobach,74
-Marion,Grant Township,Secretary of State,,R,Kris Kobach,49
-Marion,Hillsboro Ward 1,Secretary of State,,R,Kris Kobach,297
-Marion,Hillsboro Ward 2,Secretary of State,,R,Kris Kobach,356
-Marion,Lehigh Township,Secretary of State,,R,Kris Kobach,64
-Marion,Liberty Township,Secretary of State,,R,Kris Kobach,101
-Marion,Logan Township,Secretary of State,,R,Kris Kobach,18
-Marion,Lost Springs Township,Secretary of State,,R,Kris Kobach,63
-Marion,Marion North Ward,Secretary of State,,R,Kris Kobach,219
-Marion,Marion South Ward,Secretary of State,,R,Kris Kobach,202
-Marion,Menno Township,Secretary of State,,R,Kris Kobach,106
-Marion,Milton Township,Secretary of State,,R,Kris Kobach,59
-Marion,Moore Township,Secretary of State,,R,Kris Kobach,20
-Marion,Peabody East,Secretary of State,,R,Kris Kobach,92
-Marion,Peabody West,Secretary of State,,R,Kris Kobach,148
-Marion,Risley Township,Secretary of State,,R,Kris Kobach,88
-Marion,Summit Township,Secretary of State,,R,Kris Kobach,17
-Marion,West Branch Township,Secretary of State,,R,Kris Kobach,211
-Marion,Wilson Township,Secretary of State,,R,Kris Kobach,67
-Marion,Blaine Township,Secretary of State,,D,Jean Schodorf,22
-Marion,Catlin Township,Secretary of State,,D,Jean Schodorf,29
-Marion,Centre Township,Secretary of State,,D,Jean Schodorf,74
-Marion,Clark Township,Secretary of State,,D,Jean Schodorf,17
-Marion,Clear Creek Township,Secretary of State,,D,Jean Schodorf,45
-Marion,Colfax Township,Secretary of State,,D,Jean Schodorf,20
-Marion,Doyle Township,Secretary of State,,D,Jean Schodorf,4
-Marion,Durham Park Township,Secretary of State,,D,Jean Schodorf,28
-Marion,East Branch Township,Secretary of State,,D,Jean Schodorf,40
-Marion,Fairplay Township,Secretary of State,,D,Jean Schodorf,12
-Marion,Florence Ward 1,Secretary of State,,D,Jean Schodorf,28
-Marion,Florence Ward 2,Secretary of State,,D,Jean Schodorf,30
-Marion,Gale Township,Secretary of State,,D,Jean Schodorf,29
-Marion,Grant Township,Secretary of State,,D,Jean Schodorf,20
-Marion,Hillsboro Ward 1,Secretary of State,,D,Jean Schodorf,105
-Marion,Hillsboro Ward 2,Secretary of State,,D,Jean Schodorf,113
-Marion,Lehigh Township,Secretary of State,,D,Jean Schodorf,13
-Marion,Liberty Township,Secretary of State,,D,Jean Schodorf,37
-Marion,Logan Township,Secretary of State,,D,Jean Schodorf,6
-Marion,Lost Springs Township,Secretary of State,,D,Jean Schodorf,13
-Marion,Marion North Ward,Secretary of State,,D,Jean Schodorf,122
-Marion,Marion South Ward,Secretary of State,,D,Jean Schodorf,103
-Marion,Menno Township,Secretary of State,,D,Jean Schodorf,48
-Marion,Milton Township,Secretary of State,,D,Jean Schodorf,23
-Marion,Moore Township,Secretary of State,,D,Jean Schodorf,7
-Marion,Peabody East,Secretary of State,,D,Jean Schodorf,74
-Marion,Peabody West,Secretary of State,,D,Jean Schodorf,86
-Marion,Risley Township,Secretary of State,,D,Jean Schodorf,21
-Marion,Summit Township,Secretary of State,,D,Jean Schodorf,16
-Marion,West Branch Township,Secretary of State,,D,Jean Schodorf,167
-Marion,Wilson Township,Secretary of State,,D,Jean Schodorf,14
-Marion,Blaine Township,Attorney General,,R,Derek Schmidt,51
-Marion,Catlin Township,Attorney General,,R,Derek Schmidt,60
-Marion,Centre Township,Attorney General,,R,Derek Schmidt,192
-Marion,Clark Township,Attorney General,,R,Derek Schmidt,52
-Marion,Clear Creek Township,Attorney General,,R,Derek Schmidt,150
-Marion,Colfax Township,Attorney General,,R,Derek Schmidt,57
-Marion,Doyle Township,Attorney General,,R,Derek Schmidt,16
-Marion,Durham Park Township,Attorney General,,R,Derek Schmidt,68
-Marion,East Branch Township,Attorney General,,R,Derek Schmidt,69
-Marion,Fairplay Township,Attorney General,,R,Derek Schmidt,52
-Marion,Florence Ward 1,Attorney General,,R,Derek Schmidt,40
-Marion,Florence Ward 2,Attorney General,,R,Derek Schmidt,53
-Marion,Gale Township,Attorney General,,R,Derek Schmidt,80
-Marion,Grant Township,Attorney General,,R,Derek Schmidt,53
-Marion,Hillsboro Ward 1,Attorney General,,R,Derek Schmidt,336
-Marion,Hillsboro Ward 2,Attorney General,,R,Derek Schmidt,409
-Marion,Lehigh Township,Attorney General,,R,Derek Schmidt,66
-Marion,Liberty Township,Attorney General,,R,Derek Schmidt,112
-Marion,Logan Township,Attorney General,,R,Derek Schmidt,21
-Marion,Lost Springs Township,Attorney General,,R,Derek Schmidt,67
-Marion,Marion North Ward,Attorney General,,R,Derek Schmidt,255
-Marion,Marion South Ward,Attorney General,,R,Derek Schmidt,245
-Marion,Menno Township,Attorney General,,R,Derek Schmidt,128
-Marion,Milton Township,Attorney General,,R,Derek Schmidt,68
-Marion,Moore Township,Attorney General,,R,Derek Schmidt,19
-Marion,Peabody East,Attorney General,,R,Derek Schmidt,129
-Marion,Peabody West,Attorney General,,R,Derek Schmidt,173
-Marion,Risley Township,Attorney General,,R,Derek Schmidt,99
-Marion,Summit Township,Attorney General,,R,Derek Schmidt,25
-Marion,West Branch Township,Attorney General,,R,Derek Schmidt,273
-Marion,Wilson Township,Attorney General,,R,Derek Schmidt,72
-Marion,Blaine Township,Attorney General,,D,A J Kotich,15
-Marion,Catlin Township,Attorney General,,D,A J Kotich,22
-Marion,Centre Township,Attorney General,,D,A J Kotich,48
-Marion,Clark Township,Attorney General,,D,A J Kotich,5
-Marion,Clear Creek Township,Attorney General,,D,A J Kotich,24
-Marion,Colfax Township,Attorney General,,D,A J Kotich,17
-Marion,Doyle Township,Attorney General,,D,A J Kotich,3
-Marion,Durham Park Township,Attorney General,,D,A J Kotich,18
-Marion,East Branch Township,Attorney General,,D,A J Kotich,29
-Marion,Fairplay Township,Attorney General,,D,A J Kotich,5
-Marion,Florence Ward 1,Attorney General,,D,A J Kotich,22
-Marion,Florence Ward 2,Attorney General,,D,A J Kotich,24
-Marion,Gale Township,Attorney General,,D,A J Kotich,19
-Marion,Grant Township,Attorney General,,D,A J Kotich,15
-Marion,Hillsboro Ward 1,Attorney General,,D,A J Kotich,62
-Marion,Hillsboro Ward 2,Attorney General,,D,A J Kotich,59
-Marion,Lehigh Township,Attorney General,,D,A J Kotich,11
-Marion,Liberty Township,Attorney General,,D,A J Kotich,22
-Marion,Logan Township,Attorney General,,D,A J Kotich,3
-Marion,Lost Springs Township,Attorney General,,D,A J Kotich,7
-Marion,Marion North Ward,Attorney General,,D,A J Kotich,81
-Marion,Marion South Ward,Attorney General,,D,A J Kotich,60
-Marion,Menno Township,Attorney General,,D,A J Kotich,23
-Marion,Milton Township,Attorney General,,D,A J Kotich,14
-Marion,Moore Township,Attorney General,,D,A J Kotich,7
-Marion,Peabody East,Attorney General,,D,A J Kotich,39
-Marion,Peabody West,Attorney General,,D,A J Kotich,59
-Marion,Risley Township,Attorney General,,D,A J Kotich,10
-Marion,Summit Township,Attorney General,,D,A J Kotich,8
-Marion,West Branch Township,Attorney General,,D,A J Kotich,103
-Marion,Wilson Township,Attorney General,,D,A J Kotich,8
-Marion,Blaine Township,State Treasurer,,R,Ron Estes,50
-Marion,Catlin Township,State Treasurer,,R,Ron Estes,62
-Marion,Centre Township,State Treasurer,,R,Ron Estes,203
-Marion,Clark Township,State Treasurer,,R,Ron Estes,49
-Marion,Clear Creek Township,State Treasurer,,R,Ron Estes,145
-Marion,Colfax Township,State Treasurer,,R,Ron Estes,55
-Marion,Doyle Township,State Treasurer,,R,Ron Estes,14
-Marion,Durham Park Township,State Treasurer,,R,Ron Estes,68
-Marion,East Branch Township,State Treasurer,,R,Ron Estes,75
-Marion,Fairplay Township,State Treasurer,,R,Ron Estes,51
-Marion,Florence Ward 1,State Treasurer,,R,Ron Estes,42
-Marion,Florence Ward 2,State Treasurer,,R,Ron Estes,57
-Marion,Gale Township,State Treasurer,,R,Ron Estes,83
-Marion,Grant Township,State Treasurer,,R,Ron Estes,54
-Marion,Hillsboro Ward 1,State Treasurer,,R,Ron Estes,336
-Marion,Hillsboro Ward 2,State Treasurer,,R,Ron Estes,403
-Marion,Lehigh Township,State Treasurer,,R,Ron Estes,65
-Marion,Liberty Township,State Treasurer,,R,Ron Estes,112
-Marion,Logan Township,State Treasurer,,R,Ron Estes,21
-Marion,Lost Springs Township,State Treasurer,,R,Ron Estes,69
-Marion,Marion North Ward,State Treasurer,,R,Ron Estes,251
-Marion,Marion South Ward,State Treasurer,,R,Ron Estes,236
-Marion,Menno Township,State Treasurer,,R,Ron Estes,120
-Marion,Milton Township,State Treasurer,,R,Ron Estes,66
-Marion,Moore Township,State Treasurer,,R,Ron Estes,23
-Marion,Peabody East,State Treasurer,,R,Ron Estes,122
-Marion,Peabody West,State Treasurer,,R,Ron Estes,175
-Marion,Risley Township,State Treasurer,,R,Ron Estes,97
-Marion,Summit Township,State Treasurer,,R,Ron Estes,27
-Marion,West Branch Township,State Treasurer,,R,Ron Estes,271
-Marion,Wilson Township,State Treasurer,,R,Ron Estes,72
-Marion,Blaine Township,State Treasurer,,D,Carmen Alldritt,14
-Marion,Catlin Township,State Treasurer,,D,Carmen Alldritt,21
-Marion,Centre Township,State Treasurer,,D,Carmen Alldritt,38
-Marion,Clark Township,State Treasurer,,D,Carmen Alldritt,8
-Marion,Clear Creek Township,State Treasurer,,D,Carmen Alldritt,28
-Marion,Colfax Township,State Treasurer,,D,Carmen Alldritt,19
-Marion,Doyle Township,State Treasurer,,D,Carmen Alldritt,4
-Marion,Durham Park Township,State Treasurer,,D,Carmen Alldritt,18
-Marion,East Branch Township,State Treasurer,,D,Carmen Alldritt,22
-Marion,Fairplay Township,State Treasurer,,D,Carmen Alldritt,5
-Marion,Florence Ward 1,State Treasurer,,D,Carmen Alldritt,20
-Marion,Florence Ward 2,State Treasurer,,D,Carmen Alldritt,19
-Marion,Gale Township,State Treasurer,,D,Carmen Alldritt,17
-Marion,Grant Township,State Treasurer,,D,Carmen Alldritt,13
-Marion,Hillsboro Ward 1,State Treasurer,,D,Carmen Alldritt,59
-Marion,Hillsboro Ward 2,State Treasurer,,D,Carmen Alldritt,60
-Marion,Lehigh Township,State Treasurer,,D,Carmen Alldritt,10
-Marion,Liberty Township,State Treasurer,,D,Carmen Alldritt,22
-Marion,Logan Township,State Treasurer,,D,Carmen Alldritt,3
-Marion,Lost Springs Township,State Treasurer,,D,Carmen Alldritt,6
-Marion,Marion North Ward,State Treasurer,,D,Carmen Alldritt,85
-Marion,Marion South Ward,State Treasurer,,D,Carmen Alldritt,67
-Marion,Menno Township,State Treasurer,,D,Carmen Alldritt,28
-Marion,Milton Township,State Treasurer,,D,Carmen Alldritt,14
-Marion,Moore Township,State Treasurer,,D,Carmen Alldritt,3
-Marion,Peabody East,State Treasurer,,D,Carmen Alldritt,43
-Marion,Peabody West,State Treasurer,,D,Carmen Alldritt,56
-Marion,Risley Township,State Treasurer,,D,Carmen Alldritt,11
-Marion,Summit Township,State Treasurer,,D,Carmen Alldritt,6
-Marion,West Branch Township,State Treasurer,,D,Carmen Alldritt,98
-Marion,Wilson Township,State Treasurer,,D,Carmen Alldritt,6
-Marion,Blaine Township,Insurance Commissioner,,R,Ken Selzer,47
-Marion,Catlin Township,Insurance Commissioner,,R,Ken Selzer,59
-Marion,Centre Township,Insurance Commissioner,,R,Ken Selzer,188
-Marion,Clark Township,Insurance Commissioner,,R,Ken Selzer,51
-Marion,Clear Creek Township,Insurance Commissioner,,R,Ken Selzer,140
-Marion,Colfax Township,Insurance Commissioner,,R,Ken Selzer,54
-Marion,Doyle Township,Insurance Commissioner,,R,Ken Selzer,15
-Marion,Durham Park Township,Insurance Commissioner,,R,Ken Selzer,62
-Marion,East Branch Township,Insurance Commissioner,,R,Ken Selzer,73
-Marion,Fairplay Township,Insurance Commissioner,,R,Ken Selzer,47
-Marion,Florence Ward 1,Insurance Commissioner,,R,Ken Selzer,42
-Marion,Florence Ward 2,Insurance Commissioner,,R,Ken Selzer,51
-Marion,Gale Township,Insurance Commissioner,,R,Ken Selzer,75
-Marion,Grant Township,Insurance Commissioner,,R,Ken Selzer,51
-Marion,Hillsboro Ward 1,Insurance Commissioner,,R,Ken Selzer,315
-Marion,Hillsboro Ward 2,Insurance Commissioner,,R,Ken Selzer,369
-Marion,Lehigh Township,Insurance Commissioner,,R,Ken Selzer,68
-Marion,Liberty Township,Insurance Commissioner,,R,Ken Selzer,108
-Marion,Logan Township,Insurance Commissioner,,R,Ken Selzer,20
-Marion,Lost Springs Township,Insurance Commissioner,,R,Ken Selzer,59
-Marion,Marion North Ward,Insurance Commissioner,,R,Ken Selzer,233
-Marion,Marion South Ward,Insurance Commissioner,,R,Ken Selzer,216
-Marion,Menno Township,Insurance Commissioner,,R,Ken Selzer,129
-Marion,Milton Township,Insurance Commissioner,,R,Ken Selzer,57
-Marion,Moore Township,Insurance Commissioner,,R,Ken Selzer,22
-Marion,Peabody East,Insurance Commissioner,,R,Ken Selzer,110
-Marion,Peabody West,Insurance Commissioner,,R,Ken Selzer,159
-Marion,Risley Township,Insurance Commissioner,,R,Ken Selzer,97
-Marion,Summit Township,Insurance Commissioner,,R,Ken Selzer,26
-Marion,West Branch Township,Insurance Commissioner,,R,Ken Selzer,281
-Marion,Wilson Township,Insurance Commissioner,,R,Ken Selzer,69
-Marion,Blaine Township,Insurance Commissioner,,D,Dennis Anderson,16
-Marion,Catlin Township,Insurance Commissioner,,D,Dennis Anderson,22
-Marion,Centre Township,Insurance Commissioner,,D,Dennis Anderson,50
-Marion,Clark Township,Insurance Commissioner,,D,Dennis Anderson,6
-Marion,Clear Creek Township,Insurance Commissioner,,D,Dennis Anderson,32
-Marion,Colfax Township,Insurance Commissioner,,D,Dennis Anderson,20
-Marion,Doyle Township,Insurance Commissioner,,D,Dennis Anderson,3
-Marion,Durham Park Township,Insurance Commissioner,,D,Dennis Anderson,23
-Marion,East Branch Township,Insurance Commissioner,,D,Dennis Anderson,23
-Marion,Fairplay Township,Insurance Commissioner,,D,Dennis Anderson,7
-Marion,Florence Ward 1,Insurance Commissioner,,D,Dennis Anderson,21
-Marion,Florence Ward 2,Insurance Commissioner,,D,Dennis Anderson,26
-Marion,Gale Township,Insurance Commissioner,,D,Dennis Anderson,21
-Marion,Grant Township,Insurance Commissioner,,D,Dennis Anderson,15
-Marion,Hillsboro Ward 1,Insurance Commissioner,,D,Dennis Anderson,72
-Marion,Hillsboro Ward 2,Insurance Commissioner,,D,Dennis Anderson,86
-Marion,Lehigh Township,Insurance Commissioner,,D,Dennis Anderson,9
-Marion,Liberty Township,Insurance Commissioner,,D,Dennis Anderson,26
-Marion,Logan Township,Insurance Commissioner,,D,Dennis Anderson,4
-Marion,Lost Springs Township,Insurance Commissioner,,D,Dennis Anderson,14
-Marion,Marion North Ward,Insurance Commissioner,,D,Dennis Anderson,93
-Marion,Marion South Ward,Insurance Commissioner,,D,Dennis Anderson,79
-Marion,Menno Township,Insurance Commissioner,,D,Dennis Anderson,22
-Marion,Milton Township,Insurance Commissioner,,D,Dennis Anderson,25
-Marion,Moore Township,Insurance Commissioner,,D,Dennis Anderson,5
-Marion,Peabody East,Insurance Commissioner,,D,Dennis Anderson,50
-Marion,Peabody West,Insurance Commissioner,,D,Dennis Anderson,70
-Marion,Risley Township,Insurance Commissioner,,D,Dennis Anderson,13
-Marion,Summit Township,Insurance Commissioner,,D,Dennis Anderson,6
-Marion,West Branch Township,Insurance Commissioner,,D,Dennis Anderson,98
-Marion,Wilson Township,Insurance Commissioner,,D,Dennis Anderson,9
-Marion,Blaine Township,State Senate,35,R,Rick Wilborn,59
-Marion,Catlin Township,State Senate,35,R,Rick Wilborn,63
-Marion,Centre Township,State Senate,35,R,Rick Wilborn,206
-Marion,Clark Township,State Senate,35,R,Rick Wilborn,52
-Marion,Clear Creek Township,State Senate,35,R,Rick Wilborn,137
-Marion,Colfax Township,State Senate,35,R,Rick Wilborn,64
-Marion,Doyle Township,State Senate,35,R,Rick Wilborn,12
-Marion,Durham Park Township,State Senate,35,R,Rick Wilborn,77
-Marion,East Branch Township,State Senate,35,R,Rick Wilborn,76
-Marion,Fairplay Township,State Senate,35,R,Rick Wilborn,48
-Marion,Florence Ward 1,State Senate,35,R,Rick Wilborn,49
-Marion,Florence Ward 2,State Senate,35,R,Rick Wilborn,60
-Marion,Gale Township,State Senate,35,R,Rick Wilborn,80
-Marion,Grant Township,State Senate,35,R,Rick Wilborn,52
-Marion,Hillsboro Ward 1,State Senate,35,R,Rick Wilborn,359
-Marion,Hillsboro Ward 2,State Senate,35,R,Rick Wilborn,425
-Marion,Lehigh Township,State Senate,35,R,Rick Wilborn,70
-Marion,Liberty Township,State Senate,35,R,Rick Wilborn,123
-Marion,Logan Township,State Senate,35,R,Rick Wilborn,23
-Marion,Lost Springs Township,State Senate,35,R,Rick Wilborn,68
-Marion,Marion North Ward,State Senate,35,R,Rick Wilborn,262
-Marion,Marion South Ward,State Senate,35,R,Rick Wilborn,245
-Marion,Menno Township,State Senate,35,R,Rick Wilborn,134
-Marion,Milton Township,State Senate,35,R,Rick Wilborn,66
-Marion,Moore Township,State Senate,35,R,Rick Wilborn,24
-Marion,Peabody East,State Senate,35,R,Rick Wilborn,120
-Marion,Peabody West,State Senate,35,R,Rick Wilborn,199
-Marion,Risley Township,State Senate,35,R,Rick Wilborn,99
-Marion,Summit Township,State Senate,35,R,Rick Wilborn,29
-Marion,West Branch Township,State Senate,35,R,Rick Wilborn,305
-Marion,Wilson Township,State Senate,35,R,Rick Wilborn,69
-Marion,Blaine Township,State House,70,R,John Barker,57
-Marion,Catlin Township,State House,74,R,Don Schroeder,68
-Marion,Centre Township,State House,70,R,John Barker,211
-Marion,Clark Township,State House,70,R,John Barker,54
-Marion,Clear Creek Township,State House,70,R,John Barker,154
-Marion,Colfax Township,State House,70,R,John Barker,64
-Marion,Doyle Township,State House,74,R,Don Schroeder,14
-Marion,Durham Park Township,State House,70,R,John Barker,75
-Marion,East Branch Township,State House,74,R,Don Schroeder,80
-Marion,Fairplay Township,State House,74,R,Don Schroeder,51
-Marion,Florence Ward 1,State House,74,R,Don Schroeder,50
-Marion,Florence Ward 2,State House,74,R,Don Schroeder,64
-Marion,Gale Township,State House,70,R,John Barker,74
-Marion,Grant Township,State House,70,R,John Barker,51
-Marion,Hillsboro Ward 1,State House,74,R,Don Schroeder,370
-Marion,Hillsboro Ward 2,State House,74,R,Don Schroeder,433
-Marion,Lehigh Township,State House,70,R,John Barker,70
-Marion,Liberty Township,State House,74,R,Don Schroeder,127
-Marion,Logan Township,State House,70,R,John Barker,24
-Marion,Lost Springs Township,State House,70,R,John Barker,70
-Marion,Marion North Ward,State House,70,R,John Barker,272
-Marion,Marion South Ward,State House,70,R,John Barker,251
-Marion,Menno Township,State House,74,R,Don Schroeder,139
-Marion,Milton Township,State House,74,R,Don Schroeder,68
-Marion,Moore Township,State House,70,R,John Barker,23
-Marion,Peabody East,State House,74,R,Don Schroeder,138
-Marion,Peabody West,State House,74,R,Don Schroeder,206
-Marion,Risley Township,State House,74,R,Don Schroeder,103
-Marion,Summit Township,State House,74,R,Don Schroeder,29
-Marion,West Branch Township,State House,74,R,Don Schroeder,329
-Marion,Wilson Township,State House,74,R,Don Schroeder,72
+county,precinct,office,district,party,candidate,votes,vtd
+MARION,Blaine Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000010
+MARION,Blaine Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+MARION,Blaine Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000010
+MARION,Catlin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000020
+MARION,Catlin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+MARION,Catlin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000020
+MARION,Centre Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",95,000030
+MARION,Centre Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000030
+MARION,Centre Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",139,000030
+MARION,Clark Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000040
+MARION,Clark Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+MARION,Clark Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000040
+MARION,Clear Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000050
+MARION,Clear Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000050
+MARION,Clear Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000050
+MARION,Colfax Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000060
+MARION,Colfax Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000060
+MARION,Colfax Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,000060
+MARION,Doyle Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000070
+MARION,Doyle Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+MARION,Doyle Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000070
+MARION,Durham Park Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000080
+MARION,Durham Park Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000080
+MARION,Durham Park Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000080
+MARION,East Branch Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000090
+MARION,East Branch Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000090
+MARION,East Branch Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000090
+MARION,Fairplay Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000100
+MARION,Fairplay Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000100
+MARION,Fairplay Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000100
+MARION,Florence Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,00011A
+MARION,Florence Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,00011A
+MARION,Florence Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,00011A
+MARION,Florence Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00011B
+MARION,Florence Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00011B
+MARION,Florence Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00011B
+MARION,Florence Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,000120
+MARION,Florence Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000120
+MARION,Florence Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000120
+MARION,Gale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000130
+MARION,Gale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000130
+MARION,Gale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000130
+MARION,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000140
+MARION,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000140
+MARION,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000140
+MARION,Hillsboro Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",135,000150
+MARION,Hillsboro Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000150
+MARION,Hillsboro Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",252,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00016C
+MARION,Lehigh Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000170
+MARION,Lehigh Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000170
+MARION,Lehigh Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000170
+MARION,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000180
+MARION,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000180
+MARION,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000180
+MARION,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000190
+MARION,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000190
+MARION,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000190
+MARION,Lost Springs Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000200
+MARION,Lost Springs Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000200
+MARION,Lost Springs Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000200
+MARION,Marion North Ward,Governor / Lt. Governor,,Democratic,"Davis, Paul",148,000210
+MARION,Marion North Ward,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000210
+MARION,Marion North Ward,Governor / Lt. Governor,,Republican,"Brownback, Sam",170,000210
+MARION,Marion South Ward,Governor / Lt. Governor,,Democratic,"Davis, Paul",138,00022A
+MARION,Marion South Ward,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,00022A
+MARION,Marion South Ward,Governor / Lt. Governor,,Republican,"Brownback, Sam",152,00022A
+MARION,Marion South Ward Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022B
+MARION,Marion South Ward Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022B
+MARION,Marion South Ward Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022B
+MARION,Menno Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,000230
+MARION,Menno Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000230
+MARION,Menno Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000230
+MARION,Milton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000240
+MARION,Milton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000240
+MARION,Milton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000240
+MARION,Moore Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000250
+MARION,Moore Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000250
+MARION,Moore Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000250
+MARION,Peabody East,Governor / Lt. Governor,,Democratic,"Davis, Paul",79,000260
+MARION,Peabody East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000260
+MARION,Peabody East,Governor / Lt. Governor,,Republican,"Brownback, Sam",78,000260
+MARION,Peabody West,Governor / Lt. Governor,,Democratic,"Davis, Paul",87,000270
+MARION,Peabody West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000270
+MARION,Peabody West,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000270
+MARION,Risley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000280
+MARION,Risley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000280
+MARION,Risley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000280
+MARION,Summit Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000290
+MARION,Summit Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000290
+MARION,Summit Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000290
+MARION,West Branch Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",187,000300
+MARION,West Branch Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000300
+MARION,West Branch Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",177,000300
+MARION,Wilson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000310
+MARION,Wilson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000310
+MARION,Wilson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000310
+MARION,Hillsboro Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",151,900010
+MARION,Hillsboro Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,900010
+MARION,Hillsboro Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",304,900010
+MARION,Hillsboro Ward 2 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+MARION,Hillsboro Ward 2 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+MARION,Blaine Township,Kansas House of Representatives,70,Republican,"Barker, John E",57,000010
+MARION,Catlin Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",68,000020
+MARION,Centre Township,Kansas House of Representatives,70,Republican,"Barker, John E",211,000030
+MARION,Clark Township,Kansas House of Representatives,70,Republican,"Barker, John E",54,000040
+MARION,Clear Creek Township,Kansas House of Representatives,70,Republican,"Barker, John E",154,000050
+MARION,Colfax Township,Kansas House of Representatives,70,Republican,"Barker, John E",64,000060
+MARION,Doyle Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",14,000070
+MARION,Durham Park Township,Kansas House of Representatives,70,Republican,"Barker, John E",75,000080
+MARION,East Branch Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",80,000090
+MARION,Fairplay Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",51,000100
+MARION,Florence Ward 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",50,00011A
+MARION,Florence Ward 1 Exclave,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,00011B
+MARION,Florence Ward 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",64,000120
+MARION,Gale Township,Kansas House of Representatives,70,Republican,"Barker, John E",74,000130
+MARION,Grant Township,Kansas House of Representatives,70,Republican,"Barker, John E",51,000140
+MARION,Hillsboro Ward 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",370,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,00016C
+MARION,Lehigh Township,Kansas House of Representatives,70,Republican,"Barker, John E",70,000170
+MARION,Liberty Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",127,000180
+MARION,Logan Township,Kansas House of Representatives,70,Republican,"Barker, John E",24,000190
+MARION,Lost Springs Township,Kansas House of Representatives,70,Republican,"Barker, John E",70,000200
+MARION,Marion North Ward,Kansas House of Representatives,70,Republican,"Barker, John E",272,000210
+MARION,Marion South Ward,Kansas House of Representatives,70,Republican,"Barker, John E",251,00022A
+MARION,Marion South Ward Exclave,Kansas House of Representatives,70,Republican,"Barker, John E",0,00022B
+MARION,Menno Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",139,000230
+MARION,Milton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",68,000240
+MARION,Moore Township,Kansas House of Representatives,70,Republican,"Barker, John E",23,000250
+MARION,Peabody East,Kansas House of Representatives,74,Republican,"Schroeder, Don",138,000260
+MARION,Peabody West,Kansas House of Representatives,74,Republican,"Schroeder, Don",206,000270
+MARION,Risley Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",103,000280
+MARION,Summit Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",29,000290
+MARION,West Branch Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",329,000300
+MARION,Wilson Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",72,000310
+MARION,Hillsboro Ward 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",433,900010
+MARION,Hillsboro Ward 2 Exclave A,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,900020
+MARION,Blaine Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000010
+MARION,Blaine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000010
+MARION,Catlin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",26,000020
+MARION,Catlin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000020
+MARION,Centre Township,United States House of Representatives,1,Democratic,"Sherow, James E.",65,000030
+MARION,Centre Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",176,000030
+MARION,Clark Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000040
+MARION,Clark Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000040
+MARION,Clear Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",42,000050
+MARION,Clear Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",137,000050
+MARION,Colfax Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000060
+MARION,Colfax Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",57,000060
+MARION,Doyle Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000070
+MARION,Doyle Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000070
+MARION,Durham Park Township,United States House of Representatives,1,Democratic,"Sherow, James E.",28,000080
+MARION,Durham Park Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000080
+MARION,East Branch Township,United States House of Representatives,1,Democratic,"Sherow, James E.",37,000090
+MARION,East Branch Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000090
+MARION,Fairplay Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000100
+MARION,Fairplay Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000100
+MARION,Florence Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",24,00011A
+MARION,Florence Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,00011A
+MARION,Florence Ward 1 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00011B
+MARION,Florence Ward 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00011B
+MARION,Florence Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000120
+MARION,Florence Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000120
+MARION,Gale Township,United States House of Representatives,1,Democratic,"Sherow, James E.",28,000130
+MARION,Gale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000130
+MARION,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000140
+MARION,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000140
+MARION,Hillsboro Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",100,000150
+MARION,Hillsboro Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",297,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00016C
+MARION,Lehigh Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000170
+MARION,Lehigh Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,000170
+MARION,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",39,000180
+MARION,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",102,000180
+MARION,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000190
+MARION,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000190
+MARION,Lost Springs Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000200
+MARION,Lost Springs Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,000200
+MARION,Marion North Ward,United States House of Representatives,1,Democratic,"Sherow, James E.",110,000210
+MARION,Marion North Ward,United States House of Representatives,1,Republican,"Huelskamp, Tim",229,000210
+MARION,Marion South Ward,United States House of Representatives,1,Democratic,"Sherow, James E.",94,00022A
+MARION,Marion South Ward,United States House of Representatives,1,Republican,"Huelskamp, Tim",212,00022A
+MARION,Marion South Ward Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00022B
+MARION,Marion South Ward Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022B
+MARION,Menno Township,United States House of Representatives,1,Democratic,"Sherow, James E.",46,000230
+MARION,Menno Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",109,000230
+MARION,Milton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,000240
+MARION,Milton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000240
+MARION,Moore Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000250
+MARION,Moore Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000250
+MARION,Peabody East,United States House of Representatives,1,Democratic,"Sherow, James E.",57,000260
+MARION,Peabody East,United States House of Representatives,1,Republican,"Huelskamp, Tim",107,000260
+MARION,Peabody West,United States House of Representatives,1,Democratic,"Sherow, James E.",75,000270
+MARION,Peabody West,United States House of Representatives,1,Republican,"Huelskamp, Tim",160,000270
+MARION,Risley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,000280
+MARION,Risley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",86,000280
+MARION,Summit Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000290
+MARION,Summit Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000290
+MARION,West Branch Township,United States House of Representatives,1,Democratic,"Sherow, James E.",145,000300
+MARION,West Branch Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",232,000300
+MARION,Wilson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000310
+MARION,Wilson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000310
+MARION,Hillsboro Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",103,900010
+MARION,Hillsboro Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",376,900010
+MARION,Hillsboro Ward 2 Exclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+MARION,Blaine Township,Attorney General,,Democratic,"Kotich, A.J.",15,000010
+MARION,Blaine Township,Attorney General,,Republican,"Schmidt, Derek",51,000010
+MARION,Catlin Township,Attorney General,,Democratic,"Kotich, A.J.",22,000020
+MARION,Catlin Township,Attorney General,,Republican,"Schmidt, Derek",60,000020
+MARION,Centre Township,Attorney General,,Democratic,"Kotich, A.J.",48,000030
+MARION,Centre Township,Attorney General,,Republican,"Schmidt, Derek",192,000030
+MARION,Clark Township,Attorney General,,Democratic,"Kotich, A.J.",5,000040
+MARION,Clark Township,Attorney General,,Republican,"Schmidt, Derek",52,000040
+MARION,Clear Creek Township,Attorney General,,Democratic,"Kotich, A.J.",24,000050
+MARION,Clear Creek Township,Attorney General,,Republican,"Schmidt, Derek",150,000050
+MARION,Colfax Township,Attorney General,,Democratic,"Kotich, A.J.",17,000060
+MARION,Colfax Township,Attorney General,,Republican,"Schmidt, Derek",57,000060
+MARION,Doyle Township,Attorney General,,Democratic,"Kotich, A.J.",3,000070
+MARION,Doyle Township,Attorney General,,Republican,"Schmidt, Derek",16,000070
+MARION,Durham Park Township,Attorney General,,Democratic,"Kotich, A.J.",18,000080
+MARION,Durham Park Township,Attorney General,,Republican,"Schmidt, Derek",68,000080
+MARION,East Branch Township,Attorney General,,Democratic,"Kotich, A.J.",29,000090
+MARION,East Branch Township,Attorney General,,Republican,"Schmidt, Derek",69,000090
+MARION,Fairplay Township,Attorney General,,Democratic,"Kotich, A.J.",5,000100
+MARION,Fairplay Township,Attorney General,,Republican,"Schmidt, Derek",52,000100
+MARION,Florence Ward 1,Attorney General,,Democratic,"Kotich, A.J.",22,00011A
+MARION,Florence Ward 1,Attorney General,,Republican,"Schmidt, Derek",40,00011A
+MARION,Florence Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00011B
+MARION,Florence Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00011B
+MARION,Florence Ward 2,Attorney General,,Democratic,"Kotich, A.J.",24,000120
+MARION,Florence Ward 2,Attorney General,,Republican,"Schmidt, Derek",53,000120
+MARION,Gale Township,Attorney General,,Democratic,"Kotich, A.J.",19,000130
+MARION,Gale Township,Attorney General,,Republican,"Schmidt, Derek",80,000130
+MARION,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",15,000140
+MARION,Grant Township,Attorney General,,Republican,"Schmidt, Derek",53,000140
+MARION,Hillsboro Ward 1,Attorney General,,Democratic,"Kotich, A.J.",62,000150
+MARION,Hillsboro Ward 1,Attorney General,,Republican,"Schmidt, Derek",336,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Attorney General,,Democratic,"Kotich, A.J.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Attorney General,,Republican,"Schmidt, Derek",0,00016C
+MARION,Lehigh Township,Attorney General,,Democratic,"Kotich, A.J.",11,000170
+MARION,Lehigh Township,Attorney General,,Republican,"Schmidt, Derek",66,000170
+MARION,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",22,000180
+MARION,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",112,000180
+MARION,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",3,000190
+MARION,Logan Township,Attorney General,,Republican,"Schmidt, Derek",21,000190
+MARION,Lost Springs Township,Attorney General,,Democratic,"Kotich, A.J.",7,000200
+MARION,Lost Springs Township,Attorney General,,Republican,"Schmidt, Derek",67,000200
+MARION,Marion North Ward,Attorney General,,Democratic,"Kotich, A.J.",81,000210
+MARION,Marion North Ward,Attorney General,,Republican,"Schmidt, Derek",255,000210
+MARION,Marion South Ward,Attorney General,,Democratic,"Kotich, A.J.",60,00022A
+MARION,Marion South Ward,Attorney General,,Republican,"Schmidt, Derek",245,00022A
+MARION,Marion South Ward Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00022B
+MARION,Marion South Ward Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00022B
+MARION,Menno Township,Attorney General,,Democratic,"Kotich, A.J.",23,000230
+MARION,Menno Township,Attorney General,,Republican,"Schmidt, Derek",128,000230
+MARION,Milton Township,Attorney General,,Democratic,"Kotich, A.J.",14,000240
+MARION,Milton Township,Attorney General,,Republican,"Schmidt, Derek",68,000240
+MARION,Moore Township,Attorney General,,Democratic,"Kotich, A.J.",7,000250
+MARION,Moore Township,Attorney General,,Republican,"Schmidt, Derek",19,000250
+MARION,Peabody East,Attorney General,,Democratic,"Kotich, A.J.",39,000260
+MARION,Peabody East,Attorney General,,Republican,"Schmidt, Derek",129,000260
+MARION,Peabody West,Attorney General,,Democratic,"Kotich, A.J.",59,000270
+MARION,Peabody West,Attorney General,,Republican,"Schmidt, Derek",173,000270
+MARION,Risley Township,Attorney General,,Democratic,"Kotich, A.J.",10,000280
+MARION,Risley Township,Attorney General,,Republican,"Schmidt, Derek",99,000280
+MARION,Summit Township,Attorney General,,Democratic,"Kotich, A.J.",8,000290
+MARION,Summit Township,Attorney General,,Republican,"Schmidt, Derek",25,000290
+MARION,West Branch Township,Attorney General,,Democratic,"Kotich, A.J.",103,000300
+MARION,West Branch Township,Attorney General,,Republican,"Schmidt, Derek",273,000300
+MARION,Wilson Township,Attorney General,,Democratic,"Kotich, A.J.",8,000310
+MARION,Wilson Township,Attorney General,,Republican,"Schmidt, Derek",72,000310
+MARION,Hillsboro Ward 2,Attorney General,,Democratic,"Kotich, A.J.",59,900010
+MARION,Hillsboro Ward 2,Attorney General,,Republican,"Schmidt, Derek",409,900010
+MARION,Hillsboro Ward 2 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,900020
+MARION,Blaine Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000010
+MARION,Blaine Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000010
+MARION,Catlin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000020
+MARION,Catlin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",59,000020
+MARION,Centre Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000030
+MARION,Centre Township,Commissioner of Insurance,,Republican,"Selzer, Ken",188,000030
+MARION,Clark Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000040
+MARION,Clark Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000040
+MARION,Clear Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,000050
+MARION,Clear Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",140,000050
+MARION,Colfax Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000060
+MARION,Colfax Township,Commissioner of Insurance,,Republican,"Selzer, Ken",54,000060
+MARION,Doyle Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000070
+MARION,Doyle Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000070
+MARION,Durham Park Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000080
+MARION,Durham Park Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000080
+MARION,East Branch Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000090
+MARION,East Branch Township,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000090
+MARION,Fairplay Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000100
+MARION,Fairplay Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000100
+MARION,Florence Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,00011A
+MARION,Florence Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",42,00011A
+MARION,Florence Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00011B
+MARION,Florence Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00011B
+MARION,Florence Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000120
+MARION,Florence Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000120
+MARION,Gale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000130
+MARION,Gale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",75,000130
+MARION,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000140
+MARION,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000140
+MARION,Hillsboro Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000150
+MARION,Hillsboro Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",315,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00016C
+MARION,Lehigh Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000170
+MARION,Lehigh Township,Commissioner of Insurance,,Republican,"Selzer, Ken",68,000170
+MARION,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000180
+MARION,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",108,000180
+MARION,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000190
+MARION,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000190
+MARION,Lost Springs Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000200
+MARION,Lost Springs Township,Commissioner of Insurance,,Republican,"Selzer, Ken",59,000200
+MARION,Marion North Ward,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,000210
+MARION,Marion North Ward,Commissioner of Insurance,,Republican,"Selzer, Ken",233,000210
+MARION,Marion South Ward,Commissioner of Insurance,,Democratic,"Anderson, Dennis",79,00022A
+MARION,Marion South Ward,Commissioner of Insurance,,Republican,"Selzer, Ken",216,00022A
+MARION,Marion South Ward Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022B
+MARION,Marion South Ward Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022B
+MARION,Menno Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000230
+MARION,Menno Township,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000230
+MARION,Milton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000240
+MARION,Milton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000240
+MARION,Moore Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000250
+MARION,Moore Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000250
+MARION,Peabody East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000260
+MARION,Peabody East,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000260
+MARION,Peabody West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",70,000270
+MARION,Peabody West,Commissioner of Insurance,,Republican,"Selzer, Ken",159,000270
+MARION,Risley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000280
+MARION,Risley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000280
+MARION,Summit Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000290
+MARION,Summit Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000290
+MARION,West Branch Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",98,000300
+MARION,West Branch Township,Commissioner of Insurance,,Republican,"Selzer, Ken",281,000300
+MARION,Wilson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000310
+MARION,Wilson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",69,000310
+MARION,Hillsboro Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,900010
+MARION,Hillsboro Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",369,900010
+MARION,Hillsboro Ward 2 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+MARION,Hillsboro Ward 2 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+MARION,Blaine Township,Kansas Senate,35,Republican,"Wilborn, Richard",59,000010
+MARION,Catlin Township,Kansas Senate,35,Republican,"Wilborn, Richard",63,000020
+MARION,Centre Township,Kansas Senate,35,Republican,"Wilborn, Richard",206,000030
+MARION,Clark Township,Kansas Senate,35,Republican,"Wilborn, Richard",52,000040
+MARION,Clear Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",137,000050
+MARION,Colfax Township,Kansas Senate,35,Republican,"Wilborn, Richard",64,000060
+MARION,Doyle Township,Kansas Senate,35,Republican,"Wilborn, Richard",12,000070
+MARION,Durham Park Township,Kansas Senate,35,Republican,"Wilborn, Richard",77,000080
+MARION,East Branch Township,Kansas Senate,35,Republican,"Wilborn, Richard",76,000090
+MARION,Fairplay Township,Kansas Senate,35,Republican,"Wilborn, Richard",48,000100
+MARION,Florence Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",49,00011A
+MARION,Florence Ward 1 Exclave,Kansas Senate,35,Republican,"Wilborn, Richard",0,00011B
+MARION,Florence Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",60,000120
+MARION,Gale Township,Kansas Senate,35,Republican,"Wilborn, Richard",80,000130
+MARION,Grant Township,Kansas Senate,35,Republican,"Wilborn, Richard",52,000140
+MARION,Hillsboro Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",359,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Kansas Senate,35,Republican,"Wilborn, Richard",0,00016C
+MARION,Lehigh Township,Kansas Senate,35,Republican,"Wilborn, Richard",70,000170
+MARION,Liberty Township,Kansas Senate,35,Republican,"Wilborn, Richard",123,000180
+MARION,Logan Township,Kansas Senate,35,Republican,"Wilborn, Richard",23,000190
+MARION,Lost Springs Township,Kansas Senate,35,Republican,"Wilborn, Richard",68,000200
+MARION,Marion North Ward,Kansas Senate,35,Republican,"Wilborn, Richard",262,000210
+MARION,Marion South Ward,Kansas Senate,35,Republican,"Wilborn, Richard",245,00022A
+MARION,Marion South Ward Exclave,Kansas Senate,35,Republican,"Wilborn, Richard",0,00022B
+MARION,Menno Township,Kansas Senate,35,Republican,"Wilborn, Richard",134,000230
+MARION,Milton Township,Kansas Senate,35,Republican,"Wilborn, Richard",66,000240
+MARION,Moore Township,Kansas Senate,35,Republican,"Wilborn, Richard",24,000250
+MARION,Peabody East,Kansas Senate,35,Republican,"Wilborn, Richard",120,000260
+MARION,Peabody West,Kansas Senate,35,Republican,"Wilborn, Richard",199,000270
+MARION,Risley Township,Kansas Senate,35,Republican,"Wilborn, Richard",99,000280
+MARION,Summit Township,Kansas Senate,35,Republican,"Wilborn, Richard",29,000290
+MARION,West Branch Township,Kansas Senate,35,Republican,"Wilborn, Richard",305,000300
+MARION,Wilson Township,Kansas Senate,35,Republican,"Wilborn, Richard",69,000310
+MARION,Hillsboro Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",425,900010
+MARION,Hillsboro Ward 2 Exclave A,Kansas Senate,35,Republican,"Wilborn, Richard",0,900020
+MARION,Blaine Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000010
+MARION,Blaine Township,Secretary of State,,Republican,"Kobach, Kris",45,000010
+MARION,Catlin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000020
+MARION,Catlin Township,Secretary of State,,Republican,"Kobach, Kris",54,000020
+MARION,Centre Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000030
+MARION,Centre Township,Secretary of State,,Republican,"Kobach, Kris",171,000030
+MARION,Clark Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000040
+MARION,Clark Township,Secretary of State,,Republican,"Kobach, Kris",41,000040
+MARION,Clear Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000050
+MARION,Clear Creek Township,Secretary of State,,Republican,"Kobach, Kris",130,000050
+MARION,Colfax Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000060
+MARION,Colfax Township,Secretary of State,,Republican,"Kobach, Kris",55,000060
+MARION,Doyle Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000070
+MARION,Doyle Township,Secretary of State,,Republican,"Kobach, Kris",15,000070
+MARION,Durham Park Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000080
+MARION,Durham Park Township,Secretary of State,,Republican,"Kobach, Kris",61,000080
+MARION,East Branch Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000090
+MARION,East Branch Township,Secretary of State,,Republican,"Kobach, Kris",59,000090
+MARION,Fairplay Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000100
+MARION,Fairplay Township,Secretary of State,,Republican,"Kobach, Kris",46,000100
+MARION,Florence Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,00011A
+MARION,Florence Ward 1,Secretary of State,,Republican,"Kobach, Kris",35,00011A
+MARION,Florence Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00011B
+MARION,Florence Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00011B
+MARION,Florence Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000120
+MARION,Florence Ward 2,Secretary of State,,Republican,"Kobach, Kris",47,000120
+MARION,Gale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000130
+MARION,Gale Township,Secretary of State,,Republican,"Kobach, Kris",74,000130
+MARION,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000140
+MARION,Grant Township,Secretary of State,,Republican,"Kobach, Kris",49,000140
+MARION,Hillsboro Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,000150
+MARION,Hillsboro Ward 1,Secretary of State,,Republican,"Kobach, Kris",297,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Secretary of State,,Republican,"Kobach, Kris",0,00016C
+MARION,Lehigh Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000170
+MARION,Lehigh Township,Secretary of State,,Republican,"Kobach, Kris",64,000170
+MARION,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000180
+MARION,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",101,000180
+MARION,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000190
+MARION,Logan Township,Secretary of State,,Republican,"Kobach, Kris",18,000190
+MARION,Lost Springs Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000200
+MARION,Lost Springs Township,Secretary of State,,Republican,"Kobach, Kris",63,000200
+MARION,Marion North Ward,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",122,000210
+MARION,Marion North Ward,Secretary of State,,Republican,"Kobach, Kris",219,000210
+MARION,Marion South Ward,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,00022A
+MARION,Marion South Ward,Secretary of State,,Republican,"Kobach, Kris",202,00022A
+MARION,Marion South Ward Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022B
+MARION,Marion South Ward Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00022B
+MARION,Menno Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000230
+MARION,Menno Township,Secretary of State,,Republican,"Kobach, Kris",106,000230
+MARION,Milton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000240
+MARION,Milton Township,Secretary of State,,Republican,"Kobach, Kris",59,000240
+MARION,Moore Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000250
+MARION,Moore Township,Secretary of State,,Republican,"Kobach, Kris",20,000250
+MARION,Peabody East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000260
+MARION,Peabody East,Secretary of State,,Republican,"Kobach, Kris",92,000260
+MARION,Peabody West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,000270
+MARION,Peabody West,Secretary of State,,Republican,"Kobach, Kris",148,000270
+MARION,Risley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000280
+MARION,Risley Township,Secretary of State,,Republican,"Kobach, Kris",88,000280
+MARION,Summit Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000290
+MARION,Summit Township,Secretary of State,,Republican,"Kobach, Kris",17,000290
+MARION,West Branch Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",167,000300
+MARION,West Branch Township,Secretary of State,,Republican,"Kobach, Kris",211,000300
+MARION,Wilson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000310
+MARION,Wilson Township,Secretary of State,,Republican,"Kobach, Kris",67,000310
+MARION,Hillsboro Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",113,900010
+MARION,Hillsboro Ward 2,Secretary of State,,Republican,"Kobach, Kris",356,900010
+MARION,Hillsboro Ward 2 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+MARION,Hillsboro Ward 2 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,900020
+MARION,Blaine Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000010
+MARION,Blaine Township,State Treasurer,,Republican,"Estes, Ron",50,000010
+MARION,Catlin Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000020
+MARION,Catlin Township,State Treasurer,,Republican,"Estes, Ron",62,000020
+MARION,Centre Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000030
+MARION,Centre Township,State Treasurer,,Republican,"Estes, Ron",203,000030
+MARION,Clark Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000040
+MARION,Clark Township,State Treasurer,,Republican,"Estes, Ron",49,000040
+MARION,Clear Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000050
+MARION,Clear Creek Township,State Treasurer,,Republican,"Estes, Ron",145,000050
+MARION,Colfax Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000060
+MARION,Colfax Township,State Treasurer,,Republican,"Estes, Ron",55,000060
+MARION,Doyle Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000070
+MARION,Doyle Township,State Treasurer,,Republican,"Estes, Ron",14,000070
+MARION,Durham Park Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000080
+MARION,Durham Park Township,State Treasurer,,Republican,"Estes, Ron",68,000080
+MARION,East Branch Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000090
+MARION,East Branch Township,State Treasurer,,Republican,"Estes, Ron",75,000090
+MARION,Fairplay Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000100
+MARION,Fairplay Township,State Treasurer,,Republican,"Estes, Ron",51,000100
+MARION,Florence Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",20,00011A
+MARION,Florence Ward 1,State Treasurer,,Republican,"Estes, Ron",42,00011A
+MARION,Florence Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00011B
+MARION,Florence Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00011B
+MARION,Florence Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",19,000120
+MARION,Florence Ward 2,State Treasurer,,Republican,"Estes, Ron",57,000120
+MARION,Gale Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000130
+MARION,Gale Township,State Treasurer,,Republican,"Estes, Ron",83,000130
+MARION,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000140
+MARION,Grant Township,State Treasurer,,Republican,"Estes, Ron",54,000140
+MARION,Hillsboro Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",59,000150
+MARION,Hillsboro Ward 1,State Treasurer,,Republican,"Estes, Ron",336,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,State Treasurer,,Democratic,"Alldritt, Carmen",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,State Treasurer,,Republican,"Estes, Ron",0,00016C
+MARION,Lehigh Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000170
+MARION,Lehigh Township,State Treasurer,,Republican,"Estes, Ron",65,000170
+MARION,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000180
+MARION,Liberty Township,State Treasurer,,Republican,"Estes, Ron",112,000180
+MARION,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000190
+MARION,Logan Township,State Treasurer,,Republican,"Estes, Ron",21,000190
+MARION,Lost Springs Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000200
+MARION,Lost Springs Township,State Treasurer,,Republican,"Estes, Ron",69,000200
+MARION,Marion North Ward,State Treasurer,,Democratic,"Alldritt, Carmen",85,000210
+MARION,Marion North Ward,State Treasurer,,Republican,"Estes, Ron",251,000210
+MARION,Marion South Ward,State Treasurer,,Democratic,"Alldritt, Carmen",67,00022A
+MARION,Marion South Ward,State Treasurer,,Republican,"Estes, Ron",236,00022A
+MARION,Marion South Ward Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022B
+MARION,Marion South Ward Exclave,State Treasurer,,Republican,"Estes, Ron",0,00022B
+MARION,Menno Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000230
+MARION,Menno Township,State Treasurer,,Republican,"Estes, Ron",120,000230
+MARION,Milton Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000240
+MARION,Milton Township,State Treasurer,,Republican,"Estes, Ron",66,000240
+MARION,Moore Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000250
+MARION,Moore Township,State Treasurer,,Republican,"Estes, Ron",23,000250
+MARION,Peabody East,State Treasurer,,Democratic,"Alldritt, Carmen",43,000260
+MARION,Peabody East,State Treasurer,,Republican,"Estes, Ron",122,000260
+MARION,Peabody West,State Treasurer,,Democratic,"Alldritt, Carmen",56,000270
+MARION,Peabody West,State Treasurer,,Republican,"Estes, Ron",175,000270
+MARION,Risley Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000280
+MARION,Risley Township,State Treasurer,,Republican,"Estes, Ron",97,000280
+MARION,Summit Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000290
+MARION,Summit Township,State Treasurer,,Republican,"Estes, Ron",27,000290
+MARION,West Branch Township,State Treasurer,,Democratic,"Alldritt, Carmen",98,000300
+MARION,West Branch Township,State Treasurer,,Republican,"Estes, Ron",271,000300
+MARION,Wilson Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000310
+MARION,Wilson Township,State Treasurer,,Republican,"Estes, Ron",72,000310
+MARION,Hillsboro Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",60,900010
+MARION,Hillsboro Ward 2,State Treasurer,,Republican,"Estes, Ron",403,900010
+MARION,Hillsboro Ward 2 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+MARION,Hillsboro Ward 2 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,900020
+MARION,Blaine Township,United States Senate,,independent,"Orman, Greg",18,000010
+MARION,Blaine Township,United States Senate,,Libertarian,"Batson, Randall",2,000010
+MARION,Blaine Township,United States Senate,,Republican,"Roberts, Pat",48,000010
+MARION,Catlin Township,United States Senate,,independent,"Orman, Greg",28,000020
+MARION,Catlin Township,United States Senate,,Libertarian,"Batson, Randall",3,000020
+MARION,Catlin Township,United States Senate,,Republican,"Roberts, Pat",52,000020
+MARION,Centre Township,United States Senate,,independent,"Orman, Greg",76,000030
+MARION,Centre Township,United States Senate,,Libertarian,"Batson, Randall",15,000030
+MARION,Centre Township,United States Senate,,Republican,"Roberts, Pat",159,000030
+MARION,Clark Township,United States Senate,,independent,"Orman, Greg",11,000040
+MARION,Clark Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+MARION,Clark Township,United States Senate,,Republican,"Roberts, Pat",50,000040
+MARION,Clear Creek Township,United States Senate,,independent,"Orman, Greg",40,000050
+MARION,Clear Creek Township,United States Senate,,Libertarian,"Batson, Randall",11,000050
+MARION,Clear Creek Township,United States Senate,,Republican,"Roberts, Pat",129,000050
+MARION,Colfax Township,United States Senate,,independent,"Orman, Greg",19,000060
+MARION,Colfax Township,United States Senate,,Libertarian,"Batson, Randall",1,000060
+MARION,Colfax Township,United States Senate,,Republican,"Roberts, Pat",55,000060
+MARION,Doyle Township,United States Senate,,independent,"Orman, Greg",4,000070
+MARION,Doyle Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+MARION,Doyle Township,United States Senate,,Republican,"Roberts, Pat",15,000070
+MARION,Durham Park Township,United States Senate,,independent,"Orman, Greg",27,000080
+MARION,Durham Park Township,United States Senate,,Libertarian,"Batson, Randall",2,000080
+MARION,Durham Park Township,United States Senate,,Republican,"Roberts, Pat",60,000080
+MARION,East Branch Township,United States Senate,,independent,"Orman, Greg",36,000090
+MARION,East Branch Township,United States Senate,,Libertarian,"Batson, Randall",5,000090
+MARION,East Branch Township,United States Senate,,Republican,"Roberts, Pat",57,000090
+MARION,Fairplay Township,United States Senate,,independent,"Orman, Greg",10,000100
+MARION,Fairplay Township,United States Senate,,Libertarian,"Batson, Randall",2,000100
+MARION,Fairplay Township,United States Senate,,Republican,"Roberts, Pat",48,000100
+MARION,Florence Ward 1,United States Senate,,independent,"Orman, Greg",26,00011A
+MARION,Florence Ward 1,United States Senate,,Libertarian,"Batson, Randall",9,00011A
+MARION,Florence Ward 1,United States Senate,,Republican,"Roberts, Pat",28,00011A
+MARION,Florence Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,00011B
+MARION,Florence Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00011B
+MARION,Florence Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00011B
+MARION,Florence Ward 2,United States Senate,,independent,"Orman, Greg",33,000120
+MARION,Florence Ward 2,United States Senate,,Libertarian,"Batson, Randall",6,000120
+MARION,Florence Ward 2,United States Senate,,Republican,"Roberts, Pat",37,000120
+MARION,Gale Township,United States Senate,,independent,"Orman, Greg",33,000130
+MARION,Gale Township,United States Senate,,Libertarian,"Batson, Randall",6,000130
+MARION,Gale Township,United States Senate,,Republican,"Roberts, Pat",64,000130
+MARION,Grant Township,United States Senate,,independent,"Orman, Greg",23,000140
+MARION,Grant Township,United States Senate,,Libertarian,"Batson, Randall",1,000140
+MARION,Grant Township,United States Senate,,Republican,"Roberts, Pat",45,000140
+MARION,Hillsboro Ward 1,United States Senate,,independent,"Orman, Greg",105,000150
+MARION,Hillsboro Ward 1,United States Senate,,Libertarian,"Batson, Randall",13,000150
+MARION,Hillsboro Ward 1,United States Senate,,Republican,"Roberts, Pat",290,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States Senate,,independent,"Orman, Greg",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States Senate,,Libertarian,"Batson, Randall",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States Senate,,Republican,"Roberts, Pat",0,00016C
+MARION,Lehigh Township,United States Senate,,independent,"Orman, Greg",18,000170
+MARION,Lehigh Township,United States Senate,,Libertarian,"Batson, Randall",0,000170
+MARION,Lehigh Township,United States Senate,,Republican,"Roberts, Pat",58,000170
+MARION,Liberty Township,United States Senate,,independent,"Orman, Greg",39,000180
+MARION,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",7,000180
+MARION,Liberty Township,United States Senate,,Republican,"Roberts, Pat",96,000180
+MARION,Logan Township,United States Senate,,independent,"Orman, Greg",6,000190
+MARION,Logan Township,United States Senate,,Libertarian,"Batson, Randall",0,000190
+MARION,Logan Township,United States Senate,,Republican,"Roberts, Pat",19,000190
+MARION,Lost Springs Township,United States Senate,,independent,"Orman, Greg",14,000200
+MARION,Lost Springs Township,United States Senate,,Libertarian,"Batson, Randall",0,000200
+MARION,Lost Springs Township,United States Senate,,Republican,"Roberts, Pat",64,000200
+MARION,Marion North Ward,United States Senate,,independent,"Orman, Greg",125,000210
+MARION,Marion North Ward,United States Senate,,Libertarian,"Batson, Randall",18,000210
+MARION,Marion North Ward,United States Senate,,Republican,"Roberts, Pat",200,000210
+MARION,Marion South Ward,United States Senate,,independent,"Orman, Greg",106,00022A
+MARION,Marion South Ward,United States Senate,,Libertarian,"Batson, Randall",17,00022A
+MARION,Marion South Ward,United States Senate,,Republican,"Roberts, Pat",184,00022A
+MARION,Marion South Ward Exclave,United States Senate,,independent,"Orman, Greg",0,00022B
+MARION,Marion South Ward Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00022B
+MARION,Marion South Ward Exclave,United States Senate,,Republican,"Roberts, Pat",0,00022B
+MARION,Menno Township,United States Senate,,independent,"Orman, Greg",49,000230
+MARION,Menno Township,United States Senate,,Libertarian,"Batson, Randall",7,000230
+MARION,Menno Township,United States Senate,,Republican,"Roberts, Pat",100,000230
+MARION,Milton Township,United States Senate,,independent,"Orman, Greg",25,000240
+MARION,Milton Township,United States Senate,,Libertarian,"Batson, Randall",5,000240
+MARION,Milton Township,United States Senate,,Republican,"Roberts, Pat",53,000240
+MARION,Moore Township,United States Senate,,independent,"Orman, Greg",7,000250
+MARION,Moore Township,United States Senate,,Libertarian,"Batson, Randall",0,000250
+MARION,Moore Township,United States Senate,,Republican,"Roberts, Pat",20,000250
+MARION,Peabody East,United States Senate,,independent,"Orman, Greg",70,000260
+MARION,Peabody East,United States Senate,,Libertarian,"Batson, Randall",9,000260
+MARION,Peabody East,United States Senate,,Republican,"Roberts, Pat",89,000260
+MARION,Peabody West,United States Senate,,independent,"Orman, Greg",75,000270
+MARION,Peabody West,United States Senate,,Libertarian,"Batson, Randall",23,000270
+MARION,Peabody West,United States Senate,,Republican,"Roberts, Pat",136,000270
+MARION,Risley Township,United States Senate,,independent,"Orman, Greg",16,000280
+MARION,Risley Township,United States Senate,,Libertarian,"Batson, Randall",1,000280
+MARION,Risley Township,United States Senate,,Republican,"Roberts, Pat",94,000280
+MARION,Summit Township,United States Senate,,independent,"Orman, Greg",11,000290
+MARION,Summit Township,United States Senate,,Libertarian,"Batson, Randall",2,000290
+MARION,Summit Township,United States Senate,,Republican,"Roberts, Pat",20,000290
+MARION,West Branch Township,United States Senate,,independent,"Orman, Greg",173,000300
+MARION,West Branch Township,United States Senate,,Libertarian,"Batson, Randall",26,000300
+MARION,West Branch Township,United States Senate,,Republican,"Roberts, Pat",185,000300
+MARION,Wilson Township,United States Senate,,independent,"Orman, Greg",15,000310
+MARION,Wilson Township,United States Senate,,Libertarian,"Batson, Randall",6,000310
+MARION,Wilson Township,United States Senate,,Republican,"Roberts, Pat",61,000310
+MARION,Hillsboro Ward 2,United States Senate,,independent,"Orman, Greg",125,900010
+MARION,Hillsboro Ward 2,United States Senate,,Libertarian,"Batson, Randall",22,900010
+MARION,Hillsboro Ward 2,United States Senate,,Republican,"Roberts, Pat",331,900010
+MARION,Hillsboro Ward 2 Exclave A,United States Senate,,independent,"Orman, Greg",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,900020

--- a/2014/20141104__ks__general__marshall__precinct.csv
+++ b/2014/20141104__ks__general__marshall__precinct.csv
@@ -1,604 +1,632 @@
-county,precinct,office,district,party,candidate,votes
-Marshall,Balderson Township,U.S. Senate,,IND,Greg Orman,2
-Marshall,Bigelow Township,U.S. Senate,,IND,Greg Orman,7
-Marshall,Blue Rapids Township,U.S. Senate,,IND,Greg Orman,5
-Marshall,Blue Rapids City Township,U.S. Senate,,IND,Greg Orman,84
-Marshall,Center Township,U.S. Senate,,IND,Greg Orman,14
-Marshall,Clear Fork Township,U.S. Senate,,IND,Greg Orman,5
-Marshall,Cleveland Township,U.S. Senate,,IND,Greg Orman,5
-Marshall,Cottage Hill Township,U.S. Senate,,IND,Greg Orman,19
-Marshall,Elm Creek Township,U.S. Senate,,IND,Greg Orman,14
-Marshall,Franklin Township-District 1,U.S. Senate,,IND,Greg Orman,17
-Marshall,Franklin Township-District 2,U.S. Senate,,IND,Greg Orman,15
-Marshall,Guittard Township-District 1,U.S. Senate,,IND,Greg Orman,1
-Marshall,Guittard Township-District 2,U.S. Senate,,IND,Greg Orman,49
-Marshall,Herkimer Township,U.S. Senate,,IND,Greg Orman,10
-Marshall,Lincoln Township,U.S. Senate,,IND,Greg Orman,9
-Marshall,Logan Township,U.S. Senate,,IND,Greg Orman,15
-Marshall,Marysville Township,U.S. Senate,,IND,Greg Orman,22
-Marshall,Murray Township,U.S. Senate,,IND,Greg Orman,70
-Marshall,Noble Township,U.S. Senate,,IND,Greg Orman,14
-Marshall,Oketo Township,U.S. Senate,,IND,Greg Orman,14
-Marshall,Richland Township,U.S. Senate,,IND,Greg Orman,15
-Marshall,Rock Township,U.S. Senate,,IND,Greg Orman,7
-Marshall,St. Bridget Township,U.S. Senate,,IND,Greg Orman,11
-Marshall,Vermillion Twp-East Precinct,U.S. Senate,,IND,Greg Orman,56
-Marshall,Vermillion Twp-West Precinct,U.S. Senate,,IND,Greg Orman,60
-Marshall,Walnut Township,U.S. Senate,,IND,Greg Orman,6
-Marshall,Waterville Township,U.S. Senate,,IND,Greg Orman,75
-Marshall,Wells Township,U.S. Senate,,IND,Greg Orman,12
-Marshall,Marysville City - Ward 1,U.S. Senate,,IND,Greg Orman,62
-Marshall,Marysville City - Ward 2,U.S. Senate,,IND,Greg Orman,43
-Marshall,Marysville City - Ward 3,U.S. Senate,,IND,Greg Orman,31
-Marshall,Marysville City - Ward 4,U.S. Senate,,IND,Greg Orman,55
-Marshall,Advance Voters,U.S. Senate,,IND,Greg Orman,453
-Marshall,Provisional,U.S. Senate,,IND,Greg Orman,18
-Marshall,Balderson Township,U.S. Senate,,R,Pat Roberts,21
-Marshall,Bigelow Township,U.S. Senate,,R,Pat Roberts,7
-Marshall,Blue Rapids Township,U.S. Senate,,R,Pat Roberts,12
-Marshall,Blue Rapids City Township,U.S. Senate,,R,Pat Roberts,136
-Marshall,Center Township,U.S. Senate,,R,Pat Roberts,21
-Marshall,Clear Fork Township,U.S. Senate,,R,Pat Roberts,9
-Marshall,Cleveland Township,U.S. Senate,,R,Pat Roberts,20
-Marshall,Cottage Hill Township,U.S. Senate,,R,Pat Roberts,41
-Marshall,Elm Creek Township,U.S. Senate,,R,Pat Roberts,33
-Marshall,Franklin Township-District 1,U.S. Senate,,R,Pat Roberts,29
-Marshall,Franklin Township-District 2,U.S. Senate,,R,Pat Roberts,19
-Marshall,Guittard Township-District 1,U.S. Senate,,R,Pat Roberts,2
-Marshall,Guittard Township-District 2,U.S. Senate,,R,Pat Roberts,76
-Marshall,Herkimer Township,U.S. Senate,,R,Pat Roberts,54
-Marshall,Lincoln Township,U.S. Senate,,R,Pat Roberts,49
-Marshall,Logan Township,U.S. Senate,,R,Pat Roberts,62
-Marshall,Marysville Township,U.S. Senate,,R,Pat Roberts,55
-Marshall,Murray Township,U.S. Senate,,R,Pat Roberts,137
-Marshall,Noble Township,U.S. Senate,,R,Pat Roberts,46
-Marshall,Oketo Township,U.S. Senate,,R,Pat Roberts,40
-Marshall,Richland Township,U.S. Senate,,R,Pat Roberts,48
-Marshall,Rock Township,U.S. Senate,,R,Pat Roberts,37
-Marshall,St. Bridget Township,U.S. Senate,,R,Pat Roberts,29
-Marshall,Vermillion Twp-East Precinct,U.S. Senate,,R,Pat Roberts,102
-Marshall,Vermillion Twp-West Precinct,U.S. Senate,,R,Pat Roberts,79
-Marshall,Walnut Township,U.S. Senate,,R,Pat Roberts,27
-Marshall,Waterville Township,U.S. Senate,,R,Pat Roberts,131
-Marshall,Wells Township,U.S. Senate,,R,Pat Roberts,26
-Marshall,Marysville City - Ward 1,U.S. Senate,,R,Pat Roberts,116
-Marshall,Marysville City - Ward 2,U.S. Senate,,R,Pat Roberts,93
-Marshall,Marysville City - Ward 3,U.S. Senate,,R,Pat Roberts,62
-Marshall,Marysville City - Ward 4,U.S. Senate,,R,Pat Roberts,114
-Marshall,Advance Voters,U.S. Senate,,R,Pat Roberts,482
-Marshall,Provisional,U.S. Senate,,R,Pat Roberts,35
-Marshall,Balderson Township,U.S. Senate,,LBT,Randall Batson,1
-Marshall,Bigelow Township,U.S. Senate,,LBT,Randall Batson,0
-Marshall,Blue Rapids Township,U.S. Senate,,LBT,Randall Batson,1
-Marshall,Blue Rapids City Township,U.S. Senate,,LBT,Randall Batson,18
-Marshall,Center Township,U.S. Senate,,LBT,Randall Batson,0
-Marshall,Clear Fork Township,U.S. Senate,,LBT,Randall Batson,0
-Marshall,Cleveland Township,U.S. Senate,,LBT,Randall Batson,3
-Marshall,Cottage Hill Township,U.S. Senate,,LBT,Randall Batson,1
-Marshall,Elm Creek Township,U.S. Senate,,LBT,Randall Batson,5
-Marshall,Franklin Township-District 1,U.S. Senate,,LBT,Randall Batson,2
-Marshall,Franklin Township-District 2,U.S. Senate,,LBT,Randall Batson,1
-Marshall,Guittard Township-District 1,U.S. Senate,,LBT,Randall Batson,0
-Marshall,Guittard Township-District 2,U.S. Senate,,LBT,Randall Batson,5
-Marshall,Herkimer Township,U.S. Senate,,LBT,Randall Batson,1
-Marshall,Lincoln Township,U.S. Senate,,LBT,Randall Batson,0
-Marshall,Logan Township,U.S. Senate,,LBT,Randall Batson,5
-Marshall,Marysville Township,U.S. Senate,,LBT,Randall Batson,3
-Marshall,Murray Township,U.S. Senate,,LBT,Randall Batson,14
-Marshall,Noble Township,U.S. Senate,,LBT,Randall Batson,3
-Marshall,Oketo Township,U.S. Senate,,LBT,Randall Batson,2
-Marshall,Richland Township,U.S. Senate,,LBT,Randall Batson,2
-Marshall,Rock Township,U.S. Senate,,LBT,Randall Batson,0
-Marshall,St. Bridget Township,U.S. Senate,,LBT,Randall Batson,8
-Marshall,Vermillion Twp-East Precinct,U.S. Senate,,LBT,Randall Batson,4
-Marshall,Vermillion Twp-West Precinct,U.S. Senate,,LBT,Randall Batson,4
-Marshall,Walnut Township,U.S. Senate,,LBT,Randall Batson,0
-Marshall,Waterville Township,U.S. Senate,,LBT,Randall Batson,12
-Marshall,Wells Township,U.S. Senate,,LBT,Randall Batson,2
-Marshall,Marysville City - Ward 1,U.S. Senate,,LBT,Randall Batson,11
-Marshall,Marysville City - Ward 2,U.S. Senate,,LBT,Randall Batson,10
-Marshall,Marysville City - Ward 3,U.S. Senate,,LBT,Randall Batson,5
-Marshall,Marysville City - Ward 4,U.S. Senate,,LBT,Randall Batson,6
-Marshall,Advance Voters,U.S. Senate,,LBT,Randall Batson,25
-Marshall,Provisional,U.S. Senate,,LBT,Randall Batson,4
-Marshall,Balderson Township,U.S. House,1,R,Tim Huelskamp,20
-Marshall,Franklin Township-District 1,U.S. House,1,R,Tim Huelskamp,31
-Marshall,Guittard Township-District 1,U.S. House,1,R,Tim Huelskamp,3
-Marshall,Herkimer Township,U.S. House,1,R,Tim Huelskamp,54
-Marshall,Logan Township,U.S. House,1,R,Tim Huelskamp,60
-Marshall,Marysville Township,U.S. House,1,R,Tim Huelskamp,57
-Marshall,Oketo Township,U.S. House,1,R,Tim Huelskamp,38
-Marshall,Richland Township,U.S. House,1,R,Tim Huelskamp,47
-Marshall,St. Bridget Township,U.S. House,1,R,Tim Huelskamp,32
-Marshall,Marysville City - Ward 1,U.S. House,1,R,Tim Huelskamp,126
-Marshall,Marysville City - Ward 2,U.S. House,1,R,Tim Huelskamp,99
-Marshall,Marysville City - Ward 3,U.S. House,1,R,Tim Huelskamp,66
-Marshall,Marysville City - Ward 4,U.S. House,1,R,Tim Huelskamp,123
-Marshall,Advance Voters,U.S. House,1,R,Tim Huelskamp,348
-Marshall,Provisional,U.S. House,1,R,Tim Huelskamp,17
-Marshall,Balderson Township,U.S. House,1,D,Jim Sherow,4
-Marshall,Franklin Township-District 1,U.S. House,1,D,Jim Sherow,17
-Marshall,Guittard Township-District 1,U.S. House,1,D,Jim Sherow,0
-Marshall,Herkimer Township,U.S. House,1,D,Jim Sherow,10
-Marshall,Logan Township,U.S. House,1,D,Jim Sherow,21
-Marshall,Marysville Township,U.S. House,1,D,Jim Sherow,23
-Marshall,Oketo Township,U.S. House,1,D,Jim Sherow,16
-Marshall,Richland Township,U.S. House,1,D,Jim Sherow,17
-Marshall,St. Bridget Township,U.S. House,1,D,Jim Sherow,15
-Marshall,Marysville City - Ward 1,U.S. House,1,D,Jim Sherow,62
-Marshall,Marysville City - Ward 2,U.S. House,1,D,Jim Sherow,44
-Marshall,Marysville City - Ward 3,U.S. House,1,D,Jim Sherow,31
-Marshall,Marysville City - Ward 4,U.S. House,1,D,Jim Sherow,52
-Marshall,Advance Voters,U.S. House,1,D,Jim Sherow,296
-Marshall,Provisional,U.S. House,1,D,Jim Sherow,9
-Marshall,Bigelow Township,U.S. House,2,R,Lynn Jenkins,8
-Marshall,Blue Rapids Township,U.S. House,2,R,Lynn Jenkins,13
-Marshall,Blue Rapids City Township,U.S. House,2,R,Lynn Jenkins,167
-Marshall,Center Township,U.S. House,2,R,Lynn Jenkins,21
-Marshall,Clear Fork Township,U.S. House,2,R,Lynn Jenkins,10
-Marshall,Cleveland Township,U.S. House,2,R,Lynn Jenkins,23
-Marshall,Cottage Hill Township,U.S. House,2,R,Lynn Jenkins,51
-Marshall,Elm Creek Township,U.S. House,2,R,Lynn Jenkins,32
-Marshall,Franklin Township-District 2,U.S. House,2,R,Lynn Jenkins,21
-Marshall,Guittard Township-District 2,U.S. House,2,R,Lynn Jenkins,89
-Marshall,Lincoln Township,U.S. House,2,R,Lynn Jenkins,50
-Marshall,Murray Township,U.S. House,2,R,Lynn Jenkins,147
-Marshall,Noble Township,U.S. House,2,R,Lynn Jenkins,49
-Marshall,Rock Township,U.S. House,2,R,Lynn Jenkins,36
-Marshall,Vermillion Twp-East Precinct,U.S. House,2,R,Lynn Jenkins,114
-Marshall,Vermillion Twp-West Precinct,U.S. House,2,R,Lynn Jenkins,97
-Marshall,Walnut Township,U.S. House,2,R,Lynn Jenkins,27
-Marshall,Waterville Township,U.S. House,2,R,Lynn Jenkins,155
-Marshall,Wells Township,U.S. House,2,R,Lynn Jenkins,28
-Marshall,Advance Voters,U.S. House,2,R,Lynn Jenkins,188
-Marshall,Provisional,U.S. House,2,R,Lynn Jenkins,23
-Marshall,Bigelow Township,U.S. House,2,D,Margie Wakefield,6
-Marshall,Blue Rapids Township,U.S. House,2,D,Margie Wakefield,5
-Marshall,Blue Rapids City Township,U.S. House,2,D,Margie Wakefield,61
-Marshall,Center Township,U.S. House,2,D,Margie Wakefield,9
-Marshall,Clear Fork Township,U.S. House,2,D,Margie Wakefield,4
-Marshall,Cleveland Township,U.S. House,2,D,Margie Wakefield,4
-Marshall,Cottage Hill Township,U.S. House,2,D,Margie Wakefield,9
-Marshall,Elm Creek Township,U.S. House,2,D,Margie Wakefield,14
-Marshall,Franklin Township-District 2,U.S. House,2,D,Margie Wakefield,12
-Marshall,Guittard Township-District 2,U.S. House,2,D,Margie Wakefield,39
-Marshall,Lincoln Township,U.S. House,2,D,Margie Wakefield,6
-Marshall,Murray Township,U.S. House,2,D,Margie Wakefield,61
-Marshall,Noble Township,U.S. House,2,D,Margie Wakefield,12
-Marshall,Rock Township,U.S. House,2,D,Margie Wakefield,7
-Marshall,Vermillion Twp-East Precinct,U.S. House,2,D,Margie Wakefield,50
-Marshall,Vermillion Twp-West Precinct,U.S. House,2,D,Margie Wakefield,42
-Marshall,Walnut Township,U.S. House,2,D,Margie Wakefield,6
-Marshall,Waterville Township,U.S. House,2,D,Margie Wakefield,59
-Marshall,Wells Township,U.S. House,2,D,Margie Wakefield,11
-Marshall,Advance Voters,U.S. House,2,D,Margie Wakefield,112
-Marshall,Provisional,U.S. House,2,D,Margie Wakefield,9
-Marshall,Bigelow Township,U.S. House,2,LBT,Christopher Clemmons,0
-Marshall,Blue Rapids Township,U.S. House,2,LBT,Christopher Clemmons,0
-Marshall,Blue Rapids City Township,U.S. House,2,LBT,Christopher Clemmons,12
-Marshall,Center Township,U.S. House,2,LBT,Christopher Clemmons,5
-Marshall,Clear Fork Township,U.S. House,2,LBT,Christopher Clemmons,0
-Marshall,Cleveland Township,U.S. House,2,LBT,Christopher Clemmons,1
-Marshall,Cottage Hill Township,U.S. House,2,LBT,Christopher Clemmons,2
-Marshall,Elm Creek Township,U.S. House,2,LBT,Christopher Clemmons,5
-Marshall,Franklin Township-District 2,U.S. House,2,LBT,Christopher Clemmons,2
-Marshall,Guittard Township-District 2,U.S. House,2,LBT,Christopher Clemmons,3
-Marshall,Lincoln Township,U.S. House,2,LBT,Christopher Clemmons,2
-Marshall,Murray Township,U.S. House,2,LBT,Christopher Clemmons,11
-Marshall,Noble Township,U.S. House,2,LBT,Christopher Clemmons,2
-Marshall,Rock Township,U.S. House,2,LBT,Christopher Clemmons,1
-Marshall,Vermillion Twp-East Precinct,U.S. House,2,LBT,Christopher Clemmons,0
-Marshall,Vermillion Twp-West Precinct,U.S. House,2,LBT,Christopher Clemmons,6
-Marshall,Walnut Township,U.S. House,2,LBT,Christopher Clemmons,0
-Marshall,Waterville Township,U.S. House,2,LBT,Christopher Clemmons,8
-Marshall,Wells Township,U.S. House,2,LBT,Christopher Clemmons,3
-Marshall,Advance Voters,U.S. House,2,LBT,Christopher Clemmons,10
-Marshall,Provisional,U.S. House,2,LBT,Christopher Clemmons,0
-Marshall,Balderson Township,Governor,,D,Paul Davis,7
-Marshall,Bigelow Township,Governor,,D,Paul Davis,7
-Marshall,Blue Rapids Township,Governor,,D,Paul Davis,5
-Marshall,Blue Rapids City Township,Governor,,D,Paul Davis,94
-Marshall,Center Township,Governor,,D,Paul Davis,12
-Marshall,Clear Fork Township,Governor,,D,Paul Davis,7
-Marshall,Cleveland Township,Governor,,D,Paul Davis,9
-Marshall,Cottage Hill Township,Governor,,D,Paul Davis,20
-Marshall,Elm Creek Township,Governor,,D,Paul Davis,22
-Marshall,Franklin Township-District 1,Governor,,D,Paul Davis,21
-Marshall,Franklin Township-District 2,Governor,,D,Paul Davis,16
-Marshall,Guittard Township-District 1,Governor,,D,Paul Davis,1
-Marshall,Guittard Township-District 2,Governor,,D,Paul Davis,61
-Marshall,Herkimer Township,Governor,,D,Paul Davis,12
-Marshall,Lincoln Township,Governor,,D,Paul Davis,18
-Marshall,Logan Township,Governor,,D,Paul Davis,18
-Marshall,Marysville Township,Governor,,D,Paul Davis,26
-Marshall,Murray Township,Governor,,D,Paul Davis,90
-Marshall,Noble Township,Governor,,D,Paul Davis,17
-Marshall,Oketo Township,Governor,,D,Paul Davis,17
-Marshall,Richland Township,Governor,,D,Paul Davis,18
-Marshall,Rock Township,Governor,,D,Paul Davis,15
-Marshall,St. Bridget Township,Governor,,D,Paul Davis,22
-Marshall,Vermillion Twp-East Precinct,Governor,,D,Paul Davis,65
-Marshall,Vermillion Twp-West Precinct,Governor,,D,Paul Davis,72
-Marshall,Walnut Township,Governor,,D,Paul Davis,13
-Marshall,Waterville Township,Governor,,D,Paul Davis,85
-Marshall,Wells Township,Governor,,D,Paul Davis,19
-Marshall,Marysville City - Ward 1,Governor,,D,Paul Davis,88
-Marshall,Marysville City - Ward 2,Governor,,D,Paul Davis,52
-Marshall,Marysville City - Ward 3,Governor,,D,Paul Davis,41
-Marshall,Marysville City - Ward 4,Governor,,D,Paul Davis,77
-Marshall,Advance Voters,Governor,,D,Paul Davis,495
-Marshall,Provisional,Governor,,D,Paul Davis,21
-Marshall,Balderson Township,Governor,,LBT,Keen Umbehr,1
-Marshall,Bigelow Township,Governor,,LBT,Keen Umbehr,0
-Marshall,Blue Rapids Township,Governor,,LBT,Keen Umbehr,0
-Marshall,Blue Rapids City Township,Governor,,LBT,Keen Umbehr,18
-Marshall,Center Township,Governor,,LBT,Keen Umbehr,4
-Marshall,Clear Fork Township,Governor,,LBT,Keen Umbehr,1
-Marshall,Cleveland Township,Governor,,LBT,Keen Umbehr,0
-Marshall,Cottage Hill Township,Governor,,LBT,Keen Umbehr,0
-Marshall,Elm Creek Township,Governor,,LBT,Keen Umbehr,2
-Marshall,Franklin Township-District 1,Governor,,LBT,Keen Umbehr,0
-Marshall,Franklin Township-District 2,Governor,,LBT,Keen Umbehr,1
-Marshall,Guittard Township-District 1,Governor,,LBT,Keen Umbehr,0
-Marshall,Guittard Township-District 2,Governor,,LBT,Keen Umbehr,4
-Marshall,Herkimer Township,Governor,,LBT,Keen Umbehr,0
-Marshall,Lincoln Township,Governor,,LBT,Keen Umbehr,2
-Marshall,Logan Township,Governor,,LBT,Keen Umbehr,6
-Marshall,Marysville Township,Governor,,LBT,Keen Umbehr,5
-Marshall,Murray Township,Governor,,LBT,Keen Umbehr,12
-Marshall,Noble Township,Governor,,LBT,Keen Umbehr,4
-Marshall,Oketo Township,Governor,,LBT,Keen Umbehr,2
-Marshall,Richland Township,Governor,,LBT,Keen Umbehr,0
-Marshall,Rock Township,Governor,,LBT,Keen Umbehr,2
-Marshall,St. Bridget Township,Governor,,LBT,Keen Umbehr,3
-Marshall,Vermillion Twp-East Precinct,Governor,,LBT,Keen Umbehr,7
-Marshall,Vermillion Twp-West Precinct,Governor,,LBT,Keen Umbehr,9
-Marshall,Walnut Township,Governor,,LBT,Keen Umbehr,1
-Marshall,Waterville Township,Governor,,LBT,Keen Umbehr,15
-Marshall,Wells Township,Governor,,LBT,Keen Umbehr,1
-Marshall,Marysville City - Ward 1,Governor,,LBT,Keen Umbehr,12
-Marshall,Marysville City - Ward 2,Governor,,LBT,Keen Umbehr,9
-Marshall,Marysville City - Ward 3,Governor,,LBT,Keen Umbehr,3
-Marshall,Marysville City - Ward 4,Governor,,LBT,Keen Umbehr,11
-Marshall,Advance Voters,Governor,,LBT,Keen Umbehr,31
-Marshall,Provisional,Governor,,LBT,Keen Umbehr,2
-Marshall,Balderson Township,Governor,,R,Sam Brownback,16
-Marshall,Bigelow Township,Governor,,R,Sam Brownback,7
-Marshall,Blue Rapids Township,Governor,,R,Sam Brownback,12
-Marshall,Blue Rapids City Township,Governor,,R,Sam Brownback,127
-Marshall,Center Township,Governor,,R,Sam Brownback,20
-Marshall,Clear Fork Township,Governor,,R,Sam Brownback,6
-Marshall,Cleveland Township,Governor,,R,Sam Brownback,18
-Marshall,Cottage Hill Township,Governor,,R,Sam Brownback,43
-Marshall,Elm Creek Township,Governor,,R,Sam Brownback,27
-Marshall,Franklin Township-District 1,Governor,,R,Sam Brownback,27
-Marshall,Franklin Township-District 2,Governor,,R,Sam Brownback,18
-Marshall,Guittard Township-District 1,Governor,,R,Sam Brownback,2
-Marshall,Guittard Township-District 2,Governor,,R,Sam Brownback,66
-Marshall,Herkimer Township,Governor,,R,Sam Brownback,53
-Marshall,Lincoln Township,Governor,,R,Sam Brownback,37
-Marshall,Logan Township,Governor,,R,Sam Brownback,57
-Marshall,Marysville Township,Governor,,R,Sam Brownback,50
-Marshall,Murray Township,Governor,,R,Sam Brownback,122
-Marshall,Noble Township,Governor,,R,Sam Brownback,43
-Marshall,Oketo Township,Governor,,R,Sam Brownback,36
-Marshall,Richland Township,Governor,,R,Sam Brownback,47
-Marshall,Rock Township,Governor,,R,Sam Brownback,25
-Marshall,St. Bridget Township,Governor,,R,Sam Brownback,25
-Marshall,Vermillion Twp-East Precinct,Governor,,R,Sam Brownback,89
-Marshall,Vermillion Twp-West Precinct,Governor,,R,Sam Brownback,62
-Marshall,Walnut Township,Governor,,R,Sam Brownback,19
-Marshall,Waterville Township,Governor,,R,Sam Brownback,126
-Marshall,Wells Township,Governor,,R,Sam Brownback,22
-Marshall,Marysville City - Ward 1,Governor,,R,Sam Brownback,88
-Marshall,Marysville City - Ward 2,Governor,,R,Sam Brownback,84
-Marshall,Marysville City - Ward 3,Governor,,R,Sam Brownback,53
-Marshall,Marysville City - Ward 4,Governor,,R,Sam Brownback,87
-Marshall,Advance Voters,Governor,,R,Sam Brownback,442
-Marshall,Provisional,Governor,,R,Sam Brownback,34
-Marshall,Balderson Township,Secretary of State,,D,Jean Schodorf,4
-Marshall,Bigelow Township,Secretary of State,,D,Jean Schodorf,6
-Marshall,Blue Rapids Township,Secretary of State,,D,Jean Schodorf,6
-Marshall,Blue Rapids City Township,Secretary of State,,D,Jean Schodorf,69
-Marshall,Center Township,Secretary of State,,D,Jean Schodorf,8
-Marshall,Clear Fork Township,Secretary of State,,D,Jean Schodorf,3
-Marshall,Cleveland Township,Secretary of State,,D,Jean Schodorf,4
-Marshall,Cottage Hill Township,Secretary of State,,D,Jean Schodorf,7
-Marshall,Elm Creek Township,Secretary of State,,D,Jean Schodorf,18
-Marshall,Franklin Township-District 1,Secretary of State,,D,Jean Schodorf,11
-Marshall,Franklin Township-District 2,Secretary of State,,D,Jean Schodorf,9
-Marshall,Guittard Township-District 1,Secretary of State,,D,Jean Schodorf,0
-Marshall,Guittard Township-District 2,Secretary of State,,D,Jean Schodorf,48
-Marshall,Herkimer Township,Secretary of State,,D,Jean Schodorf,10
-Marshall,Lincoln Township,Secretary of State,,D,Jean Schodorf,9
-Marshall,Logan Township,Secretary of State,,D,Jean Schodorf,15
-Marshall,Marysville Township,Secretary of State,,D,Jean Schodorf,16
-Marshall,Murray Township,Secretary of State,,D,Jean Schodorf,71
-Marshall,Noble Township,Secretary of State,,D,Jean Schodorf,9
-Marshall,Oketo Township,Secretary of State,,D,Jean Schodorf,12
-Marshall,Richland Township,Secretary of State,,D,Jean Schodorf,21
-Marshall,Rock Township,Secretary of State,,D,Jean Schodorf,8
-Marshall,St. Bridget Township,Secretary of State,,D,Jean Schodorf,16
-Marshall,Vermillion Twp-East Precinct,Secretary of State,,D,Jean Schodorf,47
-Marshall,Vermillion Twp-West Precinct,Secretary of State,,D,Jean Schodorf,49
-Marshall,Walnut Township,Secretary of State,,D,Jean Schodorf,10
-Marshall,Waterville Township,Secretary of State,,D,Jean Schodorf,59
-Marshall,Wells Township,Secretary of State,,D,Jean Schodorf,14
-Marshall,Marysville City - Ward 1,Secretary of State,,D,Jean Schodorf,54
-Marshall,Marysville City - Ward 2,Secretary of State,,D,Jean Schodorf,38
-Marshall,Marysville City - Ward 3,Secretary of State,,D,Jean Schodorf,22
-Marshall,Marysville City - Ward 4,Secretary of State,,D,Jean Schodorf,48
-Marshall,Advance Voters,Secretary of State,,D,Jean Schodorf,396
-Marshall,Provisional,Secretary of State,,D,Jean Schodorf,20
-Marshall,Balderson Township,Secretary of State,,R,Kris Kobach,20
-Marshall,Bigelow Township,Secretary of State,,R,Kris Kobach,8
-Marshall,Blue Rapids Township,Secretary of State,,R,Kris Kobach,13
-Marshall,Blue Rapids City Township,Secretary of State,,R,Kris Kobach,167
-Marshall,Center Township,Secretary of State,,R,Kris Kobach,27
-Marshall,Clear Fork Township,Secretary of State,,R,Kris Kobach,11
-Marshall,Cleveland Township,Secretary of State,,R,Kris Kobach,24
-Marshall,Cottage Hill Township,Secretary of State,,R,Kris Kobach,55
-Marshall,Elm Creek Township,Secretary of State,,R,Kris Kobach,32
-Marshall,Franklin Township-District 1,Secretary of State,,R,Kris Kobach,37
-Marshall,Franklin Township-District 2,Secretary of State,,R,Kris Kobach,25
-Marshall,Guittard Township-District 1,Secretary of State,,R,Kris Kobach,3
-Marshall,Guittard Township-District 2,Secretary of State,,R,Kris Kobach,83
-Marshall,Herkimer Township,Secretary of State,,R,Kris Kobach,53
-Marshall,Lincoln Township,Secretary of State,,R,Kris Kobach,48
-Marshall,Logan Township,Secretary of State,,R,Kris Kobach,67
-Marshall,Marysville Township,Secretary of State,,R,Kris Kobach,62
-Marshall,Murray Township,Secretary of State,,R,Kris Kobach,150
-Marshall,Noble Township,Secretary of State,,R,Kris Kobach,53
-Marshall,Oketo Township,Secretary of State,,R,Kris Kobach,42
-Marshall,Richland Township,Secretary of State,,R,Kris Kobach,43
-Marshall,Rock Township,Secretary of State,,R,Kris Kobach,36
-Marshall,St. Bridget Township,Secretary of State,,R,Kris Kobach,33
-Marshall,Vermillion Twp-East Precinct,Secretary of State,,R,Kris Kobach,113
-Marshall,Vermillion Twp-West Precinct,Secretary of State,,R,Kris Kobach,93
-Marshall,Walnut Township,Secretary of State,,R,Kris Kobach,22
-Marshall,Waterville Township,Secretary of State,,R,Kris Kobach,160
-Marshall,Wells Township,Secretary of State,,R,Kris Kobach,29
-Marshall,Marysville City - Ward 1,Secretary of State,,R,Kris Kobach,131
-Marshall,Marysville City - Ward 2,Secretary of State,,R,Kris Kobach,105
-Marshall,Marysville City - Ward 3,Secretary of State,,R,Kris Kobach,75
-Marshall,Marysville City - Ward 4,Secretary of State,,R,Kris Kobach,127
-Marshall,Advance Voters,Secretary of State,,R,Kris Kobach,553
-Marshall,Provisional,Secretary of State,,R,Kris Kobach,37
-Marshall,Balderson Township,Attorney General,,R,Derek Schmidt,22
-Marshall,Bigelow Township,Attorney General,,R,Derek Schmidt,9
-Marshall,Blue Rapids Township,Attorney General,,R,Derek Schmidt,16
-Marshall,Blue Rapids City Township,Attorney General,,R,Derek Schmidt,182
-Marshall,Center Township,Attorney General,,R,Derek Schmidt,25
-Marshall,Clear Fork Township,Attorney General,,R,Derek Schmidt,11
-Marshall,Cleveland Township,Attorney General,,R,Derek Schmidt,24
-Marshall,Cottage Hill Township,Attorney General,,R,Derek Schmidt,54
-Marshall,Elm Creek Township,Attorney General,,R,Derek Schmidt,35
-Marshall,Franklin Township-District 1,Attorney General,,R,Derek Schmidt,36
-Marshall,Franklin Township-District 2,Attorney General,,R,Derek Schmidt,27
-Marshall,Guittard Township-District 1,Attorney General,,R,Derek Schmidt,3
-Marshall,Guittard Township-District 2,Attorney General,,R,Derek Schmidt,91
-Marshall,Herkimer Township,Attorney General,,R,Derek Schmidt,55
-Marshall,Lincoln Township,Attorney General,,R,Derek Schmidt,45
-Marshall,Logan Township,Attorney General,,R,Derek Schmidt,62
-Marshall,Marysville Township,Attorney General,,R,Derek Schmidt,66
-Marshall,Murray Township,Attorney General,,R,Derek Schmidt,162
-Marshall,Noble Township,Attorney General,,R,Derek Schmidt,52
-Marshall,Oketo Township,Attorney General,,R,Derek Schmidt,41
-Marshall,Richland Township,Attorney General,,R,Derek Schmidt,50
-Marshall,Rock Township,Attorney General,,R,Derek Schmidt,32
-Marshall,St. Bridget Township,Attorney General,,R,Derek Schmidt,31
-Marshall,Vermillion Twp-East Precinct,Attorney General,,R,Derek Schmidt,123
-Marshall,Vermillion Twp-West Precinct,Attorney General,,R,Derek Schmidt,103
-Marshall,Walnut Township,Attorney General,,R,Derek Schmidt,25
-Marshall,Waterville Township,Attorney General,,R,Derek Schmidt,170
-Marshall,Wells Township,Attorney General,,R,Derek Schmidt,26
-Marshall,Marysville City - Ward 1,Attorney General,,R,Derek Schmidt,134
-Marshall,Marysville City - Ward 2,Attorney General,,R,Derek Schmidt,105
-Marshall,Marysville City - Ward 3,Attorney General,,R,Derek Schmidt,74
-Marshall,Marysville City - Ward 4,Attorney General,,R,Derek Schmidt,134
-Marshall,Advance Voters,Attorney General,,R,Derek Schmidt,619
-Marshall,Provisional,Attorney General,,R,Derek Schmidt,40
-Marshall,Balderson Township,Attorney General,,D,A.J. Kotich,2
-Marshall,Bigelow Township,Attorney General,,D,A.J. Kotich,5
-Marshall,Blue Rapids Township,Attorney General,,D,A.J. Kotich,3
-Marshall,Blue Rapids City Township,Attorney General,,D,A.J. Kotich,51
-Marshall,Center Township,Attorney General,,D,A.J. Kotich,8
-Marshall,Clear Fork Township,Attorney General,,D,A.J. Kotich,3
-Marshall,Cleveland Township,Attorney General,,D,A.J. Kotich,3
-Marshall,Cottage Hill Township,Attorney General,,D,A.J. Kotich,6
-Marshall,Elm Creek Township,Attorney General,,D,A.J. Kotich,15
-Marshall,Franklin Township-District 1,Attorney General,,D,A.J. Kotich,11
-Marshall,Franklin Township-District 2,Attorney General,,D,A.J. Kotich,7
-Marshall,Guittard Township-District 1,Attorney General,,D,A.J. Kotich,0
-Marshall,Guittard Township-District 2,Attorney General,,D,A.J. Kotich,36
-Marshall,Herkimer Township,Attorney General,,D,A.J. Kotich,6
-Marshall,Lincoln Township,Attorney General,,D,A.J. Kotich,8
-Marshall,Logan Township,Attorney General,,D,A.J. Kotich,15
-Marshall,Marysville Township,Attorney General,,D,A.J. Kotich,12
-Marshall,Murray Township,Attorney General,,D,A.J. Kotich,50
-Marshall,Noble Township,Attorney General,,D,A.J. Kotich,10
-Marshall,Oketo Township,Attorney General,,D,A.J. Kotich,14
-Marshall,Richland Township,Attorney General,,D,A.J. Kotich,14
-Marshall,Rock Township,Attorney General,,D,A.J. Kotich,8
-Marshall,St. Bridget Township,Attorney General,,D,A.J. Kotich,14
-Marshall,Vermillion Twp-East Precinct,Attorney General,,D,A.J. Kotich,36
-Marshall,Vermillion Twp-West Precinct,Attorney General,,D,A.J. Kotich,37
-Marshall,Walnut Township,Attorney General,,D,A.J. Kotich,6
-Marshall,Waterville Township,Attorney General,,D,A.J. Kotich,49
-Marshall,Wells Township,Attorney General,,D,A.J. Kotich,14
-Marshall,Marysville City - Ward 1,Attorney General,,D,A.J. Kotich,51
-Marshall,Marysville City - Ward 2,Attorney General,,D,A.J. Kotich,36
-Marshall,Marysville City - Ward 3,Attorney General,,D,A.J. Kotich,24
-Marshall,Marysville City - Ward 4,Attorney General,,D,A.J. Kotich,38
-Marshall,Advance Voters,Attorney General,,D,A.J. Kotich,314
-Marshall,Provisional,Attorney General,,D,A.J. Kotich,15
-Marshall,Balderson Township,State Treasurer,,R,Ron Estes,18
-Marshall,Bigelow Township,State Treasurer,,R,Ron Estes,9
-Marshall,Blue Rapids Township,State Treasurer,,R,Ron Estes,14
-Marshall,Blue Rapids City Township,State Treasurer,,R,Ron Estes,189
-Marshall,Center Township,State Treasurer,,R,Ron Estes,25
-Marshall,Clear Fork Township,State Treasurer,,R,Ron Estes,11
-Marshall,Cleveland Township,State Treasurer,,R,Ron Estes,25
-Marshall,Cottage Hill Township,State Treasurer,,R,Ron Estes,53
-Marshall,Elm Creek Township,State Treasurer,,R,Ron Estes,35
-Marshall,Franklin Township-District 1,State Treasurer,,R,Ron Estes,35
-Marshall,Franklin Township-District 2,State Treasurer,,R,Ron Estes,27
-Marshall,Guittard Township-District 1,State Treasurer,,R,Ron Estes,2
-Marshall,Guittard Township-District 2,State Treasurer,,R,Ron Estes,90
-Marshall,Herkimer Township,State Treasurer,,R,Ron Estes,55
-Marshall,Lincoln Township,State Treasurer,,R,Ron Estes,50
-Marshall,Logan Township,State Treasurer,,R,Ron Estes,66
-Marshall,Marysville Township,State Treasurer,,R,Ron Estes,64
-Marshall,Murray Township,State Treasurer,,R,Ron Estes,151
-Marshall,Noble Township,State Treasurer,,R,Ron Estes,53
-Marshall,Oketo Township,State Treasurer,,R,Ron Estes,34
-Marshall,Richland Township,State Treasurer,,R,Ron Estes,48
-Marshall,Rock Township,State Treasurer,,R,Ron Estes,33
-Marshall,St. Bridget Township,State Treasurer,,R,Ron Estes,34
-Marshall,Vermillion Twp-East Precinct,State Treasurer,,R,Ron Estes,124
-Marshall,Vermillion Twp-West Precinct,State Treasurer,,R,Ron Estes,101
-Marshall,Walnut Township,State Treasurer,,R,Ron Estes,26
-Marshall,Waterville Township,State Treasurer,,R,Ron Estes,167
-Marshall,Wells Township,State Treasurer,,R,Ron Estes,31
-Marshall,Marysville City - Ward 1,State Treasurer,,R,Ron Estes,135
-Marshall,Marysville City - Ward 2,State Treasurer,,R,Ron Estes,95
-Marshall,Marysville City - Ward 3,State Treasurer,,R,Ron Estes,76
-Marshall,Marysville City - Ward 4,State Treasurer,,R,Ron Estes,127
-Marshall,Advance Voters,State Treasurer,,R,Ron Estes,589
-Marshall,Provisional,State Treasurer,,R,Ron Estes,37
-Marshall,Balderson Township,State Treasurer,,D,Carmen Alldritt,6
-Marshall,Bigelow Township,State Treasurer,,D,Carmen Alldritt,5
-Marshall,Blue Rapids Township,State Treasurer,,D,Carmen Alldritt,3
-Marshall,Blue Rapids City Township,State Treasurer,,D,Carmen Alldritt,45
-Marshall,Center Township,State Treasurer,,D,Carmen Alldritt,9
-Marshall,Clear Fork Township,State Treasurer,,D,Carmen Alldritt,3
-Marshall,Cleveland Township,State Treasurer,,D,Carmen Alldritt,3
-Marshall,Cottage Hill Township,State Treasurer,,D,Carmen Alldritt,4
-Marshall,Elm Creek Township,State Treasurer,,D,Carmen Alldritt,15
-Marshall,Franklin Township-District 1,State Treasurer,,D,Carmen Alldritt,13
-Marshall,Franklin Township-District 2,State Treasurer,,D,Carmen Alldritt,7
-Marshall,Guittard Township-District 1,State Treasurer,,D,Carmen Alldritt,1
-Marshall,Guittard Township-District 2,State Treasurer,,D,Carmen Alldritt,37
-Marshall,Herkimer Township,State Treasurer,,D,Carmen Alldritt,7
-Marshall,Lincoln Township,State Treasurer,,D,Carmen Alldritt,3
-Marshall,Logan Township,State Treasurer,,D,Carmen Alldritt,13
-Marshall,Marysville Township,State Treasurer,,D,Carmen Alldritt,13
-Marshall,Murray Township,State Treasurer,,D,Carmen Alldritt,54
-Marshall,Noble Township,State Treasurer,,D,Carmen Alldritt,8
-Marshall,Oketo Township,State Treasurer,,D,Carmen Alldritt,19
-Marshall,Richland Township,State Treasurer,,D,Carmen Alldritt,16
-Marshall,Rock Township,State Treasurer,,D,Carmen Alldritt,10
-Marshall,St. Bridget Township,State Treasurer,,D,Carmen Alldritt,12
-Marshall,Vermillion Twp-East Precinct,State Treasurer,,D,Carmen Alldritt,34
-Marshall,Vermillion Twp-West Precinct,State Treasurer,,D,Carmen Alldritt,37
-Marshall,Walnut Township,State Treasurer,,D,Carmen Alldritt,6
-Marshall,Waterville Township,State Treasurer,,D,Carmen Alldritt,51
-Marshall,Wells Township,State Treasurer,,D,Carmen Alldritt,7
-Marshall,Marysville City - Ward 1,State Treasurer,,D,Carmen Alldritt,49
-Marshall,Marysville City - Ward 2,State Treasurer,,D,Carmen Alldritt,43
-Marshall,Marysville City - Ward 3,State Treasurer,,D,Carmen Alldritt,21
-Marshall,Marysville City - Ward 4,State Treasurer,,D,Carmen Alldritt,46
-Marshall,Advance Voters,State Treasurer,,D,Carmen Alldritt,335
-Marshall,Provisional,State Treasurer,,D,Carmen Alldritt,16
-Marshall,Balderson Township,Insurance Commissioner,,R,Ken Selzer,21
-Marshall,Bigelow Township,Insurance Commissioner,,R,Ken Selzer,8
-Marshall,Blue Rapids Township,Insurance Commissioner,,R,Ken Selzer,13
-Marshall,Blue Rapids City Township,Insurance Commissioner,,R,Ken Selzer,166
-Marshall,Center Township,Insurance Commissioner,,R,Ken Selzer,23
-Marshall,Clear Fork Township,Insurance Commissioner,,R,Ken Selzer,9
-Marshall,Cleveland Township,Insurance Commissioner,,R,Ken Selzer,19
-Marshall,Cottage Hill Township,Insurance Commissioner,,R,Ken Selzer,44
-Marshall,Elm Creek Township,Insurance Commissioner,,R,Ken Selzer,27
-Marshall,Franklin Township-District 1,Insurance Commissioner,,R,Ken Selzer,34
-Marshall,Franklin Township-District 2,Insurance Commissioner,,R,Ken Selzer,24
-Marshall,Guittard Township-District 1,Insurance Commissioner,,R,Ken Selzer,2
-Marshall,Guittard Township-District 2,Insurance Commissioner,,R,Ken Selzer,78
-Marshall,Herkimer Township,Insurance Commissioner,,R,Ken Selzer,51
-Marshall,Lincoln Township,Insurance Commissioner,,R,Ken Selzer,48
-Marshall,Logan Township,Insurance Commissioner,,R,Ken Selzer,62
-Marshall,Marysville Township,Insurance Commissioner,,R,Ken Selzer,60
-Marshall,Murray Township,Insurance Commissioner,,R,Ken Selzer,132
-Marshall,Noble Township,Insurance Commissioner,,R,Ken Selzer,52
-Marshall,Oketo Township,Insurance Commissioner,,R,Ken Selzer,35
-Marshall,Richland Township,Insurance Commissioner,,R,Ken Selzer,46
-Marshall,Rock Township,Insurance Commissioner,,R,Ken Selzer,31
-Marshall,St. Bridget Township,Insurance Commissioner,,R,Ken Selzer,29
-Marshall,Vermillion Twp-East Precinct,Insurance Commissioner,,R,Ken Selzer,103
-Marshall,Vermillion Twp-West Precinct,Insurance Commissioner,,R,Ken Selzer,94
-Marshall,Walnut Township,Insurance Commissioner,,R,Ken Selzer,26
-Marshall,Waterville Township,Insurance Commissioner,,R,Ken Selzer,147
-Marshall,Wells Township,Insurance Commissioner,,R,Ken Selzer,28
-Marshall,Marysville City - Ward 1,Insurance Commissioner,,R,Ken Selzer,123
-Marshall,Marysville City - Ward 2,Insurance Commissioner,,R,Ken Selzer,88
-Marshall,Marysville City - Ward 3,Insurance Commissioner,,R,Ken Selzer,67
-Marshall,Marysville City - Ward 4,Insurance Commissioner,,R,Ken Selzer,121
-Marshall,Advance Voters,Insurance Commissioner,,R,Ken Selzer,538
-Marshall,Provisional,Insurance Commissioner,,R,Ken Selzer,32
-Marshall,Balderson Township,Insurance Commissioner,,D,Dennis Anderson,3
-Marshall,Bigelow Township,Insurance Commissioner,,D,Dennis Anderson,6
-Marshall,Blue Rapids Township,Insurance Commissioner,,D,Dennis Anderson,3
-Marshall,Blue Rapids City Township,Insurance Commissioner,,D,Dennis Anderson,64
-Marshall,Center Township,Insurance Commissioner,,D,Dennis Anderson,10
-Marshall,Clear Fork Township,Insurance Commissioner,,D,Dennis Anderson,5
-Marshall,Cleveland Township,Insurance Commissioner,,D,Dennis Anderson,9
-Marshall,Cottage Hill Township,Insurance Commissioner,,D,Dennis Anderson,10
-Marshall,Elm Creek Township,Insurance Commissioner,,D,Dennis Anderson,22
-Marshall,Franklin Township-District 1,Insurance Commissioner,,D,Dennis Anderson,14
-Marshall,Franklin Township-District 2,Insurance Commissioner,,D,Dennis Anderson,9
-Marshall,Guittard Township-District 1,Insurance Commissioner,,D,Dennis Anderson,1
-Marshall,Guittard Township-District 2,Insurance Commissioner,,D,Dennis Anderson,45
-Marshall,Herkimer Township,Insurance Commissioner,,D,Dennis Anderson,9
-Marshall,Lincoln Township,Insurance Commissioner,,D,Dennis Anderson,4
-Marshall,Logan Township,Insurance Commissioner,,D,Dennis Anderson,16
-Marshall,Marysville Township,Insurance Commissioner,,D,Dennis Anderson,15
-Marshall,Murray Township,Insurance Commissioner,,D,Dennis Anderson,70
-Marshall,Noble Township,Insurance Commissioner,,D,Dennis Anderson,9
-Marshall,Oketo Township,Insurance Commissioner,,D,Dennis Anderson,20
-Marshall,Richland Township,Insurance Commissioner,,D,Dennis Anderson,16
-Marshall,Rock Township,Insurance Commissioner,,D,Dennis Anderson,9
-Marshall,St. Bridget Township,Insurance Commissioner,,D,Dennis Anderson,13
-Marshall,Vermillion Twp-East Precinct,Insurance Commissioner,,D,Dennis Anderson,50
-Marshall,Vermillion Twp-West Precinct,Insurance Commissioner,,D,Dennis Anderson,42
-Marshall,Walnut Township,Insurance Commissioner,,D,Dennis Anderson,6
-Marshall,Waterville Township,Insurance Commissioner,,D,Dennis Anderson,60
-Marshall,Wells Township,Insurance Commissioner,,D,Dennis Anderson,10
-Marshall,Marysville City - Ward 1,Insurance Commissioner,,D,Dennis Anderson,56
-Marshall,Marysville City - Ward 2,Insurance Commissioner,,D,Dennis Anderson,47
-Marshall,Marysville City - Ward 3,Insurance Commissioner,,D,Dennis Anderson,29
-Marshall,Marysville City - Ward 4,Insurance Commissioner,,D,Dennis Anderson,50
-Marshall,Advance Voters,Insurance Commissioner,,D,Dennis Anderson,372
-Marshall,Provisional,Insurance Commissioner,,D,Dennis Anderson,22
-Marshall,Balderson Township,State House,106,R,Schwartz,20
-Marshall,Bigelow Township,State House,106,R,Schwartz,11
-Marshall,Blue Rapids Township,State House,106,R,Schwartz,15
-Marshall,Blue Rapids City Township,State House,106,R,Schwartz,205
-Marshall,Center Township,State House,106,R,Schwartz,30
-Marshall,Clear Fork Township,State House,106,R,Schwartz,12
-Marshall,Cleveland Township,State House,106,R,Schwartz,23
-Marshall,Cottage Hill Township,State House,106,R,Schwartz,56
-Marshall,Elm Creek Township,State House,106,R,Schwartz,40
-Marshall,Franklin Township-District 1,State House,106,R,Schwartz,42
-Marshall,Franklin Township-District 2,State House,106,R,Schwartz,31
-Marshall,Guittard Township-District 1,State House,106,R,Schwartz,3
-Marshall,Guittard Township-District 2,State House,106,R,Schwartz,111
-Marshall,Herkimer Township,State House,106,R,Schwartz,60
-Marshall,Lincoln Township,State House,106,R,Schwartz,48
-Marshall,Logan Township,State House,106,R,Schwartz,72
-Marshall,Marysville Township,State House,106,R,Schwartz,68
-Marshall,Murray Township,State House,106,R,Schwartz,195
-Marshall,Noble Township,State House,106,R,Schwartz,59
-Marshall,Oketo Township,State House,106,R,Schwartz,50
-Marshall,Richland Township,State House,106,R,Schwartz,63
-Marshall,Rock Township,State House,106,R,Schwartz,41
-Marshall,St. Bridget Township,State House,106,R,Schwartz,39
-Marshall,Vermillion Twp-East Precinct,State House,106,R,Schwartz,129
-Marshall,Vermillion Twp-West Precinct,State House,106,R,Schwartz,125
-Marshall,Walnut Township,State House,106,R,Schwartz,28
-Marshall,Waterville Township,State House,106,R,Schwartz,186
-Marshall,Wells Township,State House,106,R,Schwartz,34
-Marshall,Marysville City - Ward 1,State House,106,R,Schwartz,176
-Marshall,Marysville City - Ward 2,State House,106,R,Schwartz,121
-Marshall,Marysville City - Ward 3,State House,106,R,Schwartz,86
-Marshall,Marysville City - Ward 4,State House,106,R,Schwartz,147
-Marshall,Advance Voters,State House,106,R,Schwartz,763
-Marshall,Provisional,State House,106,R,Schwartz,53
+county,precinct,office,district,party,candidate,votes,vtd
+MARSHALL,Balderson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000010
+MARSHALL,Balderson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+MARSHALL,Balderson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000010
+MARSHALL,Bigelow Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000020
+MARSHALL,Bigelow Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+MARSHALL,Bigelow Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000020
+MARSHALL,Blue Rapids City,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000030
+MARSHALL,Blue Rapids City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000030
+MARSHALL,Blue Rapids City,Governor / Lt. Governor,,Republican,"Brownback, Sam",162,000030
+MARSHALL,Blue Rapids Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000040
+MARSHALL,Blue Rapids Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+MARSHALL,Blue Rapids Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000040
+MARSHALL,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000050
+MARSHALL,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000050
+MARSHALL,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000050
+MARSHALL,Clear Fork Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000060
+MARSHALL,Clear Fork Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+MARSHALL,Clear Fork Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",6,000060
+MARSHALL,Cleveland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000070
+MARSHALL,Cleveland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+MARSHALL,Cleveland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000070
+MARSHALL,Cottage Hill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000080
+MARSHALL,Cottage Hill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+MARSHALL,Cottage Hill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000080
+MARSHALL,East Vermillion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000090
+MARSHALL,East Vermillion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000090
+MARSHALL,East Vermillion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",104,000090
+MARSHALL,Elm Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000100
+MARSHALL,Elm Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000100
+MARSHALL,Elm Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000100
+MARSHALL,Herkimer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000130
+MARSHALL,Herkimer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000130
+MARSHALL,Herkimer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",78,000130
+MARSHALL,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000140
+MARSHALL,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000140
+MARSHALL,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000140
+MARSHALL,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000150
+MARSHALL,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000150
+MARSHALL,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",74,000150
+MARSHALL,Marysville City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",173,000160
+MARSHALL,Marysville City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000160
+MARSHALL,Marysville City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",165,000160
+MARSHALL,Marysville City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",120,00017A
+MARSHALL,Marysville City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00017A
+MARSHALL,Marysville City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",131,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00017B
+MARSHALL,Marysville City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,00018A
+MARSHALL,Marysville City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,00018A
+MARSHALL,Marysville City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",149,00019A
+MARSHALL,Marysville City Ward 4 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00019A
+MARSHALL,Marysville City Ward 4 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",138,00019A
+MARSHALL,Marysville City Ward 4 Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00019C
+MARSHALL,Marysville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000200
+MARSHALL,Marysville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000200
+MARSHALL,Marysville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000200
+MARSHALL,Murray Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",97,000210
+MARSHALL,Murray Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000210
+MARSHALL,Murray Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",137,000210
+MARSHALL,Noble Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000220
+MARSHALL,Noble Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000220
+MARSHALL,Noble Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000220
+MARSHALL,Oketo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000230
+MARSHALL,Oketo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000230
+MARSHALL,Oketo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000230
+MARSHALL,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000240
+MARSHALL,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000240
+MARSHALL,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000240
+MARSHALL,Rock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000250
+MARSHALL,Rock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000250
+MARSHALL,Rock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000250
+MARSHALL,St. Bridget Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000260
+MARSHALL,St. Bridget Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000260
+MARSHALL,St. Bridget Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000260
+MARSHALL,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000270
+MARSHALL,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000270
+MARSHALL,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000270
+MARSHALL,Waterville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",109,000280
+MARSHALL,Waterville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000280
+MARSHALL,Waterville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",145,000280
+MARSHALL,Wells Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000290
+MARSHALL,Wells Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000290
+MARSHALL,Wells Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000290
+MARSHALL,West Vermillion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",80,000300
+MARSHALL,West Vermillion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000300
+MARSHALL,West Vermillion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000300
+MARSHALL,Franklin Township C1,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,120020
+MARSHALL,Franklin Township C1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120020
+MARSHALL,Franklin Township C1,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,120020
+MARSHALL,Franklin Township C2,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,120030
+MARSHALL,Franklin Township C2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120030
+MARSHALL,Franklin Township C2,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,120030
+MARSHALL,Guittard Township C1,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120040
+MARSHALL,Guittard Township C1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120040
+MARSHALL,Guittard Township C1,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,120040
+MARSHALL,Guittard Township C2,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,120050
+MARSHALL,Guittard Township C2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120050
+MARSHALL,Guittard Township C2,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,120050
+MARSHALL,Balderson Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",29,000010
+MARSHALL,Bigelow Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",11,000020
+MARSHALL,Blue Rapids City,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",264,000030
+MARSHALL,Blue Rapids Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",28,000040
+MARSHALL,Center Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",42,000050
+MARSHALL,Clear Fork Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",13,000060
+MARSHALL,Cleveland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",29,000070
+MARSHALL,Cottage Hill Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",57,000080
+MARSHALL,East Vermillion Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",159,000090
+MARSHALL,Elm Creek Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",57,000100
+MARSHALL,Herkimer Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",86,000130
+MARSHALL,Lincoln Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",53,000140
+MARSHALL,Logan Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",99,000150
+MARSHALL,Marysville City Ward 1,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",304,000160
+MARSHALL,Marysville City Ward 2,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",209,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00017B
+MARSHALL,Marysville City Ward 3,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",150,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",241,00019A
+MARSHALL,Marysville City Ward 4 Part B,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00019C
+MARSHALL,Marysville Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",103,000200
+MARSHALL,Murray Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",213,000210
+MARSHALL,Noble Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",71,000220
+MARSHALL,Oketo Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",76,000230
+MARSHALL,Richland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",69,000240
+MARSHALL,Rock Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",51,000250
+MARSHALL,St. Bridget Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",46,000260
+MARSHALL,Walnut Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",47,000270
+MARSHALL,Waterville Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",226,000280
+MARSHALL,Wells Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",42,000290
+MARSHALL,West Vermillion Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",142,000300
+MARSHALL,Franklin Township C1,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",55,120020
+MARSHALL,Franklin Township C2,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",50,120030
+MARSHALL,Guittard Township C1,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",3,120040
+MARSHALL,Guittard Township C2,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",117,120050
+MARSHALL,Balderson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000010
+MARSHALL,Balderson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000010
+MARSHALL,Bigelow Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,000020
+MARSHALL,Bigelow Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000020
+MARSHALL,Bigelow Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",9,000020
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Democratic,"Wakefield, Margie",90,000030
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000030
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Republican,"Jenkins, Lynn",202,000030
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",8,000040
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000040
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",24,000040
+MARSHALL,Center Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000050
+MARSHALL,Center Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000050
+MARSHALL,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000050
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,000060
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000060
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",10,000060
+MARSHALL,Cleveland Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000070
+MARSHALL,Cleveland Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000070
+MARSHALL,Cleveland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",26,000070
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000080
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000080
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,000080
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",59,000090
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000090
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,000090
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,000100
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000100
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000100
+MARSHALL,Herkimer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000130
+MARSHALL,Herkimer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000130
+MARSHALL,Lincoln Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,000140
+MARSHALL,Lincoln Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000140
+MARSHALL,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000140
+MARSHALL,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000150
+MARSHALL,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000150
+MARSHALL,Marysville City Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",134,000160
+MARSHALL,Marysville City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",219,000160
+MARSHALL,Marysville City Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",98,00017A
+MARSHALL,Marysville City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",160,00017A
+MARSHALL,Marysville City Ward 2 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00017B
+MARSHALL,Marysville City Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",74,00018A
+MARSHALL,Marysville City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,00018A
+MARSHALL,Marysville City Ward 3 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",108,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",191,00019A
+MARSHALL,Marysville City Ward 4 Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019C
+MARSHALL,Marysville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",47,000200
+MARSHALL,Marysville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",79,000200
+MARSHALL,Murray Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",65,000210
+MARSHALL,Murray Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000210
+MARSHALL,Murray Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",165,000210
+MARSHALL,Noble Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,000220
+MARSHALL,Noble Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000220
+MARSHALL,Noble Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000220
+MARSHALL,Oketo Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000230
+MARSHALL,Oketo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000230
+MARSHALL,Richland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000240
+MARSHALL,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,000240
+MARSHALL,Rock Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",10,000250
+MARSHALL,Rock Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000250
+MARSHALL,Rock Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,000250
+MARSHALL,St. Bridget Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000260
+MARSHALL,St. Bridget Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000260
+MARSHALL,Walnut Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",11,000270
+MARSHALL,Walnut Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000270
+MARSHALL,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,000270
+MARSHALL,Waterville Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",80,000280
+MARSHALL,Waterville Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000280
+MARSHALL,Waterville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,000280
+MARSHALL,Wells Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000290
+MARSHALL,Wells Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000290
+MARSHALL,Wells Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",32,000290
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",48,000300
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000300
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",107,000300
+MARSHALL,Franklin Township C1,United States House of Representatives,1,Democratic,"Sherow, James E.",28,120020
+MARSHALL,Franklin Township C1,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,120020
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,120030
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120030
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,120030
+MARSHALL,Guittard Township C1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120040
+MARSHALL,Guittard Township C1,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,120040
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Democratic,"Wakefield, Margie",44,120050
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,120050
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",95,120050
+MARSHALL,Balderson Township,Attorney General,,Democratic,"Kotich, A.J.",4,000010
+MARSHALL,Balderson Township,Attorney General,,Republican,"Schmidt, Derek",29,000010
+MARSHALL,Bigelow Township,Attorney General,,Democratic,"Kotich, A.J.",5,000020
+MARSHALL,Bigelow Township,Attorney General,,Republican,"Schmidt, Derek",10,000020
+MARSHALL,Blue Rapids City,Attorney General,,Democratic,"Kotich, A.J.",72,000030
+MARSHALL,Blue Rapids City,Attorney General,,Republican,"Schmidt, Derek",230,000030
+MARSHALL,Blue Rapids Township,Attorney General,,Democratic,"Kotich, A.J.",7,000040
+MARSHALL,Blue Rapids Township,Attorney General,,Republican,"Schmidt, Derek",26,000040
+MARSHALL,Center Township,Attorney General,,Democratic,"Kotich, A.J.",8,000050
+MARSHALL,Center Township,Attorney General,,Republican,"Schmidt, Derek",37,000050
+MARSHALL,Clear Fork Township,Attorney General,,Democratic,"Kotich, A.J.",5,000060
+MARSHALL,Clear Fork Township,Attorney General,,Republican,"Schmidt, Derek",11,000060
+MARSHALL,Cleveland Township,Attorney General,,Democratic,"Kotich, A.J.",9,000070
+MARSHALL,Cleveland Township,Attorney General,,Republican,"Schmidt, Derek",31,000070
+MARSHALL,Cottage Hill Township,Attorney General,,Democratic,"Kotich, A.J.",6,000080
+MARSHALL,Cottage Hill Township,Attorney General,,Republican,"Schmidt, Derek",55,000080
+MARSHALL,East Vermillion Township,Attorney General,,Democratic,"Kotich, A.J.",48,000090
+MARSHALL,East Vermillion Township,Attorney General,,Republican,"Schmidt, Derek",140,000090
+MARSHALL,Elm Creek Township,Attorney General,,Democratic,"Kotich, A.J.",20,000100
+MARSHALL,Elm Creek Township,Attorney General,,Republican,"Schmidt, Derek",47,000100
+MARSHALL,Herkimer Township,Attorney General,,Democratic,"Kotich, A.J.",10,000130
+MARSHALL,Herkimer Township,Attorney General,,Republican,"Schmidt, Derek",78,000130
+MARSHALL,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",8,000140
+MARSHALL,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",50,000140
+MARSHALL,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",24,000150
+MARSHALL,Logan Township,Attorney General,,Republican,"Schmidt, Derek",87,000150
+MARSHALL,Marysville City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",112,000160
+MARSHALL,Marysville City Ward 1,Attorney General,,Republican,"Schmidt, Derek",230,000160
+MARSHALL,Marysville City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",75,00017A
+MARSHALL,Marysville City Ward 2,Attorney General,,Republican,"Schmidt, Derek",180,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00017B
+MARSHALL,Marysville City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",52,00018A
+MARSHALL,Marysville City Ward 3,Attorney General,,Republican,"Schmidt, Derek",127,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Attorney General,,Democratic,"Kotich, A.J.",85,00019A
+MARSHALL,Marysville City Ward 4 Part A,Attorney General,,Republican,"Schmidt, Derek",209,00019A
+MARSHALL,Marysville City Ward 4 Part B,Attorney General,,Democratic,"Kotich, A.J.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Attorney General,,Republican,"Schmidt, Derek",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00019C
+MARSHALL,Marysville Township,Attorney General,,Democratic,"Kotich, A.J.",28,000200
+MARSHALL,Marysville Township,Attorney General,,Republican,"Schmidt, Derek",94,000200
+MARSHALL,Murray Township,Attorney General,,Democratic,"Kotich, A.J.",56,000210
+MARSHALL,Murray Township,Attorney General,,Republican,"Schmidt, Derek",178,000210
+MARSHALL,Noble Township,Attorney General,,Democratic,"Kotich, A.J.",18,000220
+MARSHALL,Noble Township,Attorney General,,Republican,"Schmidt, Derek",60,000220
+MARSHALL,Oketo Township,Attorney General,,Democratic,"Kotich, A.J.",32,000230
+MARSHALL,Oketo Township,Attorney General,,Republican,"Schmidt, Derek",56,000230
+MARSHALL,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",14,000240
+MARSHALL,Richland Township,Attorney General,,Republican,"Schmidt, Derek",57,000240
+MARSHALL,Rock Township,Attorney General,,Democratic,"Kotich, A.J.",10,000250
+MARSHALL,Rock Township,Attorney General,,Republican,"Schmidt, Derek",40,000250
+MARSHALL,St. Bridget Township,Attorney General,,Democratic,"Kotich, A.J.",17,000260
+MARSHALL,St. Bridget Township,Attorney General,,Republican,"Schmidt, Derek",38,000260
+MARSHALL,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",10,000270
+MARSHALL,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",42,000270
+MARSHALL,Waterville Township,Attorney General,,Democratic,"Kotich, A.J.",62,000280
+MARSHALL,Waterville Township,Attorney General,,Republican,"Schmidt, Derek",203,000280
+MARSHALL,Wells Township,Attorney General,,Democratic,"Kotich, A.J.",16,000290
+MARSHALL,Wells Township,Attorney General,,Republican,"Schmidt, Derek",32,000290
+MARSHALL,West Vermillion Township,Attorney General,,Democratic,"Kotich, A.J.",40,000300
+MARSHALL,West Vermillion Township,Attorney General,,Republican,"Schmidt, Derek",116,000300
+MARSHALL,Franklin Township C1,Attorney General,,Democratic,"Kotich, A.J.",20,120020
+MARSHALL,Franklin Township C1,Attorney General,,Republican,"Schmidt, Derek",44,120020
+MARSHALL,Franklin Township C2,Attorney General,,Democratic,"Kotich, A.J.",8,120030
+MARSHALL,Franklin Township C2,Attorney General,,Republican,"Schmidt, Derek",45,120030
+MARSHALL,Guittard Township C1,Attorney General,,Democratic,"Kotich, A.J.",0,120040
+MARSHALL,Guittard Township C1,Attorney General,,Republican,"Schmidt, Derek",3,120040
+MARSHALL,Guittard Township C2,Attorney General,,Democratic,"Kotich, A.J.",40,120050
+MARSHALL,Guittard Township C2,Attorney General,,Republican,"Schmidt, Derek",99,120050
+MARSHALL,Balderson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000010
+MARSHALL,Balderson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000010
+MARSHALL,Bigelow Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000020
+MARSHALL,Bigelow Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000020
+MARSHALL,Blue Rapids City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,000030
+MARSHALL,Blue Rapids City,Commissioner of Insurance,,Republican,"Selzer, Ken",199,000030
+MARSHALL,Blue Rapids Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000040
+MARSHALL,Blue Rapids Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000040
+MARSHALL,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000050
+MARSHALL,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000050
+MARSHALL,Clear Fork Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000060
+MARSHALL,Clear Fork Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000060
+MARSHALL,Cleveland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000070
+MARSHALL,Cleveland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000070
+MARSHALL,Cottage Hill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000080
+MARSHALL,Cottage Hill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000080
+MARSHALL,East Vermillion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,000090
+MARSHALL,East Vermillion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",118,000090
+MARSHALL,Elm Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000100
+MARSHALL,Elm Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000100
+MARSHALL,Herkimer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000130
+MARSHALL,Herkimer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000130
+MARSHALL,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000140
+MARSHALL,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000140
+MARSHALL,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000150
+MARSHALL,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",80,000150
+MARSHALL,Marysville City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",122,000160
+MARSHALL,Marysville City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",212,000160
+MARSHALL,Marysville City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",95,00017A
+MARSHALL,Marysville City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",151,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00017B
+MARSHALL,Marysville City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,00018A
+MARSHALL,Marysville City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",107,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",96,00019A
+MARSHALL,Marysville City Ward 4 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",194,00019A
+MARSHALL,Marysville City Ward 4 Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00019C
+MARSHALL,Marysville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000200
+MARSHALL,Marysville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",81,000200
+MARSHALL,Murray Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000210
+MARSHALL,Murray Township,Commissioner of Insurance,,Republican,"Selzer, Ken",149,000210
+MARSHALL,Noble Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000220
+MARSHALL,Noble Township,Commissioner of Insurance,,Republican,"Selzer, Ken",60,000220
+MARSHALL,Oketo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000230
+MARSHALL,Oketo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000230
+MARSHALL,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000240
+MARSHALL,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",52,000240
+MARSHALL,Rock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000250
+MARSHALL,Rock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000250
+MARSHALL,St. Bridget Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000260
+MARSHALL,St. Bridget Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000260
+MARSHALL,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000270
+MARSHALL,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000270
+MARSHALL,Waterville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000280
+MARSHALL,Waterville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",174,000280
+MARSHALL,Wells Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000290
+MARSHALL,Wells Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000290
+MARSHALL,West Vermillion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,000300
+MARSHALL,West Vermillion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000300
+MARSHALL,Franklin Township C1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,120020
+MARSHALL,Franklin Township C1,Commissioner of Insurance,,Republican,"Selzer, Ken",42,120020
+MARSHALL,Franklin Township C2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,120030
+MARSHALL,Franklin Township C2,Commissioner of Insurance,,Republican,"Selzer, Ken",41,120030
+MARSHALL,Guittard Township C1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,120040
+MARSHALL,Guittard Township C1,Commissioner of Insurance,,Republican,"Selzer, Ken",2,120040
+MARSHALL,Guittard Township C2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,120050
+MARSHALL,Guittard Township C2,Commissioner of Insurance,,Republican,"Selzer, Ken",85,120050
+MARSHALL,Balderson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000010
+MARSHALL,Balderson Township,Secretary of State,,Republican,"Kobach, Kris",28,000010
+MARSHALL,Bigelow Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000020
+MARSHALL,Bigelow Township,Secretary of State,,Republican,"Kobach, Kris",9,000020
+MARSHALL,Blue Rapids City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",99,000030
+MARSHALL,Blue Rapids City,Secretary of State,,Republican,"Kobach, Kris",203,000030
+MARSHALL,Blue Rapids Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000040
+MARSHALL,Blue Rapids Township,Secretary of State,,Republican,"Kobach, Kris",23,000040
+MARSHALL,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000050
+MARSHALL,Center Township,Secretary of State,,Republican,"Kobach, Kris",39,000050
+MARSHALL,Clear Fork Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000060
+MARSHALL,Clear Fork Township,Secretary of State,,Republican,"Kobach, Kris",11,000060
+MARSHALL,Cleveland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000070
+MARSHALL,Cleveland Township,Secretary of State,,Republican,"Kobach, Kris",26,000070
+MARSHALL,Cottage Hill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000080
+MARSHALL,Cottage Hill Township,Secretary of State,,Republican,"Kobach, Kris",56,000080
+MARSHALL,East Vermillion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000090
+MARSHALL,East Vermillion Township,Secretary of State,,Republican,"Kobach, Kris",131,000090
+MARSHALL,Elm Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000100
+MARSHALL,Elm Creek Township,Secretary of State,,Republican,"Kobach, Kris",44,000100
+MARSHALL,Herkimer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000130
+MARSHALL,Herkimer Township,Secretary of State,,Republican,"Kobach, Kris",78,000130
+MARSHALL,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000140
+MARSHALL,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",51,000140
+MARSHALL,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000150
+MARSHALL,Logan Township,Secretary of State,,Republican,"Kobach, Kris",87,000150
+MARSHALL,Marysville City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",121,000160
+MARSHALL,Marysville City Ward 1,Secretary of State,,Republican,"Kobach, Kris",225,000160
+MARSHALL,Marysville City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,00017A
+MARSHALL,Marysville City Ward 2,Secretary of State,,Republican,"Kobach, Kris",169,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00017B
+MARSHALL,Marysville City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,00018A
+MARSHALL,Marysville City Ward 3,Secretary of State,,Republican,"Kobach, Kris",118,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,00019A
+MARSHALL,Marysville City Ward 4 Part A,Secretary of State,,Republican,"Kobach, Kris",195,00019A
+MARSHALL,Marysville City Ward 4 Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Secretary of State,,Republican,"Kobach, Kris",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00019C
+MARSHALL,Marysville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000200
+MARSHALL,Marysville Township,Secretary of State,,Republican,"Kobach, Kris",86,000200
+MARSHALL,Murray Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",76,000210
+MARSHALL,Murray Township,Secretary of State,,Republican,"Kobach, Kris",167,000210
+MARSHALL,Noble Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000220
+MARSHALL,Noble Township,Secretary of State,,Republican,"Kobach, Kris",62,000220
+MARSHALL,Oketo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000230
+MARSHALL,Oketo Township,Secretary of State,,Republican,"Kobach, Kris",60,000230
+MARSHALL,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000240
+MARSHALL,Richland Township,Secretary of State,,Republican,"Kobach, Kris",50,000240
+MARSHALL,Rock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000250
+MARSHALL,Rock Township,Secretary of State,,Republican,"Kobach, Kris",42,000250
+MARSHALL,St. Bridget Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000260
+MARSHALL,St. Bridget Township,Secretary of State,,Republican,"Kobach, Kris",40,000260
+MARSHALL,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000270
+MARSHALL,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",37,000270
+MARSHALL,Waterville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,000280
+MARSHALL,Waterville Township,Secretary of State,,Republican,"Kobach, Kris",188,000280
+MARSHALL,Wells Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000290
+MARSHALL,Wells Township,Secretary of State,,Republican,"Kobach, Kris",30,000290
+MARSHALL,West Vermillion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,000300
+MARSHALL,West Vermillion Township,Secretary of State,,Republican,"Kobach, Kris",103,000300
+MARSHALL,Franklin Township C1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,120020
+MARSHALL,Franklin Township C1,Secretary of State,,Republican,"Kobach, Kris",45,120020
+MARSHALL,Franklin Township C2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,120030
+MARSHALL,Franklin Township C2,Secretary of State,,Republican,"Kobach, Kris",42,120030
+MARSHALL,Guittard Township C1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120040
+MARSHALL,Guittard Township C1,Secretary of State,,Republican,"Kobach, Kris",3,120040
+MARSHALL,Guittard Township C2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,120050
+MARSHALL,Guittard Township C2,Secretary of State,,Republican,"Kobach, Kris",89,120050
+MARSHALL,Balderson Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000010
+MARSHALL,Balderson Township,State Treasurer,,Republican,"Estes, Ron",26,000010
+MARSHALL,Bigelow Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000020
+MARSHALL,Bigelow Township,State Treasurer,,Republican,"Estes, Ron",10,000020
+MARSHALL,Blue Rapids City,State Treasurer,,Democratic,"Alldritt, Carmen",67,000030
+MARSHALL,Blue Rapids City,State Treasurer,,Republican,"Estes, Ron",232,000030
+MARSHALL,Blue Rapids Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000040
+MARSHALL,Blue Rapids Township,State Treasurer,,Republican,"Estes, Ron",25,000040
+MARSHALL,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000050
+MARSHALL,Center Township,State Treasurer,,Republican,"Estes, Ron",37,000050
+MARSHALL,Clear Fork Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000060
+MARSHALL,Clear Fork Township,State Treasurer,,Republican,"Estes, Ron",11,000060
+MARSHALL,Cleveland Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000070
+MARSHALL,Cleveland Township,State Treasurer,,Republican,"Estes, Ron",32,000070
+MARSHALL,Cottage Hill Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000080
+MARSHALL,Cottage Hill Township,State Treasurer,,Republican,"Estes, Ron",54,000080
+MARSHALL,East Vermillion Township,State Treasurer,,Democratic,"Alldritt, Carmen",44,000090
+MARSHALL,East Vermillion Township,State Treasurer,,Republican,"Estes, Ron",141,000090
+MARSHALL,Elm Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000100
+MARSHALL,Elm Creek Township,State Treasurer,,Republican,"Estes, Ron",49,000100
+MARSHALL,Herkimer Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000130
+MARSHALL,Herkimer Township,State Treasurer,,Republican,"Estes, Ron",79,000130
+MARSHALL,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000140
+MARSHALL,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",53,000140
+MARSHALL,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000150
+MARSHALL,Logan Township,State Treasurer,,Republican,"Estes, Ron",88,000150
+MARSHALL,Marysville City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",109,000160
+MARSHALL,Marysville City Ward 1,State Treasurer,,Republican,"Estes, Ron",232,000160
+MARSHALL,Marysville City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",88,00017A
+MARSHALL,Marysville City Ward 2,State Treasurer,,Republican,"Estes, Ron",162,00017A
+MARSHALL,Marysville City Ward 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00017B
+MARSHALL,Marysville City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",57,00018A
+MARSHALL,Marysville City Ward 3,State Treasurer,,Republican,"Estes, Ron",120,00018A
+MARSHALL,Marysville City Ward 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",90,00019A
+MARSHALL,Marysville City Ward 4 Part A,State Treasurer,,Republican,"Estes, Ron",201,00019A
+MARSHALL,Marysville City Ward 4 Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,State Treasurer,,Republican,"Estes, Ron",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,State Treasurer,,Republican,"Estes, Ron",0,00019C
+MARSHALL,Marysville Township,State Treasurer,,Democratic,"Alldritt, Carmen",34,000200
+MARSHALL,Marysville Township,State Treasurer,,Republican,"Estes, Ron",87,000200
+MARSHALL,Murray Township,State Treasurer,,Democratic,"Alldritt, Carmen",59,000210
+MARSHALL,Murray Township,State Treasurer,,Republican,"Estes, Ron",168,000210
+MARSHALL,Noble Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000220
+MARSHALL,Noble Township,State Treasurer,,Republican,"Estes, Ron",62,000220
+MARSHALL,Oketo Township,State Treasurer,,Democratic,"Alldritt, Carmen",36,000230
+MARSHALL,Oketo Township,State Treasurer,,Republican,"Estes, Ron",50,000230
+MARSHALL,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000240
+MARSHALL,Richland Township,State Treasurer,,Republican,"Estes, Ron",55,000240
+MARSHALL,Rock Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000250
+MARSHALL,Rock Township,State Treasurer,,Republican,"Estes, Ron",40,000250
+MARSHALL,St. Bridget Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000260
+MARSHALL,St. Bridget Township,State Treasurer,,Republican,"Estes, Ron",41,000260
+MARSHALL,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000270
+MARSHALL,Walnut Township,State Treasurer,,Republican,"Estes, Ron",41,000270
+MARSHALL,Waterville Township,State Treasurer,,Democratic,"Alldritt, Carmen",68,000280
+MARSHALL,Waterville Township,State Treasurer,,Republican,"Estes, Ron",196,000280
+MARSHALL,Wells Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000290
+MARSHALL,Wells Township,State Treasurer,,Republican,"Estes, Ron",35,000290
+MARSHALL,West Vermillion Township,State Treasurer,,Democratic,"Alldritt, Carmen",42,000300
+MARSHALL,West Vermillion Township,State Treasurer,,Republican,"Estes, Ron",113,000300
+MARSHALL,Franklin Township C1,State Treasurer,,Democratic,"Alldritt, Carmen",21,120020
+MARSHALL,Franklin Township C1,State Treasurer,,Republican,"Estes, Ron",46,120020
+MARSHALL,Franklin Township C2,State Treasurer,,Democratic,"Alldritt, Carmen",9,120030
+MARSHALL,Franklin Township C2,State Treasurer,,Republican,"Estes, Ron",44,120030
+MARSHALL,Guittard Township C1,State Treasurer,,Democratic,"Alldritt, Carmen",1,120040
+MARSHALL,Guittard Township C1,State Treasurer,,Republican,"Estes, Ron",2,120040
+MARSHALL,Guittard Township C2,State Treasurer,,Democratic,"Alldritt, Carmen",42,120050
+MARSHALL,Guittard Township C2,State Treasurer,,Republican,"Estes, Ron",97,120050
+MARSHALL,Balderson Township,United States Senate,,independent,"Orman, Greg",4,000010
+MARSHALL,Balderson Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+MARSHALL,Balderson Township,United States Senate,,Republican,"Roberts, Pat",29,000010
+MARSHALL,Bigelow Township,United States Senate,,independent,"Orman, Greg",7,000020
+MARSHALL,Bigelow Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+MARSHALL,Bigelow Township,United States Senate,,Republican,"Roberts, Pat",8,000020
+MARSHALL,Blue Rapids City,United States Senate,,independent,"Orman, Greg",114,000030
+MARSHALL,Blue Rapids City,United States Senate,,Libertarian,"Batson, Randall",20,000030
+MARSHALL,Blue Rapids City,United States Senate,,Republican,"Roberts, Pat",172,000030
+MARSHALL,Blue Rapids Township,United States Senate,,independent,"Orman, Greg",9,000040
+MARSHALL,Blue Rapids Township,United States Senate,,Libertarian,"Batson, Randall",1,000040
+MARSHALL,Blue Rapids Township,United States Senate,,Republican,"Roberts, Pat",22,000040
+MARSHALL,Center Township,United States Senate,,independent,"Orman, Greg",16,000050
+MARSHALL,Center Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+MARSHALL,Center Township,United States Senate,,Republican,"Roberts, Pat",31,000050
+MARSHALL,Clear Fork Township,United States Senate,,independent,"Orman, Greg",7,000060
+MARSHALL,Clear Fork Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+MARSHALL,Clear Fork Township,United States Senate,,Republican,"Roberts, Pat",9,000060
+MARSHALL,Cleveland Township,United States Senate,,independent,"Orman, Greg",18,000070
+MARSHALL,Cleveland Township,United States Senate,,Libertarian,"Batson, Randall",3,000070
+MARSHALL,Cleveland Township,United States Senate,,Republican,"Roberts, Pat",22,000070
+MARSHALL,Cottage Hill Township,United States Senate,,independent,"Orman, Greg",19,000080
+MARSHALL,Cottage Hill Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+MARSHALL,Cottage Hill Township,United States Senate,,Republican,"Roberts, Pat",42,000080
+MARSHALL,East Vermillion Township,United States Senate,,independent,"Orman, Greg",64,000090
+MARSHALL,East Vermillion Township,United States Senate,,Libertarian,"Batson, Randall",6,000090
+MARSHALL,East Vermillion Township,United States Senate,,Republican,"Roberts, Pat",124,000090
+MARSHALL,Elm Creek Township,United States Senate,,independent,"Orman, Greg",21,000100
+MARSHALL,Elm Creek Township,United States Senate,,Libertarian,"Batson, Randall",5,000100
+MARSHALL,Elm Creek Township,United States Senate,,Republican,"Roberts, Pat",45,000100
+MARSHALL,Herkimer Township,United States Senate,,independent,"Orman, Greg",14,000130
+MARSHALL,Herkimer Township,United States Senate,,Libertarian,"Batson, Randall",1,000130
+MARSHALL,Herkimer Township,United States Senate,,Republican,"Roberts, Pat",79,000130
+MARSHALL,Lincoln Township,United States Senate,,independent,"Orman, Greg",10,000140
+MARSHALL,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",0,000140
+MARSHALL,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",53,000140
+MARSHALL,Logan Township,United States Senate,,independent,"Orman, Greg",28,000150
+MARSHALL,Logan Township,United States Senate,,Libertarian,"Batson, Randall",6,000150
+MARSHALL,Logan Township,United States Senate,,Republican,"Roberts, Pat",81,000150
+MARSHALL,Marysville City Ward 1,United States Senate,,independent,"Orman, Greg",146,000160
+MARSHALL,Marysville City Ward 1,United States Senate,,Libertarian,"Batson, Randall",13,000160
+MARSHALL,Marysville City Ward 1,United States Senate,,Republican,"Roberts, Pat",196,000160
+MARSHALL,Marysville City Ward 2,United States Senate,,independent,"Orman, Greg",107,00017A
+MARSHALL,Marysville City Ward 2,United States Senate,,Libertarian,"Batson, Randall",13,00017A
+MARSHALL,Marysville City Ward 2,United States Senate,,Republican,"Roberts, Pat",141,00017A
+MARSHALL,Marysville City Ward 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00017B
+MARSHALL,Marysville City Ward 3,United States Senate,,independent,"Orman, Greg",75,00018A
+MARSHALL,Marysville City Ward 3,United States Senate,,Libertarian,"Batson, Randall",8,00018A
+MARSHALL,Marysville City Ward 3,United States Senate,,Republican,"Roberts, Pat",96,00018A
+MARSHALL,Marysville City Ward 3 Exclave,United States Senate,,independent,"Orman, Greg",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,United States Senate,,independent,"Orman, Greg",119,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States Senate,,Libertarian,"Batson, Randall",12,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States Senate,,Republican,"Roberts, Pat",168,00019A
+MARSHALL,Marysville City Ward 4 Part B,United States Senate,,independent,"Orman, Greg",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States Senate,,Libertarian,"Batson, Randall",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States Senate,,Republican,"Roberts, Pat",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States Senate,,independent,"Orman, Greg",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States Senate,,Republican,"Roberts, Pat",0,00019C
+MARSHALL,Marysville Township,United States Senate,,independent,"Orman, Greg",47,000200
+MARSHALL,Marysville Township,United States Senate,,Libertarian,"Batson, Randall",3,000200
+MARSHALL,Marysville Township,United States Senate,,Republican,"Roberts, Pat",77,000200
+MARSHALL,Murray Township,United States Senate,,independent,"Orman, Greg",75,000210
+MARSHALL,Murray Township,United States Senate,,Libertarian,"Batson, Randall",14,000210
+MARSHALL,Murray Township,United States Senate,,Republican,"Roberts, Pat",154,000210
+MARSHALL,Noble Township,United States Senate,,independent,"Orman, Greg",23,000220
+MARSHALL,Noble Township,United States Senate,,Libertarian,"Batson, Randall",4,000220
+MARSHALL,Noble Township,United States Senate,,Republican,"Roberts, Pat",53,000220
+MARSHALL,Oketo Township,United States Senate,,independent,"Orman, Greg",31,000230
+MARSHALL,Oketo Township,United States Senate,,Libertarian,"Batson, Randall",3,000230
+MARSHALL,Oketo Township,United States Senate,,Republican,"Roberts, Pat",56,000230
+MARSHALL,Richland Township,United States Senate,,independent,"Orman, Greg",16,000240
+MARSHALL,Richland Township,United States Senate,,Libertarian,"Batson, Randall",2,000240
+MARSHALL,Richland Township,United States Senate,,Republican,"Roberts, Pat",54,000240
+MARSHALL,Rock Township,United States Senate,,independent,"Orman, Greg",12,000250
+MARSHALL,Rock Township,United States Senate,,Libertarian,"Batson, Randall",0,000250
+MARSHALL,Rock Township,United States Senate,,Republican,"Roberts, Pat",44,000250
+MARSHALL,St. Bridget Township,United States Senate,,independent,"Orman, Greg",15,000260
+MARSHALL,St. Bridget Township,United States Senate,,Libertarian,"Batson, Randall",8,000260
+MARSHALL,St. Bridget Township,United States Senate,,Republican,"Roberts, Pat",35,000260
+MARSHALL,Walnut Township,United States Senate,,independent,"Orman, Greg",14,000270
+MARSHALL,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",0,000270
+MARSHALL,Walnut Township,United States Senate,,Republican,"Roberts, Pat",40,000270
+MARSHALL,Waterville Township,United States Senate,,independent,"Orman, Greg",96,000280
+MARSHALL,Waterville Township,United States Senate,,Libertarian,"Batson, Randall",17,000280
+MARSHALL,Waterville Township,United States Senate,,Republican,"Roberts, Pat",151,000280
+MARSHALL,Wells Township,United States Senate,,independent,"Orman, Greg",16,000290
+MARSHALL,Wells Township,United States Senate,,Libertarian,"Batson, Randall",2,000290
+MARSHALL,Wells Township,United States Senate,,Republican,"Roberts, Pat",31,000290
+MARSHALL,West Vermillion Township,United States Senate,,independent,"Orman, Greg",67,000300
+MARSHALL,West Vermillion Township,United States Senate,,Libertarian,"Batson, Randall",7,000300
+MARSHALL,West Vermillion Township,United States Senate,,Republican,"Roberts, Pat",87,000300
+MARSHALL,Franklin Township C1,United States Senate,,independent,"Orman, Greg",28,120020
+MARSHALL,Franklin Township C1,United States Senate,,Libertarian,"Batson, Randall",2,120020
+MARSHALL,Franklin Township C1,United States Senate,,Republican,"Roberts, Pat",35,120020
+MARSHALL,Franklin Township C2,United States Senate,,independent,"Orman, Greg",21,120030
+MARSHALL,Franklin Township C2,United States Senate,,Libertarian,"Batson, Randall",1,120030
+MARSHALL,Franklin Township C2,United States Senate,,Republican,"Roberts, Pat",31,120030
+MARSHALL,Guittard Township C1,United States Senate,,independent,"Orman, Greg",1,120040
+MARSHALL,Guittard Township C1,United States Senate,,Libertarian,"Batson, Randall",0,120040
+MARSHALL,Guittard Township C1,United States Senate,,Republican,"Roberts, Pat",2,120040
+MARSHALL,Guittard Township C2,United States Senate,,independent,"Orman, Greg",55,120050
+MARSHALL,Guittard Township C2,United States Senate,,Libertarian,"Batson, Randall",5,120050
+MARSHALL,Guittard Township C2,United States Senate,,Republican,"Roberts, Pat",82,120050

--- a/2014/20141104__ks__general__mcpherson__precinct.csv
+++ b/2014/20141104__ks__general__mcpherson__precinct.csv
@@ -1,621 +1,640 @@
-county,precinct,office,district,party,candidate,votes
-McPherson,McPherson City 1,Attorney General,,D,A.J. Kotich,584
-McPherson,McPherson City 2,Attorney General,,D,A.J. Kotich,169
-McPherson,McPherson City 3,Attorney General,,D,A.J. Kotich,103
-McPherson,McPherson City 4,Attorney General,,D,A.J. Kotich,187
-McPherson,Lindsborg City 1,Attorney General,,D,A.J. Kotich,92
-McPherson,Lindsborg City 2,Attorney General,,D,A.J. Kotich,144
-McPherson,Lindsborg City 3,Attorney General,,D,A.J. Kotich,93
-McPherson,Lindsborg City 4,Attorney General,,D,A.J. Kotich,114
-McPherson,BH,Attorney General,,D,A.J. Kotich,8
-McPherson,BON,Attorney General,,D,A.J. Kotich,0
-McPherson,CAN,Attorney General,,D,A.J. Kotich,60
-McPherson,CAS,Attorney General,,D,A.J. Kotich,18
-McPherson,DEL,Attorney General,,D,A.J. Kotich,12
-McPherson,EMP,Attorney General,,D,A.J. Kotich,70
-McPherson,GR,Attorney General,,D,A.J. Kotich,9
-McPherson,GC,Attorney General,,D,A.J. Kotich,12
-McPherson,HAR,Attorney General,,D,A.J. Kotich,11
-McPherson,HAY,Attorney General,,D,A.J. Kotich,18
-McPherson,JAC,Attorney General,,D,A.J. Kotich,17
-McPherson,KC,Attorney General,,D,A.J. Kotich,50
-McPherson,LV,Attorney General,,D,A.J. Kotich,22
-McPherson,LT,Attorney General,,D,A.J. Kotich,21
-McPherson,MQ,Attorney General,,D,A.J. Kotich,83
-McPherson,MP,Attorney General,,D,A.J. Kotich,54
-McPherson,MER,Attorney General,,D,A.J. Kotich,12
-McPherson,MD,Attorney General,,D,A.J. Kotich,178
-McPherson,NG,Attorney General,,D,A.J. Kotich,29
-McPherson,SH,Attorney General,,D,A.J. Kotich,37
-McPherson,SSC,Attorney General,,D,A.J. Kotich,7
-McPherson,SV,Attorney General,,D,A.J. Kotich,12
-McPherson,SU,Attorney General,,D,A.J. Kotich,75
-McPherson,TC,Attorney General,,D,A.J. Kotich,23
-McPherson,UN,Attorney General,,D,A.J. Kotich,13
-McPherson,McPherson City 1,Attorney General,,R,Derek Schmidt,1762
-McPherson,McPherson City 2,Attorney General,,R,Derek Schmidt,538
-McPherson,McPherson City 3,Attorney General,,R,Derek Schmidt,290
-McPherson,McPherson City 4,Attorney General,,R,Derek Schmidt,679
-McPherson,Lindsborg City 1,Attorney General,,R,Derek Schmidt,176
-McPherson,Lindsborg City 2,Attorney General,,R,Derek Schmidt,253
-McPherson,Lindsborg City 3,Attorney General,,R,Derek Schmidt,197
-McPherson,Lindsborg City 4,Attorney General,,R,Derek Schmidt,195
-McPherson,BH,Attorney General,,R,Derek Schmidt,38
-McPherson,BON,Attorney General,,R,Derek Schmidt,36
-McPherson,CAN,Attorney General,,R,Derek Schmidt,240
-McPherson,CAS,Attorney General,,R,Derek Schmidt,47
-McPherson,DEL,Attorney General,,R,Derek Schmidt,51
-McPherson,EMP,Attorney General,,R,Derek Schmidt,326
-McPherson,GR,Attorney General,,R,Derek Schmidt,70
-McPherson,GC,Attorney General,,R,Derek Schmidt,65
-McPherson,HAR,Attorney General,,R,Derek Schmidt,57
-McPherson,HAY,Attorney General,,R,Derek Schmidt,71
-McPherson,JAC,Attorney General,,R,Derek Schmidt,73
-McPherson,KC,Attorney General,,R,Derek Schmidt,168
-McPherson,LV,Attorney General,,R,Derek Schmidt,137
-McPherson,LT,Attorney General,,R,Derek Schmidt,66
-McPherson,MQ,Attorney General,,R,Derek Schmidt,210
-McPherson,MP,Attorney General,,R,Derek Schmidt,184
-McPherson,MER,Attorney General,,R,Derek Schmidt,90
-McPherson,MD,Attorney General,,R,Derek Schmidt,494
-McPherson,NG,Attorney General,,R,Derek Schmidt,169
-McPherson,SH,Attorney General,,R,Derek Schmidt,104
-McPherson,SSC,Attorney General,,R,Derek Schmidt,37
-McPherson,SV,Attorney General,,R,Derek Schmidt,111
-McPherson,SU,Attorney General,,R,Derek Schmidt,536
-McPherson,TC,Attorney General,,R,Derek Schmidt,80
-McPherson,UN,Attorney General,,R,Derek Schmidt,61
-McPherson,McPherson City 1,Governor,,L,Keen A. Umbehr,82
-McPherson,McPherson City 2,Governor,,L,Keen A. Umbehr,28
-McPherson,McPherson City 3,Governor,,L,Keen A. Umbehr,14
-McPherson,McPherson City 4,Governor,,L,Keen A. Umbehr,36
-McPherson,Lindsborg City 1,Governor,,L,Keen A. Umbehr,8
-McPherson,Lindsborg City 2,Governor,,L,Keen A. Umbehr,17
-McPherson,Lindsborg City 3,Governor,,L,Keen A. Umbehr,11
-McPherson,Lindsborg City 4,Governor,,L,Keen A. Umbehr,17
-McPherson,BH,Governor,,L,Keen A. Umbehr,0
-McPherson,BON,Governor,,L,Keen A. Umbehr,1
-McPherson,CAN,Governor,,L,Keen A. Umbehr,14
-McPherson,CAS,Governor,,L,Keen A. Umbehr,6
-McPherson,DEL,Governor,,L,Keen A. Umbehr,4
-McPherson,EMP,Governor,,L,Keen A. Umbehr,19
-McPherson,GR,Governor,,L,Keen A. Umbehr,4
-McPherson,GC,Governor,,L,Keen A. Umbehr,2
-McPherson,HAR,Governor,,L,Keen A. Umbehr,4
-McPherson,HAY,Governor,,L,Keen A. Umbehr,4
-McPherson,JAC,Governor,,L,Keen A. Umbehr,7
-McPherson,KC,Governor,,L,Keen A. Umbehr,10
-McPherson,LV,Governor,,L,Keen A. Umbehr,5
-McPherson,LT,Governor,,L,Keen A. Umbehr,2
-McPherson,MQ,Governor,,L,Keen A. Umbehr,18
-McPherson,MP,Governor,,L,Keen A. Umbehr,12
-McPherson,MER,Governor,,L,Keen A. Umbehr,4
-McPherson,MD,Governor,,L,Keen A. Umbehr,34
-McPherson,NG,Governor,,L,Keen A. Umbehr,5
-McPherson,SH,Governor,,L,Keen A. Umbehr,4
-McPherson,SSC,Governor,,L,Keen A. Umbehr,2
-McPherson,SV,Governor,,L,Keen A. Umbehr,4
-McPherson,SU,Governor,,L,Keen A. Umbehr,30
-McPherson,TC,Governor,,L,Keen A. Umbehr,1
-McPherson,UN,Governor,,L,Keen A. Umbehr,5
-McPherson,McPherson City 1,Governor,,D,Paul Davis,1052
-McPherson,McPherson City 2,Governor,,D,Paul Davis,306
-McPherson,McPherson City 3,Governor,,D,Paul Davis,153
-McPherson,McPherson City 4,Governor,,D,Paul Davis,376
-McPherson,Lindsborg City 1,Governor,,D,Paul Davis,167
-McPherson,Lindsborg City 2,Governor,,D,Paul Davis,226
-McPherson,Lindsborg City 3,Governor,,D,Paul Davis,152
-McPherson,Lindsborg City 4,Governor,,D,Paul Davis,169
-McPherson,BH,Governor,,D,Paul Davis,25
-McPherson,BON,Governor,,D,Paul Davis,1
-McPherson,CAN,Governor,,D,Paul Davis,108
-McPherson,CAS,Governor,,D,Paul Davis,27
-McPherson,DEL,Governor,,D,Paul Davis,17
-McPherson,EMP,Governor,,D,Paul Davis,135
-McPherson,GR,Governor,,D,Paul Davis,24
-McPherson,GC,Governor,,D,Paul Davis,25
-McPherson,HAR,Governor,,D,Paul Davis,15
-McPherson,HAY,Governor,,D,Paul Davis,38
-McPherson,JAC,Governor,,D,Paul Davis,38
-McPherson,KC,Governor,,D,Paul Davis,81
-McPherson,LV,Governor,,D,Paul Davis,41
-McPherson,LT,Governor,,D,Paul Davis,28
-McPherson,MQ,Governor,,D,Paul Davis,154
-McPherson,MP,Governor,,D,Paul Davis,81
-McPherson,MER,Governor,,D,Paul Davis,34
-McPherson,MD,Governor,,D,Paul Davis,324
-McPherson,NG,Governor,,D,Paul Davis,57
-McPherson,SH,Governor,,D,Paul Davis,53
-McPherson,SSC,Governor,,D,Paul Davis,13
-McPherson,SV,Governor,,D,Paul Davis,28
-McPherson,SU,Governor,,D,Paul Davis,177
-McPherson,TC,Governor,,D,Paul Davis,34
-McPherson,UN,Governor,,D,Paul Davis,24
-McPherson,McPherson City 1,Governor,,R,Sam Brownback,1248
-McPherson,McPherson City 2,Governor,,R,Sam Brownback,391
-McPherson,McPherson City 3,Governor,,R,Sam Brownback,232
-McPherson,McPherson City 4,Governor,,R,Sam Brownback,470
-McPherson,Lindsborg City 1,Governor,,R,Sam Brownback,102
-McPherson,Lindsborg City 2,Governor,,R,Sam Brownback,160
-McPherson,Lindsborg City 3,Governor,,R,Sam Brownback,136
-McPherson,Lindsborg City 4,Governor,,R,Sam Brownback,133
-McPherson,BH,Governor,,R,Sam Brownback,24
-McPherson,BON,Governor,,R,Sam Brownback,35
-McPherson,CAN,Governor,,R,Sam Brownback,184
-McPherson,CAS,Governor,,R,Sam Brownback,32
-McPherson,DEL,Governor,,R,Sam Brownback,44
-McPherson,EMP,Governor,,R,Sam Brownback,251
-McPherson,GR,Governor,,R,Sam Brownback,54
-McPherson,GC,Governor,,R,Sam Brownback,53
-McPherson,HAR,Governor,,R,Sam Brownback,50
-McPherson,HAY,Governor,,R,Sam Brownback,49
-McPherson,JAC,Governor,,R,Sam Brownback,49
-McPherson,KC,Governor,,R,Sam Brownback,133
-McPherson,LV,Governor,,R,Sam Brownback,116
-McPherson,LT,Governor,,R,Sam Brownback,58
-McPherson,MQ,Governor,,R,Sam Brownback,130
-McPherson,MP,Governor,,R,Sam Brownback,145
-McPherson,MER,Governor,,R,Sam Brownback,65
-McPherson,MD,Governor,,R,Sam Brownback,338
-McPherson,NG,Governor,,R,Sam Brownback,134
-McPherson,SH,Governor,,R,Sam Brownback,88
-McPherson,SSC,Governor,,R,Sam Brownback,29
-McPherson,SV,Governor,,R,Sam Brownback,91
-McPherson,SU,Governor,,R,Sam Brownback,420
-McPherson,TC,Governor,,R,Sam Brownback,72
-McPherson,UN,Governor,,R,Sam Brownback,45
-McPherson,McPherson City 1,Insurance Commissioner,,D,Dennis Anderson,703
-McPherson,McPherson City 2,Insurance Commissioner,,D,Dennis Anderson,191
-McPherson,McPherson City 3,Insurance Commissioner,,D,Dennis Anderson,113
-McPherson,McPherson City 4,Insurance Commissioner,,D,Dennis Anderson,236
-McPherson,Lindsborg City 1,Insurance Commissioner,,D,Dennis Anderson,110
-McPherson,Lindsborg City 2,Insurance Commissioner,,D,Dennis Anderson,170
-McPherson,Lindsborg City 3,Insurance Commissioner,,D,Dennis Anderson,105
-McPherson,Lindsborg City 4,Insurance Commissioner,,D,Dennis Anderson,128
-McPherson,BH,Insurance Commissioner,,D,Dennis Anderson,13
-McPherson,BON,Insurance Commissioner,,D,Dennis Anderson,2
-McPherson,CAN,Insurance Commissioner,,D,Dennis Anderson,55
-McPherson,CAS,Insurance Commissioner,,D,Dennis Anderson,22
-McPherson,DEL,Insurance Commissioner,,D,Dennis Anderson,13
-McPherson,EMP,Insurance Commissioner,,D,Dennis Anderson,71
-McPherson,GR,Insurance Commissioner,,D,Dennis Anderson,16
-McPherson,GC,Insurance Commissioner,,D,Dennis Anderson,14
-McPherson,HAR,Insurance Commissioner,,D,Dennis Anderson,11
-McPherson,HAY,Insurance Commissioner,,D,Dennis Anderson,27
-McPherson,JAC,Insurance Commissioner,,D,Dennis Anderson,24
-McPherson,KC,Insurance Commissioner,,D,Dennis Anderson,56
-McPherson,LV,Insurance Commissioner,,D,Dennis Anderson,25
-McPherson,LT,Insurance Commissioner,,D,Dennis Anderson,19
-McPherson,MQ,Insurance Commissioner,,D,Dennis Anderson,107
-McPherson,MP,Insurance Commissioner,,D,Dennis Anderson,61
-McPherson,MER,Insurance Commissioner,,D,Dennis Anderson,18
-McPherson,MD,Insurance Commissioner,,D,Dennis Anderson,210
-McPherson,NG,Insurance Commissioner,,D,Dennis Anderson,40
-McPherson,SH,Insurance Commissioner,,D,Dennis Anderson,43
-McPherson,SSC,Insurance Commissioner,,D,Dennis Anderson,11
-McPherson,SV,Insurance Commissioner,,D,Dennis Anderson,13
-McPherson,SU,Insurance Commissioner,,D,Dennis Anderson,115
-McPherson,TC,Insurance Commissioner,,D,Dennis Anderson,23
-McPherson,UN,Insurance Commissioner,,D,Dennis Anderson,16
-McPherson,McPherson City 1,Insurance Commissioner,,R,Ken Selzer,1622
-McPherson,McPherson City 2,Insurance Commissioner,,R,Ken Selzer,513
-McPherson,McPherson City 3,Insurance Commissioner,,R,Ken Selzer,278
-McPherson,McPherson City 4,Insurance Commissioner,,R,Ken Selzer,629
-McPherson,Lindsborg City 1,Insurance Commissioner,,R,Ken Selzer,159
-McPherson,Lindsborg City 2,Insurance Commissioner,,R,Ken Selzer,220
-McPherson,Lindsborg City 3,Insurance Commissioner,,R,Ken Selzer,180
-McPherson,Lindsborg City 4,Insurance Commissioner,,R,Ken Selzer,177
-McPherson,BH,Insurance Commissioner,,R,Ken Selzer,32
-McPherson,BON,Insurance Commissioner,,R,Ken Selzer,34
-McPherson,CAN,Insurance Commissioner,,R,Ken Selzer,242
-McPherson,CAS,Insurance Commissioner,,R,Ken Selzer,40
-McPherson,DEL,Insurance Commissioner,,R,Ken Selzer,50
-McPherson,EMP,Insurance Commissioner,,R,Ken Selzer,322
-McPherson,GR,Insurance Commissioner,,R,Ken Selzer,62
-McPherson,GC,Insurance Commissioner,,R,Ken Selzer,63
-McPherson,HAR,Insurance Commissioner,,R,Ken Selzer,57
-McPherson,HAY,Insurance Commissioner,,R,Ken Selzer,64
-McPherson,JAC,Insurance Commissioner,,R,Ken Selzer,69
-McPherson,KC,Insurance Commissioner,,R,Ken Selzer,162
-McPherson,LV,Insurance Commissioner,,R,Ken Selzer,131
-McPherson,LT,Insurance Commissioner,,R,Ken Selzer,67
-McPherson,MQ,Insurance Commissioner,,R,Ken Selzer,184
-McPherson,MP,Insurance Commissioner,,R,Ken Selzer,173
-McPherson,MER,Insurance Commissioner,,R,Ken Selzer,83
-McPherson,MD,Insurance Commissioner,,R,Ken Selzer,447
-McPherson,NG,Insurance Commissioner,,R,Ken Selzer,157
-McPherson,SH,Insurance Commissioner,,R,Ken Selzer,97
-McPherson,SSC,Insurance Commissioner,,R,Ken Selzer,30
-McPherson,SV,Insurance Commissioner,,R,Ken Selzer,111
-McPherson,SU,Insurance Commissioner,,R,Ken Selzer,481
-McPherson,TC,Insurance Commissioner,,R,Ken Selzer,80
-McPherson,UN,Insurance Commissioner,,R,Ken Selzer,56
-McPherson,McPherson City 1,Secretary of State,,D,Jean Schodorf,867
-McPherson,McPherson City 2,Secretary of State,,D,Jean Schodorf,237
-McPherson,McPherson City 3,Secretary of State,,D,Jean Schodorf,127
-McPherson,McPherson City 4,Secretary of State,,D,Jean Schodorf,302
-McPherson,Lindsborg City 1,Secretary of State,,D,Jean Schodorf,141
-McPherson,Lindsborg City 2,Secretary of State,,D,Jean Schodorf,197
-McPherson,Lindsborg City 3,Secretary of State,,D,Jean Schodorf,129
-McPherson,Lindsborg City 4,Secretary of State,,D,Jean Schodorf,155
-McPherson,BH,Secretary of State,,D,Jean Schodorf,16
-McPherson,BON,Secretary of State,,D,Jean Schodorf,4
-McPherson,CAN,Secretary of State,,D,Jean Schodorf,83
-McPherson,CAS,Secretary of State,,D,Jean Schodorf,27
-McPherson,DEL,Secretary of State,,D,Jean Schodorf,19
-McPherson,EMP,Secretary of State,,D,Jean Schodorf,95
-McPherson,GR,Secretary of State,,D,Jean Schodorf,24
-McPherson,GC,Secretary of State,,D,Jean Schodorf,24
-McPherson,HAR,Secretary of State,,D,Jean Schodorf,15
-McPherson,HAY,Secretary of State,,D,Jean Schodorf,36
-McPherson,JAC,Secretary of State,,D,Jean Schodorf,37
-McPherson,KC,Secretary of State,,D,Jean Schodorf,67
-McPherson,LV,Secretary of State,,D,Jean Schodorf,40
-McPherson,LT,Secretary of State,,D,Jean Schodorf,27
-McPherson,MQ,Secretary of State,,D,Jean Schodorf,123
-McPherson,MP,Secretary of State,,D,Jean Schodorf,80
-McPherson,MER,Secretary of State,,D,Jean Schodorf,28
-McPherson,MD,Secretary of State,,D,Jean Schodorf,268
-McPherson,NG,Secretary of State,,D,Jean Schodorf,36
-McPherson,SH,Secretary of State,,D,Jean Schodorf,51
-McPherson,SSC,Secretary of State,,D,Jean Schodorf,13
-McPherson,SV,Secretary of State,,D,Jean Schodorf,28
-McPherson,SU,Secretary of State,,D,Jean Schodorf,137
-McPherson,TC,Secretary of State,,D,Jean Schodorf,30
-McPherson,UN,Secretary of State,,D,Jean Schodorf,18
-McPherson,McPherson City 1,Secretary of State,,R,Kris Kobach,1506
-McPherson,McPherson City 2,Secretary of State,,R,Kris Kobach,480
-McPherson,McPherson City 3,Secretary of State,,R,Kris Kobach,273
-McPherson,McPherson City 4,Secretary of State,,R,Kris Kobach,579
-McPherson,Lindsborg City 1,Secretary of State,,R,Kris Kobach,136
-McPherson,Lindsborg City 2,Secretary of State,,R,Kris Kobach,205
-McPherson,Lindsborg City 3,Secretary of State,,R,Kris Kobach,165
-McPherson,Lindsborg City 4,Secretary of State,,R,Kris Kobach,162
-McPherson,BH,Secretary of State,,R,Kris Kobach,31
-McPherson,BON,Secretary of State,,R,Kris Kobach,33
-McPherson,CAN,Secretary of State,,R,Kris Kobach,220
-McPherson,CAS,Secretary of State,,R,Kris Kobach,39
-McPherson,DEL,Secretary of State,,R,Kris Kobach,48
-McPherson,EMP,Secretary of State,,R,Kris Kobach,306
-McPherson,GR,Secretary of State,,R,Kris Kobach,57
-McPherson,GC,Secretary of State,,R,Kris Kobach,54
-McPherson,HAR,Secretary of State,,R,Kris Kobach,53
-McPherson,HAY,Secretary of State,,R,Kris Kobach,54
-McPherson,JAC,Secretary of State,,R,Kris Kobach,57
-McPherson,KC,Secretary of State,,R,Kris Kobach,156
-McPherson,LV,Secretary of State,,R,Kris Kobach,118
-McPherson,LT,Secretary of State,,R,Kris Kobach,60
-McPherson,MQ,Secretary of State,,R,Kris Kobach,175
-McPherson,MP,Secretary of State,,R,Kris Kobach,159
-McPherson,MER,Secretary of State,,R,Kris Kobach,75
-McPherson,MD,Secretary of State,,R,Kris Kobach,415
-McPherson,NG,Secretary of State,,R,Kris Kobach,162
-McPherson,SH,Secretary of State,,R,Kris Kobach,92
-McPherson,SSC,Secretary of State,,R,Kris Kobach,30
-McPherson,SV,Secretary of State,,R,Kris Kobach,96
-McPherson,SU,Secretary of State,,R,Kris Kobach,475
-McPherson,TC,Secretary of State,,R,Kris Kobach,76
-McPherson,UN,Secretary of State,,R,Kris Kobach,56
-McPherson,McPherson City 1,State House,73,R,Les Mason,1607
-McPherson,McPherson City 2,State House,73,R,Les Mason,491
-McPherson,McPherson City 3,State House,73,R,Les Mason,268
-McPherson,McPherson City 4,State House,73,R,Les Mason,612
-McPherson,BH,State House,73,R,Les Mason,24
-McPherson,BON,State House,73,R,Les Mason,34
-McPherson,CAN,State House,73,R,Les Mason,155
-McPherson,CAS,State House,73,R,Les Mason,38
-McPherson,DEL,State House,73,R,Les Mason,52
-McPherson,EMP,State House,73,R,Les Mason,285
-McPherson,GR,State House,73,R,Les Mason,57
-McPherson,GC,State House,73,R,Les Mason,47
-McPherson,HAR,State House,73,R,Les Mason,51
-McPherson,HAY,State House,73,R,Les Mason,58
-McPherson,JAC,State House,73,R,Les Mason,59
-McPherson,KC,State House,73,R,Les Mason,156
-McPherson,LV,State House,73,R,Les Mason,128
-McPherson,LT,State House,73,R,Les Mason,60
-McPherson,MQ,State House,73,R,Les Mason,149
-McPherson,MP,State House,73,R,Les Mason,163
-McPherson,NG,State House,73,R,Les Mason,156
-McPherson,SSC,State House,73,R,Les Mason,27
-McPherson,SV,State House,73,R,Les Mason,88
-McPherson,SU,State House,73,R,Les Mason,481
-McPherson,TC,State House,73,R,Les Mason,73
-McPherson,UN,State House,73,R,Les Mason,53
-McPherson,McPherson City 1,State House,73,D,Von Peterson,744
-McPherson,McPherson City 2,State House,73,D,Von Peterson,226
-McPherson,McPherson City 3,State House,73,D,Von Peterson,129
-McPherson,McPherson City 4,State House,73,D,Von Peterson,267
-McPherson,BH,State House,73,D,Von Peterson,23
-McPherson,BON,State House,73,D,Von Peterson,2
-McPherson,CAN,State House,73,D,Von Peterson,145
-McPherson,CAS,State House,73,D,Von Peterson,28
-McPherson,DEL,State House,73,D,Von Peterson,15
-McPherson,EMP,State House,73,D,Von Peterson,112
-McPherson,GR,State House,73,D,Von Peterson,22
-McPherson,GC,State House,73,D,Von Peterson,30
-McPherson,HAR,State House,73,D,Von Peterson,18
-McPherson,HAY,State House,73,D,Von Peterson,33
-McPherson,JAC,State House,73,D,Von Peterson,34
-McPherson,KC,State House,73,D,Von Peterson,61
-McPherson,LV,State House,73,D,Von Peterson,27
-McPherson,LT,State House,73,D,Von Peterson,27
-McPherson,MQ,State House,73,D,Von Peterson,150
-McPherson,MP,State House,73,D,Von Peterson,76
-McPherson,NG,State House,73,D,Von Peterson,40
-McPherson,SSC,State House,73,D,Von Peterson,15
-McPherson,SV,State House,73,D,Von Peterson,36
-McPherson,SU,State House,73,D,Von Peterson,122
-McPherson,TC,State House,73,D,Von Peterson,26
-McPherson,UN,State House,73,D,Von Peterson,21
-McPherson,MER,State House,74,R,Don Schroeder,95
-McPherson,MD,State House,74,R,Don Schroeder,602
-McPherson,Lindsborg City 1,State House,108,R,Steven Johnson,221
-McPherson,Lindsborg City 2,State House,108,R,Steven Johnson,333
-McPherson,Lindsborg City 3,State House,108,R,Steven Johnson,252
-McPherson,Lindsborg City 4,State House,108,R,Steven Johnson,258
-McPherson,SH,State House,108,R,Steven Johnson,129
-McPherson,McPherson City 1,State Senate,35,R,Richard WIlbom,2068
-McPherson,McPherson City 2,State Senate,35,R,Richard WIlbom,650
-McPherson,McPherson City 3,State Senate,35,R,Richard WIlbom,333
-McPherson,McPherson City 4,State Senate,35,R,Richard WIlbom,787
-McPherson,Lindsborg City 1,State Senate,35,R,Richard WIlbom,220
-McPherson,Lindsborg City 2,State Senate,35,R,Richard WIlbom,321
-McPherson,Lindsborg City 3,State Senate,35,R,Richard WIlbom,234
-McPherson,Lindsborg City 4,State Senate,35,R,Richard WIlbom,248
-McPherson,BH,State Senate,35,R,Richard WIlbom,38
-McPherson,BON,State Senate,35,R,Richard WIlbom,35
-McPherson,CAN,State Senate,35,R,Richard WIlbom,264
-McPherson,CAS,State Senate,35,R,Richard WIlbom,55
-McPherson,DEL,State Senate,35,R,Richard WIlbom,64
-McPherson,EMP,State Senate,35,R,Richard WIlbom,357
-McPherson,GR,State Senate,35,R,Richard WIlbom,72
-McPherson,GC,State Senate,35,R,Richard WIlbom,61
-McPherson,HAR,State Senate,35,R,Richard WIlbom,62
-McPherson,HAY,State Senate,35,R,Richard WIlbom,72
-McPherson,JAC,State Senate,35,R,Richard WIlbom,84
-McPherson,KC,State Senate,35,R,Richard WIlbom,197
-McPherson,LV,State Senate,35,R,Richard WIlbom,145
-McPherson,LT,State Senate,35,R,Richard WIlbom,79
-McPherson,MQ,State Senate,35,R,Richard WIlbom,243
-McPherson,MP,State Senate,35,R,Richard WIlbom,208
-McPherson,MER,State Senate,35,R,Richard WIlbom,93
-McPherson,MD,State Senate,35,R,Richard WIlbom,570
-McPherson,NG,State Senate,35,R,Richard WIlbom,184
-McPherson,SH,State Senate,35,R,Richard WIlbom,124
-McPherson,SSC,State Senate,35,R,Richard WIlbom,41
-McPherson,SV,State Senate,35,R,Richard WIlbom,113
-McPherson,SU,State Senate,35,R,Richard WIlbom,562
-McPherson,TC,State Senate,35,R,Richard WIlbom,89
-McPherson,UN,State Senate,35,R,Richard WIlbom,64
-McPherson,McPherson City 1,State Treasurer,,D,Carmen Alldritt,543
-McPherson,McPherson City 2,State Treasurer,,D,Carmen Alldritt,161
-McPherson,McPherson City 3,State Treasurer,,D,Carmen Alldritt,87
-McPherson,McPherson City 4,State Treasurer,,D,Carmen Alldritt,165
-McPherson,Lindsborg City 1,State Treasurer,,D,Carmen Alldritt,91
-McPherson,Lindsborg City 2,State Treasurer,,D,Carmen Alldritt,131
-McPherson,Lindsborg City 3,State Treasurer,,D,Carmen Alldritt,83
-McPherson,Lindsborg City 4,State Treasurer,,D,Carmen Alldritt,111
-McPherson,BH,State Treasurer,,D,Carmen Alldritt,10
-McPherson,BON,State Treasurer,,D,Carmen Alldritt,0
-McPherson,CAN,State Treasurer,,D,Carmen Alldritt,55
-McPherson,CAS,State Treasurer,,D,Carmen Alldritt,20
-McPherson,DEL,State Treasurer,,D,Carmen Alldritt,12
-McPherson,EMP,State Treasurer,,D,Carmen Alldritt,62
-McPherson,GR,State Treasurer,,D,Carmen Alldritt,8
-McPherson,GC,State Treasurer,,D,Carmen Alldritt,12
-McPherson,HAR,State Treasurer,,D,Carmen Alldritt,8
-McPherson,HAY,State Treasurer,,D,Carmen Alldritt,17
-McPherson,JAC,State Treasurer,,D,Carmen Alldritt,22
-McPherson,KC,State Treasurer,,D,Carmen Alldritt,47
-McPherson,LV,State Treasurer,,D,Carmen Alldritt,20
-McPherson,LT,State Treasurer,,D,Carmen Alldritt,16
-McPherson,MQ,State Treasurer,,D,Carmen Alldritt,83
-McPherson,MP,State Treasurer,,D,Carmen Alldritt,43
-McPherson,MER,State Treasurer,,D,Carmen Alldritt,11
-McPherson,MD,State Treasurer,,D,Carmen Alldritt,161
-McPherson,NG,State Treasurer,,D,Carmen Alldritt,32
-McPherson,SH,State Treasurer,,D,Carmen Alldritt,38
-McPherson,SSC,State Treasurer,,D,Carmen Alldritt,8
-McPherson,SV,State Treasurer,,D,Carmen Alldritt,10
-McPherson,SU,State Treasurer,,D,Carmen Alldritt,74
-McPherson,TC,State Treasurer,,D,Carmen Alldritt,21
-McPherson,UN,State Treasurer,,D,Carmen Alldritt,14
-McPherson,McPherson City 1,State Treasurer,,R,Ron Estes,1793
-McPherson,McPherson City 2,State Treasurer,,R,Ron Estes,545
-McPherson,McPherson City 3,State Treasurer,,R,Ron Estes,305
-McPherson,McPherson City 4,State Treasurer,,R,Ron Estes,699
-McPherson,Lindsborg City 1,State Treasurer,,R,Ron Estes,172
-McPherson,Lindsborg City 2,State Treasurer,,R,Ron Estes,266
-McPherson,Lindsborg City 3,State Treasurer,,R,Ron Estes,204
-McPherson,Lindsborg City 4,State Treasurer,,R,Ron Estes,197
-McPherson,BH,State Treasurer,,R,Ron Estes,35
-McPherson,BON,State Treasurer,,R,Ron Estes,36
-McPherson,CAN,State Treasurer,,R,Ron Estes,240
-McPherson,CAS,State Treasurer,,R,Ron Estes,46
-McPherson,DEL,State Treasurer,,R,Ron Estes,53
-McPherson,EMP,State Treasurer,,R,Ron Estes,329
-McPherson,GR,State Treasurer,,R,Ron Estes,69
-McPherson,GC,State Treasurer,,R,Ron Estes,66
-McPherson,HAR,State Treasurer,,R,Ron Estes,59
-McPherson,HAY,State Treasurer,,R,Ron Estes,72
-McPherson,JAC,State Treasurer,,R,Ron Estes,68
-McPherson,KC,State Treasurer,,R,Ron Estes,172
-McPherson,LV,State Treasurer,,R,Ron Estes,136
-McPherson,LT,State Treasurer,,R,Ron Estes,71
-McPherson,MQ,State Treasurer,,R,Ron Estes,211
-McPherson,MP,State Treasurer,,R,Ron Estes,191
-McPherson,MER,State Treasurer,,R,Ron Estes,91
-McPherson,MD,State Treasurer,,R,Ron Estes,499
-McPherson,NG,State Treasurer,,R,Ron Estes,163
-McPherson,SH,State Treasurer,,R,Ron Estes,104
-McPherson,SSC,State Treasurer,,R,Ron Estes,32
-McPherson,SV,State Treasurer,,R,Ron Estes,113
-McPherson,SU,State Treasurer,,R,Ron Estes,529
-McPherson,TC,State Treasurer,,R,Ron Estes,81
-McPherson,UN,State Treasurer,,R,Ron Estes,59
-McPherson,McPherson City 1,U.S. House,1,D,James Sherow,811
-McPherson,McPherson City 2,U.S. House,1,D,James Sherow,224
-McPherson,McPherson City 3,U.S. House,1,D,James Sherow,123
-McPherson,McPherson City 4,U.S. House,1,D,James Sherow,285
-McPherson,Lindsborg City 1,U.S. House,1,D,James Sherow,144
-McPherson,Lindsborg City 2,U.S. House,1,D,James Sherow,195
-McPherson,Lindsborg City 3,U.S. House,1,D,James Sherow,120
-McPherson,Lindsborg City 4,U.S. House,1,D,James Sherow,143
-McPherson,BH,U.S. House,1,D,James Sherow,16
-McPherson,BON,U.S. House,1,D,James Sherow,3
-McPherson,CAN,U.S. House,1,D,James Sherow,79
-McPherson,CAS,U.S. House,1,D,James Sherow,23
-McPherson,DEL,U.S. House,1,D,James Sherow,17
-McPherson,EMP,U.S. House,1,D,James Sherow,80
-McPherson,GR,U.S. House,1,D,James Sherow,23
-McPherson,GC,U.S. House,1,D,James Sherow,21
-McPherson,HAR,U.S. House,1,D,James Sherow,15
-McPherson,HAY,U.S. House,1,D,James Sherow,35
-McPherson,JAC,U.S. House,1,D,James Sherow,35
-McPherson,KC,U.S. House,1,D,James Sherow,67
-McPherson,LV,U.S. House,1,D,James Sherow,40
-McPherson,LT,U.S. House,1,D,James Sherow,32
-McPherson,MQ,U.S. House,1,D,James Sherow,121
-McPherson,MP,U.S. House,1,D,James Sherow,74
-McPherson,MER,U.S. House,1,D,James Sherow,29
-McPherson,MD,U.S. House,1,D,James Sherow,243
-McPherson,NG,U.S. House,1,D,James Sherow,43
-McPherson,SH,U.S. House,1,D,James Sherow,49
-McPherson,SSC,U.S. House,1,D,James Sherow,10
-McPherson,SV,U.S. House,1,D,James Sherow,21
-McPherson,SU,U.S. House,1,D,James Sherow,134
-McPherson,TC,U.S. House,1,D,James Sherow,24
-McPherson,UN,U.S. House,1,D,James Sherow,17
-McPherson,McPherson City 1,U.S. House,1,R,Tim Hueslkamp,1552
-McPherson,McPherson City 2,U.S. House,1,R,Tim Hueslkamp,493
-McPherson,McPherson City 3,U.S. House,1,R,Tim Hueslkamp,278
-McPherson,McPherson City 4,U.S. House,1,R,Tim Hueslkamp,588
-McPherson,Lindsborg City 1,U.S. House,1,R,Tim Hueslkamp,134
-McPherson,Lindsborg City 2,U.S. House,1,R,Tim Hueslkamp,212
-McPherson,Lindsborg City 3,U.S. House,1,R,Tim Hueslkamp,173
-McPherson,Lindsborg City 4,U.S. House,1,R,Tim Hueslkamp,169
-McPherson,BH,U.S. House,1,R,Tim Hueslkamp,33
-McPherson,BON,U.S. House,1,R,Tim Hueslkamp,34
-McPherson,CAN,U.S. House,1,R,Tim Hueslkamp,227
-McPherson,CAS,U.S. House,1,R,Tim Hueslkamp,43
-McPherson,DEL,U.S. House,1,R,Tim Hueslkamp,48
-McPherson,EMP,U.S. House,1,R,Tim Hueslkamp,320
-McPherson,GR,U.S. House,1,R,Tim Hueslkamp,55
-McPherson,GC,U.S. House,1,R,Tim Hueslkamp,59
-McPherson,HAR,U.S. House,1,R,Tim Hueslkamp,51
-McPherson,HAY,U.S. House,1,R,Tim Hueslkamp,55
-McPherson,JAC,U.S. House,1,R,Tim Hueslkamp,58
-McPherson,KC,U.S. House,1,R,Tim Hueslkamp,157
-McPherson,LV,U.S. House,1,R,Tim Hueslkamp,118
-McPherson,LT,U.S. House,1,R,Tim Hueslkamp,55
-McPherson,MQ,U.S. House,1,R,Tim Hueslkamp,180
-McPherson,MP,U.S. House,1,R,Tim Hueslkamp,164
-McPherson,MER,U.S. House,1,R,Tim Hueslkamp,74
-McPherson,MD,U.S. House,1,R,Tim Hueslkamp,440
-McPherson,NG,U.S. House,1,R,Tim Hueslkamp,153
-McPherson,SH,U.S. House,1,R,Tim Hueslkamp,95
-McPherson,SSC,U.S. House,1,R,Tim Hueslkamp,35
-McPherson,SV,U.S. House,1,R,Tim Hueslkamp,102
-McPherson,SU,U.S. House,1,R,Tim Hueslkamp,470
-McPherson,TC,U.S. House,1,R,Tim Hueslkamp,80
-McPherson,UN,U.S. House,1,R,Tim Hueslkamp,56
-McPherson,McPherson City 1,U.S. Senate,,I,Greg Orman,886
-McPherson,McPherson City 2,U.S. Senate,,I,Greg Orman,258
-McPherson,McPherson City 3,U.S. Senate,,I,Greg Orman,135
-McPherson,McPherson City 4,U.S. Senate,,I,Greg Orman,325
-McPherson,Lindsborg City 1,U.S. Senate,,I,Greg Orman,137
-McPherson,Lindsborg City 2,U.S. Senate,,I,Greg Orman,191
-McPherson,Lindsborg City 3,U.S. Senate,,I,Greg Orman,125
-McPherson,Lindsborg City 4,U.S. Senate,,I,Greg Orman,150
-McPherson,BH,U.S. Senate,,I,Greg Orman,17
-McPherson,BON,U.S. Senate,,I,Greg Orman,2
-McPherson,CAN,U.S. Senate,,I,Greg Orman,94
-McPherson,CAS,U.S. Senate,,I,Greg Orman,26
-McPherson,DEL,U.S. Senate,,I,Greg Orman,16
-McPherson,EMP,U.S. Senate,,I,Greg Orman,106
-McPherson,GR,U.S. Senate,,I,Greg Orman,24
-McPherson,GC,U.S. Senate,,I,Greg Orman,20
-McPherson,HAR,U.S. Senate,,I,Greg Orman,16
-McPherson,HAY,U.S. Senate,,I,Greg Orman,33
-McPherson,JAC,U.S. Senate,,I,Greg Orman,35
-McPherson,KC,U.S. Senate,,I,Greg Orman,82
-McPherson,LV,U.S. Senate,,I,Greg Orman,36
-McPherson,LT,U.S. Senate,,I,Greg Orman,25
-McPherson,MQ,U.S. Senate,,I,Greg Orman,116
-McPherson,MP,U.S. Senate,,I,Greg Orman,78
-McPherson,MER,U.S. Senate,,I,Greg Orman,31
-McPherson,MD,U.S. Senate,,I,Greg Orman,292
-McPherson,NG,U.S. Senate,,I,Greg Orman,45
-McPherson,SH,U.S. Senate,,I,Greg Orman,50
-McPherson,SSC,U.S. Senate,,I,Greg Orman,11
-McPherson,SV,U.S. Senate,,I,Greg Orman,23
-McPherson,SU,U.S. Senate,,I,Greg Orman,154
-McPherson,TC,U.S. Senate,,I,Greg Orman,31
-McPherson,UN,U.S. Senate,,I,Greg Orman,18
-McPherson,McPherson City 1,U.S. Senate,,R,Pat Roberts,1367
-McPherson,McPherson City 2,U.S. Senate,,R,Pat Roberts,428
-McPherson,McPherson City 3,U.S. Senate,,R,Pat Roberts,244
-McPherson,McPherson City 4,U.S. Senate,,R,Pat Roberts,512
-McPherson,Lindsborg City 1,U.S. Senate,,R,Pat Roberts,128
-McPherson,Lindsborg City 2,U.S. Senate,,R,Pat Roberts,202
-McPherson,Lindsborg City 3,U.S. Senate,,R,Pat Roberts,157
-McPherson,Lindsborg City 4,U.S. Senate,,R,Pat Roberts,147
-McPherson,BH,U.S. Senate,,R,Pat Roberts,29
-McPherson,BON,U.S. Senate,,R,Pat Roberts,34
-McPherson,CAN,U.S. Senate,,R,Pat Roberts,191
-McPherson,CAS,U.S. Senate,,R,Pat Roberts,33
-McPherson,DEL,U.S. Senate,,R,Pat Roberts,48
-McPherson,EMP,U.S. Senate,,R,Pat Roberts,274
-McPherson,GR,U.S. Senate,,R,Pat Roberts,51
-McPherson,GC,U.S. Senate,,R,Pat Roberts,58
-McPherson,HAR,U.S. Senate,,R,Pat Roberts,51
-McPherson,HAY,U.S. Senate,,R,Pat Roberts,56
-McPherson,JAC,U.S. Senate,,R,Pat Roberts,52
-McPherson,KC,U.S. Senate,,R,Pat Roberts,135
-McPherson,LV,U.S. Senate,,R,Pat Roberts,121
-McPherson,LT,U.S. Senate,,R,Pat Roberts,58
-McPherson,MQ,U.S. Senate,,R,Pat Roberts,164
-McPherson,MP,U.S. Senate,,R,Pat Roberts,151
-McPherson,MER,U.S. Senate,,R,Pat Roberts,67
-McPherson,MD,U.S. Senate,,R,Pat Roberts,364
-McPherson,NG,U.S. Senate,,R,Pat Roberts,144
-McPherson,SH,U.S. Senate,,R,Pat Roberts,89
-McPherson,SSC,U.S. Senate,,R,Pat Roberts,32
-McPherson,SV,U.S. Senate,,R,Pat Roberts,94
-McPherson,SU,U.S. Senate,,R,Pat Roberts,436
-McPherson,TC,U.S. Senate,,R,Pat Roberts,74
-McPherson,UN,U.S. Senate,,R,Pat Roberts,52
-McPherson,McPherson City 1,U.S. Senate,,L,Randall Batson,118
-McPherson,McPherson City 2,U.S. Senate,,L,Randall Batson,40
-McPherson,McPherson City 3,U.S. Senate,,L,Randall Batson,20
-McPherson,McPherson City 4,U.S. Senate,,L,Randall Batson,45
-McPherson,Lindsborg City 1,U.S. Senate,,L,Randall Batson,15
-McPherson,Lindsborg City 2,U.S. Senate,,L,Randall Batson,14
-McPherson,Lindsborg City 3,U.S. Senate,,L,Randall Batson,12
-McPherson,Lindsborg City 4,U.S. Senate,,L,Randall Batson,19
-McPherson,BH,U.S. Senate,,L,Randall Batson,2
-McPherson,BON,U.S. Senate,,L,Randall Batson,1
-McPherson,CAN,U.S. Senate,,L,Randall Batson,19
-McPherson,CAS,U.S. Senate,,L,Randall Batson,6
-McPherson,DEL,U.S. Senate,,L,Randall Batson,2
-McPherson,EMP,U.S. Senate,,L,Randall Batson,26
-McPherson,GR,U.S. Senate,,L,Randall Batson,7
-McPherson,GC,U.S. Senate,,L,Randall Batson,0
-McPherson,HAR,U.S. Senate,,L,Randall Batson,2
-McPherson,HAY,U.S. Senate,,L,Randall Batson,2
-McPherson,JAC,U.S. Senate,,L,Randall Batson,6
-McPherson,KC,U.S. Senate,,L,Randall Batson,7
-McPherson,LV,U.S. Senate,,L,Randall Batson,5
-McPherson,LT,U.S. Senate,,L,Randall Batson,4
-McPherson,MQ,U.S. Senate,,L,Randall Batson,20
-McPherson,MP,U.S. Senate,,L,Randall Batson,12
-McPherson,MER,U.S. Senate,,L,Randall Batson,5
-McPherson,MD,U.S. Senate,,L,Randall Batson,36
-McPherson,NG,U.S. Senate,,L,Randall Batson,8
-McPherson,SH,U.S. Senate,,L,Randall Batson,7
-McPherson,SSC,U.S. Senate,,L,Randall Batson,2
-McPherson,SV,U.S. Senate,,L,Randall Batson,6
-McPherson,SU,U.S. Senate,,L,Randall Batson,32
-McPherson,TC,U.S. Senate,,L,Randall Batson,3
-McPherson,UN,U.S. Senate,,L,Randall Batson,4
+county,precinct,office,district,party,candidate,votes,vtd
+MCPHERSON,Battle Hill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000010
+MCPHERSON,Battle Hill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+MCPHERSON,Battle Hill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000010
+MCPHERSON,Bonaville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000020
+MCPHERSON,Bonaville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+MCPHERSON,Bonaville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000020
+MCPHERSON,Canton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",108,000030
+MCPHERSON,Canton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000030
+MCPHERSON,Canton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",184,000030
+MCPHERSON,Castle Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000040
+MCPHERSON,Castle Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000040
+MCPHERSON,Castle Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000040
+MCPHERSON,Delmore Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000050
+MCPHERSON,Delmore Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000050
+MCPHERSON,Delmore Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000050
+MCPHERSON,Empire Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",135,000060
+MCPHERSON,Empire Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000060
+MCPHERSON,Empire Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",251,000060
+MCPHERSON,Groveland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000070
+MCPHERSON,Groveland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000070
+MCPHERSON,Groveland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000070
+MCPHERSON,Gypsum Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000080
+MCPHERSON,Gypsum Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+MCPHERSON,Gypsum Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000080
+MCPHERSON,Harper Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000090
+MCPHERSON,Harper Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000090
+MCPHERSON,Harper Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000090
+MCPHERSON,Hayes Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,000100
+MCPHERSON,Hayes Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000100
+MCPHERSON,Hayes Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000100
+MCPHERSON,Jackson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,000110
+MCPHERSON,Jackson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000110
+MCPHERSON,Jackson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000110
+MCPHERSON,King City Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000120
+MCPHERSON,King City Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000120
+MCPHERSON,King City Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000120
+MCPHERSON,Lindsborg Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",167,000130
+MCPHERSON,Lindsborg Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000130
+MCPHERSON,Lindsborg Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000130
+MCPHERSON,Lindsborg Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",226,000140
+MCPHERSON,Lindsborg Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000140
+MCPHERSON,Lindsborg Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",160,000140
+MCPHERSON,Lindsborg Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",152,000150
+MCPHERSON,Lindsborg Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000150
+MCPHERSON,Lindsborg Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,000150
+MCPHERSON,Lindsborg Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",169,000160
+MCPHERSON,Lindsborg Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000160
+MCPHERSON,Lindsborg Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000160
+MCPHERSON,Little Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000170
+MCPHERSON,Little Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000170
+MCPHERSON,Little Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",116,000170
+MCPHERSON,Lone Tree Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000180
+MCPHERSON,Lone Tree Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000180
+MCPHERSON,Lone Tree Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000180
+MCPHERSON,Marquette Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",154,000190
+MCPHERSON,Marquette Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000190
+MCPHERSON,Marquette Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000190
+MCPHERSON,McPherson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000200
+MCPHERSON,McPherson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000200
+MCPHERSON,McPherson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",145,000200
+MCPHERSON,Meridian Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000290
+MCPHERSON,Meridian Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000290
+MCPHERSON,Meridian Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,000290
+MCPHERSON,Mound Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",324,000300
+MCPHERSON,Mound Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",34,000300
+MCPHERSON,Mound Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",338,000300
+MCPHERSON,New Gottland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",57,000310
+MCPHERSON,New Gottland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000310
+MCPHERSON,New Gottland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",134,000310
+MCPHERSON,Smoky Hill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000320
+MCPHERSON,Smoky Hill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000320
+MCPHERSON,Smoky Hill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",88,000320
+MCPHERSON,South Sharps Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000330
+MCPHERSON,South Sharps Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000330
+MCPHERSON,South Sharps Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000330
+MCPHERSON,Spring Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000340
+MCPHERSON,Spring Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000340
+MCPHERSON,Spring Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000340
+MCPHERSON,Superior Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",177,000350
+MCPHERSON,Superior Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000350
+MCPHERSON,Superior Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",420,000350
+MCPHERSON,Turkey Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000360
+MCPHERSON,Turkey Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000360
+MCPHERSON,Turkey Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000360
+MCPHERSON,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000370
+MCPHERSON,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000370
+MCPHERSON,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",1052,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",82,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",1248,900010
+MCPHERSON,McPherson Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",306,900020
+MCPHERSON,McPherson Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,900020
+MCPHERSON,McPherson Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",391,900020
+MCPHERSON,McPherson Ward 3 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",153,900030
+MCPHERSON,McPherson Ward 3 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,900030
+MCPHERSON,McPherson Ward 3 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",232,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",376,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",36,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",470,900040
+MCPHERSON,McPherson Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+MCPHERSON,Battle Hill Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",23,000010
+MCPHERSON,Battle Hill Township,Kansas House of Representatives,73,Republican,"Mason, Les",24,000010
+MCPHERSON,Bonaville Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",2,000020
+MCPHERSON,Bonaville Township,Kansas House of Representatives,73,Republican,"Mason, Les",34,000020
+MCPHERSON,Canton Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",145,000030
+MCPHERSON,Canton Township,Kansas House of Representatives,73,Republican,"Mason, Les",155,000030
+MCPHERSON,Castle Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",28,000040
+MCPHERSON,Castle Township,Kansas House of Representatives,73,Republican,"Mason, Les",38,000040
+MCPHERSON,Delmore Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",15,000050
+MCPHERSON,Delmore Township,Kansas House of Representatives,73,Republican,"Mason, Les",52,000050
+MCPHERSON,Empire Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",112,000060
+MCPHERSON,Empire Township,Kansas House of Representatives,73,Republican,"Mason, Les",285,000060
+MCPHERSON,Groveland Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",22,000070
+MCPHERSON,Groveland Township,Kansas House of Representatives,73,Republican,"Mason, Les",57,000070
+MCPHERSON,Gypsum Creek Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",30,000080
+MCPHERSON,Gypsum Creek Township,Kansas House of Representatives,73,Republican,"Mason, Les",47,000080
+MCPHERSON,Harper Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",18,000090
+MCPHERSON,Harper Township,Kansas House of Representatives,73,Republican,"Mason, Les",51,000090
+MCPHERSON,Hayes Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",33,000100
+MCPHERSON,Hayes Township,Kansas House of Representatives,73,Republican,"Mason, Les",58,000100
+MCPHERSON,Jackson Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",34,000110
+MCPHERSON,Jackson Township,Kansas House of Representatives,73,Republican,"Mason, Les",59,000110
+MCPHERSON,King City Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",61,000120
+MCPHERSON,King City Township,Kansas House of Representatives,73,Republican,"Mason, Les",156,000120
+MCPHERSON,Lindsborg Ward 1,Kansas House of Representatives,108,Republican,"Johnson, Steven",221,000130
+MCPHERSON,Lindsborg Ward 2,Kansas House of Representatives,108,Republican,"Johnson, Steven",333,000140
+MCPHERSON,Lindsborg Ward 3,Kansas House of Representatives,108,Republican,"Johnson, Steven",252,000150
+MCPHERSON,Lindsborg Ward 4,Kansas House of Representatives,108,Republican,"Johnson, Steven",258,000160
+MCPHERSON,Little Valley Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",27,000170
+MCPHERSON,Little Valley Township,Kansas House of Representatives,73,Republican,"Mason, Les",128,000170
+MCPHERSON,Lone Tree Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",27,000180
+MCPHERSON,Lone Tree Township,Kansas House of Representatives,73,Republican,"Mason, Les",60,000180
+MCPHERSON,Marquette Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",150,000190
+MCPHERSON,Marquette Township,Kansas House of Representatives,73,Republican,"Mason, Les",149,000190
+MCPHERSON,McPherson Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",76,000200
+MCPHERSON,McPherson Township,Kansas House of Representatives,73,Republican,"Mason, Les",163,000200
+MCPHERSON,Meridian Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",95,000290
+MCPHERSON,Mound Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",602,000300
+MCPHERSON,New Gottland Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",40,000310
+MCPHERSON,New Gottland Township,Kansas House of Representatives,73,Republican,"Mason, Les",156,000310
+MCPHERSON,Smoky Hill Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",129,000320
+MCPHERSON,South Sharps Creek Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",15,000330
+MCPHERSON,South Sharps Creek Township,Kansas House of Representatives,73,Republican,"Mason, Les",27,000330
+MCPHERSON,Spring Valley Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",36,000340
+MCPHERSON,Spring Valley Township,Kansas House of Representatives,73,Republican,"Mason, Les",88,000340
+MCPHERSON,Superior Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",122,000350
+MCPHERSON,Superior Township,Kansas House of Representatives,73,Republican,"Mason, Les",481,000350
+MCPHERSON,Turkey Creek Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",26,000360
+MCPHERSON,Turkey Creek Township,Kansas House of Representatives,73,Republican,"Mason, Les",73,000360
+MCPHERSON,Union Township,Kansas House of Representatives,73,Democratic,"Peterson, Von",21,000370
+MCPHERSON,Union Township,Kansas House of Representatives,73,Republican,"Mason, Les",53,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,Kansas House of Representatives,73,Democratic,"Peterson, Von",744,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,Kansas House of Representatives,73,Republican,"Mason, Les",1607,900010
+MCPHERSON,McPherson Ward 2,Kansas House of Representatives,73,Democratic,"Peterson, Von",226,900020
+MCPHERSON,McPherson Ward 2,Kansas House of Representatives,73,Republican,"Mason, Les",491,900020
+MCPHERSON,McPherson Ward 3 Part A,Kansas House of Representatives,73,Democratic,"Peterson, Von",129,900030
+MCPHERSON,McPherson Ward 3 Part A,Kansas House of Representatives,73,Republican,"Mason, Les",268,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas House of Representatives,73,Democratic,"Peterson, Von",267,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas House of Representatives,73,Republican,"Mason, Les",612,900040
+MCPHERSON,McPherson Ward 1 Exclave,Kansas House of Representatives,73,Democratic,"Peterson, Von",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,Kansas House of Representatives,73,Republican,"Mason, Les",0,900050
+MCPHERSON,Battle Hill Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000010
+MCPHERSON,Battle Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000010
+MCPHERSON,Bonaville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000020
+MCPHERSON,Bonaville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000020
+MCPHERSON,Canton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",79,000030
+MCPHERSON,Canton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",227,000030
+MCPHERSON,Castle Township,United States House of Representatives,1,Democratic,"Sherow, James E.",23,000040
+MCPHERSON,Castle Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000040
+MCPHERSON,Delmore Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000050
+MCPHERSON,Delmore Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000050
+MCPHERSON,Empire Township,United States House of Representatives,1,Democratic,"Sherow, James E.",80,000060
+MCPHERSON,Empire Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",320,000060
+MCPHERSON,Groveland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",23,000070
+MCPHERSON,Groveland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000070
+MCPHERSON,Gypsum Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",21,000080
+MCPHERSON,Gypsum Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000080
+MCPHERSON,Harper Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000090
+MCPHERSON,Harper Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000090
+MCPHERSON,Hayes Township,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000100
+MCPHERSON,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000100
+MCPHERSON,Jackson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000110
+MCPHERSON,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000110
+MCPHERSON,King City Township,United States House of Representatives,1,Democratic,"Sherow, James E.",67,000120
+MCPHERSON,King City Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",157,000120
+MCPHERSON,Lindsborg Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",144,000130
+MCPHERSON,Lindsborg Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,000130
+MCPHERSON,Lindsborg Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",195,000140
+MCPHERSON,Lindsborg Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",212,000140
+MCPHERSON,Lindsborg Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",120,000150
+MCPHERSON,Lindsborg Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",173,000150
+MCPHERSON,Lindsborg Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",143,000160
+MCPHERSON,Lindsborg Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",169,000160
+MCPHERSON,Little Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000170
+MCPHERSON,Little Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",118,000170
+MCPHERSON,Lone Tree Township,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000180
+MCPHERSON,Lone Tree Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000180
+MCPHERSON,Marquette Township,United States House of Representatives,1,Democratic,"Sherow, James E.",121,000190
+MCPHERSON,Marquette Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",180,000190
+MCPHERSON,McPherson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",74,000200
+MCPHERSON,McPherson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000200
+MCPHERSON,Meridian Township,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000290
+MCPHERSON,Meridian Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,000290
+MCPHERSON,Mound Township,United States House of Representatives,1,Democratic,"Sherow, James E.",243,000300
+MCPHERSON,Mound Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",440,000300
+MCPHERSON,New Gottland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",43,000310
+MCPHERSON,New Gottland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",153,000310
+MCPHERSON,Smoky Hill Township,United States House of Representatives,1,Democratic,"Sherow, James E.",49,000320
+MCPHERSON,Smoky Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000320
+MCPHERSON,South Sharps Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000330
+MCPHERSON,South Sharps Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000330
+MCPHERSON,Spring Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",21,000340
+MCPHERSON,Spring Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",102,000340
+MCPHERSON,Superior Township,United States House of Representatives,1,Democratic,"Sherow, James E.",134,000350
+MCPHERSON,Superior Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",470,000350
+MCPHERSON,Turkey Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000360
+MCPHERSON,Turkey Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000360
+MCPHERSON,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000370
+MCPHERSON,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",811,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",1552,900010
+MCPHERSON,McPherson Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",224,900020
+MCPHERSON,McPherson Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",493,900020
+MCPHERSON,McPherson Ward 3 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",123,900030
+MCPHERSON,McPherson Ward 3 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",278,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",285,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",588,900040
+MCPHERSON,McPherson Ward 1 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050
+MCPHERSON,Battle Hill Township,Attorney General,,Democratic,"Kotich, A.J.",8,000010
+MCPHERSON,Battle Hill Township,Attorney General,,Republican,"Schmidt, Derek",38,000010
+MCPHERSON,Bonaville Township,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+MCPHERSON,Bonaville Township,Attorney General,,Republican,"Schmidt, Derek",36,000020
+MCPHERSON,Canton Township,Attorney General,,Democratic,"Kotich, A.J.",60,000030
+MCPHERSON,Canton Township,Attorney General,,Republican,"Schmidt, Derek",240,000030
+MCPHERSON,Castle Township,Attorney General,,Democratic,"Kotich, A.J.",18,000040
+MCPHERSON,Castle Township,Attorney General,,Republican,"Schmidt, Derek",47,000040
+MCPHERSON,Delmore Township,Attorney General,,Democratic,"Kotich, A.J.",12,000050
+MCPHERSON,Delmore Township,Attorney General,,Republican,"Schmidt, Derek",51,000050
+MCPHERSON,Empire Township,Attorney General,,Democratic,"Kotich, A.J.",70,000060
+MCPHERSON,Empire Township,Attorney General,,Republican,"Schmidt, Derek",326,000060
+MCPHERSON,Groveland Township,Attorney General,,Democratic,"Kotich, A.J.",9,000070
+MCPHERSON,Groveland Township,Attorney General,,Republican,"Schmidt, Derek",70,000070
+MCPHERSON,Gypsum Creek Township,Attorney General,,Democratic,"Kotich, A.J.",12,000080
+MCPHERSON,Gypsum Creek Township,Attorney General,,Republican,"Schmidt, Derek",65,000080
+MCPHERSON,Harper Township,Attorney General,,Democratic,"Kotich, A.J.",11,000090
+MCPHERSON,Harper Township,Attorney General,,Republican,"Schmidt, Derek",57,000090
+MCPHERSON,Hayes Township,Attorney General,,Democratic,"Kotich, A.J.",18,000100
+MCPHERSON,Hayes Township,Attorney General,,Republican,"Schmidt, Derek",71,000100
+MCPHERSON,Jackson Township,Attorney General,,Democratic,"Kotich, A.J.",17,000110
+MCPHERSON,Jackson Township,Attorney General,,Republican,"Schmidt, Derek",73,000110
+MCPHERSON,King City Township,Attorney General,,Democratic,"Kotich, A.J.",50,000120
+MCPHERSON,King City Township,Attorney General,,Republican,"Schmidt, Derek",168,000120
+MCPHERSON,Lindsborg Ward 1,Attorney General,,Democratic,"Kotich, A.J.",92,000130
+MCPHERSON,Lindsborg Ward 1,Attorney General,,Republican,"Schmidt, Derek",176,000130
+MCPHERSON,Lindsborg Ward 2,Attorney General,,Democratic,"Kotich, A.J.",144,000140
+MCPHERSON,Lindsborg Ward 2,Attorney General,,Republican,"Schmidt, Derek",253,000140
+MCPHERSON,Lindsborg Ward 3,Attorney General,,Democratic,"Kotich, A.J.",93,000150
+MCPHERSON,Lindsborg Ward 3,Attorney General,,Republican,"Schmidt, Derek",197,000150
+MCPHERSON,Lindsborg Ward 4,Attorney General,,Democratic,"Kotich, A.J.",114,000160
+MCPHERSON,Lindsborg Ward 4,Attorney General,,Republican,"Schmidt, Derek",195,000160
+MCPHERSON,Little Valley Township,Attorney General,,Democratic,"Kotich, A.J.",22,000170
+MCPHERSON,Little Valley Township,Attorney General,,Republican,"Schmidt, Derek",137,000170
+MCPHERSON,Lone Tree Township,Attorney General,,Democratic,"Kotich, A.J.",21,000180
+MCPHERSON,Lone Tree Township,Attorney General,,Republican,"Schmidt, Derek",66,000180
+MCPHERSON,Marquette Township,Attorney General,,Democratic,"Kotich, A.J.",83,000190
+MCPHERSON,Marquette Township,Attorney General,,Republican,"Schmidt, Derek",210,000190
+MCPHERSON,McPherson Township,Attorney General,,Democratic,"Kotich, A.J.",54,000200
+MCPHERSON,McPherson Township,Attorney General,,Republican,"Schmidt, Derek",184,000200
+MCPHERSON,Meridian Township,Attorney General,,Democratic,"Kotich, A.J.",12,000290
+MCPHERSON,Meridian Township,Attorney General,,Republican,"Schmidt, Derek",90,000290
+MCPHERSON,Mound Township,Attorney General,,Democratic,"Kotich, A.J.",178,000300
+MCPHERSON,Mound Township,Attorney General,,Republican,"Schmidt, Derek",494,000300
+MCPHERSON,New Gottland Township,Attorney General,,Democratic,"Kotich, A.J.",29,000310
+MCPHERSON,New Gottland Township,Attorney General,,Republican,"Schmidt, Derek",169,000310
+MCPHERSON,Smoky Hill Township,Attorney General,,Democratic,"Kotich, A.J.",37,000320
+MCPHERSON,Smoky Hill Township,Attorney General,,Republican,"Schmidt, Derek",104,000320
+MCPHERSON,South Sharps Creek Township,Attorney General,,Democratic,"Kotich, A.J.",7,000330
+MCPHERSON,South Sharps Creek Township,Attorney General,,Republican,"Schmidt, Derek",37,000330
+MCPHERSON,Spring Valley Township,Attorney General,,Democratic,"Kotich, A.J.",12,000340
+MCPHERSON,Spring Valley Township,Attorney General,,Republican,"Schmidt, Derek",111,000340
+MCPHERSON,Superior Township,Attorney General,,Democratic,"Kotich, A.J.",75,000350
+MCPHERSON,Superior Township,Attorney General,,Republican,"Schmidt, Derek",536,000350
+MCPHERSON,Turkey Creek Township,Attorney General,,Democratic,"Kotich, A.J.",23,000360
+MCPHERSON,Turkey Creek Township,Attorney General,,Republican,"Schmidt, Derek",80,000360
+MCPHERSON,Union Township,Attorney General,,Democratic,"Kotich, A.J.",13,000370
+MCPHERSON,Union Township,Attorney General,,Republican,"Schmidt, Derek",61,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",584,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",1762,900010
+MCPHERSON,McPherson Ward 2,Attorney General,,Democratic,"Kotich, A.J.",169,900020
+MCPHERSON,McPherson Ward 2,Attorney General,,Republican,"Schmidt, Derek",538,900020
+MCPHERSON,McPherson Ward 3 Part A,Attorney General,,Democratic,"Kotich, A.J.",103,900030
+MCPHERSON,McPherson Ward 3 Part A,Attorney General,,Republican,"Schmidt, Derek",290,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Attorney General,,Democratic,"Kotich, A.J.",187,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Attorney General,,Republican,"Schmidt, Derek",679,900040
+MCPHERSON,McPherson Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900050
+MCPHERSON,Battle Hill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000010
+MCPHERSON,Battle Hill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000010
+MCPHERSON,Bonaville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000020
+MCPHERSON,Bonaville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000020
+MCPHERSON,Canton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",55,000030
+MCPHERSON,Canton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",242,000030
+MCPHERSON,Castle Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000040
+MCPHERSON,Castle Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000040
+MCPHERSON,Delmore Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000050
+MCPHERSON,Delmore Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000050
+MCPHERSON,Empire Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000060
+MCPHERSON,Empire Township,Commissioner of Insurance,,Republican,"Selzer, Ken",322,000060
+MCPHERSON,Groveland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000070
+MCPHERSON,Groveland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000070
+MCPHERSON,Gypsum Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000080
+MCPHERSON,Gypsum Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",63,000080
+MCPHERSON,Harper Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000090
+MCPHERSON,Harper Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000090
+MCPHERSON,Hayes Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000100
+MCPHERSON,Hayes Township,Commissioner of Insurance,,Republican,"Selzer, Ken",64,000100
+MCPHERSON,Jackson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000110
+MCPHERSON,Jackson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",69,000110
+MCPHERSON,King City Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,000120
+MCPHERSON,King City Township,Commissioner of Insurance,,Republican,"Selzer, Ken",162,000120
+MCPHERSON,Lindsborg Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",110,000130
+MCPHERSON,Lindsborg Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",159,000130
+MCPHERSON,Lindsborg Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",170,000140
+MCPHERSON,Lindsborg Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",220,000140
+MCPHERSON,Lindsborg Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",105,000150
+MCPHERSON,Lindsborg Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",180,000150
+MCPHERSON,Lindsborg Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",128,000160
+MCPHERSON,Lindsborg Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",177,000160
+MCPHERSON,Little Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000170
+MCPHERSON,Little Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",131,000170
+MCPHERSON,Lone Tree Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000180
+MCPHERSON,Lone Tree Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000180
+MCPHERSON,Marquette Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",107,000190
+MCPHERSON,Marquette Township,Commissioner of Insurance,,Republican,"Selzer, Ken",184,000190
+MCPHERSON,McPherson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,000200
+MCPHERSON,McPherson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000200
+MCPHERSON,Meridian Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000290
+MCPHERSON,Meridian Township,Commissioner of Insurance,,Republican,"Selzer, Ken",83,000290
+MCPHERSON,Mound Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",210,000300
+MCPHERSON,Mound Township,Commissioner of Insurance,,Republican,"Selzer, Ken",447,000300
+MCPHERSON,New Gottland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000310
+MCPHERSON,New Gottland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",157,000310
+MCPHERSON,Smoky Hill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000320
+MCPHERSON,Smoky Hill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000320
+MCPHERSON,South Sharps Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000330
+MCPHERSON,South Sharps Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000330
+MCPHERSON,Spring Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000340
+MCPHERSON,Spring Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000340
+MCPHERSON,Superior Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,000350
+MCPHERSON,Superior Township,Commissioner of Insurance,,Republican,"Selzer, Ken",481,000350
+MCPHERSON,Turkey Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000360
+MCPHERSON,Turkey Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",80,000360
+MCPHERSON,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000370
+MCPHERSON,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",56,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",703,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",1622,900010
+MCPHERSON,McPherson Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",191,900020
+MCPHERSON,McPherson Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",513,900020
+MCPHERSON,McPherson Ward 3 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",113,900030
+MCPHERSON,McPherson Ward 3 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",278,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",236,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",629,900040
+MCPHERSON,McPherson Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+MCPHERSON,Battle Hill Township,Kansas Senate,35,Republican,"Wilborn, Richard",38,000010
+MCPHERSON,Bonaville Township,Kansas Senate,35,Republican,"Wilborn, Richard",35,000020
+MCPHERSON,Canton Township,Kansas Senate,35,Republican,"Wilborn, Richard",264,000030
+MCPHERSON,Castle Township,Kansas Senate,35,Republican,"Wilborn, Richard",55,000040
+MCPHERSON,Delmore Township,Kansas Senate,35,Republican,"Wilborn, Richard",64,000050
+MCPHERSON,Empire Township,Kansas Senate,35,Republican,"Wilborn, Richard",357,000060
+MCPHERSON,Groveland Township,Kansas Senate,35,Republican,"Wilborn, Richard",72,000070
+MCPHERSON,Gypsum Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",61,000080
+MCPHERSON,Harper Township,Kansas Senate,35,Republican,"Wilborn, Richard",62,000090
+MCPHERSON,Hayes Township,Kansas Senate,35,Republican,"Wilborn, Richard",72,000100
+MCPHERSON,Jackson Township,Kansas Senate,35,Republican,"Wilborn, Richard",84,000110
+MCPHERSON,King City Township,Kansas Senate,35,Republican,"Wilborn, Richard",197,000120
+MCPHERSON,Lindsborg Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",220,000130
+MCPHERSON,Lindsborg Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",321,000140
+MCPHERSON,Lindsborg Ward 3,Kansas Senate,35,Republican,"Wilborn, Richard",234,000150
+MCPHERSON,Lindsborg Ward 4,Kansas Senate,35,Republican,"Wilborn, Richard",248,000160
+MCPHERSON,Little Valley Township,Kansas Senate,35,Republican,"Wilborn, Richard",145,000170
+MCPHERSON,Lone Tree Township,Kansas Senate,35,Republican,"Wilborn, Richard",79,000180
+MCPHERSON,Marquette Township,Kansas Senate,35,Republican,"Wilborn, Richard",243,000190
+MCPHERSON,McPherson Township,Kansas Senate,35,Republican,"Wilborn, Richard",208,000200
+MCPHERSON,Meridian Township,Kansas Senate,35,Republican,"Wilborn, Richard",93,000290
+MCPHERSON,Mound Township,Kansas Senate,35,Republican,"Wilborn, Richard",570,000300
+MCPHERSON,New Gottland Township,Kansas Senate,35,Republican,"Wilborn, Richard",184,000310
+MCPHERSON,Smoky Hill Township,Kansas Senate,35,Republican,"Wilborn, Richard",124,000320
+MCPHERSON,South Sharps Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",41,000330
+MCPHERSON,Spring Valley Township,Kansas Senate,35,Republican,"Wilborn, Richard",113,000340
+MCPHERSON,Superior Township,Kansas Senate,35,Republican,"Wilborn, Richard",562,000350
+MCPHERSON,Turkey Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",89,000360
+MCPHERSON,Union Township,Kansas Senate,35,Republican,"Wilborn, Richard",64,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,Kansas Senate,35,Republican,"Wilborn, Richard",2068,900010
+MCPHERSON,McPherson Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",650,900020
+MCPHERSON,McPherson Ward 3 Part A,Kansas Senate,35,Republican,"Wilborn, Richard",333,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas Senate,35,Republican,"Wilborn, Richard",787,900040
+MCPHERSON,McPherson Ward 1 Exclave,Kansas Senate,35,Republican,"Wilborn, Richard",0,900050
+MCPHERSON,Battle Hill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000010
+MCPHERSON,Battle Hill Township,Secretary of State,,Republican,"Kobach, Kris",31,000010
+MCPHERSON,Bonaville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000020
+MCPHERSON,Bonaville Township,Secretary of State,,Republican,"Kobach, Kris",33,000020
+MCPHERSON,Canton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",83,000030
+MCPHERSON,Canton Township,Secretary of State,,Republican,"Kobach, Kris",220,000030
+MCPHERSON,Castle Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000040
+MCPHERSON,Castle Township,Secretary of State,,Republican,"Kobach, Kris",39,000040
+MCPHERSON,Delmore Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000050
+MCPHERSON,Delmore Township,Secretary of State,,Republican,"Kobach, Kris",48,000050
+MCPHERSON,Empire Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",95,000060
+MCPHERSON,Empire Township,Secretary of State,,Republican,"Kobach, Kris",306,000060
+MCPHERSON,Groveland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000070
+MCPHERSON,Groveland Township,Secretary of State,,Republican,"Kobach, Kris",57,000070
+MCPHERSON,Gypsum Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000080
+MCPHERSON,Gypsum Creek Township,Secretary of State,,Republican,"Kobach, Kris",54,000080
+MCPHERSON,Harper Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000090
+MCPHERSON,Harper Township,Secretary of State,,Republican,"Kobach, Kris",53,000090
+MCPHERSON,Hayes Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000100
+MCPHERSON,Hayes Township,Secretary of State,,Republican,"Kobach, Kris",54,000100
+MCPHERSON,Jackson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000110
+MCPHERSON,Jackson Township,Secretary of State,,Republican,"Kobach, Kris",57,000110
+MCPHERSON,King City Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000120
+MCPHERSON,King City Township,Secretary of State,,Republican,"Kobach, Kris",156,000120
+MCPHERSON,Lindsborg Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",141,000130
+MCPHERSON,Lindsborg Ward 1,Secretary of State,,Republican,"Kobach, Kris",136,000130
+MCPHERSON,Lindsborg Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",197,000140
+MCPHERSON,Lindsborg Ward 2,Secretary of State,,Republican,"Kobach, Kris",205,000140
+MCPHERSON,Lindsborg Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",129,000150
+MCPHERSON,Lindsborg Ward 3,Secretary of State,,Republican,"Kobach, Kris",165,000150
+MCPHERSON,Lindsborg Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",155,000160
+MCPHERSON,Lindsborg Ward 4,Secretary of State,,Republican,"Kobach, Kris",162,000160
+MCPHERSON,Little Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000170
+MCPHERSON,Little Valley Township,Secretary of State,,Republican,"Kobach, Kris",118,000170
+MCPHERSON,Lone Tree Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000180
+MCPHERSON,Lone Tree Township,Secretary of State,,Republican,"Kobach, Kris",60,000180
+MCPHERSON,Marquette Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",123,000190
+MCPHERSON,Marquette Township,Secretary of State,,Republican,"Kobach, Kris",175,000190
+MCPHERSON,McPherson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",80,000200
+MCPHERSON,McPherson Township,Secretary of State,,Republican,"Kobach, Kris",159,000200
+MCPHERSON,Meridian Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000290
+MCPHERSON,Meridian Township,Secretary of State,,Republican,"Kobach, Kris",75,000290
+MCPHERSON,Mound Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",268,000300
+MCPHERSON,Mound Township,Secretary of State,,Republican,"Kobach, Kris",415,000300
+MCPHERSON,New Gottland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000310
+MCPHERSON,New Gottland Township,Secretary of State,,Republican,"Kobach, Kris",162,000310
+MCPHERSON,Smoky Hill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",51,000320
+MCPHERSON,Smoky Hill Township,Secretary of State,,Republican,"Kobach, Kris",92,000320
+MCPHERSON,South Sharps Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000330
+MCPHERSON,South Sharps Creek Township,Secretary of State,,Republican,"Kobach, Kris",30,000330
+MCPHERSON,Spring Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000340
+MCPHERSON,Spring Valley Township,Secretary of State,,Republican,"Kobach, Kris",96,000340
+MCPHERSON,Superior Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",137,000350
+MCPHERSON,Superior Township,Secretary of State,,Republican,"Kobach, Kris",475,000350
+MCPHERSON,Turkey Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000360
+MCPHERSON,Turkey Creek Township,Secretary of State,,Republican,"Kobach, Kris",76,000360
+MCPHERSON,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000370
+MCPHERSON,Union Township,Secretary of State,,Republican,"Kobach, Kris",56,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",867,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",1506,900010
+MCPHERSON,McPherson Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",237,900020
+MCPHERSON,McPherson Ward 2,Secretary of State,,Republican,"Kobach, Kris",480,900020
+MCPHERSON,McPherson Ward 3 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",127,900030
+MCPHERSON,McPherson Ward 3 Part A,Secretary of State,,Republican,"Kobach, Kris",273,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",302,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Secretary of State,,Republican,"Kobach, Kris",579,900040
+MCPHERSON,McPherson Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900050
+MCPHERSON,Battle Hill Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000010
+MCPHERSON,Battle Hill Township,State Treasurer,,Republican,"Estes, Ron",35,000010
+MCPHERSON,Bonaville Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+MCPHERSON,Bonaville Township,State Treasurer,,Republican,"Estes, Ron",36,000020
+MCPHERSON,Canton Township,State Treasurer,,Democratic,"Alldritt, Carmen",55,000030
+MCPHERSON,Canton Township,State Treasurer,,Republican,"Estes, Ron",240,000030
+MCPHERSON,Castle Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000040
+MCPHERSON,Castle Township,State Treasurer,,Republican,"Estes, Ron",46,000040
+MCPHERSON,Delmore Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000050
+MCPHERSON,Delmore Township,State Treasurer,,Republican,"Estes, Ron",53,000050
+MCPHERSON,Empire Township,State Treasurer,,Democratic,"Alldritt, Carmen",62,000060
+MCPHERSON,Empire Township,State Treasurer,,Republican,"Estes, Ron",329,000060
+MCPHERSON,Groveland Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000070
+MCPHERSON,Groveland Township,State Treasurer,,Republican,"Estes, Ron",69,000070
+MCPHERSON,Gypsum Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000080
+MCPHERSON,Gypsum Creek Township,State Treasurer,,Republican,"Estes, Ron",66,000080
+MCPHERSON,Harper Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000090
+MCPHERSON,Harper Township,State Treasurer,,Republican,"Estes, Ron",59,000090
+MCPHERSON,Hayes Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000100
+MCPHERSON,Hayes Township,State Treasurer,,Republican,"Estes, Ron",72,000100
+MCPHERSON,Jackson Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000110
+MCPHERSON,Jackson Township,State Treasurer,,Republican,"Estes, Ron",68,000110
+MCPHERSON,King City Township,State Treasurer,,Democratic,"Alldritt, Carmen",47,000120
+MCPHERSON,King City Township,State Treasurer,,Republican,"Estes, Ron",172,000120
+MCPHERSON,Lindsborg Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",91,000130
+MCPHERSON,Lindsborg Ward 1,State Treasurer,,Republican,"Estes, Ron",172,000130
+MCPHERSON,Lindsborg Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",131,000140
+MCPHERSON,Lindsborg Ward 2,State Treasurer,,Republican,"Estes, Ron",266,000140
+MCPHERSON,Lindsborg Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",83,000150
+MCPHERSON,Lindsborg Ward 3,State Treasurer,,Republican,"Estes, Ron",204,000150
+MCPHERSON,Lindsborg Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",111,000160
+MCPHERSON,Lindsborg Ward 4,State Treasurer,,Republican,"Estes, Ron",197,000160
+MCPHERSON,Little Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000170
+MCPHERSON,Little Valley Township,State Treasurer,,Republican,"Estes, Ron",136,000170
+MCPHERSON,Lone Tree Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000180
+MCPHERSON,Lone Tree Township,State Treasurer,,Republican,"Estes, Ron",71,000180
+MCPHERSON,Marquette Township,State Treasurer,,Democratic,"Alldritt, Carmen",83,000190
+MCPHERSON,Marquette Township,State Treasurer,,Republican,"Estes, Ron",211,000190
+MCPHERSON,McPherson Township,State Treasurer,,Democratic,"Alldritt, Carmen",43,000200
+MCPHERSON,McPherson Township,State Treasurer,,Republican,"Estes, Ron",191,000200
+MCPHERSON,Meridian Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000290
+MCPHERSON,Meridian Township,State Treasurer,,Republican,"Estes, Ron",91,000290
+MCPHERSON,Mound Township,State Treasurer,,Democratic,"Alldritt, Carmen",161,000300
+MCPHERSON,Mound Township,State Treasurer,,Republican,"Estes, Ron",499,000300
+MCPHERSON,New Gottland Township,State Treasurer,,Democratic,"Alldritt, Carmen",32,000310
+MCPHERSON,New Gottland Township,State Treasurer,,Republican,"Estes, Ron",163,000310
+MCPHERSON,Smoky Hill Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000320
+MCPHERSON,Smoky Hill Township,State Treasurer,,Republican,"Estes, Ron",104,000320
+MCPHERSON,South Sharps Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000330
+MCPHERSON,South Sharps Creek Township,State Treasurer,,Republican,"Estes, Ron",32,000330
+MCPHERSON,Spring Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000340
+MCPHERSON,Spring Valley Township,State Treasurer,,Republican,"Estes, Ron",113,000340
+MCPHERSON,Superior Township,State Treasurer,,Democratic,"Alldritt, Carmen",74,000350
+MCPHERSON,Superior Township,State Treasurer,,Republican,"Estes, Ron",529,000350
+MCPHERSON,Turkey Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000360
+MCPHERSON,Turkey Creek Township,State Treasurer,,Republican,"Estes, Ron",81,000360
+MCPHERSON,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000370
+MCPHERSON,Union Township,State Treasurer,,Republican,"Estes, Ron",59,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",543,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",1793,900010
+MCPHERSON,McPherson Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",161,900020
+MCPHERSON,McPherson Ward 2,State Treasurer,,Republican,"Estes, Ron",545,900020
+MCPHERSON,McPherson Ward 3 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",87,900030
+MCPHERSON,McPherson Ward 3 Part A,State Treasurer,,Republican,"Estes, Ron",305,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",165,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,State Treasurer,,Republican,"Estes, Ron",699,900040
+MCPHERSON,McPherson Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900050
+MCPHERSON,Battle Hill Township,United States Senate,,independent,"Orman, Greg",17,000010
+MCPHERSON,Battle Hill Township,United States Senate,,Libertarian,"Batson, Randall",2,000010
+MCPHERSON,Battle Hill Township,United States Senate,,Republican,"Roberts, Pat",29,000010
+MCPHERSON,Bonaville Township,United States Senate,,independent,"Orman, Greg",2,000020
+MCPHERSON,Bonaville Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+MCPHERSON,Bonaville Township,United States Senate,,Republican,"Roberts, Pat",34,000020
+MCPHERSON,Canton Township,United States Senate,,independent,"Orman, Greg",94,000030
+MCPHERSON,Canton Township,United States Senate,,Libertarian,"Batson, Randall",19,000030
+MCPHERSON,Canton Township,United States Senate,,Republican,"Roberts, Pat",191,000030
+MCPHERSON,Castle Township,United States Senate,,independent,"Orman, Greg",26,000040
+MCPHERSON,Castle Township,United States Senate,,Libertarian,"Batson, Randall",6,000040
+MCPHERSON,Castle Township,United States Senate,,Republican,"Roberts, Pat",33,000040
+MCPHERSON,Delmore Township,United States Senate,,independent,"Orman, Greg",16,000050
+MCPHERSON,Delmore Township,United States Senate,,Libertarian,"Batson, Randall",2,000050
+MCPHERSON,Delmore Township,United States Senate,,Republican,"Roberts, Pat",48,000050
+MCPHERSON,Empire Township,United States Senate,,independent,"Orman, Greg",106,000060
+MCPHERSON,Empire Township,United States Senate,,Libertarian,"Batson, Randall",26,000060
+MCPHERSON,Empire Township,United States Senate,,Republican,"Roberts, Pat",274,000060
+MCPHERSON,Groveland Township,United States Senate,,independent,"Orman, Greg",24,000070
+MCPHERSON,Groveland Township,United States Senate,,Libertarian,"Batson, Randall",7,000070
+MCPHERSON,Groveland Township,United States Senate,,Republican,"Roberts, Pat",51,000070
+MCPHERSON,Gypsum Creek Township,United States Senate,,independent,"Orman, Greg",20,000080
+MCPHERSON,Gypsum Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+MCPHERSON,Gypsum Creek Township,United States Senate,,Republican,"Roberts, Pat",58,000080
+MCPHERSON,Harper Township,United States Senate,,independent,"Orman, Greg",16,000090
+MCPHERSON,Harper Township,United States Senate,,Libertarian,"Batson, Randall",2,000090
+MCPHERSON,Harper Township,United States Senate,,Republican,"Roberts, Pat",51,000090
+MCPHERSON,Hayes Township,United States Senate,,independent,"Orman, Greg",33,000100
+MCPHERSON,Hayes Township,United States Senate,,Libertarian,"Batson, Randall",2,000100
+MCPHERSON,Hayes Township,United States Senate,,Republican,"Roberts, Pat",56,000100
+MCPHERSON,Jackson Township,United States Senate,,independent,"Orman, Greg",35,000110
+MCPHERSON,Jackson Township,United States Senate,,Libertarian,"Batson, Randall",6,000110
+MCPHERSON,Jackson Township,United States Senate,,Republican,"Roberts, Pat",52,000110
+MCPHERSON,King City Township,United States Senate,,independent,"Orman, Greg",82,000120
+MCPHERSON,King City Township,United States Senate,,Libertarian,"Batson, Randall",7,000120
+MCPHERSON,King City Township,United States Senate,,Republican,"Roberts, Pat",135,000120
+MCPHERSON,Lindsborg Ward 1,United States Senate,,independent,"Orman, Greg",137,000130
+MCPHERSON,Lindsborg Ward 1,United States Senate,,Libertarian,"Batson, Randall",15,000130
+MCPHERSON,Lindsborg Ward 1,United States Senate,,Republican,"Roberts, Pat",128,000130
+MCPHERSON,Lindsborg Ward 2,United States Senate,,independent,"Orman, Greg",191,000140
+MCPHERSON,Lindsborg Ward 2,United States Senate,,Libertarian,"Batson, Randall",14,000140
+MCPHERSON,Lindsborg Ward 2,United States Senate,,Republican,"Roberts, Pat",202,000140
+MCPHERSON,Lindsborg Ward 3,United States Senate,,independent,"Orman, Greg",125,000150
+MCPHERSON,Lindsborg Ward 3,United States Senate,,Libertarian,"Batson, Randall",12,000150
+MCPHERSON,Lindsborg Ward 3,United States Senate,,Republican,"Roberts, Pat",157,000150
+MCPHERSON,Lindsborg Ward 4,United States Senate,,independent,"Orman, Greg",150,000160
+MCPHERSON,Lindsborg Ward 4,United States Senate,,Libertarian,"Batson, Randall",19,000160
+MCPHERSON,Lindsborg Ward 4,United States Senate,,Republican,"Roberts, Pat",147,000160
+MCPHERSON,Little Valley Township,United States Senate,,independent,"Orman, Greg",36,000170
+MCPHERSON,Little Valley Township,United States Senate,,Libertarian,"Batson, Randall",5,000170
+MCPHERSON,Little Valley Township,United States Senate,,Republican,"Roberts, Pat",121,000170
+MCPHERSON,Lone Tree Township,United States Senate,,independent,"Orman, Greg",25,000180
+MCPHERSON,Lone Tree Township,United States Senate,,Libertarian,"Batson, Randall",4,000180
+MCPHERSON,Lone Tree Township,United States Senate,,Republican,"Roberts, Pat",58,000180
+MCPHERSON,Marquette Township,United States Senate,,independent,"Orman, Greg",116,000190
+MCPHERSON,Marquette Township,United States Senate,,Libertarian,"Batson, Randall",20,000190
+MCPHERSON,Marquette Township,United States Senate,,Republican,"Roberts, Pat",164,000190
+MCPHERSON,McPherson Township,United States Senate,,independent,"Orman, Greg",78,000200
+MCPHERSON,McPherson Township,United States Senate,,Libertarian,"Batson, Randall",12,000200
+MCPHERSON,McPherson Township,United States Senate,,Republican,"Roberts, Pat",151,000200
+MCPHERSON,Meridian Township,United States Senate,,independent,"Orman, Greg",31,000290
+MCPHERSON,Meridian Township,United States Senate,,Libertarian,"Batson, Randall",5,000290
+MCPHERSON,Meridian Township,United States Senate,,Republican,"Roberts, Pat",67,000290
+MCPHERSON,Mound Township,United States Senate,,independent,"Orman, Greg",292,000300
+MCPHERSON,Mound Township,United States Senate,,Libertarian,"Batson, Randall",36,000300
+MCPHERSON,Mound Township,United States Senate,,Republican,"Roberts, Pat",364,000300
+MCPHERSON,New Gottland Township,United States Senate,,independent,"Orman, Greg",45,000310
+MCPHERSON,New Gottland Township,United States Senate,,Libertarian,"Batson, Randall",8,000310
+MCPHERSON,New Gottland Township,United States Senate,,Republican,"Roberts, Pat",144,000310
+MCPHERSON,Smoky Hill Township,United States Senate,,independent,"Orman, Greg",50,000320
+MCPHERSON,Smoky Hill Township,United States Senate,,Libertarian,"Batson, Randall",7,000320
+MCPHERSON,Smoky Hill Township,United States Senate,,Republican,"Roberts, Pat",89,000320
+MCPHERSON,South Sharps Creek Township,United States Senate,,independent,"Orman, Greg",11,000330
+MCPHERSON,South Sharps Creek Township,United States Senate,,Libertarian,"Batson, Randall",2,000330
+MCPHERSON,South Sharps Creek Township,United States Senate,,Republican,"Roberts, Pat",32,000330
+MCPHERSON,Spring Valley Township,United States Senate,,independent,"Orman, Greg",23,000340
+MCPHERSON,Spring Valley Township,United States Senate,,Libertarian,"Batson, Randall",6,000340
+MCPHERSON,Spring Valley Township,United States Senate,,Republican,"Roberts, Pat",94,000340
+MCPHERSON,Superior Township,United States Senate,,independent,"Orman, Greg",154,000350
+MCPHERSON,Superior Township,United States Senate,,Libertarian,"Batson, Randall",32,000350
+MCPHERSON,Superior Township,United States Senate,,Republican,"Roberts, Pat",436,000350
+MCPHERSON,Turkey Creek Township,United States Senate,,independent,"Orman, Greg",31,000360
+MCPHERSON,Turkey Creek Township,United States Senate,,Libertarian,"Batson, Randall",3,000360
+MCPHERSON,Turkey Creek Township,United States Senate,,Republican,"Roberts, Pat",74,000360
+MCPHERSON,Union Township,United States Senate,,independent,"Orman, Greg",18,000370
+MCPHERSON,Union Township,United States Senate,,Libertarian,"Batson, Randall",4,000370
+MCPHERSON,Union Township,United States Senate,,Republican,"Roberts, Pat",52,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",886,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",118,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",1367,900010
+MCPHERSON,McPherson Ward 2,United States Senate,,independent,"Orman, Greg",258,900020
+MCPHERSON,McPherson Ward 2,United States Senate,,Libertarian,"Batson, Randall",40,900020
+MCPHERSON,McPherson Ward 2,United States Senate,,Republican,"Roberts, Pat",428,900020
+MCPHERSON,McPherson Ward 3 Part A,United States Senate,,independent,"Orman, Greg",135,900030
+MCPHERSON,McPherson Ward 3 Part A,United States Senate,,Libertarian,"Batson, Randall",20,900030
+MCPHERSON,McPherson Ward 3 Part A,United States Senate,,Republican,"Roberts, Pat",244,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States Senate,,independent,"Orman, Greg",325,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States Senate,,Libertarian,"Batson, Randall",45,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States Senate,,Republican,"Roberts, Pat",512,900040
+MCPHERSON,McPherson Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900050

--- a/2014/20141104__ks__general__meade__precinct.csv
+++ b/2014/20141104__ks__general__meade__precinct.csv
@@ -1,168 +1,163 @@
-county,precinct,office,district,party,candidate,votes
-Meade,FOWLER,Attorney General,,D,A.J. Kotich,26
-Meade,LOGAN,Attorney General,,D,A.J. Kotich,8
-Meade,SAND CRK,Attorney General,,D,A.J. Kotich,0
-Meade,MEADE CTR,Attorney General,,D,A.J. Kotich,89
-Meade,CROOKED CRK,Attorney General,,D,A.J. Kotich,4
-Meade,ODEE,Attorney General,,D,A.J. Kotich,1
-Meade,W PLAINS,Attorney General,,D,A.J. Kotich,58
-Meade,MERTILLA,Attorney General,,D,A.J. Kotich,4
-Meade,CIMARRON,Attorney General,,D,A.J. Kotich,3
-Meade,FOWLER,Attorney General,,R,Derek Schmidt,190
-Meade,LOGAN,Attorney General,,R,Derek Schmidt,47
-Meade,SAND CRK,Attorney General,,R,Derek Schmidt,16
-Meade,MEADE CTR,Attorney General,,R,Derek Schmidt,624
-Meade,CROOKED CRK,Attorney General,,R,Derek Schmidt,31
-Meade,ODEE,Attorney General,,R,Derek Schmidt,15
-Meade,W PLAINS,Attorney General,,R,Derek Schmidt,208
-Meade,MERTILLA,Attorney General,,R,Derek Schmidt,35
-Meade,CIMARRON,Attorney General,,R,Derek Schmidt,28
-Meade,MEADE CTR,U.S. House,1,,Melvin Neufeld,1
-Meade,W PLAINS,U.S. House,1,,Melvin Neufeld,1
-Meade,FOWLER,U.S. House,1,D,James Sherow,44
-Meade,LOGAN,U.S. House,1,D,James Sherow,17
-Meade,SAND CRK,U.S. House,1,D,James Sherow,1
-Meade,MEADE CTR,U.S. House,1,D,James Sherow,179
-Meade,CROOKED CRK,U.S. House,1,D,James Sherow,6
-Meade,ODEE,U.S. House,1,D,James Sherow,1
-Meade,W PLAINS,U.S. House,1,D,James Sherow,84
-Meade,MERTILLA,U.S. House,1,D,James Sherow,10
-Meade,CIMARRON,U.S. House,1,D,James Sherow,4
-Meade,FOWLER,U.S. House,1,R,Tim Huelskamp,185
-Meade,LOGAN,U.S. House,1,R,Tim Huelskamp,37
-Meade,SAND CRK,U.S. House,1,R,Tim Huelskamp,16
-Meade,MEADE CTR,U.S. House,1,R,Tim Huelskamp,543
-Meade,CROOKED CRK,U.S. House,1,R,Tim Huelskamp,31
-Meade,ODEE,U.S. House,1,R,Tim Huelskamp,15
-Meade,W PLAINS,U.S. House,1,R,Tim Huelskamp,187
-Meade,MERTILLA,U.S. House,1,R,Tim Huelskamp,30
-Meade,CIMARRON,U.S. House,1,R,Tim Huelskamp,27
-Meade,MEADE CTR,GOVERNOR,,,Write-ins,1
-Meade,FOWLER,GOVERNOR,,L,Keen A. Umberhr,5
-Meade,LOGAN,GOVERNOR,,L,Keen A. Umberhr,3
-Meade,SAND CRK,GOVERNOR,,L,Keen A. Umberhr,0
-Meade,MEADE CTR,GOVERNOR,,L,Keen A. Umberhr,31
-Meade,CROOKED CRK,GOVERNOR,,L,Keen A. Umberhr,1
-Meade,ODEE,GOVERNOR,,L,Keen A. Umberhr,1
-Meade,W PLAINS,GOVERNOR,,L,Keen A. Umberhr,13
-Meade,MERTILLA,GOVERNOR,,L,Keen A. Umberhr,1
-Meade,CIMARRON,GOVERNOR,,L,Keen A. Umberhr,0
-Meade,FOWLER,GOVERNOR,,D,Paul Davis,58
-Meade,LOGAN,GOVERNOR,,D,Paul Davis,12
-Meade,SAND CRK,GOVERNOR,,D,Paul Davis,0
-Meade,MEADE CTR,GOVERNOR,,D,Paul Davis,197
-Meade,CROOKED CRK,GOVERNOR,,D,Paul Davis,7
-Meade,ODEE,GOVERNOR,,D,Paul Davis,1
-Meade,W PLAINS,GOVERNOR,,D,Paul Davis,96
-Meade,MERTILLA,GOVERNOR,,D,Paul Davis,6
-Meade,CIMARRON,GOVERNOR,,D,Paul Davis,4
-Meade,FOWLER,GOVERNOR,,R,Sam Brownback,166
-Meade,LOGAN,GOVERNOR,,R,Sam Brownback,41
-Meade,SAND CRK,GOVERNOR,,R,Sam Brownback,17
-Meade,MEADE CTR,GOVERNOR,,R,Sam Brownback,501
-Meade,CROOKED CRK,GOVERNOR,,R,Sam Brownback,30
-Meade,ODEE,GOVERNOR,,R,Sam Brownback,14
-Meade,W PLAINS,GOVERNOR,,R,Sam Brownback,165
-Meade,MERTILLA,GOVERNOR,,R,Sam Brownback,33
-Meade,CIMARRON,GOVERNOR,,R,Sam Brownback,27
-Meade,MEADE CTR,Insurance Commissioner,,,Write-ins,2
-Meade,FOWLER,Insurance Commissioner,,D,Dennis Anderson,36
-Meade,LOGAN,Insurance Commissioner,,D,Dennis Anderson,8
-Meade,SAND CRK,Insurance Commissioner,,D,Dennis Anderson,0
-Meade,MEADE CTR,Insurance Commissioner,,D,Dennis Anderson,118
-Meade,CROOKED CRK,Insurance Commissioner,,D,Dennis Anderson,3
-Meade,ODEE,Insurance Commissioner,,D,Dennis Anderson,1
-Meade,W PLAINS,Insurance Commissioner,,D,Dennis Anderson,56
-Meade,MERTILLA,Insurance Commissioner,,D,Dennis Anderson,4
-Meade,CIMARRON,Insurance Commissioner,,D,Dennis Anderson,4
-Meade,FOWLER,Insurance Commissioner,,R,Ken Selzer,176
-Meade,LOGAN,Insurance Commissioner,,R,Ken Selzer,44
-Meade,SAND CRK,Insurance Commissioner,,R,Ken Selzer,17
-Meade,MEADE CTR,Insurance Commissioner,,R,Ken Selzer,587
-Meade,CROOKED CRK,Insurance Commissioner,,R,Ken Selzer,33
-Meade,ODEE,Insurance Commissioner,,R,Ken Selzer,15
-Meade,W PLAINS,Insurance Commissioner,,R,Ken Selzer,202
-Meade,MERTILLA,Insurance Commissioner,,R,Ken Selzer,35
-Meade,CIMARRON,Insurance Commissioner,,R,Ken Selzer,24
-Meade,FOWLER,Secretary of State,,D,Jean Kurtis Schodorf,49
-Meade,LOGAN,Secretary of State,,D,Jean Kurtis Schodorf,9
-Meade,SAND CRK,Secretary of State,,D,Jean Kurtis Schodorf,1
-Meade,MEADE CTR,Secretary of State,,D,Jean Kurtis Schodorf,156
-Meade,CROOKED CRK,Secretary of State,,D,Jean Kurtis Schodorf,4
-Meade,ODEE,Secretary of State,,D,Jean Kurtis Schodorf,2
-Meade,W PLAINS,Secretary of State,,D,Jean Kurtis Schodorf,77
-Meade,MERTILLA,Secretary of State,,D,Jean Kurtis Schodorf,9
-Meade,CIMARRON,Secretary of State,,D,Jean Kurtis Schodorf,5
-Meade,FOWLER,Secretary of State,,R,Kris Kobach,172
-Meade,LOGAN,Secretary of State,,R,Kris Kobach,46
-Meade,SAND CRK,Secretary of State,,R,Kris Kobach,16
-Meade,MEADE CTR,Secretary of State,,R,Kris Kobach,569
-Meade,CROOKED CRK,Secretary of State,,R,Kris Kobach,32
-Meade,ODEE,Secretary of State,,R,Kris Kobach,14
-Meade,W PLAINS,Secretary of State,,R,Kris Kobach,195
-Meade,MERTILLA,Secretary of State,,R,Kris Kobach,30
-Meade,CIMARRON,Secretary of State,,R,Kris Kobach,26
-Meade,FOWLER,State House,115,D,Mark Low,95
-Meade,LOGAN,State House,115,D,Mark Low,11
-Meade,SAND CRK,State House,115,D,Mark Low,1
-Meade,MEADE CTR,State House,115,D,Mark Low,220
-Meade,CROOKED CRK,State House,115,D,Mark Low,10
-Meade,ODEE,State House,115,D,Mark Low,1
-Meade,W PLAINS,State House,115,D,Mark Low,83
-Meade,MERTILLA,State House,115,D,Mark Low,9
-Meade,CIMARRON,State House,115,D,Mark Low,5
-Meade,FOWLER,State House,115,R,Ronald W Ryckman Sr,134
-Meade,LOGAN,State House,115,R,Ronald W Ryckman Sr,44
-Meade,SAND CRK,State House,115,R,Ronald W Ryckman Sr,16
-Meade,MEADE CTR,State House,115,R,Ronald W Ryckman Sr,508
-Meade,CROOKED CRK,State House,115,R,Ronald W Ryckman Sr,26
-Meade,ODEE,State House,115,R,Ronald W Ryckman Sr,15
-Meade,W PLAINS,State House,115,R,Ronald W Ryckman Sr,187
-Meade,MERTILLA,State House,115,R,Ronald W Ryckman Sr,30
-Meade,CIMARRON,State House,115,R,Ronald W Ryckman Sr,25
-Meade,MEADE CTR,State Treasurer,,,Write-ins,1
-Meade,LOGAN,State Treasurer,,D,Carment Alldritt,6
-Meade,SAND CRK,State Treasurer,,D,Carment Alldritt,0
-Meade,MEADE CTR,State Treasurer,,D,Carment Alldritt,86
-Meade,CROOKED CRK,State Treasurer,,D,Carment Alldritt,1
-Meade,ODEE,State Treasurer,,D,Carment Alldritt,1
-Meade,W PLAINS,State Treasurer,,D,Carment Alldritt,44
-Meade,MERTILLA,State Treasurer,,D,Carment Alldritt,4
-Meade,CIMARRON,State Treasurer,,D,Carment Alldritt,3
-Meade,FOWLER,State Treasurer,,R,Ron Estes,195
-Meade,LOGAN,State Treasurer,,R,Ron Estes,50
-Meade,SAND CRK,State Treasurer,,R,Ron Estes,17
-Meade,MEADE CTR,State Treasurer,,R,Ron Estes,632
-Meade,CROOKED CRK,State Treasurer,,R,Ron Estes,35
-Meade,ODEE,State Treasurer,,R,Ron Estes,15
-Meade,W PLAINS,State Treasurer,,R,Ron Estes,223
-Meade,MERTILLA,State Treasurer,,R,Ron Estes,35
-Meade,CIMARRON,State Treasurer,,R,Ron Estes,26
-Meade,SAND CRK,U.S. Senate,,,Wayne Watkins,1
-Meade,FOWLER,U.S. Senate,,I,Greg Orman,45
-Meade,LOGAN,U.S. Senate,,I,Greg Orman,11
-Meade,SAND CRK,U.S. Senate,,I,Greg Orman,2
-Meade,MEADE CTR,U.S. Senate,,I,Greg Orman,155
-Meade,CROOKED CRK,U.S. Senate,,I,Greg Orman,4
-Meade,ODEE,U.S. Senate,,I,Greg Orman,2
-Meade,W PLAINS,U.S. Senate,,I,Greg Orman,87
-Meade,MERTILLA,U.S. Senate,,I,Greg Orman,4
-Meade,CIMARRON,U.S. Senate,,I,Greg Orman,4
-Meade,FOWLER,U.S. Senate,,R,Pat Roberts,176
-Meade,LOGAN,U.S. Senate,,R,Pat Roberts,43
-Meade,SAND CRK,U.S. Senate,,R,Pat Roberts,14
-Meade,MEADE CTR,U.S. Senate,,R,Pat Roberts,556
-Meade,CROOKED CRK,U.S. Senate,,R,Pat Roberts,1
-Meade,ODEE,U.S. Senate,,R,Pat Roberts,13
-Meade,W PLAINS,U.S. Senate,,R,Pat Roberts,170
-Meade,MERTILLA,U.S. Senate,,R,Pat Roberts,35
-Meade,CIMARRON,U.S. Senate,,R,Pat Roberts,27
-Meade,FOWLER,U.S. Senate,,L,Randall Batson,9
-Meade,LOGAN,U.S. Senate,,L,Randall Batson,2
-Meade,SAND CRK,U.S. Senate,,L,Randall Batson,0
-Meade,MEADE CTR,U.S. Senate,,L,Randall Batson,21
-Meade,CROOKED CRK,U.S. Senate,,L,Randall Batson,0
-Meade,ODEE,U.S. Senate,,L,Randall Batson,1
-Meade,W PLAINS,U.S. Senate,,L,Randall Batson,17
-Meade,MERTILLA,U.S. Senate,,L,Randall Batson,2
-Meade,CIMARRON,U.S. Senate,,L,Randall Batson,0
+county,precinct,office,district,party,candidate,votes,vtd
+MEADE,Cimarron Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000010
+MEADE,Cimarron Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+MEADE,Cimarron Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000010
+MEADE,Crooked Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000020
+MEADE,Crooked Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+MEADE,Crooked Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000020
+MEADE,Fowler Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",58,000030
+MEADE,Fowler Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000030
+MEADE,Fowler Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",166,000030
+MEADE,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000040
+MEADE,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+MEADE,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000040
+MEADE,Meade Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",197,000050
+MEADE,Meade Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",31,000050
+MEADE,Meade Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",501,000050
+MEADE,Mertilla Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000060
+MEADE,Mertilla Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+MEADE,Mertilla Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000060
+MEADE,Odee Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000070
+MEADE,Odee Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+MEADE,Odee Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000070
+MEADE,Sand Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000080
+MEADE,Sand Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+MEADE,Sand Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000080
+MEADE,West Plains Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",96,000090
+MEADE,West Plains Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000090
+MEADE,West Plains Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",165,000090
+MEADE,Cimarron Township,Kansas House of Representatives,115,Democratic,"Low, Mark",5,000010
+MEADE,Cimarron Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",25,000010
+MEADE,Crooked Creek Township,Kansas House of Representatives,115,Democratic,"Low, Mark",10,000020
+MEADE,Crooked Creek Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",26,000020
+MEADE,Fowler Township,Kansas House of Representatives,115,Democratic,"Low, Mark",95,000030
+MEADE,Fowler Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",134,000030
+MEADE,Logan Township,Kansas House of Representatives,115,Democratic,"Low, Mark",11,000040
+MEADE,Logan Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",44,000040
+MEADE,Meade Center Township,Kansas House of Representatives,115,Democratic,"Low, Mark",220,000050
+MEADE,Meade Center Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",508,000050
+MEADE,Mertilla Township,Kansas House of Representatives,115,Democratic,"Low, Mark",9,000060
+MEADE,Mertilla Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",30,000060
+MEADE,Odee Township,Kansas House of Representatives,115,Democratic,"Low, Mark",1,000070
+MEADE,Odee Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",15,000070
+MEADE,Sand Creek Township,Kansas House of Representatives,115,Democratic,"Low, Mark",1,000080
+MEADE,Sand Creek Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",16,000080
+MEADE,West Plains Township,Kansas House of Representatives,115,Democratic,"Low, Mark",83,000090
+MEADE,West Plains Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald W Sr.",187,000090
+MEADE,Cimarron Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000010
+MEADE,Cimarron Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000010
+MEADE,Crooked Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000020
+MEADE,Crooked Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000020
+MEADE,Fowler Township,United States House of Representatives,1,Democratic,"Sherow, James E.",44,000030
+MEADE,Fowler Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",185,000030
+MEADE,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000040
+MEADE,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000040
+MEADE,Meade Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",179,000050
+MEADE,Meade Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",543,000050
+MEADE,Mertilla Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000060
+MEADE,Mertilla Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000060
+MEADE,Odee Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000070
+MEADE,Odee Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000070
+MEADE,Sand Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000080
+MEADE,Sand Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000080
+MEADE,West Plains Township,United States House of Representatives,1,Democratic,"Sherow, James E.",84,000090
+MEADE,West Plains Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",187,000090
+MEADE,Cimarron Township,Attorney General,,Democratic,"Kotich, A.J.",3,000010
+MEADE,Cimarron Township,Attorney General,,Republican,"Schmidt, Derek",28,000010
+MEADE,Crooked Creek Township,Attorney General,,Democratic,"Kotich, A.J.",4,000020
+MEADE,Crooked Creek Township,Attorney General,,Republican,"Schmidt, Derek",31,000020
+MEADE,Fowler Township,Attorney General,,Democratic,"Kotich, A.J.",26,000030
+MEADE,Fowler Township,Attorney General,,Republican,"Schmidt, Derek",190,000030
+MEADE,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",8,000040
+MEADE,Logan Township,Attorney General,,Republican,"Schmidt, Derek",47,000040
+MEADE,Meade Center Township,Attorney General,,Democratic,"Kotich, A.J.",89,000050
+MEADE,Meade Center Township,Attorney General,,Republican,"Schmidt, Derek",624,000050
+MEADE,Mertilla Township,Attorney General,,Democratic,"Kotich, A.J.",4,000060
+MEADE,Mertilla Township,Attorney General,,Republican,"Schmidt, Derek",35,000060
+MEADE,Odee Township,Attorney General,,Democratic,"Kotich, A.J.",1,000070
+MEADE,Odee Township,Attorney General,,Republican,"Schmidt, Derek",15,000070
+MEADE,Sand Creek Township,Attorney General,,Democratic,"Kotich, A.J.",0,000080
+MEADE,Sand Creek Township,Attorney General,,Republican,"Schmidt, Derek",16,000080
+MEADE,West Plains Township,Attorney General,,Democratic,"Kotich, A.J.",58,000090
+MEADE,West Plains Township,Attorney General,,Republican,"Schmidt, Derek",208,000090
+MEADE,Cimarron Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000010
+MEADE,Cimarron Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000010
+MEADE,Crooked Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000020
+MEADE,Crooked Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000020
+MEADE,Fowler Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000030
+MEADE,Fowler Township,Commissioner of Insurance,,Republican,"Selzer, Ken",176,000030
+MEADE,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000040
+MEADE,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",44,000040
+MEADE,Meade Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",118,000050
+MEADE,Meade Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",587,000050
+MEADE,Mertilla Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000060
+MEADE,Mertilla Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000060
+MEADE,Odee Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000070
+MEADE,Odee Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000070
+MEADE,Sand Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000080
+MEADE,Sand Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000080
+MEADE,West Plains Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,000090
+MEADE,West Plains Township,Commissioner of Insurance,,Republican,"Selzer, Ken",202,000090
+MEADE,Cimarron Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000010
+MEADE,Cimarron Township,Secretary of State,,Republican,"Kobach, Kris",26,000010
+MEADE,Crooked Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000020
+MEADE,Crooked Creek Township,Secretary of State,,Republican,"Kobach, Kris",32,000020
+MEADE,Fowler Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000030
+MEADE,Fowler Township,Secretary of State,,Republican,"Kobach, Kris",172,000030
+MEADE,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000040
+MEADE,Logan Township,Secretary of State,,Republican,"Kobach, Kris",46,000040
+MEADE,Meade Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",156,000050
+MEADE,Meade Center Township,Secretary of State,,Republican,"Kobach, Kris",569,000050
+MEADE,Mertilla Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000060
+MEADE,Mertilla Township,Secretary of State,,Republican,"Kobach, Kris",30,000060
+MEADE,Odee Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000070
+MEADE,Odee Township,Secretary of State,,Republican,"Kobach, Kris",14,000070
+MEADE,Sand Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000080
+MEADE,Sand Creek Township,Secretary of State,,Republican,"Kobach, Kris",16,000080
+MEADE,West Plains Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,000090
+MEADE,West Plains Township,Secretary of State,,Republican,"Kobach, Kris",195,000090
+MEADE,Cimarron Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000010
+MEADE,Cimarron Township,State Treasurer,,Republican,"Estes, Ron",26,000010
+MEADE,Crooked Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000020
+MEADE,Crooked Creek Township,State Treasurer,,Republican,"Estes, Ron",35,000020
+MEADE,Fowler Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000030
+MEADE,Fowler Township,State Treasurer,,Republican,"Estes, Ron",195,000030
+MEADE,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000040
+MEADE,Logan Township,State Treasurer,,Republican,"Estes, Ron",50,000040
+MEADE,Meade Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",86,000050
+MEADE,Meade Center Township,State Treasurer,,Republican,"Estes, Ron",632,000050
+MEADE,Mertilla Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000060
+MEADE,Mertilla Township,State Treasurer,,Republican,"Estes, Ron",35,000060
+MEADE,Odee Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000070
+MEADE,Odee Township,State Treasurer,,Republican,"Estes, Ron",15,000070
+MEADE,Sand Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000080
+MEADE,Sand Creek Township,State Treasurer,,Republican,"Estes, Ron",17,000080
+MEADE,West Plains Township,State Treasurer,,Democratic,"Alldritt, Carmen",44,000090
+MEADE,West Plains Township,State Treasurer,,Republican,"Estes, Ron",223,000090
+MEADE,Cimarron Township,United States Senate,,independent,"Orman, Greg",4,000010
+MEADE,Cimarron Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+MEADE,Cimarron Township,United States Senate,,Republican,"Roberts, Pat",27,000010
+MEADE,Crooked Creek Township,United States Senate,,independent,"Orman, Greg",4,000020
+MEADE,Crooked Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+MEADE,Crooked Creek Township,United States Senate,,Republican,"Roberts, Pat",1,000020
+MEADE,Fowler Township,United States Senate,,independent,"Orman, Greg",45,000030
+MEADE,Fowler Township,United States Senate,,Libertarian,"Batson, Randall",9,000030
+MEADE,Fowler Township,United States Senate,,Republican,"Roberts, Pat",176,000030
+MEADE,Logan Township,United States Senate,,independent,"Orman, Greg",11,000040
+MEADE,Logan Township,United States Senate,,Libertarian,"Batson, Randall",2,000040
+MEADE,Logan Township,United States Senate,,Republican,"Roberts, Pat",43,000040
+MEADE,Meade Center Township,United States Senate,,independent,"Orman, Greg",155,000050
+MEADE,Meade Center Township,United States Senate,,Libertarian,"Batson, Randall",21,000050
+MEADE,Meade Center Township,United States Senate,,Republican,"Roberts, Pat",556,000050
+MEADE,Mertilla Township,United States Senate,,independent,"Orman, Greg",4,000060
+MEADE,Mertilla Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+MEADE,Mertilla Township,United States Senate,,Republican,"Roberts, Pat",35,000060
+MEADE,Odee Township,United States Senate,,independent,"Orman, Greg",2,000070
+MEADE,Odee Township,United States Senate,,Libertarian,"Batson, Randall",1,000070
+MEADE,Odee Township,United States Senate,,Republican,"Roberts, Pat",13,000070
+MEADE,Sand Creek Township,United States Senate,,independent,"Orman, Greg",2,000080
+MEADE,Sand Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+MEADE,Sand Creek Township,United States Senate,,Republican,"Roberts, Pat",14,000080
+MEADE,West Plains Township,United States Senate,,independent,"Orman, Greg",87,000090
+MEADE,West Plains Township,United States Senate,,Libertarian,"Batson, Randall",17,000090
+MEADE,West Plains Township,United States Senate,,Republican,"Roberts, Pat",170,000090

--- a/2014/20141104__ks__general__miami__precinct.csv
+++ b/2014/20141104__ks__general__miami__precinct.csv
@@ -1,1357 +1,1280 @@
-county,precinct,office,district,party,candidate,votes,advance,polls
-Miami,EMC(2),Voters,,,Registered,178,,
-Miami,EMC(3),Voters,,,Registered,588,,
-Miami,EV,Voters,,,Registered,300,,
-Miami,FC,Voters,,,Registered,104,,
-Miami,LC 01,Voters,,,Registered,564,,
-Miami,LC 02,Voters,,,Registered,725,,
-Miami,LC 03,Voters,,,Registered,705,,
-Miami,LC 04,Voters,,,Registered,657,,
-Miami,MI,Voters,,,Registered,380,,
-Miami,MND,Voters,,,Registered,477,,
-Miami,NMV(2),Voters,,,Registered,190,,
-Miami,NMV(3),Voters,,,Registered,555,,
-Miami,NPW,Voters,,,Registered,328,,
-Miami,NPE Prt1,Voters,,,Registered,14,,
-Miami,NPE Prt2,Voters,,,Registered,105,,
-Miami,NW,Voters,,,Registered,457,,
-Miami,OSAGE,Voters,,,Registered,312,,
-Miami,OC 01,Voters,,,Registered,468,,
-Miami,OC 02,Voters,,,Registered,593,,
-Miami,OC 03,Voters,,,Registered,633,,
-Miami,OC 04,Voters,,,Registered,481,,
-Miami,OSA TWP,Voters,,,Registered,481,,
-Miami,PC 01,Voters,,,Registered,846,,
-Miami,PC 02,Voters,,,Registered,836,,
-Miami,PC 03,Voters,,,Registered,842,,
-Miami,PC 04,Voters,,,Registered,943,,
-Miami,RICH,Voters,,,Registered,1413,,
-Miami,SMV(3),Voters,,,Registered,21,,
-Miami,SMV(2),Voters,,,Registered,950,,
-Miami,SPE Prt2,Voters,,,Registered,136,,
-Miami,SPW,Voters,,,Registered,220,,
-Miami,SW,Voters,,,Registered,996,,
-Miami,SH 01,Voters,,,Registered,1107,,
-Miami,SH 02,Voters,,,Registered,292,,
-Miami,SH 03,Voters,,,Registered,69,,
-Miami,STAN 368,Voters,,,Registered,439,,
-Miami,STAN 367,Voters,,,Registered,194,,
-Miami,SC,Voters,,,Registered,319,,
-Miami,TM,Voters,,,Registered,1007,,
-Miami,WMC 416,Voters,,,Registered,139,,
-Miami,WMC 368,Voters,,,Registered,394,,
-Miami,WV(6),Voters,,,Registered,184,,
-Miami,WV(12) 368,Voters,,,Registered,95,,
-Miami,WV(12) 367,Voters,,,Registered,187,,
-Miami,WV(5),Voters,,,Registered,201,,
-Miami,EMC(2),Voters,,,Cast,92,,
-Miami,EMC(3),Voters,,,Cast,336,,
-Miami,EV,Voters,,,Cast,177,,
-Miami,FC,Voters,,,Cast,46,,
-Miami,LC 01,Voters,,,Cast,269,,
-Miami,LC 02,Voters,,,Cast,338,,
-Miami,LC 03,Voters,,,Cast,332,,
-Miami,LC 04,Voters,,,Cast,319,,
-Miami,MI,Voters,,,Cast,219,,
-Miami,MND,Voters,,,Cast,249,,
-Miami,NMV(2),Voters,,,Cast,108,,
-Miami,NMV(3),Voters,,,Cast,309,,
-Miami,NPW,Voters,,,Cast,187,,
-Miami,NPE Prt1,Voters,,,Cast,9,,
-Miami,NPE Prt2,Voters,,,Cast,70,,
-Miami,NW,Voters,,,Cast,265,,
-Miami,OSAGE,Voters,,,Cast,173,,
-Miami,OC 01,Voters,,,Cast,172,,
-Miami,OC 02,Voters,,,Cast,278,,
-Miami,OC 03,Voters,,,Cast,299,,
-Miami,OC 04,Voters,,,Cast,153,,
-Miami,OSA TWP,Voters,,,Cast,260,,
-Miami,PC 01,Voters,,,Cast,403,,
-Miami,PC 02,Voters,,,Cast,319,,
-Miami,PC 03,Voters,,,Cast,402,,
-Miami,PC 04,Voters,,,Cast,451,,
-Miami,RICH,Voters,,,Cast,764,,
-Miami,SMV(3),Voters,,,Cast,7,,
-Miami,SMV(2),Voters,,,Cast,523,,
-Miami,SPE Prt2,Voters,,,Cast,74,,
-Miami,SPW,Voters,,,Cast,113,,
-Miami,SW,Voters,,,Cast,591,,
-Miami,SH 01,Voters,,,Cast,454,,
-Miami,SH 02,Voters,,,Cast,137,,
-Miami,SH 03,Voters,,,Cast,39,,
-Miami,STAN 368,Voters,,,Cast,214,,
-Miami,STAN 367,Voters,,,Cast,106,,
-Miami,SC,Voters,,,Cast,173,,
-Miami,TM,Voters,,,Cast,559,,
-Miami,WMC 416,Voters,,,Cast,65,,
-Miami,WMC 368,Voters,,,Cast,215,,
-Miami,WV(6),Voters,,,Cast,97,,
-Miami,WV(12) 368,Voters,,,Cast,46,,
-Miami,WV(12) 367,Voters,,,Cast,119,,
-Miami,WV(5),Voters,,,Cast,96,,
-Miami,EMC(2),U.S. Senate,,I,Greg Orman,26,12,38
-Miami,EMC(3),U.S. Senate,,I,Greg Orman,94,22,116
-Miami,EV,U.S. Senate,,I,Greg Orman,48,17,65
-Miami,FC,U.S. Senate,,I,Greg Orman,16,3,19
-Miami,LC 01,U.S. Senate,,I,Greg Orman,88,20,108
-Miami,LC 02,U.S. Senate,,I,Greg Orman,121,13,134
-Miami,LC 03,U.S. Senate,,I,Greg Orman,100,23,123
-Miami,LC 04,U.S. Senate,,I,Greg Orman,102,18,120
-Miami,MI,U.S. Senate,,I,Greg Orman,55,17,72
-Miami,MND,U.S. Senate,,I,Greg Orman,70,32,102
-Miami,NMV(2),U.S. Senate,,I,Greg Orman,18,6,24
-Miami,NMV(3),U.S. Senate,,I,Greg Orman,86,35,121
-Miami,NPW,U.S. Senate,,I,Greg Orman,49,23,72
-Miami,NPE Prt1,U.S. Senate,,I,Greg Orman,5,0,5
-Miami,NPE Prt2,U.S. Senate,,I,Greg Orman,13,6,19
-Miami,NW,U.S. Senate,,I,Greg Orman,69,12,81
-Miami,OSAGE,U.S. Senate,,I,Greg Orman,55,17,72
-Miami,OC 01,U.S. Senate,,I,Greg Orman,63,26,89
-Miami,OC 02,U.S. Senate,,I,Greg Orman,96,35,131
-Miami,OC 03,U.S. Senate,,I,Greg Orman,108,44,152
-Miami,OC 04,U.S. Senate,,I,Greg Orman,56,17,73
-Miami,OSA TWP,U.S. Senate,,I,Greg Orman,78,31,109
-Miami,PC 01,U.S. Senate,,I,Greg Orman,86,84,170
-Miami,PC 02,U.S. Senate,,I,Greg Orman,91,59,150
-Miami,PC 03,U.S. Senate,,I,Greg Orman,103,69,172
-Miami,PC 04,U.S. Senate,,I,Greg Orman,104,83,187
-Miami,RICH,U.S. Senate,,I,Greg Orman,147,87,234
-Miami,SMV(3),U.S. Senate,,I,Greg Orman,2,0,2
-Miami,SMV(2),U.S. Senate,,I,Greg Orman,129,64,193
-Miami,SPE Prt2,U.S. Senate,,I,Greg Orman,18,12,30
-Miami,SPW,U.S. Senate,,I,Greg Orman,30,22,52
-Miami,SW,U.S. Senate,,I,Greg Orman,113,36,149
-Miami,SH 01,U.S. Senate,,I,Greg Orman,139,26,165
-Miami,SH 02,U.S. Senate,,I,Greg Orman,38,24,62
-Miami,SH 03,U.S. Senate,,I,Greg Orman,13,2,15
-Miami,STAN 368,U.S. Senate,,I,Greg Orman,52,40,92
-Miami,STAN 367,U.S. Senate,,I,Greg Orman,19,15,34
-Miami,SC,U.S. Senate,,I,Greg Orman,41,10,51
-Miami,TM,U.S. Senate,,I,Greg Orman,124,49,173
-Miami,WMC 416,U.S. Senate,,I,Greg Orman,18,5,23
-Miami,WMC 368,U.S. Senate,,I,Greg Orman,38,23,61
-Miami,WV(6),U.S. Senate,,I,Greg Orman,17,25,42
-Miami,WV(12) 368,U.S. Senate,,I,Greg Orman,12,5,17
-Miami,WV(12) 367,U.S. Senate,,I,Greg Orman,31,22,53
-Miami,WV(5),U.S. Senate,,I,Greg Orman,30,10,40
-Miami,EMC(2),U.S. Senate,,R,Pat Roberts,46,6,52
-Miami,EMC(3),U.S. Senate,,R,Pat Roberts,172,42,214
-Miami,EV,U.S. Senate,,R,Pat Roberts,76,29,105
-Miami,FC,U.S. Senate,,R,Pat Roberts,18,4,22
-Miami,LC 01,U.S. Senate,,R,Pat Roberts,110,25,135
-Miami,LC 02,U.S. Senate,,R,Pat Roberts,172,19,191
-Miami,LC 03,U.S. Senate,,R,Pat Roberts,168,21,189
-Miami,LC 04,U.S. Senate,,R,Pat Roberts,157,23,180
-Miami,MI,U.S. Senate,,R,Pat Roberts,103,29,132
-Miami,MND,U.S. Senate,,R,Pat Roberts,103,29,132
-Miami,NMV(2),U.S. Senate,,R,Pat Roberts,62,17,79
-Miami,NMV(3),U.S. Senate,,R,Pat Roberts,155,25,180
-Miami,NPW,U.S. Senate,,R,Pat Roberts,78,31,109
-Miami,NPE Prt1,U.S. Senate,,R,Pat Roberts,3,1,4
-Miami,NPE Prt2,U.S. Senate,,R,Pat Roberts,38,8,46
-Miami,NW,U.S. Senate,,R,Pat Roberts,162,14,176
-Miami,OSAGE,U.S. Senate,,R,Pat Roberts,87,8,95
-Miami,OC 01,U.S. Senate,,R,Pat Roberts,58,19,77
-Miami,OC 02,U.S. Senate,,R,Pat Roberts,90,25,115
-Miami,OC 03,U.S. Senate,,R,Pat Roberts,99,29,128
-Miami,OC 04,U.S. Senate,,R,Pat Roberts,52,14,66
-Miami,OSA TWP,U.S. Senate,,R,Pat Roberts,110,30,140
-Miami,PC 01,U.S. Senate,,R,Pat Roberts,134,84,218
-Miami,PC 02,U.S. Senate,,R,Pat Roberts,106,39,145
-Miami,PC 03,U.S. Senate,,R,Pat Roberts,143,65,208
-Miami,PC 04,U.S. Senate,,R,Pat Roberts,137,97,234
-Miami,RICH,U.S. Senate,,R,Pat Roberts,354,142,496
-Miami,SMV(3),U.S. Senate,,R,Pat Roberts,5,0,5
-Miami,SMV(2),U.S. Senate,,R,Pat Roberts,247,58,305
-Miami,SPE Prt2,U.S. Senate,,R,Pat Roberts,24,12,36
-Miami,SPW,U.S. Senate,,R,Pat Roberts,43,12,55
-Miami,SW,U.S. Senate,,R,Pat Roberts,358,67,425
-Miami,SH 01,U.S. Senate,,R,Pat Roberts,245,22,267
-Miami,SH 02,U.S. Senate,,R,Pat Roberts,57,14,71
-Miami,SH 03,U.S. Senate,,R,Pat Roberts,18,5,23
-Miami,STAN 368,U.S. Senate,,R,Pat Roberts,61,53,114
-Miami,STAN 367,U.S. Senate,,R,Pat Roberts,56,12,68
-Miami,SC,U.S. Senate,,R,Pat Roberts,96,19,115
-Miami,TM,U.S. Senate,,R,Pat Roberts,297,66,363
-Miami,WMC 416,U.S. Senate,,R,Pat Roberts,28,14,42
-Miami,WMC 368,U.S. Senate,,R,Pat Roberts,104,41,145
-Miami,WV(6),U.S. Senate,,R,Pat Roberts,28,27,55
-Miami,WV(12) 368,U.S. Senate,,R,Pat Roberts,21,7,28
-Miami,WV(12) 367,U.S. Senate,,R,Pat Roberts,41,15,56
-Miami,WV(5),U.S. Senate,,R,Pat Roberts,40,9,49
-Miami,EMC(2),U.S. Senate,,L,Randall Batson,2,0,2
-Miami,EMC(3),U.S. Senate,,L,Randall Batson,5,1,6
-Miami,EV,U.S. Senate,,L,Randall Batson,3,2,5
-Miami,FC,U.S. Senate,,L,Randall Batson,5,0,5
-Miami,LC 01,U.S. Senate,,L,Randall Batson,18,3,21
-Miami,LC 02,U.S. Senate,,L,Randall Batson,11,1,12
-Miami,LC 03,U.S. Senate,,L,Randall Batson,13,3,16
-Miami,LC 04,U.S. Senate,,L,Randall Batson,10,2,12
-Miami,MI,U.S. Senate,,L,Randall Batson,8,1,9
-Miami,MND,U.S. Senate,,L,Randall Batson,12,2,14
-Miami,NMV(2),U.S. Senate,,L,Randall Batson,3,2,5
-Miami,NMV(3),U.S. Senate,,L,Randall Batson,4,0,4
-Miami,NPW,U.S. Senate,,L,Randall Batson,4,0,4
-Miami,NPE Prt1,U.S. Senate,,L,Randall Batson,0,0,0
-Miami,NPE Prt2,U.S. Senate,,L,Randall Batson,5,0,5
-Miami,NW,U.S. Senate,,L,Randall Batson,6,1,7
-Miami,OSAGE,U.S. Senate,,L,Randall Batson,4,1,5
-Miami,OC 01,U.S. Senate,,L,Randall Batson,3,2,5
-Miami,OC 02,U.S. Senate,,L,Randall Batson,16,7,23
-Miami,OC 03,U.S. Senate,,L,Randall Batson,10,7,17
-Miami,OC 04,U.S. Senate,,L,Randall Batson,11,0,11
-Miami,OSA TWP,U.S. Senate,,L,Randall Batson,7,1,8
-Miami,PC 01,U.S. Senate,,L,Randall Batson,4,7,11
-Miami,PC 02,U.S. Senate,,L,Randall Batson,10,6,16
-Miami,PC 03,U.S. Senate,,L,Randall Batson,8,6,14
-Miami,PC 04,U.S. Senate,,L,Randall Batson,9,14,23
-Miami,RICH,U.S. Senate,,L,Randall Batson,24,4,28
-Miami,SMV(3),U.S. Senate,,L,Randall Batson,0,0,0
-Miami,SMV(2),U.S. Senate,,L,Randall Batson,19,0,19
-Miami,SPE Prt2,U.S. Senate,,L,Randall Batson,3,2,5
-Miami,SPW,U.S. Senate,,L,Randall Batson,2,3,5
-Miami,SW,U.S. Senate,,L,Randall Batson,7,3,10
-Miami,SH 01,U.S. Senate,,L,Randall Batson,18,2,20
-Miami,SH 02,U.S. Senate,,L,Randall Batson,1,1,2
-Miami,SH 03,U.S. Senate,,L,Randall Batson,1,0,1
-Miami,STAN 368,U.S. Senate,,L,Randall Batson,4,3,7
-Miami,STAN 367,U.S. Senate,,L,Randall Batson,4,0,4
-Miami,SC,U.S. Senate,,L,Randall Batson,4,1,5
-Miami,TM,U.S. Senate,,L,Randall Batson,15,2,17
-Miami,WMC 416,U.S. Senate,,L,Randall Batson,0,0,0
-Miami,WMC 368,U.S. Senate,,L,Randall Batson,5,3,8
-Miami,WV(6),U.S. Senate,,L,Randall Batson,0,0,0
-Miami,WV(12) 368,U.S. Senate,,L,Randall Batson,1,0,1
-Miami,WV(12) 367,U.S. Senate,,L,Randall Batson,7,3,10
-Miami,WV(5),U.S. Senate,,L,Randall Batson,4,2,6
-Miami,EMC(2),U.S. Senate,,,Write-ins,0,0,0
-Miami,EMC(3),U.S. Senate,,,Write-ins,0,0,0
-Miami,EV,U.S. Senate,,,Write-ins,0,1,1
-Miami,FC,U.S. Senate,,,Write-ins,0,0,0
-Miami,LC 01,U.S. Senate,,,Write-ins,0,0,0
-Miami,LC 02,U.S. Senate,,,Write-ins,0,1,1
-Miami,LC 03,U.S. Senate,,,Write-ins,0,0,0
-Miami,LC 04,U.S. Senate,,,Write-ins,0,1,1
-Miami,MI,U.S. Senate,,,Write-ins,0,0,0
-Miami,MND,U.S. Senate,,,Write-ins,0,0,0
-Miami,NMV(2),U.S. Senate,,,Write-ins,0,0,0
-Miami,NMV(3),U.S. Senate,,,Write-ins,1,0,1
-Miami,NPW,U.S. Senate,,,Write-ins,0,0,0
-Miami,NPE Prt1,U.S. Senate,,,Write-ins,0,0,0
-Miami,NPE Prt2,U.S. Senate,,,Write-ins,0,0,0
-Miami,NW,U.S. Senate,,,Write-ins,0,0,0
-Miami,OSAGE,U.S. Senate,,,Write-ins,0,0,0
-Miami,OC 01,U.S. Senate,,,Write-ins,0,0,0
-Miami,OC 02,U.S. Senate,,,Write-ins,2,3,5
-Miami,OC 03,U.S. Senate,,,Write-ins,0,0,0
-Miami,OC 04,U.S. Senate,,,Write-ins,0,0,0
-Miami,OSA TWP,U.S. Senate,,,Write-ins,0,0,0
-Miami,PC 01,U.S. Senate,,,Write-ins,0,0,0
-Miami,PC 02,U.S. Senate,,,Write-ins,0,0,0
-Miami,PC 03,U.S. Senate,,,Write-ins,1,0,1
-Miami,PC 04,U.S. Senate,,,Write-ins,0,0,0
-Miami,RICH,U.S. Senate,,,Write-ins,0,0,0
-Miami,SMV(3),U.S. Senate,,,Write-ins,0,0,0
-Miami,SMV(2),U.S. Senate,,,Write-ins,1,0,1
-Miami,SPE Prt2,U.S. Senate,,,Write-ins,0,0,0
-Miami,SPW,U.S. Senate,,,Write-ins,0,0,0
-Miami,SW,U.S. Senate,,,Write-ins,0,0,0
-Miami,SH 01,U.S. Senate,,,Write-ins,0,0,0
-Miami,SH 02,U.S. Senate,,,Write-ins,0,0,0
-Miami,SH 03,U.S. Senate,,,Write-ins,0,0,0
-Miami,STAN 368,U.S. Senate,,,Write-ins,1,0,1
-Miami,STAN 367,U.S. Senate,,,Write-ins,0,0,0
-Miami,SC,U.S. Senate,,,Write-ins,0,0,0
-Miami,TM,U.S. Senate,,,Write-ins,1,0,1
-Miami,WMC 416,U.S. Senate,,,Write-ins,0,0,0
-Miami,WMC 368,U.S. Senate,,,Write-ins,0,0,0
-Miami,WV(6),U.S. Senate,,,Write-ins,0,0,0
-Miami,WV(12) 368,U.S. Senate,,,Write-ins,0,0,0
-Miami,WV(12) 367,U.S. Senate,,,Write-ins,0,0,0
-Miami,WV(5),U.S. Senate,,,Write-ins,0,1,1
-Miami,EMC(2),U.S. House,2,D,Margie Wakefield,14,6,20
-Miami,EV,U.S. House,2,D,Margie Wakefield,28,14,42
-Miami,FC,U.S. House,2,D,Margie Wakefield,12,1,13
-Miami,MI,U.S. House,2,D,Margie Wakefield,35,12,47
-Miami,MND,U.S. House,2,D,Margie Wakefield,49,26,75
-Miami,NMV(2),U.S. House,2,D,Margie Wakefield,10,4,14
-Miami,NPW,U.S. House,2,D,Margie Wakefield,31,16,47
-Miami,NPE Prt1,U.S. House,2,D,Margie Wakefield,2,0,2
-Miami,NPE Prt2,U.S. House,2,D,Margie Wakefield,7,5,12
-Miami,OSAGE,U.S. House,2,D,Margie Wakefield,39,12,51
-Miami,OC 01,U.S. House,2,D,Margie Wakefield,37,29,66
-Miami,OC 02,U.S. House,2,D,Margie Wakefield,68,27,95
-Miami,OC 03,U.S. House,2,D,Margie Wakefield,83,33,116
-Miami,OC 04,U.S. House,2,D,Margie Wakefield,44,8,52
-Miami,OSA TWP,U.S. House,2,D,Margie Wakefield,53,25,78
-Miami,PC 01,U.S. House,2,D,Margie Wakefield,49,62,111
-Miami,PC 02,U.S. House,2,D,Margie Wakefield,60,41,101
-Miami,PC 03,U.S. House,2,D,Margie Wakefield,63,57,120
-Miami,PC 04,U.S. House,2,D,Margie Wakefield,60,61,121
-Miami,RICH,U.S. House,2,D,Margie Wakefield,89,66,155
-Miami,SMV(2),U.S. House,2,D,Margie Wakefield,76,45,121
-Miami,SPE Prt2,U.S. House,2,D,Margie Wakefield,11,9,20
-Miami,SPW,U.S. House,2,D,Margie Wakefield,18,12,30
-Miami,STAN 368,U.S. House,2,D,Margie Wakefield,25,22,47
-Miami,STAN 367,U.S. House,2,D,Margie Wakefield,12,14,26
-Miami,SC,U.S. House,2,D,Margie Wakefield,23,4,27
-Miami,WMC 416,U.S. House,2,D,Margie Wakefield,8,4,12
-Miami,WMC 368,U.S. House,2,D,Margie Wakefield,22,18,40
-Miami,WV(6),U.S. House,2,D,Margie Wakefield,10,18,28
-Miami,WV(12) 368,U.S. House,2,D,Margie Wakefield,4,3,7
-Miami,WV(12) 367,U.S. House,2,D,Margie Wakefield,17,11,28
-Miami,WV(5),U.S. House,2,D,Margie Wakefield,22,10,32
-Miami,EMC(2),U.S. House,2,R,Lynn Jenkins,14,6,20
-Miami,EV,U.S. House,2,R,Lynn Jenkins,28,14,42
-Miami,FC,U.S. House,2,R,Lynn Jenkins,12,1,13
-Miami,MI,U.S. House,2,R,Lynn Jenkins,35,12,47
-Miami,MND,U.S. House,2,R,Lynn Jenkins,49,26,75
-Miami,NMV(2),U.S. House,2,R,Lynn Jenkins,10,4,14
-Miami,NPW,U.S. House,2,R,Lynn Jenkins,31,16,47
-Miami,NPE Prt1,U.S. House,2,R,Lynn Jenkins,2,0,2
-Miami,NPE Prt2,U.S. House,2,R,Lynn Jenkins,7,5,12
-Miami,OSAGE,U.S. House,2,R,Lynn Jenkins,39,12,51
-Miami,OC 01,U.S. House,2,R,Lynn Jenkins,37,29,66
-Miami,OC 02,U.S. House,2,R,Lynn Jenkins,68,27,95
-Miami,OC 03,U.S. House,2,R,Lynn Jenkins,83,33,116
-Miami,OC 04,U.S. House,2,R,Lynn Jenkins,44,8,52
-Miami,OSA TWP,U.S. House,2,R,Lynn Jenkins,53,25,78
-Miami,PC 01,U.S. House,2,R,Lynn Jenkins,49,62,111
-Miami,PC 02,U.S. House,2,R,Lynn Jenkins,60,41,101
-Miami,PC 03,U.S. House,2,R,Lynn Jenkins,63,57,120
-Miami,PC 04,U.S. House,2,R,Lynn Jenkins,60,61,121
-Miami,RICH,U.S. House,2,R,Lynn Jenkins,89,66,155
-Miami,SMV(2),U.S. House,2,R,Lynn Jenkins,76,45,121
-Miami,SPE Prt2,U.S. House,2,R,Lynn Jenkins,11,9,20
-Miami,SPW,U.S. House,2,R,Lynn Jenkins,18,12,30
-Miami,STAN 368,U.S. House,2,R,Lynn Jenkins,25,22,47
-Miami,STAN 367,U.S. House,2,R,Lynn Jenkins,12,14,26
-Miami,SC,U.S. House,2,R,Lynn Jenkins,23,4,27
-Miami,WMC 416,U.S. House,2,R,Lynn Jenkins,8,4,12
-Miami,WMC 368,U.S. House,2,R,Lynn Jenkins,22,18,40
-Miami,WV(6),U.S. House,2,R,Lynn Jenkins,10,18,28
-Miami,WV(12) 368,U.S. House,2,R,Lynn Jenkins,4,3,7
-Miami,WV(12) 367,U.S. House,2,R,Lynn Jenkins,17,11,28
-Miami,WV(5),U.S. House,2,R,Lynn Jenkins,22,10,32
-Miami,EMC(2),U.S. House,2,L,Chris Clemmons,6,0,6
-Miami,EV,U.S. House,2,L,Chris Clemmons,6,2,8
-Miami,FC,U.S. House,2,L,Chris Clemmons,1,0,1
-Miami,MI,U.S. House,2,L,Chris Clemmons,3,0,3
-Miami,MND,U.S. House,2,L,Chris Clemmons,6,2,8
-Miami,NMV(2),U.S. House,2,L,Chris Clemmons,2,0,2
-Miami,NPW,U.S. House,2,L,Chris Clemmons,2,0,2
-Miami,NPE Prt1,U.S. House,2,L,Chris Clemmons,2,0,2
-Miami,NPE Prt2,U.S. House,2,L,Chris Clemmons,2,0,2
-Miami,OSAGE,U.S. House,2,L,Chris Clemmons,2,1,3
-Miami,OC 01,U.S. House,2,L,Chris Clemmons,8,1,9
-Miami,OC 02,U.S. House,2,L,Chris Clemmons,10,2,12
-Miami,OC 03,U.S. House,2,L,Chris Clemmons,6,6,12
-Miami,OC 04,U.S. House,2,L,Chris Clemmons,9,4,13
-Miami,OSA TWP,U.S. House,2,L,Chris Clemmons,5,0,5
-Miami,PC 01,U.S. House,2,L,Chris Clemmons,6,4,10
-Miami,PC 02,U.S. House,2,L,Chris Clemmons,7,7,14
-Miami,PC 03,U.S. House,2,L,Chris Clemmons,6,2,8
-Miami,PC 04,U.S. House,2,L,Chris Clemmons,12,7,19
-Miami,RICH,U.S. House,2,L,Chris Clemmons,20,2,22
-Miami,SMV(2),U.S. House,2,L,Chris Clemmons,14,2,16
-Miami,SPE Prt2,U.S. House,2,L,Chris Clemmons,3,2,5
-Miami,SPW,U.S. House,2,L,Chris Clemmons,2,3,5
-Miami,STAN 368,U.S. House,2,L,Chris Clemmons,6,4,10
-Miami,STAN 367,U.S. House,2,L,Chris Clemmons,2,0,2
-Miami,SC,U.S. House,2,L,Chris Clemmons,1,0,1
-Miami,WMC 416,U.S. House,2,L,Chris Clemmons,1,0,1
-Miami,WMC 368,U.S. House,2,L,Chris Clemmons,3,2,5
-Miami,WV(6),U.S. House,2,L,Chris Clemmons,1,0,1
-Miami,WV(12) 368,U.S. House,2,L,Chris Clemmons,1,0,1
-Miami,WV(12) 367,U.S. House,2,L,Chris Clemmons,2,0,2
-Miami,WV(5),U.S. House,2,L,Chris Clemmons,3,1,4
-Miami,EMC(2),U.S. House,2,,Write-ins,0,0,0
-Miami,EV,U.S. House,2,,Write-ins,0,0,0
-Miami,FC,U.S. House,2,,Write-ins,0,0,0
-Miami,MI,U.S. House,2,,Write-ins,0,0,0
-Miami,MND,U.S. House,2,,Write-ins,0,0,0
-Miami,NMV(2),U.S. House,2,,Write-ins,0,0,0
-Miami,NPW,U.S. House,2,,Write-ins,1,0,1
-Miami,NPE Prt1,U.S. House,2,,Write-ins,0,0,0
-Miami,NPE Prt2,U.S. House,2,,Write-ins,0,0,0
-Miami,OSAGE,U.S. House,2,,Write-ins,0,0,0
-Miami,OC 01,U.S. House,2,,Write-ins,0,0,0
-Miami,OC 02,U.S. House,2,,Write-ins,1,2,3
-Miami,OC 03,U.S. House,2,,Write-ins,0,0,0
-Miami,OC 04,U.S. House,2,,Write-ins,0,0,0
-Miami,OSA TWP,U.S. House,2,,Write-ins,0,0,0
-Miami,PC 01,U.S. House,2,,Write-ins,1,0,1
-Miami,PC 02,U.S. House,2,,Write-ins,0,0,0
-Miami,PC 03,U.S. House,2,,Write-ins,0,0,0
-Miami,PC 04,U.S. House,2,,Write-ins,1,0,1
-Miami,RICH,U.S. House,2,,Write-ins,0,0,0
-Miami,SMV(2),U.S. House,2,,Write-ins,0,0,0
-Miami,SPE Prt2,U.S. House,2,,Write-ins,0,0,0
-Miami,SPW,U.S. House,2,,Write-ins,0,0,0
-Miami,STAN 368,U.S. House,2,,Write-ins,0,0,0
-Miami,STAN 367,U.S. House,2,,Write-ins,0,0,0
-Miami,SC,U.S. House,2,,Write-ins,0,0,0
-Miami,WMC 416,U.S. House,2,,Write-ins,0,0,0
-Miami,WMC 368,U.S. House,2,,Write-ins,0,0,0
-Miami,WV(6),U.S. House,2,,Write-ins,0,0,0
-Miami,WV(12) 368,U.S. House,2,,Write-ins,0,0,0
-Miami,WV(12) 367,U.S. House,2,,Write-ins,0,0,0
-Miami,WV(5),U.S. House,2,,Write-ins,0,0,0
-Miami,EMC(3),U.S. House,3,D,Kelly Kultala,63,22,85
-Miami,LC 01,U.S. House,3,D,Kelly Kultala,64,21,85
-Miami,LC 02,U.S. House,3,D,Kelly Kultala,87,11,98
-Miami,LC 03,U.S. House,3,D,Kelly Kultala,69,18,87
-Miami,LC 04,U.S. House,3,D,Kelly Kultala,51,8,59
-Miami,NMV(3),U.S. House,3,D,Kelly Kultala,64,33,97
-Miami,NW,U.S. House,3,D,Kelly Kultala,44,8,52
-Miami,SMV(3),U.S. House,3,D,Kelly Kultala,2,0,2
-Miami,SW,U.S. House,3,D,Kelly Kultala,76,20,96
-Miami,SH 01,U.S. House,3,D,Kelly Kultala,83,24,107
-Miami,SH 02,U.S. House,3,D,Kelly Kultala,26,19,45
-Miami,SH 03,U.S. House,3,D,Kelly Kultala,9,2,11
-Miami,TM,U.S. House,3,D,Kelly Kultala,93,38,131
-Miami,EMC(3),U.S. House,3,R,Kevin Yoder,205,43,248
-Miami,LC 01,U.S. House,3,R,Kevin Yoder,148,27,175
-Miami,LC 02,U.S. House,3,R,Kevin Yoder,214,21,235
-Miami,LC 03,U.S. House,3,R,Kevin Yoder,214,29,243
-Miami,LC 04,U.S. House,3,R,Kevin Yoder,216,35,251
-Miami,NMV(3),U.S. House,3,R,Kevin Yoder,182,27,209
-Miami,NW,U.S. House,3,R,Kevin Yoder,194,19,213
-Miami,SMV(3),U.S. House,3,R,Kevin Yoder,5,0,5
-Miami,SW,U.S. House,3,R,Kevin Yoder,402,85,487
-Miami,SH 01,U.S. House,3,R,Kevin Yoder,317,27,344
-Miami,SH 02,U.S. House,3,R,Kevin Yoder,68,22,90
-Miami,SH 03,U.S. House,3,R,Kevin Yoder,23,5,28
-Miami,TM,U.S. House,3,R,Kevin Yoder,343,76,419
-Miami,EMC(3),U.S. House,3,,Write-ins,0,0,0
-Miami,LC 01,U.S. House,3,,Write-ins,1,0,1
-Miami,LC 02,U.S. House,3,,Write-ins,1,1,2
-Miami,LC 03,U.S. House,3,,Write-ins,0,0,0
-Miami,LC 04,U.S. House,3,,Write-ins,0,1,1
-Miami,NMV(3),U.S. House,3,,Write-ins,0,0,0
-Miami,NW,U.S. House,3,,Write-ins,0,0,0
-Miami,SMV(3),U.S. House,3,,Write-ins,0,0,0
-Miami,SW,U.S. House,3,,Write-ins,0,0,0
-Miami,SH 01,U.S. House,3,,Write-ins,0,0,0
-Miami,SH 02,U.S. House,3,,Write-ins,1,0,1
-Miami,SH 03,U.S. House,3,,Write-ins,0,0,0
-Miami,TM,U.S. House,3,,Write-ins,2,1,3
-Miami,EMC(2),Governor,,D,Paul Davis,18,9,27
-Miami,EMC(3),Governor,,D,Paul Davis,86,25,111
-Miami,EV,Governor,,D,Paul Davis,48,18,66
-Miami,FC,Governor,,D,Paul Davis,18,3,21
-Miami,LC 01,Governor,,D,Paul Davis,85,21,106
-Miami,LC 02,Governor,,D,Paul Davis,121,10,131
-Miami,LC 03,Governor,,D,Paul Davis,104,23,127
-Miami,LC 04,Governor,,D,Paul Davis,99,14,113
-Miami,MI,Governor,,D,Paul Davis,57,18,75
-Miami,MND,Governor,,D,Paul Davis,73,29,102
-Miami,NMV(2),Governor,,D,Paul Davis,17,7,24
-Miami,NMV(3),Governor,,D,Paul Davis,76,33,109
-Miami,NPW,Governor,,D,Paul Davis,53,21,74
-Miami,NPE Prt1,Governor,,D,Paul Davis,3,0,3
-Miami,NPE Prt2,Governor,,D,Paul Davis,10,6,16
-Miami,NW,Governor,,D,Paul Davis,62,11,73
-Miami,OSAGE,Governor,,D,Paul Davis,50,19,69
-Miami,OC 01,Governor,,D,Paul Davis,62,30,92
-Miami,OC 02,Governor,,D,Paul Davis,98,39,137
-Miami,OC 03,Governor,,D,Paul Davis,126,47,173
-Miami,OC 04,Governor,,D,Paul Davis,58,8,66
-Miami,OSA TWP,Governor,,D,Paul Davis,81,30,111
-Miami,PC 01,Governor,,D,Paul Davis,85,90,175
-Miami,PC 02,Governor,,D,Paul Davis,98,55,153
-Miami,PC 03,Governor,,D,Paul Davis,107,78,185
-Miami,PC 04,Governor,,D,Paul Davis,111,94,205
-Miami,RICH,Governor,,D,Paul Davis,137,82,219
-Miami,SMV(3),Governor,,D,Paul Davis,1,0,1
-Miami,SMV(2),Governor,,D,Paul Davis,135,61,196
-Miami,SPE Prt2,Governor,,D,Paul Davis,22,12,34
-Miami,SPW,Governor,,D,Paul Davis,29,21,50
-Miami,SW,Governor,,D,Paul Davis,121,31,152
-Miami,SH 01,Governor,,D,Paul Davis,140,28,168
-Miami,SH 02,Governor,,D,Paul Davis,46,24,70
-Miami,SH 03,Governor,,D,Paul Davis,14,2,16
-Miami,STAN 368,Governor,,D,Paul Davis,47,36,83
-Miami,STAN 367,Governor,,D,Paul Davis,25,16,41
-Miami,SC,Governor,,D,Paul Davis,33,9,42
-Miami,TM,Governor,,D,Paul Davis,122,46,168
-Miami,WMC 416,Governor,,D,Paul Davis,16,4,20
-Miami,WMC 368,Governor,,D,Paul Davis,40,21,61
-Miami,WV(6),Governor,,D,Paul Davis,17,26,43
-Miami,WV(12) 368,Governor,,D,Paul Davis,9,5,14
-Miami,WV(12) 367,Governor,,D,Paul Davis,34,23,57
-Miami,WV(5),Governor,,D,Paul Davis,31,11,42
-Miami,EMC(2),Governor,,L,Keen Umbehr,4,0,4
-Miami,EMC(3),Governor,,L,Keen Umbehr,9,2,11
-Miami,EV,Governor,,L,Keen Umbehr,4,2,6
-Miami,FC,Governor,,L,Keen Umbehr,4,0,4
-Miami,LC 01,Governor,,L,Keen Umbehr,12,1,13
-Miami,LC 02,Governor,,L,Keen Umbehr,11,2,13
-Miami,LC 03,Governor,,L,Keen Umbehr,10,2,12
-Miami,LC 04,Governor,,L,Keen Umbehr,11,3,14
-Miami,MI,Governor,,L,Keen Umbehr,6,1,7
-Miami,MND,Governor,,L,Keen Umbehr,8,6,14
-Miami,NMV(2),Governor,,L,Keen Umbehr,2,0,2
-Miami,NMV(3),Governor,,L,Keen Umbehr,5,3,8
-Miami,NPW,Governor,,L,Keen Umbehr,1,0,1
-Miami,NPE Prt1,Governor,,L,Keen Umbehr,0,0,0
-Miami,NPE Prt2,Governor,,L,Keen Umbehr,4,1,5
-Miami,NW,Governor,,L,Keen Umbehr,10,0,10
-Miami,OSAGE,Governor,,L,Keen Umbehr,9,1,10
-Miami,OC 01,Governor,,L,Keen Umbehr,7,2,9
-Miami,OC 02,Governor,,L,Keen Umbehr,12,7,19
-Miami,OC 03,Governor,,L,Keen Umbehr,9,5,14
-Miami,OC 04,Governor,,L,Keen Umbehr,13,7,20
-Miami,OSA TWP,Governor,,L,Keen Umbehr,6,0,6
-Miami,PC 01,Governor,,L,Keen Umbehr,9,4,13
-Miami,PC 02,Governor,,L,Keen Umbehr,9,6,15
-Miami,PC 03,Governor,,L,Keen Umbehr,13,2,15
-Miami,PC 04,Governor,,L,Keen Umbehr,10,5,15
-Miami,RICH,Governor,,L,Keen Umbehr,22,4,26
-Miami,SMV(3),Governor,,L,Keen Umbehr,1,0,1
-Miami,SMV(2),Governor,,L,Keen Umbehr,17,5,22
-Miami,SPE Prt2,Governor,,L,Keen Umbehr,4,1,5
-Miami,SPW,Governor,,L,Keen Umbehr,2,4,6
-Miami,SW,Governor,,L,Keen Umbehr,10,2,12
-Miami,SH 01,Governor,,L,Keen Umbehr,14,1,15
-Miami,SH 02,Governor,,L,Keen Umbehr,2,0,2
-Miami,SH 03,Governor,,L,Keen Umbehr,0,0,0
-Miami,STAN 368,Governor,,L,Keen Umbehr,5,3,8
-Miami,STAN 367,Governor,,L,Keen Umbehr,1,0,1
-Miami,SC,Governor,,L,Keen Umbehr,9,1,10
-Miami,TM,Governor,,L,Keen Umbehr,11,1,12
-Miami,WMC 416,Governor,,L,Keen Umbehr,1,0,1
-Miami,WMC 368,Governor,,L,Keen Umbehr,4,3,7
-Miami,WV(6),Governor,,L,Keen Umbehr,0,1,1
-Miami,WV(12) 368,Governor,,L,Keen Umbehr,0,0,0
-Miami,WV(12) 367,Governor,,L,Keen Umbehr,2,1,3
-Miami,WV(5),Governor,,L,Keen Umbehr,5,2,7
-Miami,EMC(2),Governor,,R,Sam Brownback,51,9,60
-Miami,EMC(3),Governor,,R,Sam Brownback,176,38,214
-Miami,EV,Governor,,R,Sam Brownback,72,30,102
-Miami,FC,Governor,,R,Sam Brownback,17,4,21
-Miami,LC 01,Governor,,R,Sam Brownback,118,27,145
-Miami,LC 02,Governor,,R,Sam Brownback,170,20,190
-Miami,LC 03,Governor,,R,Sam Brownback,169,22,191
-Miami,LC 04,Governor,,R,Sam Brownback,161,25,186
-Miami,MI,Governor,,R,Sam Brownback,105,27,132
-Miami,MND,Governor,,R,Sam Brownback,105,27,132
-Miami,NMV(2),Governor,,R,Sam Brownback,64,18,82
-Miami,NMV(3),Governor,,R,Sam Brownback,166,24,190
-Miami,NPW,Governor,,R,Sam Brownback,79,32,111
-Miami,NPE Prt1,Governor,,R,Sam Brownback,5,1,6
-Miami,NPE Prt2,Governor,,R,Sam Brownback,42,7,49
-Miami,NW,Governor,,R,Sam Brownback,166,16,182
-Miami,OSAGE,Governor,,R,Sam Brownback,87,6,93
-Miami,OC 01,Governor,,R,Sam Brownback,53,15,68
-Miami,OC 02,Governor,,R,Sam Brownback,93,26,119
-Miami,OC 03,Governor,,R,Sam Brownback,84,27,111
-Miami,OC 04,Governor,,R,Sam Brownback,50,16,66
-Miami,OSA TWP,Governor,,R,Sam Brownback,109,32,141
-Miami,PC 01,Governor,,R,Sam Brownback,129,82,211
-Miami,PC 02,Governor,,R,Sam Brownback,98,42,140
-Miami,PC 03,Governor,,R,Sam Brownback,138,61,199
-Miami,PC 04,Governor,,R,Sam Brownback,130,97,227
-Miami,RICH,Governor,,R,Sam Brownback,367,147,514
-Miami,SMV(3),Governor,,R,Sam Brownback,5,0,5
-Miami,SMV(2),Governor,,R,Sam Brownback,245,56,301
-Miami,SPE Prt2,Governor,,R,Sam Brownback,19,14,33
-Miami,SPW,Governor,,R,Sam Brownback,43,12,55
-Miami,SW,Governor,,R,Sam Brownback,347,73,420
-Miami,SH 01,Governor,,R,Sam Brownback,247,21,268
-Miami,SH 02,Governor,,R,Sam Brownback,48,16,64
-Miami,SH 03,Governor,,R,Sam Brownback,18,5,23
-Miami,STAN 368,Governor,,R,Sam Brownback,65,56,121
-Miami,STAN 367,Governor,,R,Sam Brownback,53,10,63
-Miami,SC,Governor,,R,Sam Brownback,100,20,120
-Miami,TM,Governor,,R,Sam Brownback,305,69,374
-Miami,WMC 416,Governor,,R,Sam Brownback,29,15,44
-Miami,WMC 368,Governor,,R,Sam Brownback,103,42,145
-Miami,WV(6),Governor,,R,Sam Brownback,28,25,53
-Miami,WV(12) 368,Governor,,R,Sam Brownback,25,6,31
-Miami,WV(12) 367,Governor,,R,Sam Brownback,43,15,58
-Miami,WV(5),Governor,,R,Sam Brownback,38,9,47
-Miami,EMC(2),Governor,,,Write-ins,0,0,0
-Miami,EMC(3),Governor,,,Write-ins,0,0,0
-Miami,EV,Governor,,,Write-ins,0,0,0
-Miami,FC,Governor,,,Write-ins,0,0,0
-Miami,LC 01,Governor,,,Write-ins,1,0,1
-Miami,LC 02,Governor,,,Write-ins,0,1,1
-Miami,LC 03,Governor,,,Write-ins,0,0,0
-Miami,LC 04,Governor,,,Write-ins,0,2,2
-Miami,MI,Governor,,,Write-ins,0,0,0
-Miami,MND,Governor,,,Write-ins,0,0,0
-Miami,NMV(2),Governor,,,Write-ins,0,0,0
-Miami,NMV(3),Governor,,,Write-ins,0,0,0
-Miami,NPW,Governor,,,Write-ins,0,0,0
-Miami,NPE Prt1,Governor,,,Write-ins,0,0,0
-Miami,NPE Prt2,Governor,,,Write-ins,0,0,0
-Miami,NW,Governor,,,Write-ins,0,0,0
-Miami,OSAGE,Governor,,,Write-ins,0,0,0
-Miami,OC 01,Governor,,,Write-ins,0,0,0
-Miami,OC 02,Governor,,,Write-ins,0,0,0
-Miami,OC 03,Governor,,,Write-ins,0,0,0
-Miami,OC 04,Governor,,,Write-ins,0,0,0
-Miami,OSA TWP,Governor,,,Write-ins,0,0,0
-Miami,PC 01,Governor,,,Write-ins,1,0,1
-Miami,PC 02,Governor,,,Write-ins,1,0,1
-Miami,PC 03,Governor,,,Write-ins,0,0,0
-Miami,PC 04,Governor,,,Write-ins,0,0,0
-Miami,RICH,Governor,,,Write-ins,1,0,1
-Miami,SMV(3),Governor,,,Write-ins,0,0,0
-Miami,SMV(2),Governor,,,Write-ins,0,0,0
-Miami,SPE Prt2,Governor,,,Write-ins,0,0,0
-Miami,SPW,Governor,,,Write-ins,0,0,0
-Miami,SW,Governor,,,Write-ins,0,0,0
-Miami,SH 01,Governor,,,Write-ins,1,0,1
-Miami,SH 02,Governor,,,Write-ins,0,1,1
-Miami,SH 03,Governor,,,Write-ins,0,0,0
-Miami,STAN 368,Governor,,,Write-ins,1,0,1
-Miami,STAN 367,Governor,,,Write-ins,0,0,0
-Miami,SC,Governor,,,Write-ins,0,0,0
-Miami,TM,Governor,,,Write-ins,0,0,0
-Miami,WMC 416,Governor,,,Write-ins,0,0,0
-Miami,WMC 368,Governor,,,Write-ins,0,0,0
-Miami,WV(6),Governor,,,Write-ins,0,0,0
-Miami,WV(12) 368,Governor,,,Write-ins,0,0,0
-Miami,WV(12) 367,Governor,,,Write-ins,0,0,0
-Miami,WV(5),Governor,,,Write-ins,0,0,0
-Miami,EMC(2),Secretary of State,,D,Jean Schodorf,18,6,24
-Miami,EMC(3),Secretary of State,,D,Jean Schodorf,68,24,92
-Miami,EV,Secretary of State,,D,Jean Schodorf,38,18,56
-Miami,FC,Secretary of State,,D,Jean Schodorf,16,2,18
-Miami,LC 01,Secretary of State,,D,Jean Schodorf,72,22,94
-Miami,LC 02,Secretary of State,,D,Jean Schodorf,95,8,103
-Miami,LC 03,Secretary of State,,D,Jean Schodorf,82,23,105
-Miami,LC 04,Secretary of State,,D,Jean Schodorf,73,13,86
-Miami,MI,Secretary of State,,D,Jean Schodorf,49,17,66
-Miami,MND,Secretary of State,,D,Jean Schodorf,63,31,94
-Miami,NMV(2),Secretary of State,,D,Jean Schodorf,15,8,23
-Miami,NMV(3),Secretary of State,,D,Jean Schodorf,67,31,98
-Miami,NPW,Secretary of State,,D,Jean Schodorf,41,20,61
-Miami,NPE Prt1,Secretary of State,,D,Jean Schodorf,2,0,2
-Miami,NPE Prt2,Secretary of State,,D,Jean Schodorf,11,5,16
-Miami,NW,Secretary of State,,D,Jean Schodorf,55,10,65
-Miami,OSAGE,Secretary of State,,D,Jean Schodorf,39,18,57
-Miami,OC 01,Secretary of State,,D,Jean Schodorf,57,30,87
-Miami,OC 02,Secretary of State,,D,Jean Schodorf,84,34,118
-Miami,OC 03,Secretary of State,,D,Jean Schodorf,99,39,138
-Miami,OC 04,Secretary of State,,D,Jean Schodorf,54,11,65
-Miami,OSA TWP,Secretary of State,,D,Jean Schodorf,62,28,90
-Miami,PC 01,Secretary of State,,D,Jean Schodorf,67,68,135
-Miami,PC 02,Secretary of State,,D,Jean Schodorf,83,55,138
-Miami,PC 03,Secretary of State,,D,Jean Schodorf,86,69,155
-Miami,PC 04,Secretary of State,,D,Jean Schodorf,87,76,163
-Miami,RICH,Secretary of State,,D,Jean Schodorf,120,66,186
-Miami,SMV(3),Secretary of State,,D,Jean Schodorf,3,0,3
-Miami,SMV(2),Secretary of State,,D,Jean Schodorf,106,57,163
-Miami,SPE Prt2,Secretary of State,,D,Jean Schodorf,15,11,26
-Miami,SPW,Secretary of State,,D,Jean Schodorf,17,18,35
-Miami,SW,Secretary of State,,D,Jean Schodorf,85,25,110
-Miami,SH 01,Secretary of State,,D,Jean Schodorf,99,25,124
-Miami,SH 02,Secretary of State,,D,Jean Schodorf,33,21,54
-Miami,SH 03,Secretary of State,,D,Jean Schodorf,9,2,11
-Miami,STAN 368,Secretary of State,,D,Jean Schodorf,37,33,70
-Miami,STAN 367,Secretary of State,,D,Jean Schodorf,22,14,36
-Miami,SC,Secretary of State,,D,Jean Schodorf,31,7,38
-Miami,TM,Secretary of State,,D,Jean Schodorf,100,47,147
-Miami,WMC 416,Secretary of State,,D,Jean Schodorf,10,5,15
-Miami,WMC 368,Secretary of State,,D,Jean Schodorf,35,24,59
-Miami,WV(6),Secretary of State,,D,Jean Schodorf,12,25,37
-Miami,WV(12) 368,Secretary of State,,D,Jean Schodorf,8,3,11
-Miami,WV(12) 367,Secretary of State,,D,Jean Schodorf,26,16,42
-Miami,WV(5),Secretary of State,,D,Jean Schodorf,30,10,40
-Miami,EMC(2),Secretary of State,,R,Kris Kobach,55,12,67
-Miami,EMC(3),Secretary of State,,R,Kris Kobach,199,41,240
-Miami,EV,Secretary of State,,R,Kris Kobach,85,31,116
-Miami,FC,Secretary of State,,R,Kris Kobach,22,5,27
-Miami,LC 01,Secretary of State,,R,Kris Kobach,144,26,170
-Miami,LC 02,Secretary of State,,R,Kris Kobach,204,23,227
-Miami,LC 03,Secretary of State,,R,Kris Kobach,199,24,223
-Miami,LC 04,Secretary of State,,R,Kris Kobach,193,31,224
-Miami,MI,Secretary of State,,R,Kris Kobach,118,29,147
-Miami,MND,Secretary of State,,R,Kris Kobach,120,31,151
-Miami,NMV(2),Secretary of State,,R,Kris Kobach,67,17,84
-Miami,NMV(3),Secretary of State,,R,Kris Kobach,179,29,208
-Miami,NPW,Secretary of State,,R,Kris Kobach,87,34,121
-Miami,NPE Prt1,Secretary of State,,R,Kris Kobach,6,1,7
-Miami,NPE Prt2,Secretary of State,,R,Kris Kobach,45,8,53
-Miami,NW,Secretary of State,,R,Kris Kobach,179,17,196
-Miami,OSAGE,Secretary of State,,R,Kris Kobach,100,8,108
-Miami,OC 01,Secretary of State,,R,Kris Kobach,66,17,83
-Miami,OC 02,Secretary of State,,R,Kris Kobach,118,37,155
-Miami,OC 03,Secretary of State,,R,Kris Kobach,113,38,151
-Miami,OC 04,Secretary of State,,R,Kris Kobach,64,20,84
-Miami,OSA TWP,Secretary of State,,R,Kris Kobach,132,33,165
-Miami,PC 01,Secretary of State,,R,Kris Kobach,154,104,258
-Miami,PC 02,Secretary of State,,R,Kris Kobach,122,48,170
-Miami,PC 03,Secretary of State,,R,Kris Kobach,169,72,241
-Miami,PC 04,Secretary of State,,R,Kris Kobach,158,117,275
-Miami,RICH,Secretary of State,,R,Kris Kobach,402,167,569
-Miami,SMV(3),Secretary of State,,R,Kris Kobach,4,0,4
-Miami,SMV(2),Secretary of State,,R,Kris Kobach,286,65,351
-Miami,SPE Prt2,Secretary of State,,R,Kris Kobach,30,14,44
-Miami,SPW,Secretary of State,,R,Kris Kobach,55,19,74
-Miami,SW,Secretary of State,,R,Kris Kobach,393,78,471
-Miami,SH 01,Secretary of State,,R,Kris Kobach,298,25,323
-Miami,SH 02,Secretary of State,,R,Kris Kobach,61,18,79
-Miami,SH 03,Secretary of State,,R,Kris Kobach,23,5,28
-Miami,STAN 368,Secretary of State,,R,Kris Kobach,79,60,139
-Miami,STAN 367,Secretary of State,,R,Kris Kobach,56,13,69
-Miami,SC,Secretary of State,,R,Kris Kobach,108,23,131
-Miami,TM,Secretary of State,,R,Kris Kobach,338,68,406
-Miami,WMC 416,Secretary of State,,R,Kris Kobach,36,14,50
-Miami,WMC 368,Secretary of State,,R,Kris Kobach,113,43,156
-Miami,WV(6),Secretary of State,,R,Kris Kobach,33,26,59
-Miami,WV(12) 368,Secretary of State,,R,Kris Kobach,25,9,34
-Miami,WV(12) 367,Secretary of State,,R,Kris Kobach,53,24,77
-Miami,WV(5),Secretary of State,,R,Kris Kobach,42,11,53
-Miami,EMC(2),Secretary of State,,,Write-ins,0,0,0
-Miami,EMC(3),Secretary of State,,,Write-ins,0,0,0
-Miami,EV,Secretary of State,,,Write-ins,0,0,0
-Miami,FC,Secretary of State,,,Write-ins,1,0,1
-Miami,LC 01,Secretary of State,,,Write-ins,0,0,0
-Miami,LC 02,Secretary of State,,,Write-ins,0,1,1
-Miami,LC 03,Secretary of State,,,Write-ins,0,0,0
-Miami,LC 04,Secretary of State,,,Write-ins,0,0,0
-Miami,MI,Secretary of State,,,Write-ins,0,0,0
-Miami,MND,Secretary of State,,,Write-ins,0,0,0
-Miami,NMV(2),Secretary of State,,,Write-ins,0,0,0
-Miami,NMV(3),Secretary of State,,,Write-ins,0,0,0
-Miami,NPW,Secretary of State,,,Write-ins,0,0,0
-Miami,NPE Prt1,Secretary of State,,,Write-ins,0,0,0
-Miami,NPE Prt2,Secretary of State,,,Write-ins,0,0,0
-Miami,NW,Secretary of State,,,Write-ins,0,0,0
-Miami,OSAGE,Secretary of State,,,Write-ins,0,0,0
-Miami,OC 01,Secretary of State,,,Write-ins,0,0,0
-Miami,OC 02,Secretary of State,,,Write-ins,0,0,0
-Miami,OC 03,Secretary of State,,,Write-ins,0,0,0
-Miami,OC 04,Secretary of State,,,Write-ins,2,0,2
-Miami,OSA TWP,Secretary of State,,,Write-ins,0,0,0
-Miami,PC 01,Secretary of State,,,Write-ins,0,0,0
-Miami,PC 02,Secretary of State,,,Write-ins,0,0,0
-Miami,PC 03,Secretary of State,,,Write-ins,1,0,1
-Miami,PC 04,Secretary of State,,,Write-ins,0,0,0
-Miami,RICH,Secretary of State,,,Write-ins,1,0,1
-Miami,SMV(3),Secretary of State,,,Write-ins,0,0,0
-Miami,SMV(2),Secretary of State,,,Write-ins,0,0,0
-Miami,SPE Prt2,Secretary of State,,,Write-ins,0,0,0
-Miami,SPW,Secretary of State,,,Write-ins,0,0,0
-Miami,SW,Secretary of State,,,Write-ins,0,0,0
-Miami,SH 01,Secretary of State,,,Write-ins,0,0,0
-Miami,SH 02,Secretary of State,,,Write-ins,0,0,0
-Miami,SH 03,Secretary of State,,,Write-ins,0,0,0
-Miami,STAN 368,Secretary of State,,,Write-ins,0,0,0
-Miami,STAN 367,Secretary of State,,,Write-ins,0,0,0
-Miami,SC,Secretary of State,,,Write-ins,0,0,0
-Miami,TM,Secretary of State,,,Write-ins,0,0,0
-Miami,WMC 416,Secretary of State,,,Write-ins,0,0,0
-Miami,WMC 368,Secretary of State,,,Write-ins,0,0,0
-Miami,WV(6),Secretary of State,,,Write-ins,0,0,0
-Miami,WV(12) 368,Secretary of State,,,Write-ins,0,0,0
-Miami,WV(12) 367,Secretary of State,,,Write-ins,0,0,0
-Miami,WV(5),Secretary of State,,,Write-ins,0,0,0
-Miami,EMC(2),Attorney General,,R,Derek Schmidt,57,10,67
-Miami,EMC(3),Attorney General,,R,Derek Schmidt,207,43,250
-Miami,EV,Attorney General,,R,Derek Schmidt,84,33,117
-Miami,FC,Attorney General,,R,Derek Schmidt,24,4,28
-Miami,LC 01,Attorney General,,R,Derek Schmidt,145,23,168
-Miami,LC 02,Attorney General,,R,Derek Schmidt,215,21,236
-Miami,LC 03,Attorney General,,R,Derek Schmidt,202,26,228
-Miami,LC 04,Attorney General,,R,Derek Schmidt,205,32,237
-Miami,MI,Attorney General,,R,Derek Schmidt,120,28,148
-Miami,MND,Attorney General,,R,Derek Schmidt,121,37,158
-Miami,NMV(2),Attorney General,,R,Derek Schmidt,69,19,88
-Miami,NMV(3),Attorney General,,R,Derek Schmidt,183,34,217
-Miami,NPW,Attorney General,,R,Derek Schmidt,90,38,128
-Miami,NPE Prt1,Attorney General,,R,Derek Schmidt,6,1,7
-Miami,NPE Prt2,Attorney General,,R,Derek Schmidt,48,8,56
-Miami,NW,Attorney General,,R,Derek Schmidt,183,17,200
-Miami,OSAGE,Attorney General,,R,Derek Schmidt,100,10,110
-Miami,OC 01,Attorney General,,R,Derek Schmidt,72,22,94
-Miami,OC 02,Attorney General,,R,Derek Schmidt,125,39,164
-Miami,OC 03,Attorney General,,R,Derek Schmidt,122,36,158
-Miami,OC 04,Attorney General,,R,Derek Schmidt,69,19,88
-Miami,OSA TWP,Attorney General,,R,Derek Schmidt,138,33,171
-Miami,PC 01,Attorney General,,R,Derek Schmidt,157,107,264
-Miami,PC 02,Attorney General,,R,Derek Schmidt,130,51,181
-Miami,PC 03,Attorney General,,R,Derek Schmidt,180,74,254
-Miami,PC 04,Attorney General,,R,Derek Schmidt,158,131,289
-Miami,RICH,Attorney General,,R,Derek Schmidt,408,163,571
-Miami,SMV(3),Attorney General,,R,Derek Schmidt,5,0,5
-Miami,SMV(2),Attorney General,,R,Derek Schmidt,290,73,363
-Miami,SPE Prt2,Attorney General,,R,Derek Schmidt,29,18,47
-Miami,SPW,Attorney General,,R,Derek Schmidt,54,21,75
-Miami,SW,Attorney General,,R,Derek Schmidt,394,81,475
-Miami,SH 01,Attorney General,,R,Derek Schmidt,307,26,333
-Miami,SH 02,Attorney General,,R,Derek Schmidt,64,25,89
-Miami,SH 03,Attorney General,,R,Derek Schmidt,21,4,25
-Miami,STAN 368,Attorney General,,R,Derek Schmidt,80,64,144
-Miami,STAN 367,Attorney General,,R,Derek Schmidt,58,14,72
-Miami,SC,Attorney General,,R,Derek Schmidt,111,23,134
-Miami,TM,Attorney General,,R,Derek Schmidt,338,77,415
-Miami,WMC 416,Attorney General,,R,Derek Schmidt,35,15,50
-Miami,WMC 368,Attorney General,,R,Derek Schmidt,114,43,157
-Miami,WV(6),Attorney General,,R,Derek Schmidt,36,32,68
-Miami,WV(12) 368,Attorney General,,R,Derek Schmidt,25,11,36
-Miami,WV(12) 367,Attorney General,,R,Derek Schmidt,55,20,75
-Miami,WV(5),Attorney General,,R,Derek Schmidt,45,11,56
-Miami,EMC(2),Attorney General,,D,A J Kotich,16,7,23
-Miami,EMC(3),Attorney General,,D,A J Kotich,61,22,83
-Miami,EV,Attorney General,,D,A J Kotich,38,16,54
-Miami,FC,Attorney General,,D,A J Kotich,15,3,18
-Miami,LC 01,Attorney General,,D,A J Kotich,65,24,89
-Miami,LC 02,Attorney General,,D,A J Kotich,82,11,93
-Miami,LC 03,Attorney General,,D,A J Kotich,71,20,91
-Miami,LC 04,Attorney General,,D,A J Kotich,58,12,70
-Miami,MI,Attorney General,,D,A J Kotich,38,17,55
-Miami,MND,Attorney General,,D,A J Kotich,61,26,87
-Miami,NMV(2),Attorney General,,D,A J Kotich,12,6,18
-Miami,NMV(3),Attorney General,,D,A J Kotich,61,26,87
-Miami,NPW,Attorney General,,D,A J Kotich,37,16,53
-Miami,NPE Prt1,Attorney General,,D,A J Kotich,2,0,2
-Miami,NPE Prt2,Attorney General,,D,A J Kotich,8,4,12
-Miami,NW,Attorney General,,D,A J Kotich,47,10,57
-Miami,OSAGE,Attorney General,,D,A J Kotich,38,16,54
-Miami,OC 01,Attorney General,,D,A J Kotich,51,25,76
-Miami,OC 02,Attorney General,,D,A J Kotich,76,32,108
-Miami,OC 03,Attorney General,,D,A J Kotich,90,43,133
-Miami,OC 04,Attorney General,,D,A J Kotich,49,12,61
-Miami,OSA TWP,Attorney General,,D,A J Kotich,56,27,83
-Miami,PC 01,Attorney General,,D,A J Kotich,62,62,124
-Miami,PC 02,Attorney General,,D,A J Kotich,73,52,125
-Miami,PC 03,Attorney General,,D,A J Kotich,72,63,135
-Miami,PC 04,Attorney General,,D,A J Kotich,83,60,143
-Miami,RICH,Attorney General,,D,A J Kotich,109,66,175
-Miami,SMV(3),Attorney General,,D,A J Kotich,2,0,2
-Miami,SMV(2),Attorney General,,D,A J Kotich,103,48,151
-Miami,SPE Prt2,Attorney General,,D,A J Kotich,14,8,22
-Miami,SPW,Attorney General,,D,A J Kotich,19,14,33
-Miami,SW,Attorney General,,D,A J Kotich,82,23,105
-Miami,SH 01,Attorney General,,D,A J Kotich,86,25,111
-Miami,SH 02,Attorney General,,D,A J Kotich,26,16,42
-Miami,SH 03,Attorney General,,D,A J Kotich,11,3,14
-Miami,STAN 368,Attorney General,,D,A J Kotich,36,30,66
-Miami,STAN 367,Attorney General,,D,A J Kotich,21,13,34
-Miami,SC,Attorney General,,D,A J Kotich,27,7,34
-Miami,TM,Attorney General,,D,A J Kotich,92,35,127
-Miami,WMC 416,Attorney General,,D,A J Kotich,9,4,13
-Miami,WMC 368,Attorney General,,D,A J Kotich,31,24,55
-Miami,WV(6),Attorney General,,D,A J Kotich,9,19,28
-Miami,WV(12) 368,Attorney General,,D,A J Kotich,8,1,9
-Miami,WV(12) 367,Attorney General,,D,A J Kotich,24,20,44
-Miami,WV(5),Attorney General,,D,A J Kotich,28,11,39
-Miami,EMC(2),Attorney General,,,Write-ins,0,0,0
-Miami,EMC(3),Attorney General,,,Write-ins,0,0,0
-Miami,EV,Attorney General,,,Write-ins,0,0,0
-Miami,FC,Attorney General,,,Write-ins,0,0,0
-Miami,LC 01,Attorney General,,,Write-ins,1,0,1
-Miami,LC 02,Attorney General,,,Write-ins,0,1,1
-Miami,LC 03,Attorney General,,,Write-ins,0,0,0
-Miami,LC 04,Attorney General,,,Write-ins,0,0,0
-Miami,MI,Attorney General,,,Write-ins,0,0,0
-Miami,MND,Attorney General,,,Write-ins,0,0,0
-Miami,NMV(2),Attorney General,,,Write-ins,0,0,0
-Miami,NMV(3),Attorney General,,,Write-ins,0,0,0
-Miami,NPW,Attorney General,,,Write-ins,0,0,0
-Miami,NPE Prt1,Attorney General,,,Write-ins,0,0,0
-Miami,NPE Prt2,Attorney General,,,Write-ins,0,0,0
-Miami,NW,Attorney General,,,Write-ins,0,0,0
-Miami,OSAGE,Attorney General,,,Write-ins,0,0,0
-Miami,OC 01,Attorney General,,,Write-ins,0,0,0
-Miami,OC 02,Attorney General,,,Write-ins,0,0,0
-Miami,OC 03,Attorney General,,,Write-ins,2,0,2
-Miami,OC 04,Attorney General,,,Write-ins,0,0,0
-Miami,OSA TWP,Attorney General,,,Write-ins,0,0,0
-Miami,PC 01,Attorney General,,,Write-ins,1,1,2
-Miami,PC 02,Attorney General,,,Write-ins,1,0,1
-Miami,PC 03,Attorney General,,,Write-ins,1,0,1
-Miami,PC 04,Attorney General,,,Write-ins,0,0,0
-Miami,RICH,Attorney General,,,Write-ins,0,0,0
-Miami,SMV(3),Attorney General,,,Write-ins,0,0,0
-Miami,SMV(2),Attorney General,,,Write-ins,0,0,0
-Miami,SPE Prt2,Attorney General,,,Write-ins,0,0,0
-Miami,SPW,Attorney General,,,Write-ins,0,0,0
-Miami,SW,Attorney General,,,Write-ins,0,0,0
-Miami,SH 01,Attorney General,,,Write-ins,0,0,0
-Miami,SH 02,Attorney General,,,Write-ins,0,0,0
-Miami,SH 03,Attorney General,,,Write-ins,0,0,0
-Miami,STAN 368,Attorney General,,,Write-ins,1,0,1
-Miami,STAN 367,Attorney General,,,Write-ins,0,0,0
-Miami,SC,Attorney General,,,Write-ins,0,0,0
-Miami,TM,Attorney General,,,Write-ins,0,0,0
-Miami,WMC 416,Attorney General,,,Write-ins,0,0,0
-Miami,WMC 368,Attorney General,,,Write-ins,0,0,0
-Miami,WV(6),Attorney General,,,Write-ins,0,0,0
-Miami,WV(12) 368,Attorney General,,,Write-ins,0,0,0
-Miami,WV(12) 367,Attorney General,,,Write-ins,0,0,0
-Miami,WV(5),Attorney General,,,Write-ins,0,0,0
-Miami,EMC(2),State Treasurer,,R,Ron Estes,55,11,66
-Miami,EMC(3),State Treasurer,,R,Ron Estes,200,46,246
-Miami,EV,State Treasurer,,R,Ron Estes,91,35,126
-Miami,FC,State Treasurer,,R,Ron Estes,24,3,27
-Miami,LC 01,State Treasurer,,R,Ron Estes,146,24,170
-Miami,LC 02,State Treasurer,,R,Ron Estes,211,20,231
-Miami,LC 03,State Treasurer,,R,Ron Estes,202,27,229
-Miami,LC 04,State Treasurer,,R,Ron Estes,206,33,239
-Miami,MI,State Treasurer,,R,Ron Estes,123,30,153
-Miami,MND,State Treasurer,,R,Ron Estes,120,35,155
-Miami,NMV(2),State Treasurer,,R,Ron Estes,73,17,90
-Miami,NMV(3),State Treasurer,,R,Ron Estes,182,35,217
-Miami,NPW,State Treasurer,,R,Ron Estes,93,38,131
-Miami,NPE Prt1,State Treasurer,,R,Ron Estes,5,1,6
-Miami,NPE Prt2,State Treasurer,,R,Ron Estes,47,8,55
-Miami,NW,State Treasurer,,R,Ron Estes,187,16,203
-Miami,OSAGE,State Treasurer,,R,Ron Estes,104,10,114
-Miami,OC 01,State Treasurer,,R,Ron Estes,78,22,100
-Miami,OC 02,State Treasurer,,R,Ron Estes,126,36,162
-Miami,OC 03,State Treasurer,,R,Ron Estes,125,40,165
-Miami,OC 04,State Treasurer,,R,Ron Estes,66,17,83
-Miami,OSA TWP,State Treasurer,,R,Ron Estes,134,35,169
-Miami,PC 01,State Treasurer,,R,Ron Estes,156,110,266
-Miami,PC 02,State Treasurer,,R,Ron Estes,136,57,193
-Miami,PC 03,State Treasurer,,R,Ron Estes,185,77,262
-Miami,PC 04,State Treasurer,,R,Ron Estes,169,128,297
-Miami,RICH,State Treasurer,,R,Ron Estes,420,161,581
-Miami,SMV(3),State Treasurer,,R,Ron Estes,5,0,5
-Miami,SMV(2),State Treasurer,,R,Ron Estes,304,77,381
-Miami,SPE Prt2,State Treasurer,,R,Ron Estes,30,17,47
-Miami,SPW,State Treasurer,,R,Ron Estes,57,22,79
-Miami,SW,State Treasurer,,R,Ron Estes,392,79,471
-Miami,SH 01,State Treasurer,,R,Ron Estes,303,28,331
-Miami,SH 02,State Treasurer,,R,Ron Estes,66,23,89
-Miami,SH 03,State Treasurer,,R,Ron Estes,23,5,28
-Miami,STAN 368,State Treasurer,,R,Ron Estes,88,66,154
-Miami,STAN 367,State Treasurer,,R,Ron Estes,54,12,66
-Miami,SC,State Treasurer,,R,Ron Estes,109,21,130
-Miami,TM,State Treasurer,,R,Ron Estes,344,77,421
-Miami,WMC 416,State Treasurer,,R,Ron Estes,34,14,48
-Miami,WMC 368,State Treasurer,,R,Ron Estes,118,42,160
-Miami,WV(6),State Treasurer,,R,Ron Estes,32,32,64
-Miami,WV(12) 368,State Treasurer,,R,Ron Estes,25,11,36
-Miami,WV(12) 367,State Treasurer,,R,Ron Estes,53,24,77
-Miami,WV(5),State Treasurer,,R,Ron Estes,42,12,54
-Miami,EMC(2),State Treasurer,,D,Carmen Alldritt,17,6,23
-Miami,EMC(3),State Treasurer,,D,Carmen Alldritt,61,19,80
-Miami,EV,State Treasurer,,D,Carmen Alldritt,33,14,47
-Miami,FC,State Treasurer,,D,Carmen Alldritt,13,3,16
-Miami,LC 01,State Treasurer,,D,Carmen Alldritt,64,24,88
-Miami,LC 02,State Treasurer,,D,Carmen Alldritt,82,12,94
-Miami,LC 03,State Treasurer,,D,Carmen Alldritt,71,20,91
-Miami,LC 04,State Treasurer,,D,Carmen Alldritt,57,11,68
-Miami,MI,State Treasurer,,D,Carmen Alldritt,39,13,52
-Miami,MND,State Treasurer,,D,Carmen Alldritt,64,28,92
-Miami,NMV(2),State Treasurer,,D,Carmen Alldritt,9,6,15
-Miami,NMV(3),State Treasurer,,D,Carmen Alldritt,60,25,85
-Miami,NPW,State Treasurer,,D,Carmen Alldritt,36,16,52
-Miami,NPE Prt1,State Treasurer,,D,Carmen Alldritt,2,0,2
-Miami,NPE Prt2,State Treasurer,,D,Carmen Alldritt,8,5,13
-Miami,NW,State Treasurer,,D,Carmen Alldritt,43,10,53
-Miami,OSAGE,State Treasurer,,D,Carmen Alldritt,35,15,50
-Miami,OC 01,State Treasurer,,D,Carmen Alldritt,45,25,70
-Miami,OC 02,State Treasurer,,D,Carmen Alldritt,74,35,109
-Miami,OC 03,State Treasurer,,D,Carmen Alldritt,90,40,130
-Miami,OC 04,State Treasurer,,D,Carmen Alldritt,52,13,65
-Miami,OSA TWP,State Treasurer,,D,Carmen Alldritt,58,26,84
-Miami,PC 01,State Treasurer,,D,Carmen Alldritt,60,62,122
-Miami,PC 02,State Treasurer,,D,Carmen Alldritt,68,47,115
-Miami,PC 03,State Treasurer,,D,Carmen Alldritt,67,61,128
-Miami,PC 04,State Treasurer,,D,Carmen Alldritt,75,63,138
-Miami,RICH,State Treasurer,,D,Carmen Alldritt,95,66,161
-Miami,SMV(3),State Treasurer,,D,Carmen Alldritt,2,0,2
-Miami,SMV(2),State Treasurer,,D,Carmen Alldritt,86,42,128
-Miami,SPE Prt2,State Treasurer,,D,Carmen Alldritt,12,9,21
-Miami,SPW,State Treasurer,,D,Carmen Alldritt,18,14,32
-Miami,SW,State Treasurer,,D,Carmen Alldritt,81,26,107
-Miami,SH 01,State Treasurer,,D,Carmen Alldritt,86,23,109
-Miami,SH 02,State Treasurer,,D,Carmen Alldritt,26,18,44
-Miami,SH 03,State Treasurer,,D,Carmen Alldritt,8,2,10
-Miami,STAN 368,State Treasurer,,D,Carmen Alldritt,27,28,55
-Miami,STAN 367,State Treasurer,,D,Carmen Alldritt,24,15,39
-Miami,SC,State Treasurer,,D,Carmen Alldritt,26,7,33
-Miami,TM,State Treasurer,,D,Carmen Alldritt,84,34,118
-Miami,WMC 416,State Treasurer,,D,Carmen Alldritt,12,5,17
-Miami,WMC 368,State Treasurer,,D,Carmen Alldritt,28,25,53
-Miami,WV(6),State Treasurer,,D,Carmen Alldritt,13,18,31
-Miami,WV(12) 368,State Treasurer,,D,Carmen Alldritt,7,1,8
-Miami,WV(12) 367,State Treasurer,,D,Carmen Alldritt,26,16,42
-Miami,WV(5),State Treasurer,,D,Carmen Alldritt,31,10,41
-Miami,EMC(2),State Treasurer,,,Write-ins,0,0,0
-Miami,EMC(3),State Treasurer,,,Write-ins,0,0,0
-Miami,EV,State Treasurer,,,Write-ins,0,0,0
-Miami,FC,State Treasurer,,,Write-ins,0,0,0
-Miami,LC 01,State Treasurer,,,Write-ins,0,0,0
-Miami,LC 02,State Treasurer,,,Write-ins,1,1,2
-Miami,LC 03,State Treasurer,,,Write-ins,0,0,0
-Miami,LC 04,State Treasurer,,,Write-ins,0,0,0
-Miami,MI,State Treasurer,,,Write-ins,0,0,0
-Miami,MND,State Treasurer,,,Write-ins,0,0,0
-Miami,NMV(2),State Treasurer,,,Write-ins,0,0,0
-Miami,NMV(3),State Treasurer,,,Write-ins,0,0,0
-Miami,NPW,State Treasurer,,,Write-ins,0,0,0
-Miami,NPE Prt1,State Treasurer,,,Write-ins,0,0,0
-Miami,NPE Prt2,State Treasurer,,,Write-ins,0,0,0
-Miami,NW,State Treasurer,,,Write-ins,0,0,0
-Miami,OSAGE,State Treasurer,,,Write-ins,0,0,0
-Miami,OC 01,State Treasurer,,,Write-ins,0,0,0
-Miami,OC 02,State Treasurer,,,Write-ins,0,0,0
-Miami,OC 03,State Treasurer,,,Write-ins,0,0,0
-Miami,OC 04,State Treasurer,,,Write-ins,0,0,0
-Miami,OSA TWP,State Treasurer,,,Write-ins,0,0,0
-Miami,PC 01,State Treasurer,,,Write-ins,0,1,1
-Miami,PC 02,State Treasurer,,,Write-ins,0,0,0
-Miami,PC 03,State Treasurer,,,Write-ins,0,0,0
-Miami,PC 04,State Treasurer,,,Write-ins,0,0,0
-Miami,RICH,State Treasurer,,,Write-ins,0,0,0
-Miami,SMV(3),State Treasurer,,,Write-ins,0,0,0
-Miami,SMV(2),State Treasurer,,,Write-ins,0,0,0
-Miami,SPE Prt2,State Treasurer,,,Write-ins,0,0,0
-Miami,SPW,State Treasurer,,,Write-ins,0,0,0
-Miami,SW,State Treasurer,,,Write-ins,1,0,1
-Miami,SH 01,State Treasurer,,,Write-ins,0,0,0
-Miami,SH 02,State Treasurer,,,Write-ins,0,0,0
-Miami,SH 03,State Treasurer,,,Write-ins,0,0,0
-Miami,STAN 368,State Treasurer,,,Write-ins,0,0,0
-Miami,STAN 367,State Treasurer,,,Write-ins,0,0,0
-Miami,SC,State Treasurer,,,Write-ins,0,0,0
-Miami,TM,State Treasurer,,,Write-ins,0,0,0
-Miami,WMC 416,State Treasurer,,,Write-ins,0,0,0
-Miami,WMC 368,State Treasurer,,,Write-ins,0,0,0
-Miami,WV(6),State Treasurer,,,Write-ins,0,0,0
-Miami,WV(12) 368,State Treasurer,,,Write-ins,0,0,0
-Miami,WV(12) 367,State Treasurer,,,Write-ins,0,0,0
-Miami,WV(5),State Treasurer,,,Write-ins,0,0,0
-Miami,EMC(2),Insurance Commissioner,,R,Ken Selzer,53,10,63
-Miami,EMC(3),Insurance Commissioner,,R,Ken Selzer,199,45,244
-Miami,EV,Insurance Commissioner,,R,Ken Selzer,79,33,112
-Miami,FC,Insurance Commissioner,,R,Ken Selzer,24,5,29
-Miami,LC 01,Insurance Commissioner,,R,Ken Selzer,148,26,174
-Miami,LC 02,Insurance Commissioner,,R,Ken Selzer,204,20,224
-Miami,LC 03,Insurance Commissioner,,R,Ken Selzer,191,25,216
-Miami,LC 04,Insurance Commissioner,,R,Ken Selzer,200,29,229
-Miami,MI,Insurance Commissioner,,R,Ken Selzer,116,27,143
-Miami,MND,Insurance Commissioner,,R,Ken Selzer,109,31,140
-Miami,NMV(2),Insurance Commissioner,,R,Ken Selzer,65,16,81
-Miami,NMV(3),Insurance Commissioner,,R,Ken Selzer,179,27,206
-Miami,NPW,Insurance Commissioner,,R,Ken Selzer,88,38,126
-Miami,NPE Prt1,Insurance Commissioner,,R,Ken Selzer,5,1,6
-Miami,NPE Prt2,Insurance Commissioner,,R,Ken Selzer,42,8,50
-Miami,NW,Insurance Commissioner,,R,Ken Selzer,180,16,196
-Miami,OSAGE,Insurance Commissioner,,R,Ken Selzer,98,11,109
-Miami,OC 01,Insurance Commissioner,,R,Ken Selzer,65,19,84
-Miami,OC 02,Insurance Commissioner,,R,Ken Selzer,111,40,151
-Miami,OC 03,Insurance Commissioner,,R,Ken Selzer,114,35,149
-Miami,OC 04,Insurance Commissioner,,R,Ken Selzer,60,16,76
-Miami,OSA TWP,Insurance Commissioner,,R,Ken Selzer,123,31,154
-Miami,PC 01,Insurance Commissioner,,R,Ken Selzer,151,105,256
-Miami,PC 02,Insurance Commissioner,,R,Ken Selzer,126,56,182
-Miami,PC 03,Insurance Commissioner,,R,Ken Selzer,167,77,244
-Miami,PC 04,Insurance Commissioner,,R,Ken Selzer,153,114,267
-Miami,RICH,Insurance Commissioner,,R,Ken Selzer,405,159,564
-Miami,SMV(3),Insurance Commissioner,,R,Ken Selzer,5,0,5
-Miami,SMV(2),Insurance Commissioner,,R,Ken Selzer,284,67,351
-Miami,SPE Prt2,Insurance Commissioner,,R,Ken Selzer,30,15,45
-Miami,SPW,Insurance Commissioner,,R,Ken Selzer,53,17,70
-Miami,SW,Insurance Commissioner,,R,Ken Selzer,393,80,473
-Miami,SH 01,Insurance Commissioner,,R,Ken Selzer,293,23,316
-Miami,SH 02,Insurance Commissioner,,R,Ken Selzer,64,22,86
-Miami,SH 03,Insurance Commissioner,,R,Ken Selzer,21,4,25
-Miami,STAN 368,Insurance Commissioner,,R,Ken Selzer,76,65,141
-Miami,STAN 367,Insurance Commissioner,,R,Ken Selzer,52,12,64
-Miami,SC,Insurance Commissioner,,R,Ken Selzer,104,22,126
-Miami,TM,Insurance Commissioner,,R,Ken Selzer,340,81,421
-Miami,WMC 416,Insurance Commissioner,,R,Ken Selzer,33,14,47
-Miami,WMC 368,Insurance Commissioner,,R,Ken Selzer,111,39,150
-Miami,WV(6),Insurance Commissioner,,R,Ken Selzer,32,29,61
-Miami,WV(12) 368,Insurance Commissioner,,R,Ken Selzer,25,11,36
-Miami,WV(12) 367,Insurance Commissioner,,R,Ken Selzer,51,22,73
-Miami,WV(5),Insurance Commissioner,,R,Ken Selzer,42,12,54
-Miami,EMC(2),Insurance Commissioner,,D,Dennis Anderson,19,7,26
-Miami,EMC(3),Insurance Commissioner,,D,Dennis Anderson,66,20,86
-Miami,EV,Insurance Commissioner,,D,Dennis Anderson,42,16,58
-Miami,FC,Insurance Commissioner,,D,Dennis Anderson,15,2,17
-Miami,LC 01,Insurance Commissioner,,D,Dennis Anderson,64,22,86
-Miami,LC 02,Insurance Commissioner,,D,Dennis Anderson,92,12,104
-Miami,LC 03,Insurance Commissioner,,D,Dennis Anderson,81,21,102
-Miami,LC 04,Insurance Commissioner,,D,Dennis Anderson,65,15,80
-Miami,MI,Insurance Commissioner,,D,Dennis Anderson,44,16,60
-Miami,MND,Insurance Commissioner,,D,Dennis Anderson,72,30,102
-Miami,NMV(2),Insurance Commissioner,,D,Dennis Anderson,15,6,21
-Miami,NMV(3),Insurance Commissioner,,D,Dennis Anderson,63,33,96
-Miami,NPW,Insurance Commissioner,,D,Dennis Anderson,41,14,55
-Miami,NPE Prt1,Insurance Commissioner,,D,Dennis Anderson,2,0,2
-Miami,NPE Prt2,Insurance Commissioner,,D,Dennis Anderson,13,4,17
-Miami,NW,Insurance Commissioner,,D,Dennis Anderson,49,10,59
-Miami,OSAGE,Insurance Commissioner,,D,Dennis Anderson,41,15,56
-Miami,OC 01,Insurance Commissioner,,D,Dennis Anderson,58,29,87
-Miami,OC 02,Insurance Commissioner,,D,Dennis Anderson,90,30,120
-Miami,OC 03,Insurance Commissioner,,D,Dennis Anderson,103,44,147
-Miami,OC 04,Insurance Commissioner,,D,Dennis Anderson,55,13,68
-Miami,OSA TWP,Insurance Commissioner,,D,Dennis Anderson,69,30,99
-Miami,PC 01,Insurance Commissioner,,D,Dennis Anderson,64,68,132
-Miami,PC 02,Insurance Commissioner,,D,Dennis Anderson,80,49,129
-Miami,PC 03,Insurance Commissioner,,D,Dennis Anderson,85,60,145
-Miami,PC 04,Insurance Commissioner,,D,Dennis Anderson,85,78,163
-Miami,RICH,Insurance Commissioner,,D,Dennis Anderson,107,66,173
-Miami,SMV(3),Insurance Commissioner,,D,Dennis Anderson,2,0,2
-Miami,SMV(2),Insurance Commissioner,,D,Dennis Anderson,108,54,162
-Miami,SPE Prt2,Insurance Commissioner,,D,Dennis Anderson,13,11,24
-Miami,SPW,Insurance Commissioner,,D,Dennis Anderson,20,18,38
-Miami,SW,Insurance Commissioner,,D,Dennis Anderson,84,26,110
-Miami,SH 01,Insurance Commissioner,,D,Dennis Anderson,97,25,122
-Miami,SH 02,Insurance Commissioner,,D,Dennis Anderson,27,19,46
-Miami,SH 03,Insurance Commissioner,,D,Dennis Anderson,9,3,12
-Miami,STAN 368,Insurance Commissioner,,D,Dennis Anderson,38,29,67
-Miami,STAN 367,Insurance Commissioner,,D,Dennis Anderson,25,15,40
-Miami,SC,Insurance Commissioner,,D,Dennis Anderson,32,6,38
-Miami,TM,Insurance Commissioner,,D,Dennis Anderson,92,34,126
-Miami,WMC 416,Insurance Commissioner,,D,Dennis Anderson,13,5,18
-Miami,WMC 368,Insurance Commissioner,,D,Dennis Anderson,34,28,62
-Miami,WV(6),Insurance Commissioner,,D,Dennis Anderson,13,21,34
-Miami,WV(12) 368,Insurance Commissioner,,D,Dennis Anderson,8,1,9
-Miami,WV(12) 367,Insurance Commissioner,,D,Dennis Anderson,28,18,46
-Miami,WV(5),Insurance Commissioner,,D,Dennis Anderson,31,10,41
-Miami,EMC(2),Insurance Commissioner,,,Write-ins,0,0,0
-Miami,EMC(3),Insurance Commissioner,,,Write-ins,0,0,0
-Miami,EV,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,FC,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,LC 01,Insurance Commissioner,,,Write-ins,1,0,1
-Miami,LC 02,Insurance Commissioner,,,Write-ins,1,1,2
-Miami,LC 03,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,LC 04,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,MI,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,MND,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,NMV(2),Insurance Commissioner,,,Write-ins,0,0,0
-Miami,NMV(3),Insurance Commissioner,,,Write-ins,0,0,0
-Miami,NPW,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,NPE Prt1,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,NPE Prt2,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,NW,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,OSAGE,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,OC 01,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,OC 02,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,OC 03,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,OC 04,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,OSA TWP,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,PC 01,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,PC 02,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,PC 03,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,PC 04,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,RICH,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SMV(3),Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SMV(2),Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SPE Prt2,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SPW,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SW,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SH 01,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SH 02,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SH 03,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,STAN 368,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,STAN 367,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,SC,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,TM,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,WMC 416,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,WMC 368,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,WV(6),Insurance Commissioner,,,Write-ins,0,0,0
-Miami,WV(12) 368,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,WV(12) 367,Insurance Commissioner,,,Write-ins,0,0,0
-Miami,WV(5),Insurance Commissioner,,,Write-ins,0,0,0
-Miami,EMC(2),State Senate,37,R,Molly Baumgardner,65,13,78
-Miami,EMC(3),State Senate,37,R,Molly Baumgardner,231,47,278
-Miami,LC 01,State Senate,37,R,Molly Baumgardner,185,42,227
-Miami,LC 02,State Senate,37,R,Molly Baumgardner,251,30,281
-Miami,LC 03,State Senate,37,R,Molly Baumgardner,241,37,278
-Miami,LC 04,State Senate,37,R,Molly Baumgardner,248,38,286
-Miami,NMV(2),State Senate,37,R,Molly Baumgardner,74,23,97
-Miami,NMV(3),State Senate,37,R,Molly Baumgardner,209,41,250
-Miami,NPW,State Senate,37,R,Molly Baumgardner,103,44,147
-Miami,NPE Prt1,State Senate,37,R,Molly Baumgardner,8,1,9
-Miami,NPE Prt2,State Senate,37,R,Molly Baumgardner,51,10,61
-Miami,NW,State Senate,37,R,Molly Baumgardner,202,21,223
-Miami,PC 01,State Senate,37,R,Molly Baumgardner,188,142,330
-Miami,PC 02,State Senate,37,R,Molly Baumgardner,185,85,270
-Miami,PC 03,State Senate,37,R,Molly Baumgardner,222,108,330
-Miami,PC 04,State Senate,37,R,Molly Baumgardner,209,156,365
-Miami,RICH,State Senate,37,R,Molly Baumgardner,471,186,657
-Miami,SMV(3),State Senate,37,R,Molly Baumgardner,5,0,5
-Miami,SMV(2),State Senate,37,R,Molly Baumgardner,356,93,449
-Miami,SPE Prt2,State Senate,37,R,Molly Baumgardner,39,21,60
-Miami,SPW,State Senate,37,R,Molly Baumgardner,60,28,88
-Miami,SW,State Senate,37,R,Molly Baumgardner,415,92,507
-Miami,SH 01,State Senate,37,R,Molly Baumgardner,359,35,394
-Miami,SH 02,State Senate,37,R,Molly Baumgardner,83,30,113
-Miami,SH 03,State Senate,37,R,Molly Baumgardner,26,6,32
-Miami,STAN 368,State Senate,37,R,Molly Baumgardner,103,78,181
-Miami,STAN 367,State Senate,37,R,Molly Baumgardner,69,19,88
-Miami,TM,State Senate,37,R,Molly Baumgardner,383,94,477
-Miami,WMC 416,State Senate,37,R,Molly Baumgardner,37,17,54
-Miami,WMC 368,State Senate,37,R,Molly Baumgardner,133,55,188
-Miami,WV(6),State Senate,37,R,Molly Baumgardner,40,43,83
-Miami,WV(5),State Senate,37,R,Molly Baumgardner,59,18,77
-Miami,EMC(2),State Senate,37,,Write-ins,2,0,2
-Miami,EMC(3),State Senate,37,,Write-ins,5,6,11
-Miami,LC 01,State Senate,37,,Write-ins,5,1,6
-Miami,LC 02,State Senate,37,,Write-ins,3,1,4
-Miami,LC 03,State Senate,37,,Write-ins,8,1,9
-Miami,LC 04,State Senate,37,,Write-ins,4,0,4
-Miami,NMV(2),State Senate,37,,Write-ins,0,0,0
-Miami,NMV(3),State Senate,37,,Write-ins,0,2,2
-Miami,NPW,State Senate,37,,Write-ins,1,2,3
-Miami,NPE Prt1,State Senate,37,,Write-ins,0,0,0
-Miami,NPE Prt2,State Senate,37,,Write-ins,0,0,0
-Miami,NW,State Senate,37,,Write-ins,7,0,7
-Miami,PC 01,State Senate,37,,Write-ins,1,5,6
-Miami,PC 02,State Senate,37,,Write-ins,1,2,3
-Miami,PC 03,State Senate,37,,Write-ins,1,2,3
-Miami,PC 04,State Senate,37,,Write-ins,4,5,9
-Miami,RICH,State Senate,37,,Write-ins,2,3,5
-Miami,SMV(3),State Senate,37,,Write-ins,0,0,0
-Miami,SMV(2),State Senate,37,,Write-ins,2,1,3
-Miami,SPE Prt2,State Senate,37,,Write-ins,0,0,0
-Miami,SPW,State Senate,37,,Write-ins,1,1,2
-Miami,SW,State Senate,37,,Write-ins,8,4,12
-Miami,SH 01,State Senate,37,,Write-ins,3,3,6
-Miami,SH 02,State Senate,37,,Write-ins,1,0,1
-Miami,SH 03,State Senate,37,,Write-ins,0,0,0
-Miami,STAN 368,State Senate,37,,Write-ins,0,0,0
-Miami,STAN 367,State Senate,37,,Write-ins,0,1,1
-Miami,TM,State Senate,37,,Write-ins,8,0,8
-Miami,WMC 416,State Senate,37,,Write-ins,1,0,1
-Miami,WMC 368,State Senate,37,,Write-ins,1,1,2
-Miami,WV(6),State Senate,37,,Write-ins,0,0,0
-Miami,WV(5),State Senate,37,,Write-ins,2,0,2
-Miami,MND,State House,5,D,Cleon Rickel,63,27,90
-Miami,OC 01,State House,5,D,Cleon Rickel,51,27,78
-Miami,OC 02,State House,5,D,Cleon Rickel,69,30,99
-Miami,OC 03,State House,5,D,Cleon Rickel,87,33,120
-Miami,OC 04,State House,5,D,Cleon Rickel,51,12,63
-Miami,OSA TWP,State House,5,D,Cleon Rickel,57,29,86
-Miami,STAN 368,State House,5,D,Cleon Rickel,32,28,60
-Miami,STAN 367,State House,5,D,Cleon Rickel,21,16,37
-Miami,WV(5),State House,5,D,Cleon Rickel,27,9,36
-Miami,MND,State House,5,R,Kevin Jones,121,34,155
-Miami,OC 01,State House,5,R,Kevin Jones,72,20,92
-Miami,OC 02,State House,5,R,Kevin Jones,131,41,172
-Miami,OC 03,State House,5,R,Kevin Jones,128,44,172
-Miami,OC 04,State House,5,R,Kevin Jones,69,17,86
-Miami,OSA TWP,State House,5,R,Kevin Jones,135,32,167
-Miami,STAN 368,State House,5,R,Kevin Jones,84,65,149
-Miami,STAN 367,State House,5,R,Kevin Jones,58,11,69
-Miami,WV(5),State House,5,R,Kevin Jones,46,13,59
-Miami,MND,State House,5,,Write-ins,0,0,0
-Miami,OC 01,State House,5,,Write-ins,0,0,0
-Miami,OC 02,State House,5,,Write-ins,0,1,1
-Miami,OC 03,State House,5,,Write-ins,0,1,1
-Miami,OC 04,State House,5,,Write-ins,0,0,0
-Miami,OSA TWP,State House,5,,Write-ins,0,0,0
-Miami,STAN 368,State House,5,,Write-ins,0,0,0
-Miami,STAN 367,State House,5,,Write-ins,0,0,0
-Miami,WV(5),State House,5,,Write-ins,0,0,0
-Miami,EMC(2),State House,6,D,Christy Levings,21,5,26
-Miami,EMC(3),State House,6,D,Christy Levings,75,22,97
-Miami,EV,State House,6,D,Christy Levings,40,19,59
-Miami,FC,State House,6,D,Christy Levings,17,2,19
-Miami,LC 01,State House,6,D,Christy Levings,83,22,105
-Miami,LC 02,State House,6,D,Christy Levings,101,12,113
-Miami,LC 03,State House,6,D,Christy Levings,90,18,108
-Miami,LC 04,State House,6,D,Christy Levings,90,10,100
-Miami,MI,State House,6,D,Christy Levings,47,15,62
-Miami,NPW,State House,6,D,Christy Levings,48,18,66
-Miami,NPE Prt1,State House,6,D,Christy Levings,2,0,2
-Miami,NPE Prt2,State House,6,D,Christy Levings,8,5,13
-Miami,NW,State House,6,D,Christy Levings,65,10,75
-Miami,OSAGE,State House,6,D,Christy Levings,51,17,68
-Miami,PC 01,State House,6,D,Christy Levings,79,77,156
-Miami,PC 02,State House,6,D,Christy Levings,87,56,143
-Miami,PC 03,State House,6,D,Christy Levings,105,79,184
-Miami,PC 04,State House,6,D,Christy Levings,97,86,183
-Miami,RICH,State House,6,D,Christy Levings,131,67,198
-Miami,SMV(3),State House,6,D,Christy Levings,1,0,1
-Miami,SMV(2),State House,6,D,Christy Levings,123,61,184
-Miami,SPE Prt2,State House,6,D,Christy Levings,16,14,30
-Miami,SPW,State House,6,D,Christy Levings,25,21,46
-Miami,SW,State House,6,D,Christy Levings,101,31,132
-Miami,SC,State House,6,D,Christy Levings,33,8,41
-Miami,TM,State House,6,D,Christy Levings,89,41,130
-Miami,WMC 416,State House,6,D,Christy Levings,18,4,22
-Miami,WMC 368,State House,6,D,Christy Levings,33,24,57
-Miami,WV(6),State House,6,D,Christy Levings,15,23,38
-Miami,WV(12) 368,State House,6,D,Christy Levings,9,2,11
-Miami,WV(12) 367,State House,6,D,Christy Levings,26,25,51
-Miami,EMC(2),State House,6,R,Jene Vickrey,53,13,66
-Miami,EMC(3),State House,6,R,Jene Vickrey,195,42,237
-Miami,EV,State House,6,R,Jene Vickrey,86,31,117
-Miami,FC,State House,6,R,Jene Vickrey,22,5,27
-Miami,LC 01,State House,6,R,Jene Vickrey,130,28,158
-Miami,LC 02,State House,6,R,Jene Vickrey,199,21,220
-Miami,LC 03,State House,6,R,Jene Vickrey,193,29,222
-Miami,LC 04,State House,6,R,Jene Vickrey,185,33,218
-Miami,MI,State House,6,R,Jene Vickrey,121,30,151
-Miami,NPW,State House,6,R,Jene Vickrey,84,35,119
-Miami,NPE Prt1,State House,6,R,Jene Vickrey,6,1,7
-Miami,NPE Prt2,State House,6,R,Jene Vickrey,47,9,56
-Miami,NW,State House,6,R,Jene Vickrey,171,17,188
-Miami,OSAGE,State House,6,R,Jene Vickrey,95,9,104
-Miami,PC 01,State House,6,R,Jene Vickrey,145,96,241
-Miami,PC 02,State House,6,R,Jene Vickrey,124,49,173
-Miami,PC 03,State House,6,R,Jene Vickrey,153,63,216
-Miami,PC 04,State House,6,R,Jene Vickrey,151,110,261
-Miami,RICH,State House,6,R,Jene Vickrey,395,165,560
-Miami,SMV(3),State House,6,R,Jene Vickrey,6,0,6
-Miami,SMV(2),State House,6,R,Jene Vickrey,272,61,333
-Miami,SPE Prt2,State House,6,R,Jene Vickrey,30,12,42
-Miami,SPW,State House,6,R,Jene Vickrey,50,15,65
-Miami,SW,State House,6,R,Jene Vickrey,381,74,455
-Miami,SC,State House,6,R,Jene Vickrey,108,22,130
-Miami,TM,State House,6,R,Jene Vickrey,348,75,423
-Miami,WMC 416,State House,6,R,Jene Vickrey,28,15,43
-Miami,WMC 368,State House,6,R,Jene Vickrey,112,42,154
-Miami,WV(6),State House,6,R,Jene Vickrey,30,28,58
-Miami,WV(12) 368,State House,6,R,Jene Vickrey,24,10,34
-Miami,WV(12) 367,State House,6,R,Jene Vickrey,52,15,67
-Miami,EMC(2),State House,6,,Write-ins,0,0,0
-Miami,EMC(3),State House,6,,Write-ins,0,0,0
-Miami,EV,State House,6,,Write-ins,0,0,0
-Miami,FC,State House,6,,Write-ins,0,0,0
-Miami,LC 01,State House,6,,Write-ins,1,0,1
-Miami,LC 02,State House,6,,Write-ins,0,1,1
-Miami,LC 03,State House,6,,Write-ins,0,0,0
-Miami,LC 04,State House,6,,Write-ins,0,0,0
-Miami,MI,State House,6,,Write-ins,0,0,0
-Miami,NPW,State House,6,,Write-ins,0,0,0
-Miami,NPE Prt1,State House,6,,Write-ins,0,0,0
-Miami,NPE Prt2,State House,6,,Write-ins,0,0,0
-Miami,NW,State House,6,,Write-ins,0,0,0
-Miami,OSAGE,State House,6,,Write-ins,0,0,0
-Miami,PC 01,State House,6,,Write-ins,0,1,1
-Miami,PC 02,State House,6,,Write-ins,0,0,0
-Miami,PC 03,State House,6,,Write-ins,1,0,1
-Miami,PC 04,State House,6,,Write-ins,0,0,0
-Miami,RICH,State House,6,,Write-ins,0,0,0
-Miami,SMV(3),State House,6,,Write-ins,0,0,0
-Miami,SMV(2),State House,6,,Write-ins,0,0,0
-Miami,SPE Prt2,State House,6,,Write-ins,0,0,0
-Miami,SPW,State House,6,,Write-ins,0,0,0
-Miami,SW,State House,6,,Write-ins,0,0,0
-Miami,SC,State House,6,,Write-ins,0,0,0
-Miami,TM,State House,6,,Write-ins,0,0,0
-Miami,WMC 416,State House,6,,Write-ins,0,0,0
-Miami,WMC 368,State House,6,,Write-ins,0,0,0
-Miami,WV(6),State House,6,,Write-ins,0,0,0
-Miami,WV(12) 368,State House,6,,Write-ins,0,0,0
-Miami,WV(12) 367,State House,6,,Write-ins,0,0,0
-Miami,NMV(2),State House,26,D,Cheron Tiffany,8,6,14
-Miami,NMV(3),State House,26,D,Cheron Tiffany,70,29,99
-Miami,SH 01,State House,26,D,Cheron Tiffany,93,24,117
-Miami,SH 02,State House,26,D,Cheron Tiffany,27,16,43
-Miami,SH 03,State House,26,D,Cheron Tiffany,10,2,12
-Miami,NMV(2),State House,26,R,Larry Campbell,72,17,89
-Miami,NMV(3),State House,26,R,Larry Campbell,172,29,201
-Miami,SH 01,State House,26,R,Larry Campbell,298,25,323
-Miami,SH 02,State House,26,R,Larry Campbell,64,23,87
-Miami,SH 03,State House,26,R,Larry Campbell,21,5,26
-Miami,NMV(2),State House,26,,Write-ins,0,0,0
-Miami,NMV(3),State House,26,,Write-ins,0,0,0
-Miami,SH 01,State House,26,,Write-ins,0,0,0
-Miami,SH 02,State House,26,,Write-ins,0,0,0
-Miami,SH 03,State House,26,,Write-ins,0,0,0
+county,precinct,office,district,party,candidate,votes,vtd
+MIAMI,East Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,000020
+MIAMI,East Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000020
+MIAMI,East Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000020
+MIAMI,Louisburg Ward 1 Exclave Park,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00004C
+MIAMI,Miami Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",75,000050
+MIAMI,Miami Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000050
+MIAMI,Miami Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000050
+MIAMI,Mound Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",102,000060
+MIAMI,Mound Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000060
+MIAMI,Mound Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000060
+MIAMI,North Marysville Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00007B
+MIAMI,North Marysville Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00007B
+MIAMI,North Marysville Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00007B
+MIAMI,North Wea Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000080
+MIAMI,North Wea Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000080
+MIAMI,North Wea Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",182,000080
+MIAMI,Osage Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000090
+MIAMI,Osage Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000090
+MIAMI,Osage Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",114,000090
+MIAMI,Osawatomie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,000100
+MIAMI,Osawatomie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000100
+MIAMI,Osawatomie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00011B
+MIAMI,Osawatomie Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",137,00012A
+MIAMI,Osawatomie Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,00012A
+MIAMI,Osawatomie Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00012B
+MIAMI,Osawatomie Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",173,00013A
+MIAMI,Osawatomie Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00013A
+MIAMI,Osawatomie Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",111,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00013C
+MIAMI,Osawatomie Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,000140
+MIAMI,Osawatomie Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000140
+MIAMI,Osawatomie Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,000140
+MIAMI,Paola Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",175,00016A
+MIAMI,Paola Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,00016A
+MIAMI,Paola Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",211,00016A
+MIAMI,Paola Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00016B
+MIAMI,Paola Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00016B
+MIAMI,Paola Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00016B
+MIAMI,Paola Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",153,000170
+MIAMI,Paola Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000170
+MIAMI,Paola Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",140,000170
+MIAMI,Paola Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",185,00018A
+MIAMI,Paola Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,00018A
+MIAMI,Paola Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",199,00018A
+MIAMI,Paola Ward 3 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018B
+MIAMI,Paola Ward 3 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018B
+MIAMI,Paola Ward 3 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018B
+MIAMI,Paola Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",205,00019A
+MIAMI,Paola Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,00019A
+MIAMI,Paola Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",227,00019A
+MIAMI,Paola Ward 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00019B
+MIAMI,Paola Ward 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00019B
+MIAMI,Paola Ward 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00019B
+MIAMI,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",219,000200
+MIAMI,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000200
+MIAMI,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",514,000200
+MIAMI,South Wea Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",152,000220
+MIAMI,South Wea Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000220
+MIAMI,South Wea Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",420,000220
+MIAMI,Spring Hill City Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",168,00023A
+MIAMI,Spring Hill City Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,00023A
+MIAMI,Spring Hill City Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",268,00023A
+MIAMI,Spring Hill City Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00023B
+MIAMI,Spring Hill City Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00023B
+MIAMI,Spring Hill City Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00023B
+MIAMI,Spring Hill City Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",70,00023C
+MIAMI,Spring Hill City Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00023C
+MIAMI,Spring Hill City Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,00023C
+MIAMI,Spring Hill City Exclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00023D
+MIAMI,Spring Hill City Exclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00023D
+MIAMI,Spring Hill City Exclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00023D
+MIAMI,Stanton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000240
+MIAMI,Stanton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000240
+MIAMI,Stanton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",184,000240
+MIAMI,Sugar Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000250
+MIAMI,Sugar Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000250
+MIAMI,Sugar Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",120,000250
+MIAMI,Ten Mile Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",168,000260
+MIAMI,Ten Mile Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000260
+MIAMI,Ten Mile Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",374,000260
+MIAMI,West Middle Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000270
+MIAMI,West Middle Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000270
+MIAMI,West Middle Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",189,000270
+MIAMI,East Middle Creek Township C2,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,120020
+MIAMI,East Middle Creek Township C2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,120020
+MIAMI,East Middle Creek Township C2,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,120020
+MIAMI,East Middle Creek Township C3,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,120030
+MIAMI,East Middle Creek Township C3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,120030
+MIAMI,East Middle Creek Township C3,Governor / Lt. Governor,,Republican,"Brownback, Sam",214,120030
+MIAMI,North Marysville Township C2,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,120040
+MIAMI,North Marysville Township C2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120040
+MIAMI,North Marysville Township C2,Governor / Lt. Governor,,Republican,"Brownback, Sam",82,120040
+MIAMI,North Marysville Township C3,Governor / Lt. Governor,,Democratic,"Davis, Paul",125,120050
+MIAMI,North Marysville Township C3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,120050
+MIAMI,North Marysville Township C3,Governor / Lt. Governor,,Republican,"Brownback, Sam",213,120050
+MIAMI,Osawatomie Ward 1 H5,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,120060
+MIAMI,Osawatomie Ward 1 H5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,120060
+MIAMI,Osawatomie Ward 1 H5,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,120060
+MIAMI,Osawatomie Ward 1 H6,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120070
+MIAMI,Osawatomie Ward 1 H6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120070
+MIAMI,Osawatomie Ward 1 H6,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120070
+MIAMI,South Marysville Township C2,Governor / Lt. Governor,,Democratic,"Davis, Paul",196,120080
+MIAMI,South Marysville Township C2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,120080
+MIAMI,South Marysville Township C2,Governor / Lt. Governor,,Republican,"Brownback, Sam",301,120080
+MIAMI,South Marysville Township C3,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120090
+MIAMI,South Marysville Township C3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120090
+MIAMI,South Marysville Township C3,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,120090
+MIAMI,West Valley Township H5,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,120100
+MIAMI,West Valley Township H5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,120100
+MIAMI,West Valley Township H5,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,120100
+MIAMI,West Valley Township H6,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,120110
+MIAMI,West Valley Township H6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120110
+MIAMI,West Valley Township H6,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,120110
+MIAMI,Louisburg Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",106,140010
+MIAMI,Louisburg Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,140010
+MIAMI,Louisburg Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",145,140010
+MIAMI,Louisburg Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",131,140020
+MIAMI,Louisburg Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,140020
+MIAMI,Louisburg Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",190,140020
+MIAMI,Louisburg Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",127,140030
+MIAMI,Louisburg Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,140030
+MIAMI,Louisburg Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",191,140030
+MIAMI,Louisburg Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",113,140040
+MIAMI,Louisburg Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,140040
+MIAMI,Louisburg Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",186,140040
+MIAMI,North Paola Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,200010
+MIAMI,North Paola Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,200010
+MIAMI,North Paola Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",111,200010
+MIAMI,South Paola Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,200020
+MIAMI,South Paola Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,200020
+MIAMI,South Paola Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,200020
+MIAMI,Osawatomie Township Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+MIAMI,Osawatomie Township Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+MIAMI,Osawatomie Township Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+MIAMI,Osawatomie Township Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+MIAMI,Osawatomie Township Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+MIAMI,Osawatomie Township Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900070
+MIAMI,Paola Ward 1 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900080
+MIAMI,Paola Ward 1 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900080
+MIAMI,Paola Ward 1 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900080
+MIAMI,South Wea Township Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900090
+MIAMI,South Wea Township Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900090
+MIAMI,South Wea Township Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900090
+MIAMI,South Wea Township Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900100
+MIAMI,South Wea Township Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900100
+MIAMI,South Wea Township Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900100
+MIAMI,South Wea Township Enclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900110
+MIAMI,South Wea Township Enclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900110
+MIAMI,South Wea Township Enclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900110
+MIAMI,West Valley Township Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,900120
+MIAMI,West Valley Township Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,900120
+MIAMI,West Valley Township Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,900120
+MIAMI,North Marysville Township Enclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900130
+MIAMI,North Marysville Township Enclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900130
+MIAMI,North Marysville Township Enclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900130
+MIAMI,North Paola Township Part 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,900140
+MIAMI,North Paola Township Part 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900140
+MIAMI,North Paola Township Part 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",6,900140
+MIAMI,North Paola Township Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,900150
+MIAMI,North Paola Township Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,900150
+MIAMI,North Paola Township Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,900150
+MIAMI,North Paola Township Part 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900160
+MIAMI,North Paola Township Part 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900160
+MIAMI,North Paola Township Part 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900160
+MIAMI,South Paola Township Part 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,900180
+MIAMI,South Paola Township Part 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,900180
+MIAMI,South Paola Township Part 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,900180
+MIAMI,East Valley Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",59,000020
+MIAMI,East Valley Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",117,000020
+MIAMI,Louisburg Ward 1 Exclave Park,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00004C
+MIAMI,Miami Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",62,000050
+MIAMI,Miami Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",151,000050
+MIAMI,Mound Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",90,000060
+MIAMI,Mound Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",155,000060
+MIAMI,North Marysville Township Enclave,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",0,00007B
+MIAMI,North Marysville Township Enclave,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",0,00007B
+MIAMI,North Wea Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",75,000080
+MIAMI,North Wea Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",188,000080
+MIAMI,Osage Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",87,000090
+MIAMI,Osage Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",131,000090
+MIAMI,Osawatomie Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",86,000100
+MIAMI,Osawatomie Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",167,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00011B
+MIAMI,Osawatomie Ward 2,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",99,00012A
+MIAMI,Osawatomie Ward 2,Kansas House of Representatives,5,Republican,"Jones, Kevin",172,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00012B
+MIAMI,Osawatomie Ward 3,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",120,00013A
+MIAMI,Osawatomie Ward 3,Kansas House of Representatives,5,Republican,"Jones, Kevin",172,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00013C
+MIAMI,Osawatomie Ward 4,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",63,000140
+MIAMI,Osawatomie Ward 4,Kansas House of Representatives,5,Republican,"Jones, Kevin",86,000140
+MIAMI,Paola Ward 1,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",156,00016A
+MIAMI,Paola Ward 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",241,00016A
+MIAMI,Paola Ward 1 Exclave,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,00016B
+MIAMI,Paola Ward 1 Exclave,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00016B
+MIAMI,Paola Ward 2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",143,000170
+MIAMI,Paola Ward 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",173,000170
+MIAMI,Paola Ward 3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",184,00018A
+MIAMI,Paola Ward 3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",216,00018A
+MIAMI,Paola Ward 3 Exclave A,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,00018B
+MIAMI,Paola Ward 3 Exclave A,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00018B
+MIAMI,Paola Ward 4,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",183,00019A
+MIAMI,Paola Ward 4,Kansas House of Representatives,6,Republican,"Vickrey, Jene",261,00019A
+MIAMI,Paola Ward 4 Exclave,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,00019B
+MIAMI,Paola Ward 4 Exclave,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00019B
+MIAMI,Richland Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",198,000200
+MIAMI,Richland Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",560,000200
+MIAMI,South Wea Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",132,000220
+MIAMI,South Wea Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",455,000220
+MIAMI,Spring Hill City Precinct 01,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",117,00023A
+MIAMI,Spring Hill City Precinct 01,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",323,00023A
+MIAMI,Spring Hill City Exclave A,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",0,00023B
+MIAMI,Spring Hill City Exclave A,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",0,00023B
+MIAMI,Spring Hill City Exclave B,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",43,00023C
+MIAMI,Spring Hill City Exclave B,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",87,00023C
+MIAMI,Spring Hill City Exclave C,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",0,00023D
+MIAMI,Spring Hill City Exclave C,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",0,00023D
+MIAMI,Stanton Township,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",97,000240
+MIAMI,Stanton Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",218,000240
+MIAMI,Sugar Creek Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",41,000250
+MIAMI,Sugar Creek Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",130,000250
+MIAMI,Ten Mile Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",130,000260
+MIAMI,Ten Mile Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",423,000260
+MIAMI,West Middle Creek Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",79,000270
+MIAMI,West Middle Creek Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",197,000270
+MIAMI,East Middle Creek Township C2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",26,120020
+MIAMI,East Middle Creek Township C2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",66,120020
+MIAMI,East Middle Creek Township C3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",97,120030
+MIAMI,East Middle Creek Township C3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",237,120030
+MIAMI,North Marysville Township C2,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",14,120040
+MIAMI,North Marysville Township C2,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",89,120040
+MIAMI,North Marysville Township C3,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",111,120050
+MIAMI,North Marysville Township C3,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",227,120050
+MIAMI,Osawatomie Ward 1 H5,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",78,120060
+MIAMI,Osawatomie Ward 1 H5,Kansas House of Representatives,5,Republican,"Jones, Kevin",92,120060
+MIAMI,Osawatomie Ward 1 H6,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,120070
+MIAMI,Osawatomie Ward 1 H6,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,120070
+MIAMI,South Marysville Township C2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",184,120080
+MIAMI,South Marysville Township C2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",333,120080
+MIAMI,South Marysville Township C3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",1,120090
+MIAMI,South Marysville Township C3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",6,120090
+MIAMI,West Valley Township H5,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",36,120100
+MIAMI,West Valley Township H5,Kansas House of Representatives,5,Republican,"Jones, Kevin",59,120100
+MIAMI,West Valley Township H6,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",38,120110
+MIAMI,West Valley Township H6,Kansas House of Representatives,6,Republican,"Vickrey, Jene",58,120110
+MIAMI,Louisburg Ward 1,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",105,140010
+MIAMI,Louisburg Ward 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",158,140010
+MIAMI,Louisburg Ward 2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",113,140020
+MIAMI,Louisburg Ward 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",220,140020
+MIAMI,Louisburg Ward 3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",108,140030
+MIAMI,Louisburg Ward 3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",222,140030
+MIAMI,Louisburg Ward 4,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",100,140040
+MIAMI,Louisburg Ward 4,Kansas House of Representatives,6,Republican,"Vickrey, Jene",218,140040
+MIAMI,North Paola Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",66,200010
+MIAMI,North Paola Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",119,200010
+MIAMI,South Paola Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",46,200020
+MIAMI,South Paola Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",65,200020
+MIAMI,Osawatomie Township Enclave A,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",0,900010
+MIAMI,Osawatomie Township Enclave A,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,900010
+MIAMI,Osawatomie Township Enclave B,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",0,900020
+MIAMI,Osawatomie Township Enclave B,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,Kansas House of Representatives,5,Democratic,"Rickel, Cleon",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,900070
+MIAMI,Paola Ward 1 Exclave B,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,900080
+MIAMI,Paola Ward 1 Exclave B,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900080
+MIAMI,South Wea Township Enclave A,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,900090
+MIAMI,South Wea Township Enclave A,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900090
+MIAMI,South Wea Township Enclave B,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,900100
+MIAMI,South Wea Township Enclave B,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900100
+MIAMI,South Wea Township Enclave C,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,900110
+MIAMI,South Wea Township Enclave C,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900110
+MIAMI,West Valley Township Exclave,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",62,900120
+MIAMI,West Valley Township Exclave,Kansas House of Representatives,6,Republican,"Vickrey, Jene",101,900120
+MIAMI,North Marysville Township Enclave 2,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",0,900130
+MIAMI,North Marysville Township Enclave 2,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",0,900130
+MIAMI,North Paola Township Part 1,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",2,900140
+MIAMI,North Paola Township Part 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",7,900140
+MIAMI,North Paola Township Part 2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",13,900150
+MIAMI,North Paola Township Part 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",56,900150
+MIAMI,North Paola Township Part 3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",0,900160
+MIAMI,North Paola Township Part 3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900160
+MIAMI,South Paola Township Part 2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",30,900180
+MIAMI,South Paola Township Part 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",42,900180
+MIAMI,East Valley Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",42,000020
+MIAMI,East Valley Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000020
+MIAMI,East Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",127,000020
+MIAMI,Louisburg Ward 1 Exclave Park,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00004C
+MIAMI,Miami Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,000050
+MIAMI,Miami Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000050
+MIAMI,Miami Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000050
+MIAMI,Mound Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",75,000060
+MIAMI,Mound Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000060
+MIAMI,Mound Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000060
+MIAMI,North Marysville Township Enclave,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00007B
+MIAMI,North Marysville Township Enclave,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00007B
+MIAMI,North Wea Township,United States House of Representatives,3,Democratic,"Kultala, Kelly",52,000080
+MIAMI,North Wea Township,United States House of Representatives,3,Republican,"Yoder, Kevin",213,000080
+MIAMI,Osage Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",64,000090
+MIAMI,Osage Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000090
+MIAMI,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",145,000090
+MIAMI,Osawatomie Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",78,000100
+MIAMI,Osawatomie Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000100
+MIAMI,Osawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",174,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00011B
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",95,00012A
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,00012A
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",165,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00012B
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",116,00013A
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,00013A
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",170,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013C
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",52,000140
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000140
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,000140
+MIAMI,Paola Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",111,00016A
+MIAMI,Paola Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,00016A
+MIAMI,Paola Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",276,00016A
+MIAMI,Paola Ward 1 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00016B
+MIAMI,Paola Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00016B
+MIAMI,Paola Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016B
+MIAMI,Paola Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",101,000170
+MIAMI,Paola Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000170
+MIAMI,Paola Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,000170
+MIAMI,Paola Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",120,00018A
+MIAMI,Paola Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,00018A
+MIAMI,Paola Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",273,00018A
+MIAMI,Paola Ward 3 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00018B
+MIAMI,Paola Ward 3 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00018B
+MIAMI,Paola Ward 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018B
+MIAMI,Paola Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",121,00019A
+MIAMI,Paola Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,00019A
+MIAMI,Paola Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",307,00019A
+MIAMI,Paola Ward 4 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00019B
+MIAMI,Paola Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00019B
+MIAMI,Paola Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00019B
+MIAMI,Richland Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",155,000200
+MIAMI,Richland Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,000200
+MIAMI,Richland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",587,000200
+MIAMI,South Wea Township,United States House of Representatives,3,Democratic,"Kultala, Kelly",96,000220
+MIAMI,South Wea Township,United States House of Representatives,3,Republican,"Yoder, Kevin",487,000220
+MIAMI,Spring Hill City Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",107,00023A
+MIAMI,Spring Hill City Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",344,00023A
+MIAMI,Spring Hill City Exclave A,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00023B
+MIAMI,Spring Hill City Exclave A,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00023B
+MIAMI,Spring Hill City Exclave B,United States House of Representatives,3,Democratic,"Kultala, Kelly",45,00023C
+MIAMI,Spring Hill City Exclave B,United States House of Representatives,3,Republican,"Yoder, Kevin",90,00023C
+MIAMI,Spring Hill City Exclave C,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,00023D
+MIAMI,Spring Hill City Exclave C,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00023D
+MIAMI,Stanton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",73,000240
+MIAMI,Stanton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000240
+MIAMI,Stanton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",232,000240
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,000250
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000250
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",145,000250
+MIAMI,Ten Mile Township,United States House of Representatives,3,Democratic,"Kultala, Kelly",131,000260
+MIAMI,Ten Mile Township,United States House of Representatives,3,Republican,"Yoder, Kevin",419,000260
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",52,000270
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000270
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",217,000270
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,120020
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,120020
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,120020
+MIAMI,East Middle Creek Township C3,United States House of Representatives,3,Democratic,"Kultala, Kelly",85,120030
+MIAMI,East Middle Creek Township C3,United States House of Representatives,3,Republican,"Yoder, Kevin",248,120030
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,120040
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120040
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,120040
+MIAMI,North Marysville Township C3,United States House of Representatives,3,Democratic,"Kultala, Kelly",108,120050
+MIAMI,North Marysville Township C3,United States House of Representatives,3,Republican,"Yoder, Kevin",237,120050
+MIAMI,Osawatomie Ward 1 H5,United States House of Representatives,2,Democratic,"Wakefield, Margie",66,120060
+MIAMI,Osawatomie Ward 1 H5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,120060
+MIAMI,Osawatomie Ward 1 H5,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,120060
+MIAMI,Osawatomie Ward 1 H6,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120070
+MIAMI,Osawatomie Ward 1 H6,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120070
+MIAMI,Osawatomie Ward 1 H6,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120070
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Democratic,"Wakefield, Margie",121,120080
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,120080
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",382,120080
+MIAMI,South Marysville Township C3,United States House of Representatives,3,Democratic,"Kultala, Kelly",2,120090
+MIAMI,South Marysville Township C3,United States House of Representatives,3,Republican,"Yoder, Kevin",5,120090
+MIAMI,West Valley Township H5,United States House of Representatives,2,Democratic,"Wakefield, Margie",32,120100
+MIAMI,West Valley Township H5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,120100
+MIAMI,West Valley Township H5,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,120100
+MIAMI,West Valley Township H6,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,120110
+MIAMI,West Valley Township H6,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,120110
+MIAMI,West Valley Township H6,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,120110
+MIAMI,Louisburg Ward 1,United States House of Representatives,3,Democratic,"Kultala, Kelly",85,140010
+MIAMI,Louisburg Ward 1,United States House of Representatives,3,Republican,"Yoder, Kevin",175,140010
+MIAMI,Louisburg Ward 2,United States House of Representatives,3,Democratic,"Kultala, Kelly",98,140020
+MIAMI,Louisburg Ward 2,United States House of Representatives,3,Republican,"Yoder, Kevin",235,140020
+MIAMI,Louisburg Ward 3,United States House of Representatives,3,Democratic,"Kultala, Kelly",87,140030
+MIAMI,Louisburg Ward 3,United States House of Representatives,3,Republican,"Yoder, Kevin",243,140030
+MIAMI,Louisburg Ward 4,United States House of Representatives,3,Democratic,"Kultala, Kelly",59,140040
+MIAMI,Louisburg Ward 4,United States House of Representatives,3,Republican,"Yoder, Kevin",251,140040
+MIAMI,North Paola Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,200010
+MIAMI,North Paola Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,200010
+MIAMI,North Paola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",136,200010
+MIAMI,South Paola Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",30,200020
+MIAMI,South Paola Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,200020
+MIAMI,South Paola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,200020
+MIAMI,Osawatomie Township Enclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+MIAMI,Osawatomie Township Enclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+MIAMI,Osawatomie Township Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+MIAMI,Osawatomie Township Enclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+MIAMI,Osawatomie Township Enclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+MIAMI,Osawatomie Township Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900070
+MIAMI,Paola Ward 1 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900080
+MIAMI,Paola Ward 1 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900080
+MIAMI,Paola Ward 1 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900080
+MIAMI,South Wea Township Enclave A,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,900090
+MIAMI,South Wea Township Enclave A,United States House of Representatives,3,Republican,"Yoder, Kevin",0,900090
+MIAMI,South Wea Township Enclave B,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,900100
+MIAMI,South Wea Township Enclave B,United States House of Representatives,3,Republican,"Yoder, Kevin",0,900100
+MIAMI,South Wea Township Enclave C,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,900110
+MIAMI,South Wea Township Enclave C,United States House of Representatives,3,Republican,"Yoder, Kevin",0,900110
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",35,900120
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,900120
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",127,900120
+MIAMI,North Marysville Township Enclave 2,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,900130
+MIAMI,North Marysville Township Enclave 2,United States House of Representatives,3,Republican,"Yoder, Kevin",0,900130
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",2,900140
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,900140
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",5,900140
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",12,900150
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,900150
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,900150
+MIAMI,North Paola Township Part 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900160
+MIAMI,North Paola Township Part 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900160
+MIAMI,North Paola Township Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900160
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,900180
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,900180
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,900180
+MIAMI,East Valley Township,Attorney General,,Democratic,"Kotich, A.J.",54,000020
+MIAMI,East Valley Township,Attorney General,,Republican,"Schmidt, Derek",117,000020
+MIAMI,Louisburg Ward 1 Exclave Park,Attorney General,,Democratic,"Kotich, A.J.",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,Attorney General,,Republican,"Schmidt, Derek",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00004C
+MIAMI,Miami Township,Attorney General,,Democratic,"Kotich, A.J.",55,000050
+MIAMI,Miami Township,Attorney General,,Republican,"Schmidt, Derek",148,000050
+MIAMI,Mound Township,Attorney General,,Democratic,"Kotich, A.J.",87,000060
+MIAMI,Mound Township,Attorney General,,Republican,"Schmidt, Derek",158,000060
+MIAMI,North Marysville Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00007B
+MIAMI,North Marysville Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00007B
+MIAMI,North Wea Township,Attorney General,,Democratic,"Kotich, A.J.",57,000080
+MIAMI,North Wea Township,Attorney General,,Republican,"Schmidt, Derek",200,000080
+MIAMI,Osage Township,Attorney General,,Democratic,"Kotich, A.J.",72,000090
+MIAMI,Osage Township,Attorney General,,Republican,"Schmidt, Derek",138,000090
+MIAMI,Osawatomie Township,Attorney General,,Democratic,"Kotich, A.J.",83,000100
+MIAMI,Osawatomie Township,Attorney General,,Republican,"Schmidt, Derek",171,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Attorney General,,Democratic,"Kotich, A.J.",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Attorney General,,Republican,"Schmidt, Derek",0,00011B
+MIAMI,Osawatomie Ward 2,Attorney General,,Democratic,"Kotich, A.J.",108,00012A
+MIAMI,Osawatomie Ward 2,Attorney General,,Republican,"Schmidt, Derek",164,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,Attorney General,,Democratic,"Kotich, A.J.",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,Attorney General,,Republican,"Schmidt, Derek",0,00012B
+MIAMI,Osawatomie Ward 3,Attorney General,,Democratic,"Kotich, A.J.",133,00013A
+MIAMI,Osawatomie Ward 3,Attorney General,,Republican,"Schmidt, Derek",158,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00013C
+MIAMI,Osawatomie Ward 4,Attorney General,,Democratic,"Kotich, A.J.",61,000140
+MIAMI,Osawatomie Ward 4,Attorney General,,Republican,"Schmidt, Derek",88,000140
+MIAMI,Paola Ward 1,Attorney General,,Democratic,"Kotich, A.J.",124,00016A
+MIAMI,Paola Ward 1,Attorney General,,Republican,"Schmidt, Derek",264,00016A
+MIAMI,Paola Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00016B
+MIAMI,Paola Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00016B
+MIAMI,Paola Ward 2,Attorney General,,Democratic,"Kotich, A.J.",125,000170
+MIAMI,Paola Ward 2,Attorney General,,Republican,"Schmidt, Derek",181,000170
+MIAMI,Paola Ward 3,Attorney General,,Democratic,"Kotich, A.J.",135,00018A
+MIAMI,Paola Ward 3,Attorney General,,Republican,"Schmidt, Derek",254,00018A
+MIAMI,Paola Ward 3 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00018B
+MIAMI,Paola Ward 3 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00018B
+MIAMI,Paola Ward 4,Attorney General,,Democratic,"Kotich, A.J.",143,00019A
+MIAMI,Paola Ward 4,Attorney General,,Republican,"Schmidt, Derek",289,00019A
+MIAMI,Paola Ward 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00019B
+MIAMI,Paola Ward 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00019B
+MIAMI,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",175,000200
+MIAMI,Richland Township,Attorney General,,Republican,"Schmidt, Derek",571,000200
+MIAMI,South Wea Township,Attorney General,,Democratic,"Kotich, A.J.",105,000220
+MIAMI,South Wea Township,Attorney General,,Republican,"Schmidt, Derek",475,000220
+MIAMI,Spring Hill City Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",111,00023A
+MIAMI,Spring Hill City Precinct 01,Attorney General,,Republican,"Schmidt, Derek",333,00023A
+MIAMI,Spring Hill City Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00023B
+MIAMI,Spring Hill City Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00023B
+MIAMI,Spring Hill City Exclave B,Attorney General,,Democratic,"Kotich, A.J.",42,00023C
+MIAMI,Spring Hill City Exclave B,Attorney General,,Republican,"Schmidt, Derek",89,00023C
+MIAMI,Spring Hill City Exclave C,Attorney General,,Democratic,"Kotich, A.J.",0,00023D
+MIAMI,Spring Hill City Exclave C,Attorney General,,Republican,"Schmidt, Derek",0,00023D
+MIAMI,Stanton Township,Attorney General,,Democratic,"Kotich, A.J.",100,000240
+MIAMI,Stanton Township,Attorney General,,Republican,"Schmidt, Derek",216,000240
+MIAMI,Sugar Creek Township,Attorney General,,Democratic,"Kotich, A.J.",34,000250
+MIAMI,Sugar Creek Township,Attorney General,,Republican,"Schmidt, Derek",134,000250
+MIAMI,Ten Mile Township,Attorney General,,Democratic,"Kotich, A.J.",127,000260
+MIAMI,Ten Mile Township,Attorney General,,Republican,"Schmidt, Derek",415,000260
+MIAMI,West Middle Creek Township,Attorney General,,Democratic,"Kotich, A.J.",68,000270
+MIAMI,West Middle Creek Township,Attorney General,,Republican,"Schmidt, Derek",207,000270
+MIAMI,East Middle Creek Township C2,Attorney General,,Democratic,"Kotich, A.J.",23,120020
+MIAMI,East Middle Creek Township C2,Attorney General,,Republican,"Schmidt, Derek",67,120020
+MIAMI,East Middle Creek Township C3,Attorney General,,Democratic,"Kotich, A.J.",83,120030
+MIAMI,East Middle Creek Township C3,Attorney General,,Republican,"Schmidt, Derek",250,120030
+MIAMI,North Marysville Township C2,Attorney General,,Democratic,"Kotich, A.J.",18,120040
+MIAMI,North Marysville Township C2,Attorney General,,Republican,"Schmidt, Derek",88,120040
+MIAMI,North Marysville Township C3,Attorney General,,Democratic,"Kotich, A.J.",101,120050
+MIAMI,North Marysville Township C3,Attorney General,,Republican,"Schmidt, Derek",242,120050
+MIAMI,Osawatomie Ward 1 H5,Attorney General,,Democratic,"Kotich, A.J.",76,120060
+MIAMI,Osawatomie Ward 1 H5,Attorney General,,Republican,"Schmidt, Derek",94,120060
+MIAMI,Osawatomie Ward 1 H6,Attorney General,,Democratic,"Kotich, A.J.",0,120070
+MIAMI,Osawatomie Ward 1 H6,Attorney General,,Republican,"Schmidt, Derek",0,120070
+MIAMI,South Marysville Township C2,Attorney General,,Democratic,"Kotich, A.J.",151,120080
+MIAMI,South Marysville Township C2,Attorney General,,Republican,"Schmidt, Derek",363,120080
+MIAMI,South Marysville Township C3,Attorney General,,Democratic,"Kotich, A.J.",2,120090
+MIAMI,South Marysville Township C3,Attorney General,,Republican,"Schmidt, Derek",5,120090
+MIAMI,West Valley Township H5,Attorney General,,Democratic,"Kotich, A.J.",39,120100
+MIAMI,West Valley Township H5,Attorney General,,Republican,"Schmidt, Derek",56,120100
+MIAMI,West Valley Township H6,Attorney General,,Democratic,"Kotich, A.J.",28,120110
+MIAMI,West Valley Township H6,Attorney General,,Republican,"Schmidt, Derek",68,120110
+MIAMI,Louisburg Ward 1,Attorney General,,Democratic,"Kotich, A.J.",89,140010
+MIAMI,Louisburg Ward 1,Attorney General,,Republican,"Schmidt, Derek",168,140010
+MIAMI,Louisburg Ward 2,Attorney General,,Democratic,"Kotich, A.J.",93,140020
+MIAMI,Louisburg Ward 2,Attorney General,,Republican,"Schmidt, Derek",236,140020
+MIAMI,Louisburg Ward 3,Attorney General,,Democratic,"Kotich, A.J.",91,140030
+MIAMI,Louisburg Ward 3,Attorney General,,Republican,"Schmidt, Derek",228,140030
+MIAMI,Louisburg Ward 4,Attorney General,,Democratic,"Kotich, A.J.",70,140040
+MIAMI,Louisburg Ward 4,Attorney General,,Republican,"Schmidt, Derek",237,140040
+MIAMI,North Paola Township,Attorney General,,Democratic,"Kotich, A.J.",53,200010
+MIAMI,North Paola Township,Attorney General,,Republican,"Schmidt, Derek",128,200010
+MIAMI,South Paola Township,Attorney General,,Democratic,"Kotich, A.J.",33,200020
+MIAMI,South Paola Township,Attorney General,,Republican,"Schmidt, Derek",75,200020
+MIAMI,Osawatomie Township Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+MIAMI,Osawatomie Township Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,900010
+MIAMI,Osawatomie Township Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+MIAMI,Osawatomie Township Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,Attorney General,,Republican,"Schmidt, Derek",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,Attorney General,,Republican,"Schmidt, Derek",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,Attorney General,,Democratic,"Kotich, A.J.",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,Attorney General,,Republican,"Schmidt, Derek",0,900070
+MIAMI,Paola Ward 1 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900080
+MIAMI,Paola Ward 1 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,900080
+MIAMI,South Wea Township Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900090
+MIAMI,South Wea Township Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,900090
+MIAMI,South Wea Township Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900100
+MIAMI,South Wea Township Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,900100
+MIAMI,South Wea Township Enclave C,Attorney General,,Democratic,"Kotich, A.J.",0,900110
+MIAMI,South Wea Township Enclave C,Attorney General,,Republican,"Schmidt, Derek",0,900110
+MIAMI,West Valley Township Exclave,Attorney General,,Democratic,"Kotich, A.J.",53,900120
+MIAMI,West Valley Township Exclave,Attorney General,,Republican,"Schmidt, Derek",111,900120
+MIAMI,North Marysville Township Enclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900130
+MIAMI,North Marysville Township Enclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900130
+MIAMI,North Paola Township Part 1,Attorney General,,Democratic,"Kotich, A.J.",2,900140
+MIAMI,North Paola Township Part 1,Attorney General,,Republican,"Schmidt, Derek",7,900140
+MIAMI,North Paola Township Part 2,Attorney General,,Democratic,"Kotich, A.J.",12,900150
+MIAMI,North Paola Township Part 2,Attorney General,,Republican,"Schmidt, Derek",56,900150
+MIAMI,North Paola Township Part 3,Attorney General,,Democratic,"Kotich, A.J.",0,900160
+MIAMI,North Paola Township Part 3,Attorney General,,Republican,"Schmidt, Derek",0,900160
+MIAMI,South Paola Township Part 2,Attorney General,,Democratic,"Kotich, A.J.",22,900180
+MIAMI,South Paola Township Part 2,Attorney General,,Republican,"Schmidt, Derek",47,900180
+MIAMI,East Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,000020
+MIAMI,East Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",112,000020
+MIAMI,Louisburg Ward 1 Exclave Park,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00004C
+MIAMI,Miami Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",60,000050
+MIAMI,Miami Township,Commissioner of Insurance,,Republican,"Selzer, Ken",143,000050
+MIAMI,Mound Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",102,000060
+MIAMI,Mound Township,Commissioner of Insurance,,Republican,"Selzer, Ken",140,000060
+MIAMI,North Marysville Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00007B
+MIAMI,North Marysville Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00007B
+MIAMI,North Wea Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000080
+MIAMI,North Wea Township,Commissioner of Insurance,,Republican,"Selzer, Ken",196,000080
+MIAMI,Osage Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000090
+MIAMI,Osage Township,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000090
+MIAMI,Osawatomie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",99,000100
+MIAMI,Osawatomie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",154,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00011B
+MIAMI,Osawatomie Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",120,00012A
+MIAMI,Osawatomie Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",151,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00012B
+MIAMI,Osawatomie Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",147,00013A
+MIAMI,Osawatomie Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",149,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00013C
+MIAMI,Osawatomie Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",68,000140
+MIAMI,Osawatomie Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",76,000140
+MIAMI,Paola Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",132,00016A
+MIAMI,Paola Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",256,00016A
+MIAMI,Paola Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00016B
+MIAMI,Paola Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00016B
+MIAMI,Paola Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",129,000170
+MIAMI,Paola Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",182,000170
+MIAMI,Paola Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",145,00018A
+MIAMI,Paola Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",244,00018A
+MIAMI,Paola Ward 3 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018B
+MIAMI,Paola Ward 3 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018B
+MIAMI,Paola Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",163,00019A
+MIAMI,Paola Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",267,00019A
+MIAMI,Paola Ward 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00019B
+MIAMI,Paola Ward 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00019B
+MIAMI,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",173,000200
+MIAMI,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",564,000200
+MIAMI,South Wea Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",110,000220
+MIAMI,South Wea Township,Commissioner of Insurance,,Republican,"Selzer, Ken",473,000220
+MIAMI,Spring Hill City Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",122,00023A
+MIAMI,Spring Hill City Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",316,00023A
+MIAMI,Spring Hill City Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00023B
+MIAMI,Spring Hill City Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00023B
+MIAMI,Spring Hill City Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,00023C
+MIAMI,Spring Hill City Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",86,00023C
+MIAMI,Spring Hill City Exclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00023D
+MIAMI,Spring Hill City Exclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00023D
+MIAMI,Stanton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",107,000240
+MIAMI,Stanton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",205,000240
+MIAMI,Sugar Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000250
+MIAMI,Sugar Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",126,000250
+MIAMI,Ten Mile Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",126,000260
+MIAMI,Ten Mile Township,Commissioner of Insurance,,Republican,"Selzer, Ken",421,000260
+MIAMI,West Middle Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000270
+MIAMI,West Middle Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",197,000270
+MIAMI,East Middle Creek Township C2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,120020
+MIAMI,East Middle Creek Township C2,Commissioner of Insurance,,Republican,"Selzer, Ken",63,120020
+MIAMI,East Middle Creek Township C3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,120030
+MIAMI,East Middle Creek Township C3,Commissioner of Insurance,,Republican,"Selzer, Ken",244,120030
+MIAMI,North Marysville Township C2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,120040
+MIAMI,North Marysville Township C2,Commissioner of Insurance,,Republican,"Selzer, Ken",81,120040
+MIAMI,North Marysville Township C3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",108,120050
+MIAMI,North Marysville Township C3,Commissioner of Insurance,,Republican,"Selzer, Ken",231,120050
+MIAMI,Osawatomie Ward 1 H5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",87,120060
+MIAMI,Osawatomie Ward 1 H5,Commissioner of Insurance,,Republican,"Selzer, Ken",84,120060
+MIAMI,Osawatomie Ward 1 H6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120070
+MIAMI,Osawatomie Ward 1 H6,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120070
+MIAMI,South Marysville Township C2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",162,120080
+MIAMI,South Marysville Township C2,Commissioner of Insurance,,Republican,"Selzer, Ken",351,120080
+MIAMI,South Marysville Township C3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,120090
+MIAMI,South Marysville Township C3,Commissioner of Insurance,,Republican,"Selzer, Ken",5,120090
+MIAMI,West Valley Township H5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,120100
+MIAMI,West Valley Township H5,Commissioner of Insurance,,Republican,"Selzer, Ken",54,120100
+MIAMI,West Valley Township H6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,120110
+MIAMI,West Valley Township H6,Commissioner of Insurance,,Republican,"Selzer, Ken",61,120110
+MIAMI,Louisburg Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",86,140010
+MIAMI,Louisburg Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",174,140010
+MIAMI,Louisburg Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",104,140020
+MIAMI,Louisburg Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",224,140020
+MIAMI,Louisburg Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",102,140030
+MIAMI,Louisburg Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",216,140030
+MIAMI,Louisburg Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,140040
+MIAMI,Louisburg Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",229,140040
+MIAMI,North Paola Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",55,200010
+MIAMI,North Paola Township,Commissioner of Insurance,,Republican,"Selzer, Ken",126,200010
+MIAMI,South Paola Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,200020
+MIAMI,South Paola Township,Commissioner of Insurance,,Republican,"Selzer, Ken",70,200020
+MIAMI,Osawatomie Township Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+MIAMI,Osawatomie Township Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+MIAMI,Osawatomie Township Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+MIAMI,Osawatomie Township Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900070
+MIAMI,Paola Ward 1 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900080
+MIAMI,Paola Ward 1 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900080
+MIAMI,South Wea Township Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900090
+MIAMI,South Wea Township Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900090
+MIAMI,South Wea Township Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900100
+MIAMI,South Wea Township Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900100
+MIAMI,South Wea Township Enclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900110
+MIAMI,South Wea Township Enclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900110
+MIAMI,West Valley Township Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",55,900120
+MIAMI,West Valley Township Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",109,900120
+MIAMI,North Marysville Township Enclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900130
+MIAMI,North Marysville Township Enclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900130
+MIAMI,North Paola Township Part 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,900140
+MIAMI,North Paola Township Part 1,Commissioner of Insurance,,Republican,"Selzer, Ken",6,900140
+MIAMI,North Paola Township Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,900150
+MIAMI,North Paola Township Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",50,900150
+MIAMI,North Paola Township Part 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900160
+MIAMI,North Paola Township Part 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900160
+MIAMI,South Paola Township Part 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,900180
+MIAMI,South Paola Township Part 2,Commissioner of Insurance,,Republican,"Selzer, Ken",45,900180
+MIAMI,Louisburg Ward 1 Exclave Park,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00004C
+MIAMI,North Marysville Township Enclave,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00007B
+MIAMI,North Wea Township,Kansas Senate,37,Republican,"Baumgardner, Molly",223,000080
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00011B
+MIAMI,Osawatomie Ward 2 Exclave Lake,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00012B
+MIAMI,Paola Ward 1,Kansas Senate,37,Republican,"Baumgardner, Molly",330,00016A
+MIAMI,Paola Ward 1 Exclave,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00016B
+MIAMI,Paola Ward 2,Kansas Senate,37,Republican,"Baumgardner, Molly",270,000170
+MIAMI,Paola Ward 3,Kansas Senate,37,Republican,"Baumgardner, Molly",330,00018A
+MIAMI,Paola Ward 3 Exclave A,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00018B
+MIAMI,Paola Ward 4,Kansas Senate,37,Republican,"Baumgardner, Molly",365,00019A
+MIAMI,Paola Ward 4 Exclave,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00019B
+MIAMI,Richland Township,Kansas Senate,37,Republican,"Baumgardner, Molly",657,000200
+MIAMI,South Wea Township,Kansas Senate,37,Republican,"Baumgardner, Molly",507,000220
+MIAMI,Spring Hill City Precinct 01,Kansas Senate,37,Republican,"Baumgardner, Molly",394,00023A
+MIAMI,Spring Hill City Exclave A,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00023B
+MIAMI,Spring Hill City Exclave B,Kansas Senate,37,Republican,"Baumgardner, Molly",113,00023C
+MIAMI,Spring Hill City Exclave C,Kansas Senate,37,Republican,"Baumgardner, Molly",0,00023D
+MIAMI,Stanton Township,Kansas Senate,37,Republican,"Baumgardner, Molly",269,000240
+MIAMI,Ten Mile Township,Kansas Senate,37,Republican,"Baumgardner, Molly",477,000260
+MIAMI,West Middle Creek Township,Kansas Senate,37,Republican,"Baumgardner, Molly",242,000270
+MIAMI,East Middle Creek Township C2,Kansas Senate,37,Republican,"Baumgardner, Molly",78,120020
+MIAMI,East Middle Creek Township C3,Kansas Senate,37,Republican,"Baumgardner, Molly",278,120030
+MIAMI,North Marysville Township C2,Kansas Senate,37,Republican,"Baumgardner, Molly",97,120040
+MIAMI,North Marysville Township C3,Kansas Senate,37,Republican,"Baumgardner, Molly",282,120050
+MIAMI,South Marysville Township C2,Kansas Senate,37,Republican,"Baumgardner, Molly",449,120080
+MIAMI,South Marysville Township C3,Kansas Senate,37,Republican,"Baumgardner, Molly",5,120090
+MIAMI,West Valley Township H5,Kansas Senate,37,Republican,"Baumgardner, Molly",77,120100
+MIAMI,West Valley Township H6,Kansas Senate,37,Republican,"Baumgardner, Molly",83,120110
+MIAMI,Louisburg Ward 1,Kansas Senate,37,Republican,"Baumgardner, Molly",227,140010
+MIAMI,Louisburg Ward 2,Kansas Senate,37,Republican,"Baumgardner, Molly",281,140020
+MIAMI,Louisburg Ward 3,Kansas Senate,37,Republican,"Baumgardner, Molly",278,140030
+MIAMI,Louisburg Ward 4,Kansas Senate,37,Republican,"Baumgardner, Molly",286,140040
+MIAMI,North Paola Township,Kansas Senate,37,Republican,"Baumgardner, Molly",147,200010
+MIAMI,South Paola Township,Kansas Senate,37,Republican,"Baumgardner, Molly",88,200020
+MIAMI,Osawatomie Ward 1 Exclave B,Kansas Senate,37,Republican,"Baumgardner, Molly",0,900030
+MIAMI,Paola Ward 1 Exclave B,Kansas Senate,37,Republican,"Baumgardner, Molly",0,900080
+MIAMI,South Wea Township Enclave A,Kansas Senate,37,Republican,"Baumgardner, Molly",0,900090
+MIAMI,South Wea Township Enclave B,Kansas Senate,37,Republican,"Baumgardner, Molly",0,900100
+MIAMI,South Wea Township Enclave C,Kansas Senate,37,Republican,"Baumgardner, Molly",0,900110
+MIAMI,North Marysville Township Enclave 2,Kansas Senate,37,Republican,"Baumgardner, Molly",0,900130
+MIAMI,North Paola Township Part 1,Kansas Senate,37,Republican,"Baumgardner, Molly",9,900140
+MIAMI,North Paola Township Part 2,Kansas Senate,37,Republican,"Baumgardner, Molly",61,900150
+MIAMI,North Paola Township Part 3,Kansas Senate,37,Republican,"Baumgardner, Molly",0,900160
+MIAMI,South Paola Township Part 2,Kansas Senate,37,Republican,"Baumgardner, Molly",60,900180
+MIAMI,East Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,000020
+MIAMI,East Valley Township,Secretary of State,,Republican,"Kobach, Kris",116,000020
+MIAMI,Louisburg Ward 1 Exclave Park,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,Secretary of State,,Republican,"Kobach, Kris",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00004C
+MIAMI,Miami Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,000050
+MIAMI,Miami Township,Secretary of State,,Republican,"Kobach, Kris",147,000050
+MIAMI,Mound Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000060
+MIAMI,Mound Township,Secretary of State,,Republican,"Kobach, Kris",151,000060
+MIAMI,North Marysville Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00007B
+MIAMI,North Marysville Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00007B
+MIAMI,North Wea Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000080
+MIAMI,North Wea Township,Secretary of State,,Republican,"Kobach, Kris",196,000080
+MIAMI,Osage Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000090
+MIAMI,Osage Township,Secretary of State,,Republican,"Kobach, Kris",135,000090
+MIAMI,Osawatomie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,000100
+MIAMI,Osawatomie Township,Secretary of State,,Republican,"Kobach, Kris",165,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Secretary of State,,Republican,"Kobach, Kris",0,00011B
+MIAMI,Osawatomie Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",118,00012A
+MIAMI,Osawatomie Ward 2,Secretary of State,,Republican,"Kobach, Kris",155,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,Secretary of State,,Republican,"Kobach, Kris",0,00012B
+MIAMI,Osawatomie Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",138,00013A
+MIAMI,Osawatomie Ward 3,Secretary of State,,Republican,"Kobach, Kris",151,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00013C
+MIAMI,Osawatomie Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000140
+MIAMI,Osawatomie Ward 4,Secretary of State,,Republican,"Kobach, Kris",84,000140
+MIAMI,Paola Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",135,00016A
+MIAMI,Paola Ward 1,Secretary of State,,Republican,"Kobach, Kris",258,00016A
+MIAMI,Paola Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00016B
+MIAMI,Paola Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00016B
+MIAMI,Paola Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",138,000170
+MIAMI,Paola Ward 2,Secretary of State,,Republican,"Kobach, Kris",170,000170
+MIAMI,Paola Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",155,00018A
+MIAMI,Paola Ward 3,Secretary of State,,Republican,"Kobach, Kris",241,00018A
+MIAMI,Paola Ward 3 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018B
+MIAMI,Paola Ward 3 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00018B
+MIAMI,Paola Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",163,00019A
+MIAMI,Paola Ward 4,Secretary of State,,Republican,"Kobach, Kris",275,00019A
+MIAMI,Paola Ward 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00019B
+MIAMI,Paola Ward 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00019B
+MIAMI,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",186,000200
+MIAMI,Richland Township,Secretary of State,,Republican,"Kobach, Kris",569,000200
+MIAMI,South Wea Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,000220
+MIAMI,South Wea Township,Secretary of State,,Republican,"Kobach, Kris",471,000220
+MIAMI,Spring Hill City Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",124,00023A
+MIAMI,Spring Hill City Precinct 01,Secretary of State,,Republican,"Kobach, Kris",323,00023A
+MIAMI,Spring Hill City Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00023B
+MIAMI,Spring Hill City Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00023B
+MIAMI,Spring Hill City Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,00023C
+MIAMI,Spring Hill City Exclave B,Secretary of State,,Republican,"Kobach, Kris",79,00023C
+MIAMI,Spring Hill City Exclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00023D
+MIAMI,Spring Hill City Exclave C,Secretary of State,,Republican,"Kobach, Kris",0,00023D
+MIAMI,Stanton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",106,000240
+MIAMI,Stanton Township,Secretary of State,,Republican,"Kobach, Kris",208,000240
+MIAMI,Sugar Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000250
+MIAMI,Sugar Creek Township,Secretary of State,,Republican,"Kobach, Kris",131,000250
+MIAMI,Ten Mile Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",147,000260
+MIAMI,Ten Mile Township,Secretary of State,,Republican,"Kobach, Kris",406,000260
+MIAMI,West Middle Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000270
+MIAMI,West Middle Creek Township,Secretary of State,,Republican,"Kobach, Kris",206,000270
+MIAMI,East Middle Creek Township C2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,120020
+MIAMI,East Middle Creek Township C2,Secretary of State,,Republican,"Kobach, Kris",67,120020
+MIAMI,East Middle Creek Township C3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",92,120030
+MIAMI,East Middle Creek Township C3,Secretary of State,,Republican,"Kobach, Kris",240,120030
+MIAMI,North Marysville Township C2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,120040
+MIAMI,North Marysville Township C2,Secretary of State,,Republican,"Kobach, Kris",84,120040
+MIAMI,North Marysville Township C3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",109,120050
+MIAMI,North Marysville Township C3,Secretary of State,,Republican,"Kobach, Kris",236,120050
+MIAMI,Osawatomie Ward 1 H5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",87,120060
+MIAMI,Osawatomie Ward 1 H5,Secretary of State,,Republican,"Kobach, Kris",83,120060
+MIAMI,Osawatomie Ward 1 H6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120070
+MIAMI,Osawatomie Ward 1 H6,Secretary of State,,Republican,"Kobach, Kris",0,120070
+MIAMI,South Marysville Township C2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",163,120080
+MIAMI,South Marysville Township C2,Secretary of State,,Republican,"Kobach, Kris",351,120080
+MIAMI,South Marysville Township C3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,120090
+MIAMI,South Marysville Township C3,Secretary of State,,Republican,"Kobach, Kris",4,120090
+MIAMI,West Valley Township H5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,120100
+MIAMI,West Valley Township H5,Secretary of State,,Republican,"Kobach, Kris",53,120100
+MIAMI,West Valley Township H6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,120110
+MIAMI,West Valley Township H6,Secretary of State,,Republican,"Kobach, Kris",59,120110
+MIAMI,Louisburg Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,140010
+MIAMI,Louisburg Ward 1,Secretary of State,,Republican,"Kobach, Kris",170,140010
+MIAMI,Louisburg Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,140020
+MIAMI,Louisburg Ward 2,Secretary of State,,Republican,"Kobach, Kris",227,140020
+MIAMI,Louisburg Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,140030
+MIAMI,Louisburg Ward 3,Secretary of State,,Republican,"Kobach, Kris",223,140030
+MIAMI,Louisburg Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,140040
+MIAMI,Louisburg Ward 4,Secretary of State,,Republican,"Kobach, Kris",224,140040
+MIAMI,North Paola Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,200010
+MIAMI,North Paola Township,Secretary of State,,Republican,"Kobach, Kris",121,200010
+MIAMI,South Paola Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,200020
+MIAMI,South Paola Township,Secretary of State,,Republican,"Kobach, Kris",74,200020
+MIAMI,Osawatomie Township Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+MIAMI,Osawatomie Township Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,900010
+MIAMI,Osawatomie Township Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+MIAMI,Osawatomie Township Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,Secretary of State,,Republican,"Kobach, Kris",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,Secretary of State,,Republican,"Kobach, Kris",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,Secretary of State,,Republican,"Kobach, Kris",0,900070
+MIAMI,Paola Ward 1 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900080
+MIAMI,Paola Ward 1 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,900080
+MIAMI,South Wea Township Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900090
+MIAMI,South Wea Township Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,900090
+MIAMI,South Wea Township Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900100
+MIAMI,South Wea Township Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,900100
+MIAMI,South Wea Township Enclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900110
+MIAMI,South Wea Township Enclave C,Secretary of State,,Republican,"Kobach, Kris",0,900110
+MIAMI,West Valley Township Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,900120
+MIAMI,West Valley Township Exclave,Secretary of State,,Republican,"Kobach, Kris",111,900120
+MIAMI,North Marysville Township Enclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900130
+MIAMI,North Marysville Township Enclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900130
+MIAMI,North Paola Township Part 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,900140
+MIAMI,North Paola Township Part 1,Secretary of State,,Republican,"Kobach, Kris",7,900140
+MIAMI,North Paola Township Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,900150
+MIAMI,North Paola Township Part 2,Secretary of State,,Republican,"Kobach, Kris",53,900150
+MIAMI,North Paola Township Part 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900160
+MIAMI,North Paola Township Part 3,Secretary of State,,Republican,"Kobach, Kris",0,900160
+MIAMI,South Paola Township Part 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,900180
+MIAMI,South Paola Township Part 2,Secretary of State,,Republican,"Kobach, Kris",44,900180
+MIAMI,East Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",47,000020
+MIAMI,East Valley Township,State Treasurer,,Republican,"Estes, Ron",126,000020
+MIAMI,Louisburg Ward 1 Exclave Park,State Treasurer,,Democratic,"Alldritt, Carmen",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,State Treasurer,,Republican,"Estes, Ron",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00004C
+MIAMI,Miami Township,State Treasurer,,Democratic,"Alldritt, Carmen",52,000050
+MIAMI,Miami Township,State Treasurer,,Republican,"Estes, Ron",153,000050
+MIAMI,Mound Township,State Treasurer,,Democratic,"Alldritt, Carmen",92,000060
+MIAMI,Mound Township,State Treasurer,,Republican,"Estes, Ron",155,000060
+MIAMI,North Marysville Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00007B
+MIAMI,North Marysville Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,00007B
+MIAMI,North Wea Township,State Treasurer,,Democratic,"Alldritt, Carmen",53,000080
+MIAMI,North Wea Township,State Treasurer,,Republican,"Estes, Ron",203,000080
+MIAMI,Osage Township,State Treasurer,,Democratic,"Alldritt, Carmen",66,000090
+MIAMI,Osage Township,State Treasurer,,Republican,"Estes, Ron",141,000090
+MIAMI,Osawatomie Township,State Treasurer,,Democratic,"Alldritt, Carmen",84,000100
+MIAMI,Osawatomie Township,State Treasurer,,Republican,"Estes, Ron",169,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,State Treasurer,,Democratic,"Alldritt, Carmen",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,State Treasurer,,Republican,"Estes, Ron",0,00011B
+MIAMI,Osawatomie Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",109,00012A
+MIAMI,Osawatomie Ward 2,State Treasurer,,Republican,"Estes, Ron",162,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,State Treasurer,,Democratic,"Alldritt, Carmen",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,State Treasurer,,Republican,"Estes, Ron",0,00012B
+MIAMI,Osawatomie Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",130,00013A
+MIAMI,Osawatomie Ward 3,State Treasurer,,Republican,"Estes, Ron",165,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00013C
+MIAMI,Osawatomie Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",65,000140
+MIAMI,Osawatomie Ward 4,State Treasurer,,Republican,"Estes, Ron",83,000140
+MIAMI,Paola Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",122,00016A
+MIAMI,Paola Ward 1,State Treasurer,,Republican,"Estes, Ron",266,00016A
+MIAMI,Paola Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00016B
+MIAMI,Paola Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00016B
+MIAMI,Paola Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",115,000170
+MIAMI,Paola Ward 2,State Treasurer,,Republican,"Estes, Ron",193,000170
+MIAMI,Paola Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",128,00018A
+MIAMI,Paola Ward 3,State Treasurer,,Republican,"Estes, Ron",262,00018A
+MIAMI,Paola Ward 3 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018B
+MIAMI,Paola Ward 3 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00018B
+MIAMI,Paola Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",138,00019A
+MIAMI,Paola Ward 4,State Treasurer,,Republican,"Estes, Ron",297,00019A
+MIAMI,Paola Ward 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00019B
+MIAMI,Paola Ward 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00019B
+MIAMI,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",161,000200
+MIAMI,Richland Township,State Treasurer,,Republican,"Estes, Ron",581,000200
+MIAMI,South Wea Township,State Treasurer,,Democratic,"Alldritt, Carmen",107,000220
+MIAMI,South Wea Township,State Treasurer,,Republican,"Estes, Ron",471,000220
+MIAMI,Spring Hill City Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",109,00023A
+MIAMI,Spring Hill City Precinct 01,State Treasurer,,Republican,"Estes, Ron",331,00023A
+MIAMI,Spring Hill City Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00023B
+MIAMI,Spring Hill City Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00023B
+MIAMI,Spring Hill City Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",44,00023C
+MIAMI,Spring Hill City Exclave B,State Treasurer,,Republican,"Estes, Ron",89,00023C
+MIAMI,Spring Hill City Exclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00023D
+MIAMI,Spring Hill City Exclave C,State Treasurer,,Republican,"Estes, Ron",0,00023D
+MIAMI,Stanton Township,State Treasurer,,Democratic,"Alldritt, Carmen",94,000240
+MIAMI,Stanton Township,State Treasurer,,Republican,"Estes, Ron",220,000240
+MIAMI,Sugar Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,000250
+MIAMI,Sugar Creek Township,State Treasurer,,Republican,"Estes, Ron",130,000250
+MIAMI,Ten Mile Township,State Treasurer,,Democratic,"Alldritt, Carmen",118,000260
+MIAMI,Ten Mile Township,State Treasurer,,Republican,"Estes, Ron",421,000260
+MIAMI,West Middle Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",70,000270
+MIAMI,West Middle Creek Township,State Treasurer,,Republican,"Estes, Ron",208,000270
+MIAMI,East Middle Creek Township C2,State Treasurer,,Democratic,"Alldritt, Carmen",23,120020
+MIAMI,East Middle Creek Township C2,State Treasurer,,Republican,"Estes, Ron",66,120020
+MIAMI,East Middle Creek Township C3,State Treasurer,,Democratic,"Alldritt, Carmen",80,120030
+MIAMI,East Middle Creek Township C3,State Treasurer,,Republican,"Estes, Ron",246,120030
+MIAMI,North Marysville Township C2,State Treasurer,,Democratic,"Alldritt, Carmen",15,120040
+MIAMI,North Marysville Township C2,State Treasurer,,Republican,"Estes, Ron",90,120040
+MIAMI,North Marysville Township C3,State Treasurer,,Democratic,"Alldritt, Carmen",95,120050
+MIAMI,North Marysville Township C3,State Treasurer,,Republican,"Estes, Ron",245,120050
+MIAMI,Osawatomie Ward 1 H5,State Treasurer,,Democratic,"Alldritt, Carmen",70,120060
+MIAMI,Osawatomie Ward 1 H5,State Treasurer,,Republican,"Estes, Ron",100,120060
+MIAMI,Osawatomie Ward 1 H6,State Treasurer,,Democratic,"Alldritt, Carmen",0,120070
+MIAMI,Osawatomie Ward 1 H6,State Treasurer,,Republican,"Estes, Ron",0,120070
+MIAMI,South Marysville Township C2,State Treasurer,,Democratic,"Alldritt, Carmen",128,120080
+MIAMI,South Marysville Township C2,State Treasurer,,Republican,"Estes, Ron",381,120080
+MIAMI,South Marysville Township C3,State Treasurer,,Democratic,"Alldritt, Carmen",2,120090
+MIAMI,South Marysville Township C3,State Treasurer,,Republican,"Estes, Ron",5,120090
+MIAMI,West Valley Township H5,State Treasurer,,Democratic,"Alldritt, Carmen",41,120100
+MIAMI,West Valley Township H5,State Treasurer,,Republican,"Estes, Ron",54,120100
+MIAMI,West Valley Township H6,State Treasurer,,Democratic,"Alldritt, Carmen",31,120110
+MIAMI,West Valley Township H6,State Treasurer,,Republican,"Estes, Ron",64,120110
+MIAMI,Louisburg Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",88,140010
+MIAMI,Louisburg Ward 1,State Treasurer,,Republican,"Estes, Ron",170,140010
+MIAMI,Louisburg Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",94,140020
+MIAMI,Louisburg Ward 2,State Treasurer,,Republican,"Estes, Ron",231,140020
+MIAMI,Louisburg Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",91,140030
+MIAMI,Louisburg Ward 3,State Treasurer,,Republican,"Estes, Ron",229,140030
+MIAMI,Louisburg Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",68,140040
+MIAMI,Louisburg Ward 4,State Treasurer,,Republican,"Estes, Ron",239,140040
+MIAMI,North Paola Township,State Treasurer,,Democratic,"Alldritt, Carmen",52,200010
+MIAMI,North Paola Township,State Treasurer,,Republican,"Estes, Ron",131,200010
+MIAMI,South Paola Township,State Treasurer,,Democratic,"Alldritt, Carmen",32,200020
+MIAMI,South Paola Township,State Treasurer,,Republican,"Estes, Ron",79,200020
+MIAMI,Osawatomie Township Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+MIAMI,Osawatomie Township Enclave A,State Treasurer,,Republican,"Estes, Ron",0,900010
+MIAMI,Osawatomie Township Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+MIAMI,Osawatomie Township Enclave B,State Treasurer,,Republican,"Estes, Ron",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,State Treasurer,,Republican,"Estes, Ron",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,State Treasurer,,Republican,"Estes, Ron",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,State Treasurer,,Democratic,"Alldritt, Carmen",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,State Treasurer,,Republican,"Estes, Ron",0,900070
+MIAMI,Paola Ward 1 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900080
+MIAMI,Paola Ward 1 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,900080
+MIAMI,South Wea Township Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900090
+MIAMI,South Wea Township Enclave A,State Treasurer,,Republican,"Estes, Ron",0,900090
+MIAMI,South Wea Township Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900100
+MIAMI,South Wea Township Enclave B,State Treasurer,,Republican,"Estes, Ron",0,900100
+MIAMI,South Wea Township Enclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,900110
+MIAMI,South Wea Township Enclave C,State Treasurer,,Republican,"Estes, Ron",0,900110
+MIAMI,West Valley Township Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",50,900120
+MIAMI,West Valley Township Exclave,State Treasurer,,Republican,"Estes, Ron",113,900120
+MIAMI,North Marysville Township Enclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900130
+MIAMI,North Marysville Township Enclave 2,State Treasurer,,Republican,"Estes, Ron",0,900130
+MIAMI,North Paola Township Part 1,State Treasurer,,Democratic,"Alldritt, Carmen",2,900140
+MIAMI,North Paola Township Part 1,State Treasurer,,Republican,"Estes, Ron",6,900140
+MIAMI,North Paola Township Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",13,900150
+MIAMI,North Paola Township Part 2,State Treasurer,,Republican,"Estes, Ron",55,900150
+MIAMI,North Paola Township Part 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,900160
+MIAMI,North Paola Township Part 3,State Treasurer,,Republican,"Estes, Ron",0,900160
+MIAMI,South Paola Township Part 2,State Treasurer,,Democratic,"Alldritt, Carmen",21,900180
+MIAMI,South Paola Township Part 2,State Treasurer,,Republican,"Estes, Ron",47,900180
+MIAMI,East Valley Township,United States Senate,,independent,"Orman, Greg",65,000020
+MIAMI,East Valley Township,United States Senate,,Libertarian,"Batson, Randall",5,000020
+MIAMI,East Valley Township,United States Senate,,Republican,"Roberts, Pat",105,000020
+MIAMI,Louisburg Ward 1 Exclave Park,United States Senate,,independent,"Orman, Greg",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,United States Senate,,Libertarian,"Batson, Randall",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,United States Senate,,Republican,"Roberts, Pat",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,United States Senate,,independent,"Orman, Greg",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,United States Senate,,independent,"Orman, Greg",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00004C
+MIAMI,Miami Township,United States Senate,,independent,"Orman, Greg",72,000050
+MIAMI,Miami Township,United States Senate,,Libertarian,"Batson, Randall",9,000050
+MIAMI,Miami Township,United States Senate,,Republican,"Roberts, Pat",132,000050
+MIAMI,Mound Township,United States Senate,,independent,"Orman, Greg",102,000060
+MIAMI,Mound Township,United States Senate,,Libertarian,"Batson, Randall",14,000060
+MIAMI,Mound Township,United States Senate,,Republican,"Roberts, Pat",132,000060
+MIAMI,North Marysville Township Enclave,United States Senate,,independent,"Orman, Greg",0,00007B
+MIAMI,North Marysville Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00007B
+MIAMI,North Marysville Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,00007B
+MIAMI,North Wea Township,United States Senate,,independent,"Orman, Greg",81,000080
+MIAMI,North Wea Township,United States Senate,,Libertarian,"Batson, Randall",7,000080
+MIAMI,North Wea Township,United States Senate,,Republican,"Roberts, Pat",176,000080
+MIAMI,Osage Township,United States Senate,,independent,"Orman, Greg",91,000090
+MIAMI,Osage Township,United States Senate,,Libertarian,"Batson, Randall",10,000090
+MIAMI,Osage Township,United States Senate,,Republican,"Roberts, Pat",117,000090
+MIAMI,Osawatomie Township,United States Senate,,independent,"Orman, Greg",109,000100
+MIAMI,Osawatomie Township,United States Senate,,Libertarian,"Batson, Randall",8,000100
+MIAMI,Osawatomie Township,United States Senate,,Republican,"Roberts, Pat",140,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States Senate,,independent,"Orman, Greg",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States Senate,,Libertarian,"Batson, Randall",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States Senate,,Republican,"Roberts, Pat",0,00011B
+MIAMI,Osawatomie Ward 2,United States Senate,,independent,"Orman, Greg",131,00012A
+MIAMI,Osawatomie Ward 2,United States Senate,,Libertarian,"Batson, Randall",23,00012A
+MIAMI,Osawatomie Ward 2,United States Senate,,Republican,"Roberts, Pat",115,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States Senate,,independent,"Orman, Greg",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States Senate,,Libertarian,"Batson, Randall",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States Senate,,Republican,"Roberts, Pat",0,00012B
+MIAMI,Osawatomie Ward 3,United States Senate,,independent,"Orman, Greg",152,00013A
+MIAMI,Osawatomie Ward 3,United States Senate,,Libertarian,"Batson, Randall",17,00013A
+MIAMI,Osawatomie Ward 3,United States Senate,,Republican,"Roberts, Pat",128,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,United States Senate,,independent,"Orman, Greg",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,United States Senate,,independent,"Orman, Greg",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00013C
+MIAMI,Osawatomie Ward 4,United States Senate,,independent,"Orman, Greg",73,000140
+MIAMI,Osawatomie Ward 4,United States Senate,,Libertarian,"Batson, Randall",11,000140
+MIAMI,Osawatomie Ward 4,United States Senate,,Republican,"Roberts, Pat",66,000140
+MIAMI,Paola Ward 1,United States Senate,,independent,"Orman, Greg",170,00016A
+MIAMI,Paola Ward 1,United States Senate,,Libertarian,"Batson, Randall",11,00016A
+MIAMI,Paola Ward 1,United States Senate,,Republican,"Roberts, Pat",218,00016A
+MIAMI,Paola Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,00016B
+MIAMI,Paola Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00016B
+MIAMI,Paola Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00016B
+MIAMI,Paola Ward 2,United States Senate,,independent,"Orman, Greg",150,000170
+MIAMI,Paola Ward 2,United States Senate,,Libertarian,"Batson, Randall",16,000170
+MIAMI,Paola Ward 2,United States Senate,,Republican,"Roberts, Pat",145,000170
+MIAMI,Paola Ward 3,United States Senate,,independent,"Orman, Greg",172,00018A
+MIAMI,Paola Ward 3,United States Senate,,Libertarian,"Batson, Randall",14,00018A
+MIAMI,Paola Ward 3,United States Senate,,Republican,"Roberts, Pat",208,00018A
+MIAMI,Paola Ward 3 Exclave A,United States Senate,,independent,"Orman, Greg",0,00018B
+MIAMI,Paola Ward 3 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00018B
+MIAMI,Paola Ward 3 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00018B
+MIAMI,Paola Ward 4,United States Senate,,independent,"Orman, Greg",187,00019A
+MIAMI,Paola Ward 4,United States Senate,,Libertarian,"Batson, Randall",23,00019A
+MIAMI,Paola Ward 4,United States Senate,,Republican,"Roberts, Pat",234,00019A
+MIAMI,Paola Ward 4 Exclave,United States Senate,,independent,"Orman, Greg",0,00019B
+MIAMI,Paola Ward 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00019B
+MIAMI,Paola Ward 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00019B
+MIAMI,Richland Township,United States Senate,,independent,"Orman, Greg",234,000200
+MIAMI,Richland Township,United States Senate,,Libertarian,"Batson, Randall",28,000200
+MIAMI,Richland Township,United States Senate,,Republican,"Roberts, Pat",496,000200
+MIAMI,South Wea Township,United States Senate,,independent,"Orman, Greg",149,000220
+MIAMI,South Wea Township,United States Senate,,Libertarian,"Batson, Randall",10,000220
+MIAMI,South Wea Township,United States Senate,,Republican,"Roberts, Pat",425,000220
+MIAMI,Spring Hill City Precinct 01,United States Senate,,independent,"Orman, Greg",165,00023A
+MIAMI,Spring Hill City Precinct 01,United States Senate,,Libertarian,"Batson, Randall",20,00023A
+MIAMI,Spring Hill City Precinct 01,United States Senate,,Republican,"Roberts, Pat",267,00023A
+MIAMI,Spring Hill City Exclave A,United States Senate,,independent,"Orman, Greg",0,00023B
+MIAMI,Spring Hill City Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00023B
+MIAMI,Spring Hill City Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00023B
+MIAMI,Spring Hill City Exclave B,United States Senate,,independent,"Orman, Greg",62,00023C
+MIAMI,Spring Hill City Exclave B,United States Senate,,Libertarian,"Batson, Randall",2,00023C
+MIAMI,Spring Hill City Exclave B,United States Senate,,Republican,"Roberts, Pat",71,00023C
+MIAMI,Spring Hill City Exclave C,United States Senate,,independent,"Orman, Greg",0,00023D
+MIAMI,Spring Hill City Exclave C,United States Senate,,Libertarian,"Batson, Randall",0,00023D
+MIAMI,Spring Hill City Exclave C,United States Senate,,Republican,"Roberts, Pat",0,00023D
+MIAMI,Stanton Township,United States Senate,,independent,"Orman, Greg",126,000240
+MIAMI,Stanton Township,United States Senate,,Libertarian,"Batson, Randall",11,000240
+MIAMI,Stanton Township,United States Senate,,Republican,"Roberts, Pat",182,000240
+MIAMI,Sugar Creek Township,United States Senate,,independent,"Orman, Greg",51,000250
+MIAMI,Sugar Creek Township,United States Senate,,Libertarian,"Batson, Randall",5,000250
+MIAMI,Sugar Creek Township,United States Senate,,Republican,"Roberts, Pat",115,000250
+MIAMI,Ten Mile Township,United States Senate,,independent,"Orman, Greg",173,000260
+MIAMI,Ten Mile Township,United States Senate,,Libertarian,"Batson, Randall",17,000260
+MIAMI,Ten Mile Township,United States Senate,,Republican,"Roberts, Pat",363,000260
+MIAMI,West Middle Creek Township,United States Senate,,independent,"Orman, Greg",84,000270
+MIAMI,West Middle Creek Township,United States Senate,,Libertarian,"Batson, Randall",8,000270
+MIAMI,West Middle Creek Township,United States Senate,,Republican,"Roberts, Pat",187,000270
+MIAMI,East Middle Creek Township C2,United States Senate,,independent,"Orman, Greg",38,120020
+MIAMI,East Middle Creek Township C2,United States Senate,,Libertarian,"Batson, Randall",2,120020
+MIAMI,East Middle Creek Township C2,United States Senate,,Republican,"Roberts, Pat",52,120020
+MIAMI,East Middle Creek Township C3,United States Senate,,independent,"Orman, Greg",116,120030
+MIAMI,East Middle Creek Township C3,United States Senate,,Libertarian,"Batson, Randall",6,120030
+MIAMI,East Middle Creek Township C3,United States Senate,,Republican,"Roberts, Pat",214,120030
+MIAMI,North Marysville Township C2,United States Senate,,independent,"Orman, Greg",24,120040
+MIAMI,North Marysville Township C2,United States Senate,,Libertarian,"Batson, Randall",5,120040
+MIAMI,North Marysville Township C2,United States Senate,,Republican,"Roberts, Pat",79,120040
+MIAMI,North Marysville Township C3,United States Senate,,independent,"Orman, Greg",136,120050
+MIAMI,North Marysville Township C3,United States Senate,,Libertarian,"Batson, Randall",5,120050
+MIAMI,North Marysville Township C3,United States Senate,,Republican,"Roberts, Pat",203,120050
+MIAMI,Osawatomie Ward 1 H5,United States Senate,,independent,"Orman, Greg",89,120060
+MIAMI,Osawatomie Ward 1 H5,United States Senate,,Libertarian,"Batson, Randall",5,120060
+MIAMI,Osawatomie Ward 1 H5,United States Senate,,Republican,"Roberts, Pat",77,120060
+MIAMI,Osawatomie Ward 1 H6,United States Senate,,independent,"Orman, Greg",0,120070
+MIAMI,Osawatomie Ward 1 H6,United States Senate,,Libertarian,"Batson, Randall",0,120070
+MIAMI,Osawatomie Ward 1 H6,United States Senate,,Republican,"Roberts, Pat",0,120070
+MIAMI,South Marysville Township C2,United States Senate,,independent,"Orman, Greg",193,120080
+MIAMI,South Marysville Township C2,United States Senate,,Libertarian,"Batson, Randall",19,120080
+MIAMI,South Marysville Township C2,United States Senate,,Republican,"Roberts, Pat",305,120080
+MIAMI,South Marysville Township C3,United States Senate,,independent,"Orman, Greg",2,120090
+MIAMI,South Marysville Township C3,United States Senate,,Libertarian,"Batson, Randall",0,120090
+MIAMI,South Marysville Township C3,United States Senate,,Republican,"Roberts, Pat",5,120090
+MIAMI,West Valley Township H5,United States Senate,,independent,"Orman, Greg",40,120100
+MIAMI,West Valley Township H5,United States Senate,,Libertarian,"Batson, Randall",6,120100
+MIAMI,West Valley Township H5,United States Senate,,Republican,"Roberts, Pat",49,120100
+MIAMI,West Valley Township H6,United States Senate,,independent,"Orman, Greg",42,120110
+MIAMI,West Valley Township H6,United States Senate,,Libertarian,"Batson, Randall",0,120110
+MIAMI,West Valley Township H6,United States Senate,,Republican,"Roberts, Pat",55,120110
+MIAMI,Louisburg Ward 1,United States Senate,,independent,"Orman, Greg",108,140010
+MIAMI,Louisburg Ward 1,United States Senate,,Libertarian,"Batson, Randall",21,140010
+MIAMI,Louisburg Ward 1,United States Senate,,Republican,"Roberts, Pat",135,140010
+MIAMI,Louisburg Ward 2,United States Senate,,independent,"Orman, Greg",134,140020
+MIAMI,Louisburg Ward 2,United States Senate,,Libertarian,"Batson, Randall",12,140020
+MIAMI,Louisburg Ward 2,United States Senate,,Republican,"Roberts, Pat",191,140020
+MIAMI,Louisburg Ward 3,United States Senate,,independent,"Orman, Greg",123,140030
+MIAMI,Louisburg Ward 3,United States Senate,,Libertarian,"Batson, Randall",16,140030
+MIAMI,Louisburg Ward 3,United States Senate,,Republican,"Roberts, Pat",189,140030
+MIAMI,Louisburg Ward 4,United States Senate,,independent,"Orman, Greg",120,140040
+MIAMI,Louisburg Ward 4,United States Senate,,Libertarian,"Batson, Randall",12,140040
+MIAMI,Louisburg Ward 4,United States Senate,,Republican,"Roberts, Pat",180,140040
+MIAMI,North Paola Township,United States Senate,,independent,"Orman, Greg",72,200010
+MIAMI,North Paola Township,United States Senate,,Libertarian,"Batson, Randall",4,200010
+MIAMI,North Paola Township,United States Senate,,Republican,"Roberts, Pat",109,200010
+MIAMI,South Paola Township,United States Senate,,independent,"Orman, Greg",52,200020
+MIAMI,South Paola Township,United States Senate,,Libertarian,"Batson, Randall",5,200020
+MIAMI,South Paola Township,United States Senate,,Republican,"Roberts, Pat",55,200020
+MIAMI,Osawatomie Township Enclave A,United States Senate,,independent,"Orman, Greg",0,900010
+MIAMI,Osawatomie Township Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,900010
+MIAMI,Osawatomie Township Enclave A,United States Senate,,Republican,"Roberts, Pat",0,900010
+MIAMI,Osawatomie Township Enclave B,United States Senate,,independent,"Orman, Greg",0,900020
+MIAMI,Osawatomie Township Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,900020
+MIAMI,Osawatomie Township Enclave B,United States Senate,,Republican,"Roberts, Pat",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,United States Senate,,independent,"Orman, Greg",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,United States Senate,,independent,"Orman, Greg",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,United States Senate,,Libertarian,"Batson, Randall",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,United States Senate,,Republican,"Roberts, Pat",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,United States Senate,,independent,"Orman, Greg",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,United States Senate,,Libertarian,"Batson, Randall",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,United States Senate,,Republican,"Roberts, Pat",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,United States Senate,,independent,"Orman, Greg",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,United States Senate,,Libertarian,"Batson, Randall",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,United States Senate,,Republican,"Roberts, Pat",0,900070
+MIAMI,Paola Ward 1 Exclave B,United States Senate,,independent,"Orman, Greg",0,900080
+MIAMI,Paola Ward 1 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,900080
+MIAMI,Paola Ward 1 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,900080
+MIAMI,South Wea Township Enclave A,United States Senate,,independent,"Orman, Greg",0,900090
+MIAMI,South Wea Township Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,900090
+MIAMI,South Wea Township Enclave A,United States Senate,,Republican,"Roberts, Pat",0,900090
+MIAMI,South Wea Township Enclave B,United States Senate,,independent,"Orman, Greg",0,900100
+MIAMI,South Wea Township Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,900100
+MIAMI,South Wea Township Enclave B,United States Senate,,Republican,"Roberts, Pat",0,900100
+MIAMI,South Wea Township Enclave C,United States Senate,,independent,"Orman, Greg",0,900110
+MIAMI,South Wea Township Enclave C,United States Senate,,Libertarian,"Batson, Randall",0,900110
+MIAMI,South Wea Township Enclave C,United States Senate,,Republican,"Roberts, Pat",0,900110
+MIAMI,West Valley Township Exclave,United States Senate,,independent,"Orman, Greg",70,900120
+MIAMI,West Valley Township Exclave,United States Senate,,Libertarian,"Batson, Randall",11,900120
+MIAMI,West Valley Township Exclave,United States Senate,,Republican,"Roberts, Pat",84,900120
+MIAMI,North Marysville Township Enclave 2,United States Senate,,independent,"Orman, Greg",0,900130
+MIAMI,North Marysville Township Enclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900130
+MIAMI,North Marysville Township Enclave 2,United States Senate,,Republican,"Roberts, Pat",0,900130
+MIAMI,North Paola Township Part 1,United States Senate,,independent,"Orman, Greg",5,900140
+MIAMI,North Paola Township Part 1,United States Senate,,Libertarian,"Batson, Randall",0,900140
+MIAMI,North Paola Township Part 1,United States Senate,,Republican,"Roberts, Pat",4,900140
+MIAMI,North Paola Township Part 2,United States Senate,,independent,"Orman, Greg",19,900150
+MIAMI,North Paola Township Part 2,United States Senate,,Libertarian,"Batson, Randall",5,900150
+MIAMI,North Paola Township Part 2,United States Senate,,Republican,"Roberts, Pat",46,900150
+MIAMI,North Paola Township Part 3,United States Senate,,independent,"Orman, Greg",0,900160
+MIAMI,North Paola Township Part 3,United States Senate,,Libertarian,"Batson, Randall",0,900160
+MIAMI,North Paola Township Part 3,United States Senate,,Republican,"Roberts, Pat",0,900160
+MIAMI,South Paola Township Part 2,United States Senate,,independent,"Orman, Greg",30,900180
+MIAMI,South Paola Township Part 2,United States Senate,,Libertarian,"Batson, Randall",5,900180
+MIAMI,South Paola Township Part 2,United States Senate,,Republican,"Roberts, Pat",36,900180

--- a/2014/20141104__ks__general__mitchell__precinct.csv
+++ b/2014/20141104__ks__general__mitchell__precinct.csv
@@ -1,426 +1,562 @@
-county,precinct,office,district,party,candidate,votes
-Mitchell,Ward 1,U.S. Senate,,R,Pat Roberts,127
-Mitchell,Ward 2,U.S. Senate,,R,Pat Roberts,224
-Mitchell,Ward 3,U.S. Senate,,R,Pat Roberts,249
-Mitchell,Ward 4,U.S. Senate,,R,Pat Roberts,198
-Mitchell,Beloit,U.S. Senate,,R,Pat Roberts,88
-Mitchell,Custer,U.S. Senate,,R,Pat Roberts,33
-Mitchell,Pittsburg,U.S. Senate,,R,Pat Roberts,110
-Mitchell,Carr Ck,U.S. Senate,,R,Pat Roberts,11
-Mitchell,Cawker,U.S. Senate,,R,Pat Roberts,114
-Mitchell,Blue Hill,U.S. Senate,,R,Pat Roberts,17
-Mitchell,Hayes,U.S. Senate,,R,Pat Roberts,11
-Mitchell,Walnut Ck,U.S. Senate,,R,Pat Roberts,14
-Mitchell,Glen Elder,U.S. Senate,,R,Pat Roberts,148
-Mitchell,Round Spr,U.S. Senate,,R,Pat Roberts,11
-Mitchell,Center,U.S. Senate,,R,Pat Roberts,12
-Mitchell,Solomon,U.S. Senate,,R,Pat Roberts,20
-Mitchell,Turkey Ck,U.S. Senate,,R,Pat Roberts,43
-Mitchell,Salt Ck,U.S. Senate,,R,Pat Roberts,10
-Mitchell,Bloomfield,U.S. Senate,,R,Pat Roberts,29
-Mitchell,Plum Ck,U.S. Senate,,R,Pat Roberts,50
-Mitchell,Eureka,U.S. Senate,,R,Pat Roberts,11
-Mitchell,Logan,U.S. Senate,,R,Pat Roberts,26
-Mitchell,Asherville,U.S. Senate,,R,Pat Roberts,29
-Mitchell,Lulu,U.S. Senate,,R,Pat Roberts,25
-Mitchell,Prov,U.S. Senate,,R,Pat Roberts,25
-Mitchell,Ward 1,U.S. Senate,,I,Greg Orman,44
-Mitchell,Ward 2,U.S. Senate,,I,Greg Orman,111
-Mitchell,Ward 3,U.S. Senate,,I,Greg Orman,85
-Mitchell,Ward 4,U.S. Senate,,I,Greg Orman,66
-Mitchell,Beloit,U.S. Senate,,I,Greg Orman,25
-Mitchell,Custer,U.S. Senate,,I,Greg Orman,16
-Mitchell,Pittsburg,U.S. Senate,,I,Greg Orman,24
-Mitchell,Carr Ck,U.S. Senate,,I,Greg Orman,0
-Mitchell,Cawker,U.S. Senate,,I,Greg Orman,46
-Mitchell,Blue Hill,U.S. Senate,,I,Greg Orman,0
-Mitchell,Hayes,U.S. Senate,,I,Greg Orman,2
-Mitchell,Walnut Ck,U.S. Senate,,I,Greg Orman,5
-Mitchell,Glen Elder,U.S. Senate,,I,Greg Orman,42
-Mitchell,Round Spr,U.S. Senate,,I,Greg Orman,2
-Mitchell,Center,U.S. Senate,,I,Greg Orman,0
-Mitchell,Solomon,U.S. Senate,,I,Greg Orman,10
-Mitchell,Turkey Ck,U.S. Senate,,I,Greg Orman,7
-Mitchell,Salt Ck,U.S. Senate,,I,Greg Orman,2
-Mitchell,Bloomfield,U.S. Senate,,I,Greg Orman,4
-Mitchell,Plum Ck,U.S. Senate,,I,Greg Orman,5
-Mitchell,Eureka,U.S. Senate,,I,Greg Orman,2
-Mitchell,Logan,U.S. Senate,,I,Greg Orman,15
-Mitchell,Asherville,U.S. Senate,,I,Greg Orman,8
-Mitchell,Lulu,U.S. Senate,,I,Greg Orman,2
-Mitchell,Prov,U.S. Senate,,I,Greg Orman,4
-Mitchell,Ward 1,U.S. Senate,,L,Randall Batson,16
-Mitchell,Ward 2,U.S. Senate,,L,Randall Batson,12
-Mitchell,Ward 3,U.S. Senate,,L,Randall Batson,15
-Mitchell,Ward 4,U.S. Senate,,L,Randall Batson,7
-Mitchell,Beloit,U.S. Senate,,L,Randall Batson,2
-Mitchell,Custer,U.S. Senate,,L,Randall Batson,3
-Mitchell,Pittsburg,U.S. Senate,,L,Randall Batson,3
-Mitchell,Carr Ck,U.S. Senate,,L,Randall Batson,0
-Mitchell,Cawker,U.S. Senate,,L,Randall Batson,15
-Mitchell,Blue Hill,U.S. Senate,,L,Randall Batson,2
-Mitchell,Hayes,U.S. Senate,,L,Randall Batson,0
-Mitchell,Walnut Ck,U.S. Senate,,L,Randall Batson,1
-Mitchell,Glen Elder,U.S. Senate,,L,Randall Batson,9
-Mitchell,Round Spr,U.S. Senate,,L,Randall Batson,0
-Mitchell,Center,U.S. Senate,,L,Randall Batson,0
-Mitchell,Solomon,U.S. Senate,,L,Randall Batson,0
-Mitchell,Turkey Ck,U.S. Senate,,L,Randall Batson,3
-Mitchell,Salt Ck,U.S. Senate,,L,Randall Batson,0
-Mitchell,Bloomfield,U.S. Senate,,L,Randall Batson,1
-Mitchell,Plum Ck,U.S. Senate,,L,Randall Batson,0
-Mitchell,Eureka,U.S. Senate,,L,Randall Batson,0
-Mitchell,Logan,U.S. Senate,,L,Randall Batson,0
-Mitchell,Asherville,U.S. Senate,,L,Randall Batson,3
-Mitchell,Lulu,U.S. Senate,,L,Randall Batson,0
-Mitchell,Prov,U.S. Senate,,L,Randall Batson,2
-Mitchell,Ward 1,U.S. House,1,R,Tim Huelskamp,113
-Mitchell,Ward 2,U.S. House,1,R,Tim Huelskamp,228
-Mitchell,Ward 3,U.S. House,1,R,Tim Huelskamp,240
-Mitchell,Ward 4,U.S. House,1,R,Tim Huelskamp,185
-Mitchell,Beloit,U.S. House,1,R,Tim Huelskamp,83
-Mitchell,Custer,U.S. House,1,R,Tim Huelskamp,37
-Mitchell,Pittsburg,U.S. House,1,R,Tim Huelskamp,101
-Mitchell,Carr Ck,U.S. House,1,R,Tim Huelskamp,11
-Mitchell,Cawker,U.S. House,1,R,Tim Huelskamp,136
-Mitchell,Blue Hill,U.S. House,1,R,Tim Huelskamp,15
-Mitchell,Hayes,U.S. House,1,R,Tim Huelskamp,8
-Mitchell,Walnut Ck,U.S. House,1,R,Tim Huelskamp,12
-Mitchell,Glen Elder,U.S. House,1,R,Tim Huelskamp,153
-Mitchell,Round Spr,U.S. House,1,R,Tim Huelskamp,10
-Mitchell,Center,U.S. House,1,R,Tim Huelskamp,7
-Mitchell,Solomon,U.S. House,1,R,Tim Huelskamp,19
-Mitchell,Turkey Ck,U.S. House,1,R,Tim Huelskamp,37
-Mitchell,Salt Ck,U.S. House,1,R,Tim Huelskamp,12
-Mitchell,Bloomfield,U.S. House,1,R,Tim Huelskamp,28
-Mitchell,Plum Ck,U.S. House,1,R,Tim Huelskamp,48
-Mitchell,Eureka,U.S. House,1,R,Tim Huelskamp,10
-Mitchell,Logan,U.S. House,1,R,Tim Huelskamp,31
-Mitchell,Asherville,U.S. House,1,R,Tim Huelskamp,30
-Mitchell,Lulu,U.S. House,1,R,Tim Huelskamp,24
-Mitchell,Prov,U.S. House,1,R,Tim Huelskamp,24
-Mitchell,Ward 1,U.S. House,1,D,James Sherow,70
-Mitchell,Ward 2,U.S. House,1,D,James Sherow,116
-Mitchell,Ward 3,U.S. House,1,D,James Sherow,100
-Mitchell,Ward 4,U.S. House,1,D,James Sherow,81
-Mitchell,Beloit,U.S. House,1,D,James Sherow,29
-Mitchell,Custer,U.S. House,1,D,James Sherow,13
-Mitchell,Pittsburg,U.S. House,1,D,James Sherow,31
-Mitchell,Carr Ck,U.S. House,1,D,James Sherow,0
-Mitchell,Cawker,U.S. House,1,D,James Sherow,39
-Mitchell,Blue Hill,U.S. House,1,D,James Sherow,4
-Mitchell,Hayes,U.S. House,1,D,James Sherow,4
-Mitchell,Walnut Ck,U.S. House,1,D,James Sherow,8
-Mitchell,Glen Elder,U.S. House,1,D,James Sherow,40
-Mitchell,Round Spr,U.S. House,1,D,James Sherow,2
-Mitchell,Center,U.S. House,1,D,James Sherow,5
-Mitchell,Solomon,U.S. House,1,D,James Sherow,8
-Mitchell,Turkey Ck,U.S. House,1,D,James Sherow,16
-Mitchell,Salt Ck,U.S. House,1,D,James Sherow,0
-Mitchell,Bloomfield,U.S. House,1,D,James Sherow,6
-Mitchell,Plum Ck,U.S. House,1,D,James Sherow,7
-Mitchell,Eureka,U.S. House,1,D,James Sherow,4
-Mitchell,Logan,U.S. House,1,D,James Sherow,8
-Mitchell,Asherville,U.S. House,1,D,James Sherow,10
-Mitchell,Lulu,U.S. House,1,D,James Sherow,2
-Mitchell,Prov,U.S. House,1,D,James Sherow,7
-Mitchell,Ward 1,Governor,,R,Sam Brownback,112
-Mitchell,Ward 2,Governor,,R,Sam Brownback,210
-Mitchell,Ward 3,Governor,,R,Sam Brownback,216
-Mitchell,Ward 4,Governor,,R,Sam Brownback,166
-Mitchell,Beloit,Governor,,R,Sam Brownback,82
-Mitchell,Custer,Governor,,R,Sam Brownback,26
-Mitchell,Pittsburg,Governor,,R,Sam Brownback,103
-Mitchell,Carr Ck,Governor,,R,Sam Brownback,11
-Mitchell,Cawker,Governor,,R,Sam Brownback,113
-Mitchell,Blue Hill,Governor,,R,Sam Brownback,11
-Mitchell,Hayes,Governor,,R,Sam Brownback,9
-Mitchell,Walnut Ck,Governor,,R,Sam Brownback,13
-Mitchell,Glen Elder,Governor,,R,Sam Brownback,127
-Mitchell,Round Spr,Governor,,R,Sam Brownback,13
-Mitchell,Center,Governor,,R,Sam Brownback,8
-Mitchell,Solomon,Governor,,R,Sam Brownback,17
-Mitchell,Turkey Ck,Governor,,R,Sam Brownback,35
-Mitchell,Salt Ck,Governor,,R,Sam Brownback,11
-Mitchell,Bloomfield,Governor,,R,Sam Brownback,26
-Mitchell,Plum Ck,Governor,,R,Sam Brownback,48
-Mitchell,Eureka,Governor,,R,Sam Brownback,10
-Mitchell,Logan,Governor,,R,Sam Brownback,23
-Mitchell,Asherville,Governor,,R,Sam Brownback,26
-Mitchell,Lulu,Governor,,R,Sam Brownback,25
-Mitchell,Prov,Governor,,R,Sam Brownback,23
-Mitchell,Ward 1,Governor,,D,Paul Davis,72
-Mitchell,Ward 2,Governor,,D,Paul Davis,137
-Mitchell,Ward 3,Governor,,D,Paul Davis,122
-Mitchell,Ward 4,Governor,,D,Paul Davis,104
-Mitchell,Beloit,Governor,,D,Paul Davis,30
-Mitchell,Custer,Governor,,D,Paul Davis,24
-Mitchell,Pittsburg,Governor,,D,Paul Davis,33
-Mitchell,Carr Ck,Governor,,D,Paul Davis,0
-Mitchell,Cawker,Governor,,D,Paul Davis,62
-Mitchell,Blue Hill,Governor,,D,Paul Davis,6
-Mitchell,Hayes,Governor,,D,Paul Davis,4
-Mitchell,Walnut Ck,Governor,,D,Paul Davis,7
-Mitchell,Glen Elder,Governor,,D,Paul Davis,69
-Mitchell,Round Spr,Governor,,D,Paul Davis,2
-Mitchell,Center,Governor,,D,Paul Davis,4
-Mitchell,Solomon,Governor,,D,Paul Davis,11
-Mitchell,Turkey Ck,Governor,,D,Paul Davis,15
-Mitchell,Salt Ck,Governor,,D,Paul Davis,1
-Mitchell,Bloomfield,Governor,,D,Paul Davis,7
-Mitchell,Plum Ck,Governor,,D,Paul Davis,6
-Mitchell,Eureka,Governor,,D,Paul Davis,3
-Mitchell,Logan,Governor,,D,Paul Davis,15
-Mitchell,Asherville,Governor,,D,Paul Davis,16
-Mitchell,Lulu,Governor,,D,Paul Davis,2
-Mitchell,Prov,Governor,,D,Paul Davis,13
-Mitchell,Ward 1,Governor,,L,Keen Umbehr,11
-Mitchell,Ward 2,Governor,,L,Keen Umbehr,15
-Mitchell,Ward 3,Governor,,L,Keen Umbehr,19
-Mitchell,Ward 4,Governor,,L,Keen Umbehr,12
-Mitchell,Beloit,Governor,,L,Keen Umbehr,1
-Mitchell,Custer,Governor,,L,Keen Umbehr,2
-Mitchell,Pittsburg,Governor,,L,Keen Umbehr,4
-Mitchell,Carr Ck,Governor,,L,Keen Umbehr,0
-Mitchell,Cawker,Governor,,L,Keen Umbehr,7
-Mitchell,Blue Hill,Governor,,L,Keen Umbehr,2
-Mitchell,Hayes,Governor,,L,Keen Umbehr,0
-Mitchell,Walnut Ck,Governor,,L,Keen Umbehr,0
-Mitchell,Glen Elder,Governor,,L,Keen Umbehr,13
-Mitchell,Round Spr,Governor,,L,Keen Umbehr,0
-Mitchell,Center,Governor,,L,Keen Umbehr,0
-Mitchell,Solomon,Governor,,L,Keen Umbehr,2
-Mitchell,Turkey Ck,Governor,,L,Keen Umbehr,3
-Mitchell,Salt Ck,Governor,,L,Keen Umbehr,0
-Mitchell,Bloomfield,Governor,,L,Keen Umbehr,1
-Mitchell,Plum Ck,Governor,,L,Keen Umbehr,1
-Mitchell,Eureka,Governor,,L,Keen Umbehr,1
-Mitchell,Logan,Governor,,L,Keen Umbehr,1
-Mitchell,Asherville,Governor,,L,Keen Umbehr,2
-Mitchell,Lulu,Governor,,L,Keen Umbehr,0
-Mitchell,Prov,Governor,,L,Keen Umbehr,2
-Mitchell,Ward 1,Secretary of State,,R,Kris Kobach,127
-Mitchell,Ward 2,Secretary of State,,R,Kris Kobach,243
-Mitchell,Ward 3,Secretary of State,,R,Kris Kobach,251
-Mitchell,Ward 4,Secretary of State,,R,Kris Kobach,209
-Mitchell,Beloit,Secretary of State,,R,Kris Kobach,85
-Mitchell,Custer,Secretary of State,,R,Kris Kobach,29
-Mitchell,Pittsburg,Secretary of State,,R,Kris Kobach,106
-Mitchell,Carr Ck,Secretary of State,,R,Kris Kobach,11
-Mitchell,Cawker,Secretary of State,,R,Kris Kobach,134
-Mitchell,Blue Hill,Secretary of State,,R,Kris Kobach,15
-Mitchell,Hayes,Secretary of State,,R,Kris Kobach,9
-Mitchell,Walnut Ck,Secretary of State,,R,Kris Kobach,15
-Mitchell,Glen Elder,Secretary of State,,R,Kris Kobach,159
-Mitchell,Round Spr,Secretary of State,,R,Kris Kobach,12
-Mitchell,Center,Secretary of State,,R,Kris Kobach,8
-Mitchell,Solomon,Secretary of State,,R,Kris Kobach,19
-Mitchell,Turkey Ck,Secretary of State,,R,Kris Kobach,45
-Mitchell,Salt Ck,Secretary of State,,R,Kris Kobach,10
-Mitchell,Bloomfield,Secretary of State,,R,Kris Kobach,26
-Mitchell,Plum Ck,Secretary of State,,R,Kris Kobach,50
-Mitchell,Eureka,Secretary of State,,R,Kris Kobach,10
-Mitchell,Logan,Secretary of State,,R,Kris Kobach,29
-Mitchell,Asherville,Secretary of State,,R,Kris Kobach,32
-Mitchell,Lulu,Secretary of State,,R,Kris Kobach,26
-Mitchell,Prov,Secretary of State,,R,Kris Kobach,29
-Mitchell,Ward 1,Secretary of State,,D,Jean Schodorf,67
-Mitchell,Ward 2,Secretary of State,,D,Jean Schodorf,114
-Mitchell,Ward 3,Secretary of State,,D,Jean Schodorf,104
-Mitchell,Ward 4,Secretary of State,,D,Jean Schodorf,73
-Mitchell,Beloit,Secretary of State,,D,Jean Schodorf,26
-Mitchell,Custer,Secretary of State,,D,Jean Schodorf,19
-Mitchell,Pittsburg,Secretary of State,,D,Jean Schodorf,33
-Mitchell,Carr Ck,Secretary of State,,D,Jean Schodorf,0
-Mitchell,Cawker,Secretary of State,,D,Jean Schodorf,45
-Mitchell,Blue Hill,Secretary of State,,D,Jean Schodorf,4
-Mitchell,Hayes,Secretary of State,,D,Jean Schodorf,4
-Mitchell,Walnut Ck,Secretary of State,,D,Jean Schodorf,5
-Mitchell,Glen Elder,Secretary of State,,D,Jean Schodorf,46
-Mitchell,Round Spr,Secretary of State,,D,Jean Schodorf,2
-Mitchell,Center,Secretary of State,,D,Jean Schodorf,4
-Mitchell,Solomon,Secretary of State,,D,Jean Schodorf,8
-Mitchell,Turkey Ck,Secretary of State,,D,Jean Schodorf,7
-Mitchell,Salt Ck,Secretary of State,,D,Jean Schodorf,2
-Mitchell,Bloomfield,Secretary of State,,D,Jean Schodorf,7
-Mitchell,Plum Ck,Secretary of State,,D,Jean Schodorf,4
-Mitchell,Eureka,Secretary of State,,D,Jean Schodorf,4
-Mitchell,Logan,Secretary of State,,D,Jean Schodorf,8
-Mitchell,Asherville,Secretary of State,,D,Jean Schodorf,12
-Mitchell,Lulu,Secretary of State,,D,Jean Schodorf,1
-Mitchell,Prov,Secretary of State,,D,Jean Schodorf,3
-Mitchell,Ward 1,Attorney General,,R,Derek Schmidt,159
-Mitchell,Ward 2,Attorney General,,R,Derek Schmidt,272
-Mitchell,Ward 3,Attorney General,,R,Derek Schmidt,281
-Mitchell,Ward 4,Attorney General,,R,Derek Schmidt,233
-Mitchell,Beloit,Attorney General,,R,Derek Schmidt,98
-Mitchell,Custer,Attorney General,,R,Derek Schmidt,37
-Mitchell,Pittsburg,Attorney General,,R,Derek Schmidt,126
-Mitchell,Carr Ck,Attorney General,,R,Derek Schmidt,11
-Mitchell,Cawker,Attorney General,,R,Derek Schmidt,153
-Mitchell,Blue Hill,Attorney General,,R,Derek Schmidt,19
-Mitchell,Hayes,Attorney General,,R,Derek Schmidt,10
-Mitchell,Walnut Ck,Attorney General,,R,Derek Schmidt,14
-Mitchell,Glen Elder,Attorney General,,R,Derek Schmidt,168
-Mitchell,Round Spr,Attorney General,,R,Derek Schmidt,12
-Mitchell,Center,Attorney General,,R,Derek Schmidt,12
-Mitchell,Solomon,Attorney General,,R,Derek Schmidt,20
-Mitchell,Turkey Ck,Attorney General,,R,Derek Schmidt,50
-Mitchell,Salt Ck,Attorney General,,R,Derek Schmidt,10
-Mitchell,Bloomfield,Attorney General,,R,Derek Schmidt,29
-Mitchell,Plum Ck,Attorney General,,R,Derek Schmidt,52
-Mitchell,Eureka,Attorney General,,R,Derek Schmidt,12
-Mitchell,Logan,Attorney General,,R,Derek Schmidt,31
-Mitchell,Asherville,Attorney General,,R,Derek Schmidt,35
-Mitchell,Lulu,Attorney General,,R,Derek Schmidt,25
-Mitchell,Prov,Attorney General,,R,Derek Schmidt,28
-Mitchell,Ward 1,Attorney General,,D,AJ Kotich,32
-Mitchell,Ward 2,Attorney General,,D,AJ Kotich,80
-Mitchell,Ward 3,Attorney General,,D,AJ Kotich,66
-Mitchell,Ward 4,Attorney General,,D,AJ Kotich,41
-Mitchell,Beloit,Attorney General,,D,AJ Kotich,16
-Mitchell,Custer,Attorney General,,D,AJ Kotich,10
-Mitchell,Pittsburg,Attorney General,,D,AJ Kotich,12
-Mitchell,Carr Ck,Attorney General,,D,AJ Kotich,0
-Mitchell,Cawker,Attorney General,,D,AJ Kotich,27
-Mitchell,Blue Hill,Attorney General,,D,AJ Kotich,0
-Mitchell,Hayes,Attorney General,,D,AJ Kotich,3
-Mitchell,Walnut Ck,Attorney General,,D,AJ Kotich,5
-Mitchell,Glen Elder,Attorney General,,D,AJ Kotich,34
-Mitchell,Round Spr,Attorney General,,D,AJ Kotich,2
-Mitchell,Center,Attorney General,,D,AJ Kotich,0
-Mitchell,Solomon,Attorney General,,D,AJ Kotich,7
-Mitchell,Turkey Ck,Attorney General,,D,AJ Kotich,2
-Mitchell,Salt Ck,Attorney General,,D,AJ Kotich,2
-Mitchell,Bloomfield,Attorney General,,D,AJ Kotich,4
-Mitchell,Plum Ck,Attorney General,,D,AJ Kotich,3
-Mitchell,Eureka,Attorney General,,D,AJ Kotich,2
-Mitchell,Logan,Attorney General,,D,AJ Kotich,6
-Mitchell,Asherville,Attorney General,,D,AJ Kotich,9
-Mitchell,Lulu,Attorney General,,D,AJ Kotich,2
-Mitchell,Prov,Attorney General,,D,AJ Kotich,4
-Mitchell,Ward 1,State Treasurer,,R,Ron Estes,148
-Mitchell,Ward 2,State Treasurer,,R,Ron Estes,271
-Mitchell,Ward 3,State Treasurer,,R,Ron Estes,282
-Mitchell,Ward 4,State Treasurer,,R,Ron Estes,232
-Mitchell,Beloit,State Treasurer,,R,Ron Estes,96
-Mitchell,Custer,State Treasurer,,R,Ron Estes,38
-Mitchell,Pittsburg,State Treasurer,,R,Ron Estes,123
-Mitchell,Carr Ck,State Treasurer,,R,Ron Estes,11
-Mitchell,Cawker,State Treasurer,,R,Ron Estes,145
-Mitchell,Blue Hill,State Treasurer,,R,Ron Estes,18
-Mitchell,Hayes,State Treasurer,,R,Ron Estes,10
-Mitchell,Walnut Ck,State Treasurer,,R,Ron Estes,13
-Mitchell,Glen Elder,State Treasurer,,R,Ron Estes,161
-Mitchell,Round Spr,State Treasurer,,R,Ron Estes,14
-Mitchell,Center,State Treasurer,,R,Ron Estes,12
-Mitchell,Solomon,State Treasurer,,R,Ron Estes,22
-Mitchell,Turkey Ck,State Treasurer,,R,Ron Estes,50
-Mitchell,Salt Ck,State Treasurer,,R,Ron Estes,10
-Mitchell,Bloomfield,State Treasurer,,R,Ron Estes,29
-Mitchell,Plum Ck,State Treasurer,,R,Ron Estes,51
-Mitchell,Eureka,State Treasurer,,R,Ron Estes,9
-Mitchell,Logan,State Treasurer,,R,Ron Estes,30
-Mitchell,Asherville,State Treasurer,,R,Ron Estes,35
-Mitchell,Lulu,State Treasurer,,R,Ron Estes,25
-Mitchell,Prov,State Treasurer,,R,Ron Estes,27
-Mitchell,Ward 1,State Treasurer,,D,Carmen Alldritt,41
-Mitchell,Ward 2,State Treasurer,,D,Carmen Alldritt,80
-Mitchell,Ward 3,State Treasurer,,D,Carmen Alldritt,62
-Mitchell,Ward 4,State Treasurer,,D,Carmen Alldritt,44
-Mitchell,Beloit,State Treasurer,,D,Carmen Alldritt,18
-Mitchell,Custer,State Treasurer,,D,Carmen Alldritt,9
-Mitchell,Pittsburg,State Treasurer,,D,Carmen Alldritt,13
-Mitchell,Carr Ck,State Treasurer,,D,Carmen Alldritt,0
-Mitchell,Cawker,State Treasurer,,D,Carmen Alldritt,36
-Mitchell,Blue Hill,State Treasurer,,D,Carmen Alldritt,1
-Mitchell,Hayes,State Treasurer,,D,Carmen Alldritt,2
-Mitchell,Walnut Ck,State Treasurer,,D,Carmen Alldritt,6
-Mitchell,Glen Elder,State Treasurer,,D,Carmen Alldritt,39
-Mitchell,Round Spr,State Treasurer,,D,Carmen Alldritt,0
-Mitchell,Center,State Treasurer,,D,Carmen Alldritt,0
-Mitchell,Solomon,State Treasurer,,D,Carmen Alldritt,5
-Mitchell,Turkey Ck,State Treasurer,,D,Carmen Alldritt,2
-Mitchell,Salt Ck,State Treasurer,,D,Carmen Alldritt,2
-Mitchell,Bloomfield,State Treasurer,,D,Carmen Alldritt,5
-Mitchell,Plum Ck,State Treasurer,,D,Carmen Alldritt,4
-Mitchell,Eureka,State Treasurer,,D,Carmen Alldritt,4
-Mitchell,Logan,State Treasurer,,D,Carmen Alldritt,6
-Mitchell,Asherville,State Treasurer,,D,Carmen Alldritt,8
-Mitchell,Lulu,State Treasurer,,D,Carmen Alldritt,1
-Mitchell,Prov,State Treasurer,,D,Carmen Alldritt,5
-Mitchell,Ward 1,Insurance Commissioner,,R,Ken Selzer,141
-Mitchell,Ward 2,Insurance Commissioner,,R,Ken Selzer,255
-Mitchell,Ward 3,Insurance Commissioner,,R,Ken Selzer,268
-Mitchell,Ward 4,Insurance Commissioner,,R,Ken Selzer,219
-Mitchell,Beloit,Insurance Commissioner,,R,Ken Selzer,94
-Mitchell,Custer,Insurance Commissioner,,R,Ken Selzer,35
-Mitchell,Pittsburg,Insurance Commissioner,,R,Ken Selzer,107
-Mitchell,Carr Ck,Insurance Commissioner,,R,Ken Selzer,11
-Mitchell,Cawker,Insurance Commissioner,,R,Ken Selzer,132
-Mitchell,Blue Hill,Insurance Commissioner,,R,Ken Selzer,19
-Mitchell,Hayes,Insurance Commissioner,,R,Ken Selzer,10
-Mitchell,Walnut Ck,Insurance Commissioner,,R,Ken Selzer,11
-Mitchell,Glen Elder,Insurance Commissioner,,R,Ken Selzer,155
-Mitchell,Round Spr,Insurance Commissioner,,R,Ken Selzer,11
-Mitchell,Center,Insurance Commissioner,,R,Ken Selzer,12
-Mitchell,Solomon,Insurance Commissioner,,R,Ken Selzer,19
-Mitchell,Turkey Ck,Insurance Commissioner,,R,Ken Selzer,47
-Mitchell,Salt Ck,Insurance Commissioner,,R,Ken Selzer,10
-Mitchell,Bloomfield,Insurance Commissioner,,R,Ken Selzer,28
-Mitchell,Plum Ck,Insurance Commissioner,,R,Ken Selzer,49
-Mitchell,Eureka,Insurance Commissioner,,R,Ken Selzer,11
-Mitchell,Logan,Insurance Commissioner,,R,Ken Selzer,28
-Mitchell,Asherville,Insurance Commissioner,,R,Ken Selzer,32
-Mitchell,Lulu,Insurance Commissioner,,R,Ken Selzer,25
-Mitchell,Prov,Insurance Commissioner,,R,Ken Selzer,28
-Mitchell,Ward 1,Insurance Commissioner,,D,Dennis Anderson,49
-Mitchell,Ward 2,Insurance Commissioner,,D,Dennis Anderson,93
-Mitchell,Ward 3,Insurance Commissioner,,D,Dennis Anderson,76
-Mitchell,Ward 4,Insurance Commissioner,,D,Dennis Anderson,49
-Mitchell,Beloit,Insurance Commissioner,,D,Dennis Anderson,20
-Mitchell,Custer,Insurance Commissioner,,D,Dennis Anderson,14
-Mitchell,Pittsburg,Insurance Commissioner,,D,Dennis Anderson,28
-Mitchell,Carr Ck,Insurance Commissioner,,D,Dennis Anderson,0
-Mitchell,Cawker,Insurance Commissioner,,D,Dennis Anderson,45
-Mitchell,Blue Hill,Insurance Commissioner,,D,Dennis Anderson,0
-Mitchell,Hayes,Insurance Commissioner,,D,Dennis Anderson,2
-Mitchell,Walnut Ck,Insurance Commissioner,,D,Dennis Anderson,8
-Mitchell,Glen Elder,Insurance Commissioner,,D,Dennis Anderson,45
-Mitchell,Round Spr,Insurance Commissioner,,D,Dennis Anderson,2
-Mitchell,Center,Insurance Commissioner,,D,Dennis Anderson,0
-Mitchell,Solomon,Insurance Commissioner,,D,Dennis Anderson,7
-Mitchell,Turkey Ck,Insurance Commissioner,,D,Dennis Anderson,5
-Mitchell,Salt Ck,Insurance Commissioner,,D,Dennis Anderson,2
-Mitchell,Bloomfield,Insurance Commissioner,,D,Dennis Anderson,4
-Mitchell,Plum Ck,Insurance Commissioner,,D,Dennis Anderson,4
-Mitchell,Eureka,Insurance Commissioner,,D,Dennis Anderson,3
-Mitchell,Logan,Insurance Commissioner,,D,Dennis Anderson,8
-Mitchell,Asherville,Insurance Commissioner,,D,Dennis Anderson,12
-Mitchell,Lulu,Insurance Commissioner,,D,Dennis Anderson,1
-Mitchell,Prov,Insurance Commissioner,,D,Dennis Anderson,4
-Mitchell,Ward 1,State House,107,R,Susan Concannon,181
-Mitchell,Ward 2,State House,107,R,Susan Concannon,345
-Mitchell,Ward 3,State House,107,R,Susan Concannon,345
-Mitchell,Ward 4,State House,107,R,Susan Concannon,264
-Mitchell,Beloit,State House,107,R,Susan Concannon,109
-Mitchell,Custer,State House,107,R,Susan Concannon,50
-Mitchell,Pittsburg,State House,107,R,Susan Concannon,138
-Mitchell,Carr Ck,State House,107,R,Susan Concannon,11
-Mitchell,Cawker,State House,107,R,Susan Concannon,169
-Mitchell,Blue Hill,State House,107,R,Susan Concannon,19
-Mitchell,Hayes,State House,107,R,Susan Concannon,13
-Mitchell,Walnut Ck,State House,107,R,Susan Concannon,19
-Mitchell,Glen Elder,State House,107,R,Susan Concannon,193
-Mitchell,Round Spr,State House,107,R,Susan Concannon,13
-Mitchell,Center,State House,107,R,Susan Concannon,12
-Mitchell,Solomon,State House,107,R,Susan Concannon,25
-Mitchell,Turkey Ck,State House,107,R,Susan Concannon,49
-Mitchell,Salt Ck,State House,107,R,Susan Concannon,12
-Mitchell,Bloomfield,State House,107,R,Susan Concannon,30
-Mitchell,Plum Ck,State House,107,R,Susan Concannon,51
-Mitchell,Eureka,State House,107,R,Susan Concannon,14
-Mitchell,Logan,State House,107,R,Susan Concannon,38
-Mitchell,Asherville,State House,107,R,Susan Concannon,40
-Mitchell,Lulu,State House,107,R,Susan Concannon,28
-Mitchell,Prov,State House,107,R,Susan Concannon,31
+county,precinct,office,district,party,candidate,votes,vtd
+MITCHELL,Asherville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000010
+MITCHELL,Asherville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+MITCHELL,Asherville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000010
+MITCHELL,Beloit City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,000020
+MITCHELL,Beloit City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000020
+MITCHELL,Beloit City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,000020
+MITCHELL,Beloit City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",139,000030
+MITCHELL,Beloit City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000030
+MITCHELL,Beloit City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",213,000030
+MITCHELL,Beloit City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",129,000040
+MITCHELL,Beloit City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000040
+MITCHELL,Beloit City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",223,000040
+MITCHELL,Beloit City Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",105,000050
+MITCHELL,Beloit City Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000050
+MITCHELL,Beloit City Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,000050
+MITCHELL,Beloit Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,00006A
+MITCHELL,Beloit Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00006A
+MITCHELL,Beloit Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",85,00006A
+MITCHELL,Beloit Township Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006B
+MITCHELL,Beloit Township Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006B
+MITCHELL,Beloit Township Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006B
+MITCHELL,Beloit Township Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006C
+MITCHELL,Beloit Township Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006C
+MITCHELL,Beloit Township Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006C
+MITCHELL,Beloit Township Enclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006D
+MITCHELL,Beloit Township Enclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006D
+MITCHELL,Beloit Township Enclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006D
+MITCHELL,Bloomfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000070
+MITCHELL,Bloomfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+MITCHELL,Bloomfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000070
+MITCHELL,Blue Hill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000080
+MITCHELL,Blue Hill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+MITCHELL,Blue Hill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000080
+MITCHELL,Carr Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000090
+MITCHELL,Carr Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+MITCHELL,Carr Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000090
+MITCHELL,Cawker City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000100
+MITCHELL,Cawker City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+MITCHELL,Cawker City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000100
+MITCHELL,Cawker Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",63,000110
+MITCHELL,Cawker Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000110
+MITCHELL,Cawker Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000110
+MITCHELL,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000120
+MITCHELL,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+MITCHELL,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000120
+MITCHELL,Custer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000130
+MITCHELL,Custer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000130
+MITCHELL,Custer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000130
+MITCHELL,Eureka Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000140
+MITCHELL,Eureka Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+MITCHELL,Eureka Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000140
+MITCHELL,Glen Elder City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000150
+MITCHELL,Glen Elder City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000150
+MITCHELL,Glen Elder City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000150
+MITCHELL,Glen Elder Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",69,000160
+MITCHELL,Glen Elder Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000160
+MITCHELL,Glen Elder Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",127,000160
+MITCHELL,Hayes Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000170
+MITCHELL,Hayes Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000170
+MITCHELL,Hayes Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000170
+MITCHELL,Hunter City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000180
+MITCHELL,Hunter City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000180
+MITCHELL,Hunter City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000180
+MITCHELL,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000190
+MITCHELL,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000190
+MITCHELL,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000190
+MITCHELL,Lulu Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000200
+MITCHELL,Lulu Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000200
+MITCHELL,Lulu Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000200
+MITCHELL,Pittsburg Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000210
+MITCHELL,Pittsburg Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000210
+MITCHELL,Pittsburg Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000210
+MITCHELL,Plum Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000220
+MITCHELL,Plum Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000220
+MITCHELL,Plum Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000220
+MITCHELL,Round Springs Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000230
+MITCHELL,Round Springs Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+MITCHELL,Round Springs Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000230
+MITCHELL,Salt Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000240
+MITCHELL,Salt Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000240
+MITCHELL,Salt Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000240
+MITCHELL,Scottsville City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000250
+MITCHELL,Scottsville City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000250
+MITCHELL,Scottsville City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000250
+MITCHELL,Simpson City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000260
+MITCHELL,Simpson City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000260
+MITCHELL,Simpson City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000260
+MITCHELL,Solomon Rapids Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000270
+MITCHELL,Solomon Rapids Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000270
+MITCHELL,Solomon Rapids Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000270
+MITCHELL,Tipton City,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000280
+MITCHELL,Tipton City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000280
+MITCHELL,Tipton City,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000280
+MITCHELL,Turkey Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000290
+MITCHELL,Turkey Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000290
+MITCHELL,Turkey Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000290
+MITCHELL,Walnut Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000300
+MITCHELL,Walnut Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000300
+MITCHELL,Walnut Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000300
+MITCHELL,Asherville Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",41,000010
+MITCHELL,Beloit City Ward 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",182,000020
+MITCHELL,Beloit City Ward 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",350,000030
+MITCHELL,Beloit City Ward 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",354,000040
+MITCHELL,Beloit City Ward 4,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",271,000050
+MITCHELL,Beloit Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",113,00006A
+MITCHELL,Beloit Township Enclave A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006B
+MITCHELL,Beloit Township Enclave B,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006C
+MITCHELL,Beloit Township Enclave C,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006D
+MITCHELL,Bloomfield Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",30,000070
+MITCHELL,Blue Hill Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",19,000080
+MITCHELL,Carr Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",11,000090
+MITCHELL,Cawker City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000100
+MITCHELL,Cawker Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",172,000110
+MITCHELL,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",12,000120
+MITCHELL,Custer Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",51,000130
+MITCHELL,Eureka Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",14,000140
+MITCHELL,Glen Elder City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000150
+MITCHELL,Glen Elder Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",193,000160
+MITCHELL,Hayes Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",13,000170
+MITCHELL,Hunter City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000180
+MITCHELL,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",38,000190
+MITCHELL,Lulu Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",28,000200
+MITCHELL,Pittsburg Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",138,000210
+MITCHELL,Plum Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",51,000220
+MITCHELL,Round Springs Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",13,000230
+MITCHELL,Salt Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",12,000240
+MITCHELL,Scottsville City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000250
+MITCHELL,Simpson City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000260
+MITCHELL,Solomon Rapids Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",25,000270
+MITCHELL,Tipton City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000280
+MITCHELL,Turkey Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",49,000290
+MITCHELL,Walnut Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",19,000300
+MITCHELL,Asherville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000010
+MITCHELL,Asherville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000010
+MITCHELL,Beloit City Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",70,000020
+MITCHELL,Beloit City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",114,000020
+MITCHELL,Beloit City Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",116,000030
+MITCHELL,Beloit City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",232,000030
+MITCHELL,Beloit City Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",103,000040
+MITCHELL,Beloit City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",246,000040
+MITCHELL,Beloit City Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",83,000050
+MITCHELL,Beloit City Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",190,000050
+MITCHELL,Beloit Township,United States House of Representatives,1,Democratic,"Sherow, James E.",29,00006A
+MITCHELL,Beloit Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",87,00006A
+MITCHELL,Beloit Township Enclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00006B
+MITCHELL,Beloit Township Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+MITCHELL,Beloit Township Enclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00006C
+MITCHELL,Beloit Township Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006C
+MITCHELL,Beloit Township Enclave C,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00006D
+MITCHELL,Beloit Township Enclave C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006D
+MITCHELL,Bloomfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000070
+MITCHELL,Bloomfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000070
+MITCHELL,Blue Hill Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000080
+MITCHELL,Blue Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000080
+MITCHELL,Carr Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000090
+MITCHELL,Carr Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000090
+MITCHELL,Cawker City,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000100
+MITCHELL,Cawker City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000100
+MITCHELL,Cawker Township,United States House of Representatives,1,Democratic,"Sherow, James E.",41,000110
+MITCHELL,Cawker Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",137,000110
+MITCHELL,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000120
+MITCHELL,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000120
+MITCHELL,Custer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000130
+MITCHELL,Custer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000130
+MITCHELL,Eureka Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000140
+MITCHELL,Eureka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000140
+MITCHELL,Glen Elder City,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000150
+MITCHELL,Glen Elder City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000150
+MITCHELL,Glen Elder Township,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000160
+MITCHELL,Glen Elder Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",153,000160
+MITCHELL,Hayes Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000170
+MITCHELL,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000170
+MITCHELL,Hunter City,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000180
+MITCHELL,Hunter City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000180
+MITCHELL,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000190
+MITCHELL,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000190
+MITCHELL,Lulu Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000200
+MITCHELL,Lulu Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000200
+MITCHELL,Pittsburg Township,United States House of Representatives,1,Democratic,"Sherow, James E.",31,000210
+MITCHELL,Pittsburg Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000210
+MITCHELL,Plum Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000220
+MITCHELL,Plum Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000220
+MITCHELL,Round Springs Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000230
+MITCHELL,Round Springs Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000230
+MITCHELL,Salt Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000240
+MITCHELL,Salt Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000240
+MITCHELL,Scottsville City,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000250
+MITCHELL,Scottsville City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000250
+MITCHELL,Simpson City,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000260
+MITCHELL,Simpson City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000260
+MITCHELL,Solomon Rapids Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000270
+MITCHELL,Solomon Rapids Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000270
+MITCHELL,Tipton City,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000280
+MITCHELL,Tipton City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000280
+MITCHELL,Turkey Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000290
+MITCHELL,Turkey Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000290
+MITCHELL,Walnut Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000300
+MITCHELL,Walnut Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000300
+MITCHELL,Asherville Township,Attorney General,,Democratic,"Kotich, A.J.",9,000010
+MITCHELL,Asherville Township,Attorney General,,Republican,"Schmidt, Derek",36,000010
+MITCHELL,Beloit City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",32,000020
+MITCHELL,Beloit City Ward 1,Attorney General,,Republican,"Schmidt, Derek",160,000020
+MITCHELL,Beloit City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",80,000030
+MITCHELL,Beloit City Ward 2,Attorney General,,Republican,"Schmidt, Derek",277,000030
+MITCHELL,Beloit City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",67,000040
+MITCHELL,Beloit City Ward 3,Attorney General,,Republican,"Schmidt, Derek",289,000040
+MITCHELL,Beloit City Ward 4,Attorney General,,Democratic,"Kotich, A.J.",43,000050
+MITCHELL,Beloit City Ward 4,Attorney General,,Republican,"Schmidt, Derek",238,000050
+MITCHELL,Beloit Township,Attorney General,,Democratic,"Kotich, A.J.",16,00006A
+MITCHELL,Beloit Township,Attorney General,,Republican,"Schmidt, Derek",102,00006A
+MITCHELL,Beloit Township Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00006B
+MITCHELL,Beloit Township Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,00006B
+MITCHELL,Beloit Township Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00006C
+MITCHELL,Beloit Township Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,00006C
+MITCHELL,Beloit Township Enclave C,Attorney General,,Democratic,"Kotich, A.J.",0,00006D
+MITCHELL,Beloit Township Enclave C,Attorney General,,Republican,"Schmidt, Derek",0,00006D
+MITCHELL,Bloomfield Township,Attorney General,,Democratic,"Kotich, A.J.",4,000070
+MITCHELL,Bloomfield Township,Attorney General,,Republican,"Schmidt, Derek",29,000070
+MITCHELL,Blue Hill Township,Attorney General,,Democratic,"Kotich, A.J.",0,000080
+MITCHELL,Blue Hill Township,Attorney General,,Republican,"Schmidt, Derek",19,000080
+MITCHELL,Carr Creek Township,Attorney General,,Democratic,"Kotich, A.J.",0,000090
+MITCHELL,Carr Creek Township,Attorney General,,Republican,"Schmidt, Derek",11,000090
+MITCHELL,Cawker City,Attorney General,,Democratic,"Kotich, A.J.",0,000100
+MITCHELL,Cawker City,Attorney General,,Republican,"Schmidt, Derek",0,000100
+MITCHELL,Cawker Township,Attorney General,,Democratic,"Kotich, A.J.",28,000110
+MITCHELL,Cawker Township,Attorney General,,Republican,"Schmidt, Derek",155,000110
+MITCHELL,Center Township,Attorney General,,Democratic,"Kotich, A.J.",0,000120
+MITCHELL,Center Township,Attorney General,,Republican,"Schmidt, Derek",12,000120
+MITCHELL,Custer Township,Attorney General,,Democratic,"Kotich, A.J.",10,000130
+MITCHELL,Custer Township,Attorney General,,Republican,"Schmidt, Derek",38,000130
+MITCHELL,Eureka Township,Attorney General,,Democratic,"Kotich, A.J.",2,000140
+MITCHELL,Eureka Township,Attorney General,,Republican,"Schmidt, Derek",12,000140
+MITCHELL,Glen Elder City,Attorney General,,Democratic,"Kotich, A.J.",0,000150
+MITCHELL,Glen Elder City,Attorney General,,Republican,"Schmidt, Derek",0,000150
+MITCHELL,Glen Elder Township,Attorney General,,Democratic,"Kotich, A.J.",34,000160
+MITCHELL,Glen Elder Township,Attorney General,,Republican,"Schmidt, Derek",168,000160
+MITCHELL,Hayes Township,Attorney General,,Democratic,"Kotich, A.J.",3,000170
+MITCHELL,Hayes Township,Attorney General,,Republican,"Schmidt, Derek",10,000170
+MITCHELL,Hunter City,Attorney General,,Democratic,"Kotich, A.J.",0,000180
+MITCHELL,Hunter City,Attorney General,,Republican,"Schmidt, Derek",0,000180
+MITCHELL,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",6,000190
+MITCHELL,Logan Township,Attorney General,,Republican,"Schmidt, Derek",31,000190
+MITCHELL,Lulu Township,Attorney General,,Democratic,"Kotich, A.J.",2,000200
+MITCHELL,Lulu Township,Attorney General,,Republican,"Schmidt, Derek",26,000200
+MITCHELL,Pittsburg Township,Attorney General,,Democratic,"Kotich, A.J.",12,000210
+MITCHELL,Pittsburg Township,Attorney General,,Republican,"Schmidt, Derek",126,000210
+MITCHELL,Plum Creek Township,Attorney General,,Democratic,"Kotich, A.J.",3,000220
+MITCHELL,Plum Creek Township,Attorney General,,Republican,"Schmidt, Derek",52,000220
+MITCHELL,Round Springs Township,Attorney General,,Democratic,"Kotich, A.J.",2,000230
+MITCHELL,Round Springs Township,Attorney General,,Republican,"Schmidt, Derek",12,000230
+MITCHELL,Salt Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000240
+MITCHELL,Salt Creek Township,Attorney General,,Republican,"Schmidt, Derek",10,000240
+MITCHELL,Scottsville City,Attorney General,,Democratic,"Kotich, A.J.",0,000250
+MITCHELL,Scottsville City,Attorney General,,Republican,"Schmidt, Derek",0,000250
+MITCHELL,Simpson City,Attorney General,,Democratic,"Kotich, A.J.",0,000260
+MITCHELL,Simpson City,Attorney General,,Republican,"Schmidt, Derek",0,000260
+MITCHELL,Solomon Rapids Township,Attorney General,,Democratic,"Kotich, A.J.",7,000270
+MITCHELL,Solomon Rapids Township,Attorney General,,Republican,"Schmidt, Derek",20,000270
+MITCHELL,Tipton City,Attorney General,,Democratic,"Kotich, A.J.",0,000280
+MITCHELL,Tipton City,Attorney General,,Republican,"Schmidt, Derek",0,000280
+MITCHELL,Turkey Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000290
+MITCHELL,Turkey Creek Township,Attorney General,,Republican,"Schmidt, Derek",50,000290
+MITCHELL,Walnut Creek Township,Attorney General,,Democratic,"Kotich, A.J.",5,000300
+MITCHELL,Walnut Creek Township,Attorney General,,Republican,"Schmidt, Derek",14,000300
+MITCHELL,Asherville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000010
+MITCHELL,Asherville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000010
+MITCHELL,Beloit City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",49,000020
+MITCHELL,Beloit City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",142,000020
+MITCHELL,Beloit City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,000030
+MITCHELL,Beloit City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",260,000030
+MITCHELL,Beloit City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000040
+MITCHELL,Beloit City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",276,000040
+MITCHELL,Beloit City Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,000050
+MITCHELL,Beloit City Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",224,000050
+MITCHELL,Beloit Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,00006A
+MITCHELL,Beloit Township,Commissioner of Insurance,,Republican,"Selzer, Ken",98,00006A
+MITCHELL,Beloit Township Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006B
+MITCHELL,Beloit Township Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006B
+MITCHELL,Beloit Township Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006C
+MITCHELL,Beloit Township Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006C
+MITCHELL,Beloit Township Enclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006D
+MITCHELL,Beloit Township Enclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006D
+MITCHELL,Bloomfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000070
+MITCHELL,Bloomfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000070
+MITCHELL,Blue Hill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000080
+MITCHELL,Blue Hill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000080
+MITCHELL,Carr Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000090
+MITCHELL,Carr Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000090
+MITCHELL,Cawker City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000100
+MITCHELL,Cawker City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000100
+MITCHELL,Cawker Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000110
+MITCHELL,Cawker Township,Commissioner of Insurance,,Republican,"Selzer, Ken",134,000110
+MITCHELL,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000120
+MITCHELL,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000120
+MITCHELL,Custer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000130
+MITCHELL,Custer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000130
+MITCHELL,Eureka Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000140
+MITCHELL,Eureka Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000140
+MITCHELL,Glen Elder City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000150
+MITCHELL,Glen Elder City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000150
+MITCHELL,Glen Elder Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000160
+MITCHELL,Glen Elder Township,Commissioner of Insurance,,Republican,"Selzer, Ken",155,000160
+MITCHELL,Hayes Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000170
+MITCHELL,Hayes Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000170
+MITCHELL,Hunter City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000180
+MITCHELL,Hunter City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000180
+MITCHELL,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000190
+MITCHELL,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000190
+MITCHELL,Lulu Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000200
+MITCHELL,Lulu Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000200
+MITCHELL,Pittsburg Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000210
+MITCHELL,Pittsburg Township,Commissioner of Insurance,,Republican,"Selzer, Ken",107,000210
+MITCHELL,Plum Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000220
+MITCHELL,Plum Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000220
+MITCHELL,Round Springs Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000230
+MITCHELL,Round Springs Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000230
+MITCHELL,Salt Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000240
+MITCHELL,Salt Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000240
+MITCHELL,Scottsville City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000250
+MITCHELL,Scottsville City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000250
+MITCHELL,Simpson City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000260
+MITCHELL,Simpson City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000260
+MITCHELL,Solomon Rapids Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000270
+MITCHELL,Solomon Rapids Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000270
+MITCHELL,Tipton City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000280
+MITCHELL,Tipton City,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000280
+MITCHELL,Turkey Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000290
+MITCHELL,Turkey Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000290
+MITCHELL,Walnut Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000300
+MITCHELL,Walnut Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000300
+MITCHELL,Asherville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000010
+MITCHELL,Asherville Township,Secretary of State,,Republican,"Kobach, Kris",33,000010
+MITCHELL,Beloit City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000020
+MITCHELL,Beloit City Ward 1,Secretary of State,,Republican,"Kobach, Kris",128,000020
+MITCHELL,Beloit City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",114,000030
+MITCHELL,Beloit City Ward 2,Secretary of State,,Republican,"Kobach, Kris",248,000030
+MITCHELL,Beloit City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,000040
+MITCHELL,Beloit City Ward 3,Secretary of State,,Republican,"Kobach, Kris",259,000040
+MITCHELL,Beloit City Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000050
+MITCHELL,Beloit City Ward 4,Secretary of State,,Republican,"Kobach, Kris",215,000050
+MITCHELL,Beloit Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,00006A
+MITCHELL,Beloit Township,Secretary of State,,Republican,"Kobach, Kris",89,00006A
+MITCHELL,Beloit Township Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006B
+MITCHELL,Beloit Township Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,00006B
+MITCHELL,Beloit Township Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006C
+MITCHELL,Beloit Township Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,00006C
+MITCHELL,Beloit Township Enclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006D
+MITCHELL,Beloit Township Enclave C,Secretary of State,,Republican,"Kobach, Kris",0,00006D
+MITCHELL,Bloomfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000070
+MITCHELL,Bloomfield Township,Secretary of State,,Republican,"Kobach, Kris",26,000070
+MITCHELL,Blue Hill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000080
+MITCHELL,Blue Hill Township,Secretary of State,,Republican,"Kobach, Kris",15,000080
+MITCHELL,Carr Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000090
+MITCHELL,Carr Creek Township,Secretary of State,,Republican,"Kobach, Kris",11,000090
+MITCHELL,Cawker City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000100
+MITCHELL,Cawker City,Secretary of State,,Republican,"Kobach, Kris",0,000100
+MITCHELL,Cawker Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000110
+MITCHELL,Cawker Township,Secretary of State,,Republican,"Kobach, Kris",136,000110
+MITCHELL,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000120
+MITCHELL,Center Township,Secretary of State,,Republican,"Kobach, Kris",8,000120
+MITCHELL,Custer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000130
+MITCHELL,Custer Township,Secretary of State,,Republican,"Kobach, Kris",30,000130
+MITCHELL,Eureka Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000140
+MITCHELL,Eureka Township,Secretary of State,,Republican,"Kobach, Kris",10,000140
+MITCHELL,Glen Elder City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000150
+MITCHELL,Glen Elder City,Secretary of State,,Republican,"Kobach, Kris",0,000150
+MITCHELL,Glen Elder Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000160
+MITCHELL,Glen Elder Township,Secretary of State,,Republican,"Kobach, Kris",159,000160
+MITCHELL,Hayes Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000170
+MITCHELL,Hayes Township,Secretary of State,,Republican,"Kobach, Kris",9,000170
+MITCHELL,Hunter City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000180
+MITCHELL,Hunter City,Secretary of State,,Republican,"Kobach, Kris",0,000180
+MITCHELL,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000190
+MITCHELL,Logan Township,Secretary of State,,Republican,"Kobach, Kris",29,000190
+MITCHELL,Lulu Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000200
+MITCHELL,Lulu Township,Secretary of State,,Republican,"Kobach, Kris",27,000200
+MITCHELL,Pittsburg Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000210
+MITCHELL,Pittsburg Township,Secretary of State,,Republican,"Kobach, Kris",106,000210
+MITCHELL,Plum Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000220
+MITCHELL,Plum Creek Township,Secretary of State,,Republican,"Kobach, Kris",50,000220
+MITCHELL,Round Springs Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000230
+MITCHELL,Round Springs Township,Secretary of State,,Republican,"Kobach, Kris",12,000230
+MITCHELL,Salt Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000240
+MITCHELL,Salt Creek Township,Secretary of State,,Republican,"Kobach, Kris",10,000240
+MITCHELL,Scottsville City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000250
+MITCHELL,Scottsville City,Secretary of State,,Republican,"Kobach, Kris",0,000250
+MITCHELL,Simpson City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000260
+MITCHELL,Simpson City,Secretary of State,,Republican,"Kobach, Kris",0,000260
+MITCHELL,Solomon Rapids Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000270
+MITCHELL,Solomon Rapids Township,Secretary of State,,Republican,"Kobach, Kris",19,000270
+MITCHELL,Tipton City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000280
+MITCHELL,Tipton City,Secretary of State,,Republican,"Kobach, Kris",0,000280
+MITCHELL,Turkey Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000290
+MITCHELL,Turkey Creek Township,Secretary of State,,Republican,"Kobach, Kris",45,000290
+MITCHELL,Walnut Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000300
+MITCHELL,Walnut Creek Township,Secretary of State,,Republican,"Kobach, Kris",15,000300
+MITCHELL,Asherville Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000010
+MITCHELL,Asherville Township,State Treasurer,,Republican,"Estes, Ron",36,000010
+MITCHELL,Beloit City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",41,000020
+MITCHELL,Beloit City Ward 1,State Treasurer,,Republican,"Estes, Ron",149,000020
+MITCHELL,Beloit City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",80,000030
+MITCHELL,Beloit City Ward 2,State Treasurer,,Republican,"Estes, Ron",276,000030
+MITCHELL,Beloit City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",64,000040
+MITCHELL,Beloit City Ward 3,State Treasurer,,Republican,"Estes, Ron",289,000040
+MITCHELL,Beloit City Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",46,000050
+MITCHELL,Beloit City Ward 4,State Treasurer,,Republican,"Estes, Ron",237,000050
+MITCHELL,Beloit Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,00006A
+MITCHELL,Beloit Township,State Treasurer,,Republican,"Estes, Ron",100,00006A
+MITCHELL,Beloit Township Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006B
+MITCHELL,Beloit Township Enclave A,State Treasurer,,Republican,"Estes, Ron",0,00006B
+MITCHELL,Beloit Township Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006C
+MITCHELL,Beloit Township Enclave B,State Treasurer,,Republican,"Estes, Ron",0,00006C
+MITCHELL,Beloit Township Enclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006D
+MITCHELL,Beloit Township Enclave C,State Treasurer,,Republican,"Estes, Ron",0,00006D
+MITCHELL,Bloomfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000070
+MITCHELL,Bloomfield Township,State Treasurer,,Republican,"Estes, Ron",29,000070
+MITCHELL,Blue Hill Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000080
+MITCHELL,Blue Hill Township,State Treasurer,,Republican,"Estes, Ron",18,000080
+MITCHELL,Carr Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000090
+MITCHELL,Carr Creek Township,State Treasurer,,Republican,"Estes, Ron",11,000090
+MITCHELL,Cawker City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000100
+MITCHELL,Cawker City,State Treasurer,,Republican,"Estes, Ron",0,000100
+MITCHELL,Cawker Township,State Treasurer,,Democratic,"Alldritt, Carmen",37,000110
+MITCHELL,Cawker Township,State Treasurer,,Republican,"Estes, Ron",147,000110
+MITCHELL,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000120
+MITCHELL,Center Township,State Treasurer,,Republican,"Estes, Ron",12,000120
+MITCHELL,Custer Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000130
+MITCHELL,Custer Township,State Treasurer,,Republican,"Estes, Ron",39,000130
+MITCHELL,Eureka Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000140
+MITCHELL,Eureka Township,State Treasurer,,Republican,"Estes, Ron",9,000140
+MITCHELL,Glen Elder City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000150
+MITCHELL,Glen Elder City,State Treasurer,,Republican,"Estes, Ron",0,000150
+MITCHELL,Glen Elder Township,State Treasurer,,Democratic,"Alldritt, Carmen",39,000160
+MITCHELL,Glen Elder Township,State Treasurer,,Republican,"Estes, Ron",161,000160
+MITCHELL,Hayes Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000170
+MITCHELL,Hayes Township,State Treasurer,,Republican,"Estes, Ron",10,000170
+MITCHELL,Hunter City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000180
+MITCHELL,Hunter City,State Treasurer,,Republican,"Estes, Ron",0,000180
+MITCHELL,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000190
+MITCHELL,Logan Township,State Treasurer,,Republican,"Estes, Ron",30,000190
+MITCHELL,Lulu Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000200
+MITCHELL,Lulu Township,State Treasurer,,Republican,"Estes, Ron",26,000200
+MITCHELL,Pittsburg Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000210
+MITCHELL,Pittsburg Township,State Treasurer,,Republican,"Estes, Ron",123,000210
+MITCHELL,Plum Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000220
+MITCHELL,Plum Creek Township,State Treasurer,,Republican,"Estes, Ron",51,000220
+MITCHELL,Round Springs Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000230
+MITCHELL,Round Springs Township,State Treasurer,,Republican,"Estes, Ron",14,000230
+MITCHELL,Salt Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000240
+MITCHELL,Salt Creek Township,State Treasurer,,Republican,"Estes, Ron",10,000240
+MITCHELL,Scottsville City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000250
+MITCHELL,Scottsville City,State Treasurer,,Republican,"Estes, Ron",0,000250
+MITCHELL,Simpson City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000260
+MITCHELL,Simpson City,State Treasurer,,Republican,"Estes, Ron",0,000260
+MITCHELL,Solomon Rapids Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000270
+MITCHELL,Solomon Rapids Township,State Treasurer,,Republican,"Estes, Ron",22,000270
+MITCHELL,Tipton City,State Treasurer,,Democratic,"Alldritt, Carmen",0,000280
+MITCHELL,Tipton City,State Treasurer,,Republican,"Estes, Ron",0,000280
+MITCHELL,Turkey Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000290
+MITCHELL,Turkey Creek Township,State Treasurer,,Republican,"Estes, Ron",50,000290
+MITCHELL,Walnut Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000300
+MITCHELL,Walnut Creek Township,State Treasurer,,Republican,"Estes, Ron",13,000300
+MITCHELL,Asherville Township,United States Senate,,independent,"Orman, Greg",8,000010
+MITCHELL,Asherville Township,United States Senate,,Libertarian,"Batson, Randall",4,000010
+MITCHELL,Asherville Township,United States Senate,,Republican,"Roberts, Pat",29,000010
+MITCHELL,Beloit City Ward 1,United States Senate,,independent,"Orman, Greg",44,000020
+MITCHELL,Beloit City Ward 1,United States Senate,,Libertarian,"Batson, Randall",16,000020
+MITCHELL,Beloit City Ward 1,United States Senate,,Republican,"Roberts, Pat",128,000020
+MITCHELL,Beloit City Ward 2,United States Senate,,independent,"Orman, Greg",111,000030
+MITCHELL,Beloit City Ward 2,United States Senate,,Libertarian,"Batson, Randall",12,000030
+MITCHELL,Beloit City Ward 2,United States Senate,,Republican,"Roberts, Pat",228,000030
+MITCHELL,Beloit City Ward 3,United States Senate,,independent,"Orman, Greg",87,000040
+MITCHELL,Beloit City Ward 3,United States Senate,,Libertarian,"Batson, Randall",15,000040
+MITCHELL,Beloit City Ward 3,United States Senate,,Republican,"Roberts, Pat",256,000040
+MITCHELL,Beloit City Ward 4,United States Senate,,independent,"Orman, Greg",68,000050
+MITCHELL,Beloit City Ward 4,United States Senate,,Libertarian,"Batson, Randall",7,000050
+MITCHELL,Beloit City Ward 4,United States Senate,,Republican,"Roberts, Pat",203,000050
+MITCHELL,Beloit Township,United States Senate,,independent,"Orman, Greg",25,00006A
+MITCHELL,Beloit Township,United States Senate,,Libertarian,"Batson, Randall",2,00006A
+MITCHELL,Beloit Township,United States Senate,,Republican,"Roberts, Pat",92,00006A
+MITCHELL,Beloit Township Enclave A,United States Senate,,independent,"Orman, Greg",0,00006B
+MITCHELL,Beloit Township Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,00006B
+MITCHELL,Beloit Township Enclave A,United States Senate,,Republican,"Roberts, Pat",0,00006B
+MITCHELL,Beloit Township Enclave B,United States Senate,,independent,"Orman, Greg",0,00006C
+MITCHELL,Beloit Township Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,00006C
+MITCHELL,Beloit Township Enclave B,United States Senate,,Republican,"Roberts, Pat",0,00006C
+MITCHELL,Beloit Township Enclave C,United States Senate,,independent,"Orman, Greg",0,00006D
+MITCHELL,Beloit Township Enclave C,United States Senate,,Libertarian,"Batson, Randall",0,00006D
+MITCHELL,Beloit Township Enclave C,United States Senate,,Republican,"Roberts, Pat",0,00006D
+MITCHELL,Bloomfield Township,United States Senate,,independent,"Orman, Greg",4,000070
+MITCHELL,Bloomfield Township,United States Senate,,Libertarian,"Batson, Randall",1,000070
+MITCHELL,Bloomfield Township,United States Senate,,Republican,"Roberts, Pat",29,000070
+MITCHELL,Blue Hill Township,United States Senate,,independent,"Orman, Greg",0,000080
+MITCHELL,Blue Hill Township,United States Senate,,Libertarian,"Batson, Randall",2,000080
+MITCHELL,Blue Hill Township,United States Senate,,Republican,"Roberts, Pat",17,000080
+MITCHELL,Carr Creek Township,United States Senate,,independent,"Orman, Greg",0,000090
+MITCHELL,Carr Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+MITCHELL,Carr Creek Township,United States Senate,,Republican,"Roberts, Pat",11,000090
+MITCHELL,Cawker City,United States Senate,,independent,"Orman, Greg",0,000100
+MITCHELL,Cawker City,United States Senate,,Libertarian,"Batson, Randall",0,000100
+MITCHELL,Cawker City,United States Senate,,Republican,"Roberts, Pat",0,000100
+MITCHELL,Cawker Township,United States Senate,,independent,"Orman, Greg",46,000110
+MITCHELL,Cawker Township,United States Senate,,Libertarian,"Batson, Randall",16,000110
+MITCHELL,Cawker Township,United States Senate,,Republican,"Roberts, Pat",116,000110
+MITCHELL,Center Township,United States Senate,,independent,"Orman, Greg",0,000120
+MITCHELL,Center Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+MITCHELL,Center Township,United States Senate,,Republican,"Roberts, Pat",12,000120
+MITCHELL,Custer Township,United States Senate,,independent,"Orman, Greg",16,000130
+MITCHELL,Custer Township,United States Senate,,Libertarian,"Batson, Randall",3,000130
+MITCHELL,Custer Township,United States Senate,,Republican,"Roberts, Pat",34,000130
+MITCHELL,Eureka Township,United States Senate,,independent,"Orman, Greg",2,000140
+MITCHELL,Eureka Township,United States Senate,,Libertarian,"Batson, Randall",0,000140
+MITCHELL,Eureka Township,United States Senate,,Republican,"Roberts, Pat",11,000140
+MITCHELL,Glen Elder City,United States Senate,,independent,"Orman, Greg",0,000150
+MITCHELL,Glen Elder City,United States Senate,,Libertarian,"Batson, Randall",0,000150
+MITCHELL,Glen Elder City,United States Senate,,Republican,"Roberts, Pat",0,000150
+MITCHELL,Glen Elder Township,United States Senate,,independent,"Orman, Greg",42,000160
+MITCHELL,Glen Elder Township,United States Senate,,Libertarian,"Batson, Randall",9,000160
+MITCHELL,Glen Elder Township,United States Senate,,Republican,"Roberts, Pat",148,000160
+MITCHELL,Hayes Township,United States Senate,,independent,"Orman, Greg",2,000170
+MITCHELL,Hayes Township,United States Senate,,Libertarian,"Batson, Randall",0,000170
+MITCHELL,Hayes Township,United States Senate,,Republican,"Roberts, Pat",11,000170
+MITCHELL,Hunter City,United States Senate,,independent,"Orman, Greg",0,000180
+MITCHELL,Hunter City,United States Senate,,Libertarian,"Batson, Randall",0,000180
+MITCHELL,Hunter City,United States Senate,,Republican,"Roberts, Pat",0,000180
+MITCHELL,Logan Township,United States Senate,,independent,"Orman, Greg",15,000190
+MITCHELL,Logan Township,United States Senate,,Libertarian,"Batson, Randall",0,000190
+MITCHELL,Logan Township,United States Senate,,Republican,"Roberts, Pat",26,000190
+MITCHELL,Lulu Township,United States Senate,,independent,"Orman, Greg",2,000200
+MITCHELL,Lulu Township,United States Senate,,Libertarian,"Batson, Randall",0,000200
+MITCHELL,Lulu Township,United States Senate,,Republican,"Roberts, Pat",26,000200
+MITCHELL,Pittsburg Township,United States Senate,,independent,"Orman, Greg",24,000210
+MITCHELL,Pittsburg Township,United States Senate,,Libertarian,"Batson, Randall",3,000210
+MITCHELL,Pittsburg Township,United States Senate,,Republican,"Roberts, Pat",110,000210
+MITCHELL,Plum Creek Township,United States Senate,,independent,"Orman, Greg",5,000220
+MITCHELL,Plum Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000220
+MITCHELL,Plum Creek Township,United States Senate,,Republican,"Roberts, Pat",50,000220
+MITCHELL,Round Springs Township,United States Senate,,independent,"Orman, Greg",2,000230
+MITCHELL,Round Springs Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+MITCHELL,Round Springs Township,United States Senate,,Republican,"Roberts, Pat",11,000230
+MITCHELL,Salt Creek Township,United States Senate,,independent,"Orman, Greg",2,000240
+MITCHELL,Salt Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000240
+MITCHELL,Salt Creek Township,United States Senate,,Republican,"Roberts, Pat",10,000240
+MITCHELL,Scottsville City,United States Senate,,independent,"Orman, Greg",0,000250
+MITCHELL,Scottsville City,United States Senate,,Libertarian,"Batson, Randall",0,000250
+MITCHELL,Scottsville City,United States Senate,,Republican,"Roberts, Pat",0,000250
+MITCHELL,Simpson City,United States Senate,,independent,"Orman, Greg",0,000260
+MITCHELL,Simpson City,United States Senate,,Libertarian,"Batson, Randall",0,000260
+MITCHELL,Simpson City,United States Senate,,Republican,"Roberts, Pat",0,000260
+MITCHELL,Solomon Rapids Township,United States Senate,,independent,"Orman, Greg",10,000270
+MITCHELL,Solomon Rapids Township,United States Senate,,Libertarian,"Batson, Randall",0,000270
+MITCHELL,Solomon Rapids Township,United States Senate,,Republican,"Roberts, Pat",20,000270
+MITCHELL,Tipton City,United States Senate,,independent,"Orman, Greg",0,000280
+MITCHELL,Tipton City,United States Senate,,Libertarian,"Batson, Randall",0,000280
+MITCHELL,Tipton City,United States Senate,,Republican,"Roberts, Pat",0,000280
+MITCHELL,Turkey Creek Township,United States Senate,,independent,"Orman, Greg",7,000290
+MITCHELL,Turkey Creek Township,United States Senate,,Libertarian,"Batson, Randall",3,000290
+MITCHELL,Turkey Creek Township,United States Senate,,Republican,"Roberts, Pat",43,000290
+MITCHELL,Walnut Creek Township,United States Senate,,independent,"Orman, Greg",5,000300
+MITCHELL,Walnut Creek Township,United States Senate,,Libertarian,"Batson, Randall",1,000300
+MITCHELL,Walnut Creek Township,United States Senate,,Republican,"Roberts, Pat",14,000300

--- a/2014/20141104__ks__general__montgomery__precinct.csv
+++ b/2014/20141104__ks__general__montgomery__precinct.csv
@@ -1,1121 +1,1289 @@
-county,precinct,office,district,party,candidate,votes
-Montgomery,CANEY W1P1,Voters,,,,116
-Montgomery,CANEY W1P2 H12,Voters,,,,4
-Montgomery,CANEY W2P1,Voters,,,,101
-Montgomery,CANEY W3P1,Voters,,,,121
-Montgomery,CANEY W3P2,Voters,,,,2
-Montgomery,CANEY W4P1,Voters,,,,142
-Montgomery,CANEY W4P2,Voters,,,,1
-Montgomery,CHERRYVALE 1,Voters,,,,303
-Montgomery,CHERRYVALE 2,Voters,,,,233
-Montgomery,COFFEYVILLE 1,Voters,,,,27
-Montgomery,COFFEYVILLE 2,Voters,,,,81
-Montgomery,COFFEYVILLE 3,Voters,,,,123
-Montgomery,COFFEYVILLE 4,Voters,,,,150
-Montgomery,COFFEYVILLE 5,Voters,,,,193
-Montgomery,COFFEYVILLE 6,Voters,,,,59
-Montgomery,COFFEYVILLE 7,Voters,,,,77
-Montgomery,COFFEYVILLE 8,Voters,,,,105
-Montgomery,COFFEYVILLE 9,Voters,,,,34
-Montgomery,COFFEYVILLE 10,Voters,,,,105
-Montgomery,COFFEYVILLE 11,Voters,,,,266
-Montgomery,COFFEYVILLE 12,Voters,,,,375
-Montgomery,COFFEYVILLE 13,Voters,,,,324
-Montgomery,INDEPENDENCE W1P1,Voters,,,,109
-Montgomery,INDEPENDENCE W1P2,Voters,,,,197
-Montgomery,INDEPENDENCE W2P1,Voters,,,,81
-Montgomery,INDEPENDENCE W2P2,Voters,,,,64
-Montgomery,INDEPENDENCE W3P1,Voters,,,,158
-Montgomery,INDEPENDENCE W3P2,Voters,,,,87
-Montgomery,INDEPENDENCE W3P2 EX,Voters,,,,1
-Montgomery,INDEPENDENCE W4P1,Voters,,,,175
-Montgomery,INDEPENDENCE W4P2,Voters,,,,110
-Montgomery,INDEPENDENCE W5P1,Voters,,,,106
-Montgomery,INDEPENDENCE W5P2,Voters,,,,211
-Montgomery,INDEPENDENCE W6P1 H11,Voters,,,,21
-Montgomery,INDEPENDENCE W6P1 H12,Voters,,,,286
-Montgomery,INDEPENDENCE W6P2 H11,Voters,,,,232
-Montgomery,INDEPENDENCE W6P2 H12,Voters,,,,74
-Montgomery,INDEPENDENCE W6P2 H11A,Voters,,,,111
-Montgomery,INDEPENDENCE W6P2 H12A,Voters,,,,9
-Montgomery,CANEY-HAVANA,Voters,,,,201
-Montgomery,CANEY-TYRO,Voters,,,,240
-Montgomery,CHEROKEE,Voters,,,,133
-Montgomery,CHERRY,Voters,,,,204
-Montgomery,DRUM CREEK ,Voters,,,,207
-Montgomery,FAWN CREEK-DEARING,Voters,,,,533
-Montgomery,FAWN CREEK-TYRO,Voters,,,,150
-Montgomery,INDEPENDENCE TWP 1 H11,Voters,,,,532
-Montgomery,INDEPENDENCE TWP 1 H12,Voters,,,,102
-Montgomery,INDEPENDENCE TWP 2 A H12,Voters,,,,136
-Montgomery,INDEPENDENCE TWP 2 C H11,Voters,,,,40
-Montgomery,LIBERTY,Voters,,,,185
-Montgomery,LOUISBURG,Voters,,,,175
-Montgomery,PARKER 1,Voters,,,,93
-Montgomery,PARKER 2,Voters,,,,308
-Montgomery,PARKER 2 EX H11,Voters,,,,10
-Montgomery,RUTLAND,Voters,,,,132
-Montgomery,SYCAMORE,Voters,,,,340
-Montgomery,WEST CHERRY,Voters,,,,103
-Montgomery,CANEY W1P1,U.S. Senate,,R,Pat Roberts,82
-Montgomery,CANEY W1P2 H12,U.S. Senate,,R,Pat Roberts,3
-Montgomery,CANEY W2P1,U.S. Senate,,R,Pat Roberts,72
-Montgomery,CANEY W3P1,U.S. Senate,,R,Pat Roberts,96
-Montgomery,CANEY W3P2,U.S. Senate,,R,Pat Roberts,2
-Montgomery,CANEY W4P1,U.S. Senate,,R,Pat Roberts,116
-Montgomery,CANEY W4P2,U.S. Senate,,R,Pat Roberts,1
-Montgomery,CHERRYVALE 1,U.S. Senate,,R,Pat Roberts,195
-Montgomery,CHERRYVALE 2,U.S. Senate,,R,Pat Roberts,151
-Montgomery,COFFEYVILLE 1,U.S. Senate,,R,Pat Roberts,4
-Montgomery,COFFEYVILLE 2,U.S. Senate,,R,Pat Roberts,46
-Montgomery,COFFEYVILLE 3,U.S. Senate,,R,Pat Roberts,69
-Montgomery,COFFEYVILLE 4,U.S. Senate,,R,Pat Roberts,95
-Montgomery,COFFEYVILLE 5,U.S. Senate,,R,Pat Roberts,105
-Montgomery,COFFEYVILLE 6,U.S. Senate,,R,Pat Roberts,32
-Montgomery,COFFEYVILLE 7,U.S. Senate,,R,Pat Roberts,43
-Montgomery,COFFEYVILLE 8,U.S. Senate,,R,Pat Roberts,65
-Montgomery,COFFEYVILLE 9,U.S. Senate,,R,Pat Roberts,16
-Montgomery,COFFEYVILLE 10,U.S. Senate,,R,Pat Roberts,58
-Montgomery,COFFEYVILLE 11,U.S. Senate,,R,Pat Roberts,163
-Montgomery,COFFEYVILLE 12,U.S. Senate,,R,Pat Roberts,253
-Montgomery,COFFEYVILLE 13,U.S. Senate,,R,Pat Roberts,214
-Montgomery,INDEPENDENCE W1P1,U.S. Senate,,R,Pat Roberts,62
-Montgomery,INDEPENDENCE W1P2,U.S. Senate,,R,Pat Roberts,123
-Montgomery,INDEPENDENCE W2P1,U.S. Senate,,R,Pat Roberts,50
-Montgomery,INDEPENDENCE W2P2,U.S. Senate,,R,Pat Roberts,39
-Montgomery,INDEPENDENCE W3P1,U.S. Senate,,R,Pat Roberts,97
-Montgomery,INDEPENDENCE W3P2,U.S. Senate,,R,Pat Roberts,52
-Montgomery,INDEPENDENCE W3P2 EX,U.S. Senate,,R,Pat Roberts,1
-Montgomery,INDEPENDENCE W4P1,U.S. Senate,,R,Pat Roberts,100
-Montgomery,INDEPENDENCE W4P2,U.S. Senate,,R,Pat Roberts,66
-Montgomery,INDEPENDENCE W5P1,U.S. Senate,,R,Pat Roberts,65
-Montgomery,INDEPENDENCE W5P2,U.S. Senate,,R,Pat Roberts,127
-Montgomery,INDEPENDENCE W6P1 H11,U.S. Senate,,R,Pat Roberts,12
-Montgomery,INDEPENDENCE W6P1 H12,U.S. Senate,,R,Pat Roberts,186
-Montgomery,INDEPENDENCE W6P2 H11,U.S. Senate,,R,Pat Roberts,172
-Montgomery,INDEPENDENCE W6P2 H12,U.S. Senate,,R,Pat Roberts,59
-Montgomery,INDEPENDENCE W6P2 H11A,U.S. Senate,,R,Pat Roberts,59
-Montgomery,INDEPENDENCE W6P2 H12A,U.S. Senate,,R,Pat Roberts,6
-Montgomery,CANEY-HAVANA,U.S. Senate,,R,Pat Roberts,167
-Montgomery,CANEY-TYRO,U.S. Senate,,R,Pat Roberts,212
-Montgomery,CHEROKEE,U.S. Senate,,R,Pat Roberts,86
-Montgomery,CHERRY,U.S. Senate,,R,Pat Roberts,135
-Montgomery,DRUM CREEK ,U.S. Senate,,R,Pat Roberts,167
-Montgomery,FAWN CREEK-DEARING,U.S. Senate,,R,Pat Roberts,396
-Montgomery,FAWN CREEK-TYRO,U.S. Senate,,R,Pat Roberts,122
-Montgomery,INDEPENDENCE TWP 1 H11,U.S. Senate,,R,Pat Roberts,408
-Montgomery,INDEPENDENCE TWP 1 H12,U.S. Senate,,R,Pat Roberts,71
-Montgomery,INDEPENDENCE TWP 2 A H12,U.S. Senate,,R,Pat Roberts,100
-Montgomery,INDEPENDENCE TWP 2 C H11,U.S. Senate,,R,Pat Roberts,30
-Montgomery,LIBERTY,U.S. Senate,,R,Pat Roberts,138
-Montgomery,LOUISBURG,U.S. Senate,,R,Pat Roberts,122
-Montgomery,PARKER 1,U.S. Senate,,R,Pat Roberts,63
-Montgomery,PARKER 2,U.S. Senate,,R,Pat Roberts,188
-Montgomery,PARKER 2 EX H11,U.S. Senate,,R,Pat Roberts,6
-Montgomery,RUTLAND,U.S. Senate,,R,Pat Roberts,107
-Montgomery,SYCAMORE,U.S. Senate,,R,Pat Roberts,252
-Montgomery,WEST CHERRY,U.S. Senate,,R,Pat Roberts,70
-Montgomery,CANEY W1P1,U.S. Senate,,I,Greg Orman,25
-Montgomery,CANEY W1P2 H12,U.S. Senate,,I,Greg Orman,0
-Montgomery,CANEY W2P1,U.S. Senate,,I,Greg Orman,22
-Montgomery,CANEY W3P1,U.S. Senate,,I,Greg Orman,16
-Montgomery,CANEY W3P2,U.S. Senate,,I,Greg Orman,0
-Montgomery,CANEY W4P1,U.S. Senate,,I,Greg Orman,17
-Montgomery,CANEY W4P2,U.S. Senate,,I,Greg Orman,0
-Montgomery,CHERRYVALE 1,U.S. Senate,,I,Greg Orman,78
-Montgomery,CHERRYVALE 2,U.S. Senate,,I,Greg Orman,60
-Montgomery,COFFEYVILLE 1,U.S. Senate,,I,Greg Orman,18
-Montgomery,COFFEYVILLE 2,U.S. Senate,,I,Greg Orman,27
-Montgomery,COFFEYVILLE 3,U.S. Senate,,I,Greg Orman,41
-Montgomery,COFFEYVILLE 4,U.S. Senate,,I,Greg Orman,46
-Montgomery,COFFEYVILLE 5,U.S. Senate,,I,Greg Orman,76
-Montgomery,COFFEYVILLE 6,U.S. Senate,,I,Greg Orman,16
-Montgomery,COFFEYVILLE 7,U.S. Senate,,I,Greg Orman,28
-Montgomery,COFFEYVILLE 8,U.S. Senate,,I,Greg Orman,25
-Montgomery,COFFEYVILLE 9,U.S. Senate,,I,Greg Orman,15
-Montgomery,COFFEYVILLE 10,U.S. Senate,,I,Greg Orman,36
-Montgomery,COFFEYVILLE 11,U.S. Senate,,I,Greg Orman,85
-Montgomery,COFFEYVILLE 12,U.S. Senate,,I,Greg Orman,98
-Montgomery,COFFEYVILLE 13,U.S. Senate,,I,Greg Orman,95
-Montgomery,INDEPENDENCE W1P1,U.S. Senate,,I,Greg Orman,37
-Montgomery,INDEPENDENCE W1P2,U.S. Senate,,I,Greg Orman,64
-Montgomery,INDEPENDENCE W2P1,U.S. Senate,,I,Greg Orman,29
-Montgomery,INDEPENDENCE W2P2,U.S. Senate,,I,Greg Orman,17
-Montgomery,INDEPENDENCE W3P1,U.S. Senate,,I,Greg Orman,39
-Montgomery,INDEPENDENCE W3P2,U.S. Senate,,I,Greg Orman,23
-Montgomery,INDEPENDENCE W3P2 EX,U.S. Senate,,I,Greg Orman,0
-Montgomery,INDEPENDENCE W4P1,U.S. Senate,,I,Greg Orman,58
-Montgomery,INDEPENDENCE W4P2,U.S. Senate,,I,Greg Orman,32
-Montgomery,INDEPENDENCE W5P1,U.S. Senate,,I,Greg Orman,29
-Montgomery,INDEPENDENCE W5P2,U.S. Senate,,I,Greg Orman,71
-Montgomery,INDEPENDENCE W6P1 H11,U.S. Senate,,I,Greg Orman,8
-Montgomery,INDEPENDENCE W6P1 H12,U.S. Senate,,I,Greg Orman,86
-Montgomery,INDEPENDENCE W6P2 H11,U.S. Senate,,I,Greg Orman,54
-Montgomery,INDEPENDENCE W6P2 H12,U.S. Senate,,I,Greg Orman,14
-Montgomery,INDEPENDENCE W6P2 H11A,U.S. Senate,,I,Greg Orman,43
-Montgomery,INDEPENDENCE W6P2 H12A,U.S. Senate,,I,Greg Orman,3
-Montgomery,CANEY-HAVANA,U.S. Senate,,I,Greg Orman,42
-Montgomery,CANEY-TYRO,U.S. Senate,,I,Greg Orman,24
-Montgomery,CHEROKEE,U.S. Senate,,I,Greg Orman,33
-Montgomery,CHERRY,U.S. Senate,,I,Greg Orman,42
-Montgomery,DRUM CREEK ,U.S. Senate,,I,Greg Orman,33
-Montgomery,FAWN CREEK-DEARING,U.S. Senate,,I,Greg Orman,120
-Montgomery,FAWN CREEK-TYRO,U.S. Senate,,I,Greg Orman,21
-Montgomery,INDEPENDENCE TWP 1 H11,U.S. Senate,,I,Greg Orman,101
-Montgomery,INDEPENDENCE TWP 1 H12,U.S. Senate,,I,Greg Orman,17
-Montgomery,INDEPENDENCE TWP 2 A H12,U.S. Senate,,I,Greg Orman,30
-Montgomery,INDEPENDENCE TWP 2 C H11,U.S. Senate,,I,Greg Orman,8
-Montgomery,LIBERTY,U.S. Senate,,I,Greg Orman,41
-Montgomery,LOUISBURG,U.S. Senate,,I,Greg Orman,35
-Montgomery,PARKER 1,U.S. Senate,,I,Greg Orman,27
-Montgomery,PARKER 2,U.S. Senate,,I,Greg Orman,105
-Montgomery,PARKER 2 EX H11,U.S. Senate,,I,Greg Orman,3
-Montgomery,RUTLAND,U.S. Senate,,I,Greg Orman,17
-Montgomery,SYCAMORE,U.S. Senate,,I,Greg Orman,60
-Montgomery,WEST CHERRY,U.S. Senate,,I,Greg Orman,23
-Montgomery,CANEY W1P1,U.S. Senate,,l,Randall Batson,8
-Montgomery,CANEY W1P2 H12,U.S. Senate,,l,Randall Batson,0
-Montgomery,CANEY W2P1,U.S. Senate,,l,Randall Batson,6
-Montgomery,CANEY W3P1,U.S. Senate,,l,Randall Batson,7
-Montgomery,CANEY W3P2,U.S. Senate,,l,Randall Batson,0
-Montgomery,CANEY W4P1,U.S. Senate,,l,Randall Batson,8
-Montgomery,CANEY W4P2,U.S. Senate,,l,Randall Batson,0
-Montgomery,CHERRYVALE 1,U.S. Senate,,l,Randall Batson,21
-Montgomery,CHERRYVALE 2,U.S. Senate,,l,Randall Batson,15
-Montgomery,COFFEYVILLE 1,U.S. Senate,,l,Randall Batson,2
-Montgomery,COFFEYVILLE 2,U.S. Senate,,l,Randall Batson,3
-Montgomery,COFFEYVILLE 3,U.S. Senate,,l,Randall Batson,8
-Montgomery,COFFEYVILLE 4,U.S. Senate,,l,Randall Batson,6
-Montgomery,COFFEYVILLE 5,U.S. Senate,,l,Randall Batson,8
-Montgomery,COFFEYVILLE 6,U.S. Senate,,l,Randall Batson,5
-Montgomery,COFFEYVILLE 7,U.S. Senate,,l,Randall Batson,6
-Montgomery,COFFEYVILLE 8,U.S. Senate,,l,Randall Batson,8
-Montgomery,COFFEYVILLE 9,U.S. Senate,,l,Randall Batson,2
-Montgomery,COFFEYVILLE 10,U.S. Senate,,l,Randall Batson,7
-Montgomery,COFFEYVILLE 11,U.S. Senate,,l,Randall Batson,12
-Montgomery,COFFEYVILLE 12,U.S. Senate,,l,Randall Batson,19
-Montgomery,COFFEYVILLE 13,U.S. Senate,,l,Randall Batson,9
-Montgomery,INDEPENDENCE W1P1,U.S. Senate,,l,Randall Batson,8
-Montgomery,INDEPENDENCE W1P2,U.S. Senate,,l,Randall Batson,8
-Montgomery,INDEPENDENCE W2P1,U.S. Senate,,l,Randall Batson,2
-Montgomery,INDEPENDENCE W2P2,U.S. Senate,,l,Randall Batson,4
-Montgomery,INDEPENDENCE W3P1,U.S. Senate,,l,Randall Batson,13
-Montgomery,INDEPENDENCE W3P2,U.S. Senate,,l,Randall Batson,8
-Montgomery,INDEPENDENCE W3P2 EX,U.S. Senate,,l,Randall Batson,0
-Montgomery,INDEPENDENCE W4P1,U.S. Senate,,l,Randall Batson,12
-Montgomery,INDEPENDENCE W4P2,U.S. Senate,,l,Randall Batson,7
-Montgomery,INDEPENDENCE W5P1,U.S. Senate,,l,Randall Batson,8
-Montgomery,INDEPENDENCE W5P2,U.S. Senate,,l,Randall Batson,9
-Montgomery,INDEPENDENCE W6P1 H11,U.S. Senate,,l,Randall Batson,0
-Montgomery,INDEPENDENCE W6P1 H12,U.S. Senate,,l,Randall Batson,11
-Montgomery,INDEPENDENCE W6P2 H11,U.S. Senate,,l,Randall Batson,4
-Montgomery,INDEPENDENCE W6P2 H12,U.S. Senate,,l,Randall Batson,1
-Montgomery,INDEPENDENCE W6P2 H11A,U.S. Senate,,l,Randall Batson,7
-Montgomery,INDEPENDENCE W6P2 H12A,U.S. Senate,,l,Randall Batson,0
-Montgomery,CANEY-HAVANA,U.S. Senate,,l,Randall Batson,3
-Montgomery,CANEY-TYRO,U.S. Senate,,l,Randall Batson,5
-Montgomery,CHEROKEE,U.S. Senate,,l,Randall Batson,7
-Montgomery,CHERRY,U.S. Senate,,l,Randall Batson,10
-Montgomery,DRUM CREEK ,U.S. Senate,,l,Randall Batson,7
-Montgomery,FAWN CREEK-DEARING,U.S. Senate,,l,Randall Batson,17
-Montgomery,FAWN CREEK-TYRO,U.S. Senate,,l,Randall Batson,1
-Montgomery,INDEPENDENCE TWP 1 H11,U.S. Senate,,l,Randall Batson,22
-Montgomery,INDEPENDENCE TWP 1 H12,U.S. Senate,,l,Randall Batson,3
-Montgomery,INDEPENDENCE TWP 2 A H12,U.S. Senate,,l,Randall Batson,6
-Montgomery,INDEPENDENCE TWP 2 C H11,U.S. Senate,,l,Randall Batson,2
-Montgomery,LIBERTY,U.S. Senate,,l,Randall Batson,7
-Montgomery,LOUISBURG,U.S. Senate,,l,Randall Batson,10
-Montgomery,PARKER 1,U.S. Senate,,l,Randall Batson,2
-Montgomery,PARKER 2,U.S. Senate,,l,Randall Batson,15
-Montgomery,PARKER 2 EX H11,U.S. Senate,,l,Randall Batson,1
-Montgomery,RUTLAND,U.S. Senate,,l,Randall Batson,4
-Montgomery,SYCAMORE,U.S. Senate,,l,Randall Batson,13
-Montgomery,WEST CHERRY,U.S. Senate,,l,Randall Batson,6
-Montgomery,CANEY W1P1,U.S. House,2,R,Lynn Jenkins,88
-Montgomery,CANEY W1P2 H12,U.S. House,2,R,Lynn Jenkins,1
-Montgomery,CANEY W2P1,U.S. House,2,R,Lynn Jenkins,74
-Montgomery,CANEY W3P1,U.S. House,2,R,Lynn Jenkins,99
-Montgomery,CANEY W3P2,U.S. House,2,R,Lynn Jenkins,2
-Montgomery,CANEY W4P1,U.S. House,2,R,Lynn Jenkins,118
-Montgomery,CANEY W4P2,U.S. House,2,R,Lynn Jenkins,1
-Montgomery,CHERRYVALE 1,U.S. House,2,R,Lynn Jenkins,205
-Montgomery,CHERRYVALE 2,U.S. House,2,R,Lynn Jenkins,161
-Montgomery,COFFEYVILLE 1,U.S. House,2,R,Lynn Jenkins,5
-Montgomery,COFFEYVILLE 2,U.S. House,2,R,Lynn Jenkins,51
-Montgomery,COFFEYVILLE 3,U.S. House,2,R,Lynn Jenkins,68
-Montgomery,COFFEYVILLE 4,U.S. House,2,R,Lynn Jenkins,101
-Montgomery,COFFEYVILLE 5,U.S. House,2,R,Lynn Jenkins,118
-Montgomery,COFFEYVILLE 6,U.S. House,2,R,Lynn Jenkins,31
-Montgomery,COFFEYVILLE 7,U.S. House,2,R,Lynn Jenkins,46
-Montgomery,COFFEYVILLE 8,U.S. House,2,R,Lynn Jenkins,63
-Montgomery,COFFEYVILLE 9,U.S. House,2,R,Lynn Jenkins,14
-Montgomery,COFFEYVILLE 10,U.S. House,2,R,Lynn Jenkins,62
-Montgomery,COFFEYVILLE 11,U.S. House,2,R,Lynn Jenkins,161
-Montgomery,COFFEYVILLE 12,U.S. House,2,R,Lynn Jenkins,259
-Montgomery,COFFEYVILLE 13,U.S. House,2,R,Lynn Jenkins,222
-Montgomery,INDEPENDENCE W1P1,U.S. House,2,R,Lynn Jenkins,70
-Montgomery,INDEPENDENCE W1P2,U.S. House,2,R,Lynn Jenkins,148
-Montgomery,INDEPENDENCE W2P1,U.S. House,2,R,Lynn Jenkins,56
-Montgomery,INDEPENDENCE W2P2,U.S. House,2,R,Lynn Jenkins,43
-Montgomery,INDEPENDENCE W3P1,U.S. House,2,R,Lynn Jenkins,122
-Montgomery,INDEPENDENCE W3P2,U.S. House,2,R,Lynn Jenkins,57
-Montgomery,INDEPENDENCE W3P2 EX,U.S. House,2,R,Lynn Jenkins,1
-Montgomery,INDEPENDENCE W4P1,U.S. House,2,R,Lynn Jenkins,107
-Montgomery,INDEPENDENCE W4P2,U.S. House,2,R,Lynn Jenkins,70
-Montgomery,INDEPENDENCE W5P1,U.S. House,2,R,Lynn Jenkins,73
-Montgomery,INDEPENDENCE W5P2,U.S. House,2,R,Lynn Jenkins,138
-Montgomery,INDEPENDENCE W6P1 H11,U.S. House,2,R,Lynn Jenkins,12
-Montgomery,INDEPENDENCE W6P1 H12,U.S. House,2,R,Lynn Jenkins,197
-Montgomery,INDEPENDENCE W6P2 H11,U.S. House,2,R,Lynn Jenkins,184
-Montgomery,INDEPENDENCE W6P2 H12,U.S. House,2,R,Lynn Jenkins,62
-Montgomery,INDEPENDENCE W6P2 H11A,U.S. House,2,R,Lynn Jenkins,75
-Montgomery,INDEPENDENCE W6P2 H12A,U.S. House,2,R,Lynn Jenkins,6
-Montgomery,CANEY-HAVANA,U.S. House,2,R,Lynn Jenkins,180
-Montgomery,CANEY-TYRO,U.S. House,2,R,Lynn Jenkins,211
-Montgomery,CHEROKEE,U.S. House,2,R,Lynn Jenkins,89
-Montgomery,CHERRY,U.S. House,2,R,Lynn Jenkins,145
-Montgomery,DRUM CREEK ,U.S. House,2,R,Lynn Jenkins,168
-Montgomery,FAWN CREEK-DEARING,U.S. House,2,R,Lynn Jenkins,421
-Montgomery,FAWN CREEK-TYRO,U.S. House,2,R,Lynn Jenkins,124
-Montgomery,INDEPENDENCE TWP 1 H11,U.S. House,2,R,Lynn Jenkins,423
-Montgomery,INDEPENDENCE TWP 1 H12,U.S. House,2,R,Lynn Jenkins,73
-Montgomery,INDEPENDENCE TWP 2 A H12,U.S. House,2,R,Lynn Jenkins,106
-Montgomery,INDEPENDENCE TWP 2 C H11,U.S. House,2,R,Lynn Jenkins,35
-Montgomery,LIBERTY,U.S. House,2,R,Lynn Jenkins,137
-Montgomery,LOUISBURG,U.S. House,2,R,Lynn Jenkins,134
-Montgomery,PARKER 1,U.S. House,2,R,Lynn Jenkins,64
-Montgomery,PARKER 2,U.S. House,2,R,Lynn Jenkins,202
-Montgomery,PARKER 2 EX H11,U.S. House,2,R,Lynn Jenkins,5
-Montgomery,RUTLAND,U.S. House,2,R,Lynn Jenkins,110
-Montgomery,SYCAMORE,U.S. House,2,R,Lynn Jenkins,269
-Montgomery,WEST CHERRY,U.S. House,2,R,Lynn Jenkins,78
-Montgomery,CANEY W1P1,U.S. House,2,D,Margie Wakefield,21
-Montgomery,CANEY W1P2 H12,U.S. House,2,D,Margie Wakefield,2
-Montgomery,CANEY W2P1,U.S. House,2,D,Margie Wakefield,21
-Montgomery,CANEY W3P1,U.S. House,2,D,Margie Wakefield,17
-Montgomery,CANEY W3P2,U.S. House,2,D,Margie Wakefield,0
-Montgomery,CANEY W4P1,U.S. House,2,D,Margie Wakefield,17
-Montgomery,CANEY W4P2,U.S. House,2,D,Margie Wakefield,0
-Montgomery,CHERRYVALE 1,U.S. House,2,D,Margie Wakefield,71
-Montgomery,CHERRYVALE 2,U.S. House,2,D,Margie Wakefield,56
-Montgomery,COFFEYVILLE 1,U.S. House,2,D,Margie Wakefield,22
-Montgomery,COFFEYVILLE 2,U.S. House,2,D,Margie Wakefield,26
-Montgomery,COFFEYVILLE 3,U.S. House,2,D,Margie Wakefield,45
-Montgomery,COFFEYVILLE 4,U.S. House,2,D,Margie Wakefield,42
-Montgomery,COFFEYVILLE 5,U.S. House,2,D,Margie Wakefield,65
-Montgomery,COFFEYVILLE 6,U.S. House,2,D,Margie Wakefield,24
-Montgomery,COFFEYVILLE 7,U.S. House,2,D,Margie Wakefield,27
-Montgomery,COFFEYVILLE 8,U.S. House,2,D,Margie Wakefield,37
-Montgomery,COFFEYVILLE 9,U.S. House,2,D,Margie Wakefield,16
-Montgomery,COFFEYVILLE 10,U.S. House,2,D,Margie Wakefield,38
-Montgomery,COFFEYVILLE 11,U.S. House,2,D,Margie Wakefield,88
-Montgomery,COFFEYVILLE 12,U.S. House,2,D,Margie Wakefield,99
-Montgomery,COFFEYVILLE 13,U.S. House,2,D,Margie Wakefield,84
-Montgomery,INDEPENDENCE W1P1,U.S. House,2,D,Margie Wakefield,34
-Montgomery,INDEPENDENCE W1P2,U.S. House,2,D,Margie Wakefield,45
-Montgomery,INDEPENDENCE W2P1,U.S. House,2,D,Margie Wakefield,20
-Montgomery,INDEPENDENCE W2P2,U.S. House,2,D,Margie Wakefield,18
-Montgomery,INDEPENDENCE W3P1,U.S. House,2,D,Margie Wakefield,28
-Montgomery,INDEPENDENCE W3P2,U.S. House,2,D,Margie Wakefield,20
-Montgomery,INDEPENDENCE W3P2 EX,U.S. House,2,D,Margie Wakefield,0
-Montgomery,INDEPENDENCE W4P1,U.S. House,2,D,Margie Wakefield,55
-Montgomery,INDEPENDENCE W4P2,U.S. House,2,D,Margie Wakefield,28
-Montgomery,INDEPENDENCE W5P1,U.S. House,2,D,Margie Wakefield,26
-Montgomery,INDEPENDENCE W5P2,U.S. House,2,D,Margie Wakefield,64
-Montgomery,INDEPENDENCE W6P1 H11,U.S. House,2,D,Margie Wakefield,6
-Montgomery,INDEPENDENCE W6P1 H12,U.S. House,2,D,Margie Wakefield,78
-Montgomery,INDEPENDENCE W6P2 H11,U.S. House,2,D,Margie Wakefield,44
-Montgomery,INDEPENDENCE W6P2 H12,U.S. House,2,D,Margie Wakefield,10
-Montgomery,INDEPENDENCE W6P2 H11A,U.S. House,2,D,Margie Wakefield,30
-Montgomery,INDEPENDENCE W6P2 H12A,U.S. House,2,D,Margie Wakefield,3
-Montgomery,CANEY-HAVANA,U.S. House,2,D,Margie Wakefield,25
-Montgomery,CANEY-TYRO,U.S. House,2,D,Margie Wakefield,24
-Montgomery,CHEROKEE,U.S. House,2,D,Margie Wakefield,31
-Montgomery,CHERRY,U.S. House,2,D,Margie Wakefield,32
-Montgomery,DRUM CREEK ,U.S. House,2,D,Margie Wakefield,35
-Montgomery,FAWN CREEK-DEARING,U.S. House,2,D,Margie Wakefield,94
-Montgomery,FAWN CREEK-TYRO,U.S. House,2,D,Margie Wakefield,14
-Montgomery,INDEPENDENCE TWP 1 H11,U.S. House,2,D,Margie Wakefield,85
-Montgomery,INDEPENDENCE TWP 1 H12,U.S. House,2,D,Margie Wakefield,12
-Montgomery,INDEPENDENCE TWP 2 A H12,U.S. House,2,D,Margie Wakefield,29
-Montgomery,INDEPENDENCE TWP 2 C H11,U.S. House,2,D,Margie Wakefield,3
-Montgomery,LIBERTY,U.S. House,2,D,Margie Wakefield,38
-Montgomery,LOUISBURG,U.S. House,2,D,Margie Wakefield,25
-Montgomery,PARKER 1,U.S. House,2,D,Margie Wakefield,23
-Montgomery,PARKER 2,U.S. House,2,D,Margie Wakefield,87
-Montgomery,PARKER 2 EX H11,U.S. House,2,D,Margie Wakefield,3
-Montgomery,RUTLAND,U.S. House,2,D,Margie Wakefield,17
-Montgomery,SYCAMORE,U.S. House,2,D,Margie Wakefield,46
-Montgomery,WEST CHERRY,U.S. House,2,D,Margie Wakefield,18
-Montgomery,CANEY W1P1,U.S. House,2,L,Christopher Clemmons,4
-Montgomery,CANEY W1P2 H12,U.S. House,2,L,Christopher Clemmons,0
-Montgomery,CANEY W2P1,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,CANEY W3P1,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,CANEY W3P2,U.S. House,2,L,Christopher Clemmons,0
-Montgomery,CANEY W4P1,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,CANEY W4P2,U.S. House,2,L,Christopher Clemmons,0
-Montgomery,CHERRYVALE 1,U.S. House,2,L,Christopher Clemmons,22
-Montgomery,CHERRYVALE 2,U.S. House,2,L,Christopher Clemmons,13
-Montgomery,COFFEYVILLE 1,U.S. House,2,L,Christopher Clemmons,0
-Montgomery,COFFEYVILLE 2,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,COFFEYVILLE 3,U.S. House,2,L,Christopher Clemmons,8
-Montgomery,COFFEYVILLE 4,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,COFFEYVILLE 5,U.S. House,2,L,Christopher Clemmons,8
-Montgomery,COFFEYVILLE 6,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,COFFEYVILLE 7,U.S. House,2,L,Christopher Clemmons,3
-Montgomery,COFFEYVILLE 8,U.S. House,2,L,Christopher Clemmons,3
-Montgomery,COFFEYVILLE 9,U.S. House,2,L,Christopher Clemmons,3
-Montgomery,COFFEYVILLE 10,U.S. House,2,L,Christopher Clemmons,3
-Montgomery,COFFEYVILLE 11,U.S. House,2,L,Christopher Clemmons,8
-Montgomery,COFFEYVILLE 12,U.S. House,2,L,Christopher Clemmons,11
-Montgomery,COFFEYVILLE 13,U.S. House,2,L,Christopher Clemmons,12
-Montgomery,INDEPENDENCE W1P1,U.S. House,2,L,Christopher Clemmons,4
-Montgomery,INDEPENDENCE W1P2,U.S. House,2,L,Christopher Clemmons,3
-Montgomery,INDEPENDENCE W2P1,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,INDEPENDENCE W2P2,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,INDEPENDENCE W3P1,U.S. House,2,L,Christopher Clemmons,3
-Montgomery,INDEPENDENCE W3P2,U.S. House,2,L,Christopher Clemmons,9
-Montgomery,INDEPENDENCE W3P2 EX,U.S. House,2,L,Christopher Clemmons,0
-Montgomery,INDEPENDENCE W4P1,U.S. House,2,L,Christopher Clemmons,10
-Montgomery,INDEPENDENCE W4P2,U.S. House,2,L,Christopher Clemmons,10
-Montgomery,INDEPENDENCE W5P1,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,INDEPENDENCE W5P2,U.S. House,2,L,Christopher Clemmons,7
-Montgomery,INDEPENDENCE W6P1 H11,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,INDEPENDENCE W6P1 H12,U.S. House,2,L,Christopher Clemmons,11
-Montgomery,INDEPENDENCE W6P2 H11,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,INDEPENDENCE W6P2 H12,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,INDEPENDENCE W6P2 H11A,U.S. House,2,L,Christopher Clemmons,4
-Montgomery,INDEPENDENCE W6P2 H12A,U.S. House,2,L,Christopher Clemmons,0
-Montgomery,CANEY-HAVANA,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,CANEY-TYRO,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,CHEROKEE,U.S. House,2,L,Christopher Clemmons,6
-Montgomery,CHERRY,U.S. House,2,L,Christopher Clemmons,10
-Montgomery,DRUM CREEK ,U.S. House,2,L,Christopher Clemmons,3
-Montgomery,FAWN CREEK-DEARING,U.S. House,2,L,Christopher Clemmons,19
-Montgomery,FAWN CREEK-TYRO,U.S. House,2,L,Christopher Clemmons,4
-Montgomery,INDEPENDENCE TWP 1 H11,U.S. House,2,L,Christopher Clemmons,21
-Montgomery,INDEPENDENCE TWP 1 H12,U.S. House,2,L,Christopher Clemmons,6
-Montgomery,INDEPENDENCE TWP 2 A H12,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,INDEPENDENCE TWP 2 C H11,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,LIBERTY,U.S. House,2,L,Christopher Clemmons,10
-Montgomery,LOUISBURG,U.S. House,2,L,Christopher Clemmons,5
-Montgomery,PARKER 1,U.S. House,2,L,Christopher Clemmons,4
-Montgomery,PARKER 2,U.S. House,2,L,Christopher Clemmons,17
-Montgomery,PARKER 2 EX H11,U.S. House,2,L,Christopher Clemmons,2
-Montgomery,RUTLAND,U.S. House,2,L,Christopher Clemmons,1
-Montgomery,SYCAMORE,U.S. House,2,L,Christopher Clemmons,11
-Montgomery,WEST CHERRY,U.S. House,2,L,Christopher Clemmons,4
-Montgomery,CANEY W1P1,Governor,,R,Sam Brownback,79
-Montgomery,CANEY W1P2 H12,Governor,,R,Sam Brownback,3
-Montgomery,CANEY W2P1,Governor,,R,Sam Brownback,63
-Montgomery,CANEY W3P1,Governor,,R,Sam Brownback,94
-Montgomery,CANEY W3P2,Governor,,R,Sam Brownback,2
-Montgomery,CANEY W4P1,Governor,,R,Sam Brownback,104
-Montgomery,CANEY W4P2,Governor,,R,Sam Brownback,1
-Montgomery,CHERRYVALE 1,Governor,,R,Sam Brownback,175
-Montgomery,CHERRYVALE 2,Governor,,R,Sam Brownback,136
-Montgomery,COFFEYVILLE 1,Governor,,R,Sam Brownback,4
-Montgomery,COFFEYVILLE 2,Governor,,R,Sam Brownback,42
-Montgomery,COFFEYVILLE 3,Governor,,R,Sam Brownback,63
-Montgomery,COFFEYVILLE 4,Governor,,R,Sam Brownback,91
-Montgomery,COFFEYVILLE 5,Governor,,R,Sam Brownback,95
-Montgomery,COFFEYVILLE 6,Governor,,R,Sam Brownback,28
-Montgomery,COFFEYVILLE 7,Governor,,R,Sam Brownback,37
-Montgomery,COFFEYVILLE 8,Governor,,R,Sam Brownback,48
-Montgomery,COFFEYVILLE 9,Governor,,R,Sam Brownback,15
-Montgomery,COFFEYVILLE 10,Governor,,R,Sam Brownback,54
-Montgomery,COFFEYVILLE 11,Governor,,R,Sam Brownback,141
-Montgomery,COFFEYVILLE 12,Governor,,R,Sam Brownback,217
-Montgomery,COFFEYVILLE 13,Governor,,R,Sam Brownback,189
-Montgomery,INDEPENDENCE W1P1,Governor,,R,Sam Brownback,55
-Montgomery,INDEPENDENCE W1P2,Governor,,R,Sam Brownback,117
-Montgomery,INDEPENDENCE W2P1,Governor,,R,Sam Brownback,40
-Montgomery,INDEPENDENCE W2P2,Governor,,R,Sam Brownback,40
-Montgomery,INDEPENDENCE W3P1,Governor,,R,Sam Brownback,102
-Montgomery,INDEPENDENCE W3P2,Governor,,R,Sam Brownback,48
-Montgomery,INDEPENDENCE W3P2 EX,Governor,,R,Sam Brownback,1
-Montgomery,INDEPENDENCE W4P1,Governor,,R,Sam Brownback,96
-Montgomery,INDEPENDENCE W4P2,Governor,,R,Sam Brownback,63
-Montgomery,INDEPENDENCE W5P1,Governor,,R,Sam Brownback,64
-Montgomery,INDEPENDENCE W5P2,Governor,,R,Sam Brownback,103
-Montgomery,INDEPENDENCE W6P1 H11,Governor,,R,Sam Brownback,11
-Montgomery,INDEPENDENCE W6P1 H12,Governor,,R,Sam Brownback,172
-Montgomery,INDEPENDENCE W6P2 H11,Governor,,R,Sam Brownback,133
-Montgomery,INDEPENDENCE W6P2 H12,Governor,,R,Sam Brownback,48
-Montgomery,INDEPENDENCE W6P2 H11A,Governor,,R,Sam Brownback,58
-Montgomery,INDEPENDENCE W6P2 H12A,Governor,,R,Sam Brownback,6
-Montgomery,CANEY-HAVANA,Governor,,R,Sam Brownback,168
-Montgomery,CANEY-TYRO,Governor,,R,Sam Brownback,197
-Montgomery,CHEROKEE,Governor,,R,Sam Brownback,79
-Montgomery,CHERRY,Governor,,R,Sam Brownback,125
-Montgomery,DRUM CREEK ,Governor,,R,Sam Brownback,159
-Montgomery,FAWN CREEK-DEARING,Governor,,R,Sam Brownback,373
-Montgomery,FAWN CREEK-TYRO,Governor,,R,Sam Brownback,115
-Montgomery,INDEPENDENCE TWP 1 H11,Governor,,R,Sam Brownback,373
-Montgomery,INDEPENDENCE TWP 1 H12,Governor,,R,Sam Brownback,58
-Montgomery,INDEPENDENCE TWP 2 A H12,Governor,,R,Sam Brownback,94
-Montgomery,INDEPENDENCE TWP 2 C H11,Governor,,R,Sam Brownback,20
-Montgomery,LIBERTY,Governor,,R,Sam Brownback,125
-Montgomery,LOUISBURG,Governor,,R,Sam Brownback,122
-Montgomery,PARKER 1,Governor,,R,Sam Brownback,58
-Montgomery,PARKER 2,Governor,,R,Sam Brownback,171
-Montgomery,PARKER 2 EX H11,Governor,,R,Sam Brownback,5
-Montgomery,RUTLAND,Governor,,R,Sam Brownback,99
-Montgomery,SYCAMORE,Governor,,R,Sam Brownback,240
-Montgomery,WEST CHERRY,Governor,,R,Sam Brownback,76
-Montgomery,CANEY W1P1,Governor,,D,Paul Davis,32
-Montgomery,CANEY W1P2 H12,Governor,,D,Paul Davis,1
-Montgomery,CANEY W2P1,Governor,,D,Paul Davis,28
-Montgomery,CANEY W3P1,Governor,,D,Paul Davis,19
-Montgomery,CANEY W3P2,Governor,,D,Paul Davis,0
-Montgomery,CANEY W4P1,Governor,,D,Paul Davis,27
-Montgomery,CANEY W4P2,Governor,,D,Paul Davis,0
-Montgomery,CHERRYVALE 1,Governor,,D,Paul Davis,107
-Montgomery,CHERRYVALE 2,Governor,,D,Paul Davis,89
-Montgomery,COFFEYVILLE 1,Governor,,D,Paul Davis,23
-Montgomery,COFFEYVILLE 2,Governor,,D,Paul Davis,37
-Montgomery,COFFEYVILLE 3,Governor,,D,Paul Davis,54
-Montgomery,COFFEYVILLE 4,Governor,,D,Paul Davis,53
-Montgomery,COFFEYVILLE 5,Governor,,D,Paul Davis,85
-Montgomery,COFFEYVILLE 6,Governor,,D,Paul Davis,27
-Montgomery,COFFEYVILLE 7,Governor,,D,Paul Davis,35
-Montgomery,COFFEYVILLE 8,Governor,,D,Paul Davis,50
-Montgomery,COFFEYVILLE 9,Governor,,D,Paul Davis,16
-Montgomery,COFFEYVILLE 10,Governor,,D,Paul Davis,42
-Montgomery,COFFEYVILLE 11,Governor,,D,Paul Davis,112
-Montgomery,COFFEYVILLE 12,Governor,,D,Paul Davis,141
-Montgomery,COFFEYVILLE 13,Governor,,D,Paul Davis,124
-Montgomery,INDEPENDENCE W1P1,Governor,,D,Paul Davis,52
-Montgomery,INDEPENDENCE W1P2,Governor,,D,Paul Davis,66
-Montgomery,INDEPENDENCE W2P1,Governor,,D,Paul Davis,39
-Montgomery,INDEPENDENCE W2P2,Governor,,D,Paul Davis,24
-Montgomery,INDEPENDENCE W3P1,Governor,,D,Paul Davis,49
-Montgomery,INDEPENDENCE W3P2,Governor,,D,Paul Davis,32
-Montgomery,INDEPENDENCE W3P2 EX,Governor,,D,Paul Davis,0
-Montgomery,INDEPENDENCE W4P1,Governor,,D,Paul Davis,68
-Montgomery,INDEPENDENCE W4P2,Governor,,D,Paul Davis,37
-Montgomery,INDEPENDENCE W5P1,Governor,,D,Paul Davis,36
-Montgomery,INDEPENDENCE W5P2,Governor,,D,Paul Davis,94
-Montgomery,INDEPENDENCE W6P1 H11,Governor,,D,Paul Davis,9
-Montgomery,INDEPENDENCE W6P1 H12,Governor,,D,Paul Davis,103
-Montgomery,INDEPENDENCE W6P2 H11,Governor,,D,Paul Davis,88
-Montgomery,INDEPENDENCE W6P2 H12,Governor,,D,Paul Davis,22
-Montgomery,INDEPENDENCE W6P2 H11A,Governor,,D,Paul Davis,50
-Montgomery,INDEPENDENCE W6P2 H12A,Governor,,D,Paul Davis,3
-Montgomery,CANEY-HAVANA,Governor,,D,Paul Davis,38
-Montgomery,CANEY-TYRO,Governor,,D,Paul Davis,39
-Montgomery,CHEROKEE,Governor,,D,Paul Davis,41
-Montgomery,CHERRY,Governor,,D,Paul Davis,49
-Montgomery,DRUM CREEK ,Governor,,D,Paul Davis,44
-Montgomery,FAWN CREEK-DEARING,Governor,,D,Paul Davis,140
-Montgomery,FAWN CREEK-TYRO,Governor,,D,Paul Davis,24
-Montgomery,INDEPENDENCE TWP 1 H11,Governor,,D,Paul Davis,141
-Montgomery,INDEPENDENCE TWP 1 H12,Governor,,D,Paul Davis,24
-Montgomery,INDEPENDENCE TWP 2 A H12,Governor,,D,Paul Davis,38
-Montgomery,INDEPENDENCE TWP 2 C H11,Governor,,D,Paul Davis,19
-Montgomery,LIBERTY,Governor,,D,Paul Davis,49
-Montgomery,LOUISBURG,Governor,,D,Paul Davis,43
-Montgomery,PARKER 1,Governor,,D,Paul Davis,32
-Montgomery,PARKER 2,Governor,,D,Paul Davis,126
-Montgomery,PARKER 2 EX H11,Governor,,D,Paul Davis,3
-Montgomery,RUTLAND,Governor,,D,Paul Davis,24
-Montgomery,SYCAMORE,Governor,,D,Paul Davis,77
-Montgomery,WEST CHERRY,Governor,,D,Paul Davis,28
-Montgomery,CANEY W1P1,Governor,,L,Keen Umbehr,3
-Montgomery,CANEY W1P2 H12,Governor,,L,Keen Umbehr,0
-Montgomery,CANEY W2P1,Governor,,L,Keen Umbehr,9
-Montgomery,CANEY W3P1,Governor,,L,Keen Umbehr,7
-Montgomery,CANEY W3P2,Governor,,L,Keen Umbehr,0
-Montgomery,CANEY W4P1,Governor,,L,Keen Umbehr,8
-Montgomery,CANEY W4P2,Governor,,L,Keen Umbehr,0
-Montgomery,CHERRYVALE 1,Governor,,L,Keen Umbehr,19
-Montgomery,CHERRYVALE 2,Governor,,L,Keen Umbehr,7
-Montgomery,COFFEYVILLE 1,Governor,,L,Keen Umbehr,0
-Montgomery,COFFEYVILLE 2,Governor,,L,Keen Umbehr,1
-Montgomery,COFFEYVILLE 3,Governor,,L,Keen Umbehr,4
-Montgomery,COFFEYVILLE 4,Governor,,L,Keen Umbehr,4
-Montgomery,COFFEYVILLE 5,Governor,,L,Keen Umbehr,9
-Montgomery,COFFEYVILLE 6,Governor,,L,Keen Umbehr,4
-Montgomery,COFFEYVILLE 7,Governor,,L,Keen Umbehr,5
-Montgomery,COFFEYVILLE 8,Governor,,L,Keen Umbehr,5
-Montgomery,COFFEYVILLE 9,Governor,,L,Keen Umbehr,1
-Montgomery,COFFEYVILLE 10,Governor,,L,Keen Umbehr,6
-Montgomery,COFFEYVILLE 11,Governor,,L,Keen Umbehr,10
-Montgomery,COFFEYVILLE 12,Governor,,L,Keen Umbehr,13
-Montgomery,COFFEYVILLE 13,Governor,,L,Keen Umbehr,7
-Montgomery,INDEPENDENCE W1P1,Governor,,L,Keen Umbehr,2
-Montgomery,INDEPENDENCE W1P2,Governor,,L,Keen Umbehr,13
-Montgomery,INDEPENDENCE W2P1,Governor,,L,Keen Umbehr,2
-Montgomery,INDEPENDENCE W2P2,Governor,,L,Keen Umbehr,0
-Montgomery,INDEPENDENCE W3P1,Governor,,L,Keen Umbehr,6
-Montgomery,INDEPENDENCE W3P2,Governor,,L,Keen Umbehr,6
-Montgomery,INDEPENDENCE W3P2 EX,Governor,,L,Keen Umbehr,0
-Montgomery,INDEPENDENCE W4P1,Governor,,L,Keen Umbehr,7
-Montgomery,INDEPENDENCE W4P2,Governor,,L,Keen Umbehr,10
-Montgomery,INDEPENDENCE W5P1,Governor,,L,Keen Umbehr,5
-Montgomery,INDEPENDENCE W5P2,Governor,,L,Keen Umbehr,11
-Montgomery,INDEPENDENCE W6P1 H11,Governor,,L,Keen Umbehr,1
-Montgomery,INDEPENDENCE W6P1 H12,Governor,,L,Keen Umbehr,9
-Montgomery,INDEPENDENCE W6P2 H11,Governor,,L,Keen Umbehr,10
-Montgomery,INDEPENDENCE W6P2 H12,Governor,,L,Keen Umbehr,3
-Montgomery,INDEPENDENCE W6P2 H11A,Governor,,L,Keen Umbehr,3
-Montgomery,INDEPENDENCE W6P2 H12A,Governor,,L,Keen Umbehr,0
-Montgomery,CANEY-HAVANA,Governor,,L,Keen Umbehr,7
-Montgomery,CANEY-TYRO,Governor,,L,Keen Umbehr,8
-Montgomery,CHEROKEE,Governor,,L,Keen Umbehr,8
-Montgomery,CHERRY,Governor,,L,Keen Umbehr,13
-Montgomery,DRUM CREEK ,Governor,,L,Keen Umbehr,6
-Montgomery,FAWN CREEK-DEARING,Governor,,L,Keen Umbehr,22
-Montgomery,FAWN CREEK-TYRO,Governor,,L,Keen Umbehr,7
-Montgomery,INDEPENDENCE TWP 1 H11,Governor,,L,Keen Umbehr,19
-Montgomery,INDEPENDENCE TWP 1 H12,Governor,,L,Keen Umbehr,10
-Montgomery,INDEPENDENCE TWP 2 A H12,Governor,,L,Keen Umbehr,2
-Montgomery,INDEPENDENCE TWP 2 C H11,Governor,,L,Keen Umbehr,1
-Montgomery,LIBERTY,Governor,,L,Keen Umbehr,12
-Montgomery,LOUISBURG,Governor,,L,Keen Umbehr,4
-Montgomery,PARKER 1,Governor,,L,Keen Umbehr,2
-Montgomery,PARKER 2,Governor,,L,Keen Umbehr,17
-Montgomery,PARKER 2 EX H11,Governor,,L,Keen Umbehr,2
-Montgomery,RUTLAND,Governor,,L,Keen Umbehr,6
-Montgomery,SYCAMORE,Governor,,L,Keen Umbehr,9
-Montgomery,WEST CHERRY,Governor,,L,Keen Umbehr,0
-Montgomery,CANEY W1P1,Secretary of State,,R,Kris Kobach,83
-Montgomery,CANEY W1P2 H12,Secretary of State,,R,Kris Kobach,2
-Montgomery,CANEY W2P1,Secretary of State,,R,Kris Kobach,74
-Montgomery,CANEY W3P1,Secretary of State,,R,Kris Kobach,93
-Montgomery,CANEY W3P2,Secretary of State,,R,Kris Kobach,2
-Montgomery,CANEY W4P1,Secretary of State,,R,Kris Kobach,110
-Montgomery,CANEY W4P2,Secretary of State,,R,Kris Kobach,1
-Montgomery,CHERRYVALE 1,Secretary of State,,R,Kris Kobach,196
-Montgomery,CHERRYVALE 2,Secretary of State,,R,Kris Kobach,154
-Montgomery,COFFEYVILLE 1,Secretary of State,,R,Kris Kobach,4
-Montgomery,COFFEYVILLE 2,Secretary of State,,R,Kris Kobach,44
-Montgomery,COFFEYVILLE 3,Secretary of State,,R,Kris Kobach,58
-Montgomery,COFFEYVILLE 4,Secretary of State,,R,Kris Kobach,96
-Montgomery,COFFEYVILLE 5,Secretary of State,,R,Kris Kobach,111
-Montgomery,COFFEYVILLE 6,Secretary of State,,R,Kris Kobach,32
-Montgomery,COFFEYVILLE 7,Secretary of State,,R,Kris Kobach,46
-Montgomery,COFFEYVILLE 8,Secretary of State,,R,Kris Kobach,56
-Montgomery,COFFEYVILLE 9,Secretary of State,,R,Kris Kobach,15
-Montgomery,COFFEYVILLE 10,Secretary of State,,R,Kris Kobach,62
-Montgomery,COFFEYVILLE 11,Secretary of State,,R,Kris Kobach,159
-Montgomery,COFFEYVILLE 12,Secretary of State,,R,Kris Kobach,246
-Montgomery,COFFEYVILLE 13,Secretary of State,,R,Kris Kobach,206
-Montgomery,INDEPENDENCE W1P1,Secretary of State,,R,Kris Kobach,54
-Montgomery,INDEPENDENCE W1P2,Secretary of State,,R,Kris Kobach,127
-Montgomery,INDEPENDENCE W2P1,Secretary of State,,R,Kris Kobach,55
-Montgomery,INDEPENDENCE W2P2,Secretary of State,,R,Kris Kobach,38
-Montgomery,INDEPENDENCE W3P1,Secretary of State,,R,Kris Kobach,103
-Montgomery,INDEPENDENCE W3P2,Secretary of State,,R,Kris Kobach,53
-Montgomery,INDEPENDENCE W3P2 EX,Secretary of State,,R,Kris Kobach,1
-Montgomery,INDEPENDENCE W4P1,Secretary of State,,R,Kris Kobach,107
-Montgomery,INDEPENDENCE W4P2,Secretary of State,,R,Kris Kobach,69
-Montgomery,INDEPENDENCE W5P1,Secretary of State,,R,Kris Kobach,68
-Montgomery,INDEPENDENCE W5P2,Secretary of State,,R,Kris Kobach,123
-Montgomery,INDEPENDENCE W6P1 H11,Secretary of State,,R,Kris Kobach,13
-Montgomery,INDEPENDENCE W6P1 H12,Secretary of State,,R,Kris Kobach,177
-Montgomery,INDEPENDENCE W6P2 H11,Secretary of State,,R,Kris Kobach,161
-Montgomery,INDEPENDENCE W6P2 H12,Secretary of State,,R,Kris Kobach,57
-Montgomery,INDEPENDENCE W6P2 H11A,Secretary of State,,R,Kris Kobach,61
-Montgomery,INDEPENDENCE W6P2 H12A,Secretary of State,,R,Kris Kobach,6
-Montgomery,CANEY-HAVANA,Secretary of State,,R,Kris Kobach,172
-Montgomery,CANEY-TYRO,Secretary of State,,R,Kris Kobach,204
-Montgomery,CHEROKEE,Secretary of State,,R,Kris Kobach,84
-Montgomery,CHERRY,Secretary of State,,R,Kris Kobach,136
-Montgomery,DRUM CREEK ,Secretary of State,,R,Kris Kobach,163
-Montgomery,FAWN CREEK-DEARING,Secretary of State,,R,Kris Kobach,394
-Montgomery,FAWN CREEK-TYRO,Secretary of State,,R,Kris Kobach,120
-Montgomery,INDEPENDENCE TWP 1 H11,Secretary of State,,R,Kris Kobach,412
-Montgomery,INDEPENDENCE TWP 1 H12,Secretary of State,,R,Kris Kobach,71
-Montgomery,INDEPENDENCE TWP 2 A H12,Secretary of State,,R,Kris Kobach,95
-Montgomery,INDEPENDENCE TWP 2 C H11,Secretary of State,,R,Kris Kobach,32
-Montgomery,LIBERTY,Secretary of State,,R,Kris Kobach,134
-Montgomery,LOUISBURG,Secretary of State,,R,Kris Kobach,127
-Montgomery,PARKER 1,Secretary of State,,R,Kris Kobach,59
-Montgomery,PARKER 2,Secretary of State,,R,Kris Kobach,184
-Montgomery,PARKER 2 EX H11,Secretary of State,,R,Kris Kobach,5
-Montgomery,RUTLAND,Secretary of State,,R,Kris Kobach,105
-Montgomery,SYCAMORE,Secretary of State,,R,Kris Kobach,252
-Montgomery,WEST CHERRY,Secretary of State,,R,Kris Kobach,79
-Montgomery,CANEY W1P1,Secretary of State,,D,Jean Schodorf,31
-Montgomery,CANEY W1P2 H12,Secretary of State,,D,Jean Schodorf,1
-Montgomery,CANEY W2P1,Secretary of State,,D,Jean Schodorf,26
-Montgomery,CANEY W3P1,Secretary of State,,D,Jean Schodorf,25
-Montgomery,CANEY W3P2,Secretary of State,,D,Jean Schodorf,0
-Montgomery,CANEY W4P1,Secretary of State,,D,Jean Schodorf,29
-Montgomery,CANEY W4P2,Secretary of State,,D,Jean Schodorf,0
-Montgomery,CHERRYVALE 1,Secretary of State,,D,Jean Schodorf,103
-Montgomery,CHERRYVALE 2,Secretary of State,,D,Jean Schodorf,73
-Montgomery,COFFEYVILLE 1,Secretary of State,,D,Jean Schodorf,23
-Montgomery,COFFEYVILLE 2,Secretary of State,,D,Jean Schodorf,36
-Montgomery,COFFEYVILLE 3,Secretary of State,,D,Jean Schodorf,61
-Montgomery,COFFEYVILLE 4,Secretary of State,,D,Jean Schodorf,50
-Montgomery,COFFEYVILLE 5,Secretary of State,,D,Jean Schodorf,77
-Montgomery,COFFEYVILLE 6,Secretary of State,,D,Jean Schodorf,27
-Montgomery,COFFEYVILLE 7,Secretary of State,,D,Jean Schodorf,30
-Montgomery,COFFEYVILLE 8,Secretary of State,,D,Jean Schodorf,43
-Montgomery,COFFEYVILLE 9,Secretary of State,,D,Jean Schodorf,19
-Montgomery,COFFEYVILLE 10,Secretary of State,,D,Jean Schodorf,42
-Montgomery,COFFEYVILLE 11,Secretary of State,,D,Jean Schodorf,102
-Montgomery,COFFEYVILLE 12,Secretary of State,,D,Jean Schodorf,123
-Montgomery,COFFEYVILLE 13,Secretary of State,,D,Jean Schodorf,106
-Montgomery,INDEPENDENCE W1P1,Secretary of State,,D,Jean Schodorf,55
-Montgomery,INDEPENDENCE W1P2,Secretary of State,,D,Jean Schodorf,68
-Montgomery,INDEPENDENCE W2P1,Secretary of State,,D,Jean Schodorf,25
-Montgomery,INDEPENDENCE W2P2,Secretary of State,,D,Jean Schodorf,23
-Montgomery,INDEPENDENCE W3P1,Secretary of State,,D,Jean Schodorf,52
-Montgomery,INDEPENDENCE W3P2,Secretary of State,,D,Jean Schodorf,31
-Montgomery,INDEPENDENCE W3P2 EX,Secretary of State,,D,Jean Schodorf,0
-Montgomery,INDEPENDENCE W4P1,Secretary of State,,D,Jean Schodorf,66
-Montgomery,INDEPENDENCE W4P2,Secretary of State,,D,Jean Schodorf,41
-Montgomery,INDEPENDENCE W5P1,Secretary of State,,D,Jean Schodorf,35
-Montgomery,INDEPENDENCE W5P2,Secretary of State,,D,Jean Schodorf,84
-Montgomery,INDEPENDENCE W6P1 H11,Secretary of State,,D,Jean Schodorf,7
-Montgomery,INDEPENDENCE W6P1 H12,Secretary of State,,D,Jean Schodorf,105
-Montgomery,INDEPENDENCE W6P2 H11,Secretary of State,,D,Jean Schodorf,66
-Montgomery,INDEPENDENCE W6P2 H12,Secretary of State,,D,Jean Schodorf,17
-Montgomery,INDEPENDENCE W6P2 H11A,Secretary of State,,D,Jean Schodorf,48
-Montgomery,INDEPENDENCE W6P2 H12A,Secretary of State,,D,Jean Schodorf,3
-Montgomery,CANEY-HAVANA,Secretary of State,,D,Jean Schodorf,39
-Montgomery,CANEY-TYRO,Secretary of State,,D,Jean Schodorf,37
-Montgomery,CHEROKEE,Secretary of State,,D,Jean Schodorf,40
-Montgomery,CHERRY,Secretary of State,,D,Jean Schodorf,48
-Montgomery,DRUM CREEK ,Secretary of State,,D,Jean Schodorf,44
-Montgomery,FAWN CREEK-DEARING,Secretary of State,,D,Jean Schodorf,139
-Montgomery,FAWN CREEK-TYRO,Secretary of State,,D,Jean Schodorf,23
-Montgomery,INDEPENDENCE TWP 1 H11,Secretary of State,,D,Jean Schodorf,115
-Montgomery,INDEPENDENCE TWP 1 H12,Secretary of State,,D,Jean Schodorf,20
-Montgomery,INDEPENDENCE TWP 2 A H12,Secretary of State,,D,Jean Schodorf,41
-Montgomery,INDEPENDENCE TWP 2 C H11,Secretary of State,,D,Jean Schodorf,8
-Montgomery,LIBERTY,Secretary of State,,D,Jean Schodorf,52
-Montgomery,LOUISBURG,Secretary of State,,D,Jean Schodorf,39
-Montgomery,PARKER 1,Secretary of State,,D,Jean Schodorf,30
-Montgomery,PARKER 2,Secretary of State,,D,Jean Schodorf,122
-Montgomery,PARKER 2 EX H11,Secretary of State,,D,Jean Schodorf,4
-Montgomery,RUTLAND,Secretary of State,,D,Jean Schodorf,24
-Montgomery,SYCAMORE,Secretary of State,,D,Jean Schodorf,70
-Montgomery,WEST CHERRY,Secretary of State,,D,Jean Schodorf,23
-Montgomery,CANEY W1P1,Attorney General,,R,Derek Schmidt,96
-Montgomery,CANEY W1P2 H12,Attorney General,,R,Derek Schmidt,4
-Montgomery,CANEY W2P1,Attorney General,,R,Derek Schmidt,79
-Montgomery,CANEY W3P1,Attorney General,,R,Derek Schmidt,103
-Montgomery,CANEY W3P2,Attorney General,,R,Derek Schmidt,2
-Montgomery,CANEY W4P1,Attorney General,,R,Derek Schmidt,129
-Montgomery,CANEY W4P2,Attorney General,,R,Derek Schmidt,1
-Montgomery,CHERRYVALE 1,Attorney General,,R,Derek Schmidt,235
-Montgomery,CHERRYVALE 2,Attorney General,,R,Derek Schmidt,174
-Montgomery,COFFEYVILLE 1,Attorney General,,R,Derek Schmidt,5
-Montgomery,COFFEYVILLE 2,Attorney General,,R,Derek Schmidt,56
-Montgomery,COFFEYVILLE 3,Attorney General,,R,Derek Schmidt,78
-Montgomery,COFFEYVILLE 4,Attorney General,,R,Derek Schmidt,109
-Montgomery,COFFEYVILLE 5,Attorney General,,R,Derek Schmidt,129
-Montgomery,COFFEYVILLE 6,Attorney General,,R,Derek Schmidt,35
-Montgomery,COFFEYVILLE 7,Attorney General,,R,Derek Schmidt,55
-Montgomery,COFFEYVILLE 8,Attorney General,,R,Derek Schmidt,67
-Montgomery,COFFEYVILLE 9,Attorney General,,R,Derek Schmidt,18
-Montgomery,COFFEYVILLE 10,Attorney General,,R,Derek Schmidt,68
-Montgomery,COFFEYVILLE 11,Attorney General,,R,Derek Schmidt,181
-Montgomery,COFFEYVILLE 12,Attorney General,,R,Derek Schmidt,273
-Montgomery,COFFEYVILLE 13,Attorney General,,R,Derek Schmidt,255
-Montgomery,INDEPENDENCE W1P1,Attorney General,,R,Derek Schmidt,94
-Montgomery,INDEPENDENCE W1P2,Attorney General,,R,Derek Schmidt,167
-Montgomery,INDEPENDENCE W2P1,Attorney General,,R,Derek Schmidt,62
-Montgomery,INDEPENDENCE W2P2,Attorney General,,R,Derek Schmidt,46
-Montgomery,INDEPENDENCE W3P1,Attorney General,,R,Derek Schmidt,133
-Montgomery,INDEPENDENCE W3P2,Attorney General,,R,Derek Schmidt,71
-Montgomery,INDEPENDENCE W3P2 EX,Attorney General,,R,Derek Schmidt,1
-Montgomery,INDEPENDENCE W4P1,Attorney General,,R,Derek Schmidt,136
-Montgomery,INDEPENDENCE W4P2,Attorney General,,R,Derek Schmidt,87
-Montgomery,INDEPENDENCE W5P1,Attorney General,,R,Derek Schmidt,82
-Montgomery,INDEPENDENCE W5P2,Attorney General,,R,Derek Schmidt,169
-Montgomery,INDEPENDENCE W6P1 H11,Attorney General,,R,Derek Schmidt,18
-Montgomery,INDEPENDENCE W6P1 H12,Attorney General,,R,Derek Schmidt,246
-Montgomery,INDEPENDENCE W6P2 H11,Attorney General,,R,Derek Schmidt,212
-Montgomery,INDEPENDENCE W6P2 H12,Attorney General,,R,Derek Schmidt,65
-Montgomery,INDEPENDENCE W6P2 H11A,Attorney General,,R,Derek Schmidt,86
-Montgomery,INDEPENDENCE W6P2 H12A,Attorney General,,R,Derek Schmidt,8
-Montgomery,CANEY-HAVANA,Attorney General,,R,Derek Schmidt,190
-Montgomery,CANEY-TYRO,Attorney General,,R,Derek Schmidt,220
-Montgomery,CHEROKEE,Attorney General,,R,Derek Schmidt,101
-Montgomery,CHERRY,Attorney General,,R,Derek Schmidt,154
-Montgomery,DRUM CREEK ,Attorney General,,R,Derek Schmidt,186
-Montgomery,FAWN CREEK-DEARING,Attorney General,,R,Derek Schmidt,442
-Montgomery,FAWN CREEK-TYRO,Attorney General,,R,Derek Schmidt,133
-Montgomery,INDEPENDENCE TWP 1 H11,Attorney General,,R,Derek Schmidt,461
-Montgomery,INDEPENDENCE TWP 1 H12,Attorney General,,R,Derek Schmidt,79
-Montgomery,INDEPENDENCE TWP 2 A H12,Attorney General,,R,Derek Schmidt,125
-Montgomery,INDEPENDENCE TWP 2 C H11,Attorney General,,R,Derek Schmidt,36
-Montgomery,LIBERTY,Attorney General,,R,Derek Schmidt,158
-Montgomery,LOUISBURG,Attorney General,,R,Derek Schmidt,145
-Montgomery,PARKER 1,Attorney General,,R,Derek Schmidt,68
-Montgomery,PARKER 2,Attorney General,,R,Derek Schmidt,230
-Montgomery,PARKER 2 EX H11,Attorney General,,R,Derek Schmidt,6
-Montgomery,RUTLAND,Attorney General,,R,Derek Schmidt,117
-Montgomery,SYCAMORE,Attorney General,,R,Derek Schmidt,292
-Montgomery,WEST CHERRY,Attorney General,,R,Derek Schmidt,82
-Montgomery,CANEY W1P1,Attorney General,,D,AJ Kotich,15
-Montgomery,CANEY W1P2 H12,Attorney General,,D,AJ Kotich,0
-Montgomery,CANEY W2P1,Attorney General,,D,AJ Kotich,21
-Montgomery,CANEY W3P1,Attorney General,,D,AJ Kotich,16
-Montgomery,CANEY W3P2,Attorney General,,D,AJ Kotich,0
-Montgomery,CANEY W4P1,Attorney General,,D,AJ Kotich,11
-Montgomery,CANEY W4P2,Attorney General,,D,AJ Kotich,0
-Montgomery,CHERRYVALE 1,Attorney General,,D,AJ Kotich,64
-Montgomery,CHERRYVALE 2,Attorney General,,D,AJ Kotich,51
-Montgomery,COFFEYVILLE 1,Attorney General,,D,AJ Kotich,22
-Montgomery,COFFEYVILLE 2,Attorney General,,D,AJ Kotich,24
-Montgomery,COFFEYVILLE 3,Attorney General,,D,AJ Kotich,45
-Montgomery,COFFEYVILLE 4,Attorney General,,D,AJ Kotich,39
-Montgomery,COFFEYVILLE 5,Attorney General,,D,AJ Kotich,58
-Montgomery,COFFEYVILLE 6,Attorney General,,D,AJ Kotich,23
-Montgomery,COFFEYVILLE 7,Attorney General,,D,AJ Kotich,22
-Montgomery,COFFEYVILLE 8,Attorney General,,D,AJ Kotich,34
-Montgomery,COFFEYVILLE 9,Attorney General,,D,AJ Kotich,16
-Montgomery,COFFEYVILLE 10,Attorney General,,D,AJ Kotich,34
-Montgomery,COFFEYVILLE 11,Attorney General,,D,AJ Kotich,80
-Montgomery,COFFEYVILLE 12,Attorney General,,D,AJ Kotich,99
-Montgomery,COFFEYVILLE 13,Attorney General,,D,AJ Kotich,62
-Montgomery,INDEPENDENCE W1P1,Attorney General,,D,AJ Kotich,14
-Montgomery,INDEPENDENCE W1P2,Attorney General,,D,AJ Kotich,29
-Montgomery,INDEPENDENCE W2P1,Attorney General,,D,AJ Kotich,19
-Montgomery,INDEPENDENCE W2P2,Attorney General,,D,AJ Kotich,18
-Montgomery,INDEPENDENCE W3P1,Attorney General,,D,AJ Kotich,20
-Montgomery,INDEPENDENCE W3P2,Attorney General,,D,AJ Kotich,16
-Montgomery,INDEPENDENCE W3P2 EX,Attorney General,,D,AJ Kotich,0
-Montgomery,INDEPENDENCE W4P1,Attorney General,,D,AJ Kotich,37
-Montgomery,INDEPENDENCE W4P2,Attorney General,,D,AJ Kotich,20
-Montgomery,INDEPENDENCE W5P1,Attorney General,,D,AJ Kotich,21
-Montgomery,INDEPENDENCE W5P2,Attorney General,,D,AJ Kotich,40
-Montgomery,INDEPENDENCE W6P1 H11,Attorney General,,D,AJ Kotich,3
-Montgomery,INDEPENDENCE W6P1 H12,Attorney General,,D,AJ Kotich,40
-Montgomery,INDEPENDENCE W6P2 H11,Attorney General,,D,AJ Kotich,17
-Montgomery,INDEPENDENCE W6P2 H12,Attorney General,,D,AJ Kotich,9
-Montgomery,INDEPENDENCE W6P2 H11A,Attorney General,,D,AJ Kotich,24
-Montgomery,INDEPENDENCE W6P2 H12A,Attorney General,,D,AJ Kotich,1
-Montgomery,CANEY-HAVANA,Attorney General,,D,AJ Kotich,22
-Montgomery,CANEY-TYRO,Attorney General,,D,AJ Kotich,21
-Montgomery,CHEROKEE,Attorney General,,D,AJ Kotich,26
-Montgomery,CHERRY,Attorney General,,D,AJ Kotich,31
-Montgomery,DRUM CREEK ,Attorney General,,D,AJ Kotich,20
-Montgomery,FAWN CREEK-DEARING,Attorney General,,D,AJ Kotich,94
-Montgomery,FAWN CREEK-TYRO,Attorney General,,D,AJ Kotich,12
-Montgomery,INDEPENDENCE TWP 1 H11,Attorney General,,D,AJ Kotich,67
-Montgomery,INDEPENDENCE TWP 1 H12,Attorney General,,D,AJ Kotich,13
-Montgomery,INDEPENDENCE TWP 2 A H12,Attorney General,,D,AJ Kotich,13
-Montgomery,INDEPENDENCE TWP 2 C H11,Attorney General,,D,AJ Kotich,3
-Montgomery,LIBERTY,Attorney General,,D,AJ Kotich,28
-Montgomery,LOUISBURG,Attorney General,,D,AJ Kotich,24
-Montgomery,PARKER 1,Attorney General,,D,AJ Kotich,23
-Montgomery,PARKER 2,Attorney General,,D,AJ Kotich,82
-Montgomery,PARKER 2 EX H11,Attorney General,,D,AJ Kotich,4
-Montgomery,RUTLAND,Attorney General,,D,AJ Kotich,12
-Montgomery,SYCAMORE,Attorney General,,D,AJ Kotich,30
-Montgomery,WEST CHERRY,Attorney General,,D,AJ Kotich,22
-Montgomery,CANEY W1P1,State Treasurer,,R,Ron Estes,94
-Montgomery,CANEY W1P2 H12,State Treasurer,,R,Ron Estes,2
-Montgomery,CANEY W2P1,State Treasurer,,R,Ron Estes,78
-Montgomery,CANEY W3P1,State Treasurer,,R,Ron Estes,99
-Montgomery,CANEY W3P2,State Treasurer,,R,Ron Estes,2
-Montgomery,CANEY W4P1,State Treasurer,,R,Ron Estes,122
-Montgomery,CANEY W4P2,State Treasurer,,R,Ron Estes,1
-Montgomery,CHERRYVALE 1,State Treasurer,,R,Ron Estes,216
-Montgomery,CHERRYVALE 2,State Treasurer,,R,Ron Estes,170
-Montgomery,COFFEYVILLE 1,State Treasurer,,R,Ron Estes,4
-Montgomery,COFFEYVILLE 2,State Treasurer,,R,Ron Estes,49
-Montgomery,COFFEYVILLE 3,State Treasurer,,R,Ron Estes,69
-Montgomery,COFFEYVILLE 4,State Treasurer,,R,Ron Estes,101
-Montgomery,COFFEYVILLE 5,State Treasurer,,R,Ron Estes,116
-Montgomery,COFFEYVILLE 6,State Treasurer,,R,Ron Estes,34
-Montgomery,COFFEYVILLE 7,State Treasurer,,R,Ron Estes,52
-Montgomery,COFFEYVILLE 8,State Treasurer,,R,Ron Estes,58
-Montgomery,COFFEYVILLE 9,State Treasurer,,R,Ron Estes,17
-Montgomery,COFFEYVILLE 10,State Treasurer,,R,Ron Estes,66
-Montgomery,COFFEYVILLE 11,State Treasurer,,R,Ron Estes,163
-Montgomery,COFFEYVILLE 12,State Treasurer,,R,Ron Estes,260
-Montgomery,COFFEYVILLE 13,State Treasurer,,R,Ron Estes,222
-Montgomery,INDEPENDENCE W1P1,State Treasurer,,R,Ron Estes,72
-Montgomery,INDEPENDENCE W1P2,State Treasurer,,R,Ron Estes,156
-Montgomery,INDEPENDENCE W2P1,State Treasurer,,R,Ron Estes,66
-Montgomery,INDEPENDENCE W2P2,State Treasurer,,R,Ron Estes,44
-Montgomery,INDEPENDENCE W3P1,State Treasurer,,R,Ron Estes,122
-Montgomery,INDEPENDENCE W3P2,State Treasurer,,R,Ron Estes,59
-Montgomery,INDEPENDENCE W3P2 EX,State Treasurer,,R,Ron Estes,1
-Montgomery,INDEPENDENCE W4P1,State Treasurer,,R,Ron Estes,121
-Montgomery,INDEPENDENCE W4P2,State Treasurer,,R,Ron Estes,77
-Montgomery,INDEPENDENCE W5P1,State Treasurer,,R,Ron Estes,78
-Montgomery,INDEPENDENCE W5P2,State Treasurer,,R,Ron Estes,146
-Montgomery,INDEPENDENCE W6P1 H11,State Treasurer,,R,Ron Estes,17
-Montgomery,INDEPENDENCE W6P1 H12,State Treasurer,,R,Ron Estes,206
-Montgomery,INDEPENDENCE W6P2 H11,State Treasurer,,R,Ron Estes,198
-Montgomery,INDEPENDENCE W6P2 H12,State Treasurer,,R,Ron Estes,62
-Montgomery,INDEPENDENCE W6P2 H11A,State Treasurer,,R,Ron Estes,82
-Montgomery,INDEPENDENCE W6P2 H12A,State Treasurer,,R,Ron Estes,7
-Montgomery,CANEY-HAVANA,State Treasurer,,R,Ron Estes,183
-Montgomery,CANEY-TYRO,State Treasurer,,R,Ron Estes,220
-Montgomery,CHEROKEE,State Treasurer,,R,Ron Estes,91
-Montgomery,CHERRY,State Treasurer,,R,Ron Estes,144
-Montgomery,DRUM CREEK ,State Treasurer,,R,Ron Estes,176
-Montgomery,FAWN CREEK-DEARING,State Treasurer,,R,Ron Estes,411
-Montgomery,FAWN CREEK-TYRO,State Treasurer,,R,Ron Estes,126
-Montgomery,INDEPENDENCE TWP 1 H11,State Treasurer,,R,Ron Estes,437
-Montgomery,INDEPENDENCE TWP 1 H12,State Treasurer,,R,Ron Estes,75
-Montgomery,INDEPENDENCE TWP 2 A H12,State Treasurer,,R,Ron Estes,109
-Montgomery,INDEPENDENCE TWP 2 C H11,State Treasurer,,R,Ron Estes,34
-Montgomery,LIBERTY,State Treasurer,,R,Ron Estes,148
-Montgomery,LOUISBURG,State Treasurer,,R,Ron Estes,137
-Montgomery,PARKER 1,State Treasurer,,R,Ron Estes,64
-Montgomery,PARKER 2,State Treasurer,,R,Ron Estes,200
-Montgomery,PARKER 2 EX H11,State Treasurer,,R,Ron Estes,5
-Montgomery,RUTLAND,State Treasurer,,R,Ron Estes,110
-Montgomery,SYCAMORE,State Treasurer,,R,Ron Estes,278
-Montgomery,WEST CHERRY,State Treasurer,,R,Ron Estes,80
-Montgomery,CANEY W1P1,State Treasurer,,D,Carmen Alldritt,20
-Montgomery,CANEY W1P2 H12,State Treasurer,,D,Carmen Alldritt,2
-Montgomery,CANEY W2P1,State Treasurer,,D,Carmen Alldritt,21
-Montgomery,CANEY W3P1,State Treasurer,,D,Carmen Alldritt,18
-Montgomery,CANEY W3P2,State Treasurer,,D,Carmen Alldritt,0
-Montgomery,CANEY W4P1,State Treasurer,,D,Carmen Alldritt,18
-Montgomery,CANEY W4P2,State Treasurer,,D,Carmen Alldritt,0
-Montgomery,CHERRYVALE 1,State Treasurer,,D,Carmen Alldritt,84
-Montgomery,CHERRYVALE 2,State Treasurer,,D,Carmen Alldritt,57
-Montgomery,COFFEYVILLE 1,State Treasurer,,D,Carmen Alldritt,23
-Montgomery,COFFEYVILLE 2,State Treasurer,,D,Carmen Alldritt,30
-Montgomery,COFFEYVILLE 3,State Treasurer,,D,Carmen Alldritt,52
-Montgomery,COFFEYVILLE 4,State Treasurer,,D,Carmen Alldritt,46
-Montgomery,COFFEYVILLE 5,State Treasurer,,D,Carmen Alldritt,71
-Montgomery,COFFEYVILLE 6,State Treasurer,,D,Carmen Alldritt,23
-Montgomery,COFFEYVILLE 7,State Treasurer,,D,Carmen Alldritt,24
-Montgomery,COFFEYVILLE 8,State Treasurer,,D,Carmen Alldritt,42
-Montgomery,COFFEYVILLE 9,State Treasurer,,D,Carmen Alldritt,16
-Montgomery,COFFEYVILLE 10,State Treasurer,,D,Carmen Alldritt,36
-Montgomery,COFFEYVILLE 11,State Treasurer,,D,Carmen Alldritt,93
-Montgomery,COFFEYVILLE 12,State Treasurer,,D,Carmen Alldritt,109
-Montgomery,COFFEYVILLE 13,State Treasurer,,D,Carmen Alldritt,89
-Montgomery,INDEPENDENCE W1P1,State Treasurer,,D,Carmen Alldritt,34
-Montgomery,INDEPENDENCE W1P2,State Treasurer,,D,Carmen Alldritt,39
-Montgomery,INDEPENDENCE W2P1,State Treasurer,,D,Carmen Alldritt,15
-Montgomery,INDEPENDENCE W2P2,State Treasurer,,D,Carmen Alldritt,20
-Montgomery,INDEPENDENCE W3P1,State Treasurer,,D,Carmen Alldritt,30
-Montgomery,INDEPENDENCE W3P2,State Treasurer,,D,Carmen Alldritt,25
-Montgomery,INDEPENDENCE W3P2 EX,State Treasurer,,D,Carmen Alldritt,0
-Montgomery,INDEPENDENCE W4P1,State Treasurer,,D,Carmen Alldritt,51
-Montgomery,INDEPENDENCE W4P2,State Treasurer,,D,Carmen Alldritt,32
-Montgomery,INDEPENDENCE W5P1,State Treasurer,,D,Carmen Alldritt,23
-Montgomery,INDEPENDENCE W5P2,State Treasurer,,D,Carmen Alldritt,61
-Montgomery,INDEPENDENCE W6P1 H11,State Treasurer,,D,Carmen Alldritt,4
-Montgomery,INDEPENDENCE W6P1 H12,State Treasurer,,D,Carmen Alldritt,74
-Montgomery,INDEPENDENCE W6P2 H11,State Treasurer,,D,Carmen Alldritt,27
-Montgomery,INDEPENDENCE W6P2 H12,State Treasurer,,D,Carmen Alldritt,10
-Montgomery,INDEPENDENCE W6P2 H11A,State Treasurer,,D,Carmen Alldritt,25
-Montgomery,INDEPENDENCE W6P2 H12A,State Treasurer,,D,Carmen Alldritt,1
-Montgomery,CANEY-HAVANA,State Treasurer,,D,Carmen Alldritt,28
-Montgomery,CANEY-TYRO,State Treasurer,,D,Carmen Alldritt,19
-Montgomery,CHEROKEE,State Treasurer,,D,Carmen Alldritt,33
-Montgomery,CHERRY,State Treasurer,,D,Carmen Alldritt,36
-Montgomery,DRUM CREEK ,State Treasurer,,D,Carmen Alldritt,30
-Montgomery,FAWN CREEK-DEARING,State Treasurer,,D,Carmen Alldritt,123
-Montgomery,FAWN CREEK-TYRO,State Treasurer,,D,Carmen Alldritt,15
-Montgomery,INDEPENDENCE TWP 1 H11,State Treasurer,,D,Carmen Alldritt,84
-Montgomery,INDEPENDENCE TWP 1 H12,State Treasurer,,D,Carmen Alldritt,17
-Montgomery,INDEPENDENCE TWP 2 A H12,State Treasurer,,D,Carmen Alldritt,27
-Montgomery,INDEPENDENCE TWP 2 C H11,State Treasurer,,D,Carmen Alldritt,6
-Montgomery,LIBERTY,State Treasurer,,D,Carmen Alldritt,36
-Montgomery,LOUISBURG,State Treasurer,,D,Carmen Alldritt,27
-Montgomery,PARKER 1,State Treasurer,,D,Carmen Alldritt,28
-Montgomery,PARKER 2,State Treasurer,,D,Carmen Alldritt,104
-Montgomery,PARKER 2 EX H11,State Treasurer,,D,Carmen Alldritt,5
-Montgomery,RUTLAND,State Treasurer,,D,Carmen Alldritt,19
-Montgomery,SYCAMORE,State Treasurer,,D,Carmen Alldritt,42
-Montgomery,WEST CHERRY,State Treasurer,,D,Carmen Alldritt,23
-Montgomery,CANEY W1P1,Insurance Commissioner,,R,Ken Selzer,87
-Montgomery,CANEY W1P2 H12,Insurance Commissioner,,R,Ken Selzer,2
-Montgomery,CANEY W2P1,Insurance Commissioner,,R,Ken Selzer,74
-Montgomery,CANEY W3P1,Insurance Commissioner,,R,Ken Selzer,98
-Montgomery,CANEY W3P2,Insurance Commissioner,,R,Ken Selzer,2
-Montgomery,CANEY W4P1,Insurance Commissioner,,R,Ken Selzer,120
-Montgomery,CANEY W4P2,Insurance Commissioner,,R,Ken Selzer,1
-Montgomery,CHERRYVALE 1,Insurance Commissioner,,R,Ken Selzer,204
-Montgomery,CHERRYVALE 2,Insurance Commissioner,,R,Ken Selzer,154
-Montgomery,COFFEYVILLE 1,Insurance Commissioner,,R,Ken Selzer,4
-Montgomery,COFFEYVILLE 2,Insurance Commissioner,,R,Ken Selzer,43
-Montgomery,COFFEYVILLE 3,Insurance Commissioner,,R,Ken Selzer,62
-Montgomery,COFFEYVILLE 4,Insurance Commissioner,,R,Ken Selzer,94
-Montgomery,COFFEYVILLE 5,Insurance Commissioner,,R,Ken Selzer,108
-Montgomery,COFFEYVILLE 6,Insurance Commissioner,,R,Ken Selzer,33
-Montgomery,COFFEYVILLE 7,Insurance Commissioner,,R,Ken Selzer,48
-Montgomery,COFFEYVILLE 8,Insurance Commissioner,,R,Ken Selzer,61
-Montgomery,COFFEYVILLE 9,Insurance Commissioner,,R,Ken Selzer,12
-Montgomery,COFFEYVILLE 10,Insurance Commissioner,,R,Ken Selzer,63
-Montgomery,COFFEYVILLE 11,Insurance Commissioner,,R,Ken Selzer,155
-Montgomery,COFFEYVILLE 12,Insurance Commissioner,,R,Ken Selzer,245
-Montgomery,COFFEYVILLE 13,Insurance Commissioner,,R,Ken Selzer,215
-Montgomery,INDEPENDENCE W1P1,Insurance Commissioner,,R,Ken Selzer,67
-Montgomery,INDEPENDENCE W1P2,Insurance Commissioner,,R,Ken Selzer,147
-Montgomery,INDEPENDENCE W2P1,Insurance Commissioner,,R,Ken Selzer,57
-Montgomery,INDEPENDENCE W2P2,Insurance Commissioner,,R,Ken Selzer,41
-Montgomery,INDEPENDENCE W3P1,Insurance Commissioner,,R,Ken Selzer,111
-Montgomery,INDEPENDENCE W3P2,Insurance Commissioner,,R,Ken Selzer,56
-Montgomery,INDEPENDENCE W3P2 EX,Insurance Commissioner,,R,Ken Selzer,1
-Montgomery,INDEPENDENCE W4P1,Insurance Commissioner,,R,Ken Selzer,106
-Montgomery,INDEPENDENCE W4P2,Insurance Commissioner,,R,Ken Selzer,74
-Montgomery,INDEPENDENCE W5P1,Insurance Commissioner,,R,Ken Selzer,74
-Montgomery,INDEPENDENCE W5P2,Insurance Commissioner,,R,Ken Selzer,134
-Montgomery,INDEPENDENCE W6P1 H11,Insurance Commissioner,,R,Ken Selzer,14
-Montgomery,INDEPENDENCE W6P1 H12,Insurance Commissioner,,R,Ken Selzer,189
-Montgomery,INDEPENDENCE W6P2 H11,Insurance Commissioner,,R,Ken Selzer,184
-Montgomery,INDEPENDENCE W6P2 H12,Insurance Commissioner,,R,Ken Selzer,60
-Montgomery,INDEPENDENCE W6P2 H11A,Insurance Commissioner,,R,Ken Selzer,68
-Montgomery,INDEPENDENCE W6P2 H12A,Insurance Commissioner,,R,Ken Selzer,6
-Montgomery,CANEY-HAVANA,Insurance Commissioner,,R,Ken Selzer,177
-Montgomery,CANEY-TYRO,Insurance Commissioner,,R,Ken Selzer,212
-Montgomery,CHEROKEE,Insurance Commissioner,,R,Ken Selzer,87
-Montgomery,CHERRY,Insurance Commissioner,,R,Ken Selzer,135
-Montgomery,DRUM CREEK ,Insurance Commissioner,,R,Ken Selzer,171
-Montgomery,FAWN CREEK-DEARING,Insurance Commissioner,,R,Ken Selzer,382
-Montgomery,FAWN CREEK-TYRO,Insurance Commissioner,,R,Ken Selzer,123
-Montgomery,INDEPENDENCE TWP 1 H11,Insurance Commissioner,,R,Ken Selzer,409
-Montgomery,INDEPENDENCE TWP 1 H12,Insurance Commissioner,,R,Ken Selzer,68
-Montgomery,INDEPENDENCE TWP 2 A H12,Insurance Commissioner,,R,Ken Selzer,96
-Montgomery,INDEPENDENCE TWP 2 C H11,Insurance Commissioner,,R,Ken Selzer,33
-Montgomery,LIBERTY,Insurance Commissioner,,R,Ken Selzer,139
-Montgomery,LOUISBURG,Insurance Commissioner,,R,Ken Selzer,122
-Montgomery,PARKER 1,Insurance Commissioner,,R,Ken Selzer,62
-Montgomery,PARKER 2,Insurance Commissioner,,R,Ken Selzer,191
-Montgomery,PARKER 2 EX H11,Insurance Commissioner,,R,Ken Selzer,4
-Montgomery,RUTLAND,Insurance Commissioner,,R,Ken Selzer,109
-Montgomery,SYCAMORE,Insurance Commissioner,,R,Ken Selzer,266
-Montgomery,WEST CHERRY,Insurance Commissioner,,R,Ken Selzer,75
-Montgomery,CANEY W1P1,Insurance Commissioner,,D,Dennis Anderson,25
-Montgomery,CANEY W1P2 H12,Insurance Commissioner,,D,Dennis Anderson,2
-Montgomery,CANEY W2P1,Insurance Commissioner,,D,Dennis Anderson,24
-Montgomery,CANEY W3P1,Insurance Commissioner,,D,Dennis Anderson,21
-Montgomery,CANEY W3P2,Insurance Commissioner,,D,Dennis Anderson,0
-Montgomery,CANEY W4P1,Insurance Commissioner,,D,Dennis Anderson,17
-Montgomery,CANEY W4P2,Insurance Commissioner,,D,Dennis Anderson,0
-Montgomery,CHERRYVALE 1,Insurance Commissioner,,D,Dennis Anderson,88
-Montgomery,CHERRYVALE 2,Insurance Commissioner,,D,Dennis Anderson,67
-Montgomery,COFFEYVILLE 1,Insurance Commissioner,,D,Dennis Anderson,23
-Montgomery,COFFEYVILLE 2,Insurance Commissioner,,D,Dennis Anderson,37
-Montgomery,COFFEYVILLE 3,Insurance Commissioner,,D,Dennis Anderson,54
-Montgomery,COFFEYVILLE 4,Insurance Commissioner,,D,Dennis Anderson,52
-Montgomery,COFFEYVILLE 5,Insurance Commissioner,,D,Dennis Anderson,77
-Montgomery,COFFEYVILLE 6,Insurance Commissioner,,D,Dennis Anderson,23
-Montgomery,COFFEYVILLE 7,Insurance Commissioner,,D,Dennis Anderson,27
-Montgomery,COFFEYVILLE 8,Insurance Commissioner,,D,Dennis Anderson,40
-Montgomery,COFFEYVILLE 9,Insurance Commissioner,,D,Dennis Anderson,21
-Montgomery,COFFEYVILLE 10,Insurance Commissioner,,D,Dennis Anderson,41
-Montgomery,COFFEYVILLE 11,Insurance Commissioner,,D,Dennis Anderson,96
-Montgomery,COFFEYVILLE 12,Insurance Commissioner,,D,Dennis Anderson,116
-Montgomery,COFFEYVILLE 13,Insurance Commissioner,,D,Dennis Anderson,91
-Montgomery,INDEPENDENCE W1P1,Insurance Commissioner,,D,Dennis Anderson,38
-Montgomery,INDEPENDENCE W1P2,Insurance Commissioner,,D,Dennis Anderson,46
-Montgomery,INDEPENDENCE W2P1,Insurance Commissioner,,D,Dennis Anderson,21
-Montgomery,INDEPENDENCE W2P2,Insurance Commissioner,,D,Dennis Anderson,21
-Montgomery,INDEPENDENCE W3P1,Insurance Commissioner,,D,Dennis Anderson,36
-Montgomery,INDEPENDENCE W3P2,Insurance Commissioner,,D,Dennis Anderson,27
-Montgomery,INDEPENDENCE W3P2 EX,Insurance Commissioner,,D,Dennis Anderson,0
-Montgomery,INDEPENDENCE W4P1,Insurance Commissioner,,D,Dennis Anderson,59
-Montgomery,INDEPENDENCE W4P2,Insurance Commissioner,,D,Dennis Anderson,33
-Montgomery,INDEPENDENCE W5P1,Insurance Commissioner,,D,Dennis Anderson,25
-Montgomery,INDEPENDENCE W5P2,Insurance Commissioner,,D,Dennis Anderson,68
-Montgomery,INDEPENDENCE W6P1 H11,Insurance Commissioner,,D,Dennis Anderson,7
-Montgomery,INDEPENDENCE W6P1 H12,Insurance Commissioner,,D,Dennis Anderson,84
-Montgomery,INDEPENDENCE W6P2 H11,Insurance Commissioner,,D,Dennis Anderson,36
-Montgomery,INDEPENDENCE W6P2 H12,Insurance Commissioner,,D,Dennis Anderson,11
-Montgomery,INDEPENDENCE W6P2 H11A,Insurance Commissioner,,D,Dennis Anderson,36
-Montgomery,INDEPENDENCE W6P2 H12A,Insurance Commissioner,,D,Dennis Anderson,2
-Montgomery,CANEY-HAVANA,Insurance Commissioner,,D,Dennis Anderson,30
-Montgomery,CANEY-TYRO,Insurance Commissioner,,D,Dennis Anderson,25
-Montgomery,CHEROKEE,Insurance Commissioner,,D,Dennis Anderson,34
-Montgomery,CHERRY,Insurance Commissioner,,D,Dennis Anderson,42
-Montgomery,DRUM CREEK ,Insurance Commissioner,,D,Dennis Anderson,33
-Montgomery,FAWN CREEK-DEARING,Insurance Commissioner,,D,Dennis Anderson,128
-Montgomery,FAWN CREEK-TYRO,Insurance Commissioner,,D,Dennis Anderson,16
-Montgomery,INDEPENDENCE TWP 1 H11,Insurance Commissioner,,D,Dennis Anderson,100
-Montgomery,INDEPENDENCE TWP 1 H12,Insurance Commissioner,,D,Dennis Anderson,20
-Montgomery,INDEPENDENCE TWP 2 A H12,Insurance Commissioner,,D,Dennis Anderson,35
-Montgomery,INDEPENDENCE TWP 2 C H11,Insurance Commissioner,,D,Dennis Anderson,5
-Montgomery,LIBERTY,Insurance Commissioner,,D,Dennis Anderson,41
-Montgomery,LOUISBURG,Insurance Commissioner,,D,Dennis Anderson,34
-Montgomery,PARKER 1,Insurance Commissioner,,D,Dennis Anderson,28
-Montgomery,PARKER 2,Insurance Commissioner,,D,Dennis Anderson,108
-Montgomery,PARKER 2 EX H11,Insurance Commissioner,,D,Dennis Anderson,6
-Montgomery,RUTLAND,Insurance Commissioner,,D,Dennis Anderson,16
-Montgomery,SYCAMORE,Insurance Commissioner,,D,Dennis Anderson,50
-Montgomery,WEST CHERRY,Insurance Commissioner,,D,Dennis Anderson,23
-Montgomery,CANEY W1P1,State House,12,R,Virgil Peck,83
-Montgomery,CANEY W1P2 H12,State House,12,R,Virgil Peck,4
-Montgomery,CANEY W2P1,State House,12,R,Virgil Peck,74
-Montgomery,CANEY W3P1,State House,12,R,Virgil Peck,95
-Montgomery,CANEY W3P2,State House,12,R,Virgil Peck,2
-Montgomery,CANEY W4P1,State House,12,R,Virgil Peck,116
-Montgomery,CANEY W4P2,State House,12,R,Virgil Peck,1
-Montgomery,CHERRYVALE 1,State House,11,R,Jim Kelly,268
-Montgomery,CHERRYVALE 2,State House,11,R,Jim Kelly,200
-Montgomery,COFFEYVILLE 1,State House,11,R,Jim Kelly,13
-Montgomery,COFFEYVILLE 2,State House,11,R,Jim Kelly,60
-Montgomery,COFFEYVILLE 3,State House,11,R,Jim Kelly,100
-Montgomery,COFFEYVILLE 4,State House,11,R,Jim Kelly,126
-Montgomery,COFFEYVILLE 5,State House,11,R,Jim Kelly,155
-Montgomery,COFFEYVILLE 6,State House,11,R,Jim Kelly,45
-Montgomery,COFFEYVILLE 7,State House,11,R,Jim Kelly,64
-Montgomery,COFFEYVILLE 8,State House,11,R,Jim Kelly,88
-Montgomery,COFFEYVILLE 9,State House,11,R,Jim Kelly,25
-Montgomery,COFFEYVILLE 10,State House,11,R,Jim Kelly,80
-Montgomery,COFFEYVILLE 11,State House,11,R,Jim Kelly,204
-Montgomery,COFFEYVILLE 12,State House,11,R,Jim Kelly,315
-Montgomery,COFFEYVILLE 13,State House,11,R,Jim Kelly,278
-Montgomery,INDEPENDENCE W1P1,State House,11,R,Jim Kelly,99
-Montgomery,INDEPENDENCE W1P2,State House,11,R,Jim Kelly,174
-Montgomery,INDEPENDENCE W2P1,State House,11,R,Jim Kelly,69
-Montgomery,INDEPENDENCE W2P2,State House,12,R,Virgil Peck,44
-Montgomery,INDEPENDENCE W3P1,State House,11,R,Jim Kelly,136
-Montgomery,INDEPENDENCE W3P2,State House,12,R,Virgil Peck,63
-Montgomery,INDEPENDENCE W3P2 EX,State House,11,R,Jim Kelly,1
-Montgomery,INDEPENDENCE W4P1,State House,11,R,Jim Kelly,160
-Montgomery,INDEPENDENCE W4P2,State House,11,R,Jim Kelly,94
-Montgomery,INDEPENDENCE W5P1,State House,12,R,Virgil Peck,74
-Montgomery,INDEPENDENCE W5P2,State House,12,R,Virgil Peck,141
-Montgomery,INDEPENDENCE W6P1 H11,State House,11,R,Jim Kelly,19
-Montgomery,INDEPENDENCE W6P1 H12,State House,12,R,Virgil Peck,199
-Montgomery,INDEPENDENCE W6P2 H11,State House,11,R,Jim Kelly,219
-Montgomery,INDEPENDENCE W6P2 H12,State House,12,R,Virgil Peck,58
-Montgomery,INDEPENDENCE W6P2 H11A,State House,11,R,Jim Kelly,100
-Montgomery,INDEPENDENCE W6P2 H12A,State House,12,R,Virgil Peck,7
-Montgomery,CANEY-HAVANA,State House,12,R,Virgil Peck,171
-Montgomery,CANEY-TYRO,State House,12,R,Virgil Peck,202
-Montgomery,CHEROKEE,State House,7,R,Richard Proehl,110
-Montgomery,CHERRY,State House,11,R,Jim Kelly,165
-Montgomery,DRUM CREEK ,State House,11,R,Jim Kelly,187
-Montgomery,FAWN CREEK-DEARING,State House,11,R,Jim Kelly,483
-Montgomery,FAWN CREEK-TYRO,State House,12,R,Virgil Peck,123
-Montgomery,INDEPENDENCE TWP 1 H11,State House,11,R,Jim Kelly,487
-Montgomery,INDEPENDENCE TWP 1 H12,State House,12,R,Virgil Peck,68
-Montgomery,INDEPENDENCE TWP 2 A H12,State House,12,R,Virgil Peck,110
-Montgomery,INDEPENDENCE TWP 2 C H11,State House,11,R,Jim Kelly,36
-Montgomery,LIBERTY,State House,7,R,Richard Proehl,160
-Montgomery,LOUISBURG,State House,12,R,Virgil Peck,135
-Montgomery,PARKER 1,State House,7,R,Richard Proehl,72
-Montgomery,PARKER 2,State House,7,R,Richard Proehl,253
-Montgomery,PARKER 2 EX H11,State House,11,R,Jim Kelly,8
-Montgomery,RUTLAND,State House,12,R,Virgil Peck,106
-Montgomery,SYCAMORE,State House,11,R,Jim Kelly,306
-Montgomery,WEST CHERRY,State House,11,R,Jim Kelly,90
-Montgomery,CANEY W1P1,State House,12,D,Eden Fuson,29
-Montgomery,CANEY W2P1,State House,12,D,Eden Fuson,24
-Montgomery,CANEY W3P1,State House,12,D,Eden Fuson,22
-Montgomery,CANEY W4P1,State House,12,D,Eden Fuson,22
-Montgomery,INDEPENDENCE W2P2,State House,12,D,Eden Fuson,20
-Montgomery,INDEPENDENCE W3P2,State House,12,D,Eden Fuson,21
-Montgomery,INDEPENDENCE W5P1,State House,12,D,Eden Fuson,29
-Montgomery,INDEPENDENCE W5P2,State House,12,D,Eden Fuson,68
-Montgomery,INDEPENDENCE W6P1 H12,State House,12,D,Eden Fuson,84
-Montgomery,INDEPENDENCE W6P2 H12,State House,12,D,Eden Fuson,14
-Montgomery,INDEPENDENCE W6P2 H12A,State House,12,D,Eden Fuson,3
-Montgomery,CANEY-HAVANA,State House,12,D,Eden Fuson,38
-Montgomery,CANEY-TYRO,State House,12,D,Eden Fuson,37
-Montgomery,FAWN CREEK-TYRO,State House,12,D,Eden Fuson,22
-Montgomery,INDEPENDENCE TWP 1 H12,State House,12,D,Eden Fuson,23
-Montgomery,INDEPENDENCE TWP 2 A H12,State House,12,D,Eden Fuson,27
-Montgomery,LOUISBURG,State House,12,D,Eden Fuson,33
-Montgomery,RUTLAND,State House,12,D,Eden Fuson,22
+county,precinct,office,district,party,candidate,votes,vtd
+MONTGOMERY,Caney City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,00001A
+MONTGOMERY,Caney City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,00001A
+MONTGOMERY,Caney City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00001C
+MONTGOMERY,Caney City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000020
+MONTGOMERY,Caney City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000020
+MONTGOMERY,Caney City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000020
+MONTGOMERY,Caney City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000030
+MONTGOMERY,Caney City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000030
+MONTGOMERY,Caney City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,000030
+MONTGOMERY,Caney City Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000040
+MONTGOMERY,Caney City Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000040
+MONTGOMERY,Caney City Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",105,000040
+MONTGOMERY,Caney Township Havana,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,000050
+MONTGOMERY,Caney Township Havana,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000050
+MONTGOMERY,Caney Township Havana,Governor / Lt. Governor,,Republican,"Brownback, Sam",168,000050
+MONTGOMERY,Caney Township Tyro,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000060
+MONTGOMERY,Caney Township Tyro,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000060
+MONTGOMERY,Caney Township Tyro,Governor / Lt. Governor,,Republican,"Brownback, Sam",197,000060
+MONTGOMERY,Cherokee Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000070
+MONTGOMERY,Cherokee Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000070
+MONTGOMERY,Cherokee Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000070
+MONTGOMERY,Cherry Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000080
+MONTGOMERY,Cherry Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000080
+MONTGOMERY,Cherry Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000080
+MONTGOMERY,Cherryvale Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,000090
+MONTGOMERY,Cherryvale Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000090
+MONTGOMERY,Cherryvale Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",175,000090
+MONTGOMERY,Cherryvale Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,000100
+MONTGOMERY,Cherryvale Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000100
+MONTGOMERY,Cherryvale Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",54,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",85,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",95,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Governor / Lt. Governor,,Democratic,"Davis, Paul",112,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Governor / Lt. Governor,,Democratic,"Davis, Paul",141,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Governor / Lt. Governor,,Republican,"Brownback, Sam",217,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Governor / Lt. Governor,,Republican,"Brownback, Sam",189,000230
+MONTGOMERY,Drum Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",44,000240
+MONTGOMERY,Drum Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000240
+MONTGOMERY,Drum Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",159,000240
+MONTGOMERY,Fawn Creek Township Dearing,Governor / Lt. Governor,,Democratic,"Davis, Paul",140,000250
+MONTGOMERY,Fawn Creek Township Dearing,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000250
+MONTGOMERY,Fawn Creek Township Dearing,Governor / Lt. Governor,,Republican,"Brownback, Sam",373,000250
+MONTGOMERY,Fawn Creek Township Tyro,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000260
+MONTGOMERY,Fawn Creek Township Tyro,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000260
+MONTGOMERY,Fawn Creek Township Tyro,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",52,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",68,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",94,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000360
+MONTGOMERY,Independence Township 2 Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,00040C
+MONTGOMERY,Independence Township 2 Part C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,00040C
+MONTGOMERY,Independence Township 2 Part C,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,00040C
+MONTGOMERY,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000410
+MONTGOMERY,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000410
+MONTGOMERY,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000410
+MONTGOMERY,Louisburg Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000420
+MONTGOMERY,Louisburg Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000420
+MONTGOMERY,Louisburg Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",122,000420
+MONTGOMERY,Parker Township 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000430
+MONTGOMERY,Parker Township 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000430
+MONTGOMERY,Parker Township 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000430
+MONTGOMERY,Parker Township 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",126,00044A
+MONTGOMERY,Parker Township 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,00044A
+MONTGOMERY,Parker Township 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",171,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00044C
+MONTGOMERY,Rutland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000450
+MONTGOMERY,Rutland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000450
+MONTGOMERY,Rutland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,000450
+MONTGOMERY,West Cherry Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000470
+MONTGOMERY,West Cherry Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000470
+MONTGOMERY,West Cherry Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Governor / Lt. Governor,,Democratic,"Davis, Paul",103,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Governor / Lt. Governor,,Democratic,"Davis, Paul",88,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",6,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,120050
+MONTGOMERY,Independence Township 1 H11,Governor / Lt. Governor,,Democratic,"Davis, Paul",141,120060
+MONTGOMERY,Independence Township 1 H11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,120060
+MONTGOMERY,Independence Township 1 H11,Governor / Lt. Governor,,Republican,"Brownback, Sam",373,120060
+MONTGOMERY,Independence Township 1 H12,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,120070
+MONTGOMERY,Independence Township 1 H12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,120070
+MONTGOMERY,Independence Township 1 H12,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,120070
+MONTGOMERY,Independence Township 2 Part A H11,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,120090
+MONTGOMERY,Independence Township 2 Part A H12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120090
+MONTGOMERY,Independence Township 2 Part A H12,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,120090
+MONTGOMERY,Sycamore Township H11,Governor / Lt. Governor,,Democratic,"Davis, Paul",77,120100
+MONTGOMERY,Sycamore Township H11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,120100
+MONTGOMERY,Sycamore Township H11,Governor / Lt. Governor,,Republican,"Brownback, Sam",240,120100
+MONTGOMERY,Sycamore Township H12 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12011C
+MONTGOMERY,Sycamore Township H12,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120110
+MONTGOMERY,Sycamore Township H12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120110
+MONTGOMERY,Sycamore Township H12,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120110
+MONTGOMERY,Coffeyville Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+MONTGOMERY,Coffeyville Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+MONTGOMERY,Coffeyville Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,900030
+MONTGOMERY,Parker Township 2 Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,900040
+MONTGOMERY,Parker Township 2 Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,900040
+MONTGOMERY,Parker Township 2 Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,900040
+MONTGOMERY,Independence Township 1 Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+MONTGOMERY,Independence Township 1 Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+MONTGOMERY,Independence Exclave Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900060
+MONTGOMERY,Independence Exclave Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+MONTGOMERY,Independence Exclave Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900060
+MONTGOMERY,Caney City Ward 1,Kansas House of Representatives,12,Democratic,"Fuson, Eden",29,00001A
+MONTGOMERY,Caney City Ward 1,Kansas House of Representatives,12,Republican,"Peck, Virgil",83,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas House of Representatives,12,Republican,"Peck, Virgil",4,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,00001C
+MONTGOMERY,Caney City Ward 2,Kansas House of Representatives,12,Democratic,"Fuson, Eden",24,000020
+MONTGOMERY,Caney City Ward 2,Kansas House of Representatives,12,Republican,"Peck, Virgil",74,000020
+MONTGOMERY,Caney City Ward 3,Kansas House of Representatives,12,Democratic,"Fuson, Eden",22,000030
+MONTGOMERY,Caney City Ward 3,Kansas House of Representatives,12,Republican,"Peck, Virgil",95,000030
+MONTGOMERY,Caney City Ward 4,Kansas House of Representatives,12,Democratic,"Fuson, Eden",22,000040
+MONTGOMERY,Caney City Ward 4,Kansas House of Representatives,12,Republican,"Peck, Virgil",117,000040
+MONTGOMERY,Caney Township Havana,Kansas House of Representatives,12,Democratic,"Fuson, Eden",38,000050
+MONTGOMERY,Caney Township Havana,Kansas House of Representatives,12,Republican,"Peck, Virgil",171,000050
+MONTGOMERY,Caney Township Tyro,Kansas House of Representatives,12,Democratic,"Fuson, Eden",37,000060
+MONTGOMERY,Caney Township Tyro,Kansas House of Representatives,12,Republican,"Peck, Virgil",202,000060
+MONTGOMERY,Cherokee Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",110,000070
+MONTGOMERY,Cherry Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",165,000080
+MONTGOMERY,Cherryvale Ward 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",268,000090
+MONTGOMERY,Cherryvale Ward 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",200,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Kansas House of Representatives,11,Republican,"Kelly, Jim",13,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Kansas House of Representatives,11,Republican,"Kelly, Jim",60,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Kansas House of Representatives,11,Republican,"Kelly, Jim",100,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Kansas House of Representatives,11,Republican,"Kelly, Jim",126,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Kansas House of Representatives,11,Republican,"Kelly, Jim",155,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Kansas House of Representatives,11,Republican,"Kelly, Jim",45,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Kansas House of Representatives,11,Republican,"Kelly, Jim",64,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Kansas House of Representatives,11,Republican,"Kelly, Jim",88,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Kansas House of Representatives,11,Republican,"Kelly, Jim",25,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Kansas House of Representatives,11,Republican,"Kelly, Jim",80,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Kansas House of Representatives,11,Republican,"Kelly, Jim",204,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Kansas House of Representatives,11,Republican,"Kelly, Jim",315,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Kansas House of Representatives,11,Republican,"Kelly, Jim",278,000230
+MONTGOMERY,Drum Creek Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",187,000240
+MONTGOMERY,Fawn Creek Township Dearing,Kansas House of Representatives,11,Republican,"Kelly, Jim",483,000250
+MONTGOMERY,Fawn Creek Township Tyro,Kansas House of Representatives,12,Democratic,"Fuson, Eden",22,000260
+MONTGOMERY,Fawn Creek Township Tyro,Kansas House of Representatives,12,Republican,"Peck, Virgil",123,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",99,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",174,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",69,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas House of Representatives,12,Democratic,"Fuson, Eden",20,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas House of Representatives,12,Republican,"Peck, Virgil",44,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",136,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas House of Representatives,12,Democratic,"Fuson, Eden",21,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas House of Representatives,12,Republican,"Peck, Virgil",63,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Kansas House of Representatives,11,Republican,"Kelly, Jim",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",160,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",94,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas House of Representatives,12,Democratic,"Fuson, Eden",29,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas House of Representatives,12,Republican,"Peck, Virgil",74,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas House of Representatives,12,Democratic,"Fuson, Eden",68,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas House of Representatives,12,Republican,"Peck, Virgil",141,000360
+MONTGOMERY,Independence Township 2 Part B,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Kansas House of Representatives,11,Republican,"Kelly, Jim",36,00040C
+MONTGOMERY,Liberty Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",160,000410
+MONTGOMERY,Louisburg Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",33,000420
+MONTGOMERY,Louisburg Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",135,000420
+MONTGOMERY,Parker Township 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",72,000430
+MONTGOMERY,Parker Township 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",253,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,00044C
+MONTGOMERY,Rutland Township,Kansas House of Representatives,12,Democratic,"Fuson, Eden",22,000450
+MONTGOMERY,Rutland Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",106,000450
+MONTGOMERY,West Cherry Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",90,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",27,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas House of Representatives,12,Democratic,"Fuson, Eden",84,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",199,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Kansas House of Representatives,11,Republican,"Kelly, Jim",101,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",211,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas House of Representatives,12,Democratic,"Fuson, Eden",3,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas House of Representatives,12,Republican,"Peck, Virgil",6,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas House of Representatives,12,Democratic,"Fuson, Eden",14,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",58,120050
+MONTGOMERY,Independence Township 1 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",487,120060
+MONTGOMERY,Independence Township 1 H12,Kansas House of Representatives,12,Democratic,"Fuson, Eden",23,120070
+MONTGOMERY,Independence Township 1 H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",68,120070
+MONTGOMERY,Independence Township 2 Part A H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Kansas House of Representatives,12,Democratic,"Fuson, Eden",27,120090
+MONTGOMERY,Independence Township 2 Part A H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",110,120090
+MONTGOMERY,Sycamore Township H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",306,120100
+MONTGOMERY,Sycamore Township H12 A,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,12011C
+MONTGOMERY,Sycamore Township H12,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,120110
+MONTGOMERY,Sycamore Township H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,120110
+MONTGOMERY,Coffeyville Airport,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas House of Representatives,12,Republican,"Peck, Virgil",2,900030
+MONTGOMERY,Parker Township 2 Enclave,Kansas House of Representatives,11,Republican,"Kelly, Jim",8,900040
+MONTGOMERY,Independence Township 1 Enclave,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,900050
+MONTGOMERY,Independence Township 1 Enclave,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,900050
+MONTGOMERY,Independence Exclave Airport,Kansas House of Representatives,12,Democratic,"Fuson, Eden",0,900060
+MONTGOMERY,Independence Exclave Airport,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,900060
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",21,00001A
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,00001A
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",88,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",1,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00001C
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",21,000020
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000020
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",74,000020
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000030
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000030
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000030
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000040
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000040
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",119,000040
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000050
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000050
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Republican,"Jenkins, Lynn",180,000050
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,000060
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000060
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,000060
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,000070
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000070
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",89,000070
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",32,000080
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000080
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",145,000080
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",71,000090
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,000090
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",205,000090
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",56,000100
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000100
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",22,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",5,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",45,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",42,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",101,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",65,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",118,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",37,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",14,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",88,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Democratic,"Wakefield, Margie",99,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Republican,"Jenkins, Lynn",259,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Democratic,"Wakefield, Margie",84,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Republican,"Jenkins, Lynn",222,000230
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",35,000240
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000240
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",168,000240
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Democratic,"Wakefield, Margie",94,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Republican,"Jenkins, Lynn",421,000250
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Republican,"Jenkins, Lynn",124,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",34,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",45,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",148,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",42,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",55,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",107,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",28,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",64,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,000360
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00040B
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Democratic,"Wakefield, Margie",3,00040C
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,00040C
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Republican,"Jenkins, Lynn",35,00040C
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,000410
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000410
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,000410
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000420
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000420
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,000420
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",23,000430
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000430
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000430
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",87,00044A
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,00044A
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",202,00044A
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00044C
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000450
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000450
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,000450
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000470
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000470
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",12,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Democratic,"Wakefield, Margie",78,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",197,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Democratic,"Wakefield, Margie",30,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",74,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Democratic,"Wakefield, Margie",44,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Democratic,"Wakefield, Margie",3,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",6,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Democratic,"Wakefield, Margie",10,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,120050
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Democratic,"Wakefield, Margie",85,120060
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,120060
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",423,120060
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Democratic,"Wakefield, Margie",12,120070
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,120070
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,120070
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Democratic,"Wakefield, Margie",29,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,120090
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Democratic,"Wakefield, Margie",46,120100
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,120100
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",269,120100
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011A
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011B
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011C
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120110
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120110
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120110
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",2,900030
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",3,900040
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,900040
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",5,900040
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900050
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900060
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900060
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900060
+MONTGOMERY,Caney City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",15,00001A
+MONTGOMERY,Caney City Ward 1,Attorney General,,Republican,"Schmidt, Derek",96,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Attorney General,,Republican,"Schmidt, Derek",4,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00001C
+MONTGOMERY,Caney City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",21,000020
+MONTGOMERY,Caney City Ward 2,Attorney General,,Republican,"Schmidt, Derek",79,000020
+MONTGOMERY,Caney City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",16,000030
+MONTGOMERY,Caney City Ward 3,Attorney General,,Republican,"Schmidt, Derek",103,000030
+MONTGOMERY,Caney City Ward 4,Attorney General,,Democratic,"Kotich, A.J.",11,000040
+MONTGOMERY,Caney City Ward 4,Attorney General,,Republican,"Schmidt, Derek",130,000040
+MONTGOMERY,Caney Township Havana,Attorney General,,Democratic,"Kotich, A.J.",22,000050
+MONTGOMERY,Caney Township Havana,Attorney General,,Republican,"Schmidt, Derek",190,000050
+MONTGOMERY,Caney Township Tyro,Attorney General,,Democratic,"Kotich, A.J.",21,000060
+MONTGOMERY,Caney Township Tyro,Attorney General,,Republican,"Schmidt, Derek",220,000060
+MONTGOMERY,Cherokee Township,Attorney General,,Democratic,"Kotich, A.J.",26,000070
+MONTGOMERY,Cherokee Township,Attorney General,,Republican,"Schmidt, Derek",101,000070
+MONTGOMERY,Cherry Township,Attorney General,,Democratic,"Kotich, A.J.",31,000080
+MONTGOMERY,Cherry Township,Attorney General,,Republican,"Schmidt, Derek",154,000080
+MONTGOMERY,Cherryvale Ward 1,Attorney General,,Democratic,"Kotich, A.J.",64,000090
+MONTGOMERY,Cherryvale Ward 1,Attorney General,,Republican,"Schmidt, Derek",235,000090
+MONTGOMERY,Cherryvale Ward 2,Attorney General,,Democratic,"Kotich, A.J.",51,000100
+MONTGOMERY,Cherryvale Ward 2,Attorney General,,Republican,"Schmidt, Derek",174,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",22,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Attorney General,,Republican,"Schmidt, Derek",5,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",24,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",56,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",45,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Attorney General,,Republican,"Schmidt, Derek",78,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Attorney General,,Democratic,"Kotich, A.J.",39,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Attorney General,,Republican,"Schmidt, Derek",109,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",58,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Attorney General,,Republican,"Schmidt, Derek",129,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Attorney General,,Democratic,"Kotich, A.J.",23,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Attorney General,,Republican,"Schmidt, Derek",35,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Attorney General,,Democratic,"Kotich, A.J.",22,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Attorney General,,Republican,"Schmidt, Derek",55,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Attorney General,,Democratic,"Kotich, A.J.",34,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Attorney General,,Republican,"Schmidt, Derek",67,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Attorney General,,Democratic,"Kotich, A.J.",16,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Attorney General,,Republican,"Schmidt, Derek",18,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Attorney General,,Democratic,"Kotich, A.J.",34,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Attorney General,,Republican,"Schmidt, Derek",68,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Attorney General,,Democratic,"Kotich, A.J.",80,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Attorney General,,Republican,"Schmidt, Derek",181,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Attorney General,,Democratic,"Kotich, A.J.",99,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Attorney General,,Republican,"Schmidt, Derek",273,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Attorney General,,Democratic,"Kotich, A.J.",62,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Attorney General,,Republican,"Schmidt, Derek",255,000230
+MONTGOMERY,Drum Creek Township,Attorney General,,Democratic,"Kotich, A.J.",20,000240
+MONTGOMERY,Drum Creek Township,Attorney General,,Republican,"Schmidt, Derek",186,000240
+MONTGOMERY,Fawn Creek Township Dearing,Attorney General,,Democratic,"Kotich, A.J.",94,000250
+MONTGOMERY,Fawn Creek Township Dearing,Attorney General,,Republican,"Schmidt, Derek",442,000250
+MONTGOMERY,Fawn Creek Township Tyro,Attorney General,,Democratic,"Kotich, A.J.",12,000260
+MONTGOMERY,Fawn Creek Township Tyro,Attorney General,,Republican,"Schmidt, Derek",133,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",14,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",94,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",29,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",167,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",19,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",62,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",18,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",46,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",20,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",133,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",16,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",71,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",37,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",136,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",20,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",87,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",21,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",82,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",40,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",169,000360
+MONTGOMERY,Independence Township 2 Part B,Attorney General,,Democratic,"Kotich, A.J.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Attorney General,,Republican,"Schmidt, Derek",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Attorney General,,Democratic,"Kotich, A.J.",3,00040C
+MONTGOMERY,Independence Township 2 Part C,Attorney General,,Republican,"Schmidt, Derek",36,00040C
+MONTGOMERY,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",28,000410
+MONTGOMERY,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",158,000410
+MONTGOMERY,Louisburg Township,Attorney General,,Democratic,"Kotich, A.J.",24,000420
+MONTGOMERY,Louisburg Township,Attorney General,,Republican,"Schmidt, Derek",145,000420
+MONTGOMERY,Parker Township 1,Attorney General,,Democratic,"Kotich, A.J.",23,000430
+MONTGOMERY,Parker Township 1,Attorney General,,Republican,"Schmidt, Derek",68,000430
+MONTGOMERY,Parker Township 2,Attorney General,,Democratic,"Kotich, A.J.",82,00044A
+MONTGOMERY,Parker Township 2,Attorney General,,Republican,"Schmidt, Derek",230,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,00044C
+MONTGOMERY,Rutland Township,Attorney General,,Democratic,"Kotich, A.J.",12,000450
+MONTGOMERY,Rutland Township,Attorney General,,Republican,"Schmidt, Derek",117,000450
+MONTGOMERY,West Cherry Township,Attorney General,,Democratic,"Kotich, A.J.",22,000470
+MONTGOMERY,West Cherry Township,Attorney General,,Republican,"Schmidt, Derek",82,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Attorney General,,Democratic,"Kotich, A.J.",3,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Attorney General,,Republican,"Schmidt, Derek",18,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Attorney General,,Democratic,"Kotich, A.J.",40,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Attorney General,,Republican,"Schmidt, Derek",246,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Attorney General,,Democratic,"Kotich, A.J.",24,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Attorney General,,Republican,"Schmidt, Derek",86,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Attorney General,,Democratic,"Kotich, A.J.",17,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Attorney General,,Republican,"Schmidt, Derek",212,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Attorney General,,Democratic,"Kotich, A.J.",1,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Attorney General,,Republican,"Schmidt, Derek",8,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Attorney General,,Democratic,"Kotich, A.J.",9,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Attorney General,,Republican,"Schmidt, Derek",65,120050
+MONTGOMERY,Independence Township 1 H11,Attorney General,,Democratic,"Kotich, A.J.",67,120060
+MONTGOMERY,Independence Township 1 H11,Attorney General,,Republican,"Schmidt, Derek",461,120060
+MONTGOMERY,Independence Township 1 H12,Attorney General,,Democratic,"Kotich, A.J.",13,120070
+MONTGOMERY,Independence Township 1 H12,Attorney General,,Republican,"Schmidt, Derek",79,120070
+MONTGOMERY,Independence Township 2 Part A H11,Attorney General,,Democratic,"Kotich, A.J.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,Attorney General,,Republican,"Schmidt, Derek",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Attorney General,,Democratic,"Kotich, A.J.",13,120090
+MONTGOMERY,Independence Township 2 Part A H12,Attorney General,,Republican,"Schmidt, Derek",125,120090
+MONTGOMERY,Sycamore Township H11,Attorney General,,Democratic,"Kotich, A.J.",30,120100
+MONTGOMERY,Sycamore Township H11,Attorney General,,Republican,"Schmidt, Derek",292,120100
+MONTGOMERY,Sycamore Township H12 A,Attorney General,,Democratic,"Kotich, A.J.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Attorney General,,Republican,"Schmidt, Derek",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Attorney General,,Democratic,"Kotich, A.J.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Attorney General,,Republican,"Schmidt, Derek",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Attorney General,,Democratic,"Kotich, A.J.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Attorney General,,Republican,"Schmidt, Derek",0,12011C
+MONTGOMERY,Sycamore Township H12,Attorney General,,Democratic,"Kotich, A.J.",0,120110
+MONTGOMERY,Sycamore Township H12,Attorney General,,Republican,"Schmidt, Derek",0,120110
+MONTGOMERY,Coffeyville Airport,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+MONTGOMERY,Coffeyville Airport,Attorney General,,Republican,"Schmidt, Derek",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",2,900030
+MONTGOMERY,Parker Township 2 Enclave,Attorney General,,Democratic,"Kotich, A.J.",4,900040
+MONTGOMERY,Parker Township 2 Enclave,Attorney General,,Republican,"Schmidt, Derek",6,900040
+MONTGOMERY,Independence Township 1 Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900050
+MONTGOMERY,Independence Exclave Airport,Attorney General,,Democratic,"Kotich, A.J.",0,900060
+MONTGOMERY,Independence Exclave Airport,Attorney General,,Republican,"Schmidt, Derek",0,900060
+MONTGOMERY,Caney City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,00001A
+MONTGOMERY,Caney City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",87,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00001C
+MONTGOMERY,Caney City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000020
+MONTGOMERY,Caney City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",74,000020
+MONTGOMERY,Caney City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000030
+MONTGOMERY,Caney City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",98,000030
+MONTGOMERY,Caney City Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000040
+MONTGOMERY,Caney City Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000040
+MONTGOMERY,Caney Township Havana,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000050
+MONTGOMERY,Caney Township Havana,Commissioner of Insurance,,Republican,"Selzer, Ken",177,000050
+MONTGOMERY,Caney Township Tyro,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000060
+MONTGOMERY,Caney Township Tyro,Commissioner of Insurance,,Republican,"Selzer, Ken",212,000060
+MONTGOMERY,Cherokee Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000070
+MONTGOMERY,Cherokee Township,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000070
+MONTGOMERY,Cherry Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000080
+MONTGOMERY,Cherry Township,Commissioner of Insurance,,Republican,"Selzer, Ken",135,000080
+MONTGOMERY,Cherryvale Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",88,000090
+MONTGOMERY,Cherryvale Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",204,000090
+MONTGOMERY,Cherryvale Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,000100
+MONTGOMERY,Cherryvale Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",154,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",4,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",43,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Commissioner of Insurance,,Republican,"Selzer, Ken",94,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",108,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Commissioner of Insurance,,Republican,"Selzer, Ken",63,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",96,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Commissioner of Insurance,,Republican,"Selzer, Ken",155,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",116,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Commissioner of Insurance,,Republican,"Selzer, Ken",245,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Commissioner of Insurance,,Republican,"Selzer, Ken",215,000230
+MONTGOMERY,Drum Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000240
+MONTGOMERY,Drum Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",171,000240
+MONTGOMERY,Fawn Creek Township Dearing,Commissioner of Insurance,,Democratic,"Anderson, Dennis",128,000250
+MONTGOMERY,Fawn Creek Township Dearing,Commissioner of Insurance,,Republican,"Selzer, Ken",382,000250
+MONTGOMERY,Fawn Creek Township Tyro,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000260
+MONTGOMERY,Fawn Creek Township Tyro,Commissioner of Insurance,,Republican,"Selzer, Ken",123,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",147,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",56,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",106,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",74,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",80,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",68,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",128,000360
+MONTGOMERY,Independence Township 2 Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,00040C
+MONTGOMERY,Independence Township 2 Part C,Commissioner of Insurance,,Republican,"Selzer, Ken",33,00040C
+MONTGOMERY,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000410
+MONTGOMERY,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000410
+MONTGOMERY,Louisburg Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000420
+MONTGOMERY,Louisburg Township,Commissioner of Insurance,,Republican,"Selzer, Ken",122,000420
+MONTGOMERY,Parker Township 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000430
+MONTGOMERY,Parker Township 1,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000430
+MONTGOMERY,Parker Township 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",108,00044A
+MONTGOMERY,Parker Township 2,Commissioner of Insurance,,Republican,"Selzer, Ken",191,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00044C
+MONTGOMERY,Rutland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000450
+MONTGOMERY,Rutland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",109,000450
+MONTGOMERY,West Cherry Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000470
+MONTGOMERY,West Cherry Township,Commissioner of Insurance,,Republican,"Selzer, Ken",75,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Commissioner of Insurance,,Republican,"Selzer, Ken",14,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",84,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Commissioner of Insurance,,Republican,"Selzer, Ken",189,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Commissioner of Insurance,,Republican,"Selzer, Ken",68,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Commissioner of Insurance,,Republican,"Selzer, Ken",184,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Commissioner of Insurance,,Republican,"Selzer, Ken",6,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Commissioner of Insurance,,Republican,"Selzer, Ken",60,120050
+MONTGOMERY,Independence Township 1 H11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",100,120060
+MONTGOMERY,Independence Township 1 H11,Commissioner of Insurance,,Republican,"Selzer, Ken",409,120060
+MONTGOMERY,Independence Township 1 H12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,120070
+MONTGOMERY,Independence Township 1 H12,Commissioner of Insurance,,Republican,"Selzer, Ken",68,120070
+MONTGOMERY,Independence Township 2 Part A H11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",35,120090
+MONTGOMERY,Independence Township 2 Part A H12,Commissioner of Insurance,,Republican,"Selzer, Ken",96,120090
+MONTGOMERY,Sycamore Township H11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,120100
+MONTGOMERY,Sycamore Township H11,Commissioner of Insurance,,Republican,"Selzer, Ken",266,120100
+MONTGOMERY,Sycamore Township H12 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12011C
+MONTGOMERY,Sycamore Township H12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120110
+MONTGOMERY,Sycamore Township H12,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120110
+MONTGOMERY,Coffeyville Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+MONTGOMERY,Coffeyville Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",2,900030
+MONTGOMERY,Parker Township 2 Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,900040
+MONTGOMERY,Parker Township 2 Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",4,900040
+MONTGOMERY,Independence Township 1 Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+MONTGOMERY,Independence Township 1 Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+MONTGOMERY,Independence Exclave Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900060
+MONTGOMERY,Independence Exclave Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900060
+MONTGOMERY,Caney City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,00001A
+MONTGOMERY,Caney City Ward 1,Secretary of State,,Republican,"Kobach, Kris",83,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Secretary of State,,Republican,"Kobach, Kris",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00001C
+MONTGOMERY,Caney City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000020
+MONTGOMERY,Caney City Ward 2,Secretary of State,,Republican,"Kobach, Kris",74,000020
+MONTGOMERY,Caney City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000030
+MONTGOMERY,Caney City Ward 3,Secretary of State,,Republican,"Kobach, Kris",93,000030
+MONTGOMERY,Caney City Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000040
+MONTGOMERY,Caney City Ward 4,Secretary of State,,Republican,"Kobach, Kris",111,000040
+MONTGOMERY,Caney Township Havana,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000050
+MONTGOMERY,Caney Township Havana,Secretary of State,,Republican,"Kobach, Kris",172,000050
+MONTGOMERY,Caney Township Tyro,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000060
+MONTGOMERY,Caney Township Tyro,Secretary of State,,Republican,"Kobach, Kris",204,000060
+MONTGOMERY,Cherokee Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000070
+MONTGOMERY,Cherokee Township,Secretary of State,,Republican,"Kobach, Kris",84,000070
+MONTGOMERY,Cherry Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000080
+MONTGOMERY,Cherry Township,Secretary of State,,Republican,"Kobach, Kris",136,000080
+MONTGOMERY,Cherryvale Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,000090
+MONTGOMERY,Cherryvale Ward 1,Secretary of State,,Republican,"Kobach, Kris",196,000090
+MONTGOMERY,Cherryvale Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,000100
+MONTGOMERY,Cherryvale Ward 2,Secretary of State,,Republican,"Kobach, Kris",154,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Secretary of State,,Republican,"Kobach, Kris",4,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",44,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Secretary of State,,Republican,"Kobach, Kris",58,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Secretary of State,,Republican,"Kobach, Kris",96,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Secretary of State,,Republican,"Kobach, Kris",111,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Secretary of State,,Republican,"Kobach, Kris",32,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Secretary of State,,Republican,"Kobach, Kris",46,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Secretary of State,,Republican,"Kobach, Kris",56,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Secretary of State,,Republican,"Kobach, Kris",15,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Secretary of State,,Republican,"Kobach, Kris",62,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",102,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Secretary of State,,Republican,"Kobach, Kris",159,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",123,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Secretary of State,,Republican,"Kobach, Kris",246,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",106,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Secretary of State,,Republican,"Kobach, Kris",206,000230
+MONTGOMERY,Drum Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000240
+MONTGOMERY,Drum Creek Township,Secretary of State,,Republican,"Kobach, Kris",163,000240
+MONTGOMERY,Fawn Creek Township Dearing,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",139,000250
+MONTGOMERY,Fawn Creek Township Dearing,Secretary of State,,Republican,"Kobach, Kris",394,000250
+MONTGOMERY,Fawn Creek Township Tyro,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000260
+MONTGOMERY,Fawn Creek Township Tyro,Secretary of State,,Republican,"Kobach, Kris",120,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",55,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",126,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",56,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",37,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",103,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",53,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",107,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",69,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",68,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",84,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",123,000360
+MONTGOMERY,Independence Township 2 Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Secretary of State,,Republican,"Kobach, Kris",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,00040C
+MONTGOMERY,Independence Township 2 Part C,Secretary of State,,Republican,"Kobach, Kris",32,00040C
+MONTGOMERY,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,000410
+MONTGOMERY,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",134,000410
+MONTGOMERY,Louisburg Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000420
+MONTGOMERY,Louisburg Township,Secretary of State,,Republican,"Kobach, Kris",127,000420
+MONTGOMERY,Parker Township 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000430
+MONTGOMERY,Parker Township 1,Secretary of State,,Republican,"Kobach, Kris",59,000430
+MONTGOMERY,Parker Township 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",119,00044A
+MONTGOMERY,Parker Township 2,Secretary of State,,Republican,"Kobach, Kris",184,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,00044C
+MONTGOMERY,Rutland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000450
+MONTGOMERY,Rutland Township,Secretary of State,,Republican,"Kobach, Kris",105,000450
+MONTGOMERY,West Cherry Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000470
+MONTGOMERY,West Cherry Township,Secretary of State,,Republican,"Kobach, Kris",79,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Secretary of State,,Republican,"Kobach, Kris",13,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Secretary of State,,Republican,"Kobach, Kris",177,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Secretary of State,,Republican,"Kobach, Kris",61,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Secretary of State,,Republican,"Kobach, Kris",161,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Secretary of State,,Republican,"Kobach, Kris",6,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Secretary of State,,Republican,"Kobach, Kris",57,120050
+MONTGOMERY,Independence Township 1 H11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",115,120060
+MONTGOMERY,Independence Township 1 H11,Secretary of State,,Republican,"Kobach, Kris",412,120060
+MONTGOMERY,Independence Township 1 H12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,120070
+MONTGOMERY,Independence Township 1 H12,Secretary of State,,Republican,"Kobach, Kris",71,120070
+MONTGOMERY,Independence Township 2 Part A H11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,Secretary of State,,Republican,"Kobach, Kris",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,120090
+MONTGOMERY,Independence Township 2 Part A H12,Secretary of State,,Republican,"Kobach, Kris",95,120090
+MONTGOMERY,Sycamore Township H11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,120100
+MONTGOMERY,Sycamore Township H11,Secretary of State,,Republican,"Kobach, Kris",252,120100
+MONTGOMERY,Sycamore Township H12 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Secretary of State,,Republican,"Kobach, Kris",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Secretary of State,,Republican,"Kobach, Kris",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Secretary of State,,Republican,"Kobach, Kris",0,12011C
+MONTGOMERY,Sycamore Township H12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120110
+MONTGOMERY,Sycamore Township H12,Secretary of State,,Republican,"Kobach, Kris",0,120110
+MONTGOMERY,Coffeyville Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+MONTGOMERY,Coffeyville Airport,Secretary of State,,Republican,"Kobach, Kris",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",2,900030
+MONTGOMERY,Parker Township 2 Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,900040
+MONTGOMERY,Parker Township 2 Enclave,Secretary of State,,Republican,"Kobach, Kris",5,900040
+MONTGOMERY,Independence Township 1 Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+MONTGOMERY,Independence Township 1 Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900050
+MONTGOMERY,Independence Exclave Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900060
+MONTGOMERY,Independence Exclave Airport,Secretary of State,,Republican,"Kobach, Kris",0,900060
+MONTGOMERY,Caney City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",20,00001A
+MONTGOMERY,Caney City Ward 1,State Treasurer,,Republican,"Estes, Ron",94,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,State Treasurer,,Republican,"Estes, Ron",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00001C
+MONTGOMERY,Caney City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",21,000020
+MONTGOMERY,Caney City Ward 2,State Treasurer,,Republican,"Estes, Ron",78,000020
+MONTGOMERY,Caney City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",18,000030
+MONTGOMERY,Caney City Ward 3,State Treasurer,,Republican,"Estes, Ron",99,000030
+MONTGOMERY,Caney City Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",18,000040
+MONTGOMERY,Caney City Ward 4,State Treasurer,,Republican,"Estes, Ron",123,000040
+MONTGOMERY,Caney Township Havana,State Treasurer,,Democratic,"Alldritt, Carmen",28,000050
+MONTGOMERY,Caney Township Havana,State Treasurer,,Republican,"Estes, Ron",183,000050
+MONTGOMERY,Caney Township Tyro,State Treasurer,,Democratic,"Alldritt, Carmen",19,000060
+MONTGOMERY,Caney Township Tyro,State Treasurer,,Republican,"Estes, Ron",220,000060
+MONTGOMERY,Cherokee Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,000070
+MONTGOMERY,Cherokee Township,State Treasurer,,Republican,"Estes, Ron",91,000070
+MONTGOMERY,Cherry Township,State Treasurer,,Democratic,"Alldritt, Carmen",36,000080
+MONTGOMERY,Cherry Township,State Treasurer,,Republican,"Estes, Ron",144,000080
+MONTGOMERY,Cherryvale Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",84,000090
+MONTGOMERY,Cherryvale Ward 1,State Treasurer,,Republican,"Estes, Ron",216,000090
+MONTGOMERY,Cherryvale Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",57,000100
+MONTGOMERY,Cherryvale Ward 2,State Treasurer,,Republican,"Estes, Ron",170,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",23,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,State Treasurer,,Republican,"Estes, Ron",4,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",30,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,State Treasurer,,Republican,"Estes, Ron",49,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",52,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,State Treasurer,,Republican,"Estes, Ron",69,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,State Treasurer,,Democratic,"Alldritt, Carmen",46,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,State Treasurer,,Republican,"Estes, Ron",101,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",71,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,State Treasurer,,Republican,"Estes, Ron",116,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,State Treasurer,,Democratic,"Alldritt, Carmen",23,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,State Treasurer,,Republican,"Estes, Ron",34,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,State Treasurer,,Democratic,"Alldritt, Carmen",24,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,State Treasurer,,Republican,"Estes, Ron",52,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,State Treasurer,,Democratic,"Alldritt, Carmen",42,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,State Treasurer,,Republican,"Estes, Ron",58,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,State Treasurer,,Democratic,"Alldritt, Carmen",16,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,State Treasurer,,Republican,"Estes, Ron",17,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,State Treasurer,,Democratic,"Alldritt, Carmen",36,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,State Treasurer,,Republican,"Estes, Ron",66,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,State Treasurer,,Democratic,"Alldritt, Carmen",93,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,State Treasurer,,Republican,"Estes, Ron",163,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,State Treasurer,,Democratic,"Alldritt, Carmen",109,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,State Treasurer,,Republican,"Estes, Ron",260,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,State Treasurer,,Democratic,"Alldritt, Carmen",89,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,State Treasurer,,Republican,"Estes, Ron",222,000230
+MONTGOMERY,Drum Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000240
+MONTGOMERY,Drum Creek Township,State Treasurer,,Republican,"Estes, Ron",176,000240
+MONTGOMERY,Fawn Creek Township Dearing,State Treasurer,,Democratic,"Alldritt, Carmen",123,000250
+MONTGOMERY,Fawn Creek Township Dearing,State Treasurer,,Republican,"Estes, Ron",411,000250
+MONTGOMERY,Fawn Creek Township Tyro,State Treasurer,,Democratic,"Alldritt, Carmen",15,000260
+MONTGOMERY,Fawn Creek Township Tyro,State Treasurer,,Republican,"Estes, Ron",126,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",34,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",72,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",39,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",156,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",15,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",66,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",20,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",44,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",30,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",122,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",25,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,State Treasurer,,Republican,"Estes, Ron",59,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,State Treasurer,,Republican,"Estes, Ron",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",51,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",121,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",32,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",77,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",23,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,State Treasurer,,Republican,"Estes, Ron",78,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",61,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,State Treasurer,,Republican,"Estes, Ron",146,000360
+MONTGOMERY,Independence Township 2 Part B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00040B
+MONTGOMERY,Independence Township 2 Part B,State Treasurer,,Republican,"Estes, Ron",0,00040B
+MONTGOMERY,Independence Township 2 Part C,State Treasurer,,Democratic,"Alldritt, Carmen",6,00040C
+MONTGOMERY,Independence Township 2 Part C,State Treasurer,,Republican,"Estes, Ron",34,00040C
+MONTGOMERY,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",36,000410
+MONTGOMERY,Liberty Township,State Treasurer,,Republican,"Estes, Ron",148,000410
+MONTGOMERY,Louisburg Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000420
+MONTGOMERY,Louisburg Township,State Treasurer,,Republican,"Estes, Ron",137,000420
+MONTGOMERY,Parker Township 1,State Treasurer,,Democratic,"Alldritt, Carmen",28,000430
+MONTGOMERY,Parker Township 1,State Treasurer,,Republican,"Estes, Ron",64,000430
+MONTGOMERY,Parker Township 2,State Treasurer,,Democratic,"Alldritt, Carmen",104,00044A
+MONTGOMERY,Parker Township 2,State Treasurer,,Republican,"Estes, Ron",200,00044A
+MONTGOMERY,Parker Township 2 Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,State Treasurer,,Republican,"Estes, Ron",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,State Treasurer,,Republican,"Estes, Ron",0,00044C
+MONTGOMERY,Rutland Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000450
+MONTGOMERY,Rutland Township,State Treasurer,,Republican,"Estes, Ron",110,000450
+MONTGOMERY,West Cherry Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000470
+MONTGOMERY,West Cherry Township,State Treasurer,,Republican,"Estes, Ron",80,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,State Treasurer,,Democratic,"Alldritt, Carmen",4,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,State Treasurer,,Republican,"Estes, Ron",17,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,State Treasurer,,Democratic,"Alldritt, Carmen",74,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,State Treasurer,,Republican,"Estes, Ron",206,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,State Treasurer,,Democratic,"Alldritt, Carmen",25,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,State Treasurer,,Republican,"Estes, Ron",82,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,State Treasurer,,Democratic,"Alldritt, Carmen",27,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,State Treasurer,,Republican,"Estes, Ron",198,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,State Treasurer,,Democratic,"Alldritt, Carmen",1,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,State Treasurer,,Republican,"Estes, Ron",7,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,State Treasurer,,Democratic,"Alldritt, Carmen",10,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,State Treasurer,,Republican,"Estes, Ron",62,120050
+MONTGOMERY,Independence Township 1 H11,State Treasurer,,Democratic,"Alldritt, Carmen",84,120060
+MONTGOMERY,Independence Township 1 H11,State Treasurer,,Republican,"Estes, Ron",437,120060
+MONTGOMERY,Independence Township 1 H12,State Treasurer,,Democratic,"Alldritt, Carmen",17,120070
+MONTGOMERY,Independence Township 1 H12,State Treasurer,,Republican,"Estes, Ron",75,120070
+MONTGOMERY,Independence Township 2 Part A H11,State Treasurer,,Democratic,"Alldritt, Carmen",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,State Treasurer,,Republican,"Estes, Ron",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,State Treasurer,,Democratic,"Alldritt, Carmen",27,120090
+MONTGOMERY,Independence Township 2 Part A H12,State Treasurer,,Republican,"Estes, Ron",109,120090
+MONTGOMERY,Sycamore Township H11,State Treasurer,,Democratic,"Alldritt, Carmen",42,120100
+MONTGOMERY,Sycamore Township H11,State Treasurer,,Republican,"Estes, Ron",278,120100
+MONTGOMERY,Sycamore Township H12 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,12011A
+MONTGOMERY,Sycamore Township H12 A,State Treasurer,,Republican,"Estes, Ron",0,12011A
+MONTGOMERY,Sycamore Township H12 B,State Treasurer,,Democratic,"Alldritt, Carmen",0,12011B
+MONTGOMERY,Sycamore Township H12 B,State Treasurer,,Republican,"Estes, Ron",0,12011B
+MONTGOMERY,Sycamore Township H12 C,State Treasurer,,Democratic,"Alldritt, Carmen",0,12011C
+MONTGOMERY,Sycamore Township H12 C,State Treasurer,,Republican,"Estes, Ron",0,12011C
+MONTGOMERY,Sycamore Township H12,State Treasurer,,Democratic,"Alldritt, Carmen",0,120110
+MONTGOMERY,Sycamore Township H12,State Treasurer,,Republican,"Estes, Ron",0,120110
+MONTGOMERY,Coffeyville Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+MONTGOMERY,Coffeyville Airport,State Treasurer,,Republican,"Estes, Ron",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,State Treasurer,,Republican,"Estes, Ron",2,900030
+MONTGOMERY,Parker Township 2 Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",5,900040
+MONTGOMERY,Parker Township 2 Enclave,State Treasurer,,Republican,"Estes, Ron",5,900040
+MONTGOMERY,Independence Township 1 Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+MONTGOMERY,Independence Township 1 Enclave,State Treasurer,,Republican,"Estes, Ron",0,900050
+MONTGOMERY,Independence Exclave Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,900060
+MONTGOMERY,Independence Exclave Airport,State Treasurer,,Republican,"Estes, Ron",0,900060
+MONTGOMERY,Caney City Ward 1,United States Senate,,independent,"Orman, Greg",25,00001A
+MONTGOMERY,Caney City Ward 1,United States Senate,,Libertarian,"Batson, Randall",8,00001A
+MONTGOMERY,Caney City Ward 1,United States Senate,,Republican,"Roberts, Pat",82,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,United States Senate,,independent,"Orman, Greg",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States Senate,,Republican,"Roberts, Pat",3,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,United States Senate,,independent,"Orman, Greg",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00001C
+MONTGOMERY,Caney City Ward 2,United States Senate,,independent,"Orman, Greg",22,000020
+MONTGOMERY,Caney City Ward 2,United States Senate,,Libertarian,"Batson, Randall",6,000020
+MONTGOMERY,Caney City Ward 2,United States Senate,,Republican,"Roberts, Pat",72,000020
+MONTGOMERY,Caney City Ward 3,United States Senate,,independent,"Orman, Greg",16,000030
+MONTGOMERY,Caney City Ward 3,United States Senate,,Libertarian,"Batson, Randall",7,000030
+MONTGOMERY,Caney City Ward 3,United States Senate,,Republican,"Roberts, Pat",96,000030
+MONTGOMERY,Caney City Ward 4,United States Senate,,independent,"Orman, Greg",17,000040
+MONTGOMERY,Caney City Ward 4,United States Senate,,Libertarian,"Batson, Randall",8,000040
+MONTGOMERY,Caney City Ward 4,United States Senate,,Republican,"Roberts, Pat",117,000040
+MONTGOMERY,Caney Township Havana,United States Senate,,independent,"Orman, Greg",42,000050
+MONTGOMERY,Caney Township Havana,United States Senate,,Libertarian,"Batson, Randall",3,000050
+MONTGOMERY,Caney Township Havana,United States Senate,,Republican,"Roberts, Pat",167,000050
+MONTGOMERY,Caney Township Tyro,United States Senate,,independent,"Orman, Greg",24,000060
+MONTGOMERY,Caney Township Tyro,United States Senate,,Libertarian,"Batson, Randall",5,000060
+MONTGOMERY,Caney Township Tyro,United States Senate,,Republican,"Roberts, Pat",212,000060
+MONTGOMERY,Cherokee Township,United States Senate,,independent,"Orman, Greg",33,000070
+MONTGOMERY,Cherokee Township,United States Senate,,Libertarian,"Batson, Randall",7,000070
+MONTGOMERY,Cherokee Township,United States Senate,,Republican,"Roberts, Pat",86,000070
+MONTGOMERY,Cherry Township,United States Senate,,independent,"Orman, Greg",41,000080
+MONTGOMERY,Cherry Township,United States Senate,,Libertarian,"Batson, Randall",10,000080
+MONTGOMERY,Cherry Township,United States Senate,,Republican,"Roberts, Pat",135,000080
+MONTGOMERY,Cherryvale Ward 1,United States Senate,,independent,"Orman, Greg",78,000090
+MONTGOMERY,Cherryvale Ward 1,United States Senate,,Libertarian,"Batson, Randall",21,000090
+MONTGOMERY,Cherryvale Ward 1,United States Senate,,Republican,"Roberts, Pat",195,000090
+MONTGOMERY,Cherryvale Ward 2,United States Senate,,independent,"Orman, Greg",60,000100
+MONTGOMERY,Cherryvale Ward 2,United States Senate,,Libertarian,"Batson, Randall",15,000100
+MONTGOMERY,Cherryvale Ward 2,United States Senate,,Republican,"Roberts, Pat",151,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States Senate,,independent,"Orman, Greg",18,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",2,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States Senate,,Republican,"Roberts, Pat",4,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States Senate,,independent,"Orman, Greg",27,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",3,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States Senate,,Republican,"Roberts, Pat",46,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States Senate,,independent,"Orman, Greg",41,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",8,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States Senate,,Republican,"Roberts, Pat",69,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States Senate,,independent,"Orman, Greg",46,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",6,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States Senate,,Republican,"Roberts, Pat",95,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States Senate,,independent,"Orman, Greg",76,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",8,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States Senate,,Republican,"Roberts, Pat",105,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States Senate,,independent,"Orman, Greg",16,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",5,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States Senate,,Republican,"Roberts, Pat",32,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States Senate,,independent,"Orman, Greg",28,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",6,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States Senate,,Republican,"Roberts, Pat",43,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States Senate,,independent,"Orman, Greg",25,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",8,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States Senate,,Republican,"Roberts, Pat",65,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States Senate,,independent,"Orman, Greg",15,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",2,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States Senate,,Republican,"Roberts, Pat",16,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States Senate,,independent,"Orman, Greg",36,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",7,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States Senate,,Republican,"Roberts, Pat",58,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States Senate,,independent,"Orman, Greg",85,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",12,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States Senate,,Republican,"Roberts, Pat",163,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States Senate,,independent,"Orman, Greg",98,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",19,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States Senate,,Republican,"Roberts, Pat",253,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States Senate,,independent,"Orman, Greg",95,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",9,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States Senate,,Republican,"Roberts, Pat",214,000230
+MONTGOMERY,Drum Creek Township,United States Senate,,independent,"Orman, Greg",34,000240
+MONTGOMERY,Drum Creek Township,United States Senate,,Libertarian,"Batson, Randall",7,000240
+MONTGOMERY,Drum Creek Township,United States Senate,,Republican,"Roberts, Pat",167,000240
+MONTGOMERY,Fawn Creek Township Dearing,United States Senate,,independent,"Orman, Greg",120,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States Senate,,Libertarian,"Batson, Randall",17,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States Senate,,Republican,"Roberts, Pat",396,000250
+MONTGOMERY,Fawn Creek Township Tyro,United States Senate,,independent,"Orman, Greg",21,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States Senate,,Libertarian,"Batson, Randall",1,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States Senate,,Republican,"Roberts, Pat",122,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",37,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",8,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",62,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",64,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",8,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",123,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",29,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",2,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",50,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",17,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",4,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",39,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",39,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",13,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",97,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States Senate,,independent,"Orman, Greg",23,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",8,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States Senate,,Republican,"Roberts, Pat",52,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States Senate,,Republican,"Roberts, Pat",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",58,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",12,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",100,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",32,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",7,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",66,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States Senate,,independent,"Orman, Greg",29,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",8,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States Senate,,Republican,"Roberts, Pat",65,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States Senate,,independent,"Orman, Greg",71,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",9,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States Senate,,Republican,"Roberts, Pat",127,000360
+MONTGOMERY,Independence Township 2 Part B,United States Senate,,independent,"Orman, Greg",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States Senate,,Libertarian,"Batson, Randall",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States Senate,,Republican,"Roberts, Pat",0,00040B
+MONTGOMERY,Independence Township 2 Part C,United States Senate,,independent,"Orman, Greg",8,00040C
+MONTGOMERY,Independence Township 2 Part C,United States Senate,,Libertarian,"Batson, Randall",2,00040C
+MONTGOMERY,Independence Township 2 Part C,United States Senate,,Republican,"Roberts, Pat",30,00040C
+MONTGOMERY,Liberty Township,United States Senate,,independent,"Orman, Greg",41,000410
+MONTGOMERY,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",7,000410
+MONTGOMERY,Liberty Township,United States Senate,,Republican,"Roberts, Pat",138,000410
+MONTGOMERY,Louisburg Township,United States Senate,,independent,"Orman, Greg",35,000420
+MONTGOMERY,Louisburg Township,United States Senate,,Libertarian,"Batson, Randall",10,000420
+MONTGOMERY,Louisburg Township,United States Senate,,Republican,"Roberts, Pat",122,000420
+MONTGOMERY,Parker Township 1,United States Senate,,independent,"Orman, Greg",27,000430
+MONTGOMERY,Parker Township 1,United States Senate,,Libertarian,"Batson, Randall",2,000430
+MONTGOMERY,Parker Township 1,United States Senate,,Republican,"Roberts, Pat",63,000430
+MONTGOMERY,Parker Township 2,United States Senate,,independent,"Orman, Greg",105,00044A
+MONTGOMERY,Parker Township 2,United States Senate,,Libertarian,"Batson, Randall",15,00044A
+MONTGOMERY,Parker Township 2,United States Senate,,Republican,"Roberts, Pat",188,00044A
+MONTGOMERY,Parker Township 2 Enclave A,United States Senate,,independent,"Orman, Greg",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States Senate,,Republican,"Roberts, Pat",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,United States Senate,,independent,"Orman, Greg",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States Senate,,Republican,"Roberts, Pat",0,00044C
+MONTGOMERY,Rutland Township,United States Senate,,independent,"Orman, Greg",17,000450
+MONTGOMERY,Rutland Township,United States Senate,,Libertarian,"Batson, Randall",4,000450
+MONTGOMERY,Rutland Township,United States Senate,,Republican,"Roberts, Pat",107,000450
+MONTGOMERY,West Cherry Township,United States Senate,,independent,"Orman, Greg",23,000470
+MONTGOMERY,West Cherry Township,United States Senate,,Libertarian,"Batson, Randall",6,000470
+MONTGOMERY,West Cherry Township,United States Senate,,Republican,"Roberts, Pat",70,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States Senate,,independent,"Orman, Greg",9,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States Senate,,Libertarian,"Batson, Randall",1,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States Senate,,Republican,"Roberts, Pat",13,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States Senate,,independent,"Orman, Greg",85,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States Senate,,Libertarian,"Batson, Randall",10,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States Senate,,Republican,"Roberts, Pat",185,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States Senate,,independent,"Orman, Greg",14,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States Senate,,Libertarian,"Batson, Randall",1,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States Senate,,Republican,"Roberts, Pat",59,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States Senate,,independent,"Orman, Greg",54,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States Senate,,Libertarian,"Batson, Randall",4,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States Senate,,Republican,"Roberts, Pat",172,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States Senate,,independent,"Orman, Greg",3,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States Senate,,Libertarian,"Batson, Randall",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States Senate,,Republican,"Roberts, Pat",6,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States Senate,,independent,"Orman, Greg",43,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States Senate,,Libertarian,"Batson, Randall",7,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States Senate,,Republican,"Roberts, Pat",59,120050
+MONTGOMERY,Independence Township 1 H11,United States Senate,,independent,"Orman, Greg",101,120060
+MONTGOMERY,Independence Township 1 H11,United States Senate,,Libertarian,"Batson, Randall",22,120060
+MONTGOMERY,Independence Township 1 H11,United States Senate,,Republican,"Roberts, Pat",408,120060
+MONTGOMERY,Independence Township 1 H12,United States Senate,,independent,"Orman, Greg",17,120070
+MONTGOMERY,Independence Township 1 H12,United States Senate,,Libertarian,"Batson, Randall",3,120070
+MONTGOMERY,Independence Township 1 H12,United States Senate,,Republican,"Roberts, Pat",71,120070
+MONTGOMERY,Independence Township 2 Part A H11,United States Senate,,independent,"Orman, Greg",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States Senate,,Libertarian,"Batson, Randall",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States Senate,,Republican,"Roberts, Pat",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,United States Senate,,independent,"Orman, Greg",30,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States Senate,,Libertarian,"Batson, Randall",6,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States Senate,,Republican,"Roberts, Pat",100,120090
+MONTGOMERY,Sycamore Township H11,United States Senate,,independent,"Orman, Greg",60,120100
+MONTGOMERY,Sycamore Township H11,United States Senate,,Libertarian,"Batson, Randall",13,120100
+MONTGOMERY,Sycamore Township H11,United States Senate,,Republican,"Roberts, Pat",252,120100
+MONTGOMERY,Sycamore Township H12 A,United States Senate,,independent,"Orman, Greg",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States Senate,,Libertarian,"Batson, Randall",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States Senate,,Republican,"Roberts, Pat",0,12011A
+MONTGOMERY,Sycamore Township H12 B,United States Senate,,independent,"Orman, Greg",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States Senate,,Libertarian,"Batson, Randall",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States Senate,,Republican,"Roberts, Pat",0,12011B
+MONTGOMERY,Sycamore Township H12 C,United States Senate,,independent,"Orman, Greg",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States Senate,,Libertarian,"Batson, Randall",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States Senate,,Republican,"Roberts, Pat",0,12011C
+MONTGOMERY,Sycamore Township H12,United States Senate,,independent,"Orman, Greg",0,120110
+MONTGOMERY,Sycamore Township H12,United States Senate,,Libertarian,"Batson, Randall",0,120110
+MONTGOMERY,Sycamore Township H12,United States Senate,,Republican,"Roberts, Pat",0,120110
+MONTGOMERY,Coffeyville Airport,United States Senate,,independent,"Orman, Greg",0,900010
+MONTGOMERY,Coffeyville Airport,United States Senate,,Libertarian,"Batson, Randall",0,900010
+MONTGOMERY,Coffeyville Airport,United States Senate,,Republican,"Roberts, Pat",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States Senate,,independent,"Orman, Greg",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,United States Senate,,independent,"Orman, Greg",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States Senate,,Republican,"Roberts, Pat",2,900030
+MONTGOMERY,Parker Township 2 Enclave,United States Senate,,independent,"Orman, Greg",3,900040
+MONTGOMERY,Parker Township 2 Enclave,United States Senate,,Libertarian,"Batson, Randall",1,900040
+MONTGOMERY,Parker Township 2 Enclave,United States Senate,,Republican,"Roberts, Pat",6,900040
+MONTGOMERY,Independence Township 1 Enclave,United States Senate,,independent,"Orman, Greg",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States Senate,,Republican,"Roberts, Pat",0,900050
+MONTGOMERY,Independence Exclave Airport,United States Senate,,independent,"Orman, Greg",0,900060
+MONTGOMERY,Independence Exclave Airport,United States Senate,,Libertarian,"Batson, Randall",0,900060
+MONTGOMERY,Independence Exclave Airport,United States Senate,,Republican,"Roberts, Pat",0,900060

--- a/2014/20141104__ks__general__morris__precinct.csv
+++ b/2014/20141104__ks__general__morris__precinct.csv
@@ -1,271 +1,343 @@
-county,precinct,office,district,party,candidate,votes
-Morris,Highland,Attorney General,,D,A. J. Kotich,7
-Morris,Overland,Attorney General,,D,A. J. Kotich,6
-Morris,Twp 1 Pct 1,Attorney General,,D,A. J. Kotich,31
-Morris,Twp 1 Pct 2,Attorney General,,D,A. J. Kotich,19
-Morris,Twp 2,Attorney General,,D,A. J. Kotich,90
-Morris,Twp 3,Attorney General,,D,A. J. Kotich,38
-Morris,Twp 4,Attorney General,,D,A. J. Kotich,13
-Morris,Twp 5,Attorney General,,D,A. J. Kotich,27
-Morris,Twp 6,Attorney General,,D,A. J. Kotich,4
-Morris,Twp 7,Attorney General,,D,A. J. Kotich,20
-Morris,Twp 8,Attorney General,,D,A. J. Kotich,12
-Morris,Twp 9,Attorney General,,D,A. J. Kotich,20
-Morris,Ward 1,Attorney General,,D,A. J. Kotich,60
-Morris,Ward 2,Attorney General,,D,A. J. Kotich,47
-Morris,Ward 3,Attorney General,,D,A. J. Kotich,96
-Morris,Highland,Attorney General,,R,Derek Schmidt,39
-Morris,Overland,Attorney General,,R,Derek Schmidt,18
-Morris,Twp 1 Pct 1,Attorney General,,R,Derek Schmidt,76
-Morris,Twp 1 Pct 2,Attorney General,,R,Derek Schmidt,62
-Morris,Twp 2,Attorney General,,R,Derek Schmidt,228
-Morris,Twp 3,Attorney General,,R,Derek Schmidt,134
-Morris,Twp 4,Attorney General,,R,Derek Schmidt,79
-Morris,Twp 5,Attorney General,,R,Derek Schmidt,184
-Morris,Twp 6,Attorney General,,R,Derek Schmidt,36
-Morris,Twp 7,Attorney General,,R,Derek Schmidt,76
-Morris,Twp 8,Attorney General,,R,Derek Schmidt,81
-Morris,Twp 9,Attorney General,,R,Derek Schmidt,90
-Morris,Ward 1,Attorney General,,R,Derek Schmidt,134
-Morris,Ward 2,Attorney General,,R,Derek Schmidt,113
-Morris,Ward 3,Attorney General,,R,Derek Schmidt,231
-Morris,Highland,U.S. House,1,D,James E Sherow,10
-Morris,Overland,U.S. House,1,D,James E Sherow,9
-Morris,Twp 1 Pct 1,U.S. House,1,D,James E Sherow,39
-Morris,Twp 1 Pct 2,U.S. House,1,D,James E Sherow,29
-Morris,Twp 2,U.S. House,1,D,James E Sherow,130
-Morris,Twp 3,U.S. House,1,D,James E Sherow,52
-Morris,Twp 4,U.S. House,1,D,James E Sherow,23
-Morris,Twp 5,U.S. House,1,D,James E Sherow,37
-Morris,Twp 6,U.S. House,1,D,James E Sherow,6
-Morris,Twp 7,U.S. House,1,D,James E Sherow,29
-Morris,Twp 8,U.S. House,1,D,James E Sherow,24
-Morris,Twp 9,U.S. House,1,D,James E Sherow,33
-Morris,Ward 1,U.S. House,1,D,James E Sherow,76
-Morris,Ward 2,U.S. House,1,D,James E Sherow,61
-Morris,Ward 3,U.S. House,1,D,James E Sherow,142
-Morris,Highland,U.S. House,1,R,Tim Huelskamp,35
-Morris,Overland,U.S. House,1,R,Tim Huelskamp,16
-Morris,Twp 1 Pct 1,U.S. House,1,R,Tim Huelskamp,67
-Morris,Twp 1 Pct 2,U.S. House,1,R,Tim Huelskamp,49
-Morris,Twp 2,U.S. House,1,R,Tim Huelskamp,191
-Morris,Twp 3,U.S. House,1,R,Tim Huelskamp,117
-Morris,Twp 4,U.S. House,1,R,Tim Huelskamp,68
-Morris,Twp 5,U.S. House,1,R,Tim Huelskamp,176
-Morris,Twp 6,U.S. House,1,R,Tim Huelskamp,34
-Morris,Twp 7,U.S. House,1,R,Tim Huelskamp,69
-Morris,Twp 8,U.S. House,1,R,Tim Huelskamp,71
-Morris,Twp 9,U.S. House,1,R,Tim Huelskamp,76
-Morris,Ward 1,U.S. House,1,R,Tim Huelskamp,115
-Morris,Ward 2,U.S. House,1,R,Tim Huelskamp,97
-Morris,Ward 3,U.S. House,1,R,Tim Huelskamp,191
-Morris,Highland,Governor,,L,Keen Umbehr,3
-Morris,Overland,Governor,,L,Keen Umbehr,5
-Morris,Twp 1 Pct 1,Governor,,L,Keen Umbehr,8
-Morris,Twp 1 Pct 2,Governor,,L,Keen Umbehr,12
-Morris,Twp 2,Governor,,L,Keen Umbehr,27
-Morris,Twp 3,Governor,,L,Keen Umbehr,15
-Morris,Twp 4,Governor,,L,Keen Umbehr,12
-Morris,Twp 5,Governor,,L,Keen Umbehr,17
-Morris,Twp 6,Governor,,L,Keen Umbehr,3
-Morris,Twp 7,Governor,,L,Keen Umbehr,8
-Morris,Twp 8,Governor,,L,Keen Umbehr,4
-Morris,Twp 9,Governor,,L,Keen Umbehr,15
-Morris,Ward 1,Governor,,L,Keen Umbehr,21
-Morris,Ward 2,Governor,,L,Keen Umbehr,15
-Morris,Ward 3,Governor,,L,Keen Umbehr,35
-Morris,Highland,Governor,,D,Paul Davis,17
-Morris,Overland,Governor,,D,Paul Davis,9
-Morris,Twp 1 Pct 1,Governor,,D,Paul Davis,43
-Morris,Twp 1 Pct 2,Governor,,D,Paul Davis,37
-Morris,Twp 2,Governor,,D,Paul Davis,167
-Morris,Twp 3,Governor,,D,Paul Davis,64
-Morris,Twp 4,Governor,,D,Paul Davis,32
-Morris,Twp 5,Governor,,D,Paul Davis,65
-Morris,Twp 6,Governor,,D,Paul Davis,7
-Morris,Twp 7,Governor,,D,Paul Davis,38
-Morris,Twp 8,Governor,,D,Paul Davis,31
-Morris,Twp 9,Governor,,D,Paul Davis,45
-Morris,Ward 1,Governor,,D,Paul Davis,98
-Morris,Ward 2,Governor,,D,Paul Davis,75
-Morris,Ward 3,Governor,,D,Paul Davis,184
-Morris,Highland,Governor,,R,Sam Brownback,30
-Morris,Overland,Governor,,R,Sam Brownback,14
-Morris,Twp 1 Pct 1,Governor,,R,Sam Brownback,56
-Morris,Twp 1 Pct 2,Governor,,R,Sam Brownback,39
-Morris,Twp 2,Governor,,R,Sam Brownback,129
-Morris,Twp 3,Governor,,R,Sam Brownback,94
-Morris,Twp 4,Governor,,R,Sam Brownback,49
-Morris,Twp 5,Governor,,R,Sam Brownback,129
-Morris,Twp 6,Governor,,R,Sam Brownback,30
-Morris,Twp 7,Governor,,R,Sam Brownback,56
-Morris,Twp 8,Governor,,R,Sam Brownback,60
-Morris,Twp 9,Governor,,R,Sam Brownback,53
-Morris,Ward 1,Governor,,R,Sam Brownback,75
-Morris,Ward 2,Governor,,R,Sam Brownback,71
-Morris,Ward 3,Governor,,R,Sam Brownback,115
-Morris,Highland,Insurance Commissioner,,D,Dennis Anderson,6
-Morris,Overland,Insurance Commissioner,,D,Dennis Anderson,6
-Morris,Twp 1 Pct 1,Insurance Commissioner,,D,Dennis Anderson,29
-Morris,Twp 1 Pct 2,Insurance Commissioner,,D,Dennis Anderson,25
-Morris,Twp 2,Insurance Commissioner,,D,Dennis Anderson,114
-Morris,Twp 3,Insurance Commissioner,,D,Dennis Anderson,47
-Morris,Twp 4,Insurance Commissioner,,D,Dennis Anderson,18
-Morris,Twp 5,Insurance Commissioner,,D,Dennis Anderson,38
-Morris,Twp 6,Insurance Commissioner,,D,Dennis Anderson,5
-Morris,Twp 7,Insurance Commissioner,,D,Dennis Anderson,27
-Morris,Twp 8,Insurance Commissioner,,D,Dennis Anderson,14
-Morris,Twp 9,Insurance Commissioner,,D,Dennis Anderson,23
-Morris,Ward 1,Insurance Commissioner,,D,Dennis Anderson,76
-Morris,Ward 2,Insurance Commissioner,,D,Dennis Anderson,58
-Morris,Ward 3,Insurance Commissioner,,D,Dennis Anderson,124
-Morris,Highland,Insurance Commissioner,,R,Ken Selzer,37
-Morris,Overland,Insurance Commissioner,,R,Ken Selzer,16
-Morris,Twp 1 Pct 1,Insurance Commissioner,,R,Ken Selzer,73
-Morris,Twp 1 Pct 2,Insurance Commissioner,,R,Ken Selzer,53
-Morris,Twp 2,Insurance Commissioner,,R,Ken Selzer,197
-Morris,Twp 3,Insurance Commissioner,,R,Ken Selzer,118
-Morris,Twp 4,Insurance Commissioner,,R,Ken Selzer,73
-Morris,Twp 5,Insurance Commissioner,,R,Ken Selzer,174
-Morris,Twp 6,Insurance Commissioner,,R,Ken Selzer,32
-Morris,Twp 7,Insurance Commissioner,,R,Ken Selzer,69
-Morris,Twp 8,Insurance Commissioner,,R,Ken Selzer,78
-Morris,Twp 9,Insurance Commissioner,,R,Ken Selzer,81
-Morris,Ward 1,Insurance Commissioner,,R,Ken Selzer,108
-Morris,Ward 2,Insurance Commissioner,,R,Ken Selzer,94
-Morris,Ward 3,Insurance Commissioner,,R,Ken Selzer,195
-Morris,Highland,Secretary of State,,D,Jean Kurtis Schodorf,8
-Morris,Overland,Secretary of State,,D,Jean Kurtis Schodorf,8
-Morris,Twp 1 Pct 1,Secretary of State,,D,Jean Kurtis Schodorf,39
-Morris,Twp 1 Pct 2,Secretary of State,,D,Jean Kurtis Schodorf,29
-Morris,Twp 2,Secretary of State,,D,Jean Kurtis Schodorf,126
-Morris,Twp 3,Secretary of State,,D,Jean Kurtis Schodorf,47
-Morris,Twp 4,Secretary of State,,D,Jean Kurtis Schodorf,19
-Morris,Twp 5,Secretary of State,,D,Jean Kurtis Schodorf,33
-Morris,Twp 6,Secretary of State,,D,Jean Kurtis Schodorf,5
-Morris,Twp 7,Secretary of State,,D,Jean Kurtis Schodorf,30
-Morris,Twp 8,Secretary of State,,D,Jean Kurtis Schodorf,20
-Morris,Twp 9,Secretary of State,,D,Jean Kurtis Schodorf,29
-Morris,Ward 1,Secretary of State,,D,Jean Kurtis Schodorf,72
-Morris,Ward 2,Secretary of State,,D,Jean Kurtis Schodorf,59
-Morris,Ward 3,Secretary of State,,D,Jean Kurtis Schodorf,123
-Morris,Highland,Secretary of State,,R,Kris Kobach,40
-Morris,Overland,Secretary of State,,R,Kris Kobach,16
-Morris,Twp 1 Pct 1,Secretary of State,,R,Kris Kobach,70
-Morris,Twp 1 Pct 2,Secretary of State,,R,Kris Kobach,52
-Morris,Twp 2,Secretary of State,,R,Kris Kobach,193
-Morris,Twp 3,Secretary of State,,R,Kris Kobach,124
-Morris,Twp 4,Secretary of State,,R,Kris Kobach,74
-Morris,Twp 5,Secretary of State,,R,Kris Kobach,179
-Morris,Twp 6,Secretary of State,,R,Kris Kobach,34
-Morris,Twp 7,Secretary of State,,R,Kris Kobach,69
-Morris,Twp 8,Secretary of State,,R,Kris Kobach,76
-Morris,Twp 9,Secretary of State,,R,Kris Kobach,81
-Morris,Ward 1,Secretary of State,,R,Kris Kobach,120
-Morris,Ward 2,Secretary of State,,R,Kris Kobach,104
-Morris,Ward 3,Secretary of State,,R,Kris Kobach,208
-Morris,Highland,State Senate,37,R,Richard Wilborn,38
-Morris,Overland,State Senate,37,R,Richard Wilborn,16
-Morris,Twp 1 Pct 1,State Senate,37,R,Richard Wilborn,82
-Morris,Twp 1 Pct 2,State Senate,37,R,Richard Wilborn,64
-Morris,Twp 2,State Senate,37,R,Richard Wilborn,259
-Morris,Twp 3,State Senate,37,R,Richard Wilborn,134
-Morris,Twp 4,State Senate,37,R,Richard Wilborn,74
-Morris,Twp 5,State Senate,37,R,Richard Wilborn,189
-Morris,Twp 6,State Senate,37,R,Richard Wilborn,33
-Morris,Twp 7,State Senate,37,R,Richard Wilborn,79
-Morris,Twp 8,State Senate,37,R,Richard Wilborn,86
-Morris,Twp 9,State Senate,37,R,Richard Wilborn,96
-Morris,Ward 1,State Senate,37,R,Richard Wilborn,153
-Morris,Ward 2,State Senate,37,R,Richard Wilborn,116
-Morris,Ward 3,State Senate,37,R,Richard Wilborn,276
-Morris,Highland,State House,68,R,Tom Moxley,43
-Morris,Overland,State House,68,R,Tom Moxley,24
-Morris,Twp 1 Pct 1,State House,68,R,Tom Moxley,90
-Morris,Twp 1 Pct 2,State House,68,R,Tom Moxley,66
-Morris,Twp 2,State House,68,R,Tom Moxley,285
-Morris,Twp 3,State House,68,R,Tom Moxley,146
-Morris,Twp 4,State House,68,R,Tom Moxley,80
-Morris,Twp 5,State House,68,R,Tom Moxley,199
-Morris,Twp 6,State House,68,R,Tom Moxley,30
-Morris,Twp 7,State House,68,R,Tom Moxley,85
-Morris,Twp 8,State House,68,R,Tom Moxley,88
-Morris,Twp 9,State House,68,R,Tom Moxley,98
-Morris,Ward 1,State House,68,R,Tom Moxley,168
-Morris,Ward 2,State House,68,R,Tom Moxley,138
-Morris,Ward 3,State House,68,R,Tom Moxley,312
-Morris,Highland,State Treasurer,,D,Carmen Alldritt,6
-Morris,Overland,State Treasurer,,D,Carmen Alldritt,6
-Morris,Twp 1 Pct 1,State Treasurer,,D,Carmen Alldritt,25
-Morris,Twp 1 Pct 2,State Treasurer,,D,Carmen Alldritt,20
-Morris,Twp 2,State Treasurer,,D,Carmen Alldritt,85
-Morris,Twp 3,State Treasurer,,D,Carmen Alldritt,40
-Morris,Twp 4,State Treasurer,,D,Carmen Alldritt,14
-Morris,Twp 5,State Treasurer,,D,Carmen Alldritt,26
-Morris,Twp 6,State Treasurer,,D,Carmen Alldritt,4
-Morris,Twp 7,State Treasurer,,D,Carmen Alldritt,24
-Morris,Twp 8,State Treasurer,,D,Carmen Alldritt,11
-Morris,Twp 9,State Treasurer,,D,Carmen Alldritt,19
-Morris,Ward 1,State Treasurer,,D,Carmen Alldritt,70
-Morris,Ward 2,State Treasurer,,D,Carmen Alldritt,47
-Morris,Ward 3,State Treasurer,,D,Carmen Alldritt,82
-Morris,Highland,State Treasurer,,R,Ron Estes,38
-Morris,Overland,State Treasurer,,R,Ron Estes,16
-Morris,Twp 1 Pct 1,State Treasurer,,R,Ron Estes,80
-Morris,Twp 1 Pct 2,State Treasurer,,R,Ron Estes,61
-Morris,Twp 2,State Treasurer,,R,Ron Estes,232
-Morris,Twp 3,State Treasurer,,R,Ron Estes,131
-Morris,Twp 4,State Treasurer,,R,Ron Estes,77
-Morris,Twp 5,State Treasurer,,R,Ron Estes,186
-Morris,Twp 6,State Treasurer,,R,Ron Estes,33
-Morris,Twp 7,State Treasurer,,R,Ron Estes,73
-Morris,Twp 8,State Treasurer,,R,Ron Estes,81
-Morris,Twp 9,State Treasurer,,R,Ron Estes,89
-Morris,Ward 1,State Treasurer,,R,Ron Estes,124
-Morris,Ward 2,State Treasurer,,R,Ron Estes,97
-Morris,Ward 3,State Treasurer,,R,Ron Estes,244
-Morris,Highland,U.S. Senate,,I,Greg Orman,11
-Morris,Overland,U.S. Senate,,I,Greg Orman,7
-Morris,Twp 1 Pct 1,U.S. Senate,,I,Greg Orman,32
-Morris,Twp 1 Pct 2,U.S. Senate,,I,Greg Orman,20
-Morris,Twp 2,U.S. Senate,,I,Greg Orman,134
-Morris,Twp 3,U.S. Senate,,I,Greg Orman,52
-Morris,Twp 4,U.S. Senate,,I,Greg Orman,20
-Morris,Twp 5,U.S. Senate,,I,Greg Orman,45
-Morris,Twp 6,U.S. Senate,,I,Greg Orman,12
-Morris,Twp 7,U.S. Senate,,I,Greg Orman,30
-Morris,Twp 8,U.S. Senate,,I,Greg Orman,18
-Morris,Twp 9,U.S. Senate,,I,Greg Orman,32
-Morris,Ward 1,U.S. Senate,,I,Greg Orman,87
-Morris,Ward 2,U.S. Senate,,I,Greg Orman,62
-Morris,Ward 3,U.S. Senate,,I,Greg Orman,161
-Morris,Highland,U.S. Senate,,R,Pat Roberts,35
-Morris,Overland,U.S. Senate,,R,Pat Roberts,15
-Morris,Twp 1 Pct 1,U.S. Senate,,R,Pat Roberts,65
-Morris,Twp 1 Pct 2,U.S. Senate,,R,Pat Roberts,47
-Morris,Twp 2,U.S. Senate,,R,Pat Roberts,169
-Morris,Twp 3,U.S. Senate,,R,Pat Roberts,107
-Morris,Twp 4,U.S. Senate,,R,Pat Roberts,63
-Morris,Twp 5,U.S. Senate,,R,Pat Roberts,153
-Morris,Twp 6,U.S. Senate,,R,Pat Roberts,31
-Morris,Twp 7,U.S. Senate,,R,Pat Roberts,63
-Morris,Twp 8,U.S. Senate,,R,Pat Roberts,62
-Morris,Twp 9,U.S. Senate,,R,Pat Roberts,63
-Morris,Ward 1,U.S. Senate,,R,Pat Roberts,96
-Morris,Ward 2,U.S. Senate,,R,Pat Roberts,84
-Morris,Ward 3,U.S. Senate,,R,Pat Roberts,143
-Morris,Highland,U.S. Senate,,L,Randall Batson,3
-Morris,Overland,U.S. Senate,,L,Randall Batson,3
-Morris,Twp 1 Pct 1,U.S. Senate,,L,Randall Batson,7
-Morris,Twp 1 Pct 2,U.S. Senate,,L,Randall Batson,3
-Morris,Twp 2,U.S. Senate,,L,Randall Batson,9
-Morris,Twp 3,U.S. Senate,,L,Randall Batson,11
-Morris,Twp 4,U.S. Senate,,L,Randall Batson,6
-Morris,Twp 5,U.S. Senate,,L,Randall Batson,10
-Morris,Twp 6,U.S. Senate,,L,Randall Batson,2
-Morris,Twp 7,U.S. Senate,,L,Randall Batson,4
-Morris,Twp 8,U.S. Senate,,L,Randall Batson,7
-Morris,Twp 9,U.S. Senate,,L,Randall Batson,11
-Morris,Ward 1,U.S. Senate,,L,Randall Batson,13
-Morris,Ward 2,U.S. Senate,,L,Randall Batson,8
-Morris,Ward 3,U.S. Senate,,L,Randall Batson,19
+county,precinct,office,district,party,candidate,votes,vtd
+MORRIS,Council Grove Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",98,000010
+MORRIS,Council Grove Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000010
+MORRIS,Council Grove Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000010
+MORRIS,Council Grove Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",75,000020
+MORRIS,Council Grove Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000020
+MORRIS,Council Grove Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000020
+MORRIS,Council Grove Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",184,000030
+MORRIS,Council Grove Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",35,000030
+MORRIS,Council Grove Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000030
+MORRIS,Herington Ward 1 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000040
+MORRIS,Herington Ward 1 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+MORRIS,Herington Ward 1 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000040
+MORRIS,Herington Ward 1 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000050
+MORRIS,Herington Ward 1 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+MORRIS,Herington Ward 1 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000050
+MORRIS,Highland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000060
+MORRIS,Highland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000060
+MORRIS,Highland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000060
+MORRIS,Overland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000070
+MORRIS,Overland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000070
+MORRIS,Overland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000070
+MORRIS,Township 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000080
+MORRIS,Township 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000080
+MORRIS,Township 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,000080
+MORRIS,Township 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000090
+MORRIS,Township 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000090
+MORRIS,Township 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000090
+MORRIS,Township 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",167,000100
+MORRIS,Township 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",27,000100
+MORRIS,Township 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",129,000100
+MORRIS,Township 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",64,000110
+MORRIS,Township 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000110
+MORRIS,Township 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,000110
+MORRIS,Township 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000120
+MORRIS,Township 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000120
+MORRIS,Township 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000120
+MORRIS,Township 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000130
+MORRIS,Township 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000130
+MORRIS,Township 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",129,000130
+MORRIS,Township 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000140
+MORRIS,Township 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000140
+MORRIS,Township 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000140
+MORRIS,Township 7,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,000150
+MORRIS,Township 7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000150
+MORRIS,Township 7,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,000150
+MORRIS,Township 8,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000160
+MORRIS,Township 8,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000160
+MORRIS,Township 8,Governor / Lt. Governor,,Republican,"Brownback, Sam",60,000160
+MORRIS,Township 9,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000170
+MORRIS,Township 9,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000170
+MORRIS,Township 9,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000170
+MORRIS,Council Grove Ward 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+MORRIS,Council Grove Ward 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+MORRIS,Herington Exclave C Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+MORRIS,Herington Exclave C Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+MORRIS,Herington Exclave C Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+MORRIS,Council Grove Ward 1,Kansas House of Representatives,68,Republican,"Moxley, Tom",168,000010
+MORRIS,Council Grove Ward 2,Kansas House of Representatives,68,Republican,"Moxley, Tom",138,000020
+MORRIS,Council Grove Ward 3,Kansas House of Representatives,68,Republican,"Moxley, Tom",312,000030
+MORRIS,Herington Ward 1 Exclave A,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,000040
+MORRIS,Herington Ward 1 Exclave B,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,000050
+MORRIS,Highland Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",43,000060
+MORRIS,Overland Township,Kansas House of Representatives,68,Republican,"Moxley, Tom",24,000070
+MORRIS,Township 1 Precinct 1,Kansas House of Representatives,68,Republican,"Moxley, Tom",90,000080
+MORRIS,Township 1 Precinct 2,Kansas House of Representatives,68,Republican,"Moxley, Tom",66,000090
+MORRIS,Township 2,Kansas House of Representatives,68,Republican,"Moxley, Tom",285,000100
+MORRIS,Township 3,Kansas House of Representatives,68,Republican,"Moxley, Tom",146,000110
+MORRIS,Township 4,Kansas House of Representatives,68,Republican,"Moxley, Tom",80,000120
+MORRIS,Township 5,Kansas House of Representatives,68,Republican,"Moxley, Tom",199,000130
+MORRIS,Township 6,Kansas House of Representatives,68,Republican,"Moxley, Tom",30,000140
+MORRIS,Township 7,Kansas House of Representatives,68,Republican,"Moxley, Tom",85,000150
+MORRIS,Township 8,Kansas House of Representatives,68,Republican,"Moxley, Tom",88,000160
+MORRIS,Township 9,Kansas House of Representatives,68,Republican,"Moxley, Tom",98,000170
+MORRIS,Council Grove Ward 3 Exclave,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,900010
+MORRIS,Herington Exclave C Airport,Kansas House of Representatives,68,Republican,"Moxley, Tom",0,900020
+MORRIS,Council Grove Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",76,000010
+MORRIS,Council Grove Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",115,000010
+MORRIS,Council Grove Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",61,000020
+MORRIS,Council Grove Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",97,000020
+MORRIS,Council Grove Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",142,000030
+MORRIS,Council Grove Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",191,000030
+MORRIS,Herington Ward 1 Exclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000040
+MORRIS,Herington Ward 1 Exclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000050
+MORRIS,Highland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000060
+MORRIS,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000060
+MORRIS,Overland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000070
+MORRIS,Overland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000070
+MORRIS,Township 1 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",39,000080
+MORRIS,Township 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000080
+MORRIS,Township 1 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000090
+MORRIS,Township 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000090
+MORRIS,Township 2,United States House of Representatives,1,Democratic,"Sherow, James E.",130,000100
+MORRIS,Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",191,000100
+MORRIS,Township 3,United States House of Representatives,1,Democratic,"Sherow, James E.",52,000110
+MORRIS,Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",117,000110
+MORRIS,Township 4,United States House of Representatives,1,Democratic,"Sherow, James E.",23,000120
+MORRIS,Township 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",68,000120
+MORRIS,Township 5,United States House of Representatives,1,Democratic,"Sherow, James E.",37,000130
+MORRIS,Township 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",176,000130
+MORRIS,Township 6,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000140
+MORRIS,Township 6,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000140
+MORRIS,Township 7,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000150
+MORRIS,Township 7,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,000150
+MORRIS,Township 8,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000160
+MORRIS,Township 8,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,000160
+MORRIS,Township 9,United States House of Representatives,1,Democratic,"Sherow, James E.",33,000170
+MORRIS,Township 9,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000170
+MORRIS,Council Grove Ward 3 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+MORRIS,Herington Exclave C Airport,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+MORRIS,Herington Exclave C Airport,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+MORRIS,Council Grove Ward 1,Attorney General,,Democratic,"Kotich, A.J.",60,000010
+MORRIS,Council Grove Ward 1,Attorney General,,Republican,"Schmidt, Derek",134,000010
+MORRIS,Council Grove Ward 2,Attorney General,,Democratic,"Kotich, A.J.",47,000020
+MORRIS,Council Grove Ward 2,Attorney General,,Republican,"Schmidt, Derek",113,000020
+MORRIS,Council Grove Ward 3,Attorney General,,Democratic,"Kotich, A.J.",96,000030
+MORRIS,Council Grove Ward 3,Attorney General,,Republican,"Schmidt, Derek",231,000030
+MORRIS,Herington Ward 1 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,000040
+MORRIS,Herington Ward 1 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,000040
+MORRIS,Herington Ward 1 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,000050
+MORRIS,Herington Ward 1 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,000050
+MORRIS,Highland Township,Attorney General,,Democratic,"Kotich, A.J.",7,000060
+MORRIS,Highland Township,Attorney General,,Republican,"Schmidt, Derek",39,000060
+MORRIS,Overland Township,Attorney General,,Democratic,"Kotich, A.J.",6,000070
+MORRIS,Overland Township,Attorney General,,Republican,"Schmidt, Derek",18,000070
+MORRIS,Township 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",31,000080
+MORRIS,Township 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",76,000080
+MORRIS,Township 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",19,000090
+MORRIS,Township 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",62,000090
+MORRIS,Township 2,Attorney General,,Democratic,"Kotich, A.J.",90,000100
+MORRIS,Township 2,Attorney General,,Republican,"Schmidt, Derek",228,000100
+MORRIS,Township 3,Attorney General,,Democratic,"Kotich, A.J.",38,000110
+MORRIS,Township 3,Attorney General,,Republican,"Schmidt, Derek",134,000110
+MORRIS,Township 4,Attorney General,,Democratic,"Kotich, A.J.",13,000120
+MORRIS,Township 4,Attorney General,,Republican,"Schmidt, Derek",79,000120
+MORRIS,Township 5,Attorney General,,Democratic,"Kotich, A.J.",27,000130
+MORRIS,Township 5,Attorney General,,Republican,"Schmidt, Derek",184,000130
+MORRIS,Township 6,Attorney General,,Democratic,"Kotich, A.J.",4,000140
+MORRIS,Township 6,Attorney General,,Republican,"Schmidt, Derek",36,000140
+MORRIS,Township 7,Attorney General,,Democratic,"Kotich, A.J.",20,000150
+MORRIS,Township 7,Attorney General,,Republican,"Schmidt, Derek",76,000150
+MORRIS,Township 8,Attorney General,,Democratic,"Kotich, A.J.",12,000160
+MORRIS,Township 8,Attorney General,,Republican,"Schmidt, Derek",81,000160
+MORRIS,Township 9,Attorney General,,Democratic,"Kotich, A.J.",20,000170
+MORRIS,Township 9,Attorney General,,Republican,"Schmidt, Derek",90,000170
+MORRIS,Council Grove Ward 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+MORRIS,Herington Exclave C Airport,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+MORRIS,Herington Exclave C Airport,Attorney General,,Republican,"Schmidt, Derek",0,900020
+MORRIS,Council Grove Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,000010
+MORRIS,Council Grove Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",108,000010
+MORRIS,Council Grove Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,000020
+MORRIS,Council Grove Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",94,000020
+MORRIS,Council Grove Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",124,000030
+MORRIS,Council Grove Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",195,000030
+MORRIS,Herington Ward 1 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000040
+MORRIS,Herington Ward 1 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000040
+MORRIS,Herington Ward 1 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000050
+MORRIS,Herington Ward 1 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000050
+MORRIS,Highland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000060
+MORRIS,Highland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000060
+MORRIS,Overland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000070
+MORRIS,Overland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000070
+MORRIS,Township 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000080
+MORRIS,Township 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000080
+MORRIS,Township 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000090
+MORRIS,Township 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",53,000090
+MORRIS,Township 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",114,000100
+MORRIS,Township 2,Commissioner of Insurance,,Republican,"Selzer, Ken",197,000100
+MORRIS,Township 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000110
+MORRIS,Township 3,Commissioner of Insurance,,Republican,"Selzer, Ken",118,000110
+MORRIS,Township 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000120
+MORRIS,Township 4,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000120
+MORRIS,Township 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000130
+MORRIS,Township 5,Commissioner of Insurance,,Republican,"Selzer, Ken",174,000130
+MORRIS,Township 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000140
+MORRIS,Township 6,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000140
+MORRIS,Township 7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000150
+MORRIS,Township 7,Commissioner of Insurance,,Republican,"Selzer, Ken",69,000150
+MORRIS,Township 8,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000160
+MORRIS,Township 8,Commissioner of Insurance,,Republican,"Selzer, Ken",78,000160
+MORRIS,Township 9,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000170
+MORRIS,Township 9,Commissioner of Insurance,,Republican,"Selzer, Ken",81,000170
+MORRIS,Council Grove Ward 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+MORRIS,Council Grove Ward 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+MORRIS,Herington Exclave C Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+MORRIS,Herington Exclave C Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+MORRIS,Council Grove Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",153,000010
+MORRIS,Council Grove Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",116,000020
+MORRIS,Council Grove Ward 3,Kansas Senate,35,Republican,"Wilborn, Richard",276,000030
+MORRIS,Herington Ward 1 Exclave A,Kansas Senate,35,Republican,"Wilborn, Richard",0,000040
+MORRIS,Herington Ward 1 Exclave B,Kansas Senate,35,Republican,"Wilborn, Richard",0,000050
+MORRIS,Highland Township,Kansas Senate,35,Republican,"Wilborn, Richard",38,000060
+MORRIS,Overland Township,Kansas Senate,35,Republican,"Wilborn, Richard",16,000070
+MORRIS,Township 1 Precinct 1,Kansas Senate,35,Republican,"Wilborn, Richard",82,000080
+MORRIS,Township 1 Precinct 2,Kansas Senate,35,Republican,"Wilborn, Richard",64,000090
+MORRIS,Township 2,Kansas Senate,35,Republican,"Wilborn, Richard",259,000100
+MORRIS,Township 3,Kansas Senate,35,Republican,"Wilborn, Richard",134,000110
+MORRIS,Township 4,Kansas Senate,35,Republican,"Wilborn, Richard",74,000120
+MORRIS,Township 5,Kansas Senate,35,Republican,"Wilborn, Richard",189,000130
+MORRIS,Township 6,Kansas Senate,35,Republican,"Wilborn, Richard",33,000140
+MORRIS,Township 7,Kansas Senate,35,Republican,"Wilborn, Richard",79,000150
+MORRIS,Township 8,Kansas Senate,35,Republican,"Wilborn, Richard",86,000160
+MORRIS,Township 9,Kansas Senate,35,Republican,"Wilborn, Richard",96,000170
+MORRIS,Council Grove Ward 3 Exclave,Kansas Senate,35,Republican,"Wilborn, Richard",0,900010
+MORRIS,Herington Exclave C Airport,Kansas Senate,35,Republican,"Wilborn, Richard",0,900020
+MORRIS,Council Grove Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,000010
+MORRIS,Council Grove Ward 1,Secretary of State,,Republican,"Kobach, Kris",120,000010
+MORRIS,Council Grove Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000020
+MORRIS,Council Grove Ward 2,Secretary of State,,Republican,"Kobach, Kris",104,000020
+MORRIS,Council Grove Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",123,000030
+MORRIS,Council Grove Ward 3,Secretary of State,,Republican,"Kobach, Kris",208,000030
+MORRIS,Herington Ward 1 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000040
+MORRIS,Herington Ward 1 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,000040
+MORRIS,Herington Ward 1 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000050
+MORRIS,Herington Ward 1 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,000050
+MORRIS,Highland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000060
+MORRIS,Highland Township,Secretary of State,,Republican,"Kobach, Kris",40,000060
+MORRIS,Overland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000070
+MORRIS,Overland Township,Secretary of State,,Republican,"Kobach, Kris",16,000070
+MORRIS,Township 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000080
+MORRIS,Township 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",70,000080
+MORRIS,Township 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000090
+MORRIS,Township 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",52,000090
+MORRIS,Township 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",126,000100
+MORRIS,Township 2,Secretary of State,,Republican,"Kobach, Kris",193,000100
+MORRIS,Township 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000110
+MORRIS,Township 3,Secretary of State,,Republican,"Kobach, Kris",124,000110
+MORRIS,Township 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000120
+MORRIS,Township 4,Secretary of State,,Republican,"Kobach, Kris",74,000120
+MORRIS,Township 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000130
+MORRIS,Township 5,Secretary of State,,Republican,"Kobach, Kris",179,000130
+MORRIS,Township 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000140
+MORRIS,Township 6,Secretary of State,,Republican,"Kobach, Kris",34,000140
+MORRIS,Township 7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000150
+MORRIS,Township 7,Secretary of State,,Republican,"Kobach, Kris",69,000150
+MORRIS,Township 8,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000160
+MORRIS,Township 8,Secretary of State,,Republican,"Kobach, Kris",76,000160
+MORRIS,Township 9,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000170
+MORRIS,Township 9,Secretary of State,,Republican,"Kobach, Kris",81,000170
+MORRIS,Council Grove Ward 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+MORRIS,Council Grove Ward 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+MORRIS,Herington Exclave C Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+MORRIS,Herington Exclave C Airport,Secretary of State,,Republican,"Kobach, Kris",0,900020
+MORRIS,Council Grove Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",70,000010
+MORRIS,Council Grove Ward 1,State Treasurer,,Republican,"Estes, Ron",124,000010
+MORRIS,Council Grove Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",47,000020
+MORRIS,Council Grove Ward 2,State Treasurer,,Republican,"Estes, Ron",97,000020
+MORRIS,Council Grove Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",82,000030
+MORRIS,Council Grove Ward 3,State Treasurer,,Republican,"Estes, Ron",244,000030
+MORRIS,Herington Ward 1 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+MORRIS,Herington Ward 1 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,000040
+MORRIS,Herington Ward 1 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,000050
+MORRIS,Herington Ward 1 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,000050
+MORRIS,Highland Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000060
+MORRIS,Highland Township,State Treasurer,,Republican,"Estes, Ron",38,000060
+MORRIS,Overland Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000070
+MORRIS,Overland Township,State Treasurer,,Republican,"Estes, Ron",16,000070
+MORRIS,Township 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",25,000080
+MORRIS,Township 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",80,000080
+MORRIS,Township 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",20,000090
+MORRIS,Township 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",61,000090
+MORRIS,Township 2,State Treasurer,,Democratic,"Alldritt, Carmen",85,000100
+MORRIS,Township 2,State Treasurer,,Republican,"Estes, Ron",232,000100
+MORRIS,Township 3,State Treasurer,,Democratic,"Alldritt, Carmen",40,000110
+MORRIS,Township 3,State Treasurer,,Republican,"Estes, Ron",131,000110
+MORRIS,Township 4,State Treasurer,,Democratic,"Alldritt, Carmen",14,000120
+MORRIS,Township 4,State Treasurer,,Republican,"Estes, Ron",77,000120
+MORRIS,Township 5,State Treasurer,,Democratic,"Alldritt, Carmen",26,000130
+MORRIS,Township 5,State Treasurer,,Republican,"Estes, Ron",186,000130
+MORRIS,Township 6,State Treasurer,,Democratic,"Alldritt, Carmen",4,000140
+MORRIS,Township 6,State Treasurer,,Republican,"Estes, Ron",33,000140
+MORRIS,Township 7,State Treasurer,,Democratic,"Alldritt, Carmen",24,000150
+MORRIS,Township 7,State Treasurer,,Republican,"Estes, Ron",73,000150
+MORRIS,Township 8,State Treasurer,,Democratic,"Alldritt, Carmen",11,000160
+MORRIS,Township 8,State Treasurer,,Republican,"Estes, Ron",81,000160
+MORRIS,Township 9,State Treasurer,,Democratic,"Alldritt, Carmen",19,000170
+MORRIS,Township 9,State Treasurer,,Republican,"Estes, Ron",89,000170
+MORRIS,Council Grove Ward 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+MORRIS,Council Grove Ward 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+MORRIS,Herington Exclave C Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+MORRIS,Herington Exclave C Airport,State Treasurer,,Republican,"Estes, Ron",0,900020
+MORRIS,Council Grove Ward 1,United States Senate,,independent,"Orman, Greg",87,000010
+MORRIS,Council Grove Ward 1,United States Senate,,Libertarian,"Batson, Randall",13,000010
+MORRIS,Council Grove Ward 1,United States Senate,,Republican,"Roberts, Pat",96,000010
+MORRIS,Council Grove Ward 2,United States Senate,,independent,"Orman, Greg",62,000020
+MORRIS,Council Grove Ward 2,United States Senate,,Libertarian,"Batson, Randall",8,000020
+MORRIS,Council Grove Ward 2,United States Senate,,Republican,"Roberts, Pat",84,000020
+MORRIS,Council Grove Ward 3,United States Senate,,independent,"Orman, Greg",161,000030
+MORRIS,Council Grove Ward 3,United States Senate,,Libertarian,"Batson, Randall",19,000030
+MORRIS,Council Grove Ward 3,United States Senate,,Republican,"Roberts, Pat",143,000030
+MORRIS,Herington Ward 1 Exclave A,United States Senate,,independent,"Orman, Greg",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,000040
+MORRIS,Herington Ward 1 Exclave B,United States Senate,,independent,"Orman, Greg",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,000050
+MORRIS,Highland Township,United States Senate,,independent,"Orman, Greg",11,000060
+MORRIS,Highland Township,United States Senate,,Libertarian,"Batson, Randall",3,000060
+MORRIS,Highland Township,United States Senate,,Republican,"Roberts, Pat",35,000060
+MORRIS,Overland Township,United States Senate,,independent,"Orman, Greg",7,000070
+MORRIS,Overland Township,United States Senate,,Libertarian,"Batson, Randall",3,000070
+MORRIS,Overland Township,United States Senate,,Republican,"Roberts, Pat",15,000070
+MORRIS,Township 1 Precinct 1,United States Senate,,independent,"Orman, Greg",32,000080
+MORRIS,Township 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",7,000080
+MORRIS,Township 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",65,000080
+MORRIS,Township 1 Precinct 2,United States Senate,,independent,"Orman, Greg",20,000090
+MORRIS,Township 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",3,000090
+MORRIS,Township 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",47,000090
+MORRIS,Township 2,United States Senate,,independent,"Orman, Greg",134,000100
+MORRIS,Township 2,United States Senate,,Libertarian,"Batson, Randall",9,000100
+MORRIS,Township 2,United States Senate,,Republican,"Roberts, Pat",169,000100
+MORRIS,Township 3,United States Senate,,independent,"Orman, Greg",52,000110
+MORRIS,Township 3,United States Senate,,Libertarian,"Batson, Randall",11,000110
+MORRIS,Township 3,United States Senate,,Republican,"Roberts, Pat",107,000110
+MORRIS,Township 4,United States Senate,,independent,"Orman, Greg",20,000120
+MORRIS,Township 4,United States Senate,,Libertarian,"Batson, Randall",6,000120
+MORRIS,Township 4,United States Senate,,Republican,"Roberts, Pat",63,000120
+MORRIS,Township 5,United States Senate,,independent,"Orman, Greg",45,000130
+MORRIS,Township 5,United States Senate,,Libertarian,"Batson, Randall",10,000130
+MORRIS,Township 5,United States Senate,,Republican,"Roberts, Pat",153,000130
+MORRIS,Township 6,United States Senate,,independent,"Orman, Greg",12,000140
+MORRIS,Township 6,United States Senate,,Libertarian,"Batson, Randall",2,000140
+MORRIS,Township 6,United States Senate,,Republican,"Roberts, Pat",31,000140
+MORRIS,Township 7,United States Senate,,independent,"Orman, Greg",30,000150
+MORRIS,Township 7,United States Senate,,Libertarian,"Batson, Randall",4,000150
+MORRIS,Township 7,United States Senate,,Republican,"Roberts, Pat",63,000150
+MORRIS,Township 8,United States Senate,,independent,"Orman, Greg",18,000160
+MORRIS,Township 8,United States Senate,,Libertarian,"Batson, Randall",7,000160
+MORRIS,Township 8,United States Senate,,Republican,"Roberts, Pat",62,000160
+MORRIS,Township 9,United States Senate,,independent,"Orman, Greg",32,000170
+MORRIS,Township 9,United States Senate,,Libertarian,"Batson, Randall",11,000170
+MORRIS,Township 9,United States Senate,,Republican,"Roberts, Pat",63,000170
+MORRIS,Council Grove Ward 3 Exclave,United States Senate,,independent,"Orman, Greg",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900010
+MORRIS,Herington Exclave C Airport,United States Senate,,independent,"Orman, Greg",0,900020
+MORRIS,Herington Exclave C Airport,United States Senate,,Libertarian,"Batson, Randall",0,900020
+MORRIS,Herington Exclave C Airport,United States Senate,,Republican,"Roberts, Pat",0,900020

--- a/2014/20141104__ks__general__morton__precinct.csv
+++ b/2014/20141104__ks__general__morton__precinct.csv
@@ -1,171 +1,171 @@
-county,precinct,office,district,party,candidate,votes
-Morton,Cimarron,U.S. Senate,,R,Pat Roberts,22
-Morton,E Richfield,U.S. Senate,,R,Pat Roberts,27
-Morton,Elkhart W1,U.S. Senate,,R,Pat Roberts,148
-Morton,Elkhart W2,U.S. Senate,,R,Pat Roberts,129
-Morton,Elkhart W3,U.S. Senate,,R,Pat Roberts,166
-Morton,Jones,U.S. Senate,,R,Pat Roberts,9
-Morton,Rolla,U.S. Senate,,R,Pat Roberts,104
-Morton,Taloga,U.S. Senate,,R,Pat Roberts,32
-Morton,W Richfield,U.S. Senate,,R,Pat Roberts,38
-Morton,Westola,U.S. Senate,,R,Pat Roberts,24
-Morton,Cimarron,U.S. Senate,,I,Greg Orman,4
-Morton,E Richfield,U.S. Senate,,I,Greg Orman,8
-Morton,Elkhart W1,U.S. Senate,,I,Greg Orman,33
-Morton,Elkhart W2,U.S. Senate,,I,Greg Orman,30
-Morton,Elkhart W3,U.S. Senate,,I,Greg Orman,44
-Morton,Jones,U.S. Senate,,I,Greg Orman,0
-Morton,Rolla,U.S. Senate,,I,Greg Orman,46
-Morton,Taloga,U.S. Senate,,I,Greg Orman,3
-Morton,W Richfield,U.S. Senate,,I,Greg Orman,3
-Morton,Westola,U.S. Senate,,I,Greg Orman,5
-Morton,Cimarron,U.S. Senate,,L,Randall Batson,0
-Morton,E Richfield,U.S. Senate,,L,Randall Batson,2
-Morton,Elkhart W1,U.S. Senate,,L,Randall Batson,9
-Morton,Elkhart W2,U.S. Senate,,L,Randall Batson,10
-Morton,Elkhart W3,U.S. Senate,,L,Randall Batson,8
-Morton,Jones,U.S. Senate,,L,Randall Batson,0
-Morton,Rolla,U.S. Senate,,L,Randall Batson,4
-Morton,Taloga,U.S. Senate,,L,Randall Batson,2
-Morton,W Richfield,U.S. Senate,,L,Randall Batson,0
-Morton,Westola,U.S. Senate,,L,Randall Batson,0
-Morton,Cimarron,U.S. House 1,1,R,Tim Huelskamp,22
-Morton,E Richfield,U.S. House 1,1,R,Tim Huelskamp,27
-Morton,Elkhart W1,U.S. House 1,1,R,Tim Huelskamp,161
-Morton,Elkhart W2,U.S. House 1,1,R,Tim Huelskamp,139
-Morton,Elkhart W3,U.S. House 1,1,R,Tim Huelskamp,181
-Morton,Jones,U.S. House 1,1,R,Tim Huelskamp,9
-Morton,Rolla,U.S. House 1,1,R,Tim Huelskamp,121
-Morton,Taloga,U.S. House 1,1,R,Tim Huelskamp,34
-Morton,W Richfield,U.S. House 1,1,R,Tim Huelskamp,40
-Morton,Westola,U.S. House 1,1,R,Tim Huelskamp,26
-Morton,Cimarron,U.S. House 1,1,D,James Sherow,4
-Morton,E Richfield,U.S. House 1,1,D,James Sherow,9
-Morton,Elkhart W1,U.S. House 1,1,D,James Sherow,30
-Morton,Elkhart W2,U.S. House 1,1,D,James Sherow,32
-Morton,Elkhart W3,U.S. House 1,1,D,James Sherow,36
-Morton,Jones,U.S. House 1,1,D,James Sherow,0
-Morton,Rolla,U.S. House 1,1,D,James Sherow,32
-Morton,Taloga,U.S. House 1,1,D,James Sherow,3
-Morton,W Richfield,U.S. House 1,1,D,James Sherow,1
-Morton,Westola,U.S. House 1,1,D,James Sherow,3
-Morton,Cimarron,Governor,,R,Sam Brownback,18
-Morton,E Richfield,Governor,,R,Sam Brownback,19
-Morton,Elkhart W1,Governor,,R,Sam Brownback,117
-Morton,Elkhart W2,Governor,,R,Sam Brownback,119
-Morton,Elkhart W3,Governor,,R,Sam Brownback,133
-Morton,Jones,Governor,,R,Sam Brownback,8
-Morton,Rolla,Governor,,R,Sam Brownback,91
-Morton,Taloga,Governor,,R,Sam Brownback,34
-Morton,W Richfield,Governor,,R,Sam Brownback,37
-Morton,Westola,Governor,,R,Sam Brownback,21
-Morton,Cimarron,Governor,,D,Paul Davis,5
-Morton,E Richfield,Governor,,D,Paul Davis,15
-Morton,Elkhart W1,Governor,,D,Paul Davis,59
-Morton,Elkhart W2,Governor,,D,Paul Davis,46
-Morton,Elkhart W3,Governor,,D,Paul Davis,69
-Morton,Jones,Governor,,D,Paul Davis,1
-Morton,Rolla,Governor,,D,Paul Davis,58
-Morton,Taloga,Governor,,D,Paul Davis,4
-Morton,W Richfield,Governor,,D,Paul Davis,3
-Morton,Westola,Governor,,D,Paul Davis,8
-Morton,Cimarron,Governor,,L,Keen Umbehr,2
-Morton,E Richfield,Governor,,L,Keen Umbehr,1
-Morton,Elkhart W1,Governor,,L,Keen Umbehr,10
-Morton,Elkhart W2,Governor,,L,Keen Umbehr,8
-Morton,Elkhart W3,Governor,,L,Keen Umbehr,13
-Morton,Jones,Governor,,L,Keen Umbehr,0
-Morton,Rolla,Governor,,L,Keen Umbehr,5
-Morton,Taloga,Governor,,L,Keen Umbehr,1
-Morton,W Richfield,Governor,,L,Keen Umbehr,1
-Morton,Westola,Governor,,L,Keen Umbehr,0
-Morton,Cimarron,Secretary of State,,R,Kris Kobach,23
-Morton,E Richfield,Secretary of State,,R,Kris Kobach,22
-Morton,Elkhart W1,Secretary of State,,R,Kris Kobach,156
-Morton,Elkhart W2,Secretary of State,,R,Kris Kobach,137
-Morton,Elkhart W3,Secretary of State,,R,Kris Kobach,176
-Morton,Jones,Secretary of State,,R,Kris Kobach,9
-Morton,Rolla,Secretary of State,,R,Kris Kobach,126
-Morton,Taloga,Secretary of State,,R,Kris Kobach,35
-Morton,W Richfield,Secretary of State,,R,Kris Kobach,40
-Morton,Westola,Secretary of State,,R,Kris Kobach,26
-Morton,Cimarron,Secretary of State,,D,Jean Schodorf,4
-Morton,E Richfield,Secretary of State,,D,Jean Schodorf,12
-Morton,Elkhart W1,Secretary of State,,D,Jean Schodorf,34
-Morton,Elkhart W2,Secretary of State,,D,Jean Schodorf,35
-Morton,Elkhart W3,Secretary of State,,D,Jean Schodorf,40
-Morton,Jones,Secretary of State,,D,Jean Schodorf,0
-Morton,Rolla,Secretary of State,,D,Jean Schodorf,28
-Morton,Taloga,Secretary of State,,D,Jean Schodorf,3
-Morton,W Richfield,Secretary of State,,D,Jean Schodorf,1
-Morton,Westola,Secretary of State,,D,Jean Schodorf,3
-Morton,Cimarron,Attorney General,,R,Derek Schmidt,22
-Morton,E Richfield,Attorney General,,R,Derek Schmidt,26
-Morton,Elkhart W1,Attorney General,,R,Derek Schmidt,165
-Morton,Elkhart W2,Attorney General,,R,Derek Schmidt,152
-Morton,Elkhart W3,Attorney General,,R,Derek Schmidt,177
-Morton,Jones,Attorney General,,R,Derek Schmidt,9
-Morton,Rolla,Attorney General,,R,Derek Schmidt,136
-Morton,Taloga,Attorney General,,R,Derek Schmidt,34
-Morton,W Richfield,Attorney General,,R,Derek Schmidt,40
-Morton,Westola,Attorney General,,R,Derek Schmidt,25
-Morton,Cimarron,Attorney General,,D,AJ Kotich,4
-Morton,E Richfield,Attorney General,,D,AJ Kotich,8
-Morton,Elkhart W1,Attorney General,,D,AJ Kotich,21
-Morton,Elkhart W2,Attorney General,,D,AJ Kotich,20
-Morton,Elkhart W3,Attorney General,,D,AJ Kotich,40
-Morton,Jones,Attorney General,,D,AJ Kotich,0
-Morton,Rolla,Attorney General,,D,AJ Kotich,16
-Morton,Taloga,Attorney General,,D,AJ Kotich,2
-Morton,W Richfield,Attorney General,,D,AJ Kotich,1
-Morton,Westola,Attorney General,,D,AJ Kotich,4
-Morton,Cimarron,State Treasurer,,R,Ron Estes,24
-Morton,E Richfield,State Treasurer,,R,Ron Estes,26
-Morton,Elkhart W1,State Treasurer,,R,Ron Estes,150
-Morton,Elkhart W2,State Treasurer,,R,Ron Estes,136
-Morton,Elkhart W3,State Treasurer,,R,Ron Estes,174
-Morton,Jones,State Treasurer,,R,Ron Estes,9
-Morton,Rolla,State Treasurer,,R,Ron Estes,120
-Morton,Taloga,State Treasurer,,R,Ron Estes,34
-Morton,W Richfield,State Treasurer,,R,Ron Estes,39
-Morton,Westola,State Treasurer,,R,Ron Estes,24
-Morton,Cimarron,State Treasurer,,D,Carmen Alldritt,3
-Morton,E Richfield,State Treasurer,,D,Carmen Alldritt,7
-Morton,Elkhart W1,State Treasurer,,D,Carmen Alldritt,34
-Morton,Elkhart W2,State Treasurer,,D,Carmen Alldritt,34
-Morton,Elkhart W3,State Treasurer,,D,Carmen Alldritt,38
-Morton,Jones,State Treasurer,,D,Carmen Alldritt,0
-Morton,Rolla,State Treasurer,,D,Carmen Alldritt,26
-Morton,Taloga,State Treasurer,,D,Carmen Alldritt,2
-Morton,W Richfield,State Treasurer,,D,Carmen Alldritt,0
-Morton,Westola,State Treasurer,,D,Carmen Alldritt,3
-Morton,Cimarron,Insurance Commissioner,,R,Ken Selzer,24
-Morton,E Richfield,Insurance Commissioner,,R,Ken Selzer,26
-Morton,Elkhart W1,Insurance Commissioner,,R,Ken Selzer,160
-Morton,Elkhart W2,Insurance Commissioner,,R,Ken Selzer,152
-Morton,Elkhart W3,Insurance Commissioner,,R,Ken Selzer,184
-Morton,Jones,Insurance Commissioner,,R,Ken Selzer,9
-Morton,Rolla,Insurance Commissioner,,R,Ken Selzer,141
-Morton,Taloga,Insurance Commissioner,,R,Ken Selzer,33
-Morton,W Richfield,Insurance Commissioner,,R,Ken Selzer,41
-Morton,Westola,Insurance Commissioner,,R,Ken Selzer,27
-Morton,Cimarron,Insurance Commissioner,,D,Dennis Anderson,2
-Morton,E Richfield,Insurance Commissioner,,D,Dennis Anderson,8
-Morton,Elkhart W1,Insurance Commissioner,,D,Dennis Anderson,27
-Morton,Elkhart W2,Insurance Commissioner,,D,Dennis Anderson,20
-Morton,Elkhart W3,Insurance Commissioner,,D,Dennis Anderson,30
-Morton,Jones,Insurance Commissioner,,D,Dennis Anderson,0
-Morton,Rolla,Insurance Commissioner,,D,Dennis Anderson,10
-Morton,Taloga,Insurance Commissioner,,D,Dennis Anderson,4
-Morton,W Richfield,Insurance Commissioner,,D,Dennis Anderson,0
-Morton,Westola,Insurance Commissioner,,D,Dennis Anderson,1
-Morton,Cimarron,State House,124,R,Stephen Alford,26
-Morton,E Richfield,State House,124,R,Stephen Alford,30
-Morton,Elkhart W1,State House,124,R,Stephen Alford,174
-Morton,Elkhart W2,State House,124,R,Stephen Alford,149
-Morton,Elkhart W3,State House,124,R,Stephen Alford,195
-Morton,Jones,State House,124,R,Stephen Alford,9
-Morton,Rolla,State House,124,R,Stephen Alford,139
-Morton,Taloga,State House,124,R,Stephen Alford,35
-Morton,W Richfield,State House,124,R,Stephen Alford,41
-Morton,Westola,State House,124,R,Stephen Alford,25
+county,precinct,office,district,party,candidate,votes,vtd
+MORTON,Cimarron Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000010
+MORTON,Cimarron Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+MORTON,Cimarron Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000010
+MORTON,East Richfield,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000020
+MORTON,East Richfield,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+MORTON,East Richfield,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000020
+MORTON,Elkhart Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",59,000030
+MORTON,Elkhart Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000030
+MORTON,Elkhart Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,000030
+MORTON,Elkhart Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000040
+MORTON,Elkhart Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000040
+MORTON,Elkhart Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000040
+MORTON,Elkhart Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",69,000050
+MORTON,Elkhart Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000050
+MORTON,Elkhart Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000050
+MORTON,Jones Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000060
+MORTON,Jones Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+MORTON,Jones Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000060
+MORTON,Rolla Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",58,000070
+MORTON,Rolla Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000070
+MORTON,Rolla Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000070
+MORTON,Taloga Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000080
+MORTON,Taloga Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+MORTON,Taloga Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000080
+MORTON,West Richfield,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000090
+MORTON,West Richfield,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+MORTON,West Richfield,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000090
+MORTON,Westola Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000100
+MORTON,Westola Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+MORTON,Westola Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000100
+MORTON,Cimarron Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",26,000010
+MORTON,East Richfield,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",30,000020
+MORTON,Elkhart Ward 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",174,000030
+MORTON,Elkhart Ward 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",149,000040
+MORTON,Elkhart Ward 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",195,000050
+MORTON,Jones Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",9,000060
+MORTON,Rolla Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",139,000070
+MORTON,Taloga Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",35,000080
+MORTON,West Richfield,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",41,000090
+MORTON,Westola Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",25,000100
+MORTON,Cimarron Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000010
+MORTON,Cimarron Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000010
+MORTON,East Richfield,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000020
+MORTON,East Richfield,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000020
+MORTON,Elkhart Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",30,000030
+MORTON,Elkhart Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",161,000030
+MORTON,Elkhart Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000040
+MORTON,Elkhart Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",139,000040
+MORTON,Elkhart Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000050
+MORTON,Elkhart Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",181,000050
+MORTON,Jones Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000060
+MORTON,Jones Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000060
+MORTON,Rolla Township,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000070
+MORTON,Rolla Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",121,000070
+MORTON,Taloga Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000080
+MORTON,Taloga Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000080
+MORTON,West Richfield,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000090
+MORTON,West Richfield,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000090
+MORTON,Westola Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000100
+MORTON,Westola Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000100
+MORTON,Cimarron Township,Attorney General,,Democratic,"Kotich, A.J.",4,000010
+MORTON,Cimarron Township,Attorney General,,Republican,"Schmidt, Derek",22,000010
+MORTON,East Richfield,Attorney General,,Democratic,"Kotich, A.J.",8,000020
+MORTON,East Richfield,Attorney General,,Republican,"Schmidt, Derek",26,000020
+MORTON,Elkhart Ward 1,Attorney General,,Democratic,"Kotich, A.J.",21,000030
+MORTON,Elkhart Ward 1,Attorney General,,Republican,"Schmidt, Derek",165,000030
+MORTON,Elkhart Ward 2,Attorney General,,Democratic,"Kotich, A.J.",20,000040
+MORTON,Elkhart Ward 2,Attorney General,,Republican,"Schmidt, Derek",152,000040
+MORTON,Elkhart Ward 3,Attorney General,,Democratic,"Kotich, A.J.",40,000050
+MORTON,Elkhart Ward 3,Attorney General,,Republican,"Schmidt, Derek",177,000050
+MORTON,Jones Township,Attorney General,,Democratic,"Kotich, A.J.",0,000060
+MORTON,Jones Township,Attorney General,,Republican,"Schmidt, Derek",9,000060
+MORTON,Rolla Township,Attorney General,,Democratic,"Kotich, A.J.",16,000070
+MORTON,Rolla Township,Attorney General,,Republican,"Schmidt, Derek",136,000070
+MORTON,Taloga Township,Attorney General,,Democratic,"Kotich, A.J.",2,000080
+MORTON,Taloga Township,Attorney General,,Republican,"Schmidt, Derek",34,000080
+MORTON,West Richfield,Attorney General,,Democratic,"Kotich, A.J.",1,000090
+MORTON,West Richfield,Attorney General,,Republican,"Schmidt, Derek",40,000090
+MORTON,Westola Township,Attorney General,,Democratic,"Kotich, A.J.",4,000100
+MORTON,Westola Township,Attorney General,,Republican,"Schmidt, Derek",25,000100
+MORTON,Cimarron Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000010
+MORTON,Cimarron Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000010
+MORTON,East Richfield,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000020
+MORTON,East Richfield,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000020
+MORTON,Elkhart Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000030
+MORTON,Elkhart Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",150,000030
+MORTON,Elkhart Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000040
+MORTON,Elkhart Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",136,000040
+MORTON,Elkhart Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000050
+MORTON,Elkhart Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",174,000050
+MORTON,Jones Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000060
+MORTON,Jones Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000060
+MORTON,Rolla Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000070
+MORTON,Rolla Township,Commissioner of Insurance,,Republican,"Selzer, Ken",120,000070
+MORTON,Taloga Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000080
+MORTON,Taloga Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000080
+MORTON,West Richfield,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000090
+MORTON,West Richfield,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000090
+MORTON,Westola Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000100
+MORTON,Westola Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000100
+MORTON,Cimarron Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000010
+MORTON,Cimarron Township,Secretary of State,,Republican,"Kobach, Kris",23,000010
+MORTON,East Richfield,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000020
+MORTON,East Richfield,Secretary of State,,Republican,"Kobach, Kris",22,000020
+MORTON,Elkhart Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000030
+MORTON,Elkhart Ward 1,Secretary of State,,Republican,"Kobach, Kris",156,000030
+MORTON,Elkhart Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000040
+MORTON,Elkhart Ward 2,Secretary of State,,Republican,"Kobach, Kris",137,000040
+MORTON,Elkhart Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000050
+MORTON,Elkhart Ward 3,Secretary of State,,Republican,"Kobach, Kris",176,000050
+MORTON,Jones Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000060
+MORTON,Jones Township,Secretary of State,,Republican,"Kobach, Kris",9,000060
+MORTON,Rolla Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000070
+MORTON,Rolla Township,Secretary of State,,Republican,"Kobach, Kris",126,000070
+MORTON,Taloga Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000080
+MORTON,Taloga Township,Secretary of State,,Republican,"Kobach, Kris",35,000080
+MORTON,West Richfield,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000090
+MORTON,West Richfield,Secretary of State,,Republican,"Kobach, Kris",40,000090
+MORTON,Westola Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000100
+MORTON,Westola Township,Secretary of State,,Republican,"Kobach, Kris",26,000100
+MORTON,Cimarron Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+MORTON,Cimarron Township,State Treasurer,,Republican,"Estes, Ron",24,000010
+MORTON,East Richfield,State Treasurer,,Democratic,"Alldritt, Carmen",8,000020
+MORTON,East Richfield,State Treasurer,,Republican,"Estes, Ron",26,000020
+MORTON,Elkhart Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",27,000030
+MORTON,Elkhart Ward 1,State Treasurer,,Republican,"Estes, Ron",160,000030
+MORTON,Elkhart Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",20,000040
+MORTON,Elkhart Ward 2,State Treasurer,,Republican,"Estes, Ron",152,000040
+MORTON,Elkhart Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",30,000050
+MORTON,Elkhart Ward 3,State Treasurer,,Republican,"Estes, Ron",184,000050
+MORTON,Jones Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000060
+MORTON,Jones Township,State Treasurer,,Republican,"Estes, Ron",9,000060
+MORTON,Rolla Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000070
+MORTON,Rolla Township,State Treasurer,,Republican,"Estes, Ron",141,000070
+MORTON,Taloga Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000080
+MORTON,Taloga Township,State Treasurer,,Republican,"Estes, Ron",33,000080
+MORTON,West Richfield,State Treasurer,,Democratic,"Alldritt, Carmen",0,000090
+MORTON,West Richfield,State Treasurer,,Republican,"Estes, Ron",41,000090
+MORTON,Westola Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000100
+MORTON,Westola Township,State Treasurer,,Republican,"Estes, Ron",27,000100
+MORTON,Cimarron Township,United States Senate,,independent,"Orman, Greg",4,000010
+MORTON,Cimarron Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+MORTON,Cimarron Township,United States Senate,,Republican,"Roberts, Pat",22,000010
+MORTON,East Richfield,United States Senate,,independent,"Orman, Greg",8,000020
+MORTON,East Richfield,United States Senate,,Libertarian,"Batson, Randall",2,000020
+MORTON,East Richfield,United States Senate,,Republican,"Roberts, Pat",27,000020
+MORTON,Elkhart Ward 1,United States Senate,,independent,"Orman, Greg",33,000030
+MORTON,Elkhart Ward 1,United States Senate,,Libertarian,"Batson, Randall",9,000030
+MORTON,Elkhart Ward 1,United States Senate,,Republican,"Roberts, Pat",148,000030
+MORTON,Elkhart Ward 2,United States Senate,,independent,"Orman, Greg",30,000040
+MORTON,Elkhart Ward 2,United States Senate,,Libertarian,"Batson, Randall",10,000040
+MORTON,Elkhart Ward 2,United States Senate,,Republican,"Roberts, Pat",129,000040
+MORTON,Elkhart Ward 3,United States Senate,,independent,"Orman, Greg",44,000050
+MORTON,Elkhart Ward 3,United States Senate,,Libertarian,"Batson, Randall",8,000050
+MORTON,Elkhart Ward 3,United States Senate,,Republican,"Roberts, Pat",166,000050
+MORTON,Jones Township,United States Senate,,independent,"Orman, Greg",0,000060
+MORTON,Jones Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+MORTON,Jones Township,United States Senate,,Republican,"Roberts, Pat",9,000060
+MORTON,Rolla Township,United States Senate,,independent,"Orman, Greg",46,000070
+MORTON,Rolla Township,United States Senate,,Libertarian,"Batson, Randall",4,000070
+MORTON,Rolla Township,United States Senate,,Republican,"Roberts, Pat",104,000070
+MORTON,Taloga Township,United States Senate,,independent,"Orman, Greg",3,000080
+MORTON,Taloga Township,United States Senate,,Libertarian,"Batson, Randall",2,000080
+MORTON,Taloga Township,United States Senate,,Republican,"Roberts, Pat",32,000080
+MORTON,West Richfield,United States Senate,,independent,"Orman, Greg",3,000090
+MORTON,West Richfield,United States Senate,,Libertarian,"Batson, Randall",0,000090
+MORTON,West Richfield,United States Senate,,Republican,"Roberts, Pat",38,000090
+MORTON,Westola Township,United States Senate,,independent,"Orman, Greg",5,000100
+MORTON,Westola Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+MORTON,Westola Township,United States Senate,,Republican,"Roberts, Pat",24,000100

--- a/2014/20141104__ks__general__nemaha__precinct.csv
+++ b/2014/20141104__ks__general__nemaha__precinct.csv
@@ -1,571 +1,723 @@
-county,precinct,office,district,party,candidate,poll
-Nemaha,Sabetha City Ward 1,U.S. Senate,,R,Pat Roberts,174
-Nemaha,Sabetha City Ward 2,U.S. Senate,,R,Pat Roberts,185
-Nemaha,Sabetha City Ward 3,U.S. Senate,,R,Pat Roberts,186
-Nemaha,Sabetha City Ward 4,U.S. Senate,,R,Pat Roberts,104
-Nemaha,Seneca City Ward 1,U.S. Senate,,R,Pat Roberts,131
-Nemaha,Seneca City Ward 2,U.S. Senate,,R,Pat Roberts,196
-Nemaha,Seneca City Ward 3,U.S. Senate,,R,Pat Roberts,220
-Nemaha,Adams,U.S. Senate,,R,Pat Roberts,71
-Nemaha,Berwick,U.S. Senate,,R,Pat Roberts,146
-Nemaha,Capioma,U.S. Senate,,R,Pat Roberts,59
-Nemaha,Center,U.S. Senate,,R,Pat Roberts,44
-Nemaha,Clear Creek,U.S. Senate,,R,Pat Roberts,28
-Nemaha,Gilman,U.S. Senate,,R,Pat Roberts,54
-Nemaha,Granada,U.S. Senate,,R,Pat Roberts,28
-Nemaha,Harrison-Goff,U.S. Senate,,R,Pat Roberts,41
-Nemaha,Harrison-Kelly,U.S. Senate,,R,Pat Roberts,24
-Nemaha,Home,U.S. Senate,,R,Pat Roberts,40
-Nemaha,Illinois,U.S. Senate,,R,Pat Roberts,114
-Nemaha,Marion Township,U.S. Senate,,R,Pat Roberts,124
-Nemaha,Mitchell  Township,U.S. Senate,,R,Pat Roberts,97
-Nemaha,Nemaha Township,U.S. Senate,,R,Pat Roberts,62
-Nemaha,Neuchatel,U.S. Senate,,R,Pat Roberts,41
-Nemaha,Red  Vermillion,U.S. Senate,,R,Pat Roberts,26
-Nemaha,Reilly,U.S. Senate,,R,Pat Roberts,45
-Nemaha,Richmond Township,U.S. Senate,,R,Pat Roberts,179
-Nemaha,Rock Creek,U.S. Senate,,R,Pat Roberts,156
-Nemaha,Washington,U.S. Senate,,R,Pat Roberts,148
-Nemaha,Wetmore,U.S. Senate,,R,Pat Roberts,83
-Nemaha,Centralia-Home,U.S. Senate,,R,Pat Roberts,75
-Nemaha,Centralia-Illinois,U.S. Senate,,R,Pat Roberts,9
-Nemaha,Sabetha City Ward 1,U.S. Senate,,I,Greg Orman,80
-Nemaha,Sabetha City Ward 2,U.S. Senate,,I,Greg Orman,70
-Nemaha,Sabetha City Ward 3,U.S. Senate,,I,Greg Orman,64
-Nemaha,Sabetha City Ward 4,U.S. Senate,,I,Greg Orman,51
-Nemaha,Seneca City Ward 1,U.S. Senate,,I,Greg Orman,79
-Nemaha,Seneca City Ward 2,U.S. Senate,,I,Greg Orman,99
-Nemaha,Seneca City Ward 3,U.S. Senate,,I,Greg Orman,105
-Nemaha,Adams,U.S. Senate,,I,Greg Orman,15
-Nemaha,Berwick,U.S. Senate,,I,Greg Orman,21
-Nemaha,Capioma,U.S. Senate,,I,Greg Orman,11
-Nemaha,Center,U.S. Senate,,I,Greg Orman,16
-Nemaha,Clear Creek,U.S. Senate,,I,Greg Orman,18
-Nemaha,Gilman,U.S. Senate,,I,Greg Orman,29
-Nemaha,Granada,U.S. Senate,,I,Greg Orman,22
-Nemaha,Harrison-Goff,U.S. Senate,,I,Greg Orman,17
-Nemaha,Harrison-Kelly,U.S. Senate,,I,Greg Orman,18
-Nemaha,Home,U.S. Senate,,I,Greg Orman,14
-Nemaha,Illinois,U.S. Senate,,I,Greg Orman,48
-Nemaha,Marion Township,U.S. Senate,,I,Greg Orman,55
-Nemaha,Mitchell  Township,U.S. Senate,,I,Greg Orman,29
-Nemaha,Nemaha Township,U.S. Senate,,I,Greg Orman,4
-Nemaha,Neuchatel,U.S. Senate,,I,Greg Orman,11
-Nemaha,Red  Vermillion,U.S. Senate,,I,Greg Orman,13
-Nemaha,Reilly,U.S. Senate,,I,Greg Orman,14
-Nemaha,Richmond Township,U.S. Senate,,I,Greg Orman,56
-Nemaha,Rock Creek,U.S. Senate,,I,Greg Orman,30
-Nemaha,Washington,U.S. Senate,,I,Greg Orman,32
-Nemaha,Wetmore,U.S. Senate,,I,Greg Orman,53
-Nemaha,Centralia-Home,U.S. Senate,,I,Greg Orman,46
-Nemaha,Centralia-Illinois,U.S. Senate,,I,Greg Orman,14
-Nemaha,Sabetha City Ward 1,U.S. Senate,,L,Randall Batson,7
-Nemaha,Sabetha City Ward 2,U.S. Senate,,L,Randall Batson,11
-Nemaha,Sabetha City Ward 3,U.S. Senate,,L,Randall Batson,8
-Nemaha,Sabetha City Ward 4,U.S. Senate,,L,Randall Batson,11
-Nemaha,Seneca City Ward 1,U.S. Senate,,L,Randall Batson,13
-Nemaha,Seneca City Ward 2,U.S. Senate,,L,Randall Batson,13
-Nemaha,Seneca City Ward 3,U.S. Senate,,L,Randall Batson,11
-Nemaha,Adams,U.S. Senate,,L,Randall Batson,5
-Nemaha,Berwick,U.S. Senate,,L,Randall Batson,10
-Nemaha,Capioma,U.S. Senate,,L,Randall Batson,1
-Nemaha,Center,U.S. Senate,,L,Randall Batson,5
-Nemaha,Clear Creek,U.S. Senate,,L,Randall Batson,3
-Nemaha,Gilman,U.S. Senate,,L,Randall Batson,5
-Nemaha,Granada,U.S. Senate,,L,Randall Batson,2
-Nemaha,Harrison-Goff,U.S. Senate,,L,Randall Batson,6
-Nemaha,Harrison-Kelly,U.S. Senate,,L,Randall Batson,0
-Nemaha,Home,U.S. Senate,,L,Randall Batson,8
-Nemaha,Illinois,U.S. Senate,,L,Randall Batson,11
-Nemaha,Marion Township,U.S. Senate,,L,Randall Batson,5
-Nemaha,Mitchell  Township,U.S. Senate,,L,Randall Batson,3
-Nemaha,Nemaha Township,U.S. Senate,,L,Randall Batson,2
-Nemaha,Neuchatel,U.S. Senate,,L,Randall Batson,1
-Nemaha,Red  Vermillion,U.S. Senate,,L,Randall Batson,1
-Nemaha,Reilly,U.S. Senate,,L,Randall Batson,3
-Nemaha,Richmond Township,U.S. Senate,,L,Randall Batson,4
-Nemaha,Rock Creek,U.S. Senate,,L,Randall Batson,7
-Nemaha,Washington,U.S. Senate,,L,Randall Batson,10
-Nemaha,Wetmore,U.S. Senate,,L,Randall Batson,11
-Nemaha,Centralia-Home,U.S. Senate,,L,Randall Batson,10
-Nemaha,Centralia-Illinois,U.S. Senate,,L,Randall Batson,1
-Nemaha,Sabetha City Ward 1,U.S. House,2,R,Lynn Jenkins,193
-Nemaha,Sabetha City Ward 2,U.S. House,2,R,Lynn Jenkins,210
-Nemaha,Sabetha City Ward 3,U.S. House,2,R,Lynn Jenkins,198
-Nemaha,Sabetha City Ward 4,U.S. House,2,R,Lynn Jenkins,124
-Nemaha,Seneca City Ward 1,U.S. House,2,R,Lynn Jenkins,155
-Nemaha,Seneca City Ward 2,U.S. House,2,R,Lynn Jenkins,209
-Nemaha,Seneca City Ward 3,U.S. House,2,R,Lynn Jenkins,242
-Nemaha,Adams,U.S. House,2,R,Lynn Jenkins,76
-Nemaha,Berwick,U.S. House,2,R,Lynn Jenkins,156
-Nemaha,Capioma,U.S. House,2,R,Lynn Jenkins,65
-Nemaha,Center,U.S. House,2,R,Lynn Jenkins,44
-Nemaha,Clear Creek,U.S. House,2,R,Lynn Jenkins,32
-Nemaha,Gilman,U.S. House,2,R,Lynn Jenkins,61
-Nemaha,Granada,U.S. House,2,R,Lynn Jenkins,38
-Nemaha,Harrison-Goff,U.S. House,2,R,Lynn Jenkins,42
-Nemaha,Harrison-Kelly,U.S. House,2,R,Lynn Jenkins,31
-Nemaha,Home,U.S. House,2,R,Lynn Jenkins,44
-Nemaha,Illinois,U.S. House,2,R,Lynn Jenkins,130
-Nemaha,Marion Township,U.S. House,2,R,Lynn Jenkins,131
-Nemaha,Mitchell  Township,U.S. House,2,R,Lynn Jenkins,102
-Nemaha,Nemaha Township,U.S. House,2,R,Lynn Jenkins,62
-Nemaha,Neuchatel,U.S. House,2,R,Lynn Jenkins,38
-Nemaha,Red  Vermillion,U.S. House,2,R,Lynn Jenkins,31
-Nemaha,Reilly,U.S. House,2,R,Lynn Jenkins,52
-Nemaha,Richmond Township,U.S. House,2,R,Lynn Jenkins,197
-Nemaha,Rock Creek,U.S. House,2,R,Lynn Jenkins,162
-Nemaha,Washington,U.S. House,2,R,Lynn Jenkins,158
-Nemaha,Wetmore,U.S. House,2,R,Lynn Jenkins,91
-Nemaha,Centralia-Home,U.S. House,2,R,Lynn Jenkins,86
-Nemaha,Centralia-Illinois,U.S. House,2,R,Lynn Jenkins,14
-Nemaha,Sabetha City Ward 1,U.S. House,2,D,Margie Wakefield,55
-Nemaha,Sabetha City Ward 2,U.S. House,2,D,Margie Wakefield,46
-Nemaha,Sabetha City Ward 3,U.S. House,2,D,Margie Wakefield,49
-Nemaha,Sabetha City Ward 4,U.S. House,2,D,Margie Wakefield,38
-Nemaha,Seneca City Ward 1,U.S. House,2,D,Margie Wakefield,55
-Nemaha,Seneca City Ward 2,U.S. House,2,D,Margie Wakefield,95
-Nemaha,Seneca City Ward 3,U.S. House,2,D,Margie Wakefield,83
-Nemaha,Adams,U.S. House,2,D,Margie Wakefield,15
-Nemaha,Berwick,U.S. House,2,D,Margie Wakefield,15
-Nemaha,Capioma,U.S. House,2,D,Margie Wakefield,9
-Nemaha,Center,U.S. House,2,D,Margie Wakefield,18
-Nemaha,Clear Creek,U.S. House,2,D,Margie Wakefield,16
-Nemaha,Gilman,U.S. House,2,D,Margie Wakefield,25
-Nemaha,Granada,U.S. House,2,D,Margie Wakefield,12
-Nemaha,Harrison-Goff,U.S. House,2,D,Margie Wakefield,18
-Nemaha,Harrison-Kelly,U.S. House,2,D,Margie Wakefield,8
-Nemaha,Home,U.S. House,2,D,Margie Wakefield,11
-Nemaha,Illinois,U.S. House,2,D,Margie Wakefield,38
-Nemaha,Marion Township,U.S. House,2,D,Margie Wakefield,50
-Nemaha,Mitchell  Township,U.S. House,2,D,Margie Wakefield,25
-Nemaha,Nemaha Township,U.S. House,2,D,Margie Wakefield,3
-Nemaha,Neuchatel,U.S. House,2,D,Margie Wakefield,13
-Nemaha,Red  Vermillion,U.S. House,2,D,Margie Wakefield,6
-Nemaha,Reilly,U.S. House,2,D,Margie Wakefield,9
-Nemaha,Richmond Township,U.S. House,2,D,Margie Wakefield,40
-Nemaha,Rock Creek,U.S. House,2,D,Margie Wakefield,24
-Nemaha,Washington,U.S. House,2,D,Margie Wakefield,24
-Nemaha,Wetmore,U.S. House,2,D,Margie Wakefield,50
-Nemaha,Centralia-Home,U.S. House,2,D,Margie Wakefield,39
-Nemaha,Centralia-Illinois,U.S. House,2,D,Margie Wakefield,10
-Nemaha,Sabetha City Ward 1,U.S. House,2,L,Christopher Clemmons,11
-Nemaha,Sabetha City Ward 2,U.S. House,2,L,Christopher Clemmons,12
-Nemaha,Sabetha City Ward 3,U.S. House,2,L,Christopher Clemmons,11
-Nemaha,Sabetha City Ward 4,U.S. House,2,L,Christopher Clemmons,4
-Nemaha,Seneca City Ward 1,U.S. House,2,L,Christopher Clemmons,10
-Nemaha,Seneca City Ward 2,U.S. House,2,L,Christopher Clemmons,11
-Nemaha,Seneca City Ward 3,U.S. House,2,L,Christopher Clemmons,10
-Nemaha,Adams,U.S. House,2,L,Christopher Clemmons,1
-Nemaha,Berwick,U.S. House,2,L,Christopher Clemmons,6
-Nemaha,Capioma,U.S. House,2,L,Christopher Clemmons,1
-Nemaha,Center,U.S. House,2,L,Christopher Clemmons,4
-Nemaha,Clear Creek,U.S. House,2,L,Christopher Clemmons,2
-Nemaha,Gilman,U.S. House,2,L,Christopher Clemmons,2
-Nemaha,Granada,U.S. House,2,L,Christopher Clemmons,2
-Nemaha,Harrison-Goff,U.S. House,2,L,Christopher Clemmons,4
-Nemaha,Harrison-Kelly,U.S. House,2,L,Christopher Clemmons,3
-Nemaha,Home,U.S. House,2,L,Christopher Clemmons,7
-Nemaha,Illinois,U.S. House,2,L,Christopher Clemmons,6
-Nemaha,Marion Township,U.S. House,2,L,Christopher Clemmons,5
-Nemaha,Mitchell  Township,U.S. House,2,L,Christopher Clemmons,1
-Nemaha,Nemaha Township,U.S. House,2,L,Christopher Clemmons,1
-Nemaha,Neuchatel,U.S. House,2,L,Christopher Clemmons,2
-Nemaha,Red  Vermillion,U.S. House,2,L,Christopher Clemmons,3
-Nemaha,Reilly,U.S. House,2,L,Christopher Clemmons,1
-Nemaha,Richmond Township,U.S. House,2,L,Christopher Clemmons,4
-Nemaha,Rock Creek,U.S. House,2,L,Christopher Clemmons,10
-Nemaha,Washington,U.S. House,2,L,Christopher Clemmons,5
-Nemaha,Wetmore,U.S. House,2,L,Christopher Clemmons,7
-Nemaha,Centralia-Home,U.S. House,2,L,Christopher Clemmons,5
-Nemaha,Centralia-Illinois,U.S. House,2,L,Christopher Clemmons,0
-Nemaha,Sabetha City Ward 1,Governor,,R,Sam Brownback,150
-Nemaha,Sabetha City Ward 2,Governor,,R,Sam Brownback,161
-Nemaha,Sabetha City Ward 3,Governor,,R,Sam Brownback,172
-Nemaha,Sabetha City Ward 4,Governor,,R,Sam Brownback,103
-Nemaha,Seneca City Ward 1,Governor,,R,Sam Brownback,121
-Nemaha,Seneca City Ward 2,Governor,,R,Sam Brownback,177
-Nemaha,Seneca City Ward 3,Governor,,R,Sam Brownback,193
-Nemaha,Adams,Governor,,R,Sam Brownback,71
-Nemaha,Berwick,Governor,,R,Sam Brownback,151
-Nemaha,Capioma,Governor,,R,Sam Brownback,55
-Nemaha,Center,Governor,,R,Sam Brownback,33
-Nemaha,Clear Creek,Governor,,R,Sam Brownback,28
-Nemaha,Gilman,Governor,,R,Sam Brownback,55
-Nemaha,Granada,Governor,,R,Sam Brownback,33
-Nemaha,Harrison-Goff,Governor,,R,Sam Brownback,37
-Nemaha,Harrison-Kelly,Governor,,R,Sam Brownback,25
-Nemaha,Home,Governor,,R,Sam Brownback,28
-Nemaha,Illinois,Governor,,R,Sam Brownback,103
-Nemaha,Marion Township,Governor,,R,Sam Brownback,108
-Nemaha,Mitchell  Township,Governor,,R,Sam Brownback,82
-Nemaha,Nemaha Township,Governor,,R,Sam Brownback,59
-Nemaha,Neuchatel,Governor,,R,Sam Brownback,32
-Nemaha,Red  Vermillion,Governor,,R,Sam Brownback,21
-Nemaha,Reilly,Governor,,R,Sam Brownback,41
-Nemaha,Richmond Township,Governor,,R,Sam Brownback,164
-Nemaha,Rock Creek,Governor,,R,Sam Brownback,135
-Nemaha,Washington,Governor,,R,Sam Brownback,140
-Nemaha,Wetmore,Governor,,R,Sam Brownback,74
-Nemaha,Centralia-Home,Governor,,R,Sam Brownback,57
-Nemaha,Centralia-Illinois,Governor,,R,Sam Brownback,7
-Nemaha,Sabetha City Ward 1,Governor,,D,Paul Davis,93
-Nemaha,Sabetha City Ward 2,Governor,,D,Paul Davis,94
-Nemaha,Sabetha City Ward 3,Governor,,D,Paul Davis,78
-Nemaha,Sabetha City Ward 4,Governor,,D,Paul Davis,50
-Nemaha,Seneca City Ward 1,Governor,,D,Paul Davis,90
-Nemaha,Seneca City Ward 2,Governor,,D,Paul Davis,132
-Nemaha,Seneca City Ward 3,Governor,,D,Paul Davis,130
-Nemaha,Adams,Governor,,D,Paul Davis,19
-Nemaha,Berwick,Governor,,D,Paul Davis,24
-Nemaha,Capioma,Governor,,D,Paul Davis,18
-Nemaha,Center,Governor,,D,Paul Davis,29
-Nemaha,Clear Creek,Governor,,D,Paul Davis,21
-Nemaha,Gilman,Governor,,D,Paul Davis,30
-Nemaha,Granada,Governor,,D,Paul Davis,16
-Nemaha,Harrison-Goff,Governor,,D,Paul Davis,22
-Nemaha,Harrison-Kelly,Governor,,D,Paul Davis,15
-Nemaha,Home,Governor,,D,Paul Davis,26
-Nemaha,Illinois,Governor,,D,Paul Davis,65
-Nemaha,Marion Township,Governor,,D,Paul Davis,73
-Nemaha,Mitchell  Township,Governor,,D,Paul Davis,43
-Nemaha,Nemaha Township,Governor,,D,Paul Davis,7
-Nemaha,Neuchatel,Governor,,D,Paul Davis,18
-Nemaha,Red  Vermillion,Governor,,D,Paul Davis,18
-Nemaha,Reilly,Governor,,D,Paul Davis,20
-Nemaha,Richmond Township,Governor,,D,Paul Davis,70
-Nemaha,Rock Creek,Governor,,D,Paul Davis,54
-Nemaha,Washington,Governor,,D,Paul Davis,43
-Nemaha,Wetmore,Governor,,D,Paul Davis,63
-Nemaha,Centralia-Home,Governor,,D,Paul Davis,66
-Nemaha,Centralia-Illinois,Governor,,D,Paul Davis,17
-Nemaha,Sabetha City Ward 1,Governor,,L,Keen Umbehr,11
-Nemaha,Sabetha City Ward 2,Governor,,L,Keen Umbehr,10
-Nemaha,Sabetha City Ward 3,Governor,,L,Keen Umbehr,9
-Nemaha,Sabetha City Ward 4,Governor,,L,Keen Umbehr,9
-Nemaha,Seneca City Ward 1,Governor,,L,Keen Umbehr,9
-Nemaha,Seneca City Ward 2,Governor,,L,Keen Umbehr,6
-Nemaha,Seneca City Ward 3,Governor,,L,Keen Umbehr,12
-Nemaha,Adams,Governor,,L,Keen Umbehr,2
-Nemaha,Berwick,Governor,,L,Keen Umbehr,4
-Nemaha,Capioma,Governor,,L,Keen Umbehr,0
-Nemaha,Center,Governor,,L,Keen Umbehr,3
-Nemaha,Clear Creek,Governor,,L,Keen Umbehr,1
-Nemaha,Gilman,Governor,,L,Keen Umbehr,3
-Nemaha,Granada,Governor,,L,Keen Umbehr,3
-Nemaha,Harrison-Goff,Governor,,L,Keen Umbehr,4
-Nemaha,Harrison-Kelly,Governor,,L,Keen Umbehr,1
-Nemaha,Home,Governor,,L,Keen Umbehr,8
-Nemaha,Illinois,Governor,,L,Keen Umbehr,4
-Nemaha,Marion Township,Governor,,L,Keen Umbehr,1
-Nemaha,Mitchell  Township,Governor,,L,Keen Umbehr,3
-Nemaha,Nemaha Township,Governor,,L,Keen Umbehr,1
-Nemaha,Neuchatel,Governor,,L,Keen Umbehr,2
-Nemaha,Red  Vermillion,Governor,,L,Keen Umbehr,2
-Nemaha,Reilly,Governor,,L,Keen Umbehr,1
-Nemaha,Richmond Township,Governor,,L,Keen Umbehr,6
-Nemaha,Rock Creek,Governor,,L,Keen Umbehr,4
-Nemaha,Washington,Governor,,L,Keen Umbehr,6
-Nemaha,Wetmore,Governor,,L,Keen Umbehr,10
-Nemaha,Centralia-Home,Governor,,L,Keen Umbehr,8
-Nemaha,Centralia-Illinois,Governor,,L,Keen Umbehr,0
-Nemaha,Sabetha City Ward 1,Secretary of State,,R,Kris Kobach,193
-Nemaha,Sabetha City Ward 2,Secretary of State,,R,Kris Kobach,201
-Nemaha,Sabetha City Ward 3,Secretary of State,,R,Kris Kobach,196
-Nemaha,Sabetha City Ward 4,Secretary of State,,R,Kris Kobach,123
-Nemaha,Seneca City Ward 1,Secretary of State,,R,Kris Kobach,150
-Nemaha,Seneca City Ward 2,Secretary of State,,R,Kris Kobach,207
-Nemaha,Seneca City Ward 3,Secretary of State,,R,Kris Kobach,235
-Nemaha,Adams,Secretary of State,,R,Kris Kobach,76
-Nemaha,Berwick,Secretary of State,,R,Kris Kobach,160
-Nemaha,Capioma,Secretary of State,,R,Kris Kobach,66
-Nemaha,Center,Secretary of State,,R,Kris Kobach,45
-Nemaha,Clear Creek,Secretary of State,,R,Kris Kobach,33
-Nemaha,Gilman,Secretary of State,,R,Kris Kobach,67
-Nemaha,Granada,Secretary of State,,R,Kris Kobach,37
-Nemaha,Harrison-Goff,Secretary of State,,R,Kris Kobach,45
-Nemaha,Harrison-Kelly,Secretary of State,,R,Kris Kobach,29
-Nemaha,Home,Secretary of State,,R,Kris Kobach,44
-Nemaha,Illinois,Secretary of State,,R,Kris Kobach,128
-Nemaha,Marion Township,Secretary of State,,R,Kris Kobach,136
-Nemaha,Mitchell  Township,Secretary of State,,R,Kris Kobach,100
-Nemaha,Nemaha Township,Secretary of State,,R,Kris Kobach,61
-Nemaha,Neuchatel,Secretary of State,,R,Kris Kobach,41
-Nemaha,Red  Vermillion,Secretary of State,,R,Kris Kobach,31
-Nemaha,Reilly,Secretary of State,,R,Kris Kobach,47
-Nemaha,Richmond Township,Secretary of State,,R,Kris Kobach,191
-Nemaha,Rock Creek,Secretary of State,,R,Kris Kobach,161
-Nemaha,Washington,Secretary of State,,R,Kris Kobach,163
-Nemaha,Wetmore,Secretary of State,,R,Kris Kobach,105
-Nemaha,Centralia-Home,Secretary of State,,R,Kris Kobach,83
-Nemaha,Centralia-Illinois,Secretary of State,,R,Kris Kobach,16
-Nemaha,Sabetha City Ward 1,Secretary of State,,D,Jean Schodorf,61
-Nemaha,Sabetha City Ward 2,Secretary of State,,D,Jean Schodorf,54
-Nemaha,Sabetha City Ward 3,Secretary of State,,D,Jean Schodorf,58
-Nemaha,Sabetha City Ward 4,Secretary of State,,D,Jean Schodorf,36
-Nemaha,Seneca City Ward 1,Secretary of State,,D,Jean Schodorf,63
-Nemaha,Seneca City Ward 2,Secretary of State,,D,Jean Schodorf,94
-Nemaha,Seneca City Ward 3,Secretary of State,,D,Jean Schodorf,91
-Nemaha,Adams,Secretary of State,,D,Jean Schodorf,15
-Nemaha,Berwick,Secretary of State,,D,Jean Schodorf,13
-Nemaha,Capioma,Secretary of State,,D,Jean Schodorf,8
-Nemaha,Center,Secretary of State,,D,Jean Schodorf,18
-Nemaha,Clear Creek,Secretary of State,,D,Jean Schodorf,16
-Nemaha,Gilman,Secretary of State,,D,Jean Schodorf,20
-Nemaha,Granada,Secretary of State,,D,Jean Schodorf,14
-Nemaha,Harrison-Goff,Secretary of State,,D,Jean Schodorf,16
-Nemaha,Harrison-Kelly,Secretary of State,,D,Jean Schodorf,12
-Nemaha,Home,Secretary of State,,D,Jean Schodorf,17
-Nemaha,Illinois,Secretary of State,,D,Jean Schodorf,41
-Nemaha,Marion Township,Secretary of State,,D,Jean Schodorf,38
-Nemaha,Mitchell  Township,Secretary of State,,D,Jean Schodorf,22
-Nemaha,Nemaha Township,Secretary of State,,D,Jean Schodorf,3
-Nemaha,Neuchatel,Secretary of State,,D,Jean Schodorf,10
-Nemaha,Red  Vermillion,Secretary of State,,D,Jean Schodorf,8
-Nemaha,Reilly,Secretary of State,,D,Jean Schodorf,14
-Nemaha,Richmond Township,Secretary of State,,D,Jean Schodorf,45
-Nemaha,Rock Creek,Secretary of State,,D,Jean Schodorf,31
-Nemaha,Washington,Secretary of State,,D,Jean Schodorf,25
-Nemaha,Wetmore,Secretary of State,,D,Jean Schodorf,42
-Nemaha,Centralia-Home,Secretary of State,,D,Jean Schodorf,46
-Nemaha,Centralia-Illinois,Secretary of State,,D,Jean Schodorf,8
-Nemaha,Sabetha City Ward 1,Attorney General,,R,Derek Schmidt,194
-Nemaha,Sabetha City Ward 2,Attorney General,,R,Derek Schmidt,203
-Nemaha,Sabetha City Ward 3,Attorney General,,R,Derek Schmidt,212
-Nemaha,Sabetha City Ward 4,Attorney General,,R,Derek Schmidt,121
-Nemaha,Seneca City Ward 1,Attorney General,,R,Derek Schmidt,160
-Nemaha,Seneca City Ward 2,Attorney General,,R,Derek Schmidt,220
-Nemaha,Seneca City Ward 3,Attorney General,,R,Derek Schmidt,256
-Nemaha,Adams,Attorney General,,R,Derek Schmidt,72
-Nemaha,Berwick,Attorney General,,R,Derek Schmidt,158
-Nemaha,Capioma,Attorney General,,R,Derek Schmidt,65
-Nemaha,Center,Attorney General,,R,Derek Schmidt,49
-Nemaha,Clear Creek,Attorney General,,R,Derek Schmidt,36
-Nemaha,Gilman,Attorney General,,R,Derek Schmidt,65
-Nemaha,Granada,Attorney General,,R,Derek Schmidt,42
-Nemaha,Harrison-Goff,Attorney General,,R,Derek Schmidt,43
-Nemaha,Harrison-Kelly,Attorney General,,R,Derek Schmidt,30
-Nemaha,Home,Attorney General,,R,Derek Schmidt,49
-Nemaha,Illinois,Attorney General,,R,Derek Schmidt,135
-Nemaha,Marion Township,Attorney General,,R,Derek Schmidt,143
-Nemaha,Mitchell  Township,Attorney General,,R,Derek Schmidt,100
-Nemaha,Nemaha Township,Attorney General,,R,Derek Schmidt,64
-Nemaha,Neuchatel,Attorney General,,R,Derek Schmidt,40
-Nemaha,Red  Vermillion,Attorney General,,R,Derek Schmidt,31
-Nemaha,Reilly,Attorney General,,R,Derek Schmidt,50
-Nemaha,Richmond Township,Attorney General,,R,Derek Schmidt,199
-Nemaha,Rock Creek,Attorney General,,R,Derek Schmidt,165
-Nemaha,Washington,Attorney General,,R,Derek Schmidt,163
-Nemaha,Wetmore,Attorney General,,R,Derek Schmidt,102
-Nemaha,Centralia-Home,Attorney General,,R,Derek Schmidt,95
-Nemaha,Centralia-Illinois,Attorney General,,R,Derek Schmidt,17
-Nemaha,Sabetha City Ward 1,Attorney General,,D,AJ Kotich,58
-Nemaha,Sabetha City Ward 2,Attorney General,,D,AJ Kotich,47
-Nemaha,Sabetha City Ward 3,Attorney General,,D,AJ Kotich,42
-Nemaha,Sabetha City Ward 4,Attorney General,,D,AJ Kotich,31
-Nemaha,Seneca City Ward 1,Attorney General,,D,AJ Kotich,50
-Nemaha,Seneca City Ward 2,Attorney General,,D,AJ Kotich,71
-Nemaha,Seneca City Ward 3,Attorney General,,D,AJ Kotich,70
-Nemaha,Adams,Attorney General,,D,AJ Kotich,14
-Nemaha,Berwick,Attorney General,,D,AJ Kotich,12
-Nemaha,Capioma,Attorney General,,D,AJ Kotich,7
-Nemaha,Center,Attorney General,,D,AJ Kotich,12
-Nemaha,Clear Creek,Attorney General,,D,AJ Kotich,11
-Nemaha,Gilman,Attorney General,,D,AJ Kotich,19
-Nemaha,Granada,Attorney General,,D,AJ Kotich,7
-Nemaha,Harrison-Goff,Attorney General,,D,AJ Kotich,17
-Nemaha,Harrison-Kelly,Attorney General,,D,AJ Kotich,10
-Nemaha,Home,Attorney General,,D,AJ Kotich,11
-Nemaha,Illinois,Attorney General,,D,AJ Kotich,30
-Nemaha,Marion Township,Attorney General,,D,AJ Kotich,30
-Nemaha,Mitchell  Township,Attorney General,,D,AJ Kotich,19
-Nemaha,Nemaha Township,Attorney General,,D,AJ Kotich,1
-Nemaha,Neuchatel,Attorney General,,D,AJ Kotich,10
-Nemaha,Red  Vermillion,Attorney General,,D,AJ Kotich,7
-Nemaha,Reilly,Attorney General,,D,AJ Kotich,11
-Nemaha,Richmond Township,Attorney General,,D,AJ Kotich,31
-Nemaha,Rock Creek,Attorney General,,D,AJ Kotich,22
-Nemaha,Washington,Attorney General,,D,AJ Kotich,20
-Nemaha,Wetmore,Attorney General,,D,AJ Kotich,43
-Nemaha,Centralia-Home,Attorney General,,D,AJ Kotich,33
-Nemaha,Centralia-Illinois,Attorney General,,D,AJ Kotich,7
-Nemaha,Sabetha City Ward 1,State Treasurer,,R,Ron Estes,198
-Nemaha,Sabetha City Ward 2,State Treasurer,,R,Ron Estes,205
-Nemaha,Sabetha City Ward 3,State Treasurer,,R,Ron Estes,214
-Nemaha,Sabetha City Ward 4,State Treasurer,,R,Ron Estes,119
-Nemaha,Seneca City Ward 1,State Treasurer,,R,Ron Estes,153
-Nemaha,Seneca City Ward 2,State Treasurer,,R,Ron Estes,201
-Nemaha,Seneca City Ward 3,State Treasurer,,R,Ron Estes,234
-Nemaha,Adams,State Treasurer,,R,Ron Estes,68
-Nemaha,Berwick,State Treasurer,,R,Ron Estes,160
-Nemaha,Capioma,State Treasurer,,R,Ron Estes,66
-Nemaha,Center,State Treasurer,,R,Ron Estes,45
-Nemaha,Clear Creek,State Treasurer,,R,Ron Estes,34
-Nemaha,Gilman,State Treasurer,,R,Ron Estes,60
-Nemaha,Granada,State Treasurer,,R,Ron Estes,39
-Nemaha,Harrison-Goff,State Treasurer,,R,Ron Estes,40
-Nemaha,Harrison-Kelly,State Treasurer,,R,Ron Estes,31
-Nemaha,Home,State Treasurer,,R,Ron Estes,42
-Nemaha,Illinois,State Treasurer,,R,Ron Estes,131
-Nemaha,Marion Township,State Treasurer,,R,Ron Estes,133
-Nemaha,Mitchell  Township,State Treasurer,,R,Ron Estes,108
-Nemaha,Nemaha Township,State Treasurer,,R,Ron Estes,62
-Nemaha,Neuchatel,State Treasurer,,R,Ron Estes,40
-Nemaha,Red  Vermillion,State Treasurer,,R,Ron Estes,31
-Nemaha,Reilly,State Treasurer,,R,Ron Estes,47
-Nemaha,Richmond Township,State Treasurer,,R,Ron Estes,180
-Nemaha,Rock Creek,State Treasurer,,R,Ron Estes,163
-Nemaha,Washington,State Treasurer,,R,Ron Estes,157
-Nemaha,Wetmore,State Treasurer,,R,Ron Estes,102
-Nemaha,Centralia-Home,State Treasurer,,R,Ron Estes,83
-Nemaha,Centralia-Illinois,State Treasurer,,R,Ron Estes,16
-Nemaha,Sabetha City Ward 1,State Treasurer,,D,Carmen Alldritt,52
-Nemaha,Sabetha City Ward 2,State Treasurer,,D,Carmen Alldritt,44
-Nemaha,Sabetha City Ward 3,State Treasurer,,D,Carmen Alldritt,39
-Nemaha,Sabetha City Ward 4,State Treasurer,,D,Carmen Alldritt,31
-Nemaha,Seneca City Ward 1,State Treasurer,,D,Carmen Alldritt,50
-Nemaha,Seneca City Ward 2,State Treasurer,,D,Carmen Alldritt,85
-Nemaha,Seneca City Ward 3,State Treasurer,,D,Carmen Alldritt,71
-Nemaha,Adams,State Treasurer,,D,Carmen Alldritt,10
-Nemaha,Berwick,State Treasurer,,D,Carmen Alldritt,11
-Nemaha,Capioma,State Treasurer,,D,Carmen Alldritt,4
-Nemaha,Center,State Treasurer,,D,Carmen Alldritt,12
-Nemaha,Clear Creek,State Treasurer,,D,Carmen Alldritt,12
-Nemaha,Gilman,State Treasurer,,D,Carmen Alldritt,23
-Nemaha,Granada,State Treasurer,,D,Carmen Alldritt,10
-Nemaha,Harrison-Goff,State Treasurer,,D,Carmen Alldritt,17
-Nemaha,Harrison-Kelly,State Treasurer,,D,Carmen Alldritt,9
-Nemaha,Home,State Treasurer,,D,Carmen Alldritt,16
-Nemaha,Illinois,State Treasurer,,D,Carmen Alldritt,36
-Nemaha,Marion Township,State Treasurer,,D,Carmen Alldritt,35
-Nemaha,Mitchell  Township,State Treasurer,,D,Carmen Alldritt,15
-Nemaha,Nemaha Township,State Treasurer,,D,Carmen Alldritt,2
-Nemaha,Neuchatel,State Treasurer,,D,Carmen Alldritt,10
-Nemaha,Red  Vermillion,State Treasurer,,D,Carmen Alldritt,7
-Nemaha,Reilly,State Treasurer,,D,Carmen Alldritt,13
-Nemaha,Richmond Township,State Treasurer,,D,Carmen Alldritt,40
-Nemaha,Rock Creek,State Treasurer,,D,Carmen Alldritt,20
-Nemaha,Washington,State Treasurer,,D,Carmen Alldritt,25
-Nemaha,Wetmore,State Treasurer,,D,Carmen Alldritt,42
-Nemaha,Centralia-Home,State Treasurer,,D,Carmen Alldritt,39
-Nemaha,Centralia-Illinois,State Treasurer,,D,Carmen Alldritt,7
-Nemaha,Sabetha City Ward 1,Insurance Commissioner,,R,Ken Selzer,181
-Nemaha,Sabetha City Ward 2,Insurance Commissioner,,R,Ken Selzer,191
-Nemaha,Sabetha City Ward 3,Insurance Commissioner,,R,Ken Selzer,192
-Nemaha,Sabetha City Ward 4,Insurance Commissioner,,R,Ken Selzer,116
-Nemaha,Seneca City Ward 1,Insurance Commissioner,,R,Ken Selzer,130
-Nemaha,Seneca City Ward 2,Insurance Commissioner,,R,Ken Selzer,174
-Nemaha,Seneca City Ward 3,Insurance Commissioner,,R,Ken Selzer,202
-Nemaha,Adams,Insurance Commissioner,,R,Ken Selzer,61
-Nemaha,Berwick,Insurance Commissioner,,R,Ken Selzer,150
-Nemaha,Capioma,Insurance Commissioner,,R,Ken Selzer,62
-Nemaha,Center,Insurance Commissioner,,R,Ken Selzer,44
-Nemaha,Clear Creek,Insurance Commissioner,,R,Ken Selzer,23
-Nemaha,Gilman,Insurance Commissioner,,R,Ken Selzer,53
-Nemaha,Granada,Insurance Commissioner,,R,Ken Selzer,33
-Nemaha,Harrison-Goff,Insurance Commissioner,,R,Ken Selzer,37
-Nemaha,Harrison-Kelly,Insurance Commissioner,,R,Ken Selzer,23
-Nemaha,Home,Insurance Commissioner,,R,Ken Selzer,42
-Nemaha,Illinois,Insurance Commissioner,,R,Ken Selzer,114
-Nemaha,Marion Township,Insurance Commissioner,,R,Ken Selzer,118
-Nemaha,Mitchell  Township,Insurance Commissioner,,R,Ken Selzer,86
-Nemaha,Nemaha Township,Insurance Commissioner,,R,Ken Selzer,55
-Nemaha,Neuchatel,Insurance Commissioner,,R,Ken Selzer,36
-Nemaha,Red  Vermillion,Insurance Commissioner,,R,Ken Selzer,26
-Nemaha,Reilly,Insurance Commissioner,,R,Ken Selzer,40
-Nemaha,Richmond Township,Insurance Commissioner,,R,Ken Selzer,161
-Nemaha,Rock Creek,Insurance Commissioner,,R,Ken Selzer,154
-Nemaha,Washington,Insurance Commissioner,,R,Ken Selzer,148
-Nemaha,Wetmore,Insurance Commissioner,,R,Ken Selzer,85
-Nemaha,Centralia-Home,Insurance Commissioner,,R,Ken Selzer,70
-Nemaha,Centralia-Illinois,Insurance Commissioner,,R,Ken Selzer,14
-Nemaha,Sabetha City Ward 1,Insurance Commissioner,,D,Dennis Anderson,58
-Nemaha,Sabetha City Ward 2,Insurance Commissioner,,D,Dennis Anderson,57
-Nemaha,Sabetha City Ward 3,Insurance Commissioner,,D,Dennis Anderson,62
-Nemaha,Sabetha City Ward 4,Insurance Commissioner,,D,Dennis Anderson,34
-Nemaha,Seneca City Ward 1,Insurance Commissioner,,D,Dennis Anderson,69
-Nemaha,Seneca City Ward 2,Insurance Commissioner,,D,Dennis Anderson,106
-Nemaha,Seneca City Ward 3,Insurance Commissioner,,D,Dennis Anderson,103
-Nemaha,Adams,Insurance Commissioner,,D,Dennis Anderson,15
-Nemaha,Berwick,Insurance Commissioner,,D,Dennis Anderson,18
-Nemaha,Capioma,Insurance Commissioner,,D,Dennis Anderson,8
-Nemaha,Center,Insurance Commissioner,,D,Dennis Anderson,15
-Nemaha,Clear Creek,Insurance Commissioner,,D,Dennis Anderson,23
-Nemaha,Gilman,Insurance Commissioner,,D,Dennis Anderson,30
-Nemaha,Granada,Insurance Commissioner,,D,Dennis Anderson,12
-Nemaha,Harrison-Goff,Insurance Commissioner,,D,Dennis Anderson,20
-Nemaha,Harrison-Kelly,Insurance Commissioner,,D,Dennis Anderson,16
-Nemaha,Home,Insurance Commissioner,,D,Dennis Anderson,14
-Nemaha,Illinois,Insurance Commissioner,,D,Dennis Anderson,47
-Nemaha,Marion Township,Insurance Commissioner,,D,Dennis Anderson,48
-Nemaha,Mitchell  Township,Insurance Commissioner,,D,Dennis Anderson,32
-Nemaha,Nemaha Township,Insurance Commissioner,,D,Dennis Anderson,4
-Nemaha,Neuchatel,Insurance Commissioner,,D,Dennis Anderson,12
-Nemaha,Red  Vermillion,Insurance Commissioner,,D,Dennis Anderson,10
-Nemaha,Reilly,Insurance Commissioner,,D,Dennis Anderson,18
-Nemaha,Richmond Township,Insurance Commissioner,,D,Dennis Anderson,49
-Nemaha,Rock Creek,Insurance Commissioner,,D,Dennis Anderson,23
-Nemaha,Washington,Insurance Commissioner,,D,Dennis Anderson,33
-Nemaha,Wetmore,Insurance Commissioner,,D,Dennis Anderson,52
-Nemaha,Centralia-Home,Insurance Commissioner,,D,Dennis Anderson,54
-Nemaha,Centralia-Illinois,Insurance Commissioner,,D,Dennis Anderson,10
-Nemaha,Sabetha City Ward 1,State House,62,R,Randy Garber R,135
-Nemaha,Sabetha City Ward 2,State House,62,R,Randy Garber R,146
-Nemaha,Sabetha City Ward 3,State House,62,R,Randy Garber R,143
-Nemaha,Sabetha City Ward 4,State House,62,R,Randy Garber R,105
-Nemaha,Seneca City Ward 1,State House,62,R,Randy Garber R,106
-Nemaha,Seneca City Ward 2,State House,62,R,Randy Garber R,150
-Nemaha,Seneca City Ward 3,State House,62,R,Randy Garber R,169
-Nemaha,Adams,State House,62,R,Randy Garber R,59
-Nemaha,Berwick,State House,62,R,Randy Garber R,132
-Nemaha,Capioma,State House,62,R,Randy Garber R,46
-Nemaha,Center,State House,62,R,Randy Garber R,23
-Nemaha,Clear Creek,State House,62,R,Randy Garber R,17
-Nemaha,Gilman,State House,62,R,Randy Garber R,52
-Nemaha,Granada,State House,62,R,Randy Garber R,26
-Nemaha,Harrison-Goff,State House,62,R,Randy Garber R,33
-Nemaha,Harrison-Kelly,State House,62,R,Randy Garber R,20
-Nemaha,Home,State House,62,R,Randy Garber R,27
-Nemaha,Illinois,State House,62,R,Randy Garber R,84
-Nemaha,Marion Township,State House,62,R,Randy Garber R,76
-Nemaha,Mitchell  Township,State House,62,R,Randy Garber R,70
-Nemaha,Nemaha Township,State House,62,R,Randy Garber R,48
-Nemaha,Neuchatel,State House,62,R,Randy Garber R,30
-Nemaha,Red  Vermillion,State House,62,R,Randy Garber R,20
-Nemaha,Reilly,State House,62,R,Randy Garber R,38
-Nemaha,Richmond Township,State House,62,R,Randy Garber R,134
-Nemaha,Rock Creek,State House,62,R,Randy Garber R,119
-Nemaha,Washington,State House,62,R,Randy Garber R,137
-Nemaha,Wetmore,State House,62,R,Randy Garber R,65
-Nemaha,Centralia-Home,State House,62,R,Randy Garber R,47
-Nemaha,Centralia-Illinois,State House,62,R,Randy Garber R,9
-Nemaha,Sabetha City Ward 1,State House,62,D,Steve Luckert D,125
-Nemaha,Sabetha City Ward 2,State House,62,D,Steve Luckert D,120
-Nemaha,Sabetha City Ward 3,State House,62,D,Steve Luckert D,118
-Nemaha,Sabetha City Ward 4,State House,62,D,Steve Luckert D,63
-Nemaha,Seneca City Ward 1,State House,62,D,Steve Luckert D,116
-Nemaha,Seneca City Ward 2,State House,62,D,Steve Luckert D,164
-Nemaha,Seneca City Ward 3,State House,62,D,Steve Luckert D,167
-Nemaha,Adams,State House,62,D,Steve Luckert D,32
-Nemaha,Berwick,State House,62,D,Steve Luckert D,47
-Nemaha,Capioma,State House,62,D,Steve Luckert D,29
-Nemaha,Center,State House,62,D,Steve Luckert D,41
-Nemaha,Clear Creek,State House,62,D,Steve Luckert D,33
-Nemaha,Gilman,State House,62,D,Steve Luckert D,36
-Nemaha,Granada,State House,62,D,Steve Luckert D,26
-Nemaha,Harrison-Goff,State House,62,D,Steve Luckert D,30
-Nemaha,Harrison-Kelly,State House,62,D,Steve Luckert D,22
-Nemaha,Home,State House,62,D,Steve Luckert D,35
-Nemaha,Illinois,State House,62,D,Steve Luckert D,91
-Nemaha,Marion Township,State House,62,D,Steve Luckert D,108
-Nemaha,Mitchell  Township,State House,62,D,Steve Luckert D,59
-Nemaha,Nemaha Township,State House,62,D,Steve Luckert D,20
-Nemaha,Neuchatel,State House,62,D,Steve Luckert D,22
-Nemaha,Red  Vermillion,State House,62,D,Steve Luckert D,20
-Nemaha,Reilly,State House,62,D,Steve Luckert D,24
-Nemaha,Richmond Township,State House,62,D,Steve Luckert D,105
-Nemaha,Rock Creek,State House,62,D,Steve Luckert D,76
-Nemaha,Washington,State House,62,D,Steve Luckert D,49
-Nemaha,Wetmore,State House,62,D,Steve Luckert D,83
-Nemaha,Centralia-Home,State House,62,D,Steve Luckert D,83
-Nemaha,Centralia-Illinois,State House,62,D,Steve Luckert D,15
+county,precinct,office,district,party,candidate,votes,vtd
+NEMAHA,Adams Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000010
+NEMAHA,Adams Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+NEMAHA,Adams Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000010
+NEMAHA,Berwick Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000020
+NEMAHA,Berwick Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000020
+NEMAHA,Berwick Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",151,000020
+NEMAHA,Capioma Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000030
+NEMAHA,Capioma Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+NEMAHA,Capioma Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000030
+NEMAHA,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000040
+NEMAHA,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+NEMAHA,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000040
+NEMAHA,Centralia,Governor / Lt. Governor,,Democratic,"Davis, Paul",66,00005A
+NEMAHA,Centralia,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00005A
+NEMAHA,Centralia,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,00005A
+NEMAHA,Centralia Illinois A,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,00005B
+NEMAHA,Centralia Illinois A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+NEMAHA,Centralia Illinois A,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,00005B
+NEMAHA,Centralia Illinois B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005C
+NEMAHA,Centralia Illinois B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005C
+NEMAHA,Centralia Illinois B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005C
+NEMAHA,Clear Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000060
+NEMAHA,Clear Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+NEMAHA,Clear Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000060
+NEMAHA,Gilman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000070
+NEMAHA,Gilman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000070
+NEMAHA,Gilman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000070
+NEMAHA,Granada Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000080
+NEMAHA,Granada Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000080
+NEMAHA,Granada Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000080
+NEMAHA,Harrison - Goff,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000090
+NEMAHA,Harrison - Goff,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000090
+NEMAHA,Harrison - Goff,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000090
+NEMAHA,Harrison - Kelly,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000100
+NEMAHA,Harrison - Kelly,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+NEMAHA,Harrison - Kelly,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000100
+NEMAHA,Home Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000110
+NEMAHA,Home Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000110
+NEMAHA,Home Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000110
+NEMAHA,Illinois Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000120
+NEMAHA,Illinois Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000120
+NEMAHA,Illinois Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000120
+NEMAHA,Marion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000130
+NEMAHA,Marion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000130
+NEMAHA,Marion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",108,000130
+NEMAHA,Mitchell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000140
+NEMAHA,Mitchell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000140
+NEMAHA,Mitchell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",82,000140
+NEMAHA,Nemaha Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000150
+NEMAHA,Nemaha Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+NEMAHA,Nemaha Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",59,000150
+NEMAHA,Neuchatel Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000160
+NEMAHA,Neuchatel Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000160
+NEMAHA,Neuchatel Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000160
+NEMAHA,Red Vermillion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000170
+NEMAHA,Red Vermillion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000170
+NEMAHA,Red Vermillion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000170
+NEMAHA,Reilly Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000180
+NEMAHA,Reilly Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000180
+NEMAHA,Reilly Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000180
+NEMAHA,Richmond Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",70,000190
+NEMAHA,Richmond Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000190
+NEMAHA,Richmond Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",164,000190
+NEMAHA,Rock Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",54,00020A
+NEMAHA,Rock Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,00020A
+NEMAHA,Rock Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,00020A
+NEMAHA,Rock Creek Township Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00020C
+NEMAHA,Sabetha Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,000210
+NEMAHA,Sabetha Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000210
+NEMAHA,Sabetha Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",150,000210
+NEMAHA,Sabetha Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",94,000220
+NEMAHA,Sabetha Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000220
+NEMAHA,Sabetha Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",161,000220
+NEMAHA,Sabetha Ward,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,00023A
+NEMAHA,Sabetha Ward,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,00023A
+NEMAHA,Sabetha Ward,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00023B
+NEMAHA,Sabetha Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000240
+NEMAHA,Sabetha Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000240
+NEMAHA,Sabetha Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000240
+NEMAHA,Sabetha Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000250
+NEMAHA,Sabetha Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000250
+NEMAHA,Sabetha Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000250
+NEMAHA,Seneca Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000260
+NEMAHA,Seneca Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000260
+NEMAHA,Seneca Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",121,000260
+NEMAHA,Seneca Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",132,000270
+NEMAHA,Seneca Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000270
+NEMAHA,Seneca Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",177,000270
+NEMAHA,Seneca Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",130,000280
+NEMAHA,Seneca Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000280
+NEMAHA,Seneca Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",193,000280
+NEMAHA,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000290
+NEMAHA,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000290
+NEMAHA,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",140,000290
+NEMAHA,Wetmore Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",63,000300
+NEMAHA,Wetmore Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000300
+NEMAHA,Wetmore Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",74,000300
+NEMAHA,Richmond Township Enclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+NEMAHA,Richmond Township Enclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+NEMAHA,Richmond Township Enclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+NEMAHA,Richland Township Enclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+NEMAHA,Richland Township Enclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+NEMAHA,Richland Township Enclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+NEMAHA,Sabetha Ward Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+NEMAHA,Sabetha Ward Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+NEMAHA,Sabetha Ward Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+NEMAHA,Adams Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",32,000010
+NEMAHA,Adams Township,Kansas House of Representatives,62,Republican,"Garber, Randy",59,000010
+NEMAHA,Berwick Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",47,000020
+NEMAHA,Berwick Township,Kansas House of Representatives,62,Republican,"Garber, Randy",132,000020
+NEMAHA,Capioma Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",29,000030
+NEMAHA,Capioma Township,Kansas House of Representatives,62,Republican,"Garber, Randy",46,000030
+NEMAHA,Center Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",41,000040
+NEMAHA,Center Township,Kansas House of Representatives,62,Republican,"Garber, Randy",23,000040
+NEMAHA,Centralia,Kansas House of Representatives,62,Democratic,"Lukert, Steve",83,00005A
+NEMAHA,Centralia,Kansas House of Representatives,62,Republican,"Garber, Randy",47,00005A
+NEMAHA,Centralia Illinois A,Kansas House of Representatives,62,Democratic,"Lukert, Steve",15,00005B
+NEMAHA,Centralia Illinois A,Kansas House of Representatives,62,Republican,"Garber, Randy",9,00005B
+NEMAHA,Centralia Illinois B,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00005C
+NEMAHA,Centralia Illinois B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00005C
+NEMAHA,Clear Creek Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",33,000060
+NEMAHA,Clear Creek Township,Kansas House of Representatives,62,Republican,"Garber, Randy",17,000060
+NEMAHA,Gilman Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",36,000070
+NEMAHA,Gilman Township,Kansas House of Representatives,62,Republican,"Garber, Randy",52,000070
+NEMAHA,Granada Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",26,000080
+NEMAHA,Granada Township,Kansas House of Representatives,62,Republican,"Garber, Randy",26,000080
+NEMAHA,Harrison - Goff,Kansas House of Representatives,62,Democratic,"Lukert, Steve",30,000090
+NEMAHA,Harrison - Goff,Kansas House of Representatives,62,Republican,"Garber, Randy",33,000090
+NEMAHA,Harrison - Kelly,Kansas House of Representatives,62,Democratic,"Lukert, Steve",22,000100
+NEMAHA,Harrison - Kelly,Kansas House of Representatives,62,Republican,"Garber, Randy",20,000100
+NEMAHA,Home Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",35,000110
+NEMAHA,Home Township,Kansas House of Representatives,62,Republican,"Garber, Randy",27,000110
+NEMAHA,Illinois Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",91,000120
+NEMAHA,Illinois Township,Kansas House of Representatives,62,Republican,"Garber, Randy",84,000120
+NEMAHA,Marion Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",108,000130
+NEMAHA,Marion Township,Kansas House of Representatives,62,Republican,"Garber, Randy",76,000130
+NEMAHA,Mitchell Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",59,000140
+NEMAHA,Mitchell Township,Kansas House of Representatives,62,Republican,"Garber, Randy",70,000140
+NEMAHA,Nemaha Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",20,000150
+NEMAHA,Nemaha Township,Kansas House of Representatives,62,Republican,"Garber, Randy",48,000150
+NEMAHA,Neuchatel Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",22,000160
+NEMAHA,Neuchatel Township,Kansas House of Representatives,62,Republican,"Garber, Randy",30,000160
+NEMAHA,Red Vermillion Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",20,000170
+NEMAHA,Red Vermillion Township,Kansas House of Representatives,62,Republican,"Garber, Randy",20,000170
+NEMAHA,Reilly Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",24,000180
+NEMAHA,Reilly Township,Kansas House of Representatives,62,Republican,"Garber, Randy",38,000180
+NEMAHA,Richmond Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",105,000190
+NEMAHA,Richmond Township,Kansas House of Representatives,62,Republican,"Garber, Randy",134,000190
+NEMAHA,Rock Creek Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",76,00020A
+NEMAHA,Rock Creek Township,Kansas House of Representatives,62,Republican,"Garber, Randy",119,00020A
+NEMAHA,Rock Creek Township Enclave A,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00020C
+NEMAHA,Sabetha Ward 1,Kansas House of Representatives,62,Democratic,"Lukert, Steve",125,000210
+NEMAHA,Sabetha Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",135,000210
+NEMAHA,Sabetha Ward 2,Kansas House of Representatives,62,Democratic,"Lukert, Steve",120,000220
+NEMAHA,Sabetha Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",146,000220
+NEMAHA,Sabetha Ward,Kansas House of Representatives,62,Democratic,"Lukert, Steve",118,00023A
+NEMAHA,Sabetha Ward,Kansas House of Representatives,62,Republican,"Garber, Randy",143,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00023B
+NEMAHA,Sabetha Ward 4,Kansas House of Representatives,62,Democratic,"Lukert, Steve",63,000240
+NEMAHA,Sabetha Ward 4,Kansas House of Representatives,62,Republican,"Garber, Randy",105,000240
+NEMAHA,Sabetha Ward 5,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,000250
+NEMAHA,Sabetha Ward 5,Kansas House of Representatives,62,Republican,"Garber, Randy",0,000250
+NEMAHA,Seneca Ward 1,Kansas House of Representatives,62,Democratic,"Lukert, Steve",116,000260
+NEMAHA,Seneca Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",106,000260
+NEMAHA,Seneca Ward 2,Kansas House of Representatives,62,Democratic,"Lukert, Steve",164,000270
+NEMAHA,Seneca Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",150,000270
+NEMAHA,Seneca Ward 3,Kansas House of Representatives,62,Democratic,"Lukert, Steve",167,000280
+NEMAHA,Seneca Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",169,000280
+NEMAHA,Washington Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",49,000290
+NEMAHA,Washington Township,Kansas House of Representatives,62,Republican,"Garber, Randy",137,000290
+NEMAHA,Wetmore Township,Kansas House of Representatives,62,Democratic,"Lukert, Steve",83,000300
+NEMAHA,Wetmore Township,Kansas House of Representatives,62,Republican,"Garber, Randy",65,000300
+NEMAHA,Richmond Township Enclave 1,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,900010
+NEMAHA,Richmond Township Enclave 1,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900010
+NEMAHA,Richland Township Enclave 2,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,900020
+NEMAHA,Richland Township Enclave 2,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900020
+NEMAHA,Sabetha Ward Exclave,Kansas House of Representatives,62,Democratic,"Lukert, Steve",0,900030
+NEMAHA,Sabetha Ward Exclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900030
+NEMAHA,Adams Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,000010
+NEMAHA,Adams Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000010
+NEMAHA,Adams Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000010
+NEMAHA,Berwick Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,000020
+NEMAHA,Berwick Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000020
+NEMAHA,Berwick Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000020
+NEMAHA,Capioma Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000030
+NEMAHA,Capioma Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000030
+NEMAHA,Capioma Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,000030
+NEMAHA,Center Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000040
+NEMAHA,Center Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000040
+NEMAHA,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,000040
+NEMAHA,Centralia,United States House of Representatives,2,Democratic,"Wakefield, Margie",39,00005A
+NEMAHA,Centralia,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,00005A
+NEMAHA,Centralia,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,00005A
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Democratic,"Wakefield, Margie",10,00005B
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00005B
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Republican,"Jenkins, Lynn",14,00005B
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00005C
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00005C
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000060
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000060
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",32,000060
+NEMAHA,Gilman Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000070
+NEMAHA,Gilman Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000070
+NEMAHA,Gilman Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000070
+NEMAHA,Granada Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",12,000080
+NEMAHA,Granada Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000080
+NEMAHA,Granada Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,000080
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000090
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000090
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Republican,"Jenkins, Lynn",42,000090
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Democratic,"Wakefield, Margie",8,000100
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000100
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000100
+NEMAHA,Home Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",11,000110
+NEMAHA,Home Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000110
+NEMAHA,Home Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,000110
+NEMAHA,Illinois Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,000120
+NEMAHA,Illinois Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000120
+NEMAHA,Illinois Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,000120
+NEMAHA,Marion Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",50,000130
+NEMAHA,Marion Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000130
+NEMAHA,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,000130
+NEMAHA,Mitchell Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",25,000140
+NEMAHA,Mitchell Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000140
+NEMAHA,Mitchell Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000140
+NEMAHA,Nemaha Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",3,000150
+NEMAHA,Nemaha Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000150
+NEMAHA,Nemaha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000150
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",13,000160
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000160
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,000160
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,000170
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000170
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000170
+NEMAHA,Reilly Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000180
+NEMAHA,Reilly Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000180
+NEMAHA,Reilly Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,000180
+NEMAHA,Richmond Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",40,000190
+NEMAHA,Richmond Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000190
+NEMAHA,Richmond Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",197,000190
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,00020A
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,00020A
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",162,00020A
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020B
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020C
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",55,000210
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000210
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",193,000210
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",46,000220
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000220
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",210,000220
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Democratic,"Wakefield, Margie",49,00023A
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,00023A
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Republican,"Jenkins, Lynn",198,00023A
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00023B
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,000240
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000240
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",124,000240
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,000250
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000250
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000250
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",55,000260
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000260
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",155,000260
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",95,000270
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000270
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",209,000270
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",83,000280
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000280
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",242,000280
+NEMAHA,Washington Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,000290
+NEMAHA,Washington Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000290
+NEMAHA,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",158,000290
+NEMAHA,Wetmore Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",50,000300
+NEMAHA,Wetmore Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000300
+NEMAHA,Wetmore Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,000300
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+NEMAHA,Adams Township,Attorney General,,Democratic,"Kotich, A.J.",14,000010
+NEMAHA,Adams Township,Attorney General,,Republican,"Schmidt, Derek",72,000010
+NEMAHA,Berwick Township,Attorney General,,Democratic,"Kotich, A.J.",12,000020
+NEMAHA,Berwick Township,Attorney General,,Republican,"Schmidt, Derek",158,000020
+NEMAHA,Capioma Township,Attorney General,,Democratic,"Kotich, A.J.",7,000030
+NEMAHA,Capioma Township,Attorney General,,Republican,"Schmidt, Derek",65,000030
+NEMAHA,Center Township,Attorney General,,Democratic,"Kotich, A.J.",12,000040
+NEMAHA,Center Township,Attorney General,,Republican,"Schmidt, Derek",49,000040
+NEMAHA,Centralia,Attorney General,,Democratic,"Kotich, A.J.",33,00005A
+NEMAHA,Centralia,Attorney General,,Republican,"Schmidt, Derek",95,00005A
+NEMAHA,Centralia Illinois A,Attorney General,,Democratic,"Kotich, A.J.",7,00005B
+NEMAHA,Centralia Illinois A,Attorney General,,Republican,"Schmidt, Derek",17,00005B
+NEMAHA,Centralia Illinois B,Attorney General,,Democratic,"Kotich, A.J.",0,00005C
+NEMAHA,Centralia Illinois B,Attorney General,,Republican,"Schmidt, Derek",0,00005C
+NEMAHA,Clear Creek Township,Attorney General,,Democratic,"Kotich, A.J.",11,000060
+NEMAHA,Clear Creek Township,Attorney General,,Republican,"Schmidt, Derek",36,000060
+NEMAHA,Gilman Township,Attorney General,,Democratic,"Kotich, A.J.",19,000070
+NEMAHA,Gilman Township,Attorney General,,Republican,"Schmidt, Derek",65,000070
+NEMAHA,Granada Township,Attorney General,,Democratic,"Kotich, A.J.",7,000080
+NEMAHA,Granada Township,Attorney General,,Republican,"Schmidt, Derek",42,000080
+NEMAHA,Harrison - Goff,Attorney General,,Democratic,"Kotich, A.J.",17,000090
+NEMAHA,Harrison - Goff,Attorney General,,Republican,"Schmidt, Derek",43,000090
+NEMAHA,Harrison - Kelly,Attorney General,,Democratic,"Kotich, A.J.",10,000100
+NEMAHA,Harrison - Kelly,Attorney General,,Republican,"Schmidt, Derek",30,000100
+NEMAHA,Home Township,Attorney General,,Democratic,"Kotich, A.J.",11,000110
+NEMAHA,Home Township,Attorney General,,Republican,"Schmidt, Derek",49,000110
+NEMAHA,Illinois Township,Attorney General,,Democratic,"Kotich, A.J.",30,000120
+NEMAHA,Illinois Township,Attorney General,,Republican,"Schmidt, Derek",135,000120
+NEMAHA,Marion Township,Attorney General,,Democratic,"Kotich, A.J.",30,000130
+NEMAHA,Marion Township,Attorney General,,Republican,"Schmidt, Derek",143,000130
+NEMAHA,Mitchell Township,Attorney General,,Democratic,"Kotich, A.J.",19,000140
+NEMAHA,Mitchell Township,Attorney General,,Republican,"Schmidt, Derek",100,000140
+NEMAHA,Nemaha Township,Attorney General,,Democratic,"Kotich, A.J.",1,000150
+NEMAHA,Nemaha Township,Attorney General,,Republican,"Schmidt, Derek",64,000150
+NEMAHA,Neuchatel Township,Attorney General,,Democratic,"Kotich, A.J.",10,000160
+NEMAHA,Neuchatel Township,Attorney General,,Republican,"Schmidt, Derek",40,000160
+NEMAHA,Red Vermillion Township,Attorney General,,Democratic,"Kotich, A.J.",7,000170
+NEMAHA,Red Vermillion Township,Attorney General,,Republican,"Schmidt, Derek",31,000170
+NEMAHA,Reilly Township,Attorney General,,Democratic,"Kotich, A.J.",11,000180
+NEMAHA,Reilly Township,Attorney General,,Republican,"Schmidt, Derek",50,000180
+NEMAHA,Richmond Township,Attorney General,,Democratic,"Kotich, A.J.",31,000190
+NEMAHA,Richmond Township,Attorney General,,Republican,"Schmidt, Derek",199,000190
+NEMAHA,Rock Creek Township,Attorney General,,Democratic,"Kotich, A.J.",22,00020A
+NEMAHA,Rock Creek Township,Attorney General,,Republican,"Schmidt, Derek",165,00020A
+NEMAHA,Rock Creek Township Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,00020C
+NEMAHA,Sabetha Ward 1,Attorney General,,Democratic,"Kotich, A.J.",58,000210
+NEMAHA,Sabetha Ward 1,Attorney General,,Republican,"Schmidt, Derek",194,000210
+NEMAHA,Sabetha Ward 2,Attorney General,,Democratic,"Kotich, A.J.",47,000220
+NEMAHA,Sabetha Ward 2,Attorney General,,Republican,"Schmidt, Derek",203,000220
+NEMAHA,Sabetha Ward,Attorney General,,Democratic,"Kotich, A.J.",42,00023A
+NEMAHA,Sabetha Ward,Attorney General,,Republican,"Schmidt, Derek",212,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00023B
+NEMAHA,Sabetha Ward 4,Attorney General,,Democratic,"Kotich, A.J.",31,000240
+NEMAHA,Sabetha Ward 4,Attorney General,,Republican,"Schmidt, Derek",121,000240
+NEMAHA,Sabetha Ward 5,Attorney General,,Democratic,"Kotich, A.J.",0,000250
+NEMAHA,Sabetha Ward 5,Attorney General,,Republican,"Schmidt, Derek",0,000250
+NEMAHA,Seneca Ward 1,Attorney General,,Democratic,"Kotich, A.J.",50,000260
+NEMAHA,Seneca Ward 1,Attorney General,,Republican,"Schmidt, Derek",160,000260
+NEMAHA,Seneca Ward 2,Attorney General,,Democratic,"Kotich, A.J.",71,000270
+NEMAHA,Seneca Ward 2,Attorney General,,Republican,"Schmidt, Derek",220,000270
+NEMAHA,Seneca Ward 3,Attorney General,,Democratic,"Kotich, A.J.",70,000280
+NEMAHA,Seneca Ward 3,Attorney General,,Republican,"Schmidt, Derek",256,000280
+NEMAHA,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",20,000290
+NEMAHA,Washington Township,Attorney General,,Republican,"Schmidt, Derek",163,000290
+NEMAHA,Wetmore Township,Attorney General,,Democratic,"Kotich, A.J.",43,000300
+NEMAHA,Wetmore Township,Attorney General,,Republican,"Schmidt, Derek",102,000300
+NEMAHA,Richmond Township Enclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+NEMAHA,Richmond Township Enclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900010
+NEMAHA,Richland Township Enclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+NEMAHA,Richland Township Enclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900020
+NEMAHA,Sabetha Ward Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+NEMAHA,Sabetha Ward Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900030
+NEMAHA,Adams Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000010
+NEMAHA,Adams Township,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000010
+NEMAHA,Berwick Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000020
+NEMAHA,Berwick Township,Commissioner of Insurance,,Republican,"Selzer, Ken",150,000020
+NEMAHA,Capioma Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000030
+NEMAHA,Capioma Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000030
+NEMAHA,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000040
+NEMAHA,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",44,000040
+NEMAHA,Centralia,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,00005A
+NEMAHA,Centralia,Commissioner of Insurance,,Republican,"Selzer, Ken",70,00005A
+NEMAHA,Centralia Illinois A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,00005B
+NEMAHA,Centralia Illinois A,Commissioner of Insurance,,Republican,"Selzer, Ken",14,00005B
+NEMAHA,Centralia Illinois B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005C
+NEMAHA,Centralia Illinois B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005C
+NEMAHA,Clear Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000060
+NEMAHA,Clear Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000060
+NEMAHA,Gilman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000070
+NEMAHA,Gilman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",53,000070
+NEMAHA,Granada Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000080
+NEMAHA,Granada Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000080
+NEMAHA,Harrison - Goff,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000090
+NEMAHA,Harrison - Goff,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000090
+NEMAHA,Harrison - Kelly,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000100
+NEMAHA,Harrison - Kelly,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000100
+NEMAHA,Home Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000110
+NEMAHA,Home Township,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000110
+NEMAHA,Illinois Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000120
+NEMAHA,Illinois Township,Commissioner of Insurance,,Republican,"Selzer, Ken",114,000120
+NEMAHA,Marion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000130
+NEMAHA,Marion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",118,000130
+NEMAHA,Mitchell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,000140
+NEMAHA,Mitchell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",86,000140
+NEMAHA,Nemaha Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000150
+NEMAHA,Nemaha Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000150
+NEMAHA,Neuchatel Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000160
+NEMAHA,Neuchatel Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000160
+NEMAHA,Red Vermillion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000170
+NEMAHA,Red Vermillion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000170
+NEMAHA,Reilly Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000180
+NEMAHA,Reilly Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000180
+NEMAHA,Richmond Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",49,000190
+NEMAHA,Richmond Township,Commissioner of Insurance,,Republican,"Selzer, Ken",161,000190
+NEMAHA,Rock Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,00020A
+NEMAHA,Rock Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",154,00020A
+NEMAHA,Rock Creek Township Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00020C
+NEMAHA,Sabetha Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,000210
+NEMAHA,Sabetha Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",181,000210
+NEMAHA,Sabetha Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000220
+NEMAHA,Sabetha Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",191,000220
+NEMAHA,Sabetha Ward,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,00023A
+NEMAHA,Sabetha Ward,Commissioner of Insurance,,Republican,"Selzer, Ken",192,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00023B
+NEMAHA,Sabetha Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000240
+NEMAHA,Sabetha Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",116,000240
+NEMAHA,Sabetha Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000250
+NEMAHA,Sabetha Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000250
+NEMAHA,Seneca Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000260
+NEMAHA,Seneca Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",130,000260
+NEMAHA,Seneca Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",106,000270
+NEMAHA,Seneca Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",174,000270
+NEMAHA,Seneca Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",103,000280
+NEMAHA,Seneca Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",202,000280
+NEMAHA,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000290
+NEMAHA,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",148,000290
+NEMAHA,Wetmore Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000300
+NEMAHA,Wetmore Township,Commissioner of Insurance,,Republican,"Selzer, Ken",85,000300
+NEMAHA,Richmond Township Enclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+NEMAHA,Richmond Township Enclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+NEMAHA,Richland Township Enclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+NEMAHA,Richland Township Enclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+NEMAHA,Sabetha Ward Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+NEMAHA,Sabetha Ward Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+NEMAHA,Adams Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000010
+NEMAHA,Adams Township,Secretary of State,,Republican,"Kobach, Kris",76,000010
+NEMAHA,Berwick Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000020
+NEMAHA,Berwick Township,Secretary of State,,Republican,"Kobach, Kris",160,000020
+NEMAHA,Capioma Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000030
+NEMAHA,Capioma Township,Secretary of State,,Republican,"Kobach, Kris",66,000030
+NEMAHA,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000040
+NEMAHA,Center Township,Secretary of State,,Republican,"Kobach, Kris",45,000040
+NEMAHA,Centralia,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,00005A
+NEMAHA,Centralia,Secretary of State,,Republican,"Kobach, Kris",83,00005A
+NEMAHA,Centralia Illinois A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,00005B
+NEMAHA,Centralia Illinois A,Secretary of State,,Republican,"Kobach, Kris",16,00005B
+NEMAHA,Centralia Illinois B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005C
+NEMAHA,Centralia Illinois B,Secretary of State,,Republican,"Kobach, Kris",0,00005C
+NEMAHA,Clear Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000060
+NEMAHA,Clear Creek Township,Secretary of State,,Republican,"Kobach, Kris",33,000060
+NEMAHA,Gilman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000070
+NEMAHA,Gilman Township,Secretary of State,,Republican,"Kobach, Kris",67,000070
+NEMAHA,Granada Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000080
+NEMAHA,Granada Township,Secretary of State,,Republican,"Kobach, Kris",37,000080
+NEMAHA,Harrison - Goff,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000090
+NEMAHA,Harrison - Goff,Secretary of State,,Republican,"Kobach, Kris",45,000090
+NEMAHA,Harrison - Kelly,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000100
+NEMAHA,Harrison - Kelly,Secretary of State,,Republican,"Kobach, Kris",29,000100
+NEMAHA,Home Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000110
+NEMAHA,Home Township,Secretary of State,,Republican,"Kobach, Kris",44,000110
+NEMAHA,Illinois Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000120
+NEMAHA,Illinois Township,Secretary of State,,Republican,"Kobach, Kris",128,000120
+NEMAHA,Marion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000130
+NEMAHA,Marion Township,Secretary of State,,Republican,"Kobach, Kris",136,000130
+NEMAHA,Mitchell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000140
+NEMAHA,Mitchell Township,Secretary of State,,Republican,"Kobach, Kris",100,000140
+NEMAHA,Nemaha Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000150
+NEMAHA,Nemaha Township,Secretary of State,,Republican,"Kobach, Kris",61,000150
+NEMAHA,Neuchatel Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000160
+NEMAHA,Neuchatel Township,Secretary of State,,Republican,"Kobach, Kris",41,000160
+NEMAHA,Red Vermillion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000170
+NEMAHA,Red Vermillion Township,Secretary of State,,Republican,"Kobach, Kris",31,000170
+NEMAHA,Reilly Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000180
+NEMAHA,Reilly Township,Secretary of State,,Republican,"Kobach, Kris",47,000180
+NEMAHA,Richmond Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000190
+NEMAHA,Richmond Township,Secretary of State,,Republican,"Kobach, Kris",191,000190
+NEMAHA,Rock Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,00020A
+NEMAHA,Rock Creek Township,Secretary of State,,Republican,"Kobach, Kris",161,00020A
+NEMAHA,Rock Creek Township Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,00020C
+NEMAHA,Sabetha Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000210
+NEMAHA,Sabetha Ward 1,Secretary of State,,Republican,"Kobach, Kris",193,000210
+NEMAHA,Sabetha Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,000220
+NEMAHA,Sabetha Ward 2,Secretary of State,,Republican,"Kobach, Kris",201,000220
+NEMAHA,Sabetha Ward,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,00023A
+NEMAHA,Sabetha Ward,Secretary of State,,Republican,"Kobach, Kris",196,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00023B
+NEMAHA,Sabetha Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000240
+NEMAHA,Sabetha Ward 4,Secretary of State,,Republican,"Kobach, Kris",123,000240
+NEMAHA,Sabetha Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000250
+NEMAHA,Sabetha Ward 5,Secretary of State,,Republican,"Kobach, Kris",0,000250
+NEMAHA,Seneca Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",63,000260
+NEMAHA,Seneca Ward 1,Secretary of State,,Republican,"Kobach, Kris",150,000260
+NEMAHA,Seneca Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000270
+NEMAHA,Seneca Ward 2,Secretary of State,,Republican,"Kobach, Kris",207,000270
+NEMAHA,Seneca Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",91,000280
+NEMAHA,Seneca Ward 3,Secretary of State,,Republican,"Kobach, Kris",235,000280
+NEMAHA,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000290
+NEMAHA,Washington Township,Secretary of State,,Republican,"Kobach, Kris",163,000290
+NEMAHA,Wetmore Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000300
+NEMAHA,Wetmore Township,Secretary of State,,Republican,"Kobach, Kris",105,000300
+NEMAHA,Richmond Township Enclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+NEMAHA,Richmond Township Enclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900010
+NEMAHA,Richland Township Enclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+NEMAHA,Richland Township Enclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900020
+NEMAHA,Sabetha Ward Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+NEMAHA,Sabetha Ward Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900030
+NEMAHA,Adams Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000010
+NEMAHA,Adams Township,State Treasurer,,Republican,"Estes, Ron",68,000010
+NEMAHA,Berwick Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000020
+NEMAHA,Berwick Township,State Treasurer,,Republican,"Estes, Ron",160,000020
+NEMAHA,Capioma Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+NEMAHA,Capioma Township,State Treasurer,,Republican,"Estes, Ron",66,000030
+NEMAHA,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000040
+NEMAHA,Center Township,State Treasurer,,Republican,"Estes, Ron",45,000040
+NEMAHA,Centralia,State Treasurer,,Democratic,"Alldritt, Carmen",39,00005A
+NEMAHA,Centralia,State Treasurer,,Republican,"Estes, Ron",83,00005A
+NEMAHA,Centralia Illinois A,State Treasurer,,Democratic,"Alldritt, Carmen",7,00005B
+NEMAHA,Centralia Illinois A,State Treasurer,,Republican,"Estes, Ron",16,00005B
+NEMAHA,Centralia Illinois B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005C
+NEMAHA,Centralia Illinois B,State Treasurer,,Republican,"Estes, Ron",0,00005C
+NEMAHA,Clear Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000060
+NEMAHA,Clear Creek Township,State Treasurer,,Republican,"Estes, Ron",34,000060
+NEMAHA,Gilman Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000070
+NEMAHA,Gilman Township,State Treasurer,,Republican,"Estes, Ron",60,000070
+NEMAHA,Granada Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000080
+NEMAHA,Granada Township,State Treasurer,,Republican,"Estes, Ron",39,000080
+NEMAHA,Harrison - Goff,State Treasurer,,Democratic,"Alldritt, Carmen",17,000090
+NEMAHA,Harrison - Goff,State Treasurer,,Republican,"Estes, Ron",40,000090
+NEMAHA,Harrison - Kelly,State Treasurer,,Democratic,"Alldritt, Carmen",9,000100
+NEMAHA,Harrison - Kelly,State Treasurer,,Republican,"Estes, Ron",31,000100
+NEMAHA,Home Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000110
+NEMAHA,Home Township,State Treasurer,,Republican,"Estes, Ron",42,000110
+NEMAHA,Illinois Township,State Treasurer,,Democratic,"Alldritt, Carmen",36,000120
+NEMAHA,Illinois Township,State Treasurer,,Republican,"Estes, Ron",131,000120
+NEMAHA,Marion Township,State Treasurer,,Democratic,"Alldritt, Carmen",35,000130
+NEMAHA,Marion Township,State Treasurer,,Republican,"Estes, Ron",133,000130
+NEMAHA,Mitchell Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000140
+NEMAHA,Mitchell Township,State Treasurer,,Republican,"Estes, Ron",108,000140
+NEMAHA,Nemaha Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000150
+NEMAHA,Nemaha Township,State Treasurer,,Republican,"Estes, Ron",62,000150
+NEMAHA,Neuchatel Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000160
+NEMAHA,Neuchatel Township,State Treasurer,,Republican,"Estes, Ron",40,000160
+NEMAHA,Red Vermillion Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000170
+NEMAHA,Red Vermillion Township,State Treasurer,,Republican,"Estes, Ron",31,000170
+NEMAHA,Reilly Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000180
+NEMAHA,Reilly Township,State Treasurer,,Republican,"Estes, Ron",47,000180
+NEMAHA,Richmond Township,State Treasurer,,Democratic,"Alldritt, Carmen",40,000190
+NEMAHA,Richmond Township,State Treasurer,,Republican,"Estes, Ron",180,000190
+NEMAHA,Rock Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,00020A
+NEMAHA,Rock Creek Township,State Treasurer,,Republican,"Estes, Ron",163,00020A
+NEMAHA,Rock Creek Township Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00020B
+NEMAHA,Rock Creek Township Enclave A,State Treasurer,,Republican,"Estes, Ron",0,00020B
+NEMAHA,Rock Creek Township Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00020C
+NEMAHA,Rock Creek Township Enclave B,State Treasurer,,Republican,"Estes, Ron",0,00020C
+NEMAHA,Sabetha Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",52,000210
+NEMAHA,Sabetha Ward 1,State Treasurer,,Republican,"Estes, Ron",198,000210
+NEMAHA,Sabetha Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",44,000220
+NEMAHA,Sabetha Ward 2,State Treasurer,,Republican,"Estes, Ron",205,000220
+NEMAHA,Sabetha Ward,State Treasurer,,Democratic,"Alldritt, Carmen",39,00023A
+NEMAHA,Sabetha Ward,State Treasurer,,Republican,"Estes, Ron",214,00023A
+NEMAHA,Sabetha Ward 3 Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,State Treasurer,,Republican,"Estes, Ron",0,00023B
+NEMAHA,Sabetha Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",31,000240
+NEMAHA,Sabetha Ward 4,State Treasurer,,Republican,"Estes, Ron",119,000240
+NEMAHA,Sabetha Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",0,000250
+NEMAHA,Sabetha Ward 5,State Treasurer,,Republican,"Estes, Ron",0,000250
+NEMAHA,Seneca Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",50,000260
+NEMAHA,Seneca Ward 1,State Treasurer,,Republican,"Estes, Ron",153,000260
+NEMAHA,Seneca Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",85,000270
+NEMAHA,Seneca Ward 2,State Treasurer,,Republican,"Estes, Ron",201,000270
+NEMAHA,Seneca Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",71,000280
+NEMAHA,Seneca Ward 3,State Treasurer,,Republican,"Estes, Ron",234,000280
+NEMAHA,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000290
+NEMAHA,Washington Township,State Treasurer,,Republican,"Estes, Ron",157,000290
+NEMAHA,Wetmore Township,State Treasurer,,Democratic,"Alldritt, Carmen",42,000300
+NEMAHA,Wetmore Township,State Treasurer,,Republican,"Estes, Ron",102,000300
+NEMAHA,Richmond Township Enclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+NEMAHA,Richmond Township Enclave 1,State Treasurer,,Republican,"Estes, Ron",0,900010
+NEMAHA,Richland Township Enclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+NEMAHA,Richland Township Enclave 2,State Treasurer,,Republican,"Estes, Ron",0,900020
+NEMAHA,Sabetha Ward Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+NEMAHA,Sabetha Ward Exclave,State Treasurer,,Republican,"Estes, Ron",0,900030
+NEMAHA,Adams Township,United States Senate,,independent,"Orman, Greg",15,000010
+NEMAHA,Adams Township,United States Senate,,Libertarian,"Batson, Randall",5,000010
+NEMAHA,Adams Township,United States Senate,,Republican,"Roberts, Pat",71,000010
+NEMAHA,Berwick Township,United States Senate,,independent,"Orman, Greg",21,000020
+NEMAHA,Berwick Township,United States Senate,,Libertarian,"Batson, Randall",10,000020
+NEMAHA,Berwick Township,United States Senate,,Republican,"Roberts, Pat",146,000020
+NEMAHA,Capioma Township,United States Senate,,independent,"Orman, Greg",11,000030
+NEMAHA,Capioma Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+NEMAHA,Capioma Township,United States Senate,,Republican,"Roberts, Pat",59,000030
+NEMAHA,Center Township,United States Senate,,independent,"Orman, Greg",16,000040
+NEMAHA,Center Township,United States Senate,,Libertarian,"Batson, Randall",5,000040
+NEMAHA,Center Township,United States Senate,,Republican,"Roberts, Pat",44,000040
+NEMAHA,Centralia,United States Senate,,independent,"Orman, Greg",46,00005A
+NEMAHA,Centralia,United States Senate,,Libertarian,"Batson, Randall",10,00005A
+NEMAHA,Centralia,United States Senate,,Republican,"Roberts, Pat",75,00005A
+NEMAHA,Centralia Illinois A,United States Senate,,independent,"Orman, Greg",14,00005B
+NEMAHA,Centralia Illinois A,United States Senate,,Libertarian,"Batson, Randall",1,00005B
+NEMAHA,Centralia Illinois A,United States Senate,,Republican,"Roberts, Pat",9,00005B
+NEMAHA,Centralia Illinois B,United States Senate,,independent,"Orman, Greg",0,00005C
+NEMAHA,Centralia Illinois B,United States Senate,,Libertarian,"Batson, Randall",0,00005C
+NEMAHA,Centralia Illinois B,United States Senate,,Republican,"Roberts, Pat",0,00005C
+NEMAHA,Clear Creek Township,United States Senate,,independent,"Orman, Greg",18,000060
+NEMAHA,Clear Creek Township,United States Senate,,Libertarian,"Batson, Randall",3,000060
+NEMAHA,Clear Creek Township,United States Senate,,Republican,"Roberts, Pat",28,000060
+NEMAHA,Gilman Township,United States Senate,,independent,"Orman, Greg",29,000070
+NEMAHA,Gilman Township,United States Senate,,Libertarian,"Batson, Randall",5,000070
+NEMAHA,Gilman Township,United States Senate,,Republican,"Roberts, Pat",54,000070
+NEMAHA,Granada Township,United States Senate,,independent,"Orman, Greg",22,000080
+NEMAHA,Granada Township,United States Senate,,Libertarian,"Batson, Randall",2,000080
+NEMAHA,Granada Township,United States Senate,,Republican,"Roberts, Pat",28,000080
+NEMAHA,Harrison - Goff,United States Senate,,independent,"Orman, Greg",17,000090
+NEMAHA,Harrison - Goff,United States Senate,,Libertarian,"Batson, Randall",6,000090
+NEMAHA,Harrison - Goff,United States Senate,,Republican,"Roberts, Pat",41,000090
+NEMAHA,Harrison - Kelly,United States Senate,,independent,"Orman, Greg",18,000100
+NEMAHA,Harrison - Kelly,United States Senate,,Libertarian,"Batson, Randall",0,000100
+NEMAHA,Harrison - Kelly,United States Senate,,Republican,"Roberts, Pat",24,000100
+NEMAHA,Home Township,United States Senate,,independent,"Orman, Greg",14,000110
+NEMAHA,Home Township,United States Senate,,Libertarian,"Batson, Randall",8,000110
+NEMAHA,Home Township,United States Senate,,Republican,"Roberts, Pat",40,000110
+NEMAHA,Illinois Township,United States Senate,,independent,"Orman, Greg",48,000120
+NEMAHA,Illinois Township,United States Senate,,Libertarian,"Batson, Randall",11,000120
+NEMAHA,Illinois Township,United States Senate,,Republican,"Roberts, Pat",114,000120
+NEMAHA,Marion Township,United States Senate,,independent,"Orman, Greg",55,000130
+NEMAHA,Marion Township,United States Senate,,Libertarian,"Batson, Randall",5,000130
+NEMAHA,Marion Township,United States Senate,,Republican,"Roberts, Pat",124,000130
+NEMAHA,Mitchell Township,United States Senate,,independent,"Orman, Greg",29,000140
+NEMAHA,Mitchell Township,United States Senate,,Libertarian,"Batson, Randall",3,000140
+NEMAHA,Mitchell Township,United States Senate,,Republican,"Roberts, Pat",97,000140
+NEMAHA,Nemaha Township,United States Senate,,independent,"Orman, Greg",4,000150
+NEMAHA,Nemaha Township,United States Senate,,Libertarian,"Batson, Randall",2,000150
+NEMAHA,Nemaha Township,United States Senate,,Republican,"Roberts, Pat",62,000150
+NEMAHA,Neuchatel Township,United States Senate,,independent,"Orman, Greg",11,000160
+NEMAHA,Neuchatel Township,United States Senate,,Libertarian,"Batson, Randall",1,000160
+NEMAHA,Neuchatel Township,United States Senate,,Republican,"Roberts, Pat",41,000160
+NEMAHA,Red Vermillion Township,United States Senate,,independent,"Orman, Greg",13,000170
+NEMAHA,Red Vermillion Township,United States Senate,,Libertarian,"Batson, Randall",1,000170
+NEMAHA,Red Vermillion Township,United States Senate,,Republican,"Roberts, Pat",26,000170
+NEMAHA,Reilly Township,United States Senate,,independent,"Orman, Greg",14,000180
+NEMAHA,Reilly Township,United States Senate,,Libertarian,"Batson, Randall",3,000180
+NEMAHA,Reilly Township,United States Senate,,Republican,"Roberts, Pat",45,000180
+NEMAHA,Richmond Township,United States Senate,,independent,"Orman, Greg",56,000190
+NEMAHA,Richmond Township,United States Senate,,Libertarian,"Batson, Randall",4,000190
+NEMAHA,Richmond Township,United States Senate,,Republican,"Roberts, Pat",179,000190
+NEMAHA,Rock Creek Township,United States Senate,,independent,"Orman, Greg",30,00020A
+NEMAHA,Rock Creek Township,United States Senate,,Libertarian,"Batson, Randall",7,00020A
+NEMAHA,Rock Creek Township,United States Senate,,Republican,"Roberts, Pat",156,00020A
+NEMAHA,Rock Creek Township Enclave A,United States Senate,,independent,"Orman, Greg",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States Senate,,Republican,"Roberts, Pat",0,00020B
+NEMAHA,Rock Creek Township Enclave B,United States Senate,,independent,"Orman, Greg",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States Senate,,Republican,"Roberts, Pat",0,00020C
+NEMAHA,Sabetha Ward 1,United States Senate,,independent,"Orman, Greg",80,000210
+NEMAHA,Sabetha Ward 1,United States Senate,,Libertarian,"Batson, Randall",7,000210
+NEMAHA,Sabetha Ward 1,United States Senate,,Republican,"Roberts, Pat",174,000210
+NEMAHA,Sabetha Ward 2,United States Senate,,independent,"Orman, Greg",70,000220
+NEMAHA,Sabetha Ward 2,United States Senate,,Libertarian,"Batson, Randall",11,000220
+NEMAHA,Sabetha Ward 2,United States Senate,,Republican,"Roberts, Pat",185,000220
+NEMAHA,Sabetha Ward,United States Senate,,independent,"Orman, Greg",64,00023A
+NEMAHA,Sabetha Ward,United States Senate,,Libertarian,"Batson, Randall",8,00023A
+NEMAHA,Sabetha Ward,United States Senate,,Republican,"Roberts, Pat",186,00023A
+NEMAHA,Sabetha Ward 3 Enclave,United States Senate,,independent,"Orman, Greg",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States Senate,,Republican,"Roberts, Pat",0,00023B
+NEMAHA,Sabetha Ward 4,United States Senate,,independent,"Orman, Greg",51,000240
+NEMAHA,Sabetha Ward 4,United States Senate,,Libertarian,"Batson, Randall",11,000240
+NEMAHA,Sabetha Ward 4,United States Senate,,Republican,"Roberts, Pat",104,000240
+NEMAHA,Sabetha Ward 5,United States Senate,,independent,"Orman, Greg",0,000250
+NEMAHA,Sabetha Ward 5,United States Senate,,Libertarian,"Batson, Randall",0,000250
+NEMAHA,Sabetha Ward 5,United States Senate,,Republican,"Roberts, Pat",0,000250
+NEMAHA,Seneca Ward 1,United States Senate,,independent,"Orman, Greg",79,000260
+NEMAHA,Seneca Ward 1,United States Senate,,Libertarian,"Batson, Randall",13,000260
+NEMAHA,Seneca Ward 1,United States Senate,,Republican,"Roberts, Pat",131,000260
+NEMAHA,Seneca Ward 2,United States Senate,,independent,"Orman, Greg",99,000270
+NEMAHA,Seneca Ward 2,United States Senate,,Libertarian,"Batson, Randall",13,000270
+NEMAHA,Seneca Ward 2,United States Senate,,Republican,"Roberts, Pat",196,000270
+NEMAHA,Seneca Ward 3,United States Senate,,independent,"Orman, Greg",105,000280
+NEMAHA,Seneca Ward 3,United States Senate,,Libertarian,"Batson, Randall",11,000280
+NEMAHA,Seneca Ward 3,United States Senate,,Republican,"Roberts, Pat",220,000280
+NEMAHA,Washington Township,United States Senate,,independent,"Orman, Greg",32,000290
+NEMAHA,Washington Township,United States Senate,,Libertarian,"Batson, Randall",10,000290
+NEMAHA,Washington Township,United States Senate,,Republican,"Roberts, Pat",148,000290
+NEMAHA,Wetmore Township,United States Senate,,independent,"Orman, Greg",53,000300
+NEMAHA,Wetmore Township,United States Senate,,Libertarian,"Batson, Randall",11,000300
+NEMAHA,Wetmore Township,United States Senate,,Republican,"Roberts, Pat",83,000300
+NEMAHA,Richmond Township Enclave 1,United States Senate,,independent,"Orman, Greg",0,900010
+NEMAHA,Richmond Township Enclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900010
+NEMAHA,Richmond Township Enclave 1,United States Senate,,Republican,"Roberts, Pat",0,900010
+NEMAHA,Richland Township Enclave 2,United States Senate,,independent,"Orman, Greg",0,900020
+NEMAHA,Richland Township Enclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900020
+NEMAHA,Richland Township Enclave 2,United States Senate,,Republican,"Roberts, Pat",0,900020
+NEMAHA,Sabetha Ward Exclave,United States Senate,,independent,"Orman, Greg",0,900030
+NEMAHA,Sabetha Ward Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900030
+NEMAHA,Sabetha Ward Exclave,United States Senate,,Republican,"Roberts, Pat",0,900030

--- a/2014/20141104__ks__general__neosho__precinct.csv
+++ b/2014/20141104__ks__general__neosho__precinct.csv
@@ -1,451 +1,595 @@
-county,precinct,office,district,party,candidate,votes
-Neosho,Big Creek Township,U.S. Senate,,R,Pat Roberts,149
-Neosho,Canville Township,U.S. Senate,,R,Pat Roberts,143
-Neosho,Centerville Township,U.S. Senate,,R,Pat Roberts,117
-Neosho,Chetopa Township H9,U.S. Senate,,R,Pat Roberts,66
-Neosho,Chetopa Township H13,U.S. Senate,,R,Pat Roberts,171
-Neosho,East Erie,U.S. Senate,,R,Pat Roberts,98
-Neosho,West Erie,U.S. Senate,,R,Pat Roberts,159
-Neosho,Grant Township,U.S. Senate,,R,Pat Roberts,91
-Neosho,Ladore Township,U.S. Senate,,R,Pat Roberts,54
-Neosho,Lincoln Township,U.S. Senate,,R,Pat Roberts,37
-Neosho,Mission Township,U.S. Senate,,R,Pat Roberts,223
-Neosho,North Tioga Township,U.S. Senate,,R,Pat Roberts,125
-Neosho,South Tioga East Township,U.S. Senate,,R,Pat Roberts,57
-Neosho,South Tioga West Township,U.S. Senate,,R,Pat Roberts,36
-Neosho,Shiloh Township,U.S. Senate,,R,Pat Roberts,92
-Neosho,Walnut Grove Township,U.S. Senate,,R,Pat Roberts,69
-Neosho,Chanute Ward 1,U.S. Senate,,R,Pat Roberts,40
-Neosho,Chanute Ward 2 Precinct 1,U.S. Senate,,R,Pat Roberts,100
-Neosho,Chanute Ward 2 Precinct 2,U.S. Senate,,R,Pat Roberts,148
-Neosho,Chanute Ward 3 Precinct 1,U.S. Senate,,R,Pat Roberts,177
-Neosho,Chanute Ward 3 Precinct 2,U.S. Senate,,R,Pat Roberts,145
-Neosho,Chanute Ward 3 Precinct 3,U.S. Senate,,R,Pat Roberts,286
-Neosho,Chanute Ward 4 Precinct 1,U.S. Senate,,R,Pat Roberts,140
-Neosho,Chanute Ward 4 Precinct 2,U.S. Senate,,R,Pat Roberts,87
-Neosho,Chanute Ward 4 Precinct 3,U.S. Senate,,R,Pat Roberts,95
-Neosho,Big Creek Township,U.S. Senate,,IND,Greg Orman,43
-Neosho,Canville Township,U.S. Senate,,IND,Greg Orman,80
-Neosho,Centerville Township,U.S. Senate,,IND,Greg Orman,67
-Neosho,Chetopa Township H9,U.S. Senate,,IND,Greg Orman,12
-Neosho,Chetopa Township H13,U.S. Senate,,IND,Greg Orman,41
-Neosho,East Erie,U.S. Senate,,IND,Greg Orman,89
-Neosho,West Erie,U.S. Senate,,IND,Greg Orman,77
-Neosho,Grant Township,U.S. Senate,,IND,Greg Orman,55
-Neosho,Ladore Township,U.S. Senate,,IND,Greg Orman,70
-Neosho,Lincoln Township,U.S. Senate,,IND,Greg Orman,29
-Neosho,Mission Township,U.S. Senate,,IND,Greg Orman,88
-Neosho,North Tioga Township,U.S. Senate,,IND,Greg Orman,37
-Neosho,South Tioga East Township,U.S. Senate,,IND,Greg Orman,28
-Neosho,South Tioga West Township,U.S. Senate,,IND,Greg Orman,14
-Neosho,Shiloh Township,U.S. Senate,,IND,Greg Orman,15
-Neosho,Walnut Grove Township,U.S. Senate,,IND,Greg Orman,49
-Neosho,Chanute Ward 1,U.S. Senate,,IND,Greg Orman,17
-Neosho,Chanute Ward 2 Precinct 1,U.S. Senate,,IND,Greg Orman,66
-Neosho,Chanute Ward 2 Precinct 2,U.S. Senate,,IND,Greg Orman,61
-Neosho,Chanute Ward 3 Precinct 1,U.S. Senate,,IND,Greg Orman,127
-Neosho,Chanute Ward 3 Precinct 2,U.S. Senate,,IND,Greg Orman,84
-Neosho,Chanute Ward 3 Precinct 3,U.S. Senate,,IND,Greg Orman,155
-Neosho,Chanute Ward 4 Precinct 1,U.S. Senate,,IND,Greg Orman,118
-Neosho,Chanute Ward 4 Precinct 2,U.S. Senate,,IND,Greg Orman,90
-Neosho,Chanute Ward 4 Precinct 3,U.S. Senate,,IND,Greg Orman,53
-Neosho,Big Creek Township,U.S. Senate,,LBT,Randall Batson,9
-Neosho,Canville Township,U.S. Senate,,LBT,Randall Batson,22
-Neosho,Centerville Township,U.S. Senate,,LBT,Randall Batson,14
-Neosho,Chetopa Township H9,U.S. Senate,,LBT,Randall Batson,2
-Neosho,Chetopa Township H13,U.S. Senate,,LBT,Randall Batson,6
-Neosho,East Erie,U.S. Senate,,LBT,Randall Batson,23
-Neosho,West Erie,U.S. Senate,,LBT,Randall Batson,13
-Neosho,Grant Township,U.S. Senate,,LBT,Randall Batson,9
-Neosho,Ladore Township,U.S. Senate,,LBT,Randall Batson,13
-Neosho,Lincoln Township,U.S. Senate,,LBT,Randall Batson,6
-Neosho,Mission Township,U.S. Senate,,LBT,Randall Batson,12
-Neosho,North Tioga Township,U.S. Senate,,LBT,Randall Batson,11
-Neosho,South Tioga East Township,U.S. Senate,,LBT,Randall Batson,7
-Neosho,South Tioga West Township,U.S. Senate,,LBT,Randall Batson,3
-Neosho,Shiloh Township,U.S. Senate,,LBT,Randall Batson,10
-Neosho,Walnut Grove Township,U.S. Senate,,LBT,Randall Batson,6
-Neosho,Chanute Ward 1,U.S. Senate,,LBT,Randall Batson,5
-Neosho,Chanute Ward 2 Precinct 1,U.S. Senate,,LBT,Randall Batson,9
-Neosho,Chanute Ward 2 Precinct 2,U.S. Senate,,LBT,Randall Batson,22
-Neosho,Chanute Ward 3 Precinct 1,U.S. Senate,,LBT,Randall Batson,39
-Neosho,Chanute Ward 3 Precinct 2,U.S. Senate,,LBT,Randall Batson,16
-Neosho,Chanute Ward 3 Precinct 3,U.S. Senate,,LBT,Randall Batson,28
-Neosho,Chanute Ward 4 Precinct 1,U.S. Senate,,LBT,Randall Batson,21
-Neosho,Chanute Ward 4 Precinct 2,U.S. Senate,,LBT,Randall Batson,18
-Neosho,Chanute Ward 4 Precinct 3,U.S. Senate,,LBT,Randall Batson,14
-Neosho,Big Creek Township,U.S. House,2,R,Lynn Jenkins,162
-Neosho,Canville Township,U.S. House,2,R,Lynn Jenkins,169
-Neosho,Centerville Township,U.S. House,2,R,Lynn Jenkins,130
-Neosho,Chetopa Township H9,U.S. House,2,R,Lynn Jenkins,71
-Neosho,Chetopa Township H13,U.S. House,2,R,Lynn Jenkins,180
-Neosho,East Erie,U.S. House,2,R,Lynn Jenkins,120
-Neosho,West Erie,U.S. House,2,R,Lynn Jenkins,176
-Neosho,Grant Township,U.S. House,2,R,Lynn Jenkins,106
-Neosho,Ladore Township,U.S. House,2,R,Lynn Jenkins,63
-Neosho,Lincoln Township,U.S. House,2,R,Lynn Jenkins,47
-Neosho,Mission Township,U.S. House,2,R,Lynn Jenkins,230
-Neosho,North Tioga Township,U.S. House,2,R,Lynn Jenkins,138
-Neosho,South Tioga East Township,U.S. House,2,R,Lynn Jenkins,65
-Neosho,South Tioga West Township,U.S. House,2,R,Lynn Jenkins,44
-Neosho,Shiloh Township,U.S. House,2,R,Lynn Jenkins,99
-Neosho,Walnut Grove Township,U.S. House,2,R,Lynn Jenkins,73
-Neosho,Chanute Ward 1,U.S. House,2,R,Lynn Jenkins,41
-Neosho,Chanute Ward 2 Precinct 1,U.S. House,2,R,Lynn Jenkins,119
-Neosho,Chanute Ward 2 Precinct 2,U.S. House,2,R,Lynn Jenkins,167
-Neosho,Chanute Ward 3 Precinct 1,U.S. House,2,R,Lynn Jenkins,210
-Neosho,Chanute Ward 3 Precinct 2,U.S. House,2,R,Lynn Jenkins,160
-Neosho,Chanute Ward 3 Precinct 3,U.S. House,2,R,Lynn Jenkins,316
-Neosho,Chanute Ward 4 Precinct 1,U.S. House,2,R,Lynn Jenkins,166
-Neosho,Chanute Ward 4 Precinct 2,U.S. House,2,R,Lynn Jenkins,102
-Neosho,Chanute Ward 4 Precinct 3,U.S. House,2,R,Lynn Jenkins,103
-Neosho,Big Creek Township,U.S. House,2,D,Margie Wakefield,31
-Neosho,Canville Township,U.S. House,2,D,Margie Wakefield,66
-Neosho,Centerville Township,U.S. House,2,D,Margie Wakefield,67
-Neosho,Chetopa Township H9,U.S. House,2,D,Margie Wakefield,8
-Neosho,Chetopa Township H13,U.S. House,2,D,Margie Wakefield,32
-Neosho,East Erie,U.S. House,2,D,Margie Wakefield,82
-Neosho,West Erie,U.S. House,2,D,Margie Wakefield,63
-Neosho,Grant Township,U.S. House,2,D,Margie Wakefield,42
-Neosho,Ladore Township,U.S. House,2,D,Margie Wakefield,63
-Neosho,Lincoln Township,U.S. House,2,D,Margie Wakefield,23
-Neosho,Mission Township,U.S. House,2,D,Margie Wakefield,88
-Neosho,North Tioga Township,U.S. House,2,D,Margie Wakefield,27
-Neosho,South Tioga East Township,U.S. House,2,D,Margie Wakefield,21
-Neosho,South Tioga West Township,U.S. House,2,D,Margie Wakefield,8
-Neosho,Shiloh Township,U.S. House,2,D,Margie Wakefield,10
-Neosho,Walnut Grove Township,U.S. House,2,D,Margie Wakefield,50
-Neosho,Chanute Ward 1,U.S. House,2,D,Margie Wakefield,14
-Neosho,Chanute Ward 2 Precinct 1,U.S. House,2,D,Margie Wakefield,44
-Neosho,Chanute Ward 2 Precinct 2,U.S. House,2,D,Margie Wakefield,57
-Neosho,Chanute Ward 3 Precinct 1,U.S. House,2,D,Margie Wakefield,107
-Neosho,Chanute Ward 3 Precinct 2,U.S. House,2,D,Margie Wakefield,76
-Neosho,Chanute Ward 3 Precinct 3,U.S. House,2,D,Margie Wakefield,139
-Neosho,Chanute Ward 4 Precinct 1,U.S. House,2,D,Margie Wakefield,101
-Neosho,Chanute Ward 4 Precinct 2,U.S. House,2,D,Margie Wakefield,82
-Neosho,Chanute Ward 4 Precinct 3,U.S. House,2,D,Margie Wakefield,53
-Neosho,Big Creek Township,U.S. House,2,LBT,Christopher Clemmons,8
-Neosho,Canville Township,U.S. House,2,LBT,Christopher Clemmons,12
-Neosho,Centerville Township,U.S. House,2,LBT,Christopher Clemmons,7
-Neosho,Chetopa Township H9,U.S. House,2,LBT,Christopher Clemmons,2
-Neosho,Chetopa Township H13,U.S. House,2,LBT,Christopher Clemmons,8
-Neosho,East Erie,U.S. House,2,LBT,Christopher Clemmons,14
-Neosho,West Erie,U.S. House,2,LBT,Christopher Clemmons,8
-Neosho,Grant Township,U.S. House,2,LBT,Christopher Clemmons,10
-Neosho,Ladore Township,U.S. House,2,LBT,Christopher Clemmons,10
-Neosho,Lincoln Township,U.S. House,2,LBT,Christopher Clemmons,4
-Neosho,Mission Township,U.S. House,2,LBT,Christopher Clemmons,11
-Neosho,North Tioga Township,U.S. House,2,LBT,Christopher Clemmons,8
-Neosho,South Tioga East Township,U.S. House,2,LBT,Christopher Clemmons,6
-Neosho,South Tioga West Township,U.S. House,2,LBT,Christopher Clemmons,2
-Neosho,Shiloh Township,U.S. House,2,LBT,Christopher Clemmons,9
-Neosho,Walnut Grove Township,U.S. House,2,LBT,Christopher Clemmons,5
-Neosho,Chanute Ward 1,U.S. House,2,LBT,Christopher Clemmons,7
-Neosho,Chanute Ward 2 Precinct 1,U.S. House,2,LBT,Christopher Clemmons,11
-Neosho,Chanute Ward 2 Precinct 2,U.S. House,2,LBT,Christopher Clemmons,12
-Neosho,Chanute Ward 3 Precinct 1,U.S. House,2,LBT,Christopher Clemmons,34
-Neosho,Chanute Ward 3 Precinct 2,U.S. House,2,LBT,Christopher Clemmons,12
-Neosho,Chanute Ward 3 Precinct 3,U.S. House,2,LBT,Christopher Clemmons,17
-Neosho,Chanute Ward 4 Precinct 1,U.S. House,2,LBT,Christopher Clemmons,16
-Neosho,Chanute Ward 4 Precinct 2,U.S. House,2,LBT,Christopher Clemmons,12
-Neosho,Chanute Ward 4 Precinct 3,U.S. House,2,LBT,Christopher Clemmons,11
-Neosho,Big Creek Township,Governor,,R,Sam Brownback,123
-Neosho,Canville Township,Governor,,R,Sam Brownback,132
-Neosho,Centerville Township,Governor,,R,Sam Brownback,107
-Neosho,Chetopa Township H9,Governor,,R,Sam Brownback,65
-Neosho,Chetopa Township H13,Governor,,R,Sam Brownback,163
-Neosho,East Erie,Governor,,R,Sam Brownback,83
-Neosho,West Erie,Governor,,R,Sam Brownback,147
-Neosho,Grant Township,Governor,,R,Sam Brownback,85
-Neosho,Ladore Township,Governor,,R,Sam Brownback,53
-Neosho,Lincoln Township,Governor,,R,Sam Brownback,39
-Neosho,Mission Township,Governor,,R,Sam Brownback,193
-Neosho,North Tioga Township,Governor,,R,Sam Brownback,116
-Neosho,South Tioga East Township,Governor,,R,Sam Brownback,50
-Neosho,South Tioga West Township,Governor,,R,Sam Brownback,33
-Neosho,Shiloh Township,Governor,,R,Sam Brownback,91
-Neosho,Walnut Grove Township,Governor,,R,Sam Brownback,57
-Neosho,Chanute Ward 1,Governor,,R,Sam Brownback,36
-Neosho,Chanute Ward 2 Precinct 1,Governor,,R,Sam Brownback,92
-Neosho,Chanute Ward 2 Precinct 2,Governor,,R,Sam Brownback,147
-Neosho,Chanute Ward 3 Precinct 1,Governor,,R,Sam Brownback,155
-Neosho,Chanute Ward 3 Precinct 2,Governor,,R,Sam Brownback,129
-Neosho,Chanute Ward 3 Precinct 3,Governor,,R,Sam Brownback,255
-Neosho,Chanute Ward 4 Precinct 1,Governor,,R,Sam Brownback,123
-Neosho,Chanute Ward 4 Precinct 2,Governor,,R,Sam Brownback,76
-Neosho,Chanute Ward 4 Precinct 3,Governor,,R,Sam Brownback,94
-Neosho,Big Creek Township,Governor,,D,Paul Davis,69
-Neosho,Canville Township,Governor,,D,Paul Davis,105
-Neosho,Centerville Township,Governor,,D,Paul Davis,88
-Neosho,Chetopa Township H9,Governor,,D,Paul Davis,15
-Neosho,Chetopa Township H13,Governor,,D,Paul Davis,49
-Neosho,East Erie,Governor,,D,Paul Davis,116
-Neosho,West Erie,Governor,,D,Paul Davis,100
-Neosho,Grant Township,Governor,,D,Paul Davis,62
-Neosho,Ladore Township,Governor,,D,Paul Davis,76
-Neosho,Lincoln Township,Governor,,D,Paul Davis,31
-Neosho,Mission Township,Governor,,D,Paul Davis,127
-Neosho,North Tioga Township,Governor,,D,Paul Davis,52
-Neosho,South Tioga East Township,Governor,,D,Paul Davis,36
-Neosho,South Tioga West Township,Governor,,D,Paul Davis,18
-Neosho,Shiloh Township,Governor,,D,Paul Davis,20
-Neosho,Walnut Grove Township,Governor,,D,Paul Davis,65
-Neosho,Chanute Ward 1,Governor,,D,Paul Davis,22
-Neosho,Chanute Ward 2 Precinct 1,Governor,,D,Paul Davis,78
-Neosho,Chanute Ward 2 Precinct 2,Governor,,D,Paul Davis,78
-Neosho,Chanute Ward 3 Precinct 1,Governor,,D,Paul Davis,160
-Neosho,Chanute Ward 3 Precinct 2,Governor,,D,Paul Davis,111
-Neosho,Chanute Ward 3 Precinct 3,Governor,,D,Paul Davis,204
-Neosho,Chanute Ward 4 Precinct 1,Governor,,D,Paul Davis,148
-Neosho,Chanute Ward 4 Precinct 2,Governor,,D,Paul Davis,111
-Neosho,Chanute Ward 4 Precinct 3,Governor,,D,Paul Davis,64
-Neosho,Big Creek Township,Governor,,LBT,Keen Umbehr,8
-Neosho,Canville Township,Governor,,LBT,Keen Umbehr,13
-Neosho,Centerville Township,Governor,,LBT,Keen Umbehr,6
-Neosho,Chetopa Township H9,Governor,,LBT,Keen Umbehr,2
-Neosho,Chetopa Township H13,Governor,,LBT,Keen Umbehr,8
-Neosho,East Erie,Governor,,LBT,Keen Umbehr,15
-Neosho,West Erie,Governor,,LBT,Keen Umbehr,3
-Neosho,Grant Township,Governor,,LBT,Keen Umbehr,9
-Neosho,Ladore Township,Governor,,LBT,Keen Umbehr,6
-Neosho,Lincoln Township,Governor,,LBT,Keen Umbehr,4
-Neosho,Mission Township,Governor,,LBT,Keen Umbehr,6
-Neosho,North Tioga Township,Governor,,LBT,Keen Umbehr,6
-Neosho,South Tioga East Township,Governor,,LBT,Keen Umbehr,5
-Neosho,South Tioga West Township,Governor,,LBT,Keen Umbehr,3
-Neosho,Shiloh Township,Governor,,LBT,Keen Umbehr,7
-Neosho,Walnut Grove Township,Governor,,LBT,Keen Umbehr,5
-Neosho,Chanute Ward 1,Governor,,LBT,Keen Umbehr,3
-Neosho,Chanute Ward 2 Precinct 1,Governor,,LBT,Keen Umbehr,8
-Neosho,Chanute Ward 2 Precinct 2,Governor,,LBT,Keen Umbehr,11
-Neosho,Chanute Ward 3 Precinct 1,Governor,,LBT,Keen Umbehr,34
-Neosho,Chanute Ward 3 Precinct 2,Governor,,LBT,Keen Umbehr,8
-Neosho,Chanute Ward 3 Precinct 3,Governor,,LBT,Keen Umbehr,11
-Neosho,Chanute Ward 4 Precinct 1,Governor,,LBT,Keen Umbehr,13
-Neosho,Chanute Ward 4 Precinct 2,Governor,,LBT,Keen Umbehr,9
-Neosho,Chanute Ward 4 Precinct 3,Governor,,LBT,Keen Umbehr,11
-Neosho,Big Creek Township,Secretary of State,,R,Kris Kobach,160
-Neosho,Canville Township,Secretary of State,,R,Kris Kobach,171
-Neosho,Centerville Township,Secretary of State,,R,Kris Kobach,133
-Neosho,Chetopa Township H9,Secretary of State,,R,Kris Kobach,69
-Neosho,Chetopa Township H13,Secretary of State,,R,Kris Kobach,176
-Neosho,East Erie,Secretary of State,,R,Kris Kobach,115
-Neosho,West Erie,Secretary of State,,R,Kris Kobach,175
-Neosho,Grant Township,Secretary of State,,R,Kris Kobach,105
-Neosho,Ladore Township,Secretary of State,,R,Kris Kobach,64
-Neosho,Lincoln Township,Secretary of State,,R,Kris Kobach,47
-Neosho,Mission Township,Secretary of State,,R,Kris Kobach,217
-Neosho,North Tioga Township,Secretary of State,,R,Kris Kobach,138
-Neosho,South Tioga East Township,Secretary of State,,R,Kris Kobach,62
-Neosho,South Tioga West Township,Secretary of State,,R,Kris Kobach,41
-Neosho,Shiloh Township,Secretary of State,,R,Kris Kobach,100
-Neosho,Walnut Grove Township,Secretary of State,,R,Kris Kobach,78
-Neosho,Chanute Ward 1,Secretary of State,,R,Kris Kobach,39
-Neosho,Chanute Ward 2 Precinct 1,Secretary of State,,R,Kris Kobach,116
-Neosho,Chanute Ward 2 Precinct 2,Secretary of State,,R,Kris Kobach,169
-Neosho,Chanute Ward 3 Precinct 1,Secretary of State,,R,Kris Kobach,222
-Neosho,Chanute Ward 3 Precinct 2,Secretary of State,,R,Kris Kobach,154
-Neosho,Chanute Ward 3 Precinct 3,Secretary of State,,R,Kris Kobach,301
-Neosho,Chanute Ward 4 Precinct 1,Secretary of State,,R,Kris Kobach,162
-Neosho,Chanute Ward 4 Precinct 2,Secretary of State,,R,Kris Kobach,108
-Neosho,Chanute Ward 4 Precinct 3,Secretary of State,,R,Kris Kobach,111
-Neosho,Big Creek Township,Secretary of State,,D,Jean Schodorf,38
-Neosho,Canville Township,Secretary of State,,D,Jean Schodorf,75
-Neosho,Centerville Township,Secretary of State,,D,Jean Schodorf,71
-Neosho,Chetopa Township H9,Secretary of State,,D,Jean Schodorf,10
-Neosho,Chetopa Township H13,Secretary of State,,D,Jean Schodorf,39
-Neosho,East Erie,Secretary of State,,D,Jean Schodorf,93
-Neosho,West Erie,Secretary of State,,D,Jean Schodorf,72
-Neosho,Grant Township,Secretary of State,,D,Jean Schodorf,49
-Neosho,Ladore Township,Secretary of State,,D,Jean Schodorf,70
-Neosho,Lincoln Township,Secretary of State,,D,Jean Schodorf,26
-Neosho,Mission Township,Secretary of State,,D,Jean Schodorf,101
-Neosho,North Tioga Township,Secretary of State,,D,Jean Schodorf,36
-Neosho,South Tioga East Township,Secretary of State,,D,Jean Schodorf,27
-Neosho,South Tioga West Township,Secretary of State,,D,Jean Schodorf,12
-Neosho,Shiloh Township,Secretary of State,,D,Jean Schodorf,17
-Neosho,Walnut Grove Township,Secretary of State,,D,Jean Schodorf,44
-Neosho,Chanute Ward 1,Secretary of State,,D,Jean Schodorf,23
-Neosho,Chanute Ward 2 Precinct 1,Secretary of State,,D,Jean Schodorf,57
-Neosho,Chanute Ward 2 Precinct 2,Secretary of State,,D,Jean Schodorf,61
-Neosho,Chanute Ward 3 Precinct 1,Secretary of State,,D,Jean Schodorf,117
-Neosho,Chanute Ward 3 Precinct 2,Secretary of State,,D,Jean Schodorf,90
-Neosho,Chanute Ward 3 Precinct 3,Secretary of State,,D,Jean Schodorf,163
-Neosho,Chanute Ward 4 Precinct 1,Secretary of State,,D,Jean Schodorf,112
-Neosho,Chanute Ward 4 Precinct 2,Secretary of State,,D,Jean Schodorf,83
-Neosho,Chanute Ward 4 Precinct 3,Secretary of State,,D,Jean Schodorf,55
-Neosho,Big Creek Township,Attorney General,,R,Derek Schmidt,172
-Neosho,Canville Township,Attorney General,,R,Derek Schmidt,181
-Neosho,Centerville Township,Attorney General,,R,Derek Schmidt,136
-Neosho,Chetopa Township H9,Attorney General,,R,Derek Schmidt,69
-Neosho,Chetopa Township H13,Attorney General,,R,Derek Schmidt,183
-Neosho,East Erie,Attorney General,,R,Derek Schmidt,140
-Neosho,West Erie,Attorney General,,R,Derek Schmidt,183
-Neosho,Grant Township,Attorney General,,R,Derek Schmidt,110
-Neosho,Ladore Township,Attorney General,,R,Derek Schmidt,68
-Neosho,Lincoln Township,Attorney General,,R,Derek Schmidt,47
-Neosho,Mission Township,Attorney General,,R,Derek Schmidt,224
-Neosho,North Tioga Township,Attorney General,,R,Derek Schmidt,144
-Neosho,South Tioga East Township,Attorney General,,R,Derek Schmidt,68
-Neosho,South Tioga West Township,Attorney General,,R,Derek Schmidt,43
-Neosho,Shiloh Township,Attorney General,,R,Derek Schmidt,101
-Neosho,Walnut Grove Township,Attorney General,,R,Derek Schmidt,94
-Neosho,Chanute Ward 1,Attorney General,,R,Derek Schmidt,45
-Neosho,Chanute Ward 2 Precinct 1,Attorney General,,R,Derek Schmidt,134
-Neosho,Chanute Ward 2 Precinct 2,Attorney General,,R,Derek Schmidt,176
-Neosho,Chanute Ward 3 Precinct 1,Attorney General,,R,Derek Schmidt,234
-Neosho,Chanute Ward 3 Precinct 2,Attorney General,,R,Derek Schmidt,173
-Neosho,Chanute Ward 3 Precinct 3,Attorney General,,R,Derek Schmidt,332
-Neosho,Chanute Ward 4 Precinct 1,Attorney General,,R,Derek Schmidt,179
-Neosho,Chanute Ward 4 Precinct 2,Attorney General,,R,Derek Schmidt,113
-Neosho,Chanute Ward 4 Precinct 3,Attorney General,,R,Derek Schmidt,117
-Neosho,Big Creek Township,Attorney General,,D,A.J. Kotich,28
-Neosho,Canville Township,Attorney General,,D,A.J. Kotich,63
-Neosho,Centerville Township,Attorney General,,D,A.J. Kotich,66
-Neosho,Chetopa Township H9,Attorney General,,D,A.J. Kotich,10
-Neosho,Chetopa Township H13,Attorney General,,D,A.J. Kotich,31
-Neosho,East Erie,Attorney General,,D,A.J. Kotich,63
-Neosho,West Erie,Attorney General,,D,A.J. Kotich,59
-Neosho,Grant Township,Attorney General,,D,A.J. Kotich,43
-Neosho,Ladore Township,Attorney General,,D,A.J. Kotich,65
-Neosho,Lincoln Township,Attorney General,,D,A.J. Kotich,26
-Neosho,Mission Township,Attorney General,,D,A.J. Kotich,86
-Neosho,North Tioga Township,Attorney General,,D,A.J. Kotich,30
-Neosho,South Tioga East Township,Attorney General,,D,A.J. Kotich,23
-Neosho,South Tioga West Township,Attorney General,,D,A.J. Kotich,9
-Neosho,Shiloh Township,Attorney General,,D,A.J. Kotich,15
-Neosho,Walnut Grove Township,Attorney General,,D,A.J. Kotich,28
-Neosho,Chanute Ward 1,Attorney General,,D,A.J. Kotich,17
-Neosho,Chanute Ward 2 Precinct 1,Attorney General,,D,A.J. Kotich,37
-Neosho,Chanute Ward 2 Precinct 2,Attorney General,,D,A.J. Kotich,55
-Neosho,Chanute Ward 3 Precinct 1,Attorney General,,D,A.J. Kotich,109
-Neosho,Chanute Ward 3 Precinct 2,Attorney General,,D,A.J. Kotich,71
-Neosho,Chanute Ward 3 Precinct 3,Attorney General,,D,A.J. Kotich,134
-Neosho,Chanute Ward 4 Precinct 1,Attorney General,,D,A.J. Kotich,90
-Neosho,Chanute Ward 4 Precinct 2,Attorney General,,D,A.J. Kotich,78
-Neosho,Chanute Ward 4 Precinct 3,Attorney General,,D,A.J. Kotich,49
-Neosho,Big Creek Township,State Treasurer,,R,Ron Estes,165
-Neosho,Canville Township,State Treasurer,,R,Ron Estes,186
-Neosho,Centerville Township,State Treasurer,,R,Ron Estes,134
-Neosho,Chetopa Township H9,State Treasurer,,R,Ron Estes,69
-Neosho,Chetopa Township H13,State Treasurer,,R,Ron Estes,180
-Neosho,East Erie,State Treasurer,,R,Ron Estes,132
-Neosho,West Erie,State Treasurer,,R,Ron Estes,183
-Neosho,Grant Township,State Treasurer,,R,Ron Estes,108
-Neosho,Ladore Township,State Treasurer,,R,Ron Estes,71
-Neosho,Lincoln Township,State Treasurer,,R,Ron Estes,44
-Neosho,Mission Township,State Treasurer,,R,Ron Estes,216
-Neosho,North Tioga Township,State Treasurer,,R,Ron Estes,142
-Neosho,South Tioga East Township,State Treasurer,,R,Ron Estes,69
-Neosho,South Tioga West Township,State Treasurer,,R,Ron Estes,44
-Neosho,Shiloh Township,State Treasurer,,R,Ron Estes,101
-Neosho,Walnut Grove Township,State Treasurer,,R,Ron Estes,81
-Neosho,Chanute Ward 1,State Treasurer,,R,Ron Estes,42
-Neosho,Chanute Ward 2 Precinct 1,State Treasurer,,R,Ron Estes,126
-Neosho,Chanute Ward 2 Precinct 2,State Treasurer,,R,Ron Estes,171
-Neosho,Chanute Ward 3 Precinct 1,State Treasurer,,R,Ron Estes,211
-Neosho,Chanute Ward 3 Precinct 2,State Treasurer,,R,Ron Estes,164
-Neosho,Chanute Ward 3 Precinct 3,State Treasurer,,R,Ron Estes,334
-Neosho,Chanute Ward 4 Precinct 1,State Treasurer,,R,Ron Estes,171
-Neosho,Chanute Ward 4 Precinct 2,State Treasurer,,R,Ron Estes,109
-Neosho,Chanute Ward 4 Precinct 3,State Treasurer,,R,Ron Estes,113
-Neosho,Big Creek Township,State Treasurer,,D,Carmen Alldritt,34
-Neosho,Canville Township,State Treasurer,,D,Carmen Alldritt,60
-Neosho,Centerville Township,State Treasurer,,D,Carmen Alldritt,65
-Neosho,Chetopa Township H9,State Treasurer,,D,Carmen Alldritt,9
-Neosho,Chetopa Township H13,State Treasurer,,D,Carmen Alldritt,34
-Neosho,East Erie,State Treasurer,,D,Carmen Alldritt,69
-Neosho,West Erie,State Treasurer,,D,Carmen Alldritt,59
-Neosho,Grant Township,State Treasurer,,D,Carmen Alldritt,45
-Neosho,Ladore Township,State Treasurer,,D,Carmen Alldritt,60
-Neosho,Lincoln Township,State Treasurer,,D,Carmen Alldritt,29
-Neosho,Mission Township,State Treasurer,,D,Carmen Alldritt,89
-Neosho,North Tioga Township,State Treasurer,,D,Carmen Alldritt,31
-Neosho,South Tioga East Township,State Treasurer,,D,Carmen Alldritt,20
-Neosho,South Tioga West Township,State Treasurer,,D,Carmen Alldritt,9
-Neosho,Shiloh Township,State Treasurer,,D,Carmen Alldritt,15
-Neosho,Walnut Grove Township,State Treasurer,,D,Carmen Alldritt,38
-Neosho,Chanute Ward 1,State Treasurer,,D,Carmen Alldritt,20
-Neosho,Chanute Ward 2 Precinct 1,State Treasurer,,D,Carmen Alldritt,44
-Neosho,Chanute Ward 2 Precinct 2,State Treasurer,,D,Carmen Alldritt,59
-Neosho,Chanute Ward 3 Precinct 1,State Treasurer,,D,Carmen Alldritt,126
-Neosho,Chanute Ward 3 Precinct 2,State Treasurer,,D,Carmen Alldritt,76
-Neosho,Chanute Ward 3 Precinct 3,State Treasurer,,D,Carmen Alldritt,131
-Neosho,Chanute Ward 4 Precinct 1,State Treasurer,,D,Carmen Alldritt,99
-Neosho,Chanute Ward 4 Precinct 2,State Treasurer,,D,Carmen Alldritt,82
-Neosho,Chanute Ward 4 Precinct 3,State Treasurer,,D,Carmen Alldritt,54
-Neosho,Big Creek Township,Insurance Commissioner,,R,Ken Selzer,162
-Neosho,Canville Township,Insurance Commissioner,,R,Ken Selzer,166
-Neosho,Centerville Township,Insurance Commissioner,,R,Ken Selzer,132
-Neosho,Chetopa Township H9,Insurance Commissioner,,R,Ken Selzer,59
-Neosho,Chetopa Township H13,Insurance Commissioner,,R,Ken Selzer,171
-Neosho,East Erie,Insurance Commissioner,,R,Ken Selzer,119
-Neosho,West Erie,Insurance Commissioner,,R,Ken Selzer,161
-Neosho,Grant Township,Insurance Commissioner,,R,Ken Selzer,103
-Neosho,Ladore Township,Insurance Commissioner,,R,Ken Selzer,65
-Neosho,Lincoln Township,Insurance Commissioner,,R,Ken Selzer,41
-Neosho,Mission Township,Insurance Commissioner,,R,Ken Selzer,195
-Neosho,North Tioga Township,Insurance Commissioner,,R,Ken Selzer,138
-Neosho,South Tioga East Township,Insurance Commissioner,,R,Ken Selzer,62
-Neosho,South Tioga West Township,Insurance Commissioner,,R,Ken Selzer,41
-Neosho,Shiloh Township,Insurance Commissioner,,R,Ken Selzer,91
-Neosho,Walnut Grove Township,Insurance Commissioner,,R,Ken Selzer,77
-Neosho,Chanute Ward 1,Insurance Commissioner,,R,Ken Selzer,37
-Neosho,Chanute Ward 2 Precinct 1,Insurance Commissioner,,R,Ken Selzer,121
-Neosho,Chanute Ward 2 Precinct 2,Insurance Commissioner,,R,Ken Selzer,163
-Neosho,Chanute Ward 3 Precinct 1,Insurance Commissioner,,R,Ken Selzer,201
-Neosho,Chanute Ward 3 Precinct 2,Insurance Commissioner,,R,Ken Selzer,158
-Neosho,Chanute Ward 3 Precinct 3,Insurance Commissioner,,R,Ken Selzer,312
-Neosho,Chanute Ward 4 Precinct 1,Insurance Commissioner,,R,Ken Selzer,158
-Neosho,Chanute Ward 4 Precinct 2,Insurance Commissioner,,R,Ken Selzer,107
-Neosho,Chanute Ward 4 Precinct 3,Insurance Commissioner,,R,Ken Selzer,110
-Neosho,Big Creek Township,Insurance Commissioner,,D,Dennis Anderson,36
-Neosho,Canville Township,Insurance Commissioner,,D,Dennis Anderson,72
-Neosho,Centerville Township,Insurance Commissioner,,D,Dennis Anderson,65
-Neosho,Chetopa Township H9,Insurance Commissioner,,D,Dennis Anderson,16
-Neosho,Chetopa Township H13,Insurance Commissioner,,D,Dennis Anderson,43
-Neosho,East Erie,Insurance Commissioner,,D,Dennis Anderson,80
-Neosho,West Erie,Insurance Commissioner,,D,Dennis Anderson,73
-Neosho,Grant Township,Insurance Commissioner,,D,Dennis Anderson,50
-Neosho,Ladore Township,Insurance Commissioner,,D,Dennis Anderson,66
-Neosho,Lincoln Township,Insurance Commissioner,,D,Dennis Anderson,32
-Neosho,Mission Township,Insurance Commissioner,,D,Dennis Anderson,110
-Neosho,North Tioga Township,Insurance Commissioner,,D,Dennis Anderson,33
-Neosho,South Tioga East Township,Insurance Commissioner,,D,Dennis Anderson,27
-Neosho,South Tioga West Township,Insurance Commissioner,,D,Dennis Anderson,11
-Neosho,Shiloh Township,Insurance Commissioner,,D,Dennis Anderson,23
-Neosho,Walnut Grove Township,Insurance Commissioner,,D,Dennis Anderson,40
-Neosho,Chanute Ward 1,Insurance Commissioner,,D,Dennis Anderson,25
-Neosho,Chanute Ward 2 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,49
-Neosho,Chanute Ward 2 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,65
-Neosho,Chanute Ward 3 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,128
-Neosho,Chanute Ward 3 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,79
-Neosho,Chanute Ward 3 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,149
-Neosho,Chanute Ward 4 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,109
-Neosho,Chanute Ward 4 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,83
-Neosho,Chanute Ward 4 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,54
-Neosho,Canville Township,State House,9,R,Kent Thompson,217
-Neosho,Chetopa Township H9,State House,9,R,Kent Thompson,73
-Neosho,North Tioga Township,State House,9,R,Kent Thompson,159
-Neosho,South Tioga East Township,State House,9,R,Kent Thompson,84
-Neosho,South Tioga West Township,State House,9,R,Kent Thompson,48
-Neosho,Chanute Ward 1,State House,9,R,Kent Thompson,51
-Neosho,Chanute Ward 2 Precinct 1,State House,9,R,Kent Thompson,154
-Neosho,Chanute Ward 2 Precinct 2,State House,9,R,Kent Thompson,200
-Neosho,Chanute Ward 3 Precinct 1,State House,9,R,Kent Thompson,298
-Neosho,Chanute Ward 3 Precinct 2,State House,9,R,Kent Thompson,203
-Neosho,Chanute Ward 3 Precinct 3,State House,9,R,Kent Thompson,407
-Neosho,Chanute Ward 4 Precinct 1,State House,9,R,Kent Thompson,220
-Neosho,Chanute Ward 4 Precinct 2,State House,9,R,Kent Thompson,151
-Neosho,Chanute Ward 4 Precinct 3,State House,9,R,Kent Thompson,135
-Neosho,Chetopa Township H13,State House,13,R,Larry Hibbard,196
-Neosho,Shiloh Township,State House,13,R,Larry Hibbard,108
-Neosho,Big Creek Township,State House,2,D,Adam Tasker,120
-Neosho,Centerville Township,State House,2,D,Adam Tasker,126
-Neosho,East Erie,State House,2,D,Adam Tasker,147
-Neosho,West Erie,State House,2,D,Adam Tasker,156
-Neosho,Grant Township,State House,2,D,Adam Tasker,89
-Neosho,Ladore Township,State House,2,D,Adam Tasker,100
-Neosho,Lincoln Township,State House,2,D,Adam Tasker,49
-Neosho,Mission Township,State House,2,D,Adam Tasker,217
-Neosho,Walnut Grove Township,State House,2,D,Adam Tasker,86
+county,precinct,office,district,party,candidate,votes,vtd
+NEOSHO,Big Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",69,000010
+NEOSHO,Big Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000010
+NEOSHO,Big Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",123,000010
+NEOSHO,Canville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",105,00002A
+NEOSHO,Canville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,00002A
+NEOSHO,Canville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,00002A
+NEOSHO,Centerville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",88,000030
+NEOSHO,Centerville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000030
+NEOSHO,Centerville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000030
+NEOSHO,Chanute Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000040
+NEOSHO,Chanute Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+NEOSHO,Chanute Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,000050
+NEOSHO,Chanute Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000050
+NEOSHO,Chanute Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,000060
+NEOSHO,Chanute Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000060
+NEOSHO,Chanute Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",147,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",160,000070
+NEOSHO,Chanute Ward 3 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",34,000070
+NEOSHO,Chanute Ward 3 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",155,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,000080
+NEOSHO,Chanute Ward 3 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000080
+NEOSHO,Chanute Ward 3 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",129,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",204,000090
+NEOSHO,Chanute Ward 3 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000090
+NEOSHO,Chanute Ward 3 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",255,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",148,000100
+NEOSHO,Chanute Ward 4 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000100
+NEOSHO,Chanute Ward 4 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",123,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,000110
+NEOSHO,Chanute Ward 4 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000110
+NEOSHO,Chanute Ward 4 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",64,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00012C
+NEOSHO,East Erie,Governor / Lt. Governor,,Democratic,"Davis, Paul",116,000140
+NEOSHO,East Erie,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000140
+NEOSHO,East Erie,Governor / Lt. Governor,,Republican,"Brownback, Sam",83,000140
+NEOSHO,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,000150
+NEOSHO,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000150
+NEOSHO,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",85,000150
+NEOSHO,Ladore Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,000160
+NEOSHO,Ladore Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000160
+NEOSHO,Ladore Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000160
+NEOSHO,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000170
+NEOSHO,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000170
+NEOSHO,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000170
+NEOSHO,Mission Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",127,000180
+NEOSHO,Mission Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000180
+NEOSHO,Mission Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",193,000180
+NEOSHO,North Tioga Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",52,000190
+NEOSHO,North Tioga Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000190
+NEOSHO,North Tioga Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",116,000190
+NEOSHO,Shiloh Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000200
+NEOSHO,Shiloh Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000200
+NEOSHO,Shiloh Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000200
+NEOSHO,South Tioga East Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000210
+NEOSHO,South Tioga East Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000210
+NEOSHO,South Tioga East Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000210
+NEOSHO,South Tioga West Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,00022A
+NEOSHO,South Tioga West Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,00022A
+NEOSHO,South Tioga West Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,00022A
+NEOSHO,South Tioga West Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022B
+NEOSHO,South Tioga West Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022B
+NEOSHO,South Tioga West Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022C
+NEOSHO,South Tioga West Township Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022D
+NEOSHO,South Tioga West Township Enclave C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022D
+NEOSHO,Walnut Grove Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000230
+NEOSHO,Walnut Grove Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000230
+NEOSHO,Walnut Grove Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000230
+NEOSHO,West Erie,Governor / Lt. Governor,,Democratic,"Davis, Paul",100,000240
+NEOSHO,West Erie,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000240
+NEOSHO,West Erie,Governor / Lt. Governor,,Republican,"Brownback, Sam",147,000240
+NEOSHO,Chetopa Township H13,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,120020
+NEOSHO,Chetopa Township H13,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,120020
+NEOSHO,Chetopa Township H13,Governor / Lt. Governor,,Republican,"Brownback, Sam",163,120020
+NEOSHO,Chetopa Township H2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120030
+NEOSHO,Chetopa Township H2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+NEOSHO,Chetopa Township H2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120030
+NEOSHO,Chetopa Township H9,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,120040
+NEOSHO,Chetopa Township H9,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120040
+NEOSHO,Chetopa Township H9,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+NEOSHO,Big Creek Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",120,000010
+NEOSHO,Canville Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",217,00002A
+NEOSHO,Centerville Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",126,000030
+NEOSHO,Chanute Ward 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",51,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",154,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",200,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",298,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",203,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",407,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",220,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",151,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",135,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00012C
+NEOSHO,East Erie,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",147,000140
+NEOSHO,Grant Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",89,000150
+NEOSHO,Ladore Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",100,000160
+NEOSHO,Lincoln Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",49,000170
+NEOSHO,Mission Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",217,000180
+NEOSHO,North Tioga Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",159,000190
+NEOSHO,Shiloh Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",108,000200
+NEOSHO,South Tioga East Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",84,000210
+NEOSHO,South Tioga West Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",48,00022A
+NEOSHO,South Tioga West Township Enclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00022D
+NEOSHO,Walnut Grove Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",86,000230
+NEOSHO,West Erie,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",156,000240
+NEOSHO,Chetopa Township H13,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",196,120020
+NEOSHO,Chetopa Township H2,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",0,120030
+NEOSHO,Chetopa Township H9,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",73,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,900020
+NEOSHO,Big Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,000010
+NEOSHO,Big Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000010
+NEOSHO,Big Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",162,000010
+NEOSHO,Canville Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",66,00002A
+NEOSHO,Canville Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,00002A
+NEOSHO,Canville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",169,00002A
+NEOSHO,Centerville Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",67,000030
+NEOSHO,Centerville Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000030
+NEOSHO,Centerville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,000030
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,000040
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000040
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000040
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",44,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",119,000050
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",57,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000060
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",107,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",34,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",210,000070
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",76,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",160,000080
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",139,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",316,000090
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",101,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000100
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000110
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",103,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00012C
+NEOSHO,East Erie,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,000140
+NEOSHO,East Erie,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000140
+NEOSHO,East Erie,United States House of Representatives,2,Republican,"Jenkins, Lynn",120,000140
+NEOSHO,Grant Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",42,000150
+NEOSHO,Grant Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000150
+NEOSHO,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000150
+NEOSHO,Ladore Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",63,000160
+NEOSHO,Ladore Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000160
+NEOSHO,Ladore Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000160
+NEOSHO,Lincoln Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",23,000170
+NEOSHO,Lincoln Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000170
+NEOSHO,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000170
+NEOSHO,Mission Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",88,000180
+NEOSHO,Mission Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000180
+NEOSHO,Mission Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,000180
+NEOSHO,North Tioga Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,000190
+NEOSHO,North Tioga Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000190
+NEOSHO,North Tioga Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,000190
+NEOSHO,Shiloh Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",10,000200
+NEOSHO,Shiloh Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000200
+NEOSHO,Shiloh Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000200
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",21,000210
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000210
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,000210
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",8,00022A
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,00022A
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,00022A
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022B
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022C
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022D
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",50,000230
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000230
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000230
+NEOSHO,West Erie,United States House of Representatives,2,Democratic,"Wakefield, Margie",63,000240
+NEOSHO,West Erie,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000240
+NEOSHO,West Erie,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000240
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Democratic,"Wakefield, Margie",32,120020
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,120020
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Republican,"Jenkins, Lynn",180,120020
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,120030
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,120030
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Democratic,"Wakefield, Margie",8,120040
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,120040
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Republican,"Jenkins, Lynn",71,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+NEOSHO,Big Creek Township,Attorney General,,Democratic,"Kotich, A.J.",28,000010
+NEOSHO,Big Creek Township,Attorney General,,Republican,"Schmidt, Derek",172,000010
+NEOSHO,Canville Township,Attorney General,,Democratic,"Kotich, A.J.",63,00002A
+NEOSHO,Canville Township,Attorney General,,Republican,"Schmidt, Derek",181,00002A
+NEOSHO,Centerville Township,Attorney General,,Democratic,"Kotich, A.J.",66,000030
+NEOSHO,Centerville Township,Attorney General,,Republican,"Schmidt, Derek",136,000030
+NEOSHO,Chanute Ward 1,Attorney General,,Democratic,"Kotich, A.J.",17,000040
+NEOSHO,Chanute Ward 1,Attorney General,,Republican,"Schmidt, Derek",45,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",37,000050
+NEOSHO,Chanute Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",134,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",55,000060
+NEOSHO,Chanute Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",176,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",109,000070
+NEOSHO,Chanute Ward 3 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",234,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",71,000080
+NEOSHO,Chanute Ward 3 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",173,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",134,000090
+NEOSHO,Chanute Ward 3 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",332,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",90,000100
+NEOSHO,Chanute Ward 4 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",179,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",78,000110
+NEOSHO,Chanute Ward 4 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",113,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",49,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",117,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00012C
+NEOSHO,East Erie,Attorney General,,Democratic,"Kotich, A.J.",63,000140
+NEOSHO,East Erie,Attorney General,,Republican,"Schmidt, Derek",140,000140
+NEOSHO,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",43,000150
+NEOSHO,Grant Township,Attorney General,,Republican,"Schmidt, Derek",110,000150
+NEOSHO,Ladore Township,Attorney General,,Democratic,"Kotich, A.J.",65,000160
+NEOSHO,Ladore Township,Attorney General,,Republican,"Schmidt, Derek",68,000160
+NEOSHO,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",26,000170
+NEOSHO,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",47,000170
+NEOSHO,Mission Township,Attorney General,,Democratic,"Kotich, A.J.",86,000180
+NEOSHO,Mission Township,Attorney General,,Republican,"Schmidt, Derek",224,000180
+NEOSHO,North Tioga Township,Attorney General,,Democratic,"Kotich, A.J.",30,000190
+NEOSHO,North Tioga Township,Attorney General,,Republican,"Schmidt, Derek",144,000190
+NEOSHO,Shiloh Township,Attorney General,,Democratic,"Kotich, A.J.",15,000200
+NEOSHO,Shiloh Township,Attorney General,,Republican,"Schmidt, Derek",101,000200
+NEOSHO,South Tioga East Township,Attorney General,,Democratic,"Kotich, A.J.",23,000210
+NEOSHO,South Tioga East Township,Attorney General,,Republican,"Schmidt, Derek",68,000210
+NEOSHO,South Tioga West Township,Attorney General,,Democratic,"Kotich, A.J.",9,00022A
+NEOSHO,South Tioga West Township,Attorney General,,Republican,"Schmidt, Derek",43,00022A
+NEOSHO,South Tioga West Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00022B
+NEOSHO,South Tioga West Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Attorney General,,Democratic,"Kotich, A.J.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,Attorney General,,Republican,"Schmidt, Derek",0,00022D
+NEOSHO,Walnut Grove Township,Attorney General,,Democratic,"Kotich, A.J.",28,000230
+NEOSHO,Walnut Grove Township,Attorney General,,Republican,"Schmidt, Derek",94,000230
+NEOSHO,West Erie,Attorney General,,Democratic,"Kotich, A.J.",59,000240
+NEOSHO,West Erie,Attorney General,,Republican,"Schmidt, Derek",183,000240
+NEOSHO,Chetopa Township H13,Attorney General,,Democratic,"Kotich, A.J.",31,120020
+NEOSHO,Chetopa Township H13,Attorney General,,Republican,"Schmidt, Derek",183,120020
+NEOSHO,Chetopa Township H2,Attorney General,,Democratic,"Kotich, A.J.",0,120030
+NEOSHO,Chetopa Township H2,Attorney General,,Republican,"Schmidt, Derek",0,120030
+NEOSHO,Chetopa Township H9,Attorney General,,Democratic,"Kotich, A.J.",10,120040
+NEOSHO,Chetopa Township H9,Attorney General,,Republican,"Schmidt, Derek",69,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900020
+NEOSHO,Big Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000010
+NEOSHO,Big Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",162,000010
+NEOSHO,Canville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,00002A
+NEOSHO,Canville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",166,00002A
+NEOSHO,Centerville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,000030
+NEOSHO,Centerville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",132,000030
+NEOSHO,Chanute Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000040
+NEOSHO,Chanute Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",49,000050
+NEOSHO,Chanute Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,000060
+NEOSHO,Chanute Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",163,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",128,000070
+NEOSHO,Chanute Ward 3 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",201,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",79,000080
+NEOSHO,Chanute Ward 3 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",149,000090
+NEOSHO,Chanute Ward 3 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",312,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",109,000100
+NEOSHO,Chanute Ward 4 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",83,000110
+NEOSHO,Chanute Ward 4 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",107,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",110,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00012C
+NEOSHO,East Erie,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000140
+NEOSHO,East Erie,Commissioner of Insurance,,Republican,"Selzer, Ken",119,000140
+NEOSHO,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000150
+NEOSHO,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000150
+NEOSHO,Ladore Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,000160
+NEOSHO,Ladore Township,Commissioner of Insurance,,Republican,"Selzer, Ken",65,000160
+NEOSHO,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,000170
+NEOSHO,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000170
+NEOSHO,Mission Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",110,000180
+NEOSHO,Mission Township,Commissioner of Insurance,,Republican,"Selzer, Ken",195,000180
+NEOSHO,North Tioga Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000190
+NEOSHO,North Tioga Township,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000190
+NEOSHO,Shiloh Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000200
+NEOSHO,Shiloh Township,Commissioner of Insurance,,Republican,"Selzer, Ken",91,000200
+NEOSHO,South Tioga East Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000210
+NEOSHO,South Tioga East Township,Commissioner of Insurance,,Republican,"Selzer, Ken",62,000210
+NEOSHO,South Tioga West Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,00022A
+NEOSHO,South Tioga West Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,00022A
+NEOSHO,South Tioga West Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022B
+NEOSHO,South Tioga West Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022C
+NEOSHO,South Tioga West Township Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022D
+NEOSHO,South Tioga West Township Enclave C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022D
+NEOSHO,Walnut Grove Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000230
+NEOSHO,Walnut Grove Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000230
+NEOSHO,West Erie,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000240
+NEOSHO,West Erie,Commissioner of Insurance,,Republican,"Selzer, Ken",161,000240
+NEOSHO,Chetopa Township H13,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,120020
+NEOSHO,Chetopa Township H13,Commissioner of Insurance,,Republican,"Selzer, Ken",171,120020
+NEOSHO,Chetopa Township H2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120030
+NEOSHO,Chetopa Township H2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120030
+NEOSHO,Chetopa Township H9,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,120040
+NEOSHO,Chetopa Township H9,Commissioner of Insurance,,Republican,"Selzer, Ken",59,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+NEOSHO,Big Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000010
+NEOSHO,Big Creek Township,Secretary of State,,Republican,"Kobach, Kris",160,000010
+NEOSHO,Canville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,00002A
+NEOSHO,Canville Township,Secretary of State,,Republican,"Kobach, Kris",171,00002A
+NEOSHO,Centerville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,000030
+NEOSHO,Centerville Township,Secretary of State,,Republican,"Kobach, Kris",133,000030
+NEOSHO,Chanute Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000040
+NEOSHO,Chanute Ward 1,Secretary of State,,Republican,"Kobach, Kris",39,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000050
+NEOSHO,Chanute Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",116,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000060
+NEOSHO,Chanute Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",169,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",117,000070
+NEOSHO,Chanute Ward 3 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",222,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,000080
+NEOSHO,Chanute Ward 3 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",154,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",163,000090
+NEOSHO,Chanute Ward 3 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",301,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",112,000100
+NEOSHO,Chanute Ward 4 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",162,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",83,000110
+NEOSHO,Chanute Ward 4 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",108,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",111,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00012C
+NEOSHO,East Erie,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",93,000140
+NEOSHO,East Erie,Secretary of State,,Republican,"Kobach, Kris",115,000140
+NEOSHO,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000150
+NEOSHO,Grant Township,Secretary of State,,Republican,"Kobach, Kris",105,000150
+NEOSHO,Ladore Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,000160
+NEOSHO,Ladore Township,Secretary of State,,Republican,"Kobach, Kris",64,000160
+NEOSHO,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000170
+NEOSHO,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",47,000170
+NEOSHO,Mission Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",101,000180
+NEOSHO,Mission Township,Secretary of State,,Republican,"Kobach, Kris",217,000180
+NEOSHO,North Tioga Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000190
+NEOSHO,North Tioga Township,Secretary of State,,Republican,"Kobach, Kris",138,000190
+NEOSHO,Shiloh Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000200
+NEOSHO,Shiloh Township,Secretary of State,,Republican,"Kobach, Kris",100,000200
+NEOSHO,South Tioga East Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000210
+NEOSHO,South Tioga East Township,Secretary of State,,Republican,"Kobach, Kris",62,000210
+NEOSHO,South Tioga West Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,00022A
+NEOSHO,South Tioga West Township,Secretary of State,,Republican,"Kobach, Kris",41,00022A
+NEOSHO,South Tioga West Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022B
+NEOSHO,South Tioga West Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022C
+NEOSHO,South Tioga West Township Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022D
+NEOSHO,South Tioga West Township Enclave C,Secretary of State,,Republican,"Kobach, Kris",0,00022D
+NEOSHO,Walnut Grove Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000230
+NEOSHO,Walnut Grove Township,Secretary of State,,Republican,"Kobach, Kris",78,000230
+NEOSHO,West Erie,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",72,000240
+NEOSHO,West Erie,Secretary of State,,Republican,"Kobach, Kris",175,000240
+NEOSHO,Chetopa Township H13,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,120020
+NEOSHO,Chetopa Township H13,Secretary of State,,Republican,"Kobach, Kris",176,120020
+NEOSHO,Chetopa Township H2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120030
+NEOSHO,Chetopa Township H2,Secretary of State,,Republican,"Kobach, Kris",0,120030
+NEOSHO,Chetopa Township H9,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,120040
+NEOSHO,Chetopa Township H9,Secretary of State,,Republican,"Kobach, Kris",69,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900020
+NEOSHO,Big Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",34,000010
+NEOSHO,Big Creek Township,State Treasurer,,Republican,"Estes, Ron",165,000010
+NEOSHO,Canville Township,State Treasurer,,Democratic,"Alldritt, Carmen",60,00002A
+NEOSHO,Canville Township,State Treasurer,,Republican,"Estes, Ron",186,00002A
+NEOSHO,Centerville Township,State Treasurer,,Democratic,"Alldritt, Carmen",65,000030
+NEOSHO,Centerville Township,State Treasurer,,Republican,"Estes, Ron",134,000030
+NEOSHO,Chanute Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",20,000040
+NEOSHO,Chanute Ward 1,State Treasurer,,Republican,"Estes, Ron",42,000040
+NEOSHO,Chanute Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",44,000050
+NEOSHO,Chanute Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",126,000050
+NEOSHO,Chanute Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",59,000060
+NEOSHO,Chanute Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",171,000060
+NEOSHO,Chanute Ward 3 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",126,000070
+NEOSHO,Chanute Ward 3 Precinct 1,State Treasurer,,Republican,"Estes, Ron",211,000070
+NEOSHO,Chanute Ward 3 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",76,000080
+NEOSHO,Chanute Ward 3 Precinct 2,State Treasurer,,Republican,"Estes, Ron",164,000080
+NEOSHO,Chanute Ward 3 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",131,000090
+NEOSHO,Chanute Ward 3 Precinct 3,State Treasurer,,Republican,"Estes, Ron",334,000090
+NEOSHO,Chanute Ward 4 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",99,000100
+NEOSHO,Chanute Ward 4 Precinct 1,State Treasurer,,Republican,"Estes, Ron",171,000100
+NEOSHO,Chanute Ward 4 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",82,000110
+NEOSHO,Chanute Ward 4 Precinct 2,State Treasurer,,Republican,"Estes, Ron",109,000110
+NEOSHO,Chanute Ward 4 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",54,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,State Treasurer,,Republican,"Estes, Ron",113,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00012C
+NEOSHO,East Erie,State Treasurer,,Democratic,"Alldritt, Carmen",69,000140
+NEOSHO,East Erie,State Treasurer,,Republican,"Estes, Ron",132,000140
+NEOSHO,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",45,000150
+NEOSHO,Grant Township,State Treasurer,,Republican,"Estes, Ron",108,000150
+NEOSHO,Ladore Township,State Treasurer,,Democratic,"Alldritt, Carmen",60,000160
+NEOSHO,Ladore Township,State Treasurer,,Republican,"Estes, Ron",71,000160
+NEOSHO,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000170
+NEOSHO,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",44,000170
+NEOSHO,Mission Township,State Treasurer,,Democratic,"Alldritt, Carmen",89,000180
+NEOSHO,Mission Township,State Treasurer,,Republican,"Estes, Ron",216,000180
+NEOSHO,North Tioga Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000190
+NEOSHO,North Tioga Township,State Treasurer,,Republican,"Estes, Ron",142,000190
+NEOSHO,Shiloh Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000200
+NEOSHO,Shiloh Township,State Treasurer,,Republican,"Estes, Ron",101,000200
+NEOSHO,South Tioga East Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000210
+NEOSHO,South Tioga East Township,State Treasurer,,Republican,"Estes, Ron",69,000210
+NEOSHO,South Tioga West Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,00022A
+NEOSHO,South Tioga West Township,State Treasurer,,Republican,"Estes, Ron",44,00022A
+NEOSHO,South Tioga West Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022B
+NEOSHO,South Tioga West Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,00022B
+NEOSHO,South Tioga West Township Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022C
+NEOSHO,South Tioga West Township Enclave B,State Treasurer,,Republican,"Estes, Ron",0,00022C
+NEOSHO,South Tioga West Township Enclave C,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022D
+NEOSHO,South Tioga West Township Enclave C,State Treasurer,,Republican,"Estes, Ron",0,00022D
+NEOSHO,Walnut Grove Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000230
+NEOSHO,Walnut Grove Township,State Treasurer,,Republican,"Estes, Ron",81,000230
+NEOSHO,West Erie,State Treasurer,,Democratic,"Alldritt, Carmen",59,000240
+NEOSHO,West Erie,State Treasurer,,Republican,"Estes, Ron",183,000240
+NEOSHO,Chetopa Township H13,State Treasurer,,Democratic,"Alldritt, Carmen",34,120020
+NEOSHO,Chetopa Township H13,State Treasurer,,Republican,"Estes, Ron",180,120020
+NEOSHO,Chetopa Township H2,State Treasurer,,Democratic,"Alldritt, Carmen",0,120030
+NEOSHO,Chetopa Township H2,State Treasurer,,Republican,"Estes, Ron",0,120030
+NEOSHO,Chetopa Township H9,State Treasurer,,Democratic,"Alldritt, Carmen",9,120040
+NEOSHO,Chetopa Township H9,State Treasurer,,Republican,"Estes, Ron",69,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900020
+NEOSHO,Big Creek Township,United States Senate,,independent,"Orman, Greg",43,000010
+NEOSHO,Big Creek Township,United States Senate,,Libertarian,"Batson, Randall",9,000010
+NEOSHO,Big Creek Township,United States Senate,,Republican,"Roberts, Pat",149,000010
+NEOSHO,Canville Township,United States Senate,,independent,"Orman, Greg",80,00002A
+NEOSHO,Canville Township,United States Senate,,Libertarian,"Batson, Randall",22,00002A
+NEOSHO,Canville Township,United States Senate,,Republican,"Roberts, Pat",143,00002A
+NEOSHO,Centerville Township,United States Senate,,independent,"Orman, Greg",67,000030
+NEOSHO,Centerville Township,United States Senate,,Libertarian,"Batson, Randall",14,000030
+NEOSHO,Centerville Township,United States Senate,,Republican,"Roberts, Pat",117,000030
+NEOSHO,Chanute Ward 1,United States Senate,,independent,"Orman, Greg",17,000040
+NEOSHO,Chanute Ward 1,United States Senate,,Libertarian,"Batson, Randall",5,000040
+NEOSHO,Chanute Ward 1,United States Senate,,Republican,"Roberts, Pat",40,000040
+NEOSHO,Chanute Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",66,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",9,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",100,000050
+NEOSHO,Chanute Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",61,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",22,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",148,000060
+NEOSHO,Chanute Ward 3 Precinct 1,United States Senate,,independent,"Orman, Greg",127,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",39,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States Senate,,Republican,"Roberts, Pat",177,000070
+NEOSHO,Chanute Ward 3 Precinct 2,United States Senate,,independent,"Orman, Greg",84,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",16,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States Senate,,Republican,"Roberts, Pat",145,000080
+NEOSHO,Chanute Ward 3 Precinct 3,United States Senate,,independent,"Orman, Greg",155,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",28,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States Senate,,Republican,"Roberts, Pat",286,000090
+NEOSHO,Chanute Ward 4 Precinct 1,United States Senate,,independent,"Orman, Greg",118,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",21,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States Senate,,Republican,"Roberts, Pat",140,000100
+NEOSHO,Chanute Ward 4 Precinct 2,United States Senate,,independent,"Orman, Greg",90,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",18,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States Senate,,Republican,"Roberts, Pat",87,000110
+NEOSHO,Chanute Ward 4 Precinct 3,United States Senate,,independent,"Orman, Greg",53,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",14,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States Senate,,Republican,"Roberts, Pat",95,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States Senate,,independent,"Orman, Greg",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States Senate,,independent,"Orman, Greg",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00012C
+NEOSHO,East Erie,United States Senate,,independent,"Orman, Greg",89,000140
+NEOSHO,East Erie,United States Senate,,Libertarian,"Batson, Randall",23,000140
+NEOSHO,East Erie,United States Senate,,Republican,"Roberts, Pat",98,000140
+NEOSHO,Grant Township,United States Senate,,independent,"Orman, Greg",55,000150
+NEOSHO,Grant Township,United States Senate,,Libertarian,"Batson, Randall",9,000150
+NEOSHO,Grant Township,United States Senate,,Republican,"Roberts, Pat",91,000150
+NEOSHO,Ladore Township,United States Senate,,independent,"Orman, Greg",70,000160
+NEOSHO,Ladore Township,United States Senate,,Libertarian,"Batson, Randall",13,000160
+NEOSHO,Ladore Township,United States Senate,,Republican,"Roberts, Pat",54,000160
+NEOSHO,Lincoln Township,United States Senate,,independent,"Orman, Greg",29,000170
+NEOSHO,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",6,000170
+NEOSHO,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",37,000170
+NEOSHO,Mission Township,United States Senate,,independent,"Orman, Greg",88,000180
+NEOSHO,Mission Township,United States Senate,,Libertarian,"Batson, Randall",12,000180
+NEOSHO,Mission Township,United States Senate,,Republican,"Roberts, Pat",223,000180
+NEOSHO,North Tioga Township,United States Senate,,independent,"Orman, Greg",37,000190
+NEOSHO,North Tioga Township,United States Senate,,Libertarian,"Batson, Randall",11,000190
+NEOSHO,North Tioga Township,United States Senate,,Republican,"Roberts, Pat",125,000190
+NEOSHO,Shiloh Township,United States Senate,,independent,"Orman, Greg",15,000200
+NEOSHO,Shiloh Township,United States Senate,,Libertarian,"Batson, Randall",10,000200
+NEOSHO,Shiloh Township,United States Senate,,Republican,"Roberts, Pat",92,000200
+NEOSHO,South Tioga East Township,United States Senate,,independent,"Orman, Greg",28,000210
+NEOSHO,South Tioga East Township,United States Senate,,Libertarian,"Batson, Randall",7,000210
+NEOSHO,South Tioga East Township,United States Senate,,Republican,"Roberts, Pat",57,000210
+NEOSHO,South Tioga West Township,United States Senate,,independent,"Orman, Greg",14,00022A
+NEOSHO,South Tioga West Township,United States Senate,,Libertarian,"Batson, Randall",3,00022A
+NEOSHO,South Tioga West Township,United States Senate,,Republican,"Roberts, Pat",36,00022A
+NEOSHO,South Tioga West Township Enclave,United States Senate,,independent,"Orman, Greg",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,00022B
+NEOSHO,South Tioga West Township Enclave B,United States Senate,,independent,"Orman, Greg",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States Senate,,Republican,"Roberts, Pat",0,00022C
+NEOSHO,South Tioga West Township Enclave C,United States Senate,,independent,"Orman, Greg",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States Senate,,Libertarian,"Batson, Randall",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States Senate,,Republican,"Roberts, Pat",0,00022D
+NEOSHO,Walnut Grove Township,United States Senate,,independent,"Orman, Greg",49,000230
+NEOSHO,Walnut Grove Township,United States Senate,,Libertarian,"Batson, Randall",6,000230
+NEOSHO,Walnut Grove Township,United States Senate,,Republican,"Roberts, Pat",69,000230
+NEOSHO,West Erie,United States Senate,,independent,"Orman, Greg",77,000240
+NEOSHO,West Erie,United States Senate,,Libertarian,"Batson, Randall",13,000240
+NEOSHO,West Erie,United States Senate,,Republican,"Roberts, Pat",159,000240
+NEOSHO,Chetopa Township H13,United States Senate,,independent,"Orman, Greg",41,120020
+NEOSHO,Chetopa Township H13,United States Senate,,Libertarian,"Batson, Randall",6,120020
+NEOSHO,Chetopa Township H13,United States Senate,,Republican,"Roberts, Pat",171,120020
+NEOSHO,Chetopa Township H2,United States Senate,,independent,"Orman, Greg",0,120030
+NEOSHO,Chetopa Township H2,United States Senate,,Libertarian,"Batson, Randall",0,120030
+NEOSHO,Chetopa Township H2,United States Senate,,Republican,"Roberts, Pat",0,120030
+NEOSHO,Chetopa Township H9,United States Senate,,independent,"Orman, Greg",12,120040
+NEOSHO,Chetopa Township H9,United States Senate,,Libertarian,"Batson, Randall",2,120040
+NEOSHO,Chetopa Township H9,United States Senate,,Republican,"Roberts, Pat",66,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States Senate,,independent,"Orman, Greg",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States Senate,,independent,"Orman, Greg",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900020

--- a/2014/20141104__ks__general__ness__precinct.csv
+++ b/2014/20141104__ks__general__ness__precinct.csv
@@ -1,205 +1,188 @@
-county,precinct,office,district,party,candidate,votes
-Ness,Bazine,U.S. Senate,,R,Pat Roberts,102
-Ness,Highpoint,U.S. Senate,,R,Pat Roberts,25
-Ness,North Center,U.S. Senate,,R,Pat Roberts,206
-Ness,Johnson,U.S. Senate,,R,Pat Roberts,19
-Ness,South Center,U.S. Senate,,R,Pat Roberts,100
-Ness,Nevada,U.S. Senate,,R,Pat Roberts,101
-Ness,Eden,U.S. Senate,,R,Pat Roberts,28
-Ness,Ohio,U.S. Senate,,R,Pat Roberts,63
-Ness,Forrester,U.S. Senate,,R,Pat Roberts,35
-Ness,Waring,U.S. Senate,,R,Pat Roberts,32
-Ness,Franklin,U.S. Senate,,R,Pat Roberts,36
-Ness,Advance,U.S. Senate,,R,Pat Roberts,170
-Ness,Bazine,U.S. Senate,,I,Greg Orman,18
-Ness,Highpoint,U.S. Senate,,I,Greg Orman,1
-Ness,North Center,U.S. Senate,,I,Greg Orman,55
-Ness,Johnson,U.S. Senate,,I,Greg Orman,2
-Ness,South Center,U.S. Senate,,I,Greg Orman,34
-Ness,Nevada,U.S. Senate,,I,Greg Orman,29
-Ness,Eden,U.S. Senate,,I,Greg Orman,3
-Ness,Ohio,U.S. Senate,,I,Greg Orman,8
-Ness,Forrester,U.S. Senate,,I,Greg Orman,4
-Ness,Waring,U.S. Senate,,I,Greg Orman,6
-Ness,Franklin,U.S. Senate,,I,Greg Orman,3
-Ness,Advance,U.S. Senate,,I,Greg Orman,57
-Ness,Bazine,U.S. Senate,,L,Randall Batson,3
-Ness,Highpoint,U.S. Senate,,L,Randall Batson,1
-Ness,North Center,U.S. Senate,,L,Randall Batson,9
-Ness,Johnson,U.S. Senate,,L,Randall Batson,2
-Ness,South Center,U.S. Senate,,L,Randall Batson,4
-Ness,Nevada,U.S. Senate,,L,Randall Batson,6
-Ness,Eden,U.S. Senate,,L,Randall Batson,0
-Ness,Ohio,U.S. Senate,,L,Randall Batson,2
-Ness,Forrester,U.S. Senate,,L,Randall Batson,0
-Ness,Waring,U.S. Senate,,L,Randall Batson,0
-Ness,Franklin,U.S. Senate,,L,Randall Batson,1
-Ness,Advance,U.S. Senate,,L,Randall Batson,13
-Ness,Bazine,U.S. House,1,R,Tim Huelskamp,102
-Ness,Highpoint,U.S. House,1,R,Tim Huelskamp,22
-Ness,North Center,U.S. House,1,R,Tim Huelskamp,212
-Ness,Johnson,U.S. House,1,R,Tim Huelskamp,17
-Ness,South Center,U.S. House,1,R,Tim Huelskamp,104
-Ness,Nevada,U.S. House,1,R,Tim Huelskamp,95
-Ness,Eden,U.S. House,1,R,Tim Huelskamp,27
-Ness,Ohio,U.S. House,1,R,Tim Huelskamp,63
-Ness,Forrester,U.S. House,1,R,Tim Huelskamp,37
-Ness,Waring,U.S. House,1,R,Tim Huelskamp,27
-Ness,Franklin,U.S. House,1,R,Tim Huelskamp,36
-Ness,Advance,U.S. House,1,R,Tim Huelskamp,183
-Ness,Bazine,U.S. House,1,D,James Sherow,19
-Ness,Highpoint,U.S. House,1,D,James Sherow,5
-Ness,North Center,U.S. House,1,D,James Sherow,55
-Ness,Johnson,U.S. House,1,D,James Sherow,5
-Ness,South Center,U.S. House,1,D,James Sherow,31
-Ness,Nevada,U.S. House,1,D,James Sherow,39
-Ness,Eden,U.S. House,1,D,James Sherow,3
-Ness,Ohio,U.S. House,1,D,James Sherow,10
-Ness,Forrester,U.S. House,1,D,James Sherow,2
-Ness,Waring,U.S. House,1,D,James Sherow,10
-Ness,Franklin,U.S. House,1,D,James Sherow,3
-Ness,Advance,U.S. House,1,D,James Sherow,53
-Ness,Bazine,Governor,,R,Sam Brownback,95
-Ness,Highpoint,Governor,,R,Sam Brownback,25
-Ness,North Center,Governor,,R,Sam Brownback,203
-Ness,Johnson,Governor,,R,Sam Brownback,18
-Ness,South Center,Governor,,R,Sam Brownback,96
-Ness,Nevada,Governor,,R,Sam Brownback,90
-Ness,Eden,Governor,,R,Sam Brownback,28
-Ness,Ohio,Governor,,R,Sam Brownback,59
-Ness,Forrester,Governor,,R,Sam Brownback,33
-Ness,Waring,Governor,,R,Sam Brownback,31
-Ness,Franklin,Governor,,R,Sam Brownback,31
-Ness,Advance,Governor,,R,Sam Brownback,171
-Ness,Bazine,Governor,,D,Paul Davis,26
-Ness,Highpoint,Governor,,D,Paul Davis,1
-Ness,North Center,Governor,,D,Paul Davis,58
-Ness,Johnson,Governor,,D,Paul Davis,2
-Ness,South Center,Governor,,D,Paul Davis,40
-Ness,Nevada,Governor,,D,Paul Davis,36
-Ness,Eden,Governor,,D,Paul Davis,3
-Ness,Ohio,Governor,,D,Paul Davis,12
-Ness,Forrester,Governor,,D,Paul Davis,6
-Ness,Waring,Governor,,D,Paul Davis,6
-Ness,Franklin,Governor,,D,Paul Davis,7
-Ness,Advance,Governor,,D,Paul Davis,63
-Ness,Bazine,Governor,,L,Keen Umbehr,3
-Ness,Highpoint,Governor,,L,Keen Umbehr,1
-Ness,North Center,Governor,,L,Keen Umbehr,11
-Ness,Johnson,Governor,,L,Keen Umbehr,3
-Ness,South Center,Governor,,L,Keen Umbehr,1
-Ness,Nevada,Governor,,L,Keen Umbehr,9
-Ness,Eden,Governor,,L,Keen Umbehr,0
-Ness,Ohio,Governor,,L,Keen Umbehr,2
-Ness,Forrester,Governor,,L,Keen Umbehr,1
-Ness,Waring,Governor,,L,Keen Umbehr,1
-Ness,Franklin,Governor,,L,Keen Umbehr,2
-Ness,Advance,Governor,,L,Keen Umbehr,6
-Ness,Bazine,Secretary of State,,R,Kris Kobach,99
-Ness,Highpoint,Secretary of State,,R,Kris Kobach,26
-Ness,North Center,Secretary of State,,R,Kris Kobach,216
-Ness,Johnson,Secretary of State,,R,Kris Kobach,20
-Ness,South Center,Secretary of State,,R,Kris Kobach,101
-Ness,Nevada,Secretary of State,,R,Kris Kobach,106
-Ness,Eden,Secretary of State,,R,Kris Kobach,26
-Ness,Ohio,Secretary of State,,R,Kris Kobach,63
-Ness,Forrester,Secretary of State,,R,Kris Kobach,35
-Ness,Waring,Secretary of State,,R,Kris Kobach,32
-Ness,Franklin,Secretary of State,,R,Kris Kobach,28
-Ness,Advance,Secretary of State,,R,Kris Kobach,180
-Ness,Bazine,Secretary of State,,D,Jean Schodorf,23
-Ness,Highpoint,Secretary of State,,D,Jean Schodorf,1
-Ness,North Center,Secretary of State,,D,Jean Schodorf,53
-Ness,Johnson,Secretary of State,,D,Jean Schodorf,2
-Ness,South Center,Secretary of State,,D,Jean Schodorf,31
-Ness,Nevada,Secretary of State,,D,Jean Schodorf,30
-Ness,Eden,Secretary of State,,D,Jean Schodorf,5
-Ness,Ohio,Secretary of State,,D,Jean Schodorf,9
-Ness,Forrester,Secretary of State,,D,Jean Schodorf,4
-Ness,Waring,Secretary of State,,D,Jean Schodorf,6
-Ness,Franklin,Secretary of State,,D,Jean Schodorf,9
-Ness,Advance,Secretary of State,,D,Jean Schodorf,55
-Ness,Bazine,Attorney General,,R,Derek Schmidt,114
-Ness,Highpoint,Attorney General,,R,Derek Schmidt,27
-Ness,North Center,Attorney General,,R,Derek Schmidt,229
-Ness,Johnson,Attorney General,,R,Derek Schmidt,22
-Ness,South Center,Attorney General,,R,Derek Schmidt,103
-Ness,Nevada,Attorney General,,R,Derek Schmidt,113
-Ness,Eden,Attorney General,,R,Derek Schmidt,24
-Ness,Ohio,Attorney General,,R,Derek Schmidt,65
-Ness,Forrester,Attorney General,,R,Derek Schmidt,36
-Ness,Waring,Attorney General,,R,Derek Schmidt,36
-Ness,Franklin,Attorney General,,R,Derek Schmidt,32
-Ness,Advance,Attorney General,,R,Derek Schmidt,203
-Ness,Bazine,Attorney General,,D,AJ Kotich,6
-Ness,Highpoint,Attorney General,,D,AJ Kotich,0
-Ness,North Center,Attorney General,,D,AJ Kotich,32
-Ness,Johnson,Attorney General,,D,AJ Kotich,1
-Ness,South Center,Attorney General,,D,AJ Kotich,28
-Ness,Nevada,Attorney General,,D,AJ Kotich,21
-Ness,Eden,Attorney General,,D,AJ Kotich,6
-Ness,Ohio,Attorney General,,D,AJ Kotich,9
-Ness,Forrester,Attorney General,,D,AJ Kotich,3
-Ness,Waring,Attorney General,,D,AJ Kotich,2
-Ness,Franklin,Attorney General,,D,AJ Kotich,4
-Ness,Advance,Attorney General,,D,AJ Kotich,28
-Ness,Bazine,State Treasurer,,R,Ron Estes,110
-Ness,Highpoint,State Treasurer,,R,Ron Estes,26
-Ness,North Center,State Treasurer,,R,Ron Estes,233
-Ness,Johnson,State Treasurer,,R,Ron Estes,22
-Ness,South Center,State Treasurer,,R,Ron Estes,114
-Ness,Nevada,State Treasurer,,R,Ron Estes,118
-Ness,Eden,State Treasurer,,R,Ron Estes,28
-Ness,Ohio,State Treasurer,,R,Ron Estes,68
-Ness,Forrester,State Treasurer,,R,Ron Estes,36
-Ness,Waring,State Treasurer,,R,Ron Estes,34
-Ness,Franklin,State Treasurer,,R,Ron Estes,36
-Ness,Advance,State Treasurer,,R,Ron Estes,203
-Ness,Bazine,State Treasurer,,D,Carmen Alldritt,10
-Ness,Highpoint,State Treasurer,,D,Carmen Alldritt,0
-Ness,North Center,State Treasurer,,D,Carmen Alldritt,32
-Ness,Johnson,State Treasurer,,D,Carmen Alldritt,1
-Ness,South Center,State Treasurer,,D,Carmen Alldritt,19
-Ness,Nevada,State Treasurer,,D,Carmen Alldritt,16
-Ness,Eden,State Treasurer,,D,Carmen Alldritt,2
-Ness,Ohio,State Treasurer,,D,Carmen Alldritt,6
-Ness,Forrester,State Treasurer,,D,Carmen Alldritt,2
-Ness,Waring,State Treasurer,,D,Carmen Alldritt,3
-Ness,Franklin,State Treasurer,,D,Carmen Alldritt,2
-Ness,Advance,State Treasurer,,D,Carmen Alldritt,33
-Ness,Bazine,Insurance Commissioner,,R,Ken Selzer,97
-Ness,Highpoint,Insurance Commissioner,,R,Ken Selzer,26
-Ness,North Center,Insurance Commissioner,,R,Ken Selzer,207
-Ness,Johnson,Insurance Commissioner,,R,Ken Selzer,21
-Ness,South Center,Insurance Commissioner,,R,Ken Selzer,100
-Ness,Nevada,Insurance Commissioner,,R,Ken Selzer,97
-Ness,Eden,Insurance Commissioner,,R,Ken Selzer,23
-Ness,Ohio,Insurance Commissioner,,R,Ken Selzer,62
-Ness,Forrester,Insurance Commissioner,,R,Ken Selzer,35
-Ness,Waring,Insurance Commissioner,,R,Ken Selzer,29
-Ness,Franklin,Insurance Commissioner,,R,Ken Selzer,31
-Ness,Advance,Insurance Commissioner,,R,Ken Selzer,172
-Ness,Bazine,Insurance Commissioner,,D,Dennis Anderson,18
-Ness,Highpoint,Insurance Commissioner,,D,Dennis Anderson,1
-Ness,North Center,Insurance Commissioner,,D,Dennis Anderson,44
-Ness,Johnson,Insurance Commissioner,,D,Dennis Anderson,1
-Ness,South Center,Insurance Commissioner,,D,Dennis Anderson,30
-Ness,Nevada,Insurance Commissioner,,D,Dennis Anderson,36
-Ness,Eden,Insurance Commissioner,,D,Dennis Anderson,6
-Ness,Ohio,Insurance Commissioner,,D,Dennis Anderson,10
-Ness,Forrester,Insurance Commissioner,,D,Dennis Anderson,4
-Ness,Waring,Insurance Commissioner,,D,Dennis Anderson,8
-Ness,Franklin,Insurance Commissioner,,D,Dennis Anderson,3
-Ness,Advance,Insurance Commissioner,,D,Dennis Anderson,56
-Ness,Bazine,State House,117,R,John L. Ewy,114
-Ness,Highpoint,State House,117,R,John L. Ewy,26
-Ness,North Center,State House,117,R,John L. Ewy,244
-Ness,Johnson,State House,117,R,John L. Ewy,22
-Ness,South Center,State House,117,R,John L. Ewy,133
-Ness,Nevada,State House,117,R,John L. Ewy,126
-Ness,Eden,State House,117,R,John L. Ewy,30
-Ness,Ohio,State House,117,R,John L. Ewy,69
-Ness,Forrester,State House,117,R,John L. Ewy,38
-Ness,Waring,State House,117,R,John L. Ewy,37
-Ness,Franklin,State House,117,R,John L. Ewy,35
-Ness,Advance,State House,117,R,John L. Ewy,223
+county,precinct,office,district,party,candidate,votes,vtd
+NESS,Bazine Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000010
+NESS,Bazine Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000010
+NESS,Bazine Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",112,000010
+NESS,Eden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000020
+NESS,Eden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+NESS,Eden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000020
+NESS,Forrester Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+NESS,Forrester Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+NESS,Forrester Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000030
+NESS,Franklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000040
+NESS,Franklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+NESS,Franklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000040
+NESS,Highpoint Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000050
+NESS,Highpoint Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+NESS,Highpoint Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000050
+NESS,Johnson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000060
+NESS,Johnson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000060
+NESS,Johnson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000060
+NESS,Nevada Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000070
+NESS,Nevada Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000070
+NESS,Nevada Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000070
+NESS,North Center,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000080
+NESS,North Center,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000080
+NESS,North Center,Governor / Lt. Governor,,Republican,"Brownback, Sam",262,000080
+NESS,Ohio Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000090
+NESS,Ohio Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000090
+NESS,Ohio Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000090
+NESS,South Center,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000100
+NESS,South Center,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000100
+NESS,South Center,Governor / Lt. Governor,,Republican,"Brownback, Sam",122,000100
+NESS,Waring Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000110
+NESS,Waring Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000110
+NESS,Waring Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000110
+NESS,Bazine Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",133,000010
+NESS,Eden Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",36,000020
+NESS,Forrester Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",44,000030
+NESS,Franklin Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",43,000040
+NESS,Highpoint Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",33,000050
+NESS,Johnson Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",33,000060
+NESS,Nevada Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",148,000070
+NESS,North Center,Kansas House of Representatives,117,Republican,"Ewy, John L.",324,000080
+NESS,Ohio Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",92,000090
+NESS,South Center,Kansas House of Representatives,117,Republican,"Ewy, John L.",169,000100
+NESS,Waring Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",42,000110
+NESS,Bazine Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000010
+NESS,Bazine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",118,000010
+NESS,Eden Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000020
+NESS,Eden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000020
+NESS,Forrester Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000030
+NESS,Forrester Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000030
+NESS,Franklin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000040
+NESS,Franklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000040
+NESS,Highpoint Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000050
+NESS,Highpoint Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000050
+NESS,Johnson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000060
+NESS,Johnson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000060
+NESS,Nevada Township,United States House of Representatives,1,Democratic,"Sherow, James E.",49,000070
+NESS,Nevada Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",111,000070
+NESS,North Center,United States House of Representatives,1,Democratic,"Sherow, James E.",73,000080
+NESS,North Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",274,000080
+NESS,Ohio Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000090
+NESS,Ohio Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,000090
+NESS,South Center,United States House of Representatives,1,Democratic,"Sherow, James E.",41,000100
+NESS,South Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,000100
+NESS,Waring Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000110
+NESS,Waring Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000110
+NESS,Bazine Township,Attorney General,,Democratic,"Kotich, A.J.",7,000010
+NESS,Bazine Township,Attorney General,,Republican,"Schmidt, Derek",132,000010
+NESS,Eden Township,Attorney General,,Democratic,"Kotich, A.J.",6,000020
+NESS,Eden Township,Attorney General,,Republican,"Schmidt, Derek",30,000020
+NESS,Forrester Township,Attorney General,,Democratic,"Kotich, A.J.",4,000030
+NESS,Forrester Township,Attorney General,,Republican,"Schmidt, Derek",42,000030
+NESS,Franklin Township,Attorney General,,Democratic,"Kotich, A.J.",4,000040
+NESS,Franklin Township,Attorney General,,Republican,"Schmidt, Derek",42,000040
+NESS,Highpoint Township,Attorney General,,Democratic,"Kotich, A.J.",0,000050
+NESS,Highpoint Township,Attorney General,,Republican,"Schmidt, Derek",34,000050
+NESS,Johnson Township,Attorney General,,Democratic,"Kotich, A.J.",1,000060
+NESS,Johnson Township,Attorney General,,Republican,"Schmidt, Derek",33,000060
+NESS,Nevada Township,Attorney General,,Democratic,"Kotich, A.J.",28,000070
+NESS,Nevada Township,Attorney General,,Republican,"Schmidt, Derek",131,000070
+NESS,North Center,Attorney General,,Democratic,"Kotich, A.J.",39,000080
+NESS,North Center,Attorney General,,Republican,"Schmidt, Derek",300,000080
+NESS,Ohio Township,Attorney General,,Democratic,"Kotich, A.J.",13,000090
+NESS,Ohio Township,Attorney General,,Republican,"Schmidt, Derek",84,000090
+NESS,South Center,Attorney General,,Democratic,"Kotich, A.J.",35,000100
+NESS,South Center,Attorney General,,Republican,"Schmidt, Derek",135,000100
+NESS,Waring Township,Attorney General,,Democratic,"Kotich, A.J.",3,000110
+NESS,Waring Township,Attorney General,,Republican,"Schmidt, Derek",41,000110
+NESS,Bazine Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000010
+NESS,Bazine Township,Commissioner of Insurance,,Republican,"Selzer, Ken",115,000010
+NESS,Eden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000020
+NESS,Eden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000020
+NESS,Forrester Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000030
+NESS,Forrester Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000030
+NESS,Franklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000040
+NESS,Franklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000040
+NESS,Highpoint Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000050
+NESS,Highpoint Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000050
+NESS,Johnson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000060
+NESS,Johnson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000060
+NESS,Nevada Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",47,000070
+NESS,Nevada Township,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000070
+NESS,North Center,Commissioner of Insurance,,Democratic,"Anderson, Dennis",64,000080
+NESS,North Center,Commissioner of Insurance,,Republican,"Selzer, Ken",264,000080
+NESS,Ohio Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000090
+NESS,Ohio Township,Commissioner of Insurance,,Republican,"Selzer, Ken",81,000090
+NESS,South Center,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000100
+NESS,South Center,Commissioner of Insurance,,Republican,"Selzer, Ken",128,000100
+NESS,Waring Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000110
+NESS,Waring Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000110
+NESS,Bazine Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000010
+NESS,Bazine Township,Secretary of State,,Republican,"Kobach, Kris",117,000010
+NESS,Eden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000020
+NESS,Eden Township,Secretary of State,,Republican,"Kobach, Kris",31,000020
+NESS,Forrester Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000030
+NESS,Forrester Township,Secretary of State,,Republican,"Kobach, Kris",39,000030
+NESS,Franklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000040
+NESS,Franklin Township,Secretary of State,,Republican,"Kobach, Kris",35,000040
+NESS,Highpoint Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000050
+NESS,Highpoint Township,Secretary of State,,Republican,"Kobach, Kris",33,000050
+NESS,Johnson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000060
+NESS,Johnson Township,Secretary of State,,Republican,"Kobach, Kris",27,000060
+NESS,Nevada Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000070
+NESS,Nevada Township,Secretary of State,,Republican,"Kobach, Kris",121,000070
+NESS,North Center,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000080
+NESS,North Center,Secretary of State,,Republican,"Kobach, Kris",275,000080
+NESS,Ohio Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000090
+NESS,Ohio Township,Secretary of State,,Republican,"Kobach, Kris",82,000090
+NESS,South Center,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000100
+NESS,South Center,Secretary of State,,Republican,"Kobach, Kris",135,000100
+NESS,Waring Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000110
+NESS,Waring Township,Secretary of State,,Republican,"Kobach, Kris",37,000110
+NESS,Bazine Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000010
+NESS,Bazine Township,State Treasurer,,Republican,"Estes, Ron",129,000010
+NESS,Eden Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000020
+NESS,Eden Township,State Treasurer,,Republican,"Estes, Ron",34,000020
+NESS,Forrester Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+NESS,Forrester Township,State Treasurer,,Republican,"Estes, Ron",41,000030
+NESS,Franklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000040
+NESS,Franklin Township,State Treasurer,,Republican,"Estes, Ron",45,000040
+NESS,Highpoint Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000050
+NESS,Highpoint Township,State Treasurer,,Republican,"Estes, Ron",33,000050
+NESS,Johnson Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000060
+NESS,Johnson Township,State Treasurer,,Republican,"Estes, Ron",30,000060
+NESS,Nevada Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000070
+NESS,Nevada Township,State Treasurer,,Republican,"Estes, Ron",135,000070
+NESS,North Center,State Treasurer,,Democratic,"Alldritt, Carmen",39,000080
+NESS,North Center,State Treasurer,,Republican,"Estes, Ron",306,000080
+NESS,Ohio Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000090
+NESS,Ohio Township,State Treasurer,,Republican,"Estes, Ron",90,000090
+NESS,South Center,State Treasurer,,Democratic,"Alldritt, Carmen",24,000100
+NESS,South Center,State Treasurer,,Republican,"Estes, Ron",148,000100
+NESS,Waring Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000110
+NESS,Waring Township,State Treasurer,,Republican,"Estes, Ron",37,000110
+NESS,Bazine Township,United States Senate,,independent,"Orman, Greg",20,000010
+NESS,Bazine Township,United States Senate,,Libertarian,"Batson, Randall",3,000010
+NESS,Bazine Township,United States Senate,,Republican,"Roberts, Pat",119,000010
+NESS,Eden Township,United States Senate,,independent,"Orman, Greg",5,000020
+NESS,Eden Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+NESS,Eden Township,United States Senate,,Republican,"Roberts, Pat",32,000020
+NESS,Forrester Township,United States Senate,,independent,"Orman, Greg",6,000030
+NESS,Forrester Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+NESS,Forrester Township,United States Senate,,Republican,"Roberts, Pat",40,000030
+NESS,Franklin Township,United States Senate,,independent,"Orman, Greg",4,000040
+NESS,Franklin Township,United States Senate,,Libertarian,"Batson, Randall",1,000040
+NESS,Franklin Township,United States Senate,,Republican,"Roberts, Pat",45,000040
+NESS,Highpoint Township,United States Senate,,independent,"Orman, Greg",1,000050
+NESS,Highpoint Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+NESS,Highpoint Township,United States Senate,,Republican,"Roberts, Pat",31,000050
+NESS,Johnson Township,United States Senate,,independent,"Orman, Greg",5,000060
+NESS,Johnson Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+NESS,Johnson Township,United States Senate,,Republican,"Roberts, Pat",26,000060
+NESS,Nevada Township,United States Senate,,independent,"Orman, Greg",40,000070
+NESS,Nevada Township,United States Senate,,Libertarian,"Batson, Randall",11,000070
+NESS,Nevada Township,United States Senate,,Republican,"Roberts, Pat",111,000070
+NESS,North Center,United States Senate,,independent,"Orman, Greg",75,000080
+NESS,North Center,United States Senate,,Libertarian,"Batson, Randall",12,000080
+NESS,North Center,United States Senate,,Republican,"Roberts, Pat",264,000080
+NESS,Ohio Township,United States Senate,,independent,"Orman, Greg",12,000090
+NESS,Ohio Township,United States Senate,,Libertarian,"Batson, Randall",2,000090
+NESS,Ohio Township,United States Senate,,Republican,"Roberts, Pat",85,000090
+NESS,South Center,United States Senate,,independent,"Orman, Greg",43,000100
+NESS,South Center,United States Senate,,Libertarian,"Batson, Randall",9,000100
+NESS,South Center,United States Senate,,Republican,"Roberts, Pat",129,000100
+NESS,Waring Township,United States Senate,,independent,"Orman, Greg",9,000110
+NESS,Waring Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+NESS,Waring Township,United States Senate,,Republican,"Roberts, Pat",35,000110

--- a/2014/20141104__ks__general__norton__precinct.csv
+++ b/2014/20141104__ks__general__norton__precinct.csv
@@ -1,241 +1,205 @@
-county,precinct,office,dist,party,candidate,total,poll,adv,prov
-Norton,Almena Township,U.S. Senate,,R,Pat Roberts,151,147,4,0
-Norton,Center Precinct 1,U.S. Senate,,R,Pat Roberts,199,165,33,1
-Norton,Belle Plaine-Sol 1,U.S. Senate,,R,Pat Roberts,11,11,0,0
-Norton,Center Precinct 2,U.S. Senate,,R,Pat Roberts,50,40,10,0
-Norton,Highland Precinct 1,U.S. Senate,,R,Pat Roberts,132,124,8,0
-Norton,Highland Precinct 2,U.S. Senate,,R,Pat Roberts,27,24,3,0
-Norton,Highland Precinct 3,U.S. Senate,,R,Pat Roberts,28,24,3,1
-Norton,Norton Ward 1,U.S. Senate,,R,Pat Roberts,209,185,23,1
-Norton,Norton Ward 2,U.S. Senate,,R,Pat Roberts,278,227,47,4
-Norton,Norton Ward 3,U.S. Senate,,R,Pat Roberts,211,175,32,4
-Norton,Solomon Precinct 1,U.S. Senate,,R,Pat Roberts,23,23,0,0
-Norton,Sandcreek-Sol 1,U.S. Senate,,R,Pat Roberts,6,4,2,0
-Norton,Solomon Precinct 2,U.S. Senate,,R,Pat Roberts,14,12,2,0
-Norton,Almena Township,U.S. Senate,,I,Greg Orman,34,33,1,0
-Norton,Center Precinct 1,U.S. Senate,,I,Greg Orman,54,45,9,0
-Norton,Belle Plaine,U.S. Senate,,I,Greg Orman,2,1,1,0
-Norton,Center Precinct 2,U.S. Senate,,I,Greg Orman,9,8,1,0
-Norton,Highland Precinct 1,U.S. Senate,,I,Greg Orman,33,29,4,0
-Norton,Highland Precinct 2,U.S. Senate,,I,Greg Orman,8,6,2,0
-Norton,Highland Precinct 3,U.S. Senate,,I,Greg Orman,4,4,0,0
-Norton,Norton Ward 1,U.S. Senate,,I,Greg Orman,60,51,8,1
-Norton,Norton Ward 2,U.S. Senate,,I,Greg Orman,100,67,30,3
-Norton,Norton Ward 3,U.S. Senate,,I,Greg Orman,83,66,16,1
-Norton,Solomon Precinct 1,U.S. Senate,,I,Greg Orman,3,2,1,0
-Norton,Sandcreek-Sol 1,U.S. Senate,,I,Greg Orman,0,0,0,0
-Norton,Solomon Precinct 2,U.S. Senate,,I,Greg Orman,0,0,0,0
-Norton,Almena Township,U.S. Senate,,L,Nathan Batson,7,7,0,0
-Norton,Center Precinct 1,U.S. Senate,,L,Nathan Batson,7,6,1,0
-Norton,Belle Plaine,U.S. Senate,,L,Nathan Batson,0,0,0,0
-Norton,Center Precinct 2,U.S. Senate,,L,Nathan Batson,0,0,0,0
-Norton,Highland Precinct 1,U.S. Senate,,L,Nathan Batson,13,10,3,0
-Norton,Highland Precinct 2,U.S. Senate,,L,Nathan Batson,2,2,0,0
-Norton,Highland Precinct 3,U.S. Senate,,L,Nathan Batson,3,2,1,0
-Norton,Norton Ward 1,U.S. Senate,,L,Nathan Batson,19,19,0,0
-Norton,Norton Ward 2,U.S. Senate,,L,Nathan Batson,14,12,2,0
-Norton,Norton Ward 3,U.S. Senate,,L,Nathan Batson,22,21,1,0
-Norton,Solomon Precinct 1,U.S. Senate,,L,Nathan Batson,0,0,0,0
-Norton,Sandcreek-Sol 1,U.S. Senate,,L,Nathan Batson,0,0,0,0
-Norton,Solomon Precinct 2,U.S. Senate,,L,Nathan Batson,0,0,0,0
-Norton,Norton Ward 2,U.S. Senate,,,Taryn Stover,1,1,0,0
-Norton,Norton Ward 2,U.S. Senate,,,Al Ebke,1,1,0,0
-Norton,Almena Township,U.S. House,1,R,Tim Huelskamp,158,156,2,0
-Norton,Center Precinct 1,U.S. House,1,R,Tim Huelskamp,219,181,37,1
-Norton,Belle Plaine,U.S. House,1,R,Tim Huelskamp,12,12,0,0
-Norton,Center Precinct 2,U.S. House,1,R,Tim Huelskamp,47,39,8,0
-Norton,Highland Precinct 1,U.S. House,1,R,Tim Huelskamp,133,121,12,0
-Norton,Highland Precinct 2,U.S. House,1,R,Tim Huelskamp,29,25,4,0
-Norton,Highland Precinct 3,U.S. House,1,R,Tim Huelskamp,33,29,3,1
-Norton,Solomon Precinct 1,U.S. House,1,R,Tim Huelskamp,22,22,0,0
-Norton,Sandcreek-Sol 1,U.S. House,1,R,Tim Huelskamp,6,4,2,0
-Norton,Solomon Precinct 2,U.S. House,1,R,Tim Huelskamp,11,11,0,0
-Norton,Norton Ward 1,U.S. House,1,R,Tim Huelskamp,233,204,27,2
-Norton,Norton Ward 2,U.S. House,1,R,Tim Huelskamp,304,247,51,6
-Norton,Norton Ward 3,U.S. House,1,R,Tim Huelskamp,236,199,33,4
-Norton,Almena Township,U.S. House,1,D,James Sherow,35,32,3,0
-Norton,Center Precinct 1,U.S. House,1,D,James Sherow,37,31,6,0
-Norton,Belle Plaine,U.S. House,1,D,James Sherow,1,0,1,0
-Norton,Center Precinct 2,U.S. House,1,D,James Sherow,11,8,3,0
-Norton,Highland Precinct 1,U.S. House,1,D,James Sherow,41,38,3,0
-Norton,Highland Precinct 2,U.S. House,1,D,James Sherow,6,5,1,0
-Norton,Highland Precinct 3,U.S. House,1,D,James Sherow,1,1,0,0
-Norton,Solomon Precinct 1,U.S. House,1,D,James Sherow,4,3,1,0
-Norton,Sandcreek-Sol 1,U.S. House,1,D,James Sherow,0,0,0,0
-Norton,Solomon Precinct 2,U.S. House,1,D,James Sherow,1,1,0,0
-Norton,Norton Ward 1,U.S. House,1,D,James Sherow,55,50,5,0
-Norton,Norton Ward 2,U.S. House,1,D,James Sherow,90,63,26,1
-Norton,Norton Ward 3,U.S. House,1,D,James Sherow,79,60,18,1
-Norton,Highland 1,U.S. House,1,,Write-ins,1,1,0,0
-Norton,Almena Township,Governor,,R,Sam Brownback,137,133,4,0
-Norton,Center Precinct 1,Governor,,R,Sam Brownback,183,152,30,1
-Norton,Belle Plaine,Governor,,R,Sam Brownback,11,11,0,0
-Norton,Center Precinct 2,Governor,,R,Sam Brownback,43,33,10,0
-Norton,Highland Precinct 1,Governor,,R,Sam Brownback,131,121,10,0
-Norton,Highland Precinct 2,Governor,,R,Sam Brownback,27,23,4,0
-Norton,Highland Precinct 3,Governor,,R,Sam Brownback,24,21,2,1
-Norton,Solomon Precinct 1,Governor,,R,Sam Brownback,21,21,0,0
-Norton,Sandcreek-Sol 1,Governor,,R,Sam Brownback,4,3,1,0
-Norton,Solomon Precinct 2,Governor,,R,Sam Brownback,11,11,0,0
-Norton,Norton Ward 1,Governor,,R,Sam Brownback,183,160,23,0
-Norton,Norton Ward 2,Governor,,R,Sam Brownback,255,207,44,4
-Norton,Norton Ward 3,Governor,,R,Sam Brownback,186,158,24,4
-Norton,Almena Township,Governor,,D,Paul Davis,45,44,1,0
-Norton,Center Precinct 1,Governor,,D,Paul Davis,65,53,12,0
-Norton,Belle Plaine,Governor,,D,Paul Davis,2,1,1,0
-Norton,Center Precinct 2,Governor,,D,Paul Davis,14,12,2,0
-Norton,Highland Precinct 1,Governor,,D,Paul Davis,35,31,4,0
-Norton,Highland Precinct 2,Governor,,D,Paul Davis,11,9,2,0
-Norton,Highland Precinct 3,Governor,,D,Paul Davis,9,8,1,0
-Norton,Solomon Precinct 1,Governor,,D,Paul Davis,5,4,1,0
-Norton,Sandcreek-Sol 1,Governor,,D,Paul Davis,2,1,1,0
-Norton,Solomon Precinct 2,Governor,,D,Paul Davis,1,1,0,0
-Norton,Norton Ward 1,Governor,,D,Paul Davis,92,84,7,1
-Norton,Norton Ward 2,Governor,,D,Paul Davis,127,92,32,3
-Norton,Norton Ward 3,Governor,,D,Paul Davis,110,85,24,1
-Norton,Almena Township,Governor,,L,Keen Umbehr,11,11,0,0
-Norton,Center Precinct 1,Governor,,L,Keen Umbehr,10,9,1,0
-Norton,Belle Plaine,Governor,,L,Keen Umbehr,0,0,0,0
-Norton,Center Precinct 2,Governor,,L,Keen Umbehr,3,3,0,0
-Norton,Highland Precinct 1,Governor,,L,Keen Umbehr,11,10,1,0
-Norton,Highland Precinct 2,Governor,,L,Keen Umbehr,1,1,0,0
-Norton,Highland Precinct 3,Governor,,L,Keen Umbehr,2,1,1,0
-Norton,Solomon Precinct 1,Governor,,L,Keen Umbehr,0,0,0,0
-Norton,Sandcreek-Sol 1,Governor,,L,Keen Umbehr,0,0,0,0
-Norton,Solomon Precinct 2,Governor,,L,Keen Umbehr,0,0,0,0
-Norton,Norton Ward 1,Governor,,L,Keen Umbehr,16,13,2,1
-Norton,Norton Ward 2,Governor,,L,Keen Umbehr,14,11,3,0
-Norton,Norton Ward 3,Governor,,L,Keen Umbehr,22,20,2,0
-Norton,Almena Township,Secretary of State,,R,Kris Kobach,170,166,4,0
-Norton,Center Precinct 1,Secretary of State,,R,Kris Kobach,207,174,32,1
-Norton,Belle Plaine,Secretary of State,,R,Kris Kobach,10,10,0,0
-Norton,Center Precinct 2,Secretary of State,,R,Kris Kobach,47,38,9,0
-Norton,Highland Precinct 1,Secretary of State,,R,Kris Kobach,128,118,10,0
-Norton,Highland Precinct 2,Secretary of State,,R,Kris Kobach,76,26,5,0
-Norton,Highland Precinct 3,Secretary of State,,R,Kris Kobach,34,29,4,1
-Norton,Solomon Precinct 1,Secretary of State,,R,Kris Kobach,24,23,1,0
-Norton,Sandcreek-Sol 1,Secretary of State,,R,Kris Kobach,4,3,1,0
-Norton,Solomon Precinct 2,Secretary of State,,R,Kris Kobach,11,11,0,0
-Norton,Norton Ward 1,Secretary of State,,R,Kris Kobach,225,197,26,2
-Norton,Norton Ward 2,Secretary of State,,R,Kris Kobach,309,260,45,4
-Norton,Norton Ward 3,Secretary of State,,R,Kris Kobach,244,205,35,4
-Norton,Almena Township,Secretary of State,,D,Jean Schodorf,24,23,1,0
-Norton,Center Precinct 1,Secretary of State,,D,Jean Schodorf,43,33,10,0
-Norton,Belle Plaine,Secretary of State,,D,Jean Schodorf,1,0,1,0
-Norton,Center Precinct 2,Secretary of State,,D,Jean Schodorf,15,8,7,0
-Norton,Highland Precinct 1,Secretary of State,,D,Jean Schodorf,39,34,5,0
-Norton,Highland Precinct 2,Secretary of State,,D,Jean Schodorf,6,5,1,0
-Norton,Highland Precinct 3,Secretary of State,,D,Jean Schodorf,0,0,0,0
-Norton,Solomon Precinct 1,Secretary of State,,D,Jean Schodorf,0,0,0,0
-Norton,Sandcreek-Sol 1,Secretary of State,,D,Jean Schodorf,2,1,1,0
-Norton,Solomon Precinct 2,Secretary of State,,D,Jean Schodorf,1,1,0,0
-Norton,Norton Ward 1,Secretary of State,,D,Jean Schodorf,59,53,6,0
-Norton,Norton Ward 2,Secretary of State,,D,Jean Schodorf,89,53,34,2
-Norton,Norton Ward 3,Secretary of State,,D,Jean Schodorf,67,51,15,1
-Norton,Norton Ward 2,Secretary of State,,,Kylie Ulrich,1,1,0,0
-Norton,Almena Township,Attorney General,,R,Derek Schmidt,166,162,4,0
-Norton,Center Precinct 1,Attorney General,,R,Derek Schmidt,213,178,34,1
-Norton,Belle Plaine,Attorney General,,R,Derek Schmidt,9,9,0,0
-Norton,Center Precinct 2,Attorney General,,R,Derek Schmidt,54,39,15,0
-Norton,Highland Precinct 1,Attorney General,,R,Derek Schmidt,149,135,14,0
-Norton,Highland Precinct 2,Attorney General,,R,Derek Schmidt,32,27,5,0
-Norton,Highland Precinct 3,Attorney General,,R,Derek Schmidt,34,29,4,1
-Norton,Solomon Precinct 1,Attorney General,,R,Derek Schmidt,24,23,1,0
-Norton,Sandcreek-Sol 1,Attorney General,,R,Derek Schmidt,4,3,1,0
-Norton,Solomon Precinct 2,Attorney General,,R,Derek Schmidt,10,10,0,0
-Norton,Norton Ward 1,Attorney General,,R,Derek Schmidt,235,204,29,2
-Norton,Norton Ward 2,Attorney General,,R,Derek Schmidt,319,258,55,6
-Norton,Norton Ward 3,Attorney General,,R,Derek Schmidt,254,213,37,4
-Norton,Almena Township,Attorney General,,D,A J Kotich,23,22,1,0
-Norton,Center Precinct 1,Attorney General,,D,A J Kotich,35,27,8,0
-Norton,Belle Plaine,Attorney General,,D,A J Kotich,2,1,1,0
-Norton,Center Precinct 2,Attorney General,,D,A J Kotich,8,7,1,0
-Norton,Highland Precinct 1,Attorney General,,D,A J Kotich,21,20,1,0
-Norton,Highland Precinct 2,Attorney General,,D,A J Kotich,5,4,1,0
-Norton,Highland Precinct 3,Attorney General,,D,A J Kotich,1,1,0,0
-Norton,Solomon Precinct 1,Attorney General,,D,A J Kotich,2,2,0,0
-Norton,Sandcreek-Sol 1,Attorney General,,D,A J Kotich,1,1,0,0
-Norton,Solomon Precinct 2,Attorney General,,D,A J Kotich,2,2,0,0
-Norton,Norton Ward 1,Attorney General,,D,A J Kotich,40,37,3,0
-Norton,Norton Ward 2,Attorney General,,D,A J Kotich,65,43,21,1
-Norton,Norton Ward 3,Attorney General,,D,A J Kotich,60,45,14,1
-Norton,Almena Township,State Treasurer,,R,Ron Estes,170,166,4,0
-Norton,Center Precinct 1,State Treasurer,,R,Ron Estes,214,181,32,1
-Norton,Belle Plaine,State Treasurer,,R,Ron Estes,9,9,0,0
-Norton,Center Precinct 2,State Treasurer,,R,Ron Estes,47,38,9,0
-Norton,Highland Precinct 1,State Treasurer,,R,Ron Estes,144,130,14,0
-Norton,Highland Precinct 2,State Treasurer,,R,Ron Estes,32,28,4,0
-Norton,Highland Precinct 3,State Treasurer,,R,Ron Estes,35,30,4,1
-Norton,Solomon Precinct 1,State Treasurer,,R,Ron Estes,25,24,1,0
-Norton,Sandcreek-Sol 1,State Treasurer,,R,Ron Estes,4,3,1,0
-Norton,Solomon Precinct 2,State Treasurer,,R,Ron Estes,11,11,0,0
-Norton,Norton Ward 1,State Treasurer,,R,Ron Estes,238,208,28,2
-Norton,Norton Ward 2,State Treasurer,,R,Ron Estes,326,267,55,4
-Norton,Norton Ward 3,State Treasurer,,R,Ron Estes,258,219,35,4
-Norton,Almena Township,State Treasurer,,D,Carmen Alldritt,21,20,1,0
-Norton,Center Precinct 1,State Treasurer,,D,Carmen Alldritt,37,28,9,0
-Norton,Belle Plaine,State Treasurer,,D,Carmen Alldritt,2,1,1,0
-Norton,Center Precinct 2,State Treasurer,,D,Carmen Alldritt,9,7,2,0
-Norton,Highland Precinct 1,State Treasurer,,D,Carmen Alldritt,24,23,1,0
-Norton,Highland Precinct 2,State Treasurer,,D,Carmen Alldritt,5,3,2,0
-Norton,Highland Precinct 3,State Treasurer,,D,Carmen Alldritt,0,0,0,0
-Norton,Solomon Precinct 1,State Treasurer,,D,Carmen Alldritt,1,1,0,0
-Norton,Sandcreek-Sol 1,State Treasurer,,D,Carmen Alldritt,1,1,0,0
-Norton,Solomon Precinct 2,State Treasurer,,D,Carmen Alldritt,1,1,0,0
-Norton,Norton Ward 1,State Treasurer,,D,Carmen Alldritt,41,38,3,0
-Norton,Norton Ward 2,State Treasurer,,D,Carmen Alldritt,58,36,21,1
-Norton,Norton Ward 3,State Treasurer,,D,Carmen Alldritt,56,40,15,1
-Norton,Almena Township,Insurance Commissioner,,R,Ken Selzer,154,151,3,0
-Norton,Center Precinct 1,Insurance Commissioner,,R,Ken Selzer,199,168,30,1
-Norton,Belle Plaine,Insurance Commissioner,,R,Ken Selzer,10,10,0,0
-Norton,Center Precinct 2,Insurance Commissioner,,R,Ken Selzer,42,34,8,0
-Norton,Highland Precinct 1,Insurance Commissioner,,R,Ken Selzer,132,122,10,0
-Norton,Highland Precinct 2,Insurance Commissioner,,R,Ken Selzer,27,22,5,0
-Norton,Highland Precinct 3,Insurance Commissioner,,R,Ken Selzer,33,28,4,1
-Norton,Solomon Precinct 1,Insurance Commissioner,,R,Ken Selzer,24,23,1,0
-Norton,Sandcreek-Sol 1,Insurance Commissioner,,R,Ken Selzer,3,2,1,0
-Norton,Solomon Precinct 2,Insurance Commissioner,,R,Ken Selzer,10,10,0,0
-Norton,Norton Ward 1,Insurance Commissioner,,R,Ken Selzer,235,206,28,1
-Norton,Norton Ward 2,Insurance Commissioner,,R,Ken Selzer,282,233,44,5
-Norton,Norton Ward 3,Insurance Commissioner,,R,Ken Selzer,236,200,32,4
-Norton,Almena Township,Insurance Commissioner,,D,Dennis Anderson,32,30,2,0
-Norton,Center Precinct 1,Insurance Commissioner,,D,Dennis Anderson,38,28,10,0
-Norton,Belle Plaine,Insurance Commissioner,,D,Dennis Anderson,1,0,1,0
-Norton,Center Precinct 2,Insurance Commissioner,,D,Dennis Anderson,12,9,3,0
-Norton,Highland Precinct 1,Insurance Commissioner,,D,Dennis Anderson,33,29,4,0
-Norton,Highland Precinct 2,Insurance Commissioner,,D,Dennis Anderson,8,7,1,0
-Norton,Highland Precinct 3,Insurance Commissioner,,D,Dennis Anderson,2,2,0,0
-Norton,Solomon Precinct 1,Insurance Commissioner,,D,Dennis Anderson,1,1,0,0
-Norton,Sandcreek-Sol 1,Insurance Commissioner,,D,Dennis Anderson,1,1,0,0
-Norton,Solomon Precinct 2,Insurance Commissioner,,D,Dennis Anderson,2,2,0,0
-Norton,Norton Ward 1,Insurance Commissioner,,D,Dennis Anderson,46,43,3,0
-Norton,Norton Ward 2,Insurance Commissioner,,D,Dennis Anderson,85,62,22,1
-Norton,Norton Ward 3,Insurance Commissioner,,D,Dennis Anderson,69,50,18,1
-Norton,Highland Precinct 1,Insurance Commissioner,,,Write-ins,1,1,0,0
-Norton,Norton Ward 2,Insurance Commissioner,,,Ron Estes,2,0,2,0
-Norton,Almena Township,State House,110,R,Travis Couture-Lovelady,178,174,4,0
-Norton,Center Precinct 1,State House,110,R,Travis Couture-Lovelady,227,191,35,1
-Norton,Belle Plaine,State House,110,R,Travis Couture-Lovelady,11,10,1,0
-Norton,Center Precinct 2,State House,110,R,Travis Couture-Lovelady,46,37,9,0
-Norton,Highland Precinct 1,State House,110,R,Travis Couture-Lovelady,155,141,14,0
-Norton,Highland Precinct 2,State House,110,R,Travis Couture-Lovelady,34,31,3,0
-Norton,Highland Precinct 3,State House,110,R,Travis Couture-Lovelady,34,29,4,1
-Norton,Solomon Precinct 1,State House,110,R,Travis Couture-Lovelady,25,24,1,0
-Norton,Sandcreek-Sol 1,State House,110,R,Travis Couture-Lovelady,4,4,0,0
-Norton,Solomon Precinct 2,State House,110,R,Travis Couture-Lovelady,11,11,0,0
-Norton,Norton Ward 1,State House,110,R,Travis Couture-Lovelady,261,231,28,2
-Norton,Norton Ward 2,State House,110,R,Travis Couture-Lovelady,342,274,61,7
-Norton,Norton Ward 3,State House,110,R,Travis Couture-Lovelady,273,230,38,5
-Norton,Almena Township,State House,110,,Write-ins,2,2,0,0
-Norton,Center Precinct 1,State House,110,,Write-ins,0,0,0,0
-Norton,Belle Plaine,State House,110,,Write-ins,0,0,0,0
-Norton,Center Precinct 2,State House,110,,Write-ins,1,1,0,0
-Norton,Highland Precinct 1,State House,110,,Write-ins,1,1,0,0
-Norton,Highland Precinct 2,State House,110,,Write-ins,0,0,0,0
-Norton,Highland Precinct 3,State House,110,,Write-ins,0,0,0,0
-Norton,Solomon Precinct 1,State House,110,,Write-ins,0,0,0,0
-Norton,Sandcreek-Sol 1,State House,110,,Write-ins,0,0,0,0
-Norton,Solomon Precinct 2,State House,110,,Write-ins,0,0,0,0
-Norton,Norton Ward 1,State House,110,,Write-ins,2,2,0,0
-Norton,Norton Ward 2,State House,110,,Write-ins,9,6,3,0
-Norton,Norton Ward 3,State House,110,,Write-ins,8,4,4,0
+county,precinct,office,district,party,candidate,votes,vtd
+NORTON,Almena Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000010
+NORTON,Almena Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000010
+NORTON,Almena Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",137,000010
+NORTON,Center Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000020
+NORTON,Center Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000020
+NORTON,Center Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",183,000020
+NORTON,Center Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000030
+NORTON,Center Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000030
+NORTON,Center Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000030
+NORTON,Harrison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000040
+NORTON,Harrison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+NORTON,Harrison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000040
+NORTON,Highland Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,000050
+NORTON,Highland Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000050
+NORTON,Highland Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",131,000050
+NORTON,Highland Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000060
+NORTON,Highland Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+NORTON,Highland Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000060
+NORTON,Highland Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000070
+NORTON,Highland Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000070
+NORTON,Highland Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000070
+NORTON,Norton Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000080
+NORTON,Norton Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000080
+NORTON,Norton Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",183,000080
+NORTON,Norton Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",127,000090
+NORTON,Norton Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000090
+NORTON,Norton Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",255,000090
+NORTON,Norton Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",110,000100
+NORTON,Norton Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000100
+NORTON,Norton Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",186,000100
+NORTON,Solomon Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000110
+NORTON,Solomon Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+NORTON,Solomon Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000110
+NORTON,Solomon Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000120
+NORTON,Solomon Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+NORTON,Solomon Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000120
+NORTON,Almena Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",178,000010
+NORTON,Center Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",227,000020
+NORTON,Center Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",46,000030
+NORTON,Harrison Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",0,000040
+NORTON,Highland Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",155,000050
+NORTON,Highland Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",34,000060
+NORTON,Highland Precinct 3,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",34,000070
+NORTON,Norton Ward 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",261,000080
+NORTON,Norton Ward 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",340,000090
+NORTON,Norton Ward 3,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",273,000100
+NORTON,Solomon Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",42,000110
+NORTON,Solomon Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",11,000120
+NORTON,Almena Township,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000010
+NORTON,Almena Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",158,000010
+NORTON,Center Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",37,000020
+NORTON,Center Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",219,000020
+NORTON,Center Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000030
+NORTON,Center Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000030
+NORTON,Harrison Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000040
+NORTON,Harrison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000040
+NORTON,Highland Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",41,000050
+NORTON,Highland Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",133,000050
+NORTON,Highland Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000060
+NORTON,Highland Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000060
+NORTON,Highland Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000070
+NORTON,Highland Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000070
+NORTON,Norton Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",55,000080
+NORTON,Norton Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",233,000080
+NORTON,Norton Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",90,000090
+NORTON,Norton Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",304,000090
+NORTON,Norton Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",79,000100
+NORTON,Norton Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",236,000100
+NORTON,Solomon Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000110
+NORTON,Solomon Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000110
+NORTON,Solomon Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000120
+NORTON,Solomon Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000120
+NORTON,Almena Township,Attorney General,,Democratic,"Kotich, A.J.",23,000010
+NORTON,Almena Township,Attorney General,,Republican,"Schmidt, Derek",166,000010
+NORTON,Center Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",35,000020
+NORTON,Center Precinct 1,Attorney General,,Republican,"Schmidt, Derek",213,000020
+NORTON,Center Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",8,000030
+NORTON,Center Precinct 2,Attorney General,,Republican,"Schmidt, Derek",49,000030
+NORTON,Harrison Township,Attorney General,,Democratic,"Kotich, A.J.",0,000040
+NORTON,Harrison Township,Attorney General,,Republican,"Schmidt, Derek",0,000040
+NORTON,Highland Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",21,000050
+NORTON,Highland Precinct 1,Attorney General,,Republican,"Schmidt, Derek",149,000050
+NORTON,Highland Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",5,000060
+NORTON,Highland Precinct 2,Attorney General,,Republican,"Schmidt, Derek",32,000060
+NORTON,Highland Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",1,000070
+NORTON,Highland Precinct 3,Attorney General,,Republican,"Schmidt, Derek",34,000070
+NORTON,Norton Ward 1,Attorney General,,Democratic,"Kotich, A.J.",40,000080
+NORTON,Norton Ward 1,Attorney General,,Republican,"Schmidt, Derek",240,000080
+NORTON,Norton Ward 2,Attorney General,,Democratic,"Kotich, A.J.",65,000090
+NORTON,Norton Ward 2,Attorney General,,Republican,"Schmidt, Derek",319,000090
+NORTON,Norton Ward 3,Attorney General,,Democratic,"Kotich, A.J.",60,000100
+NORTON,Norton Ward 3,Attorney General,,Republican,"Schmidt, Derek",254,000100
+NORTON,Solomon Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",5,000110
+NORTON,Solomon Precinct 1,Attorney General,,Republican,"Schmidt, Derek",37,000110
+NORTON,Solomon Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",2,000120
+NORTON,Solomon Precinct 2,Attorney General,,Republican,"Schmidt, Derek",10,000120
+NORTON,Almena Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,000010
+NORTON,Almena Township,Commissioner of Insurance,,Republican,"Selzer, Ken",154,000010
+NORTON,Center Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000020
+NORTON,Center Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",199,000020
+NORTON,Center Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000030
+NORTON,Center Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000030
+NORTON,Harrison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000040
+NORTON,Harrison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000040
+NORTON,Highland Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000050
+NORTON,Highland Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000050
+NORTON,Highland Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000060
+NORTON,Highland Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000060
+NORTON,Highland Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000070
+NORTON,Highland Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000070
+NORTON,Norton Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000080
+NORTON,Norton Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",229,000080
+NORTON,Norton Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",85,000090
+NORTON,Norton Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",287,000090
+NORTON,Norton Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000100
+NORTON,Norton Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",236,000100
+NORTON,Solomon Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000110
+NORTON,Solomon Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000110
+NORTON,Solomon Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000120
+NORTON,Solomon Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000120
+NORTON,Almena Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000010
+NORTON,Almena Township,Secretary of State,,Republican,"Kobach, Kris",170,000010
+NORTON,Center Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000020
+NORTON,Center Precinct 1,Secretary of State,,Republican,"Kobach, Kris",207,000020
+NORTON,Center Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000030
+NORTON,Center Precinct 2,Secretary of State,,Republican,"Kobach, Kris",47,000030
+NORTON,Harrison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000040
+NORTON,Harrison Township,Secretary of State,,Republican,"Kobach, Kris",0,000040
+NORTON,Highland Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000050
+NORTON,Highland Precinct 1,Secretary of State,,Republican,"Kobach, Kris",128,000050
+NORTON,Highland Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000060
+NORTON,Highland Precinct 2,Secretary of State,,Republican,"Kobach, Kris",31,000060
+NORTON,Highland Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000070
+NORTON,Highland Precinct 3,Secretary of State,,Republican,"Kobach, Kris",34,000070
+NORTON,Norton Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000080
+NORTON,Norton Ward 1,Secretary of State,,Republican,"Kobach, Kris",225,000080
+NORTON,Norton Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,000090
+NORTON,Norton Ward 2,Secretary of State,,Republican,"Kobach, Kris",299,000090
+NORTON,Norton Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000100
+NORTON,Norton Ward 3,Secretary of State,,Republican,"Kobach, Kris",244,000100
+NORTON,Solomon Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000110
+NORTON,Solomon Precinct 1,Secretary of State,,Republican,"Kobach, Kris",38,000110
+NORTON,Solomon Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000120
+NORTON,Solomon Precinct 2,Secretary of State,,Republican,"Kobach, Kris",11,000120
+NORTON,Almena Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000010
+NORTON,Almena Township,State Treasurer,,Republican,"Estes, Ron",170,000010
+NORTON,Center Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",37,000020
+NORTON,Center Precinct 1,State Treasurer,,Republican,"Estes, Ron",214,000020
+NORTON,Center Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",9,000030
+NORTON,Center Precinct 2,State Treasurer,,Republican,"Estes, Ron",47,000030
+NORTON,Harrison Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+NORTON,Harrison Township,State Treasurer,,Republican,"Estes, Ron",0,000040
+NORTON,Highland Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",24,000050
+NORTON,Highland Precinct 1,State Treasurer,,Republican,"Estes, Ron",144,000050
+NORTON,Highland Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",5,000060
+NORTON,Highland Precinct 2,State Treasurer,,Republican,"Estes, Ron",32,000060
+NORTON,Highland Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,000070
+NORTON,Highland Precinct 3,State Treasurer,,Republican,"Estes, Ron",35,000070
+NORTON,Norton Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",41,000080
+NORTON,Norton Ward 1,State Treasurer,,Republican,"Estes, Ron",238,000080
+NORTON,Norton Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",58,000090
+NORTON,Norton Ward 2,State Treasurer,,Republican,"Estes, Ron",326,000090
+NORTON,Norton Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",56,000100
+NORTON,Norton Ward 3,State Treasurer,,Republican,"Estes, Ron",259,000100
+NORTON,Solomon Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",4,000110
+NORTON,Solomon Precinct 1,State Treasurer,,Republican,"Estes, Ron",38,000110
+NORTON,Solomon Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",1,000120
+NORTON,Solomon Precinct 2,State Treasurer,,Republican,"Estes, Ron",11,000120
+NORTON,Almena Township,United States Senate,,independent,"Orman, Greg",34,000010
+NORTON,Almena Township,United States Senate,,Libertarian,"Batson, Randall",7,000010
+NORTON,Almena Township,United States Senate,,Republican,"Roberts, Pat",151,000010
+NORTON,Center Precinct 1,United States Senate,,independent,"Orman, Greg",54,000020
+NORTON,Center Precinct 1,United States Senate,,Libertarian,"Batson, Randall",7,000020
+NORTON,Center Precinct 1,United States Senate,,Republican,"Roberts, Pat",199,000020
+NORTON,Center Precinct 2,United States Senate,,independent,"Orman, Greg",9,000030
+NORTON,Center Precinct 2,United States Senate,,Libertarian,"Batson, Randall",0,000030
+NORTON,Center Precinct 2,United States Senate,,Republican,"Roberts, Pat",50,000030
+NORTON,Harrison Township,United States Senate,,independent,"Orman, Greg",0,000040
+NORTON,Harrison Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+NORTON,Harrison Township,United States Senate,,Republican,"Roberts, Pat",0,000040
+NORTON,Highland Precinct 1,United States Senate,,independent,"Orman, Greg",33,000050
+NORTON,Highland Precinct 1,United States Senate,,Libertarian,"Batson, Randall",13,000050
+NORTON,Highland Precinct 1,United States Senate,,Republican,"Roberts, Pat",132,000050
+NORTON,Highland Precinct 2,United States Senate,,independent,"Orman, Greg",8,000060
+NORTON,Highland Precinct 2,United States Senate,,Libertarian,"Batson, Randall",2,000060
+NORTON,Highland Precinct 2,United States Senate,,Republican,"Roberts, Pat",27,000060
+NORTON,Highland Precinct 3,United States Senate,,independent,"Orman, Greg",4,000070
+NORTON,Highland Precinct 3,United States Senate,,Libertarian,"Batson, Randall",3,000070
+NORTON,Highland Precinct 3,United States Senate,,Republican,"Roberts, Pat",28,000070
+NORTON,Norton Ward 1,United States Senate,,independent,"Orman, Greg",60,000080
+NORTON,Norton Ward 1,United States Senate,,Libertarian,"Batson, Randall",19,000080
+NORTON,Norton Ward 1,United States Senate,,Republican,"Roberts, Pat",209,000080
+NORTON,Norton Ward 2,United States Senate,,independent,"Orman, Greg",100,000090
+NORTON,Norton Ward 2,United States Senate,,Libertarian,"Batson, Randall",14,000090
+NORTON,Norton Ward 2,United States Senate,,Republican,"Roberts, Pat",278,000090
+NORTON,Norton Ward 3,United States Senate,,independent,"Orman, Greg",83,000100
+NORTON,Norton Ward 3,United States Senate,,Libertarian,"Batson, Randall",22,000100
+NORTON,Norton Ward 3,United States Senate,,Republican,"Roberts, Pat",211,000100
+NORTON,Solomon Precinct 1,United States Senate,,independent,"Orman, Greg",5,000110
+NORTON,Solomon Precinct 1,United States Senate,,Libertarian,"Batson, Randall",0,000110
+NORTON,Solomon Precinct 1,United States Senate,,Republican,"Roberts, Pat",40,000110
+NORTON,Solomon Precinct 2,United States Senate,,independent,"Orman, Greg",0,000120
+NORTON,Solomon Precinct 2,United States Senate,,Libertarian,"Batson, Randall",0,000120
+NORTON,Solomon Precinct 2,United States Senate,,Republican,"Roberts, Pat",14,000120

--- a/2014/20141104__ks__general__osage__precinct.csv
+++ b/2014/20141104__ks__general__osage__precinct.csv
@@ -1,494 +1,550 @@
-county,precinct,office,district,party,candidate,votes
-Osage,09 Grant Township,Voters,,,Ballots Cast,119
-Osage,01 Agency Township,Voters,,,Ballots Cast,154
-Osage,02 Arvonia Township,Voters,,,Ballots Cast,56
-Osage,03 Barclay Township,Voters,,,Ballots Cast,83
-Osage,06 Dragoon Township,Voters,,,Ballots Cast,96
-Osage,07 Elk Township,Voters,,,Ballots Cast,747
-Osage,08 Fairfax Township,Voters,,,Ballots Cast,255
-Osage,12 Lincoln Township,Voters,,,Ballots Cast,43
-Osage,13 Melvern Township,Voters,,,Ballots Cast,248
-Osage,10 Michigan Valley Township,Voters,,,Ballots Cast,167
-Osage,04 North Burlingame,Voters,,,Ballots Cast,351
-Osage,15 North Ridgeway,Voters,,,Ballots Cast,435
-Osage,19 North Valleybrook,Voters,,,Ballots Cast,397
-Osage,14 Olivet Township,Voters,,,Ballots Cast,93
-Osage,21 Osage City Ward 1,Voters,,,Ballots Cast,286
-Osage,22 Osage City Ward 2,Voters,,,Ballots Cast,156
-Osage,23 Osage City Ward 3,Voters,,,Ballots Cast,202
-Osage,24 Osage City Ward 4,Voters,,,Ballots Cast,262
-Osage,17 Scranton Township,Voters,,,Ballots Cast,369
-Osage,05 South Burlingame,Voters,,,Ballots Cast,311
-Osage,16 South Ridgeway,Voters,,,Ballots Cast,421
-Osage,20 South Valleybrook,Voters,,,Ballots Cast,166
-Osage,18 Superior Township,Voters,,,Ballots Cast,127
-Osage,11 Vassar Township,Voters,,,Ballots Cast,302
-Osage,09 Grant Township,U.S. Senate,,R,Pat Roberts,70
-Osage,01 Agency Township,U.S. Senate,,R,Pat Roberts,98
-Osage,02 Arvonia Township,U.S. Senate,,R,Pat Roberts,33
-Osage,03 Barclay Township,U.S. Senate,,R,Pat Roberts,47
-Osage,06 Dragoon Township,U.S. Senate,,R,Pat Roberts,58
-Osage,07 Elk Township,U.S. Senate,,R,Pat Roberts,447
-Osage,08 Fairfax Township,U.S. Senate,,R,Pat Roberts,146
-Osage,12 Lincoln Township,U.S. Senate,,R,Pat Roberts,28
-Osage,13 Melvern Township,U.S. Senate,,R,Pat Roberts,159
-Osage,10 Michigan Valley Township,U.S. Senate,,R,Pat Roberts,93
-Osage,04 North Burlingame,U.S. Senate,,R,Pat Roberts,187
-Osage,15 North Ridgeway,U.S. Senate,,R,Pat Roberts,218
-Osage,19 North Valleybrook,U.S. Senate,,R,Pat Roberts,207
-Osage,14 Olivet Township,U.S. Senate,,R,Pat Roberts,55
-Osage,21 Osage City Ward 1,U.S. Senate,,R,Pat Roberts,146
-Osage,22 Osage City Ward 2,U.S. Senate,,R,Pat Roberts,75
-Osage,23 Osage City Ward 3,U.S. Senate,,R,Pat Roberts,104
-Osage,24 Osage City Ward 4,U.S. Senate,,R,Pat Roberts,143
-Osage,17 Scranton Township,U.S. Senate,,R,Pat Roberts,213
-Osage,05 South Burlingame,U.S. Senate,,R,Pat Roberts,161
-Osage,16 South Ridgeway,U.S. Senate,,R,Pat Roberts,195
-Osage,20 South Valleybrook,U.S. Senate,,R,Pat Roberts,87
-Osage,18 Superior Township,U.S. Senate,,R,Pat Roberts,74
-Osage,11 Vassar Township,U.S. Senate,,R,Pat Roberts,154
-Osage,09 Grant Township,U.S. Senate,,IND,Greg Orman,43
-Osage,01 Agency Township,U.S. Senate,,IND,Greg Orman,46
-Osage,02 Arvonia Township,U.S. Senate,,IND,Greg Orman,22
-Osage,03 Barclay Township,U.S. Senate,,IND,Greg Orman,29
-Osage,06 Dragoon Township,U.S. Senate,,IND,Greg Orman,32
-Osage,07 Elk Township,U.S. Senate,,IND,Greg Orman,255
-Osage,08 Fairfax Township,U.S. Senate,,IND,Greg Orman,102
-Osage,12 Lincoln Township,U.S. Senate,,IND,Greg Orman,11
-Osage,13 Melvern Township,U.S. Senate,,IND,Greg Orman,77
-Osage,10 Michigan Valley Township,U.S. Senate,,IND,Greg Orman,64
-Osage,04 North Burlingame,U.S. Senate,,IND,Greg Orman,142
-Osage,15 North Ridgeway,U.S. Senate,,IND,Greg Orman,183
-Osage,19 North Valleybrook,U.S. Senate,,IND,Greg Orman,157
-Osage,14 Olivet Township,U.S. Senate,,IND,Greg Orman,34
-Osage,21 Osage City Ward 1,U.S. Senate,,IND,Greg Orman,121
-Osage,22 Osage City Ward 2,U.S. Senate,,IND,Greg Orman,69
-Osage,23 Osage City Ward 3,U.S. Senate,,IND,Greg Orman,83
-Osage,24 Osage City Ward 4,U.S. Senate,,IND,Greg Orman,109
-Osage,17 Scranton Township,U.S. Senate,,IND,Greg Orman,131
-Osage,05 South Burlingame,U.S. Senate,,IND,Greg Orman,123
-Osage,16 South Ridgeway,U.S. Senate,,IND,Greg Orman,196
-Osage,20 South Valleybrook,U.S. Senate,,IND,Greg Orman,64
-Osage,18 Superior Township,U.S. Senate,,IND,Greg Orman,49
-Osage,11 Vassar Township,U.S. Senate,,IND,Greg Orman,136
-Osage,09 Grant Township,U.S. Senate,,LBT,Randall Batson,5
-Osage,01 Agency Township,U.S. Senate,,LBT,Randall Batson,10
-Osage,02 Arvonia Township,U.S. Senate,,LBT,Randall Batson,1
-Osage,03 Barclay Township,U.S. Senate,,LBT,Randall Batson,6
-Osage,06 Dragoon Township,U.S. Senate,,LBT,Randall Batson,6
-Osage,07 Elk Township,U.S. Senate,,LBT,Randall Batson,35
-Osage,08 Fairfax Township,U.S. Senate,,LBT,Randall Batson,6
-Osage,12 Lincoln Township,U.S. Senate,,LBT,Randall Batson,3
-Osage,13 Melvern Township,U.S. Senate,,LBT,Randall Batson,10
-Osage,10 Michigan Valley Township,U.S. Senate,,LBT,Randall Batson,10
-Osage,04 North Burlingame,U.S. Senate,,LBT,Randall Batson,16
-Osage,15 North Ridgeway,U.S. Senate,,LBT,Randall Batson,28
-Osage,19 North Valleybrook,U.S. Senate,,LBT,Randall Batson,28
-Osage,14 Olivet Township,U.S. Senate,,LBT,Randall Batson,4
-Osage,21 Osage City Ward 1,U.S. Senate,,LBT,Randall Batson,18
-Osage,22 Osage City Ward 2,U.S. Senate,,LBT,Randall Batson,11
-Osage,23 Osage City Ward 3,U.S. Senate,,LBT,Randall Batson,11
-Osage,24 Osage City Ward 4,U.S. Senate,,LBT,Randall Batson,6
-Osage,17 Scranton Township,U.S. Senate,,LBT,Randall Batson,20
-Osage,05 South Burlingame,U.S. Senate,,LBT,Randall Batson,24
-Osage,16 South Ridgeway,U.S. Senate,,LBT,Randall Batson,27
-Osage,20 South Valleybrook,U.S. Senate,,LBT,Randall Batson,15
-Osage,18 Superior Township,U.S. Senate,,LBT,Randall Batson,4
-Osage,11 Vassar Township,U.S. Senate,,LBT,Randall Batson,11
-Osage,09 Grant Township,U.S. House,2,R,Lynn Jenkins,78
-Osage,01 Agency Township,U.S. House,2,R,Lynn Jenkins,110
-Osage,02 Arvonia Township,U.S. House,2,R,Lynn Jenkins,36
-Osage,03 Barclay Township,U.S. House,2,R,Lynn Jenkins,56
-Osage,06 Dragoon Township,U.S. House,2,R,Lynn Jenkins,61
-Osage,07 Elk Township,U.S. House,2,R,Lynn Jenkins,511
-Osage,08 Fairfax Township,U.S. House,2,R,Lynn Jenkins,164
-Osage,12 Lincoln Township,U.S. House,2,R,Lynn Jenkins,29
-Osage,13 Melvern Township,U.S. House,2,R,Lynn Jenkins,176
-Osage,10 Michigan Valley Township,U.S. House,2,R,Lynn Jenkins,110
-Osage,04 North Burlingame,U.S. House,2,R,Lynn Jenkins,214
-Osage,15 North Ridgeway,U.S. House,2,R,Lynn Jenkins,261
-Osage,19 North Valleybrook,U.S. House,2,R,Lynn Jenkins,262
-Osage,14 Olivet Township,U.S. House,2,R,Lynn Jenkins,63
-Osage,21 Osage City Ward 1,U.S. House,2,R,Lynn Jenkins,167
-Osage,22 Osage City Ward 2,U.S. House,2,R,Lynn Jenkins,91
-Osage,23 Osage City Ward 3,U.S. House,2,R,Lynn Jenkins,121
-Osage,24 Osage City Ward 4,U.S. House,2,R,Lynn Jenkins,171
-Osage,17 Scranton Township,U.S. House,2,R,Lynn Jenkins,239
-Osage,05 South Burlingame,U.S. House,2,R,Lynn Jenkins,195
-Osage,16 South Ridgeway,U.S. House,2,R,Lynn Jenkins,244
-Osage,20 South Valleybrook,U.S. House,2,R,Lynn Jenkins,98
-Osage,18 Superior Township,U.S. House,2,R,Lynn Jenkins,85
-Osage,11 Vassar Township,U.S. House,2,R,Lynn Jenkins,185
-Osage,09 Grant Township,U.S. House,2,D,Margie Wakefield,33
-Osage,01 Agency Township,U.S. House,2,D,Margie Wakefield,31
-Osage,02 Arvonia Township,U.S. House,2,D,Margie Wakefield,20
-Osage,03 Barclay Township,U.S. House,2,D,Margie Wakefield,19
-Osage,06 Dragoon Township,U.S. House,2,D,Margie Wakefield,27
-Osage,07 Elk Township,U.S. House,2,D,Margie Wakefield,198
-Osage,08 Fairfax Township,U.S. House,2,D,Margie Wakefield,81
-Osage,12 Lincoln Township,U.S. House,2,D,Margie Wakefield,13
-Osage,13 Melvern Township,U.S. House,2,D,Margie Wakefield,59
-Osage,10 Michigan Valley Township,U.S. House,2,D,Margie Wakefield,52
-Osage,04 North Burlingame,U.S. House,2,D,Margie Wakefield,114
-Osage,15 North Ridgeway,U.S. House,2,D,Margie Wakefield,141
-Osage,19 North Valleybrook,U.S. House,2,D,Margie Wakefield,110
-Osage,14 Olivet Township,U.S. House,2,D,Margie Wakefield,24
-Osage,21 Osage City Ward 1,U.S. House,2,D,Margie Wakefield,104
-Osage,22 Osage City Ward 2,U.S. House,2,D,Margie Wakefield,52
-Osage,23 Osage City Ward 3,U.S. House,2,D,Margie Wakefield,70
-Osage,24 Osage City Ward 4,U.S. House,2,D,Margie Wakefield,76
-Osage,17 Scranton Township,U.S. House,2,D,Margie Wakefield,105
-Osage,05 South Burlingame,U.S. House,2,D,Margie Wakefield,92
-Osage,16 South Ridgeway,U.S. House,2,D,Margie Wakefield,155
-Osage,20 South Valleybrook,U.S. House,2,D,Margie Wakefield,50
-Osage,18 Superior Township,U.S. House,2,D,Margie Wakefield,29
-Osage,11 Vassar Township,U.S. House,2,D,Margie Wakefield,103
-Osage,09 Grant Township,U.S. House,2,LBT,Christopher Clemmons,7
-Osage,01 Agency Township,U.S. House,2,LBT,Christopher Clemmons,13
-Osage,02 Arvonia Township,U.S. House,2,LBT,Christopher Clemmons,0
-Osage,03 Barclay Township,U.S. House,2,LBT,Christopher Clemmons,8
-Osage,06 Dragoon Township,U.S. House,2,LBT,Christopher Clemmons,8
-Osage,07 Elk Township,U.S. House,2,LBT,Christopher Clemmons,31
-Osage,08 Fairfax Township,U.S. House,2,LBT,Christopher Clemmons,9
-Osage,12 Lincoln Township,U.S. House,2,LBT,Christopher Clemmons,1
-Osage,13 Melvern Township,U.S. House,2,LBT,Christopher Clemmons,12
-Osage,10 Michigan Valley Township,U.S. House,2,LBT,Christopher Clemmons,5
-Osage,04 North Burlingame,U.S. House,2,LBT,Christopher Clemmons,19
-Osage,15 North Ridgeway,U.S. House,2,LBT,Christopher Clemmons,29
-Osage,19 North Valleybrook,U.S. House,2,LBT,Christopher Clemmons,24
-Osage,14 Olivet Township,U.S. House,2,LBT,Christopher Clemmons,6
-Osage,21 Osage City Ward 1,U.S. House,2,LBT,Christopher Clemmons,13
-Osage,22 Osage City Ward 2,U.S. House,2,LBT,Christopher Clemmons,12
-Osage,23 Osage City Ward 3,U.S. House,2,LBT,Christopher Clemmons,8
-Osage,24 Osage City Ward 4,U.S. House,2,LBT,Christopher Clemmons,10
-Osage,17 Scranton Township,U.S. House,2,LBT,Christopher Clemmons,18
-Osage,05 South Burlingame,U.S. House,2,LBT,Christopher Clemmons,24
-Osage,16 South Ridgeway,U.S. House,2,LBT,Christopher Clemmons,19
-Osage,20 South Valleybrook,U.S. House,2,LBT,Christopher Clemmons,14
-Osage,18 Superior Township,U.S. House,2,LBT,Christopher Clemmons,12
-Osage,11 Vassar Township,U.S. House,2,LBT,Christopher Clemmons,12
-Osage,09 Grant Township,Governor,,R,Sam Brownback,63
-Osage,01 Agency Township,Governor,,R,Sam Brownback,89
-Osage,02 Arvonia Township,Governor,,R,Sam Brownback,24
-Osage,03 Barclay Township,Governor,,R,Sam Brownback,49
-Osage,06 Dragoon Township,Governor,,R,Sam Brownback,55
-Osage,07 Elk Township,Governor,,R,Sam Brownback,393
-Osage,08 Fairfax Township,Governor,,R,Sam Brownback,139
-Osage,12 Lincoln Township,Governor,,R,Sam Brownback,24
-Osage,13 Melvern Township,Governor,,R,Sam Brownback,128
-Osage,10 Michigan Valley Township,Governor,,R,Sam Brownback,86
-Osage,04 North Burlingame,Governor,,R,Sam Brownback,174
-Osage,15 North Ridgeway,Governor,,R,Sam Brownback,196
-Osage,19 North Valleybrook,Governor,,R,Sam Brownback,185
-Osage,14 Olivet Township,Governor,,R,Sam Brownback,54
-Osage,21 Osage City Ward 1,Governor,,R,Sam Brownback,135
-Osage,22 Osage City Ward 2,Governor,,R,Sam Brownback,63
-Osage,23 Osage City Ward 3,Governor,,R,Sam Brownback,80
-Osage,24 Osage City Ward 4,Governor,,R,Sam Brownback,119
-Osage,17 Scranton Township,Governor,,R,Sam Brownback,194
-Osage,05 South Burlingame,Governor,,R,Sam Brownback,148
-Osage,16 South Ridgeway,Governor,,R,Sam Brownback,180
-Osage,20 South Valleybrook,Governor,,R,Sam Brownback,76
-Osage,18 Superior Township,Governor,,R,Sam Brownback,69
-Osage,11 Vassar Township,Governor,,R,Sam Brownback,148
-Osage,09 Grant Township,Governor,,D,Paul Davis,45
-Osage,01 Agency Township,Governor,,D,Paul Davis,49
-Osage,02 Arvonia Township,Governor,,D,Paul Davis,25
-Osage,03 Barclay Township,Governor,,D,Paul Davis,27
-Osage,06 Dragoon Township,Governor,,D,Paul Davis,34
-Osage,07 Elk Township,Governor,,D,Paul Davis,307
-Osage,08 Fairfax Township,Governor,,D,Paul Davis,107
-Osage,12 Lincoln Township,Governor,,D,Paul Davis,14
-Osage,13 Melvern Township,Governor,,D,Paul Davis,102
-Osage,10 Michigan Valley Township,Governor,,D,Paul Davis,65
-Osage,04 North Burlingame,Governor,,D,Paul Davis,154
-Osage,15 North Ridgeway,Governor,,D,Paul Davis,204
-Osage,19 North Valleybrook,Governor,,D,Paul Davis,189
-Osage,14 Olivet Township,Governor,,D,Paul Davis,34
-Osage,21 Osage City Ward 1,Governor,,D,Paul Davis,139
-Osage,22 Osage City Ward 2,Governor,,D,Paul Davis,81
-Osage,23 Osage City Ward 3,Governor,,D,Paul Davis,109
-Osage,24 Osage City Ward 4,Governor,,D,Paul Davis,132
-Osage,17 Scranton Township,Governor,,D,Paul Davis,143
-Osage,05 South Burlingame,Governor,,D,Paul Davis,130
-Osage,16 South Ridgeway,Governor,,D,Paul Davis,213
-Osage,20 South Valleybrook,Governor,,D,Paul Davis,76
-Osage,18 Superior Township,Governor,,D,Paul Davis,50
-Osage,11 Vassar Township,Governor,,D,Paul Davis,144
-Osage,09 Grant Township,Governor,,LBT,Keen Umbehr,10
-Osage,01 Agency Township,Governor,,LBT,Keen Umbehr,15
-Osage,02 Arvonia Township,Governor,,LBT,Keen Umbehr,6
-Osage,03 Barclay Township,Governor,,LBT,Keen Umbehr,6
-Osage,06 Dragoon Township,Governor,,LBT,Keen Umbehr,7
-Osage,07 Elk Township,Governor,,LBT,Keen Umbehr,38
-Osage,08 Fairfax Township,Governor,,LBT,Keen Umbehr,8
-Osage,12 Lincoln Township,Governor,,LBT,Keen Umbehr,4
-Osage,13 Melvern Township,Governor,,LBT,Keen Umbehr,16
-Osage,10 Michigan Valley Township,Governor,,LBT,Keen Umbehr,16
-Osage,04 North Burlingame,Governor,,LBT,Keen Umbehr,22
-Osage,15 North Ridgeway,Governor,,LBT,Keen Umbehr,31
-Osage,19 North Valleybrook,Governor,,LBT,Keen Umbehr,20
-Osage,14 Olivet Township,Governor,,LBT,Keen Umbehr,5
-Osage,21 Osage City Ward 1,Governor,,LBT,Keen Umbehr,12
-Osage,22 Osage City Ward 2,Governor,,LBT,Keen Umbehr,11
-Osage,23 Osage City Ward 3,Governor,,LBT,Keen Umbehr,12
-Osage,24 Osage City Ward 4,Governor,,LBT,Keen Umbehr,8
-Osage,17 Scranton Township,Governor,,LBT,Keen Umbehr,31
-Osage,05 South Burlingame,Governor,,LBT,Keen Umbehr,29
-Osage,16 South Ridgeway,Governor,,LBT,Keen Umbehr,26
-Osage,20 South Valleybrook,Governor,,LBT,Keen Umbehr,13
-Osage,18 Superior Township,Governor,,LBT,Keen Umbehr,7
-Osage,11 Vassar Township,Governor,,LBT,Keen Umbehr,7
-Osage,09 Grant Township,Secretary of  State,,R,Kris Kobach,82
-Osage,01 Agency Township,Secretary of  State,,R,Kris Kobach,120
-Osage,02 Arvonia Township,Secretary of  State,,R,Kris Kobach,34
-Osage,03 Barclay Township,Secretary of  State,,R,Kris Kobach,59
-Osage,06 Dragoon Township,Secretary of  State,,R,Kris Kobach,64
-Osage,07 Elk Township,Secretary of  State,,R,Kris Kobach,510
-Osage,08 Fairfax Township,Secretary of  State,,R,Kris Kobach,173
-Osage,12 Lincoln Township,Secretary of  State,,R,Kris Kobach,26
-Osage,13 Melvern Township,Secretary of  State,,R,Kris Kobach,166
-Osage,10 Michigan Valley Township,Secretary of  State,,R,Kris Kobach,108
-Osage,04 North Burlingame,Secretary of  State,,R,Kris Kobach,230
-Osage,15 North Ridgeway,Secretary of  State,,R,Kris Kobach,280
-Osage,19 North Valleybrook,Secretary of  State,,R,Kris Kobach,268
-Osage,14 Olivet Township,Secretary of  State,,R,Kris Kobach,70
-Osage,21 Osage City Ward 1,Secretary of  State,,R,Kris Kobach,182
-Osage,22 Osage City Ward 2,Secretary of  State,,R,Kris Kobach,103
-Osage,23 Osage City Ward 3,Secretary of  State,,R,Kris Kobach,126
-Osage,24 Osage City Ward 4,Secretary of  State,,R,Kris Kobach,168
-Osage,17 Scranton Township,Secretary of  State,,R,Kris Kobach,258
-Osage,05 South Burlingame,Secretary of  State,,R,Kris Kobach,211
-Osage,16 South Ridgeway,Secretary of  State,,R,Kris Kobach,244
-Osage,20 South Valleybrook,Secretary of  State,,R,Kris Kobach,109
-Osage,18 Superior Township,Secretary of  State,,R,Kris Kobach,91
-Osage,11 Vassar Township,Secretary of  State,,R,Kris Kobach,189
-Osage,09 Grant Township,Secretary of  State,,D,Jean Schodorf,36
-Osage,01 Agency Township,Secretary of  State,,D,Jean Schodorf,34
-Osage,02 Arvonia Township,Secretary of  State,,D,Jean Schodorf,21
-Osage,03 Barclay Township,Secretary of  State,,D,Jean Schodorf,21
-Osage,06 Dragoon Township,Secretary of  State,,D,Jean Schodorf,30
-Osage,07 Elk Township,Secretary of  State,,D,Jean Schodorf,225
-Osage,08 Fairfax Township,Secretary of  State,,D,Jean Schodorf,81
-Osage,12 Lincoln Township,Secretary of  State,,D,Jean Schodorf,15
-Osage,13 Melvern Township,Secretary of  State,,D,Jean Schodorf,78
-Osage,10 Michigan Valley Township,Secretary of  State,,D,Jean Schodorf,57
-Osage,04 North Burlingame,Secretary of  State,,D,Jean Schodorf,114
-Osage,15 North Ridgeway,Secretary of  State,,D,Jean Schodorf,150
-Osage,19 North Valleybrook,Secretary of  State,,D,Jean Schodorf,121
-Osage,14 Olivet Township,Secretary of  State,,D,Jean Schodorf,22
-Osage,21 Osage City Ward 1,Secretary of  State,,D,Jean Schodorf,98
-Osage,22 Osage City Ward 2,Secretary of  State,,D,Jean Schodorf,52
-Osage,23 Osage City Ward 3,Secretary of  State,,D,Jean Schodorf,71
-Osage,24 Osage City Ward 4,Secretary of  State,,D,Jean Schodorf,83
-Osage,17 Scranton Township,Secretary of  State,,D,Jean Schodorf,105
-Osage,05 South Burlingame,Secretary of  State,,D,Jean Schodorf,99
-Osage,16 South Ridgeway,Secretary of  State,,D,Jean Schodorf,171
-Osage,20 South Valleybrook,Secretary of  State,,D,Jean Schodorf,54
-Osage,18 Superior Township,Secretary of  State,,D,Jean Schodorf,35
-Osage,11 Vassar Township,Secretary of  State,,D,Jean Schodorf,113
-Osage,09 Grant Township,Attorney General,,R,Derek Schmidt,88
-Osage,01 Agency Township,Attorney General,,R,Derek Schmidt,124
-Osage,02 Arvonia Township,Attorney General,,R,Derek Schmidt,38
-Osage,03 Barclay Township,Attorney General,,R,Derek Schmidt,67
-Osage,06 Dragoon Township,Attorney General,,R,Derek Schmidt,77
-Osage,07 Elk Township,Attorney General,,R,Derek Schmidt,548
-Osage,08 Fairfax Township,Attorney General,,R,Derek Schmidt,193
-Osage,12 Lincoln Township,Attorney General,,R,Derek Schmidt,32
-Osage,13 Melvern Township,Attorney General,,R,Derek Schmidt,186
-Osage,10 Michigan Valley Township,Attorney General,,R,Derek Schmidt,116
-Osage,04 North Burlingame,Attorney General,,R,Derek Schmidt,258
-Osage,15 North Ridgeway,Attorney General,,R,Derek Schmidt,308
-Osage,19 North Valleybrook,Attorney General,,R,Derek Schmidt,288
-Osage,14 Olivet Township,Attorney General,,R,Derek Schmidt,74
-Osage,21 Osage City Ward 1,Attorney General,,R,Derek Schmidt,190
-Osage,22 Osage City Ward 2,Attorney General,,R,Derek Schmidt,109
-Osage,23 Osage City Ward 3,Attorney General,,R,Derek Schmidt,142
-Osage,24 Osage City Ward 4,Attorney General,,R,Derek Schmidt,183
-Osage,17 Scranton Township,Attorney General,,R,Derek Schmidt,260
-Osage,05 South Burlingame,Attorney General,,R,Derek Schmidt,223
-Osage,16 South Ridgeway,Attorney General,,R,Derek Schmidt,266
-Osage,20 South Valleybrook,Attorney General,,R,Derek Schmidt,121
-Osage,18 Superior Township,Attorney General,,R,Derek Schmidt,98
-Osage,11 Vassar Township,Attorney General,,R,Derek Schmidt,205
-Osage,09 Grant Township,Attorney General,,D,A.J. Kotich,28
-Osage,01 Agency Township,Attorney General,,D,A.J. Kotich,30
-Osage,02 Arvonia Township,Attorney General,,D,A.J. Kotich,17
-Osage,03 Barclay Township,Attorney General,,D,A.J. Kotich,13
-Osage,06 Dragoon Township,Attorney General,,D,A.J. Kotich,18
-Osage,07 Elk Township,Attorney General,,D,A.J. Kotich,179
-Osage,08 Fairfax Township,Attorney General,,D,A.J. Kotich,60
-Osage,12 Lincoln Township,Attorney General,,D,A.J. Kotich,9
-Osage,13 Melvern Township,Attorney General,,D,A.J. Kotich,54
-Osage,10 Michigan Valley Township,Attorney General,,D,A.J. Kotich,46
-Osage,04 North Burlingame,Attorney General,,D,A.J. Kotich,83
-Osage,15 North Ridgeway,Attorney General,,D,A.J. Kotich,120
-Osage,19 North Valleybrook,Attorney General,,D,A.J. Kotich,96
-Osage,14 Olivet Township,Attorney General,,D,A.J. Kotich,16
-Osage,21 Osage City Ward 1,Attorney General,,D,A.J. Kotich,87
-Osage,22 Osage City Ward 2,Attorney General,,D,A.J. Kotich,45
-Osage,23 Osage City Ward 3,Attorney General,,D,A.J. Kotich,57
-Osage,24 Osage City Ward 4,Attorney General,,D,A.J. Kotich,68
-Osage,17 Scranton Township,Attorney General,,D,A.J. Kotich,100
-Osage,05 South Burlingame,Attorney General,,D,A.J. Kotich,81
-Osage,16 South Ridgeway,Attorney General,,D,A.J. Kotich,146
-Osage,20 South Valleybrook,Attorney General,,D,A.J. Kotich,44
-Osage,18 Superior Township,Attorney General,,D,A.J. Kotich,27
-Osage,11 Vassar Township,Attorney General,,D,A.J. Kotich,92
-Osage,09 Grant Township,State Treasurer,,R,Ron Estes,95
-Osage,01 Agency Township,State Treasurer,,R,Ron Estes,117
-Osage,02 Arvonia Township,State Treasurer,,R,Ron Estes,40
-Osage,03 Barclay Township,State Treasurer,,R,Ron Estes,73
-Osage,06 Dragoon Township,State Treasurer,,R,Ron Estes,69
-Osage,07 Elk Township,State Treasurer,,R,Ron Estes,525
-Osage,08 Fairfax Township,State Treasurer,,R,Ron Estes,189
-Osage,12 Lincoln Township,State Treasurer,,R,Ron Estes,26
-Osage,13 Melvern Township,State Treasurer,,R,Ron Estes,173
-Osage,10 Michigan Valley Township,State Treasurer,,R,Ron Estes,112
-Osage,04 North Burlingame,State Treasurer,,R,Ron Estes,251
-Osage,15 North Ridgeway,State Treasurer,,R,Ron Estes,282
-Osage,19 North Valleybrook,State Treasurer,,R,Ron Estes,288
-Osage,14 Olivet Township,State Treasurer,,R,Ron Estes,72
-Osage,21 Osage City Ward 1,State Treasurer,,R,Ron Estes,211
-Osage,22 Osage City Ward 2,State Treasurer,,R,Ron Estes,118
-Osage,23 Osage City Ward 3,State Treasurer,,R,Ron Estes,142
-Osage,24 Osage City Ward 4,State Treasurer,,R,Ron Estes,184
-Osage,17 Scranton Township,State Treasurer,,R,Ron Estes,254
-Osage,05 South Burlingame,State Treasurer,,R,Ron Estes,213
-Osage,16 South Ridgeway,State Treasurer,,R,Ron Estes,257
-Osage,20 South Valleybrook,State Treasurer,,R,Ron Estes,111
-Osage,18 Superior Township,State Treasurer,,R,Ron Estes,102
-Osage,11 Vassar Township,State Treasurer,,R,Ron Estes,199
-Osage,09 Grant Township,State Treasurer,,D,Carmen Alldritt,21
-Osage,01 Agency Township,State Treasurer,,D,Carmen Alldritt,37
-Osage,02 Arvonia Township,State Treasurer,,D,Carmen Alldritt,16
-Osage,03 Barclay Township,State Treasurer,,D,Carmen Alldritt,8
-Osage,06 Dragoon Township,State Treasurer,,D,Carmen Alldritt,23
-Osage,07 Elk Township,State Treasurer,,D,Carmen Alldritt,202
-Osage,08 Fairfax Township,State Treasurer,,D,Carmen Alldritt,59
-Osage,12 Lincoln Township,State Treasurer,,D,Carmen Alldritt,16
-Osage,13 Melvern Township,State Treasurer,,D,Carmen Alldritt,66
-Osage,10 Michigan Valley Township,State Treasurer,,D,Carmen Alldritt,48
-Osage,04 North Burlingame,State Treasurer,,D,Carmen Alldritt,90
-Osage,15 North Ridgeway,State Treasurer,,D,Carmen Alldritt,138
-Osage,19 North Valleybrook,State Treasurer,,D,Carmen Alldritt,97
-Osage,14 Olivet Township,State Treasurer,,D,Carmen Alldritt,19
-Osage,21 Osage City Ward 1,State Treasurer,,D,Carmen Alldritt,68
-Osage,22 Osage City Ward 2,State Treasurer,,D,Carmen Alldritt,36
-Osage,23 Osage City Ward 3,State Treasurer,,D,Carmen Alldritt,54
-Osage,24 Osage City Ward 4,State Treasurer,,D,Carmen Alldritt,66
-Osage,17 Scranton Township,State Treasurer,,D,Carmen Alldritt,101
-Osage,05 South Burlingame,State Treasurer,,D,Carmen Alldritt,91
-Osage,16 South Ridgeway,State Treasurer,,D,Carmen Alldritt,153
-Osage,20 South Valleybrook,State Treasurer,,D,Carmen Alldritt,51
-Osage,18 Superior Township,State Treasurer,,D,Carmen Alldritt,23
-Osage,11 Vassar Township,State Treasurer,,D,Carmen Alldritt,97
-Osage,09 Grant Township,Insurance Commissioner,,R,Ken Selzer,81
-Osage,01 Agency Township,Insurance Commissioner,,R,Ken Selzer,106
-Osage,02 Arvonia Township,Insurance Commissioner,,R,Ken Selzer,35
-Osage,03 Barclay Township,Insurance Commissioner,,R,Ken Selzer,55
-Osage,06 Dragoon Township,Insurance Commissioner,,R,Ken Selzer,61
-Osage,07 Elk Township,Insurance Commissioner,,R,Ken Selzer,495
-Osage,08 Fairfax Township,Insurance Commissioner,,R,Ken Selzer,156
-Osage,12 Lincoln Township,Insurance Commissioner,,R,Ken Selzer,29
-Osage,13 Melvern Township,Insurance Commissioner,,R,Ken Selzer,163
-Osage,10 Michigan Valley Township,Insurance Commissioner,,R,Ken Selzer,105
-Osage,04 North Burlingame,Insurance Commissioner,,R,Ken Selzer,223
-Osage,15 North Ridgeway,Insurance Commissioner,,R,Ken Selzer,259
-Osage,19 North Valleybrook,Insurance Commissioner,,R,Ken Selzer,242
-Osage,14 Olivet Township,Insurance Commissioner,,R,Ken Selzer,60
-Osage,21 Osage City Ward 1,Insurance Commissioner,,R,Ken Selzer,159
-Osage,22 Osage City Ward 2,Insurance Commissioner,,R,Ken Selzer,88
-Osage,23 Osage City Ward 3,Insurance Commissioner,,R,Ken Selzer,113
-Osage,24 Osage City Ward 4,Insurance Commissioner,,R,Ken Selzer,156
-Osage,17 Scranton Township,Insurance Commissioner,,R,Ken Selzer,232
-Osage,05 South Burlingame,Insurance Commissioner,,R,Ken Selzer,185
-Osage,16 South Ridgeway,Insurance Commissioner,,R,Ken Selzer,231
-Osage,20 South Valleybrook,Insurance Commissioner,,R,Ken Selzer,101
-Osage,18 Superior Township,Insurance Commissioner,,R,Ken Selzer,86
-Osage,11 Vassar Township,Insurance Commissioner,,R,Ken Selzer,185
-Osage,09 Grant Township,Insurance Commissioner,,D,Dennis Anderson,34
-Osage,01 Agency Township,Insurance Commissioner,,D,Dennis Anderson,44
-Osage,02 Arvonia Township,Insurance Commissioner,,D,Dennis Anderson,19
-Osage,03 Barclay Township,Insurance Commissioner,,D,Dennis Anderson,25
-Osage,06 Dragoon Township,Insurance Commissioner,,D,Dennis Anderson,31
-Osage,07 Elk Township,Insurance Commissioner,,D,Dennis Anderson,228
-Osage,08 Fairfax Township,Insurance Commissioner,,D,Dennis Anderson,89
-Osage,12 Lincoln Township,Insurance Commissioner,,D,Dennis Anderson,12
-Osage,13 Melvern Township,Insurance Commissioner,,D,Dennis Anderson,73
-Osage,10 Michigan Valley Township,Insurance Commissioner,,D,Dennis Anderson,50
-Osage,04 North Burlingame,Insurance Commissioner,,D,Dennis Anderson,113
-Osage,15 North Ridgeway,Insurance Commissioner,,D,Dennis Anderson,155
-Osage,19 North Valleybrook,Insurance Commissioner,,D,Dennis Anderson,132
-Osage,14 Olivet Township,Insurance Commissioner,,D,Dennis Anderson,27
-Osage,21 Osage City Ward 1,Insurance Commissioner,,D,Dennis Anderson,118
-Osage,22 Osage City Ward 2,Insurance Commissioner,,D,Dennis Anderson,65
-Osage,23 Osage City Ward 3,Insurance Commissioner,,D,Dennis Anderson,80
-Osage,24 Osage City Ward 4,Insurance Commissioner,,D,Dennis Anderson,85
-Osage,17 Scranton Township,Insurance Commissioner,,D,Dennis Anderson,115
-Osage,05 South Burlingame,Insurance Commissioner,,D,Dennis Anderson,115
-Osage,16 South Ridgeway,Insurance Commissioner,,D,Dennis Anderson,175
-Osage,20 South Valleybrook,Insurance Commissioner,,D,Dennis Anderson,60
-Osage,18 Superior Township,Insurance Commissioner,,D,Dennis Anderson,38
-Osage,11 Vassar Township,Insurance Commissioner,,D,Dennis Anderson,112
-Osage,09 Grant Township,State House,76,R,Peggy Mast ,71
-Osage,01 Agency Township,State House,76,R,Peggy Mast ,92
-Osage,02 Arvonia Township,State House,76,R,Peggy Mast ,24
-Osage,03 Barclay Township,State House,76,R,Peggy Mast ,47
-Osage,06 Dragoon Township,State House,76,R,Peggy Mast ,57
-Osage,07 Elk Township,State House,54,R,Ken Corbet ,421
-Osage,08 Fairfax Township,State House,59,R,Blaine Finch ,163
-Osage,12 Lincoln Township,State House,76,R,Peggy Mast ,22
-Osage,13 Melvern Township,State House,76,R,Peggy Mast ,145
-Osage,10 Michigan Valley Township,State House,59,R,Blaine Finch ,107
-Osage,04 North Burlingame,State House,54,R,Ken Corbet ,204
-Osage,15 North Ridgeway,State House,54,R,Ken Corbet ,240
-Osage,19 North Valleybrook,State House,59,R,Blaine Finch ,259
-Osage,14 Olivet Township,State House,76,R,Peggy Mast ,53
-Osage,21 Osage City Ward 1,State House,76,R,Peggy Mast ,146
-Osage,22 Osage City Ward 2,State House,76,R,Peggy Mast ,82
-Osage,23 Osage City Ward 3,State House,76,R,Peggy Mast ,94
-Osage,24 Osage City Ward 4,State House,76,R,Peggy Mast ,138
-Osage,17 Scranton Township,State House,54,R,Ken Corbet ,242
-Osage,05 South Burlingame,State House,54,R,Ken Corbet ,187
-Osage,16 South Ridgeway,State House,54,R,Ken Corbet ,215
-Osage,20 South Valleybrook,State House,59,R,Blaine Finch ,102
-Osage,18 Superior Township,State House,76,R,Peggy Mast ,70
-Osage,11 Vassar Township,State House,59,R,Blaine Finch ,191
-Osage,09 Grant Township,State House,76,D,Teresa Briggs ,38
-Osage,01 Agency Township,State House,76,D,Teresa Briggs ,34
-Osage,02 Arvonia Township,State House,76,D,Teresa Briggs ,29
-Osage,03 Barclay Township,State House,76,D,Teresa Briggs ,26
-Osage,06 Dragoon Township,State House,76,D,Teresa Briggs ,26
-Osage,07 Elk Township,State House,54,D,Ann Mah ,315
-Osage,08 Fairfax Township,State House,59,D,Scott Barnhardt ,81
-Osage,12 Lincoln Township,State House,76,D,Teresa Briggs ,11
-Osage,13 Melvern Township,State House,76,D,Teresa Briggs ,56
-Osage,10 Michigan Valley Township,State House,59,D,Scott Barnhardt ,52
-Osage,04 North Burlingame,State House,54,D,Ann Mah ,141
-Osage,15 North Ridgeway,State House,54,D,Ann Mah ,189
-Osage,19 North Valleybrook,State House,59,D,Scott Barnhardt ,117
-Osage,14 Olivet Township,State House,76,D,Teresa Briggs ,26
-Osage,21 Osage City Ward 1,State House,76,D,Teresa Briggs ,110
-Osage,22 Osage City Ward 2,State House,76,D,Teresa Briggs ,53
-Osage,23 Osage City Ward 3,State House,76,D,Teresa Briggs ,87
-Osage,24 Osage City Ward 4,State House,76,D,Teresa Briggs ,99
-Osage,17 Scranton Township,State House,54,D,Ann Mah ,119
-Osage,05 South Burlingame,State House,54,D,Ann Mah ,121
-Osage,16 South Ridgeway,State House,54,D,Ann Mah ,201
-Osage,20 South Valleybrook,State House,59,D,Scott Barnhardt ,56
-Osage,18 Superior Township,State House,76,D,Teresa Briggs ,43
-Osage,11 Vassar Township,State House,59,D,Scott Barnhardt ,106
-Osage,09 Grant Township,State House,76,IND,Bill Otto ,8
-Osage,01 Agency Township,State House,76,IND,Bill Otto ,28
-Osage,02 Arvonia Township,State House,76,IND,Bill Otto ,3
-Osage,03 Barclay Township,State House,76,IND,Bill Otto ,10
-Osage,06 Dragoon Township,State House,76,IND,Bill Otto ,13
-Osage,12 Lincoln Township,State House,76,IND,Bill Otto ,10
-Osage,13 Melvern Township,State House,76,IND,Bill Otto ,45
-Osage,14 Olivet Township,State House,76,IND,Bill Otto ,14
-Osage,21 Osage City Ward 1,State House,76,IND,Bill Otto ,27
-Osage,22 Osage City Ward 2,State House,76,IND,Bill Otto ,19
-Osage,23 Osage City Ward 3,State House,76,IND,Bill Otto ,17
-Osage,24 Osage City Ward 4,State House,76,IND,Bill Otto ,17
-Osage,18 Superior Township,State House,76,IND,Bill Otto ,12
+county,precinct,office,district,party,candidate,votes,vtd
+OSAGE,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000007
+OSAGE,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000007
+OSAGE,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000007
+OSAGE,Agency Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000010
+OSAGE,Agency Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000010
+OSAGE,Agency Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000010
+OSAGE,Arvonia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000020
+OSAGE,Arvonia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000020
+OSAGE,Arvonia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000020
+OSAGE,Barclay Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000030
+OSAGE,Barclay Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000030
+OSAGE,Barclay Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000030
+OSAGE,Dragoon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000040
+OSAGE,Dragoon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000040
+OSAGE,Dragoon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000040
+OSAGE,Elk Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",307,000050
+OSAGE,Elk Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",38,000050
+OSAGE,Elk Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",393,000050
+OSAGE,Fairfax Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",107,000060
+OSAGE,Fairfax Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000060
+OSAGE,Fairfax Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",139,000060
+OSAGE,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000080
+OSAGE,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000080
+OSAGE,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000080
+OSAGE,Melvern Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",102,000090
+OSAGE,Melvern Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000090
+OSAGE,Melvern Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000090
+OSAGE,Michigan Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000100
+OSAGE,Michigan Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000100
+OSAGE,Michigan Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,000100
+OSAGE,North Burlingame,Governor / Lt. Governor,,Democratic,"Davis, Paul",154,000110
+OSAGE,North Burlingame,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000110
+OSAGE,North Burlingame,Governor / Lt. Governor,,Republican,"Brownback, Sam",174,000110
+OSAGE,North Ridgeway,Governor / Lt. Governor,,Democratic,"Davis, Paul",204,000120
+OSAGE,North Ridgeway,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",31,000120
+OSAGE,North Ridgeway,Governor / Lt. Governor,,Republican,"Brownback, Sam",196,000120
+OSAGE,North Valleybrook,Governor / Lt. Governor,,Democratic,"Davis, Paul",189,000130
+OSAGE,North Valleybrook,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000130
+OSAGE,North Valleybrook,Governor / Lt. Governor,,Republican,"Brownback, Sam",185,000130
+OSAGE,Olivet Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000140
+OSAGE,Olivet Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000140
+OSAGE,Olivet Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000140
+OSAGE,Osage City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",139,000150
+OSAGE,Osage City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000150
+OSAGE,Osage City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,000150
+OSAGE,Osage City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000160
+OSAGE,Osage City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000160
+OSAGE,Osage City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000160
+OSAGE,Osage City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",109,000170
+OSAGE,Osage City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000170
+OSAGE,Osage City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000170
+OSAGE,Osage City Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",132,000180
+OSAGE,Osage City Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000180
+OSAGE,Osage City Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000180
+OSAGE,Scranton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",143,000190
+OSAGE,Scranton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",31,000190
+OSAGE,Scranton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",194,000190
+OSAGE,South Burlingame,Governor / Lt. Governor,,Democratic,"Davis, Paul",130,000200
+OSAGE,South Burlingame,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",29,000200
+OSAGE,South Burlingame,Governor / Lt. Governor,,Republican,"Brownback, Sam",148,000200
+OSAGE,South Ridgeway,Governor / Lt. Governor,,Democratic,"Davis, Paul",213,000210
+OSAGE,South Ridgeway,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000210
+OSAGE,South Ridgeway,Governor / Lt. Governor,,Republican,"Brownback, Sam",180,000210
+OSAGE,South Valleybrook,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,000220
+OSAGE,South Valleybrook,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000220
+OSAGE,South Valleybrook,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000220
+OSAGE,Superior Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000230
+OSAGE,Superior Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000230
+OSAGE,Superior Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000230
+OSAGE,Vassar Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,000240
+OSAGE,Vassar Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000240
+OSAGE,Vassar Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",148,000240
+OSAGE,Superior Township Enclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+OSAGE,Superior Township Enclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+OSAGE,Superior Township Enclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+OSAGE,Grant Township Enclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+OSAGE,Grant Township Enclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+OSAGE,Grant Township Enclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+OSAGE,Grant Township Enclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+OSAGE,Grant Township Enclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+OSAGE,Grant Township Enclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+OSAGE,Osage City Ward 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+OSAGE,Osage City Ward 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+OSAGE,Osage City Ward 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+OSAGE,Grant Township,Kansas House of Representatives,76,independent,"Otto, Bill",8,000007
+OSAGE,Grant Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",38,000007
+OSAGE,Grant Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",71,000007
+OSAGE,Agency Township,Kansas House of Representatives,76,independent,"Otto, Bill",28,000010
+OSAGE,Agency Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",34,000010
+OSAGE,Agency Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",92,000010
+OSAGE,Arvonia Township,Kansas House of Representatives,76,independent,"Otto, Bill",3,000020
+OSAGE,Arvonia Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",29,000020
+OSAGE,Arvonia Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",24,000020
+OSAGE,Barclay Township,Kansas House of Representatives,76,independent,"Otto, Bill",10,000030
+OSAGE,Barclay Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",26,000030
+OSAGE,Barclay Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",47,000030
+OSAGE,Dragoon Township,Kansas House of Representatives,76,independent,"Otto, Bill",13,000040
+OSAGE,Dragoon Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",26,000040
+OSAGE,Dragoon Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",57,000040
+OSAGE,Elk Township,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",315,000050
+OSAGE,Elk Township,Kansas House of Representatives,54,Republican,"Corbet, Ken",421,000050
+OSAGE,Fairfax Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",81,000060
+OSAGE,Fairfax Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",163,000060
+OSAGE,Lincoln Township,Kansas House of Representatives,76,independent,"Otto, Bill",10,000080
+OSAGE,Lincoln Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",11,000080
+OSAGE,Lincoln Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",22,000080
+OSAGE,Melvern Township,Kansas House of Representatives,76,independent,"Otto, Bill",45,000090
+OSAGE,Melvern Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",56,000090
+OSAGE,Melvern Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",145,000090
+OSAGE,Michigan Valley Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",52,000100
+OSAGE,Michigan Valley Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",107,000100
+OSAGE,North Burlingame,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",141,000110
+OSAGE,North Burlingame,Kansas House of Representatives,54,Republican,"Corbet, Ken",204,000110
+OSAGE,North Ridgeway,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",189,000120
+OSAGE,North Ridgeway,Kansas House of Representatives,54,Republican,"Corbet, Ken",240,000120
+OSAGE,North Valleybrook,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",117,000130
+OSAGE,North Valleybrook,Kansas House of Representatives,59,Republican,"Finch, Blaine",259,000130
+OSAGE,Olivet Township,Kansas House of Representatives,76,independent,"Otto, Bill",14,000140
+OSAGE,Olivet Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",26,000140
+OSAGE,Olivet Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",53,000140
+OSAGE,Osage City Ward 1,Kansas House of Representatives,76,independent,"Otto, Bill",27,000150
+OSAGE,Osage City Ward 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",110,000150
+OSAGE,Osage City Ward 1,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",146,000150
+OSAGE,Osage City Ward 2,Kansas House of Representatives,76,independent,"Otto, Bill",19,000160
+OSAGE,Osage City Ward 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",53,000160
+OSAGE,Osage City Ward 2,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",82,000160
+OSAGE,Osage City Ward 3,Kansas House of Representatives,76,independent,"Otto, Bill",17,000170
+OSAGE,Osage City Ward 3,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",87,000170
+OSAGE,Osage City Ward 3,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",94,000170
+OSAGE,Osage City Ward 4,Kansas House of Representatives,76,independent,"Otto, Bill",17,000180
+OSAGE,Osage City Ward 4,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",99,000180
+OSAGE,Osage City Ward 4,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",138,000180
+OSAGE,Scranton Township,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",119,000190
+OSAGE,Scranton Township,Kansas House of Representatives,54,Republican,"Corbet, Ken",242,000190
+OSAGE,South Burlingame,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",121,000200
+OSAGE,South Burlingame,Kansas House of Representatives,54,Republican,"Corbet, Ken",187,000200
+OSAGE,South Ridgeway,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",201,000210
+OSAGE,South Ridgeway,Kansas House of Representatives,54,Republican,"Corbet, Ken",215,000210
+OSAGE,South Valleybrook,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",56,000220
+OSAGE,South Valleybrook,Kansas House of Representatives,59,Republican,"Finch, Blaine",102,000220
+OSAGE,Superior Township,Kansas House of Representatives,76,independent,"Otto, Bill",12,000230
+OSAGE,Superior Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",43,000230
+OSAGE,Superior Township,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",70,000230
+OSAGE,Vassar Township,Kansas House of Representatives,59,Democratic,"Barnhart, Scott James",106,000240
+OSAGE,Vassar Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",191,000240
+OSAGE,Superior Township Enclave 1,Kansas House of Representatives,76,independent,"Otto, Bill",0,900010
+OSAGE,Superior Township Enclave 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900010
+OSAGE,Superior Township Enclave 1,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,900010
+OSAGE,Grant Township Enclave 1,Kansas House of Representatives,76,independent,"Otto, Bill",0,900020
+OSAGE,Grant Township Enclave 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900020
+OSAGE,Grant Township Enclave 1,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,900020
+OSAGE,Grant Township Enclave 2,Kansas House of Representatives,76,independent,"Otto, Bill",0,900030
+OSAGE,Grant Township Enclave 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900030
+OSAGE,Grant Township Enclave 2,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,900030
+OSAGE,Osage City Ward 2 Exclave,Kansas House of Representatives,76,independent,"Otto, Bill",0,900040
+OSAGE,Osage City Ward 2 Exclave,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900040
+OSAGE,Osage City Ward 2 Exclave,Kansas House of Representatives,76,Republican,"Mast, Peggy L.",0,900040
+OSAGE,Grant Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",33,000007
+OSAGE,Grant Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000007
+OSAGE,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,000007
+OSAGE,Agency Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,000010
+OSAGE,Agency Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000010
+OSAGE,Agency Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,000010
+OSAGE,Arvonia Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",20,000020
+OSAGE,Arvonia Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000020
+OSAGE,Arvonia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,000020
+OSAGE,Barclay Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",19,000030
+OSAGE,Barclay Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000030
+OSAGE,Barclay Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,000030
+OSAGE,Dragoon Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,000040
+OSAGE,Dragoon Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000040
+OSAGE,Dragoon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000040
+OSAGE,Elk Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",198,000050
+OSAGE,Elk Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",31,000050
+OSAGE,Elk Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",511,000050
+OSAGE,Fairfax Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",81,000060
+OSAGE,Fairfax Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000060
+OSAGE,Fairfax Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",164,000060
+OSAGE,Lincoln Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",13,000080
+OSAGE,Lincoln Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000080
+OSAGE,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",29,000080
+OSAGE,Melvern Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",59,000090
+OSAGE,Melvern Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000090
+OSAGE,Melvern Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000090
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",52,000100
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000100
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,000100
+OSAGE,North Burlingame,United States House of Representatives,2,Democratic,"Wakefield, Margie",114,000110
+OSAGE,North Burlingame,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000110
+OSAGE,North Burlingame,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000110
+OSAGE,North Ridgeway,United States House of Representatives,2,Democratic,"Wakefield, Margie",141,000120
+OSAGE,North Ridgeway,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",29,000120
+OSAGE,North Ridgeway,United States House of Representatives,2,Republican,"Jenkins, Lynn",261,000120
+OSAGE,North Valleybrook,United States House of Representatives,2,Democratic,"Wakefield, Margie",110,000130
+OSAGE,North Valleybrook,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000130
+OSAGE,North Valleybrook,United States House of Representatives,2,Republican,"Jenkins, Lynn",262,000130
+OSAGE,Olivet Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",24,000140
+OSAGE,Olivet Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000140
+OSAGE,Olivet Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000140
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",104,000150
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000150
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000150
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",52,000160
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000160
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,000160
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",70,000170
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000170
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",121,000170
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",76,000180
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000180
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",171,000180
+OSAGE,Scranton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",105,000190
+OSAGE,Scranton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000190
+OSAGE,Scranton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",239,000190
+OSAGE,South Burlingame,United States House of Representatives,2,Democratic,"Wakefield, Margie",92,000200
+OSAGE,South Burlingame,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,000200
+OSAGE,South Burlingame,United States House of Representatives,2,Republican,"Jenkins, Lynn",195,000200
+OSAGE,South Ridgeway,United States House of Representatives,2,Democratic,"Wakefield, Margie",155,000210
+OSAGE,South Ridgeway,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000210
+OSAGE,South Ridgeway,United States House of Representatives,2,Republican,"Jenkins, Lynn",244,000210
+OSAGE,South Valleybrook,United States House of Representatives,2,Democratic,"Wakefield, Margie",50,000220
+OSAGE,South Valleybrook,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000220
+OSAGE,South Valleybrook,United States House of Representatives,2,Republican,"Jenkins, Lynn",98,000220
+OSAGE,Superior Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",29,000230
+OSAGE,Superior Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000230
+OSAGE,Superior Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,000230
+OSAGE,Vassar Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",103,000240
+OSAGE,Vassar Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000240
+OSAGE,Vassar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,000240
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+OSAGE,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",28,000007
+OSAGE,Grant Township,Attorney General,,Republican,"Schmidt, Derek",88,000007
+OSAGE,Agency Township,Attorney General,,Democratic,"Kotich, A.J.",30,000010
+OSAGE,Agency Township,Attorney General,,Republican,"Schmidt, Derek",124,000010
+OSAGE,Arvonia Township,Attorney General,,Democratic,"Kotich, A.J.",17,000020
+OSAGE,Arvonia Township,Attorney General,,Republican,"Schmidt, Derek",38,000020
+OSAGE,Barclay Township,Attorney General,,Democratic,"Kotich, A.J.",13,000030
+OSAGE,Barclay Township,Attorney General,,Republican,"Schmidt, Derek",67,000030
+OSAGE,Dragoon Township,Attorney General,,Democratic,"Kotich, A.J.",18,000040
+OSAGE,Dragoon Township,Attorney General,,Republican,"Schmidt, Derek",77,000040
+OSAGE,Elk Township,Attorney General,,Democratic,"Kotich, A.J.",179,000050
+OSAGE,Elk Township,Attorney General,,Republican,"Schmidt, Derek",548,000050
+OSAGE,Fairfax Township,Attorney General,,Democratic,"Kotich, A.J.",60,000060
+OSAGE,Fairfax Township,Attorney General,,Republican,"Schmidt, Derek",193,000060
+OSAGE,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",9,000080
+OSAGE,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",32,000080
+OSAGE,Melvern Township,Attorney General,,Democratic,"Kotich, A.J.",54,000090
+OSAGE,Melvern Township,Attorney General,,Republican,"Schmidt, Derek",186,000090
+OSAGE,Michigan Valley Township,Attorney General,,Democratic,"Kotich, A.J.",46,000100
+OSAGE,Michigan Valley Township,Attorney General,,Republican,"Schmidt, Derek",116,000100
+OSAGE,North Burlingame,Attorney General,,Democratic,"Kotich, A.J.",83,000110
+OSAGE,North Burlingame,Attorney General,,Republican,"Schmidt, Derek",258,000110
+OSAGE,North Ridgeway,Attorney General,,Democratic,"Kotich, A.J.",120,000120
+OSAGE,North Ridgeway,Attorney General,,Republican,"Schmidt, Derek",308,000120
+OSAGE,North Valleybrook,Attorney General,,Democratic,"Kotich, A.J.",96,000130
+OSAGE,North Valleybrook,Attorney General,,Republican,"Schmidt, Derek",288,000130
+OSAGE,Olivet Township,Attorney General,,Democratic,"Kotich, A.J.",16,000140
+OSAGE,Olivet Township,Attorney General,,Republican,"Schmidt, Derek",74,000140
+OSAGE,Osage City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",87,000150
+OSAGE,Osage City Ward 1,Attorney General,,Republican,"Schmidt, Derek",190,000150
+OSAGE,Osage City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",45,000160
+OSAGE,Osage City Ward 2,Attorney General,,Republican,"Schmidt, Derek",109,000160
+OSAGE,Osage City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",57,000170
+OSAGE,Osage City Ward 3,Attorney General,,Republican,"Schmidt, Derek",142,000170
+OSAGE,Osage City Ward 4,Attorney General,,Democratic,"Kotich, A.J.",68,000180
+OSAGE,Osage City Ward 4,Attorney General,,Republican,"Schmidt, Derek",183,000180
+OSAGE,Scranton Township,Attorney General,,Democratic,"Kotich, A.J.",100,000190
+OSAGE,Scranton Township,Attorney General,,Republican,"Schmidt, Derek",260,000190
+OSAGE,South Burlingame,Attorney General,,Democratic,"Kotich, A.J.",81,000200
+OSAGE,South Burlingame,Attorney General,,Republican,"Schmidt, Derek",223,000200
+OSAGE,South Ridgeway,Attorney General,,Democratic,"Kotich, A.J.",146,000210
+OSAGE,South Ridgeway,Attorney General,,Republican,"Schmidt, Derek",266,000210
+OSAGE,South Valleybrook,Attorney General,,Democratic,"Kotich, A.J.",44,000220
+OSAGE,South Valleybrook,Attorney General,,Republican,"Schmidt, Derek",121,000220
+OSAGE,Superior Township,Attorney General,,Democratic,"Kotich, A.J.",27,000230
+OSAGE,Superior Township,Attorney General,,Republican,"Schmidt, Derek",98,000230
+OSAGE,Vassar Township,Attorney General,,Democratic,"Kotich, A.J.",92,000240
+OSAGE,Vassar Township,Attorney General,,Republican,"Schmidt, Derek",205,000240
+OSAGE,Superior Township Enclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+OSAGE,Superior Township Enclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900010
+OSAGE,Grant Township Enclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+OSAGE,Grant Township Enclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900020
+OSAGE,Grant Township Enclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+OSAGE,Grant Township Enclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900030
+OSAGE,Osage City Ward 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+OSAGE,Osage City Ward 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900040
+OSAGE,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000007
+OSAGE,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",81,000007
+OSAGE,Agency Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",44,000010
+OSAGE,Agency Township,Commissioner of Insurance,,Republican,"Selzer, Ken",106,000010
+OSAGE,Arvonia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000020
+OSAGE,Arvonia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000020
+OSAGE,Barclay Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000030
+OSAGE,Barclay Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000030
+OSAGE,Dragoon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000040
+OSAGE,Dragoon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000040
+OSAGE,Elk Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",228,000050
+OSAGE,Elk Township,Commissioner of Insurance,,Republican,"Selzer, Ken",495,000050
+OSAGE,Fairfax Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",89,000060
+OSAGE,Fairfax Township,Commissioner of Insurance,,Republican,"Selzer, Ken",156,000060
+OSAGE,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000080
+OSAGE,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000080
+OSAGE,Melvern Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000090
+OSAGE,Melvern Township,Commissioner of Insurance,,Republican,"Selzer, Ken",163,000090
+OSAGE,Michigan Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000100
+OSAGE,Michigan Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",105,000100
+OSAGE,North Burlingame,Commissioner of Insurance,,Democratic,"Anderson, Dennis",113,000110
+OSAGE,North Burlingame,Commissioner of Insurance,,Republican,"Selzer, Ken",223,000110
+OSAGE,North Ridgeway,Commissioner of Insurance,,Democratic,"Anderson, Dennis",155,000120
+OSAGE,North Ridgeway,Commissioner of Insurance,,Republican,"Selzer, Ken",259,000120
+OSAGE,North Valleybrook,Commissioner of Insurance,,Democratic,"Anderson, Dennis",132,000130
+OSAGE,North Valleybrook,Commissioner of Insurance,,Republican,"Selzer, Ken",242,000130
+OSAGE,Olivet Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000140
+OSAGE,Olivet Township,Commissioner of Insurance,,Republican,"Selzer, Ken",60,000140
+OSAGE,Osage City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",118,000150
+OSAGE,Osage City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",159,000150
+OSAGE,Osage City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,000160
+OSAGE,Osage City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",88,000160
+OSAGE,Osage City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000170
+OSAGE,Osage City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",113,000170
+OSAGE,Osage City Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",85,000180
+OSAGE,Osage City Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",156,000180
+OSAGE,Scranton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,000190
+OSAGE,Scranton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",232,000190
+OSAGE,South Burlingame,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,000200
+OSAGE,South Burlingame,Commissioner of Insurance,,Republican,"Selzer, Ken",185,000200
+OSAGE,South Ridgeway,Commissioner of Insurance,,Democratic,"Anderson, Dennis",175,000210
+OSAGE,South Ridgeway,Commissioner of Insurance,,Republican,"Selzer, Ken",231,000210
+OSAGE,South Valleybrook,Commissioner of Insurance,,Democratic,"Anderson, Dennis",60,000220
+OSAGE,South Valleybrook,Commissioner of Insurance,,Republican,"Selzer, Ken",101,000220
+OSAGE,Superior Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000230
+OSAGE,Superior Township,Commissioner of Insurance,,Republican,"Selzer, Ken",86,000230
+OSAGE,Vassar Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",112,000240
+OSAGE,Vassar Township,Commissioner of Insurance,,Republican,"Selzer, Ken",185,000240
+OSAGE,Superior Township Enclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+OSAGE,Superior Township Enclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+OSAGE,Grant Township Enclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+OSAGE,Grant Township Enclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+OSAGE,Grant Township Enclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+OSAGE,Grant Township Enclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+OSAGE,Osage City Ward 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+OSAGE,Osage City Ward 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+OSAGE,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000007
+OSAGE,Grant Township,Secretary of State,,Republican,"Kobach, Kris",82,000007
+OSAGE,Agency Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000010
+OSAGE,Agency Township,Secretary of State,,Republican,"Kobach, Kris",120,000010
+OSAGE,Arvonia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000020
+OSAGE,Arvonia Township,Secretary of State,,Republican,"Kobach, Kris",34,000020
+OSAGE,Barclay Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000030
+OSAGE,Barclay Township,Secretary of State,,Republican,"Kobach, Kris",59,000030
+OSAGE,Dragoon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000040
+OSAGE,Dragoon Township,Secretary of State,,Republican,"Kobach, Kris",64,000040
+OSAGE,Elk Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",225,000050
+OSAGE,Elk Township,Secretary of State,,Republican,"Kobach, Kris",510,000050
+OSAGE,Fairfax Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",81,000060
+OSAGE,Fairfax Township,Secretary of State,,Republican,"Kobach, Kris",173,000060
+OSAGE,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000080
+OSAGE,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",26,000080
+OSAGE,Melvern Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",78,000090
+OSAGE,Melvern Township,Secretary of State,,Republican,"Kobach, Kris",166,000090
+OSAGE,Michigan Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000100
+OSAGE,Michigan Valley Township,Secretary of State,,Republican,"Kobach, Kris",108,000100
+OSAGE,North Burlingame,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",114,000110
+OSAGE,North Burlingame,Secretary of State,,Republican,"Kobach, Kris",230,000110
+OSAGE,North Ridgeway,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",150,000120
+OSAGE,North Ridgeway,Secretary of State,,Republican,"Kobach, Kris",280,000120
+OSAGE,North Valleybrook,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",121,000130
+OSAGE,North Valleybrook,Secretary of State,,Republican,"Kobach, Kris",268,000130
+OSAGE,Olivet Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000140
+OSAGE,Olivet Township,Secretary of State,,Republican,"Kobach, Kris",70,000140
+OSAGE,Osage City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",98,000150
+OSAGE,Osage City Ward 1,Secretary of State,,Republican,"Kobach, Kris",182,000150
+OSAGE,Osage City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,000160
+OSAGE,Osage City Ward 2,Secretary of State,,Republican,"Kobach, Kris",103,000160
+OSAGE,Osage City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,000170
+OSAGE,Osage City Ward 3,Secretary of State,,Republican,"Kobach, Kris",126,000170
+OSAGE,Osage City Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",83,000180
+OSAGE,Osage City Ward 4,Secretary of State,,Republican,"Kobach, Kris",168,000180
+OSAGE,Scranton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,000190
+OSAGE,Scranton Township,Secretary of State,,Republican,"Kobach, Kris",258,000190
+OSAGE,South Burlingame,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",99,000200
+OSAGE,South Burlingame,Secretary of State,,Republican,"Kobach, Kris",211,000200
+OSAGE,South Ridgeway,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",171,000210
+OSAGE,South Ridgeway,Secretary of State,,Republican,"Kobach, Kris",244,000210
+OSAGE,South Valleybrook,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,000220
+OSAGE,South Valleybrook,Secretary of State,,Republican,"Kobach, Kris",109,000220
+OSAGE,Superior Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000230
+OSAGE,Superior Township,Secretary of State,,Republican,"Kobach, Kris",91,000230
+OSAGE,Vassar Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",113,000240
+OSAGE,Vassar Township,Secretary of State,,Republican,"Kobach, Kris",189,000240
+OSAGE,Superior Township Enclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+OSAGE,Superior Township Enclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900010
+OSAGE,Grant Township Enclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+OSAGE,Grant Township Enclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900020
+OSAGE,Grant Township Enclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+OSAGE,Grant Township Enclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900030
+OSAGE,Osage City Ward 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+OSAGE,Osage City Ward 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900040
+OSAGE,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000007
+OSAGE,Grant Township,State Treasurer,,Republican,"Estes, Ron",95,000007
+OSAGE,Agency Township,State Treasurer,,Democratic,"Alldritt, Carmen",37,000010
+OSAGE,Agency Township,State Treasurer,,Republican,"Estes, Ron",117,000010
+OSAGE,Arvonia Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000020
+OSAGE,Arvonia Township,State Treasurer,,Republican,"Estes, Ron",40,000020
+OSAGE,Barclay Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000030
+OSAGE,Barclay Township,State Treasurer,,Republican,"Estes, Ron",73,000030
+OSAGE,Dragoon Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000040
+OSAGE,Dragoon Township,State Treasurer,,Republican,"Estes, Ron",69,000040
+OSAGE,Elk Township,State Treasurer,,Democratic,"Alldritt, Carmen",202,000050
+OSAGE,Elk Township,State Treasurer,,Republican,"Estes, Ron",525,000050
+OSAGE,Fairfax Township,State Treasurer,,Democratic,"Alldritt, Carmen",59,000060
+OSAGE,Fairfax Township,State Treasurer,,Republican,"Estes, Ron",189,000060
+OSAGE,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000080
+OSAGE,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",26,000080
+OSAGE,Melvern Township,State Treasurer,,Democratic,"Alldritt, Carmen",66,000090
+OSAGE,Melvern Township,State Treasurer,,Republican,"Estes, Ron",173,000090
+OSAGE,Michigan Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000100
+OSAGE,Michigan Valley Township,State Treasurer,,Republican,"Estes, Ron",112,000100
+OSAGE,North Burlingame,State Treasurer,,Democratic,"Alldritt, Carmen",90,000110
+OSAGE,North Burlingame,State Treasurer,,Republican,"Estes, Ron",251,000110
+OSAGE,North Ridgeway,State Treasurer,,Democratic,"Alldritt, Carmen",138,000120
+OSAGE,North Ridgeway,State Treasurer,,Republican,"Estes, Ron",282,000120
+OSAGE,North Valleybrook,State Treasurer,,Democratic,"Alldritt, Carmen",97,000130
+OSAGE,North Valleybrook,State Treasurer,,Republican,"Estes, Ron",288,000130
+OSAGE,Olivet Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000140
+OSAGE,Olivet Township,State Treasurer,,Republican,"Estes, Ron",72,000140
+OSAGE,Osage City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",68,000150
+OSAGE,Osage City Ward 1,State Treasurer,,Republican,"Estes, Ron",211,000150
+OSAGE,Osage City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",36,000160
+OSAGE,Osage City Ward 2,State Treasurer,,Republican,"Estes, Ron",118,000160
+OSAGE,Osage City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",54,000170
+OSAGE,Osage City Ward 3,State Treasurer,,Republican,"Estes, Ron",142,000170
+OSAGE,Osage City Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",66,000180
+OSAGE,Osage City Ward 4,State Treasurer,,Republican,"Estes, Ron",184,000180
+OSAGE,Scranton Township,State Treasurer,,Democratic,"Alldritt, Carmen",101,000190
+OSAGE,Scranton Township,State Treasurer,,Republican,"Estes, Ron",254,000190
+OSAGE,South Burlingame,State Treasurer,,Democratic,"Alldritt, Carmen",91,000200
+OSAGE,South Burlingame,State Treasurer,,Republican,"Estes, Ron",213,000200
+OSAGE,South Ridgeway,State Treasurer,,Democratic,"Alldritt, Carmen",153,000210
+OSAGE,South Ridgeway,State Treasurer,,Republican,"Estes, Ron",257,000210
+OSAGE,South Valleybrook,State Treasurer,,Democratic,"Alldritt, Carmen",51,000220
+OSAGE,South Valleybrook,State Treasurer,,Republican,"Estes, Ron",111,000220
+OSAGE,Superior Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000230
+OSAGE,Superior Township,State Treasurer,,Republican,"Estes, Ron",102,000230
+OSAGE,Vassar Township,State Treasurer,,Democratic,"Alldritt, Carmen",97,000240
+OSAGE,Vassar Township,State Treasurer,,Republican,"Estes, Ron",199,000240
+OSAGE,Superior Township Enclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+OSAGE,Superior Township Enclave 1,State Treasurer,,Republican,"Estes, Ron",0,900010
+OSAGE,Grant Township Enclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+OSAGE,Grant Township Enclave 1,State Treasurer,,Republican,"Estes, Ron",0,900020
+OSAGE,Grant Township Enclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+OSAGE,Grant Township Enclave 2,State Treasurer,,Republican,"Estes, Ron",0,900030
+OSAGE,Osage City Ward 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+OSAGE,Osage City Ward 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900040
+OSAGE,Grant Township,United States Senate,,independent,"Orman, Greg",43,000007
+OSAGE,Grant Township,United States Senate,,Libertarian,"Batson, Randall",5,000007
+OSAGE,Grant Township,United States Senate,,Republican,"Roberts, Pat",70,000007
+OSAGE,Agency Township,United States Senate,,independent,"Orman, Greg",46,000010
+OSAGE,Agency Township,United States Senate,,Libertarian,"Batson, Randall",10,000010
+OSAGE,Agency Township,United States Senate,,Republican,"Roberts, Pat",98,000010
+OSAGE,Arvonia Township,United States Senate,,independent,"Orman, Greg",22,000020
+OSAGE,Arvonia Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+OSAGE,Arvonia Township,United States Senate,,Republican,"Roberts, Pat",33,000020
+OSAGE,Barclay Township,United States Senate,,independent,"Orman, Greg",29,000030
+OSAGE,Barclay Township,United States Senate,,Libertarian,"Batson, Randall",6,000030
+OSAGE,Barclay Township,United States Senate,,Republican,"Roberts, Pat",47,000030
+OSAGE,Dragoon Township,United States Senate,,independent,"Orman, Greg",32,000040
+OSAGE,Dragoon Township,United States Senate,,Libertarian,"Batson, Randall",6,000040
+OSAGE,Dragoon Township,United States Senate,,Republican,"Roberts, Pat",58,000040
+OSAGE,Elk Township,United States Senate,,independent,"Orman, Greg",255,000050
+OSAGE,Elk Township,United States Senate,,Libertarian,"Batson, Randall",35,000050
+OSAGE,Elk Township,United States Senate,,Republican,"Roberts, Pat",447,000050
+OSAGE,Fairfax Township,United States Senate,,independent,"Orman, Greg",102,000060
+OSAGE,Fairfax Township,United States Senate,,Libertarian,"Batson, Randall",6,000060
+OSAGE,Fairfax Township,United States Senate,,Republican,"Roberts, Pat",146,000060
+OSAGE,Lincoln Township,United States Senate,,independent,"Orman, Greg",11,000080
+OSAGE,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",3,000080
+OSAGE,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",28,000080
+OSAGE,Melvern Township,United States Senate,,independent,"Orman, Greg",77,000090
+OSAGE,Melvern Township,United States Senate,,Libertarian,"Batson, Randall",10,000090
+OSAGE,Melvern Township,United States Senate,,Republican,"Roberts, Pat",159,000090
+OSAGE,Michigan Valley Township,United States Senate,,independent,"Orman, Greg",64,000100
+OSAGE,Michigan Valley Township,United States Senate,,Libertarian,"Batson, Randall",10,000100
+OSAGE,Michigan Valley Township,United States Senate,,Republican,"Roberts, Pat",93,000100
+OSAGE,North Burlingame,United States Senate,,independent,"Orman, Greg",142,000110
+OSAGE,North Burlingame,United States Senate,,Libertarian,"Batson, Randall",16,000110
+OSAGE,North Burlingame,United States Senate,,Republican,"Roberts, Pat",187,000110
+OSAGE,North Ridgeway,United States Senate,,independent,"Orman, Greg",183,000120
+OSAGE,North Ridgeway,United States Senate,,Libertarian,"Batson, Randall",28,000120
+OSAGE,North Ridgeway,United States Senate,,Republican,"Roberts, Pat",218,000120
+OSAGE,North Valleybrook,United States Senate,,independent,"Orman, Greg",157,000130
+OSAGE,North Valleybrook,United States Senate,,Libertarian,"Batson, Randall",28,000130
+OSAGE,North Valleybrook,United States Senate,,Republican,"Roberts, Pat",207,000130
+OSAGE,Olivet Township,United States Senate,,independent,"Orman, Greg",34,000140
+OSAGE,Olivet Township,United States Senate,,Libertarian,"Batson, Randall",4,000140
+OSAGE,Olivet Township,United States Senate,,Republican,"Roberts, Pat",55,000140
+OSAGE,Osage City Ward 1,United States Senate,,independent,"Orman, Greg",121,000150
+OSAGE,Osage City Ward 1,United States Senate,,Libertarian,"Batson, Randall",18,000150
+OSAGE,Osage City Ward 1,United States Senate,,Republican,"Roberts, Pat",146,000150
+OSAGE,Osage City Ward 2,United States Senate,,independent,"Orman, Greg",69,000160
+OSAGE,Osage City Ward 2,United States Senate,,Libertarian,"Batson, Randall",11,000160
+OSAGE,Osage City Ward 2,United States Senate,,Republican,"Roberts, Pat",75,000160
+OSAGE,Osage City Ward 3,United States Senate,,independent,"Orman, Greg",83,000170
+OSAGE,Osage City Ward 3,United States Senate,,Libertarian,"Batson, Randall",11,000170
+OSAGE,Osage City Ward 3,United States Senate,,Republican,"Roberts, Pat",104,000170
+OSAGE,Osage City Ward 4,United States Senate,,independent,"Orman, Greg",109,000180
+OSAGE,Osage City Ward 4,United States Senate,,Libertarian,"Batson, Randall",6,000180
+OSAGE,Osage City Ward 4,United States Senate,,Republican,"Roberts, Pat",143,000180
+OSAGE,Scranton Township,United States Senate,,independent,"Orman, Greg",131,000190
+OSAGE,Scranton Township,United States Senate,,Libertarian,"Batson, Randall",20,000190
+OSAGE,Scranton Township,United States Senate,,Republican,"Roberts, Pat",213,000190
+OSAGE,South Burlingame,United States Senate,,independent,"Orman, Greg",123,000200
+OSAGE,South Burlingame,United States Senate,,Libertarian,"Batson, Randall",24,000200
+OSAGE,South Burlingame,United States Senate,,Republican,"Roberts, Pat",161,000200
+OSAGE,South Ridgeway,United States Senate,,independent,"Orman, Greg",196,000210
+OSAGE,South Ridgeway,United States Senate,,Libertarian,"Batson, Randall",27,000210
+OSAGE,South Ridgeway,United States Senate,,Republican,"Roberts, Pat",195,000210
+OSAGE,South Valleybrook,United States Senate,,independent,"Orman, Greg",64,000220
+OSAGE,South Valleybrook,United States Senate,,Libertarian,"Batson, Randall",15,000220
+OSAGE,South Valleybrook,United States Senate,,Republican,"Roberts, Pat",87,000220
+OSAGE,Superior Township,United States Senate,,independent,"Orman, Greg",49,000230
+OSAGE,Superior Township,United States Senate,,Libertarian,"Batson, Randall",4,000230
+OSAGE,Superior Township,United States Senate,,Republican,"Roberts, Pat",74,000230
+OSAGE,Vassar Township,United States Senate,,independent,"Orman, Greg",136,000240
+OSAGE,Vassar Township,United States Senate,,Libertarian,"Batson, Randall",11,000240
+OSAGE,Vassar Township,United States Senate,,Republican,"Roberts, Pat",154,000240
+OSAGE,Superior Township Enclave 1,United States Senate,,independent,"Orman, Greg",0,900010
+OSAGE,Superior Township Enclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900010
+OSAGE,Superior Township Enclave 1,United States Senate,,Republican,"Roberts, Pat",0,900010
+OSAGE,Grant Township Enclave 1,United States Senate,,independent,"Orman, Greg",0,900020
+OSAGE,Grant Township Enclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900020
+OSAGE,Grant Township Enclave 1,United States Senate,,Republican,"Roberts, Pat",0,900020
+OSAGE,Grant Township Enclave 2,United States Senate,,independent,"Orman, Greg",0,900030
+OSAGE,Grant Township Enclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900030
+OSAGE,Grant Township Enclave 2,United States Senate,,Republican,"Roberts, Pat",0,900030
+OSAGE,Osage City Ward 2 Exclave,United States Senate,,independent,"Orman, Greg",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900040

--- a/2014/20141104__ks__general__osborne__precinct.csv
+++ b/2014/20141104__ks__general__osborne__precinct.csv
@@ -1,477 +1,460 @@
-county,precinct,office,district,party,candidate,votes
-Osborne,Bethany-Portis,U.S. Senate,,R,Pat Roberts,41
-Osborne,Bloom Township,U.S. Senate,,R,Pat Roberts,22
-Osborne,Corinth Township,U.S. Senate,,R,Pat Roberts,14
-Osborne,Covert Township,U.S. Senate,,R,Pat Roberts,4
-Osborne,Delhi Township,U.S. Senate,,R,Pat Roberts,8
-Osborne,Grant Township,U.S. Senate,,R,Pat Roberts,9
-Osborne,Hancock Township,U.S. Senate,,R,Pat Roberts,10
-Osborne,Hawkeye Township,U.S. Senate,,R,Pat Roberts,9
-Osborne,Independence Township,U.S. Senate,,R,Pat Roberts,9
-Osborne,Jackson Township,U.S. Senate,,R,Pat Roberts,15
-Osborne,Kill Creek Township,U.S. Senate,,R,Pat Roberts,3
-Osborne,Lawrence Township,U.S. Senate,,R,Pat Roberts,11
-Osborne,Liberty Township,U.S. Senate,,R,Pat Roberts,13
-Osborne,Mount Ayr Township,U.S. Senate,,R,Pat Roberts,22
-Osborne,Natoma City/Twp,U.S. Senate,,R,Pat Roberts,95
-Osborne,Osborne Ward 1,U.S. Senate,,R,Pat Roberts,119
-Osborne,Osborne Ward 2,U.S. Senate,,R,Pat Roberts,157
-Osborne,Osborne Ward 3,U.S. Senate,,R,Pat Roberts,74
-Osborne,Penn Township,U.S. Senate,,R,Pat Roberts,39
-Osborne,Ross 1,U.S. Senate,,R,Pat Roberts,33
-Osborne,Ross 2 Downs City,U.S. Senate,,R,Pat Roberts,204
-Osborne,Round Mound Township,U.S. Senate,,R,Pat Roberts,21
-Osborne,Sumner Township,U.S. Senate,,R,Pat Roberts,45
-Osborne,Tilden Township,U.S. Senate,,R,Pat Roberts,32
-Osborne,Valley Township,U.S. Senate,,R,Pat Roberts,1
-Osborne,Victor Township,U.S. Senate,,R,Pat Roberts,8
-Osborne,Winfield Township,U.S. Senate,,R,Pat Roberts,10
-Osborne,Provisional Osb 3,U.S. Senate,,R,Pat Roberts,18
-Osborne,Bethany-Portis,U.S. Senate,,LBT,Randall Batson,4
-Osborne,Bloom Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Corinth Township,U.S. Senate,,LBT,Randall Batson,1
-Osborne,Covert Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Delhi Township,U.S. Senate,,LBT,Randall Batson,1
-Osborne,Grant Township,U.S. Senate,,LBT,Randall Batson,2
-Osborne,Hancock Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Hawkeye Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Independence Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Jackson Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Kill Creek Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Lawrence Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Liberty Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Mount Ayr Township,U.S. Senate,,LBT,Randall Batson,1
-Osborne,Natoma City/Twp,U.S. Senate,,LBT,Randall Batson,4
-Osborne,Osborne Ward 1,U.S. Senate,,LBT,Randall Batson,12
-Osborne,Osborne Ward 2,U.S. Senate,,LBT,Randall Batson,11
-Osborne,Osborne Ward 3,U.S. Senate,,LBT,Randall Batson,8
-Osborne,Penn Township,U.S. Senate,,LBT,Randall Batson,1
-Osborne,Ross 1,U.S. Senate,,LBT,Randall Batson,3
-Osborne,Ross 2 Downs City,U.S. Senate,,LBT,Randall Batson,21
-Osborne,Round Mound Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Sumner Township,U.S. Senate,,LBT,Randall Batson,1
-Osborne,Tilden Township,U.S. Senate,,LBT,Randall Batson,1
-Osborne,Valley Township,U.S. Senate,,LBT,Randall Batson,1
-Osborne,Victor Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Winfield Township,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Provisional Osb 3,U.S. Senate,,LBT,Randall Batson,0
-Osborne,Bethany-Portis,U.S. Senate,,IND,Greg Orman,18
-Osborne,Bloom Township,U.S. Senate,,IND,Greg Orman,4
-Osborne,Corinth Township,U.S. Senate,,IND,Greg Orman,7
-Osborne,Covert Township,U.S. Senate,,IND,Greg Orman,0
-Osborne,Delhi Township,U.S. Senate,,IND,Greg Orman,5
-Osborne,Grant Township,U.S. Senate,,IND,Greg Orman,0
-Osborne,Hancock Township,U.S. Senate,,IND,Greg Orman,0
-Osborne,Hawkeye Township,U.S. Senate,,IND,Greg Orman,1
-Osborne,Independence Township,U.S. Senate,,IND,Greg Orman,2
-Osborne,Jackson Township,U.S. Senate,,IND,Greg Orman,1
-Osborne,Kill Creek Township,U.S. Senate,,IND,Greg Orman,0
-Osborne,Lawrence Township,U.S. Senate,,IND,Greg Orman,4
-Osborne,Liberty Township,U.S. Senate,,IND,Greg Orman,1
-Osborne,Mount Ayr Township,U.S. Senate,,IND,Greg Orman,2
-Osborne,Natoma City/Twp,U.S. Senate,,IND,Greg Orman,17
-Osborne,Osborne Ward 1,U.S. Senate,,IND,Greg Orman,48
-Osborne,Osborne Ward 2,U.S. Senate,,IND,Greg Orman,61
-Osborne,Osborne Ward 3,U.S. Senate,,IND,Greg Orman,35
-Osborne,Penn Township,U.S. Senate,,IND,Greg Orman,8
-Osborne,Ross 1,U.S. Senate,,IND,Greg Orman,8
-Osborne,Ross 2 Downs City,U.S. Senate,,IND,Greg Orman,93
-Osborne,Round Mound Township,U.S. Senate,,IND,Greg Orman,0
-Osborne,Sumner Township,U.S. Senate,,IND,Greg Orman,8
-Osborne,Tilden Township,U.S. Senate,,IND,Greg Orman,2
-Osborne,Valley Township,U.S. Senate,,IND,Greg Orman,0
-Osborne,Victor Township,U.S. Senate,,IND,Greg Orman,3
-Osborne,Winfield Township,U.S. Senate,,IND,Greg Orman,0
-Osborne,Provisional Osb 3,U.S. Senate,,IND,Greg Orman,1
-Osborne,Bethany-Portis,U.S. House,1,R,Tim Huelskamp,14
-Osborne,Bloom Township,U.S. House,1,R,Tim Huelskamp,5
-Osborne,Corinth Township,U.S. House,1,R,Tim Huelskamp,6
-Osborne,Covert Township,U.S. House,1,R,Tim Huelskamp,1
-Osborne,Delhi Township,U.S. House,1,R,Tim Huelskamp,3
-Osborne,Grant Township,U.S. House,1,R,Tim Huelskamp,4
-Osborne,Hancock Township,U.S. House,1,R,Tim Huelskamp,1
-Osborne,Hawkeye Township,U.S. House,1,R,Tim Huelskamp,3
-Osborne,Independence Township,U.S. House,1,R,Tim Huelskamp,1
-Osborne,Jackson Township,U.S. House,1,R,Tim Huelskamp,1
-Osborne,Kill Creek Township,U.S. House,1,R,Tim Huelskamp,0
-Osborne,Lawrence Township,U.S. House,1,R,Tim Huelskamp,4
-Osborne,Liberty Township,U.S. House,1,R,Tim Huelskamp,2
-Osborne,Mount Ayr Township,U.S. House,1,R,Tim Huelskamp,0
-Osborne,Natoma City/Twp,U.S. House,1,R,Tim Huelskamp,19
-Osborne,Osborne Ward 1,U.S. House,1,R,Tim Huelskamp,53
-Osborne,Osborne Ward 2,U.S. House,1,R,Tim Huelskamp,72
-Osborne,Osborne Ward 3,U.S. House,1,R,Tim Huelskamp,37
-Osborne,Penn Township,U.S. House,1,R,Tim Huelskamp,10
-Osborne,Ross 1,U.S. House,1,R,Tim Huelskamp,9
-Osborne,Ross 2 Downs City,U.S. House,1,R,Tim Huelskamp,87
-Osborne,Round Mound Township,U.S. House,1,R,Tim Huelskamp,0
-Osborne,Sumner Township,U.S. House,1,R,Tim Huelskamp,10
-Osborne,Tilden Township,U.S. House,1,R,Tim Huelskamp,2
-Osborne,Valley Township,U.S. House,1,R,Tim Huelskamp,0
-Osborne,Victor Township,U.S. House,1,R,Tim Huelskamp,5
-Osborne,Winfield Township,U.S. House,1,R,Tim Huelskamp,1
-Osborne,Provisional Osb 3,U.S. House,1,R,Tim Huelskamp,3
-Osborne,Bethany-Portis,U.S. House,1,D,James Sherow,49
-Osborne,Bloom Township,U.S. House,1,D,James Sherow,20
-Osborne,Corinth Township,U.S. House,1,D,James Sherow,14
-Osborne,Covert Township,U.S. House,1,D,James Sherow,3
-Osborne,Delhi Township,U.S. House,1,D,James Sherow,10
-Osborne,Grant Township,U.S. House,1,D,James Sherow,6
-Osborne,Hancock Township,U.S. House,1,D,James Sherow,9
-Osborne,Hawkeye Township,U.S. House,1,D,James Sherow,7
-Osborne,Independence Township,U.S. House,1,D,James Sherow,10
-Osborne,Jackson Township,U.S. House,1,D,James Sherow,15
-Osborne,Kill Creek Township,U.S. House,1,D,James Sherow,3
-Osborne,Lawrence Township,U.S. House,1,D,James Sherow,12
-Osborne,Liberty Township,U.S. House,1,D,James Sherow,12
-Osborne,Mount Ayr Township,U.S. House,1,D,James Sherow,25
-Osborne,Natoma City/Twp,U.S. House,1,D,James Sherow,97
-Osborne,Osborne Ward 1,U.S. House,1,D,James Sherow,127
-Osborne,Osborne Ward 2,U.S. House,1,D,James Sherow,156
-Osborne,Osborne Ward 3,U.S. House,1,D,James Sherow,79
-Osborne,Penn Township,U.S. House,1,D,James Sherow,34
-Osborne,Ross 1,U.S. House,1,D,James Sherow,35
-Osborne,Ross 2 Downs City,U.S. House,1,D,James Sherow,221
-Osborne,Round Mound Township,U.S. House,1,D,James Sherow,21
-Osborne,Sumner Township,U.S. House,1,D,James Sherow,45
-Osborne,Tilden Township,U.S. House,1,D,James Sherow,31
-Osborne,Valley Township,U.S. House,1,D,James Sherow,2
-Osborne,Victor Township,U.S. House,1,D,James Sherow,6
-Osborne,Winfield Township,U.S. House,1,D,James Sherow,9
-Osborne,Provisional Osb 3,U.S. House,1,D,James Sherow,16
-Osborne,Bethany-Portis,Governor,,D,Paul Davis,21
-Osborne,Bloom Township,Governor,,D,Paul Davis,7
-Osborne,Corinth Township,Governor,,D,Paul Davis,8
-Osborne,Covert Township,Governor,,D,Paul Davis,1
-Osborne,Delhi Township,Governor,,D,Paul Davis,4
-Osborne,Grant Township,Governor,,D,Paul Davis,2
-Osborne,Hancock Township,Governor,,D,Paul Davis,0
-Osborne,Hawkeye Township,Governor,,D,Paul Davis,2
-Osborne,Independence Township,Governor,,D,Paul Davis,1
-Osborne,Jackson Township,Governor,,D,Paul Davis,1
-Osborne,Kill Creek Township,Governor,,D,Paul Davis,0
-Osborne,Lawrence Township,Governor,,D,Paul Davis,4
-Osborne,Liberty Township,Governor,,D,Paul Davis,2
-Osborne,Mount Ayr Township,Governor,,D,Paul Davis,0
-Osborne,Natoma City/Twp,Governor,,D,Paul Davis,22
-Osborne,Osborne Ward 1,Governor,,D,Paul Davis,71
-Osborne,Osborne Ward 2,Governor,,D,Paul Davis,84
-Osborne,Osborne Ward 3,Governor,,D,Paul Davis,42
-Osborne,Penn Township,Governor,,D,Paul Davis,12
-Osborne,Ross 1,Governor,,D,Paul Davis,13
-Osborne,Ross 2 Downs City,Governor,,D,Paul Davis,119
-Osborne,Round Mound Township,Governor,,D,Paul Davis,1
-Osborne,Sumner Township,Governor,,D,Paul Davis,11
-Osborne,Tilden Township,Governor,,D,Paul Davis,4
-Osborne,Valley Township,Governor,,D,Paul Davis,1
-Osborne,Victor Township,Governor,,D,Paul Davis,3
-Osborne,Winfield Township,Governor,,D,Paul Davis,2
-Osborne,Provisional Osb 3,Governor,,D,Paul Davis,2
-Osborne,Bethany-Portis,Governor,,R,Sam Brownback,39
-Osborne,Bloom Township,Governor,,R,Sam Brownback,19
-Osborne,Corinth Township,Governor,,R,Sam Brownback,11
-Osborne,Covert Township,Governor,,R,Sam Brownback,3
-Osborne,Delhi Township,Governor,,R,Sam Brownback,9
-Osborne,Grant Township,Governor,,R,Sam Brownback,8
-Osborne,Hancock Township,Governor,,R,Sam Brownback,10
-Osborne,Hawkeye Township,Governor,,R,Sam Brownback,8
-Osborne,Independence Township,Governor,,R,Sam Brownback,9
-Osborne,Jackson Township,Governor,,R,Sam Brownback,15
-Osborne,Kill Creek Township,Governor,,R,Sam Brownback,3
-Osborne,Lawrence Township,Governor,,R,Sam Brownback,11
-Osborne,Liberty Township,Governor,,R,Sam Brownback,11
-Osborne,Mount Ayr Township,Governor,,R,Sam Brownback,24
-Osborne,Natoma City/Twp,Governor,,R,Sam Brownback,90
-Osborne,Osborne Ward 1,Governor,,R,Sam Brownback,104
-Osborne,Osborne Ward 2,Governor,,R,Sam Brownback,132
-Osborne,Osborne Ward 3,Governor,,R,Sam Brownback,59
-Osborne,Penn Township,Governor,,R,Sam Brownback,38
-Osborne,Ross 1,Governor,,R,Sam Brownback,30
-Osborne,Ross 2 Downs City,Governor,,R,Sam Brownback,172
-Osborne,Round Mound Township,Governor,,R,Sam Brownback,20
-Osborne,Sumner Township,Governor,,R,Sam Brownback,38
-Osborne,Tilden Township,Governor,,R,Sam Brownback,29
-Osborne,Valley Township,Governor,,R,Sam Brownback,1
-Osborne,Victor Township,Governor,,R,Sam Brownback,8
-Osborne,Winfield Township,Governor,,R,Sam Brownback,6
-Osborne,Provisional Osb 3,Governor,,R,Sam Brownback,17
-Osborne,Bethany-Portis,Governor,,LBT,Keen Umbehr,4
-Osborne,Bloom Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Corinth Township,Governor,,LBT,Keen Umbehr,2
-Osborne,Covert Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Delhi Township,Governor,,LBT,Keen Umbehr,1
-Osborne,Grant Township,Governor,,LBT,Keen Umbehr,1
-Osborne,Hancock Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Hawkeye Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Independence Township,Governor,,LBT,Keen Umbehr,1
-Osborne,Jackson Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Kill Creek Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Lawrence Township,Governor,,LBT,Keen Umbehr,1
-Osborne,Liberty Township,Governor,,LBT,Keen Umbehr,1
-Osborne,Mount Ayr Township,Governor,,LBT,Keen Umbehr,1
-Osborne,Natoma City/Twp,Governor,,LBT,Keen Umbehr,4
-Osborne,Osborne Ward 1,Governor,,LBT,Keen Umbehr,8
-Osborne,Osborne Ward 2,Governor,,LBT,Keen Umbehr,12
-Osborne,Osborne Ward 3,Governor,,LBT,Keen Umbehr,16
-Osborne,Penn Township,Governor,,LBT,Keen Umbehr,3
-Osborne,Ross 1,Governor,,LBT,Keen Umbehr,1
-Osborne,Ross 2 Downs City,Governor,,LBT,Keen Umbehr,25
-Osborne,Round Mound Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Sumner Township,Governor,,LBT,Keen Umbehr,2
-Osborne,Tilden Township,Governor,,LBT,Keen Umbehr,1
-Osborne,Valley Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Victor Township,Governor,,LBT,Keen Umbehr,0
-Osborne,Winfield Township,Governor,,LBT,Keen Umbehr,2
-Osborne,Provisional Osb 3,Governor,,LBT,Keen Umbehr,0
-Osborne,Bethany-Portis,Secretary of State,,D,Jean Schodorf,14
-Osborne,Bloom Township,Secretary of State,,D,Jean Schodorf,6
-Osborne,Corinth Township,Secretary of State,,D,Jean Schodorf,9
-Osborne,Covert Township,Secretary of State,,D,Jean Schodorf,1
-Osborne,Delhi Township,Secretary of State,,D,Jean Schodorf,3
-Osborne,Grant Township,Secretary of State,,D,Jean Schodorf,2
-Osborne,Hancock Township,Secretary of State,,D,Jean Schodorf,0
-Osborne,Hawkeye Township,Secretary of State,,D,Jean Schodorf,1
-Osborne,Independence Township,Secretary of State,,D,Jean Schodorf,1
-Osborne,Jackson Township,Secretary of State,,D,Jean Schodorf,1
-Osborne,Kill Creek Township,Secretary of State,,D,Jean Schodorf,1
-Osborne,Lawrence Township,Secretary of State,,D,Jean Schodorf,4
-Osborne,Liberty Township,Secretary of State,,D,Jean Schodorf,2
-Osborne,Mount Ayr Township,Secretary of State,,D,Jean Schodorf,1
-Osborne,Natoma City/Twp,Secretary of State,,D,Jean Schodorf,17
-Osborne,Osborne Ward 1,Secretary of State,,D,Jean Schodorf,59
-Osborne,Osborne Ward 2,Secretary of State,,D,Jean Schodorf,58
-Osborne,Osborne Ward 3,Secretary of State,,D,Jean Schodorf,35
-Osborne,Penn Township,Secretary of State,,D,Jean Schodorf,10
-Osborne,Ross 1,Secretary of State,,D,Jean Schodorf,8
-Osborne,Ross 2 Downs City,Secretary of State,,D,Jean Schodorf,84
-Osborne,Round Mound Township,Secretary of State,,D,Jean Schodorf,0
-Osborne,Sumner Township,Secretary of State,,D,Jean Schodorf,11
-Osborne,Tilden Township,Secretary of State,,D,Jean Schodorf,2
-Osborne,Valley Township,Secretary of State,,D,Jean Schodorf,0
-Osborne,Victor Township,Secretary of State,,D,Jean Schodorf,7
-Osborne,Winfield Township,Secretary of State,,D,Jean Schodorf,3
-Osborne,Provisional Osb 3,Secretary of State,,D,Jean Schodorf,1
-Osborne,Bethany-Portis,Secretary of State,,R,Kris Kobach,49
-Osborne,Bloom Township,Secretary of State,,R,Kris Kobach,20
-Osborne,Corinth Township,Secretary of State,,R,Kris Kobach,11
-Osborne,Covert Township,Secretary of State,,R,Kris Kobach,3
-Osborne,Delhi Township,Secretary of State,,R,Kris Kobach,10
-Osborne,Grant Township,Secretary of State,,R,Kris Kobach,9
-Osborne,Hancock Township,Secretary of State,,R,Kris Kobach,9
-Osborne,Hawkeye Township,Secretary of State,,R,Kris Kobach,9
-Osborne,Independence Township,Secretary of State,,R,Kris Kobach,7
-Osborne,Jackson Township,Secretary of State,,R,Kris Kobach,15
-Osborne,Kill Creek Township,Secretary of State,,R,Kris Kobach,2
-Osborne,Lawrence Township,Secretary of State,,R,Kris Kobach,12
-Osborne,Liberty Township,Secretary of State,,R,Kris Kobach,12
-Osborne,Mount Ayr Township,Secretary of State,,R,Kris Kobach,24
-Osborne,Natoma City/Twp,Secretary of State,,R,Kris Kobach,100
-Osborne,Osborne Ward 1,Secretary of State,,R,Kris Kobach,123
-Osborne,Osborne Ward 2,Secretary of State,,R,Kris Kobach,165
-Osborne,Osborne Ward 3,Secretary of State,,R,Kris Kobach,82
-Osborne,Penn Township,Secretary of State,,R,Kris Kobach,36
-Osborne,Ross 1,Secretary of State,,R,Kris Kobach,35
-Osborne,Ross 2 Downs City,Secretary of State,,R,Kris Kobach,227
-Osborne,Round Mound Township,Secretary of State,,R,Kris Kobach,21
-Osborne,Sumner Township,Secretary of State,,R,Kris Kobach,39
-Osborne,Tilden Township,Secretary of State,,R,Kris Kobach,32
-Osborne,Valley Township,Secretary of State,,R,Kris Kobach,2
-Osborne,Victor Township,Secretary of State,,R,Kris Kobach,4
-Osborne,Winfield Township,Secretary of State,,R,Kris Kobach,7
-Osborne,Provisional Osb 3,Secretary of State,,R,Kris Kobach,18
-Osborne,Bethany-Portis,Attorney General,,D,A.J. Kotich,12
-Osborne,Bloom Township,Attorney General,,D,A.J. Kotich,3
-Osborne,Corinth Township,Attorney General,,D,A.J. Kotich,2
-Osborne,Covert Township,Attorney General,,D,A.J. Kotich,0
-Osborne,Delhi Township,Attorney General,,D,A.J. Kotich,0
-Osborne,Grant Township,Attorney General,,D,A.J. Kotich,1
-Osborne,Hancock Township,Attorney General,,D,A.J. Kotich,0
-Osborne,Hawkeye Township,Attorney General,,D,A.J. Kotich,2
-Osborne,Independence Township,Attorney General,,D,A.J. Kotich,1
-Osborne,Jackson Township,Attorney General,,D,A.J. Kotich,2
-Osborne,Kill Creek Township,Attorney General,,D,A.J. Kotich,0
-Osborne,Lawrence Township,Attorney General,,D,A.J. Kotich,3
-Osborne,Liberty Township,Attorney General,,D,A.J. Kotich,2
-Osborne,Mount Ayr Township,Attorney General,,D,A.J. Kotich,1
-Osborne,Natoma City/Twp,Attorney General,,D,A.J. Kotich,11
-Osborne,Osborne Ward 1,Attorney General,,D,A.J. Kotich,31
-Osborne,Osborne Ward 2,Attorney General,,D,A.J. Kotich,41
-Osborne,Osborne Ward 3,Attorney General,,D,A.J. Kotich,28
-Osborne,Penn Township,Attorney General,,D,A.J. Kotich,7
-Osborne,Ross 1,Attorney General,,D,A.J. Kotich,6
-Osborne,Ross 2 Downs City,Attorney General,,D,A.J. Kotich,50
-Osborne,Round Mound Township,Attorney General,,D,A.J. Kotich,0
-Osborne,Sumner Township,Attorney General,,D,A.J. Kotich,4
-Osborne,Tilden Township,Attorney General,,D,A.J. Kotich,0
-Osborne,Valley Township,Attorney General,,D,A.J. Kotich,0
-Osborne,Victor Township,Attorney General,,D,A.J. Kotich,2
-Osborne,Winfield Township,Attorney General,,D,A.J. Kotich,1
-Osborne,Provisional Osb 3,Attorney General,,D,A.J. Kotich,2
-Osborne,Bethany-Portis,Attorney General,,R,Derek Schmidt,52
-Osborne,Bloom Township,Attorney General,,R,Derek Schmidt,23
-Osborne,Corinth Township,Attorney General,,R,Derek Schmidt,18
-Osborne,Covert Township,Attorney General,,R,Derek Schmidt,3
-Osborne,Delhi Township,Attorney General,,R,Derek Schmidt,12
-Osborne,Grant Township,Attorney General,,R,Derek Schmidt,10
-Osborne,Hancock Township,Attorney General,,R,Derek Schmidt,9
-Osborne,Hawkeye Township,Attorney General,,R,Derek Schmidt,8
-Osborne,Independence Township,Attorney General,,R,Derek Schmidt,10
-Osborne,Jackson Township,Attorney General,,R,Derek Schmidt,13
-Osborne,Kill Creek Township,Attorney General,,R,Derek Schmidt,2
-Osborne,Lawrence Township,Attorney General,,R,Derek Schmidt,12
-Osborne,Liberty Township,Attorney General,,R,Derek Schmidt,12
-Osborne,Mount Ayr Township,Attorney General,,R,Derek Schmidt,24
-Osborne,Natoma City/Twp,Attorney General,,R,Derek Schmidt,105
-Osborne,Osborne Ward 1,Attorney General,,R,Derek Schmidt,145
-Osborne,Osborne Ward 2,Attorney General,,R,Derek Schmidt,182
-Osborne,Osborne Ward 3,Attorney General,,R,Derek Schmidt,85
-Osborne,Penn Township,Attorney General,,R,Derek Schmidt,39
-Osborne,Ross 1,Attorney General,,R,Derek Schmidt,38
-Osborne,Ross 2 Downs City,Attorney General,,R,Derek Schmidt,260
-Osborne,Round Mound Township,Attorney General,,R,Derek Schmidt,21
-Osborne,Sumner Township,Attorney General,,R,Derek Schmidt,48
-Osborne,Tilden Township,Attorney General,,R,Derek Schmidt,34
-Osborne,Valley Township,Attorney General,,R,Derek Schmidt,2
-Osborne,Victor Township,Attorney General,,R,Derek Schmidt,9
-Osborne,Winfield Township,Attorney General,,R,Derek Schmidt,9
-Osborne,Provisional Osb 3,Attorney General,,R,Derek Schmidt,17
-Osborne,Bethany-Portis,State Treasurer,,D,Carmen Alldritt,13
-Osborne,Bloom Township,State Treasurer,,D,Carmen Alldritt,3
-Osborne,Corinth Township,State Treasurer,,D,Carmen Alldritt,3
-Osborne,Covert Township,State Treasurer,,D,Carmen Alldritt,0
-Osborne,Delhi Township,State Treasurer,,D,Carmen Alldritt,1
-Osborne,Grant Township,State Treasurer,,D,Carmen Alldritt,2
-Osborne,Hancock Township,State Treasurer,,D,Carmen Alldritt,0
-Osborne,Hawkeye Township,State Treasurer,,D,Carmen Alldritt,1
-Osborne,Independence Township,State Treasurer,,D,Carmen Alldritt,0
-Osborne,Jackson Township,State Treasurer,,D,Carmen Alldritt,2
-Osborne,Kill Creek Township,State Treasurer,,D,Carmen Alldritt,0
-Osborne,Lawrence Township,State Treasurer,,D,Carmen Alldritt,3
-Osborne,Liberty Township,State Treasurer,,D,Carmen Alldritt,2
-Osborne,Mount Ayr Township,State Treasurer,,D,Carmen Alldritt,1
-Osborne,Natoma City/Twp,State Treasurer,,D,Carmen Alldritt,9
-Osborne,Osborne Ward 1,State Treasurer,,D,Carmen Alldritt,34
-Osborne,Osborne Ward 2,State Treasurer,,D,Carmen Alldritt,42
-Osborne,Osborne Ward 3,State Treasurer,,D,Carmen Alldritt,34
-Osborne,Penn Township,State Treasurer,,D,Carmen Alldritt,9
-Osborne,Ross 1,State Treasurer,,D,Carmen Alldritt,6
-Osborne,Ross 2 Downs City,State Treasurer,,D,Carmen Alldritt,57
-Osborne,Round Mound Township,State Treasurer,,D,Carmen Alldritt,0
-Osborne,Sumner Township,State Treasurer,,D,Carmen Alldritt,4
-Osborne,Tilden Township,State Treasurer,,D,Carmen Alldritt,2
-Osborne,Valley Township,State Treasurer,,D,Carmen Alldritt,0
-Osborne,Victor Township,State Treasurer,,D,Carmen Alldritt,2
-Osborne,Winfield Township,State Treasurer,,D,Carmen Alldritt,2
-Osborne,Provisional Osb 3,State Treasurer,,D,Carmen Alldritt,1
-Osborne,Bethany-Portis,State Treasurer,,R,Ron Estes,49
-Osborne,Bloom Township,State Treasurer,,R,Ron Estes,23
-Osborne,Corinth Township,State Treasurer,,R,Ron Estes,17
-Osborne,Covert Township,State Treasurer,,R,Ron Estes,2
-Osborne,Delhi Township,State Treasurer,,R,Ron Estes,11
-Osborne,Grant Township,State Treasurer,,R,Ron Estes,9
-Osborne,Hancock Township,State Treasurer,,R,Ron Estes,9
-Osborne,Hawkeye Township,State Treasurer,,R,Ron Estes,9
-Osborne,Independence Township,State Treasurer,,R,Ron Estes,9
-Osborne,Jackson Township,State Treasurer,,R,Ron Estes,13
-Osborne,Kill Creek Township,State Treasurer,,R,Ron Estes,3
-Osborne,Lawrence Township,State Treasurer,,R,Ron Estes,11
-Osborne,Liberty Township,State Treasurer,,R,Ron Estes,12
-Osborne,Mount Ayr Township,State Treasurer,,R,Ron Estes,23
-Osborne,Natoma City/Twp,State Treasurer,,R,Ron Estes,107
-Osborne,Osborne Ward 1,State Treasurer,,R,Ron Estes,146
-Osborne,Osborne Ward 2,State Treasurer,,R,Ron Estes,178
-Osborne,Osborne Ward 3,State Treasurer,,R,Ron Estes,77
-Osborne,Penn Township,State Treasurer,,R,Ron Estes,37
-Osborne,Ross 1,State Treasurer,,R,Ron Estes,37
-Osborne,Ross 2 Downs City,State Treasurer,,R,Ron Estes,256
-Osborne,Round Mound Township,State Treasurer,,R,Ron Estes,21
-Osborne,Sumner Township,State Treasurer,,R,Ron Estes,49
-Osborne,Tilden Township,State Treasurer,,R,Ron Estes,31
-Osborne,Valley Township,State Treasurer,,R,Ron Estes,2
-Osborne,Victor Township,State Treasurer,,R,Ron Estes,9
-Osborne,Winfield Township,State Treasurer,,R,Ron Estes,8
-Osborne,Provisional Osb 3,State Treasurer,,R,Ron Estes,17
-Osborne,Bethany-Portis,Insurance Commissioner,,D,Dennis Anderson,21
-Osborne,Bloom Township,Insurance Commissioner,,D,Dennis Anderson,4
-Osborne,Corinth Township,Insurance Commissioner,,D,Dennis Anderson,2
-Osborne,Covert Township,Insurance Commissioner,,D,Dennis Anderson,0
-Osborne,Delhi Township,Insurance Commissioner,,D,Dennis Anderson,3
-Osborne,Grant Township,Insurance Commissioner,,D,Dennis Anderson,1
-Osborne,Hancock Township,Insurance Commissioner,,D,Dennis Anderson,1
-Osborne,Hawkeye Township,Insurance Commissioner,,D,Dennis Anderson,3
-Osborne,Independence Township,Insurance Commissioner,,D,Dennis Anderson,1
-Osborne,Jackson Township,Insurance Commissioner,,D,Dennis Anderson,2
-Osborne,Kill Creek Township,Insurance Commissioner,,D,Dennis Anderson,0
-Osborne,Lawrence Township,Insurance Commissioner,,D,Dennis Anderson,3
-Osborne,Liberty Township,Insurance Commissioner,,D,Dennis Anderson,2
-Osborne,Mount Ayr Township,Insurance Commissioner,,D,Dennis Anderson,1
-Osborne,Natoma City/Twp,Insurance Commissioner,,D,Dennis Anderson,12
-Osborne,Osborne Ward 1,Insurance Commissioner,,D,Dennis Anderson,40
-Osborne,Osborne Ward 2,Insurance Commissioner,,D,Dennis Anderson,52
-Osborne,Osborne Ward 3,Insurance Commissioner,,D,Dennis Anderson,33
-Osborne,Penn Township,Insurance Commissioner,,D,Dennis Anderson,8
-Osborne,Ross 1,Insurance Commissioner,,D,Dennis Anderson,6
-Osborne,Ross 2 Downs City,Insurance Commissioner,,D,Dennis Anderson,67
-Osborne,Round Mound Township,Insurance Commissioner,,D,Dennis Anderson,0
-Osborne,Sumner Township,Insurance Commissioner,,D,Dennis Anderson,7
-Osborne,Tilden Township,Insurance Commissioner,,D,Dennis Anderson,2
-Osborne,Valley Township,Insurance Commissioner,,D,Dennis Anderson,1
-Osborne,Victor Township,Insurance Commissioner,,D,Dennis Anderson,1
-Osborne,Winfield Township,Insurance Commissioner,,D,Dennis Anderson,2
-Osborne,Provisional Osb 3,Insurance Commissioner,,D,Dennis Anderson,1
-Osborne,Bethany-Portis,Insurance Commissioner,,R,Ken Selzer,42
-Osborne,Bloom Township,Insurance Commissioner,,R,Ken Selzer,21
-Osborne,Corinth Township,Insurance Commissioner,,R,Ken Selzer,18
-Osborne,Covert Township,Insurance Commissioner,,R,Ken Selzer,2
-Osborne,Delhi Township,Insurance Commissioner,,R,Ken Selzer,9
-Osborne,Grant Township,Insurance Commissioner,,R,Ken Selzer,9
-Osborne,Hancock Township,Insurance Commissioner,,R,Ken Selzer,9
-Osborne,Hawkeye Township,Insurance Commissioner,,R,Ken Selzer,7
-Osborne,Independence Township,Insurance Commissioner,,R,Ken Selzer,8
-Osborne,Jackson Township,Insurance Commissioner,,R,Ken Selzer,14
-Osborne,Kill Creek Township,Insurance Commissioner,,R,Ken Selzer,3
-Osborne,Lawrence Township,Insurance Commissioner,,R,Ken Selzer,10
-Osborne,Liberty Township,Insurance Commissioner,,R,Ken Selzer,11
-Osborne,Mount Ayr Township,Insurance Commissioner,,R,Ken Selzer,21
-Osborne,Natoma City/Twp,Insurance Commissioner,,R,Ken Selzer,100
-Osborne,Osborne Ward 1,Insurance Commissioner,,R,Ken Selzer,133
-Osborne,Osborne Ward 2,Insurance Commissioner,,R,Ken Selzer,164
-Osborne,Osborne Ward 3,Insurance Commissioner,,R,Ken Selzer,76
-Osborne,Penn Township,Insurance Commissioner,,R,Ken Selzer,35
-Osborne,Ross 1,Insurance Commissioner,,R,Ken Selzer,35
-Osborne,Ross 2 Downs City,Insurance Commissioner,,R,Ken Selzer,237
-Osborne,Round Mound Township,Insurance Commissioner,,R,Ken Selzer,21
-Osborne,Sumner Township,Insurance Commissioner,,R,Ken Selzer,46
-Osborne,Tilden Township,Insurance Commissioner,,R,Ken Selzer,30
-Osborne,Valley Township,Insurance Commissioner,,R,Ken Selzer,1
-Osborne,Victor Township,Insurance Commissioner,,R,Ken Selzer,10
-Osborne,Winfield Township,Insurance Commissioner,,R,Ken Selzer,8
-Osborne,Provisional Osb 3,Insurance Commissioner,,R,Ken Selzer,17
-Osborne,Bethany-Portis,State House,109,R,Troy Waymaster,54
-Osborne,Bloom Township,State House,109,R,Troy Waymaster,25
-Osborne,Corinth Township,State House,109,R,Troy Waymaster,17
-Osborne,Covert Township,State House,109,R,Troy Waymaster,4
-Osborne,Delhi Township,State House,109,R,Troy Waymaster,13
-Osborne,Grant Township,State House,109,R,Troy Waymaster,10
-Osborne,Hancock Township,State House,109,R,Troy Waymaster,9
-Osborne,Hawkeye Township,State House,109,R,Troy Waymaster,9
-Osborne,Independence Township,State House,109,R,Troy Waymaster,10
-Osborne,Jackson Township,State House,109,R,Troy Waymaster,16
-Osborne,Kill Creek Township,State House,109,R,Troy Waymaster,3
-Osborne,Lawrence Township,State House,109,R,Troy Waymaster,14
-Osborne,Liberty Township,State House,109,R,Troy Waymaster,14
-Osborne,Mount Ayr Township,State House,109,R,Troy Waymaster,25
-Osborne,Natoma City/Twp,State House,109,R,Troy Waymaster,109
-Osborne,Osborne Ward 1,State House,109,R,Troy Waymaster,164
-Osborne,Osborne Ward 2,State House,109,R,Troy Waymaster,192
-Osborne,Osborne Ward 3,State House,109,R,Troy Waymaster,93
-Osborne,Penn Township,State House,109,R,Troy Waymaster,43
-Osborne,Ross 1,State House,109,R,Troy Waymaster,37
-Osborne,Ross 2 Downs City,State House,109,R,Troy Waymaster,281
-Osborne,Round Mound Township,State House,109,R,Troy Waymaster,21
-Osborne,Sumner Township,State House,109,R,Troy Waymaster,51
-Osborne,Tilden Township,State House,109,R,Troy Waymaster,30
-Osborne,Valley Township,State House,109,R,Troy Waymaster,2
-Osborne,Victor Township,State House,109,R,Troy Waymaster,11
-Osborne,Winfield Township,State House,109,R,Troy Waymaster,10
-Osborne,Provisional Osb 3,State House,109,R,Troy Waymaster,18
+county,precinct,office,district,party,candidate,votes,vtd
+OSBORNE,Bethany Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000010
+OSBORNE,Bethany Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+OSBORNE,Bethany Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000010
+OSBORNE,Bloom Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000020
+OSBORNE,Bloom Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+OSBORNE,Bloom Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000020
+OSBORNE,Corinth Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+OSBORNE,Corinth Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000030
+OSBORNE,Corinth Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000030
+OSBORNE,Covert Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000040
+OSBORNE,Covert Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+OSBORNE,Covert Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000040
+OSBORNE,Delhi Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000050
+OSBORNE,Delhi Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+OSBORNE,Delhi Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000050
+OSBORNE,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000060
+OSBORNE,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+OSBORNE,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000060
+OSBORNE,Hancock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000070
+OSBORNE,Hancock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+OSBORNE,Hancock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000070
+OSBORNE,Hawkeye Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000080
+OSBORNE,Hawkeye Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+OSBORNE,Hawkeye Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000080
+OSBORNE,Independence Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000090
+OSBORNE,Independence Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+OSBORNE,Independence Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000090
+OSBORNE,Jackson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000100
+OSBORNE,Jackson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+OSBORNE,Jackson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000100
+OSBORNE,Kill Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000110
+OSBORNE,Kill Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+OSBORNE,Kill Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000110
+OSBORNE,Lawrence Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000120
+OSBORNE,Lawrence Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000120
+OSBORNE,Lawrence Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000120
+OSBORNE,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000130
+OSBORNE,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000130
+OSBORNE,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000130
+OSBORNE,Mount Ayr Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000140
+OSBORNE,Mount Ayr Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+OSBORNE,Mount Ayr Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000140
+OSBORNE,Natoma Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000150
+OSBORNE,Natoma Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000150
+OSBORNE,Natoma Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",90,000150
+OSBORNE,Osborne Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,000160
+OSBORNE,Osborne Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000160
+OSBORNE,Osborne Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",104,000160
+OSBORNE,Osborne Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",84,000170
+OSBORNE,Osborne Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000170
+OSBORNE,Osborne Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000170
+OSBORNE,Osborne Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",44,000180
+OSBORNE,Osborne Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000180
+OSBORNE,Osborne Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000180
+OSBORNE,Penn Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000190
+OSBORNE,Penn Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000190
+OSBORNE,Penn Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000190
+OSBORNE,Ross 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000200
+OSBORNE,Ross 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000200
+OSBORNE,Ross 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000200
+OSBORNE,Ross 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000210
+OSBORNE,Ross 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000210
+OSBORNE,Ross 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,000210
+OSBORNE,Round Mound Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000220
+OSBORNE,Round Mound Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000220
+OSBORNE,Round Mound Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000220
+OSBORNE,Sumner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000230
+OSBORNE,Sumner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000230
+OSBORNE,Sumner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000230
+OSBORNE,Tilden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000240
+OSBORNE,Tilden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000240
+OSBORNE,Tilden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000240
+OSBORNE,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000250
+OSBORNE,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000250
+OSBORNE,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",1,000250
+OSBORNE,Victor Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000260
+OSBORNE,Victor Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000260
+OSBORNE,Victor Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000260
+OSBORNE,Winfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000270
+OSBORNE,Winfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000270
+OSBORNE,Winfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",6,000270
+OSBORNE,Bethany Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",54,000010
+OSBORNE,Bloom Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000020
+OSBORNE,Corinth Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",17,000030
+OSBORNE,Covert Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",4,000040
+OSBORNE,Delhi Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000050
+OSBORNE,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000060
+OSBORNE,Hancock Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",9,000070
+OSBORNE,Hawkeye Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",9,000080
+OSBORNE,Independence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000090
+OSBORNE,Jackson Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000100
+OSBORNE,Kill Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",3,000110
+OSBORNE,Lawrence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000120
+OSBORNE,Liberty Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000130
+OSBORNE,Mount Ayr Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000140
+OSBORNE,Natoma Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",109,000150
+OSBORNE,Osborne Ward 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",164,000160
+OSBORNE,Osborne Ward 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",192,000170
+OSBORNE,Osborne Ward 3,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",111,000180
+OSBORNE,Penn Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",43,000190
+OSBORNE,Ross 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",37,000200
+OSBORNE,Ross 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",281,000210
+OSBORNE,Round Mound Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000220
+OSBORNE,Sumner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",51,000230
+OSBORNE,Tilden Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",30,000240
+OSBORNE,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",2,000250
+OSBORNE,Victor Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",11,000260
+OSBORNE,Winfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000270
+OSBORNE,Bethany Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000010
+OSBORNE,Bethany Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000010
+OSBORNE,Bloom Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000020
+OSBORNE,Bloom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000020
+OSBORNE,Corinth Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000030
+OSBORNE,Corinth Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000030
+OSBORNE,Covert Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000040
+OSBORNE,Covert Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000040
+OSBORNE,Delhi Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000050
+OSBORNE,Delhi Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000050
+OSBORNE,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000060
+OSBORNE,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",6,000060
+OSBORNE,Hancock Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000070
+OSBORNE,Hancock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000070
+OSBORNE,Hawkeye Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000080
+OSBORNE,Hawkeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000080
+OSBORNE,Independence Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000090
+OSBORNE,Independence Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000090
+OSBORNE,Jackson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000100
+OSBORNE,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000100
+OSBORNE,Kill Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000110
+OSBORNE,Kill Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000110
+OSBORNE,Lawrence Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000120
+OSBORNE,Lawrence Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000120
+OSBORNE,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000130
+OSBORNE,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000130
+OSBORNE,Mount Ayr Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000140
+OSBORNE,Mount Ayr Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000140
+OSBORNE,Natoma Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000150
+OSBORNE,Natoma Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",97,000150
+OSBORNE,Osborne Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",53,000160
+OSBORNE,Osborne Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",127,000160
+OSBORNE,Osborne Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",72,000170
+OSBORNE,Osborne Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",156,000170
+OSBORNE,Osborne Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000180
+OSBORNE,Osborne Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000180
+OSBORNE,Penn Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000190
+OSBORNE,Penn Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000190
+OSBORNE,Ross 1,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000200
+OSBORNE,Ross 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000200
+OSBORNE,Ross 2,United States House of Representatives,1,Democratic,"Sherow, James E.",87,000210
+OSBORNE,Ross 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",221,000210
+OSBORNE,Round Mound Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000220
+OSBORNE,Round Mound Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000220
+OSBORNE,Sumner Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000230
+OSBORNE,Sumner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000230
+OSBORNE,Tilden Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000240
+OSBORNE,Tilden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000240
+OSBORNE,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000250
+OSBORNE,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,000250
+OSBORNE,Victor Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000260
+OSBORNE,Victor Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",6,000260
+OSBORNE,Winfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000270
+OSBORNE,Winfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000270
+OSBORNE,Bethany Township,Attorney General,,Democratic,"Kotich, A.J.",12,000010
+OSBORNE,Bethany Township,Attorney General,,Republican,"Schmidt, Derek",52,000010
+OSBORNE,Bloom Township,Attorney General,,Democratic,"Kotich, A.J.",3,000020
+OSBORNE,Bloom Township,Attorney General,,Republican,"Schmidt, Derek",23,000020
+OSBORNE,Corinth Township,Attorney General,,Democratic,"Kotich, A.J.",2,000030
+OSBORNE,Corinth Township,Attorney General,,Republican,"Schmidt, Derek",18,000030
+OSBORNE,Covert Township,Attorney General,,Democratic,"Kotich, A.J.",0,000040
+OSBORNE,Covert Township,Attorney General,,Republican,"Schmidt, Derek",3,000040
+OSBORNE,Delhi Township,Attorney General,,Democratic,"Kotich, A.J.",0,000050
+OSBORNE,Delhi Township,Attorney General,,Republican,"Schmidt, Derek",12,000050
+OSBORNE,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",1,000060
+OSBORNE,Grant Township,Attorney General,,Republican,"Schmidt, Derek",10,000060
+OSBORNE,Hancock Township,Attorney General,,Democratic,"Kotich, A.J.",0,000070
+OSBORNE,Hancock Township,Attorney General,,Republican,"Schmidt, Derek",9,000070
+OSBORNE,Hawkeye Township,Attorney General,,Democratic,"Kotich, A.J.",2,000080
+OSBORNE,Hawkeye Township,Attorney General,,Republican,"Schmidt, Derek",8,000080
+OSBORNE,Independence Township,Attorney General,,Democratic,"Kotich, A.J.",1,000090
+OSBORNE,Independence Township,Attorney General,,Republican,"Schmidt, Derek",10,000090
+OSBORNE,Jackson Township,Attorney General,,Democratic,"Kotich, A.J.",2,000100
+OSBORNE,Jackson Township,Attorney General,,Republican,"Schmidt, Derek",13,000100
+OSBORNE,Kill Creek Township,Attorney General,,Democratic,"Kotich, A.J.",0,000110
+OSBORNE,Kill Creek Township,Attorney General,,Republican,"Schmidt, Derek",2,000110
+OSBORNE,Lawrence Township,Attorney General,,Democratic,"Kotich, A.J.",3,000120
+OSBORNE,Lawrence Township,Attorney General,,Republican,"Schmidt, Derek",12,000120
+OSBORNE,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",2,000130
+OSBORNE,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",12,000130
+OSBORNE,Mount Ayr Township,Attorney General,,Democratic,"Kotich, A.J.",1,000140
+OSBORNE,Mount Ayr Township,Attorney General,,Republican,"Schmidt, Derek",24,000140
+OSBORNE,Natoma Township,Attorney General,,Democratic,"Kotich, A.J.",11,000150
+OSBORNE,Natoma Township,Attorney General,,Republican,"Schmidt, Derek",105,000150
+OSBORNE,Osborne Ward 1,Attorney General,,Democratic,"Kotich, A.J.",31,000160
+OSBORNE,Osborne Ward 1,Attorney General,,Republican,"Schmidt, Derek",145,000160
+OSBORNE,Osborne Ward 2,Attorney General,,Democratic,"Kotich, A.J.",41,000170
+OSBORNE,Osborne Ward 2,Attorney General,,Republican,"Schmidt, Derek",182,000170
+OSBORNE,Osborne Ward 3,Attorney General,,Democratic,"Kotich, A.J.",30,000180
+OSBORNE,Osborne Ward 3,Attorney General,,Republican,"Schmidt, Derek",102,000180
+OSBORNE,Penn Township,Attorney General,,Democratic,"Kotich, A.J.",7,000190
+OSBORNE,Penn Township,Attorney General,,Republican,"Schmidt, Derek",39,000190
+OSBORNE,Ross 1,Attorney General,,Democratic,"Kotich, A.J.",6,000200
+OSBORNE,Ross 1,Attorney General,,Republican,"Schmidt, Derek",38,000200
+OSBORNE,Ross 2,Attorney General,,Democratic,"Kotich, A.J.",50,000210
+OSBORNE,Ross 2,Attorney General,,Republican,"Schmidt, Derek",260,000210
+OSBORNE,Round Mound Township,Attorney General,,Democratic,"Kotich, A.J.",0,000220
+OSBORNE,Round Mound Township,Attorney General,,Republican,"Schmidt, Derek",21,000220
+OSBORNE,Sumner Township,Attorney General,,Democratic,"Kotich, A.J.",4,000230
+OSBORNE,Sumner Township,Attorney General,,Republican,"Schmidt, Derek",48,000230
+OSBORNE,Tilden Township,Attorney General,,Democratic,"Kotich, A.J.",0,000240
+OSBORNE,Tilden Township,Attorney General,,Republican,"Schmidt, Derek",34,000240
+OSBORNE,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",0,000250
+OSBORNE,Valley Township,Attorney General,,Republican,"Schmidt, Derek",2,000250
+OSBORNE,Victor Township,Attorney General,,Democratic,"Kotich, A.J.",2,000260
+OSBORNE,Victor Township,Attorney General,,Republican,"Schmidt, Derek",9,000260
+OSBORNE,Winfield Township,Attorney General,,Democratic,"Kotich, A.J.",1,000270
+OSBORNE,Winfield Township,Attorney General,,Republican,"Schmidt, Derek",9,000270
+OSBORNE,Bethany Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000010
+OSBORNE,Bethany Township,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000010
+OSBORNE,Bloom Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000020
+OSBORNE,Bloom Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000020
+OSBORNE,Corinth Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000030
+OSBORNE,Corinth Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000030
+OSBORNE,Covert Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000040
+OSBORNE,Covert Township,Commissioner of Insurance,,Republican,"Selzer, Ken",2,000040
+OSBORNE,Delhi Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000050
+OSBORNE,Delhi Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000050
+OSBORNE,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000060
+OSBORNE,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000060
+OSBORNE,Hancock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000070
+OSBORNE,Hancock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000070
+OSBORNE,Hawkeye Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000080
+OSBORNE,Hawkeye Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000080
+OSBORNE,Independence Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000090
+OSBORNE,Independence Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000090
+OSBORNE,Jackson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000100
+OSBORNE,Jackson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000100
+OSBORNE,Kill Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000110
+OSBORNE,Kill Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",3,000110
+OSBORNE,Lawrence Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000120
+OSBORNE,Lawrence Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000120
+OSBORNE,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000130
+OSBORNE,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000130
+OSBORNE,Mount Ayr Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000140
+OSBORNE,Mount Ayr Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000140
+OSBORNE,Natoma Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000150
+OSBORNE,Natoma Township,Commissioner of Insurance,,Republican,"Selzer, Ken",100,000150
+OSBORNE,Osborne Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000160
+OSBORNE,Osborne Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000160
+OSBORNE,Osborne Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000170
+OSBORNE,Osborne Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",164,000170
+OSBORNE,Osborne Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000180
+OSBORNE,Osborne Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",93,000180
+OSBORNE,Penn Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000190
+OSBORNE,Penn Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000190
+OSBORNE,Ross 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000200
+OSBORNE,Ross 1,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000200
+OSBORNE,Ross 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,000210
+OSBORNE,Ross 2,Commissioner of Insurance,,Republican,"Selzer, Ken",237,000210
+OSBORNE,Round Mound Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000220
+OSBORNE,Round Mound Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000220
+OSBORNE,Sumner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000230
+OSBORNE,Sumner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000230
+OSBORNE,Tilden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000240
+OSBORNE,Tilden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000240
+OSBORNE,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000250
+OSBORNE,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",1,000250
+OSBORNE,Victor Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000260
+OSBORNE,Victor Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000260
+OSBORNE,Winfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000270
+OSBORNE,Winfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000270
+OSBORNE,Bethany Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000010
+OSBORNE,Bethany Township,Secretary of State,,Republican,"Kobach, Kris",49,000010
+OSBORNE,Bloom Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000020
+OSBORNE,Bloom Township,Secretary of State,,Republican,"Kobach, Kris",20,000020
+OSBORNE,Corinth Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000030
+OSBORNE,Corinth Township,Secretary of State,,Republican,"Kobach, Kris",11,000030
+OSBORNE,Covert Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000040
+OSBORNE,Covert Township,Secretary of State,,Republican,"Kobach, Kris",3,000040
+OSBORNE,Delhi Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000050
+OSBORNE,Delhi Township,Secretary of State,,Republican,"Kobach, Kris",10,000050
+OSBORNE,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000060
+OSBORNE,Grant Township,Secretary of State,,Republican,"Kobach, Kris",9,000060
+OSBORNE,Hancock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000070
+OSBORNE,Hancock Township,Secretary of State,,Republican,"Kobach, Kris",9,000070
+OSBORNE,Hawkeye Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000080
+OSBORNE,Hawkeye Township,Secretary of State,,Republican,"Kobach, Kris",9,000080
+OSBORNE,Independence Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000090
+OSBORNE,Independence Township,Secretary of State,,Republican,"Kobach, Kris",7,000090
+OSBORNE,Jackson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000100
+OSBORNE,Jackson Township,Secretary of State,,Republican,"Kobach, Kris",15,000100
+OSBORNE,Kill Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000110
+OSBORNE,Kill Creek Township,Secretary of State,,Republican,"Kobach, Kris",2,000110
+OSBORNE,Lawrence Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000120
+OSBORNE,Lawrence Township,Secretary of State,,Republican,"Kobach, Kris",12,000120
+OSBORNE,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000130
+OSBORNE,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",12,000130
+OSBORNE,Mount Ayr Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000140
+OSBORNE,Mount Ayr Township,Secretary of State,,Republican,"Kobach, Kris",24,000140
+OSBORNE,Natoma Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000150
+OSBORNE,Natoma Township,Secretary of State,,Republican,"Kobach, Kris",100,000150
+OSBORNE,Osborne Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000160
+OSBORNE,Osborne Ward 1,Secretary of State,,Republican,"Kobach, Kris",123,000160
+OSBORNE,Osborne Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000170
+OSBORNE,Osborne Ward 2,Secretary of State,,Republican,"Kobach, Kris",165,000170
+OSBORNE,Osborne Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000180
+OSBORNE,Osborne Ward 3,Secretary of State,,Republican,"Kobach, Kris",100,000180
+OSBORNE,Penn Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000190
+OSBORNE,Penn Township,Secretary of State,,Republican,"Kobach, Kris",36,000190
+OSBORNE,Ross 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000200
+OSBORNE,Ross 1,Secretary of State,,Republican,"Kobach, Kris",35,000200
+OSBORNE,Ross 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",84,000210
+OSBORNE,Ross 2,Secretary of State,,Republican,"Kobach, Kris",227,000210
+OSBORNE,Round Mound Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000220
+OSBORNE,Round Mound Township,Secretary of State,,Republican,"Kobach, Kris",21,000220
+OSBORNE,Sumner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000230
+OSBORNE,Sumner Township,Secretary of State,,Republican,"Kobach, Kris",39,000230
+OSBORNE,Tilden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000240
+OSBORNE,Tilden Township,Secretary of State,,Republican,"Kobach, Kris",32,000240
+OSBORNE,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000250
+OSBORNE,Valley Township,Secretary of State,,Republican,"Kobach, Kris",2,000250
+OSBORNE,Victor Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000260
+OSBORNE,Victor Township,Secretary of State,,Republican,"Kobach, Kris",4,000260
+OSBORNE,Winfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000270
+OSBORNE,Winfield Township,Secretary of State,,Republican,"Kobach, Kris",7,000270
+OSBORNE,Bethany Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000010
+OSBORNE,Bethany Township,State Treasurer,,Republican,"Estes, Ron",49,000010
+OSBORNE,Bloom Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000020
+OSBORNE,Bloom Township,State Treasurer,,Republican,"Estes, Ron",23,000020
+OSBORNE,Corinth Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+OSBORNE,Corinth Township,State Treasurer,,Republican,"Estes, Ron",17,000030
+OSBORNE,Covert Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+OSBORNE,Covert Township,State Treasurer,,Republican,"Estes, Ron",2,000040
+OSBORNE,Delhi Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000050
+OSBORNE,Delhi Township,State Treasurer,,Republican,"Estes, Ron",11,000050
+OSBORNE,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000060
+OSBORNE,Grant Township,State Treasurer,,Republican,"Estes, Ron",9,000060
+OSBORNE,Hancock Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000070
+OSBORNE,Hancock Township,State Treasurer,,Republican,"Estes, Ron",9,000070
+OSBORNE,Hawkeye Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000080
+OSBORNE,Hawkeye Township,State Treasurer,,Republican,"Estes, Ron",9,000080
+OSBORNE,Independence Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000090
+OSBORNE,Independence Township,State Treasurer,,Republican,"Estes, Ron",9,000090
+OSBORNE,Jackson Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000100
+OSBORNE,Jackson Township,State Treasurer,,Republican,"Estes, Ron",13,000100
+OSBORNE,Kill Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000110
+OSBORNE,Kill Creek Township,State Treasurer,,Republican,"Estes, Ron",3,000110
+OSBORNE,Lawrence Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000120
+OSBORNE,Lawrence Township,State Treasurer,,Republican,"Estes, Ron",11,000120
+OSBORNE,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000130
+OSBORNE,Liberty Township,State Treasurer,,Republican,"Estes, Ron",12,000130
+OSBORNE,Mount Ayr Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000140
+OSBORNE,Mount Ayr Township,State Treasurer,,Republican,"Estes, Ron",23,000140
+OSBORNE,Natoma Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000150
+OSBORNE,Natoma Township,State Treasurer,,Republican,"Estes, Ron",107,000150
+OSBORNE,Osborne Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",34,000160
+OSBORNE,Osborne Ward 1,State Treasurer,,Republican,"Estes, Ron",146,000160
+OSBORNE,Osborne Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",42,000170
+OSBORNE,Osborne Ward 2,State Treasurer,,Republican,"Estes, Ron",178,000170
+OSBORNE,Osborne Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",35,000180
+OSBORNE,Osborne Ward 3,State Treasurer,,Republican,"Estes, Ron",94,000180
+OSBORNE,Penn Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000190
+OSBORNE,Penn Township,State Treasurer,,Republican,"Estes, Ron",37,000190
+OSBORNE,Ross 1,State Treasurer,,Democratic,"Alldritt, Carmen",6,000200
+OSBORNE,Ross 1,State Treasurer,,Republican,"Estes, Ron",37,000200
+OSBORNE,Ross 2,State Treasurer,,Democratic,"Alldritt, Carmen",57,000210
+OSBORNE,Ross 2,State Treasurer,,Republican,"Estes, Ron",256,000210
+OSBORNE,Round Mound Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000220
+OSBORNE,Round Mound Township,State Treasurer,,Republican,"Estes, Ron",21,000220
+OSBORNE,Sumner Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000230
+OSBORNE,Sumner Township,State Treasurer,,Republican,"Estes, Ron",49,000230
+OSBORNE,Tilden Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000240
+OSBORNE,Tilden Township,State Treasurer,,Republican,"Estes, Ron",31,000240
+OSBORNE,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000250
+OSBORNE,Valley Township,State Treasurer,,Republican,"Estes, Ron",2,000250
+OSBORNE,Victor Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000260
+OSBORNE,Victor Township,State Treasurer,,Republican,"Estes, Ron",9,000260
+OSBORNE,Winfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000270
+OSBORNE,Winfield Township,State Treasurer,,Republican,"Estes, Ron",8,000270
+OSBORNE,Bethany Township,United States Senate,,independent,"Orman, Greg",18,000010
+OSBORNE,Bethany Township,United States Senate,,Libertarian,"Batson, Randall",4,000010
+OSBORNE,Bethany Township,United States Senate,,Republican,"Roberts, Pat",41,000010
+OSBORNE,Bloom Township,United States Senate,,independent,"Orman, Greg",4,000020
+OSBORNE,Bloom Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+OSBORNE,Bloom Township,United States Senate,,Republican,"Roberts, Pat",22,000020
+OSBORNE,Corinth Township,United States Senate,,independent,"Orman, Greg",7,000030
+OSBORNE,Corinth Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+OSBORNE,Corinth Township,United States Senate,,Republican,"Roberts, Pat",14,000030
+OSBORNE,Covert Township,United States Senate,,independent,"Orman, Greg",0,000040
+OSBORNE,Covert Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+OSBORNE,Covert Township,United States Senate,,Republican,"Roberts, Pat",4,000040
+OSBORNE,Delhi Township,United States Senate,,independent,"Orman, Greg",5,000050
+OSBORNE,Delhi Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+OSBORNE,Delhi Township,United States Senate,,Republican,"Roberts, Pat",8,000050
+OSBORNE,Grant Township,United States Senate,,independent,"Orman, Greg",0,000060
+OSBORNE,Grant Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+OSBORNE,Grant Township,United States Senate,,Republican,"Roberts, Pat",9,000060
+OSBORNE,Hancock Township,United States Senate,,independent,"Orman, Greg",0,000070
+OSBORNE,Hancock Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+OSBORNE,Hancock Township,United States Senate,,Republican,"Roberts, Pat",10,000070
+OSBORNE,Hawkeye Township,United States Senate,,independent,"Orman, Greg",1,000080
+OSBORNE,Hawkeye Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+OSBORNE,Hawkeye Township,United States Senate,,Republican,"Roberts, Pat",9,000080
+OSBORNE,Independence Township,United States Senate,,independent,"Orman, Greg",2,000090
+OSBORNE,Independence Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+OSBORNE,Independence Township,United States Senate,,Republican,"Roberts, Pat",9,000090
+OSBORNE,Jackson Township,United States Senate,,independent,"Orman, Greg",1,000100
+OSBORNE,Jackson Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+OSBORNE,Jackson Township,United States Senate,,Republican,"Roberts, Pat",15,000100
+OSBORNE,Kill Creek Township,United States Senate,,independent,"Orman, Greg",0,000110
+OSBORNE,Kill Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+OSBORNE,Kill Creek Township,United States Senate,,Republican,"Roberts, Pat",3,000110
+OSBORNE,Lawrence Township,United States Senate,,independent,"Orman, Greg",4,000120
+OSBORNE,Lawrence Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+OSBORNE,Lawrence Township,United States Senate,,Republican,"Roberts, Pat",11,000120
+OSBORNE,Liberty Township,United States Senate,,independent,"Orman, Greg",1,000130
+OSBORNE,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",0,000130
+OSBORNE,Liberty Township,United States Senate,,Republican,"Roberts, Pat",13,000130
+OSBORNE,Mount Ayr Township,United States Senate,,independent,"Orman, Greg",2,000140
+OSBORNE,Mount Ayr Township,United States Senate,,Libertarian,"Batson, Randall",1,000140
+OSBORNE,Mount Ayr Township,United States Senate,,Republican,"Roberts, Pat",22,000140
+OSBORNE,Natoma Township,United States Senate,,independent,"Orman, Greg",17,000150
+OSBORNE,Natoma Township,United States Senate,,Libertarian,"Batson, Randall",4,000150
+OSBORNE,Natoma Township,United States Senate,,Republican,"Roberts, Pat",95,000150
+OSBORNE,Osborne Ward 1,United States Senate,,independent,"Orman, Greg",48,000160
+OSBORNE,Osborne Ward 1,United States Senate,,Libertarian,"Batson, Randall",12,000160
+OSBORNE,Osborne Ward 1,United States Senate,,Republican,"Roberts, Pat",119,000160
+OSBORNE,Osborne Ward 2,United States Senate,,independent,"Orman, Greg",61,000170
+OSBORNE,Osborne Ward 2,United States Senate,,Libertarian,"Batson, Randall",11,000170
+OSBORNE,Osborne Ward 2,United States Senate,,Republican,"Roberts, Pat",157,000170
+OSBORNE,Osborne Ward 3,United States Senate,,independent,"Orman, Greg",36,000180
+OSBORNE,Osborne Ward 3,United States Senate,,Libertarian,"Batson, Randall",8,000180
+OSBORNE,Osborne Ward 3,United States Senate,,Republican,"Roberts, Pat",92,000180
+OSBORNE,Penn Township,United States Senate,,independent,"Orman, Greg",8,000190
+OSBORNE,Penn Township,United States Senate,,Libertarian,"Batson, Randall",1,000190
+OSBORNE,Penn Township,United States Senate,,Republican,"Roberts, Pat",39,000190
+OSBORNE,Ross 1,United States Senate,,independent,"Orman, Greg",8,000200
+OSBORNE,Ross 1,United States Senate,,Libertarian,"Batson, Randall",3,000200
+OSBORNE,Ross 1,United States Senate,,Republican,"Roberts, Pat",33,000200
+OSBORNE,Ross 2,United States Senate,,independent,"Orman, Greg",93,000210
+OSBORNE,Ross 2,United States Senate,,Libertarian,"Batson, Randall",21,000210
+OSBORNE,Ross 2,United States Senate,,Republican,"Roberts, Pat",204,000210
+OSBORNE,Round Mound Township,United States Senate,,independent,"Orman, Greg",0,000220
+OSBORNE,Round Mound Township,United States Senate,,Libertarian,"Batson, Randall",0,000220
+OSBORNE,Round Mound Township,United States Senate,,Republican,"Roberts, Pat",21,000220
+OSBORNE,Sumner Township,United States Senate,,independent,"Orman, Greg",8,000230
+OSBORNE,Sumner Township,United States Senate,,Libertarian,"Batson, Randall",1,000230
+OSBORNE,Sumner Township,United States Senate,,Republican,"Roberts, Pat",45,000230
+OSBORNE,Tilden Township,United States Senate,,independent,"Orman, Greg",2,000240
+OSBORNE,Tilden Township,United States Senate,,Libertarian,"Batson, Randall",1,000240
+OSBORNE,Tilden Township,United States Senate,,Republican,"Roberts, Pat",32,000240
+OSBORNE,Valley Township,United States Senate,,independent,"Orman, Greg",0,000250
+OSBORNE,Valley Township,United States Senate,,Libertarian,"Batson, Randall",1,000250
+OSBORNE,Valley Township,United States Senate,,Republican,"Roberts, Pat",1,000250
+OSBORNE,Victor Township,United States Senate,,independent,"Orman, Greg",3,000260
+OSBORNE,Victor Township,United States Senate,,Libertarian,"Batson, Randall",0,000260
+OSBORNE,Victor Township,United States Senate,,Republican,"Roberts, Pat",8,000260
+OSBORNE,Winfield Township,United States Senate,,independent,"Orman, Greg",0,000270
+OSBORNE,Winfield Township,United States Senate,,Libertarian,"Batson, Randall",0,000270
+OSBORNE,Winfield Township,United States Senate,,Republican,"Roberts, Pat",10,000270

--- a/2014/20141104__ks__general__ottawa__precinct.csv
+++ b/2014/20141104__ks__general__ottawa__precinct.csv
@@ -1,408 +1,409 @@
-county,precinct,office,district,party,candidate,votes
-Ottawa,Mpls 1,Attorney General,,D,A.J. Kotich,38
-Ottawa,Mpls II,Attorney General,,D,A.J. Kotich,28
-Ottawa,Mpls III,Attorney General,,D,A.J. Kotich,39
-Ottawa,Mpls 1,Attorney General,,R,Derek Schmidt,231
-Ottawa,Mpls II,Attorney General,,R,Derek Schmidt,150
-Ottawa,Mpls III,Attorney General,,R,Derek Schmidt,219
-Ottawa,Mpls 1,U.S. House,1,D,James Sherow,59
-Ottawa,Mpls II,U.S. House,1,D,James Sherow,44
-Ottawa,Mpls III,U.S. House,1,D,James Sherow,67
-Ottawa,Mpls 1,U.S. House,1,R,Tim Huelskamp,211
-Ottawa,Mpls II,U.S. House,1,R,Tim Huelskamp,134
-Ottawa,Mpls III,U.S. House,1,R,Tim Huelskamp,191
-Ottawa,Mpls 1,U.S. House,1,,Write-ins,1
-Ottawa,Mpls III,U.S. House,1,,Write-ins,1
-Ottawa,Mpls 1,Governor ,,L,Keen Umbehr,17
-Ottawa,Mpls II,Governor ,,L,Keen Umbehr,19
-Ottawa,Mpls III,Governor ,,L,Keen Umbehr,22
-Ottawa,Mpls 1,Governor ,,D,Paul Davis,72
-Ottawa,Mpls II,Governor ,,D,Paul Davis,48
-Ottawa,Mpls III,Governor ,,D,Paul Davis,73
-Ottawa,Mpls 1,Governor ,,R,Sam Brownback,187
-Ottawa,Mpls II,Governor ,,R,Sam Brownback,111
-Ottawa,Mpls III,Governor ,,R,Sam Brownback,173
-Ottawa,Mpls 1,Insurance Commissioner,,D,Dennis Anderson,42
-Ottawa,Mpls II,Insurance Commissioner,,D,Dennis Anderson,36
-Ottawa,Mpls III,Insurance Commissioner,,D,Dennis Anderson,54
-Ottawa,Mpls 1,Insurance Commissioner,,R,Ken Selzer,212
-Ottawa,Mpls II,Insurance Commissioner,,R,Ken Selzer,138
-Ottawa,Mpls III,Insurance Commissioner,,R,Ken Selzer,197
-Ottawa,Mpls 1,Insurance Commissioner,,,Write-ins,1
-Ottawa,Mpls 1,Secretary of State,,D,Jean Kurtis Schodorf,67
-Ottawa,Mpls II,Secretary of State,,D,Jean Kurtis Schodorf,43
-Ottawa,Mpls III,Secretary of State,,D,Jean Kurtis Schodorf,62
-Ottawa,Mpls 1,Secretary of State,,R,Kris Kobach,204
-Ottawa,Mpls II,Secretary of State,,R,Kris Kobach,137
-Ottawa,Mpls III,Secretary of State,,R,Kris Kobach,199
-Ottawa,Mpls 1,State House,107,R,Susan Concannon,228
-Ottawa,Mpls II,State House,107,R,Susan Concannon,150
-Ottawa,Mpls III,State House,107,R,Susan Concannon,220
-Ottawa,Mpls 1,State House,107,,Write-ins,1
-Ottawa,Mpls III,State House,107,,Write-ins,1
-Ottawa,Mpls 1,State Treasurer,,D,Carmen Alldritt,37
-Ottawa,Mpls II,State Treasurer,,D,Carmen Alldritt,27
-Ottawa,Mpls III,State Treasurer,,D,Carmen Alldritt,37
-Ottawa,Mpls 1,State Treasurer,,R,Ron Estes,229
-Ottawa,Mpls II,State Treasurer,,R,Ron Estes,151
-Ottawa,Mpls III,State Treasurer,,R,Ron Estes,218
-Ottawa,Mpls 1,U.S. Senate,,I,Greg Orman,57
-Ottawa,Mpls II,U.S. Senate,,I,Greg Orman,36
-Ottawa,Mpls III,U.S. Senate,,I,Greg Orman,58
-Ottawa,Mpls 1,U.S. Senate,,R,Pat Roberts,204
-Ottawa,Mpls II,U.S. Senate,,R,Pat Roberts,127
-Ottawa,Mpls III,U.S. Senate,,R,Pat Roberts,188
-Ottawa,Mpls 1,U.S. Senate,,L,Randall Batson,11
-Ottawa,Mpls II,U.S. Senate,,L,Randall Batson,15
-Ottawa,Mpls III,U.S. Senate,,L,Randall Batson,17
-Ottawa,Mpls III,U.S. Senate,,,Write-ins,1
-Ottawa,Bennington,Attorney General,,D,A.J. Kotich,89
-Ottawa,Blaine,Attorney General,,D,A.J. Kotich,10
-Ottawa,Buckeye,Attorney General,,D,A.J. Kotich,9
-Ottawa,Center,Attorney General,,D,A.J. Kotich,4
-Ottawa,Chapman,Attorney General,,D,A.J. Kotich,2
-Ottawa,Concord,Attorney General,,D,A.J. Kotich,14
-Ottawa,Culver,Attorney General,,D,A.J. Kotich,22
-Ottawa,Durham,Attorney General,,D,A.J. Kotich,0
-Ottawa,Fountain,Attorney General,,D,A.J. Kotich,7
-Ottawa,Garfield,Attorney General,,D,A.J. Kotich,3
-Ottawa,Grant,Attorney General,,D,A.J. Kotich,1
-Ottawa,Henry,Attorney General,,D,A.J. Kotich,2
-Ottawa,Lincoln,Attorney General,,D,A.J. Kotich,20
-Ottawa,Logan,Attorney General,,D,A.J. Kotich,3
-Ottawa,Morton,Attorney General,,D,A.J. Kotich,27
-Ottawa,Ottawa,Attorney General,,D,A.J. Kotich,5
-Ottawa,Richland,Attorney General,,D,A.J. Kotich,15
-Ottawa,Sheridan,Attorney General,,D,A.J. Kotich,36
-Ottawa,Sherman,Attorney General,,D,A.J. Kotich,4
-Ottawa,Stanton,Attorney General,,D,A.J. Kotich,6
-Ottawa,Bennington,Attorney General,,R,Derek Schmidt,369
-Ottawa,Blaine,Attorney General,,R,Derek Schmidt,49
-Ottawa,Buckeye,Attorney General,,R,Derek Schmidt,41
-Ottawa,Center,Attorney General,,R,Derek Schmidt,35
-Ottawa,Chapman,Attorney General,,R,Derek Schmidt,30
-Ottawa,Concord,Attorney General,,R,Derek Schmidt,84
-Ottawa,Culver,Attorney General,,R,Derek Schmidt,90
-Ottawa,Durham,Attorney General,,R,Derek Schmidt,6
-Ottawa,Fountain,Attorney General,,R,Derek Schmidt,48
-Ottawa,Garfield,Attorney General,,R,Derek Schmidt,36
-Ottawa,Grant,Attorney General,,R,Derek Schmidt,39
-Ottawa,Henry,Attorney General,,R,Derek Schmidt,7
-Ottawa,Lincoln,Attorney General,,R,Derek Schmidt,35
-Ottawa,Logan,Attorney General,,R,Derek Schmidt,28
-Ottawa,Morton,Attorney General,,R,Derek Schmidt,136
-Ottawa,Ottawa,Attorney General,,R,Derek Schmidt,14
-Ottawa,Richland,Attorney General,,R,Derek Schmidt,93
-Ottawa,Sheridan,Attorney General,,R,Derek Schmidt,139
-Ottawa,Sherman,Attorney General,,R,Derek Schmidt,22
-Ottawa,Stanton,Attorney General,,R,Derek Schmidt,20
-Ottawa,Bennington,Attorney General,,,Write-ins,1
-Ottawa,Bennington,U.S. House,1,D,James Sherow,133
-Ottawa,Blaine,U.S. House,1,D,James Sherow,10
-Ottawa,Buckeye,U.S. House,1,D,James Sherow,13
-Ottawa,Center,U.S. House,1,D,James Sherow,5
-Ottawa,Chapman,U.S. House,1,D,James Sherow,4
-Ottawa,Concord,U.S. House,1,D,James Sherow,23
-Ottawa,Culver,U.S. House,1,D,James Sherow,25
-Ottawa,Durham,U.S. House,1,D,James Sherow,2
-Ottawa,Fountain,U.S. House,1,D,James Sherow,12
-Ottawa,Garfield,U.S. House,1,D,James Sherow,5
-Ottawa,Grant,U.S. House,1,D,James Sherow,4
-Ottawa,Henry,U.S. House,1,D,James Sherow,2
-Ottawa,Lincoln,U.S. House,1,D,James Sherow,24
-Ottawa,Logan,U.S. House,1,D,James Sherow,7
-Ottawa,Morton,U.S. House,1,D,James Sherow,35
-Ottawa,Ottawa,U.S. House,1,D,James Sherow,5
-Ottawa,Richland,U.S. House,1,D,James Sherow,19
-Ottawa,Sheridan,U.S. House,1,D,James Sherow,48
-Ottawa,Sherman,U.S. House,1,D,James Sherow,4
-Ottawa,Stanton,U.S. House,1,D,James Sherow,9
-Ottawa,Bennington,U.S. House,1,R,Tim Huelskamp,327
-Ottawa,Blaine,U.S. House,1,R,Tim Huelskamp,48
-Ottawa,Buckeye,U.S. House,1,R,Tim Huelskamp,36
-Ottawa,Center,U.S. House,1,R,Tim Huelskamp,34
-Ottawa,Chapman,U.S. House,1,R,Tim Huelskamp,28
-Ottawa,Concord,U.S. House,1,R,Tim Huelskamp,76
-Ottawa,Culver,U.S. House,1,R,Tim Huelskamp,82
-Ottawa,Durham,U.S. House,1,R,Tim Huelskamp,4
-Ottawa,Fountain,U.S. House,1,R,Tim Huelskamp,42
-Ottawa,Garfield,U.S. House,1,R,Tim Huelskamp,34
-Ottawa,Grant,U.S. House,1,R,Tim Huelskamp,38
-Ottawa,Henry,U.S. House,1,R,Tim Huelskamp,7
-Ottawa,Lincoln,U.S. House,1,R,Tim Huelskamp,31
-Ottawa,Logan,U.S. House,1,R,Tim Huelskamp,25
-Ottawa,Morton,U.S. House,1,R,Tim Huelskamp,129
-Ottawa,Ottawa,U.S. House,1,R,Tim Huelskamp,16
-Ottawa,Richland,U.S. House,1,R,Tim Huelskamp,87
-Ottawa,Sheridan,U.S. House,1,R,Tim Huelskamp,130
-Ottawa,Sherman,U.S. House,1,R,Tim Huelskamp,22
-Ottawa,Stanton,U.S. House,1,R,Tim Huelskamp,15
-Ottawa,Bennington,U.S. House,1,,Write-ins,1
-Ottawa,Bennington,Governor ,,L,Keen Umbehr,31
-Ottawa,Blaine,Governor ,,L,Keen Umbehr,5
-Ottawa,Buckeye,Governor ,,L,Keen Umbehr,4
-Ottawa,Center,Governor ,,L,Keen Umbehr,3
-Ottawa,Chapman,Governor ,,L,Keen Umbehr,2
-Ottawa,Concord,Governor ,,L,Keen Umbehr,5
-Ottawa,Culver,Governor ,,L,Keen Umbehr,5
-Ottawa,Durham,Governor ,,L,Keen Umbehr,0
-Ottawa,Fountain,Governor ,,L,Keen Umbehr,2
-Ottawa,Garfield,Governor ,,L,Keen Umbehr,2
-Ottawa,Grant,Governor ,,L,Keen Umbehr,2
-Ottawa,Henry,Governor ,,L,Keen Umbehr,1
-Ottawa,Lincoln,Governor ,,L,Keen Umbehr,1
-Ottawa,Logan,Governor ,,L,Keen Umbehr,2
-Ottawa,Morton,Governor ,,L,Keen Umbehr,20
-Ottawa,Ottawa,Governor ,,L,Keen Umbehr,1
-Ottawa,Richland,Governor ,,L,Keen Umbehr,8
-Ottawa,Sheridan,Governor ,,L,Keen Umbehr,19
-Ottawa,Sherman,Governor ,,L,Keen Umbehr,0
-Ottawa,Stanton,Governor ,,L,Keen Umbehr,0
-Ottawa,Bennington,Governor ,,D,Paul Davis,177
-Ottawa,Blaine,Governor ,,D,Paul Davis,15
-Ottawa,Buckeye,Governor ,,D,Paul Davis,15
-Ottawa,Center,Governor ,,D,Paul Davis,4
-Ottawa,Chapman,Governor ,,D,Paul Davis,4
-Ottawa,Concord,Governor ,,D,Paul Davis,28
-Ottawa,Culver,Governor ,,D,Paul Davis,35
-Ottawa,Durham,Governor ,,D,Paul Davis,3
-Ottawa,Fountain,Governor ,,D,Paul Davis,15
-Ottawa,Garfield,Governor ,,D,Paul Davis,6
-Ottawa,Grant,Governor ,,D,Paul Davis,10
-Ottawa,Henry,Governor ,,D,Paul Davis,1
-Ottawa,Lincoln,Governor ,,D,Paul Davis,28
-Ottawa,Logan,Governor ,,D,Paul Davis,4
-Ottawa,Morton,Governor ,,D,Paul Davis,45
-Ottawa,Ottawa,Governor ,,D,Paul Davis,5
-Ottawa,Richland,Governor ,,D,Paul Davis,20
-Ottawa,Sheridan,Governor ,,D,Paul Davis,55
-Ottawa,Sherman,Governor ,,D,Paul Davis,2
-Ottawa,Stanton,Governor ,,D,Paul Davis,12
-Ottawa,Bennington,Governor ,,R,Sam Brownback,261
-Ottawa,Blaine,Governor ,,R,Sam Brownback,39
-Ottawa,Buckeye,Governor ,,R,Sam Brownback,31
-Ottawa,Center,Governor ,,R,Sam Brownback,32
-Ottawa,Chapman,Governor ,,R,Sam Brownback,25
-Ottawa,Concord,Governor ,,R,Sam Brownback,68
-Ottawa,Culver,Governor ,,R,Sam Brownback,72
-Ottawa,Durham,Governor ,,R,Sam Brownback,3
-Ottawa,Fountain,Governor ,,R,Sam Brownback,37
-Ottawa,Garfield,Governor ,,R,Sam Brownback,31
-Ottawa,Grant,Governor ,,R,Sam Brownback,30
-Ottawa,Henry,Governor ,,R,Sam Brownback,7
-Ottawa,Lincoln,Governor ,,R,Sam Brownback,26
-Ottawa,Logan,Governor ,,R,Sam Brownback,26
-Ottawa,Morton,Governor ,,R,Sam Brownback,103
-Ottawa,Ottawa,Governor ,,R,Sam Brownback,15
-Ottawa,Richland,Governor ,,R,Sam Brownback,79
-Ottawa,Sheridan,Governor ,,R,Sam Brownback,106
-Ottawa,Sherman,Governor ,,R,Sam Brownback,24
-Ottawa,Stanton,Governor ,,R,Sam Brownback,14
-Ottawa,Lincoln,Governor ,,,Write-ins,2
-Ottawa,Bennington,Insurance Commissioner,,D,Dennis Anderson,105
-Ottawa,Blaine,Insurance Commissioner,,D,Dennis Anderson,13
-Ottawa,Buckeye,Insurance Commissioner,,D,Dennis Anderson,8
-Ottawa,Center,Insurance Commissioner,,D,Dennis Anderson,6
-Ottawa,Chapman,Insurance Commissioner,,D,Dennis Anderson,3
-Ottawa,Concord,Insurance Commissioner,,D,Dennis Anderson,19
-Ottawa,Culver,Insurance Commissioner,,D,Dennis Anderson,26
-Ottawa,Durham,Insurance Commissioner,,D,Dennis Anderson,1
-Ottawa,Fountain,Insurance Commissioner,,D,Dennis Anderson,11
-Ottawa,Garfield,Insurance Commissioner,,D,Dennis Anderson,4
-Ottawa,Grant,Insurance Commissioner,,D,Dennis Anderson,4
-Ottawa,Henry,Insurance Commissioner,,D,Dennis Anderson,1
-Ottawa,Lincoln,Insurance Commissioner,,D,Dennis Anderson,20
-Ottawa,Logan,Insurance Commissioner,,D,Dennis Anderson,5
-Ottawa,Morton,Insurance Commissioner,,D,Dennis Anderson,30
-Ottawa,Ottawa,Insurance Commissioner,,D,Dennis Anderson,5
-Ottawa,Richland,Insurance Commissioner,,D,Dennis Anderson,14
-Ottawa,Sheridan,Insurance Commissioner,,D,Dennis Anderson,28
-Ottawa,Sherman,Insurance Commissioner,,D,Dennis Anderson,4
-Ottawa,Stanton,Insurance Commissioner,,D,Dennis Anderson,7
-Ottawa,Bennington,Insurance Commissioner,,R,Ken Selzer,338
-Ottawa,Blaine,Insurance Commissioner,,R,Ken Selzer,41
-Ottawa,Buckeye,Insurance Commissioner,,R,Ken Selzer,39
-Ottawa,Center,Insurance Commissioner,,R,Ken Selzer,30
-Ottawa,Chapman,Insurance Commissioner,,R,Ken Selzer,27
-Ottawa,Concord,Insurance Commissioner,,R,Ken Selzer,77
-Ottawa,Culver,Insurance Commissioner,,R,Ken Selzer,83
-Ottawa,Durham,Insurance Commissioner,,R,Ken Selzer,5
-Ottawa,Fountain,Insurance Commissioner,,R,Ken Selzer,36
-Ottawa,Garfield,Insurance Commissioner,,R,Ken Selzer,32
-Ottawa,Grant,Insurance Commissioner,,R,Ken Selzer,36
-Ottawa,Henry,Insurance Commissioner,,R,Ken Selzer,8
-Ottawa,Lincoln,Insurance Commissioner,,R,Ken Selzer,33
-Ottawa,Logan,Insurance Commissioner,,R,Ken Selzer,26
-Ottawa,Morton,Insurance Commissioner,,R,Ken Selzer,127
-Ottawa,Ottawa,Insurance Commissioner,,R,Ken Selzer,14
-Ottawa,Richland,Insurance Commissioner,,R,Ken Selzer,89
-Ottawa,Sheridan,Insurance Commissioner,,R,Ken Selzer,145
-Ottawa,Sherman,Insurance Commissioner,,R,Ken Selzer,22
-Ottawa,Stanton,Insurance Commissioner,,R,Ken Selzer,19
-Ottawa,Bennington,Insurance Commissioner,,,Write-ins,1
-Ottawa,Bennington,Secretary of State,,D,Jean Kurtis Schodorf,133
-Ottawa,Blaine,Secretary of State,,D,Jean Kurtis Schodorf,15
-Ottawa,Buckeye,Secretary of State,,D,Jean Kurtis Schodorf,11
-Ottawa,Center,Secretary of State,,D,Jean Kurtis Schodorf,6
-Ottawa,Chapman,Secretary of State,,D,Jean Kurtis Schodorf,6
-Ottawa,Concord,Secretary of State,,D,Jean Kurtis Schodorf,24
-Ottawa,Culver,Secretary of State,,D,Jean Kurtis Schodorf,35
-Ottawa,Durham,Secretary of State,,D,Jean Kurtis Schodorf,1
-Ottawa,Fountain,Secretary of State,,D,Jean Kurtis Schodorf,15
-Ottawa,Garfield,Secretary of State,,D,Jean Kurtis Schodorf,7
-Ottawa,Grant,Secretary of State,,D,Jean Kurtis Schodorf,3
-Ottawa,Henry,Secretary of State,,D,Jean Kurtis Schodorf,4
-Ottawa,Lincoln,Secretary of State,,D,Jean Kurtis Schodorf,25
-Ottawa,Logan,Secretary of State,,D,Jean Kurtis Schodorf,6
-Ottawa,Morton,Secretary of State,,D,Jean Kurtis Schodorf,47
-Ottawa,Ottawa,Secretary of State,,D,Jean Kurtis Schodorf,5
-Ottawa,Richland,Secretary of State,,D,Jean Kurtis Schodorf,16
-Ottawa,Sheridan,Secretary of State,,D,Jean Kurtis Schodorf,41
-Ottawa,Sherman,Secretary of State,,D,Jean Kurtis Schodorf,3
-Ottawa,Stanton,Secretary of State,,D,Jean Kurtis Schodorf,9
-Ottawa,Bennington,Secretary of State,,R,Kris Kobach,334
-Ottawa,Blaine,Secretary of State,,R,Kris Kobach,43
-Ottawa,Buckeye,Secretary of State,,R,Kris Kobach,39
-Ottawa,Center,Secretary of State,,R,Kris Kobach,33
-Ottawa,Chapman,Secretary of State,,R,Kris Kobach,26
-Ottawa,Concord,Secretary of State,,R,Kris Kobach,77
-Ottawa,Culver,Secretary of State,,R,Kris Kobach,77
-Ottawa,Durham,Secretary of State,,R,Kris Kobach,5
-Ottawa,Fountain,Secretary of State,,R,Kris Kobach,39
-Ottawa,Garfield,Secretary of State,,R,Kris Kobach,32
-Ottawa,Grant,Secretary of State,,R,Kris Kobach,39
-Ottawa,Henry,Secretary of State,,R,Kris Kobach,5
-Ottawa,Lincoln,Secretary of State,,R,Kris Kobach,31
-Ottawa,Logan,Secretary of State,,R,Kris Kobach,25
-Ottawa,Morton,Secretary of State,,R,Kris Kobach,120
-Ottawa,Ottawa,Secretary of State,,R,Kris Kobach,16
-Ottawa,Richland,Secretary of State,,R,Kris Kobach,91
-Ottawa,Sheridan,Secretary of State,,R,Kris Kobach,137
-Ottawa,Sherman,Secretary of State,,R,Kris Kobach,23
-Ottawa,Stanton,Secretary of State,,R,Kris Kobach,17
-Ottawa,Henry,Secretary of State,,,Write-ins,1
-Ottawa,Bennington,State House,107,R,Susan Concannon,405
-Ottawa,Blaine,State House,107,R,Susan Concannon,45
-Ottawa,Buckeye,State House,107,R,Susan Concannon,46
-Ottawa,Center,State House,107,R,Susan Concannon,34
-Ottawa,Chapman,State House,107,R,Susan Concannon,30
-Ottawa,Concord,State House,107,R,Susan Concannon,87
-Ottawa,Culver,State House,107,R,Susan Concannon,95
-Ottawa,Durham,State House,107,R,Susan Concannon,6
-Ottawa,Fountain,State House,107,R,Susan Concannon,47
-Ottawa,Garfield,State House,107,R,Susan Concannon,33
-Ottawa,Grant,State House,107,R,Susan Concannon,39
-Ottawa,Henry,State House,107,R,Susan Concannon,9
-Ottawa,Lincoln,State House,107,R,Susan Concannon,41
-Ottawa,Logan,State House,107,R,Susan Concannon,29
-Ottawa,Morton,State House,107,R,Susan Concannon,150
-Ottawa,Ottawa,State House,107,R,Susan Concannon,15
-Ottawa,Richland,State House,107,R,Susan Concannon,103
-Ottawa,Sheridan,State House,107,R,Susan Concannon,155
-Ottawa,Sherman,State House,107,R,Susan Concannon,25
-Ottawa,Stanton,State House,107,R,Susan Concannon,23
-Ottawa,Bennington,State House,107,,Write-ins,2
-Ottawa,Blaine,State House,107,,Write-ins,1
-Ottawa,Lincoln,State House,107,,Write-ins,3
-Ottawa,Sheridan,State House,107,,Write-ins,2
-Ottawa,Bennington,State Treasurer,,D,Carmen Alldritt,81
-Ottawa,Blaine,State Treasurer,,D,Carmen Alldritt,9
-Ottawa,Buckeye,State Treasurer,,D,Carmen Alldritt,9
-Ottawa,Center,State Treasurer,,D,Carmen Alldritt,3
-Ottawa,Chapman,State Treasurer,,D,Carmen Alldritt,3
-Ottawa,Concord,State Treasurer,,D,Carmen Alldritt,14
-Ottawa,Culver,State Treasurer,,D,Carmen Alldritt,25
-Ottawa,Durham,State Treasurer,,D,Carmen Alldritt,0
-Ottawa,Fountain,State Treasurer,,D,Carmen Alldritt,9
-Ottawa,Garfield,State Treasurer,,D,Carmen Alldritt,3
-Ottawa,Grant,State Treasurer,,D,Carmen Alldritt,1
-Ottawa,Henry,State Treasurer,,D,Carmen Alldritt,2
-Ottawa,Lincoln,State Treasurer,,D,Carmen Alldritt,20
-Ottawa,Logan,State Treasurer,,D,Carmen Alldritt,5
-Ottawa,Morton,State Treasurer,,D,Carmen Alldritt,24
-Ottawa,Ottawa,State Treasurer,,D,Carmen Alldritt,4
-Ottawa,Richland,State Treasurer,,D,Carmen Alldritt,12
-Ottawa,Sheridan,State Treasurer,,D,Carmen Alldritt,30
-Ottawa,Sherman,State Treasurer,,D,Carmen Alldritt,2
-Ottawa,Stanton,State Treasurer,,D,Carmen Alldritt,8
-Ottawa,Bennington,State Treasurer,,R,Ron Estes,376
-Ottawa,Blaine,State Treasurer,,R,Ron Estes,50
-Ottawa,Buckeye,State Treasurer,,R,Ron Estes,40
-Ottawa,Center,State Treasurer,,R,Ron Estes,36
-Ottawa,Chapman,State Treasurer,,R,Ron Estes,28
-Ottawa,Concord,State Treasurer,,R,Ron Estes,83
-Ottawa,Culver,State Treasurer,,R,Ron Estes,86
-Ottawa,Durham,State Treasurer,,R,Ron Estes,6
-Ottawa,Fountain,State Treasurer,,R,Ron Estes,45
-Ottawa,Garfield,State Treasurer,,R,Ron Estes,36
-Ottawa,Grant,State Treasurer,,R,Ron Estes,41
-Ottawa,Henry,State Treasurer,,R,Ron Estes,7
-Ottawa,Lincoln,State Treasurer,,R,Ron Estes,35
-Ottawa,Logan,State Treasurer,,R,Ron Estes,27
-Ottawa,Morton,State Treasurer,,R,Ron Estes,138
-Ottawa,Ottawa,State Treasurer,,R,Ron Estes,16
-Ottawa,Richland,State Treasurer,,R,Ron Estes,95
-Ottawa,Sheridan,State Treasurer,,R,Ron Estes,143
-Ottawa,Sherman,State Treasurer,,R,Ron Estes,24
-Ottawa,Stanton,State Treasurer,,R,Ron Estes,18
-Ottawa,Bennington,State Treasurer,,,Write-ins,1
-Ottawa,Bennington,U.S. Senate,,I,Greg Orman,121
-Ottawa,Blaine,U.S. Senate,,I,Greg Orman,10
-Ottawa,Buckeye,U.S. Senate,,I,Greg Orman,13
-Ottawa,Center,U.S. Senate,,I,Greg Orman,4
-Ottawa,Chapman,U.S. Senate,,I,Greg Orman,4
-Ottawa,Concord,U.S. Senate,,I,Greg Orman,23
-Ottawa,Culver,U.S. Senate,,I,Greg Orman,30
-Ottawa,Durham,U.S. Senate,,I,Greg Orman,1
-Ottawa,Fountain,U.S. Senate,,I,Greg Orman,10
-Ottawa,Garfield,U.S. Senate,,I,Greg Orman,4
-Ottawa,Grant,U.S. Senate,,I,Greg Orman,4
-Ottawa,Henry,U.S. Senate,,I,Greg Orman,2
-Ottawa,Lincoln,U.S. Senate,,I,Greg Orman,24
-Ottawa,Logan,U.S. Senate,,I,Greg Orman,4
-Ottawa,Morton,U.S. Senate,,I,Greg Orman,25
-Ottawa,Ottawa,U.S. Senate,,I,Greg Orman,6
-Ottawa,Richland,U.S. Senate,,I,Greg Orman,15
-Ottawa,Sheridan,U.S. Senate,,I,Greg Orman,39
-Ottawa,Sherman,U.S. Senate,,I,Greg Orman,4
-Ottawa,Stanton,U.S. Senate,,I,Greg Orman,9
-Ottawa,Bennington,U.S. Senate,,R,Pat Roberts,320
-Ottawa,Blaine,U.S. Senate,,R,Pat Roberts,43
-Ottawa,Buckeye,U.S. Senate,,R,Pat Roberts,33
-Ottawa,Center,U.S. Senate,,R,Pat Roberts,34
-Ottawa,Chapman,U.S. Senate,,R,Pat Roberts,28
-Ottawa,Concord,U.S. Senate,,R,Pat Roberts,70
-Ottawa,Culver,U.S. Senate,,R,Pat Roberts,72
-Ottawa,Durham,U.S. Senate,,R,Pat Roberts,4
-Ottawa,Fountain,U.S. Senate,,R,Pat Roberts,39
-Ottawa,Garfield,U.S. Senate,,R,Pat Roberts,34
-Ottawa,Grant,U.S. Senate,,R,Pat Roberts,36
-Ottawa,Henry,U.S. Senate,,R,Pat Roberts,7
-Ottawa,Lincoln,U.S. Senate,,R,Pat Roberts,30
-Ottawa,Logan,U.S. Senate,,R,Pat Roberts,28
-Ottawa,Morton,U.S. Senate,,R,Pat Roberts,122
-Ottawa,Ottawa,U.S. Senate,,R,Pat Roberts,15
-Ottawa,Richland,U.S. Senate,,R,Pat Roberts,85
-Ottawa,Sheridan,U.S. Senate,,R,Pat Roberts,125
-Ottawa,Sherman,U.S. Senate,,R,Pat Roberts,22
-Ottawa,Stanton,U.S. Senate,,R,Pat Roberts,17
-Ottawa,Bennington,U.S. Senate,,L,Randall Batson,22
-Ottawa,Blaine,U.S. Senate,,L,Randall Batson,5
-Ottawa,Buckeye,U.S. Senate,,L,Randall Batson,4
-Ottawa,Center,U.S. Senate,,L,Randall Batson,1
-Ottawa,Chapman,U.S. Senate,,L,Randall Batson,0
-Ottawa,Concord,U.S. Senate,,L,Randall Batson,5
-Ottawa,Culver,U.S. Senate,,L,Randall Batson,6
-Ottawa,Durham,U.S. Senate,,L,Randall Batson,1
-Ottawa,Fountain,U.S. Senate,,L,Randall Batson,5
-Ottawa,Garfield,U.S. Senate,,L,Randall Batson,1
-Ottawa,Grant,U.S. Senate,,L,Randall Batson,2
-Ottawa,Henry,U.S. Senate,,L,Randall Batson,0
-Ottawa,Lincoln,U.S. Senate,,L,Randall Batson,1
-Ottawa,Logan,U.S. Senate,,L,Randall Batson,0
-Ottawa,Morton,U.S. Senate,,L,Randall Batson,21
-Ottawa,Ottawa,U.S. Senate,,L,Randall Batson,0
-Ottawa,Richland,U.S. Senate,,L,Randall Batson,5
-Ottawa,Sheridan,U.S. Senate,,L,Randall Batson,14
-Ottawa,Sherman,U.S. Senate,,L,Randall Batson,0
-Ottawa,Stanton,U.S. Senate,,L,Randall Batson,0
+county,precinct,office,district,party,candidate,votes,vtd
+OTTAWA,Bennington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",177,000010
+OTTAWA,Bennington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",31,000010
+OTTAWA,Bennington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",261,000010
+OTTAWA,Blaine Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000020
+OTTAWA,Blaine Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000020
+OTTAWA,Blaine Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000020
+OTTAWA,Buckeye Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000030
+OTTAWA,Buckeye Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000030
+OTTAWA,Buckeye Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000030
+OTTAWA,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000040
+OTTAWA,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+OTTAWA,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000040
+OTTAWA,Chapman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000050
+OTTAWA,Chapman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000050
+OTTAWA,Chapman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000050
+OTTAWA,Concord Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000060
+OTTAWA,Concord Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000060
+OTTAWA,Concord Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000060
+OTTAWA,Culver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,000070
+OTTAWA,Culver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000070
+OTTAWA,Culver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000070
+OTTAWA,Durham Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000080
+OTTAWA,Durham Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+OTTAWA,Durham Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000080
+OTTAWA,Fountain Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000090
+OTTAWA,Fountain Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000090
+OTTAWA,Fountain Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000090
+OTTAWA,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000100
+OTTAWA,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000100
+OTTAWA,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000100
+OTTAWA,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000110
+OTTAWA,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000110
+OTTAWA,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000110
+OTTAWA,Henry Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000120
+OTTAWA,Henry Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000120
+OTTAWA,Henry Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,000120
+OTTAWA,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000130
+OTTAWA,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000130
+OTTAWA,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000130
+OTTAWA,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000140
+OTTAWA,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000140
+OTTAWA,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000140
+OTTAWA,Minneapolis Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,000150
+OTTAWA,Minneapolis Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000150
+OTTAWA,Minneapolis Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",187,000150
+OTTAWA,Minneapolis Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,00016A
+OTTAWA,Minneapolis Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,00016A
+OTTAWA,Minneapolis Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",111,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00016B
+OTTAWA,Minneapolis Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000170
+OTTAWA,Minneapolis Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000170
+OTTAWA,Minneapolis Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",173,000170
+OTTAWA,Morton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000180
+OTTAWA,Morton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000180
+OTTAWA,Morton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000180
+OTTAWA,Ottawa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000190
+OTTAWA,Ottawa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000190
+OTTAWA,Ottawa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000190
+OTTAWA,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000200
+OTTAWA,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000200
+OTTAWA,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000200
+OTTAWA,Sheridan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000210
+OTTAWA,Sheridan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000210
+OTTAWA,Sheridan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",106,000210
+OTTAWA,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000220
+OTTAWA,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000220
+OTTAWA,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000220
+OTTAWA,Stanton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000230
+OTTAWA,Stanton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+OTTAWA,Stanton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000230
+OTTAWA,Bennington Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",405,000010
+OTTAWA,Blaine Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",45,000020
+OTTAWA,Buckeye Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",46,000030
+OTTAWA,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",34,000040
+OTTAWA,Chapman Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",30,000050
+OTTAWA,Concord Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",87,000060
+OTTAWA,Culver Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",95,000070
+OTTAWA,Durham Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",6,000080
+OTTAWA,Fountain Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",47,000090
+OTTAWA,Garfield Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",33,000100
+OTTAWA,Grant Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",39,000110
+OTTAWA,Henry Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",9,000120
+OTTAWA,Lincoln Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",41,000130
+OTTAWA,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",29,000140
+OTTAWA,Minneapolis Precinct 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",228,000150
+OTTAWA,Minneapolis Precinct 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",150,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00016B
+OTTAWA,Minneapolis Precinct 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",220,000170
+OTTAWA,Morton Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",150,000180
+OTTAWA,Ottawa Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",15,000190
+OTTAWA,Richland Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",103,000200
+OTTAWA,Sheridan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",155,000210
+OTTAWA,Sherman Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",25,000220
+OTTAWA,Stanton Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",23,000230
+OTTAWA,Bennington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",133,000010
+OTTAWA,Bennington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",327,000010
+OTTAWA,Blaine Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000020
+OTTAWA,Blaine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000020
+OTTAWA,Buckeye Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000030
+OTTAWA,Buckeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000030
+OTTAWA,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000040
+OTTAWA,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000040
+OTTAWA,Chapman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000050
+OTTAWA,Chapman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000050
+OTTAWA,Concord Township,United States House of Representatives,1,Democratic,"Sherow, James E.",23,000060
+OTTAWA,Concord Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000060
+OTTAWA,Culver Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,000070
+OTTAWA,Culver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,000070
+OTTAWA,Durham Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000080
+OTTAWA,Durham Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,000080
+OTTAWA,Fountain Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000090
+OTTAWA,Fountain Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000090
+OTTAWA,Garfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000100
+OTTAWA,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000100
+OTTAWA,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000110
+OTTAWA,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000110
+OTTAWA,Henry Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000120
+OTTAWA,Henry Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000120
+OTTAWA,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000130
+OTTAWA,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000130
+OTTAWA,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000140
+OTTAWA,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000140
+OTTAWA,Minneapolis Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",59,000150
+OTTAWA,Minneapolis Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",211,000150
+OTTAWA,Minneapolis Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",44,00016A
+OTTAWA,Minneapolis Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00016B
+OTTAWA,Minneapolis Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",67,000170
+OTTAWA,Minneapolis Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",191,000170
+OTTAWA,Morton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000180
+OTTAWA,Morton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",129,000180
+OTTAWA,Ottawa Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000190
+OTTAWA,Ottawa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000190
+OTTAWA,Richland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000200
+OTTAWA,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",87,000200
+OTTAWA,Sheridan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",48,000210
+OTTAWA,Sheridan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",130,000210
+OTTAWA,Sherman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000220
+OTTAWA,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000220
+OTTAWA,Stanton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000230
+OTTAWA,Stanton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000230
+OTTAWA,Bennington Township,Attorney General,,Democratic,"Kotich, A.J.",89,000010
+OTTAWA,Bennington Township,Attorney General,,Republican,"Schmidt, Derek",369,000010
+OTTAWA,Blaine Township,Attorney General,,Democratic,"Kotich, A.J.",10,000020
+OTTAWA,Blaine Township,Attorney General,,Republican,"Schmidt, Derek",49,000020
+OTTAWA,Buckeye Township,Attorney General,,Democratic,"Kotich, A.J.",9,000030
+OTTAWA,Buckeye Township,Attorney General,,Republican,"Schmidt, Derek",41,000030
+OTTAWA,Center Township,Attorney General,,Democratic,"Kotich, A.J.",4,000040
+OTTAWA,Center Township,Attorney General,,Republican,"Schmidt, Derek",35,000040
+OTTAWA,Chapman Township,Attorney General,,Democratic,"Kotich, A.J.",2,000050
+OTTAWA,Chapman Township,Attorney General,,Republican,"Schmidt, Derek",30,000050
+OTTAWA,Concord Township,Attorney General,,Democratic,"Kotich, A.J.",14,000060
+OTTAWA,Concord Township,Attorney General,,Republican,"Schmidt, Derek",84,000060
+OTTAWA,Culver Township,Attorney General,,Democratic,"Kotich, A.J.",22,000070
+OTTAWA,Culver Township,Attorney General,,Republican,"Schmidt, Derek",90,000070
+OTTAWA,Durham Township,Attorney General,,Democratic,"Kotich, A.J.",0,000080
+OTTAWA,Durham Township,Attorney General,,Republican,"Schmidt, Derek",6,000080
+OTTAWA,Fountain Township,Attorney General,,Democratic,"Kotich, A.J.",7,000090
+OTTAWA,Fountain Township,Attorney General,,Republican,"Schmidt, Derek",48,000090
+OTTAWA,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",3,000100
+OTTAWA,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",36,000100
+OTTAWA,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",1,000110
+OTTAWA,Grant Township,Attorney General,,Republican,"Schmidt, Derek",39,000110
+OTTAWA,Henry Township,Attorney General,,Democratic,"Kotich, A.J.",2,000120
+OTTAWA,Henry Township,Attorney General,,Republican,"Schmidt, Derek",7,000120
+OTTAWA,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",20,000130
+OTTAWA,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",35,000130
+OTTAWA,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",3,000140
+OTTAWA,Logan Township,Attorney General,,Republican,"Schmidt, Derek",28,000140
+OTTAWA,Minneapolis Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",38,000150
+OTTAWA,Minneapolis Precinct 1,Attorney General,,Republican,"Schmidt, Derek",231,000150
+OTTAWA,Minneapolis Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",28,00016A
+OTTAWA,Minneapolis Precinct 2,Attorney General,,Republican,"Schmidt, Derek",150,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00016B
+OTTAWA,Minneapolis Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",39,000170
+OTTAWA,Minneapolis Precinct 3,Attorney General,,Republican,"Schmidt, Derek",219,000170
+OTTAWA,Morton Township,Attorney General,,Democratic,"Kotich, A.J.",27,000180
+OTTAWA,Morton Township,Attorney General,,Republican,"Schmidt, Derek",136,000180
+OTTAWA,Ottawa Township,Attorney General,,Democratic,"Kotich, A.J.",5,000190
+OTTAWA,Ottawa Township,Attorney General,,Republican,"Schmidt, Derek",14,000190
+OTTAWA,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",15,000200
+OTTAWA,Richland Township,Attorney General,,Republican,"Schmidt, Derek",93,000200
+OTTAWA,Sheridan Township,Attorney General,,Democratic,"Kotich, A.J.",36,000210
+OTTAWA,Sheridan Township,Attorney General,,Republican,"Schmidt, Derek",139,000210
+OTTAWA,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",4,000220
+OTTAWA,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",22,000220
+OTTAWA,Stanton Township,Attorney General,,Democratic,"Kotich, A.J.",6,000230
+OTTAWA,Stanton Township,Attorney General,,Republican,"Schmidt, Derek",20,000230
+OTTAWA,Bennington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",105,000010
+OTTAWA,Bennington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",338,000010
+OTTAWA,Blaine Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000020
+OTTAWA,Blaine Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000020
+OTTAWA,Buckeye Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000030
+OTTAWA,Buckeye Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000030
+OTTAWA,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000040
+OTTAWA,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000040
+OTTAWA,Chapman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000050
+OTTAWA,Chapman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000050
+OTTAWA,Concord Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000060
+OTTAWA,Concord Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000060
+OTTAWA,Culver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000070
+OTTAWA,Culver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",83,000070
+OTTAWA,Durham Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000080
+OTTAWA,Durham Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,000080
+OTTAWA,Fountain Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000090
+OTTAWA,Fountain Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000090
+OTTAWA,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000100
+OTTAWA,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000100
+OTTAWA,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000110
+OTTAWA,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000110
+OTTAWA,Henry Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000120
+OTTAWA,Henry Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000120
+OTTAWA,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000130
+OTTAWA,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000130
+OTTAWA,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000140
+OTTAWA,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000140
+OTTAWA,Minneapolis Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000150
+OTTAWA,Minneapolis Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",212,000150
+OTTAWA,Minneapolis Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,00016A
+OTTAWA,Minneapolis Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",138,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00016B
+OTTAWA,Minneapolis Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000170
+OTTAWA,Minneapolis Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",197,000170
+OTTAWA,Morton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000180
+OTTAWA,Morton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",127,000180
+OTTAWA,Ottawa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000190
+OTTAWA,Ottawa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000190
+OTTAWA,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000200
+OTTAWA,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",89,000200
+OTTAWA,Sheridan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000210
+OTTAWA,Sheridan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",145,000210
+OTTAWA,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000220
+OTTAWA,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000220
+OTTAWA,Stanton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000230
+OTTAWA,Stanton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000230
+OTTAWA,Bennington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",133,000010
+OTTAWA,Bennington Township,Secretary of State,,Republican,"Kobach, Kris",334,000010
+OTTAWA,Blaine Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000020
+OTTAWA,Blaine Township,Secretary of State,,Republican,"Kobach, Kris",43,000020
+OTTAWA,Buckeye Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000030
+OTTAWA,Buckeye Township,Secretary of State,,Republican,"Kobach, Kris",39,000030
+OTTAWA,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000040
+OTTAWA,Center Township,Secretary of State,,Republican,"Kobach, Kris",33,000040
+OTTAWA,Chapman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000050
+OTTAWA,Chapman Township,Secretary of State,,Republican,"Kobach, Kris",26,000050
+OTTAWA,Concord Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000060
+OTTAWA,Concord Township,Secretary of State,,Republican,"Kobach, Kris",77,000060
+OTTAWA,Culver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000070
+OTTAWA,Culver Township,Secretary of State,,Republican,"Kobach, Kris",77,000070
+OTTAWA,Durham Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000080
+OTTAWA,Durham Township,Secretary of State,,Republican,"Kobach, Kris",5,000080
+OTTAWA,Fountain Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000090
+OTTAWA,Fountain Township,Secretary of State,,Republican,"Kobach, Kris",39,000090
+OTTAWA,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000100
+OTTAWA,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",32,000100
+OTTAWA,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000110
+OTTAWA,Grant Township,Secretary of State,,Republican,"Kobach, Kris",39,000110
+OTTAWA,Henry Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000120
+OTTAWA,Henry Township,Secretary of State,,Republican,"Kobach, Kris",5,000120
+OTTAWA,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000130
+OTTAWA,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",31,000130
+OTTAWA,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000140
+OTTAWA,Logan Township,Secretary of State,,Republican,"Kobach, Kris",25,000140
+OTTAWA,Minneapolis Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000150
+OTTAWA,Minneapolis Precinct 1,Secretary of State,,Republican,"Kobach, Kris",204,000150
+OTTAWA,Minneapolis Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,00016A
+OTTAWA,Minneapolis Precinct 2,Secretary of State,,Republican,"Kobach, Kris",137,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00016B
+OTTAWA,Minneapolis Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,000170
+OTTAWA,Minneapolis Precinct 3,Secretary of State,,Republican,"Kobach, Kris",199,000170
+OTTAWA,Morton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000180
+OTTAWA,Morton Township,Secretary of State,,Republican,"Kobach, Kris",120,000180
+OTTAWA,Ottawa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000190
+OTTAWA,Ottawa Township,Secretary of State,,Republican,"Kobach, Kris",16,000190
+OTTAWA,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000200
+OTTAWA,Richland Township,Secretary of State,,Republican,"Kobach, Kris",91,000200
+OTTAWA,Sheridan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000210
+OTTAWA,Sheridan Township,Secretary of State,,Republican,"Kobach, Kris",137,000210
+OTTAWA,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000220
+OTTAWA,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",23,000220
+OTTAWA,Stanton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000230
+OTTAWA,Stanton Township,Secretary of State,,Republican,"Kobach, Kris",17,000230
+OTTAWA,Bennington Township,State Treasurer,,Democratic,"Alldritt, Carmen",81,000010
+OTTAWA,Bennington Township,State Treasurer,,Republican,"Estes, Ron",376,000010
+OTTAWA,Blaine Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000020
+OTTAWA,Blaine Township,State Treasurer,,Republican,"Estes, Ron",50,000020
+OTTAWA,Buckeye Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000030
+OTTAWA,Buckeye Township,State Treasurer,,Republican,"Estes, Ron",40,000030
+OTTAWA,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000040
+OTTAWA,Center Township,State Treasurer,,Republican,"Estes, Ron",36,000040
+OTTAWA,Chapman Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000050
+OTTAWA,Chapman Township,State Treasurer,,Republican,"Estes, Ron",28,000050
+OTTAWA,Concord Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000060
+OTTAWA,Concord Township,State Treasurer,,Republican,"Estes, Ron",83,000060
+OTTAWA,Culver Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000070
+OTTAWA,Culver Township,State Treasurer,,Republican,"Estes, Ron",86,000070
+OTTAWA,Durham Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000080
+OTTAWA,Durham Township,State Treasurer,,Republican,"Estes, Ron",6,000080
+OTTAWA,Fountain Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000090
+OTTAWA,Fountain Township,State Treasurer,,Republican,"Estes, Ron",45,000090
+OTTAWA,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000100
+OTTAWA,Garfield Township,State Treasurer,,Republican,"Estes, Ron",36,000100
+OTTAWA,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000110
+OTTAWA,Grant Township,State Treasurer,,Republican,"Estes, Ron",41,000110
+OTTAWA,Henry Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000120
+OTTAWA,Henry Township,State Treasurer,,Republican,"Estes, Ron",7,000120
+OTTAWA,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000130
+OTTAWA,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",35,000130
+OTTAWA,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000140
+OTTAWA,Logan Township,State Treasurer,,Republican,"Estes, Ron",27,000140
+OTTAWA,Minneapolis Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",37,000150
+OTTAWA,Minneapolis Precinct 1,State Treasurer,,Republican,"Estes, Ron",229,000150
+OTTAWA,Minneapolis Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",27,00016A
+OTTAWA,Minneapolis Precinct 2,State Treasurer,,Republican,"Estes, Ron",151,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00016B
+OTTAWA,Minneapolis Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",37,000170
+OTTAWA,Minneapolis Precinct 3,State Treasurer,,Republican,"Estes, Ron",218,000170
+OTTAWA,Morton Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000180
+OTTAWA,Morton Township,State Treasurer,,Republican,"Estes, Ron",138,000180
+OTTAWA,Ottawa Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000190
+OTTAWA,Ottawa Township,State Treasurer,,Republican,"Estes, Ron",16,000190
+OTTAWA,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000200
+OTTAWA,Richland Township,State Treasurer,,Republican,"Estes, Ron",95,000200
+OTTAWA,Sheridan Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000210
+OTTAWA,Sheridan Township,State Treasurer,,Republican,"Estes, Ron",143,000210
+OTTAWA,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000220
+OTTAWA,Sherman Township,State Treasurer,,Republican,"Estes, Ron",24,000220
+OTTAWA,Stanton Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000230
+OTTAWA,Stanton Township,State Treasurer,,Republican,"Estes, Ron",18,000230
+OTTAWA,Bennington Township,United States Senate,,independent,"Orman, Greg",121,000010
+OTTAWA,Bennington Township,United States Senate,,Libertarian,"Batson, Randall",22,000010
+OTTAWA,Bennington Township,United States Senate,,Republican,"Roberts, Pat",320,000010
+OTTAWA,Blaine Township,United States Senate,,independent,"Orman, Greg",10,000020
+OTTAWA,Blaine Township,United States Senate,,Libertarian,"Batson, Randall",5,000020
+OTTAWA,Blaine Township,United States Senate,,Republican,"Roberts, Pat",43,000020
+OTTAWA,Buckeye Township,United States Senate,,independent,"Orman, Greg",13,000030
+OTTAWA,Buckeye Township,United States Senate,,Libertarian,"Batson, Randall",4,000030
+OTTAWA,Buckeye Township,United States Senate,,Republican,"Roberts, Pat",33,000030
+OTTAWA,Center Township,United States Senate,,independent,"Orman, Greg",4,000040
+OTTAWA,Center Township,United States Senate,,Libertarian,"Batson, Randall",1,000040
+OTTAWA,Center Township,United States Senate,,Republican,"Roberts, Pat",34,000040
+OTTAWA,Chapman Township,United States Senate,,independent,"Orman, Greg",4,000050
+OTTAWA,Chapman Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+OTTAWA,Chapman Township,United States Senate,,Republican,"Roberts, Pat",28,000050
+OTTAWA,Concord Township,United States Senate,,independent,"Orman, Greg",23,000060
+OTTAWA,Concord Township,United States Senate,,Libertarian,"Batson, Randall",5,000060
+OTTAWA,Concord Township,United States Senate,,Republican,"Roberts, Pat",70,000060
+OTTAWA,Culver Township,United States Senate,,independent,"Orman, Greg",30,000070
+OTTAWA,Culver Township,United States Senate,,Libertarian,"Batson, Randall",6,000070
+OTTAWA,Culver Township,United States Senate,,Republican,"Roberts, Pat",72,000070
+OTTAWA,Durham Township,United States Senate,,independent,"Orman, Greg",1,000080
+OTTAWA,Durham Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+OTTAWA,Durham Township,United States Senate,,Republican,"Roberts, Pat",4,000080
+OTTAWA,Fountain Township,United States Senate,,independent,"Orman, Greg",10,000090
+OTTAWA,Fountain Township,United States Senate,,Libertarian,"Batson, Randall",5,000090
+OTTAWA,Fountain Township,United States Senate,,Republican,"Roberts, Pat",39,000090
+OTTAWA,Garfield Township,United States Senate,,independent,"Orman, Greg",4,000100
+OTTAWA,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+OTTAWA,Garfield Township,United States Senate,,Republican,"Roberts, Pat",34,000100
+OTTAWA,Grant Township,United States Senate,,independent,"Orman, Greg",4,000110
+OTTAWA,Grant Township,United States Senate,,Libertarian,"Batson, Randall",2,000110
+OTTAWA,Grant Township,United States Senate,,Republican,"Roberts, Pat",36,000110
+OTTAWA,Henry Township,United States Senate,,independent,"Orman, Greg",2,000120
+OTTAWA,Henry Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+OTTAWA,Henry Township,United States Senate,,Republican,"Roberts, Pat",7,000120
+OTTAWA,Lincoln Township,United States Senate,,independent,"Orman, Greg",24,000130
+OTTAWA,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",1,000130
+OTTAWA,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",30,000130
+OTTAWA,Logan Township,United States Senate,,independent,"Orman, Greg",4,000140
+OTTAWA,Logan Township,United States Senate,,Libertarian,"Batson, Randall",0,000140
+OTTAWA,Logan Township,United States Senate,,Republican,"Roberts, Pat",28,000140
+OTTAWA,Minneapolis Precinct 1,United States Senate,,independent,"Orman, Greg",57,000150
+OTTAWA,Minneapolis Precinct 1,United States Senate,,Libertarian,"Batson, Randall",11,000150
+OTTAWA,Minneapolis Precinct 1,United States Senate,,Republican,"Roberts, Pat",204,000150
+OTTAWA,Minneapolis Precinct 2,United States Senate,,independent,"Orman, Greg",36,00016A
+OTTAWA,Minneapolis Precinct 2,United States Senate,,Libertarian,"Batson, Randall",15,00016A
+OTTAWA,Minneapolis Precinct 2,United States Senate,,Republican,"Roberts, Pat",127,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00016B
+OTTAWA,Minneapolis Precinct 3,United States Senate,,independent,"Orman, Greg",58,000170
+OTTAWA,Minneapolis Precinct 3,United States Senate,,Libertarian,"Batson, Randall",17,000170
+OTTAWA,Minneapolis Precinct 3,United States Senate,,Republican,"Roberts, Pat",188,000170
+OTTAWA,Morton Township,United States Senate,,independent,"Orman, Greg",25,000180
+OTTAWA,Morton Township,United States Senate,,Libertarian,"Batson, Randall",21,000180
+OTTAWA,Morton Township,United States Senate,,Republican,"Roberts, Pat",122,000180
+OTTAWA,Ottawa Township,United States Senate,,independent,"Orman, Greg",6,000190
+OTTAWA,Ottawa Township,United States Senate,,Libertarian,"Batson, Randall",0,000190
+OTTAWA,Ottawa Township,United States Senate,,Republican,"Roberts, Pat",15,000190
+OTTAWA,Richland Township,United States Senate,,independent,"Orman, Greg",15,000200
+OTTAWA,Richland Township,United States Senate,,Libertarian,"Batson, Randall",5,000200
+OTTAWA,Richland Township,United States Senate,,Republican,"Roberts, Pat",85,000200
+OTTAWA,Sheridan Township,United States Senate,,independent,"Orman, Greg",39,000210
+OTTAWA,Sheridan Township,United States Senate,,Libertarian,"Batson, Randall",14,000210
+OTTAWA,Sheridan Township,United States Senate,,Republican,"Roberts, Pat",125,000210
+OTTAWA,Sherman Township,United States Senate,,independent,"Orman, Greg",4,000220
+OTTAWA,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",0,000220
+OTTAWA,Sherman Township,United States Senate,,Republican,"Roberts, Pat",22,000220
+OTTAWA,Stanton Township,United States Senate,,independent,"Orman, Greg",9,000230
+OTTAWA,Stanton Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+OTTAWA,Stanton Township,United States Senate,,Republican,"Roberts, Pat",17,000230

--- a/2014/20141104__ks__general__pawnee__precinct.csv
+++ b/2014/20141104__ks__general__pawnee__precinct.csv
@@ -1,460 +1,477 @@
-county,precinct,office,district,party,candidate,votes
-Pawnee,Ash Valley Township,U.S. Senate,,R,Pat Roberts,12
-Pawnee,Browns Grove Township C1,U.S. Senate,,R,Pat Roberts,84
-Pawnee,Conkling Township,U.S. Senate,,R,Pat Roberts,8
-Pawnee,Grant Township C1,U.S. Senate,,R,Pat Roberts,65
-Pawnee,Larned Township,U.S. Senate,,R,Pat Roberts,82
-Pawnee,Larned Ward 1,U.S. Senate,,R,Pat Roberts,155
-Pawnee,Larned Ward 2,U.S. Senate,,R,Pat Roberts,249
-Pawnee,Larned Ward 3,U.S. Senate,,R,Pat Roberts,277
-Pawnee,Larned Ward 4,U.S. Senate,,R,Pat Roberts,92
-Pawnee,Lincoln Township,U.S. Senate,,R,Pat Roberts,10
-Pawnee,Logan Township,U.S. Senate,,R,Pat Roberts,21
-Pawnee,Morton Township,U.S. Senate,,R,Pat Roberts,22
-Pawnee,Orange Township,U.S. Senate,,R,Pat Roberts,10
-Pawnee,Pawnee Township,U.S. Senate,,R,Pat Roberts,22
-Pawnee,Pleasant Grove Township,U.S. Senate,,R,Pat Roberts,43
-Pawnee,Pleasant Valley Township,U.S. Senate,,R,Pat Roberts,27
-Pawnee,River Township,U.S. Senate,,R,Pat Roberts,25
-Pawnee,Santa Fe Township,U.S. Senate,,R,Pat Roberts,32
-Pawnee,Shiley Township,U.S. Senate,,R,Pat Roberts,15
-Pawnee,Valley Center Township,U.S. Senate,,R,Pat Roberts,12
-Pawnee,Walnut Township,U.S. Senate,,R,Pat Roberts,19
-Pawnee,Browns Grove Township C4,U.S. Senate,,R,Pat Roberts,1
-Pawnee,Garfield Township,U.S. Senate,,R,Pat Roberts,47
-Pawnee,Grant Township C4,U.S. Senate,,R,Pat Roberts,11
-Pawnee,Keysville Township,U.S. Senate,,R,Pat Roberts,13
-Pawnee,Pleasant Ridge Township,U.S. Senate,,R,Pat Roberts,10
-Pawnee,Sawmill Township,U.S. Senate,,R,Pat Roberts,9
-Pawnee,Ash Valley Township,U.S. Senate,,I,Greg Orman,17
-Pawnee,Browns Grove Township C1,U.S. Senate,,I,Greg Orman,26
-Pawnee,Conkling Township,U.S. Senate,,I,Greg Orman,2
-Pawnee,Grant Township C1,U.S. Senate,,I,Greg Orman,14
-Pawnee,Larned Township,U.S. Senate,,I,Greg Orman,40
-Pawnee,Larned Ward 1,U.S. Senate,,I,Greg Orman,103
-Pawnee,Larned Ward 2,U.S. Senate,,I,Greg Orman,148
-Pawnee,Larned Ward 3,U.S. Senate,,I,Greg Orman,145
-Pawnee,Larned Ward 4,U.S. Senate,,I,Greg Orman,90
-Pawnee,Lincoln Township,U.S. Senate,,I,Greg Orman,0
-Pawnee,Logan Township,U.S. Senate,,I,Greg Orman,1
-Pawnee,Morton Township,U.S. Senate,,I,Greg Orman,5
-Pawnee,Orange Township,U.S. Senate,,I,Greg Orman,4
-Pawnee,Pawnee Township,U.S. Senate,,I,Greg Orman,12
-Pawnee,Pleasant Grove Township,U.S. Senate,,I,Greg Orman,16
-Pawnee,Pleasant Valley Township,U.S. Senate,,I,Greg Orman,9
-Pawnee,River Township,U.S. Senate,,I,Greg Orman,3
-Pawnee,Santa Fe Township,U.S. Senate,,I,Greg Orman,19
-Pawnee,Shiley Township,U.S. Senate,,I,Greg Orman,0
-Pawnee,Valley Center Township,U.S. Senate,,I,Greg Orman,1
-Pawnee,Walnut Township,U.S. Senate,,I,Greg Orman,11
-Pawnee,Browns Grove Township C4,U.S. Senate,,I,Greg Orman,1
-Pawnee,Garfield Township,U.S. Senate,,I,Greg Orman,17
-Pawnee,Grant Township C4,U.S. Senate,,I,Greg Orman,1
-Pawnee,Keysville Township,U.S. Senate,,I,Greg Orman,5
-Pawnee,Pleasant Ridge Township,U.S. Senate,,I,Greg Orman,5
-Pawnee,Sawmill Township,U.S. Senate,,I,Greg Orman,2
-Pawnee,Ash Valley Township,U.S. Senate,,L,Randall Batson,0
-Pawnee,Browns Grove Township C1,U.S. Senate,,L,Randall Batson,8
-Pawnee,Conkling Township,U.S. Senate,,L,Randall Batson,0
-Pawnee,Grant Township C1,U.S. Senate,,L,Randall Batson,1
-Pawnee,Larned Township,U.S. Senate,,L,Randall Batson,6
-Pawnee,Larned Ward 1,U.S. Senate,,L,Randall Batson,16
-Pawnee,Larned Ward 2,U.S. Senate,,L,Randall Batson,16
-Pawnee,Larned Ward 3,U.S. Senate,,L,Randall Batson,9
-Pawnee,Larned Ward 4,U.S. Senate,,L,Randall Batson,7
-Pawnee,Lincoln Township,U.S. Senate,,L,Randall Batson,1
-Pawnee,Logan Township,U.S. Senate,,L,Randall Batson,1
-Pawnee,Morton Township,U.S. Senate,,L,Randall Batson,0
-Pawnee,Orange Township,U.S. Senate,,L,Randall Batson,4
-Pawnee,Pawnee Township,U.S. Senate,,L,Randall Batson,2
-Pawnee,Pleasant Grove Township,U.S. Senate,,L,Randall Batson,5
-Pawnee,Pleasant Valley Township,U.S. Senate,,L,Randall Batson,2
-Pawnee,River Township,U.S. Senate,,L,Randall Batson,0
-Pawnee,Santa Fe Township,U.S. Senate,,L,Randall Batson,4
-Pawnee,Shiley Township,U.S. Senate,,L,Randall Batson,0
-Pawnee,Valley Center Township,U.S. Senate,,L,Randall Batson,2
-Pawnee,Walnut Township,U.S. Senate,,L,Randall Batson,1
-Pawnee,Browns Grove Township C4,U.S. Senate,,L,Randall Batson,0
-Pawnee,Garfield Township,U.S. Senate,,L,Randall Batson,4
-Pawnee,Grant Township C4,U.S. Senate,,L,Randall Batson,0
-Pawnee,Keysville Township,U.S. Senate,,L,Randall Batson,0
-Pawnee,Pleasant Ridge Township,U.S. Senate,,L,Randall Batson,2
-Pawnee,Sawmill Township,U.S. Senate,,L,Randall Batson,1
-Pawnee,Ash Valley Township,U.S. House,1,R,Tim Huelskamp,13
-Pawnee,Browns Grove Township C1,U.S. House,1,R,Tim Huelskamp,84
-Pawnee,Conkling Township,U.S. House,1,R,Tim Huelskamp,7
-Pawnee,Grant Township C1,U.S. House,1,R,Tim Huelskamp,61
-Pawnee,Larned Township,U.S. House,1,R,Tim Huelskamp,90
-Pawnee,Larned Ward 1,U.S. House,1,R,Tim Huelskamp,185
-Pawnee,Larned Ward 2,U.S. House,1,R,Tim Huelskamp,278
-Pawnee,Larned Ward 3,U.S. House,1,R,Tim Huelskamp,290
-Pawnee,Larned Ward 4,U.S. House,1,R,Tim Huelskamp,106
-Pawnee,Lincoln Township,U.S. House,1,R,Tim Huelskamp,10
-Pawnee,Logan Township,U.S. House,1,R,Tim Huelskamp,24
-Pawnee,Morton Township,U.S. House,1,R,Tim Huelskamp,20
-Pawnee,Orange Township,U.S. House,1,R,Tim Huelskamp,13
-Pawnee,Pawnee Township,U.S. House,1,R,Tim Huelskamp,24
-Pawnee,Pleasant Grove Township,U.S. House,1,R,Tim Huelskamp,49
-Pawnee,Pleasant Valley Township,U.S. House,1,R,Tim Huelskamp,34
-Pawnee,River Township,U.S. House,1,R,Tim Huelskamp,26
-Pawnee,Santa Fe Township,U.S. House,1,R,Tim Huelskamp,29
-Pawnee,Shiley Township,U.S. House,1,R,Tim Huelskamp,12
-Pawnee,Valley Center Township,U.S. House,1,R,Tim Huelskamp,12
-Pawnee,Walnut Township,U.S. House,1,R,Tim Huelskamp,21
-Pawnee,Ash Valley Township,U.S. House,1,D,James Sherow,16
-Pawnee,Browns Grove Township C1,U.S. House,1,D,James Sherow,32
-Pawnee,Conkling Township,U.S. House,1,D,James Sherow,3
-Pawnee,Grant Township C1,U.S. House,1,D,James Sherow,20
-Pawnee,Larned Township,U.S. House,1,D,James Sherow,36
-Pawnee,Larned Ward 1,U.S. House,1,D,James Sherow,86
-Pawnee,Larned Ward 2,U.S. House,1,D,James Sherow,138
-Pawnee,Larned Ward 3,U.S. House,1,D,James Sherow,134
-Pawnee,Larned Ward 4,U.S. House,1,D,James Sherow,85
-Pawnee,Lincoln Township,U.S. House,1,D,James Sherow,1
-Pawnee,Logan Township,U.S. House,1,D,James Sherow,1
-Pawnee,Morton Township,U.S. House,1,D,James Sherow,6
-Pawnee,Orange Township,U.S. House,1,D,James Sherow,5
-Pawnee,Pawnee Township,U.S. House,1,D,James Sherow,11
-Pawnee,Pleasant Grove Township,U.S. House,1,D,James Sherow,14
-Pawnee,Pleasant Valley Township,U.S. House,1,D,James Sherow,4
-Pawnee,River Township,U.S. House,1,D,James Sherow,2
-Pawnee,Santa Fe Township,U.S. House,1,D,James Sherow,24
-Pawnee,Shiley Township,U.S. House,1,D,James Sherow,1
-Pawnee,Valley Center Township,U.S. House,1,D,James Sherow,3
-Pawnee,Walnut Township,U.S. House,1,D,James Sherow,10
-Pawnee,Browns Grove Township C4,U.S. House,4,R,Mike Pompeo,2
-Pawnee,Garfield Township,U.S. House,4,R,Mike Pompeo,54
-Pawnee,Grant Township C4,U.S. House,4,R,Mike Pompeo,11
-Pawnee,Keysville Township,U.S. House,4,R,Mike Pompeo,14
-Pawnee,Pleasant Ridge Township,U.S. House,4,R,Mike Pompeo,13
-Pawnee,Sawmill Township,U.S. House,4,R,Mike Pompeo,9
-Pawnee,Browns Grove Township C4,U.S. House,4,D,Perry Schuckman,0
-Pawnee,Garfield Township,U.S. House,4,D,Perry Schuckman,14
-Pawnee,Grant Township C4,U.S. House,4,D,Perry Schuckman,1
-Pawnee,Keysville Township,U.S. House,4,D,Perry Schuckman,4
-Pawnee,Pleasant Ridge Township,U.S. House,4,D,Perry Schuckman,4
-Pawnee,Sawmill Township,U.S. House,4,D,Perry Schuckman,3
-Pawnee,Ash Valley Township,Governor,,R,Sam Brownback,12
-Pawnee,Browns Grove Township C1,Governor,,R,Sam Brownback,69
-Pawnee,Conkling Township,Governor,,R,Sam Brownback,5
-Pawnee,Grant Township C1,Governor,,R,Sam Brownback,55
-Pawnee,Larned Township,Governor,,R,Sam Brownback,72
-Pawnee,Larned Ward 1,Governor,,R,Sam Brownback,120
-Pawnee,Larned Ward 2,Governor,,R,Sam Brownback,182
-Pawnee,Larned Ward 3,Governor,,R,Sam Brownback,221
-Pawnee,Larned Ward 4,Governor,,R,Sam Brownback,72
-Pawnee,Lincoln Township,Governor,,R,Sam Brownback,9
-Pawnee,Logan Township,Governor,,R,Sam Brownback,23
-Pawnee,Morton Township,Governor,,R,Sam Brownback,17
-Pawnee,Orange Township,Governor,,R,Sam Brownback,11
-Pawnee,Pawnee Township,Governor,,R,Sam Brownback,20
-Pawnee,Pleasant Grove Township,Governor,,R,Sam Brownback,39
-Pawnee,Pleasant Valley Township,Governor,,R,Sam Brownback,28
-Pawnee,River Township,Governor,,R,Sam Brownback,22
-Pawnee,Santa Fe Township,Governor,,R,Sam Brownback,22
-Pawnee,Shiley Township,Governor,,R,Sam Brownback,15
-Pawnee,Valley Center Township,Governor,,R,Sam Brownback,13
-Pawnee,Walnut Township,Governor,,R,Sam Brownback,15
-Pawnee,Browns Grove Township C4,Governor,,R,Sam Brownback,1
-Pawnee,Garfield Township,Governor,,R,Sam Brownback,42
-Pawnee,Grant Township C4,Governor,,R,Sam Brownback,11
-Pawnee,Keysville Township,Governor,,R,Sam Brownback,13
-Pawnee,Pleasant Ridge Township,Governor,,R,Sam Brownback,9
-Pawnee,Sawmill Township,Governor,,R,Sam Brownback,8
-Pawnee,Ash Valley Township,Governor,,D,Paul Davis,17
-Pawnee,Browns Grove Township C1,Governor,,D,Paul Davis,40
-Pawnee,Conkling Township,Governor,,D,Paul Davis,5
-Pawnee,Grant Township C1,Governor,,D,Paul Davis,23
-Pawnee,Larned Township,Governor,,D,Paul Davis,49
-Pawnee,Larned Ward 1,Governor,,D,Paul Davis,139
-Pawnee,Larned Ward 2,Governor,,D,Paul Davis,207
-Pawnee,Larned Ward 3,Governor,,D,Paul Davis,199
-Pawnee,Larned Ward 4,Governor,,D,Paul Davis,104
-Pawnee,Lincoln Township,Governor,,D,Paul Davis,2
-Pawnee,Logan Township,Governor,,D,Paul Davis,2
-Pawnee,Morton Township,Governor,,D,Paul Davis,8
-Pawnee,Orange Township,Governor,,D,Paul Davis,6
-Pawnee,Pawnee Township,Governor,,D,Paul Davis,16
-Pawnee,Pleasant Grove Township,Governor,,D,Paul Davis,23
-Pawnee,Pleasant Valley Township,Governor,,D,Paul Davis,10
-Pawnee,River Township,Governor,,D,Paul Davis,5
-Pawnee,Santa Fe Township,Governor,,D,Paul Davis,27
-Pawnee,Shiley Township,Governor,,D,Paul Davis,0
-Pawnee,Valley Center Township,Governor,,D,Paul Davis,1
-Pawnee,Walnut Township,Governor,,D,Paul Davis,12
-Pawnee,Browns Grove Township C4,Governor,,D,Paul Davis,1
-Pawnee,Garfield Township,Governor,,D,Paul Davis,26
-Pawnee,Grant Township C4,Governor,,D,Paul Davis,1
-Pawnee,Keysville Township,Governor,,D,Paul Davis,5
-Pawnee,Pleasant Ridge Township,Governor,,D,Paul Davis,7
-Pawnee,Sawmill Township,Governor,,D,Paul Davis,3
-Pawnee,Ash Valley Township,Governor,,L,Keen Umbehr,0
-Pawnee,Browns Grove Township C1,Governor,,L,Keen Umbehr,7
-Pawnee,Conkling Township,Governor,,L,Keen Umbehr,0
-Pawnee,Grant Township C1,Governor,,L,Keen Umbehr,2
-Pawnee,Larned Township,Governor,,L,Keen Umbehr,5
-Pawnee,Larned Ward 1,Governor,,L,Keen Umbehr,13
-Pawnee,Larned Ward 2,Governor,,L,Keen Umbehr,20
-Pawnee,Larned Ward 3,Governor,,L,Keen Umbehr,9
-Pawnee,Larned Ward 4,Governor,,L,Keen Umbehr,9
-Pawnee,Lincoln Township,Governor,,L,Keen Umbehr,0
-Pawnee,Logan Township,Governor,,L,Keen Umbehr,0
-Pawnee,Morton Township,Governor,,L,Keen Umbehr,0
-Pawnee,Orange Township,Governor,,L,Keen Umbehr,1
-Pawnee,Pawnee Township,Governor,,L,Keen Umbehr,0
-Pawnee,Pleasant Grove Township,Governor,,L,Keen Umbehr,2
-Pawnee,Pleasant Valley Township,Governor,,L,Keen Umbehr,1
-Pawnee,River Township,Governor,,L,Keen Umbehr,1
-Pawnee,Santa Fe Township,Governor,,L,Keen Umbehr,3
-Pawnee,Shiley Township,Governor,,L,Keen Umbehr,0
-Pawnee,Valley Center Township,Governor,,L,Keen Umbehr,1
-Pawnee,Walnut Township,Governor,,L,Keen Umbehr,4
-Pawnee,Browns Grove Township C4,Governor,,L,Keen Umbehr,0
-Pawnee,Garfield Township,Governor,,L,Keen Umbehr,1
-Pawnee,Grant Township C4,Governor,,L,Keen Umbehr,0
-Pawnee,Keysville Township,Governor,,L,Keen Umbehr,0
-Pawnee,Pleasant Ridge Township,Governor,,L,Keen Umbehr,1
-Pawnee,Sawmill Township,Governor,,L,Keen Umbehr,1
-Pawnee,Ash Valley Township,Secretary of State,,R,Kris Kobach,14
-Pawnee,Browns Grove Township C1,Secretary of State,,R,Kris Kobach,85
-Pawnee,Conkling Township,Secretary of State,,R,Kris Kobach,7
-Pawnee,Grant Township C1,Secretary of State,,R,Kris Kobach,62
-Pawnee,Larned Township,Secretary of State,,R,Kris Kobach,82
-Pawnee,Larned Ward 1,Secretary of State,,R,Kris Kobach,179
-Pawnee,Larned Ward 2,Secretary of State,,R,Kris Kobach,261
-Pawnee,Larned Ward 3,Secretary of State,,R,Kris Kobach,294
-Pawnee,Larned Ward 4,Secretary of State,,R,Kris Kobach,103
-Pawnee,Lincoln Township,Secretary of State,,R,Kris Kobach,9
-Pawnee,Logan Township,Secretary of State,,R,Kris Kobach,24
-Pawnee,Morton Township,Secretary of State,,R,Kris Kobach,22
-Pawnee,Orange Township,Secretary of State,,R,Kris Kobach,12
-Pawnee,Pawnee Township,Secretary of State,,R,Kris Kobach,24
-Pawnee,Pleasant Grove Township,Secretary of State,,R,Kris Kobach,46
-Pawnee,Pleasant Valley Township,Secretary of State,,R,Kris Kobach,31
-Pawnee,River Township,Secretary of State,,R,Kris Kobach,24
-Pawnee,Santa Fe Township,Secretary of State,,R,Kris Kobach,33
-Pawnee,Shiley Township,Secretary of State,,R,Kris Kobach,15
-Pawnee,Valley Center Township,Secretary of State,,R,Kris Kobach,14
-Pawnee,Walnut Township,Secretary of State,,R,Kris Kobach,20
-Pawnee,Browns Grove Township C4,Secretary of State,,R,Kris Kobach,0
-Pawnee,Garfield Township,Secretary of State,,R,Kris Kobach,19
-Pawnee,Grant Township C4,Secretary of State,,R,Kris Kobach,0
-Pawnee,Keysville Township,Secretary of State,,R,Kris Kobach,3
-Pawnee,Pleasant Ridge Township,Secretary of State,,R,Kris Kobach,6
-Pawnee,Sawmill Township,Secretary of State,,R,Kris Kobach,2
-Pawnee,Ash Valley Township,Secretary of State,,D,Jean Schodorf,15
-Pawnee,Browns Grove Township C1,Secretary of State,,D,Jean Schodorf,27
-Pawnee,Conkling Township,Secretary of State,,D,Jean Schodorf,3
-Pawnee,Grant Township C1,Secretary of State,,D,Jean Schodorf,18
-Pawnee,Larned Township,Secretary of State,,D,Jean Schodorf,44
-Pawnee,Larned Ward 1,Secretary of State,,D,Jean Schodorf,91
-Pawnee,Larned Ward 2,Secretary of State,,D,Jean Schodorf,152
-Pawnee,Larned Ward 3,Secretary of State,,D,Jean Schodorf,132
-Pawnee,Larned Ward 4,Secretary of State,,D,Jean Schodorf,87
-Pawnee,Lincoln Township,Secretary of State,,D,Jean Schodorf,2
-Pawnee,Logan Township,Secretary of State,,D,Jean Schodorf,1
-Pawnee,Morton Township,Secretary of State,,D,Jean Schodorf,5
-Pawnee,Orange Township,Secretary of State,,D,Jean Schodorf,5
-Pawnee,Pawnee Township,Secretary of State,,D,Jean Schodorf,12
-Pawnee,Pleasant Grove Township,Secretary of State,,D,Jean Schodorf,17
-Pawnee,Pleasant Valley Township,Secretary of State,,D,Jean Schodorf,8
-Pawnee,River Township,Secretary of State,,D,Jean Schodorf,4
-Pawnee,Santa Fe Township,Secretary of State,,D,Jean Schodorf,23
-Pawnee,Shiley Township,Secretary of State,,D,Jean Schodorf,0
-Pawnee,Valley Center Township,Secretary of State,,D,Jean Schodorf,1
-Pawnee,Walnut Township,Secretary of State,,D,Jean Schodorf,10
-Pawnee,Browns Grove Township C4,Secretary of State,,D,Jean Schodorf,0
-Pawnee,Garfield Township,Secretary of State,,D,Jean Schodorf,19
-Pawnee,Grant Township C4,Secretary of State,,D,Jean Schodorf,0
-Pawnee,Keysville Township,Secretary of State,,D,Jean Schodorf,3
-Pawnee,Pleasant Ridge Township,Secretary of State,,D,Jean Schodorf,6
-Pawnee,Sawmill Township,Secretary of State,,D,Jean Schodorf,2
-Pawnee,Ash Valley Township,Attorney General,,R,Derek Schmidt,16
-Pawnee,Browns Grove Township C1,Attorney General,,R,Derek Schmidt,94
-Pawnee,Conkling Township,Attorney General,,R,Derek Schmidt,10
-Pawnee,Grant Township C1,Attorney General,,R,Derek Schmidt,71
-Pawnee,Larned Township,Attorney General,,R,Derek Schmidt,103
-Pawnee,Larned Ward 1,Attorney General,,R,Derek Schmidt,201
-Pawnee,Larned Ward 2,Attorney General,,R,Derek Schmidt,336
-Pawnee,Larned Ward 3,Attorney General,,R,Derek Schmidt,339
-Pawnee,Larned Ward 4,Attorney General,,R,Derek Schmidt,125
-Pawnee,Lincoln Township,Attorney General,,R,Derek Schmidt,10
-Pawnee,Logan Township,Attorney General,,R,Derek Schmidt,25
-Pawnee,Morton Township,Attorney General,,R,Derek Schmidt,22
-Pawnee,Orange Township,Attorney General,,R,Derek Schmidt,13
-Pawnee,Pawnee Township,Attorney General,,R,Derek Schmidt,27
-Pawnee,Pleasant Grove Township,Attorney General,,R,Derek Schmidt,48
-Pawnee,Pleasant Valley Township,Attorney General,,R,Derek Schmidt,33
-Pawnee,River Township,Attorney General,,R,Derek Schmidt,27
-Pawnee,Santa Fe Township,Attorney General,,R,Derek Schmidt,33
-Pawnee,Shiley Township,Attorney General,,R,Derek Schmidt,13
-Pawnee,Valley Center Township,Attorney General,,R,Derek Schmidt,14
-Pawnee,Walnut Township,Attorney General,,R,Derek Schmidt,24
-Pawnee,Browns Grove Township C4,Attorney General,,R,Derek Schmidt,2
-Pawnee,Garfield Township,Attorney General,,R,Derek Schmidt,52
-Pawnee,Grant Township C4,Attorney General,,R,Derek Schmidt,12
-Pawnee,Keysville Township,Attorney General,,R,Derek Schmidt,13
-Pawnee,Pleasant Ridge Township,Attorney General,,R,Derek Schmidt,13
-Pawnee,Sawmill Township,Attorney General,,R,Derek Schmidt,11
-Pawnee,Ash Valley Township,Attorney General,,D,AJ Kotich,13
-Pawnee,Browns Grove Township C1,Attorney General,,D,AJ Kotich,16
-Pawnee,Conkling Township,Attorney General,,D,AJ Kotich,0
-Pawnee,Grant Township C1,Attorney General,,D,AJ Kotich,9
-Pawnee,Larned Township,Attorney General,,D,AJ Kotich,24
-Pawnee,Larned Ward 1,Attorney General,,D,AJ Kotich,68
-Pawnee,Larned Ward 2,Attorney General,,D,AJ Kotich,73
-Pawnee,Larned Ward 3,Attorney General,,D,AJ Kotich,83
-Pawnee,Larned Ward 4,Attorney General,,D,AJ Kotich,65
-Pawnee,Lincoln Township,Attorney General,,D,AJ Kotich,1
-Pawnee,Logan Township,Attorney General,,D,AJ Kotich,0
-Pawnee,Morton Township,Attorney General,,D,AJ Kotich,4
-Pawnee,Orange Township,Attorney General,,D,AJ Kotich,5
-Pawnee,Pawnee Township,Attorney General,,D,AJ Kotich,8
-Pawnee,Pleasant Grove Township,Attorney General,,D,AJ Kotich,14
-Pawnee,Pleasant Valley Township,Attorney General,,D,AJ Kotich,3
-Pawnee,River Township,Attorney General,,D,AJ Kotich,1
-Pawnee,Santa Fe Township,Attorney General,,D,AJ Kotich,22
-Pawnee,Shiley Township,Attorney General,,D,AJ Kotich,2
-Pawnee,Valley Center Township,Attorney General,,D,AJ Kotich,1
-Pawnee,Walnut Township,Attorney General,,D,AJ Kotich,7
-Pawnee,Browns Grove Township C4,Attorney General,,D,AJ Kotich,0
-Pawnee,Garfield Township,Attorney General,,D,AJ Kotich,16
-Pawnee,Grant Township C4,Attorney General,,D,AJ Kotich,0
-Pawnee,Keysville Township,Attorney General,,D,AJ Kotich,4
-Pawnee,Pleasant Ridge Township,Attorney General,,D,AJ Kotich,4
-Pawnee,Sawmill Township,Attorney General,,D,AJ Kotich,1
-Pawnee,Ash Valley Township,State Treasurer,,R,Ron Estes,16
-Pawnee,Browns Grove Township C1,State Treasurer,,R,Ron Estes,102
-Pawnee,Conkling Township,State Treasurer,,R,Ron Estes,10
-Pawnee,Grant Township C1,State Treasurer,,R,Ron Estes,68
-Pawnee,Larned Township,State Treasurer,,R,Ron Estes,104
-Pawnee,Larned Ward 1,State Treasurer,,R,Ron Estes,195
-Pawnee,Larned Ward 2,State Treasurer,,R,Ron Estes,316
-Pawnee,Larned Ward 3,State Treasurer,,R,Ron Estes,333
-Pawnee,Larned Ward 4,State Treasurer,,R,Ron Estes,123
-Pawnee,Lincoln Township,State Treasurer,,R,Ron Estes,11
-Pawnee,Logan Township,State Treasurer,,R,Ron Estes,25
-Pawnee,Morton Township,State Treasurer,,R,Ron Estes,24
-Pawnee,Orange Township,State Treasurer,,R,Ron Estes,13
-Pawnee,Pawnee Township,State Treasurer,,R,Ron Estes,23
-Pawnee,Pleasant Grove Township,State Treasurer,,R,Ron Estes,47
-Pawnee,Pleasant Valley Township,State Treasurer,,R,Ron Estes,31
-Pawnee,River Township,State Treasurer,,R,Ron Estes,26
-Pawnee,Santa Fe Township,State Treasurer,,R,Ron Estes,34
-Pawnee,Shiley Township,State Treasurer,,R,Ron Estes,15
-Pawnee,Valley Center Township,State Treasurer,,R,Ron Estes,13
-Pawnee,Walnut Township,State Treasurer,,R,Ron Estes,23
-Pawnee,Browns Grove Township C4,State Treasurer,,R,Ron Estes,2
-Pawnee,Garfield Township,State Treasurer,,R,Ron Estes,51
-Pawnee,Grant Township C4,State Treasurer,,R,Ron Estes,11
-Pawnee,Keysville Township,State Treasurer,,R,Ron Estes,15
-Pawnee,Pleasant Ridge Township,State Treasurer,,R,Ron Estes,12
-Pawnee,Sawmill Township,State Treasurer,,R,Ron Estes,9
-Pawnee,Ash Valley Township,State Treasurer,,D,Carmen Alldritt,13
-Pawnee,Browns Grove Township C1,State Treasurer,,D,Carmen Alldritt,13
-Pawnee,Conkling Township,State Treasurer,,D,Carmen Alldritt,0
-Pawnee,Grant Township C1,State Treasurer,,D,Carmen Alldritt,11
-Pawnee,Larned Township,State Treasurer,,D,Carmen Alldritt,22
-Pawnee,Larned Ward 1,State Treasurer,,D,Carmen Alldritt,68
-Pawnee,Larned Ward 2,State Treasurer,,D,Carmen Alldritt,87
-Pawnee,Larned Ward 3,State Treasurer,,D,Carmen Alldritt,80
-Pawnee,Larned Ward 4,State Treasurer,,D,Carmen Alldritt,62
-Pawnee,Lincoln Township,State Treasurer,,D,Carmen Alldritt,0
-Pawnee,Logan Township,State Treasurer,,D,Carmen Alldritt,0
-Pawnee,Morton Township,State Treasurer,,D,Carmen Alldritt,2
-Pawnee,Orange Township,State Treasurer,,D,Carmen Alldritt,5
-Pawnee,Pawnee Township,State Treasurer,,D,Carmen Alldritt,10
-Pawnee,Pleasant Grove Township,State Treasurer,,D,Carmen Alldritt,13
-Pawnee,Pleasant Valley Township,State Treasurer,,D,Carmen Alldritt,7
-Pawnee,River Township,State Treasurer,,D,Carmen Alldritt,2
-Pawnee,Santa Fe Township,State Treasurer,,D,Carmen Alldritt,19
-Pawnee,Shiley Township,State Treasurer,,D,Carmen Alldritt,0
-Pawnee,Valley Center Township,State Treasurer,,D,Carmen Alldritt,1
-Pawnee,Walnut Township,State Treasurer,,D,Carmen Alldritt,7
-Pawnee,Browns Grove Township C4,State Treasurer,,D,Carmen Alldritt,0
-Pawnee,Garfield Township,State Treasurer,,D,Carmen Alldritt,14
-Pawnee,Grant Township C4,State Treasurer,,D,Carmen Alldritt,0
-Pawnee,Keysville Township,State Treasurer,,D,Carmen Alldritt,2
-Pawnee,Pleasant Ridge Township,State Treasurer,,D,Carmen Alldritt,3
-Pawnee,Sawmill Township,State Treasurer,,D,Carmen Alldritt,3
-Pawnee,Ash Valley Township,Insurance Commissioner,,R,Ken Selzer,14
-Pawnee,Browns Grove Township C1,Insurance Commissioner,,R,Ken Selzer,81
-Pawnee,Conkling Township,Insurance Commissioner,,R,Ken Selzer,7
-Pawnee,Grant Township C1,Insurance Commissioner,,R,Ken Selzer,67
-Pawnee,Larned Township,Insurance Commissioner,,R,Ken Selzer,95
-Pawnee,Larned Ward 1,Insurance Commissioner,,R,Ken Selzer,187
-Pawnee,Larned Ward 2,Insurance Commissioner,,R,Ken Selzer,274
-Pawnee,Larned Ward 3,Insurance Commissioner,,R,Ken Selzer,294
-Pawnee,Larned Ward 4,Insurance Commissioner,,R,Ken Selzer,109
-Pawnee,Lincoln Township,Insurance Commissioner,,R,Ken Selzer,9
-Pawnee,Logan Township,Insurance Commissioner,,R,Ken Selzer,24
-Pawnee,Morton Township,Insurance Commissioner,,R,Ken Selzer,21
-Pawnee,Orange Township,Insurance Commissioner,,R,Ken Selzer,12
-Pawnee,Pawnee Township,Insurance Commissioner,,R,Ken Selzer,22
-Pawnee,Pleasant Grove Township,Insurance Commissioner,,R,Ken Selzer,46
-Pawnee,Pleasant Valley Township,Insurance Commissioner,,R,Ken Selzer,27
-Pawnee,River Township,Insurance Commissioner,,R,Ken Selzer,29
-Pawnee,Santa Fe Township,Insurance Commissioner,,R,Ken Selzer,30
-Pawnee,Shiley Township,Insurance Commissioner,,R,Ken Selzer,14
-Pawnee,Valley Center Township,Insurance Commissioner,,R,Ken Selzer,14
-Pawnee,Walnut Township,Insurance Commissioner,,R,Ken Selzer,19
-Pawnee,Browns Grove Township C4,Insurance Commissioner,,R,Ken Selzer,2
-Pawnee,Garfield Township,Insurance Commissioner,,R,Ken Selzer,49
-Pawnee,Grant Township C4,Insurance Commissioner,,R,Ken Selzer,11
-Pawnee,Keysville Township,Insurance Commissioner,,R,Ken Selzer,11
-Pawnee,Pleasant Ridge Township,Insurance Commissioner,,R,Ken Selzer,10
-Pawnee,Sawmill Township,Insurance Commissioner,,R,Ken Selzer,9
-Pawnee,Ash Valley Township,Insurance Commissioner,,D,Dennis Anderson,15
-Pawnee,Browns Grove Township C1,Insurance Commissioner,,D,Dennis Anderson,29
-Pawnee,Conkling Township,Insurance Commissioner,,D,Dennis Anderson,2
-Pawnee,Grant Township C1,Insurance Commissioner,,D,Dennis Anderson,12
-Pawnee,Larned Township,Insurance Commissioner,,D,Dennis Anderson,31
-Pawnee,Larned Ward 1,Insurance Commissioner,,D,Dennis Anderson,76
-Pawnee,Larned Ward 2,Insurance Commissioner,,D,Dennis Anderson,127
-Pawnee,Larned Ward 3,Insurance Commissioner,,D,Dennis Anderson,112
-Pawnee,Larned Ward 4,Insurance Commissioner,,D,Dennis Anderson,78
-Pawnee,Lincoln Township,Insurance Commissioner,,D,Dennis Anderson,2
-Pawnee,Logan Township,Insurance Commissioner,,D,Dennis Anderson,1
-Pawnee,Morton Township,Insurance Commissioner,,D,Dennis Anderson,4
-Pawnee,Orange Township,Insurance Commissioner,,D,Dennis Anderson,5
-Pawnee,Pawnee Township,Insurance Commissioner,,D,Dennis Anderson,11
-Pawnee,Pleasant Grove Township,Insurance Commissioner,,D,Dennis Anderson,15
-Pawnee,Pleasant Valley Township,Insurance Commissioner,,D,Dennis Anderson,8
-Pawnee,River Township,Insurance Commissioner,,D,Dennis Anderson,1
-Pawnee,Santa Fe Township,Insurance Commissioner,,D,Dennis Anderson,23
-Pawnee,Shiley Township,Insurance Commissioner,,D,Dennis Anderson,1
-Pawnee,Valley Center Township,Insurance Commissioner,,D,Dennis Anderson,1
-Pawnee,Walnut Township,Insurance Commissioner,,D,Dennis Anderson,10
-Pawnee,Browns Grove Township C4,Insurance Commissioner,,D,Dennis Anderson,0
-Pawnee,Garfield Township,Insurance Commissioner,,D,Dennis Anderson,18
-Pawnee,Grant Township C4,Insurance Commissioner,,D,Dennis Anderson,0
-Pawnee,Keysville Township,Insurance Commissioner,,D,Dennis Anderson,4
-Pawnee,Pleasant Ridge Township,Insurance Commissioner,,D,Dennis Anderson,5
-Pawnee,Sawmill Township,Insurance Commissioner,,D,Dennis Anderson,3
-Pawnee,Ash Valley Township,State House,117,R,John Ewy,19
-Pawnee,Browns Grove Township C1,State House,117,R,John Ewy,108
-Pawnee,Conkling Township,State House,117,R,John Ewy,9
-Pawnee,Grant Township C1,State House,117,R,John Ewy,78
-Pawnee,Larned Township,State House,117,R,John Ewy,115
-Pawnee,Larned Ward 1,State House,117,R,John Ewy,234
-Pawnee,Larned Ward 2,State House,117,R,John Ewy,377
-Pawnee,Larned Ward 3,State House,117,R,John Ewy,368
-Pawnee,Larned Ward 4,State House,117,R,John Ewy,164
-Pawnee,Lincoln Township,State House,117,R,John Ewy,11
-Pawnee,Logan Township,State House,113,R,Jeremy Dannebohm,22
-Pawnee,Morton Township,State House,117,R,John Ewy,25
-Pawnee,Orange Township,State House,117,R,John Ewy,18
-Pawnee,Pawnee Township,State House,117,R,John Ewy,32
-Pawnee,Pleasant Grove Township,State House,117,R,John Ewy,60
-Pawnee,Pleasant Valley Township,State House,117,R,John Ewy,37
-Pawnee,River Township,State House,113,R,Jeremy Dannebohm,28
-Pawnee,Santa Fe Township,State House,117,R,John Ewy,41
-Pawnee,Shiley Township,State House,117,R,John Ewy,13
-Pawnee,Valley Center Township,State House,113,R,Jeremy Dannebohm,15
-Pawnee,Walnut Township,State House,117,R,John Ewy,27
-Pawnee,Browns Grove Township C4,State House,117,R,John Ewy,2
-Pawnee,Garfield Township,State House,117,R,John Ewy,60
-Pawnee,Grant Township C4,State House,117,R,John Ewy,12
-Pawnee,Keysville Township,State House,117,R,John Ewy,16
-Pawnee,Pleasant Ridge Township,State House,117,R,John Ewy,15
-Pawnee,Sawmill Township,State House,117,R,John Ewy,10
+county,precinct,office,district,party,candidate,votes,vtd
+PAWNEE,Ash Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000010
+PAWNEE,Ash Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+PAWNEE,Ash Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000010
+PAWNEE,Conkling Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000030
+PAWNEE,Conkling Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+PAWNEE,Conkling Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,000030
+PAWNEE,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000040
+PAWNEE,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+PAWNEE,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000040
+PAWNEE,Keysville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000060
+PAWNEE,Keysville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+PAWNEE,Keysville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000060
+PAWNEE,Larned Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000070
+PAWNEE,Larned Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000070
+PAWNEE,Larned Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000070
+PAWNEE,Larned Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",139,000080
+PAWNEE,Larned Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000080
+PAWNEE,Larned Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",120,000080
+PAWNEE,Larned Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",207,000090
+PAWNEE,Larned Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000090
+PAWNEE,Larned Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",182,000090
+PAWNEE,Larned Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",199,000100
+PAWNEE,Larned Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000100
+PAWNEE,Larned Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",221,000100
+PAWNEE,Larned Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",104,000110
+PAWNEE,Larned Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000110
+PAWNEE,Larned Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000110
+PAWNEE,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000120
+PAWNEE,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+PAWNEE,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000120
+PAWNEE,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000130
+PAWNEE,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000130
+PAWNEE,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000130
+PAWNEE,Morton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000140
+PAWNEE,Morton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000140
+PAWNEE,Morton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000140
+PAWNEE,Orange Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000150
+PAWNEE,Orange Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+PAWNEE,Orange Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000150
+PAWNEE,Pawnee Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000160
+PAWNEE,Pawnee Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000160
+PAWNEE,Pawnee Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000160
+PAWNEE,Pleasant Grove Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,00017A
+PAWNEE,Pleasant Grove Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00017A
+PAWNEE,Pleasant Grove Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00017B
+PAWNEE,Pleasant Ridge Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000180
+PAWNEE,Pleasant Ridge Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000180
+PAWNEE,Pleasant Ridge Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000180
+PAWNEE,Pleasant Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000190
+PAWNEE,Pleasant Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000190
+PAWNEE,Pleasant Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000190
+PAWNEE,River Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000200
+PAWNEE,River Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000200
+PAWNEE,River Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000200
+PAWNEE,Santa Fe Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000210
+PAWNEE,Santa Fe Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000210
+PAWNEE,Santa Fe Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000210
+PAWNEE,Sawmill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000220
+PAWNEE,Sawmill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000220
+PAWNEE,Sawmill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000220
+PAWNEE,Shiley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000230
+PAWNEE,Shiley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+PAWNEE,Shiley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000230
+PAWNEE,Valley Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000240
+PAWNEE,Valley Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000240
+PAWNEE,Valley Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000240
+PAWNEE,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000250
+PAWNEE,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000250
+PAWNEE,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000250
+PAWNEE,Browns Grove Township C1,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,120020
+PAWNEE,Browns Grove Township C1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,120020
+PAWNEE,Browns Grove Township C1,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,120020
+PAWNEE,Browns Grove Township C4,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120030
+PAWNEE,Browns Grove Township C4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+PAWNEE,Browns Grove Township C4,Governor / Lt. Governor,,Republican,"Brownback, Sam",1,120030
+PAWNEE,Grant Township C1,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,120040
+PAWNEE,Grant Township C1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120040
+PAWNEE,Grant Township C1,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,120040
+PAWNEE,Grant Township C4,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120050
+PAWNEE,Grant Township C4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120050
+PAWNEE,Grant Township C4,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,120050
+PAWNEE,Ash Valley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",19,000010
+PAWNEE,Conkling Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",9,000030
+PAWNEE,Garfield Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",60,000040
+PAWNEE,Keysville Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",16,000060
+PAWNEE,Larned Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",115,000070
+PAWNEE,Larned Ward 1,Kansas House of Representatives,117,Republican,"Ewy, John L.",234,000080
+PAWNEE,Larned Ward 2,Kansas House of Representatives,117,Republican,"Ewy, John L.",377,000090
+PAWNEE,Larned Ward 3,Kansas House of Representatives,117,Republican,"Ewy, John L.",368,000100
+PAWNEE,Larned Ward 4,Kansas House of Representatives,117,Republican,"Ewy, John L.",164,000110
+PAWNEE,Lincoln Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",11,000120
+PAWNEE,Logan Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",22,000130
+PAWNEE,Morton Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",25,000140
+PAWNEE,Orange Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",18,000150
+PAWNEE,Pawnee Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",32,000160
+PAWNEE,Pleasant Grove Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",60,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Kansas House of Representatives,117,Republican,"Ewy, John L.",0,00017B
+PAWNEE,Pleasant Ridge Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",15,000180
+PAWNEE,Pleasant Valley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",37,000190
+PAWNEE,River Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",28,000200
+PAWNEE,Santa Fe Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",41,000210
+PAWNEE,Sawmill Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",10,000220
+PAWNEE,Shiley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",13,000230
+PAWNEE,Valley Center Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",15,000240
+PAWNEE,Walnut Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",27,000250
+PAWNEE,Browns Grove Township C1,Kansas House of Representatives,117,Republican,"Ewy, John L.",108,120020
+PAWNEE,Browns Grove Township C4,Kansas House of Representatives,117,Republican,"Ewy, John L.",2,120030
+PAWNEE,Grant Township C1,Kansas House of Representatives,117,Republican,"Ewy, John L.",78,120040
+PAWNEE,Grant Township C4,Kansas House of Representatives,117,Republican,"Ewy, John L.",12,120050
+PAWNEE,Ash Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000010
+PAWNEE,Ash Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000010
+PAWNEE,Conkling Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000030
+PAWNEE,Conkling Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000030
+PAWNEE,Garfield Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",14,000040
+PAWNEE,Garfield Township,United States House of Representatives,4,Republican,"Pompeo, Mike",54,000040
+PAWNEE,Keysville Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000060
+PAWNEE,Keysville Township,United States House of Representatives,4,Republican,"Pompeo, Mike",14,000060
+PAWNEE,Larned Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000070
+PAWNEE,Larned Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",90,000070
+PAWNEE,Larned Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",86,000080
+PAWNEE,Larned Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",185,000080
+PAWNEE,Larned Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",138,000090
+PAWNEE,Larned Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",278,000090
+PAWNEE,Larned Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",134,000100
+PAWNEE,Larned Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",290,000100
+PAWNEE,Larned Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",85,000110
+PAWNEE,Larned Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",106,000110
+PAWNEE,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000120
+PAWNEE,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000120
+PAWNEE,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000130
+PAWNEE,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000130
+PAWNEE,Morton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000140
+PAWNEE,Morton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000140
+PAWNEE,Orange Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000150
+PAWNEE,Orange Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000150
+PAWNEE,Pawnee Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000160
+PAWNEE,Pawnee Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000160
+PAWNEE,Pleasant Grove Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,00017A
+PAWNEE,Pleasant Grove Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00017B
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000180
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,Republican,"Pompeo, Mike",13,000180
+PAWNEE,Pleasant Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000190
+PAWNEE,Pleasant Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000190
+PAWNEE,River Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000200
+PAWNEE,River Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000200
+PAWNEE,Santa Fe Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000210
+PAWNEE,Santa Fe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000210
+PAWNEE,Sawmill Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,000220
+PAWNEE,Sawmill Township,United States House of Representatives,4,Republican,"Pompeo, Mike",9,000220
+PAWNEE,Shiley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000230
+PAWNEE,Shiley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000230
+PAWNEE,Valley Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000240
+PAWNEE,Valley Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000240
+PAWNEE,Walnut Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000250
+PAWNEE,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000250
+PAWNEE,Browns Grove Township C1,United States House of Representatives,1,Democratic,"Sherow, James E.",32,120020
+PAWNEE,Browns Grove Township C1,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,120020
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,120030
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,Republican,"Pompeo, Mike",2,120030
+PAWNEE,Grant Township C1,United States House of Representatives,1,Democratic,"Sherow, James E.",20,120040
+PAWNEE,Grant Township C1,United States House of Representatives,1,Republican,"Huelskamp, Tim",61,120040
+PAWNEE,Grant Township C4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,120050
+PAWNEE,Grant Township C4,United States House of Representatives,4,Republican,"Pompeo, Mike",11,120050
+PAWNEE,Ash Valley Township,Attorney General,,Democratic,"Kotich, A.J.",13,000010
+PAWNEE,Ash Valley Township,Attorney General,,Republican,"Schmidt, Derek",16,000010
+PAWNEE,Conkling Township,Attorney General,,Democratic,"Kotich, A.J.",0,000030
+PAWNEE,Conkling Township,Attorney General,,Republican,"Schmidt, Derek",10,000030
+PAWNEE,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",16,000040
+PAWNEE,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",52,000040
+PAWNEE,Keysville Township,Attorney General,,Democratic,"Kotich, A.J.",4,000060
+PAWNEE,Keysville Township,Attorney General,,Republican,"Schmidt, Derek",13,000060
+PAWNEE,Larned Township,Attorney General,,Democratic,"Kotich, A.J.",24,000070
+PAWNEE,Larned Township,Attorney General,,Republican,"Schmidt, Derek",103,000070
+PAWNEE,Larned Ward 1,Attorney General,,Democratic,"Kotich, A.J.",68,000080
+PAWNEE,Larned Ward 1,Attorney General,,Republican,"Schmidt, Derek",201,000080
+PAWNEE,Larned Ward 2,Attorney General,,Democratic,"Kotich, A.J.",73,000090
+PAWNEE,Larned Ward 2,Attorney General,,Republican,"Schmidt, Derek",336,000090
+PAWNEE,Larned Ward 3,Attorney General,,Democratic,"Kotich, A.J.",83,000100
+PAWNEE,Larned Ward 3,Attorney General,,Republican,"Schmidt, Derek",339,000100
+PAWNEE,Larned Ward 4,Attorney General,,Democratic,"Kotich, A.J.",65,000110
+PAWNEE,Larned Ward 4,Attorney General,,Republican,"Schmidt, Derek",125,000110
+PAWNEE,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",1,000120
+PAWNEE,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",10,000120
+PAWNEE,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",0,000130
+PAWNEE,Logan Township,Attorney General,,Republican,"Schmidt, Derek",25,000130
+PAWNEE,Morton Township,Attorney General,,Democratic,"Kotich, A.J.",4,000140
+PAWNEE,Morton Township,Attorney General,,Republican,"Schmidt, Derek",22,000140
+PAWNEE,Orange Township,Attorney General,,Democratic,"Kotich, A.J.",5,000150
+PAWNEE,Orange Township,Attorney General,,Republican,"Schmidt, Derek",13,000150
+PAWNEE,Pawnee Township,Attorney General,,Democratic,"Kotich, A.J.",8,000160
+PAWNEE,Pawnee Township,Attorney General,,Republican,"Schmidt, Derek",27,000160
+PAWNEE,Pleasant Grove Township,Attorney General,,Democratic,"Kotich, A.J.",14,00017A
+PAWNEE,Pleasant Grove Township,Attorney General,,Republican,"Schmidt, Derek",48,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00017B
+PAWNEE,Pleasant Ridge Township,Attorney General,,Democratic,"Kotich, A.J.",4,000180
+PAWNEE,Pleasant Ridge Township,Attorney General,,Republican,"Schmidt, Derek",13,000180
+PAWNEE,Pleasant Valley Township,Attorney General,,Democratic,"Kotich, A.J.",3,000190
+PAWNEE,Pleasant Valley Township,Attorney General,,Republican,"Schmidt, Derek",33,000190
+PAWNEE,River Township,Attorney General,,Democratic,"Kotich, A.J.",1,000200
+PAWNEE,River Township,Attorney General,,Republican,"Schmidt, Derek",27,000200
+PAWNEE,Santa Fe Township,Attorney General,,Democratic,"Kotich, A.J.",22,000210
+PAWNEE,Santa Fe Township,Attorney General,,Republican,"Schmidt, Derek",33,000210
+PAWNEE,Sawmill Township,Attorney General,,Democratic,"Kotich, A.J.",1,000220
+PAWNEE,Sawmill Township,Attorney General,,Republican,"Schmidt, Derek",11,000220
+PAWNEE,Shiley Township,Attorney General,,Democratic,"Kotich, A.J.",2,000230
+PAWNEE,Shiley Township,Attorney General,,Republican,"Schmidt, Derek",13,000230
+PAWNEE,Valley Center Township,Attorney General,,Democratic,"Kotich, A.J.",1,000240
+PAWNEE,Valley Center Township,Attorney General,,Republican,"Schmidt, Derek",14,000240
+PAWNEE,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",7,000250
+PAWNEE,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",24,000250
+PAWNEE,Browns Grove Township C1,Attorney General,,Democratic,"Kotich, A.J.",16,120020
+PAWNEE,Browns Grove Township C1,Attorney General,,Republican,"Schmidt, Derek",94,120020
+PAWNEE,Browns Grove Township C4,Attorney General,,Democratic,"Kotich, A.J.",0,120030
+PAWNEE,Browns Grove Township C4,Attorney General,,Republican,"Schmidt, Derek",2,120030
+PAWNEE,Grant Township C1,Attorney General,,Democratic,"Kotich, A.J.",9,120040
+PAWNEE,Grant Township C1,Attorney General,,Republican,"Schmidt, Derek",71,120040
+PAWNEE,Grant Township C4,Attorney General,,Democratic,"Kotich, A.J.",0,120050
+PAWNEE,Grant Township C4,Attorney General,,Republican,"Schmidt, Derek",12,120050
+PAWNEE,Ash Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000010
+PAWNEE,Ash Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000010
+PAWNEE,Conkling Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000030
+PAWNEE,Conkling Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000030
+PAWNEE,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000040
+PAWNEE,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000040
+PAWNEE,Keysville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000060
+PAWNEE,Keysville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000060
+PAWNEE,Larned Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000070
+PAWNEE,Larned Township,Commissioner of Insurance,,Republican,"Selzer, Ken",95,000070
+PAWNEE,Larned Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,000080
+PAWNEE,Larned Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",187,000080
+PAWNEE,Larned Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",127,000090
+PAWNEE,Larned Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",274,000090
+PAWNEE,Larned Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",112,000100
+PAWNEE,Larned Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",294,000100
+PAWNEE,Larned Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",78,000110
+PAWNEE,Larned Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",109,000110
+PAWNEE,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000120
+PAWNEE,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000120
+PAWNEE,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000130
+PAWNEE,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000130
+PAWNEE,Morton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000140
+PAWNEE,Morton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000140
+PAWNEE,Orange Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000150
+PAWNEE,Orange Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000150
+PAWNEE,Pawnee Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000160
+PAWNEE,Pawnee Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000160
+PAWNEE,Pleasant Grove Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,00017A
+PAWNEE,Pleasant Grove Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00017B
+PAWNEE,Pleasant Ridge Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000180
+PAWNEE,Pleasant Ridge Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000180
+PAWNEE,Pleasant Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000190
+PAWNEE,Pleasant Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000190
+PAWNEE,River Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000200
+PAWNEE,River Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000200
+PAWNEE,Santa Fe Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000210
+PAWNEE,Santa Fe Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000210
+PAWNEE,Sawmill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000220
+PAWNEE,Sawmill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000220
+PAWNEE,Shiley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000230
+PAWNEE,Shiley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000230
+PAWNEE,Valley Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000240
+PAWNEE,Valley Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000240
+PAWNEE,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000250
+PAWNEE,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000250
+PAWNEE,Browns Grove Township C1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,120020
+PAWNEE,Browns Grove Township C1,Commissioner of Insurance,,Republican,"Selzer, Ken",81,120020
+PAWNEE,Browns Grove Township C4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120030
+PAWNEE,Browns Grove Township C4,Commissioner of Insurance,,Republican,"Selzer, Ken",2,120030
+PAWNEE,Grant Township C1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,120040
+PAWNEE,Grant Township C1,Commissioner of Insurance,,Republican,"Selzer, Ken",67,120040
+PAWNEE,Grant Township C4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120050
+PAWNEE,Grant Township C4,Commissioner of Insurance,,Republican,"Selzer, Ken",11,120050
+PAWNEE,Ash Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000010
+PAWNEE,Ash Valley Township,Secretary of State,,Republican,"Kobach, Kris",14,000010
+PAWNEE,Conkling Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000030
+PAWNEE,Conkling Township,Secretary of State,,Republican,"Kobach, Kris",7,000030
+PAWNEE,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000040
+PAWNEE,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",49,000040
+PAWNEE,Keysville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000060
+PAWNEE,Keysville Township,Secretary of State,,Republican,"Kobach, Kris",15,000060
+PAWNEE,Larned Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000070
+PAWNEE,Larned Township,Secretary of State,,Republican,"Kobach, Kris",82,000070
+PAWNEE,Larned Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",91,000080
+PAWNEE,Larned Ward 1,Secretary of State,,Republican,"Kobach, Kris",179,000080
+PAWNEE,Larned Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",152,000090
+PAWNEE,Larned Ward 2,Secretary of State,,Republican,"Kobach, Kris",261,000090
+PAWNEE,Larned Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",132,000100
+PAWNEE,Larned Ward 3,Secretary of State,,Republican,"Kobach, Kris",294,000100
+PAWNEE,Larned Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",87,000110
+PAWNEE,Larned Ward 4,Secretary of State,,Republican,"Kobach, Kris",103,000110
+PAWNEE,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000120
+PAWNEE,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",9,000120
+PAWNEE,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000130
+PAWNEE,Logan Township,Secretary of State,,Republican,"Kobach, Kris",24,000130
+PAWNEE,Morton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000140
+PAWNEE,Morton Township,Secretary of State,,Republican,"Kobach, Kris",22,000140
+PAWNEE,Orange Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000150
+PAWNEE,Orange Township,Secretary of State,,Republican,"Kobach, Kris",12,000150
+PAWNEE,Pawnee Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000160
+PAWNEE,Pawnee Township,Secretary of State,,Republican,"Kobach, Kris",24,000160
+PAWNEE,Pleasant Grove Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,00017A
+PAWNEE,Pleasant Grove Township,Secretary of State,,Republican,"Kobach, Kris",46,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00017B
+PAWNEE,Pleasant Ridge Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000180
+PAWNEE,Pleasant Ridge Township,Secretary of State,,Republican,"Kobach, Kris",10,000180
+PAWNEE,Pleasant Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000190
+PAWNEE,Pleasant Valley Township,Secretary of State,,Republican,"Kobach, Kris",31,000190
+PAWNEE,River Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000200
+PAWNEE,River Township,Secretary of State,,Republican,"Kobach, Kris",24,000200
+PAWNEE,Santa Fe Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000210
+PAWNEE,Santa Fe Township,Secretary of State,,Republican,"Kobach, Kris",33,000210
+PAWNEE,Sawmill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000220
+PAWNEE,Sawmill Township,Secretary of State,,Republican,"Kobach, Kris",10,000220
+PAWNEE,Shiley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000230
+PAWNEE,Shiley Township,Secretary of State,,Republican,"Kobach, Kris",15,000230
+PAWNEE,Valley Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000240
+PAWNEE,Valley Center Township,Secretary of State,,Republican,"Kobach, Kris",14,000240
+PAWNEE,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000250
+PAWNEE,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",20,000250
+PAWNEE,Browns Grove Township C1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,120020
+PAWNEE,Browns Grove Township C1,Secretary of State,,Republican,"Kobach, Kris",85,120020
+PAWNEE,Browns Grove Township C4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120030
+PAWNEE,Browns Grove Township C4,Secretary of State,,Republican,"Kobach, Kris",2,120030
+PAWNEE,Grant Township C1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,120040
+PAWNEE,Grant Township C1,Secretary of State,,Republican,"Kobach, Kris",62,120040
+PAWNEE,Grant Township C4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120050
+PAWNEE,Grant Township C4,Secretary of State,,Republican,"Kobach, Kris",11,120050
+PAWNEE,Ash Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000010
+PAWNEE,Ash Valley Township,State Treasurer,,Republican,"Estes, Ron",16,000010
+PAWNEE,Conkling Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000030
+PAWNEE,Conkling Township,State Treasurer,,Republican,"Estes, Ron",10,000030
+PAWNEE,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000040
+PAWNEE,Garfield Township,State Treasurer,,Republican,"Estes, Ron",51,000040
+PAWNEE,Keysville Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000060
+PAWNEE,Keysville Township,State Treasurer,,Republican,"Estes, Ron",15,000060
+PAWNEE,Larned Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000070
+PAWNEE,Larned Township,State Treasurer,,Republican,"Estes, Ron",104,000070
+PAWNEE,Larned Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",68,000080
+PAWNEE,Larned Ward 1,State Treasurer,,Republican,"Estes, Ron",195,000080
+PAWNEE,Larned Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",87,000090
+PAWNEE,Larned Ward 2,State Treasurer,,Republican,"Estes, Ron",316,000090
+PAWNEE,Larned Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",80,000100
+PAWNEE,Larned Ward 3,State Treasurer,,Republican,"Estes, Ron",333,000100
+PAWNEE,Larned Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",62,000110
+PAWNEE,Larned Ward 4,State Treasurer,,Republican,"Estes, Ron",123,000110
+PAWNEE,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000120
+PAWNEE,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",11,000120
+PAWNEE,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000130
+PAWNEE,Logan Township,State Treasurer,,Republican,"Estes, Ron",25,000130
+PAWNEE,Morton Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000140
+PAWNEE,Morton Township,State Treasurer,,Republican,"Estes, Ron",24,000140
+PAWNEE,Orange Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000150
+PAWNEE,Orange Township,State Treasurer,,Republican,"Estes, Ron",13,000150
+PAWNEE,Pawnee Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000160
+PAWNEE,Pawnee Township,State Treasurer,,Republican,"Estes, Ron",23,000160
+PAWNEE,Pleasant Grove Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,00017A
+PAWNEE,Pleasant Grove Township,State Treasurer,,Republican,"Estes, Ron",47,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,State Treasurer,,Republican,"Estes, Ron",0,00017B
+PAWNEE,Pleasant Ridge Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000180
+PAWNEE,Pleasant Ridge Township,State Treasurer,,Republican,"Estes, Ron",12,000180
+PAWNEE,Pleasant Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000190
+PAWNEE,Pleasant Valley Township,State Treasurer,,Republican,"Estes, Ron",31,000190
+PAWNEE,River Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000200
+PAWNEE,River Township,State Treasurer,,Republican,"Estes, Ron",26,000200
+PAWNEE,Santa Fe Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000210
+PAWNEE,Santa Fe Township,State Treasurer,,Republican,"Estes, Ron",34,000210
+PAWNEE,Sawmill Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000220
+PAWNEE,Sawmill Township,State Treasurer,,Republican,"Estes, Ron",9,000220
+PAWNEE,Shiley Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000230
+PAWNEE,Shiley Township,State Treasurer,,Republican,"Estes, Ron",15,000230
+PAWNEE,Valley Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000240
+PAWNEE,Valley Center Township,State Treasurer,,Republican,"Estes, Ron",13,000240
+PAWNEE,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000250
+PAWNEE,Walnut Township,State Treasurer,,Republican,"Estes, Ron",23,000250
+PAWNEE,Browns Grove Township C1,State Treasurer,,Democratic,"Alldritt, Carmen",13,120020
+PAWNEE,Browns Grove Township C1,State Treasurer,,Republican,"Estes, Ron",102,120020
+PAWNEE,Browns Grove Township C4,State Treasurer,,Democratic,"Alldritt, Carmen",0,120030
+PAWNEE,Browns Grove Township C4,State Treasurer,,Republican,"Estes, Ron",2,120030
+PAWNEE,Grant Township C1,State Treasurer,,Democratic,"Alldritt, Carmen",11,120040
+PAWNEE,Grant Township C1,State Treasurer,,Republican,"Estes, Ron",68,120040
+PAWNEE,Grant Township C4,State Treasurer,,Democratic,"Alldritt, Carmen",0,120050
+PAWNEE,Grant Township C4,State Treasurer,,Republican,"Estes, Ron",11,120050
+PAWNEE,Ash Valley Township,United States Senate,,independent,"Orman, Greg",17,000010
+PAWNEE,Ash Valley Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+PAWNEE,Ash Valley Township,United States Senate,,Republican,"Roberts, Pat",12,000010
+PAWNEE,Conkling Township,United States Senate,,independent,"Orman, Greg",2,000030
+PAWNEE,Conkling Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+PAWNEE,Conkling Township,United States Senate,,Republican,"Roberts, Pat",8,000030
+PAWNEE,Garfield Township,United States Senate,,independent,"Orman, Greg",17,000040
+PAWNEE,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",4,000040
+PAWNEE,Garfield Township,United States Senate,,Republican,"Roberts, Pat",47,000040
+PAWNEE,Keysville Township,United States Senate,,independent,"Orman, Greg",5,000060
+PAWNEE,Keysville Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+PAWNEE,Keysville Township,United States Senate,,Republican,"Roberts, Pat",13,000060
+PAWNEE,Larned Township,United States Senate,,independent,"Orman, Greg",40,000070
+PAWNEE,Larned Township,United States Senate,,Libertarian,"Batson, Randall",6,000070
+PAWNEE,Larned Township,United States Senate,,Republican,"Roberts, Pat",82,000070
+PAWNEE,Larned Ward 1,United States Senate,,independent,"Orman, Greg",103,000080
+PAWNEE,Larned Ward 1,United States Senate,,Libertarian,"Batson, Randall",16,000080
+PAWNEE,Larned Ward 1,United States Senate,,Republican,"Roberts, Pat",155,000080
+PAWNEE,Larned Ward 2,United States Senate,,independent,"Orman, Greg",148,000090
+PAWNEE,Larned Ward 2,United States Senate,,Libertarian,"Batson, Randall",16,000090
+PAWNEE,Larned Ward 2,United States Senate,,Republican,"Roberts, Pat",249,000090
+PAWNEE,Larned Ward 3,United States Senate,,independent,"Orman, Greg",145,000100
+PAWNEE,Larned Ward 3,United States Senate,,Libertarian,"Batson, Randall",9,000100
+PAWNEE,Larned Ward 3,United States Senate,,Republican,"Roberts, Pat",277,000100
+PAWNEE,Larned Ward 4,United States Senate,,independent,"Orman, Greg",90,000110
+PAWNEE,Larned Ward 4,United States Senate,,Libertarian,"Batson, Randall",7,000110
+PAWNEE,Larned Ward 4,United States Senate,,Republican,"Roberts, Pat",92,000110
+PAWNEE,Lincoln Township,United States Senate,,independent,"Orman, Greg",0,000120
+PAWNEE,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",1,000120
+PAWNEE,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",10,000120
+PAWNEE,Logan Township,United States Senate,,independent,"Orman, Greg",1,000130
+PAWNEE,Logan Township,United States Senate,,Libertarian,"Batson, Randall",1,000130
+PAWNEE,Logan Township,United States Senate,,Republican,"Roberts, Pat",21,000130
+PAWNEE,Morton Township,United States Senate,,independent,"Orman, Greg",5,000140
+PAWNEE,Morton Township,United States Senate,,Libertarian,"Batson, Randall",0,000140
+PAWNEE,Morton Township,United States Senate,,Republican,"Roberts, Pat",22,000140
+PAWNEE,Orange Township,United States Senate,,independent,"Orman, Greg",4,000150
+PAWNEE,Orange Township,United States Senate,,Libertarian,"Batson, Randall",4,000150
+PAWNEE,Orange Township,United States Senate,,Republican,"Roberts, Pat",10,000150
+PAWNEE,Pawnee Township,United States Senate,,independent,"Orman, Greg",12,000160
+PAWNEE,Pawnee Township,United States Senate,,Libertarian,"Batson, Randall",2,000160
+PAWNEE,Pawnee Township,United States Senate,,Republican,"Roberts, Pat",22,000160
+PAWNEE,Pleasant Grove Township,United States Senate,,independent,"Orman, Greg",16,00017A
+PAWNEE,Pleasant Grove Township,United States Senate,,Libertarian,"Batson, Randall",5,00017A
+PAWNEE,Pleasant Grove Township,United States Senate,,Republican,"Roberts, Pat",43,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,United States Senate,,independent,"Orman, Greg",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States Senate,,Republican,"Roberts, Pat",0,00017B
+PAWNEE,Pleasant Ridge Township,United States Senate,,independent,"Orman, Greg",5,000180
+PAWNEE,Pleasant Ridge Township,United States Senate,,Libertarian,"Batson, Randall",2,000180
+PAWNEE,Pleasant Ridge Township,United States Senate,,Republican,"Roberts, Pat",10,000180
+PAWNEE,Pleasant Valley Township,United States Senate,,independent,"Orman, Greg",9,000190
+PAWNEE,Pleasant Valley Township,United States Senate,,Libertarian,"Batson, Randall",2,000190
+PAWNEE,Pleasant Valley Township,United States Senate,,Republican,"Roberts, Pat",27,000190
+PAWNEE,River Township,United States Senate,,independent,"Orman, Greg",3,000200
+PAWNEE,River Township,United States Senate,,Libertarian,"Batson, Randall",0,000200
+PAWNEE,River Township,United States Senate,,Republican,"Roberts, Pat",25,000200
+PAWNEE,Santa Fe Township,United States Senate,,independent,"Orman, Greg",19,000210
+PAWNEE,Santa Fe Township,United States Senate,,Libertarian,"Batson, Randall",4,000210
+PAWNEE,Santa Fe Township,United States Senate,,Republican,"Roberts, Pat",32,000210
+PAWNEE,Sawmill Township,United States Senate,,independent,"Orman, Greg",2,000220
+PAWNEE,Sawmill Township,United States Senate,,Libertarian,"Batson, Randall",1,000220
+PAWNEE,Sawmill Township,United States Senate,,Republican,"Roberts, Pat",9,000220
+PAWNEE,Shiley Township,United States Senate,,independent,"Orman, Greg",0,000230
+PAWNEE,Shiley Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+PAWNEE,Shiley Township,United States Senate,,Republican,"Roberts, Pat",15,000230
+PAWNEE,Valley Center Township,United States Senate,,independent,"Orman, Greg",1,000240
+PAWNEE,Valley Center Township,United States Senate,,Libertarian,"Batson, Randall",2,000240
+PAWNEE,Valley Center Township,United States Senate,,Republican,"Roberts, Pat",12,000240
+PAWNEE,Walnut Township,United States Senate,,independent,"Orman, Greg",11,000250
+PAWNEE,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",1,000250
+PAWNEE,Walnut Township,United States Senate,,Republican,"Roberts, Pat",19,000250
+PAWNEE,Browns Grove Township C1,United States Senate,,independent,"Orman, Greg",26,120020
+PAWNEE,Browns Grove Township C1,United States Senate,,Libertarian,"Batson, Randall",8,120020
+PAWNEE,Browns Grove Township C1,United States Senate,,Republican,"Roberts, Pat",84,120020
+PAWNEE,Browns Grove Township C4,United States Senate,,independent,"Orman, Greg",1,120030
+PAWNEE,Browns Grove Township C4,United States Senate,,Libertarian,"Batson, Randall",0,120030
+PAWNEE,Browns Grove Township C4,United States Senate,,Republican,"Roberts, Pat",1,120030
+PAWNEE,Grant Township C1,United States Senate,,independent,"Orman, Greg",14,120040
+PAWNEE,Grant Township C1,United States Senate,,Libertarian,"Batson, Randall",1,120040
+PAWNEE,Grant Township C1,United States Senate,,Republican,"Roberts, Pat",65,120040
+PAWNEE,Grant Township C4,United States Senate,,independent,"Orman, Greg",1,120050
+PAWNEE,Grant Township C4,United States Senate,,Libertarian,"Batson, Randall",0,120050
+PAWNEE,Grant Township C4,United States Senate,,Republican,"Roberts, Pat",11,120050

--- a/2014/20141104__ks__general__phillips__precinct.csv
+++ b/2014/20141104__ks__general__phillips__precinct.csv
@@ -1,528 +1,494 @@
-county,precinct,office,district,party,candidate,votes
-Phillips,Arcade,U.S. Senate,,R,Pat Roberts,33
-Phillips,Beaver,U.S. Senate,,R,Pat Roberts,25
-Phillips,Belmont,U.S. Senate,,R,Pat Roberts,34
-Phillips,Bow Creek,U.S. Senate,,R,Pat Roberts,17
-Phillips,Crystal,U.S. Senate,,R,Pat Roberts,22
-Phillips,Dayton,U.S. Senate,,R,Pat Roberts,18
-Phillips,Deer Creek,U.S. Senate,,R,Pat Roberts,34
-Phillips,Freedom,U.S. Senate,,R,Pat Roberts,43
-Phillips,Glenwood,U.S. Senate,,R,Pat Roberts,18
-Phillips,Granite,U.S. Senate,,R,Pat Roberts,16
-Phillips,Greenwood,U.S. Senate,,R,Pat Roberts,25
-Phillips,Kirwin,U.S. Senate,,R,Pat Roberts,29
-Phillips,Logan,U.S. Senate,,R,Pat Roberts,178
-Phillips,Long Island,U.S. Senate,,R,Pat Roberts,77
-Phillips,Mound,U.S. Senate,,R,Pat Roberts,48
-Phillips,Phillipsburg,U.S. Senate,,R,Pat Roberts,112
-Phillips,Plainview,U.S. Senate,,R,Pat Roberts,5
-Phillips,Plum,U.S. Senate,,R,Pat Roberts,41
-Phillips,Prairie View,U.S. Senate,,R,Pat Roberts,80
-Phillips,Rushville,U.S. Senate,,R,Pat Roberts,9
-Phillips,Solomon,U.S. Senate,,R,Pat Roberts,48
-Phillips,Sumner,U.S. Senate,,R,Pat Roberts,17
-Phillips,Towanda,U.S. Senate,,R,Pat Roberts,11
-Phillips,Valley,U.S. Senate,,R,Pat Roberts,11
-Phillips,Walnut,U.S. Senate,,R,Pat Roberts,4
-Phillips,Ward 1,U.S. Senate,,R,Pat Roberts,324
-Phillips,Ward 2,U.S. Senate,,R,Pat Roberts,226
-Phillips,Ward 3,U.S. Senate,,R,Pat Roberts,233
-Phillips,Agra City,U.S. Senate,,R,Pat Roberts,89
-Phillips,Glade City,U.S. Senate,,R,Pat Roberts,22
-Phillips,Kirwin City,U.S. Senate,,R,Pat Roberts,40
-Phillips,Arcade,U.S. Senate,,I,Greg Orman,16
-Phillips,Beaver,U.S. Senate,,I,Greg Orman,1
-Phillips,Belmont,U.S. Senate,,I,Greg Orman,4
-Phillips,Bow Creek,U.S. Senate,,I,Greg Orman,2
-Phillips,Crystal,U.S. Senate,,I,Greg Orman,5
-Phillips,Dayton,U.S. Senate,,I,Greg Orman,2
-Phillips,Deer Creek,U.S. Senate,,I,Greg Orman,1
-Phillips,Freedom,U.S. Senate,,I,Greg Orman,5
-Phillips,Glenwood,U.S. Senate,,I,Greg Orman,2
-Phillips,Granite,U.S. Senate,,I,Greg Orman,1
-Phillips,Greenwood,U.S. Senate,,I,Greg Orman,2
-Phillips,Kirwin,U.S. Senate,,I,Greg Orman,5
-Phillips,Logan,U.S. Senate,,I,Greg Orman,59
-Phillips,Long Island,U.S. Senate,,I,Greg Orman,15
-Phillips,Mound,U.S. Senate,,I,Greg Orman,11
-Phillips,Phillipsburg,U.S. Senate,,I,Greg Orman,26
-Phillips,Plainview,U.S. Senate,,I,Greg Orman,3
-Phillips,Plum,U.S. Senate,,I,Greg Orman,9
-Phillips,Prairie View,U.S. Senate,,I,Greg Orman,10
-Phillips,Rushville,U.S. Senate,,I,Greg Orman,0
-Phillips,Solomon,U.S. Senate,,I,Greg Orman,8
-Phillips,Sumner,U.S. Senate,,I,Greg Orman,1
-Phillips,Towanda,U.S. Senate,,I,Greg Orman,1
-Phillips,Valley,U.S. Senate,,I,Greg Orman,3
-Phillips,Walnut,U.S. Senate,,I,Greg Orman,0
-Phillips,Ward 1,U.S. Senate,,I,Greg Orman,98
-Phillips,Ward 2,U.S. Senate,,I,Greg Orman,79
-Phillips,Ward 3,U.S. Senate,,I,Greg Orman,84
-Phillips,Agra City,U.S. Senate,,I,Greg Orman,21
-Phillips,Glade City,U.S. Senate,,I,Greg Orman,2
-Phillips,Kirwin City,U.S. Senate,,I,Greg Orman,16
-Phillips,Arcade,U.S. Senate,,L,Randall Batson,1
-Phillips,Beaver,U.S. Senate,,L,Randall Batson,0
-Phillips,Belmont,U.S. Senate,,L,Randall Batson,2
-Phillips,Bow Creek,U.S. Senate,,L,Randall Batson,0
-Phillips,Crystal,U.S. Senate,,L,Randall Batson,1
-Phillips,Dayton,U.S. Senate,,L,Randall Batson,0
-Phillips,Deer Creek,U.S. Senate,,L,Randall Batson,3
-Phillips,Freedom,U.S. Senate,,L,Randall Batson,1
-Phillips,Glenwood,U.S. Senate,,L,Randall Batson,1
-Phillips,Granite,U.S. Senate,,L,Randall Batson,1
-Phillips,Greenwood,U.S. Senate,,L,Randall Batson,0
-Phillips,Kirwin,U.S. Senate,,L,Randall Batson,2
-Phillips,Logan,U.S. Senate,,L,Randall Batson,12
-Phillips,Long Island,U.S. Senate,,L,Randall Batson,2
-Phillips,Mound,U.S. Senate,,L,Randall Batson,6
-Phillips,Phillipsburg,U.S. Senate,,L,Randall Batson,3
-Phillips,Plainview,U.S. Senate,,L,Randall Batson,1
-Phillips,Plum,U.S. Senate,,L,Randall Batson,2
-Phillips,Prairie View,U.S. Senate,,L,Randall Batson,1
-Phillips,Rushville,U.S. Senate,,L,Randall Batson,0
-Phillips,Solomon,U.S. Senate,,L,Randall Batson,1
-Phillips,Sumner,U.S. Senate,,L,Randall Batson,0
-Phillips,Towanda,U.S. Senate,,L,Randall Batson,0
-Phillips,Valley,U.S. Senate,,L,Randall Batson,1
-Phillips,Walnut,U.S. Senate,,L,Randall Batson,0
-Phillips,Ward 1,U.S. Senate,,L,Randall Batson,18
-Phillips,Ward 2,U.S. Senate,,L,Randall Batson,18
-Phillips,Ward 3,U.S. Senate,,L,Randall Batson,20
-Phillips,Agra City,U.S. Senate,,L,Randall Batson,11
-Phillips,Glade City,U.S. Senate,,L,Randall Batson,1
-Phillips,Kirwin City,U.S. Senate,,L,Randall Batson,4
-Phillips,Arcade,U.S. House,1,R,Tim Huelskamp,38
-Phillips,Beaver,U.S. House,1,R,Tim Huelskamp,22
-Phillips,Belmont,U.S. House,1,R,Tim Huelskamp,33
-Phillips,Bow Creek,U.S. House,1,R,Tim Huelskamp,16
-Phillips,Crystal,U.S. House,1,R,Tim Huelskamp,20
-Phillips,Dayton,U.S. House,1,R,Tim Huelskamp,11
-Phillips,Deer Creek,U.S. House,1,R,Tim Huelskamp,37
-Phillips,Freedom,U.S. House,1,R,Tim Huelskamp,42
-Phillips,Glenwood,U.S. House,1,R,Tim Huelskamp,19
-Phillips,Granite,U.S. House,1,R,Tim Huelskamp,15
-Phillips,Greenwood,U.S. House,1,R,Tim Huelskamp,25
-Phillips,Kirwin,U.S. House,1,R,Tim Huelskamp,29
-Phillips,Logan,U.S. House,1,R,Tim Huelskamp,187
-Phillips,Long Island,U.S. House,1,R,Tim Huelskamp,83
-Phillips,Mound,U.S. House,1,R,Tim Huelskamp,50
-Phillips,Phillipsburg,U.S. House,1,R,Tim Huelskamp,110
-Phillips,Plainview,U.S. House,1,R,Tim Huelskamp,7
-Phillips,Plum,U.S. House,1,R,Tim Huelskamp,37
-Phillips,Prairie View,U.S. House,1,R,Tim Huelskamp,74
-Phillips,Rushville,U.S. House,1,R,Tim Huelskamp,7
-Phillips,Solomon,U.S. House,1,R,Tim Huelskamp,45
-Phillips,Sumner,U.S. House,1,R,Tim Huelskamp,15
-Phillips,Towanda,U.S. House,1,R,Tim Huelskamp,9
-Phillips,Valley,U.S. House,1,R,Tim Huelskamp,12
-Phillips,Walnut,U.S. House,1,R,Tim Huelskamp,3
-Phillips,Ward 1,U.S. House,1,R,Tim Huelskamp,348
-Phillips,Ward 2,U.S. House,1,R,Tim Huelskamp,254
-Phillips,Ward 3,U.S. House,1,R,Tim Huelskamp,255
-Phillips,Agra City,U.S. House,1,R,Tim Huelskamp,99
-Phillips,Glade City,U.S. House,1,R,Tim Huelskamp,22
-Phillips,Kirwin City,U.S. House,1,R,Tim Huelskamp,38
-Phillips,Arcade,U.S. House,1,D,James Sherow,11
-Phillips,Beaver,U.S. House,1,D,James Sherow,3
-Phillips,Belmont,U.S. House,1,D,James Sherow,6
-Phillips,Bow Creek,U.S. House,1,D,James Sherow,2
-Phillips,Crystal,U.S. House,1,D,James Sherow,7
-Phillips,Dayton,U.S. House,1,D,James Sherow,8
-Phillips,Deer Creek,U.S. House,1,D,James Sherow,1
-Phillips,Freedom,U.S. House,1,D,James Sherow,6
-Phillips,Glenwood,U.S. House,1,D,James Sherow,0
-Phillips,Granite,U.S. House,1,D,James Sherow,3
-Phillips,Greenwood,U.S. House,1,D,James Sherow,2
-Phillips,Kirwin,U.S. House,1,D,James Sherow,4
-Phillips,Logan,U.S. House,1,D,James Sherow,57
-Phillips,Long Island,U.S. House,1,D,James Sherow,10
-Phillips,Mound,U.S. House,1,D,James Sherow,13
-Phillips,Phillipsburg,U.S. House,1,D,James Sherow,28
-Phillips,Plainview,U.S. House,1,D,James Sherow,2
-Phillips,Plum,U.S. House,1,D,James Sherow,11
-Phillips,Prairie View,U.S. House,1,D,James Sherow,16
-Phillips,Rushville,U.S. House,1,D,James Sherow,1
-Phillips,Solomon,U.S. House,1,D,James Sherow,11
-Phillips,Sumner,U.S. House,1,D,James Sherow,3
-Phillips,Towanda,U.S. House,1,D,James Sherow,3
-Phillips,Valley,U.S. House,1,D,James Sherow,3
-Phillips,Walnut,U.S. House,1,D,James Sherow,1
-Phillips,Ward 1,U.S. House,1,D,James Sherow,81
-Phillips,Ward 2,U.S. House,1,D,James Sherow,60
-Phillips,Ward 3,U.S. House,1,D,James Sherow,81
-Phillips,Agra City,U.S. House,1,D,James Sherow,17
-Phillips,Glade City,U.S. House,1,D,James Sherow,2
-Phillips,Kirwin City,U.S. House,1,D,James Sherow,19
-Phillips,Arcade,Governor,,R,Sam Brownback,29
-Phillips,Beaver,Governor,,R,Sam Brownback,25
-Phillips,Belmont,Governor,,R,Sam Brownback,30
-Phillips,Bow Creek,Governor,,R,Sam Brownback,17
-Phillips,Crystal,Governor,,R,Sam Brownback,22
-Phillips,Dayton,Governor,,R,Sam Brownback,17
-Phillips,Deer Creek,Governor,,R,Sam Brownback,34
-Phillips,Freedom,Governor,,R,Sam Brownback,39
-Phillips,Glenwood,Governor,,R,Sam Brownback,18
-Phillips,Granite,Governor,,R,Sam Brownback,14
-Phillips,Greenwood,Governor,,R,Sam Brownback,24
-Phillips,Kirwin,Governor,,R,Sam Brownback,28
-Phillips,Logan,Governor,,R,Sam Brownback,162
-Phillips,Long Island,Governor,,R,Sam Brownback,69
-Phillips,Mound,Governor,,R,Sam Brownback,44
-Phillips,Phillipsburg,Governor,,R,Sam Brownback,107
-Phillips,Plainview,Governor,,R,Sam Brownback,4
-Phillips,Plum,Governor,,R,Sam Brownback,37
-Phillips,Prairie View,Governor,,R,Sam Brownback,68
-Phillips,Rushville,Governor,,R,Sam Brownback,9
-Phillips,Solomon,Governor,,R,Sam Brownback,46
-Phillips,Sumner,Governor,,R,Sam Brownback,16
-Phillips,Towanda,Governor,,R,Sam Brownback,10
-Phillips,Valley,Governor,,R,Sam Brownback,10
-Phillips,Walnut,Governor,,R,Sam Brownback,3
-Phillips,Ward 1,Governor,,R,Sam Brownback,280
-Phillips,Ward 2,Governor,,R,Sam Brownback,217
-Phillips,Ward 3,Governor,,R,Sam Brownback,197
-Phillips,Agra City,Governor,,R,Sam Brownback,83
-Phillips,Glade City,Governor,,R,Sam Brownback,21
-Phillips,Kirwin City,Governor,,R,Sam Brownback,38
-Phillips,Arcade,Governor,,L,Keen Umbehr,6
-Phillips,Beaver,Governor,,L,Keen Umbehr,1
-Phillips,Belmont,Governor,,L,Keen Umbehr,2
-Phillips,Bow Creek,Governor,,L,Keen Umbehr,1
-Phillips,Crystal,Governor,,L,Keen Umbehr,0
-Phillips,Dayton,Governor,,L,Keen Umbehr,0
-Phillips,Deer Creek,Governor,,L,Keen Umbehr,1
-Phillips,Freedom,Governor,,L,Keen Umbehr,3
-Phillips,Glenwood,Governor,,L,Keen Umbehr,0
-Phillips,Granite,Governor,,L,Keen Umbehr,0
-Phillips,Greenwood,Governor,,L,Keen Umbehr,1
-Phillips,Kirwin,Governor,,L,Keen Umbehr,2
-Phillips,Logan,Governor,,L,Keen Umbehr,9
-Phillips,Long Island,Governor,,L,Keen Umbehr,5
-Phillips,Mound,Governor,,L,Keen Umbehr,9
-Phillips,Phillipsburg,Governor,,L,Keen Umbehr,5
-Phillips,Plainview,Governor,,L,Keen Umbehr,0
-Phillips,Plum,Governor,,L,Keen Umbehr,5
-Phillips,Prairie View,Governor,,L,Keen Umbehr,5
-Phillips,Rushville,Governor,,L,Keen Umbehr,0
-Phillips,Solomon,Governor,,L,Keen Umbehr,0
-Phillips,Sumner,Governor,,L,Keen Umbehr,1
-Phillips,Towanda,Governor,,L,Keen Umbehr,0
-Phillips,Valley,Governor,,L,Keen Umbehr,2
-Phillips,Walnut,Governor,,L,Keen Umbehr,1
-Phillips,Ward 1,Governor,,L,Keen Umbehr,19
-Phillips,Ward 2,Governor,,L,Keen Umbehr,25
-Phillips,Ward 3,Governor,,L,Keen Umbehr,21
-Phillips,Agra City,Governor,,L,Keen Umbehr,6
-Phillips,Glade City,Governor,,L,Keen Umbehr,1
-Phillips,Kirwin City,Governor,,L,Keen Umbehr,5
-Phillips,Arcade,Governor,,D,Paul Davis,15
-Phillips,Beaver,Governor,,D,Paul Davis,0
-Phillips,Belmont,Governor,,D,Paul Davis,6
-Phillips,Bow Creek,Governor,,D,Paul Davis,1
-Phillips,Crystal,Governor,,D,Paul Davis,5
-Phillips,Dayton,Governor,,D,Paul Davis,3
-Phillips,Deer Creek,Governor,,D,Paul Davis,2
-Phillips,Freedom,Governor,,D,Paul Davis,7
-Phillips,Glenwood,Governor,,D,Paul Davis,1
-Phillips,Granite,Governor,,D,Paul Davis,4
-Phillips,Greenwood,Governor,,D,Paul Davis,2
-Phillips,Kirwin,Governor,,D,Paul Davis,6
-Phillips,Logan,Governor,,D,Paul Davis,80
-Phillips,Long Island,Governor,,D,Paul Davis,19
-Phillips,Mound,Governor,,D,Paul Davis,12
-Phillips,Phillipsburg,Governor,,D,Paul Davis,30
-Phillips,Plainview,Governor,,D,Paul Davis,4
-Phillips,Plum,Governor,,D,Paul Davis,8
-Phillips,Prairie View,Governor,,D,Paul Davis,20
-Phillips,Rushville,Governor,,D,Paul Davis,0
-Phillips,Solomon,Governor,,D,Paul Davis,10
-Phillips,Sumner,Governor,,D,Paul Davis,1
-Phillips,Towanda,Governor,,D,Paul Davis,2
-Phillips,Valley,Governor,,D,Paul Davis,3
-Phillips,Walnut,Governor,,D,Paul Davis,0
-Phillips,Ward 1,Governor,,D,Paul Davis,133
-Phillips,Ward 2,Governor,,D,Paul Davis,76
-Phillips,Ward 3,Governor,,D,Paul Davis,122
-Phillips,Agra City,Governor,,D,Paul Davis,25
-Phillips,Glade City,Governor,,D,Paul Davis,3
-Phillips,Kirwin City,Governor,,D,Paul Davis,17
-Phillips,Arcade,Secretary of State,,R,Kris Kobach,40
-Phillips,Beaver,Secretary of State,,R,Kris Kobach,25
-Phillips,Belmont,Secretary of State,,R,Kris Kobach,33
-Phillips,Bow Creek,Secretary of State,,R,Kris Kobach,17
-Phillips,Crystal,Secretary of State,,R,Kris Kobach,26
-Phillips,Dayton,Secretary of State,,R,Kris Kobach,18
-Phillips,Deer Creek,Secretary of State,,R,Kris Kobach,33
-Phillips,Freedom,Secretary of State,,R,Kris Kobach,41
-Phillips,Glenwood,Secretary of State,,R,Kris Kobach,17
-Phillips,Granite,Secretary of State,,R,Kris Kobach,15
-Phillips,Greenwood,Secretary of State,,R,Kris Kobach,25
-Phillips,Kirwin,Secretary of State,,R,Kris Kobach,31
-Phillips,Logan,Secretary of State,,R,Kris Kobach,177
-Phillips,Long Island,Secretary of State,,R,Kris Kobach,79
-Phillips,Mound,Secretary of State,,R,Kris Kobach,51
-Phillips,Phillipsburg,Secretary of State,,R,Kris Kobach,124
-Phillips,Plainview,Secretary of State,,R,Kris Kobach,6
-Phillips,Plum,Secretary of State,,R,Kris Kobach,45
-Phillips,Prairie View,Secretary of State,,R,Kris Kobach,77
-Phillips,Rushville,Secretary of State,,R,Kris Kobach,7
-Phillips,Solomon,Secretary of State,,R,Kris Kobach,49
-Phillips,Sumner,Secretary of State,,R,Kris Kobach,14
-Phillips,Towanda,Secretary of State,,R,Kris Kobach,10
-Phillips,Valley,Secretary of State,,R,Kris Kobach,9
-Phillips,Walnut,Secretary of State,,R,Kris Kobach,3
-Phillips,Ward 1,Secretary of State,,R,Kris Kobach,355
-Phillips,Ward 2,Secretary of State,,R,Kris Kobach,252
-Phillips,Ward 3,Secretary of State,,R,Kris Kobach,258
-Phillips,Agra City,Secretary of State,,R,Kris Kobach,96
-Phillips,Glade City,Secretary of State,,R,Kris Kobach,21
-Phillips,Kirwin City,Secretary of State,,R,Kris Kobach,40
-Phillips,Arcade,Secretary of State,,D,AJ Kotich,9
-Phillips,Beaver,Secretary of State,,D,AJ Kotich,0
-Phillips,Belmont,Secretary of State,,D,AJ Kotich,3
-Phillips,Bow Creek,Secretary of State,,D,AJ Kotich,1
-Phillips,Crystal,Secretary of State,,D,AJ Kotich,1
-Phillips,Dayton,Secretary of State,,D,AJ Kotich,2
-Phillips,Deer Creek,Secretary of State,,D,AJ Kotich,3
-Phillips,Freedom,Secretary of State,,D,AJ Kotich,8
-Phillips,Glenwood,Secretary of State,,D,AJ Kotich,1
-Phillips,Granite,Secretary of State,,D,AJ Kotich,1
-Phillips,Greenwood,Secretary of State,,D,AJ Kotich,0
-Phillips,Kirwin,Secretary of State,,D,AJ Kotich,3
-Phillips,Logan,Secretary of State,,D,AJ Kotich,69
-Phillips,Long Island,Secretary of State,,D,AJ Kotich,10
-Phillips,Mound,Secretary of State,,D,AJ Kotich,12
-Phillips,Phillipsburg,Secretary of State,,D,AJ Kotich,16
-Phillips,Plainview,Secretary of State,,D,AJ Kotich,3
-Phillips,Plum,Secretary of State,,D,AJ Kotich,4
-Phillips,Prairie View,Secretary of State,,D,AJ Kotich,14
-Phillips,Rushville,Secretary of State,,D,AJ Kotich,1
-Phillips,Solomon,Secretary of State,,D,AJ Kotich,8
-Phillips,Sumner,Secretary of State,,D,AJ Kotich,2
-Phillips,Towanda,Secretary of State,,D,AJ Kotich,1
-Phillips,Valley,Secretary of State,,D,AJ Kotich,4
-Phillips,Walnut,Secretary of State,,D,AJ Kotich,0
-Phillips,Ward 1,Secretary of State,,D,AJ Kotich,80
-Phillips,Ward 2,Secretary of State,,D,AJ Kotich,56
-Phillips,Ward 3,Secretary of State,,D,AJ Kotich,71
-Phillips,Agra City,Secretary of State,,D,AJ Kotich,21
-Phillips,Glade City,Secretary of State,,D,AJ Kotich,4
-Phillips,Kirwin City,Secretary of State,,D,AJ Kotich,17
-Phillips,Arcade,Attorney General,,R,Derek Schmidt,40
-Phillips,Beaver,Attorney General,,R,Derek Schmidt,23
-Phillips,Belmont,Attorney General,,R,Derek Schmidt,34
-Phillips,Bow Creek,Attorney General,,R,Derek Schmidt,16
-Phillips,Crystal,Attorney General,,R,Derek Schmidt,25
-Phillips,Dayton,Attorney General,,R,Derek Schmidt,18
-Phillips,Deer Creek,Attorney General,,R,Derek Schmidt,34
-Phillips,Freedom,Attorney General,,R,Derek Schmidt,45
-Phillips,Glenwood,Attorney General,,R,Derek Schmidt,17
-Phillips,Granite,Attorney General,,R,Derek Schmidt,15
-Phillips,Greenwood,Attorney General,,R,Derek Schmidt,25
-Phillips,Kirwin,Attorney General,,R,Derek Schmidt,31
-Phillips,Logan,Attorney General,,R,Derek Schmidt,209
-Phillips,Long Island,Attorney General,,R,Derek Schmidt,82
-Phillips,Mound,Attorney General,,R,Derek Schmidt,56
-Phillips,Phillipsburg,Attorney General,,R,Derek Schmidt,123
-Phillips,Plainview,Attorney General,,R,Derek Schmidt,8
-Phillips,Plum,Attorney General,,R,Derek Schmidt,45
-Phillips,Prairie View,Attorney General,,R,Derek Schmidt,85
-Phillips,Rushville,Attorney General,,R,Derek Schmidt,8
-Phillips,Solomon,Attorney General,,R,Derek Schmidt,51
-Phillips,Sumner,Attorney General,,R,Derek Schmidt,15
-Phillips,Towanda,Attorney General,,R,Derek Schmidt,8
-Phillips,Valley,Attorney General,,R,Derek Schmidt,12
-Phillips,Walnut,Attorney General,,R,Derek Schmidt,3
-Phillips,Ward 1,Attorney General,,R,Derek Schmidt,377
-Phillips,Ward 2,Attorney General,,R,Derek Schmidt,262
-Phillips,Ward 3,Attorney General,,R,Derek Schmidt,280
-Phillips,Agra City,Attorney General,,R,Derek Schmidt,104
-Phillips,Glade City,Attorney General,,R,Derek Schmidt,21
-Phillips,Kirwin City,Attorney General,,R,Derek Schmidt,40
-Phillips,Arcade,Attorney General,,D,AJ Kotich,9
-Phillips,Beaver,Attorney General,,D,AJ Kotich,0
-Phillips,Belmont,Attorney General,,D,AJ Kotich,3
-Phillips,Bow Creek,Attorney General,,D,AJ Kotich,2
-Phillips,Crystal,Attorney General,,D,AJ Kotich,2
-Phillips,Dayton,Attorney General,,D,AJ Kotich,2
-Phillips,Deer Creek,Attorney General,,D,AJ Kotich,2
-Phillips,Freedom,Attorney General,,D,AJ Kotich,4
-Phillips,Glenwood,Attorney General,,D,AJ Kotich,1
-Phillips,Granite,Attorney General,,D,AJ Kotich,0
-Phillips,Greenwood,Attorney General,,D,AJ Kotich,0
-Phillips,Kirwin,Attorney General,,D,AJ Kotich,2
-Phillips,Logan,Attorney General,,D,AJ Kotich,36
-Phillips,Long Island,Attorney General,,D,AJ Kotich,7
-Phillips,Mound,Attorney General,,D,AJ Kotich,6
-Phillips,Phillipsburg,Attorney General,,D,AJ Kotich,15
-Phillips,Plainview,Attorney General,,D,AJ Kotich,1
-Phillips,Plum,Attorney General,,D,AJ Kotich,3
-Phillips,Prairie View,Attorney General,,D,AJ Kotich,6
-Phillips,Rushville,Attorney General,,D,AJ Kotich,0
-Phillips,Solomon,Attorney General,,D,AJ Kotich,7
-Phillips,Sumner,Attorney General,,D,AJ Kotich,1
-Phillips,Towanda,Attorney General,,D,AJ Kotich,3
-Phillips,Valley,Attorney General,,D,AJ Kotich,1
-Phillips,Walnut,Attorney General,,D,AJ Kotich,0
-Phillips,Ward 1,Attorney General,,D,AJ Kotich,49
-Phillips,Ward 2,Attorney General,,D,AJ Kotich,45
-Phillips,Ward 3,Attorney General,,D,AJ Kotich,43
-Phillips,Agra City,Attorney General,,D,AJ Kotich,13
-Phillips,Glade City,Attorney General,,D,AJ Kotich,4
-Phillips,Kirwin City,Attorney General,,D,AJ Kotich,16
-Phillips,Arcade,State Treasurer,,R,Ron Estes,40
-Phillips,Beaver,State Treasurer,,R,Ron Estes,23
-Phillips,Belmont,State Treasurer,,R,Ron Estes,31
-Phillips,Bow Creek,State Treasurer,,R,Ron Estes,16
-Phillips,Crystal,State Treasurer,,R,Ron Estes,24
-Phillips,Dayton,State Treasurer,,R,Ron Estes,17
-Phillips,Deer Creek,State Treasurer,,R,Ron Estes,32
-Phillips,Freedom,State Treasurer,,R,Ron Estes,45
-Phillips,Glenwood,State Treasurer,,R,Ron Estes,17
-Phillips,Granite,State Treasurer,,R,Ron Estes,15
-Phillips,Greenwood,State Treasurer,,R,Ron Estes,25
-Phillips,Kirwin,State Treasurer,,R,Ron Estes,32
-Phillips,Logan,State Treasurer,,R,Ron Estes,203
-Phillips,Long Island,State Treasurer,,R,Ron Estes,84
-Phillips,Mound,State Treasurer,,R,Ron Estes,52
-Phillips,Phillipsburg,State Treasurer,,R,Ron Estes,122
-Phillips,Plainview,State Treasurer,,R,Ron Estes,8
-Phillips,Plum,State Treasurer,,R,Ron Estes,45
-Phillips,Prairie View,State Treasurer,,R,Ron Estes,81
-Phillips,Rushville,State Treasurer,,R,Ron Estes,7
-Phillips,Solomon,State Treasurer,,R,Ron Estes,50
-Phillips,Sumner,State Treasurer,,R,Ron Estes,14
-Phillips,Towanda,State Treasurer,,R,Ron Estes,11
-Phillips,Valley,State Treasurer,,R,Ron Estes,10
-Phillips,Walnut,State Treasurer,,R,Ron Estes,3
-Phillips,Ward 1,State Treasurer,,R,Ron Estes,369
-Phillips,Ward 2,State Treasurer,,R,Ron Estes,262
-Phillips,Ward 3,State Treasurer,,R,Ron Estes,277
-Phillips,Agra City,State Treasurer,,R,Ron Estes,102
-Phillips,Glade City,State Treasurer,,R,Ron Estes,22
-Phillips,Kirwin City,State Treasurer,,R,Ron Estes,45
-Phillips,Arcade,State Treasurer,,D,Carmen Alldritt,7
-Phillips,Beaver,State Treasurer,,D,Carmen Alldritt,1
-Phillips,Belmont,State Treasurer,,D,Carmen Alldritt,3
-Phillips,Bow Creek,State Treasurer,,D,Carmen Alldritt,2
-Phillips,Crystal,State Treasurer,,D,Carmen Alldritt,2
-Phillips,Dayton,State Treasurer,,D,Carmen Alldritt,2
-Phillips,Deer Creek,State Treasurer,,D,Carmen Alldritt,4
-Phillips,Freedom,State Treasurer,,D,Carmen Alldritt,3
-Phillips,Glenwood,State Treasurer,,D,Carmen Alldritt,1
-Phillips,Granite,State Treasurer,,D,Carmen Alldritt,1
-Phillips,Greenwood,State Treasurer,,D,Carmen Alldritt,0
-Phillips,Kirwin,State Treasurer,,D,Carmen Alldritt,2
-Phillips,Logan,State Treasurer,,D,Carmen Alldritt,41
-Phillips,Long Island,State Treasurer,,D,Carmen Alldritt,7
-Phillips,Mound,State Treasurer,,D,Carmen Alldritt,9
-Phillips,Phillipsburg,State Treasurer,,D,Carmen Alldritt,13
-Phillips,Plainview,State Treasurer,,D,Carmen Alldritt,1
-Phillips,Plum,State Treasurer,,D,Carmen Alldritt,3
-Phillips,Prairie View,State Treasurer,,D,Carmen Alldritt,9
-Phillips,Rushville,State Treasurer,,D,Carmen Alldritt,1
-Phillips,Solomon,State Treasurer,,D,Carmen Alldritt,7
-Phillips,Sumner,State Treasurer,,D,Carmen Alldritt,2
-Phillips,Towanda,State Treasurer,,D,Carmen Alldritt,0
-Phillips,Valley,State Treasurer,,D,Carmen Alldritt,3
-Phillips,Walnut,State Treasurer,,D,Carmen Alldritt,0
-Phillips,Ward 1,State Treasurer,,D,Carmen Alldritt,55
-Phillips,Ward 2,State Treasurer,,D,Carmen Alldritt,48
-Phillips,Ward 3,State Treasurer,,D,Carmen Alldritt,42
-Phillips,Agra City,State Treasurer,,D,Carmen Alldritt,13
-Phillips,Glade City,State Treasurer,,D,Carmen Alldritt,3
-Phillips,Kirwin City,State Treasurer,,D,Carmen Alldritt,11
-Phillips,Arcade,Insurance Commissioner,,R,Ken Setzer,41
-Phillips,Beaver,Insurance Commissioner,,R,Ken Setzer,22
-Phillips,Belmont,Insurance Commissioner,,R,Ken Setzer,29
-Phillips,Bow Creek,Insurance Commissioner,,R,Ken Setzer,16
-Phillips,Crystal,Insurance Commissioner,,R,Ken Setzer,22
-Phillips,Dayton,Insurance Commissioner,,R,Ken Setzer,17
-Phillips,Deer Creek,Insurance Commissioner,,R,Ken Setzer,33
-Phillips,Freedom,Insurance Commissioner,,R,Ken Setzer,44
-Phillips,Glenwood,Insurance Commissioner,,R,Ken Setzer,17
-Phillips,Granite,Insurance Commissioner,,R,Ken Setzer,14
-Phillips,Greenwood,Insurance Commissioner,,R,Ken Setzer,24
-Phillips,Kirwin,Insurance Commissioner,,R,Ken Setzer,31
-Phillips,Logan,Insurance Commissioner,,R,Ken Setzer,194
-Phillips,Long Island,Insurance Commissioner,,R,Ken Setzer,81
-Phillips,Mound,Insurance Commissioner,,R,Ken Setzer,58
-Phillips,Phillipsburg,Insurance Commissioner,,R,Ken Setzer,118
-Phillips,Plainview,Insurance Commissioner,,R,Ken Setzer,7
-Phillips,Plum,Insurance Commissioner,,R,Ken Setzer,44
-Phillips,Prairie View,Insurance Commissioner,,R,Ken Setzer,77
-Phillips,Rushville,Insurance Commissioner,,R,Ken Setzer,8
-Phillips,Solomon,Insurance Commissioner,,R,Ken Setzer,51
-Phillips,Sumner,Insurance Commissioner,,R,Ken Setzer,14
-Phillips,Towanda,Insurance Commissioner,,R,Ken Setzer,10
-Phillips,Valley,Insurance Commissioner,,R,Ken Setzer,11
-Phillips,Walnut,Insurance Commissioner,,R,Ken Setzer,3
-Phillips,Ward 1,Insurance Commissioner,,R,Ken Setzer,354
-Phillips,Ward 2,Insurance Commissioner,,R,Ken Setzer,252
-Phillips,Ward 3,Insurance Commissioner,,R,Ken Setzer,268
-Phillips,Agra City,Insurance Commissioner,,R,Ken Setzer,93
-Phillips,Glade City,Insurance Commissioner,,R,Ken Setzer,21
-Phillips,Kirwin City,Insurance Commissioner,,R,Ken Setzer,41
-Phillips,Arcade,Insurance Commissioner,,D,Dennis Anderson,8
-Phillips,Beaver,Insurance Commissioner,,D,Dennis Anderson,1
-Phillips,Belmont,Insurance Commissioner,,D,Dennis Anderson,5
-Phillips,Bow Creek,Insurance Commissioner,,D,Dennis Anderson,2
-Phillips,Crystal,Insurance Commissioner,,D,Dennis Anderson,3
-Phillips,Dayton,Insurance Commissioner,,D,Dennis Anderson,2
-Phillips,Deer Creek,Insurance Commissioner,,D,Dennis Anderson,3
-Phillips,Freedom,Insurance Commissioner,,D,Dennis Anderson,4
-Phillips,Glenwood,Insurance Commissioner,,D,Dennis Anderson,1
-Phillips,Granite,Insurance Commissioner,,D,Dennis Anderson,1
-Phillips,Greenwood,Insurance Commissioner,,D,Dennis Anderson,1
-Phillips,Kirwin,Insurance Commissioner,,D,Dennis Anderson,2
-Phillips,Logan,Insurance Commissioner,,D,Dennis Anderson,47
-Phillips,Long Island,Insurance Commissioner,,D,Dennis Anderson,7
-Phillips,Mound,Insurance Commissioner,,D,Dennis Anderson,4
-Phillips,Phillipsburg,Insurance Commissioner,,D,Dennis Anderson,18
-Phillips,Plainview,Insurance Commissioner,,D,Dennis Anderson,2
-Phillips,Plum,Insurance Commissioner,,D,Dennis Anderson,5
-Phillips,Prairie View,Insurance Commissioner,,D,Dennis Anderson,8
-Phillips,Rushville,Insurance Commissioner,,D,Dennis Anderson,0
-Phillips,Solomon,Insurance Commissioner,,D,Dennis Anderson,5
-Phillips,Sumner,Insurance Commissioner,,D,Dennis Anderson,2
-Phillips,Towanda,Insurance Commissioner,,D,Dennis Anderson,1
-Phillips,Valley,Insurance Commissioner,,D,Dennis Anderson,2
-Phillips,Walnut,Insurance Commissioner,,D,Dennis Anderson,0
-Phillips,Ward 1,Insurance Commissioner,,D,Dennis Anderson,62
-Phillips,Ward 2,Insurance Commissioner,,D,Dennis Anderson,57
-Phillips,Ward 3,Insurance Commissioner,,D,Dennis Anderson,53
-Phillips,Agra City,Insurance Commissioner,,D,Dennis Anderson,19
-Phillips,Glade City,Insurance Commissioner,,D,Dennis Anderson,3
-Phillips,Kirwin City,Insurance Commissioner,,D,Dennis Anderson,15
-Phillips,Arcade,State House,110,R,Travis Couture-Lovelady,46
-Phillips,Beaver,State House,110,R,Travis Couture-Lovelady,23
-Phillips,Belmont,State House,110,R,Travis Couture-Lovelady,35
-Phillips,Bow Creek,State House,110,R,Travis Couture-Lovelady,19
-Phillips,Crystal,State House,110,R,Travis Couture-Lovelady,24
-Phillips,Dayton,State House,110,R,Travis Couture-Lovelady,18
-Phillips,Deer Creek,State House,110,R,Travis Couture-Lovelady,34
-Phillips,Freedom,State House,110,R,Travis Couture-Lovelady,45
-Phillips,Glenwood,State House,110,R,Travis Couture-Lovelady,17
-Phillips,Granite,State House,110,R,Travis Couture-Lovelady,16
-Phillips,Greenwood,State House,110,R,Travis Couture-Lovelady,24
-Phillips,Kirwin,State House,110,R,Travis Couture-Lovelady,35
-Phillips,Logan,State House,110,R,Travis Couture-Lovelady,216
-Phillips,Long Island,State House,110,R,Travis Couture-Lovelady,87
-Phillips,Mound,State House,110,R,Travis Couture-Lovelady,62
-Phillips,Phillipsburg,State House,110,R,Travis Couture-Lovelady,130
-Phillips,Plainview,State House,110,R,Travis Couture-Lovelady,9
-Phillips,Plum,State House,110,R,Travis Couture-Lovelady,46
-Phillips,Prairie View,State House,110,R,Travis Couture-Lovelady,85
-Phillips,Rushville,State House,110,R,Travis Couture-Lovelady,8
-Phillips,Solomon,State House,110,R,Travis Couture-Lovelady,52
-Phillips,Sumner,State House,110,R,Travis Couture-Lovelady,16
-Phillips,Towanda,State House,110,R,Travis Couture-Lovelady,11
-Phillips,Valley,State House,110,R,Travis Couture-Lovelady,13
-Phillips,Walnut,State House,110,R,Travis Couture-Lovelady,3
-Phillips,Ward 1,State House,110,R,Travis Couture-Lovelady,389
-Phillips,Ward 2,State House,110,R,Travis Couture-Lovelady,287
-Phillips,Ward 3,State House,110,R,Travis Couture-Lovelady,311
-Phillips,Agra City,State House,110,R,Travis Couture-Lovelady,101
-Phillips,Glade City,State House,110,R,Travis Couture-Lovelady,22
-Phillips,Kirwin City,State House,110,R,Travis Couture-Lovelady,47
+county,precinct,office,district,party,candidate,votes,vtd
+PHILLIPS,Arcade Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000010
+PHILLIPS,Arcade Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000010
+PHILLIPS,Arcade Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000010
+PHILLIPS,Beaver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000020
+PHILLIPS,Beaver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000020
+PHILLIPS,Beaver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000020
+PHILLIPS,Belmont Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000030
+PHILLIPS,Belmont Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000030
+PHILLIPS,Belmont Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000030
+PHILLIPS,Bow Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000040
+PHILLIPS,Bow Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+PHILLIPS,Bow Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000040
+PHILLIPS,Crystal Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000050
+PHILLIPS,Crystal Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+PHILLIPS,Crystal Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000050
+PHILLIPS,Dayton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000060
+PHILLIPS,Dayton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+PHILLIPS,Dayton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000060
+PHILLIPS,Deer Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000070
+PHILLIPS,Deer Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+PHILLIPS,Deer Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000070
+PHILLIPS,Freedom Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000080
+PHILLIPS,Freedom Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000080
+PHILLIPS,Freedom Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000080
+PHILLIPS,Glenwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000090
+PHILLIPS,Glenwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+PHILLIPS,Glenwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000090
+PHILLIPS,Granite Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000100
+PHILLIPS,Granite Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+PHILLIPS,Granite Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000100
+PHILLIPS,Greenwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000110
+PHILLIPS,Greenwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000110
+PHILLIPS,Greenwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000110
+PHILLIPS,Kirwin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000120
+PHILLIPS,Kirwin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000120
+PHILLIPS,Kirwin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000120
+PHILLIPS,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000130
+PHILLIPS,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000130
+PHILLIPS,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",164,000130
+PHILLIPS,Long Island Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000140
+PHILLIPS,Long Island Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000140
+PHILLIPS,Long Island Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000140
+PHILLIPS,Mound Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000150
+PHILLIPS,Mound Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000150
+PHILLIPS,Mound Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,000150
+PHILLIPS,Phillipsburg City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",136,000160
+PHILLIPS,Phillipsburg City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000160
+PHILLIPS,Phillipsburg City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",288,000160
+PHILLIPS,Phillipsburg City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000170
+PHILLIPS,Phillipsburg City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000170
+PHILLIPS,Phillipsburg City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",225,000170
+PHILLIPS,Phillipsburg City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,00018A
+PHILLIPS,Phillipsburg City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,00018A
+PHILLIPS,Phillipsburg City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",201,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00018B
+PHILLIPS,Phillipsburg Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000190
+PHILLIPS,Phillipsburg Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000190
+PHILLIPS,Phillipsburg Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",110,000190
+PHILLIPS,Plainview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000200
+PHILLIPS,Plainview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000200
+PHILLIPS,Plainview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,000200
+PHILLIPS,Plum Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000210
+PHILLIPS,Plum Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000210
+PHILLIPS,Plum Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",121,000210
+PHILLIPS,Prairie View Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000220
+PHILLIPS,Prairie View Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000220
+PHILLIPS,Prairie View Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000220
+PHILLIPS,Rushville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000230
+PHILLIPS,Rushville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+PHILLIPS,Rushville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000230
+PHILLIPS,Solomon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000240
+PHILLIPS,Solomon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000240
+PHILLIPS,Solomon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",67,000240
+PHILLIPS,Sumner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000250
+PHILLIPS,Sumner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000250
+PHILLIPS,Sumner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000250
+PHILLIPS,Towanda Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000260
+PHILLIPS,Towanda Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000260
+PHILLIPS,Towanda Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000260
+PHILLIPS,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000270
+PHILLIPS,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000270
+PHILLIPS,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000270
+PHILLIPS,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000280
+PHILLIPS,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000280
+PHILLIPS,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,000280
+PHILLIPS,Arcade Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",46,000010
+PHILLIPS,Beaver Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",23,000020
+PHILLIPS,Belmont Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",36,000030
+PHILLIPS,Bow Creek Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",19,000040
+PHILLIPS,Crystal Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",25,000050
+PHILLIPS,Dayton Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",18,000060
+PHILLIPS,Deer Creek Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",34,000070
+PHILLIPS,Freedom Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",46,000080
+PHILLIPS,Glenwood Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",17,000090
+PHILLIPS,Granite Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",16,000100
+PHILLIPS,Greenwood Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",25,000110
+PHILLIPS,Kirwin Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",86,000120
+PHILLIPS,Logan Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",219,000130
+PHILLIPS,Long Island Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",90,000140
+PHILLIPS,Mound Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",63,000150
+PHILLIPS,Phillipsburg City Ward 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",397,000160
+PHILLIPS,Phillipsburg City Ward 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",299,000170
+PHILLIPS,Phillipsburg City Ward 3,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",316,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",0,00018B
+PHILLIPS,Phillipsburg Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",133,000190
+PHILLIPS,Plainview Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",10,000200
+PHILLIPS,Plum Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",149,000210
+PHILLIPS,Prairie View Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",85,000220
+PHILLIPS,Rushville Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",8,000230
+PHILLIPS,Solomon Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",75,000240
+PHILLIPS,Sumner Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",16,000250
+PHILLIPS,Towanda Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",11,000260
+PHILLIPS,Valley Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",13,000270
+PHILLIPS,Walnut Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",3,000280
+PHILLIPS,Arcade Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000010
+PHILLIPS,Arcade Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000010
+PHILLIPS,Beaver Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000020
+PHILLIPS,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000020
+PHILLIPS,Belmont Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000030
+PHILLIPS,Belmont Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000030
+PHILLIPS,Bow Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000040
+PHILLIPS,Bow Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000040
+PHILLIPS,Crystal Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000050
+PHILLIPS,Crystal Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000050
+PHILLIPS,Dayton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000060
+PHILLIPS,Dayton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000060
+PHILLIPS,Deer Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000070
+PHILLIPS,Deer Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000070
+PHILLIPS,Freedom Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000080
+PHILLIPS,Freedom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000080
+PHILLIPS,Glenwood Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000090
+PHILLIPS,Glenwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000090
+PHILLIPS,Granite Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000100
+PHILLIPS,Granite Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000100
+PHILLIPS,Greenwood Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000110
+PHILLIPS,Greenwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000110
+PHILLIPS,Kirwin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000120
+PHILLIPS,Kirwin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,000120
+PHILLIPS,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",57,000130
+PHILLIPS,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",190,000130
+PHILLIPS,Long Island Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000140
+PHILLIPS,Long Island Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,000140
+PHILLIPS,Mound Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000150
+PHILLIPS,Mound Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000150
+PHILLIPS,Phillipsburg City Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",84,000160
+PHILLIPS,Phillipsburg City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",356,000160
+PHILLIPS,Phillipsburg City Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",64,000170
+PHILLIPS,Phillipsburg City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",263,000170
+PHILLIPS,Phillipsburg City Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",82,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",260,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00018B
+PHILLIPS,Phillipsburg Township,United States House of Representatives,1,Democratic,"Sherow, James E.",28,000190
+PHILLIPS,Phillipsburg Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",113,000190
+PHILLIPS,Plainview Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000200
+PHILLIPS,Plainview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000200
+PHILLIPS,Plum Township,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000210
+PHILLIPS,Plum Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",137,000210
+PHILLIPS,Prairie View Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000220
+PHILLIPS,Prairie View Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,000220
+PHILLIPS,Rushville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000230
+PHILLIPS,Rushville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000230
+PHILLIPS,Solomon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000240
+PHILLIPS,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",68,000240
+PHILLIPS,Sumner Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000250
+PHILLIPS,Sumner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000250
+PHILLIPS,Towanda Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000260
+PHILLIPS,Towanda Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000260
+PHILLIPS,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000270
+PHILLIPS,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000270
+PHILLIPS,Walnut Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000280
+PHILLIPS,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000280
+PHILLIPS,Arcade Township,Attorney General,,Democratic,"Kotich, A.J.",9,000010
+PHILLIPS,Arcade Township,Attorney General,,Republican,"Schmidt, Derek",40,000010
+PHILLIPS,Beaver Township,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+PHILLIPS,Beaver Township,Attorney General,,Republican,"Schmidt, Derek",23,000020
+PHILLIPS,Belmont Township,Attorney General,,Democratic,"Kotich, A.J.",3,000030
+PHILLIPS,Belmont Township,Attorney General,,Republican,"Schmidt, Derek",35,000030
+PHILLIPS,Bow Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000040
+PHILLIPS,Bow Creek Township,Attorney General,,Republican,"Schmidt, Derek",16,000040
+PHILLIPS,Crystal Township,Attorney General,,Democratic,"Kotich, A.J.",2,000050
+PHILLIPS,Crystal Township,Attorney General,,Republican,"Schmidt, Derek",26,000050
+PHILLIPS,Dayton Township,Attorney General,,Democratic,"Kotich, A.J.",2,000060
+PHILLIPS,Dayton Township,Attorney General,,Republican,"Schmidt, Derek",18,000060
+PHILLIPS,Deer Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000070
+PHILLIPS,Deer Creek Township,Attorney General,,Republican,"Schmidt, Derek",34,000070
+PHILLIPS,Freedom Township,Attorney General,,Democratic,"Kotich, A.J.",5,000080
+PHILLIPS,Freedom Township,Attorney General,,Republican,"Schmidt, Derek",46,000080
+PHILLIPS,Glenwood Township,Attorney General,,Democratic,"Kotich, A.J.",1,000090
+PHILLIPS,Glenwood Township,Attorney General,,Republican,"Schmidt, Derek",17,000090
+PHILLIPS,Granite Township,Attorney General,,Democratic,"Kotich, A.J.",0,000100
+PHILLIPS,Granite Township,Attorney General,,Republican,"Schmidt, Derek",15,000100
+PHILLIPS,Greenwood Township,Attorney General,,Democratic,"Kotich, A.J.",0,000110
+PHILLIPS,Greenwood Township,Attorney General,,Republican,"Schmidt, Derek",26,000110
+PHILLIPS,Kirwin Township,Attorney General,,Democratic,"Kotich, A.J.",19,000120
+PHILLIPS,Kirwin Township,Attorney General,,Republican,"Schmidt, Derek",74,000120
+PHILLIPS,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",36,000130
+PHILLIPS,Logan Township,Attorney General,,Republican,"Schmidt, Derek",212,000130
+PHILLIPS,Long Island Township,Attorney General,,Democratic,"Kotich, A.J.",8,000140
+PHILLIPS,Long Island Township,Attorney General,,Republican,"Schmidt, Derek",84,000140
+PHILLIPS,Mound Township,Attorney General,,Democratic,"Kotich, A.J.",6,000150
+PHILLIPS,Mound Township,Attorney General,,Republican,"Schmidt, Derek",57,000150
+PHILLIPS,Phillipsburg City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",53,000160
+PHILLIPS,Phillipsburg City Ward 1,Attorney General,,Republican,"Schmidt, Derek",384,000160
+PHILLIPS,Phillipsburg City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",48,000170
+PHILLIPS,Phillipsburg City Ward 2,Attorney General,,Republican,"Schmidt, Derek",272,000170
+PHILLIPS,Phillipsburg City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",44,00018A
+PHILLIPS,Phillipsburg City Ward 3,Attorney General,,Republican,"Schmidt, Derek",285,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00018B
+PHILLIPS,Phillipsburg Township,Attorney General,,Democratic,"Kotich, A.J.",15,000190
+PHILLIPS,Phillipsburg Township,Attorney General,,Republican,"Schmidt, Derek",126,000190
+PHILLIPS,Plainview Township,Attorney General,,Democratic,"Kotich, A.J.",1,000200
+PHILLIPS,Plainview Township,Attorney General,,Republican,"Schmidt, Derek",9,000200
+PHILLIPS,Plum Township,Attorney General,,Democratic,"Kotich, A.J.",17,000210
+PHILLIPS,Plum Township,Attorney General,,Republican,"Schmidt, Derek",150,000210
+PHILLIPS,Prairie View Township,Attorney General,,Democratic,"Kotich, A.J.",7,000220
+PHILLIPS,Prairie View Township,Attorney General,,Republican,"Schmidt, Derek",85,000220
+PHILLIPS,Rushville Township,Attorney General,,Democratic,"Kotich, A.J.",0,000230
+PHILLIPS,Rushville Township,Attorney General,,Republican,"Schmidt, Derek",8,000230
+PHILLIPS,Solomon Township,Attorney General,,Democratic,"Kotich, A.J.",11,000240
+PHILLIPS,Solomon Township,Attorney General,,Republican,"Schmidt, Derek",73,000240
+PHILLIPS,Sumner Township,Attorney General,,Democratic,"Kotich, A.J.",1,000250
+PHILLIPS,Sumner Township,Attorney General,,Republican,"Schmidt, Derek",15,000250
+PHILLIPS,Towanda Township,Attorney General,,Democratic,"Kotich, A.J.",3,000260
+PHILLIPS,Towanda Township,Attorney General,,Republican,"Schmidt, Derek",8,000260
+PHILLIPS,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",1,000270
+PHILLIPS,Valley Township,Attorney General,,Republican,"Schmidt, Derek",12,000270
+PHILLIPS,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",0,000280
+PHILLIPS,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",3,000280
+PHILLIPS,Arcade Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000010
+PHILLIPS,Arcade Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000010
+PHILLIPS,Beaver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000020
+PHILLIPS,Beaver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000020
+PHILLIPS,Belmont Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000030
+PHILLIPS,Belmont Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000030
+PHILLIPS,Bow Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000040
+PHILLIPS,Bow Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000040
+PHILLIPS,Crystal Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000050
+PHILLIPS,Crystal Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000050
+PHILLIPS,Dayton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000060
+PHILLIPS,Dayton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000060
+PHILLIPS,Deer Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000070
+PHILLIPS,Deer Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000070
+PHILLIPS,Freedom Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000080
+PHILLIPS,Freedom Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000080
+PHILLIPS,Glenwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000090
+PHILLIPS,Glenwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000090
+PHILLIPS,Granite Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000100
+PHILLIPS,Granite Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000100
+PHILLIPS,Greenwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000110
+PHILLIPS,Greenwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000110
+PHILLIPS,Kirwin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000120
+PHILLIPS,Kirwin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",75,000120
+PHILLIPS,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000130
+PHILLIPS,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",196,000130
+PHILLIPS,Long Island Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000140
+PHILLIPS,Long Island Township,Commissioner of Insurance,,Republican,"Selzer, Ken",83,000140
+PHILLIPS,Mound Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000150
+PHILLIPS,Mound Township,Commissioner of Insurance,,Republican,"Selzer, Ken",59,000150
+PHILLIPS,Phillipsburg City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,000160
+PHILLIPS,Phillipsburg City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",362,000160
+PHILLIPS,Phillipsburg City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,000170
+PHILLIPS,Phillipsburg City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",260,000170
+PHILLIPS,Phillipsburg City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,00018A
+PHILLIPS,Phillipsburg City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",273,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00018B
+PHILLIPS,Phillipsburg Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000190
+PHILLIPS,Phillipsburg Township,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000190
+PHILLIPS,Plainview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000200
+PHILLIPS,Plainview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000200
+PHILLIPS,Plum Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000210
+PHILLIPS,Plum Township,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000210
+PHILLIPS,Prairie View Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000220
+PHILLIPS,Prairie View Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000220
+PHILLIPS,Rushville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000230
+PHILLIPS,Rushville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000230
+PHILLIPS,Solomon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000240
+PHILLIPS,Solomon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000240
+PHILLIPS,Sumner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000250
+PHILLIPS,Sumner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000250
+PHILLIPS,Towanda Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000260
+PHILLIPS,Towanda Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000260
+PHILLIPS,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000270
+PHILLIPS,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000270
+PHILLIPS,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000280
+PHILLIPS,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",3,000280
+PHILLIPS,Arcade Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000010
+PHILLIPS,Arcade Township,Secretary of State,,Republican,"Kobach, Kris",40,000010
+PHILLIPS,Beaver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+PHILLIPS,Beaver Township,Secretary of State,,Republican,"Kobach, Kris",25,000020
+PHILLIPS,Belmont Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000030
+PHILLIPS,Belmont Township,Secretary of State,,Republican,"Kobach, Kris",34,000030
+PHILLIPS,Bow Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000040
+PHILLIPS,Bow Creek Township,Secretary of State,,Republican,"Kobach, Kris",17,000040
+PHILLIPS,Crystal Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000050
+PHILLIPS,Crystal Township,Secretary of State,,Republican,"Kobach, Kris",27,000050
+PHILLIPS,Dayton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000060
+PHILLIPS,Dayton Township,Secretary of State,,Republican,"Kobach, Kris",18,000060
+PHILLIPS,Deer Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000070
+PHILLIPS,Deer Creek Township,Secretary of State,,Republican,"Kobach, Kris",33,000070
+PHILLIPS,Freedom Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000080
+PHILLIPS,Freedom Township,Secretary of State,,Republican,"Kobach, Kris",42,000080
+PHILLIPS,Glenwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000090
+PHILLIPS,Glenwood Township,Secretary of State,,Republican,"Kobach, Kris",17,000090
+PHILLIPS,Granite Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000100
+PHILLIPS,Granite Township,Secretary of State,,Republican,"Kobach, Kris",15,000100
+PHILLIPS,Greenwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000110
+PHILLIPS,Greenwood Township,Secretary of State,,Republican,"Kobach, Kris",26,000110
+PHILLIPS,Kirwin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000120
+PHILLIPS,Kirwin Township,Secretary of State,,Republican,"Kobach, Kris",74,000120
+PHILLIPS,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,000130
+PHILLIPS,Logan Township,Secretary of State,,Republican,"Kobach, Kris",179,000130
+PHILLIPS,Long Island Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000140
+PHILLIPS,Long Island Township,Secretary of State,,Republican,"Kobach, Kris",82,000140
+PHILLIPS,Mound Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000150
+PHILLIPS,Mound Township,Secretary of State,,Republican,"Kobach, Kris",52,000150
+PHILLIPS,Phillipsburg City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",84,000160
+PHILLIPS,Phillipsburg City Ward 1,Secretary of State,,Republican,"Kobach, Kris",362,000160
+PHILLIPS,Phillipsburg City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000170
+PHILLIPS,Phillipsburg City Ward 2,Secretary of State,,Republican,"Kobach, Kris",260,000170
+PHILLIPS,Phillipsburg City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,00018A
+PHILLIPS,Phillipsburg City Ward 3,Secretary of State,,Republican,"Kobach, Kris",262,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00018B
+PHILLIPS,Phillipsburg Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000190
+PHILLIPS,Phillipsburg Township,Secretary of State,,Republican,"Kobach, Kris",127,000190
+PHILLIPS,Plainview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000200
+PHILLIPS,Plainview Township,Secretary of State,,Republican,"Kobach, Kris",7,000200
+PHILLIPS,Plum Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000210
+PHILLIPS,Plum Township,Secretary of State,,Republican,"Kobach, Kris",142,000210
+PHILLIPS,Prairie View Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000220
+PHILLIPS,Prairie View Township,Secretary of State,,Republican,"Kobach, Kris",77,000220
+PHILLIPS,Rushville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000230
+PHILLIPS,Rushville Township,Secretary of State,,Republican,"Kobach, Kris",7,000230
+PHILLIPS,Solomon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000240
+PHILLIPS,Solomon Township,Secretary of State,,Republican,"Kobach, Kris",70,000240
+PHILLIPS,Sumner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000250
+PHILLIPS,Sumner Township,Secretary of State,,Republican,"Kobach, Kris",14,000250
+PHILLIPS,Towanda Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000260
+PHILLIPS,Towanda Township,Secretary of State,,Republican,"Kobach, Kris",10,000260
+PHILLIPS,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000270
+PHILLIPS,Valley Township,Secretary of State,,Republican,"Kobach, Kris",9,000270
+PHILLIPS,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000280
+PHILLIPS,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",3,000280
+PHILLIPS,Arcade Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000010
+PHILLIPS,Arcade Township,State Treasurer,,Republican,"Estes, Ron",40,000010
+PHILLIPS,Beaver Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000020
+PHILLIPS,Beaver Township,State Treasurer,,Republican,"Estes, Ron",23,000020
+PHILLIPS,Belmont Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+PHILLIPS,Belmont Township,State Treasurer,,Republican,"Estes, Ron",32,000030
+PHILLIPS,Bow Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000040
+PHILLIPS,Bow Creek Township,State Treasurer,,Republican,"Estes, Ron",16,000040
+PHILLIPS,Crystal Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000050
+PHILLIPS,Crystal Township,State Treasurer,,Republican,"Estes, Ron",25,000050
+PHILLIPS,Dayton Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000060
+PHILLIPS,Dayton Township,State Treasurer,,Republican,"Estes, Ron",17,000060
+PHILLIPS,Deer Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000070
+PHILLIPS,Deer Creek Township,State Treasurer,,Republican,"Estes, Ron",32,000070
+PHILLIPS,Freedom Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000080
+PHILLIPS,Freedom Township,State Treasurer,,Republican,"Estes, Ron",46,000080
+PHILLIPS,Glenwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000090
+PHILLIPS,Glenwood Township,State Treasurer,,Republican,"Estes, Ron",17,000090
+PHILLIPS,Granite Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000100
+PHILLIPS,Granite Township,State Treasurer,,Republican,"Estes, Ron",15,000100
+PHILLIPS,Greenwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000110
+PHILLIPS,Greenwood Township,State Treasurer,,Republican,"Estes, Ron",26,000110
+PHILLIPS,Kirwin Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000120
+PHILLIPS,Kirwin Township,State Treasurer,,Republican,"Estes, Ron",80,000120
+PHILLIPS,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",42,000130
+PHILLIPS,Logan Township,State Treasurer,,Republican,"Estes, Ron",205,000130
+PHILLIPS,Long Island Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000140
+PHILLIPS,Long Island Township,State Treasurer,,Republican,"Estes, Ron",87,000140
+PHILLIPS,Mound Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000150
+PHILLIPS,Mound Township,State Treasurer,,Republican,"Estes, Ron",53,000150
+PHILLIPS,Phillipsburg City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",58,000160
+PHILLIPS,Phillipsburg City Ward 1,State Treasurer,,Republican,"Estes, Ron",377,000160
+PHILLIPS,Phillipsburg City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",53,000170
+PHILLIPS,Phillipsburg City Ward 2,State Treasurer,,Republican,"Estes, Ron",270,000170
+PHILLIPS,Phillipsburg City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",42,00018A
+PHILLIPS,Phillipsburg City Ward 3,State Treasurer,,Republican,"Estes, Ron",283,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00018B
+PHILLIPS,Phillipsburg Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000190
+PHILLIPS,Phillipsburg Township,State Treasurer,,Republican,"Estes, Ron",125,000190
+PHILLIPS,Plainview Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000200
+PHILLIPS,Plainview Township,State Treasurer,,Republican,"Estes, Ron",9,000200
+PHILLIPS,Plum Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000210
+PHILLIPS,Plum Township,State Treasurer,,Republican,"Estes, Ron",148,000210
+PHILLIPS,Prairie View Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000220
+PHILLIPS,Prairie View Township,State Treasurer,,Republican,"Estes, Ron",81,000220
+PHILLIPS,Rushville Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000230
+PHILLIPS,Rushville Township,State Treasurer,,Republican,"Estes, Ron",7,000230
+PHILLIPS,Solomon Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000240
+PHILLIPS,Solomon Township,State Treasurer,,Republican,"Estes, Ron",72,000240
+PHILLIPS,Sumner Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000250
+PHILLIPS,Sumner Township,State Treasurer,,Republican,"Estes, Ron",14,000250
+PHILLIPS,Towanda Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000260
+PHILLIPS,Towanda Township,State Treasurer,,Republican,"Estes, Ron",11,000260
+PHILLIPS,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000270
+PHILLIPS,Valley Township,State Treasurer,,Republican,"Estes, Ron",10,000270
+PHILLIPS,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000280
+PHILLIPS,Walnut Township,State Treasurer,,Republican,"Estes, Ron",3,000280
+PHILLIPS,Arcade Township,United States Senate,,independent,"Orman, Greg",16,000010
+PHILLIPS,Arcade Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+PHILLIPS,Arcade Township,United States Senate,,Republican,"Roberts, Pat",33,000010
+PHILLIPS,Beaver Township,United States Senate,,independent,"Orman, Greg",1,000020
+PHILLIPS,Beaver Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+PHILLIPS,Beaver Township,United States Senate,,Republican,"Roberts, Pat",25,000020
+PHILLIPS,Belmont Township,United States Senate,,independent,"Orman, Greg",4,000030
+PHILLIPS,Belmont Township,United States Senate,,Libertarian,"Batson, Randall",3,000030
+PHILLIPS,Belmont Township,United States Senate,,Republican,"Roberts, Pat",34,000030
+PHILLIPS,Bow Creek Township,United States Senate,,independent,"Orman, Greg",2,000040
+PHILLIPS,Bow Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+PHILLIPS,Bow Creek Township,United States Senate,,Republican,"Roberts, Pat",17,000040
+PHILLIPS,Crystal Township,United States Senate,,independent,"Orman, Greg",5,000050
+PHILLIPS,Crystal Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+PHILLIPS,Crystal Township,United States Senate,,Republican,"Roberts, Pat",23,000050
+PHILLIPS,Dayton Township,United States Senate,,independent,"Orman, Greg",2,000060
+PHILLIPS,Dayton Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+PHILLIPS,Dayton Township,United States Senate,,Republican,"Roberts, Pat",18,000060
+PHILLIPS,Deer Creek Township,United States Senate,,independent,"Orman, Greg",1,000070
+PHILLIPS,Deer Creek Township,United States Senate,,Libertarian,"Batson, Randall",3,000070
+PHILLIPS,Deer Creek Township,United States Senate,,Republican,"Roberts, Pat",34,000070
+PHILLIPS,Freedom Township,United States Senate,,independent,"Orman, Greg",6,000080
+PHILLIPS,Freedom Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+PHILLIPS,Freedom Township,United States Senate,,Republican,"Roberts, Pat",44,000080
+PHILLIPS,Glenwood Township,United States Senate,,independent,"Orman, Greg",2,000090
+PHILLIPS,Glenwood Township,United States Senate,,Libertarian,"Batson, Randall",1,000090
+PHILLIPS,Glenwood Township,United States Senate,,Republican,"Roberts, Pat",18,000090
+PHILLIPS,Granite Township,United States Senate,,independent,"Orman, Greg",1,000100
+PHILLIPS,Granite Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+PHILLIPS,Granite Township,United States Senate,,Republican,"Roberts, Pat",16,000100
+PHILLIPS,Greenwood Township,United States Senate,,independent,"Orman, Greg",2,000110
+PHILLIPS,Greenwood Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+PHILLIPS,Greenwood Township,United States Senate,,Republican,"Roberts, Pat",26,000110
+PHILLIPS,Kirwin Township,United States Senate,,independent,"Orman, Greg",22,000120
+PHILLIPS,Kirwin Township,United States Senate,,Libertarian,"Batson, Randall",7,000120
+PHILLIPS,Kirwin Township,United States Senate,,Republican,"Roberts, Pat",71,000120
+PHILLIPS,Logan Township,United States Senate,,independent,"Orman, Greg",60,000130
+PHILLIPS,Logan Township,United States Senate,,Libertarian,"Batson, Randall",12,000130
+PHILLIPS,Logan Township,United States Senate,,Republican,"Roberts, Pat",180,000130
+PHILLIPS,Long Island Township,United States Senate,,independent,"Orman, Greg",15,000140
+PHILLIPS,Long Island Township,United States Senate,,Libertarian,"Batson, Randall",2,000140
+PHILLIPS,Long Island Township,United States Senate,,Republican,"Roberts, Pat",80,000140
+PHILLIPS,Mound Township,United States Senate,,independent,"Orman, Greg",11,000150
+PHILLIPS,Mound Township,United States Senate,,Libertarian,"Batson, Randall",6,000150
+PHILLIPS,Mound Township,United States Senate,,Republican,"Roberts, Pat",49,000150
+PHILLIPS,Phillipsburg City Ward 1,United States Senate,,independent,"Orman, Greg",102,000160
+PHILLIPS,Phillipsburg City Ward 1,United States Senate,,Libertarian,"Batson, Randall",18,000160
+PHILLIPS,Phillipsburg City Ward 1,United States Senate,,Republican,"Roberts, Pat",331,000160
+PHILLIPS,Phillipsburg City Ward 2,United States Senate,,independent,"Orman, Greg",82,000170
+PHILLIPS,Phillipsburg City Ward 2,United States Senate,,Libertarian,"Batson, Randall",18,000170
+PHILLIPS,Phillipsburg City Ward 2,United States Senate,,Republican,"Roberts, Pat",235,000170
+PHILLIPS,Phillipsburg City Ward 3,United States Senate,,independent,"Orman, Greg",86,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States Senate,,Libertarian,"Batson, Randall",20,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States Senate,,Republican,"Roberts, Pat",237,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States Senate,,independent,"Orman, Greg",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00018B
+PHILLIPS,Phillipsburg Township,United States Senate,,independent,"Orman, Greg",26,000190
+PHILLIPS,Phillipsburg Township,United States Senate,,Libertarian,"Batson, Randall",3,000190
+PHILLIPS,Phillipsburg Township,United States Senate,,Republican,"Roberts, Pat",115,000190
+PHILLIPS,Plainview Township,United States Senate,,independent,"Orman, Greg",3,000200
+PHILLIPS,Plainview Township,United States Senate,,Libertarian,"Batson, Randall",1,000200
+PHILLIPS,Plainview Township,United States Senate,,Republican,"Roberts, Pat",6,000200
+PHILLIPS,Plum Township,United States Senate,,independent,"Orman, Greg",30,000210
+PHILLIPS,Plum Township,United States Senate,,Libertarian,"Batson, Randall",13,000210
+PHILLIPS,Plum Township,United States Senate,,Republican,"Roberts, Pat",132,000210
+PHILLIPS,Prairie View Township,United States Senate,,independent,"Orman, Greg",10,000220
+PHILLIPS,Prairie View Township,United States Senate,,Libertarian,"Batson, Randall",2,000220
+PHILLIPS,Prairie View Township,United States Senate,,Republican,"Roberts, Pat",80,000220
+PHILLIPS,Rushville Township,United States Senate,,independent,"Orman, Greg",0,000230
+PHILLIPS,Rushville Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+PHILLIPS,Rushville Township,United States Senate,,Republican,"Roberts, Pat",9,000230
+PHILLIPS,Solomon Township,United States Senate,,independent,"Orman, Greg",10,000240
+PHILLIPS,Solomon Township,United States Senate,,Libertarian,"Batson, Randall",3,000240
+PHILLIPS,Solomon Township,United States Senate,,Republican,"Roberts, Pat",70,000240
+PHILLIPS,Sumner Township,United States Senate,,independent,"Orman, Greg",1,000250
+PHILLIPS,Sumner Township,United States Senate,,Libertarian,"Batson, Randall",0,000250
+PHILLIPS,Sumner Township,United States Senate,,Republican,"Roberts, Pat",17,000250
+PHILLIPS,Towanda Township,United States Senate,,independent,"Orman, Greg",1,000260
+PHILLIPS,Towanda Township,United States Senate,,Libertarian,"Batson, Randall",0,000260
+PHILLIPS,Towanda Township,United States Senate,,Republican,"Roberts, Pat",11,000260
+PHILLIPS,Valley Township,United States Senate,,independent,"Orman, Greg",3,000270
+PHILLIPS,Valley Township,United States Senate,,Libertarian,"Batson, Randall",1,000270
+PHILLIPS,Valley Township,United States Senate,,Republican,"Roberts, Pat",11,000270
+PHILLIPS,Walnut Township,United States Senate,,independent,"Orman, Greg",0,000280
+PHILLIPS,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",0,000280
+PHILLIPS,Walnut Township,United States Senate,,Republican,"Roberts, Pat",4,000280

--- a/2014/20141104__ks__general__pottawatomie__precinct.csv
+++ b/2014/20141104__ks__general__pottawatomie__precinct.csv
@@ -1,515 +1,619 @@
-county,precinct,office,district,party,candidate,votes
-Pottawatomie,Belvue,Attorney General,,D,A.J. Kotich,12
-Pottawatomie,Blue,Attorney General,,D,A.J. Kotich,290
-Pottawatomie,Blue Valley,Attorney General,,D,A.J. Kotich,32
-Pottawatomie,Center,Attorney General,,D,A.J. Kotich,1
-Pottawatomie,Clerk Creek,Attorney General,,D,A.J. Kotich,12
-Pottawatomie,Emmett,Attorney General,,D,A.J. Kotich,41
-Pottawatomie,Grant,Attorney General,,D,A.J. Kotich,24
-Pottawatomie,Green,Attorney General,,D,A.J. Kotich,17
-Pottawatomie,Lincoln,Attorney General,,D,A.J. Kotich,13
-Pottawatomie,Lone Tree,Attorney General,,D,A.J. Kotich,17
-Pottawatomie,Louisville,Attorney General,,D,A.J. Kotich,50
-Pottawatomie,Mill Creek,Attorney General,,D,A.J. Kotich,82
-Pottawatomie,Pottawatomie,Attorney General,,D,A.J. Kotich,41
-Pottawatomie,Rock Creek,Attorney General,,D,A.J. Kotich,42
-Pottawatomie,Shannon ,Attorney General,,D,A.J. Kotich,24
-Pottawatomie,Sherman,Attorney General,,D,A.J. Kotich,5
-Pottawatomie,Spring Creek,Attorney General,,D,A.J. Kotich,4
-Pottawatomie,St Clere,Attorney General,,D,A.J. Kotich,5
-Pottawatomie,St George 1,Attorney General,,D,A.J. Kotich,4
-Pottawatomie,St George 17,Attorney General,,D,A.J. Kotich,240
-Pottawatomie,St Marys City,Attorney General,,D,A.J. Kotich,141
-Pottawatomie,St Marys twp,Attorney General,,D,A.J. Kotich,37
-Pottawatomie,Union,Attorney General,,D,A.J. Kotich,24
-Pottawatomie,Vienna,Attorney General,,D,A.J. Kotich,6
-Pottawatomie,Wamego City 17-7,Attorney General,,D,A.J. Kotich,79
-Pottawatomie,Wamego City 18-4,Attorney General,,D,A.J. Kotich,274
-Pottawatomie,Wamego twp 1-6,Attorney General,,D,A.J. Kotich,0
-Pottawatomie,Wamego twp 17-7,Attorney General,,D,A.J. Kotich,54
-Pottawatomie,Wamego twp 18-4,Attorney General,,D,A.J. Kotich,31
-Pottawatomie,Belvue,Attorney General,,R,Derek Schmidt,116
-Pottawatomie,Blue,Attorney General,,R,Derek Schmidt,886
-Pottawatomie,Blue Valley,Attorney General,,R,Derek Schmidt,108
-Pottawatomie,Center,Attorney General,,R,Derek Schmidt,55
-Pottawatomie,Clerk Creek,Attorney General,,R,Derek Schmidt,51
-Pottawatomie,Emmett,Attorney General,,R,Derek Schmidt,89
-Pottawatomie,Grant,Attorney General,,R,Derek Schmidt,76
-Pottawatomie,Green,Attorney General,,R,Derek Schmidt,77
-Pottawatomie,Lincoln,Attorney General,,R,Derek Schmidt,46
-Pottawatomie,Lone Tree,Attorney General,,R,Derek Schmidt,74
-Pottawatomie,Louisville,Attorney General,,R,Derek Schmidt,275
-Pottawatomie,Mill Creek,Attorney General,,R,Derek Schmidt,231
-Pottawatomie,Pottawatomie,Attorney General,,R,Derek Schmidt,215
-Pottawatomie,Rock Creek,Attorney General,,R,Derek Schmidt,194
-Pottawatomie,Shannon ,Attorney General,,R,Derek Schmidt,96
-Pottawatomie,Sherman,Attorney General,,R,Derek Schmidt,31
-Pottawatomie,Spring Creek,Attorney General,,R,Derek Schmidt,19
-Pottawatomie,St Clere,Attorney General,,R,Derek Schmidt,18
-Pottawatomie,St George 1,Attorney General,,R,Derek Schmidt,9
-Pottawatomie,St George 17,Attorney General,,R,Derek Schmidt,910
-Pottawatomie,St Marys City,Attorney General,,R,Derek Schmidt,865
-Pottawatomie,St Marys twp,Attorney General,,R,Derek Schmidt,318
-Pottawatomie,Union,Attorney General,,R,Derek Schmidt,73
-Pottawatomie,Vienna,Attorney General,,R,Derek Schmidt,42
-Pottawatomie,Wamego City 17-7,Attorney General,,R,Derek Schmidt,382
-Pottawatomie,Wamego City 18-4,Attorney General,,R,Derek Schmidt,651
-Pottawatomie,Wamego twp 1-6,Attorney General,,R,Derek Schmidt,14
-Pottawatomie,Wamego twp 17-7,Attorney General,,R,Derek Schmidt,178
-Pottawatomie,Wamego twp 18-4,Attorney General,,R,Derek Schmidt,110
-Pottawatomie,Belvue,Insurance Commissioner,,D,Dennis Anderson,20
-Pottawatomie,Blue,Insurance Commissioner,,D,Dennis Anderson,331
-Pottawatomie,Blue Valley,Insurance Commissioner,,D,Dennis Anderson,42
-Pottawatomie,Center,Insurance Commissioner,,D,Dennis Anderson,4
-Pottawatomie,Clerk Creek,Insurance Commissioner,,D,Dennis Anderson,19
-Pottawatomie,Emmett,Insurance Commissioner,,D,Dennis Anderson,48
-Pottawatomie,Grant,Insurance Commissioner,,D,Dennis Anderson,30
-Pottawatomie,Green,Insurance Commissioner,,D,Dennis Anderson,21
-Pottawatomie,Lincoln,Insurance Commissioner,,D,Dennis Anderson,18
-Pottawatomie,Lone Tree,Insurance Commissioner,,D,Dennis Anderson,20
-Pottawatomie,Louisville,Insurance Commissioner,,D,Dennis Anderson,65
-Pottawatomie,Mill Creek,Insurance Commissioner,,D,Dennis Anderson,91
-Pottawatomie,Pottawatomie,Insurance Commissioner,,D,Dennis Anderson,53
-Pottawatomie,Rock Creek,Insurance Commissioner,,D,Dennis Anderson,57
-Pottawatomie,Shannon ,Insurance Commissioner,,D,Dennis Anderson,25
-Pottawatomie,Sherman,Insurance Commissioner,,D,Dennis Anderson,6
-Pottawatomie,Spring Creek,Insurance Commissioner,,D,Dennis Anderson,5
-Pottawatomie,St Clere,Insurance Commissioner,,D,Dennis Anderson,6
-Pottawatomie,St George 1,Insurance Commissioner,,D,Dennis Anderson,4
-Pottawatomie,St George 17,Insurance Commissioner,,D,Dennis Anderson,275
-Pottawatomie,St Marys City,Insurance Commissioner,,D,Dennis Anderson,153
-Pottawatomie,St Marys twp,Insurance Commissioner,,D,Dennis Anderson,37
-Pottawatomie,Union,Insurance Commissioner,,D,Dennis Anderson,31
-Pottawatomie,Vienna,Insurance Commissioner,,D,Dennis Anderson,9
-Pottawatomie,Wamego City 17-7,Insurance Commissioner,,D,Dennis Anderson,103
-Pottawatomie,Wamego City 18-4,Insurance Commissioner,,D,Dennis Anderson,301
-Pottawatomie,Wamego twp 1-6,Insurance Commissioner,,D,Dennis Anderson,0
-Pottawatomie,Wamego twp 17-7,Insurance Commissioner,,D,Dennis Anderson,63
-Pottawatomie,Wamego twp 18-4,Insurance Commissioner,,D,Dennis Anderson,32
-Pottawatomie,Belvue,Insurance Commissioner,,R,Ken Selzer,105
-Pottawatomie,Blue,Insurance Commissioner,,R,Ken Selzer,818
-Pottawatomie,Blue Valley,Insurance Commissioner,,R,Ken Selzer,98
-Pottawatomie,Center,Insurance Commissioner,,R,Ken Selzer,52
-Pottawatomie,Clerk Creek,Insurance Commissioner,,R,Ken Selzer,42
-Pottawatomie,Emmett,Insurance Commissioner,,R,Ken Selzer,81
-Pottawatomie,Grant,Insurance Commissioner,,R,Ken Selzer,65
-Pottawatomie,Green,Insurance Commissioner,,R,Ken Selzer,72
-Pottawatomie,Lincoln,Insurance Commissioner,,R,Ken Selzer,42
-Pottawatomie,Lone Tree,Insurance Commissioner,,R,Ken Selzer,71
-Pottawatomie,Louisville,Insurance Commissioner,,R,Ken Selzer,253
-Pottawatomie,Mill Creek,Insurance Commissioner,,R,Ken Selzer,212
-Pottawatomie,Pottawatomie,Insurance Commissioner,,R,Ken Selzer,197
-Pottawatomie,Rock Creek,Insurance Commissioner,,R,Ken Selzer,168
-Pottawatomie,Shannon ,Insurance Commissioner,,R,Ken Selzer,89
-Pottawatomie,Sherman,Insurance Commissioner,,R,Ken Selzer,30
-Pottawatomie,Spring Creek,Insurance Commissioner,,R,Ken Selzer,19
-Pottawatomie,St Clere,Insurance Commissioner,,R,Ken Selzer,17
-Pottawatomie,St George 1,Insurance Commissioner,,R,Ken Selzer,9
-Pottawatomie,St George 17,Insurance Commissioner,,R,Ken Selzer,854
-Pottawatomie,St Marys City,Insurance Commissioner,,R,Ken Selzer,835
-Pottawatomie,St Marys twp,Insurance Commissioner,,R,Ken Selzer,322
-Pottawatomie,Union,Insurance Commissioner,,R,Ken Selzer,66
-Pottawatomie,Vienna,Insurance Commissioner,,R,Ken Selzer,37
-Pottawatomie,Wamego City 17-7,Insurance Commissioner,,R,Ken Selzer,354
-Pottawatomie,Wamego City 18-4,Insurance Commissioner,,R,Ken Selzer,603
-Pottawatomie,Wamego twp 1-6,Insurance Commissioner,,R,Ken Selzer,14
-Pottawatomie,Wamego twp 17-7,Insurance Commissioner,,R,Ken Selzer,170
-Pottawatomie,Wamego twp 18-4,Insurance Commissioner,,R,Ken Selzer,99
-Pottawatomie,Belvue,Governor,,L,Keen Umbehr,14
-Pottawatomie,Blue,Governor,,L,Keen Umbehr,67
-Pottawatomie,Blue Valley,Governor,,L,Keen Umbehr,5
-Pottawatomie,Center,Governor,,L,Keen Umbehr,2
-Pottawatomie,Clerk Creek,Governor,,L,Keen Umbehr,3
-Pottawatomie,Emmett,Governor,,L,Keen Umbehr,7
-Pottawatomie,Grant,Governor,,L,Keen Umbehr,3
-Pottawatomie,Green,Governor,,L,Keen Umbehr,1
-Pottawatomie,Lincoln,Governor,,L,Keen Umbehr,4
-Pottawatomie,Lone Tree,Governor,,L,Keen Umbehr,6
-Pottawatomie,Louisville,Governor,,L,Keen Umbehr,23
-Pottawatomie,Mill Creek,Governor,,L,Keen Umbehr,23
-Pottawatomie,Pottawatomie,Governor,,L,Keen Umbehr,9
-Pottawatomie,Rock Creek,Governor,,L,Keen Umbehr,25
-Pottawatomie,Shannon ,Governor,,L,Keen Umbehr,6
-Pottawatomie,Sherman,Governor,,L,Keen Umbehr,5
-Pottawatomie,Spring Creek,Governor,,L,Keen Umbehr,0
-Pottawatomie,St Clere,Governor,,L,Keen Umbehr,1
-Pottawatomie,St George 1,Governor,,L,Keen Umbehr,0
-Pottawatomie,St George 17,Governor,,L,Keen Umbehr,79
-Pottawatomie,St Marys City,Governor,,L,Keen Umbehr,42
-Pottawatomie,St Marys twp,Governor,,L,Keen Umbehr,8
-Pottawatomie,Union,Governor,,L,Keen Umbehr,8
-Pottawatomie,Vienna,Governor,,L,Keen Umbehr,4
-Pottawatomie,Wamego City 17-7,Governor,,L,Keen Umbehr,27
-Pottawatomie,Wamego City 18-4,Governor,,L,Keen Umbehr,68
-Pottawatomie,Wamego twp 1-6,Governor,,L,Keen Umbehr,0
-Pottawatomie,Wamego twp 17-7,Governor,,L,Keen Umbehr,13
-Pottawatomie,Wamego twp 18-4,Governor,,L,Keen Umbehr,9
-Pottawatomie,Belvue,Governor,,D,Paul Davis,27
-Pottawatomie,Blue,Governor,,D,Paul Davis,472
-Pottawatomie,Blue Valley,Governor,,D,Paul Davis,54
-Pottawatomie,Center,Governor,,D,Paul Davis,7
-Pottawatomie,Clerk Creek,Governor,,D,Paul Davis,26
-Pottawatomie,Emmett,Governor,,D,Paul Davis,49
-Pottawatomie,Grant,Governor,,D,Paul Davis,45
-Pottawatomie,Green,Governor,,D,Paul Davis,25
-Pottawatomie,Lincoln,Governor,,D,Paul Davis,17
-Pottawatomie,Lone Tree,Governor,,D,Paul Davis,27
-Pottawatomie,Louisville,Governor,,D,Paul Davis,88
-Pottawatomie,Mill Creek,Governor,,D,Paul Davis,134
-Pottawatomie,Pottawatomie,Governor,,D,Paul Davis,76
-Pottawatomie,Rock Creek,Governor,,D,Paul Davis,87
-Pottawatomie,Shannon ,Governor,,D,Paul Davis,43
-Pottawatomie,Sherman,Governor,,D,Paul Davis,8
-Pottawatomie,Spring Creek,Governor,,D,Paul Davis,8
-Pottawatomie,St Clere,Governor,,D,Paul Davis,8
-Pottawatomie,St George 1,Governor,,D,Paul Davis,8
-Pottawatomie,St George 17,Governor,,D,Paul Davis,383
-Pottawatomie,St Marys City,Governor,,D,Paul Davis,207
-Pottawatomie,St Marys twp,Governor,,D,Paul Davis,46
-Pottawatomie,Union,Governor,,D,Paul Davis,34
-Pottawatomie,Vienna,Governor,,D,Paul Davis,14
-Pottawatomie,Wamego City 17-7,Governor,,D,Paul Davis,166
-Pottawatomie,Wamego City 18-4,Governor,,D,Paul Davis,389
-Pottawatomie,Wamego twp 1-6,Governor,,D,Paul Davis,1
-Pottawatomie,Wamego twp 17-7,Governor,,D,Paul Davis,97
-Pottawatomie,Wamego twp 18-4,Governor,,D,Paul Davis,47
-Pottawatomie,Belvue,Governor,,R,Sam Brownback,87
-Pottawatomie,Blue,Governor,,R,Sam Brownback,656
-Pottawatomie,Blue Valley,Governor,,R,Sam Brownback,86
-Pottawatomie,Center,Governor,,R,Sam Brownback,49
-Pottawatomie,Clerk Creek,Governor,,R,Sam Brownback,34
-Pottawatomie,Emmett,Governor,,R,Sam Brownback,76
-Pottawatomie,Grant,Governor,,R,Sam Brownback,51
-Pottawatomie,Green,Governor,,R,Sam Brownback,72
-Pottawatomie,Lincoln,Governor,,R,Sam Brownback,40
-Pottawatomie,Lone Tree,Governor,,R,Sam Brownback,62
-Pottawatomie,Louisville,Governor,,R,Sam Brownback,222
-Pottawatomie,Mill Creek,Governor,,R,Sam Brownback,157
-Pottawatomie,Pottawatomie,Governor,,R,Sam Brownback,180
-Pottawatomie,Rock Creek,Governor,,R,Sam Brownback,127
-Pottawatomie,Shannon ,Governor,,R,Sam Brownback,72
-Pottawatomie,Sherman,Governor,,R,Sam Brownback,23
-Pottawatomie,Spring Creek,Governor,,R,Sam Brownback,18
-Pottawatomie,St Clere,Governor,,R,Sam Brownback,16
-Pottawatomie,St George 1,Governor,,R,Sam Brownback,6
-Pottawatomie,St George 17,Governor,,R,Sam Brownback,711
-Pottawatomie,St Marys City,Governor,,R,Sam Brownback,782
-Pottawatomie,St Marys twp,Governor,,R,Sam Brownback,311
-Pottawatomie,Union,Governor,,R,Sam Brownback,56
-Pottawatomie,Vienna,Governor,,R,Sam Brownback,32
-Pottawatomie,Wamego City 17-7,Governor,,R,Sam Brownback,279
-Pottawatomie,Wamego City 18-4,Governor,,R,Sam Brownback,489
-Pottawatomie,Wamego twp 1-6,Governor,,R,Sam Brownback,13
-Pottawatomie,Wamego twp 17-7,Governor,,R,Sam Brownback,131
-Pottawatomie,Wamego twp 18-4,Governor,,R,Sam Brownback,87
-Pottawatomie,Belvue,Secretary of State,,D,Jean Kurtis Schodorf,18
-Pottawatomie,Blue,Secretary of State,,D,Jean Kurtis Schodorf,366
-Pottawatomie,Blue Valley,Secretary of State,,D,Jean Kurtis Schodorf,37
-Pottawatomie,Center,Secretary of State,,D,Jean Kurtis Schodorf,2
-Pottawatomie,Clerk Creek,Secretary of State,,D,Jean Kurtis Schodorf,19
-Pottawatomie,Emmett,Secretary of State,,D,Jean Kurtis Schodorf,42
-Pottawatomie,Grant,Secretary of State,,D,Jean Kurtis Schodorf,29
-Pottawatomie,Green,Secretary of State,,D,Jean Kurtis Schodorf,24
-Pottawatomie,Lincoln,Secretary of State,,D,Jean Kurtis Schodorf,19
-Pottawatomie,Lone Tree,Secretary of State,,D,Jean Kurtis Schodorf,25
-Pottawatomie,Louisville,Secretary of State,,D,Jean Kurtis Schodorf,67
-Pottawatomie,Mill Creek,Secretary of State,,D,Jean Kurtis Schodorf,86
-Pottawatomie,Pottawatomie,Secretary of State,,D,Jean Kurtis Schodorf,53
-Pottawatomie,Rock Creek,Secretary of State,,D,Jean Kurtis Schodorf,58
-Pottawatomie,Shannon ,Secretary of State,,D,Jean Kurtis Schodorf,29
-Pottawatomie,Sherman,Secretary of State,,D,Jean Kurtis Schodorf,3
-Pottawatomie,Spring Creek,Secretary of State,,D,Jean Kurtis Schodorf,9
-Pottawatomie,St Clere,Secretary of State,,D,Jean Kurtis Schodorf,8
-Pottawatomie,St George 1,Secretary of State,,D,Jean Kurtis Schodorf,6
-Pottawatomie,St George 17,Secretary of State,,D,Jean Kurtis Schodorf,293
-Pottawatomie,St Marys City,Secretary of State,,D,Jean Kurtis Schodorf,162
-Pottawatomie,St Marys twp,Secretary of State,,D,Jean Kurtis Schodorf,44
-Pottawatomie,Union,Secretary of State,,D,Jean Kurtis Schodorf,28
-Pottawatomie,Vienna,Secretary of State,,D,Jean Kurtis Schodorf,12
-Pottawatomie,Wamego City 17-7,Secretary of State,,D,Jean Kurtis Schodorf,104
-Pottawatomie,Wamego City 18-4,Secretary of State,,D,Jean Kurtis Schodorf,311
-Pottawatomie,Wamego twp 1-6,Secretary of State,,D,Jean Kurtis Schodorf,1
-Pottawatomie,Wamego twp 17-7,Secretary of State,,D,Jean Kurtis Schodorf,62
-Pottawatomie,Wamego twp 18-4,Secretary of State,,D,Jean Kurtis Schodorf,33
-Pottawatomie,Belvue,Secretary of State,,R,Kris Kobach,111
-Pottawatomie,Blue,Secretary of State,,R,Kris Kobach,817
-Pottawatomie,Blue Valley,Secretary of State,,R,Kris Kobach,107
-Pottawatomie,Center,Secretary of State,,R,Kris Kobach,56
-Pottawatomie,Clerk Creek,Secretary of State,,R,Kris Kobach,42
-Pottawatomie,Emmett,Secretary of State,,R,Kris Kobach,89
-Pottawatomie,Grant,Secretary of State,,R,Kris Kobach,72
-Pottawatomie,Green,Secretary of State,,R,Kris Kobach,71
-Pottawatomie,Lincoln,Secretary of State,,R,Kris Kobach,41
-Pottawatomie,Lone Tree,Secretary of State,,R,Kris Kobach,68
-Pottawatomie,Louisville,Secretary of State,,R,Kris Kobach,260
-Pottawatomie,Mill Creek,Secretary of State,,R,Kris Kobach,229
-Pottawatomie,Pottawatomie,Secretary of State,,R,Kris Kobach,207
-Pottawatomie,Rock Creek,Secretary of State,,R,Kris Kobach,181
-Pottawatomie,Shannon ,Secretary of State,,R,Kris Kobach,93
-Pottawatomie,Sherman,Secretary of State,,R,Kris Kobach,33
-Pottawatomie,Spring Creek,Secretary of State,,R,Kris Kobach,17
-Pottawatomie,St Clere,Secretary of State,,R,Kris Kobach,17
-Pottawatomie,St George 1,Secretary of State,,R,Kris Kobach,8
-Pottawatomie,St George 17,Secretary of State,,R,Kris Kobach,870
-Pottawatomie,St Marys City,Secretary of State,,R,Kris Kobach,862
-Pottawatomie,St Marys twp,Secretary of State,,R,Kris Kobach,322
-Pottawatomie,Union,Secretary of State,,R,Kris Kobach,68
-Pottawatomie,Vienna,Secretary of State,,R,Kris Kobach,37
-Pottawatomie,Wamego City 17-7,Secretary of State,,R,Kris Kobach,369
-Pottawatomie,Wamego City 18-4,Secretary of State,,R,Kris Kobach,627
-Pottawatomie,Wamego twp 1-6,Secretary of State,,R,Kris Kobach,13
-Pottawatomie,Wamego twp 17-7,Secretary of State,,R,Kris Kobach,175
-Pottawatomie,Wamego twp 18-4,Secretary of State,,R,Kris Kobach,107
-Pottawatomie,Blue,State House,51,R,Ron Highland,1016
-Pottawatomie,St George 1,State House,51,R,Ron Highland,10
-Pottawatomie,St George 17,State House,51,R,Ron Highland,1003
-Pottawatomie,Wamego City 17-7,State House,51,R,Ron Highland,430
-Pottawatomie,Wamego City 18-4,State House,51,R,Ron Highland,790
-Pottawatomie,Wamego twp 1-6,State House,51,R,Ron Highland,13
-Pottawatomie,Wamego twp 17-7,State House,51,R,Ron Highland,210
-Pottawatomie,Wamego twp 18-4,State House,51,R,Ron Highland,121
-Pottawatomie,Belvue,State House,61,R,Becky J. Hutchins,95
-Pottawatomie,Blue Valley,State House,61,R,Becky J. Hutchins,89
-Pottawatomie,Center,State House,61,R,Becky J. Hutchins,51
-Pottawatomie,Clerk Creek,State House,61,R,Becky J. Hutchins,41
-Pottawatomie,Emmett,State House,61,R,Becky J. Hutchins,66
-Pottawatomie,Grant,State House,61,R,Becky J. Hutchins,58
-Pottawatomie,Green,State House,61,R,Becky J. Hutchins,70
-Pottawatomie,Lincoln,State House,61,R,Becky J. Hutchins,36
-Pottawatomie,Lone Tree,State House,61,R,Becky J. Hutchins,66
-Pottawatomie,Louisville,State House,61,R,Becky J. Hutchins,243
-Pottawatomie,Mill Creek,State House,61,R,Becky J. Hutchins,155
-Pottawatomie,Pottawatomie,State House,61,R,Becky J. Hutchins,193
-Pottawatomie,Rock Creek,State House,61,R,Becky J. Hutchins,159
-Pottawatomie,Shannon ,State House,61,R,Becky J. Hutchins,84
-Pottawatomie,Sherman,State House,61,R,Becky J. Hutchins,28
-Pottawatomie,Spring Creek,State House,61,R,Becky J. Hutchins,18
-Pottawatomie,St Clere,State House,61,R,Becky J. Hutchins,14
-Pottawatomie,St Marys City,State House,61,R,Becky J. Hutchins,752
-Pottawatomie,St Marys twp,State House,61,R,Becky J. Hutchins,287
-Pottawatomie,Union,State House,61,R,Becky J. Hutchins,64
-Pottawatomie,Vienna,State House,61,R,Becky J. Hutchins,30
-Pottawatomie,Belvue,State House,61,D,Vivien J. Olsen,31
-Pottawatomie,Blue Valley,State House,61,D,Vivien J. Olsen,55
-Pottawatomie,Center,State House,61,D,Vivien J. Olsen,6
-Pottawatomie,Clerk Creek,State House,61,D,Vivien J. Olsen,22
-Pottawatomie,Emmett,State House,61,D,Vivien J. Olsen,65
-Pottawatomie,Grant,State House,61,D,Vivien J. Olsen,42
-Pottawatomie,Green,State House,61,D,Vivien J. Olsen,24
-Pottawatomie,Lincoln,State House,61,D,Vivien J. Olsen,24
-Pottawatomie,Lone Tree,State House,61,D,Vivien J. Olsen,30
-Pottawatomie,Louisville,State House,61,D,Vivien J. Olsen,74
-Pottawatomie,Mill Creek,State House,61,D,Vivien J. Olsen,158
-Pottawatomie,Pottawatomie,State House,61,D,Vivien J. Olsen,58
-Pottawatomie,Rock Creek,State House,61,D,Vivien J. Olsen,79
-Pottawatomie,Shannon ,State House,61,D,Vivien J. Olsen,35
-Pottawatomie,Sherman,State House,61,D,Vivien J. Olsen,8
-Pottawatomie,Spring Creek,State House,61,D,Vivien J. Olsen,7
-Pottawatomie,St Clere,State House,61,D,Vivien J. Olsen,11
-Pottawatomie,St Marys City,State House,61,D,Vivien J. Olsen,269
-Pottawatomie,St Marys twp,State House,61,D,Vivien J. Olsen,76
-Pottawatomie,Union,State House,61,D,Vivien J. Olsen,33
-Pottawatomie,Vienna,State House,61,D,Vivien J. Olsen,20
-Pottawatomie,Belvue,State Treasurer,,D,Carmen Alldritt,17
-Pottawatomie,Blue,State Treasurer,,D,Carmen Alldritt,295
-Pottawatomie,Blue Valley,State Treasurer,,D,Carmen Alldritt,37
-Pottawatomie,Center,State Treasurer,,D,Carmen Alldritt,0
-Pottawatomie,Clerk Creek,State Treasurer,,D,Carmen Alldritt,15
-Pottawatomie,Emmett,State Treasurer,,D,Carmen Alldritt,42
-Pottawatomie,Grant,State Treasurer,,D,Carmen Alldritt,28
-Pottawatomie,Green,State Treasurer,,D,Carmen Alldritt,19
-Pottawatomie,Lincoln,State Treasurer,,D,Carmen Alldritt,14
-Pottawatomie,Lone Tree,State Treasurer,,D,Carmen Alldritt,19
-Pottawatomie,Louisville,State Treasurer,,D,Carmen Alldritt,51
-Pottawatomie,Mill Creek,State Treasurer,,D,Carmen Alldritt,80
-Pottawatomie,Pottawatomie,State Treasurer,,D,Carmen Alldritt,41
-Pottawatomie,Rock Creek,State Treasurer,,D,Carmen Alldritt,48
-Pottawatomie,Shannon ,State Treasurer,,D,Carmen Alldritt,25
-Pottawatomie,Sherman,State Treasurer,,D,Carmen Alldritt,7
-Pottawatomie,Spring Creek,State Treasurer,,D,Carmen Alldritt,3
-Pottawatomie,St Clere,State Treasurer,,D,Carmen Alldritt,7
-Pottawatomie,St George 1,State Treasurer,,D,Carmen Alldritt,4
-Pottawatomie,St George 17,State Treasurer,,D,Carmen Alldritt,231
-Pottawatomie,St Marys City,State Treasurer,,D,Carmen Alldritt,139
-Pottawatomie,St Marys twp,State Treasurer,,D,Carmen Alldritt,34
-Pottawatomie,Union,State Treasurer,,D,Carmen Alldritt,23
-Pottawatomie,Vienna,State Treasurer,,D,Carmen Alldritt,7
-Pottawatomie,Wamego City 17-7,State Treasurer,,D,Carmen Alldritt,77
-Pottawatomie,Wamego City 18-4,State Treasurer,,D,Carmen Alldritt,272
-Pottawatomie,Wamego twp 1-6,State Treasurer,,D,Carmen Alldritt,0
-Pottawatomie,Wamego twp 17-7,State Treasurer,,D,Carmen Alldritt,51
-Pottawatomie,Wamego twp 18-4,State Treasurer,,D,Carmen Alldritt,30
-Pottawatomie,Belvue,State Treasurer,,R,Ron Estes,110
-Pottawatomie,Blue,State Treasurer,,R,Ron Estes,868
-Pottawatomie,Blue Valley,State Treasurer,,R,Ron Estes,104
-Pottawatomie,Center,State Treasurer,,R,Ron Estes,58
-Pottawatomie,Clerk Creek,State Treasurer,,R,Ron Estes,46
-Pottawatomie,Emmett,State Treasurer,,R,Ron Estes,89
-Pottawatomie,Grant,State Treasurer,,R,Ron Estes,71
-Pottawatomie,Green,State Treasurer,,R,Ron Estes,76
-Pottawatomie,Lincoln,State Treasurer,,R,Ron Estes,46
-Pottawatomie,Lone Tree,State Treasurer,,R,Ron Estes,74
-Pottawatomie,Louisville,State Treasurer,,R,Ron Estes,274
-Pottawatomie,Mill Creek,State Treasurer,,R,Ron Estes,231
-Pottawatomie,Pottawatomie,State Treasurer,,R,Ron Estes,214
-Pottawatomie,Rock Creek,State Treasurer,,R,Ron Estes,185
-Pottawatomie,Shannon ,State Treasurer,,R,Ron Estes,93
-Pottawatomie,Sherman,State Treasurer,,R,Ron Estes,29
-Pottawatomie,Spring Creek,State Treasurer,,R,Ron Estes,20
-Pottawatomie,St Clere,State Treasurer,,R,Ron Estes,18
-Pottawatomie,St George 1,State Treasurer,,R,Ron Estes,10
-Pottawatomie,St George 17,State Treasurer,,R,Ron Estes,916
-Pottawatomie,St Marys City,State Treasurer,,R,Ron Estes,863
-Pottawatomie,St Marys twp,State Treasurer,,R,Ron Estes,326
-Pottawatomie,Union,State Treasurer,,R,Ron Estes,73
-Pottawatomie,Vienna,State Treasurer,,R,Ron Estes,41
-Pottawatomie,Wamego City 17-7,State Treasurer,,R,Ron Estes,391
-Pottawatomie,Wamego City 18-4,State Treasurer,,R,Ron Estes,652
-Pottawatomie,Wamego twp 1-6,State Treasurer,,R,Ron Estes,14
-Pottawatomie,Wamego twp 17-7,State Treasurer,,R,Ron Estes,184
-Pottawatomie,Wamego twp 18-4,State Treasurer,,R,Ron Estes,108
-Pottawatomie,Belvue,U.S. Senate,,I,Greg Orman,25
-Pottawatomie,Blue,U.S. Senate,,I,Greg Orman,420
-Pottawatomie,Blue Valley,U.S. Senate,,I,Greg Orman,49
-Pottawatomie,Center,U.S. Senate,,I,Greg Orman,5
-Pottawatomie,Clerk Creek,U.S. Senate,,I,Greg Orman,21
-Pottawatomie,Emmett,U.S. Senate,,I,Greg Orman,42
-Pottawatomie,Grant,U.S. Senate,,I,Greg Orman,40
-Pottawatomie,Green,U.S. Senate,,I,Greg Orman,23
-Pottawatomie,Lincoln,U.S. Senate,,I,Greg Orman,18
-Pottawatomie,Lone Tree,U.S. Senate,,I,Greg Orman,28
-Pottawatomie,Louisville,U.S. Senate,,I,Greg Orman,73
-Pottawatomie,Mill Creek,U.S. Senate,,I,Greg Orman,121
-Pottawatomie,Pottawatomie,U.S. Senate,,I,Greg Orman,72
-Pottawatomie,Rock Creek,U.S. Senate,,I,Greg Orman,84
-Pottawatomie,Shannon ,U.S. Senate,,I,Greg Orman,39
-Pottawatomie,Sherman,U.S. Senate,,I,Greg Orman,10
-Pottawatomie,Spring Creek,U.S. Senate,,I,Greg Orman,9
-Pottawatomie,St Clere,U.S. Senate,,I,Greg Orman,6
-Pottawatomie,St George 1,U.S. Senate,,I,Greg Orman,8
-Pottawatomie,St George 17,U.S. Senate,,I,Greg Orman,339
-Pottawatomie,St Marys City,U.S. Senate,,I,Greg Orman,174
-Pottawatomie,St Marys twp,U.S. Senate,,I,Greg Orman,44
-Pottawatomie,Union,U.S. Senate,,I,Greg Orman,34
-Pottawatomie,Vienna,U.S. Senate,,I,Greg Orman,10
-Pottawatomie,Wamego City 17-7,U.S. Senate,,I,Greg Orman,135
-Pottawatomie,Wamego City 18-4,U.S. Senate,,I,Greg Orman,353
-Pottawatomie,Wamego twp 1-6,U.S. Senate,,I,Greg Orman,1
-Pottawatomie,Wamego twp 17-7,U.S. Senate,,I,Greg Orman,80
-Pottawatomie,Wamego twp 18-4,U.S. Senate,,I,Greg Orman,40
-Pottawatomie,Belvue,U.S. Senate,,R,Pat Roberts,97
-Pottawatomie,Blue,U.S. Senate,,R,Pat Roberts,726
-Pottawatomie,Blue Valley,U.S. Senate,,R,Pat Roberts,96
-Pottawatomie,Center,U.S. Senate,,R,Pat Roberts,51
-Pottawatomie,Clerk Creek,U.S. Senate,,R,Pat Roberts,38
-Pottawatomie,Emmett,U.S. Senate,,R,Pat Roberts,82
-Pottawatomie,Grant,U.S. Senate,,R,Pat Roberts,56
-Pottawatomie,Green,U.S. Senate,,R,Pat Roberts,72
-Pottawatomie,Lincoln,U.S. Senate,,R,Pat Roberts,43
-Pottawatomie,Lone Tree,U.S. Senate,,R,Pat Roberts,64
-Pottawatomie,Louisville,U.S. Senate,,R,Pat Roberts,245
-Pottawatomie,Mill Creek,U.S. Senate,,R,Pat Roberts,177
-Pottawatomie,Pottawatomie,U.S. Senate,,R,Pat Roberts,190
-Pottawatomie,Rock Creek,U.S. Senate,,R,Pat Roberts,136
-Pottawatomie,Shannon ,U.S. Senate,,R,Pat Roberts,79
-Pottawatomie,Sherman,U.S. Senate,,R,Pat Roberts,27
-Pottawatomie,Spring Creek,U.S. Senate,,R,Pat Roberts,16
-Pottawatomie,St Clere,U.S. Senate,,R,Pat Roberts,17
-Pottawatomie,St George 1,U.S. Senate,,R,Pat Roberts,6
-Pottawatomie,St George 17,U.S. Senate,,R,Pat Roberts,784
-Pottawatomie,St Marys City,U.S. Senate,,R,Pat Roberts,816
-Pottawatomie,St Marys twp,U.S. Senate,,R,Pat Roberts,311
-Pottawatomie,Union,U.S. Senate,,R,Pat Roberts,58
-Pottawatomie,Vienna,U.S. Senate,,R,Pat Roberts,37
-Pottawatomie,Wamego City 17-7,U.S. Senate,,R,Pat Roberts,322
-Pottawatomie,Wamego City 18-4,U.S. Senate,,R,Pat Roberts,536
-Pottawatomie,Wamego twp 1-6,U.S. Senate,,R,Pat Roberts,13
-Pottawatomie,Wamego twp 17-7,U.S. Senate,,R,Pat Roberts,150
-Pottawatomie,Wamego twp 18-4,U.S. Senate,,R,Pat Roberts,97
-Pottawatomie,Belvue,U.S. Senate,,L,Randall Batson,10
-Pottawatomie,Blue,U.S. Senate,,L,Randall Batson,49
-Pottawatomie,Blue Valley,U.S. Senate,,L,Randall Batson,2
-Pottawatomie,Center,U.S. Senate,,L,Randall Batson,2
-Pottawatomie,Clerk Creek,U.S. Senate,,L,Randall Batson,2
-Pottawatomie,Emmett,U.S. Senate,,L,Randall Batson,7
-Pottawatomie,Grant,U.S. Senate,,L,Randall Batson,5
-Pottawatomie,Green,U.S. Senate,,L,Randall Batson,1
-Pottawatomie,Lincoln,U.S. Senate,,L,Randall Batson,0
-Pottawatomie,Lone Tree,U.S. Senate,,L,Randall Batson,5
-Pottawatomie,Louisville,U.S. Senate,,L,Randall Batson,16
-Pottawatomie,Mill Creek,U.S. Senate,,L,Randall Batson,18
-Pottawatomie,Pottawatomie,U.S. Senate,,L,Randall Batson,3
-Pottawatomie,Rock Creek,U.S. Senate,,L,Randall Batson,19
-Pottawatomie,Shannon ,U.S. Senate,,L,Randall Batson,5
-Pottawatomie,Sherman,U.S. Senate,,L,Randall Batson,0
-Pottawatomie,Spring Creek,U.S. Senate,,L,Randall Batson,1
-Pottawatomie,St Clere,U.S. Senate,,L,Randall Batson,2
-Pottawatomie,St George 1,U.S. Senate,,L,Randall Batson,0
-Pottawatomie,St George 17,U.S. Senate,,L,Randall Batson,51
-Pottawatomie,St Marys City,U.S. Senate,,L,Randall Batson,34
-Pottawatomie,St Marys twp,U.S. Senate,,L,Randall Batson,10
-Pottawatomie,Union,U.S. Senate,,L,Randall Batson,6
-Pottawatomie,Vienna,U.S. Senate,,L,Randall Batson,3
-Pottawatomie,Wamego City 17-7,U.S. Senate,,L,Randall Batson,16
-Pottawatomie,Wamego City 18-4,U.S. Senate,,L,Randall Batson,56
-Pottawatomie,Wamego twp 1-6,U.S. Senate,,L,Randall Batson,0
-Pottawatomie,Wamego twp 17-7,U.S. Senate,,L,Randall Batson,7
-Pottawatomie,Wamego twp 18-4,U.S. Senate,,L,Randall Batson,8
-Pottawatomie,Belvue,U.S. House,1,D,James E. Sherow,22
-Pottawatomie,Blue,U.S. House,1,D,James E. Sherow,442
-Pottawatomie,Blue Valley,U.S. House,1,D,James E. Sherow,46
-Pottawatomie,Center,U.S. House,1,D,James E. Sherow,5
-Pottawatomie,Clerk Creek,U.S. House,1,D,James E. Sherow,19
-Pottawatomie,Emmett,U.S. House,1,D,James E. Sherow,43
-Pottawatomie,Grant,U.S. House,1,D,James E. Sherow,37
-Pottawatomie,Green,U.S. House,1,D,James E. Sherow,25
-Pottawatomie,Lincoln,U.S. House,1,D,James E. Sherow,17
-Pottawatomie,Lone Tree,U.S. House,1,D,James E. Sherow,27
-Pottawatomie,Louisville,U.S. House,1,D,James E. Sherow,81
-Pottawatomie,Mill Creek,U.S. House,1,D,James E. Sherow,103
-Pottawatomie,Pottawatomie,U.S. House,1,D,James E. Sherow,62
-Pottawatomie,Rock Creek,U.S. House,1,D,James E. Sherow,81
-Pottawatomie,Shannon ,U.S. House,1,D,James E. Sherow,36
-Pottawatomie,Sherman,U.S. House,1,D,James E. Sherow,9
-Pottawatomie,Spring Creek,U.S. House,1,D,James E. Sherow,8
-Pottawatomie,St Clere,U.S. House,1,D,James E. Sherow,9
-Pottawatomie,St George 1,U.S. House,1,D,James E. Sherow,6
-Pottawatomie,St George 17,U.S. House,1,D,James E. Sherow,369
-Pottawatomie,St Marys City,U.S. House,1,D,James E. Sherow,170
-Pottawatomie,St Marys twp,U.S. House,1,D,James E. Sherow,45
-Pottawatomie,Union,U.S. House,1,D,James E. Sherow,32
-Pottawatomie,Vienna,U.S. House,1,D,James E. Sherow,12
-Pottawatomie,Wamego City 17-7,U.S. House,1,D,James E. Sherow,133
-Pottawatomie,Wamego City 18-4,U.S. House,1,D,James E. Sherow,340
-Pottawatomie,Wamego twp 1-6,U.S. House,1,D,James E. Sherow,1
-Pottawatomie,Wamego twp 17-7,U.S. House,1,D,James E. Sherow,81
-Pottawatomie,Wamego twp 18-4,U.S. House,1,D,James E. Sherow,40
-Pottawatomie,Belvue,U.S. House,1,R,Tim Huelskamp,105
-Pottawatomie,Blue,U.S. House,1,R,Tim Huelskamp,741
-Pottawatomie,Blue Valley,U.S. House,1,R,Tim Huelskamp,98
-Pottawatomie,Center,U.S. House,1,R,Tim Huelskamp,52
-Pottawatomie,Clerk Creek,U.S. House,1,R,Tim Huelskamp,44
-Pottawatomie,Emmett,U.S. House,1,R,Tim Huelskamp,87
-Pottawatomie,Grant,U.S. House,1,R,Tim Huelskamp,63
-Pottawatomie,Green,U.S. House,1,R,Tim Huelskamp,71
-Pottawatomie,Lincoln,U.S. House,1,R,Tim Huelskamp,42
-Pottawatomie,Lone Tree,U.S. House,1,R,Tim Huelskamp,62
-Pottawatomie,Louisville,U.S. House,1,R,Tim Huelskamp,247
-Pottawatomie,Mill Creek,U.S. House,1,R,Tim Huelskamp,206
-Pottawatomie,Pottawatomie,U.S. House,1,R,Tim Huelskamp,195
-Pottawatomie,Rock Creek,U.S. House,1,R,Tim Huelskamp,154
-Pottawatomie,Shannon ,U.S. House,1,R,Tim Huelskamp,84
-Pottawatomie,Sherman,U.S. House,1,R,Tim Huelskamp,27
-Pottawatomie,Spring Creek,U.S. House,1,R,Tim Huelskamp,18
-Pottawatomie,St Clere,U.S. House,1,R,Tim Huelskamp,16
-Pottawatomie,St George 1,U.S. House,1,R,Tim Huelskamp,8
-Pottawatomie,St George 17,U.S. House,1,R,Tim Huelskamp,792
-Pottawatomie,St Marys City,U.S. House,1,R,Tim Huelskamp,848
-Pottawatomie,St Marys twp,U.S. House,1,R,Tim Huelskamp,320
-Pottawatomie,Union,U.S. House,1,R,Tim Huelskamp,65
-Pottawatomie,Vienna,U.S. House,1,R,Tim Huelskamp,37
-Pottawatomie,Wamego City 17-7,U.S. House,1,R,Tim Huelskamp,338
-Pottawatomie,Wamego City 18-4,U.S. House,1,R,Tim Huelskamp,591
-Pottawatomie,Wamego twp 1-6,U.S. House,1,R,Tim Huelskamp,13
-Pottawatomie,Wamego twp 17-7,U.S. House,1,R,Tim Huelskamp,157
-Pottawatomie,Wamego twp 18-4,U.S. House,1,R,Tim Huelskamp,101
+county,precinct,office,district,party,candidate,votes,vtd
+POTTAWATOMIE,Belvue Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000010
+POTTAWATOMIE,Belvue Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000010
+POTTAWATOMIE,Belvue Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,000010
+POTTAWATOMIE,Blue Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",484,000020
+POTTAWATOMIE,Blue Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",68,000020
+POTTAWATOMIE,Blue Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",659,000020
+POTTAWATOMIE,Blue Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000030
+POTTAWATOMIE,Blue Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000030
+POTTAWATOMIE,Blue Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,000030
+POTTAWATOMIE,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000040
+POTTAWATOMIE,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+POTTAWATOMIE,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000040
+POTTAWATOMIE,Clear Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000050
+POTTAWATOMIE,Clear Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000050
+POTTAWATOMIE,Clear Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000050
+POTTAWATOMIE,Emmett Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000060
+POTTAWATOMIE,Emmett Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000060
+POTTAWATOMIE,Emmett Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000060
+POTTAWATOMIE,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000070
+POTTAWATOMIE,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000070
+POTTAWATOMIE,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,000070
+POTTAWATOMIE,Green Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000080
+POTTAWATOMIE,Green Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+POTTAWATOMIE,Green Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000080
+POTTAWATOMIE,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000090
+POTTAWATOMIE,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000090
+POTTAWATOMIE,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000090
+POTTAWATOMIE,Lone Tree Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000100
+POTTAWATOMIE,Lone Tree Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000100
+POTTAWATOMIE,Lone Tree Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",62,000100
+POTTAWATOMIE,Louisville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000110
+POTTAWATOMIE,Louisville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000110
+POTTAWATOMIE,Louisville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",226,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,000120
+POTTAWATOMIE,Mill Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",136,000130
+POTTAWATOMIE,Mill Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000130
+POTTAWATOMIE,Mill Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",158,000130
+POTTAWATOMIE,Pottawatomie County,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,000140
+POTTAWATOMIE,Pottawatomie County,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000140
+POTTAWATOMIE,Pottawatomie County,Governor / Lt. Governor,,Republican,"Brownback, Sam",181,000140
+POTTAWATOMIE,Rock Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",88,000150
+POTTAWATOMIE,Rock Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000150
+POTTAWATOMIE,Rock Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000150
+POTTAWATOMIE,Shannon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000160
+POTTAWATOMIE,Shannon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000160
+POTTAWATOMIE,Shannon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",73,000160
+POTTAWATOMIE,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000170
+POTTAWATOMIE,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000170
+POTTAWATOMIE,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000170
+POTTAWATOMIE,Spring Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000180
+POTTAWATOMIE,Spring Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000180
+POTTAWATOMIE,Spring Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000180
+POTTAWATOMIE,St. Clere Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000190
+POTTAWATOMIE,St. Clere Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000190
+POTTAWATOMIE,St. Clere Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000190
+POTTAWATOMIE,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000230
+POTTAWATOMIE,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000230
+POTTAWATOMIE,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000230
+POTTAWATOMIE,Vienna Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000240
+POTTAWATOMIE,Vienna Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000240
+POTTAWATOMIE,Vienna Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000240
+POTTAWATOMIE,St. George Township S1,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,120020
+POTTAWATOMIE,St. George Township S1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120020
+POTTAWATOMIE,St. George Township S1,Governor / Lt. Governor,,Republican,"Brownback, Sam",6,120020
+POTTAWATOMIE,St. George Township S17,Governor / Lt. Governor,,Democratic,"Davis, Paul",387,120030
+POTTAWATOMIE,St. George Township S17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",80,120030
+POTTAWATOMIE,St. George Township S17,Governor / Lt. Governor,,Republican,"Brownback, Sam",725,120030
+POTTAWATOMIE,Wamego East S17,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120040
+POTTAWATOMIE,Wamego East S17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120040
+POTTAWATOMIE,Wamego East S17,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120040
+POTTAWATOMIE,Wamego Township S1,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,120060
+POTTAWATOMIE,Wamego Township S1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120060
+POTTAWATOMIE,Wamego Township S1,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,120060
+POTTAWATOMIE,Wamego Township S17,Governor / Lt. Governor,,Democratic,"Davis, Paul",98,120070
+POTTAWATOMIE,Wamego Township S17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,120070
+POTTAWATOMIE,Wamego Township S17,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,120070
+POTTAWATOMIE,Wamego Township S18,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,120080
+POTTAWATOMIE,Wamego Township S18,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,120080
+POTTAWATOMIE,Wamego Township S18,Governor / Lt. Governor,,Republican,"Brownback, Sam",88,120080
+POTTAWATOMIE,Wamego West S17 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120110
+POTTAWATOMIE,Wamego West S17 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120110
+POTTAWATOMIE,Wamego West S17 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120110
+POTTAWATOMIE,St. Marys City,Governor / Lt. Governor,,Democratic,"Davis, Paul",208,130010
+POTTAWATOMIE,St. Marys City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",42,130010
+POTTAWATOMIE,St. Marys City,Governor / Lt. Governor,,Republican,"Brownback, Sam",793,130010
+POTTAWATOMIE,St. Marys Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,130020
+POTTAWATOMIE,St. Marys Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,130020
+POTTAWATOMIE,St. Marys Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",321,130020
+POTTAWATOMIE,Wamego City S18,Governor / Lt. Governor,,Democratic,"Davis, Paul",394,130030
+POTTAWATOMIE,Wamego City S18,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",72,130030
+POTTAWATOMIE,Wamego City S18,Governor / Lt. Governor,,Republican,"Brownback, Sam",495,130030
+POTTAWATOMIE,Wamego City S17,Governor / Lt. Governor,,Democratic,"Davis, Paul",168,130040
+POTTAWATOMIE,Wamego City S17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",27,130040
+POTTAWATOMIE,Wamego City S17,Governor / Lt. Governor,,Republican,"Brownback, Sam",279,130040
+POTTAWATOMIE,Wamego Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+POTTAWATOMIE,Wamego Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+POTTAWATOMIE,Wamego Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+POTTAWATOMIE,Wamego East Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+POTTAWATOMIE,Wamego East Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+POTTAWATOMIE,Wamego East Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+POTTAWATOMIE,Belvue Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",31,000010
+POTTAWATOMIE,Belvue Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",95,000010
+POTTAWATOMIE,Blue Township,Kansas House of Representatives,51,Republican,"Highland, Ron",1027,000020
+POTTAWATOMIE,Blue Valley Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",55,000030
+POTTAWATOMIE,Blue Valley Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",89,000030
+POTTAWATOMIE,Center Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",6,000040
+POTTAWATOMIE,Center Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",51,000040
+POTTAWATOMIE,Clear Creek Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",22,000050
+POTTAWATOMIE,Clear Creek Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",41,000050
+POTTAWATOMIE,Emmett Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",65,000060
+POTTAWATOMIE,Emmett Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",70,000060
+POTTAWATOMIE,Grant Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",43,000070
+POTTAWATOMIE,Grant Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",60,000070
+POTTAWATOMIE,Green Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",24,000080
+POTTAWATOMIE,Green Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",71,000080
+POTTAWATOMIE,Lincoln Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",25,000090
+POTTAWATOMIE,Lincoln Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",36,000090
+POTTAWATOMIE,Lone Tree Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",30,000100
+POTTAWATOMIE,Lone Tree Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",66,000100
+POTTAWATOMIE,Louisville Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",78,000110
+POTTAWATOMIE,Louisville Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",247,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",0,000120
+POTTAWATOMIE,Mill Creek Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",160,000130
+POTTAWATOMIE,Mill Creek Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",156,000130
+POTTAWATOMIE,Pottawatomie County,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",58,000140
+POTTAWATOMIE,Pottawatomie County,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",194,000140
+POTTAWATOMIE,Rock Creek Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",79,000150
+POTTAWATOMIE,Rock Creek Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",162,000150
+POTTAWATOMIE,Shannon Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",35,000160
+POTTAWATOMIE,Shannon Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",85,000160
+POTTAWATOMIE,Sherman Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",8,000170
+POTTAWATOMIE,Sherman Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",28,000170
+POTTAWATOMIE,Spring Creek Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",7,000180
+POTTAWATOMIE,Spring Creek Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",18,000180
+POTTAWATOMIE,St. Clere Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",11,000190
+POTTAWATOMIE,St. Clere Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",14,000190
+POTTAWATOMIE,Union Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",33,000230
+POTTAWATOMIE,Union Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",65,000230
+POTTAWATOMIE,Vienna Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",21,000240
+POTTAWATOMIE,Vienna Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",30,000240
+POTTAWATOMIE,St. George Township S1,Kansas House of Representatives,51,Republican,"Highland, Ron",10,120020
+POTTAWATOMIE,St. George Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",1019,120030
+POTTAWATOMIE,Wamego East S17,Kansas House of Representatives,51,Republican,"Highland, Ron",0,120040
+POTTAWATOMIE,Wamego Township S1,Kansas House of Representatives,51,Republican,"Highland, Ron",13,120060
+POTTAWATOMIE,Wamego Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",214,120070
+POTTAWATOMIE,Wamego Township S18,Kansas House of Representatives,51,Republican,"Highland, Ron",122,120080
+POTTAWATOMIE,Wamego West S17 A,Kansas House of Representatives,51,Republican,"Highland, Ron",0,120110
+POTTAWATOMIE,St. Marys City,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",270,130010
+POTTAWATOMIE,St. Marys City,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",763,130010
+POTTAWATOMIE,St. Marys Township,Kansas House of Representatives,61,Democratic,"Olsen, Vivien J.",79,130020
+POTTAWATOMIE,St. Marys Township,Kansas House of Representatives,61,Republican,"Hutchins, Becky J.",296,130020
+POTTAWATOMIE,Wamego City S18,Kansas House of Representatives,51,Republican,"Highland, Ron",805,130030
+POTTAWATOMIE,Wamego City S17,Kansas House of Representatives,51,Republican,"Highland, Ron",432,130040
+POTTAWATOMIE,Wamego Township Enclave,Kansas House of Representatives,51,Republican,"Highland, Ron",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Kansas House of Representatives,51,Republican,"Highland, Ron",0,900030
+POTTAWATOMIE,Wamego East Enclave,Kansas House of Representatives,51,Republican,"Highland, Ron",0,900040
+POTTAWATOMIE,Belvue Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000010
+POTTAWATOMIE,Belvue Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,000010
+POTTAWATOMIE,Blue Township,United States House of Representatives,1,Democratic,"Sherow, James E.",452,000020
+POTTAWATOMIE,Blue Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",747,000020
+POTTAWATOMIE,Blue Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",47,000030
+POTTAWATOMIE,Blue Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",98,000030
+POTTAWATOMIE,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000040
+POTTAWATOMIE,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000040
+POTTAWATOMIE,Clear Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000050
+POTTAWATOMIE,Clear Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000050
+POTTAWATOMIE,Emmett Township,United States House of Representatives,1,Democratic,"Sherow, James E.",43,000060
+POTTAWATOMIE,Emmett Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",91,000060
+POTTAWATOMIE,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",39,000070
+POTTAWATOMIE,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000070
+POTTAWATOMIE,Green Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,000080
+POTTAWATOMIE,Green Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000080
+POTTAWATOMIE,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000090
+POTTAWATOMIE,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000090
+POTTAWATOMIE,Lone Tree Township,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000100
+POTTAWATOMIE,Lone Tree Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",62,000100
+POTTAWATOMIE,Louisville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",84,000110
+POTTAWATOMIE,Louisville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",252,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000120
+POTTAWATOMIE,Mill Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",105,000130
+POTTAWATOMIE,Mill Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",207,000130
+POTTAWATOMIE,Pottawatomie County,United States House of Representatives,1,Democratic,"Sherow, James E.",62,000140
+POTTAWATOMIE,Pottawatomie County,United States House of Representatives,1,Republican,"Huelskamp, Tim",196,000140
+POTTAWATOMIE,Rock Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",81,000150
+POTTAWATOMIE,Rock Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",157,000150
+POTTAWATOMIE,Shannon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000160
+POTTAWATOMIE,Shannon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,000160
+POTTAWATOMIE,Sherman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000170
+POTTAWATOMIE,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000170
+POTTAWATOMIE,Spring Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000180
+POTTAWATOMIE,Spring Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000180
+POTTAWATOMIE,St. Clere Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000190
+POTTAWATOMIE,St. Clere Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000190
+POTTAWATOMIE,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000230
+POTTAWATOMIE,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,000230
+POTTAWATOMIE,Vienna Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000240
+POTTAWATOMIE,Vienna Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000240
+POTTAWATOMIE,St. George Township S1,United States House of Representatives,1,Democratic,"Sherow, James E.",6,120020
+POTTAWATOMIE,St. George Township S1,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,120020
+POTTAWATOMIE,St. George Township S17,United States House of Representatives,1,Democratic,"Sherow, James E.",376,120030
+POTTAWATOMIE,St. George Township S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",804,120030
+POTTAWATOMIE,Wamego East S17,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120040
+POTTAWATOMIE,Wamego East S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120040
+POTTAWATOMIE,Wamego Township S1,United States House of Representatives,1,Democratic,"Sherow, James E.",1,120060
+POTTAWATOMIE,Wamego Township S1,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,120060
+POTTAWATOMIE,Wamego Township S17,United States House of Representatives,1,Democratic,"Sherow, James E.",82,120070
+POTTAWATOMIE,Wamego Township S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",160,120070
+POTTAWATOMIE,Wamego Township S18,United States House of Representatives,1,Democratic,"Sherow, James E.",40,120080
+POTTAWATOMIE,Wamego Township S18,United States House of Representatives,1,Republican,"Huelskamp, Tim",102,120080
+POTTAWATOMIE,Wamego West S17 A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120110
+POTTAWATOMIE,Wamego West S17 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120110
+POTTAWATOMIE,St. Marys City,United States House of Representatives,1,Democratic,"Sherow, James E.",171,130010
+POTTAWATOMIE,St. Marys City,United States House of Representatives,1,Republican,"Huelskamp, Tim",858,130010
+POTTAWATOMIE,St. Marys Township,United States House of Representatives,1,Democratic,"Sherow, James E.",46,130020
+POTTAWATOMIE,St. Marys Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",331,130020
+POTTAWATOMIE,Wamego City S18,United States House of Representatives,1,Democratic,"Sherow, James E.",344,130030
+POTTAWATOMIE,Wamego City S18,United States House of Representatives,1,Republican,"Huelskamp, Tim",602,130030
+POTTAWATOMIE,Wamego City S17,United States House of Representatives,1,Democratic,"Sherow, James E.",134,130040
+POTTAWATOMIE,Wamego City S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",339,130040
+POTTAWATOMIE,Wamego Township Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+POTTAWATOMIE,Wamego Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+POTTAWATOMIE,Wamego East Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900040
+POTTAWATOMIE,Wamego East Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+POTTAWATOMIE,Belvue Township,Attorney General,,Democratic,"Kotich, A.J.",12,000010
+POTTAWATOMIE,Belvue Township,Attorney General,,Republican,"Schmidt, Derek",116,000010
+POTTAWATOMIE,Blue Township,Attorney General,,Democratic,"Kotich, A.J.",299,000020
+POTTAWATOMIE,Blue Township,Attorney General,,Republican,"Schmidt, Derek",893,000020
+POTTAWATOMIE,Blue Valley Township,Attorney General,,Democratic,"Kotich, A.J.",33,000030
+POTTAWATOMIE,Blue Valley Township,Attorney General,,Republican,"Schmidt, Derek",108,000030
+POTTAWATOMIE,Center Township,Attorney General,,Democratic,"Kotich, A.J.",1,000040
+POTTAWATOMIE,Center Township,Attorney General,,Republican,"Schmidt, Derek",55,000040
+POTTAWATOMIE,Clear Creek Township,Attorney General,,Democratic,"Kotich, A.J.",12,000050
+POTTAWATOMIE,Clear Creek Township,Attorney General,,Republican,"Schmidt, Derek",51,000050
+POTTAWATOMIE,Emmett Township,Attorney General,,Democratic,"Kotich, A.J.",41,000060
+POTTAWATOMIE,Emmett Township,Attorney General,,Republican,"Schmidt, Derek",93,000060
+POTTAWATOMIE,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",25,000070
+POTTAWATOMIE,Grant Township,Attorney General,,Republican,"Schmidt, Derek",79,000070
+POTTAWATOMIE,Green Township,Attorney General,,Democratic,"Kotich, A.J.",17,000080
+POTTAWATOMIE,Green Township,Attorney General,,Republican,"Schmidt, Derek",78,000080
+POTTAWATOMIE,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",14,000090
+POTTAWATOMIE,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",46,000090
+POTTAWATOMIE,Lone Tree Township,Attorney General,,Democratic,"Kotich, A.J.",17,000100
+POTTAWATOMIE,Lone Tree Township,Attorney General,,Republican,"Schmidt, Derek",74,000100
+POTTAWATOMIE,Louisville Township,Attorney General,,Democratic,"Kotich, A.J.",54,000110
+POTTAWATOMIE,Louisville Township,Attorney General,,Republican,"Schmidt, Derek",280,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Attorney General,,Democratic,"Kotich, A.J.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Attorney General,,Republican,"Schmidt, Derek",0,000120
+POTTAWATOMIE,Mill Creek Township,Attorney General,,Democratic,"Kotich, A.J.",83,000130
+POTTAWATOMIE,Mill Creek Township,Attorney General,,Republican,"Schmidt, Derek",233,000130
+POTTAWATOMIE,Pottawatomie County,Attorney General,,Democratic,"Kotich, A.J.",41,000140
+POTTAWATOMIE,Pottawatomie County,Attorney General,,Republican,"Schmidt, Derek",216,000140
+POTTAWATOMIE,Rock Creek Township,Attorney General,,Democratic,"Kotich, A.J.",42,000150
+POTTAWATOMIE,Rock Creek Township,Attorney General,,Republican,"Schmidt, Derek",198,000150
+POTTAWATOMIE,Shannon Township,Attorney General,,Democratic,"Kotich, A.J.",24,000160
+POTTAWATOMIE,Shannon Township,Attorney General,,Republican,"Schmidt, Derek",97,000160
+POTTAWATOMIE,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",5,000170
+POTTAWATOMIE,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",31,000170
+POTTAWATOMIE,Spring Creek Township,Attorney General,,Democratic,"Kotich, A.J.",4,000180
+POTTAWATOMIE,Spring Creek Township,Attorney General,,Republican,"Schmidt, Derek",19,000180
+POTTAWATOMIE,St. Clere Township,Attorney General,,Democratic,"Kotich, A.J.",5,000190
+POTTAWATOMIE,St. Clere Township,Attorney General,,Republican,"Schmidt, Derek",18,000190
+POTTAWATOMIE,Union Township,Attorney General,,Democratic,"Kotich, A.J.",24,000230
+POTTAWATOMIE,Union Township,Attorney General,,Republican,"Schmidt, Derek",74,000230
+POTTAWATOMIE,Vienna Township,Attorney General,,Democratic,"Kotich, A.J.",6,000240
+POTTAWATOMIE,Vienna Township,Attorney General,,Republican,"Schmidt, Derek",43,000240
+POTTAWATOMIE,St. George Township S1,Attorney General,,Democratic,"Kotich, A.J.",4,120020
+POTTAWATOMIE,St. George Township S1,Attorney General,,Republican,"Schmidt, Derek",9,120020
+POTTAWATOMIE,St. George Township S17,Attorney General,,Democratic,"Kotich, A.J.",245,120030
+POTTAWATOMIE,St. George Township S17,Attorney General,,Republican,"Schmidt, Derek",924,120030
+POTTAWATOMIE,Wamego East S17,Attorney General,,Democratic,"Kotich, A.J.",0,120040
+POTTAWATOMIE,Wamego East S17,Attorney General,,Republican,"Schmidt, Derek",0,120040
+POTTAWATOMIE,Wamego Township S1,Attorney General,,Democratic,"Kotich, A.J.",0,120060
+POTTAWATOMIE,Wamego Township S1,Attorney General,,Republican,"Schmidt, Derek",14,120060
+POTTAWATOMIE,Wamego Township S17,Attorney General,,Democratic,"Kotich, A.J.",55,120070
+POTTAWATOMIE,Wamego Township S17,Attorney General,,Republican,"Schmidt, Derek",181,120070
+POTTAWATOMIE,Wamego Township S18,Attorney General,,Democratic,"Kotich, A.J.",31,120080
+POTTAWATOMIE,Wamego Township S18,Attorney General,,Republican,"Schmidt, Derek",111,120080
+POTTAWATOMIE,Wamego West S17 A,Attorney General,,Democratic,"Kotich, A.J.",0,120110
+POTTAWATOMIE,Wamego West S17 A,Attorney General,,Republican,"Schmidt, Derek",0,120110
+POTTAWATOMIE,St. Marys City,Attorney General,,Democratic,"Kotich, A.J.",142,130010
+POTTAWATOMIE,St. Marys City,Attorney General,,Republican,"Schmidt, Derek",876,130010
+POTTAWATOMIE,St. Marys Township,Attorney General,,Democratic,"Kotich, A.J.",39,130020
+POTTAWATOMIE,St. Marys Township,Attorney General,,Republican,"Schmidt, Derek",328,130020
+POTTAWATOMIE,Wamego City S18,Attorney General,,Democratic,"Kotich, A.J.",278,130030
+POTTAWATOMIE,Wamego City S18,Attorney General,,Republican,"Schmidt, Derek",662,130030
+POTTAWATOMIE,Wamego City S17,Attorney General,,Democratic,"Kotich, A.J.",80,130040
+POTTAWATOMIE,Wamego City S17,Attorney General,,Republican,"Schmidt, Derek",383,130040
+POTTAWATOMIE,Wamego Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+POTTAWATOMIE,Wamego Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900030
+POTTAWATOMIE,Wamego East Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+POTTAWATOMIE,Wamego East Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900040
+POTTAWATOMIE,ADVANCE VOTES,Attorney General,,Democratic,"Kotich, A.J.",0,999001
+POTTAWATOMIE,ADVANCE VOTES,Attorney General,,Republican,"Schmidt, Derek",0,999001
+POTTAWATOMIE,Belvue Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000010
+POTTAWATOMIE,Belvue Township,Commissioner of Insurance,,Republican,"Selzer, Ken",105,000010
+POTTAWATOMIE,Blue Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",341,000020
+POTTAWATOMIE,Blue Township,Commissioner of Insurance,,Republican,"Selzer, Ken",824,000020
+POTTAWATOMIE,Blue Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000030
+POTTAWATOMIE,Blue Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",98,000030
+POTTAWATOMIE,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000040
+POTTAWATOMIE,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",52,000040
+POTTAWATOMIE,Clear Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000050
+POTTAWATOMIE,Clear Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000050
+POTTAWATOMIE,Emmett Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000060
+POTTAWATOMIE,Emmett Township,Commissioner of Insurance,,Republican,"Selzer, Ken",85,000060
+POTTAWATOMIE,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000070
+POTTAWATOMIE,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000070
+POTTAWATOMIE,Green Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000080
+POTTAWATOMIE,Green Township,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000080
+POTTAWATOMIE,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000090
+POTTAWATOMIE,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000090
+POTTAWATOMIE,Lone Tree Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000100
+POTTAWATOMIE,Lone Tree Township,Commissioner of Insurance,,Republican,"Selzer, Ken",71,000100
+POTTAWATOMIE,Louisville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000110
+POTTAWATOMIE,Louisville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",256,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Commissioner of Insurance,,Republican,"Selzer, Ken",0,000120
+POTTAWATOMIE,Mill Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,000130
+POTTAWATOMIE,Mill Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",214,000130
+POTTAWATOMIE,Pottawatomie County,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000140
+POTTAWATOMIE,Pottawatomie County,Commissioner of Insurance,,Republican,"Selzer, Ken",198,000140
+POTTAWATOMIE,Rock Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000150
+POTTAWATOMIE,Rock Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",171,000150
+POTTAWATOMIE,Shannon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000160
+POTTAWATOMIE,Shannon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",90,000160
+POTTAWATOMIE,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000170
+POTTAWATOMIE,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000170
+POTTAWATOMIE,Spring Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000180
+POTTAWATOMIE,Spring Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000180
+POTTAWATOMIE,St. Clere Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000190
+POTTAWATOMIE,St. Clere Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000190
+POTTAWATOMIE,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000230
+POTTAWATOMIE,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000230
+POTTAWATOMIE,Vienna Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000240
+POTTAWATOMIE,Vienna Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000240
+POTTAWATOMIE,St. George Township S1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,120020
+POTTAWATOMIE,St. George Township S1,Commissioner of Insurance,,Republican,"Selzer, Ken",9,120020
+POTTAWATOMIE,St. George Township S17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",280,120030
+POTTAWATOMIE,St. George Township S17,Commissioner of Insurance,,Republican,"Selzer, Ken",868,120030
+POTTAWATOMIE,Wamego East S17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120040
+POTTAWATOMIE,Wamego East S17,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120040
+POTTAWATOMIE,Wamego Township S1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120060
+POTTAWATOMIE,Wamego Township S1,Commissioner of Insurance,,Republican,"Selzer, Ken",14,120060
+POTTAWATOMIE,Wamego Township S17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",64,120070
+POTTAWATOMIE,Wamego Township S17,Commissioner of Insurance,,Republican,"Selzer, Ken",173,120070
+POTTAWATOMIE,Wamego Township S18,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,120080
+POTTAWATOMIE,Wamego Township S18,Commissioner of Insurance,,Republican,"Selzer, Ken",100,120080
+POTTAWATOMIE,Wamego West S17 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120110
+POTTAWATOMIE,Wamego West S17 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120110
+POTTAWATOMIE,St. Marys City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",154,130010
+POTTAWATOMIE,St. Marys City,Commissioner of Insurance,,Republican,"Selzer, Ken",846,130010
+POTTAWATOMIE,St. Marys Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,130020
+POTTAWATOMIE,St. Marys Township,Commissioner of Insurance,,Republican,"Selzer, Ken",331,130020
+POTTAWATOMIE,Wamego City S18,Commissioner of Insurance,,Democratic,"Anderson, Dennis",306,130030
+POTTAWATOMIE,Wamego City S18,Commissioner of Insurance,,Republican,"Selzer, Ken",613,130030
+POTTAWATOMIE,Wamego City S17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",105,130040
+POTTAWATOMIE,Wamego City S17,Commissioner of Insurance,,Republican,"Selzer, Ken",354,130040
+POTTAWATOMIE,Wamego Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+POTTAWATOMIE,Wamego Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+POTTAWATOMIE,Wamego East Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+POTTAWATOMIE,Wamego East Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+POTTAWATOMIE,Belvue Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000010
+POTTAWATOMIE,Belvue Township,Secretary of State,,Republican,"Kobach, Kris",111,000010
+POTTAWATOMIE,Blue Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",376,000020
+POTTAWATOMIE,Blue Township,Secretary of State,,Republican,"Kobach, Kris",823,000020
+POTTAWATOMIE,Blue Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000030
+POTTAWATOMIE,Blue Valley Township,Secretary of State,,Republican,"Kobach, Kris",107,000030
+POTTAWATOMIE,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000040
+POTTAWATOMIE,Center Township,Secretary of State,,Republican,"Kobach, Kris",56,000040
+POTTAWATOMIE,Clear Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000050
+POTTAWATOMIE,Clear Creek Township,Secretary of State,,Republican,"Kobach, Kris",42,000050
+POTTAWATOMIE,Emmett Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000060
+POTTAWATOMIE,Emmett Township,Secretary of State,,Republican,"Kobach, Kris",93,000060
+POTTAWATOMIE,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000070
+POTTAWATOMIE,Grant Township,Secretary of State,,Republican,"Kobach, Kris",75,000070
+POTTAWATOMIE,Green Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000080
+POTTAWATOMIE,Green Township,Secretary of State,,Republican,"Kobach, Kris",72,000080
+POTTAWATOMIE,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000090
+POTTAWATOMIE,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",41,000090
+POTTAWATOMIE,Lone Tree Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000100
+POTTAWATOMIE,Lone Tree Township,Secretary of State,,Republican,"Kobach, Kris",68,000100
+POTTAWATOMIE,Louisville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,000110
+POTTAWATOMIE,Louisville Township,Secretary of State,,Republican,"Kobach, Kris",266,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Secretary of State,,Republican,"Kobach, Kris",0,000120
+POTTAWATOMIE,Mill Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",88,000130
+POTTAWATOMIE,Mill Creek Township,Secretary of State,,Republican,"Kobach, Kris",230,000130
+POTTAWATOMIE,Pottawatomie County,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,000140
+POTTAWATOMIE,Pottawatomie County,Secretary of State,,Republican,"Kobach, Kris",208,000140
+POTTAWATOMIE,Rock Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000150
+POTTAWATOMIE,Rock Creek Township,Secretary of State,,Republican,"Kobach, Kris",185,000150
+POTTAWATOMIE,Shannon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000160
+POTTAWATOMIE,Shannon Township,Secretary of State,,Republican,"Kobach, Kris",94,000160
+POTTAWATOMIE,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000170
+POTTAWATOMIE,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",33,000170
+POTTAWATOMIE,Spring Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000180
+POTTAWATOMIE,Spring Creek Township,Secretary of State,,Republican,"Kobach, Kris",17,000180
+POTTAWATOMIE,St. Clere Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000190
+POTTAWATOMIE,St. Clere Township,Secretary of State,,Republican,"Kobach, Kris",17,000190
+POTTAWATOMIE,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000230
+POTTAWATOMIE,Union Township,Secretary of State,,Republican,"Kobach, Kris",69,000230
+POTTAWATOMIE,Vienna Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000240
+POTTAWATOMIE,Vienna Township,Secretary of State,,Republican,"Kobach, Kris",38,000240
+POTTAWATOMIE,St. George Township S1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,120020
+POTTAWATOMIE,St. George Township S1,Secretary of State,,Republican,"Kobach, Kris",8,120020
+POTTAWATOMIE,St. George Township S17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",298,120030
+POTTAWATOMIE,St. George Township S17,Secretary of State,,Republican,"Kobach, Kris",884,120030
+POTTAWATOMIE,Wamego East S17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120040
+POTTAWATOMIE,Wamego East S17,Secretary of State,,Republican,"Kobach, Kris",0,120040
+POTTAWATOMIE,Wamego Township S1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,120060
+POTTAWATOMIE,Wamego Township S1,Secretary of State,,Republican,"Kobach, Kris",13,120060
+POTTAWATOMIE,Wamego Township S17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,120070
+POTTAWATOMIE,Wamego Township S17,Secretary of State,,Republican,"Kobach, Kris",179,120070
+POTTAWATOMIE,Wamego Township S18,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,120080
+POTTAWATOMIE,Wamego Township S18,Secretary of State,,Republican,"Kobach, Kris",108,120080
+POTTAWATOMIE,Wamego West S17 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120110
+POTTAWATOMIE,Wamego West S17 A,Secretary of State,,Republican,"Kobach, Kris",0,120110
+POTTAWATOMIE,St. Marys City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",163,130010
+POTTAWATOMIE,St. Marys City,Secretary of State,,Republican,"Kobach, Kris",873,130010
+POTTAWATOMIE,St. Marys Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,130020
+POTTAWATOMIE,St. Marys Township,Secretary of State,,Republican,"Kobach, Kris",333,130020
+POTTAWATOMIE,Wamego City S18,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",315,130030
+POTTAWATOMIE,Wamego City S18,Secretary of State,,Republican,"Kobach, Kris",638,130030
+POTTAWATOMIE,Wamego City S17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,130040
+POTTAWATOMIE,Wamego City S17,Secretary of State,,Republican,"Kobach, Kris",370,130040
+POTTAWATOMIE,Wamego Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+POTTAWATOMIE,Wamego Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900030
+POTTAWATOMIE,Wamego East Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+POTTAWATOMIE,Wamego East Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900040
+POTTAWATOMIE,Belvue Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000010
+POTTAWATOMIE,Belvue Township,State Treasurer,,Republican,"Estes, Ron",110,000010
+POTTAWATOMIE,Blue Township,State Treasurer,,Democratic,"Alldritt, Carmen",304,000020
+POTTAWATOMIE,Blue Township,State Treasurer,,Republican,"Estes, Ron",875,000020
+POTTAWATOMIE,Blue Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000030
+POTTAWATOMIE,Blue Valley Township,State Treasurer,,Republican,"Estes, Ron",104,000030
+POTTAWATOMIE,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+POTTAWATOMIE,Center Township,State Treasurer,,Republican,"Estes, Ron",58,000040
+POTTAWATOMIE,Clear Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000050
+POTTAWATOMIE,Clear Creek Township,State Treasurer,,Republican,"Estes, Ron",46,000050
+POTTAWATOMIE,Emmett Township,State Treasurer,,Democratic,"Alldritt, Carmen",42,000060
+POTTAWATOMIE,Emmett Township,State Treasurer,,Republican,"Estes, Ron",93,000060
+POTTAWATOMIE,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000070
+POTTAWATOMIE,Grant Township,State Treasurer,,Republican,"Estes, Ron",74,000070
+POTTAWATOMIE,Green Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000080
+POTTAWATOMIE,Green Township,State Treasurer,,Republican,"Estes, Ron",77,000080
+POTTAWATOMIE,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000090
+POTTAWATOMIE,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",46,000090
+POTTAWATOMIE,Lone Tree Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000100
+POTTAWATOMIE,Lone Tree Township,State Treasurer,,Republican,"Estes, Ron",74,000100
+POTTAWATOMIE,Louisville Township,State Treasurer,,Democratic,"Alldritt, Carmen",54,000110
+POTTAWATOMIE,Louisville Township,State Treasurer,,Republican,"Estes, Ron",278,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,State Treasurer,,Democratic,"Alldritt, Carmen",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,State Treasurer,,Republican,"Estes, Ron",0,000120
+POTTAWATOMIE,Mill Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",81,000130
+POTTAWATOMIE,Mill Creek Township,State Treasurer,,Republican,"Estes, Ron",233,000130
+POTTAWATOMIE,Pottawatomie County,State Treasurer,,Democratic,"Alldritt, Carmen",41,000140
+POTTAWATOMIE,Pottawatomie County,State Treasurer,,Republican,"Estes, Ron",215,000140
+POTTAWATOMIE,Rock Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",49,000150
+POTTAWATOMIE,Rock Creek Township,State Treasurer,,Republican,"Estes, Ron",188,000150
+POTTAWATOMIE,Shannon Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000160
+POTTAWATOMIE,Shannon Township,State Treasurer,,Republican,"Estes, Ron",94,000160
+POTTAWATOMIE,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000170
+POTTAWATOMIE,Sherman Township,State Treasurer,,Republican,"Estes, Ron",29,000170
+POTTAWATOMIE,Spring Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000180
+POTTAWATOMIE,Spring Creek Township,State Treasurer,,Republican,"Estes, Ron",20,000180
+POTTAWATOMIE,St. Clere Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000190
+POTTAWATOMIE,St. Clere Township,State Treasurer,,Republican,"Estes, Ron",18,000190
+POTTAWATOMIE,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000230
+POTTAWATOMIE,Union Township,State Treasurer,,Republican,"Estes, Ron",74,000230
+POTTAWATOMIE,Vienna Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000240
+POTTAWATOMIE,Vienna Township,State Treasurer,,Republican,"Estes, Ron",42,000240
+POTTAWATOMIE,St. George Township S1,State Treasurer,,Democratic,"Alldritt, Carmen",4,120020
+POTTAWATOMIE,St. George Township S1,State Treasurer,,Republican,"Estes, Ron",10,120020
+POTTAWATOMIE,St. George Township S17,State Treasurer,,Democratic,"Alldritt, Carmen",237,120030
+POTTAWATOMIE,St. George Township S17,State Treasurer,,Republican,"Estes, Ron",929,120030
+POTTAWATOMIE,Wamego East S17,State Treasurer,,Democratic,"Alldritt, Carmen",0,120040
+POTTAWATOMIE,Wamego East S17,State Treasurer,,Republican,"Estes, Ron",0,120040
+POTTAWATOMIE,Wamego Township S1,State Treasurer,,Democratic,"Alldritt, Carmen",0,120060
+POTTAWATOMIE,Wamego Township S1,State Treasurer,,Republican,"Estes, Ron",14,120060
+POTTAWATOMIE,Wamego Township S17,State Treasurer,,Democratic,"Alldritt, Carmen",52,120070
+POTTAWATOMIE,Wamego Township S17,State Treasurer,,Republican,"Estes, Ron",187,120070
+POTTAWATOMIE,Wamego Township S18,State Treasurer,,Democratic,"Alldritt, Carmen",30,120080
+POTTAWATOMIE,Wamego Township S18,State Treasurer,,Republican,"Estes, Ron",109,120080
+POTTAWATOMIE,Wamego West S17 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,120110
+POTTAWATOMIE,Wamego West S17 A,State Treasurer,,Republican,"Estes, Ron",0,120110
+POTTAWATOMIE,St. Marys City,State Treasurer,,Democratic,"Alldritt, Carmen",140,130010
+POTTAWATOMIE,St. Marys City,State Treasurer,,Republican,"Estes, Ron",874,130010
+POTTAWATOMIE,St. Marys Township,State Treasurer,,Democratic,"Alldritt, Carmen",34,130020
+POTTAWATOMIE,St. Marys Township,State Treasurer,,Republican,"Estes, Ron",337,130020
+POTTAWATOMIE,Wamego City S18,State Treasurer,,Democratic,"Alldritt, Carmen",277,130030
+POTTAWATOMIE,Wamego City S18,State Treasurer,,Republican,"Estes, Ron",662,130030
+POTTAWATOMIE,Wamego City S17,State Treasurer,,Democratic,"Alldritt, Carmen",79,130040
+POTTAWATOMIE,Wamego City S17,State Treasurer,,Republican,"Estes, Ron",391,130040
+POTTAWATOMIE,Wamego Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+POTTAWATOMIE,Wamego Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900030
+POTTAWATOMIE,Wamego East Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+POTTAWATOMIE,Wamego East Enclave,State Treasurer,,Republican,"Estes, Ron",0,900040
+POTTAWATOMIE,Belvue Township,United States Senate,,independent,"Orman, Greg",25,000010
+POTTAWATOMIE,Belvue Township,United States Senate,,Libertarian,"Batson, Randall",10,000010
+POTTAWATOMIE,Belvue Township,United States Senate,,Republican,"Roberts, Pat",97,000010
+POTTAWATOMIE,Blue Township,United States Senate,,independent,"Orman, Greg",432,000020
+POTTAWATOMIE,Blue Township,United States Senate,,Libertarian,"Batson, Randall",49,000020
+POTTAWATOMIE,Blue Township,United States Senate,,Republican,"Roberts, Pat",730,000020
+POTTAWATOMIE,Blue Valley Township,United States Senate,,independent,"Orman, Greg",50,000030
+POTTAWATOMIE,Blue Valley Township,United States Senate,,Libertarian,"Batson, Randall",2,000030
+POTTAWATOMIE,Blue Valley Township,United States Senate,,Republican,"Roberts, Pat",96,000030
+POTTAWATOMIE,Center Township,United States Senate,,independent,"Orman, Greg",5,000040
+POTTAWATOMIE,Center Township,United States Senate,,Libertarian,"Batson, Randall",2,000040
+POTTAWATOMIE,Center Township,United States Senate,,Republican,"Roberts, Pat",51,000040
+POTTAWATOMIE,Clear Creek Township,United States Senate,,independent,"Orman, Greg",21,000050
+POTTAWATOMIE,Clear Creek Township,United States Senate,,Libertarian,"Batson, Randall",2,000050
+POTTAWATOMIE,Clear Creek Township,United States Senate,,Republican,"Roberts, Pat",38,000050
+POTTAWATOMIE,Emmett Township,United States Senate,,independent,"Orman, Greg",42,000060
+POTTAWATOMIE,Emmett Township,United States Senate,,Libertarian,"Batson, Randall",7,000060
+POTTAWATOMIE,Emmett Township,United States Senate,,Republican,"Roberts, Pat",86,000060
+POTTAWATOMIE,Grant Township,United States Senate,,independent,"Orman, Greg",43,000070
+POTTAWATOMIE,Grant Township,United States Senate,,Libertarian,"Batson, Randall",5,000070
+POTTAWATOMIE,Grant Township,United States Senate,,Republican,"Roberts, Pat",57,000070
+POTTAWATOMIE,Green Township,United States Senate,,independent,"Orman, Greg",23,000080
+POTTAWATOMIE,Green Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+POTTAWATOMIE,Green Township,United States Senate,,Republican,"Roberts, Pat",73,000080
+POTTAWATOMIE,Lincoln Township,United States Senate,,independent,"Orman, Greg",19,000090
+POTTAWATOMIE,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+POTTAWATOMIE,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",43,000090
+POTTAWATOMIE,Lone Tree Township,United States Senate,,independent,"Orman, Greg",28,000100
+POTTAWATOMIE,Lone Tree Township,United States Senate,,Libertarian,"Batson, Randall",5,000100
+POTTAWATOMIE,Lone Tree Township,United States Senate,,Republican,"Roberts, Pat",64,000100
+POTTAWATOMIE,Louisville Township,United States Senate,,independent,"Orman, Greg",75,000110
+POTTAWATOMIE,Louisville Township,United States Senate,,Libertarian,"Batson, Randall",17,000110
+POTTAWATOMIE,Louisville Township,United States Senate,,Republican,"Roberts, Pat",250,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States Senate,,independent,"Orman, Greg",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States Senate,,Libertarian,"Batson, Randall",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States Senate,,Republican,"Roberts, Pat",0,000120
+POTTAWATOMIE,Mill Creek Township,United States Senate,,independent,"Orman, Greg",122,000130
+POTTAWATOMIE,Mill Creek Township,United States Senate,,Libertarian,"Batson, Randall",19,000130
+POTTAWATOMIE,Mill Creek Township,United States Senate,,Republican,"Roberts, Pat",178,000130
+POTTAWATOMIE,Pottawatomie County,United States Senate,,independent,"Orman, Greg",72,000140
+POTTAWATOMIE,Pottawatomie County,United States Senate,,Libertarian,"Batson, Randall",3,000140
+POTTAWATOMIE,Pottawatomie County,United States Senate,,Republican,"Roberts, Pat",191,000140
+POTTAWATOMIE,Rock Creek Township,United States Senate,,independent,"Orman, Greg",85,000150
+POTTAWATOMIE,Rock Creek Township,United States Senate,,Libertarian,"Batson, Randall",19,000150
+POTTAWATOMIE,Rock Creek Township,United States Senate,,Republican,"Roberts, Pat",139,000150
+POTTAWATOMIE,Shannon Township,United States Senate,,independent,"Orman, Greg",39,000160
+POTTAWATOMIE,Shannon Township,United States Senate,,Libertarian,"Batson, Randall",5,000160
+POTTAWATOMIE,Shannon Township,United States Senate,,Republican,"Roberts, Pat",80,000160
+POTTAWATOMIE,Sherman Township,United States Senate,,independent,"Orman, Greg",10,000170
+POTTAWATOMIE,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",0,000170
+POTTAWATOMIE,Sherman Township,United States Senate,,Republican,"Roberts, Pat",27,000170
+POTTAWATOMIE,Spring Creek Township,United States Senate,,independent,"Orman, Greg",9,000180
+POTTAWATOMIE,Spring Creek Township,United States Senate,,Libertarian,"Batson, Randall",1,000180
+POTTAWATOMIE,Spring Creek Township,United States Senate,,Republican,"Roberts, Pat",16,000180
+POTTAWATOMIE,St. Clere Township,United States Senate,,independent,"Orman, Greg",6,000190
+POTTAWATOMIE,St. Clere Township,United States Senate,,Libertarian,"Batson, Randall",2,000190
+POTTAWATOMIE,St. Clere Township,United States Senate,,Republican,"Roberts, Pat",17,000190
+POTTAWATOMIE,Union Township,United States Senate,,independent,"Orman, Greg",34,000230
+POTTAWATOMIE,Union Township,United States Senate,,Libertarian,"Batson, Randall",6,000230
+POTTAWATOMIE,Union Township,United States Senate,,Republican,"Roberts, Pat",59,000230
+POTTAWATOMIE,Vienna Township,United States Senate,,independent,"Orman, Greg",10,000240
+POTTAWATOMIE,Vienna Township,United States Senate,,Libertarian,"Batson, Randall",3,000240
+POTTAWATOMIE,Vienna Township,United States Senate,,Republican,"Roberts, Pat",38,000240
+POTTAWATOMIE,St. George Township S1,United States Senate,,independent,"Orman, Greg",8,120020
+POTTAWATOMIE,St. George Township S1,United States Senate,,Libertarian,"Batson, Randall",0,120020
+POTTAWATOMIE,St. George Township S1,United States Senate,,Republican,"Roberts, Pat",6,120020
+POTTAWATOMIE,St. George Township S17,United States Senate,,independent,"Orman, Greg",345,120030
+POTTAWATOMIE,St. George Township S17,United States Senate,,Libertarian,"Batson, Randall",53,120030
+POTTAWATOMIE,St. George Township S17,United States Senate,,Republican,"Roberts, Pat",795,120030
+POTTAWATOMIE,Wamego East S17,United States Senate,,independent,"Orman, Greg",0,120040
+POTTAWATOMIE,Wamego East S17,United States Senate,,Libertarian,"Batson, Randall",0,120040
+POTTAWATOMIE,Wamego East S17,United States Senate,,Republican,"Roberts, Pat",0,120040
+POTTAWATOMIE,Wamego Township S1,United States Senate,,independent,"Orman, Greg",1,120060
+POTTAWATOMIE,Wamego Township S1,United States Senate,,Libertarian,"Batson, Randall",0,120060
+POTTAWATOMIE,Wamego Township S1,United States Senate,,Republican,"Roberts, Pat",13,120060
+POTTAWATOMIE,Wamego Township S17,United States Senate,,independent,"Orman, Greg",81,120070
+POTTAWATOMIE,Wamego Township S17,United States Senate,,Libertarian,"Batson, Randall",8,120070
+POTTAWATOMIE,Wamego Township S17,United States Senate,,Republican,"Roberts, Pat",152,120070
+POTTAWATOMIE,Wamego Township S18,United States Senate,,independent,"Orman, Greg",40,120080
+POTTAWATOMIE,Wamego Township S18,United States Senate,,Libertarian,"Batson, Randall",8,120080
+POTTAWATOMIE,Wamego Township S18,United States Senate,,Republican,"Roberts, Pat",98,120080
+POTTAWATOMIE,Wamego West S17 A,United States Senate,,independent,"Orman, Greg",0,120110
+POTTAWATOMIE,Wamego West S17 A,United States Senate,,Libertarian,"Batson, Randall",0,120110
+POTTAWATOMIE,Wamego West S17 A,United States Senate,,Republican,"Roberts, Pat",0,120110
+POTTAWATOMIE,St. Marys City,United States Senate,,independent,"Orman, Greg",175,130010
+POTTAWATOMIE,St. Marys City,United States Senate,,Libertarian,"Batson, Randall",34,130010
+POTTAWATOMIE,St. Marys City,United States Senate,,Republican,"Roberts, Pat",827,130010
+POTTAWATOMIE,St. Marys Township,United States Senate,,independent,"Orman, Greg",44,130020
+POTTAWATOMIE,St. Marys Township,United States Senate,,Libertarian,"Batson, Randall",11,130020
+POTTAWATOMIE,St. Marys Township,United States Senate,,Republican,"Roberts, Pat",322,130020
+POTTAWATOMIE,Wamego City S18,United States Senate,,independent,"Orman, Greg",357,130030
+POTTAWATOMIE,Wamego City S18,United States Senate,,Libertarian,"Batson, Randall",59,130030
+POTTAWATOMIE,Wamego City S18,United States Senate,,Republican,"Roberts, Pat",543,130030
+POTTAWATOMIE,Wamego City S17,United States Senate,,independent,"Orman, Greg",137,130040
+POTTAWATOMIE,Wamego City S17,United States Senate,,Libertarian,"Batson, Randall",16,130040
+POTTAWATOMIE,Wamego City S17,United States Senate,,Republican,"Roberts, Pat",322,130040
+POTTAWATOMIE,Wamego Township Enclave,United States Senate,,independent,"Orman, Greg",0,900010
+POTTAWATOMIE,Wamego Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+POTTAWATOMIE,Wamego Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,United States Senate,,independent,"Orman, Greg",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900030
+POTTAWATOMIE,Wamego East Enclave,United States Senate,,independent,"Orman, Greg",0,900040
+POTTAWATOMIE,Wamego East Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900040
+POTTAWATOMIE,Wamego East Enclave,United States Senate,,Republican,"Roberts, Pat",0,900040

--- a/2014/20141104__ks__general__pratt__precinct.csv
+++ b/2014/20141104__ks__general__pratt__precinct.csv
@@ -1,205 +1,290 @@
-county,precinct,office,district,party,candidate,poll
-Pratt,WARD 1,U.S. Senate,,R,Pat Roberts,237
-Pratt,WARD 2,U.S. Senate,,R,Pat Roberts,143
-Pratt,WARD 3,U.S. Senate,,R,Pat Roberts,335
-Pratt,WARD 4,U.S. Senate,,R,Pat Roberts,241
-Pratt,WARD 5,U.S. Senate,,R,Pat Roberts,249
-Pratt,TWP 6,U.S. Senate,,R,Pat Roberts,134
-Pratt,TWP 7,U.S. Senate,,R,Pat Roberts,80
-Pratt,TWP 8,U.S. Senate,,R,Pat Roberts,31
-Pratt,TWP 9,U.S. Senate,,R,Pat Roberts,83
-Pratt,TWP 10,U.S. Senate,,R,Pat Roberts,45
-Pratt,TWP 11,U.S. Senate,,R,Pat Roberts,82
-Pratt,TWP 12,U.S. Senate,,R,Pat Roberts,308
-Pratt,WARD 1,U.S. Senate,,I,Greg Orman,135
-Pratt,WARD 2,U.S. Senate,,I,Greg Orman,73
-Pratt,WARD 3,U.S. Senate,,I,Greg Orman,212
-Pratt,WARD 4,U.S. Senate,,I,Greg Orman,169
-Pratt,WARD 5,U.S. Senate,,I,Greg Orman,130
-Pratt,TWP 6,U.S. Senate,,I,Greg Orman,56
-Pratt,TWP 7,U.S. Senate,,I,Greg Orman,32
-Pratt,TWP 8,U.S. Senate,,I,Greg Orman,17
-Pratt,TWP 9,U.S. Senate,,I,Greg Orman,20
-Pratt,TWP 10,U.S. Senate,,I,Greg Orman,13
-Pratt,TWP 11,U.S. Senate,,I,Greg Orman,21
-Pratt,TWP 12,U.S. Senate,,I,Greg Orman,128
-Pratt,WARD 1,U.S. Senate,,L,Randall Batson,22
-Pratt,WARD 2,U.S. Senate,,L,Randall Batson,13
-Pratt,WARD 3,U.S. Senate,,L,Randall Batson,23
-Pratt,WARD 4,U.S. Senate,,L,Randall Batson,30
-Pratt,WARD 5,U.S. Senate,,L,Randall Batson,23
-Pratt,TWP 6,U.S. Senate,,L,Randall Batson,11
-Pratt,TWP 7,U.S. Senate,,L,Randall Batson,2
-Pratt,TWP 8,U.S. Senate,,L,Randall Batson,0
-Pratt,TWP 9,U.S. Senate,,L,Randall Batson,5
-Pratt,TWP 10,U.S. Senate,,L,Randall Batson,1
-Pratt,TWP 11,U.S. Senate,,L,Randall Batson,5
-Pratt,TWP 12,U.S. Senate,,L,Randall Batson,17
-Pratt,WARD 1,U.S. House,4,D,Perry Schuckman,87
-Pratt,WARD 2,U.S. House,4,D,Perry Schuckman,62
-Pratt,WARD 3,U.S. House,4,D,Perry Schuckman,131
-Pratt,WARD 4,U.S. House,4,D,Perry Schuckman,134
-Pratt,WARD 5,U.S. House,4,D,Perry Schuckman,80
-Pratt,TWP 6,U.S. House,4,D,Perry Schuckman,47
-Pratt,TWP 7,U.S. House,4,D,Perry Schuckman,27
-Pratt,TWP 8,U.S. House,4,D,Perry Schuckman,9
-Pratt,TWP 9,U.S. House,4,D,Perry Schuckman,19
-Pratt,TWP 10,U.S. House,4,D,Perry Schuckman,11
-Pratt,TWP 11,U.S. House,4,D,Perry Schuckman,21
-Pratt,TWP 12,U.S. House,4,D,Perry Schuckman,87
-Pratt,WARD 1,U.S. House,4,R,Mike Pompeo,297
-Pratt,WARD 2,U.S. House,4,R,Mike Pompeo,166
-Pratt,WARD 3,U.S. House,4,R,Mike Pompeo,435
-Pratt,WARD 4,U.S. House,4,R,Mike Pompeo,297
-Pratt,WARD 5,U.S. House,4,R,Mike Pompeo,316
-Pratt,TWP 6,U.S. House,4,R,Mike Pompeo,148
-Pratt,TWP 7,U.S. House,4,R,Mike Pompeo,84
-Pratt,TWP 8,U.S. House,4,R,Mike Pompeo,38
-Pratt,TWP 9,U.S. House,4,R,Mike Pompeo,89
-Pratt,TWP 10,U.S. House,4,R,Mike Pompeo,45
-Pratt,TWP 11,U.S. House,4,R,Mike Pompeo,86
-Pratt,TWP 12,U.S. House,4,R,Mike Pompeo,362
-Pratt,WARD 1,Governor,,R,Sam Brownback,212
-Pratt,WARD 2,Governor,,R,Sam Brownback,131
-Pratt,WARD 3,Governor,,R,Sam Brownback,265
-Pratt,WARD 4,Governor,,R,Sam Brownback,218
-Pratt,WARD 5,Governor,,R,Sam Brownback,224
-Pratt,TWP 6,Governor,,R,Sam Brownback,125
-Pratt,TWP 7,Governor,,R,Sam Brownback,68
-Pratt,TWP 8,Governor,,R,Sam Brownback,27
-Pratt,TWP 9,Governor,,R,Sam Brownback,75
-Pratt,TWP 10,Governor,,R,Sam Brownback,41
-Pratt,TWP 11,Governor,,R,Sam Brownback,75
-Pratt,TWP 12,Governor,,R,Sam Brownback,258
-Pratt,WARD 1,Governor,,D,Paul Davis,165
-Pratt,WARD 2,Governor,,D,Paul Davis,90
-Pratt,WARD 3,Governor,,D,Paul Davis,287
-Pratt,WARD 4,Governor,,D,Paul Davis,203
-Pratt,WARD 5,Governor,,D,Paul Davis,164
-Pratt,TWP 6,Governor,,D,Paul Davis,70
-Pratt,TWP 7,Governor,,D,Paul Davis,39
-Pratt,TWP 8,Governor,,D,Paul Davis,20
-Pratt,TWP 9,Governor,,D,Paul Davis,30
-Pratt,TWP 10,Governor,,D,Paul Davis,16
-Pratt,TWP 11,Governor,,D,Paul Davis,29
-Pratt,TWP 12,Governor,,D,Paul Davis,185
-Pratt,WARD 1,Governor,,L,Keen Umbehr,20
-Pratt,WARD 2,Governor,,L,Keen Umbehr,12
-Pratt,WARD 3,Governor,,L,Keen Umbehr,26
-Pratt,WARD 4,Governor,,L,Keen Umbehr,21
-Pratt,WARD 5,Governor,,L,Keen Umbehr,17
-Pratt,TWP 6,Governor,,L,Keen Umbehr,7
-Pratt,TWP 7,Governor,,L,Keen Umbehr,7
-Pratt,TWP 8,Governor,,L,Keen Umbehr,0
-Pratt,TWP 9,Governor,,L,Keen Umbehr,3
-Pratt,TWP 10,Governor,,L,Keen Umbehr,2
-Pratt,TWP 11,Governor,,L,Keen Umbehr,5
-Pratt,TWP 12,Governor,,L,Keen Umbehr,13
-Pratt,WARD 1,Secretary of  State,,D,Jean Schodorf,126
-Pratt,WARD 2,Secretary of  State,,D,Jean Schodorf,74
-Pratt,WARD 3,Secretary of  State,,D,Jean Schodorf,193
-Pratt,WARD 4,Secretary of  State,,D,Jean Schodorf,169
-Pratt,WARD 5,Secretary of  State,,D,Jean Schodorf,129
-Pratt,TWP 6,Secretary of  State,,D,Jean Schodorf,60
-Pratt,TWP 7,Secretary of  State,,D,Jean Schodorf,34
-Pratt,TWP 8,Secretary of  State,,D,Jean Schodorf,29
-Pratt,TWP 9,Secretary of  State,,D,Jean Schodorf,22
-Pratt,TWP 10,Secretary of  State,,D,Jean Schodorf,13
-Pratt,TWP 11,Secretary of  State,,D,Jean Schodorf,22
-Pratt,TWP 12,Secretary of  State,,D,Jean Schodorf,134
-Pratt,WARD 1,Secretary of  State,,R,Kris Kobach,265
-Pratt,WARD 2,Secretary of  State,,R,Kris Kobach,154
-Pratt,WARD 3,Secretary of  State,,R,Kris Kobach,366
-Pratt,WARD 4,Secretary of  State,,R,Kris Kobach,265
-Pratt,WARD 5,Secretary of  State,,R,Kris Kobach,267
-Pratt,TWP 6,Secretary of  State,,R,Kris Kobach,141
-Pratt,TWP 7,Secretary of  State,,R,Kris Kobach,77
-Pratt,TWP 8,Secretary of  State,,R,Kris Kobach,27
-Pratt,TWP 9,Secretary of  State,,R,Kris Kobach,85
-Pratt,TWP 10,Secretary of  State,,R,Kris Kobach,45
-Pratt,TWP 11,Secretary of  State,,R,Kris Kobach,84
-Pratt,TWP 12,Secretary of  State,,R,Kris Kobach,314
-Pratt,WARD 1,Attorney General,,R,Derek Schmidt,310
-Pratt,WARD 2,Attorney General,,R,Derek Schmidt,174
-Pratt,WARD 3,Attorney General,,R,Derek Schmidt,440
-Pratt,WARD 4,Attorney General,,R,Derek Schmidt,329
-Pratt,WARD 5,Attorney General,,R,Derek Schmidt,322
-Pratt,TWP 6,Attorney General,,R,Derek Schmidt,162
-Pratt,TWP 7,Attorney General,,R,Derek Schmidt,91
-Pratt,TWP 8,Attorney General,,R,Derek Schmidt,41
-Pratt,TWP 9,Attorney General,,R,Derek Schmidt,88
-Pratt,TWP 10,Attorney General,,R,Derek Schmidt,48
-Pratt,TWP 11,Attorney General,,R,Derek Schmidt,89
-Pratt,TWP 12,Attorney General,,R,Derek Schmidt,369
-Pratt,WARD 1,Attorney General,,D,AJ Kotich,76
-Pratt,WARD 2,Attorney General,,D,AJ Kotich,52
-Pratt,WARD 3,Attorney General,,D,AJ Kotich,112
-Pratt,WARD 4,Attorney General,,D,AJ Kotich,103
-Pratt,WARD 5,Attorney General,,D,AJ Kotich,67
-Pratt,TWP 6,Attorney General,,D,AJ Kotich,35
-Pratt,TWP 7,Attorney General,,D,AJ Kotich,18
-Pratt,TWP 8,Attorney General,,D,AJ Kotich,4
-Pratt,TWP 9,Attorney General,,D,AJ Kotich,17
-Pratt,TWP 10,Attorney General,,D,AJ Kotich,8
-Pratt,TWP 11,Attorney General,,D,AJ Kotich,16
-Pratt,TWP 12,Attorney General,,D,AJ Kotich,69
-Pratt,WARD 1,State Treasurer,,R,Ron Estes,311
-Pratt,WARD 2,State Treasurer,,R,Ron Estes,170
-Pratt,WARD 3,State Treasurer,,R,Ron Estes,444
-Pratt,WARD 4,State Treasurer,,R,Ron Estes,317
-Pratt,WARD 5,State Treasurer,,R,Ron Estes,322
-Pratt,TWP 6,State Treasurer,,R,Ron Estes,163
-Pratt,TWP 7,State Treasurer,,R,Ron Estes,89
-Pratt,TWP 8,State Treasurer,,R,Ron Estes,43
-Pratt,TWP 9,State Treasurer,,R,Ron Estes,90
-Pratt,TWP 10,State Treasurer,,R,Ron Estes,51
-Pratt,TWP 11,State Treasurer,,R,Ron Estes,91
-Pratt,TWP 12,State Treasurer,,R,Ron Estes,378
-Pratt,WARD 1,State Treasurer,,D,Carmen Alldritt,75
-Pratt,WARD 2,State Treasurer,,D,Carmen Alldritt,53
-Pratt,WARD 3,State Treasurer,,D,Carmen Alldritt,105
-Pratt,WARD 4,State Treasurer,,D,Carmen Alldritt,108
-Pratt,WARD 5,State Treasurer,,D,Carmen Alldritt,66
-Pratt,TWP 6,State Treasurer,,D,Carmen Alldritt,34
-Pratt,TWP 7,State Treasurer,,D,Carmen Alldritt,23
-Pratt,TWP 8,State Treasurer,,D,Carmen Alldritt,2
-Pratt,TWP 9,State Treasurer,,D,Carmen Alldritt,17
-Pratt,TWP 10,State Treasurer,,D,Carmen Alldritt,6
-Pratt,TWP 11,State Treasurer,,D,Carmen Alldritt,14
-Pratt,TWP 12,State Treasurer,,D,Carmen Alldritt,68
-Pratt,WARD 1,Insurance Commissioner,,R,Ken Selzer,273
-Pratt,WARD 2,Insurance Commissioner,,R,Ken Selzer,161
-Pratt,WARD 3,Insurance Commissioner,,R,Ken Selzer,391
-Pratt,WARD 4,Insurance Commissioner,,R,Ken Selzer,282
-Pratt,WARD 5,Insurance Commissioner,,R,Ken Selzer,283
-Pratt,TWP 6,Insurance Commissioner,,R,Ken Selzer,146
-Pratt,TWP 7,Insurance Commissioner,,R,Ken Selzer,84
-Pratt,TWP 8,Insurance Commissioner,,R,Ken Selzer,38
-Pratt,TWP 9,Insurance Commissioner,,R,Ken Selzer,87
-Pratt,TWP 10,Insurance Commissioner,,R,Ken Selzer,49
-Pratt,TWP 11,Insurance Commissioner,,R,Ken Selzer,83
-Pratt,TWP 12,Insurance Commissioner,,R,Ken Selzer,326
-Pratt,WARD 1,Insurance Commissioner,,D,Dennis Anderson,102
-Pratt,WARD 2,Insurance Commissioner,,D,Dennis Anderson,61
-Pratt,WARD 3,Insurance Commissioner,,D,Dennis Anderson,153
-Pratt,WARD 4,Insurance Commissioner,,D,Dennis Anderson,134
-Pratt,WARD 5,Insurance Commissioner,,D,Dennis Anderson,90
-Pratt,TWP 6,Insurance Commissioner,,D,Dennis Anderson,46
-Pratt,TWP 7,Insurance Commissioner,,D,Dennis Anderson,26
-Pratt,TWP 8,Insurance Commissioner,,D,Dennis Anderson,5
-Pratt,TWP 9,Insurance Commissioner,,D,Dennis Anderson,17
-Pratt,TWP 10,Insurance Commissioner,,D,Dennis Anderson,6
-Pratt,TWP 11,Insurance Commissioner,,D,Dennis Anderson,20
-Pratt,TWP 12,Insurance Commissioner,,D,Dennis Anderson,103
-Pratt,WARD 1,State House,113,R,Jeremy Dannebohm,324
-Pratt,WARD 2,State House,113,R,Jeremy Dannebohm,189
-Pratt,WARD 3,State House,113,R,Jeremy Dannebohm,456
-Pratt,WARD 4,State House,113,R,Jeremy Dannebohm,337
-Pratt,WARD 5,State House,113,R,Jeremy Dannebohm,322
-Pratt,TWP 6,State House,113,R,Jeremy Dannebohm,163
-Pratt,TWP 7,State House,113,R,Jeremy Dannebohm,90
-Pratt,TWP 8,State House,113,R,Jeremy Dannebohm,37
-Pratt,TWP 9,State House,113,R,Jeremy Dannebohm,91
-Pratt,TWP 10,State House,113,R,Jeremy Dannebohm,51
-Pratt,TWP 11,State House,113,R,Jeremy Dannebohm,89
-Pratt,TWP 12,State House,113,R,Jeremy Dannebohm,369
+county,precinct,office,district,party,candidate,votes,vtd
+PRATT,Pratt Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",165,00001A
+PRATT,Pratt Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,00001A
+PRATT,Pratt Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",212,00001A
+PRATT,Pratt Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,00002A
+PRATT,Pratt Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00002A
+PRATT,Pratt Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",131,00002A
+PRATT,Pratt Ward 2 Exclave Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00002B
+PRATT,Pratt Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",287,000030
+PRATT,Pratt Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000030
+PRATT,Pratt Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",265,000030
+PRATT,Pratt Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",203,00004A
+PRATT,Pratt Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,00004A
+PRATT,Pratt Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",218,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00004C
+PRATT,Pratt Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",164,00005A
+PRATT,Pratt Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,00005A
+PRATT,Pratt Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",224,00005A
+PRATT,Pratt Ward Exclave Pratt College,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+PRATT,Township 6,Governor / Lt. Governor,,Democratic,"Davis, Paul",70,000060
+PRATT,Township 6,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000060
+PRATT,Township 6,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000060
+PRATT,Township 7,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000070
+PRATT,Township 7,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000070
+PRATT,Township 7,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000070
+PRATT,Township 8,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000080
+PRATT,Township 8,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+PRATT,Township 8,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000080
+PRATT,Township 9,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000090
+PRATT,Township 9,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000090
+PRATT,Township 9,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000090
+PRATT,Township 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000100
+PRATT,Township 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000100
+PRATT,Township 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,000100
+PRATT,Township 11,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000110
+PRATT,Township 11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000110
+PRATT,Township 11,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000110
+PRATT,Township 12,Governor / Lt. Governor,,Democratic,"Davis, Paul",185,00012A
+PRATT,Township 12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,00012A
+PRATT,Township 12,Governor / Lt. Governor,,Republican,"Brownback, Sam",258,00012A
+PRATT,Township 12 Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00012B
+PRATT,Township 12 Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00012B
+PRATT,Township 12 Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00012B
+PRATT,Pratt Ward 1,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",324,00001A
+PRATT,Pratt Ward 2,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",189,00002A
+PRATT,Pratt Ward 2 Exclave Airport,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",0,00002B
+PRATT,Pratt Ward 3,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",456,000030
+PRATT,Pratt Ward 4,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",337,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",0,00004C
+PRATT,Pratt Ward 5,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",322,00005A
+PRATT,Pratt Ward Exclave Pratt College,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",0,00005B
+PRATT,Township 6,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",163,000060
+PRATT,Township 7,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",90,000070
+PRATT,Township 8,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",37,000080
+PRATT,Township 9,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",91,000090
+PRATT,Township 10,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",51,000100
+PRATT,Township 11,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",89,000110
+PRATT,Township 12,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",369,00012A
+PRATT,Township 12 Enclave,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",0,00012B
+PRATT,Pratt Ward 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",87,00001A
+PRATT,Pratt Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",297,00001A
+PRATT,Pratt Ward 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",62,00002A
+PRATT,Pratt Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",166,00002A
+PRATT,Pratt Ward 2 Exclave Airport,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00002B
+PRATT,Pratt Ward 3,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",131,000030
+PRATT,Pratt Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",435,000030
+PRATT,Pratt Ward 4,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",134,00004A
+PRATT,Pratt Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",297,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00004C
+PRATT,Pratt Ward 5,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",80,00005A
+PRATT,Pratt Ward 5,United States House of Representatives,4,Republican,"Pompeo, Mike",316,00005A
+PRATT,Pratt Ward Exclave Pratt College,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00005B
+PRATT,Township 6,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",47,000060
+PRATT,Township 6,United States House of Representatives,4,Republican,"Pompeo, Mike",148,000060
+PRATT,Township 7,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",27,000070
+PRATT,Township 7,United States House of Representatives,4,Republican,"Pompeo, Mike",84,000070
+PRATT,Township 8,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,000080
+PRATT,Township 8,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000080
+PRATT,Township 9,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,000090
+PRATT,Township 9,United States House of Representatives,4,Republican,"Pompeo, Mike",89,000090
+PRATT,Township 10,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,000100
+PRATT,Township 10,United States House of Representatives,4,Republican,"Pompeo, Mike",45,000100
+PRATT,Township 11,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",21,000110
+PRATT,Township 11,United States House of Representatives,4,Republican,"Pompeo, Mike",86,000110
+PRATT,Township 12,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",87,00012A
+PRATT,Township 12,United States House of Representatives,4,Republican,"Pompeo, Mike",362,00012A
+PRATT,Township 12 Enclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,00012B
+PRATT,Township 12 Enclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00012B
+PRATT,Pratt Ward 1,Attorney General,,Democratic,"Kotich, A.J.",76,00001A
+PRATT,Pratt Ward 1,Attorney General,,Republican,"Schmidt, Derek",310,00001A
+PRATT,Pratt Ward 2,Attorney General,,Democratic,"Kotich, A.J.",52,00002A
+PRATT,Pratt Ward 2,Attorney General,,Republican,"Schmidt, Derek",174,00002A
+PRATT,Pratt Ward 2 Exclave Airport,Attorney General,,Democratic,"Kotich, A.J.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,Attorney General,,Republican,"Schmidt, Derek",0,00002B
+PRATT,Pratt Ward 3,Attorney General,,Democratic,"Kotich, A.J.",112,000030
+PRATT,Pratt Ward 3,Attorney General,,Republican,"Schmidt, Derek",440,000030
+PRATT,Pratt Ward 4,Attorney General,,Democratic,"Kotich, A.J.",103,00004A
+PRATT,Pratt Ward 4,Attorney General,,Republican,"Schmidt, Derek",329,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Attorney General,,Democratic,"Kotich, A.J.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Attorney General,,Republican,"Schmidt, Derek",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,Attorney General,,Democratic,"Kotich, A.J.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,Attorney General,,Republican,"Schmidt, Derek",0,00004C
+PRATT,Pratt Ward 5,Attorney General,,Democratic,"Kotich, A.J.",67,00005A
+PRATT,Pratt Ward 5,Attorney General,,Republican,"Schmidt, Derek",322,00005A
+PRATT,Pratt Ward Exclave Pratt College,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+PRATT,Township 6,Attorney General,,Democratic,"Kotich, A.J.",35,000060
+PRATT,Township 6,Attorney General,,Republican,"Schmidt, Derek",162,000060
+PRATT,Township 7,Attorney General,,Democratic,"Kotich, A.J.",18,000070
+PRATT,Township 7,Attorney General,,Republican,"Schmidt, Derek",91,000070
+PRATT,Township 8,Attorney General,,Democratic,"Kotich, A.J.",4,000080
+PRATT,Township 8,Attorney General,,Republican,"Schmidt, Derek",41,000080
+PRATT,Township 9,Attorney General,,Democratic,"Kotich, A.J.",17,000090
+PRATT,Township 9,Attorney General,,Republican,"Schmidt, Derek",88,000090
+PRATT,Township 10,Attorney General,,Democratic,"Kotich, A.J.",8,000100
+PRATT,Township 10,Attorney General,,Republican,"Schmidt, Derek",48,000100
+PRATT,Township 11,Attorney General,,Democratic,"Kotich, A.J.",16,000110
+PRATT,Township 11,Attorney General,,Republican,"Schmidt, Derek",89,000110
+PRATT,Township 12,Attorney General,,Democratic,"Kotich, A.J.",69,00012A
+PRATT,Township 12,Attorney General,,Republican,"Schmidt, Derek",369,00012A
+PRATT,Township 12 Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00012B
+PRATT,Township 12 Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00012B
+PRATT,Pratt Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",102,00001A
+PRATT,Pratt Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",273,00001A
+PRATT,Pratt Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,00002A
+PRATT,Pratt Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",161,00002A
+PRATT,Pratt Ward 2 Exclave Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00002B
+PRATT,Pratt Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",153,000030
+PRATT,Pratt Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",391,000030
+PRATT,Pratt Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",134,00004A
+PRATT,Pratt Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",282,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00004C
+PRATT,Pratt Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",90,00005A
+PRATT,Pratt Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",283,00005A
+PRATT,Pratt Ward Exclave Pratt College,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+PRATT,Township 6,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000060
+PRATT,Township 6,Commissioner of Insurance,,Republican,"Selzer, Ken",146,000060
+PRATT,Township 7,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000070
+PRATT,Township 7,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000070
+PRATT,Township 8,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000080
+PRATT,Township 8,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000080
+PRATT,Township 9,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000090
+PRATT,Township 9,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000090
+PRATT,Township 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000100
+PRATT,Township 10,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000100
+PRATT,Township 11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000110
+PRATT,Township 11,Commissioner of Insurance,,Republican,"Selzer, Ken",83,000110
+PRATT,Township 12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",103,00012A
+PRATT,Township 12,Commissioner of Insurance,,Republican,"Selzer, Ken",326,00012A
+PRATT,Township 12 Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00012B
+PRATT,Township 12 Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00012B
+PRATT,Pratt Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",126,00001A
+PRATT,Pratt Ward 1,Secretary of State,,Republican,"Kobach, Kris",265,00001A
+PRATT,Pratt Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,00002A
+PRATT,Pratt Ward 2,Secretary of State,,Republican,"Kobach, Kris",154,00002A
+PRATT,Pratt Ward 2 Exclave Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,Secretary of State,,Republican,"Kobach, Kris",0,00002B
+PRATT,Pratt Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",193,000030
+PRATT,Pratt Ward 3,Secretary of State,,Republican,"Kobach, Kris",366,000030
+PRATT,Pratt Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",169,00004A
+PRATT,Pratt Ward 4,Secretary of State,,Republican,"Kobach, Kris",265,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Secretary of State,,Republican,"Kobach, Kris",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,Secretary of State,,Republican,"Kobach, Kris",0,00004C
+PRATT,Pratt Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",129,00005A
+PRATT,Pratt Ward 5,Secretary of State,,Republican,"Kobach, Kris",267,00005A
+PRATT,Pratt Ward Exclave Pratt College,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+PRATT,Township 6,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,000060
+PRATT,Township 6,Secretary of State,,Republican,"Kobach, Kris",141,000060
+PRATT,Township 7,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000070
+PRATT,Township 7,Secretary of State,,Republican,"Kobach, Kris",77,000070
+PRATT,Township 8,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000080
+PRATT,Township 8,Secretary of State,,Republican,"Kobach, Kris",27,000080
+PRATT,Township 9,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000090
+PRATT,Township 9,Secretary of State,,Republican,"Kobach, Kris",85,000090
+PRATT,Township 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000100
+PRATT,Township 10,Secretary of State,,Republican,"Kobach, Kris",45,000100
+PRATT,Township 11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000110
+PRATT,Township 11,Secretary of State,,Republican,"Kobach, Kris",84,000110
+PRATT,Township 12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",134,00012A
+PRATT,Township 12,Secretary of State,,Republican,"Kobach, Kris",314,00012A
+PRATT,Township 12 Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00012B
+PRATT,Township 12 Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00012B
+PRATT,Pratt Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",75,00001A
+PRATT,Pratt Ward 1,State Treasurer,,Republican,"Estes, Ron",311,00001A
+PRATT,Pratt Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",53,00002A
+PRATT,Pratt Ward 2,State Treasurer,,Republican,"Estes, Ron",170,00002A
+PRATT,Pratt Ward 2 Exclave Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,State Treasurer,,Republican,"Estes, Ron",0,00002B
+PRATT,Pratt Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",105,000030
+PRATT,Pratt Ward 3,State Treasurer,,Republican,"Estes, Ron",444,000030
+PRATT,Pratt Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",108,00004A
+PRATT,Pratt Ward 4,State Treasurer,,Republican,"Estes, Ron",317,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,State Treasurer,,Democratic,"Alldritt, Carmen",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,State Treasurer,,Republican,"Estes, Ron",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,State Treasurer,,Democratic,"Alldritt, Carmen",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,State Treasurer,,Republican,"Estes, Ron",0,00004C
+PRATT,Pratt Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",66,00005A
+PRATT,Pratt Ward 5,State Treasurer,,Republican,"Estes, Ron",322,00005A
+PRATT,Pratt Ward Exclave Pratt College,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,State Treasurer,,Republican,"Estes, Ron",0,00005B
+PRATT,Township 6,State Treasurer,,Democratic,"Alldritt, Carmen",34,000060
+PRATT,Township 6,State Treasurer,,Republican,"Estes, Ron",163,000060
+PRATT,Township 7,State Treasurer,,Democratic,"Alldritt, Carmen",23,000070
+PRATT,Township 7,State Treasurer,,Republican,"Estes, Ron",89,000070
+PRATT,Township 8,State Treasurer,,Democratic,"Alldritt, Carmen",2,000080
+PRATT,Township 8,State Treasurer,,Republican,"Estes, Ron",43,000080
+PRATT,Township 9,State Treasurer,,Democratic,"Alldritt, Carmen",17,000090
+PRATT,Township 9,State Treasurer,,Republican,"Estes, Ron",90,000090
+PRATT,Township 10,State Treasurer,,Democratic,"Alldritt, Carmen",6,000100
+PRATT,Township 10,State Treasurer,,Republican,"Estes, Ron",51,000100
+PRATT,Township 11,State Treasurer,,Democratic,"Alldritt, Carmen",14,000110
+PRATT,Township 11,State Treasurer,,Republican,"Estes, Ron",91,000110
+PRATT,Township 12,State Treasurer,,Democratic,"Alldritt, Carmen",68,00012A
+PRATT,Township 12,State Treasurer,,Republican,"Estes, Ron",378,00012A
+PRATT,Township 12 Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00012B
+PRATT,Township 12 Enclave,State Treasurer,,Republican,"Estes, Ron",0,00012B
+PRATT,Pratt Ward 1,United States Senate,,independent,"Orman, Greg",135,00001A
+PRATT,Pratt Ward 1,United States Senate,,Libertarian,"Batson, Randall",22,00001A
+PRATT,Pratt Ward 1,United States Senate,,Republican,"Roberts, Pat",237,00001A
+PRATT,Pratt Ward 2,United States Senate,,independent,"Orman, Greg",73,00002A
+PRATT,Pratt Ward 2,United States Senate,,Libertarian,"Batson, Randall",13,00002A
+PRATT,Pratt Ward 2,United States Senate,,Republican,"Roberts, Pat",143,00002A
+PRATT,Pratt Ward 2 Exclave Airport,United States Senate,,independent,"Orman, Greg",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States Senate,,Libertarian,"Batson, Randall",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States Senate,,Republican,"Roberts, Pat",0,00002B
+PRATT,Pratt Ward 3,United States Senate,,independent,"Orman, Greg",212,000030
+PRATT,Pratt Ward 3,United States Senate,,Libertarian,"Batson, Randall",23,000030
+PRATT,Pratt Ward 3,United States Senate,,Republican,"Roberts, Pat",335,000030
+PRATT,Pratt Ward 4,United States Senate,,independent,"Orman, Greg",169,00004A
+PRATT,Pratt Ward 4,United States Senate,,Libertarian,"Batson, Randall",30,00004A
+PRATT,Pratt Ward 4,United States Senate,,Republican,"Roberts, Pat",241,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States Senate,,independent,"Orman, Greg",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States Senate,,Libertarian,"Batson, Randall",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States Senate,,Republican,"Roberts, Pat",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,United States Senate,,independent,"Orman, Greg",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States Senate,,Libertarian,"Batson, Randall",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States Senate,,Republican,"Roberts, Pat",0,00004C
+PRATT,Pratt Ward 5,United States Senate,,independent,"Orman, Greg",130,00005A
+PRATT,Pratt Ward 5,United States Senate,,Libertarian,"Batson, Randall",23,00005A
+PRATT,Pratt Ward 5,United States Senate,,Republican,"Roberts, Pat",249,00005A
+PRATT,Pratt Ward Exclave Pratt College,United States Senate,,independent,"Orman, Greg",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States Senate,,Republican,"Roberts, Pat",0,00005B
+PRATT,Township 6,United States Senate,,independent,"Orman, Greg",56,000060
+PRATT,Township 6,United States Senate,,Libertarian,"Batson, Randall",11,000060
+PRATT,Township 6,United States Senate,,Republican,"Roberts, Pat",134,000060
+PRATT,Township 7,United States Senate,,independent,"Orman, Greg",32,000070
+PRATT,Township 7,United States Senate,,Libertarian,"Batson, Randall",2,000070
+PRATT,Township 7,United States Senate,,Republican,"Roberts, Pat",80,000070
+PRATT,Township 8,United States Senate,,independent,"Orman, Greg",17,000080
+PRATT,Township 8,United States Senate,,Libertarian,"Batson, Randall",0,000080
+PRATT,Township 8,United States Senate,,Republican,"Roberts, Pat",31,000080
+PRATT,Township 9,United States Senate,,independent,"Orman, Greg",20,000090
+PRATT,Township 9,United States Senate,,Libertarian,"Batson, Randall",5,000090
+PRATT,Township 9,United States Senate,,Republican,"Roberts, Pat",83,000090
+PRATT,Township 10,United States Senate,,independent,"Orman, Greg",13,000100
+PRATT,Township 10,United States Senate,,Libertarian,"Batson, Randall",1,000100
+PRATT,Township 10,United States Senate,,Republican,"Roberts, Pat",45,000100
+PRATT,Township 11,United States Senate,,independent,"Orman, Greg",21,000110
+PRATT,Township 11,United States Senate,,Libertarian,"Batson, Randall",5,000110
+PRATT,Township 11,United States Senate,,Republican,"Roberts, Pat",82,000110
+PRATT,Township 12,United States Senate,,independent,"Orman, Greg",128,00012A
+PRATT,Township 12,United States Senate,,Libertarian,"Batson, Randall",17,00012A
+PRATT,Township 12,United States Senate,,Republican,"Roberts, Pat",308,00012A
+PRATT,Township 12 Enclave,United States Senate,,independent,"Orman, Greg",0,00012B
+PRATT,Township 12 Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00012B
+PRATT,Township 12 Enclave,United States Senate,,Republican,"Roberts, Pat",0,00012B

--- a/2014/20141104__ks__general__rawlins__precinct.csv
+++ b/2014/20141104__ks__general__rawlins__precinct.csv
@@ -1,303 +1,307 @@
-county,precinct,office,district,party,candidate,votes
-Rawlins,Achilles Township,U.S. Senate,,R,Pat Roberts,21
-Rawlins,Atwood City Precinct 1 East,U.S. Senate,,R,Pat Roberts,74
-Rawlins,Atwood City Precinct 1 North,U.S. Senate,,R,Pat Roberts,28
-Rawlins,Atwood City Precinct 1 West,U.S. Senate,,R,Pat Roberts,28
-Rawlins,Atwood City Precinct 2,U.S. Senate,,R,Pat Roberts,187
-Rawlins,Atwood Township,U.S. Senate,,R,Pat Roberts,15
-Rawlins,Driftwood Township,U.S. Senate,,R,Pat Roberts,36
-Rawlins,East Center,U.S. Senate,,R,Pat Roberts,54
-Rawlins,Herl Township,U.S. Senate,,R,Pat Roberts,77
-Rawlins,Herndon City,U.S. Senate,,R,Pat Roberts,46
-Rawlins,Jefferson Township,U.S. Senate,,R,Pat Roberts,22
-Rawlins,Ludell Township,U.S. Senate,,R,Pat Roberts,45
-Rawlins,McDonald City,U.S. Senate,,R,Pat Roberts,56
-Rawlins,Mirage Township,U.S. Senate,,R,Pat Roberts,25
-Rawlins,Rocewood Township,U.S. Senate,,R,Pat Roberts,131
-Rawlins,Union Township,U.S. Senate,,R,Pat Roberts,15
-Rawlins,West Center,U.S. Senate,,R,Pat Roberts,68
-Rawlins,Achilles Township,U.S. Senate,,I,Greg Orman,1
-Rawlins,Atwood City Precinct 1 East,U.S. Senate,,I,Greg Orman,26
-Rawlins,Atwood City Precinct 1 North,U.S. Senate,,I,Greg Orman,13
-Rawlins,Atwood City Precinct 1 West,U.S. Senate,,I,Greg Orman,14
-Rawlins,Atwood City Precinct 2,U.S. Senate,,I,Greg Orman,46
-Rawlins,Atwood Township,U.S. Senate,,I,Greg Orman,1
-Rawlins,Driftwood Township,U.S. Senate,,I,Greg Orman,2
-Rawlins,East Center,U.S. Senate,,I,Greg Orman,6
-Rawlins,Herl Township,U.S. Senate,,I,Greg Orman,15
-Rawlins,Herndon City,U.S. Senate,,I,Greg Orman,11
-Rawlins,Jefferson Township,U.S. Senate,,I,Greg Orman,2
-Rawlins,Ludell Township,U.S. Senate,,I,Greg Orman,10
-Rawlins,McDonald City,U.S. Senate,,I,Greg Orman,6
-Rawlins,Mirage Township,U.S. Senate,,I,Greg Orman,0
-Rawlins,Rocewood Township,U.S. Senate,,I,Greg Orman,5
-Rawlins,Union Township,U.S. Senate,,I,Greg Orman,3
-Rawlins,West Center,U.S. Senate,,I,Greg Orman,11
-Rawlins,Achilles Township,U.S. Senate,,L,Randall Batson,1
-Rawlins,Atwood City Precinct 1 East,U.S. Senate,,L,Randall Batson,4
-Rawlins,Atwood City Precinct 1 North,U.S. Senate,,L,Randall Batson,3
-Rawlins,Atwood City Precinct 1 West,U.S. Senate,,L,Randall Batson,3
-Rawlins,Atwood City Precinct 2,U.S. Senate,,L,Randall Batson,13
-Rawlins,Atwood Township,U.S. Senate,,L,Randall Batson,0
-Rawlins,Driftwood Township,U.S. Senate,,L,Randall Batson,0
-Rawlins,East Center,U.S. Senate,,L,Randall Batson,2
-Rawlins,Herl Township,U.S. Senate,,L,Randall Batson,1
-Rawlins,Herndon City,U.S. Senate,,L,Randall Batson,8
-Rawlins,Jefferson Township,U.S. Senate,,L,Randall Batson,0
-Rawlins,Ludell Township,U.S. Senate,,L,Randall Batson,2
-Rawlins,McDonald City,U.S. Senate,,L,Randall Batson,1
-Rawlins,Mirage Township,U.S. Senate,,L,Randall Batson,0
-Rawlins,Rocewood Township,U.S. Senate,,L,Randall Batson,4
-Rawlins,Union Township,U.S. Senate,,L,Randall Batson,2
-Rawlins,West Center,U.S. Senate,,L,Randall Batson,1
-Rawlins,Achilles Township,U.S. House,1,R,Tim Huelskamp,23
-Rawlins,Atwood City Precinct 1 East,U.S. House,1,R,Tim Huelskamp,78
-Rawlins,Atwood City Precinct 1 North,U.S. House,1,R,Tim Huelskamp,35
-Rawlins,Atwood City Precinct 1 West,U.S. House,1,R,Tim Huelskamp,30
-Rawlins,Atwood City Precinct 2,U.S. House,1,R,Tim Huelskamp,186
-Rawlins,Atwood Township,U.S. House,1,R,Tim Huelskamp,14
-Rawlins,Driftwood Township,U.S. House,1,R,Tim Huelskamp,33
-Rawlins,East Center,U.S. House,1,R,Tim Huelskamp,56
-Rawlins,Herl Township,U.S. House,1,R,Tim Huelskamp,81
-Rawlins,Herndon City,U.S. House,1,R,Tim Huelskamp,55
-Rawlins,Jefferson Township,U.S. House,1,R,Tim Huelskamp,22
-Rawlins,Ludell Township,U.S. House,1,R,Tim Huelskamp,43
-Rawlins,McDonald City,U.S. House,1,R,Tim Huelskamp,58
-Rawlins,Mirage Township,U.S. House,1,R,Tim Huelskamp,25
-Rawlins,Rocewood Township,U.S. House,1,R,Tim Huelskamp,131
-Rawlins,Union Township,U.S. House,1,R,Tim Huelskamp,17
-Rawlins,West Center,U.S. House,1,R,Tim Huelskamp,66
-Rawlins,Achilles Township,U.S. House,1,D,James Sherow,2
-Rawlins,Atwood City Precinct 1 East,U.S. House,1,D,James Sherow,26
-Rawlins,Atwood City Precinct 1 North,U.S. House,1,D,James Sherow,11
-Rawlins,Atwood City Precinct 1 West,U.S. House,1,D,James Sherow,12
-Rawlins,Atwood City Precinct 2,U.S. House,1,D,James Sherow,58
-Rawlins,Atwood Township,U.S. House,1,D,James Sherow,2
-Rawlins,Driftwood Township,U.S. House,1,D,James Sherow,5
-Rawlins,East Center,U.S. House,1,D,James Sherow,5
-Rawlins,Herl Township,U.S. House,1,D,James Sherow,12
-Rawlins,Herndon City,U.S. House,1,D,James Sherow,12
-Rawlins,Jefferson Township,U.S. House,1,D,James Sherow,2
-Rawlins,Ludell Township,U.S. House,1,D,James Sherow,11
-Rawlins,McDonald City,U.S. House,1,D,James Sherow,6
-Rawlins,Mirage Township,U.S. House,1,D,James Sherow,0
-Rawlins,Rocewood Township,U.S. House,1,D,James Sherow,7
-Rawlins,Union Township,U.S. House,1,D,James Sherow,2
-Rawlins,West Center,U.S. House,1,D,James Sherow,13
-Rawlins,Achilles Township,Governor,,R,Sam Brownback,22
-Rawlins,Atwood City Precinct 1 East,Governor,,R,Sam Brownback,62
-Rawlins,Atwood City Precinct 1 North,Governor,,R,Sam Brownback,30
-Rawlins,Atwood City Precinct 1 West,Governor,,R,Sam Brownback,24
-Rawlins,Atwood City Precinct 2,Governor,,R,Sam Brownback,162
-Rawlins,Atwood Township,Governor,,R,Sam Brownback,10
-Rawlins,Driftwood Township,Governor,,R,Sam Brownback,30
-Rawlins,East Center,Governor,,R,Sam Brownback,52
-Rawlins,Herl Township,Governor,,R,Sam Brownback,67
-Rawlins,Herndon City,Governor,,R,Sam Brownback,44
-Rawlins,Jefferson Township,Governor,,R,Sam Brownback,22
-Rawlins,Ludell Township,Governor,,R,Sam Brownback,42
-Rawlins,McDonald City,Governor,,R,Sam Brownback,55
-Rawlins,Mirage Township,Governor,,R,Sam Brownback,23
-Rawlins,Rocewood Township,Governor,,R,Sam Brownback,131
-Rawlins,Union Township,Governor,,R,Sam Brownback,16
-Rawlins,West Center,Governor,,R,Sam Brownback,64
-Rawlins,Achilles Township,Governor,,D,Paul Davis,2
-Rawlins,Atwood City Precinct 1 East,Governor,,D,Paul Davis,32
-Rawlins,Atwood City Precinct 1 North,Governor,,D,Paul Davis,14
-Rawlins,Atwood City Precinct 1 West,Governor,,D,Paul Davis,19
-Rawlins,Atwood City Precinct 2,Governor,,D,Paul Davis,76
-Rawlins,Atwood Township,Governor,,D,Paul Davis,5
-Rawlins,Driftwood Township,Governor,,D,Paul Davis,7
-Rawlins,East Center,Governor,,D,Paul Davis,9
-Rawlins,Herl Township,Governor,,D,Paul Davis,19
-Rawlins,Herndon City,Governor,,D,Paul Davis,14
-Rawlins,Jefferson Township,Governor,,D,Paul Davis,2
-Rawlins,Ludell Township,Governor,,D,Paul Davis,8
-Rawlins,McDonald City,Governor,,D,Paul Davis,7
-Rawlins,Mirage Township,Governor,,D,Paul Davis,1
-Rawlins,Rocewood Township,Governor,,D,Paul Davis,6
-Rawlins,Union Township,Governor,,D,Paul Davis,3
-Rawlins,West Center,Governor,,D,Paul Davis,14
-Rawlins,Achilles Township,Governor,,L,Keen Umbehr,1
-Rawlins,Atwood City Precinct 1 East,Governor,,L,Keen Umbehr,7
-Rawlins,Atwood City Precinct 1 North,Governor,,L,Keen Umbehr,1
-Rawlins,Atwood City Precinct 1 West,Governor,,L,Keen Umbehr,3
-Rawlins,Atwood City Precinct 2,Governor,,L,Keen Umbehr,12
-Rawlins,Atwood Township,Governor,,L,Keen Umbehr,0
-Rawlins,Driftwood Township,Governor,,L,Keen Umbehr,1
-Rawlins,East Center,Governor,,L,Keen Umbehr,2
-Rawlins,Herl Township,Governor,,L,Keen Umbehr,5
-Rawlins,Herndon City,Governor,,L,Keen Umbehr,4
-Rawlins,Jefferson Township,Governor,,L,Keen Umbehr,0
-Rawlins,Ludell Township,Governor,,L,Keen Umbehr,2
-Rawlins,McDonald City,Governor,,L,Keen Umbehr,0
-Rawlins,Mirage Township,Governor,,L,Keen Umbehr,1
-Rawlins,Rocewood Township,Governor,,L,Keen Umbehr,1
-Rawlins,Union Township,Governor,,L,Keen Umbehr,1
-Rawlins,West Center,Governor,,L,Keen Umbehr,2
-Rawlins,Achilles Township,Secretary of State,,R,Kris Kobach,22
-Rawlins,Atwood City Precinct 1 East,Secretary of State,,R,Kris Kobach,78
-Rawlins,Atwood City Precinct 1 North,Secretary of State,,R,Kris Kobach,33
-Rawlins,Atwood City Precinct 1 West,Secretary of State,,R,Kris Kobach,29
-Rawlins,Atwood City Precinct 2,Secretary of State,,R,Kris Kobach,190
-Rawlins,Atwood Township,Secretary of State,,R,Kris Kobach,15
-Rawlins,Driftwood Township,Secretary of State,,R,Kris Kobach,32
-Rawlins,East Center,Secretary of State,,R,Kris Kobach,55
-Rawlins,Herl Township,Secretary of State,,R,Kris Kobach,76
-Rawlins,Herndon City,Secretary of State,,R,Kris Kobach,47
-Rawlins,Jefferson Township,Secretary of State,,R,Kris Kobach,21
-Rawlins,Ludell Township,Secretary of State,,R,Kris Kobach,38
-Rawlins,McDonald City,Secretary of State,,R,Kris Kobach,54
-Rawlins,Mirage Township,Secretary of State,,R,Kris Kobach,25
-Rawlins,Rocewood Township,Secretary of State,,R,Kris Kobach,126
-Rawlins,Union Township,Secretary of State,,R,Kris Kobach,16
-Rawlins,West Center,Secretary of State,,R,Kris Kobach,63
-Rawlins,Achilles Township,Secretary of State,,D,Jean Schodorf,3
-Rawlins,Atwood City Precinct 1 East,Secretary of State,,D,Jean Schodorf,24
-Rawlins,Atwood City Precinct 1 North,Secretary of State,,D,Jean Schodorf,12
-Rawlins,Atwood City Precinct 1 West,Secretary of State,,D,Jean Schodorf,14
-Rawlins,Atwood City Precinct 2,Secretary of State,,D,Jean Schodorf,56
-Rawlins,Atwood Township,Secretary of State,,D,Jean Schodorf,0
-Rawlins,Driftwood Township,Secretary of State,,D,Jean Schodorf,6
-Rawlins,East Center,Secretary of State,,D,Jean Schodorf,7
-Rawlins,Herl Township,Secretary of State,,D,Jean Schodorf,12
-Rawlins,Herndon City,Secretary of State,,D,Jean Schodorf,16
-Rawlins,Jefferson Township,Secretary of State,,D,Jean Schodorf,3
-Rawlins,Ludell Township,Secretary of State,,D,Jean Schodorf,12
-Rawlins,McDonald City,Secretary of State,,D,Jean Schodorf,8
-Rawlins,Mirage Township,Secretary of State,,D,Jean Schodorf,0
-Rawlins,Rocewood Township,Secretary of State,,D,Jean Schodorf,9
-Rawlins,Union Township,Secretary of State,,D,Jean Schodorf,2
-Rawlins,West Center,Secretary of State,,D,Jean Schodorf,11
-Rawlins,Achilles Township,Attorney General,,R,Derek Schmidt,23
-Rawlins,Atwood City Precinct 1 East,Attorney General,,R,Derek Schmidt,85
-Rawlins,Atwood City Precinct 1 North,Attorney General,,R,Derek Schmidt,37
-Rawlins,Atwood City Precinct 1 West,Attorney General,,R,Derek Schmidt,34
-Rawlins,Atwood City Precinct 2,Attorney General,,R,Derek Schmidt,203
-Rawlins,Atwood Township,Attorney General,,R,Derek Schmidt,16
-Rawlins,Driftwood Township,Attorney General,,R,Derek Schmidt,34
-Rawlins,East Center,Attorney General,,R,Derek Schmidt,56
-Rawlins,Herl Township,Attorney General,,R,Derek Schmidt,84
-Rawlins,Herndon City,Attorney General,,R,Derek Schmidt,54
-Rawlins,Jefferson Township,Attorney General,,R,Derek Schmidt,22
-Rawlins,Ludell Township,Attorney General,,R,Derek Schmidt,46
-Rawlins,McDonald City,Attorney General,,R,Derek Schmidt,55
-Rawlins,Mirage Township,Attorney General,,R,Derek Schmidt,24
-Rawlins,Rocewood Township,Attorney General,,R,Derek Schmidt,130
-Rawlins,Union Township,Attorney General,,R,Derek Schmidt,17
-Rawlins,West Center,Attorney General,,R,Derek Schmidt,68
-Rawlins,Achilles Township,Attorney General,,D,AJ Kotich,2
-Rawlins,Atwood City Precinct 1 East,Attorney General,,D,AJ Kotich,17
-Rawlins,Atwood City Precinct 1 North,Attorney General,,D,AJ Kotich,8
-Rawlins,Atwood City Precinct 1 West,Attorney General,,D,AJ Kotich,9
-Rawlins,Atwood City Precinct 2,Attorney General,,D,AJ Kotich,37
-Rawlins,Atwood Township,Attorney General,,D,AJ Kotich,0
-Rawlins,Driftwood Township,Attorney General,,D,AJ Kotich,2
-Rawlins,East Center,Attorney General,,D,AJ Kotich,4
-Rawlins,Herl Township,Attorney General,,D,AJ Kotich,6
-Rawlins,Herndon City,Attorney General,,D,AJ Kotich,9
-Rawlins,Jefferson Township,Attorney General,,D,AJ Kotich,1
-Rawlins,Ludell Township,Attorney General,,D,AJ Kotich,9
-Rawlins,McDonald City,Attorney General,,D,AJ Kotich,7
-Rawlins,Mirage Township,Attorney General,,D,AJ Kotich,1
-Rawlins,Rocewood Township,Attorney General,,D,AJ Kotich,6
-Rawlins,Union Township,Attorney General,,D,AJ Kotich,2
-Rawlins,West Center,Attorney General,,D,AJ Kotich,5
-Rawlins,Achilles Township,State Treasurer,,R,Ron Estes,20
-Rawlins,Atwood City Precinct 1 East,State Treasurer,,R,Ron Estes,80
-Rawlins,Atwood City Precinct 1 North,State Treasurer,,R,Ron Estes,36
-Rawlins,Atwood City Precinct 1 West,State Treasurer,,R,Ron Estes,27
-Rawlins,Atwood City Precinct 2,State Treasurer,,R,Ron Estes,201
-Rawlins,Atwood Township,State Treasurer,,R,Ron Estes,14
-Rawlins,Driftwood Township,State Treasurer,,R,Ron Estes,32
-Rawlins,East Center,State Treasurer,,R,Ron Estes,56
-Rawlins,Herl Township,State Treasurer,,R,Ron Estes,84
-Rawlins,Herndon City,State Treasurer,,R,Ron Estes,51
-Rawlins,Jefferson Township,State Treasurer,,R,Ron Estes,22
-Rawlins,Ludell Township,State Treasurer,,R,Ron Estes,45
-Rawlins,McDonald City,State Treasurer,,R,Ron Estes,55
-Rawlins,Mirage Township,State Treasurer,,R,Ron Estes,25
-Rawlins,Rocewood Township,State Treasurer,,R,Ron Estes,128
-Rawlins,Union Township,State Treasurer,,R,Ron Estes,16
-Rawlins,West Center,State Treasurer,,R,Ron Estes,63
-Rawlins,Achilles Township,State Treasurer,,D,Carmen Alldritt,2
-Rawlins,Atwood City Precinct 1 East,State Treasurer,,D,Carmen Alldritt,19
-Rawlins,Atwood City Precinct 1 North,State Treasurer,,D,Carmen Alldritt,8
-Rawlins,Atwood City Precinct 1 West,State Treasurer,,D,Carmen Alldritt,14
-Rawlins,Atwood City Precinct 2,State Treasurer,,D,Carmen Alldritt,40
-Rawlins,Atwood Township,State Treasurer,,D,Carmen Alldritt,1
-Rawlins,Driftwood Township,State Treasurer,,D,Carmen Alldritt,3
-Rawlins,East Center,State Treasurer,,D,Carmen Alldritt,5
-Rawlins,Herl Township,State Treasurer,,D,Carmen Alldritt,5
-Rawlins,Herndon City,State Treasurer,,D,Carmen Alldritt,13
-Rawlins,Jefferson Township,State Treasurer,,D,Carmen Alldritt,1
-Rawlins,Ludell Township,State Treasurer,,D,Carmen Alldritt,8
-Rawlins,McDonald City,State Treasurer,,D,Carmen Alldritt,8
-Rawlins,Mirage Township,State Treasurer,,D,Carmen Alldritt,0
-Rawlins,Rocewood Township,State Treasurer,,D,Carmen Alldritt,5
-Rawlins,Union Township,State Treasurer,,D,Carmen Alldritt,2
-Rawlins,West Center,State Treasurer,,D,Carmen Alldritt,8
-Rawlins,Achilles Township,Insurance Commissioner,,R,Ken Selzer,23
-Rawlins,Atwood City Precinct 1 East,Insurance Commissioner,,R,Ken Selzer,77
-Rawlins,Atwood City Precinct 1 North,Insurance Commissioner,,R,Ken Selzer,34
-Rawlins,Atwood City Precinct 1 West,Insurance Commissioner,,R,Ken Selzer,28
-Rawlins,Atwood City Precinct 2,Insurance Commissioner,,R,Ken Selzer,184
-Rawlins,Atwood Township,Insurance Commissioner,,R,Ken Selzer,15
-Rawlins,Driftwood Township,Insurance Commissioner,,R,Ken Selzer,30
-Rawlins,East Center,Insurance Commissioner,,R,Ken Selzer,56
-Rawlins,Herl Township,Insurance Commissioner,,R,Ken Selzer,71
-Rawlins,Herndon City,Insurance Commissioner,,R,Ken Selzer,50
-Rawlins,Jefferson Township,Insurance Commissioner,,R,Ken Selzer,20
-Rawlins,Ludell Township,Insurance Commissioner,,R,Ken Selzer,35
-Rawlins,McDonald City,Insurance Commissioner,,R,Ken Selzer,54
-Rawlins,Mirage Township,Insurance Commissioner,,R,Ken Selzer,25
-Rawlins,Rocewood Township,Insurance Commissioner,,R,Ken Selzer,119
-Rawlins,Union Township,Insurance Commissioner,,R,Ken Selzer,16
-Rawlins,West Center,Insurance Commissioner,,R,Ken Selzer,66
-Rawlins,Achilles Township,Insurance Commissioner,,D,Dennis Anderson,2
-Rawlins,Atwood City Precinct 1 East,Insurance Commissioner,,D,Dennis Anderson,18
-Rawlins,Atwood City Precinct 1 North,Insurance Commissioner,,D,Dennis Anderson,10
-Rawlins,Atwood City Precinct 1 West,Insurance Commissioner,,D,Dennis Anderson,14
-Rawlins,Atwood City Precinct 2,Insurance Commissioner,,D,Dennis Anderson,53
-Rawlins,Atwood Township,Insurance Commissioner,,D,Dennis Anderson,1
-Rawlins,Driftwood Township,Insurance Commissioner,,D,Dennis Anderson,3
-Rawlins,East Center,Insurance Commissioner,,D,Dennis Anderson,4
-Rawlins,Herl Township,Insurance Commissioner,,D,Dennis Anderson,14
-Rawlins,Herndon City,Insurance Commissioner,,D,Dennis Anderson,10
-Rawlins,Jefferson Township,Insurance Commissioner,,D,Dennis Anderson,3
-Rawlins,Ludell Township,Insurance Commissioner,,D,Dennis Anderson,11
-Rawlins,McDonald City,Insurance Commissioner,,D,Dennis Anderson,8
-Rawlins,Mirage Township,Insurance Commissioner,,D,Dennis Anderson,0
-Rawlins,Rocewood Township,Insurance Commissioner,,D,Dennis Anderson,11
-Rawlins,Union Township,Insurance Commissioner,,D,Dennis Anderson,1
-Rawlins,West Center,Insurance Commissioner,,D,Dennis Anderson,7
-Rawlins,Achilles Township,State House,120,R,Rick Billinger,24
-Rawlins,Atwood City Precinct 1 East,State House,120,R,Rick Billinger,91
-Rawlins,Atwood City Precinct 1 North,State House,120,R,Rick Billinger,41
-Rawlins,Atwood City Precinct 1 West,State House,120,R,Rick Billinger,42
-Rawlins,Atwood City Precinct 2,State House,120,R,Rick Billinger,225
-Rawlins,Atwood Township,State House,120,R,Rick Billinger,15
-Rawlins,Driftwood Township,State House,120,R,Rick Billinger,34
-Rawlins,East Center,State House,120,R,Rick Billinger,52
-Rawlins,Herl Township,State House,120,R,Rick Billinger,83
-Rawlins,Herndon City,State House,120,R,Rick Billinger,58
-Rawlins,Jefferson Township,State House,120,R,Rick Billinger,21
-Rawlins,Ludell Township,State House,120,R,Rick Billinger,44
-Rawlins,McDonald City,State House,120,R,Rick Billinger,59
-Rawlins,Mirage Township,State House,120,R,Rick Billinger,23
-Rawlins,Rocewood Township,State House,120,R,Rick Billinger,128
-Rawlins,Union Township,State House,120,R,Rick Billinger,19
-Rawlins,West Center,State House,120,R,Rick Billinger,70
-Rawlins,Atwood City E 1,U.S. Senate,,,Write-ins,1
-Rawlins,Atwood City E 1,Governor,,,Write-ins,1
-Rawlins,Atwood City N 1,State House,120,,Write-ins,1
-Rawlins,Atwood City W 1,Secretary of State,,,Write-ins,1
-Rawlins,Atwood City W 1,State Treasurer,,,Write-ins,1
-Rawlins,Atwood City 2,U.S. Senate,,,Write-ins,2
-Rawlins,Atwood City 2,State House,120,,Write-ins,2
-Rawlins,Herndon City,State Treasurer,,,Write-ins,1
-Rawlins,Herndon City,State House,120,,Write-ins,1
-Rawlins,Atwood twp,State House,120,,Write-ins,1
-Rawlins,East Center,State House,120,,Write-ins,1
-Rawlins,Rocewood,State Treasurer,,,Write-ins,1
-Rawlins,Rocewood,Insurance Commissioner,,,Write-ins,1
+county,precinct,office,district,party,candidate,votes,vtd
+RAWLINS,Achilles Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000010
+RAWLINS,Achilles Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+RAWLINS,Achilles Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000010
+RAWLINS,Atwood City Precinct 1 East,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000020
+RAWLINS,Atwood City Precinct 1 East,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000020
+RAWLINS,Atwood City Precinct 1 East,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000020
+RAWLINS,Atwood City Precinct 1 North,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000030
+RAWLINS,Atwood City Precinct 1 North,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+RAWLINS,Atwood City Precinct 1 North,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000030
+RAWLINS,Atwood City Precinct 1 West,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000040
+RAWLINS,Atwood City Precinct 1 West,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000040
+RAWLINS,Atwood City Precinct 1 West,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000040
+RAWLINS,Atwood City Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",80,000050
+RAWLINS,Atwood City Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000050
+RAWLINS,Atwood City Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",163,000050
+RAWLINS,Atwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000060
+RAWLINS,Atwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+RAWLINS,Atwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000060
+RAWLINS,Driftwood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000070
+RAWLINS,Driftwood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+RAWLINS,Driftwood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000070
+RAWLINS,East Center,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000080
+RAWLINS,East Center,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+RAWLINS,East Center,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000080
+RAWLINS,Herl Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,00009A
+RAWLINS,Herl Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,00009A
+RAWLINS,Herl Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,00009A
+RAWLINS,Herl Township South,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00009B
+RAWLINS,Herl Township South,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00009B
+RAWLINS,Herl Township South,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00009B
+RAWLINS,Herndon City,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000100
+RAWLINS,Herndon City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000100
+RAWLINS,Herndon City,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000100
+RAWLINS,Jefferson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000110
+RAWLINS,Jefferson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+RAWLINS,Jefferson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000110
+RAWLINS,Ludell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000120
+RAWLINS,Ludell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000120
+RAWLINS,Ludell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000120
+RAWLINS,McDonald City,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000130
+RAWLINS,McDonald City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000130
+RAWLINS,McDonald City,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,000130
+RAWLINS,Mirage Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000140
+RAWLINS,Mirage Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+RAWLINS,Mirage Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000140
+RAWLINS,Rocewood Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000150
+RAWLINS,Rocewood Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+RAWLINS,Rocewood Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000150
+RAWLINS,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000160
+RAWLINS,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000160
+RAWLINS,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000160
+RAWLINS,West Center,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000170
+RAWLINS,West Center,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000170
+RAWLINS,West Center,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,000170
+RAWLINS,Achilles Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",25,000010
+RAWLINS,Atwood City Precinct 1 East,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",92,000020
+RAWLINS,Atwood City Precinct 1 North,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",42,000030
+RAWLINS,Atwood City Precinct 1 West,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",43,000040
+RAWLINS,Atwood City Precinct 2,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",228,000050
+RAWLINS,Atwood Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",15,000060
+RAWLINS,Driftwood Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",35,000070
+RAWLINS,East Center,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",54,000080
+RAWLINS,Herl Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",84,00009A
+RAWLINS,Herl Township South,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",0,00009B
+RAWLINS,Herndon City,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",58,000100
+RAWLINS,Jefferson Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",21,000110
+RAWLINS,Ludell Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",45,000120
+RAWLINS,McDonald City,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",60,000130
+RAWLINS,Mirage Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",23,000140
+RAWLINS,Rocewood Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",129,000150
+RAWLINS,Union Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",21,000160
+RAWLINS,West Center,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",72,000170
+RAWLINS,Achilles Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000010
+RAWLINS,Achilles Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000010
+RAWLINS,Atwood City Precinct 1 East,United States House of Representatives,1,Democratic,"Sherow, James E.",26,000020
+RAWLINS,Atwood City Precinct 1 East,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000020
+RAWLINS,Atwood City Precinct 1 North,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000030
+RAWLINS,Atwood City Precinct 1 North,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000030
+RAWLINS,Atwood City Precinct 1 West,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000040
+RAWLINS,Atwood City Precinct 1 West,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000040
+RAWLINS,Atwood City Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",62,000050
+RAWLINS,Atwood City Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",187,000050
+RAWLINS,Atwood Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000060
+RAWLINS,Atwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000060
+RAWLINS,Driftwood Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000070
+RAWLINS,Driftwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000070
+RAWLINS,East Center,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000080
+RAWLINS,East Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000080
+RAWLINS,Herl Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,00009A
+RAWLINS,Herl Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,00009A
+RAWLINS,Herl Township South,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00009B
+RAWLINS,Herl Township South,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00009B
+RAWLINS,Herndon City,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000100
+RAWLINS,Herndon City,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000100
+RAWLINS,Jefferson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000110
+RAWLINS,Jefferson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000110
+RAWLINS,Ludell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000120
+RAWLINS,Ludell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000120
+RAWLINS,McDonald City,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000130
+RAWLINS,McDonald City,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000130
+RAWLINS,Mirage Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000140
+RAWLINS,Mirage Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000140
+RAWLINS,Rocewood Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000150
+RAWLINS,Rocewood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",132,000150
+RAWLINS,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000160
+RAWLINS,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000160
+RAWLINS,West Center,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000170
+RAWLINS,West Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",68,000170
+RAWLINS,Achilles Township,Attorney General,,Democratic,"Kotich, A.J.",2,000010
+RAWLINS,Achilles Township,Attorney General,,Republican,"Schmidt, Derek",24,000010
+RAWLINS,Atwood City Precinct 1 East,Attorney General,,Democratic,"Kotich, A.J.",17,000020
+RAWLINS,Atwood City Precinct 1 East,Attorney General,,Republican,"Schmidt, Derek",87,000020
+RAWLINS,Atwood City Precinct 1 North,Attorney General,,Democratic,"Kotich, A.J.",8,000030
+RAWLINS,Atwood City Precinct 1 North,Attorney General,,Republican,"Schmidt, Derek",38,000030
+RAWLINS,Atwood City Precinct 1 West,Attorney General,,Democratic,"Kotich, A.J.",9,000040
+RAWLINS,Atwood City Precinct 1 West,Attorney General,,Republican,"Schmidt, Derek",35,000040
+RAWLINS,Atwood City Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",41,000050
+RAWLINS,Atwood City Precinct 2,Attorney General,,Republican,"Schmidt, Derek",204,000050
+RAWLINS,Atwood Township,Attorney General,,Democratic,"Kotich, A.J.",0,000060
+RAWLINS,Atwood Township,Attorney General,,Republican,"Schmidt, Derek",16,000060
+RAWLINS,Driftwood Township,Attorney General,,Democratic,"Kotich, A.J.",2,000070
+RAWLINS,Driftwood Township,Attorney General,,Republican,"Schmidt, Derek",34,000070
+RAWLINS,East Center,Attorney General,,Democratic,"Kotich, A.J.",4,000080
+RAWLINS,East Center,Attorney General,,Republican,"Schmidt, Derek",58,000080
+RAWLINS,Herl Township,Attorney General,,Democratic,"Kotich, A.J.",6,00009A
+RAWLINS,Herl Township,Attorney General,,Republican,"Schmidt, Derek",85,00009A
+RAWLINS,Herl Township South,Attorney General,,Democratic,"Kotich, A.J.",0,00009B
+RAWLINS,Herl Township South,Attorney General,,Republican,"Schmidt, Derek",0,00009B
+RAWLINS,Herndon City,Attorney General,,Democratic,"Kotich, A.J.",9,000100
+RAWLINS,Herndon City,Attorney General,,Republican,"Schmidt, Derek",54,000100
+RAWLINS,Jefferson Township,Attorney General,,Democratic,"Kotich, A.J.",1,000110
+RAWLINS,Jefferson Township,Attorney General,,Republican,"Schmidt, Derek",22,000110
+RAWLINS,Ludell Township,Attorney General,,Democratic,"Kotich, A.J.",9,000120
+RAWLINS,Ludell Township,Attorney General,,Republican,"Schmidt, Derek",47,000120
+RAWLINS,McDonald City,Attorney General,,Democratic,"Kotich, A.J.",7,000130
+RAWLINS,McDonald City,Attorney General,,Republican,"Schmidt, Derek",56,000130
+RAWLINS,Mirage Township,Attorney General,,Democratic,"Kotich, A.J.",1,000140
+RAWLINS,Mirage Township,Attorney General,,Republican,"Schmidt, Derek",24,000140
+RAWLINS,Rocewood Township,Attorney General,,Democratic,"Kotich, A.J.",6,000150
+RAWLINS,Rocewood Township,Attorney General,,Republican,"Schmidt, Derek",131,000150
+RAWLINS,Union Township,Attorney General,,Democratic,"Kotich, A.J.",2,000160
+RAWLINS,Union Township,Attorney General,,Republican,"Schmidt, Derek",19,000160
+RAWLINS,West Center,Attorney General,,Democratic,"Kotich, A.J.",5,000170
+RAWLINS,West Center,Attorney General,,Republican,"Schmidt, Derek",70,000170
+RAWLINS,Achilles Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000010
+RAWLINS,Achilles Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000010
+RAWLINS,Atwood City Precinct 1 East,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000020
+RAWLINS,Atwood City Precinct 1 East,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000020
+RAWLINS,Atwood City Precinct 1 North,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000030
+RAWLINS,Atwood City Precinct 1 North,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000030
+RAWLINS,Atwood City Precinct 1 West,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000040
+RAWLINS,Atwood City Precinct 1 West,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000040
+RAWLINS,Atwood City Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",57,000050
+RAWLINS,Atwood City Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",185,000050
+RAWLINS,Atwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000060
+RAWLINS,Atwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000060
+RAWLINS,Driftwood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000070
+RAWLINS,Driftwood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000070
+RAWLINS,East Center,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000080
+RAWLINS,East Center,Commissioner of Insurance,,Republican,"Selzer, Ken",58,000080
+RAWLINS,Herl Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,00009A
+RAWLINS,Herl Township,Commissioner of Insurance,,Republican,"Selzer, Ken",72,00009A
+RAWLINS,Herl Township South,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00009B
+RAWLINS,Herl Township South,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00009B
+RAWLINS,Herndon City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000100
+RAWLINS,Herndon City,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000100
+RAWLINS,Jefferson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000110
+RAWLINS,Jefferson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000110
+RAWLINS,Ludell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000120
+RAWLINS,Ludell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000120
+RAWLINS,McDonald City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000130
+RAWLINS,McDonald City,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000130
+RAWLINS,Mirage Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000140
+RAWLINS,Mirage Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000140
+RAWLINS,Rocewood Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000150
+RAWLINS,Rocewood Township,Commissioner of Insurance,,Republican,"Selzer, Ken",120,000150
+RAWLINS,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000160
+RAWLINS,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000160
+RAWLINS,West Center,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000170
+RAWLINS,West Center,Commissioner of Insurance,,Republican,"Selzer, Ken",68,000170
+RAWLINS,Achilles Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+RAWLINS,Achilles Township,Secretary of State,,Republican,"Kobach, Kris",23,000010
+RAWLINS,Atwood City Precinct 1 East,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000020
+RAWLINS,Atwood City Precinct 1 East,Secretary of State,,Republican,"Kobach, Kris",79,000020
+RAWLINS,Atwood City Precinct 1 North,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000030
+RAWLINS,Atwood City Precinct 1 North,Secretary of State,,Republican,"Kobach, Kris",34,000030
+RAWLINS,Atwood City Precinct 1 West,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000040
+RAWLINS,Atwood City Precinct 1 West,Secretary of State,,Republican,"Kobach, Kris",30,000040
+RAWLINS,Atwood City Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,000050
+RAWLINS,Atwood City Precinct 2,Secretary of State,,Republican,"Kobach, Kris",191,000050
+RAWLINS,Atwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000060
+RAWLINS,Atwood Township,Secretary of State,,Republican,"Kobach, Kris",15,000060
+RAWLINS,Driftwood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000070
+RAWLINS,Driftwood Township,Secretary of State,,Republican,"Kobach, Kris",33,000070
+RAWLINS,East Center,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000080
+RAWLINS,East Center,Secretary of State,,Republican,"Kobach, Kris",57,000080
+RAWLINS,Herl Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,00009A
+RAWLINS,Herl Township,Secretary of State,,Republican,"Kobach, Kris",77,00009A
+RAWLINS,Herl Township South,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00009B
+RAWLINS,Herl Township South,Secretary of State,,Republican,"Kobach, Kris",0,00009B
+RAWLINS,Herndon City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000100
+RAWLINS,Herndon City,Secretary of State,,Republican,"Kobach, Kris",47,000100
+RAWLINS,Jefferson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000110
+RAWLINS,Jefferson Township,Secretary of State,,Republican,"Kobach, Kris",21,000110
+RAWLINS,Ludell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000120
+RAWLINS,Ludell Township,Secretary of State,,Republican,"Kobach, Kris",39,000120
+RAWLINS,McDonald City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000130
+RAWLINS,McDonald City,Secretary of State,,Republican,"Kobach, Kris",55,000130
+RAWLINS,Mirage Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000140
+RAWLINS,Mirage Township,Secretary of State,,Republican,"Kobach, Kris",25,000140
+RAWLINS,Rocewood Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000150
+RAWLINS,Rocewood Township,Secretary of State,,Republican,"Kobach, Kris",127,000150
+RAWLINS,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000160
+RAWLINS,Union Township,Secretary of State,,Republican,"Kobach, Kris",18,000160
+RAWLINS,West Center,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000170
+RAWLINS,West Center,Secretary of State,,Republican,"Kobach, Kris",65,000170
+RAWLINS,Achilles Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+RAWLINS,Achilles Township,State Treasurer,,Republican,"Estes, Ron",21,000010
+RAWLINS,Atwood City Precinct 1 East,State Treasurer,,Democratic,"Alldritt, Carmen",19,000020
+RAWLINS,Atwood City Precinct 1 East,State Treasurer,,Republican,"Estes, Ron",82,000020
+RAWLINS,Atwood City Precinct 1 North,State Treasurer,,Democratic,"Alldritt, Carmen",8,000030
+RAWLINS,Atwood City Precinct 1 North,State Treasurer,,Republican,"Estes, Ron",37,000030
+RAWLINS,Atwood City Precinct 1 West,State Treasurer,,Democratic,"Alldritt, Carmen",14,000040
+RAWLINS,Atwood City Precinct 1 West,State Treasurer,,Republican,"Estes, Ron",28,000040
+RAWLINS,Atwood City Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",44,000050
+RAWLINS,Atwood City Precinct 2,State Treasurer,,Republican,"Estes, Ron",202,000050
+RAWLINS,Atwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000060
+RAWLINS,Atwood Township,State Treasurer,,Republican,"Estes, Ron",14,000060
+RAWLINS,Driftwood Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000070
+RAWLINS,Driftwood Township,State Treasurer,,Republican,"Estes, Ron",32,000070
+RAWLINS,East Center,State Treasurer,,Democratic,"Alldritt, Carmen",5,000080
+RAWLINS,East Center,State Treasurer,,Republican,"Estes, Ron",58,000080
+RAWLINS,Herl Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,00009A
+RAWLINS,Herl Township,State Treasurer,,Republican,"Estes, Ron",85,00009A
+RAWLINS,Herl Township South,State Treasurer,,Democratic,"Alldritt, Carmen",0,00009B
+RAWLINS,Herl Township South,State Treasurer,,Republican,"Estes, Ron",0,00009B
+RAWLINS,Herndon City,State Treasurer,,Democratic,"Alldritt, Carmen",13,000100
+RAWLINS,Herndon City,State Treasurer,,Republican,"Estes, Ron",51,000100
+RAWLINS,Jefferson Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000110
+RAWLINS,Jefferson Township,State Treasurer,,Republican,"Estes, Ron",22,000110
+RAWLINS,Ludell Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000120
+RAWLINS,Ludell Township,State Treasurer,,Republican,"Estes, Ron",45,000120
+RAWLINS,McDonald City,State Treasurer,,Democratic,"Alldritt, Carmen",8,000130
+RAWLINS,McDonald City,State Treasurer,,Republican,"Estes, Ron",56,000130
+RAWLINS,Mirage Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000140
+RAWLINS,Mirage Township,State Treasurer,,Republican,"Estes, Ron",25,000140
+RAWLINS,Rocewood Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000150
+RAWLINS,Rocewood Township,State Treasurer,,Republican,"Estes, Ron",129,000150
+RAWLINS,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000160
+RAWLINS,Union Township,State Treasurer,,Republican,"Estes, Ron",18,000160
+RAWLINS,West Center,State Treasurer,,Democratic,"Alldritt, Carmen",8,000170
+RAWLINS,West Center,State Treasurer,,Republican,"Estes, Ron",65,000170
+RAWLINS,Achilles Township,United States Senate,,independent,"Orman, Greg",1,000010
+RAWLINS,Achilles Township,United States Senate,,Libertarian,"Batson, Randall",2,000010
+RAWLINS,Achilles Township,United States Senate,,Republican,"Roberts, Pat",21,000010
+RAWLINS,Atwood City Precinct 1 East,United States Senate,,independent,"Orman, Greg",26,000020
+RAWLINS,Atwood City Precinct 1 East,United States Senate,,Libertarian,"Batson, Randall",4,000020
+RAWLINS,Atwood City Precinct 1 East,United States Senate,,Republican,"Roberts, Pat",76,000020
+RAWLINS,Atwood City Precinct 1 North,United States Senate,,independent,"Orman, Greg",13,000030
+RAWLINS,Atwood City Precinct 1 North,United States Senate,,Libertarian,"Batson, Randall",3,000030
+RAWLINS,Atwood City Precinct 1 North,United States Senate,,Republican,"Roberts, Pat",29,000030
+RAWLINS,Atwood City Precinct 1 West,United States Senate,,independent,"Orman, Greg",14,000040
+RAWLINS,Atwood City Precinct 1 West,United States Senate,,Libertarian,"Batson, Randall",3,000040
+RAWLINS,Atwood City Precinct 1 West,United States Senate,,Republican,"Roberts, Pat",29,000040
+RAWLINS,Atwood City Precinct 2,United States Senate,,independent,"Orman, Greg",50,000050
+RAWLINS,Atwood City Precinct 2,United States Senate,,Libertarian,"Batson, Randall",13,000050
+RAWLINS,Atwood City Precinct 2,United States Senate,,Republican,"Roberts, Pat",188,000050
+RAWLINS,Atwood Township,United States Senate,,independent,"Orman, Greg",1,000060
+RAWLINS,Atwood Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+RAWLINS,Atwood Township,United States Senate,,Republican,"Roberts, Pat",15,000060
+RAWLINS,Driftwood Township,United States Senate,,independent,"Orman, Greg",2,000070
+RAWLINS,Driftwood Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+RAWLINS,Driftwood Township,United States Senate,,Republican,"Roberts, Pat",37,000070
+RAWLINS,East Center,United States Senate,,independent,"Orman, Greg",6,000080
+RAWLINS,East Center,United States Senate,,Libertarian,"Batson, Randall",2,000080
+RAWLINS,East Center,United States Senate,,Republican,"Roberts, Pat",56,000080
+RAWLINS,Herl Township,United States Senate,,independent,"Orman, Greg",15,00009A
+RAWLINS,Herl Township,United States Senate,,Libertarian,"Batson, Randall",1,00009A
+RAWLINS,Herl Township,United States Senate,,Republican,"Roberts, Pat",78,00009A
+RAWLINS,Herl Township South,United States Senate,,independent,"Orman, Greg",0,00009B
+RAWLINS,Herl Township South,United States Senate,,Libertarian,"Batson, Randall",0,00009B
+RAWLINS,Herl Township South,United States Senate,,Republican,"Roberts, Pat",0,00009B
+RAWLINS,Herndon City,United States Senate,,independent,"Orman, Greg",11,000100
+RAWLINS,Herndon City,United States Senate,,Libertarian,"Batson, Randall",8,000100
+RAWLINS,Herndon City,United States Senate,,Republican,"Roberts, Pat",46,000100
+RAWLINS,Jefferson Township,United States Senate,,independent,"Orman, Greg",2,000110
+RAWLINS,Jefferson Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+RAWLINS,Jefferson Township,United States Senate,,Republican,"Roberts, Pat",22,000110
+RAWLINS,Ludell Township,United States Senate,,independent,"Orman, Greg",10,000120
+RAWLINS,Ludell Township,United States Senate,,Libertarian,"Batson, Randall",2,000120
+RAWLINS,Ludell Township,United States Senate,,Republican,"Roberts, Pat",46,000120
+RAWLINS,McDonald City,United States Senate,,independent,"Orman, Greg",6,000130
+RAWLINS,McDonald City,United States Senate,,Libertarian,"Batson, Randall",1,000130
+RAWLINS,McDonald City,United States Senate,,Republican,"Roberts, Pat",57,000130
+RAWLINS,Mirage Township,United States Senate,,independent,"Orman, Greg",0,000140
+RAWLINS,Mirage Township,United States Senate,,Libertarian,"Batson, Randall",0,000140
+RAWLINS,Mirage Township,United States Senate,,Republican,"Roberts, Pat",25,000140
+RAWLINS,Rocewood Township,United States Senate,,independent,"Orman, Greg",5,000150
+RAWLINS,Rocewood Township,United States Senate,,Libertarian,"Batson, Randall",4,000150
+RAWLINS,Rocewood Township,United States Senate,,Republican,"Roberts, Pat",132,000150
+RAWLINS,Union Township,United States Senate,,independent,"Orman, Greg",3,000160
+RAWLINS,Union Township,United States Senate,,Libertarian,"Batson, Randall",2,000160
+RAWLINS,Union Township,United States Senate,,Republican,"Roberts, Pat",17,000160
+RAWLINS,West Center,United States Senate,,independent,"Orman, Greg",11,000170
+RAWLINS,West Center,United States Senate,,Libertarian,"Batson, Randall",1,000170
+RAWLINS,West Center,United States Senate,,Republican,"Roberts, Pat",70,000170

--- a/2014/20141104__ks__general__reno__precinct.csv
+++ b/2014/20141104__ks__general__reno__precinct.csv
@@ -1,2211 +1,1428 @@
-county,precinct,office,district,party,candidate,votes,advance,polling
-Reno,CITY #01-H102,Attorney General,,D,Kotich,61,21,40
-Reno,CITY #01-HII4,Attorney General,,D,Kotich,5,3,2
-Reno,CITY #02,Attorney General,,D,Kotich,54,18,36
-Reno,CITY #03,Attorney General,,D,Kotich,36,11,25
-Reno,CITY #04,Attorney General,,D,Kotich,153,60,93
-Reno,CITY #05,Attorney General,,D,Kotich,99,21,78
-Reno,CITY #06,Attorney General,,D,Kotich,83,22,61
-Reno,CITY #07,Attorney General,,D,Kotich,122,39,83
-Reno,CITY #08,Attorney General,,D,Kotich,51,13,38
-Reno,CITY #09,Attorney General,,D,Kotich,149,67,82
-Reno,CITY #10,Attorney General,,D,Kotich,125,33,92
-Reno,CITY #11,Attorney General,,D,Kotich,155,51,104
-Reno,CITY #12,Attorney General,,D,Kotich,112,45,67
-Reno,CITY #13,Attorney General,,D,Kotich,140,49,91
-Reno,CITY #14,Attorney General,,D,Kotich,98,35,63
-Reno,CITY #15,Attorney General,,D,Kotich,70,24,46
-Reno,CITY #16,Attorney General,,D,Kotich,144,46,98
-Reno,CITY #17,Attorney General,,D,Kotich,132,55,77
-Reno,CITY #18,Attorney General,,D,Kotich,55,21,34
-Reno,CITY #19,Attorney General,,D,Kotich,68,17,51
-Reno,CITY #20,Attorney General,,D,Kotich,79,27,52
-Reno,CITY #21,Attorney General,,D,Kotich,86,24,62
-Reno,CITY #22,Attorney General,,D,Kotich,150,52,98
-Reno,CITY #23,Attorney General,,D,Kotich,202,95,107
-Reno,CITY #23 EX,Attorney General,,D,Kotich,34,12,22
-Reno,CITY #24,Attorney General,,D,Kotich,126,46,80
-Reno,CITY #25,Attorney General,,D,Kotich,87,36,51
-Reno,CITY #26,Attorney General,,D,Kotich,43,19,24
-Reno,CITY #26 EX,Attorney General,,D,Kotich,10,2,8
-Reno,CITY #27,Attorney General,,D,Kotich,67,21,46
-Reno,CITY #28,Attorney General,,D,Kotich,170,47,123
-Reno,CITY #28 EX,Attorney General,,D,Kotich,53,19,34
-Reno,CITY #29,Attorney General,,D,Kotich,94,32,62
-Reno,CITY #30,Attorney General,,D,Kotich,44,13,31
-Reno,CITY #31,Attorney General,,D,Kotich,89,31,58
-Reno,CITY #32,Attorney General,,D,Kotich,21,7,14
-Reno,CITY #33,Attorney General,,D,Kotich,36,10,26
-Reno,CITY #34,Attorney General,,D,Kotich,15,3,12
-Reno,CITY #34 EX,Attorney General,,D,Kotich,0,0,0
-Reno,CITY #35,Attorney General,,D,Kotich,54,10,44
-Reno,CITY #01-H102,Attorney General,,R,Schmidt,75,17,58
-Reno,CITY #01-HII4,Attorney General,,R,Schmidt,2,0,2
-Reno,CITY #02,Attorney General,,R,Schmidt,64,18,46
-Reno,CITY #03,Attorney General,,R,Schmidt,40,13,27
-Reno,CITY #04,Attorney General,,R,Schmidt,545,213,332
-Reno,CITY #05,Attorney General,,R,Schmidt,141,52,89
-Reno,CITY #06,Attorney General,,R,Schmidt,139,49,90
-Reno,CITY #07,Attorney General,,R,Schmidt,191,54,137
-Reno,CITY #08,Attorney General,,R,Schmidt,112,37,75
-Reno,CITY #09,Attorney General,,R,Schmidt,329,125,204
-Reno,CITY #10,Attorney General,,R,Schmidt,468,114,354
-Reno,CITY #11,Attorney General,,R,Schmidt,449,145,304
-Reno,CITY #12,Attorney General,,R,Schmidt,216,56,160
-Reno,CITY #13,Attorney General,,R,Schmidt,244,43,201
-Reno,CITY #14,Attorney General,,R,Schmidt,174,34,140
-Reno,CITY #15,Attorney General,,R,Schmidt,92,27,65
-Reno,CITY #16,Attorney General,,R,Schmidt,176,33,143
-Reno,CITY #17,Attorney General,,R,Schmidt,294,84,210
-Reno,CITY #18,Attorney General,,R,Schmidt,93,28,65
-Reno,CITY #19,Attorney General,,R,Schmidt,91,23,68
-Reno,CITY #20,Attorney General,,R,Schmidt,175,33,142
-Reno,CITY #21,Attorney General,,R,Schmidt,130,30,100
-Reno,CITY #22,Attorney General,,R,Schmidt,345,124,221
-Reno,CITY #23,Attorney General,,R,Schmidt,484,182,302
-Reno,CITY #23 EX,Attorney General,,R,Schmidt,105,23,82
-Reno,CITY #24,Attorney General,,R,Schmidt,322,81,241
-Reno,CITY #25,Attorney General,,R,Schmidt,108,22,86
-Reno,CITY #26,Attorney General,,R,Schmidt,93,26,67
-Reno,CITY #26 EX,Attorney General,,R,Schmidt,17,5,12
-Reno,CITY #27,Attorney General,,R,Schmidt,228,65,163
-Reno,CITY #28,Attorney General,,R,Schmidt,499,125,374
-Reno,CITY #28 EX,Attorney General,,R,Schmidt,289,97,192
-Reno,CITY #29,Attorney General,,R,Schmidt,215,71,144
-Reno,CITY #30,Attorney General,,R,Schmidt,89,26,63
-Reno,CITY #31,Attorney General,,R,Schmidt,185,64,121
-Reno,CITY #32,Attorney General,,R,Schmidt,78,21,57
-Reno,CITY #33,Attorney General,,R,Schmidt,127,25,102
-Reno,CITY #34,Attorney General,,R,Schmidt,35,13,22
-Reno,CITY #34 EX,Attorney General,,R,Schmidt,1,0,1
-Reno,CITY #35,Attorney General,,R,Schmidt,94,21,73
-Reno,CITY #01-H102,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #01-HII4,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #02,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #03,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #04,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #05,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #06,Attorney General,,,Write-ins,1,0,1
-Reno,CITY #07,Attorney General,,,Write-ins,1,0,1
-Reno,CITY #08,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #09,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #10,Attorney General,,,Write-ins,1,0,1
-Reno,CITY #11,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #12,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #13,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #14,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #15,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #16,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #17,Attorney General,,,Write-ins,1,0,1
-Reno,CITY #18,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #19,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #20,Attorney General,,,Write-ins,1,0,1
-Reno,CITY #21,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #22,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #23,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #23 EX,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #24,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #25,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #26,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #26 EX,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #27,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #28,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #28 EX,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #29,Attorney General,,,Write-ins,1,0,1
-Reno,CITY #30,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #31,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #32,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #33,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #34,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #34 EX,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #35,Attorney General,,,Write-ins,0,0,0
-Reno,CITY #01-H102,U.S. House,1,R,Huelskamp,69,17,52
-Reno,CITY #01-HII4,U.S. House,1,R,Huelskamp,1,0,1
-Reno,CITY #02,U.S. House,1,R,Huelskamp,57,16,41
-Reno,CITY #03,U.S. House,1,R,Huelskamp,35,10,25
-Reno,CITY #04,U.S. House,1,R,Huelskamp,450,162,288
-Reno,CITY #05,U.S. House,1,R,Huelskamp,143,48,95
-Reno,CITY #06,U.S. House,1,R,Huelskamp,134,44,90
-Reno,CITY #07,U.S. House,1,R,Huelskamp,166,39,127
-Reno,CITY #08,U.S. House,1,R,Huelskamp,98,30,68
-Reno,CITY #09,U.S. House,1,R,Huelskamp,259,100,159
-Reno,CITY #10,U.S. House,1,R,Huelskamp,362,83,279
-Reno,CITY #11,U.S. House,1,R,Huelskamp,363,98,265
-Reno,CITY #12,U.S. House,1,R,Huelskamp,172,42,130
-Reno,CITY #13,U.S. House,1,R,Huelskamp,219,31,188
-Reno,CITY #14,U.S. House,1,R,Huelskamp,162,28,134
-Reno,CITY #15,U.S. House,1,R,Huelskamp,92,25,67
-Reno,CITY #16,U.S. House,1,R,Huelskamp,157,29,128
-Reno,CITY #17,U.S. House,1,R,Huelskamp,256,81,175
-Reno,CITY #18,U.S. House,1,R,Huelskamp,86,22,64
-Reno,CITY #19,U.S. House,1,R,Huelskamp,76,14,62
-Reno,CITY #20,U.S. House,1,R,Huelskamp,157,31,126
-Reno,CITY #21,U.S. House,1,R,Huelskamp,125,24,101
-Reno,CITY #22,U.S. House,1,R,Huelskamp,285,101,184
-Reno,CITY #23,U.S. House,1,R,Huelskamp,410,147,263
-Reno,CITY #23 EX,U.S. House,1,R,Huelskamp,91,18,73
-Reno,CITY #24,U.S. House,1,R,Huelskamp,269,65,204
-Reno,CITY #25,U.S. House,1,R,Huelskamp,91,17,74
-Reno,CITY #26,U.S. House,1,R,Huelskamp,80,24,56
-Reno,CITY #26 EX,U.S. House,1,R,Huelskamp,18,5,13
-Reno,CITY #27,U.S. House,1,R,Huelskamp,174,51,123
-Reno,CITY #28,U.S. House,1,R,Huelskamp,420,98,322
-Reno,CITY #28 EX,U.S. House,1,R,Huelskamp,237,75,162
-Reno,CITY #29,U.S. House,1,R,Huelskamp,172,53,119
-Reno,CITY #30,U.S. House,1,R,Huelskamp,72,17,55
-Reno,CITY #31,U.S. House,1,R,Huelskamp,165,56,109
-Reno,CITY #32,U.S. House,1,R,Huelskamp,59,14,45
-Reno,CITY #33,U.S. House,1,R,Huelskamp,120,21,99
-Reno,CITY #34,U.S. House,1,R,Huelskamp,30,12,18
-Reno,CITY #34 EX,U.S. House,1,R,Huelskamp,1,0,1
-Reno,CITY #35,U.S. House,1,R,Huelskamp,84,18,66
-Reno,CITY #01-H102,U.S. House,1,D,Sherow,66,20,46
-Reno,CITY #01-HII4,U.S. House,1,D,Sherow,7,3,4
-Reno,CITY #02,U.S. House,1,D,Sherow,58,19,39
-Reno,CITY #03,U.S. House,1,D,Sherow,41,14,27
-Reno,CITY #04,U.S. House,1,D,Sherow,249,111,138
-Reno,CITY #05,U.S. House,1,D,Sherow,98,26,72
-Reno,CITY #06,U.S. House,1,D,Sherow,91,26,65
-Reno,CITY #07,U.S. House,1,D,Sherow,158,56,102
-Reno,CITY #08,U.S. House,1,D,Sherow,68,22,46
-Reno,CITY #09,U.S. House,1,D,Sherow,221,92,129
-Reno,CITY #10,U.S. House,1,D,Sherow,227,64,163
-Reno,CITY #11,U.S. House,1,D,Sherow,245,100,145
-Reno,CITY #12,U.S. House,1,D,Sherow,156,58,98
-Reno,CITY #13,U.S. House,1,D,Sherow,170,61,109
-Reno,CITY #14,U.S. House,1,D,Sherow,113,42,71
-Reno,CITY #15,U.S. House,1,D,Sherow,72,27,45
-Reno,CITY #16,U.S. House,1,D,Sherow,170,52,118
-Reno,CITY #17,U.S. House,1,D,Sherow,177,59,118
-Reno,CITY #18,U.S. House,1,D,Sherow,61,26,35
-Reno,CITY #19,U.S. House,1,D,Sherow,85,28,57
-Reno,CITY #20,U.S. House,1,D,Sherow,105,29,76
-Reno,CITY #21,U.S. House,1,D,Sherow,95,33,62
-Reno,CITY #22,U.S. House,1,D,Sherow,213,75,138
-Reno,CITY #23,U.S. House,1,D,Sherow,278,129,149
-Reno,CITY #23 EX,U.S. House,1,D,Sherow,52,19,33
-Reno,CITY #24,U.S. House,1,D,Sherow,175,61,114
-Reno,CITY #25,U.S. House,1,D,Sherow,106,42,64
-Reno,CITY #26,U.S. House,1,D,Sherow,59,21,38
-Reno,CITY #26 EX,U.S. House,1,D,Sherow,9,2,7
-Reno,CITY #27,U.S. House,1,D,Sherow,120,32,88
-Reno,CITY #28,U.S. House,1,D,Sherow,251,74,177
-Reno,CITY #28 EX,U.S. House,1,D,Sherow,108,43,65
-Reno,CITY #29,U.S. House,1,D,Sherow,138,50,88
-Reno,CITY #30,U.S. House,1,D,Sherow,61,21,40
-Reno,CITY #31,U.S. House,1,D,Sherow,112,39,73
-Reno,CITY #32,U.S. House,1,D,Sherow,40,13,27
-Reno,CITY #33,U.S. House,1,D,Sherow,43,13,30
-Reno,CITY #34,U.S. House,1,D,Sherow,18,4,14
-Reno,CITY #34 EX,U.S. House,1,D,Sherow,0,0,0
-Reno,CITY #35,U.S. House,1,D,Sherow,65,13,52
-Reno,CITY #01-H102,U.S. House,1,,Write-ins,1,0,1
-Reno,CITY #01-HII4,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #02,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #03,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #04,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #05,U.S. House,1,,Write-ins,1,0,1
-Reno,CITY #06,U.S. House,1,,Write-ins,1,0,1
-Reno,CITY #07,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #08,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #09,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #10,U.S. House,1,,Write-ins,3,1,2
-Reno,CITY #11,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #12,U.S. House,1,,Write-ins,3,1,2
-Reno,CITY #13,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #14,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #15,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #16,U.S. House,1,,Write-ins,3,0,3
-Reno,CITY #17,U.S. House,1,,Write-ins,2,0,2
-Reno,CITY #18,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #19,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #20,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #21,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #22,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #23,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #23 EX,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #24,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #25,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #26,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #26 EX,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #27,U.S. House,1,,Write-ins,1,0,1
-Reno,CITY #28,U.S. House,1,,Write-ins,1,0,1
-Reno,CITY #28 EX,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #29,U.S. House,1,,Write-ins,1,0,1
-Reno,CITY #30,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #31,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #32,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #33,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #34,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #34 EX,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #35,U.S. House,1,,Write-ins,0,0,0
-Reno,CITY #01-H102,Governor,,R,Brownback,43,10,33
-Reno,CITY #01-HII4,Governor,,R,Brownback,0,0,0
-Reno,CITY #02,Governor,,R,Brownback,46,12,34
-Reno,CITY #03,Governor,,R,Brownback,28,9,19
-Reno,CITY #04,Governor,,R,Brownback,371,137,234
-Reno,CITY #05,Governor,,R,Brownback,104,38,66
-Reno,CITY #06,Governor,,R,Brownback,102,39,63
-Reno,CITY #07,Governor,,R,Brownback,123,29,94
-Reno,CITY #08,Governor,,R,Brownback,87,32,55
-Reno,CITY #09,Governor,,R,Brownback,213,83,130
-Reno,CITY #10,Governor,,R,Brownback,289,70,219
-Reno,CITY #11,Governor,,R,Brownback,304,91,213
-Reno,CITY #12,Governor,,R,Brownback,157,43,114
-Reno,CITY #13,Governor,,R,Brownback,172,33,139
-Reno,CITY #14,Governor,,R,Brownback,134,23,111
-Reno,CITY #15,Governor,,R,Brownback,72,23,49
-Reno,CITY #16,Governor,,R,Brownback,115,19,96
-Reno,CITY #17,Governor,,R,Brownback,187,61,126
-Reno,CITY #18,Governor,,R,Brownback,61,16,45
-Reno,CITY #19,Governor,,R,Brownback,54,10,44
-Reno,CITY #20,Governor,,R,Brownback,117,23,94
-Reno,CITY #21,Governor,,R,Brownback,87,14,73
-Reno,CITY #22,Governor,,R,Brownback,219,77,142
-Reno,CITY #23,Governor,,R,Brownback,328,120,208
-Reno,CITY #23 EX,Governor,,R,Brownback,69,10,59
-Reno,CITY #24,Governor,,R,Brownback,211,54,157
-Reno,CITY #25,Governor,,R,Brownback,69,12,57
-Reno,CITY #26,Governor,,R,Brownback,56,19,37
-Reno,CITY #26 EX,Governor,,R,Brownback,11,4,7
-Reno,CITY #27,Governor,,R,Brownback,145,49,96
-Reno,CITY #28,Governor,,R,Brownback,349,85,264
-Reno,CITY #28 EX,Governor,,R,Brownback,216,71,145
-Reno,CITY #29,Governor,,R,Brownback,134,46,88
-Reno,CITY #30,Governor,,R,Brownback,55,16,39
-Reno,CITY #31,Governor,,R,Brownback,132,50,82
-Reno,CITY #32,Governor,,R,Brownback,52,14,38
-Reno,CITY #33,Governor,,R,Brownback,90,19,71
-Reno,CITY #34,Governor,,R,Brownback,25,9,16
-Reno,CITY #34 EX,Governor,,R,Brownback,1,0,1
-Reno,CITY #35,Governor,,R,Brownback,64,15,49
-Reno,CITY #01-H102,Governor,,D,Davis,78,22,56
-Reno,CITY #01-HII4,Governor,,D,Davis,8,3,5
-Reno,CITY #02,Governor,,D,Davis,65,21,44
-Reno,CITY #03,Governor,,D,Davis,44,16,28
-Reno,CITY #04,Governor,,D,Davis,328,138,190
-Reno,CITY #05,Governor,,D,Davis,119,28,91
-Reno,CITY #06,Governor,,D,Davis,117,30,87
-Reno,CITY #07,Governor,,D,Davis,194,67,127
-Reno,CITY #08,Governor,,D,Davis,73,18,55
-Reno,CITY #09,Governor,,D,Davis,248,104,144
-Reno,CITY #10,Governor,,D,Davis,293,73,220
-Reno,CITY #11,Governor,,D,Davis,288,101,187
-Reno,CITY #12,Governor,,D,Davis,176,61,115
-Reno,CITY #13,Governor,,D,Davis,212,59,153
-Reno,CITY #14,Governor,,D,Davis,132,45,87
-Reno,CITY #15,Governor,,D,Davis,84,28,56
-Reno,CITY #16,Governor,,D,Davis,199,57,142
-Reno,CITY #17,Governor,,D,Davis,240,79,161
-Reno,CITY #18,Governor,,D,Davis,74,27,47
-Reno,CITY #19,Governor,,D,Davis,90,22,68
-Reno,CITY #20,Governor,,D,Davis,129,34,95
-Reno,CITY #21,Governor,,D,Davis,118,39,79
-Reno,CITY #22,Governor,,D,Davis,267,97,170
-Reno,CITY #23,Governor,,D,Davis,347,152,195
-Reno,CITY #23 EX,Governor,,D,Davis,70,26,44
-Reno,CITY #24,Governor,,D,Davis,220,72,148
-Reno,CITY #25,Governor,,D,Davis,119,41,78
-Reno,CITY #26,Governor,,D,Davis,74,24,50
-Reno,CITY #26 EX,Governor,,D,Davis,13,2,11
-Reno,CITY #27,Governor,,D,Davis,148,37,111
-Reno,CITY #28,Governor,,D,Davis,303,84,219
-Reno,CITY #28 EX,Governor,,D,Davis,123,44,79
-Reno,CITY #29,Governor,,D,Davis,167,57,110
-Reno,CITY #30,Governor,,D,Davis,71,22,49
-Reno,CITY #31,Governor,,D,Davis,136,43,93
-Reno,CITY #32,Governor,,D,Davis,48,15,33
-Reno,CITY #33,Governor,,D,Davis,74,17,57
-Reno,CITY #34,Governor,,D,Davis,20,6,14
-Reno,CITY #34 EX,Governor,,D,Davis,0,0,0
-Reno,CITY #35,Governor,,D,Davis,77,12,65
-Reno,CITY #01-H102,Governor,,L,Umbehr,16,6,10
-Reno,CITY #01-HII4,Governor,,L,Umbehr,0,0,0
-Reno,CITY #02,Governor,,L,Umbehr,6,2,4
-Reno,CITY #03,Governor,,L,Umbehr,5,0,5
-Reno,CITY #04,Governor,,L,Umbehr,11,4,7
-Reno,CITY #05,Governor,,L,Umbehr,23,9,14
-Reno,CITY #06,Governor,,L,Umbehr,9,2,7
-Reno,CITY #07,Governor,,L,Umbehr,9,1,8
-Reno,CITY #08,Governor,,L,Umbehr,6,1,5
-Reno,CITY #09,Governor,,L,Umbehr,25,9,16
-Reno,CITY #10,Governor,,L,Umbehr,18,6,12
-Reno,CITY #11,Governor,,L,Umbehr,19,8,11
-Reno,CITY #12,Governor,,L,Umbehr,8,2,6
-Reno,CITY #13,Governor,,L,Umbehr,8,2,6
-Reno,CITY #14,Governor,,L,Umbehr,7,2,5
-Reno,CITY #15,Governor,,L,Umbehr,11,3,8
-Reno,CITY #16,Governor,,L,Umbehr,17,6,11
-Reno,CITY #17,Governor,,L,Umbehr,20,4,16
-Reno,CITY #18,Governor,,L,Umbehr,12,6,6
-Reno,CITY #19,Governor,,L,Umbehr,19,10,9
-Reno,CITY #20,Governor,,L,Umbehr,18,3,15
-Reno,CITY #21,Governor,,L,Umbehr,15,4,11
-Reno,CITY #22,Governor,,L,Umbehr,20,6,14
-Reno,CITY #23,Governor,,L,Umbehr,27,13,14
-Reno,CITY #23 EX,Governor,,L,Umbehr,5,2,3
-Reno,CITY #24,Governor,,L,Umbehr,20,1,19
-Reno,CITY #25,Governor,,L,Umbehr,9,3,6
-Reno,CITY #26,Governor,,L,Umbehr,10,2,8
-Reno,CITY #26 EX,Governor,,L,Umbehr,3,1,2
-Reno,CITY #27,Governor,,L,Umbehr,10,1,9
-Reno,CITY #28,Governor,,L,Umbehr,19,2,17
-Reno,CITY #28 EX,Governor,,L,Umbehr,4,2,2
-Reno,CITY #29,Governor,,L,Umbehr,14,1,13
-Reno,CITY #30,Governor,,L,Umbehr,9,1,8
-Reno,CITY #31,Governor,,L,Umbehr,10,3,7
-Reno,CITY #32,Governor,,L,Umbehr,2,0,2
-Reno,CITY #33,Governor,,L,Umbehr,5,0,5
-Reno,CITY #34,Governor,,L,Umbehr,5,1,4
-Reno,CITY #34 EX,Governor,,L,Umbehr,0,0,0
-Reno,CITY #35,Governor,,L,Umbehr,7,4,3
-Reno,CITY #01-H102,Governor,,,Write-ins,1,0,1
-Reno,CITY #01-HII4,Governor,,,Write-ins,0,0,0
-Reno,CITY #02,Governor,,,Write-ins,0,0,0
-Reno,CITY #03,Governor,,,Write-ins,0,0,0
-Reno,CITY #04,Governor,,,Write-ins,1,0,1
-Reno,CITY #05,Governor,,,Write-ins,0,0,0
-Reno,CITY #06,Governor,,,Write-ins,0,0,0
-Reno,CITY #07,Governor,,,Write-ins,0,0,0
-Reno,CITY #08,Governor,,,Write-ins,0,0,0
-Reno,CITY #09,Governor,,,Write-ins,2,0,2
-Reno,CITY #10,Governor,,,Write-ins,0,0,0
-Reno,CITY #11,Governor,,,Write-ins,1,1,0
-Reno,CITY #12,Governor,,,Write-ins,0,0,0
-Reno,CITY #13,Governor,,,Write-ins,0,0,0
-Reno,CITY #14,Governor,,,Write-ins,1,0,1
-Reno,CITY #15,Governor,,,Write-ins,0,0,0
-Reno,CITY #16,Governor,,,Write-ins,2,0,2
-Reno,CITY #17,Governor,,,Write-ins,0,0,0
-Reno,CITY #18,Governor,,,Write-ins,0,0,0
-Reno,CITY #19,Governor,,,Write-ins,0,0,0
-Reno,CITY #20,Governor,,,Write-ins,1,0,1
-Reno,CITY #21,Governor,,,Write-ins,1,0,1
-Reno,CITY #22,Governor,,,Write-ins,1,0,1
-Reno,CITY #23,Governor,,,Write-ins,4,0,4
-Reno,CITY #23 EX,Governor,,,Write-ins,0,0,0
-Reno,CITY #24,Governor,,,Write-ins,0,0,0
-Reno,CITY #25,Governor,,,Write-ins,0,0,0
-Reno,CITY #26,Governor,,,Write-ins,0,0,0
-Reno,CITY #26 EX,Governor,,,Write-ins,0,0,0
-Reno,CITY #27,Governor,,,Write-ins,0,0,0
-Reno,CITY #28,Governor,,,Write-ins,1,0,1
-Reno,CITY #28 EX,Governor,,,Write-ins,0,0,0
-Reno,CITY #29,Governor,,,Write-ins,0,0,0
-Reno,CITY #30,Governor,,,Write-ins,0,0,0
-Reno,CITY #31,Governor,,,Write-ins,0,0,0
-Reno,CITY #32,Governor,,,Write-ins,0,0,0
-Reno,CITY #33,Governor,,,Write-ins,0,0,0
-Reno,CITY #34,Governor,,,Write-ins,0,0,0
-Reno,CITY #34 EX,Governor,,,Write-ins,0,0,0
-Reno,CITY #35,Governor,,,Write-ins,0,0,0
-Reno,CITY #01-H102,Insurance Commissioner,,D,Anderson,74,23,51
-Reno,CITY #01-HII4,Insurance Commissioner,,D,Anderson,7,3,4
-Reno,CITY #02,Insurance Commissioner,,D,Anderson,58,21,37
-Reno,CITY #03,Insurance Commissioner,,D,Anderson,40,15,25
-Reno,CITY #04,Insurance Commissioner,,D,Anderson,201,84,117
-Reno,CITY #05,Insurance Commissioner,,D,Anderson,111,23,88
-Reno,CITY #06,Insurance Commissioner,,D,Anderson,106,29,77
-Reno,CITY #07,Insurance Commissioner,,D,Anderson,144,52,92
-Reno,CITY #08,Insurance Commissioner,,D,Anderson,59,19,40
-Reno,CITY #09,Insurance Commissioner,,D,Anderson,188,85,103
-Reno,CITY #10,Insurance Commissioner,,D,Anderson,176,46,130
-Reno,CITY #11,Insurance Commissioner,,D,Anderson,191,72,119
-Reno,CITY #12,Insurance Commissioner,,D,Anderson,142,55,87
-Reno,CITY #13,Insurance Commissioner,,D,Anderson,163,51,112
-Reno,CITY #14,Insurance Commissioner,,D,Anderson,112,38,74
-Reno,CITY #15,Insurance Commissioner,,D,Anderson,78,23,55
-Reno,CITY #16,Insurance Commissioner,,D,Anderson,159,53,106
-Reno,CITY #17,Insurance Commissioner,,D,Anderson,159,57,102
-Reno,CITY #18,Insurance Commissioner,,D,Anderson,63,29,34
-Reno,CITY #19,Insurance Commissioner,,D,Anderson,77,20,57
-Reno,CITY #20,Insurance Commissioner,,D,Anderson,106,31,75
-Reno,CITY #21,Insurance Commissioner,,D,Anderson,98,33,65
-Reno,CITY #22,Insurance Commissioner,,D,Anderson,190,70,120
-Reno,CITY #23,Insurance Commissioner,,D,Anderson,237,116,121
-Reno,CITY #23 EX,Insurance Commissioner,,D,Anderson,43,17,26
-Reno,CITY #24,Insurance Commissioner,,D,Anderson,168,54,114
-Reno,CITY #25,Insurance Commissioner,,D,Anderson,98,40,58
-Reno,CITY #26,Insurance Commissioner,,D,Anderson,53,18,35
-Reno,CITY #26 EX,Insurance Commissioner,,D,Anderson,10,2,8
-Reno,CITY #27,Insurance Commissioner,,D,Anderson,93,28,65
-Reno,CITY #28,Insurance Commissioner,,D,Anderson,225,62,163
-Reno,CITY #28 EX,Insurance Commissioner,,D,Anderson,72,29,43
-Reno,CITY #29,Insurance Commissioner,,D,Anderson,121,44,77
-Reno,CITY #30,Insurance Commissioner,,D,Anderson,56,18,38
-Reno,CITY #31,Insurance Commissioner,,D,Anderson,102,37,65
-Reno,CITY #32,Insurance Commissioner,,D,Anderson,34,12,22
-Reno,CITY #33,Insurance Commissioner,,D,Anderson,43,13,30
-Reno,CITY #34,Insurance Commissioner,,D,Anderson,17,2,15
-Reno,CITY #34 EX,Insurance Commissioner,,D,Anderson,0,0,0
-Reno,CITY #35,Insurance Commissioner,,D,Anderson,60,12,48
-Reno,CITY #01-H102,Insurance Commissioner,,R,Selzer,60,15,45
-Reno,CITY #01-HII4,Insurance Commissioner,,R,Selzer,1,0,1
-Reno,CITY #02,Insurance Commissioner,,R,Selzer,56,14,42
-Reno,CITY #03,Insurance Commissioner,,R,Selzer,36,9,27
-Reno,CITY #04,Insurance Commissioner,,R,Selzer,485,183,302
-Reno,CITY #05,Insurance Commissioner,,R,Selzer,130,49,81
-Reno,CITY #06,Insurance Commissioner,,R,Selzer,118,42,76
-Reno,CITY #07,Insurance Commissioner,,R,Selzer,170,38,132
-Reno,CITY #08,Insurance Commissioner,,R,Selzer,104,32,72
-Reno,CITY #09,Insurance Commissioner,,R,Selzer,285,104,181
-Reno,CITY #10,Insurance Commissioner,,R,Selzer,407,95,312
-Reno,CITY #11,Insurance Commissioner,,R,Selzer,405,122,283
-Reno,CITY #12,Insurance Commissioner,,R,Selzer,184,46,138
-Reno,CITY #13,Insurance Commissioner,,R,Selzer,214,40,174
-Reno,CITY #14,Insurance Commissioner,,R,Selzer,159,32,127
-Reno,CITY #15,Insurance Commissioner,,R,Selzer,80,25,55
-Reno,CITY #16,Insurance Commissioner,,R,Selzer,158,26,132
-Reno,CITY #17,Insurance Commissioner,,R,Selzer,267,81,186
-Reno,CITY #18,Insurance Commissioner,,R,Selzer,82,18,64
-Reno,CITY #19,Insurance Commissioner,,R,Selzer,79,18,61
-Reno,CITY #20,Insurance Commissioner,,R,Selzer,148,28,120
-Reno,CITY #21,Insurance Commissioner,,R,Selzer,113,20,93
-Reno,CITY #22,Insurance Commissioner,,R,Selzer,304,108,196
-Reno,CITY #23,Insurance Commissioner,,R,Selzer,439,156,283
-Reno,CITY #23 EX,Insurance Commissioner,,R,Selzer,94,18,76
-Reno,CITY #24,Insurance Commissioner,,R,Selzer,273,71,202
-Reno,CITY #25,Insurance Commissioner,,R,Selzer,88,14,74
-Reno,CITY #26,Insurance Commissioner,,R,Selzer,82,27,55
-Reno,CITY #26 EX,Insurance Commissioner,,R,Selzer,17,5,12
-Reno,CITY #27,Insurance Commissioner,,R,Selzer,195,56,139
-Reno,CITY #28,Insurance Commissioner,,R,Selzer,439,108,331
-Reno,CITY #28 EX,Insurance Commissioner,,R,Selzer,268,87,181
-Reno,CITY #29,Insurance Commissioner,,R,Selzer,186,57,129
-Reno,CITY #30,Insurance Commissioner,,R,Selzer,78,21,57
-Reno,CITY #31,Insurance Commissioner,,R,Selzer,170,57,113
-Reno,CITY #32,Insurance Commissioner,,R,Selzer,65,15,50
-Reno,CITY #33,Insurance Commissioner,,R,Selzer,119,22,97
-Reno,CITY #34,Insurance Commissioner,,R,Selzer,33,14,19
-Reno,CITY #34 EX,Insurance Commissioner,,R,Selzer,1,0,1
-Reno,CITY #35,Insurance Commissioner,,R,Selzer,87,19,68
-Reno,CITY #01-H102,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #01-HII4,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #02,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #03,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #04,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #05,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #06,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,CITY #07,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #08,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #09,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,CITY #10,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #11,Insurance Commissioner,,,Write-ins,2,1,1
-Reno,CITY #12,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,CITY #13,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #14,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #15,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #16,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #17,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #18,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #19,Insurance Commissioner,,,Write-ins,1,1,0
-Reno,CITY #20,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #21,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #22,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #23,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #23 EX,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #24,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #25,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #26,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #26 EX,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #27,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #28,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #28 EX,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #29,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #30,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #31,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #32,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,CITY #33,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #34,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #34 EX,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #35,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,CITY #01-H102,Secretary of State,,R,Kobach,59,14,45
-Reno,CITY #01-HII4,Secretary of State,,R,Kobach,2,0,2
-Reno,CITY #02,Secretary of State,,R,Kobach,58,14,44
-Reno,CITY #03,Secretary of State,,R,Kobach,28,8,20
-Reno,CITY #04,Secretary of State,,R,Kobach,446,162,284
-Reno,CITY #05,Secretary of State,,R,Kobach,128,47,81
-Reno,CITY #06,Secretary of State,,R,Kobach,120,44,76
-Reno,CITY #07,Secretary of State,,R,Kobach,152,37,115
-Reno,CITY #08,Secretary of State,,R,Kobach,97,33,64
-Reno,CITY #09,Secretary of State,,R,Kobach,256,97,159
-Reno,CITY #10,Secretary of State,,R,Kobach,375,83,292
-Reno,CITY #11,Secretary of State,,R,Kobach,374,102,272
-Reno,CITY #12,Secretary of State,,R,Kobach,164,43,121
-Reno,CITY #13,Secretary of State,,R,Kobach,207,41,166
-Reno,CITY #14,Secretary of State,,R,Kobach,148,28,120
-Reno,CITY #15,Secretary of State,,R,Kobach,85,24,61
-Reno,CITY #16,Secretary of State,,R,Kobach,147,24,123
-Reno,CITY #17,Secretary of State,,R,Kobach,237,70,167
-Reno,CITY #18,Secretary of State,,R,Kobach,73,18,55
-Reno,CITY #19,Secretary of State,,R,Kobach,72,18,54
-Reno,CITY #20,Secretary of State,,R,Kobach,145,30,115
-Reno,CITY #21,Secretary of State,,R,Kobach,111,21,90
-Reno,CITY #22,Secretary of State,,R,Kobach,285,101,184
-Reno,CITY #23,Secretary of State,,R,Kobach,410,141,269
-Reno,CITY #23 EX,Secretary of State,,R,Kobach,98,22,76
-Reno,CITY #24,Secretary of State,,R,Kobach,256,65,191
-Reno,CITY #25,Secretary of State,,R,Kobach,91,20,71
-Reno,CITY #26,Secretary of State,,R,Kobach,73,23,50
-Reno,CITY #26 EX,Secretary of State,,R,Kobach,16,4,12
-Reno,CITY #27,Secretary of State,,R,Kobach,186,53,133
-Reno,CITY #28,Secretary of State,,R,Kobach,431,100,331
-Reno,CITY #28 EX,Secretary of State,,R,Kobach,247,76,171
-Reno,CITY #29,Secretary of State,,R,Kobach,173,55,118
-Reno,CITY #30,Secretary of State,,R,Kobach,74,21,53
-Reno,CITY #31,Secretary of State,,R,Kobach,163,55,108
-Reno,CITY #32,Secretary of State,,R,Kobach,64,16,48
-Reno,CITY #33,Secretary of State,,R,Kobach,112,21,91
-Reno,CITY #34,Secretary of State,,R,Kobach,32,13,19
-Reno,CITY #34 EX,Secretary of State,,R,Kobach,1,0,1
-Reno,CITY #35,Secretary of State,,R,Kobach,84,18,66
-Reno,CITY #01-H102,Secretary of State,,D,Schodorf,79,24,55
-Reno,CITY #01-HII4,Secretary of State,,D,Schodorf,6,3,3
-Reno,CITY #02,Secretary of State,,D,Schodorf,59,22,37
-Reno,CITY #03,Secretary of State,,D,Schodorf,48,16,32
-Reno,CITY #04,Secretary of State,,D,Schodorf,262,116,146
-Reno,CITY #05,Secretary of State,,D,Schodorf,114,27,87
-Reno,CITY #06,Secretary of State,,D,Schodorf,106,27,79
-Reno,CITY #07,Secretary of State,,D,Schodorf,168,59,109
-Reno,CITY #08,Secretary of State,,D,Schodorf,69,18,51
-Reno,CITY #09,Secretary of State,,D,Schodorf,227,98,129
-Reno,CITY #10,Secretary of State,,D,Schodorf,228,65,163
-Reno,CITY #11,Secretary of State,,D,Schodorf,240,98,142
-Reno,CITY #12,Secretary of State,,D,Schodorf,168,61,107
-Reno,CITY #13,Secretary of State,,D,Schodorf,181,51,130
-Reno,CITY #14,Secretary of State,,D,Schodorf,125,42,83
-Reno,CITY #15,Secretary of State,,D,Schodorf,79,28,51
-Reno,CITY #16,Secretary of State,,D,Schodorf,181,58,123
-Reno,CITY #17,Secretary of State,,D,Schodorf,201,72,129
-Reno,CITY #18,Secretary of State,,D,Schodorf,74,31,43
-Reno,CITY #19,Secretary of State,,D,Schodorf,89,24,65
-Reno,CITY #20,Secretary of State,,D,Schodorf,112,30,82
-Reno,CITY #21,Secretary of State,,D,Schodorf,107,34,73
-Reno,CITY #22,Secretary of State,,D,Schodorf,215,78,137
-Reno,CITY #23,Secretary of State,,D,Schodorf,287,140,147
-Reno,CITY #23 EX,Secretary of State,,D,Schodorf,45,16,29
-Reno,CITY #24,Secretary of State,,D,Schodorf,196,64,132
-Reno,CITY #25,Secretary of State,,D,Schodorf,100,36,64
-Reno,CITY #26,Secretary of State,,D,Schodorf,63,22,41
-Reno,CITY #26 EX,Secretary of State,,D,Schodorf,11,3,8
-Reno,CITY #27,Secretary of State,,D,Schodorf,111,32,79
-Reno,CITY #28,Secretary of State,,D,Schodorf,243,74,169
-Reno,CITY #28 EX,Secretary of State,,D,Schodorf,99,42,57
-Reno,CITY #29,Secretary of State,,D,Schodorf,140,49,91
-Reno,CITY #30,Secretary of State,,D,Schodorf,61,17,44
-Reno,CITY #31,Secretary of State,,D,Schodorf,113,40,73
-Reno,CITY #32,Secretary of State,,D,Schodorf,38,13,25
-Reno,CITY #33,Secretary of State,,D,Schodorf,55,15,40
-Reno,CITY #34,Secretary of State,,D,Schodorf,18,3,15
-Reno,CITY #34 EX,Secretary of State,,D,Schodorf,0,0,0
-Reno,CITY #35,Secretary of State,,D,Schodorf,65,13,52
-Reno,CITY #01-H102,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #01-HII4,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #02,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #03,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #04,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #05,Secretary of State,,,Write-ins,1,0,1
-Reno,CITY #06,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #07,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #08,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #09,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #10,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #11,Secretary of State,,,Write-ins,1,1,0
-Reno,CITY #12,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #13,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #14,Secretary of State,,,Write-ins,1,0,1
-Reno,CITY #15,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #16,Secretary of State,,,Write-ins,1,0,1
-Reno,CITY #17,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #18,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #19,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #20,Secretary of State,,,Write-ins,1,0,1
-Reno,CITY #21,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #22,Secretary of State,,,Write-ins,1,0,1
-Reno,CITY #23,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #23 EX,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #24,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #25,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #26,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #26 EX,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #27,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #28,Secretary of State,,,Write-ins,1,0,1
-Reno,CITY #28 EX,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #29,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #30,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #31,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #32,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #33,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #34,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #34 EX,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #35,Secretary of State,,,Write-ins,0,0,0
-Reno,CITY #01-H102,State House,102,D,Brian Davis,71,21,50
-Reno,CITY #02,State House,102,D,Brian Davis,62,25,37
-Reno,CITY #05,State House,102,D,Brian Davis,120,29,91
-Reno,CITY #06,State House,102,D,Brian Davis,107,30,77
-Reno,CITY #07,State House,102,D,Brian Davis,167,59,108
-Reno,CITY #08,State House,102,D,Brian Davis,66,16,50
-Reno,CITY #09,State House,102,D,Brian Davis,206,94,112
-Reno,CITY #14,State House,102,D,Brian Davis,110,40,70
-Reno,CITY #15,State House,102,D,Brian Davis,72,25,47
-Reno,CITY #16,State House,102,D,Brian Davis,164,56,108
-Reno,CITY #18,State House,102,D,Brian Davis,68,33,35
-Reno,CITY #19,State House,102,D,Brian Davis,87,26,61
-Reno,CITY #20,State House,102,D,Brian Davis,113,26,87
-Reno,CITY #25,State House,102,D,Brian Davis,104,33,71
-Reno,CITY #26,State House,102,D,Brian Davis,72,24,48
-Reno,CITY #26 EX,State House,102,D,Brian Davis,13,2,11
-Reno,CITY #29,State House,102,D,Brian Davis,131,46,85
-Reno,CITY #30,State House,102,D,Brian Davis,63,21,42
-Reno,CITY #34,State House,102,D,Brian Davis,18,5,13
-Reno,CITY #34 EX,State House,102,D,Brian Davis,0,0,0
-Reno,CITY #35,State House,102,D,Brian Davis,64,12,52
-Reno,CITY #01-H102,State House,102,R,Jan Pauls,67,17,50
-Reno,CITY #02,State House,102,R,Jan Pauls,54,11,43
-Reno,CITY #05,State House,102,R,Jan Pauls,125,45,80
-Reno,CITY #06,State House,102,R,Jan Pauls,119,40,79
-Reno,CITY #07,State House,102,R,Jan Pauls,158,37,121
-Reno,CITY #08,State House,102,R,Jan Pauls,97,32,65
-Reno,CITY #09,State House,102,R,Jan Pauls,273,102,171
-Reno,CITY #14,State House,102,R,Jan Pauls,163,29,134
-Reno,CITY #15,State House,102,R,Jan Pauls,94,29,65
-Reno,CITY #16,State House,102,R,Jan Pauls,169,26,143
-Reno,CITY #18,State House,102,R,Jan Pauls,79,16,63
-Reno,CITY #19,State House,102,R,Jan Pauls,76,16,60
-Reno,CITY #20,State House,102,R,Jan Pauls,150,34,116
-Reno,CITY #25,State House,102,R,Jan Pauls,94,26,68
-Reno,CITY #26,State House,102,R,Jan Pauls,67,21,46
-Reno,CITY #26 EX,State House,102,R,Jan Pauls,14,5,9
-Reno,CITY #29,State House,102,R,Jan Pauls,177,57,120
-Reno,CITY #30,State House,102,R,Jan Pauls,73,18,55
-Reno,CITY #34,State House,102,R,Jan Pauls,32,11,21
-Reno,CITY #34 EX,State House,102,R,Jan Pauls,1,0,1
-Reno,CITY #35,State House,102,R,Jan Pauls,84,19,65
-Reno,CITY #01-H102,State House,102,,Write-ins,0,0,0
-Reno,CITY #02,State House,102,,Write-ins,0,0,0
-Reno,CITY #05,State House,102,,Write-ins,0,0,0
-Reno,CITY #06,State House,102,,Write-ins,1,0,1
-Reno,CITY #07,State House,102,,Write-ins,0,0,0
-Reno,CITY #08,State House,102,,Write-ins,0,0,0
-Reno,CITY #09,State House,102,,Write-ins,3,0,3
-Reno,CITY #14,State House,102,,Write-ins,2,1,1
-Reno,CITY #15,State House,102,,Write-ins,0,0,0
-Reno,CITY #16,State House,102,,Write-ins,0,0,0
-Reno,CITY #18,State House,102,,Write-ins,1,1,0
-Reno,CITY #19,State House,102,,Write-ins,0,0,0
-Reno,CITY #20,State House,102,,Write-ins,0,0,0
-Reno,CITY #25,State House,102,,Write-ins,0,0,0
-Reno,CITY #26,State House,102,,Write-ins,0,0,0
-Reno,CITY #26 EX,State House,102,,Write-ins,0,0,0
-Reno,CITY #29,State House,102,,Write-ins,2,0,2
-Reno,CITY #30,State House,102,,Write-ins,0,0,0
-Reno,CITY #34,State House,102,,Write-ins,0,0,0
-Reno,CITY #34 EX,State House,102,,Write-ins,0,0,0
-Reno,CITY #35,State House,102,,Write-ins,0,0,0
-Reno,CITY #04,State House,104,R,Stephen Becker,625,244,381
-Reno,CITY #10,State House,104,R,Stephen Becker,533,128,405
-Reno,CITY #11,State House,104,R,Stephen Becker,550,178,372
-Reno,CITY #12,State House,104,R,Stephen Becker,293,83,210
-Reno,CITY #13,State House,104,R,Stephen Becker,338,83,255
-Reno,CITY #17,State House,104,R,Stephen Becker,385,121,264
-Reno,CITY #21,State House,104,R,Stephen Becker,193,51,142
-Reno,CITY #22,State House,104,R,Stephen Becker,443,159,284
-Reno,CITY #23,State House,104,R,Stephen Becker,621,240,381
-Reno,CITY #23 EX,State House,104,R,Stephen Becker,122,30,92
-Reno,CITY #24,State House,104,R,Stephen Becker,408,108,300
-Reno,CITY #27,State House,104,R,Stephen Becker,263,71,192
-Reno,CITY #28,State House,104,R,Stephen Becker,601,149,452
-Reno,CITY #28 EX,State House,104,R,Stephen Becker,315,104,211
-Reno,CITY #31,State House,104,R,Stephen Becker,246,85,161
-Reno,CITY #32,State House,104,R,Stephen Becker,91,26,65
-Reno,CITY #33,State House,104,R,Stephen Becker,152,32,120
-Reno,CITY #04,State House,104,,Write-ins,11,4,7
-Reno,CITY #10,State House,104,,Write-ins,9,2,7
-Reno,CITY #11,State House,104,,Write-ins,9,4,5
-Reno,CITY #12,State House,104,,Write-ins,8,1,7
-Reno,CITY #13,State House,104,,Write-ins,13,0,13
-Reno,CITY #17,State House,104,,Write-ins,9,5,4
-Reno,CITY #21,State House,104,,Write-ins,5,0,5
-Reno,CITY #22,State House,104,,Write-ins,11,3,8
-Reno,CITY #23,State House,104,,Write-ins,12,4,8
-Reno,CITY #23 EX,State House,104,,Write-ins,3,0,3
-Reno,CITY #24,State House,104,,Write-ins,4,1,3
-Reno,CITY #27,State House,104,,Write-ins,5,1,4
-Reno,CITY #28,State House,104,,Write-ins,16,2,14
-Reno,CITY #28 EX,State House,104,,Write-ins,5,2,3
-Reno,CITY #31,State House,104,,Write-ins,3,1,2
-Reno,CITY #32,State House,104,,Write-ins,3,2,1
-Reno,CITY #33,State House,104,,Write-ins,2,0,2
-Reno,CITY #01-HII4,State House,114,R,Jack Thimisch,0,0,0
-Reno,CITY #03,State House,114,R,Jack Thimisch,35,9,26
-Reno,CITY #01-HII4,State House,114,D,Mark Schnittker,8,3,5
-Reno,CITY #03,State House,114,D,Mark Schnittker,41,15,26
-Reno,CITY #01-HII4,State House,114,,Write-ins,0,0,0
-Reno,CITY #03,State House,114,,Write-ins,0,0,0
-Reno,CITY #01-H102,State Treasurer,,D,Alldritt,71,21,50
-Reno,CITY #01-HII4,State Treasurer,,D,Alldritt,6,3,3
-Reno,CITY #02,State Treasurer,,D,Alldritt,52,18,34
-Reno,CITY #03,State Treasurer,,D,Alldritt,43,15,28
-Reno,CITY #04,State Treasurer,,D,Alldritt,126,52,74
-Reno,CITY #05,State Treasurer,,D,Alldritt,96,18,78
-Reno,CITY #06,State Treasurer,,D,Alldritt,87,26,61
-Reno,CITY #07,State Treasurer,,D,Alldritt,118,45,73
-Reno,CITY #08,State Treasurer,,D,Alldritt,53,17,36
-Reno,CITY #09,State Treasurer,,D,Alldritt,144,67,77
-Reno,CITY #10,State Treasurer,,D,Alldritt,122,38,84
-Reno,CITY #11,State Treasurer,,D,Alldritt,155,61,94
-Reno,CITY #12,State Treasurer,,D,Alldritt,103,44,59
-Reno,CITY #13,State Treasurer,,D,Alldritt,138,44,94
-Reno,CITY #14,State Treasurer,,D,Alldritt,92,34,58
-Reno,CITY #15,State Treasurer,,D,Alldritt,62,21,41
-Reno,CITY #16,State Treasurer,,D,Alldritt,141,45,96
-Reno,CITY #17,State Treasurer,,D,Alldritt,122,50,72
-Reno,CITY #18,State Treasurer,,D,Alldritt,54,26,28
-Reno,CITY #19,State Treasurer,,D,Alldritt,62,18,44
-Reno,CITY #20,State Treasurer,,D,Alldritt,84,25,59
-Reno,CITY #21,State Treasurer,,D,Alldritt,75,26,49
-Reno,CITY #22,State Treasurer,,D,Alldritt,158,62,96
-Reno,CITY #23,State Treasurer,,D,Alldritt,189,99,90
-Reno,CITY #23 EX,State Treasurer,,D,Alldritt,32,15,17
-Reno,CITY #24,State Treasurer,,D,Alldritt,130,44,86
-Reno,CITY #25,State Treasurer,,D,Alldritt,87,35,52
-Reno,CITY #26,State Treasurer,,D,Alldritt,48,15,33
-Reno,CITY #26 EX,State Treasurer,,D,Alldritt,10,1,9
-Reno,CITY #27,State Treasurer,,D,Alldritt,69,20,49
-Reno,CITY #28,State Treasurer,,D,Alldritt,157,47,110
-Reno,CITY #28 EX,State Treasurer,,D,Alldritt,38,13,25
-Reno,CITY #29,State Treasurer,,D,Alldritt,92,35,57
-Reno,CITY #30,State Treasurer,,D,Alldritt,51,16,35
-Reno,CITY #31,State Treasurer,,D,Alldritt,84,33,51
-Reno,CITY #32,State Treasurer,,D,Alldritt,22,8,14
-Reno,CITY #33,State Treasurer,,D,Alldritt,31,9,22
-Reno,CITY #34,State Treasurer,,D,Alldritt,14,2,12
-Reno,CITY #34 EX,State Treasurer,,D,Alldritt,0,0,0
-Reno,CITY #35,State Treasurer,,D,Alldritt,47,9,38
-Reno,CITY #01-H102,State Treasurer,,R,Estes,64,17,47
-Reno,CITY #01-HII4,State Treasurer,,R,Estes,2,0,2
-Reno,CITY #02,State Treasurer,,R,Estes,65,18,47
-Reno,CITY #03,State Treasurer,,R,Estes,33,9,24
-Reno,CITY #04,State Treasurer,,R,Estes,561,217,344
-Reno,CITY #05,State Treasurer,,R,Estes,145,54,91
-Reno,CITY #06,State Treasurer,,R,Estes,139,45,94
-Reno,CITY #07,State Treasurer,,R,Estes,196,47,149
-Reno,CITY #08,State Treasurer,,R,Estes,111,34,77
-Reno,CITY #09,State Treasurer,,R,Estes,336,126,210
-Reno,CITY #10,State Treasurer,,R,Estes,470,110,360
-Reno,CITY #11,State Treasurer,,R,Estes,449,137,312
-Reno,CITY #12,State Treasurer,,R,Estes,228,58,170
-Reno,CITY #13,State Treasurer,,R,Estes,240,47,193
-Reno,CITY #14,State Treasurer,,R,Estes,177,37,140
-Reno,CITY #15,State Treasurer,,R,Estes,99,30,69
-Reno,CITY #16,State Treasurer,,R,Estes,181,35,146
-Reno,CITY #17,State Treasurer,,R,Estes,304,91,213
-Reno,CITY #18,State Treasurer,,R,Estes,94,24,70
-Reno,CITY #19,State Treasurer,,R,Estes,96,21,75
-Reno,CITY #20,State Treasurer,,R,Estes,174,35,139
-Reno,CITY #21,State Treasurer,,R,Estes,141,30,111
-Reno,CITY #22,State Treasurer,,R,Estes,339,114,225
-Reno,CITY #23,State Treasurer,,R,Estes,496,178,318
-Reno,CITY #23 EX,State Treasurer,,R,Estes,106,20,86
-Reno,CITY #24,State Treasurer,,R,Estes,312,81,231
-Reno,CITY #25,State Treasurer,,R,Estes,107,21,86
-Reno,CITY #26,State Treasurer,,R,Estes,88,30,58
-Reno,CITY #26 EX,State Treasurer,,R,Estes,17,6,11
-Reno,CITY #27,State Treasurer,,R,Estes,226,66,160
-Reno,CITY #28,State Treasurer,,R,Estes,507,122,385
-Reno,CITY #28 EX,State Treasurer,,R,Estes,302,103,199
-Reno,CITY #29,State Treasurer,,R,Estes,215,67,148
-Reno,CITY #30,State Treasurer,,R,Estes,84,23,61
-Reno,CITY #31,State Treasurer,,R,Estes,190,61,129
-Reno,CITY #32,State Treasurer,,R,Estes,79,20,59
-Reno,CITY #33,State Treasurer,,R,Estes,133,27,106
-Reno,CITY #34,State Treasurer,,R,Estes,36,14,22
-Reno,CITY #34 EX,State Treasurer,,R,Estes,1,0,1
-Reno,CITY #35,State Treasurer,,R,Estes,99,22,77
-Reno,CITY #01-H102,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #01-HII4,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #02,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #03,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #04,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #05,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #06,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #07,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #08,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #09,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #10,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #11,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #12,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #13,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #14,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #15,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #16,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #17,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #18,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #19,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #20,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #21,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #22,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #23,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #23 EX,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #24,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #25,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #26,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #26 EX,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #27,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #28,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #28 EX,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #29,State Treasurer,,,Write-ins,1,0,1
-Reno,CITY #30,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #31,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #32,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #33,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #34,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #34 EX,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #35,State Treasurer,,,Write-ins,0,0,0
-Reno,CITY #01-H102,U.S. Senate,,L,Batson,16,7,9
-Reno,CITY #01-HII4,U.S. Senate,,L,Batson,0,0,0
-Reno,CITY #02,U.S. Senate,,L,Batson,5,2,3
-Reno,CITY #03,U.S. Senate,,L,Batson,5,0,5
-Reno,CITY #04,U.S. Senate,,L,Batson,20,5,15
-Reno,CITY #05,U.S. Senate,,L,Batson,17,5,12
-Reno,CITY #06,U.S. Senate,,L,Batson,14,4,10
-Reno,CITY #07,U.S. Senate,,L,Batson,19,5,14
-Reno,CITY #08,U.S. Senate,,L,Batson,14,5,9
-Reno,CITY #09,U.S. Senate,,L,Batson,33,16,17
-Reno,CITY #10,U.S. Senate,,L,Batson,18,4,14
-Reno,CITY #11,U.S. Senate,,L,Batson,27,7,20
-Reno,CITY #12,U.S. Senate,,L,Batson,11,2,9
-Reno,CITY #13,U.S. Senate,,L,Batson,19,5,14
-Reno,CITY #14,U.S. Senate,,L,Batson,14,3,11
-Reno,CITY #15,U.S. Senate,,L,Batson,10,2,8
-Reno,CITY #16,U.S. Senate,,L,Batson,15,6,9
-Reno,CITY #17,U.S. Senate,,L,Batson,20,4,16
-Reno,CITY #18,U.S. Senate,,L,Batson,14,5,9
-Reno,CITY #19,U.S. Senate,,L,Batson,19,9,10
-Reno,CITY #20,U.S. Senate,,L,Batson,19,3,16
-Reno,CITY #21,U.S. Senate,,L,Batson,12,6,6
-Reno,CITY #22,U.S. Senate,,L,Batson,22,7,15
-Reno,CITY #23,U.S. Senate,,L,Batson,34,12,22
-Reno,CITY #23 EX,U.S. Senate,,L,Batson,4,1,3
-Reno,CITY #24,U.S. Senate,,L,Batson,25,2,23
-Reno,CITY #25,U.S. Senate,,L,Batson,11,2,9
-Reno,CITY #26,U.S. Senate,,L,Batson,8,1,7
-Reno,CITY #26 EX,U.S. Senate,,L,Batson,3,1,2
-Reno,CITY #27,U.S. Senate,,L,Batson,13,3,10
-Reno,CITY #28,U.S. Senate,,L,Batson,22,3,19
-Reno,CITY #28 EX,U.S. Senate,,L,Batson,5,1,4
-Reno,CITY #29,U.S. Senate,,L,Batson,15,2,13
-Reno,CITY #30,U.S. Senate,,L,Batson,16,4,12
-Reno,CITY #31,U.S. Senate,,L,Batson,13,6,7
-Reno,CITY #32,U.S. Senate,,L,Batson,3,1,2
-Reno,CITY #33,U.S. Senate,,L,Batson,5,0,5
-Reno,CITY #34,U.S. Senate,,L,Batson,5,3,2
-Reno,CITY #34 EX,U.S. Senate,,L,Batson,0,0,0
-Reno,CITY #35,U.S. Senate,,L,Batson,10,1,9
-Reno,CITY #01-H102,U.S. Senate,,I,Orman,69,19,50
-Reno,CITY #01-HII4,U.S. Senate,,I,Orman,7,3,4
-Reno,CITY #02,U.S. Senate,,I,Orman,63,20,43
-Reno,CITY #03,U.S. Senate,,I,Orman,39,13,26
-Reno,CITY #04,U.S. Senate,,I,Orman,281,121,160
-Reno,CITY #05,U.S. Senate,,I,Orman,110,27,83
-Reno,CITY #06,U.S. Senate,,I,Orman,102,28,74
-Reno,CITY #07,U.S. Senate,,I,Orman,167,62,105
-Reno,CITY #08,U.S. Senate,,I,Orman,68,20,48
-Reno,CITY #09,U.S. Senate,,I,Orman,223,93,130
-Reno,CITY #10,U.S. Senate,,I,Orman,252,67,185
-Reno,CITY #11,U.S. Senate,,I,Orman,250,93,157
-Reno,CITY #12,U.S. Senate,,I,Orman,153,56,97
-Reno,CITY #13,U.S. Senate,,I,Orman,193,57,136
-Reno,CITY #14,U.S. Senate,,I,Orman,124,46,78
-Reno,CITY #15,U.S. Senate,,I,Orman,82,27,55
-Reno,CITY #16,U.S. Senate,,I,Orman,181,54,127
-Reno,CITY #17,U.S. Senate,,I,Orman,199,68,131
-Reno,CITY #18,U.S. Senate,,I,Orman,72,30,42
-Reno,CITY #19,U.S. Senate,,I,Orman,83,22,61
-Reno,CITY #20,U.S. Senate,,I,Orman,126,29,97
-Reno,CITY #21,U.S. Senate,,I,Orman,112,34,78
-Reno,CITY #22,U.S. Senate,,I,Orman,236,89,147
-Reno,CITY #23,U.S. Senate,,I,Orman,303,142,161
-Reno,CITY #23 EX,U.S. Senate,,I,Orman,64,25,39
-Reno,CITY #24,U.S. Senate,,I,Orman,186,61,125
-Reno,CITY #25,U.S. Senate,,I,Orman,112,41,71
-Reno,CITY #26,U.S. Senate,,I,Orman,66,22,44
-Reno,CITY #26 EX,U.S. Senate,,I,Orman,13,2,11
-Reno,CITY #27,U.S. Senate,,I,Orman,129,35,94
-Reno,CITY #28,U.S. Senate,,I,Orman,266,73,193
-Reno,CITY #28 EX,U.S. Senate,,I,Orman,102,45,57
-Reno,CITY #29,U.S. Senate,,I,Orman,148,54,94
-Reno,CITY #30,U.S. Senate,,I,Orman,59,18,41
-Reno,CITY #31,U.S. Senate,,I,Orman,121,38,83
-Reno,CITY #32,U.S. Senate,,I,Orman,39,11,28
-Reno,CITY #33,U.S. Senate,,I,Orman,58,18,40
-Reno,CITY #34,U.S. Senate,,I,Orman,16,4,12
-Reno,CITY #34 EX,U.S. Senate,,I,Orman,0,0,0
-Reno,CITY #35,U.S. Senate,,I,Orman,66,14,52
-Reno,CITY #01-H102,U.S. Senate,,R,Roberts,50,11,39
-Reno,CITY #01-HII4,U.S. Senate,,R,Roberts,1,0,1
-Reno,CITY #02,U.S. Senate,,R,Roberts,47,12,35
-Reno,CITY #03,U.S. Senate,,R,Roberts,31,11,20
-Reno,CITY #04,U.S. Senate,,R,Roberts,407,154,253
-Reno,CITY #05,U.S. Senate,,R,Roberts,115,42,73
-Reno,CITY #06,U.S. Senate,,R,Roberts,110,37,73
-Reno,CITY #07,U.S. Senate,,R,Roberts,139,30,109
-Reno,CITY #08,U.S. Senate,,R,Roberts,82,26,56
-Reno,CITY #09,U.S. Senate,,R,Roberts,227,84,143
-Reno,CITY #10,U.S. Senate,,R,Roberts,326,79,247
-Reno,CITY #11,U.S. Senate,,R,Roberts,335,99,236
-Reno,CITY #12,U.S. Senate,,R,Roberts,173,46,127
-Reno,CITY #13,U.S. Senate,,R,Roberts,176,29,147
-Reno,CITY #14,U.S. Senate,,R,Roberts,139,22,117
-Reno,CITY #15,U.S. Senate,,R,Roberts,73,23,50
-Reno,CITY #16,U.S. Senate,,R,Roberts,130,21,109
-Reno,CITY #17,U.S. Senate,,R,Roberts,219,68,151
-Reno,CITY #18,U.S. Senate,,R,Roberts,62,15,47
-Reno,CITY #19,U.S. Senate,,R,Roberts,56,10,46
-Reno,CITY #20,U.S. Senate,,R,Roberts,119,27,92
-Reno,CITY #21,U.S. Senate,,R,Roberts,94,16,78
-Reno,CITY #22,U.S. Senate,,R,Roberts,246,83,163
-Reno,CITY #23,U.S. Senate,,R,Roberts,361,124,237
-Reno,CITY #23 EX,U.S. Senate,,R,Roberts,76,12,64
-Reno,CITY #24,U.S. Senate,,R,Roberts,234,63,171
-Reno,CITY #25,U.S. Senate,,R,Roberts,73,15,58
-Reno,CITY #26,U.S. Senate,,R,Roberts,64,22,42
-Reno,CITY #26 EX,U.S. Senate,,R,Roberts,11,4,7
-Reno,CITY #27,U.S. Senate,,R,Roberts,157,47,110
-Reno,CITY #28,U.S. Senate,,R,Roberts,381,96,285
-Reno,CITY #28 EX,U.S. Senate,,R,Roberts,239,71,168
-Reno,CITY #29,U.S. Senate,,R,Roberts,148,48,100
-Reno,CITY #30,U.S. Senate,,R,Roberts,60,17,43
-Reno,CITY #31,U.S. Senate,,R,Roberts,142,50,92
-Reno,CITY #32,U.S. Senate,,R,Roberts,59,16,43
-Reno,CITY #33,U.S. Senate,,R,Roberts,106,18,88
-Reno,CITY #34,U.S. Senate,,R,Roberts,28,9,19
-Reno,CITY #34 EX,U.S. Senate,,R,Roberts,1,0,1
-Reno,CITY #35,U.S. Senate,,R,Roberts,73,16,57
-Reno,CITY #01-H102,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #01-HII4,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #02,U.S. Senate,,,Write-ins,1,0,1
-Reno,CITY #03,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #04,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #05,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #06,U.S. Senate,,,Write-ins,1,1,0
-Reno,CITY #07,U.S. Senate,,,Write-ins,1,0,1
-Reno,CITY #08,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #09,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #10,U.S. Senate,,,Write-ins,1,0,1
-Reno,CITY #11,U.S. Senate,,,Write-ins,1,1,0
-Reno,CITY #12,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #13,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #14,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #15,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #16,U.S. Senate,,,Write-ins,2,0,2
-Reno,CITY #17,U.S. Senate,,,Write-ins,3,1,2
-Reno,CITY #18,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #19,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #20,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #21,U.S. Senate,,,Write-ins,1,0,1
-Reno,CITY #22,U.S. Senate,,,Write-ins,1,0,1
-Reno,CITY #23,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #23 EX,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #24,U.S. Senate,,,Write-ins,1,0,1
-Reno,CITY #25,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #26,U.S. Senate,,,Write-ins,1,0,1
-Reno,CITY #26 EX,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #27,U.S. Senate,,,Write-ins,1,0,1
-Reno,CITY #28,U.S. Senate,,,Write-ins,2,1,1
-Reno,CITY #28 EX,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #29,U.S. Senate,,,Write-ins,2,0,2
-Reno,CITY #30,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #31,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #32,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #33,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #34,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #34 EX,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #35,U.S. Senate,,,Write-ins,0,0,0
-Reno,CITY #01-H102,Voters,,,Ballots,138,38,100
-Reno,CITY #01-HII4,Voters,,,Ballots,8,3,5
-Reno,CITY #02,Voters,,,Ballots,119,36,83
-Reno,CITY #03,Voters,,,Ballots,77,25,52
-Reno,CITY #04,Voters,,,Ballots,717,281,436
-Reno,CITY #05,Voters,,,Ballots,247,76,171
-Reno,CITY #06,Voters,,,Ballots,228,71,157
-Reno,CITY #07,Voters,,,Ballots,328,98,230
-Reno,CITY #08,Voters,,,Ballots,167,52,115
-Reno,CITY #09,Voters,,,Ballots,491,198,293
-Reno,CITY #10,Voters,,,Ballots,612,152,460
-Reno,CITY #11,Voters,,,Ballots,619,203,416
-Reno,CITY #12,Voters,,,Ballots,342,106,236
-Reno,CITY #13,Voters,,,Ballots,393,95,298
-Reno,CITY #14,Voters,,,Ballots,280,72,208
-Reno,CITY #15,Voters,,,Ballots,167,54,113
-Reno,CITY #16,Voters,,,Ballots,335,83,252
-Reno,CITY #17,Voters,,,Ballots,450,146,304
-Reno,CITY #18,Voters,,,Ballots,149,50,99
-Reno,CITY #19,Voters,,,Ballots,163,42,121
-Reno,CITY #20,Voters,,,Ballots,266,60,206
-Reno,CITY #21,Voters,,,Ballots,221,57,164
-Reno,CITY #22,Voters,,,Ballots,511,181,330
-Reno,CITY #23,Voters,,,Ballots,710,286,424
-Reno,CITY #23 EX,Voters,,,Ballots,144,38,106
-Reno,CITY #24,Voters,,,Ballots,456,131,325
-Reno,CITY #25,Voters,,,Ballots,201,60,141
-Reno,CITY #26,Voters,,,Ballots,140,45,95
-Reno,CITY #26 EX,Voters,,,Ballots,28,8,20
-Reno,CITY #27,Voters,,,Ballots,303,87,216
-Reno,CITY #28,Voters,,,Ballots,679,175,504
-Reno,CITY #28 EX,Voters,,,Ballots,347,118,229
-Reno,CITY #29,Voters,,,Ballots,316,104,212
-Reno,CITY #30,Voters,,,Ballots,136,39,97
-Reno,CITY #31,Voters,,,Ballots,281,98,183
-Reno,CITY #32,Voters,,,Ballots,102,29,73
-Reno,CITY #33,Voters,,,Ballots,169,36,133
-Reno,CITY #34,Voters,,,Ballots,50,16,34
-Reno,CITY #34 EX,Voters,,,Ballots,1,0,1
-Reno,CITY #35,Voters,,,Ballots,149,31,118
-Reno,CITY #01-H102,Voters,,,Registered,545,545,545
-Reno,CITY #01-HII4,Voters,,,Registered,33,33,33
-Reno,CITY #02,Voters,,,Registered,551,551,551
-Reno,CITY #03,Voters,,,Registered,327,327,327
-Reno,CITY #04,Voters,,,Registered,1171,1171,1171
-Reno,CITY #05,Voters,,,Registered,878,878,878
-Reno,CITY #06,Voters,,,Registered,681,681,681
-Reno,CITY #07,Voters,,,Registered,844,844,844
-Reno,CITY #08,Voters,,,Registered,370,370,370
-Reno,CITY #09,Voters,,,Registered,1009,1009,1009
-Reno,CITY #10,Voters,,,Registered,1026,1026,1026
-Reno,CITY #11,Voters,,,Registered,1052,1052,1052
-Reno,CITY #12,Voters,,,Registered,719,719,719
-Reno,CITY #13,Voters,,,Registered,807,807,807
-Reno,CITY #14,Voters,,,Registered,705,705,705
-Reno,CITY #15,Voters,,,Registered,691,691,691
-Reno,CITY #16,Voters,,,Registered,984,984,984
-Reno,CITY #17,Voters,,,Registered,864,864,864
-Reno,CITY #18,Voters,,,Registered,465,465,465
-Reno,CITY #19,Voters,,,Registered,552,552,552
-Reno,CITY #20,Voters,,,Registered,753,753,753
-Reno,CITY #21,Voters,,,Registered,1250,1250,1250
-Reno,CITY #22,Voters,,,Registered,1043,1043,1043
-Reno,CITY #23,Voters,,,Registered,1316,1316,1316
-Reno,CITY #23 EX,Voters,,,Registered,257,257,257
-Reno,CITY #24,Voters,,,Registered,847,847,847
-Reno,CITY #25,Voters,,,Registered,843,843,843
-Reno,CITY #26,Voters,,,Registered,366,366,366
-Reno,CITY #26 EX,Voters,,,Registered,87,87,87
-Reno,CITY #27,Voters,,,Registered,635,635,635
-Reno,CITY #28,Voters,,,Registered,1203,1203,1203
-Reno,CITY #28 EX,Voters,,,Registered,517,517,517
-Reno,CITY #29,Voters,,,Registered,576,576,576
-Reno,CITY #30,Voters,,,Registered,448,448,448
-Reno,CITY #31,Voters,,,Registered,676,676,676
-Reno,CITY #32,Voters,,,Registered,152,152,152
-Reno,CITY #33,Voters,,,Registered,249,249,249
-Reno,CITY #34,Voters,,,Registered,141,141,141
-Reno,CITY #34 EX,Voters,,,Registered,1,1,1
-Reno,CITY #35,Voters,,,Registered,360,360,360
-Reno,Albion twp,Attorney General,,D,Kotich,59,8,51
-Reno,Arlington twp,Attorney General,,D,Kotich,59,5,54
-Reno,Bell twp,Attorney General,,D,Kotich,6,1,5
-Reno,Castleton twp,Attorney General,,D,Kotich,27,5,22
-Reno,Center twp,Attorney General,,D,Kotich,26,4,22
-Reno,Clay N twp,Attorney General,,D,Kotich,85,30,55
-Reno,Clay S 101 twp,Attorney General,,D,Kotich,89,24,65
-Reno,Clay S H102A twp,Attorney General,,D,Kotich,1,0,1
-Reno,Enterprise twp,Attorney General,,D,Kotich,9,3,6
-Reno,Grant twp,Attorney General,,D,Kotich,122,28,94
-Reno,Grove twp,Attorney General,,D,Kotich,3,0,3
-Reno,Haven twp,Attorney General,,D,Kotich,142,20,122
-Reno,Hayes twp,Attorney General,,D,Kotich,4,2,2
-Reno,Huntsville twp,Attorney General,,D,Kotich,3,0,3
-Reno,Langdon twp,Attorney General,,D,Kotich,8,1,7
-Reno,Lincoln twp,Attorney General,,D,Kotich,18,5,13
-Reno,Little River twp,Attorney General,,D,Kotich,143,28,115
-Reno,Loda twp,Attorney General,,D,Kotich,8,4,4
-Reno,Medford twp,Attorney General,,D,Kotich,6,3,3
-Reno,Medora twp,Attorney General,,D,Kotich,134,43,91
-Reno,Miami twp,Attorney General,,D,Kotich,31,5,26
-Reno,Nickerson Ward #1,Attorney General,,D,Kotich,33,1,32
-Reno,Nickerson Ward #2,Attorney General,,D,Kotich,19,2,17
-Reno,Nickerson Ward #3,Attorney General,,D,Kotich,23,7,16
-Reno,Ninnescah twp,Attorney General,,D,Kotich,23,4,19
-Reno,Plevna twp,Attorney General,,D,Kotich,10,0,10
-Reno,Reno N twp,Attorney General,,D,Kotich,133,38,95
-Reno,Reno S twp,Attorney General,,D,Kotich,19,1,18
-Reno,Roscoe twp,Attorney General,,D,Kotich,8,0,8
-Reno,S Hutchinson #1,Attorney General,,D,Kotich,53,13,40
-Reno,S Hutchinson #2,Attorney General,,D,Kotich,72,15,57
-Reno,S Hutchinson #3,Attorney General,,D,Kotich,75,13,62
-Reno,Salt Creek twp,Attorney General,,D,Kotich,20,2,18
-Reno,Sumner twp,Attorney General,,D,Kotich,36,2,34
-Reno,Sylvia twp,Attorney General,,D,Kotich,16,1,15
-Reno,Troy twp,Attorney General,,D,Kotich,11,2,9
-Reno,Valley twp,Attorney General,,D,Kotich,61,23,38
-Reno,Walnut twp,Attorney General,,D,Kotich,6,3,3
-Reno,Westminster twp,Attorney General,,D,Kotich,19,0,19
-Reno,Yoder twp,Attorney General,,D,Kotich,30,7,23
-Reno,Albion twp,Attorney General,,R,Schmidt,255,24,231
-Reno,Arlington twp,Attorney General,,R,Schmidt,121,17,104
-Reno,Bell twp,Attorney General,,R,Schmidt,25,3,22
-Reno,Castleton twp,Attorney General,,R,Schmidt,96,11,85
-Reno,Center twp,Attorney General,,R,Schmidt,97,13,84
-Reno,Clay N twp,Attorney General,,R,Schmidt,300,61,239
-Reno,Clay S 101 twp,Attorney General,,R,Schmidt,278,40,238
-Reno,Clay S H102A twp,Attorney General,,R,Schmidt,5,2,3
-Reno,Enterprise twp,Attorney General,,R,Schmidt,51,5,46
-Reno,Grant twp,Attorney General,,R,Schmidt,496,98,398
-Reno,Grove twp,Attorney General,,R,Schmidt,18,2,16
-Reno,Haven twp,Attorney General,,R,Schmidt,420,38,382
-Reno,Hayes twp,Attorney General,,R,Schmidt,26,9,17
-Reno,Huntsville twp,Attorney General,,R,Schmidt,46,5,41
-Reno,Langdon twp,Attorney General,,R,Schmidt,36,4,32
-Reno,Lincoln twp,Attorney General,,R,Schmidt,131,9,122
-Reno,Little River twp,Attorney General,,R,Schmidt,644,102,542
-Reno,Loda twp,Attorney General,,R,Schmidt,34,5,29
-Reno,Medford twp,Attorney General,,R,Schmidt,56,7,49
-Reno,Medora twp,Attorney General,,R,Schmidt,521,99,422
-Reno,Miami twp,Attorney General,,R,Schmidt,80,9,71
-Reno,Nickerson Ward #1,Attorney General,,R,Schmidt,92,16,76
-Reno,Nickerson Ward #2,Attorney General,,R,Schmidt,51,9,42
-Reno,Nickerson Ward #3,Attorney General,,R,Schmidt,65,13,52
-Reno,Ninnescah twp,Attorney General,,R,Schmidt,54,11,43
-Reno,Plevna twp,Attorney General,,R,Schmidt,85,11,74
-Reno,Reno N twp,Attorney General,,R,Schmidt,418,82,336
-Reno,Reno S twp,Attorney General,,R,Schmidt,86,13,73
-Reno,Roscoe twp,Attorney General,,R,Schmidt,34,4,30
-Reno,S Hutchinson #1,Attorney General,,R,Schmidt,103,21,82
-Reno,S Hutchinson #2,Attorney General,,R,Schmidt,247,40,207
-Reno,S Hutchinson #3,Attorney General,,R,Schmidt,190,23,167
-Reno,Salt Creek twp,Attorney General,,R,Schmidt,115,13,102
-Reno,Sumner twp,Attorney General,,R,Schmidt,188,12,176
-Reno,Sylvia twp,Attorney General,,R,Schmidt,88,12,76
-Reno,Troy twp,Attorney General,,R,Schmidt,42,6,36
-Reno,Valley twp,Attorney General,,R,Schmidt,251,63,188
-Reno,Walnut twp,Attorney General,,R,Schmidt,46,8,38
-Reno,Westminster twp,Attorney General,,R,Schmidt,68,8,60
-Reno,Yoder twp,Attorney General,,R,Schmidt,168,23,145
-Reno,Albion twp,Attorney General,,,Write-ins,1,0,1
-Reno,Arlington twp,Attorney General,,,Write-ins,0,0,0
-Reno,Bell twp,Attorney General,,,Write-ins,0,0,0
-Reno,Castleton twp,Attorney General,,,Write-ins,0,0,0
-Reno,Center twp,Attorney General,,,Write-ins,0,0,0
-Reno,Clay N twp,Attorney General,,,Write-ins,1,0,1
-Reno,Clay S 101 twp,Attorney General,,,Write-ins,1,0,1
-Reno,Clay S H102A twp,Attorney General,,,Write-ins,0,0,0
-Reno,Enterprise twp,Attorney General,,,Write-ins,0,0,0
-Reno,Grant twp,Attorney General,,,Write-ins,1,0,1
-Reno,Grove twp,Attorney General,,,Write-ins,0,0,0
-Reno,Haven twp,Attorney General,,,Write-ins,0,0,0
-Reno,Hayes twp,Attorney General,,,Write-ins,0,0,0
-Reno,Huntsville twp,Attorney General,,,Write-ins,0,0,0
-Reno,Langdon twp,Attorney General,,,Write-ins,0,0,0
-Reno,Lincoln twp,Attorney General,,,Write-ins,1,0,1
-Reno,Little River twp,Attorney General,,,Write-ins,1,0,1
-Reno,Loda twp,Attorney General,,,Write-ins,0,0,0
-Reno,Medford twp,Attorney General,,,Write-ins,0,0,0
-Reno,Medora twp,Attorney General,,,Write-ins,0,0,0
-Reno,Miami twp,Attorney General,,,Write-ins,1,0,1
-Reno,Nickerson Ward #1,Attorney General,,,Write-ins,1,0,1
-Reno,Nickerson Ward #2,Attorney General,,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,Attorney General,,,Write-ins,0,0,0
-Reno,Ninnescah twp,Attorney General,,,Write-ins,0,0,0
-Reno,Plevna twp,Attorney General,,,Write-ins,0,0,0
-Reno,Reno N twp,Attorney General,,,Write-ins,0,0,0
-Reno,Reno S twp,Attorney General,,,Write-ins,0,0,0
-Reno,Roscoe twp,Attorney General,,,Write-ins,0,0,0
-Reno,S Hutchinson #1,Attorney General,,,Write-ins,0,0,0
-Reno,S Hutchinson #2,Attorney General,,,Write-ins,0,0,0
-Reno,S Hutchinson #3,Attorney General,,,Write-ins,0,0,0
-Reno,Salt Creek twp,Attorney General,,,Write-ins,0,0,0
-Reno,Sumner twp,Attorney General,,,Write-ins,1,1,0
-Reno,Sylvia twp,Attorney General,,,Write-ins,0,0,0
-Reno,Troy twp,Attorney General,,,Write-ins,0,0,0
-Reno,Valley twp,Attorney General,,,Write-ins,1,0,1
-Reno,Walnut twp,Attorney General,,,Write-ins,0,0,0
-Reno,Westminster twp,Attorney General,,,Write-ins,0,0,0
-Reno,Yoder twp,Attorney General,,,Write-ins,0,0,0
-Reno,Albion twp,U.S. House,1,R,Huelskamp,227,21,206
-Reno,Arlington twp,U.S. House,1,R,Huelskamp,109,16,93
-Reno,Bell twp,U.S. House,1,R,Huelskamp,20,3,17
-Reno,Castleton twp,U.S. House,1,R,Huelskamp,27,1,26
-Reno,Center twp,U.S. House,1,R,Huelskamp,94,11,83
-Reno,Clay N twp,U.S. House,1,R,Huelskamp,249,55,194
-Reno,Clay S 101 twp,U.S. House,1,R,Huelskamp,256,34,222
-Reno,Clay S H102A twp,U.S. House,1,R,Huelskamp,4,1,3
-Reno,Enterprise twp,U.S. House,1,R,Huelskamp,48,4,44
-Reno,Grant twp,U.S. House,1,R,Huelskamp,417,73,344
-Reno,Grove twp,U.S. House,1,R,Huelskamp,17,2,15
-Reno,Haven twp,U.S. House,1,R,Huelskamp,373,33,340
-Reno,Hayes twp,U.S. House,1,R,Huelskamp,24,7,17
-Reno,Huntsville twp,U.S. House,1,R,Huelskamp,40,5,35
-Reno,Langdon twp,U.S. House,1,R,Huelskamp,33,4,29
-Reno,Lincoln twp,U.S. House,1,R,Huelskamp,118,5,113
-Reno,Little River twp,U.S. House,1,R,Huelskamp,580,85,495
-Reno,Loda twp,U.S. House,1,R,Huelskamp,29,4,25
-Reno,Medford twp,U.S. House,1,R,Huelskamp,50,7,43
-Reno,Medora twp,U.S. House,1,R,Huelskamp,468,90,378
-Reno,Miami twp,U.S. House,1,R,Huelskamp,76,9,67
-Reno,Nickerson Ward #1,U.S. House,1,R,Huelskamp,84,13,71
-Reno,Nickerson Ward #2,U.S. House,1,R,Huelskamp,44,6,38
-Reno,Nickerson Ward #3,U.S. House,1,R,Huelskamp,55,11,44
-Reno,Ninnescah twp,U.S. House,1,R,Huelskamp,54,11,43
-Reno,Plevna twp,U.S. House,1,R,Huelskamp,79,10,69
-Reno,Reno N twp,U.S. House,1,R,Huelskamp,387,70,317
-Reno,Reno S twp,U.S. House,1,R,Huelskamp,70,8,62
-Reno,Roscoe twp,U.S. House,1,R,Huelskamp,25,3,22
-Reno,S Hutchinson #1,U.S. House,1,R,Huelskamp,84,16,68
-Reno,S Hutchinson #2,U.S. House,1,R,Huelskamp,212,33,179
-Reno,S Hutchinson #3,U.S. House,1,R,Huelskamp,168,21,147
-Reno,Salt Creek twp,U.S. House,1,R,Huelskamp,113,15,98
-Reno,Sumner twp,U.S. House,1,R,Huelskamp,175,10,165
-Reno,Sylvia twp,U.S. House,1,R,Huelskamp,75,12,63
-Reno,Troy twp,U.S. House,1,R,Huelskamp,29,5,24
-Reno,Valley twp,U.S. House,1,R,Huelskamp,229,59,170
-Reno,Walnut twp,U.S. House,1,R,Huelskamp,46,7,39
-Reno,Westminster twp,U.S. House,1,R,Huelskamp,70,8,62
-Reno,Yoder twp,U.S. House,1,R,Huelskamp,158,22,136
-Reno,Albion twp,U.S. House,1,D,Sherow,91,11,80
-Reno,Arlington twp,U.S. House,1,D,Sherow,74,7,67
-Reno,Bell twp,U.S. House,1,D,Sherow,11,1,10
-Reno,Castleton twp,U.S. House,1,D,Sherow,14,3,11
-Reno,Center twp,U.S. House,1,D,Sherow,38,6,32
-Reno,Clay N twp,U.S. House,1,D,Sherow,134,36,98
-Reno,Clay S 101 twp,U.S. House,1,D,Sherow,112,31,81
-Reno,Clay S H102A twp,U.S. House,1,D,Sherow,4,3,1
-Reno,Enterprise twp,U.S. House,1,D,Sherow,13,4,9
-Reno,Grant twp,U.S. House,1,D,Sherow,201,53,148
-Reno,Grove twp,U.S. House,1,D,Sherow,4,0,4
-Reno,Haven twp,U.S. House,1,D,Sherow,183,22,161
-Reno,Hayes twp,U.S. House,1,D,Sherow,6,4,2
-Reno,Huntsville twp,U.S. House,1,D,Sherow,9,0,9
-Reno,Langdon twp,U.S. House,1,D,Sherow,11,1,10
-Reno,Lincoln twp,U.S. House,1,D,Sherow,34,9,25
-Reno,Little River twp,U.S. House,1,D,Sherow,213,46,167
-Reno,Loda twp,U.S. House,1,D,Sherow,13,5,8
-Reno,Medford twp,U.S. House,1,D,Sherow,10,2,8
-Reno,Medora twp,U.S. House,1,D,Sherow,190,55,135
-Reno,Miami twp,U.S. House,1,D,Sherow,40,5,35
-Reno,Nickerson Ward #1,U.S. House,1,D,Sherow,42,3,39
-Reno,Nickerson Ward #2,U.S. House,1,D,Sherow,27,6,21
-Reno,Nickerson Ward #3,U.S. House,1,D,Sherow,32,8,24
-Reno,Ninnescah twp,U.S. House,1,D,Sherow,24,4,20
-Reno,Plevna twp,U.S. House,1,D,Sherow,18,1,17
-Reno,Reno N twp,U.S. House,1,D,Sherow,168,52,116
-Reno,Reno S twp,U.S. House,1,D,Sherow,36,6,30
-Reno,Roscoe twp,U.S. House,1,D,Sherow,16,1,15
-Reno,S Hutchinson #1,U.S. House,1,D,Sherow,69,15,54
-Reno,S Hutchinson #2,U.S. House,1,D,Sherow,107,20,87
-Reno,S Hutchinson #3,U.S. House,1,D,Sherow,100,16,84
-Reno,Salt Creek twp,U.S. House,1,D,Sherow,28,0,28
-Reno,Sumner twp,U.S. House,1,D,Sherow,55,5,50
-Reno,Sylvia twp,U.S. House,1,D,Sherow,26,1,25
-Reno,Troy twp,U.S. House,1,D,Sherow,24,3,21
-Reno,Valley twp,U.S. House,1,D,Sherow,84,30,54
-Reno,Walnut twp,U.S. House,1,D,Sherow,7,4,3
-Reno,Westminster twp,U.S. House,1,D,Sherow,20,0,20
-Reno,Yoder twp,U.S. House,1,D,Sherow,41,8,33
-Reno,Albion twp,U.S. House,1,,Write-ins,1,0,1
-Reno,Arlington twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Bell twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Castleton twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Center twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Clay N twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Clay S 101 twp,U.S. House,1,,Write-ins,1,1,0
-Reno,Clay S H102A twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Enterprise twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Grant twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Grove twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Haven twp,U.S. House,1,,Write-ins,3,1,2
-Reno,Hayes twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Huntsville twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Langdon twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Lincoln twp,U.S. House,1,,Write-ins,1,0,1
-Reno,Little River twp,U.S. House,1,,Write-ins,1,0,1
-Reno,Loda twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Medford twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Medora twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Miami twp,U.S. House,1,,Write-ins,1,0,1
-Reno,Nickerson Ward #1,U.S. House,1,,Write-ins,1,0,1
-Reno,Nickerson Ward #2,U.S. House,1,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,U.S. House,1,,Write-ins,0,0,0
-Reno,Ninnescah twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Plevna twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Reno N twp,U.S. House,1,,Write-ins,1,0,1
-Reno,Reno S twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Roscoe twp,U.S. House,1,,Write-ins,0,0,0
-Reno,S Hutchinson #1,U.S. House,1,,Write-ins,0,0,0
-Reno,S Hutchinson #2,U.S. House,1,,Write-ins,0,0,0
-Reno,S Hutchinson #3,U.S. House,1,,Write-ins,0,0,0
-Reno,Salt Creek twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Sumner twp,U.S. House,1,,Write-ins,1,1,0
-Reno,Sylvia twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Troy twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Valley twp,U.S. House,1,,Write-ins,1,0,1
-Reno,Walnut twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Westminster twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Yoder twp,U.S. House,1,,Write-ins,0,0,0
-Reno,Albion twp,Governor,,R,Brownback,196,20,176
-Reno,Arlington twp,Governor,,R,Brownback,77,10,67
-Reno,Bell twp,Governor,,R,Brownback,25,3,22
-Reno,Castleton twp,Governor,,R,Brownback,76,9,67
-Reno,Center twp,Governor,,R,Brownback,88,10,78
-Reno,Clay N twp,Governor,,R,Brownback,210,44,166
-Reno,Clay S 101 twp,Governor,,R,Brownback,209,30,179
-Reno,Clay S H102A twp,Governor,,R,Brownback,4,1,3
-Reno,Enterprise twp,Governor,,R,Brownback,44,2,42
-Reno,Grant twp,Governor,,R,Brownback,376,72,304
-Reno,Grove twp,Governor,,R,Brownback,16,2,14
-Reno,Haven twp,Governor,,R,Brownback,314,23,291
-Reno,Hayes twp,Governor,,R,Brownback,20,6,14
-Reno,Huntsville twp,Governor,,R,Brownback,36,3,33
-Reno,Langdon twp,Governor,,R,Brownback,20,2,18
-Reno,Lincoln twp,Governor,,R,Brownback,106,7,99
-Reno,Little River twp,Governor,,R,Brownback,499,78,421
-Reno,Loda twp,Governor,,R,Brownback,29,5,24
-Reno,Medford twp,Governor,,R,Brownback,43,6,37
-Reno,Medora twp,Governor,,R,Brownback,401,76,325
-Reno,Miami twp,Governor,,R,Brownback,61,7,54
-Reno,Nickerson Ward #1,Governor,,R,Brownback,61,10,51
-Reno,Nickerson Ward #2,Governor,,R,Brownback,32,4,28
-Reno,Nickerson Ward #3,Governor,,R,Brownback,39,10,29
-Reno,Ninnescah twp,Governor,,R,Brownback,40,9,31
-Reno,Plevna twp,Governor,,R,Brownback,75,10,65
-Reno,Reno N twp,Governor,,R,Brownback,314,55,259
-Reno,Reno S twp,Governor,,R,Brownback,63,9,54
-Reno,Roscoe twp,Governor,,R,Brownback,26,4,22
-Reno,S Hutchinson #1,Governor,,R,Brownback,77,15,62
-Reno,S Hutchinson #2,Governor,,R,Brownback,187,30,157
-Reno,S Hutchinson #3,Governor,,R,Brownback,133,16,117
-Reno,Salt Creek twp,Governor,,R,Brownback,99,12,87
-Reno,Sumner twp,Governor,,R,Brownback,158,11,147
-Reno,Sylvia twp,Governor,,R,Brownback,59,8,51
-Reno,Troy twp,Governor,,R,Brownback,32,5,27
-Reno,Valley twp,Governor,,R,Brownback,189,47,142
-Reno,Walnut twp,Governor,,R,Brownback,43,7,36
-Reno,Westminster twp,Governor,,R,Brownback,51,8,43
-Reno,Yoder twp,Governor,,R,Brownback,152,21,131
-Reno,Albion twp,Governor,,D,Davis,119,10,109
-Reno,Arlington twp,Governor,,D,Davis,92,10,82
-Reno,Bell twp,Governor,,D,Davis,8,1,7
-Reno,Castleton twp,Governor,,D,Davis,46,7,39
-Reno,Center twp,Governor,,D,Davis,39,6,33
-Reno,Clay N twp,Governor,,D,Davis,171,47,124
-Reno,Clay S 101 twp,Governor,,D,Davis,143,35,108
-Reno,Clay S H102A twp,Governor,,D,Davis,4,3,1
-Reno,Enterprise twp,Governor,,D,Davis,18,6,12
-Reno,Grant twp,Governor,,D,Davis,230,52,178
-Reno,Grove twp,Governor,,D,Davis,5,0,5
-Reno,Haven twp,Governor,,D,Davis,215,27,188
-Reno,Hayes twp,Governor,,D,Davis,10,5,5
-Reno,Huntsville twp,Governor,,D,Davis,11,2,9
-Reno,Langdon twp,Governor,,D,Davis,18,3,15
-Reno,Lincoln twp,Governor,,D,Davis,41,6,35
-Reno,Little River twp,Governor,,D,Davis,276,51,225
-Reno,Loda twp,Governor,,D,Davis,10,3,7
-Reno,Medford twp,Governor,,D,Davis,17,4,13
-Reno,Medora twp,Governor,,D,Davis,245,65,180
-Reno,Miami twp,Governor,,D,Davis,46,5,41
-Reno,Nickerson Ward #1,Governor,,D,Davis,55,3,52
-Reno,Nickerson Ward #2,Governor,,D,Davis,36,7,29
-Reno,Nickerson Ward #3,Governor,,D,Davis,41,9,32
-Reno,Ninnescah twp,Governor,,D,Davis,31,6,25
-Reno,Plevna twp,Governor,,D,Davis,20,1,19
-Reno,Reno N twp,Governor,,D,Davis,219,59,160
-Reno,Reno S twp,Governor,,D,Davis,40,4,36
-Reno,Roscoe twp,Governor,,D,Davis,14,0,14
-Reno,S Hutchinson #1,Governor,,D,Davis,71,16,55
-Reno,S Hutchinson #2,Governor,,D,Davis,120,24,96
-Reno,S Hutchinson #3,Governor,,D,Davis,123,18,105
-Reno,Salt Creek twp,Governor,,D,Davis,39,2,37
-Reno,Sumner twp,Governor,,D,Davis,68,2,66
-Reno,Sylvia twp,Governor,,D,Davis,37,1,36
-Reno,Troy twp,Governor,,D,Davis,18,2,16
-Reno,Valley twp,Governor,,D,Davis,111,38,73
-Reno,Walnut twp,Governor,,D,Davis,10,3,7
-Reno,Westminster twp,Governor,,D,Davis,33,0,33
-Reno,Yoder twp,Governor,,D,Davis,42,6,36
-Reno,Albion twp,Governor,,L,Umbehr,12,3,9
-Reno,Arlington twp,Governor,,L,Umbehr,15,3,12
-Reno,Bell twp,Governor,,L,Umbehr,1,0,1
-Reno,Castleton twp,Governor,,L,Umbehr,2,0,2
-Reno,Center twp,Governor,,L,Umbehr,5,0,5
-Reno,Clay N twp,Governor,,L,Umbehr,9,0,9
-Reno,Clay S 101 twp,Governor,,L,Umbehr,25,3,22
-Reno,Clay S H102A twp,Governor,,L,Umbehr,0,0,0
-Reno,Enterprise twp,Governor,,L,Umbehr,1,0,1
-Reno,Grant twp,Governor,,L,Umbehr,20,2,18
-Reno,Grove twp,Governor,,L,Umbehr,0,0,0
-Reno,Haven twp,Governor,,L,Umbehr,36,7,29
-Reno,Hayes twp,Governor,,L,Umbehr,0,0,0
-Reno,Huntsville twp,Governor,,L,Umbehr,3,0,3
-Reno,Langdon twp,Governor,,L,Umbehr,6,0,6
-Reno,Lincoln twp,Governor,,L,Umbehr,6,1,5
-Reno,Little River twp,Governor,,L,Umbehr,25,2,23
-Reno,Loda twp,Governor,,L,Umbehr,3,1,2
-Reno,Medford twp,Governor,,L,Umbehr,2,0,2
-Reno,Medora twp,Governor,,L,Umbehr,19,3,16
-Reno,Miami twp,Governor,,L,Umbehr,11,2,9
-Reno,Nickerson Ward #1,Governor,,L,Umbehr,11,4,7
-Reno,Nickerson Ward #2,Governor,,L,Umbehr,5,1,4
-Reno,Nickerson Ward #3,Governor,,L,Umbehr,8,1,7
-Reno,Ninnescah twp,Governor,,L,Umbehr,7,0,7
-Reno,Plevna twp,Governor,,L,Umbehr,2,0,2
-Reno,Reno N twp,Governor,,L,Umbehr,26,8,18
-Reno,Reno S twp,Governor,,L,Umbehr,4,1,3
-Reno,Roscoe twp,Governor,,L,Umbehr,1,0,1
-Reno,S Hutchinson #1,Governor,,L,Umbehr,8,2,6
-Reno,S Hutchinson #2,Governor,,L,Umbehr,19,2,17
-Reno,S Hutchinson #3,Governor,,L,Umbehr,13,2,11
-Reno,Salt Creek twp,Governor,,L,Umbehr,4,1,3
-Reno,Sumner twp,Governor,,L,Umbehr,7,2,5
-Reno,Sylvia twp,Governor,,L,Umbehr,8,4,4
-Reno,Troy twp,Governor,,L,Umbehr,3,1,2
-Reno,Valley twp,Governor,,L,Umbehr,17,5,12
-Reno,Walnut twp,Governor,,L,Umbehr,1,1,0
-Reno,Westminster twp,Governor,,L,Umbehr,6,0,6
-Reno,Yoder twp,Governor,,L,Umbehr,7,4,3
-Reno,Albion twp,Governor,,,Write-ins,0,0,0
-Reno,Arlington twp,Governor,,,Write-ins,0,0,0
-Reno,Bell twp,Governor,,,Write-ins,0,0,0
-Reno,Castleton twp,Governor,,,Write-ins,0,0,0
-Reno,Center twp,Governor,,,Write-ins,1,0,1
-Reno,Clay N twp,Governor,,,Write-ins,0,0,0
-Reno,Clay S 101 twp,Governor,,,Write-ins,0,0,0
-Reno,Clay S H102A twp,Governor,,,Write-ins,0,0,0
-Reno,Enterprise twp,Governor,,,Write-ins,0,0,0
-Reno,Grant twp,Governor,,,Write-ins,0,0,0
-Reno,Grove twp,Governor,,,Write-ins,0,0,0
-Reno,Haven twp,Governor,,,Write-ins,3,1,2
-Reno,Hayes twp,Governor,,,Write-ins,0,0,0
-Reno,Huntsville twp,Governor,,,Write-ins,0,0,0
-Reno,Langdon twp,Governor,,,Write-ins,0,0,0
-Reno,Lincoln twp,Governor,,,Write-ins,0,0,0
-Reno,Little River twp,Governor,,,Write-ins,2,0,2
-Reno,Loda twp,Governor,,,Write-ins,0,0,0
-Reno,Medford twp,Governor,,,Write-ins,0,0,0
-Reno,Medora twp,Governor,,,Write-ins,1,0,1
-Reno,Miami twp,Governor,,,Write-ins,1,0,1
-Reno,Nickerson Ward #1,Governor,,,Write-ins,0,0,0
-Reno,Nickerson Ward #2,Governor,,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,Governor,,,Write-ins,0,0,0
-Reno,Ninnescah twp,Governor,,,Write-ins,0,0,0
-Reno,Plevna twp,Governor,,,Write-ins,0,0,0
-Reno,Reno N twp,Governor,,,Write-ins,1,0,1
-Reno,Reno S twp,Governor,,,Write-ins,0,0,0
-Reno,Roscoe twp,Governor,,,Write-ins,0,0,0
-Reno,S Hutchinson #1,Governor,,,Write-ins,0,0,0
-Reno,S Hutchinson #2,Governor,,,Write-ins,0,0,0
-Reno,S Hutchinson #3,Governor,,,Write-ins,0,0,0
-Reno,Salt Creek twp,Governor,,,Write-ins,0,0,0
-Reno,Sumner twp,Governor,,,Write-ins,1,1,0
-Reno,Sylvia twp,Governor,,,Write-ins,0,0,0
-Reno,Troy twp,Governor,,,Write-ins,0,0,0
-Reno,Valley twp,Governor,,,Write-ins,0,0,0
-Reno,Walnut twp,Governor,,,Write-ins,0,0,0
-Reno,Westminster twp,Governor,,,Write-ins,0,0,0
-Reno,Yoder twp,Governor,,,Write-ins,0,0,0
-Reno,Albion twp,Insurance Commissioner,,D,Anderson,73,6,67
-Reno,Arlington twp,Insurance Commissioner,,D,Anderson,66,8,58
-Reno,Bell twp,Insurance Commissioner,,D,Anderson,6,1,5
-Reno,Castleton twp,Insurance Commissioner,,D,Anderson,36,4,32
-Reno,Center twp,Insurance Commissioner,,D,Anderson,33,6,27
-Reno,Clay N twp,Insurance Commissioner,,D,Anderson,97,33,64
-Reno,Clay S 101 twp,Insurance Commissioner,,D,Anderson,106,27,79
-Reno,Clay S H102A twp,Insurance Commissioner,,D,Anderson,1,0,1
-Reno,Enterprise twp,Insurance Commissioner,,D,Anderson,14,4,10
-Reno,Grant twp,Insurance Commissioner,,D,Anderson,154,39,115
-Reno,Grove twp,Insurance Commissioner,,D,Anderson,3,0,3
-Reno,Haven twp,Insurance Commissioner,,D,Anderson,162,22,140
-Reno,Hayes twp,Insurance Commissioner,,D,Anderson,7,4,3
-Reno,Huntsville twp,Insurance Commissioner,,D,Anderson,9,1,8
-Reno,Langdon twp,Insurance Commissioner,,D,Anderson,11,1,10
-Reno,Lincoln twp,Insurance Commissioner,,D,Anderson,23,5,18
-Reno,Little River twp,Insurance Commissioner,,D,Anderson,164,32,132
-Reno,Loda twp,Insurance Commissioner,,D,Anderson,11,3,8
-Reno,Medford twp,Insurance Commissioner,,D,Anderson,9,2,7
-Reno,Medora twp,Insurance Commissioner,,D,Anderson,180,47,133
-Reno,Miami twp,Insurance Commissioner,,D,Anderson,40,7,33
-Reno,Nickerson Ward #1,Insurance Commissioner,,D,Anderson,42,3,39
-Reno,Nickerson Ward #2,Insurance Commissioner,,D,Anderson,23,3,20
-Reno,Nickerson Ward #3,Insurance Commissioner,,D,Anderson,25,7,18
-Reno,Ninnescah twp,Insurance Commissioner,,D,Anderson,29,4,25
-Reno,Plevna twp,Insurance Commissioner,,D,Anderson,17,1,16
-Reno,Reno N twp,Insurance Commissioner,,D,Anderson,151,46,105
-Reno,Reno S twp,Insurance Commissioner,,D,Anderson,26,2,24
-Reno,Roscoe twp,Insurance Commissioner,,D,Anderson,10,0,10
-Reno,S Hutchinson #1,Insurance Commissioner,,D,Anderson,68,17,51
-Reno,S Hutchinson #2,Insurance Commissioner,,D,Anderson,89,17,72
-Reno,S Hutchinson #3,Insurance Commissioner,,D,Anderson,83,14,69
-Reno,Salt Creek twp,Insurance Commissioner,,D,Anderson,27,3,24
-Reno,Sumner twp,Insurance Commissioner,,D,Anderson,51,5,46
-Reno,Sylvia twp,Insurance Commissioner,,D,Anderson,26,2,24
-Reno,Troy twp,Insurance Commissioner,,D,Anderson,20,3,17
-Reno,Valley twp,Insurance Commissioner,,D,Anderson,81,29,52
-Reno,Walnut twp,Insurance Commissioner,,D,Anderson,7,4,3
-Reno,Westminster twp,Insurance Commissioner,,D,Anderson,22,0,22
-Reno,Yoder twp,Insurance Commissioner,,D,Anderson,36,6,30
-Reno,Albion twp,Insurance Commissioner,,R,Selzer,227,27,200
-Reno,Arlington twp,Insurance Commissioner,,R,Selzer,108,15,93
-Reno,Bell twp,Insurance Commissioner,,R,Selzer,23,3,20
-Reno,Castleton twp,Insurance Commissioner,,R,Selzer,84,11,73
-Reno,Center twp,Insurance Commissioner,,R,Selzer,92,11,81
-Reno,Clay N twp,Insurance Commissioner,,R,Selzer,283,56,227
-Reno,Clay S 101 twp,Insurance Commissioner,,R,Selzer,262,39,223
-Reno,Clay S H102A twp,Insurance Commissioner,,R,Selzer,5,2,3
-Reno,Enterprise twp,Insurance Commissioner,,R,Selzer,44,3,41
-Reno,Grant twp,Insurance Commissioner,,R,Selzer,458,86,372
-Reno,Grove twp,Insurance Commissioner,,R,Selzer,18,2,16
-Reno,Haven twp,Insurance Commissioner,,R,Selzer,389,32,357
-Reno,Hayes twp,Insurance Commissioner,,R,Selzer,22,7,15
-Reno,Huntsville twp,Insurance Commissioner,,R,Selzer,35,3,32
-Reno,Langdon twp,Insurance Commissioner,,R,Selzer,32,4,28
-Reno,Lincoln twp,Insurance Commissioner,,R,Selzer,126,9,117
-Reno,Little River twp,Insurance Commissioner,,R,Selzer,611,95,516
-Reno,Loda twp,Insurance Commissioner,,R,Selzer,29,5,24
-Reno,Medford twp,Insurance Commissioner,,R,Selzer,52,7,45
-Reno,Medora twp,Insurance Commissioner,,R,Selzer,465,93,372
-Reno,Miami twp,Insurance Commissioner,,R,Selzer,67,6,61
-Reno,Nickerson Ward #1,Insurance Commissioner,,R,Selzer,82,14,68
-Reno,Nickerson Ward #2,Insurance Commissioner,,R,Selzer,48,9,39
-Reno,Nickerson Ward #3,Insurance Commissioner,,R,Selzer,61,12,49
-Reno,Ninnescah twp,Insurance Commissioner,,R,Selzer,45,11,34
-Reno,Plevna twp,Insurance Commissioner,,R,Selzer,75,10,65
-Reno,Reno N twp,Insurance Commissioner,,R,Selzer,394,74,320
-Reno,Reno S twp,Insurance Commissioner,,R,Selzer,77,12,65
-Reno,Roscoe twp,Insurance Commissioner,,R,Selzer,31,4,27
-Reno,S Hutchinson #1,Insurance Commissioner,,R,Selzer,87,17,70
-Reno,S Hutchinson #2,Insurance Commissioner,,R,Selzer,221,36,185
-Reno,S Hutchinson #3,Insurance Commissioner,,R,Selzer,178,22,156
-Reno,Salt Creek twp,Insurance Commissioner,,R,Selzer,107,12,95
-Reno,Sumner twp,Insurance Commissioner,,R,Selzer,164,10,154
-Reno,Sylvia twp,Insurance Commissioner,,R,Selzer,74,10,64
-Reno,Troy twp,Insurance Commissioner,,R,Selzer,31,4,27
-Reno,Valley twp,Insurance Commissioner,,R,Selzer,229,57,172
-Reno,Walnut twp,Insurance Commissioner,,R,Selzer,45,7,38
-Reno,Westminster twp,Insurance Commissioner,,R,Selzer,64,8,56
-Reno,Yoder twp,Insurance Commissioner,,R,Selzer,160,24,136
-Reno,Albion twp,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,Arlington twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Bell twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Castleton twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Center twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Clay N twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Clay S 101 twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Clay S H102A twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Enterprise twp,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,Grant twp,Insurance Commissioner,,,Write-ins,2,0,2
-Reno,Grove twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Haven twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Hayes twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Huntsville twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Langdon twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Lincoln twp,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,Little River twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Loda twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Medford twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Medora twp,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,Miami twp,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,Nickerson Ward #1,Insurance Commissioner,,,Write-ins,1,0,1
-Reno,Nickerson Ward #2,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Ninnescah twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Plevna twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Reno N twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Reno S twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Roscoe twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,S Hutchinson #1,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,S Hutchinson #2,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,S Hutchinson #3,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Salt Creek twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Sumner twp,Insurance Commissioner,,,Write-ins,1,1,0
-Reno,Sylvia twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Troy twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Valley twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Walnut twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Westminster twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Yoder twp,Insurance Commissioner,,,Write-ins,0,0,0
-Reno,Albion twp,Secretary of State,,R,Kobach,216,21,195
-Reno,Arlington twp,Secretary of State,,R,Kobach,106,16,90
-Reno,Bell twp,Secretary of State,,R,Kobach,25,3,22
-Reno,Castleton twp,Secretary of State,,R,Kobach,83,10,73
-Reno,Center twp,Secretary of State,,R,Kobach,90,11,79
-Reno,Clay N twp,Secretary of State,,R,Kobach,264,51,213
-Reno,Clay S 101 twp,Secretary of State,,R,Kobach,251,38,213
-Reno,Clay S H102A twp,Secretary of State,,R,Kobach,4,1,3
-Reno,Enterprise twp,Secretary of State,,R,Kobach,46,4,42
-Reno,Grant twp,Secretary of State,,R,Kobach,418,71,347
-Reno,Grove twp,Secretary of State,,R,Kobach,19,2,17
-Reno,Haven twp,Secretary of State,,R,Kobach,363,32,331
-Reno,Hayes twp,Secretary of State,,R,Kobach,22,6,16
-Reno,Huntsville twp,Secretary of State,,R,Kobach,38,3,35
-Reno,Langdon twp,Secretary of State,,R,Kobach,32,4,28
-Reno,Lincoln twp,Secretary of State,,R,Kobach,117,7,110
-Reno,Little River twp,Secretary of State,,R,Kobach,547,83,464
-Reno,Loda twp,Secretary of State,,R,Kobach,27,4,23
-Reno,Medford twp,Secretary of State,,R,Kobach,44,6,38
-Reno,Medora twp,Secretary of State,,R,Kobach,465,86,379
-Reno,Miami twp,Secretary of State,,R,Kobach,73,8,65
-Reno,Nickerson Ward #1,Secretary of State,,R,Kobach,80,14,66
-Reno,Nickerson Ward #2,Secretary of State,,R,Kobach,41,5,36
-Reno,Nickerson Ward #3,Secretary of State,,R,Kobach,52,11,41
-Reno,Ninnescah twp,Secretary of State,,R,Kobach,44,10,34
-Reno,Plevna twp,Secretary of State,,R,Kobach,79,9,70
-Reno,Reno N twp,Secretary of State,,R,Kobach,375,67,308
-Reno,Reno S twp,Secretary of State,,R,Kobach,73,10,63
-Reno,Roscoe twp,Secretary of State,,R,Kobach,28,4,24
-Reno,S Hutchinson #1,Secretary of State,,R,Kobach,89,15,74
-Reno,S Hutchinson #2,Secretary of State,,R,Kobach,213,39,174
-Reno,S Hutchinson #3,Secretary of State,,R,Kobach,160,15,145
-Reno,Salt Creek twp,Secretary of State,,R,Kobach,112,14,98
-Reno,Sumner twp,Secretary of State,,R,Kobach,174,11,163
-Reno,Sylvia twp,Secretary of State,,R,Kobach,66,11,55
-Reno,Troy twp,Secretary of State,,R,Kobach,27,5,22
-Reno,Valley twp,Secretary of State,,R,Kobach,216,52,164
-Reno,Walnut twp,Secretary of State,,R,Kobach,43,7,36
-Reno,Westminster twp,Secretary of State,,R,Kobach,62,6,56
-Reno,Yoder twp,Secretary of State,,R,Kobach,165,24,141
-Reno,Albion twp,Secretary of State,,D,Schodorf,108,12,96
-Reno,Arlington twp,Secretary of State,,D,Schodorf,79,7,72
-Reno,Bell twp,Secretary of State,,D,Schodorf,7,1,6
-Reno,Castleton twp,Secretary of State,,D,Schodorf,39,5,34
-Reno,Center twp,Secretary of State,,D,Schodorf,40,6,34
-Reno,Clay N twp,Secretary of State,,D,Schodorf,125,41,84
-Reno,Clay S 101 twp,Secretary of State,,D,Schodorf,117,29,88
-Reno,Clay S H102A twp,Secretary of State,,D,Schodorf,4,3,1
-Reno,Enterprise twp,Secretary of State,,D,Schodorf,15,4,11
-Reno,Grant twp,Secretary of State,,D,Schodorf,204,56,148
-Reno,Grove twp,Secretary of State,,D,Schodorf,2,0,2
-Reno,Haven twp,Secretary of State,,D,Schodorf,203,26,177
-Reno,Hayes twp,Secretary of State,,D,Schodorf,8,5,3
-Reno,Huntsville twp,Secretary of State,,D,Schodorf,11,2,9
-Reno,Langdon twp,Secretary of State,,D,Schodorf,12,1,11
-Reno,Lincoln twp,Secretary of State,,D,Schodorf,34,7,27
-Reno,Little River twp,Secretary of State,,D,Schodorf,247,49,198
-Reno,Loda twp,Secretary of State,,D,Schodorf,15,5,10
-Reno,Medford twp,Secretary of State,,D,Schodorf,19,4,15
-Reno,Medora twp,Secretary of State,,D,Schodorf,195,59,136
-Reno,Miami twp,Secretary of State,,D,Schodorf,41,6,35
-Reno,Nickerson Ward #1,Secretary of State,,D,Schodorf,47,3,44
-Reno,Nickerson Ward #2,Secretary of State,,D,Schodorf,30,7,23
-Reno,Nickerson Ward #3,Secretary of State,,D,Schodorf,35,8,27
-Reno,Ninnescah twp,Secretary of State,,D,Schodorf,33,5,28
-Reno,Plevna twp,Secretary of State,,D,Schodorf,19,2,17
-Reno,Reno N twp,Secretary of State,,D,Schodorf,181,55,126
-Reno,Reno S twp,Secretary of State,,D,Schodorf,34,4,30
-Reno,Roscoe twp,Secretary of State,,D,Schodorf,13,0,13
-Reno,S Hutchinson #1,Secretary of State,,D,Schodorf,66,18,48
-Reno,S Hutchinson #2,Secretary of State,,D,Schodorf,110,17,93
-Reno,S Hutchinson #3,Secretary of State,,D,Schodorf,110,21,89
-Reno,Salt Creek twp,Secretary of State,,D,Schodorf,29,1,28
-Reno,Sumner twp,Secretary of State,,D,Schodorf,56,4,52
-Reno,Sylvia twp,Secretary of State,,D,Schodorf,36,2,34
-Reno,Troy twp,Secretary of State,,D,Schodorf,25,3,22
-Reno,Valley twp,Secretary of State,,D,Schodorf,93,35,58
-Reno,Walnut twp,Secretary of State,,D,Schodorf,9,4,5
-Reno,Westminster twp,Secretary of State,,D,Schodorf,27,2,25
-Reno,Yoder twp,Secretary of State,,D,Schodorf,36,6,30
-Reno,Albion twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Arlington twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Bell twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Castleton twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Center twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Clay N twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Clay S 101 twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Clay S H102A twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Enterprise twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Grant twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Grove twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Haven twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Hayes twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Huntsville twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Langdon twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Lincoln twp,Secretary of State,,,Write-ins,1,0,1
-Reno,Little River twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Loda twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Medford twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Medora twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Miami twp,Secretary of State,,,Write-ins,1,0,1
-Reno,Nickerson Ward #1,Secretary of State,,,Write-ins,1,0,1
-Reno,Nickerson Ward #2,Secretary of State,,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,Secretary of State,,,Write-ins,0,0,0
-Reno,Ninnescah twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Plevna twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Reno N twp,Secretary of State,,,Write-ins,1,0,1
-Reno,Reno S twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Roscoe twp,Secretary of State,,,Write-ins,0,0,0
-Reno,S Hutchinson #1,Secretary of State,,,Write-ins,0,0,0
-Reno,S Hutchinson #2,Secretary of State,,,Write-ins,0,0,0
-Reno,S Hutchinson #3,Secretary of State,,,Write-ins,0,0,0
-Reno,Salt Creek twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Sumner twp,Secretary of State,,,Write-ins,1,1,0
-Reno,Sylvia twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Troy twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Valley twp,Secretary of State,,,Write-ins,3,1,2
-Reno,Walnut twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Westminster twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Yoder twp,Secretary of State,,,Write-ins,0,0,0
-Reno,Albion twp,State House,101,R,Joe Seiwert,248,24,224
-Reno,Castleton twp,State House,101,R,Joe Seiwert,106,12,94
-Reno,Clay S 101 twp,State House,101,R,Joe Seiwert,333,54,279
-Reno,Haven twp,State House,101,R,Joe Seiwert,470,47,423
-Reno,Lincoln twp,State House,101,R,Joe Seiwert,134,7,127
-Reno,Ninnescah twp,State House,101,R,Joe Seiwert,58,10,48
-Reno,Roscoe twp,State House,101,R,Joe Seiwert,27,4,23
-Reno,Sumner twp,State House,101,R,Joe Seiwert,202,14,188
-Reno,Valley twp,State House,101,R,Joe Seiwert,280,76,204
-Reno,Yoder twp,State House,101,R,Joe Seiwert,183,25,158
-Reno,Albion twp,State House,101,,Write-ins,12,2,10
-Reno,Castleton twp,State House,101,,Write-ins,2,1,1
-Reno,Clay S 101 twp,State House,101,,Write-ins,5,2,3
-Reno,Haven twp,State House,101,,Write-ins,18,5,13
-Reno,Lincoln twp,State House,101,,Write-ins,2,0,2
-Reno,Ninnescah twp,State House,101,,Write-ins,4,1,3
-Reno,Roscoe twp,State House,101,,Write-ins,4,0,4
-Reno,Sumner twp,State House,101,,Write-ins,1,0,1
-Reno,Valley twp,State House,101,,Write-ins,3,1,2
-Reno,Yoder twp,State House,101,,Write-ins,0,0,2
-Reno,Clay S H102A twp,State House,102,D,Brian Davis,3,2,1
-Reno,Clay S H102A twp,State House,102,R,Jan Pauls,3,1,2
-Reno,Clay S H102A twp,State House,102,,Write-ins,0,0,0
-Reno,Clay N twp,State House,104,R,Stephen Becker,362,81,281
-Reno,Little River twp,State House,104,R,Stephen Becker,733,118,615
-Reno,Medora twp,State House,104,R,Stephen Becker,593,126,467
-Reno,Clay N twp,State House,104,,Write-ins,8,2,6
-Reno,Little River twp,State House,104,,Write-ins,13,2,11
-Reno,Medora twp,State House,104,,Write-ins,7,2,5
-Reno,Arlington twp,State House,114,R,Jack Thimisch,111,17,94
-Reno,Bell twp,State House,114,R,Jack Thimisch,21,3,18
-Reno,Center twp,State House,114,R,Jack Thimisch,92,11,81
-Reno,Enterprise twp,State House,114,R,Jack Thimisch,46,5,41
-Reno,Grant twp,State House,114,R,Jack Thimisch,445,83,362
-Reno,Grove twp,State House,114,R,Jack Thimisch,17,2,15
-Reno,Hayes twp,State House,114,R,Jack Thimisch,26,9,17
-Reno,Huntsville twp,State House,114,R,Jack Thimisch,39,3,36
-Reno,Langdon twp,State House,114,R,Jack Thimisch,38,4,34
-Reno,Loda twp,State House,114,R,Jack Thimisch,26,5,21
-Reno,Medford twp,State House,114,R,Jack Thimisch,50,7,43
-Reno,Miami twp,State House,114,R,Jack Thimisch,85,9,76
-Reno,Nickerson Ward #1,State House,114,R,Jack Thimisch,80,15,65
-Reno,Nickerson Ward #2,State House,114,R,Jack Thimisch,41,6,35
-Reno,Nickerson Ward #3,State House,114,R,Jack Thimisch,59,11,48
-Reno,Plevna twp,State House,114,R,Jack Thimisch,83,10,73
-Reno,Reno N twp,State House,114,R,Jack Thimisch,388,69,319
-Reno,Reno S twp,State House,114,R,Jack Thimisch,70,10,60
-Reno,S Hutchinson #1,State House,114,R,Jack Thimisch,88,18,70
-Reno,S Hutchinson #2,State House,114,R,Jack Thimisch,216,34,182
-Reno,S Hutchinson #3,State House,114,R,Jack Thimisch,169,20,149
-Reno,Salt Creek twp,State House,114,R,Jack Thimisch,107,12,95
-Reno,Sylvia twp,State House,114,R,Jack Thimisch,78,11,67
-Reno,Troy twp,State House,114,R,Jack Thimisch,35,5,30
-Reno,Walnut twp,State House,114,R,Jack Thimisch,41,7,34
-Reno,Westminster twp,State House,114,R,Jack Thimisch,66,8,58
-Reno,Arlington twp,State House,114,D,Mark Schnittker,69,5,64
-Reno,Bell twp,State House,114,D,Mark Schnittker,10,1,9
-Reno,Center twp,State House,114,D,Mark Schnittker,32,6,26
-Reno,Enterprise twp,State House,114,D,Mark Schnittker,16,3,13
-Reno,Grant twp,State House,114,D,Mark Schnittker,168,43,125
-Reno,Grove twp,State House,114,D,Mark Schnittker,3,0,3
-Reno,Hayes twp,State House,114,D,Mark Schnittker,4,2,2
-Reno,Huntsville twp,State House,114,D,Mark Schnittker,7,0,7
-Reno,Langdon twp,State House,114,D,Mark Schnittker,6,1,5
-Reno,Loda twp,State House,114,D,Mark Schnittker,16,4,12
-Reno,Medford twp,State House,114,D,Mark Schnittker,11,2,9
-Reno,Miami twp,State House,114,D,Mark Schnittker,32,5,27
-Reno,Nickerson Ward #1,State House,114,D,Mark Schnittker,46,2,44
-Reno,Nickerson Ward #2,State House,114,D,Mark Schnittker,30,6,24
-Reno,Nickerson Ward #3,State House,114,D,Mark Schnittker,28,8,20
-Reno,Plevna twp,State House,114,D,Mark Schnittker,14,1,13
-Reno,Reno N twp,State House,114,D,Mark Schnittker,165,50,115
-Reno,Reno S twp,State House,114,D,Mark Schnittker,36,4,32
-Reno,S Hutchinson #1,State House,114,D,Mark Schnittker,65,15,50
-Reno,S Hutchinson #2,State House,114,D,Mark Schnittker,98,19,79
-Reno,S Hutchinson #3,State House,114,D,Mark Schnittker,95,14,81
-Reno,Salt Creek twp,State House,114,D,Mark Schnittker,27,2,25
-Reno,Sylvia twp,State House,114,D,Mark Schnittker,25,2,23
-Reno,Troy twp,State House,114,D,Mark Schnittker,17,3,14
-Reno,Walnut twp,State House,114,D,Mark Schnittker,11,4,7
-Reno,Westminster twp,State House,114,D,Mark Schnittker,23,0,23
-Reno,Arlington twp,State House,114,,Write-ins,0,0,0
-Reno,Bell twp,State House,114,,Write-ins,0,0,0
-Reno,Center twp,State House,114,,Write-ins,0,0,0
-Reno,Enterprise twp,State House,114,,Write-ins,0,0,0
-Reno,Grant twp,State House,114,,Write-ins,1,0,1
-Reno,Grove twp,State House,114,,Write-ins,0,0,0
-Reno,Hayes twp,State House,114,,Write-ins,0,0,0
-Reno,Huntsville twp,State House,114,,Write-ins,0,0,0
-Reno,Langdon twp,State House,114,,Write-ins,0,0,0
-Reno,Loda twp,State House,114,,Write-ins,0,0,0
-Reno,Medford twp,State House,114,,Write-ins,0,0,0
-Reno,Miami twp,State House,114,,Write-ins,1,0,1
-Reno,Nickerson Ward #1,State House,114,,Write-ins,1,0,1
-Reno,Nickerson Ward #2,State House,114,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,State House,114,,Write-ins,0,0,0
-Reno,Plevna twp,State House,114,,Write-ins,0,0,0
-Reno,Reno N twp,State House,114,,Write-ins,0,0,0
-Reno,Reno S twp,State House,114,,Write-ins,0,0,0
-Reno,S Hutchinson #1,State House,114,,Write-ins,0,0,0
-Reno,S Hutchinson #2,State House,114,,Write-ins,0,0,0
-Reno,S Hutchinson #3,State House,114,,Write-ins,1,0,1
-Reno,Salt Creek twp,State House,114,,Write-ins,0,0,0
-Reno,Sylvia twp,State House,114,,Write-ins,0,0,0
-Reno,Troy twp,State House,114,,Write-ins,0,0,0
-Reno,Walnut twp,State House,114,,Write-ins,0,0,0
-Reno,Westminster twp,State House,114,,Write-ins,0,0,0
-Reno,Albion twp,State Treasurer,,D,Alldritt,55,8,47
-Reno,Arlington twp,State Treasurer,,D,Alldritt,56,4,52
-Reno,Bell twp,State Treasurer,,D,Alldritt,8,1,7
-Reno,Castleton twp,State Treasurer,,D,Alldritt,25,5,20
-Reno,Center twp,State Treasurer,,D,Alldritt,28,3,25
-Reno,Clay N twp,State Treasurer,,D,Alldritt,69,20,49
-Reno,Clay S 101 twp,State Treasurer,,D,Alldritt,85,21,64
-Reno,Clay S H102A twp,State Treasurer,,D,Alldritt,3,2,1
-Reno,Enterprise twp,State Treasurer,,D,Alldritt,14,5,9
-Reno,Grant twp,State Treasurer,,D,Alldritt,112,30,82
-Reno,Grove twp,State Treasurer,,D,Alldritt,2,0,2
-Reno,Haven twp,State Treasurer,,D,Alldritt,127,19,108
-Reno,Hayes twp,State Treasurer,,D,Alldritt,4,2,2
-Reno,Huntsville twp,State Treasurer,,D,Alldritt,7,0,7
-Reno,Langdon twp,State Treasurer,,D,Alldritt,7,1,6
-Reno,Lincoln twp,State Treasurer,,D,Alldritt,17,4,13
-Reno,Little River twp,State Treasurer,,D,Alldritt,134,27,107
-Reno,Loda twp,State Treasurer,,D,Alldritt,9,3,6
-Reno,Medford twp,State Treasurer,,D,Alldritt,6,3,3
-Reno,Medora twp,State Treasurer,,D,Alldritt,128,40,88
-Reno,Miami twp,State Treasurer,,D,Alldritt,30,5,25
-Reno,Nickerson Ward #1,State Treasurer,,D,Alldritt,31,1,30
-Reno,Nickerson Ward #2,State Treasurer,,D,Alldritt,19,2,17
-Reno,Nickerson Ward #3,State Treasurer,,D,Alldritt,20,4,16
-Reno,Ninnescah twp,State Treasurer,,D,Alldritt,20,4,16
-Reno,Plevna twp,State Treasurer,,D,Alldritt,12,0,12
-Reno,Reno N twp,State Treasurer,,D,Alldritt,117,39,78
-Reno,Reno S twp,State Treasurer,,D,Alldritt,22,2,20
-Reno,Roscoe twp,State Treasurer,,D,Alldritt,10,0,10
-Reno,S Hutchinson #1,State Treasurer,,D,Alldritt,53,16,37
-Reno,S Hutchinson #2,State Treasurer,,D,Alldritt,73,14,59
-Reno,S Hutchinson #3,State Treasurer,,D,Alldritt,70,12,58
-Reno,Salt Creek twp,State Treasurer,,D,Alldritt,20,2,18
-Reno,Sumner twp,State Treasurer,,D,Alldritt,31,4,27
-Reno,Sylvia twp,State Treasurer,,D,Alldritt,15,1,14
-Reno,Troy twp,State Treasurer,,D,Alldritt,14,2,12
-Reno,Valley twp,State Treasurer,,D,Alldritt,60,19,41
-Reno,Walnut twp,State Treasurer,,D,Alldritt,7,3,4
-Reno,Westminster twp,State Treasurer,,D,Alldritt,18,0,18
-Reno,Yoder twp,State Treasurer,,D,Alldritt,22,3,19
-Reno,Albion twp,State Treasurer,,R,Estes,253,25,228
-Reno,Arlington twp,State Treasurer,,R,Estes,121,18,103
-Reno,Bell twp,State Treasurer,,R,Estes,25,3,22
-Reno,Castleton twp,State Treasurer,,R,Estes,98,11,87
-Reno,Center twp,State Treasurer,,R,Estes,98,14,84
-Reno,Clay N twp,State Treasurer,,R,Estes,316,69,247
-Reno,Clay S 101 twp,State Treasurer,,R,Estes,285,45,240
-Reno,Clay S H102A twp,State Treasurer,,R,Estes,5,2,3
-Reno,Enterprise twp,State Treasurer,,R,Estes,46,3,43
-Reno,Grant twp,State Treasurer,,R,Estes,506,94,412
-Reno,Grove twp,State Treasurer,,R,Estes,19,2,17
-Reno,Haven twp,State Treasurer,,R,Estes,431,37,394
-Reno,Hayes twp,State Treasurer,,R,Estes,26,9,17
-Reno,Huntsville twp,State Treasurer,,R,Estes,41,5,36
-Reno,Langdon twp,State Treasurer,,R,Estes,37,4,33
-Reno,Lincoln twp,State Treasurer,,R,Estes,132,9,123
-Reno,Little River twp,State Treasurer,,R,Estes,648,100,548
-Reno,Loda twp,State Treasurer,,R,Estes,33,6,27
-Reno,Medford twp,State Treasurer,,R,Estes,56,7,49
-Reno,Medora twp,State Treasurer,,R,Estes,525,103,422
-Reno,Miami twp,State Treasurer,,R,Estes,82,9,73
-Reno,Nickerson Ward #1,State Treasurer,,R,Estes,94,16,78
-Reno,Nickerson Ward #2,State Treasurer,,R,Estes,52,9,43
-Reno,Nickerson Ward #3,State Treasurer,,R,Estes,65,13,52
-Reno,Ninnescah twp,State Treasurer,,R,Estes,57,11,46
-Reno,Plevna twp,State Treasurer,,R,Estes,84,11,73
-Reno,Reno N twp,State Treasurer,,R,Estes,435,83,352
-Reno,Reno S twp,State Treasurer,,R,Estes,83,12,71
-Reno,Roscoe twp,State Treasurer,,R,Estes,32,4,28
-Reno,S Hutchinson #1,State Treasurer,,R,Estes,101,18,83
-Reno,S Hutchinson #2,State Treasurer,,R,Estes,243,41,202
-Reno,S Hutchinson #3,State Treasurer,,R,Estes,197,24,173
-Reno,Salt Creek twp,State Treasurer,,R,Estes,113,13,100
-Reno,Sumner twp,State Treasurer,,R,Estes,192,10,182
-Reno,Sylvia twp,State Treasurer,,R,Estes,87,12,75
-Reno,Troy twp,State Treasurer,,R,Estes,39,6,33
-Reno,Valley twp,State Treasurer,,R,Estes,250,67,183
-Reno,Walnut twp,State Treasurer,,R,Estes,45,8,37
-Reno,Westminster twp,State Treasurer,,R,Estes,72,8,64
-Reno,Yoder twp,State Treasurer,,R,Estes,176,27,149
-Reno,Albion twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Arlington twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Bell twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Castleton twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Center twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Clay N twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Clay S 101 twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Clay S H102A twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Enterprise twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Grant twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Grove twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Haven twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Hayes twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Huntsville twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Langdon twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Lincoln twp,State Treasurer,,,Write-ins,1,0,1
-Reno,Little River twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Loda twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Medford twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Medora twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Miami twp,State Treasurer,,,Write-ins,1,0,1
-Reno,Nickerson Ward #1,State Treasurer,,,Write-ins,1,0,1
-Reno,Nickerson Ward #2,State Treasurer,,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,State Treasurer,,,Write-ins,0,0,0
-Reno,Ninnescah twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Plevna twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Reno N twp,State Treasurer,,,Write-ins,1,0,1
-Reno,Reno S twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Roscoe twp,State Treasurer,,,Write-ins,0,0,0
-Reno,S Hutchinson #1,State Treasurer,,,Write-ins,0,0,0
-Reno,S Hutchinson #2,State Treasurer,,,Write-ins,0,0,0
-Reno,S Hutchinson #3,State Treasurer,,,Write-ins,0,0,0
-Reno,Salt Creek twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Sumner twp,State Treasurer,,,Write-ins,1,1,0
-Reno,Sylvia twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Troy twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Valley twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Walnut twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Westminster twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Yoder twp,State Treasurer,,,Write-ins,0,0,0
-Reno,Albion twp,U.S. Senate,,L,Batson,15,1,14
-Reno,Arlington twp,U.S. Senate,,L,Batson,20,1,19
-Reno,Bell twp,U.S. Senate,,L,Batson,0,0,0
-Reno,Castleton twp,U.S. Senate,,L,Batson,0,0,0
-Reno,Center twp,U.S. Senate,,L,Batson,5,0,5
-Reno,Clay N twp,U.S. Senate,,L,Batson,13,2,11
-Reno,Clay S 101 twp,U.S. Senate,,L,Batson,26,5,21
-Reno,Clay S H102A twp,U.S. Senate,,L,Batson,0,0,0
-Reno,Enterprise twp,U.S. Senate,,L,Batson,0,0,0
-Reno,Grant twp,U.S. Senate,,L,Batson,31,1,30
-Reno,Grove twp,U.S. Senate,,L,Batson,2,0,2
-Reno,Haven twp,U.S. Senate,,L,Batson,35,7,28
-Reno,Hayes twp,U.S. Senate,,L,Batson,0,0,0
-Reno,Huntsville twp,U.S. Senate,,L,Batson,4,0,4
-Reno,Langdon twp,U.S. Senate,,L,Batson,4,1,3
-Reno,Lincoln twp,U.S. Senate,,L,Batson,10,2,8
-Reno,Little River twp,U.S. Senate,,L,Batson,34,4,30
-Reno,Loda twp,U.S. Senate,,L,Batson,4,1,3
-Reno,Medford twp,U.S. Senate,,L,Batson,2,1,1
-Reno,Medora twp,U.S. Senate,,L,Batson,30,5,25
-Reno,Miami twp,U.S. Senate,,L,Batson,9,2,7
-Reno,Nickerson Ward #1,U.S. Senate,,L,Batson,9,2,7
-Reno,Nickerson Ward #2,U.S. Senate,,L,Batson,4,1,3
-Reno,Nickerson Ward #3,U.S. Senate,,L,Batson,7,0,7
-Reno,Ninnescah twp,U.S. Senate,,L,Batson,5,0,5
-Reno,Plevna twp,U.S. Senate,,L,Batson,5,0,5
-Reno,Reno N twp,U.S. Senate,,L,Batson,24,5,19
-Reno,Reno S twp,U.S. Senate,,L,Batson,5,1,4
-Reno,Roscoe twp,U.S. Senate,,L,Batson,1,0,1
-Reno,S Hutchinson #1,U.S. Senate,,L,Batson,13,2,11
-Reno,S Hutchinson #2,U.S. Senate,,L,Batson,27,2,25
-Reno,S Hutchinson #3,U.S. Senate,,L,Batson,11,0,11
-Reno,Salt Creek twp,U.S. Senate,,L,Batson,7,2,5
-Reno,Sumner twp,U.S. Senate,,L,Batson,6,1,5
-Reno,Sylvia twp,U.S. Senate,,L,Batson,10,2,8
-Reno,Troy twp,U.S. Senate,,L,Batson,1,1,0
-Reno,Valley twp,U.S. Senate,,L,Batson,10,1,9
-Reno,Walnut twp,U.S. Senate,,L,Batson,0,0,0
-Reno,Westminster twp,U.S. Senate,,L,Batson,5,0,5
-Reno,Yoder twp,U.S. Senate,,L,Batson,7,3,4
-Reno,Albion twp,U.S. Senate,,I,Orman,92,10,82
-Reno,Arlington twp,U.S. Senate,,I,Orman,78,10,68
-Reno,Bell twp,U.S. Senate,,I,Orman,9,1,8
-Reno,Castleton twp,U.S. Senate,,I,Orman,18,3,15
-Reno,Center twp,U.S. Senate,,I,Orman,40,8,32
-Reno,Clay N twp,U.S. Senate,,I,Orman,132,40,92
-Reno,Clay S 101 twp,U.S. Senate,,I,Orman,125,32,93
-Reno,Clay S H102A twp,U.S. Senate,,I,Orman,4,2,2
-Reno,Enterprise twp,U.S. Senate,,I,Orman,16,5,11
-Reno,Grant twp,U.S. Senate,,I,Orman,209,53,156
-Reno,Grove twp,U.S. Senate,,I,Orman,4,0,4
-Reno,Haven twp,U.S. Senate,,I,Orman,177,20,157
-Reno,Hayes twp,U.S. Senate,,I,Orman,7,3,4
-Reno,Huntsville twp,U.S. Senate,,I,Orman,10,2,8
-Reno,Langdon twp,U.S. Senate,,I,Orman,19,2,17
-Reno,Lincoln twp,U.S. Senate,,I,Orman,29,5,24
-Reno,Little River twp,U.S. Senate,,I,Orman,233,41,192
-Reno,Loda twp,U.S. Senate,,I,Orman,10,3,7
-Reno,Medford twp,U.S. Senate,,I,Orman,13,2,11
-Reno,Medora twp,U.S. Senate,,I,Orman,219,62,157
-Reno,Miami twp,U.S. Senate,,I,Orman,44,5,39
-Reno,Nickerson Ward #1,U.S. Senate,,I,Orman,53,3,50
-Reno,Nickerson Ward #2,U.S. Senate,,I,Orman,33,6,27
-Reno,Nickerson Ward #3,U.S. Senate,,I,Orman,43,12,31
-Reno,Ninnescah twp,U.S. Senate,,I,Orman,32,6,26
-Reno,Plevna twp,U.S. Senate,,I,Orman,20,2,18
-Reno,Reno N twp,U.S. Senate,,I,Orman,174,55,119
-Reno,Reno S twp,U.S. Senate,,I,Orman,33,3,30
-Reno,Roscoe twp,U.S. Senate,,I,Orman,11,0,11
-Reno,S Hutchinson #1,U.S. Senate,,I,Orman,58,16,42
-Reno,S Hutchinson #2,U.S. Senate,,I,Orman,113,22,91
-Reno,S Hutchinson #3,U.S. Senate,,I,Orman,108,20,88
-Reno,Salt Creek twp,U.S. Senate,,I,Orman,28,2,26
-Reno,Sumner twp,U.S. Senate,,I,Orman,62,3,59
-Reno,Sylvia twp,U.S. Senate,,I,Orman,32,2,30
-Reno,Troy twp,U.S. Senate,,I,Orman,18,2,16
-Reno,Valley twp,U.S. Senate,,I,Orman,95,34,61
-Reno,Walnut twp,U.S. Senate,,I,Orman,9,4,5
-Reno,Westminster twp,U.S. Senate,,I,Orman,31,2,29
-Reno,Yoder twp,U.S. Senate,,I,Orman,44,7,37
-Reno,Albion twp,U.S. Senate,,R,Roberts,217,22,195
-Reno,Arlington twp,U.S. Senate,,R,Roberts,85,12,73
-Reno,Bell twp,U.S. Senate,,R,Roberts,25,3,22
-Reno,Castleton twp,U.S. Senate,,R,Roberts,22,1,21
-Reno,Center twp,U.S. Senate,,R,Roberts,89,9,80
-Reno,Clay N twp,U.S. Senate,,R,Roberts,247,50,197
-Reno,Clay S 101 twp,U.S. Senate,,R,Roberts,224,30,194
-Reno,Clay S H102A twp,U.S. Senate,,R,Roberts,4,2,2
-Reno,Enterprise twp,U.S. Senate,,R,Roberts,46,3,43
-Reno,Grant twp,U.S. Senate,,R,Roberts,380,71,309
-Reno,Grove twp,U.S. Senate,,R,Roberts,15,2,13
-Reno,Haven twp,U.S. Senate,,R,Roberts,355,31,324
-Reno,Hayes twp,U.S. Senate,,R,Roberts,23,8,15
-Reno,Huntsville twp,U.S. Senate,,R,Roberts,36,3,33
-Reno,Langdon twp,U.S. Senate,,R,Roberts,21,2,19
-Reno,Lincoln twp,U.S. Senate,,R,Roberts,116,7,109
-Reno,Little River twp,U.S. Senate,,R,Roberts,533,87,446
-Reno,Loda twp,U.S. Senate,,R,Roberts,28,5,23
-Reno,Medford twp,U.S. Senate,,R,Roberts,47,6,41
-Reno,Medora twp,U.S. Senate,,R,Roberts,414,78,336
-Reno,Miami twp,U.S. Senate,,R,Roberts,62,7,55
-Reno,Nickerson Ward #1,U.S. Senate,,R,Roberts,67,12,55
-Reno,Nickerson Ward #2,U.S. Senate,,R,Roberts,34,5,29
-Reno,Nickerson Ward #3,U.S. Senate,,R,Roberts,38,8,30
-Reno,Ninnescah twp,U.S. Senate,,R,Roberts,41,9,32
-Reno,Plevna twp,U.S. Senate,,R,Roberts,72,9,63
-Reno,Reno N twp,U.S. Senate,,R,Roberts,352,60,292
-Reno,Reno S twp,U.S. Senate,,R,Roberts,68,10,58
-Reno,Roscoe twp,U.S. Senate,,R,Roberts,29,4,25
-Reno,S Hutchinson #1,U.S. Senate,,R,Roberts,80,14,66
-Reno,S Hutchinson #2,U.S. Senate,,R,Roberts,177,29,148
-Reno,S Hutchinson #3,U.S. Senate,,R,Roberts,149,17,132
-Reno,Salt Creek twp,U.S. Senate,,R,Roberts,106,11,95
-Reno,Sumner twp,U.S. Senate,,R,Roberts,165,12,153
-Reno,Sylvia twp,U.S. Senate,,R,Roberts,62,9,53
-Reno,Troy twp,U.S. Senate,,R,Roberts,34,5,29
-Reno,Valley twp,U.S. Senate,,R,Roberts,207,55,152
-Reno,Walnut twp,U.S. Senate,,R,Roberts,45,7,38
-Reno,Westminster twp,U.S. Senate,,R,Roberts,54,6,48
-Reno,Yoder twp,U.S. Senate,,R,Roberts,150,21,129
-Reno,Albion twp,U.S. Senate,,,Write-ins,1,0,1
-Reno,Arlington twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Bell twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Castleton twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Center twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Clay N twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Clay S 101 twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Clay S H102A twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Enterprise twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Grant twp,U.S. Senate,,,Write-ins,1,0,1
-Reno,Grove twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Haven twp,U.S. Senate,,,Write-ins,1,0,1
-Reno,Hayes twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Huntsville twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Langdon twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Lincoln twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Little River twp,U.S. Senate,,,Write-ins,1,0,1
-Reno,Loda twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Medford twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Medora twp,U.S. Senate,,,Write-ins,1,0,1
-Reno,Miami twp,U.S. Senate,,,Write-ins,1,0,1
-Reno,Nickerson Ward #1,U.S. Senate,,,Write-ins,0,0,0
-Reno,Nickerson Ward #2,U.S. Senate,,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,U.S. Senate,,,Write-ins,0,0,0
-Reno,Ninnescah twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Plevna twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Reno N twp,U.S. Senate,,,Write-ins,3,0,3
-Reno,Reno S twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Roscoe twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,S Hutchinson #1,U.S. Senate,,,Write-ins,0,0,0
-Reno,S Hutchinson #2,U.S. Senate,,,Write-ins,2,0,2
-Reno,S Hutchinson #3,U.S. Senate,,,Write-ins,0,0,0
-Reno,Salt Creek twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Sumner twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Sylvia twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Troy twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Valley twp,U.S. Senate,,,Write-ins,1,0,1
-Reno,Walnut twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Westminster twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Yoder twp,U.S. Senate,,,Write-ins,0,0,0
-Reno,Albion twp,Voters,,,Ballots,330,33,297
-Reno,Arlington twp,Voters,,,Ballots,186,23,163
-Reno,Bell twp,Voters,,,Ballots,34,4,30
-Reno,Castleton twp,Voters,,,Ballots,125,16,109
-Reno,Center twp,Voters,,,Ballots,135,17,118
-Reno,Clay N twp,Voters,,,Ballots,393,92,301
-Reno,Clay S 101 twp,Voters,,,Ballots,378,68,310
-Reno,Clay S H102A twp,Voters,,,Ballots,8,4,4
-Reno,Enterprise twp,Voters,,,Ballots,63,8,55
-Reno,Grant twp,Voters,,,Ballots,629,127,502
-Reno,Grove twp,Voters,,,Ballots,21,2,19
-Reno,Haven twp,Voters,,,Ballots,571,58,513
-Reno,Hayes twp,Voters,,,Ballots,30,11,19
-Reno,Huntsville twp,Voters,,,Ballots,50,5,45
-Reno,Langdon twp,Voters,,,Ballots,44,5,39
-Reno,Lincoln twp,Voters,,,Ballots,155,14,141
-Reno,Little River twp,Voters,,,Ballots,806,132,674
-Reno,Loda twp,Voters,,,Ballots,42,9,33
-Reno,Medford twp,Voters,,,Ballots,63,10,53
-Reno,Medora twp,Voters,,,Ballots,670,145,525
-Reno,Miami twp,Voters,,,Ballots,119,14,105
-Reno,Nickerson Ward #1,Voters,,,Ballots,130,17,113
-Reno,Nickerson Ward #2,Voters,,,Ballots,73,12,61
-Reno,Nickerson Ward #3,Voters,,,Ballots,88,20,68
-Reno,Ninnescah twp,Voters,,,Ballots,78,15,63
-Reno,Plevna twp,Voters,,,Ballots,98,11,87
-Reno,Reno N twp,Voters,,,Ballots,564,124,440
-Reno,Reno S twp,Voters,,,Ballots,107,14,93
-Reno,Roscoe twp,Voters,,,Ballots,42,4,38
-Reno,S Hutchinson #1,Voters,,,Ballots,158,34,124
-Reno,S Hutchinson #2,Voters,,,Ballots,329,56,273
-Reno,S Hutchinson #3,Voters,,,Ballots,275,37,238
-Reno,Salt Creek twp,Voters,,,Ballots,142,15,127
-Reno,Sumner twp,Voters,,,Ballots,234,16,218
-Reno,Sylvia twp,Voters,,,Ballots,104,13,91
-Reno,Troy twp,Voters,,,Ballots,53,8,45
-Reno,Valley twp,Voters,,,Ballots,317,90,227
-Reno,Walnut twp,Voters,,,Ballots,54,11,43
-Reno,Westminster twp,Voters,,,Ballots,91,8,83
-Reno,Yoder twp,Voters,,,Ballots,202,31,171
-Reno,Albion twp,Voters,,,Registered,607,607,607
-Reno,Arlington twp,Voters,,,Registered,393,393,393
-Reno,Bell twp,Voters,,,Registered,56,56,56
-Reno,Castleton twp,Voters,,,Registered,201,201,201
-Reno,Center twp,Voters,,,Registered,305,305,305
-Reno,Clay N twp,Voters,,,Registered,662,662,662
-Reno,Clay S 101 twp,Voters,,,Registered,749,749,749
-Reno,Clay S H102A twp,Voters,,,Registered,6,6,6
-Reno,Enterprise twp,Voters,,,Registered,92,92,92
-Reno,Grant twp,Voters,,,Registered,1070,1070,1070
-Reno,Grove twp,Voters,,,Registered,33,33,33
-Reno,Haven twp,Voters,,,Registered,1110,1110,1110
-Reno,Hayes twp,Voters,,,Registered,63,63,63
-Reno,Huntsville twp,Voters,,,Registered,81,81,81
-Reno,Langdon twp,Voters,,,Registered,100,100,100
-Reno,Lincoln twp,Voters,,,Registered,329,329,329
-Reno,Little River twp,Voters,,,Registered,1276,1276,1276
-Reno,Loda twp,Voters,,,Registered,70,70,70
-Reno,Medford twp,Voters,,,Registered,106,106,106
-Reno,Medora twp,Voters,,,Registered,1092,1092,1092
-Reno,Miami twp,Voters,,,Registered,282,282,282
-Reno,Nickerson Ward #1,Voters,,,Registered,298,298,298
-Reno,Nickerson Ward #2,Voters,,,Registered,192,192,192
-Reno,Nickerson Ward #3,Voters,,,Registered,227,227,227
-Reno,Ninnescah twp,Voters,,,Registered,163,163,163
-Reno,Plevna twp,Voters,,,Registered,172,172,172
-Reno,Reno N twp,Voters,,,Registered,1108,1108,1108
-Reno,Reno S twp,Voters,,,Registered,199,199,199
-Reno,Roscoe twp,Voters,,,Registered,82,82,82
-Reno,S Hutchinson #1,Voters,,,Registered,468,468,468
-Reno,S Hutchinson #2,Voters,,,Registered,691,691,691
-Reno,S Hutchinson #3,Voters,,,Registered,442,442,442
-Reno,Salt Creek twp,Voters,,,Registered,250,250,250
-Reno,Sumner twp,Voters,,,Registered,377,377,377
-Reno,Sylvia twp,Voters,,,Registered,214,214,214
-Reno,Troy twp,Voters,,,Registered,82,82,82
-Reno,Valley twp,Voters,,,Registered,579,579,579
-Reno,Walnut twp,Voters,,,Registered,69,69,69
-Reno,Westminster twp,Voters,,,Registered,156,156,156
-Reno,Yoder twp,Voters,,,Registered,387,387,387
+county,precinct,office,district,party,candidate,votes,vtd
+RENO,Albion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000010
+RENO,Albion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000010
+RENO,Albion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",196,000010
+RENO,Arlington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000020
+RENO,Arlington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000020
+RENO,Arlington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",77,000020
+RENO,Bell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+RENO,Bell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+RENO,Bell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000030
+RENO,Castleton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000040
+RENO,Castleton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+RENO,Castleton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",76,000040
+RENO,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000050
+RENO,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000050
+RENO,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",88,000050
+RENO,Enterprise Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000060
+RENO,Enterprise Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+RENO,Enterprise Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000060
+RENO,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",230,000070
+RENO,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000070
+RENO,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",376,000070
+RENO,Grove Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000080
+RENO,Grove Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+RENO,Grove Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000080
+RENO,Haven Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",215,000090
+RENO,Haven Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",36,000090
+RENO,Haven Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",314,000090
+RENO,Hayes Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000100
+RENO,Hayes Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+RENO,Hayes Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000100
+RENO,Huntsville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000110
+RENO,Huntsville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000110
+RENO,Huntsville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000110
+RENO,Hutchinson Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000130
+RENO,Hutchinson Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000130
+RENO,Hutchinson Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000130
+RENO,Hutchinson Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",44,000140
+RENO,Hutchinson Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000140
+RENO,Hutchinson Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000140
+RENO,Hutchinson Precinct 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",328,000150
+RENO,Hutchinson Precinct 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000150
+RENO,Hutchinson Precinct 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",371,000150
+RENO,Hutchinson Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000160
+RENO,Hutchinson Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000160
+RENO,Hutchinson Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",104,000160
+RENO,Hutchinson Precinct 06,Governor / Lt. Governor,,Democratic,"Davis, Paul",117,000170
+RENO,Hutchinson Precinct 06,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000170
+RENO,Hutchinson Precinct 06,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000170
+RENO,Hutchinson Precinct 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",194,000180
+RENO,Hutchinson Precinct 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000180
+RENO,Hutchinson Precinct 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",123,000180
+RENO,Hutchinson Precinct 09,Governor / Lt. Governor,,Democratic,"Davis, Paul",248,000200
+RENO,Hutchinson Precinct 09,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000200
+RENO,Hutchinson Precinct 09,Governor / Lt. Governor,,Republican,"Brownback, Sam",213,000200
+RENO,Hutchinson Precinct 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",293,000210
+RENO,Hutchinson Precinct 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000210
+RENO,Hutchinson Precinct 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",289,000210
+RENO,Hutchinson Precinct 11,Governor / Lt. Governor,,Democratic,"Davis, Paul",288,000220
+RENO,Hutchinson Precinct 11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000220
+RENO,Hutchinson Precinct 11,Governor / Lt. Governor,,Republican,"Brownback, Sam",304,000220
+RENO,Hutchinson Precinct 12,Governor / Lt. Governor,,Democratic,"Davis, Paul",176,000230
+RENO,Hutchinson Precinct 12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000230
+RENO,Hutchinson Precinct 12,Governor / Lt. Governor,,Republican,"Brownback, Sam",157,000230
+RENO,Hutchinson Precinct 13,Governor / Lt. Governor,,Democratic,"Davis, Paul",212,000240
+RENO,Hutchinson Precinct 13,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000240
+RENO,Hutchinson Precinct 13,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,000240
+RENO,Hutchinson Precinct 14,Governor / Lt. Governor,,Democratic,"Davis, Paul",132,000250
+RENO,Hutchinson Precinct 14,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000250
+RENO,Hutchinson Precinct 14,Governor / Lt. Governor,,Republican,"Brownback, Sam",134,000250
+RENO,Hutchinson Precinct 15,Governor / Lt. Governor,,Democratic,"Davis, Paul",84,000260
+RENO,Hutchinson Precinct 15,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000260
+RENO,Hutchinson Precinct 15,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000260
+RENO,Hutchinson Precinct 16,Governor / Lt. Governor,,Democratic,"Davis, Paul",199,000270
+RENO,Hutchinson Precinct 16,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000270
+RENO,Hutchinson Precinct 16,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000270
+RENO,Hutchinson Precinct 17,Governor / Lt. Governor,,Democratic,"Davis, Paul",240,000280
+RENO,Hutchinson Precinct 17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000280
+RENO,Hutchinson Precinct 17,Governor / Lt. Governor,,Republican,"Brownback, Sam",187,000280
+RENO,Hutchinson Precinct 18,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000290
+RENO,Hutchinson Precinct 18,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000290
+RENO,Hutchinson Precinct 18,Governor / Lt. Governor,,Republican,"Brownback, Sam",61,000290
+RENO,Hutchinson Precinct 19,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000300
+RENO,Hutchinson Precinct 19,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000300
+RENO,Hutchinson Precinct 19,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000300
+RENO,Hutchinson Precinct 20,Governor / Lt. Governor,,Democratic,"Davis, Paul",129,000310
+RENO,Hutchinson Precinct 20,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000310
+RENO,Hutchinson Precinct 20,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,000310
+RENO,Hutchinson Precinct 21,Governor / Lt. Governor,,Democratic,"Davis, Paul",118,000320
+RENO,Hutchinson Precinct 21,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000320
+RENO,Hutchinson Precinct 21,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,000320
+RENO,Hutchinson Precinct 22,Governor / Lt. Governor,,Democratic,"Davis, Paul",267,000330
+RENO,Hutchinson Precinct 22,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000330
+RENO,Hutchinson Precinct 22,Governor / Lt. Governor,,Republican,"Brownback, Sam",219,000330
+RENO,Hutchinson Precinct 24,Governor / Lt. Governor,,Democratic,"Davis, Paul",220,000350
+RENO,Hutchinson Precinct 24,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000350
+RENO,Hutchinson Precinct 24,Governor / Lt. Governor,,Republican,"Brownback, Sam",211,000350
+RENO,Hutchinson Precinct 25,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000360
+RENO,Hutchinson Precinct 25,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000360
+RENO,Hutchinson Precinct 25,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000360
+RENO,Hutchinson Precinct 26,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,00037A
+RENO,Hutchinson Precinct 26,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,00037A
+RENO,Hutchinson Precinct 26,Governor / Lt. Governor,,Republican,"Brownback, Sam",56,00037A
+RENO,Hutchinson Precinct 26 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,00037B
+RENO,Hutchinson Precinct 26 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,00037B
+RENO,Hutchinson Precinct 26 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,00037B
+RENO,Hutchinson Precinct 27,Governor / Lt. Governor,,Democratic,"Davis, Paul",148,000380
+RENO,Hutchinson Precinct 27,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000380
+RENO,Hutchinson Precinct 27,Governor / Lt. Governor,,Republican,"Brownback, Sam",145,000380
+RENO,Hutchinson Precinct 28,Governor / Lt. Governor,,Democratic,"Davis, Paul",303,00039A
+RENO,Hutchinson Precinct 28,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,00039A
+RENO,Hutchinson Precinct 28,Governor / Lt. Governor,,Republican,"Brownback, Sam",349,00039A
+RENO,Hutchinson Precinct 28 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",123,00039B
+RENO,Hutchinson Precinct 28 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,00039B
+RENO,Hutchinson Precinct 28 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",216,00039B
+RENO,Hutchinson Precinct 29,Governor / Lt. Governor,,Democratic,"Davis, Paul",167,000400
+RENO,Hutchinson Precinct 29,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000400
+RENO,Hutchinson Precinct 29,Governor / Lt. Governor,,Republican,"Brownback, Sam",134,000400
+RENO,Hutchinson Precinct 30,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,000410
+RENO,Hutchinson Precinct 30,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000410
+RENO,Hutchinson Precinct 30,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000410
+RENO,Hutchinson Precinct 31,Governor / Lt. Governor,,Democratic,"Davis, Paul",136,000420
+RENO,Hutchinson Precinct 31,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000420
+RENO,Hutchinson Precinct 31,Governor / Lt. Governor,,Republican,"Brownback, Sam",132,000420
+RENO,Hutchinson Precinct 32,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000430
+RENO,Hutchinson Precinct 32,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000430
+RENO,Hutchinson Precinct 32,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000430
+RENO,Langdon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000440
+RENO,Langdon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000440
+RENO,Langdon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000440
+RENO,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000450
+RENO,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000450
+RENO,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",106,000450
+RENO,Little River Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",276,000460
+RENO,Little River Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000460
+RENO,Little River Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",499,000460
+RENO,Loda Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000470
+RENO,Loda Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000470
+RENO,Loda Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000470
+RENO,Medford Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000480
+RENO,Medford Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000480
+RENO,Medford Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000480
+RENO,Medora Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",245,000490
+RENO,Medora Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000490
+RENO,Medora Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",401,000490
+RENO,Miami Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000500
+RENO,Miami Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000500
+RENO,Miami Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",61,000500
+RENO,Nickerson Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000510
+RENO,Nickerson Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000510
+RENO,Nickerson Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",61,000510
+RENO,Nickerson Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000520
+RENO,Nickerson Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000520
+RENO,Nickerson Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000520
+RENO,Nickerson Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000530
+RENO,Nickerson Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000530
+RENO,Nickerson Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000530
+RENO,Ninnescah Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000540
+RENO,Ninnescah Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000540
+RENO,Ninnescah Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000540
+RENO,North Clay Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",171,00055A
+RENO,North Clay Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,00055A
+RENO,North Clay Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",210,00055A
+RENO,North Reno Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",219,000560
+RENO,North Reno Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000560
+RENO,North Reno Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",314,000560
+RENO,Plevna Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000570
+RENO,Plevna Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000570
+RENO,Plevna Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000570
+RENO,Roscoe Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000580
+RENO,Roscoe Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000580
+RENO,Roscoe Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000580
+RENO,Salt Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000590
+RENO,Salt Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000590
+RENO,Salt Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,000590
+RENO,South Hutchinson Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,000610
+RENO,South Hutchinson Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000610
+RENO,South Hutchinson Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",77,000610
+RENO,South Hutchinson Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",120,000620
+RENO,South Hutchinson Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000620
+RENO,South Hutchinson Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",187,000620
+RENO,South Hutchinson Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",123,000630
+RENO,South Hutchinson Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000630
+RENO,South Hutchinson Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",133,000630
+RENO,South Reno Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000640
+RENO,South Reno Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000640
+RENO,South Reno Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000640
+RENO,Sumner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",68,000650
+RENO,Sumner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000650
+RENO,Sumner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",158,000650
+RENO,Sylvia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000660
+RENO,Sylvia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000660
+RENO,Sylvia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",59,000660
+RENO,Troy Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000670
+RENO,Troy Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000670
+RENO,Troy Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000670
+RENO,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,000680
+RENO,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000680
+RENO,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",189,000680
+RENO,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000690
+RENO,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000690
+RENO,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000690
+RENO,Westminister Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000700
+RENO,Westminister Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000700
+RENO,Westminister Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,000700
+RENO,Yoder Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000710
+RENO,Yoder Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000710
+RENO,Yoder Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",152,000710
+RENO,Hutchinson Precinct 01 H102,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,120020
+RENO,Hutchinson Precinct 01 H102,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,120020
+RENO,Hutchinson Precinct 01 H102,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,120020
+RENO,Hutchinson Precinct 01 H114,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,120030
+RENO,Hutchinson Precinct 01 H114,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+RENO,Hutchinson Precinct 01 H114,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120030
+RENO,South Clay Township H101,Governor / Lt. Governor,,Democratic,"Davis, Paul",143,120040
+RENO,South Clay Township H101,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,120040
+RENO,South Clay Township H101,Governor / Lt. Governor,,Republican,"Brownback, Sam",209,120040
+RENO,South Clay Township Clay H102 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,12005A
+RENO,South Clay Township Clay H102 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12005A
+RENO,South Clay Township Clay H102 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,12005A
+RENO,Hutchinson Precinct 34 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120060
+RENO,Hutchinson Precinct 34 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",1,120060
+RENO,Hutchinson Precinct 36,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120070
+RENO,Hutchinson Precinct 36,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120070
+RENO,Hutchinson Precinct 36,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120070
+RENO,Hutchinson Precinct 08 H101,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,200010
+RENO,Hutchinson Precinct 08 H101,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,200010
+RENO,Hutchinson Precinct 08 H101,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,200010
+RENO,Hutchinson Precinct 35,Governor / Lt. Governor,,Democratic,"Davis, Paul",77,200020
+RENO,Hutchinson Precinct 35,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,200020
+RENO,Hutchinson Precinct 35,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,200020
+RENO,Hutchinson Precinct 23 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",70,200030
+RENO,Hutchinson Precinct 23 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,200030
+RENO,Hutchinson Precinct 23 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,200030
+RENO,Hutchinson Precinct 23 H104,Governor / Lt. Governor,,Democratic,"Davis, Paul",347,200040
+RENO,Hutchinson Precinct 23 H104,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",27,200040
+RENO,Hutchinson Precinct 23 H104,Governor / Lt. Governor,,Republican,"Brownback, Sam",328,200040
+RENO,Hutchinson Precinct 33,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,200050
+RENO,Hutchinson Precinct 33,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,200050
+RENO,Hutchinson Precinct 33,Governor / Lt. Governor,,Republican,"Brownback, Sam",90,200050
+RENO,Hutchinson Precinct 34,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,200060
+RENO,Hutchinson Precinct 34,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,200060
+RENO,Hutchinson Precinct 34,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,200060
+RENO,Albion Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",248,000010
+RENO,Arlington Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",69,000020
+RENO,Arlington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",111,000020
+RENO,Bell Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",10,000030
+RENO,Bell Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",21,000030
+RENO,Castleton Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",106,000040
+RENO,Center Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",32,000050
+RENO,Center Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",92,000050
+RENO,Enterprise Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",16,000060
+RENO,Enterprise Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",46,000060
+RENO,Grant Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",168,000070
+RENO,Grant Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",445,000070
+RENO,Grove Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",3,000080
+RENO,Grove Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",17,000080
+RENO,Haven Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",470,000090
+RENO,Hayes Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",4,000100
+RENO,Hayes Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",26,000100
+RENO,Huntsville Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",7,000110
+RENO,Huntsville Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",39,000110
+RENO,Hutchinson Precinct 02,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",62,000130
+RENO,Hutchinson Precinct 02,Kansas House of Representatives,102,Republican,"Pauls, Jan",54,000130
+RENO,Hutchinson Precinct 03,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",41,000140
+RENO,Hutchinson Precinct 03,Kansas House of Representatives,114,Republican,"Thimesch, Jack",35,000140
+RENO,Hutchinson Precinct 04,Kansas House of Representatives,104,Republican,"Becker, Steven R.",625,000150
+RENO,Hutchinson Precinct 05,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",120,000160
+RENO,Hutchinson Precinct 05,Kansas House of Representatives,102,Republican,"Pauls, Jan",125,000160
+RENO,Hutchinson Precinct 06,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",107,000170
+RENO,Hutchinson Precinct 06,Kansas House of Representatives,102,Republican,"Pauls, Jan",119,000170
+RENO,Hutchinson Precinct 07,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",167,000180
+RENO,Hutchinson Precinct 07,Kansas House of Representatives,102,Republican,"Pauls, Jan",158,000180
+RENO,Hutchinson Precinct 09,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",206,000200
+RENO,Hutchinson Precinct 09,Kansas House of Representatives,102,Republican,"Pauls, Jan",273,000200
+RENO,Hutchinson Precinct 10,Kansas House of Representatives,104,Republican,"Becker, Steven R.",533,000210
+RENO,Hutchinson Precinct 11,Kansas House of Representatives,104,Republican,"Becker, Steven R.",550,000220
+RENO,Hutchinson Precinct 12,Kansas House of Representatives,104,Republican,"Becker, Steven R.",293,000230
+RENO,Hutchinson Precinct 13,Kansas House of Representatives,104,Republican,"Becker, Steven R.",338,000240
+RENO,Hutchinson Precinct 14,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",110,000250
+RENO,Hutchinson Precinct 14,Kansas House of Representatives,102,Republican,"Pauls, Jan",163,000250
+RENO,Hutchinson Precinct 15,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",72,000260
+RENO,Hutchinson Precinct 15,Kansas House of Representatives,102,Republican,"Pauls, Jan",94,000260
+RENO,Hutchinson Precinct 16,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",164,000270
+RENO,Hutchinson Precinct 16,Kansas House of Representatives,102,Republican,"Pauls, Jan",169,000270
+RENO,Hutchinson Precinct 17,Kansas House of Representatives,104,Republican,"Becker, Steven R.",385,000280
+RENO,Hutchinson Precinct 18,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",68,000290
+RENO,Hutchinson Precinct 18,Kansas House of Representatives,102,Republican,"Pauls, Jan",79,000290
+RENO,Hutchinson Precinct 19,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",87,000300
+RENO,Hutchinson Precinct 19,Kansas House of Representatives,102,Republican,"Pauls, Jan",76,000300
+RENO,Hutchinson Precinct 20,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",113,000310
+RENO,Hutchinson Precinct 20,Kansas House of Representatives,102,Republican,"Pauls, Jan",150,000310
+RENO,Hutchinson Precinct 21,Kansas House of Representatives,104,Republican,"Becker, Steven R.",193,000320
+RENO,Hutchinson Precinct 22,Kansas House of Representatives,104,Republican,"Becker, Steven R.",443,000330
+RENO,Hutchinson Precinct 24,Kansas House of Representatives,104,Republican,"Becker, Steven R.",408,000350
+RENO,Hutchinson Precinct 25,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",104,000360
+RENO,Hutchinson Precinct 25,Kansas House of Representatives,102,Republican,"Pauls, Jan",94,000360
+RENO,Hutchinson Precinct 26,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",72,00037A
+RENO,Hutchinson Precinct 26,Kansas House of Representatives,102,Republican,"Pauls, Jan",67,00037A
+RENO,Hutchinson Precinct 26 Exclave,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",13,00037B
+RENO,Hutchinson Precinct 26 Exclave,Kansas House of Representatives,102,Republican,"Pauls, Jan",14,00037B
+RENO,Hutchinson Precinct 27,Kansas House of Representatives,104,Republican,"Becker, Steven R.",263,000380
+RENO,Hutchinson Precinct 28,Kansas House of Representatives,104,Republican,"Becker, Steven R.",601,00039A
+RENO,Hutchinson Precinct 28 Exclave,Kansas House of Representatives,104,Republican,"Becker, Steven R.",315,00039B
+RENO,Hutchinson Precinct 29,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",131,000400
+RENO,Hutchinson Precinct 29,Kansas House of Representatives,102,Republican,"Pauls, Jan",177,000400
+RENO,Hutchinson Precinct 30,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",63,000410
+RENO,Hutchinson Precinct 30,Kansas House of Representatives,102,Republican,"Pauls, Jan",73,000410
+RENO,Hutchinson Precinct 31,Kansas House of Representatives,104,Republican,"Becker, Steven R.",246,000420
+RENO,Hutchinson Precinct 32,Kansas House of Representatives,104,Republican,"Becker, Steven R.",91,000430
+RENO,Langdon Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",6,000440
+RENO,Langdon Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",38,000440
+RENO,Lincoln Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",134,000450
+RENO,Little River Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",733,000460
+RENO,Loda Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",16,000470
+RENO,Loda Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",26,000470
+RENO,Medford Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",11,000480
+RENO,Medford Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",50,000480
+RENO,Medora Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",593,000490
+RENO,Miami Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",32,000500
+RENO,Miami Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",85,000500
+RENO,Nickerson Ward 1,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",46,000510
+RENO,Nickerson Ward 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",80,000510
+RENO,Nickerson Ward 2,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",30,000520
+RENO,Nickerson Ward 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",41,000520
+RENO,Nickerson Ward 3,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",28,000530
+RENO,Nickerson Ward 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",59,000530
+RENO,Ninnescah Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",58,000540
+RENO,North Clay Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",362,00055A
+RENO,North Reno Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",165,000560
+RENO,North Reno Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",388,000560
+RENO,Plevna Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",14,000570
+RENO,Plevna Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",83,000570
+RENO,Roscoe Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",27,000580
+RENO,Salt Creek Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",27,000590
+RENO,Salt Creek Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",107,000590
+RENO,South Hutchinson Precinct 1,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",65,000610
+RENO,South Hutchinson Precinct 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",88,000610
+RENO,South Hutchinson Precinct 2,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",98,000620
+RENO,South Hutchinson Precinct 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",216,000620
+RENO,South Hutchinson Precinct 3,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",95,000630
+RENO,South Hutchinson Precinct 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",169,000630
+RENO,South Reno Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",36,000640
+RENO,South Reno Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",70,000640
+RENO,Sumner Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",202,000650
+RENO,Sylvia Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",25,000660
+RENO,Sylvia Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",78,000660
+RENO,Troy Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",17,000670
+RENO,Troy Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",35,000670
+RENO,Valley Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",280,000680
+RENO,Walnut Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",11,000690
+RENO,Walnut Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",41,000690
+RENO,Westminister Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",23,000700
+RENO,Westminister Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",66,000700
+RENO,Yoder Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",183,000710
+RENO,Hutchinson Precinct 01 H102,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",71,120020
+RENO,Hutchinson Precinct 01 H102,Kansas House of Representatives,102,Republican,"Pauls, Jan",67,120020
+RENO,Hutchinson Precinct 01 H114,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",8,120030
+RENO,Hutchinson Precinct 01 H114,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,120030
+RENO,South Clay Township H101,Kansas House of Representatives,101,Republican,"Seiwert, Joe",333,120040
+RENO,South Clay Township Clay H102 A,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",3,12005A
+RENO,South Clay Township Clay H102 A,Kansas House of Representatives,102,Republican,"Pauls, Jan",3,12005A
+RENO,Hutchinson Precinct 34 Exclave,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,Kansas House of Representatives,102,Republican,"Pauls, Jan",1,120060
+RENO,Hutchinson Precinct 36,Kansas House of Representatives,104,Republican,"Becker, Steven R.",0,120070
+RENO,Hutchinson Precinct 08 H101,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",66,200010
+RENO,Hutchinson Precinct 08 H101,Kansas House of Representatives,102,Republican,"Pauls, Jan",97,200010
+RENO,Hutchinson Precinct 35,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",64,200020
+RENO,Hutchinson Precinct 35,Kansas House of Representatives,102,Republican,"Pauls, Jan",84,200020
+RENO,Hutchinson Precinct 23 Exclave,Kansas House of Representatives,104,Republican,"Becker, Steven R.",122,200030
+RENO,Hutchinson Precinct 23 H104,Kansas House of Representatives,104,Republican,"Becker, Steven R.",621,200040
+RENO,Hutchinson Precinct 33,Kansas House of Representatives,104,Republican,"Becker, Steven R.",152,200050
+RENO,Hutchinson Precinct 34,Kansas House of Representatives,102,Democratic,"Davis, Brian E.",18,200060
+RENO,Hutchinson Precinct 34,Kansas House of Representatives,102,Republican,"Pauls, Jan",32,200060
+RENO,Albion Township,United States House of Representatives,1,Democratic,"Sherow, James E.",91,000010
+RENO,Albion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",227,000010
+RENO,Arlington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",74,000020
+RENO,Arlington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",109,000020
+RENO,Bell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000030
+RENO,Bell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000030
+RENO,Castleton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000040
+RENO,Castleton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000040
+RENO,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",38,000050
+RENO,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000050
+RENO,Enterprise Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000060
+RENO,Enterprise Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000060
+RENO,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",201,000070
+RENO,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",417,000070
+RENO,Grove Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000080
+RENO,Grove Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000080
+RENO,Haven Township,United States House of Representatives,1,Democratic,"Sherow, James E.",183,000090
+RENO,Haven Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",373,000090
+RENO,Hayes Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000100
+RENO,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000100
+RENO,Huntsville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000110
+RENO,Huntsville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000110
+RENO,Hutchinson Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",58,000130
+RENO,Hutchinson Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",57,000130
+RENO,Hutchinson Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",41,000140
+RENO,Hutchinson Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000140
+RENO,Hutchinson Precinct 04,United States House of Representatives,1,Democratic,"Sherow, James E.",249,000150
+RENO,Hutchinson Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",450,000150
+RENO,Hutchinson Precinct 05,United States House of Representatives,1,Democratic,"Sherow, James E.",98,000160
+RENO,Hutchinson Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",143,000160
+RENO,Hutchinson Precinct 06,United States House of Representatives,1,Democratic,"Sherow, James E.",91,000170
+RENO,Hutchinson Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,000170
+RENO,Hutchinson Precinct 07,United States House of Representatives,1,Democratic,"Sherow, James E.",158,000180
+RENO,Hutchinson Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",166,000180
+RENO,Hutchinson Precinct 09,United States House of Representatives,1,Democratic,"Sherow, James E.",221,000200
+RENO,Hutchinson Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",259,000200
+RENO,Hutchinson Precinct 10,United States House of Representatives,1,Democratic,"Sherow, James E.",227,000210
+RENO,Hutchinson Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",362,000210
+RENO,Hutchinson Precinct 11,United States House of Representatives,1,Democratic,"Sherow, James E.",245,000220
+RENO,Hutchinson Precinct 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",363,000220
+RENO,Hutchinson Precinct 12,United States House of Representatives,1,Democratic,"Sherow, James E.",156,000230
+RENO,Hutchinson Precinct 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",172,000230
+RENO,Hutchinson Precinct 13,United States House of Representatives,1,Democratic,"Sherow, James E.",170,000240
+RENO,Hutchinson Precinct 13,United States House of Representatives,1,Republican,"Huelskamp, Tim",219,000240
+RENO,Hutchinson Precinct 14,United States House of Representatives,1,Democratic,"Sherow, James E.",113,000250
+RENO,Hutchinson Precinct 14,United States House of Representatives,1,Republican,"Huelskamp, Tim",162,000250
+RENO,Hutchinson Precinct 15,United States House of Representatives,1,Democratic,"Sherow, James E.",72,000260
+RENO,Hutchinson Precinct 15,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,000260
+RENO,Hutchinson Precinct 16,United States House of Representatives,1,Democratic,"Sherow, James E.",170,000270
+RENO,Hutchinson Precinct 16,United States House of Representatives,1,Republican,"Huelskamp, Tim",157,000270
+RENO,Hutchinson Precinct 17,United States House of Representatives,1,Democratic,"Sherow, James E.",177,000280
+RENO,Hutchinson Precinct 17,United States House of Representatives,1,Republican,"Huelskamp, Tim",256,000280
+RENO,Hutchinson Precinct 18,United States House of Representatives,1,Democratic,"Sherow, James E.",61,000290
+RENO,Hutchinson Precinct 18,United States House of Representatives,1,Republican,"Huelskamp, Tim",86,000290
+RENO,Hutchinson Precinct 19,United States House of Representatives,1,Democratic,"Sherow, James E.",85,000300
+RENO,Hutchinson Precinct 19,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000300
+RENO,Hutchinson Precinct 20,United States House of Representatives,1,Democratic,"Sherow, James E.",105,000310
+RENO,Hutchinson Precinct 20,United States House of Representatives,1,Republican,"Huelskamp, Tim",157,000310
+RENO,Hutchinson Precinct 21,United States House of Representatives,1,Democratic,"Sherow, James E.",95,000320
+RENO,Hutchinson Precinct 21,United States House of Representatives,1,Republican,"Huelskamp, Tim",125,000320
+RENO,Hutchinson Precinct 22,United States House of Representatives,1,Democratic,"Sherow, James E.",213,000330
+RENO,Hutchinson Precinct 22,United States House of Representatives,1,Republican,"Huelskamp, Tim",285,000330
+RENO,Hutchinson Precinct 24,United States House of Representatives,1,Democratic,"Sherow, James E.",175,000350
+RENO,Hutchinson Precinct 24,United States House of Representatives,1,Republican,"Huelskamp, Tim",269,000350
+RENO,Hutchinson Precinct 25,United States House of Representatives,1,Democratic,"Sherow, James E.",106,000360
+RENO,Hutchinson Precinct 25,United States House of Representatives,1,Republican,"Huelskamp, Tim",91,000360
+RENO,Hutchinson Precinct 26,United States House of Representatives,1,Democratic,"Sherow, James E.",59,00037A
+RENO,Hutchinson Precinct 26,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,00037A
+RENO,Hutchinson Precinct 26 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",9,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,00037B
+RENO,Hutchinson Precinct 27,United States House of Representatives,1,Democratic,"Sherow, James E.",120,000380
+RENO,Hutchinson Precinct 27,United States House of Representatives,1,Republican,"Huelskamp, Tim",174,000380
+RENO,Hutchinson Precinct 28,United States House of Representatives,1,Democratic,"Sherow, James E.",251,00039A
+RENO,Hutchinson Precinct 28,United States House of Representatives,1,Republican,"Huelskamp, Tim",420,00039A
+RENO,Hutchinson Precinct 28 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",108,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",237,00039B
+RENO,Hutchinson Precinct 29,United States House of Representatives,1,Democratic,"Sherow, James E.",138,000400
+RENO,Hutchinson Precinct 29,United States House of Representatives,1,Republican,"Huelskamp, Tim",172,000400
+RENO,Hutchinson Precinct 30,United States House of Representatives,1,Democratic,"Sherow, James E.",61,000410
+RENO,Hutchinson Precinct 30,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000410
+RENO,Hutchinson Precinct 31,United States House of Representatives,1,Democratic,"Sherow, James E.",112,000420
+RENO,Hutchinson Precinct 31,United States House of Representatives,1,Republican,"Huelskamp, Tim",165,000420
+RENO,Hutchinson Precinct 32,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000430
+RENO,Hutchinson Precinct 32,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000430
+RENO,Langdon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000440
+RENO,Langdon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000440
+RENO,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",34,000450
+RENO,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",118,000450
+RENO,Little River Township,United States House of Representatives,1,Democratic,"Sherow, James E.",213,000460
+RENO,Little River Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",580,000460
+RENO,Loda Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000470
+RENO,Loda Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000470
+RENO,Medford Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000480
+RENO,Medford Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000480
+RENO,Medora Township,United States House of Representatives,1,Democratic,"Sherow, James E.",190,000490
+RENO,Medora Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",468,000490
+RENO,Miami Township,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000500
+RENO,Miami Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000500
+RENO,Nickerson Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",42,000510
+RENO,Nickerson Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000510
+RENO,Nickerson Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000520
+RENO,Nickerson Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000520
+RENO,Nickerson Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000530
+RENO,Nickerson Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000530
+RENO,Ninnescah Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000540
+RENO,Ninnescah Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,000540
+RENO,North Clay Township,United States House of Representatives,1,Democratic,"Sherow, James E.",134,00055A
+RENO,North Clay Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",249,00055A
+RENO,North Reno Township,United States House of Representatives,1,Democratic,"Sherow, James E.",168,000560
+RENO,North Reno Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",387,000560
+RENO,Plevna Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000570
+RENO,Plevna Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",79,000570
+RENO,Roscoe Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000580
+RENO,Roscoe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000580
+RENO,Salt Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",28,000590
+RENO,Salt Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",113,000590
+RENO,South Hutchinson Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",69,000610
+RENO,South Hutchinson Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000610
+RENO,South Hutchinson Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",107,000620
+RENO,South Hutchinson Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",212,000620
+RENO,South Hutchinson Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",100,000630
+RENO,South Hutchinson Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",168,000630
+RENO,South Reno Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000640
+RENO,South Reno Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000640
+RENO,Sumner Township,United States House of Representatives,1,Democratic,"Sherow, James E.",55,000650
+RENO,Sumner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",175,000650
+RENO,Sylvia Township,United States House of Representatives,1,Democratic,"Sherow, James E.",26,000660
+RENO,Sylvia Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",75,000660
+RENO,Troy Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000670
+RENO,Troy Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000670
+RENO,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",84,000680
+RENO,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",229,000680
+RENO,Walnut Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000690
+RENO,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000690
+RENO,Westminister Township,United States House of Representatives,1,Democratic,"Sherow, James E.",20,000700
+RENO,Westminister Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000700
+RENO,Yoder Township,United States House of Representatives,1,Democratic,"Sherow, James E.",41,000710
+RENO,Yoder Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",158,000710
+RENO,Hutchinson Precinct 01 H102,United States House of Representatives,1,Democratic,"Sherow, James E.",66,120020
+RENO,Hutchinson Precinct 01 H102,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,120020
+RENO,Hutchinson Precinct 01 H114,United States House of Representatives,1,Democratic,"Sherow, James E.",7,120030
+RENO,Hutchinson Precinct 01 H114,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,120030
+RENO,South Clay Township H101,United States House of Representatives,1,Democratic,"Sherow, James E.",112,120040
+RENO,South Clay Township H101,United States House of Representatives,1,Republican,"Huelskamp, Tim",256,120040
+RENO,South Clay Township Clay H102 A,United States House of Representatives,1,Democratic,"Sherow, James E.",4,12005A
+RENO,South Clay Township Clay H102 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,12005A
+RENO,Hutchinson Precinct 34 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,120060
+RENO,Hutchinson Precinct 36,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120070
+RENO,Hutchinson Precinct 36,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120070
+RENO,Hutchinson Precinct 08 H101,United States House of Representatives,1,Democratic,"Sherow, James E.",68,200010
+RENO,Hutchinson Precinct 08 H101,United States House of Representatives,1,Republican,"Huelskamp, Tim",98,200010
+RENO,Hutchinson Precinct 35,United States House of Representatives,1,Democratic,"Sherow, James E.",65,200020
+RENO,Hutchinson Precinct 35,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,200020
+RENO,Hutchinson Precinct 23 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",52,200030
+RENO,Hutchinson Precinct 23 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",91,200030
+RENO,Hutchinson Precinct 23 H104,United States House of Representatives,1,Democratic,"Sherow, James E.",278,200040
+RENO,Hutchinson Precinct 23 H104,United States House of Representatives,1,Republican,"Huelskamp, Tim",410,200040
+RENO,Hutchinson Precinct 33,United States House of Representatives,1,Democratic,"Sherow, James E.",43,200050
+RENO,Hutchinson Precinct 33,United States House of Representatives,1,Republican,"Huelskamp, Tim",120,200050
+RENO,Hutchinson Precinct 34,United States House of Representatives,1,Democratic,"Sherow, James E.",18,200060
+RENO,Hutchinson Precinct 34,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,200060
+RENO,Albion Township,Attorney General,,Democratic,"Kotich, A.J.",59,000010
+RENO,Albion Township,Attorney General,,Republican,"Schmidt, Derek",255,000010
+RENO,Arlington Township,Attorney General,,Democratic,"Kotich, A.J.",59,000020
+RENO,Arlington Township,Attorney General,,Republican,"Schmidt, Derek",121,000020
+RENO,Bell Township,Attorney General,,Democratic,"Kotich, A.J.",6,000030
+RENO,Bell Township,Attorney General,,Republican,"Schmidt, Derek",25,000030
+RENO,Castleton Township,Attorney General,,Democratic,"Kotich, A.J.",27,000040
+RENO,Castleton Township,Attorney General,,Republican,"Schmidt, Derek",96,000040
+RENO,Center Township,Attorney General,,Democratic,"Kotich, A.J.",26,000050
+RENO,Center Township,Attorney General,,Republican,"Schmidt, Derek",97,000050
+RENO,Enterprise Township,Attorney General,,Democratic,"Kotich, A.J.",9,000060
+RENO,Enterprise Township,Attorney General,,Republican,"Schmidt, Derek",51,000060
+RENO,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",122,000070
+RENO,Grant Township,Attorney General,,Republican,"Schmidt, Derek",496,000070
+RENO,Grove Township,Attorney General,,Democratic,"Kotich, A.J.",3,000080
+RENO,Grove Township,Attorney General,,Republican,"Schmidt, Derek",18,000080
+RENO,Haven Township,Attorney General,,Democratic,"Kotich, A.J.",142,000090
+RENO,Haven Township,Attorney General,,Republican,"Schmidt, Derek",420,000090
+RENO,Hayes Township,Attorney General,,Democratic,"Kotich, A.J.",4,000100
+RENO,Hayes Township,Attorney General,,Republican,"Schmidt, Derek",26,000100
+RENO,Huntsville Township,Attorney General,,Democratic,"Kotich, A.J.",3,000110
+RENO,Huntsville Township,Attorney General,,Republican,"Schmidt, Derek",46,000110
+RENO,Hutchinson Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",54,000130
+RENO,Hutchinson Precinct 02,Attorney General,,Republican,"Schmidt, Derek",64,000130
+RENO,Hutchinson Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",36,000140
+RENO,Hutchinson Precinct 03,Attorney General,,Republican,"Schmidt, Derek",40,000140
+RENO,Hutchinson Precinct 04,Attorney General,,Democratic,"Kotich, A.J.",153,000150
+RENO,Hutchinson Precinct 04,Attorney General,,Republican,"Schmidt, Derek",545,000150
+RENO,Hutchinson Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",99,000160
+RENO,Hutchinson Precinct 05,Attorney General,,Republican,"Schmidt, Derek",141,000160
+RENO,Hutchinson Precinct 06,Attorney General,,Democratic,"Kotich, A.J.",83,000170
+RENO,Hutchinson Precinct 06,Attorney General,,Republican,"Schmidt, Derek",139,000170
+RENO,Hutchinson Precinct 07,Attorney General,,Democratic,"Kotich, A.J.",122,000180
+RENO,Hutchinson Precinct 07,Attorney General,,Republican,"Schmidt, Derek",191,000180
+RENO,Hutchinson Precinct 09,Attorney General,,Democratic,"Kotich, A.J.",149,000200
+RENO,Hutchinson Precinct 09,Attorney General,,Republican,"Schmidt, Derek",329,000200
+RENO,Hutchinson Precinct 10,Attorney General,,Democratic,"Kotich, A.J.",125,000210
+RENO,Hutchinson Precinct 10,Attorney General,,Republican,"Schmidt, Derek",468,000210
+RENO,Hutchinson Precinct 11,Attorney General,,Democratic,"Kotich, A.J.",155,000220
+RENO,Hutchinson Precinct 11,Attorney General,,Republican,"Schmidt, Derek",449,000220
+RENO,Hutchinson Precinct 12,Attorney General,,Democratic,"Kotich, A.J.",112,000230
+RENO,Hutchinson Precinct 12,Attorney General,,Republican,"Schmidt, Derek",216,000230
+RENO,Hutchinson Precinct 13,Attorney General,,Democratic,"Kotich, A.J.",140,000240
+RENO,Hutchinson Precinct 13,Attorney General,,Republican,"Schmidt, Derek",244,000240
+RENO,Hutchinson Precinct 14,Attorney General,,Democratic,"Kotich, A.J.",98,000250
+RENO,Hutchinson Precinct 14,Attorney General,,Republican,"Schmidt, Derek",174,000250
+RENO,Hutchinson Precinct 15,Attorney General,,Democratic,"Kotich, A.J.",70,000260
+RENO,Hutchinson Precinct 15,Attorney General,,Republican,"Schmidt, Derek",92,000260
+RENO,Hutchinson Precinct 16,Attorney General,,Democratic,"Kotich, A.J.",144,000270
+RENO,Hutchinson Precinct 16,Attorney General,,Republican,"Schmidt, Derek",176,000270
+RENO,Hutchinson Precinct 17,Attorney General,,Democratic,"Kotich, A.J.",132,000280
+RENO,Hutchinson Precinct 17,Attorney General,,Republican,"Schmidt, Derek",294,000280
+RENO,Hutchinson Precinct 18,Attorney General,,Democratic,"Kotich, A.J.",55,000290
+RENO,Hutchinson Precinct 18,Attorney General,,Republican,"Schmidt, Derek",93,000290
+RENO,Hutchinson Precinct 19,Attorney General,,Democratic,"Kotich, A.J.",68,000300
+RENO,Hutchinson Precinct 19,Attorney General,,Republican,"Schmidt, Derek",91,000300
+RENO,Hutchinson Precinct 20,Attorney General,,Democratic,"Kotich, A.J.",79,000310
+RENO,Hutchinson Precinct 20,Attorney General,,Republican,"Schmidt, Derek",175,000310
+RENO,Hutchinson Precinct 21,Attorney General,,Democratic,"Kotich, A.J.",86,000320
+RENO,Hutchinson Precinct 21,Attorney General,,Republican,"Schmidt, Derek",130,000320
+RENO,Hutchinson Precinct 22,Attorney General,,Democratic,"Kotich, A.J.",150,000330
+RENO,Hutchinson Precinct 22,Attorney General,,Republican,"Schmidt, Derek",345,000330
+RENO,Hutchinson Precinct 24,Attorney General,,Democratic,"Kotich, A.J.",126,000350
+RENO,Hutchinson Precinct 24,Attorney General,,Republican,"Schmidt, Derek",322,000350
+RENO,Hutchinson Precinct 25,Attorney General,,Democratic,"Kotich, A.J.",87,000360
+RENO,Hutchinson Precinct 25,Attorney General,,Republican,"Schmidt, Derek",108,000360
+RENO,Hutchinson Precinct 26,Attorney General,,Democratic,"Kotich, A.J.",43,00037A
+RENO,Hutchinson Precinct 26,Attorney General,,Republican,"Schmidt, Derek",93,00037A
+RENO,Hutchinson Precinct 26 Exclave,Attorney General,,Democratic,"Kotich, A.J.",10,00037B
+RENO,Hutchinson Precinct 26 Exclave,Attorney General,,Republican,"Schmidt, Derek",17,00037B
+RENO,Hutchinson Precinct 27,Attorney General,,Democratic,"Kotich, A.J.",67,000380
+RENO,Hutchinson Precinct 27,Attorney General,,Republican,"Schmidt, Derek",228,000380
+RENO,Hutchinson Precinct 28,Attorney General,,Democratic,"Kotich, A.J.",170,00039A
+RENO,Hutchinson Precinct 28,Attorney General,,Republican,"Schmidt, Derek",499,00039A
+RENO,Hutchinson Precinct 28 Exclave,Attorney General,,Democratic,"Kotich, A.J.",53,00039B
+RENO,Hutchinson Precinct 28 Exclave,Attorney General,,Republican,"Schmidt, Derek",289,00039B
+RENO,Hutchinson Precinct 29,Attorney General,,Democratic,"Kotich, A.J.",94,000400
+RENO,Hutchinson Precinct 29,Attorney General,,Republican,"Schmidt, Derek",215,000400
+RENO,Hutchinson Precinct 30,Attorney General,,Democratic,"Kotich, A.J.",44,000410
+RENO,Hutchinson Precinct 30,Attorney General,,Republican,"Schmidt, Derek",89,000410
+RENO,Hutchinson Precinct 31,Attorney General,,Democratic,"Kotich, A.J.",89,000420
+RENO,Hutchinson Precinct 31,Attorney General,,Republican,"Schmidt, Derek",185,000420
+RENO,Hutchinson Precinct 32,Attorney General,,Democratic,"Kotich, A.J.",21,000430
+RENO,Hutchinson Precinct 32,Attorney General,,Republican,"Schmidt, Derek",78,000430
+RENO,Langdon Township,Attorney General,,Democratic,"Kotich, A.J.",8,000440
+RENO,Langdon Township,Attorney General,,Republican,"Schmidt, Derek",36,000440
+RENO,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",18,000450
+RENO,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",131,000450
+RENO,Little River Township,Attorney General,,Democratic,"Kotich, A.J.",143,000460
+RENO,Little River Township,Attorney General,,Republican,"Schmidt, Derek",644,000460
+RENO,Loda Township,Attorney General,,Democratic,"Kotich, A.J.",8,000470
+RENO,Loda Township,Attorney General,,Republican,"Schmidt, Derek",34,000470
+RENO,Medford Township,Attorney General,,Democratic,"Kotich, A.J.",6,000480
+RENO,Medford Township,Attorney General,,Republican,"Schmidt, Derek",56,000480
+RENO,Medora Township,Attorney General,,Democratic,"Kotich, A.J.",134,000490
+RENO,Medora Township,Attorney General,,Republican,"Schmidt, Derek",521,000490
+RENO,Miami Township,Attorney General,,Democratic,"Kotich, A.J.",31,000500
+RENO,Miami Township,Attorney General,,Republican,"Schmidt, Derek",80,000500
+RENO,Nickerson Ward 1,Attorney General,,Democratic,"Kotich, A.J.",33,000510
+RENO,Nickerson Ward 1,Attorney General,,Republican,"Schmidt, Derek",92,000510
+RENO,Nickerson Ward 2,Attorney General,,Democratic,"Kotich, A.J.",19,000520
+RENO,Nickerson Ward 2,Attorney General,,Republican,"Schmidt, Derek",51,000520
+RENO,Nickerson Ward 3,Attorney General,,Democratic,"Kotich, A.J.",23,000530
+RENO,Nickerson Ward 3,Attorney General,,Republican,"Schmidt, Derek",65,000530
+RENO,Ninnescah Township,Attorney General,,Democratic,"Kotich, A.J.",23,000540
+RENO,Ninnescah Township,Attorney General,,Republican,"Schmidt, Derek",54,000540
+RENO,North Clay Township,Attorney General,,Democratic,"Kotich, A.J.",85,00055A
+RENO,North Clay Township,Attorney General,,Republican,"Schmidt, Derek",300,00055A
+RENO,North Reno Township,Attorney General,,Democratic,"Kotich, A.J.",133,000560
+RENO,North Reno Township,Attorney General,,Republican,"Schmidt, Derek",418,000560
+RENO,Plevna Township,Attorney General,,Democratic,"Kotich, A.J.",10,000570
+RENO,Plevna Township,Attorney General,,Republican,"Schmidt, Derek",85,000570
+RENO,Roscoe Township,Attorney General,,Democratic,"Kotich, A.J.",8,000580
+RENO,Roscoe Township,Attorney General,,Republican,"Schmidt, Derek",34,000580
+RENO,Salt Creek Township,Attorney General,,Democratic,"Kotich, A.J.",20,000590
+RENO,Salt Creek Township,Attorney General,,Republican,"Schmidt, Derek",115,000590
+RENO,South Hutchinson Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",53,000610
+RENO,South Hutchinson Precinct 1,Attorney General,,Republican,"Schmidt, Derek",103,000610
+RENO,South Hutchinson Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",72,000620
+RENO,South Hutchinson Precinct 2,Attorney General,,Republican,"Schmidt, Derek",247,000620
+RENO,South Hutchinson Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",75,000630
+RENO,South Hutchinson Precinct 3,Attorney General,,Republican,"Schmidt, Derek",190,000630
+RENO,South Reno Township,Attorney General,,Democratic,"Kotich, A.J.",19,000640
+RENO,South Reno Township,Attorney General,,Republican,"Schmidt, Derek",86,000640
+RENO,Sumner Township,Attorney General,,Democratic,"Kotich, A.J.",36,000650
+RENO,Sumner Township,Attorney General,,Republican,"Schmidt, Derek",188,000650
+RENO,Sylvia Township,Attorney General,,Democratic,"Kotich, A.J.",16,000660
+RENO,Sylvia Township,Attorney General,,Republican,"Schmidt, Derek",88,000660
+RENO,Troy Township,Attorney General,,Democratic,"Kotich, A.J.",11,000670
+RENO,Troy Township,Attorney General,,Republican,"Schmidt, Derek",42,000670
+RENO,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",61,000680
+RENO,Valley Township,Attorney General,,Republican,"Schmidt, Derek",251,000680
+RENO,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",6,000690
+RENO,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",46,000690
+RENO,Westminister Township,Attorney General,,Democratic,"Kotich, A.J.",19,000700
+RENO,Westminister Township,Attorney General,,Republican,"Schmidt, Derek",68,000700
+RENO,Yoder Township,Attorney General,,Democratic,"Kotich, A.J.",30,000710
+RENO,Yoder Township,Attorney General,,Republican,"Schmidt, Derek",168,000710
+RENO,Hutchinson Precinct 01 H102,Attorney General,,Democratic,"Kotich, A.J.",61,120020
+RENO,Hutchinson Precinct 01 H102,Attorney General,,Republican,"Schmidt, Derek",75,120020
+RENO,Hutchinson Precinct 01 H114,Attorney General,,Democratic,"Kotich, A.J.",5,120030
+RENO,Hutchinson Precinct 01 H114,Attorney General,,Republican,"Schmidt, Derek",2,120030
+RENO,South Clay Township H101,Attorney General,,Democratic,"Kotich, A.J.",89,120040
+RENO,South Clay Township H101,Attorney General,,Republican,"Schmidt, Derek",278,120040
+RENO,South Clay Township Clay H102 A,Attorney General,,Democratic,"Kotich, A.J.",1,12005A
+RENO,South Clay Township Clay H102 A,Attorney General,,Republican,"Schmidt, Derek",5,12005A
+RENO,Hutchinson Precinct 34 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,Attorney General,,Republican,"Schmidt, Derek",1,120060
+RENO,Hutchinson Precinct 36,Attorney General,,Democratic,"Kotich, A.J.",0,120070
+RENO,Hutchinson Precinct 36,Attorney General,,Republican,"Schmidt, Derek",0,120070
+RENO,Hutchinson Precinct 08 H101,Attorney General,,Democratic,"Kotich, A.J.",51,200010
+RENO,Hutchinson Precinct 08 H101,Attorney General,,Republican,"Schmidt, Derek",112,200010
+RENO,Hutchinson Precinct 35,Attorney General,,Democratic,"Kotich, A.J.",54,200020
+RENO,Hutchinson Precinct 35,Attorney General,,Republican,"Schmidt, Derek",94,200020
+RENO,Hutchinson Precinct 23 Exclave,Attorney General,,Democratic,"Kotich, A.J.",34,200030
+RENO,Hutchinson Precinct 23 Exclave,Attorney General,,Republican,"Schmidt, Derek",105,200030
+RENO,Hutchinson Precinct 23 H104,Attorney General,,Democratic,"Kotich, A.J.",202,200040
+RENO,Hutchinson Precinct 23 H104,Attorney General,,Republican,"Schmidt, Derek",484,200040
+RENO,Hutchinson Precinct 33,Attorney General,,Democratic,"Kotich, A.J.",36,200050
+RENO,Hutchinson Precinct 33,Attorney General,,Republican,"Schmidt, Derek",127,200050
+RENO,Hutchinson Precinct 34,Attorney General,,Democratic,"Kotich, A.J.",15,200060
+RENO,Hutchinson Precinct 34,Attorney General,,Republican,"Schmidt, Derek",35,200060
+RENO,Albion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000010
+RENO,Albion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",227,000010
+RENO,Arlington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,000020
+RENO,Arlington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",108,000020
+RENO,Bell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000030
+RENO,Bell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000030
+RENO,Castleton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000040
+RENO,Castleton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000040
+RENO,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000050
+RENO,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",92,000050
+RENO,Enterprise Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000060
+RENO,Enterprise Township,Commissioner of Insurance,,Republican,"Selzer, Ken",44,000060
+RENO,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",154,000070
+RENO,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",458,000070
+RENO,Grove Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000080
+RENO,Grove Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000080
+RENO,Haven Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",162,000090
+RENO,Haven Township,Commissioner of Insurance,,Republican,"Selzer, Ken",389,000090
+RENO,Hayes Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000100
+RENO,Hayes Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000100
+RENO,Huntsville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000110
+RENO,Huntsville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000110
+RENO,Hutchinson Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",58,000130
+RENO,Hutchinson Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",56,000130
+RENO,Hutchinson Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000140
+RENO,Hutchinson Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000140
+RENO,Hutchinson Precinct 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",201,000150
+RENO,Hutchinson Precinct 04,Commissioner of Insurance,,Republican,"Selzer, Ken",485,000150
+RENO,Hutchinson Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",111,000160
+RENO,Hutchinson Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",130,000160
+RENO,Hutchinson Precinct 06,Commissioner of Insurance,,Democratic,"Anderson, Dennis",106,000170
+RENO,Hutchinson Precinct 06,Commissioner of Insurance,,Republican,"Selzer, Ken",118,000170
+RENO,Hutchinson Precinct 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",144,000180
+RENO,Hutchinson Precinct 07,Commissioner of Insurance,,Republican,"Selzer, Ken",170,000180
+RENO,Hutchinson Precinct 09,Commissioner of Insurance,,Democratic,"Anderson, Dennis",188,000200
+RENO,Hutchinson Precinct 09,Commissioner of Insurance,,Republican,"Selzer, Ken",285,000200
+RENO,Hutchinson Precinct 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",176,000210
+RENO,Hutchinson Precinct 10,Commissioner of Insurance,,Republican,"Selzer, Ken",407,000210
+RENO,Hutchinson Precinct 11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",191,000220
+RENO,Hutchinson Precinct 11,Commissioner of Insurance,,Republican,"Selzer, Ken",405,000220
+RENO,Hutchinson Precinct 12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",142,000230
+RENO,Hutchinson Precinct 12,Commissioner of Insurance,,Republican,"Selzer, Ken",184,000230
+RENO,Hutchinson Precinct 13,Commissioner of Insurance,,Democratic,"Anderson, Dennis",163,000240
+RENO,Hutchinson Precinct 13,Commissioner of Insurance,,Republican,"Selzer, Ken",214,000240
+RENO,Hutchinson Precinct 14,Commissioner of Insurance,,Democratic,"Anderson, Dennis",112,000250
+RENO,Hutchinson Precinct 14,Commissioner of Insurance,,Republican,"Selzer, Ken",159,000250
+RENO,Hutchinson Precinct 15,Commissioner of Insurance,,Democratic,"Anderson, Dennis",78,000260
+RENO,Hutchinson Precinct 15,Commissioner of Insurance,,Republican,"Selzer, Ken",80,000260
+RENO,Hutchinson Precinct 16,Commissioner of Insurance,,Democratic,"Anderson, Dennis",159,000270
+RENO,Hutchinson Precinct 16,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000270
+RENO,Hutchinson Precinct 17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",159,000280
+RENO,Hutchinson Precinct 17,Commissioner of Insurance,,Republican,"Selzer, Ken",267,000280
+RENO,Hutchinson Precinct 18,Commissioner of Insurance,,Democratic,"Anderson, Dennis",63,000290
+RENO,Hutchinson Precinct 18,Commissioner of Insurance,,Republican,"Selzer, Ken",82,000290
+RENO,Hutchinson Precinct 19,Commissioner of Insurance,,Democratic,"Anderson, Dennis",77,000300
+RENO,Hutchinson Precinct 19,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000300
+RENO,Hutchinson Precinct 20,Commissioner of Insurance,,Democratic,"Anderson, Dennis",106,000310
+RENO,Hutchinson Precinct 20,Commissioner of Insurance,,Republican,"Selzer, Ken",148,000310
+RENO,Hutchinson Precinct 21,Commissioner of Insurance,,Democratic,"Anderson, Dennis",98,000320
+RENO,Hutchinson Precinct 21,Commissioner of Insurance,,Republican,"Selzer, Ken",113,000320
+RENO,Hutchinson Precinct 22,Commissioner of Insurance,,Democratic,"Anderson, Dennis",190,000330
+RENO,Hutchinson Precinct 22,Commissioner of Insurance,,Republican,"Selzer, Ken",304,000330
+RENO,Hutchinson Precinct 24,Commissioner of Insurance,,Democratic,"Anderson, Dennis",168,000350
+RENO,Hutchinson Precinct 24,Commissioner of Insurance,,Republican,"Selzer, Ken",273,000350
+RENO,Hutchinson Precinct 25,Commissioner of Insurance,,Democratic,"Anderson, Dennis",98,000360
+RENO,Hutchinson Precinct 25,Commissioner of Insurance,,Republican,"Selzer, Ken",88,000360
+RENO,Hutchinson Precinct 26,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,00037A
+RENO,Hutchinson Precinct 26,Commissioner of Insurance,,Republican,"Selzer, Ken",82,00037A
+RENO,Hutchinson Precinct 26 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,00037B
+RENO,Hutchinson Precinct 26 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",17,00037B
+RENO,Hutchinson Precinct 27,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,000380
+RENO,Hutchinson Precinct 27,Commissioner of Insurance,,Republican,"Selzer, Ken",195,000380
+RENO,Hutchinson Precinct 28,Commissioner of Insurance,,Democratic,"Anderson, Dennis",225,00039A
+RENO,Hutchinson Precinct 28,Commissioner of Insurance,,Republican,"Selzer, Ken",439,00039A
+RENO,Hutchinson Precinct 28 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,00039B
+RENO,Hutchinson Precinct 28 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",268,00039B
+RENO,Hutchinson Precinct 29,Commissioner of Insurance,,Democratic,"Anderson, Dennis",121,000400
+RENO,Hutchinson Precinct 29,Commissioner of Insurance,,Republican,"Selzer, Ken",186,000400
+RENO,Hutchinson Precinct 30,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,000410
+RENO,Hutchinson Precinct 30,Commissioner of Insurance,,Republican,"Selzer, Ken",78,000410
+RENO,Hutchinson Precinct 31,Commissioner of Insurance,,Democratic,"Anderson, Dennis",102,000420
+RENO,Hutchinson Precinct 31,Commissioner of Insurance,,Republican,"Selzer, Ken",170,000420
+RENO,Hutchinson Precinct 32,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000430
+RENO,Hutchinson Precinct 32,Commissioner of Insurance,,Republican,"Selzer, Ken",65,000430
+RENO,Langdon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000440
+RENO,Langdon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000440
+RENO,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000450
+RENO,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",126,000450
+RENO,Little River Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",164,000460
+RENO,Little River Township,Commissioner of Insurance,,Republican,"Selzer, Ken",611,000460
+RENO,Loda Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000470
+RENO,Loda Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000470
+RENO,Medford Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000480
+RENO,Medford Township,Commissioner of Insurance,,Republican,"Selzer, Ken",52,000480
+RENO,Medora Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",180,000490
+RENO,Medora Township,Commissioner of Insurance,,Republican,"Selzer, Ken",465,000490
+RENO,Miami Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",40,000500
+RENO,Miami Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000500
+RENO,Nickerson Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000510
+RENO,Nickerson Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",82,000510
+RENO,Nickerson Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000520
+RENO,Nickerson Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000520
+RENO,Nickerson Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000530
+RENO,Nickerson Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000530
+RENO,Ninnescah Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000540
+RENO,Ninnescah Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000540
+RENO,North Clay Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,00055A
+RENO,North Clay Township,Commissioner of Insurance,,Republican,"Selzer, Ken",283,00055A
+RENO,North Reno Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",151,000560
+RENO,North Reno Township,Commissioner of Insurance,,Republican,"Selzer, Ken",394,000560
+RENO,Plevna Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000570
+RENO,Plevna Township,Commissioner of Insurance,,Republican,"Selzer, Ken",75,000570
+RENO,Roscoe Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000580
+RENO,Roscoe Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000580
+RENO,Salt Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000590
+RENO,Salt Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",107,000590
+RENO,South Hutchinson Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",68,000610
+RENO,South Hutchinson Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",87,000610
+RENO,South Hutchinson Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",89,000620
+RENO,South Hutchinson Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",221,000620
+RENO,South Hutchinson Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",83,000630
+RENO,South Hutchinson Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",178,000630
+RENO,South Reno Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000640
+RENO,South Reno Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000640
+RENO,Sumner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,000650
+RENO,Sumner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",164,000650
+RENO,Sylvia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000660
+RENO,Sylvia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",74,000660
+RENO,Troy Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000670
+RENO,Troy Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000670
+RENO,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000680
+RENO,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",229,000680
+RENO,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000690
+RENO,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000690
+RENO,Westminister Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000700
+RENO,Westminister Township,Commissioner of Insurance,,Republican,"Selzer, Ken",64,000700
+RENO,Yoder Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000710
+RENO,Yoder Township,Commissioner of Insurance,,Republican,"Selzer, Ken",160,000710
+RENO,Hutchinson Precinct 01 H102,Commissioner of Insurance,,Democratic,"Anderson, Dennis",74,120020
+RENO,Hutchinson Precinct 01 H102,Commissioner of Insurance,,Republican,"Selzer, Ken",60,120020
+RENO,Hutchinson Precinct 01 H114,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,120030
+RENO,Hutchinson Precinct 01 H114,Commissioner of Insurance,,Republican,"Selzer, Ken",1,120030
+RENO,South Clay Township H101,Commissioner of Insurance,,Democratic,"Anderson, Dennis",106,120040
+RENO,South Clay Township H101,Commissioner of Insurance,,Republican,"Selzer, Ken",262,120040
+RENO,South Clay Township Clay H102 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,12005A
+RENO,South Clay Township Clay H102 A,Commissioner of Insurance,,Republican,"Selzer, Ken",5,12005A
+RENO,Hutchinson Precinct 34 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120060
+RENO,Hutchinson Precinct 34 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",1,120060
+RENO,Hutchinson Precinct 36,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120070
+RENO,Hutchinson Precinct 36,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120070
+RENO,Hutchinson Precinct 08 H101,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,200010
+RENO,Hutchinson Precinct 08 H101,Commissioner of Insurance,,Republican,"Selzer, Ken",104,200010
+RENO,Hutchinson Precinct 35,Commissioner of Insurance,,Democratic,"Anderson, Dennis",60,200020
+RENO,Hutchinson Precinct 35,Commissioner of Insurance,,Republican,"Selzer, Ken",87,200020
+RENO,Hutchinson Precinct 23 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,200030
+RENO,Hutchinson Precinct 23 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",94,200030
+RENO,Hutchinson Precinct 23 H104,Commissioner of Insurance,,Democratic,"Anderson, Dennis",237,200040
+RENO,Hutchinson Precinct 23 H104,Commissioner of Insurance,,Republican,"Selzer, Ken",439,200040
+RENO,Hutchinson Precinct 33,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,200050
+RENO,Hutchinson Precinct 33,Commissioner of Insurance,,Republican,"Selzer, Ken",119,200050
+RENO,Hutchinson Precinct 34,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,200060
+RENO,Hutchinson Precinct 34,Commissioner of Insurance,,Republican,"Selzer, Ken",33,200060
+RENO,Albion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",108,000010
+RENO,Albion Township,Secretary of State,,Republican,"Kobach, Kris",216,000010
+RENO,Arlington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",79,000020
+RENO,Arlington Township,Secretary of State,,Republican,"Kobach, Kris",106,000020
+RENO,Bell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000030
+RENO,Bell Township,Secretary of State,,Republican,"Kobach, Kris",25,000030
+RENO,Castleton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000040
+RENO,Castleton Township,Secretary of State,,Republican,"Kobach, Kris",83,000040
+RENO,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000050
+RENO,Center Township,Secretary of State,,Republican,"Kobach, Kris",90,000050
+RENO,Enterprise Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000060
+RENO,Enterprise Township,Secretary of State,,Republican,"Kobach, Kris",46,000060
+RENO,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",204,000070
+RENO,Grant Township,Secretary of State,,Republican,"Kobach, Kris",418,000070
+RENO,Grove Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000080
+RENO,Grove Township,Secretary of State,,Republican,"Kobach, Kris",19,000080
+RENO,Haven Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",203,000090
+RENO,Haven Township,Secretary of State,,Republican,"Kobach, Kris",363,000090
+RENO,Hayes Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000100
+RENO,Hayes Township,Secretary of State,,Republican,"Kobach, Kris",22,000100
+RENO,Huntsville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000110
+RENO,Huntsville Township,Secretary of State,,Republican,"Kobach, Kris",38,000110
+RENO,Hutchinson Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000130
+RENO,Hutchinson Precinct 02,Secretary of State,,Republican,"Kobach, Kris",58,000130
+RENO,Hutchinson Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000140
+RENO,Hutchinson Precinct 03,Secretary of State,,Republican,"Kobach, Kris",28,000140
+RENO,Hutchinson Precinct 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",262,000150
+RENO,Hutchinson Precinct 04,Secretary of State,,Republican,"Kobach, Kris",446,000150
+RENO,Hutchinson Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",114,000160
+RENO,Hutchinson Precinct 05,Secretary of State,,Republican,"Kobach, Kris",128,000160
+RENO,Hutchinson Precinct 06,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",106,000170
+RENO,Hutchinson Precinct 06,Secretary of State,,Republican,"Kobach, Kris",120,000170
+RENO,Hutchinson Precinct 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",168,000180
+RENO,Hutchinson Precinct 07,Secretary of State,,Republican,"Kobach, Kris",152,000180
+RENO,Hutchinson Precinct 09,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",227,000200
+RENO,Hutchinson Precinct 09,Secretary of State,,Republican,"Kobach, Kris",256,000200
+RENO,Hutchinson Precinct 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",228,000210
+RENO,Hutchinson Precinct 10,Secretary of State,,Republican,"Kobach, Kris",375,000210
+RENO,Hutchinson Precinct 11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",240,000220
+RENO,Hutchinson Precinct 11,Secretary of State,,Republican,"Kobach, Kris",374,000220
+RENO,Hutchinson Precinct 12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",168,000230
+RENO,Hutchinson Precinct 12,Secretary of State,,Republican,"Kobach, Kris",164,000230
+RENO,Hutchinson Precinct 13,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",181,000240
+RENO,Hutchinson Precinct 13,Secretary of State,,Republican,"Kobach, Kris",207,000240
+RENO,Hutchinson Precinct 14,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",125,000250
+RENO,Hutchinson Precinct 14,Secretary of State,,Republican,"Kobach, Kris",148,000250
+RENO,Hutchinson Precinct 15,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",79,000260
+RENO,Hutchinson Precinct 15,Secretary of State,,Republican,"Kobach, Kris",85,000260
+RENO,Hutchinson Precinct 16,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",181,000270
+RENO,Hutchinson Precinct 16,Secretary of State,,Republican,"Kobach, Kris",147,000270
+RENO,Hutchinson Precinct 17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",201,000280
+RENO,Hutchinson Precinct 17,Secretary of State,,Republican,"Kobach, Kris",237,000280
+RENO,Hutchinson Precinct 18,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000290
+RENO,Hutchinson Precinct 18,Secretary of State,,Republican,"Kobach, Kris",73,000290
+RENO,Hutchinson Precinct 19,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,000300
+RENO,Hutchinson Precinct 19,Secretary of State,,Republican,"Kobach, Kris",72,000300
+RENO,Hutchinson Precinct 20,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",112,000310
+RENO,Hutchinson Precinct 20,Secretary of State,,Republican,"Kobach, Kris",145,000310
+RENO,Hutchinson Precinct 21,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",107,000320
+RENO,Hutchinson Precinct 21,Secretary of State,,Republican,"Kobach, Kris",111,000320
+RENO,Hutchinson Precinct 22,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",215,000330
+RENO,Hutchinson Precinct 22,Secretary of State,,Republican,"Kobach, Kris",285,000330
+RENO,Hutchinson Precinct 24,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",196,000350
+RENO,Hutchinson Precinct 24,Secretary of State,,Republican,"Kobach, Kris",256,000350
+RENO,Hutchinson Precinct 25,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",100,000360
+RENO,Hutchinson Precinct 25,Secretary of State,,Republican,"Kobach, Kris",91,000360
+RENO,Hutchinson Precinct 26,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",63,00037A
+RENO,Hutchinson Precinct 26,Secretary of State,,Republican,"Kobach, Kris",73,00037A
+RENO,Hutchinson Precinct 26 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,00037B
+RENO,Hutchinson Precinct 26 Exclave,Secretary of State,,Republican,"Kobach, Kris",16,00037B
+RENO,Hutchinson Precinct 27,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",111,000380
+RENO,Hutchinson Precinct 27,Secretary of State,,Republican,"Kobach, Kris",186,000380
+RENO,Hutchinson Precinct 28,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",243,00039A
+RENO,Hutchinson Precinct 28,Secretary of State,,Republican,"Kobach, Kris",431,00039A
+RENO,Hutchinson Precinct 28 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",99,00039B
+RENO,Hutchinson Precinct 28 Exclave,Secretary of State,,Republican,"Kobach, Kris",247,00039B
+RENO,Hutchinson Precinct 29,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",140,000400
+RENO,Hutchinson Precinct 29,Secretary of State,,Republican,"Kobach, Kris",173,000400
+RENO,Hutchinson Precinct 30,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000410
+RENO,Hutchinson Precinct 30,Secretary of State,,Republican,"Kobach, Kris",74,000410
+RENO,Hutchinson Precinct 31,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",113,000420
+RENO,Hutchinson Precinct 31,Secretary of State,,Republican,"Kobach, Kris",163,000420
+RENO,Hutchinson Precinct 32,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000430
+RENO,Hutchinson Precinct 32,Secretary of State,,Republican,"Kobach, Kris",64,000430
+RENO,Langdon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000440
+RENO,Langdon Township,Secretary of State,,Republican,"Kobach, Kris",32,000440
+RENO,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000450
+RENO,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",117,000450
+RENO,Little River Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",247,000460
+RENO,Little River Township,Secretary of State,,Republican,"Kobach, Kris",547,000460
+RENO,Loda Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000470
+RENO,Loda Township,Secretary of State,,Republican,"Kobach, Kris",27,000470
+RENO,Medford Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000480
+RENO,Medford Township,Secretary of State,,Republican,"Kobach, Kris",44,000480
+RENO,Medora Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",195,000490
+RENO,Medora Township,Secretary of State,,Republican,"Kobach, Kris",465,000490
+RENO,Miami Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000500
+RENO,Miami Township,Secretary of State,,Republican,"Kobach, Kris",73,000500
+RENO,Nickerson Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000510
+RENO,Nickerson Ward 1,Secretary of State,,Republican,"Kobach, Kris",80,000510
+RENO,Nickerson Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000520
+RENO,Nickerson Ward 2,Secretary of State,,Republican,"Kobach, Kris",41,000520
+RENO,Nickerson Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000530
+RENO,Nickerson Ward 3,Secretary of State,,Republican,"Kobach, Kris",52,000530
+RENO,Ninnescah Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000540
+RENO,Ninnescah Township,Secretary of State,,Republican,"Kobach, Kris",44,000540
+RENO,North Clay Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",125,00055A
+RENO,North Clay Township,Secretary of State,,Republican,"Kobach, Kris",264,00055A
+RENO,North Reno Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",181,000560
+RENO,North Reno Township,Secretary of State,,Republican,"Kobach, Kris",375,000560
+RENO,Plevna Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000570
+RENO,Plevna Township,Secretary of State,,Republican,"Kobach, Kris",79,000570
+RENO,Roscoe Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000580
+RENO,Roscoe Township,Secretary of State,,Republican,"Kobach, Kris",28,000580
+RENO,Salt Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000590
+RENO,Salt Creek Township,Secretary of State,,Republican,"Kobach, Kris",112,000590
+RENO,South Hutchinson Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,000610
+RENO,South Hutchinson Precinct 1,Secretary of State,,Republican,"Kobach, Kris",89,000610
+RENO,South Hutchinson Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,000620
+RENO,South Hutchinson Precinct 2,Secretary of State,,Republican,"Kobach, Kris",213,000620
+RENO,South Hutchinson Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,000630
+RENO,South Hutchinson Precinct 3,Secretary of State,,Republican,"Kobach, Kris",160,000630
+RENO,South Reno Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000640
+RENO,South Reno Township,Secretary of State,,Republican,"Kobach, Kris",73,000640
+RENO,Sumner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,000650
+RENO,Sumner Township,Secretary of State,,Republican,"Kobach, Kris",174,000650
+RENO,Sylvia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000660
+RENO,Sylvia Township,Secretary of State,,Republican,"Kobach, Kris",66,000660
+RENO,Troy Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000670
+RENO,Troy Township,Secretary of State,,Republican,"Kobach, Kris",27,000670
+RENO,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",93,000680
+RENO,Valley Township,Secretary of State,,Republican,"Kobach, Kris",216,000680
+RENO,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000690
+RENO,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",43,000690
+RENO,Westminister Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000700
+RENO,Westminister Township,Secretary of State,,Republican,"Kobach, Kris",62,000700
+RENO,Yoder Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,000710
+RENO,Yoder Township,Secretary of State,,Republican,"Kobach, Kris",165,000710
+RENO,Hutchinson Precinct 01 H102,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",79,120020
+RENO,Hutchinson Precinct 01 H102,Secretary of State,,Republican,"Kobach, Kris",59,120020
+RENO,Hutchinson Precinct 01 H114,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,120030
+RENO,Hutchinson Precinct 01 H114,Secretary of State,,Republican,"Kobach, Kris",2,120030
+RENO,South Clay Township H101,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",117,120040
+RENO,South Clay Township H101,Secretary of State,,Republican,"Kobach, Kris",251,120040
+RENO,South Clay Township Clay H102 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,12005A
+RENO,South Clay Township Clay H102 A,Secretary of State,,Republican,"Kobach, Kris",4,12005A
+RENO,Hutchinson Precinct 34 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120060
+RENO,Hutchinson Precinct 34 Exclave,Secretary of State,,Republican,"Kobach, Kris",1,120060
+RENO,Hutchinson Precinct 36,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120070
+RENO,Hutchinson Precinct 36,Secretary of State,,Republican,"Kobach, Kris",0,120070
+RENO,Hutchinson Precinct 08 H101,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",69,200010
+RENO,Hutchinson Precinct 08 H101,Secretary of State,,Republican,"Kobach, Kris",97,200010
+RENO,Hutchinson Precinct 35,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,200020
+RENO,Hutchinson Precinct 35,Secretary of State,,Republican,"Kobach, Kris",84,200020
+RENO,Hutchinson Precinct 23 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,200030
+RENO,Hutchinson Precinct 23 Exclave,Secretary of State,,Republican,"Kobach, Kris",98,200030
+RENO,Hutchinson Precinct 23 H104,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",287,200040
+RENO,Hutchinson Precinct 23 H104,Secretary of State,,Republican,"Kobach, Kris",410,200040
+RENO,Hutchinson Precinct 33,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,200050
+RENO,Hutchinson Precinct 33,Secretary of State,,Republican,"Kobach, Kris",112,200050
+RENO,Hutchinson Precinct 34,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,200060
+RENO,Hutchinson Precinct 34,Secretary of State,,Republican,"Kobach, Kris",32,200060
+RENO,Albion Township,State Treasurer,,Democratic,"Alldritt, Carmen",55,000010
+RENO,Albion Township,State Treasurer,,Republican,"Estes, Ron",253,000010
+RENO,Arlington Township,State Treasurer,,Democratic,"Alldritt, Carmen",56,000020
+RENO,Arlington Township,State Treasurer,,Republican,"Estes, Ron",121,000020
+RENO,Bell Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000030
+RENO,Bell Township,State Treasurer,,Republican,"Estes, Ron",25,000030
+RENO,Castleton Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000040
+RENO,Castleton Township,State Treasurer,,Republican,"Estes, Ron",98,000040
+RENO,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000050
+RENO,Center Township,State Treasurer,,Republican,"Estes, Ron",98,000050
+RENO,Enterprise Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000060
+RENO,Enterprise Township,State Treasurer,,Republican,"Estes, Ron",46,000060
+RENO,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",112,000070
+RENO,Grant Township,State Treasurer,,Republican,"Estes, Ron",506,000070
+RENO,Grove Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000080
+RENO,Grove Township,State Treasurer,,Republican,"Estes, Ron",19,000080
+RENO,Haven Township,State Treasurer,,Democratic,"Alldritt, Carmen",127,000090
+RENO,Haven Township,State Treasurer,,Republican,"Estes, Ron",431,000090
+RENO,Hayes Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000100
+RENO,Hayes Township,State Treasurer,,Republican,"Estes, Ron",26,000100
+RENO,Huntsville Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000110
+RENO,Huntsville Township,State Treasurer,,Republican,"Estes, Ron",41,000110
+RENO,Hutchinson Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",52,000130
+RENO,Hutchinson Precinct 02,State Treasurer,,Republican,"Estes, Ron",65,000130
+RENO,Hutchinson Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",43,000140
+RENO,Hutchinson Precinct 03,State Treasurer,,Republican,"Estes, Ron",33,000140
+RENO,Hutchinson Precinct 04,State Treasurer,,Democratic,"Alldritt, Carmen",126,000150
+RENO,Hutchinson Precinct 04,State Treasurer,,Republican,"Estes, Ron",561,000150
+RENO,Hutchinson Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",96,000160
+RENO,Hutchinson Precinct 05,State Treasurer,,Republican,"Estes, Ron",145,000160
+RENO,Hutchinson Precinct 06,State Treasurer,,Democratic,"Alldritt, Carmen",87,000170
+RENO,Hutchinson Precinct 06,State Treasurer,,Republican,"Estes, Ron",139,000170
+RENO,Hutchinson Precinct 07,State Treasurer,,Democratic,"Alldritt, Carmen",118,000180
+RENO,Hutchinson Precinct 07,State Treasurer,,Republican,"Estes, Ron",196,000180
+RENO,Hutchinson Precinct 09,State Treasurer,,Democratic,"Alldritt, Carmen",144,000200
+RENO,Hutchinson Precinct 09,State Treasurer,,Republican,"Estes, Ron",336,000200
+RENO,Hutchinson Precinct 10,State Treasurer,,Democratic,"Alldritt, Carmen",122,000210
+RENO,Hutchinson Precinct 10,State Treasurer,,Republican,"Estes, Ron",470,000210
+RENO,Hutchinson Precinct 11,State Treasurer,,Democratic,"Alldritt, Carmen",155,000220
+RENO,Hutchinson Precinct 11,State Treasurer,,Republican,"Estes, Ron",449,000220
+RENO,Hutchinson Precinct 12,State Treasurer,,Democratic,"Alldritt, Carmen",103,000230
+RENO,Hutchinson Precinct 12,State Treasurer,,Republican,"Estes, Ron",228,000230
+RENO,Hutchinson Precinct 13,State Treasurer,,Democratic,"Alldritt, Carmen",138,000240
+RENO,Hutchinson Precinct 13,State Treasurer,,Republican,"Estes, Ron",240,000240
+RENO,Hutchinson Precinct 14,State Treasurer,,Democratic,"Alldritt, Carmen",92,000250
+RENO,Hutchinson Precinct 14,State Treasurer,,Republican,"Estes, Ron",177,000250
+RENO,Hutchinson Precinct 15,State Treasurer,,Democratic,"Alldritt, Carmen",62,000260
+RENO,Hutchinson Precinct 15,State Treasurer,,Republican,"Estes, Ron",99,000260
+RENO,Hutchinson Precinct 16,State Treasurer,,Democratic,"Alldritt, Carmen",141,000270
+RENO,Hutchinson Precinct 16,State Treasurer,,Republican,"Estes, Ron",181,000270
+RENO,Hutchinson Precinct 17,State Treasurer,,Democratic,"Alldritt, Carmen",122,000280
+RENO,Hutchinson Precinct 17,State Treasurer,,Republican,"Estes, Ron",304,000280
+RENO,Hutchinson Precinct 18,State Treasurer,,Democratic,"Alldritt, Carmen",54,000290
+RENO,Hutchinson Precinct 18,State Treasurer,,Republican,"Estes, Ron",94,000290
+RENO,Hutchinson Precinct 19,State Treasurer,,Democratic,"Alldritt, Carmen",62,000300
+RENO,Hutchinson Precinct 19,State Treasurer,,Republican,"Estes, Ron",96,000300
+RENO,Hutchinson Precinct 20,State Treasurer,,Democratic,"Alldritt, Carmen",84,000310
+RENO,Hutchinson Precinct 20,State Treasurer,,Republican,"Estes, Ron",174,000310
+RENO,Hutchinson Precinct 21,State Treasurer,,Democratic,"Alldritt, Carmen",75,000320
+RENO,Hutchinson Precinct 21,State Treasurer,,Republican,"Estes, Ron",141,000320
+RENO,Hutchinson Precinct 22,State Treasurer,,Democratic,"Alldritt, Carmen",158,000330
+RENO,Hutchinson Precinct 22,State Treasurer,,Republican,"Estes, Ron",339,000330
+RENO,Hutchinson Precinct 24,State Treasurer,,Democratic,"Alldritt, Carmen",130,000350
+RENO,Hutchinson Precinct 24,State Treasurer,,Republican,"Estes, Ron",312,000350
+RENO,Hutchinson Precinct 25,State Treasurer,,Democratic,"Alldritt, Carmen",87,000360
+RENO,Hutchinson Precinct 25,State Treasurer,,Republican,"Estes, Ron",107,000360
+RENO,Hutchinson Precinct 26,State Treasurer,,Democratic,"Alldritt, Carmen",48,00037A
+RENO,Hutchinson Precinct 26,State Treasurer,,Republican,"Estes, Ron",88,00037A
+RENO,Hutchinson Precinct 26 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",10,00037B
+RENO,Hutchinson Precinct 26 Exclave,State Treasurer,,Republican,"Estes, Ron",17,00037B
+RENO,Hutchinson Precinct 27,State Treasurer,,Democratic,"Alldritt, Carmen",69,000380
+RENO,Hutchinson Precinct 27,State Treasurer,,Republican,"Estes, Ron",226,000380
+RENO,Hutchinson Precinct 28,State Treasurer,,Democratic,"Alldritt, Carmen",157,00039A
+RENO,Hutchinson Precinct 28,State Treasurer,,Republican,"Estes, Ron",507,00039A
+RENO,Hutchinson Precinct 28 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",38,00039B
+RENO,Hutchinson Precinct 28 Exclave,State Treasurer,,Republican,"Estes, Ron",302,00039B
+RENO,Hutchinson Precinct 29,State Treasurer,,Democratic,"Alldritt, Carmen",92,000400
+RENO,Hutchinson Precinct 29,State Treasurer,,Republican,"Estes, Ron",215,000400
+RENO,Hutchinson Precinct 30,State Treasurer,,Democratic,"Alldritt, Carmen",51,000410
+RENO,Hutchinson Precinct 30,State Treasurer,,Republican,"Estes, Ron",84,000410
+RENO,Hutchinson Precinct 31,State Treasurer,,Democratic,"Alldritt, Carmen",84,000420
+RENO,Hutchinson Precinct 31,State Treasurer,,Republican,"Estes, Ron",190,000420
+RENO,Hutchinson Precinct 32,State Treasurer,,Democratic,"Alldritt, Carmen",22,000430
+RENO,Hutchinson Precinct 32,State Treasurer,,Republican,"Estes, Ron",79,000430
+RENO,Langdon Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000440
+RENO,Langdon Township,State Treasurer,,Republican,"Estes, Ron",37,000440
+RENO,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000450
+RENO,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",132,000450
+RENO,Little River Township,State Treasurer,,Democratic,"Alldritt, Carmen",134,000460
+RENO,Little River Township,State Treasurer,,Republican,"Estes, Ron",648,000460
+RENO,Loda Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000470
+RENO,Loda Township,State Treasurer,,Republican,"Estes, Ron",33,000470
+RENO,Medford Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000480
+RENO,Medford Township,State Treasurer,,Republican,"Estes, Ron",56,000480
+RENO,Medora Township,State Treasurer,,Democratic,"Alldritt, Carmen",128,000490
+RENO,Medora Township,State Treasurer,,Republican,"Estes, Ron",525,000490
+RENO,Miami Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000500
+RENO,Miami Township,State Treasurer,,Republican,"Estes, Ron",82,000500
+RENO,Nickerson Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",31,000510
+RENO,Nickerson Ward 1,State Treasurer,,Republican,"Estes, Ron",94,000510
+RENO,Nickerson Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",19,000520
+RENO,Nickerson Ward 2,State Treasurer,,Republican,"Estes, Ron",52,000520
+RENO,Nickerson Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",20,000530
+RENO,Nickerson Ward 3,State Treasurer,,Republican,"Estes, Ron",65,000530
+RENO,Ninnescah Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000540
+RENO,Ninnescah Township,State Treasurer,,Republican,"Estes, Ron",57,000540
+RENO,North Clay Township,State Treasurer,,Democratic,"Alldritt, Carmen",69,00055A
+RENO,North Clay Township,State Treasurer,,Republican,"Estes, Ron",316,00055A
+RENO,North Reno Township,State Treasurer,,Democratic,"Alldritt, Carmen",117,000560
+RENO,North Reno Township,State Treasurer,,Republican,"Estes, Ron",435,000560
+RENO,Plevna Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000570
+RENO,Plevna Township,State Treasurer,,Republican,"Estes, Ron",84,000570
+RENO,Roscoe Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000580
+RENO,Roscoe Township,State Treasurer,,Republican,"Estes, Ron",32,000580
+RENO,Salt Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000590
+RENO,Salt Creek Township,State Treasurer,,Republican,"Estes, Ron",113,000590
+RENO,South Hutchinson Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",53,000610
+RENO,South Hutchinson Precinct 1,State Treasurer,,Republican,"Estes, Ron",101,000610
+RENO,South Hutchinson Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",73,000620
+RENO,South Hutchinson Precinct 2,State Treasurer,,Republican,"Estes, Ron",243,000620
+RENO,South Hutchinson Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",70,000630
+RENO,South Hutchinson Precinct 3,State Treasurer,,Republican,"Estes, Ron",197,000630
+RENO,South Reno Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000640
+RENO,South Reno Township,State Treasurer,,Republican,"Estes, Ron",83,000640
+RENO,Sumner Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000650
+RENO,Sumner Township,State Treasurer,,Republican,"Estes, Ron",192,000650
+RENO,Sylvia Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000660
+RENO,Sylvia Township,State Treasurer,,Republican,"Estes, Ron",87,000660
+RENO,Troy Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000670
+RENO,Troy Township,State Treasurer,,Republican,"Estes, Ron",39,000670
+RENO,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",60,000680
+RENO,Valley Township,State Treasurer,,Republican,"Estes, Ron",250,000680
+RENO,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000690
+RENO,Walnut Township,State Treasurer,,Republican,"Estes, Ron",45,000690
+RENO,Westminister Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000700
+RENO,Westminister Township,State Treasurer,,Republican,"Estes, Ron",72,000700
+RENO,Yoder Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000710
+RENO,Yoder Township,State Treasurer,,Republican,"Estes, Ron",176,000710
+RENO,Hutchinson Precinct 01 H102,State Treasurer,,Democratic,"Alldritt, Carmen",71,120020
+RENO,Hutchinson Precinct 01 H102,State Treasurer,,Republican,"Estes, Ron",64,120020
+RENO,Hutchinson Precinct 01 H114,State Treasurer,,Democratic,"Alldritt, Carmen",6,120030
+RENO,Hutchinson Precinct 01 H114,State Treasurer,,Republican,"Estes, Ron",2,120030
+RENO,South Clay Township H101,State Treasurer,,Democratic,"Alldritt, Carmen",85,120040
+RENO,South Clay Township H101,State Treasurer,,Republican,"Estes, Ron",285,120040
+RENO,South Clay Township Clay H102 A,State Treasurer,,Democratic,"Alldritt, Carmen",3,12005A
+RENO,South Clay Township Clay H102 A,State Treasurer,,Republican,"Estes, Ron",5,12005A
+RENO,Hutchinson Precinct 34 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,120060
+RENO,Hutchinson Precinct 34 Exclave,State Treasurer,,Republican,"Estes, Ron",1,120060
+RENO,Hutchinson Precinct 36,State Treasurer,,Democratic,"Alldritt, Carmen",0,120070
+RENO,Hutchinson Precinct 36,State Treasurer,,Republican,"Estes, Ron",0,120070
+RENO,Hutchinson Precinct 08 H101,State Treasurer,,Democratic,"Alldritt, Carmen",53,200010
+RENO,Hutchinson Precinct 08 H101,State Treasurer,,Republican,"Estes, Ron",111,200010
+RENO,Hutchinson Precinct 35,State Treasurer,,Democratic,"Alldritt, Carmen",47,200020
+RENO,Hutchinson Precinct 35,State Treasurer,,Republican,"Estes, Ron",99,200020
+RENO,Hutchinson Precinct 23 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",32,200030
+RENO,Hutchinson Precinct 23 Exclave,State Treasurer,,Republican,"Estes, Ron",106,200030
+RENO,Hutchinson Precinct 23 H104,State Treasurer,,Democratic,"Alldritt, Carmen",189,200040
+RENO,Hutchinson Precinct 23 H104,State Treasurer,,Republican,"Estes, Ron",496,200040
+RENO,Hutchinson Precinct 33,State Treasurer,,Democratic,"Alldritt, Carmen",31,200050
+RENO,Hutchinson Precinct 33,State Treasurer,,Republican,"Estes, Ron",133,200050
+RENO,Hutchinson Precinct 34,State Treasurer,,Democratic,"Alldritt, Carmen",14,200060
+RENO,Hutchinson Precinct 34,State Treasurer,,Republican,"Estes, Ron",36,200060
+RENO,Albion Township,United States Senate,,independent,"Orman, Greg",92,000010
+RENO,Albion Township,United States Senate,,Libertarian,"Batson, Randall",15,000010
+RENO,Albion Township,United States Senate,,Republican,"Roberts, Pat",217,000010
+RENO,Arlington Township,United States Senate,,independent,"Orman, Greg",78,000020
+RENO,Arlington Township,United States Senate,,Libertarian,"Batson, Randall",20,000020
+RENO,Arlington Township,United States Senate,,Republican,"Roberts, Pat",85,000020
+RENO,Bell Township,United States Senate,,independent,"Orman, Greg",9,000030
+RENO,Bell Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+RENO,Bell Township,United States Senate,,Republican,"Roberts, Pat",25,000030
+RENO,Castleton Township,United States Senate,,independent,"Orman, Greg",18,000040
+RENO,Castleton Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+RENO,Castleton Township,United States Senate,,Republican,"Roberts, Pat",22,000040
+RENO,Center Township,United States Senate,,independent,"Orman, Greg",40,000050
+RENO,Center Township,United States Senate,,Libertarian,"Batson, Randall",5,000050
+RENO,Center Township,United States Senate,,Republican,"Roberts, Pat",89,000050
+RENO,Enterprise Township,United States Senate,,independent,"Orman, Greg",16,000060
+RENO,Enterprise Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+RENO,Enterprise Township,United States Senate,,Republican,"Roberts, Pat",46,000060
+RENO,Grant Township,United States Senate,,independent,"Orman, Greg",209,000070
+RENO,Grant Township,United States Senate,,Libertarian,"Batson, Randall",31,000070
+RENO,Grant Township,United States Senate,,Republican,"Roberts, Pat",380,000070
+RENO,Grove Township,United States Senate,,independent,"Orman, Greg",4,000080
+RENO,Grove Township,United States Senate,,Libertarian,"Batson, Randall",2,000080
+RENO,Grove Township,United States Senate,,Republican,"Roberts, Pat",15,000080
+RENO,Haven Township,United States Senate,,independent,"Orman, Greg",177,000090
+RENO,Haven Township,United States Senate,,Libertarian,"Batson, Randall",35,000090
+RENO,Haven Township,United States Senate,,Republican,"Roberts, Pat",355,000090
+RENO,Hayes Township,United States Senate,,independent,"Orman, Greg",7,000100
+RENO,Hayes Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+RENO,Hayes Township,United States Senate,,Republican,"Roberts, Pat",23,000100
+RENO,Huntsville Township,United States Senate,,independent,"Orman, Greg",10,000110
+RENO,Huntsville Township,United States Senate,,Libertarian,"Batson, Randall",4,000110
+RENO,Huntsville Township,United States Senate,,Republican,"Roberts, Pat",36,000110
+RENO,Hutchinson Precinct 02,United States Senate,,independent,"Orman, Greg",63,000130
+RENO,Hutchinson Precinct 02,United States Senate,,Libertarian,"Batson, Randall",5,000130
+RENO,Hutchinson Precinct 02,United States Senate,,Republican,"Roberts, Pat",47,000130
+RENO,Hutchinson Precinct 03,United States Senate,,independent,"Orman, Greg",39,000140
+RENO,Hutchinson Precinct 03,United States Senate,,Libertarian,"Batson, Randall",5,000140
+RENO,Hutchinson Precinct 03,United States Senate,,Republican,"Roberts, Pat",31,000140
+RENO,Hutchinson Precinct 04,United States Senate,,independent,"Orman, Greg",281,000150
+RENO,Hutchinson Precinct 04,United States Senate,,Libertarian,"Batson, Randall",20,000150
+RENO,Hutchinson Precinct 04,United States Senate,,Republican,"Roberts, Pat",407,000150
+RENO,Hutchinson Precinct 05,United States Senate,,independent,"Orman, Greg",110,000160
+RENO,Hutchinson Precinct 05,United States Senate,,Libertarian,"Batson, Randall",17,000160
+RENO,Hutchinson Precinct 05,United States Senate,,Republican,"Roberts, Pat",115,000160
+RENO,Hutchinson Precinct 06,United States Senate,,independent,"Orman, Greg",102,000170
+RENO,Hutchinson Precinct 06,United States Senate,,Libertarian,"Batson, Randall",14,000170
+RENO,Hutchinson Precinct 06,United States Senate,,Republican,"Roberts, Pat",110,000170
+RENO,Hutchinson Precinct 07,United States Senate,,independent,"Orman, Greg",167,000180
+RENO,Hutchinson Precinct 07,United States Senate,,Libertarian,"Batson, Randall",19,000180
+RENO,Hutchinson Precinct 07,United States Senate,,Republican,"Roberts, Pat",139,000180
+RENO,Hutchinson Precinct 09,United States Senate,,independent,"Orman, Greg",223,000200
+RENO,Hutchinson Precinct 09,United States Senate,,Libertarian,"Batson, Randall",33,000200
+RENO,Hutchinson Precinct 09,United States Senate,,Republican,"Roberts, Pat",227,000200
+RENO,Hutchinson Precinct 10,United States Senate,,independent,"Orman, Greg",252,000210
+RENO,Hutchinson Precinct 10,United States Senate,,Libertarian,"Batson, Randall",18,000210
+RENO,Hutchinson Precinct 10,United States Senate,,Republican,"Roberts, Pat",326,000210
+RENO,Hutchinson Precinct 11,United States Senate,,independent,"Orman, Greg",250,000220
+RENO,Hutchinson Precinct 11,United States Senate,,Libertarian,"Batson, Randall",27,000220
+RENO,Hutchinson Precinct 11,United States Senate,,Republican,"Roberts, Pat",335,000220
+RENO,Hutchinson Precinct 12,United States Senate,,independent,"Orman, Greg",153,000230
+RENO,Hutchinson Precinct 12,United States Senate,,Libertarian,"Batson, Randall",11,000230
+RENO,Hutchinson Precinct 12,United States Senate,,Republican,"Roberts, Pat",173,000230
+RENO,Hutchinson Precinct 13,United States Senate,,independent,"Orman, Greg",193,000240
+RENO,Hutchinson Precinct 13,United States Senate,,Libertarian,"Batson, Randall",19,000240
+RENO,Hutchinson Precinct 13,United States Senate,,Republican,"Roberts, Pat",176,000240
+RENO,Hutchinson Precinct 14,United States Senate,,independent,"Orman, Greg",124,000250
+RENO,Hutchinson Precinct 14,United States Senate,,Libertarian,"Batson, Randall",14,000250
+RENO,Hutchinson Precinct 14,United States Senate,,Republican,"Roberts, Pat",139,000250
+RENO,Hutchinson Precinct 15,United States Senate,,independent,"Orman, Greg",82,000260
+RENO,Hutchinson Precinct 15,United States Senate,,Libertarian,"Batson, Randall",10,000260
+RENO,Hutchinson Precinct 15,United States Senate,,Republican,"Roberts, Pat",73,000260
+RENO,Hutchinson Precinct 16,United States Senate,,independent,"Orman, Greg",181,000270
+RENO,Hutchinson Precinct 16,United States Senate,,Libertarian,"Batson, Randall",15,000270
+RENO,Hutchinson Precinct 16,United States Senate,,Republican,"Roberts, Pat",130,000270
+RENO,Hutchinson Precinct 17,United States Senate,,independent,"Orman, Greg",199,000280
+RENO,Hutchinson Precinct 17,United States Senate,,Libertarian,"Batson, Randall",20,000280
+RENO,Hutchinson Precinct 17,United States Senate,,Republican,"Roberts, Pat",219,000280
+RENO,Hutchinson Precinct 18,United States Senate,,independent,"Orman, Greg",72,000290
+RENO,Hutchinson Precinct 18,United States Senate,,Libertarian,"Batson, Randall",14,000290
+RENO,Hutchinson Precinct 18,United States Senate,,Republican,"Roberts, Pat",62,000290
+RENO,Hutchinson Precinct 19,United States Senate,,independent,"Orman, Greg",83,000300
+RENO,Hutchinson Precinct 19,United States Senate,,Libertarian,"Batson, Randall",19,000300
+RENO,Hutchinson Precinct 19,United States Senate,,Republican,"Roberts, Pat",56,000300
+RENO,Hutchinson Precinct 20,United States Senate,,independent,"Orman, Greg",126,000310
+RENO,Hutchinson Precinct 20,United States Senate,,Libertarian,"Batson, Randall",19,000310
+RENO,Hutchinson Precinct 20,United States Senate,,Republican,"Roberts, Pat",119,000310
+RENO,Hutchinson Precinct 21,United States Senate,,independent,"Orman, Greg",112,000320
+RENO,Hutchinson Precinct 21,United States Senate,,Libertarian,"Batson, Randall",12,000320
+RENO,Hutchinson Precinct 21,United States Senate,,Republican,"Roberts, Pat",94,000320
+RENO,Hutchinson Precinct 22,United States Senate,,independent,"Orman, Greg",236,000330
+RENO,Hutchinson Precinct 22,United States Senate,,Libertarian,"Batson, Randall",22,000330
+RENO,Hutchinson Precinct 22,United States Senate,,Republican,"Roberts, Pat",246,000330
+RENO,Hutchinson Precinct 24,United States Senate,,independent,"Orman, Greg",186,000350
+RENO,Hutchinson Precinct 24,United States Senate,,Libertarian,"Batson, Randall",25,000350
+RENO,Hutchinson Precinct 24,United States Senate,,Republican,"Roberts, Pat",234,000350
+RENO,Hutchinson Precinct 25,United States Senate,,independent,"Orman, Greg",112,000360
+RENO,Hutchinson Precinct 25,United States Senate,,Libertarian,"Batson, Randall",11,000360
+RENO,Hutchinson Precinct 25,United States Senate,,Republican,"Roberts, Pat",73,000360
+RENO,Hutchinson Precinct 26,United States Senate,,independent,"Orman, Greg",66,00037A
+RENO,Hutchinson Precinct 26,United States Senate,,Libertarian,"Batson, Randall",8,00037A
+RENO,Hutchinson Precinct 26,United States Senate,,Republican,"Roberts, Pat",64,00037A
+RENO,Hutchinson Precinct 26 Exclave,United States Senate,,independent,"Orman, Greg",13,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States Senate,,Libertarian,"Batson, Randall",3,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States Senate,,Republican,"Roberts, Pat",11,00037B
+RENO,Hutchinson Precinct 27,United States Senate,,independent,"Orman, Greg",129,000380
+RENO,Hutchinson Precinct 27,United States Senate,,Libertarian,"Batson, Randall",13,000380
+RENO,Hutchinson Precinct 27,United States Senate,,Republican,"Roberts, Pat",157,000380
+RENO,Hutchinson Precinct 28,United States Senate,,independent,"Orman, Greg",266,00039A
+RENO,Hutchinson Precinct 28,United States Senate,,Libertarian,"Batson, Randall",22,00039A
+RENO,Hutchinson Precinct 28,United States Senate,,Republican,"Roberts, Pat",381,00039A
+RENO,Hutchinson Precinct 28 Exclave,United States Senate,,independent,"Orman, Greg",102,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States Senate,,Libertarian,"Batson, Randall",5,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States Senate,,Republican,"Roberts, Pat",239,00039B
+RENO,Hutchinson Precinct 29,United States Senate,,independent,"Orman, Greg",148,000400
+RENO,Hutchinson Precinct 29,United States Senate,,Libertarian,"Batson, Randall",15,000400
+RENO,Hutchinson Precinct 29,United States Senate,,Republican,"Roberts, Pat",148,000400
+RENO,Hutchinson Precinct 30,United States Senate,,independent,"Orman, Greg",59,000410
+RENO,Hutchinson Precinct 30,United States Senate,,Libertarian,"Batson, Randall",16,000410
+RENO,Hutchinson Precinct 30,United States Senate,,Republican,"Roberts, Pat",60,000410
+RENO,Hutchinson Precinct 31,United States Senate,,independent,"Orman, Greg",121,000420
+RENO,Hutchinson Precinct 31,United States Senate,,Libertarian,"Batson, Randall",13,000420
+RENO,Hutchinson Precinct 31,United States Senate,,Republican,"Roberts, Pat",142,000420
+RENO,Hutchinson Precinct 32,United States Senate,,independent,"Orman, Greg",39,000430
+RENO,Hutchinson Precinct 32,United States Senate,,Libertarian,"Batson, Randall",3,000430
+RENO,Hutchinson Precinct 32,United States Senate,,Republican,"Roberts, Pat",59,000430
+RENO,Langdon Township,United States Senate,,independent,"Orman, Greg",19,000440
+RENO,Langdon Township,United States Senate,,Libertarian,"Batson, Randall",4,000440
+RENO,Langdon Township,United States Senate,,Republican,"Roberts, Pat",21,000440
+RENO,Lincoln Township,United States Senate,,independent,"Orman, Greg",29,000450
+RENO,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",10,000450
+RENO,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",116,000450
+RENO,Little River Township,United States Senate,,independent,"Orman, Greg",233,000460
+RENO,Little River Township,United States Senate,,Libertarian,"Batson, Randall",34,000460
+RENO,Little River Township,United States Senate,,Republican,"Roberts, Pat",533,000460
+RENO,Loda Township,United States Senate,,independent,"Orman, Greg",10,000470
+RENO,Loda Township,United States Senate,,Libertarian,"Batson, Randall",4,000470
+RENO,Loda Township,United States Senate,,Republican,"Roberts, Pat",28,000470
+RENO,Medford Township,United States Senate,,independent,"Orman, Greg",13,000480
+RENO,Medford Township,United States Senate,,Libertarian,"Batson, Randall",2,000480
+RENO,Medford Township,United States Senate,,Republican,"Roberts, Pat",47,000480
+RENO,Medora Township,United States Senate,,independent,"Orman, Greg",219,000490
+RENO,Medora Township,United States Senate,,Libertarian,"Batson, Randall",30,000490
+RENO,Medora Township,United States Senate,,Republican,"Roberts, Pat",414,000490
+RENO,Miami Township,United States Senate,,independent,"Orman, Greg",44,000500
+RENO,Miami Township,United States Senate,,Libertarian,"Batson, Randall",9,000500
+RENO,Miami Township,United States Senate,,Republican,"Roberts, Pat",62,000500
+RENO,Nickerson Ward 1,United States Senate,,independent,"Orman, Greg",53,000510
+RENO,Nickerson Ward 1,United States Senate,,Libertarian,"Batson, Randall",9,000510
+RENO,Nickerson Ward 1,United States Senate,,Republican,"Roberts, Pat",67,000510
+RENO,Nickerson Ward 2,United States Senate,,independent,"Orman, Greg",33,000520
+RENO,Nickerson Ward 2,United States Senate,,Libertarian,"Batson, Randall",4,000520
+RENO,Nickerson Ward 2,United States Senate,,Republican,"Roberts, Pat",34,000520
+RENO,Nickerson Ward 3,United States Senate,,independent,"Orman, Greg",43,000530
+RENO,Nickerson Ward 3,United States Senate,,Libertarian,"Batson, Randall",7,000530
+RENO,Nickerson Ward 3,United States Senate,,Republican,"Roberts, Pat",38,000530
+RENO,Ninnescah Township,United States Senate,,independent,"Orman, Greg",32,000540
+RENO,Ninnescah Township,United States Senate,,Libertarian,"Batson, Randall",5,000540
+RENO,Ninnescah Township,United States Senate,,Republican,"Roberts, Pat",41,000540
+RENO,North Clay Township,United States Senate,,independent,"Orman, Greg",132,00055A
+RENO,North Clay Township,United States Senate,,Libertarian,"Batson, Randall",13,00055A
+RENO,North Clay Township,United States Senate,,Republican,"Roberts, Pat",247,00055A
+RENO,North Reno Township,United States Senate,,independent,"Orman, Greg",174,000560
+RENO,North Reno Township,United States Senate,,Libertarian,"Batson, Randall",24,000560
+RENO,North Reno Township,United States Senate,,Republican,"Roberts, Pat",352,000560
+RENO,Plevna Township,United States Senate,,independent,"Orman, Greg",20,000570
+RENO,Plevna Township,United States Senate,,Libertarian,"Batson, Randall",5,000570
+RENO,Plevna Township,United States Senate,,Republican,"Roberts, Pat",72,000570
+RENO,Roscoe Township,United States Senate,,independent,"Orman, Greg",11,000580
+RENO,Roscoe Township,United States Senate,,Libertarian,"Batson, Randall",1,000580
+RENO,Roscoe Township,United States Senate,,Republican,"Roberts, Pat",29,000580
+RENO,Salt Creek Township,United States Senate,,independent,"Orman, Greg",28,000590
+RENO,Salt Creek Township,United States Senate,,Libertarian,"Batson, Randall",7,000590
+RENO,Salt Creek Township,United States Senate,,Republican,"Roberts, Pat",106,000590
+RENO,South Hutchinson Precinct 1,United States Senate,,independent,"Orman, Greg",58,000610
+RENO,South Hutchinson Precinct 1,United States Senate,,Libertarian,"Batson, Randall",13,000610
+RENO,South Hutchinson Precinct 1,United States Senate,,Republican,"Roberts, Pat",80,000610
+RENO,South Hutchinson Precinct 2,United States Senate,,independent,"Orman, Greg",113,000620
+RENO,South Hutchinson Precinct 2,United States Senate,,Libertarian,"Batson, Randall",27,000620
+RENO,South Hutchinson Precinct 2,United States Senate,,Republican,"Roberts, Pat",177,000620
+RENO,South Hutchinson Precinct 3,United States Senate,,independent,"Orman, Greg",108,000630
+RENO,South Hutchinson Precinct 3,United States Senate,,Libertarian,"Batson, Randall",11,000630
+RENO,South Hutchinson Precinct 3,United States Senate,,Republican,"Roberts, Pat",149,000630
+RENO,South Reno Township,United States Senate,,independent,"Orman, Greg",33,000640
+RENO,South Reno Township,United States Senate,,Libertarian,"Batson, Randall",5,000640
+RENO,South Reno Township,United States Senate,,Republican,"Roberts, Pat",68,000640
+RENO,Sumner Township,United States Senate,,independent,"Orman, Greg",62,000650
+RENO,Sumner Township,United States Senate,,Libertarian,"Batson, Randall",6,000650
+RENO,Sumner Township,United States Senate,,Republican,"Roberts, Pat",165,000650
+RENO,Sylvia Township,United States Senate,,independent,"Orman, Greg",32,000660
+RENO,Sylvia Township,United States Senate,,Libertarian,"Batson, Randall",10,000660
+RENO,Sylvia Township,United States Senate,,Republican,"Roberts, Pat",62,000660
+RENO,Troy Township,United States Senate,,independent,"Orman, Greg",18,000670
+RENO,Troy Township,United States Senate,,Libertarian,"Batson, Randall",1,000670
+RENO,Troy Township,United States Senate,,Republican,"Roberts, Pat",34,000670
+RENO,Valley Township,United States Senate,,independent,"Orman, Greg",95,000680
+RENO,Valley Township,United States Senate,,Libertarian,"Batson, Randall",10,000680
+RENO,Valley Township,United States Senate,,Republican,"Roberts, Pat",207,000680
+RENO,Walnut Township,United States Senate,,independent,"Orman, Greg",9,000690
+RENO,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",0,000690
+RENO,Walnut Township,United States Senate,,Republican,"Roberts, Pat",45,000690
+RENO,Westminister Township,United States Senate,,independent,"Orman, Greg",31,000700
+RENO,Westminister Township,United States Senate,,Libertarian,"Batson, Randall",5,000700
+RENO,Westminister Township,United States Senate,,Republican,"Roberts, Pat",54,000700
+RENO,Yoder Township,United States Senate,,independent,"Orman, Greg",44,000710
+RENO,Yoder Township,United States Senate,,Libertarian,"Batson, Randall",7,000710
+RENO,Yoder Township,United States Senate,,Republican,"Roberts, Pat",150,000710
+RENO,Hutchinson Precinct 01 H102,United States Senate,,independent,"Orman, Greg",69,120020
+RENO,Hutchinson Precinct 01 H102,United States Senate,,Libertarian,"Batson, Randall",16,120020
+RENO,Hutchinson Precinct 01 H102,United States Senate,,Republican,"Roberts, Pat",50,120020
+RENO,Hutchinson Precinct 01 H114,United States Senate,,independent,"Orman, Greg",7,120030
+RENO,Hutchinson Precinct 01 H114,United States Senate,,Libertarian,"Batson, Randall",0,120030
+RENO,Hutchinson Precinct 01 H114,United States Senate,,Republican,"Roberts, Pat",1,120030
+RENO,South Clay Township H101,United States Senate,,independent,"Orman, Greg",125,120040
+RENO,South Clay Township H101,United States Senate,,Libertarian,"Batson, Randall",26,120040
+RENO,South Clay Township H101,United States Senate,,Republican,"Roberts, Pat",224,120040
+RENO,South Clay Township Clay H102 A,United States Senate,,independent,"Orman, Greg",4,12005A
+RENO,South Clay Township Clay H102 A,United States Senate,,Libertarian,"Batson, Randall",0,12005A
+RENO,South Clay Township Clay H102 A,United States Senate,,Republican,"Roberts, Pat",4,12005A
+RENO,Hutchinson Precinct 34 Exclave,United States Senate,,independent,"Orman, Greg",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States Senate,,Republican,"Roberts, Pat",1,120060
+RENO,Hutchinson Precinct 36,United States Senate,,independent,"Orman, Greg",0,120070
+RENO,Hutchinson Precinct 36,United States Senate,,Libertarian,"Batson, Randall",0,120070
+RENO,Hutchinson Precinct 36,United States Senate,,Republican,"Roberts, Pat",0,120070
+RENO,Hutchinson Precinct 08 H101,United States Senate,,independent,"Orman, Greg",68,200010
+RENO,Hutchinson Precinct 08 H101,United States Senate,,Libertarian,"Batson, Randall",14,200010
+RENO,Hutchinson Precinct 08 H101,United States Senate,,Republican,"Roberts, Pat",82,200010
+RENO,Hutchinson Precinct 35,United States Senate,,independent,"Orman, Greg",66,200020
+RENO,Hutchinson Precinct 35,United States Senate,,Libertarian,"Batson, Randall",10,200020
+RENO,Hutchinson Precinct 35,United States Senate,,Republican,"Roberts, Pat",73,200020
+RENO,Hutchinson Precinct 23 Exclave,United States Senate,,independent,"Orman, Greg",64,200030
+RENO,Hutchinson Precinct 23 Exclave,United States Senate,,Libertarian,"Batson, Randall",4,200030
+RENO,Hutchinson Precinct 23 Exclave,United States Senate,,Republican,"Roberts, Pat",76,200030
+RENO,Hutchinson Precinct 23 H104,United States Senate,,independent,"Orman, Greg",303,200040
+RENO,Hutchinson Precinct 23 H104,United States Senate,,Libertarian,"Batson, Randall",34,200040
+RENO,Hutchinson Precinct 23 H104,United States Senate,,Republican,"Roberts, Pat",361,200040
+RENO,Hutchinson Precinct 33,United States Senate,,independent,"Orman, Greg",58,200050
+RENO,Hutchinson Precinct 33,United States Senate,,Libertarian,"Batson, Randall",5,200050
+RENO,Hutchinson Precinct 33,United States Senate,,Republican,"Roberts, Pat",106,200050
+RENO,Hutchinson Precinct 34,United States Senate,,independent,"Orman, Greg",16,200060
+RENO,Hutchinson Precinct 34,United States Senate,,Libertarian,"Batson, Randall",5,200060
+RENO,Hutchinson Precinct 34,United States Senate,,Republican,"Roberts, Pat",28,200060

--- a/2014/20141104__ks__general__republic__precinct.csv
+++ b/2014/20141104__ks__general__republic__precinct.csv
@@ -1,431 +1,443 @@
-county,precinct,office,district,party,candidate,votes
-Republic,1st Ward,U.S. Senate,,R,Pat Roberts,183
-Republic,2nd Ward,U.S. Senate,,R,Pat Roberts,193
-Republic,3rd Ward,U.S. Senate,,R,Pat Roberts,117
-Republic,0004 Albion,U.S. Senate,,R,Pat Roberts,33
-Republic,0005 Beaver,U.S. Senate,,R,Pat Roberts,21
-Republic,0006 Belleville,U.S. Senate,,R,Pat Roberts,83
-Republic,0007 Big Bend,U.S. Senate,,R,Pat Roberts,48
-Republic,0008 Courtland,U.S. Senate,,R,Pat Roberts,110
-Republic,0009 Elk Creek,U.S. Senate,,R,Pat Roberts,51
-Republic,0010 Fairview,U.S. Senate,,R,Pat Roberts,55
-Republic,0011 Farmington,U.S. Senate,,R,Pat Roberts,21
-Republic,0012 Freedom,U.S. Senate,,R,Pat Roberts,60
-Republic,0013 Grant,U.S. Senate,,R,Pat Roberts,18
-Republic,0014 Jefferson,U.S. Senate,,R,Pat Roberts,33
-Republic,0015 Liberty,U.S. Senate,,R,Pat Roberts,12
-Republic,0016 Lincoln,U.S. Senate,,R,Pat Roberts,27
-Republic,0017 Norway,U.S. Senate,,R,Pat Roberts,48
-Republic,0018 Richland,U.S. Senate,,R,Pat Roberts,72
-Republic,0019 Rose Creek,U.S. Senate,,R,Pat Roberts,51
-Republic,0020 Scandia,U.S. Senate,,R,Pat Roberts,107
-Republic,0021 Union,U.S. Senate,,R,Pat Roberts,11
-Republic,0022 Washington,U.S. Senate,,R,Pat Roberts,31
-Republic,0023 White Rock,U.S. Senate,,R,Pat Roberts,36
-Republic,1st Ward,U.S. Senate,,I,Greg Orman,72
-Republic,2nd Ward,U.S. Senate,,I,Greg Orman,83
-Republic,3rd Ward,U.S. Senate,,I,Greg Orman,41
-Republic,0004 Albion,U.S. Senate,,I,Greg Orman,15
-Republic,0005 Beaver,U.S. Senate,,I,Greg Orman,11
-Republic,0006 Belleville,U.S. Senate,,I,Greg Orman,12
-Republic,0007 Big Bend,U.S. Senate,,I,Greg Orman,11
-Republic,0008 Courtland,U.S. Senate,,I,Greg Orman,49
-Republic,0009 Elk Creek,U.S. Senate,,I,Greg Orman,14
-Republic,0010 Fairview,U.S. Senate,,I,Greg Orman,16
-Republic,0011 Farmington,U.S. Senate,,I,Greg Orman,3
-Republic,0012 Freedom,U.S. Senate,,I,Greg Orman,13
-Republic,0013 Grant,U.S. Senate,,I,Greg Orman,6
-Republic,0014 Jefferson,U.S. Senate,,I,Greg Orman,10
-Republic,0015 Liberty,U.S. Senate,,I,Greg Orman,2
-Republic,0016 Lincoln,U.S. Senate,,I,Greg Orman,4
-Republic,0017 Norway,U.S. Senate,,I,Greg Orman,9
-Republic,0018 Richland,U.S. Senate,,I,Greg Orman,30
-Republic,0019 Rose Creek,U.S. Senate,,I,Greg Orman,13
-Republic,0020 Scandia,U.S. Senate,,I,Greg Orman,52
-Republic,0021 Union,U.S. Senate,,I,Greg Orman,6
-Republic,0022 Washington,U.S. Senate,,I,Greg Orman,4
-Republic,0023 White Rock,U.S. Senate,,I,Greg Orman,7
-Republic,1st Ward,U.S. Senate,,L,Randall Batson,15
-Republic,2nd Ward,U.S. Senate,,L,Randall Batson,16
-Republic,3rd Ward,U.S. Senate,,L,Randall Batson,10
-Republic,0004 Albion,U.S. Senate,,L,Randall Batson,5
-Republic,0005 Beaver,U.S. Senate,,L,Randall Batson,4
-Republic,0006 Belleville,U.S. Senate,,L,Randall Batson,5
-Republic,0007 Big Bend,U.S. Senate,,L,Randall Batson,7
-Republic,0008 Courtland,U.S. Senate,,L,Randall Batson,10
-Republic,0009 Elk Creek,U.S. Senate,,L,Randall Batson,0
-Republic,0010 Fairview,U.S. Senate,,L,Randall Batson,1
-Republic,0011 Farmington,U.S. Senate,,L,Randall Batson,0
-Republic,0012 Freedom,U.S. Senate,,L,Randall Batson,2
-Republic,0013 Grant,U.S. Senate,,L,Randall Batson,2
-Republic,0014 Jefferson,U.S. Senate,,L,Randall Batson,2
-Republic,0015 Liberty,U.S. Senate,,L,Randall Batson,1
-Republic,0016 Lincoln,U.S. Senate,,L,Randall Batson,0
-Republic,0017 Norway,U.S. Senate,,L,Randall Batson,2
-Republic,0018 Richland,U.S. Senate,,L,Randall Batson,6
-Republic,0019 Rose Creek,U.S. Senate,,L,Randall Batson,0
-Republic,0020 Scandia,U.S. Senate,,L,Randall Batson,7
-Republic,0021 Union,U.S. Senate,,L,Randall Batson,0
-Republic,0022 Washington,U.S. Senate,,L,Randall Batson,0
-Republic,0023 White Rock,U.S. Senate,,L,Randall Batson,1
-Republic,0006 Belleville,U.S. Senate,,,Write-ins,1
-Republic,0018 Richland,U.S. Senate,,,Write-ins,1
-Republic,1st Ward,U.S. House,1,D,James Sherow,77
-Republic,2nd Ward,U.S. House,1,D,James Sherow,90
-Republic,3rd Ward,U.S. House,1,D,James Sherow,43
-Republic,0004 Albion,U.S. House,1,D,James Sherow,9
-Republic,0005 Beaver,U.S. House,1,D,James Sherow,14
-Republic,0006 Belleville,U.S. House,1,D,James Sherow,16
-Republic,0007 Big Bend,U.S. House,1,D,James Sherow,15
-Republic,0008 Courtland,U.S. House,1,D,James Sherow,62
-Republic,0009 Elk Creek,U.S. House,1,D,James Sherow,15
-Republic,0010 Fairview,U.S. House,1,D,James Sherow,19
-Republic,0011 Farmington,U.S. House,1,D,James Sherow,5
-Republic,0012 Freedom,U.S. House,1,D,James Sherow,13
-Republic,0013 Grant,U.S. House,1,D,James Sherow,7
-Republic,0014 Jefferson,U.S. House,1,D,James Sherow,12
-Republic,0015 Liberty,U.S. House,1,D,James Sherow,5
-Republic,0016 Lincoln,U.S. House,1,D,James Sherow,7
-Republic,0017 Norway,U.S. House,1,D,James Sherow,14
-Republic,0018 Richland,U.S. House,1,D,James Sherow,34
-Republic,0019 Rose Creek,U.S. House,1,D,James Sherow,18
-Republic,0020 Scandia,U.S. House,1,D,James Sherow,56
-Republic,0021 Union,U.S. House,1,D,James Sherow,6
-Republic,0022 Washington,U.S. House,1,D,James Sherow,5
-Republic,0023 White Rock,U.S. House,1,D,James Sherow,11
-Republic,1st Ward,U.S. House,1,R,Tim Huelskamp,193
-Republic,2nd Ward,U.S. House,1,R,Tim Huelskamp,196
-Republic,3rd Ward,U.S. House,1,R,Tim Huelskamp,122
-Republic,0004 Albion,U.S. House,1,R,Tim Huelskamp,41
-Republic,0005 Beaver,U.S. House,1,R,Tim Huelskamp,22
-Republic,0006 Belleville,U.S. House,1,R,Tim Huelskamp,84
-Republic,0007 Big Bend,U.S. House,1,R,Tim Huelskamp,49
-Republic,0008 Courtland,U.S. House,1,R,Tim Huelskamp,104
-Republic,0009 Elk Creek,U.S. House,1,R,Tim Huelskamp,49
-Republic,0010 Fairview,U.S. House,1,R,Tim Huelskamp,52
-Republic,0011 Farmington,U.S. House,1,R,Tim Huelskamp,18
-Republic,0012 Freedom,U.S. House,1,R,Tim Huelskamp,63
-Republic,0013 Grant,U.S. House,1,R,Tim Huelskamp,19
-Republic,0014 Jefferson,U.S. House,1,R,Tim Huelskamp,33
-Republic,0015 Liberty,U.S. House,1,R,Tim Huelskamp,10
-Republic,0016 Lincoln,U.S. House,1,R,Tim Huelskamp,24
-Republic,0017 Norway,U.S. House,1,R,Tim Huelskamp,45
-Republic,0018 Richland,U.S. House,1,R,Tim Huelskamp,67
-Republic,0019 Rose Creek,U.S. House,1,R,Tim Huelskamp,45
-Republic,0020 Scandia,U.S. House,1,R,Tim Huelskamp,108
-Republic,0021 Union,U.S. House,1,R,Tim Huelskamp,11
-Republic,0022 Washington,U.S. House,1,R,Tim Huelskamp,29
-Republic,0023 White Rock,U.S. House,1,R,Tim Huelskamp,33
-Republic,2nd Ward,U.S. House,1,,Write-ins,2
-Republic,0008 Courtland,U.S. House,1,,Write-ins,1
-Republic,0018 Richland,U.S. House,1,,Write-ins,2
-Republic,1st Ward,Governor,,R,Sam Brownback,170
-Republic,2nd Ward,Governor,,R,Sam Brownback,173
-Republic,3rd Ward,Governor,,R,Sam Brownback,102
-Republic,0004 Albion,Governor,,R,Sam Brownback,36
-Republic,0005 Beaver,Governor,,R,Sam Brownback,21
-Republic,0006 Belleville,Governor,,R,Sam Brownback,80
-Republic,0007 Big Bend,Governor,,R,Sam Brownback,40
-Republic,0008 Courtland,Governor,,R,Sam Brownback,103
-Republic,0009 Elk Creek,Governor,,R,Sam Brownback,47
-Republic,0010 Fairview,Governor,,R,Sam Brownback,52
-Republic,0011 Farmington,Governor,,R,Sam Brownback,18
-Republic,0012 Freedom,Governor,,R,Sam Brownback,53
-Republic,0013 Grant,Governor,,R,Sam Brownback,16
-Republic,0014 Jefferson,Governor,,R,Sam Brownback,27
-Republic,0015 Liberty,Governor,,R,Sam Brownback,9
-Republic,0016 Lincoln,Governor,,R,Sam Brownback,24
-Republic,0017 Norway,Governor,,R,Sam Brownback,40
-Republic,0018 Richland,Governor,,R,Sam Brownback,65
-Republic,0019 Rose Creek,Governor,,R,Sam Brownback,49
-Republic,0020 Scandia,Governor,,R,Sam Brownback,90
-Republic,0021 Union,Governor,,R,Sam Brownback,10
-Republic,0022 Washington,Governor,,R,Sam Brownback,32
-Republic,0023 White Rock,Governor,,R,Sam Brownback,33
-Republic,1st Ward,Governor,,D,Paul Davis,88
-Republic,2nd Ward,Governor,,D,Paul Davis,104
-Republic,3rd Ward,Governor,,D,Paul Davis,49
-Republic,0004 Albion,Governor,,D,Paul Davis,12
-Republic,0005 Beaver,Governor,,D,Paul Davis,14
-Republic,0006 Belleville,Governor,,D,Paul Davis,14
-Republic,0007 Big Bend,Governor,,D,Paul Davis,19
-Republic,0008 Courtland,Governor,,D,Paul Davis,64
-Republic,0009 Elk Creek,Governor,,D,Paul Davis,16
-Republic,0010 Fairview,Governor,,D,Paul Davis,17
-Republic,0011 Farmington,Governor,,D,Paul Davis,3
-Republic,0012 Freedom,Governor,,D,Paul Davis,22
-Republic,0013 Grant,Governor,,D,Paul Davis,10
-Republic,0014 Jefferson,Governor,,D,Paul Davis,17
-Republic,0015 Liberty,Governor,,D,Paul Davis,4
-Republic,0016 Lincoln,Governor,,D,Paul Davis,5
-Republic,0017 Norway,Governor,,D,Paul Davis,18
-Republic,0018 Richland,Governor,,D,Paul Davis,34
-Republic,0019 Rose Creek,Governor,,D,Paul Davis,14
-Republic,0020 Scandia,Governor,,D,Paul Davis,70
-Republic,0021 Union,Governor,,D,Paul Davis,8
-Republic,0022 Washington,Governor,,D,Paul Davis,4
-Republic,0023 White Rock,Governor,,D,Paul Davis,9
-Republic,1st Ward,Governor,,L,Keen Umbehr,16
-Republic,2nd Ward,Governor,,L,Keen Umbehr,14
-Republic,3rd Ward,Governor,,L,Keen Umbehr,16
-Republic,0004 Albion,Governor,,L,Keen Umbehr,4
-Republic,0005 Beaver,Governor,,L,Keen Umbehr,2
-Republic,0006 Belleville,Governor,,L,Keen Umbehr,7
-Republic,0007 Big Bend,Governor,,L,Keen Umbehr,7
-Republic,0008 Courtland,Governor,,L,Keen Umbehr,5
-Republic,0009 Elk Creek,Governor,,L,Keen Umbehr,3
-Republic,0010 Fairview,Governor,,L,Keen Umbehr,3
-Republic,0011 Farmington,Governor,,L,Keen Umbehr,2
-Republic,0012 Freedom,Governor,,L,Keen Umbehr,4
-Republic,0013 Grant,Governor,,L,Keen Umbehr,0
-Republic,0014 Jefferson,Governor,,L,Keen Umbehr,3
-Republic,0015 Liberty,Governor,,L,Keen Umbehr,1
-Republic,0016 Lincoln,Governor,,L,Keen Umbehr,2
-Republic,0017 Norway,Governor,,L,Keen Umbehr,1
-Republic,0018 Richland,Governor,,L,Keen Umbehr,9
-Republic,0019 Rose Creek,Governor,,L,Keen Umbehr,1
-Republic,0020 Scandia,Governor,,L,Keen Umbehr,8
-Republic,0021 Union,Governor,,L,Keen Umbehr,0
-Republic,0022 Washington,Governor,,L,Keen Umbehr,0
-Republic,0023 White Rock,Governor,,L,Keen Umbehr,3
-Republic,0008 Courtland,Governor,,,Write-ins,1
-Republic,0011 Farmington,Governor,,,Write-ins,1
-Republic,0015 Liberty,Governor,,,Write-ins,1
-Republic,0018 Richland,Governor,,,Write-ins,2
-Republic,1st Ward,Secretary of State,,R,Kris Kobach,208
-Republic,2nd Ward,Secretary of State,,R,Kris Kobach,211
-Republic,3rd Ward,Secretary of State,,R,Kris Kobach,130
-Republic,0004 Albion,Secretary of State,,R,Kris Kobach,39
-Republic,0005 Beaver,Secretary of State,,R,Kris Kobach,24
-Republic,0006 Belleville,Secretary of State,,R,Kris Kobach,90
-Republic,0007 Big Bend,Secretary of State,,R,Kris Kobach,54
-Republic,0008 Courtland,Secretary of State,,R,Kris Kobach,120
-Republic,0009 Elk Creek,Secretary of State,,R,Kris Kobach,53
-Republic,0010 Fairview,Secretary of State,,R,Kris Kobach,54
-Republic,0011 Farmington,Secretary of State,,R,Kris Kobach,22
-Republic,0012 Freedom,Secretary of State,,R,Kris Kobach,65
-Republic,0013 Grant,Secretary of State,,R,Kris Kobach,17
-Republic,0014 Jefferson,Secretary of State,,R,Kris Kobach,37
-Republic,0015 Liberty,Secretary of State,,R,Kris Kobach,11
-Republic,0016 Lincoln,Secretary of State,,R,Kris Kobach,24
-Republic,0017 Norway,Secretary of State,,R,Kris Kobach,44
-Republic,0018 Richland,Secretary of State,,R,Kris Kobach,83
-Republic,0019 Rose Creek,Secretary of State,,R,Kris Kobach,50
-Republic,0020 Scandia,Secretary of State,,R,Kris Kobach,120
-Republic,0021 Union,Secretary of State,,R,Kris Kobach,11
-Republic,0022 Washington,Secretary of State,,R,Kris Kobach,30
-Republic,0023 White Rock,Secretary of State,,R,Kris Kobach,36
-Republic,1st Ward,Secretary of State,,D,Jean Schodorf,57
-Republic,2nd Ward,Secretary of State,,D,Jean Schodorf,77
-Republic,3rd Ward,Secretary of State,,D,Jean Schodorf,36
-Republic,0004 Albion,Secretary of State,,D,Jean Schodorf,10
-Republic,0005 Beaver,Secretary of State,,D,Jean Schodorf,13
-Republic,0006 Belleville,Secretary of State,,D,Jean Schodorf,11
-Republic,0007 Big Bend,Secretary of State,,D,Jean Schodorf,11
-Republic,0008 Courtland,Secretary of State,,D,Jean Schodorf,46
-Republic,0009 Elk Creek,Secretary of State,,D,Jean Schodorf,11
-Republic,0010 Fairview,Secretary of State,,D,Jean Schodorf,17
-Republic,0011 Farmington,Secretary of State,,D,Jean Schodorf,2
-Republic,0012 Freedom,Secretary of State,,D,Jean Schodorf,11
-Republic,0013 Grant,Secretary of State,,D,Jean Schodorf,9
-Republic,0014 Jefferson,Secretary of State,,D,Jean Schodorf,8
-Republic,0015 Liberty,Secretary of State,,D,Jean Schodorf,3
-Republic,0016 Lincoln,Secretary of State,,D,Jean Schodorf,6
-Republic,0017 Norway,Secretary of State,,D,Jean Schodorf,15
-Republic,0018 Richland,Secretary of State,,D,Jean Schodorf,22
-Republic,0019 Rose Creek,Secretary of State,,D,Jean Schodorf,12
-Republic,0020 Scandia,Secretary of State,,D,Jean Schodorf,44
-Republic,0021 Union,Secretary of State,,D,Jean Schodorf,6
-Republic,0022 Washington,Secretary of State,,D,Jean Schodorf,5
-Republic,0023 White Rock,Secretary of State,,D,Jean Schodorf,8
-Republic,0018 Richland,Secretary of State,,,Write-ins,1
-Republic,1st Ward,Attorney General,,R,Derek Schmidt,214
-Republic,2nd Ward,Attorney General,,R,Derek Schmidt,236
-Republic,3rd Ward,Attorney General,,R,Derek Schmidt,133
-Republic,0004 Albion,Attorney General,,R,Derek Schmidt,39
-Republic,0005 Beaver,Attorney General,,R,Derek Schmidt,26
-Republic,0006 Belleville,Attorney General,,R,Derek Schmidt,88
-Republic,0007 Big Bend,Attorney General,,R,Derek Schmidt,52
-Republic,0008 Courtland,Attorney General,,R,Derek Schmidt,132
-Republic,0009 Elk Creek,Attorney General,,R,Derek Schmidt,51
-Republic,0010 Fairview,Attorney General,,R,Derek Schmidt,54
-Republic,0011 Farmington,Attorney General,,R,Derek Schmidt,20
-Republic,0012 Freedom,Attorney General,,R,Derek Schmidt,68
-Republic,0013 Grant,Attorney General,,R,Derek Schmidt,18
-Republic,0014 Jefferson,Attorney General,,R,Derek Schmidt,37
-Republic,0015 Liberty,Attorney General,,R,Derek Schmidt,11
-Republic,0016 Lincoln,Attorney General,,R,Derek Schmidt,26
-Republic,0017 Norway,Attorney General,,R,Derek Schmidt,50
-Republic,0018 Richland,Attorney General,,R,Derek Schmidt,73
-Republic,0019 Rose Creek,Attorney General,,R,Derek Schmidt,49
-Republic,0020 Scandia,Attorney General,,R,Derek Schmidt,131
-Republic,0021 Union,Attorney General,,R,Derek Schmidt,15
-Republic,0022 Washington,Attorney General,,R,Derek Schmidt,29
-Republic,0023 White Rock,Attorney General,,R,Derek Schmidt,32
-Republic,1st Ward,Attorney General,,D,AJ Kotich,46
-Republic,2nd Ward,Attorney General,,D,AJ Kotich,47
-Republic,3rd Ward,Attorney General,,D,AJ Kotich,29
-Republic,0004 Albion,Attorney General,,D,AJ Kotich,9
-Republic,0005 Beaver,Attorney General,,D,AJ Kotich,10
-Republic,0006 Belleville,Attorney General,,D,AJ Kotich,11
-Republic,0007 Big Bend,Attorney General,,D,AJ Kotich,12
-Republic,0008 Courtland,Attorney General,,D,AJ Kotich,32
-Republic,0009 Elk Creek,Attorney General,,D,AJ Kotich,12
-Republic,0010 Fairview,Attorney General,,D,AJ Kotich,14
-Republic,0011 Farmington,Attorney General,,D,AJ Kotich,2
-Republic,0012 Freedom,Attorney General,,D,AJ Kotich,7
-Republic,0013 Grant,Attorney General,,D,AJ Kotich,7
-Republic,0014 Jefferson,Attorney General,,D,AJ Kotich,6
-Republic,0015 Liberty,Attorney General,,D,AJ Kotich,4
-Republic,0016 Lincoln,Attorney General,,D,AJ Kotich,5
-Republic,0017 Norway,Attorney General,,D,AJ Kotich,7
-Republic,0018 Richland,Attorney General,,D,AJ Kotich,24
-Republic,0019 Rose Creek,Attorney General,,D,AJ Kotich,11
-Republic,0020 Scandia,Attorney General,,D,AJ Kotich,31
-Republic,0021 Union,Attorney General,,D,AJ Kotich,3
-Republic,0022 Washington,Attorney General,,D,AJ Kotich,4
-Republic,0023 White Rock,Attorney General,,D,AJ Kotich,9
-Republic,0018 Richland,Attorney General,,,Write-ins,2
-Republic,0020 Scandia,Attorney General,,,Write-ins,1
-Republic,1st Ward,State Treasurer,,R,Ken Estes,222
-Republic,2nd Ward,State Treasurer,,R,Ken Estes,233
-Republic,3rd Ward,State Treasurer,,R,Ken Estes,132
-Republic,0004 Albion,State Treasurer,,R,Ken Estes,40
-Republic,0005 Beaver,State Treasurer,,R,Ken Estes,26
-Republic,0006 Belleville,State Treasurer,,R,Ken Estes,90
-Republic,0007 Big Bend,State Treasurer,,R,Ken Estes,59
-Republic,0008 Courtland,State Treasurer,,R,Ken Estes,139
-Republic,0009 Elk Creek,State Treasurer,,R,Ken Estes,52
-Republic,0010 Fairview,State Treasurer,,R,Ken Estes,50
-Republic,0011 Farmington,State Treasurer,,R,Ken Estes,20
-Republic,0012 Freedom,State Treasurer,,R,Ken Estes,68
-Republic,0013 Grant,State Treasurer,,R,Ken Estes,22
-Republic,0014 Jefferson,State Treasurer,,R,Ken Estes,39
-Republic,0015 Liberty,State Treasurer,,R,Ken Estes,11
-Republic,0016 Lincoln,State Treasurer,,R,Ken Estes,24
-Republic,0017 Norway,State Treasurer,,R,Ken Estes,55
-Republic,0018 Richland,State Treasurer,,R,Ken Estes,83
-Republic,0019 Rose Creek,State Treasurer,,R,Ken Estes,49
-Republic,0020 Scandia,State Treasurer,,R,Ken Estes,139
-Republic,0021 Union,State Treasurer,,R,Ken Estes,14
-Republic,0022 Washington,State Treasurer,,R,Ken Estes,31
-Republic,0023 White Rock,State Treasurer,,R,Ken Estes,37
-Republic,1st Ward,State Treasurer,,D,Carmen Alldritt,46
-Republic,2nd Ward,State Treasurer,,D,Carmen Alldritt,54
-Republic,3rd Ward,State Treasurer,,D,Carmen Alldritt,29
-Republic,0004 Albion,State Treasurer,,D,Carmen Alldritt,8
-Republic,0005 Beaver,State Treasurer,,D,Carmen Alldritt,9
-Republic,0006 Belleville,State Treasurer,,D,Carmen Alldritt,9
-Republic,0007 Big Bend,State Treasurer,,D,Carmen Alldritt,7
-Republic,0008 Courtland,State Treasurer,,D,Carmen Alldritt,30
-Republic,0009 Elk Creek,State Treasurer,,D,Carmen Alldritt,11
-Republic,0010 Fairview,State Treasurer,,D,Carmen Alldritt,18
-Republic,0011 Farmington,State Treasurer,,D,Carmen Alldritt,2
-Republic,0012 Freedom,State Treasurer,,D,Carmen Alldritt,7
-Republic,0013 Grant,State Treasurer,,D,Carmen Alldritt,3
-Republic,0014 Jefferson,State Treasurer,,D,Carmen Alldritt,6
-Republic,0015 Liberty,State Treasurer,,D,Carmen Alldritt,4
-Republic,0016 Lincoln,State Treasurer,,D,Carmen Alldritt,6
-Republic,0017 Norway,State Treasurer,,D,Carmen Alldritt,4
-Republic,0018 Richland,State Treasurer,,D,Carmen Alldritt,17
-Republic,0019 Rose Creek,State Treasurer,,D,Carmen Alldritt,11
-Republic,0020 Scandia,State Treasurer,,D,Carmen Alldritt,27
-Republic,0021 Union,State Treasurer,,D,Carmen Alldritt,4
-Republic,0022 Washington,State Treasurer,,D,Carmen Alldritt,3
-Republic,0023 White Rock,State Treasurer,,D,Carmen Alldritt,6
-Republic,0018 Richland,State Treasurer,,,Write-ins,1
-Republic,1st Ward,Insurance Commissioner,,R,Ken Selzer,206
-Republic,2nd Ward,Insurance Commissioner,,R,Ken Selzer,208
-Republic,3rd Ward,Insurance Commissioner,,R,Ken Selzer,122
-Republic,0004 Albion,Insurance Commissioner,,R,Ken Selzer,40
-Republic,0005 Beaver,Insurance Commissioner,,R,Ken Selzer,26
-Republic,0006 Belleville,Insurance Commissioner,,R,Ken Selzer,89
-Republic,0007 Big Bend,Insurance Commissioner,,R,Ken Selzer,51
-Republic,0008 Courtland,Insurance Commissioner,,R,Ken Selzer,122
-Republic,0009 Elk Creek,Insurance Commissioner,,R,Ken Selzer,53
-Republic,0010 Fairview,Insurance Commissioner,,R,Ken Selzer,50
-Republic,0011 Farmington,Insurance Commissioner,,R,Ken Selzer,19
-Republic,0012 Freedom,Insurance Commissioner,,R,Ken Selzer,66
-Republic,0013 Grant,Insurance Commissioner,,R,Ken Selzer,18
-Republic,0014 Jefferson,Insurance Commissioner,,R,Ken Selzer,31
-Republic,0015 Liberty,Insurance Commissioner,,R,Ken Selzer,12
-Republic,0016 Lincoln,Insurance Commissioner,,R,Ken Selzer,23
-Republic,0017 Norway,Insurance Commissioner,,R,Ken Selzer,49
-Republic,0018 Richland,Insurance Commissioner,,R,Ken Selzer,69
-Republic,0019 Rose Creek,Insurance Commissioner,,R,Ken Selzer,44
-Republic,0020 Scandia,Insurance Commissioner,,R,Ken Selzer,123
-Republic,0021 Union,Insurance Commissioner,,R,Ken Selzer,13
-Republic,0022 Washington,Insurance Commissioner,,R,Ken Selzer,29
-Republic,0023 White Rock,Insurance Commissioner,,R,Ken Selzer,36
-Republic,1st Ward,Insurance Commissioner,,D,Dennis Anderson,54
-Republic,2nd Ward,Insurance Commissioner,,D,Dennis Anderson,75
-Republic,3rd Ward,Insurance Commissioner,,D,Dennis Anderson,38
-Republic,0004 Albion,Insurance Commissioner,,D,Dennis Anderson,8
-Republic,0005 Beaver,Insurance Commissioner,,D,Dennis Anderson,10
-Republic,0006 Belleville,Insurance Commissioner,,D,Dennis Anderson,9
-Republic,0007 Big Bend,Insurance Commissioner,,D,Dennis Anderson,13
-Republic,0008 Courtland,Insurance Commissioner,,D,Dennis Anderson,45
-Republic,0009 Elk Creek,Insurance Commissioner,,D,Dennis Anderson,11
-Republic,0010 Fairview,Insurance Commissioner,,D,Dennis Anderson,16
-Republic,0011 Farmington,Insurance Commissioner,,D,Dennis Anderson,2
-Republic,0012 Freedom,Insurance Commissioner,,D,Dennis Anderson,10
-Republic,0013 Grant,Insurance Commissioner,,D,Dennis Anderson,6
-Republic,0014 Jefferson,Insurance Commissioner,,D,Dennis Anderson,8
-Republic,0015 Liberty,Insurance Commissioner,,D,Dennis Anderson,3
-Republic,0016 Lincoln,Insurance Commissioner,,D,Dennis Anderson,6
-Republic,0017 Norway,Insurance Commissioner,,D,Dennis Anderson,9
-Republic,0018 Richland,Insurance Commissioner,,D,Dennis Anderson,30
-Republic,0019 Rose Creek,Insurance Commissioner,,D,Dennis Anderson,13
-Republic,0020 Scandia,Insurance Commissioner,,D,Dennis Anderson,39
-Republic,0021 Union,Insurance Commissioner,,D,Dennis Anderson,4
-Republic,0022 Washington,Insurance Commissioner,,D,Dennis Anderson,5
-Republic,0023 White Rock,Insurance Commissioner,,D,Dennis Anderson,7
-Republic,2nd Ward,Insurance Commissioner,,,Write-ins,1
-Republic,0009 Elk Creek,Insurance Commissioner,,,Write-ins,1
-Republic,0018 Richland,Insurance Commissioner,,,Write-ins,1
-Republic,1st Ward,State House,106,R,Sharon Schwartz,246
-Republic,2nd Ward,State House,106,R,Sharon Schwartz,262
-Republic,3rd Ward,State House,106,R,Sharon Schwartz,144
-Republic,0004 Albion,State House,106,R,Sharon Schwartz,45
-Republic,0005 Beaver,State House,106,R,Sharon Schwartz,33
-Republic,0006 Belleville,State House,106,R,Sharon Schwartz,93
-Republic,0007 Big Bend,State House,106,R,Sharon Schwartz,60
-Republic,0008 Courtland,State House,106,R,Sharon Schwartz,158
-Republic,0009 Elk Creek,State House,106,R,Sharon Schwartz,62
-Republic,0010 Fairview,State House,106,R,Sharon Schwartz,57
-Republic,0011 Farmington,State House,106,R,Sharon Schwartz,22
-Republic,0012 Freedom,State House,106,R,Sharon Schwartz,69
-Republic,0013 Grant,State House,106,R,Sharon Schwartz,24
-Republic,0014 Jefferson,State House,106,R,Sharon Schwartz,40
-Republic,0015 Liberty,State House,106,R,Sharon Schwartz,13
-Republic,0016 Lincoln,State House,106,R,Sharon Schwartz,28
-Republic,0017 Norway,State House,106,R,Sharon Schwartz,55
-Republic,0018 Richland,State House,106,R,Sharon Schwartz,92
-Republic,0019 Rose Creek,State House,106,R,Sharon Schwartz,53
-Republic,0020 Scandia,State House,106,R,Sharon Schwartz,152
-Republic,0021 Union,State House,106,R,Sharon Schwartz,13
-Republic,0022 Washington,State House,106,R,Sharon Schwartz,32
-Republic,0023 White Rock,State House,106,R,Sharon Schwartz,34
-Republic,1st Ward,State House,106,,Write-ins,3
-Republic,2nd Ward,State House,106,,Write-ins,5
-Republic,3rd Ward,State House,106,,Write-ins,6
-Republic,0004 Albion,State House,106,,Write-ins,1
-Republic,0005 Beaver,State House,106,,Write-ins,2
-Republic,0006 Belleville,State House,106,,Write-ins,1
-Republic,0007 Big Bend,State House,106,,Write-ins,0
-Republic,0008 Courtland,State House,106,,Write-ins,5
-Republic,0009 Elk Creek,State House,106,,Write-ins,0
-Republic,0010 Fairview,State House,106,,Write-ins,4
-Republic,0011 Farmington,State House,106,,Write-ins,0
-Republic,0012 Freedom,State House,106,,Write-ins,1
-Republic,0013 Grant,State House,106,,Write-ins,0
-Republic,0014 Jefferson,State House,106,,Write-ins,0
-Republic,0015 Liberty,State House,106,,Write-ins,1
-Republic,0016 Lincoln,State House,106,,Write-ins,0
-Republic,0017 Norway,State House,106,,Write-ins,1
-Republic,0018 Richland,State House,106,,Write-ins,3
-Republic,0019 Rose Creek,State House,106,,Write-ins,1
-Republic,0020 Scandia,State House,106,,Write-ins,3
-Republic,0021 Union,State House,106,,Write-ins,1
-Republic,0022 Washington,State House,106,,Write-ins,1
-Republic,0023 White Rock,State House,106,,Write-ins,3
+county,precinct,office,district,party,candidate,votes,vtd
+REPUBLIC,Albion Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000010
+REPUBLIC,Albion Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+REPUBLIC,Albion Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000010
+REPUBLIC,Beaver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000020
+REPUBLIC,Beaver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+REPUBLIC,Beaver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000020
+REPUBLIC,Belleville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000030
+REPUBLIC,Belleville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000030
+REPUBLIC,Belleville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000030
+REPUBLIC,Belleville Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",88,000040
+REPUBLIC,Belleville Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000040
+REPUBLIC,Belleville Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",170,000040
+REPUBLIC,Belleville Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",104,00005A
+REPUBLIC,Belleville Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00005A
+REPUBLIC,Belleville Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",173,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+REPUBLIC,Belleville Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,00006A
+REPUBLIC,Belleville Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00006A
+REPUBLIC,Belleville Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00006B
+REPUBLIC,Big Bend Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000070
+REPUBLIC,Big Bend Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000070
+REPUBLIC,Big Bend Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000070
+REPUBLIC,Courtland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",64,000080
+REPUBLIC,Courtland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000080
+REPUBLIC,Courtland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000080
+REPUBLIC,Elk Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000090
+REPUBLIC,Elk Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000090
+REPUBLIC,Elk Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,000090
+REPUBLIC,Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000100
+REPUBLIC,Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000100
+REPUBLIC,Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000100
+REPUBLIC,Farmington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000110
+REPUBLIC,Farmington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000110
+REPUBLIC,Farmington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000110
+REPUBLIC,Freedom Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,00012A
+REPUBLIC,Freedom Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,00012A
+REPUBLIC,Freedom Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,00012A
+REPUBLIC,Freedom Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00012B
+REPUBLIC,Freedom Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00012B
+REPUBLIC,Freedom Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00012B
+REPUBLIC,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000130
+REPUBLIC,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000130
+REPUBLIC,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000130
+REPUBLIC,Jefferson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000140
+REPUBLIC,Jefferson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000140
+REPUBLIC,Jefferson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000140
+REPUBLIC,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000150
+REPUBLIC,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000150
+REPUBLIC,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",9,000150
+REPUBLIC,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000160
+REPUBLIC,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000160
+REPUBLIC,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000160
+REPUBLIC,Norway Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000170
+REPUBLIC,Norway Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000170
+REPUBLIC,Norway Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000170
+REPUBLIC,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000180
+REPUBLIC,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000180
+REPUBLIC,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",65,000180
+REPUBLIC,Rose Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000190
+REPUBLIC,Rose Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000190
+REPUBLIC,Rose Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000190
+REPUBLIC,Scandia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",70,000200
+REPUBLIC,Scandia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000200
+REPUBLIC,Scandia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",90,000200
+REPUBLIC,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000210
+REPUBLIC,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000210
+REPUBLIC,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000210
+REPUBLIC,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000220
+REPUBLIC,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000220
+REPUBLIC,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000220
+REPUBLIC,White Rock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000230
+REPUBLIC,White Rock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000230
+REPUBLIC,White Rock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000230
+REPUBLIC,Albion Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",45,000010
+REPUBLIC,Beaver Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",33,000020
+REPUBLIC,Belleville Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",93,000030
+REPUBLIC,Belleville Ward 1,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",246,000040
+REPUBLIC,Belleville Ward 2,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",262,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00005B
+REPUBLIC,Belleville Ward 3,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",144,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00006B
+REPUBLIC,Big Bend Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",60,000070
+REPUBLIC,Courtland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",158,000080
+REPUBLIC,Elk Creek Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",62,000090
+REPUBLIC,Fairview Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",57,000100
+REPUBLIC,Farmington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",22,000110
+REPUBLIC,Freedom Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",69,00012A
+REPUBLIC,Freedom Township Enclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00012B
+REPUBLIC,Grant Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",24,000130
+REPUBLIC,Jefferson Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",40,000140
+REPUBLIC,Liberty Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",13,000150
+REPUBLIC,Lincoln Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",28,000160
+REPUBLIC,Norway Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",55,000170
+REPUBLIC,Richland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",92,000180
+REPUBLIC,Rose Creek Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",53,000190
+REPUBLIC,Scandia Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",152,000200
+REPUBLIC,Union Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",13,000210
+REPUBLIC,Washington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",32,000220
+REPUBLIC,White Rock Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",34,000230
+REPUBLIC,Albion Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000010
+REPUBLIC,Albion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000010
+REPUBLIC,Beaver Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000020
+REPUBLIC,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000020
+REPUBLIC,Belleville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000030
+REPUBLIC,Belleville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000030
+REPUBLIC,Belleville Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",77,000040
+REPUBLIC,Belleville Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",193,000040
+REPUBLIC,Belleville Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",90,00005A
+REPUBLIC,Belleville Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",196,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+REPUBLIC,Belleville Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",43,00006A
+REPUBLIC,Belleville Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",122,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+REPUBLIC,Big Bend Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000070
+REPUBLIC,Big Bend Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000070
+REPUBLIC,Courtland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",62,000080
+REPUBLIC,Courtland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,000080
+REPUBLIC,Elk Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000090
+REPUBLIC,Elk Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000090
+REPUBLIC,Fairview Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000100
+REPUBLIC,Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000100
+REPUBLIC,Farmington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000110
+REPUBLIC,Farmington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000110
+REPUBLIC,Freedom Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,00012A
+REPUBLIC,Freedom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,00012A
+REPUBLIC,Freedom Township Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00012B
+REPUBLIC,Freedom Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00012B
+REPUBLIC,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000130
+REPUBLIC,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000130
+REPUBLIC,Jefferson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000140
+REPUBLIC,Jefferson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000140
+REPUBLIC,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000150
+REPUBLIC,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000150
+REPUBLIC,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000160
+REPUBLIC,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000160
+REPUBLIC,Norway Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000170
+REPUBLIC,Norway Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000170
+REPUBLIC,Richland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",34,000180
+REPUBLIC,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000180
+REPUBLIC,Rose Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000190
+REPUBLIC,Rose Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000190
+REPUBLIC,Scandia Township,United States House of Representatives,1,Democratic,"Sherow, James E.",56,000200
+REPUBLIC,Scandia Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",108,000200
+REPUBLIC,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000210
+REPUBLIC,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000210
+REPUBLIC,Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000220
+REPUBLIC,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000220
+REPUBLIC,White Rock Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000230
+REPUBLIC,White Rock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000230
+REPUBLIC,Albion Township,Attorney General,,Democratic,"Kotich, A.J.",9,000010
+REPUBLIC,Albion Township,Attorney General,,Republican,"Schmidt, Derek",39,000010
+REPUBLIC,Beaver Township,Attorney General,,Democratic,"Kotich, A.J.",10,000020
+REPUBLIC,Beaver Township,Attorney General,,Republican,"Schmidt, Derek",26,000020
+REPUBLIC,Belleville Township,Attorney General,,Democratic,"Kotich, A.J.",11,000030
+REPUBLIC,Belleville Township,Attorney General,,Republican,"Schmidt, Derek",88,000030
+REPUBLIC,Belleville Ward 1,Attorney General,,Democratic,"Kotich, A.J.",46,000040
+REPUBLIC,Belleville Ward 1,Attorney General,,Republican,"Schmidt, Derek",214,000040
+REPUBLIC,Belleville Ward 2,Attorney General,,Democratic,"Kotich, A.J.",47,00005A
+REPUBLIC,Belleville Ward 2,Attorney General,,Republican,"Schmidt, Derek",236,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+REPUBLIC,Belleville Ward 3,Attorney General,,Democratic,"Kotich, A.J.",29,00006A
+REPUBLIC,Belleville Ward 3,Attorney General,,Republican,"Schmidt, Derek",133,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Attorney General,,Democratic,"Kotich, A.J.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Attorney General,,Republican,"Schmidt, Derek",0,00006B
+REPUBLIC,Big Bend Township,Attorney General,,Democratic,"Kotich, A.J.",12,000070
+REPUBLIC,Big Bend Township,Attorney General,,Republican,"Schmidt, Derek",52,000070
+REPUBLIC,Courtland Township,Attorney General,,Democratic,"Kotich, A.J.",32,000080
+REPUBLIC,Courtland Township,Attorney General,,Republican,"Schmidt, Derek",132,000080
+REPUBLIC,Elk Creek Township,Attorney General,,Democratic,"Kotich, A.J.",12,000090
+REPUBLIC,Elk Creek Township,Attorney General,,Republican,"Schmidt, Derek",51,000090
+REPUBLIC,Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",14,000100
+REPUBLIC,Fairview Township,Attorney General,,Republican,"Schmidt, Derek",54,000100
+REPUBLIC,Farmington Township,Attorney General,,Democratic,"Kotich, A.J.",2,000110
+REPUBLIC,Farmington Township,Attorney General,,Republican,"Schmidt, Derek",20,000110
+REPUBLIC,Freedom Township,Attorney General,,Democratic,"Kotich, A.J.",7,00012A
+REPUBLIC,Freedom Township,Attorney General,,Republican,"Schmidt, Derek",68,00012A
+REPUBLIC,Freedom Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00012B
+REPUBLIC,Freedom Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00012B
+REPUBLIC,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",7,000130
+REPUBLIC,Grant Township,Attorney General,,Republican,"Schmidt, Derek",18,000130
+REPUBLIC,Jefferson Township,Attorney General,,Democratic,"Kotich, A.J.",6,000140
+REPUBLIC,Jefferson Township,Attorney General,,Republican,"Schmidt, Derek",37,000140
+REPUBLIC,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",4,000150
+REPUBLIC,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",11,000150
+REPUBLIC,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",5,000160
+REPUBLIC,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",26,000160
+REPUBLIC,Norway Township,Attorney General,,Democratic,"Kotich, A.J.",7,000170
+REPUBLIC,Norway Township,Attorney General,,Republican,"Schmidt, Derek",50,000170
+REPUBLIC,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",24,000180
+REPUBLIC,Richland Township,Attorney General,,Republican,"Schmidt, Derek",73,000180
+REPUBLIC,Rose Creek Township,Attorney General,,Democratic,"Kotich, A.J.",11,000190
+REPUBLIC,Rose Creek Township,Attorney General,,Republican,"Schmidt, Derek",49,000190
+REPUBLIC,Scandia Township,Attorney General,,Democratic,"Kotich, A.J.",31,000200
+REPUBLIC,Scandia Township,Attorney General,,Republican,"Schmidt, Derek",131,000200
+REPUBLIC,Union Township,Attorney General,,Democratic,"Kotich, A.J.",3,000210
+REPUBLIC,Union Township,Attorney General,,Republican,"Schmidt, Derek",15,000210
+REPUBLIC,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",4,000220
+REPUBLIC,Washington Township,Attorney General,,Republican,"Schmidt, Derek",29,000220
+REPUBLIC,White Rock Township,Attorney General,,Democratic,"Kotich, A.J.",9,000230
+REPUBLIC,White Rock Township,Attorney General,,Republican,"Schmidt, Derek",32,000230
+REPUBLIC,Albion Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000010
+REPUBLIC,Albion Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000010
+REPUBLIC,Beaver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000020
+REPUBLIC,Beaver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000020
+REPUBLIC,Belleville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000030
+REPUBLIC,Belleville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",89,000030
+REPUBLIC,Belleville Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000040
+REPUBLIC,Belleville Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",206,000040
+REPUBLIC,Belleville Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",75,00005A
+REPUBLIC,Belleville Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",208,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+REPUBLIC,Belleville Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,00006A
+REPUBLIC,Belleville Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",122,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00006B
+REPUBLIC,Big Bend Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000070
+REPUBLIC,Big Bend Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000070
+REPUBLIC,Courtland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000080
+REPUBLIC,Courtland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",122,000080
+REPUBLIC,Elk Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000090
+REPUBLIC,Elk Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",53,000090
+REPUBLIC,Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000100
+REPUBLIC,Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000100
+REPUBLIC,Farmington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000110
+REPUBLIC,Farmington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000110
+REPUBLIC,Freedom Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,00012A
+REPUBLIC,Freedom Township,Commissioner of Insurance,,Republican,"Selzer, Ken",66,00012A
+REPUBLIC,Freedom Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00012B
+REPUBLIC,Freedom Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00012B
+REPUBLIC,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000130
+REPUBLIC,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000130
+REPUBLIC,Jefferson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000140
+REPUBLIC,Jefferson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000140
+REPUBLIC,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000150
+REPUBLIC,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000150
+REPUBLIC,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000160
+REPUBLIC,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000160
+REPUBLIC,Norway Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000170
+REPUBLIC,Norway Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000170
+REPUBLIC,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000180
+REPUBLIC,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",69,000180
+REPUBLIC,Rose Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000190
+REPUBLIC,Rose Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",44,000190
+REPUBLIC,Scandia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000200
+REPUBLIC,Scandia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",123,000200
+REPUBLIC,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000210
+REPUBLIC,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000210
+REPUBLIC,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000220
+REPUBLIC,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000220
+REPUBLIC,White Rock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000230
+REPUBLIC,White Rock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000230
+REPUBLIC,Albion Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000010
+REPUBLIC,Albion Township,Secretary of State,,Republican,"Kobach, Kris",39,000010
+REPUBLIC,Beaver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000020
+REPUBLIC,Beaver Township,Secretary of State,,Republican,"Kobach, Kris",24,000020
+REPUBLIC,Belleville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000030
+REPUBLIC,Belleville Township,Secretary of State,,Republican,"Kobach, Kris",90,000030
+REPUBLIC,Belleville Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000040
+REPUBLIC,Belleville Ward 1,Secretary of State,,Republican,"Kobach, Kris",208,000040
+REPUBLIC,Belleville Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,00005A
+REPUBLIC,Belleville Ward 2,Secretary of State,,Republican,"Kobach, Kris",211,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+REPUBLIC,Belleville Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",36,00006A
+REPUBLIC,Belleville Ward 3,Secretary of State,,Republican,"Kobach, Kris",130,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Secretary of State,,Republican,"Kobach, Kris",0,00006B
+REPUBLIC,Big Bend Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000070
+REPUBLIC,Big Bend Township,Secretary of State,,Republican,"Kobach, Kris",54,000070
+REPUBLIC,Courtland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000080
+REPUBLIC,Courtland Township,Secretary of State,,Republican,"Kobach, Kris",120,000080
+REPUBLIC,Elk Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000090
+REPUBLIC,Elk Creek Township,Secretary of State,,Republican,"Kobach, Kris",53,000090
+REPUBLIC,Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000100
+REPUBLIC,Fairview Township,Secretary of State,,Republican,"Kobach, Kris",54,000100
+REPUBLIC,Farmington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000110
+REPUBLIC,Farmington Township,Secretary of State,,Republican,"Kobach, Kris",22,000110
+REPUBLIC,Freedom Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,00012A
+REPUBLIC,Freedom Township,Secretary of State,,Republican,"Kobach, Kris",65,00012A
+REPUBLIC,Freedom Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00012B
+REPUBLIC,Freedom Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00012B
+REPUBLIC,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000130
+REPUBLIC,Grant Township,Secretary of State,,Republican,"Kobach, Kris",17,000130
+REPUBLIC,Jefferson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000140
+REPUBLIC,Jefferson Township,Secretary of State,,Republican,"Kobach, Kris",37,000140
+REPUBLIC,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000150
+REPUBLIC,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",11,000150
+REPUBLIC,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000160
+REPUBLIC,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",24,000160
+REPUBLIC,Norway Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000170
+REPUBLIC,Norway Township,Secretary of State,,Republican,"Kobach, Kris",44,000170
+REPUBLIC,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000180
+REPUBLIC,Richland Township,Secretary of State,,Republican,"Kobach, Kris",83,000180
+REPUBLIC,Rose Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000190
+REPUBLIC,Rose Creek Township,Secretary of State,,Republican,"Kobach, Kris",50,000190
+REPUBLIC,Scandia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000200
+REPUBLIC,Scandia Township,Secretary of State,,Republican,"Kobach, Kris",120,000200
+REPUBLIC,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000210
+REPUBLIC,Union Township,Secretary of State,,Republican,"Kobach, Kris",11,000210
+REPUBLIC,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000220
+REPUBLIC,Washington Township,Secretary of State,,Republican,"Kobach, Kris",30,000220
+REPUBLIC,White Rock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000230
+REPUBLIC,White Rock Township,Secretary of State,,Republican,"Kobach, Kris",36,000230
+REPUBLIC,Albion Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000010
+REPUBLIC,Albion Township,State Treasurer,,Republican,"Estes, Ron",40,000010
+REPUBLIC,Beaver Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000020
+REPUBLIC,Beaver Township,State Treasurer,,Republican,"Estes, Ron",26,000020
+REPUBLIC,Belleville Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000030
+REPUBLIC,Belleville Township,State Treasurer,,Republican,"Estes, Ron",90,000030
+REPUBLIC,Belleville Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",46,000040
+REPUBLIC,Belleville Ward 1,State Treasurer,,Republican,"Estes, Ron",222,000040
+REPUBLIC,Belleville Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",54,00005A
+REPUBLIC,Belleville Ward 2,State Treasurer,,Republican,"Estes, Ron",233,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,State Treasurer,,Republican,"Estes, Ron",0,00005B
+REPUBLIC,Belleville Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",29,00006A
+REPUBLIC,Belleville Ward 3,State Treasurer,,Republican,"Estes, Ron",132,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,State Treasurer,,Democratic,"Alldritt, Carmen",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,State Treasurer,,Republican,"Estes, Ron",0,00006B
+REPUBLIC,Big Bend Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000070
+REPUBLIC,Big Bend Township,State Treasurer,,Republican,"Estes, Ron",59,000070
+REPUBLIC,Courtland Township,State Treasurer,,Democratic,"Alldritt, Carmen",30,000080
+REPUBLIC,Courtland Township,State Treasurer,,Republican,"Estes, Ron",139,000080
+REPUBLIC,Elk Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000090
+REPUBLIC,Elk Creek Township,State Treasurer,,Republican,"Estes, Ron",52,000090
+REPUBLIC,Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000100
+REPUBLIC,Fairview Township,State Treasurer,,Republican,"Estes, Ron",50,000100
+REPUBLIC,Farmington Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000110
+REPUBLIC,Farmington Township,State Treasurer,,Republican,"Estes, Ron",20,000110
+REPUBLIC,Freedom Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,00012A
+REPUBLIC,Freedom Township,State Treasurer,,Republican,"Estes, Ron",68,00012A
+REPUBLIC,Freedom Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00012B
+REPUBLIC,Freedom Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,00012B
+REPUBLIC,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000130
+REPUBLIC,Grant Township,State Treasurer,,Republican,"Estes, Ron",22,000130
+REPUBLIC,Jefferson Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000140
+REPUBLIC,Jefferson Township,State Treasurer,,Republican,"Estes, Ron",39,000140
+REPUBLIC,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000150
+REPUBLIC,Liberty Township,State Treasurer,,Republican,"Estes, Ron",11,000150
+REPUBLIC,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000160
+REPUBLIC,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",24,000160
+REPUBLIC,Norway Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000170
+REPUBLIC,Norway Township,State Treasurer,,Republican,"Estes, Ron",55,000170
+REPUBLIC,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000180
+REPUBLIC,Richland Township,State Treasurer,,Republican,"Estes, Ron",83,000180
+REPUBLIC,Rose Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000190
+REPUBLIC,Rose Creek Township,State Treasurer,,Republican,"Estes, Ron",49,000190
+REPUBLIC,Scandia Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000200
+REPUBLIC,Scandia Township,State Treasurer,,Republican,"Estes, Ron",139,000200
+REPUBLIC,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000210
+REPUBLIC,Union Township,State Treasurer,,Republican,"Estes, Ron",14,000210
+REPUBLIC,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000220
+REPUBLIC,Washington Township,State Treasurer,,Republican,"Estes, Ron",31,000220
+REPUBLIC,White Rock Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000230
+REPUBLIC,White Rock Township,State Treasurer,,Republican,"Estes, Ron",37,000230
+REPUBLIC,Albion Township,United States Senate,,independent,"Orman, Greg",15,000010
+REPUBLIC,Albion Township,United States Senate,,Libertarian,"Batson, Randall",5,000010
+REPUBLIC,Albion Township,United States Senate,,Republican,"Roberts, Pat",33,000010
+REPUBLIC,Beaver Township,United States Senate,,independent,"Orman, Greg",11,000020
+REPUBLIC,Beaver Township,United States Senate,,Libertarian,"Batson, Randall",4,000020
+REPUBLIC,Beaver Township,United States Senate,,Republican,"Roberts, Pat",21,000020
+REPUBLIC,Belleville Township,United States Senate,,independent,"Orman, Greg",12,000030
+REPUBLIC,Belleville Township,United States Senate,,Libertarian,"Batson, Randall",5,000030
+REPUBLIC,Belleville Township,United States Senate,,Republican,"Roberts, Pat",83,000030
+REPUBLIC,Belleville Ward 1,United States Senate,,independent,"Orman, Greg",72,000040
+REPUBLIC,Belleville Ward 1,United States Senate,,Libertarian,"Batson, Randall",15,000040
+REPUBLIC,Belleville Ward 1,United States Senate,,Republican,"Roberts, Pat",183,000040
+REPUBLIC,Belleville Ward 2,United States Senate,,independent,"Orman, Greg",83,00005A
+REPUBLIC,Belleville Ward 2,United States Senate,,Libertarian,"Batson, Randall",16,00005A
+REPUBLIC,Belleville Ward 2,United States Senate,,Republican,"Roberts, Pat",193,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States Senate,,independent,"Orman, Greg",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States Senate,,Republican,"Roberts, Pat",0,00005B
+REPUBLIC,Belleville Ward 3,United States Senate,,independent,"Orman, Greg",41,00006A
+REPUBLIC,Belleville Ward 3,United States Senate,,Libertarian,"Batson, Randall",10,00006A
+REPUBLIC,Belleville Ward 3,United States Senate,,Republican,"Roberts, Pat",117,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States Senate,,independent,"Orman, Greg",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States Senate,,Libertarian,"Batson, Randall",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States Senate,,Republican,"Roberts, Pat",0,00006B
+REPUBLIC,Big Bend Township,United States Senate,,independent,"Orman, Greg",11,000070
+REPUBLIC,Big Bend Township,United States Senate,,Libertarian,"Batson, Randall",7,000070
+REPUBLIC,Big Bend Township,United States Senate,,Republican,"Roberts, Pat",48,000070
+REPUBLIC,Courtland Township,United States Senate,,independent,"Orman, Greg",49,000080
+REPUBLIC,Courtland Township,United States Senate,,Libertarian,"Batson, Randall",10,000080
+REPUBLIC,Courtland Township,United States Senate,,Republican,"Roberts, Pat",110,000080
+REPUBLIC,Elk Creek Township,United States Senate,,independent,"Orman, Greg",14,000090
+REPUBLIC,Elk Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+REPUBLIC,Elk Creek Township,United States Senate,,Republican,"Roberts, Pat",51,000090
+REPUBLIC,Fairview Township,United States Senate,,independent,"Orman, Greg",16,000100
+REPUBLIC,Fairview Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+REPUBLIC,Fairview Township,United States Senate,,Republican,"Roberts, Pat",55,000100
+REPUBLIC,Farmington Township,United States Senate,,independent,"Orman, Greg",3,000110
+REPUBLIC,Farmington Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+REPUBLIC,Farmington Township,United States Senate,,Republican,"Roberts, Pat",21,000110
+REPUBLIC,Freedom Township,United States Senate,,independent,"Orman, Greg",13,00012A
+REPUBLIC,Freedom Township,United States Senate,,Libertarian,"Batson, Randall",2,00012A
+REPUBLIC,Freedom Township,United States Senate,,Republican,"Roberts, Pat",60,00012A
+REPUBLIC,Freedom Township Enclave,United States Senate,,independent,"Orman, Greg",0,00012B
+REPUBLIC,Freedom Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00012B
+REPUBLIC,Freedom Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,00012B
+REPUBLIC,Grant Township,United States Senate,,independent,"Orman, Greg",6,000130
+REPUBLIC,Grant Township,United States Senate,,Libertarian,"Batson, Randall",2,000130
+REPUBLIC,Grant Township,United States Senate,,Republican,"Roberts, Pat",18,000130
+REPUBLIC,Jefferson Township,United States Senate,,independent,"Orman, Greg",10,000140
+REPUBLIC,Jefferson Township,United States Senate,,Libertarian,"Batson, Randall",2,000140
+REPUBLIC,Jefferson Township,United States Senate,,Republican,"Roberts, Pat",33,000140
+REPUBLIC,Liberty Township,United States Senate,,independent,"Orman, Greg",2,000150
+REPUBLIC,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",1,000150
+REPUBLIC,Liberty Township,United States Senate,,Republican,"Roberts, Pat",12,000150
+REPUBLIC,Lincoln Township,United States Senate,,independent,"Orman, Greg",4,000160
+REPUBLIC,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",0,000160
+REPUBLIC,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",27,000160
+REPUBLIC,Norway Township,United States Senate,,independent,"Orman, Greg",9,000170
+REPUBLIC,Norway Township,United States Senate,,Libertarian,"Batson, Randall",2,000170
+REPUBLIC,Norway Township,United States Senate,,Republican,"Roberts, Pat",48,000170
+REPUBLIC,Richland Township,United States Senate,,independent,"Orman, Greg",30,000180
+REPUBLIC,Richland Township,United States Senate,,Libertarian,"Batson, Randall",6,000180
+REPUBLIC,Richland Township,United States Senate,,Republican,"Roberts, Pat",72,000180
+REPUBLIC,Rose Creek Township,United States Senate,,independent,"Orman, Greg",13,000190
+REPUBLIC,Rose Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000190
+REPUBLIC,Rose Creek Township,United States Senate,,Republican,"Roberts, Pat",51,000190
+REPUBLIC,Scandia Township,United States Senate,,independent,"Orman, Greg",52,000200
+REPUBLIC,Scandia Township,United States Senate,,Libertarian,"Batson, Randall",7,000200
+REPUBLIC,Scandia Township,United States Senate,,Republican,"Roberts, Pat",107,000200
+REPUBLIC,Union Township,United States Senate,,independent,"Orman, Greg",6,000210
+REPUBLIC,Union Township,United States Senate,,Libertarian,"Batson, Randall",0,000210
+REPUBLIC,Union Township,United States Senate,,Republican,"Roberts, Pat",11,000210
+REPUBLIC,Washington Township,United States Senate,,independent,"Orman, Greg",4,000220
+REPUBLIC,Washington Township,United States Senate,,Libertarian,"Batson, Randall",0,000220
+REPUBLIC,Washington Township,United States Senate,,Republican,"Roberts, Pat",31,000220
+REPUBLIC,White Rock Township,United States Senate,,independent,"Orman, Greg",7,000230
+REPUBLIC,White Rock Township,United States Senate,,Libertarian,"Batson, Randall",1,000230
+REPUBLIC,White Rock Township,United States Senate,,Republican,"Roberts, Pat",36,000230

--- a/2014/20141104__ks__general__rice__precinct.csv
+++ b/2014/20141104__ks__general__rice__precinct.csv
@@ -1,509 +1,506 @@
-county,precinct,office,district,party,candidate,poll
-Rice,ATLANTA,Attorney General,,D,A.J. Kotich,6
-Rice,BELL,Attorney General,,D,A.J. Kotich,0
-Rice,CENTER,Attorney General,,D,A.J. Kotich,2
-Rice,EUREKA,Attorney General,,D,A.J. Kotich,0
-Rice,FARMER,Attorney General,,D,A.J. Kotich,19
-Rice,GALT,Attorney General,,D,A.J. Kotich,4
-Rice,HARRISON,Attorney General,,D,A.J. Kotich,4
-Rice,LINCOLN,Attorney General,,D,A.J. Kotich,21
-Rice,LYONS  3RD,Attorney General,,D,A.J. Kotich,31
-Rice,LYONS 1ST,Attorney General,,D,A.J. Kotich,32
-Rice,LYONS 2ND,Attorney General,,D,A.J. Kotich,33
-Rice,LYONS 4TH,Attorney General,,D,A.J. Kotich,36
-Rice,MITCHELL,Attorney General,,D,A.J. Kotich,10
-Rice,ODESSA,Attorney General,,D,A.J. Kotich,2
-Rice,Pioneer,Attorney General,,D,A.J. Kotich,2
-Rice,Raymond,Attorney General,,D,A.J. Kotich,1
-Rice,Rockville,Attorney General,,D,A.J. Kotich,13
-Rice,STERING,Attorney General,,D,A.J. Kotich,5
-Rice,STERLING EAST,Attorney General,,D,A.J. Kotich,47
-Rice,STERLING WEST,Attorney General,,D,A.J. Kotich,40
-Rice,UNION,Attorney General,,D,A.J. Kotich,36
-Rice,VALLEY,Attorney General,,D,A.J. Kotich,15
-Rice,VICTORIA,Attorney General,,D,A.J. Kotich,20
-Rice,WASH E,Attorney General,,D,A.J. Kotich,7
-Rice,WASH W,Attorney General,,D,A.J. Kotich,7
-Rice,WILSON,Attorney General,,D,A.J. Kotich,4
-Rice,ATLANTA,Attorney General,,R,Derek Schmidt,38
-Rice,BELL,Attorney General,,R,Derek Schmidt,4
-Rice,CENTER,Attorney General,,R,Derek Schmidt,31
-Rice,EUREKA,Attorney General,,R,Derek Schmidt,13
-Rice,FARMER,Attorney General,,R,Derek Schmidt,97
-Rice,GALT,Attorney General,,R,Derek Schmidt,28
-Rice,HARRISON,Attorney General,,R,Derek Schmidt,44
-Rice,LINCOLN,Attorney General,,R,Derek Schmidt,105
-Rice,LYONS  3RD,Attorney General,,R,Derek Schmidt,93
-Rice,LYONS 1ST,Attorney General,,R,Derek Schmidt,155
-Rice,LYONS 2ND,Attorney General,,R,Derek Schmidt,112
-Rice,LYONS 4TH,Attorney General,,R,Derek Schmidt,108
-Rice,MITCHELL,Attorney General,,R,Derek Schmidt,27
-Rice,ODESSA,Attorney General,,R,Derek Schmidt,19
-Rice,Pioneer,Attorney General,,R,Derek Schmidt,16
-Rice,Raymond,Attorney General,,R,Derek Schmidt,35
-Rice,Rockville,Attorney General,,R,Derek Schmidt,38
-Rice,STERING,Attorney General,,R,Derek Schmidt,47
-Rice,STERLING EAST,Attorney General,,R,Derek Schmidt,316
-Rice,STERLING WEST,Attorney General,,R,Derek Schmidt,154
-Rice,UNION,Attorney General,,R,Derek Schmidt,162
-Rice,VALLEY,Attorney General,,R,Derek Schmidt,44
-Rice,VICTORIA,Attorney General,,R,Derek Schmidt,73
-Rice,WASH E,Attorney General,,R,Derek Schmidt,26
-Rice,WASH W,Attorney General,,R,Derek Schmidt,18
-Rice,WILSON,Attorney General,,R,Derek Schmidt,32
-Rice,ATLANTA,U.S. House,1,D,James E. Sherow,16
-Rice,BELL,U.S. House,1,D,James E. Sherow,0
-Rice,CENTER,U.S. House,1,D,James E. Sherow,4
-Rice,EUREKA,U.S. House,1,D,James E. Sherow,0
-Rice,FARMER,U.S. House,1,D,James E. Sherow,33
-Rice,GALT,U.S. House,1,D,James E. Sherow,5
-Rice,HARRISON,U.S. House,1,D,James E. Sherow,4
-Rice,LINCOLN,U.S. House,1,D,James E. Sherow,28
-Rice,LYONS  3RD,U.S. House,1,D,James E. Sherow,42
-Rice,LYONS 1ST,U.S. House,1,D,James E. Sherow,48
-Rice,LYONS 2ND,U.S. House,1,D,James E. Sherow,40
-Rice,LYONS 4TH,U.S. House,1,D,James E. Sherow,47
-Rice,MITCHELL,U.S. House,1,D,James E. Sherow,11
-Rice,ODESSA,U.S. House,1,D,James E. Sherow,4
-Rice,Pioneer,U.S. House,1,D,James E. Sherow,3
-Rice,Raymond,U.S. House,1,D,James E. Sherow,5
-Rice,Rockville,U.S. House,1,D,James E. Sherow,14
-Rice,STERING,U.S. House,1,D,James E. Sherow,18
-Rice,STERLING EAST,U.S. House,1,D,James E. Sherow,89
-Rice,STERLING WEST,U.S. House,1,D,James E. Sherow,58
-Rice,UNION,U.S. House,1,D,James E. Sherow,55
-Rice,VALLEY,U.S. House,1,D,James E. Sherow,12
-Rice,VICTORIA,U.S. House,1,D,James E. Sherow,29
-Rice,WASH E,U.S. House,1,D,James E. Sherow,7
-Rice,WASH W,U.S. House,1,D,James E. Sherow,8
-Rice,WILSON,U.S. House,1,D,James E. Sherow,11
-Rice,ATLANTA,U.S. House,1,R,Tim Huelskamp,29
-Rice,BELL,U.S. House,1,R,Tim Huelskamp,4
-Rice,CENTER,U.S. House,1,R,Tim Huelskamp,30
-Rice,EUREKA,U.S. House,1,R,Tim Huelskamp,13
-Rice,FARMER,U.S. House,1,R,Tim Huelskamp,85
-Rice,GALT,U.S. House,1,R,Tim Huelskamp,27
-Rice,HARRISON,U.S. House,1,R,Tim Huelskamp,46
-Rice,LINCOLN,U.S. House,1,R,Tim Huelskamp,96
-Rice,LYONS  3RD,U.S. House,1,R,Tim Huelskamp,84
-Rice,LYONS 1ST,U.S. House,1,R,Tim Huelskamp,142
-Rice,LYONS 2ND,U.S. House,1,R,Tim Huelskamp,105
-Rice,LYONS 4TH,U.S. House,1,R,Tim Huelskamp,97
-Rice,MITCHELL,U.S. House,1,R,Tim Huelskamp,25
-Rice,ODESSA,U.S. House,1,R,Tim Huelskamp,17
-Rice,Pioneer,U.S. House,1,R,Tim Huelskamp,15
-Rice,Raymond,U.S. House,1,R,Tim Huelskamp,31
-Rice,Rockville,U.S. House,1,R,Tim Huelskamp,35
-Rice,STERING,U.S. House,1,R,Tim Huelskamp,34
-Rice,STERLING EAST,U.S. House,1,R,Tim Huelskamp,274
-Rice,STERLING WEST,U.S. House,1,R,Tim Huelskamp,137
-Rice,UNION,U.S. House,1,R,Tim Huelskamp,148
-Rice,VALLEY,U.S. House,1,R,Tim Huelskamp,47
-Rice,VICTORIA,U.S. House,1,R,Tim Huelskamp,67
-Rice,WASH E,U.S. House,1,R,Tim Huelskamp,27
-Rice,WASH W,U.S. House,1,R,Tim Huelskamp,17
-Rice,WILSON,U.S. House,1,R,Tim Huelskamp,24
-Rice,ATLANTA,Governor,,L,Keen A. Umbehr,3
-Rice,BELL,Governor,,L,Keen A. Umbehr,0
-Rice,CENTER,Governor,,L,Keen A. Umbehr,1
-Rice,EUREKA,Governor,,L,Keen A. Umbehr,0
-Rice,FARMER,Governor,,L,Keen A. Umbehr,7
-Rice,GALT,Governor,,L,Keen A. Umbehr,0
-Rice,HARRISON,Governor,,L,Keen A. Umbehr,5
-Rice,LINCOLN,Governor,,L,Keen A. Umbehr,14
-Rice,LYONS  3RD,Governor,,L,Keen A. Umbehr,11
-Rice,LYONS 1ST,Governor,,L,Keen A. Umbehr,12
-Rice,LYONS 2ND,Governor,,L,Keen A. Umbehr,7
-Rice,LYONS 4TH,Governor,,L,Keen A. Umbehr,8
-Rice,MITCHELL,Governor,,L,Keen A. Umbehr,1
-Rice,ODESSA,Governor,,L,Keen A. Umbehr,0
-Rice,Pioneer,Governor,,L,Keen A. Umbehr,2
-Rice,Raymond,Governor,,L,Keen A. Umbehr,1
-Rice,Rockville,Governor,,L,Keen A. Umbehr,1
-Rice,STERING,Governor,,L,Keen A. Umbehr,1
-Rice,STERLING EAST,Governor,,L,Keen A. Umbehr,20
-Rice,STERLING WEST,Governor,,L,Keen A. Umbehr,9
-Rice,UNION,Governor,,L,Keen A. Umbehr,13
-Rice,VALLEY,Governor,,L,Keen A. Umbehr,3
-Rice,VICTORIA,Governor,,L,Keen A. Umbehr,6
-Rice,WASH E,Governor,,L,Keen A. Umbehr,1
-Rice,WASH W,Governor,,L,Keen A. Umbehr,0
-Rice,WILSON,Governor,,L,Keen A. Umbehr,1
-Rice,ATLANTA,Governor,,D,Paul Davis,17
-Rice,BELL,Governor,,D,Paul Davis,0
-Rice,CENTER,Governor,,D,Paul Davis,4
-Rice,EUREKA,Governor,,D,Paul Davis,0
-Rice,FARMER,Governor,,D,Paul Davis,40
-Rice,GALT,Governor,,D,Paul Davis,12
-Rice,HARRISON,Governor,,D,Paul Davis,6
-Rice,LINCOLN,Governor,,D,Paul Davis,42
-Rice,LYONS  3RD,Governor,,D,Paul Davis,57
-Rice,LYONS 1ST,Governor,,D,Paul Davis,62
-Rice,LYONS 2ND,Governor,,D,Paul Davis,61
-Rice,LYONS 4TH,Governor,,D,Paul Davis,66
-Rice,MITCHELL,Governor,,D,Paul Davis,15
-Rice,ODESSA,Governor,,D,Paul Davis,4
-Rice,Pioneer,Governor,,D,Paul Davis,5
-Rice,Raymond,Governor,,D,Paul Davis,7
-Rice,Rockville,Governor,,D,Paul Davis,19
-Rice,STERING,Governor,,D,Paul Davis,21
-Rice,STERLING EAST,Governor,,D,Paul Davis,118
-Rice,STERLING WEST,Governor,,D,Paul Davis,77
-Rice,UNION,Governor,,D,Paul Davis,69
-Rice,VALLEY,Governor,,D,Paul Davis,21
-Rice,VICTORIA,Governor,,D,Paul Davis,37
-Rice,WASH E,Governor,,D,Paul Davis,8
-Rice,WASH W,Governor,,D,Paul Davis,11
-Rice,WILSON,Governor,,D,Paul Davis,11
-Rice,ATLANTA,Governor,,R,Sam Brownback,23
-Rice,BELL,Governor,,R,Sam Brownback,4
-Rice,CENTER,Governor,,R,Sam Brownback,29
-Rice,EUREKA,Governor,,R,Sam Brownback,13
-Rice,FARMER,Governor,,R,Sam Brownback,73
-Rice,GALT,Governor,,R,Sam Brownback,20
-Rice,HARRISON,Governor,,R,Sam Brownback,39
-Rice,LINCOLN,Governor,,R,Sam Brownback,71
-Rice,LYONS  3RD,Governor,,R,Sam Brownback,58
-Rice,LYONS 1ST,Governor,,R,Sam Brownback,118
-Rice,LYONS 2ND,Governor,,R,Sam Brownback,79
-Rice,LYONS 4TH,Governor,,R,Sam Brownback,71
-Rice,MITCHELL,Governor,,R,Sam Brownback,22
-Rice,ODESSA,Governor,,R,Sam Brownback,16
-Rice,Pioneer,Governor,,R,Sam Brownback,11
-Rice,Raymond,Governor,,R,Sam Brownback,28
-Rice,Rockville,Governor,,R,Sam Brownback,31
-Rice,STERING,Governor,,R,Sam Brownback,29
-Rice,STERLING EAST,Governor,,R,Sam Brownback,226
-Rice,STERLING WEST,Governor,,R,Sam Brownback,109
-Rice,UNION,Governor,,R,Sam Brownback,124
-Rice,VALLEY,Governor,,R,Sam Brownback,36
-Rice,VICTORIA,Governor,,R,Sam Brownback,53
-Rice,WASH E,Governor,,R,Sam Brownback,25
-Rice,WASH W,Governor,,R,Sam Brownback,14
-Rice,WILSON,Governor,,R,Sam Brownback,24
-Rice,ATLANTA,Insurance Commissioner,,D,Dennis Anderson,6
-Rice,BELL,Insurance Commissioner,,D,Dennis Anderson,0
-Rice,CENTER,Insurance Commissioner,,D,Dennis Anderson,4
-Rice,EUREKA,Insurance Commissioner,,D,Dennis Anderson,0
-Rice,FARMER,Insurance Commissioner,,D,Dennis Anderson,35
-Rice,GALT,Insurance Commissioner,,D,Dennis Anderson,6
-Rice,HARRISON,Insurance Commissioner,,D,Dennis Anderson,4
-Rice,LINCOLN,Insurance Commissioner,,D,Dennis Anderson,30
-Rice,LYONS  3RD,Insurance Commissioner,,D,Dennis Anderson,47
-Rice,LYONS 1ST,Insurance Commissioner,,D,Dennis Anderson,33
-Rice,LYONS 2ND,Insurance Commissioner,,D,Dennis Anderson,33
-Rice,LYONS 4TH,Insurance Commissioner,,D,Dennis Anderson,46
-Rice,MITCHELL,Insurance Commissioner,,D,Dennis Anderson,10
-Rice,ODESSA,Insurance Commissioner,,D,Dennis Anderson,3
-Rice,Pioneer,Insurance Commissioner,,D,Dennis Anderson,3
-Rice,Raymond,Insurance Commissioner,,D,Dennis Anderson,4
-Rice,Rockville,Insurance Commissioner,,D,Dennis Anderson,14
-Rice,STERING,Insurance Commissioner,,D,Dennis Anderson,11
-Rice,STERLING EAST,Insurance Commissioner,,D,Dennis Anderson,68
-Rice,STERLING WEST,Insurance Commissioner,,D,Dennis Anderson,46
-Rice,UNION,Insurance Commissioner,,D,Dennis Anderson,44
-Rice,VALLEY,Insurance Commissioner,,D,Dennis Anderson,19
-Rice,VICTORIA,Insurance Commissioner,,D,Dennis Anderson,24
-Rice,WASH E,Insurance Commissioner,,D,Dennis Anderson,7
-Rice,WASH W,Insurance Commissioner,,D,Dennis Anderson,4
-Rice,WILSON,Insurance Commissioner,,D,Dennis Anderson,9
-Rice,ATLANTA,Insurance Commissioner,,R,Ken Selzer,38
-Rice,BELL,Insurance Commissioner,,R,Ken Selzer,4
-Rice,CENTER,Insurance Commissioner,,R,Ken Selzer,28
-Rice,EUREKA,Insurance Commissioner,,R,Ken Selzer,13
-Rice,FARMER,Insurance Commissioner,,R,Ken Selzer,79
-Rice,GALT,Insurance Commissioner,,R,Ken Selzer,25
-Rice,HARRISON,Insurance Commissioner,,R,Ken Selzer,45
-Rice,LINCOLN,Insurance Commissioner,,R,Ken Selzer,93
-Rice,LYONS  3RD,Insurance Commissioner,,R,Ken Selzer,78
-Rice,LYONS 1ST,Insurance Commissioner,,R,Ken Selzer,153
-Rice,LYONS 2ND,Insurance Commissioner,,R,Ken Selzer,108
-Rice,LYONS 4TH,Insurance Commissioner,,R,Ken Selzer,97
-Rice,MITCHELL,Insurance Commissioner,,R,Ken Selzer,27
-Rice,ODESSA,Insurance Commissioner,,R,Ken Selzer,18
-Rice,Pioneer,Insurance Commissioner,,R,Ken Selzer,15
-Rice,Raymond,Insurance Commissioner,,R,Ken Selzer,32
-Rice,Rockville,Insurance Commissioner,,R,Ken Selzer,37
-Rice,STERING,Insurance Commissioner,,R,Ken Selzer,40
-Rice,STERLING EAST,Insurance Commissioner,,R,Ken Selzer,289
-Rice,STERLING WEST,Insurance Commissioner,,R,Ken Selzer,146
-Rice,UNION,Insurance Commissioner,,R,Ken Selzer,153
-Rice,VALLEY,Insurance Commissioner,,R,Ken Selzer,41
-Rice,VICTORIA,Insurance Commissioner,,R,Ken Selzer,72
-Rice,WASH E,Insurance Commissioner,,R,Ken Selzer,25
-Rice,WASH W,Insurance Commissioner,,R,Ken Selzer,21
-Rice,WILSON,Insurance Commissioner,,R,Ken Selzer,27
-Rice,ATLANTA,Secretary of State,,D,Jean Kurtis Shodorf,16
-Rice,BELL,Secretary of State,,D,Jean Kurtis Shodorf,0
-Rice,CENTER,Secretary of State,,D,Jean Kurtis Shodorf,6
-Rice,EUREKA,Secretary of State,,D,Jean Kurtis Shodorf,1
-Rice,FARMER,Secretary of State,,D,Jean Kurtis Shodorf,39
-Rice,GALT,Secretary of State,,D,Jean Kurtis Shodorf,7
-Rice,HARRISON,Secretary of State,,D,Jean Kurtis Shodorf,4
-Rice,LINCOLN,Secretary of State,,D,Jean Kurtis Shodorf,28
-Rice,LYONS  3RD,Secretary of State,,D,Jean Kurtis Shodorf,46
-Rice,LYONS 1ST,Secretary of State,,D,Jean Kurtis Shodorf,48
-Rice,LYONS 2ND,Secretary of State,,D,Jean Kurtis Shodorf,36
-Rice,LYONS 4TH,Secretary of State,,D,Jean Kurtis Shodorf,43
-Rice,MITCHELL,Secretary of State,,D,Jean Kurtis Shodorf,10
-Rice,ODESSA,Secretary of State,,D,Jean Kurtis Shodorf,4
-Rice,Pioneer,Secretary of State,,D,Jean Kurtis Shodorf,2
-Rice,Raymond,Secretary of State,,D,Jean Kurtis Shodorf,3
-Rice,Rockville,Secretary of State,,D,Jean Kurtis Shodorf,17
-Rice,STERING,Secretary of State,,D,Jean Kurtis Shodorf,15
-Rice,STERLING EAST,Secretary of State,,D,Jean Kurtis Shodorf,100
-Rice,STERLING WEST,Secretary of State,,D,Jean Kurtis Shodorf,62
-Rice,UNION,Secretary of State,,D,Jean Kurtis Shodorf,56
-Rice,VALLEY,Secretary of State,,D,Jean Kurtis Shodorf,18
-Rice,VICTORIA,Secretary of State,,D,Jean Kurtis Shodorf,22
-Rice,WASH E,Secretary of State,,D,Jean Kurtis Shodorf,10
-Rice,WASH W,Secretary of State,,D,Jean Kurtis Shodorf,7
-Rice,WILSON,Secretary of State,,D,Jean Kurtis Shodorf,9
-Rice,ATLANTA,Secretary of State,,R,Kris Kobach,29
-Rice,BELL,Secretary of State,,R,Kris Kobach,4
-Rice,CENTER,Secretary of State,,R,Kris Kobach,27
-Rice,EUREKA,Secretary of State,,R,Kris Kobach,12
-Rice,FARMER,Secretary of State,,R,Kris Kobach,82
-Rice,GALT,Secretary of State,,R,Kris Kobach,26
-Rice,HARRISON,Secretary of State,,R,Kris Kobach,45
-Rice,LINCOLN,Secretary of State,,R,Kris Kobach,97
-Rice,LYONS  3RD,Secretary of State,,R,Kris Kobach,80
-Rice,LYONS 1ST,Secretary of State,,R,Kris Kobach,142
-Rice,LYONS 2ND,Secretary of State,,R,Kris Kobach,108
-Rice,LYONS 4TH,Secretary of State,,R,Kris Kobach,102
-Rice,MITCHELL,Secretary of State,,R,Kris Kobach,28
-Rice,ODESSA,Secretary of State,,R,Kris Kobach,17
-Rice,Pioneer,Secretary of State,,R,Kris Kobach,16
-Rice,Raymond,Secretary of State,,R,Kris Kobach,33
-Rice,Rockville,Secretary of State,,R,Kris Kobach,34
-Rice,STERING,Secretary of State,,R,Kris Kobach,35
-Rice,STERLING EAST,Secretary of State,,R,Kris Kobach,265
-Rice,STERLING WEST,Secretary of State,,R,Kris Kobach,133
-Rice,UNION,Secretary of State,,R,Kris Kobach,150
-Rice,VALLEY,Secretary of State,,R,Kris Kobach,42
-Rice,VICTORIA,Secretary of State,,R,Kris Kobach,74
-Rice,WASH E,Secretary of State,,R,Kris Kobach,24
-Rice,WASH W,Secretary of State,,R,Kris Kobach,18
-Rice,WILSON,Secretary of State,,R,Kris Kobach,27
-Rice,EUREKA,State House,108,R,Steven Johnson,13
-Rice,FARMER,State House,108,R,Steven Johnson,95
-Rice,GALT,State House,108,R,Steven Johnson,29
-Rice,MITCHELL,State House,108,R,Steven Johnson,35
-Rice,ODESSA,State House,108,R,Steven Johnson,19
-Rice,UNION,State House,108,R,Steven Johnson,185
-Rice,VICTORIA,State House,108,R,Steven Johnson,76
-Rice,ATLANTA,State House,113,R,Jeremy Dannebohm,40
-Rice,BELL,State House,113,R,Jeremy Dannebohm,4
-Rice,CENTER,State House,113,R,Jeremy Dannebohm,28
-Rice,HARRISON,State House,113,R,Jeremy Dannebohm,47
-Rice,LINCOLN,State House,113,R,Jeremy Dannebohm,115
-Rice,LYONS  3RD,State House,113,R,Jeremy Dannebohm,113
-Rice,LYONS 1ST,State House,113,R,Jeremy Dannebohm,170
-Rice,LYONS 2ND,State House,113,R,Jeremy Dannebohm,120
-Rice,LYONS 4TH,State House,113,R,Jeremy Dannebohm,122
-Rice,Pioneer,State House,113,R,Jeremy Dannebohm,17
-Rice,Raymond,State House,113,R,Jeremy Dannebohm,30
-Rice,VALLEY,State House,113,R,Jeremy Dannebohm,51
-Rice,STERING,State House,114,R,Jack Thimesch,37
-Rice,STERLING EAST,State House,114,R,Jack Thimesch,249
-Rice,STERLING WEST,State House,114,R,Jack Thimesch,131
-Rice,WASH E,State House,114,R,Jack Thimesch,28
-Rice,WASH W,State House,114,R,Jack Thimesch,16
-Rice,WILSON,State House,114,R,Jack Thimesch,25
-Rice,Rockville,State House,114,D,Mark Schnittker,16
-Rice,STERING,State House,114,D,Mark Schnittker,16
-Rice,STERLING EAST,State House,114,D,Mark Schnittker,112
-Rice,STERLING WEST,State House,114,D,Mark Schnittker,64
-Rice,WASH E,State House,114,D,Mark Schnittker,4
-Rice,WASH W,State House,114,D,Mark Schnittker,9
-Rice,WILSON,State House,114,D,Mark Schnittker,11
-Rice,Rockville,State Senate,35,R,Richard Wilborn,41
-Rice,ATLANTA,State Senate,35,R,Richard Wilborn,38
-Rice,GALT,State Senate,35,R,Richard Wilborn,27
-Rice,HARRISON,State Senate,35,R,Richard Wilborn,42
-Rice,LYONS  3RD,State Senate,35,R,Richard Wilborn,105
-Rice,LYONS 1ST,State Senate,35,R,Richard Wilborn,160
-Rice,LYONS 2ND,State Senate,35,R,Richard Wilborn,117
-Rice,LYONS 4TH,State Senate,35,R,Richard Wilborn,112
-Rice,MITCHELL,State Senate,35,R,Richard Wilborn,33
-Rice,ODESSA,State Senate,35,R,Richard Wilborn,19
-Rice,STERING,State Senate,35,R,Richard Wilborn,43
-Rice,STERLING EAST,State Senate,35,R,Richard Wilborn,289
-Rice,STERLING WEST,State Senate,35,R,Richard Wilborn,163
-Rice,UNION,State Senate,35,R,Richard Wilborn,163
-Rice,VICTORIA,State Senate,35,R,Richard Wilborn,65
-Rice,WASH E,State Senate,35,R,Richard Wilborn,22
-Rice,WASH W,State Senate,35,R,Richard Wilborn,20
-Rice,WILSON,State Senate,35,R,Richard Wilborn,27
-Rice,ATLANTA,State Treasurer,,D,Carmen Alldritt,5
-Rice,BELL,State Treasurer,,D,Carmen Alldritt,0
-Rice,CENTER,State Treasurer,,D,Carmen Alldritt,2
-Rice,EUREKA,State Treasurer,,D,Carmen Alldritt,0
-Rice,FARMER,State Treasurer,,D,Carmen Alldritt,18
-Rice,GALT,State Treasurer,,D,Carmen Alldritt,3
-Rice,HARRISON,State Treasurer,,D,Carmen Alldritt,2
-Rice,LINCOLN,State Treasurer,,D,Carmen Alldritt,22
-Rice,LYONS  3RD,State Treasurer,,D,Carmen Alldritt,34
-Rice,LYONS 1ST,State Treasurer,,D,Carmen Alldritt,29
-Rice,LYONS 2ND,State Treasurer,,D,Carmen Alldritt,26
-Rice,LYONS 4TH,State Treasurer,,D,Carmen Alldritt,38
-Rice,MITCHELL,State Treasurer,,D,Carmen Alldritt,9
-Rice,ODESSA,State Treasurer,,D,Carmen Alldritt,1
-Rice,Pioneer,State Treasurer,,D,Carmen Alldritt,2
-Rice,Raymond,State Treasurer,,D,Carmen Alldritt,2
-Rice,Rockville,State Treasurer,,D,Carmen Alldritt,12
-Rice,STERING,State Treasurer,,D,Carmen Alldritt,5
-Rice,STERLING EAST,State Treasurer,,D,Carmen Alldritt,54
-Rice,STERLING WEST,State Treasurer,,D,Carmen Alldritt,48
-Rice,UNION,State Treasurer,,D,Carmen Alldritt,39
-Rice,VALLEY,State Treasurer,,D,Carmen Alldritt,11
-Rice,VICTORIA,State Treasurer,,D,Carmen Alldritt,24
-Rice,WASH E,State Treasurer,,D,Carmen Alldritt,5
-Rice,WASH W,State Treasurer,,D,Carmen Alldritt,4
-Rice,WILSON,State Treasurer,,D,Carmen Alldritt,5
-Rice,ATLANTA,State Treasurer,,R,Ron Estes,40
-Rice,BELL,State Treasurer,,R,Ron Estes,4
-Rice,CENTER,State Treasurer,,R,Ron Estes,30
-Rice,EUREKA,State Treasurer,,R,Ron Estes,13
-Rice,FARMER,State Treasurer,,R,Ron Estes,99
-Rice,GALT,State Treasurer,,R,Ron Estes,29
-Rice,HARRISON,State Treasurer,,R,Ron Estes,46
-Rice,LINCOLN,State Treasurer,,R,Ron Estes,104
-Rice,LYONS  3RD,State Treasurer,,R,Ron Estes,90
-Rice,LYONS 1ST,State Treasurer,,R,Ron Estes,159
-Rice,LYONS 2ND,State Treasurer,,R,Ron Estes,119
-Rice,LYONS 4TH,State Treasurer,,R,Ron Estes,107
-Rice,MITCHELL,State Treasurer,,R,Ron Estes,28
-Rice,ODESSA,State Treasurer,,R,Ron Estes,20
-Rice,Pioneer,State Treasurer,,R,Ron Estes,16
-Rice,Raymond,State Treasurer,,R,Ron Estes,34
-Rice,Rockville,State Treasurer,,R,Ron Estes,39
-Rice,STERING,State Treasurer,,R,Ron Estes,46
-Rice,STERLING EAST,State Treasurer,,R,Ron Estes,311
-Rice,STERLING WEST,State Treasurer,,R,Ron Estes,145
-Rice,UNION,State Treasurer,,R,Ron Estes,164
-Rice,VALLEY,State Treasurer,,R,Ron Estes,48
-Rice,VICTORIA,State Treasurer,,R,Ron Estes,71
-Rice,WASH E,State Treasurer,,R,Ron Estes,29
-Rice,WASH W,State Treasurer,,R,Ron Estes,21
-Rice,WILSON,State Treasurer,,R,Ron Estes,31
-Rice,ATLANTA,U.S. Senate,,I,Greg Orman,14
-Rice,BELL,U.S. Senate,,I,Greg Orman,1
-Rice,CENTER,U.S. Senate,,I,Greg Orman,4
-Rice,EUREKA,U.S. Senate,,I,Greg Orman,0
-Rice,FARMER,U.S. Senate,,I,Greg Orman,33
-Rice,GALT,U.S. Senate,,I,Greg Orman,5
-Rice,HARRISON,U.S. Senate,,I,Greg Orman,13
-Rice,LINCOLN,U.S. Senate,,I,Greg Orman,42
-Rice,LYONS  3RD,U.S. Senate,,I,Greg Orman,48
-Rice,LYONS 1ST,U.S. Senate,,I,Greg Orman,59
-Rice,LYONS 2ND,U.S. Senate,,I,Greg Orman,51
-Rice,LYONS 4TH,U.S. Senate,,I,Greg Orman,53
-Rice,MITCHELL,U.S. Senate,,I,Greg Orman,13
-Rice,ODESSA,U.S. Senate,,I,Greg Orman,3
-Rice,Pioneer,U.S. Senate,,I,Greg Orman,4
-Rice,Raymond,U.S. Senate,,I,Greg Orman,4
-Rice,Rockville,U.S. Senate,,I,Greg Orman,16
-Rice,STERING,U.S. Senate,,I,Greg Orman,16
-Rice,STERLING EAST,U.S. Senate,,I,Greg Orman,107
-Rice,STERLING WEST,U.S. Senate,,I,Greg Orman,71
-Rice,UNION,U.S. Senate,,I,Greg Orman,64
-Rice,VALLEY,U.S. Senate,,I,Greg Orman,20
-Rice,VICTORIA,U.S. Senate,,I,Greg Orman,28
-Rice,WASH E,U.S. Senate,,I,Greg Orman,8
-Rice,WASH W,U.S. Senate,,I,Greg Orman,9
-Rice,WILSON,U.S. Senate,,I,Greg Orman,8
-Rice,ATLANTA,U.S. Senate,,R,Pat Roberts,26
-Rice,BELL,U.S. Senate,,R,Pat Roberts,3
-Rice,CENTER,U.S. Senate,,R,Pat Roberts,29
-Rice,EUREKA,U.S. Senate,,R,Pat Roberts,13
-Rice,FARMER,U.S. Senate,,R,Pat Roberts,83
-Rice,GALT,U.S. Senate,,R,Pat Roberts,26
-Rice,HARRISON,U.S. Senate,,R,Pat Roberts,34
-Rice,LINCOLN,U.S. Senate,,R,Pat Roberts,70
-Rice,LYONS  3RD,U.S. Senate,,R,Pat Roberts,66
-Rice,LYONS 1ST,U.S. Senate,,R,Pat Roberts,121
-Rice,LYONS 2ND,U.S. Senate,,R,Pat Roberts,88
-Rice,LYONS 4TH,U.S. Senate,,R,Pat Roberts,82
-Rice,MITCHELL,U.S. Senate,,R,Pat Roberts,25
-Rice,ODESSA,U.S. Senate,,R,Pat Roberts,17
-Rice,Pioneer,U.S. Senate,,R,Pat Roberts,13
-Rice,Raymond,U.S. Senate,,R,Pat Roberts,31
-Rice,Rockville,U.S. Senate,,R,Pat Roberts,35
-Rice,STERING,U.S. Senate,,R,Pat Roberts,36
-Rice,STERLING EAST,U.S. Senate,,R,Pat Roberts,245
-Rice,STERLING WEST,U.S. Senate,,R,Pat Roberts,117
-Rice,UNION,U.S. Senate,,R,Pat Roberts,129
-Rice,VALLEY,U.S. Senate,,R,Pat Roberts,39
-Rice,VICTORIA,U.S. Senate,,R,Pat Roberts,63
-Rice,WASH E,U.S. Senate,,R,Pat Roberts,24
-Rice,WASH W,U.S. Senate,,R,Pat Roberts,16
-Rice,WILSON,U.S. Senate,,R,Pat Roberts,25
-Rice,ATLANTA,U.S. Senate,,L,Randall Batson,5
-Rice,BELL,U.S. Senate,,L,Randall Batson,0
-Rice,CENTER,U.S. Senate,,L,Randall Batson,1
-Rice,EUREKA,U.S. Senate,,L,Randall Batson,0
-Rice,FARMER,U.S. Senate,,L,Randall Batson,5
-Rice,GALT,U.S. Senate,,L,Randall Batson,2
-Rice,HARRISON,U.S. Senate,,L,Randall Batson,3
-Rice,LINCOLN,U.S. Senate,,L,Randall Batson,15
-Rice,LYONS  3RD,U.S. Senate,,L,Randall Batson,12
-Rice,LYONS 1ST,U.S. Senate,,L,Randall Batson,11
-Rice,LYONS 2ND,U.S. Senate,,L,Randall Batson,10
-Rice,LYONS 4TH,U.S. Senate,,L,Randall Batson,8
-Rice,MITCHELL,U.S. Senate,,L,Randall Batson,0
-Rice,ODESSA,U.S. Senate,,L,Randall Batson,1
-Rice,Pioneer,U.S. Senate,,L,Randall Batson,1
-Rice,Raymond,U.S. Senate,,L,Randall Batson,1
-Rice,Rockville,U.S. Senate,,L,Randall Batson,0
-Rice,STERING,U.S. Senate,,L,Randall Batson,1
-Rice,STERLING EAST,U.S. Senate,,L,Randall Batson,16
-Rice,STERLING WEST,U.S. Senate,,L,Randall Batson,8
-Rice,UNION,U.S. Senate,,L,Randall Batson,12
-Rice,VALLEY,U.S. Senate,,L,Randall Batson,1
-Rice,VICTORIA,U.S. Senate,,L,Randall Batson,7
-Rice,WASH E,U.S. Senate,,L,Randall Batson,2
-Rice,WASH W,U.S. Senate,,L,Randall Batson,1
-Rice,WILSON,U.S. Senate,,L,Randall Batson,3
-Rice,Advance,Attorney General,,D,A.J. Kotich,142
-Rice,Provisional,Attorney General,,D,A.J. Kotich,14
-Rice,Advance,Attorney General,,R,Derek Schmidt,520
-Rice,Provisional,Attorney General,,R,Derek Schmidt,28
-Rice,Advance,U.S. House,,D,James E. Sherow,232
-Rice,Provisional,U.S. House,,D,James E. Sherow,13
-Rice,Advance,U.S. House,,R,Tim Huelskamp,432
-Rice,Provisional,U.S. House,,R,Tim Huelskamp,28
-Rice,Advance,Governor,,L,Keen A. Umbehr,15
-Rice,Provisional,Governor,,L,Keen A. Umbehr,2
-Rice,Advance,Governor,,D,Paul Davis,261
-Rice,Provisional,Governor,,D,Paul Davis,13
-Rice,Advance,Governor,,R,Sam Brownback,395
-Rice,Provisional,Governor,,R,Sam Brownback,28
-Rice,Advance,Insurance Commissioner,,D,Dennis Anderson,175
-Rice,Provisional,Insurance Commissioner,,D,Dennis Anderson,15
-Rice,Advance,Insurance Commissioner,,R,Ken Selzer,481
-Rice,Provisional,Insurance Commissioner,,R,Ken Selzer,27
-Rice,Advance,Secretary of State,,D,Jean Kurtis Shodorf,230
-Rice,Provisional,Secretary of State,,D,Jean Kurtis Shodorf,17
-Rice,Advance,Secretary of State,,R,Kris Kobach,439
-Rice,Provisional,Secretary of State,,R,Kris Kobach,25
-Rice,Advance,State House,108,R,Steven Johnson,86
-Rice,Provisional,State House,108,R,Steven Johnson,11
-Rice,Advance,State House,109,R,Jeremy Dannebohm,325
-Rice,Provisional,State House,109,R,Jeremy Dannebohm,21
-Rice,Advance,State House,114,R,Jack Thimesch,114
-Rice,Provisional,State House,114,R,Jack Thimesch,6
-Rice,Advance,State House,114,D,Mark Schnittker,59
-Rice,Provisional,State House,114,D,Mark Schnittker,3
-Rice,Advance,State Senate,35,R,Richard Wilborn,468
-Rice,Provisional,State Senate,35,R,Richard Wilborn,31
-Rice,Advance,State Treasurer,,D,Carmen Alldritt,148
-Rice,Provisional,State Treasurer,,D,Carmen Alldritt,13
-Rice,Advance,State Treasurer,,R,Ron Estes,510
-Rice,Provisional,State Treasurer,,R,Ron Estes,29
-Rice,Advance,U.S. Senate,,R,Pat Roberts,416
-Rice,Provisional,U.S. Senate,,R,Pat Roberts,27
-Rice,Advance,U.S. Senate,,I,Greg Orman,230
-Rice,Provisional,U.S. Senate,,I,Greg Orman,12
-Rice,Advance,U.S. Senate,,L,Randall Batson,25
-Rice,Provisional,U.S. Senate,,L,Randall Batson,3
+county,precinct,office,district,party,candidate,votes,vtd
+RICE,Atlanta Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000010
+RICE,Atlanta Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+RICE,Atlanta Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000010
+RICE,Bell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000020
+RICE,Bell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+RICE,Bell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,000020
+RICE,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000030
+RICE,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000030
+RICE,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000030
+RICE,East Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000040
+RICE,East Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+RICE,East Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000040
+RICE,Eureka Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000050
+RICE,Eureka Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+RICE,Eureka Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000050
+RICE,Farmer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000060
+RICE,Farmer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000060
+RICE,Farmer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000060
+RICE,Galt Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000070
+RICE,Galt Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+RICE,Galt Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000070
+RICE,Harrison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000080
+RICE,Harrison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000080
+RICE,Harrison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000080
+RICE,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",46,000090
+RICE,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000090
+RICE,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000090
+RICE,Lyons Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",122,000100
+RICE,Lyons Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000100
+RICE,Lyons Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",165,000100
+RICE,Lyons Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000110
+RICE,Lyons Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000110
+RICE,Lyons Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",121,000110
+RICE,Lyons Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,000120
+RICE,Lyons Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000120
+RICE,Lyons Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000120
+RICE,Lyons Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",87,000130
+RICE,Lyons Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000130
+RICE,Lyons Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",122,000130
+RICE,Mitchell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000140
+RICE,Mitchell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000140
+RICE,Mitchell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000140
+RICE,Odessa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000150
+RICE,Odessa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000150
+RICE,Odessa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000150
+RICE,Pioneer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000160
+RICE,Pioneer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000160
+RICE,Pioneer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000160
+RICE,Raymond Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000170
+RICE,Raymond Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000170
+RICE,Raymond Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000170
+RICE,Rockville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000180
+RICE,Rockville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000180
+RICE,Rockville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000180
+RICE,Sterling City East Ward,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,00019A
+RICE,Sterling City East Ward,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,00019A
+RICE,Sterling City East Ward,Governor / Lt. Governor,,Republican,"Brownback, Sam",263,00019A
+RICE,Sterling City East Ward Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00019B
+RICE,Sterling City East Ward Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00019B
+RICE,Sterling City East Ward Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00019B
+RICE,Sterling City East Ward Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00019C
+RICE,Sterling City East Ward Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00019C
+RICE,Sterling City East Ward Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00019C
+RICE,Sterling City West Ward,Governor / Lt. Governor,,Democratic,"Davis, Paul",91,000200
+RICE,Sterling City West Ward,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000200
+RICE,Sterling City West Ward,Governor / Lt. Governor,,Republican,"Brownback, Sam",142,000200
+RICE,Sterling Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000210
+RICE,Sterling Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000210
+RICE,Sterling Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000210
+RICE,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",79,000220
+RICE,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000220
+RICE,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",140,000220
+RICE,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",28,000230
+RICE,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000230
+RICE,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000230
+RICE,Victoria Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,000240
+RICE,Victoria Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000240
+RICE,Victoria Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000240
+RICE,West Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000250
+RICE,West Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000250
+RICE,West Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000250
+RICE,Wilson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000260
+RICE,Wilson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000260
+RICE,Wilson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000260
+RICE,Atlanta Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",58,000010
+RICE,Bell Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",4,000020
+RICE,Center Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",36,000030
+RICE,East Washington Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",9,000040
+RICE,East Washington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",44,000040
+RICE,Eureka Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",18,000050
+RICE,Farmer Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",118,000060
+RICE,Galt Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",31,000070
+RICE,Harrison Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",64,000080
+RICE,Lincoln Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",127,000090
+RICE,Lyons Ward 1,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",257,000100
+RICE,Lyons Ward 2,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",179,000110
+RICE,Lyons Ward 3,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",158,000120
+RICE,Lyons Ward 4,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",183,000130
+RICE,Mitchell Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",55,000140
+RICE,Odessa Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",22,000150
+RICE,Pioneer Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",22,000160
+RICE,Raymond Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",47,000170
+RICE,Rockville Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",20,000180
+RICE,Rockville Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",37,000180
+RICE,Sterling City East Ward,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",138,00019A
+RICE,Sterling City East Ward,Kansas House of Representatives,114,Republican,"Thimesch, Jack",288,00019A
+RICE,Sterling City East Ward Exclave A,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",0,00019B
+RICE,Sterling City East Ward Exclave A,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00019B
+RICE,Sterling City East Ward Exclave B,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",0,00019C
+RICE,Sterling City East Ward Exclave B,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00019C
+RICE,Sterling City West Ward,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",77,000200
+RICE,Sterling City West Ward,Kansas House of Representatives,114,Republican,"Thimesch, Jack",165,000200
+RICE,Sterling Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",18,000210
+RICE,Sterling Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",41,000210
+RICE,Union Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",210,000220
+RICE,Valley Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",68,000230
+RICE,Victoria Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",95,000240
+RICE,West Washington Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",15,000250
+RICE,West Washington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",31,000250
+RICE,Wilson Township,Kansas House of Representatives,114,Democratic,"Schnittker, Mark",17,000260
+RICE,Wilson Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",35,000260
+RICE,Atlanta Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,000010
+RICE,Atlanta Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000010
+RICE,Bell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000020
+RICE,Bell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,000020
+RICE,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000030
+RICE,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000030
+RICE,East Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000040
+RICE,East Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000040
+RICE,Eureka Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000050
+RICE,Eureka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000050
+RICE,Farmer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",41,000060
+RICE,Farmer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,000060
+RICE,Galt Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000070
+RICE,Galt Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000070
+RICE,Harrison Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000080
+RICE,Harrison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000080
+RICE,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",31,000090
+RICE,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",106,000090
+RICE,Lyons Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",97,000100
+RICE,Lyons Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",201,000100
+RICE,Lyons Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",68,000110
+RICE,Lyons Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",149,000110
+RICE,Lyons Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",66,000120
+RICE,Lyons Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",114,000120
+RICE,Lyons Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",63,000130
+RICE,Lyons Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",154,000130
+RICE,Mitchell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000140
+RICE,Mitchell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000140
+RICE,Odessa Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000150
+RICE,Odessa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000150
+RICE,Pioneer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000160
+RICE,Pioneer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000160
+RICE,Raymond Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000170
+RICE,Raymond Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000170
+RICE,Rockville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000180
+RICE,Rockville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000180
+RICE,Sterling City East Ward,United States House of Representatives,1,Democratic,"Sherow, James E.",112,00019A
+RICE,Sterling City East Ward,United States House of Representatives,1,Republican,"Huelskamp, Tim",315,00019A
+RICE,Sterling City East Ward Exclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00019B
+RICE,Sterling City East Ward Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019B
+RICE,Sterling City East Ward Exclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00019C
+RICE,Sterling City East Ward Exclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019C
+RICE,Sterling City West Ward,United States House of Representatives,1,Democratic,"Sherow, James E.",74,000200
+RICE,Sterling City West Ward,United States House of Representatives,1,Republican,"Huelskamp, Tim",167,000200
+RICE,Sterling Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000210
+RICE,Sterling Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000210
+RICE,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",65,000220
+RICE,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",165,000220
+RICE,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",20,000230
+RICE,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",62,000230
+RICE,Victoria Township,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000240
+RICE,Victoria Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,000240
+RICE,West Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000250
+RICE,West Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000250
+RICE,Wilson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000260
+RICE,Wilson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000260
+RICE,Atlanta Township,Attorney General,,Democratic,"Kotich, A.J.",11,000010
+RICE,Atlanta Township,Attorney General,,Republican,"Schmidt, Derek",55,000010
+RICE,Bell Township,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+RICE,Bell Township,Attorney General,,Republican,"Schmidt, Derek",4,000020
+RICE,Center Township,Attorney General,,Democratic,"Kotich, A.J.",5,000030
+RICE,Center Township,Attorney General,,Republican,"Schmidt, Derek",36,000030
+RICE,East Washington Township,Attorney General,,Democratic,"Kotich, A.J.",12,000040
+RICE,East Washington Township,Attorney General,,Republican,"Schmidt, Derek",41,000040
+RICE,Eureka Township,Attorney General,,Democratic,"Kotich, A.J.",1,000050
+RICE,Eureka Township,Attorney General,,Republican,"Schmidt, Derek",17,000050
+RICE,Farmer Township,Attorney General,,Democratic,"Kotich, A.J.",25,000060
+RICE,Farmer Township,Attorney General,,Republican,"Schmidt, Derek",118,000060
+RICE,Galt Township,Attorney General,,Democratic,"Kotich, A.J.",4,000070
+RICE,Galt Township,Attorney General,,Republican,"Schmidt, Derek",30,000070
+RICE,Harrison Township,Attorney General,,Democratic,"Kotich, A.J.",9,000080
+RICE,Harrison Township,Attorney General,,Republican,"Schmidt, Derek",59,000080
+RICE,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",23,000090
+RICE,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",116,000090
+RICE,Lyons Ward 1,Attorney General,,Democratic,"Kotich, A.J.",61,000100
+RICE,Lyons Ward 1,Attorney General,,Republican,"Schmidt, Derek",234,000100
+RICE,Lyons Ward 2,Attorney General,,Democratic,"Kotich, A.J.",48,000110
+RICE,Lyons Ward 2,Attorney General,,Republican,"Schmidt, Derek",170,000110
+RICE,Lyons Ward 3,Attorney General,,Democratic,"Kotich, A.J.",46,000120
+RICE,Lyons Ward 3,Attorney General,,Republican,"Schmidt, Derek",134,000120
+RICE,Lyons Ward 4,Attorney General,,Democratic,"Kotich, A.J.",47,000130
+RICE,Lyons Ward 4,Attorney General,,Republican,"Schmidt, Derek",170,000130
+RICE,Mitchell Township,Attorney General,,Democratic,"Kotich, A.J.",14,000140
+RICE,Mitchell Township,Attorney General,,Republican,"Schmidt, Derek",48,000140
+RICE,Odessa Township,Attorney General,,Democratic,"Kotich, A.J.",2,000150
+RICE,Odessa Township,Attorney General,,Republican,"Schmidt, Derek",22,000150
+RICE,Pioneer Township,Attorney General,,Democratic,"Kotich, A.J.",3,000160
+RICE,Pioneer Township,Attorney General,,Republican,"Schmidt, Derek",20,000160
+RICE,Raymond Township,Attorney General,,Democratic,"Kotich, A.J.",2,000170
+RICE,Raymond Township,Attorney General,,Republican,"Schmidt, Derek",51,000170
+RICE,Rockville Township,Attorney General,,Democratic,"Kotich, A.J.",16,000180
+RICE,Rockville Township,Attorney General,,Republican,"Schmidt, Derek",41,000180
+RICE,Sterling City East Ward,Attorney General,,Democratic,"Kotich, A.J.",64,00019A
+RICE,Sterling City East Ward,Attorney General,,Republican,"Schmidt, Derek",363,00019A
+RICE,Sterling City East Ward Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00019B
+RICE,Sterling City East Ward Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,00019B
+RICE,Sterling City East Ward Exclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00019C
+RICE,Sterling City East Ward Exclave B,Attorney General,,Republican,"Schmidt, Derek",0,00019C
+RICE,Sterling City West Ward,Attorney General,,Democratic,"Kotich, A.J.",48,000200
+RICE,Sterling City West Ward,Attorney General,,Republican,"Schmidt, Derek",191,000200
+RICE,Sterling Township,Attorney General,,Democratic,"Kotich, A.J.",5,000210
+RICE,Sterling Township,Attorney General,,Republican,"Schmidt, Derek",53,000210
+RICE,Union Township,Attorney General,,Democratic,"Kotich, A.J.",42,000220
+RICE,Union Township,Attorney General,,Republican,"Schmidt, Derek",183,000220
+RICE,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",21,000230
+RICE,Valley Township,Attorney General,,Republican,"Schmidt, Derek",61,000230
+RICE,Victoria Township,Attorney General,,Democratic,"Kotich, A.J.",25,000240
+RICE,Victoria Township,Attorney General,,Republican,"Schmidt, Derek",87,000240
+RICE,West Washington Township,Attorney General,,Democratic,"Kotich, A.J.",11,000250
+RICE,West Washington Township,Attorney General,,Republican,"Schmidt, Derek",35,000250
+RICE,Wilson Township,Attorney General,,Democratic,"Kotich, A.J.",8,000260
+RICE,Wilson Township,Attorney General,,Republican,"Schmidt, Derek",44,000260
+RICE,Atlanta Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000010
+RICE,Atlanta Township,Commissioner of Insurance,,Republican,"Selzer, Ken",54,000010
+RICE,Bell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000020
+RICE,Bell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",4,000020
+RICE,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000030
+RICE,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000030
+RICE,East Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000040
+RICE,East Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000040
+RICE,Eureka Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000050
+RICE,Eureka Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000050
+RICE,Farmer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000060
+RICE,Farmer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",98,000060
+RICE,Galt Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000070
+RICE,Galt Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000070
+RICE,Harrison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000080
+RICE,Harrison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000080
+RICE,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000090
+RICE,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000090
+RICE,Lyons Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,000100
+RICE,Lyons Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",223,000100
+RICE,Lyons Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000110
+RICE,Lyons Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",159,000110
+RICE,Lyons Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,000120
+RICE,Lyons Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000120
+RICE,Lyons Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000130
+RICE,Lyons Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",157,000130
+RICE,Mitchell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000140
+RICE,Mitchell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000140
+RICE,Odessa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000150
+RICE,Odessa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000150
+RICE,Pioneer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000160
+RICE,Pioneer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000160
+RICE,Raymond Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000170
+RICE,Raymond Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000170
+RICE,Rockville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000180
+RICE,Rockville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000180
+RICE,Sterling City East Ward,Commissioner of Insurance,,Democratic,"Anderson, Dennis",84,00019A
+RICE,Sterling City East Ward,Commissioner of Insurance,,Republican,"Selzer, Ken",337,00019A
+RICE,Sterling City East Ward Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00019B
+RICE,Sterling City East Ward Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00019B
+RICE,Sterling City East Ward Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00019C
+RICE,Sterling City East Ward Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00019C
+RICE,Sterling City West Ward,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,000200
+RICE,Sterling City West Ward,Commissioner of Insurance,,Republican,"Selzer, Ken",181,000200
+RICE,Sterling Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000210
+RICE,Sterling Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000210
+RICE,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,000220
+RICE,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000220
+RICE,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000230
+RICE,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000230
+RICE,Victoria Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000240
+RICE,Victoria Township,Commissioner of Insurance,,Republican,"Selzer, Ken",88,000240
+RICE,West Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000250
+RICE,West Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000250
+RICE,Wilson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000260
+RICE,Wilson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000260
+RICE,Atlanta Township,Kansas Senate,35,Republican,"Wilborn, Richard",56,000010
+RICE,East Washington Township,Kansas Senate,35,Republican,"Wilborn, Richard",40,000040
+RICE,Galt Township,Kansas Senate,35,Republican,"Wilborn, Richard",29,000070
+RICE,Harrison Township,Kansas Senate,35,Republican,"Wilborn, Richard",57,000080
+RICE,Lyons Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",245,000100
+RICE,Lyons Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",175,000110
+RICE,Lyons Ward 3,Kansas Senate,35,Republican,"Wilborn, Richard",150,000120
+RICE,Lyons Ward 4,Kansas Senate,35,Republican,"Wilborn, Richard",169,000130
+RICE,Mitchell Township,Kansas Senate,35,Republican,"Wilborn, Richard",54,000140
+RICE,Odessa Township,Kansas Senate,35,Republican,"Wilborn, Richard",21,000150
+RICE,Rockville Township,Kansas Senate,35,Republican,"Wilborn, Richard",44,000180
+RICE,Sterling City East Ward,Kansas Senate,35,Republican,"Wilborn, Richard",342,00019A
+RICE,Sterling City East Ward Exclave A,Kansas Senate,35,Republican,"Wilborn, Richard",0,00019B
+RICE,Sterling City East Ward Exclave B,Kansas Senate,35,Republican,"Wilborn, Richard",0,00019C
+RICE,Sterling City West Ward,Kansas Senate,35,Republican,"Wilborn, Richard",205,000200
+RICE,Sterling Township,Kansas Senate,35,Republican,"Wilborn, Richard",49,000210
+RICE,Union Township,Kansas Senate,35,Republican,"Wilborn, Richard",189,000220
+RICE,Victoria Township,Kansas Senate,35,Republican,"Wilborn, Richard",81,000240
+RICE,West Washington Township,Kansas Senate,35,Republican,"Wilborn, Richard",38,000250
+RICE,Wilson Township,Kansas Senate,35,Republican,"Wilborn, Richard",41,000260
+RICE,Atlanta Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000010
+RICE,Atlanta Township,Secretary of State,,Republican,"Kobach, Kris",42,000010
+RICE,Bell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000020
+RICE,Bell Township,Secretary of State,,Republican,"Kobach, Kris",4,000020
+RICE,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000030
+RICE,Center Township,Secretary of State,,Republican,"Kobach, Kris",33,000030
+RICE,East Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000040
+RICE,East Washington Township,Secretary of State,,Republican,"Kobach, Kris",37,000040
+RICE,Eureka Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000050
+RICE,Eureka Township,Secretary of State,,Republican,"Kobach, Kris",17,000050
+RICE,Farmer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",49,000060
+RICE,Farmer Township,Secretary of State,,Republican,"Kobach, Kris",100,000060
+RICE,Galt Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000070
+RICE,Galt Township,Secretary of State,,Republican,"Kobach, Kris",28,000070
+RICE,Harrison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000080
+RICE,Harrison Township,Secretary of State,,Republican,"Kobach, Kris",59,000080
+RICE,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000090
+RICE,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",105,000090
+RICE,Lyons Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",94,000100
+RICE,Lyons Ward 1,Secretary of State,,Republican,"Kobach, Kris",205,000100
+RICE,Lyons Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",67,000110
+RICE,Lyons Ward 2,Secretary of State,,Republican,"Kobach, Kris",150,000110
+RICE,Lyons Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000120
+RICE,Lyons Ward 3,Secretary of State,,Republican,"Kobach, Kris",108,000120
+RICE,Lyons Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",58,000130
+RICE,Lyons Ward 4,Secretary of State,,Republican,"Kobach, Kris",161,000130
+RICE,Mitchell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000140
+RICE,Mitchell Township,Secretary of State,,Republican,"Kobach, Kris",47,000140
+RICE,Odessa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000150
+RICE,Odessa Township,Secretary of State,,Republican,"Kobach, Kris",20,000150
+RICE,Pioneer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000160
+RICE,Pioneer Township,Secretary of State,,Republican,"Kobach, Kris",18,000160
+RICE,Raymond Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000170
+RICE,Raymond Township,Secretary of State,,Republican,"Kobach, Kris",47,000170
+RICE,Rockville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000180
+RICE,Rockville Township,Secretary of State,,Republican,"Kobach, Kris",36,000180
+RICE,Sterling City East Ward,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",120,00019A
+RICE,Sterling City East Ward,Secretary of State,,Republican,"Kobach, Kris",309,00019A
+RICE,Sterling City East Ward Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00019B
+RICE,Sterling City East Ward Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,00019B
+RICE,Sterling City East Ward Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00019C
+RICE,Sterling City East Ward Exclave B,Secretary of State,,Republican,"Kobach, Kris",0,00019C
+RICE,Sterling City West Ward,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000200
+RICE,Sterling City West Ward,Secretary of State,,Republican,"Kobach, Kris",168,000200
+RICE,Sterling Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000210
+RICE,Sterling Township,Secretary of State,,Republican,"Kobach, Kris",40,000210
+RICE,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000220
+RICE,Union Township,Secretary of State,,Republican,"Kobach, Kris",165,000220
+RICE,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000230
+RICE,Valley Township,Secretary of State,,Republican,"Kobach, Kris",57,000230
+RICE,Victoria Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000240
+RICE,Victoria Township,Secretary of State,,Republican,"Kobach, Kris",90,000240
+RICE,West Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000250
+RICE,West Washington Township,Secretary of State,,Republican,"Kobach, Kris",32,000250
+RICE,Wilson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000260
+RICE,Wilson Township,Secretary of State,,Republican,"Kobach, Kris",36,000260
+RICE,Atlanta Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000010
+RICE,Atlanta Township,State Treasurer,,Republican,"Estes, Ron",58,000010
+RICE,Bell Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+RICE,Bell Township,State Treasurer,,Republican,"Estes, Ron",4,000020
+RICE,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+RICE,Center Township,State Treasurer,,Republican,"Estes, Ron",36,000030
+RICE,East Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000040
+RICE,East Washington Township,State Treasurer,,Republican,"Estes, Ron",44,000040
+RICE,Eureka Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000050
+RICE,Eureka Township,State Treasurer,,Republican,"Estes, Ron",17,000050
+RICE,Farmer Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000060
+RICE,Farmer Township,State Treasurer,,Republican,"Estes, Ron",121,000060
+RICE,Galt Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000070
+RICE,Galt Township,State Treasurer,,Republican,"Estes, Ron",31,000070
+RICE,Harrison Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000080
+RICE,Harrison Township,State Treasurer,,Republican,"Estes, Ron",62,000080
+RICE,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000090
+RICE,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",112,000090
+RICE,Lyons Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",58,000100
+RICE,Lyons Ward 1,State Treasurer,,Republican,"Estes, Ron",235,000100
+RICE,Lyons Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",40,000110
+RICE,Lyons Ward 2,State Treasurer,,Republican,"Estes, Ron",178,000110
+RICE,Lyons Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",53,000120
+RICE,Lyons Ward 3,State Treasurer,,Republican,"Estes, Ron",126,000120
+RICE,Lyons Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",50,000130
+RICE,Lyons Ward 4,State Treasurer,,Republican,"Estes, Ron",168,000130
+RICE,Mitchell Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000140
+RICE,Mitchell Township,State Treasurer,,Republican,"Estes, Ron",48,000140
+RICE,Odessa Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000150
+RICE,Odessa Township,State Treasurer,,Republican,"Estes, Ron",23,000150
+RICE,Pioneer Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000160
+RICE,Pioneer Township,State Treasurer,,Republican,"Estes, Ron",19,000160
+RICE,Raymond Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000170
+RICE,Raymond Township,State Treasurer,,Republican,"Estes, Ron",50,000170
+RICE,Rockville Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000180
+RICE,Rockville Township,State Treasurer,,Republican,"Estes, Ron",41,000180
+RICE,Sterling City East Ward,State Treasurer,,Democratic,"Alldritt, Carmen",69,00019A
+RICE,Sterling City East Ward,State Treasurer,,Republican,"Estes, Ron",358,00019A
+RICE,Sterling City East Ward Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00019B
+RICE,Sterling City East Ward Exclave A,State Treasurer,,Republican,"Estes, Ron",0,00019B
+RICE,Sterling City East Ward Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00019C
+RICE,Sterling City East Ward Exclave B,State Treasurer,,Republican,"Estes, Ron",0,00019C
+RICE,Sterling City West Ward,State Treasurer,,Democratic,"Alldritt, Carmen",56,000200
+RICE,Sterling City West Ward,State Treasurer,,Republican,"Estes, Ron",181,000200
+RICE,Sterling Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000210
+RICE,Sterling Township,State Treasurer,,Republican,"Estes, Ron",52,000210
+RICE,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000220
+RICE,Union Township,State Treasurer,,Republican,"Estes, Ron",182,000220
+RICE,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000230
+RICE,Valley Township,State Treasurer,,Republican,"Estes, Ron",65,000230
+RICE,Victoria Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000240
+RICE,Victoria Township,State Treasurer,,Republican,"Estes, Ron",88,000240
+RICE,West Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000250
+RICE,West Washington Township,State Treasurer,,Republican,"Estes, Ron",38,000250
+RICE,Wilson Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000260
+RICE,Wilson Township,State Treasurer,,Republican,"Estes, Ron",45,000260
+RICE,Atlanta Township,United States Senate,,independent,"Orman, Greg",22,000010
+RICE,Atlanta Township,United States Senate,,Libertarian,"Batson, Randall",6,000010
+RICE,Atlanta Township,United States Senate,,Republican,"Roberts, Pat",39,000010
+RICE,Bell Township,United States Senate,,independent,"Orman, Greg",1,000020
+RICE,Bell Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+RICE,Bell Township,United States Senate,,Republican,"Roberts, Pat",3,000020
+RICE,Center Township,United States Senate,,independent,"Orman, Greg",6,000030
+RICE,Center Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+RICE,Center Township,United States Senate,,Republican,"Roberts, Pat",35,000030
+RICE,East Washington Township,United States Senate,,independent,"Orman, Greg",15,000040
+RICE,East Washington Township,United States Senate,,Libertarian,"Batson, Randall",2,000040
+RICE,East Washington Township,United States Senate,,Republican,"Roberts, Pat",39,000040
+RICE,Eureka Township,United States Senate,,independent,"Orman, Greg",1,000050
+RICE,Eureka Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+RICE,Eureka Township,United States Senate,,Republican,"Roberts, Pat",17,000050
+RICE,Farmer Township,United States Senate,,independent,"Orman, Greg",42,000060
+RICE,Farmer Township,United States Senate,,Libertarian,"Batson, Randall",5,000060
+RICE,Farmer Township,United States Senate,,Republican,"Roberts, Pat",102,000060
+RICE,Galt Township,United States Senate,,independent,"Orman, Greg",5,000070
+RICE,Galt Township,United States Senate,,Libertarian,"Batson, Randall",2,000070
+RICE,Galt Township,United States Senate,,Republican,"Roberts, Pat",28,000070
+RICE,Harrison Township,United States Senate,,independent,"Orman, Greg",19,000080
+RICE,Harrison Township,United States Senate,,Libertarian,"Batson, Randall",4,000080
+RICE,Harrison Township,United States Senate,,Republican,"Roberts, Pat",47,000080
+RICE,Lincoln Township,United States Senate,,independent,"Orman, Greg",46,000090
+RICE,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",15,000090
+RICE,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",79,000090
+RICE,Lyons Ward 1,United States Senate,,independent,"Orman, Greg",115,000100
+RICE,Lyons Ward 1,United States Senate,,Libertarian,"Batson, Randall",12,000100
+RICE,Lyons Ward 1,United States Senate,,Republican,"Roberts, Pat",172,000100
+RICE,Lyons Ward 2,United States Senate,,independent,"Orman, Greg",78,000110
+RICE,Lyons Ward 2,United States Senate,,Libertarian,"Batson, Randall",16,000110
+RICE,Lyons Ward 2,United States Senate,,Republican,"Roberts, Pat",128,000110
+RICE,Lyons Ward 3,United States Senate,,independent,"Orman, Greg",72,000120
+RICE,Lyons Ward 3,United States Senate,,Libertarian,"Batson, Randall",19,000120
+RICE,Lyons Ward 3,United States Senate,,Republican,"Roberts, Pat",89,000120
+RICE,Lyons Ward 4,United States Senate,,independent,"Orman, Greg",72,000130
+RICE,Lyons Ward 4,United States Senate,,Libertarian,"Batson, Randall",11,000130
+RICE,Lyons Ward 4,United States Senate,,Republican,"Roberts, Pat",133,000130
+RICE,Mitchell Township,United States Senate,,independent,"Orman, Greg",19,000140
+RICE,Mitchell Township,United States Senate,,Libertarian,"Batson, Randall",1,000140
+RICE,Mitchell Township,United States Senate,,Republican,"Roberts, Pat",43,000140
+RICE,Odessa Township,United States Senate,,independent,"Orman, Greg",3,000150
+RICE,Odessa Township,United States Senate,,Libertarian,"Batson, Randall",1,000150
+RICE,Odessa Township,United States Senate,,Republican,"Roberts, Pat",20,000150
+RICE,Pioneer Township,United States Senate,,independent,"Orman, Greg",6,000160
+RICE,Pioneer Township,United States Senate,,Libertarian,"Batson, Randall",1,000160
+RICE,Pioneer Township,United States Senate,,Republican,"Roberts, Pat",16,000160
+RICE,Raymond Township,United States Senate,,independent,"Orman, Greg",7,000170
+RICE,Raymond Township,United States Senate,,Libertarian,"Batson, Randall",1,000170
+RICE,Raymond Township,United States Senate,,Republican,"Roberts, Pat",46,000170
+RICE,Rockville Township,United States Senate,,independent,"Orman, Greg",20,000180
+RICE,Rockville Township,United States Senate,,Libertarian,"Batson, Randall",0,000180
+RICE,Rockville Township,United States Senate,,Republican,"Roberts, Pat",38,000180
+RICE,Sterling City East Ward,United States Senate,,independent,"Orman, Greg",125,00019A
+RICE,Sterling City East Ward,United States Senate,,Libertarian,"Batson, Randall",21,00019A
+RICE,Sterling City East Ward,United States Senate,,Republican,"Roberts, Pat",290,00019A
+RICE,Sterling City East Ward Exclave A,United States Senate,,independent,"Orman, Greg",0,00019B
+RICE,Sterling City East Ward Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,00019B
+RICE,Sterling City East Ward Exclave A,United States Senate,,Republican,"Roberts, Pat",0,00019B
+RICE,Sterling City East Ward Exclave B,United States Senate,,independent,"Orman, Greg",0,00019C
+RICE,Sterling City East Ward Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,00019C
+RICE,Sterling City East Ward Exclave B,United States Senate,,Republican,"Roberts, Pat",0,00019C
+RICE,Sterling City West Ward,United States Senate,,independent,"Orman, Greg",84,000200
+RICE,Sterling City West Ward,United States Senate,,Libertarian,"Batson, Randall",8,000200
+RICE,Sterling City West Ward,United States Senate,,Republican,"Roberts, Pat",151,000200
+RICE,Sterling Township,United States Senate,,independent,"Orman, Greg",17,000210
+RICE,Sterling Township,United States Senate,,Libertarian,"Batson, Randall",1,000210
+RICE,Sterling Township,United States Senate,,Republican,"Roberts, Pat",41,000210
+RICE,Union Township,United States Senate,,independent,"Orman, Greg",74,000220
+RICE,Union Township,United States Senate,,Libertarian,"Batson, Randall",13,000220
+RICE,Union Township,United States Senate,,Republican,"Roberts, Pat",145,000220
+RICE,Valley Township,United States Senate,,independent,"Orman, Greg",27,000230
+RICE,Valley Township,United States Senate,,Libertarian,"Batson, Randall",1,000230
+RICE,Valley Township,United States Senate,,Republican,"Roberts, Pat",55,000230
+RICE,Victoria Township,United States Senate,,independent,"Orman, Greg",33,000240
+RICE,Victoria Township,United States Senate,,Libertarian,"Batson, Randall",9,000240
+RICE,Victoria Township,United States Senate,,Republican,"Roberts, Pat",76,000240
+RICE,West Washington Township,United States Senate,,independent,"Orman, Greg",15,000250
+RICE,West Washington Township,United States Senate,,Libertarian,"Batson, Randall",1,000250
+RICE,West Washington Township,United States Senate,,Republican,"Roberts, Pat",30,000250
+RICE,Wilson Township,United States Senate,,independent,"Orman, Greg",12,000260
+RICE,Wilson Township,United States Senate,,Libertarian,"Batson, Randall",3,000260
+RICE,Wilson Township,United States Senate,,Republican,"Roberts, Pat",37,000260

--- a/2014/20141104__ks__general__riley__precinct.csv
+++ b/2014/20141104__ks__general__riley__precinct.csv
@@ -1,1257 +1,1242 @@
-county,precinct,office,district,party,candidate,votes,code
-Riley,W1P1,Attorney General,,D,A.J. Kotich,260,RI01
-Riley,W2P1,Attorney General,,D,A.J. Kotich,234,RI02
-Riley,W2P2,Attorney General,,D,A.J. Kotich,108,RI03
-Riley,W2P3,Attorney General,,D,A.J. Kotich,338,RI04
-Riley,W2P4,Attorney General,,D,A.J. Kotich,152,RI05
-Riley,W3P2,Attorney General,,D,A.J. Kotich,110,RI06
-Riley,W3P3,Attorney General,,D,A.J. Kotich,204,RI07
-Riley,W4P2,Attorney General,,D,A.J. Kotich,94,RI08
-Riley,W4P3,Attorney General,,D,A.J. Kotich,251,RI09
-Riley,W4P4,Attorney General,,D,A.J. Kotich,370,RI10
-Riley,W4P5,Attorney General,,D,A.J. Kotich,181,RI11
-Riley,W4P6,Attorney General,,D,A.J. Kotich,61,RI12
-Riley,W4P7,Attorney General,,D,A.J. Kotich,2,RI13
-Riley,W5P2,Attorney General,,D,A.J. Kotich,273,RI14
-Riley,W5P3,Attorney General,,D,A.J. Kotich,234,RI15
-Riley,W5P5,Attorney General,,D,A.J. Kotich,100,RI16
-Riley,W5P6,Attorney General,,D,A.J. Kotich,206,RI17
-Riley,W5P7,Attorney General,,D,A.J. Kotich,94,RI18
-Riley,W5P8,Attorney General,,D,A.J. Kotich,132,RI19
-Riley,W5P9,Attorney General,,D,A.J. Kotich,347,RI20
-Riley,W5P10,Attorney General,,D,A.J. Kotich,334,RI21
-Riley,W5P11,Attorney General,,D,A.J. Kotich,334,RI22
-Riley,W6P1,Attorney General,,D,A.J. Kotich,0,RI23
-Riley,W8P1,Attorney General,,D,A.J. Kotich,59,RI24
-Riley,W8P2,Attorney General,,D,A.J. Kotich,1,RI25
-Riley,W8P3,Attorney General,,D,A.J. Kotich,64,RI26
-Riley,W9P1,Attorney General,,D,A.J. Kotich,28,RI27
-Riley,W9P2,Attorney General,,D,A.J. Kotich,50,RI28
-Riley,W9P3,Attorney General,,D,A.J. Kotich,11,RI29
-Riley,W10P1,Attorney General,,D,A.J. Kotich,17,RI30
-Riley,W11P1,Attorney General,,D,A.J. Kotich,47,RI31
-Riley,W11P1B,Attorney General,,D,A.J. Kotich,35,RI32
-Riley,W11P3,Attorney General,,D,A.J. Kotich,2,RI33
-Riley,Ashland,Attorney General,,D,A.J. Kotich,37,RI34
-Riley,Bala,Attorney General,,D,A.J. Kotich,38,RI35
-Riley,Center,Attorney General,,D,A.J. Kotich,3,RI36
-Riley,Fancy Creek,Attorney General,,D,A.J. Kotich,4,RI37
-Riley,Grant ,Attorney General,,D,A.J. Kotich,141,RI38
-Riley,Jackson,Attorney General,,D,A.J. Kotich,27,RI39
-Riley,Madison H64,Attorney General,,D,A.J. Kotich,100,RI40
-Riley,Madison H67,Attorney General,,D,A.J. Kotich,1,RI41
-Riley,Man twp 1,Attorney General,,D,A.J. Kotich,71,RI42
-Riley,Man twp 2,Attorney General,,D,A.J. Kotich,90,RI43
-Riley,Man twp 3,Attorney General,,D,A.J. Kotich,21,RI44
-Riley,Man twp 4,Attorney General,,D,A.J. Kotich,61,RI45
-Riley,May Day,Attorney General,,D,A.J. Kotich,1,RI46
-Riley,Ogden,Attorney General,,D,A.J. Kotich,26,RI47
-Riley,Ogden/Ft Ril,Attorney General,,D,A.J. Kotich,68,RI48
-Riley,Sherman,Attorney General,,D,A.J. Kotich,52,RI49
-Riley,Swede Creek,Attorney General,,D,A.J. Kotich,18,RI50
-Riley,Wildcat,Attorney General,,D,A.J. Kotich,81,RI51
-Riley,Zeandale,Attorney General,,D,A.J. Kotich,48,RI52
-Riley,Mad/Ft Ril A,Attorney General,,D,A.J. Kotich,4,RI53
-Riley,Mad/Ft Ril B,Attorney General,,D,A.J. Kotich,3,RI54
-Riley,W1P1,Attorney General,,R,Derek Schmidt,202,RI01
-Riley,W2P1,Attorney General,,R,Derek Schmidt,154,RI02
-Riley,W2P2,Attorney General,,R,Derek Schmidt,78,RI03
-Riley,W2P3,Attorney General,,R,Derek Schmidt,492,RI04
-Riley,W2P4,Attorney General,,R,Derek Schmidt,289,RI05
-Riley,W3P2,Attorney General,,R,Derek Schmidt,77,RI06
-Riley,W3P3,Attorney General,,R,Derek Schmidt,281,RI07
-Riley,W4P2,Attorney General,,R,Derek Schmidt,111,RI08
-Riley,W4P3,Attorney General,,R,Derek Schmidt,240,RI09
-Riley,W4P4,Attorney General,,R,Derek Schmidt,559,RI10
-Riley,W4P5,Attorney General,,R,Derek Schmidt,285,RI11
-Riley,W4P6,Attorney General,,R,Derek Schmidt,175,RI12
-Riley,W4P7,Attorney General,,R,Derek Schmidt,12,RI13
-Riley,W5P2,Attorney General,,R,Derek Schmidt,173,RI14
-Riley,W5P3,Attorney General,,R,Derek Schmidt,206,RI15
-Riley,W5P5,Attorney General,,R,Derek Schmidt,154,RI16
-Riley,W5P6,Attorney General,,R,Derek Schmidt,406,RI17
-Riley,W5P7,Attorney General,,R,Derek Schmidt,147,RI18
-Riley,W5P8,Attorney General,,R,Derek Schmidt,250,RI19
-Riley,W5P9,Attorney General,,R,Derek Schmidt,643,RI20
-Riley,W5P10,Attorney General,,R,Derek Schmidt,630,RI21
-Riley,W5P11,Attorney General,,R,Derek Schmidt,643,RI22
-Riley,W6P1,Attorney General,,R,Derek Schmidt,2,RI23
-Riley,W8P1,Attorney General,,R,Derek Schmidt,79,RI24
-Riley,W8P2,Attorney General,,R,Derek Schmidt,0,RI25
-Riley,W8P3,Attorney General,,R,Derek Schmidt,94,RI26
-Riley,W9P1,Attorney General,,R,Derek Schmidt,62,RI27
-Riley,W9P2,Attorney General,,R,Derek Schmidt,64,RI28
-Riley,W9P3,Attorney General,,R,Derek Schmidt,25,RI29
-Riley,W10P1,Attorney General,,R,Derek Schmidt,16,RI30
-Riley,W11P1,Attorney General,,R,Derek Schmidt,65,RI31
-Riley,W11P1B,Attorney General,,R,Derek Schmidt,64,RI32
-Riley,W11P3,Attorney General,,R,Derek Schmidt,19,RI33
-Riley,Ashland,Attorney General,,R,Derek Schmidt,58,RI34
-Riley,Bala,Attorney General,,R,Derek Schmidt,225,RI35
-Riley,Center,Attorney General,,R,Derek Schmidt,37,RI36
-Riley,Fancy Creek,Attorney General,,R,Derek Schmidt,52,RI37
-Riley,Grant ,Attorney General,,R,Derek Schmidt,378,RI38
-Riley,Jackson,Attorney General,,R,Derek Schmidt,98,RI39
-Riley,Madison H64,Attorney General,,R,Derek Schmidt,298,RI40
-Riley,Madison H67,Attorney General,,R,Derek Schmidt,14,RI41
-Riley,Man twp 1,Attorney General,,R,Derek Schmidt,170,RI42
-Riley,Man twp 2,Attorney General,,R,Derek Schmidt,167,RI43
-Riley,Man twp 3,Attorney General,,R,Derek Schmidt,66,RI44
-Riley,Man twp 4,Attorney General,,R,Derek Schmidt,155,RI45
-Riley,May Day,Attorney General,,R,Derek Schmidt,34,RI46
-Riley,Ogden,Attorney General,,R,Derek Schmidt,130,RI47
-Riley,Ogden/Ft Ril,Attorney General,,R,Derek Schmidt,179,RI48
-Riley,Sherman,Attorney General,,R,Derek Schmidt,187,RI49
-Riley,Swede Creek,Attorney General,,R,Derek Schmidt,39,RI50
-Riley,Wildcat,Attorney General,,R,Derek Schmidt,331,RI51
-Riley,Zeandale,Attorney General,,R,Derek Schmidt,129,RI52
-Riley,Mad/Ft Ril A,Attorney General,,R,Derek Schmidt,4,RI53
-Riley,Mad/Ft Ril B,Attorney General,,R,Derek Schmidt,5,RI54
-Riley,W1P1,Commissioner of Insurance,,D,Dennis Anderson,279,RI01
-Riley,W2P1,Commissioner of Insurance,,D,Dennis Anderson,254,RI02
-Riley,W2P2,Commissioner of Insurance,,D,Dennis Anderson,113,RI03
-Riley,W2P3,Commissioner of Insurance,,D,Dennis Anderson,373,RI04
-Riley,W2P4,Commissioner of Insurance,,D,Dennis Anderson,191,RI05
-Riley,W3P2,Commissioner of Insurance,,D,Dennis Anderson,115,RI06
-Riley,W3P3,Commissioner of Insurance,,D,Dennis Anderson,227,RI07
-Riley,W4P2,Commissioner of Insurance,,D,Dennis Anderson,105,RI08
-Riley,W4P3,Commissioner of Insurance,,D,Dennis Anderson,281,RI09
-Riley,W4P4,Commissioner of Insurance,,D,Dennis Anderson,404,RI10
-Riley,W4P5,Commissioner of Insurance,,D,Dennis Anderson,198,RI11
-Riley,W4P6,Commissioner of Insurance,,D,Dennis Anderson,69,RI12
-Riley,W4P7,Commissioner of Insurance,,D,Dennis Anderson,3,RI13
-Riley,W5P2,Commissioner of Insurance,,D,Dennis Anderson,288,RI14
-Riley,W5P3,Commissioner of Insurance,,D,Dennis Anderson,253,RI15
-Riley,W5P5,Commissioner of Insurance,,D,Dennis Anderson,115,RI16
-Riley,W5P6,Commissioner of Insurance,,D,Dennis Anderson,237,RI17
-Riley,W5P7,Commissioner of Insurance,,D,Dennis Anderson,107,RI18
-Riley,W5P8,Commissioner of Insurance,,D,Dennis Anderson,156,RI19
-Riley,W5P9,Commissioner of Insurance,,D,Dennis Anderson,409,RI20
-Riley,W5P10,Commissioner of Insurance,,D,Dennis Anderson,393,RI21
-Riley,W5P11,Commissioner of Insurance,,D,Dennis Anderson,399,RI22
-Riley,W6P1,Commissioner of Insurance,,D,Dennis Anderson,0,RI23
-Riley,W8P1,Commissioner of Insurance,,D,Dennis Anderson,66,RI24
-Riley,W8P2,Commissioner of Insurance,,D,Dennis Anderson,0,RI25
-Riley,W8P3,Commissioner of Insurance,,D,Dennis Anderson,70,RI26
-Riley,W9P1,Commissioner of Insurance,,D,Dennis Anderson,37,RI27
-Riley,W9P2,Commissioner of Insurance,,D,Dennis Anderson,56,RI28
-Riley,W9P3,Commissioner of Insurance,,D,Dennis Anderson,12,RI29
-Riley,W10P1,Commissioner of Insurance,,D,Dennis Anderson,18,RI30
-Riley,W11P1,Commissioner of Insurance,,D,Dennis Anderson,45,RI31
-Riley,W11P1B,Commissioner of Insurance,,D,Dennis Anderson,38,RI32
-Riley,W11P3,Commissioner of Insurance,,D,Dennis Anderson,4,RI33
-Riley,Ashland,Commissioner of Insurance,,D,Dennis Anderson,41,RI34
-Riley,Bala,Commissioner of Insurance,,D,Dennis Anderson,59,RI35
-Riley,Center,Commissioner of Insurance,,D,Dennis Anderson,7,RI36
-Riley,Fancy Creek,Commissioner of Insurance,,D,Dennis Anderson,8,RI37
-Riley,Grant ,Commissioner of Insurance,,D,Dennis Anderson,167,RI38
-Riley,Jackson,Commissioner of Insurance,,D,Dennis Anderson,28,RI39
-Riley,Madison H64,Commissioner of Insurance,,D,Dennis Anderson,120,RI40
-Riley,Madison H67,Commissioner of Insurance,,D,Dennis Anderson,2,RI41
-Riley,Man twp 1,Commissioner of Insurance,,D,Dennis Anderson,67,RI42
-Riley,Man twp 2,Commissioner of Insurance,,D,Dennis Anderson,101,RI43
-Riley,Man twp 3,Commissioner of Insurance,,D,Dennis Anderson,28,RI44
-Riley,Man twp 4,Commissioner of Insurance,,D,Dennis Anderson,72,RI45
-Riley,May Day,Commissioner of Insurance,,D,Dennis Anderson,4,RI46
-Riley,Ogden,Commissioner of Insurance,,D,Dennis Anderson,33,RI47
-Riley,Ogden/Ft Ril,Commissioner of Insurance,,D,Dennis Anderson,84,RI48
-Riley,Sherman,Commissioner of Insurance,,D,Dennis Anderson,62,RI49
-Riley,Swede Creek,Commissioner of Insurance,,D,Dennis Anderson,21,RI50
-Riley,Wildcat,Commissioner of Insurance,,D,Dennis Anderson,93,RI51
-Riley,Zeandale,Commissioner of Insurance,,D,Dennis Anderson,53,RI52
-Riley,Mad/Ft Ril A,Commissioner of Insurance,,D,Dennis Anderson,4,RI53
-Riley,Mad/Ft Ril B,Commissioner of Insurance,,D,Dennis Anderson,3,RI54
-Riley,W1P1,Commissioner of Insurance,,R,Ken Selzer,181,RI01
-Riley,W2P1,Commissioner of Insurance,,R,Ken Selzer,134,RI02
-Riley,W2P2,Commissioner of Insurance,,R,Ken Selzer,71,RI03
-Riley,W2P3,Commissioner of Insurance,,R,Ken Selzer,449,RI04
-Riley,W2P4,Commissioner of Insurance,,R,Ken Selzer,240,RI05
-Riley,W3P2,Commissioner of Insurance,,R,Ken Selzer,66,RI06
-Riley,W3P3,Commissioner of Insurance,,R,Ken Selzer,252,RI07
-Riley,W4P2,Commissioner of Insurance,,R,Ken Selzer,94,RI08
-Riley,W4P3,Commissioner of Insurance,,R,Ken Selzer,201,RI09
-Riley,W4P4,Commissioner of Insurance,,R,Ken Selzer,506,RI10
-Riley,W4P5,Commissioner of Insurance,,R,Ken Selzer,267,RI11
-Riley,W4P6,Commissioner of Insurance,,R,Ken Selzer,167,RI12
-Riley,W4P7,Commissioner of Insurance,,R,Ken Selzer,10,RI13
-Riley,W5P2,Commissioner of Insurance,,R,Ken Selzer,152,RI14
-Riley,W5P3,Commissioner of Insurance,,R,Ken Selzer,179,RI15
-Riley,W5P5,Commissioner of Insurance,,R,Ken Selzer,132,RI16
-Riley,W5P6,Commissioner of Insurance,,R,Ken Selzer,369,RI17
-Riley,W5P7,Commissioner of Insurance,,R,Ken Selzer,129,RI18
-Riley,W5P8,Commissioner of Insurance,,R,Ken Selzer,221,RI19
-Riley,W5P9,Commissioner of Insurance,,R,Ken Selzer,568,RI20
-Riley,W5P10,Commissioner of Insurance,,R,Ken Selzer,563,RI21
-Riley,W5P11,Commissioner of Insurance,,R,Ken Selzer,563,RI22
-Riley,W6P1,Commissioner of Insurance,,R,Ken Selzer,2,RI23
-Riley,W8P1,Commissioner of Insurance,,R,Ken Selzer,73,RI24
-Riley,W8P2,Commissioner of Insurance,,R,Ken Selzer,1,RI25
-Riley,W8P3,Commissioner of Insurance,,R,Ken Selzer,84,RI26
-Riley,W9P1,Commissioner of Insurance,,R,Ken Selzer,51,RI27
-Riley,W9P2,Commissioner of Insurance,,R,Ken Selzer,55,RI28
-Riley,W9P3,Commissioner of Insurance,,R,Ken Selzer,24,RI29
-Riley,W10P1,Commissioner of Insurance,,R,Ken Selzer,14,RI30
-Riley,W11P1,Commissioner of Insurance,,R,Ken Selzer,65,RI31
-Riley,W11P1B,Commissioner of Insurance,,R,Ken Selzer,61,RI32
-Riley,W11P3,Commissioner of Insurance,,R,Ken Selzer,16,RI33
-Riley,Ashland,Commissioner of Insurance,,R,Ken Selzer,50,RI34
-Riley,Bala,Commissioner of Insurance,,R,Ken Selzer,203,RI35
-Riley,Center,Commissioner of Insurance,,R,Ken Selzer,30,RI36
-Riley,Fancy Creek,Commissioner of Insurance,,R,Ken Selzer,49,RI37
-Riley,Grant ,Commissioner of Insurance,,R,Ken Selzer,339,RI38
-Riley,Jackson,Commissioner of Insurance,,R,Ken Selzer,97,RI39
-Riley,Madison H64,Commissioner of Insurance,,R,Ken Selzer,271,RI40
-Riley,Madison H67,Commissioner of Insurance,,R,Ken Selzer,13,RI41
-Riley,Man twp 1,Commissioner of Insurance,,R,Ken Selzer,169,RI42
-Riley,Man twp 2,Commissioner of Insurance,,R,Ken Selzer,150,RI43
-Riley,Man twp 3,Commissioner of Insurance,,R,Ken Selzer,58,RI44
-Riley,Man twp 4,Commissioner of Insurance,,R,Ken Selzer,140,RI45
-Riley,May Day,Commissioner of Insurance,,R,Ken Selzer,31,RI46
-Riley,Ogden,Commissioner of Insurance,,R,Ken Selzer,124,RI47
-Riley,Ogden/Ft Ril,Commissioner of Insurance,,R,Ken Selzer,156,RI48
-Riley,Sherman,Commissioner of Insurance,,R,Ken Selzer,168,RI49
-Riley,Swede Creek,Commissioner of Insurance,,R,Ken Selzer,36,RI50
-Riley,Wildcat,Commissioner of Insurance,,R,Ken Selzer,317,RI51
-Riley,Zeandale,Commissioner of Insurance,,R,Ken Selzer,121,RI52
-Riley,Mad/Ft Ril A,Commissioner of Insurance,,R,Ken Selzer,5,RI53
-Riley,Mad/Ft Ril B,Commissioner of Insurance,,R,Ken Selzer,5,RI54
-Riley,W1P1,Governor,,D,Paul Davis,305,RI01
-Riley,W2P1,Governor,,D,Paul Davis,292,RI02
-Riley,W2P2,Governor,,D,Paul Davis,136,RI03
-Riley,W2P3,Governor,,D,Paul Davis,447,RI04
-Riley,W2P4,Governor,,D,Paul Davis,245,RI05
-Riley,W3P2,Governor,,D,Paul Davis,135,RI06
-Riley,W3P3,Governor,,D,Paul Davis,279,RI07
-Riley,W4P2,Governor,,D,Paul Davis,116,RI08
-Riley,W4P3,Governor,,D,Paul Davis,322,RI09
-Riley,W4P4,Governor,,D,Paul Davis,527,RI10
-Riley,W4P5,Governor,,D,Paul Davis,260,RI11
-Riley,W4P6,Governor,,D,Paul Davis,94,RI12
-Riley,W4P7,Governor,,D,Paul Davis,6,RI13
-Riley,W5P2,Governor,,D,Paul Davis,327,RI14
-Riley,W5P3,Governor,,D,Paul Davis,284,RI15
-Riley,W5P5,Governor,,D,Paul Davis,142,RI16
-Riley,W5P6,Governor,,D,Paul Davis,311,RI17
-Riley,W5P7,Governor,,D,Paul Davis,144,RI18
-Riley,W5P8,Governor,,D,Paul Davis,213,RI19
-Riley,W5P9,Governor,,D,Paul Davis,547,RI20
-Riley,W5P10,Governor,,D,Paul Davis,520,RI21
-Riley,W5P11,Governor,,D,Paul Davis,511,RI22
-Riley,W6P1,Governor,,D,Paul Davis,0,RI23
-Riley,W8P1,Governor,,D,Paul Davis,78,RI24
-Riley,W8P2,Governor,,D,Paul Davis,1,RI25
-Riley,W8P3,Governor,,D,Paul Davis,89,RI26
-Riley,W9P1,Governor,,D,Paul Davis,43,RI27
-Riley,W9P2,Governor,,D,Paul Davis,69,RI28
-Riley,W9P3,Governor,,D,Paul Davis,19,RI29
-Riley,W10P1,Governor,,D,Paul Davis,22,RI30
-Riley,W11P1,Governor,,D,Paul Davis,73,RI31
-Riley,W11P1B,Governor,,D,Paul Davis,47,RI32
-Riley,W11P3,Governor,,D,Paul Davis,8,RI33
-Riley,Ashland,Governor,,D,Paul Davis,45,RI34
-Riley,Bala,Governor,,D,Paul Davis,77,RI35
-Riley,Center,Governor,,D,Paul Davis,7,RI36
-Riley,Fancy Creek,Governor,,D,Paul Davis,12,RI37
-Riley,Grant ,Governor,,D,Paul Davis,217,RI38
-Riley,Jackson,Governor,,D,Paul Davis,49,RI39
-Riley,Madison H64,Governor,,D,Paul Davis,179,RI40
-Riley,Madison H67,Governor,,D,Paul Davis,2,RI41
-Riley,Man twp 1,Governor,,D,Paul Davis,94,RI42
-Riley,Man twp 2,Governor,,D,Paul Davis,130,RI43
-Riley,Man twp 3,Governor,,D,Paul Davis,33,RI44
-Riley,Man twp 4,Governor,,D,Paul Davis,92,RI45
-Riley,May Day,Governor,,D,Paul Davis,6,RI46
-Riley,Ogden,Governor,,D,Paul Davis,40,RI47
-Riley,Ogden/Ft Ril,Governor,,D,Paul Davis,101,RI48
-Riley,Sherman,Governor,,D,Paul Davis,81,RI49
-Riley,Swede Creek,Governor,,D,Paul Davis,29,RI50
-Riley,Wildcat,Governor,,D,Paul Davis,154,RI51
-Riley,Zeandale,Governor,,D,Paul Davis,68,RI52
-Riley,Mad/Ft Ril A,Governor,,D,Paul Davis,4,RI53
-Riley,Mad/Ft Ril B,Governor,,D,Paul Davis,3,RI54
-Riley,W1P1,Governor,,L,Keen A. Umbehr,20,RI01
-Riley,W2P1,Governor,,L,Keen A. Umbehr,24,RI02
-Riley,W2P2,Governor,,L,Keen A. Umbehr,11,RI03
-Riley,W2P3,Governor,,L,Keen A. Umbehr,66,RI04
-Riley,W2P4,Governor,,L,Keen A. Umbehr,32,RI05
-Riley,W3P2,Governor,,L,Keen A. Umbehr,10,RI06
-Riley,W3P3,Governor,,L,Keen A. Umbehr,15,RI07
-Riley,W4P2,Governor,,L,Keen A. Umbehr,8,RI08
-Riley,W4P3,Governor,,L,Keen A. Umbehr,13,RI09
-Riley,W4P4,Governor,,L,Keen A. Umbehr,31,RI10
-Riley,W4P5,Governor,,L,Keen A. Umbehr,21,RI11
-Riley,W4P6,Governor,,L,Keen A. Umbehr,16,RI12
-Riley,W4P7,Governor,,L,Keen A. Umbehr,1,RI13
-Riley,W5P2,Governor,,L,Keen A. Umbehr,11,RI14
-Riley,W5P3,Governor,,L,Keen A. Umbehr,17,RI15
-Riley,W5P5,Governor,,L,Keen A. Umbehr,17,RI16
-Riley,W5P6,Governor,,L,Keen A. Umbehr,29,RI17
-Riley,W5P7,Governor,,L,Keen A. Umbehr,10,RI18
-Riley,W5P8,Governor,,L,Keen A. Umbehr,11,RI19
-Riley,W5P9,Governor,,L,Keen A. Umbehr,17,RI20
-Riley,W5P10,Governor,,L,Keen A. Umbehr,18,RI21
-Riley,W5P11,Governor,,L,Keen A. Umbehr,38,RI22
-Riley,W6P1,Governor,,L,Keen A. Umbehr,0,RI23
-Riley,W8P1,Governor,,L,Keen A. Umbehr,9,RI24
-Riley,W8P2,Governor,,L,Keen A. Umbehr,0,RI25
-Riley,W8P3,Governor,,L,Keen A. Umbehr,12,RI26
-Riley,W9P1,Governor,,L,Keen A. Umbehr,2,RI27
-Riley,W9P2,Governor,,L,Keen A. Umbehr,2,RI28
-Riley,W9P3,Governor,,L,Keen A. Umbehr,2,RI29
-Riley,W10P1,Governor,,L,Keen A. Umbehr,0,RI30
-Riley,W11P1,Governor,,L,Keen A. Umbehr,5,RI31
-Riley,W11P1B,Governor,,L,Keen A. Umbehr,8,RI32
-Riley,W11P3,Governor,,L,Keen A. Umbehr,1,RI33
-Riley,Ashland,Governor,,L,Keen A. Umbehr,3,RI34
-Riley,Bala,Governor,,L,Keen A. Umbehr,13,RI35
-Riley,Center,Governor,,L,Keen A. Umbehr,1,RI36
-Riley,Fancy Creek,Governor,,L,Keen A. Umbehr,1,RI37
-Riley,Grant ,Governor,,L,Keen A. Umbehr,20,RI38
-Riley,Jackson,Governor,,L,Keen A. Umbehr,10,RI39
-Riley,Madison H64,Governor,,L,Keen A. Umbehr,21,RI40
-Riley,Madison H67,Governor,,L,Keen A. Umbehr,2,RI41
-Riley,Man twp 1,Governor,,L,Keen A. Umbehr,14,RI42
-Riley,Man twp 2,Governor,,L,Keen A. Umbehr,17,RI43
-Riley,Man twp 3,Governor,,L,Keen A. Umbehr,6,RI44
-Riley,Man twp 4,Governor,,L,Keen A. Umbehr,14,RI45
-Riley,May Day,Governor,,L,Keen A. Umbehr,1,RI46
-Riley,Ogden,Governor,,L,Keen A. Umbehr,14,RI47
-Riley,Ogden/Ft Ril,Governor,,L,Keen A. Umbehr,23,RI48
-Riley,Sherman,Governor,,L,Keen A. Umbehr,8,RI49
-Riley,Swede Creek,Governor,,L,Keen A. Umbehr,2,RI50
-Riley,Wildcat,Governor,,L,Keen A. Umbehr,18,RI51
-Riley,Zeandale,Governor,,L,Keen A. Umbehr,7,RI52
-Riley,Mad/Ft Ril A,Governor,,L,Keen A. Umbehr,1,RI53
-Riley,Mad/Ft Ril B,Governor,,L,Keen A. Umbehr,0,RI54
-Riley,W1P1,Governor,,R,Sam Brownback,157,RI01
-Riley,W2P1,Governor,,R,Sam Brownback,95,RI02
-Riley,W2P2,Governor,,R,Sam Brownback,50,RI03
-Riley,W2P3,Governor,,R,Sam Brownback,341,RI04
-Riley,W2P4,Governor,,R,Sam Brownback,183,RI05
-Riley,W3P2,Governor,,R,Sam Brownback,53,RI06
-Riley,W3P3,Governor,,R,Sam Brownback,211,RI07
-Riley,W4P2,Governor,,R,Sam Brownback,81,RI08
-Riley,W4P3,Governor,,R,Sam Brownback,165,RI09
-Riley,W4P4,Governor,,R,Sam Brownback,387,RI10
-Riley,W4P5,Governor,,R,Sam Brownback,209,RI11
-Riley,W4P6,Governor,,R,Sam Brownback,131,RI12
-Riley,W4P7,Governor,,R,Sam Brownback,7,RI13
-Riley,W5P2,Governor,,R,Sam Brownback,118,RI14
-Riley,W5P3,Governor,,R,Sam Brownback,156,RI15
-Riley,W5P5,Governor,,R,Sam Brownback,100,RI16
-Riley,W5P6,Governor,,R,Sam Brownback,287,RI17
-Riley,W5P7,Governor,,R,Sam Brownback,95,RI18
-Riley,W5P8,Governor,,R,Sam Brownback,161,RI19
-Riley,W5P9,Governor,,R,Sam Brownback,449,RI20
-Riley,W5P10,Governor,,R,Sam Brownback,447,RI21
-Riley,W5P11,Governor,,R,Sam Brownback,460,RI22
-Riley,W6P1,Governor,,R,Sam Brownback,2,RI23
-Riley,W8P1,Governor,,R,Sam Brownback,51,RI24
-Riley,W8P2,Governor,,R,Sam Brownback,0,RI25
-Riley,W8P3,Governor,,R,Sam Brownback,62,RI26
-Riley,W9P1,Governor,,R,Sam Brownback,47,RI27
-Riley,W9P2,Governor,,R,Sam Brownback,43,RI28
-Riley,W9P3,Governor,,R,Sam Brownback,16,RI29
-Riley,W10P1,Governor,,R,Sam Brownback,12,RI30
-Riley,W11P1,Governor,,R,Sam Brownback,41,RI31
-Riley,W11P1B,Governor,,R,Sam Brownback,44,RI32
-Riley,W11P3,Governor,,R,Sam Brownback,13,RI33
-Riley,Ashland,Governor,,R,Sam Brownback,50,RI34
-Riley,Bala,Governor,,R,Sam Brownback,180,RI35
-Riley,Center,Governor,,R,Sam Brownback,31,RI36
-Riley,Fancy Creek,Governor,,R,Sam Brownback,43,RI37
-Riley,Grant ,Governor,,R,Sam Brownback,289,RI38
-Riley,Jackson,Governor,,R,Sam Brownback,71,RI39
-Riley,Madison H64,Governor,,R,Sam Brownback,209,RI40
-Riley,Madison H67,Governor,,R,Sam Brownback,11,RI41
-Riley,Man twp 1,Governor,,R,Sam Brownback,135,RI42
-Riley,Man twp 2,Governor,,R,Sam Brownback,114,RI43
-Riley,Man twp 3,Governor,,R,Sam Brownback,50,RI44
-Riley,Man twp 4,Governor,,R,Sam Brownback,115,RI45
-Riley,May Day,Governor,,R,Sam Brownback,28,RI46
-Riley,Ogden,Governor,,R,Sam Brownback,109,RI47
-Riley,Ogden/Ft Ril,Governor,,R,Sam Brownback,128,RI48
-Riley,Sherman,Governor,,R,Sam Brownback,155,RI49
-Riley,Swede Creek,Governor,,R,Sam Brownback,31,RI50
-Riley,Wildcat,Governor,,R,Sam Brownback,247,RI51
-Riley,Zeandale,Governor,,R,Sam Brownback,104,RI52
-Riley,Mad/Ft Ril A,Governor,,R,Sam Brownback,5,RI53
-Riley,Mad/Ft Ril B,Governor,,R,Sam Brownback,5,RI54
-Riley,W1P1,State House,66,D,Sydney Carlin,384,RI01
-Riley,W2P1,State House,66,D,Sydney Carlin,336,RI02
-Riley,W2P2,State House,66,D,Sydney Carlin,165,RI03
-Riley,W2P3,State House,66,D,Sydney Carlin,661,RI04
-Riley,W2P4,State House,66,D,Sydney Carlin,353,RI05
-Riley,W3P2,State House,66,D,Sydney Carlin,160,RI06
-Riley,W3P3,State House,66,D,Sydney Carlin,375,RI07
-Riley,W4P2,State House,66,D,Sydney Carlin,154,RI08
-Riley,W4P3,State House,67,R,Tom Phillips,371,RI09
-Riley,W4P4,State House,67,R,Tom Phillips,800,RI10
-Riley,W4P5,State House,67,R,Tom Phillips,409,RI11
-Riley,W4P6,State House,67,R,Tom Phillips,216,RI12
-Riley,W4P7,State House,67,R,Tom Phillips,13,RI13
-Riley,W5P2,State House,66,D,Sydney Carlin,376,RI14
-Riley,W5P3,State House,66,D,Sydney Carlin,347,RI15
-Riley,W5P5,State House,67,R,Tom Phillips,205,RI16
-Riley,W5P6,State House,67,R,Tom Phillips,549,RI17
-Riley,W5P7,State House,67,R,Tom Phillips,210,RI18
-Riley,W5P8,State House,67,R,Tom Phillips,333,RI19
-Riley,W5P9,State House,67,R,Tom Phillips,881,RI20
-Riley,W5P10,State House,67,R,Tom Phillips,844,RI21
-Riley,W5P11,State House,67,R,Tom Phillips,852,RI22
-Riley,W6P1,State House,64,R,Susie Swanson,2,RI23
-Riley,W8P1,State House,66,D,Sydney Carlin,112,RI24
-Riley,W8P2,State House,66,D,Sydney Carlin,1,RI25
-Riley,W8P3,State House,66,D,Sydney Carlin,129,RI26
-Riley,W9P1,State House,66,D,Sydney Carlin,70,RI27
-Riley,W9P2,State House,66,D,Sydney Carlin,85,RI28
-Riley,W9P3,State House,67,R,Tom Phillips,31,RI29
-Riley,W10P1,State House,67,R,Tom Phillips,26,RI30
-Riley,W11P1,State House,67,R,Tom Phillips,92,RI31
-Riley,W11P1B,State House,67,R,Tom Phillips,80,RI32
-Riley,W11P3,State House,67,R,Tom Phillips,21,RI33
-Riley,Ashland,State House,67,R,Tom Phillips,81,RI34
-Riley,Bala,State House,64,R,Susie Swanson,227,RI35
-Riley,Center,State House,64,R,Susie Swanson,37,RI36
-Riley,Fancy Creek,State House,64,R,Susie Swanson,44,RI37
-Riley,Grant ,State House,67,R,Tom Phillips,462,RI38
-Riley,Jackson,State House,64,R,Susie Swanson,113,RI39
-Riley,Madison H64,State House,64,R,Susie Swanson,341,RI40
-Riley,Madison H67,State House,67,R,Tom Phillips,15,RI41
-Riley,Man twp 1,State House,66,D,Sydney Carlin,149,RI42
-Riley,Man twp 2,State House,67,R,Tom Phillips,217,RI43
-Riley,Man twp 3,State House,67,R,Tom Phillips,77,RI44
-Riley,Man twp 4,State House,66,D,Sydney Carlin,154,RI45
-Riley,May Day,State House,64,R,Susie Swanson,33,RI46
-Riley,Ogden,State House,64,R,Susie Swanson,143,RI47
-Riley,Ogden/Ft Ril,State House,64,R,Susie Swanson,209,RI48
-Riley,Sherman,State House,64,R,Susie Swanson,223,RI49
-Riley,Swede Creek,State House,64,R,Susie Swanson,56,RI50
-Riley,Wildcat,State House,67,R,Tom Phillips,372,RI51
-Riley,Zeandale,State House,51,R,Ron Highland,151,RI52
-Riley,Mad/Ft Ril A,State House,64,R,Susie Swanson,7,RI53
-Riley,Mad/Ft Ril B,State House,64,R,Susie Swanson,7,RI54
-Riley,W1P1,State House,66,,Write-ins,19,RI01
-Riley,W2P1,State House,66,,Write-ins,10,RI02
-Riley,W2P2,State House,66,,Write-ins,2,RI03
-Riley,W2P3,State House,66,,Write-ins,37,RI04
-Riley,W2P4,State House,66,,Write-ins,14,RI05
-Riley,W3P2,State House,66,,Write-ins,8,RI06
-Riley,W3P3,State House,66,,Write-ins,16,RI07
-Riley,W4P2,State House,66,,Write-ins,12,RI08
-Riley,W4P3,State House,67,,Write-ins,21,RI09
-Riley,W4P4,State House,67,,Write-ins,33,RI10
-Riley,W4P5,State House,67,,Write-ins,7,RI11
-Riley,W4P6,State House,67,,Write-ins,2,RI12
-Riley,W4P7,State House,67,,Write-ins,0,RI13
-Riley,W5P2,State House,66,,Write-ins,15,RI14
-Riley,W5P3,State House,66,,Write-ins,12,RI15
-Riley,W5P5,State House,67,,Write-ins,2,RI16
-Riley,W5P6,State House,67,,Write-ins,7,RI17
-Riley,W5P7,State House,67,,Write-ins,1,RI18
-Riley,W5P8,State House,67,,Write-ins,3,RI19
-Riley,W5P9,State House,67,,Write-ins,17,RI20
-Riley,W5P10,State House,67,,Write-ins,18,RI21
-Riley,W5P11,State House,67,,Write-ins,19,RI22
-Riley,W6P1,State House,64,,Write-ins,0,RI23
-Riley,W8P1,State House,66,,Write-ins,6,RI24
-Riley,W8P2,State House,66,,Write-ins,0,RI25
-Riley,W8P3,State House,66,,Write-ins,4,RI26
-Riley,W9P1,State House,66,,Write-ins,0,RI27
-Riley,W9P2,State House,67,,Write-ins,8,RI28
-Riley,W9P3,State House,67,,Write-ins,1,RI29
-Riley,W10P1,State House,67,,Write-ins,3,RI30
-Riley,W11P1,State House,67,,Write-ins,2,RI31
-Riley,W11P1B,State House,67,,Write-ins,4,RI32
-Riley,W11P3,State House,67,,Write-ins,0,RI33
-Riley,Ashland,State House,67,,Write-ins,2,RI34
-Riley,Bala,State House,64,,Write-ins,19,RI35
-Riley,Center,State House,64,,Write-ins,0,RI36
-Riley,Fancy Creek,State House,64,,Write-ins,7,RI37
-Riley,Grant ,State House,67,,Write-ins,4,RI38
-Riley,Jackson,State House,64,,Write-ins,5,RI39
-Riley,Madison H64,State House,64,,Write-ins,15,RI40
-Riley,Madison H67,State House,67,,Write-ins,0,RI41
-Riley,Man twp 1,State House,66,,Write-ins,66,RI42
-Riley,Man twp 2,State House,67,,Write-ins,7,RI43
-Riley,Man twp 3,State House,67,,Write-ins,1,RI44
-Riley,Man twp 4,State House,66,,Write-ins,7,RI45
-Riley,May Day,State House,64,,Write-ins,1,RI46
-Riley,Ogden,State House,64,,Write-ins,8,RI47
-Riley,Ogden/Ft Ril A,State House,64,,Write-ins,7,RI48
-Riley,Sherman,State House,64,,Write-ins,6,RI49
-Riley,Swede Creek,State House,64,,Write-ins,0,RI50
-Riley,Wildcat,State House,67,,Write-ins,7,RI51
-Riley,Zeandale,State House,51,,Write-ins,3,RI52
-Riley,Mad/Ft Ril A,State House,64,,Write-ins,0,RI53
-Riley,Mad/Ft Ril B,State House,64,,Write-ins,0,RI54
-Riley,W1P1,Secretary of State,,D,Jean Kurtis Schodorf,181,RI01
-Riley,W2P1,Secretary of State,,D,Jean Kurtis Schodorf,133,RI02
-Riley,W2P2,Secretary of State,,D,Jean Kurtis Schodorf,65,RI03
-Riley,W2P3,Secretary of State,,D,Jean Kurtis Schodorf,438,RI04
-Riley,W2P4,Secretary of State,,D,Jean Kurtis Schodorf,239,RI05
-Riley,W3P2,Secretary of State,,D,Jean Kurtis Schodorf,74,RI06
-Riley,W3P3,Secretary of State,,D,Jean Kurtis Schodorf,250,RI07
-Riley,W4P2,Secretary of State,,D,Jean Kurtis Schodorf,89,RI08
-Riley,W4P3,Secretary of State,,D,Jean Kurtis Schodorf,186,RI09
-Riley,W4P4,Secretary of State,,D,Jean Kurtis Schodorf,492,RI10
-Riley,W4P5,Secretary of State,,D,Jean Kurtis Schodorf,252,RI11
-Riley,W4P6,Secretary of State,,D,Jean Kurtis Schodorf,156,RI12
-Riley,W4P7,Secretary of State,,D,Jean Kurtis Schodorf,8,RI13
-Riley,W5P2,Secretary of State,,D,Jean Kurtis Schodorf,143,RI14
-Riley,W5P3,Secretary of State,,D,Jean Kurtis Schodorf,188,RI15
-Riley,W5P5,Secretary of State,,D,Jean Kurtis Schodorf,124,RI16
-Riley,W5P6,Secretary of State,,D,Jean Kurtis Schodorf,352,RI17
-Riley,W5P7,Secretary of State,,D,Jean Kurtis Schodorf,121,RI18
-Riley,W5P8,Secretary of State,,D,Jean Kurtis Schodorf,210,RI19
-Riley,W5P9,Secretary of State,,D,Jean Kurtis Schodorf,510,RI20
-Riley,W5P10,Secretary of State,,D,Jean Kurtis Schodorf,535,RI21
-Riley,W5P11,Secretary of State,,D,Jean Kurtis Schodorf,550,RI22
-Riley,W6P1,Secretary of State,,D,Jean Kurtis Schodorf,2,RI23
-Riley,W8P1,Secretary of State,,D,Jean Kurtis Schodorf,76,RI24
-Riley,W8P2,Secretary of State,,D,Jean Kurtis Schodorf,0,RI25
-Riley,W8P3,Secretary of State,,D,Jean Kurtis Schodorf,86,RI26
-Riley,W9P1,Secretary of State,,D,Jean Kurtis Schodorf,50,RI27
-Riley,W9P2,Secretary of State,,D,Jean Kurtis Schodorf,46,RI28
-Riley,W9P3,Secretary of State,,D,Jean Kurtis Schodorf,22,RI29
-Riley,W10P1,Secretary of State,,D,Jean Kurtis Schodorf,14,RI30
-Riley,W11P1,Secretary of State,,D,Jean Kurtis Schodorf,50,RI31
-Riley,W11P1B,Secretary of State,,D,Jean Kurtis Schodorf,59,RI32
-Riley,W11P3,Secretary of State,,D,Jean Kurtis Schodorf,16,RI33
-Riley,Ashland,Secretary of State,,D,Jean Kurtis Schodorf,56,RI34
-Riley,Bala,Secretary of State,,D,Jean Kurtis Schodorf,212,RI35
-Riley,Center,Secretary of State,,D,Jean Kurtis Schodorf,37,RI36
-Riley,Fancy Creek,Secretary of State,,D,Jean Kurtis Schodorf,50,RI37
-Riley,Grant ,Secretary of State,,D,Jean Kurtis Schodorf,339,RI38
-Riley,Jackson,Secretary of State,,D,Jean Kurtis Schodorf,90,RI39
-Riley,Madison H64,Secretary of State,,D,Jean Kurtis Schodorf,269,RI40
-Riley,Madison H67,Secretary of State,,D,Jean Kurtis Schodorf,14,RI41
-Riley,Man twp 1,Secretary of State,,D,Jean Kurtis Schodorf,160,RI42
-Riley,Man twp 2,Secretary of State,,D,Jean Kurtis Schodorf,141,RI43
-Riley,Man twp 3,Secretary of State,,D,Jean Kurtis Schodorf,61,RI44
-Riley,Man twp 4,Secretary of State,,D,Jean Kurtis Schodorf,147,RI45
-Riley,May Day,Secretary of State,,D,Jean Kurtis Schodorf,33,RI46
-Riley,Ogden,Secretary of State,,D,Jean Kurtis Schodorf,123,RI47
-Riley,Ogden/Ft Ril,Secretary of State,,D,Jean Kurtis Schodorf,162,RI48
-Riley,Sherman,Secretary of State,,D,Jean Kurtis Schodorf,177,RI49
-Riley,Swede Creek,Secretary of State,,D,Jean Kurtis Schodorf,41,RI50
-Riley,Wildcat,Secretary of State,,D,Jean Kurtis Schodorf,302,RI51
-Riley,Zeandale,Secretary of State,,D,Jean Kurtis Schodorf,124,RI52
-Riley,Mad/Ft Ril A,Secretary of State,,D,Jean Kurtis Schodorf,6,RI53
-Riley,Mad/Ft Ril B,Secretary of State,,D,Jean Kurtis Schodorf,5,RI54
-Riley,W1P1,Secretary of State,,R,Kris Kobach,290,RI01
-Riley,W2P1,Secretary of State,,R,Kris Kobach,269,RI02
-Riley,W2P2,Secretary of State,,R,Kris Kobach,125,RI03
-Riley,W2P3,Secretary of State,,R,Kris Kobach,399,RI04
-Riley,W2P4,Secretary of State,,R,Kris Kobach,206,RI05
-Riley,W3P2,Secretary of State,,R,Kris Kobach,120,RI06
-Riley,W3P3,Secretary of State,,R,Kris Kobach,247,RI07
-Riley,W4P2,Secretary of State,,R,Kris Kobach,115,RI08
-Riley,W4P3,Secretary of State,,R,Kris Kobach,309,RI09
-Riley,W4P4,Secretary of State,,R,Kris Kobach,444,RI10
-Riley,W4P5,Secretary of State,,R,Kris Kobach,224,RI11
-Riley,W4P6,Secretary of State,,R,Kris Kobach,82,RI12
-Riley,W4P7,Secretary of State,,R,Kris Kobach,5,RI13
-Riley,W5P2,Secretary of State,,R,Kris Kobach,304,RI14
-Riley,W5P3,Secretary of State,,R,Kris Kobach,260,RI15
-Riley,W5P5,Secretary of State,,R,Kris Kobach,129,RI16
-Riley,W5P6,Secretary of State,,R,Kris Kobach,267,RI17
-Riley,W5P7,Secretary of State,,R,Kris Kobach,123,RI18
-Riley,W5P8,Secretary of State,,R,Kris Kobach,177,RI19
-Riley,W5P9,Secretary of State,,R,Kris Kobach,492,RI20
-Riley,W5P10,Secretary of State,,R,Kris Kobach,436,RI21
-Riley,W5P11,Secretary of State,,R,Kris Kobach,436,RI22
-Riley,W6P1,Secretary of State,,R,Kris Kobach,0,RI23
-Riley,W8P1,Secretary of State,,R,Kris Kobach,62,RI24
-Riley,W8P2,Secretary of State,,R,Kris Kobach,1,RI25
-Riley,W8P3,Secretary of State,,R,Kris Kobach,75,RI26
-Riley,W9P1,Secretary of State,,R,Kris Kobach,39,RI27
-Riley,W9P2,Secretary of State,,R,Kris Kobach,69,RI28
-Riley,W9P3,Secretary of State,,R,Kris Kobach,13,RI29
-Riley,W10P1,Secretary of State,,R,Kris Kobach,19,RI30
-Riley,W11P1,Secretary of State,,R,Kris Kobach,63,RI31
-Riley,W11P1B,Secretary of State,,R,Kris Kobach,41,RI32
-Riley,W11P3,Secretary of State,,R,Kris Kobach,5,RI33
-Riley,Ashland,Secretary of State,,R,Kris Kobach,42,RI34
-Riley,Bala,Secretary of State,,R,Kris Kobach,51,RI35
-Riley,Center,Secretary of State,,R,Kris Kobach,3,RI36
-Riley,Fancy Creek,Secretary of State,,R,Kris Kobach,7,RI37
-Riley,Grant ,Secretary of State,,R,Kris Kobach,181,RI38
-Riley,Jackson,Secretary of State,,R,Kris Kobach,36,RI39
-Riley,Madison H64,Secretary of State,,R,Kris Kobach,127,RI40
-Riley,Madison H67,Secretary of State,,R,Kris Kobach,1,RI41
-Riley,Man twp 1,Secretary of State,,R,Kris Kobach,81,RI42
-Riley,Man twp 2,Secretary of State,,R,Kris Kobach,118,RI43
-Riley,Man twp 3,Secretary of State,,R,Kris Kobach,28,RI44
-Riley,Man twp 4,Secretary of State,,R,Kris Kobach,72,RI45
-Riley,May Day,Secretary of State,,R,Kris Kobach,2,RI46
-Riley,Ogden,Secretary of State,,R,Kris Kobach,36,RI47
-Riley,Ogden/Ft Ril,Secretary of State,,R,Kris Kobach,85,RI48
-Riley,Sherman,Secretary of State,,R,Kris Kobach,65,RI49
-Riley,Swede Creek,Secretary of State,,R,Kris Kobach,19,RI50
-Riley,Wildcat,Secretary of State,,R,Kris Kobach,116,RI51
-Riley,Zeandale,Secretary of State,,R,Kris Kobach,56,RI52
-Riley,Mad/Ft Ril A,Secretary of State,,R,Kris Kobach,4,RI53
-Riley,Mad/Ft Ril B,Secretary of State,,R,Kris Kobach,3,RI54
-Riley,W1P1,State Treasurer,,D,Carmen Alldritt,256,RI01
-Riley,W2P1,State Treasurer,,D,Carmen Alldritt,232,RI02
-Riley,W2P2,State Treasurer,,D,Carmen Alldritt,106,RI03
-Riley,W2P3,State Treasurer,,D,Carmen Alldritt,338,RI04
-Riley,W2P4,State Treasurer,,D,Carmen Alldritt,164,RI05
-Riley,W3P2,State Treasurer,,D,Carmen Alldritt,112,RI06
-Riley,W3P3,State Treasurer,,D,Carmen Alldritt,200,RI07
-Riley,W4P2,State Treasurer,,D,Carmen Alldritt,89,RI08
-Riley,W4P3,State Treasurer,,D,Carmen Alldritt,251,RI09
-Riley,W4P4,State Treasurer,,D,Carmen Alldritt,377,RI10
-Riley,W4P5,State Treasurer,,D,Carmen Alldritt,177,RI11
-Riley,W4P6,State Treasurer,,D,Carmen Alldritt,59,RI12
-Riley,W4P7,State Treasurer,,D,Carmen Alldritt,2,RI13
-Riley,W5P2,State Treasurer,,D,Carmen Alldritt,262,RI14
-Riley,W5P3,State Treasurer,,D,Carmen Alldritt,223,RI15
-Riley,W5P5,State Treasurer,,D,Carmen Alldritt,93,RI16
-Riley,W5P6,State Treasurer,,D,Carmen Alldritt,210,RI17
-Riley,W5P7,State Treasurer,,D,Carmen Alldritt,94,RI18
-Riley,W5P8,State Treasurer,,D,Carmen Alldritt,133,RI19
-Riley,W5P9,State Treasurer,,D,Carmen Alldritt,341,RI20
-Riley,W5P10,State Treasurer,,D,Carmen Alldritt,332,RI21
-Riley,W5P11,State Treasurer,,D,Carmen Alldritt,335,RI22
-Riley,W6P1,State Treasurer,,D,Carmen Alldritt,0,RI23
-Riley,W8P1,State Treasurer,,D,Carmen Alldritt,62,RI24
-Riley,W8P2,State Treasurer,,D,Carmen Alldritt,0,RI25
-Riley,W8P3,State Treasurer,,D,Carmen Alldritt,64,RI26
-Riley,W9P1,State Treasurer,,D,Carmen Alldritt,31,RI27
-Riley,W9P2,State Treasurer,,D,Carmen Alldritt,45,RI28
-Riley,W9P3,State Treasurer,,D,Carmen Alldritt,10,RI29
-Riley,W10P1,State Treasurer,,D,Carmen Alldritt,16,RI30
-Riley,W11P1,State Treasurer,,D,Carmen Alldritt,49,RI31
-Riley,W11P1B,State Treasurer,,D,Carmen Alldritt,36,RI32
-Riley,W11P3,State Treasurer,,D,Carmen Alldritt,3,RI33
-Riley,Ashland,State Treasurer,,D,Carmen Alldritt,33,RI34
-Riley,Bala,State Treasurer,,D,Carmen Alldritt,48,RI35
-Riley,Center,State Treasurer,,D,Carmen Alldritt,2,RI36
-Riley,Fancy Creek,State Treasurer,,D,Carmen Alldritt,5,RI37
-Riley,Grant ,State Treasurer,,D,Carmen Alldritt,142,RI38
-Riley,Jackson,State Treasurer,,D,Carmen Alldritt,23,RI39
-Riley,Madison H64,State Treasurer,,D,Carmen Alldritt,99,RI40
-Riley,Madison H67,State Treasurer,,D,Carmen Alldritt,3,RI41
-Riley,Man twp 1,State Treasurer,,D,Carmen Alldritt,54,RI42
-Riley,Man twp 2,State Treasurer,,D,Carmen Alldritt,83,RI43
-Riley,Man twp 3,State Treasurer,,D,Carmen Alldritt,27,RI44
-Riley,Man twp 4,State Treasurer,,D,Carmen Alldritt,62,RI45
-Riley,May Day,State Treasurer,,D,Carmen Alldritt,1,RI46
-Riley,Ogden,State Treasurer,,D,Carmen Alldritt,26,RI47
-Riley,Ogden/Ft Ril,State Treasurer,,D,Carmen Alldritt,69,RI48
-Riley,Sherman,State Treasurer,,D,Carmen Alldritt,48,RI49
-Riley,Swede Creek,State Treasurer,,D,Carmen Alldritt,17,RI50
-Riley,Wildcat,State Treasurer,,D,Carmen Alldritt,71,RI51
-Riley,Zeandale,State Treasurer,,D,Carmen Alldritt,41,RI52
-Riley,Mad/Ft Ril A,State Treasurer,,D,Carmen Alldritt,4,RI53
-Riley,Mad/Ft Ril B,State Treasurer,,D,Carmen Alldritt,3,RI54
-Riley,W1P1,State Treasurer,,R,Ron Estes,204,RI01
-Riley,W2P1,State Treasurer,,R,Ron Estes,158,RI02
-Riley,W2P2,State Treasurer,,R,Ron Estes,80,RI03
-Riley,W2P3,State Treasurer,,R,Ron Estes,492,RI04
-Riley,W2P4,State Treasurer,,R,Ron Estes,274,RI05
-Riley,W3P2,State Treasurer,,R,Ron Estes,71,RI06
-Riley,W3P3,State Treasurer,,R,Ron Estes,285,RI07
-Riley,W4P2,State Treasurer,,R,Ron Estes,110,RI08
-Riley,W4P3,State Treasurer,,R,Ron Estes,233,RI09
-Riley,W4P4,State Treasurer,,R,Ron Estes,543,RI10
-Riley,W4P5,State Treasurer,,R,Ron Estes,288,RI11
-Riley,W4P6,State Treasurer,,R,Ron Estes,177,RI12
-Riley,W4P7,State Treasurer,,R,Ron Estes,11,RI13
-Riley,W5P2,State Treasurer,,R,Ron Estes,177,RI14
-Riley,W5P3,State Treasurer,,R,Ron Estes,210,RI15
-Riley,W5P5,State Treasurer,,R,Ron Estes,156,RI16
-Riley,W5P6,State Treasurer,,R,Ron Estes,401,RI17
-Riley,W5P7,State Treasurer,,R,Ron Estes,149,RI18
-Riley,W5P8,State Treasurer,,R,Ron Estes,250,RI19
-Riley,W5P9,State Treasurer,,R,Ron Estes,639,RI20
-Riley,W5P10,State Treasurer,,R,Ron Estes,626,RI21
-Riley,W5P11,State Treasurer,,R,Ron Estes,640,RI22
-Riley,W6P1,State Treasurer,,R,Ron Estes,2,RI23
-Riley,W8P1,State Treasurer,,R,Ron Estes,77,RI24
-Riley,W8P2,State Treasurer,,R,Ron Estes,1,RI25
-Riley,W8P3,State Treasurer,,R,Ron Estes,92,RI26
-Riley,W9P1,State Treasurer,,R,Ron Estes,59,RI27
-Riley,W9P2,State Treasurer,,R,Ron Estes,67,RI28
-Riley,W9P3,State Treasurer,,R,Ron Estes,27,RI29
-Riley,W10P1,State Treasurer,,R,Ron Estes,17,RI30
-Riley,W11P1,State Treasurer,,R,Ron Estes,61,RI31
-Riley,W11P1B,State Treasurer,,R,Ron Estes,63,RI32
-Riley,W11P3,State Treasurer,,R,Ron Estes,18,RI33
-Riley,Ashland,State Treasurer,,R,Ron Estes,62,RI34
-Riley,Bala,State Treasurer,,R,Ron Estes,215,RI35
-Riley,Center,State Treasurer,,R,Ron Estes,36,RI36
-Riley,Fancy Creek,State Treasurer,,R,Ron Estes,51,RI37
-Riley,Grant ,State Treasurer,,R,Ron Estes,368,RI38
-Riley,Jackson,State Treasurer,,R,Ron Estes,104,RI39
-Riley,Madison H64,State Treasurer,,R,Ron Estes,297,RI40
-Riley,Madison H67,State Treasurer,,R,Ron Estes,12,RI41
-Riley,Man twp 1,State Treasurer,,R,Ron Estes,181,RI42
-Riley,Man twp 2,State Treasurer,,R,Ron Estes,172,RI43
-Riley,Man twp 3,State Treasurer,,R,Ron Estes,60,RI44
-Riley,Man twp 4,State Treasurer,,R,Ron Estes,155,RI45
-Riley,May Day,State Treasurer,,R,Ron Estes,33,RI46
-Riley,Ogden,State Treasurer,,R,Ron Estes,134,RI47
-Riley,Ogden/Ft Ril,State Treasurer,,R,Ron Estes,173,RI48
-Riley,Sherman,State Treasurer,,R,Ron Estes,189,RI49
-Riley,Swede Creek,State Treasurer,,R,Ron Estes,40,RI50
-Riley,Wildcat,State Treasurer,,R,Ron Estes,340,RI51
-Riley,Zeandale,State Treasurer,,R,Ron Estes,137,RI52
-Riley,Mad/Ft Ril A,State Treasurer,,R,Ron Estes,5,RI53
-Riley,Mad/Ft Ril B,State Treasurer,,R,Ron Estes,5,RI54
-Riley,W1P1,U.S. House,1,D,James E. Sherow,148,RI01
-Riley,W2P1,U.S. House,1,D,James E. Sherow,114,RI02
-Riley,W2P2,U.S. House,1,D,James E. Sherow,56,RI03
-Riley,W2P3,U.S. House,1,D,James E. Sherow,365,RI04
-Riley,W2P4,U.S. House,1,D,James E. Sherow,193,RI05
-Riley,W3P2,U.S. House,1,D,James E. Sherow,70,RI06
-Riley,W3P3,U.S. House,1,D,James E. Sherow,215,RI07
-Riley,W4P2,U.S. House,1,D,James E. Sherow,84,RI08
-Riley,W4P3,U.S. House,1,D,James E. Sherow,171,RI09
-Riley,W4P4,U.S. House,1,D,James E. Sherow,412,RI10
-Riley,W4P5,U.S. House,1,D,James E. Sherow,231,RI11
-Riley,W4P6,U.S. House,1,D,James E. Sherow,142,RI12
-Riley,W4P7,U.S. House,1,D,James E. Sherow,8,RI13
-Riley,W5P2,U.S. House,1,D,James E. Sherow,133,RI14
-Riley,W5P3,U.S. House,1,D,James E. Sherow,162,RI15
-Riley,W5P5,U.S. House,1,D,James E. Sherow,111,RI16
-Riley,W5P6,U.S. House,1,D,James E. Sherow,310,RI17
-Riley,W5P7,U.S. House,1,D,James E. Sherow,101,RI18
-Riley,W5P8,U.S. House,1,D,James E. Sherow,171,RI19
-Riley,W5P9,U.S. House,1,D,James E. Sherow,442,RI20
-Riley,W5P10,U.S. House,1,D,James E. Sherow,437,RI21
-Riley,W5P11,U.S. House,1,D,James E. Sherow,476,RI22
-Riley,W6P1,U.S. House,1,D,James E. Sherow,2,RI23
-Riley,W8P1,U.S. House,1,D,James E. Sherow,64,RI24
-Riley,W8P2,U.S. House,1,D,James E. Sherow,0,RI25
-Riley,W8P3,U.S. House,1,D,James E. Sherow,75,RI26
-Riley,W9P1,U.S. House,1,D,James E. Sherow,43,RI27
-Riley,W9P2,U.S. House,1,D,James E. Sherow,41,RI28
-Riley,W9P3,U.S. House,1,D,James E. Sherow,17,RI29
-Riley,W10P1,U.S. House,1,D,James E. Sherow,14,RI30
-Riley,W11P1,U.S. House,1,D,James E. Sherow,51,RI31
-Riley,W11P1B,U.S. House,1,D,James E. Sherow,52,RI32
-Riley,W11P3,U.S. House,1,D,James E. Sherow,11,RI33
-Riley,Ashland,U.S. House,1,D,James E. Sherow,47,RI34
-Riley,Bala,U.S. House,1,D,James E. Sherow,191,RI35
-Riley,Center,U.S. House,1,D,James E. Sherow,32,RI36
-Riley,Fancy Creek,U.S. House,1,D,James E. Sherow,46,RI37
-Riley,Grant ,U.S. House,1,D,James E. Sherow,304,RI38
-Riley,Jackson,U.S. House,1,D,James E. Sherow,82,RI39
-Riley,Madison H64,U.S. House,1,D,James E. Sherow,239,RI40
-Riley,Madison H67,U.S. House,1,D,James E. Sherow,12,RI41
-Riley,Man twp 1,U.S. House,1,D,James E. Sherow,149,RI42
-Riley,Man twp 2,U.S. House,1,D,James E. Sherow,121,RI43
-Riley,Man twp 3,U.S. House,1,D,James E. Sherow,51,RI44
-Riley,Man twp 4,U.S. House,1,D,James E. Sherow,125,RI45
-Riley,May Day,U.S. House,1,D,James E. Sherow,29,RI46
-Riley,Ogden,U.S. House,1,D,James E. Sherow,115,RI47
-Riley,Ogden/Ft Ril,U.S. House,1,D,James E. Sherow,149,RI48
-Riley,Sherman,U.S. House,1,D,James E. Sherow,160,RI49
-Riley,Swede Creek,U.S. House,1,D,James E. Sherow,32,RI50
-Riley,Wildcat,U.S. House,1,D,James E. Sherow,261,RI51
-Riley,Zeandale,U.S. House,1,D,James E. Sherow,109,RI52
-Riley,Mad/Ft Ril A,U.S. House,1,D,James E. Sherow,6,RI53
-Riley,Mad/Ft Ril B,U.S. House,1,D,James E. Sherow,5,RI54
-Riley,W1P1,U.S. House,1,R,Tim Huelskamp,324,RI01
-Riley,W2P1,U.S. House,1,R,Tim Huelskamp,289,RI02
-Riley,W2P2,U.S. House,1,R,Tim Huelskamp,137,RI03
-Riley,W2P3,U.S. House,1,R,Tim Huelskamp,476,RI04
-Riley,W2P4,U.S. House,1,R,Tim Huelskamp,261,RI05
-Riley,W3P2,U.S. House,1,R,Tim Huelskamp,124,RI06
-Riley,W3P3,U.S. House,1,R,Tim Huelskamp,287,RI07
-Riley,W4P2,U.S. House,1,R,Tim Huelskamp,121,RI08
-Riley,W4P3,U.S. House,1,R,Tim Huelskamp,323,RI09
-Riley,W4P4,U.S. House,1,R,Tim Huelskamp,528,RI10
-Riley,W4P5,U.S. House,1,R,Tim Huelskamp,257,RI11
-Riley,W4P6,U.S. House,1,R,Tim Huelskamp,98,RI12
-Riley,W4P7,U.S. House,1,R,Tim Huelskamp,5,RI13
-Riley,W5P2,U.S. House,1,R,Tim Huelskamp,317,RI14
-Riley,W5P3,U.S. House,1,R,Tim Huelskamp,289,RI15
-Riley,W5P5,U.S. House,1,R,Tim Huelskamp,145,RI16
-Riley,W5P6,U.S. House,1,R,Tim Huelskamp,312,RI17
-Riley,W5P7,U.S. House,1,R,Tim Huelskamp,148,RI18
-Riley,W5P8,U.S. House,1,R,Tim Huelskamp,212,RI19
-Riley,W5P9,U.S. House,1,R,Tim Huelskamp,564,RI20
-Riley,W5P10,U.S. House,1,R,Tim Huelskamp,533,RI21
-Riley,W5P11,U.S. House,1,R,Tim Huelskamp,521,RI22
-Riley,W6P1,U.S. House,1,R,Tim Huelskamp,0,RI23
-Riley,W8P1,U.S. House,1,R,Tim Huelskamp,74,RI24
-Riley,W8P2,U.S. House,1,R,Tim Huelskamp,1,RI25
-Riley,W8P3,U.S. House,1,R,Tim Huelskamp,88,RI26
-Riley,W9P1,U.S. House,1,R,Tim Huelskamp,47,RI27
-Riley,W9P2,U.S. House,1,R,Tim Huelskamp,75,RI28
-Riley,W9P3,U.S. House,1,R,Tim Huelskamp,20,RI29
-Riley,W10P1,U.S. House,1,R,Tim Huelskamp,20,RI30
-Riley,W11P1,U.S. House,1,R,Tim Huelskamp,65,RI31
-Riley,W11P1B,U.S. House,1,R,Tim Huelskamp,48,RI32
-Riley,W11P3,U.S. House,1,R,Tim Huelskamp,11,RI33
-Riley,Ashland,U.S. House,1,R,Tim Huelskamp,51,RI34
-Riley,Bala,U.S. House,1,R,Tim Huelskamp,74,RI35
-Riley,Center,U.S. House,1,R,Tim Huelskamp,7,RI36
-Riley,Fancy Creek,U.S. House,1,R,Tim Huelskamp,10,RI37
-Riley,Grant ,U.S. House,1,R,Tim Huelskamp,218,RI38
-Riley,Jackson,U.S. House,1,R,Tim Huelskamp,45,RI39
-Riley,Madison H64,U.S. House,1,R,Tim Huelskamp,162,RI40
-Riley,Madison H67,U.S. House,1,R,Tim Huelskamp,3,RI41
-Riley,Man twp 1,U.S. House,1,R,Tim Huelskamp,92,RI42
-Riley,Man twp 2,U.S. House,1,R,Tim Huelskamp,138,RI43
-Riley,Man twp 3,U.S. House,1,R,Tim Huelskamp,38,RI44
-Riley,Man twp 4,U.S. House,1,R,Tim Huelskamp,91,RI45
-Riley,May Day,U.S. House,1,R,Tim Huelskamp,6,RI46
-Riley,Ogden,U.S. House,1,R,Tim Huelskamp,45,RI47
-Riley,Ogden/Ft Ril,U.S. House,1,R,Tim Huelskamp,98,RI48
-Riley,Sherman,U.S. House,1,R,Tim Huelskamp,82,RI49
-Riley,Swede Creek,U.S. House,1,R,Tim Huelskamp,27,RI50
-Riley,Wildcat,U.S. House,1,R,Tim Huelskamp,155,RI51
-Riley,Zeandale,U.S. House,1,R,Tim Huelskamp,69,RI52
-Riley,Mad/Ft Ril A,U.S. House,1,R,Tim Huelskamp,4,RI53
-Riley,Mad/Ft Ril B,U.S. House,1,R,Tim Huelskamp,3,RI54
-Riley,W1P1,U.S. Senate,,I,Greg Orman,295,RI01
-Riley,W2P1,U.S. Senate,,I,Greg Orman,279,RI02
-Riley,W2P2,U.S. Senate,,I,Greg Orman,131,RI03
-Riley,W2P3,U.S. Senate,,I,Greg Orman,412,RI04
-Riley,W2P4,U.S. Senate,,I,Greg Orman,216,RI05
-Riley,W3P2,U.S. Senate,,I,Greg Orman,133,RI06
-Riley,W3P3,U.S. Senate,,I,Greg Orman,246,RI07
-Riley,W4P2,U.S. Senate,,I,Greg Orman,107,RI08
-Riley,W4P3,U.S. Senate,,I,Greg Orman,310,RI09
-Riley,W4P4,U.S. Senate,,I,Greg Orman,463,RI10
-Riley,W4P5,U.S. Senate,,I,Greg Orman,228,RI11
-Riley,W4P6,U.S. Senate,,I,Greg Orman,86,RI12
-Riley,W4P7,U.S. Senate,,I,Greg Orman,4,RI13
-Riley,W5P2,U.S. Senate,,I,Greg Orman,306,RI14
-Riley,W5P3,U.S. Senate,,I,Greg Orman,265,RI15
-Riley,W5P5,U.S. Senate,,I,Greg Orman,129,RI16
-Riley,W5P6,U.S. Senate,,I,Greg Orman,273,RI17
-Riley,W5P7,U.S. Senate,,I,Greg Orman,127,RI18
-Riley,W5P8,U.S. Senate,,I,Greg Orman,176,RI19
-Riley,W5P9,U.S. Senate,,I,Greg Orman,488,RI20
-Riley,W5P10,U.S. Senate,,I,Greg Orman,428,RI21
-Riley,W5P11,U.S. Senate,,I,Greg Orman,432,RI22
-Riley,W6P1,U.S. Senate,,I,Greg Orman,0,RI23
-Riley,W8P1,U.S. Senate,,I,Greg Orman,74,RI24
-Riley,W8P2,U.S. Senate,,I,Greg Orman,1,RI25
-Riley,W8P3,U.S. Senate,,I,Greg Orman,85,RI26
-Riley,W9P1,U.S. Senate,,I,Greg Orman,42,RI27
-Riley,W9P2,U.S. Senate,,I,Greg Orman,64,RI28
-Riley,W9P3,U.S. Senate,,I,Greg Orman,15,RI29
-Riley,W10P1,U.S. Senate,,I,Greg Orman,17,RI30
-Riley,W11P1,U.S. Senate,,I,Greg Orman,63,RI31
-Riley,W11P1B,U.S. Senate,,I,Greg Orman,42,RI32
-Riley,W11P3,U.S. Senate,,I,Greg Orman,3,RI33
-Riley,Ashland,U.S. Senate,,I,Greg Orman,46,RI34
-Riley,Bala,U.S. Senate,,I,Greg Orman,64,RI35
-Riley,Center,U.S. Senate,,I,Greg Orman,8,RI36
-Riley,Fancy Creek,U.S. Senate,,I,Greg Orman,7,RI37
-Riley,Grant ,U.S. Senate,,I,Greg Orman,187,RI38
-Riley,Jackson,U.S. Senate,,I,Greg Orman,43,RI39
-Riley,Madison H64,U.S. Senate,,I,Greg Orman,150,RI40
-Riley,Madison H67,U.S. Senate,,I,Greg Orman,1,RI41
-Riley,Man twp 1,U.S. Senate,,I,Greg Orman,79,RI42
-Riley,Man twp 2,U.S. Senate,,I,Greg Orman,118,RI43
-Riley,Man twp 3,U.S. Senate,,I,Greg Orman,35,RI44
-Riley,Man twp 4,U.S. Senate,,I,Greg Orman,81,RI45
-Riley,May Day,U.S. Senate,,I,Greg Orman,3,RI46
-Riley,Ogden,U.S. Senate,,I,Greg Orman,36,RI47
-Riley,Ogden/Ft Ril,U.S. Senate,,I,Greg Orman,95,RI48
-Riley,Sherman,U.S. Senate,,I,Greg Orman,70,RI49
-Riley,Swede Creek,U.S. Senate,,I,Greg Orman,25,RI50
-Riley,Wildcat,U.S. Senate,,I,Greg Orman,120,RI51
-Riley,Zeandale,U.S. Senate,,I,Greg Orman,64,RI52
-Riley,Mad/Ft Ril A,U.S. Senate,,I,Greg Orman,5,RI53
-Riley,Mad/Ft Ril B,U.S. Senate,,I,Greg Orman,5,RI54
-Riley,W1P1,U.S. Senate,,L,Randall Batson,19,RI01
-Riley,W2P1,U.S. Senate,,L,Randall Batson,13,RI02
-Riley,W2P2,U.S. Senate,,L,Randall Batson,9,RI03
-Riley,W2P3,U.S. Senate,,L,Randall Batson,52,RI04
-Riley,W2P4,U.S. Senate,,L,Randall Batson,26,RI05
-Riley,W3P2,U.S. Senate,,L,Randall Batson,6,RI06
-Riley,W3P3,U.S. Senate,,L,Randall Batson,13,RI07
-Riley,W4P2,U.S. Senate,,L,Randall Batson,5,RI08
-Riley,W4P3,U.S. Senate,,L,Randall Batson,14,RI09
-Riley,W4P4,U.S. Senate,,L,Randall Batson,21,RI10
-Riley,W4P5,U.S. Senate,,L,Randall Batson,26,RI11
-Riley,W4P6,U.S. Senate,,L,Randall Batson,2,RI12
-Riley,W4P7,U.S. Senate,,L,Randall Batson,1,RI13
-Riley,W5P2,U.S. Senate,,L,Randall Batson,10,RI14
-Riley,W5P3,U.S. Senate,,L,Randall Batson,14,RI15
-Riley,W5P5,U.S. Senate,,L,Randall Batson,10,RI16
-Riley,W5P6,U.S. Senate,,L,Randall Batson,23,RI17
-Riley,W5P7,U.S. Senate,,L,Randall Batson,4,RI18
-Riley,W5P8,U.S. Senate,,L,Randall Batson,7,RI19
-Riley,W5P9,U.S. Senate,,L,Randall Batson,5,RI20
-Riley,W5P10,U.S. Senate,,L,Randall Batson,20,RI21
-Riley,W5P11,U.S. Senate,,L,Randall Batson,26,RI22
-Riley,W6P1,U.S. Senate,,L,Randall Batson,0,RI23
-Riley,W8P1,U.S. Senate,,L,Randall Batson,5,RI24
-Riley,W8P2,U.S. Senate,,L,Randall Batson,0,RI25
-Riley,W8P3,U.S. Senate,,L,Randall Batson,7,RI26
-Riley,W9P1,U.S. Senate,,L,Randall Batson,0,RI27
-Riley,W9P2,U.S. Senate,,L,Randall Batson,2,RI28
-Riley,W9P3,U.S. Senate,,L,Randall Batson,1,RI29
-Riley,W10P1,U.S. Senate,,L,Randall Batson,0,RI30
-Riley,W11P1,U.S. Senate,,L,Randall Batson,4,RI31
-Riley,W11P1B,U.S. Senate,,L,Randall Batson,7,RI32
-Riley,W11P3,U.S. Senate,,L,Randall Batson,2,RI33
-Riley,Ashland,U.S. Senate,,L,Randall Batson,4,RI34
-Riley,Bala,U.S. Senate,,L,Randall Batson,13,RI35
-Riley,Center,U.S. Senate,,L,Randall Batson,0,RI36
-Riley,Fancy Creek,U.S. Senate,,L,Randall Batson,1,RI37
-Riley,Grant ,U.S. Senate,,L,Randall Batson,15,RI38
-Riley,Jackson,U.S. Senate,,L,Randall Batson,6,RI39
-Riley,Madison H64,U.S. Senate,,L,Randall Batson,14,RI40
-Riley,Madison H67,U.S. Senate,,L,Randall Batson,0,RI41
-Riley,Man twp 1,U.S. Senate,,L,Randall Batson,5,RI42
-Riley,Man twp 2,U.S. Senate,,L,Randall Batson,17,RI43
-Riley,Man twp 3,U.S. Senate,,L,Randall Batson,3,RI44
-Riley,Man twp 4,U.S. Senate,,L,Randall Batson,9,RI45
-Riley,May Day,U.S. Senate,,L,Randall Batson,1,RI46
-Riley,Ogden,U.S. Senate,,L,Randall Batson,4,RI47
-Riley,Ogden/Ft Ril,U.S. Senate,,L,Randall Batson,20,RI48
-Riley,Sherman,U.S. Senate,,L,Randall Batson,5,RI49
-Riley,Swede Creek,U.S. Senate,,L,Randall Batson,1,RI50
-Riley,Wildcat,U.S. Senate,,L,Randall Batson,8,RI51
-Riley,Zeandale,U.S. Senate,,L,Randall Batson,7,RI52
-Riley,Mad/Ft Ril A,U.S. Senate,,L,Randall Batson,1,RI53
-Riley,Mad/Ft Ril B,U.S. Senate,,L,Randall Batson,0,RI54
-Riley,W1P1,U.S. Senate,,R,Pat Roberts,162,RI01
-Riley,W2P1,U.S. Senate,,R,Pat Roberts,116,RI02
-Riley,W2P2,U.S. Senate,,R,Pat Roberts,52,RI03
-Riley,W2P3,U.S. Senate,,R,Pat Roberts,385,RI04
-Riley,W2P4,U.S. Senate,,R,Pat Roberts,213,RI05
-Riley,W3P2,U.S. Senate,,R,Pat Roberts,60,RI06
-Riley,W3P3,U.S. Senate,,R,Pat Roberts,245,RI07
-Riley,W4P2,U.S. Senate,,R,Pat Roberts,89,RI08
-Riley,W4P3,U.S. Senate,,R,Pat Roberts,177,RI09
-Riley,W4P4,U.S. Senate,,R,Pat Roberts,463,RI10
-Riley,W4P5,U.S. Senate,,R,Pat Roberts,234,RI11
-Riley,W4P6,U.S. Senate,,R,Pat Roberts,154,RI12
-Riley,W4P7,U.S. Senate,,R,Pat Roberts,9,RI13
-Riley,W5P2,U.S. Senate,,R,Pat Roberts,137,RI14
-Riley,W5P3,U.S. Senate,,R,Pat Roberts,179,RI15
-Riley,W5P5,U.S. Senate,,R,Pat Roberts,120,RI16
-Riley,W5P6,U.S. Senate,,R,Pat Roberts,331,RI17
-Riley,W5P7,U.S. Senate,,R,Pat Roberts,117,RI18
-Riley,W5P8,U.S. Senate,,R,Pat Roberts,202,RI19
-Riley,W5P9,U.S. Senate,,R,Pat Roberts,524,RI20
-Riley,W5P10,U.S. Senate,,R,Pat Roberts,535,RI21
-Riley,W5P11,U.S. Senate,,R,Pat Roberts,548,RI22
-Riley,W6P1,U.S. Senate,,R,Pat Roberts,2,RI23
-Riley,W8P1,U.S. Senate,,R,Pat Roberts,60,RI24
-Riley,W8P2,U.S. Senate,,R,Pat Roberts,0,RI25
-Riley,W8P3,U.S. Senate,,R,Pat Roberts,69,RI26
-Riley,W9P1,U.S. Senate,,R,Pat Roberts,49,RI27
-Riley,W9P2,U.S. Senate,,R,Pat Roberts,50,RI28
-Riley,W9P3,U.S. Senate,,R,Pat Roberts,20,RI29
-Riley,W10P1,U.S. Senate,,R,Pat Roberts,16,RI30
-Riley,W11P1,U.S. Senate,,R,Pat Roberts,50,RI31
-Riley,W11P1B,U.S. Senate,,R,Pat Roberts,50,RI32
-Riley,W11P3,U.S. Senate,,R,Pat Roberts,17,RI33
-Riley,Ashland,U.S. Senate,,R,Pat Roberts,47,RI34
-Riley,Bala,U.S. Senate,,R,Pat Roberts,188,RI35
-Riley,Center,U.S. Senate,,R,Pat Roberts,31,RI36
-Riley,Fancy Creek,U.S. Senate,,R,Pat Roberts,49,RI37
-Riley,Grant ,U.S. Senate,,R,Pat Roberts,325,RI38
-Riley,Jackson,U.S. Senate,,R,Pat Roberts,80,RI39
-Riley,Madison H64,U.S. Senate,,R,Pat Roberts,242,RI40
-Riley,Madison H67,U.S. Senate,,R,Pat Roberts,14,RI41
-Riley,Man twp 1,U.S. Senate,,R,Pat Roberts,158,RI42
-Riley,Man twp 2,U.S. Senate,,R,Pat Roberts,123,RI43
-Riley,Man twp 3,U.S. Senate,,R,Pat Roberts,52,RI44
-Riley,Man twp 4,U.S. Senate,,R,Pat Roberts,131,RI45
-Riley,May Day,U.S. Senate,,R,Pat Roberts,31,RI46
-Riley,Ogden,U.S. Senate,,R,Pat Roberts,123,RI47
-Riley,Ogden/Ft Ril,U.S. Senate,,R,Pat Roberts,137,RI48
-Riley,Sherman,U.S. Senate,,R,Pat Roberts,169,RI49
-Riley,Swede Creek,U.S. Senate,,R,Pat Roberts,36,RI50
-Riley,Wildcat,U.S. Senate,,R,Pat Roberts,292,RI51
-Riley,Zeandale,U.S. Senate,,R,Pat Roberts,108,RI52
-Riley,Mad/Ft Ril A,U.S. Senate,,R,Pat Roberts,5,RI53
-Riley,Mad/Ft Ril B,U.S. Senate,,R,Pat Roberts,3,RI54
-Riley,W1P1,Voters,,,Registered,1234,RI01
-Riley,W2P1,Voters,,,Registered,1346,RI02
-Riley,W2P2,Voters,,,Registered,524,RI03
-Riley,W2P3,Voters,,,Registered,1862,RI04
-Riley,W2P4,Voters,,,Registered,1112,RI05
-Riley,W3P2,Voters,,,Registered,906,RI06
-Riley,W3P3,Voters,,,Registered,1603,RI07
-Riley,W4P2,Voters,,,Registered,334,RI08
-Riley,W4P3,Voters,,,Registered,961,RI09
-Riley,W4P4,Voters,,,Registered,1648,RI10
-Riley,W4P5,Voters,,,Registered,992,RI11
-Riley,W4P6,Voters,,,Registered,431,RI12
-Riley,W4P7,Voters,,,Registered,52,RI13
-Riley,W5P2,Voters,,,Registered,1210,RI14
-Riley,W5P3,Voters,,,Registered,1388,RI15
-Riley,W5P5,Voters,,,Registered,634,RI16
-Riley,W5P6,Voters,,,Registered,1066,RI17
-Riley,W5P7,Voters,,,Registered,472,RI18
-Riley,W5P8,Voters,,,Registered,672,RI19
-Riley,W5P9,Voters,,,Registered,1656,RI20
-Riley,W5P10,Voters,,,Registered,1658,RI21
-Riley,W5P11,Voters,,,Registered,1958,RI22
-Riley,W6P1,Voters,,,Registered,49,RI23
-Riley,W8P1,Voters,,,Registered,438,RI24
-Riley,W8P2,Voters,,,Registered,8,RI25
-Riley,W8P3,Voters,,,Registered,640,RI26
-Riley,W9P1,Voters,,,Registered,165,RI27
-Riley,W9P2,Voters,,,Registered,149,RI28
-Riley,W9P3,Voters,,,Registered,67,RI29
-Riley,W10P1,Voters,,,Registered,65,RI30
-Riley,W11P1,Voters,,,Registered,449,RI31
-Riley,W11P1B,Voters,,,Registered,259,RI32
-Riley,W11P3,Voters,,,Registered,50,RI33
-Riley,Ashland,Voters,,,Registered,117,RI34
-Riley,Bala,Voters,,,Registered,445,RI35
-Riley,Center,Voters,,,Registered,54,RI36
-Riley,Fancy Creek,Voters,,,Registered,73,RI37
-Riley,Grant ,Voters,,,Registered,731,RI38
-Riley,Jackson,Voters,,,Registered,221,RI39
-Riley,Madison H64,Voters,,,Registered,718,RI40
-Riley,Madison H67,Voters,,,Registered,24,RI41
-Riley,Man twp 1,Voters,,,Registered,417,RI42
-Riley,Man twp 2,Voters,,,Registered,395,RI43
-Riley,Man twp 3,Voters,,,Registered,150,RI44
-Riley,Man twp 4,Voters,,,Registered,530,RI45
-Riley,May Day,Voters,,,Registered,53,RI46
-Riley,Ogden,Voters,,,Registered,292,RI47
-Riley,Ogden/Ft Ril A,Voters,,,Registered,929,RI48
-Riley,Sherman,Voters,,,Registered,421,RI49
-Riley,Swede Creek,Voters,,,Registered,93,RI50
-Riley,Wildcat,Voters,,,Registered,636,RI51
-Riley,Zeandale,Voters,,,Registered,274,RI52
-Riley,Mad/Ft Ril A,Voters,,,Registered,602,RI53
-Riley,Mad/Ft Ril B,Voters,,,Registered,340,RI54
-Riley,W1P1,Voters,,,Cast,482,RI01
-Riley,W2P1,Voters,,,Cast,404,RI02
-Riley,W2P2,Voters,,,Cast,193,RI03
-Riley,W2P3,Voters,,,Cast,856,RI04
-Riley,W2P4,Voters,,,Cast,461,RI05
-Riley,W3P2,Voters,,,Cast,198,RI06
-Riley,W3P3,Voters,,,Cast,507,RI07
-Riley,W4P2,Voters,,,Cast,207,RI08
-Riley,W4P3,Voters,,,Cast,499,RI09
-Riley,W4P4,Voters,,,Cast,955,RI10
-Riley,W4P5,Voters,,,Cast,492,RI11
-Riley,W4P6,Voters,,,Cast,243,RI12
-Riley,W4P7,Voters,,,Cast,14,RI13
-Riley,W5P2,Voters,,,Cast,454,RI14
-Riley,W5P3,Voters,,,Cast,452,RI15
-Riley,W5P5,Voters,,,Cast,255,RI16
-Riley,W5P6,Voters,,,Cast,629,RI17
-Riley,W5P7,Voters,,,Cast,247,RI18
-Riley,W5P8,Voters,,,Cast,389,RI19
-Riley,W5P9,Voters,,,Cast,1018,RI20
-Riley,W5P10,Voters,,,Cast,981,RI21
-Riley,W5P11,Voters,,,Cast,1008,RI22
-Riley,W6P1,Voters,,,Cast,2,RI23
-Riley,W8P1,Voters,,,Cast,139,RI24
-Riley,W8P2,Voters,,,Cast,1,RI25
-Riley,W8P3,Voters,,,Cast,163,RI26
-Riley,W9P1,Voters,,,Cast,92,RI27
-Riley,W9P2,Voters,,,Cast,116,RI28
-Riley,W9P3,Voters,,,Cast,37,RI29
-Riley,W10P1,Voters,,,Cast,34,RI30
-Riley,W11P1,Voters,,,Cast,119,RI31
-Riley,W11P1B,Voters,,,Cast,100,RI32
-Riley,W11P3,Voters,,,Cast,22,RI33
-Riley,Ashland,Voters,,,Cast,99,RI34
-Riley,Bala,Voters,,,Cast,270,RI35
-Riley,Center,Voters,,,Cast,40,RI36
-Riley,Fancy Creek,Voters,,,Cast,57,RI37
-Riley,Grant ,Voters,,,Cast,524,RI38
-Riley,Jackson,Voters,,,Cast,129,RI39
-Riley,Madison H64,Voters,,,Cast,406,RI40
-Riley,Madison H67,Voters,,,Cast,15,RI41
-Riley,Man twp 1,Voters,,,Cast,242,RI42
-Riley,Man twp 2,Voters,,,Cast,263,RI43
-Riley,Man twp 3,Voters,,,Cast,91,RI44
-Riley,Man twp 4,Voters,,,Cast,223,RI45
-Riley,May Day,Voters,,,Cast,35,RI46
-Riley,Ogden,Voters,,,Cast,163,RI47
-Riley,Ogden/Ft Ril A,Voters,,,Cast,252,RI48
-Riley,Sherman,Voters,,,Cast,245,RI49
-Riley,Swede Creek,Voters,,,Cast,62,RI50
-Riley,Wildcat,Voters,,,Cast,421,RI51
-Riley,Zeandale,Voters,,,Cast,181,RI52
-Riley,Mad/Ft Ril A,Voters,,,Cast,11,RI53
-Riley,Mad/Ft Ril B,Voters,,,Cast,8,RI54
-Riley,W1P1,U.S. Senate,,,Write-ins,2,RI01
-Riley,W1P1,U.S. House,1,,Write-ins,1,RI01
-Riley,W1P1,Governor,,,Write-ins,2,RI01
-Riley,W1P1,Secretary of State,,,Write-ins,2,RI01
-Riley,W1P1,Attorney General,,,Write-ins,1,RI01
-Riley,W1P1,State Treasurer,,,Write-ins,2,RI01
-Riley,W1P1,Insurance Commissioner,,,Write-ins,1,RI01
-Riley,W2P1,U.S. Senate,,,Write-ins,1,RI02
-Riley,W2P1,U.S. House,1,,Write-ins,1,RI02
-Riley,W2P1,Governor,,,Write-ins,1,RI02
-Riley,W2P1,Secretary of State,,,Write-ins,0,RI02
-Riley,W2P1,Attorney General,,,Write-ins,4,RI02
-Riley,W2P1,State Treasurer,,,Write-ins,1,RI02
-Riley,W2P1,Insurance Commissioner,,,Write-ins,1,RI02
-Riley,W2P3,U.S. Senate,,,Write-ins,2,RI03
-Riley,W2P3,U.S. House,1,,Write-ins,3,RI03
-Riley,W2P3,Governor,,,Write-ins,1,RI03
-Riley,W2P3,Secretary of State,,,Write-ins,2,RI03
-Riley,W2P3,Attorney General,,,Write-ins,1,RI03
-Riley,W2P3,State Treasurer,,,Write-ins,0,RI03
-Riley,W2P3,Insurance Commissioner,,,Write-ins,0,RI03
-Riley,W2P4,U.S. Senate,,,Write-ins,2,RI05
-Riley,W2P4,U.S. House,1,,Write-ins,1,RI05
-Riley,W2P4,Governor,,,Write-ins,0,RI05
-Riley,W2P4,Secretary of State,,,Write-ins,1,RI05
-Riley,W2P4,Attorney General,,,Write-ins,1,RI05
-Riley,W2P4,State Treasurer,,,Write-ins,1,RI05
-Riley,W2P4,Insurance Commissioner,,,Write-ins,0,RI05
-Riley,W3P2,U.S. Senate,,,Write-ins,0,RI06
-Riley,W3P2,U.S. House,1,,Write-ins,0,RI06
-Riley,W3P2,Governor,,,Write-ins,1,RI06
-Riley,W3P2,Secretary of State,,,Write-ins,0,RI06
-Riley,W3P2,Attorney General,,,Write-ins,0,RI06
-Riley,W3P2,State Treasurer,,,Write-ins,2,RI06
-Riley,W3P2,Insurance Commissioner,,,Write-ins,1,RI06
-Riley,W3P3,U.S. Senate,,,Write-ins,2,RI07
-Riley,W3P3,U.S. House,1,,Write-ins,1,RI07
-Riley,W3P3,Governor,,,Write-ins,0,RI07
-Riley,W3P3,Secretary of State,,,Write-ins,1,RI07
-Riley,W3P3,Attorney General,,,Write-ins,3,RI07
-Riley,W3P3,State Treasurer,,,Write-ins,2,RI07
-Riley,W3P3,Insurance Commissioner,,,Write-ins,2,RI07
-Riley,W4P2,U.S. Senate,,,Write-ins,1,RI08
-Riley,W4P2,U.S. House,1,,Write-ins,0,RI08
-Riley,W4P2,Governor,,,Write-ins,0,RI08
-Riley,W4P2,Secretary of State,,,Write-ins,0,RI08
-Riley,W4P2,Attorney General,,,Write-ins,0,RI08
-Riley,W4P2,State Treasurer,,,Write-ins,0,RI08
-Riley,W4P2,Insurance Commissioner,,,Write-ins,0,RI08
-Riley,W4P3,U.S. Senate,,,Write-ins,1,RI09
-Riley,W4P3,U.S. House,1,,Write-ins,1,RI09
-Riley,W4P3,Governor,,,Write-ins,2,RI09
-Riley,W4P3,Secretary of State,,,Write-ins,1,RI09
-Riley,W4P3,Attorney General,,,Write-ins,1,RI09
-Riley,W4P3,State Treasurer,,,Write-ins,0,RI09
-Riley,W4P3,Insurance Commissioner,,,Write-ins,1,RI09
-Riley,W4P4,U.S. Senate,,,Write-ins,5,RI10
-Riley,W4P4,U.S. House,1,,Write-ins,4,RI10
-Riley,W4P4,Governor,,,Write-ins,5,RI10
-Riley,W4P4,Secretary of State,,,Write-ins,3,RI10
-Riley,W4P4,Attorney General,,,Write-ins,4,RI10
-Riley,W4P4,State Treasurer,,,Write-ins,3,RI10
-Riley,W4P4,Insurance Commissioner,,,Write-ins,2,RI10
-Riley,W4P5,U.S. Senate,,,Write-ins,1,RI11
-Riley,W4P5,U.S. House,1,,Write-ins,0,RI11
-Riley,W4P5,Governor,,,Write-ins,0,RI11
-Riley,W4P5,Secretary of State,,,Write-ins,0,RI11
-Riley,W4P5,Attorney General,,,Write-ins,1,RI11
-Riley,W4P5,State Treasurer,,,Write-ins,0,RI11
-Riley,W4P5,Insurance Commissioner,,,Write-ins,0,RI11
-Riley,W5P2,U.S. Senate,,,Write-ins,1,RI14
-Riley,W5P2,U.S. House,1,,Write-ins,2,RI14
-Riley,W5P2,Governor,,,Write-ins,0,RI14
-Riley,W5P2,Secretary of State,,,Write-ins,0,RI14
-Riley,W5P2,Attorney General,,,Write-ins,0,RI14
-Riley,W5P2,State Treasurer,,,Write-ins,0,RI14
-Riley,W5P2,Insurance Commissioner,,,Write-ins,0,RI14
-Riley,W5P3,U.S. Senate,,,Write-ins,0,RI15
-Riley,W5P3,U.S. House,1,,Write-ins,1,RI15
-Riley,W5P3,Governor,,,Write-ins,1,RI15
-Riley,W5P3,Secretary of State,,,Write-ins,0,RI15
-Riley,W5P3,Attorney General,,,Write-ins,0,RI15
-Riley,W5P3,State Treasurer,,,Write-ins,0,RI15
-Riley,W5P3,Insurance Commissioner,,,Write-ins,0,RI15
-Riley,W5P6,U.S. Senate,,,Write-ins,1,RI17
-Riley,W5P6,U.S. House,1,,Write-ins,1,RI17
-Riley,W5P6,Governor,,,Write-ins,0,RI17
-Riley,W5P6,Secretary of State,,,Write-ins,0,RI17
-Riley,W5P6,Attorney General,,,Write-ins,0,RI17
-Riley,W5P6,State Treasurer,,,Write-ins,0,RI17
-Riley,W5P6,Insurance Commissioner,,,Write-ins,0,RI17
-Riley,W5P7,U.S. Senate,,,Write-ins,0,RI18
-Riley,W5P7,U.S. House,1,,Write-ins,0,RI18
-Riley,W5P7,Governor,,,Write-ins,0,RI18
-Riley,W5P7,Secretary of State,,,Write-ins,0,RI18
-Riley,W5P7,Attorney General,,,Write-ins,1,RI18
-Riley,W5P7,State Treasurer,,,Write-ins,1,RI18
-Riley,W5P7,Insurance Commissioner,,,Write-ins,1,RI18
-Riley,W5P8,U.S. Senate,,,Write-ins,1,RI19
-Riley,W5P8,U.S. House,1,,Write-ins,1,RI19
-Riley,W5P8,Governor,,,Write-ins,0,RI19
-Riley,W5P8,Secretary of State,,,Write-ins,0,RI19
-Riley,W5P8,Attorney General,,,Write-ins,1,RI19
-Riley,W5P8,State Treasurer,,,Write-ins,0,RI19
-Riley,W5P8,Insurance Commissioner,,,Write-ins,0,RI19
-Riley,W5P9,U.S. Senate,,,Write-ins,0,RI20
-Riley,W5P9,U.S. House,1,,Write-ins,2,RI20
-Riley,W5P9,Governor,,,Write-ins,0,RI20
-Riley,W5P9,Secretary of State,,,Write-ins,1,RI20
-Riley,W5P9,Attorney General,,,Write-ins,1,RI20
-Riley,W5P9,State Treasurer,,,Write-ins,1,RI20
-Riley,W5P9,Insurance Commissioner,,,Write-ins,2,RI20
-Riley,W5P10,U.S. Senate,,,Write-ins,0,RI21
-Riley,W5P10,U.S. House,1,,Write-ins,2,RI21
-Riley,W5P10,Governor,,,Write-ins,1,RI21
-Riley,W5P10,Secretary of State,,,Write-ins,0,RI21
-Riley,W5P10,Attorney General,,,Write-ins,0,RI21
-Riley,W5P10,State Treasurer,,,Write-ins,1,RI21
-Riley,W5P10,Insurance Commissioner,,,Write-ins,0,RI21
-Riley,W5P11,U.S. Senate,,,Write-ins,1,RI22
-Riley,W5P11,U.S. House,1,,Write-ins,2,RI22
-Riley,W5P11,Governor,,,Write-ins,1,RI22
-Riley,W5P11,Secretary of State,,,Write-ins,0,RI22
-Riley,W5P11,Attorney General,,,Write-ins,0,RI22
-Riley,W5P11,State Treasurer,,,Write-ins,0,RI22
-Riley,W5P11,Insurance Commissioner,,,Write-ins,0,RI22
-Riley,W8P3,U.S. Senate,,,Write-ins,1,RI26
-Riley,W8P3,U.S. House,1,,Write-ins,0,RI26
-Riley,W8P3,Governor,,,Write-ins,0,RI26
-Riley,W8P3,Secretary of State,,,Write-ins,0,RI26
-Riley,W8P3,Attorney General,,,Write-ins,0,RI26
-Riley,W8P3,State Treasurer,,,Write-ins,0,RI26
-Riley,W8P3,Insurance Commissioner,,,Write-ins,0,RI26
-Riley,W9P2,U.S. Senate,,,Write-ins,0,RI28
-Riley,W9P2,U.S. House,1,,Write-ins,0,RI28
-Riley,W9P2,Governor,,,Write-ins,2,RI28
-Riley,W9P2,Secretary of State,,,Write-ins,0,RI28
-Riley,W9P2,Attorney General,,,Write-ins,0,RI28
-Riley,W9P2,State Treasurer,,,Write-ins,0,RI28
-Riley,W9P2,Insurance Commissioner,,,Write-ins,0,RI28
-Riley,W9P3,U.S. Senate,,,Write-ins,1,RI29
-Riley,W9P3,U.S. House,1,,Write-ins,0,RI29
-Riley,W9P3,Governor,,,Write-ins,0,RI29
-Riley,W9P3,Secretary of State,,,Write-ins,0,RI29
-Riley,W9P3,Attorney General,,,Write-ins,0,RI29
-Riley,W9P3,State Treasurer,,,Write-ins,0,RI29
-Riley,W9P3,Insurance Commissioner,,,Write-ins,0,RI29
-Riley,W11P1,U.S. Senate,,,Write-ins,0,RI31
-Riley,W11P1,U.S. House,1,,Write-ins,0,RI31
-Riley,W11P1,Governor,,,Write-ins,0,RI31
-Riley,W11P1,Secretary of State,,,Write-ins,0,RI31
-Riley,W11P1,Attorney General,,,Write-ins,1,RI31
-Riley,W11P1,State Treasurer,,,Write-ins,0,RI31
-Riley,W11P1,Insurance Commissioner,,,Write-ins,0,RI31
-Riley,Bala,U.S. Senate,,,Write-ins,0,RI35
-Riley,Bala,U.S. House,1,,Write-ins,1,RI35
-Riley,Bala,Governor,,,Write-ins,0,RI35
-Riley,Bala,Secretary of State,,,Write-ins,0,RI35
-Riley,Bala,Attorney General,,,Write-ins,0,RI35
-Riley,Bala,State Treasurer,,,Write-ins,0,RI35
-Riley,Bala,Insurance Commissioner,,,Write-ins,0,RI35
-Riley,Center,U.S. Senate,,,Write-ins,1,RI36
-Riley,Man twp 3,State Treasurer,,,Write-ins,1,RI44
-Riley,Grant ,U.S. Senate,,,Write-ins,1,RI38
-Riley,Man twp 3,Attorney General,,,Write-ins,1,RI44
-Riley,Madison H64,U.S. Senate,,,Write-ins,1,RI40
-Riley,Man twp 3,Secretary of State,,,Write-ins,1,RI44
-Riley,Man twp 1,U.S. Senate,,,Write-ins,1,RI42
-Riley,Man twp 2,U.S. House,1,,Write-ins,1,RI43
-Riley,Man twp 3,U.S. House,1,,Write-ins,1,RI44
-Riley,Man twp 3,Insurance Commissioner,,,Write-ins,1,RI44
-Riley,Man twp 4,Insurance Commissioner,,,Write-ins,1,RI45
-Riley,Ogden/Ft Ril A,Attorney General,,,Write-ins,1,RI48
-Riley,Ogden/Ft Ril A,U.S. Senate,,,Write-ins,1,RI48
-Riley,Wildcat,U.S. House,1,,Write-ins,2,RI51
-Riley,Zeandale,U.S. House,1,,Write-ins,1,RI52
+county,precinct,office,district,party,candidate,votes,vtd
+RILEY,Ashland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000010
+RILEY,Ashland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000010
+RILEY,Ashland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000010
+RILEY,Bala Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",77,000020
+RILEY,Bala Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000020
+RILEY,Bala Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",180,000020
+RILEY,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000030
+RILEY,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+RILEY,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000030
+RILEY,Fancy Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000040
+RILEY,Fancy Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+RILEY,Fancy Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000040
+RILEY,Fort Riley B Madison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,00005B
+RILEY,Fort Riley B Madison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+RILEY,Fort Riley B Madison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,00005B
+RILEY,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",217,000060
+RILEY,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000060
+RILEY,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",289,000060
+RILEY,Jackson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000070
+RILEY,Jackson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000070
+RILEY,Jackson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",136,000120
+RILEY,Manhattan City Ward 02 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000120
+RILEY,Manhattan City Ward 02 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",245,000140
+RILEY,Manhattan City Ward 02 Precinct 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",32,000140
+RILEY,Manhattan City Ward 02 Precinct 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",183,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",135,000170
+RILEY,Manhattan City Ward 03 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000170
+RILEY,Manhattan City Ward 03 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",116,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",322,000230
+RILEY,Manhattan City Ward 04 Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000230
+RILEY,Manhattan City Ward 04 Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",165,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",260,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",209,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",142,000310
+RILEY,Manhattan City Ward 05 Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000310
+RILEY,Manhattan City Ward 05 Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",100,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Governor / Lt. Governor,,Democratic,"Davis, Paul",311,000320
+RILEY,Manhattan City Ward 05 Precinct 06,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",29,000320
+RILEY,Manhattan City Ward 05 Precinct 06,Governor / Lt. Governor,,Republican,"Brownback, Sam",287,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",144,000330
+RILEY,Manhattan City Ward 05 Precinct 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000330
+RILEY,Manhattan City Ward 05 Precinct 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",95,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Governor / Lt. Governor,,Democratic,"Davis, Paul",213,000340
+RILEY,Manhattan City Ward 05 Precinct 08,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000340
+RILEY,Manhattan City Ward 05 Precinct 08,Governor / Lt. Governor,,Republican,"Brownback, Sam",161,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Governor / Lt. Governor,,Democratic,"Davis, Paul",547,000350
+RILEY,Manhattan City Ward 05 Precinct 09,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000350
+RILEY,Manhattan City Ward 05 Precinct 09,Governor / Lt. Governor,,Republican,"Brownback, Sam",449,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",520,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",447,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Governor / Lt. Governor,,Democratic,"Davis, Paul",511,000370
+RILEY,Manhattan City Ward 05 Precinct 11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",38,000370
+RILEY,Manhattan City Ward 05 Precinct 11,Governor / Lt. Governor,,Republican,"Brownback, Sam",460,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Governor / Lt. Governor,,Republican,"Brownback, Sam",2,000380
+RILEY,Manhattan Township Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",94,00039A
+RILEY,Manhattan Township Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00039A
+RILEY,Manhattan Township Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00039H
+RILEY,Manhattan Township Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",130,000400
+RILEY,Manhattan Township Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000400
+RILEY,Manhattan Township Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",114,000400
+RILEY,Manhattan Township Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,000410
+RILEY,Manhattan Township Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000410
+RILEY,Manhattan Township Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000410
+RILEY,Manhattan Township Precinct 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000420
+RILEY,Manhattan Township Precinct 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000420
+RILEY,Manhattan Township Precinct 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000420
+RILEY,May Day Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000430
+RILEY,May Day Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000430
+RILEY,May Day Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000430
+RILEY,Ogden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,00044A
+RILEY,Ogden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,00044A
+RILEY,Ogden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",109,00044A
+RILEY,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000450
+RILEY,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000450
+RILEY,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",155,000450
+RILEY,Swede Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000460
+RILEY,Swede Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000460
+RILEY,Swede Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000460
+RILEY,Wildcat Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",154,00047A
+RILEY,Wildcat Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,00047A
+RILEY,Wildcat Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",247,00047A
+RILEY,Wildcat Township Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00047B
+RILEY,Wildcat Township Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00047B
+RILEY,Wildcat Township Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00047B
+RILEY,Wildcat Township Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00047C
+RILEY,Wildcat Township Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00047C
+RILEY,Wildcat Township Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,00047D
+RILEY,Zeandale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",68,000480
+RILEY,Zeandale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000480
+RILEY,Zeandale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",104,000480
+RILEY,Fort Riley A Madison Township H64,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,120020
+RILEY,Fort Riley A Madison Township H64,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120020
+RILEY,Fort Riley A Madison Township H64,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,120020
+RILEY,Fort Riley A Madison Township H67,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120030
+RILEY,Fort Riley A Madison Township H67,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+RILEY,Fort Riley A Madison Township H67,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120030
+RILEY,Madison Township H64,Governor / Lt. Governor,,Democratic,"Davis, Paul",179,120040
+RILEY,Madison Township H64,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,120040
+RILEY,Madison Township H64,Governor / Lt. Governor,,Republican,"Brownback, Sam",209,120040
+RILEY,Madison Township H67,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,120050
+RILEY,Madison Township H67,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120050
+RILEY,Madison Township H67,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",78,300020
+RILEY,Manhattan City Ward 08 Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,300020
+RILEY,Manhattan City Ward 08 Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,300030
+RILEY,Manhattan City Ward 08 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,300040
+RILEY,Manhattan City Ward 09 Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,300040
+RILEY,Manhattan City Ward 09 Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",69,300050
+RILEY,Manhattan City Ward 09 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,300050
+RILEY,Manhattan City Ward 09 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,300050
+RILEY,Ogden Township Fort Riley A,Governor / Lt. Governor,,Democratic,"Davis, Paul",101,300060
+RILEY,Ogden Township Fort Riley A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,300060
+RILEY,Ogden Township Fort Riley A,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,300090
+RILEY,Ogden Township Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,300100
+RILEY,Ogden Township Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,300100
+RILEY,Ogden Township Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",305,400010
+RILEY,Manhattan City Ward 01 Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,400010
+RILEY,Manhattan City Ward 01 Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",157,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",292,400020
+RILEY,Manhattan City Ward 02 Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,400020
+RILEY,Manhattan City Ward 02 Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",95,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",447,400030
+RILEY,Manhattan City Ward 02 Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",66,400030
+RILEY,Manhattan City Ward 02 Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",341,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",279,400040
+RILEY,Manhattan City Ward 03 Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,400040
+RILEY,Manhattan City Ward 03 Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",211,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",527,400050
+RILEY,Manhattan City Ward 04 Precinct 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",31,400050
+RILEY,Manhattan City Ward 04 Precinct 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",387,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",327,400060
+RILEY,Manhattan City Ward 05 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,400060
+RILEY,Manhattan City Ward 05 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",118,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",284,400070
+RILEY,Manhattan City Ward 05 Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,400070
+RILEY,Manhattan City Ward 05 Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",156,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,400080
+RILEY,Manhattan City Ward 04 Precinct 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,400080
+RILEY,Manhattan City Ward 04 Precinct 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Governor / Lt. Governor,,Democratic,"Davis, Paul",94,400090
+RILEY,Manhattan City Ward 04 Precinct 06,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,400090
+RILEY,Manhattan City Ward 04 Precinct 06,Governor / Lt. Governor,,Republican,"Brownback, Sam",131,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,500010
+RILEY,Manhattan City Ward 11 Precinct 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,500010
+RILEY,Manhattan City Ward 11 Precinct 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",41,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,500030
+RILEY,Manhattan City Ward 08 Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,500030
+RILEY,Manhattan City Ward 08 Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",62,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,600001
+RILEY,Manhattan City Ward 11 Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,600001
+RILEY,Manhattan City Ward 11 Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,800001
+RILEY,Manhattan City Ward 09 Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,800001
+RILEY,Manhattan City Ward 09 Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,800001
+RILEY,Ogden Township Enclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+RILEY,Ogden Township Enclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+RILEY,Ogden Township Enclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+RILEY,Ogden Township Enclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+RILEY,Ogden Township Enclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+RILEY,Ogden Township Enclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900060
+RILEY,Ashland Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",81,000010
+RILEY,Bala Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",227,000020
+RILEY,Center Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",37,000030
+RILEY,Fancy Creek Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",44,000040
+RILEY,Fort Riley B Madison Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",7,00005B
+RILEY,Grant Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",462,000060
+RILEY,Jackson Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",113,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",165,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",353,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",160,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",154,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",373,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Kansas House of Representatives,67,Republican,"Phillips, Tom",409,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Kansas House of Representatives,67,Republican,"Phillips, Tom",205,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Kansas House of Representatives,67,Republican,"Phillips, Tom",549,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Kansas House of Representatives,67,Republican,"Phillips, Tom",210,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Kansas House of Representatives,67,Republican,"Phillips, Tom",333,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Kansas House of Representatives,67,Republican,"Phillips, Tom",881,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Kansas House of Representatives,67,Republican,"Phillips, Tom",844,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Kansas House of Representatives,67,Republican,"Phillips, Tom",852,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Kansas House of Representatives,64,Republican,"Swanson, Susie",2,000380
+RILEY,Manhattan Township Precinct 1,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",149,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039H
+RILEY,Manhattan Township Precinct 2,Kansas House of Representatives,67,Republican,"Phillips, Tom",217,000400
+RILEY,Manhattan Township Precinct 3,Kansas House of Representatives,67,Republican,"Phillips, Tom",77,000410
+RILEY,Manhattan Township Precinct 4,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",154,000420
+RILEY,May Day Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",33,000430
+RILEY,Ogden Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",143,00044A
+RILEY,Sherman Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",223,000450
+RILEY,Swede Creek Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",56,000460
+RILEY,Wildcat Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",372,00047A
+RILEY,Wildcat Township Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00047B
+RILEY,Wildcat Township Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",26,00047D
+RILEY,Zeandale Township,Kansas House of Representatives,51,Republican,"Highland, Ron",151,000480
+RILEY,Fort Riley A Madison Township H64,Kansas House of Representatives,64,Republican,"Swanson, Susie",7,120020
+RILEY,Fort Riley A Madison Township H67,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,120030
+RILEY,Madison Township H64,Kansas House of Representatives,64,Republican,"Swanson, Susie",341,120040
+RILEY,Madison Township H67,Kansas House of Representatives,67,Republican,"Phillips, Tom",15,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",112,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",1,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",70,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",85,300050
+RILEY,Ogden Township Fort Riley A,Kansas House of Representatives,64,Republican,"Swanson, Susie",209,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,300090
+RILEY,Ogden Township Ward 5,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",386,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",336,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",661,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",375,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Kansas House of Representatives,67,Republican,"Phillips, Tom",800,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",376,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",347,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Kansas House of Representatives,67,Republican,"Phillips, Tom",13,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Kansas House of Representatives,67,Republican,"Phillips, Tom",216,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",92,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",129,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",21,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",31,800001
+RILEY,Ogden Township Enclave 1,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,900010
+RILEY,Ogden Township Enclave 2,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Kansas House of Representatives,67,Republican,"Phillips, Tom",80,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900060
+RILEY,Ashland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",47,000010
+RILEY,Ashland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000010
+RILEY,Bala Township,United States House of Representatives,1,Democratic,"Sherow, James E.",191,000020
+RILEY,Bala Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,000020
+RILEY,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000030
+RILEY,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000030
+RILEY,Fancy Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",46,000040
+RILEY,Fancy Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000040
+RILEY,Fort Riley B Madison Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,00005B
+RILEY,Fort Riley B Madison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,00005B
+RILEY,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",304,000060
+RILEY,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",218,000060
+RILEY,Jackson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",82,000070
+RILEY,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000070
+RILEY,Manhattan City Ward 02 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",56,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",137,000120
+RILEY,Manhattan City Ward 02 Precinct 04,United States House of Representatives,1,Democratic,"Sherow, James E.",193,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",261,000140
+RILEY,Manhattan City Ward 03 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",70,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",124,000170
+RILEY,Manhattan City Ward 04 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",84,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",121,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",171,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",323,000230
+RILEY,Manhattan City Ward 04 Precinct 05,United States House of Representatives,1,Democratic,"Sherow, James E.",231,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",257,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,United States House of Representatives,1,Democratic,"Sherow, James E.",111,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",145,000310
+RILEY,Manhattan City Ward 05 Precinct 06,United States House of Representatives,1,Democratic,"Sherow, James E.",310,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",312,000320
+RILEY,Manhattan City Ward 05 Precinct 07,United States House of Representatives,1,Democratic,"Sherow, James E.",101,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",148,000330
+RILEY,Manhattan City Ward 05 Precinct 08,United States House of Representatives,1,Democratic,"Sherow, James E.",171,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",212,000340
+RILEY,Manhattan City Ward 05 Precinct 09,United States House of Representatives,1,Democratic,"Sherow, James E.",442,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",564,000350
+RILEY,Manhattan City Ward 05 Precinct 10,United States House of Representatives,1,Democratic,"Sherow, James E.",437,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",533,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,United States House of Representatives,1,Democratic,"Sherow, James E.",476,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",521,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000380
+RILEY,Manhattan Township Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",149,00039A
+RILEY,Manhattan Township Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039H
+RILEY,Manhattan Township Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",121,000400
+RILEY,Manhattan Township Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",138,000400
+RILEY,Manhattan Township Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",51,000410
+RILEY,Manhattan Township Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000410
+RILEY,Manhattan Township Precinct 4,United States House of Representatives,1,Democratic,"Sherow, James E.",125,000420
+RILEY,Manhattan Township Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",91,000420
+RILEY,May Day Township,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000430
+RILEY,May Day Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",6,000430
+RILEY,Ogden Township,United States House of Representatives,1,Democratic,"Sherow, James E.",115,00044A
+RILEY,Ogden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,00044A
+RILEY,Sherman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",160,000450
+RILEY,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,000450
+RILEY,Swede Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",32,000460
+RILEY,Swede Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000460
+RILEY,Wildcat Township,United States House of Representatives,1,Democratic,"Sherow, James E.",261,00047A
+RILEY,Wildcat Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",155,00047A
+RILEY,Wildcat Township Enclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00047B
+RILEY,Wildcat Township Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00047B
+RILEY,Wildcat Township Enclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00047C
+RILEY,Wildcat Township Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",14,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,00047D
+RILEY,Zeandale Township,United States House of Representatives,1,Democratic,"Sherow, James E.",109,000480
+RILEY,Zeandale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,000480
+RILEY,Fort Riley A Madison Township H64,United States House of Representatives,1,Democratic,"Sherow, James E.",6,120020
+RILEY,Fort Riley A Madison Township H64,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,120020
+RILEY,Fort Riley A Madison Township H67,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120030
+RILEY,Fort Riley A Madison Township H67,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120030
+RILEY,Madison Township H64,United States House of Representatives,1,Democratic,"Sherow, James E.",239,120040
+RILEY,Madison Township H64,United States House of Representatives,1,Republican,"Huelskamp, Tim",162,120040
+RILEY,Madison Township H67,United States House of Representatives,1,Democratic,"Sherow, James E.",12,120050
+RILEY,Madison Township H67,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States House of Representatives,1,Democratic,"Sherow, James E.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",64,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,300020
+RILEY,Manhattan City Ward 08 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,300030
+RILEY,Manhattan City Ward 09 Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",43,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,300040
+RILEY,Manhattan City Ward 09 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",41,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",75,300050
+RILEY,Ogden Township Fort Riley A,United States House of Representatives,1,Democratic,"Sherow, James E.",149,300060
+RILEY,Ogden Township Fort Riley A,United States House of Representatives,1,Republican,"Huelskamp, Tim",98,300060
+RILEY,Ogden Township Ward 2 Annex order 506,United States House of Representatives,1,Democratic,"Sherow, James E.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States House of Representatives,1,Democratic,"Sherow, James E.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300090
+RILEY,Ogden Township Ward 5,United States House of Representatives,1,Democratic,"Sherow, James E.",0,300100
+RILEY,Ogden Township Ward 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",148,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",324,400010
+RILEY,Manhattan City Ward 02 Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",114,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",289,400020
+RILEY,Manhattan City Ward 02 Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",365,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",476,400030
+RILEY,Manhattan City Ward 03 Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",215,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",287,400040
+RILEY,Manhattan City Ward 04 Precinct 04,United States House of Representatives,1,Democratic,"Sherow, James E.",412,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",528,400050
+RILEY,Manhattan City Ward 05 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",133,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",317,400060
+RILEY,Manhattan City Ward 05 Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",162,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",289,400070
+RILEY,Manhattan City Ward 04 Precinct 07,United States House of Representatives,1,Democratic,"Sherow, James E.",8,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,400080
+RILEY,Manhattan City Ward 04 Precinct 06,United States House of Representatives,1,Democratic,"Sherow, James E.",142,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",98,400090
+RILEY,Manhattan City Ward 11 Precinct 01,United States House of Representatives,1,Democratic,"Sherow, James E.",51,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,500010
+RILEY,Manhattan City Ward 08 Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",75,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",88,500030
+RILEY,Manhattan City Ward 11 Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",11,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,600001
+RILEY,Manhattan City Ward 09 Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",17,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,800001
+RILEY,Ogden Township Enclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+RILEY,Ogden Township Enclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+RILEY,Ogden Township Enclave 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+RILEY,Ogden Township Enclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",52,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900060
+RILEY,Ashland Township,Attorney General,,Democratic,"Kotich, A.J.",37,000010
+RILEY,Ashland Township,Attorney General,,Republican,"Schmidt, Derek",58,000010
+RILEY,Bala Township,Attorney General,,Democratic,"Kotich, A.J.",38,000020
+RILEY,Bala Township,Attorney General,,Republican,"Schmidt, Derek",225,000020
+RILEY,Center Township,Attorney General,,Democratic,"Kotich, A.J.",3,000030
+RILEY,Center Township,Attorney General,,Republican,"Schmidt, Derek",37,000030
+RILEY,Fancy Creek Township,Attorney General,,Democratic,"Kotich, A.J.",4,000040
+RILEY,Fancy Creek Township,Attorney General,,Republican,"Schmidt, Derek",52,000040
+RILEY,Fort Riley B Madison Township,Attorney General,,Democratic,"Kotich, A.J.",3,00005B
+RILEY,Fort Riley B Madison Township,Attorney General,,Republican,"Schmidt, Derek",5,00005B
+RILEY,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",141,000060
+RILEY,Grant Township,Attorney General,,Republican,"Schmidt, Derek",378,000060
+RILEY,Jackson Township,Attorney General,,Democratic,"Kotich, A.J.",27,000070
+RILEY,Jackson Township,Attorney General,,Republican,"Schmidt, Derek",98,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",108,000120
+RILEY,Manhattan City Ward 02 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",78,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Attorney General,,Democratic,"Kotich, A.J.",152,000140
+RILEY,Manhattan City Ward 02 Precinct 04,Attorney General,,Republican,"Schmidt, Derek",289,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",110,000170
+RILEY,Manhattan City Ward 03 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",77,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",94,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",111,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,Attorney General,,Republican,"Schmidt, Derek",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",251,000230
+RILEY,Manhattan City Ward 04 Precinct 03,Attorney General,,Republican,"Schmidt, Derek",240,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",181,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,Attorney General,,Republican,"Schmidt, Derek",285,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",100,000310
+RILEY,Manhattan City Ward 05 Precinct 05,Attorney General,,Republican,"Schmidt, Derek",154,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Attorney General,,Democratic,"Kotich, A.J.",206,000320
+RILEY,Manhattan City Ward 05 Precinct 06,Attorney General,,Republican,"Schmidt, Derek",406,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Attorney General,,Democratic,"Kotich, A.J.",94,000330
+RILEY,Manhattan City Ward 05 Precinct 07,Attorney General,,Republican,"Schmidt, Derek",147,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Attorney General,,Democratic,"Kotich, A.J.",132,000340
+RILEY,Manhattan City Ward 05 Precinct 08,Attorney General,,Republican,"Schmidt, Derek",250,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Attorney General,,Democratic,"Kotich, A.J.",347,000350
+RILEY,Manhattan City Ward 05 Precinct 09,Attorney General,,Republican,"Schmidt, Derek",643,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Attorney General,,Democratic,"Kotich, A.J.",334,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,Attorney General,,Republican,"Schmidt, Derek",630,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Attorney General,,Democratic,"Kotich, A.J.",334,000370
+RILEY,Manhattan City Ward 05 Precinct 11,Attorney General,,Republican,"Schmidt, Derek",643,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Attorney General,,Democratic,"Kotich, A.J.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Attorney General,,Republican,"Schmidt, Derek",2,000380
+RILEY,Manhattan Township Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",71,00039A
+RILEY,Manhattan Township Precinct 1,Attorney General,,Republican,"Schmidt, Derek",170,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Attorney General,,Democratic,"Kotich, A.J.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,Attorney General,,Republican,"Schmidt, Derek",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Attorney General,,Democratic,"Kotich, A.J.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,Attorney General,,Republican,"Schmidt, Derek",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Attorney General,,Democratic,"Kotich, A.J.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,Attorney General,,Republican,"Schmidt, Derek",0,00039H
+RILEY,Manhattan Township Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",90,000400
+RILEY,Manhattan Township Precinct 2,Attorney General,,Republican,"Schmidt, Derek",167,000400
+RILEY,Manhattan Township Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",21,000410
+RILEY,Manhattan Township Precinct 3,Attorney General,,Republican,"Schmidt, Derek",66,000410
+RILEY,Manhattan Township Precinct 4,Attorney General,,Democratic,"Kotich, A.J.",61,000420
+RILEY,Manhattan Township Precinct 4,Attorney General,,Republican,"Schmidt, Derek",155,000420
+RILEY,May Day Township,Attorney General,,Democratic,"Kotich, A.J.",1,000430
+RILEY,May Day Township,Attorney General,,Republican,"Schmidt, Derek",34,000430
+RILEY,Ogden Township,Attorney General,,Democratic,"Kotich, A.J.",26,00044A
+RILEY,Ogden Township,Attorney General,,Republican,"Schmidt, Derek",130,00044A
+RILEY,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",52,000450
+RILEY,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",187,000450
+RILEY,Swede Creek Township,Attorney General,,Democratic,"Kotich, A.J.",18,000460
+RILEY,Swede Creek Township,Attorney General,,Republican,"Schmidt, Derek",39,000460
+RILEY,Wildcat Township,Attorney General,,Democratic,"Kotich, A.J.",81,00047A
+RILEY,Wildcat Township,Attorney General,,Republican,"Schmidt, Derek",331,00047A
+RILEY,Wildcat Township Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,00047B
+RILEY,Wildcat Township Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,00047B
+RILEY,Wildcat Township Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,00047C
+RILEY,Wildcat Township Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",17,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,Attorney General,,Republican,"Schmidt, Derek",16,00047D
+RILEY,Zeandale Township,Attorney General,,Democratic,"Kotich, A.J.",48,000480
+RILEY,Zeandale Township,Attorney General,,Republican,"Schmidt, Derek",129,000480
+RILEY,Fort Riley A Madison Township H64,Attorney General,,Democratic,"Kotich, A.J.",4,120020
+RILEY,Fort Riley A Madison Township H64,Attorney General,,Republican,"Schmidt, Derek",4,120020
+RILEY,Fort Riley A Madison Township H67,Attorney General,,Democratic,"Kotich, A.J.",0,120030
+RILEY,Fort Riley A Madison Township H67,Attorney General,,Republican,"Schmidt, Derek",0,120030
+RILEY,Madison Township H64,Attorney General,,Democratic,"Kotich, A.J.",100,120040
+RILEY,Madison Township H64,Attorney General,,Republican,"Schmidt, Derek",298,120040
+RILEY,Madison Township H67,Attorney General,,Democratic,"Kotich, A.J.",1,120050
+RILEY,Madison Township H67,Attorney General,,Republican,"Schmidt, Derek",14,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Attorney General,,Democratic,"Kotich, A.J.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Attorney General,,Republican,"Schmidt, Derek",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",59,300020
+RILEY,Manhattan City Ward 08 Precinct 01,Attorney General,,Republican,"Schmidt, Derek",79,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",1,300030
+RILEY,Manhattan City Ward 08 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",0,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",28,300040
+RILEY,Manhattan City Ward 09 Precinct 01,Attorney General,,Republican,"Schmidt, Derek",62,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",50,300050
+RILEY,Manhattan City Ward 09 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",64,300050
+RILEY,Ogden Township Fort Riley A,Attorney General,,Democratic,"Kotich, A.J.",68,300060
+RILEY,Ogden Township Fort Riley A,Attorney General,,Republican,"Schmidt, Derek",179,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Attorney General,,Democratic,"Kotich, A.J.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,Attorney General,,Republican,"Schmidt, Derek",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Attorney General,,Democratic,"Kotich, A.J.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,Attorney General,,Republican,"Schmidt, Derek",0,300090
+RILEY,Ogden Township Ward 5,Attorney General,,Democratic,"Kotich, A.J.",0,300100
+RILEY,Ogden Township Ward 5,Attorney General,,Republican,"Schmidt, Derek",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",260,400010
+RILEY,Manhattan City Ward 01 Precinct 01,Attorney General,,Republican,"Schmidt, Derek",202,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",234,400020
+RILEY,Manhattan City Ward 02 Precinct 01,Attorney General,,Republican,"Schmidt, Derek",154,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",338,400030
+RILEY,Manhattan City Ward 02 Precinct 03,Attorney General,,Republican,"Schmidt, Derek",492,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",204,400040
+RILEY,Manhattan City Ward 03 Precinct 03,Attorney General,,Republican,"Schmidt, Derek",281,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Attorney General,,Democratic,"Kotich, A.J.",370,400050
+RILEY,Manhattan City Ward 04 Precinct 04,Attorney General,,Republican,"Schmidt, Derek",559,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",273,400060
+RILEY,Manhattan City Ward 05 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",173,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",234,400070
+RILEY,Manhattan City Ward 05 Precinct 03,Attorney General,,Republican,"Schmidt, Derek",206,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Attorney General,,Democratic,"Kotich, A.J.",2,400080
+RILEY,Manhattan City Ward 04 Precinct 07,Attorney General,,Republican,"Schmidt, Derek",12,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Attorney General,,Democratic,"Kotich, A.J.",61,400090
+RILEY,Manhattan City Ward 04 Precinct 06,Attorney General,,Republican,"Schmidt, Derek",175,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Attorney General,,Democratic,"Kotich, A.J.",47,500010
+RILEY,Manhattan City Ward 11 Precinct 01,Attorney General,,Republican,"Schmidt, Derek",65,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",64,500030
+RILEY,Manhattan City Ward 08 Precinct 03,Attorney General,,Republican,"Schmidt, Derek",94,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",2,600001
+RILEY,Manhattan City Ward 11 Precinct 03,Attorney General,,Republican,"Schmidt, Derek",19,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",11,800001
+RILEY,Manhattan City Ward 09 Precinct 03,Attorney General,,Republican,"Schmidt, Derek",25,800001
+RILEY,Ogden Township Enclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+RILEY,Ogden Township Enclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900010
+RILEY,Ogden Township Enclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+RILEY,Ogden Township Enclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Attorney General,,Democratic,"Kotich, A.J.",35,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Attorney General,,Republican,"Schmidt, Derek",64,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Attorney General,,Republican,"Schmidt, Derek",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,Attorney General,,Republican,"Schmidt, Derek",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,900060
+RILEY,Ashland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",41,000010
+RILEY,Ashland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000010
+RILEY,Bala Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000020
+RILEY,Bala Township,Commissioner of Insurance,,Republican,"Selzer, Ken",203,000020
+RILEY,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000030
+RILEY,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000030
+RILEY,Fancy Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000040
+RILEY,Fancy Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000040
+RILEY,Fort Riley B Madison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,00005B
+RILEY,Fort Riley B Madison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,00005B
+RILEY,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",167,000060
+RILEY,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",339,000060
+RILEY,Jackson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000070
+RILEY,Jackson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",113,000120
+RILEY,Manhattan City Ward 02 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",71,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",191,000140
+RILEY,Manhattan City Ward 02 Precinct 04,Commissioner of Insurance,,Republican,"Selzer, Ken",240,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,000170
+RILEY,Manhattan City Ward 03 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",66,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",105,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",94,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",281,000230
+RILEY,Manhattan City Ward 04 Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",201,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",198,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",267,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",115,000310
+RILEY,Manhattan City Ward 05 Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",132,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Commissioner of Insurance,,Democratic,"Anderson, Dennis",237,000320
+RILEY,Manhattan City Ward 05 Precinct 06,Commissioner of Insurance,,Republican,"Selzer, Ken",369,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",107,000330
+RILEY,Manhattan City Ward 05 Precinct 07,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Commissioner of Insurance,,Democratic,"Anderson, Dennis",156,000340
+RILEY,Manhattan City Ward 05 Precinct 08,Commissioner of Insurance,,Republican,"Selzer, Ken",221,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Commissioner of Insurance,,Democratic,"Anderson, Dennis",409,000350
+RILEY,Manhattan City Ward 05 Precinct 09,Commissioner of Insurance,,Republican,"Selzer, Ken",568,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",393,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,Commissioner of Insurance,,Republican,"Selzer, Ken",563,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",399,000370
+RILEY,Manhattan City Ward 05 Precinct 11,Commissioner of Insurance,,Republican,"Selzer, Ken",563,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Commissioner of Insurance,,Republican,"Selzer, Ken",2,000380
+RILEY,Manhattan Township Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,00039A
+RILEY,Manhattan Township Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",169,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00039H
+RILEY,Manhattan Township Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",101,000400
+RILEY,Manhattan Township Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",150,000400
+RILEY,Manhattan Township Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000410
+RILEY,Manhattan Township Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",58,000410
+RILEY,Manhattan Township Precinct 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000420
+RILEY,Manhattan Township Precinct 4,Commissioner of Insurance,,Republican,"Selzer, Ken",140,000420
+RILEY,May Day Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000430
+RILEY,May Day Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000430
+RILEY,Ogden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,00044A
+RILEY,Ogden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",124,00044A
+RILEY,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,000450
+RILEY,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",168,000450
+RILEY,Swede Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000460
+RILEY,Swede Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000460
+RILEY,Wildcat Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,00047A
+RILEY,Wildcat Township,Commissioner of Insurance,,Republican,"Selzer, Ken",317,00047A
+RILEY,Wildcat Township Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00047B
+RILEY,Wildcat Township Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00047B
+RILEY,Wildcat Township Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00047C
+RILEY,Wildcat Township Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",14,00047D
+RILEY,Zeandale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000480
+RILEY,Zeandale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",121,000480
+RILEY,Fort Riley A Madison Township H64,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,120020
+RILEY,Fort Riley A Madison Township H64,Commissioner of Insurance,,Republican,"Selzer, Ken",5,120020
+RILEY,Fort Riley A Madison Township H67,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120030
+RILEY,Fort Riley A Madison Township H67,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120030
+RILEY,Madison Township H64,Commissioner of Insurance,,Democratic,"Anderson, Dennis",120,120040
+RILEY,Madison Township H64,Commissioner of Insurance,,Republican,"Selzer, Ken",271,120040
+RILEY,Madison Township H67,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,120050
+RILEY,Madison Township H67,Commissioner of Insurance,,Republican,"Selzer, Ken",13,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Commissioner of Insurance,,Republican,"Selzer, Ken",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,300020
+RILEY,Manhattan City Ward 08 Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",73,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",1,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,300040
+RILEY,Manhattan City Ward 09 Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",51,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,300050
+RILEY,Manhattan City Ward 09 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",55,300050
+RILEY,Ogden Township Fort Riley A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",84,300060
+RILEY,Ogden Township Fort Riley A,Commissioner of Insurance,,Republican,"Selzer, Ken",156,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,Commissioner of Insurance,,Republican,"Selzer, Ken",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,Commissioner of Insurance,,Republican,"Selzer, Ken",0,300090
+RILEY,Ogden Township Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,300100
+RILEY,Ogden Township Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",279,400010
+RILEY,Manhattan City Ward 01 Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",181,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",254,400020
+RILEY,Manhattan City Ward 02 Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",134,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",373,400030
+RILEY,Manhattan City Ward 02 Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",449,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",227,400040
+RILEY,Manhattan City Ward 03 Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",252,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",404,400050
+RILEY,Manhattan City Ward 04 Precinct 04,Commissioner of Insurance,,Republican,"Selzer, Ken",506,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",288,400060
+RILEY,Manhattan City Ward 05 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",152,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",253,400070
+RILEY,Manhattan City Ward 05 Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",179,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,400080
+RILEY,Manhattan City Ward 04 Precinct 07,Commissioner of Insurance,,Republican,"Selzer, Ken",10,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,400090
+RILEY,Manhattan City Ward 04 Precinct 06,Commissioner of Insurance,,Republican,"Selzer, Ken",167,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,500010
+RILEY,Manhattan City Ward 11 Precinct 01,Commissioner of Insurance,,Republican,"Selzer, Ken",65,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",70,500030
+RILEY,Manhattan City Ward 08 Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",84,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,600001
+RILEY,Manhattan City Ward 11 Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",16,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,800001
+RILEY,Manhattan City Ward 09 Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",24,800001
+RILEY,Ogden Township Enclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+RILEY,Ogden Township Enclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+RILEY,Ogden Township Enclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+RILEY,Ogden Township Enclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",61,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900060
+RILEY,Ashland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",56,000010
+RILEY,Ashland Township,Secretary of State,,Republican,"Kobach, Kris",42,000010
+RILEY,Bala Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",212,000020
+RILEY,Bala Township,Secretary of State,,Republican,"Kobach, Kris",51,000020
+RILEY,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000030
+RILEY,Center Township,Secretary of State,,Republican,"Kobach, Kris",3,000030
+RILEY,Fancy Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,000040
+RILEY,Fancy Creek Township,Secretary of State,,Republican,"Kobach, Kris",7,000040
+RILEY,Fort Riley B Madison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,00005B
+RILEY,Fort Riley B Madison Township,Secretary of State,,Republican,"Kobach, Kris",3,00005B
+RILEY,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",339,000060
+RILEY,Grant Township,Secretary of State,,Republican,"Kobach, Kris",181,000060
+RILEY,Jackson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,000070
+RILEY,Jackson Township,Secretary of State,,Republican,"Kobach, Kris",36,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000120
+RILEY,Manhattan City Ward 02 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",125,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",239,000140
+RILEY,Manhattan City Ward 02 Precinct 04,Secretary of State,,Republican,"Kobach, Kris",206,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000170
+RILEY,Manhattan City Ward 03 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",120,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",89,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",115,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,Secretary of State,,Republican,"Kobach, Kris",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",186,000230
+RILEY,Manhattan City Ward 04 Precinct 03,Secretary of State,,Republican,"Kobach, Kris",309,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",252,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,Secretary of State,,Republican,"Kobach, Kris",224,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",124,000310
+RILEY,Manhattan City Ward 05 Precinct 05,Secretary of State,,Republican,"Kobach, Kris",129,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",352,000320
+RILEY,Manhattan City Ward 05 Precinct 06,Secretary of State,,Republican,"Kobach, Kris",267,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",121,000330
+RILEY,Manhattan City Ward 05 Precinct 07,Secretary of State,,Republican,"Kobach, Kris",123,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",210,000340
+RILEY,Manhattan City Ward 05 Precinct 08,Secretary of State,,Republican,"Kobach, Kris",177,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",510,000350
+RILEY,Manhattan City Ward 05 Precinct 09,Secretary of State,,Republican,"Kobach, Kris",492,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",535,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,Secretary of State,,Republican,"Kobach, Kris",436,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",550,000370
+RILEY,Manhattan City Ward 05 Precinct 11,Secretary of State,,Republican,"Kobach, Kris",436,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Secretary of State,,Republican,"Kobach, Kris",0,000380
+RILEY,Manhattan Township Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",160,00039A
+RILEY,Manhattan Township Precinct 1,Secretary of State,,Republican,"Kobach, Kris",81,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,Secretary of State,,Republican,"Kobach, Kris",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,Secretary of State,,Republican,"Kobach, Kris",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,Secretary of State,,Republican,"Kobach, Kris",0,00039H
+RILEY,Manhattan Township Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",141,000400
+RILEY,Manhattan Township Precinct 2,Secretary of State,,Republican,"Kobach, Kris",118,000400
+RILEY,Manhattan Township Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000410
+RILEY,Manhattan Township Precinct 3,Secretary of State,,Republican,"Kobach, Kris",28,000410
+RILEY,Manhattan Township Precinct 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",147,000420
+RILEY,Manhattan Township Precinct 4,Secretary of State,,Republican,"Kobach, Kris",72,000420
+RILEY,May Day Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000430
+RILEY,May Day Township,Secretary of State,,Republican,"Kobach, Kris",2,000430
+RILEY,Ogden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",123,00044A
+RILEY,Ogden Township,Secretary of State,,Republican,"Kobach, Kris",36,00044A
+RILEY,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",177,000450
+RILEY,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",65,000450
+RILEY,Swede Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000460
+RILEY,Swede Creek Township,Secretary of State,,Republican,"Kobach, Kris",19,000460
+RILEY,Wildcat Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",302,00047A
+RILEY,Wildcat Township,Secretary of State,,Republican,"Kobach, Kris",116,00047A
+RILEY,Wildcat Township Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00047B
+RILEY,Wildcat Township Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,00047B
+RILEY,Wildcat Township Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00047C
+RILEY,Wildcat Township Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,Secretary of State,,Republican,"Kobach, Kris",19,00047D
+RILEY,Zeandale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",124,000480
+RILEY,Zeandale Township,Secretary of State,,Republican,"Kobach, Kris",56,000480
+RILEY,Fort Riley A Madison Township H64,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,120020
+RILEY,Fort Riley A Madison Township H64,Secretary of State,,Republican,"Kobach, Kris",4,120020
+RILEY,Fort Riley A Madison Township H67,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120030
+RILEY,Fort Riley A Madison Township H67,Secretary of State,,Republican,"Kobach, Kris",0,120030
+RILEY,Madison Township H64,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",269,120040
+RILEY,Madison Township H64,Secretary of State,,Republican,"Kobach, Kris",127,120040
+RILEY,Madison Township H67,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,120050
+RILEY,Madison Township H67,Secretary of State,,Republican,"Kobach, Kris",1,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Secretary of State,,Republican,"Kobach, Kris",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",76,300020
+RILEY,Manhattan City Ward 08 Precinct 01,Secretary of State,,Republican,"Kobach, Kris",62,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",1,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,300040
+RILEY,Manhattan City Ward 09 Precinct 01,Secretary of State,,Republican,"Kobach, Kris",39,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,300050
+RILEY,Manhattan City Ward 09 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",69,300050
+RILEY,Ogden Township Fort Riley A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",162,300060
+RILEY,Ogden Township Fort Riley A,Secretary of State,,Republican,"Kobach, Kris",85,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,Secretary of State,,Republican,"Kobach, Kris",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,Secretary of State,,Republican,"Kobach, Kris",0,300090
+RILEY,Ogden Township Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,300100
+RILEY,Ogden Township Ward 5,Secretary of State,,Republican,"Kobach, Kris",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",181,400010
+RILEY,Manhattan City Ward 01 Precinct 01,Secretary of State,,Republican,"Kobach, Kris",290,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",133,400020
+RILEY,Manhattan City Ward 02 Precinct 01,Secretary of State,,Republican,"Kobach, Kris",269,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",438,400030
+RILEY,Manhattan City Ward 02 Precinct 03,Secretary of State,,Republican,"Kobach, Kris",399,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",250,400040
+RILEY,Manhattan City Ward 03 Precinct 03,Secretary of State,,Republican,"Kobach, Kris",247,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",492,400050
+RILEY,Manhattan City Ward 04 Precinct 04,Secretary of State,,Republican,"Kobach, Kris",444,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",143,400060
+RILEY,Manhattan City Ward 05 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",304,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",188,400070
+RILEY,Manhattan City Ward 05 Precinct 03,Secretary of State,,Republican,"Kobach, Kris",260,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,400080
+RILEY,Manhattan City Ward 04 Precinct 07,Secretary of State,,Republican,"Kobach, Kris",5,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",156,400090
+RILEY,Manhattan City Ward 04 Precinct 06,Secretary of State,,Republican,"Kobach, Kris",82,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,500010
+RILEY,Manhattan City Ward 11 Precinct 01,Secretary of State,,Republican,"Kobach, Kris",63,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,500030
+RILEY,Manhattan City Ward 08 Precinct 03,Secretary of State,,Republican,"Kobach, Kris",75,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,600001
+RILEY,Manhattan City Ward 11 Precinct 03,Secretary of State,,Republican,"Kobach, Kris",5,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,800001
+RILEY,Manhattan City Ward 09 Precinct 03,Secretary of State,,Republican,"Kobach, Kris",13,800001
+RILEY,Ogden Township Enclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+RILEY,Ogden Township Enclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900010
+RILEY,Ogden Township Enclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+RILEY,Ogden Township Enclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Secretary of State,,Republican,"Kobach, Kris",41,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Secretary of State,,Republican,"Kobach, Kris",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,Secretary of State,,Republican,"Kobach, Kris",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,900060
+RILEY,Ashland Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,000010
+RILEY,Ashland Township,State Treasurer,,Republican,"Estes, Ron",62,000010
+RILEY,Bala Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000020
+RILEY,Bala Township,State Treasurer,,Republican,"Estes, Ron",215,000020
+RILEY,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000030
+RILEY,Center Township,State Treasurer,,Republican,"Estes, Ron",36,000030
+RILEY,Fancy Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000040
+RILEY,Fancy Creek Township,State Treasurer,,Republican,"Estes, Ron",51,000040
+RILEY,Fort Riley B Madison Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,00005B
+RILEY,Fort Riley B Madison Township,State Treasurer,,Republican,"Estes, Ron",5,00005B
+RILEY,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",142,000060
+RILEY,Grant Township,State Treasurer,,Republican,"Estes, Ron",368,000060
+RILEY,Jackson Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000070
+RILEY,Jackson Township,State Treasurer,,Republican,"Estes, Ron",104,000070
+RILEY,Manhattan City Ward 02 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",106,000120
+RILEY,Manhattan City Ward 02 Precinct 02,State Treasurer,,Republican,"Estes, Ron",80,000120
+RILEY,Manhattan City Ward 02 Precinct 04,State Treasurer,,Democratic,"Alldritt, Carmen",164,000140
+RILEY,Manhattan City Ward 02 Precinct 04,State Treasurer,,Republican,"Estes, Ron",274,000140
+RILEY,Manhattan City Ward 03 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",112,000170
+RILEY,Manhattan City Ward 03 Precinct 02,State Treasurer,,Republican,"Estes, Ron",71,000170
+RILEY,Manhattan City Ward 04 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",89,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,State Treasurer,,Republican,"Estes, Ron",110,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,State Treasurer,,Republican,"Estes, Ron",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",251,000230
+RILEY,Manhattan City Ward 04 Precinct 03,State Treasurer,,Republican,"Estes, Ron",233,000230
+RILEY,Manhattan City Ward 04 Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",177,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,State Treasurer,,Republican,"Estes, Ron",288,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",93,000310
+RILEY,Manhattan City Ward 05 Precinct 05,State Treasurer,,Republican,"Estes, Ron",156,000310
+RILEY,Manhattan City Ward 05 Precinct 06,State Treasurer,,Democratic,"Alldritt, Carmen",210,000320
+RILEY,Manhattan City Ward 05 Precinct 06,State Treasurer,,Republican,"Estes, Ron",401,000320
+RILEY,Manhattan City Ward 05 Precinct 07,State Treasurer,,Democratic,"Alldritt, Carmen",94,000330
+RILEY,Manhattan City Ward 05 Precinct 07,State Treasurer,,Republican,"Estes, Ron",149,000330
+RILEY,Manhattan City Ward 05 Precinct 08,State Treasurer,,Democratic,"Alldritt, Carmen",133,000340
+RILEY,Manhattan City Ward 05 Precinct 08,State Treasurer,,Republican,"Estes, Ron",250,000340
+RILEY,Manhattan City Ward 05 Precinct 09,State Treasurer,,Democratic,"Alldritt, Carmen",341,000350
+RILEY,Manhattan City Ward 05 Precinct 09,State Treasurer,,Republican,"Estes, Ron",639,000350
+RILEY,Manhattan City Ward 05 Precinct 10,State Treasurer,,Democratic,"Alldritt, Carmen",332,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,State Treasurer,,Republican,"Estes, Ron",626,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,State Treasurer,,Democratic,"Alldritt, Carmen",335,000370
+RILEY,Manhattan City Ward 05 Precinct 11,State Treasurer,,Republican,"Estes, Ron",640,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,State Treasurer,,Democratic,"Alldritt, Carmen",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,State Treasurer,,Republican,"Estes, Ron",2,000380
+RILEY,Manhattan Township Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",54,00039A
+RILEY,Manhattan Township Precinct 1,State Treasurer,,Republican,"Estes, Ron",181,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,State Treasurer,,Republican,"Estes, Ron",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,State Treasurer,,Republican,"Estes, Ron",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,State Treasurer,,Democratic,"Alldritt, Carmen",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,State Treasurer,,Republican,"Estes, Ron",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,State Treasurer,,Democratic,"Alldritt, Carmen",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,State Treasurer,,Republican,"Estes, Ron",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,State Treasurer,,Republican,"Estes, Ron",0,00039H
+RILEY,Manhattan Township Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",83,000400
+RILEY,Manhattan Township Precinct 2,State Treasurer,,Republican,"Estes, Ron",172,000400
+RILEY,Manhattan Township Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",27,000410
+RILEY,Manhattan Township Precinct 3,State Treasurer,,Republican,"Estes, Ron",60,000410
+RILEY,Manhattan Township Precinct 4,State Treasurer,,Democratic,"Alldritt, Carmen",62,000420
+RILEY,Manhattan Township Precinct 4,State Treasurer,,Republican,"Estes, Ron",155,000420
+RILEY,May Day Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000430
+RILEY,May Day Township,State Treasurer,,Republican,"Estes, Ron",33,000430
+RILEY,Ogden Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,00044A
+RILEY,Ogden Township,State Treasurer,,Republican,"Estes, Ron",134,00044A
+RILEY,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000450
+RILEY,Sherman Township,State Treasurer,,Republican,"Estes, Ron",189,000450
+RILEY,Swede Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000460
+RILEY,Swede Creek Township,State Treasurer,,Republican,"Estes, Ron",40,000460
+RILEY,Wildcat Township,State Treasurer,,Democratic,"Alldritt, Carmen",71,00047A
+RILEY,Wildcat Township,State Treasurer,,Republican,"Estes, Ron",340,00047A
+RILEY,Wildcat Township Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,00047B
+RILEY,Wildcat Township Enclave A,State Treasurer,,Republican,"Estes, Ron",0,00047B
+RILEY,Wildcat Township Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,00047C
+RILEY,Wildcat Township Enclave B,State Treasurer,,Republican,"Estes, Ron",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",16,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,State Treasurer,,Republican,"Estes, Ron",17,00047D
+RILEY,Zeandale Township,State Treasurer,,Democratic,"Alldritt, Carmen",41,000480
+RILEY,Zeandale Township,State Treasurer,,Republican,"Estes, Ron",137,000480
+RILEY,Fort Riley A Madison Township H64,State Treasurer,,Democratic,"Alldritt, Carmen",4,120020
+RILEY,Fort Riley A Madison Township H64,State Treasurer,,Republican,"Estes, Ron",5,120020
+RILEY,Fort Riley A Madison Township H67,State Treasurer,,Democratic,"Alldritt, Carmen",0,120030
+RILEY,Fort Riley A Madison Township H67,State Treasurer,,Republican,"Estes, Ron",0,120030
+RILEY,Madison Township H64,State Treasurer,,Democratic,"Alldritt, Carmen",99,120040
+RILEY,Madison Township H64,State Treasurer,,Republican,"Estes, Ron",297,120040
+RILEY,Madison Township H67,State Treasurer,,Democratic,"Alldritt, Carmen",3,120050
+RILEY,Madison Township H67,State Treasurer,,Republican,"Estes, Ron",12,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,State Treasurer,,Democratic,"Alldritt, Carmen",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,State Treasurer,,Republican,"Estes, Ron",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",62,300020
+RILEY,Manhattan City Ward 08 Precinct 01,State Treasurer,,Republican,"Estes, Ron",77,300020
+RILEY,Manhattan City Ward 08 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,State Treasurer,,Republican,"Estes, Ron",1,300030
+RILEY,Manhattan City Ward 09 Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",31,300040
+RILEY,Manhattan City Ward 09 Precinct 01,State Treasurer,,Republican,"Estes, Ron",59,300040
+RILEY,Manhattan City Ward 09 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",45,300050
+RILEY,Manhattan City Ward 09 Precinct 02,State Treasurer,,Republican,"Estes, Ron",67,300050
+RILEY,Ogden Township Fort Riley A,State Treasurer,,Democratic,"Alldritt, Carmen",69,300060
+RILEY,Ogden Township Fort Riley A,State Treasurer,,Republican,"Estes, Ron",173,300060
+RILEY,Ogden Township Ward 2 Annex order 506,State Treasurer,,Democratic,"Alldritt, Carmen",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,State Treasurer,,Republican,"Estes, Ron",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,State Treasurer,,Democratic,"Alldritt, Carmen",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,State Treasurer,,Republican,"Estes, Ron",0,300090
+RILEY,Ogden Township Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",0,300100
+RILEY,Ogden Township Ward 5,State Treasurer,,Republican,"Estes, Ron",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",256,400010
+RILEY,Manhattan City Ward 01 Precinct 01,State Treasurer,,Republican,"Estes, Ron",204,400010
+RILEY,Manhattan City Ward 02 Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",232,400020
+RILEY,Manhattan City Ward 02 Precinct 01,State Treasurer,,Republican,"Estes, Ron",158,400020
+RILEY,Manhattan City Ward 02 Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",338,400030
+RILEY,Manhattan City Ward 02 Precinct 03,State Treasurer,,Republican,"Estes, Ron",492,400030
+RILEY,Manhattan City Ward 03 Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",200,400040
+RILEY,Manhattan City Ward 03 Precinct 03,State Treasurer,,Republican,"Estes, Ron",285,400040
+RILEY,Manhattan City Ward 04 Precinct 04,State Treasurer,,Democratic,"Alldritt, Carmen",377,400050
+RILEY,Manhattan City Ward 04 Precinct 04,State Treasurer,,Republican,"Estes, Ron",543,400050
+RILEY,Manhattan City Ward 05 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",262,400060
+RILEY,Manhattan City Ward 05 Precinct 02,State Treasurer,,Republican,"Estes, Ron",177,400060
+RILEY,Manhattan City Ward 05 Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",223,400070
+RILEY,Manhattan City Ward 05 Precinct 03,State Treasurer,,Republican,"Estes, Ron",210,400070
+RILEY,Manhattan City Ward 04 Precinct 07,State Treasurer,,Democratic,"Alldritt, Carmen",2,400080
+RILEY,Manhattan City Ward 04 Precinct 07,State Treasurer,,Republican,"Estes, Ron",11,400080
+RILEY,Manhattan City Ward 04 Precinct 06,State Treasurer,,Democratic,"Alldritt, Carmen",59,400090
+RILEY,Manhattan City Ward 04 Precinct 06,State Treasurer,,Republican,"Estes, Ron",177,400090
+RILEY,Manhattan City Ward 11 Precinct 01,State Treasurer,,Democratic,"Alldritt, Carmen",49,500010
+RILEY,Manhattan City Ward 11 Precinct 01,State Treasurer,,Republican,"Estes, Ron",61,500010
+RILEY,Manhattan City Ward 08 Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",64,500030
+RILEY,Manhattan City Ward 08 Precinct 03,State Treasurer,,Republican,"Estes, Ron",92,500030
+RILEY,Manhattan City Ward 11 Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",3,600001
+RILEY,Manhattan City Ward 11 Precinct 03,State Treasurer,,Republican,"Estes, Ron",18,600001
+RILEY,Manhattan City Ward 09 Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",10,800001
+RILEY,Manhattan City Ward 09 Precinct 03,State Treasurer,,Republican,"Estes, Ron",27,800001
+RILEY,Ogden Township Enclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+RILEY,Ogden Township Enclave 1,State Treasurer,,Republican,"Estes, Ron",0,900010
+RILEY,Ogden Township Enclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+RILEY,Ogden Township Enclave 2,State Treasurer,,Republican,"Estes, Ron",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,State Treasurer,,Democratic,"Alldritt, Carmen",36,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,State Treasurer,,Republican,"Estes, Ron",63,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,State Treasurer,,Republican,"Estes, Ron",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,State Treasurer,,Republican,"Estes, Ron",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,State Treasurer,,Republican,"Estes, Ron",0,900060
+RILEY,Ashland Township,United States Senate,,independent,"Orman, Greg",46,000010
+RILEY,Ashland Township,United States Senate,,Libertarian,"Batson, Randall",4,000010
+RILEY,Ashland Township,United States Senate,,Republican,"Roberts, Pat",47,000010
+RILEY,Bala Township,United States Senate,,independent,"Orman, Greg",64,000020
+RILEY,Bala Township,United States Senate,,Libertarian,"Batson, Randall",13,000020
+RILEY,Bala Township,United States Senate,,Republican,"Roberts, Pat",188,000020
+RILEY,Center Township,United States Senate,,independent,"Orman, Greg",8,000030
+RILEY,Center Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+RILEY,Center Township,United States Senate,,Republican,"Roberts, Pat",31,000030
+RILEY,Fancy Creek Township,United States Senate,,independent,"Orman, Greg",7,000040
+RILEY,Fancy Creek Township,United States Senate,,Libertarian,"Batson, Randall",1,000040
+RILEY,Fancy Creek Township,United States Senate,,Republican,"Roberts, Pat",49,000040
+RILEY,Fort Riley B Madison Township,United States Senate,,independent,"Orman, Greg",5,00005B
+RILEY,Fort Riley B Madison Township,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+RILEY,Fort Riley B Madison Township,United States Senate,,Republican,"Roberts, Pat",3,00005B
+RILEY,Grant Township,United States Senate,,independent,"Orman, Greg",187,000060
+RILEY,Grant Township,United States Senate,,Libertarian,"Batson, Randall",15,000060
+RILEY,Grant Township,United States Senate,,Republican,"Roberts, Pat",325,000060
+RILEY,Jackson Township,United States Senate,,independent,"Orman, Greg",43,000070
+RILEY,Jackson Township,United States Senate,,Libertarian,"Batson, Randall",6,000070
+RILEY,Jackson Township,United States Senate,,Republican,"Roberts, Pat",80,000070
+RILEY,Manhattan City Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",131,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",9,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",52,000120
+RILEY,Manhattan City Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",216,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",26,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",213,000140
+RILEY,Manhattan City Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",133,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",6,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",60,000170
+RILEY,Manhattan City Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",107,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",5,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",89,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,United States Senate,,independent,"Orman, Greg",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States Senate,,Republican,"Roberts, Pat",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",310,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",14,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",177,000230
+RILEY,Manhattan City Ward 04 Precinct 05,United States Senate,,independent,"Orman, Greg",228,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",26,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States Senate,,Republican,"Roberts, Pat",234,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States Senate,,independent,"Orman, Greg",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,United States Senate,,independent,"Orman, Greg",129,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",10,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States Senate,,Republican,"Roberts, Pat",120,000310
+RILEY,Manhattan City Ward 05 Precinct 06,United States Senate,,independent,"Orman, Greg",273,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",23,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States Senate,,Republican,"Roberts, Pat",331,000320
+RILEY,Manhattan City Ward 05 Precinct 07,United States Senate,,independent,"Orman, Greg",127,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",4,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States Senate,,Republican,"Roberts, Pat",117,000330
+RILEY,Manhattan City Ward 05 Precinct 08,United States Senate,,independent,"Orman, Greg",176,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",7,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States Senate,,Republican,"Roberts, Pat",202,000340
+RILEY,Manhattan City Ward 05 Precinct 09,United States Senate,,independent,"Orman, Greg",488,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",5,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States Senate,,Republican,"Roberts, Pat",524,000350
+RILEY,Manhattan City Ward 05 Precinct 10,United States Senate,,independent,"Orman, Greg",428,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",20,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States Senate,,Republican,"Roberts, Pat",535,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,United States Senate,,independent,"Orman, Greg",432,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",26,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States Senate,,Republican,"Roberts, Pat",548,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States Senate,,independent,"Orman, Greg",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States Senate,,Libertarian,"Batson, Randall",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States Senate,,Republican,"Roberts, Pat",2,000380
+RILEY,Manhattan Township Precinct 1,United States Senate,,independent,"Orman, Greg",79,00039A
+RILEY,Manhattan Township Precinct 1,United States Senate,,Libertarian,"Batson, Randall",5,00039A
+RILEY,Manhattan Township Precinct 1,United States Senate,,Republican,"Roberts, Pat",158,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,United States Senate,,independent,"Orman, Greg",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States Senate,,Republican,"Roberts, Pat",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,United States Senate,,independent,"Orman, Greg",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States Senate,,Republican,"Roberts, Pat",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,United States Senate,,independent,"Orman, Greg",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States Senate,,Libertarian,"Batson, Randall",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States Senate,,Republican,"Roberts, Pat",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,United States Senate,,independent,"Orman, Greg",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States Senate,,Libertarian,"Batson, Randall",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States Senate,,Republican,"Roberts, Pat",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,United States Senate,,independent,"Orman, Greg",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States Senate,,Libertarian,"Batson, Randall",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States Senate,,Republican,"Roberts, Pat",0,00039H
+RILEY,Manhattan Township Precinct 2,United States Senate,,independent,"Orman, Greg",118,000400
+RILEY,Manhattan Township Precinct 2,United States Senate,,Libertarian,"Batson, Randall",17,000400
+RILEY,Manhattan Township Precinct 2,United States Senate,,Republican,"Roberts, Pat",123,000400
+RILEY,Manhattan Township Precinct 3,United States Senate,,independent,"Orman, Greg",35,000410
+RILEY,Manhattan Township Precinct 3,United States Senate,,Libertarian,"Batson, Randall",3,000410
+RILEY,Manhattan Township Precinct 3,United States Senate,,Republican,"Roberts, Pat",52,000410
+RILEY,Manhattan Township Precinct 4,United States Senate,,independent,"Orman, Greg",81,000420
+RILEY,Manhattan Township Precinct 4,United States Senate,,Libertarian,"Batson, Randall",9,000420
+RILEY,Manhattan Township Precinct 4,United States Senate,,Republican,"Roberts, Pat",131,000420
+RILEY,May Day Township,United States Senate,,independent,"Orman, Greg",3,000430
+RILEY,May Day Township,United States Senate,,Libertarian,"Batson, Randall",1,000430
+RILEY,May Day Township,United States Senate,,Republican,"Roberts, Pat",31,000430
+RILEY,Ogden Township,United States Senate,,independent,"Orman, Greg",36,00044A
+RILEY,Ogden Township,United States Senate,,Libertarian,"Batson, Randall",4,00044A
+RILEY,Ogden Township,United States Senate,,Republican,"Roberts, Pat",123,00044A
+RILEY,Sherman Township,United States Senate,,independent,"Orman, Greg",70,000450
+RILEY,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",5,000450
+RILEY,Sherman Township,United States Senate,,Republican,"Roberts, Pat",169,000450
+RILEY,Swede Creek Township,United States Senate,,independent,"Orman, Greg",25,000460
+RILEY,Swede Creek Township,United States Senate,,Libertarian,"Batson, Randall",1,000460
+RILEY,Swede Creek Township,United States Senate,,Republican,"Roberts, Pat",36,000460
+RILEY,Wildcat Township,United States Senate,,independent,"Orman, Greg",120,00047A
+RILEY,Wildcat Township,United States Senate,,Libertarian,"Batson, Randall",8,00047A
+RILEY,Wildcat Township,United States Senate,,Republican,"Roberts, Pat",292,00047A
+RILEY,Wildcat Township Enclave A,United States Senate,,independent,"Orman, Greg",0,00047B
+RILEY,Wildcat Township Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,00047B
+RILEY,Wildcat Township Enclave A,United States Senate,,Republican,"Roberts, Pat",0,00047B
+RILEY,Wildcat Township Enclave B,United States Senate,,independent,"Orman, Greg",0,00047C
+RILEY,Wildcat Township Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,00047C
+RILEY,Wildcat Township Enclave B,United States Senate,,Republican,"Roberts, Pat",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,United States Senate,,independent,"Orman, Greg",17,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States Senate,,Republican,"Roberts, Pat",16,00047D
+RILEY,Zeandale Township,United States Senate,,independent,"Orman, Greg",64,000480
+RILEY,Zeandale Township,United States Senate,,Libertarian,"Batson, Randall",7,000480
+RILEY,Zeandale Township,United States Senate,,Republican,"Roberts, Pat",108,000480
+RILEY,Fort Riley A Madison Township H64,United States Senate,,independent,"Orman, Greg",5,120020
+RILEY,Fort Riley A Madison Township H64,United States Senate,,Libertarian,"Batson, Randall",1,120020
+RILEY,Fort Riley A Madison Township H64,United States Senate,,Republican,"Roberts, Pat",5,120020
+RILEY,Fort Riley A Madison Township H67,United States Senate,,independent,"Orman, Greg",0,120030
+RILEY,Fort Riley A Madison Township H67,United States Senate,,Libertarian,"Batson, Randall",0,120030
+RILEY,Fort Riley A Madison Township H67,United States Senate,,Republican,"Roberts, Pat",0,120030
+RILEY,Madison Township H64,United States Senate,,independent,"Orman, Greg",150,120040
+RILEY,Madison Township H64,United States Senate,,Libertarian,"Batson, Randall",14,120040
+RILEY,Madison Township H64,United States Senate,,Republican,"Roberts, Pat",242,120040
+RILEY,Madison Township H67,United States Senate,,independent,"Orman, Greg",1,120050
+RILEY,Madison Township H67,United States Senate,,Libertarian,"Batson, Randall",0,120050
+RILEY,Madison Township H67,United States Senate,,Republican,"Roberts, Pat",14,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States Senate,,independent,"Orman, Greg",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States Senate,,Libertarian,"Batson, Randall",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States Senate,,Republican,"Roberts, Pat",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,United States Senate,,independent,"Orman, Greg",74,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",5,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States Senate,,Republican,"Roberts, Pat",60,300020
+RILEY,Manhattan City Ward 08 Precinct 02,United States Senate,,independent,"Orman, Greg",1,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States Senate,,Republican,"Roberts, Pat",0,300030
+RILEY,Manhattan City Ward 09 Precinct 01,United States Senate,,independent,"Orman, Greg",42,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States Senate,,Republican,"Roberts, Pat",49,300040
+RILEY,Manhattan City Ward 09 Precinct 02,United States Senate,,independent,"Orman, Greg",64,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",2,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States Senate,,Republican,"Roberts, Pat",50,300050
+RILEY,Ogden Township Fort Riley A,United States Senate,,independent,"Orman, Greg",95,300060
+RILEY,Ogden Township Fort Riley A,United States Senate,,Libertarian,"Batson, Randall",20,300060
+RILEY,Ogden Township Fort Riley A,United States Senate,,Republican,"Roberts, Pat",137,300060
+RILEY,Ogden Township Ward 2 Annex order 506,United States Senate,,independent,"Orman, Greg",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States Senate,,Libertarian,"Batson, Randall",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States Senate,,Republican,"Roberts, Pat",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States Senate,,independent,"Orman, Greg",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States Senate,,Libertarian,"Batson, Randall",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States Senate,,Republican,"Roberts, Pat",0,300090
+RILEY,Ogden Township Ward 5,United States Senate,,independent,"Orman, Greg",0,300100
+RILEY,Ogden Township Ward 5,United States Senate,,Libertarian,"Batson, Randall",0,300100
+RILEY,Ogden Township Ward 5,United States Senate,,Republican,"Roberts, Pat",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",295,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",19,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",162,400010
+RILEY,Manhattan City Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",279,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",13,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",116,400020
+RILEY,Manhattan City Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",412,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",52,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",385,400030
+RILEY,Manhattan City Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",246,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",245,400040
+RILEY,Manhattan City Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",463,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",21,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",463,400050
+RILEY,Manhattan City Ward 05 Precinct 02,United States Senate,,independent,"Orman, Greg",306,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",10,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States Senate,,Republican,"Roberts, Pat",137,400060
+RILEY,Manhattan City Ward 05 Precinct 03,United States Senate,,independent,"Orman, Greg",265,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",14,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States Senate,,Republican,"Roberts, Pat",179,400070
+RILEY,Manhattan City Ward 04 Precinct 07,United States Senate,,independent,"Orman, Greg",4,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",1,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States Senate,,Republican,"Roberts, Pat",9,400080
+RILEY,Manhattan City Ward 04 Precinct 06,United States Senate,,independent,"Orman, Greg",86,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",2,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States Senate,,Republican,"Roberts, Pat",154,400090
+RILEY,Manhattan City Ward 11 Precinct 01,United States Senate,,independent,"Orman, Greg",63,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",4,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States Senate,,Republican,"Roberts, Pat",50,500010
+RILEY,Manhattan City Ward 08 Precinct 03,United States Senate,,independent,"Orman, Greg",85,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",7,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States Senate,,Republican,"Roberts, Pat",69,500030
+RILEY,Manhattan City Ward 11 Precinct 03,United States Senate,,independent,"Orman, Greg",3,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",2,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States Senate,,Republican,"Roberts, Pat",17,600001
+RILEY,Manhattan City Ward 09 Precinct 03,United States Senate,,independent,"Orman, Greg",15,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",1,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States Senate,,Republican,"Roberts, Pat",20,800001
+RILEY,Ogden Township Enclave 1,United States Senate,,independent,"Orman, Greg",0,900010
+RILEY,Ogden Township Enclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900010
+RILEY,Ogden Township Enclave 1,United States Senate,,Republican,"Roberts, Pat",0,900010
+RILEY,Ogden Township Enclave 2,United States Senate,,independent,"Orman, Greg",0,900020
+RILEY,Ogden Township Enclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900020
+RILEY,Ogden Township Enclave 2,United States Senate,,Republican,"Roberts, Pat",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States Senate,,independent,"Orman, Greg",42,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States Senate,,Libertarian,"Batson, Randall",7,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States Senate,,Republican,"Roberts, Pat",50,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States Senate,,independent,"Orman, Greg",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States Senate,,Libertarian,"Batson, Randall",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States Senate,,Republican,"Roberts, Pat",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,United States Senate,,independent,"Orman, Greg",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States Senate,,Libertarian,"Batson, Randall",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States Senate,,Republican,"Roberts, Pat",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,United States Senate,,independent,"Orman, Greg",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States Senate,,Republican,"Roberts, Pat",0,900060

--- a/2014/20141104__ks__general__rooks__precinct.csv
+++ b/2014/20141104__ks__general__rooks__precinct.csv
@@ -1,239 +1,271 @@
-county,precinct,office,district,party,candidate,votes
-Rooks,Pre 1,U.S. Senate,,R,Pat Roberts,56
-Rooks,Pre 2,U.S. Senate,,R,Pat Roberts,122
-Rooks,Pre 3-1,U.S. Senate,,R,Pat Roberts,27
-Rooks,Pre 3-2,U.S. Senate,,R,Pat Roberts,330
-Rooks,Pre 4,U.S. Senate,,R,Pat Roberts,11
-Rooks,Pre 5,U.S. Senate,,R,Pat Roberts,39
-Rooks,Pre 6,U.S. Senate,,R,Pat Roberts,31
-Rooks,Pre 7,U.S. Senate,,R,Pat Roberts,49
-Rooks,Pre 8,U.S. Senate,,R,Pat Roberts,85
-Rooks,Pre 9,U.S. Senate,,R,Pat Roberts,20
-Rooks,Pre 10,U.S. Senate,,R,Pat Roberts,44
-Rooks,Pre 11-1,U.S. Senate,,R,Pat Roberts,183
-Rooks,Pre 11-2,U.S. Senate,,R,Pat Roberts,462
-Rooks,Pre 12,U.S. Senate,,R,Pat Roberts,51
-Rooks,Pre 1,U.S. Senate,,L,Randall Batson,5
-Rooks,Pre 2,U.S. Senate,,L,Randall Batson,6
-Rooks,Pre 3-1,U.S. Senate,,L,Randall Batson,2
-Rooks,Pre 3-2,U.S. Senate,,L,Randall Batson,34
-Rooks,Pre 4,U.S. Senate,,L,Randall Batson,0
-Rooks,Pre 5,U.S. Senate,,L,Randall Batson,0
-Rooks,Pre 6,U.S. Senate,,L,Randall Batson,1
-Rooks,Pre 7,U.S. Senate,,L,Randall Batson,5
-Rooks,Pre 8,U.S. Senate,,L,Randall Batson,3
-Rooks,Pre 9,U.S. Senate,,L,Randall Batson,0
-Rooks,Pre 10,U.S. Senate,,L,Randall Batson,8
-Rooks,Pre 11-1,U.S. Senate,,L,Randall Batson,14
-Rooks,Pre 11-2,U.S. Senate,,L,Randall Batson,43
-Rooks,Pre 12,U.S. Senate,,L,Randall Batson,0
-Rooks,Pre 1,U.S. Senate,,I,Greg Orman,16
-Rooks,Pre 2,U.S. Senate,,I,Greg Orman,28
-Rooks,Pre 3-1,U.S. Senate,,I,Greg Orman,6
-Rooks,Pre 3-2,U.S. Senate,,I,Greg Orman,106
-Rooks,Pre 4,U.S. Senate,,I,Greg Orman,8
-Rooks,Pre 5,U.S. Senate,,I,Greg Orman,4
-Rooks,Pre 6,U.S. Senate,,I,Greg Orman,6
-Rooks,Pre 7,U.S. Senate,,I,Greg Orman,15
-Rooks,Pre 8,U.S. Senate,,I,Greg Orman,26
-Rooks,Pre 9,U.S. Senate,,I,Greg Orman,8
-Rooks,Pre 10,U.S. Senate,,I,Greg Orman,11
-Rooks,Pre 11-1,U.S. Senate,,I,Greg Orman,44
-Rooks,Pre 11-2,U.S. Senate,,I,Greg Orman,99
-Rooks,Pre 12,U.S. Senate,,I,Greg Orman,19
-Rooks,Pre 1,U.S. House,1,D,James Sherow,12
-Rooks,Pre 2,U.S. House,1,D,James Sherow,37
-Rooks,Pre 3-1,U.S. House,1,D,James Sherow,7
-Rooks,Pre 3-2,U.S. House,1,D,James Sherow,101
-Rooks,Pre 4,U.S. House,1,D,James Sherow,9
-Rooks,Pre 5,U.S. House,1,D,James Sherow,4
-Rooks,Pre 6,U.S. House,1,D,James Sherow,6
-Rooks,Pre 7,U.S. House,1,D,James Sherow,15
-Rooks,Pre 8,U.S. House,1,D,James Sherow,29
-Rooks,Pre 9,U.S. House,1,D,James Sherow,5
-Rooks,Pre 10,U.S. House,1,D,James Sherow,12
-Rooks,Pre 11-1,U.S. House,1,D,James Sherow,43
-Rooks,Pre 11-2,U.S. House,1,D,James Sherow,107
-Rooks,Pre 12,U.S. House,1,D,James Sherow,15
-Rooks,Pre 1,U.S. House,1,R,Tim Huelskamp,62
-Rooks,Pre 2,U.S. House,1,R,Tim Huelskamp,114
-Rooks,Pre 3-1,U.S. House,1,R,Tim Huelskamp,27
-Rooks,Pre 3-2,U.S. House,1,R,Tim Huelskamp,366
-Rooks,Pre 4,U.S. House,1,R,Tim Huelskamp,11
-Rooks,Pre 5,U.S. House,1,R,Tim Huelskamp,39
-Rooks,Pre 6,U.S. House,1,R,Tim Huelskamp,32
-Rooks,Pre 7,U.S. House,1,R,Tim Huelskamp,54
-Rooks,Pre 8,U.S. House,1,R,Tim Huelskamp,83
-Rooks,Pre 9,U.S. House,1,R,Tim Huelskamp,23
-Rooks,Pre 10,U.S. House,1,R,Tim Huelskamp,50
-Rooks,Pre 11-1,U.S. House,1,R,Tim Huelskamp,195
-Rooks,Pre 11-2,U.S. House,1,R,Tim Huelskamp,491
-Rooks,Pre 12,U.S. House,1,R,Tim Huelskamp,51
-Rooks,Pre 1,Governor,,R,Sam Brownback,54
-Rooks,Pre 2,Governor,,R,Sam Brownback,103
-Rooks,Pre 3-1,Governor,,R,Sam Brownback,26
-Rooks,Pre 3-2,Governor,,R,Sam Brownback,303
-Rooks,Pre 4,Governor,,R,Sam Brownback,12
-Rooks,Pre 5,Governor,,R,Sam Brownback,37
-Rooks,Pre 6,Governor,,R,Sam Brownback,30
-Rooks,Pre 7,Governor,,R,Sam Brownback,46
-Rooks,Pre 8,Governor,,R,Sam Brownback,79
-Rooks,Pre 9,Governor,,R,Sam Brownback,22
-Rooks,Pre 10,Governor,,R,Sam Brownback,46
-Rooks,Pre 11-1,Governor,,R,Sam Brownback,180
-Rooks,Pre 11-2,Governor,,R,Sam Brownback,425
-Rooks,Pre 12,Governor,,R,Sam Brownback,53
-Rooks,Pre 1,Governor,,D,Paul Davis,18
-Rooks,Pre 2,Governor,,D,Paul Davis,41
-Rooks,Pre 3-1,Governor,,D,Paul Davis,9
-Rooks,Pre 3-2,Governor,,D,Paul Davis,130
-Rooks,Pre 4,Governor,,D,Paul Davis,8
-Rooks,Pre 5,Governor,,D,Paul Davis,4
-Rooks,Pre 6,Governor,,D,Paul Davis,6
-Rooks,Pre 7,Governor,,D,Paul Davis,20
-Rooks,Pre 8,Governor,,D,Paul Davis,32
-Rooks,Pre 9,Governor,,D,Paul Davis,6
-Rooks,Pre 10,Governor,,D,Paul Davis,14
-Rooks,Pre 11-1,Governor,,D,Paul Davis,50
-Rooks,Pre 11-2,Governor,,D,Paul Davis,151
-Rooks,Pre 12,Governor,,D,Paul Davis,17
-Rooks,Pre 1,Governor,,L,Keen Umbehr,4
-Rooks,Pre 2,Governor,,L,Keen Umbehr,12
-Rooks,Pre 3-1,Governor,,L,Keen Umbehr,0
-Rooks,Pre 3-2,Governor,,L,Keen Umbehr,36
-Rooks,Pre 4,Governor,,L,Keen Umbehr,0
-Rooks,Pre 5,Governor,,L,Keen Umbehr,2
-Rooks,Pre 6,Governor,,L,Keen Umbehr,2
-Rooks,Pre 7,Governor,,L,Keen Umbehr,5
-Rooks,Pre 8,Governor,,L,Keen Umbehr,2
-Rooks,Pre 9,Governor,,L,Keen Umbehr,0
-Rooks,Pre 10,Governor,,L,Keen Umbehr,2
-Rooks,Pre 11-1,Governor,,L,Keen Umbehr,10
-Rooks,Pre 11-2,Governor,,L,Keen Umbehr,30
-Rooks,Pre 12,Governor,,L,Keen Umbehr,1
-Rooks,Pre 1,Secretary of State,,D,Jean Schodorf,13
-Rooks,Pre 2,Secretary of State,,D,Jean Schodorf,26
-Rooks,Pre 3-1,Secretary of State,,D,Jean Schodorf,10
-Rooks,Pre 3-2,Secretary of State,,D,Jean Schodorf,110
-Rooks,Pre 4,Secretary of State,,D,Jean Schodorf,8
-Rooks,Pre 5,Secretary of State,,D,Jean Schodorf,3
-Rooks,Pre 6,Secretary of State,,D,Jean Schodorf,7
-Rooks,Pre 7,Secretary of State,,D,Jean Schodorf,20
-Rooks,Pre 8,Secretary of State,,D,Jean Schodorf,37
-Rooks,Pre 9,Secretary of State,,D,Jean Schodorf,6
-Rooks,Pre 10,Secretary of State,,D,Jean Schodorf,9
-Rooks,Pre 11-1,Secretary of State,,D,Jean Schodorf,42
-Rooks,Pre 11-2,Secretary of State,,D,Jean Schodorf,105
-Rooks,Pre 12,Secretary of State,,D,Jean Schodorf,17
-Rooks,Pre 1,Secretary of State,,R,Kris Kobach,62
-Rooks,Pre 2,Secretary of State,,R,Kris Kobach,125
-Rooks,Pre 3-1,Secretary of State,,R,Kris Kobach,24
-Rooks,Pre 3-2,Secretary of State,,R,Kris Kobach,357
-Rooks,Pre 4,Secretary of State,,R,Kris Kobach,10
-Rooks,Pre 5,Secretary of State,,R,Kris Kobach,40
-Rooks,Pre 6,Secretary of State,,R,Kris Kobach,31
-Rooks,Pre 7,Secretary of State,,R,Kris Kobach,47
-Rooks,Pre 8,Secretary of State,,R,Kris Kobach,76
-Rooks,Pre 9,Secretary of State,,R,Kris Kobach,22
-Rooks,Pre 10,Secretary of State,,R,Kris Kobach,53
-Rooks,Pre 11-1,Secretary of State,,R,Kris Kobach,195
-Rooks,Pre 11-2,Secretary of State,,R,Kris Kobach,490
-Rooks,Pre 12,Secretary of State,,R,Kris Kobach,50
-Rooks,Pre 1,Attorney General,,D,AJ Kotich,13
-Rooks,Pre 2,Attorney General,,D,AJ Kotich,22
-Rooks,Pre 3-1,Attorney General,,D,AJ Kotich,3
-Rooks,Pre 3-2,Attorney General,,D,AJ Kotich,61
-Rooks,Pre 4,Attorney General,,D,AJ Kotich,6
-Rooks,Pre 5,Attorney General,,D,AJ Kotich,2
-Rooks,Pre 6,Attorney General,,D,AJ Kotich,6
-Rooks,Pre 7,Attorney General,,D,AJ Kotich,18
-Rooks,Pre 8,Attorney General,,D,AJ Kotich,23
-Rooks,Pre 9,Attorney General,,D,AJ Kotich,6
-Rooks,Pre 10,Attorney General,,D,AJ Kotich,4
-Rooks,Pre 11-1,Attorney General,,D,AJ Kotich,29
-Rooks,Pre 11-2,Attorney General,,D,AJ Kotich,70
-Rooks,Pre 12,Attorney General,,D,AJ Kotich,10
-Rooks,Pre 1,Attorney General,,R,Derek Schmidt,63
-Rooks,Pre 2,Attorney General,,R,Derek Schmidt,136
-Rooks,Pre 3-1,Attorney General,,R,Derek Schmidt,31
-Rooks,Pre 3-2,Attorney General,,R,Derek Schmidt,388
-Rooks,Pre 4,Attorney General,,R,Derek Schmidt,11
-Rooks,Pre 5,Attorney General,,R,Derek Schmidt,40
-Rooks,Pre 6,Attorney General,,R,Derek Schmidt,33
-Rooks,Pre 7,Attorney General,,R,Derek Schmidt,52
-Rooks,Pre 8,Attorney General,,R,Derek Schmidt,85
-Rooks,Pre 9,Attorney General,,R,Derek Schmidt,21
-Rooks,Pre 10,Attorney General,,R,Derek Schmidt,53
-Rooks,Pre 11-1,Attorney General,,R,Derek Schmidt,209
-Rooks,Pre 11-2,Attorney General,,R,Derek Schmidt,528
-Rooks,Pre 12,Attorney General,,R,Derek Schmidt,56
-Rooks,Pre 1,State Treasurer,,D,Carmen Alldritt,11
-Rooks,Pre 2,State Treasurer,,D,Carmen Alldritt,15
-Rooks,Pre 3-1,State Treasurer,,D,Carmen Alldritt,3
-Rooks,Pre 3-2,State Treasurer,,D,Carmen Alldritt,68
-Rooks,Pre 4,State Treasurer,,D,Carmen Alldritt,7
-Rooks,Pre 5,State Treasurer,,D,Carmen Alldritt,3
-Rooks,Pre 6,State Treasurer,,D,Carmen Alldritt,4
-Rooks,Pre 7,State Treasurer,,D,Carmen Alldritt,13
-Rooks,Pre 8,State Treasurer,,D,Carmen Alldritt,26
-Rooks,Pre 9,State Treasurer,,D,Carmen Alldritt,6
-Rooks,Pre 10,State Treasurer,,D,Carmen Alldritt,6
-Rooks,Pre 11-1,State Treasurer,,D,Carmen Alldritt,29
-Rooks,Pre 11-2,State Treasurer,,D,Carmen Alldritt,63
-Rooks,Pre 12,State Treasurer,,D,Carmen Alldritt,12
-Rooks,Pre 1,Insurance Commissioner,,R,Ken Selzer,59
-Rooks,Pre 2,Insurance Commissioner,,R,Ken Selzer,125
-Rooks,Pre 3-1,Insurance Commissioner,,R,Ken Selzer,23
-Rooks,Pre 3-2,Insurance Commissioner,,R,Ken Selzer,369
-Rooks,Pre 4,Insurance Commissioner,,R,Ken Selzer,12
-Rooks,Pre 5,Insurance Commissioner,,R,Ken Selzer,41
-Rooks,Pre 6,Insurance Commissioner,,R,Ken Selzer,30
-Rooks,Pre 7,Insurance Commissioner,,R,Ken Selzer,49
-Rooks,Pre 8,Insurance Commissioner,,R,Ken Selzer,79
-Rooks,Pre 9,Insurance Commissioner,,R,Ken Selzer,21
-Rooks,Pre 10,Insurance Commissioner,,R,Ken Selzer,51
-Rooks,Pre 11-1,Insurance Commissioner,,R,Ken Selzer,194
-Rooks,Pre 11-2,Insurance Commissioner,,R,Ken Selzer,479
-Rooks,Pre 12,Insurance Commissioner,,R,Ken Selzer,53
-Rooks,Pre 1,Insurance Commissioner,,D,Dennis Anderson,14
-Rooks,Pre 2,Insurance Commissioner,,D,Dennis Anderson,26
-Rooks,Pre 3-1,Insurance Commissioner,,D,Dennis Anderson,9
-Rooks,Pre 3-2,Insurance Commissioner,,D,Dennis Anderson,82
-Rooks,Pre 4,Insurance Commissioner,,D,Dennis Anderson,6
-Rooks,Pre 5,Insurance Commissioner,,D,Dennis Anderson,2
-Rooks,Pre 6,Insurance Commissioner,,D,Dennis Anderson,7
-Rooks,Pre 7,Insurance Commissioner,,D,Dennis Anderson,14
-Rooks,Pre 8,Insurance Commissioner,,D,Dennis Anderson,26
-Rooks,Pre 9,Insurance Commissioner,,D,Dennis Anderson,5
-Rooks,Pre 10,Insurance Commissioner,,D,Dennis Anderson,8
-Rooks,Pre 11-1,Insurance Commissioner,,D,Dennis Anderson,42
-Rooks,Pre 11-2,Insurance Commissioner,,D,Dennis Anderson,104
-Rooks,Pre 12,Insurance Commissioner,,D,Dennis Anderson,13
-Rooks,Pre 1,State Treasurer,,R,Ron Estes,63
-Rooks,Pre 2,State Treasurer,,R,Ron Estes,136
-Rooks,Pre 3-1,State Treasurer,,R,Ron Estes,31
-Rooks,Pre 3-2,State Treasurer,,R,Ron Estes,388
-Rooks,Pre 4,State Treasurer,,R,Ron Estes,11
-Rooks,Pre 5,State Treasurer,,R,Ron Estes,40
-Rooks,Pre 6,State Treasurer,,R,Ron Estes,33
-Rooks,Pre 7,State Treasurer,,R,Ron Estes,52
-Rooks,Pre 8,State Treasurer,,R,Ron Estes,85
-Rooks,Pre 9,State Treasurer,,R,Ron Estes,21
-Rooks,Pre 10,State Treasurer,,R,Ron Estes,53
-Rooks,Pre 11-1,State Treasurer,,R,Ron Estes,209
-Rooks,Pre 11-2,State Treasurer,,R,Ron Estes,528
-Rooks,Pre 12,State Treasurer,,R,Ron Estes,56
-Rooks,Pre 1,State House,110,R,Travis Couture-Lovelady,67
-Rooks,Pre 2,State House,110,R,Travis Couture-Lovelady,146
-Rooks,Pre 3-1,State House,110,R,Travis Couture-Lovelady,30
-Rooks,Pre 3-2,State House,110,R,Travis Couture-Lovelady,418
-Rooks,Pre 4,State House,110,R,Travis Couture-Lovelady,14
-Rooks,Pre 5,State House,110,R,Travis Couture-Lovelady,41
-Rooks,Pre 6,State House,110,R,Travis Couture-Lovelady,34
-Rooks,Pre 7,State House,110,R,Travis Couture-Lovelady,62
-Rooks,Pre 8,State House,110,R,Travis Couture-Lovelady,98
-Rooks,Pre 9,State House,110,R,Travis Couture-Lovelady,24
-Rooks,Pre 10,State House,110,R,Travis Couture-Lovelady,55
-Rooks,Pre 11-1,State House,110,R,Travis Couture-Lovelady,213
-Rooks,Pre 11-2,State House,110,R,Travis Couture-Lovelady,527
-Rooks,Pre 12,State House,110,R,Travis Couture-Lovelady,61
+county,precinct,office,district,party,candidate,votes,vtd
+ROOKS,Township 01,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000010
+ROOKS,Township 01,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+ROOKS,Township 01,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000010
+ROOKS,Township 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",41,000020
+ROOKS,Township 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000020
+ROOKS,Township 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000020
+ROOKS,Township 03 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000030
+ROOKS,Township 03 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+ROOKS,Township 03 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000030
+ROOKS,Township 03 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",130,000040
+ROOKS,Township 03 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",36,000040
+ROOKS,Township 03 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",303,000040
+ROOKS,Township 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000050
+ROOKS,Township 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+ROOKS,Township 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000050
+ROOKS,Township 06,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000070
+ROOKS,Township 06,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000070
+ROOKS,Township 06,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000070
+ROOKS,Township 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000080
+ROOKS,Township 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000080
+ROOKS,Township 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000080
+ROOKS,Township 08,Governor / Lt. Governor,,Democratic,"Davis, Paul",32,000090
+ROOKS,Township 08,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000090
+ROOKS,Township 08,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000090
+ROOKS,Township 09,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000100
+ROOKS,Township 09,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+ROOKS,Township 09,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000100
+ROOKS,Township 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000110
+ROOKS,Township 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000110
+ROOKS,Township 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000110
+ROOKS,Township 11 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000120
+ROOKS,Township 11 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000120
+ROOKS,Township 11 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",180,000120
+ROOKS,Township 11 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",151,000130
+ROOKS,Township 11 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000130
+ROOKS,Township 11 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",425,000130
+ROOKS,Township 12,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000140
+ROOKS,Township 12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+ROOKS,Township 12,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000140
+ROOKS,Township 05 H110,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,120020
+ROOKS,Township 05 H110,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120020
+ROOKS,Township 05 H110,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,120020
+ROOKS,Township 05 H118 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12003A
+ROOKS,Township 05 H118 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12003A
+ROOKS,Township 05 H118 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12003A
+ROOKS,Township 05 H118,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120030
+ROOKS,Township 05 H118,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+ROOKS,Township 05 H118,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120030
+ROOKS,Township 01,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",67,000010
+ROOKS,Township 02,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",146,000020
+ROOKS,Township 03 Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",30,000030
+ROOKS,Township 03 Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",418,000040
+ROOKS,Township 04,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",14,000050
+ROOKS,Township 06,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",34,000070
+ROOKS,Township 07,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",62,000080
+ROOKS,Township 08,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",98,000090
+ROOKS,Township 09,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",24,000100
+ROOKS,Township 10,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",55,000110
+ROOKS,Township 11 Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",213,000120
+ROOKS,Township 11 Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",527,000130
+ROOKS,Township 12,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",61,000140
+ROOKS,Township 05 H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",41,120020
+ROOKS,Township 01,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000010
+ROOKS,Township 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",62,000010
+ROOKS,Township 02,United States House of Representatives,1,Democratic,"Sherow, James E.",37,000020
+ROOKS,Township 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",114,000020
+ROOKS,Township 03 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000030
+ROOKS,Township 03 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000030
+ROOKS,Township 03 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",101,000040
+ROOKS,Township 03 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",366,000040
+ROOKS,Township 04,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000050
+ROOKS,Township 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000050
+ROOKS,Township 06,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000070
+ROOKS,Township 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000070
+ROOKS,Township 07,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000080
+ROOKS,Township 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,000080
+ROOKS,Township 08,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000090
+ROOKS,Township 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",83,000090
+ROOKS,Township 09,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000100
+ROOKS,Township 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000100
+ROOKS,Township 10,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000110
+ROOKS,Township 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000110
+ROOKS,Township 11 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",43,000120
+ROOKS,Township 11 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",195,000120
+ROOKS,Township 11 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",107,000130
+ROOKS,Township 11 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",491,000130
+ROOKS,Township 12,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000140
+ROOKS,Township 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000140
+ROOKS,Township 05 H110,United States House of Representatives,1,Democratic,"Sherow, James E.",4,120020
+ROOKS,Township 05 H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,120020
+ROOKS,Township 05 H118 A,United States House of Representatives,1,Democratic,"Sherow, James E.",0,12003A
+ROOKS,Township 05 H118 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12003A
+ROOKS,Township 05 H118,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120030
+ROOKS,Township 05 H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120030
+ROOKS,Township 01,Attorney General,,Democratic,"Kotich, A.J.",13,000010
+ROOKS,Township 01,Attorney General,,Republican,"Schmidt, Derek",58,000010
+ROOKS,Township 02,Attorney General,,Democratic,"Kotich, A.J.",22,000020
+ROOKS,Township 02,Attorney General,,Republican,"Schmidt, Derek",130,000020
+ROOKS,Township 03 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",3,000030
+ROOKS,Township 03 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",30,000030
+ROOKS,Township 03 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",61,000040
+ROOKS,Township 03 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",393,000040
+ROOKS,Township 04,Attorney General,,Democratic,"Kotich, A.J.",6,000050
+ROOKS,Township 04,Attorney General,,Republican,"Schmidt, Derek",12,000050
+ROOKS,Township 06,Attorney General,,Democratic,"Kotich, A.J.",6,000070
+ROOKS,Township 06,Attorney General,,Republican,"Schmidt, Derek",31,000070
+ROOKS,Township 07,Attorney General,,Democratic,"Kotich, A.J.",18,000080
+ROOKS,Township 07,Attorney General,,Republican,"Schmidt, Derek",47,000080
+ROOKS,Township 08,Attorney General,,Democratic,"Kotich, A.J.",23,000090
+ROOKS,Township 08,Attorney General,,Republican,"Schmidt, Derek",85,000090
+ROOKS,Township 09,Attorney General,,Democratic,"Kotich, A.J.",6,000100
+ROOKS,Township 09,Attorney General,,Republican,"Schmidt, Derek",21,000100
+ROOKS,Township 10,Attorney General,,Democratic,"Kotich, A.J.",4,000110
+ROOKS,Township 10,Attorney General,,Republican,"Schmidt, Derek",56,000110
+ROOKS,Township 11 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",29,000120
+ROOKS,Township 11 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",208,000120
+ROOKS,Township 11 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",70,000130
+ROOKS,Township 11 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",525,000130
+ROOKS,Township 12,Attorney General,,Democratic,"Kotich, A.J.",10,000140
+ROOKS,Township 12,Attorney General,,Republican,"Schmidt, Derek",58,000140
+ROOKS,Township 05 H110,Attorney General,,Democratic,"Kotich, A.J.",2,120020
+ROOKS,Township 05 H110,Attorney General,,Republican,"Schmidt, Derek",41,120020
+ROOKS,Township 05 H118 A,Attorney General,,Democratic,"Kotich, A.J.",0,12003A
+ROOKS,Township 05 H118 A,Attorney General,,Republican,"Schmidt, Derek",0,12003A
+ROOKS,Township 05 H118,Attorney General,,Democratic,"Kotich, A.J.",0,120030
+ROOKS,Township 05 H118,Attorney General,,Republican,"Schmidt, Derek",0,120030
+ROOKS,Township 01,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000010
+ROOKS,Township 01,Commissioner of Insurance,,Republican,"Selzer, Ken",59,000010
+ROOKS,Township 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000020
+ROOKS,Township 02,Commissioner of Insurance,,Republican,"Selzer, Ken",125,000020
+ROOKS,Township 03 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000030
+ROOKS,Township 03 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000030
+ROOKS,Township 03 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",82,000040
+ROOKS,Township 03 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",369,000040
+ROOKS,Township 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000050
+ROOKS,Township 04,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000050
+ROOKS,Township 06,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000070
+ROOKS,Township 06,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000070
+ROOKS,Township 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000080
+ROOKS,Township 07,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000080
+ROOKS,Township 08,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000090
+ROOKS,Township 08,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000090
+ROOKS,Township 09,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000100
+ROOKS,Township 09,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000100
+ROOKS,Township 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000110
+ROOKS,Township 10,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000110
+ROOKS,Township 11 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000120
+ROOKS,Township 11 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",194,000120
+ROOKS,Township 11 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",104,000130
+ROOKS,Township 11 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",479,000130
+ROOKS,Township 12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000140
+ROOKS,Township 12,Commissioner of Insurance,,Republican,"Selzer, Ken",53,000140
+ROOKS,Township 05 H110,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,120020
+ROOKS,Township 05 H110,Commissioner of Insurance,,Republican,"Selzer, Ken",41,120020
+ROOKS,Township 05 H118 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12003A
+ROOKS,Township 05 H118 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12003A
+ROOKS,Township 05 H118,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120030
+ROOKS,Township 05 H118,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120030
+ROOKS,Township 01,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000010
+ROOKS,Township 01,Secretary of State,,Republican,"Kobach, Kris",62,000010
+ROOKS,Township 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000020
+ROOKS,Township 02,Secretary of State,,Republican,"Kobach, Kris",125,000020
+ROOKS,Township 03 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000030
+ROOKS,Township 03 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",24,000030
+ROOKS,Township 03 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",110,000040
+ROOKS,Township 03 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",357,000040
+ROOKS,Township 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000050
+ROOKS,Township 04,Secretary of State,,Republican,"Kobach, Kris",10,000050
+ROOKS,Township 06,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000070
+ROOKS,Township 06,Secretary of State,,Republican,"Kobach, Kris",31,000070
+ROOKS,Township 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000080
+ROOKS,Township 07,Secretary of State,,Republican,"Kobach, Kris",47,000080
+ROOKS,Township 08,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000090
+ROOKS,Township 08,Secretary of State,,Republican,"Kobach, Kris",76,000090
+ROOKS,Township 09,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000100
+ROOKS,Township 09,Secretary of State,,Republican,"Kobach, Kris",22,000100
+ROOKS,Township 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000110
+ROOKS,Township 10,Secretary of State,,Republican,"Kobach, Kris",53,000110
+ROOKS,Township 11 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000120
+ROOKS,Township 11 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",195,000120
+ROOKS,Township 11 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",105,000130
+ROOKS,Township 11 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",490,000130
+ROOKS,Township 12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000140
+ROOKS,Township 12,Secretary of State,,Republican,"Kobach, Kris",50,000140
+ROOKS,Township 05 H110,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,120020
+ROOKS,Township 05 H110,Secretary of State,,Republican,"Kobach, Kris",40,120020
+ROOKS,Township 05 H118 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12003A
+ROOKS,Township 05 H118 A,Secretary of State,,Republican,"Kobach, Kris",0,12003A
+ROOKS,Township 05 H118,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120030
+ROOKS,Township 05 H118,Secretary of State,,Republican,"Kobach, Kris",0,120030
+ROOKS,Township 01,State Treasurer,,Democratic,"Alldritt, Carmen",11,000010
+ROOKS,Township 01,State Treasurer,,Republican,"Estes, Ron",63,000010
+ROOKS,Township 02,State Treasurer,,Democratic,"Alldritt, Carmen",15,000020
+ROOKS,Township 02,State Treasurer,,Republican,"Estes, Ron",136,000020
+ROOKS,Township 03 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+ROOKS,Township 03 Precinct 1,State Treasurer,,Republican,"Estes, Ron",31,000030
+ROOKS,Township 03 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",68,000040
+ROOKS,Township 03 Precinct 2,State Treasurer,,Republican,"Estes, Ron",388,000040
+ROOKS,Township 04,State Treasurer,,Democratic,"Alldritt, Carmen",7,000050
+ROOKS,Township 04,State Treasurer,,Republican,"Estes, Ron",11,000050
+ROOKS,Township 06,State Treasurer,,Democratic,"Alldritt, Carmen",4,000070
+ROOKS,Township 06,State Treasurer,,Republican,"Estes, Ron",33,000070
+ROOKS,Township 07,State Treasurer,,Democratic,"Alldritt, Carmen",13,000080
+ROOKS,Township 07,State Treasurer,,Republican,"Estes, Ron",52,000080
+ROOKS,Township 08,State Treasurer,,Democratic,"Alldritt, Carmen",26,000090
+ROOKS,Township 08,State Treasurer,,Republican,"Estes, Ron",85,000090
+ROOKS,Township 09,State Treasurer,,Democratic,"Alldritt, Carmen",6,000100
+ROOKS,Township 09,State Treasurer,,Republican,"Estes, Ron",21,000100
+ROOKS,Township 10,State Treasurer,,Democratic,"Alldritt, Carmen",6,000110
+ROOKS,Township 10,State Treasurer,,Republican,"Estes, Ron",53,000110
+ROOKS,Township 11 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",29,000120
+ROOKS,Township 11 Precinct 1,State Treasurer,,Republican,"Estes, Ron",209,000120
+ROOKS,Township 11 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",63,000130
+ROOKS,Township 11 Precinct 2,State Treasurer,,Republican,"Estes, Ron",528,000130
+ROOKS,Township 12,State Treasurer,,Democratic,"Alldritt, Carmen",12,000140
+ROOKS,Township 12,State Treasurer,,Republican,"Estes, Ron",56,000140
+ROOKS,Township 05 H110,State Treasurer,,Democratic,"Alldritt, Carmen",3,120020
+ROOKS,Township 05 H110,State Treasurer,,Republican,"Estes, Ron",40,120020
+ROOKS,Township 05 H118 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,12003A
+ROOKS,Township 05 H118 A,State Treasurer,,Republican,"Estes, Ron",0,12003A
+ROOKS,Township 05 H118,State Treasurer,,Democratic,"Alldritt, Carmen",0,120030
+ROOKS,Township 05 H118,State Treasurer,,Republican,"Estes, Ron",0,120030
+ROOKS,Township 01,United States Senate,,independent,"Orman, Greg",16,000010
+ROOKS,Township 01,United States Senate,,Libertarian,"Batson, Randall",5,000010
+ROOKS,Township 01,United States Senate,,Republican,"Roberts, Pat",56,000010
+ROOKS,Township 02,United States Senate,,independent,"Orman, Greg",28,000020
+ROOKS,Township 02,United States Senate,,Libertarian,"Batson, Randall",6,000020
+ROOKS,Township 02,United States Senate,,Republican,"Roberts, Pat",122,000020
+ROOKS,Township 03 Precinct 1,United States Senate,,independent,"Orman, Greg",6,000030
+ROOKS,Township 03 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",2,000030
+ROOKS,Township 03 Precinct 1,United States Senate,,Republican,"Roberts, Pat",27,000030
+ROOKS,Township 03 Precinct 2,United States Senate,,independent,"Orman, Greg",106,000040
+ROOKS,Township 03 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",34,000040
+ROOKS,Township 03 Precinct 2,United States Senate,,Republican,"Roberts, Pat",330,000040
+ROOKS,Township 04,United States Senate,,independent,"Orman, Greg",8,000050
+ROOKS,Township 04,United States Senate,,Libertarian,"Batson, Randall",0,000050
+ROOKS,Township 04,United States Senate,,Republican,"Roberts, Pat",11,000050
+ROOKS,Township 06,United States Senate,,independent,"Orman, Greg",6,000070
+ROOKS,Township 06,United States Senate,,Libertarian,"Batson, Randall",1,000070
+ROOKS,Township 06,United States Senate,,Republican,"Roberts, Pat",31,000070
+ROOKS,Township 07,United States Senate,,independent,"Orman, Greg",15,000080
+ROOKS,Township 07,United States Senate,,Libertarian,"Batson, Randall",5,000080
+ROOKS,Township 07,United States Senate,,Republican,"Roberts, Pat",49,000080
+ROOKS,Township 08,United States Senate,,independent,"Orman, Greg",26,000090
+ROOKS,Township 08,United States Senate,,Libertarian,"Batson, Randall",3,000090
+ROOKS,Township 08,United States Senate,,Republican,"Roberts, Pat",85,000090
+ROOKS,Township 09,United States Senate,,independent,"Orman, Greg",8,000100
+ROOKS,Township 09,United States Senate,,Libertarian,"Batson, Randall",0,000100
+ROOKS,Township 09,United States Senate,,Republican,"Roberts, Pat",20,000100
+ROOKS,Township 10,United States Senate,,independent,"Orman, Greg",11,000110
+ROOKS,Township 10,United States Senate,,Libertarian,"Batson, Randall",8,000110
+ROOKS,Township 10,United States Senate,,Republican,"Roberts, Pat",44,000110
+ROOKS,Township 11 Precinct 1,United States Senate,,independent,"Orman, Greg",44,000120
+ROOKS,Township 11 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",14,000120
+ROOKS,Township 11 Precinct 1,United States Senate,,Republican,"Roberts, Pat",183,000120
+ROOKS,Township 11 Precinct 2,United States Senate,,independent,"Orman, Greg",99,000130
+ROOKS,Township 11 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",43,000130
+ROOKS,Township 11 Precinct 2,United States Senate,,Republican,"Roberts, Pat",462,000130
+ROOKS,Township 12,United States Senate,,independent,"Orman, Greg",19,000140
+ROOKS,Township 12,United States Senate,,Libertarian,"Batson, Randall",0,000140
+ROOKS,Township 12,United States Senate,,Republican,"Roberts, Pat",51,000140
+ROOKS,Township 05 H110,United States Senate,,independent,"Orman, Greg",4,120020
+ROOKS,Township 05 H110,United States Senate,,Libertarian,"Batson, Randall",0,120020
+ROOKS,Township 05 H110,United States Senate,,Republican,"Roberts, Pat",39,120020
+ROOKS,Township 05 H118 A,United States Senate,,independent,"Orman, Greg",0,12003A
+ROOKS,Township 05 H118 A,United States Senate,,Libertarian,"Batson, Randall",0,12003A
+ROOKS,Township 05 H118 A,United States Senate,,Republican,"Roberts, Pat",0,12003A
+ROOKS,Township 05 H118,United States Senate,,independent,"Orman, Greg",0,120030
+ROOKS,Township 05 H118,United States Senate,,Libertarian,"Batson, Randall",0,120030
+ROOKS,Township 05 H118,United States Senate,,Republican,"Roberts, Pat",0,120030

--- a/2014/20141104__ks__general__rush__precinct.csv
+++ b/2014/20141104__ks__general__rush__precinct.csv
@@ -1,235 +1,222 @@
-county,precinct,office,district,party,candidate,votes
-Rush,Alexander - Belle Prairie Township,Voters,,,Registered,89
-Rush,Banner Township,Voters,,,Registered,105
-Rush,Big Timber Township,Voters,,,Registered,116
-Rush,Brookdale,Voters,,,Registered,388
-Rush,Center Township,Voters,,,Registered,192
-Rush,Garfield Township,Voters,,,Registered,88
-Rush,Hampton - Fairview Township,Voters,,,Registered,193
-Rush,Illinois Township,Voters,,,Registered,40
-Rush,LaCrosse,Voters,,,Registered,596
-Rush,Lone Star Township,Voters,,,Registered,201
-Rush,Pioneer Township,Voters,,,Registered,227
-Rush,Pleasantdale Township,Voters,,,Registered,22
-Rush,Union Township,Voters,,,Registered,41
-Rush,Alexander - Belle Prairie Township,U.S. Senate,,R,Pat Roberts,47
-Rush,Banner Township,U.S. Senate,,R,Pat Roberts,36
-Rush,Big Timber Township,U.S. Senate,,R,Pat Roberts,45
-Rush,Brookdale,U.S. Senate,,R,Pat Roberts,130
-Rush,Center Township,U.S. Senate,,R,Pat Roberts,77
-Rush,Garfield Township,U.S. Senate,,R,Pat Roberts,36
-Rush,Hampton - Fairview Township,U.S. Senate,,R,Pat Roberts,77
-Rush,Illinois Township,U.S. Senate,,R,Pat Roberts,25
-Rush,LaCrosse,U.S. Senate,,R,Pat Roberts,213
-Rush,Lone Star Township,U.S. Senate,,R,Pat Roberts,73
-Rush,Pioneer Township,U.S. Senate,,R,Pat Roberts,96
-Rush,Pleasantdale Township,U.S. Senate,,R,Pat Roberts,7
-Rush,Union Township,U.S. Senate,,R,Pat Roberts,26
-Rush,Alexander - Belle Prairie Township,U.S. Senate,,D,Paul Davis,9
-Rush,Banner Township,U.S. Senate,,D,Paul Davis,13
-Rush,Big Timber Township,U.S. Senate,,D,Paul Davis,16
-Rush,Brookdale,U.S. Senate,,D,Paul Davis,56
-Rush,Center Township,U.S. Senate,,D,Paul Davis,24
-Rush,Garfield Township,U.S. Senate,,D,Paul Davis,14
-Rush,Hampton - Fairview Township,U.S. Senate,,D,Paul Davis,40
-Rush,Illinois Township,U.S. Senate,,D,Paul Davis,9
-Rush,LaCrosse,U.S. Senate,,D,Paul Davis,110
-Rush,Lone Star Township,U.S. Senate,,D,Paul Davis,42
-Rush,Pioneer Township,U.S. Senate,,D,Paul Davis,31
-Rush,Pleasantdale Township,U.S. Senate,,D,Paul Davis,3
-Rush,Union Township,U.S. Senate,,D,Paul Davis,3
-Rush,Alexander - Belle Prairie Township,U.S. Senate,,L,Randall Batson,1
-Rush,Banner Township,U.S. Senate,,L,Randall Batson,5
-Rush,Big Timber Township,U.S. Senate,,L,Randall Batson,5
-Rush,Brookdale,U.S. Senate,,L,Randall Batson,18
-Rush,Center Township,U.S. Senate,,L,Randall Batson,5
-Rush,Garfield Township,U.S. Senate,,L,Randall Batson,3
-Rush,Hampton - Fairview Township,U.S. Senate,,L,Randall Batson,4
-Rush,Illinois Township,U.S. Senate,,L,Randall Batson,0
-Rush,LaCrosse,U.S. Senate,,L,Randall Batson,13
-Rush,Lone Star Township,U.S. Senate,,L,Randall Batson,7
-Rush,Pioneer Township,U.S. Senate,,L,Randall Batson,6
-Rush,Pleasantdale Township,U.S. Senate,,L,Randall Batson,0
-Rush,Union Township,U.S. Senate,,L,Randall Batson,0
-Rush,Alexander - Belle Prairie Township,U.S. House,1,R,Tim Huelskamp,46
-Rush,Banner Township,U.S. House,1,R,Tim Huelskamp,43
-Rush,Big Timber Township,U.S. House,1,R,Tim Huelskamp,50
-Rush,Brookdale,U.S. House,1,R,Tim Huelskamp,145
-Rush,Center Township,U.S. House,1,R,Tim Huelskamp,80
-Rush,Garfield Township,U.S. House,1,R,Tim Huelskamp,38
-Rush,Hampton - Fairview Township,U.S. House,1,R,Tim Huelskamp,84
-Rush,Illinois Township,U.S. House,1,R,Tim Huelskamp,25
-Rush,LaCrosse,U.S. House,1,R,Tim Huelskamp,246
-Rush,Lone Star Township,U.S. House,1,R,Tim Huelskamp,76
-Rush,Pioneer Township,U.S. House,1,R,Tim Huelskamp,105
-Rush,Pleasantdale Township,U.S. House,1,R,Tim Huelskamp,8
-Rush,Union Township,U.S. House,1,R,Tim Huelskamp,25
-Rush,Alexander - Belle Prairie Township,U.S. House,1,D,James Sherow,10
-Rush,Banner Township,U.S. House,1,D,James Sherow,12
-Rush,Big Timber Township,U.S. House,1,D,James Sherow,18
-Rush,Brookdale,U.S. House,1,D,James Sherow,58
-Rush,Center Township,U.S. House,1,D,James Sherow,22
-Rush,Garfield Township,U.S. House,1,D,James Sherow,15
-Rush,Hampton - Fairview Township,U.S. House,1,D,James Sherow,38
-Rush,Illinois Township,U.S. House,1,D,James Sherow,8
-Rush,LaCrosse,U.S. House,1,D,James Sherow,90
-Rush,Lone Star Township,U.S. House,1,D,James Sherow,46
-Rush,Pioneer Township,U.S. House,1,D,James Sherow,25
-Rush,Pleasantdale Township,U.S. House,1,D,James Sherow,2
-Rush,Union Township,U.S. House,1,D,James Sherow,4
-Rush,Alexander - Belle Prairie Township,Governor,,R,Sam Brownback,48
-Rush,Banner Township,Governor,,R,Sam Brownback,36
-Rush,Big Timber Township,Governor,,R,Sam Brownback,44
-Rush,Brookdale,Governor,,R,Sam Brownback,119
-Rush,Center Township,Governor,,R,Sam Brownback,70
-Rush,Garfield Township,Governor,,R,Sam Brownback,34
-Rush,Hampton - Fairview Township,Governor,,R,Sam Brownback,69
-Rush,Illinois Township,Governor,,R,Sam Brownback,25
-Rush,LaCrosse,Governor,,R,Sam Brownback,188
-Rush,Lone Star Township,Governor,,R,Sam Brownback,61
-Rush,Pioneer Township,Governor,,R,Sam Brownback,88
-Rush,Pleasantdale Township,Governor,,R,Sam Brownback,7
-Rush,Union Township,Governor,,R,Sam Brownback,25
-Rush,Alexander - Belle Prairie Township,Governor,,D,Paul Davis,6
-Rush,Banner Township,Governor,,D,Paul Davis,17
-Rush,Big Timber Township,Governor,,D,Paul Davis,18
-Rush,Brookdale,Governor,,D,Paul Davis,73
-Rush,Center Township,Governor,,D,Paul Davis,27
-Rush,Garfield Township,Governor,,D,Paul Davis,18
-Rush,Hampton - Fairview Township,Governor,,D,Paul Davis,45
-Rush,Illinois Township,Governor,,D,Paul Davis,9
-Rush,LaCrosse,Governor,,D,Paul Davis,137
-Rush,Lone Star Township,Governor,,D,Paul Davis,51
-Rush,Pioneer Township,Governor,,D,Paul Davis,42
-Rush,Pleasantdale Township,Governor,,D,Paul Davis,4
-Rush,Union Township,Governor,,D,Paul Davis,5
-Rush,Alexander - Belle Prairie Township,Governor,,L,Keen Umbehr,1
-Rush,Banner Township,Governor,,L,Keen Umbehr,2
-Rush,Big Timber Township,Governor,,L,Keen Umbehr,4
-Rush,Brookdale,Governor,,L,Keen Umbehr,13
-Rush,Center Township,Governor,,L,Keen Umbehr,5
-Rush,Garfield Township,Governor,,L,Keen Umbehr,1
-Rush,Hampton - Fairview Township,Governor,,L,Keen Umbehr,8
-Rush,Illinois Township,Governor,,L,Keen Umbehr,0
-Rush,LaCrosse,Governor,,L,Keen Umbehr,20
-Rush,Lone Star Township,Governor,,L,Keen Umbehr,9
-Rush,Pioneer Township,Governor,,L,Keen Umbehr,3
-Rush,Pleasantdale Township,Governor,,L,Keen Umbehr,0
-Rush,Union Township,Governor,,L,Keen Umbehr,0
-Rush,Alexander - Belle Prairie Township,Secretary of State,,R,Kris Kobach,41
-Rush,Banner Township,Secretary of State,,R,Kris Kobach,41
-Rush,Big Timber Township,Secretary of State,,R,Kris Kobach,48
-Rush,Brookdale,Secretary of State,,R,Kris Kobach,146
-Rush,Center Township,Secretary of State,,R,Kris Kobach,86
-Rush,Garfield Township,Secretary of State,,R,Kris Kobach,37
-Rush,Hampton - Fairview Township,Secretary of State,,R,Kris Kobach,80
-Rush,Illinois Township,Secretary of State,,R,Kris Kobach,26
-Rush,LaCrosse,Secretary of State,,R,Kris Kobach,240
-Rush,Lone Star Township,Secretary of State,,R,Kris Kobach,81
-Rush,Pioneer Township,Secretary of State,,R,Kris Kobach,101
-Rush,Pleasantdale Township,Secretary of State,,R,Kris Kobach,7
-Rush,Union Township,Secretary of State,,R,Kris Kobach,25
-Rush,Alexander - Belle Prairie Township,Secretary of State,,D,Jean Schodorf,14
-Rush,Banner Township,Secretary of State,,D,Jean Schodorf,10
-Rush,Big Timber Township,Secretary of State,,D,Jean Schodorf,18
-Rush,Brookdale,Secretary of State,,D,Jean Schodorf,61
-Rush,Center Township,Secretary of State,,D,Jean Schodorf,16
-Rush,Garfield Township,Secretary of State,,D,Jean Schodorf,15
-Rush,Hampton - Fairview Township,Secretary of State,,D,Jean Schodorf,37
-Rush,Illinois Township,Secretary of State,,D,Jean Schodorf,7
-Rush,LaCrosse,Secretary of State,,D,Jean Schodorf,95
-Rush,Lone Star Township,Secretary of State,,D,Jean Schodorf,39
-Rush,Pioneer Township,Secretary of State,,D,Jean Schodorf,31
-Rush,Pleasantdale Township,Secretary of State,,D,Jean Schodorf,3
-Rush,Union Township,Secretary of State,,D,Jean Schodorf,5
-Rush,Alexander - Belle Prairie Township,Attorney General,,R,Derek Schmidt,49
-Rush,Banner Township,Attorney General,,R,Derek Schmidt,43
-Rush,Big Timber Township,Attorney General,,R,Derek Schmidt,57
-Rush,Brookdale,Attorney General,,R,Derek Schmidt,162
-Rush,Center Township,Attorney General,,R,Derek Schmidt,89
-Rush,Garfield Township,Attorney General,,R,Derek Schmidt,45
-Rush,Hampton - Fairview Township,Attorney General,,R,Derek Schmidt,89
-Rush,Illinois Township,Attorney General,,R,Derek Schmidt,25
-Rush,LaCrosse,Attorney General,,R,Derek Schmidt,266
-Rush,Lone Star Township,Attorney General,,R,Derek Schmidt,94
-Rush,Pioneer Township,Attorney General,,R,Derek Schmidt,110
-Rush,Pleasantdale Township,Attorney General,,R,Derek Schmidt,7
-Rush,Union Township,Attorney General,,R,Derek Schmidt,28
-Rush,Alexander - Belle Prairie Township,Attorney General,,D,A J Kotich,7
-Rush,Banner Township,Attorney General,,D,A J Kotich,8
-Rush,Big Timber Township,Attorney General,,D,A J Kotich,9
-Rush,Brookdale,Attorney General,,D,A J Kotich,40
-Rush,Center Township,Attorney General,,D,A J Kotich,13
-Rush,Garfield Township,Attorney General,,D,A J Kotich,8
-Rush,Hampton - Fairview Township,Attorney General,,D,A J Kotich,29
-Rush,Illinois Township,Attorney General,,D,A J Kotich,7
-Rush,LaCrosse,Attorney General,,D,A J Kotich,63
-Rush,Lone Star Township,Attorney General,,D,A J Kotich,23
-Rush,Pioneer Township,Attorney General,,D,A J Kotich,19
-Rush,Pleasantdale Township,Attorney General,,D,A J Kotich,3
-Rush,Union Township,Attorney General,,D,A J Kotich,2
-Rush,Alexander - Belle Prairie Township,State Treasurer,,R,Ron Estes,51
-Rush,Banner Township,State Treasurer,,R,Ron Estes,39
-Rush,Big Timber Township,State Treasurer,,R,Ron Estes,54
-Rush,Brookdale,State Treasurer,,R,Ron Estes,160
-Rush,Center Township,State Treasurer,,R,Ron Estes,93
-Rush,Garfield Township,State Treasurer,,R,Ron Estes,42
-Rush,Hampton - Fairview Township,State Treasurer,,R,Ron Estes,98
-Rush,Illinois Township,State Treasurer,,R,Ron Estes,25
-Rush,LaCrosse,State Treasurer,,R,Ron Estes,267
-Rush,Lone Star Township,State Treasurer,,R,Ron Estes,95
-Rush,Pioneer Township,State Treasurer,,R,Ron Estes,111
-Rush,Pleasantdale Township,State Treasurer,,R,Ron Estes,8
-Rush,Union Township,State Treasurer,,R,Ron Estes,29
-Rush,Alexander - Belle Prairie Township,State Treasurer,,D,Carmen Alldritt,5
-Rush,Banner Township,State Treasurer,,D,Carmen Alldritt,13
-Rush,Big Timber Township,State Treasurer,,D,Carmen Alldritt,12
-Rush,Brookdale,State Treasurer,,D,Carmen Alldritt,38
-Rush,Center Township,State Treasurer,,D,Carmen Alldritt,10
-Rush,Garfield Township,State Treasurer,,D,Carmen Alldritt,10
-Rush,Hampton - Fairview Township,State Treasurer,,D,Carmen Alldritt,21
-Rush,Illinois Township,State Treasurer,,D,Carmen Alldritt,7
-Rush,LaCrosse,State Treasurer,,D,Carmen Alldritt,61
-Rush,Lone Star Township,State Treasurer,,D,Carmen Alldritt,23
-Rush,Pioneer Township,State Treasurer,,D,Carmen Alldritt,20
-Rush,Pleasantdale Township,State Treasurer,,D,Carmen Alldritt,2
-Rush,Union Township,State Treasurer,,D,Carmen Alldritt,0
-Rush,Alexander - Belle Prairie Township,Insurance Commissioner,,R,Ken Selzer,46
-Rush,Banner Township,Insurance Commissioner,,R,Ken Selzer,34
-Rush,Big Timber Township,Insurance Commissioner,,R,Ken Selzer,54
-Rush,Brookdale,Insurance Commissioner,,R,Ken Selzer,132
-Rush,Center Township,Insurance Commissioner,,R,Ken Selzer,73
-Rush,Garfield Township,Insurance Commissioner,,R,Ken Selzer,31
-Rush,Hampton - Fairview Township,Insurance Commissioner,,R,Ken Selzer,78
-Rush,Illinois Township,Insurance Commissioner,,R,Ken Selzer,20
-Rush,LaCrosse,Insurance Commissioner,,R,Ken Selzer,223
-Rush,Lone Star Township,Insurance Commissioner,,R,Ken Selzer,79
-Rush,Pioneer Township,Insurance Commissioner,,R,Ken Selzer,91
-Rush,Pleasantdale Township,Insurance Commissioner,,R,Ken Selzer,7
-Rush,Union Township,Insurance Commissioner,,R,Ken Selzer,24
-Rush,Alexander - Belle Prairie Township,Insurance Commissioner,,D,Dennis Anderson,9
-Rush,Banner Township,Insurance Commissioner,,D,Dennis Anderson,16
-Rush,Big Timber Township,Insurance Commissioner,,D,Dennis Anderson,11
-Rush,Brookdale,Insurance Commissioner,,D,Dennis Anderson,60
-Rush,Center Township,Insurance Commissioner,,D,Dennis Anderson,25
-Rush,Garfield Township,Insurance Commissioner,,D,Dennis Anderson,19
-Rush,Hampton - Fairview Township,Insurance Commissioner,,D,Dennis Anderson,38
-Rush,Illinois Township,Insurance Commissioner,,D,Dennis Anderson,9
-Rush,LaCrosse,Insurance Commissioner,,D,Dennis Anderson,96
-Rush,Lone Star Township,Insurance Commissioner,,D,Dennis Anderson,38
-Rush,Pioneer Township,Insurance Commissioner,,D,Dennis Anderson,34
-Rush,Pleasantdale Township,Insurance Commissioner,,D,Dennis Anderson,3
-Rush,Union Township,Insurance Commissioner,,D,Dennis Anderson,4
-Rush,Alexander - Belle Prairie Township,State House,117,R,John Ewy,51
-Rush,Banner Township,State House,109,R,Troy Waymaster,46
-Rush,Big Timber Township,State House,117,R,John Ewy,63
-Rush,Brookdale,State House,117,R,John Ewy,181
-Rush,Center Township,State House,109,R,Troy Waymaster,89
-Rush,Garfield Township,State House,109,R,Troy Waymaster,45
-Rush,Hampton - Fairview Township,State House,117,R,John Ewy,100
-Rush,Illinois Township,State House,109,R,Troy Waymaster,28
-Rush,LaCrosse,State House,117,R,John Ewy,303
-Rush,Lone Star Township,State House,109,R,Troy Waymaster,102
-Rush,Pioneer Township,State House,109,R,Troy Waymaster,121
-Rush,Pleasantdale Township,State House,109,R,Troy Waymaster,10
-Rush,Union Township,State House,117,R,John Ewy,27
+county,precinct,office,district,party,candidate,votes,vtd
+RUSH,Alexander - Belle Prairie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000010
+RUSH,Alexander - Belle Prairie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+RUSH,Alexander - Belle Prairie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000010
+RUSH,Banner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000020
+RUSH,Banner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+RUSH,Banner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000020
+RUSH,Big Timber Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000030
+RUSH,Big Timber Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000030
+RUSH,Big Timber Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000030
+RUSH,Brookdale,Governor / Lt. Governor,,Democratic,"Davis, Paul",73,000040
+RUSH,Brookdale,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000040
+RUSH,Brookdale,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000040
+RUSH,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000050
+RUSH,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000050
+RUSH,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000050
+RUSH,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000060
+RUSH,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+RUSH,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000060
+RUSH,Hampton - Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000070
+RUSH,Hampton - Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000070
+RUSH,Hampton - Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000070
+RUSH,Illinois Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000080
+RUSH,Illinois Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000080
+RUSH,Illinois Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000080
+RUSH,LaCrosse,Governor / Lt. Governor,,Democratic,"Davis, Paul",137,000090
+RUSH,LaCrosse,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000090
+RUSH,LaCrosse,Governor / Lt. Governor,,Republican,"Brownback, Sam",188,000090
+RUSH,Lone Star Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",51,000100
+RUSH,Lone Star Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000100
+RUSH,Lone Star Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",61,000100
+RUSH,Pioneer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000110
+RUSH,Pioneer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000110
+RUSH,Pioneer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",88,000110
+RUSH,Pleasantdale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000120
+RUSH,Pleasantdale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+RUSH,Pleasantdale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,000120
+RUSH,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000130
+RUSH,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000130
+RUSH,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000130
+RUSH,Alexander - Belle Prairie Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",51,000010
+RUSH,Banner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",46,000020
+RUSH,Big Timber Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",63,000030
+RUSH,Brookdale,Kansas House of Representatives,117,Republican,"Ewy, John L.",181,000040
+RUSH,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",89,000050
+RUSH,Garfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",45,000060
+RUSH,Hampton - Fairview Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",100,000070
+RUSH,Illinois Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",28,000080
+RUSH,LaCrosse,Kansas House of Representatives,117,Republican,"Ewy, John L.",303,000090
+RUSH,Lone Star Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",102,000100
+RUSH,Pioneer Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",121,000110
+RUSH,Pleasantdale Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000120
+RUSH,Union Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",27,000130
+RUSH,Alexander - Belle Prairie Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000010
+RUSH,Alexander - Belle Prairie Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000010
+RUSH,Banner Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000020
+RUSH,Banner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000020
+RUSH,Big Timber Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000030
+RUSH,Big Timber Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000030
+RUSH,Brookdale,United States House of Representatives,1,Democratic,"Sherow, James E.",58,000040
+RUSH,Brookdale,United States House of Representatives,1,Republican,"Huelskamp, Tim",145,000040
+RUSH,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000050
+RUSH,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000050
+RUSH,Garfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000060
+RUSH,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000060
+RUSH,Hampton - Fairview Township,United States House of Representatives,1,Democratic,"Sherow, James E.",38,000070
+RUSH,Hampton - Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000070
+RUSH,Illinois Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000080
+RUSH,Illinois Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000080
+RUSH,LaCrosse,United States House of Representatives,1,Democratic,"Sherow, James E.",90,000090
+RUSH,LaCrosse,United States House of Representatives,1,Republican,"Huelskamp, Tim",246,000090
+RUSH,Lone Star Township,United States House of Representatives,1,Democratic,"Sherow, James E.",46,000100
+RUSH,Lone Star Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000100
+RUSH,Pioneer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,000110
+RUSH,Pioneer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,000110
+RUSH,Pleasantdale Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000120
+RUSH,Pleasantdale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000120
+RUSH,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000130
+RUSH,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000130
+RUSH,Alexander - Belle Prairie Township,Attorney General,,Democratic,"Kotich, A.J.",7,000010
+RUSH,Alexander - Belle Prairie Township,Attorney General,,Republican,"Schmidt, Derek",49,000010
+RUSH,Banner Township,Attorney General,,Democratic,"Kotich, A.J.",8,000020
+RUSH,Banner Township,Attorney General,,Republican,"Schmidt, Derek",43,000020
+RUSH,Big Timber Township,Attorney General,,Democratic,"Kotich, A.J.",9,000030
+RUSH,Big Timber Township,Attorney General,,Republican,"Schmidt, Derek",57,000030
+RUSH,Brookdale,Attorney General,,Democratic,"Kotich, A.J.",40,000040
+RUSH,Brookdale,Attorney General,,Republican,"Schmidt, Derek",162,000040
+RUSH,Center Township,Attorney General,,Democratic,"Kotich, A.J.",13,000050
+RUSH,Center Township,Attorney General,,Republican,"Schmidt, Derek",89,000050
+RUSH,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",8,000060
+RUSH,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",45,000060
+RUSH,Hampton - Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",29,000070
+RUSH,Hampton - Fairview Township,Attorney General,,Republican,"Schmidt, Derek",89,000070
+RUSH,Illinois Township,Attorney General,,Democratic,"Kotich, A.J.",7,000080
+RUSH,Illinois Township,Attorney General,,Republican,"Schmidt, Derek",25,000080
+RUSH,LaCrosse,Attorney General,,Democratic,"Kotich, A.J.",63,000090
+RUSH,LaCrosse,Attorney General,,Republican,"Schmidt, Derek",266,000090
+RUSH,Lone Star Township,Attorney General,,Democratic,"Kotich, A.J.",23,000100
+RUSH,Lone Star Township,Attorney General,,Republican,"Schmidt, Derek",94,000100
+RUSH,Pioneer Township,Attorney General,,Democratic,"Kotich, A.J.",19,000110
+RUSH,Pioneer Township,Attorney General,,Republican,"Schmidt, Derek",110,000110
+RUSH,Pleasantdale Township,Attorney General,,Democratic,"Kotich, A.J.",3,000120
+RUSH,Pleasantdale Township,Attorney General,,Republican,"Schmidt, Derek",7,000120
+RUSH,Union Township,Attorney General,,Democratic,"Kotich, A.J.",2,000130
+RUSH,Union Township,Attorney General,,Republican,"Schmidt, Derek",28,000130
+RUSH,Alexander - Belle Prairie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000010
+RUSH,Alexander - Belle Prairie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000010
+RUSH,Banner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000020
+RUSH,Banner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000020
+RUSH,Big Timber Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000030
+RUSH,Big Timber Township,Commissioner of Insurance,,Republican,"Selzer, Ken",54,000030
+RUSH,Brookdale,Commissioner of Insurance,,Democratic,"Anderson, Dennis",60,000040
+RUSH,Brookdale,Commissioner of Insurance,,Republican,"Selzer, Ken",132,000040
+RUSH,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000050
+RUSH,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",73,000050
+RUSH,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000060
+RUSH,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000060
+RUSH,Hampton - Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000070
+RUSH,Hampton - Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",78,000070
+RUSH,Illinois Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000080
+RUSH,Illinois Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000080
+RUSH,LaCrosse,Commissioner of Insurance,,Democratic,"Anderson, Dennis",96,000090
+RUSH,LaCrosse,Commissioner of Insurance,,Republican,"Selzer, Ken",223,000090
+RUSH,Lone Star Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000100
+RUSH,Lone Star Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000100
+RUSH,Pioneer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000110
+RUSH,Pioneer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",91,000110
+RUSH,Pleasantdale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000120
+RUSH,Pleasantdale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000120
+RUSH,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000130
+RUSH,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000130
+RUSH,Alexander - Belle Prairie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000010
+RUSH,Alexander - Belle Prairie Township,Secretary of State,,Republican,"Kobach, Kris",41,000010
+RUSH,Banner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000020
+RUSH,Banner Township,Secretary of State,,Republican,"Kobach, Kris",41,000020
+RUSH,Big Timber Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000030
+RUSH,Big Timber Township,Secretary of State,,Republican,"Kobach, Kris",48,000030
+RUSH,Brookdale,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000040
+RUSH,Brookdale,Secretary of State,,Republican,"Kobach, Kris",146,000040
+RUSH,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000050
+RUSH,Center Township,Secretary of State,,Republican,"Kobach, Kris",86,000050
+RUSH,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000060
+RUSH,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",37,000060
+RUSH,Hampton - Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000070
+RUSH,Hampton - Fairview Township,Secretary of State,,Republican,"Kobach, Kris",80,000070
+RUSH,Illinois Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000080
+RUSH,Illinois Township,Secretary of State,,Republican,"Kobach, Kris",26,000080
+RUSH,LaCrosse,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",95,000090
+RUSH,LaCrosse,Secretary of State,,Republican,"Kobach, Kris",240,000090
+RUSH,Lone Star Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",39,000100
+RUSH,Lone Star Township,Secretary of State,,Republican,"Kobach, Kris",81,000100
+RUSH,Pioneer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000110
+RUSH,Pioneer Township,Secretary of State,,Republican,"Kobach, Kris",101,000110
+RUSH,Pleasantdale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000120
+RUSH,Pleasantdale Township,Secretary of State,,Republican,"Kobach, Kris",7,000120
+RUSH,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000130
+RUSH,Union Township,Secretary of State,,Republican,"Kobach, Kris",25,000130
+RUSH,Alexander - Belle Prairie Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000010
+RUSH,Alexander - Belle Prairie Township,State Treasurer,,Republican,"Estes, Ron",51,000010
+RUSH,Banner Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000020
+RUSH,Banner Township,State Treasurer,,Republican,"Estes, Ron",39,000020
+RUSH,Big Timber Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000030
+RUSH,Big Timber Township,State Treasurer,,Republican,"Estes, Ron",54,000030
+RUSH,Brookdale,State Treasurer,,Democratic,"Alldritt, Carmen",38,000040
+RUSH,Brookdale,State Treasurer,,Republican,"Estes, Ron",160,000040
+RUSH,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000050
+RUSH,Center Township,State Treasurer,,Republican,"Estes, Ron",93,000050
+RUSH,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000060
+RUSH,Garfield Township,State Treasurer,,Republican,"Estes, Ron",42,000060
+RUSH,Hampton - Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000070
+RUSH,Hampton - Fairview Township,State Treasurer,,Republican,"Estes, Ron",98,000070
+RUSH,Illinois Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000080
+RUSH,Illinois Township,State Treasurer,,Republican,"Estes, Ron",25,000080
+RUSH,LaCrosse,State Treasurer,,Democratic,"Alldritt, Carmen",61,000090
+RUSH,LaCrosse,State Treasurer,,Republican,"Estes, Ron",267,000090
+RUSH,Lone Star Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000100
+RUSH,Lone Star Township,State Treasurer,,Republican,"Estes, Ron",95,000100
+RUSH,Pioneer Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000110
+RUSH,Pioneer Township,State Treasurer,,Republican,"Estes, Ron",111,000110
+RUSH,Pleasantdale Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000120
+RUSH,Pleasantdale Township,State Treasurer,,Republican,"Estes, Ron",8,000120
+RUSH,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000130
+RUSH,Union Township,State Treasurer,,Republican,"Estes, Ron",29,000130
+RUSH,Alexander - Belle Prairie Township,United States Senate,,independent,"Orman, Greg",9,000010
+RUSH,Alexander - Belle Prairie Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+RUSH,Alexander - Belle Prairie Township,United States Senate,,Republican,"Roberts, Pat",47,000010
+RUSH,Banner Township,United States Senate,,independent,"Orman, Greg",13,000020
+RUSH,Banner Township,United States Senate,,Libertarian,"Batson, Randall",5,000020
+RUSH,Banner Township,United States Senate,,Republican,"Roberts, Pat",36,000020
+RUSH,Big Timber Township,United States Senate,,independent,"Orman, Greg",16,000030
+RUSH,Big Timber Township,United States Senate,,Libertarian,"Batson, Randall",5,000030
+RUSH,Big Timber Township,United States Senate,,Republican,"Roberts, Pat",45,000030
+RUSH,Brookdale,United States Senate,,independent,"Orman, Greg",56,000040
+RUSH,Brookdale,United States Senate,,Libertarian,"Batson, Randall",18,000040
+RUSH,Brookdale,United States Senate,,Republican,"Roberts, Pat",130,000040
+RUSH,Center Township,United States Senate,,independent,"Orman, Greg",24,000050
+RUSH,Center Township,United States Senate,,Libertarian,"Batson, Randall",5,000050
+RUSH,Center Township,United States Senate,,Republican,"Roberts, Pat",77,000050
+RUSH,Garfield Township,United States Senate,,independent,"Orman, Greg",14,000060
+RUSH,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",3,000060
+RUSH,Garfield Township,United States Senate,,Republican,"Roberts, Pat",36,000060
+RUSH,Hampton - Fairview Township,United States Senate,,independent,"Orman, Greg",40,000070
+RUSH,Hampton - Fairview Township,United States Senate,,Libertarian,"Batson, Randall",4,000070
+RUSH,Hampton - Fairview Township,United States Senate,,Republican,"Roberts, Pat",77,000070
+RUSH,Illinois Township,United States Senate,,independent,"Orman, Greg",9,000080
+RUSH,Illinois Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+RUSH,Illinois Township,United States Senate,,Republican,"Roberts, Pat",25,000080
+RUSH,LaCrosse,United States Senate,,independent,"Orman, Greg",110,000090
+RUSH,LaCrosse,United States Senate,,Libertarian,"Batson, Randall",13,000090
+RUSH,LaCrosse,United States Senate,,Republican,"Roberts, Pat",213,000090
+RUSH,Lone Star Township,United States Senate,,independent,"Orman, Greg",42,000100
+RUSH,Lone Star Township,United States Senate,,Libertarian,"Batson, Randall",7,000100
+RUSH,Lone Star Township,United States Senate,,Republican,"Roberts, Pat",73,000100
+RUSH,Pioneer Township,United States Senate,,independent,"Orman, Greg",31,000110
+RUSH,Pioneer Township,United States Senate,,Libertarian,"Batson, Randall",6,000110
+RUSH,Pioneer Township,United States Senate,,Republican,"Roberts, Pat",96,000110
+RUSH,Pleasantdale Township,United States Senate,,independent,"Orman, Greg",3,000120
+RUSH,Pleasantdale Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+RUSH,Pleasantdale Township,United States Senate,,Republican,"Roberts, Pat",7,000120
+RUSH,Union Township,United States Senate,,independent,"Orman, Greg",3,000130
+RUSH,Union Township,United States Senate,,Libertarian,"Batson, Randall",0,000130
+RUSH,Union Township,United States Senate,,Republican,"Roberts, Pat",26,000130

--- a/2014/20141104__ks__general__russell__precinct.csv
+++ b/2014/20141104__ks__general__russell__precinct.csv
@@ -1,320 +1,324 @@
-county,precinct,office,district,party,candidate,votes
-Russell,Gorham City /Big Creek Township,Voters,,,Cast,175
-Russell,Center Township,Voters,,,Cast,136
-Russell,Fairfield Township,Voters,,,Cast,16
-Russell,Lucas City / Fairview Township,Voters,,,Cast,191
-Russell,Grant Township,Voters,,,Cast,88
-Russell,Lincoln Township,Voters,,,Cast,61
-Russell,Luray City / Luray Township,Voters,,,Cast,110
-Russell,Paradise City / Paradise Township,Voters,,,Cast,80
-Russell,Dorrance City / Plymouth Township,Voters,,,Cast,107
-Russell,Russell Township,Voters,,,Cast,45
-Russell,Russell Ward 1,Voters,,,Cast,344
-Russell,Russell Ward 2,Voters,,,Cast,450
-Russell,Russell Ward 3,Voters,,,Cast,365
-Russell,Russell Ward 4,Voters,,,Cast,370
-Russell,Waldo City / Waldo Township,Voters,,,Cast,42
-Russell,Winterset Township,Voters,,,Cast,40
-Russell,Gorham City /Big Creek Township,U.S. Senate,,R,Pat Roberts,137
-Russell,Center Township,U.S. Senate,,R,Pat Roberts,91
-Russell,Fairfield Township,U.S. Senate,,R,Pat Roberts,14
-Russell,Lucas City / Fairview Township,U.S. Senate,,R,Pat Roberts,121
-Russell,Grant Township,U.S. Senate,,R,Pat Roberts,69
-Russell,Lincoln Township,U.S. Senate,,R,Pat Roberts,43
-Russell,Luray City / Luray Township,U.S. Senate,,R,Pat Roberts,64
-Russell,Paradise City / Paradise Township,U.S. Senate,,R,Pat Roberts,58
-Russell,Dorrance City / Plymouth Township,U.S. Senate,,R,Pat Roberts,71
-Russell,Russell Township,U.S. Senate,,R,Pat Roberts,38
-Russell,Russell Ward 1,U.S. Senate,,R,Pat Roberts,222
-Russell,Russell Ward 2,U.S. Senate,,R,Pat Roberts,287
-Russell,Russell Ward 3,U.S. Senate,,R,Pat Roberts,220
-Russell,Russell Ward 4,U.S. Senate,,R,Pat Roberts,248
-Russell,Waldo City / Waldo Township,U.S. Senate,,R,Pat Roberts,27
-Russell,Winterset Township,U.S. Senate,,R,Pat Roberts,29
-Russell,Gorham City /Big Creek Township,U.S. Senate,,I,Greg Orman,28
-Russell,Center Township,U.S. Senate,,I,Greg Orman,35
-Russell,Fairfield Township,U.S. Senate,,I,Greg Orman,2
-Russell,Lucas City / Fairview Township,U.S. Senate,,I,Greg Orman,61
-Russell,Grant Township,U.S. Senate,,I,Greg Orman,15
-Russell,Lincoln Township,U.S. Senate,,I,Greg Orman,14
-Russell,Luray City / Luray Township,U.S. Senate,,I,Greg Orman,39
-Russell,Paradise City / Paradise Township,U.S. Senate,,I,Greg Orman,19
-Russell,Dorrance City / Plymouth Township,U.S. Senate,,I,Greg Orman,31
-Russell,Russell Township,U.S. Senate,,I,Greg Orman,5
-Russell,Russell Ward 1,U.S. Senate,,I,Greg Orman,91
-Russell,Russell Ward 2,U.S. Senate,,I,Greg Orman,133
-Russell,Russell Ward 3,U.S. Senate,,I,Greg Orman,115
-Russell,Russell Ward 4,U.S. Senate,,I,Greg Orman,95
-Russell,Waldo City / Waldo Township,U.S. Senate,,I,Greg Orman,12
-Russell,Winterset Township,U.S. Senate,,I,Greg Orman,9
-Russell,Gorham City /Big Creek Township,U.S. Senate,,L,Randall Batson,7
-Russell,Center Township,U.S. Senate,,L,Randall Batson,5
-Russell,Fairfield Township,U.S. Senate,,L,Randall Batson,0
-Russell,Lucas City / Fairview Township,U.S. Senate,,L,Randall Batson,8
-Russell,Grant Township,U.S. Senate,,L,Randall Batson,3
-Russell,Lincoln Township,U.S. Senate,,L,Randall Batson,1
-Russell,Luray City / Luray Township,U.S. Senate,,L,Randall Batson,6
-Russell,Paradise City / Paradise Township,U.S. Senate,,L,Randall Batson,2
-Russell,Dorrance City / Plymouth Township,U.S. Senate,,L,Randall Batson,2
-Russell,Russell Township,U.S. Senate,,L,Randall Batson,2
-Russell,Russell Ward 1,U.S. Senate,,L,Randall Batson,21
-Russell,Russell Ward 2,U.S. Senate,,L,Randall Batson,23
-Russell,Russell Ward 3,U.S. Senate,,L,Randall Batson,25
-Russell,Russell Ward 4,U.S. Senate,,L,Randall Batson,21
-Russell,Waldo City / Waldo Township,U.S. Senate,,L,Randall Batson,3
-Russell,Winterset Township,U.S. Senate,,L,Randall Batson,2
-Russell,Gorham City /Big Creek Township,U.S. House,1,R,Tim Huelskamp,136
-Russell,Center Township,U.S. House,1,R,Tim Huelskamp,101
-Russell,Fairfield Township,U.S. House,1,R,Tim Huelskamp,13
-Russell,Lucas City / Fairview Township,U.S. House,1,R,Tim Huelskamp,132
-Russell,Grant Township,U.S. House,1,R,Tim Huelskamp,77
-Russell,Lincoln Township,U.S. House,1,R,Tim Huelskamp,49
-Russell,Luray City / Luray Township,U.S. House,1,R,Tim Huelskamp,66
-Russell,Paradise City / Paradise Township,U.S. House,1,R,Tim Huelskamp,66
-Russell,Dorrance City / Plymouth Township,U.S. House,1,R,Tim Huelskamp,76
-Russell,Russell Township,U.S. House,1,R,Tim Huelskamp,38
-Russell,Russell Ward 1,U.S. House,1,R,Tim Huelskamp,258
-Russell,Russell Ward 2,U.S. House,1,R,Tim Huelskamp,315
-Russell,Russell Ward 3,U.S. House,1,R,Tim Huelskamp,249
-Russell,Russell Ward 4,U.S. House,1,R,Tim Huelskamp,276
-Russell,Waldo City / Waldo Township,U.S. House,1,R,Tim Huelskamp,30
-Russell,Winterset Township,U.S. House,1,R,Tim Huelskamp,28
-Russell,Gorham City /Big Creek Township,U.S. House,1,D,James Sherow,35
-Russell,Center Township,U.S. House,1,D,James Sherow,29
-Russell,Fairfield Township,U.S. House,1,D,James Sherow,3
-Russell,Lucas City / Fairview Township,U.S. House,1,D,James Sherow,54
-Russell,Grant Township,U.S. House,1,D,James Sherow,11
-Russell,Lincoln Township,U.S. House,1,D,James Sherow,10
-Russell,Luray City / Luray Township,U.S. House,1,D,James Sherow,41
-Russell,Paradise City / Paradise Township,U.S. House,1,D,James Sherow,11
-Russell,Dorrance City / Plymouth Township,U.S. House,1,D,James Sherow,26
-Russell,Russell Township,U.S. House,1,D,James Sherow,7
-Russell,Russell Ward 1,U.S. House,1,D,James Sherow,74
-Russell,Russell Ward 2,U.S. House,1,D,James Sherow,128
-Russell,Russell Ward 3,U.S. House,1,D,James Sherow,105
-Russell,Russell Ward 4,U.S. House,1,D,James Sherow,84
-Russell,Waldo City / Waldo Township,U.S. House,1,D,James Sherow,9
-Russell,Winterset Township,U.S. House,1,D,James Sherow,10
-Russell,Gorham City /Big Creek Township,Governor,,R,Sam Brownback,128
-Russell,Center Township,Governor,,R,Sam Brownback,93
-Russell,Fairfield Township,Governor,,R,Sam Brownback,11
-Russell,Lucas City / Fairview Township,Governor,,R,Sam Brownback,94
-Russell,Grant Township,Governor,,R,Sam Brownback,64
-Russell,Lincoln Township,Governor,,R,Sam Brownback,43
-Russell,Luray City / Luray Township,Governor,,R,Sam Brownback,55
-Russell,Paradise City / Paradise Township,Governor,,R,Sam Brownback,58
-Russell,Dorrance City / Plymouth Township,Governor,,R,Sam Brownback,71
-Russell,Russell Township,Governor,,R,Sam Brownback,34
-Russell,Russell Ward 1,Governor,,R,Sam Brownback,208
-Russell,Russell Ward 2,Governor,,R,Sam Brownback,251
-Russell,Russell Ward 3,Governor,,R,Sam Brownback,200
-Russell,Russell Ward 4,Governor,,R,Sam Brownback,224
-Russell,Waldo City / Waldo Township,Governor,,R,Sam Brownback,23
-Russell,Winterset Township,Governor,,R,Sam Brownback,24
-Russell,Gorham City /Big Creek Township,Governor,,D,Paul Davis,35
-Russell,Center Township,Governor,,D,Paul Davis,36
-Russell,Fairfield Township,Governor,,D,Paul Davis,4
-Russell,Lucas City / Fairview Township,Governor,,D,Paul Davis,82
-Russell,Grant Township,Governor,,D,Paul Davis,23
-Russell,Lincoln Township,Governor,,D,Paul Davis,17
-Russell,Luray City / Luray Township,Governor,,D,Paul Davis,45
-Russell,Paradise City / Paradise Township,Governor,,D,Paul Davis,16
-Russell,Dorrance City / Plymouth Township,Governor,,D,Paul Davis,31
-Russell,Russell Township,Governor,,D,Paul Davis,10
-Russell,Russell Ward 1,Governor,,D,Paul Davis,100
-Russell,Russell Ward 2,Governor,,D,Paul Davis,176
-Russell,Russell Ward 3,Governor,,D,Paul Davis,135
-Russell,Russell Ward 4,Governor,,D,Paul Davis,126
-Russell,Waldo City / Waldo Township,Governor,,D,Paul Davis,17
-Russell,Winterset Township,Governor,,D,Paul Davis,14
-Russell,Gorham City /Big Creek Township,Governor,,L,Keen Umbehr,10
-Russell,Center Township,Governor,,L,Keen Umbehr,3
-Russell,Fairfield Township,Governor,,L,Keen Umbehr,1
-Russell,Lucas City / Fairview Township,Governor,,L,Keen Umbehr,13
-Russell,Grant Township,Governor,,L,Keen Umbehr,1
-Russell,Lincoln Township,Governor,,L,Keen Umbehr,1
-Russell,Luray City / Luray Township,Governor,,L,Keen Umbehr,8
-Russell,Paradise City / Paradise Township,Governor,,L,Keen Umbehr,5
-Russell,Dorrance City / Plymouth Township,Governor,,L,Keen Umbehr,1
-Russell,Russell Township,Governor,,L,Keen Umbehr,1
-Russell,Russell Ward 1,Governor,,L,Keen Umbehr,29
-Russell,Russell Ward 2,Governor,,L,Keen Umbehr,20
-Russell,Russell Ward 3,Governor,,L,Keen Umbehr,21
-Russell,Russell Ward 4,Governor,,L,Keen Umbehr,16
-Russell,Waldo City / Waldo Township,Governor,,L,Keen Umbehr,2
-Russell,Winterset Township,Governor,,L,Keen Umbehr,2
-Russell,Gorham City /Big Creek Township,Secretary of State,,R,Kris Kobach,140
-Russell,Center Township,Secretary of State,,R,Kris Kobach,103
-Russell,Fairfield Township,Secretary of State,,R,Kris Kobach,12
-Russell,Lucas City / Fairview Township,Secretary of State,,R,Kris Kobach,128
-Russell,Grant Township,Secretary of State,,R,Kris Kobach,70
-Russell,Lincoln Township,Secretary of State,,R,Kris Kobach,48
-Russell,Luray City / Luray Township,Secretary of State,,R,Kris Kobach,70
-Russell,Paradise City / Paradise Township,Secretary of State,,R,Kris Kobach,62
-Russell,Dorrance City / Plymouth Township,Secretary of State,,R,Kris Kobach,77
-Russell,Russell Township,Secretary of State,,R,Kris Kobach,35
-Russell,Russell Ward 1,Secretary of State,,R,Kris Kobach,267
-Russell,Russell Ward 2,Secretary of State,,R,Kris Kobach,329
-Russell,Russell Ward 3,Secretary of State,,R,Kris Kobach,251
-Russell,Russell Ward 4,Secretary of State,,R,Kris Kobach,270
-Russell,Waldo City / Waldo Township,Secretary of State,,R,Kris Kobach,33
-Russell,Winterset Township,Secretary of State,,R,Kris Kobach,30
-Russell,Gorham City /Big Creek Township,Secretary of State,,D,Jean Schodorf,29
-Russell,Center Township,Secretary of State,,D,Jean Schodorf,26
-Russell,Fairfield Township,Secretary of State,,D,Jean Schodorf,4
-Russell,Lucas City / Fairview Township,Secretary of State,,D,Jean Schodorf,57
-Russell,Grant Township,Secretary of State,,D,Jean Schodorf,17
-Russell,Lincoln Township,Secretary of State,,D,Jean Schodorf,12
-Russell,Luray City / Luray Township,Secretary of State,,D,Jean Schodorf,35
-Russell,Paradise City / Paradise Township,Secretary of State,,D,Jean Schodorf,15
-Russell,Dorrance City / Plymouth Township,Secretary of State,,D,Jean Schodorf,27
-Russell,Russell Township,Secretary of State,,D,Jean Schodorf,9
-Russell,Russell Ward 1,Secretary of State,,D,Jean Schodorf,74
-Russell,Russell Ward 2,Secretary of State,,D,Jean Schodorf,113
-Russell,Russell Ward 3,Secretary of State,,D,Jean Schodorf,107
-Russell,Russell Ward 4,Secretary of State,,D,Jean Schodorf,91
-Russell,Waldo City / Waldo Township,Secretary of State,,D,Jean Schodorf,9
-Russell,Winterset Township,Secretary of State,,D,Jean Schodorf,8
-Russell,Gorham City /Big Creek Township,Attorney General,,R,Derek Schmidt,153
-Russell,Center Township,Attorney General,,R,Derek Schmidt,107
-Russell,Fairfield Township,Attorney General,,R,Derek Schmidt,12
-Russell,Lucas City / Fairview Township,Attorney General,,R,Derek Schmidt,131
-Russell,Grant Township,Attorney General,,R,Derek Schmidt,80
-Russell,Lincoln Township,Attorney General,,R,Derek Schmidt,51
-Russell,Luray City / Luray Township,Attorney General,,R,Derek Schmidt,75
-Russell,Paradise City / Paradise Township,Attorney General,,R,Derek Schmidt,63
-Russell,Dorrance City / Plymouth Township,Attorney General,,R,Derek Schmidt,86
-Russell,Russell Township,Attorney General,,R,Derek Schmidt,38
-Russell,Russell Ward 1,Attorney General,,R,Derek Schmidt,295
-Russell,Russell Ward 2,Attorney General,,R,Derek Schmidt,367
-Russell,Russell Ward 3,Attorney General,,R,Derek Schmidt,265
-Russell,Russell Ward 4,Attorney General,,R,Derek Schmidt,296
-Russell,Waldo City / Waldo Township,Attorney General,,R,Derek Schmidt,28
-Russell,Winterset Township,Attorney General,,R,Derek Schmidt,30
-Russell,Gorham City /Big Creek Township,Attorney General,,D,AJ Kotich,15
-Russell,Center Township,Attorney General,,D,AJ Kotich,23
-Russell,Fairfield Township,Attorney General,,D,AJ Kotich,4
-Russell,Lucas City / Fairview Township,Attorney General,,D,AJ Kotich,45
-Russell,Grant Township,Attorney General,,D,AJ Kotich,8
-Russell,Lincoln Township,Attorney General,,D,AJ Kotich,9
-Russell,Luray City / Luray Township,Attorney General,,D,AJ Kotich,29
-Russell,Paradise City / Paradise Township,Attorney General,,D,AJ Kotich,12
-Russell,Dorrance City / Plymouth Township,Attorney General,,D,AJ Kotich,15
-Russell,Russell Township,Attorney General,,D,AJ Kotich,6
-Russell,Russell Ward 1,Attorney General,,D,AJ Kotich,46
-Russell,Russell Ward 2,Attorney General,,D,AJ Kotich,78
-Russell,Russell Ward 3,Attorney General,,D,AJ Kotich,88
-Russell,Russell Ward 4,Attorney General,,D,AJ Kotich,61
-Russell,Waldo City / Waldo Township,Attorney General,,D,AJ Kotich,10
-Russell,Winterset Township,Attorney General,,D,AJ Kotich,7
-Russell,Gorham City /Big Creek Township,State Treasurer,,R,Ron Estes,145
-Russell,Center Township,State Treasurer,,R,Ron Estes,110
-Russell,Fairfield Township,State Treasurer,,R,Ron Estes,14
-Russell,Lucas City / Fairview Township,State Treasurer,,R,Ron Estes,134
-Russell,Grant Township,State Treasurer,,R,Ron Estes,80
-Russell,Lincoln Township,State Treasurer,,R,Ron Estes,52
-Russell,Luray City / Luray Township,State Treasurer,,R,Ron Estes,77
-Russell,Paradise City / Paradise Township,State Treasurer,,R,Ron Estes,62
-Russell,Dorrance City / Plymouth Township,State Treasurer,,R,Ron Estes,90
-Russell,Russell Township,State Treasurer,,R,Ron Estes,35
-Russell,Russell Ward 1,State Treasurer,,R,Ron Estes,290
-Russell,Russell Ward 2,State Treasurer,,R,Ron Estes,369
-Russell,Russell Ward 3,State Treasurer,,R,Ron Estes,281
-Russell,Russell Ward 4,State Treasurer,,R,Ron Estes,302
-Russell,Waldo City / Waldo Township,State Treasurer,,R,Ron Estes,31
-Russell,Winterset Township,State Treasurer,,R,Ron Estes,32
-Russell,Gorham City /Big Creek Township,State Treasurer,,D,Carmen Alldritt,20
-Russell,Center Township,State Treasurer,,D,Carmen Alldritt,20
-Russell,Fairfield Township,State Treasurer,,D,Carmen Alldritt,2
-Russell,Lucas City / Fairview Township,State Treasurer,,D,Carmen Alldritt,44
-Russell,Grant Township,State Treasurer,,D,Carmen Alldritt,8
-Russell,Lincoln Township,State Treasurer,,D,Carmen Alldritt,8
-Russell,Luray City / Luray Township,State Treasurer,,D,Carmen Alldritt,28
-Russell,Paradise City / Paradise Township,State Treasurer,,D,Carmen Alldritt,9
-Russell,Dorrance City / Plymouth Township,State Treasurer,,D,Carmen Alldritt,12
-Russell,Russell Township,State Treasurer,,D,Carmen Alldritt,9
-Russell,Russell Ward 1,State Treasurer,,D,Carmen Alldritt,46
-Russell,Russell Ward 2,State Treasurer,,D,Carmen Alldritt,74
-Russell,Russell Ward 3,State Treasurer,,D,Carmen Alldritt,74
-Russell,Russell Ward 4,State Treasurer,,D,Carmen Alldritt,60
-Russell,Waldo City / Waldo Township,State Treasurer,,D,Carmen Alldritt,8
-Russell,Winterset Township,State Treasurer,,D,Carmen Alldritt,6
-Russell,Gorham City /Big Creek Township,Insurance Commissioner,,R,Ken Selzer,138
-Russell,Center Township,Insurance Commissioner,,R,Ken Selzer,103
-Russell,Fairfield Township,Insurance Commissioner,,R,Ken Selzer,12
-Russell,Lucas City / Fairview Township,Insurance Commissioner,,R,Ken Selzer,125
-Russell,Grant Township,Insurance Commissioner,,R,Ken Selzer,77
-Russell,Lincoln Township,Insurance Commissioner,,R,Ken Selzer,48
-Russell,Luray City / Luray Township,Insurance Commissioner,,R,Ken Selzer,72
-Russell,Paradise City / Paradise Township,Insurance Commissioner,,R,Ken Selzer,59
-Russell,Dorrance City / Plymouth Township,Insurance Commissioner,,R,Ken Selzer,79
-Russell,Russell Township,Insurance Commissioner,,R,Ken Selzer,35
-Russell,Russell Ward 1,Insurance Commissioner,,R,Ken Selzer,283
-Russell,Russell Ward 2,Insurance Commissioner,,R,Ken Selzer,330
-Russell,Russell Ward 3,Insurance Commissioner,,R,Ken Selzer,257
-Russell,Russell Ward 4,Insurance Commissioner,,R,Ken Selzer,282
-Russell,Waldo City / Waldo Township,Insurance Commissioner,,R,Ken Selzer,26
-Russell,Winterset Township,Insurance Commissioner,,R,Ken Selzer,29
-Russell,Gorham City /Big Creek Township,Insurance Commissioner,,D,Dennis Anderson,22
-Russell,Center Township,Insurance Commissioner,,D,Dennis Anderson,23
-Russell,Fairfield Township,Insurance Commissioner,,D,Dennis Anderson,4
-Russell,Lucas City / Fairview Township,Insurance Commissioner,,D,Dennis Anderson,50
-Russell,Grant Township,Insurance Commissioner,,D,Dennis Anderson,10
-Russell,Lincoln Township,Insurance Commissioner,,D,Dennis Anderson,10
-Russell,Luray City / Luray Township,Insurance Commissioner,,D,Dennis Anderson,31
-Russell,Paradise City / Paradise Township,Insurance Commissioner,,D,Dennis Anderson,13
-Russell,Dorrance City / Plymouth Township,Insurance Commissioner,,D,Dennis Anderson,18
-Russell,Russell Township,Insurance Commissioner,,D,Dennis Anderson,9
-Russell,Russell Ward 1,Insurance Commissioner,,D,Dennis Anderson,50
-Russell,Russell Ward 2,Insurance Commissioner,,D,Dennis Anderson,104
-Russell,Russell Ward 3,Insurance Commissioner,,D,Dennis Anderson,91
-Russell,Russell Ward 4,Insurance Commissioner,,D,Dennis Anderson,70
-Russell,Waldo City / Waldo Township,Insurance Commissioner,,D,Dennis Anderson,12
-Russell,Winterset Township,Insurance Commissioner,,D,Dennis Anderson,9
-Russell,Gorham City /Big Creek Township,State House,109,R,Troy Waymaster R,164
-Russell,Center Township,State House,109,R,Troy Waymaster R,123
-Russell,Fairfield Township,State House,109,R,Troy Waymaster R,16
-Russell,Lucas City / Fairview Township,State House,109,R,Troy Waymaster R,165
-Russell,Grant Township,State House,109,R,Troy Waymaster R,83
-Russell,Lincoln Township,State House,109,R,Troy Waymaster R,59
-Russell,Luray City / Luray Township,State House,109,R,Troy Waymaster R,99
-Russell,Paradise City / Paradise Township,State House,109,R,Troy Waymaster R,73
-Russell,Dorrance City / Plymouth Township,State House,109,R,Troy Waymaster R,103
-Russell,Russell Township,State House,109,R,Troy Waymaster R,43
-Russell,Russell Ward 1,State House,109,R,Troy Waymaster R,321
-Russell,Russell Ward 2,State House,109,R,Troy Waymaster R,414
-Russell,Russell Ward 3,State House,109,R,Troy Waymaster R,333
-Russell,Russell Ward 4,State House,109,R,Troy Waymaster R,350
-Russell,Waldo City / Waldo Township,State House,109,R,Troy Waymaster R,40
-Russell,Winterset Township,State House,109,R,Troy Waymaster R,32
-Russell,Gorham City /Big Creek Township,U.S. Senate,,,Write-ins,1
-Russell,Bunker Hill / Center twp,U.S. Senate,,,Write-ins,2
-Russell,Bunker Hill / Center twp,Secretary of State,,,Write-ins,1
-Russell,Bunker Hill / Center twp,State House,109,,Write-ins,3
-Russell,Lucas City / Fairview Township,U.S. Senate,,,Write-ins,1
-Russell,Lucas City / Fairview Township,Governor,,,Write-ins,1
-Russell,Lucas City / Fairview Township,Attorney General,,,Write-ins,1
-Russell,Lucas City / Fairview Township,State Treasurer,,,Write-ins,1
-Russell,Lucas City / Fairview Township,Insurance Commissioner,,,Write-ins,1
-Russell,Lucas City / Fairview Township,State House,109,,Write-ins,2
-Russell,Luray City / Luray Township,State House,109,,Write-ins,1
-Russell,Paradise City / Paradise Township,State House,109,,Write-ins,1
-Russell,Russell Ward 1,U.S. House,1,,Write-ins,2
-Russell,Russell Ward 1,Governor,,,Write-ins,1
-Russell,Russell Ward 1,State House,109,,Write-ins,2
-Russell,Russell Ward 2,U.S. Senate,,,Write-ins,1
-Russell,Russell Ward 2,U.S. House,1,,Write-ins,1
-Russell,Russell Ward 2,Insurance Commissioner,,,Write-ins,1
-Russell,Russell Ward 2,State House,109,,Write-ins,4
-Russell,Russell Ward 3,U.S. Senate,,,Write-ins,3
-Russell,Russell Ward 3,U.S. House,1,,Write-ins,4
-Russell,Russell Ward 3,Governor,,,Write-ins,3
-Russell,Russell Ward 3,Secretary of State,,,Write-ins,2
-Russell,Russell Ward 3,Attorney General,,,Write-ins,2
-Russell,Russell Ward 3,State Treasurer,,,Write-ins,2
-Russell,Russell Ward 3,Insurance Commissioner,,,Write-ins,2
-Russell,Russell Ward 3,State House,109,,Write-ins,5
-Russell,Russell Ward 4,U.S. Senate,,,Write-ins,1
-Russell,Russell Ward 4,U.S. House,1,,Write-ins,2
-Russell,Russell Ward 4,Secretary of State,,,Write-ins,1
-Russell,Russell Ward 4,State House,109,,Write-ins,3
+county,precinct,office,district,party,candidate,votes,vtd
+RUSSELL,Big Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,000010
+RUSSELL,Big Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000010
+RUSSELL,Big Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000010
+RUSSELL,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000020
+RUSSELL,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000020
+RUSSELL,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",93,000020
+RUSSELL,Fairfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000030
+RUSSELL,Fairfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+RUSSELL,Fairfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000030
+RUSSELL,Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",82,000040
+RUSSELL,Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000040
+RUSSELL,Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,000040
+RUSSELL,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000050
+RUSSELL,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+RUSSELL,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000050
+RUSSELL,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000060
+RUSSELL,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+RUSSELL,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000060
+RUSSELL,Luray Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,000070
+RUSSELL,Luray Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000070
+RUSSELL,Luray Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000070
+RUSSELL,Paradise Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000080
+RUSSELL,Paradise Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000080
+RUSSELL,Paradise Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000080
+RUSSELL,Plymouth Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000090
+RUSSELL,Plymouth Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+RUSSELL,Plymouth Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000090
+RUSSELL,Russell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000100
+RUSSELL,Russell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+RUSSELL,Russell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000100
+RUSSELL,Russell Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",100,000110
+RUSSELL,Russell Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",29,000110
+RUSSELL,Russell Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",208,000110
+RUSSELL,Russell Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",176,000120
+RUSSELL,Russell Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000120
+RUSSELL,Russell Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",251,000120
+RUSSELL,Russell Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",135,000130
+RUSSELL,Russell Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000130
+RUSSELL,Russell Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",200,000130
+RUSSELL,Russell Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",126,00014A
+RUSSELL,Russell Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,00014A
+RUSSELL,Russell Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",224,00014A
+RUSSELL,Russell Ward 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00014B
+RUSSELL,Russell Ward 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00014C
+RUSSELL,Waldo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000150
+RUSSELL,Waldo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000150
+RUSSELL,Waldo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000150
+RUSSELL,Winterset Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000160
+RUSSELL,Winterset Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000160
+RUSSELL,Winterset Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000160
+RUSSELL,Russell Township Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+RUSSELL,Russell Township Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+RUSSELL,Russell Township Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+RUSSELL,Big Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",164,000010
+RUSSELL,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",123,000020
+RUSSELL,Fairfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000030
+RUSSELL,Fairview Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",165,000040
+RUSSELL,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",83,000050
+RUSSELL,Lincoln Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",59,000060
+RUSSELL,Luray Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",99,000070
+RUSSELL,Paradise Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",73,000080
+RUSSELL,Plymouth Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",103,000090
+RUSSELL,Russell Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",43,000100
+RUSSELL,Russell Ward 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",321,000110
+RUSSELL,Russell Ward 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",414,000120
+RUSSELL,Russell Ward 3,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",333,000130
+RUSSELL,Russell Ward 4,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",350,00014A
+RUSSELL,Russell Ward 4 Exclave,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,00014C
+RUSSELL,Waldo Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",40,000150
+RUSSELL,Winterset Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",32,000160
+RUSSELL,Russell Township Exclave,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,900010
+RUSSELL,Big Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000010
+RUSSELL,Big Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",136,000010
+RUSSELL,Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000020
+RUSSELL,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000020
+RUSSELL,Fairfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000030
+RUSSELL,Fairfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000030
+RUSSELL,Fairview Township,United States House of Representatives,1,Democratic,"Sherow, James E.",54,000040
+RUSSELL,Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",132,000040
+RUSSELL,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000050
+RUSSELL,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",77,000050
+RUSSELL,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000060
+RUSSELL,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000060
+RUSSELL,Luray Township,United States House of Representatives,1,Democratic,"Sherow, James E.",41,000070
+RUSSELL,Luray Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,000070
+RUSSELL,Paradise Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000080
+RUSSELL,Paradise Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,000080
+RUSSELL,Plymouth Township,United States House of Representatives,1,Democratic,"Sherow, James E.",26,000090
+RUSSELL,Plymouth Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000090
+RUSSELL,Russell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000100
+RUSSELL,Russell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000100
+RUSSELL,Russell Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",74,000110
+RUSSELL,Russell Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",258,000110
+RUSSELL,Russell Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",128,000120
+RUSSELL,Russell Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",315,000120
+RUSSELL,Russell Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",105,000130
+RUSSELL,Russell Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",249,000130
+RUSSELL,Russell Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",84,00014A
+RUSSELL,Russell Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",276,00014A
+RUSSELL,Russell Ward 4 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00014C
+RUSSELL,Waldo Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000150
+RUSSELL,Waldo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000150
+RUSSELL,Winterset Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000160
+RUSSELL,Winterset Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000160
+RUSSELL,Russell Township Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+RUSSELL,Russell Township Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+RUSSELL,Big Creek Township,Attorney General,,Democratic,"Kotich, A.J.",15,000010
+RUSSELL,Big Creek Township,Attorney General,,Republican,"Schmidt, Derek",153,000010
+RUSSELL,Center Township,Attorney General,,Democratic,"Kotich, A.J.",23,000020
+RUSSELL,Center Township,Attorney General,,Republican,"Schmidt, Derek",107,000020
+RUSSELL,Fairfield Township,Attorney General,,Democratic,"Kotich, A.J.",4,000030
+RUSSELL,Fairfield Township,Attorney General,,Republican,"Schmidt, Derek",12,000030
+RUSSELL,Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",45,000040
+RUSSELL,Fairview Township,Attorney General,,Republican,"Schmidt, Derek",131,000040
+RUSSELL,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",8,000050
+RUSSELL,Grant Township,Attorney General,,Republican,"Schmidt, Derek",80,000050
+RUSSELL,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",9,000060
+RUSSELL,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",51,000060
+RUSSELL,Luray Township,Attorney General,,Democratic,"Kotich, A.J.",29,000070
+RUSSELL,Luray Township,Attorney General,,Republican,"Schmidt, Derek",75,000070
+RUSSELL,Paradise Township,Attorney General,,Democratic,"Kotich, A.J.",12,000080
+RUSSELL,Paradise Township,Attorney General,,Republican,"Schmidt, Derek",63,000080
+RUSSELL,Plymouth Township,Attorney General,,Democratic,"Kotich, A.J.",15,000090
+RUSSELL,Plymouth Township,Attorney General,,Republican,"Schmidt, Derek",86,000090
+RUSSELL,Russell Township,Attorney General,,Democratic,"Kotich, A.J.",6,000100
+RUSSELL,Russell Township,Attorney General,,Republican,"Schmidt, Derek",38,000100
+RUSSELL,Russell Ward 1,Attorney General,,Democratic,"Kotich, A.J.",46,000110
+RUSSELL,Russell Ward 1,Attorney General,,Republican,"Schmidt, Derek",295,000110
+RUSSELL,Russell Ward 2,Attorney General,,Democratic,"Kotich, A.J.",78,000120
+RUSSELL,Russell Ward 2,Attorney General,,Republican,"Schmidt, Derek",367,000120
+RUSSELL,Russell Ward 3,Attorney General,,Democratic,"Kotich, A.J.",88,000130
+RUSSELL,Russell Ward 3,Attorney General,,Republican,"Schmidt, Derek",265,000130
+RUSSELL,Russell Ward 4,Attorney General,,Democratic,"Kotich, A.J.",61,00014A
+RUSSELL,Russell Ward 4,Attorney General,,Republican,"Schmidt, Derek",296,00014A
+RUSSELL,Russell Ward 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Attorney General,,Democratic,"Kotich, A.J.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,Attorney General,,Republican,"Schmidt, Derek",0,00014C
+RUSSELL,Waldo Township,Attorney General,,Democratic,"Kotich, A.J.",10,000150
+RUSSELL,Waldo Township,Attorney General,,Republican,"Schmidt, Derek",28,000150
+RUSSELL,Winterset Township,Attorney General,,Democratic,"Kotich, A.J.",7,000160
+RUSSELL,Winterset Township,Attorney General,,Republican,"Schmidt, Derek",30,000160
+RUSSELL,Russell Township Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+RUSSELL,Russell Township Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+RUSSELL,Big Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000010
+RUSSELL,Big Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",138,000010
+RUSSELL,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000020
+RUSSELL,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000020
+RUSSELL,Fairfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000030
+RUSSELL,Fairfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000030
+RUSSELL,Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000040
+RUSSELL,Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",125,000040
+RUSSELL,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000050
+RUSSELL,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000050
+RUSSELL,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000060
+RUSSELL,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000060
+RUSSELL,Luray Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000070
+RUSSELL,Luray Township,Commissioner of Insurance,,Republican,"Selzer, Ken",72,000070
+RUSSELL,Paradise Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000080
+RUSSELL,Paradise Township,Commissioner of Insurance,,Republican,"Selzer, Ken",59,000080
+RUSSELL,Plymouth Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000090
+RUSSELL,Plymouth Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000090
+RUSSELL,Russell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000100
+RUSSELL,Russell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000100
+RUSSELL,Russell Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000110
+RUSSELL,Russell Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",283,000110
+RUSSELL,Russell Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",104,000120
+RUSSELL,Russell Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",330,000120
+RUSSELL,Russell Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,000130
+RUSSELL,Russell Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",257,000130
+RUSSELL,Russell Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",70,00014A
+RUSSELL,Russell Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",282,00014A
+RUSSELL,Russell Ward 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00014B
+RUSSELL,Russell Ward 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00014C
+RUSSELL,Waldo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,000150
+RUSSELL,Waldo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000150
+RUSSELL,Winterset Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000160
+RUSSELL,Winterset Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000160
+RUSSELL,Russell Township Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+RUSSELL,Russell Township Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+RUSSELL,Big Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000010
+RUSSELL,Big Creek Township,Secretary of State,,Republican,"Kobach, Kris",140,000010
+RUSSELL,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000020
+RUSSELL,Center Township,Secretary of State,,Republican,"Kobach, Kris",103,000020
+RUSSELL,Fairfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000030
+RUSSELL,Fairfield Township,Secretary of State,,Republican,"Kobach, Kris",12,000030
+RUSSELL,Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000040
+RUSSELL,Fairview Township,Secretary of State,,Republican,"Kobach, Kris",128,000040
+RUSSELL,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000050
+RUSSELL,Grant Township,Secretary of State,,Republican,"Kobach, Kris",70,000050
+RUSSELL,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000060
+RUSSELL,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",48,000060
+RUSSELL,Luray Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",35,000070
+RUSSELL,Luray Township,Secretary of State,,Republican,"Kobach, Kris",70,000070
+RUSSELL,Paradise Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000080
+RUSSELL,Paradise Township,Secretary of State,,Republican,"Kobach, Kris",62,000080
+RUSSELL,Plymouth Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000090
+RUSSELL,Plymouth Township,Secretary of State,,Republican,"Kobach, Kris",77,000090
+RUSSELL,Russell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000100
+RUSSELL,Russell Township,Secretary of State,,Republican,"Kobach, Kris",35,000100
+RUSSELL,Russell Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000110
+RUSSELL,Russell Ward 1,Secretary of State,,Republican,"Kobach, Kris",267,000110
+RUSSELL,Russell Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",113,000120
+RUSSELL,Russell Ward 2,Secretary of State,,Republican,"Kobach, Kris",329,000120
+RUSSELL,Russell Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",107,000130
+RUSSELL,Russell Ward 3,Secretary of State,,Republican,"Kobach, Kris",251,000130
+RUSSELL,Russell Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",91,00014A
+RUSSELL,Russell Ward 4,Secretary of State,,Republican,"Kobach, Kris",270,00014A
+RUSSELL,Russell Ward 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00014B
+RUSSELL,Russell Ward 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,Secretary of State,,Republican,"Kobach, Kris",0,00014C
+RUSSELL,Waldo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000150
+RUSSELL,Waldo Township,Secretary of State,,Republican,"Kobach, Kris",33,000150
+RUSSELL,Winterset Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000160
+RUSSELL,Winterset Township,Secretary of State,,Republican,"Kobach, Kris",30,000160
+RUSSELL,Russell Township Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+RUSSELL,Russell Township Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+RUSSELL,Big Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000010
+RUSSELL,Big Creek Township,State Treasurer,,Republican,"Estes, Ron",145,000010
+RUSSELL,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000020
+RUSSELL,Center Township,State Treasurer,,Republican,"Estes, Ron",110,000020
+RUSSELL,Fairfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000030
+RUSSELL,Fairfield Township,State Treasurer,,Republican,"Estes, Ron",14,000030
+RUSSELL,Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",44,000040
+RUSSELL,Fairview Township,State Treasurer,,Republican,"Estes, Ron",134,000040
+RUSSELL,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000050
+RUSSELL,Grant Township,State Treasurer,,Republican,"Estes, Ron",80,000050
+RUSSELL,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000060
+RUSSELL,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",52,000060
+RUSSELL,Luray Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000070
+RUSSELL,Luray Township,State Treasurer,,Republican,"Estes, Ron",77,000070
+RUSSELL,Paradise Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000080
+RUSSELL,Paradise Township,State Treasurer,,Republican,"Estes, Ron",62,000080
+RUSSELL,Plymouth Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000090
+RUSSELL,Plymouth Township,State Treasurer,,Republican,"Estes, Ron",90,000090
+RUSSELL,Russell Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000100
+RUSSELL,Russell Township,State Treasurer,,Republican,"Estes, Ron",35,000100
+RUSSELL,Russell Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",46,000110
+RUSSELL,Russell Ward 1,State Treasurer,,Republican,"Estes, Ron",290,000110
+RUSSELL,Russell Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",74,000120
+RUSSELL,Russell Ward 2,State Treasurer,,Republican,"Estes, Ron",369,000120
+RUSSELL,Russell Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",74,000130
+RUSSELL,Russell Ward 3,State Treasurer,,Republican,"Estes, Ron",281,000130
+RUSSELL,Russell Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",60,00014A
+RUSSELL,Russell Ward 4,State Treasurer,,Republican,"Estes, Ron",302,00014A
+RUSSELL,Russell Ward 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00014B
+RUSSELL,Russell Ward 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,State Treasurer,,Republican,"Estes, Ron",0,00014C
+RUSSELL,Waldo Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000150
+RUSSELL,Waldo Township,State Treasurer,,Republican,"Estes, Ron",31,000150
+RUSSELL,Winterset Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000160
+RUSSELL,Winterset Township,State Treasurer,,Republican,"Estes, Ron",32,000160
+RUSSELL,Russell Township Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+RUSSELL,Russell Township Exclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+RUSSELL,Big Creek Township,United States Senate,,independent,"Orman, Greg",28,000010
+RUSSELL,Big Creek Township,United States Senate,,Libertarian,"Batson, Randall",7,000010
+RUSSELL,Big Creek Township,United States Senate,,Republican,"Roberts, Pat",137,000010
+RUSSELL,Center Township,United States Senate,,independent,"Orman, Greg",35,000020
+RUSSELL,Center Township,United States Senate,,Libertarian,"Batson, Randall",5,000020
+RUSSELL,Center Township,United States Senate,,Republican,"Roberts, Pat",91,000020
+RUSSELL,Fairfield Township,United States Senate,,independent,"Orman, Greg",2,000030
+RUSSELL,Fairfield Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+RUSSELL,Fairfield Township,United States Senate,,Republican,"Roberts, Pat",14,000030
+RUSSELL,Fairview Township,United States Senate,,independent,"Orman, Greg",61,000040
+RUSSELL,Fairview Township,United States Senate,,Libertarian,"Batson, Randall",8,000040
+RUSSELL,Fairview Township,United States Senate,,Republican,"Roberts, Pat",121,000040
+RUSSELL,Grant Township,United States Senate,,independent,"Orman, Greg",15,000050
+RUSSELL,Grant Township,United States Senate,,Libertarian,"Batson, Randall",3,000050
+RUSSELL,Grant Township,United States Senate,,Republican,"Roberts, Pat",69,000050
+RUSSELL,Lincoln Township,United States Senate,,independent,"Orman, Greg",14,000060
+RUSSELL,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",1,000060
+RUSSELL,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",43,000060
+RUSSELL,Luray Township,United States Senate,,independent,"Orman, Greg",39,000070
+RUSSELL,Luray Township,United States Senate,,Libertarian,"Batson, Randall",6,000070
+RUSSELL,Luray Township,United States Senate,,Republican,"Roberts, Pat",64,000070
+RUSSELL,Paradise Township,United States Senate,,independent,"Orman, Greg",19,000080
+RUSSELL,Paradise Township,United States Senate,,Libertarian,"Batson, Randall",2,000080
+RUSSELL,Paradise Township,United States Senate,,Republican,"Roberts, Pat",58,000080
+RUSSELL,Plymouth Township,United States Senate,,independent,"Orman, Greg",31,000090
+RUSSELL,Plymouth Township,United States Senate,,Libertarian,"Batson, Randall",2,000090
+RUSSELL,Plymouth Township,United States Senate,,Republican,"Roberts, Pat",71,000090
+RUSSELL,Russell Township,United States Senate,,independent,"Orman, Greg",5,000100
+RUSSELL,Russell Township,United States Senate,,Libertarian,"Batson, Randall",2,000100
+RUSSELL,Russell Township,United States Senate,,Republican,"Roberts, Pat",38,000100
+RUSSELL,Russell Ward 1,United States Senate,,independent,"Orman, Greg",91,000110
+RUSSELL,Russell Ward 1,United States Senate,,Libertarian,"Batson, Randall",21,000110
+RUSSELL,Russell Ward 1,United States Senate,,Republican,"Roberts, Pat",222,000110
+RUSSELL,Russell Ward 2,United States Senate,,independent,"Orman, Greg",133,000120
+RUSSELL,Russell Ward 2,United States Senate,,Libertarian,"Batson, Randall",23,000120
+RUSSELL,Russell Ward 2,United States Senate,,Republican,"Roberts, Pat",287,000120
+RUSSELL,Russell Ward 3,United States Senate,,independent,"Orman, Greg",115,000130
+RUSSELL,Russell Ward 3,United States Senate,,Libertarian,"Batson, Randall",25,000130
+RUSSELL,Russell Ward 3,United States Senate,,Republican,"Roberts, Pat",220,000130
+RUSSELL,Russell Ward 4,United States Senate,,independent,"Orman, Greg",95,00014A
+RUSSELL,Russell Ward 4,United States Senate,,Libertarian,"Batson, Randall",21,00014A
+RUSSELL,Russell Ward 4,United States Senate,,Republican,"Roberts, Pat",248,00014A
+RUSSELL,Russell Ward 4 Exclave,United States Senate,,independent,"Orman, Greg",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,United States Senate,,independent,"Orman, Greg",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States Senate,,Libertarian,"Batson, Randall",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States Senate,,Republican,"Roberts, Pat",0,00014C
+RUSSELL,Waldo Township,United States Senate,,independent,"Orman, Greg",12,000150
+RUSSELL,Waldo Township,United States Senate,,Libertarian,"Batson, Randall",3,000150
+RUSSELL,Waldo Township,United States Senate,,Republican,"Roberts, Pat",27,000150
+RUSSELL,Winterset Township,United States Senate,,independent,"Orman, Greg",9,000160
+RUSSELL,Winterset Township,United States Senate,,Libertarian,"Batson, Randall",2,000160
+RUSSELL,Winterset Township,United States Senate,,Republican,"Roberts, Pat",29,000160
+RUSSELL,Russell Township Exclave,United States Senate,,independent,"Orman, Greg",0,900010
+RUSSELL,Russell Township Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+RUSSELL,Russell Township Exclave,United States Senate,,Republican,"Roberts, Pat",0,900010

--- a/2014/20141104__ks__general__saline__precinct.csv
+++ b/2014/20141104__ks__general__saline__precinct.csv
@@ -1,943 +1,1128 @@
-county,precinct,office,district,party,candidate,votes
-Saline,1,U.S. Senate,,R,Pat Roberts,105
-Saline,2,U.S. Senate,,R,Pat Roberts,110
-Saline,3,U.S. Senate,,R,Pat Roberts,73
-Saline,4,U.S. Senate,,R,Pat Roberts,101
-Saline,5,U.S. Senate,,R,Pat Roberts,113
-Saline,6,U.S. Senate,,R,Pat Roberts,89
-Saline,7,U.S. Senate,,R,Pat Roberts,126
-Saline,8,U.S. Senate,,R,Pat Roberts,129
-Saline,9,U.S. Senate,,R,Pat Roberts,145
-Saline,10,U.S. Senate,,R,Pat Roberts,140
-Saline,11,U.S. Senate,,R,Pat Roberts,141
-Saline,12,U.S. Senate,,R,Pat Roberts,192
-Saline,13,U.S. Senate,,R,Pat Roberts,130
-Saline,14,U.S. Senate,,R,Pat Roberts,178
-Saline,15,U.S. Senate,,R,Pat Roberts,123
-Saline,16,U.S. Senate,,R,Pat Roberts,112
-Saline,17,U.S. Senate,,R,Pat Roberts,128
-Saline,18,U.S. Senate,,R,Pat Roberts,157
-Saline,19,U.S. Senate,,R,Pat Roberts,264
-Saline,20,U.S. Senate,,R,Pat Roberts,530
-Saline,21,U.S. Senate,,R,Pat Roberts,474
-Saline,22,U.S. Senate,,R,Pat Roberts,432
-Saline,23,U.S. Senate,,R,Pat Roberts,479
-Saline,24,U.S. Senate,,R,Pat Roberts,170
-Saline,25,U.S. Senate,,R,Pat Roberts,109
-Saline,26,U.S. Senate,,R,Pat Roberts,142
-Saline,27,U.S. Senate,,R,Pat Roberts,228
-Saline,28,U.S. Senate,,R,Pat Roberts,160
-Saline,29,U.S. Senate,,R,Pat Roberts,254
-Saline,30,U.S. Senate,,R,Pat Roberts,212
-Saline,31,U.S. Senate,,R,Pat Roberts,557
-Saline,32,U.S. Senate,,R,Pat Roberts,150
-Saline,33,U.S. Senate,,R,Pat Roberts,300
-Saline,34,U.S. Senate,,R,Pat Roberts,459
-Saline,35,U.S. Senate,,R,Pat Roberts,268
-Saline,CAMBRIA,U.S. Senate,,R,Pat Roberts,101
-Saline,DAYTON,U.S. Senate,,R,Pat Roberts,29
-Saline,ELM CREEK,U.S. Senate,,R,Pat Roberts,246
-Saline,EUREKA,U.S. Senate,,R,Pat Roberts,143
-Saline,FALUN,U.S. Senate,,R,Pat Roberts,72
-Saline,GLENDALE,U.S. Senate,,R,Pat Roberts,27
-Saline,GREELEY,U.S. Senate,,R,Pat Roberts,278
-Saline,GYPSUM,U.S. Senate,,R,Pat Roberts,54
-Saline,LIBERTY,U.S. Senate,,R,Pat Roberts,58
-Saline,OHIO,U.S. Senate,,R,Pat Roberts,107
-Saline,PLEASANT VLY,U.S. Senate,,R,Pat Roberts,102
-Saline,SMOKY HILL,U.S. Senate,,R,Pat Roberts,68
-Saline,SMOKY VIEW,U.S. Senate,,R,Pat Roberts,199
-Saline,SMOLAN,U.S. Senate,,R,Pat Roberts,192
-Saline,SOLOMON,U.S. Senate,,R,Pat Roberts,139
-Saline,SPRING CREEK,U.S. Senate,,R,Pat Roberts,101
-Saline,WALNUT,U.S. Senate,,R,Pat Roberts,164
-Saline,WASHINGTON,U.S. Senate,,R,Pat Roberts,49
-Saline,Paper Ballots,U.S. Senate,,R,Pat Roberts,85
-Saline,1,U.S. Senate,,I,Greg Orman,109
-Saline,2,U.S. Senate,,I,Greg Orman,105
-Saline,3,U.S. Senate,,I,Greg Orman,86
-Saline,4,U.S. Senate,,I,Greg Orman,140
-Saline,5,U.S. Senate,,I,Greg Orman,116
-Saline,6,U.S. Senate,,I,Greg Orman,94
-Saline,7,U.S. Senate,,I,Greg Orman,149
-Saline,8,U.S. Senate,,I,Greg Orman,144
-Saline,9,U.S. Senate,,I,Greg Orman,140
-Saline,10,U.S. Senate,,I,Greg Orman,139
-Saline,11,U.S. Senate,,I,Greg Orman,96
-Saline,12,U.S. Senate,,I,Greg Orman,209
-Saline,13,U.S. Senate,,I,Greg Orman,101
-Saline,14,U.S. Senate,,I,Greg Orman,147
-Saline,15,U.S. Senate,,I,Greg Orman,144
-Saline,16,U.S. Senate,,I,Greg Orman,89
-Saline,17,U.S. Senate,,I,Greg Orman,114
-Saline,18,U.S. Senate,,I,Greg Orman,125
-Saline,19,U.S. Senate,,I,Greg Orman,160
-Saline,20,U.S. Senate,,I,Greg Orman,342
-Saline,21,U.S. Senate,,I,Greg Orman,320
-Saline,22,U.S. Senate,,I,Greg Orman,235
-Saline,23,U.S. Senate,,I,Greg Orman,379
-Saline,24,U.S. Senate,,I,Greg Orman,121
-Saline,25,U.S. Senate,,I,Greg Orman,89
-Saline,26,U.S. Senate,,I,Greg Orman,139
-Saline,27,U.S. Senate,,I,Greg Orman,155
-Saline,28,U.S. Senate,,I,Greg Orman,95
-Saline,29,U.S. Senate,,I,Greg Orman,167
-Saline,30,U.S. Senate,,I,Greg Orman,156
-Saline,31,U.S. Senate,,I,Greg Orman,350
-Saline,32,U.S. Senate,,I,Greg Orman,94
-Saline,33,U.S. Senate,,I,Greg Orman,206
-Saline,34,U.S. Senate,,I,Greg Orman,321
-Saline,35,U.S. Senate,,I,Greg Orman,214
-Saline,CAMBRIA,U.S. Senate,,I,Greg Orman,48
-Saline,DAYTON,U.S. Senate,,I,Greg Orman,13
-Saline,ELM CREEK,U.S. Senate,,I,Greg Orman,115
-Saline,EUREKA,U.S. Senate,,I,Greg Orman,65
-Saline,FALUN,U.S. Senate,,I,Greg Orman,25
-Saline,GLENDALE,U.S. Senate,,I,Greg Orman,7
-Saline,GREELEY,U.S. Senate,,I,Greg Orman,93
-Saline,GYPSUM,U.S. Senate,,I,Greg Orman,10
-Saline,LIBERTY,U.S. Senate,,I,Greg Orman,15
-Saline,OHIO,U.S. Senate,,I,Greg Orman,41
-Saline,PLEASANT VLY,U.S. Senate,,I,Greg Orman,34
-Saline,SMOKY HILL,U.S. Senate,,I,Greg Orman,31
-Saline,SMOKY VIEW,U.S. Senate,,I,Greg Orman,105
-Saline,SMOLAN,U.S. Senate,,I,Greg Orman,95
-Saline,SOLOMON,U.S. Senate,,I,Greg Orman,43
-Saline,SPRING CREEK,U.S. Senate,,I,Greg Orman,47
-Saline,WALNUT,U.S. Senate,,I,Greg Orman,73
-Saline,WASHINGTON,U.S. Senate,,I,Greg Orman,18
-Saline,Paper Ballots,U.S. Senate,,I,Greg Orman,52
-Saline,1,U.S. Senate,,L,Randall Batson,23
-Saline,2,U.S. Senate,,L,Randall Batson,28
-Saline,3,U.S. Senate,,L,Randall Batson,19
-Saline,4,U.S. Senate,,L,Randall Batson,30
-Saline,5,U.S. Senate,,L,Randall Batson,19
-Saline,6,U.S. Senate,,L,Randall Batson,17
-Saline,7,U.S. Senate,,L,Randall Batson,28
-Saline,8,U.S. Senate,,L,Randall Batson,12
-Saline,9,U.S. Senate,,L,Randall Batson,28
-Saline,10,U.S. Senate,,L,Randall Batson,18
-Saline,11,U.S. Senate,,L,Randall Batson,25
-Saline,12,U.S. Senate,,L,Randall Batson,21
-Saline,13,U.S. Senate,,L,Randall Batson,18
-Saline,14,U.S. Senate,,L,Randall Batson,28
-Saline,15,U.S. Senate,,L,Randall Batson,19
-Saline,16,U.S. Senate,,L,Randall Batson,18
-Saline,17,U.S. Senate,,L,Randall Batson,18
-Saline,18,U.S. Senate,,L,Randall Batson,22
-Saline,19,U.S. Senate,,L,Randall Batson,11
-Saline,20,U.S. Senate,,L,Randall Batson,31
-Saline,21,U.S. Senate,,L,Randall Batson,20
-Saline,22,U.S. Senate,,L,Randall Batson,18
-Saline,23,U.S. Senate,,L,Randall Batson,42
-Saline,24,U.S. Senate,,L,Randall Batson,19
-Saline,25,U.S. Senate,,L,Randall Batson,13
-Saline,26,U.S. Senate,,L,Randall Batson,23
-Saline,27,U.S. Senate,,L,Randall Batson,21
-Saline,28,U.S. Senate,,L,Randall Batson,20
-Saline,29,U.S. Senate,,L,Randall Batson,20
-Saline,30,U.S. Senate,,L,Randall Batson,13
-Saline,31,U.S. Senate,,L,Randall Batson,48
-Saline,32,U.S. Senate,,L,Randall Batson,15
-Saline,33,U.S. Senate,,L,Randall Batson,21
-Saline,34,U.S. Senate,,L,Randall Batson,58
-Saline,35,U.S. Senate,,L,Randall Batson,36
-Saline,CAMBRIA,U.S. Senate,,L,Randall Batson,10
-Saline,DAYTON,U.S. Senate,,L,Randall Batson,1
-Saline,ELM CREEK,U.S. Senate,,L,Randall Batson,21
-Saline,EUREKA,U.S. Senate,,L,Randall Batson,10
-Saline,FALUN,U.S. Senate,,L,Randall Batson,11
-Saline,GLENDALE,U.S. Senate,,L,Randall Batson,3
-Saline,GREELEY,U.S. Senate,,L,Randall Batson,15
-Saline,GYPSUM,U.S. Senate,,L,Randall Batson,4
-Saline,LIBERTY,U.S. Senate,,L,Randall Batson,7
-Saline,OHIO,U.S. Senate,,L,Randall Batson,24
-Saline,PLEASANT VLY,U.S. Senate,,L,Randall Batson,11
-Saline,SMOKY HILL,U.S. Senate,,L,Randall Batson,5
-Saline,SMOKY VIEW,U.S. Senate,,L,Randall Batson,26
-Saline,SMOLAN,U.S. Senate,,L,Randall Batson,12
-Saline,SOLOMON,U.S. Senate,,L,Randall Batson,5
-Saline,SPRING CREEK,U.S. Senate,,L,Randall Batson,10
-Saline,WALNUT,U.S. Senate,,L,Randall Batson,7
-Saline,WASHINGTON,U.S. Senate,,L,Randall Batson,3
-Saline,Paper Ballots,U.S. Senate,,L,Randall Batson,10
-Saline,1,U.S. House,1,R,Tim Huelskamp,123
-Saline,2,U.S. House,1,R,Tim Huelskamp,142
-Saline,3,U.S. House,1,R,Tim Huelskamp,92
-Saline,4,U.S. House,1,R,Tim Huelskamp,126
-Saline,5,U.S. House,1,R,Tim Huelskamp,138
-Saline,6,U.S. House,1,R,Tim Huelskamp,104
-Saline,7,U.S. House,1,R,Tim Huelskamp,159
-Saline,8,U.S. House,1,R,Tim Huelskamp,141
-Saline,9,U.S. House,1,R,Tim Huelskamp,170
-Saline,10,U.S. House,1,R,Tim Huelskamp,150
-Saline,11,U.S. House,1,R,Tim Huelskamp,164
-Saline,12,U.S. House,1,R,Tim Huelskamp,202
-Saline,13,U.S. House,1,R,Tim Huelskamp,145
-Saline,14,U.S. House,1,R,Tim Huelskamp,219
-Saline,15,U.S. House,1,R,Tim Huelskamp,133
-Saline,16,U.S. House,1,R,Tim Huelskamp,130
-Saline,17,U.S. House,1,R,Tim Huelskamp,154
-Saline,18,U.S. House,1,R,Tim Huelskamp,181
-Saline,19,U.S. House,1,R,Tim Huelskamp,274
-Saline,20,U.S. House,1,R,Tim Huelskamp,496
-Saline,21,U.S. House,1,R,Tim Huelskamp,470
-Saline,22,U.S. House,1,R,Tim Huelskamp,424
-Saline,23,U.S. House,1,R,Tim Huelskamp,536
-Saline,24,U.S. House,1,R,Tim Huelskamp,177
-Saline,25,U.S. House,1,R,Tim Huelskamp,119
-Saline,26,U.S. House,1,R,Tim Huelskamp,161
-Saline,27,U.S. House,1,R,Tim Huelskamp,247
-Saline,28,U.S. House,1,R,Tim Huelskamp,181
-Saline,29,U.S. House,1,R,Tim Huelskamp,276
-Saline,30,U.S. House,1,R,Tim Huelskamp,226
-Saline,31,U.S. House,1,R,Tim Huelskamp,590
-Saline,32,U.S. House,1,R,Tim Huelskamp,170
-Saline,33,U.S. House,1,R,Tim Huelskamp,320
-Saline,34,U.S. House,1,R,Tim Huelskamp,511
-Saline,35,U.S. House,1,R,Tim Huelskamp,314
-Saline,CAMBRIA,U.S. House,1,R,Tim Huelskamp,113
-Saline,DAYTON,U.S. House,1,R,Tim Huelskamp,29
-Saline,ELM CREEK,U.S. House,1,R,Tim Huelskamp,273
-Saline,EUREKA,U.S. House,1,R,Tim Huelskamp,158
-Saline,FALUN,U.S. House,1,R,Tim Huelskamp,80
-Saline,GLENDALE,U.S. House,1,R,Tim Huelskamp,29
-Saline,GREELEY,U.S. House,1,R,Tim Huelskamp,268
-Saline,GYPSUM,U.S. House,1,R,Tim Huelskamp,59
-Saline,LIBERTY,U.S. House,1,R,Tim Huelskamp,56
-Saline,OHIO,U.S. House,1,R,Tim Huelskamp,124
-Saline,PLEASANT VLY,U.S. House,1,R,Tim Huelskamp,111
-Saline,SMOKY HILL,U.S. House,1,R,Tim Huelskamp,69
-Saline,SMOKY VIEW,U.S. House,1,R,Tim Huelskamp,216
-Saline,SMOLAN,U.S. House,1,R,Tim Huelskamp,202
-Saline,SOLOMON,U.S. House,1,R,Tim Huelskamp,141
-Saline,SPRING CREEK,U.S. House,1,R,Tim Huelskamp,110
-Saline,WALNUT,U.S. House,1,R,Tim Huelskamp,161
-Saline,WASHINGTON,U.S. House,1,R,Tim Huelskamp,53
-Saline,Paper Ballots,U.S. House,1,R,Tim Huelskamp,84
-Saline,1,U.S. House,1,D,James Sherow,113
-Saline,2,U.S. House,1,D,James Sherow,97
-Saline,3,U.S. House,1,D,James Sherow,86
-Saline,4,U.S. House,1,D,James Sherow,141
-Saline,5,U.S. House,1,D,James Sherow,110
-Saline,6,U.S. House,1,D,James Sherow,95
-Saline,7,U.S. House,1,D,James Sherow,145
-Saline,8,U.S. House,1,D,James Sherow,144
-Saline,9,U.S. House,1,D,James Sherow,140
-Saline,10,U.S. House,1,D,James Sherow,146
-Saline,11,U.S. House,1,D,James Sherow,97
-Saline,12,U.S. House,1,D,James Sherow,214
-Saline,13,U.S. House,1,D,James Sherow,102
-Saline,14,U.S. House,1,D,James Sherow,132
-Saline,15,U.S. House,1,D,James Sherow,148
-Saline,16,U.S. House,1,D,James Sherow,85
-Saline,17,U.S. House,1,D,James Sherow,106
-Saline,18,U.S. House,1,D,James Sherow,121
-Saline,19,U.S. House,1,D,James Sherow,160
-Saline,20,U.S. House,1,D,James Sherow,400
-Saline,21,U.S. House,1,D,James Sherow,333
-Saline,22,U.S. House,1,D,James Sherow,260
-Saline,23,U.S. House,1,D,James Sherow,355
-Saline,24,U.S. House,1,D,James Sherow,124
-Saline,25,U.S. House,1,D,James Sherow,94
-Saline,26,U.S. House,1,D,James Sherow,132
-Saline,27,U.S. House,1,D,James Sherow,157
-Saline,28,U.S. House,1,D,James Sherow,94
-Saline,29,U.S. House,1,D,James Sherow,157
-Saline,30,U.S. House,1,D,James Sherow,155
-Saline,31,U.S. House,1,D,James Sherow,357
-Saline,32,U.S. House,1,D,James Sherow,83
-Saline,33,U.S. House,1,D,James Sherow,192
-Saline,34,U.S. House,1,D,James Sherow,321
-Saline,35,U.S. House,1,D,James Sherow,205
-Saline,CAMBRIA,U.S. House,1,D,James Sherow,45
-Saline,DAYTON,U.S. House,1,D,James Sherow,16
-Saline,ELM CREEK,U.S. House,1,D,James Sherow,107
-Saline,EUREKA,U.S. House,1,D,James Sherow,63
-Saline,FALUN,U.S. House,1,D,James Sherow,27
-Saline,GLENDALE,U.S. House,1,D,James Sherow,9
-Saline,GREELEY,U.S. House,1,D,James Sherow,112
-Saline,GYPSUM,U.S. House,1,D,James Sherow,8
-Saline,LIBERTY,U.S. House,1,D,James Sherow,22
-Saline,OHIO,U.S. House,1,D,James Sherow,48
-Saline,PLEASANT VLY,U.S. House,1,D,James Sherow,36
-Saline,SMOKY HILL,U.S. House,1,D,James Sherow,34
-Saline,SMOKY VIEW,U.S. House,1,D,James Sherow,109
-Saline,SMOLAN,U.S. House,1,D,James Sherow,95
-Saline,SOLOMON,U.S. House,1,D,James Sherow,49
-Saline,SPRING CREEK,U.S. House,1,D,James Sherow,45
-Saline,WALNUT,U.S. House,1,D,James Sherow,83
-Saline,WASHINGTON,U.S. House,1,D,James Sherow,17
-Saline,Paper Ballots,U.S. House,1,D,James Sherow,63
-Saline,1,Governor,,R,Sam Brownback,98
-Saline,2,Governor,,R,Sam Brownback,99
-Saline,3,Governor,,R,Sam Brownback,69
-Saline,4,Governor,,R,Sam Brownback,89
-Saline,5,Governor,,R,Sam Brownback,103
-Saline,6,Governor,,R,Sam Brownback,75
-Saline,7,Governor,,R,Sam Brownback,107
-Saline,8,Governor,,R,Sam Brownback,109
-Saline,9,Governor,,R,Sam Brownback,111
-Saline,10,Governor,,R,Sam Brownback,115
-Saline,11,Governor,,R,Sam Brownback,128
-Saline,12,Governor,,R,Sam Brownback,149
-Saline,13,Governor,,R,Sam Brownback,107
-Saline,14,Governor,,R,Sam Brownback,163
-Saline,15,Governor,,R,Sam Brownback,114
-Saline,16,Governor,,R,Sam Brownback,104
-Saline,17,Governor,,R,Sam Brownback,119
-Saline,18,Governor,,R,Sam Brownback,138
-Saline,19,Governor,,R,Sam Brownback,235
-Saline,20,Governor,,R,Sam Brownback,443
-Saline,21,Governor,,R,Sam Brownback,422
-Saline,22,Governor,,R,Sam Brownback,366
-Saline,23,Governor,,R,Sam Brownback,428
-Saline,24,Governor,,R,Sam Brownback,141
-Saline,25,Governor,,R,Sam Brownback,101
-Saline,26,Governor,,R,Sam Brownback,118
-Saline,27,Governor,,R,Sam Brownback,197
-Saline,28,Governor,,R,Sam Brownback,140
-Saline,29,Governor,,R,Sam Brownback,208
-Saline,30,Governor,,R,Sam Brownback,183
-Saline,31,Governor,,R,Sam Brownback,468
-Saline,32,Governor,,R,Sam Brownback,130
-Saline,33,Governor,,R,Sam Brownback,258
-Saline,34,Governor,,R,Sam Brownback,401
-Saline,35,Governor,,R,Sam Brownback,249
-Saline,CAMBRIA,Governor,,R,Sam Brownback,96
-Saline,DAYTON,Governor,,R,Sam Brownback,27
-Saline,ELM CREEK,Governor,,R,Sam Brownback,228
-Saline,EUREKA,Governor,,R,Sam Brownback,125
-Saline,FALUN,Governor,,R,Sam Brownback,67
-Saline,GLENDALE,Governor,,R,Sam Brownback,25
-Saline,GREELEY,Governor,,R,Sam Brownback,249
-Saline,GYPSUM,Governor,,R,Sam Brownback,53
-Saline,LIBERTY,Governor,,R,Sam Brownback,54
-Saline,OHIO,Governor,,R,Sam Brownback,92
-Saline,PLEASANT VLY,Governor,,R,Sam Brownback,91
-Saline,SMOKY HILL,Governor,,R,Sam Brownback,62
-Saline,SMOKY VIEW,Governor,,R,Sam Brownback,174
-Saline,SMOLAN,Governor,,R,Sam Brownback,172
-Saline,SOLOMON,Governor,,R,Sam Brownback,125
-Saline,SPRING CREEK,Governor,,R,Sam Brownback,100
-Saline,WALNUT,Governor,,R,Sam Brownback,136
-Saline,WASHINGTON,Governor,,R,Sam Brownback,45
-Saline,Paper Ballots,Governor,,R,Sam Brownback,73
-Saline,1,Governor,,D,Paul Davis,123
-Saline,2,Governor,,D,Paul Davis,119
-Saline,3,Governor,,D,Paul Davis,98
-Saline,4,Governor,,D,Paul Davis,151
-Saline,5,Governor,,D,Paul Davis,128
-Saline,6,Governor,,D,Paul Davis,101
-Saline,7,Governor,,D,Paul Davis,161
-Saline,8,Governor,,D,Paul Davis,162
-Saline,9,Governor,,D,Paul Davis,167
-Saline,10,Governor,,D,Paul Davis,160
-Saline,11,Governor,,D,Paul Davis,111
-Saline,12,Governor,,D,Paul Davis,238
-Saline,13,Governor,,D,Paul Davis,124
-Saline,14,Governor,,D,Paul Davis,158
-Saline,15,Governor,,D,Paul Davis,152
-Saline,16,Governor,,D,Paul Davis,91
-Saline,17,Governor,,D,Paul Davis,122
-Saline,18,Governor,,D,Paul Davis,137
-Saline,19,Governor,,D,Paul Davis,188
-Saline,20,Governor,,D,Paul Davis,432
-Saline,21,Governor,,D,Paul Davis,362
-Saline,22,Governor,,D,Paul Davis,297
-Saline,23,Governor,,D,Paul Davis,431
-Saline,24,Governor,,D,Paul Davis,149
-Saline,25,Governor,,D,Paul Davis,98
-Saline,26,Governor,,D,Paul Davis,159
-Saline,27,Governor,,D,Paul Davis,186
-Saline,28,Governor,,D,Paul Davis,113
-Saline,29,Governor,,D,Paul Davis,211
-Saline,30,Governor,,D,Paul Davis,186
-Saline,31,Governor,,D,Paul Davis,420
-Saline,32,Governor,,D,Paul Davis,111
-Saline,33,Governor,,D,Paul Davis,245
-Saline,34,Governor,,D,Paul Davis,380
-Saline,35,Governor,,D,Paul Davis,226
-Saline,CAMBRIA,Governor,,D,Paul Davis,55
-Saline,DAYTON,Governor,,D,Paul Davis,18
-Saline,ELM CREEK,Governor,,D,Paul Davis,134
-Saline,EUREKA,Governor,,D,Paul Davis,76
-Saline,FALUN,Governor,,D,Paul Davis,30
-Saline,GLENDALE,Governor,,D,Paul Davis,11
-Saline,GREELEY,Governor,,D,Paul Davis,113
-Saline,GYPSUM,Governor,,D,Paul Davis,10
-Saline,LIBERTY,Governor,,D,Paul Davis,21
-Saline,OHIO,Governor,,D,Paul Davis,62
-Saline,PLEASANT VLY,Governor,,D,Paul Davis,47
-Saline,SMOKY HILL,Governor,,D,Paul Davis,38
-Saline,SMOKY VIEW,Governor,,D,Paul Davis,127
-Saline,SMOLAN,Governor,,D,Paul Davis,112
-Saline,SOLOMON,Governor,,D,Paul Davis,62
-Saline,SPRING CREEK,Governor,,D,Paul Davis,42
-Saline,WALNUT,Governor,,D,Paul Davis,94
-Saline,WASHINGTON,Governor,,D,Paul Davis,20
-Saline,Paper Ballots,Governor,,D,Paul Davis,61
-Saline,1,Governor,,L,Keen Umbehr,19
-Saline,2,Governor,,L,Keen Umbehr,28
-Saline,3,Governor,,L,Keen Umbehr,14
-Saline,4,Governor,,L,Keen Umbehr,33
-Saline,5,Governor,,L,Keen Umbehr,19
-Saline,6,Governor,,L,Keen Umbehr,24
-Saline,7,Governor,,L,Keen Umbehr,36
-Saline,8,Governor,,L,Keen Umbehr,15
-Saline,9,Governor,,L,Keen Umbehr,35
-Saline,10,Governor,,L,Keen Umbehr,22
-Saline,11,Governor,,L,Keen Umbehr,25
-Saline,12,Governor,,L,Keen Umbehr,34
-Saline,13,Governor,,L,Keen Umbehr,17
-Saline,14,Governor,,L,Keen Umbehr,33
-Saline,15,Governor,,L,Keen Umbehr,25
-Saline,16,Governor,,L,Keen Umbehr,23
-Saline,17,Governor,,L,Keen Umbehr,24
-Saline,18,Governor,,L,Keen Umbehr,28
-Saline,19,Governor,,L,Keen Umbehr,17
-Saline,20,Governor,,L,Keen Umbehr,31
-Saline,21,Governor,,L,Keen Umbehr,33
-Saline,22,Governor,,L,Keen Umbehr,28
-Saline,23,Governor,,L,Keen Umbehr,43
-Saline,24,Governor,,L,Keen Umbehr,21
-Saline,25,Governor,,L,Keen Umbehr,15
-Saline,26,Governor,,L,Keen Umbehr,26
-Saline,27,Governor,,L,Keen Umbehr,21
-Saline,28,Governor,,L,Keen Umbehr,23
-Saline,29,Governor,,L,Keen Umbehr,23
-Saline,30,Governor,,L,Keen Umbehr,20
-Saline,31,Governor,,L,Keen Umbehr,68
-Saline,32,Governor,,L,Keen Umbehr,18
-Saline,33,Governor,,L,Keen Umbehr,24
-Saline,34,Governor,,L,Keen Umbehr,55
-Saline,35,Governor,,L,Keen Umbehr,48
-Saline,CAMBRIA,Governor,,L,Keen Umbehr,7
-Saline,DAYTON,Governor,,L,Keen Umbehr,0
-Saline,ELM CREEK,Governor,,L,Keen Umbehr,22
-Saline,EUREKA,Governor,,L,Keen Umbehr,19
-Saline,FALUN,Governor,,L,Keen Umbehr,12
-Saline,GLENDALE,Governor,,L,Keen Umbehr,3
-Saline,GREELEY,Governor,,L,Keen Umbehr,24
-Saline,GYPSUM,Governor,,L,Keen Umbehr,5
-Saline,LIBERTY,Governor,,L,Keen Umbehr,5
-Saline,OHIO,Governor,,L,Keen Umbehr,19
-Saline,PLEASANT VLY,Governor,,L,Keen Umbehr,9
-Saline,SMOKY HILL,Governor,,L,Keen Umbehr,5
-Saline,SMOKY VIEW,Governor,,L,Keen Umbehr,28
-Saline,SMOLAN,Governor,,L,Keen Umbehr,16
-Saline,SOLOMON,Governor,,L,Keen Umbehr,2
-Saline,SPRING CREEK,Governor,,L,Keen Umbehr,16
-Saline,WALNUT,Governor,,L,Keen Umbehr,14
-Saline,WASHINGTON,Governor,,L,Keen Umbehr,5
-Saline,Paper Ballots,Governor,,L,Keen Umbehr,13
-Saline,1,Secretary of State,,R,Kris Kobach,120
-Saline,2,Secretary of State,,R,Kris Kobach,127
-Saline,3,Secretary of State,,R,Kris Kobach,87
-Saline,4,Secretary of State,,R,Kris Kobach,124
-Saline,5,Secretary of State,,R,Kris Kobach,137
-Saline,6,Secretary of State,,R,Kris Kobach,102
-Saline,7,Secretary of State,,R,Kris Kobach,157
-Saline,8,Secretary of State,,R,Kris Kobach,140
-Saline,9,Secretary of State,,R,Kris Kobach,159
-Saline,10,Secretary of State,,R,Kris Kobach,148
-Saline,11,Secretary of State,,R,Kris Kobach,160
-Saline,12,Secretary of State,,R,Kris Kobach,202
-Saline,13,Secretary of State,,R,Kris Kobach,133
-Saline,14,Secretary of State,,R,Kris Kobach,206
-Saline,15,Secretary of State,,R,Kris Kobach,140
-Saline,16,Secretary of State,,R,Kris Kobach,130
-Saline,17,Secretary of State,,R,Kris Kobach,147
-Saline,18,Secretary of State,,R,Kris Kobach,187
-Saline,19,Secretary of State,,R,Kris Kobach,278
-Saline,20,Secretary of State,,R,Kris Kobach,533
-Saline,21,Secretary of State,,R,Kris Kobach,490
-Saline,22,Secretary of State,,R,Kris Kobach,434
-Saline,23,Secretary of State,,R,Kris Kobach,536
-Saline,24,Secretary of State,,R,Kris Kobach,176
-Saline,25,Secretary of State,,R,Kris Kobach,121
-Saline,26,Secretary of State,,R,Kris Kobach,157
-Saline,27,Secretary of State,,R,Kris Kobach,236
-Saline,28,Secretary of State,,R,Kris Kobach,173
-Saline,29,Secretary of State,,R,Kris Kobach,265
-Saline,30,Secretary of State,,R,Kris Kobach,225
-Saline,31,Secretary of State,,R,Kris Kobach,599
-Saline,32,Secretary of State,,R,Kris Kobach,156
-Saline,33,Secretary of State,,R,Kris Kobach,318
-Saline,34,Secretary of State,,R,Kris Kobach,512
-Saline,35,Secretary of State,,R,Kris Kobach,307
-Saline,CAMBRIA,Secretary of State,,R,Kris Kobach,108
-Saline,DAYTON,Secretary of State,,R,Kris Kobach,26
-Saline,ELM CREEK,Secretary of State,,R,Kris Kobach,269
-Saline,EUREKA,Secretary of State,,R,Kris Kobach,158
-Saline,FALUN,Secretary of State,,R,Kris Kobach,75
-Saline,GLENDALE,Secretary of State,,R,Kris Kobach,30
-Saline,GREELEY,Secretary of State,,R,Kris Kobach,281
-Saline,GYPSUM,Secretary of State,,R,Kris Kobach,59
-Saline,LIBERTY,Secretary of State,,R,Kris Kobach,53
-Saline,OHIO,Secretary of State,,R,Kris Kobach,113
-Saline,PLEASANT VLY,Secretary of State,,R,Kris Kobach,109
-Saline,SMOKY HILL,Secretary of State,,R,Kris Kobach,69
-Saline,SMOKY VIEW,Secretary of State,,R,Kris Kobach,215
-Saline,SMOLAN,Secretary of State,,R,Kris Kobach,211
-Saline,SOLOMON,Secretary of State,,R,Kris Kobach,136
-Saline,SPRING CREEK,Secretary of State,,R,Kris Kobach,107
-Saline,WALNUT,Secretary of State,,R,Kris Kobach,161
-Saline,WASHINGTON,Secretary of State,,R,Kris Kobach,50
-Saline,Paper Ballots,Secretary of State,,R,Kris Kobach,90
-Saline,1,Secretary of State,,D,Jean Schodorf,117
-Saline,2,Secretary of State,,D,Jean Schodorf,109
-Saline,3,Secretary of State,,D,Jean Schodorf,90
-Saline,4,Secretary of State,,D,Jean Schodorf,147
-Saline,5,Secretary of State,,D,Jean Schodorf,109
-Saline,6,Secretary of State,,D,Jean Schodorf,98
-Saline,7,Secretary of State,,D,Jean Schodorf,145
-Saline,8,Secretary of State,,D,Jean Schodorf,146
-Saline,9,Secretary of State,,D,Jean Schodorf,152
-Saline,10,Secretary of State,,D,Jean Schodorf,149
-Saline,11,Secretary of State,,D,Jean Schodorf,100
-Saline,12,Secretary of State,,D,Jean Schodorf,214
-Saline,13,Secretary of State,,D,Jean Schodorf,115
-Saline,14,Secretary of State,,D,Jean Schodorf,146
-Saline,15,Secretary of State,,D,Jean Schodorf,141
-Saline,16,Secretary of State,,D,Jean Schodorf,86
-Saline,17,Secretary of State,,D,Jean Schodorf,111
-Saline,18,Secretary of State,,D,Jean Schodorf,115
-Saline,19,Secretary of State,,D,Jean Schodorf,156
-Saline,20,Secretary of State,,D,Jean Schodorf,369
-Saline,21,Secretary of State,,D,Jean Schodorf,309
-Saline,22,Secretary of State,,D,Jean Schodorf,250
-Saline,23,Secretary of State,,D,Jean Schodorf,350
-Saline,24,Secretary of State,,D,Jean Schodorf,131
-Saline,25,Secretary of State,,D,Jean Schodorf,90
-Saline,26,Secretary of State,,D,Jean Schodorf,143
-Saline,27,Secretary of State,,D,Jean Schodorf,163
-Saline,28,Secretary of State,,D,Jean Schodorf,99
-Saline,29,Secretary of State,,D,Jean Schodorf,165
-Saline,30,Secretary of State,,D,Jean Schodorf,155
-Saline,31,Secretary of State,,D,Jean Schodorf,342
-Saline,32,Secretary of State,,D,Jean Schodorf,97
-Saline,33,Secretary of State,,D,Jean Schodorf,199
-Saline,34,Secretary of State,,D,Jean Schodorf,320
-Saline,35,Secretary of State,,D,Jean Schodorf,206
-Saline,CAMBRIA,Secretary of State,,D,Jean Schodorf,50
-Saline,DAYTON,Secretary of State,,D,Jean Schodorf,18
-Saline,ELM CREEK,Secretary of State,,D,Jean Schodorf,113
-Saline,EUREKA,Secretary of State,,D,Jean Schodorf,61
-Saline,FALUN,Secretary of State,,D,Jean Schodorf,33
-Saline,GLENDALE,Secretary of State,,D,Jean Schodorf,8
-Saline,GREELEY,Secretary of State,,D,Jean Schodorf,103
-Saline,GYPSUM,Secretary of State,,D,Jean Schodorf,9
-Saline,LIBERTY,Secretary of State,,D,Jean Schodorf,26
-Saline,OHIO,Secretary of State,,D,Jean Schodorf,59
-Saline,PLEASANT VLY,Secretary of State,,D,Jean Schodorf,38
-Saline,SMOKY HILL,Secretary of State,,D,Jean Schodorf,33
-Saline,SMOKY VIEW,Secretary of State,,D,Jean Schodorf,112
-Saline,SMOLAN,Secretary of State,,D,Jean Schodorf,88
-Saline,SOLOMON,Secretary of State,,D,Jean Schodorf,52
-Saline,SPRING CREEK,Secretary of State,,D,Jean Schodorf,46
-Saline,WALNUT,Secretary of State,,D,Jean Schodorf,81
-Saline,WASHINGTON,Secretary of State,,D,Jean Schodorf,19
-Saline,Paper Ballots,Secretary of State,,D,Jean Schodorf,60
-Saline,1,Attorney General,,R,Derek Schmidt,143
-Saline,2,Attorney General,,R,Derek Schmidt,149
-Saline,3,Attorney General,,R,Derek Schmidt,110
-Saline,4,Attorney General,,R,Derek Schmidt,148
-Saline,5,Attorney General,,R,Derek Schmidt,146
-Saline,6,Attorney General,,R,Derek Schmidt,123
-Saline,7,Attorney General,,R,Derek Schmidt,181
-Saline,8,Attorney General,,R,Derek Schmidt,172
-Saline,9,Attorney General,,R,Derek Schmidt,190
-Saline,10,Attorney General,,R,Derek Schmidt,172
-Saline,11,Attorney General,,R,Derek Schmidt,183
-Saline,12,Attorney General,,R,Derek Schmidt,246
-Saline,13,Attorney General,,R,Derek Schmidt,170
-Saline,14,Attorney General,,R,Derek Schmidt,242
-Saline,15,Attorney General,,R,Derek Schmidt,174
-Saline,16,Attorney General,,R,Derek Schmidt,139
-Saline,17,Attorney General,,R,Derek Schmidt,171
-Saline,18,Attorney General,,R,Derek Schmidt,216
-Saline,19,Attorney General,,R,Derek Schmidt,317
-Saline,20,Attorney General,,R,Derek Schmidt,653
-Saline,21,Attorney General,,R,Derek Schmidt,606
-Saline,22,Attorney General,,R,Derek Schmidt,526
-Saline,23,Attorney General,,R,Derek Schmidt,637
-Saline,24,Attorney General,,R,Derek Schmidt,211
-Saline,25,Attorney General,,R,Derek Schmidt,142
-Saline,26,Attorney General,,R,Derek Schmidt,197
-Saline,27,Attorney General,,R,Derek Schmidt,287
-Saline,28,Attorney General,,R,Derek Schmidt,194
-Saline,29,Attorney General,,R,Derek Schmidt,308
-Saline,30,Attorney General,,R,Derek Schmidt,260
-Saline,31,Attorney General,,R,Derek Schmidt,706
-Saline,32,Attorney General,,R,Derek Schmidt,182
-Saline,33,Attorney General,,R,Derek Schmidt,380
-Saline,34,Attorney General,,R,Derek Schmidt,602
-Saline,35,Attorney General,,R,Derek Schmidt,340
-Saline,CAMBRIA,Attorney General,,R,Derek Schmidt,131
-Saline,DAYTON,Attorney General,,R,Derek Schmidt,31
-Saline,ELM CREEK,Attorney General,,R,Derek Schmidt,313
-Saline,EUREKA,Attorney General,,R,Derek Schmidt,176
-Saline,FALUN,Attorney General,,R,Derek Schmidt,88
-Saline,GLENDALE,Attorney General,,R,Derek Schmidt,31
-Saline,GREELEY,Attorney General,,R,Derek Schmidt,320
-Saline,GYPSUM,Attorney General,,R,Derek Schmidt,64
-Saline,LIBERTY,Attorney General,,R,Derek Schmidt,61
-Saline,OHIO,Attorney General,,R,Derek Schmidt,137
-Saline,PLEASANT VLY,Attorney General,,R,Derek Schmidt,122
-Saline,SMOKY HILL,Attorney General,,R,Derek Schmidt,86
-Saline,SMOKY VIEW,Attorney General,,R,Derek Schmidt,245
-Saline,SMOLAN,Attorney General,,R,Derek Schmidt,240
-Saline,SOLOMON,Attorney General,,R,Derek Schmidt,153
-Saline,SPRING CREEK,Attorney General,,R,Derek Schmidt,126
-Saline,WALNUT,Attorney General,,R,Derek Schmidt,195
-Saline,WASHINGTON,Attorney General,,R,Derek Schmidt,59
-Saline,Paper Ballots,Attorney General,,R,Derek Schmidt,95
-Saline,1,Attorney General,,D,A J Kotich,91
-Saline,2,Attorney General,,D,A J Kotich,88
-Saline,3,Attorney General,,D,A J Kotich,67
-Saline,4,Attorney General,,D,A J Kotich,120
-Saline,5,Attorney General,,D,A J Kotich,95
-Saline,6,Attorney General,,D,A J Kotich,76
-Saline,7,Attorney General,,D,A J Kotich,115
-Saline,8,Attorney General,,D,A J Kotich,108
-Saline,9,Attorney General,,D,A J Kotich,112
-Saline,10,Attorney General,,D,A J Kotich,121
-Saline,11,Attorney General,,D,A J Kotich,73
-Saline,12,Attorney General,,D,A J Kotich,167
-Saline,13,Attorney General,,D,A J Kotich,77
-Saline,14,Attorney General,,D,A J Kotich,106
-Saline,15,Attorney General,,D,A J Kotich,106
-Saline,16,Attorney General,,D,A J Kotich,75
-Saline,17,Attorney General,,D,A J Kotich,87
-Saline,18,Attorney General,,D,A J Kotich,83
-Saline,19,Attorney General,,D,A J Kotich,108
-Saline,20,Attorney General,,D,A J Kotich,233
-Saline,21,Attorney General,,D,A J Kotich,183
-Saline,22,Attorney General,,D,A J Kotich,150
-Saline,23,Attorney General,,D,A J Kotich,237
-Saline,24,Attorney General,,D,A J Kotich,86
-Saline,25,Attorney General,,D,A J Kotich,68
-Saline,26,Attorney General,,D,A J Kotich,100
-Saline,27,Attorney General,,D,A J Kotich,112
-Saline,28,Attorney General,,D,A J Kotich,73
-Saline,29,Attorney General,,D,A J Kotich,117
-Saline,30,Attorney General,,D,A J Kotich,114
-Saline,31,Attorney General,,D,A J Kotich,225
-Saline,32,Attorney General,,D,A J Kotich,69
-Saline,33,Attorney General,,D,A J Kotich,129
-Saline,34,Attorney General,,D,A J Kotich,218
-Saline,35,Attorney General,,D,A J Kotich,164
-Saline,CAMBRIA,Attorney General,,D,A J Kotich,25
-Saline,DAYTON,Attorney General,,D,A J Kotich,13
-Saline,ELM CREEK,Attorney General,,D,A J Kotich,64
-Saline,EUREKA,Attorney General,,D,A J Kotich,41
-Saline,FALUN,Attorney General,,D,A J Kotich,15
-Saline,GLENDALE,Attorney General,,D,A J Kotich,7
-Saline,GREELEY,Attorney General,,D,A J Kotich,60
-Saline,GYPSUM,Attorney General,,D,A J Kotich,3
-Saline,LIBERTY,Attorney General,,D,A J Kotich,17
-Saline,OHIO,Attorney General,,D,A J Kotich,33
-Saline,PLEASANT VLY,Attorney General,,D,A J Kotich,25
-Saline,SMOKY HILL,Attorney General,,D,A J Kotich,15
-Saline,SMOKY VIEW,Attorney General,,D,A J Kotich,78
-Saline,SMOLAN,Attorney General,,D,A J Kotich,56
-Saline,SOLOMON,Attorney General,,D,A J Kotich,33
-Saline,SPRING CREEK,Attorney General,,D,A J Kotich,27
-Saline,WALNUT,Attorney General,,D,A J Kotich,47
-Saline,WASHINGTON,Attorney General,,D,A J Kotich,10
-Saline,Paper Ballots,Attorney General,,D,A J Kotich,49
-Saline,1,State Treasurer,,R,Ron Estes,133
-Saline,2,State Treasurer,,R,Ron Estes,150
-Saline,3,State Treasurer,,R,Ron Estes,101
-Saline,4,State Treasurer,,R,Ron Estes,147
-Saline,5,State Treasurer,,R,Ron Estes,147
-Saline,6,State Treasurer,,R,Ron Estes,117
-Saline,7,State Treasurer,,R,Ron Estes,176
-Saline,8,State Treasurer,,R,Ron Estes,176
-Saline,9,State Treasurer,,R,Ron Estes,199
-Saline,10,State Treasurer,,R,Ron Estes,172
-Saline,11,State Treasurer,,R,Ron Estes,178
-Saline,12,State Treasurer,,R,Ron Estes,254
-Saline,13,State Treasurer,,R,Ron Estes,160
-Saline,14,State Treasurer,,R,Ron Estes,236
-Saline,15,State Treasurer,,R,Ron Estes,167
-Saline,16,State Treasurer,,R,Ron Estes,131
-Saline,17,State Treasurer,,R,Ron Estes,175
-Saline,18,State Treasurer,,R,Ron Estes,212
-Saline,19,State Treasurer,,R,Ron Estes,326
-Saline,20,State Treasurer,,R,Ron Estes,681
-Saline,21,State Treasurer,,R,Ron Estes,603
-Saline,22,State Treasurer,,R,Ron Estes,540
-Saline,23,State Treasurer,,R,Ron Estes,632
-Saline,24,State Treasurer,,R,Ron Estes,194
-Saline,25,State Treasurer,,R,Ron Estes,132
-Saline,26,State Treasurer,,R,Ron Estes,189
-Saline,27,State Treasurer,,R,Ron Estes,286
-Saline,28,State Treasurer,,R,Ron Estes,199
-Saline,29,State Treasurer,,R,Ron Estes,311
-Saline,30,State Treasurer,,R,Ron Estes,262
-Saline,31,State Treasurer,,R,Ron Estes,690
-Saline,32,State Treasurer,,R,Ron Estes,187
-Saline,33,State Treasurer,,R,Ron Estes,373
-Saline,34,State Treasurer,,R,Ron Estes,611
-Saline,35,State Treasurer,,R,Ron Estes,341
-Saline,CAMBRIA,State Treasurer,,R,Ron Estes,129
-Saline,DAYTON,State Treasurer,,R,Ron Estes,27
-Saline,ELM CREEK,State Treasurer,,R,Ron Estes,313
-Saline,EUREKA,State Treasurer,,R,Ron Estes,174
-Saline,FALUN,State Treasurer,,R,Ron Estes,83
-Saline,GLENDALE,State Treasurer,,R,Ron Estes,30
-Saline,GREELEY,State Treasurer,,R,Ron Estes,319
-Saline,GYPSUM,State Treasurer,,R,Ron Estes,62
-Saline,LIBERTY,State Treasurer,,R,Ron Estes,65
-Saline,OHIO,State Treasurer,,R,Ron Estes,134
-Saline,PLEASANT VLY,State Treasurer,,R,Ron Estes,120
-Saline,SMOKY HILL,State Treasurer,,R,Ron Estes,89
-Saline,SMOKY VIEW,State Treasurer,,R,Ron Estes,246
-Saline,SMOLAN,State Treasurer,,R,Ron Estes,240
-Saline,SOLOMON,State Treasurer,,R,Ron Estes,146
-Saline,SPRING CREEK,State Treasurer,,R,Ron Estes,120
-Saline,WALNUT,State Treasurer,,R,Ron Estes,192
-Saline,WASHINGTON,State Treasurer,,R,Ron Estes,56
-Saline,Paper Ballots,State Treasurer,,R,Ron Estes,101
-Saline,1,State Treasurer,,D,Carmen Alldritt,98
-Saline,2,State Treasurer,,D,Carmen Alldritt,86
-Saline,3,State Treasurer,,D,Carmen Alldritt,71
-Saline,4,State Treasurer,,D,Carmen Alldritt,121
-Saline,5,State Treasurer,,D,Carmen Alldritt,96
-Saline,6,State Treasurer,,D,Carmen Alldritt,80
-Saline,7,State Treasurer,,D,Carmen Alldritt,119
-Saline,8,State Treasurer,,D,Carmen Alldritt,104
-Saline,9,State Treasurer,,D,Carmen Alldritt,105
-Saline,10,State Treasurer,,D,Carmen Alldritt,122
-Saline,11,State Treasurer,,D,Carmen Alldritt,76
-Saline,12,State Treasurer,,D,Carmen Alldritt,152
-Saline,13,State Treasurer,,D,Carmen Alldritt,83
-Saline,14,State Treasurer,,D,Carmen Alldritt,109
-Saline,15,State Treasurer,,D,Carmen Alldritt,111
-Saline,16,State Treasurer,,D,Carmen Alldritt,78
-Saline,17,State Treasurer,,D,Carmen Alldritt,83
-Saline,18,State Treasurer,,D,Carmen Alldritt,84
-Saline,19,State Treasurer,,D,Carmen Alldritt,100
-Saline,20,State Treasurer,,D,Carmen Alldritt,205
-Saline,21,State Treasurer,,D,Carmen Alldritt,184
-Saline,22,State Treasurer,,D,Carmen Alldritt,131
-Saline,23,State Treasurer,,D,Carmen Alldritt,235
-Saline,24,State Treasurer,,D,Carmen Alldritt,102
-Saline,25,State Treasurer,,D,Carmen Alldritt,73
-Saline,26,State Treasurer,,D,Carmen Alldritt,103
-Saline,27,State Treasurer,,D,Carmen Alldritt,115
-Saline,28,State Treasurer,,D,Carmen Alldritt,70
-Saline,29,State Treasurer,,D,Carmen Alldritt,108
-Saline,30,State Treasurer,,D,Carmen Alldritt,110
-Saline,31,State Treasurer,,D,Carmen Alldritt,231
-Saline,32,State Treasurer,,D,Carmen Alldritt,63
-Saline,33,State Treasurer,,D,Carmen Alldritt,134
-Saline,34,State Treasurer,,D,Carmen Alldritt,206
-Saline,35,State Treasurer,,D,Carmen Alldritt,164
-Saline,CAMBRIA,State Treasurer,,D,Carmen Alldritt,23
-Saline,DAYTON,State Treasurer,,D,Carmen Alldritt,15
-Saline,ELM CREEK,State Treasurer,,D,Carmen Alldritt,69
-Saline,EUREKA,State Treasurer,,D,Carmen Alldritt,44
-Saline,FALUN,State Treasurer,,D,Carmen Alldritt,17
-Saline,GLENDALE,State Treasurer,,D,Carmen Alldritt,7
-Saline,GREELEY,State Treasurer,,D,Carmen Alldritt,62
-Saline,GYPSUM,State Treasurer,,D,Carmen Alldritt,6
-Saline,LIBERTY,State Treasurer,,D,Carmen Alldritt,14
-Saline,OHIO,State Treasurer,,D,Carmen Alldritt,33
-Saline,PLEASANT VLY,State Treasurer,,D,Carmen Alldritt,23
-Saline,SMOKY HILL,State Treasurer,,D,Carmen Alldritt,13
-Saline,SMOKY VIEW,State Treasurer,,D,Carmen Alldritt,75
-Saline,SMOLAN,State Treasurer,,D,Carmen Alldritt,53
-Saline,SOLOMON,State Treasurer,,D,Carmen Alldritt,38
-Saline,SPRING CREEK,State Treasurer,,D,Carmen Alldritt,29
-Saline,WALNUT,State Treasurer,,D,Carmen Alldritt,45
-Saline,WASHINGTON,State Treasurer,,D,Carmen Alldritt,11
-Saline,Paper Ballots,State Treasurer,,D,Carmen Alldritt,45
-Saline,1,Insurance Commissioner,,R,Ken Selzer,120
-Saline,2,Insurance Commissioner,,R,Ken Selzer,138
-Saline,3,Insurance Commissioner,,R,Ken Selzer,92
-Saline,4,Insurance Commissioner,,R,Ken Selzer,133
-Saline,5,Insurance Commissioner,,R,Ken Selzer,137
-Saline,6,Insurance Commissioner,,R,Ken Selzer,103
-Saline,7,Insurance Commissioner,,R,Ken Selzer,155
-Saline,8,Insurance Commissioner,,R,Ken Selzer,152
-Saline,9,Insurance Commissioner,,R,Ken Selzer,173
-Saline,10,Insurance Commissioner,,R,Ken Selzer,158
-Saline,11,Insurance Commissioner,,R,Ken Selzer,165
-Saline,12,Insurance Commissioner,,R,Ken Selzer,211
-Saline,13,Insurance Commissioner,,R,Ken Selzer,144
-Saline,14,Insurance Commissioner,,R,Ken Selzer,212
-Saline,15,Insurance Commissioner,,R,Ken Selzer,136
-Saline,16,Insurance Commissioner,,R,Ken Selzer,129
-Saline,17,Insurance Commissioner,,R,Ken Selzer,146
-Saline,18,Insurance Commissioner,,R,Ken Selzer,193
-Saline,19,Insurance Commissioner,,R,Ken Selzer,298
-Saline,20,Insurance Commissioner,,R,Ken Selzer,619
-Saline,21,Insurance Commissioner,,R,Ken Selzer,531
-Saline,22,Insurance Commissioner,,R,Ken Selzer,495
-Saline,23,Insurance Commissioner,,R,Ken Selzer,568
-Saline,24,Insurance Commissioner,,R,Ken Selzer,178
-Saline,25,Insurance Commissioner,,R,Ken Selzer,126
-Saline,26,Insurance Commissioner,,R,Ken Selzer,174
-Saline,27,Insurance Commissioner,,R,Ken Selzer,255
-Saline,28,Insurance Commissioner,,R,Ken Selzer,185
-Saline,29,Insurance Commissioner,,R,Ken Selzer,281
-Saline,30,Insurance Commissioner,,R,Ken Selzer,237
-Saline,31,Insurance Commissioner,,R,Ken Selzer,632
-Saline,32,Insurance Commissioner,,R,Ken Selzer,170
-Saline,33,Insurance Commissioner,,R,Ken Selzer,341
-Saline,34,Insurance Commissioner,,R,Ken Selzer,540
-Saline,35,Insurance Commissioner,,R,Ken Selzer,308
-Saline,CAMBRIA,Insurance Commissioner,,R,Ken Selzer,120
-Saline,DAYTON,Insurance Commissioner,,R,Ken Selzer,28
-Saline,ELM CREEK,Insurance Commissioner,,R,Ken Selzer,287
-Saline,EUREKA,Insurance Commissioner,,R,Ken Selzer,163
-Saline,FALUN,Insurance Commissioner,,R,Ken Selzer,85
-Saline,GLENDALE,Insurance Commissioner,,R,Ken Selzer,29
-Saline,GREELEY,Insurance Commissioner,,R,Ken Selzer,298
-Saline,GYPSUM,Insurance Commissioner,,R,Ken Selzer,61
-Saline,LIBERTY,Insurance Commissioner,,R,Ken Selzer,59
-Saline,OHIO,Insurance Commissioner,,R,Ken Selzer,127
-Saline,PLEASANT VLY,Insurance Commissioner,,R,Ken Selzer,115
-Saline,SMOKY HILL,Insurance Commissioner,,R,Ken Selzer,71
-Saline,SMOKY VIEW,Insurance Commissioner,,R,Ken Selzer,241
-Saline,SMOLAN,Insurance Commissioner,,R,Ken Selzer,221
-Saline,SOLOMON,Insurance Commissioner,,R,Ken Selzer,141
-Saline,SPRING CREEK,Insurance Commissioner,,R,Ken Selzer,109
-Saline,WALNUT,Insurance Commissioner,,R,Ken Selzer,180
-Saline,WASHINGTON,Insurance Commissioner,,R,Ken Selzer,55
-Saline,Paper Ballots,Insurance Commissioner,,R,Ken Selzer,91
-Saline,1,Insurance Commissioner,,D,Dennis Anderson,109
-Saline,2,Insurance Commissioner,,D,Dennis Anderson,97
-Saline,3,Insurance Commissioner,,D,Dennis Anderson,81
-Saline,4,Insurance Commissioner,,D,Dennis Anderson,135
-Saline,5,Insurance Commissioner,,D,Dennis Anderson,104
-Saline,6,Insurance Commissioner,,D,Dennis Anderson,94
-Saline,7,Insurance Commissioner,,D,Dennis Anderson,133
-Saline,8,Insurance Commissioner,,D,Dennis Anderson,123
-Saline,9,Insurance Commissioner,,D,Dennis Anderson,127
-Saline,10,Insurance Commissioner,,D,Dennis Anderson,130
-Saline,11,Insurance Commissioner,,D,Dennis Anderson,84
-Saline,12,Insurance Commissioner,,D,Dennis Anderson,190
-Saline,13,Insurance Commissioner,,D,Dennis Anderson,99
-Saline,14,Insurance Commissioner,,D,Dennis Anderson,130
-Saline,15,Insurance Commissioner,,D,Dennis Anderson,134
-Saline,16,Insurance Commissioner,,D,Dennis Anderson,74
-Saline,17,Insurance Commissioner,,D,Dennis Anderson,106
-Saline,18,Insurance Commissioner,,D,Dennis Anderson,96
-Saline,19,Insurance Commissioner,,D,Dennis Anderson,122
-Saline,20,Insurance Commissioner,,D,Dennis Anderson,259
-Saline,21,Insurance Commissioner,,D,Dennis Anderson,236
-Saline,22,Insurance Commissioner,,D,Dennis Anderson,171
-Saline,23,Insurance Commissioner,,D,Dennis Anderson,290
-Saline,24,Insurance Commissioner,,D,Dennis Anderson,112
-Saline,25,Insurance Commissioner,,D,Dennis Anderson,79
-Saline,26,Insurance Commissioner,,D,Dennis Anderson,116
-Saline,27,Insurance Commissioner,,D,Dennis Anderson,138
-Saline,28,Insurance Commissioner,,D,Dennis Anderson,78
-Saline,29,Insurance Commissioner,,D,Dennis Anderson,137
-Saline,30,Insurance Commissioner,,D,Dennis Anderson,133
-Saline,31,Insurance Commissioner,,D,Dennis Anderson,276
-Saline,32,Insurance Commissioner,,D,Dennis Anderson,72
-Saline,33,Insurance Commissioner,,D,Dennis Anderson,152
-Saline,34,Insurance Commissioner,,D,Dennis Anderson,275
-Saline,35,Insurance Commissioner,,D,Dennis Anderson,189
-Saline,CAMBRIA,Insurance Commissioner,,D,Dennis Anderson,33
-Saline,DAYTON,Insurance Commissioner,,D,Dennis Anderson,14
-Saline,ELM CREEK,Insurance Commissioner,,D,Dennis Anderson,90
-Saline,EUREKA,Insurance Commissioner,,D,Dennis Anderson,54
-Saline,FALUN,Insurance Commissioner,,D,Dennis Anderson,17
-Saline,GLENDALE,Insurance Commissioner,,D,Dennis Anderson,8
-Saline,GREELEY,Insurance Commissioner,,D,Dennis Anderson,72
-Saline,GYPSUM,Insurance Commissioner,,D,Dennis Anderson,5
-Saline,LIBERTY,Insurance Commissioner,,D,Dennis Anderson,18
-Saline,OHIO,Insurance Commissioner,,D,Dennis Anderson,39
-Saline,PLEASANT VLY,Insurance Commissioner,,D,Dennis Anderson,29
-Saline,SMOKY HILL,Insurance Commissioner,,D,Dennis Anderson,26
-Saline,SMOKY VIEW,Insurance Commissioner,,D,Dennis Anderson,76
-Saline,SMOLAN,Insurance Commissioner,,D,Dennis Anderson,71
-Saline,SOLOMON,Insurance Commissioner,,D,Dennis Anderson,42
-Saline,SPRING CREEK,Insurance Commissioner,,D,Dennis Anderson,38
-Saline,WALNUT,Insurance Commissioner,,D,Dennis Anderson,55
-Saline,WASHINGTON,Insurance Commissioner,,D,Dennis Anderson,14
-Saline,Paper Ballots,Insurance Commissioner,,D,Dennis Anderson,52
-Saline,1,State House,69,R,J R Claeys,122
-Saline,2,State House,69,R,J R Claeys,125
-Saline,3,State House,69,R,J R Claeys,94
-Saline,4,State House,69,R,J R Claeys,136
-Saline,5,State House,71,R,Diana Dierks,213
-Saline,6,State House,69,R,J R Claeys,116
-Saline,7,State House,69,R,J R Claeys,167
-Saline,8,State House,71,R,Diana Dierks,238
-Saline,9,State House,69,R,J R Claeys,157
-Saline,10,State House,71,R,Diana Dierks,253
-Saline,11,State House,69,R,J R Claeys,171
-Saline,12,State House,69,R,J R Claeys,208
-Saline,13,State House,69,R,J R Claeys,139
-Saline,14,State House,69,R,J R Claeys,205
-Saline,15,State House,71,R,Diana Dierks,244
-Saline,16,State House,71,R,Diana Dierks,185
-Saline,17,State House,71,R,Diana Dierks,231
-Saline,18,State House,71,R,Diana Dierks,263
-Saline,19,State House,71,R,Diana Dierks,400
-Saline,20,State House,71,R,Diana Dierks,826
-Saline,21,State House,71,R,Diana Dierks,734
-Saline,22,State House,71,R,Diana Dierks,632
-Saline,23,State House,71,R,Diana Dierks,800
-Saline,24,State House,71,R,Diana Dierks,269
-Saline,25,State House,71,R,Diana Dierks,182
-Saline,26,State House,71,R,Diana Dierks,262
-Saline,27,State House,69,R,J R Claeys,241
-Saline,28,State House,71,R,Diana Dierks,243
-Saline,29,State House,71,R,Diana Dierks,398
-Saline,30,State House,69,R,J R Claeys,229
-Saline,31,State House,69,R,J R Claeys,617
-Saline,32,State House,69,R,J R Claeys,173
-Saline,33,State House,108,R,Steven Johnson,476
-Saline,34,State House,108,R,Steven Johnson,756
-Saline,35,State House,108,R,Steven Johnson,431
-Saline,CAMBRIA,State House,71,R,Diana Dierks,146
-Saline,DAYTON,State House,71,R,Diana Dierks,37
-Saline,ELM CREEK 69,State House,71,R,Diana Dierks,279
-Saline,ELM CREEK 71,State House,71,R,Diana Dierks,1
-Saline,EUREKA,State House,108,R,Steven Johnson,205
-Saline,FALUN,State House,108,R,Steven Johnson,100
-Saline,GLENDALE,State House,69,R,J R Claeys,30
-Saline,GREELEY,State House,71,R,Diana Dierks,335
-Saline,GYPSUM,State House,108,R,Steven Johnson,66
-Saline,LIBERTY,State House,108,R,Steven Johnson,75
-Saline,OHIO,State House,108,R,Steven Johnson,157
-Saline,PLEASANT VLY,State House,69,R,J R Claeys,104
-Saline,SMOKY HILL 69,State House,69,R,J R Claeys,67
-Saline,SMOKY HILL 71,State House,71,R,Diana Dierks,4
-Saline,SMOKY VIEW,State House,69,R,J R Claeys,306
-Saline,SMOLAN,State House,69,R,J R Claeys,283
-Saline,SOLOMON,State House,71,R,Diana Dierks,158
-Saline,SPRING CREEK,State House,69,R,J R Claeys,144
-Saline,WALNUT,State House,69,R,J R Claeys,231
-Saline,WASHINGTON,State House,69,R,J R Claeys,66
-Saline,Paper Ballots,State House,69,R,J R Claeys,15
-Saline,Paper Ballots,State House,71,R,Diana Dierks,30
-Saline,Paper Ballots,State House,108,R,Steven Johnson,57
-Saline,1,State House,69,D,Gary Swartzendruber,114
-Saline,2,State House,69,D,Gary Swartzendruber,113
-Saline,3,State House,69,D,Gary Swartzendruber,81
-Saline,4,State House,69,D,Gary Swartzendruber,127
-Saline,6,State House,69,D,Gary Swartzendruber,79
-Saline,7,State House,69,D,Gary Swartzendruber,122
-Saline,9,State House,69,D,Gary Swartzendruber,145
-Saline,11,State House,69,D,Gary Swartzendruber,88
-Saline,12,State House,69,D,Gary Swartzendruber,199
-Saline,13,State House,69,D,Gary Swartzendruber,107
-Saline,14,State House,69,D,Gary Swartzendruber,142
-Saline,27,State House,69,D,Gary Swartzendruber,149
-Saline,30,State House,69,D,Gary Swartzendruber,136
-Saline,31,State House,69,D,Gary Swartzendruber,291
-Saline,32,State House,69,D,Gary Swartzendruber,72
-Saline,ELM CREEK 69,State House,69,D,Gary Swartzendruber,96
-Saline,GLENDALE,State House,69,D,Gary Swartzendruber,8
-Saline,PLEASANT VLY,State House,69,D,Gary Swartzendruber,38
-Saline,SMOKY HILL 69,State House,69,D,Gary Swartzendruber,28
-Saline,Paper Ballots,State House,69,D,Gary Swartzendruber,19
+county,precinct,office,district,party,candidate,votes,vtd
+SALINE,Cambria Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000010
+SALINE,Cambria Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000010
+SALINE,Cambria Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",96,000010
+SALINE,Dayton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000020
+SALINE,Dayton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+SALINE,Dayton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000020
+SALINE,Eureka Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,000040
+SALINE,Eureka Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000040
+SALINE,Eureka Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000040
+SALINE,Falun Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",30,000050
+SALINE,Falun Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000050
+SALINE,Falun Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",67,000050
+SALINE,Glendale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000060
+SALINE,Glendale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000060
+SALINE,Glendale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000060
+SALINE,Greeley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",113,000070
+SALINE,Greeley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000070
+SALINE,Greeley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",249,000070
+SALINE,Gypsum Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000080
+SALINE,Gypsum Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000080
+SALINE,Gypsum Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000080
+SALINE,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000090
+SALINE,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000090
+SALINE,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000090
+SALINE,Ohio Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,000100
+SALINE,Ohio Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000100
+SALINE,Ohio Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,000100
+SALINE,Pleasant Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,000110
+SALINE,Pleasant Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000110
+SALINE,Pleasant Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",91,000110
+SALINE,Salina Precinct 01 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",123,00012A
+SALINE,Salina Precinct 01 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,00012A
+SALINE,Salina Precinct 01 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",98,00012A
+SALINE,Salina Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,00013A
+SALINE,Salina Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,00013A
+SALINE,Salina Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",99,00013A
+SALINE,Salina Precinct 03,Governor / Lt. Governor,,Democratic,"Davis, Paul",98,000140
+SALINE,Salina Precinct 03,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000140
+SALINE,Salina Precinct 03,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000140
+SALINE,Salina Precinct 04,Governor / Lt. Governor,,Democratic,"Davis, Paul",151,000150
+SALINE,Salina Precinct 04,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",33,000150
+SALINE,Salina Precinct 04,Governor / Lt. Governor,,Republican,"Brownback, Sam",89,000150
+SALINE,Salina Precinct 05,Governor / Lt. Governor,,Democratic,"Davis, Paul",128,000160
+SALINE,Salina Precinct 05,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000160
+SALINE,Salina Precinct 05,Governor / Lt. Governor,,Republican,"Brownback, Sam",103,000160
+SALINE,Salina Precinct 06,Governor / Lt. Governor,,Democratic,"Davis, Paul",101,000170
+SALINE,Salina Precinct 06,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000170
+SALINE,Salina Precinct 06,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000170
+SALINE,Salina Precinct 07,Governor / Lt. Governor,,Democratic,"Davis, Paul",161,000180
+SALINE,Salina Precinct 07,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",36,000180
+SALINE,Salina Precinct 07,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000180
+SALINE,Salina Precinct 08,Governor / Lt. Governor,,Democratic,"Davis, Paul",162,000190
+SALINE,Salina Precinct 08,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000190
+SALINE,Salina Precinct 08,Governor / Lt. Governor,,Republican,"Brownback, Sam",109,000190
+SALINE,Salina Precinct 09,Governor / Lt. Governor,,Democratic,"Davis, Paul",167,000200
+SALINE,Salina Precinct 09,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",35,000200
+SALINE,Salina Precinct 09,Governor / Lt. Governor,,Republican,"Brownback, Sam",111,000200
+SALINE,Salina Precinct 10,Governor / Lt. Governor,,Democratic,"Davis, Paul",160,000210
+SALINE,Salina Precinct 10,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000210
+SALINE,Salina Precinct 10,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000210
+SALINE,Salina Precinct 11,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,000220
+SALINE,Salina Precinct 11,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,000220
+SALINE,Salina Precinct 11,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000220
+SALINE,Salina Precinct 12,Governor / Lt. Governor,,Democratic,"Davis, Paul",238,000230
+SALINE,Salina Precinct 12,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",34,000230
+SALINE,Salina Precinct 12,Governor / Lt. Governor,,Republican,"Brownback, Sam",149,000230
+SALINE,Salina Precinct 13,Governor / Lt. Governor,,Democratic,"Davis, Paul",124,000240
+SALINE,Salina Precinct 13,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000240
+SALINE,Salina Precinct 13,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000240
+SALINE,Salina Precinct 14 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",158,00025A
+SALINE,Salina Precinct 14 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",33,00025A
+SALINE,Salina Precinct 14 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",163,00025A
+SALINE,Salina Precinct 15 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",152,00026A
+SALINE,Salina Precinct 15 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,00026A
+SALINE,Salina Precinct 15 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",114,00026A
+SALINE,Salina Precinct 16,Governor / Lt. Governor,,Democratic,"Davis, Paul",91,000270
+SALINE,Salina Precinct 16,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000270
+SALINE,Salina Precinct 16,Governor / Lt. Governor,,Republican,"Brownback, Sam",104,000270
+SALINE,Salina Precinct 17,Governor / Lt. Governor,,Democratic,"Davis, Paul",122,000280
+SALINE,Salina Precinct 17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000280
+SALINE,Salina Precinct 17,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000280
+SALINE,Salina Precinct 18,Governor / Lt. Governor,,Democratic,"Davis, Paul",137,000290
+SALINE,Salina Precinct 18,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000290
+SALINE,Salina Precinct 18,Governor / Lt. Governor,,Republican,"Brownback, Sam",138,000290
+SALINE,Salina Precinct 19,Governor / Lt. Governor,,Democratic,"Davis, Paul",188,000300
+SALINE,Salina Precinct 19,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000300
+SALINE,Salina Precinct 19,Governor / Lt. Governor,,Republican,"Brownback, Sam",235,000300
+SALINE,Salina Precinct 20 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",493,00031A
+SALINE,Salina Precinct 20 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",31,00031A
+SALINE,Salina Precinct 20 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",516,00031A
+SALINE,Salina Precinct 21 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",362,00032A
+SALINE,Salina Precinct 21 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",33,00032A
+SALINE,Salina Precinct 21 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",422,00032A
+SALINE,Salina Precinct 22 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",297,00033A
+SALINE,Salina Precinct 22 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,00033A
+SALINE,Salina Precinct 22 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",366,00033A
+SALINE,Salina Precinct 23,Governor / Lt. Governor,,Democratic,"Davis, Paul",431,000340
+SALINE,Salina Precinct 23,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",43,000340
+SALINE,Salina Precinct 23,Governor / Lt. Governor,,Republican,"Brownback, Sam",428,000340
+SALINE,Salina Precinct 24,Governor / Lt. Governor,,Democratic,"Davis, Paul",149,000350
+SALINE,Salina Precinct 24,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000350
+SALINE,Salina Precinct 24,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,000350
+SALINE,Salina Precinct 25,Governor / Lt. Governor,,Democratic,"Davis, Paul",98,000360
+SALINE,Salina Precinct 25,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000360
+SALINE,Salina Precinct 25,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,000360
+SALINE,Salina Precinct 26,Governor / Lt. Governor,,Democratic,"Davis, Paul",159,000370
+SALINE,Salina Precinct 26,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000370
+SALINE,Salina Precinct 26,Governor / Lt. Governor,,Republican,"Brownback, Sam",118,000370
+SALINE,Salina Precinct 27,Governor / Lt. Governor,,Democratic,"Davis, Paul",186,000380
+SALINE,Salina Precinct 27,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000380
+SALINE,Salina Precinct 27,Governor / Lt. Governor,,Republican,"Brownback, Sam",197,000380
+SALINE,Salina Precinct 28,Governor / Lt. Governor,,Democratic,"Davis, Paul",113,000390
+SALINE,Salina Precinct 28,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000390
+SALINE,Salina Precinct 28,Governor / Lt. Governor,,Republican,"Brownback, Sam",140,000390
+SALINE,Salina Precinct 29,Governor / Lt. Governor,,Democratic,"Davis, Paul",211,000400
+SALINE,Salina Precinct 29,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",23,000400
+SALINE,Salina Precinct 29,Governor / Lt. Governor,,Republican,"Brownback, Sam",208,000400
+SALINE,Salina Precinct 30,Governor / Lt. Governor,,Democratic,"Davis, Paul",186,000410
+SALINE,Salina Precinct 30,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",20,000410
+SALINE,Salina Precinct 30,Governor / Lt. Governor,,Republican,"Brownback, Sam",183,000410
+SALINE,Salina Precinct 31 Part A,Governor / Lt. Governor,,Democratic,"Davis, Paul",420,00042A
+SALINE,Salina Precinct 31 Part A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",68,00042A
+SALINE,Salina Precinct 31 Part A,Governor / Lt. Governor,,Republican,"Brownback, Sam",468,00042A
+SALINE,Salina Precinct 32,Governor / Lt. Governor,,Democratic,"Davis, Paul",111,000430
+SALINE,Salina Precinct 32,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000430
+SALINE,Salina Precinct 32,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000430
+SALINE,Salina Precinct 33,Governor / Lt. Governor,,Democratic,"Davis, Paul",245,000440
+SALINE,Salina Precinct 33,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",24,000440
+SALINE,Salina Precinct 33,Governor / Lt. Governor,,Republican,"Brownback, Sam",258,000440
+SALINE,Salina Precinct 34,Governor / Lt. Governor,,Democratic,"Davis, Paul",380,000450
+SALINE,Salina Precinct 34,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",55,000450
+SALINE,Salina Precinct 34,Governor / Lt. Governor,,Republican,"Brownback, Sam",401,000450
+SALINE,Salina Precinct 35,Governor / Lt. Governor,,Democratic,"Davis, Paul",226,00046A
+SALINE,Salina Precinct 35,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",48,00046A
+SALINE,Salina Precinct 35,Governor / Lt. Governor,,Republican,"Brownback, Sam",249,00046A
+SALINE,Smokey Hill Township Part B,Governor / Lt. Governor,,Democratic,"Davis, Paul",38,00047B
+SALINE,Smokey Hill Township Part B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,00047B
+SALINE,Smokey Hill Township Part B,Governor / Lt. Governor,,Republican,"Brownback, Sam",62,00047B
+SALINE,Smoky View Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",127,000480
+SALINE,Smoky View Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000480
+SALINE,Smoky View Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",174,000480
+SALINE,Smolan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",112,000490
+SALINE,Smolan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000490
+SALINE,Smolan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,000490
+SALINE,Solomon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,000500
+SALINE,Solomon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000500
+SALINE,Solomon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",125,000500
+SALINE,Spring Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000510
+SALINE,Spring Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",16,000510
+SALINE,Spring Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",100,000510
+SALINE,Walnut Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",94,000520
+SALINE,Walnut Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000520
+SALINE,Walnut Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,000520
+SALINE,Elm Creek Township H69,Governor / Lt. Governor,,Democratic,"Davis, Paul",134,120020
+SALINE,Elm Creek Township H69,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,120020
+SALINE,Elm Creek Township H69,Governor / Lt. Governor,,Republican,"Brownback, Sam",228,120020
+SALINE,Elm Creek Township H71,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120030
+SALINE,Elm Creek Township H71,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+SALINE,Elm Creek Township H71,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120030
+SALINE,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,300010
+SALINE,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,300010
+SALINE,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900070
+SALINE,Salina Precinct 33 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900080
+SALINE,Salina Precinct 33 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900080
+SALINE,Salina Precinct 33 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900080
+SALINE,Salina Precinct 35 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900090
+SALINE,Salina Precinct 35 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900090
+SALINE,Salina Precinct 35 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900110
+SALINE,Cambria Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",146,000010
+SALINE,Dayton Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",37,000020
+SALINE,Eureka Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",205,000040
+SALINE,Falun Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",100,000050
+SALINE,Glendale Township,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",8,000060
+SALINE,Glendale Township,Kansas House of Representatives,69,Republican,"Claeys, J.R.",30,000060
+SALINE,Greeley Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",335,000070
+SALINE,Gypsum Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",66,000080
+SALINE,Liberty Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",75,000090
+SALINE,Ohio Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",157,000100
+SALINE,Pleasant Valley Township,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",38,000110
+SALINE,Pleasant Valley Township,Kansas House of Representatives,69,Republican,"Claeys, J.R.",104,000110
+SALINE,Salina Precinct 01 Part A,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",114,00012A
+SALINE,Salina Precinct 01 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",122,00012A
+SALINE,Salina Precinct 02,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",113,00013A
+SALINE,Salina Precinct 02,Kansas House of Representatives,69,Republican,"Claeys, J.R.",125,00013A
+SALINE,Salina Precinct 03,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",81,000140
+SALINE,Salina Precinct 03,Kansas House of Representatives,69,Republican,"Claeys, J.R.",94,000140
+SALINE,Salina Precinct 04,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",127,000150
+SALINE,Salina Precinct 04,Kansas House of Representatives,69,Republican,"Claeys, J.R.",136,000150
+SALINE,Salina Precinct 05,Kansas House of Representatives,71,Republican,"Dierks, Diana",213,000160
+SALINE,Salina Precinct 06,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",79,000170
+SALINE,Salina Precinct 06,Kansas House of Representatives,69,Republican,"Claeys, J.R.",116,000170
+SALINE,Salina Precinct 07,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",122,000180
+SALINE,Salina Precinct 07,Kansas House of Representatives,69,Republican,"Claeys, J.R.",167,000180
+SALINE,Salina Precinct 08,Kansas House of Representatives,71,Republican,"Dierks, Diana",238,000190
+SALINE,Salina Precinct 09,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",145,000200
+SALINE,Salina Precinct 09,Kansas House of Representatives,69,Republican,"Claeys, J.R.",157,000200
+SALINE,Salina Precinct 10,Kansas House of Representatives,71,Republican,"Dierks, Diana",253,000210
+SALINE,Salina Precinct 11,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",88,000220
+SALINE,Salina Precinct 11,Kansas House of Representatives,69,Republican,"Claeys, J.R.",171,000220
+SALINE,Salina Precinct 12,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",199,000230
+SALINE,Salina Precinct 12,Kansas House of Representatives,69,Republican,"Claeys, J.R.",208,000230
+SALINE,Salina Precinct 13,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",107,000240
+SALINE,Salina Precinct 13,Kansas House of Representatives,69,Republican,"Claeys, J.R.",139,000240
+SALINE,Salina Precinct 14 Part A,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",142,00025A
+SALINE,Salina Precinct 14 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",205,00025A
+SALINE,Salina Precinct 15 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",244,00026A
+SALINE,Salina Precinct 16,Kansas House of Representatives,71,Republican,"Dierks, Diana",185,000270
+SALINE,Salina Precinct 17,Kansas House of Representatives,71,Republican,"Dierks, Diana",231,000280
+SALINE,Salina Precinct 18,Kansas House of Representatives,71,Republican,"Dierks, Diana",263,000290
+SALINE,Salina Precinct 19,Kansas House of Representatives,71,Republican,"Dierks, Diana",430,000300
+SALINE,Salina Precinct 20 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",826,00031A
+SALINE,Salina Precinct 21 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",734,00032A
+SALINE,Salina Precinct 22 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",632,00033A
+SALINE,Salina Precinct 23,Kansas House of Representatives,71,Republican,"Dierks, Diana",800,000340
+SALINE,Salina Precinct 24,Kansas House of Representatives,71,Republican,"Dierks, Diana",269,000350
+SALINE,Salina Precinct 25,Kansas House of Representatives,71,Republican,"Dierks, Diana",182,000360
+SALINE,Salina Precinct 26,Kansas House of Representatives,71,Republican,"Dierks, Diana",262,000370
+SALINE,Salina Precinct 27,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",149,000380
+SALINE,Salina Precinct 27,Kansas House of Representatives,69,Republican,"Claeys, J.R.",241,000380
+SALINE,Salina Precinct 28,Kansas House of Representatives,71,Republican,"Dierks, Diana",243,000390
+SALINE,Salina Precinct 29,Kansas House of Representatives,71,Republican,"Dierks, Diana",398,000400
+SALINE,Salina Precinct 30,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",136,000410
+SALINE,Salina Precinct 30,Kansas House of Representatives,69,Republican,"Claeys, J.R.",229,000410
+SALINE,Salina Precinct 31 Part A,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",310,00042A
+SALINE,Salina Precinct 31 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",632,00042A
+SALINE,Salina Precinct 32,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",72,000430
+SALINE,Salina Precinct 32,Kansas House of Representatives,69,Republican,"Claeys, J.R.",173,000430
+SALINE,Salina Precinct 33,Kansas House of Representatives,108,Republican,"Johnson, Steven",476,000440
+SALINE,Salina Precinct 34,Kansas House of Representatives,108,Republican,"Johnson, Steven",813,000450
+SALINE,Salina Precinct 35,Kansas House of Representatives,108,Republican,"Johnson, Steven",431,00046A
+SALINE,Smokey Hill Township Part B,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",28,00047B
+SALINE,Smokey Hill Township Part B,Kansas House of Representatives,69,Republican,"Claeys, J.R.",67,00047B
+SALINE,Smoky View Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",306,000480
+SALINE,Smolan Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",283,000490
+SALINE,Solomon Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",158,000500
+SALINE,Spring Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",144,000510
+SALINE,Walnut Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",231,000520
+SALINE,Elm Creek Township H69,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",96,120020
+SALINE,Elm Creek Township H69,Kansas House of Representatives,69,Republican,"Claeys, J.R.",279,120020
+SALINE,Elm Creek Township H71,Kansas House of Representatives,71,Republican,"Dierks, Diana",1,120030
+SALINE,Washington Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",66,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900070
+SALINE,Salina Precinct 33 Exclave,Kansas House of Representatives,108,Republican,"Johnson, Steven",0,900080
+SALINE,Salina Precinct 35 Exclave,Kansas House of Representatives,108,Republican,"Johnson, Steven",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas House of Representatives,71,Republican,"Dierks, Diana",4,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900110
+SALINE,Cambria Township,United States House of Representatives,1,Democratic,"Sherow, James E.",45,000010
+SALINE,Cambria Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",113,000010
+SALINE,Dayton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000020
+SALINE,Dayton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000020
+SALINE,Eureka Township,United States House of Representatives,1,Democratic,"Sherow, James E.",63,000040
+SALINE,Eureka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",158,000040
+SALINE,Falun Township,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000050
+SALINE,Falun Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000050
+SALINE,Glendale Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000060
+SALINE,Glendale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000060
+SALINE,Greeley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",112,000070
+SALINE,Greeley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",268,000070
+SALINE,Gypsum Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000080
+SALINE,Gypsum Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000080
+SALINE,Liberty Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000090
+SALINE,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000090
+SALINE,Ohio Township,United States House of Representatives,1,Democratic,"Sherow, James E.",48,000100
+SALINE,Ohio Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",124,000100
+SALINE,Pleasant Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000110
+SALINE,Pleasant Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",111,000110
+SALINE,Salina Precinct 01 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",113,00012A
+SALINE,Salina Precinct 01 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",123,00012A
+SALINE,Salina Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",97,00013A
+SALINE,Salina Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",142,00013A
+SALINE,Salina Precinct 03,United States House of Representatives,1,Democratic,"Sherow, James E.",86,000140
+SALINE,Salina Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,000140
+SALINE,Salina Precinct 04,United States House of Representatives,1,Democratic,"Sherow, James E.",141,000150
+SALINE,Salina Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",126,000150
+SALINE,Salina Precinct 05,United States House of Representatives,1,Democratic,"Sherow, James E.",110,000160
+SALINE,Salina Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",138,000160
+SALINE,Salina Precinct 06,United States House of Representatives,1,Democratic,"Sherow, James E.",95,000170
+SALINE,Salina Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,000170
+SALINE,Salina Precinct 07,United States House of Representatives,1,Democratic,"Sherow, James E.",145,000180
+SALINE,Salina Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",159,000180
+SALINE,Salina Precinct 08,United States House of Representatives,1,Democratic,"Sherow, James E.",144,000190
+SALINE,Salina Precinct 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",141,000190
+SALINE,Salina Precinct 09,United States House of Representatives,1,Democratic,"Sherow, James E.",140,000200
+SALINE,Salina Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",170,000200
+SALINE,Salina Precinct 10,United States House of Representatives,1,Democratic,"Sherow, James E.",146,000210
+SALINE,Salina Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",150,000210
+SALINE,Salina Precinct 11,United States House of Representatives,1,Democratic,"Sherow, James E.",97,000220
+SALINE,Salina Precinct 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000220
+SALINE,Salina Precinct 12,United States House of Representatives,1,Democratic,"Sherow, James E.",214,000230
+SALINE,Salina Precinct 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",202,000230
+SALINE,Salina Precinct 13,United States House of Representatives,1,Democratic,"Sherow, James E.",102,000240
+SALINE,Salina Precinct 13,United States House of Representatives,1,Republican,"Huelskamp, Tim",145,000240
+SALINE,Salina Precinct 14 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",132,00025A
+SALINE,Salina Precinct 14 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",219,00025A
+SALINE,Salina Precinct 15 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",148,00026A
+SALINE,Salina Precinct 15 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",133,00026A
+SALINE,Salina Precinct 16,United States House of Representatives,1,Democratic,"Sherow, James E.",85,000270
+SALINE,Salina Precinct 16,United States House of Representatives,1,Republican,"Huelskamp, Tim",130,000270
+SALINE,Salina Precinct 17,United States House of Representatives,1,Democratic,"Sherow, James E.",106,000280
+SALINE,Salina Precinct 17,United States House of Representatives,1,Republican,"Huelskamp, Tim",154,000280
+SALINE,Salina Precinct 18,United States House of Representatives,1,Democratic,"Sherow, James E.",121,000290
+SALINE,Salina Precinct 18,United States House of Representatives,1,Republican,"Huelskamp, Tim",181,000290
+SALINE,Salina Precinct 19,United States House of Representatives,1,Democratic,"Sherow, James E.",160,000300
+SALINE,Salina Precinct 19,United States House of Representatives,1,Republican,"Huelskamp, Tim",274,000300
+SALINE,Salina Precinct 20 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",463,00031A
+SALINE,Salina Precinct 20 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",536,00031A
+SALINE,Salina Precinct 21 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",333,00032A
+SALINE,Salina Precinct 21 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",514,00032A
+SALINE,Salina Precinct 22 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",260,00033A
+SALINE,Salina Precinct 22 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",424,00033A
+SALINE,Salina Precinct 23,United States House of Representatives,1,Democratic,"Sherow, James E.",355,000340
+SALINE,Salina Precinct 23,United States House of Representatives,1,Republican,"Huelskamp, Tim",536,000340
+SALINE,Salina Precinct 24,United States House of Representatives,1,Democratic,"Sherow, James E.",124,000350
+SALINE,Salina Precinct 24,United States House of Representatives,1,Republican,"Huelskamp, Tim",177,000350
+SALINE,Salina Precinct 25,United States House of Representatives,1,Democratic,"Sherow, James E.",94,000360
+SALINE,Salina Precinct 25,United States House of Representatives,1,Republican,"Huelskamp, Tim",119,000360
+SALINE,Salina Precinct 26,United States House of Representatives,1,Democratic,"Sherow, James E.",132,000370
+SALINE,Salina Precinct 26,United States House of Representatives,1,Republican,"Huelskamp, Tim",161,000370
+SALINE,Salina Precinct 27,United States House of Representatives,1,Democratic,"Sherow, James E.",157,000380
+SALINE,Salina Precinct 27,United States House of Representatives,1,Republican,"Huelskamp, Tim",247,000380
+SALINE,Salina Precinct 28,United States House of Representatives,1,Democratic,"Sherow, James E.",94,000390
+SALINE,Salina Precinct 28,United States House of Representatives,1,Republican,"Huelskamp, Tim",181,000390
+SALINE,Salina Precinct 29,United States House of Representatives,1,Democratic,"Sherow, James E.",157,000400
+SALINE,Salina Precinct 29,United States House of Representatives,1,Republican,"Huelskamp, Tim",276,000400
+SALINE,Salina Precinct 30,United States House of Representatives,1,Democratic,"Sherow, James E.",155,000410
+SALINE,Salina Precinct 30,United States House of Representatives,1,Republican,"Huelskamp, Tim",226,000410
+SALINE,Salina Precinct 31 Part A,United States House of Representatives,1,Democratic,"Sherow, James E.",357,00042A
+SALINE,Salina Precinct 31 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",590,00042A
+SALINE,Salina Precinct 32,United States House of Representatives,1,Democratic,"Sherow, James E.",83,000430
+SALINE,Salina Precinct 32,United States House of Representatives,1,Republican,"Huelskamp, Tim",170,000430
+SALINE,Salina Precinct 33,United States House of Representatives,1,Democratic,"Sherow, James E.",192,000440
+SALINE,Salina Precinct 33,United States House of Representatives,1,Republican,"Huelskamp, Tim",320,000440
+SALINE,Salina Precinct 34,United States House of Representatives,1,Democratic,"Sherow, James E.",321,000450
+SALINE,Salina Precinct 34,United States House of Representatives,1,Republican,"Huelskamp, Tim",511,000450
+SALINE,Salina Precinct 35,United States House of Representatives,1,Democratic,"Sherow, James E.",205,00046A
+SALINE,Salina Precinct 35,United States House of Representatives,1,Republican,"Huelskamp, Tim",314,00046A
+SALINE,Smokey Hill Township Part B,United States House of Representatives,1,Democratic,"Sherow, James E.",34,00047B
+SALINE,Smokey Hill Township Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,00047B
+SALINE,Smoky View Township,United States House of Representatives,1,Democratic,"Sherow, James E.",109,000480
+SALINE,Smoky View Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",216,000480
+SALINE,Smolan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",95,000490
+SALINE,Smolan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",202,000490
+SALINE,Solomon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",49,000500
+SALINE,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",141,000500
+SALINE,Spring Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",45,000510
+SALINE,Spring Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",110,000510
+SALINE,Walnut Township,United States House of Representatives,1,Democratic,"Sherow, James E.",83,000520
+SALINE,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",161,000520
+SALINE,Elm Creek Township H69,United States House of Representatives,1,Democratic,"Sherow, James E.",107,120020
+SALINE,Elm Creek Township H69,United States House of Representatives,1,Republican,"Huelskamp, Tim",273,120020
+SALINE,Elm Creek Township H71,United States House of Representatives,1,Democratic,"Sherow, James E.",0,120030
+SALINE,Elm Creek Township H71,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120030
+SALINE,Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,300010
+SALINE,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900070
+SALINE,Salina Precinct 33 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900080
+SALINE,Salina Precinct 33 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900080
+SALINE,Salina Precinct 35 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900090
+SALINE,Salina Precinct 35 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900110
+SALINE,Cambria Township,Attorney General,,Democratic,"Kotich, A.J.",25,000010
+SALINE,Cambria Township,Attorney General,,Republican,"Schmidt, Derek",131,000010
+SALINE,Dayton Township,Attorney General,,Democratic,"Kotich, A.J.",13,000020
+SALINE,Dayton Township,Attorney General,,Republican,"Schmidt, Derek",31,000020
+SALINE,Eureka Township,Attorney General,,Democratic,"Kotich, A.J.",41,000040
+SALINE,Eureka Township,Attorney General,,Republican,"Schmidt, Derek",176,000040
+SALINE,Falun Township,Attorney General,,Democratic,"Kotich, A.J.",15,000050
+SALINE,Falun Township,Attorney General,,Republican,"Schmidt, Derek",88,000050
+SALINE,Glendale Township,Attorney General,,Democratic,"Kotich, A.J.",7,000060
+SALINE,Glendale Township,Attorney General,,Republican,"Schmidt, Derek",31,000060
+SALINE,Greeley Township,Attorney General,,Democratic,"Kotich, A.J.",60,000070
+SALINE,Greeley Township,Attorney General,,Republican,"Schmidt, Derek",320,000070
+SALINE,Gypsum Township,Attorney General,,Democratic,"Kotich, A.J.",3,000080
+SALINE,Gypsum Township,Attorney General,,Republican,"Schmidt, Derek",64,000080
+SALINE,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",17,000090
+SALINE,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",61,000090
+SALINE,Ohio Township,Attorney General,,Democratic,"Kotich, A.J.",33,000100
+SALINE,Ohio Township,Attorney General,,Republican,"Schmidt, Derek",137,000100
+SALINE,Pleasant Valley Township,Attorney General,,Democratic,"Kotich, A.J.",25,000110
+SALINE,Pleasant Valley Township,Attorney General,,Republican,"Schmidt, Derek",122,000110
+SALINE,Salina Precinct 01 Part A,Attorney General,,Democratic,"Kotich, A.J.",91,00012A
+SALINE,Salina Precinct 01 Part A,Attorney General,,Republican,"Schmidt, Derek",143,00012A
+SALINE,Salina Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",88,00013A
+SALINE,Salina Precinct 02,Attorney General,,Republican,"Schmidt, Derek",149,00013A
+SALINE,Salina Precinct 03,Attorney General,,Democratic,"Kotich, A.J.",67,000140
+SALINE,Salina Precinct 03,Attorney General,,Republican,"Schmidt, Derek",110,000140
+SALINE,Salina Precinct 04,Attorney General,,Democratic,"Kotich, A.J.",120,000150
+SALINE,Salina Precinct 04,Attorney General,,Republican,"Schmidt, Derek",148,000150
+SALINE,Salina Precinct 05,Attorney General,,Democratic,"Kotich, A.J.",95,000160
+SALINE,Salina Precinct 05,Attorney General,,Republican,"Schmidt, Derek",146,000160
+SALINE,Salina Precinct 06,Attorney General,,Democratic,"Kotich, A.J.",76,000170
+SALINE,Salina Precinct 06,Attorney General,,Republican,"Schmidt, Derek",123,000170
+SALINE,Salina Precinct 07,Attorney General,,Democratic,"Kotich, A.J.",115,000180
+SALINE,Salina Precinct 07,Attorney General,,Republican,"Schmidt, Derek",181,000180
+SALINE,Salina Precinct 08,Attorney General,,Democratic,"Kotich, A.J.",108,000190
+SALINE,Salina Precinct 08,Attorney General,,Republican,"Schmidt, Derek",172,000190
+SALINE,Salina Precinct 09,Attorney General,,Democratic,"Kotich, A.J.",112,000200
+SALINE,Salina Precinct 09,Attorney General,,Republican,"Schmidt, Derek",190,000200
+SALINE,Salina Precinct 10,Attorney General,,Democratic,"Kotich, A.J.",121,000210
+SALINE,Salina Precinct 10,Attorney General,,Republican,"Schmidt, Derek",172,000210
+SALINE,Salina Precinct 11,Attorney General,,Democratic,"Kotich, A.J.",73,000220
+SALINE,Salina Precinct 11,Attorney General,,Republican,"Schmidt, Derek",183,000220
+SALINE,Salina Precinct 12,Attorney General,,Democratic,"Kotich, A.J.",167,000230
+SALINE,Salina Precinct 12,Attorney General,,Republican,"Schmidt, Derek",246,000230
+SALINE,Salina Precinct 13,Attorney General,,Democratic,"Kotich, A.J.",77,000240
+SALINE,Salina Precinct 13,Attorney General,,Republican,"Schmidt, Derek",170,000240
+SALINE,Salina Precinct 14 Part A,Attorney General,,Democratic,"Kotich, A.J.",106,00025A
+SALINE,Salina Precinct 14 Part A,Attorney General,,Republican,"Schmidt, Derek",242,00025A
+SALINE,Salina Precinct 15 Part A,Attorney General,,Democratic,"Kotich, A.J.",106,00026A
+SALINE,Salina Precinct 15 Part A,Attorney General,,Republican,"Schmidt, Derek",174,00026A
+SALINE,Salina Precinct 16,Attorney General,,Democratic,"Kotich, A.J.",75,000270
+SALINE,Salina Precinct 16,Attorney General,,Republican,"Schmidt, Derek",139,000270
+SALINE,Salina Precinct 17,Attorney General,,Democratic,"Kotich, A.J.",87,000280
+SALINE,Salina Precinct 17,Attorney General,,Republican,"Schmidt, Derek",171,000280
+SALINE,Salina Precinct 18,Attorney General,,Democratic,"Kotich, A.J.",83,000290
+SALINE,Salina Precinct 18,Attorney General,,Republican,"Schmidt, Derek",216,000290
+SALINE,Salina Precinct 19,Attorney General,,Democratic,"Kotich, A.J.",108,000300
+SALINE,Salina Precinct 19,Attorney General,,Republican,"Schmidt, Derek",317,000300
+SALINE,Salina Precinct 20 Part A,Attorney General,,Democratic,"Kotich, A.J.",282,00031A
+SALINE,Salina Precinct 20 Part A,Attorney General,,Republican,"Schmidt, Derek",748,00031A
+SALINE,Salina Precinct 21 Part A,Attorney General,,Democratic,"Kotich, A.J.",183,00032A
+SALINE,Salina Precinct 21 Part A,Attorney General,,Republican,"Schmidt, Derek",606,00032A
+SALINE,Salina Precinct 22 Part A,Attorney General,,Democratic,"Kotich, A.J.",150,00033A
+SALINE,Salina Precinct 22 Part A,Attorney General,,Republican,"Schmidt, Derek",526,00033A
+SALINE,Salina Precinct 23,Attorney General,,Democratic,"Kotich, A.J.",237,000340
+SALINE,Salina Precinct 23,Attorney General,,Republican,"Schmidt, Derek",637,000340
+SALINE,Salina Precinct 24,Attorney General,,Democratic,"Kotich, A.J.",86,000350
+SALINE,Salina Precinct 24,Attorney General,,Republican,"Schmidt, Derek",211,000350
+SALINE,Salina Precinct 25,Attorney General,,Democratic,"Kotich, A.J.",68,000360
+SALINE,Salina Precinct 25,Attorney General,,Republican,"Schmidt, Derek",142,000360
+SALINE,Salina Precinct 26,Attorney General,,Democratic,"Kotich, A.J.",100,000370
+SALINE,Salina Precinct 26,Attorney General,,Republican,"Schmidt, Derek",197,000370
+SALINE,Salina Precinct 27,Attorney General,,Democratic,"Kotich, A.J.",112,000380
+SALINE,Salina Precinct 27,Attorney General,,Republican,"Schmidt, Derek",287,000380
+SALINE,Salina Precinct 28,Attorney General,,Democratic,"Kotich, A.J.",73,000390
+SALINE,Salina Precinct 28,Attorney General,,Republican,"Schmidt, Derek",194,000390
+SALINE,Salina Precinct 29,Attorney General,,Democratic,"Kotich, A.J.",117,000400
+SALINE,Salina Precinct 29,Attorney General,,Republican,"Schmidt, Derek",308,000400
+SALINE,Salina Precinct 30,Attorney General,,Democratic,"Kotich, A.J.",114,000410
+SALINE,Salina Precinct 30,Attorney General,,Republican,"Schmidt, Derek",260,000410
+SALINE,Salina Precinct 31 Part A,Attorney General,,Democratic,"Kotich, A.J.",225,00042A
+SALINE,Salina Precinct 31 Part A,Attorney General,,Republican,"Schmidt, Derek",706,00042A
+SALINE,Salina Precinct 32,Attorney General,,Democratic,"Kotich, A.J.",69,000430
+SALINE,Salina Precinct 32,Attorney General,,Republican,"Schmidt, Derek",182,000430
+SALINE,Salina Precinct 33,Attorney General,,Democratic,"Kotich, A.J.",129,000440
+SALINE,Salina Precinct 33,Attorney General,,Republican,"Schmidt, Derek",380,000440
+SALINE,Salina Precinct 34,Attorney General,,Democratic,"Kotich, A.J.",218,000450
+SALINE,Salina Precinct 34,Attorney General,,Republican,"Schmidt, Derek",602,000450
+SALINE,Salina Precinct 35,Attorney General,,Democratic,"Kotich, A.J.",164,00046A
+SALINE,Salina Precinct 35,Attorney General,,Republican,"Schmidt, Derek",340,00046A
+SALINE,Smokey Hill Township Part B,Attorney General,,Democratic,"Kotich, A.J.",15,00047B
+SALINE,Smokey Hill Township Part B,Attorney General,,Republican,"Schmidt, Derek",86,00047B
+SALINE,Smoky View Township,Attorney General,,Democratic,"Kotich, A.J.",78,000480
+SALINE,Smoky View Township,Attorney General,,Republican,"Schmidt, Derek",245,000480
+SALINE,Smolan Township,Attorney General,,Democratic,"Kotich, A.J.",56,000490
+SALINE,Smolan Township,Attorney General,,Republican,"Schmidt, Derek",240,000490
+SALINE,Solomon Township,Attorney General,,Democratic,"Kotich, A.J.",33,000500
+SALINE,Solomon Township,Attorney General,,Republican,"Schmidt, Derek",153,000500
+SALINE,Spring Creek Township,Attorney General,,Democratic,"Kotich, A.J.",27,000510
+SALINE,Spring Creek Township,Attorney General,,Republican,"Schmidt, Derek",126,000510
+SALINE,Walnut Township,Attorney General,,Democratic,"Kotich, A.J.",47,000520
+SALINE,Walnut Township,Attorney General,,Republican,"Schmidt, Derek",195,000520
+SALINE,Elm Creek Township H69,Attorney General,,Democratic,"Kotich, A.J.",64,120020
+SALINE,Elm Creek Township H69,Attorney General,,Republican,"Schmidt, Derek",313,120020
+SALINE,Elm Creek Township H71,Attorney General,,Democratic,"Kotich, A.J.",0,120030
+SALINE,Elm Creek Township H71,Attorney General,,Republican,"Schmidt, Derek",0,120030
+SALINE,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",10,300010
+SALINE,Washington Township,Attorney General,,Republican,"Schmidt, Derek",59,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Attorney General,,Republican,"Schmidt, Derek",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Attorney General,,Democratic,"Kotich, A.J.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Attorney General,,Republican,"Schmidt, Derek",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900070
+SALINE,Salina Precinct 33 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900080
+SALINE,Salina Precinct 33 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900080
+SALINE,Salina Precinct 35 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900090
+SALINE,Salina Precinct 35 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900110
+SALINE,Cambria Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000010
+SALINE,Cambria Township,Commissioner of Insurance,,Republican,"Selzer, Ken",120,000010
+SALINE,Dayton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000020
+SALINE,Dayton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",28,000020
+SALINE,Eureka Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000040
+SALINE,Eureka Township,Commissioner of Insurance,,Republican,"Selzer, Ken",163,000040
+SALINE,Falun Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000050
+SALINE,Falun Township,Commissioner of Insurance,,Republican,"Selzer, Ken",85,000050
+SALINE,Glendale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000060
+SALINE,Glendale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000060
+SALINE,Greeley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000070
+SALINE,Greeley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",298,000070
+SALINE,Gypsum Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000080
+SALINE,Gypsum Township,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000080
+SALINE,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000090
+SALINE,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",59,000090
+SALINE,Ohio Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000100
+SALINE,Ohio Township,Commissioner of Insurance,,Republican,"Selzer, Ken",127,000100
+SALINE,Pleasant Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000110
+SALINE,Pleasant Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",115,000110
+SALINE,Salina Precinct 01 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",109,00012A
+SALINE,Salina Precinct 01 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",120,00012A
+SALINE,Salina Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",97,00013A
+SALINE,Salina Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",138,00013A
+SALINE,Salina Precinct 03,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000140
+SALINE,Salina Precinct 03,Commissioner of Insurance,,Republican,"Selzer, Ken",92,000140
+SALINE,Salina Precinct 04,Commissioner of Insurance,,Democratic,"Anderson, Dennis",135,000150
+SALINE,Salina Precinct 04,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000150
+SALINE,Salina Precinct 05,Commissioner of Insurance,,Democratic,"Anderson, Dennis",104,000160
+SALINE,Salina Precinct 05,Commissioner of Insurance,,Republican,"Selzer, Ken",137,000160
+SALINE,Salina Precinct 06,Commissioner of Insurance,,Democratic,"Anderson, Dennis",94,000170
+SALINE,Salina Precinct 06,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000170
+SALINE,Salina Precinct 07,Commissioner of Insurance,,Democratic,"Anderson, Dennis",133,000180
+SALINE,Salina Precinct 07,Commissioner of Insurance,,Republican,"Selzer, Ken",155,000180
+SALINE,Salina Precinct 08,Commissioner of Insurance,,Democratic,"Anderson, Dennis",123,000190
+SALINE,Salina Precinct 08,Commissioner of Insurance,,Republican,"Selzer, Ken",152,000190
+SALINE,Salina Precinct 09,Commissioner of Insurance,,Democratic,"Anderson, Dennis",127,000200
+SALINE,Salina Precinct 09,Commissioner of Insurance,,Republican,"Selzer, Ken",173,000200
+SALINE,Salina Precinct 10,Commissioner of Insurance,,Democratic,"Anderson, Dennis",130,000210
+SALINE,Salina Precinct 10,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000210
+SALINE,Salina Precinct 11,Commissioner of Insurance,,Democratic,"Anderson, Dennis",84,000220
+SALINE,Salina Precinct 11,Commissioner of Insurance,,Republican,"Selzer, Ken",165,000220
+SALINE,Salina Precinct 12,Commissioner of Insurance,,Democratic,"Anderson, Dennis",190,000230
+SALINE,Salina Precinct 12,Commissioner of Insurance,,Republican,"Selzer, Ken",211,000230
+SALINE,Salina Precinct 13,Commissioner of Insurance,,Democratic,"Anderson, Dennis",99,000240
+SALINE,Salina Precinct 13,Commissioner of Insurance,,Republican,"Selzer, Ken",144,000240
+SALINE,Salina Precinct 14 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",130,00025A
+SALINE,Salina Precinct 14 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",212,00025A
+SALINE,Salina Precinct 15 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",134,00026A
+SALINE,Salina Precinct 15 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",136,00026A
+SALINE,Salina Precinct 16,Commissioner of Insurance,,Democratic,"Anderson, Dennis",74,000270
+SALINE,Salina Precinct 16,Commissioner of Insurance,,Republican,"Selzer, Ken",129,000270
+SALINE,Salina Precinct 17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",106,000280
+SALINE,Salina Precinct 17,Commissioner of Insurance,,Republican,"Selzer, Ken",146,000280
+SALINE,Salina Precinct 18,Commissioner of Insurance,,Democratic,"Anderson, Dennis",96,000290
+SALINE,Salina Precinct 18,Commissioner of Insurance,,Republican,"Selzer, Ken",193,000290
+SALINE,Salina Precinct 19,Commissioner of Insurance,,Democratic,"Anderson, Dennis",122,000300
+SALINE,Salina Precinct 19,Commissioner of Insurance,,Republican,"Selzer, Ken",298,000300
+SALINE,Salina Precinct 20 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",311,00031A
+SALINE,Salina Precinct 20 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",710,00031A
+SALINE,Salina Precinct 21 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",236,00032A
+SALINE,Salina Precinct 21 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",531,00032A
+SALINE,Salina Precinct 22 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",171,00033A
+SALINE,Salina Precinct 22 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",495,00033A
+SALINE,Salina Precinct 23,Commissioner of Insurance,,Democratic,"Anderson, Dennis",290,000340
+SALINE,Salina Precinct 23,Commissioner of Insurance,,Republican,"Selzer, Ken",568,000340
+SALINE,Salina Precinct 24,Commissioner of Insurance,,Democratic,"Anderson, Dennis",112,000350
+SALINE,Salina Precinct 24,Commissioner of Insurance,,Republican,"Selzer, Ken",178,000350
+SALINE,Salina Precinct 25,Commissioner of Insurance,,Democratic,"Anderson, Dennis",79,000360
+SALINE,Salina Precinct 25,Commissioner of Insurance,,Republican,"Selzer, Ken",126,000360
+SALINE,Salina Precinct 26,Commissioner of Insurance,,Democratic,"Anderson, Dennis",116,000370
+SALINE,Salina Precinct 26,Commissioner of Insurance,,Republican,"Selzer, Ken",174,000370
+SALINE,Salina Precinct 27,Commissioner of Insurance,,Democratic,"Anderson, Dennis",138,000380
+SALINE,Salina Precinct 27,Commissioner of Insurance,,Republican,"Selzer, Ken",255,000380
+SALINE,Salina Precinct 28,Commissioner of Insurance,,Democratic,"Anderson, Dennis",78,000390
+SALINE,Salina Precinct 28,Commissioner of Insurance,,Republican,"Selzer, Ken",185,000390
+SALINE,Salina Precinct 29,Commissioner of Insurance,,Democratic,"Anderson, Dennis",137,000400
+SALINE,Salina Precinct 29,Commissioner of Insurance,,Republican,"Selzer, Ken",281,000400
+SALINE,Salina Precinct 30,Commissioner of Insurance,,Democratic,"Anderson, Dennis",133,000410
+SALINE,Salina Precinct 30,Commissioner of Insurance,,Republican,"Selzer, Ken",237,000410
+SALINE,Salina Precinct 31 Part A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",276,00042A
+SALINE,Salina Precinct 31 Part A,Commissioner of Insurance,,Republican,"Selzer, Ken",632,00042A
+SALINE,Salina Precinct 32,Commissioner of Insurance,,Democratic,"Anderson, Dennis",72,000430
+SALINE,Salina Precinct 32,Commissioner of Insurance,,Republican,"Selzer, Ken",170,000430
+SALINE,Salina Precinct 33,Commissioner of Insurance,,Democratic,"Anderson, Dennis",152,000440
+SALINE,Salina Precinct 33,Commissioner of Insurance,,Republican,"Selzer, Ken",341,000440
+SALINE,Salina Precinct 34,Commissioner of Insurance,,Democratic,"Anderson, Dennis",275,000450
+SALINE,Salina Precinct 34,Commissioner of Insurance,,Republican,"Selzer, Ken",540,000450
+SALINE,Salina Precinct 35,Commissioner of Insurance,,Democratic,"Anderson, Dennis",189,00046A
+SALINE,Salina Precinct 35,Commissioner of Insurance,,Republican,"Selzer, Ken",308,00046A
+SALINE,Smokey Hill Township Part B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,00047B
+SALINE,Smokey Hill Township Part B,Commissioner of Insurance,,Republican,"Selzer, Ken",71,00047B
+SALINE,Smoky View Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",76,000480
+SALINE,Smoky View Township,Commissioner of Insurance,,Republican,"Selzer, Ken",241,000480
+SALINE,Smolan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000490
+SALINE,Smolan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",221,000490
+SALINE,Solomon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000500
+SALINE,Solomon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",141,000500
+SALINE,Spring Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000510
+SALINE,Spring Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",109,000510
+SALINE,Walnut Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",55,000520
+SALINE,Walnut Township,Commissioner of Insurance,,Republican,"Selzer, Ken",180,000520
+SALINE,Elm Creek Township H69,Commissioner of Insurance,,Democratic,"Anderson, Dennis",90,120020
+SALINE,Elm Creek Township H69,Commissioner of Insurance,,Republican,"Selzer, Ken",287,120020
+SALINE,Elm Creek Township H71,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120030
+SALINE,Elm Creek Township H71,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120030
+SALINE,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,300010
+SALINE,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900070
+SALINE,Salina Precinct 33 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900080
+SALINE,Salina Precinct 33 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900080
+SALINE,Salina Precinct 35 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900090
+SALINE,Salina Precinct 35 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900110
+SALINE,Cambria Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,000010
+SALINE,Cambria Township,Secretary of State,,Republican,"Kobach, Kris",108,000010
+SALINE,Dayton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000020
+SALINE,Dayton Township,Secretary of State,,Republican,"Kobach, Kris",26,000020
+SALINE,Eureka Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",61,000040
+SALINE,Eureka Township,Secretary of State,,Republican,"Kobach, Kris",158,000040
+SALINE,Falun Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000050
+SALINE,Falun Township,Secretary of State,,Republican,"Kobach, Kris",75,000050
+SALINE,Glendale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000060
+SALINE,Glendale Township,Secretary of State,,Republican,"Kobach, Kris",30,000060
+SALINE,Greeley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,000070
+SALINE,Greeley Township,Secretary of State,,Republican,"Kobach, Kris",281,000070
+SALINE,Gypsum Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000080
+SALINE,Gypsum Township,Secretary of State,,Republican,"Kobach, Kris",59,000080
+SALINE,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,000090
+SALINE,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",53,000090
+SALINE,Ohio Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000100
+SALINE,Ohio Township,Secretary of State,,Republican,"Kobach, Kris",113,000100
+SALINE,Pleasant Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",38,000110
+SALINE,Pleasant Valley Township,Secretary of State,,Republican,"Kobach, Kris",109,000110
+SALINE,Salina Precinct 01 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",117,00012A
+SALINE,Salina Precinct 01 Part A,Secretary of State,,Republican,"Kobach, Kris",120,00012A
+SALINE,Salina Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",109,00013A
+SALINE,Salina Precinct 02,Secretary of State,,Republican,"Kobach, Kris",127,00013A
+SALINE,Salina Precinct 03,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,000140
+SALINE,Salina Precinct 03,Secretary of State,,Republican,"Kobach, Kris",87,000140
+SALINE,Salina Precinct 04,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",147,000150
+SALINE,Salina Precinct 04,Secretary of State,,Republican,"Kobach, Kris",124,000150
+SALINE,Salina Precinct 05,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",109,000160
+SALINE,Salina Precinct 05,Secretary of State,,Republican,"Kobach, Kris",137,000160
+SALINE,Salina Precinct 06,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",98,000170
+SALINE,Salina Precinct 06,Secretary of State,,Republican,"Kobach, Kris",102,000170
+SALINE,Salina Precinct 07,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",145,000180
+SALINE,Salina Precinct 07,Secretary of State,,Republican,"Kobach, Kris",157,000180
+SALINE,Salina Precinct 08,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,000190
+SALINE,Salina Precinct 08,Secretary of State,,Republican,"Kobach, Kris",140,000190
+SALINE,Salina Precinct 09,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",152,000200
+SALINE,Salina Precinct 09,Secretary of State,,Republican,"Kobach, Kris",159,000200
+SALINE,Salina Precinct 10,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",149,000210
+SALINE,Salina Precinct 10,Secretary of State,,Republican,"Kobach, Kris",148,000210
+SALINE,Salina Precinct 11,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",100,000220
+SALINE,Salina Precinct 11,Secretary of State,,Republican,"Kobach, Kris",160,000220
+SALINE,Salina Precinct 12,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",214,000230
+SALINE,Salina Precinct 12,Secretary of State,,Republican,"Kobach, Kris",202,000230
+SALINE,Salina Precinct 13,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",115,000240
+SALINE,Salina Precinct 13,Secretary of State,,Republican,"Kobach, Kris",133,000240
+SALINE,Salina Precinct 14 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",146,00025A
+SALINE,Salina Precinct 14 Part A,Secretary of State,,Republican,"Kobach, Kris",206,00025A
+SALINE,Salina Precinct 15 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",141,00026A
+SALINE,Salina Precinct 15 Part A,Secretary of State,,Republican,"Kobach, Kris",140,00026A
+SALINE,Salina Precinct 16,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",86,000270
+SALINE,Salina Precinct 16,Secretary of State,,Republican,"Kobach, Kris",130,000270
+SALINE,Salina Precinct 17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",111,000280
+SALINE,Salina Precinct 17,Secretary of State,,Republican,"Kobach, Kris",147,000280
+SALINE,Salina Precinct 18,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",115,000290
+SALINE,Salina Precinct 18,Secretary of State,,Republican,"Kobach, Kris",187,000290
+SALINE,Salina Precinct 19,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",156,000300
+SALINE,Salina Precinct 19,Secretary of State,,Republican,"Kobach, Kris",278,000300
+SALINE,Salina Precinct 20 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",429,00031A
+SALINE,Salina Precinct 20 Part A,Secretary of State,,Republican,"Kobach, Kris",623,00031A
+SALINE,Salina Precinct 21 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",309,00032A
+SALINE,Salina Precinct 21 Part A,Secretary of State,,Republican,"Kobach, Kris",490,00032A
+SALINE,Salina Precinct 22 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",250,00033A
+SALINE,Salina Precinct 22 Part A,Secretary of State,,Republican,"Kobach, Kris",434,00033A
+SALINE,Salina Precinct 23,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",350,000340
+SALINE,Salina Precinct 23,Secretary of State,,Republican,"Kobach, Kris",536,000340
+SALINE,Salina Precinct 24,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",131,000350
+SALINE,Salina Precinct 24,Secretary of State,,Republican,"Kobach, Kris",176,000350
+SALINE,Salina Precinct 25,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,000360
+SALINE,Salina Precinct 25,Secretary of State,,Republican,"Kobach, Kris",121,000360
+SALINE,Salina Precinct 26,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",143,000370
+SALINE,Salina Precinct 26,Secretary of State,,Republican,"Kobach, Kris",157,000370
+SALINE,Salina Precinct 27,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",163,000380
+SALINE,Salina Precinct 27,Secretary of State,,Republican,"Kobach, Kris",236,000380
+SALINE,Salina Precinct 28,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",99,000390
+SALINE,Salina Precinct 28,Secretary of State,,Republican,"Kobach, Kris",173,000390
+SALINE,Salina Precinct 29,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",165,000400
+SALINE,Salina Precinct 29,Secretary of State,,Republican,"Kobach, Kris",265,000400
+SALINE,Salina Precinct 30,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",155,000410
+SALINE,Salina Precinct 30,Secretary of State,,Republican,"Kobach, Kris",225,000410
+SALINE,Salina Precinct 31 Part A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",342,00042A
+SALINE,Salina Precinct 31 Part A,Secretary of State,,Republican,"Kobach, Kris",599,00042A
+SALINE,Salina Precinct 32,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",97,000430
+SALINE,Salina Precinct 32,Secretary of State,,Republican,"Kobach, Kris",156,000430
+SALINE,Salina Precinct 33,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",199,000440
+SALINE,Salina Precinct 33,Secretary of State,,Republican,"Kobach, Kris",318,000440
+SALINE,Salina Precinct 34,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",320,000450
+SALINE,Salina Precinct 34,Secretary of State,,Republican,"Kobach, Kris",512,000450
+SALINE,Salina Precinct 35,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",206,00046A
+SALINE,Salina Precinct 35,Secretary of State,,Republican,"Kobach, Kris",307,00046A
+SALINE,Smokey Hill Township Part B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,00047B
+SALINE,Smokey Hill Township Part B,Secretary of State,,Republican,"Kobach, Kris",69,00047B
+SALINE,Smoky View Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",112,000480
+SALINE,Smoky View Township,Secretary of State,,Republican,"Kobach, Kris",215,000480
+SALINE,Smolan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",88,000490
+SALINE,Smolan Township,Secretary of State,,Republican,"Kobach, Kris",211,000490
+SALINE,Solomon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,000500
+SALINE,Solomon Township,Secretary of State,,Republican,"Kobach, Kris",136,000500
+SALINE,Spring Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000510
+SALINE,Spring Creek Township,Secretary of State,,Republican,"Kobach, Kris",107,000510
+SALINE,Walnut Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",81,000520
+SALINE,Walnut Township,Secretary of State,,Republican,"Kobach, Kris",161,000520
+SALINE,Elm Creek Township H69,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",113,120020
+SALINE,Elm Creek Township H69,Secretary of State,,Republican,"Kobach, Kris",269,120020
+SALINE,Elm Creek Township H71,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120030
+SALINE,Elm Creek Township H71,Secretary of State,,Republican,"Kobach, Kris",0,120030
+SALINE,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,300010
+SALINE,Washington Township,Secretary of State,,Republican,"Kobach, Kris",50,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Secretary of State,,Republican,"Kobach, Kris",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Secretary of State,,Republican,"Kobach, Kris",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900070
+SALINE,Salina Precinct 33 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900080
+SALINE,Salina Precinct 33 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900080
+SALINE,Salina Precinct 35 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900090
+SALINE,Salina Precinct 35 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900110
+SALINE,Cambria Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000010
+SALINE,Cambria Township,State Treasurer,,Republican,"Estes, Ron",129,000010
+SALINE,Dayton Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000020
+SALINE,Dayton Township,State Treasurer,,Republican,"Estes, Ron",27,000020
+SALINE,Eureka Township,State Treasurer,,Democratic,"Alldritt, Carmen",44,000040
+SALINE,Eureka Township,State Treasurer,,Republican,"Estes, Ron",174,000040
+SALINE,Falun Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000050
+SALINE,Falun Township,State Treasurer,,Republican,"Estes, Ron",83,000050
+SALINE,Glendale Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000060
+SALINE,Glendale Township,State Treasurer,,Republican,"Estes, Ron",30,000060
+SALINE,Greeley Township,State Treasurer,,Democratic,"Alldritt, Carmen",62,000070
+SALINE,Greeley Township,State Treasurer,,Republican,"Estes, Ron",319,000070
+SALINE,Gypsum Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000080
+SALINE,Gypsum Township,State Treasurer,,Republican,"Estes, Ron",62,000080
+SALINE,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000090
+SALINE,Liberty Township,State Treasurer,,Republican,"Estes, Ron",65,000090
+SALINE,Ohio Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,000100
+SALINE,Ohio Township,State Treasurer,,Republican,"Estes, Ron",134,000100
+SALINE,Pleasant Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000110
+SALINE,Pleasant Valley Township,State Treasurer,,Republican,"Estes, Ron",120,000110
+SALINE,Salina Precinct 01 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",98,00012A
+SALINE,Salina Precinct 01 Part A,State Treasurer,,Republican,"Estes, Ron",133,00012A
+SALINE,Salina Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",86,00013A
+SALINE,Salina Precinct 02,State Treasurer,,Republican,"Estes, Ron",150,00013A
+SALINE,Salina Precinct 03,State Treasurer,,Democratic,"Alldritt, Carmen",71,000140
+SALINE,Salina Precinct 03,State Treasurer,,Republican,"Estes, Ron",101,000140
+SALINE,Salina Precinct 04,State Treasurer,,Democratic,"Alldritt, Carmen",121,000150
+SALINE,Salina Precinct 04,State Treasurer,,Republican,"Estes, Ron",147,000150
+SALINE,Salina Precinct 05,State Treasurer,,Democratic,"Alldritt, Carmen",96,000160
+SALINE,Salina Precinct 05,State Treasurer,,Republican,"Estes, Ron",147,000160
+SALINE,Salina Precinct 06,State Treasurer,,Democratic,"Alldritt, Carmen",80,000170
+SALINE,Salina Precinct 06,State Treasurer,,Republican,"Estes, Ron",117,000170
+SALINE,Salina Precinct 07,State Treasurer,,Democratic,"Alldritt, Carmen",119,000180
+SALINE,Salina Precinct 07,State Treasurer,,Republican,"Estes, Ron",176,000180
+SALINE,Salina Precinct 08,State Treasurer,,Democratic,"Alldritt, Carmen",104,000190
+SALINE,Salina Precinct 08,State Treasurer,,Republican,"Estes, Ron",176,000190
+SALINE,Salina Precinct 09,State Treasurer,,Democratic,"Alldritt, Carmen",105,000200
+SALINE,Salina Precinct 09,State Treasurer,,Republican,"Estes, Ron",199,000200
+SALINE,Salina Precinct 10,State Treasurer,,Democratic,"Alldritt, Carmen",122,000210
+SALINE,Salina Precinct 10,State Treasurer,,Republican,"Estes, Ron",172,000210
+SALINE,Salina Precinct 11,State Treasurer,,Democratic,"Alldritt, Carmen",76,000220
+SALINE,Salina Precinct 11,State Treasurer,,Republican,"Estes, Ron",178,000220
+SALINE,Salina Precinct 12,State Treasurer,,Democratic,"Alldritt, Carmen",152,000230
+SALINE,Salina Precinct 12,State Treasurer,,Republican,"Estes, Ron",254,000230
+SALINE,Salina Precinct 13,State Treasurer,,Democratic,"Alldritt, Carmen",83,000240
+SALINE,Salina Precinct 13,State Treasurer,,Republican,"Estes, Ron",160,000240
+SALINE,Salina Precinct 14 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",109,00025A
+SALINE,Salina Precinct 14 Part A,State Treasurer,,Republican,"Estes, Ron",236,00025A
+SALINE,Salina Precinct 15 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",111,00026A
+SALINE,Salina Precinct 15 Part A,State Treasurer,,Republican,"Estes, Ron",167,00026A
+SALINE,Salina Precinct 16,State Treasurer,,Democratic,"Alldritt, Carmen",78,000270
+SALINE,Salina Precinct 16,State Treasurer,,Republican,"Estes, Ron",131,000270
+SALINE,Salina Precinct 17,State Treasurer,,Democratic,"Alldritt, Carmen",83,000280
+SALINE,Salina Precinct 17,State Treasurer,,Republican,"Estes, Ron",175,000280
+SALINE,Salina Precinct 18,State Treasurer,,Democratic,"Alldritt, Carmen",84,000290
+SALINE,Salina Precinct 18,State Treasurer,,Republican,"Estes, Ron",212,000290
+SALINE,Salina Precinct 19,State Treasurer,,Democratic,"Alldritt, Carmen",100,000300
+SALINE,Salina Precinct 19,State Treasurer,,Republican,"Estes, Ron",326,000300
+SALINE,Salina Precinct 20 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",250,00031A
+SALINE,Salina Precinct 20 Part A,State Treasurer,,Republican,"Estes, Ron",782,00031A
+SALINE,Salina Precinct 21 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",184,00032A
+SALINE,Salina Precinct 21 Part A,State Treasurer,,Republican,"Estes, Ron",603,00032A
+SALINE,Salina Precinct 22 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",131,00033A
+SALINE,Salina Precinct 22 Part A,State Treasurer,,Republican,"Estes, Ron",540,00033A
+SALINE,Salina Precinct 23,State Treasurer,,Democratic,"Alldritt, Carmen",235,000340
+SALINE,Salina Precinct 23,State Treasurer,,Republican,"Estes, Ron",632,000340
+SALINE,Salina Precinct 24,State Treasurer,,Democratic,"Alldritt, Carmen",102,000350
+SALINE,Salina Precinct 24,State Treasurer,,Republican,"Estes, Ron",194,000350
+SALINE,Salina Precinct 25,State Treasurer,,Democratic,"Alldritt, Carmen",73,000360
+SALINE,Salina Precinct 25,State Treasurer,,Republican,"Estes, Ron",132,000360
+SALINE,Salina Precinct 26,State Treasurer,,Democratic,"Alldritt, Carmen",103,000370
+SALINE,Salina Precinct 26,State Treasurer,,Republican,"Estes, Ron",189,000370
+SALINE,Salina Precinct 27,State Treasurer,,Democratic,"Alldritt, Carmen",115,000380
+SALINE,Salina Precinct 27,State Treasurer,,Republican,"Estes, Ron",286,000380
+SALINE,Salina Precinct 28,State Treasurer,,Democratic,"Alldritt, Carmen",70,000390
+SALINE,Salina Precinct 28,State Treasurer,,Republican,"Estes, Ron",199,000390
+SALINE,Salina Precinct 29,State Treasurer,,Democratic,"Alldritt, Carmen",108,000400
+SALINE,Salina Precinct 29,State Treasurer,,Republican,"Estes, Ron",311,000400
+SALINE,Salina Precinct 30,State Treasurer,,Democratic,"Alldritt, Carmen",110,000410
+SALINE,Salina Precinct 30,State Treasurer,,Republican,"Estes, Ron",262,000410
+SALINE,Salina Precinct 31 Part A,State Treasurer,,Democratic,"Alldritt, Carmen",231,00042A
+SALINE,Salina Precinct 31 Part A,State Treasurer,,Republican,"Estes, Ron",690,00042A
+SALINE,Salina Precinct 32,State Treasurer,,Democratic,"Alldritt, Carmen",63,000430
+SALINE,Salina Precinct 32,State Treasurer,,Republican,"Estes, Ron",187,000430
+SALINE,Salina Precinct 33,State Treasurer,,Democratic,"Alldritt, Carmen",134,000440
+SALINE,Salina Precinct 33,State Treasurer,,Republican,"Estes, Ron",373,000440
+SALINE,Salina Precinct 34,State Treasurer,,Democratic,"Alldritt, Carmen",206,000450
+SALINE,Salina Precinct 34,State Treasurer,,Republican,"Estes, Ron",611,000450
+SALINE,Salina Precinct 35,State Treasurer,,Democratic,"Alldritt, Carmen",164,00046A
+SALINE,Salina Precinct 35,State Treasurer,,Republican,"Estes, Ron",341,00046A
+SALINE,Smokey Hill Township Part B,State Treasurer,,Democratic,"Alldritt, Carmen",13,00047B
+SALINE,Smokey Hill Township Part B,State Treasurer,,Republican,"Estes, Ron",89,00047B
+SALINE,Smoky View Township,State Treasurer,,Democratic,"Alldritt, Carmen",75,000480
+SALINE,Smoky View Township,State Treasurer,,Republican,"Estes, Ron",246,000480
+SALINE,Smolan Township,State Treasurer,,Democratic,"Alldritt, Carmen",53,000490
+SALINE,Smolan Township,State Treasurer,,Republican,"Estes, Ron",240,000490
+SALINE,Solomon Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000500
+SALINE,Solomon Township,State Treasurer,,Republican,"Estes, Ron",146,000500
+SALINE,Spring Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000510
+SALINE,Spring Creek Township,State Treasurer,,Republican,"Estes, Ron",120,000510
+SALINE,Walnut Township,State Treasurer,,Democratic,"Alldritt, Carmen",45,000520
+SALINE,Walnut Township,State Treasurer,,Republican,"Estes, Ron",192,000520
+SALINE,Elm Creek Township H69,State Treasurer,,Democratic,"Alldritt, Carmen",69,120020
+SALINE,Elm Creek Township H69,State Treasurer,,Republican,"Estes, Ron",313,120020
+SALINE,Elm Creek Township H71,State Treasurer,,Democratic,"Alldritt, Carmen",0,120030
+SALINE,Elm Creek Township H71,State Treasurer,,Republican,"Estes, Ron",0,120030
+SALINE,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,300010
+SALINE,Washington Township,State Treasurer,,Republican,"Estes, Ron",56,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,State Treasurer,,Republican,"Estes, Ron",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,State Treasurer,,Democratic,"Alldritt, Carmen",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,State Treasurer,,Republican,"Estes, Ron",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,State Treasurer,,Republican,"Estes, Ron",0,900070
+SALINE,Salina Precinct 33 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900080
+SALINE,Salina Precinct 33 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900080
+SALINE,Salina Precinct 35 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900090
+SALINE,Salina Precinct 35 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,State Treasurer,,Republican,"Estes, Ron",0,900110
+SALINE,Cambria Township,United States Senate,,independent,"Orman, Greg",48,000010
+SALINE,Cambria Township,United States Senate,,Libertarian,"Batson, Randall",10,000010
+SALINE,Cambria Township,United States Senate,,Republican,"Roberts, Pat",101,000010
+SALINE,Dayton Township,United States Senate,,independent,"Orman, Greg",13,000020
+SALINE,Dayton Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+SALINE,Dayton Township,United States Senate,,Republican,"Roberts, Pat",29,000020
+SALINE,Eureka Township,United States Senate,,independent,"Orman, Greg",65,000040
+SALINE,Eureka Township,United States Senate,,Libertarian,"Batson, Randall",10,000040
+SALINE,Eureka Township,United States Senate,,Republican,"Roberts, Pat",143,000040
+SALINE,Falun Township,United States Senate,,independent,"Orman, Greg",25,000050
+SALINE,Falun Township,United States Senate,,Libertarian,"Batson, Randall",11,000050
+SALINE,Falun Township,United States Senate,,Republican,"Roberts, Pat",72,000050
+SALINE,Glendale Township,United States Senate,,independent,"Orman, Greg",7,000060
+SALINE,Glendale Township,United States Senate,,Libertarian,"Batson, Randall",3,000060
+SALINE,Glendale Township,United States Senate,,Republican,"Roberts, Pat",27,000060
+SALINE,Greeley Township,United States Senate,,independent,"Orman, Greg",93,000070
+SALINE,Greeley Township,United States Senate,,Libertarian,"Batson, Randall",15,000070
+SALINE,Greeley Township,United States Senate,,Republican,"Roberts, Pat",278,000070
+SALINE,Gypsum Township,United States Senate,,independent,"Orman, Greg",10,000080
+SALINE,Gypsum Township,United States Senate,,Libertarian,"Batson, Randall",4,000080
+SALINE,Gypsum Township,United States Senate,,Republican,"Roberts, Pat",54,000080
+SALINE,Liberty Township,United States Senate,,independent,"Orman, Greg",15,000090
+SALINE,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",7,000090
+SALINE,Liberty Township,United States Senate,,Republican,"Roberts, Pat",58,000090
+SALINE,Ohio Township,United States Senate,,independent,"Orman, Greg",41,000100
+SALINE,Ohio Township,United States Senate,,Libertarian,"Batson, Randall",24,000100
+SALINE,Ohio Township,United States Senate,,Republican,"Roberts, Pat",107,000100
+SALINE,Pleasant Valley Township,United States Senate,,independent,"Orman, Greg",34,000110
+SALINE,Pleasant Valley Township,United States Senate,,Libertarian,"Batson, Randall",11,000110
+SALINE,Pleasant Valley Township,United States Senate,,Republican,"Roberts, Pat",102,000110
+SALINE,Salina Precinct 01 Part A,United States Senate,,independent,"Orman, Greg",109,00012A
+SALINE,Salina Precinct 01 Part A,United States Senate,,Libertarian,"Batson, Randall",23,00012A
+SALINE,Salina Precinct 01 Part A,United States Senate,,Republican,"Roberts, Pat",105,00012A
+SALINE,Salina Precinct 02,United States Senate,,independent,"Orman, Greg",105,00013A
+SALINE,Salina Precinct 02,United States Senate,,Libertarian,"Batson, Randall",28,00013A
+SALINE,Salina Precinct 02,United States Senate,,Republican,"Roberts, Pat",110,00013A
+SALINE,Salina Precinct 03,United States Senate,,independent,"Orman, Greg",86,000140
+SALINE,Salina Precinct 03,United States Senate,,Libertarian,"Batson, Randall",19,000140
+SALINE,Salina Precinct 03,United States Senate,,Republican,"Roberts, Pat",73,000140
+SALINE,Salina Precinct 04,United States Senate,,independent,"Orman, Greg",140,000150
+SALINE,Salina Precinct 04,United States Senate,,Libertarian,"Batson, Randall",30,000150
+SALINE,Salina Precinct 04,United States Senate,,Republican,"Roberts, Pat",101,000150
+SALINE,Salina Precinct 05,United States Senate,,independent,"Orman, Greg",116,000160
+SALINE,Salina Precinct 05,United States Senate,,Libertarian,"Batson, Randall",19,000160
+SALINE,Salina Precinct 05,United States Senate,,Republican,"Roberts, Pat",113,000160
+SALINE,Salina Precinct 06,United States Senate,,independent,"Orman, Greg",94,000170
+SALINE,Salina Precinct 06,United States Senate,,Libertarian,"Batson, Randall",17,000170
+SALINE,Salina Precinct 06,United States Senate,,Republican,"Roberts, Pat",89,000170
+SALINE,Salina Precinct 07,United States Senate,,independent,"Orman, Greg",149,000180
+SALINE,Salina Precinct 07,United States Senate,,Libertarian,"Batson, Randall",28,000180
+SALINE,Salina Precinct 07,United States Senate,,Republican,"Roberts, Pat",126,000180
+SALINE,Salina Precinct 08,United States Senate,,independent,"Orman, Greg",144,000190
+SALINE,Salina Precinct 08,United States Senate,,Libertarian,"Batson, Randall",12,000190
+SALINE,Salina Precinct 08,United States Senate,,Republican,"Roberts, Pat",129,000190
+SALINE,Salina Precinct 09,United States Senate,,independent,"Orman, Greg",140,000200
+SALINE,Salina Precinct 09,United States Senate,,Libertarian,"Batson, Randall",28,000200
+SALINE,Salina Precinct 09,United States Senate,,Republican,"Roberts, Pat",145,000200
+SALINE,Salina Precinct 10,United States Senate,,independent,"Orman, Greg",139,000210
+SALINE,Salina Precinct 10,United States Senate,,Libertarian,"Batson, Randall",18,000210
+SALINE,Salina Precinct 10,United States Senate,,Republican,"Roberts, Pat",140,000210
+SALINE,Salina Precinct 11,United States Senate,,independent,"Orman, Greg",96,000220
+SALINE,Salina Precinct 11,United States Senate,,Libertarian,"Batson, Randall",25,000220
+SALINE,Salina Precinct 11,United States Senate,,Republican,"Roberts, Pat",141,000220
+SALINE,Salina Precinct 12,United States Senate,,independent,"Orman, Greg",209,000230
+SALINE,Salina Precinct 12,United States Senate,,Libertarian,"Batson, Randall",21,000230
+SALINE,Salina Precinct 12,United States Senate,,Republican,"Roberts, Pat",192,000230
+SALINE,Salina Precinct 13,United States Senate,,independent,"Orman, Greg",101,000240
+SALINE,Salina Precinct 13,United States Senate,,Libertarian,"Batson, Randall",18,000240
+SALINE,Salina Precinct 13,United States Senate,,Republican,"Roberts, Pat",130,000240
+SALINE,Salina Precinct 14 Part A,United States Senate,,independent,"Orman, Greg",147,00025A
+SALINE,Salina Precinct 14 Part A,United States Senate,,Libertarian,"Batson, Randall",28,00025A
+SALINE,Salina Precinct 14 Part A,United States Senate,,Republican,"Roberts, Pat",178,00025A
+SALINE,Salina Precinct 15 Part A,United States Senate,,independent,"Orman, Greg",144,00026A
+SALINE,Salina Precinct 15 Part A,United States Senate,,Libertarian,"Batson, Randall",19,00026A
+SALINE,Salina Precinct 15 Part A,United States Senate,,Republican,"Roberts, Pat",123,00026A
+SALINE,Salina Precinct 16,United States Senate,,independent,"Orman, Greg",89,000270
+SALINE,Salina Precinct 16,United States Senate,,Libertarian,"Batson, Randall",18,000270
+SALINE,Salina Precinct 16,United States Senate,,Republican,"Roberts, Pat",112,000270
+SALINE,Salina Precinct 17,United States Senate,,independent,"Orman, Greg",114,000280
+SALINE,Salina Precinct 17,United States Senate,,Libertarian,"Batson, Randall",18,000280
+SALINE,Salina Precinct 17,United States Senate,,Republican,"Roberts, Pat",128,000280
+SALINE,Salina Precinct 18,United States Senate,,independent,"Orman, Greg",125,000290
+SALINE,Salina Precinct 18,United States Senate,,Libertarian,"Batson, Randall",22,000290
+SALINE,Salina Precinct 18,United States Senate,,Republican,"Roberts, Pat",157,000290
+SALINE,Salina Precinct 19,United States Senate,,independent,"Orman, Greg",160,000300
+SALINE,Salina Precinct 19,United States Senate,,Libertarian,"Batson, Randall",11,000300
+SALINE,Salina Precinct 19,United States Senate,,Republican,"Roberts, Pat",264,000300
+SALINE,Salina Precinct 20 Part A,United States Senate,,independent,"Orman, Greg",394,00031A
+SALINE,Salina Precinct 20 Part A,United States Senate,,Libertarian,"Batson, Randall",41,00031A
+SALINE,Salina Precinct 20 Part A,United States Senate,,Republican,"Roberts, Pat",575,00031A
+SALINE,Salina Precinct 21 Part A,United States Senate,,independent,"Orman, Greg",320,00032A
+SALINE,Salina Precinct 21 Part A,United States Senate,,Libertarian,"Batson, Randall",20,00032A
+SALINE,Salina Precinct 21 Part A,United States Senate,,Republican,"Roberts, Pat",514,00032A
+SALINE,Salina Precinct 22 Part A,United States Senate,,independent,"Orman, Greg",235,00033A
+SALINE,Salina Precinct 22 Part A,United States Senate,,Libertarian,"Batson, Randall",18,00033A
+SALINE,Salina Precinct 22 Part A,United States Senate,,Republican,"Roberts, Pat",432,00033A
+SALINE,Salina Precinct 23,United States Senate,,independent,"Orman, Greg",379,000340
+SALINE,Salina Precinct 23,United States Senate,,Libertarian,"Batson, Randall",42,000340
+SALINE,Salina Precinct 23,United States Senate,,Republican,"Roberts, Pat",479,000340
+SALINE,Salina Precinct 24,United States Senate,,independent,"Orman, Greg",121,000350
+SALINE,Salina Precinct 24,United States Senate,,Libertarian,"Batson, Randall",19,000350
+SALINE,Salina Precinct 24,United States Senate,,Republican,"Roberts, Pat",170,000350
+SALINE,Salina Precinct 25,United States Senate,,independent,"Orman, Greg",89,000360
+SALINE,Salina Precinct 25,United States Senate,,Libertarian,"Batson, Randall",13,000360
+SALINE,Salina Precinct 25,United States Senate,,Republican,"Roberts, Pat",109,000360
+SALINE,Salina Precinct 26,United States Senate,,independent,"Orman, Greg",139,000370
+SALINE,Salina Precinct 26,United States Senate,,Libertarian,"Batson, Randall",23,000370
+SALINE,Salina Precinct 26,United States Senate,,Republican,"Roberts, Pat",142,000370
+SALINE,Salina Precinct 27,United States Senate,,independent,"Orman, Greg",155,000380
+SALINE,Salina Precinct 27,United States Senate,,Libertarian,"Batson, Randall",21,000380
+SALINE,Salina Precinct 27,United States Senate,,Republican,"Roberts, Pat",228,000380
+SALINE,Salina Precinct 28,United States Senate,,independent,"Orman, Greg",95,000390
+SALINE,Salina Precinct 28,United States Senate,,Libertarian,"Batson, Randall",20,000390
+SALINE,Salina Precinct 28,United States Senate,,Republican,"Roberts, Pat",160,000390
+SALINE,Salina Precinct 29,United States Senate,,independent,"Orman, Greg",167,000400
+SALINE,Salina Precinct 29,United States Senate,,Libertarian,"Batson, Randall",20,000400
+SALINE,Salina Precinct 29,United States Senate,,Republican,"Roberts, Pat",254,000400
+SALINE,Salina Precinct 30,United States Senate,,independent,"Orman, Greg",156,000410
+SALINE,Salina Precinct 30,United States Senate,,Libertarian,"Batson, Randall",13,000410
+SALINE,Salina Precinct 30,United States Senate,,Republican,"Roberts, Pat",212,000410
+SALINE,Salina Precinct 31 Part A,United States Senate,,independent,"Orman, Greg",350,00042A
+SALINE,Salina Precinct 31 Part A,United States Senate,,Libertarian,"Batson, Randall",48,00042A
+SALINE,Salina Precinct 31 Part A,United States Senate,,Republican,"Roberts, Pat",557,00042A
+SALINE,Salina Precinct 32,United States Senate,,independent,"Orman, Greg",94,000430
+SALINE,Salina Precinct 32,United States Senate,,Libertarian,"Batson, Randall",15,000430
+SALINE,Salina Precinct 32,United States Senate,,Republican,"Roberts, Pat",150,000430
+SALINE,Salina Precinct 33,United States Senate,,independent,"Orman, Greg",206,000440
+SALINE,Salina Precinct 33,United States Senate,,Libertarian,"Batson, Randall",21,000440
+SALINE,Salina Precinct 33,United States Senate,,Republican,"Roberts, Pat",300,000440
+SALINE,Salina Precinct 34,United States Senate,,independent,"Orman, Greg",321,000450
+SALINE,Salina Precinct 34,United States Senate,,Libertarian,"Batson, Randall",58,000450
+SALINE,Salina Precinct 34,United States Senate,,Republican,"Roberts, Pat",459,000450
+SALINE,Salina Precinct 35,United States Senate,,independent,"Orman, Greg",214,00046A
+SALINE,Salina Precinct 35,United States Senate,,Libertarian,"Batson, Randall",36,00046A
+SALINE,Salina Precinct 35,United States Senate,,Republican,"Roberts, Pat",268,00046A
+SALINE,Smokey Hill Township Part B,United States Senate,,independent,"Orman, Greg",31,00047B
+SALINE,Smokey Hill Township Part B,United States Senate,,Libertarian,"Batson, Randall",5,00047B
+SALINE,Smokey Hill Township Part B,United States Senate,,Republican,"Roberts, Pat",68,00047B
+SALINE,Smoky View Township,United States Senate,,independent,"Orman, Greg",105,000480
+SALINE,Smoky View Township,United States Senate,,Libertarian,"Batson, Randall",26,000480
+SALINE,Smoky View Township,United States Senate,,Republican,"Roberts, Pat",199,000480
+SALINE,Smolan Township,United States Senate,,independent,"Orman, Greg",95,000490
+SALINE,Smolan Township,United States Senate,,Libertarian,"Batson, Randall",12,000490
+SALINE,Smolan Township,United States Senate,,Republican,"Roberts, Pat",192,000490
+SALINE,Solomon Township,United States Senate,,independent,"Orman, Greg",43,000500
+SALINE,Solomon Township,United States Senate,,Libertarian,"Batson, Randall",5,000500
+SALINE,Solomon Township,United States Senate,,Republican,"Roberts, Pat",139,000500
+SALINE,Spring Creek Township,United States Senate,,independent,"Orman, Greg",47,000510
+SALINE,Spring Creek Township,United States Senate,,Libertarian,"Batson, Randall",10,000510
+SALINE,Spring Creek Township,United States Senate,,Republican,"Roberts, Pat",101,000510
+SALINE,Walnut Township,United States Senate,,independent,"Orman, Greg",73,000520
+SALINE,Walnut Township,United States Senate,,Libertarian,"Batson, Randall",7,000520
+SALINE,Walnut Township,United States Senate,,Republican,"Roberts, Pat",164,000520
+SALINE,Elm Creek Township H69,United States Senate,,independent,"Orman, Greg",115,120020
+SALINE,Elm Creek Township H69,United States Senate,,Libertarian,"Batson, Randall",21,120020
+SALINE,Elm Creek Township H69,United States Senate,,Republican,"Roberts, Pat",246,120020
+SALINE,Elm Creek Township H71,United States Senate,,independent,"Orman, Greg",0,120030
+SALINE,Elm Creek Township H71,United States Senate,,Libertarian,"Batson, Randall",0,120030
+SALINE,Elm Creek Township H71,United States Senate,,Republican,"Roberts, Pat",0,120030
+SALINE,Washington Township,United States Senate,,independent,"Orman, Greg",18,300010
+SALINE,Washington Township,United States Senate,,Libertarian,"Batson, Randall",3,300010
+SALINE,Washington Township,United States Senate,,Republican,"Roberts, Pat",49,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States Senate,,independent,"Orman, Greg",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,United States Senate,,independent,"Orman, Greg",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,United States Senate,,independent,"Orman, Greg",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,United States Senate,,independent,"Orman, Greg",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,United States Senate,,independent,"Orman, Greg",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States Senate,,Libertarian,"Batson, Randall",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States Senate,,Republican,"Roberts, Pat",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,United States Senate,,independent,"Orman, Greg",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States Senate,,Libertarian,"Batson, Randall",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States Senate,,Republican,"Roberts, Pat",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,United States Senate,,independent,"Orman, Greg",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States Senate,,Republican,"Roberts, Pat",0,900070
+SALINE,Salina Precinct 33 Exclave,United States Senate,,independent,"Orman, Greg",0,900080
+SALINE,Salina Precinct 33 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900080
+SALINE,Salina Precinct 33 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900080
+SALINE,Salina Precinct 35 Exclave,United States Senate,,independent,"Orman, Greg",0,900090
+SALINE,Salina Precinct 35 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900090
+SALINE,Salina Precinct 35 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,United States Senate,,independent,"Orman, Greg",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,United States Senate,,independent,"Orman, Greg",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States Senate,,Republican,"Roberts, Pat",0,900110

--- a/2014/20141104__ks__general__scott__precinct.csv
+++ b/2014/20141104__ks__general__scott__precinct.csv
@@ -1,258 +1,188 @@
-county,precinct,office,district,party,candidate,votes
-Scott,Ward 1,U.S. Senate,,R,Pat Roberts,159
-Scott,Ward 2,U.S. Senate,,R,Pat Roberts,366
-Scott,Ward 3,U.S. Senate,,R,Pat Roberts,227
-Scott,Ward 4,U.S. Senate,,R,Pat Roberts,268
-Scott,Beaver,U.S. Senate,,R,Pat Roberts,63
-Scott,Isbel,U.S. Senate,,R,Pat Roberts,34
-Scott,Keystone,U.S. Senate,,R,Pat Roberts,35
-Scott,Lake,U.S. Senate,,R,Pat Roberts,25
-Scott,Michigan,U.S. Senate,,R,Pat Roberts,29
-Scott,Scott,U.S. Senate,,R,Pat Roberts,88
-Scott,Valley,U.S. Senate,,R,Pat Roberts,69
-Scott,Ward 1,U.S. Senate,,I,Greg Orman,43
-Scott,Ward 2,U.S. Senate,,I,Greg Orman,62
-Scott,Ward 3,U.S. Senate,,I,Greg Orman,58
-Scott,Ward 4,U.S. Senate,,I,Greg Orman,81
-Scott,Beaver,U.S. Senate,,I,Greg Orman,16
-Scott,Isbel,U.S. Senate,,I,Greg Orman,7
-Scott,Keystone,U.S. Senate,,I,Greg Orman,1
-Scott,Lake,U.S. Senate,,I,Greg Orman,0
-Scott,Michigan,U.S. Senate,,I,Greg Orman,2
-Scott,Scott,U.S. Senate,,I,Greg Orman,16
-Scott,Valley,U.S. Senate,,I,Greg Orman,10
-Scott,Ward 1,U.S. Senate,,L,Randall Batson,18
-Scott,Ward 2,U.S. Senate,,L,Randall Batson,12
-Scott,Ward 3,U.S. Senate,,L,Randall Batson,19
-Scott,Ward 4,U.S. Senate,,L,Randall Batson,19
-Scott,Beaver,U.S. Senate,,L,Randall Batson,1
-Scott,Isbel,U.S. Senate,,L,Randall Batson,2
-Scott,Keystone,U.S. Senate,,L,Randall Batson,2
-Scott,Lake,U.S. Senate,,L,Randall Batson,0
-Scott,Michigan,U.S. Senate,,L,Randall Batson,1
-Scott,Scott,U.S. Senate,,L,Randall Batson,4
-Scott,Valley,U.S. Senate,,L,Randall Batson,2
-Scott,Ward 1,U.S. Senate,,R,Pat Roberts,139
-Scott,Ward 2,U.S. Senate,,R,Pat Roberts,294
-Scott,Ward 3,U.S. Senate,,R,Pat Roberts,190
-Scott,Ward 4,U.S. Senate,,R,Pat Roberts,216
-Scott,Beaver,U.S. Senate,,R,Pat Roberts,45
-Scott,Isbel,U.S. Senate,,R,Pat Roberts,25
-Scott,Keystone,U.S. Senate,,R,Pat Roberts,27
-Scott,Lake,U.S. Senate,,R,Pat Roberts,25
-Scott,Michigan,U.S. Senate,,R,Pat Roberts,22
-Scott,Scott,U.S. Senate,,R,Pat Roberts,77
-Scott,Valley,U.S. Senate,,R,Pat Roberts,54
-Scott,Absentee,U.S. Senate,,R,Pat Roberts,232
-Scott,Provisional,U.S. Senate,,R,Pat Roberts,15
-Scott,Ward 1,U.S. Senate,,I,Greg Orman,35
-Scott,Ward 2,U.S. Senate,,I,Greg Orman,56
-Scott,Ward 3,U.S. Senate,,I,Greg Orman,50
-Scott,Ward 4,U.S. Senate,,I,Greg Orman,46
-Scott,Beaver,U.S. Senate,,I,Greg Orman,10
-Scott,Isbel,U.S. Senate,,I,Greg Orman,2
-Scott,Keystone,U.S. Senate,,I,Greg Orman,2
-Scott,Lake,U.S. Senate,,I,Greg Orman,0
-Scott,Michigan,U.S. Senate,,I,Greg Orman,1
-Scott,Scott,U.S. Senate,,I,Greg Orman,14
-Scott,Valley,U.S. Senate,,I,Greg Orman,8
-Scott,Absentee,U.S. Senate,,I,Greg Orman,64
-Scott,Provisional,U.S. Senate,,I,Greg Orman,5
-Scott,Ward 1,U.S. Senate,,L,Randall Batson,15
-Scott,Ward 2,U.S. Senate,,L,Randall Batson,11
-Scott,Ward 3,U.S. Senate,,L,Randall Batson,11
-Scott,Ward 4,U.S. Senate,,L,Randall Batson,17
-Scott,Beaver,U.S. Senate,,L,Randall Batson,1
-Scott,Isbel,U.S. Senate,,L,Randall Batson,7
-Scott,Keystone,U.S. Senate,,L,Randall Batson,1
-Scott,Lake,U.S. Senate,,L,Randall Batson,0
-Scott,Michigan,U.S. Senate,,L,Randall Batson,1
-Scott,Scott,U.S. Senate,,L,Randall Batson,4
-Scott,Valley,U.S. Senate,,L,Randall Batson,2
-Scott,Absentee,U.S. Senate,,L,Randall Batson,14
-Scott,Provisional,U.S. Senate,,L,Randall Batson,1
-Scott,Isbel,U.S. Senate,,,Joshua Sauer [wri],1
-Scott,Ward 1,U.S. House,,R,Tim Huelskamp,146
-Scott,Ward 2,U.S. House,,R,Tim Huelskamp,306
-Scott,Ward 3,U.S. House,,R,Tim Huelskamp,197
-Scott,Ward 4,U.S. House,,R,Tim Huelskamp,227
-Scott,Beaver,U.S. House,,R,Tim Huelskamp,46
-Scott,Isbel,U.S. House,,R,Tim Huelskamp,31
-Scott,Keystone,U.S. House,,R,Tim Huelskamp,28
-Scott,Lake,U.S. House,,R,Tim Huelskamp,22
-Scott,Michigan,U.S. House,,R,Tim Huelskamp,24
-Scott,Scott,U.S. House,,R,Tim Huelskamp,75
-Scott,Valley,U.S. House,,R,Tim Huelskamp,52
-Scott,Absentee,U.S. House,,R,Tim Huelskamp,196
-Scott,Provisional,U.S. House,,R,Tim Huelskamp,18
-Scott,Ward 1,U.S. House,,D,James Sherow,38
-Scott,Ward 2,U.S. House,,D,James Sherow,59
-Scott,Ward 3,U.S. House,,D,James Sherow,51
-Scott,Ward 4,U.S. House,,D,James Sherow,55
-Scott,Beaver,U.S. House,,D,James Sherow,9
-Scott,Isbel,U.S. House,,D,James Sherow,3
-Scott,Keystone,U.S. House,,D,James Sherow,2
-Scott,Lake,U.S. House,,D,James Sherow,4
-Scott,Michigan,U.S. House,,D,James Sherow,20
-Scott,Scott,U.S. House,,D,James Sherow,18
-Scott,Valley,U.S. House,,D,James Sherow,9
-Scott,Absentee,U.S. House,,D,James Sherow,65
-Scott,Provisional,U.S. House,,D,James Sherow,3
-Scott,Ward 1,Governor,,R,Sam Brownback,127
-Scott,Ward 2,Governor,,R,Sam Brownback,278
-Scott,Ward 3,Governor,,R,Sam Brownback,173
-Scott,Ward 4,Governor,,R,Sam Brownback,200
-Scott,Beaver,Governor,,R,Sam Brownback,45
-Scott,Isbel,Governor,,R,Sam Brownback,23
-Scott,Keystone,Governor,,R,Sam Brownback,26
-Scott,Lake,Governor,,R,Sam Brownback,24
-Scott,Michigan,Governor,,R,Sam Brownback,19
-Scott,Scott,Governor,,R,Sam Brownback,72
-Scott,Valley,Governor,,R,Sam Brownback,55
-Scott,Absentee,Governor,,R,Sam Brownback,213
-Scott,Provisional,Governor,,R,Sam Brownback,12
-Scott,Ward 1,Governor,,D,Paul Davis,44
-Scott,Ward 2,Governor,,D,Paul Davis,79
-Scott,Ward 3,Governor,,D,Paul Davis,69
-Scott,Ward 4,Governor,,D,Paul Davis,65
-Scott,Beaver,Governor,,D,Paul Davis,8
-Scott,Isbel,Governor,,D,Paul Davis,9
-Scott,Keystone,Governor,,D,Paul Davis,2
-Scott,Lake,Governor,,D,Paul Davis,1
-Scott,Michigan,Governor,,D,Paul Davis,3
-Scott,Scott,Governor,,D,Paul Davis,15
-Scott,Valley,Governor,,D,Paul Davis,8
-Scott,Absentee,Governor,,D,Paul Davis,74
-Scott,Provisional,Governor,,D,Paul Davis,7
-Scott,Ward 1,Governor,,L,Keen Umbehr,18
-Scott,Ward 2,Governor,,L,Keen Umbehr,9
-Scott,Ward 3,Governor,,L,Keen Umbehr,7
-Scott,Ward 4,Governor,,L,Keen Umbehr,12
-Scott,Beaver,Governor,,L,Keen Umbehr,2
-Scott,Isbel,Governor,,L,Keen Umbehr,2
-Scott,Keystone,Governor,,L,Keen Umbehr,0
-Scott,Lake,Governor,,L,Keen Umbehr,0
-Scott,Michigan,Governor,,L,Keen Umbehr,2
-Scott,Scott,Governor,,L,Keen Umbehr,6
-Scott,Valley,Governor,,L,Keen Umbehr,1
-Scott,Absentee,Governor,,L,Keen Umbehr,11
-Scott,Provisional,Governor,,L,Keen Umbehr,2
-Scott,Ward 1,Secretary of State,,R,Kris Kobach,145
-Scott,Ward 2,Secretary of State,,R,Kris Kobach,313
-Scott,Ward 3,Secretary of State,,R,Kris Kobach,196
-Scott,Ward 4,Secretary of State,,R,Kris Kobach,231
-Scott,Beaver,Secretary of State,,R,Kris Kobach,46
-Scott,Isbel,Secretary of State,,R,Kris Kobach,27
-Scott,Keystone,Secretary of State,,R,Kris Kobach,29
-Scott,Lake,Secretary of State,,R,Kris Kobach,25
-Scott,Michigan,Secretary of State,,R,Kris Kobach,23
-Scott,Scott,Secretary of State,,R,Kris Kobach,81
-Scott,Valley,Secretary of State,,R,Kris Kobach,56
-Scott,Absentee,Secretary of State,,R,Kris Kobach,240
-Scott,Provisional,Secretary of State,,R,Kris Kobach,18
-Scott,Ward 1,Secretary of State,,D,Jean Schodorf,41
-Scott,Ward 2,Secretary of State,,D,Jean Schodorf,52
-Scott,Ward 3,Secretary of State,,D,Jean Schodorf,54
-Scott,Ward 4,Secretary of State,,D,Jean Schodorf,51
-Scott,Beaver,Secretary of State,,D,Jean Schodorf,9
-Scott,Isbel,Secretary of State,,D,Jean Schodorf,7
-Scott,Keystone,Secretary of State,,D,Jean Schodorf,1
-Scott,Lake,Secretary of State,,D,Jean Schodorf,1
-Scott,Michigan,Secretary of State,,D,Jean Schodorf,1
-Scott,Scott,Secretary of State,,D,Jean Schodorf,14
-Scott,Valley,Secretary of State,,D,Jean Schodorf,7
-Scott,Absentee,Secretary of State,,D,Jean Schodorf,58
-Scott,Provisional,Secretary of State,,D,Jean Schodorf,3
-Scott,Ward 1,Attorney General,,R,Derek Schmidt,155
-Scott,Ward 2,Attorney General,,R,Derek Schmidt,333
-Scott,Ward 3,Attorney General,,R,Derek Schmidt,214
-Scott,Ward 4,Attorney General,,R,Derek Schmidt,245
-Scott,Beaver,Attorney General,,R,Derek Schmidt,50
-Scott,Isbel,Attorney General,,R,Derek Schmidt,27
-Scott,Keystone,Attorney General,,R,Derek Schmidt,30
-Scott,Lake,Attorney General,,R,Derek Schmidt,25
-Scott,Michigan,Attorney General,,R,Derek Schmidt,23
-Scott,Scott,Attorney General,,R,Derek Schmidt,85
-Scott,Valley,Attorney General,,R,Derek Schmidt,55
-Scott,Absentee,Attorney General,,R,Derek Schmidt,262
-Scott,Provisional,Attorney General,,R,Derek Schmidt,17
-Scott,Ward 1,Attorney General,,D,A J Kotich,28
-Scott,Ward 2,Attorney General,,D,A J Kotich,31
-Scott,Ward 3,Attorney General,,D,A J Kotich,27
-Scott,Ward 4,Attorney General,,D,A J Kotich,33
-Scott,Beaver,Attorney General,,D,A J Kotich,5
-Scott,Isbel,Attorney General,,D,A J Kotich,5
-Scott,Keystone,Attorney General,,D,A J Kotich,0
-Scott,Lake,Attorney General,,D,A J Kotich,1
-Scott,Michigan,Attorney General,,D,A J Kotich,1
-Scott,Scott,Attorney General,,D,A J Kotich,7
-Scott,Valley,Attorney General,,D,A J Kotich,7
-Scott,Absentee,Attorney General,,D,A J Kotich,27
-Scott,Provisional,Attorney General,,D,A J Kotich,3
-Scott,Ward 1,State Treasurer,,R,Ron Estes,157
-Scott,Ward 2,State Treasurer,,R,Ron Estes,335
-Scott,Ward 3,State Treasurer,,R,Ron Estes,220
-Scott,Ward 4,State Treasurer,,R,Ron Estes,260
-Scott,Beaver,State Treasurer,,R,Ron Estes,51
-Scott,Isbel,State Treasurer,,R,Ron Estes,30
-Scott,Keystone,State Treasurer,,R,Ron Estes,29
-Scott,Lake,State Treasurer,,R,Ron Estes,26
-Scott,Michigan,State Treasurer,,R,Ron Estes,23
-Scott,Scott,State Treasurer,,R,Ron Estes,87
-Scott,Valley,State Treasurer,,R,Ron Estes,56
-Scott,Absentee,State Treasurer,,R,Ron Estes,256
-Scott,Provisional,State Treasurer,,R,Ron Estes,20
-Scott,Ward 1,State Treasurer,,D,Carmen Alldritt,25
-Scott,Ward 2,State Treasurer,,D,Carmen Alldritt,29
-Scott,Ward 3,State Treasurer,,D,Carmen Alldritt,24
-Scott,Ward 4,State Treasurer,,D,Carmen Alldritt,22
-Scott,Beaver,State Treasurer,,D,Carmen Alldritt,4
-Scott,Isbel,State Treasurer,,D,Carmen Alldritt,3
-Scott,Keystone,State Treasurer,,D,Carmen Alldritt,1
-Scott,Lake,State Treasurer,,D,Carmen Alldritt,0
-Scott,Michigan,State Treasurer,,D,Carmen Alldritt,1
-Scott,Scott,State Treasurer,,D,Carmen Alldritt,4
-Scott,Valley,State Treasurer,,D,Carmen Alldritt,6
-Scott,Absentee,State Treasurer,,D,Carmen Alldritt,35
-Scott,Provisional,State Treasurer,,D,Carmen Alldritt,1
-Scott,Ward 1,Insurance Commissioner,,R,Ken Selzer,152
-Scott,Ward 2,Insurance Commissioner,,R,Ken Selzer,324
-Scott,Ward 3,Insurance Commissioner,,R,Ken Selzer,220
-Scott,Ward 4,Insurance Commissioner,,R,Ken Selzer,245
-Scott,Beaver,Insurance Commissioner,,R,Ken Selzer,48
-Scott,Isbel,Insurance Commissioner,,R,Ken Selzer,28
-Scott,Keystone,Insurance Commissioner,,R,Ken Selzer,29
-Scott,Lake,Insurance Commissioner,,R,Ken Selzer,23
-Scott,Michigan,Insurance Commissioner,,R,Ken Selzer,23
-Scott,Scott,Insurance Commissioner,,R,Ken Selzer,82
-Scott,Valley,Insurance Commissioner,,R,Ken Selzer,53
-Scott,Absentee,Insurance Commissioner,,R,Ken Selzer,241
-Scott,Provisional,Insurance Commissioner,,R,Ken Selzer,17
-Scott,Ward 1,Insurance Commissioner,,D,Dennis Anderson,29
-Scott,Ward 2,Insurance Commissioner,,D,Dennis Anderson,34
-Scott,Ward 3,Insurance Commissioner,,D,Dennis Anderson,28
-Scott,Ward 4,Insurance Commissioner,,D,Dennis Anderson,31
-Scott,Beaver,Insurance Commissioner,,D,Dennis Anderson,6
-Scott,Isbel,Insurance Commissioner,,D,Dennis Anderson,5
-Scott,Keystone,Insurance Commissioner,,D,Dennis Anderson,1
-Scott,Lake,Insurance Commissioner,,D,Dennis Anderson,1
-Scott,Michigan,Insurance Commissioner,,D,Dennis Anderson,1
-Scott,Scott,Insurance Commissioner,,D,Dennis Anderson,7
-Scott,Valley,Insurance Commissioner,,D,Dennis Anderson,7
-Scott,Absentee,Insurance Commissioner,,D,Dennis Anderson,49
-Scott,Provisional,Insurance Commissioner,,D,Dennis Anderson,2
-Scott,Ward 1,State House,118,R,Don Hineman,175
-Scott,Ward 2,State House,118,R,Don Hineman,353
-Scott,Ward 3,State House,118,R,Don Hineman,233
-Scott,Ward 4,State House,118,R,Don Hineman,266
-Scott,Beaver,State House,118,R,Don Hineman,51
-Scott,Isbel,State House,118,R,Don Hineman,33
-Scott,Keystone,State House,118,R,Don Hineman,30
-Scott,Lake,State House,118,R,Don Hineman,26
-Scott,Michigan,State House,118,R,Don Hineman,20
-Scott,Scott,State House,118,R,Don Hineman,88
-Scott,Valley,State House,118,R,Don Hineman,59
-Scott,Absentee,State House,118,R,Don Hineman,273
-Scott,Provisional,State House,118,R,Don Hineman,19
-Scott,Ward 3,State House,118,R,Rod Haseton,1
-Scott,Keystone,State House,118,R,Jeffrey Head,1
+county,precinct,office,district,party,candidate,votes,vtd
+SCOTT,Beaver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000010
+SCOTT,Beaver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+SCOTT,Beaver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",64,000010
+SCOTT,Isbel Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000020
+SCOTT,Isbel Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+SCOTT,Isbel Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000020
+SCOTT,Keystone Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000030
+SCOTT,Keystone Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+SCOTT,Keystone Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000030
+SCOTT,Lake Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000040
+SCOTT,Lake Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+SCOTT,Lake Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000040
+SCOTT,Michigan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000050
+SCOTT,Michigan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000050
+SCOTT,Michigan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000050
+SCOTT,Scott City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",54,000060
+SCOTT,Scott City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000060
+SCOTT,Scott City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",148,000060
+SCOTT,Scott City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000070
+SCOTT,Scott City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000070
+SCOTT,Scott City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",335,000070
+SCOTT,Scott City Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",80,000080
+SCOTT,Scott City Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000080
+SCOTT,Scott City Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",211,000080
+SCOTT,Scott City Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",97,000090
+SCOTT,Scott City Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000090
+SCOTT,Scott City Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",249,000090
+SCOTT,Scott Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,00010A
+SCOTT,Scott Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,00010A
+SCOTT,Scott Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",81,00010A
+SCOTT,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000110
+SCOTT,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000110
+SCOTT,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000110
+SCOTT,Beaver Township,Kansas House of Representatives,118,Republican,"Hineman, Don",64,000010
+SCOTT,Isbel Township,Kansas House of Representatives,118,Republican,"Hineman, Don",42,000020
+SCOTT,Keystone Township,Kansas House of Representatives,118,Republican,"Hineman, Don",38,000030
+SCOTT,Lake Township,Kansas House of Representatives,118,Republican,"Hineman, Don",26,000040
+SCOTT,Michigan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",28,000050
+SCOTT,Scott City Ward 1,Kansas House of Representatives,118,Republican,"Hineman, Don",203,000060
+SCOTT,Scott City Ward 2,Kansas House of Representatives,118,Republican,"Hineman, Don",420,000070
+SCOTT,Scott City Ward 3,Kansas House of Representatives,118,Republican,"Hineman, Don",285,000080
+SCOTT,Scott City Ward 4,Kansas House of Representatives,118,Republican,"Hineman, Don",345,000090
+SCOTT,Scott Township,Kansas House of Representatives,118,Republican,"Hineman, Don",103,00010A
+SCOTT,Valley Township,Kansas House of Representatives,118,Republican,"Hineman, Don",75,000110
+SCOTT,Beaver Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000010
+SCOTT,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000010
+SCOTT,Isbel Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000020
+SCOTT,Isbel Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000020
+SCOTT,Keystone Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000030
+SCOTT,Keystone Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000030
+SCOTT,Lake Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000040
+SCOTT,Lake Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000040
+SCOTT,Michigan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000050
+SCOTT,Michigan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000050
+SCOTT,Scott City Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",47,000060
+SCOTT,Scott City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",169,000060
+SCOTT,Scott City Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",69,000070
+SCOTT,Scott City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",369,000070
+SCOTT,Scott City Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",60,000080
+SCOTT,Scott City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",240,000080
+SCOTT,Scott City Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",83,000090
+SCOTT,Scott City Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",286,000090
+SCOTT,Scott Township,United States House of Representatives,1,Democratic,"Sherow, James E.",20,00010A
+SCOTT,Scott Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",88,00010A
+SCOTT,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000110
+SCOTT,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000110
+SCOTT,Beaver Township,Attorney General,,Democratic,"Kotich, A.J.",8,000010
+SCOTT,Beaver Township,Attorney General,,Republican,"Schmidt, Derek",70,000010
+SCOTT,Isbel Township,Attorney General,,Democratic,"Kotich, A.J.",5,000020
+SCOTT,Isbel Township,Attorney General,,Republican,"Schmidt, Derek",36,000020
+SCOTT,Keystone Township,Attorney General,,Democratic,"Kotich, A.J.",0,000030
+SCOTT,Keystone Township,Attorney General,,Republican,"Schmidt, Derek",38,000030
+SCOTT,Lake Township,Attorney General,,Democratic,"Kotich, A.J.",1,000040
+SCOTT,Lake Township,Attorney General,,Republican,"Schmidt, Derek",25,000040
+SCOTT,Michigan Township,Attorney General,,Democratic,"Kotich, A.J.",1,000050
+SCOTT,Michigan Township,Attorney General,,Republican,"Schmidt, Derek",31,000050
+SCOTT,Scott City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",31,000060
+SCOTT,Scott City Ward 1,Attorney General,,Republican,"Schmidt, Derek",182,000060
+SCOTT,Scott City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",33,000070
+SCOTT,Scott City Ward 2,Attorney General,,Republican,"Schmidt, Derek",401,000070
+SCOTT,Scott City Ward 3,Attorney General,,Democratic,"Kotich, A.J.",30,000080
+SCOTT,Scott City Ward 3,Attorney General,,Republican,"Schmidt, Derek",263,000080
+SCOTT,Scott City Ward 4,Attorney General,,Democratic,"Kotich, A.J.",49,000090
+SCOTT,Scott City Ward 4,Attorney General,,Republican,"Schmidt, Derek",311,000090
+SCOTT,Scott Township,Attorney General,,Democratic,"Kotich, A.J.",8,00010A
+SCOTT,Scott Township,Attorney General,,Republican,"Schmidt, Derek",99,00010A
+SCOTT,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",10,000110
+SCOTT,Valley Township,Attorney General,,Republican,"Schmidt, Derek",68,000110
+SCOTT,Beaver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000010
+SCOTT,Beaver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000010
+SCOTT,Isbel Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000020
+SCOTT,Isbel Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000020
+SCOTT,Keystone Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000030
+SCOTT,Keystone Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000030
+SCOTT,Lake Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000040
+SCOTT,Lake Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000040
+SCOTT,Michigan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000050
+SCOTT,Michigan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000050
+SCOTT,Scott City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",34,000060
+SCOTT,Scott City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",178,000060
+SCOTT,Scott City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000070
+SCOTT,Scott City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",390,000070
+SCOTT,Scott City Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",37,000080
+SCOTT,Scott City Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",259,000080
+SCOTT,Scott City Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000090
+SCOTT,Scott City Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",304,000090
+SCOTT,Scott Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,00010A
+SCOTT,Scott Township,Commissioner of Insurance,,Republican,"Selzer, Ken",96,00010A
+SCOTT,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000110
+SCOTT,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000110
+SCOTT,Beaver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000010
+SCOTT,Beaver Township,Secretary of State,,Republican,"Kobach, Kris",65,000010
+SCOTT,Isbel Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000020
+SCOTT,Isbel Township,Secretary of State,,Republican,"Kobach, Kris",35,000020
+SCOTT,Keystone Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000030
+SCOTT,Keystone Township,Secretary of State,,Republican,"Kobach, Kris",37,000030
+SCOTT,Lake Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000040
+SCOTT,Lake Township,Secretary of State,,Republican,"Kobach, Kris",25,000040
+SCOTT,Michigan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000050
+SCOTT,Michigan Township,Secretary of State,,Republican,"Kobach, Kris",30,000050
+SCOTT,Scott City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",50,000060
+SCOTT,Scott City Ward 1,Secretary of State,,Republican,"Kobach, Kris",167,000060
+SCOTT,Scott City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",60,000070
+SCOTT,Scott City Ward 2,Secretary of State,,Republican,"Kobach, Kris",376,000070
+SCOTT,Scott City Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",63,000080
+SCOTT,Scott City Ward 3,Secretary of State,,Republican,"Kobach, Kris",239,000080
+SCOTT,Scott City Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",76,000090
+SCOTT,Scott City Ward 4,Secretary of State,,Republican,"Kobach, Kris",293,000090
+SCOTT,Scott Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,00010A
+SCOTT,Scott Township,Secretary of State,,Republican,"Kobach, Kris",93,00010A
+SCOTT,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000110
+SCOTT,Valley Township,Secretary of State,,Republican,"Kobach, Kris",71,000110
+SCOTT,Beaver Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000010
+SCOTT,Beaver Township,State Treasurer,,Republican,"Estes, Ron",70,000010
+SCOTT,Isbel Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000020
+SCOTT,Isbel Township,State Treasurer,,Republican,"Estes, Ron",39,000020
+SCOTT,Keystone Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000030
+SCOTT,Keystone Township,State Treasurer,,Republican,"Estes, Ron",37,000030
+SCOTT,Lake Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+SCOTT,Lake Township,State Treasurer,,Republican,"Estes, Ron",26,000040
+SCOTT,Michigan Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000050
+SCOTT,Michigan Township,State Treasurer,,Republican,"Estes, Ron",31,000050
+SCOTT,Scott City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",27,000060
+SCOTT,Scott City Ward 1,State Treasurer,,Republican,"Estes, Ron",186,000060
+SCOTT,Scott City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",31,000070
+SCOTT,Scott City Ward 2,State Treasurer,,Republican,"Estes, Ron",403,000070
+SCOTT,Scott City Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",29,000080
+SCOTT,Scott City Ward 3,State Treasurer,,Republican,"Estes, Ron",267,000080
+SCOTT,Scott City Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",41,000090
+SCOTT,Scott City Ward 4,State Treasurer,,Republican,"Estes, Ron",325,000090
+SCOTT,Scott Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,00010A
+SCOTT,Scott Township,State Treasurer,,Republican,"Estes, Ron",101,00010A
+SCOTT,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000110
+SCOTT,Valley Township,State Treasurer,,Republican,"Estes, Ron",70,000110
+SCOTT,Beaver Township,United States Senate,,independent,"Orman, Greg",16,000010
+SCOTT,Beaver Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+SCOTT,Beaver Township,United States Senate,,Republican,"Roberts, Pat",63,000010
+SCOTT,Isbel Township,United States Senate,,independent,"Orman, Greg",7,000020
+SCOTT,Isbel Township,United States Senate,,Libertarian,"Batson, Randall",2,000020
+SCOTT,Isbel Township,United States Senate,,Republican,"Roberts, Pat",34,000020
+SCOTT,Keystone Township,United States Senate,,independent,"Orman, Greg",1,000030
+SCOTT,Keystone Township,United States Senate,,Libertarian,"Batson, Randall",2,000030
+SCOTT,Keystone Township,United States Senate,,Republican,"Roberts, Pat",35,000030
+SCOTT,Lake Township,United States Senate,,independent,"Orman, Greg",0,000040
+SCOTT,Lake Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+SCOTT,Lake Township,United States Senate,,Republican,"Roberts, Pat",25,000040
+SCOTT,Michigan Township,United States Senate,,independent,"Orman, Greg",2,000050
+SCOTT,Michigan Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+SCOTT,Michigan Township,United States Senate,,Republican,"Roberts, Pat",29,000050
+SCOTT,Scott City Ward 1,United States Senate,,independent,"Orman, Greg",43,000060
+SCOTT,Scott City Ward 1,United States Senate,,Libertarian,"Batson, Randall",18,000060
+SCOTT,Scott City Ward 1,United States Senate,,Republican,"Roberts, Pat",159,000060
+SCOTT,Scott City Ward 2,United States Senate,,independent,"Orman, Greg",62,000070
+SCOTT,Scott City Ward 2,United States Senate,,Libertarian,"Batson, Randall",12,000070
+SCOTT,Scott City Ward 2,United States Senate,,Republican,"Roberts, Pat",366,000070
+SCOTT,Scott City Ward 3,United States Senate,,independent,"Orman, Greg",58,000080
+SCOTT,Scott City Ward 3,United States Senate,,Libertarian,"Batson, Randall",19,000080
+SCOTT,Scott City Ward 3,United States Senate,,Republican,"Roberts, Pat",227,000080
+SCOTT,Scott City Ward 4,United States Senate,,independent,"Orman, Greg",81,000090
+SCOTT,Scott City Ward 4,United States Senate,,Libertarian,"Batson, Randall",19,000090
+SCOTT,Scott City Ward 4,United States Senate,,Republican,"Roberts, Pat",268,000090
+SCOTT,Scott Township,United States Senate,,independent,"Orman, Greg",16,00010A
+SCOTT,Scott Township,United States Senate,,Libertarian,"Batson, Randall",4,00010A
+SCOTT,Scott Township,United States Senate,,Republican,"Roberts, Pat",88,00010A
+SCOTT,Valley Township,United States Senate,,independent,"Orman, Greg",10,000110
+SCOTT,Valley Township,United States Senate,,Libertarian,"Batson, Randall",2,000110
+SCOTT,Valley Township,United States Senate,,Republican,"Roberts, Pat",69,000110

--- a/2014/20141104__ks__general__sedgwick__precinct.csv
+++ b/2014/20141104__ks__general__sedgwick__precinct.csv
@@ -1,5802 +1,1306 @@
-county,precinct,office,district,party,candidate,votes
-Sedgwick,101,Voters,,,Registered,1727
-Sedgwick,102,Voters,,,Registered,1126
-Sedgwick,103,Voters,,,Registered,193
-Sedgwick,104,Voters,,,Registered,96
-Sedgwick,105,Voters,,,Registered,983
-Sedgwick,106,Voters,,,Registered,2097
-Sedgwick,107,Voters,,,Registered,1785
-Sedgwick,108,Voters,,,Registered,1263
-Sedgwick,109,Voters,,,Registered,1848
-Sedgwick,110,Voters,,,Registered,1721
-Sedgwick,111,Voters,,,Registered,446
-Sedgwick,112,Voters,,,Registered,1739
-Sedgwick,113,Voters,,,Registered,1551
-Sedgwick,114,Voters,,,Registered,1503
-Sedgwick,116,Voters,,,Registered,2122
-Sedgwick,117,Voters,,,Registered,1855
-Sedgwick,118,Voters,,,Registered,1666
-Sedgwick,119,Voters,,,Registered,1444
-Sedgwick,120,Voters,,,Registered,1408
-Sedgwick,121,Voters,,,Registered,1088
-Sedgwick,122,Voters,,,Registered,2258
-Sedgwick,123,Voters,,,Registered,558
-Sedgwick,124,Voters,,,Registered,1
-Sedgwick,127,Voters,,,Registered,409
-Sedgwick,128,Voters,,,Registered,1363
-Sedgwick,129,Voters,,,Registered,518
-Sedgwick,130,Voters,,,Registered,1035
-Sedgwick,205,Voters,,,Registered,735
-Sedgwick,206,Voters,,,Registered,595
-Sedgwick,207,Voters,,,Registered,2888
-Sedgwick,208,Voters,,,Registered,536
-Sedgwick,209,Voters,,,Registered,1467
-Sedgwick,210,Voters,,,Registered,1923
-Sedgwick,211,Voters,,,Registered,929
-Sedgwick,212,Voters,,,Registered,1512
-Sedgwick,213,Voters,,,Registered,1788
-Sedgwick,214,Voters,,,Registered,1722
-Sedgwick,215,Voters,,,Registered,2367
-Sedgwick,216,Voters,,,Registered,1472
-Sedgwick,217,Voters,,,Registered,1751
-Sedgwick,218,Voters,,,Registered,2626
-Sedgwick,221,Voters,,,Registered,1081
-Sedgwick,222,Voters,,,Registered,1609
-Sedgwick,223,Voters,,,Registered,1845
-Sedgwick,224,Voters,,,Registered,2591
-Sedgwick,225,Voters,,,Registered,2374
-Sedgwick,226,Voters,,,Registered,2442
-Sedgwick,227,Voters,,,Registered,1266
-Sedgwick,228,Voters,,,Registered,1669
-Sedgwick,233,Voters,,,Registered,668
-Sedgwick,235,Voters,,,Registered,528
-Sedgwick,236,Voters,,,Registered,1225
-Sedgwick,239,Voters,,,Registered,37
-Sedgwick,241,Voters,,,Registered,435
-Sedgwick,301,Voters,,,Registered,851
-Sedgwick,302,Voters,,,Registered,1738
-Sedgwick,303,Voters,,,Registered,749
-Sedgwick,304,Voters,,,Registered,731
-Sedgwick,305,Voters,,,Registered,1989
-Sedgwick,306,Voters,,,Registered,2251
-Sedgwick,307,Voters,,,Registered,1296
-Sedgwick,308,Voters,,,Registered,1615
-Sedgwick,309,Voters,,,Registered,1808
-Sedgwick,310,Voters,,,Registered,1482
-Sedgwick,311,Voters,,,Registered,817
-Sedgwick,312,Voters,,,Registered,796
-Sedgwick,313,Voters,,,Registered,2056
-Sedgwick,314,Voters,,,Registered,1743
-Sedgwick,315,Voters,,,Registered,1627
-Sedgwick,316,Voters,,,Registered,1632
-Sedgwick,317,Voters,,,Registered,21
-Sedgwick,318,Voters,,,Registered,57
-Sedgwick,319,Voters,,,Registered,469
-Sedgwick,320,Voters,,,Registered,461
-Sedgwick,321,Voters,,,Registered,75
-Sedgwick,324,Voters,,,Registered,785
-Sedgwick,325,Voters,,,Registered,1369
-Sedgwick,326,Voters,,,Registered,146
-Sedgwick,401,Voters,,,Registered,888
-Sedgwick,402,Voters,,,Registered,736
-Sedgwick,403,Voters,,,Registered,1068
-Sedgwick,404,Voters,,,Registered,2203
-Sedgwick,405,Voters,,,Registered,1480
-Sedgwick,406,Voters,,,Registered,1466
-Sedgwick,407,Voters,,,Registered,190
-Sedgwick,408,Voters,,,Registered,1417
-Sedgwick,409,Voters,,,Registered,824
-Sedgwick,410,Voters,,,Registered,2264
-Sedgwick,412,Voters,,,Registered,2670
-Sedgwick,413,Voters,,,Registered,2039
-Sedgwick,414,Voters,,,Registered,404
-Sedgwick,416,Voters,,,Registered,1199
-Sedgwick,417,Voters,,,Registered,1144
-Sedgwick,418,Voters,,,Registered,1593
-Sedgwick,419,Voters,,,Registered,1341
-Sedgwick,420,Voters,,,Registered,1545
-Sedgwick,422,Voters,,,Registered,1072
-Sedgwick,423,Voters,,,Registered,1379
-Sedgwick,424,Voters,,,Registered,434
-Sedgwick,425,Voters,,,Registered,2031
-Sedgwick,429,Voters,,,Registered,864
-Sedgwick,433,Voters,,,Registered,501
-Sedgwick,437,Voters,,,Registered,595
-Sedgwick,503,Voters,,,Registered,1902
-Sedgwick,504,Voters,,,Registered,1283
-Sedgwick,506,Voters,,,Registered,1904
-Sedgwick,507,Voters,,,Registered,1782
-Sedgwick,508,Voters,,,Registered,1573
-Sedgwick,509,Voters,,,Registered,1483
-Sedgwick,510,Voters,,,Registered,1794
-Sedgwick,512,Voters,,,Registered,3222
-Sedgwick,513,Voters,,,Registered,842
-Sedgwick,514,Voters,,,Registered,2125
-Sedgwick,515,Voters,,,Registered,1854
-Sedgwick,516,Voters,,,Registered,1179
-Sedgwick,517,Voters,,,Registered,1233
-Sedgwick,518,Voters,,,Registered,1487
-Sedgwick,519,Voters,,,Registered,1667
-Sedgwick,522,Voters,,,Registered,1548
-Sedgwick,523,Voters,,,Registered,1482
-Sedgwick,524,Voters,,,Registered,2334
-Sedgwick,525,Voters,,,Registered,1730
-Sedgwick,526,Voters,,,Registered,1800
-Sedgwick,527,Voters,,,Registered,1791
-Sedgwick,530,Voters,,,Registered,1555
-Sedgwick,531,Voters,,,Registered,2402
-Sedgwick,534,Voters,,,Registered,189
-Sedgwick,538,Voters,,,Registered,375
-Sedgwick,539,Voters,,,Registered,967
-Sedgwick,601,Voters,,,Registered,1656
-Sedgwick,602,Voters,,,Registered,1978
-Sedgwick,603,Voters,,,Registered,742
-Sedgwick,604,Voters,,,Registered,1913
-Sedgwick,605,Voters,,,Registered,731
-Sedgwick,606,Voters,,,Registered,577
-Sedgwick,607,Voters,,,Registered,1835
-Sedgwick,608,Voters,,,Registered,1610
-Sedgwick,609,Voters,,,Registered,2323
-Sedgwick,610,Voters,,,Registered,1600
-Sedgwick,611,Voters,,,Registered,1111
-Sedgwick,612,Voters,,,Registered,1963
-Sedgwick,613,Voters,,,Registered,1712
-Sedgwick,614,Voters,,,Registered,814
-Sedgwick,615,Voters,,,Registered,2312
-Sedgwick,616,Voters,,,Registered,1159
-Sedgwick,617,Voters,,,Registered,742
-Sedgwick,618,Voters,,,Registered,1588
-Sedgwick,619,Voters,,,Registered,1662
-Sedgwick,621,Voters,,,Registered,74
-Sedgwick,622,Voters,,,Registered,1772
-Sedgwick,623,Voters,,,Registered,1578
-Sedgwick,624,Voters,,,Registered,179
-Sedgwick,627,Voters,,,Registered,142
-Sedgwick,101,Voters,,,Cast,742
-Sedgwick,102,Voters,,,Cast,735
-Sedgwick,103,Voters,,,Cast,101
-Sedgwick,104,Voters,,,Cast,30
-Sedgwick,105,Voters,,,Cast,416
-Sedgwick,106,Voters,,,Cast,724
-Sedgwick,107,Voters,,,Cast,1126
-Sedgwick,108,Voters,,,Cast,609
-Sedgwick,109,Voters,,,Cast,710
-Sedgwick,110,Voters,,,Cast,1139
-Sedgwick,111,Voters,,,Cast,299
-Sedgwick,112,Voters,,,Cast,795
-Sedgwick,113,Voters,,,Cast,520
-Sedgwick,114,Voters,,,Cast,453
-Sedgwick,116,Voters,,,Cast,679
-Sedgwick,117,Voters,,,Cast,632
-Sedgwick,118,Voters,,,Cast,779
-Sedgwick,119,Voters,,,Cast,615
-Sedgwick,120,Voters,,,Cast,609
-Sedgwick,121,Voters,,,Cast,682
-Sedgwick,122,Voters,,,Cast,1036
-Sedgwick,123,Voters,,,Cast,297
-Sedgwick,124,Voters,,,Cast,1
-Sedgwick,127,Voters,,,Cast,214
-Sedgwick,128,Voters,,,Cast,847
-Sedgwick,129,Voters,,,Cast,165
-Sedgwick,130,Voters,,,Cast,461
-Sedgwick,205,Voters,,,Cast,207
-Sedgwick,206,Voters,,,Cast,237
-Sedgwick,207,Voters,,,Cast,1315
-Sedgwick,208,Voters,,,Cast,258
-Sedgwick,209,Voters,,,Cast,624
-Sedgwick,210,Voters,,,Cast,777
-Sedgwick,211,Voters,,,Cast,555
-Sedgwick,212,Voters,,,Cast,1068
-Sedgwick,213,Voters,,,Cast,1184
-Sedgwick,214,Voters,,,Cast,1083
-Sedgwick,215,Voters,,,Cast,1446
-Sedgwick,216,Voters,,,Cast,916
-Sedgwick,217,Voters,,,Cast,1127
-Sedgwick,218,Voters,,,Cast,1567
-Sedgwick,221,Voters,,,Cast,709
-Sedgwick,222,Voters,,,Cast,965
-Sedgwick,223,Voters,,,Cast,1171
-Sedgwick,224,Voters,,,Cast,1121
-Sedgwick,225,Voters,,,Cast,1164
-Sedgwick,226,Voters,,,Cast,1506
-Sedgwick,227,Voters,,,Cast,819
-Sedgwick,228,Voters,,,Cast,1081
-Sedgwick,233,Voters,,,Cast,297
-Sedgwick,235,Voters,,,Cast,232
-Sedgwick,236,Voters,,,Cast,710
-Sedgwick,239,Voters,,,Cast,19
-Sedgwick,241,Voters,,,Cast,280
-Sedgwick,301,Voters,,,Cast,331
-Sedgwick,302,Voters,,,Cast,586
-Sedgwick,303,Voters,,,Cast,274
-Sedgwick,304,Voters,,,Cast,316
-Sedgwick,305,Voters,,,Cast,1040
-Sedgwick,306,Voters,,,Cast,940
-Sedgwick,307,Voters,,,Cast,407
-Sedgwick,308,Voters,,,Cast,702
-Sedgwick,309,Voters,,,Cast,819
-Sedgwick,310,Voters,,,Cast,365
-Sedgwick,311,Voters,,,Cast,310
-Sedgwick,312,Voters,,,Cast,310
-Sedgwick,313,Voters,,,Cast,886
-Sedgwick,314,Voters,,,Cast,807
-Sedgwick,315,Voters,,,Cast,610
-Sedgwick,316,Voters,,,Cast,736
-Sedgwick,317,Voters,,,Cast,12
-Sedgwick,318,Voters,,,Cast,23
-Sedgwick,319,Voters,,,Cast,187
-Sedgwick,320,Voters,,,Cast,122
-Sedgwick,321,Voters,,,Cast,18
-Sedgwick,324,Voters,,,Cast,274
-Sedgwick,325,Voters,,,Cast,656
-Sedgwick,326,Voters,,,Cast,73
-Sedgwick,401,Voters,,,Cast,430
-Sedgwick,402,Voters,,,Cast,453
-Sedgwick,403,Voters,,,Cast,685
-Sedgwick,404,Voters,,,Cast,929
-Sedgwick,405,Voters,,,Cast,683
-Sedgwick,406,Voters,,,Cast,567
-Sedgwick,407,Voters,,,Cast,76
-Sedgwick,408,Voters,,,Cast,582
-Sedgwick,409,Voters,,,Cast,325
-Sedgwick,410,Voters,,,Cast,1438
-Sedgwick,412,Voters,,,Cast,1381
-Sedgwick,413,Voters,,,Cast,1009
-Sedgwick,414,Voters,,,Cast,207
-Sedgwick,416,Voters,,,Cast,676
-Sedgwick,417,Voters,,,Cast,514
-Sedgwick,418,Voters,,,Cast,761
-Sedgwick,419,Voters,,,Cast,661
-Sedgwick,420,Voters,,,Cast,710
-Sedgwick,422,Voters,,,Cast,443
-Sedgwick,423,Voters,,,Cast,528
-Sedgwick,424,Voters,,,Cast,171
-Sedgwick,425,Voters,,,Cast,1000
-Sedgwick,429,Voters,,,Cast,360
-Sedgwick,433,Voters,,,Cast,239
-Sedgwick,437,Voters,,,Cast,233
-Sedgwick,503,Voters,,,Cast,789
-Sedgwick,504,Voters,,,Cast,553
-Sedgwick,506,Voters,,,Cast,1042
-Sedgwick,507,Voters,,,Cast,984
-Sedgwick,508,Voters,,,Cast,882
-Sedgwick,509,Voters,,,Cast,852
-Sedgwick,510,Voters,,,Cast,1231
-Sedgwick,512,Voters,,,Cast,1820
-Sedgwick,513,Voters,,,Cast,520
-Sedgwick,514,Voters,,,Cast,1222
-Sedgwick,515,Voters,,,Cast,1086
-Sedgwick,516,Voters,,,Cast,732
-Sedgwick,517,Voters,,,Cast,743
-Sedgwick,518,Voters,,,Cast,896
-Sedgwick,519,Voters,,,Cast,998
-Sedgwick,522,Voters,,,Cast,956
-Sedgwick,523,Voters,,,Cast,967
-Sedgwick,524,Voters,,,Cast,1538
-Sedgwick,525,Voters,,,Cast,1031
-Sedgwick,526,Voters,,,Cast,1074
-Sedgwick,527,Voters,,,Cast,1050
-Sedgwick,530,Voters,,,Cast,1027
-Sedgwick,531,Voters,,,Cast,1656
-Sedgwick,534,Voters,,,Cast,97
-Sedgwick,538,Voters,,,Cast,204
-Sedgwick,539,Voters,,,Cast,512
-Sedgwick,601,Voters,,,Cast,508
-Sedgwick,602,Voters,,,Cast,964
-Sedgwick,603,Voters,,,Cast,472
-Sedgwick,604,Voters,,,Cast,931
-Sedgwick,605,Voters,,,Cast,347
-Sedgwick,606,Voters,,,Cast,301
-Sedgwick,607,Voters,,,Cast,1190
-Sedgwick,608,Voters,,,Cast,665
-Sedgwick,609,Voters,,,Cast,1289
-Sedgwick,610,Voters,,,Cast,995
-Sedgwick,611,Voters,,,Cast,506
-Sedgwick,612,Voters,,,Cast,1219
-Sedgwick,613,Voters,,,Cast,962
-Sedgwick,614,Voters,,,Cast,361
-Sedgwick,615,Voters,,,Cast,860
-Sedgwick,616,Voters,,,Cast,464
-Sedgwick,617,Voters,,,Cast,274
-Sedgwick,618,Voters,,,Cast,919
-Sedgwick,619,Voters,,,Cast,956
-Sedgwick,621,Voters,,,Cast,38
-Sedgwick,622,Voters,,,Cast,1185
-Sedgwick,623,Voters,,,Cast,1009
-Sedgwick,624,Voters,,,Cast,73
-Sedgwick,627,Voters,,,Cast,77
-Sedgwick,101,U.S. Senate,,R,Pat Roberts,301
-Sedgwick,102,U.S. Senate,,R,Pat Roberts,325
-Sedgwick,103,U.S. Senate,,R,Pat Roberts,25
-Sedgwick,104,U.S. Senate,,R,Pat Roberts,17
-Sedgwick,105,U.S. Senate,,R,Pat Roberts,101
-Sedgwick,106,U.S. Senate,,R,Pat Roberts,128
-Sedgwick,107,U.S. Senate,,R,Pat Roberts,448
-Sedgwick,108,U.S. Senate,,R,Pat Roberts,177
-Sedgwick,109,U.S. Senate,,R,Pat Roberts,198
-Sedgwick,110,U.S. Senate,,R,Pat Roberts,471
-Sedgwick,111,U.S. Senate,,R,Pat Roberts,127
-Sedgwick,112,U.S. Senate,,R,Pat Roberts,230
-Sedgwick,113,U.S. Senate,,R,Pat Roberts,61
-Sedgwick,114,U.S. Senate,,R,Pat Roberts,21
-Sedgwick,116,U.S. Senate,,R,Pat Roberts,42
-Sedgwick,117,U.S. Senate,,R,Pat Roberts,40
-Sedgwick,118,U.S. Senate,,R,Pat Roberts,88
-Sedgwick,119,U.S. Senate,,R,Pat Roberts,134
-Sedgwick,120,U.S. Senate,,R,Pat Roberts,178
-Sedgwick,121,U.S. Senate,,R,Pat Roberts,299
-Sedgwick,122,U.S. Senate,,R,Pat Roberts,412
-Sedgwick,123,U.S. Senate,,R,Pat Roberts,157
-Sedgwick,124,U.S. Senate,,R,Pat Roberts,0
-Sedgwick,127,U.S. Senate,,R,Pat Roberts,112
-Sedgwick,128,U.S. Senate,,R,Pat Roberts,348
-Sedgwick,129,U.S. Senate,,R,Pat Roberts,59
-Sedgwick,130,U.S. Senate,,R,Pat Roberts,163
-Sedgwick,205,U.S. Senate,,R,Pat Roberts,67
-Sedgwick,206,U.S. Senate,,R,Pat Roberts,107
-Sedgwick,207,U.S. Senate,,R,Pat Roberts,559
-Sedgwick,208,U.S. Senate,,R,Pat Roberts,113
-Sedgwick,209,U.S. Senate,,R,Pat Roberts,249
-Sedgwick,210,U.S. Senate,,R,Pat Roberts,324
-Sedgwick,211,U.S. Senate,,R,Pat Roberts,278
-Sedgwick,212,U.S. Senate,,R,Pat Roberts,509
-Sedgwick,213,U.S. Senate,,R,Pat Roberts,646
-Sedgwick,214,U.S. Senate,,R,Pat Roberts,672
-Sedgwick,215,U.S. Senate,,R,Pat Roberts,785
-Sedgwick,216,U.S. Senate,,R,Pat Roberts,468
-Sedgwick,217,U.S. Senate,,R,Pat Roberts,672
-Sedgwick,218,U.S. Senate,,R,Pat Roberts,869
-Sedgwick,221,U.S. Senate,,R,Pat Roberts,397
-Sedgwick,222,U.S. Senate,,R,Pat Roberts,536
-Sedgwick,223,U.S. Senate,,R,Pat Roberts,697
-Sedgwick,224,U.S. Senate,,R,Pat Roberts,518
-Sedgwick,225,U.S. Senate,,R,Pat Roberts,554
-Sedgwick,226,U.S. Senate,,R,Pat Roberts,883
-Sedgwick,227,U.S. Senate,,R,Pat Roberts,530
-Sedgwick,228,U.S. Senate,,R,Pat Roberts,770
-Sedgwick,233,U.S. Senate,,R,Pat Roberts,142
-Sedgwick,235,U.S. Senate,,R,Pat Roberts,82
-Sedgwick,236,U.S. Senate,,R,Pat Roberts,433
-Sedgwick,239,U.S. Senate,,R,Pat Roberts,15
-Sedgwick,241,U.S. Senate,,R,Pat Roberts,166
-Sedgwick,301,U.S. Senate,,R,Pat Roberts,145
-Sedgwick,302,U.S. Senate,,R,Pat Roberts,223
-Sedgwick,303,U.S. Senate,,R,Pat Roberts,127
-Sedgwick,304,U.S. Senate,,R,Pat Roberts,126
-Sedgwick,305,U.S. Senate,,R,Pat Roberts,393
-Sedgwick,306,U.S. Senate,,R,Pat Roberts,328
-Sedgwick,307,U.S. Senate,,R,Pat Roberts,146
-Sedgwick,308,U.S. Senate,,R,Pat Roberts,263
-Sedgwick,309,U.S. Senate,,R,Pat Roberts,320
-Sedgwick,310,U.S. Senate,,R,Pat Roberts,127
-Sedgwick,311,U.S. Senate,,R,Pat Roberts,154
-Sedgwick,312,U.S. Senate,,R,Pat Roberts,128
-Sedgwick,313,U.S. Senate,,R,Pat Roberts,329
-Sedgwick,314,U.S. Senate,,R,Pat Roberts,338
-Sedgwick,315,U.S. Senate,,R,Pat Roberts,237
-Sedgwick,316,U.S. Senate,,R,Pat Roberts,366
-Sedgwick,317,U.S. Senate,,R,Pat Roberts,6
-Sedgwick,318,U.S. Senate,,R,Pat Roberts,13
-Sedgwick,319,U.S. Senate,,R,Pat Roberts,58
-Sedgwick,320,U.S. Senate,,R,Pat Roberts,32
-Sedgwick,321,U.S. Senate,,R,Pat Roberts,3
-Sedgwick,324,U.S. Senate,,R,Pat Roberts,95
-Sedgwick,325,U.S. Senate,,R,Pat Roberts,272
-Sedgwick,326,U.S. Senate,,R,Pat Roberts,22
-Sedgwick,401,U.S. Senate,,R,Pat Roberts,246
-Sedgwick,402,U.S. Senate,,R,Pat Roberts,246
-Sedgwick,403,U.S. Senate,,R,Pat Roberts,429
-Sedgwick,404,U.S. Senate,,R,Pat Roberts,391
-Sedgwick,405,U.S. Senate,,R,Pat Roberts,300
-Sedgwick,406,U.S. Senate,,R,Pat Roberts,223
-Sedgwick,407,U.S. Senate,,R,Pat Roberts,27
-Sedgwick,408,U.S. Senate,,R,Pat Roberts,227
-Sedgwick,409,U.S. Senate,,R,Pat Roberts,132
-Sedgwick,410,U.S. Senate,,R,Pat Roberts,864
-Sedgwick,412,U.S. Senate,,R,Pat Roberts,784
-Sedgwick,413,U.S. Senate,,R,Pat Roberts,563
-Sedgwick,414,U.S. Senate,,R,Pat Roberts,106
-Sedgwick,416,U.S. Senate,,R,Pat Roberts,375
-Sedgwick,417,U.S. Senate,,R,Pat Roberts,234
-Sedgwick,418,U.S. Senate,,R,Pat Roberts,363
-Sedgwick,419,U.S. Senate,,R,Pat Roberts,272
-Sedgwick,420,U.S. Senate,,R,Pat Roberts,325
-Sedgwick,422,U.S. Senate,,R,Pat Roberts,202
-Sedgwick,423,U.S. Senate,,R,Pat Roberts,247
-Sedgwick,424,U.S. Senate,,R,Pat Roberts,72
-Sedgwick,425,U.S. Senate,,R,Pat Roberts,509
-Sedgwick,429,U.S. Senate,,R,Pat Roberts,152
-Sedgwick,433,U.S. Senate,,R,Pat Roberts,117
-Sedgwick,437,U.S. Senate,,R,Pat Roberts,134
-Sedgwick,503,U.S. Senate,,R,Pat Roberts,363
-Sedgwick,504,U.S. Senate,,R,Pat Roberts,270
-Sedgwick,506,U.S. Senate,,R,Pat Roberts,554
-Sedgwick,507,U.S. Senate,,R,Pat Roberts,496
-Sedgwick,508,U.S. Senate,,R,Pat Roberts,453
-Sedgwick,509,U.S. Senate,,R,Pat Roberts,452
-Sedgwick,510,U.S. Senate,,R,Pat Roberts,776
-Sedgwick,512,U.S. Senate,,R,Pat Roberts,1066
-Sedgwick,513,U.S. Senate,,R,Pat Roberts,350
-Sedgwick,514,U.S. Senate,,R,Pat Roberts,689
-Sedgwick,515,U.S. Senate,,R,Pat Roberts,590
-Sedgwick,516,U.S. Senate,,R,Pat Roberts,423
-Sedgwick,517,U.S. Senate,,R,Pat Roberts,367
-Sedgwick,518,U.S. Senate,,R,Pat Roberts,504
-Sedgwick,519,U.S. Senate,,R,Pat Roberts,481
-Sedgwick,522,U.S. Senate,,R,Pat Roberts,538
-Sedgwick,523,U.S. Senate,,R,Pat Roberts,536
-Sedgwick,524,U.S. Senate,,R,Pat Roberts,852
-Sedgwick,525,U.S. Senate,,R,Pat Roberts,494
-Sedgwick,526,U.S. Senate,,R,Pat Roberts,624
-Sedgwick,527,U.S. Senate,,R,Pat Roberts,590
-Sedgwick,530,U.S. Senate,,R,Pat Roberts,662
-Sedgwick,531,U.S. Senate,,R,Pat Roberts,979
-Sedgwick,534,U.S. Senate,,R,Pat Roberts,65
-Sedgwick,538,U.S. Senate,,R,Pat Roberts,120
-Sedgwick,539,U.S. Senate,,R,Pat Roberts,292
-Sedgwick,601,U.S. Senate,,R,Pat Roberts,135
-Sedgwick,602,U.S. Senate,,R,Pat Roberts,416
-Sedgwick,603,U.S. Senate,,R,Pat Roberts,297
-Sedgwick,604,U.S. Senate,,R,Pat Roberts,418
-Sedgwick,605,U.S. Senate,,R,Pat Roberts,154
-Sedgwick,606,U.S. Senate,,R,Pat Roberts,111
-Sedgwick,607,U.S. Senate,,R,Pat Roberts,344
-Sedgwick,608,U.S. Senate,,R,Pat Roberts,168
-Sedgwick,609,U.S. Senate,,R,Pat Roberts,409
-Sedgwick,610,U.S. Senate,,R,Pat Roberts,464
-Sedgwick,611,U.S. Senate,,R,Pat Roberts,232
-Sedgwick,612,U.S. Senate,,R,Pat Roberts,591
-Sedgwick,613,U.S. Senate,,R,Pat Roberts,419
-Sedgwick,614,U.S. Senate,,R,Pat Roberts,140
-Sedgwick,615,U.S. Senate,,R,Pat Roberts,227
-Sedgwick,616,U.S. Senate,,R,Pat Roberts,202
-Sedgwick,617,U.S. Senate,,R,Pat Roberts,91
-Sedgwick,618,U.S. Senate,,R,Pat Roberts,473
-Sedgwick,619,U.S. Senate,,R,Pat Roberts,438
-Sedgwick,621,U.S. Senate,,R,Pat Roberts,23
-Sedgwick,622,U.S. Senate,,R,Pat Roberts,680
-Sedgwick,623,U.S. Senate,,R,Pat Roberts,612
-Sedgwick,624,U.S. Senate,,R,Pat Roberts,27
-Sedgwick,627,U.S. Senate,,R,Pat Roberts,36
-Sedgwick,101,U.S. Senate,,I,Greg Orman,377
-Sedgwick,102,U.S. Senate,,I,Greg Orman,373
-Sedgwick,103,U.S. Senate,,I,Greg Orman,69
-Sedgwick,104,U.S. Senate,,I,Greg Orman,10
-Sedgwick,105,U.S. Senate,,I,Greg Orman,290
-Sedgwick,106,U.S. Senate,,I,Greg Orman,501
-Sedgwick,107,U.S. Senate,,I,Greg Orman,636
-Sedgwick,108,U.S. Senate,,I,Greg Orman,386
-Sedgwick,109,U.S. Senate,,I,Greg Orman,450
-Sedgwick,110,U.S. Senate,,I,Greg Orman,618
-Sedgwick,111,U.S. Senate,,I,Greg Orman,152
-Sedgwick,112,U.S. Senate,,I,Greg Orman,496
-Sedgwick,113,U.S. Senate,,I,Greg Orman,409
-Sedgwick,114,U.S. Senate,,I,Greg Orman,369
-Sedgwick,116,U.S. Senate,,I,Greg Orman,522
-Sedgwick,117,U.S. Senate,,I,Greg Orman,500
-Sedgwick,118,U.S. Senate,,I,Greg Orman,614
-Sedgwick,119,U.S. Senate,,I,Greg Orman,410
-Sedgwick,120,U.S. Senate,,I,Greg Orman,384
-Sedgwick,121,U.S. Senate,,I,Greg Orman,352
-Sedgwick,122,U.S. Senate,,I,Greg Orman,556
-Sedgwick,123,U.S. Senate,,I,Greg Orman,118
-Sedgwick,124,U.S. Senate,,I,Greg Orman,1
-Sedgwick,127,U.S. Senate,,I,Greg Orman,86
-Sedgwick,128,U.S. Senate,,I,Greg Orman,460
-Sedgwick,129,U.S. Senate,,I,Greg Orman,87
-Sedgwick,130,U.S. Senate,,I,Greg Orman,261
-Sedgwick,205,U.S. Senate,,I,Greg Orman,118
-Sedgwick,206,U.S. Senate,,I,Greg Orman,119
-Sedgwick,207,U.S. Senate,,I,Greg Orman,687
-Sedgwick,208,U.S. Senate,,I,Greg Orman,121
-Sedgwick,209,U.S. Senate,,I,Greg Orman,331
-Sedgwick,210,U.S. Senate,,I,Greg Orman,387
-Sedgwick,211,U.S. Senate,,I,Greg Orman,257
-Sedgwick,212,U.S. Senate,,I,Greg Orman,523
-Sedgwick,213,U.S. Senate,,I,Greg Orman,500
-Sedgwick,214,U.S. Senate,,I,Greg Orman,380
-Sedgwick,215,U.S. Senate,,I,Greg Orman,610
-Sedgwick,216,U.S. Senate,,I,Greg Orman,410
-Sedgwick,217,U.S. Senate,,I,Greg Orman,427
-Sedgwick,218,U.S. Senate,,I,Greg Orman,654
-Sedgwick,221,U.S. Senate,,I,Greg Orman,288
-Sedgwick,222,U.S. Senate,,I,Greg Orman,394
-Sedgwick,223,U.S. Senate,,I,Greg Orman,444
-Sedgwick,224,U.S. Senate,,I,Greg Orman,526
-Sedgwick,225,U.S. Senate,,I,Greg Orman,518
-Sedgwick,226,U.S. Senate,,I,Greg Orman,568
-Sedgwick,227,U.S. Senate,,I,Greg Orman,265
-Sedgwick,228,U.S. Senate,,I,Greg Orman,282
-Sedgwick,233,U.S. Senate,,I,Greg Orman,136
-Sedgwick,235,U.S. Senate,,I,Greg Orman,129
-Sedgwick,236,U.S. Senate,,I,Greg Orman,257
-Sedgwick,239,U.S. Senate,,I,Greg Orman,4
-Sedgwick,241,U.S. Senate,,I,Greg Orman,108
-Sedgwick,301,U.S. Senate,,I,Greg Orman,153
-Sedgwick,302,U.S. Senate,,I,Greg Orman,289
-Sedgwick,303,U.S. Senate,,I,Greg Orman,113
-Sedgwick,304,U.S. Senate,,I,Greg Orman,161
-Sedgwick,305,U.S. Senate,,I,Greg Orman,542
-Sedgwick,306,U.S. Senate,,I,Greg Orman,536
-Sedgwick,307,U.S. Senate,,I,Greg Orman,223
-Sedgwick,308,U.S. Senate,,I,Greg Orman,371
-Sedgwick,309,U.S. Senate,,I,Greg Orman,416
-Sedgwick,310,U.S. Senate,,I,Greg Orman,194
-Sedgwick,311,U.S. Senate,,I,Greg Orman,119
-Sedgwick,312,U.S. Senate,,I,Greg Orman,148
-Sedgwick,313,U.S. Senate,,I,Greg Orman,444
-Sedgwick,314,U.S. Senate,,I,Greg Orman,381
-Sedgwick,315,U.S. Senate,,I,Greg Orman,300
-Sedgwick,316,U.S. Senate,,I,Greg Orman,307
-Sedgwick,317,U.S. Senate,,I,Greg Orman,6
-Sedgwick,318,U.S. Senate,,I,Greg Orman,8
-Sedgwick,319,U.S. Senate,,I,Greg Orman,109
-Sedgwick,320,U.S. Senate,,I,Greg Orman,73
-Sedgwick,321,U.S. Senate,,I,Greg Orman,11
-Sedgwick,324,U.S. Senate,,I,Greg Orman,145
-Sedgwick,325,U.S. Senate,,I,Greg Orman,334
-Sedgwick,326,U.S. Senate,,I,Greg Orman,42
-Sedgwick,401,U.S. Senate,,I,Greg Orman,163
-Sedgwick,402,U.S. Senate,,I,Greg Orman,178
-Sedgwick,403,U.S. Senate,,I,Greg Orman,219
-Sedgwick,404,U.S. Senate,,I,Greg Orman,441
-Sedgwick,405,U.S. Senate,,I,Greg Orman,326
-Sedgwick,406,U.S. Senate,,I,Greg Orman,278
-Sedgwick,407,U.S. Senate,,I,Greg Orman,43
-Sedgwick,408,U.S. Senate,,I,Greg Orman,295
-Sedgwick,409,U.S. Senate,,I,Greg Orman,170
-Sedgwick,410,U.S. Senate,,I,Greg Orman,500
-Sedgwick,412,U.S. Senate,,I,Greg Orman,512
-Sedgwick,413,U.S. Senate,,I,Greg Orman,377
-Sedgwick,414,U.S. Senate,,I,Greg Orman,90
-Sedgwick,416,U.S. Senate,,I,Greg Orman,262
-Sedgwick,417,U.S. Senate,,I,Greg Orman,233
-Sedgwick,418,U.S. Senate,,I,Greg Orman,321
-Sedgwick,419,U.S. Senate,,I,Greg Orman,324
-Sedgwick,420,U.S. Senate,,I,Greg Orman,313
-Sedgwick,422,U.S. Senate,,I,Greg Orman,191
-Sedgwick,423,U.S. Senate,,I,Greg Orman,237
-Sedgwick,424,U.S. Senate,,I,Greg Orman,84
-Sedgwick,425,U.S. Senate,,I,Greg Orman,403
-Sedgwick,429,U.S. Senate,,I,Greg Orman,185
-Sedgwick,433,U.S. Senate,,I,Greg Orman,98
-Sedgwick,437,U.S. Senate,,I,Greg Orman,74
-Sedgwick,503,U.S. Senate,,I,Greg Orman,373
-Sedgwick,504,U.S. Senate,,I,Greg Orman,246
-Sedgwick,506,U.S. Senate,,I,Greg Orman,431
-Sedgwick,507,U.S. Senate,,I,Greg Orman,433
-Sedgwick,508,U.S. Senate,,I,Greg Orman,385
-Sedgwick,509,U.S. Senate,,I,Greg Orman,352
-Sedgwick,510,U.S. Senate,,I,Greg Orman,427
-Sedgwick,512,U.S. Senate,,I,Greg Orman,679
-Sedgwick,513,U.S. Senate,,I,Greg Orman,153
-Sedgwick,514,U.S. Senate,,I,Greg Orman,481
-Sedgwick,515,U.S. Senate,,I,Greg Orman,455
-Sedgwick,516,U.S. Senate,,I,Greg Orman,282
-Sedgwick,517,U.S. Senate,,I,Greg Orman,328
-Sedgwick,518,U.S. Senate,,I,Greg Orman,349
-Sedgwick,519,U.S. Senate,,I,Greg Orman,450
-Sedgwick,522,U.S. Senate,,I,Greg Orman,370
-Sedgwick,523,U.S. Senate,,I,Greg Orman,386
-Sedgwick,524,U.S. Senate,,I,Greg Orman,615
-Sedgwick,525,U.S. Senate,,I,Greg Orman,465
-Sedgwick,526,U.S. Senate,,I,Greg Orman,388
-Sedgwick,527,U.S. Senate,,I,Greg Orman,396
-Sedgwick,530,U.S. Senate,,I,Greg Orman,330
-Sedgwick,531,U.S. Senate,,I,Greg Orman,621
-Sedgwick,534,U.S. Senate,,I,Greg Orman,29
-Sedgwick,538,U.S. Senate,,I,Greg Orman,73
-Sedgwick,539,U.S. Senate,,I,Greg Orman,187
-Sedgwick,601,U.S. Senate,,I,Greg Orman,324
-Sedgwick,602,U.S. Senate,,I,Greg Orman,467
-Sedgwick,603,U.S. Senate,,I,Greg Orman,159
-Sedgwick,604,U.S. Senate,,I,Greg Orman,418
-Sedgwick,605,U.S. Senate,,I,Greg Orman,169
-Sedgwick,606,U.S. Senate,,I,Greg Orman,160
-Sedgwick,607,U.S. Senate,,I,Greg Orman,775
-Sedgwick,608,U.S. Senate,,I,Greg Orman,445
-Sedgwick,609,U.S. Senate,,I,Greg Orman,784
-Sedgwick,610,U.S. Senate,,I,Greg Orman,470
-Sedgwick,611,U.S. Senate,,I,Greg Orman,251
-Sedgwick,612,U.S. Senate,,I,Greg Orman,554
-Sedgwick,613,U.S. Senate,,I,Greg Orman,481
-Sedgwick,614,U.S. Senate,,I,Greg Orman,192
-Sedgwick,615,U.S. Senate,,I,Greg Orman,511
-Sedgwick,616,U.S. Senate,,I,Greg Orman,218
-Sedgwick,617,U.S. Senate,,I,Greg Orman,134
-Sedgwick,618,U.S. Senate,,I,Greg Orman,398
-Sedgwick,619,U.S. Senate,,I,Greg Orman,446
-Sedgwick,621,U.S. Senate,,I,Greg Orman,14
-Sedgwick,622,U.S. Senate,,I,Greg Orman,446
-Sedgwick,623,U.S. Senate,,I,Greg Orman,344
-Sedgwick,624,U.S. Senate,,I,Greg Orman,36
-Sedgwick,627,U.S. Senate,,I,Greg Orman,33
-Sedgwick,101,U.S. Senate,,L,Randall Batson,59
-Sedgwick,102,U.S. Senate,,L,Randall Batson,27
-Sedgwick,103,U.S. Senate,,L,Randall Batson,4
-Sedgwick,104,U.S. Senate,,L,Randall Batson,3
-Sedgwick,105,U.S. Senate,,L,Randall Batson,20
-Sedgwick,106,U.S. Senate,,L,Randall Batson,68
-Sedgwick,107,U.S. Senate,,L,Randall Batson,32
-Sedgwick,108,U.S. Senate,,L,Randall Batson,32
-Sedgwick,109,U.S. Senate,,L,Randall Batson,38
-Sedgwick,110,U.S. Senate,,L,Randall Batson,40
-Sedgwick,111,U.S. Senate,,L,Randall Batson,15
-Sedgwick,112,U.S. Senate,,L,Randall Batson,34
-Sedgwick,113,U.S. Senate,,L,Randall Batson,23
-Sedgwick,114,U.S. Senate,,L,Randall Batson,37
-Sedgwick,116,U.S. Senate,,L,Randall Batson,65
-Sedgwick,117,U.S. Senate,,L,Randall Batson,51
-Sedgwick,118,U.S. Senate,,L,Randall Batson,39
-Sedgwick,119,U.S. Senate,,L,Randall Batson,45
-Sedgwick,120,U.S. Senate,,L,Randall Batson,35
-Sedgwick,121,U.S. Senate,,L,Randall Batson,26
-Sedgwick,122,U.S. Senate,,L,Randall Batson,52
-Sedgwick,123,U.S. Senate,,L,Randall Batson,19
-Sedgwick,124,U.S. Senate,,L,Randall Batson,0
-Sedgwick,127,U.S. Senate,,L,Randall Batson,12
-Sedgwick,128,U.S. Senate,,L,Randall Batson,25
-Sedgwick,129,U.S. Senate,,L,Randall Batson,17
-Sedgwick,130,U.S. Senate,,L,Randall Batson,31
-Sedgwick,205,U.S. Senate,,L,Randall Batson,19
-Sedgwick,206,U.S. Senate,,L,Randall Batson,6
-Sedgwick,207,U.S. Senate,,L,Randall Batson,57
-Sedgwick,208,U.S. Senate,,L,Randall Batson,20
-Sedgwick,209,U.S. Senate,,L,Randall Batson,33
-Sedgwick,210,U.S. Senate,,L,Randall Batson,53
-Sedgwick,211,U.S. Senate,,L,Randall Batson,16
-Sedgwick,212,U.S. Senate,,L,Randall Batson,24
-Sedgwick,213,U.S. Senate,,L,Randall Batson,31
-Sedgwick,214,U.S. Senate,,L,Randall Batson,22
-Sedgwick,215,U.S. Senate,,L,Randall Batson,40
-Sedgwick,216,U.S. Senate,,L,Randall Batson,20
-Sedgwick,217,U.S. Senate,,L,Randall Batson,18
-Sedgwick,218,U.S. Senate,,L,Randall Batson,28
-Sedgwick,221,U.S. Senate,,L,Randall Batson,16
-Sedgwick,222,U.S. Senate,,L,Randall Batson,27
-Sedgwick,223,U.S. Senate,,L,Randall Batson,20
-Sedgwick,224,U.S. Senate,,L,Randall Batson,63
-Sedgwick,225,U.S. Senate,,L,Randall Batson,73
-Sedgwick,226,U.S. Senate,,L,Randall Batson,38
-Sedgwick,227,U.S. Senate,,L,Randall Batson,17
-Sedgwick,228,U.S. Senate,,L,Randall Batson,17
-Sedgwick,233,U.S. Senate,,L,Randall Batson,16
-Sedgwick,235,U.S. Senate,,L,Randall Batson,16
-Sedgwick,236,U.S. Senate,,L,Randall Batson,15
-Sedgwick,239,U.S. Senate,,L,Randall Batson,0
-Sedgwick,241,U.S. Senate,,L,Randall Batson,6
-Sedgwick,301,U.S. Senate,,L,Randall Batson,27
-Sedgwick,302,U.S. Senate,,L,Randall Batson,68
-Sedgwick,303,U.S. Senate,,L,Randall Batson,28
-Sedgwick,304,U.S. Senate,,L,Randall Batson,25
-Sedgwick,305,U.S. Senate,,L,Randall Batson,71
-Sedgwick,306,U.S. Senate,,L,Randall Batson,63
-Sedgwick,307,U.S. Senate,,L,Randall Batson,35
-Sedgwick,308,U.S. Senate,,L,Randall Batson,50
-Sedgwick,309,U.S. Senate,,L,Randall Batson,64
-Sedgwick,310,U.S. Senate,,L,Randall Batson,36
-Sedgwick,311,U.S. Senate,,L,Randall Batson,28
-Sedgwick,312,U.S. Senate,,L,Randall Batson,28
-Sedgwick,313,U.S. Senate,,L,Randall Batson,91
-Sedgwick,314,U.S. Senate,,L,Randall Batson,73
-Sedgwick,315,U.S. Senate,,L,Randall Batson,67
-Sedgwick,316,U.S. Senate,,L,Randall Batson,55
-Sedgwick,317,U.S. Senate,,L,Randall Batson,0
-Sedgwick,318,U.S. Senate,,L,Randall Batson,2
-Sedgwick,319,U.S. Senate,,L,Randall Batson,17
-Sedgwick,320,U.S. Senate,,L,Randall Batson,14
-Sedgwick,321,U.S. Senate,,L,Randall Batson,2
-Sedgwick,324,U.S. Senate,,L,Randall Batson,29
-Sedgwick,325,U.S. Senate,,L,Randall Batson,43
-Sedgwick,326,U.S. Senate,,L,Randall Batson,8
-Sedgwick,401,U.S. Senate,,L,Randall Batson,20
-Sedgwick,402,U.S. Senate,,L,Randall Batson,18
-Sedgwick,403,U.S. Senate,,L,Randall Batson,34
-Sedgwick,404,U.S. Senate,,L,Randall Batson,77
-Sedgwick,405,U.S. Senate,,L,Randall Batson,51
-Sedgwick,406,U.S. Senate,,L,Randall Batson,53
-Sedgwick,407,U.S. Senate,,L,Randall Batson,6
-Sedgwick,408,U.S. Senate,,L,Randall Batson,49
-Sedgwick,409,U.S. Senate,,L,Randall Batson,20
-Sedgwick,410,U.S. Senate,,L,Randall Batson,61
-Sedgwick,412,U.S. Senate,,L,Randall Batson,71
-Sedgwick,413,U.S. Senate,,L,Randall Batson,59
-Sedgwick,414,U.S. Senate,,L,Randall Batson,10
-Sedgwick,416,U.S. Senate,,L,Randall Batson,33
-Sedgwick,417,U.S. Senate,,L,Randall Batson,41
-Sedgwick,418,U.S. Senate,,L,Randall Batson,65
-Sedgwick,419,U.S. Senate,,L,Randall Batson,57
-Sedgwick,420,U.S. Senate,,L,Randall Batson,59
-Sedgwick,422,U.S. Senate,,L,Randall Batson,37
-Sedgwick,423,U.S. Senate,,L,Randall Batson,39
-Sedgwick,424,U.S. Senate,,L,Randall Batson,13
-Sedgwick,425,U.S. Senate,,L,Randall Batson,74
-Sedgwick,429,U.S. Senate,,L,Randall Batson,18
-Sedgwick,433,U.S. Senate,,L,Randall Batson,22
-Sedgwick,437,U.S. Senate,,L,Randall Batson,22
-Sedgwick,503,U.S. Senate,,L,Randall Batson,37
-Sedgwick,504,U.S. Senate,,L,Randall Batson,31
-Sedgwick,506,U.S. Senate,,L,Randall Batson,52
-Sedgwick,507,U.S. Senate,,L,Randall Batson,47
-Sedgwick,508,U.S. Senate,,L,Randall Batson,35
-Sedgwick,509,U.S. Senate,,L,Randall Batson,40
-Sedgwick,510,U.S. Senate,,L,Randall Batson,17
-Sedgwick,512,U.S. Senate,,L,Randall Batson,55
-Sedgwick,513,U.S. Senate,,L,Randall Batson,15
-Sedgwick,514,U.S. Senate,,L,Randall Batson,40
-Sedgwick,515,U.S. Senate,,L,Randall Batson,30
-Sedgwick,516,U.S. Senate,,L,Randall Batson,20
-Sedgwick,517,U.S. Senate,,L,Randall Batson,40
-Sedgwick,518,U.S. Senate,,L,Randall Batson,33
-Sedgwick,519,U.S. Senate,,L,Randall Batson,54
-Sedgwick,522,U.S. Senate,,L,Randall Batson,39
-Sedgwick,523,U.S. Senate,,L,Randall Batson,38
-Sedgwick,524,U.S. Senate,,L,Randall Batson,59
-Sedgwick,525,U.S. Senate,,L,Randall Batson,57
-Sedgwick,526,U.S. Senate,,L,Randall Batson,45
-Sedgwick,527,U.S. Senate,,L,Randall Batson,54
-Sedgwick,530,U.S. Senate,,L,Randall Batson,26
-Sedgwick,531,U.S. Senate,,L,Randall Batson,46
-Sedgwick,534,U.S. Senate,,L,Randall Batson,2
-Sedgwick,538,U.S. Senate,,L,Randall Batson,8
-Sedgwick,539,U.S. Senate,,L,Randall Batson,24
-Sedgwick,601,U.S. Senate,,L,Randall Batson,40
-Sedgwick,602,U.S. Senate,,L,Randall Batson,72
-Sedgwick,603,U.S. Senate,,L,Randall Batson,14
-Sedgwick,604,U.S. Senate,,L,Randall Batson,80
-Sedgwick,605,U.S. Senate,,L,Randall Batson,21
-Sedgwick,606,U.S. Senate,,L,Randall Batson,19
-Sedgwick,607,U.S. Senate,,L,Randall Batson,56
-Sedgwick,608,U.S. Senate,,L,Randall Batson,45
-Sedgwick,609,U.S. Senate,,L,Randall Batson,85
-Sedgwick,610,U.S. Senate,,L,Randall Batson,50
-Sedgwick,611,U.S. Senate,,L,Randall Batson,19
-Sedgwick,612,U.S. Senate,,L,Randall Batson,62
-Sedgwick,613,U.S. Senate,,L,Randall Batson,45
-Sedgwick,614,U.S. Senate,,L,Randall Batson,20
-Sedgwick,615,U.S. Senate,,L,Randall Batson,95
-Sedgwick,616,U.S. Senate,,L,Randall Batson,39
-Sedgwick,617,U.S. Senate,,L,Randall Batson,38
-Sedgwick,618,U.S. Senate,,L,Randall Batson,44
-Sedgwick,619,U.S. Senate,,L,Randall Batson,57
-Sedgwick,621,U.S. Senate,,L,Randall Batson,1
-Sedgwick,622,U.S. Senate,,L,Randall Batson,47
-Sedgwick,623,U.S. Senate,,L,Randall Batson,45
-Sedgwick,624,U.S. Senate,,L,Randall Batson,8
-Sedgwick,627,U.S. Senate,,L,Randall Batson,8
-Sedgwick,101,U.S. House,4,R,Mike Pompeo,390
-Sedgwick,102,U.S. House,4,R,Mike Pompeo,446
-Sedgwick,103,U.S. House,4,R,Mike Pompeo,41
-Sedgwick,104,U.S. House,4,R,Mike Pompeo,21
-Sedgwick,105,U.S. House,4,R,Mike Pompeo,131
-Sedgwick,106,U.S. House,4,R,Mike Pompeo,186
-Sedgwick,107,U.S. House,4,R,Mike Pompeo,559
-Sedgwick,108,U.S. House,4,R,Mike Pompeo,246
-Sedgwick,109,U.S. House,4,R,Mike Pompeo,267
-Sedgwick,110,U.S. House,4,R,Mike Pompeo,593
-Sedgwick,111,U.S. House,4,R,Mike Pompeo,169
-Sedgwick,112,U.S. House,4,R,Mike Pompeo,287
-Sedgwick,113,U.S. House,4,R,Mike Pompeo,75
-Sedgwick,114,U.S. House,4,R,Mike Pompeo,41
-Sedgwick,116,U.S. House,4,R,Mike Pompeo,53
-Sedgwick,117,U.S. House,4,R,Mike Pompeo,61
-Sedgwick,118,U.S. House,4,R,Mike Pompeo,137
-Sedgwick,119,U.S. House,4,R,Mike Pompeo,186
-Sedgwick,120,U.S. House,4,R,Mike Pompeo,253
-Sedgwick,121,U.S. House,4,R,Mike Pompeo,379
-Sedgwick,122,U.S. House,4,R,Mike Pompeo,518
-Sedgwick,123,U.S. House,4,R,Mike Pompeo,194
-Sedgwick,124,U.S. House,4,R,Mike Pompeo,0
-Sedgwick,127,U.S. House,4,R,Mike Pompeo,137
-Sedgwick,128,U.S. House,4,R,Mike Pompeo,470
-Sedgwick,129,U.S. House,4,R,Mike Pompeo,68
-Sedgwick,130,U.S. House,4,R,Mike Pompeo,209
-Sedgwick,205,U.S. House,4,R,Mike Pompeo,94
-Sedgwick,206,U.S. House,4,R,Mike Pompeo,124
-Sedgwick,207,U.S. House,4,R,Mike Pompeo,692
-Sedgwick,208,U.S. House,4,R,Mike Pompeo,144
-Sedgwick,209,U.S. House,4,R,Mike Pompeo,317
-Sedgwick,210,U.S. House,4,R,Mike Pompeo,410
-Sedgwick,211,U.S. House,4,R,Mike Pompeo,334
-Sedgwick,212,U.S. House,4,R,Mike Pompeo,638
-Sedgwick,213,U.S. House,4,R,Mike Pompeo,796
-Sedgwick,214,U.S. House,4,R,Mike Pompeo,807
-Sedgwick,215,U.S. House,4,R,Mike Pompeo,935
-Sedgwick,216,U.S. House,4,R,Mike Pompeo,586
-Sedgwick,217,U.S. House,4,R,Mike Pompeo,795
-Sedgwick,218,U.S. House,4,R,Mike Pompeo,1043
-Sedgwick,221,U.S. House,4,R,Mike Pompeo,492
-Sedgwick,222,U.S. House,4,R,Mike Pompeo,658
-Sedgwick,223,U.S. House,4,R,Mike Pompeo,830
-Sedgwick,224,U.S. House,4,R,Mike Pompeo,632
-Sedgwick,225,U.S. House,4,R,Mike Pompeo,704
-Sedgwick,226,U.S. House,4,R,Mike Pompeo,1054
-Sedgwick,227,U.S. House,4,R,Mike Pompeo,618
-Sedgwick,228,U.S. House,4,R,Mike Pompeo,899
-Sedgwick,233,U.S. House,4,R,Mike Pompeo,182
-Sedgwick,235,U.S. House,4,R,Mike Pompeo,112
-Sedgwick,236,U.S. House,4,R,Mike Pompeo,538
-Sedgwick,239,U.S. House,4,R,Mike Pompeo,16
-Sedgwick,241,U.S. House,4,R,Mike Pompeo,203
-Sedgwick,301,U.S. House,4,R,Mike Pompeo,175
-Sedgwick,302,U.S. House,4,R,Mike Pompeo,294
-Sedgwick,303,U.S. House,4,R,Mike Pompeo,152
-Sedgwick,304,U.S. House,4,R,Mike Pompeo,162
-Sedgwick,305,U.S. House,4,R,Mike Pompeo,530
-Sedgwick,306,U.S. House,4,R,Mike Pompeo,425
-Sedgwick,307,U.S. House,4,R,Mike Pompeo,176
-Sedgwick,308,U.S. House,4,R,Mike Pompeo,333
-Sedgwick,309,U.S. House,4,R,Mike Pompeo,430
-Sedgwick,310,U.S. House,4,R,Mike Pompeo,169
-Sedgwick,311,U.S. House,4,R,Mike Pompeo,188
-Sedgwick,312,U.S. House,4,R,Mike Pompeo,168
-Sedgwick,313,U.S. House,4,R,Mike Pompeo,444
-Sedgwick,314,U.S. House,4,R,Mike Pompeo,459
-Sedgwick,315,U.S. House,4,R,Mike Pompeo,314
-Sedgwick,316,U.S. House,4,R,Mike Pompeo,459
-Sedgwick,317,U.S. House,4,R,Mike Pompeo,8
-Sedgwick,318,U.S. House,4,R,Mike Pompeo,15
-Sedgwick,319,U.S. House,4,R,Mike Pompeo,78
-Sedgwick,320,U.S. House,4,R,Mike Pompeo,37
-Sedgwick,321,U.S. House,4,R,Mike Pompeo,5
-Sedgwick,324,U.S. House,4,R,Mike Pompeo,135
-Sedgwick,325,U.S. House,4,R,Mike Pompeo,348
-Sedgwick,326,U.S. House,4,R,Mike Pompeo,40
-Sedgwick,401,U.S. House,4,R,Mike Pompeo,291
-Sedgwick,402,U.S. House,4,R,Mike Pompeo,294
-Sedgwick,403,U.S. House,4,R,Mike Pompeo,515
-Sedgwick,404,U.S. House,4,R,Mike Pompeo,493
-Sedgwick,405,U.S. House,4,R,Mike Pompeo,371
-Sedgwick,406,U.S. House,4,R,Mike Pompeo,307
-Sedgwick,407,U.S. House,4,R,Mike Pompeo,40
-Sedgwick,408,U.S. House,4,R,Mike Pompeo,282
-Sedgwick,409,U.S. House,4,R,Mike Pompeo,168
-Sedgwick,410,U.S. House,4,R,Mike Pompeo,1101
-Sedgwick,412,U.S. House,4,R,Mike Pompeo,972
-Sedgwick,413,U.S. House,4,R,Mike Pompeo,696
-Sedgwick,414,U.S. House,4,R,Mike Pompeo,143
-Sedgwick,416,U.S. House,4,R,Mike Pompeo,462
-Sedgwick,417,U.S. House,4,R,Mike Pompeo,301
-Sedgwick,418,U.S. House,4,R,Mike Pompeo,450
-Sedgwick,419,U.S. House,4,R,Mike Pompeo,358
-Sedgwick,420,U.S. House,4,R,Mike Pompeo,390
-Sedgwick,422,U.S. House,4,R,Mike Pompeo,246
-Sedgwick,423,U.S. House,4,R,Mike Pompeo,300
-Sedgwick,424,U.S. House,4,R,Mike Pompeo,103
-Sedgwick,425,U.S. House,4,R,Mike Pompeo,626
-Sedgwick,429,U.S. House,4,R,Mike Pompeo,200
-Sedgwick,433,U.S. House,4,R,Mike Pompeo,153
-Sedgwick,437,U.S. House,4,R,Mike Pompeo,166
-Sedgwick,503,U.S. House,4,R,Mike Pompeo,474
-Sedgwick,504,U.S. House,4,R,Mike Pompeo,331
-Sedgwick,506,U.S. House,4,R,Mike Pompeo,716
-Sedgwick,507,U.S. House,4,R,Mike Pompeo,608
-Sedgwick,508,U.S. House,4,R,Mike Pompeo,552
-Sedgwick,509,U.S. House,4,R,Mike Pompeo,581
-Sedgwick,510,U.S. House,4,R,Mike Pompeo,965
-Sedgwick,512,U.S. House,4,R,Mike Pompeo,1325
-Sedgwick,513,U.S. House,4,R,Mike Pompeo,414
-Sedgwick,514,U.S. House,4,R,Mike Pompeo,846
-Sedgwick,515,U.S. House,4,R,Mike Pompeo,733
-Sedgwick,516,U.S. House,4,R,Mike Pompeo,511
-Sedgwick,517,U.S. House,4,R,Mike Pompeo,469
-Sedgwick,518,U.S. House,4,R,Mike Pompeo,627
-Sedgwick,519,U.S. House,4,R,Mike Pompeo,624
-Sedgwick,522,U.S. House,4,R,Mike Pompeo,676
-Sedgwick,523,U.S. House,4,R,Mike Pompeo,683
-Sedgwick,524,U.S. House,4,R,Mike Pompeo,1041
-Sedgwick,525,U.S. House,4,R,Mike Pompeo,646
-Sedgwick,526,U.S. House,4,R,Mike Pompeo,751
-Sedgwick,527,U.S. House,4,R,Mike Pompeo,756
-Sedgwick,530,U.S. House,4,R,Mike Pompeo,784
-Sedgwick,531,U.S. House,4,R,Mike Pompeo,1197
-Sedgwick,534,U.S. House,4,R,Mike Pompeo,74
-Sedgwick,538,U.S. House,4,R,Mike Pompeo,152
-Sedgwick,539,U.S. House,4,R,Mike Pompeo,357
-Sedgwick,601,U.S. House,4,R,Mike Pompeo,190
-Sedgwick,602,U.S. House,4,R,Mike Pompeo,511
-Sedgwick,603,U.S. House,4,R,Mike Pompeo,342
-Sedgwick,604,U.S. House,4,R,Mike Pompeo,536
-Sedgwick,605,U.S. House,4,R,Mike Pompeo,189
-Sedgwick,606,U.S. House,4,R,Mike Pompeo,151
-Sedgwick,607,U.S. House,4,R,Mike Pompeo,460
-Sedgwick,608,U.S. House,4,R,Mike Pompeo,228
-Sedgwick,609,U.S. House,4,R,Mike Pompeo,558
-Sedgwick,610,U.S. House,4,R,Mike Pompeo,604
-Sedgwick,611,U.S. House,4,R,Mike Pompeo,295
-Sedgwick,612,U.S. House,4,R,Mike Pompeo,762
-Sedgwick,613,U.S. House,4,R,Mike Pompeo,564
-Sedgwick,614,U.S. House,4,R,Mike Pompeo,173
-Sedgwick,615,U.S. House,4,R,Mike Pompeo,304
-Sedgwick,616,U.S. House,4,R,Mike Pompeo,255
-Sedgwick,617,U.S. House,4,R,Mike Pompeo,124
-Sedgwick,618,U.S. House,4,R,Mike Pompeo,571
-Sedgwick,619,U.S. House,4,R,Mike Pompeo,535
-Sedgwick,621,U.S. House,4,R,Mike Pompeo,34
-Sedgwick,622,U.S. House,4,R,Mike Pompeo,856
-Sedgwick,623,U.S. House,4,R,Mike Pompeo,724
-Sedgwick,624,U.S. House,4,R,Mike Pompeo,38
-Sedgwick,627,U.S. House,4,R,Mike Pompeo,47
-Sedgwick,101,U.S. House,4,D,Perry Schuckman,329
-Sedgwick,102,U.S. House,4,D,Perry Schuckman,263
-Sedgwick,103,U.S. House,4,D,Perry Schuckman,57
-Sedgwick,104,U.S. House,4,D,Perry Schuckman,9
-Sedgwick,105,U.S. House,4,D,Perry Schuckman,270
-Sedgwick,106,U.S. House,4,D,Perry Schuckman,516
-Sedgwick,107,U.S. House,4,D,Perry Schuckman,534
-Sedgwick,108,U.S. House,4,D,Perry Schuckman,346
-Sedgwick,109,U.S. House,4,D,Perry Schuckman,421
-Sedgwick,110,U.S. House,4,D,Perry Schuckman,513
-Sedgwick,111,U.S. House,4,D,Perry Schuckman,122
-Sedgwick,112,U.S. House,4,D,Perry Schuckman,476
-Sedgwick,113,U.S. House,4,D,Perry Schuckman,418
-Sedgwick,114,U.S. House,4,D,Perry Schuckman,380
-Sedgwick,116,U.S. House,4,D,Perry Schuckman,585
-Sedgwick,117,U.S. House,4,D,Perry Schuckman,543
-Sedgwick,118,U.S. House,4,D,Perry Schuckman,613
-Sedgwick,119,U.S. House,4,D,Perry Schuckman,408
-Sedgwick,120,U.S. House,4,D,Perry Schuckman,338
-Sedgwick,121,U.S. House,4,D,Perry Schuckman,290
-Sedgwick,122,U.S. House,4,D,Perry Schuckman,486
-Sedgwick,123,U.S. House,4,D,Perry Schuckman,93
-Sedgwick,124,U.S. House,4,D,Perry Schuckman,1
-Sedgwick,127,U.S. House,4,D,Perry Schuckman,72
-Sedgwick,128,U.S. House,4,D,Perry Schuckman,361
-Sedgwick,129,U.S. House,4,D,Perry Schuckman,86
-Sedgwick,130,U.S. House,4,D,Perry Schuckman,240
-Sedgwick,205,U.S. House,4,D,Perry Schuckman,109
-Sedgwick,206,U.S. House,4,D,Perry Schuckman,110
-Sedgwick,207,U.S. House,4,D,Perry Schuckman,589
-Sedgwick,208,U.S. House,4,D,Perry Schuckman,109
-Sedgwick,209,U.S. House,4,D,Perry Schuckman,291
-Sedgwick,210,U.S. House,4,D,Perry Schuckman,341
-Sedgwick,211,U.S. House,4,D,Perry Schuckman,213
-Sedgwick,212,U.S. House,4,D,Perry Schuckman,397
-Sedgwick,213,U.S. House,4,D,Perry Schuckman,364
-Sedgwick,214,U.S. House,4,D,Perry Schuckman,257
-Sedgwick,215,U.S. House,4,D,Perry Schuckman,482
-Sedgwick,216,U.S. House,4,D,Perry Schuckman,306
-Sedgwick,217,U.S. House,4,D,Perry Schuckman,306
-Sedgwick,218,U.S. House,4,D,Perry Schuckman,496
-Sedgwick,221,U.S. House,4,D,Perry Schuckman,194
-Sedgwick,222,U.S. House,4,D,Perry Schuckman,288
-Sedgwick,223,U.S. House,4,D,Perry Schuckman,323
-Sedgwick,224,U.S. House,4,D,Perry Schuckman,455
-Sedgwick,225,U.S. House,4,D,Perry Schuckman,431
-Sedgwick,226,U.S. House,4,D,Perry Schuckman,428
-Sedgwick,227,U.S. House,4,D,Perry Schuckman,183
-Sedgwick,228,U.S. House,4,D,Perry Schuckman,167
-Sedgwick,233,U.S. House,4,D,Perry Schuckman,111
-Sedgwick,235,U.S. House,4,D,Perry Schuckman,117
-Sedgwick,236,U.S. House,4,D,Perry Schuckman,162
-Sedgwick,239,U.S. House,4,D,Perry Schuckman,3
-Sedgwick,241,U.S. House,4,D,Perry Schuckman,71
-Sedgwick,301,U.S. House,4,D,Perry Schuckman,142
-Sedgwick,302,U.S. House,4,D,Perry Schuckman,281
-Sedgwick,303,U.S. House,4,D,Perry Schuckman,110
-Sedgwick,304,U.S. House,4,D,Perry Schuckman,143
-Sedgwick,305,U.S. House,4,D,Perry Schuckman,463
-Sedgwick,306,U.S. House,4,D,Perry Schuckman,490
-Sedgwick,307,U.S. House,4,D,Perry Schuckman,218
-Sedgwick,308,U.S. House,4,D,Perry Schuckman,352
-Sedgwick,309,U.S. House,4,D,Perry Schuckman,365
-Sedgwick,310,U.S. House,4,D,Perry Schuckman,191
-Sedgwick,311,U.S. House,4,D,Perry Schuckman,114
-Sedgwick,312,U.S. House,4,D,Perry Schuckman,131
-Sedgwick,313,U.S. House,4,D,Perry Schuckman,414
-Sedgwick,314,U.S. House,4,D,Perry Schuckman,324
-Sedgwick,315,U.S. House,4,D,Perry Schuckman,283
-Sedgwick,316,U.S. House,4,D,Perry Schuckman,266
-Sedgwick,317,U.S. House,4,D,Perry Schuckman,4
-Sedgwick,318,U.S. House,4,D,Perry Schuckman,8
-Sedgwick,319,U.S. House,4,D,Perry Schuckman,101
-Sedgwick,320,U.S. House,4,D,Perry Schuckman,79
-Sedgwick,321,U.S. House,4,D,Perry Schuckman,12
-Sedgwick,324,U.S. House,4,D,Perry Schuckman,129
-Sedgwick,325,U.S. House,4,D,Perry Schuckman,292
-Sedgwick,326,U.S. House,4,D,Perry Schuckman,32
-Sedgwick,401,U.S. House,4,D,Perry Schuckman,133
-Sedgwick,402,U.S. House,4,D,Perry Schuckman,148
-Sedgwick,403,U.S. House,4,D,Perry Schuckman,151
-Sedgwick,404,U.S. House,4,D,Perry Schuckman,413
-Sedgwick,405,U.S. House,4,D,Perry Schuckman,297
-Sedgwick,406,U.S. House,4,D,Perry Schuckman,241
-Sedgwick,407,U.S. House,4,D,Perry Schuckman,36
-Sedgwick,408,U.S. House,4,D,Perry Schuckman,275
-Sedgwick,409,U.S. House,4,D,Perry Schuckman,147
-Sedgwick,410,U.S. House,4,D,Perry Schuckman,306
-Sedgwick,412,U.S. House,4,D,Perry Schuckman,365
-Sedgwick,413,U.S. House,4,D,Perry Schuckman,288
-Sedgwick,414,U.S. House,4,D,Perry Schuckman,58
-Sedgwick,416,U.S. House,4,D,Perry Schuckman,198
-Sedgwick,417,U.S. House,4,D,Perry Schuckman,196
-Sedgwick,418,U.S. House,4,D,Perry Schuckman,289
-Sedgwick,419,U.S. House,4,D,Perry Schuckman,288
-Sedgwick,420,U.S. House,4,D,Perry Schuckman,303
-Sedgwick,422,U.S. House,4,D,Perry Schuckman,181
-Sedgwick,423,U.S. House,4,D,Perry Schuckman,209
-Sedgwick,424,U.S. House,4,D,Perry Schuckman,64
-Sedgwick,425,U.S. House,4,D,Perry Schuckman,347
-Sedgwick,429,U.S. House,4,D,Perry Schuckman,152
-Sedgwick,433,U.S. House,4,D,Perry Schuckman,80
-Sedgwick,437,U.S. House,4,D,Perry Schuckman,63
-Sedgwick,503,U.S. House,4,D,Perry Schuckman,295
-Sedgwick,504,U.S. House,4,D,Perry Schuckman,206
-Sedgwick,506,U.S. House,4,D,Perry Schuckman,303
-Sedgwick,507,U.S. House,4,D,Perry Schuckman,351
-Sedgwick,508,U.S. House,4,D,Perry Schuckman,302
-Sedgwick,509,U.S. House,4,D,Perry Schuckman,251
-Sedgwick,510,U.S. House,4,D,Perry Schuckman,244
-Sedgwick,512,U.S. House,4,D,Perry Schuckman,453
-Sedgwick,513,U.S. House,4,D,Perry Schuckman,90
-Sedgwick,514,U.S. House,4,D,Perry Schuckman,349
-Sedgwick,515,U.S. House,4,D,Perry Schuckman,322
-Sedgwick,516,U.S. House,4,D,Perry Schuckman,204
-Sedgwick,517,U.S. House,4,D,Perry Schuckman,256
-Sedgwick,518,U.S. House,4,D,Perry Schuckman,246
-Sedgwick,519,U.S. House,4,D,Perry Schuckman,346
-Sedgwick,522,U.S. House,4,D,Perry Schuckman,261
-Sedgwick,523,U.S. House,4,D,Perry Schuckman,261
-Sedgwick,524,U.S. House,4,D,Perry Schuckman,460
-Sedgwick,525,U.S. House,4,D,Perry Schuckman,357
-Sedgwick,526,U.S. House,4,D,Perry Schuckman,293
-Sedgwick,527,U.S. House,4,D,Perry Schuckman,271
-Sedgwick,530,U.S. House,4,D,Perry Schuckman,229
-Sedgwick,531,U.S. House,4,D,Perry Schuckman,435
-Sedgwick,534,U.S. House,4,D,Perry Schuckman,22
-Sedgwick,538,U.S. House,4,D,Perry Schuckman,47
-Sedgwick,539,U.S. House,4,D,Perry Schuckman,138
-Sedgwick,601,U.S. House,4,D,Perry Schuckman,303
-Sedgwick,602,U.S. House,4,D,Perry Schuckman,426
-Sedgwick,603,U.S. House,4,D,Perry Schuckman,120
-Sedgwick,604,U.S. House,4,D,Perry Schuckman,360
-Sedgwick,605,U.S. House,4,D,Perry Schuckman,148
-Sedgwick,606,U.S. House,4,D,Perry Schuckman,135
-Sedgwick,607,U.S. House,4,D,Perry Schuckman,688
-Sedgwick,608,U.S. House,4,D,Perry Schuckman,420
-Sedgwick,609,U.S. House,4,D,Perry Schuckman,701
-Sedgwick,610,U.S. House,4,D,Perry Schuckman,366
-Sedgwick,611,U.S. House,4,D,Perry Schuckman,198
-Sedgwick,612,U.S. House,4,D,Perry Schuckman,430
-Sedgwick,613,U.S. House,4,D,Perry Schuckman,370
-Sedgwick,614,U.S. House,4,D,Perry Schuckman,175
-Sedgwick,615,U.S. House,4,D,Perry Schuckman,528
-Sedgwick,616,U.S. House,4,D,Perry Schuckman,194
-Sedgwick,617,U.S. House,4,D,Perry Schuckman,135
-Sedgwick,618,U.S. House,4,D,Perry Schuckman,335
-Sedgwick,619,U.S. House,4,D,Perry Schuckman,392
-Sedgwick,621,U.S. House,4,D,Perry Schuckman,4
-Sedgwick,622,U.S. House,4,D,Perry Schuckman,312
-Sedgwick,623,U.S. House,4,D,Perry Schuckman,266
-Sedgwick,624,U.S. House,4,D,Perry Schuckman,33
-Sedgwick,627,U.S. House,4,D,Perry Schuckman,27
-Sedgwick,101,Governor,,R,Sam Brownback,292
-Sedgwick,102,Governor,,R,Sam Brownback,294
-Sedgwick,103,Governor,,R,Sam Brownback,26
-Sedgwick,104,Governor,,R,Sam Brownback,14
-Sedgwick,105,Governor,,R,Sam Brownback,93
-Sedgwick,106,Governor,,R,Sam Brownback,127
-Sedgwick,107,Governor,,R,Sam Brownback,421
-Sedgwick,108,Governor,,R,Sam Brownback,175
-Sedgwick,109,Governor,,R,Sam Brownback,196
-Sedgwick,110,Governor,,R,Sam Brownback,439
-Sedgwick,111,Governor,,R,Sam Brownback,118
-Sedgwick,112,Governor,,R,Sam Brownback,203
-Sedgwick,113,Governor,,R,Sam Brownback,47
-Sedgwick,114,Governor,,R,Sam Brownback,22
-Sedgwick,116,Governor,,R,Sam Brownback,50
-Sedgwick,117,Governor,,R,Sam Brownback,40
-Sedgwick,118,Governor,,R,Sam Brownback,89
-Sedgwick,119,Governor,,R,Sam Brownback,132
-Sedgwick,120,Governor,,R,Sam Brownback,167
-Sedgwick,121,Governor,,R,Sam Brownback,282
-Sedgwick,122,Governor,,R,Sam Brownback,398
-Sedgwick,123,Governor,,R,Sam Brownback,153
-Sedgwick,124,Governor,,R,Sam Brownback,0
-Sedgwick,127,Governor,,R,Sam Brownback,107
-Sedgwick,128,Governor,,R,Sam Brownback,328
-Sedgwick,129,Governor,,R,Sam Brownback,58
-Sedgwick,130,Governor,,R,Sam Brownback,150
-Sedgwick,205,Governor,,R,Sam Brownback,65
-Sedgwick,206,Governor,,R,Sam Brownback,99
-Sedgwick,207,Governor,,R,Sam Brownback,543
-Sedgwick,208,Governor,,R,Sam Brownback,106
-Sedgwick,209,Governor,,R,Sam Brownback,234
-Sedgwick,210,Governor,,R,Sam Brownback,308
-Sedgwick,211,Governor,,R,Sam Brownback,271
-Sedgwick,212,Governor,,R,Sam Brownback,472
-Sedgwick,213,Governor,,R,Sam Brownback,606
-Sedgwick,214,Governor,,R,Sam Brownback,643
-Sedgwick,215,Governor,,R,Sam Brownback,725
-Sedgwick,216,Governor,,R,Sam Brownback,457
-Sedgwick,217,Governor,,R,Sam Brownback,656
-Sedgwick,218,Governor,,R,Sam Brownback,835
-Sedgwick,221,Governor,,R,Sam Brownback,388
-Sedgwick,222,Governor,,R,Sam Brownback,521
-Sedgwick,223,Governor,,R,Sam Brownback,664
-Sedgwick,224,Governor,,R,Sam Brownback,500
-Sedgwick,225,Governor,,R,Sam Brownback,533
-Sedgwick,226,Governor,,R,Sam Brownback,871
-Sedgwick,227,Governor,,R,Sam Brownback,504
-Sedgwick,228,Governor,,R,Sam Brownback,741
-Sedgwick,233,Governor,,R,Sam Brownback,151
-Sedgwick,235,Governor,,R,Sam Brownback,79
-Sedgwick,236,Governor,,R,Sam Brownback,438
-Sedgwick,239,Governor,,R,Sam Brownback,15
-Sedgwick,241,Governor,,R,Sam Brownback,161
-Sedgwick,301,Governor,,R,Sam Brownback,139
-Sedgwick,302,Governor,,R,Sam Brownback,219
-Sedgwick,303,Governor,,R,Sam Brownback,127
-Sedgwick,304,Governor,,R,Sam Brownback,120
-Sedgwick,305,Governor,,R,Sam Brownback,383
-Sedgwick,306,Governor,,R,Sam Brownback,324
-Sedgwick,307,Governor,,R,Sam Brownback,144
-Sedgwick,308,Governor,,R,Sam Brownback,243
-Sedgwick,309,Governor,,R,Sam Brownback,326
-Sedgwick,310,Governor,,R,Sam Brownback,134
-Sedgwick,311,Governor,,R,Sam Brownback,147
-Sedgwick,312,Governor,,R,Sam Brownback,120
-Sedgwick,313,Governor,,R,Sam Brownback,331
-Sedgwick,314,Governor,,R,Sam Brownback,342
-Sedgwick,315,Governor,,R,Sam Brownback,235
-Sedgwick,316,Governor,,R,Sam Brownback,366
-Sedgwick,317,Governor,,R,Sam Brownback,7
-Sedgwick,318,Governor,,R,Sam Brownback,13
-Sedgwick,319,Governor,,R,Sam Brownback,57
-Sedgwick,320,Governor,,R,Sam Brownback,33
-Sedgwick,321,Governor,,R,Sam Brownback,1
-Sedgwick,324,Governor,,R,Sam Brownback,98
-Sedgwick,325,Governor,,R,Sam Brownback,263
-Sedgwick,326,Governor,,R,Sam Brownback,26
-Sedgwick,401,Governor,,R,Sam Brownback,226
-Sedgwick,402,Governor,,R,Sam Brownback,239
-Sedgwick,403,Governor,,R,Sam Brownback,408
-Sedgwick,404,Governor,,R,Sam Brownback,395
-Sedgwick,405,Governor,,R,Sam Brownback,296
-Sedgwick,406,Governor,,R,Sam Brownback,234
-Sedgwick,407,Governor,,R,Sam Brownback,30
-Sedgwick,408,Governor,,R,Sam Brownback,223
-Sedgwick,409,Governor,,R,Sam Brownback,121
-Sedgwick,410,Governor,,R,Sam Brownback,839
-Sedgwick,412,Governor,,R,Sam Brownback,765
-Sedgwick,413,Governor,,R,Sam Brownback,539
-Sedgwick,414,Governor,,R,Sam Brownback,115
-Sedgwick,416,Governor,,R,Sam Brownback,381
-Sedgwick,417,Governor,,R,Sam Brownback,222
-Sedgwick,418,Governor,,R,Sam Brownback,351
-Sedgwick,419,Governor,,R,Sam Brownback,261
-Sedgwick,420,Governor,,R,Sam Brownback,327
-Sedgwick,422,Governor,,R,Sam Brownback,216
-Sedgwick,423,Governor,,R,Sam Brownback,243
-Sedgwick,424,Governor,,R,Sam Brownback,72
-Sedgwick,425,Governor,,R,Sam Brownback,501
-Sedgwick,429,Governor,,R,Sam Brownback,153
-Sedgwick,433,Governor,,R,Sam Brownback,115
-Sedgwick,437,Governor,,R,Sam Brownback,134
-Sedgwick,503,Governor,,R,Sam Brownback,383
-Sedgwick,504,Governor,,R,Sam Brownback,257
-Sedgwick,506,Governor,,R,Sam Brownback,542
-Sedgwick,507,Governor,,R,Sam Brownback,476
-Sedgwick,508,Governor,,R,Sam Brownback,425
-Sedgwick,509,Governor,,R,Sam Brownback,441
-Sedgwick,510,Governor,,R,Sam Brownback,730
-Sedgwick,512,Governor,,R,Sam Brownback,1027
-Sedgwick,513,Governor,,R,Sam Brownback,340
-Sedgwick,514,Governor,,R,Sam Brownback,660
-Sedgwick,515,Governor,,R,Sam Brownback,561
-Sedgwick,516,Governor,,R,Sam Brownback,396
-Sedgwick,517,Governor,,R,Sam Brownback,351
-Sedgwick,518,Governor,,R,Sam Brownback,495
-Sedgwick,519,Governor,,R,Sam Brownback,472
-Sedgwick,522,Governor,,R,Sam Brownback,534
-Sedgwick,523,Governor,,R,Sam Brownback,518
-Sedgwick,524,Governor,,R,Sam Brownback,822
-Sedgwick,525,Governor,,R,Sam Brownback,494
-Sedgwick,526,Governor,,R,Sam Brownback,601
-Sedgwick,527,Governor,,R,Sam Brownback,572
-Sedgwick,530,Governor,,R,Sam Brownback,647
-Sedgwick,531,Governor,,R,Sam Brownback,953
-Sedgwick,534,Governor,,R,Sam Brownback,64
-Sedgwick,538,Governor,,R,Sam Brownback,116
-Sedgwick,539,Governor,,R,Sam Brownback,274
-Sedgwick,601,Governor,,R,Sam Brownback,136
-Sedgwick,602,Governor,,R,Sam Brownback,402
-Sedgwick,603,Governor,,R,Sam Brownback,284
-Sedgwick,604,Governor,,R,Sam Brownback,396
-Sedgwick,605,Governor,,R,Sam Brownback,153
-Sedgwick,606,Governor,,R,Sam Brownback,114
-Sedgwick,607,Governor,,R,Sam Brownback,320
-Sedgwick,608,Governor,,R,Sam Brownback,161
-Sedgwick,609,Governor,,R,Sam Brownback,383
-Sedgwick,610,Governor,,R,Sam Brownback,426
-Sedgwick,611,Governor,,R,Sam Brownback,223
-Sedgwick,612,Governor,,R,Sam Brownback,523
-Sedgwick,613,Governor,,R,Sam Brownback,402
-Sedgwick,614,Governor,,R,Sam Brownback,137
-Sedgwick,615,Governor,,R,Sam Brownback,229
-Sedgwick,616,Governor,,R,Sam Brownback,205
-Sedgwick,617,Governor,,R,Sam Brownback,88
-Sedgwick,618,Governor,,R,Sam Brownback,442
-Sedgwick,619,Governor,,R,Sam Brownback,412
-Sedgwick,621,Governor,,R,Sam Brownback,23
-Sedgwick,622,Governor,,R,Sam Brownback,668
-Sedgwick,623,Governor,,R,Sam Brownback,589
-Sedgwick,624,Governor,,R,Sam Brownback,29
-Sedgwick,627,Governor,,R,Sam Brownback,37
-Sedgwick,101,Governor,,D,Paul Davis,402
-Sedgwick,102,Governor,,D,Paul Davis,403
-Sedgwick,103,Governor,,D,Paul Davis,68
-Sedgwick,104,Governor,,D,Paul Davis,12
-Sedgwick,105,Governor,,D,Paul Davis,296
-Sedgwick,106,Governor,,D,Paul Davis,551
-Sedgwick,107,Governor,,D,Paul Davis,664
-Sedgwick,108,Governor,,D,Paul Davis,400
-Sedgwick,109,Governor,,D,Paul Davis,473
-Sedgwick,110,Governor,,D,Paul Davis,639
-Sedgwick,111,Governor,,D,Paul Davis,168
-Sedgwick,112,Governor,,D,Paul Davis,549
-Sedgwick,113,Governor,,D,Paul Davis,446
-Sedgwick,114,Governor,,D,Paul Davis,406
-Sedgwick,116,Governor,,D,Paul Davis,593
-Sedgwick,117,Governor,,D,Paul Davis,560
-Sedgwick,118,Governor,,D,Paul Davis,648
-Sedgwick,119,Governor,,D,Paul Davis,454
-Sedgwick,120,Governor,,D,Paul Davis,411
-Sedgwick,121,Governor,,D,Paul Davis,373
-Sedgwick,122,Governor,,D,Paul Davis,599
-Sedgwick,123,Governor,,D,Paul Davis,123
-Sedgwick,124,Governor,,D,Paul Davis,1
-Sedgwick,127,Governor,,D,Paul Davis,86
-Sedgwick,128,Governor,,D,Paul Davis,478
-Sedgwick,129,Governor,,D,Paul Davis,88
-Sedgwick,130,Governor,,D,Paul Davis,277
-Sedgwick,205,Governor,,D,Paul Davis,125
-Sedgwick,206,Governor,,D,Paul Davis,129
-Sedgwick,207,Governor,,D,Paul Davis,716
-Sedgwick,208,Governor,,D,Paul Davis,136
-Sedgwick,209,Governor,,D,Paul Davis,361
-Sedgwick,210,Governor,,D,Paul Davis,424
-Sedgwick,211,Governor,,D,Paul Davis,265
-Sedgwick,212,Governor,,D,Paul Davis,567
-Sedgwick,213,Governor,,D,Paul Davis,528
-Sedgwick,214,Governor,,D,Paul Davis,417
-Sedgwick,215,Governor,,D,Paul Davis,684
-Sedgwick,216,Governor,,D,Paul Davis,428
-Sedgwick,217,Governor,,D,Paul Davis,438
-Sedgwick,218,Governor,,D,Paul Davis,681
-Sedgwick,221,Governor,,D,Paul Davis,294
-Sedgwick,222,Governor,,D,Paul Davis,415
-Sedgwick,223,Governor,,D,Paul Davis,460
-Sedgwick,224,Governor,,D,Paul Davis,547
-Sedgwick,225,Governor,,D,Paul Davis,559
-Sedgwick,226,Governor,,D,Paul Davis,583
-Sedgwick,227,Governor,,D,Paul Davis,288
-Sedgwick,228,Governor,,D,Paul Davis,302
-Sedgwick,233,Governor,,D,Paul Davis,134
-Sedgwick,235,Governor,,D,Paul Davis,143
-Sedgwick,236,Governor,,D,Paul Davis,258
-Sedgwick,239,Governor,,D,Paul Davis,4
-Sedgwick,241,Governor,,D,Paul Davis,110
-Sedgwick,301,Governor,,D,Paul Davis,165
-Sedgwick,302,Governor,,D,Paul Davis,310
-Sedgwick,303,Governor,,D,Paul Davis,118
-Sedgwick,304,Governor,,D,Paul Davis,172
-Sedgwick,305,Governor,,D,Paul Davis,583
-Sedgwick,306,Governor,,D,Paul Davis,541
-Sedgwick,307,Governor,,D,Paul Davis,233
-Sedgwick,308,Governor,,D,Paul Davis,413
-Sedgwick,309,Governor,,D,Paul Davis,436
-Sedgwick,310,Governor,,D,Paul Davis,201
-Sedgwick,311,Governor,,D,Paul Davis,141
-Sedgwick,312,Governor,,D,Paul Davis,160
-Sedgwick,313,Governor,,D,Paul Davis,481
-Sedgwick,314,Governor,,D,Paul Davis,394
-Sedgwick,315,Governor,,D,Paul Davis,307
-Sedgwick,316,Governor,,D,Paul Davis,313
-Sedgwick,317,Governor,,D,Paul Davis,5
-Sedgwick,318,Governor,,D,Paul Davis,9
-Sedgwick,319,Governor,,D,Paul Davis,118
-Sedgwick,320,Governor,,D,Paul Davis,76
-Sedgwick,321,Governor,,D,Paul Davis,14
-Sedgwick,324,Governor,,D,Paul Davis,153
-Sedgwick,325,Governor,,D,Paul Davis,339
-Sedgwick,326,Governor,,D,Paul Davis,41
-Sedgwick,401,Governor,,D,Paul Davis,182
-Sedgwick,402,Governor,,D,Paul Davis,191
-Sedgwick,403,Governor,,D,Paul Davis,252
-Sedgwick,404,Governor,,D,Paul Davis,467
-Sedgwick,405,Governor,,D,Paul Davis,336
-Sedgwick,406,Governor,,D,Paul Davis,276
-Sedgwick,407,Governor,,D,Paul Davis,43
-Sedgwick,408,Governor,,D,Paul Davis,309
-Sedgwick,409,Governor,,D,Paul Davis,173
-Sedgwick,410,Governor,,D,Paul Davis,541
-Sedgwick,412,Governor,,D,Paul Davis,526
-Sedgwick,413,Governor,,D,Paul Davis,413
-Sedgwick,414,Governor,,D,Paul Davis,87
-Sedgwick,416,Governor,,D,Paul Davis,260
-Sedgwick,417,Governor,,D,Paul Davis,257
-Sedgwick,418,Governor,,D,Paul Davis,352
-Sedgwick,419,Governor,,D,Paul Davis,359
-Sedgwick,420,Governor,,D,Paul Davis,325
-Sedgwick,422,Governor,,D,Paul Davis,187
-Sedgwick,423,Governor,,D,Paul Davis,241
-Sedgwick,424,Governor,,D,Paul Davis,84
-Sedgwick,425,Governor,,D,Paul Davis,415
-Sedgwick,429,Governor,,D,Paul Davis,182
-Sedgwick,433,Governor,,D,Paul Davis,113
-Sedgwick,437,Governor,,D,Paul Davis,83
-Sedgwick,503,Governor,,D,Paul Davis,353
-Sedgwick,504,Governor,,D,Paul Davis,267
-Sedgwick,506,Governor,,D,Paul Davis,448
-Sedgwick,507,Governor,,D,Paul Davis,448
-Sedgwick,508,Governor,,D,Paul Davis,413
-Sedgwick,509,Governor,,D,Paul Davis,369
-Sedgwick,510,Governor,,D,Paul Davis,465
-Sedgwick,512,Governor,,D,Paul Davis,729
-Sedgwick,513,Governor,,D,Paul Davis,162
-Sedgwick,514,Governor,,D,Paul Davis,521
-Sedgwick,515,Governor,,D,Paul Davis,473
-Sedgwick,516,Governor,,D,Paul Davis,304
-Sedgwick,517,Governor,,D,Paul Davis,346
-Sedgwick,518,Governor,,D,Paul Davis,364
-Sedgwick,519,Governor,,D,Paul Davis,473
-Sedgwick,522,Governor,,D,Paul Davis,379
-Sedgwick,523,Governor,,D,Paul Davis,408
-Sedgwick,524,Governor,,D,Paul Davis,648
-Sedgwick,525,Governor,,D,Paul Davis,482
-Sedgwick,526,Governor,,D,Paul Davis,419
-Sedgwick,527,Governor,,D,Paul Davis,439
-Sedgwick,530,Governor,,D,Paul Davis,348
-Sedgwick,531,Governor,,D,Paul Davis,652
-Sedgwick,534,Governor,,D,Paul Davis,30
-Sedgwick,538,Governor,,D,Paul Davis,80
-Sedgwick,539,Governor,,D,Paul Davis,204
-Sedgwick,601,Governor,,D,Paul Davis,345
-Sedgwick,602,Governor,,D,Paul Davis,492
-Sedgwick,603,Governor,,D,Paul Davis,173
-Sedgwick,604,Governor,,D,Paul Davis,456
-Sedgwick,605,Governor,,D,Paul Davis,179
-Sedgwick,606,Governor,,D,Paul Davis,167
-Sedgwick,607,Governor,,D,Paul Davis,809
-Sedgwick,608,Governor,,D,Paul Davis,464
-Sedgwick,609,Governor,,D,Paul Davis,825
-Sedgwick,610,Governor,,D,Paul Davis,503
-Sedgwick,611,Governor,,D,Paul Davis,247
-Sedgwick,612,Governor,,D,Paul Davis,639
-Sedgwick,613,Governor,,D,Paul Davis,517
-Sedgwick,614,Governor,,D,Paul Davis,197
-Sedgwick,615,Governor,,D,Paul Davis,569
-Sedgwick,616,Governor,,D,Paul Davis,210
-Sedgwick,617,Governor,,D,Paul Davis,142
-Sedgwick,618,Governor,,D,Paul Davis,440
-Sedgwick,619,Governor,,D,Paul Davis,485
-Sedgwick,621,Governor,,D,Paul Davis,14
-Sedgwick,622,Governor,,D,Paul Davis,460
-Sedgwick,623,Governor,,D,Paul Davis,368
-Sedgwick,624,Governor,,D,Paul Davis,39
-Sedgwick,627,Governor,,D,Paul Davis,34
-Sedgwick,101,Governor,,L,Keen Umbehr,44
-Sedgwick,102,Governor,,L,Keen Umbehr,28
-Sedgwick,103,Governor,,L,Keen Umbehr,7
-Sedgwick,104,Governor,,L,Keen Umbehr,4
-Sedgwick,105,Governor,,L,Keen Umbehr,23
-Sedgwick,106,Governor,,L,Keen Umbehr,37
-Sedgwick,107,Governor,,L,Keen Umbehr,34
-Sedgwick,108,Governor,,L,Keen Umbehr,30
-Sedgwick,109,Governor,,L,Keen Umbehr,33
-Sedgwick,110,Governor,,L,Keen Umbehr,53
-Sedgwick,111,Governor,,L,Keen Umbehr,9
-Sedgwick,112,Governor,,L,Keen Umbehr,32
-Sedgwick,113,Governor,,L,Keen Umbehr,17
-Sedgwick,114,Governor,,L,Keen Umbehr,14
-Sedgwick,116,Governor,,L,Keen Umbehr,19
-Sedgwick,117,Governor,,L,Keen Umbehr,13
-Sedgwick,118,Governor,,L,Keen Umbehr,25
-Sedgwick,119,Governor,,L,Keen Umbehr,24
-Sedgwick,120,Governor,,L,Keen Umbehr,24
-Sedgwick,121,Governor,,L,Keen Umbehr,19
-Sedgwick,122,Governor,,L,Keen Umbehr,31
-Sedgwick,123,Governor,,L,Keen Umbehr,17
-Sedgwick,124,Governor,,L,Keen Umbehr,0
-Sedgwick,127,Governor,,L,Keen Umbehr,17
-Sedgwick,128,Governor,,L,Keen Umbehr,35
-Sedgwick,129,Governor,,L,Keen Umbehr,15
-Sedgwick,130,Governor,,L,Keen Umbehr,30
-Sedgwick,205,Governor,,L,Keen Umbehr,16
-Sedgwick,206,Governor,,L,Keen Umbehr,6
-Sedgwick,207,Governor,,L,Keen Umbehr,46
-Sedgwick,208,Governor,,L,Keen Umbehr,15
-Sedgwick,209,Governor,,L,Keen Umbehr,21
-Sedgwick,210,Governor,,L,Keen Umbehr,39
-Sedgwick,211,Governor,,L,Keen Umbehr,16
-Sedgwick,212,Governor,,L,Keen Umbehr,22
-Sedgwick,213,Governor,,L,Keen Umbehr,38
-Sedgwick,214,Governor,,L,Keen Umbehr,20
-Sedgwick,215,Governor,,L,Keen Umbehr,24
-Sedgwick,216,Governor,,L,Keen Umbehr,18
-Sedgwick,217,Governor,,L,Keen Umbehr,21
-Sedgwick,218,Governor,,L,Keen Umbehr,39
-Sedgwick,221,Governor,,L,Keen Umbehr,21
-Sedgwick,222,Governor,,L,Keen Umbehr,21
-Sedgwick,223,Governor,,L,Keen Umbehr,31
-Sedgwick,224,Governor,,L,Keen Umbehr,59
-Sedgwick,225,Governor,,L,Keen Umbehr,56
-Sedgwick,226,Governor,,L,Keen Umbehr,41
-Sedgwick,227,Governor,,L,Keen Umbehr,21
-Sedgwick,228,Governor,,L,Keen Umbehr,23
-Sedgwick,233,Governor,,L,Keen Umbehr,12
-Sedgwick,235,Governor,,L,Keen Umbehr,9
-Sedgwick,236,Governor,,L,Keen Umbehr,11
-Sedgwick,239,Governor,,L,Keen Umbehr,0
-Sedgwick,241,Governor,,L,Keen Umbehr,5
-Sedgwick,301,Governor,,L,Keen Umbehr,20
-Sedgwick,302,Governor,,L,Keen Umbehr,54
-Sedgwick,303,Governor,,L,Keen Umbehr,21
-Sedgwick,304,Governor,,L,Keen Umbehr,19
-Sedgwick,305,Governor,,L,Keen Umbehr,52
-Sedgwick,306,Governor,,L,Keen Umbehr,62
-Sedgwick,307,Governor,,L,Keen Umbehr,23
-Sedgwick,308,Governor,,L,Keen Umbehr,37
-Sedgwick,309,Governor,,L,Keen Umbehr,50
-Sedgwick,310,Governor,,L,Keen Umbehr,27
-Sedgwick,311,Governor,,L,Keen Umbehr,20
-Sedgwick,312,Governor,,L,Keen Umbehr,24
-Sedgwick,313,Governor,,L,Keen Umbehr,58
-Sedgwick,314,Governor,,L,Keen Umbehr,59
-Sedgwick,315,Governor,,L,Keen Umbehr,63
-Sedgwick,316,Governor,,L,Keen Umbehr,53
-Sedgwick,317,Governor,,L,Keen Umbehr,0
-Sedgwick,318,Governor,,L,Keen Umbehr,1
-Sedgwick,319,Governor,,L,Keen Umbehr,11
-Sedgwick,320,Governor,,L,Keen Umbehr,13
-Sedgwick,321,Governor,,L,Keen Umbehr,3
-Sedgwick,324,Governor,,L,Keen Umbehr,19
-Sedgwick,325,Governor,,L,Keen Umbehr,43
-Sedgwick,326,Governor,,L,Keen Umbehr,6
-Sedgwick,401,Governor,,L,Keen Umbehr,19
-Sedgwick,402,Governor,,L,Keen Umbehr,14
-Sedgwick,403,Governor,,L,Keen Umbehr,19
-Sedgwick,404,Governor,,L,Keen Umbehr,50
-Sedgwick,405,Governor,,L,Keen Umbehr,42
-Sedgwick,406,Governor,,L,Keen Umbehr,53
-Sedgwick,407,Governor,,L,Keen Umbehr,3
-Sedgwick,408,Governor,,L,Keen Umbehr,41
-Sedgwick,409,Governor,,L,Keen Umbehr,27
-Sedgwick,410,Governor,,L,Keen Umbehr,47
-Sedgwick,412,Governor,,L,Keen Umbehr,69
-Sedgwick,413,Governor,,L,Keen Umbehr,49
-Sedgwick,414,Governor,,L,Keen Umbehr,5
-Sedgwick,416,Governor,,L,Keen Umbehr,29
-Sedgwick,417,Governor,,L,Keen Umbehr,29
-Sedgwick,418,Governor,,L,Keen Umbehr,51
-Sedgwick,419,Governor,,L,Keen Umbehr,36
-Sedgwick,420,Governor,,L,Keen Umbehr,48
-Sedgwick,422,Governor,,L,Keen Umbehr,32
-Sedgwick,423,Governor,,L,Keen Umbehr,38
-Sedgwick,424,Governor,,L,Keen Umbehr,15
-Sedgwick,425,Governor,,L,Keen Umbehr,70
-Sedgwick,429,Governor,,L,Keen Umbehr,20
-Sedgwick,433,Governor,,L,Keen Umbehr,10
-Sedgwick,437,Governor,,L,Keen Umbehr,14
-Sedgwick,503,Governor,,L,Keen Umbehr,49
-Sedgwick,504,Governor,,L,Keen Umbehr,22
-Sedgwick,506,Governor,,L,Keen Umbehr,42
-Sedgwick,507,Governor,,L,Keen Umbehr,54
-Sedgwick,508,Governor,,L,Keen Umbehr,32
-Sedgwick,509,Governor,,L,Keen Umbehr,29
-Sedgwick,510,Governor,,L,Keen Umbehr,19
-Sedgwick,512,Governor,,L,Keen Umbehr,51
-Sedgwick,513,Governor,,L,Keen Umbehr,12
-Sedgwick,514,Governor,,L,Keen Umbehr,28
-Sedgwick,515,Governor,,L,Keen Umbehr,41
-Sedgwick,516,Governor,,L,Keen Umbehr,28
-Sedgwick,517,Governor,,L,Keen Umbehr,37
-Sedgwick,518,Governor,,L,Keen Umbehr,28
-Sedgwick,519,Governor,,L,Keen Umbehr,45
-Sedgwick,522,Governor,,L,Keen Umbehr,38
-Sedgwick,523,Governor,,L,Keen Umbehr,33
-Sedgwick,524,Governor,,L,Keen Umbehr,52
-Sedgwick,525,Governor,,L,Keen Umbehr,45
-Sedgwick,526,Governor,,L,Keen Umbehr,47
-Sedgwick,527,Governor,,L,Keen Umbehr,34
-Sedgwick,530,Governor,,L,Keen Umbehr,26
-Sedgwick,531,Governor,,L,Keen Umbehr,41
-Sedgwick,534,Governor,,L,Keen Umbehr,2
-Sedgwick,538,Governor,,L,Keen Umbehr,5
-Sedgwick,539,Governor,,L,Keen Umbehr,30
-Sedgwick,601,Governor,,L,Keen Umbehr,22
-Sedgwick,602,Governor,,L,Keen Umbehr,57
-Sedgwick,603,Governor,,L,Keen Umbehr,14
-Sedgwick,604,Governor,,L,Keen Umbehr,68
-Sedgwick,605,Governor,,L,Keen Umbehr,14
-Sedgwick,606,Governor,,L,Keen Umbehr,11
-Sedgwick,607,Governor,,L,Keen Umbehr,47
-Sedgwick,608,Governor,,L,Keen Umbehr,36
-Sedgwick,609,Governor,,L,Keen Umbehr,73
-Sedgwick,610,Governor,,L,Keen Umbehr,56
-Sedgwick,611,Governor,,L,Keen Umbehr,29
-Sedgwick,612,Governor,,L,Keen Umbehr,49
-Sedgwick,613,Governor,,L,Keen Umbehr,35
-Sedgwick,614,Governor,,L,Keen Umbehr,23
-Sedgwick,615,Governor,,L,Keen Umbehr,49
-Sedgwick,616,Governor,,L,Keen Umbehr,41
-Sedgwick,617,Governor,,L,Keen Umbehr,36
-Sedgwick,618,Governor,,L,Keen Umbehr,31
-Sedgwick,619,Governor,,L,Keen Umbehr,50
-Sedgwick,621,Governor,,L,Keen Umbehr,0
-Sedgwick,622,Governor,,L,Keen Umbehr,41
-Sedgwick,623,Governor,,L,Keen Umbehr,38
-Sedgwick,624,Governor,,L,Keen Umbehr,4
-Sedgwick,627,Governor,,L,Keen Umbehr,6
-Sedgwick,101,Secretary of State,,R,Kris Kobach,325
-Sedgwick,102,Secretary of State,,R,Kris Kobach,330
-Sedgwick,103,Secretary of State,,R,Kris Kobach,29
-Sedgwick,104,Secretary of State,,R,Kris Kobach,18
-Sedgwick,105,Secretary of State,,R,Kris Kobach,114
-Sedgwick,106,Secretary of State,,R,Kris Kobach,152
-Sedgwick,107,Secretary of State,,R,Kris Kobach,445
-Sedgwick,108,Secretary of State,,R,Kris Kobach,201
-Sedgwick,109,Secretary of State,,R,Kris Kobach,210
-Sedgwick,110,Secretary of State,,R,Kris Kobach,494
-Sedgwick,111,Secretary of State,,R,Kris Kobach,136
-Sedgwick,112,Secretary of State,,R,Kris Kobach,224
-Sedgwick,113,Secretary of State,,R,Kris Kobach,47
-Sedgwick,114,Secretary of State,,R,Kris Kobach,17
-Sedgwick,116,Secretary of State,,R,Kris Kobach,50
-Sedgwick,117,Secretary of State,,R,Kris Kobach,34
-Sedgwick,118,Secretary of State,,R,Kris Kobach,80
-Sedgwick,119,Secretary of State,,R,Kris Kobach,151
-Sedgwick,120,Secretary of State,,R,Kris Kobach,196
-Sedgwick,121,Secretary of State,,R,Kris Kobach,314
-Sedgwick,122,Secretary of State,,R,Kris Kobach,434
-Sedgwick,123,Secretary of State,,R,Kris Kobach,165
-Sedgwick,124,Secretary of State,,R,Kris Kobach,0
-Sedgwick,127,Secretary of State,,R,Kris Kobach,133
-Sedgwick,128,Secretary of State,,R,Kris Kobach,357
-Sedgwick,129,Secretary of State,,R,Kris Kobach,65
-Sedgwick,130,Secretary of State,,R,Kris Kobach,176
-Sedgwick,205,Secretary of State,,R,Kris Kobach,70
-Sedgwick,206,Secretary of State,,R,Kris Kobach,110
-Sedgwick,207,Secretary of State,,R,Kris Kobach,582
-Sedgwick,208,Secretary of State,,R,Kris Kobach,125
-Sedgwick,209,Secretary of State,,R,Kris Kobach,265
-Sedgwick,210,Secretary of State,,R,Kris Kobach,339
-Sedgwick,211,Secretary of State,,R,Kris Kobach,295
-Sedgwick,212,Secretary of State,,R,Kris Kobach,508
-Sedgwick,213,Secretary of State,,R,Kris Kobach,634
-Sedgwick,214,Secretary of State,,R,Kris Kobach,636
-Sedgwick,215,Secretary of State,,R,Kris Kobach,770
-Sedgwick,216,Secretary of State,,R,Kris Kobach,458
-Sedgwick,217,Secretary of State,,R,Kris Kobach,659
-Sedgwick,218,Secretary of State,,R,Kris Kobach,879
-Sedgwick,221,Secretary of State,,R,Kris Kobach,417
-Sedgwick,222,Secretary of State,,R,Kris Kobach,553
-Sedgwick,223,Secretary of State,,R,Kris Kobach,702
-Sedgwick,224,Secretary of State,,R,Kris Kobach,567
-Sedgwick,225,Secretary of State,,R,Kris Kobach,608
-Sedgwick,226,Secretary of State,,R,Kris Kobach,916
-Sedgwick,227,Secretary of State,,R,Kris Kobach,531
-Sedgwick,228,Secretary of State,,R,Kris Kobach,774
-Sedgwick,233,Secretary of State,,R,Kris Kobach,175
-Sedgwick,235,Secretary of State,,R,Kris Kobach,88
-Sedgwick,236,Secretary of State,,R,Kris Kobach,463
-Sedgwick,239,Secretary of State,,R,Kris Kobach,15
-Sedgwick,241,Secretary of State,,R,Kris Kobach,166
-Sedgwick,301,Secretary of State,,R,Kris Kobach,161
-Sedgwick,302,Secretary of State,,R,Kris Kobach,249
-Sedgwick,303,Secretary of State,,R,Kris Kobach,132
-Sedgwick,304,Secretary of State,,R,Kris Kobach,143
-Sedgwick,305,Secretary of State,,R,Kris Kobach,437
-Sedgwick,306,Secretary of State,,R,Kris Kobach,372
-Sedgwick,307,Secretary of State,,R,Kris Kobach,151
-Sedgwick,308,Secretary of State,,R,Kris Kobach,268
-Sedgwick,309,Secretary of State,,R,Kris Kobach,363
-Sedgwick,310,Secretary of State,,R,Kris Kobach,146
-Sedgwick,311,Secretary of State,,R,Kris Kobach,163
-Sedgwick,312,Secretary of State,,R,Kris Kobach,157
-Sedgwick,313,Secretary of State,,R,Kris Kobach,382
-Sedgwick,314,Secretary of State,,R,Kris Kobach,408
-Sedgwick,315,Secretary of State,,R,Kris Kobach,277
-Sedgwick,316,Secretary of State,,R,Kris Kobach,412
-Sedgwick,317,Secretary of State,,R,Kris Kobach,8
-Sedgwick,318,Secretary of State,,R,Kris Kobach,17
-Sedgwick,319,Secretary of State,,R,Kris Kobach,67
-Sedgwick,320,Secretary of State,,R,Kris Kobach,36
-Sedgwick,321,Secretary of State,,R,Kris Kobach,4
-Sedgwick,324,Secretary of State,,R,Kris Kobach,117
-Sedgwick,325,Secretary of State,,R,Kris Kobach,316
-Sedgwick,326,Secretary of State,,R,Kris Kobach,37
-Sedgwick,401,Secretary of State,,R,Kris Kobach,244
-Sedgwick,402,Secretary of State,,R,Kris Kobach,254
-Sedgwick,403,Secretary of State,,R,Kris Kobach,427
-Sedgwick,404,Secretary of State,,R,Kris Kobach,441
-Sedgwick,405,Secretary of State,,R,Kris Kobach,341
-Sedgwick,406,Secretary of State,,R,Kris Kobach,275
-Sedgwick,407,Secretary of State,,R,Kris Kobach,33
-Sedgwick,408,Secretary of State,,R,Kris Kobach,250
-Sedgwick,409,Secretary of State,,R,Kris Kobach,149
-Sedgwick,410,Secretary of State,,R,Kris Kobach,963
-Sedgwick,412,Secretary of State,,R,Kris Kobach,876
-Sedgwick,413,Secretary of State,,R,Kris Kobach,611
-Sedgwick,414,Secretary of State,,R,Kris Kobach,130
-Sedgwick,416,Secretary of State,,R,Kris Kobach,426
-Sedgwick,417,Secretary of State,,R,Kris Kobach,249
-Sedgwick,418,Secretary of State,,R,Kris Kobach,386
-Sedgwick,419,Secretary of State,,R,Kris Kobach,309
-Sedgwick,420,Secretary of State,,R,Kris Kobach,367
-Sedgwick,422,Secretary of State,,R,Kris Kobach,230
-Sedgwick,423,Secretary of State,,R,Kris Kobach,281
-Sedgwick,424,Secretary of State,,R,Kris Kobach,85
-Sedgwick,425,Secretary of State,,R,Kris Kobach,586
-Sedgwick,429,Secretary of State,,R,Kris Kobach,179
-Sedgwick,433,Secretary of State,,R,Kris Kobach,143
-Sedgwick,437,Secretary of State,,R,Kris Kobach,152
-Sedgwick,503,Secretary of State,,R,Kris Kobach,396
-Sedgwick,504,Secretary of State,,R,Kris Kobach,293
-Sedgwick,506,Secretary of State,,R,Kris Kobach,600
-Sedgwick,507,Secretary of State,,R,Kris Kobach,545
-Sedgwick,508,Secretary of State,,R,Kris Kobach,473
-Sedgwick,509,Secretary of State,,R,Kris Kobach,480
-Sedgwick,510,Secretary of State,,R,Kris Kobach,791
-Sedgwick,512,Secretary of State,,R,Kris Kobach,1176
-Sedgwick,513,Secretary of State,,R,Kris Kobach,362
-Sedgwick,514,Secretary of State,,R,Kris Kobach,726
-Sedgwick,515,Secretary of State,,R,Kris Kobach,634
-Sedgwick,516,Secretary of State,,R,Kris Kobach,421
-Sedgwick,517,Secretary of State,,R,Kris Kobach,390
-Sedgwick,518,Secretary of State,,R,Kris Kobach,532
-Sedgwick,519,Secretary of State,,R,Kris Kobach,534
-Sedgwick,522,Secretary of State,,R,Kris Kobach,578
-Sedgwick,523,Secretary of State,,R,Kris Kobach,563
-Sedgwick,524,Secretary of State,,R,Kris Kobach,889
-Sedgwick,525,Secretary of State,,R,Kris Kobach,535
-Sedgwick,526,Secretary of State,,R,Kris Kobach,647
-Sedgwick,527,Secretary of State,,R,Kris Kobach,648
-Sedgwick,530,Secretary of State,,R,Kris Kobach,696
-Sedgwick,531,Secretary of State,,R,Kris Kobach,1020
-Sedgwick,534,Secretary of State,,R,Kris Kobach,66
-Sedgwick,538,Secretary of State,,R,Kris Kobach,129
-Sedgwick,539,Secretary of State,,R,Kris Kobach,322
-Sedgwick,601,Secretary of State,,R,Kris Kobach,155
-Sedgwick,602,Secretary of State,,R,Kris Kobach,459
-Sedgwick,603,Secretary of State,,R,Kris Kobach,301
-Sedgwick,604,Secretary of State,,R,Kris Kobach,481
-Sedgwick,605,Secretary of State,,R,Kris Kobach,167
-Sedgwick,606,Secretary of State,,R,Kris Kobach,115
-Sedgwick,607,Secretary of State,,R,Kris Kobach,361
-Sedgwick,608,Secretary of State,,R,Kris Kobach,181
-Sedgwick,609,Secretary of State,,R,Kris Kobach,455
-Sedgwick,610,Secretary of State,,R,Kris Kobach,488
-Sedgwick,611,Secretary of State,,R,Kris Kobach,249
-Sedgwick,612,Secretary of State,,R,Kris Kobach,610
-Sedgwick,613,Secretary of State,,R,Kris Kobach,432
-Sedgwick,614,Secretary of State,,R,Kris Kobach,164
-Sedgwick,615,Secretary of State,,R,Kris Kobach,247
-Sedgwick,616,Secretary of State,,R,Kris Kobach,245
-Sedgwick,617,Secretary of State,,R,Kris Kobach,109
-Sedgwick,618,Secretary of State,,R,Kris Kobach,487
-Sedgwick,619,Secretary of State,,R,Kris Kobach,452
-Sedgwick,621,Secretary of State,,R,Kris Kobach,26
-Sedgwick,622,Secretary of State,,R,Kris Kobach,704
-Sedgwick,623,Secretary of State,,R,Kris Kobach,629
-Sedgwick,624,Secretary of State,,R,Kris Kobach,26
-Sedgwick,627,Secretary of State,,R,Kris Kobach,45
-Sedgwick,101,Secretary of State,,D,Jean Schodorf,405
-Sedgwick,102,Secretary of State,,D,Jean Schodorf,390
-Sedgwick,103,Secretary of State,,D,Jean Schodorf,69
-Sedgwick,104,Secretary of State,,D,Jean Schodorf,12
-Sedgwick,105,Secretary of State,,D,Jean Schodorf,291
-Sedgwick,106,Secretary of State,,D,Jean Schodorf,552
-Sedgwick,107,Secretary of State,,D,Jean Schodorf,663
-Sedgwick,108,Secretary of State,,D,Jean Schodorf,391
-Sedgwick,109,Secretary of State,,D,Jean Schodorf,485
-Sedgwick,110,Secretary of State,,D,Jean Schodorf,625
-Sedgwick,111,Secretary of State,,D,Jean Schodorf,157
-Sedgwick,112,Secretary of State,,D,Jean Schodorf,554
-Sedgwick,113,Secretary of State,,D,Jean Schodorf,457
-Sedgwick,114,Secretary of State,,D,Jean Schodorf,422
-Sedgwick,116,Secretary of State,,D,Jean Schodorf,608
-Sedgwick,117,Secretary of State,,D,Jean Schodorf,578
-Sedgwick,118,Secretary of State,,D,Jean Schodorf,682
-Sedgwick,119,Secretary of State,,D,Jean Schodorf,452
-Sedgwick,120,Secretary of State,,D,Jean Schodorf,395
-Sedgwick,121,Secretary of State,,D,Jean Schodorf,359
-Sedgwick,122,Secretary of State,,D,Jean Schodorf,578
-Sedgwick,123,Secretary of State,,D,Jean Schodorf,123
-Sedgwick,124,Secretary of State,,D,Jean Schodorf,1
-Sedgwick,127,Secretary of State,,D,Jean Schodorf,77
-Sedgwick,128,Secretary of State,,D,Jean Schodorf,481
-Sedgwick,129,Secretary of State,,D,Jean Schodorf,95
-Sedgwick,130,Secretary of State,,D,Jean Schodorf,273
-Sedgwick,205,Secretary of State,,D,Jean Schodorf,130
-Sedgwick,206,Secretary of State,,D,Jean Schodorf,122
-Sedgwick,207,Secretary of State,,D,Jean Schodorf,710
-Sedgwick,208,Secretary of State,,D,Jean Schodorf,130
-Sedgwick,209,Secretary of State,,D,Jean Schodorf,349
-Sedgwick,210,Secretary of State,,D,Jean Schodorf,419
-Sedgwick,211,Secretary of State,,D,Jean Schodorf,251
-Sedgwick,212,Secretary of State,,D,Jean Schodorf,537
-Sedgwick,213,Secretary of State,,D,Jean Schodorf,529
-Sedgwick,214,Secretary of State,,D,Jean Schodorf,434
-Sedgwick,215,Secretary of State,,D,Jean Schodorf,653
-Sedgwick,216,Secretary of State,,D,Jean Schodorf,445
-Sedgwick,217,Secretary of State,,D,Jean Schodorf,451
-Sedgwick,218,Secretary of State,,D,Jean Schodorf,667
-Sedgwick,221,Secretary of State,,D,Jean Schodorf,276
-Sedgwick,222,Secretary of State,,D,Jean Schodorf,394
-Sedgwick,223,Secretary of State,,D,Jean Schodorf,451
-Sedgwick,224,Secretary of State,,D,Jean Schodorf,523
-Sedgwick,225,Secretary of State,,D,Jean Schodorf,529
-Sedgwick,226,Secretary of State,,D,Jean Schodorf,575
-Sedgwick,227,Secretary of State,,D,Jean Schodorf,274
-Sedgwick,228,Secretary of State,,D,Jean Schodorf,284
-Sedgwick,233,Secretary of State,,D,Jean Schodorf,120
-Sedgwick,235,Secretary of State,,D,Jean Schodorf,135
-Sedgwick,236,Secretary of State,,D,Jean Schodorf,234
-Sedgwick,239,Secretary of State,,D,Jean Schodorf,4
-Sedgwick,241,Secretary of State,,D,Jean Schodorf,112
-Sedgwick,301,Secretary of State,,D,Jean Schodorf,161
-Sedgwick,302,Secretary of State,,D,Jean Schodorf,328
-Sedgwick,303,Secretary of State,,D,Jean Schodorf,138
-Sedgwick,304,Secretary of State,,D,Jean Schodorf,168
-Sedgwick,305,Secretary of State,,D,Jean Schodorf,574
-Sedgwick,306,Secretary of State,,D,Jean Schodorf,548
-Sedgwick,307,Secretary of State,,D,Jean Schodorf,244
-Sedgwick,308,Secretary of State,,D,Jean Schodorf,416
-Sedgwick,309,Secretary of State,,D,Jean Schodorf,442
-Sedgwick,310,Secretary of State,,D,Jean Schodorf,211
-Sedgwick,311,Secretary of State,,D,Jean Schodorf,142
-Sedgwick,312,Secretary of State,,D,Jean Schodorf,147
-Sedgwick,313,Secretary of State,,D,Jean Schodorf,476
-Sedgwick,314,Secretary of State,,D,Jean Schodorf,379
-Sedgwick,315,Secretary of State,,D,Jean Schodorf,321
-Sedgwick,316,Secretary of State,,D,Jean Schodorf,312
-Sedgwick,317,Secretary of State,,D,Jean Schodorf,4
-Sedgwick,318,Secretary of State,,D,Jean Schodorf,6
-Sedgwick,319,Secretary of State,,D,Jean Schodorf,116
-Sedgwick,320,Secretary of State,,D,Jean Schodorf,85
-Sedgwick,321,Secretary of State,,D,Jean Schodorf,12
-Sedgwick,324,Secretary of State,,D,Jean Schodorf,155
-Sedgwick,325,Secretary of State,,D,Jean Schodorf,325
-Sedgwick,326,Secretary of State,,D,Jean Schodorf,36
-Sedgwick,401,Secretary of State,,D,Jean Schodorf,179
-Sedgwick,402,Secretary of State,,D,Jean Schodorf,193
-Sedgwick,403,Secretary of State,,D,Jean Schodorf,248
-Sedgwick,404,Secretary of State,,D,Jean Schodorf,469
-Sedgwick,405,Secretary of State,,D,Jean Schodorf,334
-Sedgwick,406,Secretary of State,,D,Jean Schodorf,279
-Sedgwick,407,Secretary of State,,D,Jean Schodorf,43
-Sedgwick,408,Secretary of State,,D,Jean Schodorf,320
-Sedgwick,409,Secretary of State,,D,Jean Schodorf,165
-Sedgwick,410,Secretary of State,,D,Jean Schodorf,449
-Sedgwick,412,Secretary of State,,D,Jean Schodorf,475
-Sedgwick,413,Secretary of State,,D,Jean Schodorf,371
-Sedgwick,414,Secretary of State,,D,Jean Schodorf,75
-Sedgwick,416,Secretary of State,,D,Jean Schodorf,236
-Sedgwick,417,Secretary of State,,D,Jean Schodorf,253
-Sedgwick,418,Secretary of State,,D,Jean Schodorf,358
-Sedgwick,419,Secretary of State,,D,Jean Schodorf,342
-Sedgwick,420,Secretary of State,,D,Jean Schodorf,332
-Sedgwick,422,Secretary of State,,D,Jean Schodorf,201
-Sedgwick,423,Secretary of State,,D,Jean Schodorf,235
-Sedgwick,424,Secretary of State,,D,Jean Schodorf,80
-Sedgwick,425,Secretary of State,,D,Jean Schodorf,398
-Sedgwick,429,Secretary of State,,D,Jean Schodorf,174
-Sedgwick,433,Secretary of State,,D,Jean Schodorf,89
-Sedgwick,437,Secretary of State,,D,Jean Schodorf,79
-Sedgwick,503,Secretary of State,,D,Jean Schodorf,371
-Sedgwick,504,Secretary of State,,D,Jean Schodorf,245
-Sedgwick,506,Secretary of State,,D,Jean Schodorf,425
-Sedgwick,507,Secretary of State,,D,Jean Schodorf,429
-Sedgwick,508,Secretary of State,,D,Jean Schodorf,394
-Sedgwick,509,Secretary of State,,D,Jean Schodorf,353
-Sedgwick,510,Secretary of State,,D,Jean Schodorf,417
-Sedgwick,512,Secretary of State,,D,Jean Schodorf,618
-Sedgwick,513,Secretary of State,,D,Jean Schodorf,144
-Sedgwick,514,Secretary of State,,D,Jean Schodorf,478
-Sedgwick,515,Secretary of State,,D,Jean Schodorf,429
-Sedgwick,516,Secretary of State,,D,Jean Schodorf,294
-Sedgwick,517,Secretary of State,,D,Jean Schodorf,343
-Sedgwick,518,Secretary of State,,D,Jean Schodorf,345
-Sedgwick,519,Secretary of State,,D,Jean Schodorf,447
-Sedgwick,522,Secretary of State,,D,Jean Schodorf,364
-Sedgwick,523,Secretary of State,,D,Jean Schodorf,390
-Sedgwick,524,Secretary of State,,D,Jean Schodorf,618
-Sedgwick,525,Secretary of State,,D,Jean Schodorf,481
-Sedgwick,526,Secretary of State,,D,Jean Schodorf,406
-Sedgwick,527,Secretary of State,,D,Jean Schodorf,384
-Sedgwick,530,Secretary of State,,D,Jean Schodorf,320
-Sedgwick,531,Secretary of State,,D,Jean Schodorf,622
-Sedgwick,534,Secretary of State,,D,Jean Schodorf,28
-Sedgwick,538,Secretary of State,,D,Jean Schodorf,71
-Sedgwick,539,Secretary of State,,D,Jean Schodorf,180
-Sedgwick,601,Secretary of State,,D,Jean Schodorf,336
-Sedgwick,602,Secretary of State,,D,Jean Schodorf,483
-Sedgwick,603,Secretary of State,,D,Jean Schodorf,167
-Sedgwick,604,Secretary of State,,D,Jean Schodorf,427
-Sedgwick,605,Secretary of State,,D,Jean Schodorf,175
-Sedgwick,606,Secretary of State,,D,Jean Schodorf,177
-Sedgwick,607,Secretary of State,,D,Jean Schodorf,808
-Sedgwick,608,Secretary of State,,D,Jean Schodorf,469
-Sedgwick,609,Secretary of State,,D,Jean Schodorf,807
-Sedgwick,610,Secretary of State,,D,Jean Schodorf,492
-Sedgwick,611,Secretary of State,,D,Jean Schodorf,245
-Sedgwick,612,Secretary of State,,D,Jean Schodorf,589
-Sedgwick,613,Secretary of State,,D,Jean Schodorf,516
-Sedgwick,614,Secretary of State,,D,Jean Schodorf,182
-Sedgwick,615,Secretary of State,,D,Jean Schodorf,591
-Sedgwick,616,Secretary of State,,D,Jean Schodorf,204
-Sedgwick,617,Secretary of State,,D,Jean Schodorf,153
-Sedgwick,618,Secretary of State,,D,Jean Schodorf,419
-Sedgwick,619,Secretary of State,,D,Jean Schodorf,490
-Sedgwick,621,Secretary of State,,D,Jean Schodorf,12
-Sedgwick,622,Secretary of State,,D,Jean Schodorf,464
-Sedgwick,623,Secretary of State,,D,Jean Schodorf,365
-Sedgwick,624,Secretary of State,,D,Jean Schodorf,47
-Sedgwick,627,Secretary of State,,D,Jean Schodorf,28
-Sedgwick,101,Attorney General,,R,Derek Schmidt,409
-Sedgwick,102,Attorney General,,R,Derek Schmidt,430
-Sedgwick,103,Attorney General,,R,Derek Schmidt,40
-Sedgwick,104,Attorney General,,R,Derek Schmidt,21
-Sedgwick,105,Attorney General,,R,Derek Schmidt,144
-Sedgwick,106,Attorney General,,R,Derek Schmidt,198
-Sedgwick,107,Attorney General,,R,Derek Schmidt,582
-Sedgwick,108,Attorney General,,R,Derek Schmidt,254
-Sedgwick,109,Attorney General,,R,Derek Schmidt,290
-Sedgwick,110,Attorney General,,R,Derek Schmidt,614
-Sedgwick,111,Attorney General,,R,Derek Schmidt,181
-Sedgwick,112,Attorney General,,R,Derek Schmidt,298
-Sedgwick,113,Attorney General,,R,Derek Schmidt,74
-Sedgwick,114,Attorney General,,R,Derek Schmidt,47
-Sedgwick,116,Attorney General,,R,Derek Schmidt,64
-Sedgwick,117,Attorney General,,R,Derek Schmidt,57
-Sedgwick,118,Attorney General,,R,Derek Schmidt,133
-Sedgwick,119,Attorney General,,R,Derek Schmidt,188
-Sedgwick,120,Attorney General,,R,Derek Schmidt,238
-Sedgwick,121,Attorney General,,R,Derek Schmidt,401
-Sedgwick,122,Attorney General,,R,Derek Schmidt,514
-Sedgwick,123,Attorney General,,R,Derek Schmidt,198
-Sedgwick,124,Attorney General,,R,Derek Schmidt,0
-Sedgwick,127,Attorney General,,R,Derek Schmidt,139
-Sedgwick,128,Attorney General,,R,Derek Schmidt,463
-Sedgwick,129,Attorney General,,R,Derek Schmidt,78
-Sedgwick,130,Attorney General,,R,Derek Schmidt,215
-Sedgwick,205,Attorney General,,R,Derek Schmidt,86
-Sedgwick,206,Attorney General,,R,Derek Schmidt,136
-Sedgwick,207,Attorney General,,R,Derek Schmidt,732
-Sedgwick,208,Attorney General,,R,Derek Schmidt,151
-Sedgwick,209,Attorney General,,R,Derek Schmidt,338
-Sedgwick,210,Attorney General,,R,Derek Schmidt,404
-Sedgwick,211,Attorney General,,R,Derek Schmidt,340
-Sedgwick,212,Attorney General,,R,Derek Schmidt,639
-Sedgwick,213,Attorney General,,R,Derek Schmidt,795
-Sedgwick,214,Attorney General,,R,Derek Schmidt,788
-Sedgwick,215,Attorney General,,R,Derek Schmidt,953
-Sedgwick,216,Attorney General,,R,Derek Schmidt,588
-Sedgwick,217,Attorney General,,R,Derek Schmidt,808
-Sedgwick,218,Attorney General,,R,Derek Schmidt,1046
-Sedgwick,221,Attorney General,,R,Derek Schmidt,485
-Sedgwick,222,Attorney General,,R,Derek Schmidt,668
-Sedgwick,223,Attorney General,,R,Derek Schmidt,832
-Sedgwick,224,Attorney General,,R,Derek Schmidt,664
-Sedgwick,225,Attorney General,,R,Derek Schmidt,723
-Sedgwick,226,Attorney General,,R,Derek Schmidt,1078
-Sedgwick,227,Attorney General,,R,Derek Schmidt,618
-Sedgwick,228,Attorney General,,R,Derek Schmidt,862
-Sedgwick,233,Attorney General,,R,Derek Schmidt,173
-Sedgwick,235,Attorney General,,R,Derek Schmidt,102
-Sedgwick,236,Attorney General,,R,Derek Schmidt,524
-Sedgwick,239,Attorney General,,R,Derek Schmidt,16
-Sedgwick,241,Attorney General,,R,Derek Schmidt,211
-Sedgwick,301,Attorney General,,R,Derek Schmidt,187
-Sedgwick,302,Attorney General,,R,Derek Schmidt,298
-Sedgwick,303,Attorney General,,R,Derek Schmidt,163
-Sedgwick,304,Attorney General,,R,Derek Schmidt,175
-Sedgwick,305,Attorney General,,R,Derek Schmidt,569
-Sedgwick,306,Attorney General,,R,Derek Schmidt,464
-Sedgwick,307,Attorney General,,R,Derek Schmidt,195
-Sedgwick,308,Attorney General,,R,Derek Schmidt,338
-Sedgwick,309,Attorney General,,R,Derek Schmidt,428
-Sedgwick,310,Attorney General,,R,Derek Schmidt,173
-Sedgwick,311,Attorney General,,R,Derek Schmidt,188
-Sedgwick,312,Attorney General,,R,Derek Schmidt,175
-Sedgwick,313,Attorney General,,R,Derek Schmidt,449
-Sedgwick,314,Attorney General,,R,Derek Schmidt,449
-Sedgwick,315,Attorney General,,R,Derek Schmidt,347
-Sedgwick,316,Attorney General,,R,Derek Schmidt,487
-Sedgwick,317,Attorney General,,R,Derek Schmidt,8
-Sedgwick,318,Attorney General,,R,Derek Schmidt,16
-Sedgwick,319,Attorney General,,R,Derek Schmidt,89
-Sedgwick,320,Attorney General,,R,Derek Schmidt,46
-Sedgwick,321,Attorney General,,R,Derek Schmidt,4
-Sedgwick,324,Attorney General,,R,Derek Schmidt,134
-Sedgwick,325,Attorney General,,R,Derek Schmidt,381
-Sedgwick,326,Attorney General,,R,Derek Schmidt,44
-Sedgwick,401,Attorney General,,R,Derek Schmidt,280
-Sedgwick,402,Attorney General,,R,Derek Schmidt,315
-Sedgwick,403,Attorney General,,R,Derek Schmidt,517
-Sedgwick,404,Attorney General,,R,Derek Schmidt,522
-Sedgwick,405,Attorney General,,R,Derek Schmidt,393
-Sedgwick,406,Attorney General,,R,Derek Schmidt,330
-Sedgwick,407,Attorney General,,R,Derek Schmidt,38
-Sedgwick,408,Attorney General,,R,Derek Schmidt,322
-Sedgwick,409,Attorney General,,R,Derek Schmidt,185
-Sedgwick,410,Attorney General,,R,Derek Schmidt,1118
-Sedgwick,412,Attorney General,,R,Derek Schmidt,988
-Sedgwick,413,Attorney General,,R,Derek Schmidt,706
-Sedgwick,414,Attorney General,,R,Derek Schmidt,147
-Sedgwick,416,Attorney General,,R,Derek Schmidt,484
-Sedgwick,417,Attorney General,,R,Derek Schmidt,318
-Sedgwick,418,Attorney General,,R,Derek Schmidt,478
-Sedgwick,419,Attorney General,,R,Derek Schmidt,381
-Sedgwick,420,Attorney General,,R,Derek Schmidt,433
-Sedgwick,422,Attorney General,,R,Derek Schmidt,258
-Sedgwick,423,Attorney General,,R,Derek Schmidt,314
-Sedgwick,424,Attorney General,,R,Derek Schmidt,98
-Sedgwick,425,Attorney General,,R,Derek Schmidt,649
-Sedgwick,429,Attorney General,,R,Derek Schmidt,214
-Sedgwick,433,Attorney General,,R,Derek Schmidt,150
-Sedgwick,437,Attorney General,,R,Derek Schmidt,174
-Sedgwick,503,Attorney General,,R,Derek Schmidt,502
-Sedgwick,504,Attorney General,,R,Derek Schmidt,339
-Sedgwick,506,Attorney General,,R,Derek Schmidt,733
-Sedgwick,507,Attorney General,,R,Derek Schmidt,633
-Sedgwick,508,Attorney General,,R,Derek Schmidt,593
-Sedgwick,509,Attorney General,,R,Derek Schmidt,579
-Sedgwick,510,Attorney General,,R,Derek Schmidt,943
-Sedgwick,512,Attorney General,,R,Derek Schmidt,1349
-Sedgwick,513,Attorney General,,R,Derek Schmidt,413
-Sedgwick,514,Attorney General,,R,Derek Schmidt,867
-Sedgwick,515,Attorney General,,R,Derek Schmidt,759
-Sedgwick,516,Attorney General,,R,Derek Schmidt,513
-Sedgwick,517,Attorney General,,R,Derek Schmidt,490
-Sedgwick,518,Attorney General,,R,Derek Schmidt,619
-Sedgwick,519,Attorney General,,R,Derek Schmidt,655
-Sedgwick,522,Attorney General,,R,Derek Schmidt,702
-Sedgwick,523,Attorney General,,R,Derek Schmidt,704
-Sedgwick,524,Attorney General,,R,Derek Schmidt,1083
-Sedgwick,525,Attorney General,,R,Derek Schmidt,671
-Sedgwick,526,Attorney General,,R,Derek Schmidt,774
-Sedgwick,527,Attorney General,,R,Derek Schmidt,748
-Sedgwick,530,Attorney General,,R,Derek Schmidt,792
-Sedgwick,531,Attorney General,,R,Derek Schmidt,1224
-Sedgwick,534,Attorney General,,R,Derek Schmidt,71
-Sedgwick,538,Attorney General,,R,Derek Schmidt,149
-Sedgwick,539,Attorney General,,R,Derek Schmidt,367
-Sedgwick,601,Attorney General,,R,Derek Schmidt,209
-Sedgwick,602,Attorney General,,R,Derek Schmidt,547
-Sedgwick,603,Attorney General,,R,Derek Schmidt,354
-Sedgwick,604,Attorney General,,R,Derek Schmidt,568
-Sedgwick,605,Attorney General,,R,Derek Schmidt,210
-Sedgwick,606,Attorney General,,R,Derek Schmidt,171
-Sedgwick,607,Attorney General,,R,Derek Schmidt,513
-Sedgwick,608,Attorney General,,R,Derek Schmidt,243
-Sedgwick,609,Attorney General,,R,Derek Schmidt,575
-Sedgwick,610,Attorney General,,R,Derek Schmidt,636
-Sedgwick,611,Attorney General,,R,Derek Schmidt,305
-Sedgwick,612,Attorney General,,R,Derek Schmidt,767
-Sedgwick,613,Attorney General,,R,Derek Schmidt,591
-Sedgwick,614,Attorney General,,R,Derek Schmidt,182
-Sedgwick,615,Attorney General,,R,Derek Schmidt,323
-Sedgwick,616,Attorney General,,R,Derek Schmidt,267
-Sedgwick,617,Attorney General,,R,Derek Schmidt,123
-Sedgwick,618,Attorney General,,R,Derek Schmidt,592
-Sedgwick,619,Attorney General,,R,Derek Schmidt,571
-Sedgwick,621,Attorney General,,R,Derek Schmidt,34
-Sedgwick,622,Attorney General,,R,Derek Schmidt,844
-Sedgwick,623,Attorney General,,R,Derek Schmidt,731
-Sedgwick,624,Attorney General,,R,Derek Schmidt,34
-Sedgwick,627,Attorney General,,R,Derek Schmidt,54
-Sedgwick,101,Attorney General,,D,A J Kotich,292
-Sedgwick,102,Attorney General,,D,A J Kotich,273
-Sedgwick,103,Attorney General,,D,A J Kotich,54
-Sedgwick,104,Attorney General,,D,A J Kotich,8
-Sedgwick,105,Attorney General,,D,A J Kotich,246
-Sedgwick,106,Attorney General,,D,A J Kotich,490
-Sedgwick,107,Attorney General,,D,A J Kotich,492
-Sedgwick,108,Attorney General,,D,A J Kotich,328
-Sedgwick,109,Attorney General,,D,A J Kotich,392
-Sedgwick,110,Attorney General,,D,A J Kotich,478
-Sedgwick,111,Attorney General,,D,A J Kotich,103
-Sedgwick,112,Attorney General,,D,A J Kotich,456
-Sedgwick,113,Attorney General,,D,A J Kotich,420
-Sedgwick,114,Attorney General,,D,A J Kotich,379
-Sedgwick,116,Attorney General,,D,A J Kotich,562
-Sedgwick,117,Attorney General,,D,A J Kotich,536
-Sedgwick,118,Attorney General,,D,A J Kotich,592
-Sedgwick,119,Attorney General,,D,A J Kotich,402
-Sedgwick,120,Attorney General,,D,A J Kotich,343
-Sedgwick,121,Attorney General,,D,A J Kotich,258
-Sedgwick,122,Attorney General,,D,A J Kotich,462
-Sedgwick,123,Attorney General,,D,A J Kotich,87
-Sedgwick,124,Attorney General,,D,A J Kotich,1
-Sedgwick,127,Attorney General,,D,A J Kotich,64
-Sedgwick,128,Attorney General,,D,A J Kotich,344
-Sedgwick,129,Attorney General,,D,A J Kotich,77
-Sedgwick,130,Attorney General,,D,A J Kotich,219
-Sedgwick,205,Attorney General,,D,A J Kotich,107
-Sedgwick,206,Attorney General,,D,A J Kotich,90
-Sedgwick,207,Attorney General,,D,A J Kotich,542
-Sedgwick,208,Attorney General,,D,A J Kotich,96
-Sedgwick,209,Attorney General,,D,A J Kotich,260
-Sedgwick,210,Attorney General,,D,A J Kotich,332
-Sedgwick,211,Attorney General,,D,A J Kotich,196
-Sedgwick,212,Attorney General,,D,A J Kotich,369
-Sedgwick,213,Attorney General,,D,A J Kotich,346
-Sedgwick,214,Attorney General,,D,A J Kotich,249
-Sedgwick,215,Attorney General,,D,A J Kotich,440
-Sedgwick,216,Attorney General,,D,A J Kotich,289
-Sedgwick,217,Attorney General,,D,A J Kotich,276
-Sedgwick,218,Attorney General,,D,A J Kotich,464
-Sedgwick,221,Attorney General,,D,A J Kotich,185
-Sedgwick,222,Attorney General,,D,A J Kotich,261
-Sedgwick,223,Attorney General,,D,A J Kotich,290
-Sedgwick,224,Attorney General,,D,A J Kotich,386
-Sedgwick,225,Attorney General,,D,A J Kotich,397
-Sedgwick,226,Attorney General,,D,A J Kotich,379
-Sedgwick,227,Attorney General,,D,A J Kotich,168
-Sedgwick,228,Attorney General,,D,A J Kotich,168
-Sedgwick,233,Attorney General,,D,A J Kotich,114
-Sedgwick,235,Attorney General,,D,A J Kotich,121
-Sedgwick,236,Attorney General,,D,A J Kotich,164
-Sedgwick,239,Attorney General,,D,A J Kotich,3
-Sedgwick,241,Attorney General,,D,A J Kotich,59
-Sedgwick,301,Attorney General,,D,A J Kotich,127
-Sedgwick,302,Attorney General,,D,A J Kotich,271
-Sedgwick,303,Attorney General,,D,A J Kotich,99
-Sedgwick,304,Attorney General,,D,A J Kotich,128
-Sedgwick,305,Attorney General,,D,A J Kotich,408
-Sedgwick,306,Attorney General,,D,A J Kotich,440
-Sedgwick,307,Attorney General,,D,A J Kotich,193
-Sedgwick,308,Attorney General,,D,A J Kotich,332
-Sedgwick,309,Attorney General,,D,A J Kotich,351
-Sedgwick,310,Attorney General,,D,A J Kotich,180
-Sedgwick,311,Attorney General,,D,A J Kotich,108
-Sedgwick,312,Attorney General,,D,A J Kotich,124
-Sedgwick,313,Attorney General,,D,A J Kotich,387
-Sedgwick,314,Attorney General,,D,A J Kotich,317
-Sedgwick,315,Attorney General,,D,A J Kotich,249
-Sedgwick,316,Attorney General,,D,A J Kotich,230
-Sedgwick,317,Attorney General,,D,A J Kotich,4
-Sedgwick,318,Attorney General,,D,A J Kotich,6
-Sedgwick,319,Attorney General,,D,A J Kotich,86
-Sedgwick,320,Attorney General,,D,A J Kotich,71
-Sedgwick,321,Attorney General,,D,A J Kotich,13
-Sedgwick,324,Attorney General,,D,A J Kotich,127
-Sedgwick,325,Attorney General,,D,A J Kotich,248
-Sedgwick,326,Attorney General,,D,A J Kotich,23
-Sedgwick,401,Attorney General,,D,A J Kotich,124
-Sedgwick,402,Attorney General,,D,A J Kotich,115
-Sedgwick,403,Attorney General,,D,A J Kotich,136
-Sedgwick,404,Attorney General,,D,A J Kotich,362
-Sedgwick,405,Attorney General,,D,A J Kotich,264
-Sedgwick,406,Attorney General,,D,A J Kotich,201
-Sedgwick,407,Attorney General,,D,A J Kotich,35
-Sedgwick,408,Attorney General,,D,A J Kotich,232
-Sedgwick,409,Attorney General,,D,A J Kotich,121
-Sedgwick,410,Attorney General,,D,A J Kotich,258
-Sedgwick,412,Attorney General,,D,A J Kotich,333
-Sedgwick,413,Attorney General,,D,A J Kotich,257
-Sedgwick,414,Attorney General,,D,A J Kotich,53
-Sedgwick,416,Attorney General,,D,A J Kotich,164
-Sedgwick,417,Attorney General,,D,A J Kotich,169
-Sedgwick,418,Attorney General,,D,A J Kotich,244
-Sedgwick,419,Attorney General,,D,A J Kotich,252
-Sedgwick,420,Attorney General,,D,A J Kotich,259
-Sedgwick,422,Attorney General,,D,A J Kotich,165
-Sedgwick,423,Attorney General,,D,A J Kotich,186
-Sedgwick,424,Attorney General,,D,A J Kotich,64
-Sedgwick,425,Attorney General,,D,A J Kotich,307
-Sedgwick,429,Attorney General,,D,A J Kotich,130
-Sedgwick,433,Attorney General,,D,A J Kotich,80
-Sedgwick,437,Attorney General,,D,A J Kotich,56
-Sedgwick,503,Attorney General,,D,A J Kotich,262
-Sedgwick,504,Attorney General,,D,A J Kotich,182
-Sedgwick,506,Attorney General,,D,A J Kotich,264
-Sedgwick,507,Attorney General,,D,A J Kotich,305
-Sedgwick,508,Attorney General,,D,A J Kotich,250
-Sedgwick,509,Attorney General,,D,A J Kotich,228
-Sedgwick,510,Attorney General,,D,A J Kotich,218
-Sedgwick,512,Attorney General,,D,A J Kotich,399
-Sedgwick,513,Attorney General,,D,A J Kotich,80
-Sedgwick,514,Attorney General,,D,A J Kotich,306
-Sedgwick,515,Attorney General,,D,A J Kotich,278
-Sedgwick,516,Attorney General,,D,A J Kotich,178
-Sedgwick,517,Attorney General,,D,A J Kotich,223
-Sedgwick,518,Attorney General,,D,A J Kotich,228
-Sedgwick,519,Attorney General,,D,A J Kotich,305
-Sedgwick,522,Attorney General,,D,A J Kotich,220
-Sedgwick,523,Attorney General,,D,A J Kotich,222
-Sedgwick,524,Attorney General,,D,A J Kotich,383
-Sedgwick,525,Attorney General,,D,A J Kotich,316
-Sedgwick,526,Attorney General,,D,A J Kotich,254
-Sedgwick,527,Attorney General,,D,A J Kotich,250
-Sedgwick,530,Attorney General,,D,A J Kotich,205
-Sedgwick,531,Attorney General,,D,A J Kotich,369
-Sedgwick,534,Attorney General,,D,A J Kotich,20
-Sedgwick,538,Attorney General,,D,A J Kotich,43
-Sedgwick,539,Attorney General,,D,A J Kotich,115
-Sedgwick,601,Attorney General,,D,A J Kotich,273
-Sedgwick,602,Attorney General,,D,A J Kotich,372
-Sedgwick,603,Attorney General,,D,A J Kotich,104
-Sedgwick,604,Attorney General,,D,A J Kotich,315
-Sedgwick,605,Attorney General,,D,A J Kotich,122
-Sedgwick,606,Attorney General,,D,A J Kotich,109
-Sedgwick,607,Attorney General,,D,A J Kotich,612
-Sedgwick,608,Attorney General,,D,A J Kotich,391
-Sedgwick,609,Attorney General,,D,A J Kotich,655
-Sedgwick,610,Attorney General,,D,A J Kotich,327
-Sedgwick,611,Attorney General,,D,A J Kotich,180
-Sedgwick,612,Attorney General,,D,A J Kotich,385
-Sedgwick,613,Attorney General,,D,A J Kotich,321
-Sedgwick,614,Attorney General,,D,A J Kotich,157
-Sedgwick,615,Attorney General,,D,A J Kotich,495
-Sedgwick,616,Attorney General,,D,A J Kotich,170
-Sedgwick,617,Attorney General,,D,A J Kotich,126
-Sedgwick,618,Attorney General,,D,A J Kotich,288
-Sedgwick,619,Attorney General,,D,A J Kotich,339
-Sedgwick,621,Attorney General,,D,A J Kotich,4
-Sedgwick,622,Attorney General,,D,A J Kotich,281
-Sedgwick,623,Attorney General,,D,A J Kotich,236
-Sedgwick,624,Attorney General,,D,A J Kotich,35
-Sedgwick,627,Attorney General,,D,A J Kotich,21
-Sedgwick,101,State Treasurer,,R,Ron Estes,443
-Sedgwick,102,State Treasurer,,R,Ron Estes,474
-Sedgwick,103,State Treasurer,,R,Ron Estes,47
-Sedgwick,104,State Treasurer,,R,Ron Estes,21
-Sedgwick,105,State Treasurer,,R,Ron Estes,154
-Sedgwick,106,State Treasurer,,R,Ron Estes,232
-Sedgwick,107,State Treasurer,,R,Ron Estes,629
-Sedgwick,108,State Treasurer,,R,Ron Estes,275
-Sedgwick,109,State Treasurer,,R,Ron Estes,314
-Sedgwick,110,State Treasurer,,R,Ron Estes,666
-Sedgwick,111,State Treasurer,,R,Ron Estes,195
-Sedgwick,112,State Treasurer,,R,Ron Estes,329
-Sedgwick,113,State Treasurer,,R,Ron Estes,97
-Sedgwick,114,State Treasurer,,R,Ron Estes,71
-Sedgwick,116,State Treasurer,,R,Ron Estes,96
-Sedgwick,117,State Treasurer,,R,Ron Estes,98
-Sedgwick,118,State Treasurer,,R,Ron Estes,177
-Sedgwick,119,State Treasurer,,R,Ron Estes,212
-Sedgwick,120,State Treasurer,,R,Ron Estes,265
-Sedgwick,121,State Treasurer,,R,Ron Estes,424
-Sedgwick,122,State Treasurer,,R,Ron Estes,569
-Sedgwick,123,State Treasurer,,R,Ron Estes,201
-Sedgwick,124,State Treasurer,,R,Ron Estes,0
-Sedgwick,127,State Treasurer,,R,Ron Estes,150
-Sedgwick,128,State Treasurer,,R,Ron Estes,501
-Sedgwick,129,State Treasurer,,R,Ron Estes,81
-Sedgwick,130,State Treasurer,,R,Ron Estes,238
-Sedgwick,205,State Treasurer,,R,Ron Estes,98
-Sedgwick,206,State Treasurer,,R,Ron Estes,133
-Sedgwick,207,State Treasurer,,R,Ron Estes,793
-Sedgwick,208,State Treasurer,,R,Ron Estes,156
-Sedgwick,209,State Treasurer,,R,Ron Estes,380
-Sedgwick,210,State Treasurer,,R,Ron Estes,430
-Sedgwick,211,State Treasurer,,R,Ron Estes,362
-Sedgwick,212,State Treasurer,,R,Ron Estes,706
-Sedgwick,213,State Treasurer,,R,Ron Estes,856
-Sedgwick,214,State Treasurer,,R,Ron Estes,849
-Sedgwick,215,State Treasurer,,R,Ron Estes,1019
-Sedgwick,216,State Treasurer,,R,Ron Estes,623
-Sedgwick,217,State Treasurer,,R,Ron Estes,841
-Sedgwick,218,State Treasurer,,R,Ron Estes,1110
-Sedgwick,221,State Treasurer,,R,Ron Estes,526
-Sedgwick,222,State Treasurer,,R,Ron Estes,698
-Sedgwick,223,State Treasurer,,R,Ron Estes,878
-Sedgwick,224,State Treasurer,,R,Ron Estes,700
-Sedgwick,225,State Treasurer,,R,Ron Estes,776
-Sedgwick,226,State Treasurer,,R,Ron Estes,1144
-Sedgwick,227,State Treasurer,,R,Ron Estes,648
-Sedgwick,228,State Treasurer,,R,Ron Estes,902
-Sedgwick,233,State Treasurer,,R,Ron Estes,197
-Sedgwick,235,State Treasurer,,R,Ron Estes,115
-Sedgwick,236,State Treasurer,,R,Ron Estes,548
-Sedgwick,239,State Treasurer,,R,Ron Estes,17
-Sedgwick,241,State Treasurer,,R,Ron Estes,210
-Sedgwick,301,State Treasurer,,R,Ron Estes,205
-Sedgwick,302,State Treasurer,,R,Ron Estes,327
-Sedgwick,303,State Treasurer,,R,Ron Estes,173
-Sedgwick,304,State Treasurer,,R,Ron Estes,186
-Sedgwick,305,State Treasurer,,R,Ron Estes,623
-Sedgwick,306,State Treasurer,,R,Ron Estes,498
-Sedgwick,307,State Treasurer,,R,Ron Estes,211
-Sedgwick,308,State Treasurer,,R,Ron Estes,374
-Sedgwick,309,State Treasurer,,R,Ron Estes,466
-Sedgwick,310,State Treasurer,,R,Ron Estes,197
-Sedgwick,311,State Treasurer,,R,Ron Estes,205
-Sedgwick,312,State Treasurer,,R,Ron Estes,199
-Sedgwick,313,State Treasurer,,R,Ron Estes,492
-Sedgwick,314,State Treasurer,,R,Ron Estes,505
-Sedgwick,315,State Treasurer,,R,Ron Estes,364
-Sedgwick,316,State Treasurer,,R,Ron Estes,504
-Sedgwick,317,State Treasurer,,R,Ron Estes,9
-Sedgwick,318,State Treasurer,,R,Ron Estes,18
-Sedgwick,319,State Treasurer,,R,Ron Estes,89
-Sedgwick,320,State Treasurer,,R,Ron Estes,43
-Sedgwick,321,State Treasurer,,R,Ron Estes,8
-Sedgwick,324,State Treasurer,,R,Ron Estes,144
-Sedgwick,325,State Treasurer,,R,Ron Estes,409
-Sedgwick,326,State Treasurer,,R,Ron Estes,48
-Sedgwick,401,State Treasurer,,R,Ron Estes,306
-Sedgwick,402,State Treasurer,,R,Ron Estes,321
-Sedgwick,403,State Treasurer,,R,Ron Estes,538
-Sedgwick,404,State Treasurer,,R,Ron Estes,555
-Sedgwick,405,State Treasurer,,R,Ron Estes,414
-Sedgwick,406,State Treasurer,,R,Ron Estes,346
-Sedgwick,407,State Treasurer,,R,Ron Estes,51
-Sedgwick,408,State Treasurer,,R,Ron Estes,330
-Sedgwick,409,State Treasurer,,R,Ron Estes,204
-Sedgwick,410,State Treasurer,,R,Ron Estes,1170
-Sedgwick,412,State Treasurer,,R,Ron Estes,1029
-Sedgwick,413,State Treasurer,,R,Ron Estes,754
-Sedgwick,414,State Treasurer,,R,Ron Estes,148
-Sedgwick,416,State Treasurer,,R,Ron Estes,519
-Sedgwick,417,State Treasurer,,R,Ron Estes,335
-Sedgwick,418,State Treasurer,,R,Ron Estes,524
-Sedgwick,419,State Treasurer,,R,Ron Estes,422
-Sedgwick,420,State Treasurer,,R,Ron Estes,467
-Sedgwick,422,State Treasurer,,R,Ron Estes,275
-Sedgwick,423,State Treasurer,,R,Ron Estes,352
-Sedgwick,424,State Treasurer,,R,Ron Estes,101
-Sedgwick,425,State Treasurer,,R,Ron Estes,686
-Sedgwick,429,State Treasurer,,R,Ron Estes,226
-Sedgwick,433,State Treasurer,,R,Ron Estes,157
-Sedgwick,437,State Treasurer,,R,Ron Estes,176
-Sedgwick,503,State Treasurer,,R,Ron Estes,519
-Sedgwick,504,State Treasurer,,R,Ron Estes,359
-Sedgwick,506,State Treasurer,,R,Ron Estes,775
-Sedgwick,507,State Treasurer,,R,Ron Estes,660
-Sedgwick,508,State Treasurer,,R,Ron Estes,617
-Sedgwick,509,State Treasurer,,R,Ron Estes,618
-Sedgwick,510,State Treasurer,,R,Ron Estes,991
-Sedgwick,512,State Treasurer,,R,Ron Estes,1431
-Sedgwick,513,State Treasurer,,R,Ron Estes,431
-Sedgwick,514,State Treasurer,,R,Ron Estes,915
-Sedgwick,515,State Treasurer,,R,Ron Estes,787
-Sedgwick,516,State Treasurer,,R,Ron Estes,540
-Sedgwick,517,State Treasurer,,R,Ron Estes,516
-Sedgwick,518,State Treasurer,,R,Ron Estes,659
-Sedgwick,519,State Treasurer,,R,Ron Estes,704
-Sedgwick,522,State Treasurer,,R,Ron Estes,728
-Sedgwick,523,State Treasurer,,R,Ron Estes,736
-Sedgwick,524,State Treasurer,,R,Ron Estes,1158
-Sedgwick,525,State Treasurer,,R,Ron Estes,715
-Sedgwick,526,State Treasurer,,R,Ron Estes,799
-Sedgwick,527,State Treasurer,,R,Ron Estes,778
-Sedgwick,530,State Treasurer,,R,Ron Estes,828
-Sedgwick,531,State Treasurer,,R,Ron Estes,1295
-Sedgwick,534,State Treasurer,,R,Ron Estes,78
-Sedgwick,538,State Treasurer,,R,Ron Estes,154
-Sedgwick,539,State Treasurer,,R,Ron Estes,379
-Sedgwick,601,State Treasurer,,R,Ron Estes,234
-Sedgwick,602,State Treasurer,,R,Ron Estes,594
-Sedgwick,603,State Treasurer,,R,Ron Estes,382
-Sedgwick,604,State Treasurer,,R,Ron Estes,602
-Sedgwick,605,State Treasurer,,R,Ron Estes,211
-Sedgwick,606,State Treasurer,,R,Ron Estes,186
-Sedgwick,607,State Treasurer,,R,Ron Estes,570
-Sedgwick,608,State Treasurer,,R,Ron Estes,273
-Sedgwick,609,State Treasurer,,R,Ron Estes,651
-Sedgwick,610,State Treasurer,,R,Ron Estes,688
-Sedgwick,611,State Treasurer,,R,Ron Estes,318
-Sedgwick,612,State Treasurer,,R,Ron Estes,842
-Sedgwick,613,State Treasurer,,R,Ron Estes,643
-Sedgwick,614,State Treasurer,,R,Ron Estes,203
-Sedgwick,615,State Treasurer,,R,Ron Estes,348
-Sedgwick,616,State Treasurer,,R,Ron Estes,292
-Sedgwick,617,State Treasurer,,R,Ron Estes,137
-Sedgwick,618,State Treasurer,,R,Ron Estes,624
-Sedgwick,619,State Treasurer,,R,Ron Estes,596
-Sedgwick,621,State Treasurer,,R,Ron Estes,34
-Sedgwick,622,State Treasurer,,R,Ron Estes,909
-Sedgwick,623,State Treasurer,,R,Ron Estes,773
-Sedgwick,624,State Treasurer,,R,Ron Estes,41
-Sedgwick,627,State Treasurer,,R,Ron Estes,52
-Sedgwick,101,State Treasurer,,D,Carmen Alldritt,265
-Sedgwick,102,State Treasurer,,D,Carmen Alldritt,234
-Sedgwick,103,State Treasurer,,D,Carmen Alldritt,48
-Sedgwick,104,State Treasurer,,D,Carmen Alldritt,8
-Sedgwick,105,State Treasurer,,D,Carmen Alldritt,236
-Sedgwick,106,State Treasurer,,D,Carmen Alldritt,456
-Sedgwick,107,State Treasurer,,D,Carmen Alldritt,446
-Sedgwick,108,State Treasurer,,D,Carmen Alldritt,302
-Sedgwick,109,State Treasurer,,D,Carmen Alldritt,366
-Sedgwick,110,State Treasurer,,D,Carmen Alldritt,428
-Sedgwick,111,State Treasurer,,D,Carmen Alldritt,89
-Sedgwick,112,State Treasurer,,D,Carmen Alldritt,427
-Sedgwick,113,State Treasurer,,D,Carmen Alldritt,401
-Sedgwick,114,State Treasurer,,D,Carmen Alldritt,350
-Sedgwick,116,State Treasurer,,D,Carmen Alldritt,536
-Sedgwick,117,State Treasurer,,D,Carmen Alldritt,491
-Sedgwick,118,State Treasurer,,D,Carmen Alldritt,559
-Sedgwick,119,State Treasurer,,D,Carmen Alldritt,385
-Sedgwick,120,State Treasurer,,D,Carmen Alldritt,315
-Sedgwick,121,State Treasurer,,D,Carmen Alldritt,240
-Sedgwick,122,State Treasurer,,D,Carmen Alldritt,423
-Sedgwick,123,State Treasurer,,D,Carmen Alldritt,83
-Sedgwick,124,State Treasurer,,D,Carmen Alldritt,1
-Sedgwick,127,State Treasurer,,D,Carmen Alldritt,55
-Sedgwick,128,State Treasurer,,D,Carmen Alldritt,310
-Sedgwick,129,State Treasurer,,D,Carmen Alldritt,76
-Sedgwick,130,State Treasurer,,D,Carmen Alldritt,202
-Sedgwick,205,State Treasurer,,D,Carmen Alldritt,102
-Sedgwick,206,State Treasurer,,D,Carmen Alldritt,93
-Sedgwick,207,State Treasurer,,D,Carmen Alldritt,487
-Sedgwick,208,State Treasurer,,D,Carmen Alldritt,92
-Sedgwick,209,State Treasurer,,D,Carmen Alldritt,230
-Sedgwick,210,State Treasurer,,D,Carmen Alldritt,309
-Sedgwick,211,State Treasurer,,D,Carmen Alldritt,173
-Sedgwick,212,State Treasurer,,D,Carmen Alldritt,311
-Sedgwick,213,State Treasurer,,D,Carmen Alldritt,293
-Sedgwick,214,State Treasurer,,D,Carmen Alldritt,205
-Sedgwick,215,State Treasurer,,D,Carmen Alldritt,374
-Sedgwick,216,State Treasurer,,D,Carmen Alldritt,263
-Sedgwick,217,State Treasurer,,D,Carmen Alldritt,254
-Sedgwick,218,State Treasurer,,D,Carmen Alldritt,413
-Sedgwick,221,State Treasurer,,D,Carmen Alldritt,150
-Sedgwick,222,State Treasurer,,D,Carmen Alldritt,235
-Sedgwick,223,State Treasurer,,D,Carmen Alldritt,251
-Sedgwick,224,State Treasurer,,D,Carmen Alldritt,368
-Sedgwick,225,State Treasurer,,D,Carmen Alldritt,346
-Sedgwick,226,State Treasurer,,D,Carmen Alldritt,327
-Sedgwick,227,State Treasurer,,D,Carmen Alldritt,140
-Sedgwick,228,State Treasurer,,D,Carmen Alldritt,142
-Sedgwick,233,State Treasurer,,D,Carmen Alldritt,92
-Sedgwick,235,State Treasurer,,D,Carmen Alldritt,109
-Sedgwick,236,State Treasurer,,D,Carmen Alldritt,133
-Sedgwick,239,State Treasurer,,D,Carmen Alldritt,2
-Sedgwick,241,State Treasurer,,D,Carmen Alldritt,57
-Sedgwick,301,State Treasurer,,D,Carmen Alldritt,116
-Sedgwick,302,State Treasurer,,D,Carmen Alldritt,243
-Sedgwick,303,State Treasurer,,D,Carmen Alldritt,88
-Sedgwick,304,State Treasurer,,D,Carmen Alldritt,115
-Sedgwick,305,State Treasurer,,D,Carmen Alldritt,376
-Sedgwick,306,State Treasurer,,D,Carmen Alldritt,421
-Sedgwick,307,State Treasurer,,D,Carmen Alldritt,180
-Sedgwick,308,State Treasurer,,D,Carmen Alldritt,301
-Sedgwick,309,State Treasurer,,D,Carmen Alldritt,315
-Sedgwick,310,State Treasurer,,D,Carmen Alldritt,158
-Sedgwick,311,State Treasurer,,D,Carmen Alldritt,92
-Sedgwick,312,State Treasurer,,D,Carmen Alldritt,106
-Sedgwick,313,State Treasurer,,D,Carmen Alldritt,352
-Sedgwick,314,State Treasurer,,D,Carmen Alldritt,266
-Sedgwick,315,State Treasurer,,D,Carmen Alldritt,232
-Sedgwick,316,State Treasurer,,D,Carmen Alldritt,216
-Sedgwick,317,State Treasurer,,D,Carmen Alldritt,3
-Sedgwick,318,State Treasurer,,D,Carmen Alldritt,5
-Sedgwick,319,State Treasurer,,D,Carmen Alldritt,87
-Sedgwick,320,State Treasurer,,D,Carmen Alldritt,74
-Sedgwick,321,State Treasurer,,D,Carmen Alldritt,9
-Sedgwick,324,State Treasurer,,D,Carmen Alldritt,118
-Sedgwick,325,State Treasurer,,D,Carmen Alldritt,220
-Sedgwick,326,State Treasurer,,D,Carmen Alldritt,23
-Sedgwick,401,State Treasurer,,D,Carmen Alldritt,113
-Sedgwick,402,State Treasurer,,D,Carmen Alldritt,112
-Sedgwick,403,State Treasurer,,D,Carmen Alldritt,123
-Sedgwick,404,State Treasurer,,D,Carmen Alldritt,333
-Sedgwick,405,State Treasurer,,D,Carmen Alldritt,246
-Sedgwick,406,State Treasurer,,D,Carmen Alldritt,191
-Sedgwick,407,State Treasurer,,D,Carmen Alldritt,22
-Sedgwick,408,State Treasurer,,D,Carmen Alldritt,227
-Sedgwick,409,State Treasurer,,D,Carmen Alldritt,105
-Sedgwick,410,State Treasurer,,D,Carmen Alldritt,209
-Sedgwick,412,State Treasurer,,D,Carmen Alldritt,296
-Sedgwick,413,State Treasurer,,D,Carmen Alldritt,218
-Sedgwick,414,State Treasurer,,D,Carmen Alldritt,50
-Sedgwick,416,State Treasurer,,D,Carmen Alldritt,130
-Sedgwick,417,State Treasurer,,D,Carmen Alldritt,157
-Sedgwick,418,State Treasurer,,D,Carmen Alldritt,211
-Sedgwick,419,State Treasurer,,D,Carmen Alldritt,219
-Sedgwick,420,State Treasurer,,D,Carmen Alldritt,223
-Sedgwick,422,State Treasurer,,D,Carmen Alldritt,155
-Sedgwick,423,State Treasurer,,D,Carmen Alldritt,163
-Sedgwick,424,State Treasurer,,D,Carmen Alldritt,60
-Sedgwick,425,State Treasurer,,D,Carmen Alldritt,273
-Sedgwick,429,State Treasurer,,D,Carmen Alldritt,127
-Sedgwick,433,State Treasurer,,D,Carmen Alldritt,75
-Sedgwick,437,State Treasurer,,D,Carmen Alldritt,54
-Sedgwick,503,State Treasurer,,D,Carmen Alldritt,248
-Sedgwick,504,State Treasurer,,D,Carmen Alldritt,171
-Sedgwick,506,State Treasurer,,D,Carmen Alldritt,230
-Sedgwick,507,State Treasurer,,D,Carmen Alldritt,283
-Sedgwick,508,State Treasurer,,D,Carmen Alldritt,233
-Sedgwick,509,State Treasurer,,D,Carmen Alldritt,197
-Sedgwick,510,State Treasurer,,D,Carmen Alldritt,196
-Sedgwick,512,State Treasurer,,D,Carmen Alldritt,336
-Sedgwick,513,State Treasurer,,D,Carmen Alldritt,66
-Sedgwick,514,State Treasurer,,D,Carmen Alldritt,266
-Sedgwick,515,State Treasurer,,D,Carmen Alldritt,259
-Sedgwick,516,State Treasurer,,D,Carmen Alldritt,160
-Sedgwick,517,State Treasurer,,D,Carmen Alldritt,200
-Sedgwick,518,State Treasurer,,D,Carmen Alldritt,203
-Sedgwick,519,State Treasurer,,D,Carmen Alldritt,270
-Sedgwick,522,State Treasurer,,D,Carmen Alldritt,204
-Sedgwick,523,State Treasurer,,D,Carmen Alldritt,199
-Sedgwick,524,State Treasurer,,D,Carmen Alldritt,324
-Sedgwick,525,State Treasurer,,D,Carmen Alldritt,279
-Sedgwick,526,State Treasurer,,D,Carmen Alldritt,230
-Sedgwick,527,State Treasurer,,D,Carmen Alldritt,230
-Sedgwick,530,State Treasurer,,D,Carmen Alldritt,167
-Sedgwick,531,State Treasurer,,D,Carmen Alldritt,321
-Sedgwick,534,State Treasurer,,D,Carmen Alldritt,15
-Sedgwick,538,State Treasurer,,D,Carmen Alldritt,35
-Sedgwick,539,State Treasurer,,D,Carmen Alldritt,106
-Sedgwick,601,State Treasurer,,D,Carmen Alldritt,251
-Sedgwick,602,State Treasurer,,D,Carmen Alldritt,338
-Sedgwick,603,State Treasurer,,D,Carmen Alldritt,81
-Sedgwick,604,State Treasurer,,D,Carmen Alldritt,289
-Sedgwick,605,State Treasurer,,D,Carmen Alldritt,121
-Sedgwick,606,State Treasurer,,D,Carmen Alldritt,100
-Sedgwick,607,State Treasurer,,D,Carmen Alldritt,560
-Sedgwick,608,State Treasurer,,D,Carmen Alldritt,364
-Sedgwick,609,State Treasurer,,D,Carmen Alldritt,586
-Sedgwick,610,State Treasurer,,D,Carmen Alldritt,286
-Sedgwick,611,State Treasurer,,D,Carmen Alldritt,166
-Sedgwick,612,State Treasurer,,D,Carmen Alldritt,331
-Sedgwick,613,State Treasurer,,D,Carmen Alldritt,278
-Sedgwick,614,State Treasurer,,D,Carmen Alldritt,139
-Sedgwick,615,State Treasurer,,D,Carmen Alldritt,476
-Sedgwick,616,State Treasurer,,D,Carmen Alldritt,155
-Sedgwick,617,State Treasurer,,D,Carmen Alldritt,118
-Sedgwick,618,State Treasurer,,D,Carmen Alldritt,267
-Sedgwick,619,State Treasurer,,D,Carmen Alldritt,326
-Sedgwick,621,State Treasurer,,D,Carmen Alldritt,3
-Sedgwick,622,State Treasurer,,D,Carmen Alldritt,232
-Sedgwick,623,State Treasurer,,D,Carmen Alldritt,204
-Sedgwick,624,State Treasurer,,D,Carmen Alldritt,30
-Sedgwick,627,State Treasurer,,D,Carmen Alldritt,23
-Sedgwick,101,Insurance Commissioner,,R,Ken Selzer,367
-Sedgwick,102,Insurance Commissioner,,R,Ken Selzer,367
-Sedgwick,103,Insurance Commissioner,,R,Ken Selzer,31
-Sedgwick,104,Insurance Commissioner,,R,Ken Selzer,18
-Sedgwick,105,Insurance Commissioner,,R,Ken Selzer,120
-Sedgwick,106,Insurance Commissioner,,R,Ken Selzer,157
-Sedgwick,107,Insurance Commissioner,,R,Ken Selzer,503
-Sedgwick,108,Insurance Commissioner,,R,Ken Selzer,208
-Sedgwick,109,Insurance Commissioner,,R,Ken Selzer,239
-Sedgwick,110,Insurance Commissioner,,R,Ken Selzer,554
-Sedgwick,111,Insurance Commissioner,,R,Ken Selzer,157
-Sedgwick,112,Insurance Commissioner,,R,Ken Selzer,259
-Sedgwick,113,Insurance Commissioner,,R,Ken Selzer,54
-Sedgwick,114,Insurance Commissioner,,R,Ken Selzer,26
-Sedgwick,116,Insurance Commissioner,,R,Ken Selzer,46
-Sedgwick,117,Insurance Commissioner,,R,Ken Selzer,39
-Sedgwick,118,Insurance Commissioner,,R,Ken Selzer,96
-Sedgwick,119,Insurance Commissioner,,R,Ken Selzer,165
-Sedgwick,120,Insurance Commissioner,,R,Ken Selzer,207
-Sedgwick,121,Insurance Commissioner,,R,Ken Selzer,338
-Sedgwick,122,Insurance Commissioner,,R,Ken Selzer,465
-Sedgwick,123,Insurance Commissioner,,R,Ken Selzer,182
-Sedgwick,124,Insurance Commissioner,,R,Ken Selzer,0
-Sedgwick,127,Insurance Commissioner,,R,Ken Selzer,128
-Sedgwick,128,Insurance Commissioner,,R,Ken Selzer,407
-Sedgwick,129,Insurance Commissioner,,R,Ken Selzer,66
-Sedgwick,130,Insurance Commissioner,,R,Ken Selzer,184
-Sedgwick,205,Insurance Commissioner,,R,Ken Selzer,77
-Sedgwick,206,Insurance Commissioner,,R,Ken Selzer,114
-Sedgwick,207,Insurance Commissioner,,R,Ken Selzer,636
-Sedgwick,208,Insurance Commissioner,,R,Ken Selzer,131
-Sedgwick,209,Insurance Commissioner,,R,Ken Selzer,302
-Sedgwick,210,Insurance Commissioner,,R,Ken Selzer,345
-Sedgwick,211,Insurance Commissioner,,R,Ken Selzer,295
-Sedgwick,212,Insurance Commissioner,,R,Ken Selzer,564
-Sedgwick,213,Insurance Commissioner,,R,Ken Selzer,726
-Sedgwick,214,Insurance Commissioner,,R,Ken Selzer,722
-Sedgwick,215,Insurance Commissioner,,R,Ken Selzer,853
-Sedgwick,216,Insurance Commissioner,,R,Ken Selzer,514
-Sedgwick,217,Insurance Commissioner,,R,Ken Selzer,717
-Sedgwick,218,Insurance Commissioner,,R,Ken Selzer,931
-Sedgwick,221,Insurance Commissioner,,R,Ken Selzer,448
-Sedgwick,222,Insurance Commissioner,,R,Ken Selzer,605
-Sedgwick,223,Insurance Commissioner,,R,Ken Selzer,762
-Sedgwick,224,Insurance Commissioner,,R,Ken Selzer,591
-Sedgwick,225,Insurance Commissioner,,R,Ken Selzer,639
-Sedgwick,226,Insurance Commissioner,,R,Ken Selzer,970
-Sedgwick,227,Insurance Commissioner,,R,Ken Selzer,562
-Sedgwick,228,Insurance Commissioner,,R,Ken Selzer,812
-Sedgwick,233,Insurance Commissioner,,R,Ken Selzer,164
-Sedgwick,235,Insurance Commissioner,,R,Ken Selzer,100
-Sedgwick,236,Insurance Commissioner,,R,Ken Selzer,489
-Sedgwick,239,Insurance Commissioner,,R,Ken Selzer,15
-Sedgwick,241,Insurance Commissioner,,R,Ken Selzer,188
-Sedgwick,301,Insurance Commissioner,,R,Ken Selzer,166
-Sedgwick,302,Insurance Commissioner,,R,Ken Selzer,247
-Sedgwick,303,Insurance Commissioner,,R,Ken Selzer,145
-Sedgwick,304,Insurance Commissioner,,R,Ken Selzer,151
-Sedgwick,305,Insurance Commissioner,,R,Ken Selzer,466
-Sedgwick,306,Insurance Commissioner,,R,Ken Selzer,400
-Sedgwick,307,Insurance Commissioner,,R,Ken Selzer,161
-Sedgwick,308,Insurance Commissioner,,R,Ken Selzer,285
-Sedgwick,309,Insurance Commissioner,,R,Ken Selzer,367
-Sedgwick,310,Insurance Commissioner,,R,Ken Selzer,157
-Sedgwick,311,Insurance Commissioner,,R,Ken Selzer,163
-Sedgwick,312,Insurance Commissioner,,R,Ken Selzer,153
-Sedgwick,313,Insurance Commissioner,,R,Ken Selzer,382
-Sedgwick,314,Insurance Commissioner,,R,Ken Selzer,397
-Sedgwick,315,Insurance Commissioner,,R,Ken Selzer,290
-Sedgwick,316,Insurance Commissioner,,R,Ken Selzer,429
-Sedgwick,317,Insurance Commissioner,,R,Ken Selzer,7
-Sedgwick,318,Insurance Commissioner,,R,Ken Selzer,16
-Sedgwick,319,Insurance Commissioner,,R,Ken Selzer,66
-Sedgwick,320,Insurance Commissioner,,R,Ken Selzer,41
-Sedgwick,321,Insurance Commissioner,,R,Ken Selzer,4
-Sedgwick,324,Insurance Commissioner,,R,Ken Selzer,118
-Sedgwick,325,Insurance Commissioner,,R,Ken Selzer,321
-Sedgwick,326,Insurance Commissioner,,R,Ken Selzer,37
-Sedgwick,401,Insurance Commissioner,,R,Ken Selzer,267
-Sedgwick,402,Insurance Commissioner,,R,Ken Selzer,267
-Sedgwick,403,Insurance Commissioner,,R,Ken Selzer,458
-Sedgwick,404,Insurance Commissioner,,R,Ken Selzer,436
-Sedgwick,405,Insurance Commissioner,,R,Ken Selzer,339
-Sedgwick,406,Insurance Commissioner,,R,Ken Selzer,278
-Sedgwick,407,Insurance Commissioner,,R,Ken Selzer,41
-Sedgwick,408,Insurance Commissioner,,R,Ken Selzer,262
-Sedgwick,409,Insurance Commissioner,,R,Ken Selzer,165
-Sedgwick,410,Insurance Commissioner,,R,Ken Selzer,994
-Sedgwick,412,Insurance Commissioner,,R,Ken Selzer,905
-Sedgwick,413,Insurance Commissioner,,R,Ken Selzer,659
-Sedgwick,414,Insurance Commissioner,,R,Ken Selzer,134
-Sedgwick,416,Insurance Commissioner,,R,Ken Selzer,452
-Sedgwick,417,Insurance Commissioner,,R,Ken Selzer,282
-Sedgwick,418,Insurance Commissioner,,R,Ken Selzer,419
-Sedgwick,419,Insurance Commissioner,,R,Ken Selzer,321
-Sedgwick,420,Insurance Commissioner,,R,Ken Selzer,372
-Sedgwick,422,Insurance Commissioner,,R,Ken Selzer,227
-Sedgwick,423,Insurance Commissioner,,R,Ken Selzer,277
-Sedgwick,424,Insurance Commissioner,,R,Ken Selzer,96
-Sedgwick,425,Insurance Commissioner,,R,Ken Selzer,581
-Sedgwick,429,Insurance Commissioner,,R,Ken Selzer,185
-Sedgwick,433,Insurance Commissioner,,R,Ken Selzer,143
-Sedgwick,437,Insurance Commissioner,,R,Ken Selzer,165
-Sedgwick,503,Insurance Commissioner,,R,Ken Selzer,424
-Sedgwick,504,Insurance Commissioner,,R,Ken Selzer,303
-Sedgwick,506,Insurance Commissioner,,R,Ken Selzer,637
-Sedgwick,507,Insurance Commissioner,,R,Ken Selzer,558
-Sedgwick,508,Insurance Commissioner,,R,Ken Selzer,517
-Sedgwick,509,Insurance Commissioner,,R,Ken Selzer,510
-Sedgwick,510,Insurance Commissioner,,R,Ken Selzer,851
-Sedgwick,512,Insurance Commissioner,,R,Ken Selzer,1243
-Sedgwick,513,Insurance Commissioner,,R,Ken Selzer,389
-Sedgwick,514,Insurance Commissioner,,R,Ken Selzer,772
-Sedgwick,515,Insurance Commissioner,,R,Ken Selzer,672
-Sedgwick,516,Insurance Commissioner,,R,Ken Selzer,467
-Sedgwick,517,Insurance Commissioner,,R,Ken Selzer,412
-Sedgwick,518,Insurance Commissioner,,R,Ken Selzer,571
-Sedgwick,519,Insurance Commissioner,,R,Ken Selzer,560
-Sedgwick,522,Insurance Commissioner,,R,Ken Selzer,619
-Sedgwick,523,Insurance Commissioner,,R,Ken Selzer,623
-Sedgwick,524,Insurance Commissioner,,R,Ken Selzer,944
-Sedgwick,525,Insurance Commissioner,,R,Ken Selzer,592
-Sedgwick,526,Insurance Commissioner,,R,Ken Selzer,705
-Sedgwick,527,Insurance Commissioner,,R,Ken Selzer,670
-Sedgwick,530,Insurance Commissioner,,R,Ken Selzer,734
-Sedgwick,531,Insurance Commissioner,,R,Ken Selzer,1093
-Sedgwick,534,Insurance Commissioner,,R,Ken Selzer,69
-Sedgwick,538,Insurance Commissioner,,R,Ken Selzer,132
-Sedgwick,539,Insurance Commissioner,,R,Ken Selzer,334
-Sedgwick,601,Insurance Commissioner,,R,Ken Selzer,184
-Sedgwick,602,Insurance Commissioner,,R,Ken Selzer,476
-Sedgwick,603,Insurance Commissioner,,R,Ken Selzer,320
-Sedgwick,604,Insurance Commissioner,,R,Ken Selzer,481
-Sedgwick,605,Insurance Commissioner,,R,Ken Selzer,178
-Sedgwick,606,Insurance Commissioner,,R,Ken Selzer,138
-Sedgwick,607,Insurance Commissioner,,R,Ken Selzer,417
-Sedgwick,608,Insurance Commissioner,,R,Ken Selzer,204
-Sedgwick,609,Insurance Commissioner,,R,Ken Selzer,490
-Sedgwick,610,Insurance Commissioner,,R,Ken Selzer,529
-Sedgwick,611,Insurance Commissioner,,R,Ken Selzer,262
-Sedgwick,612,Insurance Commissioner,,R,Ken Selzer,658
-Sedgwick,613,Insurance Commissioner,,R,Ken Selzer,499
-Sedgwick,614,Insurance Commissioner,,R,Ken Selzer,155
-Sedgwick,615,Insurance Commissioner,,R,Ken Selzer,252
-Sedgwick,616,Insurance Commissioner,,R,Ken Selzer,226
-Sedgwick,617,Insurance Commissioner,,R,Ken Selzer,107
-Sedgwick,618,Insurance Commissioner,,R,Ken Selzer,511
-Sedgwick,619,Insurance Commissioner,,R,Ken Selzer,470
-Sedgwick,621,Insurance Commissioner,,R,Ken Selzer,29
-Sedgwick,622,Insurance Commissioner,,R,Ken Selzer,768
-Sedgwick,623,Insurance Commissioner,,R,Ken Selzer,653
-Sedgwick,624,Insurance Commissioner,,R,Ken Selzer,31
-Sedgwick,627,Insurance Commissioner,,R,Ken Selzer,43
-Sedgwick,101,Insurance Commissioner,,D,Dennis Anderson,316
-Sedgwick,102,Insurance Commissioner,,D,Dennis Anderson,313
-Sedgwick,103,Insurance Commissioner,,D,Dennis Anderson,61
-Sedgwick,104,Insurance Commissioner,,D,Dennis Anderson,9
-Sedgwick,105,Insurance Commissioner,,D,Dennis Anderson,255
-Sedgwick,106,Insurance Commissioner,,D,Dennis Anderson,507
-Sedgwick,107,Insurance Commissioner,,D,Dennis Anderson,529
-Sedgwick,108,Insurance Commissioner,,D,Dennis Anderson,353
-Sedgwick,109,Insurance Commissioner,,D,Dennis Anderson,422
-Sedgwick,110,Insurance Commissioner,,D,Dennis Anderson,498
-Sedgwick,111,Insurance Commissioner,,D,Dennis Anderson,119
-Sedgwick,112,Insurance Commissioner,,D,Dennis Anderson,479
-Sedgwick,113,Insurance Commissioner,,D,Dennis Anderson,432
-Sedgwick,114,Insurance Commissioner,,D,Dennis Anderson,386
-Sedgwick,116,Insurance Commissioner,,D,Dennis Anderson,589
-Sedgwick,117,Insurance Commissioner,,D,Dennis Anderson,549
-Sedgwick,118,Insurance Commissioner,,D,Dennis Anderson,616
-Sedgwick,119,Insurance Commissioner,,D,Dennis Anderson,409
-Sedgwick,120,Insurance Commissioner,,D,Dennis Anderson,358
-Sedgwick,121,Insurance Commissioner,,D,Dennis Anderson,302
-Sedgwick,122,Insurance Commissioner,,D,Dennis Anderson,494
-Sedgwick,123,Insurance Commissioner,,D,Dennis Anderson,93
-Sedgwick,124,Insurance Commissioner,,D,Dennis Anderson,1
-Sedgwick,127,Insurance Commissioner,,D,Dennis Anderson,62
-Sedgwick,128,Insurance Commissioner,,D,Dennis Anderson,381
-Sedgwick,129,Insurance Commissioner,,D,Dennis Anderson,82
-Sedgwick,130,Insurance Commissioner,,D,Dennis Anderson,234
-Sedgwick,205,Insurance Commissioner,,D,Dennis Anderson,115
-Sedgwick,206,Insurance Commissioner,,D,Dennis Anderson,106
-Sedgwick,207,Insurance Commissioner,,D,Dennis Anderson,602
-Sedgwick,208,Insurance Commissioner,,D,Dennis Anderson,110
-Sedgwick,209,Insurance Commissioner,,D,Dennis Anderson,287
-Sedgwick,210,Insurance Commissioner,,D,Dennis Anderson,365
-Sedgwick,211,Insurance Commissioner,,D,Dennis Anderson,228
-Sedgwick,212,Insurance Commissioner,,D,Dennis Anderson,421
-Sedgwick,213,Insurance Commissioner,,D,Dennis Anderson,383
-Sedgwick,214,Insurance Commissioner,,D,Dennis Anderson,293
-Sedgwick,215,Insurance Commissioner,,D,Dennis Anderson,487
-Sedgwick,216,Insurance Commissioner,,D,Dennis Anderson,342
-Sedgwick,217,Insurance Commissioner,,D,Dennis Anderson,325
-Sedgwick,218,Insurance Commissioner,,D,Dennis Anderson,541
-Sedgwick,221,Insurance Commissioner,,D,Dennis Anderson,201
-Sedgwick,222,Insurance Commissioner,,D,Dennis Anderson,309
-Sedgwick,223,Insurance Commissioner,,D,Dennis Anderson,321
-Sedgwick,224,Insurance Commissioner,,D,Dennis Anderson,441
-Sedgwick,225,Insurance Commissioner,,D,Dennis Anderson,437
-Sedgwick,226,Insurance Commissioner,,D,Dennis Anderson,445
-Sedgwick,227,Insurance Commissioner,,D,Dennis Anderson,199
-Sedgwick,228,Insurance Commissioner,,D,Dennis Anderson,194
-Sedgwick,233,Insurance Commissioner,,D,Dennis Anderson,117
-Sedgwick,235,Insurance Commissioner,,D,Dennis Anderson,122
-Sedgwick,236,Insurance Commissioner,,D,Dennis Anderson,179
-Sedgwick,239,Insurance Commissioner,,D,Dennis Anderson,4
-Sedgwick,241,Insurance Commissioner,,D,Dennis Anderson,75
-Sedgwick,301,Insurance Commissioner,,D,Dennis Anderson,139
-Sedgwick,302,Insurance Commissioner,,D,Dennis Anderson,302
-Sedgwick,303,Insurance Commissioner,,D,Dennis Anderson,114
-Sedgwick,304,Insurance Commissioner,,D,Dennis Anderson,138
-Sedgwick,305,Insurance Commissioner,,D,Dennis Anderson,480
-Sedgwick,306,Insurance Commissioner,,D,Dennis Anderson,492
-Sedgwick,307,Insurance Commissioner,,D,Dennis Anderson,223
-Sedgwick,308,Insurance Commissioner,,D,Dennis Anderson,370
-Sedgwick,309,Insurance Commissioner,,D,Dennis Anderson,390
-Sedgwick,310,Insurance Commissioner,,D,Dennis Anderson,191
-Sedgwick,311,Insurance Commissioner,,D,Dennis Anderson,125
-Sedgwick,312,Insurance Commissioner,,D,Dennis Anderson,139
-Sedgwick,313,Insurance Commissioner,,D,Dennis Anderson,442
-Sedgwick,314,Insurance Commissioner,,D,Dennis Anderson,341
-Sedgwick,315,Insurance Commissioner,,D,Dennis Anderson,288
-Sedgwick,316,Insurance Commissioner,,D,Dennis Anderson,266
-Sedgwick,317,Insurance Commissioner,,D,Dennis Anderson,5
-Sedgwick,318,Insurance Commissioner,,D,Dennis Anderson,6
-Sedgwick,319,Insurance Commissioner,,D,Dennis Anderson,101
-Sedgwick,320,Insurance Commissioner,,D,Dennis Anderson,71
-Sedgwick,321,Insurance Commissioner,,D,Dennis Anderson,14
-Sedgwick,324,Insurance Commissioner,,D,Dennis Anderson,132
-Sedgwick,325,Insurance Commissioner,,D,Dennis Anderson,291
-Sedgwick,326,Insurance Commissioner,,D,Dennis Anderson,29
-Sedgwick,401,Insurance Commissioner,,D,Dennis Anderson,139
-Sedgwick,402,Insurance Commissioner,,D,Dennis Anderson,153
-Sedgwick,403,Insurance Commissioner,,D,Dennis Anderson,175
-Sedgwick,404,Insurance Commissioner,,D,Dennis Anderson,417
-Sedgwick,405,Insurance Commissioner,,D,Dennis Anderson,296
-Sedgwick,406,Insurance Commissioner,,D,Dennis Anderson,240
-Sedgwick,407,Insurance Commissioner,,D,Dennis Anderson,32
-Sedgwick,408,Insurance Commissioner,,D,Dennis Anderson,281
-Sedgwick,409,Insurance Commissioner,,D,Dennis Anderson,139
-Sedgwick,410,Insurance Commissioner,,D,Dennis Anderson,338
-Sedgwick,412,Insurance Commissioner,,D,Dennis Anderson,372
-Sedgwick,413,Insurance Commissioner,,D,Dennis Anderson,294
-Sedgwick,414,Insurance Commissioner,,D,Dennis Anderson,60
-Sedgwick,416,Insurance Commissioner,,D,Dennis Anderson,184
-Sedgwick,417,Insurance Commissioner,,D,Dennis Anderson,193
-Sedgwick,418,Insurance Commissioner,,D,Dennis Anderson,288
-Sedgwick,419,Insurance Commissioner,,D,Dennis Anderson,289
-Sedgwick,420,Insurance Commissioner,,D,Dennis Anderson,310
-Sedgwick,422,Insurance Commissioner,,D,Dennis Anderson,187
-Sedgwick,423,Insurance Commissioner,,D,Dennis Anderson,213
-Sedgwick,424,Insurance Commissioner,,D,Dennis Anderson,65
-Sedgwick,425,Insurance Commissioner,,D,Dennis Anderson,350
-Sedgwick,429,Insurance Commissioner,,D,Dennis Anderson,151
-Sedgwick,433,Insurance Commissioner,,D,Dennis Anderson,81
-Sedgwick,437,Insurance Commissioner,,D,Dennis Anderson,64
-Sedgwick,503,Insurance Commissioner,,D,Dennis Anderson,319
-Sedgwick,504,Insurance Commissioner,,D,Dennis Anderson,210
-Sedgwick,506,Insurance Commissioner,,D,Dennis Anderson,333
-Sedgwick,507,Insurance Commissioner,,D,Dennis Anderson,361
-Sedgwick,508,Insurance Commissioner,,D,Dennis Anderson,306
-Sedgwick,509,Insurance Commissioner,,D,Dennis Anderson,275
-Sedgwick,510,Insurance Commissioner,,D,Dennis Anderson,281
-Sedgwick,512,Insurance Commissioner,,D,Dennis Anderson,447
-Sedgwick,513,Insurance Commissioner,,D,Dennis Anderson,93
-Sedgwick,514,Insurance Commissioner,,D,Dennis Anderson,359
-Sedgwick,515,Insurance Commissioner,,D,Dennis Anderson,340
-Sedgwick,516,Insurance Commissioner,,D,Dennis Anderson,210
-Sedgwick,517,Insurance Commissioner,,D,Dennis Anderson,270
-Sedgwick,518,Insurance Commissioner,,D,Dennis Anderson,255
-Sedgwick,519,Insurance Commissioner,,D,Dennis Anderson,370
-Sedgwick,522,Insurance Commissioner,,D,Dennis Anderson,277
-Sedgwick,523,Insurance Commissioner,,D,Dennis Anderson,268
-Sedgwick,524,Insurance Commissioner,,D,Dennis Anderson,475
-Sedgwick,525,Insurance Commissioner,,D,Dennis Anderson,367
-Sedgwick,526,Insurance Commissioner,,D,Dennis Anderson,296
-Sedgwick,527,Insurance Commissioner,,D,Dennis Anderson,288
-Sedgwick,530,Insurance Commissioner,,D,Dennis Anderson,235
-Sedgwick,531,Insurance Commissioner,,D,Dennis Anderson,463
-Sedgwick,534,Insurance Commissioner,,D,Dennis Anderson,20
-Sedgwick,538,Insurance Commissioner,,D,Dennis Anderson,52
-Sedgwick,539,Insurance Commissioner,,D,Dennis Anderson,140
-Sedgwick,601,Insurance Commissioner,,D,Dennis Anderson,284
-Sedgwick,602,Insurance Commissioner,,D,Dennis Anderson,418
-Sedgwick,603,Insurance Commissioner,,D,Dennis Anderson,130
-Sedgwick,604,Insurance Commissioner,,D,Dennis Anderson,383
-Sedgwick,605,Insurance Commissioner,,D,Dennis Anderson,146
-Sedgwick,606,Insurance Commissioner,,D,Dennis Anderson,132
-Sedgwick,607,Insurance Commissioner,,D,Dennis Anderson,677
-Sedgwick,608,Insurance Commissioner,,D,Dennis Anderson,420
-Sedgwick,609,Insurance Commissioner,,D,Dennis Anderson,703
-Sedgwick,610,Insurance Commissioner,,D,Dennis Anderson,400
-Sedgwick,611,Insurance Commissioner,,D,Dennis Anderson,211
-Sedgwick,612,Insurance Commissioner,,D,Dennis Anderson,467
-Sedgwick,613,Insurance Commissioner,,D,Dennis Anderson,375
-Sedgwick,614,Insurance Commissioner,,D,Dennis Anderson,179
-Sedgwick,615,Insurance Commissioner,,D,Dennis Anderson,542
-Sedgwick,616,Insurance Commissioner,,D,Dennis Anderson,199
-Sedgwick,617,Insurance Commissioner,,D,Dennis Anderson,135
-Sedgwick,618,Insurance Commissioner,,D,Dennis Anderson,354
-Sedgwick,619,Insurance Commissioner,,D,Dennis Anderson,419
-Sedgwick,621,Insurance Commissioner,,D,Dennis Anderson,8
-Sedgwick,622,Insurance Commissioner,,D,Dennis Anderson,338
-Sedgwick,623,Insurance Commissioner,,D,Dennis Anderson,296
-Sedgwick,624,Insurance Commissioner,,D,Dennis Anderson,37
-Sedgwick,627,Insurance Commissioner,,D,Dennis Anderson,31
-Sedgwick,102,State House,83,R,James Thomas,366
-Sedgwick,106,State House,84,R,Ray Racobs,127
-Sedgwick,107,State House,84,R,Ray Racobs,381
-Sedgwick,108,State House,84,R,Ray Racobs,152
-Sedgwick,109,State House,83,R,James Thomas,218
-Sedgwick,110,State House,84,R,Ray Racobs,403
-Sedgwick,111,State House,83,R,James Thomas,142
-Sedgwick,112,State House,89,R,Frank Chappell,242
-Sedgwick,113,State House,84,R,Ray Racobs,35
-Sedgwick,114,State House,84,R,Ray Racobs,14
-Sedgwick,116,State House,84,R,Ray Racobs,27
-Sedgwick,117,State House,89,R,Frank Chappell,43
-Sedgwick,118,State House,89,R,Frank Chappell,97
-Sedgwick,119,State House,89,R,Frank Chappell,164
-Sedgwick,120,State House,89,R,Frank Chappell,194
-Sedgwick,121,State House,87,R,Mark Kahrs,339
-Sedgwick,122,State House,85,R,Steven Brunk,494
-Sedgwick,123,State House,89,R,Frank Chappell,176
-Sedgwick,124,State House,89,R,Frank Chappell,0
-Sedgwick,127,State House,89,R,Frank Chappell,128
-Sedgwick,128,State House,83,R,James Thomas,366
-Sedgwick,205,State House,83,R,James Thomas,75
-Sedgwick,206,State House,87,R,Mark Kahrs,109
-Sedgwick,207,State House,88,R,Joseph Scapa,620
-Sedgwick,208,State House,88,R,Joseph Scapa,129
-Sedgwick,209,State House,88,R,Joseph Scapa,271
-Sedgwick,210,State House,88,R,Joseph Scapa,366
-Sedgwick,211,State House,87,R,Mark Kahrs,303
-Sedgwick,212,State House,87,R,Mark Kahrs,563
-Sedgwick,213,State House,87,R,Mark Kahrs,707
-Sedgwick,214,State House,87,R,Mark Kahrs,751
-Sedgwick,215,State House,87,R,Mark Kahrs,843
-Sedgwick,216,State House,85,R,Steven Brunk,556
-Sedgwick,217,State House,85,R,Steven Brunk,748
-Sedgwick,218,State House,85,R,Steven Brunk,992
-Sedgwick,221,State House,85,R,Steven Brunk,461
-Sedgwick,222,State House,85,R,Steven Brunk,610
-Sedgwick,223,State House,87,R,Mark Kahrs,757
-Sedgwick,224,State House,87,R,Mark Kahrs,580
-Sedgwick,225,State House,88,R,Joseph Scapa,630
-Sedgwick,226,State House,99,R,Dennis E. Hedke,1095
-Sedgwick,227,State House,99,R,Dennis E. Hedke,619
-Sedgwick,228,State House,99,R,Dennis E. Hedke,846
-Sedgwick,233,State House,81,R,Blake Carpenter,165
-Sedgwick,235,State House,88,R,Joseph Scapa,100
-Sedgwick,236,State House,85,R,Steven Brunk,490
-Sedgwick,239,State House,99,R,Dennis E. Hedke,15
-Sedgwick,241,State House,99,R,Dennis E. Hedke,203
-Sedgwick,306,State House,83,R,James Thomas,355
-Sedgwick,307,State House,83,R,James Thomas,154
-Sedgwick,308,State House,83,R,James Thomas,272
-Sedgwick,309,State House,88,R,Joseph Scapa,374
-Sedgwick,310,State House,81,R,Blake Carpenter,133
-Sedgwick,311,State House,98,R,Steven Anthimides,168
-Sedgwick,312,State House,98,R,Steven Anthimides,152
-Sedgwick,313,State House,96,R,Rick Lindsey,338
-Sedgwick,314,State House,96,R,Rick Lindsey,353
-Sedgwick,315,State House,98,R,Steven Anthimides,258
-Sedgwick,316,State House,98,R,Steven Anthimides,380
-Sedgwick,317,State House,93,R,John Whitmer,8
-Sedgwick,318,State House,98,R,Steven Anthimides,16
-Sedgwick,321,State House,83,R,James Thomas,3
-Sedgwick,325,State House,96,R,Rick Lindsey,264
-Sedgwick,326,State House,98,R,Steven Anthimides,31
-Sedgwick,401,State House,97,R,Leslie G. Osterman,311
-Sedgwick,402,State House,97,R,Leslie G. Osterman,309
-Sedgwick,403,State House,94,R,Mario Goico,501
-Sedgwick,404,State House,95,R,Benny Boman,366
-Sedgwick,405,State House,95,R,Benny Boman,294
-Sedgwick,406,State House,95,R,Benny Boman,224
-Sedgwick,408,State House,95,R,Benny Boman,223
-Sedgwick,409,State House,97,R,Leslie G. Osterman,227
-Sedgwick,410,State House,101,R,Joe Seiwert,1095
-Sedgwick,412,State House,97,R,Leslie G. Osterman,1026
-Sedgwick,413,State House,94,R,Mario Goico,760
-Sedgwick,414,State House,93,R,John Whitmer,132
-Sedgwick,416,State House,97,R,Leslie G. Osterman,520
-Sedgwick,417,State House,97,R,Leslie G. Osterman,365
-Sedgwick,418,State House,97,R,Leslie G. Osterman,530
-Sedgwick,419,State House,96,R,Rick Lindsey,274
-Sedgwick,420,State House,96,R,Rick Lindsey,307
-Sedgwick,422,State House,96,R,Rick Lindsey,196
-Sedgwick,423,State House,96,R,Rick Lindsey,251
-Sedgwick,424,State House,97,R,Leslie G. Osterman,116
-Sedgwick,425,State House,98,R,Steven Anthimides,514
-Sedgwick,429,State House,97,R,Leslie G. Osterman,247
-Sedgwick,433,State House,97,R,Leslie G. Osterman,179
-Sedgwick,437,State House,97,R,Leslie G. Osterman,188
-Sedgwick,503,State House,105,R,Mark Hutton,444
-Sedgwick,504,State House,105,R,Mark Hutton,302
-Sedgwick,506,State House,105,R,Mark Hutton,662
-Sedgwick,507,State House,105,R,Mark Hutton,569
-Sedgwick,508,State House,100,R,Dan Hawkins,527
-Sedgwick,509,State House,100,R,Dan Hawkins,530
-Sedgwick,510,State House,100,R,Dan Hawkins,883
-Sedgwick,512,State House,91,R,Gene Suellentrop,1415
-Sedgwick,513,State House,100,R,Dan Hawkins,386
-Sedgwick,514,State House,100,R,Dan Hawkins,784
-Sedgwick,515,State House,100,R,Dan Hawkins,702
-Sedgwick,516,State House,100,R,Dan Hawkins,481
-Sedgwick,517,State House,100,R,Dan Hawkins,433
-Sedgwick,518,State House,100,R,Dan Hawkins,590
-Sedgwick,519,State House,100,R,Dan Hawkins,592
-Sedgwick,522,State House,94,R,Mario Goico,683
-Sedgwick,523,State House,94,R,Mario Goico,705
-Sedgwick,524,State House,94,R,Mario Goico,1105
-Sedgwick,525,State House,94,R,Mario Goico,711
-Sedgwick,526,State House,94,R,Mario Goico,810
-Sedgwick,527,State House,90,R,Steve Huebert,742
-Sedgwick,530,State House,94,R,Mario Goico,820
-Sedgwick,531,State House,101,R,Joe Seiwert,1223
-Sedgwick,534,State House,100,R,Dan Hawkins,67
-Sedgwick,538,State House,101,R,Joe Seiwert,153
-Sedgwick,539,State House,94,R,Mario Goico,379
-Sedgwick,602,State House,95,R,Benny Boman,384
-Sedgwick,603,State House,105,R,Mark Hutton,328
-Sedgwick,604,State House,105,R,Mark Hutton,505
-Sedgwick,605,State House,95,R,Benny Boman,156
-Sedgwick,606,State House,92,R,Jeremy Alessi,136
-Sedgwick,607,State House,92,R,Jeremy Alessi,383
-Sedgwick,608,State House,92,R,Jeremy Alessi,212
-Sedgwick,609,State House,92,R,Jeremy Alessi,494
-Sedgwick,610,State House,92,R,Jeremy Alessi,526
-Sedgwick,611,State House,92,R,Jeremy Alessi,271
-Sedgwick,612,State House,105,R,Mark Hutton,675
-Sedgwick,613,State House,92,R,Jeremy Alessi,470
-Sedgwick,614,State House,95,R,Benny Boman,136
-Sedgwick,616,State House,105,R,Mark Hutton,220
-Sedgwick,618,State House,91,R,Gene Suellentrop,619
-Sedgwick,619,State House,92,R,Jeremy Alessi,531
-Sedgwick,621,State House,91,R,Gene Suellentrop,33
-Sedgwick,622,State House,91,R,Gene Suellentrop,881
-Sedgwick,623,State House,91,R,Gene Suellentrop,744
-Sedgwick,624,State House,95,R,Benny Boman,22
-Sedgwick,101,State House,86,D,Jim Ward,449
-Sedgwick,102,State House,83,D,Carolyn Bridges,338
-Sedgwick,103,State House,103,D,Ponka-We Victors,71
-Sedgwick,104,State House,103,D,Ponka-We Victors,13
-Sedgwick,105,State House,86,D,Jim Ward,288
-Sedgwick,106,State House,84,D,Gail Finney,510
-Sedgwick,107,State House,84,D,Gail Finney,570
-Sedgwick,108,State House,84,D,Gail Finney,384
-Sedgwick,109,State House,83,D,Carolyn Bridges,461
-Sedgwick,110,State House,84,D,Gail Finney,560
-Sedgwick,111,State House,83,D,Carolyn Bridges,146
-Sedgwick,112,State House,89,D,Roderick A. Houston,513
-Sedgwick,113,State House,84,D,Gail Finney,448
-Sedgwick,114,State House,84,D,Gail Finney,412
-Sedgwick,116,State House,84,D,Gail Finney,604
-Sedgwick,117,State House,89,D,Roderick A. Houston,565
-Sedgwick,118,State House,89,D,Roderick A. Houston,653
-Sedgwick,119,State House,89,D,Roderick A. Houston,426
-Sedgwick,120,State House,89,D,Roderick A. Houston,373
-Sedgwick,121,State House,87,D,Charles Jenney,312
-Sedgwick,122,State House,85,D,Patrick Thorpe,474
-Sedgwick,123,State House,89,D,Roderick A. Houston,98
-Sedgwick,124,State House,89,D,Roderick A. Houston,1
-Sedgwick,127,State House,89,D,Roderick A. Houston,68
-Sedgwick,128,State House,83,D,Carolyn Bridges,452
-Sedgwick,129,State House,103,D,Ponka-We Victors,105
-Sedgwick,130,State House,86,D,Jim Ward,274
-Sedgwick,205,State House,83,D,Carolyn Bridges,119
-Sedgwick,206,State House,87,D,Charles Jenney,113
-Sedgwick,207,State House,88,D,Patricia M. Sloop,648
-Sedgwick,208,State House,88,D,Patricia M. Sloop,124
-Sedgwick,209,State House,88,D,Patricia M. Sloop,330
-Sedgwick,210,State House,88,D,Patricia M. Sloop,374
-Sedgwick,211,State House,87,D,Charles Jenney,229
-Sedgwick,212,State House,87,D,Charles Jenney,461
-Sedgwick,213,State House,87,D,Charles Jenney,428
-Sedgwick,214,State House,87,D,Charles Jenney,299
-Sedgwick,215,State House,87,D,Charles Jenney,521
-Sedgwick,216,State House,85,D,Patrick Thorpe,303
-Sedgwick,217,State House,85,D,Patrick Thorpe,306
-Sedgwick,218,State House,85,D,Patrick Thorpe,507
-Sedgwick,221,State House,85,D,Patrick Thorpe,205
-Sedgwick,222,State House,85,D,Patrick Thorpe,296
-Sedgwick,223,State House,87,D,Charles Jenney,346
-Sedgwick,224,State House,87,D,Charles Jenney,469
-Sedgwick,225,State House,88,D,Patricia M. Sloop,492
-Sedgwick,233,State House,81,D,Lynn Wells,121
-Sedgwick,235,State House,88,D,Patricia M. Sloop,128
-Sedgwick,236,State House,85,D,Patrick Thorpe,184
-Sedgwick,301,State House,86,D,Jim Ward,188
-Sedgwick,302,State House,86,D,Jim Ward,353
-Sedgwick,303,State House,86,D,Jim Ward,148
-Sedgwick,304,State House,86,D,Jim Ward,189
-Sedgwick,305,State House,86,D,Jim Ward,700
-Sedgwick,306,State House,83,D,Carolyn Bridges,539
-Sedgwick,307,State House,83,D,Carolyn Bridges,231
-Sedgwick,308,State House,83,D,Carolyn Bridges,392
-Sedgwick,309,State House,88,D,Patricia M. Sloop,412
-Sedgwick,310,State House,81,D,Lynn Wells,212
-Sedgwick,311,State House,98,D,Steven G. Crum,127
-Sedgwick,312,State House,98,D,Steven G. Crum,136
-Sedgwick,313,State House,96,D,Brandon Whipple,512
-Sedgwick,314,State House,96,D,Brandon Whipple,419
-Sedgwick,315,State House,98,D,Steven G. Crum,318
-Sedgwick,316,State House,98,D,Steven G. Crum,319
-Sedgwick,317,State House,93,D,Sammy Flaharty,4
-Sedgwick,318,State House,98,D,Steven G. Crum,5
-Sedgwick,319,State House,86,D,Jim Ward,128
-Sedgwick,320,State House,103,D,Ponka-We Victors,86
-Sedgwick,321,State House,83,D,Carolyn Bridges,14
-Sedgwick,324,State House,103,D,Ponka-We Victors,173
-Sedgwick,325,State House,96,D,Brandon Whipple,372
-Sedgwick,326,State House,98,D,Steven G. Crum,38
-Sedgwick,404,State House,95,D,Tom Sawyer,522
-Sedgwick,405,State House,95,D,Tom Sawyer,361
-Sedgwick,406,State House,95,D,Tom Sawyer,316
-Sedgwick,407,State House,86,D,Jim Ward,43
-Sedgwick,408,State House,95,D,Tom Sawyer,334
-Sedgwick,414,State House,93,D,Sammy Flaharty,60
-Sedgwick,419,State House,96,D,Brandon Whipple,369
-Sedgwick,420,State House,96,D,Brandon Whipple,384
-Sedgwick,422,State House,96,D,Brandon Whipple,231
-Sedgwick,423,State House,96,D,Brandon Whipple,257
-Sedgwick,425,State House,98,D,Steven G. Crum,442
-Sedgwick,503,State House,105,D,Sherry Livingston,301
-Sedgwick,504,State House,105,D,Sherry Livingston,223
-Sedgwick,506,State House,105,D,Sherry Livingston,320
-Sedgwick,507,State House,105,D,Sherry Livingston,361
-Sedgwick,508,State House,100,D,John W Willoughby,285
-Sedgwick,509,State House,100,D,John W Willoughby,245
-Sedgwick,510,State House,100,D,John W Willoughby,241
-Sedgwick,513,State House,100,D,John W Willoughby,97
-Sedgwick,514,State House,100,D,John W Willoughby,335
-Sedgwick,515,State House,100,D,John W Willoughby,307
-Sedgwick,516,State House,100,D,John W Willoughby,190
-Sedgwick,517,State House,100,D,John W Willoughby,257
-Sedgwick,518,State House,100,D,John W Willoughby,237
-Sedgwick,519,State House,100,D,John W Willoughby,328
-Sedgwick,534,State House,100,D,John W Willoughby,22
-Sedgwick,601,State House,103,D,Ponka-We Victors,345
-Sedgwick,602,State House,95,D,Tom Sawyer,534
-Sedgwick,603,State House,105,D,Sherry Livingston,130
-Sedgwick,604,State House,105,D,Sherry Livingston,352
-Sedgwick,605,State House,95,D,Tom Sawyer,172
-Sedgwick,606,State House,92,D,John Carmichael,142
-Sedgwick,607,State House,92,D,John Carmichael,746
-Sedgwick,608,State House,92,D,John Carmichael,431
-Sedgwick,609,State House,92,D,John Carmichael,741
-Sedgwick,610,State House,92,D,John Carmichael,417
-Sedgwick,611,State House,92,D,John Carmichael,211
-Sedgwick,612,State House,105,D,Sherry Livingston,456
-Sedgwick,613,State House,92,D,John Carmichael,435
-Sedgwick,614,State House,95,D,Tom Sawyer,208
-Sedgwick,615,State House,103,D,Ponka-We Victors,643
-Sedgwick,616,State House,105,D,Sherry Livingston,212
-Sedgwick,617,State House,103,D,Ponka-We Victors,171
-Sedgwick,619,State House,92,D,John Carmichael,391
-Sedgwick,624,State House,95,D,Tom Sawyer,47
-Sedgwick,627,State House,103,D,Ponka-We Victors,41
-Sedgwick,101,State House,86,L,James Pruden,196
-Sedgwick,105,State House,86,L,James Pruden,80
-Sedgwick,106,State House,84,L,Gordon Bakken,56
-Sedgwick,107,State House,84,L,Gordon Bakken,87
-Sedgwick,108,State House,84,L,Gordon Bakken,38
-Sedgwick,110,State House,84,L,Gordon Bakken,86
-Sedgwick,113,State House,84,L,Gordon Bakken,20
-Sedgwick,114,State House,84,L,Gordon Bakken,15
-Sedgwick,116,State House,84,L,Gordon Bakken,16
-Sedgwick,130,State House,86,L,James Pruden,119
-Sedgwick,301,State House,86,L,James Pruden,94
-Sedgwick,302,State House,86,L,James Pruden,159
-Sedgwick,303,State House,86,L,James Pruden,80
-Sedgwick,304,State House,86,L,James Pruden,85
-Sedgwick,305,State House,86,L,James Pruden,215
-Sedgwick,319,State House,86,L,James Pruden,37
-Sedgwick,407,State House,86,L,James Pruden,23
-Sedgwick,101,U.S. Senate,,,Write-ins,1
-Sedgwick,102,U.S. Senate,,,Write-ins,1
-Sedgwick,107,U.S. Senate,,,Write-ins,3
-Sedgwick,108,U.S. Senate,,,Write-ins,2
-Sedgwick,109,U.S. Senate,,,Write-ins,2
-Sedgwick,110,U.S. Senate,,,Write-ins,1
-Sedgwick,112,U.S. Senate,,,Write-ins,3
-Sedgwick,113,U.S. Senate,,,Write-ins,1
-Sedgwick,114,U.S. Senate,,,Write-ins,3
-Sedgwick,116,U.S. Senate,,,Write-ins,2
-Sedgwick,118,U.S. Senate,,,Write-ins,2
-Sedgwick,119,U.S. Senate,,,Write-ins,1
-Sedgwick,120,U.S. Senate,,,Write-ins,3
-Sedgwick,121,U.S. Senate,,,Write-ins,1
-Sedgwick,123,U.S. Senate,,,Write-ins,1
-Sedgwick,128,U.S. Senate,,,Write-ins,2
-Sedgwick,130,U.S. Senate,,,Write-ins,1
-Sedgwick,205,U.S. Senate,,,Write-ins,1
-Sedgwick,207,U.S. Senate,,,Write-ins,2
-Sedgwick,208,U.S. Senate,,,Write-ins,2
-Sedgwick,210,U.S. Senate,,,Write-ins,2
-Sedgwick,212,U.S. Senate,,,Write-ins,1
-Sedgwick,216,U.S. Senate,,,Write-ins,3
-Sedgwick,217,U.S. Senate,,,Write-ins,1
-Sedgwick,218,U.S. Senate,,,Write-ins,3
-Sedgwick,222,U.S. Senate,,,Write-ins,2
-Sedgwick,223,U.S. Senate,,,Write-ins,2
-Sedgwick,224,U.S. Senate,,,Write-ins,1
-Sedgwick,225,U.S. Senate,,,Write-ins,1
-Sedgwick,226,U.S. Senate,,,Write-ins,3
-Sedgwick,235,U.S. Senate,,,Write-ins,1
-Sedgwick,241,U.S. Senate,,,Write-ins,1
-Sedgwick,301,U.S. Senate,,,Write-ins,4
-Sedgwick,302,U.S. Senate,,,Write-ins,1
-Sedgwick,305,U.S. Senate,,,Write-ins,5
-Sedgwick,306,U.S. Senate,,,Write-ins,1
-Sedgwick,308,U.S. Senate,,,Write-ins,1
-Sedgwick,309,U.S. Senate,,,Write-ins,1
-Sedgwick,310,U.S. Senate,,,Write-ins,1
-Sedgwick,312,U.S. Senate,,,Write-ins,1
-Sedgwick,313,U.S. Senate,,,Write-ins,4
-Sedgwick,314,U.S. Senate,,,Write-ins,2
-Sedgwick,315,U.S. Senate,,,Write-ins,2
-Sedgwick,316,U.S. Senate,,,Write-ins,1
-Sedgwick,324,U.S. Senate,,,Write-ins,1
-Sedgwick,325,U.S. Senate,,,Write-ins,1
-Sedgwick,404,U.S. Senate,,,Write-ins,2
-Sedgwick,405,U.S. Senate,,,Write-ins,1
-Sedgwick,409,U.S. Senate,,,Write-ins,1
-Sedgwick,410,U.S. Senate,,,Write-ins,1
-Sedgwick,412,U.S. Senate,,,Write-ins,4
-Sedgwick,413,U.S. Senate,,,Write-ins,2
-Sedgwick,414,U.S. Senate,,,Write-ins,1
-Sedgwick,417,U.S. Senate,,,Write-ins,1
-Sedgwick,418,U.S. Senate,,,Write-ins,1
-Sedgwick,419,U.S. Senate,,,Write-ins,1
-Sedgwick,420,U.S. Senate,,,Write-ins,1
-Sedgwick,422,U.S. Senate,,,Write-ins,3
-Sedgwick,423,U.S. Senate,,,Write-ins,2
-Sedgwick,425,U.S. Senate,,,Write-ins,2
-Sedgwick,503,U.S. Senate,,,Write-ins,4
-Sedgwick,504,U.S. Senate,,,Write-ins,2
-Sedgwick,507,U.S. Senate,,,Write-ins,1
-Sedgwick,509,U.S. Senate,,,Write-ins,1
-Sedgwick,510,U.S. Senate,,,Write-ins,2
-Sedgwick,512,U.S. Senate,,,Write-ins,4
-Sedgwick,513,U.S. Senate,,,Write-ins,2
-Sedgwick,514,U.S. Senate,,,Write-ins,2
-Sedgwick,515,U.S. Senate,,,Write-ins,2
-Sedgwick,518,U.S. Senate,,,Write-ins,1
-Sedgwick,523,U.S. Senate,,,Write-ins,1
-Sedgwick,524,U.S. Senate,,,Write-ins,3
-Sedgwick,525,U.S. Senate,,,Write-ins,3
-Sedgwick,526,U.S. Senate,,,Write-ins,2
-Sedgwick,530,U.S. Senate,,,Write-ins,2
-Sedgwick,531,U.S. Senate,,,Write-ins,2
-Sedgwick,539,U.S. Senate,,,Write-ins,1
-Sedgwick,602,U.S. Senate,,,Write-ins,1
-Sedgwick,603,U.S. Senate,,,Write-ins,1
-Sedgwick,604,U.S. Senate,,,Write-ins,1
-Sedgwick,606,U.S. Senate,,,Write-ins,1
-Sedgwick,607,U.S. Senate,,,Write-ins,1
-Sedgwick,608,U.S. Senate,,,Write-ins,2
-Sedgwick,610,U.S. Senate,,,Write-ins,3
-Sedgwick,612,U.S. Senate,,,Write-ins,2
-Sedgwick,613,U.S. Senate,,,Write-ins,1
-Sedgwick,614,U.S. Senate,,,Write-ins,2
-Sedgwick,615,U.S. Senate,,,Write-ins,2
-Sedgwick,616,U.S. Senate,,,Write-ins,1
-Sedgwick,619,U.S. Senate,,,Write-ins,3
-Sedgwick,622,U.S. Senate,,,Write-ins,2
-Sedgwick,623,U.S. Senate,,,Write-ins,4
-Sedgwick,101,U.S. House,4,,Write-ins,2
-Sedgwick,102,U.S. House,4,,Write-ins,3
-Sedgwick,105,U.S. House,4,,Write-ins,3
-Sedgwick,107,U.S. House,4,,Write-ins,5
-Sedgwick,108,U.S. House,4,,Write-ins,1
-Sedgwick,109,U.S. House,4,,Write-ins,2
-Sedgwick,110,U.S. House,4,,Write-ins,3
-Sedgwick,111,U.S. House,4,,Write-ins,2
-Sedgwick,112,U.S. House,4,,Write-ins,4
-Sedgwick,113,U.S. House,4,,Write-ins,1
-Sedgwick,114,U.S. House,4,,Write-ins,2
-Sedgwick,119,U.S. House,4,,Write-ins,4
-Sedgwick,120,U.S. House,4,,Write-ins,2
-Sedgwick,121,U.S. House,4,,Write-ins,2
-Sedgwick,122,U.S. House,4,,Write-ins,4
-Sedgwick,123,U.S. House,4,,Write-ins,1
-Sedgwick,128,U.S. House,4,,Write-ins,2
-Sedgwick,207,U.S. House,4,,Write-ins,4
-Sedgwick,209,U.S. House,4,,Write-ins,2
-Sedgwick,210,U.S. House,4,,Write-ins,1
-Sedgwick,211,U.S. House,4,,Write-ins,1
-Sedgwick,212,U.S. House,4,,Write-ins,1
-Sedgwick,213,U.S. House,4,,Write-ins,3
-Sedgwick,214,U.S. House,4,,Write-ins,1
-Sedgwick,215,U.S. House,4,,Write-ins,4
-Sedgwick,218,U.S. House,4,,Write-ins,3
-Sedgwick,221,U.S. House,4,,Write-ins,6
-Sedgwick,222,U.S. House,4,,Write-ins,1
-Sedgwick,223,U.S. House,4,,Write-ins,2
-Sedgwick,224,U.S. House,4,,Write-ins,6
-Sedgwick,226,U.S. House,4,,Write-ins,4
-Sedgwick,227,U.S. House,4,,Write-ins,1
-Sedgwick,228,U.S. House,4,,Write-ins,3
-Sedgwick,233,U.S. House,4,,Write-ins,1
-Sedgwick,235,U.S. House,4,,Write-ins,1
-Sedgwick,301,U.S. House,4,,Write-ins,4
-Sedgwick,302,U.S. House,4,,Write-ins,2
-Sedgwick,303,U.S. House,4,,Write-ins,2
-Sedgwick,305,U.S. House,4,,Write-ins,4
-Sedgwick,306,U.S. House,4,,Write-ins,5
-Sedgwick,307,U.S. House,4,,Write-ins,1
-Sedgwick,308,U.S. House,4,,Write-ins,2
-Sedgwick,309,U.S. House,4,,Write-ins,2
-Sedgwick,310,U.S. House,4,,Write-ins,1
-Sedgwick,311,U.S. House,4,,Write-ins,1
-Sedgwick,312,U.S. House,4,,Write-ins,2
-Sedgwick,313,U.S. House,4,,Write-ins,2
-Sedgwick,314,U.S. House,4,,Write-ins,2
-Sedgwick,315,U.S. House,4,,Write-ins,1
-Sedgwick,316,U.S. House,4,,Write-ins,1
-Sedgwick,319,U.S. House,4,,Write-ins,3
-Sedgwick,320,U.S. House,4,,Write-ins,3
-Sedgwick,324,U.S. House,4,,Write-ins,2
-Sedgwick,401,U.S. House,4,,Write-ins,1
-Sedgwick,402,U.S. House,4,,Write-ins,3
-Sedgwick,406,U.S. House,4,,Write-ins,1
-Sedgwick,408,U.S. House,4,,Write-ins,1
-Sedgwick,409,U.S. House,4,,Write-ins,1
-Sedgwick,410,U.S. House,4,,Write-ins,3
-Sedgwick,412,U.S. House,4,,Write-ins,11
-Sedgwick,413,U.S. House,4,,Write-ins,5
-Sedgwick,414,U.S. House,4,,Write-ins,1
-Sedgwick,416,U.S. House,4,,Write-ins,1
-Sedgwick,417,U.S. House,4,,Write-ins,2
-Sedgwick,418,U.S. House,4,,Write-ins,2
-Sedgwick,419,U.S. House,4,,Write-ins,2
-Sedgwick,420,U.S. House,4,,Write-ins,2
-Sedgwick,423,U.S. House,4,,Write-ins,2
-Sedgwick,425,U.S. House,4,,Write-ins,6
-Sedgwick,429,U.S. House,4,,Write-ins,2
-Sedgwick,433,U.S. House,4,,Write-ins,1
-Sedgwick,437,U.S. House,4,,Write-ins,2
-Sedgwick,503,U.S. House,4,,Write-ins,1
-Sedgwick,504,U.S. House,4,,Write-ins,3
-Sedgwick,506,U.S. House,4,,Write-ins,1
-Sedgwick,507,U.S. House,4,,Write-ins,6
-Sedgwick,508,U.S. House,4,,Write-ins,2
-Sedgwick,509,U.S. House,4,,Write-ins,2
-Sedgwick,512,U.S. House,4,,Write-ins,2
-Sedgwick,513,U.S. House,4,,Write-ins,4
-Sedgwick,514,U.S. House,4,,Write-ins,3
-Sedgwick,515,U.S. House,4,,Write-ins,4
-Sedgwick,516,U.S. House,4,,Write-ins,1
-Sedgwick,517,U.S. House,4,,Write-ins,5
-Sedgwick,518,U.S. House,4,,Write-ins,3
-Sedgwick,519,U.S. House,4,,Write-ins,2
-Sedgwick,522,U.S. House,4,,Write-ins,2
-Sedgwick,523,U.S. House,4,,Write-ins,2
-Sedgwick,524,U.S. House,4,,Write-ins,1
-Sedgwick,525,U.S. House,4,,Write-ins,2
-Sedgwick,526,U.S. House,4,,Write-ins,6
-Sedgwick,530,U.S. House,4,,Write-ins,1
-Sedgwick,531,U.S. House,4,,Write-ins,4
-Sedgwick,539,U.S. House,4,,Write-ins,1
-Sedgwick,601,U.S. House,4,,Write-ins,1
-Sedgwick,602,U.S. House,4,,Write-ins,2
-Sedgwick,603,U.S. House,4,,Write-ins,3
-Sedgwick,604,U.S. House,4,,Write-ins,6
-Sedgwick,605,U.S. House,4,,Write-ins,1
-Sedgwick,606,U.S. House,4,,Write-ins,2
-Sedgwick,607,U.S. House,4,,Write-ins,4
-Sedgwick,608,U.S. House,4,,Write-ins,2
-Sedgwick,609,U.S. House,4,,Write-ins,2
-Sedgwick,610,U.S. House,4,,Write-ins,2
-Sedgwick,611,U.S. House,4,,Write-ins,1
-Sedgwick,612,U.S. House,4,,Write-ins,1
-Sedgwick,613,U.S. House,4,,Write-ins,2
-Sedgwick,614,U.S. House,4,,Write-ins,1
-Sedgwick,615,U.S. House,4,,Write-ins,4
-Sedgwick,616,U.S. House,4,,Write-ins,1
-Sedgwick,617,U.S. House,4,,Write-ins,1
-Sedgwick,619,U.S. House,4,,Write-ins,3
-Sedgwick,622,U.S. House,4,,Write-ins,2
-Sedgwick,623,U.S. House,4,,Write-ins,3
-Sedgwick,627,U.S. House,4,,Write-ins,1
-Sedgwick,101,Governor,,,Write-ins,1
-Sedgwick,102,Governor,,,Write-ins,1
-Sedgwick,105,Governor,,,Write-ins,1
-Sedgwick,107,Governor,,,Write-ins,1
-Sedgwick,108,Governor,,,Write-ins,1
-Sedgwick,109,Governor,,,Write-ins,1
-Sedgwick,112,Governor,,,Write-ins,1
-Sedgwick,114,Governor,,,Write-ins,3
-Sedgwick,116,Governor,,,Write-ins,2
-Sedgwick,119,Governor,,,Write-ins,2
-Sedgwick,121,Governor,,,Write-ins,2
-Sedgwick,123,Governor,,,Write-ins,1
-Sedgwick,128,Governor,,,Write-ins,2
-Sedgwick,129,Governor,,,Write-ins,1
-Sedgwick,214,Governor,,,Write-ins,1
-Sedgwick,215,Governor,,,Write-ins,1
-Sedgwick,218,Governor,,,Write-ins,2
-Sedgwick,221,Governor,,,Write-ins,1
-Sedgwick,222,Governor,,,Write-ins,1
-Sedgwick,223,Governor,,,Write-ins,1
-Sedgwick,224,Governor,,,Write-ins,1
-Sedgwick,225,Governor,,,Write-ins,3
-Sedgwick,226,Governor,,,Write-ins,1
-Sedgwick,228,Governor,,,Write-ins,2
-Sedgwick,241,Governor,,,Write-ins,1
-Sedgwick,301,Governor,,,Write-ins,3
-Sedgwick,302,Governor,,,Write-ins,1
-Sedgwick,303,Governor,,,Write-ins,2
-Sedgwick,305,Governor,,,Write-ins,2
-Sedgwick,306,Governor,,,Write-ins,1
-Sedgwick,307,Governor,,,Write-ins,1
-Sedgwick,308,Governor,,,Write-ins,1
-Sedgwick,312,Governor,,,Write-ins,1
-Sedgwick,313,Governor,,,Write-ins,1
-Sedgwick,314,Governor,,,Write-ins,1
-Sedgwick,315,Governor,,,Write-ins,1
-Sedgwick,325,Governor,,,Write-ins,1
-Sedgwick,401,Governor,,,Write-ins,1
-Sedgwick,404,Governor,,,Write-ins,1
-Sedgwick,412,Governor,,,Write-ins,4
-Sedgwick,413,Governor,,,Write-ins,2
-Sedgwick,416,Governor,,,Write-ins,1
-Sedgwick,417,Governor,,,Write-ins,2
-Sedgwick,420,Governor,,,Write-ins,2
-Sedgwick,423,Governor,,,Write-ins,1
-Sedgwick,437,Governor,,,Write-ins,1
-Sedgwick,504,Governor,,,Write-ins,2
-Sedgwick,506,Governor,,,Write-ins,1
-Sedgwick,507,Governor,,,Write-ins,1
-Sedgwick,508,Governor,,,Write-ins,1
-Sedgwick,509,Governor,,,Write-ins,2
-Sedgwick,510,Governor,,,Write-ins,2
-Sedgwick,513,Governor,,,Write-ins,2
-Sedgwick,514,Governor,,,Write-ins,3
-Sedgwick,515,Governor,,,Write-ins,2
-Sedgwick,517,Governor,,,Write-ins,1
-Sedgwick,523,Governor,,,Write-ins,1
-Sedgwick,524,Governor,,,Write-ins,3
-Sedgwick,525,Governor,,,Write-ins,1
-Sedgwick,531,Governor,,,Write-ins,3
-Sedgwick,606,Governor,,,Write-ins,1
-Sedgwick,607,Governor,,,Write-ins,1
-Sedgwick,610,Governor,,,Write-ins,4
-Sedgwick,611,Governor,,,Write-ins,1
-Sedgwick,612,Governor,,,Write-ins,1
-Sedgwick,614,Governor,,,Write-ins,1
-Sedgwick,615,Governor,,,Write-ins,1
-Sedgwick,619,Governor,,,Write-ins,1
-Sedgwick,622,Governor,,,Write-ins,1
-Sedgwick,623,Governor,,,Write-ins,2
-Sedgwick,101,Secretary of State,,,Write-ins,1
-Sedgwick,105,Secretary of State,,,Write-ins,1
-Sedgwick,107,Secretary of State,,,Write-ins,2
-Sedgwick,108,Secretary of State,,,Write-ins,2
-Sedgwick,109,Secretary of State,,,Write-ins,1
-Sedgwick,110,Secretary of State,,,Write-ins,1
-Sedgwick,112,Secretary of State,,,Write-ins,1
-Sedgwick,114,Secretary of State,,,Write-ins,3
-Sedgwick,118,Secretary of State,,,Write-ins,1
-Sedgwick,119,Secretary of State,,,Write-ins,3
-Sedgwick,120,Secretary of State,,,Write-ins,2
-Sedgwick,121,Secretary of State,,,Write-ins,1
-Sedgwick,122,Secretary of State,,,Write-ins,1
-Sedgwick,123,Secretary of State,,,Write-ins,1
-Sedgwick,205,Secretary of State,,,Write-ins,1
-Sedgwick,207,Secretary of State,,,Write-ins,1
-Sedgwick,211,Secretary of State,,,Write-ins,1
-Sedgwick,212,Secretary of State,,,Write-ins,1
-Sedgwick,213,Secretary of State,,,Write-ins,1
-Sedgwick,215,Secretary of State,,,Write-ins,2
-Sedgwick,217,Secretary of State,,,Write-ins,1
-Sedgwick,221,Secretary of State,,,Write-ins,1
-Sedgwick,223,Secretary of State,,,Write-ins,2
-Sedgwick,224,Secretary of State,,,Write-ins,1
-Sedgwick,227,Secretary of State,,,Write-ins,1
-Sedgwick,228,Secretary of State,,,Write-ins,1
-Sedgwick,235,Secretary of State,,,Write-ins,1
-Sedgwick,301,Secretary of State,,,Write-ins,2
-Sedgwick,302,Secretary of State,,,Write-ins,1
-Sedgwick,305,Secretary of State,,,Write-ins,2
-Sedgwick,306,Secretary of State,,,Write-ins,1
-Sedgwick,308,Secretary of State,,,Write-ins,1
-Sedgwick,310,Secretary of State,,,Write-ins,1
-Sedgwick,311,Secretary of State,,,Write-ins,1
-Sedgwick,312,Secretary of State,,,Write-ins,1
-Sedgwick,313,Secretary of State,,,Write-ins,3
-Sedgwick,314,Secretary of State,,,Write-ins,1
-Sedgwick,315,Secretary of State,,,Write-ins,2
-Sedgwick,325,Secretary of State,,,Write-ins,2
-Sedgwick,402,Secretary of State,,,Write-ins,1
-Sedgwick,405,Secretary of State,,,Write-ins,1
-Sedgwick,406,Secretary of State,,,Write-ins,2
-Sedgwick,413,Secretary of State,,,Write-ins,2
-Sedgwick,417,Secretary of State,,,Write-ins,1
-Sedgwick,419,Secretary of State,,,Write-ins,1
-Sedgwick,423,Secretary of State,,,Write-ins,1
-Sedgwick,429,Secretary of State,,,Write-ins,1
-Sedgwick,433,Secretary of State,,,Write-ins,1
-Sedgwick,504,Secretary of State,,,Write-ins,3
-Sedgwick,507,Secretary of State,,,Write-ins,1
-Sedgwick,510,Secretary of State,,,Write-ins,2
-Sedgwick,512,Secretary of State,,,Write-ins,1
-Sedgwick,513,Secretary of State,,,Write-ins,2
-Sedgwick,514,Secretary of State,,,Write-ins,1
-Sedgwick,515,Secretary of State,,,Write-ins,1
-Sedgwick,523,Secretary of State,,,Write-ins,1
-Sedgwick,525,Secretary of State,,,Write-ins,1
-Sedgwick,526,Secretary of State,,,Write-ins,2
-Sedgwick,531,Secretary of State,,,Write-ins,1
-Sedgwick,601,Secretary of State,,,Write-ins,1
-Sedgwick,602,Secretary of State,,,Write-ins,3
-Sedgwick,604,Secretary of State,,,Write-ins,2
-Sedgwick,606,Secretary of State,,,Write-ins,1
-Sedgwick,607,Secretary of State,,,Write-ins,3
-Sedgwick,609,Secretary of State,,,Write-ins,3
-Sedgwick,610,Secretary of State,,,Write-ins,1
-Sedgwick,612,Secretary of State,,,Write-ins,1
-Sedgwick,614,Secretary of State,,,Write-ins,1
-Sedgwick,615,Secretary of State,,,Write-ins,2
-Sedgwick,618,Secretary of State,,,Write-ins,1
-Sedgwick,622,Secretary of State,,,Write-ins,1
-Sedgwick,623,Secretary of State,,,Write-ins,1
-Sedgwick,101,Attorney General,,,Write-ins,1
-Sedgwick,102,Attorney General,,,Write-ins,1
-Sedgwick,105,Attorney General,,,Write-ins,1
-Sedgwick,106,Attorney General,,,Write-ins,1
-Sedgwick,107,Attorney General,,,Write-ins,4
-Sedgwick,108,Attorney General,,,Write-ins,3
-Sedgwick,110,Attorney General,,,Write-ins,1
-Sedgwick,114,Attorney General,,,Write-ins,3
-Sedgwick,118,Attorney General,,,Write-ins,1
-Sedgwick,119,Attorney General,,,Write-ins,1
-Sedgwick,120,Attorney General,,,Write-ins,2
-Sedgwick,121,Attorney General,,,Write-ins,1
-Sedgwick,123,Attorney General,,,Write-ins,1
-Sedgwick,205,Attorney General,,,Write-ins,2
-Sedgwick,209,Attorney General,,,Write-ins,2
-Sedgwick,211,Attorney General,,,Write-ins,1
-Sedgwick,212,Attorney General,,,Write-ins,2
-Sedgwick,215,Attorney General,,,Write-ins,1
-Sedgwick,217,Attorney General,,,Write-ins,1
-Sedgwick,218,Attorney General,,,Write-ins,1
-Sedgwick,223,Attorney General,,,Write-ins,2
-Sedgwick,224,Attorney General,,,Write-ins,2
-Sedgwick,227,Attorney General,,,Write-ins,1
-Sedgwick,301,Attorney General,,,Write-ins,4
-Sedgwick,302,Attorney General,,,Write-ins,1
-Sedgwick,305,Attorney General,,,Write-ins,3
-Sedgwick,308,Attorney General,,,Write-ins,1
-Sedgwick,309,Attorney General,,,Write-ins,1
-Sedgwick,310,Attorney General,,,Write-ins,1
-Sedgwick,311,Attorney General,,,Write-ins,1
-Sedgwick,312,Attorney General,,,Write-ins,1
-Sedgwick,313,Attorney General,,,Write-ins,2
-Sedgwick,314,Attorney General,,,Write-ins,2
-Sedgwick,315,Attorney General,,,Write-ins,2
-Sedgwick,325,Attorney General,,,Write-ins,1
-Sedgwick,401,Attorney General,,,Write-ins,3
-Sedgwick,402,Attorney General,,,Write-ins,1
-Sedgwick,405,Attorney General,,,Write-ins,2
-Sedgwick,410,Attorney General,,,Write-ins,1
-Sedgwick,413,Attorney General,,,Write-ins,4
-Sedgwick,416,Attorney General,,,Write-ins,1
-Sedgwick,417,Attorney General,,,Write-ins,1
-Sedgwick,423,Attorney General,,,Write-ins,1
-Sedgwick,425,Attorney General,,,Write-ins,1
-Sedgwick,429,Attorney General,,,Write-ins,1
-Sedgwick,433,Attorney General,,,Write-ins,1
-Sedgwick,437,Attorney General,,,Write-ins,1
-Sedgwick,503,Attorney General,,,Write-ins,1
-Sedgwick,504,Attorney General,,,Write-ins,3
-Sedgwick,507,Attorney General,,,Write-ins,1
-Sedgwick,513,Attorney General,,,Write-ins,2
-Sedgwick,514,Attorney General,,,Write-ins,1
-Sedgwick,515,Attorney General,,,Write-ins,2
-Sedgwick,518,Attorney General,,,Write-ins,1
-Sedgwick,522,Attorney General,,,Write-ins,1
-Sedgwick,523,Attorney General,,,Write-ins,1
-Sedgwick,524,Attorney General,,,Write-ins,3
-Sedgwick,525,Attorney General,,,Write-ins,3
-Sedgwick,526,Attorney General,,,Write-ins,2
-Sedgwick,530,Attorney General,,,Write-ins,1
-Sedgwick,531,Attorney General,,,Write-ins,2
-Sedgwick,534,Attorney General,,,Write-ins,1
-Sedgwick,601,Attorney General,,,Write-ins,1
-Sedgwick,602,Attorney General,,,Write-ins,2
-Sedgwick,604,Attorney General,,,Write-ins,1
-Sedgwick,606,Attorney General,,,Write-ins,1
-Sedgwick,607,Attorney General,,,Write-ins,2
-Sedgwick,609,Attorney General,,,Write-ins,3
-Sedgwick,611,Attorney General,,,Write-ins,1
-Sedgwick,612,Attorney General,,,Write-ins,1
-Sedgwick,614,Attorney General,,,Write-ins,1
-Sedgwick,617,Attorney General,,,Write-ins,1
-Sedgwick,618,Attorney General,,,Write-ins,1
-Sedgwick,619,Attorney General,,,Write-ins,1
-Sedgwick,622,Attorney General,,,Write-ins,1
-Sedgwick,623,Attorney General,,,Write-ins,2
-Sedgwick,101,State Treasurer,,,Write-ins,2
-Sedgwick,102,State Treasurer,,,Write-ins,2
-Sedgwick,105,State Treasurer,,,Write-ins,2
-Sedgwick,106,State Treasurer,,,Write-ins,2
-Sedgwick,107,State Treasurer,,,Write-ins,3
-Sedgwick,108,State Treasurer,,,Write-ins,1
-Sedgwick,110,State Treasurer,,,Write-ins,1
-Sedgwick,112,State Treasurer,,,Write-ins,2
-Sedgwick,114,State Treasurer,,,Write-ins,2
-Sedgwick,116,State Treasurer,,,Write-ins,1
-Sedgwick,117,State Treasurer,,,Write-ins,1
-Sedgwick,118,State Treasurer,,,Write-ins,2
-Sedgwick,120,State Treasurer,,,Write-ins,2
-Sedgwick,121,State Treasurer,,,Write-ins,1
-Sedgwick,123,State Treasurer,,,Write-ins,1
-Sedgwick,207,State Treasurer,,,Write-ins,1
-Sedgwick,213,State Treasurer,,,Write-ins,1
-Sedgwick,215,State Treasurer,,,Write-ins,2
-Sedgwick,223,State Treasurer,,,Write-ins,2
-Sedgwick,224,State Treasurer,,,Write-ins,2
-Sedgwick,235,State Treasurer,,,Write-ins,1
-Sedgwick,301,State Treasurer,,,Write-ins,2
-Sedgwick,302,State Treasurer,,,Write-ins,1
-Sedgwick,305,State Treasurer,,,Write-ins,1
-Sedgwick,308,State Treasurer,,,Write-ins,3
-Sedgwick,311,State Treasurer,,,Write-ins,1
-Sedgwick,313,State Treasurer,,,Write-ins,1
-Sedgwick,315,State Treasurer,,,Write-ins,1
-Sedgwick,325,State Treasurer,,,Write-ins,1
-Sedgwick,402,State Treasurer,,,Write-ins,1
-Sedgwick,404,State Treasurer,,,Write-ins,2
-Sedgwick,406,State Treasurer,,,Write-ins,2
-Sedgwick,410,State Treasurer,,,Write-ins,1
-Sedgwick,413,State Treasurer,,,Write-ins,3
-Sedgwick,416,State Treasurer,,,Write-ins,1
-Sedgwick,417,State Treasurer,,,Write-ins,1
-Sedgwick,419,State Treasurer,,,Write-ins,1
-Sedgwick,423,State Treasurer,,,Write-ins,1
-Sedgwick,425,State Treasurer,,,Write-ins,4
-Sedgwick,429,State Treasurer,,,Write-ins,1
-Sedgwick,433,State Treasurer,,,Write-ins,1
-Sedgwick,504,State Treasurer,,,Write-ins,2
-Sedgwick,507,State Treasurer,,,Write-ins,1
-Sedgwick,508,State Treasurer,,,Write-ins,1
-Sedgwick,509,State Treasurer,,,Write-ins,1
-Sedgwick,512,State Treasurer,,,Write-ins,2
-Sedgwick,513,State Treasurer,,,Write-ins,1
-Sedgwick,514,State Treasurer,,,Write-ins,1
-Sedgwick,515,State Treasurer,,,Write-ins,1
-Sedgwick,518,State Treasurer,,,Write-ins,1
-Sedgwick,523,State Treasurer,,,Write-ins,1
-Sedgwick,526,State Treasurer,,,Write-ins,3
-Sedgwick,527,State Treasurer,,,Write-ins,2
-Sedgwick,531,State Treasurer,,,Write-ins,1
-Sedgwick,604,State Treasurer,,,Write-ins,1
-Sedgwick,606,State Treasurer,,,Write-ins,2
-Sedgwick,607,State Treasurer,,,Write-ins,1
-Sedgwick,609,State Treasurer,,,Write-ins,2
-Sedgwick,613,State Treasurer,,,Write-ins,1
-Sedgwick,614,State Treasurer,,,Write-ins,1
-Sedgwick,619,State Treasurer,,,Write-ins,1
-Sedgwick,621,State Treasurer,,,Write-ins,1
-Sedgwick,622,State Treasurer,,,Write-ins,1
-Sedgwick,623,State Treasurer,,,Write-ins,2
-Sedgwick,101,Insurance Commissioner,,,Write-ins,2
-Sedgwick,105,Insurance Commissioner,,,Write-ins,1
-Sedgwick,107,Insurance Commissioner,,,Write-ins,4
-Sedgwick,108,Insurance Commissioner,,,Write-ins,1
-Sedgwick,109,Insurance Commissioner,,,Write-ins,1
-Sedgwick,110,Insurance Commissioner,,,Write-ins,1
-Sedgwick,112,Insurance Commissioner,,,Write-ins,1
-Sedgwick,114,Insurance Commissioner,,,Write-ins,3
-Sedgwick,118,Insurance Commissioner,,,Write-ins,1
-Sedgwick,120,Insurance Commissioner,,,Write-ins,2
-Sedgwick,121,Insurance Commissioner,,,Write-ins,1
-Sedgwick,123,Insurance Commissioner,,,Write-ins,2
-Sedgwick,211,Insurance Commissioner,,,Write-ins,1
-Sedgwick,214,Insurance Commissioner,,,Write-ins,1
-Sedgwick,215,Insurance Commissioner,,,Write-ins,1
-Sedgwick,217,Insurance Commissioner,,,Write-ins,2
-Sedgwick,218,Insurance Commissioner,,,Write-ins,1
-Sedgwick,221,Insurance Commissioner,,,Write-ins,3
-Sedgwick,224,Insurance Commissioner,,,Write-ins,2
-Sedgwick,226,Insurance Commissioner,,,Write-ins,1
-Sedgwick,235,Insurance Commissioner,,,Write-ins,1
-Sedgwick,301,Insurance Commissioner,,,Write-ins,4
-Sedgwick,302,Insurance Commissioner,,,Write-ins,2
-Sedgwick,303,Insurance Commissioner,,,Write-ins,2
-Sedgwick,304,Insurance Commissioner,,,Write-ins,1
-Sedgwick,305,Insurance Commissioner,,,Write-ins,1
-Sedgwick,308,Insurance Commissioner,,,Write-ins,2
-Sedgwick,310,Insurance Commissioner,,,Write-ins,1
-Sedgwick,311,Insurance Commissioner,,,Write-ins,1
-Sedgwick,313,Insurance Commissioner,,,Write-ins,2
-Sedgwick,314,Insurance Commissioner,,,Write-ins,2
-Sedgwick,315,Insurance Commissioner,,,Write-ins,1
-Sedgwick,325,Insurance Commissioner,,,Write-ins,1
-Sedgwick,402,Insurance Commissioner,,,Write-ins,1
-Sedgwick,404,Insurance Commissioner,,,Write-ins,1
-Sedgwick,406,Insurance Commissioner,,,Write-ins,1
-Sedgwick,412,Insurance Commissioner,,,Write-ins,1
-Sedgwick,413,Insurance Commissioner,,,Write-ins,5
-Sedgwick,417,Insurance Commissioner,,,Write-ins,3
-Sedgwick,419,Insurance Commissioner,,,Write-ins,1
-Sedgwick,423,Insurance Commissioner,,,Write-ins,1
-Sedgwick,425,Insurance Commissioner,,,Write-ins,3
-Sedgwick,429,Insurance Commissioner,,,Write-ins,1
-Sedgwick,433,Insurance Commissioner,,,Write-ins,1
-Sedgwick,504,Insurance Commissioner,,,Write-ins,1
-Sedgwick,507,Insurance Commissioner,,,Write-ins,2
-Sedgwick,513,Insurance Commissioner,,,Write-ins,2
-Sedgwick,515,Insurance Commissioner,,,Write-ins,1
-Sedgwick,518,Insurance Commissioner,,,Write-ins,2
-Sedgwick,519,Insurance Commissioner,,,Write-ins,1
-Sedgwick,523,Insurance Commissioner,,,Write-ins,2
-Sedgwick,524,Insurance Commissioner,,,Write-ins,2
-Sedgwick,526,Insurance Commissioner,,,Write-ins,2
-Sedgwick,527,Insurance Commissioner,,,Write-ins,1
-Sedgwick,531,Insurance Commissioner,,,Write-ins,1
-Sedgwick,602,Insurance Commissioner,,,Write-ins,1
-Sedgwick,604,Insurance Commissioner,,,Write-ins,1
-Sedgwick,607,Insurance Commissioner,,,Write-ins,3
-Sedgwick,609,Insurance Commissioner,,,Write-ins,2
-Sedgwick,610,Insurance Commissioner,,,Write-ins,1
-Sedgwick,612,Insurance Commissioner,,,Write-ins,1
-Sedgwick,613,Insurance Commissioner,,,Write-ins,1
-Sedgwick,614,Insurance Commissioner,,,Write-ins,1
-Sedgwick,615,Insurance Commissioner,,,Write-ins,1
-Sedgwick,619,Insurance Commissioner,,,Write-ins,1
-Sedgwick,622,Insurance Commissioner,,,Write-ins,2
-Sedgwick,623,Insurance Commissioner,,,Write-ins,1
-Sedgwick,101,State House,86,,Write-ins,4
-Sedgwick,103,State House,103,,Write-ins,3
-Sedgwick,104,State House,103,,Write-ins,1
-Sedgwick,105,State House,86,,Write-ins,2
-Sedgwick,107,State House,84,,Write-ins,4
-Sedgwick,108,State House,84,,Write-ins,1
-Sedgwick,109,State House,83,,Write-ins,1
-Sedgwick,112,State House,89,,Write-ins,2
-Sedgwick,113,State House,84,,Write-ins,2
-Sedgwick,114,State House,84,,Write-ins,2
-Sedgwick,116,State House,84,,Write-ins,2
-Sedgwick,117,State House,89,,Write-ins,1
-Sedgwick,119,State House,89,,Write-ins,1
-Sedgwick,120,State House,89,,Write-ins,2
-Sedgwick,121,State House,87,,Write-ins,1
-Sedgwick,123,State House,89,,Write-ins,3
-Sedgwick,129,State House,103,,Write-ins,6
-Sedgwick,205,State House,83,,Write-ins,1
-Sedgwick,207,State House,88,,Write-ins,1
-Sedgwick,210,State House,88,,Write-ins,1
-Sedgwick,211,State House,87,,Write-ins,1
-Sedgwick,215,State House,87,,Write-ins,1
-Sedgwick,222,State House,85,,Write-ins,1
-Sedgwick,223,State House,87,,Write-ins,1
-Sedgwick,224,State House,87,,Write-ins,3
-Sedgwick,225,State House,88,,Write-ins,1
-Sedgwick,226,State House,99,,Write-ins,15
-Sedgwick,227,State House,99,,Write-ins,7
-Sedgwick,228,State House,99,,Write-ins,9
-Sedgwick,233,State House,81,,Write-ins,1
-Sedgwick,241,State House,99,,Write-ins,7
-Sedgwick,301,State House,86,,Write-ins,3
-Sedgwick,302,State House,86,,Write-ins,4
-Sedgwick,305,State House,86,,Write-ins,1
-Sedgwick,306,State House,83,,Write-ins,2
-Sedgwick,308,State House,83,,Write-ins,2
-Sedgwick,309,State House,88,,Write-ins,1
-Sedgwick,311,State House,98,,Write-ins,1
-Sedgwick,312,State House,98,,Write-ins,3
-Sedgwick,313,State House,96,,Write-ins,3
-Sedgwick,314,State House,96,,Write-ins,1
-Sedgwick,315,State House,98,,Write-ins,4
-Sedgwick,316,State House,98,,Write-ins,1
-Sedgwick,320,State House,103,,Write-ins,2
-Sedgwick,324,State House,103,,Write-ins,6
-Sedgwick,401,State House,97,,Write-ins,6
-Sedgwick,402,State House,97,,Write-ins,10
-Sedgwick,403,State House,94,,Write-ins,6
-Sedgwick,404,State House,95,,Write-ins,1
-Sedgwick,405,State House,95,,Write-ins,1
-Sedgwick,406,State House,95,,Write-ins,2
-Sedgwick,407,State House,86,,Write-ins,1
-Sedgwick,409,State House,97,,Write-ins,6
-Sedgwick,410,State House,101,,Write-ins,15
-Sedgwick,412,State House,97,,Write-ins,12
-Sedgwick,413,State House,94,,Write-ins,9
-Sedgwick,416,State House,97,,Write-ins,4
-Sedgwick,417,State House,97,,Write-ins,10
-Sedgwick,418,State House,97,,Write-ins,13
-Sedgwick,424,State House,97,,Write-ins,5
-Sedgwick,425,State House,98,,Write-ins,2
-Sedgwick,429,State House,97,,Write-ins,6
-Sedgwick,433,State House,97,,Write-ins,3
-Sedgwick,437,State House,97,,Write-ins,3
-Sedgwick,503,State House,105,,Write-ins,1
-Sedgwick,504,State House,105,,Write-ins,2
-Sedgwick,507,State House,105,,Write-ins,1
-Sedgwick,509,State House,100,,Write-ins,2
-Sedgwick,512,State House,91,,Write-ins,14
-Sedgwick,513,State House,100,,Write-ins,1
-Sedgwick,514,State House,100,,Write-ins,4
-Sedgwick,515,State House,100,,Write-ins,1
-Sedgwick,516,State House,100,,Write-ins,1
-Sedgwick,517,State House,100,,Write-ins,1
-Sedgwick,518,State House,100,,Write-ins,1
-Sedgwick,522,State House,94,,Write-ins,5
-Sedgwick,523,State House,94,,Write-ins,10
-Sedgwick,524,State House,94,,Write-ins,12
-Sedgwick,525,State House,94,,Write-ins,14
-Sedgwick,526,State House,94,,Write-ins,12
-Sedgwick,527,State House,90,,Write-ins,4
-Sedgwick,530,State House,94,,Write-ins,6
-Sedgwick,531,State House,101,,Write-ins,10
-Sedgwick,538,State House,101,,Write-ins,3
-Sedgwick,539,State House,94,,Write-ins,5
-Sedgwick,601,State House,103,,Write-ins,18
-Sedgwick,602,State House,95,,Write-ins,1
-Sedgwick,604,State House,105,,Write-ins,2
-Sedgwick,607,State House,92,,Write-ins,2
-Sedgwick,609,State House,92,,Write-ins,1
-Sedgwick,610,State House,92,,Write-ins,3
-Sedgwick,612,State House,105,,Write-ins,2
-Sedgwick,613,State House,92,,Write-ins,1
-Sedgwick,614,State House,95,,Write-ins,1
-Sedgwick,615,State House,103,,Write-ins,7
-Sedgwick,617,State House,103,,Write-ins,7
-Sedgwick,618,State House,91,,Write-ins,15
-Sedgwick,619,State House,92,,Write-ins,1
-Sedgwick,622,State House,91,,Write-ins,5
-Sedgwick,623,State House,91,,Write-ins,7
-Sedgwick,627,State House,103,,Write-ins,1
-Sedgwick,AF,Voters,,,Registration,1019
-Sedgwick,AT02,Voters,,,Registration,242
-Sedgwick,AT03,Voters,,,Registration,745
-Sedgwick,AT04,Voters,,,Registration,1
-Sedgwick,AT05,Voters,,,Registration,300
-Sedgwick,AT06,Voters,,,Registration,62
-Sedgwick,AT08,Voters,,,Registration,83
-Sedgwick,BA01,Voters,,,Registration,1754
-Sedgwick,BA02,Voters,,,Registration,1669
-Sedgwick,BA03,Voters,,,Registration,1267
-Sedgwick,DB11,Voters,,,Registration,1809
-Sedgwick,DB12,Voters,,,Registration,1176
-Sedgwick,DB14,Voters,,,Registration,685
-Sedgwick,DB15,Voters,,,Registration,60
-Sedgwick,DB21,Voters,,,Registration,1110
-Sedgwick,DB22,Voters,,,Registration,1063
-Sedgwick,DB23,Voters,,,Registration,1141
-Sedgwick,DB24,Voters,,,Registration,248
-Sedgwick,DB25,Voters,,,Registration,122
-Sedgwick,DB31,Voters,,,Registration,404
-Sedgwick,DB32,Voters,,,Registration,1221
-Sedgwick,DB36,Voters,,,Registration,1584
-Sedgwick,DB37,Voters,,,Registration,299
-Sedgwick,DB41,Voters,,,Registration,827
-Sedgwick,DB42,Voters,,,Registration,2538
-Sedgwick,DL02,Voters,,,Registration,0
-Sedgwick,DL03,Voters,,,Registration,2
-Sedgwick,DL04,Voters,,,Registration,2
-Sedgwick,EA,Voters,,,Registration,670
-Sedgwick,ER,Voters,,,Registration,53
-Sedgwick,GA,Voters,,,Registration,1214
-Sedgwick,GD,Voters,,,Registration,392
-Sedgwick,GN01,Voters,,,Registration,923
-Sedgwick,GO,Voters,,,Registration,2574
-Sedgwick,GR,Voters,,,Registration,630
-Sedgwick,GY01,Voters,,,Registration,2222
-Sedgwick,GY02,Voters,,,Registration,202
-Sedgwick,GY03,Voters,,,Registration,71
-Sedgwick,HA11,Voters,,,Registration,1161
-Sedgwick,HA21,Voters,,,Registration,1513
-Sedgwick,HA31,Voters,,,Registration,1607
-Sedgwick,HA41,Voters,,,Registration,1217
-Sedgwick,HA42,Voters,,,Registration,335
-Sedgwick,IL01,Voters,,,Registration,1181
-Sedgwick,KE01,Voters,,,Registration,16
-Sedgwick,KE03,Voters,,,Registration,1123
-Sedgwick,KE04,Voters,,,Registration,64
-Sedgwick,KE07,Voters,,,Registration,25
-Sedgwick,KE08,Voters,,,Registration,19
-Sedgwick,LI,Voters,,,Registration,348
-Sedgwick,MI01,Voters,,,Registration,1503
-Sedgwick,MI02,Voters,,,Registration,586
-Sedgwick,MI03,Voters,,,Registration,28
-Sedgwick,MI04,Voters,,,Registration,3
-Sedgwick,MI05,Voters,,,Registration,6
-Sedgwick,MI07,Voters,,,Registration,21
-Sedgwick,MI09,Voters,,,Registration,314
-Sedgwick,MI14,Voters,,,Registration,140
-Sedgwick,MO,Voters,,,Registration,1563
-Sedgwick,MV01,Voters,,,Registration,989
-Sedgwick,MV02,Voters,,,Registration,2254
-Sedgwick,NI,Voters,,,Registration,1618
-Sedgwick,NI01,Voters,,,Registration,327
-Sedgwick,OH01,Voters,,,Registration,897
-Sedgwick,PA01,Voters,,,Registration,381
-Sedgwick,PA02,Voters,,,Registration,230
-Sedgwick,PA05,Voters,,,Registration,2050
-Sedgwick,PA06,Voters,,,Registration,75
-Sedgwick,PA09,Voters,,,Registration,8
-Sedgwick,PC11,Voters,,,Registration,790
-Sedgwick,PC13,Voters,,,Registration,269
-Sedgwick,PC21,Voters,,,Registration,1165
-Sedgwick,PC31,Voters,,,Registration,1645
-Sedgwick,PC43,Voters,,,Registration,379
-Sedgwick,PY01,Voters,,,Registration,712
-Sedgwick,RI01,Voters,,,Registration,70
-Sedgwick,RI03,Voters,,,Registration,685
-Sedgwick,RI06,Voters,,,Registration,179
-Sedgwick,RI07,Voters,,,Registration,736
-Sedgwick,RI13,Voters,,,Registration,12
-Sedgwick,RO01,Voters,,,Registration,621
-Sedgwick,RO03,Voters,,,Registration,396
-Sedgwick,SA01,Voters,,,Registration,1508
-Sedgwick,SA02,Voters,,,Registration,1039
-Sedgwick,SH,Voters,,,Registration,1059
-Sedgwick,UN01,Voters,,,Registration,1394
-Sedgwick,UN02,Voters,,,Registration,100
-Sedgwick,VA,Voters,,,Registration,741
-Sedgwick,VC11,Voters,,,Registration,1093
-Sedgwick,VC21,Voters,,,Registration,1037
-Sedgwick,VC31,Voters,,,Registration,935
-Sedgwick,VC41,Voters,,,Registration,757
-Sedgwick,VC42,Voters,,,Registration,343
-Sedgwick,VI,Voters,,,Registration,304
-Sedgwick,WA01,Voters,,,Registration,93
-Sedgwick,WA02,Voters,,,Registration,359
-Sedgwick,WA03,Voters,,,Registration,18
-Sedgwick,WA12,Voters,,,Registration,3
-Sedgwick,AF,Voters,,,Cast,629
-Sedgwick,AT02,Voters,,,Cast,106
-Sedgwick,AT03,Voters,,,Cast,484
-Sedgwick,AT04,Voters,,,Cast,3
-Sedgwick,AT05,Voters,,,Cast,211
-Sedgwick,AT06,Voters,,,Cast,45
-Sedgwick,AT08,Voters,,,Cast,46
-Sedgwick,BA01,Voters,,,Cast,1126
-Sedgwick,BA02,Voters,,,Cast,998
-Sedgwick,BA03,Voters,,,Cast,719
-Sedgwick,DB11,Voters,,,Cast,979
-Sedgwick,DB12,Voters,,,Cast,528
-Sedgwick,DB14,Voters,,,Cast,369
-Sedgwick,DB15,Voters,,,Cast,29
-Sedgwick,DB21,Voters,,,Cast,535
-Sedgwick,DB22,Voters,,,Cast,576
-Sedgwick,DB23,Voters,,,Cast,714
-Sedgwick,DB24,Voters,,,Cast,131
-Sedgwick,DB25,Voters,,,Cast,52
-Sedgwick,DB31,Voters,,,Cast,215
-Sedgwick,DB32,Voters,,,Cast,668
-Sedgwick,DB36,Voters,,,Cast,885
-Sedgwick,DB37,Voters,,,Cast,129
-Sedgwick,DB41,Voters,,,Cast,404
-Sedgwick,DB42,Voters,,,Cast,1486
-Sedgwick,DL02,Voters,,,Cast,0
-Sedgwick,DL03,Voters,,,Cast,2
-Sedgwick,DL04,Voters,,,Cast,1
-Sedgwick,EA,Voters,,,Cast,379
-Sedgwick,ER,Voters,,,Cast,40
-Sedgwick,GA,Voters,,,Cast,785
-Sedgwick,GD,Voters,,,Cast,232
-Sedgwick,GN01,Voters,,,Cast,640
-Sedgwick,GO,Voters,,,Cast,1350
-Sedgwick,GR,Voters,,,Cast,386
-Sedgwick,GY01,Voters,,,Cast,1314
-Sedgwick,GY02,Voters,,,Cast,18
-Sedgwick,GY03,Voters,,,Cast,39
-Sedgwick,HA11,Voters,,,Cast,639
-Sedgwick,HA21,Voters,,,Cast,703
-Sedgwick,HA31,Voters,,,Cast,744
-Sedgwick,HA41,Voters,,,Cast,636
-Sedgwick,HA42,Voters,,,Cast,144
-Sedgwick,IL01,Voters,,,Cast,714
-Sedgwick,KE01,Voters,,,Cast,13
-Sedgwick,KE03,Voters,,,Cast,748
-Sedgwick,KE04,Voters,,,Cast,38
-Sedgwick,KE07,Voters,,,Cast,18
-Sedgwick,KE08,Voters,,,Cast,11
-Sedgwick,LI,Voters,,,Cast,253
-Sedgwick,MI01,Voters,,,Cast,1080
-Sedgwick,MI02,Voters,,,Cast,449
-Sedgwick,MI03,Voters,,,Cast,12
-Sedgwick,MI04,Voters,,,Cast,2
-Sedgwick,MI05,Voters,,,Cast,2
-Sedgwick,MI07,Voters,,,Cast,11
-Sedgwick,MI09,Voters,,,Cast,210
-Sedgwick,MI14,Voters,,,Cast,99
-Sedgwick,MO,Voters,,,Cast,918
-Sedgwick,MV01,Voters,,,Cast,556
-Sedgwick,MV02,Voters,,,Cast,1260
-Sedgwick,NI,Voters,,,Cast,900
-Sedgwick,NI01,Voters,,,Cast,190
-Sedgwick,OH01,Voters,,,Cast,544
-Sedgwick,PA01,Voters,,,Cast,211
-Sedgwick,PA02,Voters,,,Cast,119
-Sedgwick,PA05,Voters,,,Cast,1101
-Sedgwick,PA06,Voters,,,Cast,55
-Sedgwick,PA09,Voters,,,Cast,7
-Sedgwick,PC11,Voters,,,Cast,384
-Sedgwick,PC13,Voters,,,Cast,129
-Sedgwick,PC21,Voters,,,Cast,630
-Sedgwick,PC31,Voters,,,Cast,770
-Sedgwick,PC43,Voters,,,Cast,219
-Sedgwick,PY01,Voters,,,Cast,453
-Sedgwick,RI01,Voters,,,Cast,39
-Sedgwick,RI03,Voters,,,Cast,242
-Sedgwick,RI06,Voters,,,Cast,122
-Sedgwick,RI07,Voters,,,Cast,209
-Sedgwick,RI13,Voters,,,Cast,7
-Sedgwick,RO01,Voters,,,Cast,376
-Sedgwick,RO03,Voters,,,Cast,245
-Sedgwick,SA01,Voters,,,Cast,774
-Sedgwick,SA02,Voters,,,Cast,552
-Sedgwick,SH,Voters,,,Cast,592
-Sedgwick,UN01,Voters,,,Cast,835
-Sedgwick,UN02,Voters,,,Cast,59
-Sedgwick,VA,Voters,,,Cast,394
-Sedgwick,VC11,Voters,,,Cast,577
-Sedgwick,VC21,Voters,,,Cast,621
-Sedgwick,VC31,Voters,,,Cast,501
-Sedgwick,VC41,Voters,,,Cast,450
-Sedgwick,VC42,Voters,,,Cast,190
-Sedgwick,VI,Voters,,,Cast,191
-Sedgwick,WA01,Voters,,,Cast,53
-Sedgwick,WA02,Voters,,,Cast,214
-Sedgwick,WA03,Voters,,,Cast,12
-Sedgwick,WA12,Voters,,,Cast,2
-Sedgwick,AF,U.S. Senate,,R,Pat Roberts,420
-Sedgwick,AT02,U.S. Senate,,R,Pat Roberts,60
-Sedgwick,AT03,U.S. Senate,,R,Pat Roberts,341
-Sedgwick,AT04,U.S. Senate,,R,Pat Roberts,2
-Sedgwick,AT05,U.S. Senate,,R,Pat Roberts,147
-Sedgwick,AT06,U.S. Senate,,R,Pat Roberts,40
-Sedgwick,AT08,U.S. Senate,,R,Pat Roberts,30
-Sedgwick,BA01,U.S. Senate,,R,Pat Roberts,624
-Sedgwick,BA02,U.S. Senate,,R,Pat Roberts,524
-Sedgwick,BA03,U.S. Senate,,R,Pat Roberts,404
-Sedgwick,DB11,U.S. Senate,,R,Pat Roberts,572
-Sedgwick,DB12,U.S. Senate,,R,Pat Roberts,271
-Sedgwick,DB14,U.S. Senate,,R,Pat Roberts,216
-Sedgwick,DB15,U.S. Senate,,R,Pat Roberts,25
-Sedgwick,DB21,U.S. Senate,,R,Pat Roberts,286
-Sedgwick,DB22,U.S. Senate,,R,Pat Roberts,313
-Sedgwick,DB23,U.S. Senate,,R,Pat Roberts,413
-Sedgwick,DB24,U.S. Senate,,R,Pat Roberts,76
-Sedgwick,DB25,U.S. Senate,,R,Pat Roberts,22
-Sedgwick,DB31,U.S. Senate,,R,Pat Roberts,123
-Sedgwick,DB32,U.S. Senate,,R,Pat Roberts,352
-Sedgwick,DB36,U.S. Senate,,R,Pat Roberts,477
-Sedgwick,DB37,U.S. Senate,,R,Pat Roberts,63
-Sedgwick,DB41,U.S. Senate,,R,Pat Roberts,203
-Sedgwick,DB42,U.S. Senate,,R,Pat Roberts,901
-Sedgwick,DL02,U.S. Senate,,R,Pat Roberts,0
-Sedgwick,DL03,U.S. Senate,,R,Pat Roberts,2
-Sedgwick,DL04,U.S. Senate,,R,Pat Roberts,0
-Sedgwick,EA,U.S. Senate,,R,Pat Roberts,218
-Sedgwick,ER,U.S. Senate,,R,Pat Roberts,24
-Sedgwick,GA,U.S. Senate,,R,Pat Roberts,567
-Sedgwick,GD,U.S. Senate,,R,Pat Roberts,177
-Sedgwick,GN01,U.S. Senate,,R,Pat Roberts,431
-Sedgwick,GO,U.S. Senate,,R,Pat Roberts,842
-Sedgwick,GR,U.S. Senate,,R,Pat Roberts,255
-Sedgwick,GY01,U.S. Senate,,R,Pat Roberts,814
-Sedgwick,GY02,U.S. Senate,,R,Pat Roberts,10
-Sedgwick,GY03,U.S. Senate,,R,Pat Roberts,20
-Sedgwick,HA11,U.S. Senate,,R,Pat Roberts,336
-Sedgwick,HA21,U.S. Senate,,R,Pat Roberts,358
-Sedgwick,HA31,U.S. Senate,,R,Pat Roberts,371
-Sedgwick,HA41,U.S. Senate,,R,Pat Roberts,341
-Sedgwick,HA42,U.S. Senate,,R,Pat Roberts,93
-Sedgwick,IL01,U.S. Senate,,R,Pat Roberts,480
-Sedgwick,KE01,U.S. Senate,,R,Pat Roberts,12
-Sedgwick,KE03,U.S. Senate,,R,Pat Roberts,421
-Sedgwick,KE04,U.S. Senate,,R,Pat Roberts,17
-Sedgwick,KE07,U.S. Senate,,R,Pat Roberts,10
-Sedgwick,KE08,U.S. Senate,,R,Pat Roberts,9
-Sedgwick,LI,U.S. Senate,,R,Pat Roberts,167
-Sedgwick,MI01,U.S. Senate,,R,Pat Roberts,726
-Sedgwick,MI02,U.S. Senate,,R,Pat Roberts,255
-Sedgwick,MI03,U.S. Senate,,R,Pat Roberts,7
-Sedgwick,MI04,U.S. Senate,,R,Pat Roberts,1
-Sedgwick,MI05,U.S. Senate,,R,Pat Roberts,0
-Sedgwick,MI07,U.S. Senate,,R,Pat Roberts,5
-Sedgwick,MI09,U.S. Senate,,R,Pat Roberts,110
-Sedgwick,MI14,U.S. Senate,,R,Pat Roberts,62
-Sedgwick,MO,U.S. Senate,,R,Pat Roberts,539
-Sedgwick,MV01,U.S. Senate,,R,Pat Roberts,292
-Sedgwick,MV02,U.S. Senate,,R,Pat Roberts,671
-Sedgwick,NI,U.S. Senate,,R,Pat Roberts,536
-Sedgwick,NI01,U.S. Senate,,R,Pat Roberts,119
-Sedgwick,OH01,U.S. Senate,,R,Pat Roberts,347
-Sedgwick,PA01,U.S. Senate,,R,Pat Roberts,143
-Sedgwick,PA02,U.S. Senate,,R,Pat Roberts,71
-Sedgwick,PA05,U.S. Senate,,R,Pat Roberts,665
-Sedgwick,PA06,U.S. Senate,,R,Pat Roberts,31
-Sedgwick,PA09,U.S. Senate,,R,Pat Roberts,5
-Sedgwick,PC11,U.S. Senate,,R,Pat Roberts,195
-Sedgwick,PC13,U.S. Senate,,R,Pat Roberts,67
-Sedgwick,PC21,U.S. Senate,,R,Pat Roberts,344
-Sedgwick,PC31,U.S. Senate,,R,Pat Roberts,376
-Sedgwick,PC43,U.S. Senate,,R,Pat Roberts,116
-Sedgwick,PY01,U.S. Senate,,R,Pat Roberts,310
-Sedgwick,RI01,U.S. Senate,,R,Pat Roberts,20
-Sedgwick,RI03,U.S. Senate,,R,Pat Roberts,85
-Sedgwick,RI06,U.S. Senate,,R,Pat Roberts,67
-Sedgwick,RI07,U.S. Senate,,R,Pat Roberts,98
-Sedgwick,RI13,U.S. Senate,,R,Pat Roberts,4
-Sedgwick,RO01,U.S. Senate,,R,Pat Roberts,241
-Sedgwick,RO03,U.S. Senate,,R,Pat Roberts,146
-Sedgwick,SA01,U.S. Senate,,R,Pat Roberts,447
-Sedgwick,SA02,U.S. Senate,,R,Pat Roberts,322
-Sedgwick,SH,U.S. Senate,,R,Pat Roberts,410
-Sedgwick,UN01,U.S. Senate,,R,Pat Roberts,634
-Sedgwick,UN02,U.S. Senate,,R,Pat Roberts,43
-Sedgwick,VA,U.S. Senate,,R,Pat Roberts,238
-Sedgwick,VC11,U.S. Senate,,R,Pat Roberts,348
-Sedgwick,VC21,U.S. Senate,,R,Pat Roberts,363
-Sedgwick,VC31,U.S. Senate,,R,Pat Roberts,314
-Sedgwick,VC41,U.S. Senate,,R,Pat Roberts,243
-Sedgwick,VC42,U.S. Senate,,R,Pat Roberts,112
-Sedgwick,VI,U.S. Senate,,R,Pat Roberts,123
-Sedgwick,WA01,U.S. Senate,,R,Pat Roberts,37
-Sedgwick,WA02,U.S. Senate,,R,Pat Roberts,143
-Sedgwick,WA03,U.S. Senate,,R,Pat Roberts,6
-Sedgwick,WA12,U.S. Senate,,R,Pat Roberts,2
-Sedgwick,AF,U.S. Senate,,I,Greg Orman,193
-Sedgwick,AT02,U.S. Senate,,I,Greg Orman,42
-Sedgwick,AT03,U.S. Senate,,I,Greg Orman,127
-Sedgwick,AT04,U.S. Senate,,I,Greg Orman,1
-Sedgwick,AT05,U.S. Senate,,I,Greg Orman,54
-Sedgwick,AT06,U.S. Senate,,I,Greg Orman,5
-Sedgwick,AT08,U.S. Senate,,I,Greg Orman,13
-Sedgwick,BA01,U.S. Senate,,I,Greg Orman,436
-Sedgwick,BA02,U.S. Senate,,I,Greg Orman,433
-Sedgwick,BA03,U.S. Senate,,I,Greg Orman,274
-Sedgwick,DB11,U.S. Senate,,I,Greg Orman,355
-Sedgwick,DB12,U.S. Senate,,I,Greg Orman,232
-Sedgwick,DB14,U.S. Senate,,I,Greg Orman,133
-Sedgwick,DB15,U.S. Senate,,I,Greg Orman,4
-Sedgwick,DB21,U.S. Senate,,I,Greg Orman,207
-Sedgwick,DB22,U.S. Senate,,I,Greg Orman,243
-Sedgwick,DB23,U.S. Senate,,I,Greg Orman,270
-Sedgwick,DB24,U.S. Senate,,I,Greg Orman,52
-Sedgwick,DB25,U.S. Senate,,I,Greg Orman,26
-Sedgwick,DB31,U.S. Senate,,I,Greg Orman,78
-Sedgwick,DB32,U.S. Senate,,I,Greg Orman,284
-Sedgwick,DB36,U.S. Senate,,I,Greg Orman,365
-Sedgwick,DB37,U.S. Senate,,I,Greg Orman,57
-Sedgwick,DB41,U.S. Senate,,I,Greg Orman,163
-Sedgwick,DB42,U.S. Senate,,I,Greg Orman,523
-Sedgwick,DL02,U.S. Senate,,I,Greg Orman,0
-Sedgwick,DL03,U.S. Senate,,I,Greg Orman,0
-Sedgwick,DL04,U.S. Senate,,I,Greg Orman,1
-Sedgwick,EA,U.S. Senate,,I,Greg Orman,138
-Sedgwick,ER,U.S. Senate,,I,Greg Orman,13
-Sedgwick,GA,U.S. Senate,,I,Greg Orman,184
-Sedgwick,GD,U.S. Senate,,I,Greg Orman,47
-Sedgwick,GN01,U.S. Senate,,I,Greg Orman,188
-Sedgwick,GO,U.S. Senate,,I,Greg Orman,429
-Sedgwick,GR,U.S. Senate,,I,Greg Orman,94
-Sedgwick,GY01,U.S. Senate,,I,Greg Orman,434
-Sedgwick,GY02,U.S. Senate,,I,Greg Orman,8
-Sedgwick,GY03,U.S. Senate,,I,Greg Orman,15
-Sedgwick,HA11,U.S. Senate,,I,Greg Orman,258
-Sedgwick,HA21,U.S. Senate,,I,Greg Orman,278
-Sedgwick,HA31,U.S. Senate,,I,Greg Orman,299
-Sedgwick,HA41,U.S. Senate,,I,Greg Orman,247
-Sedgwick,HA42,U.S. Senate,,I,Greg Orman,44
-Sedgwick,IL01,U.S. Senate,,I,Greg Orman,194
-Sedgwick,KE01,U.S. Senate,,I,Greg Orman,1
-Sedgwick,KE03,U.S. Senate,,I,Greg Orman,290
-Sedgwick,KE04,U.S. Senate,,I,Greg Orman,17
-Sedgwick,KE07,U.S. Senate,,I,Greg Orman,7
-Sedgwick,KE08,U.S. Senate,,I,Greg Orman,1
-Sedgwick,LI,U.S. Senate,,I,Greg Orman,74
-Sedgwick,MI01,U.S. Senate,,I,Greg Orman,326
-Sedgwick,MI02,U.S. Senate,,I,Greg Orman,181
-Sedgwick,MI03,U.S. Senate,,I,Greg Orman,4
-Sedgwick,MI04,U.S. Senate,,I,Greg Orman,0
-Sedgwick,MI05,U.S. Senate,,I,Greg Orman,2
-Sedgwick,MI07,U.S. Senate,,I,Greg Orman,6
-Sedgwick,MI09,U.S. Senate,,I,Greg Orman,83
-Sedgwick,MI14,U.S. Senate,,I,Greg Orman,33
-Sedgwick,MO,U.S. Senate,,I,Greg Orman,326
-Sedgwick,MV01,U.S. Senate,,I,Greg Orman,219
-Sedgwick,MV02,U.S. Senate,,I,Greg Orman,497
-Sedgwick,NI,U.S. Senate,,I,Greg Orman,309
-Sedgwick,NI01,U.S. Senate,,I,Greg Orman,62
-Sedgwick,OH01,U.S. Senate,,I,Greg Orman,168
-Sedgwick,PA01,U.S. Senate,,I,Greg Orman,60
-Sedgwick,PA02,U.S. Senate,,I,Greg Orman,38
-Sedgwick,PA05,U.S. Senate,,I,Greg Orman,387
-Sedgwick,PA06,U.S. Senate,,I,Greg Orman,22
-Sedgwick,PA09,U.S. Senate,,I,Greg Orman,2
-Sedgwick,PC11,U.S. Senate,,I,Greg Orman,163
-Sedgwick,PC13,U.S. Senate,,I,Greg Orman,57
-Sedgwick,PC21,U.S. Senate,,I,Greg Orman,242
-Sedgwick,PC31,U.S. Senate,,I,Greg Orman,328
-Sedgwick,PC43,U.S. Senate,,I,Greg Orman,91
-Sedgwick,PY01,U.S. Senate,,I,Greg Orman,120
-Sedgwick,RI01,U.S. Senate,,I,Greg Orman,16
-Sedgwick,RI03,U.S. Senate,,I,Greg Orman,126
-Sedgwick,RI06,U.S. Senate,,I,Greg Orman,50
-Sedgwick,RI07,U.S. Senate,,I,Greg Orman,91
-Sedgwick,RI13,U.S. Senate,,I,Greg Orman,3
-Sedgwick,RO01,U.S. Senate,,I,Greg Orman,124
-Sedgwick,RO03,U.S. Senate,,I,Greg Orman,80
-Sedgwick,SA01,U.S. Senate,,I,Greg Orman,275
-Sedgwick,SA02,U.S. Senate,,I,Greg Orman,197
-Sedgwick,SH,U.S. Senate,,I,Greg Orman,170
-Sedgwick,UN01,U.S. Senate,,I,Greg Orman,170
-Sedgwick,UN02,U.S. Senate,,I,Greg Orman,13
-Sedgwick,VA,U.S. Senate,,I,Greg Orman,130
-Sedgwick,VC11,U.S. Senate,,I,Greg Orman,191
-Sedgwick,VC21,U.S. Senate,,I,Greg Orman,228
-Sedgwick,VC31,U.S. Senate,,I,Greg Orman,162
-Sedgwick,VC41,U.S. Senate,,I,Greg Orman,166
-Sedgwick,VC42,U.S. Senate,,I,Greg Orman,65
-Sedgwick,VI,U.S. Senate,,I,Greg Orman,54
-Sedgwick,WA01,U.S. Senate,,I,Greg Orman,13
-Sedgwick,WA02,U.S. Senate,,I,Greg Orman,56
-Sedgwick,WA03,U.S. Senate,,I,Greg Orman,5
-Sedgwick,WA12,U.S. Senate,,I,Greg Orman,0
-Sedgwick,AF,U.S. Senate,,L,Randall Batson,14
-Sedgwick,AT02,U.S. Senate,,L,Randall Batson,4
-Sedgwick,AT03,U.S. Senate,,L,Randall Batson,13
-Sedgwick,AT04,U.S. Senate,,L,Randall Batson,0
-Sedgwick,AT05,U.S. Senate,,L,Randall Batson,7
-Sedgwick,AT06,U.S. Senate,,L,Randall Batson,0
-Sedgwick,AT08,U.S. Senate,,L,Randall Batson,3
-Sedgwick,BA01,U.S. Senate,,L,Randall Batson,51
-Sedgwick,BA02,U.S. Senate,,L,Randall Batson,31
-Sedgwick,BA03,U.S. Senate,,L,Randall Batson,31
-Sedgwick,DB11,U.S. Senate,,L,Randall Batson,41
-Sedgwick,DB12,U.S. Senate,,L,Randall Batson,19
-Sedgwick,DB14,U.S. Senate,,L,Randall Batson,15
-Sedgwick,DB15,U.S. Senate,,L,Randall Batson,0
-Sedgwick,DB21,U.S. Senate,,L,Randall Batson,34
-Sedgwick,DB22,U.S. Senate,,L,Randall Batson,17
-Sedgwick,DB23,U.S. Senate,,L,Randall Batson,27
-Sedgwick,DB24,U.S. Senate,,L,Randall Batson,3
-Sedgwick,DB25,U.S. Senate,,L,Randall Batson,1
-Sedgwick,DB31,U.S. Senate,,L,Randall Batson,12
-Sedgwick,DB32,U.S. Senate,,L,Randall Batson,26
-Sedgwick,DB36,U.S. Senate,,L,Randall Batson,36
-Sedgwick,DB37,U.S. Senate,,L,Randall Batson,8
-Sedgwick,DB41,U.S. Senate,,L,Randall Batson,32
-Sedgwick,DB42,U.S. Senate,,L,Randall Batson,56
-Sedgwick,DL02,U.S. Senate,,L,Randall Batson,0
-Sedgwick,DL03,U.S. Senate,,L,Randall Batson,0
-Sedgwick,DL04,U.S. Senate,,L,Randall Batson,0
-Sedgwick,EA,U.S. Senate,,L,Randall Batson,17
-Sedgwick,ER,U.S. Senate,,L,Randall Batson,3
-Sedgwick,GA,U.S. Senate,,L,Randall Batson,28
-Sedgwick,GD,U.S. Senate,,L,Randall Batson,7
-Sedgwick,GN01,U.S. Senate,,L,Randall Batson,21
-Sedgwick,GO,U.S. Senate,,L,Randall Batson,68
-Sedgwick,GR,U.S. Senate,,L,Randall Batson,31
-Sedgwick,GY01,U.S. Senate,,L,Randall Batson,55
-Sedgwick,GY02,U.S. Senate,,L,Randall Batson,0
-Sedgwick,GY03,U.S. Senate,,L,Randall Batson,3
-Sedgwick,HA11,U.S. Senate,,L,Randall Batson,40
-Sedgwick,HA21,U.S. Senate,,L,Randall Batson,58
-Sedgwick,HA31,U.S. Senate,,L,Randall Batson,65
-Sedgwick,HA41,U.S. Senate,,L,Randall Batson,44
-Sedgwick,HA42,U.S. Senate,,L,Randall Batson,7
-Sedgwick,IL01,U.S. Senate,,L,Randall Batson,35
-Sedgwick,KE01,U.S. Senate,,L,Randall Batson,0
-Sedgwick,KE03,U.S. Senate,,L,Randall Batson,29
-Sedgwick,KE04,U.S. Senate,,L,Randall Batson,3
-Sedgwick,KE07,U.S. Senate,,L,Randall Batson,1
-Sedgwick,KE08,U.S. Senate,,L,Randall Batson,1
-Sedgwick,LI,U.S. Senate,,L,Randall Batson,12
-Sedgwick,MI01,U.S. Senate,,L,Randall Batson,24
-Sedgwick,MI02,U.S. Senate,,L,Randall Batson,11
-Sedgwick,MI03,U.S. Senate,,L,Randall Batson,1
-Sedgwick,MI04,U.S. Senate,,L,Randall Batson,1
-Sedgwick,MI05,U.S. Senate,,L,Randall Batson,0
-Sedgwick,MI07,U.S. Senate,,L,Randall Batson,0
-Sedgwick,MI09,U.S. Senate,,L,Randall Batson,13
-Sedgwick,MI14,U.S. Senate,,L,Randall Batson,2
-Sedgwick,MO,U.S. Senate,,L,Randall Batson,47
-Sedgwick,MV01,U.S. Senate,,L,Randall Batson,40
-Sedgwick,MV02,U.S. Senate,,L,Randall Batson,78
-Sedgwick,NI,U.S. Senate,,L,Randall Batson,48
-Sedgwick,NI01,U.S. Senate,,L,Randall Batson,8
-Sedgwick,OH01,U.S. Senate,,L,Randall Batson,26
-Sedgwick,PA01,U.S. Senate,,L,Randall Batson,8
-Sedgwick,PA02,U.S. Senate,,L,Randall Batson,6
-Sedgwick,PA05,U.S. Senate,,L,Randall Batson,39
-Sedgwick,PA06,U.S. Senate,,L,Randall Batson,2
-Sedgwick,PA09,U.S. Senate,,L,Randall Batson,0
-Sedgwick,PC11,U.S. Senate,,L,Randall Batson,25
-Sedgwick,PC13,U.S. Senate,,L,Randall Batson,5
-Sedgwick,PC21,U.S. Senate,,L,Randall Batson,39
-Sedgwick,PC31,U.S. Senate,,L,Randall Batson,53
-Sedgwick,PC43,U.S. Senate,,L,Randall Batson,7
-Sedgwick,PY01,U.S. Senate,,L,Randall Batson,19
-Sedgwick,RI01,U.S. Senate,,L,Randall Batson,3
-Sedgwick,RI03,U.S. Senate,,L,Randall Batson,26
-Sedgwick,RI06,U.S. Senate,,L,Randall Batson,3
-Sedgwick,RI07,U.S. Senate,,L,Randall Batson,17
-Sedgwick,RI13,U.S. Senate,,L,Randall Batson,0
-Sedgwick,RO01,U.S. Senate,,L,Randall Batson,8
-Sedgwick,RO03,U.S. Senate,,L,Randall Batson,17
-Sedgwick,SA01,U.S. Senate,,L,Randall Batson,41
-Sedgwick,SA02,U.S. Senate,,L,Randall Batson,30
-Sedgwick,SH,U.S. Senate,,L,Randall Batson,10
-Sedgwick,UN01,U.S. Senate,,L,Randall Batson,22
-Sedgwick,UN02,U.S. Senate,,L,Randall Batson,3
-Sedgwick,VA,U.S. Senate,,L,Randall Batson,26
-Sedgwick,VC11,U.S. Senate,,L,Randall Batson,35
-Sedgwick,VC21,U.S. Senate,,L,Randall Batson,25
-Sedgwick,VC31,U.S. Senate,,L,Randall Batson,21
-Sedgwick,VC41,U.S. Senate,,L,Randall Batson,34
-Sedgwick,VC42,U.S. Senate,,L,Randall Batson,10
-Sedgwick,VI,U.S. Senate,,L,Randall Batson,10
-Sedgwick,WA01,U.S. Senate,,L,Randall Batson,3
-Sedgwick,WA02,U.S. Senate,,L,Randall Batson,15
-Sedgwick,WA03,U.S. Senate,,L,Randall Batson,1
-Sedgwick,WA12,U.S. Senate,,L,Randall Batson,0
-Sedgwick,BA01,U.S. House,4,R,Mike Pompeo,752
-Sedgwick,BA02,U.S. House,4,R,Mike Pompeo,629
-Sedgwick,BA03,U.S. House,4,R,Mike Pompeo,493
-Sedgwick,DB11,U.S. House,4,R,Mike Pompeo,708
-Sedgwick,DB12,U.S. House,4,R,Mike Pompeo,371
-Sedgwick,DB14,U.S. House,4,R,Mike Pompeo,267
-Sedgwick,DB15,U.S. House,4,R,Mike Pompeo,27
-Sedgwick,DB21,U.S. House,4,R,Mike Pompeo,345
-Sedgwick,DB22,U.S. House,4,R,Mike Pompeo,407
-Sedgwick,DB23,U.S. House,4,R,Mike Pompeo,488
-Sedgwick,DB24,U.S. House,4,R,Mike Pompeo,92
-Sedgwick,DB25,U.S. House,4,R,Mike Pompeo,28
-Sedgwick,DB31,U.S. House,4,R,Mike Pompeo,149
-Sedgwick,DB32,U.S. House,4,R,Mike Pompeo,450
-Sedgwick,DB36,U.S. House,4,R,Mike Pompeo,620
-Sedgwick,DB37,U.S. House,4,R,Mike Pompeo,79
-Sedgwick,DB41,U.S. House,4,R,Mike Pompeo,254
-Sedgwick,DB42,U.S. House,4,R,Mike Pompeo,1072
-Sedgwick,HA11,U.S. House,4,R,Mike Pompeo,425
-Sedgwick,HA21,U.S. House,4,R,Mike Pompeo,455
-Sedgwick,HA31,U.S. House,4,R,Mike Pompeo,473
-Sedgwick,HA41,U.S. House,4,R,Mike Pompeo,438
-Sedgwick,HA42,U.S. House,4,R,Mike Pompeo,110
-Sedgwick,MV01,U.S. House,4,R,Mike Pompeo,380
-Sedgwick,MV02,U.S. House,4,R,Mike Pompeo,869
-Sedgwick,PC11,U.S. House,4,R,Mike Pompeo,253
-Sedgwick,PC13,U.S. House,4,R,Mike Pompeo,87
-Sedgwick,PC21,U.S. House,4,R,Mike Pompeo,426
-Sedgwick,PC31,U.S. House,4,R,Mike Pompeo,473
-Sedgwick,PC43,U.S. House,4,R,Mike Pompeo,146
-Sedgwick,VC11,U.S. House,4,R,Mike Pompeo,426
-Sedgwick,VC21,U.S. House,4,R,Mike Pompeo,465
-Sedgwick,VC31,U.S. House,4,R,Mike Pompeo,389
-Sedgwick,VC41,U.S. House,4,R,Mike Pompeo,331
-Sedgwick,VC42,U.S. House,4,R,Mike Pompeo,148
-Sedgwick,AF,U.S. House,4,R,Mike Pompeo,492
-Sedgwick,AT02,U.S. House,4,R,Mike Pompeo,70
-Sedgwick,AT03,U.S. House,4,R,Mike Pompeo,368
-Sedgwick,AT04,U.S. House,4,R,Mike Pompeo,2
-Sedgwick,AT05,U.S. House,4,R,Mike Pompeo,158
-Sedgwick,AT06,U.S. House,4,R,Mike Pompeo,41
-Sedgwick,AT08,U.S. House,4,R,Mike Pompeo,32
-Sedgwick,DL03,U.S. House,4,R,Mike Pompeo,1
-Sedgwick,DL04,U.S. House,4,R,Mike Pompeo,1
-Sedgwick,EA,U.S. House,4,R,Mike Pompeo,265
-Sedgwick,ER,U.S. House,4,R,Mike Pompeo,31
-Sedgwick,GA,U.S. House,4,R,Mike Pompeo,642
-Sedgwick,GD,U.S. House,4,R,Mike Pompeo,183
-Sedgwick,GN01,U.S. House,4,R,Mike Pompeo,506
-Sedgwick,GO,U.S. House,4,R,Mike Pompeo,1007
-Sedgwick,GR,U.S. House,4,R,Mike Pompeo,298
-Sedgwick,GY01,U.S. House,4,R,Mike Pompeo,958
-Sedgwick,GY02,U.S. House,4,R,Mike Pompeo,10
-Sedgwick,GY03,U.S. House,4,R,Mike Pompeo,25
-Sedgwick,IL01,U.S. House,4,R,Mike Pompeo,553
-Sedgwick,KE01,U.S. House,4,R,Mike Pompeo,12
-Sedgwick,KE03,U.S. House,4,R,Mike Pompeo,507
-Sedgwick,KE04,U.S. House,4,R,Mike Pompeo,20
-Sedgwick,KE07,U.S. House,4,R,Mike Pompeo,10
-Sedgwick,KE08,U.S. House,4,R,Mike Pompeo,11
-Sedgwick,LI,U.S. House,4,R,Mike Pompeo,196
-Sedgwick,MI01,U.S. House,4,R,Mike Pompeo,857
-Sedgwick,MI02,U.S. House,4,R,Mike Pompeo,335
-Sedgwick,MI03,U.S. House,4,R,Mike Pompeo,9
-Sedgwick,MI04,U.S. House,4,R,Mike Pompeo,2
-Sedgwick,MI05,U.S. House,4,R,Mike Pompeo,0
-Sedgwick,MI07,U.S. House,4,R,Mike Pompeo,7
-Sedgwick,MI09,U.S. House,4,R,Mike Pompeo,138
-Sedgwick,MI14,U.S. House,4,R,Mike Pompeo,71
-Sedgwick,MO,U.S. House,4,R,Mike Pompeo,665
-Sedgwick,NI,U.S. House,4,R,Mike Pompeo,652
-Sedgwick,NI01,U.S. House,4,R,Mike Pompeo,156
-Sedgwick,OH01,U.S. House,4,R,Mike Pompeo,390
-Sedgwick,PA01,U.S. House,4,R,Mike Pompeo,170
-Sedgwick,PA02,U.S. House,4,R,Mike Pompeo,75
-Sedgwick,PA05,U.S. House,4,R,Mike Pompeo,806
-Sedgwick,PA06,U.S. House,4,R,Mike Pompeo,36
-Sedgwick,PA09,U.S. House,4,R,Mike Pompeo,7
-Sedgwick,PY01,U.S. House,4,R,Mike Pompeo,357
-Sedgwick,RI01,U.S. House,4,R,Mike Pompeo,29
-Sedgwick,RI03,U.S. House,4,R,Mike Pompeo,120
-Sedgwick,RI06,U.S. House,4,R,Mike Pompeo,83
-Sedgwick,RI07,U.S. House,4,R,Mike Pompeo,130
-Sedgwick,RI13,U.S. House,4,R,Mike Pompeo,5
-Sedgwick,RO01,U.S. House,4,R,Mike Pompeo,272
-Sedgwick,RO03,U.S. House,4,R,Mike Pompeo,179
-Sedgwick,SA01,U.S. House,4,R,Mike Pompeo,549
-Sedgwick,SA02,U.S. House,4,R,Mike Pompeo,370
-Sedgwick,SH,U.S. House,4,R,Mike Pompeo,471
-Sedgwick,UN01,U.S. House,4,R,Mike Pompeo,698
-Sedgwick,UN02,U.S. House,4,R,Mike Pompeo,47
-Sedgwick,VA,U.S. House,4,R,Mike Pompeo,289
-Sedgwick,VI,U.S. House,4,R,Mike Pompeo,146
-Sedgwick,WA01,U.S. House,4,R,Mike Pompeo,43
-Sedgwick,WA02,U.S. House,4,R,Mike Pompeo,159
-Sedgwick,WA03,U.S. House,4,R,Mike Pompeo,10
-Sedgwick,WA12,U.S. House,4,R,Mike Pompeo,2
-Sedgwick,BA01,U.S. House,4,D,Perry Schuckman,351
-Sedgwick,BA02,U.S. House,4,D,Perry Schuckman,356
-Sedgwick,BA03,U.S. House,4,D,Perry Schuckman,208
-Sedgwick,DB11,U.S. House,4,D,Perry Schuckman,255
-Sedgwick,DB12,U.S. House,4,D,Perry Schuckman,152
-Sedgwick,DB14,U.S. House,4,D,Perry Schuckman,95
-Sedgwick,DB15,U.S. House,4,D,Perry Schuckman,2
-Sedgwick,DB21,U.S. House,4,D,Perry Schuckman,181
-Sedgwick,DB22,U.S. House,4,D,Perry Schuckman,161
-Sedgwick,DB23,U.S. House,4,D,Perry Schuckman,211
-Sedgwick,DB24,U.S. House,4,D,Perry Schuckman,38
-Sedgwick,DB25,U.S. House,4,D,Perry Schuckman,22
-Sedgwick,DB31,U.S. House,4,D,Perry Schuckman,62
-Sedgwick,DB32,U.S. House,4,D,Perry Schuckman,210
-Sedgwick,DB36,U.S. House,4,D,Perry Schuckman,239
-Sedgwick,DB37,U.S. House,4,D,Perry Schuckman,48
-Sedgwick,DB41,U.S. House,4,D,Perry Schuckman,141
-Sedgwick,DB42,U.S. House,4,D,Perry Schuckman,378
-Sedgwick,HA11,U.S. House,4,D,Perry Schuckman,204
-Sedgwick,HA21,U.S. House,4,D,Perry Schuckman,232
-Sedgwick,HA31,U.S. House,4,D,Perry Schuckman,253
-Sedgwick,HA41,U.S. House,4,D,Perry Schuckman,190
-Sedgwick,HA42,U.S. House,4,D,Perry Schuckman,31
-Sedgwick,MV01,U.S. House,4,D,Perry Schuckman,166
-Sedgwick,MV02,U.S. House,4,D,Perry Schuckman,371
-Sedgwick,PC11,U.S. House,4,D,Perry Schuckman,126
-Sedgwick,PC13,U.S. House,4,D,Perry Schuckman,37
-Sedgwick,PC21,U.S. House,4,D,Perry Schuckman,192
-Sedgwick,PC31,U.S. House,4,D,Perry Schuckman,275
-Sedgwick,PC43,U.S. House,4,D,Perry Schuckman,68
-Sedgwick,VC11,U.S. House,4,D,Perry Schuckman,143
-Sedgwick,VC21,U.S. House,4,D,Perry Schuckman,149
-Sedgwick,VC31,U.S. House,4,D,Perry Schuckman,104
-Sedgwick,VC41,U.S. House,4,D,Perry Schuckman,113
-Sedgwick,VC42,U.S. House,4,D,Perry Schuckman,37
-Sedgwick,AF,U.S. House,4,D,Perry Schuckman,128
-Sedgwick,AT02,U.S. House,4,D,Perry Schuckman,33
-Sedgwick,AT03,U.S. House,4,D,Perry Schuckman,105
-Sedgwick,AT04,U.S. House,4,D,Perry Schuckman,1
-Sedgwick,AT05,U.S. House,4,D,Perry Schuckman,47
-Sedgwick,AT06,U.S. House,4,D,Perry Schuckman,3
-Sedgwick,AT08,U.S. House,4,D,Perry Schuckman,13
-Sedgwick,DL03,U.S. House,4,D,Perry Schuckman,1
-Sedgwick,DL04,U.S. House,4,D,Perry Schuckman,0
-Sedgwick,EA,U.S. House,4,D,Perry Schuckman,107
-Sedgwick,ER,U.S. House,4,D,Perry Schuckman,7
-Sedgwick,GA,U.S. House,4,D,Perry Schuckman,129
-Sedgwick,GD,U.S. House,4,D,Perry Schuckman,44
-Sedgwick,GN01,U.S. House,4,D,Perry Schuckman,123
-Sedgwick,GO,U.S. House,4,D,Perry Schuckman,314
-Sedgwick,GR,U.S. House,4,D,Perry Schuckman,78
-Sedgwick,GY01,U.S. House,4,D,Perry Schuckman,329
-Sedgwick,GY02,U.S. House,4,D,Perry Schuckman,8
-Sedgwick,GY03,U.S. House,4,D,Perry Schuckman,13
-Sedgwick,IL01,U.S. House,4,D,Perry Schuckman,145
-Sedgwick,KE01,U.S. House,4,D,Perry Schuckman,1
-Sedgwick,KE03,U.S. House,4,D,Perry Schuckman,218
-Sedgwick,KE04,U.S. House,4,D,Perry Schuckman,16
-Sedgwick,KE07,U.S. House,4,D,Perry Schuckman,8
-Sedgwick,KE08,U.S. House,4,D,Perry Schuckman,0
-Sedgwick,LI,U.S. House,4,D,Perry Schuckman,53
-Sedgwick,MI01,U.S. House,4,D,Perry Schuckman,208
-Sedgwick,MI02,U.S. House,4,D,Perry Schuckman,106
-Sedgwick,MI03,U.S. House,4,D,Perry Schuckman,3
-Sedgwick,MI04,U.S. House,4,D,Perry Schuckman,0
-Sedgwick,MI05,U.S. House,4,D,Perry Schuckman,2
-Sedgwick,MI07,U.S. House,4,D,Perry Schuckman,4
-Sedgwick,MI09,U.S. House,4,D,Perry Schuckman,66
-Sedgwick,MI14,U.S. House,4,D,Perry Schuckman,26
-Sedgwick,MO,U.S. House,4,D,Perry Schuckman,234
-Sedgwick,NI,U.S. House,4,D,Perry Schuckman,235
-Sedgwick,NI01,U.S. House,4,D,Perry Schuckman,29
-Sedgwick,OH01,U.S. House,4,D,Perry Schuckman,138
-Sedgwick,PA01,U.S. House,4,D,Perry Schuckman,40
-Sedgwick,PA02,U.S. House,4,D,Perry Schuckman,40
-Sedgwick,PA05,U.S. House,4,D,Perry Schuckman,273
-Sedgwick,PA06,U.S. House,4,D,Perry Schuckman,19
-Sedgwick,PA09,U.S. House,4,D,Perry Schuckman,0
-Sedgwick,PY01,U.S. House,4,D,Perry Schuckman,91
-Sedgwick,RI01,U.S. House,4,D,Perry Schuckman,10
-Sedgwick,RI03,U.S. House,4,D,Perry Schuckman,112
-Sedgwick,RI06,U.S. House,4,D,Perry Schuckman,34
-Sedgwick,RI07,U.S. House,4,D,Perry Schuckman,76
-Sedgwick,RI13,U.S. House,4,D,Perry Schuckman,2
-Sedgwick,RO01,U.S. House,4,D,Perry Schuckman,91
-Sedgwick,RO03,U.S. House,4,D,Perry Schuckman,63
-Sedgwick,SA01,U.S. House,4,D,Perry Schuckman,212
-Sedgwick,SA02,U.S. House,4,D,Perry Schuckman,174
-Sedgwick,SH,U.S. House,4,D,Perry Schuckman,111
-Sedgwick,UN01,U.S. House,4,D,Perry Schuckman,113
-Sedgwick,UN02,U.S. House,4,D,Perry Schuckman,11
-Sedgwick,VA,U.S. House,4,D,Perry Schuckman,99
-Sedgwick,VI,U.S. House,4,D,Perry Schuckman,44
-Sedgwick,WA01,U.S. House,4,D,Perry Schuckman,8
-Sedgwick,WA02,U.S. House,4,D,Perry Schuckman,46
-Sedgwick,WA03,U.S. House,4,D,Perry Schuckman,1
-Sedgwick,WA12,U.S. House,4,D,Perry Schuckman,0
-Sedgwick,AF,Governor,,R,Sam Brownback,413
-Sedgwick,AT02,Governor,,R,Sam Brownback,58
-Sedgwick,AT03,Governor,,R,Sam Brownback,328
-Sedgwick,AT04,Governor,,R,Sam Brownback,2
-Sedgwick,AT05,Governor,,R,Sam Brownback,128
-Sedgwick,AT06,Governor,,R,Sam Brownback,40
-Sedgwick,AT08,Governor,,R,Sam Brownback,33
-Sedgwick,BA01,Governor,,R,Sam Brownback,618
-Sedgwick,BA02,Governor,,R,Sam Brownback,493
-Sedgwick,BA03,Governor,,R,Sam Brownback,385
-Sedgwick,DB11,Governor,,R,Sam Brownback,532
-Sedgwick,DB12,Governor,,R,Sam Brownback,273
-Sedgwick,DB14,Governor,,R,Sam Brownback,205
-Sedgwick,DB15,Governor,,R,Sam Brownback,24
-Sedgwick,DB21,Governor,,R,Sam Brownback,263
-Sedgwick,DB22,Governor,,R,Sam Brownback,292
-Sedgwick,DB23,Governor,,R,Sam Brownback,374
-Sedgwick,DB24,Governor,,R,Sam Brownback,76
-Sedgwick,DB25,Governor,,R,Sam Brownback,20
-Sedgwick,DB31,Governor,,R,Sam Brownback,125
-Sedgwick,DB32,Governor,,R,Sam Brownback,331
-Sedgwick,DB36,Governor,,R,Sam Brownback,454
-Sedgwick,DB37,Governor,,R,Sam Brownback,61
-Sedgwick,DB41,Governor,,R,Sam Brownback,203
-Sedgwick,DB42,Governor,,R,Sam Brownback,841
-Sedgwick,DL03,Governor,,R,Sam Brownback,1
-Sedgwick,DL04,Governor,,R,Sam Brownback,0
-Sedgwick,EA,Governor,,R,Sam Brownback,202
-Sedgwick,ER,Governor,,R,Sam Brownback,21
-Sedgwick,GA,Governor,,R,Sam Brownback,524
-Sedgwick,GD,Governor,,R,Sam Brownback,164
-Sedgwick,GN01,Governor,,R,Sam Brownback,422
-Sedgwick,GO,Governor,,R,Sam Brownback,805
-Sedgwick,GR,Governor,,R,Sam Brownback,248
-Sedgwick,GY01,Governor,,R,Sam Brownback,804
-Sedgwick,GY02,Governor,,R,Sam Brownback,8
-Sedgwick,GY03,Governor,,R,Sam Brownback,17
-Sedgwick,HA11,Governor,,R,Sam Brownback,314
-Sedgwick,HA21,Governor,,R,Sam Brownback,339
-Sedgwick,HA31,Governor,,R,Sam Brownback,360
-Sedgwick,HA41,Governor,,R,Sam Brownback,332
-Sedgwick,HA42,Governor,,R,Sam Brownback,86
-Sedgwick,IL01,Governor,,R,Sam Brownback,479
-Sedgwick,KE01,Governor,,R,Sam Brownback,12
-Sedgwick,KE03,Governor,,R,Sam Brownback,408
-Sedgwick,KE04,Governor,,R,Sam Brownback,17
-Sedgwick,KE07,Governor,,R,Sam Brownback,9
-Sedgwick,KE08,Governor,,R,Sam Brownback,8
-Sedgwick,LI,Governor,,R,Sam Brownback,170
-Sedgwick,MI01,Governor,,R,Sam Brownback,696
-Sedgwick,MI02,Governor,,R,Sam Brownback,237
-Sedgwick,MI03,Governor,,R,Sam Brownback,7
-Sedgwick,MI04,Governor,,R,Sam Brownback,1
-Sedgwick,MI05,Governor,,R,Sam Brownback,0
-Sedgwick,MI07,Governor,,R,Sam Brownback,4
-Sedgwick,MI09,Governor,,R,Sam Brownback,97
-Sedgwick,MI14,Governor,,R,Sam Brownback,62
-Sedgwick,MO,Governor,,R,Sam Brownback,495
-Sedgwick,MV01,Governor,,R,Sam Brownback,283
-Sedgwick,MV02,Governor,,R,Sam Brownback,628
-Sedgwick,NI,Governor,,R,Sam Brownback,494
-Sedgwick,NI01,Governor,,R,Sam Brownback,126
-Sedgwick,OH01,Governor,,R,Sam Brownback,344
-Sedgwick,PA01,Governor,,R,Sam Brownback,141
-Sedgwick,PA02,Governor,,R,Sam Brownback,67
-Sedgwick,PA05,Governor,,R,Sam Brownback,645
-Sedgwick,PA06,Governor,,R,Sam Brownback,31
-Sedgwick,PA09,Governor,,R,Sam Brownback,5
-Sedgwick,PC11,Governor,,R,Sam Brownback,188
-Sedgwick,PC13,Governor,,R,Sam Brownback,68
-Sedgwick,PC21,Governor,,R,Sam Brownback,332
-Sedgwick,PC31,Governor,,R,Sam Brownback,360
-Sedgwick,PC43,Governor,,R,Sam Brownback,117
-Sedgwick,PY01,Governor,,R,Sam Brownback,312
-Sedgwick,RI01,Governor,,R,Sam Brownback,20
-Sedgwick,RI03,Governor,,R,Sam Brownback,82
-Sedgwick,RI06,Governor,,R,Sam Brownback,62
-Sedgwick,RI07,Governor,,R,Sam Brownback,93
-Sedgwick,RI13,Governor,,R,Sam Brownback,4
-Sedgwick,RO01,Governor,,R,Sam Brownback,229
-Sedgwick,RO03,Governor,,R,Sam Brownback,144
-Sedgwick,SA01,Governor,,R,Sam Brownback,463
-Sedgwick,SA02,Governor,,R,Sam Brownback,304
-Sedgwick,SH,Governor,,R,Sam Brownback,385
-Sedgwick,UN01,Governor,,R,Sam Brownback,622
-Sedgwick,UN02,Governor,,R,Sam Brownback,39
-Sedgwick,VA,Governor,,R,Sam Brownback,227
-Sedgwick,VC11,Governor,,R,Sam Brownback,323
-Sedgwick,VC21,Governor,,R,Sam Brownback,338
-Sedgwick,VC31,Governor,,R,Sam Brownback,288
-Sedgwick,VC41,Governor,,R,Sam Brownback,233
-Sedgwick,VC42,Governor,,R,Sam Brownback,107
-Sedgwick,VI,Governor,,R,Sam Brownback,115
-Sedgwick,WA01,Governor,,R,Sam Brownback,34
-Sedgwick,WA02,Governor,,R,Sam Brownback,139
-Sedgwick,WA03,Governor,,R,Sam Brownback,9
-Sedgwick,WA12,Governor,,R,Sam Brownback,2
-Sedgwick,AF,Governor,,D,Paul Davis,198
-Sedgwick,AT02,Governor,,D,Paul Davis,42
-Sedgwick,AT03,Governor,,D,Paul Davis,142
-Sedgwick,AT04,Governor,,D,Paul Davis,1
-Sedgwick,AT05,Governor,,D,Paul Davis,76
-Sedgwick,AT06,Governor,,D,Paul Davis,3
-Sedgwick,AT08,Governor,,D,Paul Davis,11
-Sedgwick,BA01,Governor,,D,Paul Davis,462
-Sedgwick,BA02,Governor,,D,Paul Davis,467
-Sedgwick,BA03,Governor,,D,Paul Davis,299
-Sedgwick,DB11,Governor,,D,Paul Davis,397
-Sedgwick,DB12,Governor,,D,Paul Davis,241
-Sedgwick,DB14,Governor,,D,Paul Davis,146
-Sedgwick,DB15,Governor,,D,Paul Davis,4
-Sedgwick,DB21,Governor,,D,Paul Davis,225
-Sedgwick,DB22,Governor,,D,Paul Davis,257
-Sedgwick,DB23,Governor,,D,Paul Davis,311
-Sedgwick,DB24,Governor,,D,Paul Davis,50
-Sedgwick,DB25,Governor,,D,Paul Davis,27
-Sedgwick,DB31,Governor,,D,Paul Davis,79
-Sedgwick,DB32,Governor,,D,Paul Davis,302
-Sedgwick,DB36,Governor,,D,Paul Davis,396
-Sedgwick,DB37,Governor,,D,Paul Davis,61
-Sedgwick,DB41,Governor,,D,Paul Davis,178
-Sedgwick,DB42,Governor,,D,Paul Davis,596
-Sedgwick,DL03,Governor,,D,Paul Davis,1
-Sedgwick,DL04,Governor,,D,Paul Davis,1
-Sedgwick,EA,Governor,,D,Paul Davis,160
-Sedgwick,ER,Governor,,D,Paul Davis,15
-Sedgwick,GA,Governor,,D,Paul Davis,237
-Sedgwick,GD,Governor,,D,Paul Davis,58
-Sedgwick,GN01,Governor,,D,Paul Davis,190
-Sedgwick,GO,Governor,,D,Paul Davis,487
-Sedgwick,GR,Governor,,D,Paul Davis,109
-Sedgwick,GY01,Governor,,D,Paul Davis,455
-Sedgwick,GY02,Governor,,D,Paul Davis,10
-Sedgwick,GY03,Governor,,D,Paul Davis,17
-Sedgwick,HA11,Governor,,D,Paul Davis,288
-Sedgwick,HA21,Governor,,D,Paul Davis,302
-Sedgwick,HA31,Governor,,D,Paul Davis,318
-Sedgwick,HA41,Governor,,D,Paul Davis,266
-Sedgwick,HA42,Governor,,D,Paul Davis,49
-Sedgwick,IL01,Governor,,D,Paul Davis,199
-Sedgwick,KE01,Governor,,D,Paul Davis,1
-Sedgwick,KE03,Governor,,D,Paul Davis,309
-Sedgwick,KE04,Governor,,D,Paul Davis,16
-Sedgwick,KE07,Governor,,D,Paul Davis,7
-Sedgwick,KE08,Governor,,D,Paul Davis,3
-Sedgwick,LI,Governor,,D,Paul Davis,73
-Sedgwick,MI01,Governor,,D,Paul Davis,360
-Sedgwick,MI02,Governor,,D,Paul Davis,198
-Sedgwick,MI03,Governor,,D,Paul Davis,4
-Sedgwick,MI04,Governor,,D,Paul Davis,0
-Sedgwick,MI05,Governor,,D,Paul Davis,2
-Sedgwick,MI07,Governor,,D,Paul Davis,7
-Sedgwick,MI09,Governor,,D,Paul Davis,95
-Sedgwick,MI14,Governor,,D,Paul Davis,35
-Sedgwick,MO,Governor,,D,Paul Davis,372
-Sedgwick,MV01,Governor,,D,Paul Davis,252
-Sedgwick,MV02,Governor,,D,Paul Davis,556
-Sedgwick,NI,Governor,,D,Paul Davis,367
-Sedgwick,NI01,Governor,,D,Paul Davis,57
-Sedgwick,OH01,Governor,,D,Paul Davis,175
-Sedgwick,PA01,Governor,,D,Paul Davis,62
-Sedgwick,PA02,Governor,,D,Paul Davis,41
-Sedgwick,PA05,Governor,,D,Paul Davis,404
-Sedgwick,PA06,Governor,,D,Paul Davis,21
-Sedgwick,PA09,Governor,,D,Paul Davis,2
-Sedgwick,PC11,Governor,,D,Paul Davis,171
-Sedgwick,PC13,Governor,,D,Paul Davis,55
-Sedgwick,PC21,Governor,,D,Paul Davis,261
-Sedgwick,PC31,Governor,,D,Paul Davis,358
-Sedgwick,PC43,Governor,,D,Paul Davis,95
-Sedgwick,PY01,Governor,,D,Paul Davis,122
-Sedgwick,RI01,Governor,,D,Paul Davis,14
-Sedgwick,RI03,Governor,,D,Paul Davis,140
-Sedgwick,RI06,Governor,,D,Paul Davis,55
-Sedgwick,RI07,Governor,,D,Paul Davis,94
-Sedgwick,RI13,Governor,,D,Paul Davis,3
-Sedgwick,RO01,Governor,,D,Paul Davis,127
-Sedgwick,RO03,Governor,,D,Paul Davis,90
-Sedgwick,SA01,Governor,,D,Paul Davis,255
-Sedgwick,SA02,Governor,,D,Paul Davis,220
-Sedgwick,SH,Governor,,D,Paul Davis,187
-Sedgwick,UN01,Governor,,D,Paul Davis,182
-Sedgwick,UN02,Governor,,D,Paul Davis,17
-Sedgwick,VA,Governor,,D,Paul Davis,138
-Sedgwick,VC11,Governor,,D,Paul Davis,215
-Sedgwick,VC21,Governor,,D,Paul Davis,255
-Sedgwick,VC31,Governor,,D,Paul Davis,181
-Sedgwick,VC41,Governor,,D,Paul Davis,182
-Sedgwick,VC42,Governor,,D,Paul Davis,67
-Sedgwick,VI,Governor,,D,Paul Davis,61
-Sedgwick,WA01,Governor,,D,Paul Davis,17
-Sedgwick,WA02,Governor,,D,Paul Davis,63
-Sedgwick,WA03,Governor,,D,Paul Davis,3
-Sedgwick,WA12,Governor,,D,Paul Davis,0
-Sedgwick,AF,Governor,,L,Keen Umbehr,17
-Sedgwick,AT02,Governor,,L,Keen Umbehr,5
-Sedgwick,AT03,Governor,,L,Keen Umbehr,10
-Sedgwick,AT04,Governor,,L,Keen Umbehr,0
-Sedgwick,AT05,Governor,,L,Keen Umbehr,4
-Sedgwick,AT06,Governor,,L,Keen Umbehr,0
-Sedgwick,AT08,Governor,,L,Keen Umbehr,2
-Sedgwick,BA01,Governor,,L,Keen Umbehr,40
-Sedgwick,BA02,Governor,,L,Keen Umbehr,33
-Sedgwick,BA03,Governor,,L,Keen Umbehr,28
-Sedgwick,DB11,Governor,,L,Keen Umbehr,42
-Sedgwick,DB12,Governor,,L,Keen Umbehr,9
-Sedgwick,DB14,Governor,,L,Keen Umbehr,14
-Sedgwick,DB15,Governor,,L,Keen Umbehr,1
-Sedgwick,DB21,Governor,,L,Keen Umbehr,42
-Sedgwick,DB22,Governor,,L,Keen Umbehr,18
-Sedgwick,DB23,Governor,,L,Keen Umbehr,25
-Sedgwick,DB24,Governor,,L,Keen Umbehr,5
-Sedgwick,DB25,Governor,,L,Keen Umbehr,4
-Sedgwick,DB31,Governor,,L,Keen Umbehr,8
-Sedgwick,DB32,Governor,,L,Keen Umbehr,26
-Sedgwick,DB36,Governor,,L,Keen Umbehr,29
-Sedgwick,DB37,Governor,,L,Keen Umbehr,7
-Sedgwick,DB41,Governor,,L,Keen Umbehr,19
-Sedgwick,DB42,Governor,,L,Keen Umbehr,43
-Sedgwick,DL03,Governor,,L,Keen Umbehr,0
-Sedgwick,DL04,Governor,,L,Keen Umbehr,0
-Sedgwick,EA,Governor,,L,Keen Umbehr,10
-Sedgwick,ER,Governor,,L,Keen Umbehr,4
-Sedgwick,GA,Governor,,L,Keen Umbehr,19
-Sedgwick,GD,Governor,,L,Keen Umbehr,5
-Sedgwick,GN01,Governor,,L,Keen Umbehr,24
-Sedgwick,GO,Governor,,L,Keen Umbehr,49
-Sedgwick,GR,Governor,,L,Keen Umbehr,24
-Sedgwick,GY01,Governor,,L,Keen Umbehr,49
-Sedgwick,GY02,Governor,,L,Keen Umbehr,0
-Sedgwick,GY03,Governor,,L,Keen Umbehr,5
-Sedgwick,HA11,Governor,,L,Keen Umbehr,34
-Sedgwick,HA21,Governor,,L,Keen Umbehr,51
-Sedgwick,HA31,Governor,,L,Keen Umbehr,58
-Sedgwick,HA41,Governor,,L,Keen Umbehr,34
-Sedgwick,HA42,Governor,,L,Keen Umbehr,7
-Sedgwick,IL01,Governor,,L,Keen Umbehr,31
-Sedgwick,KE01,Governor,,L,Keen Umbehr,0
-Sedgwick,KE03,Governor,,L,Keen Umbehr,24
-Sedgwick,KE04,Governor,,L,Keen Umbehr,3
-Sedgwick,KE07,Governor,,L,Keen Umbehr,2
-Sedgwick,KE08,Governor,,L,Keen Umbehr,0
-Sedgwick,LI,Governor,,L,Keen Umbehr,9
-Sedgwick,MI01,Governor,,L,Keen Umbehr,16
-Sedgwick,MI02,Governor,,L,Keen Umbehr,12
-Sedgwick,MI03,Governor,,L,Keen Umbehr,1
-Sedgwick,MI04,Governor,,L,Keen Umbehr,1
-Sedgwick,MI05,Governor,,L,Keen Umbehr,0
-Sedgwick,MI07,Governor,,L,Keen Umbehr,0
-Sedgwick,MI09,Governor,,L,Keen Umbehr,15
-Sedgwick,MI14,Governor,,L,Keen Umbehr,2
-Sedgwick,MO,Governor,,L,Keen Umbehr,44
-Sedgwick,MV01,Governor,,L,Keen Umbehr,18
-Sedgwick,MV02,Governor,,L,Keen Umbehr,59
-Sedgwick,NI,Governor,,L,Keen Umbehr,31
-Sedgwick,NI01,Governor,,L,Keen Umbehr,6
-Sedgwick,OH01,Governor,,L,Keen Umbehr,21
-Sedgwick,PA01,Governor,,L,Keen Umbehr,7
-Sedgwick,PA02,Governor,,L,Keen Umbehr,6
-Sedgwick,PA05,Governor,,L,Keen Umbehr,43
-Sedgwick,PA06,Governor,,L,Keen Umbehr,2
-Sedgwick,PA09,Governor,,L,Keen Umbehr,0
-Sedgwick,PC11,Governor,,L,Keen Umbehr,23
-Sedgwick,PC13,Governor,,L,Keen Umbehr,6
-Sedgwick,PC21,Governor,,L,Keen Umbehr,32
-Sedgwick,PC31,Governor,,L,Keen Umbehr,42
-Sedgwick,PC43,Governor,,L,Keen Umbehr,7
-Sedgwick,PY01,Governor,,L,Keen Umbehr,12
-Sedgwick,RI01,Governor,,L,Keen Umbehr,4
-Sedgwick,RI03,Governor,,L,Keen Umbehr,18
-Sedgwick,RI06,Governor,,L,Keen Umbehr,4
-Sedgwick,RI07,Governor,,L,Keen Umbehr,20
-Sedgwick,RI13,Governor,,L,Keen Umbehr,0
-Sedgwick,RO01,Governor,,L,Keen Umbehr,17
-Sedgwick,RO03,Governor,,L,Keen Umbehr,11
-Sedgwick,SA01,Governor,,L,Keen Umbehr,49
-Sedgwick,SA02,Governor,,L,Keen Umbehr,22
-Sedgwick,SH,Governor,,L,Keen Umbehr,15
-Sedgwick,UN01,Governor,,L,Keen Umbehr,18
-Sedgwick,UN02,Governor,,L,Keen Umbehr,3
-Sedgwick,VA,Governor,,L,Keen Umbehr,27
-Sedgwick,VC11,Governor,,L,Keen Umbehr,33
-Sedgwick,VC21,Governor,,L,Keen Umbehr,21
-Sedgwick,VC31,Governor,,L,Keen Umbehr,25
-Sedgwick,VC41,Governor,,L,Keen Umbehr,30
-Sedgwick,VC42,Governor,,L,Keen Umbehr,13
-Sedgwick,VI,Governor,,L,Keen Umbehr,14
-Sedgwick,WA01,Governor,,L,Keen Umbehr,2
-Sedgwick,WA02,Governor,,L,Keen Umbehr,9
-Sedgwick,WA03,Governor,,L,Keen Umbehr,0
-Sedgwick,WA12,Governor,,L,Keen Umbehr,0
-Sedgwick,BA01,Secretary of State,,R,Kris Kobach,646
-Sedgwick,BA02,Secretary of State,,R,Kris Kobach,540
-Sedgwick,BA03,Secretary of State,,R,Kris Kobach,395
-Sedgwick,DB11,Secretary of State,,R,Kris Kobach,590
-Sedgwick,DB12,Secretary of State,,R,Kris Kobach,305
-Sedgwick,DB14,Secretary of State,,R,Kris Kobach,227
-Sedgwick,DB15,Secretary of State,,R,Kris Kobach,25
-Sedgwick,DB21,Secretary of State,,R,Kris Kobach,316
-Sedgwick,DB22,Secretary of State,,R,Kris Kobach,343
-Sedgwick,DB23,Secretary of State,,R,Kris Kobach,442
-Sedgwick,DB24,Secretary of State,,R,Kris Kobach,80
-Sedgwick,DB25,Secretary of State,,R,Kris Kobach,30
-Sedgwick,DB31,Secretary of State,,R,Kris Kobach,131
-Sedgwick,DB32,Secretary of State,,R,Kris Kobach,382
-Sedgwick,DB36,Secretary of State,,R,Kris Kobach,515
-Sedgwick,DB37,Secretary of State,,R,Kris Kobach,68
-Sedgwick,DB41,Secretary of State,,R,Kris Kobach,243
-Sedgwick,DB42,Secretary of State,,R,Kris Kobach,923
-Sedgwick,HA11,Secretary of State,,R,Kris Kobach,368
-Sedgwick,HA21,Secretary of State,,R,Kris Kobach,403
-Sedgwick,HA31,Secretary of State,,R,Kris Kobach,440
-Sedgwick,HA41,Secretary of State,,R,Kris Kobach,378
-Sedgwick,HA42,Secretary of State,,R,Kris Kobach,100
-Sedgwick,MV01,Secretary of State,,R,Kris Kobach,326
-Sedgwick,MV02,Secretary of State,,R,Kris Kobach,745
-Sedgwick,PC11,Secretary of State,,R,Kris Kobach,224
-Sedgwick,PC13,Secretary of State,,R,Kris Kobach,80
-Sedgwick,PC21,Secretary of State,,R,Kris Kobach,367
-Sedgwick,PC31,Secretary of State,,R,Kris Kobach,415
-Sedgwick,PC43,Secretary of State,,R,Kris Kobach,130
-Sedgwick,VC11,Secretary of State,,R,Kris Kobach,357
-Sedgwick,VC21,Secretary of State,,R,Kris Kobach,383
-Sedgwick,VC31,Secretary of State,,R,Kris Kobach,314
-Sedgwick,VC41,Secretary of State,,R,Kris Kobach,281
-Sedgwick,VC42,Secretary of State,,R,Kris Kobach,125
-Sedgwick,AF,Secretary of State,,R,Kris Kobach,433
-Sedgwick,AT02,Secretary of State,,R,Kris Kobach,70
-Sedgwick,AT03,Secretary of State,,R,Kris Kobach,341
-Sedgwick,AT04,Secretary of State,,R,Kris Kobach,2
-Sedgwick,AT05,Secretary of State,,R,Kris Kobach,149
-Sedgwick,AT06,Secretary of State,,R,Kris Kobach,39
-Sedgwick,AT08,Secretary of State,,R,Kris Kobach,28
-Sedgwick,DL03,Secretary of State,,R,Kris Kobach,2
-Sedgwick,DL04,Secretary of State,,R,Kris Kobach,1
-Sedgwick,EA,Secretary of State,,R,Kris Kobach,228
-Sedgwick,ER,Secretary of State,,R,Kris Kobach,28
-Sedgwick,GA,Secretary of State,,R,Kris Kobach,586
-Sedgwick,GD,Secretary of State,,R,Kris Kobach,185
-Sedgwick,GN01,Secretary of State,,R,Kris Kobach,447
-Sedgwick,GO,Secretary of State,,R,Kris Kobach,925
-Sedgwick,GR,Secretary of State,,R,Kris Kobach,270
-Sedgwick,GY01,Secretary of State,,R,Kris Kobach,889
-Sedgwick,GY02,Secretary of State,,R,Kris Kobach,9
-Sedgwick,GY03,Secretary of State,,R,Kris Kobach,24
-Sedgwick,IL01,Secretary of State,,R,Kris Kobach,511
-Sedgwick,KE01,Secretary of State,,R,Kris Kobach,11
-Sedgwick,KE03,Secretary of State,,R,Kris Kobach,451
-Sedgwick,KE04,Secretary of State,,R,Kris Kobach,17
-Sedgwick,KE07,Secretary of State,,R,Kris Kobach,10
-Sedgwick,KE08,Secretary of State,,R,Kris Kobach,8
-Sedgwick,LI,Secretary of State,,R,Kris Kobach,182
-Sedgwick,MI01,Secretary of State,,R,Kris Kobach,708
-Sedgwick,MI02,Secretary of State,,R,Kris Kobach,250
-Sedgwick,MI03,Secretary of State,,R,Kris Kobach,8
-Sedgwick,MI04,Secretary of State,,R,Kris Kobach,1
-Sedgwick,MI05,Secretary of State,,R,Kris Kobach,0
-Sedgwick,MI07,Secretary of State,,R,Kris Kobach,4
-Sedgwick,MI09,Secretary of State,,R,Kris Kobach,124
-Sedgwick,MI14,Secretary of State,,R,Kris Kobach,62
-Sedgwick,MO,Secretary of State,,R,Kris Kobach,569
-Sedgwick,NI,Secretary of State,,R,Kris Kobach,559
-Sedgwick,NI01,Secretary of State,,R,Kris Kobach,133
-Sedgwick,OH01,Secretary of State,,R,Kris Kobach,358
-Sedgwick,PA01,Secretary of State,,R,Kris Kobach,149
-Sedgwick,PA02,Secretary of State,,R,Kris Kobach,71
-Sedgwick,PA05,Secretary of State,,R,Kris Kobach,697
-Sedgwick,PA06,Secretary of State,,R,Kris Kobach,31
-Sedgwick,PA09,Secretary of State,,R,Kris Kobach,4
-Sedgwick,PY01,Secretary of State,,R,Kris Kobach,316
-Sedgwick,RI01,Secretary of State,,R,Kris Kobach,21
-Sedgwick,RI03,Secretary of State,,R,Kris Kobach,101
-Sedgwick,RI06,Secretary of State,,R,Kris Kobach,71
-Sedgwick,RI07,Secretary of State,,R,Kris Kobach,107
-Sedgwick,RI13,Secretary of State,,R,Kris Kobach,4
-Sedgwick,RO01,Secretary of State,,R,Kris Kobach,250
-Sedgwick,RO03,Secretary of State,,R,Kris Kobach,155
-Sedgwick,SA01,Secretary of State,,R,Kris Kobach,503
-Sedgwick,SA02,Secretary of State,,R,Kris Kobach,342
-Sedgwick,SH,Secretary of State,,R,Kris Kobach,402
-Sedgwick,UN01,Secretary of State,,R,Kris Kobach,650
-Sedgwick,UN02,Secretary of State,,R,Kris Kobach,42
-Sedgwick,VA,Secretary of State,,R,Kris Kobach,253
-Sedgwick,VI,Secretary of State,,R,Kris Kobach,125
-Sedgwick,WA01,Secretary of State,,R,Kris Kobach,39
-Sedgwick,WA02,Secretary of State,,R,Kris Kobach,132
-Sedgwick,WA03,Secretary of State,,R,Kris Kobach,7
-Sedgwick,WA12,Secretary of State,,R,Kris Kobach,2
-Sedgwick,BA01,Secretary of State,,D,Jean Schodorf,454
-Sedgwick,BA02,Secretary of State,,D,Jean Schodorf,447
-Sedgwick,BA03,Secretary of State,,D,Jean Schodorf,313
-Sedgwick,DB11,Secretary of State,,D,Jean Schodorf,373
-Sedgwick,DB12,Secretary of State,,D,Jean Schodorf,214
-Sedgwick,DB14,Secretary of State,,D,Jean Schodorf,133
-Sedgwick,DB15,Secretary of State,,D,Jean Schodorf,4
-Sedgwick,DB21,Secretary of State,,D,Jean Schodorf,205
-Sedgwick,DB22,Secretary of State,,D,Jean Schodorf,221
-Sedgwick,DB23,Secretary of State,,D,Jean Schodorf,263
-Sedgwick,DB24,Secretary of State,,D,Jean Schodorf,50
-Sedgwick,DB25,Secretary of State,,D,Jean Schodorf,20
-Sedgwick,DB31,Secretary of State,,D,Jean Schodorf,82
-Sedgwick,DB32,Secretary of State,,D,Jean Schodorf,277
-Sedgwick,DB36,Secretary of State,,D,Jean Schodorf,358
-Sedgwick,DB37,Secretary of State,,D,Jean Schodorf,59
-Sedgwick,DB41,Secretary of State,,D,Jean Schodorf,157
-Sedgwick,DB42,Secretary of State,,D,Jean Schodorf,538
-Sedgwick,HA11,Secretary of State,,D,Jean Schodorf,255
-Sedgwick,HA21,Secretary of State,,D,Jean Schodorf,282
-Sedgwick,HA31,Secretary of State,,D,Jean Schodorf,291
-Sedgwick,HA41,Secretary of State,,D,Jean Schodorf,254
-Sedgwick,HA42,Secretary of State,,D,Jean Schodorf,41
-Sedgwick,MV01,Secretary of State,,D,Jean Schodorf,218
-Sedgwick,MV02,Secretary of State,,D,Jean Schodorf,499
-Sedgwick,PC11,Secretary of State,,D,Jean Schodorf,145
-Sedgwick,PC13,Secretary of State,,D,Jean Schodorf,48
-Sedgwick,PC21,Secretary of State,,D,Jean Schodorf,248
-Sedgwick,PC31,Secretary of State,,D,Jean Schodorf,336
-Sedgwick,PC43,Secretary of State,,D,Jean Schodorf,84
-Sedgwick,VC11,Secretary of State,,D,Jean Schodorf,207
-Sedgwick,VC21,Secretary of State,,D,Jean Schodorf,228
-Sedgwick,VC31,Secretary of State,,D,Jean Schodorf,177
-Sedgwick,VC41,Secretary of State,,D,Jean Schodorf,157
-Sedgwick,VC42,Secretary of State,,D,Jean Schodorf,61
-Sedgwick,AF,Secretary of State,,D,Jean Schodorf,187
-Sedgwick,AT02,Secretary of State,,D,Jean Schodorf,36
-Sedgwick,AT03,Secretary of State,,D,Jean Schodorf,138
-Sedgwick,AT04,Secretary of State,,D,Jean Schodorf,1
-Sedgwick,AT05,Secretary of State,,D,Jean Schodorf,61
-Sedgwick,AT06,Secretary of State,,D,Jean Schodorf,6
-Sedgwick,AT08,Secretary of State,,D,Jean Schodorf,18
-Sedgwick,DL03,Secretary of State,,D,Jean Schodorf,0
-Sedgwick,DL04,Secretary of State,,D,Jean Schodorf,0
-Sedgwick,EA,Secretary of State,,D,Jean Schodorf,143
-Sedgwick,ER,Secretary of State,,D,Jean Schodorf,10
-Sedgwick,GA,Secretary of State,,D,Jean Schodorf,184
-Sedgwick,GD,Secretary of State,,D,Jean Schodorf,45
-Sedgwick,GN01,Secretary of State,,D,Jean Schodorf,182
-Sedgwick,GO,Secretary of State,,D,Jean Schodorf,404
-Sedgwick,GR,Secretary of State,,D,Jean Schodorf,108
-Sedgwick,GY01,Secretary of State,,D,Jean Schodorf,408
-Sedgwick,GY02,Secretary of State,,D,Jean Schodorf,8
-Sedgwick,GY03,Secretary of State,,D,Jean Schodorf,15
-Sedgwick,IL01,Secretary of State,,D,Jean Schodorf,193
-Sedgwick,KE01,Secretary of State,,D,Jean Schodorf,2
-Sedgwick,KE03,Secretary of State,,D,Jean Schodorf,283
-Sedgwick,KE04,Secretary of State,,D,Jean Schodorf,19
-Sedgwick,KE07,Secretary of State,,D,Jean Schodorf,8
-Sedgwick,KE08,Secretary of State,,D,Jean Schodorf,3
-Sedgwick,LI,Secretary of State,,D,Jean Schodorf,68
-Sedgwick,MI01,Secretary of State,,D,Jean Schodorf,359
-Sedgwick,MI02,Secretary of State,,D,Jean Schodorf,193
-Sedgwick,MI03,Secretary of State,,D,Jean Schodorf,4
-Sedgwick,MI04,Secretary of State,,D,Jean Schodorf,1
-Sedgwick,MI05,Secretary of State,,D,Jean Schodorf,2
-Sedgwick,MI07,Secretary of State,,D,Jean Schodorf,7
-Sedgwick,MI09,Secretary of State,,D,Jean Schodorf,83
-Sedgwick,MI14,Secretary of State,,D,Jean Schodorf,37
-Sedgwick,MO,Secretary of State,,D,Jean Schodorf,327
-Sedgwick,NI,Secretary of State,,D,Jean Schodorf,325
-Sedgwick,NI01,Secretary of State,,D,Jean Schodorf,53
-Sedgwick,OH01,Secretary of State,,D,Jean Schodorf,182
-Sedgwick,PA01,Secretary of State,,D,Jean Schodorf,59
-Sedgwick,PA02,Secretary of State,,D,Jean Schodorf,43
-Sedgwick,PA05,Secretary of State,,D,Jean Schodorf,381
-Sedgwick,PA06,Secretary of State,,D,Jean Schodorf,23
-Sedgwick,PA09,Secretary of State,,D,Jean Schodorf,3
-Sedgwick,PY01,Secretary of State,,D,Jean Schodorf,132
-Sedgwick,RI01,Secretary of State,,D,Jean Schodorf,18
-Sedgwick,RI03,Secretary of State,,D,Jean Schodorf,133
-Sedgwick,RI06,Secretary of State,,D,Jean Schodorf,47
-Sedgwick,RI07,Secretary of State,,D,Jean Schodorf,99
-Sedgwick,RI13,Secretary of State,,D,Jean Schodorf,3
-Sedgwick,RO01,Secretary of State,,D,Jean Schodorf,118
-Sedgwick,RO03,Secretary of State,,D,Jean Schodorf,90
-Sedgwick,SA01,Secretary of State,,D,Jean Schodorf,259
-Sedgwick,SA02,Secretary of State,,D,Jean Schodorf,204
-Sedgwick,SH,Secretary of State,,D,Jean Schodorf,182
-Sedgwick,UN01,Secretary of State,,D,Jean Schodorf,168
-Sedgwick,UN02,Secretary of State,,D,Jean Schodorf,16
-Sedgwick,VA,Secretary of State,,D,Jean Schodorf,135
-Sedgwick,VI,Secretary of State,,D,Jean Schodorf,64
-Sedgwick,WA01,Secretary of State,,D,Jean Schodorf,14
-Sedgwick,WA02,Secretary of State,,D,Jean Schodorf,78
-Sedgwick,WA03,Secretary of State,,D,Jean Schodorf,5
-Sedgwick,WA12,Secretary of State,,D,Jean Schodorf,0
-Sedgwick,BA01,Attorney General,,R,Derek Schmidt,770
-Sedgwick,BA02,Attorney General,,R,Derek Schmidt,654
-Sedgwick,BA03,Attorney General,,R,Derek Schmidt,482
-Sedgwick,DB11,Attorney General,,R,Derek Schmidt,711
-Sedgwick,DB12,Attorney General,,R,Derek Schmidt,369
-Sedgwick,DB14,Attorney General,,R,Derek Schmidt,273
-Sedgwick,DB15,Attorney General,,R,Derek Schmidt,27
-Sedgwick,DB21,Attorney General,,R,Derek Schmidt,362
-Sedgwick,DB22,Attorney General,,R,Derek Schmidt,410
-Sedgwick,DB23,Attorney General,,R,Derek Schmidt,514
-Sedgwick,DB24,Attorney General,,R,Derek Schmidt,95
-Sedgwick,DB25,Attorney General,,R,Derek Schmidt,25
-Sedgwick,DB31,Attorney General,,R,Derek Schmidt,154
-Sedgwick,DB32,Attorney General,,R,Derek Schmidt,458
-Sedgwick,DB36,Attorney General,,R,Derek Schmidt,618
-Sedgwick,DB37,Attorney General,,R,Derek Schmidt,80
-Sedgwick,DB41,Attorney General,,R,Derek Schmidt,277
-Sedgwick,DB42,Attorney General,,R,Derek Schmidt,1092
-Sedgwick,HA11,Attorney General,,R,Derek Schmidt,438
-Sedgwick,HA21,Attorney General,,R,Derek Schmidt,453
-Sedgwick,HA31,Attorney General,,R,Derek Schmidt,511
-Sedgwick,HA41,Attorney General,,R,Derek Schmidt,445
-Sedgwick,HA42,Attorney General,,R,Derek Schmidt,108
-Sedgwick,MV01,Attorney General,,R,Derek Schmidt,402
-Sedgwick,MV02,Attorney General,,R,Derek Schmidt,898
-Sedgwick,PC11,Attorney General,,R,Derek Schmidt,252
-Sedgwick,PC13,Attorney General,,R,Derek Schmidt,94
-Sedgwick,PC21,Attorney General,,R,Derek Schmidt,429
-Sedgwick,PC31,Attorney General,,R,Derek Schmidt,492
-Sedgwick,PC43,Attorney General,,R,Derek Schmidt,147
-Sedgwick,VC11,Attorney General,,R,Derek Schmidt,447
-Sedgwick,VC21,Attorney General,,R,Derek Schmidt,457
-Sedgwick,VC31,Attorney General,,R,Derek Schmidt,382
-Sedgwick,VC41,Attorney General,,R,Derek Schmidt,324
-Sedgwick,VC42,Attorney General,,R,Derek Schmidt,142
-Sedgwick,AF,Attorney General,,R,Derek Schmidt,507
-Sedgwick,AT02,Attorney General,,R,Derek Schmidt,76
-Sedgwick,AT03,Attorney General,,R,Derek Schmidt,383
-Sedgwick,AT04,Attorney General,,R,Derek Schmidt,2
-Sedgwick,AT05,Attorney General,,R,Derek Schmidt,158
-Sedgwick,AT06,Attorney General,,R,Derek Schmidt,41
-Sedgwick,AT08,Attorney General,,R,Derek Schmidt,33
-Sedgwick,DL03,Attorney General,,R,Derek Schmidt,1
-Sedgwick,DL04,Attorney General,,R,Derek Schmidt,0
-Sedgwick,EA,Attorney General,,R,Derek Schmidt,262
-Sedgwick,ER,Attorney General,,R,Derek Schmidt,28
-Sedgwick,GA,Attorney General,,R,Derek Schmidt,650
-Sedgwick,GD,Attorney General,,R,Derek Schmidt,196
-Sedgwick,GN01,Attorney General,,R,Derek Schmidt,501
-Sedgwick,GO,Attorney General,,R,Derek Schmidt,1026
-Sedgwick,GR,Attorney General,,R,Derek Schmidt,314
-Sedgwick,GY01,Attorney General,,R,Derek Schmidt,976
-Sedgwick,GY02,Attorney General,,R,Derek Schmidt,8
-Sedgwick,GY03,Attorney General,,R,Derek Schmidt,27
-Sedgwick,IL01,Attorney General,,R,Derek Schmidt,580
-Sedgwick,KE01,Attorney General,,R,Derek Schmidt,11
-Sedgwick,KE03,Attorney General,,R,Derek Schmidt,514
-Sedgwick,KE04,Attorney General,,R,Derek Schmidt,23
-Sedgwick,KE07,Attorney General,,R,Derek Schmidt,11
-Sedgwick,KE08,Attorney General,,R,Derek Schmidt,10
-Sedgwick,LI,Attorney General,,R,Derek Schmidt,200
-Sedgwick,MI01,Attorney General,,R,Derek Schmidt,847
-Sedgwick,MI02,Attorney General,,R,Derek Schmidt,322
-Sedgwick,MI03,Attorney General,,R,Derek Schmidt,10
-Sedgwick,MI04,Attorney General,,R,Derek Schmidt,2
-Sedgwick,MI05,Attorney General,,R,Derek Schmidt,0
-Sedgwick,MI07,Attorney General,,R,Derek Schmidt,5
-Sedgwick,MI09,Attorney General,,R,Derek Schmidt,155
-Sedgwick,MI14,Attorney General,,R,Derek Schmidt,74
-Sedgwick,MO,Attorney General,,R,Derek Schmidt,688
-Sedgwick,NI,Attorney General,,R,Derek Schmidt,653
-Sedgwick,NI01,Attorney General,,R,Derek Schmidt,159
-Sedgwick,OH01,Attorney General,,R,Derek Schmidt,412
-Sedgwick,PA01,Attorney General,,R,Derek Schmidt,180
-Sedgwick,PA02,Attorney General,,R,Derek Schmidt,87
-Sedgwick,PA05,Attorney General,,R,Derek Schmidt,802
-Sedgwick,PA06,Attorney General,,R,Derek Schmidt,39
-Sedgwick,PA09,Attorney General,,R,Derek Schmidt,7
-Sedgwick,PY01,Attorney General,,R,Derek Schmidt,361
-Sedgwick,RI01,Attorney General,,R,Derek Schmidt,27
-Sedgwick,RI03,Attorney General,,R,Derek Schmidt,131
-Sedgwick,RI06,Attorney General,,R,Derek Schmidt,89
-Sedgwick,RI07,Attorney General,,R,Derek Schmidt,132
-Sedgwick,RI13,Attorney General,,R,Derek Schmidt,5
-Sedgwick,RO01,Attorney General,,R,Derek Schmidt,285
-Sedgwick,RO03,Attorney General,,R,Derek Schmidt,189
-Sedgwick,SA01,Attorney General,,R,Derek Schmidt,583
-Sedgwick,SA02,Attorney General,,R,Derek Schmidt,385
-Sedgwick,SH,Attorney General,,R,Derek Schmidt,485
-Sedgwick,UN01,Attorney General,,R,Derek Schmidt,718
-Sedgwick,UN02,Attorney General,,R,Derek Schmidt,49
-Sedgwick,VA,Attorney General,,R,Derek Schmidt,302
-Sedgwick,VI,Attorney General,,R,Derek Schmidt,148
-Sedgwick,WA01,Attorney General,,R,Derek Schmidt,47
-Sedgwick,WA02,Attorney General,,R,Derek Schmidt,160
-Sedgwick,WA03,Attorney General,,R,Derek Schmidt,11
-Sedgwick,WA12,Attorney General,,R,Derek Schmidt,2
-Sedgwick,BA01,Attorney General,,D,A J Kotich,309
-Sedgwick,BA02,Attorney General,,D,A J Kotich,310
-Sedgwick,BA03,Attorney General,,D,A J Kotich,210
-Sedgwick,DB11,Attorney General,,D,A J Kotich,228
-Sedgwick,DB12,Attorney General,,D,A J Kotich,132
-Sedgwick,DB14,Attorney General,,D,A J Kotich,83
-Sedgwick,DB15,Attorney General,,D,A J Kotich,2
-Sedgwick,DB21,Attorney General,,D,A J Kotich,150
-Sedgwick,DB22,Attorney General,,D,A J Kotich,148
-Sedgwick,DB23,Attorney General,,D,A J Kotich,175
-Sedgwick,DB24,Attorney General,,D,A J Kotich,32
-Sedgwick,DB25,Attorney General,,D,A J Kotich,25
-Sedgwick,DB31,Attorney General,,D,A J Kotich,51
-Sedgwick,DB32,Attorney General,,D,A J Kotich,189
-Sedgwick,DB36,Attorney General,,D,A J Kotich,234
-Sedgwick,DB37,Attorney General,,D,A J Kotich,45
-Sedgwick,DB41,Attorney General,,D,A J Kotich,115
-Sedgwick,DB42,Attorney General,,D,A J Kotich,340
-Sedgwick,HA11,Attorney General,,D,A J Kotich,170
-Sedgwick,HA21,Attorney General,,D,A J Kotich,210
-Sedgwick,HA31,Attorney General,,D,A J Kotich,207
-Sedgwick,HA41,Attorney General,,D,A J Kotich,170
-Sedgwick,HA42,Attorney General,,D,A J Kotich,32
-Sedgwick,MV01,Attorney General,,D,A J Kotich,130
-Sedgwick,MV02,Attorney General,,D,A J Kotich,320
-Sedgwick,PC11,Attorney General,,D,A J Kotich,111
-Sedgwick,PC13,Attorney General,,D,A J Kotich,33
-Sedgwick,PC21,Attorney General,,D,A J Kotich,167
-Sedgwick,PC31,Attorney General,,D,A J Kotich,247
-Sedgwick,PC43,Attorney General,,D,A J Kotich,62
-Sedgwick,VC11,Attorney General,,D,A J Kotich,109
-Sedgwick,VC21,Attorney General,,D,A J Kotich,140
-Sedgwick,VC31,Attorney General,,D,A J Kotich,94
-Sedgwick,VC41,Attorney General,,D,A J Kotich,108
-Sedgwick,VC42,Attorney General,,D,A J Kotich,40
-Sedgwick,AF,Attorney General,,D,A J Kotich,104
-Sedgwick,AT02,Attorney General,,D,A J Kotich,26
-Sedgwick,AT03,Attorney General,,D,A J Kotich,85
-Sedgwick,AT04,Attorney General,,D,A J Kotich,1
-Sedgwick,AT05,Attorney General,,D,A J Kotich,43
-Sedgwick,AT06,Attorney General,,D,A J Kotich,4
-Sedgwick,AT08,Attorney General,,D,A J Kotich,11
-Sedgwick,DL03,Attorney General,,D,A J Kotich,1
-Sedgwick,DL04,Attorney General,,D,A J Kotich,0
-Sedgwick,EA,Attorney General,,D,A J Kotich,101
-Sedgwick,ER,Attorney General,,D,A J Kotich,7
-Sedgwick,GA,Attorney General,,D,A J Kotich,100
-Sedgwick,GD,Attorney General,,D,A J Kotich,28
-Sedgwick,GN01,Attorney General,,D,A J Kotich,125
-Sedgwick,GO,Attorney General,,D,A J Kotich,273
-Sedgwick,GR,Attorney General,,D,A J Kotich,60
-Sedgwick,GY01,Attorney General,,D,A J Kotich,298
-Sedgwick,GY02,Attorney General,,D,A J Kotich,9
-Sedgwick,GY03,Attorney General,,D,A J Kotich,12
-Sedgwick,IL01,Attorney General,,D,A J Kotich,112
-Sedgwick,KE01,Attorney General,,D,A J Kotich,1
-Sedgwick,KE03,Attorney General,,D,A J Kotich,198
-Sedgwick,KE04,Attorney General,,D,A J Kotich,12
-Sedgwick,KE07,Attorney General,,D,A J Kotich,7
-Sedgwick,KE08,Attorney General,,D,A J Kotich,1
-Sedgwick,LI,Attorney General,,D,A J Kotich,47
-Sedgwick,MI01,Attorney General,,D,A J Kotich,207
-Sedgwick,MI02,Attorney General,,D,A J Kotich,111
-Sedgwick,MI03,Attorney General,,D,A J Kotich,2
-Sedgwick,MI04,Attorney General,,D,A J Kotich,0
-Sedgwick,MI05,Attorney General,,D,A J Kotich,2
-Sedgwick,MI07,Attorney General,,D,A J Kotich,6
-Sedgwick,MI09,Attorney General,,D,A J Kotich,46
-Sedgwick,MI14,Attorney General,,D,A J Kotich,23
-Sedgwick,MO,Attorney General,,D,A J Kotich,189
-Sedgwick,NI,Attorney General,,D,A J Kotich,211
-Sedgwick,NI01,Attorney General,,D,A J Kotich,22
-Sedgwick,OH01,Attorney General,,D,A J Kotich,114
-Sedgwick,PA01,Attorney General,,D,A J Kotich,26
-Sedgwick,PA02,Attorney General,,D,A J Kotich,27
-Sedgwick,PA05,Attorney General,,D,A J Kotich,263
-Sedgwick,PA06,Attorney General,,D,A J Kotich,15
-Sedgwick,PA09,Attorney General,,D,A J Kotich,0
-Sedgwick,PY01,Attorney General,,D,A J Kotich,76
-Sedgwick,RI01,Attorney General,,D,A J Kotich,11
-Sedgwick,RI03,Attorney General,,D,A J Kotich,97
-Sedgwick,RI06,Attorney General,,D,A J Kotich,28
-Sedgwick,RI07,Attorney General,,D,A J Kotich,70
-Sedgwick,RI13,Attorney General,,D,A J Kotich,2
-Sedgwick,RO01,Attorney General,,D,A J Kotich,77
-Sedgwick,RO03,Attorney General,,D,A J Kotich,51
-Sedgwick,SA01,Attorney General,,D,A J Kotich,163
-Sedgwick,SA02,Attorney General,,D,A J Kotich,149
-Sedgwick,SH,Attorney General,,D,A J Kotich,86
-Sedgwick,UN01,Attorney General,,D,A J Kotich,84
-Sedgwick,UN02,Attorney General,,D,A J Kotich,9
-Sedgwick,VA,Attorney General,,D,A J Kotich,73
-Sedgwick,VI,Attorney General,,D,A J Kotich,36
-Sedgwick,WA01,Attorney General,,D,A J Kotich,5
-Sedgwick,WA02,Attorney General,,D,A J Kotich,44
-Sedgwick,WA03,Attorney General,,D,A J Kotich,1
-Sedgwick,WA12,Attorney General,,D,A J Kotich,0
-Sedgwick,BA01,State Treasurer,,R,Ron Estes,817
-Sedgwick,BA02,State Treasurer,,R,Ron Estes,686
-Sedgwick,BA03,State Treasurer,,R,Ron Estes,511
-Sedgwick,DB11,State Treasurer,,R,Ron Estes,750
-Sedgwick,DB12,State Treasurer,,R,Ron Estes,390
-Sedgwick,DB14,State Treasurer,,R,Ron Estes,279
-Sedgwick,DB15,State Treasurer,,R,Ron Estes,28
-Sedgwick,DB21,State Treasurer,,R,Ron Estes,389
-Sedgwick,DB22,State Treasurer,,R,Ron Estes,435
-Sedgwick,DB23,State Treasurer,,R,Ron Estes,542
-Sedgwick,DB24,State Treasurer,,R,Ron Estes,103
-Sedgwick,DB25,State Treasurer,,R,Ron Estes,32
-Sedgwick,DB31,State Treasurer,,R,Ron Estes,157
-Sedgwick,DB32,State Treasurer,,R,Ron Estes,488
-Sedgwick,DB36,State Treasurer,,R,Ron Estes,646
-Sedgwick,DB37,State Treasurer,,R,Ron Estes,88
-Sedgwick,DB41,State Treasurer,,R,Ron Estes,289
-Sedgwick,DB42,State Treasurer,,R,Ron Estes,1161
-Sedgwick,HA11,State Treasurer,,R,Ron Estes,454
-Sedgwick,HA21,State Treasurer,,R,Ron Estes,509
-Sedgwick,HA31,State Treasurer,,R,Ron Estes,556
-Sedgwick,HA41,State Treasurer,,R,Ron Estes,481
-Sedgwick,HA42,State Treasurer,,R,Ron Estes,111
-Sedgwick,MV01,State Treasurer,,R,Ron Estes,429
-Sedgwick,MV02,State Treasurer,,R,Ron Estes,944
-Sedgwick,PC11,State Treasurer,,R,Ron Estes,266
-Sedgwick,PC13,State Treasurer,,R,Ron Estes,95
-Sedgwick,PC21,State Treasurer,,R,Ron Estes,450
-Sedgwick,PC31,State Treasurer,,R,Ron Estes,505
-Sedgwick,PC43,State Treasurer,,R,Ron Estes,157
-Sedgwick,VC11,State Treasurer,,R,Ron Estes,446
-Sedgwick,VC21,State Treasurer,,R,Ron Estes,482
-Sedgwick,VC31,State Treasurer,,R,Ron Estes,397
-Sedgwick,VC41,State Treasurer,,R,Ron Estes,342
-Sedgwick,VC42,State Treasurer,,R,Ron Estes,148
-Sedgwick,AF,State Treasurer,,R,Ron Estes,522
-Sedgwick,AT02,State Treasurer,,R,Ron Estes,83
-Sedgwick,AT03,State Treasurer,,R,Ron Estes,400
-Sedgwick,AT04,State Treasurer,,R,Ron Estes,2
-Sedgwick,AT05,State Treasurer,,R,Ron Estes,166
-Sedgwick,AT06,State Treasurer,,R,Ron Estes,41
-Sedgwick,AT08,State Treasurer,,R,Ron Estes,36
-Sedgwick,DL03,State Treasurer,,R,Ron Estes,2
-Sedgwick,DL04,State Treasurer,,R,Ron Estes,1
-Sedgwick,EA,State Treasurer,,R,Ron Estes,277
-Sedgwick,ER,State Treasurer,,R,Ron Estes,31
-Sedgwick,GA,State Treasurer,,R,Ron Estes,667
-Sedgwick,GD,State Treasurer,,R,Ron Estes,203
-Sedgwick,GN01,State Treasurer,,R,Ron Estes,518
-Sedgwick,GO,State Treasurer,,R,Ron Estes,1051
-Sedgwick,GR,State Treasurer,,R,Ron Estes,320
-Sedgwick,GY01,State Treasurer,,R,Ron Estes,1036
-Sedgwick,GY02,State Treasurer,,R,Ron Estes,8
-Sedgwick,GY03,State Treasurer,,R,Ron Estes,27
-Sedgwick,IL01,State Treasurer,,R,Ron Estes,585
-Sedgwick,KE01,State Treasurer,,R,Ron Estes,12
-Sedgwick,KE03,State Treasurer,,R,Ron Estes,555
-Sedgwick,KE04,State Treasurer,,R,Ron Estes,24
-Sedgwick,KE07,State Treasurer,,R,Ron Estes,12
-Sedgwick,KE08,State Treasurer,,R,Ron Estes,9
-Sedgwick,LI,State Treasurer,,R,Ron Estes,214
-Sedgwick,MI01,State Treasurer,,R,Ron Estes,873
-Sedgwick,MI02,State Treasurer,,R,Ron Estes,336
-Sedgwick,MI03,State Treasurer,,R,Ron Estes,9
-Sedgwick,MI04,State Treasurer,,R,Ron Estes,2
-Sedgwick,MI05,State Treasurer,,R,Ron Estes,0
-Sedgwick,MI07,State Treasurer,,R,Ron Estes,7
-Sedgwick,MI09,State Treasurer,,R,Ron Estes,157
-Sedgwick,MI14,State Treasurer,,R,Ron Estes,80
-Sedgwick,MO,State Treasurer,,R,Ron Estes,719
-Sedgwick,NI,State Treasurer,,R,Ron Estes,697
-Sedgwick,NI01,State Treasurer,,R,Ron Estes,163
-Sedgwick,OH01,State Treasurer,,R,Ron Estes,430
-Sedgwick,PA01,State Treasurer,,R,Ron Estes,175
-Sedgwick,PA02,State Treasurer,,R,Ron Estes,88
-Sedgwick,PA05,State Treasurer,,R,Ron Estes,825
-Sedgwick,PA06,State Treasurer,,R,Ron Estes,41
-Sedgwick,PA09,State Treasurer,,R,Ron Estes,7
-Sedgwick,PY01,State Treasurer,,R,Ron Estes,373
-Sedgwick,RI01,State Treasurer,,R,Ron Estes,31
-Sedgwick,RI03,State Treasurer,,R,Ron Estes,140
-Sedgwick,RI06,State Treasurer,,R,Ron Estes,99
-Sedgwick,RI07,State Treasurer,,R,Ron Estes,137
-Sedgwick,RI13,State Treasurer,,R,Ron Estes,4
-Sedgwick,RO01,State Treasurer,,R,Ron Estes,303
-Sedgwick,RO03,State Treasurer,,R,Ron Estes,192
-Sedgwick,SA01,State Treasurer,,R,Ron Estes,616
-Sedgwick,SA02,State Treasurer,,R,Ron Estes,401
-Sedgwick,SH,State Treasurer,,R,Ron Estes,495
-Sedgwick,UN01,State Treasurer,,R,Ron Estes,739
-Sedgwick,UN02,State Treasurer,,R,Ron Estes,52
-Sedgwick,VA,State Treasurer,,R,Ron Estes,301
-Sedgwick,VI,State Treasurer,,R,Ron Estes,154
-Sedgwick,WA01,State Treasurer,,R,Ron Estes,44
-Sedgwick,WA02,State Treasurer,,R,Ron Estes,174
-Sedgwick,WA03,State Treasurer,,R,Ron Estes,11
-Sedgwick,WA12,State Treasurer,,R,Ron Estes,2
-Sedgwick,BA01,State Treasurer,,D,Carmen Alldritt,275
-Sedgwick,BA02,State Treasurer,,D,Carmen Alldritt,279
-Sedgwick,BA03,State Treasurer,,D,Carmen Alldritt,181
-Sedgwick,DB11,State Treasurer,,D,Carmen Alldritt,194
-Sedgwick,DB12,State Treasurer,,D,Carmen Alldritt,113
-Sedgwick,DB14,State Treasurer,,D,Carmen Alldritt,75
-Sedgwick,DB15,State Treasurer,,D,Carmen Alldritt,1
-Sedgwick,DB21,State Treasurer,,D,Carmen Alldritt,129
-Sedgwick,DB22,State Treasurer,,D,Carmen Alldritt,124
-Sedgwick,DB23,State Treasurer,,D,Carmen Alldritt,161
-Sedgwick,DB24,State Treasurer,,D,Carmen Alldritt,25
-Sedgwick,DB25,State Treasurer,,D,Carmen Alldritt,18
-Sedgwick,DB31,State Treasurer,,D,Carmen Alldritt,46
-Sedgwick,DB32,State Treasurer,,D,Carmen Alldritt,170
-Sedgwick,DB36,State Treasurer,,D,Carmen Alldritt,218
-Sedgwick,DB37,State Treasurer,,D,Carmen Alldritt,39
-Sedgwick,DB41,State Treasurer,,D,Carmen Alldritt,105
-Sedgwick,DB42,State Treasurer,,D,Carmen Alldritt,273
-Sedgwick,HA11,State Treasurer,,D,Carmen Alldritt,158
-Sedgwick,HA21,State Treasurer,,D,Carmen Alldritt,163
-Sedgwick,HA31,State Treasurer,,D,Carmen Alldritt,171
-Sedgwick,HA41,State Treasurer,,D,Carmen Alldritt,137
-Sedgwick,HA42,State Treasurer,,D,Carmen Alldritt,25
-Sedgwick,MV01,State Treasurer,,D,Carmen Alldritt,112
-Sedgwick,MV02,State Treasurer,,D,Carmen Alldritt,288
-Sedgwick,PC11,State Treasurer,,D,Carmen Alldritt,102
-Sedgwick,PC13,State Treasurer,,D,Carmen Alldritt,33
-Sedgwick,PC21,State Treasurer,,D,Carmen Alldritt,149
-Sedgwick,PC31,State Treasurer,,D,Carmen Alldritt,231
-Sedgwick,PC43,State Treasurer,,D,Carmen Alldritt,54
-Sedgwick,VC11,State Treasurer,,D,Carmen Alldritt,109
-Sedgwick,VC21,State Treasurer,,D,Carmen Alldritt,121
-Sedgwick,VC31,State Treasurer,,D,Carmen Alldritt,82
-Sedgwick,VC41,State Treasurer,,D,Carmen Alldritt,94
-Sedgwick,VC42,State Treasurer,,D,Carmen Alldritt,37
-Sedgwick,AF,State Treasurer,,D,Carmen Alldritt,96
-Sedgwick,AT02,State Treasurer,,D,Carmen Alldritt,21
-Sedgwick,AT03,State Treasurer,,D,Carmen Alldritt,73
-Sedgwick,AT04,State Treasurer,,D,Carmen Alldritt,1
-Sedgwick,AT05,State Treasurer,,D,Carmen Alldritt,40
-Sedgwick,AT06,State Treasurer,,D,Carmen Alldritt,3
-Sedgwick,AT08,State Treasurer,,D,Carmen Alldritt,10
-Sedgwick,DL03,State Treasurer,,D,Carmen Alldritt,0
-Sedgwick,DL04,State Treasurer,,D,Carmen Alldritt,0
-Sedgwick,EA,State Treasurer,,D,Carmen Alldritt,92
-Sedgwick,ER,State Treasurer,,D,Carmen Alldritt,7
-Sedgwick,GA,State Treasurer,,D,Carmen Alldritt,92
-Sedgwick,GD,State Treasurer,,D,Carmen Alldritt,23
-Sedgwick,GN01,State Treasurer,,D,Carmen Alldritt,107
-Sedgwick,GO,State Treasurer,,D,Carmen Alldritt,249
-Sedgwick,GR,State Treasurer,,D,Carmen Alldritt,57
-Sedgwick,GY01,State Treasurer,,D,Carmen Alldritt,247
-Sedgwick,GY02,State Treasurer,,D,Carmen Alldritt,9
-Sedgwick,GY03,State Treasurer,,D,Carmen Alldritt,12
-Sedgwick,IL01,State Treasurer,,D,Carmen Alldritt,112
-Sedgwick,KE01,State Treasurer,,D,Carmen Alldritt,0
-Sedgwick,KE03,State Treasurer,,D,Carmen Alldritt,170
-Sedgwick,KE04,State Treasurer,,D,Carmen Alldritt,12
-Sedgwick,KE07,State Treasurer,,D,Carmen Alldritt,6
-Sedgwick,KE08,State Treasurer,,D,Carmen Alldritt,1
-Sedgwick,LI,State Treasurer,,D,Carmen Alldritt,34
-Sedgwick,MI01,State Treasurer,,D,Carmen Alldritt,180
-Sedgwick,MI02,State Treasurer,,D,Carmen Alldritt,104
-Sedgwick,MI03,State Treasurer,,D,Carmen Alldritt,2
-Sedgwick,MI04,State Treasurer,,D,Carmen Alldritt,0
-Sedgwick,MI05,State Treasurer,,D,Carmen Alldritt,2
-Sedgwick,MI07,State Treasurer,,D,Carmen Alldritt,4
-Sedgwick,MI09,State Treasurer,,D,Carmen Alldritt,48
-Sedgwick,MI14,State Treasurer,,D,Carmen Alldritt,18
-Sedgwick,MO,State Treasurer,,D,Carmen Alldritt,159
-Sedgwick,NI,State Treasurer,,D,Carmen Alldritt,174
-Sedgwick,NI01,State Treasurer,,D,Carmen Alldritt,24
-Sedgwick,OH01,State Treasurer,,D,Carmen Alldritt,99
-Sedgwick,PA01,State Treasurer,,D,Carmen Alldritt,31
-Sedgwick,PA02,State Treasurer,,D,Carmen Alldritt,25
-Sedgwick,PA05,State Treasurer,,D,Carmen Alldritt,232
-Sedgwick,PA06,State Treasurer,,D,Carmen Alldritt,14
-Sedgwick,PA09,State Treasurer,,D,Carmen Alldritt,0
-Sedgwick,PY01,State Treasurer,,D,Carmen Alldritt,66
-Sedgwick,RI01,State Treasurer,,D,Carmen Alldritt,8
-Sedgwick,RI03,State Treasurer,,D,Carmen Alldritt,93
-Sedgwick,RI06,State Treasurer,,D,Carmen Alldritt,18
-Sedgwick,RI07,State Treasurer,,D,Carmen Alldritt,64
-Sedgwick,RI13,State Treasurer,,D,Carmen Alldritt,3
-Sedgwick,RO01,State Treasurer,,D,Carmen Alldritt,63
-Sedgwick,RO03,State Treasurer,,D,Carmen Alldritt,48
-Sedgwick,SA01,State Treasurer,,D,Carmen Alldritt,146
-Sedgwick,SA02,State Treasurer,,D,Carmen Alldritt,136
-Sedgwick,SH,State Treasurer,,D,Carmen Alldritt,85
-Sedgwick,UN01,State Treasurer,,D,Carmen Alldritt,69
-Sedgwick,UN02,State Treasurer,,D,Carmen Alldritt,4
-Sedgwick,VA,State Treasurer,,D,Carmen Alldritt,81
-Sedgwick,VI,State Treasurer,,D,Carmen Alldritt,31
-Sedgwick,WA01,State Treasurer,,D,Carmen Alldritt,6
-Sedgwick,WA02,State Treasurer,,D,Carmen Alldritt,32
-Sedgwick,WA03,State Treasurer,,D,Carmen Alldritt,1
-Sedgwick,WA12,State Treasurer,,D,Carmen Alldritt,0
-Sedgwick,BA01,Insurance Commissioner,,R,Ron Selzer,699
-Sedgwick,BA02,Insurance Commissioner,,R,Ron Selzer,586
-Sedgwick,BA03,Insurance Commissioner,,R,Ron Selzer,446
-Sedgwick,DB11,Insurance Commissioner,,R,Ron Selzer,653
-Sedgwick,DB12,Insurance Commissioner,,R,Ron Selzer,325
-Sedgwick,DB14,Insurance Commissioner,,R,Ron Selzer,243
-Sedgwick,DB15,Insurance Commissioner,,R,Ron Selzer,26
-Sedgwick,DB21,Insurance Commissioner,,R,Ron Selzer,333
-Sedgwick,DB22,Insurance Commissioner,,R,Ron Selzer,361
-Sedgwick,DB23,Insurance Commissioner,,R,Ron Selzer,469
-Sedgwick,DB24,Insurance Commissioner,,R,Ron Selzer,88
-Sedgwick,DB25,Insurance Commissioner,,R,Ron Selzer,26
-Sedgwick,DB31,Insurance Commissioner,,R,Ron Selzer,141
-Sedgwick,DB32,Insurance Commissioner,,R,Ron Selzer,405
-Sedgwick,DB36,Insurance Commissioner,,R,Ron Selzer,547
-Sedgwick,DB37,Insurance Commissioner,,R,Ron Selzer,77
-Sedgwick,DB41,Insurance Commissioner,,R,Ron Selzer,244
-Sedgwick,DB42,Insurance Commissioner,,R,Ron Selzer,996
-Sedgwick,HA11,Insurance Commissioner,,R,Ron Selzer,381
-Sedgwick,HA21,Insurance Commissioner,,R,Ron Selzer,414
-Sedgwick,HA31,Insurance Commissioner,,R,Ron Selzer,453
-Sedgwick,HA41,Insurance Commissioner,,R,Ron Selzer,400
-Sedgwick,HA42,Insurance Commissioner,,R,Ron Selzer,100
-Sedgwick,MV01,Insurance Commissioner,,R,Ron Selzer,352
-Sedgwick,MV02,Insurance Commissioner,,R,Ron Selzer,789
-Sedgwick,PC11,Insurance Commissioner,,R,Ron Selzer,233
-Sedgwick,PC13,Insurance Commissioner,,R,Ron Selzer,81
-Sedgwick,PC21,Insurance Commissioner,,R,Ron Selzer,384
-Sedgwick,PC31,Insurance Commissioner,,R,Ron Selzer,420
-Sedgwick,PC43,Insurance Commissioner,,R,Ron Selzer,134
-Sedgwick,VC11,Insurance Commissioner,,R,Ron Selzer,396
-Sedgwick,VC21,Insurance Commissioner,,R,Ron Selzer,396
-Sedgwick,VC31,Insurance Commissioner,,R,Ron Selzer,343
-Sedgwick,VC41,Insurance Commissioner,,R,Ron Selzer,296
-Sedgwick,VC42,Insurance Commissioner,,R,Ron Selzer,134
-Sedgwick,AF,Insurance Commissioner,,R,Ron Selzer,450
-Sedgwick,AT02,Insurance Commissioner,,R,Ron Selzer,59
-Sedgwick,AT03,Insurance Commissioner,,R,Ron Selzer,354
-Sedgwick,AT04,Insurance Commissioner,,R,Ron Selzer,2
-Sedgwick,AT05,Insurance Commissioner,,R,Ron Selzer,153
-Sedgwick,AT06,Insurance Commissioner,,R,Ron Selzer,40
-Sedgwick,AT08,Insurance Commissioner,,R,Ron Selzer,33
-Sedgwick,DL03,Insurance Commissioner,,R,Ron Selzer,1
-Sedgwick,DL04,Insurance Commissioner,,R,Ron Selzer,1
-Sedgwick,EA,Insurance Commissioner,,R,Ron Selzer,234
-Sedgwick,ER,Insurance Commissioner,,R,Ron Selzer,26
-Sedgwick,GA,Insurance Commissioner,,R,Ron Selzer,602
-Sedgwick,GD,Insurance Commissioner,,R,Ron Selzer,177
-Sedgwick,GN01,Insurance Commissioner,,R,Ron Selzer,463
-Sedgwick,GO,Insurance Commissioner,,R,Ron Selzer,950
-Sedgwick,GR,Insurance Commissioner,,R,Ron Selzer,287
-Sedgwick,GY01,Insurance Commissioner,,R,Ron Selzer,915
-Sedgwick,GY02,Insurance Commissioner,,R,Ron Selzer,8
-Sedgwick,GY03,Insurance Commissioner,,R,Ron Selzer,26
-Sedgwick,IL01,Insurance Commissioner,,R,Ron Selzer,523
-Sedgwick,KE01,Insurance Commissioner,,R,Ron Selzer,11
-Sedgwick,KE03,Insurance Commissioner,,R,Ron Selzer,473
-Sedgwick,KE04,Insurance Commissioner,,R,Ron Selzer,20
-Sedgwick,KE07,Insurance Commissioner,,R,Ron Selzer,12
-Sedgwick,KE08,Insurance Commissioner,,R,Ron Selzer,8
-Sedgwick,LI,Insurance Commissioner,,R,Ron Selzer,192
-Sedgwick,MI01,Insurance Commissioner,,R,Ron Selzer,772
-Sedgwick,MI02,Insurance Commissioner,,R,Ron Selzer,298
-Sedgwick,MI03,Insurance Commissioner,,R,Ron Selzer,7
-Sedgwick,MI04,Insurance Commissioner,,R,Ron Selzer,2
-Sedgwick,MI05,Insurance Commissioner,,R,Ron Selzer,0
-Sedgwick,MI07,Insurance Commissioner,,R,Ron Selzer,5
-Sedgwick,MI09,Insurance Commissioner,,R,Ron Selzer,131
-Sedgwick,MI14,Insurance Commissioner,,R,Ron Selzer,68
-Sedgwick,MO,Insurance Commissioner,,R,Ron Selzer,596
-Sedgwick,NI,Insurance Commissioner,,R,Ron Selzer,603
-Sedgwick,NI01,Insurance Commissioner,,R,Ron Selzer,143
-Sedgwick,OH01,Insurance Commissioner,,R,Ron Selzer,374
-Sedgwick,PA01,Insurance Commissioner,,R,Ron Selzer,159
-Sedgwick,PA02,Insurance Commissioner,,R,Ron Selzer,75
-Sedgwick,PA05,Insurance Commissioner,,R,Ron Selzer,729
-Sedgwick,PA06,Insurance Commissioner,,R,Ron Selzer,32
-Sedgwick,PA09,Insurance Commissioner,,R,Ron Selzer,7
-Sedgwick,PY01,Insurance Commissioner,,R,Ron Selzer,324
-Sedgwick,RI01,Insurance Commissioner,,R,Ron Selzer,21
-Sedgwick,RI03,Insurance Commissioner,,R,Ron Selzer,108
-Sedgwick,RI06,Insurance Commissioner,,R,Ron Selzer,76
-Sedgwick,RI07,Insurance Commissioner,,R,Ron Selzer,108
-Sedgwick,RI13,Insurance Commissioner,,R,Ron Selzer,5
-Sedgwick,RO01,Insurance Commissioner,,R,Ron Selzer,261
-Sedgwick,RO03,Insurance Commissioner,,R,Ron Selzer,164
-Sedgwick,SA01,Insurance Commissioner,,R,Ron Selzer,506
-Sedgwick,SA02,Insurance Commissioner,,R,Ron Selzer,344
-Sedgwick,SH,Insurance Commissioner,,R,Ron Selzer,415
-Sedgwick,UN01,Insurance Commissioner,,R,Ron Selzer,664
-Sedgwick,UN02,Insurance Commissioner,,R,Ron Selzer,46
-Sedgwick,VA,Insurance Commissioner,,R,Ron Selzer,267
-Sedgwick,VI,Insurance Commissioner,,R,Ron Selzer,133
-Sedgwick,WA01,Insurance Commissioner,,R,Ron Selzer,41
-Sedgwick,WA02,Insurance Commissioner,,R,Ron Selzer,143
-Sedgwick,WA03,Insurance Commissioner,,R,Ron Selzer,8
-Sedgwick,WA12,Insurance Commissioner,,R,Ron Selzer,0
-Sedgwick,BA01,Insurance Commissioner,,D,Dennis Anderson,372
-Sedgwick,BA02,Insurance Commissioner,,D,Dennis Anderson,348
-Sedgwick,BA03,Insurance Commissioner,,D,Dennis Anderson,230
-Sedgwick,DB11,Insurance Commissioner,,D,Dennis Anderson,271
-Sedgwick,DB12,Insurance Commissioner,,D,Dennis Anderson,163
-Sedgwick,DB14,Insurance Commissioner,,D,Dennis Anderson,103
-Sedgwick,DB15,Insurance Commissioner,,D,Dennis Anderson,3
-Sedgwick,DB21,Insurance Commissioner,,D,Dennis Anderson,152
-Sedgwick,DB22,Insurance Commissioner,,D,Dennis Anderson,180
-Sedgwick,DB23,Insurance Commissioner,,D,Dennis Anderson,211
-Sedgwick,DB24,Insurance Commissioner,,D,Dennis Anderson,34
-Sedgwick,DB25,Insurance Commissioner,,D,Dennis Anderson,23
-Sedgwick,DB31,Insurance Commissioner,,D,Dennis Anderson,54
-Sedgwick,DB32,Insurance Commissioner,,D,Dennis Anderson,222
-Sedgwick,DB36,Insurance Commissioner,,D,Dennis Anderson,279
-Sedgwick,DB37,Insurance Commissioner,,D,Dennis Anderson,47
-Sedgwick,DB41,Insurance Commissioner,,D,Dennis Anderson,140
-Sedgwick,DB42,Insurance Commissioner,,D,Dennis Anderson,401
-Sedgwick,HA11,Insurance Commissioner,,D,Dennis Anderson,215
-Sedgwick,HA21,Insurance Commissioner,,D,Dennis Anderson,235
-Sedgwick,HA31,Insurance Commissioner,,D,Dennis Anderson,252
-Sedgwick,HA41,Insurance Commissioner,,D,Dennis Anderson,200
-Sedgwick,HA42,Insurance Commissioner,,D,Dennis Anderson,33
-Sedgwick,MV01,Insurance Commissioner,,D,Dennis Anderson,170
-Sedgwick,MV02,Insurance Commissioner,,D,Dennis Anderson,395
-Sedgwick,PC11,Insurance Commissioner,,D,Dennis Anderson,117
-Sedgwick,PC13,Insurance Commissioner,,D,Dennis Anderson,40
-Sedgwick,PC21,Insurance Commissioner,,D,Dennis Anderson,188
-Sedgwick,PC31,Insurance Commissioner,,D,Dennis Anderson,287
-Sedgwick,PC43,Insurance Commissioner,,D,Dennis Anderson,67
-Sedgwick,VC11,Insurance Commissioner,,D,Dennis Anderson,145
-Sedgwick,VC21,Insurance Commissioner,,D,Dennis Anderson,191
-Sedgwick,VC31,Insurance Commissioner,,D,Dennis Anderson,129
-Sedgwick,VC41,Insurance Commissioner,,D,Dennis Anderson,121
-Sedgwick,VC42,Insurance Commissioner,,D,Dennis Anderson,48
-Sedgwick,AF,Insurance Commissioner,,D,Dennis Anderson,137
-Sedgwick,AT02,Insurance Commissioner,,D,Dennis Anderson,39
-Sedgwick,AT03,Insurance Commissioner,,D,Dennis Anderson,100
-Sedgwick,AT04,Insurance Commissioner,,D,Dennis Anderson,1
-Sedgwick,AT05,Insurance Commissioner,,D,Dennis Anderson,39
-Sedgwick,AT06,Insurance Commissioner,,D,Dennis Anderson,4
-Sedgwick,AT08,Insurance Commissioner,,D,Dennis Anderson,11
-Sedgwick,DL03,Insurance Commissioner,,D,Dennis Anderson,1
-Sedgwick,DL04,Insurance Commissioner,,D,Dennis Anderson,0
-Sedgwick,EA,Insurance Commissioner,,D,Dennis Anderson,115
-Sedgwick,ER,Insurance Commissioner,,D,Dennis Anderson,9
-Sedgwick,GA,Insurance Commissioner,,D,Dennis Anderson,124
-Sedgwick,GD,Insurance Commissioner,,D,Dennis Anderson,41
-Sedgwick,GN01,Insurance Commissioner,,D,Dennis Anderson,149
-Sedgwick,GO,Insurance Commissioner,,D,Dennis Anderson,315
-Sedgwick,GR,Insurance Commissioner,,D,Dennis Anderson,74
-Sedgwick,GY01,Insurance Commissioner,,D,Dennis Anderson,338
-Sedgwick,GY02,Insurance Commissioner,,D,Dennis Anderson,9
-Sedgwick,GY03,Insurance Commissioner,,D,Dennis Anderson,13
-Sedgwick,IL01,Insurance Commissioner,,D,Dennis Anderson,148
-Sedgwick,KE01,Insurance Commissioner,,D,Dennis Anderson,1
-Sedgwick,KE03,Insurance Commissioner,,D,Dennis Anderson,216
-Sedgwick,KE04,Insurance Commissioner,,D,Dennis Anderson,16
-Sedgwick,KE07,Insurance Commissioner,,D,Dennis Anderson,6
-Sedgwick,KE08,Insurance Commissioner,,D,Dennis Anderson,2
-Sedgwick,LI,Insurance Commissioner,,D,Dennis Anderson,52
-Sedgwick,MI01,Insurance Commissioner,,D,Dennis Anderson,247
-Sedgwick,MI02,Insurance Commissioner,,D,Dennis Anderson,131
-Sedgwick,MI03,Insurance Commissioner,,D,Dennis Anderson,4
-Sedgwick,MI04,Insurance Commissioner,,D,Dennis Anderson,0
-Sedgwick,MI05,Insurance Commissioner,,D,Dennis Anderson,2
-Sedgwick,MI07,Insurance Commissioner,,D,Dennis Anderson,6
-Sedgwick,MI09,Insurance Commissioner,,D,Dennis Anderson,66
-Sedgwick,MI14,Insurance Commissioner,,D,Dennis Anderson,29
-Sedgwick,MO,Insurance Commissioner,,D,Dennis Anderson,247
-Sedgwick,NI,Insurance Commissioner,,D,Dennis Anderson,234
-Sedgwick,NI01,Insurance Commissioner,,D,Dennis Anderson,34
-Sedgwick,OH01,Insurance Commissioner,,D,Dennis Anderson,137
-Sedgwick,PA01,Insurance Commissioner,,D,Dennis Anderson,41
-Sedgwick,PA02,Insurance Commissioner,,D,Dennis Anderson,35
-Sedgwick,PA05,Insurance Commissioner,,D,Dennis Anderson,299
-Sedgwick,PA06,Insurance Commissioner,,D,Dennis Anderson,23
-Sedgwick,PA09,Insurance Commissioner,,D,Dennis Anderson,0
-Sedgwick,PY01,Insurance Commissioner,,D,Dennis Anderson,99
-Sedgwick,RI01,Insurance Commissioner,,D,Dennis Anderson,14
-Sedgwick,RI03,Insurance Commissioner,,D,Dennis Anderson,116
-Sedgwick,RI06,Insurance Commissioner,,D,Dennis Anderson,38
-Sedgwick,RI07,Insurance Commissioner,,D,Dennis Anderson,93
-Sedgwick,RI13,Insurance Commissioner,,D,Dennis Anderson,2
-Sedgwick,RO01,Insurance Commissioner,,D,Dennis Anderson,101
-Sedgwick,RO03,Insurance Commissioner,,D,Dennis Anderson,66
-Sedgwick,SA01,Insurance Commissioner,,D,Dennis Anderson,231
-Sedgwick,SA02,Insurance Commissioner,,D,Dennis Anderson,175
-Sedgwick,SH,Insurance Commissioner,,D,Dennis Anderson,128
-Sedgwick,UN01,Insurance Commissioner,,D,Dennis Anderson,109
-Sedgwick,UN02,Insurance Commissioner,,D,Dennis Anderson,10
-Sedgwick,VA,Insurance Commissioner,,D,Dennis Anderson,105
-Sedgwick,VI,Insurance Commissioner,,D,Dennis Anderson,47
-Sedgwick,WA01,Insurance Commissioner,,D,Dennis Anderson,8
-Sedgwick,WA02,Insurance Commissioner,,D,Dennis Anderson,55
-Sedgwick,WA03,Insurance Commissioner,,D,Dennis Anderson,4
-Sedgwick,WA12,Insurance Commissioner,,D,Dennis Anderson,1
-Sedgwick,AF,State House,93,R,John Whitmer,419
-Sedgwick,AT02,State House,93,R,John Whitmer,63
-Sedgwick,AT03,State House,101,R,Joe Seiwert,402
-Sedgwick,AT04,State House,94,R,Mario Goico,2
-Sedgwick,AT05,State House,94,R,Mario Goico,157
-Sedgwick,AT06,State House,101,R,Joe Seiwert,40
-Sedgwick,AT08,State House,101,R,Joe Seiwert,37
-Sedgwick,BA01,State House,89,R,Frank Chappell,711
-Sedgwick,BA02,State House,89,R,Frank Chappell,591
-Sedgwick,BA03,State House,85,R,Steven Brunk,462
-Sedgwick,DB11,State House,81,R,Blake Carpenter,607
-Sedgwick,DB12,State House,81,R,Blake Carpenter,308
-Sedgwick,DB14,State House,81,R,Blake Carpenter,227
-Sedgwick,DB15,State House,81,R,Blake Carpenter,26
-Sedgwick,DB21,State House,82,R,Pete DeGraaf,335
-Sedgwick,DB22,State House,82,R,Pete DeGraaf,344
-Sedgwick,DB23,State House,81,R,Blake Carpenter,430
-Sedgwick,DB24,State House,81,R,Blake Carpenter,82
-Sedgwick,DB25,State House,82,R,Pete DeGraaf,21
-Sedgwick,DB31,State House,82,R,Pete DeGraaf,136
-Sedgwick,DB32,State House,82,R,Pete DeGraaf,404
-Sedgwick,DB36,State House,82,R,Pete DeGraaf,519
-Sedgwick,DB37,State House,82,R,Pete DeGraaf,70
-Sedgwick,DB41,State House,82,R,Pete DeGraaf,241
-Sedgwick,DB42,State House,82,R,Pete DeGraaf,971
-Sedgwick,DL02,State House,100,R,Dan Hawkins,0
-Sedgwick,DL03,State House,97,R,Leslie G. Osterman,2
-Sedgwick,DL04,State House,94,R,Mario Goico,1
-Sedgwick,EA,State House,90,R,Steve Huebert,287
-Sedgwick,ER,State House,93,R,John Whitmer,22
-Sedgwick,GA,State House,101,R,Joe Seiwert,677
-Sedgwick,GD,State House,101,R,Joe Seiwert,197
-Sedgwick,GN01,State House,90,R,Steve Huebert,523
-Sedgwick,GO,State House,101,R,Joe Seiwert,1071
-Sedgwick,GR,State House,90,R,Steve Huebert,303
-Sedgwick,GY01,State House,81,R,Blake Carpenter,871
-Sedgwick,GY02,State House,81,R,Blake Carpenter,9
-Sedgwick,GY03,State House,81,R,Blake Carpenter,24
-Sedgwick,HA11,State House,98,R,Steven Anthimides,319
-Sedgwick,HA21,State House,98,R,Steven Anthimides,331
-Sedgwick,HA31,State House,93,R,John Whitmer,453
-Sedgwick,HA41,State House,93,R,John Whitmer,394
-Sedgwick,HA42,State House,93,R,John Whitmer,99
-Sedgwick,IL01,State House,93,R,John Whitmer,505
-Sedgwick,KE01,State House,89,R,Frank Chappell,11
-Sedgwick,KE03,State House,91,R,Gene Suellentrop,541
-Sedgwick,KE04,State House,91,R,Gene Suellentrop,23
-Sedgwick,KE07,State House,91,R,Gene Suellentrop,15
-Sedgwick,KE08,State House,89,R,Frank Chappell,9
-Sedgwick,LI,State House,90,R,Steve Huebert,206
-Sedgwick,MI01,State House,99,R,Dennis E. Hedke,794
-Sedgwick,MI02,State House,83,R,James Thomas,296
-Sedgwick,MI03,State House,99,R,Dennis E. Hedke,10
-Sedgwick,MI04,State House,87,R,Mark Kahrs,2
-Sedgwick,MI05,State House,87,R,Mark Kahrs,0
-Sedgwick,MI07,State House,85,R,Steven Brunk,6
-Sedgwick,MI09,State House,88,R,Joseph Scapa,125
-Sedgwick,MI14,State House,99,R,Dennis E. Hedke,79
-Sedgwick,MO,State House,93,R,John Whitmer,591
-Sedgwick,MV01,State House,82,R,Pete DeGraaf,292
-Sedgwick,MV02,State House,82,R,Pete DeGraaf,679
-Sedgwick,NI,State House,93,R,John Whitmer,587
-Sedgwick,NI01,State House,93,R,John Whitmer,135
-Sedgwick,OH01,State House,93,R,John Whitmer,358
-Sedgwick,PA01,State House,91,R,Gene Suellentrop,173
-Sedgwick,PA02,State House,91,R,Gene Suellentrop,91
-Sedgwick,PA05,State House,90,R,Steve Huebert,857
-Sedgwick,PA06,State House,100,R,Dan Hawkins,33
-Sedgwick,PA09,State House,91,R,Gene Suellentrop,7
-Sedgwick,PC11,State House,91,R,Gene Suellentrop,270
-Sedgwick,PC13,State House,90,R,Steve Huebert,105
-Sedgwick,PC21,State House,91,R,Gene Suellentrop,445
-Sedgwick,PC31,State House,91,R,Gene Suellentrop,519
-Sedgwick,PC43,State House,89,R,Frank Chappell,138
-Sedgwick,PY01,State House,85,R,Steven Brunk,339
-Sedgwick,RI01,State House,98,R,Steven Anthimides,18
-Sedgwick,RI03,State House,81,R,Blake Carpenter,85
-Sedgwick,RI06,State House,81,R,Blake Carpenter,77
-Sedgwick,RI07,State House,98,R,Steven Anthimides,101
-Sedgwick,RI13,State House,98,R,Steven Anthimides,2
-Sedgwick,RO01,State House,82,R,Pete DeGraaf,256
-Sedgwick,RO03,State House,82,R,Pete DeGraaf,144
-Sedgwick,SA01,State House,93,R,John Whitmer,505
-Sedgwick,SA02,State House,93,R,John Whitmer,338
-Sedgwick,SH,State House,90,R,Steve Huebert,452
-Sedgwick,UN01,State House,90,R,Steve Huebert,681
-Sedgwick,UN02,State House,90,R,Steve Huebert,50
-Sedgwick,VA,State House,90,R,Steve Huebert,313
-Sedgwick,VC11,State House,90,R,Steve Huebert,454
-Sedgwick,VC21,State House,90,R,Steve Huebert,478
-Sedgwick,VC31,State House,90,R,Steve Huebert,420
-Sedgwick,VC41,State House,90,R,Steve Huebert,371
-Sedgwick,VC42,State House,91,R,Gene Suellentrop,147
-Sedgwick,VI,State House,93,R,John Whitmer,114
-Sedgwick,WA01,State House,93,R,John Whitmer,35
-Sedgwick,WA02,State House,97,R,Leslie G. Osterman,173
-Sedgwick,WA03,State House,97,R,Leslie G. Osterman,10
-Sedgwick,WA12,State House,98,R,Steven Anthimides,2
-Sedgwick,AF,State House,93,D,Sammy Flaharty,176
-Sedgwick,AT02,State House,93,D,Sammy Flaharty,33
-Sedgwick,BA01,State House,89,D,Roderick A. Houston,362
-Sedgwick,BA02,State House,89,D,Roderick A. Houston,352
-Sedgwick,BA03,State House,85,D,Patrick Thorpe,219
-Sedgwick,DB11,State House,81,D,Lynn Wells,332
-Sedgwick,DB12,State House,81,D,Lynn Wells,193
-Sedgwick,DB14,State House,81,D,Lynn Wells,130
-Sedgwick,DB15,State House,81,D,Lynn Wells,3
-Sedgwick,DB21,State House,82,D,Danette Harris,168
-Sedgwick,DB22,State House,82,D,Danette Harris,195
-Sedgwick,DB23,State House,81,D,Lynn Wells,265
-Sedgwick,DB24,State House,81,D,Lynn Wells,44
-Sedgwick,DB25,State House,82,D,Danette Harris,27
-Sedgwick,DB31,State House,82,D,Danette Harris,66
-Sedgwick,DB32,State House,82,D,Danette Harris,236
-Sedgwick,DB36,State House,82,D,Danette Harris,314
-Sedgwick,DB37,State House,82,D,Danette Harris,55
-Sedgwick,DB41,State House,82,D,Danette Harris,140
-Sedgwick,DB42,State House,82,D,Danette Harris,445
-Sedgwick,DL02,State House,100,D,John W Willoughby,0
-Sedgwick,ER,State House,93,D,Sammy Flaharty,14
-Sedgwick,GY01,State House,81,D,Lynn Wells,382
-Sedgwick,GY02,State House,81,D,Lynn Wells,8
-Sedgwick,GY03,State House,81,D,Lynn Wells,15
-Sedgwick,HA11,State House,98,D,Steven G. Crum,306
-Sedgwick,HA21,State House,98,D,Steven G. Crum,349
-Sedgwick,HA31,State House,93,D,Sammy Flaharty,251
-Sedgwick,HA41,State House,93,D,Sammy Flaharty,214
-Sedgwick,HA42,State House,93,D,Sammy Flaharty,33
-Sedgwick,IL01,State House,93,D,Sammy Flaharty,163
-Sedgwick,KE01,State House,89,D,Roderick A. Houston,1
-Sedgwick,KE08,State House,89,D,Roderick A. Houston,0
-Sedgwick,MI02,State House,83,D,Carolyn Bridges,137
-Sedgwick,MI04,State House,87,D,Charles Jenney,0
-Sedgwick,MI05,State House,87,D,Charles Jenney,2
-Sedgwick,MI07,State House,85,D,Patrick Thorpe,5
-Sedgwick,MI09,State House,88,D,Patricia M. Sloop,79
-Sedgwick,MO,State House,93,D,Sammy Flaharty,281
-Sedgwick,MV01,State House,82,D,Danette Harris,248
-Sedgwick,MV02,State House,82,D,Danette Harris,542
-Sedgwick,NI,State House,93,D,Sammy Flaharty,262
-Sedgwick,NI01,State House,93,D,Sammy Flaharty,43
-Sedgwick,OH01,State House,93,D,Sammy Flaharty,155
-Sedgwick,PA06,State House,100,D,John W Willoughby,21
-Sedgwick,PC43,State House,89,D,Roderick A. Houston,68
-Sedgwick,PY01,State House,85,D,Patrick Thorpe,90
-Sedgwick,RI01,State House,98,D,Steven G. Crum,18
-Sedgwick,RI03,State House,81,D,Lynn Wells,146
-Sedgwick,RI06,State House,81,D,Lynn Wells,41
-Sedgwick,RI07,State House,98,D,Steven G. Crum,101
-Sedgwick,RI13,State House,98,D,Steven G. Crum,4
-Sedgwick,RO01,State House,82,D,Danette Harris,106
-Sedgwick,RO03,State House,82,D,Danette Harris,96
-Sedgwick,SA01,State House,93,D,Sammy Flaharty,225
-Sedgwick,SA02,State House,93,D,Sammy Flaharty,170
-Sedgwick,VI,State House,93,D,Sammy Flaharty,60
-Sedgwick,WA01,State House,93,D,Sammy Flaharty,14
-Sedgwick,WA12,State House,98,D,Steven G. Crum,0
-Sedgwick,AT03,U.S. Senate,,,Write-ins,1
-Sedgwick,BA01,U.S. Senate,,,Write-ins,2
-Sedgwick,BA02,U.S. Senate,,,Write-ins,2
-Sedgwick,BA03,U.S. Senate,,,Write-ins,1
-Sedgwick,DB11,U.S. Senate,,,Write-ins,2
-Sedgwick,DB12,U.S. Senate,,,Write-ins,1
-Sedgwick,DB23,U.S. Senate,,,Write-ins,1
-Sedgwick,DB25,U.S. Senate,,,Write-ins,1
-Sedgwick,DB32,U.S. Senate,,,Write-ins,2
-Sedgwick,DB36,U.S. Senate,,,Write-ins,2
-Sedgwick,DB37,U.S. Senate,,,Write-ins,1
-Sedgwick,DB41,U.S. Senate,,,Write-ins,2
-Sedgwick,DB42,U.S. Senate,,,Write-ins,2
-Sedgwick,EA,U.S. Senate,,,Write-ins,1
-Sedgwick,GR,U.S. Senate,,,Write-ins,1
-Sedgwick,HA21,U.S. Senate,,,Write-ins,1
-Sedgwick,HA41,U.S. Senate,,,Write-ins,1
-Sedgwick,KE03,U.S. Senate,,,Write-ins,1
-Sedgwick,MI09,U.S. Senate,,,Write-ins,1
-Sedgwick,MV01,U.S. Senate,,,Write-ins,1
-Sedgwick,MV02,U.S. Senate,,,Write-ins,3
-Sedgwick,PA02,U.S. Senate,,,Write-ins,1
-Sedgwick,PC21,U.S. Senate,,,Write-ins,1
-Sedgwick,PC31,U.S. Senate,,,Write-ins,1
-Sedgwick,PC43,U.S. Senate,,,Write-ins,1
-Sedgwick,SA01,U.S. Senate,,,Write-ins,1
-Sedgwick,UN01,U.S. Senate,,,Write-ins,2
-Sedgwick,VC21,U.S. Senate,,,Write-ins,3
-Sedgwick,VC41,U.S. Senate,,,Write-ins,3
-Sedgwick,AT03,U.S. Senate,,,Write-ins,3
-Sedgwick,BA01,U.S. Senate,,,Write-ins,3
-Sedgwick,BA02,U.S. Senate,,,Write-ins,4
-Sedgwick,BA03,U.S. Senate,,,Write-ins,3
-Sedgwick,DB14,U.S. Senate,,,Write-ins,1
-Sedgwick,DB22,U.S. Senate,,,Write-ins,2
-Sedgwick,DB25,U.S. Senate,,,Write-ins,2
-Sedgwick,DB32,U.S. Senate,,,Write-ins,3
-Sedgwick,DB36,U.S. Senate,,,Write-ins,2
-Sedgwick,DB41,U.S. Senate,,,Write-ins,1
-Sedgwick,DB42,U.S. Senate,,,Write-ins,6
-Sedgwick,GA,U.S. Senate,,,Write-ins,4
-Sedgwick,GN01,U.S. Senate,,,Write-ins,3
-Sedgwick,GO,U.S. Senate,,,Write-ins,5
-Sedgwick,GR,U.S. Senate,,,Write-ins,2
-Sedgwick,GY01,U.S. Senate,,,Write-ins,4
-Sedgwick,HA21,U.S. Senate,,,Write-ins,1
-Sedgwick,HA31,U.S. Senate,,,Write-ins,2
-Sedgwick,IL01,U.S. Senate,,,Write-ins,2
-Sedgwick,KE03,U.S. Senate,,,Write-ins,2
-Sedgwick,LI,U.S. Senate,,,Write-ins,1
-Sedgwick,MI09,U.S. Senate,,,Write-ins,1
-Sedgwick,MO,U.S. Senate,,,Write-ins,1
-Sedgwick,MV01,U.S. Senate,,,Write-ins,1
-Sedgwick,MV02,U.S. Senate,,,Write-ins,2
-Sedgwick,NI01,U.S. Senate,,,Write-ins,1
-Sedgwick,OH01,U.S. Senate,,,Write-ins,2
-Sedgwick,PA02,U.S. Senate,,,Write-ins,1
-Sedgwick,PC11,U.S. Senate,,,Write-ins,1
-Sedgwick,PC13,U.S. Senate,,,Write-ins,1
-Sedgwick,PC21,U.S. Senate,,,Write-ins,2
-Sedgwick,RI06,U.S. Senate,,,Write-ins,1
-Sedgwick,RO01,U.S. Senate,,,Write-ins,3
-Sedgwick,SA01,U.S. Senate,,,Write-ins,1
-Sedgwick,SH,U.S. Senate,,,Write-ins,3
-Sedgwick,UN01,U.S. Senate,,,Write-ins,1
-Sedgwick,VA,U.S. Senate,,,Write-ins,1
-Sedgwick,VC21,U.S. Senate,,,Write-ins,1
-Sedgwick,AT03,Governor,,,Write-ins,2
-Sedgwick,DB14,Governor,,,Write-ins,1
-Sedgwick,DB25,Governor,,,Write-ins,1
-Sedgwick,DB31,Governor,,,Write-ins,1
-Sedgwick,DB32,Governor,,,Write-ins,1
-Sedgwick,DB42,Governor,,,Write-ins,2
-Sedgwick,EA,Governor,,,Write-ins,1
-Sedgwick,GD,Governor,,,Write-ins,1
-Sedgwick,GN01,Governor,,,Write-ins,1
-Sedgwick,HA31,Governor,,,Write-ins,1
-Sedgwick,KE03,Governor,,,Write-ins,1
-Sedgwick,MI09,Governor,,,Write-ins,1
-Sedgwick,MO,Governor,,,Write-ins,1
-Sedgwick,MV01,Governor,,,Write-ins,1
-Sedgwick,MV02,Governor,,,Write-ins,3
-Sedgwick,PA05,Governor,,,Write-ins,2
-Sedgwick,PC11,Governor,,,Write-ins,2
-Sedgwick,PY01,Governor,,,Write-ins,3
-Sedgwick,RI07,Governor,,,Write-ins,1
-Sedgwick,SA01,Governor,,,Write-ins,1
-Sedgwick,SH,Governor,,,Write-ins,1
-Sedgwick,UN01,Governor,,,Write-ins,1
-Sedgwick,VC11,Governor,,,Write-ins,1
-Sedgwick,VC21,Governor,,,Write-ins,1
-Sedgwick,AT03,Secretary of State,,,Write-ins,1
-Sedgwick,BA02,Secretary of State,,,Write-ins,2
-Sedgwick,BA03,Secretary of State,,,Write-ins,1
-Sedgwick,DB25,Secretary of State,,,Write-ins,2
-Sedgwick,DB32,Secretary of State,,,Write-ins,1
-Sedgwick,DB42,Secretary of State,,,Write-ins,2
-Sedgwick,GY01,Secretary of State,,,Write-ins,2
-Sedgwick,HA21,Secretary of State,,,Write-ins,1
-Sedgwick,HA41,Secretary of State,,,Write-ins,1
-Sedgwick,MI09,Secretary of State,,,Write-ins,1
-Sedgwick,MO,Secretary of State,,,Write-ins,1
-Sedgwick,MV01,Secretary of State,,,Write-ins,1
-Sedgwick,MV02,Secretary of State,,,Write-ins,1
-Sedgwick,NI01,Secretary of State,,,Write-ins,1
-Sedgwick,PA02,Secretary of State,,,Write-ins,1
-Sedgwick,PA05,Secretary of State,,,Write-ins,1
-Sedgwick,PC21,Secretary of State,,,Write-ins,2
-Sedgwick,PY01,Secretary of State,,,Write-ins,1
-Sedgwick,RO01,Secretary of State,,,Write-ins,2
-Sedgwick,VC41,Secretary of State,,,Write-ins,1
-Sedgwick,AT03,Attorney General,,,Write-ins,2
-Sedgwick,BA02,Attorney General,,,Write-ins,1
-Sedgwick,BA03,Attorney General,,,Write-ins,1
-Sedgwick,DB14,Attorney General,,,Write-ins,1
-Sedgwick,DB25,Attorney General,,,Write-ins,2
-Sedgwick,DB41,Attorney General,,,Write-ins,1
-Sedgwick,DB42,Attorney General,,,Write-ins,1
-Sedgwick,HA21,Attorney General,,,Write-ins,1
-Sedgwick,HA31,Attorney General,,,Write-ins,1
-Sedgwick,KE04,Attorney General,,,Write-ins,1
-Sedgwick,MO,Attorney General,,,Write-ins,1
-Sedgwick,MV01,Attorney General,,,Write-ins,3
-Sedgwick,NI01,Attorney General,,,Write-ins,1
-Sedgwick,PA02,Attorney General,,,Write-ins,1
-Sedgwick,PC21,Attorney General,,,Write-ins,2
-Sedgwick,RI03,Attorney General,,,Write-ins,1
-Sedgwick,RO01,Attorney General,,,Write-ins,2
-Sedgwick,AT03,State Treasurer,,,Write-ins,2
-Sedgwick,BA02,State Treasurer,,,Write-ins,1
-Sedgwick,BA03,State Treasurer,,,Write-ins,1
-Sedgwick,DB25,State Treasurer,,,Write-ins,2
-Sedgwick,DB42,State Treasurer,,,Write-ins,2
-Sedgwick,GY01,State Treasurer,,,Write-ins,2
-Sedgwick,HA31,State Treasurer,,,Write-ins,1
-Sedgwick,KE03,State Treasurer,,,Write-ins,2
-Sedgwick,MI01,State Treasurer,,,Write-ins,1
-Sedgwick,MI09,State Treasurer,,,Write-ins,1
-Sedgwick,MO,State Treasurer,,,Write-ins,2
-Sedgwick,MV01,State Treasurer,,,Write-ins,1
-Sedgwick,NI01,State Treasurer,,,Write-ins,1
-Sedgwick,PC21,State Treasurer,,,Write-ins,2
-Sedgwick,RI07,State Treasurer,,,Write-ins,1
-Sedgwick,RO01,State Treasurer,,,Write-ins,2
-Sedgwick,UN01,State Treasurer,,,Write-ins,1
-Sedgwick,VA,State Treasurer,,,Write-ins,1
-Sedgwick,VC31,State Treasurer,,,Write-ins,1
-Sedgwick,AF,Insurance Commissioner,,,Write-ins,1
-Sedgwick,AT03,Insurance Commissioner,,,Write-ins,2
-Sedgwick,BA01,Insurance Commissioner,,,Write-ins,1
-Sedgwick,BA02,Insurance Commissioner,,,Write-ins,3
-Sedgwick,DB12,Insurance Commissioner,,,Write-ins,4
-Sedgwick,DB21,Insurance Commissioner,,,Write-ins,1
-Sedgwick,DB22,Insurance Commissioner,,,Write-ins,1
-Sedgwick,DB25,Insurance Commissioner,,,Write-ins,2
-Sedgwick,DB42,Insurance Commissioner,,,Write-ins,2
-Sedgwick,GY01,Insurance Commissioner,,,Write-ins,1
-Sedgwick,HA21,Insurance Commissioner,,,Write-ins,1
-Sedgwick,HA31,Insurance Commissioner,,,Write-ins,1
-Sedgwick,KE03,Insurance Commissioner,,,Write-ins,2
-Sedgwick,LI,Insurance Commissioner,,,Write-ins,1
-Sedgwick,MI01,Insurance Commissioner,,,Write-ins,2
-Sedgwick,MO,Insurance Commissioner,,,Write-ins,1
-Sedgwick,MV01,Insurance Commissioner,,,Write-ins,1
-Sedgwick,NI,Insurance Commissioner,,,Write-ins,1
-Sedgwick,NI01,Insurance Commissioner,,,Write-ins,1
-Sedgwick,PC21,Insurance Commissioner,,,Write-ins,1
-Sedgwick,PC31,Insurance Commissioner,,,Write-ins,1
-Sedgwick,RO01,Insurance Commissioner,,,Write-ins,2
-Sedgwick,VA,Insurance Commissioner,,,Write-ins,2
-Sedgwick,AT03,State House,101,,Write-ins,6
-Sedgwick,AT06,State House,101,,Write-ins,1
-Sedgwick,AT08,State House,101,,Write-ins,1
-Sedgwick,BA02,State House,89,,Write-ins,1
-Sedgwick,BA03,State House,85,,Write-ins,2
-Sedgwick,DB11,State House,81,,Write-ins,2
-Sedgwick,DB12,State House,81,,Write-ins,2
-Sedgwick,DB25,State House,82,,Write-ins,2
-Sedgwick,DB36,State House,82,,Write-ins,1
-Sedgwick,DB41,State House,82,,Write-ins,2
-Sedgwick,DB42,State House,82,,Write-ins,2
-Sedgwick,EA,State House,90,,Write-ins,2
-Sedgwick,GD,State House,101,,Write-ins,1
-Sedgwick,GN01,State House,90,,Write-ins,7
-Sedgwick,GO,State House,101,,Write-ins,5
-Sedgwick,GY01,State House,81,,Write-ins,3
-Sedgwick,HA11,State House,98,,Write-ins,1
-Sedgwick,HA31,State House,93,,Write-ins,2
-Sedgwick,KE03,State House,91,,Write-ins,7
-Sedgwick,KE04,State House,91,,Write-ins,2
-Sedgwick,LI,State House,90,,Write-ins,2
-Sedgwick,MI01,State House,99,,Write-ins,13
-Sedgwick,MO,State House,93,,Write-ins,1
-Sedgwick,MV01,State House,82,,Write-ins,1
-Sedgwick,NI,State House,93,,Write-ins,2
-Sedgwick,NI01,State House,93,,Write-ins,1
-Sedgwick,PA01,State House,91,,Write-ins,1
-Sedgwick,PA02,State House,91,,Write-ins,2
-Sedgwick,PA05,State House,90,,Write-ins,4
-Sedgwick,PC11,State House,91,,Write-ins,10
-Sedgwick,PC13,State House,90,,Write-ins,2
-Sedgwick,PC21,State House,91,,Write-ins,6
-Sedgwick,PC31,State House,91,,Write-ins,10
-Sedgwick,RO01,State House,82,,Write-ins,2
-Sedgwick,SH,State House,90,,Write-ins,7
-Sedgwick,UN01,State House,90,,Write-ins,2
-Sedgwick,VA,State House,90,,Write-ins,5
-Sedgwick,VC11,State House,90,,Write-ins,15
-Sedgwick,VC21,State House,90,,Write-ins,10
-Sedgwick,VC31,State House,90,,Write-ins,13
-Sedgwick,VC41,State House,90,,Write-ins,11
-Sedgwick,VC42,State House,91,,Write-ins,4
+county,precinct,office,district,party,candidate,votes,vtd
+SEDGWICK,ADVANCED,Kansas House of Representatives,81,Democratic,"Wells, Lynn",1892,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,81,Republican,"Carpenter, Blake",3044,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,82,Democratic,"Harris, Danette",2638,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",4412,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,83,Democratic,"Bridges, Carolyn",2829,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,83,Republican,"Thomas, James",2247,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,84,Democratic,"Finney, Gail",3488,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,84,Libertarian,"Bakken, Gordon",318,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,84,Republican,"Racobs, Ray ""Grizzly""",1139,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,85,Democratic,"Thorpe, Patrick",2589,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,85,Republican,"Brunk, Steven",5158,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,86,Democratic,"Ward, Jim",2760,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,86,Libertarian,"Pruden, James",1088,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,87,Democratic,"Jenney, Charles",3180,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,87,Republican,"Kahrs, Mark",4954,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,88,Democratic,"Sloop, Patricia M.",2587,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,88,Republican,"Scapa, Joseph",2615,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,89,Democratic,"Houston, Roderick A.",3480,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,89,Republican,"Chappell, Frank",2504,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,90,Republican,"Huebert, Steve",6242,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,91,Republican,"Suellentrop, Gene",5923,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,92,Democratic,"Carmichael, John",3514,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,92,Republican,"Alessi, Jeremy",3023,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,93,Democratic,"Flaharty, Sammy K.",2158,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,93,Republican,"Whitmer, John",4758,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,94,Republican,"Goico, Mario",6634,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,95,Democratic,"Sawyer, Tom",2494,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,95,Republican,"Boman, Benny",1805,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,96,Democratic,"Whipple, Brandon",2544,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,96,Republican,"Lindsey, Rick",1983,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,97,Republican,"Osterman, Leslie G.",4203,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,98,Democratic,"Crum, Steven G.",2163,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,98,Republican,"Anthimides, Steven",2292,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,99,Republican,"Hedke, Dennis E.",3661,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,100,Democratic,"Willoughby, John Wallace",2565,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,100,Republican,"Hawkins, Dan",6008,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,101,Republican,"Seiwert, Joe",4895,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,103,Democratic,"Victors, Ponka-We",1648,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,105,Democratic,"Livingston, Sherry",2355,999998
+SEDGWICK,ADVANCED,Kansas House of Representatives,105,Republican,"Hutton, Mark Edward",3705,999998
+SEDGWICK,Wichita Precinct 101,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",329,001
+SEDGWICK,Wichita Precinct 101,United States House of Representatives,4,Republican,"Pompeo, Mike",390,001
+SEDGWICK,Wichita Precinct 102,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",263,002
+SEDGWICK,Wichita Precinct 102,United States House of Representatives,4,Republican,"Pompeo, Mike",446,002
+SEDGWICK,Wichita Precinct 103,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",57,003
+SEDGWICK,Wichita Precinct 103,United States House of Representatives,4,Republican,"Pompeo, Mike",41,003
+SEDGWICK,Wichita Precinct 104,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,004
+SEDGWICK,Wichita Precinct 104,United States House of Representatives,4,Republican,"Pompeo, Mike",21,004
+SEDGWICK,Wichita Precinct 105,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",270,005
+SEDGWICK,Wichita Precinct 105,United States House of Representatives,4,Republican,"Pompeo, Mike",131,005
+SEDGWICK,Wichita Precinct 106,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",516,006
+SEDGWICK,Wichita Precinct 106,United States House of Representatives,4,Republican,"Pompeo, Mike",186,006
+SEDGWICK,Wichita Precinct 107,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",534,007
+SEDGWICK,Wichita Precinct 107,United States House of Representatives,4,Republican,"Pompeo, Mike",559,007
+SEDGWICK,Wichita Precinct 108,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",346,008
+SEDGWICK,Wichita Precinct 108,United States House of Representatives,4,Republican,"Pompeo, Mike",246,008
+SEDGWICK,Wichita Precinct 109,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",421,009
+SEDGWICK,Wichita Precinct 109,United States House of Representatives,4,Republican,"Pompeo, Mike",267,009
+SEDGWICK,Wichita Precinct 110,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",513,010
+SEDGWICK,Wichita Precinct 110,United States House of Representatives,4,Republican,"Pompeo, Mike",593,010
+SEDGWICK,Wichita Precinct 111,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",122,011
+SEDGWICK,Wichita Precinct 111,United States House of Representatives,4,Republican,"Pompeo, Mike",169,011
+SEDGWICK,Wichita Precinct 112,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",476,012
+SEDGWICK,Wichita Precinct 112,United States House of Representatives,4,Republican,"Pompeo, Mike",287,012
+SEDGWICK,Wichita Precinct 113,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",418,013
+SEDGWICK,Wichita Precinct 113,United States House of Representatives,4,Republican,"Pompeo, Mike",75,013
+SEDGWICK,Wichita Precinct 114,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",380,014
+SEDGWICK,Wichita Precinct 114,United States House of Representatives,4,Republican,"Pompeo, Mike",41,014
+SEDGWICK,Wichita Precinct 116,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",585,015
+SEDGWICK,Wichita Precinct 116,United States House of Representatives,4,Republican,"Pompeo, Mike",53,015
+SEDGWICK,Wichita Precinct 117,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",543,016
+SEDGWICK,Wichita Precinct 117,United States House of Representatives,4,Republican,"Pompeo, Mike",61,016
+SEDGWICK,Wichita Precinct 118,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",613,017
+SEDGWICK,Wichita Precinct 118,United States House of Representatives,4,Republican,"Pompeo, Mike",137,017
+SEDGWICK,Wichita Precinct 119,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",408,018
+SEDGWICK,Wichita Precinct 119,United States House of Representatives,4,Republican,"Pompeo, Mike",186,018
+SEDGWICK,Wichita Precinct 120,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",338,019
+SEDGWICK,Wichita Precinct 120,United States House of Representatives,4,Republican,"Pompeo, Mike",253,019
+SEDGWICK,Wichita Precinct 121,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",290,020
+SEDGWICK,Wichita Precinct 121,United States House of Representatives,4,Republican,"Pompeo, Mike",379,020
+SEDGWICK,Wichita Precinct 122,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",486,021
+SEDGWICK,Wichita Precinct 122,United States House of Representatives,4,Republican,"Pompeo, Mike",518,021
+SEDGWICK,Wichita Precinct 123,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",93,022
+SEDGWICK,Wichita Precinct 123,United States House of Representatives,4,Republican,"Pompeo, Mike",194,022
+SEDGWICK,Wichita Precinct 124,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,023
+SEDGWICK,Wichita Precinct 124,United States House of Representatives,4,Republican,"Pompeo, Mike",0,023
+SEDGWICK,Wichita Precinct 127,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",72,024
+SEDGWICK,Wichita Precinct 127,United States House of Representatives,4,Republican,"Pompeo, Mike",137,024
+SEDGWICK,Wichita Precinct 128,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",361,025
+SEDGWICK,Wichita Precinct 128,United States House of Representatives,4,Republican,"Pompeo, Mike",470,025
+SEDGWICK,Wichita Precinct 129,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",86,026
+SEDGWICK,Wichita Precinct 129,United States House of Representatives,4,Republican,"Pompeo, Mike",68,026
+SEDGWICK,Wichita Precinct 130,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",240,027
+SEDGWICK,Wichita Precinct 130,United States House of Representatives,4,Republican,"Pompeo, Mike",209,027
+SEDGWICK,Wichita Precinct 205,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",109,028
+SEDGWICK,Wichita Precinct 205,United States House of Representatives,4,Republican,"Pompeo, Mike",94,028
+SEDGWICK,Wichita Precinct 206,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",110,029
+SEDGWICK,Wichita Precinct 206,United States House of Representatives,4,Republican,"Pompeo, Mike",124,029
+SEDGWICK,Wichita Precinct 207,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",589,030
+SEDGWICK,Wichita Precinct 207,United States House of Representatives,4,Republican,"Pompeo, Mike",692,030
+SEDGWICK,Wichita Precinct 208,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",109,031
+SEDGWICK,Wichita Precinct 208,United States House of Representatives,4,Republican,"Pompeo, Mike",144,031
+SEDGWICK,Wichita Precinct 209,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",291,032
+SEDGWICK,Wichita Precinct 209,United States House of Representatives,4,Republican,"Pompeo, Mike",317,032
+SEDGWICK,Wichita Precinct 210,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",341,033
+SEDGWICK,Wichita Precinct 210,United States House of Representatives,4,Republican,"Pompeo, Mike",410,033
+SEDGWICK,Wichita Precinct 211,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",213,034
+SEDGWICK,Wichita Precinct 211,United States House of Representatives,4,Republican,"Pompeo, Mike",334,034
+SEDGWICK,Wichita Precinct 212,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",397,035
+SEDGWICK,Wichita Precinct 212,United States House of Representatives,4,Republican,"Pompeo, Mike",638,035
+SEDGWICK,Wichita Precinct 213,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",364,036
+SEDGWICK,Wichita Precinct 213,United States House of Representatives,4,Republican,"Pompeo, Mike",796,036
+SEDGWICK,Wichita Precinct 214,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",257,037
+SEDGWICK,Wichita Precinct 214,United States House of Representatives,4,Republican,"Pompeo, Mike",807,037
+SEDGWICK,Wichita Precinct 215,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",482,038
+SEDGWICK,Wichita Precinct 215,United States House of Representatives,4,Republican,"Pompeo, Mike",935,038
+SEDGWICK,Wichita Precinct 216,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",306,039
+SEDGWICK,Wichita Precinct 216,United States House of Representatives,4,Republican,"Pompeo, Mike",586,039
+SEDGWICK,Wichita Precinct 217,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",306,040
+SEDGWICK,Wichita Precinct 217,United States House of Representatives,4,Republican,"Pompeo, Mike",795,040
+SEDGWICK,Wichita Precinct 218,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",496,041
+SEDGWICK,Wichita Precinct 218,United States House of Representatives,4,Republican,"Pompeo, Mike",1043,041
+SEDGWICK,Wichita Precinct 221,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",194,042
+SEDGWICK,Wichita Precinct 221,United States House of Representatives,4,Republican,"Pompeo, Mike",492,042
+SEDGWICK,Wichita Precinct 222,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",288,043
+SEDGWICK,Wichita Precinct 222,United States House of Representatives,4,Republican,"Pompeo, Mike",658,043
+SEDGWICK,Wichita Precinct 223,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",323,044
+SEDGWICK,Wichita Precinct 223,United States House of Representatives,4,Republican,"Pompeo, Mike",830,044
+SEDGWICK,Wichita Precinct 224,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",455,045
+SEDGWICK,Wichita Precinct 224,United States House of Representatives,4,Republican,"Pompeo, Mike",632,045
+SEDGWICK,Wichita Precinct 225,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",431,046
+SEDGWICK,Wichita Precinct 225,United States House of Representatives,4,Republican,"Pompeo, Mike",704,046
+SEDGWICK,Wichita Precinct 226,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",428,047
+SEDGWICK,Wichita Precinct 226,United States House of Representatives,4,Republican,"Pompeo, Mike",1054,047
+SEDGWICK,Wichita Precinct 227,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",183,048
+SEDGWICK,Wichita Precinct 227,United States House of Representatives,4,Republican,"Pompeo, Mike",618,048
+SEDGWICK,Wichita Precinct 228,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",167,049
+SEDGWICK,Wichita Precinct 228,United States House of Representatives,4,Republican,"Pompeo, Mike",899,049
+SEDGWICK,Wichita Precinct 233,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",111,050
+SEDGWICK,Wichita Precinct 233,United States House of Representatives,4,Republican,"Pompeo, Mike",182,050
+SEDGWICK,Wichita Precinct 235,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",117,051
+SEDGWICK,Wichita Precinct 235,United States House of Representatives,4,Republican,"Pompeo, Mike",112,051
+SEDGWICK,Wichita Precinct 236,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",162,052
+SEDGWICK,Wichita Precinct 236,United States House of Representatives,4,Republican,"Pompeo, Mike",538,052
+SEDGWICK,Wichita Precinct 239,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,053
+SEDGWICK,Wichita Precinct 239,United States House of Representatives,4,Republican,"Pompeo, Mike",16,053
+SEDGWICK,Wichita Precinct 241,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",71,054
+SEDGWICK,Wichita Precinct 241,United States House of Representatives,4,Republican,"Pompeo, Mike",203,054
+SEDGWICK,Wichita Precinct 301,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",142,055
+SEDGWICK,Wichita Precinct 301,United States House of Representatives,4,Republican,"Pompeo, Mike",175,055
+SEDGWICK,Wichita Precinct 302,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",281,056
+SEDGWICK,Wichita Precinct 302,United States House of Representatives,4,Republican,"Pompeo, Mike",294,056
+SEDGWICK,Wichita Precinct 303,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",110,057
+SEDGWICK,Wichita Precinct 303,United States House of Representatives,4,Republican,"Pompeo, Mike",152,057
+SEDGWICK,Wichita Precinct 304,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",143,058
+SEDGWICK,Wichita Precinct 304,United States House of Representatives,4,Republican,"Pompeo, Mike",162,058
+SEDGWICK,Wichita Precinct 305,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",463,059
+SEDGWICK,Wichita Precinct 305,United States House of Representatives,4,Republican,"Pompeo, Mike",530,059
+SEDGWICK,Wichita Precinct 306,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",490,060
+SEDGWICK,Wichita Precinct 306,United States House of Representatives,4,Republican,"Pompeo, Mike",425,060
+SEDGWICK,Wichita Precinct 307,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",218,061
+SEDGWICK,Wichita Precinct 307,United States House of Representatives,4,Republican,"Pompeo, Mike",176,061
+SEDGWICK,Wichita Precinct 308,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",352,062
+SEDGWICK,Wichita Precinct 308,United States House of Representatives,4,Republican,"Pompeo, Mike",333,062
+SEDGWICK,Wichita Precinct 309,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",365,063
+SEDGWICK,Wichita Precinct 309,United States House of Representatives,4,Republican,"Pompeo, Mike",430,063
+SEDGWICK,Wichita Precinct 310,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",191,064
+SEDGWICK,Wichita Precinct 310,United States House of Representatives,4,Republican,"Pompeo, Mike",169,064
+SEDGWICK,Wichita Precinct 311,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",114,065
+SEDGWICK,Wichita Precinct 311,United States House of Representatives,4,Republican,"Pompeo, Mike",188,065
+SEDGWICK,Wichita Precinct 312,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",131,066
+SEDGWICK,Wichita Precinct 312,United States House of Representatives,4,Republican,"Pompeo, Mike",168,066
+SEDGWICK,Wichita Precinct 313,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",414,067
+SEDGWICK,Wichita Precinct 313,United States House of Representatives,4,Republican,"Pompeo, Mike",444,067
+SEDGWICK,Wichita Precinct 314,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",324,068
+SEDGWICK,Wichita Precinct 314,United States House of Representatives,4,Republican,"Pompeo, Mike",459,068
+SEDGWICK,Wichita Precinct 315,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",283,069
+SEDGWICK,Wichita Precinct 315,United States House of Representatives,4,Republican,"Pompeo, Mike",314,069
+SEDGWICK,Wichita Precinct 316,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",266,070
+SEDGWICK,Wichita Precinct 316,United States House of Representatives,4,Republican,"Pompeo, Mike",459,070
+SEDGWICK,Wichita Precinct 317,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,071
+SEDGWICK,Wichita Precinct 317,United States House of Representatives,4,Republican,"Pompeo, Mike",8,071
+SEDGWICK,Wichita Precinct 318,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,072
+SEDGWICK,Wichita Precinct 318,United States House of Representatives,4,Republican,"Pompeo, Mike",15,072
+SEDGWICK,Wichita Precinct 319,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",101,073
+SEDGWICK,Wichita Precinct 319,United States House of Representatives,4,Republican,"Pompeo, Mike",78,073
+SEDGWICK,Wichita Precinct 320,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",79,074
+SEDGWICK,Wichita Precinct 320,United States House of Representatives,4,Republican,"Pompeo, Mike",37,074
+SEDGWICK,Wichita Precinct 321,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",12,075
+SEDGWICK,Wichita Precinct 321,United States House of Representatives,4,Republican,"Pompeo, Mike",5,075
+SEDGWICK,Wichita Precinct 324,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",129,076
+SEDGWICK,Wichita Precinct 324,United States House of Representatives,4,Republican,"Pompeo, Mike",135,076
+SEDGWICK,Wichita Precinct 325,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",292,077
+SEDGWICK,Wichita Precinct 325,United States House of Representatives,4,Republican,"Pompeo, Mike",348,077
+SEDGWICK,Wichita Precinct 326,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",32,078
+SEDGWICK,Wichita Precinct 326,United States House of Representatives,4,Republican,"Pompeo, Mike",40,078
+SEDGWICK,Wichita Precinct 401,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",133,079
+SEDGWICK,Wichita Precinct 401,United States House of Representatives,4,Republican,"Pompeo, Mike",291,079
+SEDGWICK,Wichita Precinct 402,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",148,080
+SEDGWICK,Wichita Precinct 402,United States House of Representatives,4,Republican,"Pompeo, Mike",294,080
+SEDGWICK,Wichita Precinct 403,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",151,081
+SEDGWICK,Wichita Precinct 403,United States House of Representatives,4,Republican,"Pompeo, Mike",515,081
+SEDGWICK,Wichita Precinct 404,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",413,082
+SEDGWICK,Wichita Precinct 404,United States House of Representatives,4,Republican,"Pompeo, Mike",493,082
+SEDGWICK,Wichita Precinct 405,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",297,083
+SEDGWICK,Wichita Precinct 405,United States House of Representatives,4,Republican,"Pompeo, Mike",371,083
+SEDGWICK,Wichita Precinct 406,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",241,084
+SEDGWICK,Wichita Precinct 406,United States House of Representatives,4,Republican,"Pompeo, Mike",307,084
+SEDGWICK,Wichita Precinct 407,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",36,085
+SEDGWICK,Wichita Precinct 407,United States House of Representatives,4,Republican,"Pompeo, Mike",40,085
+SEDGWICK,Wichita Precinct 408,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",275,086
+SEDGWICK,Wichita Precinct 408,United States House of Representatives,4,Republican,"Pompeo, Mike",282,086
+SEDGWICK,Wichita Precinct 409,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",147,087
+SEDGWICK,Wichita Precinct 409,United States House of Representatives,4,Republican,"Pompeo, Mike",168,087
+SEDGWICK,Wichita Precinct 410,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",306,088
+SEDGWICK,Wichita Precinct 410,United States House of Representatives,4,Republican,"Pompeo, Mike",1101,088
+SEDGWICK,Wichita Precinct 412,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",365,089
+SEDGWICK,Wichita Precinct 412,United States House of Representatives,4,Republican,"Pompeo, Mike",972,089
+SEDGWICK,Wichita Precinct 413,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",288,090
+SEDGWICK,Wichita Precinct 413,United States House of Representatives,4,Republican,"Pompeo, Mike",696,090
+SEDGWICK,Wichita Precinct 414,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",58,091
+SEDGWICK,Wichita Precinct 414,United States House of Representatives,4,Republican,"Pompeo, Mike",143,091
+SEDGWICK,Wichita Precinct 416,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",198,092
+SEDGWICK,Wichita Precinct 416,United States House of Representatives,4,Republican,"Pompeo, Mike",462,092
+SEDGWICK,Wichita Precinct 417,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",196,093
+SEDGWICK,Wichita Precinct 417,United States House of Representatives,4,Republican,"Pompeo, Mike",301,093
+SEDGWICK,Wichita Precinct 418,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",289,094
+SEDGWICK,Wichita Precinct 418,United States House of Representatives,4,Republican,"Pompeo, Mike",450,094
+SEDGWICK,Wichita Precinct 419,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",288,095
+SEDGWICK,Wichita Precinct 419,United States House of Representatives,4,Republican,"Pompeo, Mike",358,095
+SEDGWICK,Wichita Precinct 420,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",303,096
+SEDGWICK,Wichita Precinct 420,United States House of Representatives,4,Republican,"Pompeo, Mike",390,096
+SEDGWICK,Wichita Precinct 422,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",181,097
+SEDGWICK,Wichita Precinct 422,United States House of Representatives,4,Republican,"Pompeo, Mike",246,097
+SEDGWICK,Wichita Precinct 423,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",209,098
+SEDGWICK,Wichita Precinct 423,United States House of Representatives,4,Republican,"Pompeo, Mike",300,098
+SEDGWICK,Wichita Precinct 424,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",64,099
+SEDGWICK,Wichita Precinct 424,United States House of Representatives,4,Republican,"Pompeo, Mike",103,099
+SEDGWICK,Wichita Precinct 425,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",347,100
+SEDGWICK,Wichita Precinct 425,United States House of Representatives,4,Republican,"Pompeo, Mike",626,100
+SEDGWICK,Wichita Precinct 429,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",152,101
+SEDGWICK,Wichita Precinct 429,United States House of Representatives,4,Republican,"Pompeo, Mike",200,101
+SEDGWICK,Wichita Precinct 433,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",80,102
+SEDGWICK,Wichita Precinct 433,United States House of Representatives,4,Republican,"Pompeo, Mike",153,102
+SEDGWICK,Wichita Precinct 437,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",63,103
+SEDGWICK,Wichita Precinct 437,United States House of Representatives,4,Republican,"Pompeo, Mike",166,103
+SEDGWICK,Wichita Precinct 503,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",295,104
+SEDGWICK,Wichita Precinct 503,United States House of Representatives,4,Republican,"Pompeo, Mike",474,104
+SEDGWICK,Wichita Precinct 504,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",206,105
+SEDGWICK,Wichita Precinct 504,United States House of Representatives,4,Republican,"Pompeo, Mike",331,105
+SEDGWICK,Wichita Precinct 506,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",303,106
+SEDGWICK,Wichita Precinct 506,United States House of Representatives,4,Republican,"Pompeo, Mike",716,106
+SEDGWICK,Wichita Precinct 507,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",351,107
+SEDGWICK,Wichita Precinct 507,United States House of Representatives,4,Republican,"Pompeo, Mike",608,107
+SEDGWICK,Wichita Precinct 508,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",302,108
+SEDGWICK,Wichita Precinct 508,United States House of Representatives,4,Republican,"Pompeo, Mike",552,108
+SEDGWICK,Wichita Precinct 509,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",251,109
+SEDGWICK,Wichita Precinct 509,United States House of Representatives,4,Republican,"Pompeo, Mike",581,109
+SEDGWICK,Wichita Precinct 510,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",244,110
+SEDGWICK,Wichita Precinct 510,United States House of Representatives,4,Republican,"Pompeo, Mike",965,110
+SEDGWICK,Wichita Precinct 512,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",453,111
+SEDGWICK,Wichita Precinct 512,United States House of Representatives,4,Republican,"Pompeo, Mike",1325,111
+SEDGWICK,Wichita Precinct 513,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",90,112
+SEDGWICK,Wichita Precinct 513,United States House of Representatives,4,Republican,"Pompeo, Mike",414,112
+SEDGWICK,Wichita Precinct 514,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",349,113
+SEDGWICK,Wichita Precinct 514,United States House of Representatives,4,Republican,"Pompeo, Mike",846,113
+SEDGWICK,Wichita Precinct 515,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",322,114
+SEDGWICK,Wichita Precinct 515,United States House of Representatives,4,Republican,"Pompeo, Mike",733,114
+SEDGWICK,Wichita Precinct 516,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",204,115
+SEDGWICK,Wichita Precinct 516,United States House of Representatives,4,Republican,"Pompeo, Mike",511,115
+SEDGWICK,Wichita Precinct 517,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",256,116
+SEDGWICK,Wichita Precinct 517,United States House of Representatives,4,Republican,"Pompeo, Mike",469,116
+SEDGWICK,Wichita Precinct 518,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",246,117
+SEDGWICK,Wichita Precinct 518,United States House of Representatives,4,Republican,"Pompeo, Mike",627,117
+SEDGWICK,Wichita Precinct 519,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",346,118
+SEDGWICK,Wichita Precinct 519,United States House of Representatives,4,Republican,"Pompeo, Mike",624,118
+SEDGWICK,Wichita Precinct 522,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",261,119
+SEDGWICK,Wichita Precinct 522,United States House of Representatives,4,Republican,"Pompeo, Mike",676,119
+SEDGWICK,Wichita Precinct 523,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",261,120
+SEDGWICK,Wichita Precinct 523,United States House of Representatives,4,Republican,"Pompeo, Mike",683,120
+SEDGWICK,Wichita Precinct 524,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",460,122
+SEDGWICK,Wichita Precinct 524,United States House of Representatives,4,Republican,"Pompeo, Mike",1041,122
+SEDGWICK,Wichita Precinct 525,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",357,123
+SEDGWICK,Wichita Precinct 525,United States House of Representatives,4,Republican,"Pompeo, Mike",646,123
+SEDGWICK,Wichita Precinct 526,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",293,124
+SEDGWICK,Wichita Precinct 526,United States House of Representatives,4,Republican,"Pompeo, Mike",751,124
+SEDGWICK,Wichita Precinct 527,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",271,125
+SEDGWICK,Wichita Precinct 527,United States House of Representatives,4,Republican,"Pompeo, Mike",756,125
+SEDGWICK,Wichita Precinct 530,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",229,126
+SEDGWICK,Wichita Precinct 530,United States House of Representatives,4,Republican,"Pompeo, Mike",784,126
+SEDGWICK,Wichita Precinct 531,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",435,127
+SEDGWICK,Wichita Precinct 531,United States House of Representatives,4,Republican,"Pompeo, Mike",1197,127
+SEDGWICK,Wichita Precinct 534,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",22,128
+SEDGWICK,Wichita Precinct 534,United States House of Representatives,4,Republican,"Pompeo, Mike",74,128
+SEDGWICK,Wichita Precinct 538,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",47,129
+SEDGWICK,Wichita Precinct 538,United States House of Representatives,4,Republican,"Pompeo, Mike",152,129
+SEDGWICK,Wichita Precinct 539,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",138,130
+SEDGWICK,Wichita Precinct 539,United States House of Representatives,4,Republican,"Pompeo, Mike",357,130
+SEDGWICK,Wichita Precinct 601,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",303,131
+SEDGWICK,Wichita Precinct 601,United States House of Representatives,4,Republican,"Pompeo, Mike",190,131
+SEDGWICK,Wichita Precinct 602,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",426,132
+SEDGWICK,Wichita Precinct 602,United States House of Representatives,4,Republican,"Pompeo, Mike",511,132
+SEDGWICK,Wichita Precinct 603,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",120,133
+SEDGWICK,Wichita Precinct 603,United States House of Representatives,4,Republican,"Pompeo, Mike",342,133
+SEDGWICK,Wichita Precinct 604,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",360,134
+SEDGWICK,Wichita Precinct 604,United States House of Representatives,4,Republican,"Pompeo, Mike",536,134
+SEDGWICK,Wichita Precinct 605,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",148,135
+SEDGWICK,Wichita Precinct 605,United States House of Representatives,4,Republican,"Pompeo, Mike",189,135
+SEDGWICK,Wichita Precinct 606,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",135,136
+SEDGWICK,Wichita Precinct 606,United States House of Representatives,4,Republican,"Pompeo, Mike",151,136
+SEDGWICK,Wichita Precinct 607,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",688,137
+SEDGWICK,Wichita Precinct 607,United States House of Representatives,4,Republican,"Pompeo, Mike",460,137
+SEDGWICK,Wichita Precinct 608,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",420,138
+SEDGWICK,Wichita Precinct 608,United States House of Representatives,4,Republican,"Pompeo, Mike",228,138
+SEDGWICK,Wichita Precinct 609,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",701,139
+SEDGWICK,Wichita Precinct 609,United States House of Representatives,4,Republican,"Pompeo, Mike",558,139
+SEDGWICK,Wichita Precinct 610,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",366,140
+SEDGWICK,Wichita Precinct 610,United States House of Representatives,4,Republican,"Pompeo, Mike",604,140
+SEDGWICK,Attica Precinct 08,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",13,140010
+SEDGWICK,Attica Precinct 08,United States House of Representatives,4,Republican,"Pompeo, Mike",32,140010
+SEDGWICK,Delano Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,140020
+SEDGWICK,Delano Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",1,140020
+SEDGWICK,Delano Precinct 04,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,140030
+SEDGWICK,Delano Precinct 04,United States House of Representatives,4,Republican,"Pompeo, Mike",1,140030
+SEDGWICK,Riverside Precinct 13,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,140040
+SEDGWICK,Riverside Precinct 13,United States House of Representatives,4,Republican,"Pompeo, Mike",5,140040
+SEDGWICK,Wichita Precinct 611,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",198,141
+SEDGWICK,Wichita Precinct 611,United States House of Representatives,4,Republican,"Pompeo, Mike",295,141
+SEDGWICK,Wichita Precinct 612,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",430,142
+SEDGWICK,Wichita Precinct 612,United States House of Representatives,4,Republican,"Pompeo, Mike",762,142
+SEDGWICK,Wichita Precinct 613,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",370,143
+SEDGWICK,Wichita Precinct 613,United States House of Representatives,4,Republican,"Pompeo, Mike",564,143
+SEDGWICK,Wichita Precinct 614,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",175,144
+SEDGWICK,Wichita Precinct 614,United States House of Representatives,4,Republican,"Pompeo, Mike",173,144
+SEDGWICK,Wichita Precinct 615,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",528,145
+SEDGWICK,Wichita Precinct 615,United States House of Representatives,4,Republican,"Pompeo, Mike",304,145
+SEDGWICK,Wichita Precinct 616,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",194,146
+SEDGWICK,Wichita Precinct 616,United States House of Representatives,4,Republican,"Pompeo, Mike",255,146
+SEDGWICK,Wichita Precinct 617,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",135,147
+SEDGWICK,Wichita Precinct 617,United States House of Representatives,4,Republican,"Pompeo, Mike",124,147
+SEDGWICK,Wichita Precinct 618,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",335,148
+SEDGWICK,Wichita Precinct 618,United States House of Representatives,4,Republican,"Pompeo, Mike",571,148
+SEDGWICK,Wichita Precinct 619,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",392,149
+SEDGWICK,Wichita Precinct 619,United States House of Representatives,4,Republican,"Pompeo, Mike",535,149
+SEDGWICK,Wichita Precinct 621,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,150
+SEDGWICK,Wichita Precinct 621,United States House of Representatives,4,Republican,"Pompeo, Mike",34,150
+SEDGWICK,Wichita Precinct 622,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",312,151
+SEDGWICK,Wichita Precinct 622,United States House of Representatives,4,Republican,"Pompeo, Mike",856,151
+SEDGWICK,Wichita Precinct 623,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",266,152
+SEDGWICK,Wichita Precinct 623,United States House of Representatives,4,Republican,"Pompeo, Mike",724,152
+SEDGWICK,Wichita Precinct 624,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",33,153
+SEDGWICK,Wichita Precinct 624,United States House of Representatives,4,Republican,"Pompeo, Mike",38,153
+SEDGWICK,Wichita Precinct 627,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",27,154
+SEDGWICK,Wichita Precinct 627,United States House of Representatives,4,Republican,"Pompeo, Mike",47,154
+SEDGWICK,Afton,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",128,155
+SEDGWICK,Afton,United States House of Representatives,4,Republican,"Pompeo, Mike",492,155
+SEDGWICK,Attica Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",33,156
+SEDGWICK,Attica Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",70,156
+SEDGWICK,Attica Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",105,157
+SEDGWICK,Attica Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",368,157
+SEDGWICK,Attica Precinct 04,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,158
+SEDGWICK,Attica Precinct 04,United States House of Representatives,4,Republican,"Pompeo, Mike",2,158
+SEDGWICK,Attica Precinct 05,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",47,159
+SEDGWICK,Attica Precinct 05,United States House of Representatives,4,Republican,"Pompeo, Mike",158,159
+SEDGWICK,Attica Precinct 06,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,160
+SEDGWICK,Attica Precinct 06,United States House of Representatives,4,Republican,"Pompeo, Mike",41,160
+SEDGWICK,Bel Aire Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",351,161
+SEDGWICK,Bel Aire Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",752,161
+SEDGWICK,Bel Aire Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",356,162
+SEDGWICK,Bel Aire Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",629,162
+SEDGWICK,Bel Aire Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",208,163
+SEDGWICK,Bel Aire Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",493,163
+SEDGWICK,Derby Ward 01 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",255,164
+SEDGWICK,Derby Ward 01 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",708,164
+SEDGWICK,Derby Ward 01 Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",152,165
+SEDGWICK,Derby Ward 01 Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",371,165
+SEDGWICK,Derby Ward 01 Precinct 04,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",95,166
+SEDGWICK,Derby Ward 01 Precinct 04,United States House of Representatives,4,Republican,"Pompeo, Mike",267,166
+SEDGWICK,Derby Ward 01 Precinct 05,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,167
+SEDGWICK,Derby Ward 01 Precinct 05,United States House of Representatives,4,Republican,"Pompeo, Mike",27,167
+SEDGWICK,Derby Ward 02 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",181,168
+SEDGWICK,Derby Ward 02 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",345,168
+SEDGWICK,Derby Ward 02 Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",161,169
+SEDGWICK,Derby Ward 02 Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",407,169
+SEDGWICK,Derby Ward 02 Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",211,170
+SEDGWICK,Derby Ward 02 Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",488,170
+SEDGWICK,Derby Ward 02 Precinct 04,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",38,171
+SEDGWICK,Derby Ward 02 Precinct 04,United States House of Representatives,4,Republican,"Pompeo, Mike",92,171
+SEDGWICK,Derby Ward 02 Precinct 05,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",22,172
+SEDGWICK,Derby Ward 02 Precinct 05,United States House of Representatives,4,Republican,"Pompeo, Mike",28,172
+SEDGWICK,Derby Ward 03 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",62,173
+SEDGWICK,Derby Ward 03 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",149,173
+SEDGWICK,Derby Ward 03 Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",210,174
+SEDGWICK,Derby Ward 03 Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",450,174
+SEDGWICK,Derby Ward 03 Precinct 06,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",239,175
+SEDGWICK,Derby Ward 03 Precinct 06,United States House of Representatives,4,Republican,"Pompeo, Mike",620,175
+SEDGWICK,Derby Ward 03 Precinct 07,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",48,176
+SEDGWICK,Derby Ward 03 Precinct 07,United States House of Representatives,4,Republican,"Pompeo, Mike",79,176
+SEDGWICK,Derby Ward 04 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",141,177
+SEDGWICK,Derby Ward 04 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",254,177
+SEDGWICK,Derby Ward 04 Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",378,178
+SEDGWICK,Derby Ward 04 Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",1072,178
+SEDGWICK,Delano Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,179
+SEDGWICK,Delano Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",0,179
+SEDGWICK,Eagle,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",107,180
+SEDGWICK,Eagle,United States House of Representatives,4,Republican,"Pompeo, Mike",265,180
+SEDGWICK,Erie,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",7,181
+SEDGWICK,Erie,United States House of Representatives,4,Republican,"Pompeo, Mike",31,181
+SEDGWICK,Garden Plain,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",129,182
+SEDGWICK,Garden Plain,United States House of Representatives,4,Republican,"Pompeo, Mike",642,182
+SEDGWICK,Grand River,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",44,183
+SEDGWICK,Grand River,United States House of Representatives,4,Republican,"Pompeo, Mike",183,183
+SEDGWICK,Grant Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",123,184
+SEDGWICK,Grant Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",506,184
+SEDGWICK,Goddard,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",314,185
+SEDGWICK,Goddard,United States House of Representatives,4,Republican,"Pompeo, Mike",1007,185
+SEDGWICK,Greeley,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",78,186
+SEDGWICK,Greeley,United States House of Representatives,4,Republican,"Pompeo, Mike",298,186
+SEDGWICK,Gypsum Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",329,187
+SEDGWICK,Gypsum Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",958,187
+SEDGWICK,Gypsum Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,188
+SEDGWICK,Gypsum Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",10,188
+SEDGWICK,Gypsum Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",13,189
+SEDGWICK,Gypsum Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",25,189
+SEDGWICK,Haysville Ward 01 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",204,190
+SEDGWICK,Haysville Ward 01 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",425,190
+SEDGWICK,Haysville Ward 02 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",232,191
+SEDGWICK,Haysville Ward 02 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",455,191
+SEDGWICK,Haysville Ward 03 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",253,192
+SEDGWICK,Haysville Ward 03 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",473,192
+SEDGWICK,Haysville Ward 04 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",190,193
+SEDGWICK,Haysville Ward 04 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",438,193
+SEDGWICK,Haysville Ward 04 Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",31,194
+SEDGWICK,Haysville Ward 04 Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",110,194
+SEDGWICK,Illinois Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",145,195
+SEDGWICK,Illinois Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",553,195
+SEDGWICK,Kechi Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,196
+SEDGWICK,Kechi Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",12,196
+SEDGWICK,Kechi Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",218,197
+SEDGWICK,Kechi Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",507,197
+SEDGWICK,Kechi Precinct 04,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",16,198
+SEDGWICK,Kechi Precinct 04,United States House of Representatives,4,Republican,"Pompeo, Mike",20,198
+SEDGWICK,Kechi Precinct 07,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,199
+SEDGWICK,Kechi Precinct 07,United States House of Representatives,4,Republican,"Pompeo, Mike",10,199
+SEDGWICK,Kechi Precinct 08,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,200
+SEDGWICK,Kechi Precinct 08,United States House of Representatives,4,Republican,"Pompeo, Mike",11,200
+SEDGWICK,Lincoln,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",53,201
+SEDGWICK,Lincoln,United States House of Representatives,4,Republican,"Pompeo, Mike",196,201
+SEDGWICK,Minneha Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",208,202
+SEDGWICK,Minneha Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",857,202
+SEDGWICK,Minneha Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",106,203
+SEDGWICK,Minneha Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",335,203
+SEDGWICK,Minneha Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,204
+SEDGWICK,Minneha Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",9,204
+SEDGWICK,Minneha Precinct 04,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,205
+SEDGWICK,Minneha Precinct 04,United States House of Representatives,4,Republican,"Pompeo, Mike",2,205
+SEDGWICK,Minneha Precinct 05,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,206
+SEDGWICK,Minneha Precinct 05,United States House of Representatives,4,Republican,"Pompeo, Mike",0,206
+SEDGWICK,Minneha Precinct 07,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,207
+SEDGWICK,Minneha Precinct 07,United States House of Representatives,4,Republican,"Pompeo, Mike",7,207
+SEDGWICK,Minneha Precinct 09,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",66,208
+SEDGWICK,Minneha Precinct 09,United States House of Representatives,4,Republican,"Pompeo, Mike",138,208
+SEDGWICK,Minneha Precinct 14,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",26,209
+SEDGWICK,Minneha Precinct 14,United States House of Representatives,4,Republican,"Pompeo, Mike",71,209
+SEDGWICK,Morton,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",234,210
+SEDGWICK,Morton,United States House of Representatives,4,Republican,"Pompeo, Mike",665,210
+SEDGWICK,Mulvane City Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",166,211
+SEDGWICK,Mulvane City Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",380,211
+SEDGWICK,Mulvane City Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",371,212
+SEDGWICK,Mulvane City Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",869,212
+SEDGWICK,Ninnescah,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",235,213
+SEDGWICK,Ninnescah,United States House of Representatives,4,Republican,"Pompeo, Mike",652,213
+SEDGWICK,Ninnescah Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",29,214
+SEDGWICK,Ninnescah Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",156,214
+SEDGWICK,Ohio Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",138,215
+SEDGWICK,Ohio Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",390,215
+SEDGWICK,Park Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",40,216
+SEDGWICK,Park Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",170,216
+SEDGWICK,Park Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",40,217
+SEDGWICK,Park Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",75,217
+SEDGWICK,Park Precinct 05,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",273,218
+SEDGWICK,Park Precinct 05,United States House of Representatives,4,Republican,"Pompeo, Mike",806,218
+SEDGWICK,Park Precinct 06,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",19,219
+SEDGWICK,Park Precinct 06,United States House of Representatives,4,Republican,"Pompeo, Mike",36,219
+SEDGWICK,Park Precinct 09,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,220
+SEDGWICK,Park Precinct 09,United States House of Representatives,4,Republican,"Pompeo, Mike",7,220
+SEDGWICK,Park City Ward 01 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",126,221
+SEDGWICK,Park City Ward 01 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",253,221
+SEDGWICK,Park City Ward 01 Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",37,222
+SEDGWICK,Park City Ward 01 Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",87,222
+SEDGWICK,Park City Ward 02 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",192,223
+SEDGWICK,Park City Ward 02 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",426,223
+SEDGWICK,Park City Ward 03 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",275,224
+SEDGWICK,Park City Ward 03 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",473,224
+SEDGWICK,Park City Ward 04 Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",68,225
+SEDGWICK,Park City Ward 04 Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",146,225
+SEDGWICK,Payne Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",91,226
+SEDGWICK,Payne Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",357,226
+SEDGWICK,Riverside Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",10,227
+SEDGWICK,Riverside Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",29,227
+SEDGWICK,Riverside Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",112,228
+SEDGWICK,Riverside Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",120,228
+SEDGWICK,Riverside Precinct 06,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",34,229
+SEDGWICK,Riverside Precinct 06,United States House of Representatives,4,Republican,"Pompeo, Mike",83,229
+SEDGWICK,Riverside Precinct 07,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",76,230
+SEDGWICK,Riverside Precinct 07,United States House of Representatives,4,Republican,"Pompeo, Mike",130,230
+SEDGWICK,Rockford Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",91,231
+SEDGWICK,Rockford Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",272,231
+SEDGWICK,Rockford Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",63,232
+SEDGWICK,Rockford Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",179,232
+SEDGWICK,Salem Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",212,233
+SEDGWICK,Salem Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",549,233
+SEDGWICK,Salem Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",174,234
+SEDGWICK,Salem Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",370,234
+SEDGWICK,Sherman,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",111,235
+SEDGWICK,Sherman,United States House of Representatives,4,Republican,"Pompeo, Mike",471,235
+SEDGWICK,Union Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",113,239
+SEDGWICK,Union Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",698,239
+SEDGWICK,Union Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,240
+SEDGWICK,Union Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",47,240
+SEDGWICK,Valley Center Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",99,241
+SEDGWICK,Valley Center Township,United States House of Representatives,4,Republican,"Pompeo, Mike",289,241
+SEDGWICK,Valley Center City Ward 01 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",143,242
+SEDGWICK,Valley Center City Ward 01 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",426,242
+SEDGWICK,Valley Center City Ward 02 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",149,243
+SEDGWICK,Valley Center City Ward 02 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",465,243
+SEDGWICK,Valley Center City Ward 03 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",104,244
+SEDGWICK,Valley Center City Ward 03 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",389,244
+SEDGWICK,Valley Center City Ward 04 Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",113,245
+SEDGWICK,Valley Center City Ward 04 Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",331,245
+SEDGWICK,Valley Center City Ward 04 Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",37,246
+SEDGWICK,Valley Center City Ward 04 Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",148,246
+SEDGWICK,Viola,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",44,247
+SEDGWICK,Viola,United States House of Representatives,4,Republican,"Pompeo, Mike",146,247
+SEDGWICK,Waco Precinct 01,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,503930
+SEDGWICK,Waco Precinct 01,United States House of Representatives,4,Republican,"Pompeo, Mike",43,503930
+SEDGWICK,Waco Precinct 02,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",46,503940
+SEDGWICK,Waco Precinct 02,United States House of Representatives,4,Republican,"Pompeo, Mike",159,503940
+SEDGWICK,Waco Precinct 03,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,503990
+SEDGWICK,Waco Precinct 03,United States House of Representatives,4,Republican,"Pompeo, Mike",10,503990
+SEDGWICK,Waco Precinct 12,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,504000
+SEDGWICK,Waco Precinct 12,United States House of Representatives,4,Republican,"Pompeo, Mike",2,504000
+SEDGWICK,ADVANCED,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,999998
+SEDGWICK,ADVANCED,United States House of Representatives,4,Republican,"Pompeo, Mike",0,999998
+SEDGWICK,ADVANCED,Attorney General,,Democratic,"Kotich, A.J.",45739,999998
+SEDGWICK,ADVANCED,Attorney General,,Republican,"Schmidt, Derek",92246,999998
+SEDGWICK,ADVANCED,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52455,999998
+SEDGWICK,ADVANCED,Commissioner of Insurance,,Republican,"Selzer, Ken",81857,999998
+SEDGWICK,ADVANCED,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",64354,999998
+SEDGWICK,ADVANCED,Secretary of State,,Republican,"Kobach, Kris",77179,999998
+SEDGWICK,ADVANCED,State Treasurer,,Democratic,"Alldritt, Carmen",41079,999998
+SEDGWICK,ADVANCED,State Treasurer,,Republican,"Estes, Ron",97992,999998
+SEDGWICK,Wichita Precinct 101,United States Senate,,independent,"Orman, Greg",377,001
+SEDGWICK,Wichita Precinct 101,United States Senate,,Libertarian,"Batson, Randall",59,001
+SEDGWICK,Wichita Precinct 101,United States Senate,,Republican,"Roberts, Pat",301,001
+SEDGWICK,Wichita Precinct 102,United States Senate,,independent,"Orman, Greg",373,002
+SEDGWICK,Wichita Precinct 102,United States Senate,,Libertarian,"Batson, Randall",27,002
+SEDGWICK,Wichita Precinct 102,United States Senate,,Republican,"Roberts, Pat",325,002
+SEDGWICK,Wichita Precinct 103,United States Senate,,independent,"Orman, Greg",69,003
+SEDGWICK,Wichita Precinct 103,United States Senate,,Libertarian,"Batson, Randall",4,003
+SEDGWICK,Wichita Precinct 103,United States Senate,,Republican,"Roberts, Pat",25,003
+SEDGWICK,Wichita Precinct 104,United States Senate,,independent,"Orman, Greg",10,004
+SEDGWICK,Wichita Precinct 104,United States Senate,,Libertarian,"Batson, Randall",3,004
+SEDGWICK,Wichita Precinct 104,United States Senate,,Republican,"Roberts, Pat",17,004
+SEDGWICK,Wichita Precinct 105,United States Senate,,independent,"Orman, Greg",290,005
+SEDGWICK,Wichita Precinct 105,United States Senate,,Libertarian,"Batson, Randall",20,005
+SEDGWICK,Wichita Precinct 105,United States Senate,,Republican,"Roberts, Pat",101,005
+SEDGWICK,Wichita Precinct 106,United States Senate,,independent,"Orman, Greg",501,006
+SEDGWICK,Wichita Precinct 106,United States Senate,,Libertarian,"Batson, Randall",68,006
+SEDGWICK,Wichita Precinct 106,United States Senate,,Republican,"Roberts, Pat",128,006
+SEDGWICK,Wichita Precinct 107,United States Senate,,independent,"Orman, Greg",636,007
+SEDGWICK,Wichita Precinct 107,United States Senate,,Libertarian,"Batson, Randall",32,007
+SEDGWICK,Wichita Precinct 107,United States Senate,,Republican,"Roberts, Pat",448,007
+SEDGWICK,Wichita Precinct 108,United States Senate,,independent,"Orman, Greg",386,008
+SEDGWICK,Wichita Precinct 108,United States Senate,,Libertarian,"Batson, Randall",32,008
+SEDGWICK,Wichita Precinct 108,United States Senate,,Republican,"Roberts, Pat",177,008
+SEDGWICK,Wichita Precinct 109,United States Senate,,independent,"Orman, Greg",450,009
+SEDGWICK,Wichita Precinct 109,United States Senate,,Libertarian,"Batson, Randall",38,009
+SEDGWICK,Wichita Precinct 109,United States Senate,,Republican,"Roberts, Pat",198,009
+SEDGWICK,Wichita Precinct 110,United States Senate,,independent,"Orman, Greg",618,010
+SEDGWICK,Wichita Precinct 110,United States Senate,,Libertarian,"Batson, Randall",40,010
+SEDGWICK,Wichita Precinct 110,United States Senate,,Republican,"Roberts, Pat",471,010
+SEDGWICK,Wichita Precinct 111,United States Senate,,independent,"Orman, Greg",152,011
+SEDGWICK,Wichita Precinct 111,United States Senate,,Libertarian,"Batson, Randall",15,011
+SEDGWICK,Wichita Precinct 111,United States Senate,,Republican,"Roberts, Pat",127,011
+SEDGWICK,Wichita Precinct 112,United States Senate,,independent,"Orman, Greg",496,012
+SEDGWICK,Wichita Precinct 112,United States Senate,,Libertarian,"Batson, Randall",34,012
+SEDGWICK,Wichita Precinct 112,United States Senate,,Republican,"Roberts, Pat",230,012
+SEDGWICK,Wichita Precinct 113,United States Senate,,independent,"Orman, Greg",409,013
+SEDGWICK,Wichita Precinct 113,United States Senate,,Libertarian,"Batson, Randall",23,013
+SEDGWICK,Wichita Precinct 113,United States Senate,,Republican,"Roberts, Pat",61,013
+SEDGWICK,Wichita Precinct 114,United States Senate,,independent,"Orman, Greg",369,014
+SEDGWICK,Wichita Precinct 114,United States Senate,,Libertarian,"Batson, Randall",37,014
+SEDGWICK,Wichita Precinct 114,United States Senate,,Republican,"Roberts, Pat",21,014
+SEDGWICK,Wichita Precinct 116,United States Senate,,independent,"Orman, Greg",522,015
+SEDGWICK,Wichita Precinct 116,United States Senate,,Libertarian,"Batson, Randall",65,015
+SEDGWICK,Wichita Precinct 116,United States Senate,,Republican,"Roberts, Pat",42,015
+SEDGWICK,Wichita Precinct 117,United States Senate,,independent,"Orman, Greg",500,016
+SEDGWICK,Wichita Precinct 117,United States Senate,,Libertarian,"Batson, Randall",51,016
+SEDGWICK,Wichita Precinct 117,United States Senate,,Republican,"Roberts, Pat",40,016
+SEDGWICK,Wichita Precinct 118,United States Senate,,independent,"Orman, Greg",614,017
+SEDGWICK,Wichita Precinct 118,United States Senate,,Libertarian,"Batson, Randall",39,017
+SEDGWICK,Wichita Precinct 118,United States Senate,,Republican,"Roberts, Pat",88,017
+SEDGWICK,Wichita Precinct 119,United States Senate,,independent,"Orman, Greg",410,018
+SEDGWICK,Wichita Precinct 119,United States Senate,,Libertarian,"Batson, Randall",45,018
+SEDGWICK,Wichita Precinct 119,United States Senate,,Republican,"Roberts, Pat",134,018
+SEDGWICK,Wichita Precinct 120,United States Senate,,independent,"Orman, Greg",384,019
+SEDGWICK,Wichita Precinct 120,United States Senate,,Libertarian,"Batson, Randall",35,019
+SEDGWICK,Wichita Precinct 120,United States Senate,,Republican,"Roberts, Pat",178,019
+SEDGWICK,Wichita Precinct 121,United States Senate,,independent,"Orman, Greg",352,020
+SEDGWICK,Wichita Precinct 121,United States Senate,,Libertarian,"Batson, Randall",26,020
+SEDGWICK,Wichita Precinct 121,United States Senate,,Republican,"Roberts, Pat",299,020
+SEDGWICK,Wichita Precinct 122,United States Senate,,independent,"Orman, Greg",556,021
+SEDGWICK,Wichita Precinct 122,United States Senate,,Libertarian,"Batson, Randall",52,021
+SEDGWICK,Wichita Precinct 122,United States Senate,,Republican,"Roberts, Pat",412,021
+SEDGWICK,Wichita Precinct 123,United States Senate,,independent,"Orman, Greg",118,022
+SEDGWICK,Wichita Precinct 123,United States Senate,,Libertarian,"Batson, Randall",19,022
+SEDGWICK,Wichita Precinct 123,United States Senate,,Republican,"Roberts, Pat",157,022
+SEDGWICK,Wichita Precinct 124,United States Senate,,independent,"Orman, Greg",1,023
+SEDGWICK,Wichita Precinct 124,United States Senate,,Libertarian,"Batson, Randall",0,023
+SEDGWICK,Wichita Precinct 124,United States Senate,,Republican,"Roberts, Pat",0,023
+SEDGWICK,Wichita Precinct 127,United States Senate,,independent,"Orman, Greg",86,024
+SEDGWICK,Wichita Precinct 127,United States Senate,,Libertarian,"Batson, Randall",12,024
+SEDGWICK,Wichita Precinct 127,United States Senate,,Republican,"Roberts, Pat",112,024
+SEDGWICK,Wichita Precinct 128,United States Senate,,independent,"Orman, Greg",460,025
+SEDGWICK,Wichita Precinct 128,United States Senate,,Libertarian,"Batson, Randall",25,025
+SEDGWICK,Wichita Precinct 128,United States Senate,,Republican,"Roberts, Pat",348,025
+SEDGWICK,Wichita Precinct 129,United States Senate,,independent,"Orman, Greg",87,026
+SEDGWICK,Wichita Precinct 129,United States Senate,,Libertarian,"Batson, Randall",17,026
+SEDGWICK,Wichita Precinct 129,United States Senate,,Republican,"Roberts, Pat",59,026
+SEDGWICK,Wichita Precinct 130,United States Senate,,independent,"Orman, Greg",261,027
+SEDGWICK,Wichita Precinct 130,United States Senate,,Libertarian,"Batson, Randall",31,027
+SEDGWICK,Wichita Precinct 130,United States Senate,,Republican,"Roberts, Pat",163,027
+SEDGWICK,Wichita Precinct 205,United States Senate,,independent,"Orman, Greg",118,028
+SEDGWICK,Wichita Precinct 205,United States Senate,,Libertarian,"Batson, Randall",19,028
+SEDGWICK,Wichita Precinct 205,United States Senate,,Republican,"Roberts, Pat",67,028
+SEDGWICK,Wichita Precinct 206,United States Senate,,independent,"Orman, Greg",119,029
+SEDGWICK,Wichita Precinct 206,United States Senate,,Libertarian,"Batson, Randall",6,029
+SEDGWICK,Wichita Precinct 206,United States Senate,,Republican,"Roberts, Pat",107,029
+SEDGWICK,Wichita Precinct 207,United States Senate,,independent,"Orman, Greg",687,030
+SEDGWICK,Wichita Precinct 207,United States Senate,,Libertarian,"Batson, Randall",57,030
+SEDGWICK,Wichita Precinct 207,United States Senate,,Republican,"Roberts, Pat",559,030
+SEDGWICK,Wichita Precinct 208,United States Senate,,independent,"Orman, Greg",121,031
+SEDGWICK,Wichita Precinct 208,United States Senate,,Libertarian,"Batson, Randall",20,031
+SEDGWICK,Wichita Precinct 208,United States Senate,,Republican,"Roberts, Pat",113,031
+SEDGWICK,Wichita Precinct 209,United States Senate,,independent,"Orman, Greg",331,032
+SEDGWICK,Wichita Precinct 209,United States Senate,,Libertarian,"Batson, Randall",33,032
+SEDGWICK,Wichita Precinct 209,United States Senate,,Republican,"Roberts, Pat",249,032
+SEDGWICK,Wichita Precinct 210,United States Senate,,independent,"Orman, Greg",387,033
+SEDGWICK,Wichita Precinct 210,United States Senate,,Libertarian,"Batson, Randall",53,033
+SEDGWICK,Wichita Precinct 210,United States Senate,,Republican,"Roberts, Pat",324,033
+SEDGWICK,Wichita Precinct 211,United States Senate,,independent,"Orman, Greg",257,034
+SEDGWICK,Wichita Precinct 211,United States Senate,,Libertarian,"Batson, Randall",16,034
+SEDGWICK,Wichita Precinct 211,United States Senate,,Republican,"Roberts, Pat",278,034
+SEDGWICK,Wichita Precinct 212,United States Senate,,independent,"Orman, Greg",523,035
+SEDGWICK,Wichita Precinct 212,United States Senate,,Libertarian,"Batson, Randall",24,035
+SEDGWICK,Wichita Precinct 212,United States Senate,,Republican,"Roberts, Pat",509,035
+SEDGWICK,Wichita Precinct 213,United States Senate,,independent,"Orman, Greg",500,036
+SEDGWICK,Wichita Precinct 213,United States Senate,,Libertarian,"Batson, Randall",31,036
+SEDGWICK,Wichita Precinct 213,United States Senate,,Republican,"Roberts, Pat",646,036
+SEDGWICK,Wichita Precinct 214,United States Senate,,independent,"Orman, Greg",380,037
+SEDGWICK,Wichita Precinct 214,United States Senate,,Libertarian,"Batson, Randall",22,037
+SEDGWICK,Wichita Precinct 214,United States Senate,,Republican,"Roberts, Pat",672,037
+SEDGWICK,Wichita Precinct 215,United States Senate,,independent,"Orman, Greg",610,038
+SEDGWICK,Wichita Precinct 215,United States Senate,,Libertarian,"Batson, Randall",40,038
+SEDGWICK,Wichita Precinct 215,United States Senate,,Republican,"Roberts, Pat",785,038
+SEDGWICK,Wichita Precinct 216,United States Senate,,independent,"Orman, Greg",410,039
+SEDGWICK,Wichita Precinct 216,United States Senate,,Libertarian,"Batson, Randall",20,039
+SEDGWICK,Wichita Precinct 216,United States Senate,,Republican,"Roberts, Pat",468,039
+SEDGWICK,Wichita Precinct 217,United States Senate,,independent,"Orman, Greg",427,040
+SEDGWICK,Wichita Precinct 217,United States Senate,,Libertarian,"Batson, Randall",18,040
+SEDGWICK,Wichita Precinct 217,United States Senate,,Republican,"Roberts, Pat",672,040
+SEDGWICK,Wichita Precinct 218,United States Senate,,independent,"Orman, Greg",654,041
+SEDGWICK,Wichita Precinct 218,United States Senate,,Libertarian,"Batson, Randall",28,041
+SEDGWICK,Wichita Precinct 218,United States Senate,,Republican,"Roberts, Pat",869,041
+SEDGWICK,Wichita Precinct 221,United States Senate,,independent,"Orman, Greg",288,042
+SEDGWICK,Wichita Precinct 221,United States Senate,,Libertarian,"Batson, Randall",16,042
+SEDGWICK,Wichita Precinct 221,United States Senate,,Republican,"Roberts, Pat",397,042
+SEDGWICK,Wichita Precinct 222,United States Senate,,independent,"Orman, Greg",394,043
+SEDGWICK,Wichita Precinct 222,United States Senate,,Libertarian,"Batson, Randall",27,043
+SEDGWICK,Wichita Precinct 222,United States Senate,,Republican,"Roberts, Pat",536,043
+SEDGWICK,Wichita Precinct 223,United States Senate,,independent,"Orman, Greg",444,044
+SEDGWICK,Wichita Precinct 223,United States Senate,,Libertarian,"Batson, Randall",20,044
+SEDGWICK,Wichita Precinct 223,United States Senate,,Republican,"Roberts, Pat",697,044
+SEDGWICK,Wichita Precinct 224,United States Senate,,independent,"Orman, Greg",526,045
+SEDGWICK,Wichita Precinct 224,United States Senate,,Libertarian,"Batson, Randall",63,045
+SEDGWICK,Wichita Precinct 224,United States Senate,,Republican,"Roberts, Pat",518,045
+SEDGWICK,Wichita Precinct 225,United States Senate,,independent,"Orman, Greg",518,046
+SEDGWICK,Wichita Precinct 225,United States Senate,,Libertarian,"Batson, Randall",73,046
+SEDGWICK,Wichita Precinct 225,United States Senate,,Republican,"Roberts, Pat",554,046
+SEDGWICK,Wichita Precinct 226,United States Senate,,independent,"Orman, Greg",568,047
+SEDGWICK,Wichita Precinct 226,United States Senate,,Libertarian,"Batson, Randall",38,047
+SEDGWICK,Wichita Precinct 226,United States Senate,,Republican,"Roberts, Pat",883,047
+SEDGWICK,Wichita Precinct 227,United States Senate,,independent,"Orman, Greg",265,048
+SEDGWICK,Wichita Precinct 227,United States Senate,,Libertarian,"Batson, Randall",17,048
+SEDGWICK,Wichita Precinct 227,United States Senate,,Republican,"Roberts, Pat",530,048
+SEDGWICK,Wichita Precinct 228,United States Senate,,independent,"Orman, Greg",282,049
+SEDGWICK,Wichita Precinct 228,United States Senate,,Libertarian,"Batson, Randall",17,049
+SEDGWICK,Wichita Precinct 228,United States Senate,,Republican,"Roberts, Pat",770,049
+SEDGWICK,Wichita Precinct 233,United States Senate,,independent,"Orman, Greg",136,050
+SEDGWICK,Wichita Precinct 233,United States Senate,,Libertarian,"Batson, Randall",16,050
+SEDGWICK,Wichita Precinct 233,United States Senate,,Republican,"Roberts, Pat",142,050
+SEDGWICK,Wichita Precinct 235,United States Senate,,independent,"Orman, Greg",129,051
+SEDGWICK,Wichita Precinct 235,United States Senate,,Libertarian,"Batson, Randall",16,051
+SEDGWICK,Wichita Precinct 235,United States Senate,,Republican,"Roberts, Pat",82,051
+SEDGWICK,Wichita Precinct 236,United States Senate,,independent,"Orman, Greg",257,052
+SEDGWICK,Wichita Precinct 236,United States Senate,,Libertarian,"Batson, Randall",15,052
+SEDGWICK,Wichita Precinct 236,United States Senate,,Republican,"Roberts, Pat",433,052
+SEDGWICK,Wichita Precinct 239,United States Senate,,independent,"Orman, Greg",4,053
+SEDGWICK,Wichita Precinct 239,United States Senate,,Libertarian,"Batson, Randall",0,053
+SEDGWICK,Wichita Precinct 239,United States Senate,,Republican,"Roberts, Pat",15,053
+SEDGWICK,Wichita Precinct 241,United States Senate,,independent,"Orman, Greg",108,054
+SEDGWICK,Wichita Precinct 241,United States Senate,,Libertarian,"Batson, Randall",6,054
+SEDGWICK,Wichita Precinct 241,United States Senate,,Republican,"Roberts, Pat",166,054
+SEDGWICK,Wichita Precinct 301,United States Senate,,independent,"Orman, Greg",153,055
+SEDGWICK,Wichita Precinct 301,United States Senate,,Libertarian,"Batson, Randall",27,055
+SEDGWICK,Wichita Precinct 301,United States Senate,,Republican,"Roberts, Pat",145,055
+SEDGWICK,Wichita Precinct 302,United States Senate,,independent,"Orman, Greg",289,056
+SEDGWICK,Wichita Precinct 302,United States Senate,,Libertarian,"Batson, Randall",68,056
+SEDGWICK,Wichita Precinct 302,United States Senate,,Republican,"Roberts, Pat",223,056
+SEDGWICK,Wichita Precinct 303,United States Senate,,independent,"Orman, Greg",113,057
+SEDGWICK,Wichita Precinct 303,United States Senate,,Libertarian,"Batson, Randall",28,057
+SEDGWICK,Wichita Precinct 303,United States Senate,,Republican,"Roberts, Pat",127,057
+SEDGWICK,Wichita Precinct 304,United States Senate,,independent,"Orman, Greg",161,058
+SEDGWICK,Wichita Precinct 304,United States Senate,,Libertarian,"Batson, Randall",25,058
+SEDGWICK,Wichita Precinct 304,United States Senate,,Republican,"Roberts, Pat",126,058
+SEDGWICK,Wichita Precinct 305,United States Senate,,independent,"Orman, Greg",542,059
+SEDGWICK,Wichita Precinct 305,United States Senate,,Libertarian,"Batson, Randall",71,059
+SEDGWICK,Wichita Precinct 305,United States Senate,,Republican,"Roberts, Pat",393,059
+SEDGWICK,Wichita Precinct 306,United States Senate,,independent,"Orman, Greg",536,060
+SEDGWICK,Wichita Precinct 306,United States Senate,,Libertarian,"Batson, Randall",63,060
+SEDGWICK,Wichita Precinct 306,United States Senate,,Republican,"Roberts, Pat",328,060
+SEDGWICK,Wichita Precinct 307,United States Senate,,independent,"Orman, Greg",223,061
+SEDGWICK,Wichita Precinct 307,United States Senate,,Libertarian,"Batson, Randall",35,061
+SEDGWICK,Wichita Precinct 307,United States Senate,,Republican,"Roberts, Pat",146,061
+SEDGWICK,Wichita Precinct 308,United States Senate,,independent,"Orman, Greg",371,062
+SEDGWICK,Wichita Precinct 308,United States Senate,,Libertarian,"Batson, Randall",50,062
+SEDGWICK,Wichita Precinct 308,United States Senate,,Republican,"Roberts, Pat",263,062
+SEDGWICK,Wichita Precinct 309,United States Senate,,independent,"Orman, Greg",416,063
+SEDGWICK,Wichita Precinct 309,United States Senate,,Libertarian,"Batson, Randall",64,063
+SEDGWICK,Wichita Precinct 309,United States Senate,,Republican,"Roberts, Pat",320,063
+SEDGWICK,Wichita Precinct 310,United States Senate,,independent,"Orman, Greg",194,064
+SEDGWICK,Wichita Precinct 310,United States Senate,,Libertarian,"Batson, Randall",36,064
+SEDGWICK,Wichita Precinct 310,United States Senate,,Republican,"Roberts, Pat",127,064
+SEDGWICK,Wichita Precinct 311,United States Senate,,independent,"Orman, Greg",119,065
+SEDGWICK,Wichita Precinct 311,United States Senate,,Libertarian,"Batson, Randall",28,065
+SEDGWICK,Wichita Precinct 311,United States Senate,,Republican,"Roberts, Pat",154,065
+SEDGWICK,Wichita Precinct 312,United States Senate,,independent,"Orman, Greg",148,066
+SEDGWICK,Wichita Precinct 312,United States Senate,,Libertarian,"Batson, Randall",28,066
+SEDGWICK,Wichita Precinct 312,United States Senate,,Republican,"Roberts, Pat",128,066
+SEDGWICK,Wichita Precinct 313,United States Senate,,independent,"Orman, Greg",444,067
+SEDGWICK,Wichita Precinct 313,United States Senate,,Libertarian,"Batson, Randall",91,067
+SEDGWICK,Wichita Precinct 313,United States Senate,,Republican,"Roberts, Pat",329,067
+SEDGWICK,Wichita Precinct 314,United States Senate,,independent,"Orman, Greg",381,068
+SEDGWICK,Wichita Precinct 314,United States Senate,,Libertarian,"Batson, Randall",73,068
+SEDGWICK,Wichita Precinct 314,United States Senate,,Republican,"Roberts, Pat",338,068
+SEDGWICK,Wichita Precinct 315,United States Senate,,independent,"Orman, Greg",300,069
+SEDGWICK,Wichita Precinct 315,United States Senate,,Libertarian,"Batson, Randall",67,069
+SEDGWICK,Wichita Precinct 315,United States Senate,,Republican,"Roberts, Pat",237,069
+SEDGWICK,Wichita Precinct 316,United States Senate,,independent,"Orman, Greg",307,070
+SEDGWICK,Wichita Precinct 316,United States Senate,,Libertarian,"Batson, Randall",55,070
+SEDGWICK,Wichita Precinct 316,United States Senate,,Republican,"Roberts, Pat",366,070
+SEDGWICK,Wichita Precinct 317,United States Senate,,independent,"Orman, Greg",6,071
+SEDGWICK,Wichita Precinct 317,United States Senate,,Libertarian,"Batson, Randall",0,071
+SEDGWICK,Wichita Precinct 317,United States Senate,,Republican,"Roberts, Pat",6,071
+SEDGWICK,Wichita Precinct 318,United States Senate,,independent,"Orman, Greg",8,072
+SEDGWICK,Wichita Precinct 318,United States Senate,,Libertarian,"Batson, Randall",2,072
+SEDGWICK,Wichita Precinct 318,United States Senate,,Republican,"Roberts, Pat",13,072
+SEDGWICK,Wichita Precinct 319,United States Senate,,independent,"Orman, Greg",109,073
+SEDGWICK,Wichita Precinct 319,United States Senate,,Libertarian,"Batson, Randall",17,073
+SEDGWICK,Wichita Precinct 319,United States Senate,,Republican,"Roberts, Pat",58,073
+SEDGWICK,Wichita Precinct 320,United States Senate,,independent,"Orman, Greg",73,074
+SEDGWICK,Wichita Precinct 320,United States Senate,,Libertarian,"Batson, Randall",14,074
+SEDGWICK,Wichita Precinct 320,United States Senate,,Republican,"Roberts, Pat",32,074
+SEDGWICK,Wichita Precinct 321,United States Senate,,independent,"Orman, Greg",11,075
+SEDGWICK,Wichita Precinct 321,United States Senate,,Libertarian,"Batson, Randall",2,075
+SEDGWICK,Wichita Precinct 321,United States Senate,,Republican,"Roberts, Pat",3,075
+SEDGWICK,Wichita Precinct 324,United States Senate,,independent,"Orman, Greg",145,076
+SEDGWICK,Wichita Precinct 324,United States Senate,,Libertarian,"Batson, Randall",29,076
+SEDGWICK,Wichita Precinct 324,United States Senate,,Republican,"Roberts, Pat",95,076
+SEDGWICK,Wichita Precinct 325,United States Senate,,independent,"Orman, Greg",334,077
+SEDGWICK,Wichita Precinct 325,United States Senate,,Libertarian,"Batson, Randall",43,077
+SEDGWICK,Wichita Precinct 325,United States Senate,,Republican,"Roberts, Pat",272,077
+SEDGWICK,Wichita Precinct 326,United States Senate,,independent,"Orman, Greg",42,078
+SEDGWICK,Wichita Precinct 326,United States Senate,,Libertarian,"Batson, Randall",8,078
+SEDGWICK,Wichita Precinct 326,United States Senate,,Republican,"Roberts, Pat",22,078
+SEDGWICK,Wichita Precinct 401,United States Senate,,independent,"Orman, Greg",163,079
+SEDGWICK,Wichita Precinct 401,United States Senate,,Libertarian,"Batson, Randall",20,079
+SEDGWICK,Wichita Precinct 401,United States Senate,,Republican,"Roberts, Pat",246,079
+SEDGWICK,Wichita Precinct 402,United States Senate,,independent,"Orman, Greg",178,080
+SEDGWICK,Wichita Precinct 402,United States Senate,,Libertarian,"Batson, Randall",18,080
+SEDGWICK,Wichita Precinct 402,United States Senate,,Republican,"Roberts, Pat",246,080
+SEDGWICK,Wichita Precinct 403,United States Senate,,independent,"Orman, Greg",219,081
+SEDGWICK,Wichita Precinct 403,United States Senate,,Libertarian,"Batson, Randall",34,081
+SEDGWICK,Wichita Precinct 403,United States Senate,,Republican,"Roberts, Pat",429,081
+SEDGWICK,Wichita Precinct 404,United States Senate,,independent,"Orman, Greg",441,082
+SEDGWICK,Wichita Precinct 404,United States Senate,,Libertarian,"Batson, Randall",77,082
+SEDGWICK,Wichita Precinct 404,United States Senate,,Republican,"Roberts, Pat",391,082
+SEDGWICK,Wichita Precinct 405,United States Senate,,independent,"Orman, Greg",326,083
+SEDGWICK,Wichita Precinct 405,United States Senate,,Libertarian,"Batson, Randall",51,083
+SEDGWICK,Wichita Precinct 405,United States Senate,,Republican,"Roberts, Pat",300,083
+SEDGWICK,Wichita Precinct 406,United States Senate,,independent,"Orman, Greg",278,084
+SEDGWICK,Wichita Precinct 406,United States Senate,,Libertarian,"Batson, Randall",53,084
+SEDGWICK,Wichita Precinct 406,United States Senate,,Republican,"Roberts, Pat",223,084
+SEDGWICK,Wichita Precinct 407,United States Senate,,independent,"Orman, Greg",43,085
+SEDGWICK,Wichita Precinct 407,United States Senate,,Libertarian,"Batson, Randall",6,085
+SEDGWICK,Wichita Precinct 407,United States Senate,,Republican,"Roberts, Pat",27,085
+SEDGWICK,Wichita Precinct 408,United States Senate,,independent,"Orman, Greg",295,086
+SEDGWICK,Wichita Precinct 408,United States Senate,,Libertarian,"Batson, Randall",49,086
+SEDGWICK,Wichita Precinct 408,United States Senate,,Republican,"Roberts, Pat",227,086
+SEDGWICK,Wichita Precinct 409,United States Senate,,independent,"Orman, Greg",170,087
+SEDGWICK,Wichita Precinct 409,United States Senate,,Libertarian,"Batson, Randall",20,087
+SEDGWICK,Wichita Precinct 409,United States Senate,,Republican,"Roberts, Pat",132,087
+SEDGWICK,Wichita Precinct 410,United States Senate,,independent,"Orman, Greg",500,088
+SEDGWICK,Wichita Precinct 410,United States Senate,,Libertarian,"Batson, Randall",61,088
+SEDGWICK,Wichita Precinct 410,United States Senate,,Republican,"Roberts, Pat",864,088
+SEDGWICK,Wichita Precinct 412,United States Senate,,independent,"Orman, Greg",512,089
+SEDGWICK,Wichita Precinct 412,United States Senate,,Libertarian,"Batson, Randall",71,089
+SEDGWICK,Wichita Precinct 412,United States Senate,,Republican,"Roberts, Pat",784,089
+SEDGWICK,Wichita Precinct 413,United States Senate,,independent,"Orman, Greg",377,090
+SEDGWICK,Wichita Precinct 413,United States Senate,,Libertarian,"Batson, Randall",59,090
+SEDGWICK,Wichita Precinct 413,United States Senate,,Republican,"Roberts, Pat",563,090
+SEDGWICK,Wichita Precinct 414,United States Senate,,independent,"Orman, Greg",90,091
+SEDGWICK,Wichita Precinct 414,United States Senate,,Libertarian,"Batson, Randall",10,091
+SEDGWICK,Wichita Precinct 414,United States Senate,,Republican,"Roberts, Pat",106,091
+SEDGWICK,Wichita Precinct 416,United States Senate,,independent,"Orman, Greg",262,092
+SEDGWICK,Wichita Precinct 416,United States Senate,,Libertarian,"Batson, Randall",33,092
+SEDGWICK,Wichita Precinct 416,United States Senate,,Republican,"Roberts, Pat",375,092
+SEDGWICK,Wichita Precinct 417,United States Senate,,independent,"Orman, Greg",233,093
+SEDGWICK,Wichita Precinct 417,United States Senate,,Libertarian,"Batson, Randall",41,093
+SEDGWICK,Wichita Precinct 417,United States Senate,,Republican,"Roberts, Pat",234,093
+SEDGWICK,Wichita Precinct 418,United States Senate,,independent,"Orman, Greg",321,094
+SEDGWICK,Wichita Precinct 418,United States Senate,,Libertarian,"Batson, Randall",65,094
+SEDGWICK,Wichita Precinct 418,United States Senate,,Republican,"Roberts, Pat",363,094
+SEDGWICK,Wichita Precinct 419,United States Senate,,independent,"Orman, Greg",324,095
+SEDGWICK,Wichita Precinct 419,United States Senate,,Libertarian,"Batson, Randall",57,095
+SEDGWICK,Wichita Precinct 419,United States Senate,,Republican,"Roberts, Pat",272,095
+SEDGWICK,Wichita Precinct 420,United States Senate,,independent,"Orman, Greg",313,096
+SEDGWICK,Wichita Precinct 420,United States Senate,,Libertarian,"Batson, Randall",59,096
+SEDGWICK,Wichita Precinct 420,United States Senate,,Republican,"Roberts, Pat",325,096
+SEDGWICK,Wichita Precinct 422,United States Senate,,independent,"Orman, Greg",191,097
+SEDGWICK,Wichita Precinct 422,United States Senate,,Libertarian,"Batson, Randall",37,097
+SEDGWICK,Wichita Precinct 422,United States Senate,,Republican,"Roberts, Pat",202,097
+SEDGWICK,Wichita Precinct 423,United States Senate,,independent,"Orman, Greg",237,098
+SEDGWICK,Wichita Precinct 423,United States Senate,,Libertarian,"Batson, Randall",39,098
+SEDGWICK,Wichita Precinct 423,United States Senate,,Republican,"Roberts, Pat",247,098
+SEDGWICK,Wichita Precinct 424,United States Senate,,independent,"Orman, Greg",84,099
+SEDGWICK,Wichita Precinct 424,United States Senate,,Libertarian,"Batson, Randall",13,099
+SEDGWICK,Wichita Precinct 424,United States Senate,,Republican,"Roberts, Pat",72,099
+SEDGWICK,Wichita Precinct 425,United States Senate,,independent,"Orman, Greg",403,100
+SEDGWICK,Wichita Precinct 425,United States Senate,,Libertarian,"Batson, Randall",74,100
+SEDGWICK,Wichita Precinct 425,United States Senate,,Republican,"Roberts, Pat",509,100
+SEDGWICK,Wichita Precinct 429,United States Senate,,independent,"Orman, Greg",185,101
+SEDGWICK,Wichita Precinct 429,United States Senate,,Libertarian,"Batson, Randall",18,101
+SEDGWICK,Wichita Precinct 429,United States Senate,,Republican,"Roberts, Pat",152,101
+SEDGWICK,Wichita Precinct 433,United States Senate,,independent,"Orman, Greg",98,102
+SEDGWICK,Wichita Precinct 433,United States Senate,,Libertarian,"Batson, Randall",22,102
+SEDGWICK,Wichita Precinct 433,United States Senate,,Republican,"Roberts, Pat",117,102
+SEDGWICK,Wichita Precinct 437,United States Senate,,independent,"Orman, Greg",74,103
+SEDGWICK,Wichita Precinct 437,United States Senate,,Libertarian,"Batson, Randall",22,103
+SEDGWICK,Wichita Precinct 437,United States Senate,,Republican,"Roberts, Pat",134,103
+SEDGWICK,Wichita Precinct 503,United States Senate,,independent,"Orman, Greg",373,104
+SEDGWICK,Wichita Precinct 503,United States Senate,,Libertarian,"Batson, Randall",37,104
+SEDGWICK,Wichita Precinct 503,United States Senate,,Republican,"Roberts, Pat",363,104
+SEDGWICK,Wichita Precinct 504,United States Senate,,independent,"Orman, Greg",246,105
+SEDGWICK,Wichita Precinct 504,United States Senate,,Libertarian,"Batson, Randall",31,105
+SEDGWICK,Wichita Precinct 504,United States Senate,,Republican,"Roberts, Pat",270,105
+SEDGWICK,Wichita Precinct 506,United States Senate,,independent,"Orman, Greg",431,106
+SEDGWICK,Wichita Precinct 506,United States Senate,,Libertarian,"Batson, Randall",52,106
+SEDGWICK,Wichita Precinct 506,United States Senate,,Republican,"Roberts, Pat",554,106
+SEDGWICK,Wichita Precinct 507,United States Senate,,independent,"Orman, Greg",433,107
+SEDGWICK,Wichita Precinct 507,United States Senate,,Libertarian,"Batson, Randall",47,107
+SEDGWICK,Wichita Precinct 507,United States Senate,,Republican,"Roberts, Pat",496,107
+SEDGWICK,Wichita Precinct 508,United States Senate,,independent,"Orman, Greg",385,108
+SEDGWICK,Wichita Precinct 508,United States Senate,,Libertarian,"Batson, Randall",35,108
+SEDGWICK,Wichita Precinct 508,United States Senate,,Republican,"Roberts, Pat",453,108
+SEDGWICK,Wichita Precinct 509,United States Senate,,independent,"Orman, Greg",352,109
+SEDGWICK,Wichita Precinct 509,United States Senate,,Libertarian,"Batson, Randall",40,109
+SEDGWICK,Wichita Precinct 509,United States Senate,,Republican,"Roberts, Pat",452,109
+SEDGWICK,Wichita Precinct 510,United States Senate,,independent,"Orman, Greg",427,110
+SEDGWICK,Wichita Precinct 510,United States Senate,,Libertarian,"Batson, Randall",17,110
+SEDGWICK,Wichita Precinct 510,United States Senate,,Republican,"Roberts, Pat",776,110
+SEDGWICK,Wichita Precinct 512,United States Senate,,independent,"Orman, Greg",679,111
+SEDGWICK,Wichita Precinct 512,United States Senate,,Libertarian,"Batson, Randall",55,111
+SEDGWICK,Wichita Precinct 512,United States Senate,,Republican,"Roberts, Pat",1066,111
+SEDGWICK,Wichita Precinct 513,United States Senate,,independent,"Orman, Greg",153,112
+SEDGWICK,Wichita Precinct 513,United States Senate,,Libertarian,"Batson, Randall",15,112
+SEDGWICK,Wichita Precinct 513,United States Senate,,Republican,"Roberts, Pat",350,112
+SEDGWICK,Wichita Precinct 514,United States Senate,,independent,"Orman, Greg",481,113
+SEDGWICK,Wichita Precinct 514,United States Senate,,Libertarian,"Batson, Randall",40,113
+SEDGWICK,Wichita Precinct 514,United States Senate,,Republican,"Roberts, Pat",689,113
+SEDGWICK,Wichita Precinct 515,United States Senate,,independent,"Orman, Greg",455,114
+SEDGWICK,Wichita Precinct 515,United States Senate,,Libertarian,"Batson, Randall",30,114
+SEDGWICK,Wichita Precinct 515,United States Senate,,Republican,"Roberts, Pat",590,114
+SEDGWICK,Wichita Precinct 516,United States Senate,,independent,"Orman, Greg",282,115
+SEDGWICK,Wichita Precinct 516,United States Senate,,Libertarian,"Batson, Randall",20,115
+SEDGWICK,Wichita Precinct 516,United States Senate,,Republican,"Roberts, Pat",423,115
+SEDGWICK,Wichita Precinct 517,United States Senate,,independent,"Orman, Greg",328,116
+SEDGWICK,Wichita Precinct 517,United States Senate,,Libertarian,"Batson, Randall",40,116
+SEDGWICK,Wichita Precinct 517,United States Senate,,Republican,"Roberts, Pat",367,116
+SEDGWICK,Wichita Precinct 518,United States Senate,,independent,"Orman, Greg",349,117
+SEDGWICK,Wichita Precinct 518,United States Senate,,Libertarian,"Batson, Randall",33,117
+SEDGWICK,Wichita Precinct 518,United States Senate,,Republican,"Roberts, Pat",504,117
+SEDGWICK,Wichita Precinct 519,United States Senate,,independent,"Orman, Greg",450,118
+SEDGWICK,Wichita Precinct 519,United States Senate,,Libertarian,"Batson, Randall",54,118
+SEDGWICK,Wichita Precinct 519,United States Senate,,Republican,"Roberts, Pat",481,118
+SEDGWICK,Wichita Precinct 522,United States Senate,,independent,"Orman, Greg",370,119
+SEDGWICK,Wichita Precinct 522,United States Senate,,Libertarian,"Batson, Randall",39,119
+SEDGWICK,Wichita Precinct 522,United States Senate,,Republican,"Roberts, Pat",538,119
+SEDGWICK,Wichita Precinct 523,United States Senate,,independent,"Orman, Greg",386,120
+SEDGWICK,Wichita Precinct 523,United States Senate,,Libertarian,"Batson, Randall",38,120
+SEDGWICK,Wichita Precinct 523,United States Senate,,Republican,"Roberts, Pat",536,120
+SEDGWICK,Wichita Precinct 524,United States Senate,,independent,"Orman, Greg",615,122
+SEDGWICK,Wichita Precinct 524,United States Senate,,Libertarian,"Batson, Randall",59,122
+SEDGWICK,Wichita Precinct 524,United States Senate,,Republican,"Roberts, Pat",852,122
+SEDGWICK,Wichita Precinct 525,United States Senate,,independent,"Orman, Greg",465,123
+SEDGWICK,Wichita Precinct 525,United States Senate,,Libertarian,"Batson, Randall",57,123
+SEDGWICK,Wichita Precinct 525,United States Senate,,Republican,"Roberts, Pat",494,123
+SEDGWICK,Wichita Precinct 526,United States Senate,,independent,"Orman, Greg",388,124
+SEDGWICK,Wichita Precinct 526,United States Senate,,Libertarian,"Batson, Randall",45,124
+SEDGWICK,Wichita Precinct 526,United States Senate,,Republican,"Roberts, Pat",624,124
+SEDGWICK,Wichita Precinct 527,United States Senate,,independent,"Orman, Greg",396,125
+SEDGWICK,Wichita Precinct 527,United States Senate,,Libertarian,"Batson, Randall",54,125
+SEDGWICK,Wichita Precinct 527,United States Senate,,Republican,"Roberts, Pat",590,125
+SEDGWICK,Wichita Precinct 530,United States Senate,,independent,"Orman, Greg",330,126
+SEDGWICK,Wichita Precinct 530,United States Senate,,Libertarian,"Batson, Randall",26,126
+SEDGWICK,Wichita Precinct 530,United States Senate,,Republican,"Roberts, Pat",662,126
+SEDGWICK,Wichita Precinct 531,United States Senate,,independent,"Orman, Greg",621,127
+SEDGWICK,Wichita Precinct 531,United States Senate,,Libertarian,"Batson, Randall",46,127
+SEDGWICK,Wichita Precinct 531,United States Senate,,Republican,"Roberts, Pat",979,127
+SEDGWICK,Wichita Precinct 534,United States Senate,,independent,"Orman, Greg",29,128
+SEDGWICK,Wichita Precinct 534,United States Senate,,Libertarian,"Batson, Randall",2,128
+SEDGWICK,Wichita Precinct 534,United States Senate,,Republican,"Roberts, Pat",65,128
+SEDGWICK,Wichita Precinct 538,United States Senate,,independent,"Orman, Greg",73,129
+SEDGWICK,Wichita Precinct 538,United States Senate,,Libertarian,"Batson, Randall",8,129
+SEDGWICK,Wichita Precinct 538,United States Senate,,Republican,"Roberts, Pat",120,129
+SEDGWICK,Wichita Precinct 539,United States Senate,,independent,"Orman, Greg",187,130
+SEDGWICK,Wichita Precinct 539,United States Senate,,Libertarian,"Batson, Randall",24,130
+SEDGWICK,Wichita Precinct 539,United States Senate,,Republican,"Roberts, Pat",292,130
+SEDGWICK,Wichita Precinct 601,United States Senate,,independent,"Orman, Greg",324,131
+SEDGWICK,Wichita Precinct 601,United States Senate,,Libertarian,"Batson, Randall",40,131
+SEDGWICK,Wichita Precinct 601,United States Senate,,Republican,"Roberts, Pat",135,131
+SEDGWICK,Wichita Precinct 602,United States Senate,,independent,"Orman, Greg",467,132
+SEDGWICK,Wichita Precinct 602,United States Senate,,Libertarian,"Batson, Randall",72,132
+SEDGWICK,Wichita Precinct 602,United States Senate,,Republican,"Roberts, Pat",416,132
+SEDGWICK,Wichita Precinct 603,United States Senate,,independent,"Orman, Greg",159,133
+SEDGWICK,Wichita Precinct 603,United States Senate,,Libertarian,"Batson, Randall",14,133
+SEDGWICK,Wichita Precinct 603,United States Senate,,Republican,"Roberts, Pat",297,133
+SEDGWICK,Wichita Precinct 604,United States Senate,,independent,"Orman, Greg",418,134
+SEDGWICK,Wichita Precinct 604,United States Senate,,Libertarian,"Batson, Randall",80,134
+SEDGWICK,Wichita Precinct 604,United States Senate,,Republican,"Roberts, Pat",418,134
+SEDGWICK,Wichita Precinct 605,United States Senate,,independent,"Orman, Greg",169,135
+SEDGWICK,Wichita Precinct 605,United States Senate,,Libertarian,"Batson, Randall",21,135
+SEDGWICK,Wichita Precinct 605,United States Senate,,Republican,"Roberts, Pat",154,135
+SEDGWICK,Wichita Precinct 606,United States Senate,,independent,"Orman, Greg",160,136
+SEDGWICK,Wichita Precinct 606,United States Senate,,Libertarian,"Batson, Randall",19,136
+SEDGWICK,Wichita Precinct 606,United States Senate,,Republican,"Roberts, Pat",111,136
+SEDGWICK,Wichita Precinct 607,United States Senate,,independent,"Orman, Greg",775,137
+SEDGWICK,Wichita Precinct 607,United States Senate,,Libertarian,"Batson, Randall",56,137
+SEDGWICK,Wichita Precinct 607,United States Senate,,Republican,"Roberts, Pat",344,137
+SEDGWICK,Wichita Precinct 608,United States Senate,,independent,"Orman, Greg",445,138
+SEDGWICK,Wichita Precinct 608,United States Senate,,Libertarian,"Batson, Randall",45,138
+SEDGWICK,Wichita Precinct 608,United States Senate,,Republican,"Roberts, Pat",168,138
+SEDGWICK,Wichita Precinct 609,United States Senate,,independent,"Orman, Greg",784,139
+SEDGWICK,Wichita Precinct 609,United States Senate,,Libertarian,"Batson, Randall",85,139
+SEDGWICK,Wichita Precinct 609,United States Senate,,Republican,"Roberts, Pat",409,139
+SEDGWICK,Wichita Precinct 610,United States Senate,,independent,"Orman, Greg",470,140
+SEDGWICK,Wichita Precinct 610,United States Senate,,Libertarian,"Batson, Randall",50,140
+SEDGWICK,Wichita Precinct 610,United States Senate,,Republican,"Roberts, Pat",464,140
+SEDGWICK,Attica Precinct 08,United States Senate,,independent,"Orman, Greg",13,140010
+SEDGWICK,Attica Precinct 08,United States Senate,,Libertarian,"Batson, Randall",3,140010
+SEDGWICK,Attica Precinct 08,United States Senate,,Republican,"Roberts, Pat",30,140010
+SEDGWICK,Delano Precinct 03,United States Senate,,independent,"Orman, Greg",0,140020
+SEDGWICK,Delano Precinct 03,United States Senate,,Libertarian,"Batson, Randall",0,140020
+SEDGWICK,Delano Precinct 03,United States Senate,,Republican,"Roberts, Pat",2,140020
+SEDGWICK,Delano Precinct 04,United States Senate,,independent,"Orman, Greg",1,140030
+SEDGWICK,Delano Precinct 04,United States Senate,,Libertarian,"Batson, Randall",0,140030
+SEDGWICK,Delano Precinct 04,United States Senate,,Republican,"Roberts, Pat",0,140030
+SEDGWICK,Riverside Precinct 13,United States Senate,,independent,"Orman, Greg",3,140040
+SEDGWICK,Riverside Precinct 13,United States Senate,,Libertarian,"Batson, Randall",0,140040
+SEDGWICK,Riverside Precinct 13,United States Senate,,Republican,"Roberts, Pat",4,140040
+SEDGWICK,Wichita Precinct 611,United States Senate,,independent,"Orman, Greg",251,141
+SEDGWICK,Wichita Precinct 611,United States Senate,,Libertarian,"Batson, Randall",19,141
+SEDGWICK,Wichita Precinct 611,United States Senate,,Republican,"Roberts, Pat",232,141
+SEDGWICK,Wichita Precinct 612,United States Senate,,independent,"Orman, Greg",554,142
+SEDGWICK,Wichita Precinct 612,United States Senate,,Libertarian,"Batson, Randall",62,142
+SEDGWICK,Wichita Precinct 612,United States Senate,,Republican,"Roberts, Pat",591,142
+SEDGWICK,Wichita Precinct 613,United States Senate,,independent,"Orman, Greg",481,143
+SEDGWICK,Wichita Precinct 613,United States Senate,,Libertarian,"Batson, Randall",45,143
+SEDGWICK,Wichita Precinct 613,United States Senate,,Republican,"Roberts, Pat",419,143
+SEDGWICK,Wichita Precinct 614,United States Senate,,independent,"Orman, Greg",192,144
+SEDGWICK,Wichita Precinct 614,United States Senate,,Libertarian,"Batson, Randall",20,144
+SEDGWICK,Wichita Precinct 614,United States Senate,,Republican,"Roberts, Pat",140,144
+SEDGWICK,Wichita Precinct 615,United States Senate,,independent,"Orman, Greg",511,145
+SEDGWICK,Wichita Precinct 615,United States Senate,,Libertarian,"Batson, Randall",95,145
+SEDGWICK,Wichita Precinct 615,United States Senate,,Republican,"Roberts, Pat",227,145
+SEDGWICK,Wichita Precinct 616,United States Senate,,independent,"Orman, Greg",218,146
+SEDGWICK,Wichita Precinct 616,United States Senate,,Libertarian,"Batson, Randall",39,146
+SEDGWICK,Wichita Precinct 616,United States Senate,,Republican,"Roberts, Pat",202,146
+SEDGWICK,Wichita Precinct 617,United States Senate,,independent,"Orman, Greg",134,147
+SEDGWICK,Wichita Precinct 617,United States Senate,,Libertarian,"Batson, Randall",38,147
+SEDGWICK,Wichita Precinct 617,United States Senate,,Republican,"Roberts, Pat",91,147
+SEDGWICK,Wichita Precinct 618,United States Senate,,independent,"Orman, Greg",398,148
+SEDGWICK,Wichita Precinct 618,United States Senate,,Libertarian,"Batson, Randall",44,148
+SEDGWICK,Wichita Precinct 618,United States Senate,,Republican,"Roberts, Pat",473,148
+SEDGWICK,Wichita Precinct 619,United States Senate,,independent,"Orman, Greg",446,149
+SEDGWICK,Wichita Precinct 619,United States Senate,,Libertarian,"Batson, Randall",57,149
+SEDGWICK,Wichita Precinct 619,United States Senate,,Republican,"Roberts, Pat",438,149
+SEDGWICK,Wichita Precinct 621,United States Senate,,independent,"Orman, Greg",14,150
+SEDGWICK,Wichita Precinct 621,United States Senate,,Libertarian,"Batson, Randall",1,150
+SEDGWICK,Wichita Precinct 621,United States Senate,,Republican,"Roberts, Pat",23,150
+SEDGWICK,Wichita Precinct 622,United States Senate,,independent,"Orman, Greg",446,151
+SEDGWICK,Wichita Precinct 622,United States Senate,,Libertarian,"Batson, Randall",47,151
+SEDGWICK,Wichita Precinct 622,United States Senate,,Republican,"Roberts, Pat",680,151
+SEDGWICK,Wichita Precinct 623,United States Senate,,independent,"Orman, Greg",344,152
+SEDGWICK,Wichita Precinct 623,United States Senate,,Libertarian,"Batson, Randall",45,152
+SEDGWICK,Wichita Precinct 623,United States Senate,,Republican,"Roberts, Pat",612,152
+SEDGWICK,Wichita Precinct 624,United States Senate,,independent,"Orman, Greg",36,153
+SEDGWICK,Wichita Precinct 624,United States Senate,,Libertarian,"Batson, Randall",8,153
+SEDGWICK,Wichita Precinct 624,United States Senate,,Republican,"Roberts, Pat",27,153
+SEDGWICK,Wichita Precinct 627,United States Senate,,independent,"Orman, Greg",33,154
+SEDGWICK,Wichita Precinct 627,United States Senate,,Libertarian,"Batson, Randall",8,154
+SEDGWICK,Wichita Precinct 627,United States Senate,,Republican,"Roberts, Pat",36,154
+SEDGWICK,Afton,United States Senate,,independent,"Orman, Greg",193,155
+SEDGWICK,Afton,United States Senate,,Libertarian,"Batson, Randall",14,155
+SEDGWICK,Afton,United States Senate,,Republican,"Roberts, Pat",420,155
+SEDGWICK,Attica Precinct 02,United States Senate,,independent,"Orman, Greg",42,156
+SEDGWICK,Attica Precinct 02,United States Senate,,Libertarian,"Batson, Randall",4,156
+SEDGWICK,Attica Precinct 02,United States Senate,,Republican,"Roberts, Pat",60,156
+SEDGWICK,Attica Precinct 03,United States Senate,,independent,"Orman, Greg",127,157
+SEDGWICK,Attica Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,157
+SEDGWICK,Attica Precinct 03,United States Senate,,Republican,"Roberts, Pat",341,157
+SEDGWICK,Attica Precinct 04,United States Senate,,independent,"Orman, Greg",1,158
+SEDGWICK,Attica Precinct 04,United States Senate,,Libertarian,"Batson, Randall",0,158
+SEDGWICK,Attica Precinct 04,United States Senate,,Republican,"Roberts, Pat",2,158
+SEDGWICK,Attica Precinct 05,United States Senate,,independent,"Orman, Greg",54,159
+SEDGWICK,Attica Precinct 05,United States Senate,,Libertarian,"Batson, Randall",7,159
+SEDGWICK,Attica Precinct 05,United States Senate,,Republican,"Roberts, Pat",147,159
+SEDGWICK,Attica Precinct 06,United States Senate,,independent,"Orman, Greg",5,160
+SEDGWICK,Attica Precinct 06,United States Senate,,Libertarian,"Batson, Randall",0,160
+SEDGWICK,Attica Precinct 06,United States Senate,,Republican,"Roberts, Pat",40,160
+SEDGWICK,Bel Aire Precinct 01,United States Senate,,independent,"Orman, Greg",436,161
+SEDGWICK,Bel Aire Precinct 01,United States Senate,,Libertarian,"Batson, Randall",51,161
+SEDGWICK,Bel Aire Precinct 01,United States Senate,,Republican,"Roberts, Pat",624,161
+SEDGWICK,Bel Aire Precinct 02,United States Senate,,independent,"Orman, Greg",433,162
+SEDGWICK,Bel Aire Precinct 02,United States Senate,,Libertarian,"Batson, Randall",31,162
+SEDGWICK,Bel Aire Precinct 02,United States Senate,,Republican,"Roberts, Pat",524,162
+SEDGWICK,Bel Aire Precinct 03,United States Senate,,independent,"Orman, Greg",274,163
+SEDGWICK,Bel Aire Precinct 03,United States Senate,,Libertarian,"Batson, Randall",31,163
+SEDGWICK,Bel Aire Precinct 03,United States Senate,,Republican,"Roberts, Pat",404,163
+SEDGWICK,Derby Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",355,164
+SEDGWICK,Derby Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",41,164
+SEDGWICK,Derby Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",572,164
+SEDGWICK,Derby Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",232,165
+SEDGWICK,Derby Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",19,165
+SEDGWICK,Derby Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",271,165
+SEDGWICK,Derby Ward 01 Precinct 04,United States Senate,,independent,"Orman, Greg",133,166
+SEDGWICK,Derby Ward 01 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",15,166
+SEDGWICK,Derby Ward 01 Precinct 04,United States Senate,,Republican,"Roberts, Pat",216,166
+SEDGWICK,Derby Ward 01 Precinct 05,United States Senate,,independent,"Orman, Greg",4,167
+SEDGWICK,Derby Ward 01 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",0,167
+SEDGWICK,Derby Ward 01 Precinct 05,United States Senate,,Republican,"Roberts, Pat",25,167
+SEDGWICK,Derby Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",207,168
+SEDGWICK,Derby Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",34,168
+SEDGWICK,Derby Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",286,168
+SEDGWICK,Derby Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",243,169
+SEDGWICK,Derby Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",17,169
+SEDGWICK,Derby Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",313,169
+SEDGWICK,Derby Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",270,170
+SEDGWICK,Derby Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",27,170
+SEDGWICK,Derby Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",413,170
+SEDGWICK,Derby Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",52,171
+SEDGWICK,Derby Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",3,171
+SEDGWICK,Derby Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",76,171
+SEDGWICK,Derby Ward 02 Precinct 05,United States Senate,,independent,"Orman, Greg",26,172
+SEDGWICK,Derby Ward 02 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",1,172
+SEDGWICK,Derby Ward 02 Precinct 05,United States Senate,,Republican,"Roberts, Pat",22,172
+SEDGWICK,Derby Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",78,173
+SEDGWICK,Derby Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",12,173
+SEDGWICK,Derby Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",123,173
+SEDGWICK,Derby Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",284,174
+SEDGWICK,Derby Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",26,174
+SEDGWICK,Derby Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",352,174
+SEDGWICK,Derby Ward 03 Precinct 06,United States Senate,,independent,"Orman, Greg",365,175
+SEDGWICK,Derby Ward 03 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",36,175
+SEDGWICK,Derby Ward 03 Precinct 06,United States Senate,,Republican,"Roberts, Pat",477,175
+SEDGWICK,Derby Ward 03 Precinct 07,United States Senate,,independent,"Orman, Greg",57,176
+SEDGWICK,Derby Ward 03 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",8,176
+SEDGWICK,Derby Ward 03 Precinct 07,United States Senate,,Republican,"Roberts, Pat",63,176
+SEDGWICK,Derby Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",163,177
+SEDGWICK,Derby Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",32,177
+SEDGWICK,Derby Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",203,177
+SEDGWICK,Derby Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",523,178
+SEDGWICK,Derby Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",56,178
+SEDGWICK,Derby Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",901,178
+SEDGWICK,Eagle,United States Senate,,independent,"Orman, Greg",138,180
+SEDGWICK,Eagle,United States Senate,,Libertarian,"Batson, Randall",17,180
+SEDGWICK,Eagle,United States Senate,,Republican,"Roberts, Pat",218,180
+SEDGWICK,Erie,United States Senate,,independent,"Orman, Greg",13,181
+SEDGWICK,Erie,United States Senate,,Libertarian,"Batson, Randall",3,181
+SEDGWICK,Erie,United States Senate,,Republican,"Roberts, Pat",24,181
+SEDGWICK,Garden Plain,United States Senate,,independent,"Orman, Greg",184,182
+SEDGWICK,Garden Plain,United States Senate,,Libertarian,"Batson, Randall",28,182
+SEDGWICK,Garden Plain,United States Senate,,Republican,"Roberts, Pat",567,182
+SEDGWICK,Grand River,United States Senate,,independent,"Orman, Greg",47,183
+SEDGWICK,Grand River,United States Senate,,Libertarian,"Batson, Randall",7,183
+SEDGWICK,Grand River,United States Senate,,Republican,"Roberts, Pat",177,183
+SEDGWICK,Grant Precinct 01,United States Senate,,independent,"Orman, Greg",188,184
+SEDGWICK,Grant Precinct 01,United States Senate,,Libertarian,"Batson, Randall",21,184
+SEDGWICK,Grant Precinct 01,United States Senate,,Republican,"Roberts, Pat",431,184
+SEDGWICK,Goddard,United States Senate,,independent,"Orman, Greg",429,185
+SEDGWICK,Goddard,United States Senate,,Libertarian,"Batson, Randall",68,185
+SEDGWICK,Goddard,United States Senate,,Republican,"Roberts, Pat",842,185
+SEDGWICK,Greeley,United States Senate,,independent,"Orman, Greg",94,186
+SEDGWICK,Greeley,United States Senate,,Libertarian,"Batson, Randall",31,186
+SEDGWICK,Greeley,United States Senate,,Republican,"Roberts, Pat",255,186
+SEDGWICK,Gypsum Precinct 01,United States Senate,,independent,"Orman, Greg",434,187
+SEDGWICK,Gypsum Precinct 01,United States Senate,,Libertarian,"Batson, Randall",55,187
+SEDGWICK,Gypsum Precinct 01,United States Senate,,Republican,"Roberts, Pat",814,187
+SEDGWICK,Gypsum Precinct 02,United States Senate,,independent,"Orman, Greg",8,188
+SEDGWICK,Gypsum Precinct 02,United States Senate,,Libertarian,"Batson, Randall",0,188
+SEDGWICK,Gypsum Precinct 02,United States Senate,,Republican,"Roberts, Pat",10,188
+SEDGWICK,Gypsum Precinct 03,United States Senate,,independent,"Orman, Greg",15,189
+SEDGWICK,Gypsum Precinct 03,United States Senate,,Libertarian,"Batson, Randall",3,189
+SEDGWICK,Gypsum Precinct 03,United States Senate,,Republican,"Roberts, Pat",20,189
+SEDGWICK,Haysville Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",258,190
+SEDGWICK,Haysville Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",40,190
+SEDGWICK,Haysville Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",336,190
+SEDGWICK,Haysville Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",278,191
+SEDGWICK,Haysville Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",58,191
+SEDGWICK,Haysville Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",358,191
+SEDGWICK,Haysville Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",299,192
+SEDGWICK,Haysville Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",65,192
+SEDGWICK,Haysville Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",371,192
+SEDGWICK,Haysville Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",247,193
+SEDGWICK,Haysville Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",44,193
+SEDGWICK,Haysville Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",341,193
+SEDGWICK,Haysville Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",44,194
+SEDGWICK,Haysville Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",7,194
+SEDGWICK,Haysville Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",93,194
+SEDGWICK,Illinois Precinct 01,United States Senate,,independent,"Orman, Greg",194,195
+SEDGWICK,Illinois Precinct 01,United States Senate,,Libertarian,"Batson, Randall",35,195
+SEDGWICK,Illinois Precinct 01,United States Senate,,Republican,"Roberts, Pat",480,195
+SEDGWICK,Kechi Precinct 01,United States Senate,,independent,"Orman, Greg",1,196
+SEDGWICK,Kechi Precinct 01,United States Senate,,Libertarian,"Batson, Randall",0,196
+SEDGWICK,Kechi Precinct 01,United States Senate,,Republican,"Roberts, Pat",12,196
+SEDGWICK,Kechi Precinct 03,United States Senate,,independent,"Orman, Greg",290,197
+SEDGWICK,Kechi Precinct 03,United States Senate,,Libertarian,"Batson, Randall",29,197
+SEDGWICK,Kechi Precinct 03,United States Senate,,Republican,"Roberts, Pat",421,197
+SEDGWICK,Kechi Precinct 04,United States Senate,,independent,"Orman, Greg",17,198
+SEDGWICK,Kechi Precinct 04,United States Senate,,Libertarian,"Batson, Randall",3,198
+SEDGWICK,Kechi Precinct 04,United States Senate,,Republican,"Roberts, Pat",17,198
+SEDGWICK,Kechi Precinct 07,United States Senate,,independent,"Orman, Greg",7,199
+SEDGWICK,Kechi Precinct 07,United States Senate,,Libertarian,"Batson, Randall",1,199
+SEDGWICK,Kechi Precinct 07,United States Senate,,Republican,"Roberts, Pat",10,199
+SEDGWICK,Kechi Precinct 08,United States Senate,,independent,"Orman, Greg",1,200
+SEDGWICK,Kechi Precinct 08,United States Senate,,Libertarian,"Batson, Randall",1,200
+SEDGWICK,Kechi Precinct 08,United States Senate,,Republican,"Roberts, Pat",9,200
+SEDGWICK,Lincoln,United States Senate,,independent,"Orman, Greg",74,201
+SEDGWICK,Lincoln,United States Senate,,Libertarian,"Batson, Randall",12,201
+SEDGWICK,Lincoln,United States Senate,,Republican,"Roberts, Pat",167,201
+SEDGWICK,Minneha Precinct 01,United States Senate,,independent,"Orman, Greg",326,202
+SEDGWICK,Minneha Precinct 01,United States Senate,,Libertarian,"Batson, Randall",24,202
+SEDGWICK,Minneha Precinct 01,United States Senate,,Republican,"Roberts, Pat",726,202
+SEDGWICK,Minneha Precinct 02,United States Senate,,independent,"Orman, Greg",181,203
+SEDGWICK,Minneha Precinct 02,United States Senate,,Libertarian,"Batson, Randall",11,203
+SEDGWICK,Minneha Precinct 02,United States Senate,,Republican,"Roberts, Pat",255,203
+SEDGWICK,Minneha Precinct 03,United States Senate,,independent,"Orman, Greg",4,204
+SEDGWICK,Minneha Precinct 03,United States Senate,,Libertarian,"Batson, Randall",1,204
+SEDGWICK,Minneha Precinct 03,United States Senate,,Republican,"Roberts, Pat",7,204
+SEDGWICK,Minneha Precinct 04,United States Senate,,independent,"Orman, Greg",0,205
+SEDGWICK,Minneha Precinct 04,United States Senate,,Libertarian,"Batson, Randall",1,205
+SEDGWICK,Minneha Precinct 04,United States Senate,,Republican,"Roberts, Pat",1,205
+SEDGWICK,Minneha Precinct 05,United States Senate,,independent,"Orman, Greg",2,206
+SEDGWICK,Minneha Precinct 05,United States Senate,,Libertarian,"Batson, Randall",0,206
+SEDGWICK,Minneha Precinct 05,United States Senate,,Republican,"Roberts, Pat",0,206
+SEDGWICK,Minneha Precinct 07,United States Senate,,independent,"Orman, Greg",6,207
+SEDGWICK,Minneha Precinct 07,United States Senate,,Libertarian,"Batson, Randall",0,207
+SEDGWICK,Minneha Precinct 07,United States Senate,,Republican,"Roberts, Pat",5,207
+SEDGWICK,Minneha Precinct 09,United States Senate,,independent,"Orman, Greg",83,208
+SEDGWICK,Minneha Precinct 09,United States Senate,,Libertarian,"Batson, Randall",13,208
+SEDGWICK,Minneha Precinct 09,United States Senate,,Republican,"Roberts, Pat",110,208
+SEDGWICK,Minneha Precinct 14,United States Senate,,independent,"Orman, Greg",33,209
+SEDGWICK,Minneha Precinct 14,United States Senate,,Libertarian,"Batson, Randall",2,209
+SEDGWICK,Minneha Precinct 14,United States Senate,,Republican,"Roberts, Pat",62,209
+SEDGWICK,Morton,United States Senate,,independent,"Orman, Greg",326,210
+SEDGWICK,Morton,United States Senate,,Libertarian,"Batson, Randall",47,210
+SEDGWICK,Morton,United States Senate,,Republican,"Roberts, Pat",539,210
+SEDGWICK,Mulvane City Precinct 01,United States Senate,,independent,"Orman, Greg",219,211
+SEDGWICK,Mulvane City Precinct 01,United States Senate,,Libertarian,"Batson, Randall",40,211
+SEDGWICK,Mulvane City Precinct 01,United States Senate,,Republican,"Roberts, Pat",292,211
+SEDGWICK,Mulvane City Precinct 02,United States Senate,,independent,"Orman, Greg",497,212
+SEDGWICK,Mulvane City Precinct 02,United States Senate,,Libertarian,"Batson, Randall",78,212
+SEDGWICK,Mulvane City Precinct 02,United States Senate,,Republican,"Roberts, Pat",671,212
+SEDGWICK,Ninnescah,United States Senate,,independent,"Orman, Greg",309,213
+SEDGWICK,Ninnescah,United States Senate,,Libertarian,"Batson, Randall",48,213
+SEDGWICK,Ninnescah,United States Senate,,Republican,"Roberts, Pat",536,213
+SEDGWICK,Ninnescah Precinct 01,United States Senate,,independent,"Orman, Greg",62,214
+SEDGWICK,Ninnescah Precinct 01,United States Senate,,Libertarian,"Batson, Randall",8,214
+SEDGWICK,Ninnescah Precinct 01,United States Senate,,Republican,"Roberts, Pat",119,214
+SEDGWICK,Ohio Precinct 01,United States Senate,,independent,"Orman, Greg",168,215
+SEDGWICK,Ohio Precinct 01,United States Senate,,Libertarian,"Batson, Randall",26,215
+SEDGWICK,Ohio Precinct 01,United States Senate,,Republican,"Roberts, Pat",347,215
+SEDGWICK,Park Precinct 01,United States Senate,,independent,"Orman, Greg",60,216
+SEDGWICK,Park Precinct 01,United States Senate,,Libertarian,"Batson, Randall",8,216
+SEDGWICK,Park Precinct 01,United States Senate,,Republican,"Roberts, Pat",143,216
+SEDGWICK,Park Precinct 02,United States Senate,,independent,"Orman, Greg",38,217
+SEDGWICK,Park Precinct 02,United States Senate,,Libertarian,"Batson, Randall",6,217
+SEDGWICK,Park Precinct 02,United States Senate,,Republican,"Roberts, Pat",71,217
+SEDGWICK,Park Precinct 05,United States Senate,,independent,"Orman, Greg",387,218
+SEDGWICK,Park Precinct 05,United States Senate,,Libertarian,"Batson, Randall",39,218
+SEDGWICK,Park Precinct 05,United States Senate,,Republican,"Roberts, Pat",665,218
+SEDGWICK,Park Precinct 06,United States Senate,,independent,"Orman, Greg",22,219
+SEDGWICK,Park Precinct 06,United States Senate,,Libertarian,"Batson, Randall",2,219
+SEDGWICK,Park Precinct 06,United States Senate,,Republican,"Roberts, Pat",31,219
+SEDGWICK,Park Precinct 09,United States Senate,,independent,"Orman, Greg",2,220
+SEDGWICK,Park Precinct 09,United States Senate,,Libertarian,"Batson, Randall",0,220
+SEDGWICK,Park Precinct 09,United States Senate,,Republican,"Roberts, Pat",5,220
+SEDGWICK,Park City Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",163,221
+SEDGWICK,Park City Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",25,221
+SEDGWICK,Park City Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",195,221
+SEDGWICK,Park City Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",57,222
+SEDGWICK,Park City Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",5,222
+SEDGWICK,Park City Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",67,222
+SEDGWICK,Park City Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",242,223
+SEDGWICK,Park City Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",39,223
+SEDGWICK,Park City Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",344,223
+SEDGWICK,Park City Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",328,224
+SEDGWICK,Park City Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",53,224
+SEDGWICK,Park City Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",376,224
+SEDGWICK,Park City Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",91,225
+SEDGWICK,Park City Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",7,225
+SEDGWICK,Park City Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",116,225
+SEDGWICK,Payne Precinct 01,United States Senate,,independent,"Orman, Greg",120,226
+SEDGWICK,Payne Precinct 01,United States Senate,,Libertarian,"Batson, Randall",19,226
+SEDGWICK,Payne Precinct 01,United States Senate,,Republican,"Roberts, Pat",310,226
+SEDGWICK,Riverside Precinct 01,United States Senate,,independent,"Orman, Greg",16,227
+SEDGWICK,Riverside Precinct 01,United States Senate,,Libertarian,"Batson, Randall",3,227
+SEDGWICK,Riverside Precinct 01,United States Senate,,Republican,"Roberts, Pat",20,227
+SEDGWICK,Riverside Precinct 03,United States Senate,,independent,"Orman, Greg",126,228
+SEDGWICK,Riverside Precinct 03,United States Senate,,Libertarian,"Batson, Randall",26,228
+SEDGWICK,Riverside Precinct 03,United States Senate,,Republican,"Roberts, Pat",85,228
+SEDGWICK,Riverside Precinct 06,United States Senate,,independent,"Orman, Greg",50,229
+SEDGWICK,Riverside Precinct 06,United States Senate,,Libertarian,"Batson, Randall",3,229
+SEDGWICK,Riverside Precinct 06,United States Senate,,Republican,"Roberts, Pat",67,229
+SEDGWICK,Riverside Precinct 07,United States Senate,,independent,"Orman, Greg",91,230
+SEDGWICK,Riverside Precinct 07,United States Senate,,Libertarian,"Batson, Randall",17,230
+SEDGWICK,Riverside Precinct 07,United States Senate,,Republican,"Roberts, Pat",98,230
+SEDGWICK,Rockford Precinct 01,United States Senate,,independent,"Orman, Greg",124,231
+SEDGWICK,Rockford Precinct 01,United States Senate,,Libertarian,"Batson, Randall",8,231
+SEDGWICK,Rockford Precinct 01,United States Senate,,Republican,"Roberts, Pat",241,231
+SEDGWICK,Rockford Precinct 03,United States Senate,,independent,"Orman, Greg",80,232
+SEDGWICK,Rockford Precinct 03,United States Senate,,Libertarian,"Batson, Randall",17,232
+SEDGWICK,Rockford Precinct 03,United States Senate,,Republican,"Roberts, Pat",146,232
+SEDGWICK,Salem Precinct 01,United States Senate,,independent,"Orman, Greg",275,233
+SEDGWICK,Salem Precinct 01,United States Senate,,Libertarian,"Batson, Randall",41,233
+SEDGWICK,Salem Precinct 01,United States Senate,,Republican,"Roberts, Pat",447,233
+SEDGWICK,Salem Precinct 02,United States Senate,,independent,"Orman, Greg",197,234
+SEDGWICK,Salem Precinct 02,United States Senate,,Libertarian,"Batson, Randall",30,234
+SEDGWICK,Salem Precinct 02,United States Senate,,Republican,"Roberts, Pat",322,234
+SEDGWICK,Sherman,United States Senate,,independent,"Orman, Greg",170,235
+SEDGWICK,Sherman,United States Senate,,Libertarian,"Batson, Randall",10,235
+SEDGWICK,Sherman,United States Senate,,Republican,"Roberts, Pat",410,235
+SEDGWICK,Union Precinct 01,United States Senate,,independent,"Orman, Greg",170,239
+SEDGWICK,Union Precinct 01,United States Senate,,Libertarian,"Batson, Randall",22,239
+SEDGWICK,Union Precinct 01,United States Senate,,Republican,"Roberts, Pat",634,239
+SEDGWICK,Union Precinct 02,United States Senate,,independent,"Orman, Greg",13,240
+SEDGWICK,Union Precinct 02,United States Senate,,Libertarian,"Batson, Randall",3,240
+SEDGWICK,Union Precinct 02,United States Senate,,Republican,"Roberts, Pat",43,240
+SEDGWICK,Valley Center Township,United States Senate,,independent,"Orman, Greg",130,241
+SEDGWICK,Valley Center Township,United States Senate,,Libertarian,"Batson, Randall",26,241
+SEDGWICK,Valley Center Township,United States Senate,,Republican,"Roberts, Pat",238,241
+SEDGWICK,Valley Center City Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",191,242
+SEDGWICK,Valley Center City Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",35,242
+SEDGWICK,Valley Center City Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",348,242
+SEDGWICK,Valley Center City Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",228,243
+SEDGWICK,Valley Center City Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",25,243
+SEDGWICK,Valley Center City Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",363,243
+SEDGWICK,Valley Center City Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",162,244
+SEDGWICK,Valley Center City Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",21,244
+SEDGWICK,Valley Center City Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",314,244
+SEDGWICK,Valley Center City Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",166,245
+SEDGWICK,Valley Center City Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",34,245
+SEDGWICK,Valley Center City Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",243,245
+SEDGWICK,Valley Center City Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",65,246
+SEDGWICK,Valley Center City Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",10,246
+SEDGWICK,Valley Center City Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",112,246
+SEDGWICK,Viola,United States Senate,,independent,"Orman, Greg",54,247
+SEDGWICK,Viola,United States Senate,,Libertarian,"Batson, Randall",10,247
+SEDGWICK,Viola,United States Senate,,Republican,"Roberts, Pat",123,247
+SEDGWICK,Waco Precinct 01,United States Senate,,independent,"Orman, Greg",13,503930
+SEDGWICK,Waco Precinct 01,United States Senate,,Libertarian,"Batson, Randall",3,503930
+SEDGWICK,Waco Precinct 01,United States Senate,,Republican,"Roberts, Pat",37,503930
+SEDGWICK,Waco Precinct 02,United States Senate,,independent,"Orman, Greg",56,503940
+SEDGWICK,Waco Precinct 02,United States Senate,,Libertarian,"Batson, Randall",15,503940
+SEDGWICK,Waco Precinct 02,United States Senate,,Republican,"Roberts, Pat",143,503940
+SEDGWICK,Waco Precinct 03,United States Senate,,independent,"Orman, Greg",5,503990
+SEDGWICK,Waco Precinct 03,United States Senate,,Libertarian,"Batson, Randall",1,503990
+SEDGWICK,Waco Precinct 03,United States Senate,,Republican,"Roberts, Pat",6,503990
+SEDGWICK,Waco Precinct 12,United States Senate,,independent,"Orman, Greg",0,504000
+SEDGWICK,Waco Precinct 12,United States Senate,,Libertarian,"Batson, Randall",0,504000
+SEDGWICK,Waco Precinct 12,United States Senate,,Republican,"Roberts, Pat",2,504000
+SEDGWICK,ADVANCED,United States Senate,,independent,"Orman, Greg",0,999998
+SEDGWICK,ADVANCED,United States Senate,,Libertarian,"Batson, Randall",0,999998
+SEDGWICK,ADVANCED,United States Senate,,Republican,"Roberts, Pat",0,999998

--- a/2014/20141104__ks__general__seward__precinct.csv
+++ b/2014/20141104__ks__general__seward__precinct.csv
@@ -1,430 +1,392 @@
-county,precinct,office,district,party,candidate,votes,advance,poll,provisional
-Seward,Fargo twp 1,Attorney General,,D,AJ Kotich,3,1,2,0
-Seward,Fargo twp 2,Attorney General,,D,AJ Kotich,2,0,2,0
-Seward,Fargo twp 3,Attorney General,,D,AJ Kotich,0,0,0,0
-Seward,Fargo twp 4,Attorney General,,D,AJ Kotich,14,2,12,0
-Seward,Kismet City,Attorney General,,D,AJ Kotich,13,1,11,1
-Seward,Liberal twp 1,Attorney General,,D,AJ Kotich,8,1,7,0
-Seward,Liberal twp 2,Attorney General,,D,AJ Kotich,3,1,2,0
-Seward,Liberal twp 3,Attorney General,,D,AJ Kotich,5,1,4,0
-Seward,Liberal twp 4,Attorney General,,D,AJ Kotich,4,2,2,0
-Seward,Liberal twp 5,Attorney General,,D,AJ Kotich,3,1,2,0
-Seward,Seward twp 1,Attorney General,,D,AJ Kotich,3,0,3,0
-Seward,Seward twp 2,Attorney General,,D,AJ Kotich,4,1,2,1
-Seward,Seward twp 3,Attorney General,,D,AJ Kotich,1,0,1,0
-Seward,Fargo twp 1,Attorney General,,R,Derek Schmidt,35,8,26,1
-Seward,Fargo twp 2,Attorney General,,R,Derek Schmidt,32,10,22,0
-Seward,Fargo twp 3,Attorney General,,R,Derek Schmidt,18,6,12,0
-Seward,Fargo twp 4,Attorney General,,R,Derek Schmidt,56,20,34,2
-Seward,Kismet City,Attorney General,,R,Derek Schmidt,88,10,77,1
-Seward,Liberal twp 1,Attorney General,,R,Derek Schmidt,49,12,37,0
-Seward,Liberal twp 2,Attorney General,,R,Derek Schmidt,27,11,15,1
-Seward,Liberal twp 3,Attorney General,,R,Derek Schmidt,47,16,29,2
-Seward,Liberal twp 4,Attorney General,,R,Derek Schmidt,30,11,19,0
-Seward,Liberal twp 5,Attorney General,,R,Derek Schmidt,24,12,12,0
-Seward,Seward twp 1,Attorney General,,R,Derek Schmidt,22,9,13,0
-Seward,Seward twp 2,Attorney General,,R,Derek Schmidt,22,6,16,0
-Seward,Seward twp 3,Attorney General,,R,Derek Schmidt,16,0,16,0
-Seward,Fargo twp 1,U.S. House,1,R,Tim Huelskamp,35,8,26,1
-Seward,Fargo twp 2,U.S. House,1,R,Tim Huelskamp,31,9,22,0
-Seward,Fargo twp 3,U.S. House,1,R,Tim Huelskamp,16,4,12,0
-Seward,Fargo twp 4,U.S. House,1,R,Tim Huelskamp,46,13,32,1
-Seward,Kismet City,U.S. House,1,R,Tim Huelskamp,78,11,66,1
-Seward,Liberal twp 1,U.S. House,1,R,Tim Huelskamp,45,9,36,0
-Seward,Liberal twp 2,U.S. House,1,R,Tim Huelskamp,22,5,16,1
-Seward,Liberal twp 3,U.S. House,1,R,Tim Huelskamp,41,15,25,1
-Seward,Liberal twp 4,U.S. House,1,R,Tim Huelskamp,29,9,20,0
-Seward,Liberal twp 5,U.S. House,1,R,Tim Huelskamp,23,11,12,0
-Seward,Seward twp 1,U.S. House,1,R,Tim Huelskamp,20,7,13,0
-Seward,Seward twp 2,U.S. House,1,R,Tim Huelskamp,24,7,16,1
-Seward,Seward twp 3,U.S. House,1,R,Tim Huelskamp,12,0,12,0
-Seward,Fargo twp 1,U.S. House,1,D,James Sherow,4,1,3,0
-Seward,Fargo twp 2,U.S. House,1,D,James Sherow,5,1,4,0
-Seward,Fargo twp 3,U.S. House,1,D,James Sherow,1,1,0,0
-Seward,Fargo twp 4,U.S. House,1,D,James Sherow,27,9,17,1
-Seward,Kismet City,U.S. House,1,D,James Sherow,24,0,23,1
-Seward,Liberal twp 1,U.S. House,1,D,James Sherow,11,2,9,0
-Seward,Liberal twp 2,U.S. House,1,D,James Sherow,7,5,2,0
-Seward,Liberal twp 3,U.S. House,1,D,James Sherow,10,2,7,1
-Seward,Liberal twp 4,U.S. House,1,D,James Sherow,5,4,1,0
-Seward,Liberal twp 5,U.S. House,1,D,James Sherow,4,2,2,0
-Seward,Seward twp 1,U.S. House,1,D,James Sherow,5,2,3,0
-Seward,Seward twp 2,U.S. House,1,D,James Sherow,3,0,3,0
-Seward,Seward twp 3,U.S. House,1,D,James Sherow,4,0,4,0
-Seward,Liberal twp 1,U.S. House,1,,Write-ins,1,0,1,0
-Seward,Liberal twp 2,U.S. House,1,,Write-ins,1,1,0,0
-Seward,Fargo twp 1,Governor,,R,Sam Brownback,30,8,22,0
-Seward,Fargo twp 2,Governor,,R,Sam Brownback,31,9,22,0
-Seward,Fargo twp 3,Governor,,R,Sam Brownback,15,3,12,0
-Seward,Fargo twp 4,Governor,,R,Sam Brownback,42,11,29,2
-Seward,Kismet City,Governor,,R,Sam Brownback,66,9,57,0
-Seward,Liberal twp 1,Governor,,R,Sam Brownback,45,11,34,0
-Seward,Liberal twp 2,Governor,,R,Sam Brownback,23,7,15,1
-Seward,Liberal twp 3,Governor,,R,Sam Brownback,46,15,29,2
-Seward,Liberal twp 4,Governor,,R,Sam Brownback,25,8,17,0
-Seward,Liberal twp 5,Governor,,R,Sam Brownback,23,12,11,0
-Seward,Seward twp 1,Governor,,R,Sam Brownback,20,7,13,0
-Seward,Seward twp 2,Governor,,R,Sam Brownback,24,6,17,1
-Seward,Seward twp 3,Governor,,R,Sam Brownback,14,0,14,0
-Seward,Fargo twp 1,Governor,,D,Paul Davis,7,1,5,1
-Seward,Fargo twp 2,Governor,,D,Paul Davis,5,1,4,0
-Seward,Fargo twp 3,Governor,,D,Paul Davis,3,3,0,0
-Seward,Fargo twp 4,Governor,,D,Paul Davis,27,10,17,0
-Seward,Kismet City,Governor,,D,Paul Davis,29,1,27,1
-Seward,Liberal twp 1,Governor,,D,Paul Davis,12,2,10,0
-Seward,Liberal twp 2,Governor,,D,Paul Davis,9,6,3,0
-Seward,Liberal twp 3,Governor,,D,Paul Davis,7,2,5,0
-Seward,Liberal twp 4,Governor,,D,Paul Davis,8,4,4,0
-Seward,Liberal twp 5,Governor,,D,Paul Davis,3,1,2,0
-Seward,Seward twp 1,Governor,,D,Paul Davis,5,2,3,0
-Seward,Seward twp 2,Governor,,D,Paul Davis,3,1,2,0
-Seward,Seward twp 3,Governor,,D,Paul Davis,3,0,3,0
-Seward,Fargo twp 1,Governor,,L,Keen Umbehr,2,0,2,0
-Seward,Fargo twp 2,Governor,,L,Keen Umbehr,0,0,0,0
-Seward,Fargo twp 3,Governor,,L,Keen Umbehr,0,0,0,0
-Seward,Fargo twp 4,Governor,,L,Keen Umbehr,2,1,1,0
-Seward,Kismet City,Governor,,L,Keen Umbehr,8,1,6,1
-Seward,Liberal twp 1,Governor,,L,Keen Umbehr,0,0,0,0
-Seward,Liberal twp 2,Governor,,L,Keen Umbehr,0,0,0,0
-Seward,Liberal twp 3,Governor,,L,Keen Umbehr,2,0,2,0
-Seward,Liberal twp 4,Governor,,L,Keen Umbehr,2,1,1,0
-Seward,Liberal twp 5,Governor,,L,Keen Umbehr,1,0,1,0
-Seward,Seward twp 1,Governor,,L,Keen Umbehr,0,0,0,0
-Seward,Seward twp 2,Governor,,L,Keen Umbehr,0,0,0,0
-Seward,Seward twp 3,Governor,,L,Keen Umbehr,0,0,0,0
-Seward,Fargo twp 1,Insurance Commissioner,,D,Dennis Anderson,6,2,3,1
-Seward,Fargo twp 2,Insurance Commissioner,,D,Dennis Anderson,3,0,3,0
-Seward,Fargo twp 3,Insurance Commissioner,,D,Dennis Anderson,3,3,0,0
-Seward,Fargo twp 4,Insurance Commissioner,,D,Dennis Anderson,19,3,16,0
-Seward,Kismet City,Insurance Commissioner,,D,Dennis Anderson,16,1,14,1
-Seward,Liberal twp 1,Insurance Commissioner,,D,Dennis Anderson,9,1,8,0
-Seward,Liberal twp 2,Insurance Commissioner,,D,Dennis Anderson,4,3,1,0
-Seward,Liberal twp 3,Insurance Commissioner,,D,Dennis Anderson,4,1,3,0
-Seward,Liberal twp 4,Insurance Commissioner,,D,Dennis Anderson,5,2,3,0
-Seward,Liberal twp 5,Insurance Commissioner,,D,Dennis Anderson,3,2,1,0
-Seward,Seward twp 1,Insurance Commissioner,,D,Dennis Anderson,4,1,3,0
-Seward,Seward twp 2,Insurance Commissioner,,D,Dennis Anderson,4,1,3,0
-Seward,Seward twp 3,Insurance Commissioner,,D,Dennis Anderson,1,0,1,0
-Seward,Fargo twp 1,Insurance Commissioner,,R,Ken Selzer,31,7,24,0
-Seward,Fargo twp 2,Insurance Commissioner,,R,Ken Selzer,32,10,22,0
-Seward,Fargo twp 3,Insurance Commissioner,,R,Ken Selzer,15,3,12,0
-Seward,Fargo twp 4,Insurance Commissioner,,R,Ken Selzer,52,18,32,2
-Seward,Kismet City,Insurance Commissioner,,R,Ken Selzer,87,10,76,1
-Seward,Liberal twp 1,Insurance Commissioner,,R,Ken Selzer,46,9,37,0
-Seward,Liberal twp 2,Insurance Commissioner,,R,Ken Selzer,27,9,17,1
-Seward,Liberal twp 3,Insurance Commissioner,,R,Ken Selzer,48,16,30,2
-Seward,Liberal twp 4,Insurance Commissioner,,R,Ken Selzer,26,10,16,0
-Seward,Liberal twp 5,Insurance Commissioner,,R,Ken Selzer,22,10,12,0
-Seward,Seward twp 1,Insurance Commissioner,,R,Ken Selzer,21,8,13,0
-Seward,Seward twp 2,Insurance Commissioner,,R,Ken Selzer,21,6,14,1
-Seward,Seward twp 3,Insurance Commissioner,,R,Ken Selzer,16,0,16,0
-Seward,Liberal twp 1,Insurance Commissioner,,,Write-ins,1,0,1,0
-Seward,Fargo twp 1,Secretary of State,,R,Kris Kobach,33,8,25,0
-Seward,Fargo twp 2,Secretary of State,,R,Kris Kobach,31,9,22,0
-Seward,Fargo twp 3,Secretary of State,,R,Kris Kobach,17,6,11,0
-Seward,Fargo twp 4,Secretary of State,,R,Kris Kobach,50,16,32,2
-Seward,Kismet City,Secretary of State,,R,Kris Kobach,81,11,69,1
-Seward,Liberal twp 1,Secretary of State,,R,Kris Kobach,48,12,36,0
-Seward,Liberal twp 2,Secretary of State,,R,Kris Kobach,26,8,17,1
-Seward,Liberal twp 3,Secretary of State,,R,Kris Kobach,51,16,33,2
-Seward,Liberal twp 4,Secretary of State,,R,Kris Kobach,29,9,20,0
-Seward,Liberal twp 5,Secretary of State,,R,Kris Kobach,23,11,12,0
-Seward,Seward twp 1,Secretary of State,,R,Kris Kobach,21,8,13,0
-Seward,Seward twp 2,Secretary of State,,R,Kris Kobach,23,6,16,1
-Seward,Seward twp 3,Secretary of State,,R,Kris Kobach,16,0,16,0
-Seward,Fargo twp 1,Secretary of State,,D,Jean Schodorf,6,1,4,1
-Seward,Fargo twp 2,Secretary of State,,D,Jean Schodorf,5,1,4,0
-Seward,Fargo twp 3,Secretary of State,,D,Jean Schodorf,1,0,1,0
-Seward,Fargo twp 4,Secretary of State,,D,Jean Schodorf,23,6,17,0
-Seward,Kismet City,Secretary of State,,D,Jean Schodorf,22,0,21,1
-Seward,Liberal twp 1,Secretary of State,,D,Jean Schodorf,9,0,9,0
-Seward,Liberal twp 2,Secretary of State,,D,Jean Schodorf,6,5,1,0
-Seward,Liberal twp 3,Secretary of State,,D,Jean Schodorf,3,1,2,0
-Seward,Liberal twp 4,Secretary of State,,D,Jean Schodorf,5,4,1,0
-Seward,Liberal twp 5,Secretary of State,,D,Jean Schodorf,4,2,2,0
-Seward,Seward twp 1,Secretary of State,,D,Jean Schodorf,4,1,3,0
-Seward,Seward twp 2,Secretary of State,,D,Jean Schodorf,4,1,3,0
-Seward,Seward twp 3,Secretary of State,,D,Jean Schodorf,1,0,1,0
-Seward,Liberal twp 1,Secretary of State,,,Write-ins,1,0,1,0
-Seward,Seward twp 1,State House,124,R,J. Stephen Alford,25,9,16,0
-Seward,Seward twp 2,State House,124,R,J. Stephen Alford,23,6,16,1
-Seward,Seward twp 3,State House,124,R,J. Stephen Alford,14,0,14,0
-Seward,Fargo twp 1,State House,125,R,Shannon Francis,38,9,28,1
-Seward,Fargo twp 2,State House,125,R,Shannon Francis,34,10,24,0
-Seward,Fargo twp 3,State House,125,R,Shannon Francis,17,6,11,0
-Seward,Fargo twp 4,State House,125,R,Shannon Francis,63,21,40,2
-Seward,Kismet City,State House,125,R,Shannon Francis,102,11,90,1
-Seward,Liberal twp 1,State House,125,R,Shannon Francis,47,9,38,0
-Seward,Liberal twp 2,State House,125,R,Shannon Francis,28,12,15,1
-Seward,Liberal twp 3,State House,125,R,Shannon Francis,45,14,29,2
-Seward,Liberal twp 4,State House,125,R,Shannon Francis,33,13,20,0
-Seward,Liberal twp 5,State House,125,R,Shannon Francis,25,12,13,0
-Seward,Fargo twp 2,State House,125,,Write-ins,1,0,1,0
-Seward,Fargo twp 4,State House,125,,Write-ins,3,0,3,0
-Seward,Liberal twp 1,State House,125,,Write-ins,1,0,1,0
-Seward,Liberal twp 2,State House,125,,Write-ins,2,0,2,0
-Seward,Liberal twp 3,State House,125,,Write-ins,3,1,2,0
-Seward,Fargo twp 1,State Treasurer,,D,Carmen Alldritt,3,0,2,1
-Seward,Fargo twp 2,State Treasurer,,D,Carmen Alldritt,3,0,3,0
-Seward,Fargo twp 3,State Treasurer,,D,Carmen Alldritt,0,0,0,0
-Seward,Fargo twp 4,State Treasurer,,D,Carmen Alldritt,15,2,13,0
-Seward,Kismet City,State Treasurer,,D,Carmen Alldritt,12,1,10,1
-Seward,Liberal twp 1,State Treasurer,,D,Carmen Alldritt,8,0,8,0
-Seward,Liberal twp 2,State Treasurer,,D,Carmen Alldritt,4,2,2,0
-Seward,Liberal twp 3,State Treasurer,,D,Carmen Alldritt,4,1,3,0
-Seward,Liberal twp 4,State Treasurer,,D,Carmen Alldritt,4,2,2,0
-Seward,Liberal twp 5,State Treasurer,,D,Carmen Alldritt,2,1,1,0
-Seward,Seward twp 1,State Treasurer,,D,Carmen Alldritt,5,1,4,0
-Seward,Seward twp 2,State Treasurer,,D,Carmen Alldritt,2,0,2,0
-Seward,Seward twp 3,State Treasurer,,D,Carmen Alldritt,1,0,1,0
-Seward,Fargo twp 1,State Treasurer,,R,Ron Estes,35,9,26,0
-Seward,Fargo twp 2,State Treasurer,,R,Ron Estes,33,10,23,0
-Seward,Fargo twp 3,State Treasurer,,R,Ron Estes,18,6,12,0
-Seward,Fargo twp 4,State Treasurer,,R,Ron Estes,56,19,35,2
-Seward,Kismet City,State Treasurer,,R,Ron Estes,91,10,80,1
-Seward,Liberal twp 1,State Treasurer,,R,Ron Estes,49,12,37,0
-Seward,Liberal twp 2,State Treasurer,,R,Ron Estes,28,11,16,1
-Seward,Liberal twp 3,State Treasurer,,R,Ron Estes,48,15,31,2
-Seward,Liberal twp 4,State Treasurer,,R,Ron Estes,28,10,18,0
-Seward,Liberal twp 5,State Treasurer,,R,Ron Estes,25,12,13,0
-Seward,Seward twp 1,State Treasurer,,R,Ron Estes,20,8,12,0
-Seward,Seward twp 2,State Treasurer,,R,Ron Estes,23,7,15,1
-Seward,Seward twp 3,State Treasurer,,R,Ron Estes,16,0,16,0
-Seward,Liberal twp 1,State Treasurer,,,Write-ins,1,0,1,0
-Seward,Fargo twp 1,U.S. Senate,,L,Randall Batson,2,0,2,0
-Seward,Fargo twp 2,U.S. Senate,,L,Randall Batson,1,0,1,0
-Seward,Fargo twp 3,U.S. Senate,,L,Randall Batson,0,0,0,0
-Seward,Fargo twp 4,U.S. Senate,,L,Randall Batson,6,2,4,0
-Seward,Kismet City,U.S. Senate,,L,Randall Batson,7,0,7,0
-Seward,Liberal twp 1,U.S. Senate,,L,Randall Batson,0,0,0,0
-Seward,Liberal twp 2,U.S. Senate,,L,Randall Batson,0,0,0,0
-Seward,Liberal twp 3,U.S. Senate,,L,Randall Batson,4,1,3,0
-Seward,Liberal twp 4,U.S. Senate,,L,Randall Batson,5,2,3,0
-Seward,Liberal twp 5,U.S. Senate,,L,Randall Batson,0,0,0,0
-Seward,Seward twp 1,U.S. Senate,,L,Randall Batson,1,0,I,0
-Seward,Seward twp 2,U.S. Senate,,L,Randall Batson,0,0,0,0
-Seward,Seward twp 3,U.S. Senate,,L,Randall Batson,0,0,0,0
-Seward,Fargo twp 1,U.S. Senate,,I,Greg Orman,10,2,7,1
-Seward,Fargo twp 2,U.S. Senate,,I,Greg Orman,3,0,3,0
-Seward,Fargo twp 3,U.S. Senate,,I,Greg Orman,0,0,0,0
-Seward,Fargo twp 4,U.S. Senate,,I,Greg Orman,20,8,12,0
-Seward,Kismet City,U.S. Senate,,I,Greg Orman,24,1,22,1
-Seward,Liberal twp 1,U.S. Senate,,I,Greg Orman,14,2,12,0
-Seward,Liberal twp 2,U.S. Senate,,I,Greg Orman,6,3,3,0
-Seward,Liberal twp 3,U.S. Senate,,I,Greg Orman,8,1,7,0
-Seward,Liberal twp 4,U.S. Senate,,I,Greg Orman,6,3,3,0
-Seward,Liberal twp 5,U.S. Senate,,I,Greg Orman,3,1,2,0
-Seward,Seward twp 1,U.S. Senate,,I,Greg Orman,4,1,3,0
-Seward,Seward twp 2,U.S. Senate,,I,Greg Orman,5,2,2,1
-Seward,Seward twp 3,U.S. Senate,,I,Greg Orman,1,0,1,0
-Seward,Fargo twp 1,U.S. Senate,,R,Pat Roberts,27,7,20,0
-Seward,Fargo twp 2,U.S. Senate,,R,Pat Roberts,32,10,22,0
-Seward,Fargo twp 3,U.S. Senate,,R,Pat Roberts,17,5,12,0
-Seward,Fargo twp 4,U.S. Senate,,R,Pat Roberts,46,14,30,2
-Seward,Kismet City,U.S. Senate,,R,Pat Roberts,75,10,64,1
-Seward,Liberal twp 1,U.S. Senate,,R,Pat Roberts,44,11,33,0
-Seward,Liberal twp 2,U.S. Senate,,R,Pat Roberts,26,10,15,1
-Seward,Liberal twp 3,U.S. Senate,,R,Pat Roberts,43,15,26,2
-Seward,Liberal twp 4,U.S. Senate,,R,Pat Roberts,24,8,16,0
-Seward,Liberal twp 5,U.S. Senate,,R,Pat Roberts,24,12,12,0
-Seward,Seward twp 1,U.S. Senate,,R,Pat Roberts,20,8,12,0
-Seward,Seward twp 2,U.S. Senate,,R,Pat Roberts,22,5,17,0
-Seward,Seward twp 3,U.S. Senate,,R,Pat Roberts,16,0,16,0
-Seward,W1P1,Voters,,,Reg,894,894,0,0
-Seward,W1P2,Voters,,,Reg,1395,1395,0,0
-Seward,W1P3,Voters,,,Reg,952,952,0,0
-Seward,W2,Voters,,,Reg,924,924,0,0
-Seward,W3,Voters,,,Reg,839,839,0,0
-Seward,W4,Voters,,,Reg,589,589,0,0
-Seward,W5,Voters,,,Reg,537,537,0,0
-Seward,W6P1,Voters,,,Reg,1456,1456,0,0
-Seward,W6P2,Voters,,,Reg,1077,1077,0,0
-Seward,W1P1,Voters,,,Cast,213,150,54,9
-Seward,W1P2,Voters,,,Cast,283,186,95,2
-Seward,W1P3,Voters,,,Cast,272,165,99,8
-Seward,W2,Voters,,,Cast,323,226,86,11
-Seward,W3,Voters,,,Cast,152,93,54,5
-Seward,W4,Voters,,,Cast,220,151,63,6
-Seward,W5,Voters,,,Cast,193,127,62,4
-Seward,W6P1,Voters,,,Cast,718,473,232,13
-Seward,W6P2,Voters,,,Cast,430,283,132,15
-Seward,W1P1,Attorney General,,D,AJ Kotich,44,34,8,2
-Seward,W1P2,Attorney General,,D,AJ Kotich,84,55,27,2
-Seward,W1P3,Attorney General,,D,AJ Kotich,78,56,20,2
-Seward,W2,Attorney General,,D,AJ Kotich,62,36,23,3
-Seward,W3,Attorney General,,D,AJ Kotich,48,36,12,0
-Seward,W4,Attorney General,,D,AJ Kotich,48,31,14,3
-Seward,W5,Attorney General,,D,AJ Kotich,38,21,16,1
-Seward,W6P1,Attorney General,,D,AJ Kotich,103,65,36,2
-Seward,W6P2,Attorney General,,D,AJ Kotich,54,30,22,2
-Seward,W1P1,Attorney General,,R,Derek Schmidt,154,106,41,7
-Seward,W1P2,Attorney General,,R,Derek Schmidt,186,122,64,0
-Seward,W1P3,Attorney General,,R,Derek Schmidt,184,103,75,6
-Seward,W2,Attorney General,,R,Derek Schmidt,247,178,61,8
-Seward,W3,Attorney General,,R,Derek Schmidt,91,51,36,4
-Seward,W4,Attorney General,,R,Derek Schmidt,167,117,47,3
-Seward,W5,Attorney General,,R,Derek Schmidt,143,98,42,3
-Seward,W6P1,Attorney General,,R,Derek Schmidt,588,389,189,10
-Seward,W6P2,Attorney General,,R,Derek Schmidt,363,243,107,13
-Seward,W1P3,Attorney General,,,Write-ins,1,1,0,0
-Seward,W6P1,Attorney General,,,Write-ins,2,2,0,0
-Seward,W1P1,U.S. House,1,R,Tim Huelskamp,147,98,42,7
-Seward,W1P2,U.S. House,1,R,Tim Huelskamp,201,129,72,0
-Seward,W1P3,U.S. House,1,R,Tim Huelskamp,177,98,74,5
-Seward,W2,U.S. House,1,R,Tim Huelskamp,234,169,57,8
-Seward,W3,U.S. House,1,R,Tim Huelskamp,101,60,38,3
-Seward,W4,U.S. House,1,R,Tim Huelskamp,161,112,45,4
-Seward,W5,U.S. House,1,R,Tim Huelskamp,130,91,36,3
-Seward,W6P1,U.S. House,1,R,Tim Huelskamp,520,347,164,9
-Seward,W6P2,U.S. House,1,R,Tim Huelskamp,324,215,98,11
-Seward,W1P1,U.S. House,1,D,James Sherow,61,49,10,2
-Seward,W1P2,U.S. House,1,D,James Sherow,74,52,20,2
-Seward,W1P3,U.S. House,1,D,James Sherow,90,64,23,3
-Seward,W2,U.S. House,1,D,James Sherow,78,48,27,3
-Seward,W3,U.S. House,1,D,James Sherow,48,32,14,2
-Seward,W4,U.S. House,1,D,James Sherow,55,37,16,2
-Seward,W5,U.S. House,1,D,James Sherow,55,31,23,1
-Seward,W6P1,U.S. House,1,D,James Sherow,179,112,63,4
-Seward,W6P2,U.S. House,1,D,James Sherow,92,59,29,4
-Seward,W1P2,U.S. House,1,,Write-ins,1,1,0,0
-Seward,W2,U.S. House,1,,Write-ins,3,3,0,0
-Seward,W6P1,U.S. House,1,,Write-ins,1,0,1,0
-Seward,W6P2,U.S. House,1,,Write-ins,1,1,0,0
-Seward,W1P1,Governor,,R,Sam Brownback,135,92,37,6
-Seward,W1P2,Governor,,R,Sam Brownback,179,113,66,0
-Seward,W1P3,Governor,,R,Sam Brownback,153,80,68,5
-Seward,W2,Governor,,R,Sam Brownback,213,150,56,7
-Seward,W3,Governor,,R,Sam Brownback,88,50,34,4
-Seward,W4,Governor,,R,Sam Brownback,140,93,44,3
-Seward,W5,Governor,,R,Sam Brownback,128,88,37,3
-Seward,W6P1,Governor,,R,Sam Brownback,483,319,156,8
-Seward,W6P2,Governor,,R,Sam Brownback,302,197,96,9
-Seward,W1P1,Governor,,D,Paul Davis,52,41,8,3
-Seward,W1P2,Governor,,D,Paul Davis,74,48,24,2
-Seward,W1P3,Governor,,D,Paul Davis,105,77,26,2
-Seward,W2,Governor,,D,Paul Davis,89,61,24,4
-Seward,W3,Governor,,D,Paul Davis,52,33,18,1
-Seward,W4,Governor,,D,Paul Davis,65,44,18,3
-Seward,W5,Governor,,D,Paul Davis,56,35,20,1
-Seward,W6P1,Governor,,D,Paul Davis,196,124,68,4
-Seward,W6P2,Governor,,D,Paul Davis,115,76,33,6
-Seward,W1P1,Governor,,L,Keen Umbehr,17,11,6,0
-Seward,W1P2,Governor,,L,Keen Umbehr,21,19,2,0
-Seward,W1P3,Governor,,L,Keen Umbehr,9,6,2,1
-Seward,W2,Governor,,L,Keen Umbehr,15,11,4,0
-Seward,W3,Governor,,L,Keen Umbehr,7,5,2,0
-Seward,W4,Governor,,L,Keen Umbehr,12,12,0,0
-Seward,W5,Governor,,L,Keen Umbehr,6,3,3,0
-Seward,W6P1,Governor,,L,Keen Umbehr,30,23,6,1
-Seward,W6P2,Governor,,L,Keen Umbehr,11,8,3,0
-Seward,W4,Governor,,,Write-ins,2,1,1,0
-Seward,W6P1,Governor,,,Write-ins,1,1,0,0
-Seward,W1P1,Insurance Commissioner,,D,Dennis Anderson,54,44,8,2
-Seward,W1P2,Insurance Commissioner,,D,Dennis Anderson,80,55,23,2
-Seward,W1P3,Insurance Commissioner,,D,Dennis Anderson,83,59,22,2
-Seward,W2,Insurance Commissioner,,D,Dennis Anderson,74,48,24,2
-Seward,W3,Insurance Commissioner,,D,Dennis Anderson,52,36,14,2
-Seward,W4,Insurance Commissioner,,D,Dennis Anderson,52,36,14,2
-Seward,W5,Insurance Commissioner,,D,Dennis Anderson,42,23,18,1
-Seward,W6P1,Insurance Commissioner,,D,Dennis Anderson,123,76,44,3
-Seward,W6P2,Insurance Commissioner,,D,Dennis Anderson,66,39,24,3
-Seward,W1P1,Insurance Commissioner,,R,Ken Selzer,143,96,41,6
-Seward,W1P2,Insurance Commissioner,,R,Ken Selzer,186,122,64,0
-Seward,W1P3,Insurance Commissioner,,R,Ken Selzer,178,98,75,5
-Seward,W2,Insurance Commissioner,,R,Ken Selzer,229,164,58,7
-Seward,W3,Insurance Commissioner,,R,Ken Selzer,85,48,34,3
-Seward,W4,Insurance Commissioner,,R,Ken Selzer,159,112,44,3
-Seward,W5,Insurance Commissioner,,R,Ken Selzer,139,98,38,3
-Seward,W6P1,Insurance Commissioner,,R,Ken Selzer,565,379,177,9
-Seward,W6P2,Insurance Commissioner,,R,Ken Selzer,342,229,101,12
-Seward,W2,Insurance Commissioner,,,Write-ins,1,1,0,0
-Seward,W6P2,Insurance Commissioner,,,Write-ins,1,1,0,0
-Seward,W1P1,Secretary of State,,R,Kris Kobach,144,97,41,6
-Seward,W1P2,Secretary of State,,R,Kris Kobach,186,120,66,0
-Seward,W1P3,Secretary of State,,R,Kris Kobach,170,95,69,6
-Seward,W2,Secretary of State,,R,Kris Kobach,224,162,54,8
-Seward,W3,Secretary of State,,R,Kris Kobach,96,52,40,4
-Seward,W4,Secretary of State,,R,Kris Kobach,162,112,47,3
-Seward,W5,Secretary of State,,R,Kris Kobach,140,98,39,3
-Seward,W6P1,Secretary of State,,R,Kris Kobach,556,376,169,11
-Seward,W6P2,Secretary of State,,R,Kris Kobach,345,230,103,12
-Seward,W1P1,Secretary of State,,D,Jean Schodorf,59,47,10,2
-Seward,W1P2,Secretary of State,,D,Jean Schodorf,88,60,26,2
-Seward,W1P3,Secretary of State,,D,Jean Schodorf,95,67,26,2
-Seward,W2,Secretary of State,,D,Jean Schodorf,87,55,29,3
-Seward,W3,Secretary of State,,D,Jean Schodorf,48,35,13,0
-Seward,W4,Secretary of State,,D,Jean Schodorf,54,37,15,2
-Seward,W5,Secretary of State,,D,Jean Schodorf,45,25,19,1
-Seward,W6P1,Secretary of State,,D,Jean Schodorf,145,85,58,2
-Seward,W6P2,Secretary of State,,D,Jean Schodorf,75,47,25,3
-Seward,W4,Secretary of State,,,Write-ins,1,1,0,0
-Seward,W6P1,Secretary of State,,,Write-ins,1,1,0,0
-Seward,W6P2,Secretary of State,,,Write-ins,1,1,0,0
-Seward,W1P1,State House,125,R,Shannon Francis,186,130,48,8
-Seward,W1P2,State House,125,R,Shannon Francis,231,156,75,0
-Seward,W1P3,State House,125,R,Shannon Francis,220,129,85,5
-Seward,W2,State House,125,R,Shannon Francis,280,198,73,9
-Seward,W3,State House,125,R,Shannon Francis,127,75,48,4
-Seward,W4,State House,125,R,Shannon Francis,191,130,56,5
-Seward,W5,State House,125,R,Shannon Francis,162,108,51,3
-Seward,W6P1,State House,125,R,Shannon Francis,642,429,201,12
-Seward,W6P2,State House,125,R,Shannon Francis,392,257,122,13
-Seward,W1P1,State House,125,,Write-ins,2,2,0,0
-Seward,W1P2,State House,125,,Write-ins,2,1,1,0
-Seward,W1P3,State House,125,,Write-ins,5,3,2,0
-Seward,W2,State House,125,,Write-ins,3,2,1,0
-Seward,W3,State House,125,,Write-ins,1,0,1,0
-Seward,W4,State House,125,,Write-ins,6,5,1,0
-Seward,W6P1,State House,125,,Write-ins,1,0,1,0
-Seward,W6P2,State House,125,,Write-ins,6,6,0,0
-Seward,W1P1,State Treasurer,,D,Carmen Alldritt,46,36,8,2
-Seward,W1P2,State Treasurer,,D,Carmen Alldritt,64,43,19,2
-Seward,W1P3,State Treasurer,,D,Carmen Alldritt,82,58,23,1
-Seward,W2,State Treasurer,,D,Carmen Alldritt,62,38,21,3
-Seward,W3,State Treasurer,,D,Carmen Alldritt,47,34,11,2
-Seward,W4,State Treasurer,,D,Carmen Alldritt,49,34,12,3
-Seward,W5,State Treasurer,,D,Carmen Alldritt,37,20,16,1
-Seward,W6P1,State Treasurer,,D,Carmen Alldritt,102,63,36,3
-Seward,W6P2,State Treasurer,,D,Carmen Alldritt,50,29,17,4
-Seward,W1P1,State Treasurer,,R,Ron Estes,153,104,42,7
-Seward,W1P2,State Treasurer,,R,Ron Estes,206,134,72,0
-Seward,W1P3,State Treasurer,,R,Ron Estes,185,104,74,7
-Seward,W2,State Treasurer,,R,Ron Estes,251,182,62,7
-Seward,W3,State Treasurer,,R,Ron Estes,93,53,37,3
-Seward,W4,State Treasurer,,R,Ron Estes,165,114,48,3
-Seward,W5,State Treasurer,,R,Ron Estes,146,100,43,3
-Seward,W6P1,State Treasurer,,R,Ron Estes,592,395,188,9
-Seward,W6P2,State Treasurer,,R,Ron Estes,363,243,109,11
-Seward,W6P2,State Treasurer,,,Write-ins,1,1,0,0
-Seward,W1P1,U.S. Senate,,L,Randall Batson,13,8,4,1
-Seward,W1P2,U.S. Senate,,L,Randall Batson,20,17,2,1
-Seward,W1P3,U.S. Senate,,L,Randall Batson,16,14,1,1
-Seward,W2,U.S. Senate,,L,Randall Batson,16,11,4,1
-Seward,W3,U.S. Senate,,L,Randall Batson,10,7,3,0
-Seward,W4,U.S. Senate,,L,Randall Batson,7,7,0,0
-Seward,W5,U.S. Senate,,L,Randall Batson,7,5,2,0
-Seward,W6P1,U.S. Senate,,L,Randall Batson,30,22,7,1
-Seward,W6P2,U.S. Senate,,L,Randall Batson,6,4,2,0
-Seward,W1P1,U.S. Senate,,I,Greg Orman,48,39,7,2
-Seward,W1P2,U.S. Senate,,I,Greg Orman,54,37,16,1
-Seward,W1P3,U.S. Senate,,I,Greg Orman,76,52,22,2
-Seward,W2,U.S. Senate,,I,Greg Orman,71,47,22,2
-Seward,W3,U.S. Senate,,I,Greg Orman,42,25,16,1
-Seward,W4,U.S. Senate,,I,Greg Orman,51,31,17,3
-Seward,W5,U.S. Senate,,I,Greg Orman,46,28,18,0
-Seward,W6P1,U.S. Senate,,I,Greg Orman,147,91,54,2
-Seward,W6P2,U.S. Senate,,I,Greg Orman,90,55,30,5
-Seward,W1P1,U.S. Senate,,R,Pat Roberts,144,96,42,6
-Seward,W1P2,U.S. Senate,,R,Pat Roberts,195,124,71,0
-Seward,W1P3,U.S. Senate,,R,Pat Roberts,170,91,74,5
-Seward,W2,U.S. Senate,,R,Pat Roberts,232,166,58,8
-Seward,W3,U.S. Senate,,R,Pat Roberts,92,54,35,3
-Seward,W4,U.S. Senate,,R,Pat Roberts,156,108,45,3
-Seward,W5,U.S. Senate,,R,Pat Roberts,134,92,40,2
-Seward,W6P1,U.S. Senate,,R,Pat Roberts,534,356,168,10
-Seward,W6P2,U.S. Senate,,R,Pat Roberts,326,218,98,10
-Seward,W1P3,U.S. Senate,,,Write-ins,1,1,0,0
-Seward,W4,U.S. Senate,,,Write-ins,1,1,0,0
-Seward,W5,U.S. Senate,,,Write-ins,1,0,0,1
-Seward,W6P1,U.S. Senate,,,Write-ins,1,0,1,0
-Seward,W6P2,U.S. Senate,,,Write-ins,1,1,0,0
+county,precinct,office,district,party,candidate,votes,vtd
+SEWARD,Fargo Township 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000010
+SEWARD,Fargo Township 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+SEWARD,Fargo Township 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000010
+SEWARD,Fargo Township 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",34,000020
+SEWARD,Fargo Township 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000020
+SEWARD,Fargo Township 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",97,000020
+SEWARD,Fargo Township 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000030
+SEWARD,Fargo Township 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+SEWARD,Fargo Township 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000030
+SEWARD,Fargo Township 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000040
+SEWARD,Fargo Township 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+SEWARD,Fargo Township 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000040
+SEWARD,Liberal Township 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,00005A
+SEWARD,Liberal Township 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005A
+SEWARD,Liberal Township 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,00005A
+SEWARD,Liberal Township 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00005B
+SEWARD,Liberal Township 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00005B
+SEWARD,Liberal Township 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00005B
+SEWARD,Liberal Township 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000060
+SEWARD,Liberal Township 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+SEWARD,Liberal Township 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000060
+SEWARD,Liberal Township 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000070
+SEWARD,Liberal Township 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000070
+SEWARD,Liberal Township 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000070
+SEWARD,Liberal Township 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,00008A
+SEWARD,Liberal Township 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,00008A
+SEWARD,Liberal Township 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,00008A
+SEWARD,Liberal Township 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008B
+SEWARD,Liberal Township 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008B
+SEWARD,Liberal Township 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008B
+SEWARD,Liberal Township 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000090
+SEWARD,Liberal Township 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+SEWARD,Liberal Township 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000090
+SEWARD,Liberal Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",52,000100
+SEWARD,Liberal Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000100
+SEWARD,Liberal Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,000100
+SEWARD,Liberal Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000110
+SEWARD,Liberal Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000110
+SEWARD,Liberal Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",179,000110
+SEWARD,Liberal Ward 1 Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",105,000120
+SEWARD,Liberal Ward 1 Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000120
+SEWARD,Liberal Ward 1 Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",153,000120
+SEWARD,Liberal Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,000130
+SEWARD,Liberal Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000130
+SEWARD,Liberal Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",213,000130
+SEWARD,Liberal Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",52,000140
+SEWARD,Liberal Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000140
+SEWARD,Liberal Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",88,000140
+SEWARD,Liberal Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",65,000150
+SEWARD,Liberal Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000150
+SEWARD,Liberal Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",140,000150
+SEWARD,Liberal Ward 5,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,000160
+SEWARD,Liberal Ward 5,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000160
+SEWARD,Liberal Ward 5,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000160
+SEWARD,Liberal Ward 6 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",196,000170
+SEWARD,Liberal Ward 6 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,000170
+SEWARD,Liberal Ward 6 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",483,000170
+SEWARD,Liberal Ward 6 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",115,000180
+SEWARD,Liberal Ward 6 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000180
+SEWARD,Liberal Ward 6 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",302,000180
+SEWARD,Seward Township 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000190
+SEWARD,Seward Township 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000190
+SEWARD,Seward Township 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000190
+SEWARD,Seward Township 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000200
+SEWARD,Seward Township 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000200
+SEWARD,Seward Township 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000200
+SEWARD,Seward Township 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000210
+SEWARD,Seward Township 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000210
+SEWARD,Seward Township 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000210
+SEWARD,Fargo Township 1,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",38,000010
+SEWARD,Fargo Township 2,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",136,000020
+SEWARD,Fargo Township 3,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",17,000030
+SEWARD,Fargo Township 4,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",63,000040
+SEWARD,Liberal Township 1,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",47,00005A
+SEWARD,Liberal Township 1 Exclave,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",0,00005B
+SEWARD,Liberal Township 2,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",28,000060
+SEWARD,Liberal Township 3,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",45,000070
+SEWARD,Liberal Township 4,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",33,00008A
+SEWARD,Liberal Township 4 Exclave,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",0,00008B
+SEWARD,Liberal Township 5,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",25,000090
+SEWARD,Liberal Ward 1 Precinct 1,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",186,000100
+SEWARD,Liberal Ward 1 Precinct 2,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",231,000110
+SEWARD,Liberal Ward 1 Precinct 3,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",220,000120
+SEWARD,Liberal Ward 2,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",280,000130
+SEWARD,Liberal Ward 3,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",127,000140
+SEWARD,Liberal Ward 4,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",191,000150
+SEWARD,Liberal Ward 5,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",162,000160
+SEWARD,Liberal Ward 6 Precinct 1,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",642,000170
+SEWARD,Liberal Ward 6 Precinct 2,Kansas House of Representatives,125,Republican,"Francis, Shannon G.",392,000180
+SEWARD,Seward Township 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",25,000190
+SEWARD,Seward Township 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",23,000200
+SEWARD,Seward Township 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",14,000210
+SEWARD,Fargo Township 1,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000010
+SEWARD,Fargo Township 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000010
+SEWARD,Fargo Township 2,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000020
+SEWARD,Fargo Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",109,000020
+SEWARD,Fargo Township 3,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000030
+SEWARD,Fargo Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000030
+SEWARD,Fargo Township 4,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000040
+SEWARD,Fargo Township 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000040
+SEWARD,Liberal Township 1,United States House of Representatives,1,Democratic,"Sherow, James E.",11,00005A
+SEWARD,Liberal Township 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,00005A
+SEWARD,Liberal Township 1 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+SEWARD,Liberal Township 2,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000060
+SEWARD,Liberal Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000060
+SEWARD,Liberal Township 3,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000070
+SEWARD,Liberal Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000070
+SEWARD,Liberal Township 4,United States House of Representatives,1,Democratic,"Sherow, James E.",5,00008A
+SEWARD,Liberal Township 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,00008A
+SEWARD,Liberal Township 4 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008B
+SEWARD,Liberal Township 5,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000090
+SEWARD,Liberal Township 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000090
+SEWARD,Liberal Ward 1 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",61,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",147,000100
+SEWARD,Liberal Ward 1 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",74,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",201,000110
+SEWARD,Liberal Ward 1 Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",90,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",177,000120
+SEWARD,Liberal Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",78,000130
+SEWARD,Liberal Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",234,000130
+SEWARD,Liberal Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",48,000140
+SEWARD,Liberal Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000140
+SEWARD,Liberal Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",55,000150
+SEWARD,Liberal Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",161,000150
+SEWARD,Liberal Ward 5,United States House of Representatives,1,Democratic,"Sherow, James E.",55,000160
+SEWARD,Liberal Ward 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",130,000160
+SEWARD,Liberal Ward 6 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",179,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",520,000170
+SEWARD,Liberal Ward 6 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",92,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",324,000180
+SEWARD,Seward Township 1,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000190
+SEWARD,Seward Township 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000190
+SEWARD,Seward Township 2,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000200
+SEWARD,Seward Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000200
+SEWARD,Seward Township 3,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000210
+SEWARD,Seward Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000210
+SEWARD,Fargo Township 1,Attorney General,,Democratic,"Kotich, A.J.",3,000010
+SEWARD,Fargo Township 1,Attorney General,,Republican,"Schmidt, Derek",35,000010
+SEWARD,Fargo Township 2,Attorney General,,Democratic,"Kotich, A.J.",15,000020
+SEWARD,Fargo Township 2,Attorney General,,Republican,"Schmidt, Derek",120,000020
+SEWARD,Fargo Township 3,Attorney General,,Democratic,"Kotich, A.J.",0,000030
+SEWARD,Fargo Township 3,Attorney General,,Republican,"Schmidt, Derek",18,000030
+SEWARD,Fargo Township 4,Attorney General,,Democratic,"Kotich, A.J.",14,000040
+SEWARD,Fargo Township 4,Attorney General,,Republican,"Schmidt, Derek",56,000040
+SEWARD,Liberal Township 1,Attorney General,,Democratic,"Kotich, A.J.",8,00005A
+SEWARD,Liberal Township 1,Attorney General,,Republican,"Schmidt, Derek",49,00005A
+SEWARD,Liberal Township 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00005B
+SEWARD,Liberal Township 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00005B
+SEWARD,Liberal Township 2,Attorney General,,Democratic,"Kotich, A.J.",3,000060
+SEWARD,Liberal Township 2,Attorney General,,Republican,"Schmidt, Derek",27,000060
+SEWARD,Liberal Township 3,Attorney General,,Democratic,"Kotich, A.J.",5,000070
+SEWARD,Liberal Township 3,Attorney General,,Republican,"Schmidt, Derek",47,000070
+SEWARD,Liberal Township 4,Attorney General,,Democratic,"Kotich, A.J.",4,00008A
+SEWARD,Liberal Township 4,Attorney General,,Republican,"Schmidt, Derek",30,00008A
+SEWARD,Liberal Township 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00008B
+SEWARD,Liberal Township 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00008B
+SEWARD,Liberal Township 5,Attorney General,,Democratic,"Kotich, A.J.",3,000090
+SEWARD,Liberal Township 5,Attorney General,,Republican,"Schmidt, Derek",24,000090
+SEWARD,Liberal Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",44,000100
+SEWARD,Liberal Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",154,000100
+SEWARD,Liberal Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",84,000110
+SEWARD,Liberal Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",186,000110
+SEWARD,Liberal Ward 1 Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",78,000120
+SEWARD,Liberal Ward 1 Precinct 3,Attorney General,,Republican,"Schmidt, Derek",184,000120
+SEWARD,Liberal Ward 2,Attorney General,,Democratic,"Kotich, A.J.",62,000130
+SEWARD,Liberal Ward 2,Attorney General,,Republican,"Schmidt, Derek",247,000130
+SEWARD,Liberal Ward 3,Attorney General,,Democratic,"Kotich, A.J.",48,000140
+SEWARD,Liberal Ward 3,Attorney General,,Republican,"Schmidt, Derek",91,000140
+SEWARD,Liberal Ward 4,Attorney General,,Democratic,"Kotich, A.J.",48,000150
+SEWARD,Liberal Ward 4,Attorney General,,Republican,"Schmidt, Derek",167,000150
+SEWARD,Liberal Ward 5,Attorney General,,Democratic,"Kotich, A.J.",38,000160
+SEWARD,Liberal Ward 5,Attorney General,,Republican,"Schmidt, Derek",143,000160
+SEWARD,Liberal Ward 6 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",103,000170
+SEWARD,Liberal Ward 6 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",588,000170
+SEWARD,Liberal Ward 6 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",54,000180
+SEWARD,Liberal Ward 6 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",363,000180
+SEWARD,Seward Township 1,Attorney General,,Democratic,"Kotich, A.J.",3,000190
+SEWARD,Seward Township 1,Attorney General,,Republican,"Schmidt, Derek",22,000190
+SEWARD,Seward Township 2,Attorney General,,Democratic,"Kotich, A.J.",4,000200
+SEWARD,Seward Township 2,Attorney General,,Republican,"Schmidt, Derek",22,000200
+SEWARD,Seward Township 3,Attorney General,,Democratic,"Kotich, A.J.",1,000210
+SEWARD,Seward Township 3,Attorney General,,Republican,"Schmidt, Derek",16,000210
+SEWARD,Fargo Township 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000010
+SEWARD,Fargo Township 1,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000010
+SEWARD,Fargo Township 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000020
+SEWARD,Fargo Township 2,Commissioner of Insurance,,Republican,"Selzer, Ken",119,000020
+SEWARD,Fargo Township 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000030
+SEWARD,Fargo Township 3,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000030
+SEWARD,Fargo Township 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000040
+SEWARD,Fargo Township 4,Commissioner of Insurance,,Republican,"Selzer, Ken",52,000040
+SEWARD,Liberal Township 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,00005A
+SEWARD,Liberal Township 1,Commissioner of Insurance,,Republican,"Selzer, Ken",46,00005A
+SEWARD,Liberal Township 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00005B
+SEWARD,Liberal Township 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00005B
+SEWARD,Liberal Township 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000060
+SEWARD,Liberal Township 2,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000060
+SEWARD,Liberal Township 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000070
+SEWARD,Liberal Township 3,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000070
+SEWARD,Liberal Township 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,00008A
+SEWARD,Liberal Township 4,Commissioner of Insurance,,Republican,"Selzer, Ken",26,00008A
+SEWARD,Liberal Township 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00008B
+SEWARD,Liberal Township 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00008B
+SEWARD,Liberal Township 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000090
+SEWARD,Liberal Township 5,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000090
+SEWARD,Liberal Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",54,000100
+SEWARD,Liberal Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",143,000100
+SEWARD,Liberal Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",80,000110
+SEWARD,Liberal Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",186,000110
+SEWARD,Liberal Ward 1 Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",83,000120
+SEWARD,Liberal Ward 1 Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",178,000120
+SEWARD,Liberal Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",74,000130
+SEWARD,Liberal Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",229,000130
+SEWARD,Liberal Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000140
+SEWARD,Liberal Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",85,000140
+SEWARD,Liberal Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",52,000150
+SEWARD,Liberal Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",159,000150
+SEWARD,Liberal Ward 5,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000160
+SEWARD,Liberal Ward 5,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000160
+SEWARD,Liberal Ward 6 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",123,000170
+SEWARD,Liberal Ward 6 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",565,000170
+SEWARD,Liberal Ward 6 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,000180
+SEWARD,Liberal Ward 6 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",342,000180
+SEWARD,Seward Township 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000190
+SEWARD,Seward Township 1,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000190
+SEWARD,Seward Township 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000200
+SEWARD,Seward Township 2,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000200
+SEWARD,Seward Township 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000210
+SEWARD,Seward Township 3,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000210
+SEWARD,Fargo Township 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000010
+SEWARD,Fargo Township 1,Secretary of State,,Republican,"Kobach, Kris",33,000010
+SEWARD,Fargo Township 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000020
+SEWARD,Fargo Township 2,Secretary of State,,Republican,"Kobach, Kris",112,000020
+SEWARD,Fargo Township 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000030
+SEWARD,Fargo Township 3,Secretary of State,,Republican,"Kobach, Kris",17,000030
+SEWARD,Fargo Township 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000040
+SEWARD,Fargo Township 4,Secretary of State,,Republican,"Kobach, Kris",50,000040
+SEWARD,Liberal Township 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,00005A
+SEWARD,Liberal Township 1,Secretary of State,,Republican,"Kobach, Kris",48,00005A
+SEWARD,Liberal Township 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00005B
+SEWARD,Liberal Township 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00005B
+SEWARD,Liberal Township 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000060
+SEWARD,Liberal Township 2,Secretary of State,,Republican,"Kobach, Kris",26,000060
+SEWARD,Liberal Township 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000070
+SEWARD,Liberal Township 3,Secretary of State,,Republican,"Kobach, Kris",51,000070
+SEWARD,Liberal Township 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,00008A
+SEWARD,Liberal Township 4,Secretary of State,,Republican,"Kobach, Kris",29,00008A
+SEWARD,Liberal Township 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008B
+SEWARD,Liberal Township 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00008B
+SEWARD,Liberal Township 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000090
+SEWARD,Liberal Township 5,Secretary of State,,Republican,"Kobach, Kris",23,000090
+SEWARD,Liberal Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000100
+SEWARD,Liberal Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",144,000100
+SEWARD,Liberal Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",88,000110
+SEWARD,Liberal Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",186,000110
+SEWARD,Liberal Ward 1 Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",95,000120
+SEWARD,Liberal Ward 1 Precinct 3,Secretary of State,,Republican,"Kobach, Kris",170,000120
+SEWARD,Liberal Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",87,000130
+SEWARD,Liberal Ward 2,Secretary of State,,Republican,"Kobach, Kris",224,000130
+SEWARD,Liberal Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",48,000140
+SEWARD,Liberal Ward 3,Secretary of State,,Republican,"Kobach, Kris",96,000140
+SEWARD,Liberal Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,000150
+SEWARD,Liberal Ward 4,Secretary of State,,Republican,"Kobach, Kris",162,000150
+SEWARD,Liberal Ward 5,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",45,000160
+SEWARD,Liberal Ward 5,Secretary of State,,Republican,"Kobach, Kris",140,000160
+SEWARD,Liberal Ward 6 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",145,000170
+SEWARD,Liberal Ward 6 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",556,000170
+SEWARD,Liberal Ward 6 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",75,000180
+SEWARD,Liberal Ward 6 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",345,000180
+SEWARD,Seward Township 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000190
+SEWARD,Seward Township 1,Secretary of State,,Republican,"Kobach, Kris",21,000190
+SEWARD,Seward Township 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000200
+SEWARD,Seward Township 2,Secretary of State,,Republican,"Kobach, Kris",23,000200
+SEWARD,Seward Township 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000210
+SEWARD,Seward Township 3,Secretary of State,,Republican,"Kobach, Kris",16,000210
+SEWARD,Fargo Township 1,State Treasurer,,Democratic,"Alldritt, Carmen",3,000010
+SEWARD,Fargo Township 1,State Treasurer,,Republican,"Estes, Ron",35,000010
+SEWARD,Fargo Township 2,State Treasurer,,Democratic,"Alldritt, Carmen",15,000020
+SEWARD,Fargo Township 2,State Treasurer,,Republican,"Estes, Ron",124,000020
+SEWARD,Fargo Township 3,State Treasurer,,Democratic,"Alldritt, Carmen",0,000030
+SEWARD,Fargo Township 3,State Treasurer,,Republican,"Estes, Ron",18,000030
+SEWARD,Fargo Township 4,State Treasurer,,Democratic,"Alldritt, Carmen",15,000040
+SEWARD,Fargo Township 4,State Treasurer,,Republican,"Estes, Ron",56,000040
+SEWARD,Liberal Township 1,State Treasurer,,Democratic,"Alldritt, Carmen",8,00005A
+SEWARD,Liberal Township 1,State Treasurer,,Republican,"Estes, Ron",49,00005A
+SEWARD,Liberal Township 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00005B
+SEWARD,Liberal Township 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00005B
+SEWARD,Liberal Township 2,State Treasurer,,Democratic,"Alldritt, Carmen",4,000060
+SEWARD,Liberal Township 2,State Treasurer,,Republican,"Estes, Ron",28,000060
+SEWARD,Liberal Township 3,State Treasurer,,Democratic,"Alldritt, Carmen",4,000070
+SEWARD,Liberal Township 3,State Treasurer,,Republican,"Estes, Ron",48,000070
+SEWARD,Liberal Township 4,State Treasurer,,Democratic,"Alldritt, Carmen",4,00008A
+SEWARD,Liberal Township 4,State Treasurer,,Republican,"Estes, Ron",28,00008A
+SEWARD,Liberal Township 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008B
+SEWARD,Liberal Township 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00008B
+SEWARD,Liberal Township 5,State Treasurer,,Democratic,"Alldritt, Carmen",2,000090
+SEWARD,Liberal Township 5,State Treasurer,,Republican,"Estes, Ron",25,000090
+SEWARD,Liberal Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",46,000100
+SEWARD,Liberal Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",153,000100
+SEWARD,Liberal Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",64,000110
+SEWARD,Liberal Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",206,000110
+SEWARD,Liberal Ward 1 Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",82,000120
+SEWARD,Liberal Ward 1 Precinct 3,State Treasurer,,Republican,"Estes, Ron",185,000120
+SEWARD,Liberal Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",62,000130
+SEWARD,Liberal Ward 2,State Treasurer,,Republican,"Estes, Ron",251,000130
+SEWARD,Liberal Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",47,000140
+SEWARD,Liberal Ward 3,State Treasurer,,Republican,"Estes, Ron",93,000140
+SEWARD,Liberal Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",49,000150
+SEWARD,Liberal Ward 4,State Treasurer,,Republican,"Estes, Ron",165,000150
+SEWARD,Liberal Ward 5,State Treasurer,,Democratic,"Alldritt, Carmen",37,000160
+SEWARD,Liberal Ward 5,State Treasurer,,Republican,"Estes, Ron",146,000160
+SEWARD,Liberal Ward 6 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",102,000170
+SEWARD,Liberal Ward 6 Precinct 1,State Treasurer,,Republican,"Estes, Ron",592,000170
+SEWARD,Liberal Ward 6 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",50,000180
+SEWARD,Liberal Ward 6 Precinct 2,State Treasurer,,Republican,"Estes, Ron",363,000180
+SEWARD,Seward Township 1,State Treasurer,,Democratic,"Alldritt, Carmen",5,000190
+SEWARD,Seward Township 1,State Treasurer,,Republican,"Estes, Ron",20,000190
+SEWARD,Seward Township 2,State Treasurer,,Democratic,"Alldritt, Carmen",2,000200
+SEWARD,Seward Township 2,State Treasurer,,Republican,"Estes, Ron",23,000200
+SEWARD,Seward Township 3,State Treasurer,,Democratic,"Alldritt, Carmen",1,000210
+SEWARD,Seward Township 3,State Treasurer,,Republican,"Estes, Ron",16,000210
+SEWARD,Fargo Township 1,United States Senate,,independent,"Orman, Greg",10,000010
+SEWARD,Fargo Township 1,United States Senate,,Libertarian,"Batson, Randall",2,000010
+SEWARD,Fargo Township 1,United States Senate,,Republican,"Roberts, Pat",27,000010
+SEWARD,Fargo Township 2,United States Senate,,independent,"Orman, Greg",27,000020
+SEWARD,Fargo Township 2,United States Senate,,Libertarian,"Batson, Randall",8,000020
+SEWARD,Fargo Township 2,United States Senate,,Republican,"Roberts, Pat",107,000020
+SEWARD,Fargo Township 3,United States Senate,,independent,"Orman, Greg",0,000030
+SEWARD,Fargo Township 3,United States Senate,,Libertarian,"Batson, Randall",0,000030
+SEWARD,Fargo Township 3,United States Senate,,Republican,"Roberts, Pat",17,000030
+SEWARD,Fargo Township 4,United States Senate,,independent,"Orman, Greg",20,000040
+SEWARD,Fargo Township 4,United States Senate,,Libertarian,"Batson, Randall",6,000040
+SEWARD,Fargo Township 4,United States Senate,,Republican,"Roberts, Pat",46,000040
+SEWARD,Liberal Township 1,United States Senate,,independent,"Orman, Greg",14,00005A
+SEWARD,Liberal Township 1,United States Senate,,Libertarian,"Batson, Randall",0,00005A
+SEWARD,Liberal Township 1,United States Senate,,Republican,"Roberts, Pat",44,00005A
+SEWARD,Liberal Township 1 Exclave,United States Senate,,independent,"Orman, Greg",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00005B
+SEWARD,Liberal Township 2,United States Senate,,independent,"Orman, Greg",6,000060
+SEWARD,Liberal Township 2,United States Senate,,Libertarian,"Batson, Randall",0,000060
+SEWARD,Liberal Township 2,United States Senate,,Republican,"Roberts, Pat",26,000060
+SEWARD,Liberal Township 3,United States Senate,,independent,"Orman, Greg",8,000070
+SEWARD,Liberal Township 3,United States Senate,,Libertarian,"Batson, Randall",4,000070
+SEWARD,Liberal Township 3,United States Senate,,Republican,"Roberts, Pat",43,000070
+SEWARD,Liberal Township 4,United States Senate,,independent,"Orman, Greg",6,00008A
+SEWARD,Liberal Township 4,United States Senate,,Libertarian,"Batson, Randall",5,00008A
+SEWARD,Liberal Township 4,United States Senate,,Republican,"Roberts, Pat",24,00008A
+SEWARD,Liberal Township 4 Exclave,United States Senate,,independent,"Orman, Greg",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00008B
+SEWARD,Liberal Township 5,United States Senate,,independent,"Orman, Greg",3,000090
+SEWARD,Liberal Township 5,United States Senate,,Libertarian,"Batson, Randall",0,000090
+SEWARD,Liberal Township 5,United States Senate,,Republican,"Roberts, Pat",24,000090
+SEWARD,Liberal Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",48,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",13,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",144,000100
+SEWARD,Liberal Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",54,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",20,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",195,000110
+SEWARD,Liberal Ward 1 Precinct 3,United States Senate,,independent,"Orman, Greg",76,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States Senate,,Libertarian,"Batson, Randall",16,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States Senate,,Republican,"Roberts, Pat",170,000120
+SEWARD,Liberal Ward 2,United States Senate,,independent,"Orman, Greg",71,000130
+SEWARD,Liberal Ward 2,United States Senate,,Libertarian,"Batson, Randall",16,000130
+SEWARD,Liberal Ward 2,United States Senate,,Republican,"Roberts, Pat",232,000130
+SEWARD,Liberal Ward 3,United States Senate,,independent,"Orman, Greg",42,000140
+SEWARD,Liberal Ward 3,United States Senate,,Libertarian,"Batson, Randall",10,000140
+SEWARD,Liberal Ward 3,United States Senate,,Republican,"Roberts, Pat",92,000140
+SEWARD,Liberal Ward 4,United States Senate,,independent,"Orman, Greg",51,000150
+SEWARD,Liberal Ward 4,United States Senate,,Libertarian,"Batson, Randall",7,000150
+SEWARD,Liberal Ward 4,United States Senate,,Republican,"Roberts, Pat",156,000150
+SEWARD,Liberal Ward 5,United States Senate,,independent,"Orman, Greg",46,000160
+SEWARD,Liberal Ward 5,United States Senate,,Libertarian,"Batson, Randall",7,000160
+SEWARD,Liberal Ward 5,United States Senate,,Republican,"Roberts, Pat",134,000160
+SEWARD,Liberal Ward 6 Precinct 1,United States Senate,,independent,"Orman, Greg",147,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",30,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States Senate,,Republican,"Roberts, Pat",534,000170
+SEWARD,Liberal Ward 6 Precinct 2,United States Senate,,independent,"Orman, Greg",90,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",6,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States Senate,,Republican,"Roberts, Pat",326,000180
+SEWARD,Seward Township 1,United States Senate,,independent,"Orman, Greg",4,000190
+SEWARD,Seward Township 1,United States Senate,,Libertarian,"Batson, Randall",1,000190
+SEWARD,Seward Township 1,United States Senate,,Republican,"Roberts, Pat",20,000190
+SEWARD,Seward Township 2,United States Senate,,independent,"Orman, Greg",5,000200
+SEWARD,Seward Township 2,United States Senate,,Libertarian,"Batson, Randall",0,000200
+SEWARD,Seward Township 2,United States Senate,,Republican,"Roberts, Pat",22,000200
+SEWARD,Seward Township 3,United States Senate,,independent,"Orman, Greg",1,000210
+SEWARD,Seward Township 3,United States Senate,,Libertarian,"Batson, Randall",0,000210
+SEWARD,Seward Township 3,United States Senate,,Republican,"Roberts, Pat",16,000210

--- a/2014/20141104__ks__general__shawnee__precinct.csv
+++ b/2014/20141104__ks__general__shawnee__precinct.csv
@@ -1,4041 +1,1317 @@
-county,precinct,office,district,party,candidate,votes
-Shawnee,Ward 1 Precinct 1,U.S. Senate,,R,Pat Roberts,44
-Shawnee,Ward 1 Precinct 2,U.S. Senate,,R,Pat Roberts,57
-Shawnee,Ward 1 Precinct 3,U.S. Senate,,R,Pat Roberts,55
-Shawnee,Ward 1 Precinct 4,U.S. Senate,,R,Pat Roberts,90
-Shawnee,Ward 1 Precinct 5,U.S. Senate,,R,Pat Roberts,157
-Shawnee,Ward 1 Precinct 6,U.S. Senate,,R,Pat Roberts,216
-Shawnee,Ward 2 Precinct 1,U.S. Senate,,R,Pat Roberts,86
-Shawnee,Ward 2 Precinct 2,U.S. Senate,,R,Pat Roberts,75
-Shawnee,Ward 2 Precinct 3,U.S. Senate,,R,Pat Roberts,77
-Shawnee,Ward 2 Precinct 4,U.S. Senate,,R,Pat Roberts,61
-Shawnee,Ward 2 Precinct 5,U.S. Senate,,R,Pat Roberts,49
-Shawnee,Ward 2 Precinct 6,U.S. Senate,,R,Pat Roberts,46
-Shawnee,Ward 2 Precinct 7,U.S. Senate,,R,Pat Roberts,19
-Shawnee,Ward 2 Precinct 8,U.S. Senate,,R,Pat Roberts,11
-Shawnee,Ward 2 Precinct 9,U.S. Senate,,R,Pat Roberts,81
-Shawnee,Ward 2 Precinct 10,U.S. Senate,,R,Pat Roberts,61
-Shawnee,Ward 2 Precinct 11,U.S. Senate,,R,Pat Roberts,49
-Shawnee,Ward 3 Precinct 1,U.S. Senate,,R,Pat Roberts,75
-Shawnee,Ward 3 Precinct 2,U.S. Senate,,R,Pat Roberts,67
-Shawnee,Ward 3 Precinct 3,U.S. Senate,,R,Pat Roberts,38
-Shawnee,Ward 3 Precinct 4,U.S. Senate,,R,Pat Roberts,52
-Shawnee,Ward 3 Precinct 5,U.S. Senate,,R,Pat Roberts,27
-Shawnee,Ward 3 Precinct 6,U.S. Senate,,R,Pat Roberts,48
-Shawnee,Ward 3 Precinct 7,U.S. Senate,,R,Pat Roberts,45
-Shawnee,Ward 3 Precinct 8,U.S. Senate,,R,Pat Roberts,65
-Shawnee,Ward 3 Precinct 9,U.S. Senate,,R,Pat Roberts,54
-Shawnee,Ward 3 Precinct 10,U.S. Senate,,R,Pat Roberts,3
-Shawnee,Ward 4 Precinct 1,U.S. Senate,,R,Pat Roberts,37
-Shawnee,Ward 4 Precinct 2,U.S. Senate,,R,Pat Roberts,37
-Shawnee,Ward 4 Precinct 3,U.S. Senate,,R,Pat Roberts,20
-Shawnee,Ward 4 Precinct 4,U.S. Senate,,R,Pat Roberts,22
-Shawnee,Ward 4 Precinct 6,U.S. Senate,,R,Pat Roberts,56
-Shawnee,Ward 4 Precinct 7,U.S. Senate,,R,Pat Roberts,29
-Shawnee,Ward 4 Precinct 8,U.S. Senate,,R,Pat Roberts,54
-Shawnee,Ward 4 Precinct 9,U.S. Senate,,R,Pat Roberts,48
-Shawnee,Ward 4 Precinct 10,U.S. Senate,,R,Pat Roberts,67
-Shawnee,Ward 4 Precinct 11,U.S. Senate,,R,Pat Roberts,37
-Shawnee,Ward 4 Precinct 12,U.S. Senate,,R,Pat Roberts,1
-Shawnee,Ward 4 Precinct 15,U.S. Senate,,R,Pat Roberts,48
-Shawnee,Ward 5 Precinct 1,U.S. Senate,,R,Pat Roberts,37
-Shawnee,Ward 5 Precinct 2,U.S. Senate,,R,Pat Roberts,47
-Shawnee,Ward 5 Precinct 3,U.S. Senate,,R,Pat Roberts,71
-Shawnee,Ward 5 Precinct 4,U.S. Senate,,R,Pat Roberts,57
-Shawnee,Ward 5 Precinct 5,U.S. Senate,,R,Pat Roberts,61
-Shawnee,Ward 5 Precinct 6,U.S. Senate,,R,Pat Roberts,40
-Shawnee,Ward 5 Precinct 7,U.S. Senate,,R,Pat Roberts,49
-Shawnee,Ward 5 Precinct 8,U.S. Senate,,R,Pat Roberts,58
-Shawnee,Ward 5 Precinct 9,U.S. Senate,,R,Pat Roberts,138
-Shawnee,Ward 5 Precinct 10,U.S. Senate,,R,Pat Roberts,190
-Shawnee,Ward 5 Precinct 11,U.S. Senate,,R,Pat Roberts,136
-Shawnee,Ward 5 Precinct 14,U.S. Senate,,R,Pat Roberts,107
-Shawnee,Ward 5 Precinct 15,U.S. Senate,,R,Pat Roberts,25
-Shawnee,Ward 5 Precinct 91,U.S. Senate,,R,Pat Roberts,44
-Shawnee,Ward 6 Precinct 1,U.S. Senate,,R,Pat Roberts,33
-Shawnee,Ward 6 Precinct 2,U.S. Senate,,R,Pat Roberts,31
-Shawnee,Ward 6 Precinct 3,U.S. Senate,,R,Pat Roberts,177
-Shawnee,Ward 6 Precinct 4,U.S. Senate,,R,Pat Roberts,70
-Shawnee,Ward 6 Precinct 5,U.S. Senate,,R,Pat Roberts,117
-Shawnee,Ward 6 Precinct 6,U.S. Senate,,R,Pat Roberts,54
-Shawnee,Ward 6 Precinct 7,U.S. Senate,,R,Pat Roberts,46
-Shawnee,Ward 6 Precinct 8,U.S. Senate,,R,Pat Roberts,68
-Shawnee,Ward 6 Precinct 9,U.S. Senate,,R,Pat Roberts,238
-Shawnee,Ward 7 Precinct 1,U.S. Senate,,R,Pat Roberts,92
-Shawnee,Ward 7 Precinct 2,U.S. Senate,,R,Pat Roberts,66
-Shawnee,Ward 7 Precinct 3,U.S. Senate,,R,Pat Roberts,81
-Shawnee,Ward 7 Precinct 4,U.S. Senate,,R,Pat Roberts,129
-Shawnee,Ward 7 Precinct 5,U.S. Senate,,R,Pat Roberts,100
-Shawnee,Ward 7 Precinct 6,U.S. Senate,,R,Pat Roberts,78
-Shawnee,Ward 7 Precinct 7,U.S. Senate,,R,Pat Roberts,61
-Shawnee,Ward 7 Precinct 9,U.S. Senate,,R,Pat Roberts,85
-Shawnee,Ward 7 Precinct 10,U.S. Senate,,R,Pat Roberts,64
-Shawnee,Ward 7 Precinct 11,U.S. Senate,,R,Pat Roberts,131
-Shawnee,Ward 8 Precinct 1,U.S. Senate,,R,Pat Roberts,49
-Shawnee,Ward 8 Precinct 2,U.S. Senate,,R,Pat Roberts,63
-Shawnee,Ward 8 Precinct 3,U.S. Senate,,R,Pat Roberts,93
-Shawnee,Ward 8 Precinct 4,U.S. Senate,,R,Pat Roberts,101
-Shawnee,Ward 8 Precinct 5,U.S. Senate,,R,Pat Roberts,156
-Shawnee,Ward 8 Precinct 6,U.S. Senate,,R,Pat Roberts,107
-Shawnee,Ward 8 Precinct 7,U.S. Senate,,R,Pat Roberts,60
-Shawnee,Ward 8 Precinct 8,U.S. Senate,,R,Pat Roberts,78
-Shawnee,Ward 8 Precinct 9,U.S. Senate,,R,Pat Roberts,136
-Shawnee,Ward 8 Precinct 10,U.S. Senate,,R,Pat Roberts,151
-Shawnee,Ward 8 Precinct 11,U.S. Senate,,R,Pat Roberts,134
-Shawnee,Ward 9 Precinct 1,U.S. Senate,,R,Pat Roberts,18
-Shawnee,Ward 9 Precinct 2,U.S. Senate,,R,Pat Roberts,72
-Shawnee,Ward 9 Precinct 3,U.S. Senate,,R,Pat Roberts,167
-Shawnee,Ward 9 Precinct 4,U.S. Senate,,R,Pat Roberts,127
-Shawnee,Ward 9 Precinct 5,U.S. Senate,,R,Pat Roberts,92
-Shawnee,Ward 9 Precinct 6,U.S. Senate,,R,Pat Roberts,115
-Shawnee,Ward 9 Precinct 8,U.S. Senate,,R,Pat Roberts,139
-Shawnee,Ward 9 Precinct 9,U.S. Senate,,R,Pat Roberts,105
-Shawnee,Ward 9 Precinct 10,U.S. Senate,,R,Pat Roberts,189
-Shawnee,Ward 9 Precinct 11,U.S. Senate,,R,Pat Roberts,122
-Shawnee,Ward 9 Precinct 12,U.S. Senate,,R,Pat Roberts,45
-Shawnee,Ward 10 Precinct 1,U.S. Senate,,R,Pat Roberts,106
-Shawnee,Ward 10 Precinct 2,U.S. Senate,,R,Pat Roberts,185
-Shawnee,Ward 10 Precinct 3,U.S. Senate,,R,Pat Roberts,221
-Shawnee,Ward 10 Precinct 4,U.S. Senate,,R,Pat Roberts,127
-Shawnee,Ward 10 Precinct 5,U.S. Senate,,R,Pat Roberts,103
-Shawnee,Ward 10 Precinct 6,U.S. Senate,,R,Pat Roberts,125
-Shawnee,Ward 10 Precinct 7,U.S. Senate,,R,Pat Roberts,120
-Shawnee,Ward 10 Precinct 8,U.S. Senate,,R,Pat Roberts,88
-Shawnee,Ward 10 Precinct 9,U.S. Senate,,R,Pat Roberts,78
-Shawnee,Ward 10 Precinct 10,U.S. Senate,,R,Pat Roberts,115
-Shawnee,Ward 10 Precinct 11,U.S. Senate,,R,Pat Roberts,167
-Shawnee,Ward 10 Precinct 14,U.S. Senate,,R,Pat Roberts,120
-Shawnee,Ward 11 Precinct 1,U.S. Senate,,R,Pat Roberts,94
-Shawnee,Ward 11 Precinct 2,U.S. Senate,,R,Pat Roberts,115
-Shawnee,Ward 11 Precinct 3,U.S. Senate,,R,Pat Roberts,71
-Shawnee,Ward 11 Precinct 4,U.S. Senate,,R,Pat Roberts,163
-Shawnee,Ward 11 Precinct 5,U.S. Senate,,R,Pat Roberts,113
-Shawnee,Ward 11 Precinct 6,U.S. Senate,,R,Pat Roberts,113
-Shawnee,Ward 11 Precinct 7,U.S. Senate,,R,Pat Roberts,117
-Shawnee,Ward 11 Precinct 8,U.S. Senate,,R,Pat Roberts,112
-Shawnee,Ward 11 Precinct 9,U.S. Senate,,R,Pat Roberts,114
-Shawnee,Ward 11 Precinct 10,U.S. Senate,,R,Pat Roberts,72
-Shawnee,Ward 12 Precinct 1,U.S. Senate,,R,Pat Roberts,92
-Shawnee,Ward 12 Precinct 2,U.S. Senate,,R,Pat Roberts,71
-Shawnee,Ward 12 Precinct 3,U.S. Senate,,R,Pat Roberts,155
-Shawnee,Ward 12 Precinct 4,U.S. Senate,,R,Pat Roberts,214
-Shawnee,Ward 12 Precinct 5,U.S. Senate,,R,Pat Roberts,180
-Shawnee,Ward 12 Precinct 6,U.S. Senate,,R,Pat Roberts,162
-Shawnee,Ward 12 Precinct 7,U.S. Senate,,R,Pat Roberts,163
-Shawnee,Ward 12 Precinct 8,U.S. Senate,,R,Pat Roberts,165
-Shawnee,Ward 12 Precinct 9,U.S. Senate,,R,Pat Roberts,261
-Shawnee,Ward 12 Precinct 11,U.S. Senate,,R,Pat Roberts,304
-Shawnee,Ward 12 Precinct 13,U.S. Senate,,R,Pat Roberts,236
-Shawnee,Ward 12 Precinct 14,U.S. Senate,,R,Pat Roberts,156
-Shawnee,Ward 12 Precinct 15,U.S. Senate,,R,Pat Roberts,268
-Shawnee,Ward 12 Precinct 16,U.S. Senate,,R,Pat Roberts,260
-Shawnee,Ward 12 Precinct 19,U.S. Senate,,R,Pat Roberts,48
-Shawnee,Ward 12 Precinct 20,U.S. Senate,,R,Pat Roberts,207
-Shawnee,Ward 12 Precinct 31,U.S. Senate,,R,Pat Roberts,136
-Shawnee,Ward 13 Precinct 2,U.S. Senate,,R,Pat Roberts,39
-Shawnee,Ward 13 Precinct 5,U.S. Senate,,R,Pat Roberts,12
-Shawnee,Ward 13 Precinct 6,U.S. Senate,,R,Pat Roberts,75
-Shawnee,Ward 13 Precinct 9,U.S. Senate,,R,Pat Roberts,49
-Shawnee,Ward 13 Precinct 12,U.S. Senate,,R,Pat Roberts,286
-Shawnee,Ward 13 Precinct 21,U.S. Senate,,R,Pat Roberts,24
-Shawnee,Ward 13 Precinct 22,U.S. Senate,,R,Pat Roberts,30
-Shawnee,Ward 13 Precinct 30,U.S. Senate,,R,Pat Roberts,49
-Shawnee,Ward 14 Precinct 1,U.S. Senate,,R,Pat Roberts,249
-Shawnee,Ward 14 Precinct 2,U.S. Senate,,R,Pat Roberts,201
-Shawnee,Ward 14 Precinct 3,U.S. Senate,,R,Pat Roberts,159
-Shawnee,Ward 14 Precinct 4,U.S. Senate,,R,Pat Roberts,357
-Shawnee,Ward 14 Precinct 5,U.S. Senate,,R,Pat Roberts,224
-Shawnee,Ward 15 Precinct 1,U.S. Senate,,R,Pat Roberts,168
-Shawnee,Ward 15 Precinct 2,U.S. Senate,,R,Pat Roberts,118
-Shawnee,Ward 15 Precinct 3,U.S. Senate,,R,Pat Roberts,13
-Shawnee,Ward 1 Precinct 1,U.S. Senate,,I,Greg Orman,107
-Shawnee,Ward 1 Precinct 2,U.S. Senate,,I,Greg Orman,139
-Shawnee,Ward 1 Precinct 3,U.S. Senate,,I,Greg Orman,112
-Shawnee,Ward 1 Precinct 4,U.S. Senate,,I,Greg Orman,145
-Shawnee,Ward 1 Precinct 5,U.S. Senate,,I,Greg Orman,187
-Shawnee,Ward 1 Precinct 6,U.S. Senate,,I,Greg Orman,230
-Shawnee,Ward 2 Precinct 1,U.S. Senate,,I,Greg Orman,144
-Shawnee,Ward 2 Precinct 2,U.S. Senate,,I,Greg Orman,127
-Shawnee,Ward 2 Precinct 3,U.S. Senate,,I,Greg Orman,126
-Shawnee,Ward 2 Precinct 4,U.S. Senate,,I,Greg Orman,118
-Shawnee,Ward 2 Precinct 5,U.S. Senate,,I,Greg Orman,137
-Shawnee,Ward 2 Precinct 6,U.S. Senate,,I,Greg Orman,96
-Shawnee,Ward 2 Precinct 7,U.S. Senate,,I,Greg Orman,60
-Shawnee,Ward 2 Precinct 8,U.S. Senate,,I,Greg Orman,81
-Shawnee,Ward 2 Precinct 9,U.S. Senate,,I,Greg Orman,152
-Shawnee,Ward 2 Precinct 10,U.S. Senate,,I,Greg Orman,198
-Shawnee,Ward 2 Precinct 11,U.S. Senate,,I,Greg Orman,95
-Shawnee,Ward 3 Precinct 1,U.S. Senate,,I,Greg Orman,139
-Shawnee,Ward 3 Precinct 2,U.S. Senate,,I,Greg Orman,175
-Shawnee,Ward 3 Precinct 3,U.S. Senate,,I,Greg Orman,98
-Shawnee,Ward 3 Precinct 4,U.S. Senate,,I,Greg Orman,116
-Shawnee,Ward 3 Precinct 5,U.S. Senate,,I,Greg Orman,78
-Shawnee,Ward 3 Precinct 6,U.S. Senate,,I,Greg Orman,88
-Shawnee,Ward 3 Precinct 7,U.S. Senate,,I,Greg Orman,105
-Shawnee,Ward 3 Precinct 8,U.S. Senate,,I,Greg Orman,124
-Shawnee,Ward 3 Precinct 9,U.S. Senate,,I,Greg Orman,120
-Shawnee,Ward 3 Precinct 10,U.S. Senate,,I,Greg Orman,8
-Shawnee,Ward 4 Precinct 1,U.S. Senate,,I,Greg Orman,118
-Shawnee,Ward 4 Precinct 2,U.S. Senate,,I,Greg Orman,119
-Shawnee,Ward 4 Precinct 3,U.S. Senate,,I,Greg Orman,100
-Shawnee,Ward 4 Precinct 4,U.S. Senate,,I,Greg Orman,174
-Shawnee,Ward 4 Precinct 6,U.S. Senate,,I,Greg Orman,154
-Shawnee,Ward 4 Precinct 7,U.S. Senate,,I,Greg Orman,89
-Shawnee,Ward 4 Precinct 8,U.S. Senate,,I,Greg Orman,105
-Shawnee,Ward 4 Precinct 9,U.S. Senate,,I,Greg Orman,142
-Shawnee,Ward 4 Precinct 10,U.S. Senate,,I,Greg Orman,167
-Shawnee,Ward 4 Precinct 11,U.S. Senate,,I,Greg Orman,55
-Shawnee,Ward 4 Precinct 12,U.S. Senate,,I,Greg Orman,14
-Shawnee,Ward 4 Precinct 15,U.S. Senate,,I,Greg Orman,86
-Shawnee,Ward 5 Precinct 1,U.S. Senate,,I,Greg Orman,117
-Shawnee,Ward 5 Precinct 2,U.S. Senate,,I,Greg Orman,109
-Shawnee,Ward 5 Precinct 3,U.S. Senate,,I,Greg Orman,107
-Shawnee,Ward 5 Precinct 4,U.S. Senate,,I,Greg Orman,141
-Shawnee,Ward 5 Precinct 5,U.S. Senate,,I,Greg Orman,135
-Shawnee,Ward 5 Precinct 6,U.S. Senate,,I,Greg Orman,102
-Shawnee,Ward 5 Precinct 7,U.S. Senate,,I,Greg Orman,153
-Shawnee,Ward 5 Precinct 8,U.S. Senate,,I,Greg Orman,104
-Shawnee,Ward 5 Precinct 9,U.S. Senate,,I,Greg Orman,207
-Shawnee,Ward 5 Precinct 10,U.S. Senate,,I,Greg Orman,235
-Shawnee,Ward 5 Precinct 11,U.S. Senate,,I,Greg Orman,191
-Shawnee,Ward 5 Precinct 14,U.S. Senate,,I,Greg Orman,105
-Shawnee,Ward 5 Precinct 15,U.S. Senate,,I,Greg Orman,25
-Shawnee,Ward 5 Precinct 91,U.S. Senate,,I,Greg Orman,45
-Shawnee,Ward 6 Precinct 1,U.S. Senate,,I,Greg Orman,108
-Shawnee,Ward 6 Precinct 2,U.S. Senate,,I,Greg Orman,109
-Shawnee,Ward 6 Precinct 3,U.S. Senate,,I,Greg Orman,177
-Shawnee,Ward 6 Precinct 4,U.S. Senate,,I,Greg Orman,144
-Shawnee,Ward 6 Precinct 5,U.S. Senate,,I,Greg Orman,197
-Shawnee,Ward 6 Precinct 6,U.S. Senate,,I,Greg Orman,91
-Shawnee,Ward 6 Precinct 7,U.S. Senate,,I,Greg Orman,68
-Shawnee,Ward 6 Precinct 8,U.S. Senate,,I,Greg Orman,157
-Shawnee,Ward 6 Precinct 9,U.S. Senate,,I,Greg Orman,331
-Shawnee,Ward 7 Precinct 1,U.S. Senate,,I,Greg Orman,210
-Shawnee,Ward 7 Precinct 2,U.S. Senate,,I,Greg Orman,168
-Shawnee,Ward 7 Precinct 3,U.S. Senate,,I,Greg Orman,167
-Shawnee,Ward 7 Precinct 4,U.S. Senate,,I,Greg Orman,162
-Shawnee,Ward 7 Precinct 5,U.S. Senate,,I,Greg Orman,132
-Shawnee,Ward 7 Precinct 6,U.S. Senate,,I,Greg Orman,114
-Shawnee,Ward 7 Precinct 7,U.S. Senate,,I,Greg Orman,126
-Shawnee,Ward 7 Precinct 9,U.S. Senate,,I,Greg Orman,123
-Shawnee,Ward 7 Precinct 10,U.S. Senate,,I,Greg Orman,152
-Shawnee,Ward 7 Precinct 11,U.S. Senate,,I,Greg Orman,215
-Shawnee,Ward 8 Precinct 1,U.S. Senate,,I,Greg Orman,138
-Shawnee,Ward 8 Precinct 2,U.S. Senate,,I,Greg Orman,166
-Shawnee,Ward 8 Precinct 3,U.S. Senate,,I,Greg Orman,239
-Shawnee,Ward 8 Precinct 4,U.S. Senate,,I,Greg Orman,207
-Shawnee,Ward 8 Precinct 5,U.S. Senate,,I,Greg Orman,259
-Shawnee,Ward 8 Precinct 6,U.S. Senate,,I,Greg Orman,148
-Shawnee,Ward 8 Precinct 7,U.S. Senate,,I,Greg Orman,149
-Shawnee,Ward 8 Precinct 8,U.S. Senate,,I,Greg Orman,167
-Shawnee,Ward 8 Precinct 9,U.S. Senate,,I,Greg Orman,203
-Shawnee,Ward 8 Precinct 10,U.S. Senate,,I,Greg Orman,118
-Shawnee,Ward 8 Precinct 11,U.S. Senate,,I,Greg Orman,205
-Shawnee,Ward 9 Precinct 1,U.S. Senate,,I,Greg Orman,39
-Shawnee,Ward 9 Precinct 2,U.S. Senate,,I,Greg Orman,133
-Shawnee,Ward 9 Precinct 3,U.S. Senate,,I,Greg Orman,241
-Shawnee,Ward 9 Precinct 4,U.S. Senate,,I,Greg Orman,214
-Shawnee,Ward 9 Precinct 5,U.S. Senate,,I,Greg Orman,163
-Shawnee,Ward 9 Precinct 6,U.S. Senate,,I,Greg Orman,184
-Shawnee,Ward 9 Precinct 8,U.S. Senate,,I,Greg Orman,213
-Shawnee,Ward 9 Precinct 9,U.S. Senate,,I,Greg Orman,166
-Shawnee,Ward 9 Precinct 10,U.S. Senate,,I,Greg Orman,300
-Shawnee,Ward 9 Precinct 11,U.S. Senate,,I,Greg Orman,173
-Shawnee,Ward 9 Precinct 12,U.S. Senate,,I,Greg Orman,94
-Shawnee,Ward 10 Precinct 1,U.S. Senate,,I,Greg Orman,197
-Shawnee,Ward 10 Precinct 2,U.S. Senate,,I,Greg Orman,163
-Shawnee,Ward 10 Precinct 3,U.S. Senate,,I,Greg Orman,261
-Shawnee,Ward 10 Precinct 4,U.S. Senate,,I,Greg Orman,162
-Shawnee,Ward 10 Precinct 5,U.S. Senate,,I,Greg Orman,152
-Shawnee,Ward 10 Precinct 6,U.S. Senate,,I,Greg Orman,135
-Shawnee,Ward 10 Precinct 7,U.S. Senate,,I,Greg Orman,162
-Shawnee,Ward 10 Precinct 8,U.S. Senate,,I,Greg Orman,155
-Shawnee,Ward 10 Precinct 9,U.S. Senate,,I,Greg Orman,123
-Shawnee,Ward 10 Precinct 10,U.S. Senate,,I,Greg Orman,169
-Shawnee,Ward 10 Precinct 11,U.S. Senate,,I,Greg Orman,225
-Shawnee,Ward 10 Precinct 14,U.S. Senate,,I,Greg Orman,178
-Shawnee,Ward 11 Precinct 1,U.S. Senate,,I,Greg Orman,108
-Shawnee,Ward 11 Precinct 2,U.S. Senate,,I,Greg Orman,170
-Shawnee,Ward 11 Precinct 3,U.S. Senate,,I,Greg Orman,134
-Shawnee,Ward 11 Precinct 4,U.S. Senate,,I,Greg Orman,233
-Shawnee,Ward 11 Precinct 5,U.S. Senate,,I,Greg Orman,167
-Shawnee,Ward 11 Precinct 6,U.S. Senate,,I,Greg Orman,153
-Shawnee,Ward 11 Precinct 7,U.S. Senate,,I,Greg Orman,145
-Shawnee,Ward 11 Precinct 8,U.S. Senate,,I,Greg Orman,142
-Shawnee,Ward 11 Precinct 9,U.S. Senate,,I,Greg Orman,170
-Shawnee,Ward 11 Precinct 10,U.S. Senate,,I,Greg Orman,114
-Shawnee,Ward 12 Precinct 1,U.S. Senate,,I,Greg Orman,166
-Shawnee,Ward 12 Precinct 2,U.S. Senate,,I,Greg Orman,119
-Shawnee,Ward 12 Precinct 3,U.S. Senate,,I,Greg Orman,171
-Shawnee,Ward 12 Precinct 4,U.S. Senate,,I,Greg Orman,211
-Shawnee,Ward 12 Precinct 5,U.S. Senate,,I,Greg Orman,207
-Shawnee,Ward 12 Precinct 6,U.S. Senate,,I,Greg Orman,257
-Shawnee,Ward 12 Precinct 7,U.S. Senate,,I,Greg Orman,209
-Shawnee,Ward 12 Precinct 8,U.S. Senate,,I,Greg Orman,214
-Shawnee,Ward 12 Precinct 9,U.S. Senate,,I,Greg Orman,306
-Shawnee,Ward 12 Precinct 11,U.S. Senate,,I,Greg Orman,294
-Shawnee,Ward 12 Precinct 13,U.S. Senate,,I,Greg Orman,186
-Shawnee,Ward 12 Precinct 14,U.S. Senate,,I,Greg Orman,162
-Shawnee,Ward 12 Precinct 15,U.S. Senate,,I,Greg Orman,271
-Shawnee,Ward 12 Precinct 16,U.S. Senate,,I,Greg Orman,312
-Shawnee,Ward 12 Precinct 19,U.S. Senate,,I,Greg Orman,26
-Shawnee,Ward 12 Precinct 20,U.S. Senate,,I,Greg Orman,216
-Shawnee,Ward 12 Precinct 31,U.S. Senate,,I,Greg Orman,131
-Shawnee,Ward 13 Precinct 2,U.S. Senate,,I,Greg Orman,67
-Shawnee,Ward 13 Precinct 5,U.S. Senate,,I,Greg Orman,2
-Shawnee,Ward 13 Precinct 6,U.S. Senate,,I,Greg Orman,34
-Shawnee,Ward 13 Precinct 9,U.S. Senate,,I,Greg Orman,35
-Shawnee,Ward 13 Precinct 12,U.S. Senate,,I,Greg Orman,231
-Shawnee,Ward 13 Precinct 21,U.S. Senate,,I,Greg Orman,43
-Shawnee,Ward 13 Precinct 22,U.S. Senate,,I,Greg Orman,33
-Shawnee,Ward 13 Precinct 30,U.S. Senate,,I,Greg Orman,65
-Shawnee,Ward 14 Precinct 1,U.S. Senate,,I,Greg Orman,276
-Shawnee,Ward 14 Precinct 2,U.S. Senate,,I,Greg Orman,252
-Shawnee,Ward 14 Precinct 3,U.S. Senate,,I,Greg Orman,137
-Shawnee,Ward 14 Precinct 4,U.S. Senate,,I,Greg Orman,247
-Shawnee,Ward 14 Precinct 5,U.S. Senate,,I,Greg Orman,123
-Shawnee,Ward 15 Precinct 1,U.S. Senate,,I,Greg Orman,222
-Shawnee,Ward 15 Precinct 2,U.S. Senate,,I,Greg Orman,172
-Shawnee,Ward 15 Precinct 3,U.S. Senate,,I,Greg Orman,15
-Shawnee,Ward 1 Precinct 1,U.S. Senate,,L,Randall Batson,16
-Shawnee,Ward 1 Precinct 2,U.S. Senate,,L,Randall Batson,14
-Shawnee,Ward 1 Precinct 3,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 1 Precinct 4,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 1 Precinct 5,U.S. Senate,,L,Randall Batson,18
-Shawnee,Ward 1 Precinct 6,U.S. Senate,,L,Randall Batson,16
-Shawnee,Ward 2 Precinct 1,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 2 Precinct 2,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 2 Precinct 3,U.S. Senate,,L,Randall Batson,12
-Shawnee,Ward 2 Precinct 4,U.S. Senate,,L,Randall Batson,18
-Shawnee,Ward 2 Precinct 5,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 2 Precinct 6,U.S. Senate,,L,Randall Batson,9
-Shawnee,Ward 2 Precinct 7,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 2 Precinct 8,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 2 Precinct 9,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 2 Precinct 10,U.S. Senate,,L,Randall Batson,18
-Shawnee,Ward 2 Precinct 11,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 3 Precinct 1,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 3 Precinct 2,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 3 Precinct 3,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 3 Precinct 4,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 3 Precinct 5,U.S. Senate,,L,Randall Batson,7
-Shawnee,Ward 3 Precinct 6,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 3 Precinct 7,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 3 Precinct 8,U.S. Senate,,L,Randall Batson,11
-Shawnee,Ward 3 Precinct 9,U.S. Senate,,L,Randall Batson,12
-Shawnee,Ward 3 Precinct 10,U.S. Senate,,L,Randall Batson,1
-Shawnee,Ward 4 Precinct 1,U.S. Senate,,L,Randall Batson,20
-Shawnee,Ward 4 Precinct 2,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 4 Precinct 3,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 4 Precinct 4,U.S. Senate,,L,Randall Batson,17
-Shawnee,Ward 4 Precinct 6,U.S. Senate,,L,Randall Batson,9
-Shawnee,Ward 4 Precinct 7,U.S. Senate,,L,Randall Batson,7
-Shawnee,Ward 4 Precinct 8,U.S. Senate,,L,Randall Batson,14
-Shawnee,Ward 4 Precinct 9,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 4 Precinct 10,U.S. Senate,,L,Randall Batson,17
-Shawnee,Ward 4 Precinct 11,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 4 Precinct 12,U.S. Senate,,L,Randall Batson,1
-Shawnee,Ward 4 Precinct 15,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 5 Precinct 1,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 5 Precinct 2,U.S. Senate,,L,Randall Batson,22
-Shawnee,Ward 5 Precinct 3,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 5 Precinct 4,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 5 Precinct 5,U.S. Senate,,L,Randall Batson,11
-Shawnee,Ward 5 Precinct 6,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 5 Precinct 7,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 5 Precinct 8,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 5 Precinct 9,U.S. Senate,,L,Randall Batson,9
-Shawnee,Ward 5 Precinct 10,U.S. Senate,,L,Randall Batson,19
-Shawnee,Ward 5 Precinct 11,U.S. Senate,,L,Randall Batson,14
-Shawnee,Ward 5 Precinct 14,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 5 Precinct 15,U.S. Senate,,L,Randall Batson,1
-Shawnee,Ward 5 Precinct 91,U.S. Senate,,L,Randall Batson,3
-Shawnee,Ward 6 Precinct 1,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 6 Precinct 2,U.S. Senate,,L,Randall Batson,18
-Shawnee,Ward 6 Precinct 3,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 6 Precinct 4,U.S. Senate,,L,Randall Batson,7
-Shawnee,Ward 6 Precinct 5,U.S. Senate,,L,Randall Batson,14
-Shawnee,Ward 6 Precinct 6,U.S. Senate,,L,Randall Batson,9
-Shawnee,Ward 6 Precinct 7,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 6 Precinct 8,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 6 Precinct 9,U.S. Senate,,L,Randall Batson,29
-Shawnee,Ward 7 Precinct 1,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 7 Precinct 2,U.S. Senate,,L,Randall Batson,14
-Shawnee,Ward 7 Precinct 3,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 7 Precinct 4,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 7 Precinct 5,U.S. Senate,,L,Randall Batson,17
-Shawnee,Ward 7 Precinct 6,U.S. Senate,,L,Randall Batson,14
-Shawnee,Ward 7 Precinct 7,U.S. Senate,,L,Randall Batson,7
-Shawnee,Ward 7 Precinct 9,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 7 Precinct 10,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 7 Precinct 11,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 8 Precinct 1,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 8 Precinct 2,U.S. Senate,,L,Randall Batson,12
-Shawnee,Ward 8 Precinct 3,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 8 Precinct 4,U.S. Senate,,L,Randall Batson,11
-Shawnee,Ward 8 Precinct 5,U.S. Senate,,L,Randall Batson,18
-Shawnee,Ward 8 Precinct 6,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 8 Precinct 7,U.S. Senate,,L,Randall Batson,7
-Shawnee,Ward 8 Precinct 8,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 8 Precinct 9,U.S. Senate,,L,Randall Batson,15
-Shawnee,Ward 8 Precinct 10,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 8 Precinct 11,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 9 Precinct 1,U.S. Senate,,L,Randall Batson,2
-Shawnee,Ward 9 Precinct 2,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 9 Precinct 3,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 9 Precinct 4,U.S. Senate,,L,Randall Batson,9
-Shawnee,Ward 9 Precinct 5,U.S. Senate,,L,Randall Batson,11
-Shawnee,Ward 9 Precinct 6,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 9 Precinct 8,U.S. Senate,,L,Randall Batson,20
-Shawnee,Ward 9 Precinct 9,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 9 Precinct 10,U.S. Senate,,L,Randall Batson,21
-Shawnee,Ward 9 Precinct 11,U.S. Senate,,L,Randall Batson,3
-Shawnee,Ward 9 Precinct 12,U.S. Senate,,L,Randall Batson,4
-Shawnee,Ward 10 Precinct 1,U.S. Senate,,L,Randall Batson,15
-Shawnee,Ward 10 Precinct 2,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 10 Precinct 3,U.S. Senate,,L,Randall Batson,21
-Shawnee,Ward 10 Precinct 4,U.S. Senate,,L,Randall Batson,12
-Shawnee,Ward 10 Precinct 5,U.S. Senate,,L,Randall Batson,14
-Shawnee,Ward 10 Precinct 6,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 10 Precinct 7,U.S. Senate,,L,Randall Batson,17
-Shawnee,Ward 10 Precinct 8,U.S. Senate,,L,Randall Batson,12
-Shawnee,Ward 10 Precinct 9,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 10 Precinct 10,U.S. Senate,,L,Randall Batson,9
-Shawnee,Ward 10 Precinct 11,U.S. Senate,,L,Randall Batson,28
-Shawnee,Ward 10 Precinct 14,U.S. Senate,,L,Randall Batson,7
-Shawnee,Ward 11 Precinct 1,U.S. Senate,,L,Randall Batson,9
-Shawnee,Ward 11 Precinct 2,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 11 Precinct 3,U.S. Senate,,L,Randall Batson,12
-Shawnee,Ward 11 Precinct 4,U.S. Senate,,L,Randall Batson,19
-Shawnee,Ward 11 Precinct 5,U.S. Senate,,L,Randall Batson,15
-Shawnee,Ward 11 Precinct 6,U.S. Senate,,L,Randall Batson,17
-Shawnee,Ward 11 Precinct 7,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 11 Precinct 8,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 11 Precinct 9,U.S. Senate,,L,Randall Batson,16
-Shawnee,Ward 11 Precinct 10,U.S. Senate,,L,Randall Batson,11
-Shawnee,Ward 12 Precinct 1,U.S. Senate,,L,Randall Batson,16
-Shawnee,Ward 12 Precinct 2,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 12 Precinct 3,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 12 Precinct 4,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 12 Precinct 5,U.S. Senate,,L,Randall Batson,9
-Shawnee,Ward 12 Precinct 6,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 12 Precinct 7,U.S. Senate,,L,Randall Batson,23
-Shawnee,Ward 12 Precinct 8,U.S. Senate,,L,Randall Batson,19
-Shawnee,Ward 12 Precinct 9,U.S. Senate,,L,Randall Batson,31
-Shawnee,Ward 12 Precinct 11,U.S. Senate,,L,Randall Batson,17
-Shawnee,Ward 12 Precinct 13,U.S. Senate,,L,Randall Batson,10
-Shawnee,Ward 12 Precinct 14,U.S. Senate,,L,Randall Batson,7
-Shawnee,Ward 12 Precinct 15,U.S. Senate,,L,Randall Batson,21
-Shawnee,Ward 12 Precinct 16,U.S. Senate,,L,Randall Batson,17
-Shawnee,Ward 12 Precinct 19,U.S. Senate,,L,Randall Batson,1
-Shawnee,Ward 12 Precinct 20,U.S. Senate,,L,Randall Batson,17
-Shawnee,Ward 12 Precinct 31,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 13 Precinct 2,U.S. Senate,,L,Randall Batson,3
-Shawnee,Ward 13 Precinct 5,U.S. Senate,,L,Randall Batson,0
-Shawnee,Ward 13 Precinct 6,U.S. Senate,,L,Randall Batson,3
-Shawnee,Ward 13 Precinct 9,U.S. Senate,,L,Randall Batson,5
-Shawnee,Ward 13 Precinct 12,U.S. Senate,,L,Randall Batson,8
-Shawnee,Ward 13 Precinct 21,U.S. Senate,,L,Randall Batson,1
-Shawnee,Ward 13 Precinct 22,U.S. Senate,,L,Randall Batson,1
-Shawnee,Ward 13 Precinct 30,U.S. Senate,,L,Randall Batson,3
-Shawnee,Ward 14 Precinct 1,U.S. Senate,,L,Randall Batson,22
-Shawnee,Ward 14 Precinct 2,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 14 Precinct 3,U.S. Senate,,L,Randall Batson,6
-Shawnee,Ward 14 Precinct 4,U.S. Senate,,L,Randall Batson,13
-Shawnee,Ward 14 Precinct 5,U.S. Senate,,L,Randall Batson,4
-Shawnee,Ward 15 Precinct 1,U.S. Senate,,L,Randall Batson,23
-Shawnee,Ward 15 Precinct 2,U.S. Senate,,L,Randall Batson,14
-Shawnee,Ward 15 Precinct 3,U.S. Senate,,L,Randall Batson,0
-Shawnee,Ward 1 Precinct 1,U.S. House,2,R,Lynn Jenkins,60
-Shawnee,Ward 1 Precinct 2,U.S. House,2,R,Lynn Jenkins,82
-Shawnee,Ward 1 Precinct 3,U.S. House,2,R,Lynn Jenkins,76
-Shawnee,Ward 1 Precinct 4,U.S. House,2,R,Lynn Jenkins,106
-Shawnee,Ward 1 Precinct 5,U.S. House,2,R,Lynn Jenkins,184
-Shawnee,Ward 1 Precinct 6,U.S. House,2,R,Lynn Jenkins,255
-Shawnee,Ward 2 Precinct 1,U.S. House,2,R,Lynn Jenkins,102
-Shawnee,Ward 2 Precinct 2,U.S. House,2,R,Lynn Jenkins,86
-Shawnee,Ward 2 Precinct 3,U.S. House,2,R,Lynn Jenkins,94
-Shawnee,Ward 2 Precinct 4,U.S. House,2,R,Lynn Jenkins,73
-Shawnee,Ward 2 Precinct 5,U.S. House,2,R,Lynn Jenkins,60
-Shawnee,Ward 2 Precinct 6,U.S. House,2,R,Lynn Jenkins,49
-Shawnee,Ward 2 Precinct 7,U.S. House,2,R,Lynn Jenkins,32
-Shawnee,Ward 2 Precinct 8,U.S. House,2,R,Lynn Jenkins,20
-Shawnee,Ward 2 Precinct 9,U.S. House,2,R,Lynn Jenkins,97
-Shawnee,Ward 2 Precinct 10,U.S. House,2,R,Lynn Jenkins,76
-Shawnee,Ward 2 Precinct 11,U.S. House,2,R,Lynn Jenkins,51
-Shawnee,Ward 3 Precinct 1,U.S. House,2,R,Lynn Jenkins,96
-Shawnee,Ward 3 Precinct 2,U.S. House,2,R,Lynn Jenkins,96
-Shawnee,Ward 3 Precinct 3,U.S. House,2,R,Lynn Jenkins,51
-Shawnee,Ward 3 Precinct 4,U.S. House,2,R,Lynn Jenkins,62
-Shawnee,Ward 3 Precinct 5,U.S. House,2,R,Lynn Jenkins,36
-Shawnee,Ward 3 Precinct 6,U.S. House,2,R,Lynn Jenkins,49
-Shawnee,Ward 3 Precinct 7,U.S. House,2,R,Lynn Jenkins,58
-Shawnee,Ward 3 Precinct 8,U.S. House,2,R,Lynn Jenkins,75
-Shawnee,Ward 3 Precinct 9,U.S. House,2,R,Lynn Jenkins,73
-Shawnee,Ward 3 Precinct 10,U.S. House,2,R,Lynn Jenkins,4
-Shawnee,Ward 4 Precinct 1,U.S. House,2,R,Lynn Jenkins,47
-Shawnee,Ward 4 Precinct 2,U.S. House,2,R,Lynn Jenkins,44
-Shawnee,Ward 4 Precinct 3,U.S. House,2,R,Lynn Jenkins,28
-Shawnee,Ward 4 Precinct 4,U.S. House,2,R,Lynn Jenkins,49
-Shawnee,Ward 4 Precinct 6,U.S. House,2,R,Lynn Jenkins,70
-Shawnee,Ward 4 Precinct 7,U.S. House,2,R,Lynn Jenkins,43
-Shawnee,Ward 4 Precinct 8,U.S. House,2,R,Lynn Jenkins,59
-Shawnee,Ward 4 Precinct 9,U.S. House,2,R,Lynn Jenkins,60
-Shawnee,Ward 4 Precinct 10,U.S. House,2,R,Lynn Jenkins,78
-Shawnee,Ward 4 Precinct 11,U.S. House,2,R,Lynn Jenkins,47
-Shawnee,Ward 4 Precinct 12,U.S. House,2,R,Lynn Jenkins,1
-Shawnee,Ward 4 Precinct 15,U.S. House,2,R,Lynn Jenkins,60
-Shawnee,Ward 5 Precinct 1,U.S. House,2,R,Lynn Jenkins,49
-Shawnee,Ward 5 Precinct 2,U.S. House,2,R,Lynn Jenkins,62
-Shawnee,Ward 5 Precinct 3,U.S. House,2,R,Lynn Jenkins,92
-Shawnee,Ward 5 Precinct 4,U.S. House,2,R,Lynn Jenkins,67
-Shawnee,Ward 5 Precinct 5,U.S. House,2,R,Lynn Jenkins,68
-Shawnee,Ward 5 Precinct 6,U.S. House,2,R,Lynn Jenkins,45
-Shawnee,Ward 5 Precinct 7,U.S. House,2,R,Lynn Jenkins,56
-Shawnee,Ward 5 Precinct 8,U.S. House,2,R,Lynn Jenkins,71
-Shawnee,Ward 5 Precinct 9,U.S. House,2,R,Lynn Jenkins,162
-Shawnee,Ward 5 Precinct 10,U.S. House,2,R,Lynn Jenkins,232
-Shawnee,Ward 5 Precinct 11,U.S. House,2,R,Lynn Jenkins,160
-Shawnee,Ward 5 Precinct 14,U.S. House,2,R,Lynn Jenkins,130
-Shawnee,Ward 5 Precinct 15,U.S. House,2,R,Lynn Jenkins,32
-Shawnee,Ward 5 Precinct 91,U.S. House,2,R,Lynn Jenkins,46
-Shawnee,Ward 6 Precinct 1,U.S. House,2,R,Lynn Jenkins,47
-Shawnee,Ward 6 Precinct 2,U.S. House,2,R,Lynn Jenkins,49
-Shawnee,Ward 6 Precinct 3,U.S. House,2,R,Lynn Jenkins,202
-Shawnee,Ward 6 Precinct 4,U.S. House,2,R,Lynn Jenkins,91
-Shawnee,Ward 6 Precinct 5,U.S. House,2,R,Lynn Jenkins,147
-Shawnee,Ward 6 Precinct 6,U.S. House,2,R,Lynn Jenkins,68
-Shawnee,Ward 6 Precinct 7,U.S. House,2,R,Lynn Jenkins,60
-Shawnee,Ward 6 Precinct 8,U.S. House,2,R,Lynn Jenkins,86
-Shawnee,Ward 6 Precinct 9,U.S. House,2,R,Lynn Jenkins,298
-Shawnee,Ward 7 Precinct 1,U.S. House,2,R,Lynn Jenkins,101
-Shawnee,Ward 7 Precinct 2,U.S. House,2,R,Lynn Jenkins,81
-Shawnee,Ward 7 Precinct 3,U.S. House,2,R,Lynn Jenkins,96
-Shawnee,Ward 7 Precinct 4,U.S. House,2,R,Lynn Jenkins,147
-Shawnee,Ward 7 Precinct 5,U.S. House,2,R,Lynn Jenkins,114
-Shawnee,Ward 7 Precinct 6,U.S. House,2,R,Lynn Jenkins,102
-Shawnee,Ward 7 Precinct 7,U.S. House,2,R,Lynn Jenkins,77
-Shawnee,Ward 7 Precinct 9,U.S. House,2,R,Lynn Jenkins,104
-Shawnee,Ward 7 Precinct 10,U.S. House,2,R,Lynn Jenkins,77
-Shawnee,Ward 7 Precinct 11,U.S. House,2,R,Lynn Jenkins,146
-Shawnee,Ward 8 Precinct 1,U.S. House,2,R,Lynn Jenkins,59
-Shawnee,Ward 8 Precinct 2,U.S. House,2,R,Lynn Jenkins,70
-Shawnee,Ward 8 Precinct 3,U.S. House,2,R,Lynn Jenkins,113
-Shawnee,Ward 8 Precinct 4,U.S. House,2,R,Lynn Jenkins,120
-Shawnee,Ward 8 Precinct 5,U.S. House,2,R,Lynn Jenkins,204
-Shawnee,Ward 8 Precinct 6,U.S. House,2,R,Lynn Jenkins,136
-Shawnee,Ward 8 Precinct 7,U.S. House,2,R,Lynn Jenkins,61
-Shawnee,Ward 8 Precinct 8,U.S. House,2,R,Lynn Jenkins,91
-Shawnee,Ward 8 Precinct 9,U.S. House,2,R,Lynn Jenkins,168
-Shawnee,Ward 8 Precinct 10,U.S. House,2,R,Lynn Jenkins,157
-Shawnee,Ward 8 Precinct 11,U.S. House,2,R,Lynn Jenkins,168
-Shawnee,Ward 9 Precinct 1,U.S. House,2,R,Lynn Jenkins,26
-Shawnee,Ward 9 Precinct 2,U.S. House,2,R,Lynn Jenkins,90
-Shawnee,Ward 9 Precinct 3,U.S. House,2,R,Lynn Jenkins,197
-Shawnee,Ward 9 Precinct 4,U.S. House,2,R,Lynn Jenkins,147
-Shawnee,Ward 9 Precinct 5,U.S. House,2,R,Lynn Jenkins,112
-Shawnee,Ward 9 Precinct 6,U.S. House,2,R,Lynn Jenkins,135
-Shawnee,Ward 9 Precinct 8,U.S. House,2,R,Lynn Jenkins,167
-Shawnee,Ward 9 Precinct 9,U.S. House,2,R,Lynn Jenkins,129
-Shawnee,Ward 9 Precinct 10,U.S. House,2,R,Lynn Jenkins,214
-Shawnee,Ward 9 Precinct 11,U.S. House,2,R,Lynn Jenkins,134
-Shawnee,Ward 9 Precinct 12,U.S. House,2,R,Lynn Jenkins,52
-Shawnee,Ward 10 Precinct 1,U.S. House,2,R,Lynn Jenkins,122
-Shawnee,Ward 10 Precinct 2,U.S. House,2,R,Lynn Jenkins,206
-Shawnee,Ward 10 Precinct 3,U.S. House,2,R,Lynn Jenkins,247
-Shawnee,Ward 10 Precinct 4,U.S. House,2,R,Lynn Jenkins,144
-Shawnee,Ward 10 Precinct 5,U.S. House,2,R,Lynn Jenkins,120
-Shawnee,Ward 10 Precinct 6,U.S. House,2,R,Lynn Jenkins,149
-Shawnee,Ward 10 Precinct 7,U.S. House,2,R,Lynn Jenkins,135
-Shawnee,Ward 10 Precinct 8,U.S. House,2,R,Lynn Jenkins,110
-Shawnee,Ward 10 Precinct 9,U.S. House,2,R,Lynn Jenkins,87
-Shawnee,Ward 10 Precinct 10,U.S. House,2,R,Lynn Jenkins,134
-Shawnee,Ward 10 Precinct 11,U.S. House,2,R,Lynn Jenkins,200
-Shawnee,Ward 10 Precinct 14,U.S. House,2,R,Lynn Jenkins,155
-Shawnee,Ward 11 Precinct 1,U.S. House,2,R,Lynn Jenkins,105
-Shawnee,Ward 11 Precinct 2,U.S. House,2,R,Lynn Jenkins,139
-Shawnee,Ward 11 Precinct 3,U.S. House,2,R,Lynn Jenkins,94
-Shawnee,Ward 11 Precinct 4,U.S. House,2,R,Lynn Jenkins,194
-Shawnee,Ward 11 Precinct 5,U.S. House,2,R,Lynn Jenkins,135
-Shawnee,Ward 11 Precinct 6,U.S. House,2,R,Lynn Jenkins,130
-Shawnee,Ward 11 Precinct 7,U.S. House,2,R,Lynn Jenkins,141
-Shawnee,Ward 11 Precinct 8,U.S. House,2,R,Lynn Jenkins,131
-Shawnee,Ward 11 Precinct 9,U.S. House,2,R,Lynn Jenkins,137
-Shawnee,Ward 11 Precinct 10,U.S. House,2,R,Lynn Jenkins,87
-Shawnee,Ward 12 Precinct 1,U.S. House,2,R,Lynn Jenkins,111
-Shawnee,Ward 12 Precinct 2,U.S. House,2,R,Lynn Jenkins,93
-Shawnee,Ward 12 Precinct 3,U.S. House,2,R,Lynn Jenkins,192
-Shawnee,Ward 12 Precinct 4,U.S. House,2,R,Lynn Jenkins,235
-Shawnee,Ward 12 Precinct 5,U.S. House,2,R,Lynn Jenkins,211
-Shawnee,Ward 12 Precinct 6,U.S. House,2,R,Lynn Jenkins,191
-Shawnee,Ward 12 Precinct 7,U.S. House,2,R,Lynn Jenkins,196
-Shawnee,Ward 12 Precinct 8,U.S. House,2,R,Lynn Jenkins,176
-Shawnee,Ward 12 Precinct 9,U.S. House,2,R,Lynn Jenkins,300
-Shawnee,Ward 12 Precinct 11,U.S. House,2,R,Lynn Jenkins,356
-Shawnee,Ward 12 Precinct 13,U.S. House,2,R,Lynn Jenkins,266
-Shawnee,Ward 12 Precinct 14,U.S. House,2,R,Lynn Jenkins,174
-Shawnee,Ward 12 Precinct 15,U.S. House,2,R,Lynn Jenkins,312
-Shawnee,Ward 12 Precinct 16,U.S. House,2,R,Lynn Jenkins,292
-Shawnee,Ward 12 Precinct 19,U.S. House,2,R,Lynn Jenkins,51
-Shawnee,Ward 12 Precinct 20,U.S. House,2,R,Lynn Jenkins,230
-Shawnee,Ward 12 Precinct 31,U.S. House,2,R,Lynn Jenkins,153
-Shawnee,Ward 13 Precinct 2,U.S. House,2,R,Lynn Jenkins,48
-Shawnee,Ward 13 Precinct 5,U.S. House,2,R,Lynn Jenkins,10
-Shawnee,Ward 13 Precinct 6,U.S. House,2,R,Lynn Jenkins,82
-Shawnee,Ward 13 Precinct 9,U.S. House,2,R,Lynn Jenkins,56
-Shawnee,Ward 13 Precinct 12,U.S. House,2,R,Lynn Jenkins,336
-Shawnee,Ward 13 Precinct 21,U.S. House,2,R,Lynn Jenkins,29
-Shawnee,Ward 13 Precinct 22,U.S. House,2,R,Lynn Jenkins,40
-Shawnee,Ward 13 Precinct 30,U.S. House,2,R,Lynn Jenkins,59
-Shawnee,Ward 14 Precinct 1,U.S. House,2,R,Lynn Jenkins,284
-Shawnee,Ward 14 Precinct 2,U.S. House,2,R,Lynn Jenkins,236
-Shawnee,Ward 14 Precinct 3,U.S. House,2,R,Lynn Jenkins,184
-Shawnee,Ward 14 Precinct 4,U.S. House,2,R,Lynn Jenkins,393
-Shawnee,Ward 14 Precinct 5,U.S. House,2,R,Lynn Jenkins,250
-Shawnee,Ward 15 Precinct 1,U.S. House,2,R,Lynn Jenkins,214
-Shawnee,Ward 15 Precinct 2,U.S. House,2,R,Lynn Jenkins,139
-Shawnee,Ward 15 Precinct 3,U.S. House,2,R,Lynn Jenkins,15
-Shawnee,Ward 1 Precinct 1,U.S. House,2,D,Margie Wakefield,96
-Shawnee,Ward 1 Precinct 2,U.S. House,2,D,Margie Wakefield,117
-Shawnee,Ward 1 Precinct 3,U.S. House,2,D,Margie Wakefield,82
-Shawnee,Ward 1 Precinct 4,U.S. House,2,D,Margie Wakefield,126
-Shawnee,Ward 1 Precinct 5,U.S. House,2,D,Margie Wakefield,154
-Shawnee,Ward 1 Precinct 6,U.S. House,2,D,Margie Wakefield,187
-Shawnee,Ward 2 Precinct 1,U.S. House,2,D,Margie Wakefield,130
-Shawnee,Ward 2 Precinct 2,U.S. House,2,D,Margie Wakefield,113
-Shawnee,Ward 2 Precinct 3,U.S. House,2,D,Margie Wakefield,112
-Shawnee,Ward 2 Precinct 4,U.S. House,2,D,Margie Wakefield,112
-Shawnee,Ward 2 Precinct 5,U.S. House,2,D,Margie Wakefield,130
-Shawnee,Ward 2 Precinct 6,U.S. House,2,D,Margie Wakefield,87
-Shawnee,Ward 2 Precinct 7,U.S. House,2,D,Margie Wakefield,53
-Shawnee,Ward 2 Precinct 8,U.S. House,2,D,Margie Wakefield,75
-Shawnee,Ward 2 Precinct 9,U.S. House,2,D,Margie Wakefield,135
-Shawnee,Ward 2 Precinct 10,U.S. House,2,D,Margie Wakefield,187
-Shawnee,Ward 2 Precinct 11,U.S. House,2,D,Margie Wakefield,86
-Shawnee,Ward 3 Precinct 1,U.S. House,2,D,Margie Wakefield,114
-Shawnee,Ward 3 Precinct 2,U.S. House,2,D,Margie Wakefield,144
-Shawnee,Ward 3 Precinct 3,U.S. House,2,D,Margie Wakefield,87
-Shawnee,Ward 3 Precinct 4,U.S. House,2,D,Margie Wakefield,103
-Shawnee,Ward 3 Precinct 5,U.S. House,2,D,Margie Wakefield,73
-Shawnee,Ward 3 Precinct 6,U.S. House,2,D,Margie Wakefield,86
-Shawnee,Ward 3 Precinct 7,U.S. House,2,D,Margie Wakefield,92
-Shawnee,Ward 3 Precinct 8,U.S. House,2,D,Margie Wakefield,114
-Shawnee,Ward 3 Precinct 9,U.S. House,2,D,Margie Wakefield,109
-Shawnee,Ward 3 Precinct 10,U.S. House,2,D,Margie Wakefield,8
-Shawnee,Ward 4 Precinct 1,U.S. House,2,D,Margie Wakefield,114
-Shawnee,Ward 4 Precinct 2,U.S. House,2,D,Margie Wakefield,124
-Shawnee,Ward 4 Precinct 3,U.S. House,2,D,Margie Wakefield,93
-Shawnee,Ward 4 Precinct 4,U.S. House,2,D,Margie Wakefield,160
-Shawnee,Ward 4 Precinct 6,U.S. House,2,D,Margie Wakefield,138
-Shawnee,Ward 4 Precinct 7,U.S. House,2,D,Margie Wakefield,74
-Shawnee,Ward 4 Precinct 8,U.S. House,2,D,Margie Wakefield,104
-Shawnee,Ward 4 Precinct 9,U.S. House,2,D,Margie Wakefield,136
-Shawnee,Ward 4 Precinct 10,U.S. House,2,D,Margie Wakefield,165
-Shawnee,Ward 4 Precinct 11,U.S. House,2,D,Margie Wakefield,47
-Shawnee,Ward 4 Precinct 12,U.S. House,2,D,Margie Wakefield,15
-Shawnee,Ward 4 Precinct 15,U.S. House,2,D,Margie Wakefield,73
-Shawnee,Ward 5 Precinct 1,U.S. House,2,D,Margie Wakefield,110
-Shawnee,Ward 5 Precinct 2,U.S. House,2,D,Margie Wakefield,100
-Shawnee,Ward 5 Precinct 3,U.S. House,2,D,Margie Wakefield,92
-Shawnee,Ward 5 Precinct 4,U.S. House,2,D,Margie Wakefield,135
-Shawnee,Ward 5 Precinct 5,U.S. House,2,D,Margie Wakefield,131
-Shawnee,Ward 5 Precinct 6,U.S. House,2,D,Margie Wakefield,94
-Shawnee,Ward 5 Precinct 7,U.S. House,2,D,Margie Wakefield,145
-Shawnee,Ward 5 Precinct 8,U.S. House,2,D,Margie Wakefield,90
-Shawnee,Ward 5 Precinct 9,U.S. House,2,D,Margie Wakefield,180
-Shawnee,Ward 5 Precinct 10,U.S. House,2,D,Margie Wakefield,196
-Shawnee,Ward 5 Precinct 11,U.S. House,2,D,Margie Wakefield,158
-Shawnee,Ward 5 Precinct 14,U.S. House,2,D,Margie Wakefield,80
-Shawnee,Ward 5 Precinct 15,U.S. House,2,D,Margie Wakefield,19
-Shawnee,Ward 5 Precinct 91,U.S. House,2,D,Margie Wakefield,43
-Shawnee,Ward 6 Precinct 1,U.S. House,2,D,Margie Wakefield,102
-Shawnee,Ward 6 Precinct 2,U.S. House,2,D,Margie Wakefield,102
-Shawnee,Ward 6 Precinct 3,U.S. House,2,D,Margie Wakefield,159
-Shawnee,Ward 6 Precinct 4,U.S. House,2,D,Margie Wakefield,114
-Shawnee,Ward 6 Precinct 5,U.S. House,2,D,Margie Wakefield,167
-Shawnee,Ward 6 Precinct 6,U.S. House,2,D,Margie Wakefield,75
-Shawnee,Ward 6 Precinct 7,U.S. House,2,D,Margie Wakefield,58
-Shawnee,Ward 6 Precinct 8,U.S. House,2,D,Margie Wakefield,150
-Shawnee,Ward 6 Precinct 9,U.S. House,2,D,Margie Wakefield,272
-Shawnee,Ward 7 Precinct 1,U.S. House,2,D,Margie Wakefield,187
-Shawnee,Ward 7 Precinct 2,U.S. House,2,D,Margie Wakefield,156
-Shawnee,Ward 7 Precinct 3,U.S. House,2,D,Margie Wakefield,149
-Shawnee,Ward 7 Precinct 4,U.S. House,2,D,Margie Wakefield,146
-Shawnee,Ward 7 Precinct 5,U.S. House,2,D,Margie Wakefield,115
-Shawnee,Ward 7 Precinct 6,U.S. House,2,D,Margie Wakefield,97
-Shawnee,Ward 7 Precinct 7,U.S. House,2,D,Margie Wakefield,112
-Shawnee,Ward 7 Precinct 9,U.S. House,2,D,Margie Wakefield,102
-Shawnee,Ward 7 Precinct 10,U.S. House,2,D,Margie Wakefield,136
-Shawnee,Ward 7 Precinct 11,U.S. House,2,D,Margie Wakefield,195
-Shawnee,Ward 8 Precinct 1,U.S. House,2,D,Margie Wakefield,124
-Shawnee,Ward 8 Precinct 2,U.S. House,2,D,Margie Wakefield,163
-Shawnee,Ward 8 Precinct 3,U.S. House,2,D,Margie Wakefield,221
-Shawnee,Ward 8 Precinct 4,U.S. House,2,D,Margie Wakefield,186
-Shawnee,Ward 8 Precinct 5,U.S. House,2,D,Margie Wakefield,231
-Shawnee,Ward 8 Precinct 6,U.S. House,2,D,Margie Wakefield,120
-Shawnee,Ward 8 Precinct 7,U.S. House,2,D,Margie Wakefield,144
-Shawnee,Ward 8 Precinct 8,U.S. House,2,D,Margie Wakefield,154
-Shawnee,Ward 8 Precinct 9,U.S. House,2,D,Margie Wakefield,174
-Shawnee,Ward 8 Precinct 10,U.S. House,2,D,Margie Wakefield,110
-Shawnee,Ward 8 Precinct 11,U.S. House,2,D,Margie Wakefield,169
-Shawnee,Ward 9 Precinct 1,U.S. House,2,D,Margie Wakefield,30
-Shawnee,Ward 9 Precinct 2,U.S. House,2,D,Margie Wakefield,106
-Shawnee,Ward 9 Precinct 3,U.S. House,2,D,Margie Wakefield,208
-Shawnee,Ward 9 Precinct 4,U.S. House,2,D,Margie Wakefield,194
-Shawnee,Ward 9 Precinct 5,U.S. House,2,D,Margie Wakefield,136
-Shawnee,Ward 9 Precinct 6,U.S. House,2,D,Margie Wakefield,160
-Shawnee,Ward 9 Precinct 8,U.S. House,2,D,Margie Wakefield,179
-Shawnee,Ward 9 Precinct 9,U.S. House,2,D,Margie Wakefield,138
-Shawnee,Ward 9 Precinct 10,U.S. House,2,D,Margie Wakefield,267
-Shawnee,Ward 9 Precinct 11,U.S. House,2,D,Margie Wakefield,154
-Shawnee,Ward 9 Precinct 12,U.S. House,2,D,Margie Wakefield,81
-Shawnee,Ward 10 Precinct 1,U.S. House,2,D,Margie Wakefield,189
-Shawnee,Ward 10 Precinct 2,U.S. House,2,D,Margie Wakefield,137
-Shawnee,Ward 10 Precinct 3,U.S. House,2,D,Margie Wakefield,226
-Shawnee,Ward 10 Precinct 4,U.S. House,2,D,Margie Wakefield,138
-Shawnee,Ward 10 Precinct 5,U.S. House,2,D,Margie Wakefield,134
-Shawnee,Ward 10 Precinct 6,U.S. House,2,D,Margie Wakefield,119
-Shawnee,Ward 10 Precinct 7,U.S. House,2,D,Margie Wakefield,147
-Shawnee,Ward 10 Precinct 8,U.S. House,2,D,Margie Wakefield,127
-Shawnee,Ward 10 Precinct 9,U.S. House,2,D,Margie Wakefield,113
-Shawnee,Ward 10 Precinct 10,U.S. House,2,D,Margie Wakefield,147
-Shawnee,Ward 10 Precinct 11,U.S. House,2,D,Margie Wakefield,192
-Shawnee,Ward 10 Precinct 14,U.S. House,2,D,Margie Wakefield,140
-Shawnee,Ward 11 Precinct 1,U.S. House,2,D,Margie Wakefield,93
-Shawnee,Ward 11 Precinct 2,U.S. House,2,D,Margie Wakefield,144
-Shawnee,Ward 11 Precinct 3,U.S. House,2,D,Margie Wakefield,115
-Shawnee,Ward 11 Precinct 4,U.S. House,2,D,Margie Wakefield,200
-Shawnee,Ward 11 Precinct 5,U.S. House,2,D,Margie Wakefield,134
-Shawnee,Ward 11 Precinct 6,U.S. House,2,D,Margie Wakefield,139
-Shawnee,Ward 11 Precinct 7,U.S. House,2,D,Margie Wakefield,120
-Shawnee,Ward 11 Precinct 8,U.S. House,2,D,Margie Wakefield,120
-Shawnee,Ward 11 Precinct 9,U.S. House,2,D,Margie Wakefield,142
-Shawnee,Ward 11 Precinct 10,U.S. House,2,D,Margie Wakefield,106
-Shawnee,Ward 12 Precinct 1,U.S. House,2,D,Margie Wakefield,153
-Shawnee,Ward 12 Precinct 2,U.S. House,2,D,Margie Wakefield,100
-Shawnee,Ward 12 Precinct 3,U.S. House,2,D,Margie Wakefield,132
-Shawnee,Ward 12 Precinct 4,U.S. House,2,D,Margie Wakefield,177
-Shawnee,Ward 12 Precinct 5,U.S. House,2,D,Margie Wakefield,178
-Shawnee,Ward 12 Precinct 6,U.S. House,2,D,Margie Wakefield,221
-Shawnee,Ward 12 Precinct 7,U.S. House,2,D,Margie Wakefield,179
-Shawnee,Ward 12 Precinct 8,U.S. House,2,D,Margie Wakefield,197
-Shawnee,Ward 12 Precinct 9,U.S. House,2,D,Margie Wakefield,270
-Shawnee,Ward 12 Precinct 11,U.S. House,2,D,Margie Wakefield,240
-Shawnee,Ward 12 Precinct 13,U.S. House,2,D,Margie Wakefield,154
-Shawnee,Ward 12 Precinct 14,U.S. House,2,D,Margie Wakefield,138
-Shawnee,Ward 12 Precinct 15,U.S. House,2,D,Margie Wakefield,226
-Shawnee,Ward 12 Precinct 16,U.S. House,2,D,Margie Wakefield,276
-Shawnee,Ward 12 Precinct 19,U.S. House,2,D,Margie Wakefield,22
-Shawnee,Ward 12 Precinct 20,U.S. House,2,D,Margie Wakefield,182
-Shawnee,Ward 12 Precinct 31,U.S. House,2,D,Margie Wakefield,111
-Shawnee,Ward 13 Precinct 2,U.S. House,2,D,Margie Wakefield,53
-Shawnee,Ward 13 Precinct 5,U.S. House,2,D,Margie Wakefield,3
-Shawnee,Ward 13 Precinct 6,U.S. House,2,D,Margie Wakefield,27
-Shawnee,Ward 13 Precinct 9,U.S. House,2,D,Margie Wakefield,32
-Shawnee,Ward 13 Precinct 12,U.S. House,2,D,Margie Wakefield,182
-Shawnee,Ward 13 Precinct 21,U.S. House,2,D,Margie Wakefield,36
-Shawnee,Ward 13 Precinct 22,U.S. House,2,D,Margie Wakefield,23
-Shawnee,Ward 13 Precinct 30,U.S. House,2,D,Margie Wakefield,52
-Shawnee,Ward 14 Precinct 1,U.S. House,2,D,Margie Wakefield,241
-Shawnee,Ward 14 Precinct 2,U.S. House,2,D,Margie Wakefield,208
-Shawnee,Ward 14 Precinct 3,U.S. House,2,D,Margie Wakefield,108
-Shawnee,Ward 14 Precinct 4,U.S. House,2,D,Margie Wakefield,208
-Shawnee,Ward 14 Precinct 5,U.S. House,2,D,Margie Wakefield,95
-Shawnee,Ward 15 Precinct 1,U.S. House,2,D,Margie Wakefield,179
-Shawnee,Ward 15 Precinct 2,U.S. House,2,D,Margie Wakefield,149
-Shawnee,Ward 15 Precinct 3,U.S. House,2,D,Margie Wakefield,12
-Shawnee,Ward 1 Precinct 1,U.S. House,2,L,Chris Clemmons,12
-Shawnee,Ward 1 Precinct 2,U.S. House,2,L,Chris Clemmons,13
-Shawnee,Ward 1 Precinct 3,U.S. House,2,L,Chris Clemmons,14
-Shawnee,Ward 1 Precinct 4,U.S. House,2,L,Chris Clemmons,12
-Shawnee,Ward 1 Precinct 5,U.S. House,2,L,Chris Clemmons,27
-Shawnee,Ward 1 Precinct 6,U.S. House,2,L,Chris Clemmons,18
-Shawnee,Ward 2 Precinct 1,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 2 Precinct 2,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 2 Precinct 3,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 2 Precinct 4,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 2 Precinct 5,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 2 Precinct 6,U.S. House,2,L,Chris Clemmons,17
-Shawnee,Ward 2 Precinct 7,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 2 Precinct 8,U.S. House,2,L,Chris Clemmons,6
-Shawnee,Ward 2 Precinct 9,U.S. House,2,L,Chris Clemmons,15
-Shawnee,Ward 2 Precinct 10,U.S. House,2,L,Chris Clemmons,12
-Shawnee,Ward 2 Precinct 11,U.S. House,2,L,Chris Clemmons,13
-Shawnee,Ward 3 Precinct 1,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 3 Precinct 2,U.S. House,2,L,Chris Clemmons,10
-Shawnee,Ward 3 Precinct 3,U.S. House,2,L,Chris Clemmons,10
-Shawnee,Ward 3 Precinct 4,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 3 Precinct 5,U.S. House,2,L,Chris Clemmons,4
-Shawnee,Ward 3 Precinct 6,U.S. House,2,L,Chris Clemmons,4
-Shawnee,Ward 3 Precinct 7,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 3 Precinct 8,U.S. House,2,L,Chris Clemmons,10
-Shawnee,Ward 3 Precinct 9,U.S. House,2,L,Chris Clemmons,6
-Shawnee,Ward 3 Precinct 10,U.S. House,2,L,Chris Clemmons,0
-Shawnee,Ward 4 Precinct 1,U.S. House,2,L,Chris Clemmons,18
-Shawnee,Ward 4 Precinct 2,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 4 Precinct 3,U.S. House,2,L,Chris Clemmons,5
-Shawnee,Ward 4 Precinct 4,U.S. House,2,L,Chris Clemmons,10
-Shawnee,Ward 4 Precinct 6,U.S. House,2,L,Chris Clemmons,12
-Shawnee,Ward 4 Precinct 7,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 4 Precinct 8,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 4 Precinct 9,U.S. House,2,L,Chris Clemmons,4
-Shawnee,Ward 4 Precinct 10,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 4 Precinct 11,U.S. House,2,L,Chris Clemmons,4
-Shawnee,Ward 4 Precinct 12,U.S. House,2,L,Chris Clemmons,0
-Shawnee,Ward 4 Precinct 15,U.S. House,2,L,Chris Clemmons,6
-Shawnee,Ward 5 Precinct 1,U.S. House,2,L,Chris Clemmons,10
-Shawnee,Ward 5 Precinct 2,U.S. House,2,L,Chris Clemmons,17
-Shawnee,Ward 5 Precinct 3,U.S. House,2,L,Chris Clemmons,10
-Shawnee,Ward 5 Precinct 4,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 5 Precinct 5,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 5 Precinct 6,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 5 Precinct 7,U.S. House,2,L,Chris Clemmons,14
-Shawnee,Ward 5 Precinct 8,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 5 Precinct 9,U.S. House,2,L,Chris Clemmons,10
-Shawnee,Ward 5 Precinct 10,U.S. House,2,L,Chris Clemmons,13
-Shawnee,Ward 5 Precinct 11,U.S. House,2,L,Chris Clemmons,20
-Shawnee,Ward 5 Precinct 14,U.S. House,2,L,Chris Clemmons,6
-Shawnee,Ward 5 Precinct 15,U.S. House,2,L,Chris Clemmons,0
-Shawnee,Ward 5 Precinct 91,U.S. House,2,L,Chris Clemmons,2
-Shawnee,Ward 6 Precinct 1,U.S. House,2,L,Chris Clemmons,6
-Shawnee,Ward 6 Precinct 2,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 6 Precinct 3,U.S. House,2,L,Chris Clemmons,5
-Shawnee,Ward 6 Precinct 4,U.S. House,2,L,Chris Clemmons,17
-Shawnee,Ward 6 Precinct 5,U.S. House,2,L,Chris Clemmons,16
-Shawnee,Ward 6 Precinct 6,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 6 Precinct 7,U.S. House,2,L,Chris Clemmons,3
-Shawnee,Ward 6 Precinct 8,U.S. House,2,L,Chris Clemmons,5
-Shawnee,Ward 6 Precinct 9,U.S. House,2,L,Chris Clemmons,31
-Shawnee,Ward 7 Precinct 1,U.S. House,2,L,Chris Clemmons,25
-Shawnee,Ward 7 Precinct 2,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 7 Precinct 3,U.S. House,2,L,Chris Clemmons,13
-Shawnee,Ward 7 Precinct 4,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 7 Precinct 5,U.S. House,2,L,Chris Clemmons,19
-Shawnee,Ward 7 Precinct 6,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 7 Precinct 7,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 7 Precinct 9,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 7 Precinct 10,U.S. House,2,L,Chris Clemmons,13
-Shawnee,Ward 7 Precinct 11,U.S. House,2,L,Chris Clemmons,15
-Shawnee,Ward 8 Precinct 1,U.S. House,2,L,Chris Clemmons,17
-Shawnee,Ward 8 Precinct 2,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 8 Precinct 3,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 8 Precinct 4,U.S. House,2,L,Chris Clemmons,14
-Shawnee,Ward 8 Precinct 5,U.S. House,2,L,Chris Clemmons,15
-Shawnee,Ward 8 Precinct 6,U.S. House,2,L,Chris Clemmons,5
-Shawnee,Ward 8 Precinct 7,U.S. House,2,L,Chris Clemmons,10
-Shawnee,Ward 8 Precinct 8,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 8 Precinct 9,U.S. House,2,L,Chris Clemmons,12
-Shawnee,Ward 8 Precinct 10,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 8 Precinct 11,U.S. House,2,L,Chris Clemmons,15
-Shawnee,Ward 9 Precinct 1,U.S. House,2,L,Chris Clemmons,4
-Shawnee,Ward 9 Precinct 2,U.S. House,2,L,Chris Clemmons,13
-Shawnee,Ward 9 Precinct 3,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 9 Precinct 4,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 9 Precinct 5,U.S. House,2,L,Chris Clemmons,15
-Shawnee,Ward 9 Precinct 6,U.S. House,2,L,Chris Clemmons,12
-Shawnee,Ward 9 Precinct 8,U.S. House,2,L,Chris Clemmons,23
-Shawnee,Ward 9 Precinct 9,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 9 Precinct 10,U.S. House,2,L,Chris Clemmons,29
-Shawnee,Ward 9 Precinct 11,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 9 Precinct 12,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 10 Precinct 1,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 10 Precinct 2,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 10 Precinct 3,U.S. House,2,L,Chris Clemmons,25
-Shawnee,Ward 10 Precinct 4,U.S. House,2,L,Chris Clemmons,19
-Shawnee,Ward 10 Precinct 5,U.S. House,2,L,Chris Clemmons,15
-Shawnee,Ward 10 Precinct 6,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 10 Precinct 7,U.S. House,2,L,Chris Clemmons,16
-Shawnee,Ward 10 Precinct 8,U.S. House,2,L,Chris Clemmons,17
-Shawnee,Ward 10 Precinct 9,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 10 Precinct 10,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 10 Precinct 11,U.S. House,2,L,Chris Clemmons,24
-Shawnee,Ward 10 Precinct 14,U.S. House,2,L,Chris Clemmons,9
-Shawnee,Ward 11 Precinct 1,U.S. House,2,L,Chris Clemmons,13
-Shawnee,Ward 11 Precinct 2,U.S. House,2,L,Chris Clemmons,14
-Shawnee,Ward 11 Precinct 3,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 11 Precinct 4,U.S. House,2,L,Chris Clemmons,19
-Shawnee,Ward 11 Precinct 5,U.S. House,2,L,Chris Clemmons,22
-Shawnee,Ward 11 Precinct 6,U.S. House,2,L,Chris Clemmons,14
-Shawnee,Ward 11 Precinct 7,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 11 Precinct 8,U.S. House,2,L,Chris Clemmons,16
-Shawnee,Ward 11 Precinct 9,U.S. House,2,L,Chris Clemmons,23
-Shawnee,Ward 11 Precinct 10,U.S. House,2,L,Chris Clemmons,6
-Shawnee,Ward 12 Precinct 1,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 12 Precinct 2,U.S. House,2,L,Chris Clemmons,14
-Shawnee,Ward 12 Precinct 3,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 12 Precinct 4,U.S. House,2,L,Chris Clemmons,18
-Shawnee,Ward 12 Precinct 5,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 12 Precinct 6,U.S. House,2,L,Chris Clemmons,17
-Shawnee,Ward 12 Precinct 7,U.S. House,2,L,Chris Clemmons,21
-Shawnee,Ward 12 Precinct 8,U.S. House,2,L,Chris Clemmons,21
-Shawnee,Ward 12 Precinct 9,U.S. House,2,L,Chris Clemmons,27
-Shawnee,Ward 12 Precinct 11,U.S. House,2,L,Chris Clemmons,21
-Shawnee,Ward 12 Precinct 13,U.S. House,2,L,Chris Clemmons,13
-Shawnee,Ward 12 Precinct 14,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 12 Precinct 15,U.S. House,2,L,Chris Clemmons,22
-Shawnee,Ward 12 Precinct 16,U.S. House,2,L,Chris Clemmons,21
-Shawnee,Ward 12 Precinct 19,U.S. House,2,L,Chris Clemmons,2
-Shawnee,Ward 12 Precinct 20,U.S. House,2,L,Chris Clemmons,22
-Shawnee,Ward 12 Precinct 31,U.S. House,2,L,Chris Clemmons,14
-Shawnee,Ward 13 Precinct 2,U.S. House,2,L,Chris Clemmons,8
-Shawnee,Ward 13 Precinct 5,U.S. House,2,L,Chris Clemmons,0
-Shawnee,Ward 13 Precinct 6,U.S. House,2,L,Chris Clemmons,1
-Shawnee,Ward 13 Precinct 9,U.S. House,2,L,Chris Clemmons,3
-Shawnee,Ward 13 Precinct 12,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 13 Precinct 21,U.S. House,2,L,Chris Clemmons,4
-Shawnee,Ward 13 Precinct 22,U.S. House,2,L,Chris Clemmons,1
-Shawnee,Ward 13 Precinct 30,U.S. House,2,L,Chris Clemmons,6
-Shawnee,Ward 14 Precinct 1,U.S. House,2,L,Chris Clemmons,22
-Shawnee,Ward 14 Precinct 2,U.S. House,2,L,Chris Clemmons,20
-Shawnee,Ward 14 Precinct 3,U.S. House,2,L,Chris Clemmons,11
-Shawnee,Ward 14 Precinct 4,U.S. House,2,L,Chris Clemmons,14
-Shawnee,Ward 14 Precinct 5,U.S. House,2,L,Chris Clemmons,7
-Shawnee,Ward 15 Precinct 1,U.S. House,2,L,Chris Clemmons,22
-Shawnee,Ward 15 Precinct 2,U.S. House,2,L,Chris Clemmons,18
-Shawnee,Ward 15 Precinct 3,U.S. House,2,L,Chris Clemmons,1
-Shawnee,Ward 1 Precinct 1,Governor,,R,Sam Brownback,45
-Shawnee,Ward 1 Precinct 2,Governor,,R,Sam Brownback,55
-Shawnee,Ward 1 Precinct 3,Governor,,R,Sam Brownback,50
-Shawnee,Ward 1 Precinct 4,Governor,,R,Sam Brownback,81
-Shawnee,Ward 1 Precinct 5,Governor,,R,Sam Brownback,140
-Shawnee,Ward 1 Precinct 6,Governor,,R,Sam Brownback,207
-Shawnee,Ward 2 Precinct 1,Governor,,R,Sam Brownback,76
-Shawnee,Ward 2 Precinct 2,Governor,,R,Sam Brownback,69
-Shawnee,Ward 2 Precinct 3,Governor,,R,Sam Brownback,67
-Shawnee,Ward 2 Precinct 4,Governor,,R,Sam Brownback,50
-Shawnee,Ward 2 Precinct 5,Governor,,R,Sam Brownback,45
-Shawnee,Ward 2 Precinct 6,Governor,,R,Sam Brownback,41
-Shawnee,Ward 2 Precinct 7,Governor,,R,Sam Brownback,15
-Shawnee,Ward 2 Precinct 8,Governor,,R,Sam Brownback,9
-Shawnee,Ward 2 Precinct 9,Governor,,R,Sam Brownback,68
-Shawnee,Ward 2 Precinct 10,Governor,,R,Sam Brownback,55
-Shawnee,Ward 2 Precinct 11,Governor,,R,Sam Brownback,44
-Shawnee,Ward 3 Precinct 1,Governor,,R,Sam Brownback,64
-Shawnee,Ward 3 Precinct 2,Governor,,R,Sam Brownback,63
-Shawnee,Ward 3 Precinct 3,Governor,,R,Sam Brownback,29
-Shawnee,Ward 3 Precinct 4,Governor,,R,Sam Brownback,50
-Shawnee,Ward 3 Precinct 5,Governor,,R,Sam Brownback,26
-Shawnee,Ward 3 Precinct 6,Governor,,R,Sam Brownback,44
-Shawnee,Ward 3 Precinct 7,Governor,,R,Sam Brownback,42
-Shawnee,Ward 3 Precinct 8,Governor,,R,Sam Brownback,66
-Shawnee,Ward 3 Precinct 9,Governor,,R,Sam Brownback,53
-Shawnee,Ward 3 Precinct 10,Governor,,R,Sam Brownback,3
-Shawnee,Ward 4 Precinct 1,Governor,,R,Sam Brownback,27
-Shawnee,Ward 4 Precinct 2,Governor,,R,Sam Brownback,28
-Shawnee,Ward 4 Precinct 3,Governor,,R,Sam Brownback,21
-Shawnee,Ward 4 Precinct 4,Governor,,R,Sam Brownback,29
-Shawnee,Ward 4 Precinct 6,Governor,,R,Sam Brownback,96
-Shawnee,Ward 4 Precinct 7,Governor,,R,Sam Brownback,23
-Shawnee,Ward 4 Precinct 8,Governor,,R,Sam Brownback,45
-Shawnee,Ward 4 Precinct 9,Governor,,R,Sam Brownback,40
-Shawnee,Ward 4 Precinct 10,Governor,,R,Sam Brownback,52
-Shawnee,Ward 4 Precinct 11,Governor,,R,Sam Brownback,36
-Shawnee,Ward 4 Precinct 12,Governor,,R,Sam Brownback,0
-Shawnee,Ward 4 Precinct 15,Governor,,R,Sam Brownback,51
-Shawnee,Ward 5 Precinct 1,Governor,,R,Sam Brownback,34
-Shawnee,Ward 5 Precinct 2,Governor,,R,Sam Brownback,34
-Shawnee,Ward 5 Precinct 3,Governor,,R,Sam Brownback,64
-Shawnee,Ward 5 Precinct 4,Governor,,R,Sam Brownback,49
-Shawnee,Ward 5 Precinct 5,Governor,,R,Sam Brownback,51
-Shawnee,Ward 5 Precinct 6,Governor,,R,Sam Brownback,33
-Shawnee,Ward 5 Precinct 7,Governor,,R,Sam Brownback,48
-Shawnee,Ward 5 Precinct 8,Governor,,R,Sam Brownback,47
-Shawnee,Ward 5 Precinct 9,Governor,,R,Sam Brownback,123
-Shawnee,Ward 5 Precinct 10,Governor,,R,Sam Brownback,162
-Shawnee,Ward 5 Precinct 11,Governor,,R,Sam Brownback,113
-Shawnee,Ward 5 Precinct 14,Governor,,R,Sam Brownback,104
-Shawnee,Ward 5 Precinct 15,Governor,,R,Sam Brownback,20
-Shawnee,Ward 5 Precinct 91,Governor,,R,Sam Brownback,33
-Shawnee,Ward 6 Precinct 1,Governor,,R,Sam Brownback,30
-Shawnee,Ward 6 Precinct 2,Governor,,R,Sam Brownback,27
-Shawnee,Ward 6 Precinct 3,Governor,,R,Sam Brownback,153
-Shawnee,Ward 6 Precinct 4,Governor,,R,Sam Brownback,60
-Shawnee,Ward 6 Precinct 5,Governor,,R,Sam Brownback,104
-Shawnee,Ward 6 Precinct 6,Governor,,R,Sam Brownback,46
-Shawnee,Ward 6 Precinct 7,Governor,,R,Sam Brownback,38
-Shawnee,Ward 6 Precinct 8,Governor,,R,Sam Brownback,58
-Shawnee,Ward 6 Precinct 9,Governor,,R,Sam Brownback,232
-Shawnee,Ward 7 Precinct 1,Governor,,R,Sam Brownback,83
-Shawnee,Ward 7 Precinct 2,Governor,,R,Sam Brownback,64
-Shawnee,Ward 7 Precinct 3,Governor,,R,Sam Brownback,79
-Shawnee,Ward 7 Precinct 4,Governor,,R,Sam Brownback,106
-Shawnee,Ward 7 Precinct 5,Governor,,R,Sam Brownback,93
-Shawnee,Ward 7 Precinct 6,Governor,,R,Sam Brownback,70
-Shawnee,Ward 7 Precinct 7,Governor,,R,Sam Brownback,54
-Shawnee,Ward 7 Precinct 9,Governor,,R,Sam Brownback,73
-Shawnee,Ward 7 Precinct 10,Governor,,R,Sam Brownback,58
-Shawnee,Ward 7 Precinct 11,Governor,,R,Sam Brownback,116
-Shawnee,Ward 8 Precinct 1,Governor,,R,Sam Brownback,44
-Shawnee,Ward 8 Precinct 2,Governor,,R,Sam Brownback,57
-Shawnee,Ward 8 Precinct 3,Governor,,R,Sam Brownback,87
-Shawnee,Ward 8 Precinct 4,Governor,,R,Sam Brownback,86
-Shawnee,Ward 8 Precinct 5,Governor,,R,Sam Brownback,159
-Shawnee,Ward 8 Precinct 6,Governor,,R,Sam Brownback,107
-Shawnee,Ward 8 Precinct 7,Governor,,R,Sam Brownback,55
-Shawnee,Ward 8 Precinct 8,Governor,,R,Sam Brownback,61
-Shawnee,Ward 8 Precinct 9,Governor,,R,Sam Brownback,114
-Shawnee,Ward 8 Precinct 10,Governor,,R,Sam Brownback,131
-Shawnee,Ward 8 Precinct 11,Governor,,R,Sam Brownback,118
-Shawnee,Ward 9 Precinct 1,Governor,,R,Sam Brownback,17
-Shawnee,Ward 9 Precinct 2,Governor,,R,Sam Brownback,59
-Shawnee,Ward 9 Precinct 3,Governor,,R,Sam Brownback,154
-Shawnee,Ward 9 Precinct 4,Governor,,R,Sam Brownback,106
-Shawnee,Ward 9 Precinct 5,Governor,,R,Sam Brownback,74
-Shawnee,Ward 9 Precinct 6,Governor,,R,Sam Brownback,105
-Shawnee,Ward 9 Precinct 8,Governor,,R,Sam Brownback,123
-Shawnee,Ward 9 Precinct 9,Governor,,R,Sam Brownback,95
-Shawnee,Ward 9 Precinct 10,Governor,,R,Sam Brownback,167
-Shawnee,Ward 9 Precinct 11,Governor,,R,Sam Brownback,95
-Shawnee,Ward 9 Precinct 12,Governor,,R,Sam Brownback,44
-Shawnee,Ward 10 Precinct 1,Governor,,R,Sam Brownback,94
-Shawnee,Ward 10 Precinct 2,Governor,,R,Sam Brownback,169
-Shawnee,Ward 10 Precinct 3,Governor,,R,Sam Brownback,201
-Shawnee,Ward 10 Precinct 4,Governor,,R,Sam Brownback,121
-Shawnee,Ward 10 Precinct 5,Governor,,R,Sam Brownback,83
-Shawnee,Ward 10 Precinct 6,Governor,,R,Sam Brownback,111
-Shawnee,Ward 10 Precinct 7,Governor,,R,Sam Brownback,94
-Shawnee,Ward 10 Precinct 8,Governor,,R,Sam Brownback,75
-Shawnee,Ward 10 Precinct 9,Governor,,R,Sam Brownback,69
-Shawnee,Ward 10 Precinct 10,Governor,,R,Sam Brownback,102
-Shawnee,Ward 10 Precinct 11,Governor,,R,Sam Brownback,160
-Shawnee,Ward 10 Precinct 14,Governor,,R,Sam Brownback,100
-Shawnee,Ward 11 Precinct 1,Governor,,R,Sam Brownback,81
-Shawnee,Ward 11 Precinct 2,Governor,,R,Sam Brownback,103
-Shawnee,Ward 11 Precinct 3,Governor,,R,Sam Brownback,69
-Shawnee,Ward 11 Precinct 4,Governor,,R,Sam Brownback,135
-Shawnee,Ward 11 Precinct 5,Governor,,R,Sam Brownback,89
-Shawnee,Ward 11 Precinct 6,Governor,,R,Sam Brownback,97
-Shawnee,Ward 11 Precinct 7,Governor,,R,Sam Brownback,103
-Shawnee,Ward 11 Precinct 8,Governor,,R,Sam Brownback,96
-Shawnee,Ward 11 Precinct 9,Governor,,R,Sam Brownback,107
-Shawnee,Ward 11 Precinct 10,Governor,,R,Sam Brownback,67
-Shawnee,Ward 12 Precinct 1,Governor,,R,Sam Brownback,83
-Shawnee,Ward 12 Precinct 2,Governor,,R,Sam Brownback,53
-Shawnee,Ward 12 Precinct 3,Governor,,R,Sam Brownback,128
-Shawnee,Ward 12 Precinct 4,Governor,,R,Sam Brownback,188
-Shawnee,Ward 12 Precinct 5,Governor,,R,Sam Brownback,173
-Shawnee,Ward 12 Precinct 6,Governor,,R,Sam Brownback,146
-Shawnee,Ward 12 Precinct 7,Governor,,R,Sam Brownback,146
-Shawnee,Ward 12 Precinct 8,Governor,,R,Sam Brownback,145
-Shawnee,Ward 12 Precinct 9,Governor,,R,Sam Brownback,235
-Shawnee,Ward 12 Precinct 11,Governor,,R,Sam Brownback,262
-Shawnee,Ward 12 Precinct 13,Governor,,R,Sam Brownback,199
-Shawnee,Ward 12 Precinct 14,Governor,,R,Sam Brownback,142
-Shawnee,Ward 12 Precinct 15,Governor,,R,Sam Brownback,241
-Shawnee,Ward 12 Precinct 16,Governor,,R,Sam Brownback,217
-Shawnee,Ward 12 Precinct 19,Governor,,R,Sam Brownback,50
-Shawnee,Ward 12 Precinct 20,Governor,,R,Sam Brownback,176
-Shawnee,Ward 12 Precinct 31,Governor,,R,Sam Brownback,122
-Shawnee,Ward 13 Precinct 2,Governor,,R,Sam Brownback,30
-Shawnee,Ward 13 Precinct 5,Governor,,R,Sam Brownback,11
-Shawnee,Ward 13 Precinct 6,Governor,,R,Sam Brownback,75
-Shawnee,Ward 13 Precinct 9,Governor,,R,Sam Brownback,49
-Shawnee,Ward 13 Precinct 12,Governor,,R,Sam Brownback,257
-Shawnee,Ward 13 Precinct 21,Governor,,R,Sam Brownback,22
-Shawnee,Ward 13 Precinct 22,Governor,,R,Sam Brownback,28
-Shawnee,Ward 13 Precinct 30,Governor,,R,Sam Brownback,45
-Shawnee,Ward 14 Precinct 1,Governor,,R,Sam Brownback,216
-Shawnee,Ward 14 Precinct 2,Governor,,R,Sam Brownback,174
-Shawnee,Ward 14 Precinct 3,Governor,,R,Sam Brownback,142
-Shawnee,Ward 14 Precinct 4,Governor,,R,Sam Brownback,314
-Shawnee,Ward 14 Precinct 5,Governor,,R,Sam Brownback,191
-Shawnee,Ward 15 Precinct 1,Governor,,R,Sam Brownback,155
-Shawnee,Ward 15 Precinct 2,Governor,,R,Sam Brownback,93
-Shawnee,Ward 15 Precinct 3,Governor,,R,Sam Brownback,10
-Shawnee,Ward 1 Precinct 1,Governor,,D,Paul Davis,114
-Shawnee,Ward 1 Precinct 2,Governor,,D,Paul Davis,149
-Shawnee,Ward 1 Precinct 3,Governor,,D,Paul Davis,117
-Shawnee,Ward 1 Precinct 4,Governor,,D,Paul Davis,152
-Shawnee,Ward 1 Precinct 5,Governor,,D,Paul Davis,200
-Shawnee,Ward 1 Precinct 6,Governor,,D,Paul Davis,238
-Shawnee,Ward 2 Precinct 1,Governor,,D,Paul Davis,148
-Shawnee,Ward 2 Precinct 2,Governor,,D,Paul Davis,125
-Shawnee,Ward 2 Precinct 3,Governor,,D,Paul Davis,140
-Shawnee,Ward 2 Precinct 4,Governor,,D,Paul Davis,131
-Shawnee,Ward 2 Precinct 5,Governor,,D,Paul Davis,145
-Shawnee,Ward 2 Precinct 6,Governor,,D,Paul Davis,104
-Shawnee,Ward 2 Precinct 7,Governor,,D,Paul Davis,70
-Shawnee,Ward 2 Precinct 8,Governor,,D,Paul Davis,87
-Shawnee,Ward 2 Precinct 9,Governor,,D,Paul Davis,172
-Shawnee,Ward 2 Precinct 10,Governor,,D,Paul Davis,214
-Shawnee,Ward 2 Precinct 11,Governor,,D,Paul Davis,99
-Shawnee,Ward 3 Precinct 1,Governor,,D,Paul Davis,144
-Shawnee,Ward 3 Precinct 2,Governor,,D,Paul Davis,180
-Shawnee,Ward 3 Precinct 3,Governor,,D,Paul Davis,113
-Shawnee,Ward 3 Precinct 4,Governor,,D,Paul Davis,118
-Shawnee,Ward 3 Precinct 5,Governor,,D,Paul Davis,80
-Shawnee,Ward 3 Precinct 6,Governor,,D,Paul Davis,88
-Shawnee,Ward 3 Precinct 7,Governor,,D,Paul Davis,113
-Shawnee,Ward 3 Precinct 8,Governor,,D,Paul Davis,121
-Shawnee,Ward 3 Precinct 9,Governor,,D,Paul Davis,127
-Shawnee,Ward 3 Precinct 10,Governor,,D,Paul Davis,8
-Shawnee,Ward 4 Precinct 1,Governor,,D,Paul Davis,137
-Shawnee,Ward 4 Precinct 2,Governor,,D,Paul Davis,136
-Shawnee,Ward 4 Precinct 3,Governor,,D,Paul Davis,100
-Shawnee,Ward 4 Precinct 4,Governor,,D,Paul Davis,176
-Shawnee,Ward 4 Precinct 6,Governor,,D,Paul Davis,165
-Shawnee,Ward 4 Precinct 7,Governor,,D,Paul Davis,99
-Shawnee,Ward 4 Precinct 8,Governor,,D,Paul Davis,118
-Shawnee,Ward 4 Precinct 9,Governor,,D,Paul Davis,151
-Shawnee,Ward 4 Precinct 10,Governor,,D,Paul Davis,192
-Shawnee,Ward 4 Precinct 11,Governor,,D,Paul Davis,58
-Shawnee,Ward 4 Precinct 12,Governor,,D,Paul Davis,15
-Shawnee,Ward 4 Precinct 15,Governor,,D,Paul Davis,87
-Shawnee,Ward 5 Precinct 1,Governor,,D,Paul Davis,127
-Shawnee,Ward 5 Precinct 2,Governor,,D,Paul Davis,128
-Shawnee,Ward 5 Precinct 3,Governor,,D,Paul Davis,120
-Shawnee,Ward 5 Precinct 4,Governor,,D,Paul Davis,155
-Shawnee,Ward 5 Precinct 5,Governor,,D,Paul Davis,147
-Shawnee,Ward 5 Precinct 6,Governor,,D,Paul Davis,108
-Shawnee,Ward 5 Precinct 7,Governor,,D,Paul Davis,154
-Shawnee,Ward 5 Precinct 8,Governor,,D,Paul Davis,112
-Shawnee,Ward 5 Precinct 9,Governor,,D,Paul Davis,222
-Shawnee,Ward 5 Precinct 10,Governor,,D,Paul Davis,268
-Shawnee,Ward 5 Precinct 11,Governor,,D,Paul Davis,212
-Shawnee,Ward 5 Precinct 14,Governor,,D,Paul Davis,105
-Shawnee,Ward 5 Precinct 15,Governor,,D,Paul Davis,29
-Shawnee,Ward 5 Precinct 91,Governor,,D,Paul Davis,53
-Shawnee,Ward 6 Precinct 1,Governor,,D,Paul Davis,120
-Shawnee,Ward 6 Precinct 2,Governor,,D,Paul Davis,118
-Shawnee,Ward 6 Precinct 3,Governor,,D,Paul Davis,196
-Shawnee,Ward 6 Precinct 4,Governor,,D,Paul Davis,149
-Shawnee,Ward 6 Precinct 5,Governor,,D,Paul Davis,209
-Shawnee,Ward 6 Precinct 6,Governor,,D,Paul Davis,98
-Shawnee,Ward 6 Precinct 7,Governor,,D,Paul Davis,77
-Shawnee,Ward 6 Precinct 8,Governor,,D,Paul Davis,167
-Shawnee,Ward 6 Precinct 9,Governor,,D,Paul Davis,340
-Shawnee,Ward 7 Precinct 1,Governor,,D,Paul Davis,215
-Shawnee,Ward 7 Precinct 2,Governor,,D,Paul Davis,170
-Shawnee,Ward 7 Precinct 3,Governor,,D,Paul Davis,171
-Shawnee,Ward 7 Precinct 4,Governor,,D,Paul Davis,191
-Shawnee,Ward 7 Precinct 5,Governor,,D,Paul Davis,135
-Shawnee,Ward 7 Precinct 6,Governor,,D,Paul Davis,123
-Shawnee,Ward 7 Precinct 7,Governor,,D,Paul Davis,131
-Shawnee,Ward 7 Precinct 9,Governor,,D,Paul Davis,135
-Shawnee,Ward 7 Precinct 10,Governor,,D,Paul Davis,158
-Shawnee,Ward 7 Precinct 11,Governor,,D,Paul Davis,234
-Shawnee,Ward 8 Precinct 1,Governor,,D,Paul Davis,143
-Shawnee,Ward 8 Precinct 2,Governor,,D,Paul Davis,174
-Shawnee,Ward 8 Precinct 3,Governor,,D,Paul Davis,245
-Shawnee,Ward 8 Precinct 4,Governor,,D,Paul Davis,225
-Shawnee,Ward 8 Precinct 5,Governor,,D,Paul Davis,275
-Shawnee,Ward 8 Precinct 6,Governor,,D,Paul Davis,151
-Shawnee,Ward 8 Precinct 7,Governor,,D,Paul Davis,154
-Shawnee,Ward 8 Precinct 8,Governor,,D,Paul Davis,185
-Shawnee,Ward 8 Precinct 9,Governor,,D,Paul Davis,224
-Shawnee,Ward 8 Precinct 10,Governor,,D,Paul Davis,139
-Shawnee,Ward 8 Precinct 11,Governor,,D,Paul Davis,222
-Shawnee,Ward 9 Precinct 1,Governor,,D,Paul Davis,39
-Shawnee,Ward 9 Precinct 2,Governor,,D,Paul Davis,141
-Shawnee,Ward 9 Precinct 3,Governor,,D,Paul Davis,249
-Shawnee,Ward 9 Precinct 4,Governor,,D,Paul Davis,236
-Shawnee,Ward 9 Precinct 5,Governor,,D,Paul Davis,180
-Shawnee,Ward 9 Precinct 6,Governor,,D,Paul Davis,195
-Shawnee,Ward 9 Precinct 8,Governor,,D,Paul Davis,222
-Shawnee,Ward 9 Precinct 9,Governor,,D,Paul Davis,172
-Shawnee,Ward 9 Precinct 10,Governor,,D,Paul Davis,326
-Shawnee,Ward 9 Precinct 11,Governor,,D,Paul Davis,192
-Shawnee,Ward 9 Precinct 12,Governor,,D,Paul Davis,96
-Shawnee,Ward 10 Precinct 1,Governor,,D,Paul Davis,213
-Shawnee,Ward 10 Precinct 2,Governor,,D,Paul Davis,176
-Shawnee,Ward 10 Precinct 3,Governor,,D,Paul Davis,287
-Shawnee,Ward 10 Precinct 4,Governor,,D,Paul Davis,165
-Shawnee,Ward 10 Precinct 5,Governor,,D,Paul Davis,175
-Shawnee,Ward 10 Precinct 6,Governor,,D,Paul Davis,155
-Shawnee,Ward 10 Precinct 7,Governor,,D,Paul Davis,187
-Shawnee,Ward 10 Precinct 8,Governor,,D,Paul Davis,163
-Shawnee,Ward 10 Precinct 9,Governor,,D,Paul Davis,131
-Shawnee,Ward 10 Precinct 10,Governor,,D,Paul Davis,180
-Shawnee,Ward 10 Precinct 11,Governor,,D,Paul Davis,234
-Shawnee,Ward 10 Precinct 14,Governor,,D,Paul Davis,198
-Shawnee,Ward 11 Precinct 1,Governor,,D,Paul Davis,122
-Shawnee,Ward 11 Precinct 2,Governor,,D,Paul Davis,185
-Shawnee,Ward 11 Precinct 3,Governor,,D,Paul Davis,143
-Shawnee,Ward 11 Precinct 4,Governor,,D,Paul Davis,261
-Shawnee,Ward 11 Precinct 5,Governor,,D,Paul Davis,190
-Shawnee,Ward 11 Precinct 6,Governor,,D,Paul Davis,172
-Shawnee,Ward 11 Precinct 7,Governor,,D,Paul Davis,157
-Shawnee,Ward 11 Precinct 8,Governor,,D,Paul Davis,156
-Shawnee,Ward 11 Precinct 9,Governor,,D,Paul Davis,176
-Shawnee,Ward 11 Precinct 10,Governor,,D,Paul Davis,124
-Shawnee,Ward 12 Precinct 1,Governor,,D,Paul Davis,183
-Shawnee,Ward 12 Precinct 2,Governor,,D,Paul Davis,134
-Shawnee,Ward 12 Precinct 3,Governor,,D,Paul Davis,197
-Shawnee,Ward 12 Precinct 4,Governor,,D,Paul Davis,234
-Shawnee,Ward 12 Precinct 5,Governor,,D,Paul Davis,211
-Shawnee,Ward 12 Precinct 6,Governor,,D,Paul Davis,267
-Shawnee,Ward 12 Precinct 7,Governor,,D,Paul Davis,234
-Shawnee,Ward 12 Precinct 8,Governor,,D,Paul Davis,245
-Shawnee,Ward 12 Precinct 9,Governor,,D,Paul Davis,345
-Shawnee,Ward 12 Precinct 11,Governor,,D,Paul Davis,330
-Shawnee,Ward 12 Precinct 13,Governor,,D,Paul Davis,219
-Shawnee,Ward 12 Precinct 14,Governor,,D,Paul Davis,171
-Shawnee,Ward 12 Precinct 15,Governor,,D,Paul Davis,308
-Shawnee,Ward 12 Precinct 16,Governor,,D,Paul Davis,360
-Shawnee,Ward 12 Precinct 19,Governor,,D,Paul Davis,25
-Shawnee,Ward 12 Precinct 20,Governor,,D,Paul Davis,241
-Shawnee,Ward 12 Precinct 31,Governor,,D,Paul Davis,141
-Shawnee,Ward 13 Precinct 2,Governor,,D,Paul Davis,73
-Shawnee,Ward 13 Precinct 5,Governor,,D,Paul Davis,3
-Shawnee,Ward 13 Precinct 6,Governor,,D,Paul Davis,33
-Shawnee,Ward 13 Precinct 9,Governor,,D,Paul Davis,37
-Shawnee,Ward 13 Precinct 12,Governor,,D,Paul Davis,252
-Shawnee,Ward 13 Precinct 21,Governor,,D,Paul Davis,44
-Shawnee,Ward 13 Precinct 22,Governor,,D,Paul Davis,34
-Shawnee,Ward 13 Precinct 30,Governor,,D,Paul Davis,71
-Shawnee,Ward 14 Precinct 1,Governor,,D,Paul Davis,316
-Shawnee,Ward 14 Precinct 2,Governor,,D,Paul Davis,274
-Shawnee,Ward 14 Precinct 3,Governor,,D,Paul Davis,151
-Shawnee,Ward 14 Precinct 4,Governor,,D,Paul Davis,287
-Shawnee,Ward 14 Precinct 5,Governor,,D,Paul Davis,152
-Shawnee,Ward 15 Precinct 1,Governor,,D,Paul Davis,244
-Shawnee,Ward 15 Precinct 2,Governor,,D,Paul Davis,202
-Shawnee,Ward 15 Precinct 3,Governor,,D,Paul Davis,18
-Shawnee,Ward 1 Precinct 1,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 1 Precinct 2,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 1 Precinct 3,Governor,,L,Keen Umbehr,6
-Shawnee,Ward 1 Precinct 4,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 1 Precinct 5,Governor,,L,Keen Umbehr,22
-Shawnee,Ward 1 Precinct 6,Governor,,L,Keen Umbehr,19
-Shawnee,Ward 2 Precinct 1,Governor,,L,Keen Umbehr,20
-Shawnee,Ward 2 Precinct 2,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 2 Precinct 3,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 2 Precinct 4,Governor,,L,Keen Umbehr,13
-Shawnee,Ward 2 Precinct 5,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 2 Precinct 6,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 2 Precinct 7,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 2 Precinct 8,Governor,,L,Keen Umbehr,6
-Shawnee,Ward 2 Precinct 9,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 2 Precinct 10,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 2 Precinct 11,Governor,,L,Keen Umbehr,6
-Shawnee,Ward 3 Precinct 1,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 3 Precinct 2,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 3 Precinct 3,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 3 Precinct 4,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 3 Precinct 5,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 3 Precinct 6,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 3 Precinct 7,Governor,,L,Keen Umbehr,4
-Shawnee,Ward 3 Precinct 8,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 3 Precinct 9,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 3 Precinct 10,Governor,,L,Keen Umbehr,2
-Shawnee,Ward 4 Precinct 1,Governor,,L,Keen Umbehr,15
-Shawnee,Ward 4 Precinct 2,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 4 Precinct 3,Governor,,L,Keen Umbehr,5
-Shawnee,Ward 4 Precinct 4,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 4 Precinct 6,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 4 Precinct 7,Governor,,L,Keen Umbehr,2
-Shawnee,Ward 4 Precinct 8,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 4 Precinct 9,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 4 Precinct 10,Governor,,L,Keen Umbehr,15
-Shawnee,Ward 4 Precinct 11,Governor,,L,Keen Umbehr,3
-Shawnee,Ward 4 Precinct 12,Governor,,L,Keen Umbehr,1
-Shawnee,Ward 4 Precinct 15,Governor,,L,Keen Umbehr,2
-Shawnee,Ward 5 Precinct 1,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 5 Precinct 2,Governor,,L,Keen Umbehr,15
-Shawnee,Ward 5 Precinct 3,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 5 Precinct 4,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 5 Precinct 5,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 5 Precinct 6,Governor,,L,Keen Umbehr,6
-Shawnee,Ward 5 Precinct 7,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 5 Precinct 8,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 5 Precinct 9,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 5 Precinct 10,Governor,,L,Keen Umbehr,14
-Shawnee,Ward 5 Precinct 11,Governor,,L,Keen Umbehr,15
-Shawnee,Ward 5 Precinct 14,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 5 Precinct 15,Governor,,L,Keen Umbehr,2
-Shawnee,Ward 5 Precinct 91,Governor,,L,Keen Umbehr,5
-Shawnee,Ward 6 Precinct 1,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 6 Precinct 2,Governor,,L,Keen Umbehr,14
-Shawnee,Ward 6 Precinct 3,Governor,,L,Keen Umbehr,15
-Shawnee,Ward 6 Precinct 4,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 6 Precinct 5,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 6 Precinct 6,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 6 Precinct 7,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 6 Precinct 8,Governor,,L,Keen Umbehr,14
-Shawnee,Ward 6 Precinct 9,Governor,,L,Keen Umbehr,27
-Shawnee,Ward 7 Precinct 1,Governor,,L,Keen Umbehr,14
-Shawnee,Ward 7 Precinct 2,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 7 Precinct 3,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 7 Precinct 4,Governor,,L,Keen Umbehr,5
-Shawnee,Ward 7 Precinct 5,Governor,,L,Keen Umbehr,19
-Shawnee,Ward 7 Precinct 6,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 7 Precinct 7,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 7 Precinct 9,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 7 Precinct 10,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 7 Precinct 11,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 8 Precinct 1,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 8 Precinct 2,Governor,,L,Keen Umbehr,13
-Shawnee,Ward 8 Precinct 3,Governor,,L,Keen Umbehr,13
-Shawnee,Ward 8 Precinct 4,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 8 Precinct 5,Governor,,L,Keen Umbehr,23
-Shawnee,Ward 8 Precinct 6,Governor,,L,Keen Umbehr,5
-Shawnee,Ward 8 Precinct 7,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 8 Precinct 8,Governor,,L,Keen Umbehr,5
-Shawnee,Ward 8 Precinct 9,Governor,,L,Keen Umbehr,15
-Shawnee,Ward 8 Precinct 10,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 8 Precinct 11,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 9 Precinct 1,Governor,,L,Keen Umbehr,3
-Shawnee,Ward 9 Precinct 2,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 9 Precinct 3,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 9 Precinct 4,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 9 Precinct 5,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 9 Precinct 6,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 9 Precinct 8,Governor,,L,Keen Umbehr,25
-Shawnee,Ward 9 Precinct 9,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 9 Precinct 10,Governor,,L,Keen Umbehr,20
-Shawnee,Ward 9 Precinct 11,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 9 Precinct 12,Governor,,L,Keen Umbehr,3
-Shawnee,Ward 10 Precinct 1,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 10 Precinct 2,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 10 Precinct 3,Governor,,L,Keen Umbehr,17
-Shawnee,Ward 10 Precinct 4,Governor,,L,Keen Umbehr,15
-Shawnee,Ward 10 Precinct 5,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 10 Precinct 6,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 10 Precinct 7,Governor,,L,Keen Umbehr,17
-Shawnee,Ward 10 Precinct 8,Governor,,L,Keen Umbehr,17
-Shawnee,Ward 10 Precinct 9,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 10 Precinct 10,Governor,,L,Keen Umbehr,10
-Shawnee,Ward 10 Precinct 11,Governor,,L,Keen Umbehr,25
-Shawnee,Ward 10 Precinct 14,Governor,,L,Keen Umbehr,6
-Shawnee,Ward 11 Precinct 1,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 11 Precinct 2,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 11 Precinct 3,Governor,,L,Keen Umbehr,6
-Shawnee,Ward 11 Precinct 4,Governor,,L,Keen Umbehr,20
-Shawnee,Ward 11 Precinct 5,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 11 Precinct 6,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 11 Precinct 7,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 11 Precinct 8,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 11 Precinct 9,Governor,,L,Keen Umbehr,18
-Shawnee,Ward 11 Precinct 10,Governor,,L,Keen Umbehr,7
-Shawnee,Ward 12 Precinct 1,Governor,,L,Keen Umbehr,13
-Shawnee,Ward 12 Precinct 2,Governor,,L,Keen Umbehr,19
-Shawnee,Ward 12 Precinct 3,Governor,,L,Keen Umbehr,9
-Shawnee,Ward 12 Precinct 4,Governor,,L,Keen Umbehr,13
-Shawnee,Ward 12 Precinct 5,Governor,,L,Keen Umbehr,17
-Shawnee,Ward 12 Precinct 6,Governor,,L,Keen Umbehr,14
-Shawnee,Ward 12 Precinct 7,Governor,,L,Keen Umbehr,17
-Shawnee,Ward 12 Precinct 8,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 12 Precinct 9,Governor,,L,Keen Umbehr,18
-Shawnee,Ward 12 Precinct 11,Governor,,L,Keen Umbehr,19
-Shawnee,Ward 12 Precinct 13,Governor,,L,Keen Umbehr,15
-Shawnee,Ward 12 Precinct 14,Governor,,L,Keen Umbehr,13
-Shawnee,Ward 12 Precinct 15,Governor,,L,Keen Umbehr,17
-Shawnee,Ward 12 Precinct 16,Governor,,L,Keen Umbehr,12
-Shawnee,Ward 12 Precinct 19,Governor,,L,Keen Umbehr,0
-Shawnee,Ward 12 Precinct 20,Governor,,L,Keen Umbehr,20
-Shawnee,Ward 12 Precinct 31,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 13 Precinct 2,Governor,,L,Keen Umbehr,5
-Shawnee,Ward 13 Precinct 5,Governor,,L,Keen Umbehr,0
-Shawnee,Ward 13 Precinct 6,Governor,,L,Keen Umbehr,3
-Shawnee,Ward 13 Precinct 9,Governor,,L,Keen Umbehr,5
-Shawnee,Ward 13 Precinct 12,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 13 Precinct 21,Governor,,L,Keen Umbehr,2
-Shawnee,Ward 13 Precinct 22,Governor,,L,Keen Umbehr,1
-Shawnee,Ward 13 Precinct 30,Governor,,L,Keen Umbehr,3
-Shawnee,Ward 14 Precinct 1,Governor,,L,Keen Umbehr,17
-Shawnee,Ward 14 Precinct 2,Governor,,L,Keen Umbehr,17
-Shawnee,Ward 14 Precinct 3,Governor,,L,Keen Umbehr,8
-Shawnee,Ward 14 Precinct 4,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 14 Precinct 5,Governor,,L,Keen Umbehr,4
-Shawnee,Ward 15 Precinct 1,Governor,,L,Keen Umbehr,16
-Shawnee,Ward 15 Precinct 2,Governor,,L,Keen Umbehr,11
-Shawnee,Ward 15 Precinct 3,Governor,,L,Keen Umbehr,0
-Shawnee,Ward 1 Precinct 1,Secretary of State,,R,Kris Kobach,66
-Shawnee,Ward 1 Precinct 2,Secretary of State,,R,Kris Kobach,87
-Shawnee,Ward 1 Precinct 3,Secretary of State,,R,Kris Kobach,71
-Shawnee,Ward 1 Precinct 4,Secretary of State,,R,Kris Kobach,121
-Shawnee,Ward 1 Precinct 5,Secretary of State,,R,Kris Kobach,217
-Shawnee,Ward 1 Precinct 6,Secretary of State,,R,Kris Kobach,259
-Shawnee,Ward 2 Precinct 1,Secretary of State,,R,Kris Kobach,116
-Shawnee,Ward 2 Precinct 2,Secretary of State,,R,Kris Kobach,92
-Shawnee,Ward 2 Precinct 3,Secretary of State,,R,Kris Kobach,95
-Shawnee,Ward 2 Precinct 4,Secretary of State,,R,Kris Kobach,82
-Shawnee,Ward 2 Precinct 5,Secretary of State,,R,Kris Kobach,70
-Shawnee,Ward 2 Precinct 6,Secretary of State,,R,Kris Kobach,58
-Shawnee,Ward 2 Precinct 7,Secretary of State,,R,Kris Kobach,27
-Shawnee,Ward 2 Precinct 8,Secretary of State,,R,Kris Kobach,14
-Shawnee,Ward 2 Precinct 9,Secretary of State,,R,Kris Kobach,117
-Shawnee,Ward 2 Precinct 10,Secretary of State,,R,Kris Kobach,68
-Shawnee,Ward 2 Precinct 11,Secretary of State,,R,Kris Kobach,58
-Shawnee,Ward 3 Precinct 1,Secretary of State,,R,Kris Kobach,109
-Shawnee,Ward 3 Precinct 2,Secretary of State,,R,Kris Kobach,97
-Shawnee,Ward 3 Precinct 3,Secretary of State,,R,Kris Kobach,54
-Shawnee,Ward 3 Precinct 4,Secretary of State,,R,Kris Kobach,63
-Shawnee,Ward 3 Precinct 5,Secretary of State,,R,Kris Kobach,38
-Shawnee,Ward 3 Precinct 6,Secretary of State,,R,Kris Kobach,48
-Shawnee,Ward 3 Precinct 7,Secretary of State,,R,Kris Kobach,57
-Shawnee,Ward 3 Precinct 8,Secretary of State,,R,Kris Kobach,80
-Shawnee,Ward 3 Precinct 9,Secretary of State,,R,Kris Kobach,65
-Shawnee,Ward 3 Precinct 10,Secretary of State,,R,Kris Kobach,4
-Shawnee,Ward 4 Precinct 1,Secretary of State,,R,Kris Kobach,63
-Shawnee,Ward 4 Precinct 2,Secretary of State,,R,Kris Kobach,40
-Shawnee,Ward 4 Precinct 3,Secretary of State,,R,Kris Kobach,28
-Shawnee,Ward 4 Precinct 4,Secretary of State,,R,Kris Kobach,50
-Shawnee,Ward 4 Precinct 6,Secretary of State,,R,Kris Kobach,74
-Shawnee,Ward 4 Precinct 7,Secretary of State,,R,Kris Kobach,46
-Shawnee,Ward 4 Precinct 8,Secretary of State,,R,Kris Kobach,69
-Shawnee,Ward 4 Precinct 9,Secretary of State,,R,Kris Kobach,59
-Shawnee,Ward 4 Precinct 10,Secretary of State,,R,Kris Kobach,83
-Shawnee,Ward 4 Precinct 11,Secretary of State,,R,Kris Kobach,45
-Shawnee,Ward 4 Precinct 12,Secretary of State,,R,Kris Kobach,2
-Shawnee,Ward 4 Precinct 15,Secretary of State,,R,Kris Kobach,70
-Shawnee,Ward 5 Precinct 1,Secretary of State,,R,Kris Kobach,59
-Shawnee,Ward 5 Precinct 2,Secretary of State,,R,Kris Kobach,70
-Shawnee,Ward 5 Precinct 3,Secretary of State,,R,Kris Kobach,85
-Shawnee,Ward 5 Precinct 4,Secretary of State,,R,Kris Kobach,72
-Shawnee,Ward 5 Precinct 5,Secretary of State,,R,Kris Kobach,68
-Shawnee,Ward 5 Precinct 6,Secretary of State,,R,Kris Kobach,50
-Shawnee,Ward 5 Precinct 7,Secretary of State,,R,Kris Kobach,65
-Shawnee,Ward 5 Precinct 8,Secretary of State,,R,Kris Kobach,69
-Shawnee,Ward 5 Precinct 9,Secretary of State,,R,Kris Kobach,167
-Shawnee,Ward 5 Precinct 10,Secretary of State,,R,Kris Kobach,239
-Shawnee,Ward 5 Precinct 11,Secretary of State,,R,Kris Kobach,168
-Shawnee,Ward 5 Precinct 14,Secretary of State,,R,Kris Kobach,132
-Shawnee,Ward 5 Precinct 15,Secretary of State,,R,Kris Kobach,34
-Shawnee,Ward 5 Precinct 91,Secretary of State,,R,Kris Kobach,42
-Shawnee,Ward 6 Precinct 1,Secretary of State,,R,Kris Kobach,41
-Shawnee,Ward 6 Precinct 2,Secretary of State,,R,Kris Kobach,56
-Shawnee,Ward 6 Precinct 3,Secretary of State,,R,Kris Kobach,193
-Shawnee,Ward 6 Precinct 4,Secretary of State,,R,Kris Kobach,90
-Shawnee,Ward 6 Precinct 5,Secretary of State,,R,Kris Kobach,144
-Shawnee,Ward 6 Precinct 6,Secretary of State,,R,Kris Kobach,70
-Shawnee,Ward 6 Precinct 7,Secretary of State,,R,Kris Kobach,58
-Shawnee,Ward 6 Precinct 8,Secretary of State,,R,Kris Kobach,85
-Shawnee,Ward 6 Precinct 9,Secretary of State,,R,Kris Kobach,311
-Shawnee,Ward 7 Precinct 1,Secretary of State,,R,Kris Kobach,110
-Shawnee,Ward 7 Precinct 2,Secretary of State,,R,Kris Kobach,92
-Shawnee,Ward 7 Precinct 3,Secretary of State,,R,Kris Kobach,106
-Shawnee,Ward 7 Precinct 4,Secretary of State,,R,Kris Kobach,140
-Shawnee,Ward 7 Precinct 5,Secretary of State,,R,Kris Kobach,121
-Shawnee,Ward 7 Precinct 6,Secretary of State,,R,Kris Kobach,108
-Shawnee,Ward 7 Precinct 7,Secretary of State,,R,Kris Kobach,86
-Shawnee,Ward 7 Precinct 9,Secretary of State,,R,Kris Kobach,98
-Shawnee,Ward 7 Precinct 10,Secretary of State,,R,Kris Kobach,79
-Shawnee,Ward 7 Precinct 11,Secretary of State,,R,Kris Kobach,136
-Shawnee,Ward 8 Precinct 1,Secretary of State,,R,Kris Kobach,67
-Shawnee,Ward 8 Precinct 2,Secretary of State,,R,Kris Kobach,77
-Shawnee,Ward 8 Precinct 3,Secretary of State,,R,Kris Kobach,110
-Shawnee,Ward 8 Precinct 4,Secretary of State,,R,Kris Kobach,124
-Shawnee,Ward 8 Precinct 5,Secretary of State,,R,Kris Kobach,189
-Shawnee,Ward 8 Precinct 6,Secretary of State,,R,Kris Kobach,115
-Shawnee,Ward 8 Precinct 7,Secretary of State,,R,Kris Kobach,62
-Shawnee,Ward 8 Precinct 8,Secretary of State,,R,Kris Kobach,92
-Shawnee,Ward 8 Precinct 9,Secretary of State,,R,Kris Kobach,153
-Shawnee,Ward 8 Precinct 10,Secretary of State,,R,Kris Kobach,157
-Shawnee,Ward 8 Precinct 11,Secretary of State,,R,Kris Kobach,160
-Shawnee,Ward 9 Precinct 1,Secretary of State,,R,Kris Kobach,24
-Shawnee,Ward 9 Precinct 2,Secretary of State,,R,Kris Kobach,85
-Shawnee,Ward 9 Precinct 3,Secretary of State,,R,Kris Kobach,172
-Shawnee,Ward 9 Precinct 4,Secretary of State,,R,Kris Kobach,139
-Shawnee,Ward 9 Precinct 5,Secretary of State,,R,Kris Kobach,108
-Shawnee,Ward 9 Precinct 6,Secretary of State,,R,Kris Kobach,144
-Shawnee,Ward 9 Precinct 8,Secretary of State,,R,Kris Kobach,167
-Shawnee,Ward 9 Precinct 9,Secretary of State,,R,Kris Kobach,118
-Shawnee,Ward 9 Precinct 10,Secretary of State,,R,Kris Kobach,221
-Shawnee,Ward 9 Precinct 11,Secretary of State,,R,Kris Kobach,120
-Shawnee,Ward 9 Precinct 12,Secretary of State,,R,Kris Kobach,59
-Shawnee,Ward 10 Precinct 1,Secretary of State,,R,Kris Kobach,125
-Shawnee,Ward 10 Precinct 2,Secretary of State,,R,Kris Kobach,191
-Shawnee,Ward 10 Precinct 3,Secretary of State,,R,Kris Kobach,270
-Shawnee,Ward 10 Precinct 4,Secretary of State,,R,Kris Kobach,145
-Shawnee,Ward 10 Precinct 5,Secretary of State,,R,Kris Kobach,126
-Shawnee,Ward 10 Precinct 6,Secretary of State,,R,Kris Kobach,141
-Shawnee,Ward 10 Precinct 7,Secretary of State,,R,Kris Kobach,147
-Shawnee,Ward 10 Precinct 8,Secretary of State,,R,Kris Kobach,112
-Shawnee,Ward 10 Precinct 9,Secretary of State,,R,Kris Kobach,97
-Shawnee,Ward 10 Precinct 10,Secretary of State,,R,Kris Kobach,144
-Shawnee,Ward 10 Precinct 11,Secretary of State,,R,Kris Kobach,205
-Shawnee,Ward 10 Precinct 14,Secretary of State,,R,Kris Kobach,139
-Shawnee,Ward 11 Precinct 1,Secretary of State,,R,Kris Kobach,115
-Shawnee,Ward 11 Precinct 2,Secretary of State,,R,Kris Kobach,139
-Shawnee,Ward 11 Precinct 3,Secretary of State,,R,Kris Kobach,91
-Shawnee,Ward 11 Precinct 4,Secretary of State,,R,Kris Kobach,208
-Shawnee,Ward 11 Precinct 5,Secretary of State,,R,Kris Kobach,141
-Shawnee,Ward 11 Precinct 6,Secretary of State,,R,Kris Kobach,128
-Shawnee,Ward 11 Precinct 7,Secretary of State,,R,Kris Kobach,140
-Shawnee,Ward 11 Precinct 8,Secretary of State,,R,Kris Kobach,146
-Shawnee,Ward 11 Precinct 9,Secretary of State,,R,Kris Kobach,136
-Shawnee,Ward 11 Precinct 10,Secretary of State,,R,Kris Kobach,91
-Shawnee,Ward 12 Precinct 1,Secretary of State,,R,Kris Kobach,108
-Shawnee,Ward 12 Precinct 2,Secretary of State,,R,Kris Kobach,85
-Shawnee,Ward 12 Precinct 3,Secretary of State,,R,Kris Kobach,172
-Shawnee,Ward 12 Precinct 4,Secretary of State,,R,Kris Kobach,236
-Shawnee,Ward 12 Precinct 5,Secretary of State,,R,Kris Kobach,200
-Shawnee,Ward 12 Precinct 6,Secretary of State,,R,Kris Kobach,199
-Shawnee,Ward 12 Precinct 7,Secretary of State,,R,Kris Kobach,185
-Shawnee,Ward 12 Precinct 8,Secretary of State,,R,Kris Kobach,193
-Shawnee,Ward 12 Precinct 9,Secretary of State,,R,Kris Kobach,304
-Shawnee,Ward 12 Precinct 11,Secretary of State,,R,Kris Kobach,322
-Shawnee,Ward 12 Precinct 13,Secretary of State,,R,Kris Kobach,245
-Shawnee,Ward 12 Precinct 14,Secretary of State,,R,Kris Kobach,187
-Shawnee,Ward 12 Precinct 15,Secretary of State,,R,Kris Kobach,309
-Shawnee,Ward 12 Precinct 16,Secretary of State,,R,Kris Kobach,287
-Shawnee,Ward 12 Precinct 19,Secretary of State,,R,Kris Kobach,48
-Shawnee,Ward 12 Precinct 20,Secretary of State,,R,Kris Kobach,242
-Shawnee,Ward 12 Precinct 31,Secretary of State,,R,Kris Kobach,159
-Shawnee,Ward 13 Precinct 2,Secretary of State,,R,Kris Kobach,49
-Shawnee,Ward 13 Precinct 5,Secretary of State,,R,Kris Kobach,7
-Shawnee,Ward 13 Precinct 6,Secretary of State,,R,Kris Kobach,80
-Shawnee,Ward 13 Precinct 9,Secretary of State,,R,Kris Kobach,50
-Shawnee,Ward 13 Precinct 12,Secretary of State,,R,Kris Kobach,306
-Shawnee,Ward 13 Precinct 21,Secretary of State,,R,Kris Kobach,33
-Shawnee,Ward 13 Precinct 22,Secretary of State,,R,Kris Kobach,39
-Shawnee,Ward 13 Precinct 30,Secretary of State,,R,Kris Kobach,62
-Shawnee,Ward 14 Precinct 1,Secretary of State,,R,Kris Kobach,286
-Shawnee,Ward 14 Precinct 2,Secretary of State,,R,Kris Kobach,239
-Shawnee,Ward 14 Precinct 3,Secretary of State,,R,Kris Kobach,184
-Shawnee,Ward 14 Precinct 4,Secretary of State,,R,Kris Kobach,387
-Shawnee,Ward 14 Precinct 5,Secretary of State,,R,Kris Kobach,223
-Shawnee,Ward 15 Precinct 1,Secretary of State,,R,Kris Kobach,218
-Shawnee,Ward 15 Precinct 2,Secretary of State,,R,Kris Kobach,138
-Shawnee,Ward 15 Precinct 3,Secretary of State,,R,Kris Kobach,14
-Shawnee,Ward 1 Precinct 1,Secretary of State,,D,Jean Schodorf,98
-Shawnee,Ward 1 Precinct 2,Secretary of State,,D,Jean Schodorf,122
-Shawnee,Ward 1 Precinct 3,Secretary of State,,D,Jean Schodorf,102
-Shawnee,Ward 1 Precinct 4,Secretary of State,,D,Jean Schodorf,124
-Shawnee,Ward 1 Precinct 5,Secretary of State,,D,Jean Schodorf,143
-Shawnee,Ward 1 Precinct 6,Secretary of State,,D,Jean Schodorf,202
-Shawnee,Ward 2 Precinct 1,Secretary of State,,D,Jean Schodorf,127
-Shawnee,Ward 2 Precinct 2,Secretary of State,,D,Jean Schodorf,115
-Shawnee,Ward 2 Precinct 3,Secretary of State,,D,Jean Schodorf,118
-Shawnee,Ward 2 Precinct 4,Secretary of State,,D,Jean Schodorf,109
-Shawnee,Ward 2 Precinct 5,Secretary of State,,D,Jean Schodorf,128
-Shawnee,Ward 2 Precinct 6,Secretary of State,,D,Jean Schodorf,92
-Shawnee,Ward 2 Precinct 7,Secretary of State,,D,Jean Schodorf,67
-Shawnee,Ward 2 Precinct 8,Secretary of State,,D,Jean Schodorf,87
-Shawnee,Ward 2 Precinct 9,Secretary of State,,D,Jean Schodorf,129
-Shawnee,Ward 2 Precinct 10,Secretary of State,,D,Jean Schodorf,209
-Shawnee,Ward 2 Precinct 11,Secretary of State,,D,Jean Schodorf,92
-Shawnee,Ward 3 Precinct 1,Secretary of State,,D,Jean Schodorf,109
-Shawnee,Ward 3 Precinct 2,Secretary of State,,D,Jean Schodorf,149
-Shawnee,Ward 3 Precinct 3,Secretary of State,,D,Jean Schodorf,93
-Shawnee,Ward 3 Precinct 4,Secretary of State,,D,Jean Schodorf,108
-Shawnee,Ward 3 Precinct 5,Secretary of State,,D,Jean Schodorf,77
-Shawnee,Ward 3 Precinct 6,Secretary of State,,D,Jean Schodorf,90
-Shawnee,Ward 3 Precinct 7,Secretary of State,,D,Jean Schodorf,99
-Shawnee,Ward 3 Precinct 8,Secretary of State,,D,Jean Schodorf,120
-Shawnee,Ward 3 Precinct 9,Secretary of State,,D,Jean Schodorf,120
-Shawnee,Ward 3 Precinct 10,Secretary of State,,D,Jean Schodorf,9
-Shawnee,Ward 4 Precinct 1,Secretary of State,,D,Jean Schodorf,115
-Shawnee,Ward 4 Precinct 2,Secretary of State,,D,Jean Schodorf,133
-Shawnee,Ward 4 Precinct 3,Secretary of State,,D,Jean Schodorf,98
-Shawnee,Ward 4 Precinct 4,Secretary of State,,D,Jean Schodorf,168
-Shawnee,Ward 4 Precinct 6,Secretary of State,,D,Jean Schodorf,145
-Shawnee,Ward 4 Precinct 7,Secretary of State,,D,Jean Schodorf,79
-Shawnee,Ward 4 Precinct 8,Secretary of State,,D,Jean Schodorf,106
-Shawnee,Ward 4 Precinct 9,Secretary of State,,D,Jean Schodorf,143
-Shawnee,Ward 4 Precinct 10,Secretary of State,,D,Jean Schodorf,173
-Shawnee,Ward 4 Precinct 11,Secretary of State,,D,Jean Schodorf,53
-Shawnee,Ward 4 Precinct 12,Secretary of State,,D,Jean Schodorf,14
-Shawnee,Ward 4 Precinct 15,Secretary of State,,D,Jean Schodorf,67
-Shawnee,Ward 5 Precinct 1,Secretary of State,,D,Jean Schodorf,110
-Shawnee,Ward 5 Precinct 2,Secretary of State,,D,Jean Schodorf,108
-Shawnee,Ward 5 Precinct 3,Secretary of State,,D,Jean Schodorf,108
-Shawnee,Ward 5 Precinct 4,Secretary of State,,D,Jean Schodorf,141
-Shawnee,Ward 5 Precinct 5,Secretary of State,,D,Jean Schodorf,139
-Shawnee,Ward 5 Precinct 6,Secretary of State,,D,Jean Schodorf,95
-Shawnee,Ward 5 Precinct 7,Secretary of State,,D,Jean Schodorf,148
-Shawnee,Ward 5 Precinct 8,Secretary of State,,D,Jean Schodorf,99
-Shawnee,Ward 5 Precinct 9,Secretary of State,,D,Jean Schodorf,180
-Shawnee,Ward 5 Precinct 10,Secretary of State,,D,Jean Schodorf,200
-Shawnee,Ward 5 Precinct 11,Secretary of State,,D,Jean Schodorf,167
-Shawnee,Ward 5 Precinct 14,Secretary of State,,D,Jean Schodorf,83
-Shawnee,Ward 5 Precinct 15,Secretary of State,,D,Jean Schodorf,18
-Shawnee,Ward 5 Precinct 91,Secretary of State,,D,Jean Schodorf,46
-Shawnee,Ward 6 Precinct 1,Secretary of State,,D,Jean Schodorf,115
-Shawnee,Ward 6 Precinct 2,Secretary of State,,D,Jean Schodorf,106
-Shawnee,Ward 6 Precinct 3,Secretary of State,,D,Jean Schodorf,168
-Shawnee,Ward 6 Precinct 4,Secretary of State,,D,Jean Schodorf,132
-Shawnee,Ward 6 Precinct 5,Secretary of State,,D,Jean Schodorf,179
-Shawnee,Ward 6 Precinct 6,Secretary of State,,D,Jean Schodorf,83
-Shawnee,Ward 6 Precinct 7,Secretary of State,,D,Jean Schodorf,62
-Shawnee,Ward 6 Precinct 8,Secretary of State,,D,Jean Schodorf,153
-Shawnee,Ward 6 Precinct 9,Secretary of State,,D,Jean Schodorf,286
-Shawnee,Ward 7 Precinct 1,Secretary of State,,D,Jean Schodorf,199
-Shawnee,Ward 7 Precinct 2,Secretary of State,,D,Jean Schodorf,156
-Shawnee,Ward 7 Precinct 3,Secretary of State,,D,Jean Schodorf,150
-Shawnee,Ward 7 Precinct 4,Secretary of State,,D,Jean Schodorf,153
-Shawnee,Ward 7 Precinct 5,Secretary of State,,D,Jean Schodorf,124
-Shawnee,Ward 7 Precinct 6,Secretary of State,,D,Jean Schodorf,98
-Shawnee,Ward 7 Precinct 7,Secretary of State,,D,Jean Schodorf,107
-Shawnee,Ward 7 Precinct 9,Secretary of State,,D,Jean Schodorf,115
-Shawnee,Ward 7 Precinct 10,Secretary of State,,D,Jean Schodorf,145
-Shawnee,Ward 7 Precinct 11,Secretary of State,,D,Jean Schodorf,220
-Shawnee,Ward 8 Precinct 1,Secretary of State,,D,Jean Schodorf,133
-Shawnee,Ward 8 Precinct 2,Secretary of State,,D,Jean Schodorf,168
-Shawnee,Ward 8 Precinct 3,Secretary of State,,D,Jean Schodorf,230
-Shawnee,Ward 8 Precinct 4,Secretary of State,,D,Jean Schodorf,193
-Shawnee,Ward 8 Precinct 5,Secretary of State,,D,Jean Schodorf,254
-Shawnee,Ward 8 Precinct 6,Secretary of State,,D,Jean Schodorf,143
-Shawnee,Ward 8 Precinct 7,Secretary of State,,D,Jean Schodorf,153
-Shawnee,Ward 8 Precinct 8,Secretary of State,,D,Jean Schodorf,157
-Shawnee,Ward 8 Precinct 9,Secretary of State,,D,Jean Schodorf,195
-Shawnee,Ward 8 Precinct 10,Secretary of State,,D,Jean Schodorf,119
-Shawnee,Ward 8 Precinct 11,Secretary of State,,D,Jean Schodorf,191
-Shawnee,Ward 9 Precinct 1,Secretary of State,,D,Jean Schodorf,34
-Shawnee,Ward 9 Precinct 2,Secretary of State,,D,Jean Schodorf,121
-Shawnee,Ward 9 Precinct 3,Secretary of State,,D,Jean Schodorf,241
-Shawnee,Ward 9 Precinct 4,Secretary of State,,D,Jean Schodorf,210
-Shawnee,Ward 9 Precinct 5,Secretary of State,,D,Jean Schodorf,154
-Shawnee,Ward 9 Precinct 6,Secretary of State,,D,Jean Schodorf,158
-Shawnee,Ward 9 Precinct 8,Secretary of State,,D,Jean Schodorf,202
-Shawnee,Ward 9 Precinct 9,Secretary of State,,D,Jean Schodorf,158
-Shawnee,Ward 9 Precinct 10,Secretary of State,,D,Jean Schodorf,290
-Shawnee,Ward 9 Precinct 11,Secretary of State,,D,Jean Schodorf,178
-Shawnee,Ward 9 Precinct 12,Secretary of State,,D,Jean Schodorf,82
-Shawnee,Ward 10 Precinct 1,Secretary of State,,D,Jean Schodorf,192
-Shawnee,Ward 10 Precinct 2,Secretary of State,,D,Jean Schodorf,158
-Shawnee,Ward 10 Precinct 3,Secretary of State,,D,Jean Schodorf,231
-Shawnee,Ward 10 Precinct 4,Secretary of State,,D,Jean Schodorf,152
-Shawnee,Ward 10 Precinct 5,Secretary of State,,D,Jean Schodorf,140
-Shawnee,Ward 10 Precinct 6,Secretary of State,,D,Jean Schodorf,130
-Shawnee,Ward 10 Precinct 7,Secretary of State,,D,Jean Schodorf,152
-Shawnee,Ward 10 Precinct 8,Secretary of State,,D,Jean Schodorf,142
-Shawnee,Ward 10 Precinct 9,Secretary of State,,D,Jean Schodorf,111
-Shawnee,Ward 10 Precinct 10,Secretary of State,,D,Jean Schodorf,145
-Shawnee,Ward 10 Precinct 11,Secretary of State,,D,Jean Schodorf,204
-Shawnee,Ward 10 Precinct 14,Secretary of State,,D,Jean Schodorf,164
-Shawnee,Ward 11 Precinct 1,Secretary of State,,D,Jean Schodorf,99
-Shawnee,Ward 11 Precinct 2,Secretary of State,,D,Jean Schodorf,156
-Shawnee,Ward 11 Precinct 3,Secretary of State,,D,Jean Schodorf,124
-Shawnee,Ward 11 Precinct 4,Secretary of State,,D,Jean Schodorf,202
-Shawnee,Ward 11 Precinct 5,Secretary of State,,D,Jean Schodorf,152
-Shawnee,Ward 11 Precinct 6,Secretary of State,,D,Jean Schodorf,153
-Shawnee,Ward 11 Precinct 7,Secretary of State,,D,Jean Schodorf,129
-Shawnee,Ward 11 Precinct 8,Secretary of State,,D,Jean Schodorf,119
-Shawnee,Ward 11 Precinct 9,Secretary of State,,D,Jean Schodorf,163
-Shawnee,Ward 11 Precinct 10,Secretary of State,,D,Jean Schodorf,106
-Shawnee,Ward 12 Precinct 1,Secretary of State,,D,Jean Schodorf,167
-Shawnee,Ward 12 Precinct 2,Secretary of State,,D,Jean Schodorf,119
-Shawnee,Ward 12 Precinct 3,Secretary of State,,D,Jean Schodorf,158
-Shawnee,Ward 12 Precinct 4,Secretary of State,,D,Jean Schodorf,193
-Shawnee,Ward 12 Precinct 5,Secretary of State,,D,Jean Schodorf,195
-Shawnee,Ward 12 Precinct 6,Secretary of State,,D,Jean Schodorf,229
-Shawnee,Ward 12 Precinct 7,Secretary of State,,D,Jean Schodorf,210
-Shawnee,Ward 12 Precinct 8,Secretary of State,,D,Jean Schodorf,201
-Shawnee,Ward 12 Precinct 9,Secretary of State,,D,Jean Schodorf,290
-Shawnee,Ward 12 Precinct 11,Secretary of State,,D,Jean Schodorf,286
-Shawnee,Ward 12 Precinct 13,Secretary of State,,D,Jean Schodorf,182
-Shawnee,Ward 12 Precinct 14,Secretary of State,,D,Jean Schodorf,137
-Shawnee,Ward 12 Precinct 15,Secretary of State,,D,Jean Schodorf,242
-Shawnee,Ward 12 Precinct 16,Secretary of State,,D,Jean Schodorf,291
-Shawnee,Ward 12 Precinct 19,Secretary of State,,D,Jean Schodorf,26
-Shawnee,Ward 12 Precinct 20,Secretary of State,,D,Jean Schodorf,188
-Shawnee,Ward 12 Precinct 31,Secretary of State,,D,Jean Schodorf,118
-Shawnee,Ward 13 Precinct 2,Secretary of State,,D,Jean Schodorf,60
-Shawnee,Ward 13 Precinct 5,Secretary of State,,D,Jean Schodorf,3
-Shawnee,Ward 13 Precinct 6,Secretary of State,,D,Jean Schodorf,31
-Shawnee,Ward 13 Precinct 9,Secretary of State,,D,Jean Schodorf,40
-Shawnee,Ward 13 Precinct 12,Secretary of State,,D,Jean Schodorf,219
-Shawnee,Ward 13 Precinct 21,Secretary of State,,D,Jean Schodorf,35
-Shawnee,Ward 13 Precinct 22,Secretary of State,,D,Jean Schodorf,25
-Shawnee,Ward 13 Precinct 30,Secretary of State,,D,Jean Schodorf,57
-Shawnee,Ward 14 Precinct 1,Secretary of State,,D,Jean Schodorf,261
-Shawnee,Ward 14 Precinct 2,Secretary of State,,D,Jean Schodorf,223
-Shawnee,Ward 14 Precinct 3,Secretary of State,,D,Jean Schodorf,118
-Shawnee,Ward 14 Precinct 4,Secretary of State,,D,Jean Schodorf,225
-Shawnee,Ward 14 Precinct 5,Secretary of State,,D,Jean Schodorf,128
-Shawnee,Ward 15 Precinct 1,Secretary of State,,D,Jean Schodorf,194
-Shawnee,Ward 15 Precinct 2,Secretary of State,,D,Jean Schodorf,167
-Shawnee,Ward 15 Precinct 3,Secretary of State,,D,Jean Schodorf,14
-Shawnee,Ward 1 Precinct 1,Attorney General,,R,Derek Schmidt,63
-Shawnee,Ward 1 Precinct 2,Attorney General,,R,Derek Schmidt,95
-Shawnee,Ward 1 Precinct 3,Attorney General,,R,Derek Schmidt,93
-Shawnee,Ward 1 Precinct 4,Attorney General,,R,Derek Schmidt,134
-Shawnee,Ward 1 Precinct 5,Attorney General,,R,Derek Schmidt,209
-Shawnee,Ward 1 Precinct 6,Attorney General,,R,Derek Schmidt,290
-Shawnee,Ward 2 Precinct 1,Attorney General,,R,Derek Schmidt,125
-Shawnee,Ward 2 Precinct 2,Attorney General,,R,Derek Schmidt,92
-Shawnee,Ward 2 Precinct 3,Attorney General,,R,Derek Schmidt,102
-Shawnee,Ward 2 Precinct 4,Attorney General,,R,Derek Schmidt,84
-Shawnee,Ward 2 Precinct 5,Attorney General,,R,Derek Schmidt,75
-Shawnee,Ward 2 Precinct 6,Attorney General,,R,Derek Schmidt,60
-Shawnee,Ward 2 Precinct 7,Attorney General,,R,Derek Schmidt,29
-Shawnee,Ward 2 Precinct 8,Attorney General,,R,Derek Schmidt,19
-Shawnee,Ward 2 Precinct 9,Attorney General,,R,Derek Schmidt,114
-Shawnee,Ward 2 Precinct 10,Attorney General,,R,Derek Schmidt,80
-Shawnee,Ward 2 Precinct 11,Attorney General,,R,Derek Schmidt,57
-Shawnee,Ward 3 Precinct 1,Attorney General,,R,Derek Schmidt,116
-Shawnee,Ward 3 Precinct 2,Attorney General,,R,Derek Schmidt,110
-Shawnee,Ward 3 Precinct 3,Attorney General,,R,Derek Schmidt,56
-Shawnee,Ward 3 Precinct 4,Attorney General,,R,Derek Schmidt,77
-Shawnee,Ward 3 Precinct 5,Attorney General,,R,Derek Schmidt,43
-Shawnee,Ward 3 Precinct 6,Attorney General,,R,Derek Schmidt,61
-Shawnee,Ward 3 Precinct 7,Attorney General,,R,Derek Schmidt,62
-Shawnee,Ward 3 Precinct 8,Attorney General,,R,Derek Schmidt,88
-Shawnee,Ward 3 Precinct 9,Attorney General,,R,Derek Schmidt,72
-Shawnee,Ward 3 Precinct 10,Attorney General,,R,Derek Schmidt,4
-Shawnee,Ward 4 Precinct 1,Attorney General,,R,Derek Schmidt,67
-Shawnee,Ward 4 Precinct 2,Attorney General,,R,Derek Schmidt,48
-Shawnee,Ward 4 Precinct 3,Attorney General,,R,Derek Schmidt,37
-Shawnee,Ward 4 Precinct 4,Attorney General,,R,Derek Schmidt,56
-Shawnee,Ward 4 Precinct 6,Attorney General,,R,Derek Schmidt,73
-Shawnee,Ward 4 Precinct 7,Attorney General,,R,Derek Schmidt,49
-Shawnee,Ward 4 Precinct 8,Attorney General,,R,Derek Schmidt,68
-Shawnee,Ward 4 Precinct 9,Attorney General,,R,Derek Schmidt,63
-Shawnee,Ward 4 Precinct 10,Attorney General,,R,Derek Schmidt,103
-Shawnee,Ward 4 Precinct 11,Attorney General,,R,Derek Schmidt,48
-Shawnee,Ward 4 Precinct 12,Attorney General,,R,Derek Schmidt,3
-Shawnee,Ward 4 Precinct 15,Attorney General,,R,Derek Schmidt,78
-Shawnee,Ward 5 Precinct 1,Attorney General,,R,Derek Schmidt,59
-Shawnee,Ward 5 Precinct 2,Attorney General,,R,Derek Schmidt,71
-Shawnee,Ward 5 Precinct 3,Attorney General,,R,Derek Schmidt,96
-Shawnee,Ward 5 Precinct 4,Attorney General,,R,Derek Schmidt,88
-Shawnee,Ward 5 Precinct 5,Attorney General,,R,Derek Schmidt,88
-Shawnee,Ward 5 Precinct 6,Attorney General,,R,Derek Schmidt,61
-Shawnee,Ward 5 Precinct 7,Attorney General,,R,Derek Schmidt,72
-Shawnee,Ward 5 Precinct 8,Attorney General,,R,Derek Schmidt,77
-Shawnee,Ward 5 Precinct 9,Attorney General,,R,Derek Schmidt,197
-Shawnee,Ward 5 Precinct 10,Attorney General,,R,Derek Schmidt,279
-Shawnee,Ward 5 Precinct 11,Attorney General,,R,Derek Schmidt,184
-Shawnee,Ward 5 Precinct 14,Attorney General,,R,Derek Schmidt,153
-Shawnee,Ward 5 Precinct 15,Attorney General,,R,Derek Schmidt,35
-Shawnee,Ward 5 Precinct 91,Attorney General,,R,Derek Schmidt,47
-Shawnee,Ward 6 Precinct 1,Attorney General,,R,Derek Schmidt,49
-Shawnee,Ward 6 Precinct 2,Attorney General,,R,Derek Schmidt,63
-Shawnee,Ward 6 Precinct 3,Attorney General,,R,Derek Schmidt,231
-Shawnee,Ward 6 Precinct 4,Attorney General,,R,Derek Schmidt,116
-Shawnee,Ward 6 Precinct 5,Attorney General,,R,Derek Schmidt,174
-Shawnee,Ward 6 Precinct 6,Attorney General,,R,Derek Schmidt,81
-Shawnee,Ward 6 Precinct 7,Attorney General,,R,Derek Schmidt,68
-Shawnee,Ward 6 Precinct 8,Attorney General,,R,Derek Schmidt,105
-Shawnee,Ward 6 Precinct 9,Attorney General,,R,Derek Schmidt,358
-Shawnee,Ward 7 Precinct 1,Attorney General,,R,Derek Schmidt,156
-Shawnee,Ward 7 Precinct 2,Attorney General,,R,Derek Schmidt,107
-Shawnee,Ward 7 Precinct 3,Attorney General,,R,Derek Schmidt,122
-Shawnee,Ward 7 Precinct 4,Attorney General,,R,Derek Schmidt,158
-Shawnee,Ward 7 Precinct 5,Attorney General,,R,Derek Schmidt,144
-Shawnee,Ward 7 Precinct 6,Attorney General,,R,Derek Schmidt,116
-Shawnee,Ward 7 Precinct 7,Attorney General,,R,Derek Schmidt,96
-Shawnee,Ward 7 Precinct 9,Attorney General,,R,Derek Schmidt,115
-Shawnee,Ward 7 Precinct 10,Attorney General,,R,Derek Schmidt,88
-Shawnee,Ward 7 Precinct 11,Attorney General,,R,Derek Schmidt,171
-Shawnee,Ward 8 Precinct 1,Attorney General,,R,Derek Schmidt,82
-Shawnee,Ward 8 Precinct 2,Attorney General,,R,Derek Schmidt,88
-Shawnee,Ward 8 Precinct 3,Attorney General,,R,Derek Schmidt,135
-Shawnee,Ward 8 Precinct 4,Attorney General,,R,Derek Schmidt,153
-Shawnee,Ward 8 Precinct 5,Attorney General,,R,Derek Schmidt,243
-Shawnee,Ward 8 Precinct 6,Attorney General,,R,Derek Schmidt,168
-Shawnee,Ward 8 Precinct 7,Attorney General,,R,Derek Schmidt,93
-Shawnee,Ward 8 Precinct 8,Attorney General,,R,Derek Schmidt,116
-Shawnee,Ward 8 Precinct 9,Attorney General,,R,Derek Schmidt,184
-Shawnee,Ward 8 Precinct 10,Attorney General,,R,Derek Schmidt,181
-Shawnee,Ward 8 Precinct 11,Attorney General,,R,Derek Schmidt,199
-Shawnee,Ward 9 Precinct 1,Attorney General,,R,Derek Schmidt,35
-Shawnee,Ward 9 Precinct 2,Attorney General,,R,Derek Schmidt,101
-Shawnee,Ward 9 Precinct 3,Attorney General,,R,Derek Schmidt,239
-Shawnee,Ward 9 Precinct 4,Attorney General,,R,Derek Schmidt,187
-Shawnee,Ward 9 Precinct 5,Attorney General,,R,Derek Schmidt,143
-Shawnee,Ward 9 Precinct 6,Attorney General,,R,Derek Schmidt,165
-Shawnee,Ward 9 Precinct 8,Attorney General,,R,Derek Schmidt,190
-Shawnee,Ward 9 Precinct 9,Attorney General,,R,Derek Schmidt,170
-Shawnee,Ward 9 Precinct 10,Attorney General,,R,Derek Schmidt,286
-Shawnee,Ward 9 Precinct 11,Attorney General,,R,Derek Schmidt,187
-Shawnee,Ward 9 Precinct 12,Attorney General,,R,Derek Schmidt,66
-Shawnee,Ward 10 Precinct 1,Attorney General,,R,Derek Schmidt,155
-Shawnee,Ward 10 Precinct 2,Attorney General,,R,Derek Schmidt,233
-Shawnee,Ward 10 Precinct 3,Attorney General,,R,Derek Schmidt,307
-Shawnee,Ward 10 Precinct 4,Attorney General,,R,Derek Schmidt,166
-Shawnee,Ward 10 Precinct 5,Attorney General,,R,Derek Schmidt,138
-Shawnee,Ward 10 Precinct 6,Attorney General,,R,Derek Schmidt,167
-Shawnee,Ward 10 Precinct 7,Attorney General,,R,Derek Schmidt,162
-Shawnee,Ward 10 Precinct 8,Attorney General,,R,Derek Schmidt,147
-Shawnee,Ward 10 Precinct 9,Attorney General,,R,Derek Schmidt,102
-Shawnee,Ward 10 Precinct 10,Attorney General,,R,Derek Schmidt,164
-Shawnee,Ward 10 Precinct 11,Attorney General,,R,Derek Schmidt,241
-Shawnee,Ward 10 Precinct 14,Attorney General,,R,Derek Schmidt,172
-Shawnee,Ward 11 Precinct 1,Attorney General,,R,Derek Schmidt,135
-Shawnee,Ward 11 Precinct 2,Attorney General,,R,Derek Schmidt,171
-Shawnee,Ward 11 Precinct 3,Attorney General,,R,Derek Schmidt,118
-Shawnee,Ward 11 Precinct 4,Attorney General,,R,Derek Schmidt,228
-Shawnee,Ward 11 Precinct 5,Attorney General,,R,Derek Schmidt,160
-Shawnee,Ward 11 Precinct 6,Attorney General,,R,Derek Schmidt,156
-Shawnee,Ward 11 Precinct 7,Attorney General,,R,Derek Schmidt,147
-Shawnee,Ward 11 Precinct 8,Attorney General,,R,Derek Schmidt,165
-Shawnee,Ward 11 Precinct 9,Attorney General,,R,Derek Schmidt,160
-Shawnee,Ward 11 Precinct 10,Attorney General,,R,Derek Schmidt,93
-Shawnee,Ward 12 Precinct 1,Attorney General,,R,Derek Schmidt,131
-Shawnee,Ward 12 Precinct 2,Attorney General,,R,Derek Schmidt,95
-Shawnee,Ward 12 Precinct 3,Attorney General,,R,Derek Schmidt,208
-Shawnee,Ward 12 Precinct 4,Attorney General,,R,Derek Schmidt,276
-Shawnee,Ward 12 Precinct 5,Attorney General,,R,Derek Schmidt,267
-Shawnee,Ward 12 Precinct 6,Attorney General,,R,Derek Schmidt,234
-Shawnee,Ward 12 Precinct 7,Attorney General,,R,Derek Schmidt,226
-Shawnee,Ward 12 Precinct 8,Attorney General,,R,Derek Schmidt,211
-Shawnee,Ward 12 Precinct 9,Attorney General,,R,Derek Schmidt,358
-Shawnee,Ward 12 Precinct 11,Attorney General,,R,Derek Schmidt,412
-Shawnee,Ward 12 Precinct 13,Attorney General,,R,Derek Schmidt,306
-Shawnee,Ward 12 Precinct 14,Attorney General,,R,Derek Schmidt,204
-Shawnee,Ward 12 Precinct 15,Attorney General,,R,Derek Schmidt,352
-Shawnee,Ward 12 Precinct 16,Attorney General,,R,Derek Schmidt,338
-Shawnee,Ward 12 Precinct 19,Attorney General,,R,Derek Schmidt,53
-Shawnee,Ward 12 Precinct 20,Attorney General,,R,Derek Schmidt,264
-Shawnee,Ward 12 Precinct 31,Attorney General,,R,Derek Schmidt,175
-Shawnee,Ward 13 Precinct 2,Attorney General,,R,Derek Schmidt,52
-Shawnee,Ward 13 Precinct 5,Attorney General,,R,Derek Schmidt,9
-Shawnee,Ward 13 Precinct 6,Attorney General,,R,Derek Schmidt,81
-Shawnee,Ward 13 Precinct 9,Attorney General,,R,Derek Schmidt,69
-Shawnee,Ward 13 Precinct 12,Attorney General,,R,Derek Schmidt,363
-Shawnee,Ward 13 Precinct 21,Attorney General,,R,Derek Schmidt,34
-Shawnee,Ward 13 Precinct 22,Attorney General,,R,Derek Schmidt,37
-Shawnee,Ward 13 Precinct 30,Attorney General,,R,Derek Schmidt,75
-Shawnee,Ward 14 Precinct 1,Attorney General,,R,Derek Schmidt,344
-Shawnee,Ward 14 Precinct 2,Attorney General,,R,Derek Schmidt,298
-Shawnee,Ward 14 Precinct 3,Attorney General,,R,Derek Schmidt,209
-Shawnee,Ward 14 Precinct 4,Attorney General,,R,Derek Schmidt,440
-Shawnee,Ward 14 Precinct 5,Attorney General,,R,Derek Schmidt,268
-Shawnee,Ward 15 Precinct 1,Attorney General,,R,Derek Schmidt,249
-Shawnee,Ward 15 Precinct 2,Attorney General,,R,Derek Schmidt,170
-Shawnee,Ward 15 Precinct 3,Attorney General,,R,Derek Schmidt,18
-Shawnee,Ward 1 Precinct 1,Attorney General,,D,A J Kotich,105
-Shawnee,Ward 1 Precinct 2,Attorney General,,D,A J Kotich,112
-Shawnee,Ward 1 Precinct 3,Attorney General,,D,A J Kotich,78
-Shawnee,Ward 1 Precinct 4,Attorney General,,D,A J Kotich,108
-Shawnee,Ward 1 Precinct 5,Attorney General,,D,A J Kotich,151
-Shawnee,Ward 1 Precinct 6,Attorney General,,D,A J Kotich,164
-Shawnee,Ward 2 Precinct 1,Attorney General,,D,A J Kotich,117
-Shawnee,Ward 2 Precinct 2,Attorney General,,D,A J Kotich,115
-Shawnee,Ward 2 Precinct 3,Attorney General,,D,A J Kotich,111
-Shawnee,Ward 2 Precinct 4,Attorney General,,D,A J Kotich,105
-Shawnee,Ward 2 Precinct 5,Attorney General,,D,A J Kotich,117
-Shawnee,Ward 2 Precinct 6,Attorney General,,D,A J Kotich,90
-Shawnee,Ward 2 Precinct 7,Attorney General,,D,A J Kotich,64
-Shawnee,Ward 2 Precinct 8,Attorney General,,D,A J Kotich,82
-Shawnee,Ward 2 Precinct 9,Attorney General,,D,A J Kotich,129
-Shawnee,Ward 2 Precinct 10,Attorney General,,D,A J Kotich,197
-Shawnee,Ward 2 Precinct 11,Attorney General,,D,A J Kotich,93
-Shawnee,Ward 3 Precinct 1,Attorney General,,D,A J Kotich,103
-Shawnee,Ward 3 Precinct 2,Attorney General,,D,A J Kotich,135
-Shawnee,Ward 3 Precinct 3,Attorney General,,D,A J Kotich,90
-Shawnee,Ward 3 Precinct 4,Attorney General,,D,A J Kotich,94
-Shawnee,Ward 3 Precinct 5,Attorney General,,D,A J Kotich,72
-Shawnee,Ward 3 Precinct 6,Attorney General,,D,A J Kotich,78
-Shawnee,Ward 3 Precinct 7,Attorney General,,D,A J Kotich,93
-Shawnee,Ward 3 Precinct 8,Attorney General,,D,A J Kotich,108
-Shawnee,Ward 3 Precinct 9,Attorney General,,D,A J Kotich,115
-Shawnee,Ward 3 Precinct 10,Attorney General,,D,A J Kotich,9
-Shawnee,Ward 4 Precinct 1,Attorney General,,D,A J Kotich,109
-Shawnee,Ward 4 Precinct 2,Attorney General,,D,A J Kotich,127
-Shawnee,Ward 4 Precinct 3,Attorney General,,D,A J Kotich,88
-Shawnee,Ward 4 Precinct 4,Attorney General,,D,A J Kotich,158
-Shawnee,Ward 4 Precinct 6,Attorney General,,D,A J Kotich,145
-Shawnee,Ward 4 Precinct 7,Attorney General,,D,A J Kotich,75
-Shawnee,Ward 4 Precinct 8,Attorney General,,D,A J Kotich,106
-Shawnee,Ward 4 Precinct 9,Attorney General,,D,A J Kotich,136
-Shawnee,Ward 4 Precinct 10,Attorney General,,D,A J Kotich,150
-Shawnee,Ward 4 Precinct 11,Attorney General,,D,A J Kotich,49
-Shawnee,Ward 4 Precinct 12,Attorney General,,D,A J Kotich,12
-Shawnee,Ward 4 Precinct 15,Attorney General,,D,A J Kotich,59
-Shawnee,Ward 5 Precinct 1,Attorney General,,D,A J Kotich,109
-Shawnee,Ward 5 Precinct 2,Attorney General,,D,A J Kotich,106
-Shawnee,Ward 5 Precinct 3,Attorney General,,D,A J Kotich,95
-Shawnee,Ward 5 Precinct 4,Attorney General,,D,A J Kotich,127
-Shawnee,Ward 5 Precinct 5,Attorney General,,D,A J Kotich,118
-Shawnee,Ward 5 Precinct 6,Attorney General,,D,A J Kotich,82
-Shawnee,Ward 5 Precinct 7,Attorney General,,D,A J Kotich,140
-Shawnee,Ward 5 Precinct 8,Attorney General,,D,A J Kotich,93
-Shawnee,Ward 5 Precinct 9,Attorney General,,D,A J Kotich,145
-Shawnee,Ward 5 Precinct 10,Attorney General,,D,A J Kotich,159
-Shawnee,Ward 5 Precinct 11,Attorney General,,D,A J Kotich,147
-Shawnee,Ward 5 Precinct 14,Attorney General,,D,A J Kotich,63
-Shawnee,Ward 5 Precinct 15,Attorney General,,D,A J Kotich,16
-Shawnee,Ward 5 Precinct 91,Attorney General,,D,A J Kotich,43
-Shawnee,Ward 6 Precinct 1,Attorney General,,D,A J Kotich,106
-Shawnee,Ward 6 Precinct 2,Attorney General,,D,A J Kotich,99
-Shawnee,Ward 6 Precinct 3,Attorney General,,D,A J Kotich,125
-Shawnee,Ward 6 Precinct 4,Attorney General,,D,A J Kotich,103
-Shawnee,Ward 6 Precinct 5,Attorney General,,D,A J Kotich,145
-Shawnee,Ward 6 Precinct 6,Attorney General,,D,A J Kotich,74
-Shawnee,Ward 6 Precinct 7,Attorney General,,D,A J Kotich,53
-Shawnee,Ward 6 Precinct 8,Attorney General,,D,A J Kotich,129
-Shawnee,Ward 6 Precinct 9,Attorney General,,D,A J Kotich,237
-Shawnee,Ward 7 Precinct 1,Attorney General,,D,A J Kotich,148
-Shawnee,Ward 7 Precinct 2,Attorney General,,D,A J Kotich,134
-Shawnee,Ward 7 Precinct 3,Attorney General,,D,A J Kotich,130
-Shawnee,Ward 7 Precinct 4,Attorney General,,D,A J Kotich,137
-Shawnee,Ward 7 Precinct 5,Attorney General,,D,A J Kotich,98
-Shawnee,Ward 7 Precinct 6,Attorney General,,D,A J Kotich,88
-Shawnee,Ward 7 Precinct 7,Attorney General,,D,A J Kotich,98
-Shawnee,Ward 7 Precinct 9,Attorney General,,D,A J Kotich,97
-Shawnee,Ward 7 Precinct 10,Attorney General,,D,A J Kotich,128
-Shawnee,Ward 7 Precinct 11,Attorney General,,D,A J Kotich,174
-Shawnee,Ward 8 Precinct 1,Attorney General,,D,A J Kotich,118
-Shawnee,Ward 8 Precinct 2,Attorney General,,D,A J Kotich,152
-Shawnee,Ward 8 Precinct 3,Attorney General,,D,A J Kotich,203
-Shawnee,Ward 8 Precinct 4,Attorney General,,D,A J Kotich,162
-Shawnee,Ward 8 Precinct 5,Attorney General,,D,A J Kotich,194
-Shawnee,Ward 8 Precinct 6,Attorney General,,D,A J Kotich,92
-Shawnee,Ward 8 Precinct 7,Attorney General,,D,A J Kotich,117
-Shawnee,Ward 8 Precinct 8,Attorney General,,D,A J Kotich,130
-Shawnee,Ward 8 Precinct 9,Attorney General,,D,A J Kotich,163
-Shawnee,Ward 8 Precinct 10,Attorney General,,D,A J Kotich,94
-Shawnee,Ward 8 Precinct 11,Attorney General,,D,A J Kotich,148
-Shawnee,Ward 9 Precinct 1,Attorney General,,D,A J Kotich,24
-Shawnee,Ward 9 Precinct 2,Attorney General,,D,A J Kotich,104
-Shawnee,Ward 9 Precinct 3,Attorney General,,D,A J Kotich,170
-Shawnee,Ward 9 Precinct 4,Attorney General,,D,A J Kotich,162
-Shawnee,Ward 9 Precinct 5,Attorney General,,D,A J Kotich,118
-Shawnee,Ward 9 Precinct 6,Attorney General,,D,A J Kotich,132
-Shawnee,Ward 9 Precinct 8,Attorney General,,D,A J Kotich,171
-Shawnee,Ward 9 Precinct 9,Attorney General,,D,A J Kotich,106
-Shawnee,Ward 9 Precinct 10,Attorney General,,D,A J Kotich,223
-Shawnee,Ward 9 Precinct 11,Attorney General,,D,A J Kotich,106
-Shawnee,Ward 9 Precinct 12,Attorney General,,D,A J Kotich,74
-Shawnee,Ward 10 Precinct 1,Attorney General,,D,A J Kotich,158
-Shawnee,Ward 10 Precinct 2,Attorney General,,D,A J Kotich,111
-Shawnee,Ward 10 Precinct 3,Attorney General,,D,A J Kotich,182
-Shawnee,Ward 10 Precinct 4,Attorney General,,D,A J Kotich,129
-Shawnee,Ward 10 Precinct 5,Attorney General,,D,A J Kotich,120
-Shawnee,Ward 10 Precinct 6,Attorney General,,D,A J Kotich,105
-Shawnee,Ward 10 Precinct 7,Attorney General,,D,A J Kotich,131
-Shawnee,Ward 10 Precinct 8,Attorney General,,D,A J Kotich,105
-Shawnee,Ward 10 Precinct 9,Attorney General,,D,A J Kotich,105
-Shawnee,Ward 10 Precinct 10,Attorney General,,D,A J Kotich,121
-Shawnee,Ward 10 Precinct 11,Attorney General,,D,A J Kotich,165
-Shawnee,Ward 10 Precinct 14,Attorney General,,D,A J Kotich,128
-Shawnee,Ward 11 Precinct 1,Attorney General,,D,A J Kotich,79
-Shawnee,Ward 11 Precinct 2,Attorney General,,D,A J Kotich,119
-Shawnee,Ward 11 Precinct 3,Attorney General,,D,A J Kotich,95
-Shawnee,Ward 11 Precinct 4,Attorney General,,D,A J Kotich,177
-Shawnee,Ward 11 Precinct 5,Attorney General,,D,A J Kotich,132
-Shawnee,Ward 11 Precinct 6,Attorney General,,D,A J Kotich,124
-Shawnee,Ward 11 Precinct 7,Attorney General,,D,A J Kotich,121
-Shawnee,Ward 11 Precinct 8,Attorney General,,D,A J Kotich,100
-Shawnee,Ward 11 Precinct 9,Attorney General,,D,A J Kotich,138
-Shawnee,Ward 11 Precinct 10,Attorney General,,D,A J Kotich,102
-Shawnee,Ward 12 Precinct 1,Attorney General,,D,A J Kotich,141
-Shawnee,Ward 12 Precinct 2,Attorney General,,D,A J Kotich,107
-Shawnee,Ward 12 Precinct 3,Attorney General,,D,A J Kotich,118
-Shawnee,Ward 12 Precinct 4,Attorney General,,D,A J Kotich,147
-Shawnee,Ward 12 Precinct 5,Attorney General,,D,A J Kotich,122
-Shawnee,Ward 12 Precinct 6,Attorney General,,D,A J Kotich,185
-Shawnee,Ward 12 Precinct 7,Attorney General,,D,A J Kotich,164
-Shawnee,Ward 12 Precinct 8,Attorney General,,D,A J Kotich,176
-Shawnee,Ward 12 Precinct 9,Attorney General,,D,A J Kotich,228
-Shawnee,Ward 12 Precinct 11,Attorney General,,D,A J Kotich,195
-Shawnee,Ward 12 Precinct 13,Attorney General,,D,A J Kotich,121
-Shawnee,Ward 12 Precinct 14,Attorney General,,D,A J Kotich,119
-Shawnee,Ward 12 Precinct 15,Attorney General,,D,A J Kotich,198
-Shawnee,Ward 12 Precinct 16,Attorney General,,D,A J Kotich,244
-Shawnee,Ward 12 Precinct 19,Attorney General,,D,A J Kotich,21
-Shawnee,Ward 12 Precinct 20,Attorney General,,D,A J Kotich,160
-Shawnee,Ward 12 Precinct 31,Attorney General,,D,A J Kotich,101
-Shawnee,Ward 13 Precinct 2,Attorney General,,D,A J Kotich,55
-Shawnee,Ward 13 Precinct 5,Attorney General,,D,A J Kotich,4
-Shawnee,Ward 13 Precinct 6,Attorney General,,D,A J Kotich,28
-Shawnee,Ward 13 Precinct 9,Attorney General,,D,A J Kotich,18
-Shawnee,Ward 13 Precinct 12,Attorney General,,D,A J Kotich,154
-Shawnee,Ward 13 Precinct 21,Attorney General,,D,A J Kotich,33
-Shawnee,Ward 13 Precinct 22,Attorney General,,D,A J Kotich,25
-Shawnee,Ward 13 Precinct 30,Attorney General,,D,A J Kotich,43
-Shawnee,Ward 14 Precinct 1,Attorney General,,D,A J Kotich,200
-Shawnee,Ward 14 Precinct 2,Attorney General,,D,A J Kotich,161
-Shawnee,Ward 14 Precinct 3,Attorney General,,D,A J Kotich,89
-Shawnee,Ward 14 Precinct 4,Attorney General,,D,A J Kotich,162
-Shawnee,Ward 14 Precinct 5,Attorney General,,D,A J Kotich,79
-Shawnee,Ward 15 Precinct 1,Attorney General,,D,A J Kotich,159
-Shawnee,Ward 15 Precinct 2,Attorney General,,D,A J Kotich,133
-Shawnee,Ward 15 Precinct 3,Attorney General,,D,A J Kotich,10
-Shawnee,Ward 1 Precinct 1,State Treasurer,,R,Ron Estes,55
-Shawnee,Ward 1 Precinct 2,State Treasurer,,R,Ron Estes,78
-Shawnee,Ward 1 Precinct 3,State Treasurer,,R,Ron Estes,73
-Shawnee,Ward 1 Precinct 4,State Treasurer,,R,Ron Estes,111
-Shawnee,Ward 1 Precinct 5,State Treasurer,,R,Ron Estes,191
-Shawnee,Ward 1 Precinct 6,State Treasurer,,R,Ron Estes,279
-Shawnee,Ward 2 Precinct 1,State Treasurer,,R,Ron Estes,118
-Shawnee,Ward 2 Precinct 2,State Treasurer,,R,Ron Estes,83
-Shawnee,Ward 2 Precinct 3,State Treasurer,,R,Ron Estes,99
-Shawnee,Ward 2 Precinct 4,State Treasurer,,R,Ron Estes,80
-Shawnee,Ward 2 Precinct 5,State Treasurer,,R,Ron Estes,73
-Shawnee,Ward 2 Precinct 6,State Treasurer,,R,Ron Estes,55
-Shawnee,Ward 2 Precinct 7,State Treasurer,,R,Ron Estes,25
-Shawnee,Ward 2 Precinct 8,State Treasurer,,R,Ron Estes,16
-Shawnee,Ward 2 Precinct 9,State Treasurer,,R,Ron Estes,99
-Shawnee,Ward 2 Precinct 10,State Treasurer,,R,Ron Estes,72
-Shawnee,Ward 2 Precinct 11,State Treasurer,,R,Ron Estes,53
-Shawnee,Ward 3 Precinct 1,State Treasurer,,R,Ron Estes,97
-Shawnee,Ward 3 Precinct 2,State Treasurer,,R,Ron Estes,111
-Shawnee,Ward 3 Precinct 3,State Treasurer,,R,Ron Estes,49
-Shawnee,Ward 3 Precinct 4,State Treasurer,,R,Ron Estes,66
-Shawnee,Ward 3 Precinct 5,State Treasurer,,R,Ron Estes,39
-Shawnee,Ward 3 Precinct 6,State Treasurer,,R,Ron Estes,56
-Shawnee,Ward 3 Precinct 7,State Treasurer,,R,Ron Estes,52
-Shawnee,Ward 3 Precinct 8,State Treasurer,,R,Ron Estes,70
-Shawnee,Ward 3 Precinct 9,State Treasurer,,R,Ron Estes,72
-Shawnee,Ward 3 Precinct 10,State Treasurer,,R,Ron Estes,5
-Shawnee,Ward 4 Precinct 1,State Treasurer,,R,Ron Estes,52
-Shawnee,Ward 4 Precinct 2,State Treasurer,,R,Ron Estes,42
-Shawnee,Ward 4 Precinct 3,State Treasurer,,R,Ron Estes,32
-Shawnee,Ward 4 Precinct 4,State Treasurer,,R,Ron Estes,46
-Shawnee,Ward 4 Precinct 6,State Treasurer,,R,Ron Estes,68
-Shawnee,Ward 4 Precinct 7,State Treasurer,,R,Ron Estes,37
-Shawnee,Ward 4 Precinct 8,State Treasurer,,R,Ron Estes,62
-Shawnee,Ward 4 Precinct 9,State Treasurer,,R,Ron Estes,56
-Shawnee,Ward 4 Precinct 10,State Treasurer,,R,Ron Estes,89
-Shawnee,Ward 4 Precinct 11,State Treasurer,,R,Ron Estes,51
-Shawnee,Ward 4 Precinct 12,State Treasurer,,R,Ron Estes,2
-Shawnee,Ward 4 Precinct 15,State Treasurer,,R,Ron Estes,60
-Shawnee,Ward 5 Precinct 1,State Treasurer,,R,Ron Estes,57
-Shawnee,Ward 5 Precinct 2,State Treasurer,,R,Ron Estes,64
-Shawnee,Ward 5 Precinct 3,State Treasurer,,R,Ron Estes,87
-Shawnee,Ward 5 Precinct 4,State Treasurer,,R,Ron Estes,85
-Shawnee,Ward 5 Precinct 5,State Treasurer,,R,Ron Estes,73
-Shawnee,Ward 5 Precinct 6,State Treasurer,,R,Ron Estes,58
-Shawnee,Ward 5 Precinct 7,State Treasurer,,R,Ron Estes,60
-Shawnee,Ward 5 Precinct 8,State Treasurer,,R,Ron Estes,71
-Shawnee,Ward 5 Precinct 9,State Treasurer,,R,Ron Estes,174
-Shawnee,Ward 5 Precinct 10,State Treasurer,,R,Ron Estes,253
-Shawnee,Ward 5 Precinct 11,State Treasurer,,R,Ron Estes,179
-Shawnee,Ward 5 Precinct 14,State Treasurer,,R,Ron Estes,148
-Shawnee,Ward 5 Precinct 15,State Treasurer,,R,Ron Estes,34
-Shawnee,Ward 5 Precinct 91,State Treasurer,,R,Ron Estes,47
-Shawnee,Ward 6 Precinct 1,State Treasurer,,R,Ron Estes,41
-Shawnee,Ward 6 Precinct 2,State Treasurer,,R,Ron Estes,52
-Shawnee,Ward 6 Precinct 3,State Treasurer,,R,Ron Estes,231
-Shawnee,Ward 6 Precinct 4,State Treasurer,,R,Ron Estes,110
-Shawnee,Ward 6 Precinct 5,State Treasurer,,R,Ron Estes,169
-Shawnee,Ward 6 Precinct 6,State Treasurer,,R,Ron Estes,66
-Shawnee,Ward 6 Precinct 7,State Treasurer,,R,Ron Estes,57
-Shawnee,Ward 6 Precinct 8,State Treasurer,,R,Ron Estes,87
-Shawnee,Ward 6 Precinct 9,State Treasurer,,R,Ron Estes,340
-Shawnee,Ward 7 Precinct 1,State Treasurer,,R,Ron Estes,141
-Shawnee,Ward 7 Precinct 2,State Treasurer,,R,Ron Estes,108
-Shawnee,Ward 7 Precinct 3,State Treasurer,,R,Ron Estes,115
-Shawnee,Ward 7 Precinct 4,State Treasurer,,R,Ron Estes,149
-Shawnee,Ward 7 Precinct 5,State Treasurer,,R,Ron Estes,128
-Shawnee,Ward 7 Precinct 6,State Treasurer,,R,Ron Estes,115
-Shawnee,Ward 7 Precinct 7,State Treasurer,,R,Ron Estes,87
-Shawnee,Ward 7 Precinct 9,State Treasurer,,R,Ron Estes,115
-Shawnee,Ward 7 Precinct 10,State Treasurer,,R,Ron Estes,92
-Shawnee,Ward 7 Precinct 11,State Treasurer,,R,Ron Estes,169
-Shawnee,Ward 8 Precinct 1,State Treasurer,,R,Ron Estes,68
-Shawnee,Ward 8 Precinct 2,State Treasurer,,R,Ron Estes,96
-Shawnee,Ward 8 Precinct 3,State Treasurer,,R,Ron Estes,123
-Shawnee,Ward 8 Precinct 4,State Treasurer,,R,Ron Estes,146
-Shawnee,Ward 8 Precinct 5,State Treasurer,,R,Ron Estes,198
-Shawnee,Ward 8 Precinct 6,State Treasurer,,R,Ron Estes,164
-Shawnee,Ward 8 Precinct 7,State Treasurer,,R,Ron Estes,91
-Shawnee,Ward 8 Precinct 8,State Treasurer,,R,Ron Estes,111
-Shawnee,Ward 8 Precinct 9,State Treasurer,,R,Ron Estes,185
-Shawnee,Ward 8 Precinct 10,State Treasurer,,R,Ron Estes,168
-Shawnee,Ward 8 Precinct 11,State Treasurer,,R,Ron Estes,189
-Shawnee,Ward 9 Precinct 1,State Treasurer,,R,Ron Estes,30
-Shawnee,Ward 9 Precinct 2,State Treasurer,,R,Ron Estes,101
-Shawnee,Ward 9 Precinct 3,State Treasurer,,R,Ron Estes,219
-Shawnee,Ward 9 Precinct 4,State Treasurer,,R,Ron Estes,168
-Shawnee,Ward 9 Precinct 5,State Treasurer,,R,Ron Estes,131
-Shawnee,Ward 9 Precinct 6,State Treasurer,,R,Ron Estes,170
-Shawnee,Ward 9 Precinct 8,State Treasurer,,R,Ron Estes,190
-Shawnee,Ward 9 Precinct 9,State Treasurer,,R,Ron Estes,165
-Shawnee,Ward 9 Precinct 10,State Treasurer,,R,Ron Estes,280
-Shawnee,Ward 9 Precinct 11,State Treasurer,,R,Ron Estes,172
-Shawnee,Ward 9 Precinct 12,State Treasurer,,R,Ron Estes,63
-Shawnee,Ward 10 Precinct 1,State Treasurer,,R,Ron Estes,155
-Shawnee,Ward 10 Precinct 2,State Treasurer,,R,Ron Estes,230
-Shawnee,Ward 10 Precinct 3,State Treasurer,,R,Ron Estes,296
-Shawnee,Ward 10 Precinct 4,State Treasurer,,R,Ron Estes,154
-Shawnee,Ward 10 Precinct 5,State Treasurer,,R,Ron Estes,134
-Shawnee,Ward 10 Precinct 6,State Treasurer,,R,Ron Estes,156
-Shawnee,Ward 10 Precinct 7,State Treasurer,,R,Ron Estes,162
-Shawnee,Ward 10 Precinct 8,State Treasurer,,R,Ron Estes,127
-Shawnee,Ward 10 Precinct 9,State Treasurer,,R,Ron Estes,98
-Shawnee,Ward 10 Precinct 10,State Treasurer,,R,Ron Estes,156
-Shawnee,Ward 10 Precinct 11,State Treasurer,,R,Ron Estes,228
-Shawnee,Ward 10 Precinct 14,State Treasurer,,R,Ron Estes,174
-Shawnee,Ward 11 Precinct 1,State Treasurer,,R,Ron Estes,119
-Shawnee,Ward 11 Precinct 2,State Treasurer,,R,Ron Estes,153
-Shawnee,Ward 11 Precinct 3,State Treasurer,,R,Ron Estes,111
-Shawnee,Ward 11 Precinct 4,State Treasurer,,R,Ron Estes,235
-Shawnee,Ward 11 Precinct 5,State Treasurer,,R,Ron Estes,155
-Shawnee,Ward 11 Precinct 6,State Treasurer,,R,Ron Estes,151
-Shawnee,Ward 11 Precinct 7,State Treasurer,,R,Ron Estes,147
-Shawnee,Ward 11 Precinct 8,State Treasurer,,R,Ron Estes,161
-Shawnee,Ward 11 Precinct 9,State Treasurer,,R,Ron Estes,150
-Shawnee,Ward 11 Precinct 10,State Treasurer,,R,Ron Estes,90
-Shawnee,Ward 12 Precinct 1,State Treasurer,,R,Ron Estes,124
-Shawnee,Ward 12 Precinct 2,State Treasurer,,R,Ron Estes,91
-Shawnee,Ward 12 Precinct 3,State Treasurer,,R,Ron Estes,214
-Shawnee,Ward 12 Precinct 4,State Treasurer,,R,Ron Estes,267
-Shawnee,Ward 12 Precinct 5,State Treasurer,,R,Ron Estes,258
-Shawnee,Ward 12 Precinct 6,State Treasurer,,R,Ron Estes,222
-Shawnee,Ward 12 Precinct 7,State Treasurer,,R,Ron Estes,216
-Shawnee,Ward 12 Precinct 8,State Treasurer,,R,Ron Estes,218
-Shawnee,Ward 12 Precinct 9,State Treasurer,,R,Ron Estes,343
-Shawnee,Ward 12 Precinct 11,State Treasurer,,R,Ron Estes,382
-Shawnee,Ward 12 Precinct 13,State Treasurer,,R,Ron Estes,294
-Shawnee,Ward 12 Precinct 14,State Treasurer,,R,Ron Estes,199
-Shawnee,Ward 12 Precinct 15,State Treasurer,,R,Ron Estes,350
-Shawnee,Ward 12 Precinct 16,State Treasurer,,R,Ron Estes,345
-Shawnee,Ward 12 Precinct 19,State Treasurer,,R,Ron Estes,50
-Shawnee,Ward 12 Precinct 20,State Treasurer,,R,Ron Estes,266
-Shawnee,Ward 12 Precinct 31,State Treasurer,,R,Ron Estes,183
-Shawnee,Ward 13 Precinct 2,State Treasurer,,R,Ron Estes,51
-Shawnee,Ward 13 Precinct 5,State Treasurer,,R,Ron Estes,7
-Shawnee,Ward 13 Precinct 6,State Treasurer,,R,Ron Estes,82
-Shawnee,Ward 13 Precinct 9,State Treasurer,,R,Ron Estes,73
-Shawnee,Ward 13 Precinct 12,State Treasurer,,R,Ron Estes,355
-Shawnee,Ward 13 Precinct 21,State Treasurer,,R,Ron Estes,40
-Shawnee,Ward 13 Precinct 22,State Treasurer,,R,Ron Estes,37
-Shawnee,Ward 13 Precinct 30,State Treasurer,,R,Ron Estes,68
-Shawnee,Ward 14 Precinct 1,State Treasurer,,R,Ron Estes,318
-Shawnee,Ward 14 Precinct 2,State Treasurer,,R,Ron Estes,276
-Shawnee,Ward 14 Precinct 3,State Treasurer,,R,Ron Estes,203
-Shawnee,Ward 14 Precinct 4,State Treasurer,,R,Ron Estes,423
-Shawnee,Ward 14 Precinct 5,State Treasurer,,R,Ron Estes,271
-Shawnee,Ward 15 Precinct 1,State Treasurer,,R,Ron Estes,220
-Shawnee,Ward 15 Precinct 2,State Treasurer,,R,Ron Estes,158
-Shawnee,Ward 15 Precinct 3,State Treasurer,,R,Ron Estes,16
-Shawnee,Ward 1 Precinct 1,State Treasurer,,D,Carmen Alldritt,110
-Shawnee,Ward 1 Precinct 2,State Treasurer,,D,Carmen Alldritt,127
-Shawnee,Ward 1 Precinct 3,State Treasurer,,D,Carmen Alldritt,99
-Shawnee,Ward 1 Precinct 4,State Treasurer,,D,Carmen Alldritt,129
-Shawnee,Ward 1 Precinct 5,State Treasurer,,D,Carmen Alldritt,168
-Shawnee,Ward 1 Precinct 6,State Treasurer,,D,Carmen Alldritt,176
-Shawnee,Ward 2 Precinct 1,State Treasurer,,D,Carmen Alldritt,118
-Shawnee,Ward 2 Precinct 2,State Treasurer,,D,Carmen Alldritt,126
-Shawnee,Ward 2 Precinct 3,State Treasurer,,D,Carmen Alldritt,114
-Shawnee,Ward 2 Precinct 4,State Treasurer,,D,Carmen Alldritt,108
-Shawnee,Ward 2 Precinct 5,State Treasurer,,D,Carmen Alldritt,116
-Shawnee,Ward 2 Precinct 6,State Treasurer,,D,Carmen Alldritt,93
-Shawnee,Ward 2 Precinct 7,State Treasurer,,D,Carmen Alldritt,68
-Shawnee,Ward 2 Precinct 8,State Treasurer,,D,Carmen Alldritt,86
-Shawnee,Ward 2 Precinct 9,State Treasurer,,D,Carmen Alldritt,141
-Shawnee,Ward 2 Precinct 10,State Treasurer,,D,Carmen Alldritt,203
-Shawnee,Ward 2 Precinct 11,State Treasurer,,D,Carmen Alldritt,94
-Shawnee,Ward 3 Precinct 1,State Treasurer,,D,Carmen Alldritt,117
-Shawnee,Ward 3 Precinct 2,State Treasurer,,D,Carmen Alldritt,133
-Shawnee,Ward 3 Precinct 3,State Treasurer,,D,Carmen Alldritt,97
-Shawnee,Ward 3 Precinct 4,State Treasurer,,D,Carmen Alldritt,103
-Shawnee,Ward 3 Precinct 5,State Treasurer,,D,Carmen Alldritt,75
-Shawnee,Ward 3 Precinct 6,State Treasurer,,D,Carmen Alldritt,82
-Shawnee,Ward 3 Precinct 7,State Treasurer,,D,Carmen Alldritt,101
-Shawnee,Ward 3 Precinct 8,State Treasurer,,D,Carmen Alldritt,124
-Shawnee,Ward 3 Precinct 9,State Treasurer,,D,Carmen Alldritt,115
-Shawnee,Ward 3 Precinct 10,State Treasurer,,D,Carmen Alldritt,8
-Shawnee,Ward 4 Precinct 1,State Treasurer,,D,Carmen Alldritt,123
-Shawnee,Ward 4 Precinct 2,State Treasurer,,D,Carmen Alldritt,132
-Shawnee,Ward 4 Precinct 3,State Treasurer,,D,Carmen Alldritt,94
-Shawnee,Ward 4 Precinct 4,State Treasurer,,D,Carmen Alldritt,169
-Shawnee,Ward 4 Precinct 6,State Treasurer,,D,Carmen Alldritt,148
-Shawnee,Ward 4 Precinct 7,State Treasurer,,D,Carmen Alldritt,86
-Shawnee,Ward 4 Precinct 8,State Treasurer,,D,Carmen Alldritt,110
-Shawnee,Ward 4 Precinct 9,State Treasurer,,D,Carmen Alldritt,141
-Shawnee,Ward 4 Precinct 10,State Treasurer,,D,Carmen Alldritt,165
-Shawnee,Ward 4 Precinct 11,State Treasurer,,D,Carmen Alldritt,45
-Shawnee,Ward 4 Precinct 12,State Treasurer,,D,Carmen Alldritt,12
-Shawnee,Ward 4 Precinct 15,State Treasurer,,D,Carmen Alldritt,77
-Shawnee,Ward 5 Precinct 1,State Treasurer,,D,Carmen Alldritt,109
-Shawnee,Ward 5 Precinct 2,State Treasurer,,D,Carmen Alldritt,111
-Shawnee,Ward 5 Precinct 3,State Treasurer,,D,Carmen Alldritt,105
-Shawnee,Ward 5 Precinct 4,State Treasurer,,D,Carmen Alldritt,130
-Shawnee,Ward 5 Precinct 5,State Treasurer,,D,Carmen Alldritt,131
-Shawnee,Ward 5 Precinct 6,State Treasurer,,D,Carmen Alldritt,83
-Shawnee,Ward 5 Precinct 7,State Treasurer,,D,Carmen Alldritt,152
-Shawnee,Ward 5 Precinct 8,State Treasurer,,D,Carmen Alldritt,99
-Shawnee,Ward 5 Precinct 9,State Treasurer,,D,Carmen Alldritt,160
-Shawnee,Ward 5 Precinct 10,State Treasurer,,D,Carmen Alldritt,178
-Shawnee,Ward 5 Precinct 11,State Treasurer,,D,Carmen Alldritt,151
-Shawnee,Ward 5 Precinct 14,State Treasurer,,D,Carmen Alldritt,66
-Shawnee,Ward 5 Precinct 15,State Treasurer,,D,Carmen Alldritt,17
-Shawnee,Ward 5 Precinct 91,State Treasurer,,D,Carmen Alldritt,40
-Shawnee,Ward 6 Precinct 1,State Treasurer,,D,Carmen Alldritt,112
-Shawnee,Ward 6 Precinct 2,State Treasurer,,D,Carmen Alldritt,110
-Shawnee,Ward 6 Precinct 3,State Treasurer,,D,Carmen Alldritt,122
-Shawnee,Ward 6 Precinct 4,State Treasurer,,D,Carmen Alldritt,111
-Shawnee,Ward 6 Precinct 5,State Treasurer,,D,Carmen Alldritt,150
-Shawnee,Ward 6 Precinct 6,State Treasurer,,D,Carmen Alldritt,85
-Shawnee,Ward 6 Precinct 7,State Treasurer,,D,Carmen Alldritt,63
-Shawnee,Ward 6 Precinct 8,State Treasurer,,D,Carmen Alldritt,150
-Shawnee,Ward 6 Precinct 9,State Treasurer,,D,Carmen Alldritt,246
-Shawnee,Ward 7 Precinct 1,State Treasurer,,D,Carmen Alldritt,164
-Shawnee,Ward 7 Precinct 2,State Treasurer,,D,Carmen Alldritt,136
-Shawnee,Ward 7 Precinct 3,State Treasurer,,D,Carmen Alldritt,139
-Shawnee,Ward 7 Precinct 4,State Treasurer,,D,Carmen Alldritt,145
-Shawnee,Ward 7 Precinct 5,State Treasurer,,D,Carmen Alldritt,108
-Shawnee,Ward 7 Precinct 6,State Treasurer,,D,Carmen Alldritt,89
-Shawnee,Ward 7 Precinct 7,State Treasurer,,D,Carmen Alldritt,106
-Shawnee,Ward 7 Precinct 9,State Treasurer,,D,Carmen Alldritt,96
-Shawnee,Ward 7 Precinct 10,State Treasurer,,D,Carmen Alldritt,123
-Shawnee,Ward 7 Precinct 11,State Treasurer,,D,Carmen Alldritt,177
-Shawnee,Ward 8 Precinct 1,State Treasurer,,D,Carmen Alldritt,130
-Shawnee,Ward 8 Precinct 2,State Treasurer,,D,Carmen Alldritt,142
-Shawnee,Ward 8 Precinct 3,State Treasurer,,D,Carmen Alldritt,211
-Shawnee,Ward 8 Precinct 4,State Treasurer,,D,Carmen Alldritt,165
-Shawnee,Ward 8 Precinct 5,State Treasurer,,D,Carmen Alldritt,225
-Shawnee,Ward 8 Precinct 6,State Treasurer,,D,Carmen Alldritt,94
-Shawnee,Ward 8 Precinct 7,State Treasurer,,D,Carmen Alldritt,119
-Shawnee,Ward 8 Precinct 8,State Treasurer,,D,Carmen Alldritt,133
-Shawnee,Ward 8 Precinct 9,State Treasurer,,D,Carmen Alldritt,154
-Shawnee,Ward 8 Precinct 10,State Treasurer,,D,Carmen Alldritt,104
-Shawnee,Ward 8 Precinct 11,State Treasurer,,D,Carmen Alldritt,157
-Shawnee,Ward 9 Precinct 1,State Treasurer,,D,Carmen Alldritt,29
-Shawnee,Ward 9 Precinct 2,State Treasurer,,D,Carmen Alldritt,102
-Shawnee,Ward 9 Precinct 3,State Treasurer,,D,Carmen Alldritt,188
-Shawnee,Ward 9 Precinct 4,State Treasurer,,D,Carmen Alldritt,177
-Shawnee,Ward 9 Precinct 5,State Treasurer,,D,Carmen Alldritt,126
-Shawnee,Ward 9 Precinct 6,State Treasurer,,D,Carmen Alldritt,124
-Shawnee,Ward 9 Precinct 8,State Treasurer,,D,Carmen Alldritt,170
-Shawnee,Ward 9 Precinct 9,State Treasurer,,D,Carmen Alldritt,109
-Shawnee,Ward 9 Precinct 10,State Treasurer,,D,Carmen Alldritt,224
-Shawnee,Ward 9 Precinct 11,State Treasurer,,D,Carmen Alldritt,124
-Shawnee,Ward 9 Precinct 12,State Treasurer,,D,Carmen Alldritt,74
-Shawnee,Ward 10 Precinct 1,State Treasurer,,D,Carmen Alldritt,156
-Shawnee,Ward 10 Precinct 2,State Treasurer,,D,Carmen Alldritt,113
-Shawnee,Ward 10 Precinct 3,State Treasurer,,D,Carmen Alldritt,194
-Shawnee,Ward 10 Precinct 4,State Treasurer,,D,Carmen Alldritt,137
-Shawnee,Ward 10 Precinct 5,State Treasurer,,D,Carmen Alldritt,124
-Shawnee,Ward 10 Precinct 6,State Treasurer,,D,Carmen Alldritt,110
-Shawnee,Ward 10 Precinct 7,State Treasurer,,D,Carmen Alldritt,132
-Shawnee,Ward 10 Precinct 8,State Treasurer,,D,Carmen Alldritt,122
-Shawnee,Ward 10 Precinct 9,State Treasurer,,D,Carmen Alldritt,105
-Shawnee,Ward 10 Precinct 10,State Treasurer,,D,Carmen Alldritt,126
-Shawnee,Ward 10 Precinct 11,State Treasurer,,D,Carmen Alldritt,177
-Shawnee,Ward 10 Precinct 14,State Treasurer,,D,Carmen Alldritt,118
-Shawnee,Ward 11 Precinct 1,State Treasurer,,D,Carmen Alldritt,90
-Shawnee,Ward 11 Precinct 2,State Treasurer,,D,Carmen Alldritt,140
-Shawnee,Ward 11 Precinct 3,State Treasurer,,D,Carmen Alldritt,96
-Shawnee,Ward 11 Precinct 4,State Treasurer,,D,Carmen Alldritt,169
-Shawnee,Ward 11 Precinct 5,State Treasurer,,D,Carmen Alldritt,136
-Shawnee,Ward 11 Precinct 6,State Treasurer,,D,Carmen Alldritt,121
-Shawnee,Ward 11 Precinct 7,State Treasurer,,D,Carmen Alldritt,117
-Shawnee,Ward 11 Precinct 8,State Treasurer,,D,Carmen Alldritt,102
-Shawnee,Ward 11 Precinct 9,State Treasurer,,D,Carmen Alldritt,150
-Shawnee,Ward 11 Precinct 10,State Treasurer,,D,Carmen Alldritt,105
-Shawnee,Ward 12 Precinct 1,State Treasurer,,D,Carmen Alldritt,149
-Shawnee,Ward 12 Precinct 2,State Treasurer,,D,Carmen Alldritt,108
-Shawnee,Ward 12 Precinct 3,State Treasurer,,D,Carmen Alldritt,110
-Shawnee,Ward 12 Precinct 4,State Treasurer,,D,Carmen Alldritt,153
-Shawnee,Ward 12 Precinct 5,State Treasurer,,D,Carmen Alldritt,132
-Shawnee,Ward 12 Precinct 6,State Treasurer,,D,Carmen Alldritt,197
-Shawnee,Ward 12 Precinct 7,State Treasurer,,D,Carmen Alldritt,174
-Shawnee,Ward 12 Precinct 8,State Treasurer,,D,Carmen Alldritt,168
-Shawnee,Ward 12 Precinct 9,State Treasurer,,D,Carmen Alldritt,238
-Shawnee,Ward 12 Precinct 11,State Treasurer,,D,Carmen Alldritt,219
-Shawnee,Ward 12 Precinct 13,State Treasurer,,D,Carmen Alldritt,130
-Shawnee,Ward 12 Precinct 14,State Treasurer,,D,Carmen Alldritt,119
-Shawnee,Ward 12 Precinct 15,State Treasurer,,D,Carmen Alldritt,192
-Shawnee,Ward 12 Precinct 16,State Treasurer,,D,Carmen Alldritt,234
-Shawnee,Ward 12 Precinct 19,State Treasurer,,D,Carmen Alldritt,24
-Shawnee,Ward 12 Precinct 20,State Treasurer,,D,Carmen Alldritt,154
-Shawnee,Ward 12 Precinct 31,State Treasurer,,D,Carmen Alldritt,89
-Shawnee,Ward 13 Precinct 2,State Treasurer,,D,Carmen Alldritt,55
-Shawnee,Ward 13 Precinct 5,State Treasurer,,D,Carmen Alldritt,3
-Shawnee,Ward 13 Precinct 6,State Treasurer,,D,Carmen Alldritt,27
-Shawnee,Ward 13 Precinct 9,State Treasurer,,D,Carmen Alldritt,16
-Shawnee,Ward 13 Precinct 12,State Treasurer,,D,Carmen Alldritt,161
-Shawnee,Ward 13 Precinct 21,State Treasurer,,D,Carmen Alldritt,26
-Shawnee,Ward 13 Precinct 22,State Treasurer,,D,Carmen Alldritt,25
-Shawnee,Ward 13 Precinct 30,State Treasurer,,D,Carmen Alldritt,50
-Shawnee,Ward 14 Precinct 1,State Treasurer,,D,Carmen Alldritt,216
-Shawnee,Ward 14 Precinct 2,State Treasurer,,D,Carmen Alldritt,177
-Shawnee,Ward 14 Precinct 3,State Treasurer,,D,Carmen Alldritt,93
-Shawnee,Ward 14 Precinct 4,State Treasurer,,D,Carmen Alldritt,171
-Shawnee,Ward 14 Precinct 5,State Treasurer,,D,Carmen Alldritt,76
-Shawnee,Ward 15 Precinct 1,State Treasurer,,D,Carmen Alldritt,185
-Shawnee,Ward 15 Precinct 2,State Treasurer,,D,Carmen Alldritt,146
-Shawnee,Ward 15 Precinct 3,State Treasurer,,D,Carmen Alldritt,11
-Shawnee,Ward 1 Precinct 1,Insurance Commissioner,,R,Ken Selzer,49
-Shawnee,Ward 1 Precinct 2,Insurance Commissioner,,R,Ken Selzer,60
-Shawnee,Ward 1 Precinct 3,Insurance Commissioner,,R,Ken Selzer,65
-Shawnee,Ward 1 Precinct 4,Insurance Commissioner,,R,Ken Selzer,106
-Shawnee,Ward 1 Precinct 5,Insurance Commissioner,,R,Ken Selzer,164
-Shawnee,Ward 1 Precinct 6,Insurance Commissioner,,R,Ken Selzer,244
-Shawnee,Ward 2 Precinct 1,Insurance Commissioner,,R,Ken Selzer,87
-Shawnee,Ward 2 Precinct 2,Insurance Commissioner,,R,Ken Selzer,79
-Shawnee,Ward 2 Precinct 3,Insurance Commissioner,,R,Ken Selzer,72
-Shawnee,Ward 2 Precinct 4,Insurance Commissioner,,R,Ken Selzer,58
-Shawnee,Ward 2 Precinct 5,Insurance Commissioner,,R,Ken Selzer,56
-Shawnee,Ward 2 Precinct 6,Insurance Commissioner,,R,Ken Selzer,47
-Shawnee,Ward 2 Precinct 7,Insurance Commissioner,,R,Ken Selzer,19
-Shawnee,Ward 2 Precinct 8,Insurance Commissioner,,R,Ken Selzer,12
-Shawnee,Ward 2 Precinct 9,Insurance Commissioner,,R,Ken Selzer,88
-Shawnee,Ward 2 Precinct 10,Insurance Commissioner,,R,Ken Selzer,55
-Shawnee,Ward 2 Precinct 11,Insurance Commissioner,,R,Ken Selzer,44
-Shawnee,Ward 3 Precinct 1,Insurance Commissioner,,R,Ken Selzer,86
-Shawnee,Ward 3 Precinct 2,Insurance Commissioner,,R,Ken Selzer,87
-Shawnee,Ward 3 Precinct 3,Insurance Commissioner,,R,Ken Selzer,42
-Shawnee,Ward 3 Precinct 4,Insurance Commissioner,,R,Ken Selzer,57
-Shawnee,Ward 3 Precinct 5,Insurance Commissioner,,R,Ken Selzer,32
-Shawnee,Ward 3 Precinct 6,Insurance Commissioner,,R,Ken Selzer,47
-Shawnee,Ward 3 Precinct 7,Insurance Commissioner,,R,Ken Selzer,48
-Shawnee,Ward 3 Precinct 8,Insurance Commissioner,,R,Ken Selzer,64
-Shawnee,Ward 3 Precinct 9,Insurance Commissioner,,R,Ken Selzer,60
-Shawnee,Ward 3 Precinct 10,Insurance Commissioner,,R,Ken Selzer,3
-Shawnee,Ward 4 Precinct 1,Insurance Commissioner,,R,Ken Selzer,39
-Shawnee,Ward 4 Precinct 2,Insurance Commissioner,,R,Ken Selzer,39
-Shawnee,Ward 4 Precinct 3,Insurance Commissioner,,R,Ken Selzer,24
-Shawnee,Ward 4 Precinct 4,Insurance Commissioner,,R,Ken Selzer,40
-Shawnee,Ward 4 Precinct 6,Insurance Commissioner,,R,Ken Selzer,57
-Shawnee,Ward 4 Precinct 7,Insurance Commissioner,,R,Ken Selzer,37
-Shawnee,Ward 4 Precinct 8,Insurance Commissioner,,R,Ken Selzer,53
-Shawnee,Ward 4 Precinct 9,Insurance Commissioner,,R,Ken Selzer,43
-Shawnee,Ward 4 Precinct 10,Insurance Commissioner,,R,Ken Selzer,72
-Shawnee,Ward 4 Precinct 11,Insurance Commissioner,,R,Ken Selzer,47
-Shawnee,Ward 4 Precinct 12,Insurance Commissioner,,R,Ken Selzer,2
-Shawnee,Ward 4 Precinct 15,Insurance Commissioner,,R,Ken Selzer,56
-Shawnee,Ward 5 Precinct 1,Insurance Commissioner,,R,Ken Selzer,43
-Shawnee,Ward 5 Precinct 2,Insurance Commissioner,,R,Ken Selzer,52
-Shawnee,Ward 5 Precinct 3,Insurance Commissioner,,R,Ken Selzer,78
-Shawnee,Ward 5 Precinct 4,Insurance Commissioner,,R,Ken Selzer,67
-Shawnee,Ward 5 Precinct 5,Insurance Commissioner,,R,Ken Selzer,62
-Shawnee,Ward 5 Precinct 6,Insurance Commissioner,,R,Ken Selzer,47
-Shawnee,Ward 5 Precinct 7,Insurance Commissioner,,R,Ken Selzer,56
-Shawnee,Ward 5 Precinct 8,Insurance Commissioner,,R,Ken Selzer,62
-Shawnee,Ward 5 Precinct 9,Insurance Commissioner,,R,Ken Selzer,154
-Shawnee,Ward 5 Precinct 10,Insurance Commissioner,,R,Ken Selzer,213
-Shawnee,Ward 5 Precinct 11,Insurance Commissioner,,R,Ken Selzer,147
-Shawnee,Ward 5 Precinct 14,Insurance Commissioner,,R,Ken Selzer,130
-Shawnee,Ward 5 Precinct 15,Insurance Commissioner,,R,Ken Selzer,29
-Shawnee,Ward 5 Precinct 91,Insurance Commissioner,,R,Ken Selzer,44
-Shawnee,Ward 6 Precinct 1,Insurance Commissioner,,R,Ken Selzer,34
-Shawnee,Ward 6 Precinct 2,Insurance Commissioner,,R,Ken Selzer,46
-Shawnee,Ward 6 Precinct 3,Insurance Commissioner,,R,Ken Selzer,183
-Shawnee,Ward 6 Precinct 4,Insurance Commissioner,,R,Ken Selzer,90
-Shawnee,Ward 6 Precinct 5,Insurance Commissioner,,R,Ken Selzer,138
-Shawnee,Ward 6 Precinct 6,Insurance Commissioner,,R,Ken Selzer,57
-Shawnee,Ward 6 Precinct 7,Insurance Commissioner,,R,Ken Selzer,50
-Shawnee,Ward 6 Precinct 8,Insurance Commissioner,,R,Ken Selzer,73
-Shawnee,Ward 6 Precinct 9,Insurance Commissioner,,R,Ken Selzer,297
-Shawnee,Ward 7 Precinct 1,Insurance Commissioner,,R,Ken Selzer,120
-Shawnee,Ward 7 Precinct 2,Insurance Commissioner,,R,Ken Selzer,88
-Shawnee,Ward 7 Precinct 3,Insurance Commissioner,,R,Ken Selzer,104
-Shawnee,Ward 7 Precinct 4,Insurance Commissioner,,R,Ken Selzer,136
-Shawnee,Ward 7 Precinct 5,Insurance Commissioner,,R,Ken Selzer,116
-Shawnee,Ward 7 Precinct 6,Insurance Commissioner,,R,Ken Selzer,102
-Shawnee,Ward 7 Precinct 7,Insurance Commissioner,,R,Ken Selzer,76
-Shawnee,Ward 7 Precinct 9,Insurance Commissioner,,R,Ken Selzer,95
-Shawnee,Ward 7 Precinct 10,Insurance Commissioner,,R,Ken Selzer,80
-Shawnee,Ward 7 Precinct 11,Insurance Commissioner,,R,Ken Selzer,148
-Shawnee,Ward 8 Precinct 1,Insurance Commissioner,,R,Ken Selzer,60
-Shawnee,Ward 8 Precinct 2,Insurance Commissioner,,R,Ken Selzer,79
-Shawnee,Ward 8 Precinct 3,Insurance Commissioner,,R,Ken Selzer,111
-Shawnee,Ward 8 Precinct 4,Insurance Commissioner,,R,Ken Selzer,124
-Shawnee,Ward 8 Precinct 5,Insurance Commissioner,,R,Ken Selzer,174
-Shawnee,Ward 8 Precinct 6,Insurance Commissioner,,R,Ken Selzer,132
-Shawnee,Ward 8 Precinct 7,Insurance Commissioner,,R,Ken Selzer,71
-Shawnee,Ward 8 Precinct 8,Insurance Commissioner,,R,Ken Selzer,89
-Shawnee,Ward 8 Precinct 9,Insurance Commissioner,,R,Ken Selzer,152
-Shawnee,Ward 8 Precinct 10,Insurance Commissioner,,R,Ken Selzer,153
-Shawnee,Ward 8 Precinct 11,Insurance Commissioner,,R,Ken Selzer,155
-Shawnee,Ward 9 Precinct 1,Insurance Commissioner,,R,Ken Selzer,26
-Shawnee,Ward 9 Precinct 2,Insurance Commissioner,,R,Ken Selzer,94
-Shawnee,Ward 9 Precinct 3,Insurance Commissioner,,R,Ken Selzer,184
-Shawnee,Ward 9 Precinct 4,Insurance Commissioner,,R,Ken Selzer,139
-Shawnee,Ward 9 Precinct 5,Insurance Commissioner,,R,Ken Selzer,102
-Shawnee,Ward 9 Precinct 6,Insurance Commissioner,,R,Ken Selzer,129
-Shawnee,Ward 9 Precinct 8,Insurance Commissioner,,R,Ken Selzer,158
-Shawnee,Ward 9 Precinct 9,Insurance Commissioner,,R,Ken Selzer,125
-Shawnee,Ward 9 Precinct 10,Insurance Commissioner,,R,Ken Selzer,219
-Shawnee,Ward 9 Precinct 11,Insurance Commissioner,,R,Ken Selzer,129
-Shawnee,Ward 9 Precinct 12,Insurance Commissioner,,R,Ken Selzer,56
-Shawnee,Ward 10 Precinct 1,Insurance Commissioner,,R,Ken Selzer,126
-Shawnee,Ward 10 Precinct 2,Insurance Commissioner,,R,Ken Selzer,184
-Shawnee,Ward 10 Precinct 3,Insurance Commissioner,,R,Ken Selzer,252
-Shawnee,Ward 10 Precinct 4,Insurance Commissioner,,R,Ken Selzer,145
-Shawnee,Ward 10 Precinct 5,Insurance Commissioner,,R,Ken Selzer,120
-Shawnee,Ward 10 Precinct 6,Insurance Commissioner,,R,Ken Selzer,140
-Shawnee,Ward 10 Precinct 7,Insurance Commissioner,,R,Ken Selzer,151
-Shawnee,Ward 10 Precinct 8,Insurance Commissioner,,R,Ken Selzer,109
-Shawnee,Ward 10 Precinct 9,Insurance Commissioner,,R,Ken Selzer,86
-Shawnee,Ward 10 Precinct 10,Insurance Commissioner,,R,Ken Selzer,136
-Shawnee,Ward 10 Precinct 11,Insurance Commissioner,,R,Ken Selzer,208
-Shawnee,Ward 10 Precinct 14,Insurance Commissioner,,R,Ken Selzer,139
-Shawnee,Ward 11 Precinct 1,Insurance Commissioner,,R,Ken Selzer,111
-Shawnee,Ward 11 Precinct 2,Insurance Commissioner,,R,Ken Selzer,118
-Shawnee,Ward 11 Precinct 3,Insurance Commissioner,,R,Ken Selzer,90
-Shawnee,Ward 11 Precinct 4,Insurance Commissioner,,R,Ken Selzer,189
-Shawnee,Ward 11 Precinct 5,Insurance Commissioner,,R,Ken Selzer,131
-Shawnee,Ward 11 Precinct 6,Insurance Commissioner,,R,Ken Selzer,131
-Shawnee,Ward 11 Precinct 7,Insurance Commissioner,,R,Ken Selzer,129
-Shawnee,Ward 11 Precinct 8,Insurance Commissioner,,R,Ken Selzer,136
-Shawnee,Ward 11 Precinct 9,Insurance Commissioner,,R,Ken Selzer,130
-Shawnee,Ward 11 Precinct 10,Insurance Commissioner,,R,Ken Selzer,76
-Shawnee,Ward 12 Precinct 1,Insurance Commissioner,,R,Ken Selzer,105
-Shawnee,Ward 12 Precinct 2,Insurance Commissioner,,R,Ken Selzer,78
-Shawnee,Ward 12 Precinct 3,Insurance Commissioner,,R,Ken Selzer,171
-Shawnee,Ward 12 Precinct 4,Insurance Commissioner,,R,Ken Selzer,241
-Shawnee,Ward 12 Precinct 5,Insurance Commissioner,,R,Ken Selzer,202
-Shawnee,Ward 12 Precinct 6,Insurance Commissioner,,R,Ken Selzer,192
-Shawnee,Ward 12 Precinct 7,Insurance Commissioner,,R,Ken Selzer,197
-Shawnee,Ward 12 Precinct 8,Insurance Commissioner,,R,Ken Selzer,197
-Shawnee,Ward 12 Precinct 9,Insurance Commissioner,,R,Ken Selzer,297
-Shawnee,Ward 12 Precinct 11,Insurance Commissioner,,R,Ken Selzer,344
-Shawnee,Ward 12 Precinct 13,Insurance Commissioner,,R,Ken Selzer,262
-Shawnee,Ward 12 Precinct 14,Insurance Commissioner,,R,Ken Selzer,169
-Shawnee,Ward 12 Precinct 15,Insurance Commissioner,,R,Ken Selzer,316
-Shawnee,Ward 12 Precinct 16,Insurance Commissioner,,R,Ken Selzer,296
-Shawnee,Ward 12 Precinct 19,Insurance Commissioner,,R,Ken Selzer,48
-Shawnee,Ward 12 Precinct 20,Insurance Commissioner,,R,Ken Selzer,229
-Shawnee,Ward 12 Precinct 31,Insurance Commissioner,,R,Ken Selzer,153
-Shawnee,Ward 13 Precinct 2,Insurance Commissioner,,R,Ken Selzer,48
-Shawnee,Ward 13 Precinct 5,Insurance Commissioner,,R,Ken Selzer,8
-Shawnee,Ward 13 Precinct 6,Insurance Commissioner,,R,Ken Selzer,82
-Shawnee,Ward 13 Precinct 9,Insurance Commissioner,,R,Ken Selzer,58
-Shawnee,Ward 13 Precinct 12,Insurance Commissioner,,R,Ken Selzer,314
-Shawnee,Ward 13 Precinct 21,Insurance Commissioner,,R,Ken Selzer,32
-Shawnee,Ward 13 Precinct 22,Insurance Commissioner,,R,Ken Selzer,35
-Shawnee,Ward 13 Precinct 30,Insurance Commissioner,,R,Ken Selzer,52
-Shawnee,Ward 14 Precinct 1,Insurance Commissioner,,R,Ken Selzer,279
-Shawnee,Ward 14 Precinct 2,Insurance Commissioner,,R,Ken Selzer,235
-Shawnee,Ward 14 Precinct 3,Insurance Commissioner,,R,Ken Selzer,173
-Shawnee,Ward 14 Precinct 4,Insurance Commissioner,,R,Ken Selzer,384
-Shawnee,Ward 14 Precinct 5,Insurance Commissioner,,R,Ken Selzer,246
-Shawnee,Ward 15 Precinct 1,Insurance Commissioner,,R,Ken Selzer,197
-Shawnee,Ward 15 Precinct 2,Insurance Commissioner,,R,Ken Selzer,133
-Shawnee,Ward 15 Precinct 3,Insurance Commissioner,,R,Ken Selzer,12
-Shawnee,Ward 1 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,117
-Shawnee,Ward 1 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,143
-Shawnee,Ward 1 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,102
-Shawnee,Ward 1 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,132
-Shawnee,Ward 1 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,188
-Shawnee,Ward 1 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,207
-Shawnee,Ward 2 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,143
-Shawnee,Ward 2 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,128
-Shawnee,Ward 2 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,137
-Shawnee,Ward 2 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,130
-Shawnee,Ward 2 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,135
-Shawnee,Ward 2 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,101
-Shawnee,Ward 2 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,73
-Shawnee,Ward 2 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,85
-Shawnee,Ward 2 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,150
-Shawnee,Ward 2 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,221
-Shawnee,Ward 2 Precinct 11,Insurance Commissioner,,D,Dennis Anderson,103
-Shawnee,Ward 3 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,128
-Shawnee,Ward 3 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,152
-Shawnee,Ward 3 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,103
-Shawnee,Ward 3 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,112
-Shawnee,Ward 3 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,80
-Shawnee,Ward 3 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,89
-Shawnee,Ward 3 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,100
-Shawnee,Ward 3 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,130
-Shawnee,Ward 3 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,125
-Shawnee,Ward 3 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,10
-Shawnee,Ward 4 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,136
-Shawnee,Ward 4 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,134
-Shawnee,Ward 4 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,102
-Shawnee,Ward 4 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,174
-Shawnee,Ward 4 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,157
-Shawnee,Ward 4 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,86
-Shawnee,Ward 4 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,117
-Shawnee,Ward 4 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,153
-Shawnee,Ward 4 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,184
-Shawnee,Ward 4 Precinct 11,Insurance Commissioner,,D,Dennis Anderson,50
-Shawnee,Ward 4 Precinct 12,Insurance Commissioner,,D,Dennis Anderson,14
-Shawnee,Ward 4 Precinct 15,Insurance Commissioner,,D,Dennis Anderson,75
-Shawnee,Ward 5 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,120
-Shawnee,Ward 5 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,122
-Shawnee,Ward 5 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,108
-Shawnee,Ward 5 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,145
-Shawnee,Ward 5 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,142
-Shawnee,Ward 5 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,93
-Shawnee,Ward 5 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,155
-Shawnee,Ward 5 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,105
-Shawnee,Ward 5 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,180
-Shawnee,Ward 5 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,214
-Shawnee,Ward 5 Precinct 11,Insurance Commissioner,,D,Dennis Anderson,176
-Shawnee,Ward 5 Precinct 14,Insurance Commissioner,,D,Dennis Anderson,81
-Shawnee,Ward 5 Precinct 15,Insurance Commissioner,,D,Dennis Anderson,22
-Shawnee,Ward 5 Precinct 91,Insurance Commissioner,,D,Dennis Anderson,44
-Shawnee,Ward 6 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,118
-Shawnee,Ward 6 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,112
-Shawnee,Ward 6 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,161
-Shawnee,Ward 6 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,131
-Shawnee,Ward 6 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,178
-Shawnee,Ward 6 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,94
-Shawnee,Ward 6 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,69
-Shawnee,Ward 6 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,161
-Shawnee,Ward 6 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,283
-Shawnee,Ward 7 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,181
-Shawnee,Ward 7 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,152
-Shawnee,Ward 7 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,145
-Shawnee,Ward 7 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,152
-Shawnee,Ward 7 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,117
-Shawnee,Ward 7 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,98
-Shawnee,Ward 7 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,116
-Shawnee,Ward 7 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,111
-Shawnee,Ward 7 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,135
-Shawnee,Ward 7 Precinct 11,Insurance Commissioner,,D,Dennis Anderson,197
-Shawnee,Ward 8 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,137
-Shawnee,Ward 8 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,158
-Shawnee,Ward 8 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,225
-Shawnee,Ward 8 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,187
-Shawnee,Ward 8 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,241
-Shawnee,Ward 8 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,124
-Shawnee,Ward 8 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,139
-Shawnee,Ward 8 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,156
-Shawnee,Ward 8 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,184
-Shawnee,Ward 8 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,117
-Shawnee,Ward 8 Precinct 11,Insurance Commissioner,,D,Dennis Anderson,186
-Shawnee,Ward 9 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,31
-Shawnee,Ward 9 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,104
-Shawnee,Ward 9 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,212
-Shawnee,Ward 9 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,198
-Shawnee,Ward 9 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,150
-Shawnee,Ward 9 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,162
-Shawnee,Ward 9 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,200
-Shawnee,Ward 9 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,145
-Shawnee,Ward 9 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,279
-Shawnee,Ward 9 Precinct 11,Insurance Commissioner,,D,Dennis Anderson,157
-Shawnee,Ward 9 Precinct 12,Insurance Commissioner,,D,Dennis Anderson,81
-Shawnee,Ward 10 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,180
-Shawnee,Ward 10 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,155
-Shawnee,Ward 10 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,225
-Shawnee,Ward 10 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,147
-Shawnee,Ward 10 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,137
-Shawnee,Ward 10 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,123
-Shawnee,Ward 10 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,142
-Shawnee,Ward 10 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,140
-Shawnee,Ward 10 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,115
-Shawnee,Ward 10 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,144
-Shawnee,Ward 10 Precinct 11,Insurance Commissioner,,D,Dennis Anderson,190
-Shawnee,Ward 10 Precinct 14,Insurance Commissioner,,D,Dennis Anderson,152
-Shawnee,Ward 11 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,100
-Shawnee,Ward 11 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,171
-Shawnee,Ward 11 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,115
-Shawnee,Ward 11 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,211
-Shawnee,Ward 11 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,150
-Shawnee,Ward 11 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,141
-Shawnee,Ward 11 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,127
-Shawnee,Ward 11 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,121
-Shawnee,Ward 11 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,162
-Shawnee,Ward 11 Precinct 10,Insurance Commissioner,,D,Dennis Anderson,118
-Shawnee,Ward 12 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,163
-Shawnee,Ward 12 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,119
-Shawnee,Ward 12 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,148
-Shawnee,Ward 12 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,174
-Shawnee,Ward 12 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,184
-Shawnee,Ward 12 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,215
-Shawnee,Ward 12 Precinct 7,Insurance Commissioner,,D,Dennis Anderson,188
-Shawnee,Ward 12 Precinct 8,Insurance Commissioner,,D,Dennis Anderson,184
-Shawnee,Ward 12 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,280
-Shawnee,Ward 12 Precinct 11,Insurance Commissioner,,D,Dennis Anderson,248
-Shawnee,Ward 12 Precinct 13,Insurance Commissioner,,D,Dennis Anderson,155
-Shawnee,Ward 12 Precinct 14,Insurance Commissioner,,D,Dennis Anderson,144
-Shawnee,Ward 12 Precinct 15,Insurance Commissioner,,D,Dennis Anderson,222
-Shawnee,Ward 12 Precinct 16,Insurance Commissioner,,D,Dennis Anderson,278
-Shawnee,Ward 12 Precinct 19,Insurance Commissioner,,D,Dennis Anderson,22
-Shawnee,Ward 12 Precinct 20,Insurance Commissioner,,D,Dennis Anderson,187
-Shawnee,Ward 12 Precinct 31,Insurance Commissioner,,D,Dennis Anderson,119
-Shawnee,Ward 13 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,59
-Shawnee,Ward 13 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,1
-Shawnee,Ward 13 Precinct 6,Insurance Commissioner,,D,Dennis Anderson,27
-Shawnee,Ward 13 Precinct 9,Insurance Commissioner,,D,Dennis Anderson,31
-Shawnee,Ward 13 Precinct 12,Insurance Commissioner,,D,Dennis Anderson,190
-Shawnee,Ward 13 Precinct 21,Insurance Commissioner,,D,Dennis Anderson,34
-Shawnee,Ward 13 Precinct 22,Insurance Commissioner,,D,Dennis Anderson,27
-Shawnee,Ward 13 Precinct 30,Insurance Commissioner,,D,Dennis Anderson,63
-Shawnee,Ward 14 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,249
-Shawnee,Ward 14 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,214
-Shawnee,Ward 14 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,117
-Shawnee,Ward 14 Precinct 4,Insurance Commissioner,,D,Dennis Anderson,202
-Shawnee,Ward 14 Precinct 5,Insurance Commissioner,,D,Dennis Anderson,98
-Shawnee,Ward 15 Precinct 1,Insurance Commissioner,,D,Dennis Anderson,200
-Shawnee,Ward 15 Precinct 2,Insurance Commissioner,,D,Dennis Anderson,168
-Shawnee,Ward 15 Precinct 3,Insurance Commissioner,,D,Dennis Anderson,14
-Shawnee,Ward 1 Precinct 5,State House,50,R,Fred Patton,213
-Shawnee,Ward 1 Precinct 6,State House,50,R,Fred Patton,265
-Shawnee,Ward 3 Precinct 1,State House,55,R,James Lord,76
-Shawnee,Ward 3 Precinct 2,State House,55,R,James Lord,74
-Shawnee,Ward 3 Precinct 3,State House,55,R,James Lord,39
-Shawnee,Ward 3 Precinct 4,State House,55,R,James Lord,54
-Shawnee,Ward 3 Precinct 5,State House,55,R,James Lord,23
-Shawnee,Ward 3 Precinct 6,State House,55,R,James Lord,46
-Shawnee,Ward 3 Precinct 7,State House,55,R,James Lord,44
-Shawnee,Ward 3 Precinct 8,State House,58,R,Cordell Fischer,74
-Shawnee,Ward 3 Precinct 9,State House,58,R,Cordell Fischer,54
-Shawnee,Ward 4 Precinct 4,State House,58,R,Cordell Fischer,35
-Shawnee,Ward 4 Precinct 6,State House,58,R,Cordell Fischer,50
-Shawnee,Ward 4 Precinct 7,State House,58,R,Cordell Fischer,35
-Shawnee,Ward 4 Precinct 8,State House,58,R,Cordell Fischer,57
-Shawnee,Ward 4 Precinct 9,State House,58,R,Cordell Fischer,40
-Shawnee,Ward 4 Precinct 10,State House,58,R,Cordell Fischer,58
-Shawnee,Ward 4 Precinct 11,State House,58,R,Cordell Fischer,41
-Shawnee,Ward 4 Precinct 12,State House,58,R,Cordell Fischer,0
-Shawnee,Ward 4 Precinct 15,State House,56,R,Lane Hemsley,58
-Shawnee,Ward 5 Precinct 1,State House,58,R,Cordell Fischer,41
-Shawnee,Ward 5 Precinct 2,State House,58,R,Cordell Fischer,44
-Shawnee,Ward 5 Precinct 3,State House,58,R,Cordell Fischer,60
-Shawnee,Ward 5 Precinct 4,State House,58,R,Cordell Fischer,55
-Shawnee,Ward 5 Precinct 5,State House,58,R,Cordell Fischer,52
-Shawnee,Ward 5 Precinct 6,State House,58,R,Cordell Fischer,40
-Shawnee,Ward 5 Precinct 7,State House,58,R,Cordell Fischer,45
-Shawnee,Ward 5 Precinct 8,State House,58,R,Cordell Fischer,56
-Shawnee,Ward 5 Precinct 9,State House,58,R,Cordell Fischer,130
-Shawnee,Ward 5 Precinct 10,State House,58,R,Cordell Fischer,188
-Shawnee,Ward 5 Precinct 15,State House,54,R,Ken Corbet,21
-Shawnee,Ward 5 Precinct 91,State House,54,R,Ken Corbet,38
-Shawnee,Ward 6 Precinct 1,State House,58,R,Cordell Fischer,32
-Shawnee,Ward 6 Precinct 2,State House,58,R,Cordell Fischer,38
-Shawnee,Ward 6 Precinct 3,State House,56,R,Lane Hemsley,192
-Shawnee,Ward 6 Precinct 4,State House,56,R,Lane Hemsley,94
-Shawnee,Ward 6 Precinct 5,State House,56,R,Lane Hemsley,157
-Shawnee,Ward 6 Precinct 6,State House,56,R,Lane Hemsley,68
-Shawnee,Ward 6 Precinct 7,State House,56,R,Lane Hemsley,55
-Shawnee,Ward 6 Precinct 8,State House,58,R,Cordell Fischer,69
-Shawnee,Ward 6 Precinct 9,State House,56,R,Lane Hemsley,310
-Shawnee,Ward 7 Precinct 1,State House,55,R,James Lord,89
-Shawnee,Ward 7 Precinct 2,State House,55,R,James Lord,77
-Shawnee,Ward 7 Precinct 3,State House,55,R,James Lord,83
-Shawnee,Ward 7 Precinct 4,State House,55,R,James Lord,107
-Shawnee,Ward 7 Precinct 5,State House,55,R,James Lord,99
-Shawnee,Ward 7 Precinct 6,State House,55,R,James Lord,77
-Shawnee,Ward 7 Precinct 7,State House,55,R,James Lord,57
-Shawnee,Ward 7 Precinct 9,State House,55,R,James Lord,83
-Shawnee,Ward 7 Precinct 10,State House,55,R,James Lord,67
-Shawnee,Ward 7 Precinct 11,State House,55,R,James Lord,128
-Shawnee,Ward 8 Precinct 1,State House,55,R,James Lord,55
-Shawnee,Ward 8 Precinct 2,State House,55,R,James Lord,72
-Shawnee,Ward 8 Precinct 3,State House,55,R,James Lord,90
-Shawnee,Ward 8 Precinct 4,State House,55,R,James Lord,96
-Shawnee,Ward 8 Precinct 5,State House,55,R,James Lord,166
-Shawnee,Ward 8 Precinct 6,State House,55,R,James Lord,105
-Shawnee,Ward 8 Precinct 7,State House,55,R,James Lord,51
-Shawnee,Ward 8 Precinct 8,State House,55,R,James Lord,65
-Shawnee,Ward 8 Precinct 9,State House,55,R,James Lord,125
-Shawnee,Ward 8 Precinct 10,State House,55,R,James Lord,123
-Shawnee,Ward 8 Precinct 11,State House,55,R,James Lord,134
-Shawnee,Ward 9 Precinct 1,State House,56,R,Lane Hemsley,31
-Shawnee,Ward 9 Precinct 2,State House,56,R,Lane Hemsley,100
-Shawnee,Ward 9 Precinct 3,State House,56,R,Lane Hemsley,202
-Shawnee,Ward 9 Precinct 4,State House,56,R,Lane Hemsley,151
-Shawnee,Ward 9 Precinct 5,State House,56,R,Lane Hemsley,115
-Shawnee,Ward 9 Precinct 6,State House,56,R,Lane Hemsley,142
-Shawnee,Ward 9 Precinct 8,State House,56,R,Lane Hemsley,169
-Shawnee,Ward 9 Precinct 9,State House,56,R,Lane Hemsley,120
-Shawnee,Ward 9 Precinct 10,State House,56,R,Lane Hemsley,248
-Shawnee,Ward 9 Precinct 11,State House,56,R,Lane Hemsley,132
-Shawnee,Ward 9 Precinct 12,State House,56,R,Lane Hemsley,55
-Shawnee,Ward 10 Precinct 1,State House,53,R,T J Foy,101
-Shawnee,Ward 10 Precinct 2,State House,53,R,T J Foy,151
-Shawnee,Ward 10 Precinct 3,State House,53,R,T J Foy,207
-Shawnee,Ward 10 Precinct 4,State House,53,R,T J Foy,118
-Shawnee,Ward 10 Precinct 5,State House,53,R,T J Foy,88
-Shawnee,Ward 10 Precinct 6,State House,53,R,T J Foy,111
-Shawnee,Ward 10 Precinct 7,State House,53,R,T J Foy,117
-Shawnee,Ward 10 Precinct 8,State House,53,R,T J Foy,84
-Shawnee,Ward 10 Precinct 9,State House,53,R,T J Foy,77
-Shawnee,Ward 10 Precinct 10,State House,53,R,T J Foy,111
-Shawnee,Ward 10 Precinct 11,State House,53,R,T J Foy,153
-Shawnee,Ward 10 Precinct 14,State House,53,R,T J Foy,110
-Shawnee,Ward 11 Precinct 1,State House,53,R,T J Foy,89
-Shawnee,Ward 11 Precinct 2,State House,53,R,T J Foy,114
-Shawnee,Ward 11 Precinct 3,State House,53,R,T J Foy,75
-Shawnee,Ward 11 Precinct 4,State House,53,R,T J Foy,145
-Shawnee,Ward 11 Precinct 5,State House,53,R,T J Foy,103
-Shawnee,Ward 11 Precinct 6,State House,53,R,T J Foy,103
-Shawnee,Ward 11 Precinct 7,State House,53,R,T J Foy,109
-Shawnee,Ward 11 Precinct 8,State House,53,R,T J Foy,106
-Shawnee,Ward 11 Precinct 9,State House,53,R,T J Foy,103
-Shawnee,Ward 11 Precinct 10,State House,53,R,T J Foy,62
-Shawnee,Ward 12 Precinct 1,State House,53,R,T J Foy,86
-Shawnee,Ward 12 Precinct 2,State House,53,R,T J Foy,57
-Shawnee,Ward 12 Precinct 3,State House,53,R,T J Foy,145
-Shawnee,Ward 12 Precinct 4,State House,53,R,T J Foy,188
-Shawnee,Ward 12 Precinct 5,State House,52,R,Dick Jones,224
-Shawnee,Ward 12 Precinct 6,State House,52,R,Dick Jones,191
-Shawnee,Ward 12 Precinct 7,State House,52,R,Dick Jones,201
-Shawnee,Ward 12 Precinct 8,State House,52,R,Dick Jones,203
-Shawnee,Ward 12 Precinct 9,State House,56,R,Lane Hemsley,303
-Shawnee,Ward 12 Precinct 11,State House,52,R,Dick Jones,359
-Shawnee,Ward 12 Precinct 13,State House,53,R,T J Foy,210
-Shawnee,Ward 12 Precinct 14,State House,52,R,Dick Jones,175
-Shawnee,Ward 12 Precinct 15,State House,52,R,Dick Jones,296
-Shawnee,Ward 12 Precinct 16,State House,52,R,Dick Jones,298
-Shawnee,Ward 12 Precinct 19,State House,53,R,T J Foy,43
-Shawnee,Ward 12 Precinct 20,State House,52,R,Dick Jones,179
-Shawnee,Ward 12 Precinct 31,State House,53,R,T J Foy,128
-Shawnee,Ward 13 Precinct 2,State House,52,R,Dick Jones,64
-Shawnee,Ward 13 Precinct 5,State House,53,R,T J Foy,7
-Shawnee,Ward 13 Precinct 6,State House,52,R,Dick Jones,78
-Shawnee,Ward 13 Precinct 9,State House,52,R,Dick Jones,66
-Shawnee,Ward 13 Precinct 12,State House,52,R,Dick Jones,316
-Shawnee,Ward 13 Precinct 21,State House,52,R,Dick Jones,31
-Shawnee,Ward 13 Precinct 22,State House,52,R,Dick Jones,36
-Shawnee,Ward 13 Precinct 30,State House,53,R,T J Foy,44
-Shawnee,Ward 14 Precinct 1,State House,56,R,Lane Hemsley,297
-Shawnee,Ward 14 Precinct 2,State House,56,R,Lane Hemsley,260
-Shawnee,Ward 14 Precinct 3,State House,56,R,Lane Hemsley,186
-Shawnee,Ward 14 Precinct 4,State House,52,R,Dick Jones,402
-Shawnee,Ward 14 Precinct 5,State House,52,R,Dick Jones,255
-Shawnee,Ward 15 Precinct 1,State House,56,R,Lane Hemsley,204
-Shawnee,Ward 15 Precinct 2,State House,56,R,Lane Hemsley,139
-Shawnee,Ward 15 Precinct 3,State House,56,R,Lane Hemsley,14
-Shawnee,Ward 1 Precinct I,State House,57,D,John Alcala,135
-Shawnee,Ward 1 Precinct 2,State House,57,D,John Alcala,176
-Shawnee,Ward 1 Precinct 3,State House,57,D,John Alcala,149
-Shawnee,Ward 1 Precinct 4,State House,57,D,John Alcala,207
-Shawnee,Ward 1 Precinct 5,State House,50,D,Chris Huntsman,148
-Shawnee,Ward 1 Precinct 6,State House,50,D,Chris Huntsman,186
-Shawnee,Ward 2 Precinct 1,State House,57,D,John Alcala,196
-Shawnee,Ward 2 Precinct 2,State House,57,D,John Alcala,175
-Shawnee,Ward 2 Precinct 3,State House,57,D,John Alcala,179
-Shawnee,Ward 2 Precinct 4,State House,57,D,John Alcala,170
-Shawnee,Ward 2 Precinct 5,State House,57,D,John Alcala,169
-Shawnee,Ward 2 Precinct 6,State House,57,D,John Alcala,132
-Shawnee,Ward 2 Precinct 7,State House,57,D,John Alcala,86
-Shawnee,Ward 2 Precinct 8,State House,57,D,John Alcala,96
-Shawnee,Ward 2 Precinct 9,State House,57,D,John Alcala,209
-Shawnee,Ward 2 Precinct 10,State House,57,D,John Alcala,246
-Shawnee,Ward 2 Precinct 11,State House,57,D,John Alcala,118
-Shawnee,Ward 3 Precinct 1,State House,55,D,Annie Kuether,139
-Shawnee,Ward 3 Precinct 2,State House,55,D,Annie Kuether,171
-Shawnee,Ward 3 Precinct 3,State House,55,D,Annie Kuether,105
-Shawnee,Ward 3 Precinct 4,State House,55,D,Annie Kuether,116
-Shawnee,Ward 3 Precinct 5,State House,55,D,Annie Kuether,90
-Shawnee,Ward 3 Precinct 6,State House,55,D,Annie Kuether,92
-Shawnee,Ward 3 Precinct 7,State House,55,D,Annie Kuether,106
-Shawnee,Ward 3 Precinct 8,State House,58,D,Harold Lane,117
-Shawnee,Ward 3 Precinct 9,State House,58,D,Harold Lane,133
-Shawnee,Ward 3 Precinct 10,State House,57,D,John Alcala,11
-Shawnee,Ward 4 Precinct 1,State House,57,D,John Alcala,158
-Shawnee,Ward 4 Precinct 2,State House,57,D,John Alcala,152
-Shawnee,Ward 4 Precinct 3,State House,57,D,John Alcala,113
-Shawnee,Ward 4 Precinct 4,State House,58,D,Harold Lane,182
-Shawnee,Ward 4 Precinct 6,State House,58,D,Harold Lane,168
-Shawnee,Ward 4 Precinct 7,State House,58,D,Harold Lane,87
-Shawnee,Ward 4 Precinct 8,State House,58,D,Harold Lane,113
-Shawnee,Ward 4 Precinct 9,State House,58,D,Harold Lane,157
-Shawnee,Ward 4 Precinct 10,State House,58,D,Harold Lane,195
-Shawnee,Ward 4 Precinct 11,State House,58,D,Harold Lane,55
-Shawnee,Ward 4 Precinct 14,State House,58,D,Harold Lane,16
-Shawnee,Ward 4 Precinct 15,State House,56,D,Virgil Weigel,74
-Shawnee,Ward 5 Precinct 1,State House,58,D,Harold Lane,124
-Shawnee,Ward 5 Precinct 2,State House,58,D,Harold Lane,129
-Shawnee,Ward 5 Precinct 3,State House,58,D,Harold Lane,130
-Shawnee,Ward 5 Precinct 4,State House,58,D,Harold Lane,159
-Shawnee,Ward 5 Precinct 5,State House,58,D,Harold Lane,154
-Shawnee,Ward 5 Precinct 6,State House,58,D,Harold Lane,103
-Shawnee,Ward 5 Precinct 7,State House,58,D,Harold Lane,163
-Shawnee,Ward 5 Precinct 8,State House,58,D,Harold Lane,109
-Shawnee,Ward 5 Precinct 9,State House,58,D,Harold Lane,208
-Shawnee,Ward 5 Precinct 10,State House,58,D,Harold Lane,240
-Shawnee,Ward 5 Precinct 11,State House,57,D,John Alcala,250
-Shawnee,Ward 5 Precinct 14,State House,57,D,John Alcala,152
-Shawnee,Ward 5 Precinct 15,State House,54,D,Ann Mah,29
-Shawnee,Ward 5 Precinct 91,State House,54,D,Ann Mah,51
-Shawnee,Ward 6 Precinct 1,State House,58,D,Harold Lane,123
-Shawnee,Ward 6 Precinct 2,State House,58,D,Harold Lane,122
-Shawnee,Ward 6 Precinct 3,State House,56,D,Virgil Weigel,157
-Shawnee,Ward 6 Precinct 4,State House,56,D,Virgil Weigel,125
-Shawnee,Ward 6 Precinct 5,State House,56,D,Virgil Weigel,162
-Shawnee,Ward 6 Precinct 6,State House,56,D,Virgil Weigel,84
-Shawnee,Ward 6 Precinct 7,State House,56,D,Virgil Weigel,63
-Shawnee,Ward 6 Precinct 8,State House,58,D,Harold Lane,166
-Shawnee,Ward 6 Precinct 9,State House,56,D,Virgil Weigel,276
-Shawnee,Ward 7 Precinct 1,State House,55,D,Annie Kuether,219
-Shawnee,Ward 7 Precinct 2,State House,55,D,Annie Kuether,167
-Shawnee,Ward 7 Precinct 3,State House,55,D,Annie Kuether,169
-Shawnee,Ward 7 Precinct 4,State House,55,D,Annie Kuether,183
-Shawnee,Ward 7 Precinct 5,State House,55,D,Annie Kuether,139
-Shawnee,Ward 7 Precinct 6,State House,55,D,Annie Kuether,127
-Shawnee,Ward 7 Precinct 7,State House,55,D,Annie Kuether,135
-Shawnee,Ward 7 Precinct 9,State House,55,D,Annie Kuether,127
-Shawnee,Ward 7 Precinct 10,State House,55,D,Annie Kuether,152
-Shawnee,Ward 7 Precinct 11,State House,55,D,Annie Kuether,222
-Shawnee,Ward 8 Precinct 1,State House,55,D,Annie Kuether,146
-Shawnee,Ward 8 Precinct 2,State House,55,D,Annie Kuether,168
-Shawnee,Ward 8 Precinct 3,State House,55,D,Annie Kuether,249
-Shawnee,Ward 8 Precinct 4,State House,55,D,Annie Kuether,219
-Shawnee,Ward 8 Precinct 5,State House,55,D,Annie Kuether,281
-Shawnee,Ward 8 Precinct 6,State House,55,D,Annie Kuether,151
-Shawnee,Ward 8 Precinct 7,State House,55,D,Annie Kuether,159
-Shawnee,Ward 8 Precinct 8,State House,55,D,Annie Kuether,182
-Shawnee,Ward 8 Precinct 9,State House,55,D,Annie Kuether,223
-Shawnee,Ward 8 Precinct 10,State House,55,D,Annie Kuether,153
-Shawnee,Ward 8 Precinct 11,State House,55,D,Annie Kuether,212
-Shawnee,Ward 9 Precinct 1,State House,56,D,Virgil Weigel,28
-Shawnee,Ward 9 Precinct 2,State House,56,D,Virgil Weigel,103
-Shawnee,Ward 9 Precinct 3,State House,56,D,Virgil Weigel,205
-Shawnee,Ward 9 Precinct 4,State House,56,D,Virgil Weigel,196
-Shawnee,Ward 9 Precinct 5,State House,56,D,Virgil Weigel,142
-Shawnee,Ward 9 Precinct 6,State House,56,D,Virgil Weigel,157
-Shawnee,Ward 9 Precinct 8,State House,56,D,Virgil Weigel,192
-Shawnee,Ward 9 Precinct 9,State House,56,D,Virgil Weigel,152
-Shawnee,Ward 9 Precinct 10,State House,56,D,Virgil Weigel,257
-Shawnee,Ward 9 Precinct 11,State House,56,D,Virgil Weigel,157
-Shawnee,Ward 9 Precinct 12,State House,56,D,Virgil Weigel,82
-Shawnee,Ward 10 Precinct 1,State House,53,D,Annie Tietze,215
-Shawnee,Ward 10 Precinct 2,State House,53,D,Annie Tietze,189
-Shawnee,Ward 10 Precinct 3,State House,53,D,Annie Tietze,274
-Shawnee,Ward 10 Precinct 4,State House,53,D,Annie Tietze,179
-Shawnee,Ward 10 Precinct 5,State House,53,D,Annie Tietze,178
-Shawnee,Ward 10 Precinct 6,State House,53,D,Annie Tietze,157
-Shawnee,Ward 10 Precinct 7,State House,53,D,Annie Tietze,174
-Shawnee,Ward 10 Precinct 8,State House,53,D,Annie Tietze,167
-Shawnee,Ward 10 Precinct 9,State House,53,D,Annie Tietze,130
-Shawnee,Ward 10 Precinct 10,State House,53,D,Annie Tietze,171
-Shawnee,Ward 10 Precinct 11,State House,53,D,Annie Tietze,254
-Shawnee,Ward 10 Precinct 14,State House,53,D,Annie Tietze,190
-Shawnee,Ward 11 Precinct 1,State House,53,D,Annie Tietze,120
-Shawnee,Ward 11 Precinct 2,State House,53,D,Annie Tietze,180
-Shawnee,Ward 11 Precinct 3,State House,53,D,Annie Tietze,133
-Shawnee,Ward 11 Precinct 4,State House,53,D,Annie Tietze,261
-Shawnee,Ward 11 Precinct 5,State House,53,D,Annie Tietze,186
-Shawnee,Ward 11 Precinct 6,State House,53,D,Annie Tietze,174
-Shawnee,Ward 11 Precinct 7,State House,53,D,Annie Tietze,158
-Shawnee,Ward 11 Precinct 8,State House,53,D,Annie Tietze,153
-Shawnee,Ward 11 Precinct 9,State House,53,D,Annie Tietze,196
-Shawnee,Ward 11 Precinct 10,State House,53,D,Annie Tietze,130
-Shawnee,Ward 12 Precinct 1,State House,53,D,Annie Tietze,182
-Shawnee,Ward 12 Precinct 2,State House,53,D,Annie Tietze,139
-Shawnee,Ward 12 Precinct 3,State House,53,D,Annie Tietze,182
-Shawnee,Ward 12 Precinct 4,State House,53,D,Annie Tietze,234
-Shawnee,Ward 12 Precinct 5,State House,52,D,Ty Dragoo,157
-Shawnee,Ward 12 Precinct 6,State House,52,D,Ty Dragoo,225
-Shawnee,Ward 12 Precinct 7,State House,52,D,Ty Dragoo,185
-Shawnee,Ward 12 Precinct 8,State House,52,D,Ty Dragoo,182
-Shawnee,Ward 12 Precinct 9,State House,56,D,Virgil Weigel,279
-Shawnee,Ward 12 Precinct 11,State House,52,D,Ty Dragoo,237
-Shawnee,Ward 12 Precinct 13,State House,53,D,Annie Tietze,216
-Shawnee,Ward 12 Precinct 14,State House,52,D,Ty Dragoo,142
-Shawnee,Ward 12 Precinct 15,State House,52,D,Ty Dragoo,242
-Shawnee,Ward 12 Precinct 16,State House,52,D,Ty Dragoo,274
-Shawnee,Ward 12 Precinct 19,State House,53,D,Annie Tietze,30
-Shawnee,Ward 12 Precinct 20,State House,52,D,Ty Dragoo,241
-Shawnee,Ward 12 Precinct 31,State House,53,D,Annie Tietze,148
-Shawnee,Ward 13 Precinct 2,State House,52,D,Ty Dragoo,40
-Shawnee,Ward 13 Precinct 5,State House,53,D,Annie Tietze,3
-Shawnee,Ward 13 Precinct 6,State House,52,D,Ty Dragoo,30
-Shawnee,Ward 13 Precinct 9,State House,52,D,Ty Dragoo,23
-Shawnee,Ward 13 Precinct 12,State House,52,D,Ty Dragoo,195
-Shawnee,Ward 13 Precinct 21,State House,52,D,Ty Dragoo,35
-Shawnee,Ward 13 Precinct 22,State House,52,D,Ty Dragoo,26
-Shawnee,Ward 13 Precinct 30,State House,53,D,Annie Tietze,72
-Shawnee,Ward 14 Precinct 1,State House,56,D,Virgil Weigel,242
-Shawnee,Ward 14 Precinct 2,State House,56,D,Virgil Weigel,197
-Shawnee,Ward 14 Precinct 3,State House,56,D,Virgil Weigel,108
-Shawnee,Ward 14 Precinct 4,State House,52,D,Ty Dragoo,193
-Shawnee,Ward 14 Precinct 5,State House,52,D,Ty Dragoo,91
-Shawnee,Ward 15 Precinct 1,State House,56,D,Virgil Weigel,202
-Shawnee,Ward 15 Precinct 2,State House,56,D,Virgil Weigel,160
-Shawnee,Ward 15 Precinct 3,State House,56,D,Virgil Weigel,14
-Shawnee,1 East Rossville,U.S. Senate,,R,Pat Roberts,225
-Shawnee,2 West Rossville,U.S. Senate,,R,Pat Roberts,200
-Shawnee,9 East Silver Lake,U.S. Senate,,R,Pat Roberts,238
-Shawnee,10 West Silver Lake,U.S. Senate,,R,Pat Roberts,165
-Shawnee,12 Grove,U.S. Senate,,R,Pat Roberts,170
-Shawnee,14 Kiro,U.S. Senate,,R,Pat Roberts,249
-Shawnee,15 Messhoss Creek,U.S. Senate,,R,Pat Roberts,138
-Shawnee,22 Little Muddy Creek,U.S. Senate,,R,Pat Roberts,150
-Shawnee,24 Sac,U.S. Senate,,R,Pat Roberts,233
-Shawnee,25 Sherman,U.S. Senate,,R,Pat Roberts,206
-Shawnee,26 Iroquois,U.S. Senate,,R,Pat Roberts,206
-Shawnee,28 West Wichita,U.S. Senate,,R,Pat Roberts,185
-Shawnee,29 Indianola,U.S. Senate,,R,Pat Roberts,235
-Shawnee,30 Apache,U.S. Senate,,R,Pat Roberts,209
-Shawnee,31 East Wichita,U.S. Senate,,R,Pat Roberts,307
-Shawnee,32 Fox,U.S. Senate,,R,Pat Roberts,234
-Shawnee,33 Elmont,U.S. Senate,,R,Pat Roberts,288
-Shawnee,34 Kilmer,U.S. Senate,,R,Pat Roberts,69
-Shawnee,35 Rochester,U.S. Senate,,R,Pat Roberts,199
-Shawnee,36 East Soldier,U.S. Senate,,R,Pat Roberts,209
-Shawnee,37 Whitfield,U.S. Senate,,R,Pat Roberts,151
-Shawnee,38 Sioux,U.S. Senate,,R,Pat Roberts,179
-Shawnee,39 Pottawatomie,U.S. Senate,,R,Pat Roberts,223
-Shawnee,40 Stinson Creek,U.S. Senate,,R,Pat Roberts,73
-Shawnee,41 North Tecumseh,U.S. Senate,,R,Pat Roberts,164
-Shawnee,42 South Tecumseh,U.S. Senate,,R,Pat Roberts,164
-Shawnee,43 Pawnee,U.S. Senate,,R,Pat Roberts,283
-Shawnee,44 Kaw,U.S. Senate,,R,Pat Roberts,196
-Shawnee,45 Peck,U.S. Senate,,R,Pat Roberts,123
-Shawnee,46 East Peck,U.S. Senate,,R,Pat Roberts,148
-Shawnee,47 Kiowa,U.S. Senate,,R,Pat Roberts,269
-Shawnee,48 Cheyenne,U.S. Senate,,R,Pat Roberts,189
-Shawnee,49 Ponca,U.S. Senate,,R,Pat Roberts,136
-Shawnee,52 Deer Creek,U.S. Senate,,R,Pat Roberts,9
-Shawnee,53 Pauline,U.S. Senate,,R,Pat Roberts,67
-Shawnee,54 West Potter,U.S. Senate,,R,Pat Roberts,37
-Shawnee,55 Central Pauline,U.S. Senate,,R,Pat Roberts,30
-Shawnee,56 NW Monmouth,U.S. Senate,,R,Pat Roberts,311
-Shawnee,57 NE Monmouth,U.S. Senate,,R,Pat Roberts,216
-Shawnee,58 S Monmouth,U.S. Senate,,R,Pat Roberts,283
-Shawnee,62 Forbes,U.S. Senate,,R,Pat Roberts,27
-Shawnee,63 Montara,U.S. Senate,,R,Pat Roberts,69
-Shawnee,64 Cullen,U.S. Senate,,R,Pat Roberts,108
-Shawnee,65 Wakarusa,U.S. Senate,,R,Pat Roberts,243
-Shawnee,66 Kingston,U.S. Senate,,R,Pat Roberts,66
-Shawnee,72 City of Auburn,U.S. Senate,,R,Pat Roberts,198
-Shawnee,73 Meadowlark,U.S. Senate,,R,Pat Roberts,327
-Shawnee,74 Buffalo,U.S. Senate,,R,Pat Roberts,238
-Shawnee,80 Gaillardia,U.S. Senate,,R,Pat Roberts,241
-Shawnee,81 Dover,U.S. Senate,,R,Pat Roberts,181
-Shawnee,82 Willard,U.S. Senate,,R,Pat Roberts,199
-Shawnee,84 Yucca,U.S. Senate,,R,Pat Roberts,53
-Shawnee,85 Aldersgate,U.S. Senate,,R,Pat Roberts,89
-Shawnee,86 Sunflower,U.S. Senate,,R,Pat Roberts,383
-Shawnee,87 Washburn,U.S. Senate,,R,Pat Roberts,196
-Shawnee,89 North Mission,U.S. Senate,,R,Pat Roberts,75
-Shawnee,90 South Mission,U.S. Senate,,R,Pat Roberts,178
-Shawnee,91 Central Mission,U.S. Senate,,R,Pat Roberts,294
-Shawnee,92 Sherwood,U.S. Senate,,R,Pat Roberts,188
-Shawnee,93 South Sherwood,U.S. Senate,,R,Pat Roberts,162
-Shawnee,94 Indian Hills,U.S. Senate,,R,Pat Roberts,181
-Shawnee,95 York,U.S. Senate,,R,Pat Roberts,242
-Shawnee,96 Vaquero,U.S. Senate,,R,Pat Roberts,158
-Shawnee,97 York Outer,U.S. Senate,,R,Pat Roberts,29
-Shawnee,99 Verbena,U.S. Senate,,R,Pat Roberts,41
-Shawnee,1 East Rossville,U.S. Senate,,I,Greg Orman,175
-Shawnee,2 West Rossville,U.S. Senate,,I,Greg Orman,103
-Shawnee,9 East Silver Lake,U.S. Senate,,I,Greg Orman,242
-Shawnee,10 West Silver Lake,U.S. Senate,,I,Greg Orman,176
-Shawnee,12 Grove,U.S. Senate,,I,Greg Orman,110
-Shawnee,14 Kiro,U.S. Senate,,I,Greg Orman,202
-Shawnee,15 Messhoss Creek,U.S. Senate,,I,Greg Orman,120
-Shawnee,22 Little Muddy Creek,U.S. Senate,,I,Greg Orman,135
-Shawnee,24 Sac,U.S. Senate,,I,Greg Orman,237
-Shawnee,25 Sherman,U.S. Senate,,I,Greg Orman,193
-Shawnee,26 Iroquois,U.S. Senate,,I,Greg Orman,196
-Shawnee,28 West Wichita,U.S. Senate,,I,Greg Orman,183
-Shawnee,29 Indianola,U.S. Senate,,I,Greg Orman,216
-Shawnee,30 Apache,U.S. Senate,,I,Greg Orman,190
-Shawnee,31 East Wichita,U.S. Senate,,I,Greg Orman,290
-Shawnee,32 Fox,U.S. Senate,,I,Greg Orman,198
-Shawnee,33 Elmont,U.S. Senate,,I,Greg Orman,285
-Shawnee,34 Kilmer,U.S. Senate,,I,Greg Orman,50
-Shawnee,35 Rochester,U.S. Senate,,I,Greg Orman,203
-Shawnee,36 East Soldier,U.S. Senate,,I,Greg Orman,253
-Shawnee,37 Whitfield,U.S. Senate,,I,Greg Orman,172
-Shawnee,38 Sioux,U.S. Senate,,I,Greg Orman,179
-Shawnee,39 Pottawatomie,U.S. Senate,,I,Greg Orman,220
-Shawnee,40 Stinson Creek,U.S. Senate,,I,Greg Orman,83
-Shawnee,41 North Tecumseh,U.S. Senate,,I,Greg Orman,175
-Shawnee,42 South Tecumseh,U.S. Senate,,I,Greg Orman,199
-Shawnee,43 Pawnee,U.S. Senate,,I,Greg Orman,221
-Shawnee,44 Kaw,U.S. Senate,,I,Greg Orman,230
-Shawnee,45 Peck,U.S. Senate,,I,Greg Orman,163
-Shawnee,46 East Peck,U.S. Senate,,I,Greg Orman,124
-Shawnee,47 Kiowa,U.S. Senate,,I,Greg Orman,316
-Shawnee,48 Cheyenne,U.S. Senate,,I,Greg Orman,217
-Shawnee,49 Ponca,U.S. Senate,,I,Greg Orman,140
-Shawnee,52 Deer Creek,U.S. Senate,,I,Greg Orman,9
-Shawnee,53 Pauline,U.S. Senate,,I,Greg Orman,100
-Shawnee,54 West Potter,U.S. Senate,,I,Greg Orman,22
-Shawnee,55 Central Pauline,U.S. Senate,,I,Greg Orman,32
-Shawnee,56 NW Monmouth,U.S. Senate,,I,Greg Orman,247
-Shawnee,57 NE Monmouth,U.S. Senate,,I,Greg Orman,219
-Shawnee,58 S Monmouth,U.S. Senate,,I,Greg Orman,279
-Shawnee,62 Forbes,U.S. Senate,,I,Greg Orman,21
-Shawnee,63 Montara,U.S. Senate,,I,Greg Orman,116
-Shawnee,64 Cullen,U.S. Senate,,I,Greg Orman,150
-Shawnee,65 Wakarusa,U.S. Senate,,I,Greg Orman,183
-Shawnee,66 Kingston,U.S. Senate,,I,Greg Orman,48
-Shawnee,72 City of Auburn,U.S. Senate,,I,Greg Orman,168
-Shawnee,73 Meadowlark,U.S. Senate,,I,Greg Orman,225
-Shawnee,74 Buffalo,U.S. Senate,,I,Greg Orman,145
-Shawnee,80 Gaillardia,U.S. Senate,,I,Greg Orman,166
-Shawnee,81 Dover,U.S. Senate,,I,Greg Orman,133
-Shawnee,82 Willard,U.S. Senate,,I,Greg Orman,136
-Shawnee,84 Yucca,U.S. Senate,,I,Greg Orman,56
-Shawnee,85 Aldersgate,U.S. Senate,,I,Greg Orman,112
-Shawnee,86 Sunflower,U.S. Senate,,I,Greg Orman,278
-Shawnee,87 Washburn,U.S. Senate,,I,Greg Orman,142
-Shawnee,89 North Mission,U.S. Senate,,I,Greg Orman,44
-Shawnee,90 South Mission,U.S. Senate,,I,Greg Orman,128
-Shawnee,91 Central Mission,U.S. Senate,,I,Greg Orman,223
-Shawnee,92 Sherwood,U.S. Senate,,I,Greg Orman,172
-Shawnee,93 South Sherwood,U.S. Senate,,I,Greg Orman,137
-Shawnee,94 Indian Hills,U.S. Senate,,I,Greg Orman,193
-Shawnee,95 York,U.S. Senate,,I,Greg Orman,185
-Shawnee,96 Vaquero,U.S. Senate,,I,Greg Orman,153
-Shawnee,97 York Outer,U.S. Senate,,I,Greg Orman,20
-Shawnee,99 Verbena,U.S. Senate,,I,Greg Orman,28
-Shawnee,1 East Rossville,U.S. Senate,,L,Randall Batson,20
-Shawnee,2 West Rossville,U.S. Senate,,L,Randall Batson,9
-Shawnee,9 East Silver Lake,U.S. Senate,,L,Randall Batson,19
-Shawnee,10 West Silver Lake,U.S. Senate,,L,Randall Batson,16
-Shawnee,12 Grove,U.S. Senate,,L,Randall Batson,14
-Shawnee,14 Kiro,U.S. Senate,,L,Randall Batson,18
-Shawnee,15 Messhoss Creek,U.S. Senate,,L,Randall Batson,9
-Shawnee,22 Little Muddy Creek,U.S. Senate,,L,Randall Batson,9
-Shawnee,24 Sac,U.S. Senate,,L,Randall Batson,14
-Shawnee,25 Sherman,U.S. Senate,,L,Randall Batson,14
-Shawnee,26 Iroquois,U.S. Senate,,L,Randall Batson,14
-Shawnee,28 West Wichita,U.S. Senate,,L,Randall Batson,15
-Shawnee,29 Indianola,U.S. Senate,,L,Randall Batson,12
-Shawnee,30 Apache,U.S. Senate,,L,Randall Batson,12
-Shawnee,31 East Wichita,U.S. Senate,,L,Randall Batson,23
-Shawnee,32 Fox,U.S. Senate,,L,Randall Batson,24
-Shawnee,33 Elmont,U.S. Senate,,L,Randall Batson,22
-Shawnee,34 Kilmer,U.S. Senate,,L,Randall Batson,6
-Shawnee,35 Rochester,U.S. Senate,,L,Randall Batson,16
-Shawnee,36 East Soldier,U.S. Senate,,L,Randall Batson,8
-Shawnee,37 Whitfield,U.S. Senate,,L,Randall Batson,18
-Shawnee,38 Sioux,U.S. Senate,,L,Randall Batson,18
-Shawnee,39 Pottawatomie,U.S. Senate,,L,Randall Batson,14
-Shawnee,40 Stinson Creek,U.S. Senate,,L,Randall Batson,1
-Shawnee,41 North Tecumseh,U.S. Senate,,L,Randall Batson,17
-Shawnee,42 South Tecumseh,U.S. Senate,,L,Randall Batson,10
-Shawnee,43 Pawnee,U.S. Senate,,L,Randall Batson,13
-Shawnee,44 Kaw,U.S. Senate,,L,Randall Batson,8
-Shawnee,45 Peck,U.S. Senate,,L,Randall Batson,6
-Shawnee,46 East Peck,U.S. Senate,,L,Randall Batson,6
-Shawnee,47 Kiowa,U.S. Senate,,L,Randall Batson,19
-Shawnee,48 Cheyenne,U.S. Senate,,L,Randall Batson,19
-Shawnee,49 Ponca,U.S. Senate,,L,Randall Batson,5
-Shawnee,52 Deer Creek,U.S. Senate,,L,Randall Batson,1
-Shawnee,53 Pauline,U.S. Senate,,L,Randall Batson,8
-Shawnee,54 West Potter,U.S. Senate,,L,Randall Batson,2
-Shawnee,55 Central Pauline,U.S. Senate,,L,Randall Batson,7
-Shawnee,56 NW Monmouth,U.S. Senate,,L,Randall Batson,12
-Shawnee,57 NE Monmouth,U.S. Senate,,L,Randall Batson,13
-Shawnee,58 S Monmouth,U.S. Senate,,L,Randall Batson,21
-Shawnee,62 Forbes,U.S. Senate,,L,Randall Batson,1
-Shawnee,63 Montara,U.S. Senate,,L,Randall Batson,21
-Shawnee,64 Cullen,U.S. Senate,,L,Randall Batson,16
-Shawnee,65 Wakarusa,U.S. Senate,,L,Randall Batson,17
-Shawnee,66 Kingston,U.S. Senate,,L,Randall Batson,3
-Shawnee,72 City of Auburn,U.S. Senate,,L,Randall Batson,18
-Shawnee,73 Meadowlark,U.S. Senate,,L,Randall Batson,19
-Shawnee,74 Buffalo,U.S. Senate,,L,Randall Batson,9
-Shawnee,80 Gaillardia,U.S. Senate,,L,Randall Batson,9
-Shawnee,81 Dover,U.S. Senate,,L,Randall Batson,10
-Shawnee,82 Willard,U.S. Senate,,L,Randall Batson,8
-Shawnee,84 Yucca,U.S. Senate,,L,Randall Batson,2
-Shawnee,85 Aldersgate,U.S. Senate,,L,Randall Batson,3
-Shawnee,86 Sunflower,U.S. Senate,,L,Randall Batson,12
-Shawnee,87 Washburn,U.S. Senate,,L,Randall Batson,9
-Shawnee,89 North Mission,U.S. Senate,,L,Randall Batson,2
-Shawnee,90 South Mission,U.S. Senate,,L,Randall Batson,14
-Shawnee,91 Central Mission,U.S. Senate,,L,Randall Batson,13
-Shawnee,92 Sherwood,U.S. Senate,,L,Randall Batson,10
-Shawnee,93 South Sherwood,U.S. Senate,,L,Randall Batson,4
-Shawnee,94 Indian Hills,U.S. Senate,,L,Randall Batson,11
-Shawnee,95 York,U.S. Senate,,L,Randall Batson,8
-Shawnee,96 Vaquero,U.S. Senate,,L,Randall Batson,13
-Shawnee,97 York Outer,U.S. Senate,,L,Randall Batson,3
-Shawnee,99 Verbena,U.S. Senate,,L,Randall Batson,6
-Shawnee,1 East Rossville,U.S. House,2,R,Lynn Jenkins,261
-Shawnee,2 West Rossville,U.S. House,2,R,Lynn Jenkins,205
-Shawnee,9 East Silver Lake,U.S. House,2,R,Lynn Jenkins,275
-Shawnee,10 West Silver Lake,U.S. House,2,R,Lynn Jenkins,196
-Shawnee,12 Grove,U.S. House,2,R,Lynn Jenkins,202
-Shawnee,14 Kiro,U.S. House,2,R,Lynn Jenkins,290
-Shawnee,15 Messhoss Creek,U.S. House,2,R,Lynn Jenkins,157
-Shawnee,22 Little Muddy Creek,U.S. House,2,R,Lynn Jenkins,181
-Shawnee,24 Sac,U.S. House,2,R,Lynn Jenkins,272
-Shawnee,25 Sherman,U.S. House,2,R,Lynn Jenkins,245
-Shawnee,26 Iroquois,U.S. House,2,R,Lynn Jenkins,242
-Shawnee,28 West Wichita,U.S. House,2,R,Lynn Jenkins,211
-Shawnee,29 Indianola,U.S. House,2,R,Lynn Jenkins,290
-Shawnee,30 Apache,U.S. House,2,R,Lynn Jenkins,247
-Shawnee,31 East Wichita,U.S. House,2,R,Lynn Jenkins,361
-Shawnee,32 Fox,U.S. House,2,R,Lynn Jenkins,265
-Shawnee,33 Elmont,U.S. House,2,R,Lynn Jenkins,343
-Shawnee,34 Kilmer,U.S. House,2,R,Lynn Jenkins,77
-Shawnee,35 Rochester,U.S. House,2,R,Lynn Jenkins,232
-Shawnee,36 East Soldier,U.S. House,2,R,Lynn Jenkins,252
-Shawnee,37 Whitfield,U.S. House,2,R,Lynn Jenkins,179
-Shawnee,38 Sioux,U.S. House,2,R,Lynn Jenkins,218
-Shawnee,39 Pottawatomie,U.S. House,2,R,Lynn Jenkins,253
-Shawnee,40 Stinson Creek,U.S. House,2,R,Lynn Jenkins,88
-Shawnee,41 North Tecumseh,U.S. House,2,R,Lynn Jenkins,188
-Shawnee,42 South Tecumseh,U.S. House,2,R,Lynn Jenkins,195
-Shawnee,43 Pawnee,U.S. House,2,R,Lynn Jenkins,320
-Shawnee,44 Kaw,U.S. House,2,R,Lynn Jenkins,231
-Shawnee,45 Peck,U.S. House,2,R,Lynn Jenkins,156
-Shawnee,46 East Peck,U.S. House,2,R,Lynn Jenkins,175
-Shawnee,47 Kiowa,U.S. House,2,R,Lynn Jenkins,318
-Shawnee,48 Cheyenne,U.S. House,2,R,Lynn Jenkins,223
-Shawnee,49 Ponca,U.S. House,2,R,Lynn Jenkins,157
-Shawnee,52 Deer Creek,U.S. House,2,R,Lynn Jenkins,11
-Shawnee,53 Pauline,U.S. House,2,R,Lynn Jenkins,94
-Shawnee,54 West Potter,U.S. House,2,R,Lynn Jenkins,43
-Shawnee,55 Central Pauline,U.S. House,2,R,Lynn Jenkins,33
-Shawnee,56 NW Monmouth,U.S. House,2,R,Lynn Jenkins,351
-Shawnee,57 NE Monmouth,U.S. House,2,R,Lynn Jenkins,251
-Shawnee,58 S Monmouth,U.S. House,2,R,Lynn Jenkins,346
-Shawnee,62 Forbes,U.S. House,2,R,Lynn Jenkins,30
-Shawnee,63 Montara,U.S. House,2,R,Lynn Jenkins,89
-Shawnee,64 Cullen,U.S. House,2,R,Lynn Jenkins,136
-Shawnee,65 Wakarusa,U.S. House,2,R,Lynn Jenkins,275
-Shawnee,66 Kingston,U.S. House,2,R,Lynn Jenkins,77
-Shawnee,72 City of Auburn,U.S. House,2,R,Lynn Jenkins,223
-Shawnee,73 Meadowlark,U.S. House,2,R,Lynn Jenkins,383
-Shawnee,74 Buffalo,U.S. House,2,R,Lynn Jenkins,250
-Shawnee,80 Gaillardia,U.S. House,2,R,Lynn Jenkins,275
-Shawnee,81 Dover,U.S. House,2,R,Lynn Jenkins,207
-Shawnee,82 Willard,U.S. House,2,R,Lynn Jenkins,218
-Shawnee,84 Yucca,U.S. House,2,R,Lynn Jenkins,61
-Shawnee,85 Aldersgate,U.S. House,2,R,Lynn Jenkins,105
-Shawnee,86 Sunflower,U.S. House,2,R,Lynn Jenkins,450
-Shawnee,87 Washburn,U.S. House,2,R,Lynn Jenkins,218
-Shawnee,89 North Mission,U.S. House,2,R,Lynn Jenkins,83
-Shawnee,90 South Mission,U.S. House,2,R,Lynn Jenkins,195
-Shawnee,91 Central Mission,U.S. House,2,R,Lynn Jenkins,347
-Shawnee,92 Sherwood,U.S. House,2,R,Lynn Jenkins,217
-Shawnee,93 South Sherwood,U.S. House,2,R,Lynn Jenkins,193
-Shawnee,94 Indian Hills,U.S. House,2,R,Lynn Jenkins,217
-Shawnee,95 York,U.S. House,2,R,Lynn Jenkins,267
-Shawnee,96 Vaquero,U.S. House,2,R,Lynn Jenkins,189
-Shawnee,97 York Outer,U.S. House,2,R,Lynn Jenkins,32
-Shawnee,99 Verbena,U.S. House,2,R,Lynn Jenkins,44
-Shawnee,1 East Rossville,U.S. House,2,D,Margie Wakefield,131
-Shawnee,2 West Rossville,U.S. House,2,D,Margie Wakefield,82
-Shawnee,9 East Silver Lake,U.S. House,2,D,Margie Wakefield,213
-Shawnee,10 West Silver Lake,U.S. House,2,D,Margie Wakefield,143
-Shawnee,12 Grove,U.S. House,2,D,Margie Wakefield,77
-Shawnee,14 Kiro,U.S. House,2,D,Margie Wakefield,159
-Shawnee,15 Messhoss Creek,U.S. House,2,D,Margie Wakefield,94
-Shawnee,22 Little Muddy Creek,U.S. House,2,D,Margie Wakefield,105
-Shawnee,24 Sac,U.S. House,2,D,Margie Wakefield,187
-Shawnee,25 Sherman,U.S. House,2,D,Margie Wakefield,145
-Shawnee,26 Iroquois,U.S. House,2,D,Margie Wakefield,154
-Shawnee,28 West Wichita,U.S. House,2,D,Margie Wakefield,160
-Shawnee,29 Indianola,U.S. House,2,D,Margie Wakefield,167
-Shawnee,30 Apache,U.S. House,2,D,Margie Wakefield,145
-Shawnee,31 East Wichita,U.S. House,2,D,Margie Wakefield,235
-Shawnee,32 Fox,U.S. House,2,D,Margie Wakefield,167
-Shawnee,33 Elmont,U.S. House,2,D,Margie Wakefield,223
-Shawnee,34 Kilmer,U.S. House,2,D,Margie Wakefield,38
-Shawnee,35 Rochester,U.S. House,2,D,Margie Wakefield,168
-Shawnee,36 East Soldier,U.S. House,2,D,Margie Wakefield,207
-Shawnee,37 Whitfield,U.S. House,2,D,Margie Wakefield,135
-Shawnee,38 Sioux,U.S. House,2,D,Margie Wakefield,139
-Shawnee,39 Pottawatomie,U.S. House,2,D,Margie Wakefield,189
-Shawnee,40 Stinson Creek,U.S. House,2,D,Margie Wakefield,67
-Shawnee,41 North Tecumseh,U.S. House,2,D,Margie Wakefield,156
-Shawnee,42 South Tecumseh,U.S. House,2,D,Margie Wakefield,160
-Shawnee,43 Pawnee,U.S. House,2,D,Margie Wakefield,176
-Shawnee,44 Kaw,U.S. House,2,D,Margie Wakefield,190
-Shawnee,45 Peck,U.S. House,2,D,Margie Wakefield,129
-Shawnee,46 East Peck,U.S. House,2,D,Margie Wakefield,97
-Shawnee,47 Kiowa,U.S. House,2,D,Margie Wakefield,272
-Shawnee,48 Cheyenne,U.S. House,2,D,Margie Wakefield,185
-Shawnee,49 Ponca,U.S. House,2,D,Margie Wakefield,116
-Shawnee,52 Deer Creek,U.S. House,2,D,Margie Wakefield,8
-Shawnee,53 Pauline,U.S. House,2,D,Margie Wakefield,79
-Shawnee,54 West Potter,U.S. House,2,D,Margie Wakefield,17
-Shawnee,55 Central Pauline,U.S. House,2,D,Margie Wakefield,31
-Shawnee,56 NW Monmouth,U.S. House,2,D,Margie Wakefield,192
-Shawnee,57 NE Monmouth,U.S. House,2,D,Margie Wakefield,192
-Shawnee,58 S Monmouth,U.S. House,2,D,Margie Wakefield,207
-Shawnee,62 Forbes,U.S. House,2,D,Margie Wakefield,18
-Shawnee,63 Montara,U.S. House,2,D,Margie Wakefield,96
-Shawnee,64 Cullen,U.S. House,2,D,Margie Wakefield,118
-Shawnee,65 Wakarusa,U.S. House,2,D,Margie Wakefield,140
-Shawnee,66 Kingston,U.S. House,2,D,Margie Wakefield,38
-Shawnee,72 City of Auburn,U.S. House,2,D,Margie Wakefield,141
-Shawnee,73 Meadowlark,U.S. House,2,D,Margie Wakefield,171
-Shawnee,74 Buffalo,U.S. House,2,D,Margie Wakefield,122
-Shawnee,80 Gaillardia,U.S. House,2,D,Margie Wakefield,127
-Shawnee,81 Dover,U.S. House,2,D,Margie Wakefield,110
-Shawnee,82 Willard,U.S. House,2,D,Margie Wakefield,109
-Shawnee,84 Yucca,U.S. House,2,D,Margie Wakefield,41
-Shawnee,85 Aldersgate,U.S. House,2,D,Margie Wakefield,101
-Shawnee,86 Sunflower,U.S. House,2,D,Margie Wakefield,204
-Shawnee,87 Washburn,U.S. House,2,D,Margie Wakefield,115
-Shawnee,89 North Mission,U.S. House,2,D,Margie Wakefield,32
-Shawnee,90 South Mission,U.S. House,2,D,Margie Wakefield,116
-Shawnee,91 Central Mission,U.S. House,2,D,Margie Wakefield,173
-Shawnee,92 Sherwood,U.S. House,2,D,Margie Wakefield,142
-Shawnee,93 South Sherwood,U.S. House,2,D,Margie Wakefield,97
-Shawnee,94 Indian Hills,U.S. House,2,D,Margie Wakefield,150
-Shawnee,95 York,U.S. House,2,D,Margie Wakefield,148
-Shawnee,96 Vaquero,U.S. House,2,D,Margie Wakefield,123
-Shawnee,97 York Outer,U.S. House,2,D,Margie Wakefield,18
-Shawnee,99 Verbena,U.S. House,2,D,Margie Wakefield,27
-Shawnee,1 East Rossville,U.S. House,2,L,Chris Clemmons,28
-Shawnee,2 West Rossville,U.S. House,2,L,Chris Clemmons,18
-Shawnee,9 East Silver Lake,U.S. House,2,L,Chris Clemmons,13
-Shawnee,10 West Silver Lake,U.S. House,2,L,Chris Clemmons,17
-Shawnee,12 Grove,U.S. House,2,L,Chris Clemmons,14
-Shawnee,14 Kiro,U.S. House,2,L,Chris Clemmons,16
-Shawnee,15 Messhoss Creek,U.S. House,2,L,Chris Clemmons,17
-Shawnee,22 Little Muddy Creek,U.S. House,2,L,Chris Clemmons,7
-Shawnee,24 Sac,U.S. House,2,L,Chris Clemmons,27
-Shawnee,25 Sherman,U.S. House,2,L,Chris Clemmons,22
-Shawnee,26 Iroquois,U.S. House,2,L,Chris Clemmons,19
-Shawnee,28 West Wichita,U.S. House,2,L,Chris Clemmons,12
-Shawnee,29 Indianola,U.S. House,2,L,Chris Clemmons,8
-Shawnee,30 Apache,U.S. House,2,L,Chris Clemmons,19
-Shawnee,31 East Wichita,U.S. House,2,L,Chris Clemmons,23
-Shawnee,32 Fox,U.S. House,2,L,Chris Clemmons,22
-Shawnee,33 Elmont,U.S. House,2,L,Chris Clemmons,28
-Shawnee,34 Kilmer,U.S. House,2,L,Chris Clemmons,7
-Shawnee,35 Rochester,U.S. House,2,L,Chris Clemmons,19
-Shawnee,36 East Soldier,U.S. House,2,L,Chris Clemmons,13
-Shawnee,37 Whitfield,U.S. House,2,L,Chris Clemmons,27
-Shawnee,38 Sioux,U.S. House,2,L,Chris Clemmons,19
-Shawnee,39 Pottawatomie,U.S. House,2,L,Chris Clemmons,14
-Shawnee,40 Stinson Creek,U.S. House,2,L,Chris Clemmons,2
-Shawnee,41 North Tecumseh,U.S. House,2,L,Chris Clemmons,17
-Shawnee,42 South Tecumseh,U.S. House,2,L,Chris Clemmons,19
-Shawnee,43 Pawnee,U.S. House,2,L,Chris Clemmons,26
-Shawnee,44 Kaw,U.S. House,2,L,Chris Clemmons,12
-Shawnee,45 Peck,U.S. House,2,L,Chris Clemmons,9
-Shawnee,46 East Peck,U.S. House,2,L,Chris Clemmons,6
-Shawnee,47 Kiowa,U.S. House,2,L,Chris Clemmons,18
-Shawnee,48 Cheyenne,U.S. House,2,L,Chris Clemmons,20
-Shawnee,49 Ponca,U.S. House,2,L,Chris Clemmons,8
-Shawnee,52 Deer Creek,U.S. House,2,L,Chris Clemmons,1
-Shawnee,53 Pauline,U.S. House,2,L,Chris Clemmons,5
-Shawnee,54 West Potter,U.S. House,2,L,Chris Clemmons,1
-Shawnee,55 Central Pauline,U.S. House,2,L,Chris Clemmons,7
-Shawnee,56 NW Monmouth,U.S. House,2,L,Chris Clemmons,25
-Shawnee,57 NE Monmouth,U.S. House,2,L,Chris Clemmons,9
-Shawnee,58 S Monmouth,U.S. House,2,L,Chris Clemmons,28
-Shawnee,62 Forbes,U.S. House,2,L,Chris Clemmons,1
-Shawnee,63 Montara,U.S. House,2,L,Chris Clemmons,23
-Shawnee,64 Cullen,U.S. House,2,L,Chris Clemmons,21
-Shawnee,65 Wakarusa,U.S. House,2,L,Chris Clemmons,27
-Shawnee,66 Kingston,U.S. House,2,L,Chris Clemmons,2
-Shawnee,72 City of Auburn,U.S. House,2,L,Chris Clemmons,23
-Shawnee,73 Meadowlark,U.S. House,2,L,Chris Clemmons,23
-Shawnee,74 Buffalo,U.S. House,2,L,Chris Clemmons,22
-Shawnee,80 Gaillardia,U.S. House,2,L,Chris Clemmons,13
-Shawnee,81 Dover,U.S. House,2,L,Chris Clemmons,8
-Shawnee,82 Willard,U.S. House,2,L,Chris Clemmons,16
-Shawnee,84 Yucca,U.S. House,2,L,Chris Clemmons,7
-Shawnee,85 Aldersgate,U.S. House,2,L,Chris Clemmons,3
-Shawnee,86 Sunflower,U.S. House,2,L,Chris Clemmons,15
-Shawnee,87 Washburn,U.S. House,2,L,Chris Clemmons,12
-Shawnee,89 North Mission,U.S. House,2,L,Chris Clemmons,4
-Shawnee,90 South Mission,U.S. House,2,L,Chris Clemmons,12
-Shawnee,91 Central Mission,U.S. House,2,L,Chris Clemmons,14
-Shawnee,92 Sherwood,U.S. House,2,L,Chris Clemmons,12
-Shawnee,93 South Sherwood,U.S. House,2,L,Chris Clemmons,10
-Shawnee,94 Indian Hills,U.S. House,2,L,Chris Clemmons,19
-Shawnee,95 York,U.S. House,2,L,Chris Clemmons,19
-Shawnee,96 Vaquero,U.S. House,2,L,Chris Clemmons,13
-Shawnee,97 York Outer,U.S. House,2,L,Chris Clemmons,2
-Shawnee,99 Verbena,U.S. House,2,L,Chris Clemmons,4
-Shawnee,1 East Rossville,Governor,,R,Sam Brownback,190
-Shawnee,2 West Rossville,Governor,,R,Sam Brownback,181
-Shawnee,9 East Silver Lake,Governor,,R,Sam Brownback,187
-Shawnee,10 West Silver Lake,Governor,,R,Sam Brownback,125
-Shawnee,12 Grove,Governor,,R,Sam Brownback,145
-Shawnee,14 Kiro,Governor,,R,Sam Brownback,237
-Shawnee,15 Messhoss Creek,Governor,,R,Sam Brownback,125
-Shawnee,22 Little Muddy Creek,Governor,,R,Sam Brownback,140
-Shawnee,24 Sac,Governor,,R,Sam Brownback,206
-Shawnee,25 Sherman,Governor,,R,Sam Brownback,178
-Shawnee,26 Iroquois,Governor,,R,Sam Brownback,170
-Shawnee,28 West Wichita,Governor,,R,Sam Brownback,161
-Shawnee,29 Indianola,Governor,,R,Sam Brownback,203
-Shawnee,30 Apache,Governor,,R,Sam Brownback,192
-Shawnee,31 East Wichita,Governor,,R,Sam Brownback,262
-Shawnee,32 Fox,Governor,,R,Sam Brownback,218
-Shawnee,33 Elmont,Governor,,R,Sam Brownback,258
-Shawnee,34 Kilmer,Governor,,R,Sam Brownback,66
-Shawnee,35 Rochester,Governor,,R,Sam Brownback,177
-Shawnee,36 East Soldier,Governor,,R,Sam Brownback,184
-Shawnee,37 Whitfield,Governor,,R,Sam Brownback,135
-Shawnee,38 Sioux,Governor,,R,Sam Brownback,162
-Shawnee,39 Pottawatomie,Governor,,R,Sam Brownback,205
-Shawnee,40 Stinson Creek,Governor,,R,Sam Brownback,58
-Shawnee,41 North Tecumseh,Governor,,R,Sam Brownback,139
-Shawnee,42 South Tecumseh,Governor,,R,Sam Brownback,147
-Shawnee,43 Pawnee,Governor,,R,Sam Brownback,256
-Shawnee,44 Kaw,Governor,,R,Sam Brownback,182
-Shawnee,45 Peck,Governor,,R,Sam Brownback,116
-Shawnee,46 East Peck,Governor,,R,Sam Brownback,131
-Shawnee,47 Kiowa,Governor,,R,Sam Brownback,230
-Shawnee,48 Cheyenne,Governor,,R,Sam Brownback,151
-Shawnee,49 Ponca,Governor,,R,Sam Brownback,118
-Shawnee,52 Deer Creek,Governor,,R,Sam Brownback,8
-Shawnee,53 Pauline,Governor,,R,Sam Brownback,64
-Shawnee,54 West Potter,Governor,,R,Sam Brownback,38
-Shawnee,55 Central Pauline,Governor,,R,Sam Brownback,29
-Shawnee,56 NW Monmouth,Governor,,R,Sam Brownback,273
-Shawnee,57 NE Monmouth,Governor,,R,Sam Brownback,191
-Shawnee,58 S Monmouth,Governor,,R,Sam Brownback,261
-Shawnee,62 Forbes,Governor,,R,Sam Brownback,26
-Shawnee,63 Montara,Governor,,R,Sam Brownback,74
-Shawnee,64 Cullen,Governor,,R,Sam Brownback,94
-Shawnee,65 Wakarusa,Governor,,R,Sam Brownback,208
-Shawnee,66 Kingston,Governor,,R,Sam Brownback,61
-Shawnee,72 City of Auburn,Governor,,R,Sam Brownback,172
-Shawnee,73 Meadowlark,Governor,,R,Sam Brownback,317
-Shawnee,74 Buffalo,Governor,,R,Sam Brownback,205
-Shawnee,80 Gaillardia,Governor,,R,Sam Brownback,217
-Shawnee,81 Dover,Governor,,R,Sam Brownback,168
-Shawnee,82 Willard,Governor,,R,Sam Brownback,176
-Shawnee,84 Yucca,Governor,,R,Sam Brownback,51
-Shawnee,85 Aldersgate,Governor,,R,Sam Brownback,82
-Shawnee,86 Sunflower,Governor,,R,Sam Brownback,358
-Shawnee,87 Washburn,Governor,,R,Sam Brownback,183
-Shawnee,89 North Mission,Governor,,R,Sam Brownback,75
-Shawnee,90 South Mission,Governor,,R,Sam Brownback,156
-Shawnee,91 Central Mission,Governor,,R,Sam Brownback,277
-Shawnee,92 Sherwood,Governor,,R,Sam Brownback,174
-Shawnee,93 South Sherwood,Governor,,R,Sam Brownback,151
-Shawnee,94 Indian Hills,Governor,,R,Sam Brownback,154
-Shawnee,95 York,Governor,,R,Sam Brownback,217
-Shawnee,96 Vaquero,Governor,,R,Sam Brownback,146
-Shawnee,97 York Outer,Governor,,R,Sam Brownback,26
-Shawnee,99 Verbena,Governor,,R,Sam Brownback,38
-Shawnee,1 East Rossville,Governor,,D,Paul Davis,208
-Shawnee,2 West Rossville,Governor,,D,Paul Davis,120
-Shawnee,9 East Silver Lake,Governor,,D,Paul Davis,295
-Shawnee,10 West Silver Lake,Governor,,D,Paul Davis,215
-Shawnee,12 Grove,Governor,,D,Paul Davis,136
-Shawnee,14 Kiro,Governor,,D,Paul Davis,214
-Shawnee,15 Messhoss Creek,Governor,,D,Paul Davis,134
-Shawnee,22 Little Muddy Creek,Governor,,D,Paul Davis,140
-Shawnee,24 Sac,Governor,,D,Paul Davis,261
-Shawnee,25 Sherman,Governor,,D,Paul Davis,211
-Shawnee,26 Iroquois,Governor,,D,Paul Davis,237
-Shawnee,28 West Wichita,Governor,,D,Paul Davis,207
-Shawnee,29 Indianola,Governor,,D,Paul Davis,245
-Shawnee,30 Apache,Governor,,D,Paul Davis,205
-Shawnee,31 East Wichita,Governor,,D,Paul Davis,342
-Shawnee,32 Fox,Governor,,D,Paul Davis,214
-Shawnee,33 Elmont,Governor,,D,Paul Davis,312
-Shawnee,34 Kilmer,Governor,,D,Paul Davis,55
-Shawnee,35 Rochester,Governor,,D,Paul Davis,219
-Shawnee,36 East Soldier,Governor,,D,Paul Davis,267
-Shawnee,37 Whitfield,Governor,,D,Paul Davis,191
-Shawnee,38 Sioux,Governor,,D,Paul Davis,190
-Shawnee,39 Pottawatomie,Governor,,D,Paul Davis,238
-Shawnee,40 Stinson Creek,Governor,,D,Paul Davis,97
-Shawnee,41 North Tecumseh,Governor,,D,Paul Davis,203
-Shawnee,42 South Tecumseh,Governor,,D,Paul Davis,218
-Shawnee,43 Pawnee,Governor,,D,Paul Davis,248
-Shawnee,44 Kaw,Governor,,D,Paul Davis,242
-Shawnee,45 Peck,Governor,,D,Paul Davis,174
-Shawnee,46 East Peck,Governor,,D,Paul Davis,140
-Shawnee,47 Kiowa,Governor,,D,Paul Davis,364
-Shawnee,48 Cheyenne,Governor,,D,Paul Davis,255
-Shawnee,49 Ponca,Governor,,D,Paul Davis,160
-Shawnee,52 Deer Creek,Governor,,D,Paul Davis,10
-Shawnee,53 Pauline,Governor,,D,Paul Davis,106
-Shawnee,54 West Potter,Governor,,D,Paul Davis,21
-Shawnee,55 Central Pauline,Governor,,D,Paul Davis,33
-Shawnee,56 NW Monmouth,Governor,,D,Paul Davis,284
-Shawnee,57 NE Monmouth,Governor,,D,Paul Davis,254
-Shawnee,58 S Monmouth,Governor,,D,Paul Davis,303
-Shawnee,62 Forbes,Governor,,D,Paul Davis,21
-Shawnee,63 Montara,Governor,,D,Paul Davis,121
-Shawnee,64 Cullen,Governor,,D,Paul Davis,161
-Shawnee,65 Wakarusa,Governor,,D,Paul Davis,211
-Shawnee,66 Kingston,Governor,,D,Paul Davis,49
-Shawnee,72 City of Auburn,Governor,,D,Paul Davis,189
-Shawnee,73 Meadowlark,Governor,,D,Paul Davis,235
-Shawnee,74 Buffalo,Governor,,D,Paul Davis,162
-Shawnee,80 Gaillardia,Governor,,D,Paul Davis,193
-Shawnee,81 Dover,Governor,,D,Paul Davis,142
-Shawnee,82 Willard,Governor,,D,Paul Davis,153
-Shawnee,84 Yucca,Governor,,D,Paul Davis,56
-Shawnee,85 Aldersgate,Governor,,D,Paul Davis,118
-Shawnee,86 Sunflower,Governor,,D,Paul Davis,298
-Shawnee,87 Washburn,Governor,,D,Paul Davis,155
-Shawnee,89 North Mission,Governor,,D,Paul Davis,43
-Shawnee,90 South Mission,Governor,,D,Paul Davis,147
-Shawnee,91 Central Mission,Governor,,D,Paul Davis,239
-Shawnee,92 Sherwood,Governor,,D,Paul Davis,190
-Shawnee,93 South Sherwood,Governor,,D,Paul Davis,146
-Shawnee,94 Indian Hills,Governor,,D,Paul Davis,220
-Shawnee,95 York,Governor,,D,Paul Davis,212
-Shawnee,96 Vaquero,Governor,,D,Paul Davis,160
-Shawnee,97 York Outer,Governor,,D,Paul Davis,24
-Shawnee,99 Verbena,Governor,,D,Paul Davis,34
-Shawnee,1 East Rossville,Governor,,L,Keen Umbehr,25
-Shawnee,2 West Rossville,Governor,,L,Keen Umbehr,15
-Shawnee,9 East Silver Lake,Governor,,L,Keen Umbehr,17
-Shawnee,10 West Silver Lake,Governor,,L,Keen Umbehr,16
-Shawnee,12 Grove,Governor,,L,Keen Umbehr,12
-Shawnee,14 Kiro,Governor,,L,Keen Umbehr,19
-Shawnee,15 Messhoss Creek,Governor,,L,Keen Umbehr,12
-Shawnee,22 Little Muddy Creek,Governor,,L,Keen Umbehr,12
-Shawnee,24 Sac,Governor,,L,Keen Umbehr,20
-Shawnee,25 Sherman,Governor,,L,Keen Umbehr,26
-Shawnee,26 Iroquois,Governor,,L,Keen Umbehr,10
-Shawnee,28 West Wichita,Governor,,L,Keen Umbehr,17
-Shawnee,29 Indianola,Governor,,L,Keen Umbehr,16
-Shawnee,30 Apache,Governor,,L,Keen Umbehr,13
-Shawnee,31 East Wichita,Governor,,L,Keen Umbehr,19
-Shawnee,32 Fox,Governor,,L,Keen Umbehr,21
-Shawnee,33 Elmont,Governor,,L,Keen Umbehr,25
-Shawnee,34 Kilmer,Governor,,L,Keen Umbehr,5
-Shawnee,35 Rochester,Governor,,L,Keen Umbehr,22
-Shawnee,36 East Soldier,Governor,,L,Keen Umbehr,19
-Shawnee,37 Whitfield,Governor,,L,Keen Umbehr,15
-Shawnee,38 Sioux,Governor,,L,Keen Umbehr,25
-Shawnee,39 Pottawatomie,Governor,,L,Keen Umbehr,15
-Shawnee,40 Stinson Creek,Governor,,L,Keen Umbehr,2
-Shawnee,41 North Tecumseh,Governor,,L,Keen Umbehr,19
-Shawnee,42 South Tecumseh,Governor,,L,Keen Umbehr,8
-Shawnee,43 Pawnee,Governor,,L,Keen Umbehr,14
-Shawnee,44 Kaw,Governor,,L,Keen Umbehr,11
-Shawnee,45 Peck,Governor,,L,Keen Umbehr,3
-Shawnee,46 East Peck,Governor,,L,Keen Umbehr,6
-Shawnee,47 Kiowa,Governor,,L,Keen Umbehr,16
-Shawnee,48 Cheyenne,Governor,,L,Keen Umbehr,19
-Shawnee,49 Ponca,Governor,,L,Keen Umbehr,3
-Shawnee,52 Deer Creek,Governor,,L,Keen Umbehr,1
-Shawnee,53 Pauline,Governor,,L,Keen Umbehr,8
-Shawnee,54 West Potter,Governor,,L,Keen Umbehr,1
-Shawnee,55 Central Pauline,Governor,,L,Keen Umbehr,8
-Shawnee,56 NW Monmouth,Governor,,L,Keen Umbehr,15
-Shawnee,57 NE Monmouth,Governor,,L,Keen Umbehr,10
-Shawnee,58 S Monmouth,Governor,,L,Keen Umbehr,21
-Shawnee,62 Forbes,Governor,,L,Keen Umbehr,2
-Shawnee,63 Montara,Governor,,L,Keen Umbehr,13
-Shawnee,64 Cullen,Governor,,L,Keen Umbehr,22
-Shawnee,65 Wakarusa,Governor,,L,Keen Umbehr,25
-Shawnee,66 Kingston,Governor,,L,Keen Umbehr,7
-Shawnee,72 City of Auburn,Governor,,L,Keen Umbehr,25
-Shawnee,73 Meadowlark,Governor,,L,Keen Umbehr,22
-Shawnee,74 Buffalo,Governor,,L,Keen Umbehr,24
-Shawnee,80 Gaillardia,Governor,,L,Keen Umbehr,8
-Shawnee,81 Dover,Governor,,L,Keen Umbehr,15
-Shawnee,82 Willard,Governor,,L,Keen Umbehr,14
-Shawnee,84 Yucca,Governor,,L,Keen Umbehr,4
-Shawnee,85 Aldersgate,Governor,,L,Keen Umbehr,5
-Shawnee,86 Sunflower,Governor,,L,Keen Umbehr,16
-Shawnee,87 Washburn,Governor,,L,Keen Umbehr,10
-Shawnee,89 North Mission,Governor,,L,Keen Umbehr,3
-Shawnee,90 South Mission,Governor,,L,Keen Umbehr,17
-Shawnee,91 Central Mission,Governor,,L,Keen Umbehr,17
-Shawnee,92 Sherwood,Governor,,L,Keen Umbehr,7
-Shawnee,93 South Sherwood,Governor,,L,Keen Umbehr,5
-Shawnee,94 Indian Hills,Governor,,L,Keen Umbehr,11
-Shawnee,95 York,Governor,,L,Keen Umbehr,10
-Shawnee,96 Vaquero,Governor,,L,Keen Umbehr,18
-Shawnee,97 York Outer,Governor,,L,Keen Umbehr,2
-Shawnee,99 Verbena,Governor,,L,Keen Umbehr,4
-Shawnee,1 East Rossville,Secretary of State,,R,Kris Kobach,267
-Shawnee,2 West Rossville,Secretary of State,,R,Kris Kobach,212
-Shawnee,9 East Silver Lake,Secretary of State,,R,Kris Kobach,270
-Shawnee,10 West Silver Lake,Secretary of State,,R,Kris Kobach,210
-Shawnee,12 Grove,Secretary of State,,R,Kris Kobach,195
-Shawnee,14 Kiro,Secretary of State,,R,Kris Kobach,296
-Shawnee,15 Messhoss Creek,Secretary of State,,R,Kris Kobach,175
-Shawnee,22 Little Muddy Creek,Secretary of State,,R,Kris Kobach,182
-Shawnee,24 Sac,Secretary of State,,R,Kris Kobach,287
-Shawnee,25 Sherman,Secretary of State,,R,Kris Kobach,257
-Shawnee,26 Iroquois,Secretary of State,,R,Kris Kobach,243
-Shawnee,28 West Wichita,Secretary of State,,R,Kris Kobach,218
-Shawnee,29 Indianola,Secretary of State,,R,Kris Kobach,252
-Shawnee,30 Apache,Secretary of State,,R,Kris Kobach,249
-Shawnee,31 East Wichita,Secretary of State,,R,Kris Kobach,371
-Shawnee,32 Fox,Secretary of State,,R,Kris Kobach,288
-Shawnee,33 Elmont,Secretary of State,,R,Kris Kobach,356
-Shawnee,34 Kilmer,Secretary of State,,R,Kris Kobach,79
-Shawnee,35 Rochester,Secretary of State,,R,Kris Kobach,245
-Shawnee,36 East Soldier,Secretary of State,,R,Kris Kobach,250
-Shawnee,37 Whitfield,Secretary of State,,R,Kris Kobach,208
-Shawnee,38 Sioux,Secretary of State,,R,Kris Kobach,231
-Shawnee,39 Pottawatomie,Secretary of State,,R,Kris Kobach,267
-Shawnee,40 Stinson Creek,Secretary of State,,R,Kris Kobach,84
-Shawnee,41 North Tecumseh,Secretary of State,,R,Kris Kobach,195
-Shawnee,42 South Tecumseh,Secretary of State,,R,Kris Kobach,191
-Shawnee,43 Pawnee,Secretary of State,,R,Kris Kobach,317
-Shawnee,44 Kaw,Secretary of State,,R,Kris Kobach,242
-Shawnee,45 Peck,Secretary of State,,R,Kris Kobach,149
-Shawnee,46 East Peck,Secretary of State,,R,Kris Kobach,163
-Shawnee,47 Kiowa,Secretary of State,,R,Kris Kobach,322
-Shawnee,48 Cheyenne,Secretary of State,,R,Kris Kobach,224
-Shawnee,49 Ponca,Secretary of State,,R,Kris Kobach,150
-Shawnee,52 Deer Creek,Secretary of State,,R,Kris Kobach,10
-Shawnee,53 Pauline,Secretary of State,,R,Kris Kobach,92
-Shawnee,54 West Potter,Secretary of State,,R,Kris Kobach,39
-Shawnee,55 Central Pauline,Secretary of State,,R,Kris Kobach,47
-Shawnee,56 NW Monmouth,Secretary of State,,R,Kris Kobach,369
-Shawnee,57 NE Monmouth,Secretary of State,,R,Kris Kobach,254
-Shawnee,58 S Monmouth,Secretary of State,,R,Kris Kobach,346
-Shawnee,62 Forbes,Secretary of State,,R,Kris Kobach,28
-Shawnee,63 Montara,Secretary of State,,R,Kris Kobach,101
-Shawnee,64 Cullen,Secretary of State,,R,Kris Kobach,137
-Shawnee,65 Wakarusa,Secretary of State,,R,Kris Kobach,288
-Shawnee,66 Kingston,Secretary of State,,R,Kris Kobach,80
-Shawnee,72 City of Auburn,Secretary of State,,R,Kris Kobach,239
-Shawnee,73 Meadowlark,Secretary of State,,R,Kris Kobach,382
-Shawnee,74 Buffalo,Secretary of State,,R,Kris Kobach,256
-Shawnee,80 Gaillardia,Secretary of State,,R,Kris Kobach,258
-Shawnee,81 Dover,Secretary of State,,R,Kris Kobach,200
-Shawnee,82 Willard,Secretary of State,,R,Kris Kobach,222
-Shawnee,84 Yucca,Secretary of State,,R,Kris Kobach,67
-Shawnee,85 Aldersgate,Secretary of State,,R,Kris Kobach,112
-Shawnee,86 Sunflower,Secretary of State,,R,Kris Kobach,426
-Shawnee,87 Washburn,Secretary of State,,R,Kris Kobach,216
-Shawnee,89 North Mission,Secretary of State,,R,Kris Kobach,80
-Shawnee,90 South Mission,Secretary of State,,R,Kris Kobach,204
-Shawnee,91 Central Mission,Secretary of State,,R,Kris Kobach,332
-Shawnee,92 Sherwood,Secretary of State,,R,Kris Kobach,214
-Shawnee,93 South Sherwood,Secretary of State,,R,Kris Kobach,181
-Shawnee,94 Indian Hills,Secretary of State,,R,Kris Kobach,230
-Shawnee,95 York,Secretary of State,,R,Kris Kobach,257
-Shawnee,96 Vaquero,Secretary of State,,R,Kris Kobach,192
-Shawnee,97 York Outer,Secretary of State,,R,Kris Kobach,34
-Shawnee,99 Verbena,Secretary of State,,R,Kris Kobach,48
-Shawnee,1 East Rossville,Secretary of State,,D,Jean Schodorf,142
-Shawnee,2 West Rossville,Secretary of State,,D,Jean Schodorf,99
-Shawnee,9 East Silver Lake,Secretary of State,,D,Jean Schodorf,228
-Shawnee,10 West Silver Lake,Secretary of State,,D,Jean Schodorf,143
-Shawnee,12 Grove,Secretary of State,,D,Jean Schodorf,96
-Shawnee,14 Kiro,Secretary of State,,D,Jean Schodorf,166
-Shawnee,15 Messhoss Creek,Secretary of State,,D,Jean Schodorf,94
-Shawnee,22 Little Muddy Creek,Secretary of State,,D,Jean Schodorf,105
-Shawnee,24 Sac,Secretary of State,,D,Jean Schodorf,193
-Shawnee,25 Sherman,Secretary of State,,D,Jean Schodorf,156
-Shawnee,26 Iroquois,Secretary of State,,D,Jean Schodorf,169
-Shawnee,28 West Wichita,Secretary of State,,D,Jean Schodorf,163
-Shawnee,29 Indianola,Secretary of State,,D,Jean Schodorf,204
-Shawnee,30 Apache,Secretary of State,,D,Jean Schodorf,156
-Shawnee,31 East Wichita,Secretary of State,,D,Jean Schodorf,248
-Shawnee,32 Fox,Secretary of State,,D,Jean Schodorf,164
-Shawnee,33 Elmont,Secretary of State,,D,Jean Schodorf,230
-Shawnee,34 Kilmer,Secretary of State,,D,Jean Schodorf,45
-Shawnee,35 Rochester,Secretary of State,,D,Jean Schodorf,171
-Shawnee,36 East Soldier,Secretary of State,,D,Jean Schodorf,214
-Shawnee,37 Whitfield,Secretary of State,,D,Jean Schodorf,133
-Shawnee,38 Sioux,Secretary of State,,D,Jean Schodorf,142
-Shawnee,39 Pottawatomie,Secretary of State,,D,Jean Schodorf,193
-Shawnee,40 Stinson Creek,Secretary of State,,D,Jean Schodorf,69
-Shawnee,41 North Tecumseh,Secretary of State,,D,Jean Schodorf,162
-Shawnee,42 South Tecumseh,Secretary of State,,D,Jean Schodorf,183
-Shawnee,43 Pawnee,Secretary of State,,D,Jean Schodorf,194
-Shawnee,44 Kaw,Secretary of State,,D,Jean Schodorf,188
-Shawnee,45 Peck,Secretary of State,,D,Jean Schodorf,141
-Shawnee,46 East Peck,Secretary of State,,D,Jean Schodorf,113
-Shawnee,47 Kiowa,Secretary of State,,D,Jean Schodorf,281
-Shawnee,48 Cheyenne,Secretary of State,,D,Jean Schodorf,201
-Shawnee,49 Ponca,Secretary of State,,D,Jean Schodorf,129
-Shawnee,52 Deer Creek,Secretary of State,,D,Jean Schodorf,9
-Shawnee,53 Pauline,Secretary of State,,D,Jean Schodorf,82
-Shawnee,54 West Potter,Secretary of State,,D,Jean Schodorf,22
-Shawnee,55 Central Pauline,Secretary of State,,D,Jean Schodorf,22
-Shawnee,56 NW Monmouth,Secretary of State,,D,Jean Schodorf,202
-Shawnee,57 NE Monmouth,Secretary of State,,D,Jean Schodorf,201
-Shawnee,58 S Monmouth,Secretary of State,,D,Jean Schodorf,233
-Shawnee,62 Forbes,Secretary of State,,D,Jean Schodorf,20
-Shawnee,63 Montara,Secretary of State,,D,Jean Schodorf,106
-Shawnee,64 Cullen,Secretary of State,,D,Jean Schodorf,136
-Shawnee,65 Wakarusa,Secretary of State,,D,Jean Schodorf,148
-Shawnee,66 Kingston,Secretary of State,,D,Jean Schodorf,34
-Shawnee,72 City of Auburn,Secretary of State,,D,Jean Schodorf,145
-Shawnee,73 Meadowlark,Secretary of State,,D,Jean Schodorf,187
-Shawnee,74 Buffalo,Secretary of State,,D,Jean Schodorf,131
-Shawnee,80 Gaillardia,Secretary of State,,D,Jean Schodorf,154
-Shawnee,81 Dover,Secretary of State,,D,Jean Schodorf,123
-Shawnee,82 Willard,Secretary of State,,D,Jean Schodorf,119
-Shawnee,84 Yucca,Secretary of State,,D,Jean Schodorf,43
-Shawnee,85 Aldersgate,Secretary of State,,D,Jean Schodorf,94
-Shawnee,86 Sunflower,Secretary of State,,D,Jean Schodorf,245
-Shawnee,87 Washburn,Secretary of State,,D,Jean Schodorf,130
-Shawnee,89 North Mission,Secretary of State,,D,Jean Schodorf,39
-Shawnee,90 South Mission,Secretary of State,,D,Jean Schodorf,118
-Shawnee,91 Central Mission,Secretary of State,,D,Jean Schodorf,194
-Shawnee,92 Sherwood,Secretary of State,,D,Jean Schodorf,155
-Shawnee,93 South Sherwood,Secretary of State,,D,Jean Schodorf,114
-Shawnee,94 Indian Hills,Secretary of State,,D,Jean Schodorf,153
-Shawnee,95 York,Secretary of State,,D,Jean Schodorf,176
-Shawnee,96 Vaquero,Secretary of State,,D,Jean Schodorf,132
-Shawnee,97 York Outer,Secretary of State,,D,Jean Schodorf,18
-Shawnee,99 Verbena,Secretary of State,,D,Jean Schodorf,28
-Shawnee,1 East Rossville,Attorney General,,R,Derek Schmidt,293
-Shawnee,2 West Rossville,Attorney General,,R,Derek Schmidt,223
-Shawnee,9 East Silver Lake,Attorney General,,R,Derek Schmidt,307
-Shawnee,10 West Silver Lake,Attorney General,,R,Derek Schmidt,225
-Shawnee,12 Grove,Attorney General,,R,Derek Schmidt,225
-Shawnee,14 Kiro,Attorney General,,R,Derek Schmidt,326
-Shawnee,15 Messhoss Creek,Attorney General,,R,Derek Schmidt,185
-Shawnee,22 Little Muddy Creek,Attorney General,,R,Derek Schmidt,209
-Shawnee,24 Sac,Attorney General,,R,Derek Schmidt,306
-Shawnee,25 Sherman,Attorney General,,R,Derek Schmidt,278
-Shawnee,26 Iroquois,Attorney General,,R,Derek Schmidt,276
-Shawnee,28 West Wichita,Attorney General,,R,Derek Schmidt,228
-Shawnee,29 Indianola,Attorney General,,R,Derek Schmidt,314
-Shawnee,30 Apache,Attorney General,,R,Derek Schmidt,279
-Shawnee,31 East Wichita,Attorney General,,R,Derek Schmidt,412
-Shawnee,32 Fox,Attorney General,,R,Derek Schmidt,299
-Shawnee,33 Elmont,Attorney General,,R,Derek Schmidt,393
-Shawnee,34 Kilmer,Attorney General,,R,Derek Schmidt,88
-Shawnee,35 Rochester,Attorney General,,R,Derek Schmidt,275
-Shawnee,36 East Soldier,Attorney General,,R,Derek Schmidt,295
-Shawnee,37 Whitfield,Attorney General,,R,Derek Schmidt,211
-Shawnee,38 Sioux,Attorney General,,R,Derek Schmidt,247
-Shawnee,39 Pottawatomie,Attorney General,,R,Derek Schmidt,296
-Shawnee,40 Stinson Creek,Attorney General,,R,Derek Schmidt,91
-Shawnee,41 North Tecumseh,Attorney General,,R,Derek Schmidt,218
-Shawnee,42 South Tecumseh,Attorney General,,R,Derek Schmidt,220
-Shawnee,43 Pawnee,Attorney General,,R,Derek Schmidt,345
-Shawnee,44 Kaw,Attorney General,,R,Derek Schmidt,266
-Shawnee,45 Peck,Attorney General,,R,Derek Schmidt,180
-Shawnee,46 East Peck,Attorney General,,R,Derek Schmidt,185
-Shawnee,47 Kiowa,Attorney General,,R,Derek Schmidt,368
-Shawnee,48 Cheyenne,Attorney General,,R,Derek Schmidt,270
-Shawnee,49 Ponca,Attorney General,,R,Derek Schmidt,189
-Shawnee,52 Deer Creek,Attorney General,,R,Derek Schmidt,14
-Shawnee,53 Pauline,Attorney General,,R,Derek Schmidt,106
-Shawnee,54 West Potter,Attorney General,,R,Derek Schmidt,45
-Shawnee,55 Central Pauline,Attorney General,,R,Derek Schmidt,42
-Shawnee,56 NW Monmouth,Attorney General,,R,Derek Schmidt,405
-Shawnee,57 NE Monmouth,Attorney General,,R,Derek Schmidt,303
-Shawnee,58 S Monmouth,Attorney General,,R,Derek Schmidt,380
-Shawnee,62 Forbes,Attorney General,,R,Derek Schmidt,29
-Shawnee,63 Montara,Attorney General,,R,Derek Schmidt,115
-Shawnee,64 Cullen,Attorney General,,R,Derek Schmidt,149
-Shawnee,65 Wakarusa,Attorney General,,R,Derek Schmidt,300
-Shawnee,66 Kingston,Attorney General,,R,Derek Schmidt,84
-Shawnee,72 City of Auburn,Attorney General,,R,Derek Schmidt,261
-Shawnee,73 Meadowlark,Attorney General,,R,Derek Schmidt,409
-Shawnee,74 Buffalo,Attorney General,,R,Derek Schmidt,283
-Shawnee,80 Gaillardia,Attorney General,,R,Derek Schmidt,292
-Shawnee,81 Dover,Attorney General,,R,Derek Schmidt,226
-Shawnee,82 Willard,Attorney General,,R,Derek Schmidt,252
-Shawnee,84 Yucca,Attorney General,,R,Derek Schmidt,81
-Shawnee,85 Aldersgate,Attorney General,,R,Derek Schmidt,124
-Shawnee,86 Sunflower,Attorney General,,R,Derek Schmidt,477
-Shawnee,87 Washburn,Attorney General,,R,Derek Schmidt,234
-Shawnee,89 North Mission,Attorney General,,R,Derek Schmidt,85
-Shawnee,90 South Mission,Attorney General,,R,Derek Schmidt,219
-Shawnee,91 Central Mission,Attorney General,,R,Derek Schmidt,357
-Shawnee,92 Sherwood,Attorney General,,R,Derek Schmidt,235
-Shawnee,93 South Sherwood,Attorney General,,R,Derek Schmidt,195
-Shawnee,94 Indian Hills,Attorney General,,R,Derek Schmidt,257
-Shawnee,95 York,Attorney General,,R,Derek Schmidt,295
-Shawnee,96 Vaquero,Attorney General,,R,Derek Schmidt,195
-Shawnee,97 York Outer,Attorney General,,R,Derek Schmidt,38
-Shawnee,99 Verbena,Attorney General,,R,Derek Schmidt,53
-Shawnee,1 East Rossville,Attorney General,,D,A J Kotich,110
-Shawnee,2 West Rossville,Attorney General,,D,A J Kotich,81
-Shawnee,9 East Silver Lake,Attorney General,,D,A J Kotich,186
-Shawnee,10 West Silver Lake,Attorney General,,D,A J Kotich,120
-Shawnee,12 Grove,Attorney General,,D,A J Kotich,63
-Shawnee,14 Kiro,Attorney General,,D,A J Kotich,133
-Shawnee,15 Messhoss Creek,Attorney General,,D,A J Kotich,84
-Shawnee,22 Little Muddy Creek,Attorney General,,D,A J Kotich,78
-Shawnee,24 Sac,Attorney General,,D,A J Kotich,170
-Shawnee,25 Sherman,Attorney General,,D,A J Kotich,135
-Shawnee,26 Iroquois,Attorney General,,D,A J Kotich,134
-Shawnee,28 West Wichita,Attorney General,,D,A J Kotich,146
-Shawnee,29 Indianola,Attorney General,,D,A J Kotich,141
-Shawnee,30 Apache,Attorney General,,D,A J Kotich,120
-Shawnee,31 East Wichita,Attorney General,,D,A J Kotich,194
-Shawnee,32 Fox,Attorney General,,D,A J Kotich,147
-Shawnee,33 Elmont,Attorney General,,D,A J Kotich,183
-Shawnee,34 Kilmer,Attorney General,,D,A J Kotich,36
-Shawnee,35 Rochester,Attorney General,,D,A J Kotich,136
-Shawnee,36 East Soldier,Attorney General,,D,A J Kotich,163
-Shawnee,37 Whitfield,Attorney General,,D,A J Kotich,125
-Shawnee,38 Sioux,Attorney General,,D,A J Kotich,124
-Shawnee,39 Pottawatomie,Attorney General,,D,A J Kotich,158
-Shawnee,40 Stinson Creek,Attorney General,,D,A J Kotich,64
-Shawnee,41 North Tecumseh,Attorney General,,D,A J Kotich,133
-Shawnee,42 South Tecumseh,Attorney General,,D,A J Kotich,148
-Shawnee,43 Pawnee,Attorney General,,D,A J Kotich,164
-Shawnee,44 Kaw,Attorney General,,D,A J Kotich,157
-Shawnee,45 Peck,Attorney General,,D,A J Kotich,106
-Shawnee,46 East Peck,Attorney General,,D,A J Kotich,88
-Shawnee,47 Kiowa,Attorney General,,D,A J Kotich,225
-Shawnee,48 Cheyenne,Attorney General,,D,A J Kotich,154
-Shawnee,49 Ponca,Attorney General,,D,A J Kotich,92
-Shawnee,52 Deer Creek,Attorney General,,D,A J Kotich,5
-Shawnee,53 Pauline,Attorney General,,D,A J Kotich,70
-Shawnee,54 West Potter,Attorney General,,D,A J Kotich,16
-Shawnee,55 Central Pauline,Attorney General,,D,A J Kotich,23
-Shawnee,56 NW Monmouth,Attorney General,,D,A J Kotich,164
-Shawnee,57 NE Monmouth,Attorney General,,D,A J Kotich,146
-Shawnee,58 S Monmouth,Attorney General,,D,A J Kotich,195
-Shawnee,62 Forbes,Attorney General,,D,A J Kotich,19
-Shawnee,63 Montara,Attorney General,,D,A J Kotich,91
-Shawnee,64 Cullen,Attorney General,,D,A J Kotich,121
-Shawnee,65 Wakarusa,Attorney General,,D,A J Kotich,136
-Shawnee,66 Kingston,Attorney General,,D,A J Kotich,29
-Shawnee,72 City of Auburn,Attorney General,,D,A J Kotich,117
-Shawnee,73 Meadowlark,Attorney General,,D,A J Kotich,159
-Shawnee,74 Buffalo,Attorney General,,D,A J Kotich,98
-Shawnee,80 Gaillardia,Attorney General,,D,A J Kotich,119
-Shawnee,81 Dover,Attorney General,,D,A J Kotich,85
-Shawnee,82 Willard,Attorney General,,D,A J Kotich,81
-Shawnee,84 Yucca,Attorney General,,D,A J Kotich,28
-Shawnee,85 Aldersgate,Attorney General,,D,A J Kotich,81
-Shawnee,86 Sunflower,Attorney General,,D,A J Kotich,181
-Shawnee,87 Washburn,Attorney General,,D,A J Kotich,106
-Shawnee,89 North Mission,Attorney General,,D,A J Kotich,33
-Shawnee,90 South Mission,Attorney General,,D,A J Kotich,100
-Shawnee,91 Central Mission,Attorney General,,D,A J Kotich,166
-Shawnee,92 Sherwood,Attorney General,,D,A J Kotich,132
-Shawnee,93 South Sherwood,Attorney General,,D,A J Kotich,101
-Shawnee,94 Indian Hills,Attorney General,,D,A J Kotich,122
-Shawnee,95 York,Attorney General,,D,A J Kotich,129
-Shawnee,96 Vaquero,Attorney General,,D,A J Kotich,126
-Shawnee,97 York Outer,Attorney General,,D,A J Kotich,14
-Shawnee,99 Verbena,Attorney General,,D,A J Kotich,22
-Shawnee,1 East Rossville,State Treasurer,,R,Ron Estes,267
-Shawnee,2 West Rossville,State Treasurer,,R,Ron Estes,218
-Shawnee,9 East Silver Lake,State Treasurer,,R,Ron Estes,289
-Shawnee,10 West Silver Lake,State Treasurer,,R,Ron Estes,201
-Shawnee,12 Grove,State Treasurer,,R,Ron Estes,209
-Shawnee,14 Kiro,State Treasurer,,R,Ron Estes,314
-Shawnee,15 Messhoss Creek,State Treasurer,,R,Ron Estes,172
-Shawnee,22 Little Muddy Creek,State Treasurer,,R,Ron Estes,198
-Shawnee,24 Sac,State Treasurer,,R,Ron Estes,299
-Shawnee,25 Sherman,State Treasurer,,R,Ron Estes,257
-Shawnee,26 Iroquois,State Treasurer,,R,Ron Estes,259
-Shawnee,28 West Wichita,State Treasurer,,R,Ron Estes,231
-Shawnee,29 Indianola,State Treasurer,,R,Ron Estes,291
-Shawnee,30 Apache,State Treasurer,,R,Ron Estes,272
-Shawnee,31 East Wichita,State Treasurer,,R,Ron Estes,417
-Shawnee,32 Fox,State Treasurer,,R,Ron Estes,293
-Shawnee,33 Elmont,State Treasurer,,R,Ron Estes,374
-Shawnee,34 Kilmer,State Treasurer,,R,Ron Estes,86
-Shawnee,35 Rochester,State Treasurer,,R,Ron Estes,262
-Shawnee,36 East Soldier,State Treasurer,,R,Ron Estes,266
-Shawnee,37 Whitfield,State Treasurer,,R,Ron Estes,202
-Shawnee,38 Sioux,State Treasurer,,R,Ron Estes,224
-Shawnee,39 Pottawatomie,State Treasurer,,R,Ron Estes,267
-Shawnee,40 Stinson Creek,State Treasurer,,R,Ron Estes,88
-Shawnee,41 North Tecumseh,State Treasurer,,R,Ron Estes,214
-Shawnee,42 South Tecumseh,State Treasurer,,R,Ron Estes,213
-Shawnee,43 Pawnee,State Treasurer,,R,Ron Estes,326
-Shawnee,44 Kaw,State Treasurer,,R,Ron Estes,252
-Shawnee,45 Peck,State Treasurer,,R,Ron Estes,172
-Shawnee,46 East Peck,State Treasurer,,R,Ron Estes,168
-Shawnee,47 Kiowa,State Treasurer,,R,Ron Estes,351
-Shawnee,48 Cheyenne,State Treasurer,,R,Ron Estes,243
-Shawnee,49 Ponca,State Treasurer,,R,Ron Estes,172
-Shawnee,52 Deer Creek,State Treasurer,,R,Ron Estes,12
-Shawnee,53 Pauline,State Treasurer,,R,Ron Estes,92
-Shawnee,54 West Potter,State Treasurer,,R,Ron Estes,45
-Shawnee,55 Central Pauline,State Treasurer,,R,Ron Estes,44
-Shawnee,56 NW Monmouth,State Treasurer,,R,Ron Estes,388
-Shawnee,57 NE Monmouth,State Treasurer,,R,Ron Estes,291
-Shawnee,58 S Monmouth,State Treasurer,,R,Ron Estes,361
-Shawnee,62 Forbes,State Treasurer,,R,Ron Estes,29
-Shawnee,63 Montara,State Treasurer,,R,Ron Estes,101
-Shawnee,64 Cullen,State Treasurer,,R,Ron Estes,144
-Shawnee,65 Wakarusa,State Treasurer,,R,Ron Estes,293
-Shawnee,66 Kingston,State Treasurer,,R,Ron Estes,77
-Shawnee,72 City of Auburn,State Treasurer,,R,Ron Estes,242
-Shawnee,73 Meadowlark,State Treasurer,,R,Ron Estes,383
-Shawnee,74 Buffalo,State Treasurer,,R,Ron Estes,270
-Shawnee,80 Gaillardia,State Treasurer,,R,Ron Estes,290
-Shawnee,81 Dover,State Treasurer,,R,Ron Estes,213
-Shawnee,82 Willard,State Treasurer,,R,Ron Estes,233
-Shawnee,84 Yucca,State Treasurer,,R,Ron Estes,72
-Shawnee,85 Aldersgate,State Treasurer,,R,Ron Estes,113
-Shawnee,86 Sunflower,State Treasurer,,R,Ron Estes,462
-Shawnee,87 Washburn,State Treasurer,,R,Ron Estes,227
-Shawnee,89 North Mission,State Treasurer,,R,Ron Estes,85
-Shawnee,90 South Mission,State Treasurer,,R,Ron Estes,213
-Shawnee,91 Central Mission,State Treasurer,,R,Ron Estes,359
-Shawnee,92 Sherwood,State Treasurer,,R,Ron Estes,238
-Shawnee,93 South Sherwood,State Treasurer,,R,Ron Estes,211
-Shawnee,94 Indian Hills,State Treasurer,,R,Ron Estes,235
-Shawnee,95 York,State Treasurer,,R,Ron Estes,279
-Shawnee,96 Vaquero,State Treasurer,,R,Ron Estes,186
-Shawnee,97 York Outer,State Treasurer,,R,Ron Estes,34
-Shawnee,99 Verbena,State Treasurer,,R,Ron Estes,50
-Shawnee,1 East Rossville,State Treasurer,,D,Carmen Alldritt,133
-Shawnee,2 West Rossville,State Treasurer,,D,Carmen Alldritt,86
-Shawnee,9 East Silver Lake,State Treasurer,,D,Carmen Alldritt,201
-Shawnee,10 West Silver Lake,State Treasurer,,D,Carmen Alldritt,143
-Shawnee,12 Grove,State Treasurer,,D,Carmen Alldritt,79
-Shawnee,14 Kiro,State Treasurer,,D,Carmen Alldritt,140
-Shawnee,15 Messhoss Creek,State Treasurer,,D,Carmen Alldritt,92
-Shawnee,22 Little Muddy Creek,State Treasurer,,D,Carmen Alldritt,87
-Shawnee,24 Sac,State Treasurer,,D,Carmen Alldritt,175
-Shawnee,25 Sherman,State Treasurer,,D,Carmen Alldritt,147
-Shawnee,26 Iroquois,State Treasurer,,D,Carmen Alldritt,147
-Shawnee,28 West Wichita,State Treasurer,,D,Carmen Alldritt,142
-Shawnee,29 Indianola,State Treasurer,,D,Carmen Alldritt,161
-Shawnee,30 Apache,State Treasurer,,D,Carmen Alldritt,129
-Shawnee,31 East Wichita,State Treasurer,,D,Carmen Alldritt,188
-Shawnee,32 Fox,State Treasurer,,D,Carmen Alldritt,152
-Shawnee,33 Elmont,State Treasurer,,D,Carmen Alldritt,201
-Shawnee,34 Kilmer,State Treasurer,,D,Carmen Alldritt,33
-Shawnee,35 Rochester,State Treasurer,,D,Carmen Alldritt,144
-Shawnee,36 East Soldier,State Treasurer,,D,Carmen Alldritt,191
-Shawnee,37 Whitfield,State Treasurer,,D,Carmen Alldritt,127
-Shawnee,38 Sioux,State Treasurer,,D,Carmen Alldritt,141
-Shawnee,39 Pottawatomie,State Treasurer,,D,Carmen Alldritt,184
-Shawnee,40 Stinson Creek,State Treasurer,,D,Carmen Alldritt,63
-Shawnee,41 North Tecumseh,State Treasurer,,D,Carmen Alldritt,139
-Shawnee,42 South Tecumseh,State Treasurer,,D,Carmen Alldritt,151
-Shawnee,43 Pawnee,State Treasurer,,D,Carmen Alldritt,172
-Shawnee,44 Kaw,State Treasurer,,D,Carmen Alldritt,171
-Shawnee,45 Peck,State Treasurer,,D,Carmen Alldritt,112
-Shawnee,46 East Peck,State Treasurer,,D,Carmen Alldritt,99
-Shawnee,47 Kiowa,State Treasurer,,D,Carmen Alldritt,243
-Shawnee,48 Cheyenne,State Treasurer,,D,Carmen Alldritt,172
-Shawnee,49 Ponca,State Treasurer,,D,Carmen Alldritt,108
-Shawnee,52 Deer Creek,State Treasurer,,D,Carmen Alldritt,7
-Shawnee,53 Pauline,State Treasurer,,D,Carmen Alldritt,80
-Shawnee,54 West Potter,State Treasurer,,D,Carmen Alldritt,15
-Shawnee,55 Central Pauline,State Treasurer,,D,Carmen Alldritt,23
-Shawnee,56 NW Monmouth,State Treasurer,,D,Carmen Alldritt,178
-Shawnee,57 NE Monmouth,State Treasurer,,D,Carmen Alldritt,153
-Shawnee,58 S Monmouth,State Treasurer,,D,Carmen Alldritt,203
-Shawnee,62 Forbes,State Treasurer,,D,Carmen Alldritt,19
-Shawnee,63 Montara,State Treasurer,,D,Carmen Alldritt,102
-Shawnee,64 Cullen,State Treasurer,,D,Carmen Alldritt,126
-Shawnee,65 Wakarusa,State Treasurer,,D,Carmen Alldritt,138
-Shawnee,66 Kingston,State Treasurer,,D,Carmen Alldritt,34
-Shawnee,72 City of Auburn,State Treasurer,,D,Carmen Alldritt,139
-Shawnee,73 Meadowlark,State Treasurer,,D,Carmen Alldritt,177
-Shawnee,74 Buffalo,State Treasurer,,D,Carmen Alldritt,105
-Shawnee,80 Gaillardia,State Treasurer,,D,Carmen Alldritt,121
-Shawnee,81 Dover,State Treasurer,,D,Carmen Alldritt,100
-Shawnee,82 Willard,State Treasurer,,D,Carmen Alldritt,99
-Shawnee,84 Yucca,State Treasurer,,D,Carmen Alldritt,35
-Shawnee,85 Aldersgate,State Treasurer,,D,Carmen Alldritt,90
-Shawnee,86 Sunflower,State Treasurer,,D,Carmen Alldritt,190
-Shawnee,87 Washburn,State Treasurer,,D,Carmen Alldritt,112
-Shawnee,89 North Mission,State Treasurer,,D,Carmen Alldritt,32
-Shawnee,90 South Mission,State Treasurer,,D,Carmen Alldritt,102
-Shawnee,91 Central Mission,State Treasurer,,D,Carmen Alldritt,166
-Shawnee,92 Sherwood,State Treasurer,,D,Carmen Alldritt,128
-Shawnee,93 South Sherwood,State Treasurer,,D,Carmen Alldritt,79
-Shawnee,94 Indian Hills,State Treasurer,,D,Carmen Alldritt,139
-Shawnee,95 York,State Treasurer,,D,Carmen Alldritt,145
-Shawnee,96 Vaquero,State Treasurer,,D,Carmen Alldritt,131
-Shawnee,97 York Outer,State Treasurer,,D,Carmen Alldritt,17
-Shawnee,99 Verbena,State Treasurer,,D,Carmen Alldritt,23
-Shawnee,1 East Rossville,Insurance Commissioner,,R,Ken Selzer,235
-Shawnee,2 West Rossville,Insurance Commissioner,,R,Ken Selzer,205
-Shawnee,9 East Silver Lake,Insurance Commissioner,,R,Ken Selzer,248
-Shawnee,10 West Silver Lake,Insurance Commissioner,,R,Ken Selzer,182
-Shawnee,12 Grove,Insurance Commissioner,,R,Ken Selzer,200
-Shawnee,14 Kiro,Insurance Commissioner,,R,Ken Selzer,271
-Shawnee,15 Messhoss Creek,Insurance Commissioner,,R,Ken Selzer,160
-Shawnee,22 Little Muddy Creek,Insurance Commissioner,,R,Ken Selzer,165
-Shawnee,24 Sac,Insurance Commissioner,,R,Ken Selzer,258
-Shawnee,25 Sherman,Insurance Commissioner,,R,Ken Selzer,235
-Shawnee,26 Iroquois,Insurance Commissioner,,R,Ken Selzer,237
-Shawnee,28 West Wichita,Insurance Commissioner,,R,Ken Selzer,199
-Shawnee,29 Indianola,Insurance Commissioner,,R,Ken Selzer,236
-Shawnee,30 Apache,Insurance Commissioner,,R,Ken Selzer,235
-Shawnee,31 East Wichita,Insurance Commissioner,,R,Ken Selzer,358
-Shawnee,32 Fox,Insurance Commissioner,,R,Ken Selzer,257
-Shawnee,33 Elmont,Insurance Commissioner,,R,Ken Selzer,315
-Shawnee,34 Kilmer,Insurance Commissioner,,R,Ken Selzer,74
-Shawnee,35 Rochester,Insurance Commissioner,,R,Ken Selzer,220
-Shawnee,36 East Soldier,Insurance Commissioner,,R,Ken Selzer,232
-Shawnee,37 Whitfield,Insurance Commissioner,,R,Ken Selzer,174
-Shawnee,38 Sioux,Insurance Commissioner,,R,Ken Selzer,205
-Shawnee,39 Pottawatomie,Insurance Commissioner,,R,Ken Selzer,252
-Shawnee,40 Stinson Creek,Insurance Commissioner,,R,Ken Selzer,80
-Shawnee,41 North Tecumseh,Insurance Commissioner,,R,Ken Selzer,174
-Shawnee,42 South Tecumseh,Insurance Commissioner,,R,Ken Selzer,183
-Shawnee,43 Pawnee,Insurance Commissioner,,R,Ken Selzer,298
-Shawnee,44 Kaw,Insurance Commissioner,,R,Ken Selzer,219
-Shawnee,45 Peck,Insurance Commissioner,,R,Ken Selzer,142
-Shawnee,46 East Peck,Insurance Commissioner,,R,Ken Selzer,151
-Shawnee,47 Kiowa,Insurance Commissioner,,R,Ken Selzer,286
-Shawnee,48 Cheyenne,Insurance Commissioner,,R,Ken Selzer,219
-Shawnee,49 Ponca,Insurance Commissioner,,R,Ken Selzer,148
-Shawnee,52 Deer Creek,Insurance Commissioner,,R,Ken Selzer,11
-Shawnee,53 Pauline,Insurance Commissioner,,R,Ken Selzer,75
-Shawnee,54 West Potter,Insurance Commissioner,,R,Ken Selzer,41
-Shawnee,55 Central Pauline,Insurance Commissioner,,R,Ken Selzer,34
-Shawnee,56 NW Monmouth,Insurance Commissioner,,R,Ken Selzer,339
-Shawnee,57 NE Monmouth,Insurance Commissioner,,R,Ken Selzer,235
-Shawnee,58 S Monmouth,Insurance Commissioner,,R,Ken Selzer,313
-Shawnee,62 Forbes,Insurance Commissioner,,R,Ken Selzer,27
-Shawnee,63 Montara,Insurance Commissioner,,R,Ken Selzer,98
-Shawnee,64 Cullen,Insurance Commissioner,,R,Ken Selzer,132
-Shawnee,65 Wakarusa,Insurance Commissioner,,R,Ken Selzer,276
-Shawnee,66 Kingston,Insurance Commissioner,,R,Ken Selzer,72
-Shawnee,72 City of Auburn,Insurance Commissioner,,R,Ken Selzer,233
-Shawnee,73 Meadowlark,Insurance Commissioner,,R,Ken Selzer,358
-Shawnee,74 Buffalo,Insurance Commissioner,,R,Ken Selzer,251
-Shawnee,80 Gaillardia,Insurance Commissioner,,R,Ken Selzer,262
-Shawnee,81 Dover,Insurance Commissioner,,R,Ken Selzer,201
-Shawnee,82 Willard,Insurance Commissioner,,R,Ken Selzer,217
-Shawnee,84 Yucca,Insurance Commissioner,,R,Ken Selzer,61
-Shawnee,85 Aldersgate,Insurance Commissioner,,R,Ken Selzer,95
-Shawnee,86 Sunflower,Insurance Commissioner,,R,Ken Selzer,413
-Shawnee,87 Washburn,Insurance Commissioner,,R,Ken Selzer,210
-Shawnee,89 North Mission,Insurance Commissioner,,R,Ken Selzer,78
-Shawnee,90 South Mission,Insurance Commissioner,,R,Ken Selzer,191
-Shawnee,91 Central Mission,Insurance Commissioner,,R,Ken Selzer,319
-Shawnee,92 Sherwood,Insurance Commissioner,,R,Ken Selzer,208
-Shawnee,93 South Sherwood,Insurance Commissioner,,R,Ken Selzer,186
-Shawnee,94 Indian Hills,Insurance Commissioner,,R,Ken Selzer,201
-Shawnee,95 York,Insurance Commissioner,,R,Ken Selzer,255
-Shawnee,96 Vaquero,Insurance Commissioner,,R,Ken Selzer,177
-Shawnee,97 York Outer,Insurance Commissioner,,R,Ken Selzer,34
-Shawnee,99 Verbena,Insurance Commissioner,,R,Ken Selzer,45
-Shawnee,1 East Rossville,Insurance Commissioner,,D,Dennis Anderson,156
-Shawnee,2 West Rossville,Insurance Commissioner,,D,Dennis Anderson,97
-Shawnee,9 East Silver Lake,Insurance Commissioner,,D,Dennis Anderson,229
-Shawnee,10 West Silver Lake,Insurance Commissioner,,D,Dennis Anderson,161
-Shawnee,12 Grove,Insurance Commissioner,,D,Dennis Anderson,83
-Shawnee,14 Kiro,Insurance Commissioner,,D,Dennis Anderson,173
-Shawnee,15 Messhoss Creek,Insurance Commissioner,,D,Dennis Anderson,101
-Shawnee,22 Little Muddy Creek,Insurance Commissioner,,D,Dennis Anderson,113
-Shawnee,24 Sac,Insurance Commissioner,,D,Dennis Anderson,205
-Shawnee,25 Sherman,Insurance Commissioner,,D,Dennis Anderson,165
-Shawnee,26 Iroquois,Insurance Commissioner,,D,Dennis Anderson,165
-Shawnee,28 West Wichita,Insurance Commissioner,,D,Dennis Anderson,172
-Shawnee,29 Indianola,Insurance Commissioner,,D,Dennis Anderson,199
-Shawnee,30 Apache,Insurance Commissioner,,D,Dennis Anderson,157
-Shawnee,31 East Wichita,Insurance Commissioner,,D,Dennis Anderson,240
-Shawnee,32 Fox,Insurance Commissioner,,D,Dennis Anderson,177
-Shawnee,33 Elmont,Insurance Commissioner,,D,Dennis Anderson,244
-Shawnee,34 Kilmer,Insurance Commissioner,,D,Dennis Anderson,47
-Shawnee,35 Rochester,Insurance Commissioner,,D,Dennis Anderson,180
-Shawnee,36 East Soldier,Insurance Commissioner,,D,Dennis Anderson,212
-Shawnee,37 Whitfield,Insurance Commissioner,,D,Dennis Anderson,154
-Shawnee,38 Sioux,Insurance Commissioner,,D,Dennis Anderson,159
-Shawnee,39 Pottawatomie,Insurance Commissioner,,D,Dennis Anderson,195
-Shawnee,40 Stinson Creek,Insurance Commissioner,,D,Dennis Anderson,70
-Shawnee,41 North Tecumseh,Insurance Commissioner,,D,Dennis Anderson,172
-Shawnee,42 South Tecumseh,Insurance Commissioner,,D,Dennis Anderson,173
-Shawnee,43 Pawnee,Insurance Commissioner,,D,Dennis Anderson,194
-Shawnee,44 Kaw,Insurance Commissioner,,D,Dennis Anderson,199
-Shawnee,45 Peck,Insurance Commissioner,,D,Dennis Anderson,139
-Shawnee,46 East Peck,Insurance Commissioner,,D,Dennis Anderson,119
-Shawnee,47 Kiowa,Insurance Commissioner,,D,Dennis Anderson,296
-Shawnee,48 Cheyenne,Insurance Commissioner,,D,Dennis Anderson,190
-Shawnee,49 Ponca,Insurance Commissioner,,D,Dennis Anderson,122
-Shawnee,52 Deer Creek,Insurance Commissioner,,D,Dennis Anderson,8
-Shawnee,53 Pauline,Insurance Commissioner,,D,Dennis Anderson,95
-Shawnee,54 West Potter,Insurance Commissioner,,D,Dennis Anderson,19
-Shawnee,55 Central Pauline,Insurance Commissioner,,D,Dennis Anderson,30
-Shawnee,56 NW Monmouth,Insurance Commissioner,,D,Dennis Anderson,214
-Shawnee,57 NE Monmouth,Insurance Commissioner,,D,Dennis Anderson,203
-Shawnee,58 S Monmouth,Insurance Commissioner,,D,Dennis Anderson,246
-Shawnee,62 Forbes,Insurance Commissioner,,D,Dennis Anderson,20
-Shawnee,63 Montara,Insurance Commissioner,,D,Dennis Anderson,106
-Shawnee,64 Cullen,Insurance Commissioner,,D,Dennis Anderson,134
-Shawnee,65 Wakarusa,Insurance Commissioner,,D,Dennis Anderson,149
-Shawnee,66 Kingston,Insurance Commissioner,,D,Dennis Anderson,40
-Shawnee,72 City of Auburn,Insurance Commissioner,,D,Dennis Anderson,136
-Shawnee,73 Meadowlark,Insurance Commissioner,,D,Dennis Anderson,195
-Shawnee,74 Buffalo,Insurance Commissioner,,D,Dennis Anderson,118
-Shawnee,80 Gaillardia,Insurance Commissioner,,D,Dennis Anderson,138
-Shawnee,81 Dover,Insurance Commissioner,,D,Dennis Anderson,107
-Shawnee,82 Willard,Insurance Commissioner,,D,Dennis Anderson,112
-Shawnee,84 Yucca,Insurance Commissioner,,D,Dennis Anderson,45
-Shawnee,85 Aldersgate,Insurance Commissioner,,D,Dennis Anderson,104
-Shawnee,86 Sunflower,Insurance Commissioner,,D,Dennis Anderson,228
-Shawnee,87 Washburn,Insurance Commissioner,,D,Dennis Anderson,124
-Shawnee,89 North Mission,Insurance Commissioner,,D,Dennis Anderson,37
-Shawnee,90 South Mission,Insurance Commissioner,,D,Dennis Anderson,119
-Shawnee,91 Central Mission,Insurance Commissioner,,D,Dennis Anderson,196
-Shawnee,92 Sherwood,Insurance Commissioner,,D,Dennis Anderson,152
-Shawnee,93 South Sherwood,Insurance Commissioner,,D,Dennis Anderson,100
-Shawnee,94 Indian Hills,Insurance Commissioner,,D,Dennis Anderson,166
-Shawnee,95 York,Insurance Commissioner,,D,Dennis Anderson,164
-Shawnee,96 Vaquero,Insurance Commissioner,,D,Dennis Anderson,134
-Shawnee,97 York Outer,Insurance Commissioner,,D,Dennis Anderson,18
-Shawnee,99 Verbena,Insurance Commissioner,,D,Dennis Anderson,29
-Shawnee,1 East Rossville,State House,51,R,Ron Highland,338
-Shawnee,2 West Rossville,State House,51,R,Ron Highland,253
-Shawnee,9 East Silver Lake,State House,50,R,Fred Patton,303
-Shawnee,10 West Silver Lake,State House,50,R,Fred Patton,195
-Shawnee,12 Grove,State House,50,R,Fred Patton,186
-Shawnee,14 Kiro,State House,50,R,Fred Patton,300
-Shawnee,15 Messhoss Creek,State House,50,R,Fred Patton,167
-Shawnee,22 Little Muddy Creek,State House,50,R,Fred Patton,190
-Shawnee,24 Sac,State House,50,R,Fred Patton,309
-Shawnee,25 Sherman,State House,50,R,Fred Patton,282
-Shawnee,26 Iroquois,State House,50,R,Fred Patton,260
-Shawnee,28 West Wichita,State House,50,R,Fred Patton,229
-Shawnee,29 Indianola,State House,50,R,Fred Patton,304
-Shawnee,30 Apache,State House,50,R,Fred Patton,267
-Shawnee,31 East Wichita,State House,50,R,Fred Patton,400
-Shawnee,32 Fox,State House,50,R,Fred Patton,282
-Shawnee,33 Elmont,State House,50,R,Fred Patton,379
-Shawnee,34 Kilmer,State House,47,R,Ramon Gonzalez,78
-Shawnee,35 Rochester,State House,50,R,Fred Patton,263
-Shawnee,36 East Soldier,State House,50,R,Fred Patton,297
-Shawnee,37 Whitfield,State House,50,R,Fred Patton,207
-Shawnee,38 Sioux,State House,47,R,Ramon Gonzalez,206
-Shawnee,39 Pottawatomie,State House,50,R,Fred Patton,275
-Shawnee,40 Stinson Creek,State House,47,R,Ramon Gonzalez,82
-Shawnee,41 North Tecumseh,State House,47,R,Ramon Gonzalez,180
-Shawnee,42 South Tecumseh,State House,54,R,Ken Corbet,161
-Shawnee,43 Pawnee,State House,54,R,Ken Corbet,277
-Shawnee,44 Kaw,State House,47,R,Ramon Gonzalez,215
-Shawnee,47 Kiowa,State House,54,R,Ken Corbet,273
-Shawnee,49 Ponca,State House,54,R,Ken Corbet,125
-Shawnee,52 Deer Creek,State House,58,R,Cordell Fischer,8
-Shawnee,53 Pauline,State House,55,R,James Lord,80
-Shawnee,54 West Potter,State House,55,R,James Lord,18
-Shawnee,55 Central Pauline,State House,55,R,James Lord,26
-Shawnee,56 NW Monmouth,State House,54,R,Ken Corbet,310
-Shawnee,57 NE Monmouth,State House,54,R,Ken Corbet,207
-Shawnee,58 S Monmouth,State House,54,R,Ken Corbet,286
-Shawnee,62 Forbes,State House,54,R,Ken Corbet,28
-Shawnee,63 Montara,State House,54,R,Ken Corbet,86
-Shawnee,64 Cullen,State House,54,R,Ken Corbet,126
-Shawnee,65 Wakarusa,State House,54,R,Ken Corbet,263
-Shawnee,66 Kingston,State House,54,R,Ken Corbet,74
-Shawnee,72 City of Auburn,State House,54,R,Ken Corbet,220
-Shawnee,73 Meadowlark,State House,54,R,Ken Corbet,363
-Shawnee,74 Buffalo,State House,54,R,Ken Corbet,259
-Shawnee,80 Gaillardia,State House,52,R,Dick Jones,268
-Shawnee,81 Dover,State House,50,R,Fred Patton,193
-Shawnee,82 Willard,State House,50,R,Fred Patton,218
-Shawnee,84 Yucca,State House,50,R,Fred Patton,64
-Shawnee,85 Aldersgate,State House,52,R,Dick Jones,106
-Shawnee,86 Sunflower,State House,52,R,Dick Jones,428
-Shawnee,87 Washburn,State House,52,R,Dick Jones,215
-Shawnee,89 North Mission,State House,52,R,Dick Jones,82
-Shawnee,90 South Mission,State House,52,R,Dick Jones,195
-Shawnee,91 Central Mission,State House,52,R,Dick Jones,330
-Shawnee,92 Sherwood,State House,52,R,Dick Jones,216
-Shawnee,93 South Sherwood,State House,52,R,Dick Jones,194
-Shawnee,94 Indian Hills,State House,52,R,Dick Jones,204
-Shawnee,95 York,State House,52,R,Dick Jones,257
-Shawnee,96 Vaquero,State House,52,R,Dick Jones,172
-Shawnee,97 York Outer,State House,52,R,Dick Jones,35
-Shawnee,99 Verbena,State House,53,R,T J Foy,38
-Shawnee,9 East Silver Lake,State House,50,D,Chris Huntsman,197
-Shawnee,10 West Silver Lake,State House,50,D,Chris Huntsman,153
-Shawnee,12 Grove,State House,50,D,Chris Huntsman,105
-Shawnee,14 Kiro,State House,50,D,Chris Huntsman,154
-Shawnee,15 Messltoss Creek,State House,50,D,Chris Huntsman,97
-Shawnee,22 Little Muddy Creek,State House,50,D,Chris Huntsman,98
-Shawnee,24 Sac,State House,50,D,Chris Huntsman,169
-Shawnee,25 Sherman,State House,50,D,Chris Huntsman,126
-Shawnee,26 Iroquois,State House,50,D,Chris Huntsman,150
-Shawnee,28 West Wichita,State House,50,D,Chris Huntsman,149
-Shawnee,29 Indianola,State House,50,D,Chris Huntsman,159
-Shawnee,30 Apache,State House,50,D,Chris Huntsman,136
-Shawnee,31 East Wichita,State House,50,D,Chris Huntsman,216
-Shawnee,32 Fox,State House,50,D,Chris Huntsman,172
-Shawnee,33 Elmont,State House,50,D,Chris Huntsman,210
-Shawnee,34 Kilmer,State House,47,D,Bob Sirridge,39
-Shawnee,35 Rochester,State House,50,D,Chris Huntsman,148
-Shawnee,36 East Soldier,State House,50,D,Chris Huntsman,169
-Shawnee,37 Whitfield,State House,50,D,Chris Huntsman,126
-Shawnee,38 Sioux,State House,47,D,Bob Sirridge,152
-Shawnee,39 Potiawatomie,State House,50,D,Chris Huntsman,177
-Shawnee,40 Stinson Creek,State House,47,D,Bob Sirridge,63
-Shawnee,41 North Tecumseh,State House,47,D,Bob Sirridge,160
-Shawnee,42 South Tecumseh,State House,54,D,Ann Mah,210
-Shawnee,43 Pawnee,State House,54,D,Ann Mah,242
-Shawnee,44 Kaw,State House,47,D,Bob Sirridge,195
-Shawnee,45 Peck,State House,57,D,John Alcala,211
-Shawnee,46 East Peck,State House,57,D,John Alcala,200
-Shawnee,47 Kiowa,State House,54,D,Ann Mah,332
-Shawnee,48 Cheyenne,State House,57,D,John Alcala,324
-Shawnee,49 Ponca,State House,54,D,Ann Mah,155
-Shawnee,52 Deer Creek,State House,58,D,Harold Lane,11
-Shawnee,53 Pauline,State House,55,D,Annie Kuether,93
-Shawnee,54 West Potter,State House,55,D,Annie Kuether,43
-Shawnee,55 Central Pauline,State House,55,D,Annie Kuether,40
-Shawnee,56 NW Monmouth,State House,54,D,Ann Mah,261
-Shawnee,57 NE Monmouth,State House,54,D,Ann Mah,244
-Shawnee,58 S Monmouth,State House,54,D,Ann Mah,294
-Shawnee,62 Forbes,State House,54,D,Ann Mah,18
-Shawnee,63 Montara,State House,54,D,Ann Mah,119
-Shawnee,64 Cullen,State House,54,D,Ann Mah,146
-Shawnee,65 Wakarusa,State House,54,D,Ann Mah,177
-Shawnee,66 Kingston,State House,54,D,Ann Mah,43
-Shawnee,72 City of Auburn,State House,54,D,Ann Mah,161
-Shawnee,73 Meadowlark,State House,54,D,Ann Mah,209
-Shawnee,74 Buffalo,State House,54,D,Ann Mah,131
-Shawnee,80 Gaillardia,State House,52,D,Ty Dragoo,133
-Shawnee,81 Dover,State House,50,D,Chris Huntsman,114
-Shawnee,82 Willard,State House,50,D,Chris Huntsman,111
-Shawnee,84 Yucca,State House,50,D,Chris Huntsman,42
-Shawnee,85 Aldersgate,State House,52,D,Ty Dragoo,93
-Shawnee,86 Sunflower,State House,52,D,Ty Dragoo,224
-Shawnee,87 Washburn,State House,52,D,Ty Dragoo,122
-Shawnee,89 North Mission,State House,52,D,Ty Dragoo,33
-Shawnee,90 South Mission,State House,52,D,Ty Dragoo,120
-Shawnee,91 Central Mission,State House,52,D,Ty Dragoo,184
-Shawnee,92 Sherwood,State House,52,D,Ty Dragoo,150
-Shawnee,93 South Sherwood,State House,52,D,Ty Dragoo,95
-Shawnee,94 Indian Hills,State House,52,D,Ty Dragoo,169
-Shawnee,95 York,State House,52,D,Ty Dragoo,160
-Shawnee,96 Vaquero,State House,52,D,Ty Dragoo,143
-Shawnee,97 York Outer,State House,52,D,Ty Dragoo,17
-Shawnee,99 Verbena,State House,53,D,Annie Tietze,37
+county,precinct,office,district,party,candidate,votes,vtd
+SHAWNEE,ADVANCED,Kansas House of Representatives,47,Democratic,"Sirridge, Bob",609,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",761,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,50,Democratic,"Huntsman, Chris",3512,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,50,Republican,"Patton, Fred C.",6048,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,51,Republican,"Highland, Ron",591,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,52,Democratic,"Dragoo, Ty",4128,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,52,Republican,"Jones, Dick",6114,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,53,Democratic,"Tietze, Annie",5212,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,53,Republican,"Foy, T.J.",3383,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",2822,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,54,Republican,"Corbet, Ken",3117,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,55,Democratic,"Kuether, Annie",4602,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,55,Republican,"Lord, James R.",2305,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,56,Democratic,"Weigel, Virgil",3938,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,56,Republican,"Hemsley, Lane",3978,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,57,Democratic,"Alcala, John",4014,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,58,Democratic,"Lane, Harold",3164,999998
+SHAWNEE,ADVANCED,Kansas House of Representatives,58,Republican,"Fischer, Cordell",1302,999998
+SHAWNEE,East Peck,United States House of Representatives,2,Democratic,"Wakefield, Margie",97,000080
+SHAWNEE,East Peck,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000080
+SHAWNEE,East Peck,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000080
+SHAWNEE,East Rossville,United States House of Representatives,2,Democratic,"Wakefield, Margie",131,000090
+SHAWNEE,East Rossville,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",28,000090
+SHAWNEE,East Rossville,United States House of Representatives,2,Republican,"Jenkins, Lynn",261,000090
+SHAWNEE,Grove Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",77,000150
+SHAWNEE,Grove Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000150
+SHAWNEE,Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",202,000150
+SHAWNEE,Kiowa,United States House of Representatives,2,Democratic,"Wakefield, Margie",272,000190
+SHAWNEE,Kiowa,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,000190
+SHAWNEE,Kiowa,United States House of Representatives,2,Republican,"Jenkins, Lynn",318,000190
+SHAWNEE,Northeast Monmouth,United States House of Representatives,2,Democratic,"Wakefield, Margie",192,000270
+SHAWNEE,Northeast Monmouth,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000270
+SHAWNEE,Northeast Monmouth,United States House of Representatives,2,Republican,"Jenkins, Lynn",251,000270
+SHAWNEE,Northwest Monmouth,United States House of Representatives,2,Democratic,"Wakefield, Margie",192,000280
+SHAWNEE,Northwest Monmouth,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",25,000280
+SHAWNEE,Northwest Monmouth,United States House of Representatives,2,Republican,"Jenkins, Lynn",351,000280
+SHAWNEE,Pawnee,United States House of Representatives,2,Democratic,"Wakefield, Margie",176,000290
+SHAWNEE,Pawnee,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",26,000290
+SHAWNEE,Pawnee,United States House of Representatives,2,Republican,"Jenkins, Lynn",320,000290
+SHAWNEE,Peck,United States House of Representatives,2,Democratic,"Wakefield, Margie",129,000300
+SHAWNEE,Peck,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000300
+SHAWNEE,Peck,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000300
+SHAWNEE,Ponca,United States House of Representatives,2,Democratic,"Wakefield, Margie",116,000310
+SHAWNEE,Ponca,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000310
+SHAWNEE,Ponca,United States House of Representatives,2,Republican,"Jenkins, Lynn",157,000310
+SHAWNEE,Rochester,United States House of Representatives,2,Democratic,"Wakefield, Margie",168,000330
+SHAWNEE,Rochester,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000330
+SHAWNEE,Rochester,United States House of Representatives,2,Republican,"Jenkins, Lynn",232,000330
+SHAWNEE,Sherwood,United States House of Representatives,2,Democratic,"Wakefield, Margie",142,000340
+SHAWNEE,Sherwood,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000340
+SHAWNEE,Sherwood,United States House of Representatives,2,Republican,"Jenkins, Lynn",217,000340
+SHAWNEE,Sioux,United States House of Representatives,2,Democratic,"Wakefield, Margie",139,000350
+SHAWNEE,Sioux,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,000350
+SHAWNEE,Sioux,United States House of Representatives,2,Republican,"Jenkins, Lynn",218,000350
+SHAWNEE,South Monmouth,United States House of Representatives,2,Democratic,"Wakefield, Margie",207,000370
+SHAWNEE,South Monmouth,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",28,000370
+SHAWNEE,South Monmouth,United States House of Representatives,2,Republican,"Jenkins, Lynn",346,000370
+SHAWNEE,Topeka Ward 01 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",96,000410
+SHAWNEE,Topeka Ward 01 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000410
+SHAWNEE,Topeka Ward 01 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,000410
+SHAWNEE,Topeka Ward 01 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",117,000420
+SHAWNEE,Topeka Ward 01 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000420
+SHAWNEE,Topeka Ward 01 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,000420
+SHAWNEE,Topeka Ward 01 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,000430
+SHAWNEE,Topeka Ward 01 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000430
+SHAWNEE,Topeka Ward 01 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000430
+SHAWNEE,Topeka Ward 01 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",126,000440
+SHAWNEE,Topeka Ward 01 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000440
+SHAWNEE,Topeka Ward 01 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000440
+SHAWNEE,Topeka Ward 02 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",130,000480
+SHAWNEE,Topeka Ward 02 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000480
+SHAWNEE,Topeka Ward 02 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000480
+SHAWNEE,Topeka Ward 02 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",113,000490
+SHAWNEE,Topeka Ward 02 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000490
+SHAWNEE,Topeka Ward 02 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,000490
+SHAWNEE,Topeka Ward 02 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",112,000500
+SHAWNEE,Topeka Ward 02 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000500
+SHAWNEE,Topeka Ward 02 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000500
+SHAWNEE,Topeka Ward 02 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",112,000510
+SHAWNEE,Topeka Ward 02 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000510
+SHAWNEE,Topeka Ward 02 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000510
+SHAWNEE,Topeka Ward 02 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",130,000520
+SHAWNEE,Topeka Ward 02 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000520
+SHAWNEE,Topeka Ward 02 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,000520
+SHAWNEE,Topeka Ward 02 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",87,000530
+SHAWNEE,Topeka Ward 02 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000530
+SHAWNEE,Topeka Ward 02 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000530
+SHAWNEE,Topeka Ward 02 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,000540
+SHAWNEE,Topeka Ward 02 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000540
+SHAWNEE,Topeka Ward 02 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",32,000540
+SHAWNEE,Topeka Ward 02 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",75,000550
+SHAWNEE,Topeka Ward 02 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000550
+SHAWNEE,Topeka Ward 02 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",20,000550
+SHAWNEE,Topeka Ward 02 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",135,000560
+SHAWNEE,Topeka Ward 02 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,000560
+SHAWNEE,Topeka Ward 02 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",97,000560
+SHAWNEE,Topeka Ward 02 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",187,000570
+SHAWNEE,Topeka Ward 02 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000570
+SHAWNEE,Topeka Ward 02 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000570
+SHAWNEE,Topeka Ward 02 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",86,000580
+SHAWNEE,Topeka Ward 02 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,000580
+SHAWNEE,Topeka Ward 02 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,000580
+SHAWNEE,Topeka Ward 03 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",114,000590
+SHAWNEE,Topeka Ward 03 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000590
+SHAWNEE,Topeka Ward 03 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,000590
+SHAWNEE,Topeka Ward 03 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",144,000600
+SHAWNEE,Topeka Ward 03 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000600
+SHAWNEE,Topeka Ward 03 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,000600
+SHAWNEE,Topeka Ward 03 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",87,000610
+SHAWNEE,Topeka Ward 03 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000610
+SHAWNEE,Topeka Ward 03 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,000610
+SHAWNEE,Topeka Ward 03 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",86,000640
+SHAWNEE,Topeka Ward 03 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000640
+SHAWNEE,Topeka Ward 03 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000640
+SHAWNEE,Topeka Ward 03 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",92,000650
+SHAWNEE,Topeka Ward 03 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000650
+SHAWNEE,Topeka Ward 03 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",58,000650
+SHAWNEE,Topeka Ward 04 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",124,000700
+SHAWNEE,Topeka Ward 04 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000700
+SHAWNEE,Topeka Ward 04 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,000700
+SHAWNEE,Topeka Ward 04 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",93,000710
+SHAWNEE,Topeka Ward 04 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000710
+SHAWNEE,Topeka Ward 04 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",28,000710
+SHAWNEE,Topeka Ward 04 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",138,000740
+SHAWNEE,Topeka Ward 04 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,000740
+SHAWNEE,Topeka Ward 04 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000740
+SHAWNEE,Topeka Ward 04 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",74,000750
+SHAWNEE,Topeka Ward 04 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000750
+SHAWNEE,Topeka Ward 04 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,000750
+SHAWNEE,Topeka Ward 04 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",104,000760
+SHAWNEE,Topeka Ward 04 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000760
+SHAWNEE,Topeka Ward 04 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000760
+SHAWNEE,Topeka Ward 04 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",136,000770
+SHAWNEE,Topeka Ward 04 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000770
+SHAWNEE,Topeka Ward 04 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,000770
+SHAWNEE,Topeka Ward 04 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",165,000780
+SHAWNEE,Topeka Ward 04 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000780
+SHAWNEE,Topeka Ward 04 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,000780
+SHAWNEE,Topeka Ward 05 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",100,000820
+SHAWNEE,Topeka Ward 05 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000820
+SHAWNEE,Topeka Ward 05 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000820
+SHAWNEE,Topeka Ward 05 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",92,000830
+SHAWNEE,Topeka Ward 05 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000830
+SHAWNEE,Topeka Ward 05 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,000830
+SHAWNEE,Topeka Ward 05 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",135,000840
+SHAWNEE,Topeka Ward 05 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000840
+SHAWNEE,Topeka Ward 05 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,000840
+SHAWNEE,Topeka Ward 05 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",131,000850
+SHAWNEE,Topeka Ward 05 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000850
+SHAWNEE,Topeka Ward 05 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,000850
+SHAWNEE,Topeka Ward 05 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",94,000860
+SHAWNEE,Topeka Ward 05 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,000860
+SHAWNEE,Topeka Ward 05 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000860
+SHAWNEE,Topeka Ward 05 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",145,000870
+SHAWNEE,Topeka Ward 05 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000870
+SHAWNEE,Topeka Ward 05 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,000870
+SHAWNEE,Topeka Ward 05 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",90,000880
+SHAWNEE,Topeka Ward 05 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000880
+SHAWNEE,Topeka Ward 05 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",71,000880
+SHAWNEE,Topeka Ward 05 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",180,000890
+SHAWNEE,Topeka Ward 05 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000890
+SHAWNEE,Topeka Ward 05 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",162,000890
+SHAWNEE,Topeka Ward 15 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",179,000910
+SHAWNEE,Topeka Ward 15 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,000910
+SHAWNEE,Topeka Ward 15 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000910
+SHAWNEE,Topeka Ward 05 Precinct 91,United States House of Representatives,2,Democratic,"Wakefield, Margie",43,000930
+SHAWNEE,Topeka Ward 05 Precinct 91,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000930
+SHAWNEE,Topeka Ward 05 Precinct 91,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,000930
+SHAWNEE,Topeka Ward 06 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",102,000940
+SHAWNEE,Topeka Ward 06 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000940
+SHAWNEE,Topeka Ward 06 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000940
+SHAWNEE,Topeka Ward 06 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",102,000950
+SHAWNEE,Topeka Ward 06 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000950
+SHAWNEE,Topeka Ward 06 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000950
+SHAWNEE,Topeka Ward 06 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",159,000960
+SHAWNEE,Topeka Ward 06 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000960
+SHAWNEE,Topeka Ward 06 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",202,000960
+SHAWNEE,Topeka Ward 06 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",114,000970
+SHAWNEE,Topeka Ward 06 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000970
+SHAWNEE,Topeka Ward 06 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,000970
+SHAWNEE,Topeka Ward 06 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",167,000980
+SHAWNEE,Topeka Ward 06 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,000980
+SHAWNEE,Topeka Ward 06 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,000980
+SHAWNEE,Topeka Ward 06 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",75,000990
+SHAWNEE,Topeka Ward 06 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,000990
+SHAWNEE,Topeka Ward 06 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,000990
+SHAWNEE,Topeka Ward 06 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",58,001000
+SHAWNEE,Topeka Ward 06 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,001000
+SHAWNEE,Topeka Ward 06 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,001000
+SHAWNEE,Topeka Ward 06 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",150,001010
+SHAWNEE,Topeka Ward 06 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,001010
+SHAWNEE,Topeka Ward 06 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,001010
+SHAWNEE,Topeka Ward 07 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",187,001040
+SHAWNEE,Topeka Ward 07 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",25,001040
+SHAWNEE,Topeka Ward 07 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",101,001040
+SHAWNEE,Topeka Ward 07 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",156,001050
+SHAWNEE,Topeka Ward 07 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,001050
+SHAWNEE,Topeka Ward 07 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",81,001050
+SHAWNEE,Topeka Ward 07 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",149,001060
+SHAWNEE,Topeka Ward 07 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,001060
+SHAWNEE,Topeka Ward 07 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,001060
+SHAWNEE,Topeka Ward 07 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",146,001070
+SHAWNEE,Topeka Ward 07 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,001070
+SHAWNEE,Topeka Ward 07 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,001070
+SHAWNEE,Topeka Ward 07 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",115,001080
+SHAWNEE,Topeka Ward 07 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,001080
+SHAWNEE,Topeka Ward 07 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",114,001080
+SHAWNEE,Topeka Ward 07 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",97,001090
+SHAWNEE,Topeka Ward 07 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,001090
+SHAWNEE,Topeka Ward 07 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,001090
+SHAWNEE,Topeka Ward 07 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",112,001100
+SHAWNEE,Topeka Ward 07 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,001100
+SHAWNEE,Topeka Ward 07 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,001100
+SHAWNEE,Topeka Ward 07 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",102,001120
+SHAWNEE,Topeka Ward 07 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,001120
+SHAWNEE,Topeka Ward 07 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,001120
+SHAWNEE,Topeka Ward 07 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",136,001130
+SHAWNEE,Topeka Ward 07 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,001130
+SHAWNEE,Topeka Ward 07 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,001130
+SHAWNEE,Topeka Ward 07 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",195,001140
+SHAWNEE,Topeka Ward 07 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,001140
+SHAWNEE,Topeka Ward 07 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",146,001140
+SHAWNEE,Topeka Ward 08 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",124,001150
+SHAWNEE,Topeka Ward 08 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,001150
+SHAWNEE,Topeka Ward 08 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,001150
+SHAWNEE,Topeka Ward 08 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",163,001160
+SHAWNEE,Topeka Ward 08 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,001160
+SHAWNEE,Topeka Ward 08 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,001160
+SHAWNEE,Topeka Ward 08 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",221,001170
+SHAWNEE,Topeka Ward 08 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,001170
+SHAWNEE,Topeka Ward 08 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",113,001170
+SHAWNEE,Topeka Ward 08 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",186,001180
+SHAWNEE,Topeka Ward 08 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,001180
+SHAWNEE,Topeka Ward 08 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",120,001180
+SHAWNEE,Topeka Ward 08 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",231,001190
+SHAWNEE,Topeka Ward 08 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,001190
+SHAWNEE,Topeka Ward 08 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",204,001190
+SHAWNEE,Topeka Ward 08 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",120,001200
+SHAWNEE,Topeka Ward 08 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,001200
+SHAWNEE,Topeka Ward 08 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",136,001200
+SHAWNEE,Topeka Ward 08 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",144,001210
+SHAWNEE,Topeka Ward 08 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,001210
+SHAWNEE,Topeka Ward 08 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,001210
+SHAWNEE,Topeka Ward 08 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",154,001220
+SHAWNEE,Topeka Ward 08 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,001220
+SHAWNEE,Topeka Ward 08 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,001220
+SHAWNEE,Topeka Ward 08 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",174,001230
+SHAWNEE,Topeka Ward 08 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,001230
+SHAWNEE,Topeka Ward 08 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",168,001230
+SHAWNEE,Topeka Ward 08 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",110,001240
+SHAWNEE,Topeka Ward 08 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,001240
+SHAWNEE,Topeka Ward 08 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",157,001240
+SHAWNEE,Topeka Ward 08 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",169,001250
+SHAWNEE,Topeka Ward 08 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,001250
+SHAWNEE,Topeka Ward 08 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",168,001250
+SHAWNEE,Topeka Ward 09 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",106,001270
+SHAWNEE,Topeka Ward 09 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,001270
+SHAWNEE,Topeka Ward 09 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,001270
+SHAWNEE,Topeka Ward 09 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",208,001280
+SHAWNEE,Topeka Ward 09 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,001280
+SHAWNEE,Topeka Ward 09 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",197,001280
+SHAWNEE,Topeka Ward 09 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",194,001290
+SHAWNEE,Topeka Ward 09 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,001290
+SHAWNEE,Topeka Ward 09 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,001290
+SHAWNEE,Topeka Ward 09 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",136,001300
+SHAWNEE,Topeka Ward 09 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,001300
+SHAWNEE,Topeka Ward 09 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",112,001300
+SHAWNEE,Topeka Ward 09 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",160,001310
+SHAWNEE,Topeka Ward 09 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,001310
+SHAWNEE,Topeka Ward 09 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,001310
+SHAWNEE,Topeka Ward 09 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",179,001320
+SHAWNEE,Topeka Ward 09 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,001320
+SHAWNEE,Topeka Ward 09 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,001320
+SHAWNEE,Topeka Ward 09 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",138,001330
+SHAWNEE,Topeka Ward 09 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,001330
+SHAWNEE,Topeka Ward 09 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",129,001330
+SHAWNEE,Topeka Ward 09 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",267,001340
+SHAWNEE,Topeka Ward 09 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",29,001340
+SHAWNEE,Topeka Ward 09 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,001340
+SHAWNEE,Topeka Ward 09 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",154,001350
+SHAWNEE,Topeka Ward 09 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,001350
+SHAWNEE,Topeka Ward 09 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,001350
+SHAWNEE,Topeka Ward 10 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",189,001360
+SHAWNEE,Topeka Ward 10 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,001360
+SHAWNEE,Topeka Ward 10 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,001360
+SHAWNEE,Topeka Ward 10 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",137,001370
+SHAWNEE,Topeka Ward 10 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,001370
+SHAWNEE,Topeka Ward 10 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",206,001370
+SHAWNEE,Topeka Ward 10 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",226,001380
+SHAWNEE,Topeka Ward 10 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",25,001380
+SHAWNEE,Topeka Ward 10 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",247,001380
+SHAWNEE,Topeka Ward 10 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",134,001400
+SHAWNEE,Topeka Ward 10 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,001400
+SHAWNEE,Topeka Ward 10 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",120,001400
+SHAWNEE,Topeka Ward 10 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",119,001410
+SHAWNEE,Topeka Ward 10 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,001410
+SHAWNEE,Topeka Ward 10 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",149,001410
+SHAWNEE,Topeka Ward 10 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",147,001420
+SHAWNEE,Topeka Ward 10 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,001420
+SHAWNEE,Topeka Ward 10 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,001420
+SHAWNEE,Topeka Ward 10 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",127,001430
+SHAWNEE,Topeka Ward 10 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,001430
+SHAWNEE,Topeka Ward 10 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,001430
+SHAWNEE,Topeka Ward 10 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",113,001440
+SHAWNEE,Topeka Ward 10 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,001440
+SHAWNEE,Topeka Ward 10 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,001440
+SHAWNEE,Topeka Ward 10 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",147,001450
+SHAWNEE,Topeka Ward 10 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,001450
+SHAWNEE,Topeka Ward 10 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,001450
+SHAWNEE,Topeka Ward 10 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",192,001460
+SHAWNEE,Topeka Ward 10 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",24,001460
+SHAWNEE,Topeka Ward 10 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,001460
+SHAWNEE,Topeka Ward 11 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",93,001470
+SHAWNEE,Topeka Ward 11 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,001470
+SHAWNEE,Topeka Ward 11 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",105,001470
+SHAWNEE,Topeka Ward 11 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",144,001480
+SHAWNEE,Topeka Ward 11 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,001480
+SHAWNEE,Topeka Ward 11 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",139,001480
+SHAWNEE,Topeka Ward 11 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",115,001490
+SHAWNEE,Topeka Ward 11 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,001490
+SHAWNEE,Topeka Ward 11 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,001490
+SHAWNEE,Topeka Ward 11 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",200,001500
+SHAWNEE,Topeka Ward 11 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,001500
+SHAWNEE,Topeka Ward 11 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",194,001500
+SHAWNEE,Topeka Ward 11 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",134,001510
+SHAWNEE,Topeka Ward 11 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,001510
+SHAWNEE,Topeka Ward 11 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,001510
+SHAWNEE,Topeka Ward 11 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",139,001520
+SHAWNEE,Topeka Ward 11 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,001520
+SHAWNEE,Topeka Ward 11 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,001520
+SHAWNEE,Topeka Ward 11 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",120,001530
+SHAWNEE,Topeka Ward 11 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,001530
+SHAWNEE,Topeka Ward 11 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",141,001530
+SHAWNEE,Topeka Ward 11 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",120,001540
+SHAWNEE,Topeka Ward 11 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,001540
+SHAWNEE,Topeka Ward 11 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,001540
+SHAWNEE,Topeka Ward 11 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",142,001550
+SHAWNEE,Topeka Ward 11 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,001550
+SHAWNEE,Topeka Ward 11 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,001550
+SHAWNEE,Topeka Ward 11 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",106,001560
+SHAWNEE,Topeka Ward 11 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,001560
+SHAWNEE,Topeka Ward 11 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,001560
+SHAWNEE,Topeka Ward 12 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",153,001570
+SHAWNEE,Topeka Ward 12 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,001570
+SHAWNEE,Topeka Ward 12 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",111,001570
+SHAWNEE,Topeka Ward 12 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",132,001590
+SHAWNEE,Topeka Ward 12 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,001590
+SHAWNEE,Topeka Ward 12 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",192,001590
+SHAWNEE,Topeka Ward 12 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",177,001600
+SHAWNEE,Topeka Ward 12 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,001600
+SHAWNEE,Topeka Ward 12 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",235,001600
+SHAWNEE,Topeka Ward 12 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",178,001610
+SHAWNEE,Topeka Ward 12 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,001610
+SHAWNEE,Topeka Ward 12 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,001610
+SHAWNEE,Topeka Ward 12 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",221,001620
+SHAWNEE,Topeka Ward 12 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,001620
+SHAWNEE,Topeka Ward 12 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",191,001620
+SHAWNEE,Topeka Ward 12 Precinct 07,United States House of Representatives,2,Democratic,"Wakefield, Margie",179,001630
+SHAWNEE,Topeka Ward 12 Precinct 07,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,001630
+SHAWNEE,Topeka Ward 12 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",196,001630
+SHAWNEE,Topeka Ward 12 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",197,001640
+SHAWNEE,Topeka Ward 12 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,001640
+SHAWNEE,Topeka Ward 12 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,001640
+SHAWNEE,Topeka Ward 12 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",270,001650
+SHAWNEE,Topeka Ward 12 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,001650
+SHAWNEE,Topeka Ward 12 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",300,001650
+SHAWNEE,Topeka Ward 12 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",240,001670
+SHAWNEE,Topeka Ward 12 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,001670
+SHAWNEE,Topeka Ward 12 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",356,001670
+SHAWNEE,Topeka Ward 12 Precinct 15,United States House of Representatives,2,Democratic,"Wakefield, Margie",226,001710
+SHAWNEE,Topeka Ward 12 Precinct 15,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,001710
+SHAWNEE,Topeka Ward 12 Precinct 15,United States House of Representatives,2,Republican,"Jenkins, Lynn",312,001710
+SHAWNEE,Topeka Ward 12 Precinct 16,United States House of Representatives,2,Democratic,"Wakefield, Margie",276,001720
+SHAWNEE,Topeka Ward 12 Precinct 16,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,001720
+SHAWNEE,Topeka Ward 12 Precinct 16,United States House of Representatives,2,Republican,"Jenkins, Lynn",292,001720
+SHAWNEE,West Rossville,United States House of Representatives,2,Democratic,"Wakefield, Margie",82,001850
+SHAWNEE,West Rossville,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,001850
+SHAWNEE,West Rossville,United States House of Representatives,2,Republican,"Jenkins, Lynn",205,001850
+SHAWNEE,Whitfield,United States House of Representatives,2,Democratic,"Wakefield, Margie",135,001880
+SHAWNEE,Whitfield,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,001880
+SHAWNEE,Whitfield,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,001880
+SHAWNEE,Willard,United States House of Representatives,2,Democratic,"Wakefield, Margie",109,001890
+SHAWNEE,Willard,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,001890
+SHAWNEE,Willard,United States House of Representatives,2,Republican,"Jenkins, Lynn",218,001890
+SHAWNEE,Topeka Ward 04 Precinct 14,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,001910
+SHAWNEE,Topeka Ward 04 Precinct 14,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,001910
+SHAWNEE,Topeka Ward 04 Precinct 14,United States House of Representatives,2,Republican,"Jenkins, Lynn",1,001910
+SHAWNEE,Kilmer,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,017
+SHAWNEE,Kilmer,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,017
+SHAWNEE,Kilmer,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,017
+SHAWNEE,North Tecumseh,United States House of Representatives,2,Democratic,"Wakefield, Margie",156,023
+SHAWNEE,North Tecumseh,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,023
+SHAWNEE,North Tecumseh,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,023
+SHAWNEE,Kaw,United States House of Representatives,2,Democratic,"Wakefield, Margie",190,026
+SHAWNEE,Kaw,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,026
+SHAWNEE,Kaw,United States House of Representatives,2,Republican,"Jenkins, Lynn",231,026
+SHAWNEE,Cheyenne,United States House of Representatives,2,Democratic,"Wakefield, Margie",185,030
+SHAWNEE,Cheyenne,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,030
+SHAWNEE,Cheyenne,United States House of Representatives,2,Republican,"Jenkins, Lynn",223,030
+SHAWNEE,Washburn,United States House of Representatives,2,Democratic,"Wakefield, Margie",115,049
+SHAWNEE,Washburn,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,049
+SHAWNEE,Washburn,United States House of Representatives,2,Republican,"Jenkins, Lynn",218,049
+SHAWNEE,North Mission,United States House of Representatives,2,Democratic,"Wakefield, Margie",32,050
+SHAWNEE,North Mission,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,050
+SHAWNEE,North Mission,United States House of Representatives,2,Republican,"Jenkins, Lynn",83,050
+SHAWNEE,Topeka Ward 03 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",73,079
+SHAWNEE,Topeka Ward 03 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,079
+SHAWNEE,Topeka Ward 03 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,079
+SHAWNEE,Topeka Ward 03 Precinct 08,United States House of Representatives,2,Democratic,"Wakefield, Margie",114,082
+SHAWNEE,Topeka Ward 03 Precinct 08,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,082
+SHAWNEE,Topeka Ward 03 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,082
+SHAWNEE,Topeka Ward 03 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",109,083
+SHAWNEE,Topeka Ward 03 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,083
+SHAWNEE,Topeka Ward 03 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,083
+SHAWNEE,Topeka Ward 04 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",114,084
+SHAWNEE,Topeka Ward 04 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,084
+SHAWNEE,Topeka Ward 04 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,084
+SHAWNEE,Topeka Ward 04 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",47,093
+SHAWNEE,Topeka Ward 04 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,093
+SHAWNEE,Topeka Ward 04 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,093
+SHAWNEE,Topeka Ward 05 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",110,094
+SHAWNEE,Topeka Ward 05 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,094
+SHAWNEE,Topeka Ward 05 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,094
+SHAWNEE,Topeka Ward 13 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,100030
+SHAWNEE,Topeka Ward 13 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,100030
+SHAWNEE,Topeka Ward 13 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,100030
+SHAWNEE,Little Muddy Creek,United States House of Representatives,2,Democratic,"Wakefield, Margie",105,120070
+SHAWNEE,Little Muddy Creek,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,120070
+SHAWNEE,Little Muddy Creek,United States House of Representatives,2,Republican,"Jenkins, Lynn",181,120070
+SHAWNEE,Montara,United States House of Representatives,2,Democratic,"Wakefield, Margie",96,120090
+SHAWNEE,Montara,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,120090
+SHAWNEE,Montara,United States House of Representatives,2,Republican,"Jenkins, Lynn",89,120090
+SHAWNEE,Pauline,United States House of Representatives,2,Democratic,"Wakefield, Margie",79,120160
+SHAWNEE,Pauline,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,120160
+SHAWNEE,Pauline,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,120160
+SHAWNEE,Topeka Ward 04 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",160,120240
+SHAWNEE,Topeka Ward 04 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,120240
+SHAWNEE,Topeka Ward 04 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,120240
+SHAWNEE,Wakarusa,United States House of Representatives,2,Democratic,"Wakefield, Margie",140,120320
+SHAWNEE,Wakarusa,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,120320
+SHAWNEE,Wakarusa,United States House of Representatives,2,Republican,"Jenkins, Lynn",275,120320
+SHAWNEE,Topeka Ward 09 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",30,136
+SHAWNEE,Topeka Ward 09 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,136
+SHAWNEE,Topeka Ward 09 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",26,136
+SHAWNEE,Verbena,United States House of Representatives,2,Democratic,"Wakefield, Margie",27,140010
+SHAWNEE,Verbena,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,140010
+SHAWNEE,Verbena,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,140010
+SHAWNEE,Topeka Ward 03 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",8,140020
+SHAWNEE,Topeka Ward 03 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,140020
+SHAWNEE,Topeka Ward 03 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",4,140020
+SHAWNEE,Topeka Ward 04 Precinct 15,United States House of Representatives,2,Democratic,"Wakefield, Margie",73,140030
+SHAWNEE,Topeka Ward 04 Precinct 15,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,140030
+SHAWNEE,Topeka Ward 04 Precinct 15,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,140030
+SHAWNEE,Topeka Ward 05 Precinct 11,United States House of Representatives,2,Democratic,"Wakefield, Margie",158,140040
+SHAWNEE,Topeka Ward 05 Precinct 11,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,140040
+SHAWNEE,Topeka Ward 05 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",160,140040
+SHAWNEE,Topeka Ward 09 Precinct 12,United States House of Representatives,2,Democratic,"Wakefield, Margie",81,140050
+SHAWNEE,Topeka Ward 09 Precinct 12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,140050
+SHAWNEE,Topeka Ward 09 Precinct 12,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,140050
+SHAWNEE,Indianola,United States House of Representatives,2,Democratic,"Wakefield, Margie",167,200020
+SHAWNEE,Indianola,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,200020
+SHAWNEE,Indianola,United States House of Representatives,2,Republican,"Jenkins, Lynn",290,200020
+SHAWNEE,Cullen,United States House of Representatives,2,Democratic,"Wakefield, Margie",118,200050
+SHAWNEE,Cullen,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",21,200050
+SHAWNEE,Cullen,United States House of Representatives,2,Republican,"Jenkins, Lynn",136,200050
+SHAWNEE,Topeka Ward 12 Precinct 14,United States House of Representatives,2,Democratic,"Wakefield, Margie",138,200070
+SHAWNEE,Topeka Ward 12 Precinct 14,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,200070
+SHAWNEE,Topeka Ward 12 Precinct 14,United States House of Representatives,2,Republican,"Jenkins, Lynn",174,200070
+SHAWNEE,Topeka Ward 13 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",53,200130
+SHAWNEE,Topeka Ward 13 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,200130
+SHAWNEE,Topeka Ward 13 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",48,200130
+SHAWNEE,Topeka Ward 13 Precinct 21,United States House of Representatives,2,Democratic,"Wakefield, Margie",36,200150
+SHAWNEE,Topeka Ward 13 Precinct 21,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,200150
+SHAWNEE,Topeka Ward 13 Precinct 21,United States House of Representatives,2,Republican,"Jenkins, Lynn",29,200150
+SHAWNEE,Topeka Ward 13 Precinct 22,United States House of Representatives,2,Democratic,"Wakefield, Margie",23,200160
+SHAWNEE,Topeka Ward 13 Precinct 22,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,200160
+SHAWNEE,Topeka Ward 13 Precinct 22,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,200160
+SHAWNEE,Topeka Ward 13 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",32,300090
+SHAWNEE,Topeka Ward 13 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,300090
+SHAWNEE,Topeka Ward 13 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,300090
+SHAWNEE,Topeka Ward 13 Precinct 30,United States House of Representatives,2,Democratic,"Wakefield, Margie",52,400070
+SHAWNEE,Topeka Ward 13 Precinct 30,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,400070
+SHAWNEE,Topeka Ward 13 Precinct 30,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,400070
+SHAWNEE,West Wichita,United States House of Representatives,2,Democratic,"Wakefield, Margie",160,400100
+SHAWNEE,West Wichita,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,400100
+SHAWNEE,West Wichita,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,400100
+SHAWNEE,Topeka Ward 05 Precinct 15,United States House of Representatives,2,Democratic,"Wakefield, Margie",19,500070
+SHAWNEE,Topeka Ward 05 Precinct 15,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,500070
+SHAWNEE,Topeka Ward 05 Precinct 15,United States House of Representatives,2,Republican,"Jenkins, Lynn",32,500070
+SHAWNEE,South Tecumseh,United States House of Representatives,2,Democratic,"Wakefield, Margie",160,500080
+SHAWNEE,South Tecumseh,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,500080
+SHAWNEE,South Tecumseh,United States House of Representatives,2,Republican,"Jenkins, Lynn",195,500080
+SHAWNEE,Vacquero,United States House of Representatives,2,Democratic,"Wakefield, Margie",123,500110
+SHAWNEE,Vacquero,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,500110
+SHAWNEE,Vacquero,United States House of Representatives,2,Republican,"Jenkins, Lynn",189,500110
+SHAWNEE,Topeka Ward 05 Precinct 14,United States House of Representatives,2,Democratic,"Wakefield, Margie",80,500120
+SHAWNEE,Topeka Ward 05 Precinct 14,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,500120
+SHAWNEE,Topeka Ward 05 Precinct 14,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,500120
+SHAWNEE,Topeka Ward 13 Precinct 12,United States House of Representatives,2,Democratic,"Wakefield, Margie",182,500140
+SHAWNEE,Topeka Ward 13 Precinct 12,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,500140
+SHAWNEE,Topeka Ward 13 Precinct 12,United States House of Representatives,2,Republican,"Jenkins, Lynn",336,500140
+SHAWNEE,Topeka Ward 06 Precinct 09,United States House of Representatives,2,Democratic,"Wakefield, Margie",272,500160
+SHAWNEE,Topeka Ward 06 Precinct 09,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",31,500160
+SHAWNEE,Topeka Ward 06 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",298,500160
+SHAWNEE,Topeka Ward 01 Precinct 06,United States House of Representatives,2,Democratic,"Wakefield, Margie",187,600010
+SHAWNEE,Topeka Ward 01 Precinct 06,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,600010
+SHAWNEE,Topeka Ward 01 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",255,600010
+SHAWNEE,Topeka Ward 03 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",103,600020
+SHAWNEE,Topeka Ward 03 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,600020
+SHAWNEE,Topeka Ward 03 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,600020
+SHAWNEE,Kiro,United States House of Representatives,2,Democratic,"Wakefield, Margie",159,600050
+SHAWNEE,Kiro,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",16,600050
+SHAWNEE,Kiro,United States House of Representatives,2,Republican,"Jenkins, Lynn",290,600050
+SHAWNEE,Messhoss Creek,United States House of Representatives,2,Democratic,"Wakefield, Margie",94,600060
+SHAWNEE,Messhoss Creek,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,600060
+SHAWNEE,Messhoss Creek,United States House of Representatives,2,Republican,"Jenkins, Lynn",157,600060
+SHAWNEE,Indian Hills,United States House of Representatives,2,Democratic,"Wakefield, Margie",150,600080
+SHAWNEE,Indian Hills,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,600080
+SHAWNEE,Indian Hills,United States House of Representatives,2,Republican,"Jenkins, Lynn",217,600080
+SHAWNEE,Topeka Ward 14 Precinct 01,United States House of Representatives,2,Democratic,"Wakefield, Margie",241,600090
+SHAWNEE,Topeka Ward 14 Precinct 01,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,600090
+SHAWNEE,Topeka Ward 14 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",284,600090
+SHAWNEE,Topeka Ward 14 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",108,600110
+SHAWNEE,Topeka Ward 14 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",11,600110
+SHAWNEE,Topeka Ward 14 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",184,600110
+SHAWNEE,East Silver Lake,United States House of Representatives,2,Democratic,"Wakefield, Margie",213,600150
+SHAWNEE,East Silver Lake,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,600150
+SHAWNEE,East Silver Lake,United States House of Representatives,2,Republican,"Jenkins, Lynn",275,600150
+SHAWNEE,West Silver Lake,United States House of Representatives,2,Democratic,"Wakefield, Margie",143,600160
+SHAWNEE,West Silver Lake,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,600160
+SHAWNEE,West Silver Lake,United States House of Representatives,2,Republican,"Jenkins, Lynn",196,600160
+SHAWNEE,City of Auburn,United States House of Representatives,2,Democratic,"Wakefield, Margie",141,600170
+SHAWNEE,City of Auburn,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,600170
+SHAWNEE,City of Auburn,United States House of Representatives,2,Republican,"Jenkins, Lynn",223,600170
+SHAWNEE,Meadowlark,United States House of Representatives,2,Democratic,"Wakefield, Margie",171,600180
+SHAWNEE,Meadowlark,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,600180
+SHAWNEE,Meadowlark,United States House of Representatives,2,Republican,"Jenkins, Lynn",383,600180
+SHAWNEE,Buffalo,United States House of Representatives,2,Democratic,"Wakefield, Margie",122,600190
+SHAWNEE,Buffalo,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,600190
+SHAWNEE,Buffalo,United States House of Representatives,2,Republican,"Jenkins, Lynn",250,600190
+SHAWNEE,Topeka Ward 15 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",149,600210
+SHAWNEE,Topeka Ward 15 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",18,600210
+SHAWNEE,Topeka Ward 15 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",139,600210
+SHAWNEE,Iroquois,United States House of Representatives,2,Democratic,"Wakefield, Margie",154,600220
+SHAWNEE,Iroquois,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,600220
+SHAWNEE,Iroquois,United States House of Representatives,2,Republican,"Jenkins, Lynn",242,600220
+SHAWNEE,Apache,United States House of Representatives,2,Democratic,"Wakefield, Margie",145,600230
+SHAWNEE,Apache,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,600230
+SHAWNEE,Apache,United States House of Representatives,2,Republican,"Jenkins, Lynn",247,600230
+SHAWNEE,Elmont,United States House of Representatives,2,Democratic,"Wakefield, Margie",223,600240
+SHAWNEE,Elmont,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",28,600240
+SHAWNEE,Elmont,United States House of Representatives,2,Republican,"Jenkins, Lynn",343,600240
+SHAWNEE,Topeka Ward 14 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",95,600250
+SHAWNEE,Topeka Ward 14 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,600250
+SHAWNEE,Topeka Ward 14 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",250,600250
+SHAWNEE,Topeka Ward 12 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",100,600260
+SHAWNEE,Topeka Ward 12 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,600260
+SHAWNEE,Topeka Ward 12 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",93,600260
+SHAWNEE,Topeka Ward 12 Precinct 20,United States House of Representatives,2,Democratic,"Wakefield, Margie",182,600270
+SHAWNEE,Topeka Ward 12 Precinct 20,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,600270
+SHAWNEE,Topeka Ward 12 Precinct 20,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,600270
+SHAWNEE,Topeka Ward 12 Precinct 13,United States House of Representatives,2,Democratic,"Wakefield, Margie",154,600280
+SHAWNEE,Topeka Ward 12 Precinct 13,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,600280
+SHAWNEE,Topeka Ward 12 Precinct 13,United States House of Representatives,2,Republican,"Jenkins, Lynn",266,600280
+SHAWNEE,Topeka Ward 12 Precinct 31,United States House of Representatives,2,Democratic,"Wakefield, Margie",111,600290
+SHAWNEE,Topeka Ward 12 Precinct 31,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,600290
+SHAWNEE,Topeka Ward 12 Precinct 31,United States House of Representatives,2,Republican,"Jenkins, Lynn",153,600290
+SHAWNEE,Sunflower,United States House of Representatives,2,Democratic,"Wakefield, Margie",204,600300
+SHAWNEE,Sunflower,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",15,600300
+SHAWNEE,Sunflower,United States House of Representatives,2,Republican,"Jenkins, Lynn",450,600300
+SHAWNEE,South Sherwood,United States House of Representatives,2,Democratic,"Wakefield, Margie",97,600310
+SHAWNEE,South Sherwood,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,600310
+SHAWNEE,South Sherwood,United States House of Representatives,2,Republican,"Jenkins, Lynn",193,600310
+SHAWNEE,South Mission,United States House of Representatives,2,Democratic,"Wakefield, Margie",116,600330
+SHAWNEE,South Mission,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",12,600330
+SHAWNEE,South Mission,United States House of Representatives,2,Republican,"Jenkins, Lynn",195,600330
+SHAWNEE,East Soldier,United States House of Representatives,2,Democratic,"Wakefield, Margie",207,600340
+SHAWNEE,East Soldier,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,600340
+SHAWNEE,East Soldier,United States House of Representatives,2,Republican,"Jenkins, Lynn",252,600340
+SHAWNEE,Sherman,United States House of Representatives,2,Democratic,"Wakefield, Margie",145,600350
+SHAWNEE,Sherman,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,600350
+SHAWNEE,Sherman,United States House of Representatives,2,Republican,"Jenkins, Lynn",245,600350
+SHAWNEE,Sac,United States House of Representatives,2,Democratic,"Wakefield, Margie",187,600360
+SHAWNEE,Sac,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,600360
+SHAWNEE,Sac,United States House of Representatives,2,Republican,"Jenkins, Lynn",272,600360
+SHAWNEE,Fox,United States House of Representatives,2,Democratic,"Wakefield, Margie",167,600370
+SHAWNEE,Fox,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",22,600370
+SHAWNEE,Fox,United States House of Representatives,2,Republican,"Jenkins, Lynn",265,600370
+SHAWNEE,Pottawatomie,United States House of Representatives,2,Democratic,"Wakefield, Margie",189,600390
+SHAWNEE,Pottawatomie,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,600390
+SHAWNEE,Pottawatomie,United States House of Representatives,2,Republican,"Jenkins, Lynn",253,600390
+SHAWNEE,Topeka Ward 05 Precinct 10,United States House of Representatives,2,Democratic,"Wakefield, Margie",196,600420
+SHAWNEE,Topeka Ward 05 Precinct 10,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,600420
+SHAWNEE,Topeka Ward 05 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",232,600420
+SHAWNEE,Deer Creek,United States House of Representatives,2,Democratic,"Wakefield, Margie",8,600430
+SHAWNEE,Deer Creek,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,600430
+SHAWNEE,Deer Creek,United States House of Representatives,2,Republican,"Jenkins, Lynn",11,600430
+SHAWNEE,Topeka Ward 15 Precinct 03,United States House of Representatives,2,Democratic,"Wakefield, Margie",12,600440
+SHAWNEE,Topeka Ward 15 Precinct 03,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,600440
+SHAWNEE,Topeka Ward 15 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",15,600440
+SHAWNEE,Topeka Ward 12 Precinct 19,United States House of Representatives,2,Democratic,"Wakefield, Margie",22,600470
+SHAWNEE,Topeka Ward 12 Precinct 19,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,600470
+SHAWNEE,Topeka Ward 12 Precinct 19,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,600470
+SHAWNEE,Yucca,United States House of Representatives,2,Democratic,"Wakefield, Margie",41,600490
+SHAWNEE,Yucca,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,600490
+SHAWNEE,Yucca,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,600490
+SHAWNEE,Dover,United States House of Representatives,2,Democratic,"Wakefield, Margie",110,600500
+SHAWNEE,Dover,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,600500
+SHAWNEE,Dover,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,600500
+SHAWNEE,Topeka Ward 10 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",138,600570
+SHAWNEE,Topeka Ward 10 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,600570
+SHAWNEE,Topeka Ward 10 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",144,600570
+SHAWNEE,Topeka Ward 10 Precinct 14,United States House of Representatives,2,Democratic,"Wakefield, Margie",140,600580
+SHAWNEE,Topeka Ward 10 Precinct 14,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,600580
+SHAWNEE,Topeka Ward 10 Precinct 14,United States House of Representatives,2,Republican,"Jenkins, Lynn",155,600580
+SHAWNEE,Central Mission,United States House of Representatives,2,Democratic,"Wakefield, Margie",173,700020
+SHAWNEE,Central Mission,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,700020
+SHAWNEE,Central Mission,United States House of Representatives,2,Republican,"Jenkins, Lynn",347,700020
+SHAWNEE,Aldersgate,United States House of Representatives,2,Democratic,"Wakefield, Margie",101,800010
+SHAWNEE,Aldersgate,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,800010
+SHAWNEE,Aldersgate,United States House of Representatives,2,Republican,"Jenkins, Lynn",105,800010
+SHAWNEE,Topeka Ward 13 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",3,800020
+SHAWNEE,Topeka Ward 13 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,800020
+SHAWNEE,Topeka Ward 13 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",10,800020
+SHAWNEE,Topeka Ward 14 Precinct 04,United States House of Representatives,2,Democratic,"Wakefield, Margie",208,800040
+SHAWNEE,Topeka Ward 14 Precinct 04,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,800040
+SHAWNEE,Topeka Ward 14 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",393,800040
+SHAWNEE,Topeka Ward 14 Precinct 02,United States House of Representatives,2,Democratic,"Wakefield, Margie",208,800060
+SHAWNEE,Topeka Ward 14 Precinct 02,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",20,800060
+SHAWNEE,Topeka Ward 14 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",236,800060
+SHAWNEE,West Potter,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,800070
+SHAWNEE,West Potter,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,800070
+SHAWNEE,West Potter,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,800070
+SHAWNEE,Topeka Ward 01 Precinct 05,United States House of Representatives,2,Democratic,"Wakefield, Margie",154,900030
+SHAWNEE,Topeka Ward 01 Precinct 05,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",27,900030
+SHAWNEE,Topeka Ward 01 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",184,900030
+SHAWNEE,East Wichita,United States House of Representatives,2,Democratic,"Wakefield, Margie",235,900050
+SHAWNEE,East Wichita,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",23,900050
+SHAWNEE,East Wichita,United States House of Representatives,2,Republican,"Jenkins, Lynn",361,900050
+SHAWNEE,York Outer,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,900080
+SHAWNEE,York Outer,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,900080
+SHAWNEE,York Outer,United States House of Representatives,2,Republican,"Jenkins, Lynn",32,900080
+SHAWNEE,York,United States House of Representatives,2,Democratic,"Wakefield, Margie",148,900090
+SHAWNEE,York,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",19,900090
+SHAWNEE,York,United States House of Representatives,2,Republican,"Jenkins, Lynn",267,900090
+SHAWNEE,Stinson Creek,United States House of Representatives,2,Democratic,"Wakefield, Margie",67,990001
+SHAWNEE,Stinson Creek,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,990001
+SHAWNEE,Stinson Creek,United States House of Representatives,2,Republican,"Jenkins, Lynn",88,990001
+SHAWNEE,Central Pauline,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,990002
+SHAWNEE,Central Pauline,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",7,990002
+SHAWNEE,Central Pauline,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,990002
+SHAWNEE,Forbes,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,990003
+SHAWNEE,Forbes,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,990003
+SHAWNEE,Forbes,United States House of Representatives,2,Republican,"Jenkins, Lynn",30,990003
+SHAWNEE,Kingston,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,990004
+SHAWNEE,Kingston,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,990004
+SHAWNEE,Kingston,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,990004
+SHAWNEE,Gaillardia,United States House of Representatives,2,Democratic,"Wakefield, Margie",127,990005
+SHAWNEE,Gaillardia,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",13,990005
+SHAWNEE,Gaillardia,United States House of Representatives,2,Republican,"Jenkins, Lynn",275,990005
+SHAWNEE,ADVANCED,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,999998
+SHAWNEE,ADVANCED,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,999998
+SHAWNEE,ADVANCED,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,999998
+SHAWNEE,ADVANCED,Attorney General,,Democratic,"Kotich, A.J.",24718,999998
+SHAWNEE,ADVANCED,Attorney General,,Republican,"Schmidt, Derek",36114,999998
+SHAWNEE,ADVANCED,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29831,999998
+SHAWNEE,ADVANCED,Commissioner of Insurance,,Republican,"Selzer, Ken",29741,999998
+SHAWNEE,ADVANCED,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29873,999998
+SHAWNEE,ADVANCED,Secretary of State,,Republican,"Kobach, Kris",31528,999998
+SHAWNEE,ADVANCED,State Treasurer,,Democratic,"Alldritt, Carmen",26107,999998
+SHAWNEE,ADVANCED,State Treasurer,,Republican,"Estes, Ron",34265,999998
+SHAWNEE,East Peck,United States Senate,,independent,"Orman, Greg",124,000080
+SHAWNEE,East Peck,United States Senate,,Libertarian,"Batson, Randall",6,000080
+SHAWNEE,East Peck,United States Senate,,Republican,"Roberts, Pat",148,000080
+SHAWNEE,East Rossville,United States Senate,,independent,"Orman, Greg",175,000090
+SHAWNEE,East Rossville,United States Senate,,Libertarian,"Batson, Randall",20,000090
+SHAWNEE,East Rossville,United States Senate,,Republican,"Roberts, Pat",225,000090
+SHAWNEE,Grove Township,United States Senate,,independent,"Orman, Greg",110,000150
+SHAWNEE,Grove Township,United States Senate,,Libertarian,"Batson, Randall",14,000150
+SHAWNEE,Grove Township,United States Senate,,Republican,"Roberts, Pat",170,000150
+SHAWNEE,Kiowa,United States Senate,,independent,"Orman, Greg",316,000190
+SHAWNEE,Kiowa,United States Senate,,Libertarian,"Batson, Randall",19,000190
+SHAWNEE,Kiowa,United States Senate,,Republican,"Roberts, Pat",269,000190
+SHAWNEE,Northeast Monmouth,United States Senate,,independent,"Orman, Greg",219,000270
+SHAWNEE,Northeast Monmouth,United States Senate,,Libertarian,"Batson, Randall",13,000270
+SHAWNEE,Northeast Monmouth,United States Senate,,Republican,"Roberts, Pat",216,000270
+SHAWNEE,Northwest Monmouth,United States Senate,,independent,"Orman, Greg",247,000280
+SHAWNEE,Northwest Monmouth,United States Senate,,Libertarian,"Batson, Randall",12,000280
+SHAWNEE,Northwest Monmouth,United States Senate,,Republican,"Roberts, Pat",311,000280
+SHAWNEE,Pawnee,United States Senate,,independent,"Orman, Greg",221,000290
+SHAWNEE,Pawnee,United States Senate,,Libertarian,"Batson, Randall",13,000290
+SHAWNEE,Pawnee,United States Senate,,Republican,"Roberts, Pat",283,000290
+SHAWNEE,Peck,United States Senate,,independent,"Orman, Greg",163,000300
+SHAWNEE,Peck,United States Senate,,Libertarian,"Batson, Randall",6,000300
+SHAWNEE,Peck,United States Senate,,Republican,"Roberts, Pat",123,000300
+SHAWNEE,Ponca,United States Senate,,independent,"Orman, Greg",140,000310
+SHAWNEE,Ponca,United States Senate,,Libertarian,"Batson, Randall",5,000310
+SHAWNEE,Ponca,United States Senate,,Republican,"Roberts, Pat",136,000310
+SHAWNEE,Rochester,United States Senate,,independent,"Orman, Greg",203,000330
+SHAWNEE,Rochester,United States Senate,,Libertarian,"Batson, Randall",16,000330
+SHAWNEE,Rochester,United States Senate,,Republican,"Roberts, Pat",199,000330
+SHAWNEE,Sherwood,United States Senate,,independent,"Orman, Greg",172,000340
+SHAWNEE,Sherwood,United States Senate,,Libertarian,"Batson, Randall",10,000340
+SHAWNEE,Sherwood,United States Senate,,Republican,"Roberts, Pat",188,000340
+SHAWNEE,Sioux,United States Senate,,independent,"Orman, Greg",179,000350
+SHAWNEE,Sioux,United States Senate,,Libertarian,"Batson, Randall",18,000350
+SHAWNEE,Sioux,United States Senate,,Republican,"Roberts, Pat",179,000350
+SHAWNEE,South Monmouth,United States Senate,,independent,"Orman, Greg",279,000370
+SHAWNEE,South Monmouth,United States Senate,,Libertarian,"Batson, Randall",21,000370
+SHAWNEE,South Monmouth,United States Senate,,Republican,"Roberts, Pat",283,000370
+SHAWNEE,Topeka Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",107,000410
+SHAWNEE,Topeka Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",16,000410
+SHAWNEE,Topeka Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",44,000410
+SHAWNEE,Topeka Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",139,000420
+SHAWNEE,Topeka Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",14,000420
+SHAWNEE,Topeka Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",57,000420
+SHAWNEE,Topeka Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",112,000430
+SHAWNEE,Topeka Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",6,000430
+SHAWNEE,Topeka Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",55,000430
+SHAWNEE,Topeka Ward 01 Precinct 04,United States Senate,,independent,"Orman, Greg",145,000440
+SHAWNEE,Topeka Ward 01 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",10,000440
+SHAWNEE,Topeka Ward 01 Precinct 04,United States Senate,,Republican,"Roberts, Pat",90,000440
+SHAWNEE,Topeka Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",144,000480
+SHAWNEE,Topeka Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",13,000480
+SHAWNEE,Topeka Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",86,000480
+SHAWNEE,Topeka Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",127,000490
+SHAWNEE,Topeka Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",8,000490
+SHAWNEE,Topeka Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",75,000490
+SHAWNEE,Topeka Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",126,000500
+SHAWNEE,Topeka Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",12,000500
+SHAWNEE,Topeka Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",77,000500
+SHAWNEE,Topeka Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",118,000510
+SHAWNEE,Topeka Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",18,000510
+SHAWNEE,Topeka Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",61,000510
+SHAWNEE,Topeka Ward 02 Precinct 05,United States Senate,,independent,"Orman, Greg",137,000520
+SHAWNEE,Topeka Ward 02 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",8,000520
+SHAWNEE,Topeka Ward 02 Precinct 05,United States Senate,,Republican,"Roberts, Pat",49,000520
+SHAWNEE,Topeka Ward 02 Precinct 06,United States Senate,,independent,"Orman, Greg",96,000530
+SHAWNEE,Topeka Ward 02 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",9,000530
+SHAWNEE,Topeka Ward 02 Precinct 06,United States Senate,,Republican,"Roberts, Pat",46,000530
+SHAWNEE,Topeka Ward 02 Precinct 07,United States Senate,,independent,"Orman, Greg",60,000540
+SHAWNEE,Topeka Ward 02 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",13,000540
+SHAWNEE,Topeka Ward 02 Precinct 07,United States Senate,,Republican,"Roberts, Pat",19,000540
+SHAWNEE,Topeka Ward 02 Precinct 08,United States Senate,,independent,"Orman, Greg",81,000550
+SHAWNEE,Topeka Ward 02 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",6,000550
+SHAWNEE,Topeka Ward 02 Precinct 08,United States Senate,,Republican,"Roberts, Pat",11,000550
+SHAWNEE,Topeka Ward 02 Precinct 09,United States Senate,,independent,"Orman, Greg",152,000560
+SHAWNEE,Topeka Ward 02 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",13,000560
+SHAWNEE,Topeka Ward 02 Precinct 09,United States Senate,,Republican,"Roberts, Pat",81,000560
+SHAWNEE,Topeka Ward 02 Precinct 10,United States Senate,,independent,"Orman, Greg",198,000570
+SHAWNEE,Topeka Ward 02 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",18,000570
+SHAWNEE,Topeka Ward 02 Precinct 10,United States Senate,,Republican,"Roberts, Pat",61,000570
+SHAWNEE,Topeka Ward 02 Precinct 11,United States Senate,,independent,"Orman, Greg",95,000580
+SHAWNEE,Topeka Ward 02 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",6,000580
+SHAWNEE,Topeka Ward 02 Precinct 11,United States Senate,,Republican,"Roberts, Pat",49,000580
+SHAWNEE,Topeka Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",139,000590
+SHAWNEE,Topeka Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",6,000590
+SHAWNEE,Topeka Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",75,000590
+SHAWNEE,Topeka Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",175,000600
+SHAWNEE,Topeka Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",5,000600
+SHAWNEE,Topeka Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",67,000600
+SHAWNEE,Topeka Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",98,000610
+SHAWNEE,Topeka Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,000610
+SHAWNEE,Topeka Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",38,000610
+SHAWNEE,Topeka Ward 03 Precinct 06,United States Senate,,independent,"Orman, Greg",88,000640
+SHAWNEE,Topeka Ward 03 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",6,000640
+SHAWNEE,Topeka Ward 03 Precinct 06,United States Senate,,Republican,"Roberts, Pat",48,000640
+SHAWNEE,Topeka Ward 03 Precinct 07,United States Senate,,independent,"Orman, Greg",105,000650
+SHAWNEE,Topeka Ward 03 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",8,000650
+SHAWNEE,Topeka Ward 03 Precinct 07,United States Senate,,Republican,"Roberts, Pat",45,000650
+SHAWNEE,Topeka Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",119,000700
+SHAWNEE,Topeka Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",13,000700
+SHAWNEE,Topeka Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",37,000700
+SHAWNEE,Topeka Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",100,000710
+SHAWNEE,Topeka Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",5,000710
+SHAWNEE,Topeka Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",20,000710
+SHAWNEE,Topeka Ward 04 Precinct 06,United States Senate,,independent,"Orman, Greg",154,000740
+SHAWNEE,Topeka Ward 04 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",9,000740
+SHAWNEE,Topeka Ward 04 Precinct 06,United States Senate,,Republican,"Roberts, Pat",56,000740
+SHAWNEE,Topeka Ward 04 Precinct 07,United States Senate,,independent,"Orman, Greg",89,000750
+SHAWNEE,Topeka Ward 04 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",7,000750
+SHAWNEE,Topeka Ward 04 Precinct 07,United States Senate,,Republican,"Roberts, Pat",29,000750
+SHAWNEE,Topeka Ward 04 Precinct 08,United States Senate,,independent,"Orman, Greg",105,000760
+SHAWNEE,Topeka Ward 04 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",14,000760
+SHAWNEE,Topeka Ward 04 Precinct 08,United States Senate,,Republican,"Roberts, Pat",54,000760
+SHAWNEE,Topeka Ward 04 Precinct 09,United States Senate,,independent,"Orman, Greg",142,000770
+SHAWNEE,Topeka Ward 04 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",6,000770
+SHAWNEE,Topeka Ward 04 Precinct 09,United States Senate,,Republican,"Roberts, Pat",48,000770
+SHAWNEE,Topeka Ward 04 Precinct 10,United States Senate,,independent,"Orman, Greg",167,000780
+SHAWNEE,Topeka Ward 04 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",17,000780
+SHAWNEE,Topeka Ward 04 Precinct 10,United States Senate,,Republican,"Roberts, Pat",67,000780
+SHAWNEE,Topeka Ward 04 Precinct 12,United States Senate,,independent,"Orman, Greg",14,000800
+SHAWNEE,Topeka Ward 04 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",1,000800
+SHAWNEE,Topeka Ward 04 Precinct 12,United States Senate,,Republican,"Roberts, Pat",1,000800
+SHAWNEE,Topeka Ward 05 Precinct 02,United States Senate,,independent,"Orman, Greg",109,000820
+SHAWNEE,Topeka Ward 05 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",22,000820
+SHAWNEE,Topeka Ward 05 Precinct 02,United States Senate,,Republican,"Roberts, Pat",47,000820
+SHAWNEE,Topeka Ward 05 Precinct 03,United States Senate,,independent,"Orman, Greg",107,000830
+SHAWNEE,Topeka Ward 05 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,000830
+SHAWNEE,Topeka Ward 05 Precinct 03,United States Senate,,Republican,"Roberts, Pat",71,000830
+SHAWNEE,Topeka Ward 05 Precinct 04,United States Senate,,independent,"Orman, Greg",141,000840
+SHAWNEE,Topeka Ward 05 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",13,000840
+SHAWNEE,Topeka Ward 05 Precinct 04,United States Senate,,Republican,"Roberts, Pat",57,000840
+SHAWNEE,Topeka Ward 05 Precinct 05,United States Senate,,independent,"Orman, Greg",135,000850
+SHAWNEE,Topeka Ward 05 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",11,000850
+SHAWNEE,Topeka Ward 05 Precinct 05,United States Senate,,Republican,"Roberts, Pat",61,000850
+SHAWNEE,Topeka Ward 05 Precinct 06,United States Senate,,independent,"Orman, Greg",102,000860
+SHAWNEE,Topeka Ward 05 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",6,000860
+SHAWNEE,Topeka Ward 05 Precinct 06,United States Senate,,Republican,"Roberts, Pat",40,000860
+SHAWNEE,Topeka Ward 05 Precinct 07,United States Senate,,independent,"Orman, Greg",153,000870
+SHAWNEE,Topeka Ward 05 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",10,000870
+SHAWNEE,Topeka Ward 05 Precinct 07,United States Senate,,Republican,"Roberts, Pat",49,000870
+SHAWNEE,Topeka Ward 05 Precinct 08,United States Senate,,independent,"Orman, Greg",104,000880
+SHAWNEE,Topeka Ward 05 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",8,000880
+SHAWNEE,Topeka Ward 05 Precinct 08,United States Senate,,Republican,"Roberts, Pat",58,000880
+SHAWNEE,Topeka Ward 05 Precinct 09,United States Senate,,independent,"Orman, Greg",207,000890
+SHAWNEE,Topeka Ward 05 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",9,000890
+SHAWNEE,Topeka Ward 05 Precinct 09,United States Senate,,Republican,"Roberts, Pat",138,000890
+SHAWNEE,Topeka Ward 15 Precinct 01,United States Senate,,independent,"Orman, Greg",222,000910
+SHAWNEE,Topeka Ward 15 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",23,000910
+SHAWNEE,Topeka Ward 15 Precinct 01,United States Senate,,Republican,"Roberts, Pat",168,000910
+SHAWNEE,Topeka Ward 05 Precinct 91,United States Senate,,independent,"Orman, Greg",45,000930
+SHAWNEE,Topeka Ward 05 Precinct 91,United States Senate,,Libertarian,"Batson, Randall",3,000930
+SHAWNEE,Topeka Ward 05 Precinct 91,United States Senate,,Republican,"Roberts, Pat",44,000930
+SHAWNEE,Topeka Ward 06 Precinct 01,United States Senate,,independent,"Orman, Greg",108,000940
+SHAWNEE,Topeka Ward 06 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",10,000940
+SHAWNEE,Topeka Ward 06 Precinct 01,United States Senate,,Republican,"Roberts, Pat",33,000940
+SHAWNEE,Topeka Ward 06 Precinct 02,United States Senate,,independent,"Orman, Greg",109,000950
+SHAWNEE,Topeka Ward 06 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",18,000950
+SHAWNEE,Topeka Ward 06 Precinct 02,United States Senate,,Republican,"Roberts, Pat",31,000950
+SHAWNEE,Topeka Ward 06 Precinct 03,United States Senate,,independent,"Orman, Greg",177,000960
+SHAWNEE,Topeka Ward 06 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",8,000960
+SHAWNEE,Topeka Ward 06 Precinct 03,United States Senate,,Republican,"Roberts, Pat",177,000960
+SHAWNEE,Topeka Ward 06 Precinct 04,United States Senate,,independent,"Orman, Greg",144,000970
+SHAWNEE,Topeka Ward 06 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",7,000970
+SHAWNEE,Topeka Ward 06 Precinct 04,United States Senate,,Republican,"Roberts, Pat",70,000970
+SHAWNEE,Topeka Ward 06 Precinct 05,United States Senate,,independent,"Orman, Greg",197,000980
+SHAWNEE,Topeka Ward 06 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",14,000980
+SHAWNEE,Topeka Ward 06 Precinct 05,United States Senate,,Republican,"Roberts, Pat",117,000980
+SHAWNEE,Topeka Ward 06 Precinct 06,United States Senate,,independent,"Orman, Greg",91,000990
+SHAWNEE,Topeka Ward 06 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",9,000990
+SHAWNEE,Topeka Ward 06 Precinct 06,United States Senate,,Republican,"Roberts, Pat",54,000990
+SHAWNEE,Topeka Ward 06 Precinct 07,United States Senate,,independent,"Orman, Greg",68,001000
+SHAWNEE,Topeka Ward 06 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",8,001000
+SHAWNEE,Topeka Ward 06 Precinct 07,United States Senate,,Republican,"Roberts, Pat",46,001000
+SHAWNEE,Topeka Ward 06 Precinct 08,United States Senate,,independent,"Orman, Greg",157,001010
+SHAWNEE,Topeka Ward 06 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",13,001010
+SHAWNEE,Topeka Ward 06 Precinct 08,United States Senate,,Republican,"Roberts, Pat",68,001010
+SHAWNEE,Topeka Ward 07 Precinct 01,United States Senate,,independent,"Orman, Greg",210,001040
+SHAWNEE,Topeka Ward 07 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",10,001040
+SHAWNEE,Topeka Ward 07 Precinct 01,United States Senate,,Republican,"Roberts, Pat",92,001040
+SHAWNEE,Topeka Ward 07 Precinct 02,United States Senate,,independent,"Orman, Greg",168,001050
+SHAWNEE,Topeka Ward 07 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",14,001050
+SHAWNEE,Topeka Ward 07 Precinct 02,United States Senate,,Republican,"Roberts, Pat",66,001050
+SHAWNEE,Topeka Ward 07 Precinct 03,United States Senate,,independent,"Orman, Greg",167,001060
+SHAWNEE,Topeka Ward 07 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",10,001060
+SHAWNEE,Topeka Ward 07 Precinct 03,United States Senate,,Republican,"Roberts, Pat",81,001060
+SHAWNEE,Topeka Ward 07 Precinct 04,United States Senate,,independent,"Orman, Greg",162,001070
+SHAWNEE,Topeka Ward 07 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",10,001070
+SHAWNEE,Topeka Ward 07 Precinct 04,United States Senate,,Republican,"Roberts, Pat",129,001070
+SHAWNEE,Topeka Ward 07 Precinct 05,United States Senate,,independent,"Orman, Greg",132,001080
+SHAWNEE,Topeka Ward 07 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",17,001080
+SHAWNEE,Topeka Ward 07 Precinct 05,United States Senate,,Republican,"Roberts, Pat",100,001080
+SHAWNEE,Topeka Ward 07 Precinct 06,United States Senate,,independent,"Orman, Greg",114,001090
+SHAWNEE,Topeka Ward 07 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",14,001090
+SHAWNEE,Topeka Ward 07 Precinct 06,United States Senate,,Republican,"Roberts, Pat",78,001090
+SHAWNEE,Topeka Ward 07 Precinct 07,United States Senate,,independent,"Orman, Greg",126,001100
+SHAWNEE,Topeka Ward 07 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",7,001100
+SHAWNEE,Topeka Ward 07 Precinct 07,United States Senate,,Republican,"Roberts, Pat",61,001100
+SHAWNEE,Topeka Ward 07 Precinct 09,United States Senate,,independent,"Orman, Greg",123,001120
+SHAWNEE,Topeka Ward 07 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",8,001120
+SHAWNEE,Topeka Ward 07 Precinct 09,United States Senate,,Republican,"Roberts, Pat",85,001120
+SHAWNEE,Topeka Ward 07 Precinct 10,United States Senate,,independent,"Orman, Greg",152,001130
+SHAWNEE,Topeka Ward 07 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",6,001130
+SHAWNEE,Topeka Ward 07 Precinct 10,United States Senate,,Republican,"Roberts, Pat",64,001130
+SHAWNEE,Topeka Ward 07 Precinct 11,United States Senate,,independent,"Orman, Greg",215,001140
+SHAWNEE,Topeka Ward 07 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",10,001140
+SHAWNEE,Topeka Ward 07 Precinct 11,United States Senate,,Republican,"Roberts, Pat",131,001140
+SHAWNEE,Topeka Ward 08 Precinct 01,United States Senate,,independent,"Orman, Greg",138,001150
+SHAWNEE,Topeka Ward 08 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",13,001150
+SHAWNEE,Topeka Ward 08 Precinct 01,United States Senate,,Republican,"Roberts, Pat",49,001150
+SHAWNEE,Topeka Ward 08 Precinct 02,United States Senate,,independent,"Orman, Greg",166,001160
+SHAWNEE,Topeka Ward 08 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",12,001160
+SHAWNEE,Topeka Ward 08 Precinct 02,United States Senate,,Republican,"Roberts, Pat",63,001160
+SHAWNEE,Topeka Ward 08 Precinct 03,United States Senate,,independent,"Orman, Greg",239,001170
+SHAWNEE,Topeka Ward 08 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",13,001170
+SHAWNEE,Topeka Ward 08 Precinct 03,United States Senate,,Republican,"Roberts, Pat",93,001170
+SHAWNEE,Topeka Ward 08 Precinct 04,United States Senate,,independent,"Orman, Greg",207,001180
+SHAWNEE,Topeka Ward 08 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",11,001180
+SHAWNEE,Topeka Ward 08 Precinct 04,United States Senate,,Republican,"Roberts, Pat",101,001180
+SHAWNEE,Topeka Ward 08 Precinct 05,United States Senate,,independent,"Orman, Greg",259,001190
+SHAWNEE,Topeka Ward 08 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",18,001190
+SHAWNEE,Topeka Ward 08 Precinct 05,United States Senate,,Republican,"Roberts, Pat",156,001190
+SHAWNEE,Topeka Ward 08 Precinct 06,United States Senate,,independent,"Orman, Greg",148,001200
+SHAWNEE,Topeka Ward 08 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",5,001200
+SHAWNEE,Topeka Ward 08 Precinct 06,United States Senate,,Republican,"Roberts, Pat",107,001200
+SHAWNEE,Topeka Ward 08 Precinct 07,United States Senate,,independent,"Orman, Greg",149,001210
+SHAWNEE,Topeka Ward 08 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",7,001210
+SHAWNEE,Topeka Ward 08 Precinct 07,United States Senate,,Republican,"Roberts, Pat",60,001210
+SHAWNEE,Topeka Ward 08 Precinct 08,United States Senate,,independent,"Orman, Greg",167,001220
+SHAWNEE,Topeka Ward 08 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",6,001220
+SHAWNEE,Topeka Ward 08 Precinct 08,United States Senate,,Republican,"Roberts, Pat",78,001220
+SHAWNEE,Topeka Ward 08 Precinct 09,United States Senate,,independent,"Orman, Greg",203,001230
+SHAWNEE,Topeka Ward 08 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",15,001230
+SHAWNEE,Topeka Ward 08 Precinct 09,United States Senate,,Republican,"Roberts, Pat",136,001230
+SHAWNEE,Topeka Ward 08 Precinct 10,United States Senate,,independent,"Orman, Greg",118,001240
+SHAWNEE,Topeka Ward 08 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",8,001240
+SHAWNEE,Topeka Ward 08 Precinct 10,United States Senate,,Republican,"Roberts, Pat",151,001240
+SHAWNEE,Topeka Ward 08 Precinct 11,United States Senate,,independent,"Orman, Greg",205,001250
+SHAWNEE,Topeka Ward 08 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",13,001250
+SHAWNEE,Topeka Ward 08 Precinct 11,United States Senate,,Republican,"Roberts, Pat",134,001250
+SHAWNEE,Topeka Ward 09 Precinct 02,United States Senate,,independent,"Orman, Greg",133,001270
+SHAWNEE,Topeka Ward 09 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",5,001270
+SHAWNEE,Topeka Ward 09 Precinct 02,United States Senate,,Republican,"Roberts, Pat",72,001270
+SHAWNEE,Topeka Ward 09 Precinct 03,United States Senate,,independent,"Orman, Greg",241,001280
+SHAWNEE,Topeka Ward 09 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",5,001280
+SHAWNEE,Topeka Ward 09 Precinct 03,United States Senate,,Republican,"Roberts, Pat",167,001280
+SHAWNEE,Topeka Ward 09 Precinct 04,United States Senate,,independent,"Orman, Greg",214,001290
+SHAWNEE,Topeka Ward 09 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",9,001290
+SHAWNEE,Topeka Ward 09 Precinct 04,United States Senate,,Republican,"Roberts, Pat",127,001290
+SHAWNEE,Topeka Ward 09 Precinct 05,United States Senate,,independent,"Orman, Greg",163,001300
+SHAWNEE,Topeka Ward 09 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",11,001300
+SHAWNEE,Topeka Ward 09 Precinct 05,United States Senate,,Republican,"Roberts, Pat",92,001300
+SHAWNEE,Topeka Ward 09 Precinct 06,United States Senate,,independent,"Orman, Greg",184,001310
+SHAWNEE,Topeka Ward 09 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",8,001310
+SHAWNEE,Topeka Ward 09 Precinct 06,United States Senate,,Republican,"Roberts, Pat",115,001310
+SHAWNEE,Topeka Ward 09 Precinct 08,United States Senate,,independent,"Orman, Greg",213,001320
+SHAWNEE,Topeka Ward 09 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",20,001320
+SHAWNEE,Topeka Ward 09 Precinct 08,United States Senate,,Republican,"Roberts, Pat",139,001320
+SHAWNEE,Topeka Ward 09 Precinct 09,United States Senate,,independent,"Orman, Greg",166,001330
+SHAWNEE,Topeka Ward 09 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",5,001330
+SHAWNEE,Topeka Ward 09 Precinct 09,United States Senate,,Republican,"Roberts, Pat",105,001330
+SHAWNEE,Topeka Ward 09 Precinct 10,United States Senate,,independent,"Orman, Greg",300,001340
+SHAWNEE,Topeka Ward 09 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",21,001340
+SHAWNEE,Topeka Ward 09 Precinct 10,United States Senate,,Republican,"Roberts, Pat",189,001340
+SHAWNEE,Topeka Ward 09 Precinct 11,United States Senate,,independent,"Orman, Greg",173,001350
+SHAWNEE,Topeka Ward 09 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",3,001350
+SHAWNEE,Topeka Ward 09 Precinct 11,United States Senate,,Republican,"Roberts, Pat",122,001350
+SHAWNEE,Topeka Ward 10 Precinct 01,United States Senate,,independent,"Orman, Greg",197,001360
+SHAWNEE,Topeka Ward 10 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",15,001360
+SHAWNEE,Topeka Ward 10 Precinct 01,United States Senate,,Republican,"Roberts, Pat",106,001360
+SHAWNEE,Topeka Ward 10 Precinct 02,United States Senate,,independent,"Orman, Greg",163,001370
+SHAWNEE,Topeka Ward 10 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",8,001370
+SHAWNEE,Topeka Ward 10 Precinct 02,United States Senate,,Republican,"Roberts, Pat",185,001370
+SHAWNEE,Topeka Ward 10 Precinct 03,United States Senate,,independent,"Orman, Greg",261,001380
+SHAWNEE,Topeka Ward 10 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",21,001380
+SHAWNEE,Topeka Ward 10 Precinct 03,United States Senate,,Republican,"Roberts, Pat",221,001380
+SHAWNEE,Topeka Ward 10 Precinct 05,United States Senate,,independent,"Orman, Greg",152,001400
+SHAWNEE,Topeka Ward 10 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",14,001400
+SHAWNEE,Topeka Ward 10 Precinct 05,United States Senate,,Republican,"Roberts, Pat",103,001400
+SHAWNEE,Topeka Ward 10 Precinct 06,United States Senate,,independent,"Orman, Greg",135,001410
+SHAWNEE,Topeka Ward 10 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",13,001410
+SHAWNEE,Topeka Ward 10 Precinct 06,United States Senate,,Republican,"Roberts, Pat",125,001410
+SHAWNEE,Topeka Ward 10 Precinct 07,United States Senate,,independent,"Orman, Greg",162,001420
+SHAWNEE,Topeka Ward 10 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",17,001420
+SHAWNEE,Topeka Ward 10 Precinct 07,United States Senate,,Republican,"Roberts, Pat",120,001420
+SHAWNEE,Topeka Ward 10 Precinct 08,United States Senate,,independent,"Orman, Greg",155,001430
+SHAWNEE,Topeka Ward 10 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",12,001430
+SHAWNEE,Topeka Ward 10 Precinct 08,United States Senate,,Republican,"Roberts, Pat",88,001430
+SHAWNEE,Topeka Ward 10 Precinct 09,United States Senate,,independent,"Orman, Greg",123,001440
+SHAWNEE,Topeka Ward 10 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",10,001440
+SHAWNEE,Topeka Ward 10 Precinct 09,United States Senate,,Republican,"Roberts, Pat",78,001440
+SHAWNEE,Topeka Ward 10 Precinct 10,United States Senate,,independent,"Orman, Greg",169,001450
+SHAWNEE,Topeka Ward 10 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",9,001450
+SHAWNEE,Topeka Ward 10 Precinct 10,United States Senate,,Republican,"Roberts, Pat",115,001450
+SHAWNEE,Topeka Ward 10 Precinct 11,United States Senate,,independent,"Orman, Greg",225,001460
+SHAWNEE,Topeka Ward 10 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",28,001460
+SHAWNEE,Topeka Ward 10 Precinct 11,United States Senate,,Republican,"Roberts, Pat",167,001460
+SHAWNEE,Topeka Ward 11 Precinct 01,United States Senate,,independent,"Orman, Greg",108,001470
+SHAWNEE,Topeka Ward 11 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",9,001470
+SHAWNEE,Topeka Ward 11 Precinct 01,United States Senate,,Republican,"Roberts, Pat",94,001470
+SHAWNEE,Topeka Ward 11 Precinct 02,United States Senate,,independent,"Orman, Greg",170,001480
+SHAWNEE,Topeka Ward 11 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",10,001480
+SHAWNEE,Topeka Ward 11 Precinct 02,United States Senate,,Republican,"Roberts, Pat",115,001480
+SHAWNEE,Topeka Ward 11 Precinct 03,United States Senate,,independent,"Orman, Greg",134,001490
+SHAWNEE,Topeka Ward 11 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",12,001490
+SHAWNEE,Topeka Ward 11 Precinct 03,United States Senate,,Republican,"Roberts, Pat",71,001490
+SHAWNEE,Topeka Ward 11 Precinct 04,United States Senate,,independent,"Orman, Greg",233,001500
+SHAWNEE,Topeka Ward 11 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",19,001500
+SHAWNEE,Topeka Ward 11 Precinct 04,United States Senate,,Republican,"Roberts, Pat",163,001500
+SHAWNEE,Topeka Ward 11 Precinct 05,United States Senate,,independent,"Orman, Greg",167,001510
+SHAWNEE,Topeka Ward 11 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",15,001510
+SHAWNEE,Topeka Ward 11 Precinct 05,United States Senate,,Republican,"Roberts, Pat",113,001510
+SHAWNEE,Topeka Ward 11 Precinct 06,United States Senate,,independent,"Orman, Greg",153,001520
+SHAWNEE,Topeka Ward 11 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",17,001520
+SHAWNEE,Topeka Ward 11 Precinct 06,United States Senate,,Republican,"Roberts, Pat",113,001520
+SHAWNEE,Topeka Ward 11 Precinct 07,United States Senate,,independent,"Orman, Greg",145,001530
+SHAWNEE,Topeka Ward 11 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",10,001530
+SHAWNEE,Topeka Ward 11 Precinct 07,United States Senate,,Republican,"Roberts, Pat",117,001530
+SHAWNEE,Topeka Ward 11 Precinct 08,United States Senate,,independent,"Orman, Greg",142,001540
+SHAWNEE,Topeka Ward 11 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",13,001540
+SHAWNEE,Topeka Ward 11 Precinct 08,United States Senate,,Republican,"Roberts, Pat",112,001540
+SHAWNEE,Topeka Ward 11 Precinct 09,United States Senate,,independent,"Orman, Greg",170,001550
+SHAWNEE,Topeka Ward 11 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",16,001550
+SHAWNEE,Topeka Ward 11 Precinct 09,United States Senate,,Republican,"Roberts, Pat",114,001550
+SHAWNEE,Topeka Ward 11 Precinct 10,United States Senate,,independent,"Orman, Greg",114,001560
+SHAWNEE,Topeka Ward 11 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",11,001560
+SHAWNEE,Topeka Ward 11 Precinct 10,United States Senate,,Republican,"Roberts, Pat",72,001560
+SHAWNEE,Topeka Ward 12 Precinct 01,United States Senate,,independent,"Orman, Greg",166,001570
+SHAWNEE,Topeka Ward 12 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",16,001570
+SHAWNEE,Topeka Ward 12 Precinct 01,United States Senate,,Republican,"Roberts, Pat",92,001570
+SHAWNEE,Topeka Ward 12 Precinct 03,United States Senate,,independent,"Orman, Greg",171,001590
+SHAWNEE,Topeka Ward 12 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",8,001590
+SHAWNEE,Topeka Ward 12 Precinct 03,United States Senate,,Republican,"Roberts, Pat",155,001590
+SHAWNEE,Topeka Ward 12 Precinct 04,United States Senate,,independent,"Orman, Greg",211,001600
+SHAWNEE,Topeka Ward 12 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",6,001600
+SHAWNEE,Topeka Ward 12 Precinct 04,United States Senate,,Republican,"Roberts, Pat",214,001600
+SHAWNEE,Topeka Ward 12 Precinct 05,United States Senate,,independent,"Orman, Greg",207,001610
+SHAWNEE,Topeka Ward 12 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",9,001610
+SHAWNEE,Topeka Ward 12 Precinct 05,United States Senate,,Republican,"Roberts, Pat",180,001610
+SHAWNEE,Topeka Ward 12 Precinct 06,United States Senate,,independent,"Orman, Greg",257,001620
+SHAWNEE,Topeka Ward 12 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",10,001620
+SHAWNEE,Topeka Ward 12 Precinct 06,United States Senate,,Republican,"Roberts, Pat",162,001620
+SHAWNEE,Topeka Ward 12 Precinct 07,United States Senate,,independent,"Orman, Greg",209,001630
+SHAWNEE,Topeka Ward 12 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",23,001630
+SHAWNEE,Topeka Ward 12 Precinct 07,United States Senate,,Republican,"Roberts, Pat",163,001630
+SHAWNEE,Topeka Ward 12 Precinct 08,United States Senate,,independent,"Orman, Greg",214,001640
+SHAWNEE,Topeka Ward 12 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",19,001640
+SHAWNEE,Topeka Ward 12 Precinct 08,United States Senate,,Republican,"Roberts, Pat",165,001640
+SHAWNEE,Topeka Ward 12 Precinct 09,United States Senate,,independent,"Orman, Greg",306,001650
+SHAWNEE,Topeka Ward 12 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",31,001650
+SHAWNEE,Topeka Ward 12 Precinct 09,United States Senate,,Republican,"Roberts, Pat",261,001650
+SHAWNEE,Topeka Ward 12 Precinct 11,United States Senate,,independent,"Orman, Greg",294,001670
+SHAWNEE,Topeka Ward 12 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",17,001670
+SHAWNEE,Topeka Ward 12 Precinct 11,United States Senate,,Republican,"Roberts, Pat",304,001670
+SHAWNEE,Topeka Ward 12 Precinct 15,United States Senate,,independent,"Orman, Greg",271,001710
+SHAWNEE,Topeka Ward 12 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",21,001710
+SHAWNEE,Topeka Ward 12 Precinct 15,United States Senate,,Republican,"Roberts, Pat",268,001710
+SHAWNEE,Topeka Ward 12 Precinct 16,United States Senate,,independent,"Orman, Greg",312,001720
+SHAWNEE,Topeka Ward 12 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",17,001720
+SHAWNEE,Topeka Ward 12 Precinct 16,United States Senate,,Republican,"Roberts, Pat",260,001720
+SHAWNEE,West Rossville,United States Senate,,independent,"Orman, Greg",103,001850
+SHAWNEE,West Rossville,United States Senate,,Libertarian,"Batson, Randall",9,001850
+SHAWNEE,West Rossville,United States Senate,,Republican,"Roberts, Pat",200,001850
+SHAWNEE,Whitfield,United States Senate,,independent,"Orman, Greg",172,001880
+SHAWNEE,Whitfield,United States Senate,,Libertarian,"Batson, Randall",18,001880
+SHAWNEE,Whitfield,United States Senate,,Republican,"Roberts, Pat",151,001880
+SHAWNEE,Willard,United States Senate,,independent,"Orman, Greg",136,001890
+SHAWNEE,Willard,United States Senate,,Libertarian,"Batson, Randall",8,001890
+SHAWNEE,Willard,United States Senate,,Republican,"Roberts, Pat",199,001890
+SHAWNEE,Kilmer,United States Senate,,independent,"Orman, Greg",50,017
+SHAWNEE,Kilmer,United States Senate,,Libertarian,"Batson, Randall",6,017
+SHAWNEE,Kilmer,United States Senate,,Republican,"Roberts, Pat",69,017
+SHAWNEE,North Tecumseh,United States Senate,,independent,"Orman, Greg",175,023
+SHAWNEE,North Tecumseh,United States Senate,,Libertarian,"Batson, Randall",17,023
+SHAWNEE,North Tecumseh,United States Senate,,Republican,"Roberts, Pat",164,023
+SHAWNEE,Kaw,United States Senate,,independent,"Orman, Greg",230,026
+SHAWNEE,Kaw,United States Senate,,Libertarian,"Batson, Randall",8,026
+SHAWNEE,Kaw,United States Senate,,Republican,"Roberts, Pat",196,026
+SHAWNEE,Cheyenne,United States Senate,,independent,"Orman, Greg",217,030
+SHAWNEE,Cheyenne,United States Senate,,Libertarian,"Batson, Randall",19,030
+SHAWNEE,Cheyenne,United States Senate,,Republican,"Roberts, Pat",189,030
+SHAWNEE,Washburn,United States Senate,,independent,"Orman, Greg",142,049
+SHAWNEE,Washburn,United States Senate,,Libertarian,"Batson, Randall",9,049
+SHAWNEE,Washburn,United States Senate,,Republican,"Roberts, Pat",196,049
+SHAWNEE,North Mission,United States Senate,,independent,"Orman, Greg",44,050
+SHAWNEE,North Mission,United States Senate,,Libertarian,"Batson, Randall",2,050
+SHAWNEE,North Mission,United States Senate,,Republican,"Roberts, Pat",75,050
+SHAWNEE,Topeka Ward 03 Precinct 05,United States Senate,,independent,"Orman, Greg",78,079
+SHAWNEE,Topeka Ward 03 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",7,079
+SHAWNEE,Topeka Ward 03 Precinct 05,United States Senate,,Republican,"Roberts, Pat",27,079
+SHAWNEE,Topeka Ward 03 Precinct 08,United States Senate,,independent,"Orman, Greg",124,082
+SHAWNEE,Topeka Ward 03 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",11,082
+SHAWNEE,Topeka Ward 03 Precinct 08,United States Senate,,Republican,"Roberts, Pat",65,082
+SHAWNEE,Topeka Ward 03 Precinct 09,United States Senate,,independent,"Orman, Greg",120,083
+SHAWNEE,Topeka Ward 03 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",12,083
+SHAWNEE,Topeka Ward 03 Precinct 09,United States Senate,,Republican,"Roberts, Pat",54,083
+SHAWNEE,Topeka Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",118,084
+SHAWNEE,Topeka Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",20,084
+SHAWNEE,Topeka Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",37,084
+SHAWNEE,Topeka Ward 04 Precinct 11,United States Senate,,independent,"Orman, Greg",55,093
+SHAWNEE,Topeka Ward 04 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",5,093
+SHAWNEE,Topeka Ward 04 Precinct 11,United States Senate,,Republican,"Roberts, Pat",37,093
+SHAWNEE,Topeka Ward 05 Precinct 01,United States Senate,,independent,"Orman, Greg",117,094
+SHAWNEE,Topeka Ward 05 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",13,094
+SHAWNEE,Topeka Ward 05 Precinct 01,United States Senate,,Republican,"Roberts, Pat",37,094
+SHAWNEE,Topeka Ward 13 Precinct 06,United States Senate,,independent,"Orman, Greg",34,100030
+SHAWNEE,Topeka Ward 13 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",3,100030
+SHAWNEE,Topeka Ward 13 Precinct 06,United States Senate,,Republican,"Roberts, Pat",75,100030
+SHAWNEE,Little Muddy Creek,United States Senate,,independent,"Orman, Greg",135,120070
+SHAWNEE,Little Muddy Creek,United States Senate,,Libertarian,"Batson, Randall",9,120070
+SHAWNEE,Little Muddy Creek,United States Senate,,Republican,"Roberts, Pat",150,120070
+SHAWNEE,Montara,United States Senate,,independent,"Orman, Greg",116,120090
+SHAWNEE,Montara,United States Senate,,Libertarian,"Batson, Randall",21,120090
+SHAWNEE,Montara,United States Senate,,Republican,"Roberts, Pat",69,120090
+SHAWNEE,Pauline,United States Senate,,independent,"Orman, Greg",100,120160
+SHAWNEE,Pauline,United States Senate,,Libertarian,"Batson, Randall",8,120160
+SHAWNEE,Pauline,United States Senate,,Republican,"Roberts, Pat",67,120160
+SHAWNEE,Topeka Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",174,120240
+SHAWNEE,Topeka Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",17,120240
+SHAWNEE,Topeka Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",22,120240
+SHAWNEE,Wakarusa,United States Senate,,independent,"Orman, Greg",183,120320
+SHAWNEE,Wakarusa,United States Senate,,Libertarian,"Batson, Randall",17,120320
+SHAWNEE,Wakarusa,United States Senate,,Republican,"Roberts, Pat",243,120320
+SHAWNEE,Topeka Ward 09 Precinct 01,United States Senate,,independent,"Orman, Greg",39,136
+SHAWNEE,Topeka Ward 09 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",2,136
+SHAWNEE,Topeka Ward 09 Precinct 01,United States Senate,,Republican,"Roberts, Pat",18,136
+SHAWNEE,Verbena,United States Senate,,independent,"Orman, Greg",28,140010
+SHAWNEE,Verbena,United States Senate,,Libertarian,"Batson, Randall",6,140010
+SHAWNEE,Verbena,United States Senate,,Republican,"Roberts, Pat",41,140010
+SHAWNEE,Topeka Ward 03 Precinct 10,United States Senate,,independent,"Orman, Greg",8,140020
+SHAWNEE,Topeka Ward 03 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",1,140020
+SHAWNEE,Topeka Ward 03 Precinct 10,United States Senate,,Republican,"Roberts, Pat",3,140020
+SHAWNEE,Topeka Ward 04 Precinct 15,United States Senate,,independent,"Orman, Greg",86,140030
+SHAWNEE,Topeka Ward 04 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",6,140030
+SHAWNEE,Topeka Ward 04 Precinct 15,United States Senate,,Republican,"Roberts, Pat",48,140030
+SHAWNEE,Topeka Ward 05 Precinct 11,United States Senate,,independent,"Orman, Greg",191,140040
+SHAWNEE,Topeka Ward 05 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",14,140040
+SHAWNEE,Topeka Ward 05 Precinct 11,United States Senate,,Republican,"Roberts, Pat",136,140040
+SHAWNEE,Topeka Ward 09 Precinct 12,United States Senate,,independent,"Orman, Greg",94,140050
+SHAWNEE,Topeka Ward 09 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",4,140050
+SHAWNEE,Topeka Ward 09 Precinct 12,United States Senate,,Republican,"Roberts, Pat",45,140050
+SHAWNEE,Indianola,United States Senate,,independent,"Orman, Greg",216,200020
+SHAWNEE,Indianola,United States Senate,,Libertarian,"Batson, Randall",12,200020
+SHAWNEE,Indianola,United States Senate,,Republican,"Roberts, Pat",235,200020
+SHAWNEE,Cullen,United States Senate,,independent,"Orman, Greg",150,200050
+SHAWNEE,Cullen,United States Senate,,Libertarian,"Batson, Randall",16,200050
+SHAWNEE,Cullen,United States Senate,,Republican,"Roberts, Pat",108,200050
+SHAWNEE,Topeka Ward 12 Precinct 14,United States Senate,,independent,"Orman, Greg",162,200070
+SHAWNEE,Topeka Ward 12 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",7,200070
+SHAWNEE,Topeka Ward 12 Precinct 14,United States Senate,,Republican,"Roberts, Pat",156,200070
+SHAWNEE,Topeka Ward 13 Precinct 02,United States Senate,,independent,"Orman, Greg",67,200130
+SHAWNEE,Topeka Ward 13 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",3,200130
+SHAWNEE,Topeka Ward 13 Precinct 02,United States Senate,,Republican,"Roberts, Pat",39,200130
+SHAWNEE,Topeka Ward 13 Precinct 21,United States Senate,,independent,"Orman, Greg",43,200150
+SHAWNEE,Topeka Ward 13 Precinct 21,United States Senate,,Libertarian,"Batson, Randall",1,200150
+SHAWNEE,Topeka Ward 13 Precinct 21,United States Senate,,Republican,"Roberts, Pat",24,200150
+SHAWNEE,Topeka Ward 13 Precinct 22,United States Senate,,independent,"Orman, Greg",33,200160
+SHAWNEE,Topeka Ward 13 Precinct 22,United States Senate,,Libertarian,"Batson, Randall",1,200160
+SHAWNEE,Topeka Ward 13 Precinct 22,United States Senate,,Republican,"Roberts, Pat",30,200160
+SHAWNEE,Topeka Ward 13 Precinct 09,United States Senate,,independent,"Orman, Greg",35,300090
+SHAWNEE,Topeka Ward 13 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",5,300090
+SHAWNEE,Topeka Ward 13 Precinct 09,United States Senate,,Republican,"Roberts, Pat",49,300090
+SHAWNEE,Topeka Ward 13 Precinct 30,United States Senate,,independent,"Orman, Greg",65,400070
+SHAWNEE,Topeka Ward 13 Precinct 30,United States Senate,,Libertarian,"Batson, Randall",3,400070
+SHAWNEE,Topeka Ward 13 Precinct 30,United States Senate,,Republican,"Roberts, Pat",49,400070
+SHAWNEE,West Wichita,United States Senate,,independent,"Orman, Greg",183,400100
+SHAWNEE,West Wichita,United States Senate,,Libertarian,"Batson, Randall",15,400100
+SHAWNEE,West Wichita,United States Senate,,Republican,"Roberts, Pat",185,400100
+SHAWNEE,Topeka Ward 05 Precinct 15,United States Senate,,independent,"Orman, Greg",25,500070
+SHAWNEE,Topeka Ward 05 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",1,500070
+SHAWNEE,Topeka Ward 05 Precinct 15,United States Senate,,Republican,"Roberts, Pat",25,500070
+SHAWNEE,South Tecumseh,United States Senate,,independent,"Orman, Greg",199,500080
+SHAWNEE,South Tecumseh,United States Senate,,Libertarian,"Batson, Randall",10,500080
+SHAWNEE,South Tecumseh,United States Senate,,Republican,"Roberts, Pat",164,500080
+SHAWNEE,Vacquero,United States Senate,,independent,"Orman, Greg",153,500110
+SHAWNEE,Vacquero,United States Senate,,Libertarian,"Batson, Randall",13,500110
+SHAWNEE,Vacquero,United States Senate,,Republican,"Roberts, Pat",158,500110
+SHAWNEE,Topeka Ward 05 Precinct 14,United States Senate,,independent,"Orman, Greg",105,500120
+SHAWNEE,Topeka Ward 05 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",5,500120
+SHAWNEE,Topeka Ward 05 Precinct 14,United States Senate,,Republican,"Roberts, Pat",107,500120
+SHAWNEE,Topeka Ward 13 Precinct 12,United States Senate,,independent,"Orman, Greg",231,500140
+SHAWNEE,Topeka Ward 13 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",8,500140
+SHAWNEE,Topeka Ward 13 Precinct 12,United States Senate,,Republican,"Roberts, Pat",286,500140
+SHAWNEE,Topeka Ward 06 Precinct 09,United States Senate,,independent,"Orman, Greg",331,500160
+SHAWNEE,Topeka Ward 06 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",29,500160
+SHAWNEE,Topeka Ward 06 Precinct 09,United States Senate,,Republican,"Roberts, Pat",238,500160
+SHAWNEE,Topeka Ward 01 Precinct 06,United States Senate,,independent,"Orman, Greg",230,600010
+SHAWNEE,Topeka Ward 01 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",16,600010
+SHAWNEE,Topeka Ward 01 Precinct 06,United States Senate,,Republican,"Roberts, Pat",216,600010
+SHAWNEE,Topeka Ward 03 Precinct 04,United States Senate,,independent,"Orman, Greg",116,600020
+SHAWNEE,Topeka Ward 03 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",8,600020
+SHAWNEE,Topeka Ward 03 Precinct 04,United States Senate,,Republican,"Roberts, Pat",52,600020
+SHAWNEE,Kiro,United States Senate,,independent,"Orman, Greg",202,600050
+SHAWNEE,Kiro,United States Senate,,Libertarian,"Batson, Randall",18,600050
+SHAWNEE,Kiro,United States Senate,,Republican,"Roberts, Pat",249,600050
+SHAWNEE,Messhoss Creek,United States Senate,,independent,"Orman, Greg",120,600060
+SHAWNEE,Messhoss Creek,United States Senate,,Libertarian,"Batson, Randall",9,600060
+SHAWNEE,Messhoss Creek,United States Senate,,Republican,"Roberts, Pat",138,600060
+SHAWNEE,Indian Hills,United States Senate,,independent,"Orman, Greg",193,600080
+SHAWNEE,Indian Hills,United States Senate,,Libertarian,"Batson, Randall",11,600080
+SHAWNEE,Indian Hills,United States Senate,,Republican,"Roberts, Pat",181,600080
+SHAWNEE,Topeka Ward 14 Precinct 01,United States Senate,,independent,"Orman, Greg",276,600090
+SHAWNEE,Topeka Ward 14 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",22,600090
+SHAWNEE,Topeka Ward 14 Precinct 01,United States Senate,,Republican,"Roberts, Pat",249,600090
+SHAWNEE,Topeka Ward 14 Precinct 03,United States Senate,,independent,"Orman, Greg",137,600110
+SHAWNEE,Topeka Ward 14 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",6,600110
+SHAWNEE,Topeka Ward 14 Precinct 03,United States Senate,,Republican,"Roberts, Pat",159,600110
+SHAWNEE,East Silver Lake,United States Senate,,independent,"Orman, Greg",242,600150
+SHAWNEE,East Silver Lake,United States Senate,,Libertarian,"Batson, Randall",19,600150
+SHAWNEE,East Silver Lake,United States Senate,,Republican,"Roberts, Pat",238,600150
+SHAWNEE,West Silver Lake,United States Senate,,independent,"Orman, Greg",176,600160
+SHAWNEE,West Silver Lake,United States Senate,,Libertarian,"Batson, Randall",16,600160
+SHAWNEE,West Silver Lake,United States Senate,,Republican,"Roberts, Pat",165,600160
+SHAWNEE,City of Auburn,United States Senate,,independent,"Orman, Greg",168,600170
+SHAWNEE,City of Auburn,United States Senate,,Libertarian,"Batson, Randall",18,600170
+SHAWNEE,City of Auburn,United States Senate,,Republican,"Roberts, Pat",198,600170
+SHAWNEE,Meadowlark,United States Senate,,independent,"Orman, Greg",225,600180
+SHAWNEE,Meadowlark,United States Senate,,Libertarian,"Batson, Randall",19,600180
+SHAWNEE,Meadowlark,United States Senate,,Republican,"Roberts, Pat",327,600180
+SHAWNEE,Buffalo,United States Senate,,independent,"Orman, Greg",145,600190
+SHAWNEE,Buffalo,United States Senate,,Libertarian,"Batson, Randall",9,600190
+SHAWNEE,Buffalo,United States Senate,,Republican,"Roberts, Pat",238,600190
+SHAWNEE,Topeka Ward 15 Precinct 02,United States Senate,,independent,"Orman, Greg",172,600210
+SHAWNEE,Topeka Ward 15 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",14,600210
+SHAWNEE,Topeka Ward 15 Precinct 02,United States Senate,,Republican,"Roberts, Pat",118,600210
+SHAWNEE,Iroquois,United States Senate,,independent,"Orman, Greg",196,600220
+SHAWNEE,Iroquois,United States Senate,,Libertarian,"Batson, Randall",14,600220
+SHAWNEE,Iroquois,United States Senate,,Republican,"Roberts, Pat",206,600220
+SHAWNEE,Apache,United States Senate,,independent,"Orman, Greg",190,600230
+SHAWNEE,Apache,United States Senate,,Libertarian,"Batson, Randall",12,600230
+SHAWNEE,Apache,United States Senate,,Republican,"Roberts, Pat",209,600230
+SHAWNEE,Elmont,United States Senate,,independent,"Orman, Greg",285,600240
+SHAWNEE,Elmont,United States Senate,,Libertarian,"Batson, Randall",22,600240
+SHAWNEE,Elmont,United States Senate,,Republican,"Roberts, Pat",288,600240
+SHAWNEE,Topeka Ward 14 Precinct 05,United States Senate,,independent,"Orman, Greg",123,600250
+SHAWNEE,Topeka Ward 14 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",4,600250
+SHAWNEE,Topeka Ward 14 Precinct 05,United States Senate,,Republican,"Roberts, Pat",224,600250
+SHAWNEE,Topeka Ward 12 Precinct 02,United States Senate,,independent,"Orman, Greg",119,600260
+SHAWNEE,Topeka Ward 12 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",13,600260
+SHAWNEE,Topeka Ward 12 Precinct 02,United States Senate,,Republican,"Roberts, Pat",71,600260
+SHAWNEE,Topeka Ward 12 Precinct 20,United States Senate,,independent,"Orman, Greg",216,600270
+SHAWNEE,Topeka Ward 12 Precinct 20,United States Senate,,Libertarian,"Batson, Randall",17,600270
+SHAWNEE,Topeka Ward 12 Precinct 20,United States Senate,,Republican,"Roberts, Pat",207,600270
+SHAWNEE,Topeka Ward 12 Precinct 13,United States Senate,,independent,"Orman, Greg",186,600280
+SHAWNEE,Topeka Ward 12 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",10,600280
+SHAWNEE,Topeka Ward 12 Precinct 13,United States Senate,,Republican,"Roberts, Pat",236,600280
+SHAWNEE,Topeka Ward 12 Precinct 31,United States Senate,,independent,"Orman, Greg",131,600290
+SHAWNEE,Topeka Ward 12 Precinct 31,United States Senate,,Libertarian,"Batson, Randall",13,600290
+SHAWNEE,Topeka Ward 12 Precinct 31,United States Senate,,Republican,"Roberts, Pat",136,600290
+SHAWNEE,Sunflower,United States Senate,,independent,"Orman, Greg",278,600300
+SHAWNEE,Sunflower,United States Senate,,Libertarian,"Batson, Randall",12,600300
+SHAWNEE,Sunflower,United States Senate,,Republican,"Roberts, Pat",383,600300
+SHAWNEE,South Sherwood,United States Senate,,independent,"Orman, Greg",137,600310
+SHAWNEE,South Sherwood,United States Senate,,Libertarian,"Batson, Randall",4,600310
+SHAWNEE,South Sherwood,United States Senate,,Republican,"Roberts, Pat",162,600310
+SHAWNEE,South Mission,United States Senate,,independent,"Orman, Greg",128,600330
+SHAWNEE,South Mission,United States Senate,,Libertarian,"Batson, Randall",14,600330
+SHAWNEE,South Mission,United States Senate,,Republican,"Roberts, Pat",178,600330
+SHAWNEE,East Soldier,United States Senate,,independent,"Orman, Greg",253,600340
+SHAWNEE,East Soldier,United States Senate,,Libertarian,"Batson, Randall",8,600340
+SHAWNEE,East Soldier,United States Senate,,Republican,"Roberts, Pat",209,600340
+SHAWNEE,Sherman,United States Senate,,independent,"Orman, Greg",193,600350
+SHAWNEE,Sherman,United States Senate,,Libertarian,"Batson, Randall",14,600350
+SHAWNEE,Sherman,United States Senate,,Republican,"Roberts, Pat",206,600350
+SHAWNEE,Sac,United States Senate,,independent,"Orman, Greg",237,600360
+SHAWNEE,Sac,United States Senate,,Libertarian,"Batson, Randall",14,600360
+SHAWNEE,Sac,United States Senate,,Republican,"Roberts, Pat",233,600360
+SHAWNEE,Fox,United States Senate,,independent,"Orman, Greg",198,600370
+SHAWNEE,Fox,United States Senate,,Libertarian,"Batson, Randall",24,600370
+SHAWNEE,Fox,United States Senate,,Republican,"Roberts, Pat",234,600370
+SHAWNEE,Pottawatomie,United States Senate,,independent,"Orman, Greg",220,600390
+SHAWNEE,Pottawatomie,United States Senate,,Libertarian,"Batson, Randall",14,600390
+SHAWNEE,Pottawatomie,United States Senate,,Republican,"Roberts, Pat",223,600390
+SHAWNEE,Topeka Ward 05 Precinct 10,United States Senate,,independent,"Orman, Greg",235,600420
+SHAWNEE,Topeka Ward 05 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",19,600420
+SHAWNEE,Topeka Ward 05 Precinct 10,United States Senate,,Republican,"Roberts, Pat",190,600420
+SHAWNEE,Deer Creek,United States Senate,,independent,"Orman, Greg",9,600430
+SHAWNEE,Deer Creek,United States Senate,,Libertarian,"Batson, Randall",1,600430
+SHAWNEE,Deer Creek,United States Senate,,Republican,"Roberts, Pat",9,600430
+SHAWNEE,Topeka Ward 15 Precinct 03,United States Senate,,independent,"Orman, Greg",15,600440
+SHAWNEE,Topeka Ward 15 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",0,600440
+SHAWNEE,Topeka Ward 15 Precinct 03,United States Senate,,Republican,"Roberts, Pat",13,600440
+SHAWNEE,Topeka Ward 12 Precinct 19,United States Senate,,independent,"Orman, Greg",26,600470
+SHAWNEE,Topeka Ward 12 Precinct 19,United States Senate,,Libertarian,"Batson, Randall",1,600470
+SHAWNEE,Topeka Ward 12 Precinct 19,United States Senate,,Republican,"Roberts, Pat",48,600470
+SHAWNEE,Yucca,United States Senate,,independent,"Orman, Greg",56,600490
+SHAWNEE,Yucca,United States Senate,,Libertarian,"Batson, Randall",2,600490
+SHAWNEE,Yucca,United States Senate,,Republican,"Roberts, Pat",53,600490
+SHAWNEE,Dover,United States Senate,,independent,"Orman, Greg",133,600500
+SHAWNEE,Dover,United States Senate,,Libertarian,"Batson, Randall",10,600500
+SHAWNEE,Dover,United States Senate,,Republican,"Roberts, Pat",181,600500
+SHAWNEE,Topeka Ward 10 Precinct 04,United States Senate,,independent,"Orman, Greg",162,600570
+SHAWNEE,Topeka Ward 10 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",12,600570
+SHAWNEE,Topeka Ward 10 Precinct 04,United States Senate,,Republican,"Roberts, Pat",127,600570
+SHAWNEE,Topeka Ward 10 Precinct 14,United States Senate,,independent,"Orman, Greg",178,600580
+SHAWNEE,Topeka Ward 10 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",7,600580
+SHAWNEE,Topeka Ward 10 Precinct 14,United States Senate,,Republican,"Roberts, Pat",120,600580
+SHAWNEE,Central Mission,United States Senate,,independent,"Orman, Greg",223,700020
+SHAWNEE,Central Mission,United States Senate,,Libertarian,"Batson, Randall",13,700020
+SHAWNEE,Central Mission,United States Senate,,Republican,"Roberts, Pat",294,700020
+SHAWNEE,Aldersgate,United States Senate,,independent,"Orman, Greg",112,800010
+SHAWNEE,Aldersgate,United States Senate,,Libertarian,"Batson, Randall",3,800010
+SHAWNEE,Aldersgate,United States Senate,,Republican,"Roberts, Pat",89,800010
+SHAWNEE,Topeka Ward 13 Precinct 05,United States Senate,,independent,"Orman, Greg",2,800020
+SHAWNEE,Topeka Ward 13 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",0,800020
+SHAWNEE,Topeka Ward 13 Precinct 05,United States Senate,,Republican,"Roberts, Pat",12,800020
+SHAWNEE,Topeka Ward 14 Precinct 04,United States Senate,,independent,"Orman, Greg",247,800040
+SHAWNEE,Topeka Ward 14 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",13,800040
+SHAWNEE,Topeka Ward 14 Precinct 04,United States Senate,,Republican,"Roberts, Pat",357,800040
+SHAWNEE,Topeka Ward 14 Precinct 02,United States Senate,,independent,"Orman, Greg",252,800060
+SHAWNEE,Topeka Ward 14 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",13,800060
+SHAWNEE,Topeka Ward 14 Precinct 02,United States Senate,,Republican,"Roberts, Pat",201,800060
+SHAWNEE,West Potter,United States Senate,,independent,"Orman, Greg",22,800070
+SHAWNEE,West Potter,United States Senate,,Libertarian,"Batson, Randall",2,800070
+SHAWNEE,West Potter,United States Senate,,Republican,"Roberts, Pat",37,800070
+SHAWNEE,Topeka Ward 01 Precinct 05,United States Senate,,independent,"Orman, Greg",187,900030
+SHAWNEE,Topeka Ward 01 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",18,900030
+SHAWNEE,Topeka Ward 01 Precinct 05,United States Senate,,Republican,"Roberts, Pat",157,900030
+SHAWNEE,East Wichita,United States Senate,,independent,"Orman, Greg",290,900050
+SHAWNEE,East Wichita,United States Senate,,Libertarian,"Batson, Randall",23,900050
+SHAWNEE,East Wichita,United States Senate,,Republican,"Roberts, Pat",307,900050
+SHAWNEE,York Outer,United States Senate,,independent,"Orman, Greg",20,900080
+SHAWNEE,York Outer,United States Senate,,Libertarian,"Batson, Randall",3,900080
+SHAWNEE,York Outer,United States Senate,,Republican,"Roberts, Pat",29,900080
+SHAWNEE,York,United States Senate,,independent,"Orman, Greg",185,900090
+SHAWNEE,York,United States Senate,,Libertarian,"Batson, Randall",8,900090
+SHAWNEE,York,United States Senate,,Republican,"Roberts, Pat",242,900090
+SHAWNEE,Stinson Creek,United States Senate,,independent,"Orman, Greg",83,990001
+SHAWNEE,Stinson Creek,United States Senate,,Libertarian,"Batson, Randall",1,990001
+SHAWNEE,Stinson Creek,United States Senate,,Republican,"Roberts, Pat",73,990001
+SHAWNEE,Central Pauline,United States Senate,,independent,"Orman, Greg",32,990002
+SHAWNEE,Central Pauline,United States Senate,,Libertarian,"Batson, Randall",7,990002
+SHAWNEE,Central Pauline,United States Senate,,Republican,"Roberts, Pat",30,990002
+SHAWNEE,Forbes,United States Senate,,independent,"Orman, Greg",21,990003
+SHAWNEE,Forbes,United States Senate,,Libertarian,"Batson, Randall",1,990003
+SHAWNEE,Forbes,United States Senate,,Republican,"Roberts, Pat",27,990003
+SHAWNEE,Kingston,United States Senate,,independent,"Orman, Greg",48,990004
+SHAWNEE,Kingston,United States Senate,,Libertarian,"Batson, Randall",3,990004
+SHAWNEE,Kingston,United States Senate,,Republican,"Roberts, Pat",66,990004
+SHAWNEE,Gaillardia,United States Senate,,independent,"Orman, Greg",166,990005
+SHAWNEE,Gaillardia,United States Senate,,Libertarian,"Batson, Randall",9,990005
+SHAWNEE,Gaillardia,United States Senate,,Republican,"Roberts, Pat",241,990005
+SHAWNEE,ADVANCED,United States Senate,,independent,"Orman, Greg",0,999998
+SHAWNEE,ADVANCED,United States Senate,,Libertarian,"Batson, Randall",0,999998
+SHAWNEE,ADVANCED,United States Senate,,Republican,"Roberts, Pat",0,999998

--- a/2014/20141104__ks__general__sheridan__precinct.csv
+++ b/2014/20141104__ks__general__sheridan__precinct.csv
@@ -1,256 +1,256 @@
-county,precinct,office,district,party,candidate,votes
-Sheridan,Adell,U.S. Senate,,R,Pat Roberts,8
-Sheridan,Bloomfield,U.S. Senate,,R,Pat Roberts,16
-Sheridan,Bowcreek,U.S. Senate,,R,Pat Roberts,14
-Sheridan,Kenneth - East,U.S. Senate,,R,Pat Roberts,222
-Sheridan,Kenneth - West,U.S. Senate,,R,Pat Roberts,203
-Sheridan,Logan,U.S. Senate,,R,Pat Roberts,32
-Sheridan,Parnell,U.S. Senate,,R,Pat Roberts,41
-Sheridan,Prairie Dog,U.S. Senate,,R,Pat Roberts,14
-Sheridan,"Saline, East",U.S. Senate,,R,Pat Roberts,26
-Sheridan,"Saline, West",U.S. Senate,,R,Pat Roberts,22
-Sheridan,Sheridan,U.S. Senate,,R,Pat Roberts,74
-Sheridan,Solomon,U.S. Senate,,R,Pat Roberts,64
-Sheridan,Springbrook,U.S. Senate,,R,Pat Roberts,31
-Sheridan,Union,U.S. Senate,,R,Pat Roberts,16
-Sheridan,Valley,U.S. Senate,,R,Pat Roberts,32
-Sheridan,Adell,U.S. Senate,,I,Greg Orman,3
-Sheridan,Bloomfield,U.S. Senate,,I,Greg Orman,5
-Sheridan,Bowcreek,U.S. Senate,,I,Greg Orman,7
-Sheridan,Kenneth - East,U.S. Senate,,I,Greg Orman,71
-Sheridan,Kenneth - West,U.S. Senate,,I,Greg Orman,54
-Sheridan,Logan,U.S. Senate,,I,Greg Orman,2
-Sheridan,Parnell,U.S. Senate,,I,Greg Orman,5
-Sheridan,Prairie Dog,U.S. Senate,,I,Greg Orman,5
-Sheridan,"Saline, East",U.S. Senate,,I,Greg Orman,1
-Sheridan,"Saline, West",U.S. Senate,,I,Greg Orman,1
-Sheridan,Sheridan,U.S. Senate,,I,Greg Orman,17
-Sheridan,Solomon,U.S. Senate,,I,Greg Orman,13
-Sheridan,Springbrook,U.S. Senate,,I,Greg Orman,5
-Sheridan,Union,U.S. Senate,,I,Greg Orman,2
-Sheridan,Valley,U.S. Senate,,I,Greg Orman,9
-Sheridan,Adell,U.S. Senate,,L,Randall Batson,0
-Sheridan,Bloomfield,U.S. Senate,,L,Randall Batson,0
-Sheridan,Bowcreek,U.S. Senate,,L,Randall Batson,0
-Sheridan,Kenneth - East,U.S. Senate,,L,Randall Batson,6
-Sheridan,Kenneth - West,U.S. Senate,,L,Randall Batson,11
-Sheridan,Logan,U.S. Senate,,L,Randall Batson,0
-Sheridan,Parnell,U.S. Senate,,L,Randall Batson,0
-Sheridan,Prairie Dog,U.S. Senate,,L,Randall Batson,1
-Sheridan,"Saline, East",U.S. Senate,,L,Randall Batson,2
-Sheridan,"Saline, West",U.S. Senate,,L,Randall Batson,1
-Sheridan,Sheridan,U.S. Senate,,L,Randall Batson,6
-Sheridan,Solomon,U.S. Senate,,L,Randall Batson,4
-Sheridan,Springbrook,U.S. Senate,,L,Randall Batson,2
-Sheridan,Union,U.S. Senate,,L,Randall Batson,0
-Sheridan,Valley,U.S. Senate,,L,Randall Batson,3
-Sheridan,Adell,U.S. House,1,D,James Sherow,3
-Sheridan,Bloomfield,U.S. House,1,D,James Sherow,7
-Sheridan,Bowcreek,U.S. House,1,D,James Sherow,2
-Sheridan,Kenneth - East,U.S. House,1,D,James Sherow,65
-Sheridan,Kenneth - West,U.S. House,1,D,James Sherow,59
-Sheridan,Logan,U.S. House,1,D,James Sherow,3
-Sheridan,Parnell,U.S. House,1,D,James Sherow,8
-Sheridan,Prairie Dog,U.S. House,1,D,James Sherow,3
-Sheridan,"Saline, East",U.S. House,1,D,James Sherow,2
-Sheridan,"Saline, West",U.S. House,1,D,James Sherow,1
-Sheridan,Sheridan,U.S. House,1,D,James Sherow,21
-Sheridan,Solomon,U.S. House,1,D,James Sherow,14
-Sheridan,Springbrook,U.S. House,1,D,James Sherow,4
-Sheridan,Union,U.S. House,1,D,James Sherow,1
-Sheridan,Valley,U.S. House,1,D,James Sherow,7
-Sheridan,Adell,U.S. House,1,R,Tim Huelskamp,7
-Sheridan,Bloomfield,U.S. House,1,R,Tim Huelskamp,13
-Sheridan,Bowcreek,U.S. House,1,R,Tim Huelskamp,20
-Sheridan,Kenneth - East,U.S. House,1,R,Tim Huelskamp,231
-Sheridan,Kenneth - West,U.S. House,1,R,Tim Huelskamp,202
-Sheridan,Logan,U.S. House,1,R,Tim Huelskamp,31
-Sheridan,Parnell,U.S. House,1,R,Tim Huelskamp,38
-Sheridan,Prairie Dog,U.S. House,1,R,Tim Huelskamp,17
-Sheridan,"Saline, East",U.S. House,1,R,Tim Huelskamp,27
-Sheridan,"Saline, West",U.S. House,1,R,Tim Huelskamp,23
-Sheridan,Sheridan,U.S. House,1,R,Tim Huelskamp,77
-Sheridan,Solomon,U.S. House,1,R,Tim Huelskamp,67
-Sheridan,Springbrook,U.S. House,1,R,Tim Huelskamp,32
-Sheridan,Union,U.S. House,1,R,Tim Huelskamp,17
-Sheridan,Valley,U.S. House,1,R,Tim Huelskamp,37
-Sheridan,Adell,Governor,,D,Paul Davis,5
-Sheridan,Bloomfield,Governor,,D,Paul Davis,5
-Sheridan,Bowcreek,Governor,,D,Paul Davis,6
-Sheridan,Kenneth - East,Governor,,D,Paul Davis,81
-Sheridan,Kenneth - West,Governor,,D,Paul Davis,74
-Sheridan,Logan,Governor,,D,Paul Davis,4
-Sheridan,Parnell,Governor,,D,Paul Davis,10
-Sheridan,Prairie Dog,Governor,,D,Paul Davis,5
-Sheridan,"Saline, East",Governor,,D,Paul Davis,3
-Sheridan,"Saline, West",Governor,,D,Paul Davis,4
-Sheridan,Sheridan,Governor,,D,Paul Davis,24
-Sheridan,Solomon,Governor,,D,Paul Davis,14
-Sheridan,Springbrook,Governor,,D,Paul Davis,6
-Sheridan,Union,Governor,,D,Paul Davis,2
-Sheridan,Valley,Governor,,D,Paul Davis,11
-Sheridan,Adell,Governor,,R,Sam Brownback,6
-Sheridan,Bloomfield,Governor,,R,Sam Brownback,16
-Sheridan,Bowcreek,Governor,,R,Sam Brownback,15
-Sheridan,Kenneth - East,Governor,,R,Sam Brownback,215
-Sheridan,Kenneth - West,Governor,,R,Sam Brownback,182
-Sheridan,Logan,Governor,,R,Sam Brownback,30
-Sheridan,Parnell,Governor,,R,Sam Brownback,35
-Sheridan,Prairie Dog,Governor,,R,Sam Brownback,13
-Sheridan,"Saline, East",Governor,,R,Sam Brownback,25
-Sheridan,"Saline, West",Governor,,R,Sam Brownback,24
-Sheridan,Sheridan,Governor,,R,Sam Brownback,72
-Sheridan,Solomon,Governor,,R,Sam Brownback,66
-Sheridan,Springbrook,Governor,,R,Sam Brownback,30
-Sheridan,Union,Governor,,R,Sam Brownback,15
-Sheridan,Valley,Governor,,R,Sam Brownback,32
-Sheridan,Adell,Governor,,L,Keen Umbehr,0
-Sheridan,Bloomfield,Governor,,L,Keen Umbehr,0
-Sheridan,Bowcreek,Governor,,L,Keen Umbehr,0
-Sheridan,Kenneth - East,Governor,,L,Keen Umbehr,6
-Sheridan,Kenneth - West,Governor,,L,Keen Umbehr,13
-Sheridan,Logan,Governor,,L,Keen Umbehr,0
-Sheridan,Parnell,Governor,,L,Keen Umbehr,1
-Sheridan,Prairie Dog,Governor,,L,Keen Umbehr,2
-Sheridan,"Saline, East",Governor,,L,Keen Umbehr,1
-Sheridan,"Saline, West",Governor,,L,Keen Umbehr,0
-Sheridan,Sheridan,Governor,,L,Keen Umbehr,4
-Sheridan,Solomon,Governor,,L,Keen Umbehr,1
-Sheridan,Springbrook,Governor,,L,Keen Umbehr,2
-Sheridan,Union,Governor,,L,Keen Umbehr,1
-Sheridan,Valley,Governor,,L,Keen Umbehr,1
-Sheridan,Adell,Secretary of State,,D,Jean Schodorf,3
-Sheridan,Bloomfield,Secretary of State,,D,Jean Schodorf,3
-Sheridan,Bowcreek,Secretary of State,,D,Jean Schodorf,2
-Sheridan,Kenneth - East,Secretary of State,,D,Jean Schodorf,62
-Sheridan,Kenneth - West,Secretary of State,,D,Jean Schodorf,52
-Sheridan,Logan,Secretary of State,,D,Jean Schodorf,3
-Sheridan,Parnell,Secretary of State,,D,Jean Schodorf,6
-Sheridan,Prairie Dog,Secretary of State,,D,Jean Schodorf,3
-Sheridan,"Saline, East",Secretary of State,,D,Jean Schodorf,2
-Sheridan,"Saline, West",Secretary of State,,D,Jean Schodorf,5
-Sheridan,Sheridan,Secretary of State,,D,Jean Schodorf,25
-Sheridan,Solomon,Secretary of State,,D,Jean Schodorf,13
-Sheridan,Springbrook,Secretary of State,,D,Jean Schodorf,5
-Sheridan,Union,Secretary of State,,D,Jean Schodorf,2
-Sheridan,Valley,Secretary of State,,D,Jean Schodorf,10
-Sheridan,Adell,Secretary of State,,R,Kris Kobach,8
-Sheridan,Bloomfield,Secretary of State,,R,Kris Kobach,17
-Sheridan,Bowcreek,Secretary of State,,R,Kris Kobach,20
-Sheridan,Kenneth - East,Secretary of State,,R,Kris Kobach,232
-Sheridan,Kenneth - West,Secretary of State,,R,Kris Kobach,200
-Sheridan,Logan,Secretary of State,,R,Kris Kobach,31
-Sheridan,Parnell,Secretary of State,,R,Kris Kobach,38
-Sheridan,Prairie Dog,Secretary of State,,R,Kris Kobach,15
-Sheridan,"Saline, East",Secretary of State,,R,Kris Kobach,26
-Sheridan,"Saline, West",Secretary of State,,R,Kris Kobach,19
-Sheridan,Sheridan,Secretary of State,,R,Kris Kobach,75
-Sheridan,Solomon,Secretary of State,,R,Kris Kobach,66
-Sheridan,Springbrook,Secretary of State,,R,Kris Kobach,33
-Sheridan,Union,Secretary of State,,R,Kris Kobach,15
-Sheridan,Valley,Secretary of State,,R,Kris Kobach,34
-Sheridan,Adell,Attorney General,,D,A J Kotich,2
-Sheridan,Bloomfield,Attorney General,,D,A J Kotich,4
-Sheridan,Bowcreek,Attorney General,,D,A J Kotich,1
-Sheridan,Kenneth - East,Attorney General,,D,A J Kotich,38
-Sheridan,Kenneth - West,Attorney General,,D,A J Kotich,37
-Sheridan,Logan,Attorney General,,D,A J Kotich,4
-Sheridan,Parnell,Attorney General,,D,A J Kotich,4
-Sheridan,Prairie Dog,Attorney General,,D,A J Kotich,5
-Sheridan,"Saline, East",Attorney General,,D,A J Kotich,1
-Sheridan,"Saline, West",Attorney General,,D,A J Kotich,5
-Sheridan,Sheridan,Attorney General,,D,A J Kotich,14
-Sheridan,Solomon,Attorney General,,D,A J Kotich,11
-Sheridan,Springbrook,Attorney General,,D,A J Kotich,2
-Sheridan,Union,Attorney General,,D,A J Kotich,0
-Sheridan,Valley,Attorney General,,D,A J Kotich,7
-Sheridan,Adell,Attorney General,,R,Derek Schmidt,7
-Sheridan,Bloomfield,Attorney General,,R,Derek Schmidt,16
-Sheridan,Bowcreek,Attorney General,,R,Derek Schmidt,21
-Sheridan,Kenneth - East,Attorney General,,R,Derek Schmidt,251
-Sheridan,Kenneth - West,Attorney General,,R,Derek Schmidt,209
-Sheridan,Logan,Attorney General,,R,Derek Schmidt,30
-Sheridan,Parnell,Attorney General,,R,Derek Schmidt,41
-Sheridan,Prairie Dog,Attorney General,,R,Derek Schmidt,14
-Sheridan,"Saline, East",Attorney General,,R,Derek Schmidt,26
-Sheridan,"Saline, West",Attorney General,,R,Derek Schmidt,19
-Sheridan,Sheridan,Attorney General,,R,Derek Schmidt,82
-Sheridan,Solomon,Attorney General,,R,Derek Schmidt,69
-Sheridan,Springbrook,Attorney General,,R,Derek Schmidt,35
-Sheridan,Union,Attorney General,,R,Derek Schmidt,17
-Sheridan,Valley,Attorney General,,R,Derek Schmidt,37
-Sheridan,Adell,State Treasurer,,D,Carmen Alldritt,2
-Sheridan,Bloomfield,State Treasurer,,D,Carmen Alldritt,3
-Sheridan,Bowcreek,State Treasurer,,D,Carmen Alldritt,2
-Sheridan,Kenneth - East,State Treasurer,,D,Carmen Alldritt,38
-Sheridan,Kenneth - West,State Treasurer,,D,Carmen Alldritt,34
-Sheridan,Logan,State Treasurer,,D,Carmen Alldritt,4
-Sheridan,Parnell,State Treasurer,,D,Carmen Alldritt,3
-Sheridan,Prairie Dog,State Treasurer,,D,Carmen Alldritt,3
-Sheridan,"Saline, East",State Treasurer,,D,Carmen Alldritt,2
-Sheridan,"Saline, West",State Treasurer,,D,Carmen Alldritt,3
-Sheridan,Sheridan,State Treasurer,,D,Carmen Alldritt,22
-Sheridan,Solomon,State Treasurer,,D,Carmen Alldritt,8
-Sheridan,Springbrook,State Treasurer,,D,Carmen Alldritt,2
-Sheridan,Union,State Treasurer,,D,Carmen Alldritt,2
-Sheridan,Valley,State Treasurer,,D,Carmen Alldritt,5
-Sheridan,Adell,State Treasurer,,R,Ron Estes,7
-Sheridan,Bloomfield,State Treasurer,,R,Ron Estes,17
-Sheridan,Bowcreek,State Treasurer,,R,Ron Estes,19
-Sheridan,Kenneth - East,State Treasurer,,R,Ron Estes,254
-Sheridan,Kenneth - West,State Treasurer,,R,Ron Estes,211
-Sheridan,Logan,State Treasurer,,R,Ron Estes,30
-Sheridan,Parnell,State Treasurer,,R,Ron Estes,40
-Sheridan,Prairie Dog,State Treasurer,,R,Ron Estes,15
-Sheridan,"Saline, East",State Treasurer,,R,Ron Estes,27
-Sheridan,"Saline, West",State Treasurer,,R,Ron Estes,20
-Sheridan,Sheridan,State Treasurer,,R,Ron Estes,73
-Sheridan,Solomon,State Treasurer,,R,Ron Estes,71
-Sheridan,Springbrook,State Treasurer,,R,Ron Estes,35
-Sheridan,Union,State Treasurer,,R,Ron Estes,15
-Sheridan,Valley,State Treasurer,,R,Ron Estes,39
-Sheridan,Adell,Insurance Commissioner,,D,Dennis Anderson,2
-Sheridan,Bloomfield,Insurance Commissioner,,D,Dennis Anderson,2
-Sheridan,Bowcreek,Insurance Commissioner,,D,Dennis Anderson,1
-Sheridan,Kenneth - East,Insurance Commissioner,,D,Dennis Anderson,45
-Sheridan,Kenneth - West,Insurance Commissioner,,D,Dennis Anderson,53
-Sheridan,Logan,Insurance Commissioner,,D,Dennis Anderson,4
-Sheridan,Parnell,Insurance Commissioner,,D,Dennis Anderson,4
-Sheridan,Prairie Dog,Insurance Commissioner,,D,Dennis Anderson,2
-Sheridan,"Saline, East",Insurance Commissioner,,D,Dennis Anderson,1
-Sheridan,"Saline, West",Insurance Commissioner,,D,Dennis Anderson,4
-Sheridan,Sheridan,Insurance Commissioner,,D,Dennis Anderson,22
-Sheridan,Solomon,Insurance Commissioner,,D,Dennis Anderson,10
-Sheridan,Springbrook,Insurance Commissioner,,D,Dennis Anderson,1
-Sheridan,Union,Insurance Commissioner,,D,Dennis Anderson,3
-Sheridan,Valley,Insurance Commissioner,,D,Dennis Anderson,7
-Sheridan,Adell,Insurance Commissioner,,R,Ken Selzer,7
-Sheridan,Bloomfield,Insurance Commissioner,,R,Ken Selzer,18
-Sheridan,Bowcreek,Insurance Commissioner,,R,Ken Selzer,21
-Sheridan,Kenneth - East,Insurance Commissioner,,R,Ken Selzer,240
-Sheridan,Kenneth - West,Insurance Commissioner,,R,Ken Selzer,188
-Sheridan,Logan,Insurance Commissioner,,R,Ken Selzer,30
-Sheridan,Parnell,Insurance Commissioner,,R,Ken Selzer,40
-Sheridan,Prairie Dog,Insurance Commissioner,,R,Ken Selzer,16
-Sheridan,"Saline, East",Insurance Commissioner,,R,Ken Selzer,27
-Sheridan,"Saline, West",Insurance Commissioner,,R,Ken Selzer,19
-Sheridan,Sheridan,Insurance Commissioner,,R,Ken Selzer,70
-Sheridan,Solomon,Insurance Commissioner,,R,Ken Selzer,66
-Sheridan,Springbrook,Insurance Commissioner,,R,Ken Selzer,36
-Sheridan,Union,Insurance Commissioner,,R,Ken Selzer,13
-Sheridan,Valley,Insurance Commissioner,,R,Ken Selzer,34
-Sheridan,Adell,State House,118,R,Don Hineman,9
-Sheridan,Bloomfield,State House,118,R,Don Hineman,18
-Sheridan,Bowcreek,State House,118,R,Don Hineman,20
-Sheridan,Kenneth - East,State House,118,R,Don Hineman,264
-Sheridan,Kenneth - West,State House,118,R,Don Hineman,216
-Sheridan,Logan,State House,118,R,Don Hineman,32
-Sheridan,Parnell,State House,118,R,Don Hineman,44
-Sheridan,Prairie Dog,State House,118,R,Don Hineman,19
-Sheridan,"Saline, East",State House,118,R,Don Hineman,27
-Sheridan,"Saline, West",State House,118,R,Don Hineman,20
-Sheridan,Sheridan,State House,118,R,Don Hineman,82
-Sheridan,Solomon,State House,118,R,Don Hineman,78
-Sheridan,Springbrook,State House,118,R,Don Hineman,35
-Sheridan,Union,State House,118,R,Don Hineman,16
-Sheridan,Valley,State House,118,R,Don Hineman,40
+county,precinct,office,district,party,candidate,votes,vtd
+SHERIDAN,Adell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000010
+SHERIDAN,Adell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+SHERIDAN,Adell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",6,000010
+SHERIDAN,Bloomfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000020
+SHERIDAN,Bloomfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+SHERIDAN,Bloomfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000020
+SHERIDAN,Bow Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000030
+SHERIDAN,Bow Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+SHERIDAN,Bow Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000030
+SHERIDAN,East Kenneth,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000040
+SHERIDAN,East Kenneth,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000040
+SHERIDAN,East Kenneth,Governor / Lt. Governor,,Republican,"Brownback, Sam",215,000040
+SHERIDAN,East Saline,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000050
+SHERIDAN,East Saline,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+SHERIDAN,East Saline,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000050
+SHERIDAN,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000060
+SHERIDAN,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+SHERIDAN,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000060
+SHERIDAN,Parnell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000070
+SHERIDAN,Parnell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+SHERIDAN,Parnell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000070
+SHERIDAN,Prairie Dog Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000080
+SHERIDAN,Prairie Dog Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+SHERIDAN,Prairie Dog Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000080
+SHERIDAN,Sheridan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000090
+SHERIDAN,Sheridan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000090
+SHERIDAN,Sheridan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000090
+SHERIDAN,Solomon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000100
+SHERIDAN,Solomon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+SHERIDAN,Solomon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",66,000100
+SHERIDAN,Springbrook Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000110
+SHERIDAN,Springbrook Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000110
+SHERIDAN,Springbrook Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000110
+SHERIDAN,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000120
+SHERIDAN,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000120
+SHERIDAN,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000120
+SHERIDAN,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000130
+SHERIDAN,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000130
+SHERIDAN,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000130
+SHERIDAN,West Kenneth,Governor / Lt. Governor,,Democratic,"Davis, Paul",74,000140
+SHERIDAN,West Kenneth,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000140
+SHERIDAN,West Kenneth,Governor / Lt. Governor,,Republican,"Brownback, Sam",182,000140
+SHERIDAN,West Saline,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000150
+SHERIDAN,West Saline,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000150
+SHERIDAN,West Saline,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000150
+SHERIDAN,Adell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",9,000010
+SHERIDAN,Bloomfield Township,Kansas House of Representatives,118,Republican,"Hineman, Don",18,000020
+SHERIDAN,Bow Creek Township,Kansas House of Representatives,118,Republican,"Hineman, Don",20,000030
+SHERIDAN,East Kenneth,Kansas House of Representatives,118,Republican,"Hineman, Don",264,000040
+SHERIDAN,East Saline,Kansas House of Representatives,118,Republican,"Hineman, Don",27,000050
+SHERIDAN,Logan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",32,000060
+SHERIDAN,Parnell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",44,000070
+SHERIDAN,Prairie Dog Township,Kansas House of Representatives,118,Republican,"Hineman, Don",19,000080
+SHERIDAN,Sheridan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",82,000090
+SHERIDAN,Solomon Township,Kansas House of Representatives,118,Republican,"Hineman, Don",78,000100
+SHERIDAN,Springbrook Township,Kansas House of Representatives,118,Republican,"Hineman, Don",35,000110
+SHERIDAN,Union Township,Kansas House of Representatives,118,Republican,"Hineman, Don",16,000120
+SHERIDAN,Valley Township,Kansas House of Representatives,118,Republican,"Hineman, Don",40,000130
+SHERIDAN,West Kenneth,Kansas House of Representatives,118,Republican,"Hineman, Don",216,000140
+SHERIDAN,West Saline,Kansas House of Representatives,118,Republican,"Hineman, Don",20,000150
+SHERIDAN,Adell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000010
+SHERIDAN,Adell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000010
+SHERIDAN,Bloomfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000020
+SHERIDAN,Bloomfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000020
+SHERIDAN,Bow Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000030
+SHERIDAN,Bow Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000030
+SHERIDAN,East Kenneth,United States House of Representatives,1,Democratic,"Sherow, James E.",65,000040
+SHERIDAN,East Kenneth,United States House of Representatives,1,Republican,"Huelskamp, Tim",231,000040
+SHERIDAN,East Saline,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000050
+SHERIDAN,East Saline,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000050
+SHERIDAN,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000060
+SHERIDAN,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000060
+SHERIDAN,Parnell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000070
+SHERIDAN,Parnell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000070
+SHERIDAN,Prairie Dog Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000080
+SHERIDAN,Prairie Dog Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000080
+SHERIDAN,Sheridan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",21,000090
+SHERIDAN,Sheridan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",77,000090
+SHERIDAN,Solomon Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000100
+SHERIDAN,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000100
+SHERIDAN,Springbrook Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000110
+SHERIDAN,Springbrook Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000110
+SHERIDAN,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000120
+SHERIDAN,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000120
+SHERIDAN,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000130
+SHERIDAN,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000130
+SHERIDAN,West Kenneth,United States House of Representatives,1,Democratic,"Sherow, James E.",59,000140
+SHERIDAN,West Kenneth,United States House of Representatives,1,Republican,"Huelskamp, Tim",202,000140
+SHERIDAN,West Saline,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000150
+SHERIDAN,West Saline,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000150
+SHERIDAN,Adell Township,Attorney General,,Democratic,"Kotich, A.J.",2,000010
+SHERIDAN,Adell Township,Attorney General,,Republican,"Schmidt, Derek",7,000010
+SHERIDAN,Bloomfield Township,Attorney General,,Democratic,"Kotich, A.J.",4,000020
+SHERIDAN,Bloomfield Township,Attorney General,,Republican,"Schmidt, Derek",16,000020
+SHERIDAN,Bow Creek Township,Attorney General,,Democratic,"Kotich, A.J.",1,000030
+SHERIDAN,Bow Creek Township,Attorney General,,Republican,"Schmidt, Derek",21,000030
+SHERIDAN,East Kenneth,Attorney General,,Democratic,"Kotich, A.J.",38,000040
+SHERIDAN,East Kenneth,Attorney General,,Republican,"Schmidt, Derek",251,000040
+SHERIDAN,East Saline,Attorney General,,Democratic,"Kotich, A.J.",1,000050
+SHERIDAN,East Saline,Attorney General,,Republican,"Schmidt, Derek",26,000050
+SHERIDAN,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",4,000060
+SHERIDAN,Logan Township,Attorney General,,Republican,"Schmidt, Derek",30,000060
+SHERIDAN,Parnell Township,Attorney General,,Democratic,"Kotich, A.J.",4,000070
+SHERIDAN,Parnell Township,Attorney General,,Republican,"Schmidt, Derek",41,000070
+SHERIDAN,Prairie Dog Township,Attorney General,,Democratic,"Kotich, A.J.",5,000080
+SHERIDAN,Prairie Dog Township,Attorney General,,Republican,"Schmidt, Derek",14,000080
+SHERIDAN,Sheridan Township,Attorney General,,Democratic,"Kotich, A.J.",14,000090
+SHERIDAN,Sheridan Township,Attorney General,,Republican,"Schmidt, Derek",82,000090
+SHERIDAN,Solomon Township,Attorney General,,Democratic,"Kotich, A.J.",11,000100
+SHERIDAN,Solomon Township,Attorney General,,Republican,"Schmidt, Derek",69,000100
+SHERIDAN,Springbrook Township,Attorney General,,Democratic,"Kotich, A.J.",2,000110
+SHERIDAN,Springbrook Township,Attorney General,,Republican,"Schmidt, Derek",35,000110
+SHERIDAN,Union Township,Attorney General,,Democratic,"Kotich, A.J.",0,000120
+SHERIDAN,Union Township,Attorney General,,Republican,"Schmidt, Derek",17,000120
+SHERIDAN,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",7,000130
+SHERIDAN,Valley Township,Attorney General,,Republican,"Schmidt, Derek",37,000130
+SHERIDAN,West Kenneth,Attorney General,,Democratic,"Kotich, A.J.",37,000140
+SHERIDAN,West Kenneth,Attorney General,,Republican,"Schmidt, Derek",209,000140
+SHERIDAN,West Saline,Attorney General,,Democratic,"Kotich, A.J.",5,000150
+SHERIDAN,West Saline,Attorney General,,Republican,"Schmidt, Derek",19,000150
+SHERIDAN,Adell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000010
+SHERIDAN,Adell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",7,000010
+SHERIDAN,Bloomfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000020
+SHERIDAN,Bloomfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000020
+SHERIDAN,Bow Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000030
+SHERIDAN,Bow Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000030
+SHERIDAN,East Kenneth,Commissioner of Insurance,,Democratic,"Anderson, Dennis",45,000040
+SHERIDAN,East Kenneth,Commissioner of Insurance,,Republican,"Selzer, Ken",240,000040
+SHERIDAN,East Saline,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000050
+SHERIDAN,East Saline,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000050
+SHERIDAN,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000060
+SHERIDAN,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000060
+SHERIDAN,Parnell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000070
+SHERIDAN,Parnell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",40,000070
+SHERIDAN,Prairie Dog Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000080
+SHERIDAN,Prairie Dog Township,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000080
+SHERIDAN,Sheridan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000090
+SHERIDAN,Sheridan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",70,000090
+SHERIDAN,Solomon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000100
+SHERIDAN,Solomon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",66,000100
+SHERIDAN,Springbrook Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000110
+SHERIDAN,Springbrook Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000110
+SHERIDAN,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000120
+SHERIDAN,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000120
+SHERIDAN,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000130
+SHERIDAN,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000130
+SHERIDAN,West Kenneth,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000140
+SHERIDAN,West Kenneth,Commissioner of Insurance,,Republican,"Selzer, Ken",188,000140
+SHERIDAN,West Saline,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000150
+SHERIDAN,West Saline,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000150
+SHERIDAN,Adell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000010
+SHERIDAN,Adell Township,Secretary of State,,Republican,"Kobach, Kris",8,000010
+SHERIDAN,Bloomfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000020
+SHERIDAN,Bloomfield Township,Secretary of State,,Republican,"Kobach, Kris",17,000020
+SHERIDAN,Bow Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000030
+SHERIDAN,Bow Creek Township,Secretary of State,,Republican,"Kobach, Kris",20,000030
+SHERIDAN,East Kenneth,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,000040
+SHERIDAN,East Kenneth,Secretary of State,,Republican,"Kobach, Kris",232,000040
+SHERIDAN,East Saline,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000050
+SHERIDAN,East Saline,Secretary of State,,Republican,"Kobach, Kris",26,000050
+SHERIDAN,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000060
+SHERIDAN,Logan Township,Secretary of State,,Republican,"Kobach, Kris",31,000060
+SHERIDAN,Parnell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000070
+SHERIDAN,Parnell Township,Secretary of State,,Republican,"Kobach, Kris",38,000070
+SHERIDAN,Prairie Dog Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000080
+SHERIDAN,Prairie Dog Township,Secretary of State,,Republican,"Kobach, Kris",15,000080
+SHERIDAN,Sheridan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",25,000090
+SHERIDAN,Sheridan Township,Secretary of State,,Republican,"Kobach, Kris",75,000090
+SHERIDAN,Solomon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000100
+SHERIDAN,Solomon Township,Secretary of State,,Republican,"Kobach, Kris",66,000100
+SHERIDAN,Springbrook Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000110
+SHERIDAN,Springbrook Township,Secretary of State,,Republican,"Kobach, Kris",33,000110
+SHERIDAN,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000120
+SHERIDAN,Union Township,Secretary of State,,Republican,"Kobach, Kris",15,000120
+SHERIDAN,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000130
+SHERIDAN,Valley Township,Secretary of State,,Republican,"Kobach, Kris",34,000130
+SHERIDAN,West Kenneth,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,000140
+SHERIDAN,West Kenneth,Secretary of State,,Republican,"Kobach, Kris",200,000140
+SHERIDAN,West Saline,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000150
+SHERIDAN,West Saline,Secretary of State,,Republican,"Kobach, Kris",19,000150
+SHERIDAN,Adell Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+SHERIDAN,Adell Township,State Treasurer,,Republican,"Estes, Ron",7,000010
+SHERIDAN,Bloomfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000020
+SHERIDAN,Bloomfield Township,State Treasurer,,Republican,"Estes, Ron",17,000020
+SHERIDAN,Bow Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000030
+SHERIDAN,Bow Creek Township,State Treasurer,,Republican,"Estes, Ron",19,000030
+SHERIDAN,East Kenneth,State Treasurer,,Democratic,"Alldritt, Carmen",38,000040
+SHERIDAN,East Kenneth,State Treasurer,,Republican,"Estes, Ron",254,000040
+SHERIDAN,East Saline,State Treasurer,,Democratic,"Alldritt, Carmen",2,000050
+SHERIDAN,East Saline,State Treasurer,,Republican,"Estes, Ron",27,000050
+SHERIDAN,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000060
+SHERIDAN,Logan Township,State Treasurer,,Republican,"Estes, Ron",30,000060
+SHERIDAN,Parnell Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000070
+SHERIDAN,Parnell Township,State Treasurer,,Republican,"Estes, Ron",40,000070
+SHERIDAN,Prairie Dog Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000080
+SHERIDAN,Prairie Dog Township,State Treasurer,,Republican,"Estes, Ron",15,000080
+SHERIDAN,Sheridan Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000090
+SHERIDAN,Sheridan Township,State Treasurer,,Republican,"Estes, Ron",73,000090
+SHERIDAN,Solomon Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000100
+SHERIDAN,Solomon Township,State Treasurer,,Republican,"Estes, Ron",71,000100
+SHERIDAN,Springbrook Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000110
+SHERIDAN,Springbrook Township,State Treasurer,,Republican,"Estes, Ron",35,000110
+SHERIDAN,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000120
+SHERIDAN,Union Township,State Treasurer,,Republican,"Estes, Ron",15,000120
+SHERIDAN,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000130
+SHERIDAN,Valley Township,State Treasurer,,Republican,"Estes, Ron",39,000130
+SHERIDAN,West Kenneth,State Treasurer,,Democratic,"Alldritt, Carmen",34,000140
+SHERIDAN,West Kenneth,State Treasurer,,Republican,"Estes, Ron",211,000140
+SHERIDAN,West Saline,State Treasurer,,Democratic,"Alldritt, Carmen",3,000150
+SHERIDAN,West Saline,State Treasurer,,Republican,"Estes, Ron",20,000150
+SHERIDAN,Adell Township,United States Senate,,independent,"Orman, Greg",3,000010
+SHERIDAN,Adell Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+SHERIDAN,Adell Township,United States Senate,,Republican,"Roberts, Pat",8,000010
+SHERIDAN,Bloomfield Township,United States Senate,,independent,"Orman, Greg",5,000020
+SHERIDAN,Bloomfield Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+SHERIDAN,Bloomfield Township,United States Senate,,Republican,"Roberts, Pat",16,000020
+SHERIDAN,Bow Creek Township,United States Senate,,independent,"Orman, Greg",7,000030
+SHERIDAN,Bow Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+SHERIDAN,Bow Creek Township,United States Senate,,Republican,"Roberts, Pat",14,000030
+SHERIDAN,East Kenneth,United States Senate,,independent,"Orman, Greg",71,000040
+SHERIDAN,East Kenneth,United States Senate,,Libertarian,"Batson, Randall",6,000040
+SHERIDAN,East Kenneth,United States Senate,,Republican,"Roberts, Pat",222,000040
+SHERIDAN,East Saline,United States Senate,,independent,"Orman, Greg",1,000050
+SHERIDAN,East Saline,United States Senate,,Libertarian,"Batson, Randall",2,000050
+SHERIDAN,East Saline,United States Senate,,Republican,"Roberts, Pat",26,000050
+SHERIDAN,Logan Township,United States Senate,,independent,"Orman, Greg",2,000060
+SHERIDAN,Logan Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+SHERIDAN,Logan Township,United States Senate,,Republican,"Roberts, Pat",32,000060
+SHERIDAN,Parnell Township,United States Senate,,independent,"Orman, Greg",5,000070
+SHERIDAN,Parnell Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+SHERIDAN,Parnell Township,United States Senate,,Republican,"Roberts, Pat",41,000070
+SHERIDAN,Prairie Dog Township,United States Senate,,independent,"Orman, Greg",5,000080
+SHERIDAN,Prairie Dog Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+SHERIDAN,Prairie Dog Township,United States Senate,,Republican,"Roberts, Pat",14,000080
+SHERIDAN,Sheridan Township,United States Senate,,independent,"Orman, Greg",17,000090
+SHERIDAN,Sheridan Township,United States Senate,,Libertarian,"Batson, Randall",6,000090
+SHERIDAN,Sheridan Township,United States Senate,,Republican,"Roberts, Pat",74,000090
+SHERIDAN,Solomon Township,United States Senate,,independent,"Orman, Greg",13,000100
+SHERIDAN,Solomon Township,United States Senate,,Libertarian,"Batson, Randall",4,000100
+SHERIDAN,Solomon Township,United States Senate,,Republican,"Roberts, Pat",64,000100
+SHERIDAN,Springbrook Township,United States Senate,,independent,"Orman, Greg",5,000110
+SHERIDAN,Springbrook Township,United States Senate,,Libertarian,"Batson, Randall",2,000110
+SHERIDAN,Springbrook Township,United States Senate,,Republican,"Roberts, Pat",31,000110
+SHERIDAN,Union Township,United States Senate,,independent,"Orman, Greg",2,000120
+SHERIDAN,Union Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+SHERIDAN,Union Township,United States Senate,,Republican,"Roberts, Pat",16,000120
+SHERIDAN,Valley Township,United States Senate,,independent,"Orman, Greg",9,000130
+SHERIDAN,Valley Township,United States Senate,,Libertarian,"Batson, Randall",3,000130
+SHERIDAN,Valley Township,United States Senate,,Republican,"Roberts, Pat",32,000130
+SHERIDAN,West Kenneth,United States Senate,,independent,"Orman, Greg",54,000140
+SHERIDAN,West Kenneth,United States Senate,,Libertarian,"Batson, Randall",11,000140
+SHERIDAN,West Kenneth,United States Senate,,Republican,"Roberts, Pat",203,000140
+SHERIDAN,West Saline,United States Senate,,independent,"Orman, Greg",1,000150
+SHERIDAN,West Saline,United States Senate,,Libertarian,"Batson, Randall",1,000150
+SHERIDAN,West Saline,United States Senate,,Republican,"Roberts, Pat",22,000150

--- a/2014/20141104__ks__general__sherman__precinct.csv
+++ b/2014/20141104__ks__general__sherman__precinct.csv
@@ -1,337 +1,324 @@
-county,precinct,office,district,party,candidate,votes
-Sherman,Goodland W1,,,,Votes Cast,437
-Sherman,Goodland W2,,,,Votes Cast,213
-Sherman,Goodland W3,,,,Votes Cast,240
-Sherman,Goodland W4,,,,Votes Cast,414
-Sherman,Grant,,,,Votes Cast,32
-Sherman,Iowa,,,,Votes Cast,13
-Sherman,Itasca,,,,Votes Cast,134
-Sherman,Lincoln,,,,Votes Cast,38
-Sherman,Llanos,,,,Votes Cast,22
-Sherman,Logan,,,,Votes Cast,107
-Sherman,McPherson,,,,Votes Cast,24
-Sherman,Shermanville,,,,Votes Cast,11
-Sherman,Smoky,,,,Votes Cast,29
-Sherman,State Line,,,,Votes Cast,40
-Sherman,Union,,,,Votes Cast,29
-Sherman,Voltaire,,,,Votes Cast,179
-Sherman,Washington,,,,Votes Cast,35
-Sherman,Kanorado,,,,Votes Cast,35
-Sherman,Goodland W1,U.S. Senate,,R,Pat Roberts,310
-Sherman,Goodland W2,U.S. Senate,,R,Pat Roberts,147
-Sherman,Goodland W3,U.S. Senate,,R,Pat Roberts,168
-Sherman,Goodland W4,U.S. Senate,,R,Pat Roberts,293
-Sherman,Grant,U.S. Senate,,R,Pat Roberts,26
-Sherman,Iowa,U.S. Senate,,R,Pat Roberts,12
-Sherman,Itasca,U.S. Senate,,R,Pat Roberts,100
-Sherman,Lincoln,U.S. Senate,,R,Pat Roberts,29
-Sherman,Llanos,U.S. Senate,,R,Pat Roberts,19
-Sherman,Logan,U.S. Senate,,R,Pat Roberts,90
-Sherman,McPherson,U.S. Senate,,R,Pat Roberts,21
-Sherman,Shermanville,U.S. Senate,,R,Pat Roberts,10
-Sherman,Smoky,U.S. Senate,,R,Pat Roberts,26
-Sherman,State Line,U.S. Senate,,R,Pat Roberts,33
-Sherman,Union,U.S. Senate,,R,Pat Roberts,27
-Sherman,Voltaire,U.S. Senate,,R,Pat Roberts,147
-Sherman,Washington,U.S. Senate,,R,Pat Roberts,28
-Sherman,Kanorado,U.S. Senate,,R,Pat Roberts,25
-Sherman,Goodland W1,U.S. Senate,,I,Greg Orman,100
-Sherman,Goodland W2,U.S. Senate,,I,Greg Orman,57
-Sherman,Goodland W3,U.S. Senate,,I,Greg Orman,59
-Sherman,Goodland W4,U.S. Senate,,I,Greg Orman,102
-Sherman,Grant,U.S. Senate,,I,Greg Orman,5
-Sherman,Iowa,U.S. Senate,,I,Greg Orman,1
-Sherman,Itasca,U.S. Senate,,I,Greg Orman,29
-Sherman,Lincoln,U.S. Senate,,I,Greg Orman,9
-Sherman,Llanos,U.S. Senate,,I,Greg Orman,3
-Sherman,Logan,U.S. Senate,,I,Greg Orman,12
-Sherman,McPherson,U.S. Senate,,I,Greg Orman,3
-Sherman,Shermanville,U.S. Senate,,I,Greg Orman,1
-Sherman,Smoky,U.S. Senate,,I,Greg Orman,1
-Sherman,State Line,U.S. Senate,,I,Greg Orman,5
-Sherman,Union,U.S. Senate,,I,Greg Orman,2
-Sherman,Voltaire,U.S. Senate,,I,Greg Orman,23
-Sherman,Washington,U.S. Senate,,I,Greg Orman,6
-Sherman,Kanorado,U.S. Senate,,I,Greg Orman,8
-Sherman,Goodland W1,U.S. Senate,,L,Randall Batson,21
-Sherman,Goodland W2,U.S. Senate,,L,Randall Batson,7
-Sherman,Goodland W3,U.S. Senate,,L,Randall Batson,11
-Sherman,Goodland W4,U.S. Senate,,L,Randall Batson,12
-Sherman,Grant,U.S. Senate,,L,Randall Batson,1
-Sherman,Iowa,U.S. Senate,,L,Randall Batson,0
-Sherman,Itasca,U.S. Senate,,L,Randall Batson,5
-Sherman,Lincoln,U.S. Senate,,L,Randall Batson,0
-Sherman,Llanos,U.S. Senate,,L,Randall Batson,0
-Sherman,Logan,U.S. Senate,,L,Randall Batson,3
-Sherman,McPherson,U.S. Senate,,L,Randall Batson,0
-Sherman,Shermanville,U.S. Senate,,L,Randall Batson,0
-Sherman,Smoky,U.S. Senate,,L,Randall Batson,2
-Sherman,State Line,U.S. Senate,,L,Randall Batson,2
-Sherman,Union,U.S. Senate,,L,Randall Batson,0
-Sherman,Voltaire,U.S. Senate,,L,Randall Batson,5
-Sherman,Washington,U.S. Senate,,L,Randall Batson,1
-Sherman,Kanorado,U.S. Senate,,L,Randall Batson,1
-Sherman,Goodland W1,U.S. House,1,R,Tim Huelskamp,326
-Sherman,Goodland W2,U.S. House,1,R,Tim Huelskamp,174
-Sherman,Goodland W3,U.S. House,1,R,Tim Huelskamp,174
-Sherman,Goodland W4,U.S. House,1,R,Tim Huelskamp,298
-Sherman,Grant,U.S. House,1,R,Tim Huelskamp,25
-Sherman,Iowa,U.S. House,1,R,Tim Huelskamp,13
-Sherman,Itasca,U.S. House,1,R,Tim Huelskamp,101
-Sherman,Lincoln,U.S. House,1,R,Tim Huelskamp,31
-Sherman,Llanos,U.S. House,1,R,Tim Huelskamp,18
-Sherman,Logan,U.S. House,1,R,Tim Huelskamp,90
-Sherman,McPherson,U.S. House,1,R,Tim Huelskamp,22
-Sherman,Shermanville,U.S. House,1,R,Tim Huelskamp,11
-Sherman,Smoky,U.S. House,1,R,Tim Huelskamp,27
-Sherman,State Line,U.S. House,1,R,Tim Huelskamp,33
-Sherman,Union,U.S. House,1,R,Tim Huelskamp,27
-Sherman,Voltaire,U.S. House,1,R,Tim Huelskamp,153
-Sherman,Washington,U.S. House,1,R,Tim Huelskamp,33
-Sherman,Kanorado,U.S. House,1,R,Tim Huelskamp,24
-Sherman,Goodland W1,U.S. House,1,D,James Sherow,96
-Sherman,Goodland W2,U.S. House,1,D,James Sherow,35
-Sherman,Goodland W3,U.S. House,1,D,James Sherow,56
-Sherman,Goodland W4,U.S. House,1,D,James Sherow,104
-Sherman,Grant,U.S. House,1,D,James Sherow,7
-Sherman,Iowa,U.S. House,1,D,James Sherow,0
-Sherman,Itasca,U.S. House,1,D,James Sherow,27
-Sherman,Lincoln,U.S. House,1,D,James Sherow,7
-Sherman,Llanos,U.S. House,1,D,James Sherow,3
-Sherman,Logan,U.S. House,1,D,James Sherow,15
-Sherman,McPherson,U.S. House,1,D,James Sherow,2
-Sherman,Shermanville,U.S. House,1,D,James Sherow,0
-Sherman,Smoky,U.S. House,1,D,James Sherow,2
-Sherman,State Line,U.S. House,1,D,James Sherow,3
-Sherman,Union,U.S. House,1,D,James Sherow,2
-Sherman,Voltaire,U.S. House,1,D,James Sherow,22
-Sherman,Washington,U.S. House,1,D,James Sherow,2
-Sherman,Kanorado,U.S. House,1,D,James Sherow,10
-Sherman,Goodland W1,Governor,,R,Sam Brownback,294
-Sherman,Goodland W2,Governor,,R,Sam Brownback,141
-Sherman,Goodland W3,Governor,,R,Sam Brownback,164
-Sherman,Goodland W4,Governor,,R,Sam Brownback,269
-Sherman,Grant,Governor,,R,Sam Brownback,23
-Sherman,Iowa,Governor,,R,Sam Brownback,13
-Sherman,Itasca,Governor,,R,Sam Brownback,98
-Sherman,Lincoln,Governor,,R,Sam Brownback,27
-Sherman,Llanos,Governor,,R,Sam Brownback,18
-Sherman,Logan,Governor,,R,Sam Brownback,87
-Sherman,McPherson,Governor,,R,Sam Brownback,23
-Sherman,Shermanville,Governor,,R,Sam Brownback,11
-Sherman,Smoky,Governor,,R,Sam Brownback,23
-Sherman,State Line,Governor,,R,Sam Brownback,32
-Sherman,Union,Governor,,R,Sam Brownback,27
-Sherman,Voltaire,Governor,,R,Sam Brownback,150
-Sherman,Washington,Governor,,R,Sam Brownback,29
-Sherman,Kanorado,Governor,,R,Sam Brownback,24
-Sherman,Goodland W1,Governor,,D,Paul Davis,120
-Sherman,Goodland W2,Governor,,D,Paul Davis,56
-Sherman,Goodland W3,Governor,,D,Paul Davis,63
-Sherman,Goodland W4,Governor,,D,Paul Davis,119
-Sherman,Grant,Governor,,D,Paul Davis,7
-Sherman,Iowa,Governor,,D,Paul Davis,0
-Sherman,Itasca,Governor,,D,Paul Davis,31
-Sherman,Lincoln,Governor,,D,Paul Davis,10
-Sherman,Llanos,Governor,,D,Paul Davis,3
-Sherman,Logan,Governor,,D,Paul Davis,19
-Sherman,McPherson,Governor,,D,Paul Davis,1
-Sherman,Shermanville,Governor,,D,Paul Davis,0
-Sherman,Smoky,Governor,,D,Paul Davis,4
-Sherman,State Line,Governor,,D,Paul Davis,7
-Sherman,Union,Governor,,D,Paul Davis,2
-Sherman,Voltaire,Governor,,D,Paul Davis,23
-Sherman,Washington,Governor,,D,Paul Davis,5
-Sherman,Kanorado,Governor,,D,Paul Davis,9
-Sherman,Goodland W1,Governor,,L,Keen Umbehr,19
-Sherman,Goodland W2,Governor,,L,Keen Umbehr,12
-Sherman,Goodland W3,Governor,,L,Keen Umbehr,11
-Sherman,Goodland W4,Governor,,L,Keen Umbehr,21
-Sherman,Grant,Governor,,L,Keen Umbehr,2
-Sherman,Iowa,Governor,,L,Keen Umbehr,0
-Sherman,Itasca,Governor,,L,Keen Umbehr,4
-Sherman,Lincoln,Governor,,L,Keen Umbehr,0
-Sherman,Llanos,Governor,,L,Keen Umbehr,1
-Sherman,Logan,Governor,,L,Keen Umbehr,1
-Sherman,McPherson,Governor,,L,Keen Umbehr,0
-Sherman,Shermanville,Governor,,L,Keen Umbehr,0
-Sherman,Smoky,Governor,,L,Keen Umbehr,2
-Sherman,State Line,Governor,,L,Keen Umbehr,0
-Sherman,Union,Governor,,L,Keen Umbehr,0
-Sherman,Voltaire,Governor,,L,Keen Umbehr,4
-Sherman,Washington,Governor,,L,Keen Umbehr,1
-Sherman,Kanorado,Governor,,L,Keen Umbehr,2
-Sherman,Goodland W1,Secretary of State,,R,Kris Kobach,324
-Sherman,Goodland W2,Secretary of State,,R,Kris Kobach,163
-Sherman,Goodland W3,Secretary of State,,R,Kris Kobach,179
-Sherman,Goodland W4,Secretary of State,,R,Kris Kobach,312
-Sherman,Grant,Secretary of State,,R,Kris Kobach,27
-Sherman,Iowa,Secretary of State,,R,Kris Kobach,13
-Sherman,Itasca,Secretary of State,,R,Kris Kobach,100
-Sherman,Lincoln,Secretary of State,,R,Kris Kobach,27
-Sherman,Llanos,Secretary of State,,R,Kris Kobach,18
-Sherman,Logan,Secretary of State,,R,Kris Kobach,92
-Sherman,McPherson,Secretary of State,,R,Kris Kobach,22
-Sherman,Shermanville,Secretary of State,,R,Kris Kobach,10
-Sherman,Smoky,Secretary of State,,R,Kris Kobach,27
-Sherman,State Line,Secretary of State,,R,Kris Kobach,31
-Sherman,Union,Secretary of State,,R,Kris Kobach,28
-Sherman,Voltaire,Secretary of State,,R,Kris Kobach,161
-Sherman,Washington,Secretary of State,,R,Kris Kobach,32
-Sherman,Kanorado,Secretary of State,,R,Kris Kobach,25
-Sherman,Goodland W1,Secretary of State,,D,Jean Schodorf,102
-Sherman,Goodland W2,Secretary of State,,D,Jean Schodorf,47
-Sherman,Goodland W3,Secretary of State,,D,Jean Schodorf,54
-Sherman,Goodland W4,Secretary of State,,D,Jean Schodorf,91
-Sherman,Grant,Secretary of State,,D,Jean Schodorf,5
-Sherman,Iowa,Secretary of State,,D,Jean Schodorf,0
-Sherman,Itasca,Secretary of State,,D,Jean Schodorf,27
-Sherman,Lincoln,Secretary of State,,D,Jean Schodorf,11
-Sherman,Llanos,Secretary of State,,D,Jean Schodorf,4
-Sherman,Logan,Secretary of State,,D,Jean Schodorf,11
-Sherman,McPherson,Secretary of State,,D,Jean Schodorf,2
-Sherman,Shermanville,Secretary of State,,D,Jean Schodorf,1
-Sherman,Smoky,Secretary of State,,D,Jean Schodorf,2
-Sherman,State Line,Secretary of State,,D,Jean Schodorf,4
-Sherman,Union,Secretary of State,,D,Jean Schodorf,1
-Sherman,Voltaire,Secretary of State,,D,Jean Schodorf,16
-Sherman,Washington,Secretary of State,,D,Jean Schodorf,2
-Sherman,Kanorado,Secretary of State,,D,Jean Schodorf,10
-Sherman,Goodland W1,Attorney General,,R,Derek Schmidt,345
-Sherman,Goodland W2,Attorney General,,R,Derek Schmidt,164
-Sherman,Goodland W3,Attorney General,,R,Derek Schmidt,181
-Sherman,Goodland W4,Attorney General,,R,Derek Schmidt,329
-Sherman,Grant,Attorney General,,R,Derek Schmidt,24
-Sherman,Iowa,Attorney General,,R,Derek Schmidt,13
-Sherman,Itasca,Attorney General,,R,Derek Schmidt,104
-Sherman,Lincoln,Attorney General,,R,Derek Schmidt,26
-Sherman,Llanos,Attorney General,,R,Derek Schmidt,18
-Sherman,Logan,Attorney General,,R,Derek Schmidt,94
-Sherman,McPherson,Attorney General,,R,Derek Schmidt,21
-Sherman,Shermanville,Attorney General,,R,Derek Schmidt,11
-Sherman,Smoky,Attorney General,,R,Derek Schmidt,25
-Sherman,State Line,Attorney General,,R,Derek Schmidt,31
-Sherman,Union,Attorney General,,R,Derek Schmidt,28
-Sherman,Voltaire,Attorney General,,R,Derek Schmidt,155
-Sherman,Washington,Attorney General,,R,Derek Schmidt,32
-Sherman,Kanorado,Attorney General,,R,Derek Schmidt,24
-Sherman,Goodland W1,Attorney General,,D,A J Kotich,77
-Sherman,Goodland W2,Attorney General,,D,A J Kotich,40
-Sherman,Goodland W3,Attorney General,,D,A J Kotich,43
-Sherman,Goodland W4,Attorney General,,D,A J Kotich,69
-Sherman,Grant,Attorney General,,D,A J Kotich,7
-Sherman,Iowa,Attorney General,,D,A J Kotich,0
-Sherman,Itasca,Attorney General,,D,A J Kotich,23
-Sherman,Lincoln,Attorney General,,D,A J Kotich,11
-Sherman,Llanos,Attorney General,,D,A J Kotich,3
-Sherman,Logan,Attorney General,,D,A J Kotich,8
-Sherman,McPherson,Attorney General,,D,A J Kotich,2
-Sherman,Shermanville,Attorney General,,D,A J Kotich,0
-Sherman,Smoky,Attorney General,,D,A J Kotich,1
-Sherman,State Line,Attorney General,,D,A J Kotich,3
-Sherman,Union,Attorney General,,D,A J Kotich,1
-Sherman,Voltaire,Attorney General,,D,A J Kotich,18
-Sherman,Washington,Attorney General,,D,A J Kotich,2
-Sherman,Kanorado,Attorney General,,D,A J Kotich,9
-Sherman,Goodland W1,State Treasurer,,R,Ron Estes,338
-Sherman,Goodland W2,State Treasurer,,R,Ron Estes,167
-Sherman,Goodland W3,State Treasurer,,R,Ron Estes,184
-Sherman,Goodland W4,State Treasurer,,R,Ron Estes,342
-Sherman,Grant,State Treasurer,,R,Ron Estes,25
-Sherman,Iowa,State Treasurer,,R,Ron Estes,12
-Sherman,Itasca,State Treasurer,,R,Ron Estes,112
-Sherman,Lincoln,State Treasurer,,R,Ron Estes,28
-Sherman,Llanos,State Treasurer,,R,Ron Estes,19
-Sherman,Logan,State Treasurer,,R,Ron Estes,93
-Sherman,McPherson,State Treasurer,,R,Ron Estes,23
-Sherman,Shermanville,State Treasurer,,R,Ron Estes,10
-Sherman,Smoky,State Treasurer,,R,Ron Estes,26
-Sherman,State Line,State Treasurer,,R,Ron Estes,30
-Sherman,Union,State Treasurer,,R,Ron Estes,28
-Sherman,Voltaire,State Treasurer,,R,Ron Estes,165
-Sherman,Washington,State Treasurer,,R,Ron Estes,32
-Sherman,Kanorado,State Treasurer,,R,Ron Estes,27
-Sherman,Goodland W1,State Treasurer,,D,Carmen Alldritt,83
-Sherman,Goodland W2,State Treasurer,,D,Carmen Alldritt,35
-Sherman,Goodland W3,State Treasurer,,D,Carmen Alldritt,43
-Sherman,Goodland W4,State Treasurer,,D,Carmen Alldritt,59
-Sherman,Grant,State Treasurer,,D,Carmen Alldritt,6
-Sherman,Iowa,State Treasurer,,D,Carmen Alldritt,0
-Sherman,Itasca,State Treasurer,,D,Carmen Alldritt,16
-Sherman,Lincoln,State Treasurer,,D,Carmen Alldritt,10
-Sherman,Llanos,State Treasurer,,D,Carmen Alldritt,2
-Sherman,Logan,State Treasurer,,D,Carmen Alldritt,8
-Sherman,McPherson,State Treasurer,,D,Carmen Alldritt,1
-Sherman,Shermanville,State Treasurer,,D,Carmen Alldritt,1
-Sherman,Smoky,State Treasurer,,D,Carmen Alldritt,1
-Sherman,State Line,State Treasurer,,D,Carmen Alldritt,3
-Sherman,Union,State Treasurer,,D,Carmen Alldritt,1
-Sherman,Voltaire,State Treasurer,,D,Carmen Alldritt,12
-Sherman,Washington,State Treasurer,,D,Carmen Alldritt,3
-Sherman,Kanorado,State Treasurer,,D,Carmen Alldritt,8
-Sherman,Goodland W1,Insurance Commissioner,,R,Ron Selzer,326
-Sherman,Goodland W2,Insurance Commissioner,,R,Ron Selzer,156
-Sherman,Goodland W3,Insurance Commissioner,,R,Ron Selzer,172
-Sherman,Goodland W4,Insurance Commissioner,,R,Ron Selzer,312
-Sherman,Grant,Insurance Commissioner,,R,Ron Selzer,24
-Sherman,Iowa,Insurance Commissioner,,R,Ron Selzer,12
-Sherman,Itasca,Insurance Commissioner,,R,Ron Selzer,101
-Sherman,Lincoln,Insurance Commissioner,,R,Ron Selzer,27
-Sherman,Llanos,Insurance Commissioner,,R,Ron Selzer,19
-Sherman,Logan,Insurance Commissioner,,R,Ron Selzer,91
-Sherman,McPherson,Insurance Commissioner,,R,Ron Selzer,22
-Sherman,Shermanville,Insurance Commissioner,,R,Ron Selzer,11
-Sherman,Smoky,Insurance Commissioner,,R,Ron Selzer,24
-Sherman,State Line,Insurance Commissioner,,R,Ron Selzer,30
-Sherman,Union,Insurance Commissioner,,R,Ron Selzer,27
-Sherman,Voltaire,Insurance Commissioner,,R,Ron Selzer,155
-Sherman,Washington,Insurance Commissioner,,R,Ron Selzer,30
-Sherman,Kanorado,Insurance Commissioner,,R,Ron Selzer,23
-Sherman,Goodland W1,Insurance Commissioner,,D,Dennis Anderson,88
-Sherman,Goodland W2,Insurance Commissioner,,D,Dennis Anderson,42
-Sherman,Goodland W3,Insurance Commissioner,,D,Dennis Anderson,46
-Sherman,Goodland W4,Insurance Commissioner,,D,Dennis Anderson,81
-Sherman,Grant,Insurance Commissioner,,D,Dennis Anderson,5
-Sherman,Iowa,Insurance Commissioner,,D,Dennis Anderson,0
-Sherman,Itasca,Insurance Commissioner,,D,Dennis Anderson,25
-Sherman,Lincoln,Insurance Commissioner,,D,Dennis Anderson,11
-Sherman,Llanos,Insurance Commissioner,,D,Dennis Anderson,3
-Sherman,Logan,Insurance Commissioner,,D,Dennis Anderson,10
-Sherman,McPherson,Insurance Commissioner,,D,Dennis Anderson,2
-Sherman,Shermanville,Insurance Commissioner,,D,Dennis Anderson,0
-Sherman,Smoky,Insurance Commissioner,,D,Dennis Anderson,2
-Sherman,State Line,Insurance Commissioner,,D,Dennis Anderson,4
-Sherman,Union,Insurance Commissioner,,D,Dennis Anderson,1
-Sherman,Voltaire,Insurance Commissioner,,D,Dennis Anderson,13
-Sherman,Washington,Insurance Commissioner,,D,Dennis Anderson,4
-Sherman,Kanorado,Insurance Commissioner,,D,Dennis Anderson,10
-Sherman,Goodland W1,State House,120,R,Rick Billinger,390
-Sherman,Goodland W2,State House,120,R,Rick Billinger,196
-Sherman,Goodland W3,State House,120,R,Rick Billinger,217
-Sherman,Goodland W4,State House,120,R,Rick Billinger,388
-Sherman,Grant,State House,120,R,Rick Billinger,27
-Sherman,Iowa,State House,120,R,Rick Billinger,12
-Sherman,Itasca,State House,120,R,Rick Billinger,125
-Sherman,Lincoln,State House,120,R,Rick Billinger,32
-Sherman,Llanos,State House,120,R,Rick Billinger,22
-Sherman,Logan,State House,120,R,Rick Billinger,101
-Sherman,McPherson,State House,120,R,Rick Billinger,23
-Sherman,Shermanville,State House,120,R,Rick Billinger,11
-Sherman,Smoky,State House,120,R,Rick Billinger,28
-Sherman,State Line,State House,120,R,Rick Billinger,39
-Sherman,Union,State House,120,R,Rick Billinger,29
-Sherman,Voltaire,State House,120,R,Rick Billinger,162
-Sherman,Washington,State House,120,R,Rick Billinger,34
-Sherman,Kanorado,State House,120,R,Rick Billinger,31
-Sherman,Goodland W1,State House,120,,Write-ins,6
-Sherman,Goodland W2,State House,120,,Write-ins,1
-Sherman,Goodland W3,State House,120,,Write-ins,1
-Sherman,Goodland W4,State House,120,,Write-ins,1
-Sherman,Voltaire,State House,120,,Write-ins,2
-Sherman,Goodland W2,U.S. Senate,,,Jean Schodorf [wri],1
-Sherman,Goodland W4,U.S. Senate,,,Write-ins [wri],1
-Sherman,Itasca,U.S. House,1,,Garret Lane [wri],1
-Sherman,Voltaire,U.S. House,1,,Alan Wa Police [wri],1
-Sherman,Goodland W1,State Treasurer,,,Walter Young [wri],1
-Sherman,Goodland W1,Insurance Commissioner,,,Robert Luck [wri],1
-Sherman,Goodland W4,Insurance Commissioner,,,Robert Lamke [wri],1
+county,precinct,office,district,party,candidate,votes,vtd
+SHERMAN,Goodland Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",120,000010
+SHERMAN,Goodland Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000010
+SHERMAN,Goodland Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",294,000010
+SHERMAN,Goodland Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",56,000020
+SHERMAN,Goodland Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000020
+SHERMAN,Goodland Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,000020
+SHERMAN,Goodland Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",63,000030
+SHERMAN,Goodland Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000030
+SHERMAN,Goodland Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",164,000030
+SHERMAN,Goodland Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000040
+SHERMAN,Goodland Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",21,000040
+SHERMAN,Goodland Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",269,000040
+SHERMAN,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000050
+SHERMAN,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000050
+SHERMAN,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000050
+SHERMAN,Iowa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000060
+SHERMAN,Iowa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+SHERMAN,Iowa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000060
+SHERMAN,Itasca Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000070
+SHERMAN,Itasca Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000070
+SHERMAN,Itasca Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",98,000070
+SHERMAN,Kanorado City,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000080
+SHERMAN,Kanorado City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+SHERMAN,Kanorado City,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000080
+SHERMAN,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000090
+SHERMAN,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000090
+SHERMAN,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000090
+SHERMAN,Llanos Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000100
+SHERMAN,Llanos Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+SHERMAN,Llanos Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000100
+SHERMAN,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,00011A
+SHERMAN,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,00011A
+SHERMAN,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,00011A
+SHERMAN,Logan Township Enclave (B),Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00011C
+SHERMAN,Logan Township Enclave (B),Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00011C
+SHERMAN,Logan Township Enclave (B),Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00011C
+SHERMAN,McPherson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000120
+SHERMAN,McPherson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+SHERMAN,McPherson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000120
+SHERMAN,Shermanville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000130
+SHERMAN,Shermanville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000130
+SHERMAN,Shermanville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000130
+SHERMAN,Smoky Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000140
+SHERMAN,Smoky Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000140
+SHERMAN,Smoky Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000140
+SHERMAN,State Line Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000150
+SHERMAN,State Line Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000150
+SHERMAN,State Line Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000150
+SHERMAN,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000160
+SHERMAN,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000160
+SHERMAN,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000160
+SHERMAN,Voltaire Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000170
+SHERMAN,Voltaire Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000170
+SHERMAN,Voltaire Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",150,000170
+SHERMAN,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000180
+SHERMAN,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000180
+SHERMAN,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000180
+SHERMAN,Goodland Ward 1,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",390,000010
+SHERMAN,Goodland Ward 2,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",196,000020
+SHERMAN,Goodland Ward 3,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",217,000030
+SHERMAN,Goodland Ward 4,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",388,000040
+SHERMAN,Grant Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",27,000050
+SHERMAN,Iowa Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",12,000060
+SHERMAN,Itasca Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",125,000070
+SHERMAN,Kanorado City,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",31,000080
+SHERMAN,Lincoln Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",32,000090
+SHERMAN,Llanos Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",22,000100
+SHERMAN,Logan Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",101,00011A
+SHERMAN,Logan Township Enclave (B),Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",0,00011C
+SHERMAN,McPherson Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",23,000120
+SHERMAN,Shermanville Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",11,000130
+SHERMAN,Smoky Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",28,000140
+SHERMAN,State Line Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",39,000150
+SHERMAN,Union Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",29,000160
+SHERMAN,Voltaire Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",162,000170
+SHERMAN,Washington Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",34,000180
+SHERMAN,Goodland Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",96,000010
+SHERMAN,Goodland Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",326,000010
+SHERMAN,Goodland Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000020
+SHERMAN,Goodland Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",174,000020
+SHERMAN,Goodland Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",56,000030
+SHERMAN,Goodland Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",174,000030
+SHERMAN,Goodland Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",104,000040
+SHERMAN,Goodland Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",298,000040
+SHERMAN,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000050
+SHERMAN,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000050
+SHERMAN,Iowa Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000060
+SHERMAN,Iowa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000060
+SHERMAN,Itasca Township,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000070
+SHERMAN,Itasca Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000070
+SHERMAN,Kanorado City,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000080
+SHERMAN,Kanorado City,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000080
+SHERMAN,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000090
+SHERMAN,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000090
+SHERMAN,Llanos Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000100
+SHERMAN,Llanos Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000100
+SHERMAN,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,00011A
+SHERMAN,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",90,00011A
+SHERMAN,Logan Township Enclave (B),United States House of Representatives,1,Democratic,"Sherow, James E.",0,00011C
+SHERMAN,Logan Township Enclave (B),United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00011C
+SHERMAN,McPherson Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000120
+SHERMAN,McPherson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000120
+SHERMAN,Shermanville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000130
+SHERMAN,Shermanville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000130
+SHERMAN,Smoky Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000140
+SHERMAN,Smoky Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000140
+SHERMAN,State Line Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000150
+SHERMAN,State Line Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000150
+SHERMAN,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000160
+SHERMAN,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000160
+SHERMAN,Voltaire Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000170
+SHERMAN,Voltaire Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",153,000170
+SHERMAN,Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000180
+SHERMAN,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000180
+SHERMAN,Goodland Ward 1,Attorney General,,Democratic,"Kotich, A.J.",77,000010
+SHERMAN,Goodland Ward 1,Attorney General,,Republican,"Schmidt, Derek",345,000010
+SHERMAN,Goodland Ward 2,Attorney General,,Democratic,"Kotich, A.J.",40,000020
+SHERMAN,Goodland Ward 2,Attorney General,,Republican,"Schmidt, Derek",164,000020
+SHERMAN,Goodland Ward 3,Attorney General,,Democratic,"Kotich, A.J.",43,000030
+SHERMAN,Goodland Ward 3,Attorney General,,Republican,"Schmidt, Derek",181,000030
+SHERMAN,Goodland Ward 4,Attorney General,,Democratic,"Kotich, A.J.",69,000040
+SHERMAN,Goodland Ward 4,Attorney General,,Republican,"Schmidt, Derek",329,000040
+SHERMAN,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",7,000050
+SHERMAN,Grant Township,Attorney General,,Republican,"Schmidt, Derek",24,000050
+SHERMAN,Iowa Township,Attorney General,,Democratic,"Kotich, A.J.",0,000060
+SHERMAN,Iowa Township,Attorney General,,Republican,"Schmidt, Derek",13,000060
+SHERMAN,Itasca Township,Attorney General,,Democratic,"Kotich, A.J.",23,000070
+SHERMAN,Itasca Township,Attorney General,,Republican,"Schmidt, Derek",104,000070
+SHERMAN,Kanorado City,Attorney General,,Democratic,"Kotich, A.J.",9,000080
+SHERMAN,Kanorado City,Attorney General,,Republican,"Schmidt, Derek",24,000080
+SHERMAN,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",11,000090
+SHERMAN,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",26,000090
+SHERMAN,Llanos Township,Attorney General,,Democratic,"Kotich, A.J.",3,000100
+SHERMAN,Llanos Township,Attorney General,,Republican,"Schmidt, Derek",18,000100
+SHERMAN,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",8,00011A
+SHERMAN,Logan Township,Attorney General,,Republican,"Schmidt, Derek",94,00011A
+SHERMAN,Logan Township Enclave (B),Attorney General,,Democratic,"Kotich, A.J.",0,00011C
+SHERMAN,Logan Township Enclave (B),Attorney General,,Republican,"Schmidt, Derek",0,00011C
+SHERMAN,McPherson Township,Attorney General,,Democratic,"Kotich, A.J.",2,000120
+SHERMAN,McPherson Township,Attorney General,,Republican,"Schmidt, Derek",21,000120
+SHERMAN,Shermanville Township,Attorney General,,Democratic,"Kotich, A.J.",0,000130
+SHERMAN,Shermanville Township,Attorney General,,Republican,"Schmidt, Derek",11,000130
+SHERMAN,Smoky Township,Attorney General,,Democratic,"Kotich, A.J.",1,000140
+SHERMAN,Smoky Township,Attorney General,,Republican,"Schmidt, Derek",25,000140
+SHERMAN,State Line Township,Attorney General,,Democratic,"Kotich, A.J.",3,000150
+SHERMAN,State Line Township,Attorney General,,Republican,"Schmidt, Derek",31,000150
+SHERMAN,Union Township,Attorney General,,Democratic,"Kotich, A.J.",1,000160
+SHERMAN,Union Township,Attorney General,,Republican,"Schmidt, Derek",28,000160
+SHERMAN,Voltaire Township,Attorney General,,Democratic,"Kotich, A.J.",18,000170
+SHERMAN,Voltaire Township,Attorney General,,Republican,"Schmidt, Derek",155,000170
+SHERMAN,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",2,000180
+SHERMAN,Washington Township,Attorney General,,Republican,"Schmidt, Derek",32,000180
+SHERMAN,Goodland Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",88,000010
+SHERMAN,Goodland Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",326,000010
+SHERMAN,Goodland Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000020
+SHERMAN,Goodland Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",156,000020
+SHERMAN,Goodland Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000030
+SHERMAN,Goodland Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",172,000030
+SHERMAN,Goodland Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",81,000040
+SHERMAN,Goodland Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",312,000040
+SHERMAN,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000050
+SHERMAN,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000050
+SHERMAN,Iowa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000060
+SHERMAN,Iowa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000060
+SHERMAN,Itasca Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000070
+SHERMAN,Itasca Township,Commissioner of Insurance,,Republican,"Selzer, Ken",101,000070
+SHERMAN,Kanorado City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000080
+SHERMAN,Kanorado City,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000080
+SHERMAN,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000090
+SHERMAN,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000090
+SHERMAN,Llanos Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000100
+SHERMAN,Llanos Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000100
+SHERMAN,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,00011A
+SHERMAN,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",91,00011A
+SHERMAN,Logan Township Enclave (B),Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00011C
+SHERMAN,Logan Township Enclave (B),Commissioner of Insurance,,Republican,"Selzer, Ken",0,00011C
+SHERMAN,McPherson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000120
+SHERMAN,McPherson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000120
+SHERMAN,Shermanville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000130
+SHERMAN,Shermanville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000130
+SHERMAN,Smoky Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000140
+SHERMAN,Smoky Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000140
+SHERMAN,State Line Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000150
+SHERMAN,State Line Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000150
+SHERMAN,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000160
+SHERMAN,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000160
+SHERMAN,Voltaire Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000170
+SHERMAN,Voltaire Township,Commissioner of Insurance,,Republican,"Selzer, Ken",155,000170
+SHERMAN,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000180
+SHERMAN,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000180
+SHERMAN,Goodland Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",102,000010
+SHERMAN,Goodland Ward 1,Secretary of State,,Republican,"Kobach, Kris",324,000010
+SHERMAN,Goodland Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",47,000020
+SHERMAN,Goodland Ward 2,Secretary of State,,Republican,"Kobach, Kris",163,000020
+SHERMAN,Goodland Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,000030
+SHERMAN,Goodland Ward 3,Secretary of State,,Republican,"Kobach, Kris",179,000030
+SHERMAN,Goodland Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",91,000040
+SHERMAN,Goodland Ward 4,Secretary of State,,Republican,"Kobach, Kris",312,000040
+SHERMAN,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000050
+SHERMAN,Grant Township,Secretary of State,,Republican,"Kobach, Kris",27,000050
+SHERMAN,Iowa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000060
+SHERMAN,Iowa Township,Secretary of State,,Republican,"Kobach, Kris",13,000060
+SHERMAN,Itasca Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000070
+SHERMAN,Itasca Township,Secretary of State,,Republican,"Kobach, Kris",100,000070
+SHERMAN,Kanorado City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000080
+SHERMAN,Kanorado City,Secretary of State,,Republican,"Kobach, Kris",25,000080
+SHERMAN,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000090
+SHERMAN,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",27,000090
+SHERMAN,Llanos Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000100
+SHERMAN,Llanos Township,Secretary of State,,Republican,"Kobach, Kris",18,000100
+SHERMAN,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,00011A
+SHERMAN,Logan Township,Secretary of State,,Republican,"Kobach, Kris",92,00011A
+SHERMAN,Logan Township Enclave (B),Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00011C
+SHERMAN,Logan Township Enclave (B),Secretary of State,,Republican,"Kobach, Kris",0,00011C
+SHERMAN,McPherson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000120
+SHERMAN,McPherson Township,Secretary of State,,Republican,"Kobach, Kris",22,000120
+SHERMAN,Shermanville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000130
+SHERMAN,Shermanville Township,Secretary of State,,Republican,"Kobach, Kris",10,000130
+SHERMAN,Smoky Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000140
+SHERMAN,Smoky Township,Secretary of State,,Republican,"Kobach, Kris",27,000140
+SHERMAN,State Line Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000150
+SHERMAN,State Line Township,Secretary of State,,Republican,"Kobach, Kris",31,000150
+SHERMAN,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000160
+SHERMAN,Union Township,Secretary of State,,Republican,"Kobach, Kris",28,000160
+SHERMAN,Voltaire Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000170
+SHERMAN,Voltaire Township,Secretary of State,,Republican,"Kobach, Kris",161,000170
+SHERMAN,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000180
+SHERMAN,Washington Township,Secretary of State,,Republican,"Kobach, Kris",32,000180
+SHERMAN,Goodland Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",83,000010
+SHERMAN,Goodland Ward 1,State Treasurer,,Republican,"Estes, Ron",338,000010
+SHERMAN,Goodland Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",35,000020
+SHERMAN,Goodland Ward 2,State Treasurer,,Republican,"Estes, Ron",167,000020
+SHERMAN,Goodland Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",43,000030
+SHERMAN,Goodland Ward 3,State Treasurer,,Republican,"Estes, Ron",184,000030
+SHERMAN,Goodland Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",59,000040
+SHERMAN,Goodland Ward 4,State Treasurer,,Republican,"Estes, Ron",342,000040
+SHERMAN,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000050
+SHERMAN,Grant Township,State Treasurer,,Republican,"Estes, Ron",25,000050
+SHERMAN,Iowa Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000060
+SHERMAN,Iowa Township,State Treasurer,,Republican,"Estes, Ron",12,000060
+SHERMAN,Itasca Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000070
+SHERMAN,Itasca Township,State Treasurer,,Republican,"Estes, Ron",112,000070
+SHERMAN,Kanorado City,State Treasurer,,Democratic,"Alldritt, Carmen",8,000080
+SHERMAN,Kanorado City,State Treasurer,,Republican,"Estes, Ron",27,000080
+SHERMAN,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000090
+SHERMAN,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",28,000090
+SHERMAN,Llanos Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000100
+SHERMAN,Llanos Township,State Treasurer,,Republican,"Estes, Ron",19,000100
+SHERMAN,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,00011A
+SHERMAN,Logan Township,State Treasurer,,Republican,"Estes, Ron",93,00011A
+SHERMAN,Logan Township Enclave (B),State Treasurer,,Democratic,"Alldritt, Carmen",0,00011C
+SHERMAN,Logan Township Enclave (B),State Treasurer,,Republican,"Estes, Ron",0,00011C
+SHERMAN,McPherson Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000120
+SHERMAN,McPherson Township,State Treasurer,,Republican,"Estes, Ron",23,000120
+SHERMAN,Shermanville Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000130
+SHERMAN,Shermanville Township,State Treasurer,,Republican,"Estes, Ron",10,000130
+SHERMAN,Smoky Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000140
+SHERMAN,Smoky Township,State Treasurer,,Republican,"Estes, Ron",26,000140
+SHERMAN,State Line Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000150
+SHERMAN,State Line Township,State Treasurer,,Republican,"Estes, Ron",30,000150
+SHERMAN,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000160
+SHERMAN,Union Township,State Treasurer,,Republican,"Estes, Ron",28,000160
+SHERMAN,Voltaire Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000170
+SHERMAN,Voltaire Township,State Treasurer,,Republican,"Estes, Ron",165,000170
+SHERMAN,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000180
+SHERMAN,Washington Township,State Treasurer,,Republican,"Estes, Ron",32,000180
+SHERMAN,Goodland Ward 1,United States Senate,,independent,"Orman, Greg",100,000010
+SHERMAN,Goodland Ward 1,United States Senate,,Libertarian,"Batson, Randall",21,000010
+SHERMAN,Goodland Ward 1,United States Senate,,Republican,"Roberts, Pat",310,000010
+SHERMAN,Goodland Ward 2,United States Senate,,independent,"Orman, Greg",57,000020
+SHERMAN,Goodland Ward 2,United States Senate,,Libertarian,"Batson, Randall",7,000020
+SHERMAN,Goodland Ward 2,United States Senate,,Republican,"Roberts, Pat",147,000020
+SHERMAN,Goodland Ward 3,United States Senate,,independent,"Orman, Greg",59,000030
+SHERMAN,Goodland Ward 3,United States Senate,,Libertarian,"Batson, Randall",11,000030
+SHERMAN,Goodland Ward 3,United States Senate,,Republican,"Roberts, Pat",168,000030
+SHERMAN,Goodland Ward 4,United States Senate,,independent,"Orman, Greg",102,000040
+SHERMAN,Goodland Ward 4,United States Senate,,Libertarian,"Batson, Randall",12,000040
+SHERMAN,Goodland Ward 4,United States Senate,,Republican,"Roberts, Pat",293,000040
+SHERMAN,Grant Township,United States Senate,,independent,"Orman, Greg",5,000050
+SHERMAN,Grant Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+SHERMAN,Grant Township,United States Senate,,Republican,"Roberts, Pat",26,000050
+SHERMAN,Iowa Township,United States Senate,,independent,"Orman, Greg",1,000060
+SHERMAN,Iowa Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+SHERMAN,Iowa Township,United States Senate,,Republican,"Roberts, Pat",12,000060
+SHERMAN,Itasca Township,United States Senate,,independent,"Orman, Greg",29,000070
+SHERMAN,Itasca Township,United States Senate,,Libertarian,"Batson, Randall",5,000070
+SHERMAN,Itasca Township,United States Senate,,Republican,"Roberts, Pat",100,000070
+SHERMAN,Kanorado City,United States Senate,,independent,"Orman, Greg",8,000080
+SHERMAN,Kanorado City,United States Senate,,Libertarian,"Batson, Randall",1,000080
+SHERMAN,Kanorado City,United States Senate,,Republican,"Roberts, Pat",25,000080
+SHERMAN,Lincoln Township,United States Senate,,independent,"Orman, Greg",9,000090
+SHERMAN,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+SHERMAN,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",29,000090
+SHERMAN,Llanos Township,United States Senate,,independent,"Orman, Greg",3,000100
+SHERMAN,Llanos Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+SHERMAN,Llanos Township,United States Senate,,Republican,"Roberts, Pat",19,000100
+SHERMAN,Logan Township,United States Senate,,independent,"Orman, Greg",12,00011A
+SHERMAN,Logan Township,United States Senate,,Libertarian,"Batson, Randall",3,00011A
+SHERMAN,Logan Township,United States Senate,,Republican,"Roberts, Pat",90,00011A
+SHERMAN,Logan Township Enclave (B),United States Senate,,independent,"Orman, Greg",0,00011C
+SHERMAN,Logan Township Enclave (B),United States Senate,,Libertarian,"Batson, Randall",0,00011C
+SHERMAN,Logan Township Enclave (B),United States Senate,,Republican,"Roberts, Pat",0,00011C
+SHERMAN,McPherson Township,United States Senate,,independent,"Orman, Greg",3,000120
+SHERMAN,McPherson Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+SHERMAN,McPherson Township,United States Senate,,Republican,"Roberts, Pat",21,000120
+SHERMAN,Shermanville Township,United States Senate,,independent,"Orman, Greg",1,000130
+SHERMAN,Shermanville Township,United States Senate,,Libertarian,"Batson, Randall",0,000130
+SHERMAN,Shermanville Township,United States Senate,,Republican,"Roberts, Pat",10,000130
+SHERMAN,Smoky Township,United States Senate,,independent,"Orman, Greg",1,000140
+SHERMAN,Smoky Township,United States Senate,,Libertarian,"Batson, Randall",2,000140
+SHERMAN,Smoky Township,United States Senate,,Republican,"Roberts, Pat",26,000140
+SHERMAN,State Line Township,United States Senate,,independent,"Orman, Greg",5,000150
+SHERMAN,State Line Township,United States Senate,,Libertarian,"Batson, Randall",2,000150
+SHERMAN,State Line Township,United States Senate,,Republican,"Roberts, Pat",33,000150
+SHERMAN,Union Township,United States Senate,,independent,"Orman, Greg",2,000160
+SHERMAN,Union Township,United States Senate,,Libertarian,"Batson, Randall",0,000160
+SHERMAN,Union Township,United States Senate,,Republican,"Roberts, Pat",27,000160
+SHERMAN,Voltaire Township,United States Senate,,independent,"Orman, Greg",23,000170
+SHERMAN,Voltaire Township,United States Senate,,Libertarian,"Batson, Randall",5,000170
+SHERMAN,Voltaire Township,United States Senate,,Republican,"Roberts, Pat",147,000170
+SHERMAN,Washington Township,United States Senate,,independent,"Orman, Greg",6,000180
+SHERMAN,Washington Township,United States Senate,,Libertarian,"Batson, Randall",1,000180
+SHERMAN,Washington Township,United States Senate,,Republican,"Roberts, Pat",28,000180

--- a/2014/20141104__ks__general__smith__precinct.csv
+++ b/2014/20141104__ks__general__smith__precinct.csv
@@ -1,479 +1,477 @@
-county,precinct,office,district,party,candidate,votes
-Smith,Banner  Precinct,U.S. Senate,,R,Pat Roberts,25
-Smith,Beaver  Precinct,U.S. Senate,,R,Pat Roberts,24
-Smith,Blaine  Precinct,U.S. Senate,,R,Pat Roberts,23
-Smith,Cedar  Precinct,U.S. Senate,,R,Pat Roberts,160
-Smith,Center 1,U.S. Senate,,R,Pat Roberts,180
-Smith,Center 2,U.S. Senate,,R,Pat Roberts,196
-Smith,Center 3,U.S. Senate,,R,Pat Roberts,154
-Smith,Center 4,U.S. Senate,,R,Pat Roberts,39
-Smith,Cora  Precinct,U.S. Senate,,R,Pat Roberts,13
-Smith,Crystal   Plains  Precinct,U.S. Senate,,R,Pat Roberts,10
-Smith,Dor  Precinct,U.S. Senate,,R,Pat Roberts,16
-Smith,Garfield  Precinct,U.S. Senate,,R,Pat Roberts,11
-Smith,German  Precinct,U.S. Senate,,R,Pat Roberts,5
-Smith,Harlan  Precinct,U.S. Senate,,R,Pat Roberts,31
-Smith,Harvey  Precinct,U.S. Senate,,R,Pat Roberts,46
-Smith,Houston  Precinct,U.S. Senate,,R,Pat Roberts,45
-Smith,Lane  Precinct,U.S. Senate,,R,Pat Roberts,30
-Smith,Lincoln  Precinct,U.S. Senate,,R,Pat Roberts,31
-Smith,Logan  Precinct,U.S. Senate,,R,Pat Roberts,13
-Smith,Martin  Precinct,U.S. Senate,,R,Pat Roberts,6
-Smith,Oak  Precinct,U.S. Senate,,R,Pat Roberts,90
-Smith,Pawnee  Precinct,U.S. Senate,,R,Pat Roberts,17
-Smith,Pleasant  Precinct,U.S. Senate,,R,Pat Roberts,12
-Smith,Swan  Precinct,U.S. Senate,,R,Pat Roberts,15
-Smith,Valley  Precinct,U.S. Senate,,R,Pat Roberts,19
-Smith,Washington  Precinct,U.S. Senate,,R,Pat Roberts,16
-Smith,Webster  Precinct,U.S. Senate,,R,Pat Roberts,23
-Smith,White  Rock  Precinct,U.S. Senate,,R,Pat Roberts,22
-Smith,Banner  Precinct,U.S. Senate,,IND,Greg Orman,4
-Smith,Beaver  Precinct,U.S. Senate,,IND,Greg Orman,1
-Smith,Blaine  Precinct,U.S. Senate,,IND,Greg Orman,2
-Smith,Cedar  Precinct,U.S. Senate,,IND,Greg Orman,52
-Smith,Center 1,U.S. Senate,,IND,Greg Orman,59
-Smith,Center 2,U.S. Senate,,IND,Greg Orman,86
-Smith,Center 3,U.S. Senate,,IND,Greg Orman,35
-Smith,Center 4,U.S. Senate,,IND,Greg Orman,16
-Smith,Cora  Precinct,U.S. Senate,,IND,Greg Orman,1
-Smith,Crystal   Plains  Precinct,U.S. Senate,,IND,Greg Orman,3
-Smith,Dor  Precinct,U.S. Senate,,IND,Greg Orman,6
-Smith,Garfield  Precinct,U.S. Senate,,IND,Greg Orman,1
-Smith,German  Precinct,U.S. Senate,,IND,Greg Orman,1
-Smith,Harlan  Precinct,U.S. Senate,,IND,Greg Orman,6
-Smith,Harvey  Precinct,U.S. Senate,,IND,Greg Orman,9
-Smith,Houston  Precinct,U.S. Senate,,IND,Greg Orman,12
-Smith,Lane  Precinct,U.S. Senate,,IND,Greg Orman,18
-Smith,Lincoln  Precinct,U.S. Senate,,IND,Greg Orman,6
-Smith,Logan  Precinct,U.S. Senate,,IND,Greg Orman,5
-Smith,Martin  Precinct,U.S. Senate,,IND,Greg Orman,1
-Smith,Oak  Precinct,U.S. Senate,,IND,Greg Orman,21
-Smith,Pawnee  Precinct,U.S. Senate,,IND,Greg Orman,3
-Smith,Pleasant  Precinct,U.S. Senate,,IND,Greg Orman,5
-Smith,Swan  Precinct,U.S. Senate,,IND,Greg Orman,3
-Smith,Valley  Precinct,U.S. Senate,,IND,Greg Orman,5
-Smith,Washington  Precinct,U.S. Senate,,IND,Greg Orman,1
-Smith,Webster  Precinct,U.S. Senate,,IND,Greg Orman,1
-Smith,White  Rock  Precinct,U.S. Senate,,IND,Greg Orman,2
-Smith,Banner  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Beaver  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Blaine  Precinct,U.S. Senate,,L,Randall Batson,1
-Smith,Cedar  Precinct,U.S. Senate,,L,Randall Batson,9
-Smith,Center 1,U.S. Senate,,L,Randall Batson,15
-Smith,Center 2,U.S. Senate,,L,Randall Batson,20
-Smith,Center 3,U.S. Senate,,L,Randall Batson,15
-Smith,Center 4,U.S. Senate,,L,Randall Batson,3
-Smith,Cora  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Crystal   Plains  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Dor  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Garfield  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,German  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Harlan  Precinct,U.S. Senate,,L,Randall Batson,1
-Smith,Harvey  Precinct,U.S. Senate,,L,Randall Batson,4
-Smith,Houston  Precinct,U.S. Senate,,L,Randall Batson,4
-Smith,Lane  Precinct,U.S. Senate,,L,Randall Batson,3
-Smith,Lincoln  Precinct,U.S. Senate,,L,Randall Batson,1
-Smith,Logan  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Martin  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Oak  Precinct,U.S. Senate,,L,Randall Batson,10
-Smith,Pawnee  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Pleasant  Precinct,U.S. Senate,,L,Randall Batson,1
-Smith,Swan  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Valley  Precinct,U.S. Senate,,L,Randall Batson,1
-Smith,Washington  Precinct,U.S. Senate,,L,Randall Batson,2
-Smith,Webster  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,White  Rock  Precinct,U.S. Senate,,L,Randall Batson,0
-Smith,Banner  Precinct,U.S. House,1,R,Tim Huelskamp,26
-Smith,Beaver  Precinct,U.S. House,1,R,Tim Huelskamp,24
-Smith,Blaine  Precinct,U.S. House,1,R,Tim Huelskamp,23
-Smith,Cedar  Precinct,U.S. House,1,R,Tim Huelskamp,158
-Smith,Center 1,U.S. House,1,R,Tim Huelskamp,188
-Smith,Center 2,U.S. House,1,R,Tim Huelskamp,220
-Smith,Center 3,U.S. House,1,R,Tim Huelskamp,155
-Smith,Center 4,U.S. House,1,R,Tim Huelskamp,43
-Smith,Cora  Precinct,U.S. House,1,R,Tim Huelskamp,12
-Smith,Crystal   Plains  Precinct,U.S. House,1,R,Tim Huelskamp,7
-Smith,Dor  Precinct,U.S. House,1,R,Tim Huelskamp,18
-Smith,Garfield  Precinct,U.S. House,1,R,Tim Huelskamp,11
-Smith,German  Precinct,U.S. House,1,R,Tim Huelskamp,5
-Smith,Harlan  Precinct,U.S. House,1,R,Tim Huelskamp,32
-Smith,Harvey  Precinct,U.S. House,1,R,Tim Huelskamp,51
-Smith,Houston  Precinct,U.S. House,1,R,Tim Huelskamp,47
-Smith,Lane  Precinct,U.S. House,1,R,Tim Huelskamp,33
-Smith,Lincoln  Precinct,U.S. House,1,R,Tim Huelskamp,31
-Smith,Logan  Precinct,U.S. House,1,R,Tim Huelskamp,11
-Smith,Martin  Precinct,U.S. House,1,R,Tim Huelskamp,5
-Smith,Oak  Precinct,U.S. House,1,R,Tim Huelskamp,100
-Smith,Pawnee  Precinct,U.S. House,1,R,Tim Huelskamp,14
-Smith,Pleasant  Precinct,U.S. House,1,R,Tim Huelskamp,14
-Smith,Swan  Precinct,U.S. House,1,R,Tim Huelskamp,13
-Smith,Valley  Precinct,U.S. House,1,R,Tim Huelskamp,21
-Smith,Washington  Precinct,U.S. House,1,R,Tim Huelskamp,19
-Smith,Webster  Precinct,U.S. House,1,R,Tim Huelskamp,23
-Smith,White  Rock  Precinct,U.S. House,1,R,Tim Huelskamp,23
-Smith,Banner  Precinct,U.S. House,1,D,James Sherow,3
-Smith,Beaver  Precinct,U.S. House,1,D,James Sherow,2
-Smith,Blaine  Precinct,U.S. House,1,D,James Sherow,3
-Smith,Cedar  Precinct,U.S. House,1,D,James Sherow,59
-Smith,Center 1,U.S. House,1,D,James Sherow,63
-Smith,Center 2,U.S. House,1,D,James Sherow,84
-Smith,Center 3,U.S. House,1,D,James Sherow,44
-Smith,Center 4,U.S. House,1,D,James Sherow,13
-Smith,Cora  Precinct,U.S. House,1,D,James Sherow,1
-Smith,Crystal   Plains  Precinct,U.S. House,1,D,James Sherow,5
-Smith,Dor  Precinct,U.S. House,1,D,James Sherow,4
-Smith,Garfield  Precinct,U.S. House,1,D,James Sherow,1
-Smith,German  Precinct,U.S. House,1,D,James Sherow,1
-Smith,Harlan  Precinct,U.S. House,1,D,James Sherow,6
-Smith,Harvey  Precinct,U.S. House,1,D,James Sherow,8
-Smith,Houston  Precinct,U.S. House,1,D,James Sherow,13
-Smith,Lane  Precinct,U.S. House,1,D,James Sherow,17
-Smith,Lincoln  Precinct,U.S. House,1,D,James Sherow,7
-Smith,Logan  Precinct,U.S. House,1,D,James Sherow,7
-Smith,Martin  Precinct,U.S. House,1,D,James Sherow,2
-Smith,Oak  Precinct,U.S. House,1,D,James Sherow,17
-Smith,Pawnee  Precinct,U.S. House,1,D,James Sherow,2
-Smith,Pleasant  Precinct,U.S. House,1,D,James Sherow,4
-Smith,Swan  Precinct,U.S. House,1,D,James Sherow,5
-Smith,Valley  Precinct,U.S. House,1,D,James Sherow,4
-Smith,Washington  Precinct,U.S. House,1,D,James Sherow,0
-Smith,Webster  Precinct,U.S. House,1,D,James Sherow,1
-Smith,White  Rock  Precinct,U.S. House,1,D,James Sherow,1
-Smith,Banner  Precinct,Governor,,R,Sam Brownback,21
-Smith,Beaver  Precinct,Governor,,R,Sam Brownback,24
-Smith,Blaine  Precinct,Governor,,R,Sam Brownback,21
-Smith,Cedar  Precinct,Governor,,R,Sam Brownback,130
-Smith,Center 1,Governor,,R,Sam Brownback,152
-Smith,Center 2,Governor,,R,Sam Brownback,175
-Smith,Center 3,Governor,,R,Sam Brownback,136
-Smith,Center 4,Governor,,R,Sam Brownback,37
-Smith,Cora  Precinct,Governor,,R,Sam Brownback,11
-Smith,Crystal   Plains  Precinct,Governor,,R,Sam Brownback,10
-Smith,Dor  Precinct,Governor,,R,Sam Brownback,17
-Smith,Garfield  Precinct,Governor,,R,Sam Brownback,11
-Smith,German  Precinct,Governor,,R,Sam Brownback,5
-Smith,Harlan  Precinct,Governor,,R,Sam Brownback,31
-Smith,Harvey  Precinct,Governor,,R,Sam Brownback,46
-Smith,Houston  Precinct,Governor,,R,Sam Brownback,36
-Smith,Lane  Precinct,Governor,,R,Sam Brownback,27
-Smith,Lincoln  Precinct,Governor,,R,Sam Brownback,28
-Smith,Logan  Precinct,Governor,,R,Sam Brownback,11
-Smith,Martin  Precinct,Governor,,R,Sam Brownback,4
-Smith,Oak  Precinct,Governor,,R,Sam Brownback,87
-Smith,Pawnee  Precinct,Governor,,R,Sam Brownback,17
-Smith,Pleasant  Precinct,Governor,,R,Sam Brownback,11
-Smith,Swan  Precinct,Governor,,R,Sam Brownback,11
-Smith,Valley  Precinct,Governor,,R,Sam Brownback,18
-Smith,Washington  Precinct,Governor,,R,Sam Brownback,17
-Smith,Webster  Precinct,Governor,,R,Sam Brownback,22
-Smith,White  Rock  Precinct,Governor,,R,Sam Brownback,19
-Smith,Banner  Precinct,Governor,,D,Paul Davis,5
-Smith,Beaver  Precinct,Governor,,D,Paul Davis,3
-Smith,Blaine  Precinct,Governor,,D,Paul Davis,5
-Smith,Cedar  Precinct,Governor,,D,Paul Davis,77
-Smith,Center 1,Governor,,D,Paul Davis,93
-Smith,Center 2,Governor,,D,Paul Davis,112
-Smith,Center 3,Governor,,D,Paul Davis,55
-Smith,Center 4,Governor,,D,Paul Davis,15
-Smith,Cora  Precinct,Governor,,D,Paul Davis,3
-Smith,Crystal   Plains  Precinct,Governor,,D,Paul Davis,2
-Smith,Dor  Precinct,Governor,,D,Paul Davis,4
-Smith,Garfield  Precinct,Governor,,D,Paul Davis,1
-Smith,German  Precinct,Governor,,D,Paul Davis,2
-Smith,Harlan  Precinct,Governor,,D,Paul Davis,6
-Smith,Harvey  Precinct,Governor,,D,Paul Davis,8
-Smith,Houston  Precinct,Governor,,D,Paul Davis,25
-Smith,Lane  Precinct,Governor,,D,Paul Davis,21
-Smith,Lincoln  Precinct,Governor,,D,Paul Davis,9
-Smith,Logan  Precinct,Governor,,D,Paul Davis,7
-Smith,Martin  Precinct,Governor,,D,Paul Davis,3
-Smith,Oak  Precinct,Governor,,D,Paul Davis,26
-Smith,Pawnee  Precinct,Governor,,D,Paul Davis,3
-Smith,Pleasant  Precinct,Governor,,D,Paul Davis,6
-Smith,Swan  Precinct,Governor,,D,Paul Davis,7
-Smith,Valley  Precinct,Governor,,D,Paul Davis,5
-Smith,Washington  Precinct,Governor,,D,Paul Davis,1
-Smith,Webster  Precinct,Governor,,D,Paul Davis,1
-Smith,White  Rock  Precinct,Governor,,D,Paul Davis,4
-Smith,Banner  Precinct,Governor,,L,Keen Umbehr,2
-Smith,Beaver  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Blaine  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Cedar  Precinct,Governor,,L,Keen Umbehr,14
-Smith,Center 1,Governor,,L,Keen Umbehr,9
-Smith,Center 2,Governor,,L,Keen Umbehr,15
-Smith,Center 3,Governor,,L,Keen Umbehr,13
-Smith,Center 4,Governor,,L,Keen Umbehr,5
-Smith,Cora  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Crystal   Plains  Precinct,Governor,,L,Keen Umbehr,1
-Smith,Dor  Precinct,Governor,,L,Keen Umbehr,1
-Smith,Garfield  Precinct,Governor,,L,Keen Umbehr,0
-Smith,German  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Harlan  Precinct,Governor,,L,Keen Umbehr,1
-Smith,Harvey  Precinct,Governor,,L,Keen Umbehr,4
-Smith,Houston  Precinct,Governor,,L,Keen Umbehr,1
-Smith,Lane  Precinct,Governor,,L,Keen Umbehr,3
-Smith,Lincoln  Precinct,Governor,,L,Keen Umbehr,1
-Smith,Logan  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Martin  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Oak  Precinct,Governor,,L,Keen Umbehr,10
-Smith,Pawnee  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Pleasant  Precinct,Governor,,L,Keen Umbehr,1
-Smith,Swan  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Valley  Precinct,Governor,,L,Keen Umbehr,2
-Smith,Washington  Precinct,Governor,,L,Keen Umbehr,1
-Smith,Webster  Precinct,Governor,,L,Keen Umbehr,0
-Smith,White  Rock  Precinct,Governor,,L,Keen Umbehr,0
-Smith,Banner  Precinct,Secretary of State,,R,Kris Kobach,22
-Smith,Beaver  Precinct,Secretary of State,,R,Kris Kobach,23
-Smith,Blaine  Precinct,Secretary of State,,R,Kris Kobach,20
-Smith,Cedar  Precinct,Secretary of State,,R,Kris Kobach,162
-Smith,Center 1,Secretary of State,,R,Kris Kobach,187
-Smith,Center 2,Secretary of State,,R,Kris Kobach,217
-Smith,Center 3,Secretary of State,,R,Kris Kobach,159
-Smith,Center 4,Secretary of State,,R,Kris Kobach,49
-Smith,Cora  Precinct,Secretary of State,,R,Kris Kobach,9
-Smith,Crystal   Plains  Precinct,Secretary of State,,R,Kris Kobach,8
-Smith,Dor  Precinct,Secretary of State,,R,Kris Kobach,17
-Smith,Garfield  Precinct,Secretary of State,,R,Kris Kobach,9
-Smith,German  Precinct,Secretary of State,,R,Kris Kobach,6
-Smith,Harlan  Precinct,Secretary of State,,R,Kris Kobach,30
-Smith,Harvey  Precinct,Secretary of State,,R,Kris Kobach,50
-Smith,Houston  Precinct,Secretary of State,,R,Kris Kobach,50
-Smith,Lane  Precinct,Secretary of State,,R,Kris Kobach,29
-Smith,Lincoln  Precinct,Secretary of State,,R,Kris Kobach,32
-Smith,Logan  Precinct,Secretary of State,,R,Kris Kobach,9
-Smith,Martin  Precinct,Secretary of State,,R,Kris Kobach,6
-Smith,Oak  Precinct,Secretary of State,,R,Kris Kobach,101
-Smith,Pawnee  Precinct,Secretary of State,,R,Kris Kobach,13
-Smith,Pleasant  Precinct,Secretary of State,,R,Kris Kobach,16
-Smith,Swan  Precinct,Secretary of State,,R,Kris Kobach,12
-Smith,Valley  Precinct,Secretary of State,,R,Kris Kobach,20
-Smith,Washington  Precinct,Secretary of State,,R,Kris Kobach,17
-Smith,Webster  Precinct,Secretary of State,,R,Kris Kobach,21
-Smith,White  Rock  Precinct,Secretary of State,,R,Kris Kobach,20
-Smith,Banner  Precinct,Secretary of State,,D,Jean Schodorf,5
-Smith,Beaver  Precinct,Secretary of State,,D,Jean Schodorf,3
-Smith,Blaine  Precinct,Secretary of State,,D,Jean Schodorf,3
-Smith,Cedar  Precinct,Secretary of State,,D,Jean Schodorf,55
-Smith,Center 1,Secretary of State,,D,Jean Schodorf,59
-Smith,Center 2,Secretary of State,,D,Jean Schodorf,77
-Smith,Center 3,Secretary of State,,D,Jean Schodorf,41
-Smith,Center 4,Secretary of State,,D,Jean Schodorf,7
-Smith,Cora  Precinct,Secretary of State,,D,Jean Schodorf,1
-Smith,Crystal   Plains  Precinct,Secretary of State,,D,Jean Schodorf,4
-Smith,Dor  Precinct,Secretary of State,,D,Jean Schodorf,4
-Smith,Garfield  Precinct,Secretary of State,,D,Jean Schodorf,3
-Smith,German  Precinct,Secretary of State,,D,Jean Schodorf,1
-Smith,Harlan  Precinct,Secretary of State,,D,Jean Schodorf,8
-Smith,Harvey  Precinct,Secretary of State,,D,Jean Schodorf,7
-Smith,Houston  Precinct,Secretary of State,,D,Jean Schodorf,11
-Smith,Lane  Precinct,Secretary of State,,D,Jean Schodorf,20
-Smith,Lincoln  Precinct,Secretary of State,,D,Jean Schodorf,6
-Smith,Logan  Precinct,Secretary of State,,D,Jean Schodorf,8
-Smith,Martin  Precinct,Secretary of State,,D,Jean Schodorf,1
-Smith,Oak  Precinct,Secretary of State,,D,Jean Schodorf,19
-Smith,Pawnee  Precinct,Secretary of State,,D,Jean Schodorf,2
-Smith,Pleasant  Precinct,Secretary of State,,D,Jean Schodorf,2
-Smith,Swan  Precinct,Secretary of State,,D,Jean Schodorf,4
-Smith,Valley  Precinct,Secretary of State,,D,Jean Schodorf,5
-Smith,Washington  Precinct,Secretary of State,,D,Jean Schodorf,0
-Smith,Webster  Precinct,Secretary of State,,D,Jean Schodorf,1
-Smith,White  Rock  Precinct,Secretary of State,,D,Jean Schodorf,3
-COUNTY,PRECINCT,Attorney General,,D,Jean Schodorf,360
-Smith,Banner  Precinct,Attorney General,,R,Derek Schmidt,24
-Smith,Beaver  Precinct,Attorney General,,R,Derek Schmidt,22
-Smith,Blaine  Precinct,Attorney General,,R,Derek Schmidt,23
-Smith,Cedar  Precinct,Attorney General,,R,Derek Schmidt,169
-Smith,Center 1,Attorney General,,R,Derek Schmidt,199
-Smith,Center 2,Attorney General,,R,Derek Schmidt,229
-Smith,Center 3,Attorney General,,R,Derek Schmidt,170
-Smith,Center 4,Attorney General,,R,Derek Schmidt,46
-Smith,Cora  Precinct,Attorney General,,R,Derek Schmidt,11
-Smith,Crystal   Plains  Precinct,Attorney General,,R,Derek Schmidt,9
-Smith,Dor  Precinct,Attorney General,,R,Derek Schmidt,16
-Smith,Garfield  Precinct,Attorney General,,R,Derek Schmidt,11
-Smith,German  Precinct,Attorney General,,R,Derek Schmidt,7
-Smith,Harlan  Precinct,Attorney General,,R,Derek Schmidt,35
-Smith,Harvey  Precinct,Attorney General,,R,Derek Schmidt,51
-Smith,Houston  Precinct,Attorney General,,R,Derek Schmidt,52
-Smith,Lane  Precinct,Attorney General,,R,Derek Schmidt,30
-Smith,Lincoln  Precinct,Attorney General,,R,Derek Schmidt,33
-Smith,Logan  Precinct,Attorney General,,R,Derek Schmidt,11
-Smith,Martin  Precinct,Attorney General,,R,Derek Schmidt,6
-Smith,Oak  Precinct,Attorney General,,R,Derek Schmidt,101
-Smith,Pawnee  Precinct,Attorney General,,R,Derek Schmidt,13
-Smith,Pleasant  Precinct,Attorney General,,R,Derek Schmidt,13
-Smith,Swan  Precinct,Attorney General,,R,Derek Schmidt,11
-Smith,Valley  Precinct,Attorney General,,R,Derek Schmidt,21
-Smith,Washington  Precinct,Attorney General,,R,Derek Schmidt,17
-Smith,Webster  Precinct,Attorney General,,R,Derek Schmidt,21
-Smith,White  Rock  Precinct,Attorney General,,R,Derek Schmidt,22
-Smith,Banner  Precinct,Attorney General,,D,AJ Kotich,4
-Smith,Beaver  Precinct,Attorney General,,D,AJ Kotich,3
-Smith,Blaine  Precinct,Attorney General,,D,AJ Kotich,1
-Smith,Cedar  Precinct,Attorney General,,D,AJ Kotich,45
-Smith,Center 1,Attorney General,,D,AJ Kotich,44
-Smith,Center 2,Attorney General,,D,AJ Kotich,62
-Smith,Center 3,Attorney General,,D,AJ Kotich,24
-Smith,Center 4,Attorney General,,D,AJ Kotich,7
-Smith,Cora  Precinct,Attorney General,,D,AJ Kotich,0
-Smith,Crystal   Plains  Precinct,Attorney General,,D,AJ Kotich,2
-Smith,Dor  Precinct,Attorney General,,D,AJ Kotich,5
-Smith,Garfield  Precinct,Attorney General,,D,AJ Kotich,1
-Smith,German  Precinct,Attorney General,,D,AJ Kotich,0
-Smith,Harlan  Precinct,Attorney General,,D,AJ Kotich,3
-Smith,Harvey  Precinct,Attorney General,,D,AJ Kotich,7
-Smith,Houston  Precinct,Attorney General,,D,AJ Kotich,8
-Smith,Lane  Precinct,Attorney General,,D,AJ Kotich,19
-Smith,Lincoln  Precinct,Attorney General,,D,AJ Kotich,5
-Smith,Logan  Precinct,Attorney General,,D,AJ Kotich,6
-Smith,Martin  Precinct,Attorney General,,D,AJ Kotich,1
-Smith,Oak  Precinct,Attorney General,,D,AJ Kotich,17
-Smith,Pawnee  Precinct,Attorney General,,D,AJ Kotich,2
-Smith,Pleasant  Precinct,Attorney General,,D,AJ Kotich,4
-Smith,Swan  Precinct,Attorney General,,D,AJ Kotich,4
-Smith,Valley  Precinct,Attorney General,,D,AJ Kotich,3
-Smith,Washington  Precinct,Attorney General,,D,AJ Kotich,0
-Smith,Webster  Precinct,Attorney General,,D,AJ Kotich,1
-Smith,White  Rock  Precinct,Attorney General,,D,AJ Kotich,1
-Smith,Banner  Precinct,State Treasurer,,R,Ron Estes,22
-Smith,Beaver  Precinct,State Treasurer,,R,Ron Estes,24
-Smith,Blaine  Precinct,State Treasurer,,R,Ron Estes,23
-Smith,Cedar  Precinct,State Treasurer,,R,Ron Estes,167
-Smith,Center 1,State Treasurer,,R,Ron Estes,190
-Smith,Center 2,State Treasurer,,R,Ron Estes,230
-Smith,Center 3,State Treasurer,,R,Ron Estes,165
-Smith,Center 4,State Treasurer,,R,Ron Estes,45
-Smith,Cora  Precinct,State Treasurer,,R,Ron Estes,11
-Smith,Crystal   Plains  Precinct,State Treasurer,,R,Ron Estes,8
-Smith,Dor  Precinct,State Treasurer,,R,Ron Estes,17
-Smith,Garfield  Precinct,State Treasurer,,R,Ron Estes,10
-Smith,German  Precinct,State Treasurer,,R,Ron Estes,6
-Smith,Harlan  Precinct,State Treasurer,,R,Ron Estes,34
-Smith,Harvey  Precinct,State Treasurer,,R,Ron Estes,51
-Smith,Houston  Precinct,State Treasurer,,R,Ron Estes,50
-Smith,Lane  Precinct,State Treasurer,,R,Ron Estes,31
-Smith,Lincoln  Precinct,State Treasurer,,R,Ron Estes,31
-Smith,Logan  Precinct,State Treasurer,,R,Ron Estes,11
-Smith,Martin  Precinct,State Treasurer,,R,Ron Estes,4
-Smith,Oak  Precinct,State Treasurer,,R,Ron Estes,105
-Smith,Pawnee  Precinct,State Treasurer,,R,Ron Estes,15
-Smith,Pleasant  Precinct,State Treasurer,,R,Ron Estes,13
-Smith,Swan  Precinct,State Treasurer,,R,Ron Estes,13
-Smith,Valley  Precinct,State Treasurer,,R,Ron Estes,21
-Smith,Washington  Precinct,State Treasurer,,R,Ron Estes,17
-Smith,Webster  Precinct,State Treasurer,,R,Ron Estes,21
-Smith,White  Rock  Precinct,State Treasurer,,R,Ron Estes,22
-Smith,Banner  Precinct,State Treasurer,,D,Carmen Alldritt,4
-Smith,Beaver  Precinct,State Treasurer,,D,Carmen Alldritt,2
-Smith,Blaine  Precinct,State Treasurer,,D,Carmen Alldritt,1
-Smith,Cedar  Precinct,State Treasurer,,D,Carmen Alldritt,47
-Smith,Center 1,State Treasurer,,D,Carmen Alldritt,46
-Smith,Center 2,State Treasurer,,D,Carmen Alldritt,61
-Smith,Center 3,State Treasurer,,D,Carmen Alldritt,31
-Smith,Center 4,State Treasurer,,D,Carmen Alldritt,9
-Smith,Cora  Precinct,State Treasurer,,D,Carmen Alldritt,0
-Smith,Crystal   Plains  Precinct,State Treasurer,,D,Carmen Alldritt,4
-Smith,Dor  Precinct,State Treasurer,,D,Carmen Alldritt,5
-Smith,Garfield  Precinct,State Treasurer,,D,Carmen Alldritt,1
-Smith,German  Precinct,State Treasurer,,D,Carmen Alldritt,1
-Smith,Harlan  Precinct,State Treasurer,,D,Carmen Alldritt,4
-Smith,Harvey  Precinct,State Treasurer,,D,Carmen Alldritt,7
-Smith,Houston  Precinct,State Treasurer,,D,Carmen Alldritt,9
-Smith,Lane  Precinct,State Treasurer,,D,Carmen Alldritt,18
-Smith,Lincoln  Precinct,State Treasurer,,D,Carmen Alldritt,6
-Smith,Logan  Precinct,State Treasurer,,D,Carmen Alldritt,6
-Smith,Martin  Precinct,State Treasurer,,D,Carmen Alldritt,3
-Smith,Oak  Precinct,State Treasurer,,D,Carmen Alldritt,15
-Smith,Pawnee  Precinct,State Treasurer,,D,Carmen Alldritt,1
-Smith,Pleasant  Precinct,State Treasurer,,D,Carmen Alldritt,4
-Smith,Swan  Precinct,State Treasurer,,D,Carmen Alldritt,3
-Smith,Valley  Precinct,State Treasurer,,D,Carmen Alldritt,4
-Smith,Washington  Precinct,State Treasurer,,D,Carmen Alldritt,0
-Smith,Webster  Precinct,State Treasurer,,D,Carmen Alldritt,1
-Smith,White  Rock  Precinct,State Treasurer,,D,Carmen Alldritt,0
-Smith,Banner  Precinct,Insurance Commissioner,,R,Ken Selzer,18
-Smith,Beaver  Precinct,Insurance Commissioner,,R,Ken Selzer,17
-Smith,Blaine  Precinct,Insurance Commissioner,,R,Ken Selzer,19
-Smith,Cedar  Precinct,Insurance Commissioner,,R,Ken Selzer,154
-Smith,Center 1,Insurance Commissioner,,R,Ken Selzer,139
-Smith,Center 2,Insurance Commissioner,,R,Ken Selzer,171
-Smith,Center 3,Insurance Commissioner,,R,Ken Selzer,130
-Smith,Center 4,Insurance Commissioner,,R,Ken Selzer,33
-Smith,Cora  Precinct,Insurance Commissioner,,R,Ken Selzer,8
-Smith,Crystal   Plains  Precinct,Insurance Commissioner,,R,Ken Selzer,5
-Smith,Dor  Precinct,Insurance Commissioner,,R,Ken Selzer,15
-Smith,Garfield  Precinct,Insurance Commissioner,,R,Ken Selzer,8
-Smith,German  Precinct,Insurance Commissioner,,R,Ken Selzer,5
-Smith,Harlan  Precinct,Insurance Commissioner,,R,Ken Selzer,26
-Smith,Harvey  Precinct,Insurance Commissioner,,R,Ken Selzer,48
-Smith,Houston  Precinct,Insurance Commissioner,,R,Ken Selzer,38
-Smith,Lane  Precinct,Insurance Commissioner,,R,Ken Selzer,26
-Smith,Lincoln  Precinct,Insurance Commissioner,,R,Ken Selzer,30
-Smith,Logan  Precinct,Insurance Commissioner,,R,Ken Selzer,10
-Smith,Martin  Precinct,Insurance Commissioner,,R,Ken Selzer,4
-Smith,Oak  Precinct,Insurance Commissioner,,R,Ken Selzer,89
-Smith,Pawnee  Precinct,Insurance Commissioner,,R,Ken Selzer,13
-Smith,Pleasant  Precinct,Insurance Commissioner,,R,Ken Selzer,15
-Smith,Swan  Precinct,Insurance Commissioner,,R,Ken Selzer,12
-Smith,Valley  Precinct,Insurance Commissioner,,R,Ken Selzer,20
-Smith,Washington  Precinct,Insurance Commissioner,,R,Ken Selzer,16
-Smith,Webster  Precinct,Insurance Commissioner,,R,Ken Selzer,18
-Smith,White  Rock  Precinct,Insurance Commissioner,,R,Ken Selzer,19
-COUNTY,PRECINCT,Insurance Commissioner,,R,Ken Selzer,1106
-Smith,Banner  Precinct,Insurance Commissioner,,D,Dennis Anderson,8
-Smith,Beaver  Precinct,Insurance Commissioner,,D,Dennis Anderson,7
-Smith,Blaine  Precinct,Insurance Commissioner,,D,Dennis Anderson,5
-Smith,Cedar  Precinct,Insurance Commissioner,,D,Dennis Anderson,56
-Smith,Center 1,Insurance Commissioner,,D,Dennis Anderson,109
-Smith,Center 2,Insurance Commissioner,,D,Dennis Anderson,121
-Smith,Center 3,Insurance Commissioner,,D,Dennis Anderson,66
-Smith,Center 4,Insurance Commissioner,,D,Dennis Anderson,21
-Smith,Cora  Precinct,Insurance Commissioner,,D,Dennis Anderson,5
-Smith,Crystal   Plains  Precinct,Insurance Commissioner,,D,Dennis Anderson,7
-Smith,Dor  Precinct,Insurance Commissioner,,D,Dennis Anderson,6
-Smith,Garfield  Precinct,Insurance Commissioner,,D,Dennis Anderson,4
-Smith,German  Precinct,Insurance Commissioner,,D,Dennis Anderson,2
-Smith,Harlan  Precinct,Insurance Commissioner,,D,Dennis Anderson,11
-Smith,Harvey  Precinct,Insurance Commissioner,,D,Dennis Anderson,11
-Smith,Houston  Precinct,Insurance Commissioner,,D,Dennis Anderson,23
-Smith,Lane  Precinct,Insurance Commissioner,,D,Dennis Anderson,22
-Smith,Lincoln  Precinct,Insurance Commissioner,,D,Dennis Anderson,6
-Smith,Logan  Precinct,Insurance Commissioner,,D,Dennis Anderson,7
-Smith,Martin  Precinct,Insurance Commissioner,,D,Dennis Anderson,3
-Smith,Oak  Precinct,Insurance Commissioner,,D,Dennis Anderson,31
-Smith,Pawnee  Precinct,Insurance Commissioner,,D,Dennis Anderson,2
-Smith,Pleasant  Precinct,Insurance Commissioner,,D,Dennis Anderson,2
-Smith,Swan  Precinct,Insurance Commissioner,,D,Dennis Anderson,3
-Smith,Valley  Precinct,Insurance Commissioner,,D,Dennis Anderson,5
-Smith,Washington  Precinct,Insurance Commissioner,,D,Dennis Anderson,2
-Smith,Webster  Precinct,Insurance Commissioner,,D,Dennis Anderson,3
-Smith,White  Rock  Precinct,Insurance Commissioner,,D,Dennis Anderson,3
-Smith,Banner  Precinct,State House,109,R,Troy Waymaster,23
-Smith,Beaver  Precinct,State House,109,R,Troy Waymaster,24
-Smith,Blaine  Precinct,State House,109,R,Troy Waymaster,22
-Smith,Cedar  Precinct,State House,109,R,Troy Waymaster,188
-Smith,Center 1,State House,109,R,Troy Waymaster,217
-Smith,Center 2,State House,109,R,Troy Waymaster,252
-Smith,Center 3,State House,109,R,Troy Waymaster,176
-Smith,Center 4,State House,109,R,Troy Waymaster,53
-Smith,Cora  Precinct,State House,109,R,Troy Waymaster,10
-Smith,Crystal   Plains  Precinct,State House,109,R,Troy Waymaster,11
-Smith,Dor  Precinct,State House,109,R,Troy Waymaster,20
-Smith,Garfield  Precinct,State House,109,R,Troy Waymaster,12
-Smith,German  Precinct,State House,109,R,Troy Waymaster,6
-Smith,Harlan  Precinct,State House,109,R,Troy Waymaster,35
-Smith,Harvey  Precinct,State House,109,R,Troy Waymaster,58
-Smith,Houston  Precinct,State House,109,R,Troy Waymaster,51
-Smith,Lane  Precinct,State House,109,R,Troy Waymaster,41
-Smith,Lincoln  Precinct,State House,109,R,Troy Waymaster,34
-Smith,Logan  Precinct,State House,109,R,Troy Waymaster,13
-Smith,Martin  Precinct,State House,109,R,Troy Waymaster,6
-Smith,Oak  Precinct,State House,109,R,Troy Waymaster,111
-Smith,Pawnee  Precinct,State House,109,R,Troy Waymaster,13
-Smith,Pleasant  Precinct,State House,109,R,Troy Waymaster,13
-Smith,Swan  Precinct,State House,109,R,Troy Waymaster,11
-Smith,Valley  Precinct,State House,109,R,Troy Waymaster,23
-Smith,Washington  Precinct,State House,109,R,Troy Waymaster,19
-Smith,Webster  Precinct,State House,109,R,Troy Waymaster,21
-Smith,White  Rock  Precinct,State House,109,R,Troy Waymaster,21
+county,precinct,office,district,party,candidate,votes,vtd
+SMITH,Banner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000010
+SMITH,Banner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000010
+SMITH,Banner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000010
+SMITH,Beaver Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000020
+SMITH,Beaver Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+SMITH,Beaver Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000020
+SMITH,Blaine Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000030
+SMITH,Blaine Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+SMITH,Blaine Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000030
+SMITH,Cedar Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",77,000040
+SMITH,Cedar Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000040
+SMITH,Cedar Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000040
+SMITH,Cora Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000070
+SMITH,Cora Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000070
+SMITH,Cora Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000070
+SMITH,Crystal Plains Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000080
+SMITH,Crystal Plains Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+SMITH,Crystal Plains Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",10,000080
+SMITH,Dor Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000090
+SMITH,Dor Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+SMITH,Dor Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000090
+SMITH,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000100
+SMITH,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000100
+SMITH,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000100
+SMITH,German Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000110
+SMITH,German Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+SMITH,German Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,000110
+SMITH,Harlan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000120
+SMITH,Harlan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000120
+SMITH,Harlan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000120
+SMITH,Harvey Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000130
+SMITH,Harvey Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000130
+SMITH,Harvey Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000130
+SMITH,Houston Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000140
+SMITH,Houston Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+SMITH,Houston Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000140
+SMITH,Lane Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",21,000150
+SMITH,Lane Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000150
+SMITH,Lane Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000150
+SMITH,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000160
+SMITH,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000160
+SMITH,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000160
+SMITH,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000170
+SMITH,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000170
+SMITH,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000170
+SMITH,Martin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000180
+SMITH,Martin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000180
+SMITH,Martin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,000180
+SMITH,Pawnee Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000210
+SMITH,Pawnee Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000210
+SMITH,Pawnee Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000210
+SMITH,Pleasant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000220
+SMITH,Pleasant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000220
+SMITH,Pleasant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000220
+SMITH,Swan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000230
+SMITH,Swan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+SMITH,Swan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000230
+SMITH,Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000240
+SMITH,Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000240
+SMITH,Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000240
+SMITH,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000250
+SMITH,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000250
+SMITH,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",17,000250
+SMITH,Webster Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000260
+SMITH,Webster Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000260
+SMITH,Webster Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",22,000260
+SMITH,White Rock Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000270
+SMITH,White Rock Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000270
+SMITH,White Rock Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000270
+SMITH,Oak Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,130010
+SMITH,Oak Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,130010
+SMITH,Oak Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,130010
+SMITH,Center 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,140010
+SMITH,Center 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,140010
+SMITH,Center 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",152,140010
+SMITH,Center 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",112,140020
+SMITH,Center 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,140020
+SMITH,Center 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",175,140020
+SMITH,Center 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,140030
+SMITH,Center 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,140030
+SMITH,Center 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,140030
+SMITH,Center 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,140040
+SMITH,Center 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,140040
+SMITH,Center 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,140040
+SMITH,Banner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",23,000010
+SMITH,Beaver Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000020
+SMITH,Blaine Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",22,000030
+SMITH,Cedar Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",188,000040
+SMITH,Cora Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000070
+SMITH,Crystal Plains Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",11,000080
+SMITH,Dor Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",20,000090
+SMITH,Garfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",12,000100
+SMITH,German Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",6,000110
+SMITH,Harlan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",35,000120
+SMITH,Harvey Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",58,000130
+SMITH,Houston Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",51,000140
+SMITH,Lane Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",41,000150
+SMITH,Lincoln Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",34,000160
+SMITH,Logan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000170
+SMITH,Martin Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",6,000180
+SMITH,Pawnee Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000210
+SMITH,Pleasant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000220
+SMITH,Swan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",11,000230
+SMITH,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",23,000240
+SMITH,Washington Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",19,000250
+SMITH,Webster Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000260
+SMITH,White Rock Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000270
+SMITH,Oak Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",111,130010
+SMITH,Center 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",217,140010
+SMITH,Center 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",252,140020
+SMITH,Center 3,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",176,140030
+SMITH,Center 4,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",53,140040
+SMITH,Banner Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000010
+SMITH,Banner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000010
+SMITH,Beaver Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000020
+SMITH,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000020
+SMITH,Blaine Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000030
+SMITH,Blaine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000030
+SMITH,Cedar Township,United States House of Representatives,1,Democratic,"Sherow, James E.",59,000040
+SMITH,Cedar Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",158,000040
+SMITH,Cora Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000070
+SMITH,Cora Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000070
+SMITH,Crystal Plains Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000080
+SMITH,Crystal Plains Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000080
+SMITH,Dor Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000090
+SMITH,Dor Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000090
+SMITH,Garfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000100
+SMITH,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000100
+SMITH,German Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000110
+SMITH,German Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,000110
+SMITH,Harlan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000120
+SMITH,Harlan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000120
+SMITH,Harvey Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000130
+SMITH,Harvey Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000130
+SMITH,Houston Township,United States House of Representatives,1,Democratic,"Sherow, James E.",13,000140
+SMITH,Houston Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000140
+SMITH,Lane Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000150
+SMITH,Lane Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000150
+SMITH,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000160
+SMITH,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000160
+SMITH,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000170
+SMITH,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000170
+SMITH,Martin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000180
+SMITH,Martin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,000180
+SMITH,Pawnee Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000210
+SMITH,Pawnee Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000210
+SMITH,Pleasant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000220
+SMITH,Pleasant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000220
+SMITH,Swan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000230
+SMITH,Swan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000230
+SMITH,Valley Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000240
+SMITH,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000240
+SMITH,Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000250
+SMITH,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000250
+SMITH,Webster Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000260
+SMITH,Webster Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000260
+SMITH,White Rock Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000270
+SMITH,White Rock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000270
+SMITH,Oak Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,130010
+SMITH,Oak Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",100,130010
+SMITH,Center 1,United States House of Representatives,1,Democratic,"Sherow, James E.",63,140010
+SMITH,Center 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",188,140010
+SMITH,Center 2,United States House of Representatives,1,Democratic,"Sherow, James E.",84,140020
+SMITH,Center 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",220,140020
+SMITH,Center 3,United States House of Representatives,1,Democratic,"Sherow, James E.",44,140030
+SMITH,Center 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",155,140030
+SMITH,Center 4,United States House of Representatives,1,Democratic,"Sherow, James E.",13,140040
+SMITH,Center 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,140040
+SMITH,Banner Township,Attorney General,,Democratic,"Kotich, A.J.",4,000010
+SMITH,Banner Township,Attorney General,,Republican,"Schmidt, Derek",24,000010
+SMITH,Beaver Township,Attorney General,,Democratic,"Kotich, A.J.",3,000020
+SMITH,Beaver Township,Attorney General,,Republican,"Schmidt, Derek",22,000020
+SMITH,Blaine Township,Attorney General,,Democratic,"Kotich, A.J.",1,000030
+SMITH,Blaine Township,Attorney General,,Republican,"Schmidt, Derek",23,000030
+SMITH,Cedar Township,Attorney General,,Democratic,"Kotich, A.J.",45,000040
+SMITH,Cedar Township,Attorney General,,Republican,"Schmidt, Derek",169,000040
+SMITH,Cora Township,Attorney General,,Democratic,"Kotich, A.J.",0,000070
+SMITH,Cora Township,Attorney General,,Republican,"Schmidt, Derek",11,000070
+SMITH,Crystal Plains Township,Attorney General,,Democratic,"Kotich, A.J.",2,000080
+SMITH,Crystal Plains Township,Attorney General,,Republican,"Schmidt, Derek",9,000080
+SMITH,Dor Township,Attorney General,,Democratic,"Kotich, A.J.",5,000090
+SMITH,Dor Township,Attorney General,,Republican,"Schmidt, Derek",16,000090
+SMITH,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",1,000100
+SMITH,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",11,000100
+SMITH,German Township,Attorney General,,Democratic,"Kotich, A.J.",0,000110
+SMITH,German Township,Attorney General,,Republican,"Schmidt, Derek",7,000110
+SMITH,Harlan Township,Attorney General,,Democratic,"Kotich, A.J.",3,000120
+SMITH,Harlan Township,Attorney General,,Republican,"Schmidt, Derek",35,000120
+SMITH,Harvey Township,Attorney General,,Democratic,"Kotich, A.J.",7,000130
+SMITH,Harvey Township,Attorney General,,Republican,"Schmidt, Derek",51,000130
+SMITH,Houston Township,Attorney General,,Democratic,"Kotich, A.J.",8,000140
+SMITH,Houston Township,Attorney General,,Republican,"Schmidt, Derek",52,000140
+SMITH,Lane Township,Attorney General,,Democratic,"Kotich, A.J.",19,000150
+SMITH,Lane Township,Attorney General,,Republican,"Schmidt, Derek",30,000150
+SMITH,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",5,000160
+SMITH,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",33,000160
+SMITH,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",6,000170
+SMITH,Logan Township,Attorney General,,Republican,"Schmidt, Derek",11,000170
+SMITH,Martin Township,Attorney General,,Democratic,"Kotich, A.J.",1,000180
+SMITH,Martin Township,Attorney General,,Republican,"Schmidt, Derek",6,000180
+SMITH,Pawnee Township,Attorney General,,Democratic,"Kotich, A.J.",2,000210
+SMITH,Pawnee Township,Attorney General,,Republican,"Schmidt, Derek",13,000210
+SMITH,Pleasant Township,Attorney General,,Democratic,"Kotich, A.J.",4,000220
+SMITH,Pleasant Township,Attorney General,,Republican,"Schmidt, Derek",13,000220
+SMITH,Swan Township,Attorney General,,Democratic,"Kotich, A.J.",4,000230
+SMITH,Swan Township,Attorney General,,Republican,"Schmidt, Derek",11,000230
+SMITH,Valley Township,Attorney General,,Democratic,"Kotich, A.J.",3,000240
+SMITH,Valley Township,Attorney General,,Republican,"Schmidt, Derek",21,000240
+SMITH,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",0,000250
+SMITH,Washington Township,Attorney General,,Republican,"Schmidt, Derek",17,000250
+SMITH,Webster Township,Attorney General,,Democratic,"Kotich, A.J.",1,000260
+SMITH,Webster Township,Attorney General,,Republican,"Schmidt, Derek",21,000260
+SMITH,White Rock Township,Attorney General,,Democratic,"Kotich, A.J.",1,000270
+SMITH,White Rock Township,Attorney General,,Republican,"Schmidt, Derek",22,000270
+SMITH,Oak Township,Attorney General,,Democratic,"Kotich, A.J.",17,130010
+SMITH,Oak Township,Attorney General,,Republican,"Schmidt, Derek",101,130010
+SMITH,Center 1,Attorney General,,Democratic,"Kotich, A.J.",44,140010
+SMITH,Center 1,Attorney General,,Republican,"Schmidt, Derek",199,140010
+SMITH,Center 2,Attorney General,,Democratic,"Kotich, A.J.",62,140020
+SMITH,Center 2,Attorney General,,Republican,"Schmidt, Derek",229,140020
+SMITH,Center 3,Attorney General,,Democratic,"Kotich, A.J.",24,140030
+SMITH,Center 3,Attorney General,,Republican,"Schmidt, Derek",170,140030
+SMITH,Center 4,Attorney General,,Democratic,"Kotich, A.J.",7,140040
+SMITH,Center 4,Attorney General,,Republican,"Schmidt, Derek",46,140040
+SMITH,Banner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000010
+SMITH,Banner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000010
+SMITH,Beaver Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000020
+SMITH,Beaver Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000020
+SMITH,Blaine Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000030
+SMITH,Blaine Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000030
+SMITH,Cedar Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",56,000040
+SMITH,Cedar Township,Commissioner of Insurance,,Republican,"Selzer, Ken",154,000040
+SMITH,Cora Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000070
+SMITH,Cora Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000070
+SMITH,Crystal Plains Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000080
+SMITH,Crystal Plains Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,000080
+SMITH,Dor Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000090
+SMITH,Dor Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000090
+SMITH,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000100
+SMITH,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000100
+SMITH,German Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000110
+SMITH,German Township,Commissioner of Insurance,,Republican,"Selzer, Ken",5,000110
+SMITH,Harlan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000120
+SMITH,Harlan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000120
+SMITH,Harvey Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000130
+SMITH,Harvey Township,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000130
+SMITH,Houston Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000140
+SMITH,Houston Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000140
+SMITH,Lane Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000150
+SMITH,Lane Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000150
+SMITH,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000160
+SMITH,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",30,000160
+SMITH,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000170
+SMITH,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",10,000170
+SMITH,Martin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000180
+SMITH,Martin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",4,000180
+SMITH,Pawnee Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000210
+SMITH,Pawnee Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000210
+SMITH,Pleasant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000220
+SMITH,Pleasant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000220
+SMITH,Swan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000230
+SMITH,Swan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000230
+SMITH,Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000240
+SMITH,Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000240
+SMITH,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000250
+SMITH,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000250
+SMITH,Webster Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000260
+SMITH,Webster Township,Commissioner of Insurance,,Republican,"Selzer, Ken",18,000260
+SMITH,White Rock Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000270
+SMITH,White Rock Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000270
+SMITH,Oak Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,130010
+SMITH,Oak Township,Commissioner of Insurance,,Republican,"Selzer, Ken",89,130010
+SMITH,Center 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",109,140010
+SMITH,Center 1,Commissioner of Insurance,,Republican,"Selzer, Ken",139,140010
+SMITH,Center 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",121,140020
+SMITH,Center 2,Commissioner of Insurance,,Republican,"Selzer, Ken",171,140020
+SMITH,Center 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",66,140030
+SMITH,Center 3,Commissioner of Insurance,,Republican,"Selzer, Ken",130,140030
+SMITH,Center 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,140040
+SMITH,Center 4,Commissioner of Insurance,,Republican,"Selzer, Ken",33,140040
+SMITH,Banner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000010
+SMITH,Banner Township,Secretary of State,,Republican,"Kobach, Kris",22,000010
+SMITH,Beaver Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000020
+SMITH,Beaver Township,Secretary of State,,Republican,"Kobach, Kris",23,000020
+SMITH,Blaine Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000030
+SMITH,Blaine Township,Secretary of State,,Republican,"Kobach, Kris",20,000030
+SMITH,Cedar Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000040
+SMITH,Cedar Township,Secretary of State,,Republican,"Kobach, Kris",162,000040
+SMITH,Cora Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000070
+SMITH,Cora Township,Secretary of State,,Republican,"Kobach, Kris",9,000070
+SMITH,Crystal Plains Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000080
+SMITH,Crystal Plains Township,Secretary of State,,Republican,"Kobach, Kris",8,000080
+SMITH,Dor Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000090
+SMITH,Dor Township,Secretary of State,,Republican,"Kobach, Kris",17,000090
+SMITH,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000100
+SMITH,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",9,000100
+SMITH,German Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000110
+SMITH,German Township,Secretary of State,,Republican,"Kobach, Kris",6,000110
+SMITH,Harlan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000120
+SMITH,Harlan Township,Secretary of State,,Republican,"Kobach, Kris",30,000120
+SMITH,Harvey Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000130
+SMITH,Harvey Township,Secretary of State,,Republican,"Kobach, Kris",50,000130
+SMITH,Houston Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000140
+SMITH,Houston Township,Secretary of State,,Republican,"Kobach, Kris",50,000140
+SMITH,Lane Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000150
+SMITH,Lane Township,Secretary of State,,Republican,"Kobach, Kris",29,000150
+SMITH,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000160
+SMITH,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",32,000160
+SMITH,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000170
+SMITH,Logan Township,Secretary of State,,Republican,"Kobach, Kris",9,000170
+SMITH,Martin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000180
+SMITH,Martin Township,Secretary of State,,Republican,"Kobach, Kris",6,000180
+SMITH,Pawnee Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000210
+SMITH,Pawnee Township,Secretary of State,,Republican,"Kobach, Kris",13,000210
+SMITH,Pleasant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000220
+SMITH,Pleasant Township,Secretary of State,,Republican,"Kobach, Kris",16,000220
+SMITH,Swan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000230
+SMITH,Swan Township,Secretary of State,,Republican,"Kobach, Kris",12,000230
+SMITH,Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000240
+SMITH,Valley Township,Secretary of State,,Republican,"Kobach, Kris",20,000240
+SMITH,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000250
+SMITH,Washington Township,Secretary of State,,Republican,"Kobach, Kris",17,000250
+SMITH,Webster Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000260
+SMITH,Webster Township,Secretary of State,,Republican,"Kobach, Kris",21,000260
+SMITH,White Rock Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000270
+SMITH,White Rock Township,Secretary of State,,Republican,"Kobach, Kris",20,000270
+SMITH,Oak Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,130010
+SMITH,Oak Township,Secretary of State,,Republican,"Kobach, Kris",101,130010
+SMITH,Center 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,140010
+SMITH,Center 1,Secretary of State,,Republican,"Kobach, Kris",187,140010
+SMITH,Center 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",77,140020
+SMITH,Center 2,Secretary of State,,Republican,"Kobach, Kris",217,140020
+SMITH,Center 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,140030
+SMITH,Center 3,Secretary of State,,Republican,"Kobach, Kris",159,140030
+SMITH,Center 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,140040
+SMITH,Center 4,Secretary of State,,Republican,"Kobach, Kris",49,140040
+SMITH,Banner Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000010
+SMITH,Banner Township,State Treasurer,,Republican,"Estes, Ron",22,000010
+SMITH,Beaver Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000020
+SMITH,Beaver Township,State Treasurer,,Republican,"Estes, Ron",24,000020
+SMITH,Blaine Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000030
+SMITH,Blaine Township,State Treasurer,,Republican,"Estes, Ron",23,000030
+SMITH,Cedar Township,State Treasurer,,Democratic,"Alldritt, Carmen",47,000040
+SMITH,Cedar Township,State Treasurer,,Republican,"Estes, Ron",167,000040
+SMITH,Cora Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000070
+SMITH,Cora Township,State Treasurer,,Republican,"Estes, Ron",11,000070
+SMITH,Crystal Plains Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000080
+SMITH,Crystal Plains Township,State Treasurer,,Republican,"Estes, Ron",8,000080
+SMITH,Dor Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000090
+SMITH,Dor Township,State Treasurer,,Republican,"Estes, Ron",17,000090
+SMITH,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000100
+SMITH,Garfield Township,State Treasurer,,Republican,"Estes, Ron",10,000100
+SMITH,German Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000110
+SMITH,German Township,State Treasurer,,Republican,"Estes, Ron",6,000110
+SMITH,Harlan Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000120
+SMITH,Harlan Township,State Treasurer,,Republican,"Estes, Ron",34,000120
+SMITH,Harvey Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000130
+SMITH,Harvey Township,State Treasurer,,Republican,"Estes, Ron",51,000130
+SMITH,Houston Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000140
+SMITH,Houston Township,State Treasurer,,Republican,"Estes, Ron",50,000140
+SMITH,Lane Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000150
+SMITH,Lane Township,State Treasurer,,Republican,"Estes, Ron",31,000150
+SMITH,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000160
+SMITH,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",31,000160
+SMITH,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000170
+SMITH,Logan Township,State Treasurer,,Republican,"Estes, Ron",11,000170
+SMITH,Martin Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000180
+SMITH,Martin Township,State Treasurer,,Republican,"Estes, Ron",4,000180
+SMITH,Pawnee Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000210
+SMITH,Pawnee Township,State Treasurer,,Republican,"Estes, Ron",15,000210
+SMITH,Pleasant Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000220
+SMITH,Pleasant Township,State Treasurer,,Republican,"Estes, Ron",13,000220
+SMITH,Swan Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000230
+SMITH,Swan Township,State Treasurer,,Republican,"Estes, Ron",13,000230
+SMITH,Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000240
+SMITH,Valley Township,State Treasurer,,Republican,"Estes, Ron",21,000240
+SMITH,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000250
+SMITH,Washington Township,State Treasurer,,Republican,"Estes, Ron",17,000250
+SMITH,Webster Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000260
+SMITH,Webster Township,State Treasurer,,Republican,"Estes, Ron",21,000260
+SMITH,White Rock Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000270
+SMITH,White Rock Township,State Treasurer,,Republican,"Estes, Ron",22,000270
+SMITH,Oak Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,130010
+SMITH,Oak Township,State Treasurer,,Republican,"Estes, Ron",105,130010
+SMITH,Center 1,State Treasurer,,Democratic,"Alldritt, Carmen",46,140010
+SMITH,Center 1,State Treasurer,,Republican,"Estes, Ron",190,140010
+SMITH,Center 2,State Treasurer,,Democratic,"Alldritt, Carmen",61,140020
+SMITH,Center 2,State Treasurer,,Republican,"Estes, Ron",230,140020
+SMITH,Center 3,State Treasurer,,Democratic,"Alldritt, Carmen",31,140030
+SMITH,Center 3,State Treasurer,,Republican,"Estes, Ron",165,140030
+SMITH,Center 4,State Treasurer,,Democratic,"Alldritt, Carmen",9,140040
+SMITH,Center 4,State Treasurer,,Republican,"Estes, Ron",45,140040
+SMITH,Banner Township,United States Senate,,independent,"Orman, Greg",4,000010
+SMITH,Banner Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+SMITH,Banner Township,United States Senate,,Republican,"Roberts, Pat",25,000010
+SMITH,Beaver Township,United States Senate,,independent,"Orman, Greg",1,000020
+SMITH,Beaver Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+SMITH,Beaver Township,United States Senate,,Republican,"Roberts, Pat",24,000020
+SMITH,Blaine Township,United States Senate,,independent,"Orman, Greg",2,000030
+SMITH,Blaine Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+SMITH,Blaine Township,United States Senate,,Republican,"Roberts, Pat",23,000030
+SMITH,Cedar Township,United States Senate,,independent,"Orman, Greg",52,000040
+SMITH,Cedar Township,United States Senate,,Libertarian,"Batson, Randall",9,000040
+SMITH,Cedar Township,United States Senate,,Republican,"Roberts, Pat",160,000040
+SMITH,Cora Township,United States Senate,,independent,"Orman, Greg",1,000070
+SMITH,Cora Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+SMITH,Cora Township,United States Senate,,Republican,"Roberts, Pat",13,000070
+SMITH,Crystal Plains Township,United States Senate,,independent,"Orman, Greg",3,000080
+SMITH,Crystal Plains Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+SMITH,Crystal Plains Township,United States Senate,,Republican,"Roberts, Pat",10,000080
+SMITH,Dor Township,United States Senate,,independent,"Orman, Greg",6,000090
+SMITH,Dor Township,United States Senate,,Libertarian,"Batson, Randall",0,000090
+SMITH,Dor Township,United States Senate,,Republican,"Roberts, Pat",16,000090
+SMITH,Garfield Township,United States Senate,,independent,"Orman, Greg",1,000100
+SMITH,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",0,000100
+SMITH,Garfield Township,United States Senate,,Republican,"Roberts, Pat",11,000100
+SMITH,German Township,United States Senate,,independent,"Orman, Greg",1,000110
+SMITH,German Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+SMITH,German Township,United States Senate,,Republican,"Roberts, Pat",5,000110
+SMITH,Harlan Township,United States Senate,,independent,"Orman, Greg",6,000120
+SMITH,Harlan Township,United States Senate,,Libertarian,"Batson, Randall",1,000120
+SMITH,Harlan Township,United States Senate,,Republican,"Roberts, Pat",31,000120
+SMITH,Harvey Township,United States Senate,,independent,"Orman, Greg",9,000130
+SMITH,Harvey Township,United States Senate,,Libertarian,"Batson, Randall",4,000130
+SMITH,Harvey Township,United States Senate,,Republican,"Roberts, Pat",46,000130
+SMITH,Houston Township,United States Senate,,independent,"Orman, Greg",12,000140
+SMITH,Houston Township,United States Senate,,Libertarian,"Batson, Randall",4,000140
+SMITH,Houston Township,United States Senate,,Republican,"Roberts, Pat",45,000140
+SMITH,Lane Township,United States Senate,,independent,"Orman, Greg",18,000150
+SMITH,Lane Township,United States Senate,,Libertarian,"Batson, Randall",3,000150
+SMITH,Lane Township,United States Senate,,Republican,"Roberts, Pat",30,000150
+SMITH,Lincoln Township,United States Senate,,independent,"Orman, Greg",6,000160
+SMITH,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",1,000160
+SMITH,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",31,000160
+SMITH,Logan Township,United States Senate,,independent,"Orman, Greg",5,000170
+SMITH,Logan Township,United States Senate,,Libertarian,"Batson, Randall",0,000170
+SMITH,Logan Township,United States Senate,,Republican,"Roberts, Pat",13,000170
+SMITH,Martin Township,United States Senate,,independent,"Orman, Greg",1,000180
+SMITH,Martin Township,United States Senate,,Libertarian,"Batson, Randall",0,000180
+SMITH,Martin Township,United States Senate,,Republican,"Roberts, Pat",6,000180
+SMITH,Pawnee Township,United States Senate,,independent,"Orman, Greg",3,000210
+SMITH,Pawnee Township,United States Senate,,Libertarian,"Batson, Randall",0,000210
+SMITH,Pawnee Township,United States Senate,,Republican,"Roberts, Pat",17,000210
+SMITH,Pleasant Township,United States Senate,,independent,"Orman, Greg",5,000220
+SMITH,Pleasant Township,United States Senate,,Libertarian,"Batson, Randall",1,000220
+SMITH,Pleasant Township,United States Senate,,Republican,"Roberts, Pat",12,000220
+SMITH,Swan Township,United States Senate,,independent,"Orman, Greg",3,000230
+SMITH,Swan Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+SMITH,Swan Township,United States Senate,,Republican,"Roberts, Pat",15,000230
+SMITH,Valley Township,United States Senate,,independent,"Orman, Greg",5,000240
+SMITH,Valley Township,United States Senate,,Libertarian,"Batson, Randall",1,000240
+SMITH,Valley Township,United States Senate,,Republican,"Roberts, Pat",19,000240
+SMITH,Washington Township,United States Senate,,independent,"Orman, Greg",1,000250
+SMITH,Washington Township,United States Senate,,Libertarian,"Batson, Randall",2,000250
+SMITH,Washington Township,United States Senate,,Republican,"Roberts, Pat",16,000250
+SMITH,Webster Township,United States Senate,,independent,"Orman, Greg",1,000260
+SMITH,Webster Township,United States Senate,,Libertarian,"Batson, Randall",0,000260
+SMITH,Webster Township,United States Senate,,Republican,"Roberts, Pat",23,000260
+SMITH,White Rock Township,United States Senate,,independent,"Orman, Greg",2,000270
+SMITH,White Rock Township,United States Senate,,Libertarian,"Batson, Randall",0,000270
+SMITH,White Rock Township,United States Senate,,Republican,"Roberts, Pat",22,000270
+SMITH,Oak Township,United States Senate,,independent,"Orman, Greg",21,130010
+SMITH,Oak Township,United States Senate,,Libertarian,"Batson, Randall",10,130010
+SMITH,Oak Township,United States Senate,,Republican,"Roberts, Pat",90,130010
+SMITH,Center 1,United States Senate,,independent,"Orman, Greg",59,140010
+SMITH,Center 1,United States Senate,,Libertarian,"Batson, Randall",15,140010
+SMITH,Center 1,United States Senate,,Republican,"Roberts, Pat",180,140010
+SMITH,Center 2,United States Senate,,independent,"Orman, Greg",86,140020
+SMITH,Center 2,United States Senate,,Libertarian,"Batson, Randall",20,140020
+SMITH,Center 2,United States Senate,,Republican,"Roberts, Pat",196,140020
+SMITH,Center 3,United States Senate,,independent,"Orman, Greg",35,140030
+SMITH,Center 3,United States Senate,,Libertarian,"Batson, Randall",15,140030
+SMITH,Center 3,United States Senate,,Republican,"Roberts, Pat",154,140030
+SMITH,Center 4,United States Senate,,independent,"Orman, Greg",16,140040
+SMITH,Center 4,United States Senate,,Libertarian,"Batson, Randall",3,140040
+SMITH,Center 4,United States Senate,,Republican,"Roberts, Pat",39,140040

--- a/2014/20141104__ks__general__stafford__precinct.csv
+++ b/2014/20141104__ks__general__stafford__precinct.csv
@@ -1,409 +1,409 @@
-county,precinct,office,district,party,candidate,votes
-Stafford,Albano,Attorney General,,D,A J Kotich,3
-Stafford,Byron,Attorney General,,D,A J Kotich,1
-Stafford,Clear Creek,Attorney General,,D,A J Kotich,2
-Stafford,Cleveland,Attorney General,,D,A J Kotich,0
-Stafford,Douglas,Attorney General,,D,A J Kotich,6
-Stafford,E Cooper,Attorney General,,D,A J Kotich,2
-Stafford,E St John,Attorney General,,D,A J Kotich,39
-Stafford,Fairview,Attorney General,,D,A J Kotich,8
-Stafford,Farmington,Attorney General,,D,A J Kotich,23
-Stafford,Hayes,Attorney General,,D,A J Kotich,14
-Stafford,Lincoln,Attorney General,,D,A J Kotich,6
-Stafford,N Seward,Attorney General,,D,A J Kotich,10
-Stafford,N Stafford,Attorney General,,D,A J Kotich,35
-Stafford,Ohio,Attorney General,,D,A J Kotich,7
-Stafford,Putnam,Attorney General,,D,A J Kotich,0
-Stafford,Richland,Attorney General,,D,A J Kotich,3
-Stafford,Rose Valley,Attorney General,,D,A J Kotich,7
-Stafford,S Seward,Attorney General,,D,A J Kotich,0
-Stafford,S St John,Attorney General,,D,A J Kotich,16
-Stafford,S Stafford,Attorney General,,D,A J Kotich,42
-Stafford,Union,Attorney General,,D,A J Kotich,3
-Stafford,W Cooper,Attorney General,,D,A J Kotich,3
-Stafford,W St John,Attorney General,,D,A J Kotich,22
-Stafford,York,Attorney General,,D,A J Kotich,1
-Stafford,Albano,Attorney General,,R,Derek Schmidt,16
-Stafford,Byron,Attorney General,,R,Derek Schmidt,27
-Stafford,Clear Creek,Attorney General,,R,Derek Schmidt,15
-Stafford,Cleveland,Attorney General,,R,Derek Schmidt,25
-Stafford,Douglas,Attorney General,,R,Derek Schmidt,36
-Stafford,E Cooper,Attorney General,,R,Derek Schmidt,17
-Stafford,E St John,Attorney General,,R,Derek Schmidt,145
-Stafford,Fairview,Attorney General,,R,Derek Schmidt,28
-Stafford,Farmington,Attorney General,,R,Derek Schmidt,121
-Stafford,Hayes,Attorney General,,R,Derek Schmidt,64
-Stafford,Lincoln,Attorney General,,R,Derek Schmidt,41
-Stafford,N Seward,Attorney General,,R,Derek Schmidt,56
-Stafford,N Stafford,Attorney General,,R,Derek Schmidt,173
-Stafford,Ohio,Attorney General,,R,Derek Schmidt,32
-Stafford,Putnam,Attorney General,,R,Derek Schmidt,10
-Stafford,Richland,Attorney General,,R,Derek Schmidt,18
-Stafford,Rose Valley,Attorney General,,R,Derek Schmidt,17
-Stafford,S Seward,Attorney General,,R,Derek Schmidt,17
-Stafford,S St John,Attorney General,,R,Derek Schmidt,80
-Stafford,S Stafford,Attorney General,,R,Derek Schmidt,124
-Stafford,Union,Attorney General,,R,Derek Schmidt,10
-Stafford,W Cooper,Attorney General,,R,Derek Schmidt,24
-Stafford,W St John,Attorney General,,R,Derek Schmidt,119
-Stafford,York,Attorney General,,R,Derek Schmidt,11
-Stafford,Albano,U.S. House,4,R,Mike Pompeo,16
-Stafford,Byron,U.S. House,4,R,Mike Pompeo,28
-Stafford,Clear Creek,U.S. House,4,R,Mike Pompeo,16
-Stafford,Cleveland,U.S. House,4,R,Mike Pompeo,23
-Stafford,Douglas,U.S. House,4,R,Mike Pompeo,34
-Stafford,E Cooper,U.S. House,4,R,Mike Pompeo,18
-Stafford,E St John,U.S. House,4,R,Mike Pompeo,149
-Stafford,Fairview,U.S. House,4,R,Mike Pompeo,27
-Stafford,Farmington,U.S. House,4,R,Mike Pompeo,119
-Stafford,Hayes,U.S. House,4,R,Mike Pompeo,62
-Stafford,Lincoln,U.S. House,4,R,Mike Pompeo,42
-Stafford,N Seward,U.S. House,4,R,Mike Pompeo,55
-Stafford,N Stafford,U.S. House,4,R,Mike Pompeo,162
-Stafford,Ohio,U.S. House,4,R,Mike Pompeo,35
-Stafford,Putnam,U.S. House,4,R,Mike Pompeo,8
-Stafford,Richland,U.S. House,4,R,Mike Pompeo,18
-Stafford,Rose Valley,U.S. House,4,R,Mike Pompeo,16
-Stafford,S Seward,U.S. House,4,R,Mike Pompeo,17
-Stafford,S St John,U.S. House,4,R,Mike Pompeo,86
-Stafford,S Stafford,U.S. House,4,R,Mike Pompeo,124
-Stafford,Union,U.S. House,4,R,Mike Pompeo,8
-Stafford,W Cooper,U.S. House,4,R,Mike Pompeo,26
-Stafford,W St John,U.S. House,4,R,Mike Pompeo,111
-Stafford,York,U.S. House,4,R,Mike Pompeo,13
-Stafford,Albano,U.S. House,4,D,Perry Schuckman,3
-Stafford,Byron,U.S. House,4,D,Perry Schuckman,2
-Stafford,Clear Creek,U.S. House,4,D,Perry Schuckman,2
-Stafford,Cleveland,U.S. House,4,D,Perry Schuckman,3
-Stafford,Douglas,U.S. House,4,D,Perry Schuckman,11
-Stafford,E Cooper,U.S. House,4,D,Perry Schuckman,1
-Stafford,E St John,U.S. House,4,D,Perry Schuckman,39
-Stafford,Fairview,U.S. House,4,D,Perry Schuckman,10
-Stafford,Farmington,U.S. House,4,D,Perry Schuckman,25
-Stafford,Hayes,U.S. House,4,D,Perry Schuckman,14
-Stafford,Lincoln,U.S. House,4,D,Perry Schuckman,5
-Stafford,N Seward,U.S. House,4,D,Perry Schuckman,11
-Stafford,N Stafford,U.S. House,4,D,Perry Schuckman,48
-Stafford,Ohio,U.S. House,4,D,Perry Schuckman,5
-Stafford,Putnam,U.S. House,4,D,Perry Schuckman,2
-Stafford,Richland,U.S. House,4,D,Perry Schuckman,2
-Stafford,Rose Valley,U.S. House,4,D,Perry Schuckman,8
-Stafford,S Seward,U.S. House,4,D,Perry Schuckman,0
-Stafford,S St John,U.S. House,4,D,Perry Schuckman,17
-Stafford,S Stafford,U.S. House,4,D,Perry Schuckman,43
-Stafford,Union,U.S. House,4,D,Perry Schuckman,4
-Stafford,W Cooper,U.S. House,4,D,Perry Schuckman,2
-Stafford,W St John,U.S. House,4,D,Perry Schuckman,28
-Stafford,York,U.S. House,4,D,Perry Schuckman,0
-Stafford,Albano,Governor,,L,Keen Umbehr,0
-Stafford,Byron,Governor,,L,Keen Umbehr,0
-Stafford,Clear Creek,Governor,,L,Keen Umbehr,0
-Stafford,Cleveland,Governor,,L,Keen Umbehr,2
-Stafford,Douglas,Governor,,L,Keen Umbehr,2
-Stafford,E Cooper,Governor,,L,Keen Umbehr,0
-Stafford,E St John,Governor,,L,Keen Umbehr,4
-Stafford,Fairview,Governor,,L,Keen Umbehr,1
-Stafford,Farmington,Governor,,L,Keen Umbehr,3
-Stafford,Hayes,Governor,,L,Keen Umbehr,2
-Stafford,Lincoln,Governor,,L,Keen Umbehr,1
-Stafford,N Seward,Governor,,L,Keen Umbehr,3
-Stafford,N Stafford,Governor,,L,Keen Umbehr,13
-Stafford,Ohio,Governor,,L,Keen Umbehr,1
-Stafford,Putnam,Governor,,L,Keen Umbehr,0
-Stafford,Richland,Governor,,L,Keen Umbehr,2
-Stafford,Rose Valley,Governor,,L,Keen Umbehr,0
-Stafford,S Seward,Governor,,L,Keen Umbehr,2
-Stafford,S St John,Governor,,L,Keen Umbehr,6
-Stafford,S Stafford,Governor,,L,Keen Umbehr,8
-Stafford,Union,Governor,,L,Keen Umbehr,0
-Stafford,W Cooper,Governor,,L,Keen Umbehr,2
-Stafford,W St John,Governor,,L,Keen Umbehr,9
-Stafford,York,Governor,,L,Keen Umbehr,0
-Stafford,Albano,Governor,,D,Paul Davis,4
-Stafford,Byron,Governor,,D,Paul Davis,3
-Stafford,Clear Creek,Governor,,D,Paul Davis,4
-Stafford,Cleveland,Governor,,D,Paul Davis,5
-Stafford,Douglas,Governor,,D,Paul Davis,14
-Stafford,E Cooper,Governor,,D,Paul Davis,1
-Stafford,E St John,Governor,,D,Paul Davis,81
-Stafford,Fairview,Governor,,D,Paul Davis,20
-Stafford,Farmington,Governor,,D,Paul Davis,48
-Stafford,Hayes,Governor,,D,Paul Davis,26
-Stafford,Lincoln,Governor,,D,Paul Davis,7
-Stafford,N Seward,Governor,,D,Paul Davis,15
-Stafford,N Stafford,Governor,,D,Paul Davis,90
-Stafford,Ohio,Governor,,D,Paul Davis,11
-Stafford,Putnam,Governor,,D,Paul Davis,2
-Stafford,Richland,Governor,,D,Paul Davis,5
-Stafford,Rose Valley,Governor,,D,Paul Davis,13
-Stafford,S Seward,Governor,,D,Paul Davis,0
-Stafford,S St John,Governor,,D,Paul Davis,27
-Stafford,S Stafford,Governor,,D,Paul Davis,76
-Stafford,Union,Governor,,D,Paul Davis,6
-Stafford,W Cooper,Governor,,D,Paul Davis,4
-Stafford,W St John,Governor,,D,Paul Davis,49
-Stafford,York,Governor,,D,Paul Davis,2
-Stafford,Albano,Governor,,R,Sam Brownback,15
-Stafford,Byron,Governor,,R,Sam Brownback,28
-Stafford,Clear Creek,Governor,,R,Sam Brownback,14
-Stafford,Cleveland,Governor,,R,Sam Brownback,20
-Stafford,Douglas,Governor,,R,Sam Brownback,28
-Stafford,E Cooper,Governor,,R,Sam Brownback,18
-Stafford,E St John,Governor,,R,Sam Brownback,106
-Stafford,Fairview,Governor,,R,Sam Brownback,16
-Stafford,Farmington,Governor,,R,Sam Brownback,97
-Stafford,Hayes,Governor,,R,Sam Brownback,50
-Stafford,Lincoln,Governor,,R,Sam Brownback,38
-Stafford,N Seward,Governor,,R,Sam Brownback,48
-Stafford,N Stafford,Governor,,R,Sam Brownback,114
-Stafford,Ohio,Governor,,R,Sam Brownback,28
-Stafford,Putnam,Governor,,R,Sam Brownback,8
-Stafford,Richland,Governor,,R,Sam Brownback,14
-Stafford,Rose Valley,Governor,,R,Sam Brownback,11
-Stafford,S Seward,Governor,,R,Sam Brownback,15
-Stafford,S St John,Governor,,R,Sam Brownback,68
-Stafford,S Stafford,Governor,,R,Sam Brownback,87
-Stafford,Union,Governor,,R,Sam Brownback,7
-Stafford,W Cooper,Governor,,R,Sam Brownback,23
-Stafford,W St John,Governor,,R,Sam Brownback,86
-Stafford,York,Governor,,R,Sam Brownback,11
-Stafford,Albano,Insurance Commissioner,,D,Dennis Anderson,4
-Stafford,Byron,Insurance Commissioner,,D,Dennis Anderson,2
-Stafford,Clear Creek,Insurance Commissioner,,D,Dennis Anderson,1
-Stafford,Cleveland,Insurance Commissioner,,D,Dennis Anderson,1
-Stafford,Douglas,Insurance Commissioner,,D,Dennis Anderson,6
-Stafford,E Cooper,Insurance Commissioner,,D,Dennis Anderson,2
-Stafford,E St John,Insurance Commissioner,,D,Dennis Anderson,43
-Stafford,Fairview,Insurance Commissioner,,D,Dennis Anderson,11
-Stafford,Farmington,Insurance Commissioner,,D,Dennis Anderson,28
-Stafford,Hayes,Insurance Commissioner,,D,Dennis Anderson,18
-Stafford,Lincoln,Insurance Commissioner,,D,Dennis Anderson,8
-Stafford,N Seward,Insurance Commissioner,,D,Dennis Anderson,10
-Stafford,N Stafford,Insurance Commissioner,,D,Dennis Anderson,46
-Stafford,Ohio,Insurance Commissioner,,D,Dennis Anderson,5
-Stafford,Putnam,Insurance Commissioner,,D,Dennis Anderson,1
-Stafford,Richland,Insurance Commissioner,,D,Dennis Anderson,4
-Stafford,Rose Valley,Insurance Commissioner,,D,Dennis Anderson,8
-Stafford,S Seward,Insurance Commissioner,,D,Dennis Anderson,0
-Stafford,S St John,Insurance Commissioner,,D,Dennis Anderson,23
-Stafford,S Stafford,Insurance Commissioner,,D,Dennis Anderson,51
-Stafford,Union,Insurance Commissioner,,D,Dennis Anderson,4
-Stafford,W Cooper,Insurance Commissioner,,D,Dennis Anderson,2
-Stafford,W St John,Insurance Commissioner,,D,Dennis Anderson,39
-Stafford,York,Insurance Commissioner,,D,Dennis Anderson,1
-Stafford,Albano,Insurance Commissioner,,R,Ken Selzer,14
-Stafford,Byron,Insurance Commissioner,,R,Ken Selzer,26
-Stafford,Clear Creek,Insurance Commissioner,,R,Ken Selzer,13
-Stafford,Cleveland,Insurance Commissioner,,R,Ken Selzer,25
-Stafford,Douglas,Insurance Commissioner,,R,Ken Selzer,33
-Stafford,E Cooper,Insurance Commissioner,,R,Ken Selzer,15
-Stafford,E St John,Insurance Commissioner,,R,Ken Selzer,135
-Stafford,Fairview,Insurance Commissioner,,R,Ken Selzer,24
-Stafford,Farmington,Insurance Commissioner,,R,Ken Selzer,115
-Stafford,Hayes,Insurance Commissioner,,R,Ken Selzer,56
-Stafford,Lincoln,Insurance Commissioner,,R,Ken Selzer,38
-Stafford,N Seward,Insurance Commissioner,,R,Ken Selzer,54
-Stafford,N Stafford,Insurance Commissioner,,R,Ken Selzer,148
-Stafford,Ohio,Insurance Commissioner,,R,Ken Selzer,34
-Stafford,Putnam,Insurance Commissioner,,R,Ken Selzer,9
-Stafford,Richland,Insurance Commissioner,,R,Ken Selzer,17
-Stafford,Rose Valley,Insurance Commissioner,,R,Ken Selzer,16
-Stafford,S Seward,Insurance Commissioner,,R,Ken Selzer,17
-Stafford,S St John,Insurance Commissioner,,R,Ken Selzer,68
-Stafford,S Stafford,Insurance Commissioner,,R,Ken Selzer,110
-Stafford,Union,Insurance Commissioner,,R,Ken Selzer,8
-Stafford,W Cooper,Insurance Commissioner,,R,Ken Selzer,25
-Stafford,W St John,Insurance Commissioner,,R,Ken Selzer,96
-Stafford,York,Insurance Commissioner,,R,Ken Selzer,12
-Stafford,Albano,Secretary of State,,D,Jean Schodorf,5
-Stafford,Byron,Secretary of State,,D,Jean Schodorf,3
-Stafford,Clear Creek,Secretary of State,,D,Jean Schodorf,5
-Stafford,Cleveland,Secretary of State,,D,Jean Schodorf,5
-Stafford,Douglas,Secretary of State,,D,Jean Schodorf,10
-Stafford,E Cooper,Secretary of State,,D,Jean Schodorf,1
-Stafford,E St John,Secretary of State,,D,Jean Schodorf,59
-Stafford,Fairview,Secretary of State,,D,Jean Schodorf,15
-Stafford,Farmington,Secretary of State,,D,Jean Schodorf,34
-Stafford,Hayes,Secretary of State,,D,Jean Schodorf,20
-Stafford,Lincoln,Secretary of State,,D,Jean Schodorf,7
-Stafford,N Seward,Secretary of State,,D,Jean Schodorf,14
-Stafford,N Stafford,Secretary of State,,D,Jean Schodorf,71
-Stafford,Ohio,Secretary of State,,D,Jean Schodorf,6
-Stafford,Putnam,Secretary of State,,D,Jean Schodorf,3
-Stafford,Richland,Secretary of State,,D,Jean Schodorf,4
-Stafford,Rose Valley,Secretary of State,,D,Jean Schodorf,11
-Stafford,S Seward,Secretary of State,,D,Jean Schodorf,1
-Stafford,S St John,Secretary of State,,D,Jean Schodorf,31
-Stafford,S Stafford,Secretary of State,,D,Jean Schodorf,55
-Stafford,Union,Secretary of State,,D,Jean Schodorf,5
-Stafford,W Cooper,Secretary of State,,D,Jean Schodorf,3
-Stafford,W St John,Secretary of State,,D,Jean Schodorf,41
-Stafford,York,Secretary of State,,D,Jean Schodorf,0
-Stafford,Albano,Secretary of State,,R,Kris Kobach,14
-Stafford,Byron,Secretary of State,,R,Kris Kobach,27
-Stafford,Clear Creek,Secretary of State,,R,Kris Kobach,12
-Stafford,Cleveland,Secretary of State,,R,Kris Kobach,21
-Stafford,Douglas,Secretary of State,,R,Kris Kobach,34
-Stafford,E Cooper,Secretary of State,,R,Kris Kobach,16
-Stafford,E St John,Secretary of State,,R,Kris Kobach,128
-Stafford,Fairview,Secretary of State,,R,Kris Kobach,21
-Stafford,Farmington,Secretary of State,,R,Kris Kobach,115
-Stafford,Hayes,Secretary of State,,R,Kris Kobach,59
-Stafford,Lincoln,Secretary of State,,R,Kris Kobach,40
-Stafford,N Seward,Secretary of State,,R,Kris Kobach,52
-Stafford,N Stafford,Secretary of State,,R,Kris Kobach,139
-Stafford,Ohio,Secretary of State,,R,Kris Kobach,34
-Stafford,Putnam,Secretary of State,,R,Kris Kobach,7
-Stafford,Richland,Secretary of State,,R,Kris Kobach,16
-Stafford,Rose Valley,Secretary of State,,R,Kris Kobach,13
-Stafford,S Seward,Secretary of State,,R,Kris Kobach,16
-Stafford,S St John,Secretary of State,,R,Kris Kobach,69
-Stafford,S Stafford,Secretary of State,,R,Kris Kobach,112
-Stafford,Union,Secretary of State,,R,Kris Kobach,8
-Stafford,W Cooper,Secretary of State,,R,Kris Kobach,25
-Stafford,W St John,Secretary of State,,R,Kris Kobach,98
-Stafford,York,Secretary of State,,R,Kris Kobach,13
-Stafford,Albano,State House,113,R,Jeremy Dannebohm,17
-Stafford,Byron,State House,113,R,Jeremy Dannebohm,27
-Stafford,Clear Creek,State House,113,R,Jeremy Dannebohm,13
-Stafford,Cleveland,State House,113,R,Jeremy Dannebohm,24
-Stafford,Douglas,State House,113,R,Jeremy Dannebohm,32
-Stafford,E Cooper,State House,113,R,Jeremy Dannebohm,17
-Stafford,E St John,State House,113,R,Jeremy Dannebohm,149
-Stafford,Fairview,State House,113,R,Jeremy Dannebohm,30
-Stafford,Farmington,State House,113,R,Jeremy Dannebohm,123
-Stafford,Hayes,State House,113,R,Jeremy Dannebohm,69
-Stafford,Lincoln,State House,113,R,Jeremy Dannebohm,42
-Stafford,N Seward,State House,113,R,Jeremy Dannebohm,59
-Stafford,N Stafford,State House,113,R,Jeremy Dannebohm,170
-Stafford,Ohio,State House,113,R,Jeremy Dannebohm,33
-Stafford,Putnam,State House,113,R,Jeremy Dannebohm,9
-Stafford,Richland,State House,113,R,Jeremy Dannebohm,17
-Stafford,Rose Valley,State House,113,R,Jeremy Dannebohm,20
-Stafford,S Seward,State House,113,R,Jeremy Dannebohm,17
-Stafford,S St John,State House,113,R,Jeremy Dannebohm,77
-Stafford,S Stafford,State House,113,R,Jeremy Dannebohm,127
-Stafford,Union,State House,113,R,Jeremy Dannebohm,11
-Stafford,W Cooper,State House,113,R,Jeremy Dannebohm,23
-Stafford,W St John,State House,113,R,Jeremy Dannebohm,112
-Stafford,York,State House,113,R,Jeremy Dannebohm,11
-Stafford,Albano,State Treasurer,,D,Carmen Alldritt,4
-Stafford,Byron,State Treasurer,,D,Carmen Alldritt,0
-Stafford,Clear Creek,State Treasurer,,D,Carmen Alldritt,3
-Stafford,Cleveland,State Treasurer,,D,Carmen Alldritt,1
-Stafford,Douglas,State Treasurer,,D,Carmen Alldritt,4
-Stafford,E Cooper,State Treasurer,,D,Carmen Alldritt,1
-Stafford,E St John,State Treasurer,,D,Carmen Alldritt,31
-Stafford,Fairview,State Treasurer,,D,Carmen Alldritt,9
-Stafford,Farmington,State Treasurer,,D,Carmen Alldritt,26
-Stafford,Hayes,State Treasurer,,D,Carmen Alldritt,15
-Stafford,Lincoln,State Treasurer,,D,Carmen Alldritt,6
-Stafford,N Seward,State Treasurer,,D,Carmen Alldritt,8
-Stafford,N Stafford,State Treasurer,,D,Carmen Alldritt,34
-Stafford,Ohio,State Treasurer,,D,Carmen Alldritt,7
-Stafford,Putnam,State Treasurer,,D,Carmen Alldritt,0
-Stafford,Richland,State Treasurer,,D,Carmen Alldritt,2
-Stafford,Rose Valley,State Treasurer,,D,Carmen Alldritt,4
-Stafford,S Seward,State Treasurer,,D,Carmen Alldritt,0
-Stafford,S St John,State Treasurer,,D,Carmen Alldritt,15
-Stafford,S Stafford,State Treasurer,,D,Carmen Alldritt,38
-Stafford,Union,State Treasurer,,D,Carmen Alldritt,6
-Stafford,W Cooper,State Treasurer,,D,Carmen Alldritt,2
-Stafford,W St John,State Treasurer,,D,Carmen Alldritt,23
-Stafford,York,State Treasurer,,D,Carmen Alldritt,0
-Stafford,Albano,State Treasurer,,R,Ron Estes,15
-Stafford,Byron,State Treasurer,,R,Ron Estes,29
-Stafford,Clear Creek,State Treasurer,,R,Ron Estes,14
-Stafford,Cleveland,State Treasurer,,R,Ron Estes,25
-Stafford,Douglas,State Treasurer,,R,Ron Estes,36
-Stafford,E Cooper,State Treasurer,,R,Ron Estes,17
-Stafford,E St John,State Treasurer,,R,Ron Estes,154
-Stafford,Fairview,State Treasurer,,R,Ron Estes,27
-Stafford,Farmington,State Treasurer,,R,Ron Estes,122
-Stafford,Hayes,State Treasurer,,R,Ron Estes,63
-Stafford,Lincoln,State Treasurer,,R,Ron Estes,41
-Stafford,N Seward,State Treasurer,,R,Ron Estes,58
-Stafford,N Stafford,State Treasurer,,R,Ron Estes,172
-Stafford,Ohio,State Treasurer,,R,Ron Estes,32
-Stafford,Putnam,State Treasurer,,R,Ron Estes,10
-Stafford,Richland,State Treasurer,,R,Ron Estes,19
-Stafford,Rose Valley,State Treasurer,,R,Ron Estes,20
-Stafford,S Seward,State Treasurer,,R,Ron Estes,17
-Stafford,S St John,State Treasurer,,R,Ron Estes,83
-Stafford,S Stafford,State Treasurer,,R,Ron Estes,129
-Stafford,Union,State Treasurer,,R,Ron Estes,7
-Stafford,W Cooper,State Treasurer,,R,Ron Estes,25
-Stafford,W St John,State Treasurer,,R,Ron Estes,115
-Stafford,York,State Treasurer,,R,Ron Estes,12
-Stafford,Albano,U.S. Senate,,I,Greg Orman,3
-Stafford,Byron,U.S. Senate,,I,Greg Orman,3
-Stafford,Clear Creek,U.S. Senate,,I,Greg Orman,4
-Stafford,Cleveland,U.S. Senate,,I,Greg Orman,3
-Stafford,Douglas,U.S. Senate,,I,Greg Orman,13
-Stafford,E Cooper,U.S. Senate,,I,Greg Orman,2
-Stafford,E St John,U.S. Senate,,I,Greg Orman,59
-Stafford,Fairview,U.S. Senate,,I,Greg Orman,16
-Stafford,Farmington,U.S. Senate,,I,Greg Orman,30
-Stafford,Hayes,U.S. Senate,,I,Greg Orman,21
-Stafford,Lincoln,U.S. Senate,,I,Greg Orman,10
-Stafford,N Seward,U.S. Senate,,I,Greg Orman,16
-Stafford,N Stafford,U.S. Senate,,I,Greg Orman,72
-Stafford,Ohio,U.S. Senate,,I,Greg Orman,6
-Stafford,Putnam,U.S. Senate,,I,Greg Orman,2
-Stafford,Richland,U.S. Senate,,I,Greg Orman,4
-Stafford,Rose Valley,U.S. Senate,,I,Greg Orman,9
-Stafford,S Seward,U.S. Senate,,I,Greg Orman,2
-Stafford,S St John,U.S. Senate,,I,Greg Orman,35
-Stafford,S Stafford,U.S. Senate,,I,Greg Orman,63
-Stafford,Union,U.S. Senate,,I,Greg Orman,7
-Stafford,W Cooper,U.S. Senate,,I,Greg Orman,2
-Stafford,W St John,U.S. Senate,,I,Greg Orman,37
-Stafford,York,U.S. Senate,,I,Greg Orman,2
-Stafford,Albano,U.S. Senate,,R,Pat Roberts,16
-Stafford,Byron,U.S. Senate,,R,Pat Roberts,28
-Stafford,Clear Creek,U.S. Senate,,R,Pat Roberts,13
-Stafford,Cleveland,U.S. Senate,,R,Pat Roberts,24
-Stafford,Douglas,U.S. Senate,,R,Pat Roberts,30
-Stafford,E Cooper,U.S. Senate,,R,Pat Roberts,17
-Stafford,E St John,U.S. Senate,,R,Pat Roberts,120
-Stafford,Fairview,U.S. Senate,,R,Pat Roberts,21
-Stafford,Farmington,U.S. Senate,,R,Pat Roberts,112
-Stafford,Hayes,U.S. Senate,,R,Pat Roberts,56
-Stafford,Lincoln,U.S. Senate,,R,Pat Roberts,34
-Stafford,N Seward,U.S. Senate,,R,Pat Roberts,47
-Stafford,N Stafford,U.S. Senate,,R,Pat Roberts,125
-Stafford,Ohio,U.S. Senate,,R,Pat Roberts,33
-Stafford,Putnam,U.S. Senate,,R,Pat Roberts,8
-Stafford,Richland,U.S. Senate,,R,Pat Roberts,16
-Stafford,Rose Valley,U.S. Senate,,R,Pat Roberts,14
-Stafford,S Seward,U.S. Senate,,R,Pat Roberts,15
-Stafford,S St John,U.S. Senate,,R,Pat Roberts,62
-Stafford,S Stafford,U.S. Senate,,R,Pat Roberts,97
-Stafford,Union,U.S. Senate,,R,Pat Roberts,6
-Stafford,W Cooper,U.S. Senate,,R,Pat Roberts,25
-Stafford,W St John,U.S. Senate,,R,Pat Roberts,97
-Stafford,York,U.S. Senate,,R,Pat Roberts,11
-Stafford,Albano,U.S. Senate,,L,Randall Batson,0
-Stafford,Byron,U.S. Senate,,L,Randall Batson,0
-Stafford,Clear Creek,U.S. Senate,,L,Randall Batson,1
-Stafford,Cleveland,U.S. Senate,,L,Randall Batson,0
-Stafford,Douglas,U.S. Senate,,L,Randall Batson,1
-Stafford,E Cooper,U.S. Senate,,L,Randall Batson,0
-Stafford,E St John,U.S. Senate,,L,Randall Batson,12
-Stafford,Fairview,U.S. Senate,,L,Randall Batson,0
-Stafford,Farmington,U.S. Senate,,L,Randall Batson,5
-Stafford,Hayes,U.S. Senate,,L,Randall Batson,2
-Stafford,Lincoln,U.S. Senate,,L,Randall Batson,3
-Stafford,N Seward,U.S. Senate,,L,Randall Batson,3
-Stafford,N Stafford,U.S. Senate,,L,Randall Batson,17
-Stafford,Ohio,U.S. Senate,,L,Randall Batson,1
-Stafford,Putnam,U.S. Senate,,L,Randall Batson,0
-Stafford,Richland,U.S. Senate,,L,Randall Batson,1
-Stafford,Rose Valley,U.S. Senate,,L,Randall Batson,1
-Stafford,S Seward,U.S. Senate,,L,Randall Batson,0
-Stafford,S St John,U.S. Senate,,L,Randall Batson,4
-Stafford,S Stafford,U.S. Senate,,L,Randall Batson,10
-Stafford,Union,U.S. Senate,,L,Randall Batson,0
-Stafford,W Cooper,U.S. Senate,,L,Randall Batson,2
-Stafford,W St John,U.S. Senate,,L,Randall Batson,9
-Stafford,York,U.S. Senate,,L,Randall Batson,0
+county,precinct,office,district,party,candidate,votes,vtd
+STAFFORD,Albano Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000010
+STAFFORD,Albano Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+STAFFORD,Albano Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000010
+STAFFORD,Byron Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000020
+STAFFORD,Byron Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+STAFFORD,Byron Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000020
+STAFFORD,Clear Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000030
+STAFFORD,Clear Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+STAFFORD,Clear Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000030
+STAFFORD,Cleveland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000040
+STAFFORD,Cleveland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+STAFFORD,Cleveland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000040
+STAFFORD,Douglas Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000050
+STAFFORD,Douglas Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000050
+STAFFORD,Douglas Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000050
+STAFFORD,East Cooper Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000060
+STAFFORD,East Cooper Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+STAFFORD,East Cooper Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000060
+STAFFORD,East St. John,Governor / Lt. Governor,,Democratic,"Davis, Paul",81,000070
+STAFFORD,East St. John,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000070
+STAFFORD,East St. John,Governor / Lt. Governor,,Republican,"Brownback, Sam",106,000070
+STAFFORD,Fairview Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000080
+STAFFORD,Fairview Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+STAFFORD,Fairview Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",16,000080
+STAFFORD,Farmington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000090
+STAFFORD,Farmington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000090
+STAFFORD,Farmington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",97,000090
+STAFFORD,Hayes Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000100
+STAFFORD,Hayes Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000100
+STAFFORD,Hayes Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000100
+STAFFORD,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000110
+STAFFORD,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000110
+STAFFORD,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000110
+STAFFORD,North Seward Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000120
+STAFFORD,North Seward Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000120
+STAFFORD,North Seward Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000120
+STAFFORD,North Stafford,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000130
+STAFFORD,North Stafford,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000130
+STAFFORD,North Stafford,Governor / Lt. Governor,,Republican,"Brownback, Sam",114,000130
+STAFFORD,Ohio Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000140
+STAFFORD,Ohio Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000140
+STAFFORD,Ohio Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000140
+STAFFORD,Putnam Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000150
+STAFFORD,Putnam Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000150
+STAFFORD,Putnam Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000150
+STAFFORD,Richland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000160
+STAFFORD,Richland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000160
+STAFFORD,Richland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000160
+STAFFORD,Rose Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000170
+STAFFORD,Rose Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000170
+STAFFORD,Rose Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000170
+STAFFORD,South Seward Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000180
+STAFFORD,South Seward Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000180
+STAFFORD,South Seward Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",15,000180
+STAFFORD,South St. John,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000190
+STAFFORD,South St. John,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000190
+STAFFORD,South St. John,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000190
+STAFFORD,South Stafford,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,000200
+STAFFORD,South Stafford,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000200
+STAFFORD,South Stafford,Governor / Lt. Governor,,Republican,"Brownback, Sam",87,000200
+STAFFORD,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000210
+STAFFORD,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000210
+STAFFORD,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,000210
+STAFFORD,West Cooper Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000220
+STAFFORD,West Cooper Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000220
+STAFFORD,West Cooper Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000220
+STAFFORD,West St. John,Governor / Lt. Governor,,Democratic,"Davis, Paul",49,000230
+STAFFORD,West St. John,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000230
+STAFFORD,West St. John,Governor / Lt. Governor,,Republican,"Brownback, Sam",86,000230
+STAFFORD,York Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000240
+STAFFORD,York Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000240
+STAFFORD,York Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",11,000240
+STAFFORD,Albano Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",17,000010
+STAFFORD,Byron Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",27,000020
+STAFFORD,Clear Creek Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",13,000030
+STAFFORD,Cleveland Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",24,000040
+STAFFORD,Douglas Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",32,000050
+STAFFORD,East Cooper Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",17,000060
+STAFFORD,East St. John,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",149,000070
+STAFFORD,Fairview Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",30,000080
+STAFFORD,Farmington Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",123,000090
+STAFFORD,Hayes Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",69,000100
+STAFFORD,Lincoln Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",42,000110
+STAFFORD,North Seward Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",59,000120
+STAFFORD,North Stafford,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",170,000130
+STAFFORD,Ohio Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",33,000140
+STAFFORD,Putnam Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",9,000150
+STAFFORD,Richland Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",17,000160
+STAFFORD,Rose Valley Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",20,000170
+STAFFORD,South Seward Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",17,000180
+STAFFORD,South St. John,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",77,000190
+STAFFORD,South Stafford,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",127,000200
+STAFFORD,Union Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",11,000210
+STAFFORD,West Cooper Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",23,000220
+STAFFORD,West St. John,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",112,000230
+STAFFORD,York Township,Kansas House of Representatives,113,Republican,"Dannebohm, Jeremy ""Basil""",11,000240
+STAFFORD,Albano Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,000010
+STAFFORD,Albano Township,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000010
+STAFFORD,Byron Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000020
+STAFFORD,Byron Township,United States House of Representatives,4,Republican,"Pompeo, Mike",28,000020
+STAFFORD,Clear Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000030
+STAFFORD,Clear Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000030
+STAFFORD,Cleveland Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",3,000040
+STAFFORD,Cleveland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",23,000040
+STAFFORD,Douglas Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,000050
+STAFFORD,Douglas Township,United States House of Representatives,4,Republican,"Pompeo, Mike",34,000050
+STAFFORD,East Cooper Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,000060
+STAFFORD,East Cooper Township,United States House of Representatives,4,Republican,"Pompeo, Mike",18,000060
+STAFFORD,East St. John,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",39,000070
+STAFFORD,East St. John,United States House of Representatives,4,Republican,"Pompeo, Mike",149,000070
+STAFFORD,Fairview Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",10,000080
+STAFFORD,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Mike",27,000080
+STAFFORD,Farmington Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",25,000090
+STAFFORD,Farmington Township,United States House of Representatives,4,Republican,"Pompeo, Mike",119,000090
+STAFFORD,Hayes Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",14,000100
+STAFFORD,Hayes Township,United States House of Representatives,4,Republican,"Pompeo, Mike",62,000100
+STAFFORD,Lincoln Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000110
+STAFFORD,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000110
+STAFFORD,North Seward Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,000120
+STAFFORD,North Seward Township,United States House of Representatives,4,Republican,"Pompeo, Mike",55,000120
+STAFFORD,North Stafford,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",48,000130
+STAFFORD,North Stafford,United States House of Representatives,4,Republican,"Pompeo, Mike",162,000130
+STAFFORD,Ohio Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",5,000140
+STAFFORD,Ohio Township,United States House of Representatives,4,Republican,"Pompeo, Mike",35,000140
+STAFFORD,Putnam Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000150
+STAFFORD,Putnam Township,United States House of Representatives,4,Republican,"Pompeo, Mike",8,000150
+STAFFORD,Richland Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000160
+STAFFORD,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",18,000160
+STAFFORD,Rose Valley Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000170
+STAFFORD,Rose Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000170
+STAFFORD,South Seward Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000180
+STAFFORD,South Seward Township,United States House of Representatives,4,Republican,"Pompeo, Mike",17,000180
+STAFFORD,South St. John,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",17,000190
+STAFFORD,South St. John,United States House of Representatives,4,Republican,"Pompeo, Mike",86,000190
+STAFFORD,South Stafford,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",43,000200
+STAFFORD,South Stafford,United States House of Representatives,4,Republican,"Pompeo, Mike",124,000200
+STAFFORD,Union Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000210
+STAFFORD,Union Township,United States House of Representatives,4,Republican,"Pompeo, Mike",8,000210
+STAFFORD,West Cooper Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000220
+STAFFORD,West Cooper Township,United States House of Representatives,4,Republican,"Pompeo, Mike",26,000220
+STAFFORD,West St. John,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",28,000230
+STAFFORD,West St. John,United States House of Representatives,4,Republican,"Pompeo, Mike",111,000230
+STAFFORD,York Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000240
+STAFFORD,York Township,United States House of Representatives,4,Republican,"Pompeo, Mike",13,000240
+STAFFORD,Albano Township,Attorney General,,Democratic,"Kotich, A.J.",3,000010
+STAFFORD,Albano Township,Attorney General,,Republican,"Schmidt, Derek",16,000010
+STAFFORD,Byron Township,Attorney General,,Democratic,"Kotich, A.J.",1,000020
+STAFFORD,Byron Township,Attorney General,,Republican,"Schmidt, Derek",27,000020
+STAFFORD,Clear Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000030
+STAFFORD,Clear Creek Township,Attorney General,,Republican,"Schmidt, Derek",15,000030
+STAFFORD,Cleveland Township,Attorney General,,Democratic,"Kotich, A.J.",0,000040
+STAFFORD,Cleveland Township,Attorney General,,Republican,"Schmidt, Derek",25,000040
+STAFFORD,Douglas Township,Attorney General,,Democratic,"Kotich, A.J.",6,000050
+STAFFORD,Douglas Township,Attorney General,,Republican,"Schmidt, Derek",36,000050
+STAFFORD,East Cooper Township,Attorney General,,Democratic,"Kotich, A.J.",2,000060
+STAFFORD,East Cooper Township,Attorney General,,Republican,"Schmidt, Derek",17,000060
+STAFFORD,East St. John,Attorney General,,Democratic,"Kotich, A.J.",39,000070
+STAFFORD,East St. John,Attorney General,,Republican,"Schmidt, Derek",145,000070
+STAFFORD,Fairview Township,Attorney General,,Democratic,"Kotich, A.J.",8,000080
+STAFFORD,Fairview Township,Attorney General,,Republican,"Schmidt, Derek",28,000080
+STAFFORD,Farmington Township,Attorney General,,Democratic,"Kotich, A.J.",23,000090
+STAFFORD,Farmington Township,Attorney General,,Republican,"Schmidt, Derek",121,000090
+STAFFORD,Hayes Township,Attorney General,,Democratic,"Kotich, A.J.",14,000100
+STAFFORD,Hayes Township,Attorney General,,Republican,"Schmidt, Derek",64,000100
+STAFFORD,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",6,000110
+STAFFORD,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",41,000110
+STAFFORD,North Seward Township,Attorney General,,Democratic,"Kotich, A.J.",10,000120
+STAFFORD,North Seward Township,Attorney General,,Republican,"Schmidt, Derek",56,000120
+STAFFORD,North Stafford,Attorney General,,Democratic,"Kotich, A.J.",35,000130
+STAFFORD,North Stafford,Attorney General,,Republican,"Schmidt, Derek",173,000130
+STAFFORD,Ohio Township,Attorney General,,Democratic,"Kotich, A.J.",7,000140
+STAFFORD,Ohio Township,Attorney General,,Republican,"Schmidt, Derek",32,000140
+STAFFORD,Putnam Township,Attorney General,,Democratic,"Kotich, A.J.",0,000150
+STAFFORD,Putnam Township,Attorney General,,Republican,"Schmidt, Derek",10,000150
+STAFFORD,Richland Township,Attorney General,,Democratic,"Kotich, A.J.",3,000160
+STAFFORD,Richland Township,Attorney General,,Republican,"Schmidt, Derek",18,000160
+STAFFORD,Rose Valley Township,Attorney General,,Democratic,"Kotich, A.J.",7,000170
+STAFFORD,Rose Valley Township,Attorney General,,Republican,"Schmidt, Derek",17,000170
+STAFFORD,South Seward Township,Attorney General,,Democratic,"Kotich, A.J.",0,000180
+STAFFORD,South Seward Township,Attorney General,,Republican,"Schmidt, Derek",17,000180
+STAFFORD,South St. John,Attorney General,,Democratic,"Kotich, A.J.",16,000190
+STAFFORD,South St. John,Attorney General,,Republican,"Schmidt, Derek",80,000190
+STAFFORD,South Stafford,Attorney General,,Democratic,"Kotich, A.J.",42,000200
+STAFFORD,South Stafford,Attorney General,,Republican,"Schmidt, Derek",124,000200
+STAFFORD,Union Township,Attorney General,,Democratic,"Kotich, A.J.",3,000210
+STAFFORD,Union Township,Attorney General,,Republican,"Schmidt, Derek",10,000210
+STAFFORD,West Cooper Township,Attorney General,,Democratic,"Kotich, A.J.",3,000220
+STAFFORD,West Cooper Township,Attorney General,,Republican,"Schmidt, Derek",24,000220
+STAFFORD,West St. John,Attorney General,,Democratic,"Kotich, A.J.",22,000230
+STAFFORD,West St. John,Attorney General,,Republican,"Schmidt, Derek",119,000230
+STAFFORD,York Township,Attorney General,,Democratic,"Kotich, A.J.",1,000240
+STAFFORD,York Township,Attorney General,,Republican,"Schmidt, Derek",11,000240
+STAFFORD,Albano Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000010
+STAFFORD,Albano Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000010
+STAFFORD,Byron Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000020
+STAFFORD,Byron Township,Commissioner of Insurance,,Republican,"Selzer, Ken",26,000020
+STAFFORD,Clear Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000030
+STAFFORD,Clear Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000030
+STAFFORD,Cleveland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000040
+STAFFORD,Cleveland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000040
+STAFFORD,Douglas Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000050
+STAFFORD,Douglas Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000050
+STAFFORD,East Cooper Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000060
+STAFFORD,East Cooper Township,Commissioner of Insurance,,Republican,"Selzer, Ken",15,000060
+STAFFORD,East St. John,Commissioner of Insurance,,Democratic,"Anderson, Dennis",43,000070
+STAFFORD,East St. John,Commissioner of Insurance,,Republican,"Selzer, Ken",135,000070
+STAFFORD,Fairview Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000080
+STAFFORD,Fairview Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000080
+STAFFORD,Farmington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",28,000090
+STAFFORD,Farmington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",115,000090
+STAFFORD,Hayes Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000100
+STAFFORD,Hayes Township,Commissioner of Insurance,,Republican,"Selzer, Ken",56,000100
+STAFFORD,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000110
+STAFFORD,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000110
+STAFFORD,North Seward Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000120
+STAFFORD,North Seward Township,Commissioner of Insurance,,Republican,"Selzer, Ken",54,000120
+STAFFORD,North Stafford,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000130
+STAFFORD,North Stafford,Commissioner of Insurance,,Republican,"Selzer, Ken",148,000130
+STAFFORD,Ohio Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000140
+STAFFORD,Ohio Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000140
+STAFFORD,Putnam Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000150
+STAFFORD,Putnam Township,Commissioner of Insurance,,Republican,"Selzer, Ken",9,000150
+STAFFORD,Richland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000160
+STAFFORD,Richland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000160
+STAFFORD,Rose Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000170
+STAFFORD,Rose Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",16,000170
+STAFFORD,South Seward Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000180
+STAFFORD,South Seward Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000180
+STAFFORD,South St. John,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000190
+STAFFORD,South St. John,Commissioner of Insurance,,Republican,"Selzer, Ken",68,000190
+STAFFORD,South Stafford,Commissioner of Insurance,,Democratic,"Anderson, Dennis",51,000200
+STAFFORD,South Stafford,Commissioner of Insurance,,Republican,"Selzer, Ken",110,000200
+STAFFORD,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000210
+STAFFORD,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000210
+STAFFORD,West Cooper Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000220
+STAFFORD,West Cooper Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000220
+STAFFORD,West St. John,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000230
+STAFFORD,West St. John,Commissioner of Insurance,,Republican,"Selzer, Ken",96,000230
+STAFFORD,York Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000240
+STAFFORD,York Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000240
+STAFFORD,Albano Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000010
+STAFFORD,Albano Township,Secretary of State,,Republican,"Kobach, Kris",14,000010
+STAFFORD,Byron Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000020
+STAFFORD,Byron Township,Secretary of State,,Republican,"Kobach, Kris",27,000020
+STAFFORD,Clear Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000030
+STAFFORD,Clear Creek Township,Secretary of State,,Republican,"Kobach, Kris",12,000030
+STAFFORD,Cleveland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000040
+STAFFORD,Cleveland Township,Secretary of State,,Republican,"Kobach, Kris",21,000040
+STAFFORD,Douglas Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000050
+STAFFORD,Douglas Township,Secretary of State,,Republican,"Kobach, Kris",34,000050
+STAFFORD,East Cooper Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000060
+STAFFORD,East Cooper Township,Secretary of State,,Republican,"Kobach, Kris",16,000060
+STAFFORD,East St. John,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",59,000070
+STAFFORD,East St. John,Secretary of State,,Republican,"Kobach, Kris",128,000070
+STAFFORD,Fairview Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000080
+STAFFORD,Fairview Township,Secretary of State,,Republican,"Kobach, Kris",21,000080
+STAFFORD,Farmington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000090
+STAFFORD,Farmington Township,Secretary of State,,Republican,"Kobach, Kris",115,000090
+STAFFORD,Hayes Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000100
+STAFFORD,Hayes Township,Secretary of State,,Republican,"Kobach, Kris",59,000100
+STAFFORD,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000110
+STAFFORD,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",40,000110
+STAFFORD,North Seward Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000120
+STAFFORD,North Seward Township,Secretary of State,,Republican,"Kobach, Kris",52,000120
+STAFFORD,North Stafford,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,000130
+STAFFORD,North Stafford,Secretary of State,,Republican,"Kobach, Kris",139,000130
+STAFFORD,Ohio Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000140
+STAFFORD,Ohio Township,Secretary of State,,Republican,"Kobach, Kris",34,000140
+STAFFORD,Putnam Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000150
+STAFFORD,Putnam Township,Secretary of State,,Republican,"Kobach, Kris",7,000150
+STAFFORD,Richland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000160
+STAFFORD,Richland Township,Secretary of State,,Republican,"Kobach, Kris",16,000160
+STAFFORD,Rose Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000170
+STAFFORD,Rose Valley Township,Secretary of State,,Republican,"Kobach, Kris",13,000170
+STAFFORD,South Seward Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000180
+STAFFORD,South Seward Township,Secretary of State,,Republican,"Kobach, Kris",16,000180
+STAFFORD,South St. John,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000190
+STAFFORD,South St. John,Secretary of State,,Republican,"Kobach, Kris",69,000190
+STAFFORD,South Stafford,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000200
+STAFFORD,South Stafford,Secretary of State,,Republican,"Kobach, Kris",112,000200
+STAFFORD,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000210
+STAFFORD,Union Township,Secretary of State,,Republican,"Kobach, Kris",8,000210
+STAFFORD,West Cooper Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000220
+STAFFORD,West Cooper Township,Secretary of State,,Republican,"Kobach, Kris",25,000220
+STAFFORD,West St. John,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000230
+STAFFORD,West St. John,Secretary of State,,Republican,"Kobach, Kris",98,000230
+STAFFORD,York Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000240
+STAFFORD,York Township,Secretary of State,,Republican,"Kobach, Kris",13,000240
+STAFFORD,Albano Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000010
+STAFFORD,Albano Township,State Treasurer,,Republican,"Estes, Ron",15,000010
+STAFFORD,Byron Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+STAFFORD,Byron Township,State Treasurer,,Republican,"Estes, Ron",29,000020
+STAFFORD,Clear Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+STAFFORD,Clear Creek Township,State Treasurer,,Republican,"Estes, Ron",14,000030
+STAFFORD,Cleveland Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000040
+STAFFORD,Cleveland Township,State Treasurer,,Republican,"Estes, Ron",25,000040
+STAFFORD,Douglas Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000050
+STAFFORD,Douglas Township,State Treasurer,,Republican,"Estes, Ron",36,000050
+STAFFORD,East Cooper Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000060
+STAFFORD,East Cooper Township,State Treasurer,,Republican,"Estes, Ron",17,000060
+STAFFORD,East St. John,State Treasurer,,Democratic,"Alldritt, Carmen",31,000070
+STAFFORD,East St. John,State Treasurer,,Republican,"Estes, Ron",154,000070
+STAFFORD,Fairview Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000080
+STAFFORD,Fairview Township,State Treasurer,,Republican,"Estes, Ron",27,000080
+STAFFORD,Farmington Township,State Treasurer,,Democratic,"Alldritt, Carmen",26,000090
+STAFFORD,Farmington Township,State Treasurer,,Republican,"Estes, Ron",122,000090
+STAFFORD,Hayes Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000100
+STAFFORD,Hayes Township,State Treasurer,,Republican,"Estes, Ron",63,000100
+STAFFORD,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000110
+STAFFORD,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",41,000110
+STAFFORD,North Seward Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000120
+STAFFORD,North Seward Township,State Treasurer,,Republican,"Estes, Ron",58,000120
+STAFFORD,North Stafford,State Treasurer,,Democratic,"Alldritt, Carmen",34,000130
+STAFFORD,North Stafford,State Treasurer,,Republican,"Estes, Ron",172,000130
+STAFFORD,Ohio Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000140
+STAFFORD,Ohio Township,State Treasurer,,Republican,"Estes, Ron",32,000140
+STAFFORD,Putnam Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000150
+STAFFORD,Putnam Township,State Treasurer,,Republican,"Estes, Ron",10,000150
+STAFFORD,Richland Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000160
+STAFFORD,Richland Township,State Treasurer,,Republican,"Estes, Ron",19,000160
+STAFFORD,Rose Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000170
+STAFFORD,Rose Valley Township,State Treasurer,,Republican,"Estes, Ron",20,000170
+STAFFORD,South Seward Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000180
+STAFFORD,South Seward Township,State Treasurer,,Republican,"Estes, Ron",17,000180
+STAFFORD,South St. John,State Treasurer,,Democratic,"Alldritt, Carmen",15,000190
+STAFFORD,South St. John,State Treasurer,,Republican,"Estes, Ron",83,000190
+STAFFORD,South Stafford,State Treasurer,,Democratic,"Alldritt, Carmen",38,000200
+STAFFORD,South Stafford,State Treasurer,,Republican,"Estes, Ron",129,000200
+STAFFORD,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000210
+STAFFORD,Union Township,State Treasurer,,Republican,"Estes, Ron",7,000210
+STAFFORD,West Cooper Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000220
+STAFFORD,West Cooper Township,State Treasurer,,Republican,"Estes, Ron",25,000220
+STAFFORD,West St. John,State Treasurer,,Democratic,"Alldritt, Carmen",23,000230
+STAFFORD,West St. John,State Treasurer,,Republican,"Estes, Ron",115,000230
+STAFFORD,York Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000240
+STAFFORD,York Township,State Treasurer,,Republican,"Estes, Ron",12,000240
+STAFFORD,Albano Township,United States Senate,,independent,"Orman, Greg",3,000010
+STAFFORD,Albano Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+STAFFORD,Albano Township,United States Senate,,Republican,"Roberts, Pat",16,000010
+STAFFORD,Byron Township,United States Senate,,independent,"Orman, Greg",3,000020
+STAFFORD,Byron Township,United States Senate,,Libertarian,"Batson, Randall",0,000020
+STAFFORD,Byron Township,United States Senate,,Republican,"Roberts, Pat",28,000020
+STAFFORD,Clear Creek Township,United States Senate,,independent,"Orman, Greg",4,000030
+STAFFORD,Clear Creek Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+STAFFORD,Clear Creek Township,United States Senate,,Republican,"Roberts, Pat",13,000030
+STAFFORD,Cleveland Township,United States Senate,,independent,"Orman, Greg",3,000040
+STAFFORD,Cleveland Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+STAFFORD,Cleveland Township,United States Senate,,Republican,"Roberts, Pat",24,000040
+STAFFORD,Douglas Township,United States Senate,,independent,"Orman, Greg",13,000050
+STAFFORD,Douglas Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+STAFFORD,Douglas Township,United States Senate,,Republican,"Roberts, Pat",30,000050
+STAFFORD,East Cooper Township,United States Senate,,independent,"Orman, Greg",2,000060
+STAFFORD,East Cooper Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+STAFFORD,East Cooper Township,United States Senate,,Republican,"Roberts, Pat",17,000060
+STAFFORD,East St. John,United States Senate,,independent,"Orman, Greg",59,000070
+STAFFORD,East St. John,United States Senate,,Libertarian,"Batson, Randall",12,000070
+STAFFORD,East St. John,United States Senate,,Republican,"Roberts, Pat",120,000070
+STAFFORD,Fairview Township,United States Senate,,independent,"Orman, Greg",16,000080
+STAFFORD,Fairview Township,United States Senate,,Libertarian,"Batson, Randall",0,000080
+STAFFORD,Fairview Township,United States Senate,,Republican,"Roberts, Pat",21,000080
+STAFFORD,Farmington Township,United States Senate,,independent,"Orman, Greg",30,000090
+STAFFORD,Farmington Township,United States Senate,,Libertarian,"Batson, Randall",5,000090
+STAFFORD,Farmington Township,United States Senate,,Republican,"Roberts, Pat",112,000090
+STAFFORD,Hayes Township,United States Senate,,independent,"Orman, Greg",21,000100
+STAFFORD,Hayes Township,United States Senate,,Libertarian,"Batson, Randall",2,000100
+STAFFORD,Hayes Township,United States Senate,,Republican,"Roberts, Pat",56,000100
+STAFFORD,Lincoln Township,United States Senate,,independent,"Orman, Greg",10,000110
+STAFFORD,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",3,000110
+STAFFORD,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",34,000110
+STAFFORD,North Seward Township,United States Senate,,independent,"Orman, Greg",16,000120
+STAFFORD,North Seward Township,United States Senate,,Libertarian,"Batson, Randall",3,000120
+STAFFORD,North Seward Township,United States Senate,,Republican,"Roberts, Pat",47,000120
+STAFFORD,North Stafford,United States Senate,,independent,"Orman, Greg",72,000130
+STAFFORD,North Stafford,United States Senate,,Libertarian,"Batson, Randall",17,000130
+STAFFORD,North Stafford,United States Senate,,Republican,"Roberts, Pat",125,000130
+STAFFORD,Ohio Township,United States Senate,,independent,"Orman, Greg",6,000140
+STAFFORD,Ohio Township,United States Senate,,Libertarian,"Batson, Randall",1,000140
+STAFFORD,Ohio Township,United States Senate,,Republican,"Roberts, Pat",33,000140
+STAFFORD,Putnam Township,United States Senate,,independent,"Orman, Greg",2,000150
+STAFFORD,Putnam Township,United States Senate,,Libertarian,"Batson, Randall",0,000150
+STAFFORD,Putnam Township,United States Senate,,Republican,"Roberts, Pat",8,000150
+STAFFORD,Richland Township,United States Senate,,independent,"Orman, Greg",4,000160
+STAFFORD,Richland Township,United States Senate,,Libertarian,"Batson, Randall",1,000160
+STAFFORD,Richland Township,United States Senate,,Republican,"Roberts, Pat",16,000160
+STAFFORD,Rose Valley Township,United States Senate,,independent,"Orman, Greg",9,000170
+STAFFORD,Rose Valley Township,United States Senate,,Libertarian,"Batson, Randall",1,000170
+STAFFORD,Rose Valley Township,United States Senate,,Republican,"Roberts, Pat",14,000170
+STAFFORD,South Seward Township,United States Senate,,independent,"Orman, Greg",2,000180
+STAFFORD,South Seward Township,United States Senate,,Libertarian,"Batson, Randall",0,000180
+STAFFORD,South Seward Township,United States Senate,,Republican,"Roberts, Pat",15,000180
+STAFFORD,South St. John,United States Senate,,independent,"Orman, Greg",35,000190
+STAFFORD,South St. John,United States Senate,,Libertarian,"Batson, Randall",4,000190
+STAFFORD,South St. John,United States Senate,,Republican,"Roberts, Pat",62,000190
+STAFFORD,South Stafford,United States Senate,,independent,"Orman, Greg",63,000200
+STAFFORD,South Stafford,United States Senate,,Libertarian,"Batson, Randall",10,000200
+STAFFORD,South Stafford,United States Senate,,Republican,"Roberts, Pat",97,000200
+STAFFORD,Union Township,United States Senate,,independent,"Orman, Greg",7,000210
+STAFFORD,Union Township,United States Senate,,Libertarian,"Batson, Randall",0,000210
+STAFFORD,Union Township,United States Senate,,Republican,"Roberts, Pat",6,000210
+STAFFORD,West Cooper Township,United States Senate,,independent,"Orman, Greg",2,000220
+STAFFORD,West Cooper Township,United States Senate,,Libertarian,"Batson, Randall",2,000220
+STAFFORD,West Cooper Township,United States Senate,,Republican,"Roberts, Pat",25,000220
+STAFFORD,West St. John,United States Senate,,independent,"Orman, Greg",37,000230
+STAFFORD,West St. John,United States Senate,,Libertarian,"Batson, Randall",9,000230
+STAFFORD,West St. John,United States Senate,,Republican,"Roberts, Pat",97,000230
+STAFFORD,York Township,United States Senate,,independent,"Orman, Greg",2,000240
+STAFFORD,York Township,United States Senate,,Libertarian,"Batson, Randall",0,000240
+STAFFORD,York Township,United States Senate,,Republican,"Roberts, Pat",11,000240

--- a/2014/20141104__ks__general__stanton__precinct.csv
+++ b/2014/20141104__ks__general__stanton__precinct.csv
@@ -1,53 +1,52 @@
-county,precinct,office,district,party,candidate,votes
-Stanton,Big Bow,U.S. Senate,,R,Pat Roberts,94
-Stanton,Manter,U.S. Senate,,R,Pat Roberts,76
-Stanton,Stanton,U.S. Senate,,R,Pat Roberts,390
-Stanton,Big Bow,U.S. Senate,,Ind,Greg Orman,13
-Stanton,Manter,U.S. Senate,,Ind,Greg Orman,16
-Stanton,Stanton,U.S. Senate,,Ind,Greg Orman,90
-Stanton,Big Bow,U.S. Senate,,L,Randall Batson,2
-Stanton,Manter,U.S. Senate,,L,Randall Batson,4
-Stanton,Stanton,U.S. Senate,,L,Randall Batson,22
-Stanton,Big Bow,U.S. House,1,R,Tim Huelskamp,88
-Stanton,Manter,U.S. House,1,R,Tim Huelskamp,74
-Stanton,Stanton,U.S. House,1,R,Tim Huelskamp,384
-Stanton,Big Bow,U.S. House,1,D,James Sherow,20
-Stanton,Manter,U.S. House,1,D,James Sherow,23
-Stanton,Stanton,U.S. House,1,D,James Sherow,102
-Stanton,Big Bow,Governor,,R,Sam Brownback,85
-Stanton,Manter,Governor,,R,Sam Brownback,70
-Stanton,Stanton,Governor,,R,Sam Brownback,366
-Stanton,Big Bow,Governor,,D,Paul Davis,16
-Stanton,Manter,Governor,,D,Paul Davis,26
-Stanton,Stanton,Governor,,D,Paul Davis,119
-Stanton,Big Bow,Governor,,L,Keen Umbehr,6
-Stanton,Manter,Governor,,L,Keen Umbehr,2
-Stanton,Stanton,Governor,,L,Keen Umbehr,19
-Stanton,Big Bow,Secretary of State,,R,Kris Kobach,88
-Stanton,Manter,Secretary of State,,R,Kris Kobach,77
-Stanton,Stanton,Secretary of State,,R,Kris Kobach,379
-Stanton,Big Bow,Secretary of State,,D,Jean Schdorf,19
-Stanton,Manter,Secretary of State,,D,Jean Schdorf,16
-Stanton,Stanton,Secretary of State,,D,Jean Schdorf,108
-Stanton,Big Bow,Attorney General,,R,Derek Schmidt,97
-Stanton,Manter,Attorney General,,R,Derek Schmidt,81
-Stanton,Stanton,Attorney General,,R,Derek Schmidt,405
-Stanton,Big Bow,Attorney General,,D,AJ Kotich,8
-Stanton,Manter,Attorney General,,D,AJ Kotich,13
-Stanton,Stanton,Attorney General,,D,AJ Kotich,73
-Stanton,Big Bow,State Treasurer,,R,Ron Estes,99
-Stanton,Manter,State Treasurer,,R,Ron Estes,87
-Stanton,Stanton,State Treasurer,,R,Ron Estes,407
-Stanton,Big Bow,State Treasurer,,D,Carmen Alldritt,9
-Stanton,Manter,State Treasurer,,D,Carmen Alldritt,8
-Stanton,Stanton,State Treasurer,,D,Carmen Alldritt,64
-Stanton,Big Bow,Insurance Commissioner,,R,Ken Selzer,97
-Stanton,Manter,Insurance Commissioner,,R,Ken Selzer,74
-Stanton,Stanton,Insurance Commissioner,,R,Ken Selzer,381
-Stanton,Big Bow,Insurance Commissioner,,D,Dennis Anderson,9
-Stanton,Manter,Insurance Commissioner,,D,Dennis Anderson,19
-Stanton,Stanton,Insurance Commissioner,,D,Dennis Anderson,82
-Stanton,Big Bow,State House,124,R,Stephen Alford R,100
-Stanton,Manter,State House,124,R,Stephen Alford R,81
-Stanton,Stanton,State House,124,R,Stephen Alford R,431
-Stanton,Manter,State House,124,,Janelle Wilkerson,1
+county,precinct,office,district,party,candidate,votes,vtd
+STANTON,Big Bow,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000010
+STANTON,Big Bow,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000010
+STANTON,Big Bow,Governor / Lt. Governor,,Republican,"Brownback, Sam",85,000010
+STANTON,Manter,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000020
+STANTON,Manter,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+STANTON,Manter,Governor / Lt. Governor,,Republican,"Brownback, Sam",70,000020
+STANTON,Stanton,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000030
+STANTON,Stanton,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",19,000030
+STANTON,Stanton,Governor / Lt. Governor,,Republican,"Brownback, Sam",366,000030
+STANTON,Big Bow,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",100,000010
+STANTON,Manter,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",81,000020
+STANTON,Stanton,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",431,000030
+STANTON,Big Bow,United States House of Representatives,1,Democratic,"Sherow, James E.",20,000010
+STANTON,Big Bow,United States House of Representatives,1,Republican,"Huelskamp, Tim",88,000010
+STANTON,Manter,United States House of Representatives,1,Democratic,"Sherow, James E.",23,000020
+STANTON,Manter,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,000020
+STANTON,Stanton,United States House of Representatives,1,Democratic,"Sherow, James E.",102,000030
+STANTON,Stanton,United States House of Representatives,1,Republican,"Huelskamp, Tim",384,000030
+STANTON,Big Bow,Attorney General,,Democratic,"Kotich, A.J.",8,000010
+STANTON,Big Bow,Attorney General,,Republican,"Schmidt, Derek",97,000010
+STANTON,Manter,Attorney General,,Democratic,"Kotich, A.J.",13,000020
+STANTON,Manter,Attorney General,,Republican,"Schmidt, Derek",81,000020
+STANTON,Stanton,Attorney General,,Democratic,"Kotich, A.J.",73,000030
+STANTON,Stanton,Attorney General,,Republican,"Schmidt, Derek",405,000030
+STANTON,Big Bow,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000010
+STANTON,Big Bow,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000010
+STANTON,Manter,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000020
+STANTON,Manter,Commissioner of Insurance,,Republican,"Selzer, Ken",74,000020
+STANTON,Stanton,Commissioner of Insurance,,Democratic,"Anderson, Dennis",82,000030
+STANTON,Stanton,Commissioner of Insurance,,Republican,"Selzer, Ken",381,000030
+STANTON,Big Bow,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000010
+STANTON,Big Bow,Secretary of State,,Republican,"Kobach, Kris",88,000010
+STANTON,Manter,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000020
+STANTON,Manter,Secretary of State,,Republican,"Kobach, Kris",77,000020
+STANTON,Stanton,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",108,000030
+STANTON,Stanton,Secretary of State,,Republican,"Kobach, Kris",379,000030
+STANTON,Big Bow,State Treasurer,,Democratic,"Alldritt, Carmen",9,000010
+STANTON,Big Bow,State Treasurer,,Republican,"Estes, Ron",99,000010
+STANTON,Manter,State Treasurer,,Democratic,"Alldritt, Carmen",8,000020
+STANTON,Manter,State Treasurer,,Republican,"Estes, Ron",87,000020
+STANTON,Stanton,State Treasurer,,Democratic,"Alldritt, Carmen",64,000030
+STANTON,Stanton,State Treasurer,,Republican,"Estes, Ron",407,000030
+STANTON,Big Bow,United States Senate,,independent,"Orman, Greg",13,000010
+STANTON,Big Bow,United States Senate,,Libertarian,"Batson, Randall",2,000010
+STANTON,Big Bow,United States Senate,,Republican,"Roberts, Pat",94,000010
+STANTON,Manter,United States Senate,,independent,"Orman, Greg",16,000020
+STANTON,Manter,United States Senate,,Libertarian,"Batson, Randall",4,000020
+STANTON,Manter,United States Senate,,Republican,"Roberts, Pat",76,000020
+STANTON,Stanton,United States Senate,,independent,"Orman, Greg",90,000030
+STANTON,Stanton,United States Senate,,Libertarian,"Batson, Randall",22,000030
+STANTON,Stanton,United States Senate,,Republican,"Roberts, Pat",390,000030

--- a/2014/20141104__ks__general__stevens__precinct.csv
+++ b/2014/20141104__ks__general__stevens__precinct.csv
@@ -1,239 +1,239 @@
-county,precinct,office,district,party,candidate,votes,
-Stevens,Hugoton W1P1,U.S. Senate,,R,Pat Roberts,103,
-Stevens,Hugoton W1P2,U.S. Senate,,R,Pat Roberts,152,
-Stevens,Hugoton W2P1,U.S. Senate,,R,Pat Roberts,25,
-Stevens,Hugoton W2P2,U.S. Senate,,R,Pat Roberts,239,
-Stevens,Hugoton W3P2,U.S. Senate,,R,Pat Roberts,33,
-Stevens,Hugoton W4P2,U.S. Senate,,R,Pat Roberts,152,
-Stevens,Banner,U.S. Senate,,R,Pat Roberts,48,
-Stevens,Center 1,U.S. Senate,,R,Pat Roberts,18,
-Stevens,Center 2,U.S. Senate,,R,Pat Roberts,90,
-Stevens,Harmony,U.S. Senate,,R,Pat Roberts,25,
-Stevens,Moscow,U.S. Senate,,R,Pat Roberts,140,
-Stevens,Vorhees,U.S. Senate,,R,Pat Roberts,50,
-Stevens,West Center,U.S. Senate,,R,Pat Roberts,33,
-Stevens,Hugoton W5P2,U.S. Senate,,R,Pat Roberts,11,
-Stevens,Hugoton W1P1,U.S. Senate,,IND,Greg Orman,28,
-Stevens,Hugoton W1P2,U.S. Senate,,IND,Greg Orman,26,
-Stevens,Hugoton W2P1,U.S. Senate,,IND,Greg Orman,4,
-Stevens,Hugoton W2P2,U.S. Senate,,IND,Greg Orman,82,
-Stevens,Hugoton W3P2,U.S. Senate,,IND,Greg Orman,7,
-Stevens,Hugoton W4P2,U.S. Senate,,IND,Greg Orman,32,
-Stevens,Banner,U.S. Senate,,IND,Greg Orman,6,
-Stevens,Center 1,U.S. Senate,,IND,Greg Orman,1,
-Stevens,Center 2,U.S. Senate,,IND,Greg Orman,16,
-Stevens,Harmony,U.S. Senate,,IND,Greg Orman,2,
-Stevens,Moscow,U.S. Senate,,IND,Greg Orman,21,
-Stevens,Vorhees,U.S. Senate,,IND,Greg Orman,4,
-Stevens,West Center,U.S. Senate,,IND,Greg Orman,10,
-Stevens,Hugoton W5P2,U.S. Senate,,IND,Greg Orman,1,
-Stevens,Hugoton W1P1,U.S. Senate,,LBT,Randall Batson,10,
-Stevens,Hugoton W1P2,U.S. Senate,,LBT,Randall Batson,6,
-Stevens,Hugoton W2P1,U.S. Senate,,LBT,Randall Batson,2,
-Stevens,Hugoton W2P2,U.S. Senate,,LBT,Randall Batson,14,
-Stevens,Hugoton W3P2,U.S. Senate,,LBT,Randall Batson,1,
-Stevens,Hugoton W4P2,U.S. Senate,,LBT,Randall Batson,6,
-Stevens,Banner,U.S. Senate,,LBT,Randall Batson,2,
-Stevens,Center 1,U.S. Senate,,LBT,Randall Batson,1,
-Stevens,Center 2,U.S. Senate,,LBT,Randall Batson,7,
-Stevens,Harmony,U.S. Senate,,LBT,Randall Batson,1,
-Stevens,Moscow,U.S. Senate,,LBT,Randall Batson,9,
-Stevens,Vorhees,U.S. Senate,,LBT,Randall Batson,2,
-Stevens,West Center,U.S. Senate,,LBT,Randall Batson,4,
-Stevens,Hugoton W5P2,U.S. Senate,,LBT,Randall Batson,1,
-Stevens,Hugoton W1P1,U.S. House,1,R,Tim Huelskamp,107,
-Stevens,Hugoton W1P2,U.S. House,1,R,Tim Huelskamp,154,
-Stevens,Hugoton W2P1,U.S. House,1,R,Tim Huelskamp,27,
-Stevens,Hugoton W2P2,U.S. House,1,R,Tim Huelskamp,258,
-Stevens,Hugoton W3P2,U.S. House,1,R,Tim Huelskamp,37,
-Stevens,Hugoton W4P2,U.S. House,1,R,Tim Huelskamp,151,
-Stevens,Banner,U.S. House,1,R,Tim Huelskamp,51,
-Stevens,Center 1,U.S. House,1,R,Tim Huelskamp,16,
-Stevens,Center 2,U.S. House,1,R,Tim Huelskamp,98,
-Stevens,Harmony,U.S. House,1,R,Tim Huelskamp,27,
-Stevens,Moscow,U.S. House,1,R,Tim Huelskamp,144,
-Stevens,Vorhees,U.S. House,1,R,Tim Huelskamp,48,
-Stevens,West Center,U.S. House,1,R,Tim Huelskamp,39,
-Stevens,Hugoton W5P2,U.S. House,1,R,Tim Huelskamp,8,
-Stevens,Hugoton W1P1,U.S. House,1,D,James Sherow,33,
-Stevens,Hugoton W1P2,U.S. House,1,D,James Sherow,26,
-Stevens,Hugoton W2P1,U.S. House,1,D,James Sherow,4,
-Stevens,Hugoton W2P2,U.S. House,1,D,James Sherow,71,
-Stevens,Hugoton W3P2,U.S. House,1,D,James Sherow,4,
-Stevens,Hugoton W4P2,U.S. House,1,D,James Sherow,30,
-Stevens,Banner,U.S. House,1,D,James Sherow,6,
-Stevens,Center 1,U.S. House,1,D,James Sherow,2,
-Stevens,Center 2,U.S. House,1,D,James Sherow,16,
-Stevens,Harmony,U.S. House,1,D,James Sherow,1,
-Stevens,Moscow,U.S. House,1,D,James Sherow,22,
-Stevens,Vorhees,U.S. House,1,D,James Sherow,7,
-Stevens,West Center,U.S. House,1,D,James Sherow,7,
-Stevens,Hugoton W5P2,U.S. House,1,D,James Sherow,2,
-Stevens,Hugoton W1P1,Governor,,LBT,Keen Umbehr,8,
-Stevens,Hugoton W1P2,Governor,,LBT,Keen Umbehr,6,
-Stevens,Hugoton W2P1,Governor,,LBT,Keen Umbehr,4,
-Stevens,Hugoton W2P2,Governor,,LBT,Keen Umbehr,6,
-Stevens,Hugoton W3P2,Governor,,LBT,Keen Umbehr,1,
-Stevens,Hugoton W4P2,Governor,,LBT,Keen Umbehr,6,
-Stevens,Banner,Governor,,LBT,Keen Umbehr,0,
-Stevens,Center 1,Governor,,LBT,Keen Umbehr,2,
-Stevens,Center 2,Governor,,LBT,Keen Umbehr,6,
-Stevens,Harmony,Governor,,LBT,Keen Umbehr,1,
-Stevens,Moscow,Governor,,LBT,Keen Umbehr,9,
-Stevens,Vorhees,Governor,,LBT,Keen Umbehr,1,
-Stevens,West Center,Governor,,LBT,Keen Umbehr,4,
-Stevens,Hugoton W5P2,Governor,,LBT,Keen Umbehr,0,
-Stevens,Hugoton W1P1,Governor,,R,Sam Brownback,83,
-Stevens,Hugoton W1P2,Governor,,R,Sam Brownback,128,
-Stevens,Hugoton W2P1,Governor,,R,Sam Brownback,21,
-Stevens,Hugoton W2P2,Governor,,R,Sam Brownback,206,
-Stevens,Hugoton W3P2,Governor,,R,Sam Brownback,25,
-Stevens,Hugoton W4P2,Governor,,R,Sam Brownback,123,
-Stevens,Banner,Governor,,R,Sam Brownback,45,
-Stevens,Center 1,Governor,,R,Sam Brownback,13,
-Stevens,Center 2,Governor,,R,Sam Brownback,72,
-Stevens,Harmony,Governor,,R,Sam Brownback,26,
-Stevens,Moscow,Governor,,R,Sam Brownback,119,
-Stevens,Vorhees,Governor,,R,Sam Brownback,48,
-Stevens,West Center,Governor,,R,Sam Brownback,30,
-Stevens,Hugoton W5P2,Governor,,R,Sam Brownback,7,
-Stevens,Hugoton W1P1,Governor,,D,Paul Davis,51,
-Stevens,Hugoton W1P2,Governor,,D,Paul Davis,47,
-Stevens,Hugoton W2P1,Governor,,D,Paul Davis,6,
-Stevens,Hugoton W2P2,Governor,,D,Paul Davis,119,
-Stevens,Hugoton W3P2,Governor,,D,Paul Davis,15,
-Stevens,Hugoton W4P2,Governor,,D,Paul Davis,61,
-Stevens,Banner,Governor,,D,Paul Davis,11,
-Stevens,Center 1,Governor,,D,Paul Davis,5,
-Stevens,Center 2,Governor,,D,Paul Davis,36,
-Stevens,Harmony,Governor,,D,Paul Davis,1,
-Stevens,Moscow,Governor,,D,Paul Davis,43,
-Stevens,Vorhees,Governor,,D,Paul Davis,9,
-Stevens,West Center,Governor,,D,Paul Davis,13,
-Stevens,Hugoton W5P2,Governor,,D,Paul Davis,2,
-Stevens,Hugoton W1P1,Secretary of State,,D,Jean Schodorf,29,
-Stevens,Hugoton W1P2,Secretary of State,,D,Jean Schodorf,31,
-Stevens,Hugoton W2P1,Secretary of State,,D,Jean Schodorf,3,
-Stevens,Hugoton W2P2,Secretary of State,,D,Jean Schodorf,65,
-Stevens,Hugoton W3P2,Secretary of State,,D,Jean Schodorf,5,
-Stevens,Hugoton W4P2,Secretary of State,,D,Jean Schodorf,30,
-Stevens,Banner,Secretary of State,,D,Jean Schodorf,6,
-Stevens,Center 1,Secretary of State,,D,Jean Schodorf,3,
-Stevens,Center 2,Secretary of State,,D,Jean Schodorf,12,
-Stevens,Harmony,Secretary of State,,D,Jean Schodorf,1,
-Stevens,Moscow,Secretary of State,,D,Jean Schodorf,27,
-Stevens,Vorhees,Secretary of State,,D,Jean Schodorf,5,
-Stevens,West Center,Secretary of State,,D,Jean Schodorf,5,
-Stevens,Hugoton W5P2,Secretary of State,,D,Jean Schodorf,3,
-Stevens,Hugoton W1P1,Secretary of State,,R,Kris Kobach,110,
-Stevens,Hugoton W1P2,Secretary of State,,R,Kris Kobach,148,
-Stevens,Hugoton W2P1,Secretary of State,,R,Kris Kobach,28,
-Stevens,Hugoton W2P2,Secretary of State,,R,Kris Kobach,259,
-Stevens,Hugoton W3P2,Secretary of State,,R,Kris Kobach,36,
-Stevens,Hugoton W4P2,Secretary of State,,R,Kris Kobach,154,
-Stevens,Banner,Secretary of State,,R,Kris Kobach,51,
-Stevens,Center 1,Secretary of State,,R,Kris Kobach,17,
-Stevens,Center 2,Secretary of State,,R,Kris Kobach,96,
-Stevens,Harmony,Secretary of State,,R,Kris Kobach,26,
-Stevens,Moscow,Secretary of State,,R,Kris Kobach,139,
-Stevens,Vorhees,Secretary of State,,R,Kris Kobach,49,
-Stevens,West Center,Secretary of State,,R,Kris Kobach,41,
-Stevens,Hugoton W5P2,Secretary of State,,R,Kris Kobach,8,
-Stevens,Hugoton W1P1,Attorney General,,R,Derek Schmidt,115,
-Stevens,Hugoton W1P2,Attorney General,,R,Derek Schmidt,162,
-Stevens,Hugoton W2P1,Attorney General,,R,Derek Schmidt,28,
-Stevens,Hugoton W2P2,Attorney General,,R,Derek Schmidt,288,
-Stevens,Hugoton W3P2,Attorney General,,R,Derek Schmidt,36,
-Stevens,Hugoton W4P2,Attorney General,,R,Derek Schmidt,168,
-Stevens,Banner,Attorney General,,R,Derek Schmidt,51,
-Stevens,Center 1,Attorney General,,R,Derek Schmidt,20,
-Stevens,Center 2,Attorney General,,R,Derek Schmidt,108,
-Stevens,Harmony,Attorney General,,R,Derek Schmidt,26,
-Stevens,Moscow,Attorney General,,R,Derek Schmidt,145,
-Stevens,Vorhees,Attorney General,,R,Derek Schmidt,48,
-Stevens,West Center,Attorney General,,R,Derek Schmidt,37,
-Stevens,Hugoton W5P2,Attorney General,,R,Derek Schmidt,7,
-Stevens,Hugoton W1P1,Attorney General,,D,A.J. Kotich,21,
-Stevens,Hugoton W1P2,Attorney General,,D,A.J. Kotich,14,
-Stevens,Hugoton W2P1,Attorney General,,D,A.J. Kotich,2,
-Stevens,Hugoton W2P2,Attorney General,,D,A.J. Kotich,36,
-Stevens,Hugoton W3P2,Attorney General,,D,A.J. Kotich,3,
-Stevens,Hugoton W4P2,Attorney General,,D,A.J. Kotich,13,
-Stevens,Banner,Attorney General,,D,A.J. Kotich,6,
-Stevens,Center 1,Attorney General,,D,A.J. Kotich,0,
-Stevens,Center 2,Attorney General,,D,A.J. Kotich,1,
-Stevens,Harmony,Attorney General,,D,A.J. Kotich,1,
-Stevens,Moscow,Attorney General,,D,A.J. Kotich,16,
-Stevens,Vorhees,Attorney General,,D,A.J. Kotich,3,
-Stevens,West Center,Attorney General,,D,A.J. Kotich,6,
-Stevens,Hugoton W5P2,Attorney General,,D,A.J. Kotich,4,
-Stevens,Hugoton W1P1,State Treasurer,,R,Ron Estes,115,
-Stevens,Hugoton W1P2,State Treasurer,,R,Ron Estes,167,
-Stevens,Hugoton W2P1,State Treasurer,,R,Ron Estes,29,
-Stevens,Hugoton W2P2,State Treasurer,,R,Ron Estes,289,
-Stevens,Hugoton W3P2,State Treasurer,,R,Ron Estes,36,
-Stevens,Hugoton W4P2,State Treasurer,,R,Ron Estes,167,
-Stevens,Banner,State Treasurer,,R,Ron Estes,53,
-Stevens,Center 1,State Treasurer,,R,Ron Estes,20,
-Stevens,Center 2,State Treasurer,,R,Ron Estes,102,
-Stevens,Harmony,State Treasurer,,R,Ron Estes,26,
-Stevens,Moscow,State Treasurer,,R,Ron Estes,146,
-Stevens,Vorhees,State Treasurer,,R,Ron Estes,52,
-Stevens,West Center,State Treasurer,,R,Ron Estes,39,
-Stevens,Hugoton W5P2,State Treasurer,,R,Ron Estes,7,
-Stevens,Hugoton W1P1,State Treasurer,,D,Carmen Alldritt,21,
-Stevens,Hugoton W1P2,State Treasurer,,D,Carmen Alldritt,12,
-Stevens,Hugoton W2P1,State Treasurer,,D,Carmen Alldritt,1,
-Stevens,Hugoton W2P2,State Treasurer,,D,Carmen Alldritt,33,
-Stevens,Hugoton W3P2,State Treasurer,,D,Carmen Alldritt,3,
-Stevens,Hugoton W4P2,State Treasurer,,D,Carmen Alldritt,15,
-Stevens,Banner,State Treasurer,,D,Carmen Alldritt,2,
-Stevens,Center 1,State Treasurer,,D,Carmen Alldritt,0,
-Stevens,Center 2,State Treasurer,,D,Carmen Alldritt,5,
-Stevens,Harmony,State Treasurer,,D,Carmen Alldritt,1,
-Stevens,Moscow,State Treasurer,,D,Carmen Alldritt,17,
-Stevens,Vorhees,State Treasurer,,D,Carmen Alldritt,3,
-Stevens,West Center,State Treasurer,,D,Carmen Alldritt,6,
-Stevens,Hugoton W5P2,State Treasurer,,D,Carmen Alldritt,4,
-Stevens,Hugoton W1P1,Insurance Commissioner,,R,Ken Selzer,111,
-Stevens,Hugoton W1P2,Insurance Commissioner,,R,Ken Selzer,150,
-Stevens,Hugoton W2P1,Insurance Commissioner,,R,Ken Selzer,27,
-Stevens,Hugoton W2P2,Insurance Commissioner,,R,Ken Selzer,268,
-Stevens,Hugoton W3P2,Insurance Commissioner,,R,Ken Selzer,35,
-Stevens,Hugoton W4P2,Insurance Commissioner,,R,Ken Selzer,157,
-Stevens,Banner,Insurance Commissioner,,R,Ken Selzer,51,
-Stevens,Center 1,Insurance Commissioner,,R,Ken Selzer,17,
-Stevens,Center 2,Insurance Commissioner,,R,Ken Selzer,95,
-Stevens,Harmony,Insurance Commissioner,,R,Ken Selzer,23,
-Stevens,Moscow,Insurance Commissioner,,R,Ken Selzer,145,
-Stevens,Vorhees,Insurance Commissioner,,R,Ken Selzer,46,
-Stevens,West Center,Insurance Commissioner,,R,Ken Selzer,36,
-Stevens,Hugoton W5P2,Insurance Commissioner,,R,Ken Selzer,6,
-Stevens,Hugoton W1P1,Insurance Commissioner,,D,Dennis Anderson,23,
-Stevens,Hugoton W1P2,Insurance Commissioner,,D,Dennis Anderson,21,
-Stevens,Hugoton W2P1,Insurance Commissioner,,D,Dennis Anderson,3,
-Stevens,Hugoton W2P2,Insurance Commissioner,,D,Dennis Anderson,46,
-Stevens,Hugoton W3P2,Insurance Commissioner,,D,Dennis Anderson,3,
-Stevens,Hugoton W4P2,Insurance Commissioner,,D,Dennis Anderson,19,
-Stevens,Banner,Insurance Commissioner,,D,Dennis Anderson,3,
-Stevens,Center 1,Insurance Commissioner,,D,Dennis Anderson,1,
-Stevens,Center 2,Insurance Commissioner,,D,Dennis Anderson,7,
-Stevens,Harmony,Insurance Commissioner,,D,Dennis Anderson,1,
-Stevens,Moscow,Insurance Commissioner,,D,Dennis Anderson,19,
-Stevens,Vorhees,Insurance Commissioner,,D,Dennis Anderson,4,
-Stevens,West Center,Insurance Commissioner,,D,Dennis Anderson,8,
-Stevens,Hugoton W5P2,Insurance Commissioner,,D,Dennis Anderson,4,
-Stevens,Hugoton W1P1,State House,124,R,Stephen Alford,127,
-Stevens,Hugoton W1P2,State House,124,R,Stephen Alford,156,
-Stevens,Hugoton W2P1,State House,124,R,Stephen Alford,27,
-Stevens,Hugoton W2P2,State House,124,R,Stephen Alford,283,
-Stevens,Hugoton W3P2,State House,124,R,Stephen Alford,37,
-Stevens,Hugoton W4P2,State House,124,R,Stephen Alford,169,
-Stevens,Banner,State House,124,R,Stephen Alford,52,
-Stevens,Center 1,State House,124,R,Stephen Alford,18,
-Stevens,Center 2,State House,124,R,Stephen Alford,104,
-Stevens,Harmony,State House,124,R,Stephen Alford,25,
-Stevens,Moscow,State House,124,R,Stephen Alford,158,
-Stevens,Vorhees,State House,124,R,Stephen Alford,48,
-Stevens,West Center,State House,124,R,Stephen Alford,41,
-Stevens,Hugoton W5P2,State House,124,R,Stephen Alford,8,
+county,precinct,office,district,party,candidate,votes,vtd
+STEVENS,Banner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000010
+STEVENS,Banner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000010
+STEVENS,Banner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,000010
+STEVENS,Center Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000020
+STEVENS,Center Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000020
+STEVENS,Center Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",13,000020
+STEVENS,Center Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",36,000030
+STEVENS,Center Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000030
+STEVENS,Center Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000030
+STEVENS,Harmony Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000040
+STEVENS,Harmony Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+STEVENS,Harmony Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",51,000050
+STEVENS,Hugoton Ward 1 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000050
+STEVENS,Hugoton Ward 1 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",83,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,000060
+STEVENS,Hugoton Ward 1 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000060
+STEVENS,Hugoton Ward 1 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000070
+STEVENS,Hugoton Ward 2 Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000070
+STEVENS,Hugoton Ward 2 Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",119,000080
+STEVENS,Hugoton Ward 2 Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000080
+STEVENS,Hugoton Ward 2 Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",206,000080
+STEVENS,Moscow Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000090
+STEVENS,Moscow Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000090
+STEVENS,Moscow Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000090
+STEVENS,Voorhees Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000100
+STEVENS,Voorhees Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+STEVENS,Voorhees Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000100
+STEVENS,West Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000110
+STEVENS,West Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000110
+STEVENS,West Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",30,000110
+STEVENS,Hugoton Ward 03 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,120010
+STEVENS,Hugoton Ward 03 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,120010
+STEVENS,Hugoton Ward 03 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,120010
+STEVENS,Hugoton Ward 04 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",61,120020
+STEVENS,Hugoton Ward 04 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,120020
+STEVENS,Hugoton Ward 04 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",123,120020
+STEVENS,Hugoton Ward 05 Precinct 02,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,120030
+STEVENS,Hugoton Ward 05 Precinct 02,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,Governor / Lt. Governor,,Republican,"Brownback, Sam",7,120030
+STEVENS,Banner Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",52,000010
+STEVENS,Center Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",18,000020
+STEVENS,Center Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",104,000030
+STEVENS,Harmony Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",25,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",127,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",156,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",27,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",283,000080
+STEVENS,Moscow Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",158,000090
+STEVENS,Voorhees Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",48,000100
+STEVENS,West Center Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",41,000110
+STEVENS,Hugoton Ward 03 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",37,120010
+STEVENS,Hugoton Ward 04 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",169,120020
+STEVENS,Hugoton Ward 05 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",8,120030
+STEVENS,Banner Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000010
+STEVENS,Banner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000010
+STEVENS,Center Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000020
+STEVENS,Center Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000020
+STEVENS,Center Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000030
+STEVENS,Center Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",98,000030
+STEVENS,Harmony Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000040
+STEVENS,Harmony Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000040
+STEVENS,Hugoton Ward 1 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",33,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",107,000050
+STEVENS,Hugoton Ward 1 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",26,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",154,000060
+STEVENS,Hugoton Ward 2 Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000070
+STEVENS,Hugoton Ward 2 Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",71,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",258,000080
+STEVENS,Moscow Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000090
+STEVENS,Moscow Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",144,000090
+STEVENS,Voorhees Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000100
+STEVENS,Voorhees Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000100
+STEVENS,West Center Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000110
+STEVENS,West Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000110
+STEVENS,Hugoton Ward 03 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",4,120010
+STEVENS,Hugoton Ward 03 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,120010
+STEVENS,Hugoton Ward 04 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",30,120020
+STEVENS,Hugoton Ward 04 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",151,120020
+STEVENS,Hugoton Ward 05 Precinct 02,United States House of Representatives,1,Democratic,"Sherow, James E.",2,120030
+STEVENS,Hugoton Ward 05 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,120030
+STEVENS,Banner Township,Attorney General,,Democratic,"Kotich, A.J.",6,000010
+STEVENS,Banner Township,Attorney General,,Republican,"Schmidt, Derek",51,000010
+STEVENS,Center Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",0,000020
+STEVENS,Center Precinct 1,Attorney General,,Republican,"Schmidt, Derek",20,000020
+STEVENS,Center Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",1,000030
+STEVENS,Center Precinct 2,Attorney General,,Republican,"Schmidt, Derek",108,000030
+STEVENS,Harmony Township,Attorney General,,Democratic,"Kotich, A.J.",1,000040
+STEVENS,Harmony Township,Attorney General,,Republican,"Schmidt, Derek",26,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",21,000050
+STEVENS,Hugoton Ward 1 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",115,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",14,000060
+STEVENS,Hugoton Ward 1 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",162,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",2,000070
+STEVENS,Hugoton Ward 2 Precinct 1,Attorney General,,Republican,"Schmidt, Derek",28,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",36,000080
+STEVENS,Hugoton Ward 2 Precinct 2,Attorney General,,Republican,"Schmidt, Derek",288,000080
+STEVENS,Moscow Township,Attorney General,,Democratic,"Kotich, A.J.",16,000090
+STEVENS,Moscow Township,Attorney General,,Republican,"Schmidt, Derek",145,000090
+STEVENS,Voorhees Township,Attorney General,,Democratic,"Kotich, A.J.",3,000100
+STEVENS,Voorhees Township,Attorney General,,Republican,"Schmidt, Derek",48,000100
+STEVENS,West Center Township,Attorney General,,Democratic,"Kotich, A.J.",6,000110
+STEVENS,West Center Township,Attorney General,,Republican,"Schmidt, Derek",37,000110
+STEVENS,Hugoton Ward 03 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",3,120010
+STEVENS,Hugoton Ward 03 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",36,120010
+STEVENS,Hugoton Ward 04 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",13,120020
+STEVENS,Hugoton Ward 04 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",168,120020
+STEVENS,Hugoton Ward 05 Precinct 02,Attorney General,,Democratic,"Kotich, A.J.",4,120030
+STEVENS,Hugoton Ward 05 Precinct 02,Attorney General,,Republican,"Schmidt, Derek",7,120030
+STEVENS,Banner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000010
+STEVENS,Banner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000010
+STEVENS,Center Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000020
+STEVENS,Center Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000020
+STEVENS,Center Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000030
+STEVENS,Center Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",95,000030
+STEVENS,Harmony Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000040
+STEVENS,Harmony Township,Commissioner of Insurance,,Republican,"Selzer, Ken",23,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000050
+STEVENS,Hugoton Ward 1 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000060
+STEVENS,Hugoton Ward 1 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",150,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000070
+STEVENS,Hugoton Ward 2 Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",46,000080
+STEVENS,Hugoton Ward 2 Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",268,000080
+STEVENS,Moscow Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000090
+STEVENS,Moscow Township,Commissioner of Insurance,,Republican,"Selzer, Ken",145,000090
+STEVENS,Voorhees Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000100
+STEVENS,Voorhees Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000100
+STEVENS,West Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000110
+STEVENS,West Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",36,000110
+STEVENS,Hugoton Ward 03 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,120010
+STEVENS,Hugoton Ward 03 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",35,120010
+STEVENS,Hugoton Ward 04 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,120020
+STEVENS,Hugoton Ward 04 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",157,120020
+STEVENS,Hugoton Ward 05 Precinct 02,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,120030
+STEVENS,Hugoton Ward 05 Precinct 02,Commissioner of Insurance,,Republican,"Selzer, Ken",6,120030
+STEVENS,Banner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000010
+STEVENS,Banner Township,Secretary of State,,Republican,"Kobach, Kris",51,000010
+STEVENS,Center Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000020
+STEVENS,Center Precinct 1,Secretary of State,,Republican,"Kobach, Kris",17,000020
+STEVENS,Center Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000030
+STEVENS,Center Precinct 2,Secretary of State,,Republican,"Kobach, Kris",96,000030
+STEVENS,Harmony Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000040
+STEVENS,Harmony Township,Secretary of State,,Republican,"Kobach, Kris",26,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000050
+STEVENS,Hugoton Ward 1 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",110,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000060
+STEVENS,Hugoton Ward 1 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",148,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000070
+STEVENS,Hugoton Ward 2 Precinct 1,Secretary of State,,Republican,"Kobach, Kris",28,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000080
+STEVENS,Hugoton Ward 2 Precinct 2,Secretary of State,,Republican,"Kobach, Kris",259,000080
+STEVENS,Moscow Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000090
+STEVENS,Moscow Township,Secretary of State,,Republican,"Kobach, Kris",139,000090
+STEVENS,Voorhees Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000100
+STEVENS,Voorhees Township,Secretary of State,,Republican,"Kobach, Kris",49,000100
+STEVENS,West Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000110
+STEVENS,West Center Township,Secretary of State,,Republican,"Kobach, Kris",41,000110
+STEVENS,Hugoton Ward 03 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,120010
+STEVENS,Hugoton Ward 03 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",36,120010
+STEVENS,Hugoton Ward 04 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,120020
+STEVENS,Hugoton Ward 04 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",154,120020
+STEVENS,Hugoton Ward 05 Precinct 02,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,120030
+STEVENS,Hugoton Ward 05 Precinct 02,Secretary of State,,Republican,"Kobach, Kris",8,120030
+STEVENS,Banner Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000010
+STEVENS,Banner Township,State Treasurer,,Republican,"Estes, Ron",53,000010
+STEVENS,Center Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,000020
+STEVENS,Center Precinct 1,State Treasurer,,Republican,"Estes, Ron",20,000020
+STEVENS,Center Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",5,000030
+STEVENS,Center Precinct 2,State Treasurer,,Republican,"Estes, Ron",102,000030
+STEVENS,Harmony Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000040
+STEVENS,Harmony Township,State Treasurer,,Republican,"Estes, Ron",26,000040
+STEVENS,Hugoton Ward 1 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",21,000050
+STEVENS,Hugoton Ward 1 Precinct 1,State Treasurer,,Republican,"Estes, Ron",115,000050
+STEVENS,Hugoton Ward 1 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",12,000060
+STEVENS,Hugoton Ward 1 Precinct 2,State Treasurer,,Republican,"Estes, Ron",167,000060
+STEVENS,Hugoton Ward 2 Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",1,000070
+STEVENS,Hugoton Ward 2 Precinct 1,State Treasurer,,Republican,"Estes, Ron",29,000070
+STEVENS,Hugoton Ward 2 Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",33,000080
+STEVENS,Hugoton Ward 2 Precinct 2,State Treasurer,,Republican,"Estes, Ron",289,000080
+STEVENS,Moscow Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000090
+STEVENS,Moscow Township,State Treasurer,,Republican,"Estes, Ron",146,000090
+STEVENS,Voorhees Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000100
+STEVENS,Voorhees Township,State Treasurer,,Republican,"Estes, Ron",52,000100
+STEVENS,West Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000110
+STEVENS,West Center Township,State Treasurer,,Republican,"Estes, Ron",39,000110
+STEVENS,Hugoton Ward 03 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",3,120010
+STEVENS,Hugoton Ward 03 Precinct 02,State Treasurer,,Republican,"Estes, Ron",36,120010
+STEVENS,Hugoton Ward 04 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",15,120020
+STEVENS,Hugoton Ward 04 Precinct 02,State Treasurer,,Republican,"Estes, Ron",167,120020
+STEVENS,Hugoton Ward 05 Precinct 02,State Treasurer,,Democratic,"Alldritt, Carmen",4,120030
+STEVENS,Hugoton Ward 05 Precinct 02,State Treasurer,,Republican,"Estes, Ron",7,120030
+STEVENS,Banner Township,United States Senate,,independent,"Orman, Greg",6,000010
+STEVENS,Banner Township,United States Senate,,Libertarian,"Batson, Randall",2,000010
+STEVENS,Banner Township,United States Senate,,Republican,"Roberts, Pat",48,000010
+STEVENS,Center Precinct 1,United States Senate,,independent,"Orman, Greg",1,000020
+STEVENS,Center Precinct 1,United States Senate,,Libertarian,"Batson, Randall",1,000020
+STEVENS,Center Precinct 1,United States Senate,,Republican,"Roberts, Pat",18,000020
+STEVENS,Center Precinct 2,United States Senate,,independent,"Orman, Greg",16,000030
+STEVENS,Center Precinct 2,United States Senate,,Libertarian,"Batson, Randall",7,000030
+STEVENS,Center Precinct 2,United States Senate,,Republican,"Roberts, Pat",90,000030
+STEVENS,Harmony Township,United States Senate,,independent,"Orman, Greg",2,000040
+STEVENS,Harmony Township,United States Senate,,Libertarian,"Batson, Randall",1,000040
+STEVENS,Harmony Township,United States Senate,,Republican,"Roberts, Pat",25,000040
+STEVENS,Hugoton Ward 1 Precinct 1,United States Senate,,independent,"Orman, Greg",28,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",10,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States Senate,,Republican,"Roberts, Pat",103,000050
+STEVENS,Hugoton Ward 1 Precinct 2,United States Senate,,independent,"Orman, Greg",26,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",6,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States Senate,,Republican,"Roberts, Pat",152,000060
+STEVENS,Hugoton Ward 2 Precinct 1,United States Senate,,independent,"Orman, Greg",4,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States Senate,,Libertarian,"Batson, Randall",2,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States Senate,,Republican,"Roberts, Pat",25,000070
+STEVENS,Hugoton Ward 2 Precinct 2,United States Senate,,independent,"Orman, Greg",82,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States Senate,,Libertarian,"Batson, Randall",14,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States Senate,,Republican,"Roberts, Pat",239,000080
+STEVENS,Moscow Township,United States Senate,,independent,"Orman, Greg",21,000090
+STEVENS,Moscow Township,United States Senate,,Libertarian,"Batson, Randall",9,000090
+STEVENS,Moscow Township,United States Senate,,Republican,"Roberts, Pat",140,000090
+STEVENS,Voorhees Township,United States Senate,,independent,"Orman, Greg",4,000100
+STEVENS,Voorhees Township,United States Senate,,Libertarian,"Batson, Randall",2,000100
+STEVENS,Voorhees Township,United States Senate,,Republican,"Roberts, Pat",50,000100
+STEVENS,West Center Township,United States Senate,,independent,"Orman, Greg",10,000110
+STEVENS,West Center Township,United States Senate,,Libertarian,"Batson, Randall",4,000110
+STEVENS,West Center Township,United States Senate,,Republican,"Roberts, Pat",33,000110
+STEVENS,Hugoton Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",7,120010
+STEVENS,Hugoton Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",1,120010
+STEVENS,Hugoton Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",33,120010
+STEVENS,Hugoton Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",32,120020
+STEVENS,Hugoton Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",6,120020
+STEVENS,Hugoton Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",152,120020
+STEVENS,Hugoton Ward 05 Precinct 02,United States Senate,,independent,"Orman, Greg",1,120030
+STEVENS,Hugoton Ward 05 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",1,120030
+STEVENS,Hugoton Ward 05 Precinct 02,United States Senate,,Republican,"Roberts, Pat",11,120030

--- a/2014/20141104__ks__general__sumner__precinct.csv
+++ b/2014/20141104__ks__general__sumner__precinct.csv
@@ -1,695 +1,777 @@
-county,precinct,office,district,party,candidate,vote
-Sumner,AVON,Attorney General,,D,A.J. Kotich,23
-Sumner,BELLE PLAINE TWP   H79,Attorney General,,D,A.J. Kotich,255
-Sumner,BELLE PLAINE TWP   H82,Attorney General,,D,A.J. Kotich,2
-Sumner,BLUFF,Attorney General,,D,A.J. Kotich,1
-Sumner,CALDWELL TWP,Attorney General,,D,A.J. Kotich,9
-Sumner,CHIKASKIA,Attorney General,,D,A.J. Kotich,1
-Sumner,CONWAY,Attorney General,,D,A.J. Kotich,66
-Sumner,CREEK,Attorney General,,D,A.J. Kotich,6
-Sumner,DIXON,Attorney General,,D,A.J. Kotich,34
-Sumner,DOWNS,Attorney General,,D,A.J. Kotich,9
-Sumner,EDEN,Attorney General,,D,A.J. Kotich,23
-Sumner,FALLS,Attorney General,,D,A.J. Kotich,8
-Sumner,GORE   H79,Attorney General,,D,A.J. Kotich,53
-Sumner,GORE   H82,Attorney General,,D,A.J. Kotich,20
-Sumner,GREENE,Attorney General,,D,A.J. Kotich,1
-Sumner,GUELPH,Attorney General,,D,A.J. Kotich,7
-Sumner,HARMON,Attorney General,,D,A.J. Kotich,15
-Sumner,ILLINOIS,Attorney General,,D,A.J. Kotich,9
-Sumner,JACKSON,Attorney General,,D,A.J. Kotich,7
-Sumner,LONDON,Attorney General,,D,A.J. Kotich,47
-Sumner,MORRIS,Attorney General,,D,A.J. Kotich,0
-Sumner,OSBORNE,Attorney General,,D,A.J. Kotich,20
-Sumner,OXFORD TWP,Attorney General,,D,A.J. Kotich,101
-Sumner,PALESTINE,Attorney General,,D,A.J. Kotich,22
-Sumner,RYAN,Attorney General,,D,A.J. Kotich,16
-Sumner,SEVENTY-SIX,Attorney General,,D,A.J. Kotich,12
-Sumner,SOUTH HAVEN TWP,Attorney General,,D,A.J. Kotich,38
-Sumner,SPRINGDALE,Attorney General,,D,A.J. Kotich,46
-Sumner,Sumner,Attorney General,,D,A.J. Kotich,12
-Sumner,VALVERDE,Attorney General,,D,A.J. Kotich,7
-Sumner,WALTON,Attorney General,,D,A.J. Kotich,30
-Sumner,WELLINGTON TWP    H80,Attorney General,,D,A.J. Kotich,8
-Sumner,WELLINGTON TWP    116,Attorney General,,D,A.J. Kotich,13
-Sumner,AVON,Attorney General,,R,Derek Schmidt,95
-Sumner,BELLE PLAINE TWP   H79,Attorney General,,R,Derek Schmidt,675
-Sumner,BELLE PLAINE TWP   H82,Attorney General,,R,Derek Schmidt,3
-Sumner,BLUFF,Attorney General,,R,Derek Schmidt,19
-Sumner,CALDWELL TWP,Attorney General,,R,Derek Schmidt,42
-Sumner,CHIKASKIA,Attorney General,,R,Derek Schmidt,23
-Sumner,CONWAY,Attorney General,,R,Derek Schmidt,286
-Sumner,CREEK,Attorney General,,R,Derek Schmidt,55
-Sumner,DIXON,Attorney General,,R,Derek Schmidt,168
-Sumner,DOWNS,Attorney General,,R,Derek Schmidt,41
-Sumner,EDEN,Attorney General,,R,Derek Schmidt,101
-Sumner,FALLS,Attorney General,,R,Derek Schmidt,38
-Sumner,GORE   H79,Attorney General,,R,Derek Schmidt,209
-Sumner,GORE   H82,Attorney General,,R,Derek Schmidt,59
-Sumner,GREENE,Attorney General,,R,Derek Schmidt,26
-Sumner,GUELPH,Attorney General,,R,Derek Schmidt,47
-Sumner,HARMON,Attorney General,,R,Derek Schmidt,87
-Sumner,ILLINOIS,Attorney General,,R,Derek Schmidt,64
-Sumner,JACKSON,Attorney General,,R,Derek Schmidt,51
-Sumner,LONDON,Attorney General,,R,Derek Schmidt,200
-Sumner,MORRIS,Attorney General,,R,Derek Schmidt,8
-Sumner,OSBORNE,Attorney General,,R,Derek Schmidt,67
-Sumner,OXFORD TWP,Attorney General,,R,Derek Schmidt,350
-Sumner,PALESTINE,Attorney General,,R,Derek Schmidt,62
-Sumner,RYAN,Attorney General,,R,Derek Schmidt,40
-Sumner,SEVENTY-SIX,Attorney General,,R,Derek Schmidt,82
-Sumner,SOUTH HAVEN TWP,Attorney General,,R,Derek Schmidt,150
-Sumner,SPRINGDALE,Attorney General,,R,Derek Schmidt,155
-Sumner,Sumner,Attorney General,,R,Derek Schmidt,36
-Sumner,VALVERDE,Attorney General,,R,Derek Schmidt,48
-Sumner,WALTON,Attorney General,,R,Derek Schmidt,86
-Sumner,WELLINGTON TWP    H80,Attorney General,,R,Derek Schmidt,41
-Sumner,WELLINGTON TWP    116,Attorney General,,R,Derek Schmidt,67
-Sumner,AVON,Insurance Commissioner,,D,Dennis Anderson,32
-Sumner,BELLE PLAINE TWP   H79,Insurance Commissioner,,D,Dennis Anderson,299
-Sumner,BELLE PLAINE TWP   H82,Insurance Commissioner,,D,Dennis Anderson,2
-Sumner,BLUFF,Insurance Commissioner,,D,Dennis Anderson,9
-Sumner,CALDWELL TWP,Insurance Commissioner,,D,Dennis Anderson,16
-Sumner,CHIKASKIA,Insurance Commissioner,,D,Dennis Anderson,2
-Sumner,CONWAY,Insurance Commissioner,,D,Dennis Anderson,92
-Sumner,CREEK,Insurance Commissioner,,D,Dennis Anderson,9
-Sumner,DIXON,Insurance Commissioner,,D,Dennis Anderson,46
-Sumner,DOWNS,Insurance Commissioner,,D,Dennis Anderson,13
-Sumner,EDEN,Insurance Commissioner,,D,Dennis Anderson,26
-Sumner,FALLS,Insurance Commissioner,,D,Dennis Anderson,13
-Sumner,GORE   H79,Insurance Commissioner,,D,Dennis Anderson,64
-Sumner,GORE   H82,Insurance Commissioner,,D,Dennis Anderson,24
-Sumner,GREENE,Insurance Commissioner,,D,Dennis Anderson,5
-Sumner,GUELPH,Insurance Commissioner,,D,Dennis Anderson,11
-Sumner,HARMON,Insurance Commissioner,,D,Dennis Anderson,22
-Sumner,ILLINOIS,Insurance Commissioner,,D,Dennis Anderson,11
-Sumner,JACKSON,Insurance Commissioner,,D,Dennis Anderson,16
-Sumner,LONDON,Insurance Commissioner,,D,Dennis Anderson,65
-Sumner,MORRIS,Insurance Commissioner,,D,Dennis Anderson,0
-Sumner,OSBORNE,Insurance Commissioner,,D,Dennis Anderson,23
-Sumner,OXFORD TWP,Insurance Commissioner,,D,Dennis Anderson,130
-Sumner,PALESTINE,Insurance Commissioner,,D,Dennis Anderson,31
-Sumner,RYAN,Insurance Commissioner,,D,Dennis Anderson,16
-Sumner,SEVENTY-SIX,Insurance Commissioner,,D,Dennis Anderson,12
-Sumner,SOUTH HAVEN TWP,Insurance Commissioner,,D,Dennis Anderson,49
-Sumner,SPRINGDALE,Insurance Commissioner,,D,Dennis Anderson,48
-Sumner,Sumner,Insurance Commissioner,,D,Dennis Anderson,14
-Sumner,VALVERDE,Insurance Commissioner,,D,Dennis Anderson,9
-Sumner,WALTON,Insurance Commissioner,,D,Dennis Anderson,29
-Sumner,WELLINGTON TWP    H80,Insurance Commissioner,,D,Dennis Anderson,15
-Sumner,WELLINGTON TWP    116,Insurance Commissioner,,D,Dennis Anderson,20
-Sumner,AVON,Insurance Commissioner,,R,Ken Selzer,84
-Sumner,BELLE PLAINE TWP   H79,Insurance Commissioner,,R,Ken Selzer,619
-Sumner,BELLE PLAINE TWP   H82,Insurance Commissioner,,R,Ken Selzer,3
-Sumner,BLUFF,Insurance Commissioner,,R,Ken Selzer,11
-Sumner,CALDWELL TWP,Insurance Commissioner,,R,Ken Selzer,33
-Sumner,CHIKASKIA,Insurance Commissioner,,R,Ken Selzer,22
-Sumner,CONWAY,Insurance Commissioner,,R,Ken Selzer,251
-Sumner,CREEK,Insurance Commissioner,,R,Ken Selzer,49
-Sumner,DIXON,Insurance Commissioner,,R,Ken Selzer,155
-Sumner,DOWNS,Insurance Commissioner,,R,Ken Selzer,32
-Sumner,EDEN,Insurance Commissioner,,R,Ken Selzer,95
-Sumner,FALLS,Insurance Commissioner,,R,Ken Selzer,31
-Sumner,GORE   H79,Insurance Commissioner,,R,Ken Selzer,194
-Sumner,GORE   H82,Insurance Commissioner,,R,Ken Selzer,54
-Sumner,GREENE,Insurance Commissioner,,R,Ken Selzer,22
-Sumner,GUELPH,Insurance Commissioner,,R,Ken Selzer,42
-Sumner,HARMON,Insurance Commissioner,,R,Ken Selzer,77
-Sumner,ILLINOIS,Insurance Commissioner,,R,Ken Selzer,61
-Sumner,JACKSON,Insurance Commissioner,,R,Ken Selzer,41
-Sumner,LONDON,Insurance Commissioner,,R,Ken Selzer,177
-Sumner,MORRIS,Insurance Commissioner,,R,Ken Selzer,8
-Sumner,OSBORNE,Insurance Commissioner,,R,Ken Selzer,64
-Sumner,OXFORD TWP,Insurance Commissioner,,R,Ken Selzer,307
-Sumner,PALESTINE,Insurance Commissioner,,R,Ken Selzer,53
-Sumner,RYAN,Insurance Commissioner,,R,Ken Selzer,41
-Sumner,SEVENTY-SIX,Insurance Commissioner,,R,Ken Selzer,81
-Sumner,SOUTH HAVEN TWP,Insurance Commissioner,,R,Ken Selzer,133
-Sumner,SPRINGDALE,Insurance Commissioner,,R,Ken Selzer,151
-Sumner,Sumner,Insurance Commissioner,,R,Ken Selzer,29
-Sumner,VALVERDE,Insurance Commissioner,,R,Ken Selzer,42
-Sumner,WALTON,Insurance Commissioner,,R,Ken Selzer,84
-Sumner,WELLINGTON TWP    H80,Insurance Commissioner,,R,Ken Selzer,33
-Sumner,WELLINGTON TWP    116,Insurance Commissioner,,R,Ken Selzer,61
-Sumner,AVON,Governor,,L,Keen Umbehr,7
-Sumner,BELLE PLAINE TWP   H79,Governor,,L,Keen Umbehr,63
-Sumner,BELLE PLAINE TWP   H82,Governor,,L,Keen Umbehr,0
-Sumner,BLUFF,Governor,,L,Keen Umbehr,0
-Sumner,CALDWELL TWP,Governor,,L,Keen Umbehr,4
-Sumner,CHIKASKIA,Governor,,L,Keen Umbehr,1
-Sumner,CONWAY,Governor,,L,Keen Umbehr,18
-Sumner,CREEK,Governor,,L,Keen Umbehr,1
-Sumner,DIXON,Governor,,L,Keen Umbehr,7
-Sumner,DOWNS,Governor,,L,Keen Umbehr,1
-Sumner,EDEN,Governor,,L,Keen Umbehr,7
-Sumner,FALLS,Governor,,L,Keen Umbehr,3
-Sumner,GORE   H79,Governor,,L,Keen Umbehr,15
-Sumner,GORE   H82,Governor,,L,Keen Umbehr,7
-Sumner,GREENE,Governor,,L,Keen Umbehr,3
-Sumner,GUELPH,Governor,,L,Keen Umbehr,4
-Sumner,HARMON,Governor,,L,Keen Umbehr,6
-Sumner,ILLINOIS,Governor,,L,Keen Umbehr,4
-Sumner,JACKSON,Governor,,L,Keen Umbehr,5
-Sumner,LONDON,Governor,,L,Keen Umbehr,12
-Sumner,MORRIS,Governor,,L,Keen Umbehr,0
-Sumner,OSBORNE,Governor,,L,Keen Umbehr,4
-Sumner,OXFORD TWP,Governor,,L,Keen Umbehr,27
-Sumner,PALESTINE,Governor,,L,Keen Umbehr,1
-Sumner,RYAN,Governor,,L,Keen Umbehr,1
-Sumner,SEVENTY-SIX,Governor,,L,Keen Umbehr,5
-Sumner,SOUTH HAVEN TWP,Governor,,L,Keen Umbehr,17
-Sumner,SPRINGDALE,Governor,,L,Keen Umbehr,9
-Sumner,Sumner,Governor,,L,Keen Umbehr,0
-Sumner,VALVERDE,Governor,,L,Keen Umbehr,2
-Sumner,WALTON,Governor,,L,Keen Umbehr,3
-Sumner,WELLINGTON TWP    H80,Governor,,L,Keen Umbehr,3
-Sumner,WELLINGTON TWP    116,Governor,,L,Keen Umbehr,5
-Sumner,AVON,Governor,,D,Paul Davis,46
-Sumner,BELLE PLAINE TWP   H79,Governor,,D,Paul Davis,393
-Sumner,BELLE PLAINE TWP   H82,Governor,,D,Paul Davis,2
-Sumner,BLUFF,Governor,,D,Paul Davis,8
-Sumner,CALDWELL TWP,Governor,,D,Paul Davis,25
-Sumner,CHIKASKIA,Governor,,D,Paul Davis,5
-Sumner,CONWAY,Governor,,D,Paul Davis,138
-Sumner,CREEK,Governor,,D,Paul Davis,13
-Sumner,DIXON,Governor,,D,Paul Davis,57
-Sumner,DOWNS,Governor,,D,Paul Davis,13
-Sumner,EDEN,Governor,,D,Paul Davis,39
-Sumner,FALLS,Governor,,D,Paul Davis,24
-Sumner,GORE   H79,Governor,,D,Paul Davis,88
-Sumner,GORE   H82,Governor,,D,Paul Davis,31
-Sumner,GREENE,Governor,,D,Paul Davis,6
-Sumner,GUELPH,Governor,,D,Paul Davis,17
-Sumner,HARMON,Governor,,D,Paul Davis,29
-Sumner,ILLINOIS,Governor,,D,Paul Davis,13
-Sumner,JACKSON,Governor,,D,Paul Davis,26
-Sumner,LONDON,Governor,,D,Paul Davis,72
-Sumner,MORRIS,Governor,,D,Paul Davis,5
-Sumner,OSBORNE,Governor,,D,Paul Davis,36
-Sumner,OXFORD TWP,Governor,,D,Paul Davis,185
-Sumner,PALESTINE,Governor,,D,Paul Davis,35
-Sumner,RYAN,Governor,,D,Paul Davis,23
-Sumner,SEVENTY-SIX,Governor,,D,Paul Davis,16
-Sumner,SOUTH HAVEN TWP,Governor,,D,Paul Davis,67
-Sumner,SPRINGDALE,Governor,,D,Paul Davis,73
-Sumner,Sumner,Governor,,D,Paul Davis,18
-Sumner,VALVERDE,Governor,,D,Paul Davis,11
-Sumner,WALTON,Governor,,D,Paul Davis,47
-Sumner,WELLINGTON TWP    H80,Governor,,D,Paul Davis,22
-Sumner,WELLINGTON TWP    116,Governor,,D,Paul Davis,29
-Sumner,AVON,Governor,,R,Sam Brownback,69
-Sumner,BELLE PLAINE TWP   H79,Governor,,R,Sam Brownback,480
-Sumner,BELLE PLAINE TWP   H82,Governor,,R,Sam Brownback,3
-Sumner,BLUFF,Governor,,R,Sam Brownback,12
-Sumner,CALDWELL TWP,Governor,,R,Sam Brownback,23
-Sumner,CHIKASKIA,Governor,,R,Sam Brownback,18
-Sumner,CONWAY,Governor,,R,Sam Brownback,202
-Sumner,CREEK,Governor,,R,Sam Brownback,49
-Sumner,DIXON,Governor,,R,Sam Brownback,139
-Sumner,DOWNS,Governor,,R,Sam Brownback,35
-Sumner,EDEN,Governor,,R,Sam Brownback,80
-Sumner,FALLS,Governor,,R,Sam Brownback,20
-Sumner,GORE   H79,Governor,,R,Sam Brownback,163
-Sumner,GORE   H82,Governor,,R,Sam Brownback,42
-Sumner,GREENE,Governor,,R,Sam Brownback,18
-Sumner,GUELPH,Governor,,R,Sam Brownback,34
-Sumner,HARMON,Governor,,R,Sam Brownback,68
-Sumner,ILLINOIS,Governor,,R,Sam Brownback,55
-Sumner,JACKSON,Governor,,R,Sam Brownback,27
-Sumner,LONDON,Governor,,R,Sam Brownback,169
-Sumner,MORRIS,Governor,,R,Sam Brownback,4
-Sumner,OSBORNE,Governor,,R,Sam Brownback,49
-Sumner,OXFORD TWP,Governor,,R,Sam Brownback,247
-Sumner,PALESTINE,Governor,,R,Sam Brownback,51
-Sumner,RYAN,Governor,,R,Sam Brownback,31
-Sumner,SEVENTY-SIX,Governor,,R,Sam Brownback,74
-Sumner,SOUTH HAVEN TWP,Governor,,R,Sam Brownback,106
-Sumner,SPRINGDALE,Governor,,R,Sam Brownback,126
-Sumner,Sumner,Governor,,R,Sam Brownback,32
-Sumner,VALVERDE,Governor,,R,Sam Brownback,44
-Sumner,WALTON,Governor,,R,Sam Brownback,68
-Sumner,WELLINGTON TWP    H80,Governor,,R,Sam Brownback,25
-Sumner,WELLINGTON TWP    116,Governor,,R,Sam Brownback,48
-Sumner,AVON,Secretary of State,,D,Jean Schodorf,45
-Sumner,BELLE PLAINE TWP   H79,Secretary of State,,D,Jean Schodorf,361
-Sumner,BELLE PLAINE TWP   H82,Secretary of State,,D,Jean Schodorf,2
-Sumner,BLUFF,Secretary of State,,D,Jean Schodorf,4
-Sumner,CALDWELL TWP,Secretary of State,,D,Jean Schodorf,28
-Sumner,CHIKASKIA,Secretary of State,,D,Jean Schodorf,5
-Sumner,CONWAY,Secretary of State,,D,Jean Schodorf,114
-Sumner,CREEK,Secretary of State,,D,Jean Schodorf,15
-Sumner,DIXON,Secretary of State,,D,Jean Schodorf,53
-Sumner,DOWNS,Secretary of State,,D,Jean Schodorf,11
-Sumner,EDEN,Secretary of State,,D,Jean Schodorf,33
-Sumner,FALLS,Secretary of State,,D,Jean Schodorf,17
-Sumner,GORE   H79,Secretary of State,,D,Jean Schodorf,74
-Sumner,GORE   H82,Secretary of State,,D,Jean Schodorf,30
-Sumner,GREENE,Secretary of State,,D,Jean Schodorf,2
-Sumner,GUELPH,Secretary of State,,D,Jean Schodorf,13
-Sumner,HARMON,Secretary of State,,D,Jean Schodorf,29
-Sumner,ILLINOIS,Secretary of State,,D,Jean Schodorf,13
-Sumner,JACKSON,Secretary of State,,D,Jean Schodorf,21
-Sumner,LONDON,Secretary of State,,D,Jean Schodorf,70
-Sumner,MORRIS,Secretary of State,,D,Jean Schodorf,1
-Sumner,OSBORNE,Secretary of State,,D,Jean Schodorf,32
-Sumner,OXFORD TWP,Secretary of State,,D,Jean Schodorf,155
-Sumner,PALESTINE,Secretary of State,,D,Jean Schodorf,33
-Sumner,RYAN,Secretary of State,,D,Jean Schodorf,18
-Sumner,SEVENTY-SIX,Secretary of State,,D,Jean Schodorf,20
-Sumner,SOUTH HAVEN TWP,Secretary of State,,D,Jean Schodorf,53
-Sumner,SPRINGDALE,Secretary of State,,D,Jean Schodorf,70
-Sumner,Sumner,Secretary of State,,D,Jean Schodorf,19
-Sumner,VALVERDE,Secretary of State,,D,Jean Schodorf,12
-Sumner,WALTON,Secretary of State,,D,Jean Schodorf,33
-Sumner,WELLINGTON TWP    H80,Secretary of State,,D,Jean Schodorf,14
-Sumner,WELLINGTON TWP    116,Secretary of State,,D,Jean Schodorf,19
-Sumner,AVON,Secretary of State,,R,Kris Kobach,74
-Sumner,BELLE PLAINE TWP   H79,Secretary of State,,R,Kris Kobach,577
-Sumner,BELLE PLAINE TWP   H82,Secretary of State,,R,Kris Kobach,3
-Sumner,BLUFF,Secretary of State,,R,Kris Kobach,15
-Sumner,CALDWELL TWP,Secretary of State,,R,Kris Kobach,23
-Sumner,CHIKASKIA,Secretary of State,,R,Kris Kobach,19
-Sumner,CONWAY,Secretary of State,,R,Kris Kobach,241
-Sumner,CREEK,Secretary of State,,R,Kris Kobach,48
-Sumner,DIXON,Secretary of State,,R,Kris Kobach,149
-Sumner,DOWNS,Secretary of State,,R,Kris Kobach,37
-Sumner,EDEN,Secretary of State,,R,Kris Kobach,90
-Sumner,FALLS,Secretary of State,,R,Kris Kobach,29
-Sumner,GORE   H79,Secretary of State,,R,Kris Kobach,189
-Sumner,GORE   H82,Secretary of State,,R,Kris Kobach,49
-Sumner,GREENE,Secretary of State,,R,Kris Kobach,25
-Sumner,GUELPH,Secretary of State,,R,Kris Kobach,41
-Sumner,HARMON,Secretary of State,,R,Kris Kobach,74
-Sumner,ILLINOIS,Secretary of State,,R,Kris Kobach,59
-Sumner,JACKSON,Secretary of State,,R,Kris Kobach,37
-Sumner,LONDON,Secretary of State,,R,Kris Kobach,181
-Sumner,MORRIS,Secretary of State,,R,Kris Kobach,8
-Sumner,OSBORNE,Secretary of State,,R,Kris Kobach,56
-Sumner,OXFORD TWP,Secretary of State,,R,Kris Kobach,299
-Sumner,PALESTINE,Secretary of State,,R,Kris Kobach,53
-Sumner,RYAN,Secretary of State,,R,Kris Kobach,39
-Sumner,SEVENTY-SIX,Secretary of State,,R,Kris Kobach,73
-Sumner,SOUTH HAVEN TWP,Secretary of State,,R,Kris Kobach,136
-Sumner,SPRINGDALE,Secretary of State,,R,Kris Kobach,137
-Sumner,Sumner,Secretary of State,,R,Kris Kobach,30
-Sumner,VALVERDE,Secretary of State,,R,Kris Kobach,43
-Sumner,WALTON,Secretary of State,,R,Kris Kobach,84
-Sumner,WELLINGTON TWP    H80,Secretary of State,,R,Kris Kobach,36
-Sumner,WELLINGTON TWP    116,Secretary of State,,R,Kris Kobach,62
-Sumner,BELLE PLAINE TWP   H79,State House,79,D,Ed Trimmer D,364
-Sumner,BELLE PLAINE TWP   H82,State House,82,D,Danette Harris D,2
-Sumner,GORE   H79,State House,79,D,Ed Trimmer D,82
-Sumner,GORE   H82,State House,82,D,Danette Harris D,40
-Sumner,HARMON,State House,79,D,Ed Trimmer D,37
-Sumner,OXFORD TWP,State House,79,D,Ed Trimmer D,193
-Sumner,PALESTINE,State House,79,D,Ed Trimmer D,35
-Sumner,AVON,State House,80,R,Kasha Kelley R,103
-Sumner,BELLE PLAINE TWP   H79,State House,79,R,Larry W. Alley R,568
-Sumner,BELLE PLAINE TWP   H82,State House,82,R,Pete DeGraaf R,3
-Sumner,BLUFF,State House,80,R,Kasha Kelley R,17
-Sumner,CALDWELL TWP,State House,80,R,Kasha Kelley R,43
-Sumner,CHIKASKIA,State House,80,R,Kasha Kelley R,23
-Sumner,CONWAY,State House,116,R,Kyle  D. Hoffman R,308
-Sumner,CREEK,State House,116,R,Kyle  D. Hoffman R,54
-Sumner,DIXON,State House,116,R,Kyle  D. Hoffman R,182
-Sumner,DOWNS,State House,80,R,Kasha Kelley R,38
-Sumner,DOWNS,State House,116,R,Kyle  D. Hoffman R,104
-Sumner,FALLS,State House,80,R,Kasha Kelley R,35
-Sumner,GORE   H79,State House,79,R,Larry W. Alley R,176
-Sumner,GORE   H82,State House,82,R,Pete DeGraaf R,39
-Sumner,GREENE,State House,80,R,Kasha Kelley R,23
-Sumner,GUELPH,State House,80,R,Kasha Kelley R,45
-Sumner,HARMON,State House,79,R,Larry W. Alley R,65
-Sumner,ILLINOIS,State House,116,R,Kyle  D. Hoffman R,67
-Sumner,JACKSON,State House,80,R,Kasha Kelley R,51
-Sumner,LONDON,State House,116,R,Kyle  D. Hoffman R,216
-Sumner,MORRIS,State House,80,R,Kasha Kelley R,8
-Sumner,OSBORNE,State House,116,R,Kyle  D. Hoffman R,76
-Sumner,OXFORD TWP,State House,79,R,Larry W. Alley R,263
-Sumner,PALESTINE,State House,79,R,Larry W. Alley R,52
-Sumner,RYAN,State House,116,R,Kyle  D. Hoffman R,48
-Sumner,SEVENTY-SIX,State House,116,R,Kyle  D. Hoffman R,86
-Sumner,SOUTH HAVEN TWP,State House,80,R,Kasha Kelley R,160
-Sumner,SPRINGDALE,State House,116,R,Kyle  D. Hoffman R,182
-Sumner,Sumner,State House,116,R,Kyle  D. Hoffman R,43
-Sumner,VALVERDE,State House,80,R,Kasha Kelley R,48
-Sumner,WALTON,State House,80,R,Kasha Kelley R,102
-Sumner,WELLINGTON TWP    116,State House,116,R,Kyle  D. Hoffman R,71
-Sumner,WELLINGTON TWP    H80,State House,80,R,Kasha Kelley R,43
-Sumner,AVON,State Treasurer,,D,Carmen Alldritt,28
-Sumner,BELLE PLAINE TWP   H79,State Treasurer,,D,Carmen Alldritt,244
-Sumner,BELLE PLAINE TWP   H82,State Treasurer,,D,Carmen Alldritt,2
-Sumner,BLUFF,State Treasurer,,D,Carmen Alldritt,3
-Sumner,CALDWELL TWP,State Treasurer,,D,Carmen Alldritt,12
-Sumner,CHIKASKIA,State Treasurer,,D,Carmen Alldritt,1
-Sumner,CONWAY,State Treasurer,,D,Carmen Alldritt,62
-Sumner,CREEK,State Treasurer,,D,Carmen Alldritt,6
-Sumner,DIXON,State Treasurer,,D,Carmen Alldritt,46
-Sumner,DOWNS,State Treasurer,,D,Carmen Alldritt,10
-Sumner,EDEN,State Treasurer,,D,Carmen Alldritt,30
-Sumner,FALLS,State Treasurer,,D,Carmen Alldritt,9
-Sumner,GORE   H79,State Treasurer,,D,Carmen Alldritt,51
-Sumner,GORE   H82,State Treasurer,,D,Carmen Alldritt,20
-Sumner,GREENE,State Treasurer,,D,Carmen Alldritt,1
-Sumner,GUELPH,State Treasurer,,D,Carmen Alldritt,10
-Sumner,HARMON,State Treasurer,,D,Carmen Alldritt,18
-Sumner,ILLINOIS,State Treasurer,,D,Carmen Alldritt,11
-Sumner,JACKSON,State Treasurer,,D,Carmen Alldritt,9
-Sumner,LONDON,State Treasurer,,D,Carmen Alldritt,38
-Sumner,MORRIS,State Treasurer,,D,Carmen Alldritt,1
-Sumner,OSBORNE,State Treasurer,,D,Carmen Alldritt,20
-Sumner,OXFORD TWP,State Treasurer,,D,Carmen Alldritt,97
-Sumner,PALESTINE,State Treasurer,,D,Carmen Alldritt,20
-Sumner,RYAN,State Treasurer,,D,Carmen Alldritt,14
-Sumner,SEVENTY-SIX,State Treasurer,,D,Carmen Alldritt,9
-Sumner,SOUTH HAVEN TWP,State Treasurer,,D,Carmen Alldritt,37
-Sumner,SPRINGDALE,State Treasurer,,D,Carmen Alldritt,33
-Sumner,Sumner,State Treasurer,,D,Carmen Alldritt,11
-Sumner,VALVERDE,State Treasurer,,D,Carmen Alldritt,7
-Sumner,WALTON,State Treasurer,,D,Carmen Alldritt,20
-Sumner,WELLINGTON TWP    H80,State Treasurer,,D,Carmen Alldritt,11
-Sumner,WELLINGTON TWP    116,State Treasurer,,D,Carmen Alldritt,24
-Sumner,AVON,State Treasurer,,R,Ron Estes,90
-Sumner,BELLE PLAINE TWP   H79,State Treasurer,,R,Ron Estes,685
-Sumner,BELLE PLAINE TWP   H82,State Treasurer,,R,Ron Estes,3
-Sumner,BLUFF,State Treasurer,,R,Ron Estes,16
-Sumner,CALDWELL TWP,State Treasurer,,R,Ron Estes,38
-Sumner,CHIKASKIA,State Treasurer,,R,Ron Estes,23
-Sumner,CONWAY,State Treasurer,,R,Ron Estes,290
-Sumner,CREEK,State Treasurer,,R,Ron Estes,56
-Sumner,DIXON,State Treasurer,,R,Ron Estes,155
-Sumner,DOWNS,State Treasurer,,R,Ron Estes,38
-Sumner,EDEN,State Treasurer,,R,Ron Estes,95
-Sumner,FALLS,State Treasurer,,R,Ron Estes,37
-Sumner,GORE   H79,State Treasurer,,R,Ron Estes,212
-Sumner,GORE   H82,State Treasurer,,R,Ron Estes,59
-Sumner,GREENE,State Treasurer,,R,Ron Estes,26
-Sumner,GUELPH,State Treasurer,,R,Ron Estes,44
-Sumner,HARMON,State Treasurer,,R,Ron Estes,85
-Sumner,ILLINOIS,State Treasurer,,R,Ron Estes,61
-Sumner,JACKSON,State Treasurer,,R,Ron Estes,49
-Sumner,LONDON,State Treasurer,,R,Ron Estes,208
-Sumner,MORRIS,State Treasurer,,R,Ron Estes,7
-Sumner,OSBORNE,State Treasurer,,R,Ron Estes,68
-Sumner,OXFORD TWP,State Treasurer,,R,Ron Estes,353
-Sumner,PALESTINE,State Treasurer,,R,Ron Estes,65
-Sumner,RYAN,State Treasurer,,R,Ron Estes,43
-Sumner,SEVENTY-SIX,State Treasurer,,R,Ron Estes,85
-Sumner,SOUTH HAVEN TWP,State Treasurer,,R,Ron Estes,150
-Sumner,SPRINGDALE,State Treasurer,,R,Ron Estes,171
-Sumner,Sumner,State Treasurer,,R,Ron Estes,37
-Sumner,VALVERDE,State Treasurer,,R,Ron Estes,45
-Sumner,WALTON,State Treasurer,,R,Ron Estes,95
-Sumner,WELLINGTON TWP    H80,State Treasurer,,R,Ron Estes,39
-Sumner,WELLINGTON TWP    116,State Treasurer,,R,Ron Estes,57
-Sumner,AVON,U.S. House,4,R,Mike Pompeo,85
-Sumner,BELLE PLAINE TWP   H79,U.S. House,4,R,Mike Pompeo,644
-Sumner,BELLE PLAINE TWP   H82,U.S. House,4,R,Mike Pompeo,3
-Sumner,BLUFF,U.S. House,4,R,Mike Pompeo,18
-Sumner,CALDWELL TWP,U.S. House,4,R,Mike Pompeo,35
-Sumner,CHIKASKIA,U.S. House,4,R,Mike Pompeo,22
-Sumner,CONWAY,U.S. House,4,R,Mike Pompeo,267
-Sumner,CREEK,U.S. House,4,R,Mike Pompeo,56
-Sumner,DIXON,U.S. House,4,R,Mike Pompeo,158
-Sumner,DOWNS,U.S. House,4,R,Mike Pompeo,36
-Sumner,EDEN,U.S. House,4,R,Mike Pompeo,100
-Sumner,FALLS,U.S. House,4,R,Mike Pompeo,36
-Sumner,GORE   H79,U.S. House,4,R,Mike Pompeo,202
-Sumner,GORE   H82,U.S. House,4,R,Mike Pompeo,58
-Sumner,GREENE,U.S. House,4,R,Mike Pompeo,23
-Sumner,GUELPH,U.S. House,4,R,Mike Pompeo,42
-Sumner,HARMON,U.S. House,4,R,Mike Pompeo,85
-Sumner,ILLINOIS,U.S. House,4,R,Mike Pompeo,58
-Sumner,JACKSON,U.S. House,4,R,Mike Pompeo,43
-Sumner,LONDON,U.S. House,4,R,Mike Pompeo,194
-Sumner,MORRIS,U.S. House,4,R,Mike Pompeo,9
-Sumner,OSBORNE,U.S. House,4,R,Mike Pompeo,68
-Sumner,OXFORD TWP,U.S. House,4,R,Mike Pompeo,312
-Sumner,PALESTINE,U.S. House,4,R,Mike Pompeo,58
-Sumner,RYAN,U.S. House,4,R,Mike Pompeo,41
-Sumner,SEVENTY-SIX,U.S. House,4,R,Mike Pompeo,85
-Sumner,SOUTH HAVEN TWP,U.S. House,4,R,Mike Pompeo,150
-Sumner,SPRINGDALE,U.S. House,4,R,Mike Pompeo,154
-Sumner,Sumner,U.S. House,4,R,Mike Pompeo,34
-Sumner,VALVERDE,U.S. House,4,R,Mike Pompeo,47
-Sumner,WALTON,U.S. House,4,R,Mike Pompeo,87
-Sumner,WELLINGTON TWP    H80,U.S. House,4,R,Mike Pompeo,38
-Sumner,WELLINGTON TWP    116,U.S. House,4,R,Mike Pompeo,58
-Sumner,AVON,U.S. House,4,D,Perry Schuckman,35
-Sumner,BELLE PLAINE TWP   H79,U.S. House,4,D,Perry Schuckman,290
-Sumner,BELLE PLAINE TWP   H82,U.S. House,4,D,Perry Schuckman,2
-Sumner,BLUFF,U.S. House,4,D,Perry Schuckman,1
-Sumner,CALDWELL TWP,U.S. House,4,D,Perry Schuckman,15
-Sumner,CHIKASKIA,U.S. House,4,D,Perry Schuckman,2
-Sumner,CONWAY,U.S. House,4,D,Perry Schuckman,91
-Sumner,CREEK,U.S. House,4,D,Perry Schuckman,5
-Sumner,DIXON,U.S. House,4,D,Perry Schuckman,44
-Sumner,DOWNS,U.S. House,4,D,Perry Schuckman,11
-Sumner,EDEN,U.S. House,4,D,Perry Schuckman,25
-Sumner,FALLS,U.S. House,4,D,Perry Schuckman,10
-Sumner,GORE   H79,U.S. House,4,D,Perry Schuckman,62
-Sumner,GORE   H82,U.S. House,4,D,Perry Schuckman,22
-Sumner,GREENE,U.S. House,4,D,Perry Schuckman,4
-Sumner,GUELPH,U.S. House,4,D,Perry Schuckman,12
-Sumner,HARMON,U.S. House,4,D,Perry Schuckman,18
-Sumner,ILLINOIS,U.S. House,4,D,Perry Schuckman,12
-Sumner,JACKSON,U.S. House,4,D,Perry Schuckman,16
-Sumner,LONDON,U.S. House,4,D,Perry Schuckman,56
-Sumner,MORRIS,U.S. House,4,D,Perry Schuckman,0
-Sumner,OSBORNE,U.S. House,4,D,Perry Schuckman,20
-Sumner,OXFORD TWP,U.S. House,4,D,Perry Schuckman,139
-Sumner,PALESTINE,U.S. House,4,D,Perry Schuckman,27
-Sumner,RYAN,U.S. House,4,D,Perry Schuckman,15
-Sumner,SEVENTY-SIX,U.S. House,4,D,Perry Schuckman,9
-Sumner,SOUTH HAVEN TWP,U.S. House,4,D,Perry Schuckman,38
-Sumner,SPRINGDALE,U.S. House,4,D,Perry Schuckman,52
-Sumner,Sumner,U.S. House,4,D,Perry Schuckman,16
-Sumner,VALVERDE,U.S. House,4,D,Perry Schuckman,8
-Sumner,WALTON,U.S. House,4,D,Perry Schuckman,30
-Sumner,WELLINGTON TWP    H80,U.S. House,4,D,Perry Schuckman,13
-Sumner,WELLINGTON TWP    116,U.S. House,4,D,Perry Schuckman,24
-Sumner,AVON,U.S. Senate,,I,Greg Orman,43
-Sumner,BELLE PLAINE TWP   H79,U.S. Senate,,I,Greg Orman,345
-Sumner,BELLE PLAINE TWP   H82,U.S. Senate,,I,Greg Orman,2
-Sumner,BLUFF,U.S. Senate,,I,Greg Orman,3
-Sumner,CALDWELL TWP,U.S. Senate,,I,Greg Orman,27
-Sumner,CHIKASKIA,U.S. Senate,,I,Greg Orman,6
-Sumner,CONWAY,U.S. Senate,,I,Greg Orman,104
-Sumner,CREEK,U.S. Senate,,I,Greg Orman,11
-Sumner,DIXON,U.S. Senate,,I,Greg Orman,46
-Sumner,DOWNS,U.S. Senate,,I,Greg Orman,11
-Sumner,EDEN,U.S. Senate,,I,Greg Orman,33
-Sumner,FALLS,U.S. Senate,,I,Greg Orman,12
-Sumner,GORE   H79,U.S. Senate,,I,Greg Orman,83
-Sumner,GORE   H82,U.S. Senate,,I,Greg Orman,27
-Sumner,GREENE,U.S. Senate,,I,Greg Orman,6
-Sumner,GUELPH,U.S. Senate,,I,Greg Orman,12
-Sumner,HARMON,U.S. Senate,,I,Greg Orman,24
-Sumner,ILLINOIS,U.S. Senate,,I,Greg Orman,15
-Sumner,JACKSON,U.S. Senate,,I,Greg Orman,17
-Sumner,LONDON,U.S. Senate,,I,Greg Orman,69
-Sumner,MORRIS,U.S. Senate,,I,Greg Orman,0
-Sumner,OSBORNE,U.S. Senate,,I,Greg Orman,29
-Sumner,OXFORD TWP,U.S. Senate,,I,Greg Orman,149
-Sumner,PALESTINE,U.S. Senate,,I,Greg Orman,31
-Sumner,RYAN,U.S. Senate,,I,Greg Orman,16
-Sumner,SEVENTY-SIX,U.S. Senate,,I,Greg Orman,18
-Sumner,SOUTH HAVEN TWP,U.S. Senate,,I,Greg Orman,46
-Sumner,SPRINGDALE,U.S. Senate,,I,Greg Orman,64
-Sumner,Sumner,U.S. Senate,,I,Greg Orman,14
-Sumner,VALVERDE,U.S. Senate,,I,Greg Orman,11
-Sumner,WALTON,U.S. Senate,,I,Greg Orman,30
-Sumner,WELLINGTON TWP    H80,U.S. Senate,,I,Greg Orman,13
-Sumner,WELLINGTON TWP    116,U.S. Senate,,I,Greg Orman,25
-Sumner,AVON,U.S. Senate,,R,Pat Roberts,74
-Sumner,BELLE PLAINE TWP   H79,U.S. Senate,,R,Pat Roberts,522
-Sumner,BELLE PLAINE TWP   H82,U.S. Senate,,R,Pat Roberts,3
-Sumner,BLUFF,U.S. Senate,,R,Pat Roberts,16
-Sumner,CALDWELL TWP,U.S. Senate,,R,Pat Roberts,25
-Sumner,CHIKASKIA,U.S. Senate,,R,Pat Roberts,18
-Sumner,CONWAY,U.S. Senate,,R,Pat Roberts,226
-Sumner,CREEK,U.S. Senate,,R,Pat Roberts,50
-Sumner,DIXON,U.S. Senate,,R,Pat Roberts,149
-Sumner,DOWNS,U.S. Senate,,R,Pat Roberts,36
-Sumner,EDEN,U.S. Senate,,R,Pat Roberts,87
-Sumner,FALLS,U.S. Senate,,R,Pat Roberts,33
-Sumner,GORE   H79,U.S. Senate,,R,Pat Roberts,166
-Sumner,GORE   H82,U.S. Senate,,R,Pat Roberts,45
-Sumner,GREENE,U.S. Senate,,R,Pat Roberts,21
-Sumner,GUELPH,U.S. Senate,,R,Pat Roberts,36
-Sumner,HARMON,U.S. Senate,,R,Pat Roberts,73
-Sumner,ILLINOIS,U.S. Senate,,R,Pat Roberts,56
-Sumner,JACKSON,U.S. Senate,,R,Pat Roberts,37
-Sumner,LONDON,U.S. Senate,,R,Pat Roberts,165
-Sumner,MORRIS,U.S. Senate,,R,Pat Roberts,8
-Sumner,OSBORNE,U.S. Senate,,R,Pat Roberts,58
-Sumner,OXFORD TWP,U.S. Senate,,R,Pat Roberts,278
-Sumner,PALESTINE,U.S. Senate,,R,Pat Roberts,53
-Sumner,RYAN,U.S. Senate,,R,Pat Roberts,39
-Sumner,SEVENTY-SIX,U.S. Senate,,R,Pat Roberts,71
-Sumner,SOUTH HAVEN TWP,U.S. Senate,,R,Pat Roberts,132
-Sumner,SPRINGDALE,U.S. Senate,,R,Pat Roberts,137
-Sumner,Sumner,U.S. Senate,,R,Pat Roberts,33
-Sumner,VALVERDE,U.S. Senate,,R,Pat Roberts,40
-Sumner,WALTON,U.S. Senate,,R,Pat Roberts,77
-Sumner,WELLINGTON TWP    H80,U.S. Senate,,R,Pat Roberts,33
-Sumner,WELLINGTON TWP    116,U.S. Senate,,R,Pat Roberts,54
-Sumner,AVON,U.S. Senate,,L,Randall Batson,6
-Sumner,BELLE PLAINE TWP   H79,U.S. Senate,,L,Randall Batson,69
-Sumner,BELLE PLAINE TWP   H82,U.S. Senate,,L,Randall Batson,0
-Sumner,BLUFF,U.S. Senate,,L,Randall Batson,1
-Sumner,CALDWELL TWP,U.S. Senate,,L,Randall Batson,0
-Sumner,CHIKASKIA,U.S. Senate,,L,Randall Batson,0
-Sumner,CONWAY,U.S. Senate,,L,Randall Batson,30
-Sumner,CREEK,U.S. Senate,,L,Randall Batson,2
-Sumner,DIXON,U.S. Senate,,L,Randall Batson,11
-Sumner,DOWNS,U.S. Senate,,L,Randall Batson,3
-Sumner,EDEN,U.S. Senate,,L,Randall Batson,7
-Sumner,FALLS,U.S. Senate,,L,Randall Batson,2
-Sumner,GORE   H79,U.S. Senate,,L,Randall Batson,16
-Sumner,GORE   H82,U.S. Senate,,L,Randall Batson,8
-Sumner,GREENE,U.S. Senate,,L,Randall Batson,0
-Sumner,GUELPH,U.S. Senate,,L,Randall Batson,5
-Sumner,HARMON,U.S. Senate,,L,Randall Batson,7
-Sumner,ILLINOIS,U.S. Senate,,L,Randall Batson,1
-Sumner,JACKSON,U.S. Senate,,L,Randall Batson,4
-Sumner,LONDON,U.S. Senate,,L,Randall Batson,19
-Sumner,MORRIS,U.S. Senate,,L,Randall Batson,1
-Sumner,OSBORNE,U.S. Senate,,L,Randall Batson,3
-Sumner,OXFORD TWP,U.S. Senate,,L,Randall Batson,29
-Sumner,PALESTINE,U.S. Senate,,L,Randall Batson,3
-Sumner,RYAN,U.S. Senate,,L,Randall Batson,2
-Sumner,SEVENTY-SIX,U.S. Senate,,L,Randall Batson,6
-Sumner,SOUTH HAVEN TWP,U.S. Senate,,L,Randall Batson,13
-Sumner,SPRINGDALE,U.S. Senate,,L,Randall Batson,7
-Sumner,Sumner,U.S. Senate,,L,Randall Batson,3
-Sumner,VALVERDE,U.S. Senate,,L,Randall Batson,6
-Sumner,WALTON,U.S. Senate,,L,Randall Batson,11
-Sumner,WELLINGTON TWP    H80,U.S. Senate,,L,Randall Batson,5
-Sumner,WELLINGTON TWP    116,U.S. Senate,,L,Randall Batson,2
-Sumner,CALDWELL CITY WARD 1,Attorney General,,D,A.J. Kotich,32
-Sumner,CALDWELL CITY WARD 2,Attorney General,,D,A.J. Kotich,61
-Sumner,MULVANE CITY,Attorney General,,D,A.J. Kotich,70
-Sumner,MULVANE CITY EXCLAVE B,Attorney General,,D,A.J. Kotich,2
-Sumner,WELLINGTON CITY 1 H80,Attorney General,,D,A.J. Kotich,275
-Sumner,WELLINGTON CITY 2 116,Attorney General,,D,A.J. Kotich,398
-Sumner,CALDWELL CITY WARD 1,Attorney General,,R,Derek Schmidt,95
-Sumner,CALDWELL CITY WARD 2,Attorney General,,R,Derek Schmidt,173
-Sumner,MULVANE CITY,Attorney General,,R,Derek Schmidt,145
-Sumner,MULVANE CITY EXCLAVE B,Attorney General,,R,Derek Schmidt,3
-Sumner,WELLINGTON CITY 1 H80,Attorney General,,R,Derek Schmidt,483
-Sumner,WELLINGTON CITY 2 116,Attorney General,,R,Derek Schmidt,1023
-Sumner,CALDWELL CITY WARD 1,Insurance Commissioner,,D,Dennis Anderson,57
-Sumner,CALDWELL CITY WARD 2,Insurance Commissioner,,D,Dennis Anderson,90
-Sumner,MULVANE CITY,Insurance Commissioner,,D,Dennis Anderson,74
-Sumner,MULVANE CITY EXCLAVE B,Insurance Commissioner,,D,Dennis Anderson,1
-Sumner,WELLINGTON CITY 1 H80,Insurance Commissioner,,D,Dennis Anderson,333
-Sumner,WELLINGTON CITY 2 116,Insurance Commissioner,,D,Dennis Anderson,528
-Sumner,CALDWELL CITY WARD 1,Insurance Commissioner,,R,Ken Selzer,63
-Sumner,CALDWELL CITY WARD 2,Insurance Commissioner,,R,Ken Selzer,139
-Sumner,MULVANE CITY,Insurance Commissioner,,R,Ken Selzer,139
-Sumner,MULVANE CITY EXCLAVE B,Insurance Commissioner,,R,Ken Selzer,3
-Sumner,WELLINGTON CITY 1 H80,Insurance Commissioner,,R,Ken Selzer,423
-Sumner,WELLINGTON CITY 2 116,Insurance Commissioner,,R,Ken Selzer,874
-Sumner,CALDWELL CITY WARD 1,Governor,,L,Keen Umbehr,5
-Sumner,CALDWELL CITY WARD 2,Governor,,L,Keen Umbehr,18
-Sumner,MULVANE CITY,Governor,,L,Keen Umbehr,10
-Sumner,MULVANE CITY EXCLAVE B,Governor,,L,Keen Umbehr,0
-Sumner,WELLINGTON CITY 1 H80,Governor,,L,Keen Umbehr,37
-Sumner,WELLINGTON CITY 2 116,Governor,,L,Keen Umbehr,68
-Sumner,CALDWELL CITY WARD 1,Governor,,D,Paul Davis,90
-Sumner,CALDWELL CITY WARD 2,Governor,,D,Paul Davis,121
-Sumner,MULVANE CITY,Governor,,D,Paul Davis,93
-Sumner,MULVANE CITY EXCLAVE B,Governor,,D,Paul Davis,4
-Sumner,WELLINGTON CITY 1 H80,Governor,,D,Paul Davis,428
-Sumner,WELLINGTON CITY 2 116,Governor,,D,Paul Davis,752
-Sumner,CALDWELL CITY WARD 1,Governor,,R,Sam Brownback,33
-Sumner,CALDWELL CITY WARD 2,Governor,,R,Sam Brownback,95
-Sumner,MULVANE CITY,Governor,,R,Sam Brownback,115
-Sumner,MULVANE CITY EXCLAVE B,Governor,,R,Sam Brownback,0
-Sumner,WELLINGTON CITY 1 H80,Governor,,R,Sam Brownback,304
-Sumner,WELLINGTON CITY 2 116,Governor,,R,Sam Brownback,615
-Sumner,CALDWELL CITY WARD 1,Secretary of State,,D,Jean Schodorf,65
-Sumner,CALDWELL CITY WARD 2,Secretary of State,,D,Jean Schodorf,99
-Sumner,MULVANE CITY,Secretary of State,,D,Jean Schodorf,90
-Sumner,MULVANE CITY EXCLAVE B,Secretary of State,,D,Jean Schodorf,1
-Sumner,WELLINGTON CITY 1 H80,Secretary of State,,D,Jean Schodorf,357
-Sumner,WELLINGTON CITY 2 116,Secretary of State,,D,Jean Schodorf,617
-Sumner,CALDWELL CITY WARD 1,Secretary of State,,R,Kris Kobach,61
-Sumner,CALDWELL CITY WARD 2,Secretary of State,,R,Kris Kobach,137
-Sumner,MULVANE CITY,Secretary of State,,R,Kris Kobach,128
-Sumner,MULVANE CITY EXCLAVE B,Secretary of State,,R,Kris Kobach,4
-Sumner,WELLINGTON CITY 1 H80,Secretary of State,,R,Kris Kobach,410
-Sumner,WELLINGTON CITY 2 116,Secretary of State,,R,Kris Kobach,817
-Sumner,WELLINGTON CITY 2 116,State House,116,R,Kyle  D. Hoffman R,1203
-Sumner,MULVANE CITY EXCLAVE B,State House,79,D,Ed Trimmer D,3
-Sumner,MULVANE CITY EXCLAVE B,State House,79,R,Larry W. Alley R,2
-Sumner,CALDWELL CITY WARD 1,State House,80,R,Kasha Kelley R,95
-Sumner,CALDWELL CITY WARD 2,State House,80,R,Kasha Kelley R,192
-Sumner,WELLINGTON CITY 1 H80,State House,80,R,Kasha Kelley R,617
-Sumner,MULVANE CITY,State House,82,D,Danette Harris D,105
-Sumner,MULVANE CITY,State House,82,R,Pete DeGraaf R,110
-Sumner,CALDWELL CITY WARD 1,State Treasurer,,D,Carmen Alldritt,44
-Sumner,CALDWELL CITY WARD 2,State Treasurer,,D,Carmen Alldritt,70
-Sumner,MULVANE CITY,State Treasurer,,D,Carmen Alldritt,64
-Sumner,MULVANE CITY EXCLAVE B,State Treasurer,,D,Carmen Alldritt,1
-Sumner,WELLINGTON CITY 1 H80,State Treasurer,,D,Carmen Alldritt,262
-Sumner,WELLINGTON CITY 2 116,State Treasurer,,D,Carmen Alldritt,408
-Sumner,CALDWELL CITY WARD 1,State Treasurer,,R,Ron Estes,77
-Sumner,CALDWELL CITY WARD 2,State Treasurer,,R,Ron Estes,160
-Sumner,MULVANE CITY,State Treasurer,,R,Ron Estes,153
-Sumner,MULVANE CITY EXCLAVE B,State Treasurer,,R,Ron Estes,4
-Sumner,WELLINGTON CITY 1 H80,State Treasurer,,R,Ron Estes,495
-Sumner,WELLINGTON CITY 2 116,State Treasurer,,R,Ron Estes,1010
-Sumner,CALDWELL CITY WARD 1,U.S. House,4,R,Mike Pompeo,83
-Sumner,CALDWELL CITY WARD 2,U.S. House,4,R,Mike Pompeo,159
-Sumner,MULVANE CITY,U.S. House,4,R,Mike Pompeo,146
-Sumner,MULVANE CITY EXCLAVE B,U.S. House,4,R,Mike Pompeo,4
-Sumner,WELLINGTON CITY 1 H80,U.S. House,4,R,Mike Pompeo,456
-Sumner,WELLINGTON CITY 2 116,U.S. House,4,R,Mike Pompeo,973
-Sumner,CALDWELL CITY WARD 1,U.S. House,4,D,Perry Schuckman,40
-Sumner,CALDWELL CITY WARD 2,U.S. House,4,D,Perry Schuckman,73
-Sumner,MULVANE CITY,U.S. House,4,D,Perry Schuckman,72
-Sumner,MULVANE CITY EXCLAVE B,U.S. House,4,D,Perry Schuckman,1
-Sumner,WELLINGTON CITY 1 H80,U.S. House,4,D,Perry Schuckman,311
-Sumner,WELLINGTON CITY 2 116,U.S. House,4,D,Perry Schuckman,455
-Sumner,CALDWELL CITY WARD 1,U.S. Senate,,I,Greg Orman,73
-Sumner,CALDWELL CITY WARD 2,U.S. Senate,,I,Greg Orman,89
-Sumner,MULVANE CITY,U.S. Senate,,I,Greg Orman,85
-Sumner,MULVANE CITY EXCLAVE B,U.S. Senate,,I,Greg Orman,3
-Sumner,WELLINGTON CITY 1 H80,U.S. Senate,,I,Greg Orman,391
-Sumner,WELLINGTON CITY 2 116,U.S. Senate,,I,Greg Orman,631
-Sumner,CALDWELL CITY WARD 1,U.S. Senate,,R,Pat Roberts,51
-Sumner,CALDWELL CITY WARD 2,U.S. Senate,,R,Pat Roberts,128
-Sumner,MULVANE CITY,U.S. Senate,,R,Pat Roberts,123
-Sumner,MULVANE CITY EXCLAVE B,U.S. Senate,,R,Pat Roberts,2
-Sumner,WELLINGTON CITY 1 H80,U.S. Senate,,R,Pat Roberts,330
-Sumner,WELLINGTON CITY 2 116,U.S. Senate,,R,Pat Roberts,732
-Sumner,CALDWELL CITY WARD 1,U.S. Senate,,L,Randall Batson,2
-Sumner,CALDWELL CITY WARD 2,U.S. Senate,,L,Randall Batson,19
-Sumner,MULVANE CITY,U.S. Senate,,L,Randall Batson,13
-Sumner,MULVANE CITY EXCLAVE B,U.S. Senate,,L,Randall Batson,0
-Sumner,WELLINGTON CITY 1 H80,U.S. Senate,,L,Randall Batson,54
-Sumner,WELLINGTON CITY 2 116,U.S. Senate,,L,Randall Batson,77
-Sumner,Prov,U.S. Senate,,Rep,Pat Roberts,51
-Sumner,Prov,U.S. Senate,,Lib,Randall Batson,7
-Sumner,Prov,U.S. Senate,,ind,Greg Orman,36
-Sumner,Prov,U.S. House,4,Dem,Perry Schuckman,25
-Sumner,Prov,U.S. House,4,Rep,Mike Pompeo,67
-Sumner,Prov,Governor,,Dem,Paul Davis,46
-Sumner,Prov,Governor,,Rep,Sam Brownback,41
-Sumner,Prov,Governor,,Lib,Keen Umbehr,7
-Sumner,Prov,Secretary of State,,Dem,Jean Schodorf,33
-Sumner,Prov,Secretary of State,,Rep,Kris Kobach,60
-Sumner,Prov,Attorney General,,Dem,A.J. Kotich,25
-Sumner,Prov,Attorney General,,Rep,Derek Schmidt,61
-Sumner,Prov,State Treasurer,,Dem,Carmen Alldritt,30
-Sumner,Prov,State Treasurer,,Rep,Ron Estes,59
-Sumner,Prov,Insurance Commissioner,,Dem,Dennis Anderson,32
-Sumner,Prov,Insurance Commissioner,,Rep,Ken Selzer,56
-Sumner,Prov,State House,79,Dem,Ed Trimmer,11
-Sumner,Prov,State House,79,Rep,Larry W. Alley,9
-Sumner,Prov,State House,80,Rep,Kasha Kelley,1
-Sumner,Prov,State House,82,Dem,Danette Harris,2
-Sumner,Prov,State House,82,Rep,Pete DeGraaf,0
-Sumner,Prov,State House,116,Rep,Kyle  D. Hoffman,42
+county,precinct,office,district,party,candidate,votes,vtd
+SUMNER,Avon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,000010
+SUMNER,Avon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000010
+SUMNER,Avon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000010
+SUMNER,Bluff Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000030
+SUMNER,Bluff Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+SUMNER,Bluff Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000030
+SUMNER,Caldwell City Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000040
+SUMNER,Caldwell City Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000040
+SUMNER,Caldwell City Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000040
+SUMNER,Caldwell City Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",122,000050
+SUMNER,Caldwell City Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000050
+SUMNER,Caldwell City Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",95,000050
+SUMNER,Caldwell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000060
+SUMNER,Caldwell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000060
+SUMNER,Caldwell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000060
+SUMNER,Chikaskia Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000070
+SUMNER,Chikaskia Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+SUMNER,Chikaskia Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000070
+SUMNER,Conway Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",139,000080
+SUMNER,Conway Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000080
+SUMNER,Conway Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",203,000080
+SUMNER,Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000090
+SUMNER,Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000090
+SUMNER,Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000090
+SUMNER,Dixon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",59,000100
+SUMNER,Dixon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000100
+SUMNER,Dixon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",141,000100
+SUMNER,Downs Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000110
+SUMNER,Downs Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000110
+SUMNER,Downs Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",36,000110
+SUMNER,Eden Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",40,000120
+SUMNER,Eden Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000120
+SUMNER,Eden Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",82,000120
+SUMNER,Falls Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000130
+SUMNER,Falls Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000130
+SUMNER,Falls Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",20,000130
+SUMNER,Greene Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000150
+SUMNER,Greene Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000150
+SUMNER,Greene Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000150
+SUMNER,Guelph Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",17,000160
+SUMNER,Guelph Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000160
+SUMNER,Guelph Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000160
+SUMNER,Harmon Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000170
+SUMNER,Harmon Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000170
+SUMNER,Harmon Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",68,000170
+SUMNER,Illinois Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000180
+SUMNER,Illinois Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000180
+SUMNER,Illinois Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000180
+SUMNER,Jackson Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000190
+SUMNER,Jackson Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000190
+SUMNER,Jackson Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",27,000190
+SUMNER,London Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,000200
+SUMNER,London Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000200
+SUMNER,London Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",172,000200
+SUMNER,Morris Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000210
+SUMNER,Morris Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000210
+SUMNER,Morris Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",4,000210
+SUMNER,Mulvane City,Governor / Lt. Governor,,Democratic,"Davis, Paul",93,000220
+SUMNER,Mulvane City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000220
+SUMNER,Mulvane City,Governor / Lt. Governor,,Republican,"Brownback, Sam",115,000220
+SUMNER,Osborne Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",37,000230
+SUMNER,Osborne Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000230
+SUMNER,Osborne Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,000230
+SUMNER,Oxford Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",189,000240
+SUMNER,Oxford Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",28,000240
+SUMNER,Oxford Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",249,000240
+SUMNER,Palestine Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",35,000250
+SUMNER,Palestine Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000250
+SUMNER,Palestine Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",51,000250
+SUMNER,Ryan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000260
+SUMNER,Ryan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000260
+SUMNER,Ryan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000260
+SUMNER,South Haven Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",69,000280
+SUMNER,South Haven Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,000280
+SUMNER,South Haven Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",112,000280
+SUMNER,Springdale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",75,000290
+SUMNER,Springdale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000290
+SUMNER,Springdale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",128,000290
+SUMNER,Sumner Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000300
+SUMNER,Sumner Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000300
+SUMNER,Sumner Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000300
+SUMNER,Valverde Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000310
+SUMNER,Valverde Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000310
+SUMNER,Valverde Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000310
+SUMNER,Walton Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",47,000320
+SUMNER,Walton Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000320
+SUMNER,Walton Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",69,000320
+SUMNER,Belle Plaine Township H79,Governor / Lt. Governor,,Democratic,"Davis, Paul",398,120020
+SUMNER,Belle Plaine Township H79,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",65,120020
+SUMNER,Belle Plaine Township H79,Governor / Lt. Governor,,Republican,"Brownback, Sam",485,120020
+SUMNER,Belle Plaine Township H82,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,120030
+SUMNER,Belle Plaine Township H82,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120030
+SUMNER,Belle Plaine Township H82,Governor / Lt. Governor,,Republican,"Brownback, Sam",3,120030
+SUMNER,Gore Township H79,Governor / Lt. Governor,,Democratic,"Davis, Paul",89,120040
+SUMNER,Gore Township H79,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,120040
+SUMNER,Gore Township H79,Governor / Lt. Governor,,Republican,"Brownback, Sam",164,120040
+SUMNER,Gore Township H82,Governor / Lt. Governor,,Democratic,"Davis, Paul",33,120050
+SUMNER,Gore Township H82,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,120050
+SUMNER,Gore Township H82,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,120050
+SUMNER,Seventy - Six Township H116,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,120060
+SUMNER,Seventy - Six Township H116,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120060
+SUMNER,Seventy - Six Township H116,Governor / Lt. Governor,,Republican,"Brownback, Sam",74,120060
+SUMNER,Seventy - Six Township H80,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,120070
+SUMNER,Seventy - Six Township H80,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,120070
+SUMNER,Seventy - Six Township H80,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,120070
+SUMNER,Wellington Township H116,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,120120
+SUMNER,Wellington Township H116,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,120120
+SUMNER,Wellington Township H116,Governor / Lt. Governor,,Republican,"Brownback, Sam",49,120120
+SUMNER,Wellington Township H80 A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,12013A
+SUMNER,Wellington Township H80 A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,12013A
+SUMNER,Wellington Township H80 A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,12013A
+SUMNER,Wellington Township H80,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,120130
+SUMNER,Wellington Township H80,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,120130
+SUMNER,Wellington Township H80,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,120130
+SUMNER,Wellington City Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",434,130010
+SUMNER,Wellington City Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",37,130010
+SUMNER,Wellington City Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",307,130010
+SUMNER,Wellington City Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",765,130020
+SUMNER,Wellington City Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",70,130020
+SUMNER,Wellington City Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",626,130020
+SUMNER,Wellington City Airport,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+SUMNER,Wellington City Airport,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+SUMNER,Wellington City Airport,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+SUMNER,Wellington Lake Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+SUMNER,Wellington Lake Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+SUMNER,Wellington Lake Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+SUMNER,Gore Township Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+SUMNER,Gore Township Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+SUMNER,Gore Township Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+SUMNER,Mulvane City Exclave A,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900050
+SUMNER,Mulvane City Exclave A,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900050
+SUMNER,Mulvane City Exclave A,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900050
+SUMNER,Mulvane City Exclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,900060
+SUMNER,Mulvane City Exclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900060
+SUMNER,Mulvane City Exclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900060
+SUMNER,Avon Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",104,000010
+SUMNER,Bluff Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",17,000030
+SUMNER,Caldwell City Ward 1,Kansas House of Representatives,80,Republican,"Kelley, Kasha",97,000040
+SUMNER,Caldwell City Ward 2,Kansas House of Representatives,80,Republican,"Kelley, Kasha",193,000050
+SUMNER,Caldwell Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",43,000060
+SUMNER,Chikaskia Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",23,000070
+SUMNER,Conway Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",310,000080
+SUMNER,Creek Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",55,000090
+SUMNER,Dixon Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",187,000100
+SUMNER,Downs Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",39,000110
+SUMNER,Eden Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",106,000120
+SUMNER,Falls Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",35,000130
+SUMNER,Greene Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",23,000150
+SUMNER,Guelph Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",45,000160
+SUMNER,Harmon Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",37,000170
+SUMNER,Harmon Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",65,000170
+SUMNER,Illinois Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",67,000180
+SUMNER,Jackson Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",51,000190
+SUMNER,London Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",219,000200
+SUMNER,Morris Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",8,000210
+SUMNER,Mulvane City,Kansas House of Representatives,82,Democratic,"Harris, Danette",105,000220
+SUMNER,Mulvane City,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",110,000220
+SUMNER,Osborne Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",77,000230
+SUMNER,Oxford Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",197,000240
+SUMNER,Oxford Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",266,000240
+SUMNER,Palestine Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",35,000250
+SUMNER,Palestine Township,Kansas House of Representatives,79,Republican,"Alley, Larry W.",52,000250
+SUMNER,Ryan Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",48,000260
+SUMNER,South Haven Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",169,000280
+SUMNER,Springdale Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",186,000290
+SUMNER,Sumner Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",43,000300
+SUMNER,Valverde Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",48,000310
+SUMNER,Walton Precinct,Kansas House of Representatives,80,Republican,"Kelley, Kasha",103,000320
+SUMNER,Belle Plaine Township H79,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",370,120020
+SUMNER,Belle Plaine Township H79,Kansas House of Representatives,79,Republican,"Alley, Larry W.",573,120020
+SUMNER,Belle Plaine Township H82,Kansas House of Representatives,82,Democratic,"Harris, Danette",2,120030
+SUMNER,Belle Plaine Township H82,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",3,120030
+SUMNER,Gore Township H79,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",83,120040
+SUMNER,Gore Township H79,Kansas House of Representatives,79,Republican,"Alley, Larry W.",177,120040
+SUMNER,Gore Township H82,Kansas House of Representatives,82,Democratic,"Harris, Danette",42,120050
+SUMNER,Gore Township H82,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",39,120050
+SUMNER,Seventy - Six Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",86,120060
+SUMNER,Seventy - Six Township H80,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,120070
+SUMNER,Wellington Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",72,120120
+SUMNER,Wellington Township H80 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,12013A
+SUMNER,Wellington Township H80,Kansas House of Representatives,80,Republican,"Kelley, Kasha",43,120130
+SUMNER,Wellington City Precinct 1,Kansas House of Representatives,80,Republican,"Kelley, Kasha",622,130010
+SUMNER,Wellington City Precinct 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",1226,130020
+SUMNER,Wellington City Airport,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900020
+SUMNER,Wellington Lake Exclave,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D",0,900030
+SUMNER,Gore Township Enclave,Kansas House of Representatives,82,Democratic,"Harris, Danette",0,900040
+SUMNER,Gore Township Enclave,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",0,900040
+SUMNER,Mulvane City Exclave A,Kansas House of Representatives,82,Democratic,"Harris, Danette",0,900050
+SUMNER,Mulvane City Exclave A,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",0,900050
+SUMNER,Mulvane City Exclave B,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",3,900060
+SUMNER,Mulvane City Exclave B,Kansas House of Representatives,79,Republican,"Alley, Larry W.",2,900060
+SUMNER,Avon Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",36,000010
+SUMNER,Avon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",85,000010
+SUMNER,Bluff Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,000030
+SUMNER,Bluff Township,United States House of Representatives,4,Republican,"Pompeo, Mike",18,000030
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",40,000040
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",85,000040
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",73,000050
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",160,000050
+SUMNER,Caldwell Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",15,000060
+SUMNER,Caldwell Township,United States House of Representatives,4,Republican,"Pompeo, Mike",35,000060
+SUMNER,Chikaskia Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,000070
+SUMNER,Chikaskia Township,United States House of Representatives,4,Republican,"Pompeo, Mike",22,000070
+SUMNER,Conway Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",92,000080
+SUMNER,Conway Township,United States House of Representatives,4,Republican,"Pompeo, Mike",268,000080
+SUMNER,Creek Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",6,000090
+SUMNER,Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",57,000090
+SUMNER,Dixon Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",45,000100
+SUMNER,Dixon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",162,000100
+SUMNER,Downs Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",11,000110
+SUMNER,Downs Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000110
+SUMNER,Eden Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",26,000120
+SUMNER,Eden Township,United States House of Representatives,4,Republican,"Pompeo, Mike",101,000120
+SUMNER,Falls Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",10,000130
+SUMNER,Falls Township,United States House of Representatives,4,Republican,"Pompeo, Mike",36,000130
+SUMNER,Greene Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",4,000150
+SUMNER,Greene Township,United States House of Representatives,4,Republican,"Pompeo, Mike",23,000150
+SUMNER,Guelph Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",12,000160
+SUMNER,Guelph Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000160
+SUMNER,Harmon Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",18,000170
+SUMNER,Harmon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",85,000170
+SUMNER,Illinois Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",12,000180
+SUMNER,Illinois Township,United States House of Representatives,4,Republican,"Pompeo, Mike",58,000180
+SUMNER,Jackson Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",16,000190
+SUMNER,Jackson Township,United States House of Representatives,4,Republican,"Pompeo, Mike",43,000190
+SUMNER,London Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",56,000200
+SUMNER,London Township,United States House of Representatives,4,Republican,"Pompeo, Mike",197,000200
+SUMNER,Morris Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,000210
+SUMNER,Morris Township,United States House of Representatives,4,Republican,"Pompeo, Mike",9,000210
+SUMNER,Mulvane City,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",72,000220
+SUMNER,Mulvane City,United States House of Representatives,4,Republican,"Pompeo, Mike",146,000220
+SUMNER,Osborne Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",21,000230
+SUMNER,Osborne Township,United States House of Representatives,4,Republican,"Pompeo, Mike",68,000230
+SUMNER,Oxford Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",142,000240
+SUMNER,Oxford Township,United States House of Representatives,4,Republican,"Pompeo, Mike",316,000240
+SUMNER,Palestine Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",27,000250
+SUMNER,Palestine Township,United States House of Representatives,4,Republican,"Pompeo, Mike",58,000250
+SUMNER,Ryan Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",15,000260
+SUMNER,Ryan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",41,000260
+SUMNER,South Haven Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",40,000280
+SUMNER,South Haven Township,United States House of Representatives,4,Republican,"Pompeo, Mike",157,000280
+SUMNER,Springdale Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",53,000290
+SUMNER,Springdale Township,United States House of Representatives,4,Republican,"Pompeo, Mike",157,000290
+SUMNER,Sumner Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",16,000300
+SUMNER,Sumner Township,United States House of Representatives,4,Republican,"Pompeo, Mike",34,000300
+SUMNER,Valverde Township,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",8,000310
+SUMNER,Valverde Township,United States House of Representatives,4,Republican,"Pompeo, Mike",47,000310
+SUMNER,Walton Precinct,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",30,000320
+SUMNER,Walton Precinct,United States House of Representatives,4,Republican,"Pompeo, Mike",88,000320
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",294,120020
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,Republican,"Pompeo, Mike",652,120020
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",2,120030
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,Republican,"Pompeo, Mike",3,120030
+SUMNER,Gore Township H79,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",62,120040
+SUMNER,Gore Township H79,United States House of Representatives,4,Republican,"Pompeo, Mike",204,120040
+SUMNER,Gore Township H82,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",22,120050
+SUMNER,Gore Township H82,United States House of Representatives,4,Republican,"Pompeo, Mike",59,120050
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",9,120060
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,Republican,"Pompeo, Mike",85,120060
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,120070
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,Republican,"Pompeo, Mike",0,120070
+SUMNER,Wellington Township H116,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",24,120120
+SUMNER,Wellington Township H116,United States House of Representatives,4,Republican,"Pompeo, Mike",59,120120
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,12013A
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,12013A
+SUMNER,Wellington Township H80,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",13,120130
+SUMNER,Wellington Township H80,United States House of Representatives,4,Republican,"Pompeo, Mike",38,120130
+SUMNER,Wellington City Precinct 1,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",316,130010
+SUMNER,Wellington City Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",460,130010
+SUMNER,Wellington City Precinct 2,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",459,130020
+SUMNER,Wellington City Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",995,130020
+SUMNER,Wellington City Airport,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900020
+SUMNER,Wellington City Airport,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900020
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900030
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900030
+SUMNER,Gore Township Enclave,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900040
+SUMNER,Gore Township Enclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900040
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",0,900050
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900050
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,Democratic,"Schuckman, Perry L.",1,900060
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,Republican,"Pompeo, Mike",4,900060
+SUMNER,Avon Township,Attorney General,,Democratic,"Kotich, A.J.",23,000010
+SUMNER,Avon Township,Attorney General,,Republican,"Schmidt, Derek",96,000010
+SUMNER,Bluff Township,Attorney General,,Democratic,"Kotich, A.J.",1,000030
+SUMNER,Bluff Township,Attorney General,,Republican,"Schmidt, Derek",19,000030
+SUMNER,Caldwell City Ward 1,Attorney General,,Democratic,"Kotich, A.J.",33,000040
+SUMNER,Caldwell City Ward 1,Attorney General,,Republican,"Schmidt, Derek",96,000040
+SUMNER,Caldwell City Ward 2,Attorney General,,Democratic,"Kotich, A.J.",61,000050
+SUMNER,Caldwell City Ward 2,Attorney General,,Republican,"Schmidt, Derek",174,000050
+SUMNER,Caldwell Township,Attorney General,,Democratic,"Kotich, A.J.",9,000060
+SUMNER,Caldwell Township,Attorney General,,Republican,"Schmidt, Derek",42,000060
+SUMNER,Chikaskia Township,Attorney General,,Democratic,"Kotich, A.J.",1,000070
+SUMNER,Chikaskia Township,Attorney General,,Republican,"Schmidt, Derek",23,000070
+SUMNER,Conway Township,Attorney General,,Democratic,"Kotich, A.J.",66,000080
+SUMNER,Conway Township,Attorney General,,Republican,"Schmidt, Derek",288,000080
+SUMNER,Creek Township,Attorney General,,Democratic,"Kotich, A.J.",7,000090
+SUMNER,Creek Township,Attorney General,,Republican,"Schmidt, Derek",56,000090
+SUMNER,Dixon Township,Attorney General,,Democratic,"Kotich, A.J.",36,000100
+SUMNER,Dixon Township,Attorney General,,Republican,"Schmidt, Derek",171,000100
+SUMNER,Downs Township,Attorney General,,Democratic,"Kotich, A.J.",9,000110
+SUMNER,Downs Township,Attorney General,,Republican,"Schmidt, Derek",42,000110
+SUMNER,Eden Township,Attorney General,,Democratic,"Kotich, A.J.",24,000120
+SUMNER,Eden Township,Attorney General,,Republican,"Schmidt, Derek",102,000120
+SUMNER,Falls Township,Attorney General,,Democratic,"Kotich, A.J.",8,000130
+SUMNER,Falls Township,Attorney General,,Republican,"Schmidt, Derek",38,000130
+SUMNER,Greene Township,Attorney General,,Democratic,"Kotich, A.J.",1,000150
+SUMNER,Greene Township,Attorney General,,Republican,"Schmidt, Derek",26,000150
+SUMNER,Guelph Township,Attorney General,,Democratic,"Kotich, A.J.",7,000160
+SUMNER,Guelph Township,Attorney General,,Republican,"Schmidt, Derek",47,000160
+SUMNER,Harmon Township,Attorney General,,Democratic,"Kotich, A.J.",15,000170
+SUMNER,Harmon Township,Attorney General,,Republican,"Schmidt, Derek",87,000170
+SUMNER,Illinois Township,Attorney General,,Democratic,"Kotich, A.J.",9,000180
+SUMNER,Illinois Township,Attorney General,,Republican,"Schmidt, Derek",64,000180
+SUMNER,Jackson Township,Attorney General,,Democratic,"Kotich, A.J.",7,000190
+SUMNER,Jackson Township,Attorney General,,Republican,"Schmidt, Derek",51,000190
+SUMNER,London Township,Attorney General,,Democratic,"Kotich, A.J.",47,000200
+SUMNER,London Township,Attorney General,,Republican,"Schmidt, Derek",203,000200
+SUMNER,Morris Township,Attorney General,,Democratic,"Kotich, A.J.",0,000210
+SUMNER,Morris Township,Attorney General,,Republican,"Schmidt, Derek",8,000210
+SUMNER,Mulvane City,Attorney General,,Democratic,"Kotich, A.J.",70,000220
+SUMNER,Mulvane City,Attorney General,,Republican,"Schmidt, Derek",145,000220
+SUMNER,Osborne Township,Attorney General,,Democratic,"Kotich, A.J.",21,000230
+SUMNER,Osborne Township,Attorney General,,Republican,"Schmidt, Derek",67,000230
+SUMNER,Oxford Township,Attorney General,,Democratic,"Kotich, A.J.",103,000240
+SUMNER,Oxford Township,Attorney General,,Republican,"Schmidt, Derek",354,000240
+SUMNER,Palestine Township,Attorney General,,Democratic,"Kotich, A.J.",22,000250
+SUMNER,Palestine Township,Attorney General,,Republican,"Schmidt, Derek",62,000250
+SUMNER,Ryan Township,Attorney General,,Democratic,"Kotich, A.J.",16,000260
+SUMNER,Ryan Township,Attorney General,,Republican,"Schmidt, Derek",40,000260
+SUMNER,South Haven Township,Attorney General,,Democratic,"Kotich, A.J.",38,000280
+SUMNER,South Haven Township,Attorney General,,Republican,"Schmidt, Derek",158,000280
+SUMNER,Springdale Township,Attorney General,,Democratic,"Kotich, A.J.",47,000290
+SUMNER,Springdale Township,Attorney General,,Republican,"Schmidt, Derek",157,000290
+SUMNER,Sumner Township,Attorney General,,Democratic,"Kotich, A.J.",12,000300
+SUMNER,Sumner Township,Attorney General,,Republican,"Schmidt, Derek",36,000300
+SUMNER,Valverde Township,Attorney General,,Democratic,"Kotich, A.J.",7,000310
+SUMNER,Valverde Township,Attorney General,,Republican,"Schmidt, Derek",48,000310
+SUMNER,Walton Precinct,Attorney General,,Democratic,"Kotich, A.J.",30,000320
+SUMNER,Walton Precinct,Attorney General,,Republican,"Schmidt, Derek",87,000320
+SUMNER,Belle Plaine Township H79,Attorney General,,Democratic,"Kotich, A.J.",260,120020
+SUMNER,Belle Plaine Township H79,Attorney General,,Republican,"Schmidt, Derek",682,120020
+SUMNER,Belle Plaine Township H82,Attorney General,,Democratic,"Kotich, A.J.",2,120030
+SUMNER,Belle Plaine Township H82,Attorney General,,Republican,"Schmidt, Derek",3,120030
+SUMNER,Gore Township H79,Attorney General,,Democratic,"Kotich, A.J.",53,120040
+SUMNER,Gore Township H79,Attorney General,,Republican,"Schmidt, Derek",211,120040
+SUMNER,Gore Township H82,Attorney General,,Democratic,"Kotich, A.J.",20,120050
+SUMNER,Gore Township H82,Attorney General,,Republican,"Schmidt, Derek",60,120050
+SUMNER,Seventy - Six Township H116,Attorney General,,Democratic,"Kotich, A.J.",12,120060
+SUMNER,Seventy - Six Township H116,Attorney General,,Republican,"Schmidt, Derek",82,120060
+SUMNER,Seventy - Six Township H80,Attorney General,,Democratic,"Kotich, A.J.",0,120070
+SUMNER,Seventy - Six Township H80,Attorney General,,Republican,"Schmidt, Derek",0,120070
+SUMNER,Wellington Township H116,Attorney General,,Democratic,"Kotich, A.J.",13,120120
+SUMNER,Wellington Township H116,Attorney General,,Republican,"Schmidt, Derek",68,120120
+SUMNER,Wellington Township H80 A,Attorney General,,Democratic,"Kotich, A.J.",0,12013A
+SUMNER,Wellington Township H80 A,Attorney General,,Republican,"Schmidt, Derek",0,12013A
+SUMNER,Wellington Township H80,Attorney General,,Democratic,"Kotich, A.J.",8,120130
+SUMNER,Wellington Township H80,Attorney General,,Republican,"Schmidt, Derek",41,120130
+SUMNER,Wellington City Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",278,130010
+SUMNER,Wellington City Precinct 1,Attorney General,,Republican,"Schmidt, Derek",487,130010
+SUMNER,Wellington City Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",406,130020
+SUMNER,Wellington City Precinct 2,Attorney General,,Republican,"Schmidt, Derek",1040,130020
+SUMNER,Wellington City Airport,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+SUMNER,Wellington City Airport,Attorney General,,Republican,"Schmidt, Derek",0,900020
+SUMNER,Wellington Lake Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+SUMNER,Wellington Lake Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900030
+SUMNER,Gore Township Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+SUMNER,Gore Township Enclave,Attorney General,,Republican,"Schmidt, Derek",0,900040
+SUMNER,Mulvane City Exclave A,Attorney General,,Democratic,"Kotich, A.J.",0,900050
+SUMNER,Mulvane City Exclave A,Attorney General,,Republican,"Schmidt, Derek",0,900050
+SUMNER,Mulvane City Exclave B,Attorney General,,Democratic,"Kotich, A.J.",2,900060
+SUMNER,Mulvane City Exclave B,Attorney General,,Republican,"Schmidt, Derek",3,900060
+SUMNER,Avon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000010
+SUMNER,Avon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000010
+SUMNER,Bluff Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000030
+SUMNER,Bluff Township,Commissioner of Insurance,,Republican,"Selzer, Ken",11,000030
+SUMNER,Caldwell City Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000040
+SUMNER,Caldwell City Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",63,000040
+SUMNER,Caldwell City Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,000050
+SUMNER,Caldwell City Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000050
+SUMNER,Caldwell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000060
+SUMNER,Caldwell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000060
+SUMNER,Chikaskia Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000070
+SUMNER,Chikaskia Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000070
+SUMNER,Conway Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",92,000080
+SUMNER,Conway Township,Commissioner of Insurance,,Republican,"Selzer, Ken",253,000080
+SUMNER,Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000090
+SUMNER,Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",50,000090
+SUMNER,Dixon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",48,000100
+SUMNER,Dixon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000100
+SUMNER,Downs Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000110
+SUMNER,Downs Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000110
+SUMNER,Eden Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",26,000120
+SUMNER,Eden Township,Commissioner of Insurance,,Republican,"Selzer, Ken",97,000120
+SUMNER,Falls Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000130
+SUMNER,Falls Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000130
+SUMNER,Greene Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000150
+SUMNER,Greene Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000150
+SUMNER,Guelph Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000160
+SUMNER,Guelph Township,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000160
+SUMNER,Harmon Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000170
+SUMNER,Harmon Township,Commissioner of Insurance,,Republican,"Selzer, Ken",77,000170
+SUMNER,Illinois Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000180
+SUMNER,Illinois Township,Commissioner of Insurance,,Republican,"Selzer, Ken",61,000180
+SUMNER,Jackson Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000190
+SUMNER,Jackson Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000190
+SUMNER,London Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",65,000200
+SUMNER,London Township,Commissioner of Insurance,,Republican,"Selzer, Ken",180,000200
+SUMNER,Morris Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000210
+SUMNER,Morris Township,Commissioner of Insurance,,Republican,"Selzer, Ken",8,000210
+SUMNER,Mulvane City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",74,000220
+SUMNER,Mulvane City,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000220
+SUMNER,Osborne Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000230
+SUMNER,Osborne Township,Commissioner of Insurance,,Republican,"Selzer, Ken",64,000230
+SUMNER,Oxford Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",132,000240
+SUMNER,Oxford Township,Commissioner of Insurance,,Republican,"Selzer, Ken",311,000240
+SUMNER,Palestine Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000250
+SUMNER,Palestine Township,Commissioner of Insurance,,Republican,"Selzer, Ken",53,000250
+SUMNER,Ryan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000260
+SUMNER,Ryan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000260
+SUMNER,South Haven Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000280
+SUMNER,South Haven Township,Commissioner of Insurance,,Republican,"Selzer, Ken",141,000280
+SUMNER,Springdale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000290
+SUMNER,Springdale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",152,000290
+SUMNER,Sumner Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000300
+SUMNER,Sumner Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000300
+SUMNER,Valverde Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000310
+SUMNER,Valverde Township,Commissioner of Insurance,,Republican,"Selzer, Ken",42,000310
+SUMNER,Walton Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",29,000320
+SUMNER,Walton Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",85,000320
+SUMNER,Belle Plaine Township H79,Commissioner of Insurance,,Democratic,"Anderson, Dennis",305,120020
+SUMNER,Belle Plaine Township H79,Commissioner of Insurance,,Republican,"Selzer, Ken",625,120020
+SUMNER,Belle Plaine Township H82,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,120030
+SUMNER,Belle Plaine Township H82,Commissioner of Insurance,,Republican,"Selzer, Ken",3,120030
+SUMNER,Gore Township H79,Commissioner of Insurance,,Democratic,"Anderson, Dennis",64,120040
+SUMNER,Gore Township H79,Commissioner of Insurance,,Republican,"Selzer, Ken",196,120040
+SUMNER,Gore Township H82,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,120050
+SUMNER,Gore Township H82,Commissioner of Insurance,,Republican,"Selzer, Ken",55,120050
+SUMNER,Seventy - Six Township H116,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,120060
+SUMNER,Seventy - Six Township H116,Commissioner of Insurance,,Republican,"Selzer, Ken",81,120060
+SUMNER,Seventy - Six Township H80,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,120070
+SUMNER,Seventy - Six Township H80,Commissioner of Insurance,,Republican,"Selzer, Ken",0,120070
+SUMNER,Wellington Township H116,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,120120
+SUMNER,Wellington Township H116,Commissioner of Insurance,,Republican,"Selzer, Ken",62,120120
+SUMNER,Wellington Township H80 A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,12013A
+SUMNER,Wellington Township H80 A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,12013A
+SUMNER,Wellington Township H80,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,120130
+SUMNER,Wellington Township H80,Commissioner of Insurance,,Republican,"Selzer, Ken",33,120130
+SUMNER,Wellington City Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",338,130010
+SUMNER,Wellington City Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",426,130010
+SUMNER,Wellington City Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",536,130020
+SUMNER,Wellington City Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",891,130020
+SUMNER,Wellington City Airport,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+SUMNER,Wellington City Airport,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+SUMNER,Wellington Lake Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+SUMNER,Wellington Lake Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+SUMNER,Gore Township Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+SUMNER,Gore Township Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+SUMNER,Mulvane City Exclave A,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900050
+SUMNER,Mulvane City Exclave A,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900050
+SUMNER,Mulvane City Exclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,900060
+SUMNER,Mulvane City Exclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",3,900060
+SUMNER,Avon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",46,000010
+SUMNER,Avon Township,Secretary of State,,Republican,"Kobach, Kris",74,000010
+SUMNER,Bluff Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000030
+SUMNER,Bluff Township,Secretary of State,,Republican,"Kobach, Kris",15,000030
+SUMNER,Caldwell City Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",66,000040
+SUMNER,Caldwell City Ward 1,Secretary of State,,Republican,"Kobach, Kris",62,000040
+SUMNER,Caldwell City Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",99,000050
+SUMNER,Caldwell City Ward 2,Secretary of State,,Republican,"Kobach, Kris",138,000050
+SUMNER,Caldwell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",28,000060
+SUMNER,Caldwell Township,Secretary of State,,Republican,"Kobach, Kris",23,000060
+SUMNER,Chikaskia Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000070
+SUMNER,Chikaskia Township,Secretary of State,,Republican,"Kobach, Kris",19,000070
+SUMNER,Conway Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",115,000080
+SUMNER,Conway Township,Secretary of State,,Republican,"Kobach, Kris",242,000080
+SUMNER,Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,000090
+SUMNER,Creek Township,Secretary of State,,Republican,"Kobach, Kris",49,000090
+SUMNER,Dixon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",54,000100
+SUMNER,Dixon Township,Secretary of State,,Republican,"Kobach, Kris",153,000100
+SUMNER,Downs Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000110
+SUMNER,Downs Township,Secretary of State,,Republican,"Kobach, Kris",38,000110
+SUMNER,Eden Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",34,000120
+SUMNER,Eden Township,Secretary of State,,Republican,"Kobach, Kris",92,000120
+SUMNER,Falls Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000130
+SUMNER,Falls Township,Secretary of State,,Republican,"Kobach, Kris",29,000130
+SUMNER,Greene Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000150
+SUMNER,Greene Township,Secretary of State,,Republican,"Kobach, Kris",25,000150
+SUMNER,Guelph Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000160
+SUMNER,Guelph Township,Secretary of State,,Republican,"Kobach, Kris",41,000160
+SUMNER,Harmon Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",29,000170
+SUMNER,Harmon Township,Secretary of State,,Republican,"Kobach, Kris",74,000170
+SUMNER,Illinois Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000180
+SUMNER,Illinois Township,Secretary of State,,Republican,"Kobach, Kris",59,000180
+SUMNER,Jackson Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000190
+SUMNER,Jackson Township,Secretary of State,,Republican,"Kobach, Kris",37,000190
+SUMNER,London Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,000200
+SUMNER,London Township,Secretary of State,,Republican,"Kobach, Kris",184,000200
+SUMNER,Morris Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000210
+SUMNER,Morris Township,Secretary of State,,Republican,"Kobach, Kris",8,000210
+SUMNER,Mulvane City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",90,000220
+SUMNER,Mulvane City,Secretary of State,,Republican,"Kobach, Kris",128,000220
+SUMNER,Osborne Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000230
+SUMNER,Osborne Township,Secretary of State,,Republican,"Kobach, Kris",56,000230
+SUMNER,Oxford Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",158,000240
+SUMNER,Oxford Township,Secretary of State,,Republican,"Kobach, Kris",303,000240
+SUMNER,Palestine Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000250
+SUMNER,Palestine Township,Secretary of State,,Republican,"Kobach, Kris",53,000250
+SUMNER,Ryan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000260
+SUMNER,Ryan Township,Secretary of State,,Republican,"Kobach, Kris",39,000260
+SUMNER,South Haven Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000280
+SUMNER,South Haven Township,Secretary of State,,Republican,"Kobach, Kris",143,000280
+SUMNER,Springdale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,000290
+SUMNER,Springdale Township,Secretary of State,,Republican,"Kobach, Kris",138,000290
+SUMNER,Sumner Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000300
+SUMNER,Sumner Township,Secretary of State,,Republican,"Kobach, Kris",30,000300
+SUMNER,Valverde Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000310
+SUMNER,Valverde Township,Secretary of State,,Republican,"Kobach, Kris",43,000310
+SUMNER,Walton Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000320
+SUMNER,Walton Precinct,Secretary of State,,Republican,"Kobach, Kris",85,000320
+SUMNER,Belle Plaine Township H79,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",366,120020
+SUMNER,Belle Plaine Township H79,Secretary of State,,Republican,"Kobach, Kris",584,120020
+SUMNER,Belle Plaine Township H82,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,120030
+SUMNER,Belle Plaine Township H82,Secretary of State,,Republican,"Kobach, Kris",3,120030
+SUMNER,Gore Township H79,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,120040
+SUMNER,Gore Township H79,Secretary of State,,Republican,"Kobach, Kris",191,120040
+SUMNER,Gore Township H82,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,120050
+SUMNER,Gore Township H82,Secretary of State,,Republican,"Kobach, Kris",50,120050
+SUMNER,Seventy - Six Township H116,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,120060
+SUMNER,Seventy - Six Township H116,Secretary of State,,Republican,"Kobach, Kris",73,120060
+SUMNER,Seventy - Six Township H80,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,120070
+SUMNER,Seventy - Six Township H80,Secretary of State,,Republican,"Kobach, Kris",0,120070
+SUMNER,Wellington Township H116,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,120120
+SUMNER,Wellington Township H116,Secretary of State,,Republican,"Kobach, Kris",63,120120
+SUMNER,Wellington Township H80 A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,12013A
+SUMNER,Wellington Township H80 A,Secretary of State,,Republican,"Kobach, Kris",0,12013A
+SUMNER,Wellington Township H80,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,120130
+SUMNER,Wellington Township H80,Secretary of State,,Republican,"Kobach, Kris",36,120130
+SUMNER,Wellington City Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",362,130010
+SUMNER,Wellington City Precinct 1,Secretary of State,,Republican,"Kobach, Kris",414,130010
+SUMNER,Wellington City Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",624,130020
+SUMNER,Wellington City Precinct 2,Secretary of State,,Republican,"Kobach, Kris",835,130020
+SUMNER,Wellington City Airport,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+SUMNER,Wellington City Airport,Secretary of State,,Republican,"Kobach, Kris",0,900020
+SUMNER,Wellington Lake Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+SUMNER,Wellington Lake Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900030
+SUMNER,Gore Township Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+SUMNER,Gore Township Enclave,Secretary of State,,Republican,"Kobach, Kris",0,900040
+SUMNER,Mulvane City Exclave A,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900050
+SUMNER,Mulvane City Exclave A,Secretary of State,,Republican,"Kobach, Kris",0,900050
+SUMNER,Mulvane City Exclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,900060
+SUMNER,Mulvane City Exclave B,Secretary of State,,Republican,"Kobach, Kris",4,900060
+SUMNER,Avon Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000010
+SUMNER,Avon Township,State Treasurer,,Republican,"Estes, Ron",91,000010
+SUMNER,Bluff Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000030
+SUMNER,Bluff Township,State Treasurer,,Republican,"Estes, Ron",16,000030
+SUMNER,Caldwell City Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",45,000040
+SUMNER,Caldwell City Ward 1,State Treasurer,,Republican,"Estes, Ron",78,000040
+SUMNER,Caldwell City Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",70,000050
+SUMNER,Caldwell City Ward 2,State Treasurer,,Republican,"Estes, Ron",161,000050
+SUMNER,Caldwell Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000060
+SUMNER,Caldwell Township,State Treasurer,,Republican,"Estes, Ron",38,000060
+SUMNER,Chikaskia Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000070
+SUMNER,Chikaskia Township,State Treasurer,,Republican,"Estes, Ron",23,000070
+SUMNER,Conway Township,State Treasurer,,Democratic,"Alldritt, Carmen",62,000080
+SUMNER,Conway Township,State Treasurer,,Republican,"Estes, Ron",292,000080
+SUMNER,Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000090
+SUMNER,Creek Township,State Treasurer,,Republican,"Estes, Ron",57,000090
+SUMNER,Dixon Township,State Treasurer,,Democratic,"Alldritt, Carmen",49,000100
+SUMNER,Dixon Township,State Treasurer,,Republican,"Estes, Ron",157,000100
+SUMNER,Downs Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000110
+SUMNER,Downs Township,State Treasurer,,Republican,"Estes, Ron",39,000110
+SUMNER,Eden Township,State Treasurer,,Democratic,"Alldritt, Carmen",31,000120
+SUMNER,Eden Township,State Treasurer,,Republican,"Estes, Ron",96,000120
+SUMNER,Falls Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000130
+SUMNER,Falls Township,State Treasurer,,Republican,"Estes, Ron",37,000130
+SUMNER,Greene Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000150
+SUMNER,Greene Township,State Treasurer,,Republican,"Estes, Ron",26,000150
+SUMNER,Guelph Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000160
+SUMNER,Guelph Township,State Treasurer,,Republican,"Estes, Ron",44,000160
+SUMNER,Harmon Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000170
+SUMNER,Harmon Township,State Treasurer,,Republican,"Estes, Ron",85,000170
+SUMNER,Illinois Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000180
+SUMNER,Illinois Township,State Treasurer,,Republican,"Estes, Ron",61,000180
+SUMNER,Jackson Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000190
+SUMNER,Jackson Township,State Treasurer,,Republican,"Estes, Ron",49,000190
+SUMNER,London Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000200
+SUMNER,London Township,State Treasurer,,Republican,"Estes, Ron",211,000200
+SUMNER,Morris Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000210
+SUMNER,Morris Township,State Treasurer,,Republican,"Estes, Ron",7,000210
+SUMNER,Mulvane City,State Treasurer,,Democratic,"Alldritt, Carmen",64,000220
+SUMNER,Mulvane City,State Treasurer,,Republican,"Estes, Ron",153,000220
+SUMNER,Osborne Township,State Treasurer,,Democratic,"Alldritt, Carmen",21,000230
+SUMNER,Osborne Township,State Treasurer,,Republican,"Estes, Ron",68,000230
+SUMNER,Oxford Township,State Treasurer,,Democratic,"Alldritt, Carmen",100,000240
+SUMNER,Oxford Township,State Treasurer,,Republican,"Estes, Ron",357,000240
+SUMNER,Palestine Township,State Treasurer,,Democratic,"Alldritt, Carmen",20,000250
+SUMNER,Palestine Township,State Treasurer,,Republican,"Estes, Ron",65,000250
+SUMNER,Ryan Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000260
+SUMNER,Ryan Township,State Treasurer,,Republican,"Estes, Ron",43,000260
+SUMNER,South Haven Township,State Treasurer,,Democratic,"Alldritt, Carmen",38,000280
+SUMNER,South Haven Township,State Treasurer,,Republican,"Estes, Ron",158,000280
+SUMNER,Springdale Township,State Treasurer,,Democratic,"Alldritt, Carmen",34,000290
+SUMNER,Springdale Township,State Treasurer,,Republican,"Estes, Ron",174,000290
+SUMNER,Sumner Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000300
+SUMNER,Sumner Township,State Treasurer,,Republican,"Estes, Ron",37,000300
+SUMNER,Valverde Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000310
+SUMNER,Valverde Township,State Treasurer,,Republican,"Estes, Ron",45,000310
+SUMNER,Walton Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",20,000320
+SUMNER,Walton Precinct,State Treasurer,,Republican,"Estes, Ron",96,000320
+SUMNER,Belle Plaine Township H79,State Treasurer,,Democratic,"Alldritt, Carmen",249,120020
+SUMNER,Belle Plaine Township H79,State Treasurer,,Republican,"Estes, Ron",692,120020
+SUMNER,Belle Plaine Township H82,State Treasurer,,Democratic,"Alldritt, Carmen",2,120030
+SUMNER,Belle Plaine Township H82,State Treasurer,,Republican,"Estes, Ron",3,120030
+SUMNER,Gore Township H79,State Treasurer,,Democratic,"Alldritt, Carmen",52,120040
+SUMNER,Gore Township H79,State Treasurer,,Republican,"Estes, Ron",213,120040
+SUMNER,Gore Township H82,State Treasurer,,Democratic,"Alldritt, Carmen",20,120050
+SUMNER,Gore Township H82,State Treasurer,,Republican,"Estes, Ron",60,120050
+SUMNER,Seventy - Six Township H116,State Treasurer,,Democratic,"Alldritt, Carmen",9,120060
+SUMNER,Seventy - Six Township H116,State Treasurer,,Republican,"Estes, Ron",85,120060
+SUMNER,Seventy - Six Township H80,State Treasurer,,Democratic,"Alldritt, Carmen",0,120070
+SUMNER,Seventy - Six Township H80,State Treasurer,,Republican,"Estes, Ron",0,120070
+SUMNER,Wellington Township H116,State Treasurer,,Democratic,"Alldritt, Carmen",24,120120
+SUMNER,Wellington Township H116,State Treasurer,,Republican,"Estes, Ron",58,120120
+SUMNER,Wellington Township H80 A,State Treasurer,,Democratic,"Alldritt, Carmen",0,12013A
+SUMNER,Wellington Township H80 A,State Treasurer,,Republican,"Estes, Ron",0,12013A
+SUMNER,Wellington Township H80,State Treasurer,,Democratic,"Alldritt, Carmen",11,120130
+SUMNER,Wellington Township H80,State Treasurer,,Republican,"Estes, Ron",39,120130
+SUMNER,Wellington City Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",266,130010
+SUMNER,Wellington City Precinct 1,State Treasurer,,Republican,"Estes, Ron",499,130010
+SUMNER,Wellington City Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",416,130020
+SUMNER,Wellington City Precinct 2,State Treasurer,,Republican,"Estes, Ron",1026,130020
+SUMNER,Wellington City Airport,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+SUMNER,Wellington City Airport,State Treasurer,,Republican,"Estes, Ron",0,900020
+SUMNER,Wellington Lake Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+SUMNER,Wellington Lake Exclave,State Treasurer,,Republican,"Estes, Ron",0,900030
+SUMNER,Gore Township Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+SUMNER,Gore Township Enclave,State Treasurer,,Republican,"Estes, Ron",0,900040
+SUMNER,Mulvane City Exclave A,State Treasurer,,Democratic,"Alldritt, Carmen",0,900050
+SUMNER,Mulvane City Exclave A,State Treasurer,,Republican,"Estes, Ron",0,900050
+SUMNER,Mulvane City Exclave B,State Treasurer,,Democratic,"Alldritt, Carmen",1,900060
+SUMNER,Mulvane City Exclave B,State Treasurer,,Republican,"Estes, Ron",4,900060
+SUMNER,Avon Township,United States Senate,,independent,"Orman, Greg",43,000010
+SUMNER,Avon Township,United States Senate,,Libertarian,"Batson, Randall",7,000010
+SUMNER,Avon Township,United States Senate,,Republican,"Roberts, Pat",74,000010
+SUMNER,Bluff Township,United States Senate,,independent,"Orman, Greg",3,000030
+SUMNER,Bluff Township,United States Senate,,Libertarian,"Batson, Randall",1,000030
+SUMNER,Bluff Township,United States Senate,,Republican,"Roberts, Pat",16,000030
+SUMNER,Caldwell City Ward 1,United States Senate,,independent,"Orman, Greg",73,000040
+SUMNER,Caldwell City Ward 1,United States Senate,,Libertarian,"Batson, Randall",3,000040
+SUMNER,Caldwell City Ward 1,United States Senate,,Republican,"Roberts, Pat",52,000040
+SUMNER,Caldwell City Ward 2,United States Senate,,independent,"Orman, Greg",89,000050
+SUMNER,Caldwell City Ward 2,United States Senate,,Libertarian,"Batson, Randall",19,000050
+SUMNER,Caldwell City Ward 2,United States Senate,,Republican,"Roberts, Pat",129,000050
+SUMNER,Caldwell Township,United States Senate,,independent,"Orman, Greg",27,000060
+SUMNER,Caldwell Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+SUMNER,Caldwell Township,United States Senate,,Republican,"Roberts, Pat",25,000060
+SUMNER,Chikaskia Township,United States Senate,,independent,"Orman, Greg",6,000070
+SUMNER,Chikaskia Township,United States Senate,,Libertarian,"Batson, Randall",0,000070
+SUMNER,Chikaskia Township,United States Senate,,Republican,"Roberts, Pat",18,000070
+SUMNER,Conway Township,United States Senate,,independent,"Orman, Greg",106,000080
+SUMNER,Conway Township,United States Senate,,Libertarian,"Batson, Randall",30,000080
+SUMNER,Conway Township,United States Senate,,Republican,"Roberts, Pat",226,000080
+SUMNER,Creek Township,United States Senate,,independent,"Orman, Greg",12,000090
+SUMNER,Creek Township,United States Senate,,Libertarian,"Batson, Randall",2,000090
+SUMNER,Creek Township,United States Senate,,Republican,"Roberts, Pat",51,000090
+SUMNER,Dixon Township,United States Senate,,independent,"Orman, Greg",48,000100
+SUMNER,Dixon Township,United States Senate,,Libertarian,"Batson, Randall",12,000100
+SUMNER,Dixon Township,United States Senate,,Republican,"Roberts, Pat",151,000100
+SUMNER,Downs Township,United States Senate,,independent,"Orman, Greg",11,000110
+SUMNER,Downs Township,United States Senate,,Libertarian,"Batson, Randall",3,000110
+SUMNER,Downs Township,United States Senate,,Republican,"Roberts, Pat",37,000110
+SUMNER,Eden Township,United States Senate,,independent,"Orman, Greg",34,000120
+SUMNER,Eden Township,United States Senate,,Libertarian,"Batson, Randall",7,000120
+SUMNER,Eden Township,United States Senate,,Republican,"Roberts, Pat",89,000120
+SUMNER,Falls Township,United States Senate,,independent,"Orman, Greg",12,000130
+SUMNER,Falls Township,United States Senate,,Libertarian,"Batson, Randall",2,000130
+SUMNER,Falls Township,United States Senate,,Republican,"Roberts, Pat",33,000130
+SUMNER,Greene Township,United States Senate,,independent,"Orman, Greg",6,000150
+SUMNER,Greene Township,United States Senate,,Libertarian,"Batson, Randall",0,000150
+SUMNER,Greene Township,United States Senate,,Republican,"Roberts, Pat",21,000150
+SUMNER,Guelph Township,United States Senate,,independent,"Orman, Greg",12,000160
+SUMNER,Guelph Township,United States Senate,,Libertarian,"Batson, Randall",5,000160
+SUMNER,Guelph Township,United States Senate,,Republican,"Roberts, Pat",36,000160
+SUMNER,Harmon Township,United States Senate,,independent,"Orman, Greg",24,000170
+SUMNER,Harmon Township,United States Senate,,Libertarian,"Batson, Randall",7,000170
+SUMNER,Harmon Township,United States Senate,,Republican,"Roberts, Pat",73,000170
+SUMNER,Illinois Township,United States Senate,,independent,"Orman, Greg",15,000180
+SUMNER,Illinois Township,United States Senate,,Libertarian,"Batson, Randall",1,000180
+SUMNER,Illinois Township,United States Senate,,Republican,"Roberts, Pat",56,000180
+SUMNER,Jackson Township,United States Senate,,independent,"Orman, Greg",17,000190
+SUMNER,Jackson Township,United States Senate,,Libertarian,"Batson, Randall",4,000190
+SUMNER,Jackson Township,United States Senate,,Republican,"Roberts, Pat",37,000190
+SUMNER,London Township,United States Senate,,independent,"Orman, Greg",69,000200
+SUMNER,London Township,United States Senate,,Libertarian,"Batson, Randall",19,000200
+SUMNER,London Township,United States Senate,,Republican,"Roberts, Pat",168,000200
+SUMNER,Morris Township,United States Senate,,independent,"Orman, Greg",0,000210
+SUMNER,Morris Township,United States Senate,,Libertarian,"Batson, Randall",1,000210
+SUMNER,Morris Township,United States Senate,,Republican,"Roberts, Pat",8,000210
+SUMNER,Mulvane City,United States Senate,,independent,"Orman, Greg",85,000220
+SUMNER,Mulvane City,United States Senate,,Libertarian,"Batson, Randall",13,000220
+SUMNER,Mulvane City,United States Senate,,Republican,"Roberts, Pat",123,000220
+SUMNER,Osborne Township,United States Senate,,independent,"Orman, Greg",30,000230
+SUMNER,Osborne Township,United States Senate,,Libertarian,"Batson, Randall",3,000230
+SUMNER,Osborne Township,United States Senate,,Republican,"Roberts, Pat",58,000230
+SUMNER,Oxford Township,United States Senate,,independent,"Orman, Greg",150,000240
+SUMNER,Oxford Township,United States Senate,,Libertarian,"Batson, Randall",31,000240
+SUMNER,Oxford Township,United States Senate,,Republican,"Roberts, Pat",282,000240
+SUMNER,Palestine Township,United States Senate,,independent,"Orman, Greg",31,000250
+SUMNER,Palestine Township,United States Senate,,Libertarian,"Batson, Randall",3,000250
+SUMNER,Palestine Township,United States Senate,,Republican,"Roberts, Pat",53,000250
+SUMNER,Ryan Township,United States Senate,,independent,"Orman, Greg",16,000260
+SUMNER,Ryan Township,United States Senate,,Libertarian,"Batson, Randall",2,000260
+SUMNER,Ryan Township,United States Senate,,Republican,"Roberts, Pat",39,000260
+SUMNER,South Haven Township,United States Senate,,independent,"Orman, Greg",48,000280
+SUMNER,South Haven Township,United States Senate,,Libertarian,"Batson, Randall",13,000280
+SUMNER,South Haven Township,United States Senate,,Republican,"Roberts, Pat",139,000280
+SUMNER,Springdale Township,United States Senate,,independent,"Orman, Greg",66,000290
+SUMNER,Springdale Township,United States Senate,,Libertarian,"Batson, Randall",7,000290
+SUMNER,Springdale Township,United States Senate,,Republican,"Roberts, Pat",139,000290
+SUMNER,Sumner Township,United States Senate,,independent,"Orman, Greg",14,000300
+SUMNER,Sumner Township,United States Senate,,Libertarian,"Batson, Randall",3,000300
+SUMNER,Sumner Township,United States Senate,,Republican,"Roberts, Pat",33,000300
+SUMNER,Valverde Township,United States Senate,,independent,"Orman, Greg",11,000310
+SUMNER,Valverde Township,United States Senate,,Libertarian,"Batson, Randall",6,000310
+SUMNER,Valverde Township,United States Senate,,Republican,"Roberts, Pat",40,000310
+SUMNER,Walton Precinct,United States Senate,,independent,"Orman, Greg",30,000320
+SUMNER,Walton Precinct,United States Senate,,Libertarian,"Batson, Randall",11,000320
+SUMNER,Walton Precinct,United States Senate,,Republican,"Roberts, Pat",78,000320
+SUMNER,Belle Plaine Township H79,United States Senate,,independent,"Orman, Greg",350,120020
+SUMNER,Belle Plaine Township H79,United States Senate,,Libertarian,"Batson, Randall",69,120020
+SUMNER,Belle Plaine Township H79,United States Senate,,Republican,"Roberts, Pat",529,120020
+SUMNER,Belle Plaine Township H82,United States Senate,,independent,"Orman, Greg",2,120030
+SUMNER,Belle Plaine Township H82,United States Senate,,Libertarian,"Batson, Randall",0,120030
+SUMNER,Belle Plaine Township H82,United States Senate,,Republican,"Roberts, Pat",3,120030
+SUMNER,Gore Township H79,United States Senate,,independent,"Orman, Greg",84,120040
+SUMNER,Gore Township H79,United States Senate,,Libertarian,"Batson, Randall",16,120040
+SUMNER,Gore Township H79,United States Senate,,Republican,"Roberts, Pat",167,120040
+SUMNER,Gore Township H82,United States Senate,,independent,"Orman, Greg",29,120050
+SUMNER,Gore Township H82,United States Senate,,Libertarian,"Batson, Randall",8,120050
+SUMNER,Gore Township H82,United States Senate,,Republican,"Roberts, Pat",45,120050
+SUMNER,Seventy - Six Township H116,United States Senate,,independent,"Orman, Greg",18,120060
+SUMNER,Seventy - Six Township H116,United States Senate,,Libertarian,"Batson, Randall",6,120060
+SUMNER,Seventy - Six Township H116,United States Senate,,Republican,"Roberts, Pat",71,120060
+SUMNER,Seventy - Six Township H80,United States Senate,,independent,"Orman, Greg",0,120070
+SUMNER,Seventy - Six Township H80,United States Senate,,Libertarian,"Batson, Randall",0,120070
+SUMNER,Seventy - Six Township H80,United States Senate,,Republican,"Roberts, Pat",0,120070
+SUMNER,Wellington Township H116,United States Senate,,independent,"Orman, Greg",25,120120
+SUMNER,Wellington Township H116,United States Senate,,Libertarian,"Batson, Randall",2,120120
+SUMNER,Wellington Township H116,United States Senate,,Republican,"Roberts, Pat",55,120120
+SUMNER,Wellington Township H80 A,United States Senate,,independent,"Orman, Greg",0,12013A
+SUMNER,Wellington Township H80 A,United States Senate,,Libertarian,"Batson, Randall",0,12013A
+SUMNER,Wellington Township H80 A,United States Senate,,Republican,"Roberts, Pat",0,12013A
+SUMNER,Wellington Township H80,United States Senate,,independent,"Orman, Greg",13,120130
+SUMNER,Wellington Township H80,United States Senate,,Libertarian,"Batson, Randall",5,120130
+SUMNER,Wellington Township H80,United States Senate,,Republican,"Roberts, Pat",33,120130
+SUMNER,Wellington City Precinct 1,United States Senate,,independent,"Orman, Greg",397,130010
+SUMNER,Wellington City Precinct 1,United States Senate,,Libertarian,"Batson, Randall",55,130010
+SUMNER,Wellington City Precinct 1,United States Senate,,Republican,"Roberts, Pat",332,130010
+SUMNER,Wellington City Precinct 2,United States Senate,,independent,"Orman, Greg",641,130020
+SUMNER,Wellington City Precinct 2,United States Senate,,Libertarian,"Batson, Randall",78,130020
+SUMNER,Wellington City Precinct 2,United States Senate,,Republican,"Roberts, Pat",747,130020
+SUMNER,Wellington City Airport,United States Senate,,independent,"Orman, Greg",0,900020
+SUMNER,Wellington City Airport,United States Senate,,Libertarian,"Batson, Randall",0,900020
+SUMNER,Wellington City Airport,United States Senate,,Republican,"Roberts, Pat",0,900020
+SUMNER,Wellington Lake Exclave,United States Senate,,independent,"Orman, Greg",0,900030
+SUMNER,Wellington Lake Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900030
+SUMNER,Wellington Lake Exclave,United States Senate,,Republican,"Roberts, Pat",0,900030
+SUMNER,Gore Township Enclave,United States Senate,,independent,"Orman, Greg",0,900040
+SUMNER,Gore Township Enclave,United States Senate,,Libertarian,"Batson, Randall",0,900040
+SUMNER,Gore Township Enclave,United States Senate,,Republican,"Roberts, Pat",0,900040
+SUMNER,Mulvane City Exclave A,United States Senate,,independent,"Orman, Greg",0,900050
+SUMNER,Mulvane City Exclave A,United States Senate,,Libertarian,"Batson, Randall",0,900050
+SUMNER,Mulvane City Exclave A,United States Senate,,Republican,"Roberts, Pat",0,900050
+SUMNER,Mulvane City Exclave B,United States Senate,,independent,"Orman, Greg",3,900060
+SUMNER,Mulvane City Exclave B,United States Senate,,Libertarian,"Batson, Randall",0,900060
+SUMNER,Mulvane City Exclave B,United States Senate,,Republican,"Roberts, Pat",2,900060

--- a/2014/20141104__ks__general__thomas__precinct.csv
+++ b/2014/20141104__ks__general__thomas__precinct.csv
@@ -1,358 +1,392 @@
-county,precinct,office,district,party,candidate,votes,poll,advance,absentee,prov
-Thomas,01 Barrett twp,Attorney General,,DEM,A.J. Kotich,60,37,15,8,0
-Thomas,02 Colby Ward 1,Attorney General,,DEM,A.J. Kotich,60,37,15,8,0
-Thomas,03 Colby Ward 2,Attorney General,,DEM,A.J. Kotich,82,53,22,7,0
-Thomas,04 Colby Ward 3,Attorney General,,DEM,A.J. Kotich,74,44,10,19,1
-Thomas,05 Colby Ward 4,Attorney General,,DEM,A.J. Kotich,93,60,19,13,1
-Thomas,06 Hale twp/Brewster,Attorney General,,DEM,A.J. Kotich,15,1,1,13,0
-Thomas,07 Lacey twp/Gem,Attorney General,,DEM,A.J. Kotich,5,1,0,4,0
-Thomas,08 Menlo twp,Attorney General,,DEM,A.J. Kotich,2,1,0,1,0
-Thomas,09 S Randall twp/Oakl,Attorney General,,DEM,A.J. Kotich,15,3,2,10,0
-Thomas,10 Smith twp /Rexford,Attorney General,,DEM,A.J. Kotich,8,4,0,4,0
-Thomas,11 East Hale twp,Attorney General,,DEM,A.J. Kotich,10,5,1,4,0
-Thomas,12 Kingery twp,Attorney General,,DEM,A.J. Kotich,3,2,0,1,0
-Thomas,13 E Morgan twp,Attorney General,,DEM,A.J. Kotich,19,14,4,1,0
-Thomas,14 W Morgan twp,Attorney General,,DEM,A.J. Kotich,26,20,2,4,0
-Thomas,15 N Randall twp,Attorney General,,DEM,A.J. Kotich,0,0,0,0,0
-Thomas,16 Rovohl twp,Attorney General,,DEM,A.J. Kotich,6,4,2,0,0
-Thomas,17 Summers twp,Attorney General,,DEM,A.J. Kotich,6,2,1,3,0
-Thomas,18 Wendell twp,Attorney General,,DEM,A.J. Kotich,2,0,0,2,0
-Thomas,01 Barrett twp,Attorney General,,REP,Derek Schmidt,269,202,44,21,2
-Thomas,02 Colby Ward 1,Attorney General,,REP,Derek Schmidt,269,202,44,21,2
-Thomas,03 Colby Ward 2,Attorney General,,REP,Derek Schmidt,299,214,62,20,3
-Thomas,04 Colby Ward 3,Attorney General,,REP,Derek Schmidt,410,267,98,37,8
-Thomas,05 Colby Ward 4,Attorney General,,REP,Derek Schmidt,349,236,68,39,6
-Thomas,06 Hale twp/Brewster,Attorney General,,REP,Derek Schmidt,106,32,20,51,3
-Thomas,07 Lacey twp/Gem,Attorney General,,REP,Derek Schmidt,44,18,15,11,0
-Thomas,08 Menlo twp,Attorney General,,REP,Derek Schmidt,24,8,5,10,1
-Thomas,09 S Randall twp/Oakl,Attorney General,,REP,Derek Schmidt,87,37,2,47,1
-Thomas,10 Smith twp /Rexford,Attorney General,,REP,Derek Schmidt,67,24,8,34,1
-Thomas,11 East Hale twp,Attorney General,,REP,Derek Schmidt,45,24,4,17,0
-Thomas,12 Kingery twp,Attorney General,,REP,Derek Schmidt,36,19,2,15,0
-Thomas,13 E Morgan twp,Attorney General,,REP,Derek Schmidt,85,60,24,1,0
-Thomas,14 W Morgan twp,Attorney General,,REP,Derek Schmidt,159,108,31,20,0
-Thomas,15 N Randall twp,Attorney General,,REP,Derek Schmidt,34,16,12,4,2
-Thomas,16 Rovohl twp,Attorney General,,REP,Derek Schmidt,65,48,7,10,0
-Thomas,17 Summers twp,Attorney General,,REP,Derek Schmidt,81,47,17,17,0
-Thomas,18 Wendell twp,Attorney General,,REP,Derek Schmidt,32,10,3,19,0
-Thomas,01 Barrett twp,Attorney General,,,Write-ins,1,1,0,0,0
-Thomas,02 Colby Ward 1,Attorney General,,,Write-ins,1,1,0,0,0
-Thomas,11 East Hale twp,Attorney General,,,Write-ins,1,1,0,0,0
-Thomas,01 Barrett twp,Governor,,LIB,Keen A. Umbehr,15,15,0,0,0
-Thomas,02 Colby Ward 1,Governor,,LIB,Keen A. Umbehr,15,15,0,0,0
-Thomas,03 Colby Ward 2,Governor,,LIB,Keen A. Umbehr,18,15,1,1,1
-Thomas,04 Colby Ward 3,Governor,,LIB,Keen A. Umbehr,25,18,2,3,2
-Thomas,05 Colby Ward 4,Governor,,LIB,Keen A. Umbehr,26,15,3,8,0
-Thomas,06 Hale twp/Brewster,Governor,,LIB,Keen A. Umbehr,5,2,2,1,0
-Thomas,07 Lacey twp/Gem,Governor,,LIB,Keen A. Umbehr,2,2,0,0,0
-Thomas,08 Menlo twp,Governor,,LIB,Keen A. Umbehr,1,0,0,1,0
-Thomas,09 S Randall twp/Oakl,Governor,,LIB,Keen A. Umbehr,2,1,0,1,0
-Thomas,10 Smith twp /Rexford,Governor,,LIB,Keen A. Umbehr,3,1,0,2,0
-Thomas,11 East Hale twp,Governor,,LIB,Keen A. Umbehr,2,2,0,0,0
-Thomas,12 Kingery twp,Governor,,LIB,Keen A. Umbehr,2,1,0,1,0
-Thomas,13 E Morgan twp,Governor,,LIB,Keen A. Umbehr,3,1,2,0,0
-Thomas,14 W Morgan twp,Governor,,LIB,Keen A. Umbehr,4,3,1,0,0
-Thomas,15 N Randall twp,Governor,,LIB,Keen A. Umbehr,0,0,0,0,0
-Thomas,16 Rovohl twp,Governor,,LIB,Keen A. Umbehr,4,4,0,0,0
-Thomas,17 Summers twp,Governor,,LIB,Keen A. Umbehr,2,1,1,0,0
-Thomas,18 Wendell twp,Governor,,LIB,Keen A. Umbehr,1,0,0,1,0
-Thomas,01 Barrett twp,Governor,,DEM,Paul Davis,129,80,31,18,0
-Thomas,02 Colby Ward 1,Governor,,DEM,Paul Davis,129,80,31,18,0
-Thomas,03 Colby Ward 2,Governor,,DEM,Paul Davis,143,98,31,12,2
-Thomas,04 Colby Ward 3,Governor,,DEM,Paul Davis,174,109,32,30,3
-Thomas,05 Colby Ward 4,Governor,,DEM,Paul Davis,159,102,34,22,1
-Thomas,06 Hale twp/Brewster,Governor,,DEM,Paul Davis,29,6,4,19,0
-Thomas,07 Lacey twp/Gem,Governor,,DEM,Paul Davis,13,3,4,6,0
-Thomas,08 Menlo twp,Governor,,DEM,Paul Davis,1,0,0,1,0
-Thomas,09 S Randall twp/Oakl,Governor,,DEM,Paul Davis,27,5,3,19,0
-Thomas,10 Smith twp /Rexford,Governor,,DEM,Paul Davis,11,7,1,3,0
-Thomas,11 East Hale twp,Governor,,DEM,Paul Davis,8,5,0,3,0
-Thomas,12 Kingery twp,Governor,,DEM,Paul Davis,7,7,0,0,0
-Thomas,13 E Morgan twp,Governor,,DEM,Paul Davis,39,30,7,2,0
-Thomas,14 W Morgan twp,Governor,,DEM,Paul Davis,53,42,8,3,0
-Thomas,15 N Randall twp,Governor,,DEM,Paul Davis,2,0,2,0,0
-Thomas,16 Rovohl twp,Governor,,DEM,Paul Davis,16,13,2,1,0
-Thomas,17 Summers twp,Governor,,DEM,Paul Davis,12,2,3,7,0
-Thomas,18 Wendell twp,Governor,,DEM,Paul Davis,10,4,0,6,0
-Thomas,01 Barrett twp,Governor,,REP,Sam Brownback,192,150,30,10,2
-Thomas,02 Colby Ward 1,Governor,,REP,Sam Brownback,192,150,30,10,2
-Thomas,03 Colby Ward 2,Governor,,REP,Sam Brownback,222,153,52,17,0
-Thomas,04 Colby Ward 3,Governor,,REP,Sam Brownback,288,185,73,26,4
-Thomas,05 Colby Ward 4,Governor,,REP,Sam Brownback,267,187,52,23,5
-Thomas,06 Hale twp/Brewster,Governor,,REP,Sam Brownback,93,30,15,45,3
-Thomas,07 Lacey twp/Gem,Governor,,REP,Sam Brownback,37,15,11,11,0
-Thomas,08 Menlo twp,Governor,,REP,Sam Brownback,24,9,5,9,1
-Thomas,09 S Randall twp/Oakl,Governor,,REP,Sam Brownback,72,33,1,37,1
-Thomas,10 Smith twp /Rexford,Governor,,REP,Sam Brownback,61,20,7,33,1
-Thomas,11 East Hale twp,Governor,,REP,Sam Brownback,45,22,5,18,0
-Thomas,12 Kingery twp,Governor,,REP,Sam Brownback,31,14,2,15,0
-Thomas,13 E Morgan twp,Governor,,REP,Sam Brownback,67,47,19,1,0
-Thomas,14 W Morgan twp,Governor,,REP,Sam Brownback,130,84,25,21,0
-Thomas,15 N Randall twp,Governor,,REP,Sam Brownback,32,16,10,4,2
-Thomas,16 Rovohl twp,Governor,,REP,Sam Brownback,52,35,8,9,0
-Thomas,17 Summers twp,Governor,,REP,Sam Brownback,78,48,14,16,0
-Thomas,18 Wendell twp,Governor,,REP,Sam Brownback,23,6,3,14,0
-Thomas,09 S Randall twp/Oakl,Governor,,,Write-ins,1,1,0,0,0
-Thomas,16 Rovohl twp,Governor,,,Write-ins,1,1,0,0,0
-Thomas,01 Barrett twp,Insurance Commissioner,,DEM,Dennis Anderson,11,2,1,8,0
-Thomas,02 Colby Ward 1,Insurance Commissioner,,DEM,Dennis Anderson,71,42,16,13,0
-Thomas,03 Colby Ward 2,Insurance Commissioner,,DEM,Dennis Anderson,91,57,25,9,0
-Thomas,04 Colby Ward 3,Insurance Commissioner,,DEM,Dennis Anderson,93,54,15,23,1
-Thomas,05 Colby Ward 4,Insurance Commissioner,,DEM,Dennis Anderson,99,59,21,17,2
-Thomas,06 Hale twp/Brewster,Insurance Commissioner,,DEM,Dennis Anderson,99,32,19,45,3
-Thomas,07 Lacey twp/Gem,Insurance Commissioner,,DEM,Dennis Anderson,7,1,0,6,0
-Thomas,08 Menlo twp,Insurance Commissioner,,DEM,Dennis Anderson,4,1,0,3,0
-Thomas,09 S Randall twp/Oakl,Insurance Commissioner,,DEM,Dennis Anderson,19,3,1,15,0
-Thomas,10 Smith twp /Rexford,Insurance Commissioner,,DEM,Dennis Anderson,9,4,0,5,0
-Thomas,11 East Hale twp,Insurance Commissioner,,DEM,Dennis Anderson,9,5,1,3,0
-Thomas,12 Kingery twp,Insurance Commissioner,,DEM,Dennis Anderson,2,1,0,1,0
-Thomas,13 E Morgan twp,Insurance Commissioner,,DEM,Dennis Anderson,23,17,4,2,0
-Thomas,14 W Morgan twp,Insurance Commissioner,,DEM,Dennis Anderson,33,25,6,2,0
-Thomas,15 N Randall twp,Insurance Commissioner,,DEM,Dennis Anderson,1,0,1,0,0
-Thomas,16 Rovohl twp,Insurance Commissioner,,DEM,Dennis Anderson,5,2,2,1,0
-Thomas,17 Summers twp,Insurance Commissioner,,DEM,Dennis Anderson,6,1,1,4,0
-Thomas,18 Wendell twp,Insurance Commissioner,,DEM,Dennis Anderson,3,1,0,2,0
-Thomas,01 Barrett twp,Insurance Commissioner,,REP,Ken Selzer,35,22,3,10,0
-Thomas,02 Colby Ward 1,Insurance Commissioner,,REP,Ken Selzer,252,192,42,16,2
-Thomas,03 Colby Ward 2,Insurance Commissioner,,REP,Ken Selzer,288,207,59,19,3
-Thomas,04 Colby Ward 3,Insurance Commissioner,,REP,Ken Selzer,388,253,92,35,8
-Thomas,05 Colby Ward 4,Insurance Commissioner,,REP,Ken Selzer,337,232,66,34,5
-Thomas,06 Hale twp/Brewster,Insurance Commissioner,,REP,Ken Selzer,18,2,1,15,0
-Thomas,07 Lacey twp/Gem,Insurance Commissioner,,REP,Ken Selzer,41,18,14,9,0
-Thomas,08 Menlo twp,Insurance Commissioner,,REP,Ken Selzer,22,8,5,8,1
-Thomas,09 S Randall twp/Oakl,Insurance Commissioner,,REP,Ken Selzer,81,37,3,40,1
-Thomas,10 Smith twp /Rexford,Insurance Commissioner,,REP,Ken Selzer,65,23,8,33,1
-Thomas,11 East Hale twp,Insurance Commissioner,,REP,Ken Selzer,45,24,4,17,0
-Thomas,12 Kingery twp,Insurance Commissioner,,REP,Ken Selzer,37,20,2,15,0
-Thomas,13 E Morgan twp,Insurance Commissioner,,REP,Ken Selzer,79,56,22,1,0
-Thomas,14 W Morgan twp,Insurance Commissioner,,REP,Ken Selzer,150,101,27,22,0
-Thomas,15 N Randall twp,Insurance Commissioner,,REP,Ken Selzer,33,16,11,4,2
-Thomas,16 Rovohl twp,Insurance Commissioner,,REP,Ken Selzer,66,50,7,9,0
-Thomas,17 Summers twp,Insurance Commissioner,,REP,Ken Selzer,79,47,17,15,0
-Thomas,18 Wendell twp,Insurance Commissioner,,REP,Ken Selzer,31,9,3,19,0
-Thomas,05 Colby Ward 4,Insurance Commissioner,,,Write-ins,1,0,1,0,0
-Thomas,11 East Hale twp,Insurance Commissioner,,,Write-ins,1,1,0,0,0
-Thomas,01 Barrett twp,Secretary of State,,DEM,Jean Kurtis Schodorf,95,58,23,14,0
-Thomas,02 Colby Ward 1,Secretary of State,,DEM,Jean Kurtis Schodorf,95,58,23,14,0
-Thomas,03 Colby Ward 2,Secretary of State,,DEM,Jean Kurtis Schodorf,103,67,26,10,0
-Thomas,04 Colby Ward 3,Secretary of State,,DEM,Jean Kurtis Schodorf,122,73,22,24,3
-Thomas,05 Colby Ward 4,Secretary of State,,DEM,Jean Kurtis Schodorf,122,72,27,22,1
-Thomas,06 Hale twp/Brewster,Secretary of State,,DEM,Jean Kurtis Schodorf,20,1,2,17,0
-Thomas,07 Lacey twp/Gem,Secretary of State,,DEM,Jean Kurtis Schodorf,11,3,2,6,0
-Thomas,08 Menlo twp,Secretary of State,,DEM,Jean Kurtis Schodorf,4,0,0,4,0
-Thomas,09 S Randall twp/Oakl,Secretary of State,,DEM,Jean Kurtis Schodorf,21,4,3,14,0
-Thomas,10 Smith twp /Rexford,Secretary of State,,DEM,Jean Kurtis Schodorf,10,5,0,5,0
-Thomas,11 East Hale twp,Secretary of State,,DEM,Jean Kurtis Schodorf,12,5,2,5,0
-Thomas,12 Kingery twp,Secretary of State,,DEM,Jean Kurtis Schodorf,3,2,0,1,0
-Thomas,13 E Morgan twp,Secretary of State,,DEM,Jean Kurtis Schodorf,26,18,6,2,0
-Thomas,14 W Morgan twp,Secretary of State,,DEM,Jean Kurtis Schodorf,41,31,7,3,0
-Thomas,15 N Randall twp,Secretary of State,,DEM,Jean Kurtis Schodorf,2,0,2,0,0
-Thomas,16 Rovohl twp,Secretary of State,,DEM,Jean Kurtis Schodorf,8,5,2,1,0
-Thomas,17 Summers twp,Secretary of State,,DEM,Jean Kurtis Schodorf,9,2,1,6,0
-Thomas,18 Wendell twp,Secretary of State,,DEM,Jean Kurtis Schodorf,6,1,0,5,0
-Thomas,01 Barrett twp,Secretary of State,,REP,Kris Kobach,238,187,35,14,2
-Thomas,02 Colby Ward 1,Secretary of State,,REP,Kris Kobach,238,187,35,14,2
-Thomas,03 Colby Ward 2,Secretary of State,,REP,Kris Kobach,280,201,58,18,3
-Thomas,04 Colby Ward 3,Secretary of State,,REP,Kris Kobach,364,240,84,34,6
-Thomas,05 Colby Ward 4,Secretary of State,,REP,Kris Kobach,320,223,60,31,6
-Thomas,06 Hale twp/Brewster,Secretary of State,,REP,Kris Kobach,101,34,18,46,3
-Thomas,07 Lacey twp/Gem,Secretary of State,,REP,Kris Kobach,41,17,13,11,0
-Thomas,08 Menlo twp,Secretary of State,,REP,Kris Kobach,22,9,5,7,1
-Thomas,09 S Randall twp/Oakl,Secretary of State,,REP,Kris Kobach,79,34,1,43,1
-Thomas,10 Smith twp /Rexford,Secretary of State,,REP,Kris Kobach,65,23,8,33,1
-Thomas,11 East Hale twp,Secretary of State,,REP,Kris Kobach,44,25,3,16,0
-Thomas,12 Kingery twp,Secretary of State,,REP,Kris Kobach,36,19,2,15,0
-Thomas,13 E Morgan twp,Secretary of State,,REP,Kris Kobach,82,59,22,1,0
-Thomas,14 W Morgan twp,Secretary of State,,REP,Kris Kobach,145,98,26,21,0
-Thomas,15 N Randall twp,Secretary of State,,REP,Kris Kobach,32,16,10,4,2
-Thomas,16 Rovohl twp,Secretary of State,,REP,Kris Kobach,64,47,7,10,0
-Thomas,17 Summers twp,Secretary of State,,REP,Kris Kobach,81,48,17,16,0
-Thomas,18 Wendell twp,Secretary of State,,REP,Kris Kobach,27,8,3,16,0
-Thomas,01 Barrett twp,Secretary of State,,,Write-ins,1,1,0,0,0
-Thomas,02 Colby Ward 1,Secretary of State,,,Write-ins,1,1,0,0,0
-Thomas,09 S Randall twp/Oakl,Secretary of State,,,Write-ins,1,1,0,0,0
-Thomas,11 East Hale twp,Secretary of State,,,Write-ins,1,1,0,0,0
-Thomas,07 Lacey twp/Gem,State House,118,REP,Don Hineman,43,19,12,12,0
-Thomas,08 Menlo twp,State House,118,REP,Don Hineman,23,8,5,9,1
-Thomas,09 S Randall twp/Oakl,State House,118,REP,Don Hineman,91,38,4,48,1
-Thomas,10 Smith twp /Rexford,State House,118,REP,Don Hineman,72,27,8,36,1
-Thomas,12 Kingery twp,State House,118,REP,Don Hineman,37,19,2,16,0
-Thomas,15 N Randall twp,State House,118,REP,Don Hineman,32,15,11,4,2
-Thomas,17 Summers twp,State House,118,REP,Don Hineman,79,44,15,20,0
-Thomas,18 Wendell twp,State House,118,REP,Don Hineman,31,9,3,19,0
-Thomas,09 S Randall twp/Oakl,State House,118,,Write-ins,1,1,0,0,0
-Thomas,01 Barrett twp,State House,120,REP,Rick Billinger,303,229,50,22,2
-Thomas,02 Colby Ward 1,State House,120,REP,Rick Billinger,303,229,50,22,2
-Thomas,03 Colby Ward 2,State House,120,REP,Rick Billinger,353,255,72,23,3
-Thomas,04 Colby Ward 3,State House,120,REP,Rick Billinger,462,300,103,51,8
-Thomas,05 Colby Ward 4,State House,120,REP,Rick Billinger,406,278,77,45,6
-Thomas,06 Hale twp/Brewster,State House,120,REP,Rick Billinger,120,37,20,60,3
-Thomas,11 East Hale twp,State House,120,REP,Rick Billinger,56,30,5,21,0
-Thomas,13 E Morgan twp,State House,120,REP,Rick Billinger,103,75,26,2,0
-Thomas,14 W Morgan twp,State House,120,REP,Rick Billinger,174,118,34,22,0
-Thomas,16 Rovohl twp,State House,120,REP,Rick Billinger,69,50,8,11,0
-Thomas,01 Barrett twp,State House,120,,Write-ins,12,6,4,2,0
-Thomas,02 Colby Ward 1,State House,120,,Write-ins,12,6,4,2,0
-Thomas,03 Colby Ward 2,State House,120,,Write-ins,9,6,3,0,0
-Thomas,04 Colby Ward 3,State House,120,,Write-ins,4,3,1,0,0
-Thomas,05 Colby Ward 4,State House,120,,Write-ins,6,5,1,0,0
-Thomas,06 Hale twp/Brewster,State House,120,,Write-ins,2,0,1,1,0
-Thomas,14 W Morgan twp,State House,120,,Write-ins,4,3,0,1,0
-Thomas,01 Barrett twp,State Treasurer,,DEM,Carmen Alldritt,60,36,16,8,0
-Thomas,02 Colby Ward 1,State Treasurer,,DEM,Carmen Alldritt,60,36,16,8,0
-Thomas,03 Colby Ward 2,State Treasurer,,DEM,Carmen Alldritt,77,47,24,6,0
-Thomas,04 Colby Ward 3,State Treasurer,,DEM,Carmen Alldritt,79,44,15,19,1
-Thomas,05 Colby Ward 4,State Treasurer,,DEM,Carmen Alldritt,87,58,15,14,0
-Thomas,06 Hale twp/Brewster,State Treasurer,,DEM,Carmen Alldritt,16,2,2,12,0
-Thomas,07 Lacey twp/Gem,State Treasurer,,DEM,Carmen Alldritt,6,1,0,5,0
-Thomas,08 Menlo twp,State Treasurer,,DEM,Carmen Alldritt,0,0,0,0,0
-Thomas,09 S Randall twp/Oakl,State Treasurer,,DEM,Carmen Alldritt,14,3,1,10,0
-Thomas,10 Smith twp /Rexford,State Treasurer,,DEM,Carmen Alldritt,8,5,0,3,0
-Thomas,11 East Hale twp,State Treasurer,,DEM,Carmen Alldritt,6,4,0,2,0
-Thomas,12 Kingery twp,State Treasurer,,DEM,Carmen Alldritt,2,1,0,1,0
-Thomas,13 E Morgan twp,State Treasurer,,DEM,Carmen Alldritt,22,17,4,1,0
-Thomas,14 W Morgan twp,State Treasurer,,DEM,Carmen Alldritt,22,19,2,1,0
-Thomas,15 N Randall twp,State Treasurer,,DEM,Carmen Alldritt,0,0,0,0,0
-Thomas,16 Rovohl twp,State Treasurer,,DEM,Carmen Alldritt,1,1,0,0,0
-Thomas,17 Summers twp,State Treasurer,,DEM,Carmen Alldritt,8,2,2,4,0
-Thomas,18 Wendell twp,State Treasurer,,DEM,Carmen Alldritt,1,0,0,1,0
-Thomas,01 Barrett twp,State Treasurer,,REP,Ron Estes,270,203,44,21,2
-Thomas,02 Colby Ward 1,State Treasurer,,REP,Ron Estes,270,203,44,21,2
-Thomas,03 Colby Ward 2,State Treasurer,,REP,Ron Estes,305,220,60,22,3
-Thomas,04 Colby Ward 3,State Treasurer,,REP,Ron Estes,407,269,92,38,8
-Thomas,05 Colby Ward 4,State Treasurer,,REP,Ron Estes,353,236,72,38,7
-Thomas,06 Hale twp/Brewster,State Treasurer,,REP,Ron Estes,109,34,19,53,3
-Thomas,07 Lacey twp/Gem,State Treasurer,,REP,Ron Estes,43,19,14,10,0
-Thomas,08 Menlo twp,State Treasurer,,REP,Ron Estes,26,9,5,11,1
-Thomas,09 S Randall twp/Oakl,State Treasurer,,REP,Ron Estes,86,37,3,45,1
-Thomas,10 Smith twp /Rexford,State Treasurer,,REP,Ron Estes,67,23,8,35,1
-Thomas,11 East Hale twp,State Treasurer,,REP,Ron Estes,49,25,5,19,0
-Thomas,12 Kingery twp,State Treasurer,,REP,Ron Estes,35,19,1,15,0
-Thomas,13 E Morgan twp,State Treasurer,,REP,Ron Estes,84,58,24,2,0
-Thomas,14 W Morgan twp,State Treasurer,,REP,Ron Estes,164,110,31,23,0
-Thomas,15 N Randall twp,State Treasurer,,REP,Ron Estes,34,16,12,4,2
-Thomas,16 Rovohl twp,State Treasurer,,REP,Ron Estes,72,52,9,11,0
-Thomas,17 Summers twp,State Treasurer,,REP,Ron Estes,81,47,16,18,0
-Thomas,18 Wendell twp,State Treasurer,,REP,Ron Estes,32,10,3,19,0
-Thomas,01 Barrett twp,State Treasurer,,,Write-ins,1,1,0,0,0
-Thomas,02 Colby Ward 1,State Treasurer,,,Write-ins,1,1,0,0,0
-Thomas,04 Colby Ward 3,State Treasurer,,,Write-ins,1,1,0,0,0
-Thomas,11 East Hale twp,State Treasurer,,,Write-ins,1,1,0,0,0
-Thomas,01 Barrett twp,U.S. House,1,DEM,James E. Sherow,93,59,23,11,0
-Thomas,02 Colby Ward 1,U.S. House,1,DEM,James E. Sherow,93,59,23,11,0
-Thomas,03 Colby Ward 2,U.S. House,1,DEM,James E. Sherow,109,68,28,13,0
-Thomas,04 Colby Ward 3,U.S. House,1,DEM,James E. Sherow,120,71,25,22,2
-Thomas,05 Colby Ward 4,U.S. House,1,DEM,James E. Sherow,131,81,32,17,1
-Thomas,06 Hale twp/Brewster,U.S. House,1,DEM,James E. Sherow,18,1,3,14,0
-Thomas,07 Lacey twp/Gem,U.S. House,1,DEM,James E. Sherow,9,3,2,4,0
-Thomas,08 Menlo twp,U.S. House,1,DEM,James E. Sherow,2,0,0,2,0
-Thomas,09 S Randall twp/Oakl,U.S. House,1,DEM,James E. Sherow,24,7,2,15,0
-Thomas,10 Smith twp /Rexford,U.S. House,1,DEM,James E. Sherow,10,4,,6,0
-Thomas,11 East Hale twp,U.S. House,1,DEM,James E. Sherow,7,4,0,3,0
-Thomas,12 Kingery twp,U.S. House,1,DEM,James E. Sherow,5,4,0,1,0
-Thomas,13 E Morgan twp,U.S. House,1,DEM,James E. Sherow,25,19,6,0,0
-Thomas,14 W Morgan twp,U.S. House,1,DEM,James E. Sherow,50,37,10,3,0
-Thomas,15 N Randall twp,U.S. House,1,DEM,James E. Sherow,2,0,2,0,0
-Thomas,16 Rovohl twp,U.S. House,1,DEM,James E. Sherow,10,8,2,0,0
-Thomas,17 Summers twp,U.S. House,1,DEM,James E. Sherow,10,3,2,5,0
-Thomas,18 Wendell twp,U.S. House,1,DEM,James E. Sherow,5,2,0,3,0
-Thomas,01 Barrett twp,U.S. House,1,REP,Tim Huelskamp,241,184,37,18,2
-Thomas,02 Colby Ward 1,U.S. House,1,REP,Tim Huelskamp,241,184,37,18,2
-Thomas,03 Colby Ward 2,U.S. House,1,REP,Tim Huelskamp,274,199,56,16,3
-Thomas,04 Colby Ward 3,U.S. House,1,REP,Tim Huelskamp,367,241,82,37,7
-Thomas,05 Colby Ward 4,U.S. House,1,REP,Tim Huelskamp,319,220,57,36,6
-Thomas,06 Hale twp/Brewster,U.S. House,1,REP,Tim Huelskamp,108,36,18,51,3
-Thomas,07 Lacey twp/Gem,U.S. House,1,REP,Tim Huelskamp,42,17,12,13,0
-Thomas,08 Menlo twp,U.S. House,1,REP,Tim Huelskamp,24,9,5,9,1
-Thomas,09 S Randall twp/Oakl,U.S. House,1,REP,Tim Huelskamp,77,33,2,41,1
-Thomas,10 Smith twp /Rexford,U.S. House,1,REP,Tim Huelskamp,65,24,8,32,1
-Thomas,11 East Hale twp,U.S. House,1,REP,Tim Huelskamp,48,25,5,18,0
-Thomas,12 Kingery twp,U.S. House,1,REP,Tim Huelskamp,34,17,2,15,0
-Thomas,13 E Morgan twp,U.S. House,1,REP,Tim Huelskamp,83,58,22,3,0
-Thomas,14 W Morgan twp,U.S. House,1,REP,Tim Huelskamp,135,91,23,21,0
-Thomas,15 N Randall twp,U.S. House,1,REP,Tim Huelskamp,32,16,10,4,2
-Thomas,16 Rovohl twp,U.S. House,1,REP,Tim Huelskamp,63,45,7,11,0
-Thomas,17 Summers twp,U.S. House,1,REP,Tim Huelskamp,80,47,16,17,0
-Thomas,18 Wendell twp,U.S. House,1,REP,Tim Huelskamp,29,8,3,18,0
-Thomas,01 Barrett twp,U.S. House,1,,Write-ins,1,1,0,0,0
-Thomas,02 Colby Ward 1,U.S. House,1,,Write-ins,1,1,0,0,0
-Thomas,03 Colby Ward 2,U.S. House,1,,Write-ins,1,1,0,0,0
-Thomas,11 East Hale twp,U.S. House,1,,Write-ins,1,1,0,0,0
-Thomas,14 W Morgan twp,U.S. House,1,,Write-ins,1,0,1,0,0
-Thomas,01 Barrett twp,U.S. Senate,,IND,Greg Orman,89,51,24,14,0
-Thomas,02 Colby Ward 1,U.S. Senate,,IND,Greg Orman,89,51,24,14,0
-Thomas,03 Colby Ward 2,U.S. Senate,,IND,Greg Orman,97,62,23,10,2
-Thomas,04 Colby Ward 3,U.S. Senate,,IND,Greg Orman,135,84,25,23,3
-Thomas,05 Colby Ward 4,U.S. Senate,,IND,Greg Orman,123,82,26,13,2
-Thomas,06 Hale twp/Brewster,U.S. Senate,,IND,Greg Orman,29,6,5,18,0
-Thomas,07 Lacey twp/Gem,U.S. Senate,,IND,Greg Orman,10,2,2,6,0
-Thomas,08 Menlo twp,U.S. Senate,,IND,Greg Orman,2,0,0,2,0
-Thomas,09 S Randall twp/Oakl,U.S. Senate,,IND,Greg Orman,24,5,1,18,0
-Thomas,10 Smith twp /Rexford,U.S. Senate,,IND,Greg Orman,12,5,1,6,0
-Thomas,11 East Hale twp,U.S. Senate,,IND,Greg Orman,6,3,0,3,0
-Thomas,12 Kingery twp,U.S. Senate,,IND,Greg Orman,8,6,1,1,0
-Thomas,13 E Morgan twp,U.S. Senate,,IND,Greg Orman,24,17,5,2,0
-Thomas,14 W Morgan twp,U.S. Senate,,IND,Greg Orman,38,31,6,1,0
-Thomas,15 N Randall twp,U.S. Senate,,IND,Greg Orman,2,0,2,0,0
-Thomas,16 Rovohl twp,U.S. Senate,,IND,Greg Orman,10,7,2,1,0
-Thomas,17 Summers twp,U.S. Senate,,IND,Greg Orman,10,2,2,6,0
-Thomas,18 Wendell twp,U.S. Senate,,IND,Greg Orman,5,2,0,3,0
-Thomas,01 Barrett twp,U.S. Senate,,REP,Pat Roberts,233,184,36,11,2
-Thomas,02 Colby Ward 1,U.S. Senate,,REP,Pat Roberts,233,184,36,11,2
-Thomas,03 Colby Ward 2,U.S. Senate,,REP,Pat Roberts,271,191,61,18,1
-Thomas,04 Colby Ward 3,U.S. Senate,,REP,Pat Roberts,322,207,80,31,4
-Thomas,05 Colby Ward 4,U.S. Senate,,REP,Pat Roberts,307,206,60,36,5
-Thomas,06 Hale twp/Brewster,U.S. Senate,,REP,Pat Roberts,92,29,14,46,3
-Thomas,07 Lacey twp/Gem,U.S. Senate,,REP,Pat Roberts,40,18,12,10,0
-Thomas,08 Menlo twp,U.S. Senate,,REP,Pat Roberts,23,9,5,8,1
-Thomas,09 S Randall twp/Oakl,U.S. Senate,,REP,Pat Roberts,74,34,3,36,1
-Thomas,10 Smith twp /Rexford,U.S. Senate,,REP,Pat Roberts,61,23,7,30,1
-Thomas,11 East Hale twp,U.S. Senate,,REP,Pat Roberts,47,24,5,18,0
-Thomas,12 Kingery twp,U.S. Senate,,REP,Pat Roberts,30,15,1,14,0
-Thomas,13 E Morgan twp,U.S. Senate,,REP,Pat Roberts,75,55,19,1,0
-Thomas,14 W Morgan twp,U.S. Senate,,REP,Pat Roberts,146,96,27,23,0
-Thomas,15 N Randall twp,U.S. Senate,,REP,Pat Roberts,31,15,10,4,2
-Thomas,16 Rovohl twp,U.S. Senate,,REP,Pat Roberts,62,45,7,10,0
-Thomas,17 Summers twp,U.S. Senate,,REP,Pat Roberts,80,48,16,16,0
-Thomas,18 Wendell twp,U.S. Senate,,REP,Pat Roberts,28,8,3,17,0
-Thomas,01 Barrett twp,U.S. Senate,,LIB,Randall Batson,16,12,1,3,0
-Thomas,02 Colby Ward 1,U.S. Senate,,LIB,Randall Batson,16,12,1,3,0
-Thomas,03 Colby Ward 2,U.S. Senate,,LIB,Randall Batson,17,15,0,2,0
-Thomas,04 Colby Ward 3,U.S. Senate,,LIB,Randall Batson,24,17,1,4,2
-Thomas,05 Colby Ward 4,U.S. Senate,,LIB,Randall Batson,23,16,3,4,0
-Thomas,06 Hale twp/Brewster,U.S. Senate,,LIB,Randall Batson,4,2,1,1,0
-Thomas,07 Lacey twp/Gem,U.S. Senate,,LIB,Randall Batson,2,0,1,1,0
-Thomas,08 Menlo twp,U.S. Senate,,LIB,Randall Batson,1,0,0,1,0
-Thomas,09 S Randall twp/Oakl,U.S. Senate,,LIB,Randall Batson,3,0,0,3,0
-Thomas,10 Smith twp /Rexford,U.S. Senate,,LIB,Randall Batson,1,0,0,1,0
-Thomas,11 East Hale twp,U.S. Senate,,LIB,Randall Batson,2,2,0,0,0
-Thomas,12 Kingery twp,U.S. Senate,,LIB,Randall Batson,2,1,0,1,0
-Thomas,13 E Morgan twp,U.S. Senate,,LIB,Randall Batson,9,6,3,0,0
-Thomas,14 W Morgan twp,U.S. Senate,,LIB,Randall Batson,2,1,1,0,0
-Thomas,15 N Randall twp,U.S. Senate,,LIB,Randall Batson,0,0,0,0,0
-Thomas,16 Rovohl twp,U.S. Senate,,LIB,Randall Batson,2,1,1,0,0
-Thomas,17 Summers twp,U.S. Senate,,LIB,Randall Batson,2,1,0,1,0
-Thomas,18 Wendell twp,U.S. Senate,,LIB,Randall Batson,1,0,0,1,0
-Thomas,03 Colby Ward 2,U.S. Senate,,,Write-ins,2,2,0,0,0
-Thomas,04 Colby Ward 3,U.S. Senate,,,Write-ins,4,4,0,0,0
-Thomas,05 Colby Ward 4,U.S. Senate,,,Write-ins,1,1,0,0,0
-Thomas,09 S Randall twp/Oakl,U.S. Senate,,,Write-ins,1,1,0,0,0
-Thomas,11 East Hale twp,U.S. Senate,,,Write-ins,1,1,0,0,0
-Thomas,01 Barrett twp,VOTERS,,,BALLOTS CAST,340,248,61,29,2
-Thomas,02 Colby Ward 1,VOTERS,,,BALLOTS CAST,340,248,61,29,2
-Thomas,03 Colby Ward 2,VOTERS,,,BALLOTS CAST,390,272,85,30,3
-Thomas,04 Colby Ward 3,VOTERS,,,BALLOTS CAST,494,316,108,61,9
-Thomas,05 Colby Ward 4,VOTERS,,,BALLOTS CAST,457,306,90,54,7
-Thomas,06 Hale twp/Brewster,VOTERS,,,BALLOTS CAST,127,38,21,65,3
-Thomas,07 Lacey twp/Gem,VOTERS,,,BALLOTS CAST,52,20,15,17,0
-Thomas,08 Menlo twp,VOTERS,,,BALLOTS CAST,26,9,5,11,1
-Thomas,09 S Randall twp/Oakl,VOTERS,,,BALLOTS CAST,103,40,4,58,1
-Thomas,10 Smith twp /Rexford,VOTERS,,,BALLOTS CAST,75,28,8,38,1
-Thomas,11 East Hale twp,VOTERS,,,BALLOTS CAST,57,31,5,21,0
-Thomas,12 Kingery twp,VOTERS,,,BALLOTS CAST,40,22,2,16,0
-Thomas,13 E Morgan twp,VOTERS,,,BALLOTS CAST,109,78,28,3,0
-Thomas,14 W Morgan twp,VOTERS,,,BALLOTS CAST,187,129,34,24,0
-Thomas,15 N Randall twp,VOTERS,,,BALLOTS CAST,34,16,12,4,2
-Thomas,16 Rovohl twp,VOTERS,,,BALLOTS CAST,75,53,10,12,0
-Thomas,17 Summers twp,VOTERS,,,BALLOTS CAST,92,51,18,23,0
-Thomas,18 Wendell twp,VOTERS,,,BALLOTS CAST,34,10,3,21,0
+county,precinct,office,district,party,candidate,votes,vtd
+THOMAS,Barrett Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000010
+THOMAS,Barrett Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+THOMAS,Barrett Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000010
+THOMAS,Colby Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",129,000020
+THOMAS,Colby Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",15,000020
+THOMAS,Colby Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",192,000020
+THOMAS,Colby Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",143,00003A
+THOMAS,Colby Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",18,00003A
+THOMAS,Colby Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",222,00003A
+THOMAS,Colby Ward 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00003B
+THOMAS,Colby Ward 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00003B
+THOMAS,Colby Ward 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00003B
+THOMAS,Colby Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",174,00004A
+THOMAS,Colby Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",25,00004A
+THOMAS,Colby Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",288,00004A
+THOMAS,Colby Ward 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00004B
+THOMAS,Colby Ward 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00004B
+THOMAS,Colby Ward 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00004B
+THOMAS,Colby Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",159,000050
+THOMAS,Colby Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",26,000050
+THOMAS,Colby Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",267,000050
+THOMAS,East Hale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000060
+THOMAS,East Hale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000060
+THOMAS,East Hale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",45,000060
+THOMAS,East Morgan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",39,00007A
+THOMAS,East Morgan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,00007A
+THOMAS,East Morgan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",67,00007A
+THOMAS,East Morgan Township Enclave Voting District,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00007B
+THOMAS,Kingery Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000080
+THOMAS,Kingery Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000080
+THOMAS,Kingery Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000080
+THOMAS,Lacey Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000090
+THOMAS,Lacey Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000090
+THOMAS,Lacey Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",37,000090
+THOMAS,Menlo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000100
+THOMAS,Menlo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000100
+THOMAS,Menlo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000100
+THOMAS,North Randall Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000110
+THOMAS,North Randall Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000110
+THOMAS,North Randall Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000110
+THOMAS,Rovohl Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",16,000120
+THOMAS,Rovohl Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000120
+THOMAS,Rovohl Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",52,000120
+THOMAS,Smith Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000130
+THOMAS,Smith Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000130
+THOMAS,Smith Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",61,000130
+THOMAS,South Randall Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000140
+THOMAS,South Randall Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000140
+THOMAS,South Randall Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",72,000140
+THOMAS,Summers Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000150
+THOMAS,Summers Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000150
+THOMAS,Summers Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",78,000150
+THOMAS,Wendell Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000160
+THOMAS,Wendell Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000160
+THOMAS,Wendell Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",23,000160
+THOMAS,West Hale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000170
+THOMAS,West Hale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000170
+THOMAS,West Hale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",93,000170
+THOMAS,West Morgan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000180
+THOMAS,West Morgan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000180
+THOMAS,West Morgan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",130,000180
+THOMAS,Colby Ward 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+THOMAS,Colby Ward 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+THOMAS,Colby Ward 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+THOMAS,East Morgan Township Enclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+THOMAS,East Morgan Township Enclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+THOMAS,East Morgan Township Enclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+THOMAS,Barrett Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",41,000010
+THOMAS,Colby Ward 1,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",303,000020
+THOMAS,Colby Ward 2,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",353,00003A
+THOMAS,Colby Ward 2 Exclave,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",0,00003B
+THOMAS,Colby Ward 3,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",462,00004A
+THOMAS,Colby Ward 3 Exclave,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",0,00004B
+THOMAS,Colby Ward 4,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",406,000050
+THOMAS,East Hale Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",56,000060
+THOMAS,East Morgan Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",103,00007A
+THOMAS,East Morgan Township Enclave Voting District,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",0,00007B
+THOMAS,Kingery Township,Kansas House of Representatives,118,Republican,"Hineman, Don",37,000080
+THOMAS,Lacey Township,Kansas House of Representatives,118,Republican,"Hineman, Don",43,000090
+THOMAS,Menlo Township,Kansas House of Representatives,118,Republican,"Hineman, Don",23,000100
+THOMAS,North Randall Township,Kansas House of Representatives,118,Republican,"Hineman, Don",32,000110
+THOMAS,Rovohl Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",69,000120
+THOMAS,Smith Township,Kansas House of Representatives,118,Republican,"Hineman, Don",72,000130
+THOMAS,South Randall Township,Kansas House of Representatives,118,Republican,"Hineman, Don",91,000140
+THOMAS,Summers Township,Kansas House of Representatives,118,Republican,"Hineman, Don",79,000150
+THOMAS,Wendell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",31,000160
+THOMAS,West Hale Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",120,000170
+THOMAS,West Morgan Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",174,000180
+THOMAS,Colby Ward 4 Exclave,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",0,900010
+THOMAS,East Morgan Township Enclave 2,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",0,900020
+THOMAS,Barrett Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000010
+THOMAS,Barrett Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000010
+THOMAS,Colby Ward 1,United States House of Representatives,1,Democratic,"Sherow, James E.",93,000020
+THOMAS,Colby Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",241,000020
+THOMAS,Colby Ward 2,United States House of Representatives,1,Democratic,"Sherow, James E.",109,00003A
+THOMAS,Colby Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",274,00003A
+THOMAS,Colby Ward 2 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00003B
+THOMAS,Colby Ward 3,United States House of Representatives,1,Democratic,"Sherow, James E.",120,00004A
+THOMAS,Colby Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",367,00004A
+THOMAS,Colby Ward 3 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00004B
+THOMAS,Colby Ward 4,United States House of Representatives,1,Democratic,"Sherow, James E.",131,000050
+THOMAS,Colby Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",319,000050
+THOMAS,East Hale Township,United States House of Representatives,1,Democratic,"Sherow, James E.",7,000060
+THOMAS,East Hale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000060
+THOMAS,East Morgan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,00007A
+THOMAS,East Morgan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",83,00007A
+THOMAS,East Morgan Township Enclave Voting District,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00007B
+THOMAS,Kingery Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000080
+THOMAS,Kingery Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000080
+THOMAS,Lacey Township,United States House of Representatives,1,Democratic,"Sherow, James E.",9,000090
+THOMAS,Lacey Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000090
+THOMAS,Menlo Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000100
+THOMAS,Menlo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000100
+THOMAS,North Randall Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000110
+THOMAS,North Randall Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000110
+THOMAS,Rovohl Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000120
+THOMAS,Rovohl Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000120
+THOMAS,Smith Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000130
+THOMAS,Smith Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000130
+THOMAS,South Randall Township,United States House of Representatives,1,Democratic,"Sherow, James E.",24,000140
+THOMAS,South Randall Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",77,000140
+THOMAS,Summers Township,United States House of Representatives,1,Democratic,"Sherow, James E.",10,000150
+THOMAS,Summers Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000150
+THOMAS,Wendell Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000160
+THOMAS,Wendell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000160
+THOMAS,West Hale Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000170
+THOMAS,West Hale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",108,000170
+THOMAS,West Morgan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",50,000180
+THOMAS,West Morgan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",135,000180
+THOMAS,Colby Ward 4 Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+THOMAS,Colby Ward 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+THOMAS,East Morgan Township Enclave 2,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900020
+THOMAS,East Morgan Township Enclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+THOMAS,Barrett Township,Attorney General,,Democratic,"Kotich, A.J.",9,000010
+THOMAS,Barrett Township,Attorney General,,Republican,"Schmidt, Derek",37,000010
+THOMAS,Colby Ward 1,Attorney General,,Democratic,"Kotich, A.J.",60,000020
+THOMAS,Colby Ward 1,Attorney General,,Republican,"Schmidt, Derek",269,000020
+THOMAS,Colby Ward 2,Attorney General,,Democratic,"Kotich, A.J.",82,00003A
+THOMAS,Colby Ward 2,Attorney General,,Republican,"Schmidt, Derek",299,00003A
+THOMAS,Colby Ward 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00003B
+THOMAS,Colby Ward 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00003B
+THOMAS,Colby Ward 3,Attorney General,,Democratic,"Kotich, A.J.",74,00004A
+THOMAS,Colby Ward 3,Attorney General,,Republican,"Schmidt, Derek",410,00004A
+THOMAS,Colby Ward 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00004B
+THOMAS,Colby Ward 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00004B
+THOMAS,Colby Ward 4,Attorney General,,Democratic,"Kotich, A.J.",93,000050
+THOMAS,Colby Ward 4,Attorney General,,Republican,"Schmidt, Derek",349,000050
+THOMAS,East Hale Township,Attorney General,,Democratic,"Kotich, A.J.",10,000060
+THOMAS,East Hale Township,Attorney General,,Republican,"Schmidt, Derek",45,000060
+THOMAS,East Morgan Township,Attorney General,,Democratic,"Kotich, A.J.",19,00007A
+THOMAS,East Morgan Township,Attorney General,,Republican,"Schmidt, Derek",85,00007A
+THOMAS,East Morgan Township Enclave Voting District,Attorney General,,Democratic,"Kotich, A.J.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,Attorney General,,Republican,"Schmidt, Derek",0,00007B
+THOMAS,Kingery Township,Attorney General,,Democratic,"Kotich, A.J.",3,000080
+THOMAS,Kingery Township,Attorney General,,Republican,"Schmidt, Derek",36,000080
+THOMAS,Lacey Township,Attorney General,,Democratic,"Kotich, A.J.",5,000090
+THOMAS,Lacey Township,Attorney General,,Republican,"Schmidt, Derek",44,000090
+THOMAS,Menlo Township,Attorney General,,Democratic,"Kotich, A.J.",2,000100
+THOMAS,Menlo Township,Attorney General,,Republican,"Schmidt, Derek",24,000100
+THOMAS,North Randall Township,Attorney General,,Democratic,"Kotich, A.J.",0,000110
+THOMAS,North Randall Township,Attorney General,,Republican,"Schmidt, Derek",34,000110
+THOMAS,Rovohl Township,Attorney General,,Democratic,"Kotich, A.J.",6,000120
+THOMAS,Rovohl Township,Attorney General,,Republican,"Schmidt, Derek",65,000120
+THOMAS,Smith Township,Attorney General,,Democratic,"Kotich, A.J.",8,000130
+THOMAS,Smith Township,Attorney General,,Republican,"Schmidt, Derek",67,000130
+THOMAS,South Randall Township,Attorney General,,Democratic,"Kotich, A.J.",15,000140
+THOMAS,South Randall Township,Attorney General,,Republican,"Schmidt, Derek",87,000140
+THOMAS,Summers Township,Attorney General,,Democratic,"Kotich, A.J.",6,000150
+THOMAS,Summers Township,Attorney General,,Republican,"Schmidt, Derek",81,000150
+THOMAS,Wendell Township,Attorney General,,Democratic,"Kotich, A.J.",2,000160
+THOMAS,Wendell Township,Attorney General,,Republican,"Schmidt, Derek",32,000160
+THOMAS,West Hale Township,Attorney General,,Democratic,"Kotich, A.J.",15,000170
+THOMAS,West Hale Township,Attorney General,,Republican,"Schmidt, Derek",106,000170
+THOMAS,West Morgan Township,Attorney General,,Democratic,"Kotich, A.J.",26,000180
+THOMAS,West Morgan Township,Attorney General,,Republican,"Schmidt, Derek",159,000180
+THOMAS,Colby Ward 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+THOMAS,Colby Ward 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+THOMAS,East Morgan Township Enclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+THOMAS,East Morgan Township Enclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900020
+THOMAS,Barrett Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000010
+THOMAS,Barrett Township,Commissioner of Insurance,,Republican,"Selzer, Ken",35,000010
+THOMAS,Colby Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",71,000020
+THOMAS,Colby Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",252,000020
+THOMAS,Colby Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",91,00003A
+THOMAS,Colby Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",288,00003A
+THOMAS,Colby Ward 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00003B
+THOMAS,Colby Ward 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00003B
+THOMAS,Colby Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",93,00004A
+THOMAS,Colby Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",388,00004A
+THOMAS,Colby Ward 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00004B
+THOMAS,Colby Ward 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00004B
+THOMAS,Colby Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",99,000050
+THOMAS,Colby Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",337,000050
+THOMAS,East Hale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000060
+THOMAS,East Hale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",45,000060
+THOMAS,East Morgan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,00007A
+THOMAS,East Morgan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,00007A
+THOMAS,East Morgan Township Enclave Voting District,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00007B
+THOMAS,Kingery Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000080
+THOMAS,Kingery Township,Commissioner of Insurance,,Republican,"Selzer, Ken",37,000080
+THOMAS,Lacey Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",7,000090
+THOMAS,Lacey Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000090
+THOMAS,Menlo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000100
+THOMAS,Menlo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",22,000100
+THOMAS,North Randall Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000110
+THOMAS,North Randall Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000110
+THOMAS,Rovohl Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",5,000120
+THOMAS,Rovohl Township,Commissioner of Insurance,,Republican,"Selzer, Ken",66,000120
+THOMAS,Smith Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000130
+THOMAS,Smith Township,Commissioner of Insurance,,Republican,"Selzer, Ken",65,000130
+THOMAS,South Randall Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000140
+THOMAS,South Randall Township,Commissioner of Insurance,,Republican,"Selzer, Ken",81,000140
+THOMAS,Summers Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000150
+THOMAS,Summers Township,Commissioner of Insurance,,Republican,"Selzer, Ken",79,000150
+THOMAS,Wendell Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000160
+THOMAS,Wendell Township,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000160
+THOMAS,West Hale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000170
+THOMAS,West Hale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",99,000170
+THOMAS,West Morgan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000180
+THOMAS,West Morgan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",150,000180
+THOMAS,Colby Ward 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+THOMAS,Colby Ward 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+THOMAS,East Morgan Township Enclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+THOMAS,East Morgan Township Enclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+THOMAS,Barrett Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000010
+THOMAS,Barrett Township,Secretary of State,,Republican,"Kobach, Kris",36,000010
+THOMAS,Colby Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",95,000020
+THOMAS,Colby Ward 1,Secretary of State,,Republican,"Kobach, Kris",238,000020
+THOMAS,Colby Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",103,00003A
+THOMAS,Colby Ward 2,Secretary of State,,Republican,"Kobach, Kris",280,00003A
+THOMAS,Colby Ward 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00003B
+THOMAS,Colby Ward 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00003B
+THOMAS,Colby Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",122,00004A
+THOMAS,Colby Ward 3,Secretary of State,,Republican,"Kobach, Kris",364,00004A
+THOMAS,Colby Ward 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00004B
+THOMAS,Colby Ward 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00004B
+THOMAS,Colby Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",122,000050
+THOMAS,Colby Ward 4,Secretary of State,,Republican,"Kobach, Kris",320,000050
+THOMAS,East Hale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000060
+THOMAS,East Hale Township,Secretary of State,,Republican,"Kobach, Kris",44,000060
+THOMAS,East Morgan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",26,00007A
+THOMAS,East Morgan Township,Secretary of State,,Republican,"Kobach, Kris",82,00007A
+THOMAS,East Morgan Township Enclave Voting District,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,Secretary of State,,Republican,"Kobach, Kris",0,00007B
+THOMAS,Kingery Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000080
+THOMAS,Kingery Township,Secretary of State,,Republican,"Kobach, Kris",36,000080
+THOMAS,Lacey Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",11,000090
+THOMAS,Lacey Township,Secretary of State,,Republican,"Kobach, Kris",41,000090
+THOMAS,Menlo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000100
+THOMAS,Menlo Township,Secretary of State,,Republican,"Kobach, Kris",22,000100
+THOMAS,North Randall Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000110
+THOMAS,North Randall Township,Secretary of State,,Republican,"Kobach, Kris",32,000110
+THOMAS,Rovohl Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000120
+THOMAS,Rovohl Township,Secretary of State,,Republican,"Kobach, Kris",64,000120
+THOMAS,Smith Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000130
+THOMAS,Smith Township,Secretary of State,,Republican,"Kobach, Kris",65,000130
+THOMAS,South Randall Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000140
+THOMAS,South Randall Township,Secretary of State,,Republican,"Kobach, Kris",79,000140
+THOMAS,Summers Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000150
+THOMAS,Summers Township,Secretary of State,,Republican,"Kobach, Kris",81,000150
+THOMAS,Wendell Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000160
+THOMAS,Wendell Township,Secretary of State,,Republican,"Kobach, Kris",27,000160
+THOMAS,West Hale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000170
+THOMAS,West Hale Township,Secretary of State,,Republican,"Kobach, Kris",101,000170
+THOMAS,West Morgan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",41,000180
+THOMAS,West Morgan Township,Secretary of State,,Republican,"Kobach, Kris",145,000180
+THOMAS,Colby Ward 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+THOMAS,Colby Ward 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+THOMAS,East Morgan Township Enclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+THOMAS,East Morgan Township Enclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900020
+THOMAS,Barrett Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000010
+THOMAS,Barrett Township,State Treasurer,,Republican,"Estes, Ron",36,000010
+THOMAS,Colby Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",60,000020
+THOMAS,Colby Ward 1,State Treasurer,,Republican,"Estes, Ron",270,000020
+THOMAS,Colby Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",77,00003A
+THOMAS,Colby Ward 2,State Treasurer,,Republican,"Estes, Ron",305,00003A
+THOMAS,Colby Ward 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00003B
+THOMAS,Colby Ward 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00003B
+THOMAS,Colby Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",79,00004A
+THOMAS,Colby Ward 3,State Treasurer,,Republican,"Estes, Ron",407,00004A
+THOMAS,Colby Ward 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00004B
+THOMAS,Colby Ward 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00004B
+THOMAS,Colby Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",87,000050
+THOMAS,Colby Ward 4,State Treasurer,,Republican,"Estes, Ron",353,000050
+THOMAS,East Hale Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000060
+THOMAS,East Hale Township,State Treasurer,,Republican,"Estes, Ron",49,000060
+THOMAS,East Morgan Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,00007A
+THOMAS,East Morgan Township,State Treasurer,,Republican,"Estes, Ron",84,00007A
+THOMAS,East Morgan Township Enclave Voting District,State Treasurer,,Democratic,"Alldritt, Carmen",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,State Treasurer,,Republican,"Estes, Ron",0,00007B
+THOMAS,Kingery Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000080
+THOMAS,Kingery Township,State Treasurer,,Republican,"Estes, Ron",35,000080
+THOMAS,Lacey Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000090
+THOMAS,Lacey Township,State Treasurer,,Republican,"Estes, Ron",43,000090
+THOMAS,Menlo Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000100
+THOMAS,Menlo Township,State Treasurer,,Republican,"Estes, Ron",26,000100
+THOMAS,North Randall Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000110
+THOMAS,North Randall Township,State Treasurer,,Republican,"Estes, Ron",34,000110
+THOMAS,Rovohl Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000120
+THOMAS,Rovohl Township,State Treasurer,,Republican,"Estes, Ron",72,000120
+THOMAS,Smith Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000130
+THOMAS,Smith Township,State Treasurer,,Republican,"Estes, Ron",67,000130
+THOMAS,South Randall Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000140
+THOMAS,South Randall Township,State Treasurer,,Republican,"Estes, Ron",86,000140
+THOMAS,Summers Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000150
+THOMAS,Summers Township,State Treasurer,,Republican,"Estes, Ron",81,000150
+THOMAS,Wendell Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000160
+THOMAS,Wendell Township,State Treasurer,,Republican,"Estes, Ron",32,000160
+THOMAS,West Hale Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000170
+THOMAS,West Hale Township,State Treasurer,,Republican,"Estes, Ron",109,000170
+THOMAS,West Morgan Township,State Treasurer,,Democratic,"Alldritt, Carmen",22,000180
+THOMAS,West Morgan Township,State Treasurer,,Republican,"Estes, Ron",164,000180
+THOMAS,Colby Ward 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+THOMAS,Colby Ward 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+THOMAS,East Morgan Township Enclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+THOMAS,East Morgan Township Enclave 2,State Treasurer,,Republican,"Estes, Ron",0,900020
+THOMAS,Barrett Township,United States Senate,,independent,"Orman, Greg",12,000010
+THOMAS,Barrett Township,United States Senate,,Libertarian,"Batson, Randall",1,000010
+THOMAS,Barrett Township,United States Senate,,Republican,"Roberts, Pat",34,000010
+THOMAS,Colby Ward 1,United States Senate,,independent,"Orman, Greg",89,000020
+THOMAS,Colby Ward 1,United States Senate,,Libertarian,"Batson, Randall",16,000020
+THOMAS,Colby Ward 1,United States Senate,,Republican,"Roberts, Pat",233,000020
+THOMAS,Colby Ward 2,United States Senate,,independent,"Orman, Greg",97,00003A
+THOMAS,Colby Ward 2,United States Senate,,Libertarian,"Batson, Randall",17,00003A
+THOMAS,Colby Ward 2,United States Senate,,Republican,"Roberts, Pat",271,00003A
+THOMAS,Colby Ward 2 Exclave,United States Senate,,independent,"Orman, Greg",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00003B
+THOMAS,Colby Ward 3,United States Senate,,independent,"Orman, Greg",135,00004A
+THOMAS,Colby Ward 3,United States Senate,,Libertarian,"Batson, Randall",24,00004A
+THOMAS,Colby Ward 3,United States Senate,,Republican,"Roberts, Pat",322,00004A
+THOMAS,Colby Ward 3 Exclave,United States Senate,,independent,"Orman, Greg",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00004B
+THOMAS,Colby Ward 4,United States Senate,,independent,"Orman, Greg",123,000050
+THOMAS,Colby Ward 4,United States Senate,,Libertarian,"Batson, Randall",23,000050
+THOMAS,Colby Ward 4,United States Senate,,Republican,"Roberts, Pat",307,000050
+THOMAS,East Hale Township,United States Senate,,independent,"Orman, Greg",6,000060
+THOMAS,East Hale Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+THOMAS,East Hale Township,United States Senate,,Republican,"Roberts, Pat",47,000060
+THOMAS,East Morgan Township,United States Senate,,independent,"Orman, Greg",24,00007A
+THOMAS,East Morgan Township,United States Senate,,Libertarian,"Batson, Randall",9,00007A
+THOMAS,East Morgan Township,United States Senate,,Republican,"Roberts, Pat",75,00007A
+THOMAS,East Morgan Township Enclave Voting District,United States Senate,,independent,"Orman, Greg",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States Senate,,Libertarian,"Batson, Randall",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States Senate,,Republican,"Roberts, Pat",0,00007B
+THOMAS,Kingery Township,United States Senate,,independent,"Orman, Greg",8,000080
+THOMAS,Kingery Township,United States Senate,,Libertarian,"Batson, Randall",2,000080
+THOMAS,Kingery Township,United States Senate,,Republican,"Roberts, Pat",30,000080
+THOMAS,Lacey Township,United States Senate,,independent,"Orman, Greg",10,000090
+THOMAS,Lacey Township,United States Senate,,Libertarian,"Batson, Randall",2,000090
+THOMAS,Lacey Township,United States Senate,,Republican,"Roberts, Pat",40,000090
+THOMAS,Menlo Township,United States Senate,,independent,"Orman, Greg",2,000100
+THOMAS,Menlo Township,United States Senate,,Libertarian,"Batson, Randall",1,000100
+THOMAS,Menlo Township,United States Senate,,Republican,"Roberts, Pat",23,000100
+THOMAS,North Randall Township,United States Senate,,independent,"Orman, Greg",2,000110
+THOMAS,North Randall Township,United States Senate,,Libertarian,"Batson, Randall",0,000110
+THOMAS,North Randall Township,United States Senate,,Republican,"Roberts, Pat",31,000110
+THOMAS,Rovohl Township,United States Senate,,independent,"Orman, Greg",10,000120
+THOMAS,Rovohl Township,United States Senate,,Libertarian,"Batson, Randall",2,000120
+THOMAS,Rovohl Township,United States Senate,,Republican,"Roberts, Pat",62,000120
+THOMAS,Smith Township,United States Senate,,independent,"Orman, Greg",12,000130
+THOMAS,Smith Township,United States Senate,,Libertarian,"Batson, Randall",1,000130
+THOMAS,Smith Township,United States Senate,,Republican,"Roberts, Pat",61,000130
+THOMAS,South Randall Township,United States Senate,,independent,"Orman, Greg",24,000140
+THOMAS,South Randall Township,United States Senate,,Libertarian,"Batson, Randall",3,000140
+THOMAS,South Randall Township,United States Senate,,Republican,"Roberts, Pat",74,000140
+THOMAS,Summers Township,United States Senate,,independent,"Orman, Greg",10,000150
+THOMAS,Summers Township,United States Senate,,Libertarian,"Batson, Randall",2,000150
+THOMAS,Summers Township,United States Senate,,Republican,"Roberts, Pat",80,000150
+THOMAS,Wendell Township,United States Senate,,independent,"Orman, Greg",5,000160
+THOMAS,Wendell Township,United States Senate,,Libertarian,"Batson, Randall",1,000160
+THOMAS,Wendell Township,United States Senate,,Republican,"Roberts, Pat",28,000160
+THOMAS,West Hale Township,United States Senate,,independent,"Orman, Greg",29,000170
+THOMAS,West Hale Township,United States Senate,,Libertarian,"Batson, Randall",4,000170
+THOMAS,West Hale Township,United States Senate,,Republican,"Roberts, Pat",92,000170
+THOMAS,West Morgan Township,United States Senate,,independent,"Orman, Greg",38,000180
+THOMAS,West Morgan Township,United States Senate,,Libertarian,"Batson, Randall",2,000180
+THOMAS,West Morgan Township,United States Senate,,Republican,"Roberts, Pat",146,000180
+THOMAS,Colby Ward 4 Exclave,United States Senate,,independent,"Orman, Greg",0,900010
+THOMAS,Colby Ward 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+THOMAS,Colby Ward 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900010
+THOMAS,East Morgan Township Enclave 2,United States Senate,,independent,"Orman, Greg",0,900020
+THOMAS,East Morgan Township Enclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900020
+THOMAS,East Morgan Township Enclave 2,United States Senate,,Republican,"Roberts, Pat",0,900020

--- a/2014/20141104__ks__general__trego__precinct.csv
+++ b/2014/20141104__ks__general__trego__precinct.csv
@@ -1,188 +1,188 @@
-county,precinct,office,district,party,candidate,votes
-Trego,Collyer Township,Attorney General,,D,A J Kotich,12
-Trego,Franklin Township,Attorney General,,D,A J Kotich,7
-Trego,Glencoe Township,Attorney General,,D,A J Kotich,1
-Trego,Ogallah Township,Attorney General,,D,A J Kotich,23
-Trego,Riverside Township,Attorney General,,D,A J Kotich,11
-Trego,WaKeeney Township,Attorney General,,D,A J Kotich,28
-Trego,Wilcox Township,Attorney General,,D,A J Kotich,4
-Trego,Collyer City,Attorney General,,D,A J Kotich,1
-Trego,WaKeeney City Central ,Attorney General,,D,A J Kotich,48
-Trego,WaKeeney City East,Attorney General,,D,A J Kotich,37
-Trego,WaKeeney City West,Attorney General,,D,A J Kotich,47
-Trego,Collyer Township,Attorney General,,R,Derek Schmidt,62
-Trego,Franklin Township,Attorney General,,R,Derek Schmidt,11
-Trego,Glencoe Township,Attorney General,,R,Derek Schmidt,32
-Trego,Ogallah Township,Attorney General,,R,Derek Schmidt,54
-Trego,Riverside Township,Attorney General,,R,Derek Schmidt,28
-Trego,WaKeeney Township,Attorney General,,R,Derek Schmidt,153
-Trego,Wilcox Township,Attorney General,,R,Derek Schmidt,25
-Trego,Collyer City,Attorney General,,R,Derek Schmidt,34
-Trego,WaKeeney City Central ,Attorney General,,R,Derek Schmidt,187
-Trego,WaKeeney City East,Attorney General,,R,Derek Schmidt,160
-Trego,WaKeeney City West,Attorney General,,R,Derek Schmidt,194
-Trego,Collyer Township,U.S. House,1,D,James E Sherow,14
-Trego,Franklin Township,U.S. House,1,D,James E Sherow,6
-Trego,Glencoe Township,U.S. House,1,D,James E Sherow,4
-Trego,Ogallah Township,U.S. House,1,D,James E Sherow,27
-Trego,Riverside Township,U.S. House,1,D,James E Sherow,15
-Trego,WaKeeney Township,U.S. House,1,D,James E Sherow,49
-Trego,Wilcox Township,U.S. House,1,D,James E Sherow,3
-Trego,Collyer City,U.S. House,1,D,James E Sherow,2
-Trego,WaKeeney City Central ,U.S. House,1,D,James E Sherow,69
-Trego,WaKeeney City East,U.S. House,1,D,James E Sherow,50
-Trego,WaKeeney City West,U.S. House,1,D,James E Sherow,59
-Trego,Collyer Township,U.S. House,1,D,Tim Huelskamp,63
-Trego,Franklin Township,U.S. House,1,D,Tim Huelskamp,12
-Trego,Glencoe Township,U.S. House,1,D,Tim Huelskamp,31
-Trego,Ogallah Township,U.S. House,1,D,Tim Huelskamp,51
-Trego,Riverside Township,U.S. House,1,D,Tim Huelskamp,26
-Trego,WaKeeney Township,U.S. House,1,D,Tim Huelskamp,133
-Trego,Wilcox Township,U.S. House,1,D,Tim Huelskamp,26
-Trego,Collyer City,U.S. House,1,D,Tim Huelskamp,33
-Trego,WaKeeney City Central ,U.S. House,1,D,Tim Huelskamp,171
-Trego,WaKeeney City East,U.S. House,1,D,Tim Huelskamp,149
-Trego,WaKeeney City West,U.S. House,1,D,Tim Huelskamp,187
-Trego,Collyer Township,Governor,,L,Keen A Umbehr,4
-Trego,Franklin Township,Governor,,L,Keen A Umbehr,0
-Trego,Glencoe Township,Governor,,L,Keen A Umbehr,0
-Trego,Ogallah Township,Governor,,L,Keen A Umbehr,3
-Trego,Riverside Township,Governor,,L,Keen A Umbehr,1
-Trego,WaKeeney Township,Governor,,L,Keen A Umbehr,5
-Trego,Wilcox Township,Governor,,L,Keen A Umbehr,2
-Trego,Collyer City,Governor,,L,Keen A Umbehr,3
-Trego,WaKeeney City Central ,Governor,,L,Keen A Umbehr,12
-Trego,WaKeeney City East,Governor,,L,Keen A Umbehr,11
-Trego,WaKeeney City West,Governor,,L,Keen A Umbehr,10
-Trego,Collyer Township,Governor,,D,Paul Davis,20
-Trego,Franklin Township,Governor,,D,Paul Davis,6
-Trego,Glencoe Township,Governor,,D,Paul Davis,4
-Trego,Ogallah Township,Governor,,D,Paul Davis,31
-Trego,Riverside Township,Governor,,D,Paul Davis,14
-Trego,WaKeeney Township,Governor,,D,Paul Davis,60
-Trego,Wilcox Township,Governor,,D,Paul Davis,6
-Trego,Collyer City,Governor,,D,Paul Davis,10
-Trego,WaKeeney City Central ,Governor,,D,Paul Davis,72
-Trego,WaKeeney City East,Governor,,D,Paul Davis,59
-Trego,WaKeeney City West,Governor,,D,Paul Davis,94
-Trego,Collyer Township,Governor,,R,Sam Brownback,53
-Trego,Franklin Township,Governor,,R,Sam Brownback,12
-Trego,Glencoe Township,Governor,,R,Sam Brownback,31
-Trego,Ogallah Township,Governor,,R,Sam Brownback,46
-Trego,Riverside Township,Governor,,R,Sam Brownback,25
-Trego,WaKeeney Township,Governor,,R,Sam Brownback,119
-Trego,Wilcox Township,Governor,,R,Sam Brownback,21
-Trego,Collyer City,Governor,,R,Sam Brownback,24
-Trego,WaKeeney City Central ,Governor,,R,Sam Brownback,153
-Trego,WaKeeney City East,Governor,,R,Sam Brownback,136
-Trego,WaKeeney City West,Governor,,R,Sam Brownback,144
-Trego,Collyer Township,Insurance Commissioner,,D,Dennis Anderson,14
-Trego,Franklin Township,Insurance Commissioner,,D,Dennis Anderson,6
-Trego,Glencoe Township,Insurance Commissioner,,D,Dennis Anderson,3
-Trego,Ogallah Township,Insurance Commissioner,,D,Dennis Anderson,23
-Trego,Riverside Township,Insurance Commissioner,,D,Dennis Anderson,17
-Trego,WaKeeney Township,Insurance Commissioner,,D,Dennis Anderson,39
-Trego,Wilcox Township,Insurance Commissioner,,D,Dennis Anderson,6
-Trego,Collyer City,Insurance Commissioner,,D,Dennis Anderson,2
-Trego,WaKeeney City Central ,Insurance Commissioner,,D,Dennis Anderson,50
-Trego,WaKeeney City East,Insurance Commissioner,,D,Dennis Anderson,44
-Trego,WaKeeney City West,Insurance Commissioner,,D,Dennis Anderson,53
-Trego,Collyer Township,Insurance Commissioner,,R,Ken Selzer,55
-Trego,Franklin Township,Insurance Commissioner,,R,Ken Selzer,12
-Trego,Glencoe Township,Insurance Commissioner,,R,Ken Selzer,29
-Trego,Ogallah Township,Insurance Commissioner,,R,Ken Selzer,52
-Trego,Riverside Township,Insurance Commissioner,,R,Ken Selzer,20
-Trego,WaKeeney Township,Insurance Commissioner,,R,Ken Selzer,133
-Trego,Wilcox Township,Insurance Commissioner,,R,Ken Selzer,24
-Trego,Collyer City,Insurance Commissioner,,R,Ken Selzer,31
-Trego,WaKeeney City Central ,Insurance Commissioner,,R,Ken Selzer,175
-Trego,WaKeeney City East,Insurance Commissioner,,R,Ken Selzer,145
-Trego,WaKeeney City West,Insurance Commissioner,,R,Ken Selzer,167
-Trego,Collyer Township,Secretary of State,,D,Jean Kurtis Schodorf,21
-Trego,Franklin Township,Secretary of State,,D,Jean Kurtis Schodorf,6
-Trego,Glencoe Township,Secretary of State,,D,Jean Kurtis Schodorf,4
-Trego,Ogallah Township,Secretary of State,,D,Jean Kurtis Schodorf,32
-Trego,Riverside Township,Secretary of State,,D,Jean Kurtis Schodorf,13
-Trego,WaKeeney Township,Secretary of State,,D,Jean Kurtis Schodorf,44
-Trego,Wilcox Township,Secretary of State,,D,Jean Kurtis Schodorf,5
-Trego,Collyer City,Secretary of State,,D,Jean Kurtis Schodorf,4
-Trego,WaKeeney City Central ,Secretary of State,,D,Jean Kurtis Schodorf,55
-Trego,WaKeeney City East,Secretary of State,,D,Jean Kurtis Schodorf,52
-Trego,WaKeeney City West,Secretary of State,,D,Jean Kurtis Schodorf,63
-Trego,Collyer Township,Secretary of State,,R,Kris Kobach,54
-Trego,Franklin Township,Secretary of State,,R,Kris Kobach,12
-Trego,Glencoe Township,Secretary of State,,R,Kris Kobach,30
-Trego,Ogallah Township,Secretary of State,,R,Kris Kobach,48
-Trego,Riverside Township,Secretary of State,,R,Kris Kobach,27
-Trego,WaKeeney Township,Secretary of State,,R,Kris Kobach,138
-Trego,Wilcox Township,Secretary of State,,R,Kris Kobach,23
-Trego,Collyer City,Secretary of State,,R,Kris Kobach,31
-Trego,WaKeeney City Central ,Secretary of State,,R,Kris Kobach,179
-Trego,WaKeeney City East,Secretary of State,,R,Kris Kobach,149
-Trego,WaKeeney City West,Secretary of State,,R,Kris Kobach,179
-Trego,Collyer Township,State House,118,R,Don Hineman,71
-Trego,Franklin Township,State House,118,R,Don Hineman,16
-Trego,Glencoe Township,State House,118,R,Don Hineman,34
-Trego,Ogallah Township,State House,118,R,Don Hineman,68
-Trego,Riverside Township,State House,118,R,Don Hineman,36
-Trego,WaKeeney Township,State House,118,R,Don Hineman,161
-Trego,Wilcox Township,State House,118,R,Don Hineman,27
-Trego,Collyer City,State House,118,R,Don Hineman,33
-Trego,WaKeeney City Central ,State House,118,R,Don Hineman,211
-Trego,WaKeeney City East,State House,118,R,Don Hineman,172
-Trego,WaKeeney City West,State House,118,R,Don Hineman,206
-Trego,Collyer Township,State Treasurer,,D,Carmen Alldritt,19
-Trego,Franklin Township,State Treasurer,,D,Carmen Alldritt,6
-Trego,Glencoe Township,State Treasurer,,D,Carmen Alldritt,0
-Trego,Ogallah Township,State Treasurer,,D,Carmen Alldritt,18
-Trego,Riverside Township,State Treasurer,,D,Carmen Alldritt,13
-Trego,WaKeeney Township,State Treasurer,,D,Carmen Alldritt,28
-Trego,Wilcox Township,State Treasurer,,D,Carmen Alldritt,4
-Trego,Collyer City,State Treasurer,,D,Carmen Alldritt,4
-Trego,WaKeeney City Central ,State Treasurer,,D,Carmen Alldritt,40
-Trego,WaKeeney City East,State Treasurer,,D,Carmen Alldritt,42
-Trego,WaKeeney City West,State Treasurer,,D,Carmen Alldritt,49
-Trego,Collyer Township,State Treasurer,,R,Ron Estes,57
-Trego,Franklin Township,State Treasurer,,R,Ron Estes,12
-Trego,Glencoe Township,State Treasurer,,R,Ron Estes,33
-Trego,Ogallah Township,State Treasurer,,R,Ron Estes,61
-Trego,Riverside Township,State Treasurer,,R,Ron Estes,26
-Trego,WaKeeney Township,State Treasurer,,R,Ron Estes,150
-Trego,Wilcox Township,State Treasurer,,R,Ron Estes,25
-Trego,Collyer City,State Treasurer,,R,Ron Estes,31
-Trego,WaKeeney City Central ,State Treasurer,,R,Ron Estes,192
-Trego,WaKeeney City East,State Treasurer,,R,Ron Estes,150
-Trego,WaKeeney City West,State Treasurer,,R,Ron Estes,186
-Trego,Collyer Township,U.S. Senate,,I,Greg Orman,18
-Trego,Franklin Township,U.S. Senate,,I,Greg Orman,6
-Trego,Glencoe Township,U.S. Senate,,I,Greg Orman,2
-Trego,Ogallah Township,U.S. Senate,,I,Greg Orman,24
-Trego,Riverside Township,U.S. Senate,,I,Greg Orman,14
-Trego,WaKeeney Township,U.S. Senate,,I,Greg Orman,48
-Trego,Wilcox Township,U.S. Senate,,I,Greg Orman,4
-Trego,Collyer City,U.S. Senate,,I,Greg Orman,7
-Trego,WaKeeney City Central ,U.S. Senate,,I,Greg Orman,64
-Trego,WaKeeney City East,U.S. Senate,,I,Greg Orman,47
-Trego,WaKeeney City West,U.S. Senate,,I,Greg Orman,75
-Trego,Collyer Township,U.S. Senate,,R,Pat Roberts,47
-Trego,Franklin Township,U.S. Senate,,R,Pat Roberts,12
-Trego,Glencoe Township,U.S. Senate,,R,Pat Roberts,32
-Trego,Ogallah Township,U.S. Senate,,R,Pat Roberts,50
-Trego,Riverside Township,U.S. Senate,,R,Pat Roberts,28
-Trego,WaKeeney Township,U.S. Senate,,R,Pat Roberts,128
-Trego,Wilcox Township,U.S. Senate,,R,Pat Roberts,23
-Trego,Collyer City,U.S. Senate,,R,Pat Roberts,29
-Trego,WaKeeney City Central ,U.S. Senate,,R,Pat Roberts,160
-Trego,WaKeeney City East,U.S. Senate,,R,Pat Roberts,145
-Trego,WaKeeney City West,U.S. Senate,,R,Pat Roberts,159
-Trego,Collyer Township,U.S. Senate,,L,Randall Batson,11
-Trego,Franklin Township,U.S. Senate,,L,Randall Batson,0
-Trego,Glencoe Township,U.S. Senate,,L,Randall Batson,0
-Trego,Ogallah Township,U.S. Senate,,L,Randall Batson,5
-Trego,Riverside Township,U.S. Senate,,L,Randall Batson,0
-Trego,WaKeeney Township,U.S. Senate,,L,Randall Batson,8
-Trego,Wilcox Township,U.S. Senate,,L,Randall Batson,2
-Trego,Collyer City,U.S. Senate,,L,Randall Batson,1
-Trego,WaKeeney City Central ,U.S. Senate,,L,Randall Batson,15
-Trego,WaKeeney City East,U.S. Senate,,L,Randall Batson,12
-Trego,WaKeeney City West,U.S. Senate,,L,Randall Batson,13
+county,precinct,office,district,party,candidate,votes,vtd
+TREGO,Collyer City,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000010
+TREGO,Collyer City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000010
+TREGO,Collyer City,Governor / Lt. Governor,,Republican,"Brownback, Sam",24,000010
+TREGO,Collyer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000020
+TREGO,Collyer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000020
+TREGO,Collyer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",53,000020
+TREGO,Franklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000030
+TREGO,Franklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+TREGO,Franklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000030
+TREGO,Glencoe Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000040
+TREGO,Glencoe Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000040
+TREGO,Glencoe Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000040
+TREGO,Ogallah Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000050
+TREGO,Ogallah Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000050
+TREGO,Ogallah Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000050
+TREGO,Riverside Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000060
+TREGO,Riverside Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000060
+TREGO,Riverside Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000060
+TREGO,WaKeeney City Central Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,000070
+TREGO,WaKeeney City Central Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000070
+TREGO,WaKeeney City Central Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",153,000070
+TREGO,WaKeeney City East Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",59,000080
+TREGO,WaKeeney City East Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000080
+TREGO,WaKeeney City East Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",136,000080
+TREGO,WaKeeney City West Precinct,Governor / Lt. Governor,,Democratic,"Davis, Paul",94,000090
+TREGO,WaKeeney City West Precinct,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000090
+TREGO,WaKeeney City West Precinct,Governor / Lt. Governor,,Republican,"Brownback, Sam",144,000090
+TREGO,WaKeeney Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",60,000100
+TREGO,WaKeeney Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000100
+TREGO,WaKeeney Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",119,000100
+TREGO,Wilcox Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000110
+TREGO,Wilcox Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000110
+TREGO,Wilcox Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000110
+TREGO,Collyer City,Kansas House of Representatives,118,Republican,"Hineman, Don",33,000010
+TREGO,Collyer Township,Kansas House of Representatives,118,Republican,"Hineman, Don",71,000020
+TREGO,Franklin Township,Kansas House of Representatives,118,Republican,"Hineman, Don",16,000030
+TREGO,Glencoe Township,Kansas House of Representatives,118,Republican,"Hineman, Don",34,000040
+TREGO,Ogallah Township,Kansas House of Representatives,118,Republican,"Hineman, Don",68,000050
+TREGO,Riverside Township,Kansas House of Representatives,118,Republican,"Hineman, Don",36,000060
+TREGO,WaKeeney City Central Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",211,000070
+TREGO,WaKeeney City East Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",171,000080
+TREGO,WaKeeney City West Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",206,000090
+TREGO,WaKeeney Township,Kansas House of Representatives,118,Republican,"Hineman, Don",161,000100
+TREGO,Wilcox Township,Kansas House of Representatives,118,Republican,"Hineman, Don",27,000110
+TREGO,Collyer City,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000010
+TREGO,Collyer City,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000010
+TREGO,Collyer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",14,000020
+TREGO,Collyer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000020
+TREGO,Franklin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000030
+TREGO,Franklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000030
+TREGO,Glencoe Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000040
+TREGO,Glencoe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000040
+TREGO,Ogallah Township,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000050
+TREGO,Ogallah Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000050
+TREGO,Riverside Township,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000060
+TREGO,Riverside Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000060
+TREGO,WaKeeney City Central Precinct,United States House of Representatives,1,Democratic,"Sherow, James E.",69,000070
+TREGO,WaKeeney City Central Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",171,000070
+TREGO,WaKeeney City East Precinct,United States House of Representatives,1,Democratic,"Sherow, James E.",50,000080
+TREGO,WaKeeney City East Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",149,000080
+TREGO,WaKeeney City West Precinct,United States House of Representatives,1,Democratic,"Sherow, James E.",59,000090
+TREGO,WaKeeney City West Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",187,000090
+TREGO,WaKeeney Township,United States House of Representatives,1,Democratic,"Sherow, James E.",49,000100
+TREGO,WaKeeney Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",133,000100
+TREGO,Wilcox Township,United States House of Representatives,1,Democratic,"Sherow, James E.",3,000110
+TREGO,Wilcox Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000110
+TREGO,Collyer City,Attorney General,,Democratic,"Kotich, A.J.",1,000010
+TREGO,Collyer City,Attorney General,,Republican,"Schmidt, Derek",34,000010
+TREGO,Collyer Township,Attorney General,,Democratic,"Kotich, A.J.",12,000020
+TREGO,Collyer Township,Attorney General,,Republican,"Schmidt, Derek",62,000020
+TREGO,Franklin Township,Attorney General,,Democratic,"Kotich, A.J.",7,000030
+TREGO,Franklin Township,Attorney General,,Republican,"Schmidt, Derek",11,000030
+TREGO,Glencoe Township,Attorney General,,Democratic,"Kotich, A.J.",1,000040
+TREGO,Glencoe Township,Attorney General,,Republican,"Schmidt, Derek",32,000040
+TREGO,Ogallah Township,Attorney General,,Democratic,"Kotich, A.J.",23,000050
+TREGO,Ogallah Township,Attorney General,,Republican,"Schmidt, Derek",54,000050
+TREGO,Riverside Township,Attorney General,,Democratic,"Kotich, A.J.",11,000060
+TREGO,Riverside Township,Attorney General,,Republican,"Schmidt, Derek",28,000060
+TREGO,WaKeeney City Central Precinct,Attorney General,,Democratic,"Kotich, A.J.",48,000070
+TREGO,WaKeeney City Central Precinct,Attorney General,,Republican,"Schmidt, Derek",187,000070
+TREGO,WaKeeney City East Precinct,Attorney General,,Democratic,"Kotich, A.J.",37,000080
+TREGO,WaKeeney City East Precinct,Attorney General,,Republican,"Schmidt, Derek",160,000080
+TREGO,WaKeeney City West Precinct,Attorney General,,Democratic,"Kotich, A.J.",47,000090
+TREGO,WaKeeney City West Precinct,Attorney General,,Republican,"Schmidt, Derek",194,000090
+TREGO,WaKeeney Township,Attorney General,,Democratic,"Kotich, A.J.",28,000100
+TREGO,WaKeeney Township,Attorney General,,Republican,"Schmidt, Derek",153,000100
+TREGO,Wilcox Township,Attorney General,,Democratic,"Kotich, A.J.",4,000110
+TREGO,Wilcox Township,Attorney General,,Republican,"Schmidt, Derek",25,000110
+TREGO,Collyer City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000010
+TREGO,Collyer City,Commissioner of Insurance,,Republican,"Selzer, Ken",31,000010
+TREGO,Collyer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000020
+TREGO,Collyer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000020
+TREGO,Franklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000030
+TREGO,Franklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000030
+TREGO,Glencoe Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000040
+TREGO,Glencoe Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000040
+TREGO,Ogallah Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",23,000050
+TREGO,Ogallah Township,Commissioner of Insurance,,Republican,"Selzer, Ken",52,000050
+TREGO,Riverside Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",17,000060
+TREGO,Riverside Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000060
+TREGO,WaKeeney City Central Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",50,000070
+TREGO,WaKeeney City Central Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",175,000070
+TREGO,WaKeeney City East Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",44,000080
+TREGO,WaKeeney City East Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",145,000080
+TREGO,WaKeeney City West Precinct,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000090
+TREGO,WaKeeney City West Precinct,Commissioner of Insurance,,Republican,"Selzer, Ken",167,000090
+TREGO,WaKeeney Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000100
+TREGO,WaKeeney Township,Commissioner of Insurance,,Republican,"Selzer, Ken",133,000100
+TREGO,Wilcox Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000110
+TREGO,Wilcox Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000110
+TREGO,Collyer City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000010
+TREGO,Collyer City,Secretary of State,,Republican,"Kobach, Kris",31,000010
+TREGO,Collyer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",21,000020
+TREGO,Collyer Township,Secretary of State,,Republican,"Kobach, Kris",54,000020
+TREGO,Franklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000030
+TREGO,Franklin Township,Secretary of State,,Republican,"Kobach, Kris",12,000030
+TREGO,Glencoe Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000040
+TREGO,Glencoe Township,Secretary of State,,Republican,"Kobach, Kris",30,000040
+TREGO,Ogallah Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",32,000050
+TREGO,Ogallah Township,Secretary of State,,Republican,"Kobach, Kris",48,000050
+TREGO,Riverside Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000060
+TREGO,Riverside Township,Secretary of State,,Republican,"Kobach, Kris",27,000060
+TREGO,WaKeeney City Central Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000070
+TREGO,WaKeeney City Central Precinct,Secretary of State,,Republican,"Kobach, Kris",179,000070
+TREGO,WaKeeney City East Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,000080
+TREGO,WaKeeney City East Precinct,Secretary of State,,Republican,"Kobach, Kris",149,000080
+TREGO,WaKeeney City West Precinct,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",63,000090
+TREGO,WaKeeney City West Precinct,Secretary of State,,Republican,"Kobach, Kris",179,000090
+TREGO,WaKeeney Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",44,000100
+TREGO,WaKeeney Township,Secretary of State,,Republican,"Kobach, Kris",138,000100
+TREGO,Wilcox Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000110
+TREGO,Wilcox Township,Secretary of State,,Republican,"Kobach, Kris",23,000110
+TREGO,Collyer City,State Treasurer,,Democratic,"Alldritt, Carmen",4,000010
+TREGO,Collyer City,State Treasurer,,Republican,"Estes, Ron",31,000010
+TREGO,Collyer Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000020
+TREGO,Collyer Township,State Treasurer,,Republican,"Estes, Ron",57,000020
+TREGO,Franklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000030
+TREGO,Franklin Township,State Treasurer,,Republican,"Estes, Ron",12,000030
+TREGO,Glencoe Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000040
+TREGO,Glencoe Township,State Treasurer,,Republican,"Estes, Ron",33,000040
+TREGO,Ogallah Township,State Treasurer,,Democratic,"Alldritt, Carmen",18,000050
+TREGO,Ogallah Township,State Treasurer,,Republican,"Estes, Ron",61,000050
+TREGO,Riverside Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000060
+TREGO,Riverside Township,State Treasurer,,Republican,"Estes, Ron",26,000060
+TREGO,WaKeeney City Central Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",40,000070
+TREGO,WaKeeney City Central Precinct,State Treasurer,,Republican,"Estes, Ron",192,000070
+TREGO,WaKeeney City East Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",42,000080
+TREGO,WaKeeney City East Precinct,State Treasurer,,Republican,"Estes, Ron",150,000080
+TREGO,WaKeeney City West Precinct,State Treasurer,,Democratic,"Alldritt, Carmen",49,000090
+TREGO,WaKeeney City West Precinct,State Treasurer,,Republican,"Estes, Ron",186,000090
+TREGO,WaKeeney Township,State Treasurer,,Democratic,"Alldritt, Carmen",28,000100
+TREGO,WaKeeney Township,State Treasurer,,Republican,"Estes, Ron",150,000100
+TREGO,Wilcox Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000110
+TREGO,Wilcox Township,State Treasurer,,Republican,"Estes, Ron",25,000110
+TREGO,Collyer City,United States Senate,,independent,"Orman, Greg",7,000010
+TREGO,Collyer City,United States Senate,,Libertarian,"Batson, Randall",1,000010
+TREGO,Collyer City,United States Senate,,Republican,"Roberts, Pat",29,000010
+TREGO,Collyer Township,United States Senate,,independent,"Orman, Greg",18,000020
+TREGO,Collyer Township,United States Senate,,Libertarian,"Batson, Randall",11,000020
+TREGO,Collyer Township,United States Senate,,Republican,"Roberts, Pat",47,000020
+TREGO,Franklin Township,United States Senate,,independent,"Orman, Greg",6,000030
+TREGO,Franklin Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+TREGO,Franklin Township,United States Senate,,Republican,"Roberts, Pat",12,000030
+TREGO,Glencoe Township,United States Senate,,independent,"Orman, Greg",2,000040
+TREGO,Glencoe Township,United States Senate,,Libertarian,"Batson, Randall",0,000040
+TREGO,Glencoe Township,United States Senate,,Republican,"Roberts, Pat",32,000040
+TREGO,Ogallah Township,United States Senate,,independent,"Orman, Greg",24,000050
+TREGO,Ogallah Township,United States Senate,,Libertarian,"Batson, Randall",5,000050
+TREGO,Ogallah Township,United States Senate,,Republican,"Roberts, Pat",50,000050
+TREGO,Riverside Township,United States Senate,,independent,"Orman, Greg",14,000060
+TREGO,Riverside Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+TREGO,Riverside Township,United States Senate,,Republican,"Roberts, Pat",28,000060
+TREGO,WaKeeney City Central Precinct,United States Senate,,independent,"Orman, Greg",64,000070
+TREGO,WaKeeney City Central Precinct,United States Senate,,Libertarian,"Batson, Randall",15,000070
+TREGO,WaKeeney City Central Precinct,United States Senate,,Republican,"Roberts, Pat",160,000070
+TREGO,WaKeeney City East Precinct,United States Senate,,independent,"Orman, Greg",47,000080
+TREGO,WaKeeney City East Precinct,United States Senate,,Libertarian,"Batson, Randall",12,000080
+TREGO,WaKeeney City East Precinct,United States Senate,,Republican,"Roberts, Pat",145,000080
+TREGO,WaKeeney City West Precinct,United States Senate,,independent,"Orman, Greg",75,000090
+TREGO,WaKeeney City West Precinct,United States Senate,,Libertarian,"Batson, Randall",13,000090
+TREGO,WaKeeney City West Precinct,United States Senate,,Republican,"Roberts, Pat",159,000090
+TREGO,WaKeeney Township,United States Senate,,independent,"Orman, Greg",48,000100
+TREGO,WaKeeney Township,United States Senate,,Libertarian,"Batson, Randall",8,000100
+TREGO,WaKeeney Township,United States Senate,,Republican,"Roberts, Pat",128,000100
+TREGO,Wilcox Township,United States Senate,,independent,"Orman, Greg",4,000110
+TREGO,Wilcox Township,United States Senate,,Libertarian,"Batson, Randall",2,000110
+TREGO,Wilcox Township,United States Senate,,Republican,"Roberts, Pat",23,000110

--- a/2014/20141104__ks__general__wabaunsee__precinct.csv
+++ b/2014/20141104__ks__general__wabaunsee__precinct.csv
@@ -1,268 +1,256 @@
-county,precinct,office,district,party,candidate,votes
-Wabaunsee,Alma Township,U.S. Senate,,R,Pat Roberts,287
-Wabaunsee,Chalk Township,U.S. Senate,,R,Pat Roberts,13
-Wabaunsee,Farmer twp Alta Vista,U.S. Senate,,R,Pat Roberts,42
-Wabaunsee,Garfield Township,U.S. Senate,,R,Pat Roberts,139
-Wabaunsee,Harveyville Township,U.S. Senate,,R,Pat Roberts,128
-Wabaunsee,Hessdale Township,U.S. Senate,,R,Pat Roberts,63
-Wabaunsee,Kaw Township,U.S. Senate,,R,Pat Roberts,83
-Wabaunsee,Keene Township,U.S. Senate,,R,Pat Roberts,131
-Wabaunsee,Maple Hill Township,U.S. Senate,,R,Pat Roberts,303
-Wabaunsee,McFarland Township,U.S. Senate,,R,Pat Roberts,68
-Wabaunsee,Paxico Township,U.S. Senate,,R,Pat Roberts,238
-Wabaunsee,Wabaunsee Twp,U.S. Senate,,R,Pat Roberts,133
-Wabaunsee,Washington Township,U.S. Senate,,R,Pat Roberts,28
-Wabaunsee,Wilmington twp Eskridge,U.S. Senate,,R,Pat Roberts,113
-Wabaunsee,Alma Township,U.S. Senate,,IND,Greg Orman,171
-Wabaunsee,Chalk Township,U.S. Senate,,IND,Greg Orman,4
-Wabaunsee,Farmer twp Alta Vista,U.S. Senate,,IND,Greg Orman,14
-Wabaunsee,Garfield Township,U.S. Senate,,IND,Greg Orman,67
-Wabaunsee,Harveyville Township,U.S. Senate,,IND,Greg Orman,99
-Wabaunsee,Hessdale Township,U.S. Senate,,IND,Greg Orman,44
-Wabaunsee,Kaw Township,U.S. Senate,,IND,Greg Orman,18
-Wabaunsee,Keene Township,U.S. Senate,,IND,Greg Orman,86
-Wabaunsee,Maple Hill Township,U.S. Senate,,IND,Greg Orman,132
-Wabaunsee,McFarland Township,U.S. Senate,,IND,Greg Orman,39
-Wabaunsee,Paxico Township,U.S. Senate,,IND,Greg Orman,75
-Wabaunsee,Wabaunsee Twp,U.S. Senate,,IND,Greg Orman,80
-Wabaunsee,Washington Township,U.S. Senate,,IND,Greg Orman,15
-Wabaunsee,Wilmington twp Eskridge,U.S. Senate,,IND,Greg Orman,78
-Wabaunsee,Alma Township,U.S. Senate,,LBT,Randall Batson,37
-Wabaunsee,Chalk Township,U.S. Senate,,LBT,Randall Batson,1
-Wabaunsee,Farmer twp Alta Vista,U.S. Senate,,LBT,Randall Batson,4
-Wabaunsee,Garfield Township,U.S. Senate,,LBT,Randall Batson,20
-Wabaunsee,Harveyville Township,U.S. Senate,,LBT,Randall Batson,15
-Wabaunsee,Hessdale Township,U.S. Senate,,LBT,Randall Batson,2
-Wabaunsee,Kaw Township,U.S. Senate,,LBT,Randall Batson,5
-Wabaunsee,Keene Township,U.S. Senate,,LBT,Randall Batson,10
-Wabaunsee,Maple Hill Township,U.S. Senate,,LBT,Randall Batson,20
-Wabaunsee,McFarland Township,U.S. Senate,,LBT,Randall Batson,6
-Wabaunsee,Paxico Township,U.S. Senate,,LBT,Randall Batson,28
-Wabaunsee,Wabaunsee Twp,U.S. Senate,,LBT,Randall Batson,8
-Wabaunsee,Washington Township,U.S. Senate,,LBT,Randall Batson,3
-Wabaunsee,Wilmington twp Eskridge,U.S. Senate,,LBT,Randall Batson,14
-Wabaunsee,Alma Township,U.S. House,1,R,Tim Huelskamp,321
-Wabaunsee,Chalk Township,U.S. House,1,R,Tim Huelskamp,16
-Wabaunsee,Farmer twp Alta Vista,U.S. House,1,R,Tim Huelskamp,40
-Wabaunsee,Garfield Township,U.S. House,1,R,Tim Huelskamp,141
-Wabaunsee,Harveyville Township,U.S. House,1,R,Tim Huelskamp,162
-Wabaunsee,Hessdale Township,U.S. House,1,R,Tim Huelskamp,66
-Wabaunsee,Kaw Township,U.S. House,1,R,Tim Huelskamp,88
-Wabaunsee,Keene Township,U.S. House,1,R,Tim Huelskamp,144
-Wabaunsee,Maple Hill Township,U.S. House,1,R,Tim Huelskamp,320
-Wabaunsee,McFarland Township,U.S. House,1,R,Tim Huelskamp,82
-Wabaunsee,Paxico Township,U.S. House,1,R,Tim Huelskamp,255
-Wabaunsee,Wabaunsee Twp,U.S. House,1,R,Tim Huelskamp,139
-Wabaunsee,Washington Township,U.S. House,1,R,Tim Huelskamp,30
-Wabaunsee,Wilmington twp Eskridge,U.S. House,1,R,Tim Huelskamp,132
-Wabaunsee,Alma Township,U.S. House,1,D,James Sherow,167
-Wabaunsee,Chalk Township,U.S. House,1,D,James Sherow,2
-Wabaunsee,Farmer twp Alta Vista,U.S. House,1,D,James Sherow,19
-Wabaunsee,Garfield Township,U.S. House,1,D,James Sherow,80
-Wabaunsee,Harveyville Township,U.S. House,1,D,James Sherow,73
-Wabaunsee,Hessdale Township,U.S. House,1,D,James Sherow,40
-Wabaunsee,Kaw Township,U.S. House,1,D,James Sherow,17
-Wabaunsee,Keene Township,U.S. House,1,D,James Sherow,78
-Wabaunsee,Maple Hill Township,U.S. House,1,D,James Sherow,125
-Wabaunsee,McFarland Township,U.S. House,1,D,James Sherow,29
-Wabaunsee,Paxico Township,U.S. House,1,D,James Sherow,86
-Wabaunsee,Wabaunsee Twp,U.S. House,1,D,James Sherow,80
-Wabaunsee,Washington Township,U.S. House,1,D,James Sherow,12
-Wabaunsee,Wilmington twp Eskridge,U.S. House,1,D,James Sherow,69
-Wabaunsee,Alma Township,Governor,,R,Sam Brownback,195
-Wabaunsee,Chalk Township,Governor,,R,Sam Brownback,12
-Wabaunsee,Farmer twp Alta Vista,Governor,,R,Sam Brownback,29
-Wabaunsee,Garfield Township,Governor,,R,Sam Brownback,117
-Wabaunsee,Harveyville Township,Governor,,R,Sam Brownback,101
-Wabaunsee,Hessdale Township,Governor,,R,Sam Brownback,54
-Wabaunsee,Kaw Township,Governor,,R,Sam Brownback,75
-Wabaunsee,Keene Township,Governor,,R,Sam Brownback,113
-Wabaunsee,Maple Hill Township,Governor,,R,Sam Brownback,258
-Wabaunsee,McFarland Township,Governor,,R,Sam Brownback,50
-Wabaunsee,Paxico Township,Governor,,R,Sam Brownback,205
-Wabaunsee,Wabaunsee Twp,Governor,,R,Sam Brownback,116
-Wabaunsee,Washington Township,Governor,,R,Sam Brownback,26
-Wabaunsee,Wilmington twp Eskridge,Governor,,R,Sam Brownback,92
-Wabaunsee,Alma Township,Governor,,D,Paul Davis,154
-Wabaunsee,Chalk Township,Governor,,D,Paul Davis,3
-Wabaunsee,Farmer twp Alta Vista,Governor,,D,Paul Davis,14
-Wabaunsee,Garfield Township,Governor,,D,Paul Davis,71
-Wabaunsee,Harveyville Township,Governor,,D,Paul Davis,102
-Wabaunsee,Hessdale Township,Governor,,D,Paul Davis,43
-Wabaunsee,Kaw Township,Governor,,D,Paul Davis,18
-Wabaunsee,Keene Township,Governor,,D,Paul Davis,90
-Wabaunsee,Maple Hill Township,Governor,,D,Paul Davis,149
-Wabaunsee,McFarland Township,Governor,,D,Paul Davis,27
-Wabaunsee,Paxico Township,Governor,,D,Paul Davis,71
-Wabaunsee,Wabaunsee Twp,Governor,,D,Paul Davis,81
-Wabaunsee,Washington Township,Governor,,D,Paul Davis,12
-Wabaunsee,Wilmington twp Eskridge,Governor,,D,Paul Davis,77
-Wabaunsee,Alma Township,Governor,,LBT,Keen Umbehr,147
-Wabaunsee,Chalk Township,Governor,,LBT,Keen Umbehr,3
-Wabaunsee,Farmer twp Alta Vista,Governor,,LBT,Keen Umbehr,17
-Wabaunsee,Garfield Township,Governor,,LBT,Keen Umbehr,38
-Wabaunsee,Harveyville Township,Governor,,LBT,Keen Umbehr,38
-Wabaunsee,Hessdale Township,Governor,,LBT,Keen Umbehr,13
-Wabaunsee,Kaw Township,Governor,,LBT,Keen Umbehr,14
-Wabaunsee,Keene Township,Governor,,LBT,Keen Umbehr,22
-Wabaunsee,Maple Hill Township,Governor,,LBT,Keen Umbehr,49
-Wabaunsee,McFarland Township,Governor,,LBT,Keen Umbehr,36
-Wabaunsee,Paxico Township,Governor,,LBT,Keen Umbehr,68
-Wabaunsee,Wabaunsee Twp,Governor,,LBT,Keen Umbehr,24
-Wabaunsee,Washington Township,Governor,,LBT,Keen Umbehr,8
-Wabaunsee,Wilmington twp Eskridge,Governor,,LBT,Keen Umbehr,38
-Wabaunsee,Alma Township,Secretary of State,,R,Kris Kobach,341
-Wabaunsee,Chalk Township,Secretary of State,,R,Kris Kobach,13
-Wabaunsee,Farmer twp Alta Vista,Secretary of State,,R,Kris Kobach,44
-Wabaunsee,Garfield Township,Secretary of State,,R,Kris Kobach,158
-Wabaunsee,Harveyville Township,Secretary of State,,R,Kris Kobach,160
-Wabaunsee,Hessdale Township,Secretary of State,,R,Kris Kobach,67
-Wabaunsee,Kaw Township,Secretary of State,,R,Kris Kobach,92
-Wabaunsee,Keene Township,Secretary of State,,R,Kris Kobach,149
-Wabaunsee,Maple Hill Township,Secretary of State,,R,Kris Kobach,333
-Wabaunsee,McFarland Township,Secretary of State,,R,Kris Kobach,81
-Wabaunsee,Paxico Township,Secretary of State,,R,Kris Kobach,256
-Wabaunsee,Wabaunsee Twp,Secretary of State,,R,Kris Kobach,143
-Wabaunsee,Washington Township,Secretary of State,,R,Kris Kobach,29
-Wabaunsee,Wilmington twp Eskridge,Secretary of State,,R,Kris Kobach,135
-Wabaunsee,Alma Township,Secretary of State,,D,Jean Schodach,150
-Wabaunsee,Chalk Township,Secretary of State,,D,Jean Schodach,5
-Wabaunsee,Farmer twp Alta Vista,Secretary of State,,D,Jean Schodach,17
-Wabaunsee,Garfield Township,Secretary of State,,D,Jean Schodach,65
-Wabaunsee,Harveyville Township,Secretary of State,,D,Jean Schodach,74
-Wabaunsee,Hessdale Township,Secretary of State,,D,Jean Schodach,40
-Wabaunsee,Kaw Township,Secretary of State,,D,Jean Schodach,14
-Wabaunsee,Keene Township,Secretary of State,,D,Jean Schodach,73
-Wabaunsee,Maple Hill Township,Secretary of State,,D,Jean Schodach,117
-Wabaunsee,McFarland Township,Secretary of State,,D,Jean Schodach,31
-Wabaunsee,Paxico Township,Secretary of State,,D,Jean Schodach,88
-Wabaunsee,Wabaunsee Twp,Secretary of State,,D,Jean Schodach,76
-Wabaunsee,Washington Township,Secretary of State,,D,Jean Schodach,17
-Wabaunsee,Wilmington twp Eskridge,Secretary of State,,D,Jean Schodach,68
-Wabaunsee,Alma Township,Attorney General,,R,Derek Schmidt,366
-Wabaunsee,Chalk Township,Attorney General,,R,Derek Schmidt,16
-Wabaunsee,Farmer twp Alta Vista,Attorney General,,R,Derek Schmidt,44
-Wabaunsee,Garfield Township,Attorney General,,R,Derek Schmidt,175
-Wabaunsee,Harveyville Township,Attorney General,,R,Derek Schmidt,174
-Wabaunsee,Hessdale Township,Attorney General,,R,Derek Schmidt,77
-Wabaunsee,Kaw Township,Attorney General,,R,Derek Schmidt,92
-Wabaunsee,Keene Township,Attorney General,,R,Derek Schmidt,153
-Wabaunsee,Maple Hill Township,Attorney General,,R,Derek Schmidt,360
-Wabaunsee,McFarland Township,Attorney General,,R,Derek Schmidt,88
-Wabaunsee,Paxico Township,Attorney General,,R,Derek Schmidt,278
-Wabaunsee,Wabaunsee Twp,Attorney General,,R,Derek Schmidt,158
-Wabaunsee,Washington Township,Attorney General,,R,Derek Schmidt,34
-Wabaunsee,Wilmington twp Eskridge,Attorney General,,R,Derek Schmidt,149
-Wabaunsee,Alma Township,Attorney General,,D,A.J. Kotich,121
-Wabaunsee,Chalk Township,Attorney General,,D,A.J. Kotich,1
-Wabaunsee,Farmer twp Alta Vista,Attorney General,,D,A.J. Kotich,17
-Wabaunsee,Garfield Township,Attorney General,,D,A.J. Kotich,47
-Wabaunsee,Harveyville Township,Attorney General,,D,A.J. Kotich,58
-Wabaunsee,Hessdale Township,Attorney General,,D,A.J. Kotich,31
-Wabaunsee,Kaw Township,Attorney General,,D,A.J. Kotich,12
-Wabaunsee,Keene Township,Attorney General,,D,A.J. Kotich,72
-Wabaunsee,Maple Hill Township,Attorney General,,D,A.J. Kotich,84
-Wabaunsee,McFarland Township,Attorney General,,D,A.J. Kotich,22
-Wabaunsee,Paxico Township,Attorney General,,D,A.J. Kotich,62
-Wabaunsee,Wabaunsee Twp,Attorney General,,D,A.J. Kotich,59
-Wabaunsee,Washington Township,Attorney General,,D,A.J. Kotich,11
-Wabaunsee,Wilmington twp Eskridge,Attorney General,,D,A.J. Kotich,48
-Wabaunsee,Alma Township,State Treasurer,,R,Ron Estes,363
-Wabaunsee,Chalk Township,State Treasurer,,R,Ron Estes,12
-Wabaunsee,Farmer twp Alta Vista,State Treasurer,,R,Ron Estes,46
-Wabaunsee,Garfield Township,State Treasurer,,R,Ron Estes,169
-Wabaunsee,Harveyville Township,State Treasurer,,R,Ron Estes,161
-Wabaunsee,Hessdale Township,State Treasurer,,R,Ron Estes,79
-Wabaunsee,Kaw Township,State Treasurer,,R,Ron Estes,93
-Wabaunsee,Keene Township,State Treasurer,,R,Ron Estes,150
-Wabaunsee,Maple Hill Township,State Treasurer,,R,Ron Estes,346
-Wabaunsee,McFarland Township,State Treasurer,,R,Ron Estes,87
-Wabaunsee,Paxico Township,State Treasurer,,R,Ron Estes,276
-Wabaunsee,Wabaunsee Twp,State Treasurer,,R,Ron Estes,158
-Wabaunsee,Washington Township,State Treasurer,,R,Ron Estes,34
-Wabaunsee,Wilmington twp Eskridge,State Treasurer,,R,Ron Estes,133
-Wabaunsee,Alma Township,State Treasurer,,D,Carmen Alldritt,117
-Wabaunsee,Chalk Township,State Treasurer,,D,Carmen Alldritt,2
-Wabaunsee,Farmer twp Alta Vista,State Treasurer,,D,Carmen Alldritt,12
-Wabaunsee,Garfield Township,State Treasurer,,D,Carmen Alldritt,42
-Wabaunsee,Harveyville Township,State Treasurer,,D,Carmen Alldritt,69
-Wabaunsee,Hessdale Township,State Treasurer,,D,Carmen Alldritt,27
-Wabaunsee,Kaw Township,State Treasurer,,D,Carmen Alldritt,12
-Wabaunsee,Keene Township,State Treasurer,,D,Carmen Alldritt,68
-Wabaunsee,Maple Hill Township,State Treasurer,,D,Carmen Alldritt,94
-Wabaunsee,McFarland Township,State Treasurer,,D,Carmen Alldritt,25
-Wabaunsee,Paxico Township,State Treasurer,,D,Carmen Alldritt,64
-Wabaunsee,Wabaunsee Twp,State Treasurer,,D,Carmen Alldritt,60
-Wabaunsee,Washington Township,State Treasurer,,D,Carmen Alldritt,11
-Wabaunsee,Wilmington twp Eskridge,State Treasurer,,D,Carmen Alldritt,65
-Wabaunsee,Alma Township,Insurance Commissioner,,R,Ken Selzer,331
-Wabaunsee,Chalk Township,Insurance Commissioner,,R,Ken Selzer,12
-Wabaunsee,Farmer twp Alta Vista,Insurance Commissioner,,R,Ken Selzer,38
-Wabaunsee,Garfield Township,Insurance Commissioner,,R,Ken Selzer,156
-Wabaunsee,Harveyville Township,Insurance Commissioner,,R,Ken Selzer,141
-Wabaunsee,Hessdale Township,Insurance Commissioner,,R,Ken Selzer,70
-Wabaunsee,Kaw Township,Insurance Commissioner,,R,Ken Selzer,94
-Wabaunsee,Keene Township,Insurance Commissioner,,R,Ken Selzer,139
-Wabaunsee,Maple Hill Township,Insurance Commissioner,,R,Ken Selzer,327
-Wabaunsee,McFarland Township,Insurance Commissioner,,R,Ken Selzer,72
-Wabaunsee,Paxico Township,Insurance Commissioner,,R,Ken Selzer,263
-Wabaunsee,Wabaunsee Twp,Insurance Commissioner,,R,Ken Selzer,152
-Wabaunsee,Washington Township,Insurance Commissioner,,R,Ken Selzer,34
-Wabaunsee,Wilmington twp Eskridge,Insurance Commissioner,,R,Ken Selzer,131
-Wabaunsee,Alma Township,Insurance Commissioner,,D,Dennis Anderson,148
-Wabaunsee,Chalk Township,Insurance Commissioner,,D,Dennis Anderson,2
-Wabaunsee,Farmer twp Alta Vista,Insurance Commissioner,,D,Dennis Anderson,18
-Wabaunsee,Garfield Township,Insurance Commissioner,,D,Dennis Anderson,59
-Wabaunsee,Harveyville Township,Insurance Commissioner,,D,Dennis Anderson,88
-Wabaunsee,Hessdale Township,Insurance Commissioner,,D,Dennis Anderson,33
-Wabaunsee,Kaw Township,Insurance Commissioner,,D,Dennis Anderson,11
-Wabaunsee,Keene Township,Insurance Commissioner,,D,Dennis Anderson,73
-Wabaunsee,Maple Hill Township,Insurance Commissioner,,D,Dennis Anderson,114
-Wabaunsee,McFarland Township,Insurance Commissioner,,D,Dennis Anderson,38
-Wabaunsee,Paxico Township,Insurance Commissioner,,D,Dennis Anderson,70
-Wabaunsee,Wabaunsee Twp,Insurance Commissioner,,D,Dennis Anderson,64
-Wabaunsee,Washington Township,Insurance Commissioner,,D,Dennis Anderson,11
-Wabaunsee,Wilmington twp Eskridge,Insurance Commissioner,,D,Dennis Anderson,67
-Wabaunsee,Alma Township,State House,51,R,Ron Highland,404
-Wabaunsee,Chalk Township,State House,51,R,Ron Highland,11
-Wabaunsee,Farmer twp Alta Vista,State House,51,R,Ron Highland,50
-Wabaunsee,Garfield Township,State House,51,R,Ron Highland,188
-Wabaunsee,Harveyville Township,State House,51,R,Ron Highland,207
-Wabaunsee,Hessdale Township,State House,51,R,Ron Highland,84
-Wabaunsee,Kaw Township,State House,51,R,Ron Highland,98
-Wabaunsee,Keene Township,State House,51,R,Ron Highland,181
-Wabaunsee,Maple Hill Township,State House,51,R,Ron Highland,379
-Wabaunsee,McFarland Township,State House,51,R,Ron Highland,101
-Wabaunsee,Paxico Township,State House,51,R,Ron Highland,294
-Wabaunsee,Wabaunsee Twp,State House,51,R,Ron Highland,190
-Wabaunsee,Washington Township,State House,51,R,Ron Highland,35
-Wabaunsee,Wilmington twp Eskridge,State House,51,R,Ron Highland,171
-Wabaunsee,Alma Township,State House,51,,Write-ins,9
-Wabaunsee,Chalk Township,State House,51,,Write-ins,2
-Wabaunsee,Farmer twp Alta Vista,State House,51,,Write-ins,0
-Wabaunsee,Garfield Township,State House,51,,Write-ins,2
-Wabaunsee,Harveyville Township,State House,51,,Write-ins,0
-Wabaunsee,Hessdale Township,State House,51,,Write-ins,4
-Wabaunsee,Kaw Township,State House,51,,Write-ins,0
-Wabaunsee,Keene Township,State House,51,,Write-ins,1
-Wabaunsee,Maple Hill Township,State House,51,,Write-ins,10
-Wabaunsee,McFarland Township,State House,51,,Write-ins,0
-Wabaunsee,Paxico Township,State House,51,,Write-ins,8
-Wabaunsee,Wabaunsee Twp,State House,51,,Write-ins,6
-Wabaunsee,Washington Township,State House,51,,Write-ins,1
-Wabaunsee,Wilmington twp Eskridge,State House,51,,Write-ins,2
-Wabaunsee,Paxico Township,U.S. Senate,,,Write-ins,1
-Wabaunsee,Wabaunsee Twp,U.S. Senate,,,Write-ins,2
-Wabaunsee,Alma,U.S. House,1,,Write-ins,1
-Wabaunsee,Paxico Township,U.S. House ,1,,Write-ins,2
-Wabaunsee,Wabaunsee Twp,U.S. House,1,,Write-ins,2
-Wabaunsee,McFarland,Governor,,,Write-ins,1
-Wabaunsee,Wabaunsee Twp,Governor,,,Write-ins,1
-Wabaunsee,Wabaunsee Twp,Secretary of State,,,Write-ins,2
-Wabaunsee,Alma,Attorney General,,,Write-ins,1
-Wabaunsee,Paxico Township,Attorney General,,,Write-ins,1
-Wabaunsee,Wabaunsee Twp,Attorney General,,,Write-ins,2
-Wabaunsee,Wabaunsee Twp,State Treasurer,,,Write-ins,1
-Wabaunsee,Keene,Insurance Commissioner,,,Write-ins,1
-Wabaunsee,Paxico Township,Insurance Commissioner,,,Write-ins,2
-Wabaunsee,Wabaunsee Twp,Insurance Commissioner,,,Write-ins,1
+county,precinct,office,district,party,candidate,votes,vtd
+WABAUNSEE,Alma Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",154,000010
+WABAUNSEE,Alma Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",147,000010
+WABAUNSEE,Alma Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",195,000010
+WABAUNSEE,Chalk Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",3,000020
+WABAUNSEE,Chalk Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000020
+WABAUNSEE,Chalk Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000020
+WABAUNSEE,Farmer Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000030
+WABAUNSEE,Farmer Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",17,000030
+WABAUNSEE,Farmer Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",29,000030
+WABAUNSEE,Garfield Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,000040
+WABAUNSEE,Garfield Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",38,000040
+WABAUNSEE,Garfield Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",117,000040
+WABAUNSEE,Harveyville Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",102,000050
+WABAUNSEE,Harveyville Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",38,000050
+WABAUNSEE,Harveyville Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",101,000050
+WABAUNSEE,Hessdale Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000060
+WABAUNSEE,Hessdale Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000060
+WABAUNSEE,Hessdale Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",54,000060
+WABAUNSEE,Kaw Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,000070
+WABAUNSEE,Kaw Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000070
+WABAUNSEE,Kaw Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",75,000070
+WABAUNSEE,Keene Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",90,000080
+WABAUNSEE,Keene Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,000080
+WABAUNSEE,Keene Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,000080
+WABAUNSEE,Maple Hill Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",149,000090
+WABAUNSEE,Maple Hill Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",49,000090
+WABAUNSEE,Maple Hill Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",258,000090
+WABAUNSEE,McFarland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000100
+WABAUNSEE,McFarland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",36,000100
+WABAUNSEE,McFarland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",50,000100
+WABAUNSEE,Paxico Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,000110
+WABAUNSEE,Paxico Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",68,000110
+WABAUNSEE,Paxico Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",205,000110
+WABAUNSEE,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000130
+WABAUNSEE,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",8,000130
+WABAUNSEE,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",26,000130
+WABAUNSEE,Wilmington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",77,000140
+WABAUNSEE,Wilmington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",38,000140
+WABAUNSEE,Wilmington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",92,000140
+WABAUNSEE,Wabaunsee Township S17,Governor / Lt. Governor,,Democratic,"Davis, Paul",76,120020
+WABAUNSEE,Wabaunsee Township S17,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",22,120020
+WABAUNSEE,Wabaunsee Township S17,Governor / Lt. Governor,,Republican,"Brownback, Sam",111,120020
+WABAUNSEE,Wabaunsee Township S18,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,120030
+WABAUNSEE,Wabaunsee Township S18,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,120030
+WABAUNSEE,Wabaunsee Township S18,Governor / Lt. Governor,,Republican,"Brownback, Sam",5,120030
+WABAUNSEE,Alma Township,Kansas House of Representatives,51,Republican,"Highland, Ron",404,000010
+WABAUNSEE,Chalk Township,Kansas House of Representatives,51,Republican,"Highland, Ron",11,000020
+WABAUNSEE,Farmer Township,Kansas House of Representatives,51,Republican,"Highland, Ron",50,000030
+WABAUNSEE,Garfield Township,Kansas House of Representatives,51,Republican,"Highland, Ron",188,000040
+WABAUNSEE,Harveyville Township,Kansas House of Representatives,51,Republican,"Highland, Ron",207,000050
+WABAUNSEE,Hessdale Township,Kansas House of Representatives,51,Republican,"Highland, Ron",84,000060
+WABAUNSEE,Kaw Township,Kansas House of Representatives,51,Republican,"Highland, Ron",98,000070
+WABAUNSEE,Keene Township,Kansas House of Representatives,51,Republican,"Highland, Ron",181,000080
+WABAUNSEE,Maple Hill Township,Kansas House of Representatives,51,Republican,"Highland, Ron",379,000090
+WABAUNSEE,McFarland Township,Kansas House of Representatives,51,Republican,"Highland, Ron",101,000100
+WABAUNSEE,Paxico Township,Kansas House of Representatives,51,Republican,"Highland, Ron",294,000110
+WABAUNSEE,Washington Township,Kansas House of Representatives,51,Republican,"Highland, Ron",35,000130
+WABAUNSEE,Wilmington Township,Kansas House of Representatives,51,Republican,"Highland, Ron",171,000140
+WABAUNSEE,Wabaunsee Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",180,120020
+WABAUNSEE,Wabaunsee Township S18,Kansas House of Representatives,51,Republican,"Highland, Ron",10,120030
+WABAUNSEE,Alma Township,United States House of Representatives,1,Democratic,"Sherow, James E.",167,000010
+WABAUNSEE,Alma Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",321,000010
+WABAUNSEE,Chalk Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000020
+WABAUNSEE,Chalk Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000020
+WABAUNSEE,Farmer Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000030
+WABAUNSEE,Farmer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000030
+WABAUNSEE,Garfield Township,United States House of Representatives,1,Democratic,"Sherow, James E.",80,000040
+WABAUNSEE,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",141,000040
+WABAUNSEE,Harveyville Township,United States House of Representatives,1,Democratic,"Sherow, James E.",73,000050
+WABAUNSEE,Harveyville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",162,000050
+WABAUNSEE,Hessdale Township,United States House of Representatives,1,Democratic,"Sherow, James E.",40,000060
+WABAUNSEE,Hessdale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,000060
+WABAUNSEE,Kaw Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000070
+WABAUNSEE,Kaw Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",88,000070
+WABAUNSEE,Keene Township,United States House of Representatives,1,Democratic,"Sherow, James E.",78,000080
+WABAUNSEE,Keene Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",144,000080
+WABAUNSEE,Maple Hill Township,United States House of Representatives,1,Democratic,"Sherow, James E.",125,000090
+WABAUNSEE,Maple Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",320,000090
+WABAUNSEE,McFarland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",29,000100
+WABAUNSEE,McFarland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,000100
+WABAUNSEE,Paxico Township,United States House of Representatives,1,Democratic,"Sherow, James E.",86,000110
+WABAUNSEE,Paxico Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",255,000110
+WABAUNSEE,Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000130
+WABAUNSEE,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000130
+WABAUNSEE,Wilmington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",69,000140
+WABAUNSEE,Wilmington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",132,000140
+WABAUNSEE,Wabaunsee Township S17,United States House of Representatives,1,Democratic,"Sherow, James E.",77,120020
+WABAUNSEE,Wabaunsee Township S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,120020
+WABAUNSEE,Wabaunsee Township S18,United States House of Representatives,1,Democratic,"Sherow, James E.",3,120030
+WABAUNSEE,Wabaunsee Township S18,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,120030
+WABAUNSEE,Alma Township,Attorney General,,Democratic,"Kotich, A.J.",121,000010
+WABAUNSEE,Alma Township,Attorney General,,Republican,"Schmidt, Derek",366,000010
+WABAUNSEE,Chalk Township,Attorney General,,Democratic,"Kotich, A.J.",1,000020
+WABAUNSEE,Chalk Township,Attorney General,,Republican,"Schmidt, Derek",16,000020
+WABAUNSEE,Farmer Township,Attorney General,,Democratic,"Kotich, A.J.",17,000030
+WABAUNSEE,Farmer Township,Attorney General,,Republican,"Schmidt, Derek",44,000030
+WABAUNSEE,Garfield Township,Attorney General,,Democratic,"Kotich, A.J.",47,000040
+WABAUNSEE,Garfield Township,Attorney General,,Republican,"Schmidt, Derek",175,000040
+WABAUNSEE,Harveyville Township,Attorney General,,Democratic,"Kotich, A.J.",58,000050
+WABAUNSEE,Harveyville Township,Attorney General,,Republican,"Schmidt, Derek",174,000050
+WABAUNSEE,Hessdale Township,Attorney General,,Democratic,"Kotich, A.J.",31,000060
+WABAUNSEE,Hessdale Township,Attorney General,,Republican,"Schmidt, Derek",77,000060
+WABAUNSEE,Kaw Township,Attorney General,,Democratic,"Kotich, A.J.",12,000070
+WABAUNSEE,Kaw Township,Attorney General,,Republican,"Schmidt, Derek",92,000070
+WABAUNSEE,Keene Township,Attorney General,,Democratic,"Kotich, A.J.",72,000080
+WABAUNSEE,Keene Township,Attorney General,,Republican,"Schmidt, Derek",153,000080
+WABAUNSEE,Maple Hill Township,Attorney General,,Democratic,"Kotich, A.J.",84,000090
+WABAUNSEE,Maple Hill Township,Attorney General,,Republican,"Schmidt, Derek",360,000090
+WABAUNSEE,McFarland Township,Attorney General,,Democratic,"Kotich, A.J.",22,000100
+WABAUNSEE,McFarland Township,Attorney General,,Republican,"Schmidt, Derek",88,000100
+WABAUNSEE,Paxico Township,Attorney General,,Democratic,"Kotich, A.J.",62,000110
+WABAUNSEE,Paxico Township,Attorney General,,Republican,"Schmidt, Derek",278,000110
+WABAUNSEE,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",11,000130
+WABAUNSEE,Washington Township,Attorney General,,Republican,"Schmidt, Derek",34,000130
+WABAUNSEE,Wilmington Township,Attorney General,,Democratic,"Kotich, A.J.",48,000140
+WABAUNSEE,Wilmington Township,Attorney General,,Republican,"Schmidt, Derek",149,000140
+WABAUNSEE,Wabaunsee Township S17,Attorney General,,Democratic,"Kotich, A.J.",56,120020
+WABAUNSEE,Wabaunsee Township S17,Attorney General,,Republican,"Schmidt, Derek",153,120020
+WABAUNSEE,Wabaunsee Township S18,Attorney General,,Democratic,"Kotich, A.J.",3,120030
+WABAUNSEE,Wabaunsee Township S18,Attorney General,,Republican,"Schmidt, Derek",5,120030
+WABAUNSEE,Alma Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",148,000010
+WABAUNSEE,Alma Township,Commissioner of Insurance,,Republican,"Selzer, Ken",331,000010
+WABAUNSEE,Chalk Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000020
+WABAUNSEE,Chalk Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000020
+WABAUNSEE,Farmer Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000030
+WABAUNSEE,Farmer Township,Commissioner of Insurance,,Republican,"Selzer, Ken",38,000030
+WABAUNSEE,Garfield Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",59,000040
+WABAUNSEE,Garfield Township,Commissioner of Insurance,,Republican,"Selzer, Ken",156,000040
+WABAUNSEE,Harveyville Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",88,000050
+WABAUNSEE,Harveyville Township,Commissioner of Insurance,,Republican,"Selzer, Ken",141,000050
+WABAUNSEE,Hessdale Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000060
+WABAUNSEE,Hessdale Township,Commissioner of Insurance,,Republican,"Selzer, Ken",70,000060
+WABAUNSEE,Kaw Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000070
+WABAUNSEE,Kaw Township,Commissioner of Insurance,,Republican,"Selzer, Ken",94,000070
+WABAUNSEE,Keene Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",73,000080
+WABAUNSEE,Keene Township,Commissioner of Insurance,,Republican,"Selzer, Ken",139,000080
+WABAUNSEE,Maple Hill Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",114,000090
+WABAUNSEE,Maple Hill Township,Commissioner of Insurance,,Republican,"Selzer, Ken",327,000090
+WABAUNSEE,McFarland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000100
+WABAUNSEE,McFarland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",72,000100
+WABAUNSEE,Paxico Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",70,000110
+WABAUNSEE,Paxico Township,Commissioner of Insurance,,Republican,"Selzer, Ken",263,000110
+WABAUNSEE,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",11,000130
+WABAUNSEE,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",34,000130
+WABAUNSEE,Wilmington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,000140
+WABAUNSEE,Wilmington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",131,000140
+WABAUNSEE,Wabaunsee Township S17,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,120020
+WABAUNSEE,Wabaunsee Township S17,Commissioner of Insurance,,Republican,"Selzer, Ken",147,120020
+WABAUNSEE,Wabaunsee Township S18,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,120030
+WABAUNSEE,Wabaunsee Township S18,Commissioner of Insurance,,Republican,"Selzer, Ken",5,120030
+WABAUNSEE,Alma Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",150,000010
+WABAUNSEE,Alma Township,Secretary of State,,Republican,"Kobach, Kris",341,000010
+WABAUNSEE,Chalk Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000020
+WABAUNSEE,Chalk Township,Secretary of State,,Republican,"Kobach, Kris",13,000020
+WABAUNSEE,Farmer Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000030
+WABAUNSEE,Farmer Township,Secretary of State,,Republican,"Kobach, Kris",44,000030
+WABAUNSEE,Garfield Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",65,000040
+WABAUNSEE,Garfield Township,Secretary of State,,Republican,"Kobach, Kris",158,000040
+WABAUNSEE,Harveyville Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",74,000050
+WABAUNSEE,Harveyville Township,Secretary of State,,Republican,"Kobach, Kris",160,000050
+WABAUNSEE,Hessdale Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000060
+WABAUNSEE,Hessdale Township,Secretary of State,,Republican,"Kobach, Kris",67,000060
+WABAUNSEE,Kaw Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000070
+WABAUNSEE,Kaw Township,Secretary of State,,Republican,"Kobach, Kris",92,000070
+WABAUNSEE,Keene Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",73,000080
+WABAUNSEE,Keene Township,Secretary of State,,Republican,"Kobach, Kris",149,000080
+WABAUNSEE,Maple Hill Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",117,000090
+WABAUNSEE,Maple Hill Township,Secretary of State,,Republican,"Kobach, Kris",333,000090
+WABAUNSEE,McFarland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",31,000100
+WABAUNSEE,McFarland Township,Secretary of State,,Republican,"Kobach, Kris",81,000100
+WABAUNSEE,Paxico Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",88,000110
+WABAUNSEE,Paxico Township,Secretary of State,,Republican,"Kobach, Kris",256,000110
+WABAUNSEE,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000130
+WABAUNSEE,Washington Township,Secretary of State,,Republican,"Kobach, Kris",29,000130
+WABAUNSEE,Wilmington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000140
+WABAUNSEE,Wilmington Township,Secretary of State,,Republican,"Kobach, Kris",135,000140
+WABAUNSEE,Wabaunsee Township S17,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",71,120020
+WABAUNSEE,Wabaunsee Township S17,Secretary of State,,Republican,"Kobach, Kris",140,120020
+WABAUNSEE,Wabaunsee Township S18,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,120030
+WABAUNSEE,Wabaunsee Township S18,Secretary of State,,Republican,"Kobach, Kris",3,120030
+WABAUNSEE,Alma Township,State Treasurer,,Democratic,"Alldritt, Carmen",117,000010
+WABAUNSEE,Alma Township,State Treasurer,,Republican,"Estes, Ron",363,000010
+WABAUNSEE,Chalk Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000020
+WABAUNSEE,Chalk Township,State Treasurer,,Republican,"Estes, Ron",12,000020
+WABAUNSEE,Farmer Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000030
+WABAUNSEE,Farmer Township,State Treasurer,,Republican,"Estes, Ron",46,000030
+WABAUNSEE,Garfield Township,State Treasurer,,Democratic,"Alldritt, Carmen",42,000040
+WABAUNSEE,Garfield Township,State Treasurer,,Republican,"Estes, Ron",169,000040
+WABAUNSEE,Harveyville Township,State Treasurer,,Democratic,"Alldritt, Carmen",69,000050
+WABAUNSEE,Harveyville Township,State Treasurer,,Republican,"Estes, Ron",161,000050
+WABAUNSEE,Hessdale Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000060
+WABAUNSEE,Hessdale Township,State Treasurer,,Republican,"Estes, Ron",79,000060
+WABAUNSEE,Kaw Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000070
+WABAUNSEE,Kaw Township,State Treasurer,,Republican,"Estes, Ron",93,000070
+WABAUNSEE,Keene Township,State Treasurer,,Democratic,"Alldritt, Carmen",68,000080
+WABAUNSEE,Keene Township,State Treasurer,,Republican,"Estes, Ron",150,000080
+WABAUNSEE,Maple Hill Township,State Treasurer,,Democratic,"Alldritt, Carmen",94,000090
+WABAUNSEE,Maple Hill Township,State Treasurer,,Republican,"Estes, Ron",346,000090
+WABAUNSEE,McFarland Township,State Treasurer,,Democratic,"Alldritt, Carmen",25,000100
+WABAUNSEE,McFarland Township,State Treasurer,,Republican,"Estes, Ron",87,000100
+WABAUNSEE,Paxico Township,State Treasurer,,Democratic,"Alldritt, Carmen",64,000110
+WABAUNSEE,Paxico Township,State Treasurer,,Republican,"Estes, Ron",276,000110
+WABAUNSEE,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000130
+WABAUNSEE,Washington Township,State Treasurer,,Republican,"Estes, Ron",34,000130
+WABAUNSEE,Wilmington Township,State Treasurer,,Democratic,"Alldritt, Carmen",65,000140
+WABAUNSEE,Wilmington Township,State Treasurer,,Republican,"Estes, Ron",133,000140
+WABAUNSEE,Wabaunsee Township S17,State Treasurer,,Democratic,"Alldritt, Carmen",57,120020
+WABAUNSEE,Wabaunsee Township S17,State Treasurer,,Republican,"Estes, Ron",153,120020
+WABAUNSEE,Wabaunsee Township S18,State Treasurer,,Democratic,"Alldritt, Carmen",3,120030
+WABAUNSEE,Wabaunsee Township S18,State Treasurer,,Republican,"Estes, Ron",5,120030
+WABAUNSEE,Alma Township,United States Senate,,independent,"Orman, Greg",171,000010
+WABAUNSEE,Alma Township,United States Senate,,Libertarian,"Batson, Randall",37,000010
+WABAUNSEE,Alma Township,United States Senate,,Republican,"Roberts, Pat",287,000010
+WABAUNSEE,Chalk Township,United States Senate,,independent,"Orman, Greg",4,000020
+WABAUNSEE,Chalk Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+WABAUNSEE,Chalk Township,United States Senate,,Republican,"Roberts, Pat",13,000020
+WABAUNSEE,Farmer Township,United States Senate,,independent,"Orman, Greg",14,000030
+WABAUNSEE,Farmer Township,United States Senate,,Libertarian,"Batson, Randall",4,000030
+WABAUNSEE,Farmer Township,United States Senate,,Republican,"Roberts, Pat",42,000030
+WABAUNSEE,Garfield Township,United States Senate,,independent,"Orman, Greg",67,000040
+WABAUNSEE,Garfield Township,United States Senate,,Libertarian,"Batson, Randall",20,000040
+WABAUNSEE,Garfield Township,United States Senate,,Republican,"Roberts, Pat",139,000040
+WABAUNSEE,Harveyville Township,United States Senate,,independent,"Orman, Greg",99,000050
+WABAUNSEE,Harveyville Township,United States Senate,,Libertarian,"Batson, Randall",15,000050
+WABAUNSEE,Harveyville Township,United States Senate,,Republican,"Roberts, Pat",128,000050
+WABAUNSEE,Hessdale Township,United States Senate,,independent,"Orman, Greg",44,000060
+WABAUNSEE,Hessdale Township,United States Senate,,Libertarian,"Batson, Randall",2,000060
+WABAUNSEE,Hessdale Township,United States Senate,,Republican,"Roberts, Pat",63,000060
+WABAUNSEE,Kaw Township,United States Senate,,independent,"Orman, Greg",18,000070
+WABAUNSEE,Kaw Township,United States Senate,,Libertarian,"Batson, Randall",5,000070
+WABAUNSEE,Kaw Township,United States Senate,,Republican,"Roberts, Pat",83,000070
+WABAUNSEE,Keene Township,United States Senate,,independent,"Orman, Greg",86,000080
+WABAUNSEE,Keene Township,United States Senate,,Libertarian,"Batson, Randall",10,000080
+WABAUNSEE,Keene Township,United States Senate,,Republican,"Roberts, Pat",131,000080
+WABAUNSEE,Maple Hill Township,United States Senate,,independent,"Orman, Greg",132,000090
+WABAUNSEE,Maple Hill Township,United States Senate,,Libertarian,"Batson, Randall",20,000090
+WABAUNSEE,Maple Hill Township,United States Senate,,Republican,"Roberts, Pat",303,000090
+WABAUNSEE,McFarland Township,United States Senate,,independent,"Orman, Greg",39,000100
+WABAUNSEE,McFarland Township,United States Senate,,Libertarian,"Batson, Randall",6,000100
+WABAUNSEE,McFarland Township,United States Senate,,Republican,"Roberts, Pat",68,000100
+WABAUNSEE,Paxico Township,United States Senate,,independent,"Orman, Greg",75,000110
+WABAUNSEE,Paxico Township,United States Senate,,Libertarian,"Batson, Randall",28,000110
+WABAUNSEE,Paxico Township,United States Senate,,Republican,"Roberts, Pat",238,000110
+WABAUNSEE,Washington Township,United States Senate,,independent,"Orman, Greg",15,000130
+WABAUNSEE,Washington Township,United States Senate,,Libertarian,"Batson, Randall",3,000130
+WABAUNSEE,Washington Township,United States Senate,,Republican,"Roberts, Pat",28,000130
+WABAUNSEE,Wilmington Township,United States Senate,,independent,"Orman, Greg",78,000140
+WABAUNSEE,Wilmington Township,United States Senate,,Libertarian,"Batson, Randall",14,000140
+WABAUNSEE,Wilmington Township,United States Senate,,Republican,"Roberts, Pat",113,000140
+WABAUNSEE,Wabaunsee Township S17,United States Senate,,independent,"Orman, Greg",75,120020
+WABAUNSEE,Wabaunsee Township S17,United States Senate,,Libertarian,"Batson, Randall",5,120020
+WABAUNSEE,Wabaunsee Township S17,United States Senate,,Republican,"Roberts, Pat",130,120020
+WABAUNSEE,Wabaunsee Township S18,United States Senate,,independent,"Orman, Greg",5,120030
+WABAUNSEE,Wabaunsee Township S18,United States Senate,,Libertarian,"Batson, Randall",3,120030
+WABAUNSEE,Wabaunsee Township S18,United States Senate,,Republican,"Roberts, Pat",3,120030

--- a/2014/20141104__ks__general__wallace__precinct.csv
+++ b/2014/20141104__ks__general__wallace__precinct.csv
@@ -1,154 +1,86 @@
-county,precinct,office,district,party,candidate,votes
-Wallace,Harrison,Attorney General,,D,AJ Kotich,0
-Wallace,Sharon Sprs 1,Attorney General,,D,AJ Kotich,6
-Wallace,Sharon Sprs 2,Attorney General,,D,AJ Kotich,10
-Wallace,Sharon Sprs 3,Attorney General,,D,AJ Kotich,0
-Wallace,Sharon Sprs 4,Attorney General,,D,AJ Kotich,7
-Wallace,Wallace,Attorney General,,D,AJ Kotich,3
-Wallace,Weskan,Attorney General,,D,AJ Kotich,7
-Wallace,Advance,Attorney General,,D,AJ Kotich,14
-Wallace,Prov,Attorney General,,D,AJ Kotich,0
-Wallace,Harrison,Attorney General,,R,Derek Schmidt,23
-Wallace,Sharon Sprs 1,Attorney General,,R,Derek Schmidt,74
-Wallace,Sharon Sprs 2,Attorney General,,R,Derek Schmidt,126
-Wallace,Sharon Sprs 3,Attorney General,,R,Derek Schmidt,15
-Wallace,Sharon Sprs 4,Attorney General,,R,Derek Schmidt,52
-Wallace,Wallace,Attorney General,,R,Derek Schmidt,34
-Wallace,Weskan,Attorney General,,R,Derek Schmidt,90
-Wallace,Advance,Attorney General,,R,Derek Schmidt,137
-Wallace,Prov,Attorney General,,R,Derek Schmidt,15
-Wallace,Harrison,U.S. House,1,D,James E Sherow,0
-Wallace,Sharon Sprs 1,U.S. House,1,D,James E Sherow,10
-Wallace,Sharon Sprs 2,U.S. House,1,D,James E Sherow,15
-Wallace,Sharon Sprs 3,U.S. House,1,D,James E Sherow,0
-Wallace,Sharon Sprs 4,U.S. House,1,D,James E Sherow,6
-Wallace,Wallace,U.S. House,1,D,James E Sherow,3
-Wallace,Weskan,U.S. House,1,D,James E Sherow,12
-Wallace,Advance,U.S. House,1,D,James E Sherow,26
-Wallace,Prov,U.S. House,1,D,James E Sherow,0
-Wallace,Harrison,U.S. House,1,R,Tim Huelskamp,22
-Wallace,Sharon Sprs 1,U.S. House,1,R,Tim Huelskamp,72
-Wallace,Sharon Sprs 2,U.S. House,1,R,Tim Huelskamp,127
-Wallace,Sharon Sprs 3,U.S. House,1,R,Tim Huelskamp,16
-Wallace,Sharon Sprs 4,U.S. House,1,R,Tim Huelskamp,53
-Wallace,Wallace,U.S. House,1,R,Tim Huelskamp,34
-Wallace,Weskan,U.S. House,1,R,Tim Huelskamp,86
-Wallace,Advance,U.S. House,1,R,Tim Huelskamp,131
-Wallace,Prov,U.S. House,1,R,Tim Huelskamp,16
-Wallace,Harrison,Governor,,L,Keen Umbehr,1
-Wallace,Sharon Sprs 1,Governor,,L,Keen Umbehr,8
-Wallace,Sharon Sprs 2,Governor,,L,Keen Umbehr,6
-Wallace,Sharon Sprs 3,Governor,,L,Keen Umbehr,0
-Wallace,Sharon Sprs 4,Governor,,L,Keen Umbehr,4
-Wallace,Wallace,Governor,,L,Keen Umbehr,1
-Wallace,Weskan,Governor,,L,Keen Umbehr,3
-Wallace,Advance,Governor,,L,Keen Umbehr,4
-Wallace,Prov,Governor,,L,Keen Umbehr,0
-Wallace,Harrison,Governor,,D,Paul Davis,0
-Wallace,Sharon Sprs 1,Governor,,D,Paul Davis,13
-Wallace,Sharon Sprs 2,Governor,,D,Paul Davis,21
-Wallace,Sharon Sprs 3,Governor,,D,Paul Davis,3
-Wallace,Sharon Sprs 4,Governor,,D,Paul Davis,6
-Wallace,Wallace,Governor,,D,Paul Davis,5
-Wallace,Weskan,Governor,,D,Paul Davis,10
-Wallace,Advance,Governor,,D,Paul Davis,34
-Wallace,Prov,Governor,,D,Paul Davis,1
-Wallace,Harrison,Governor,,R,Sam Brownback,22
-Wallace,Sharon Sprs 1,Governor,,R,Sam Brownback,60
-Wallace,Sharon Sprs 2,Governor,,R,Sam Brownback,113
-Wallace,Sharon Sprs 3,Governor,,R,Sam Brownback,13
-Wallace,Sharon Sprs 4,Governor,,R,Sam Brownback,49
-Wallace,Wallace,Governor,,R,Sam Brownback,33
-Wallace,Weskan,Governor,,R,Sam Brownback,85
-Wallace,Advance,Governor,,R,Sam Brownback,120
-Wallace,Prov,Governor,,R,Sam Brownback,15
-Wallace,Harrison,Insurance Commissioner,,D,Dennis Anderson,0
-Wallace,Sharon Sprs 1,Insurance Commissioner,,D,Dennis Anderson,9
-Wallace,Sharon Sprs 2,Insurance Commissioner,,D,Dennis Anderson,12
-Wallace,Sharon Sprs 3,Insurance Commissioner,,D,Dennis Anderson,0
-Wallace,Sharon Sprs 4,Insurance Commissioner,,D,Dennis Anderson,5
-Wallace,Wallace,Insurance Commissioner,,D,Dennis Anderson,2
-Wallace,Weskan,Insurance Commissioner,,D,Dennis Anderson,7
-Wallace,Advance,Insurance Commissioner,,D,Dennis Anderson,22
-Wallace,Prov,Insurance Commissioner,,D,Dennis Anderson,0
-Wallace,Harrison,Insurance Commissioner,,R,Ken Selzer,23
-Wallace,Sharon Sprs 1,Insurance Commissioner,,R,Ken Selzer,67
-Wallace,Sharon Sprs 2,Insurance Commissioner,,R,Ken Selzer,121
-Wallace,Sharon Sprs 3,Insurance Commissioner,,R,Ken Selzer,15
-Wallace,Sharon Sprs 4,Insurance Commissioner,,R,Ken Selzer,52
-Wallace,Wallace,Insurance Commissioner,,R,Ken Selzer,34
-Wallace,Weskan,Insurance Commissioner,,R,Ken Selzer,89
-Wallace,Advance,Insurance Commissioner,,R,Ken Selzer,127
-Wallace,Prov,Insurance Commissioner,,R,Ken Selzer,15
-Wallace,Harrison,Secretary of State,,D,Jean Schodorf,0
-Wallace,Sharon Sprs 1,Secretary of State,,D,Jean Schodorf,10
-Wallace,Sharon Sprs 2,Secretary of State,,D,Jean Schodorf,15
-Wallace,Sharon Sprs 3,Secretary of State,,D,Jean Schodorf,0
-Wallace,Sharon Sprs 4,Secretary of State,,D,Jean Schodorf,4
-Wallace,Wallace,Secretary of State,,D,Jean Schodorf,4
-Wallace,Weskan,Secretary of State,,D,Jean Schodorf,9
-Wallace,Advance,Secretary of State,,D,Jean Schodorf,27
-Wallace,Prov,Secretary of State,,D,Jean Schodorf,0
-Wallace,Harrison,Secretary of State,,R,Kris Kobach,23
-Wallace,Sharon Sprs 1,Secretary of State,,R,Kris Kobach,70
-Wallace,Sharon Sprs 2,Secretary of State,,R,Kris Kobach,124
-Wallace,Sharon Sprs 3,Secretary of State,,R,Kris Kobach,15
-Wallace,Sharon Sprs 4,Secretary of State,,R,Kris Kobach,55
-Wallace,Wallace,Secretary of State,,R,Kris Kobach,30
-Wallace,Weskan,Secretary of State,,R,Kris Kobach,88
-Wallace,Advance,Secretary of State,,R,Kris Kobach,121
-Wallace,Prov,Secretary of State,,R,Kris Kobach,16
-Wallace,Harrison,State House,120,R,Richard Billinger,23
-Wallace,Sharon Sprs 1,State House,120,R,Richard Billinger,72
-Wallace,Sharon Sprs 2,State House,120,R,Richard Billinger,130
-Wallace,Sharon Sprs 3,State House,120,R,Richard Billinger,15
-Wallace,Sharon Sprs 4,State House,120,R,Richard Billinger,58
-Wallace,Wallace,State House,120,R,Richard Billinger,32
-Wallace,Weskan,State House,120,R,Richard Billinger,90
-Wallace,Advance,State House,120,R,Richard Billinger,138
-Wallace,Prov,State House,120,R,Richard Billinger,15
-Wallace,Harrison,State Treasurer,,D,Carmen Alldritt,0
-Wallace,Sharon Sprs 1,State Treasurer,,D,Carmen Alldritt,7
-Wallace,Sharon Sprs 2,State Treasurer,,D,Carmen Alldritt,8
-Wallace,Sharon Sprs 3,State Treasurer,,D,Carmen Alldritt,0
-Wallace,Sharon Sprs 4,State Treasurer,,D,Carmen Alldritt,3
-Wallace,Wallace,State Treasurer,,D,Carmen Alldritt,5
-Wallace,Weskan,State Treasurer,,D,Carmen Alldritt,8
-Wallace,Advance,State Treasurer,,D,Carmen Alldritt,15
-Wallace,Prov,State Treasurer,,D,Carmen Alldritt,0
-Wallace,Harrison,State Treasurer,,R,Ron Estes,23
-Wallace,Sharon Sprs 1,State Treasurer,,R,Ron Estes,74
-Wallace,Sharon Sprs 2,State Treasurer,,R,Ron Estes,128
-Wallace,Sharon Sprs 3,State Treasurer,,R,Ron Estes,15
-Wallace,Sharon Sprs 4,State Treasurer,,R,Ron Estes,45
-Wallace,Wallace,State Treasurer,,R,Ron Estes,31
-Wallace,Weskan,State Treasurer,,R,Ron Estes,89
-Wallace,Advance,State Treasurer,,R,Ron Estes,135
-Wallace,Prov,State Treasurer,,R,Ron Estes,15
-Wallace,Harrison,United State Senate,,I,Greg Orman,0
-Wallace,Sharon Sprs 1,United State Senate,,I,Greg Orman,12
-Wallace,Sharon Sprs 2,United State Senate,,I,Greg Orman,10
-Wallace,Sharon Sprs 3,United State Senate,,I,Greg Orman,0
-Wallace,Sharon Sprs 4,United State Senate,,I,Greg Orman,3
-Wallace,Wallace,United State Senate,,I,Greg Orman,5
-Wallace,Weskan,United State Senate,,I,Greg Orman,8
-Wallace,Advance,United State Senate,,I,Greg Orman,29
-Wallace,Prov,United State Senate,,I,Greg Orman,1
-Wallace,Harrison,United State Senate,,R,Pat Roberts,23
-Wallace,Sharon Sprs 1,United State Senate,,R,Pat Roberts,64
-Wallace,Sharon Sprs 2,United State Senate,,R,Pat Roberts,128
-Wallace,Sharon Sprs 3,United State Senate,,R,Pat Roberts,15
-Wallace,Sharon Sprs 4,United State Senate,,R,Pat Roberts,52
-Wallace,Wallace,United State Senate,,R,Pat Roberts,33
-Wallace,Weskan,United State Senate,,R,Pat Roberts,88
-Wallace,Advance,United State Senate,,R,Pat Roberts,127
-Wallace,Prov,United State Senate,,R,Pat Roberts,15
-Wallace,Harrison,United State Senate,,L,Randall Batson,0
-Wallace,Sharon Sprs 1,United State Senate,,L,Randall Batson,5
-Wallace,Sharon Sprs 2,United State Senate,,L,Randall Batson,3
-Wallace,Sharon Sprs 3,United State Senate,,L,Randall Batson,0
-Wallace,Sharon Sprs 4,United State Senate,,L,Randall Batson,4
-Wallace,Wallace,United State Senate,,L,Randall Batson,1
-Wallace,Weskan,United State Senate,,L,Randall Batson,1
-Wallace,Advance,United State Senate,,L,Randall Batson,3
-Wallace,Prov,United State Senate,,L,Randall Batson,0
+county,precinct,office,district,party,candidate,votes,vtd
+WALLACE,Harrison Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,000010
+WALLACE,Harrison Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+WALLACE,Harrison Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",32,000010
+WALLACE,Sharon Springs Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",29,000020
+WALLACE,Sharon Springs Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000020
+WALLACE,Sharon Springs Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",102,000020
+WALLACE,Sharon Springs Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",43,000030
+WALLACE,Sharon Springs Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",11,000030
+WALLACE,Sharon Springs Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",205,000030
+WALLACE,Wallace Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000040
+WALLACE,Wallace Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000040
+WALLACE,Wallace Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000040
+WALLACE,Weskan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000050
+WALLACE,Weskan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000050
+WALLACE,Weskan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",116,000050
+WALLACE,Harrison Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",32,000010
+WALLACE,Sharon Springs Precinct 1,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",123,000020
+WALLACE,Sharon Springs Precinct 2,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",243,000030
+WALLACE,Wallace Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",53,000040
+WALLACE,Weskan Township,Kansas House of Representatives,120,Republican,"Billinger, Richard (Rick)",122,000050
+WALLACE,Harrison Township,United States House of Representatives,1,Democratic,"Sherow, James E.",0,000010
+WALLACE,Harrison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000010
+WALLACE,Sharon Springs Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",15,000020
+WALLACE,Sharon Springs Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",123,000020
+WALLACE,Sharon Springs Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",35,000030
+WALLACE,Sharon Springs Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",228,000030
+WALLACE,Wallace Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000040
+WALLACE,Wallace Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000040
+WALLACE,Weskan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000050
+WALLACE,Weskan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",119,000050
+WALLACE,Harrison Township,Attorney General,,Democratic,"Kotich, A.J.",0,000010
+WALLACE,Harrison Township,Attorney General,,Republican,"Schmidt, Derek",33,000010
+WALLACE,Sharon Springs Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",10,000020
+WALLACE,Sharon Springs Precinct 1,Attorney General,,Republican,"Schmidt, Derek",122,000020
+WALLACE,Sharon Springs Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",24,000030
+WALLACE,Sharon Springs Precinct 2,Attorney General,,Republican,"Schmidt, Derek",231,000030
+WALLACE,Wallace Township,Attorney General,,Democratic,"Kotich, A.J.",4,000040
+WALLACE,Wallace Township,Attorney General,,Republican,"Schmidt, Derek",55,000040
+WALLACE,Weskan Township,Attorney General,,Democratic,"Kotich, A.J.",9,000050
+WALLACE,Weskan Township,Attorney General,,Republican,"Schmidt, Derek",125,000050
+WALLACE,Harrison Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,000010
+WALLACE,Harrison Township,Commissioner of Insurance,,Republican,"Selzer, Ken",33,000010
+WALLACE,Sharon Springs Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000020
+WALLACE,Sharon Springs Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",107,000020
+WALLACE,Sharon Springs Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000030
+WALLACE,Sharon Springs Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",224,000030
+WALLACE,Wallace Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000040
+WALLACE,Wallace Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000040
+WALLACE,Weskan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000050
+WALLACE,Weskan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",124,000050
+WALLACE,Harrison Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000010
+WALLACE,Harrison Township,Secretary of State,,Republican,"Kobach, Kris",32,000010
+WALLACE,Sharon Springs Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000020
+WALLACE,Sharon Springs Precinct 1,Secretary of State,,Republican,"Kobach, Kris",113,000020
+WALLACE,Sharon Springs Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",33,000030
+WALLACE,Sharon Springs Precinct 2,Secretary of State,,Republican,"Kobach, Kris",224,000030
+WALLACE,Wallace Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000040
+WALLACE,Wallace Township,Secretary of State,,Republican,"Kobach, Kris",52,000040
+WALLACE,Weskan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000050
+WALLACE,Weskan Township,Secretary of State,,Republican,"Kobach, Kris",121,000050
+WALLACE,Harrison Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000010
+WALLACE,Harrison Township,State Treasurer,,Republican,"Estes, Ron",33,000010
+WALLACE,Sharon Springs Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",12,000020
+WALLACE,Sharon Springs Precinct 1,State Treasurer,,Republican,"Estes, Ron",122,000020
+WALLACE,Sharon Springs Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",18,000030
+WALLACE,Sharon Springs Precinct 2,State Treasurer,,Republican,"Estes, Ron",224,000030
+WALLACE,Wallace Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000040
+WALLACE,Wallace Township,State Treasurer,,Republican,"Estes, Ron",52,000040
+WALLACE,Weskan Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000050
+WALLACE,Weskan Township,State Treasurer,,Republican,"Estes, Ron",124,000050
+WALLACE,Harrison Township,United States Senate,,independent,"Orman, Greg",0,000010
+WALLACE,Harrison Township,United States Senate,,Libertarian,"Batson, Randall",0,000010
+WALLACE,Harrison Township,United States Senate,,Republican,"Roberts, Pat",33,000010
+WALLACE,Sharon Springs Precinct 1,United States Senate,,independent,"Orman, Greg",26,000020
+WALLACE,Sharon Springs Precinct 1,United States Senate,,Libertarian,"Batson, Randall",8,000020
+WALLACE,Sharon Springs Precinct 1,United States Senate,,Republican,"Roberts, Pat",105,000020
+WALLACE,Sharon Springs Precinct 2,United States Senate,,independent,"Orman, Greg",25,000030
+WALLACE,Sharon Springs Precinct 2,United States Senate,,Libertarian,"Batson, Randall",7,000030
+WALLACE,Sharon Springs Precinct 2,United States Senate,,Republican,"Roberts, Pat",229,000030
+WALLACE,Wallace Township,United States Senate,,independent,"Orman, Greg",6,000040
+WALLACE,Wallace Township,United States Senate,,Libertarian,"Batson, Randall",1,000040
+WALLACE,Wallace Township,United States Senate,,Republican,"Roberts, Pat",56,000040
+WALLACE,Weskan Township,United States Senate,,independent,"Orman, Greg",11,000050
+WALLACE,Weskan Township,United States Senate,,Libertarian,"Batson, Randall",1,000050
+WALLACE,Weskan Township,United States Senate,,Republican,"Roberts, Pat",122,000050

--- a/2014/20141104__ks__general__washington__precinct.csv
+++ b/2014/20141104__ks__general__washington__precinct.csv
@@ -1,522 +1,494 @@
-county,precinct,office,district,party,candidate,votes
-Washington,01 Barnes,,,,Registration,129
-Washington,01 Barnes,,,,Cast,76
-Washington,01 Barnes,U.S. Senate,,R,Pat Roberts,56
-Washington,01 Barnes,U.S. Senate,,I,Greg Orman,17
-Washington,01 Barnes,U.S. Senate,,L,Nathaniel Batson,2
-Washington,01 Barnes,U.S. House,1,R,Tim Huelskamp,53
-Washington,01 Barnes,U.S. House,1,D,James Sherow,22
-Washington,01 Barnes,Governor,,R,Sam Brownback,48
-Washington,01 Barnes,Governor,,D,Paul Davis,27
-Washington,01 Barnes,Governor,,L,Keen Umbehr,1
-Washington,01 Barnes,Secretary of State,,R,Kris Kobach,54
-Washington,01 Barnes,Secretary of State,,D,Jean Schodorf,20
-Washington,01 Barnes,Attorney General,,R,Derek Schmidt,56
-Washington,01 Barnes,Attorney General,,D,A J Kotich,15
-Washington,01 Barnes,State Treasurer,,R,Ron Estes,59
-Washington,01 Barnes,State Treasurer,,D,Carmen Alldritt,12
-Washington,01 Barnes,Insurance Commissioner,,R,Ken Selzer,55
-Washington,01 Barnes,Insurance Commissioner,,D,Dennis Anderson,16
-Washington,01 Barnes,State House,106,R,Sharon Schwartz,57
-Washington,01 Barnes,State House,106,,Write-ins,4
-Washington,02 Brantford,,,,Registration,54
-Washington,02 Brantford,,,,Cast,38
-Washington,02 Brantford,U.S. Senate,,R,Pat Roberts,33
-Washington,02 Brantford,U.S. Senate,,I,Greg Orman,4
-Washington,02 Brantford,U.S. Senate,,L,Nathaniel Batson,1
-Washington,02 Brantford,U.S. House,1,R,Tim Huelskamp,34
-Washington,02 Brantford,U.S. House,1,D,James Sherow,4
-Washington,02 Brantford,Governor,,R,Sam Brownback,34
-Washington,02 Brantford,Governor,,D,Paul Davis,4
-Washington,02 Brantford,Governor,,L,Keen Umbehr,0
-Washington,02 Brantford,Secretary of State,,R,Kris Kobach,34
-Washington,02 Brantford,Secretary of State,,D,Jean Schodorf,2
-Washington,02 Brantford,Attorney General,,R,Derek Schmidt,37
-Washington,02 Brantford,Attorney General,,D,A J Kotich,1
-Washington,02 Brantford,State Treasurer,,R,Ron Estes,36
-Washington,02 Brantford,State Treasurer,,D,Carmen Alldritt,2
-Washington,02 Brantford,Insurance Commissioner,,R,Ken Selzer,32
-Washington,02 Brantford,Insurance Commissioner,,D,Dennis Anderson,3
-Washington,02 Brantford,State House,106,R,Sharon Schwartz,29
-Washington,02 Brantford,State House,106,,Write-ins,1
-Washington,03 Charleston,,,,Registration,48
-Washington,03 Charleston,,,,Cast,34
-Washington,03 Charleston,U.S. Senate,,,R,30
-Washington,03 Charleston,U.S. Senate,,,I,4
-Washington,03 Charleston,U.S. Senate,,,L,0
-Washington,03 Charleston,U.S. House,1,,R,28
-Washington,03 Charleston,U.S. House,1,,D,5
-Washington,03 Charleston,Governor,,,R,28
-Washington,03 Charleston,Governor,,,D,6
-Washington,03 Charleston,Governor,,,L,0
-Washington,03 Charleston,Secretary of State,,,R,26
-Washington,03 Charleston,Secretary of State,,,D,7
-Washington,03 Charleston,Attorney General,,,R,28
-Washington,03 Charleston,Attorney General,,,D,4
-Washington,03 Charleston,State Treasurer,,,R,27
-Washington,03 Charleston,State Treasurer,,,D,4
-Washington,03 Charleston,Insurance Commissioner,,,R,24
-Washington,03 Charleston,Insurance Commissioner,,,D,6
-Washington,03 Charleston,State House,106,,R,34
-Washington,03 Charleston,State House,106,,,0
-Washington,04 Clifton,,,,Registration,260
-Washington,04 Clifton,,,,Cast,164
-Washington,04 Clifton,U.S. Senate,,,R,112
-Washington,04 Clifton,U.S. Senate,,,I,38
-Washington,04 Clifton,U.S. Senate,,,L,11
-Washington,04 Clifton,U.S. House,1,,R,101
-Washington,04 Clifton,U.S. House,1,,D,54
-Washington,04 Clifton,U.S. House,1,,,2
-Washington,04 Clifton,Governor,,,R,107
-Washington,04 Clifton,Governor,,,D,48
-Washington,04 Clifton,Governor,,,L,7
-Washington,04 Clifton,Secretary of State,,,R,118
-Washington,04 Clifton,Secretary of State,,,D,42
-Washington,04 Clifton,Attorney General,,,R,127
-Washington,04 Clifton,Attorney General,,,D,32
-Washington,04 Clifton,State Treasurer,,,R,132
-Washington,04 Clifton,State Treasurer,,,D,27
-Washington,04 Clifton,Insurance Commissioner,,,R,124
-Washington,04 Clifton,Insurance Commissioner,,,D,30
-Washington,04 Clifton,State House,106,,R,147
-Washington,04 Clifton,State House,106,,,2
-Washington,05 Coleman,,,,Registration,47
-Washington,05 Coleman,,,,Cast,25
-Washington,05 Coleman,U.S. Senate,,,R,20
-Washington,05 Coleman,U.S. Senate,,,I,4
-Washington,05 Coleman,U.S. Senate,,,L,0
-Washington,05 Coleman,U.S. House,1,,R,19
-Washington,05 Coleman,U.S. House,1,,D,5
-Washington,05 Coleman,Governor,,,R,19
-Washington,05 Coleman,Governor,,,D,6
-Washington,05 Coleman,Governor,,,L,0
-Washington,05 Coleman,Secretary of State,,,R,19
-Washington,05 Coleman,Secretary of State,,,D,6
-Washington,05 Coleman,Attorney General,,,R,23
-Washington,05 Coleman,Attorney General,,,D,2
-Washington,05 Coleman,State Treasurer,,,R,23
-Washington,05 Coleman,State Treasurer,,,D,2
-Washington,05 Coleman,Insurance Commissioner,,,R,21
-Washington,05 Coleman,Insurance Commissioner,,,D,4
-Washington,05 Coleman,State House,106,,R,21
-Washington,05 Coleman,State House,106,,,0
-Washington,06 Farmington,,,,Registration,125
-Washington,06 Farmington,,,,Cast,74
-Washington,06 Farmington,U.S. Senate,,,R,46
-Washington,06 Farmington,U.S. Senate,,,I,23
-Washington,06 Farmington,U.S. Senate,,,L,4
-Washington,06 Farmington,U.S. House,1,,R,47
-Washington,06 Farmington,U.S. House,1,,D,25
-Washington,06 Farmington,Governor,,,R,43
-Washington,06 Farmington,Governor,,,D,25
-Washington,06 Farmington,Governor,,,L,3
-Washington,06 Farmington,Secretary of State,,,R,49
-Washington,06 Farmington,Secretary of State,,,D,20
-Washington,06 Farmington,Attorney General,,,R,53
-Washington,06 Farmington,Attorney General,,,D,15
-Washington,06 Farmington,State Treasurer,,,R,60
-Washington,06 Farmington,State Treasurer,,,D,11
-Washington,06 Farmington,Insurance Commissioner,,,R,49
-Washington,06 Farmington,Insurance Commissioner,,,D,15
-Washington,06 Farmington,State House,106,,R,70
-Washington,06 Farmington,State House,106,,,0
-Washington,07 Franklin,,,,Registration,84
-Washington,07 Franklin,,,,Cast,46
-Washington,07 Franklin,U.S. Senate,,,R,31
-Washington,07 Franklin,U.S. Senate,,,I,11
-Washington,07 Franklin,U.S. Senate,,,L,3
-Washington,07 Franklin,U.S. House,1,,R,34
-Washington,07 Franklin,U.S. House,1,,D,12
-Washington,07 Franklin,Governor,,,R,33
-Washington,07 Franklin,Governor,,,D,12
-Washington,07 Franklin,Governor,,,L,1
-Washington,07 Franklin,Secretary of State,,,R,32
-Washington,07 Franklin,Secretary of State,,,D,10
-Washington,07 Franklin,Attorney General,,,R,32
-Washington,07 Franklin,Attorney General,,,D,10
-Washington,07 Franklin,State Treasurer,,,R,31
-Washington,07 Franklin,State Treasurer,,,D,9
-Washington,07 Franklin,Insurance Commissioner,,,R,32
-Washington,07 Franklin,Insurance Commissioner,,,D,8
-Washington,07 Franklin,State House,106,,R,37
-Washington,07 Franklin,State House,106,,,0
-Washington,08 Grant,,,,Registration,21
-Washington,08 Grant,,,,Cast,15
-Washington,08 Grant,U.S. Senate,,,R,12
-Washington,08 Grant,U.S. Senate,,,I,2
-Washington,08 Grant,U.S. Senate,,,L,1
-Washington,08 Grant,U.S. House,1,,R,13
-Washington,08 Grant,U.S. House,1,,D,2
-Washington,08 Grant,Governor,,,R,12
-Washington,08 Grant,Governor,,,D,2
-Washington,08 Grant,Governor,,,L,1
-Washington,08 Grant,Secretary of State,,,R,13
-Washington,08 Grant,Secretary of State,,,D,2
-Washington,08 Grant,Attorney General,,,R,13
-Washington,08 Grant,Attorney General,,,D,1
-Washington,08 Grant,State Treasurer,,,R,12
-Washington,08 Grant,State Treasurer,,,D,2
-Washington,08 Grant,Insurance Commissioner,,,R,13
-Washington,08 Grant,Insurance Commissioner,,,D,1
-Washington,08 Grant,State House,106,,R,12
-Washington,08 Grant,State House,106,,,1
-Washington,09 Greenleaf,,,,Registration,262
-Washington,09 Greenleaf,,,,Cast,135
-Washington,09 Greenleaf,U.S. Senate,,,R,89
-Washington,09 Greenleaf,U.S. Senate,,,I,35
-Washington,09 Greenleaf,U.S. Senate,,,L,8
-Washington,09 Greenleaf,U.S. House,1,,R,99
-Washington,09 Greenleaf,U.S. House,1,,D,33
-Washington,09 Greenleaf,Governor,,,R,85
-Washington,09 Greenleaf,Governor,,,D,42
-Washington,09 Greenleaf,Governor,,,L,6
-Washington,09 Greenleaf,Secretary of State,,,R,103
-Washington,09 Greenleaf,Secretary of State,,,D,30
-Washington,09 Greenleaf,Attorney General,,,R,114
-Washington,09 Greenleaf,Attorney General,,,D,19
-Washington,09 Greenleaf,State Treasurer,,,R,110
-Washington,09 Greenleaf,State Treasurer,,,D,19
-Washington,09 Greenleaf,Insurance Commissioner,,,R,103
-Washington,09 Greenleaf,Insurance Commissioner,,,D,25
-Washington,09 Greenleaf,State House,106,,R,106
-Washington,09 Greenleaf,State House,106,,,4
-Washington,10 Haddam,,,,Registration,111
-Washington,10 Haddam,,,,Cast,71
-Washington,10 Haddam,U.S. Senate,,,R,46
-Washington,10 Haddam,U.S. Senate,,,I,20
-Washington,10 Haddam,U.S. Senate,,,L,3
-Washington,10 Haddam,U.S. House,1,,R,49
-Washington,10 Haddam,U.S. House,1,,D,19
-Washington,10 Haddam,Governor,,,R,42
-Washington,10 Haddam,Governor,,,D,19
-Washington,10 Haddam,Governor,,,L,7
-Washington,10 Haddam,Secretary of State,,,R,50
-Washington,10 Haddam,Secretary of State,,,D,18
-Washington,10 Haddam,Attorney General,,,R,50
-Washington,10 Haddam,Attorney General,,,D,15
-Washington,10 Haddam,State Treasurer,,,R,50
-Washington,10 Haddam,State Treasurer,,,D,15
-Washington,10 Haddam,Insurance Commissioner,,,R,47
-Washington,10 Haddam,Insurance Commissioner,,,D,14
-Washington,10 Haddam,State House,106,,R,61
-Washington,10 Haddam,State House,106,,,0
-Washington,11 Hanover,,,,Registration,592
-Washington,11 Hanover,,,,Cast,363
-Washington,11 Hanover,U.S. Senate,,,R,267
-Washington,11 Hanover,U.S. Senate,,,I,72
-Washington,11 Hanover,U.S. Senate,,,L,15
-Washington,11 Hanover,U.S. House,1,,R,276
-Washington,11 Hanover,U.S. House,1,,D,72
-Washington,11 Hanover,Governor,,,R,241
-Washington,11 Hanover,Governor,,,D,100
-Washington,11 Hanover,Governor,,,L,14
-Washington,11 Hanover,Secretary of State,,,R,279
-Washington,11 Hanover,Secretary of State,,,D,68
-Washington,11 Hanover,Attorney General,,,R,289
-Washington,11 Hanover,Attorney General,,,D,48
-Washington,11 Hanover,State Treasurer,,,R,293
-Washington,11 Hanover,State Treasurer,,,D,44
-Washington,11 Hanover,Insurance Commissioner,,,R,273
-Washington,11 Hanover,Insurance Commissioner,,,D,62
-Washington,11 Hanover,State House,106,,R,305
-Washington,11 Hanover,State House,106,,,10
-Washington,12 Highland,,,,Registration,19
-Washington,12 Highland,,,,Cast,13
-Washington,12 Highland,U.S. Senate,,,R,10
-Washington,12 Highland,U.S. Senate,,,I,3
-Washington,12 Highland,U.S. Senate,,,L,0
-Washington,12 Highland,U.S. House,1,,R,12
-Washington,12 Highland,U.S. House,1,,D,1
-Washington,12 Highland,Governor,,,R,12
-Washington,12 Highland,Governor,,,D,1
-Washington,12 Highland,Governor,,,L,0
-Washington,12 Highland,Secretary of State,,,R,12
-Washington,12 Highland,Secretary of State,,,D,1
-Washington,12 Highland,Attorney General,,,R,12
-Washington,12 Highland,Attorney General,,,D,1
-Washington,12 Highland,State Treasurer,,,R,12
-Washington,12 Highland,State Treasurer,,,D,1
-Washington,12 Highland,Insurance Commissioner,,,R,12
-Washington,12 Highland,Insurance Commissioner,,,D,1
-Washington,12 Highland,State House,106,,R,9
-Washington,12 Highland,State House,106,,,0
-Washington,13 Independence,,,,Registration,82
-Washington,13 Independence,,,,Cast,55
-Washington,13 Independence,U.S. Senate,,,R,45
-Washington,13 Independence,U.S. Senate,,,I,8
-Washington,13 Independence,U.S. Senate,,,L,1
-Washington,13 Independence,U.S. House,1,,R,47
-Washington,13 Independence,U.S. House,1,,D,8
-Washington,13 Independence,Governor,,,R,47
-Washington,13 Independence,Governor,,,D,6
-Washington,13 Independence,Governor,,,L,2
-Washington,13 Independence,Secretary of State,,,R,50
-Washington,13 Independence,Secretary of State,,,D,4
-Washington,13 Independence,Attorney General,,,R,48
-Washington,13 Independence,Attorney General,,,D,7
-Washington,13 Independence,State Treasurer,,,R,50
-Washington,13 Independence,State Treasurer,,,D,4
-Washington,13 Independence,Insurance Commissioner,,,R,47
-Washington,13 Independence,Insurance Commissioner,,,D,6
-Washington,13 Independence,State House,106,,R,51
-Washington,13 Independence,State House,106,,,0
-Washington,14 Kimeo,,,,Registration,46
-Washington,14 Kimeo,,,,Cast,28
-Washington,14 Kimeo,U.S. Senate,,,R,19
-Washington,14 Kimeo,U.S. Senate,,,I,9
-Washington,14 Kimeo,U.S. Senate,,,L,0
-Washington,14 Kimeo,U.S. House,1,,R,22
-Washington,14 Kimeo,U.S. House,1,,D,6
-Washington,14 Kimeo,Governor,,,R,21
-Washington,14 Kimeo,Governor,,,D,7
-Washington,14 Kimeo,Governor,,,L,0
-Washington,14 Kimeo,Secretary of State,,,R,20
-Washington,14 Kimeo,Secretary of State,,,D,8
-Washington,14 Kimeo,Attorney General,,,R,25
-Washington,14 Kimeo,Attorney General,,,D,3
-Washington,14 Kimeo,State Treasurer,,,R,26
-Washington,14 Kimeo,State Treasurer,,,D,2
-Washington,14 Kimeo,Insurance Commissioner,,,R,24
-Washington,14 Kimeo,Insurance Commissioner,,,D,3
-Washington,14 Kimeo,State House,106,,R,26
-Washington,14 Kimeo,State House,106,,,0
-Washington,15 Lincoln Township,,,,Registration,37
-Washington,15 Lincoln Township,,,,Cast,22
-Washington,15 Lincoln Township,U.S. Senate,,,R,20
-Washington,15 Lincoln Township,U.S. Senate,,,I,1
-Washington,15 Lincoln Township,U.S. Senate,,,L,1
-Washington,15 Lincoln Township,U.S. House,1,,R,20
-Washington,15 Lincoln Township,U.S. House,1,,D,2
-Washington,15 Lincoln Township,Governor,,,R,19
-Washington,15 Lincoln Township,Governor,,,D,2
-Washington,15 Lincoln Township,Governor,,,L,1
-Washington,15 Lincoln Township,Secretary of State,,,R,20
-Washington,15 Lincoln Township,Secretary of State,,,D,2
-Washington,15 Lincoln Township,Attorney General,,,R,21
-Washington,15 Lincoln Township,Attorney General,,,D,1
-Washington,15 Lincoln Township,State Treasurer,,,R,22
-Washington,15 Lincoln Township,State Treasurer,,,D,0
-Washington,15 Lincoln Township,Insurance Commissioner,,,R,20
-Washington,15 Lincoln Township,Insurance Commissioner,,,D,1
-Washington,15 Lincoln Township,State House,106,,R,19
-Washington,15 Lincoln Township,State House,106,,,0
-Washington,16 Linn Township,,,,Registration,332
-Washington,16 Linn Township,,,,Cast,196
-Washington,16 Linn Township,U.S. Senate,,,R,152
-Washington,16 Linn Township,U.S. Senate,,,I,32
-Washington,16 Linn Township,U.S. Senate,,,L,9
-Washington,16 Linn Township,U.S. House,1,,R,154
-Washington,16 Linn Township,U.S. House,1,,D,36
-Washington,16 Linn Township,Governor,,,R,135
-Washington,16 Linn Township,Governor,,,D,48
-Washington,16 Linn Township,Governor,,,L,9
-Washington,16 Linn Township,Secretary of State,,,R,159
-Washington,16 Linn Township,Secretary of State,,,D,30
-Washington,16 Linn Township,Attorney General,,,R,165
-Washington,16 Linn Township,Attorney General,,,D,25
-Washington,16 Linn Township,State Treasurer,,,R,166
-Washington,16 Linn Township,State Treasurer,,,D,24
-Washington,16 Linn Township,Insurance Commissioner,,,R,158
-Washington,16 Linn Township,Insurance Commissioner,,,D,27
-Washington,16 Linn Township,State House,106,,R,162
-Washington,16 Linn Township,State House,106,,,3
-Washington,17 Little Blue Township,,,,Registration,52
-Washington,17 Little Blue Township,,,,Cast,35
-Washington,17 Little Blue Township,U.S. Senate,,,R,20
-Washington,17 Little Blue Township,U.S. Senate,,,I,15
-Washington,17 Little Blue Township,U.S. Senate,,,L,0
-Washington,17 Little Blue Township,U.S. House,1,,R,19
-Washington,17 Little Blue Township,U.S. House,1,,D,16
-Washington,17 Little Blue Township,Governor,,,R,19
-Washington,17 Little Blue Township,Governor,,,D,14
-Washington,17 Little Blue Township,Governor,,,L,2
-Washington,17 Little Blue Township,Secretary of State,,,R,26
-Washington,17 Little Blue Township,Secretary of State,,,D,9
-Washington,17 Little Blue Township,Attorney General,,,R,26
-Washington,17 Little Blue Township,Attorney General,,,D,9
-Washington,17 Little Blue Township,State Treasurer,,,R,26
-Washington,17 Little Blue Township,State Treasurer,,,D,9
-Washington,17 Little Blue Township,Insurance Commissioner,,,R,19
-Washington,17 Little Blue Township,Insurance Commissioner,,,D,13
-Washington,17 Little Blue Township,State House,106,,R,28
-Washington,17 Little Blue Township,State House,106,,,2
-Washington,18 Logan Township,,,,Registration,73
-Washington,18 Logan Township,,,,Cast,51
-Washington,18 Logan Township,U.S. Senate,,,R,36
-Washington,18 Logan Township,U.S. Senate,,,I,12
-Washington,18 Logan Township,U.S. Senate,,,L,3
-Washington,18 Logan Township,U.S. House,1,,R,37
-Washington,18 Logan Township,U.S. House,1,,D,12
-Washington,18 Logan Township,Governor,,,R,35
-Washington,18 Logan Township,Governor,,,D,13
-Washington,18 Logan Township,Governor,,,L,3
-Washington,18 Logan Township,Secretary of State,,,R,41
-Washington,18 Logan Township,Secretary of State,,,D,9
-Washington,18 Logan Township,Attorney General,,,R,48
-Washington,18 Logan Township,Attorney General,,,D,2
-Washington,18 Logan Township,State Treasurer,,,R,47
-Washington,18 Logan Township,State Treasurer,,,D,3
-Washington,18 Logan Township,Insurance Commissioner,,,R,44
-Washington,18 Logan Township,Insurance Commissioner,,,D,4
-Washington,18 Logan Township,State House,106,,R,41
-Washington,18 Logan Township,State House,106,,,1
-Washington,19 Lowe Township,,,,Registration,47
-Washington,19 Lowe Township,,,,Cast,20
-Washington,19 Lowe Township,U.S. Senate,,,R,20
-Washington,19 Lowe Township,U.S. Senate,,,I,0
-Washington,19 Lowe Township,U.S. Senate,,,L,0
-Washington,19 Lowe Township,U.S. House,1,,R,18
-Washington,19 Lowe Township,U.S. House,1,,D,2
-Washington,19 Lowe Township,Governor,,,R,18
-Washington,19 Lowe Township,Governor,,,D,2
-Washington,19 Lowe Township,Governor,,,L,0
-Washington,19 Lowe Township,Secretary of State,,,R,19
-Washington,19 Lowe Township,Secretary of State,,,D,0
-Washington,19 Lowe Township,Attorney General,,,R,17
-Washington,19 Lowe Township,Attorney General,,,D,0
-Washington,19 Lowe Township,State Treasurer,,,R,19
-Washington,19 Lowe Township,State Treasurer,,,D,0
-Washington,19 Lowe Township,Insurance Commissioner,,,R,17
-Washington,19 Lowe Township,Insurance Commissioner,,,D,1
-Washington,19 Lowe Township,State House,106,,R,18
-Washington,19 Lowe Township,State House,106,,,0
-Washington,20 Mill Creek Township,,,,Registration,152
-Washington,20 Mill Creek Township,,,,Cast,89
-Washington,20 Mill Creek Township,U.S. Senate,,,R,65
-Washington,20 Mill Creek Township,U.S. Senate,,,I,18
-Washington,20 Mill Creek Township,U.S. Senate,,,L,5
-Washington,20 Mill Creek Township,U.S. House,1,,R,68
-Washington,20 Mill Creek Township,U.S. House,1,,D,18
-Washington,20 Mill Creek Township,Governor,,,R,57
-Washington,20 Mill Creek Township,Governor,,,D,24
-Washington,20 Mill Creek Township,Governor,,,L,4
-Washington,20 Mill Creek Township,Secretary of State,,,R,71
-Washington,20 Mill Creek Township,Secretary of State,,,D,14
-Washington,20 Mill Creek Township,Attorney General,,,R,79
-Washington,20 Mill Creek Township,Attorney General,,,D,5
-Washington,20 Mill Creek Township,State Treasurer,,,R,78
-Washington,20 Mill Creek Township,State Treasurer,,,D,5
-Washington,20 Mill Creek Township,Insurance Commissioner,,,R,69
-Washington,20 Mill Creek Township,Insurance Commissioner,,,D,10
-Washington,20 Mill Creek Township,State House,106,,R,63
-Washington,20 Mill Creek Township,State House,106,,,5
-Washington,21 Sheridan Township,,,,Registration,68
-Washington,21 Sheridan Township,,,,Cast,42
-Washington,21 Sheridan Township,U.S. Senate,,,R,32
-Washington,21 Sheridan Township,U.S. Senate,,,I,7
-Washington,21 Sheridan Township,U.S. Senate,,,L,3
-Washington,21 Sheridan Township,U.S. House,1,,R,35
-Washington,21 Sheridan Township,U.S. House,1,,D,6
-Washington,21 Sheridan Township,Governor,,,R,31
-Washington,21 Sheridan Township,Governor,,,D,8
-Washington,21 Sheridan Township,Governor,,,L,3
-Washington,21 Sheridan Township,Secretary of State,,,R,35
-Washington,21 Sheridan Township,Secretary of State,,,D,5
-Washington,21 Sheridan Township,Attorney General,,,R,37
-Washington,21 Sheridan Township,Attorney General,,,D,4
-Washington,21 Sheridan Township,State Treasurer,,,R,34
-Washington,21 Sheridan Township,State Treasurer,,,D,7
-Washington,21 Sheridan Township,Insurance Commissioner,,,R,39
-Washington,21 Sheridan Township,Insurance Commissioner,,,D,2
-Washington,21 Sheridan Township,State House,106,,R,37
-Washington,21 Sheridan Township,State House,106,,,2
-Washington,22 Sherman Township,,,,Registration,178
-Washington,22 Sherman Township,,,,Cast,104
-Washington,22 Sherman Township,U.S. Senate,,,R,80
-Washington,22 Sherman Township,U.S. Senate,,,I,19
-Washington,22 Sherman Township,U.S. Senate,,,L,4
-Washington,22 Sherman Township,U.S. House,1,,R,85
-Washington,22 Sherman Township,U.S. House,1,,D,17
-Washington,22 Sherman Township,Governor,,,R,80
-Washington,22 Sherman Township,Governor,,,D,22
-Washington,22 Sherman Township,Governor,,,L,1
-Washington,22 Sherman Township,Secretary of State,,,R,90
-Washington,22 Sherman Township,Secretary of State,,,D,13
-Washington,22 Sherman Township,Attorney General,,,R,92
-Washington,22 Sherman Township,Attorney General,,,D,8
-Washington,22 Sherman Township,State Treasurer,,,R,94
-Washington,22 Sherman Township,State Treasurer,,,D,7
-Washington,22 Sherman Township,Insurance Commissioner,,,R,84
-Washington,22 Sherman Township,Insurance Commissioner,,,D,13
-Washington,22 Sherman Township,State House,106,,R,92
-Washington,22 Sherman Township,State House,106,,,2
-Washington,23 Strawberry Township,,,,Registration,79
-Washington,23 Strawberry Township,,,,Cast,49
-Washington,23 Strawberry Township,U.S. Senate,,,R,41
-Washington,23 Strawberry Township,U.S. Senate,,,I,4
-Washington,23 Strawberry Township,U.S. Senate,,,L,3
-Washington,23 Strawberry Township,U.S. House,1,,R,37
-Washington,23 Strawberry Township,U.S. House,1,,D,11
-Washington,23 Strawberry Township,Governor,,,R,39
-Washington,23 Strawberry Township,Governor,,,D,7
-Washington,23 Strawberry Township,Governor,,,L,3
-Washington,23 Strawberry Township,Secretary of State,,,R,41
-Washington,23 Strawberry Township,Secretary of State,,,D,7
-Washington,23 Strawberry Township,Attorney General,,,R,44
-Washington,23 Strawberry Township,Attorney General,,,D,3
-Washington,23 Strawberry Township,State Treasurer,,,R,45
-Washington,23 Strawberry Township,State Treasurer,,,D,2
-Washington,23 Strawberry Township,Insurance Commissioner,,,R,41
-Washington,23 Strawberry Township,Insurance Commissioner,,,D,4
-Washington,23 Strawberry Township,State House,106,,R,35
-Washington,23 Strawberry Township,State House,106,,,1
-Washington,24 Union Township,,,,Registration,67
-Washington,24 Union Township,,,,Cast,31
-Washington,24 Union Township,U.S. Senate,,,R,22
-Washington,24 Union Township,U.S. Senate,,,I,8
-Washington,24 Union Township,U.S. Senate,,,L,1
-Washington,24 Union Township,U.S. House,1,,R,20
-Washington,24 Union Township,U.S. House,1,,D,11
-Washington,24 Union Township,Governor,,,R,19
-Washington,24 Union Township,Governor,,,D,12
-Washington,24 Union Township,Governor,,,L,0
-Washington,24 Union Township,Secretary of State,,,R,24
-Washington,24 Union Township,Secretary of State,,,D,7
-Washington,24 Union Township,Attorney General,,,R,24
-Washington,24 Union Township,Attorney General,,,D,7
-Washington,24 Union Township,State Treasurer,,,R,26
-Washington,24 Union Township,State Treasurer,,,D,5
-Washington,24 Union Township,Insurance Commissioner,,,R,25
-Washington,24 Union Township,Insurance Commissioner,,,D,6
-Washington,24 Union Township,State House,106,,R,26
-Washington,24 Union Township,State House,106,,,0
-Washington,25 Washington Township,,,,Registration,150
-Washington,25 Washington Township,,,,Cast,108
-Washington,25 Washington Township,U.S. Senate,,,R,87
-Washington,25 Washington Township,U.S. Senate,,,I,19
-Washington,25 Washington Township,U.S. Senate,,,L,1
-Washington,25 Washington Township,U.S. House,1,,R,83
-Washington,25 Washington Township,U.S. House,1,,D,21
-Washington,25 Washington Township,Governor,,,R,79
-Washington,25 Washington Township,Governor,,,D,25
-Washington,25 Washington Township,Governor,,,L,4
-Washington,25 Washington Township,Secretary of State,,,R,88
-Washington,25 Washington Township,Secretary of State,,,D,16
-Washington,25 Washington Township,Attorney General,,,R,95
-Washington,25 Washington Township,Attorney General,,,D,8
-Washington,25 Washington Township,State Treasurer,,,R,96
-Washington,25 Washington Township,State Treasurer,,,D,9
-Washington,25 Washington Township,Insurance Commissioner,,,R,88
-Washington,25 Washington Township,Insurance Commissioner,,,D,12
-Washington,25 Washington Township,State House,106,,R,94
-Washington,25 Washington Township,State House,106,,,3
-Washington,26 Washington City,,,,Registration,749
-Washington,26 Washington City,,,,Cast,445
-Washington,26 Washington City,U.S. Senate,,R,Pat Roberts,293
-Washington,26 Washington City,U.S. Senate,,I,Greg Orman,111
-Washington,26 Washington City,U.S. Senate,,L,Nathaniel Batson,34
-Washington,26 Washington City,U.S. House,1,R,Tim Huelskamp,307
-Washington,26 Washington City,U.S. House,1,D,James Sherow,120
-Washington,26 Washington City,Governor,,R,Sam Brownback,244
-Washington,26 Washington City,Governor,,D,Paul Davis,160
-Washington,26 Washington City,Governor,,L,Keen Umbehr,30
-Washington,26 Washington City,Secretary of State,,R,Kris Kobach,320
-Washington,26 Washington City,Secretary of State,,D,Jean Schodorf,112
-Washington,26 Washington City,Attorney General,,R,Derek Schmidt,341
-Washington,26 Washington City,Attorney General,,D,A J Kotich,84
-Washington,26 Washington City,State Treasurer,,R,Ron Estes,351
-Washington,26 Washington City,State Treasurer,,D,Carmen Alldritt,75
-Washington,26 Washington City,Insurance Commissioner,,R,Ken Selzer,317
-Washington,26 Washington City,Insurance Commissioner,,D,Dennis Anderson,88
-Washington,26 Washington City,State House,106,R,Sharon Schwartz,357
-Washington,26 Washington City,State House,106,,Write-ins,14
+county,precinct,office,district,party,candidate,votes,vtd
+WASHINGTON,Barnes Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000010
+WASHINGTON,Barnes Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000010
+WASHINGTON,Barnes Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",48,000010
+WASHINGTON,Brantford Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",4,000020
+WASHINGTON,Brantford Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000020
+WASHINGTON,Brantford Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",34,000020
+WASHINGTON,Charleston Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000030
+WASHINGTON,Charleston Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+WASHINGTON,Charleston Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000030
+WASHINGTON,Clifton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000040
+WASHINGTON,Clifton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000040
+WASHINGTON,Clifton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",107,000040
+WASHINGTON,Coleman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000050
+WASHINGTON,Coleman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000050
+WASHINGTON,Coleman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000050
+WASHINGTON,Farmington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,000060
+WASHINGTON,Farmington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000060
+WASHINGTON,Farmington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000060
+WASHINGTON,Franklin Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000070
+WASHINGTON,Franklin Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000070
+WASHINGTON,Franklin Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000070
+WASHINGTON,Grant Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000080
+WASHINGTON,Grant Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000080
+WASHINGTON,Grant Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000080
+WASHINGTON,Greenleaf Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",42,000090
+WASHINGTON,Greenleaf Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000090
+WASHINGTON,Greenleaf Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",85,000090
+WASHINGTON,Haddam Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000100
+WASHINGTON,Haddam Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000100
+WASHINGTON,Haddam Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",42,000100
+WASHINGTON,Hanover Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",100,000110
+WASHINGTON,Hanover Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000110
+WASHINGTON,Hanover Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",241,000110
+WASHINGTON,Highland Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000120
+WASHINGTON,Highland Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+WASHINGTON,Highland Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",12,000120
+WASHINGTON,Independence Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",6,000130
+WASHINGTON,Independence Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000130
+WASHINGTON,Independence Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",47,000130
+WASHINGTON,Kimeo Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000140
+WASHINGTON,Kimeo Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000140
+WASHINGTON,Kimeo Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",21,000140
+WASHINGTON,Lincoln Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",1,000150
+WASHINGTON,Lincoln Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000150
+WASHINGTON,Lincoln Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000150
+WASHINGTON,Linn Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",48,000160
+WASHINGTON,Linn Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000160
+WASHINGTON,Linn Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",135,000160
+WASHINGTON,Little Blue Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000170
+WASHINGTON,Little Blue Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000170
+WASHINGTON,Little Blue Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000170
+WASHINGTON,Logan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000180
+WASHINGTON,Logan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000180
+WASHINGTON,Logan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",35,000180
+WASHINGTON,Lowe Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",2,000190
+WASHINGTON,Lowe Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000190
+WASHINGTON,Lowe Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",18,000190
+WASHINGTON,Mill Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",24,000200
+WASHINGTON,Mill Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000200
+WASHINGTON,Mill Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",57,000200
+WASHINGTON,Sheridan Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",8,000210
+WASHINGTON,Sheridan Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000210
+WASHINGTON,Sheridan Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",31,000210
+WASHINGTON,Sherman Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000220
+WASHINGTON,Sherman Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000220
+WASHINGTON,Sherman Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",80,000220
+WASHINGTON,Strawberry Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000230
+WASHINGTON,Strawberry Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000230
+WASHINGTON,Strawberry Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000230
+WASHINGTON,Union Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",12,000240
+WASHINGTON,Union Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000240
+WASHINGTON,Union Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",19,000240
+WASHINGTON,Washington Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",25,00025A
+WASHINGTON,Washington Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,00025A
+WASHINGTON,Washington Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,00025A
+WASHINGTON,Washington Township Rural Enclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00025B
+WASHINGTON,Washington City,Governor / Lt. Governor,,Democratic,"Davis, Paul",160,00026A
+WASHINGTON,Washington City,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",30,00026A
+WASHINGTON,Washington City,Governor / Lt. Governor,,Republican,"Brownback, Sam",244,00026A
+WASHINGTON,Washington City Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00026B
+WASHINGTON,Washington City Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00026B
+WASHINGTON,Washington City Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+WASHINGTON,Barnes Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",57,000010
+WASHINGTON,Brantford Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",29,000020
+WASHINGTON,Charleston Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",34,000030
+WASHINGTON,Clifton Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",147,000040
+WASHINGTON,Coleman Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",21,000050
+WASHINGTON,Farmington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",70,000060
+WASHINGTON,Franklin Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",37,000070
+WASHINGTON,Grant Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",12,000080
+WASHINGTON,Greenleaf Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",106,000090
+WASHINGTON,Haddam Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",61,000100
+WASHINGTON,Hanover Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",305,000110
+WASHINGTON,Highland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",9,000120
+WASHINGTON,Independence Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",51,000130
+WASHINGTON,Kimeo Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",26,000140
+WASHINGTON,Lincoln Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",19,000150
+WASHINGTON,Linn Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",162,000160
+WASHINGTON,Little Blue Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",28,000170
+WASHINGTON,Logan Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",41,000180
+WASHINGTON,Lowe Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",18,000190
+WASHINGTON,Mill Creek Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",63,000200
+WASHINGTON,Sheridan Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",37,000210
+WASHINGTON,Sherman Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",92,000220
+WASHINGTON,Strawberry Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",35,000230
+WASHINGTON,Union Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",26,000240
+WASHINGTON,Washington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",94,00025A
+WASHINGTON,Washington Township Rural Enclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00025B
+WASHINGTON,Washington City,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",357,00026A
+WASHINGTON,Washington City Exclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Kansas House of Representatives,106,Republican,"Schwartz, Sharon J.",0,900010
+WASHINGTON,Barnes Township,United States House of Representatives,1,Democratic,"Sherow, James E.",22,000010
+WASHINGTON,Barnes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000010
+WASHINGTON,Brantford Township,United States House of Representatives,1,Democratic,"Sherow, James E.",4,000020
+WASHINGTON,Brantford Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000020
+WASHINGTON,Charleston Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000030
+WASHINGTON,Charleston Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000030
+WASHINGTON,Clifton Township,United States House of Representatives,1,Democratic,"Sherow, James E.",54,000040
+WASHINGTON,Clifton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000040
+WASHINGTON,Coleman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",5,000050
+WASHINGTON,Coleman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000050
+WASHINGTON,Farmington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",25,000060
+WASHINGTON,Farmington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000060
+WASHINGTON,Franklin Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000070
+WASHINGTON,Franklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000070
+WASHINGTON,Grant Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000080
+WASHINGTON,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000080
+WASHINGTON,Greenleaf Township,United States House of Representatives,1,Democratic,"Sherow, James E.",33,000090
+WASHINGTON,Greenleaf Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",99,000090
+WASHINGTON,Haddam Township,United States House of Representatives,1,Democratic,"Sherow, James E.",19,000100
+WASHINGTON,Haddam Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000100
+WASHINGTON,Hanover Township,United States House of Representatives,1,Democratic,"Sherow, James E.",72,000110
+WASHINGTON,Hanover Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",276,000110
+WASHINGTON,Highland Township,United States House of Representatives,1,Democratic,"Sherow, James E.",1,000120
+WASHINGTON,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000120
+WASHINGTON,Independence Township,United States House of Representatives,1,Democratic,"Sherow, James E.",8,000130
+WASHINGTON,Independence Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000130
+WASHINGTON,Kimeo Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000140
+WASHINGTON,Kimeo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000140
+WASHINGTON,Lincoln Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000150
+WASHINGTON,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000150
+WASHINGTON,Linn Township,United States House of Representatives,1,Democratic,"Sherow, James E.",36,000160
+WASHINGTON,Linn Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",154,000160
+WASHINGTON,Little Blue Township,United States House of Representatives,1,Democratic,"Sherow, James E.",16,000170
+WASHINGTON,Little Blue Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000170
+WASHINGTON,Logan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",12,000180
+WASHINGTON,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000180
+WASHINGTON,Lowe Township,United States House of Representatives,1,Democratic,"Sherow, James E.",2,000190
+WASHINGTON,Lowe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000190
+WASHINGTON,Mill Creek Township,United States House of Representatives,1,Democratic,"Sherow, James E.",18,000200
+WASHINGTON,Mill Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",68,000200
+WASHINGTON,Sheridan Township,United States House of Representatives,1,Democratic,"Sherow, James E.",6,000210
+WASHINGTON,Sheridan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000210
+WASHINGTON,Sherman Township,United States House of Representatives,1,Democratic,"Sherow, James E.",17,000220
+WASHINGTON,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,000220
+WASHINGTON,Strawberry Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000230
+WASHINGTON,Strawberry Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000230
+WASHINGTON,Union Township,United States House of Representatives,1,Democratic,"Sherow, James E.",11,000240
+WASHINGTON,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000240
+WASHINGTON,Washington Township,United States House of Representatives,1,Democratic,"Sherow, James E.",21,00025A
+WASHINGTON,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",83,00025A
+WASHINGTON,Washington Township Rural Enclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00025B
+WASHINGTON,Washington City,United States House of Representatives,1,Democratic,"Sherow, James E.",120,00026A
+WASHINGTON,Washington City,United States House of Representatives,1,Republican,"Huelskamp, Tim",307,00026A
+WASHINGTON,Washington City Exclave,United States House of Representatives,1,Democratic,"Sherow, James E.",0,00026B
+WASHINGTON,Washington City Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,United States House of Representatives,1,Democratic,"Sherow, James E.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+WASHINGTON,Barnes Township,Attorney General,,Democratic,"Kotich, A.J.",15,000010
+WASHINGTON,Barnes Township,Attorney General,,Republican,"Schmidt, Derek",56,000010
+WASHINGTON,Brantford Township,Attorney General,,Democratic,"Kotich, A.J.",1,000020
+WASHINGTON,Brantford Township,Attorney General,,Republican,"Schmidt, Derek",37,000020
+WASHINGTON,Charleston Township,Attorney General,,Democratic,"Kotich, A.J.",4,000030
+WASHINGTON,Charleston Township,Attorney General,,Republican,"Schmidt, Derek",28,000030
+WASHINGTON,Clifton Township,Attorney General,,Democratic,"Kotich, A.J.",32,000040
+WASHINGTON,Clifton Township,Attorney General,,Republican,"Schmidt, Derek",127,000040
+WASHINGTON,Coleman Township,Attorney General,,Democratic,"Kotich, A.J.",2,000050
+WASHINGTON,Coleman Township,Attorney General,,Republican,"Schmidt, Derek",23,000050
+WASHINGTON,Farmington Township,Attorney General,,Democratic,"Kotich, A.J.",15,000060
+WASHINGTON,Farmington Township,Attorney General,,Republican,"Schmidt, Derek",53,000060
+WASHINGTON,Franklin Township,Attorney General,,Democratic,"Kotich, A.J.",10,000070
+WASHINGTON,Franklin Township,Attorney General,,Republican,"Schmidt, Derek",32,000070
+WASHINGTON,Grant Township,Attorney General,,Democratic,"Kotich, A.J.",1,000080
+WASHINGTON,Grant Township,Attorney General,,Republican,"Schmidt, Derek",13,000080
+WASHINGTON,Greenleaf Township,Attorney General,,Democratic,"Kotich, A.J.",19,000090
+WASHINGTON,Greenleaf Township,Attorney General,,Republican,"Schmidt, Derek",114,000090
+WASHINGTON,Haddam Township,Attorney General,,Democratic,"Kotich, A.J.",15,000100
+WASHINGTON,Haddam Township,Attorney General,,Republican,"Schmidt, Derek",50,000100
+WASHINGTON,Hanover Township,Attorney General,,Democratic,"Kotich, A.J.",48,000110
+WASHINGTON,Hanover Township,Attorney General,,Republican,"Schmidt, Derek",289,000110
+WASHINGTON,Highland Township,Attorney General,,Democratic,"Kotich, A.J.",1,000120
+WASHINGTON,Highland Township,Attorney General,,Republican,"Schmidt, Derek",12,000120
+WASHINGTON,Independence Township,Attorney General,,Democratic,"Kotich, A.J.",7,000130
+WASHINGTON,Independence Township,Attorney General,,Republican,"Schmidt, Derek",48,000130
+WASHINGTON,Kimeo Township,Attorney General,,Democratic,"Kotich, A.J.",3,000140
+WASHINGTON,Kimeo Township,Attorney General,,Republican,"Schmidt, Derek",25,000140
+WASHINGTON,Lincoln Township,Attorney General,,Democratic,"Kotich, A.J.",1,000150
+WASHINGTON,Lincoln Township,Attorney General,,Republican,"Schmidt, Derek",21,000150
+WASHINGTON,Linn Township,Attorney General,,Democratic,"Kotich, A.J.",25,000160
+WASHINGTON,Linn Township,Attorney General,,Republican,"Schmidt, Derek",165,000160
+WASHINGTON,Little Blue Township,Attorney General,,Democratic,"Kotich, A.J.",9,000170
+WASHINGTON,Little Blue Township,Attorney General,,Republican,"Schmidt, Derek",26,000170
+WASHINGTON,Logan Township,Attorney General,,Democratic,"Kotich, A.J.",2,000180
+WASHINGTON,Logan Township,Attorney General,,Republican,"Schmidt, Derek",48,000180
+WASHINGTON,Lowe Township,Attorney General,,Democratic,"Kotich, A.J.",0,000190
+WASHINGTON,Lowe Township,Attorney General,,Republican,"Schmidt, Derek",17,000190
+WASHINGTON,Mill Creek Township,Attorney General,,Democratic,"Kotich, A.J.",5,000200
+WASHINGTON,Mill Creek Township,Attorney General,,Republican,"Schmidt, Derek",79,000200
+WASHINGTON,Sheridan Township,Attorney General,,Democratic,"Kotich, A.J.",4,000210
+WASHINGTON,Sheridan Township,Attorney General,,Republican,"Schmidt, Derek",37,000210
+WASHINGTON,Sherman Township,Attorney General,,Democratic,"Kotich, A.J.",8,000220
+WASHINGTON,Sherman Township,Attorney General,,Republican,"Schmidt, Derek",92,000220
+WASHINGTON,Strawberry Township,Attorney General,,Democratic,"Kotich, A.J.",3,000230
+WASHINGTON,Strawberry Township,Attorney General,,Republican,"Schmidt, Derek",44,000230
+WASHINGTON,Union Township,Attorney General,,Democratic,"Kotich, A.J.",7,000240
+WASHINGTON,Union Township,Attorney General,,Republican,"Schmidt, Derek",24,000240
+WASHINGTON,Washington Township,Attorney General,,Democratic,"Kotich, A.J.",8,00025A
+WASHINGTON,Washington Township,Attorney General,,Republican,"Schmidt, Derek",95,00025A
+WASHINGTON,Washington Township Rural Enclave,Attorney General,,Democratic,"Kotich, A.J.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Attorney General,,Republican,"Schmidt, Derek",0,00025B
+WASHINGTON,Washington City,Attorney General,,Democratic,"Kotich, A.J.",84,00026A
+WASHINGTON,Washington City,Attorney General,,Republican,"Schmidt, Derek",341,00026A
+WASHINGTON,Washington City Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00026B
+WASHINGTON,Washington City Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Attorney General,,Republican,"Schmidt, Derek",0,900010
+WASHINGTON,Barnes Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000010
+WASHINGTON,Barnes Township,Commissioner of Insurance,,Republican,"Selzer, Ken",55,000010
+WASHINGTON,Brantford Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000020
+WASHINGTON,Brantford Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000020
+WASHINGTON,Charleston Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000030
+WASHINGTON,Charleston Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000030
+WASHINGTON,Clifton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",30,000040
+WASHINGTON,Clifton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",124,000040
+WASHINGTON,Coleman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000050
+WASHINGTON,Coleman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",21,000050
+WASHINGTON,Farmington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",15,000060
+WASHINGTON,Farmington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000060
+WASHINGTON,Franklin Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000070
+WASHINGTON,Franklin Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000070
+WASHINGTON,Grant Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000080
+WASHINGTON,Grant Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000080
+WASHINGTON,Greenleaf Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",25,000090
+WASHINGTON,Greenleaf Township,Commissioner of Insurance,,Republican,"Selzer, Ken",103,000090
+WASHINGTON,Haddam Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000100
+WASHINGTON,Haddam Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000100
+WASHINGTON,Hanover Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",62,000110
+WASHINGTON,Hanover Township,Commissioner of Insurance,,Republican,"Selzer, Ken",273,000110
+WASHINGTON,Highland Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000120
+WASHINGTON,Highland Township,Commissioner of Insurance,,Republican,"Selzer, Ken",12,000120
+WASHINGTON,Independence Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000130
+WASHINGTON,Independence Township,Commissioner of Insurance,,Republican,"Selzer, Ken",47,000130
+WASHINGTON,Kimeo Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",3,000140
+WASHINGTON,Kimeo Township,Commissioner of Insurance,,Republican,"Selzer, Ken",24,000140
+WASHINGTON,Lincoln Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000150
+WASHINGTON,Lincoln Township,Commissioner of Insurance,,Republican,"Selzer, Ken",20,000150
+WASHINGTON,Linn Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",27,000160
+WASHINGTON,Linn Township,Commissioner of Insurance,,Republican,"Selzer, Ken",158,000160
+WASHINGTON,Little Blue Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000170
+WASHINGTON,Little Blue Township,Commissioner of Insurance,,Republican,"Selzer, Ken",19,000170
+WASHINGTON,Logan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000180
+WASHINGTON,Logan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",44,000180
+WASHINGTON,Lowe Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",1,000190
+WASHINGTON,Lowe Township,Commissioner of Insurance,,Republican,"Selzer, Ken",17,000190
+WASHINGTON,Mill Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",10,000200
+WASHINGTON,Mill Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",69,000200
+WASHINGTON,Sheridan Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000210
+WASHINGTON,Sheridan Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000210
+WASHINGTON,Sherman Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000220
+WASHINGTON,Sherman Township,Commissioner of Insurance,,Republican,"Selzer, Ken",84,000220
+WASHINGTON,Strawberry Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000230
+WASHINGTON,Strawberry Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000230
+WASHINGTON,Union Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",6,000240
+WASHINGTON,Union Township,Commissioner of Insurance,,Republican,"Selzer, Ken",25,000240
+WASHINGTON,Washington Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",12,00025A
+WASHINGTON,Washington Township,Commissioner of Insurance,,Republican,"Selzer, Ken",88,00025A
+WASHINGTON,Washington Township Rural Enclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00025B
+WASHINGTON,Washington City,Commissioner of Insurance,,Democratic,"Anderson, Dennis",88,00026A
+WASHINGTON,Washington City,Commissioner of Insurance,,Republican,"Selzer, Ken",317,00026A
+WASHINGTON,Washington City Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00026B
+WASHINGTON,Washington City Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+WASHINGTON,Barnes Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000010
+WASHINGTON,Barnes Township,Secretary of State,,Republican,"Kobach, Kris",54,000010
+WASHINGTON,Brantford Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000020
+WASHINGTON,Brantford Township,Secretary of State,,Republican,"Kobach, Kris",34,000020
+WASHINGTON,Charleston Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000030
+WASHINGTON,Charleston Township,Secretary of State,,Republican,"Kobach, Kris",26,000030
+WASHINGTON,Clifton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000040
+WASHINGTON,Clifton Township,Secretary of State,,Republican,"Kobach, Kris",118,000040
+WASHINGTON,Coleman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000050
+WASHINGTON,Coleman Township,Secretary of State,,Republican,"Kobach, Kris",19,000050
+WASHINGTON,Farmington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000060
+WASHINGTON,Farmington Township,Secretary of State,,Republican,"Kobach, Kris",49,000060
+WASHINGTON,Franklin Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000070
+WASHINGTON,Franklin Township,Secretary of State,,Republican,"Kobach, Kris",32,000070
+WASHINGTON,Grant Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000080
+WASHINGTON,Grant Township,Secretary of State,,Republican,"Kobach, Kris",13,000080
+WASHINGTON,Greenleaf Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000090
+WASHINGTON,Greenleaf Township,Secretary of State,,Republican,"Kobach, Kris",103,000090
+WASHINGTON,Haddam Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000100
+WASHINGTON,Haddam Township,Secretary of State,,Republican,"Kobach, Kris",50,000100
+WASHINGTON,Hanover Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",68,000110
+WASHINGTON,Hanover Township,Secretary of State,,Republican,"Kobach, Kris",279,000110
+WASHINGTON,Highland Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",1,000120
+WASHINGTON,Highland Township,Secretary of State,,Republican,"Kobach, Kris",12,000120
+WASHINGTON,Independence Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",4,000130
+WASHINGTON,Independence Township,Secretary of State,,Republican,"Kobach, Kris",50,000130
+WASHINGTON,Kimeo Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",8,000140
+WASHINGTON,Kimeo Township,Secretary of State,,Republican,"Kobach, Kris",20,000140
+WASHINGTON,Lincoln Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",2,000150
+WASHINGTON,Lincoln Township,Secretary of State,,Republican,"Kobach, Kris",20,000150
+WASHINGTON,Linn Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",30,000160
+WASHINGTON,Linn Township,Secretary of State,,Republican,"Kobach, Kris",159,000160
+WASHINGTON,Little Blue Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000170
+WASHINGTON,Little Blue Township,Secretary of State,,Republican,"Kobach, Kris",26,000170
+WASHINGTON,Logan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",9,000180
+WASHINGTON,Logan Township,Secretary of State,,Republican,"Kobach, Kris",41,000180
+WASHINGTON,Lowe Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,000190
+WASHINGTON,Lowe Township,Secretary of State,,Republican,"Kobach, Kris",19,000190
+WASHINGTON,Mill Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",14,000200
+WASHINGTON,Mill Creek Township,Secretary of State,,Republican,"Kobach, Kris",71,000200
+WASHINGTON,Sheridan Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000210
+WASHINGTON,Sheridan Township,Secretary of State,,Republican,"Kobach, Kris",35,000210
+WASHINGTON,Sherman Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000220
+WASHINGTON,Sherman Township,Secretary of State,,Republican,"Kobach, Kris",90,000220
+WASHINGTON,Strawberry Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000230
+WASHINGTON,Strawberry Township,Secretary of State,,Republican,"Kobach, Kris",41,000230
+WASHINGTON,Union Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000240
+WASHINGTON,Union Township,Secretary of State,,Republican,"Kobach, Kris",24,000240
+WASHINGTON,Washington Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16,00025A
+WASHINGTON,Washington Township,Secretary of State,,Republican,"Kobach, Kris",88,00025A
+WASHINGTON,Washington Township Rural Enclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Secretary of State,,Republican,"Kobach, Kris",0,00025B
+WASHINGTON,Washington City,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",112,00026A
+WASHINGTON,Washington City,Secretary of State,,Republican,"Kobach, Kris",320,00026A
+WASHINGTON,Washington City Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00026B
+WASHINGTON,Washington City Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Secretary of State,,Republican,"Kobach, Kris",0,900010
+WASHINGTON,Barnes Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000010
+WASHINGTON,Barnes Township,State Treasurer,,Republican,"Estes, Ron",59,000010
+WASHINGTON,Brantford Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000020
+WASHINGTON,Brantford Township,State Treasurer,,Republican,"Estes, Ron",36,000020
+WASHINGTON,Charleston Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000030
+WASHINGTON,Charleston Township,State Treasurer,,Republican,"Estes, Ron",27,000030
+WASHINGTON,Clifton Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000040
+WASHINGTON,Clifton Township,State Treasurer,,Republican,"Estes, Ron",132,000040
+WASHINGTON,Coleman Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000050
+WASHINGTON,Coleman Township,State Treasurer,,Republican,"Estes, Ron",23,000050
+WASHINGTON,Farmington Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000060
+WASHINGTON,Farmington Township,State Treasurer,,Republican,"Estes, Ron",60,000060
+WASHINGTON,Franklin Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000070
+WASHINGTON,Franklin Township,State Treasurer,,Republican,"Estes, Ron",31,000070
+WASHINGTON,Grant Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000080
+WASHINGTON,Grant Township,State Treasurer,,Republican,"Estes, Ron",12,000080
+WASHINGTON,Greenleaf Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000090
+WASHINGTON,Greenleaf Township,State Treasurer,,Republican,"Estes, Ron",110,000090
+WASHINGTON,Haddam Township,State Treasurer,,Democratic,"Alldritt, Carmen",15,000100
+WASHINGTON,Haddam Township,State Treasurer,,Republican,"Estes, Ron",50,000100
+WASHINGTON,Hanover Township,State Treasurer,,Democratic,"Alldritt, Carmen",44,000110
+WASHINGTON,Hanover Township,State Treasurer,,Republican,"Estes, Ron",293,000110
+WASHINGTON,Highland Township,State Treasurer,,Democratic,"Alldritt, Carmen",1,000120
+WASHINGTON,Highland Township,State Treasurer,,Republican,"Estes, Ron",12,000120
+WASHINGTON,Independence Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000130
+WASHINGTON,Independence Township,State Treasurer,,Republican,"Estes, Ron",50,000130
+WASHINGTON,Kimeo Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000140
+WASHINGTON,Kimeo Township,State Treasurer,,Republican,"Estes, Ron",26,000140
+WASHINGTON,Lincoln Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000150
+WASHINGTON,Lincoln Township,State Treasurer,,Republican,"Estes, Ron",22,000150
+WASHINGTON,Linn Township,State Treasurer,,Democratic,"Alldritt, Carmen",24,000160
+WASHINGTON,Linn Township,State Treasurer,,Republican,"Estes, Ron",166,000160
+WASHINGTON,Little Blue Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,000170
+WASHINGTON,Little Blue Township,State Treasurer,,Republican,"Estes, Ron",26,000170
+WASHINGTON,Logan Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000180
+WASHINGTON,Logan Township,State Treasurer,,Republican,"Estes, Ron",47,000180
+WASHINGTON,Lowe Township,State Treasurer,,Democratic,"Alldritt, Carmen",0,000190
+WASHINGTON,Lowe Township,State Treasurer,,Republican,"Estes, Ron",19,000190
+WASHINGTON,Mill Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000200
+WASHINGTON,Mill Creek Township,State Treasurer,,Republican,"Estes, Ron",78,000200
+WASHINGTON,Sheridan Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000210
+WASHINGTON,Sheridan Township,State Treasurer,,Republican,"Estes, Ron",34,000210
+WASHINGTON,Sherman Township,State Treasurer,,Democratic,"Alldritt, Carmen",7,000220
+WASHINGTON,Sherman Township,State Treasurer,,Republican,"Estes, Ron",94,000220
+WASHINGTON,Strawberry Township,State Treasurer,,Democratic,"Alldritt, Carmen",2,000230
+WASHINGTON,Strawberry Township,State Treasurer,,Republican,"Estes, Ron",45,000230
+WASHINGTON,Union Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000240
+WASHINGTON,Union Township,State Treasurer,,Republican,"Estes, Ron",26,000240
+WASHINGTON,Washington Township,State Treasurer,,Democratic,"Alldritt, Carmen",9,00025A
+WASHINGTON,Washington Township,State Treasurer,,Republican,"Estes, Ron",96,00025A
+WASHINGTON,Washington Township Rural Enclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00025B
+WASHINGTON,Washington Township Rural Enclave,State Treasurer,,Republican,"Estes, Ron",0,00025B
+WASHINGTON,Washington City,State Treasurer,,Democratic,"Alldritt, Carmen",75,00026A
+WASHINGTON,Washington City,State Treasurer,,Republican,"Estes, Ron",351,00026A
+WASHINGTON,Washington City Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00026B
+WASHINGTON,Washington City Exclave,State Treasurer,,Republican,"Estes, Ron",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+WASHINGTON,Washington Township Rural Enclave B,State Treasurer,,Republican,"Estes, Ron",0,900010
+WASHINGTON,Barnes Township,United States Senate,,independent,"Orman, Greg",17,000010
+WASHINGTON,Barnes Township,United States Senate,,Libertarian,"Batson, Randall",2,000010
+WASHINGTON,Barnes Township,United States Senate,,Republican,"Roberts, Pat",56,000010
+WASHINGTON,Brantford Township,United States Senate,,independent,"Orman, Greg",4,000020
+WASHINGTON,Brantford Township,United States Senate,,Libertarian,"Batson, Randall",1,000020
+WASHINGTON,Brantford Township,United States Senate,,Republican,"Roberts, Pat",33,000020
+WASHINGTON,Charleston Township,United States Senate,,independent,"Orman, Greg",4,000030
+WASHINGTON,Charleston Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+WASHINGTON,Charleston Township,United States Senate,,Republican,"Roberts, Pat",30,000030
+WASHINGTON,Clifton Township,United States Senate,,independent,"Orman, Greg",38,000040
+WASHINGTON,Clifton Township,United States Senate,,Libertarian,"Batson, Randall",11,000040
+WASHINGTON,Clifton Township,United States Senate,,Republican,"Roberts, Pat",112,000040
+WASHINGTON,Coleman Township,United States Senate,,independent,"Orman, Greg",4,000050
+WASHINGTON,Coleman Township,United States Senate,,Libertarian,"Batson, Randall",0,000050
+WASHINGTON,Coleman Township,United States Senate,,Republican,"Roberts, Pat",20,000050
+WASHINGTON,Farmington Township,United States Senate,,independent,"Orman, Greg",23,000060
+WASHINGTON,Farmington Township,United States Senate,,Libertarian,"Batson, Randall",4,000060
+WASHINGTON,Farmington Township,United States Senate,,Republican,"Roberts, Pat",46,000060
+WASHINGTON,Franklin Township,United States Senate,,independent,"Orman, Greg",11,000070
+WASHINGTON,Franklin Township,United States Senate,,Libertarian,"Batson, Randall",3,000070
+WASHINGTON,Franklin Township,United States Senate,,Republican,"Roberts, Pat",31,000070
+WASHINGTON,Grant Township,United States Senate,,independent,"Orman, Greg",2,000080
+WASHINGTON,Grant Township,United States Senate,,Libertarian,"Batson, Randall",1,000080
+WASHINGTON,Grant Township,United States Senate,,Republican,"Roberts, Pat",12,000080
+WASHINGTON,Greenleaf Township,United States Senate,,independent,"Orman, Greg",35,000090
+WASHINGTON,Greenleaf Township,United States Senate,,Libertarian,"Batson, Randall",8,000090
+WASHINGTON,Greenleaf Township,United States Senate,,Republican,"Roberts, Pat",89,000090
+WASHINGTON,Haddam Township,United States Senate,,independent,"Orman, Greg",20,000100
+WASHINGTON,Haddam Township,United States Senate,,Libertarian,"Batson, Randall",3,000100
+WASHINGTON,Haddam Township,United States Senate,,Republican,"Roberts, Pat",46,000100
+WASHINGTON,Hanover Township,United States Senate,,independent,"Orman, Greg",72,000110
+WASHINGTON,Hanover Township,United States Senate,,Libertarian,"Batson, Randall",15,000110
+WASHINGTON,Hanover Township,United States Senate,,Republican,"Roberts, Pat",267,000110
+WASHINGTON,Highland Township,United States Senate,,independent,"Orman, Greg",3,000120
+WASHINGTON,Highland Township,United States Senate,,Libertarian,"Batson, Randall",0,000120
+WASHINGTON,Highland Township,United States Senate,,Republican,"Roberts, Pat",10,000120
+WASHINGTON,Independence Township,United States Senate,,independent,"Orman, Greg",8,000130
+WASHINGTON,Independence Township,United States Senate,,Libertarian,"Batson, Randall",1,000130
+WASHINGTON,Independence Township,United States Senate,,Republican,"Roberts, Pat",45,000130
+WASHINGTON,Kimeo Township,United States Senate,,independent,"Orman, Greg",9,000140
+WASHINGTON,Kimeo Township,United States Senate,,Libertarian,"Batson, Randall",0,000140
+WASHINGTON,Kimeo Township,United States Senate,,Republican,"Roberts, Pat",19,000140
+WASHINGTON,Lincoln Township,United States Senate,,independent,"Orman, Greg",1,000150
+WASHINGTON,Lincoln Township,United States Senate,,Libertarian,"Batson, Randall",1,000150
+WASHINGTON,Lincoln Township,United States Senate,,Republican,"Roberts, Pat",20,000150
+WASHINGTON,Linn Township,United States Senate,,independent,"Orman, Greg",32,000160
+WASHINGTON,Linn Township,United States Senate,,Libertarian,"Batson, Randall",9,000160
+WASHINGTON,Linn Township,United States Senate,,Republican,"Roberts, Pat",152,000160
+WASHINGTON,Little Blue Township,United States Senate,,independent,"Orman, Greg",15,000170
+WASHINGTON,Little Blue Township,United States Senate,,Libertarian,"Batson, Randall",0,000170
+WASHINGTON,Little Blue Township,United States Senate,,Republican,"Roberts, Pat",20,000170
+WASHINGTON,Logan Township,United States Senate,,independent,"Orman, Greg",12,000180
+WASHINGTON,Logan Township,United States Senate,,Libertarian,"Batson, Randall",3,000180
+WASHINGTON,Logan Township,United States Senate,,Republican,"Roberts, Pat",36,000180
+WASHINGTON,Lowe Township,United States Senate,,independent,"Orman, Greg",0,000190
+WASHINGTON,Lowe Township,United States Senate,,Libertarian,"Batson, Randall",0,000190
+WASHINGTON,Lowe Township,United States Senate,,Republican,"Roberts, Pat",20,000190
+WASHINGTON,Mill Creek Township,United States Senate,,independent,"Orman, Greg",18,000200
+WASHINGTON,Mill Creek Township,United States Senate,,Libertarian,"Batson, Randall",5,000200
+WASHINGTON,Mill Creek Township,United States Senate,,Republican,"Roberts, Pat",65,000200
+WASHINGTON,Sheridan Township,United States Senate,,independent,"Orman, Greg",7,000210
+WASHINGTON,Sheridan Township,United States Senate,,Libertarian,"Batson, Randall",3,000210
+WASHINGTON,Sheridan Township,United States Senate,,Republican,"Roberts, Pat",32,000210
+WASHINGTON,Sherman Township,United States Senate,,independent,"Orman, Greg",19,000220
+WASHINGTON,Sherman Township,United States Senate,,Libertarian,"Batson, Randall",4,000220
+WASHINGTON,Sherman Township,United States Senate,,Republican,"Roberts, Pat",80,000220
+WASHINGTON,Strawberry Township,United States Senate,,independent,"Orman, Greg",4,000230
+WASHINGTON,Strawberry Township,United States Senate,,Libertarian,"Batson, Randall",3,000230
+WASHINGTON,Strawberry Township,United States Senate,,Republican,"Roberts, Pat",41,000230
+WASHINGTON,Union Township,United States Senate,,independent,"Orman, Greg",8,000240
+WASHINGTON,Union Township,United States Senate,,Libertarian,"Batson, Randall",1,000240
+WASHINGTON,Union Township,United States Senate,,Republican,"Roberts, Pat",22,000240
+WASHINGTON,Washington Township,United States Senate,,independent,"Orman, Greg",19,00025A
+WASHINGTON,Washington Township,United States Senate,,Libertarian,"Batson, Randall",1,00025A
+WASHINGTON,Washington Township,United States Senate,,Republican,"Roberts, Pat",87,00025A
+WASHINGTON,Washington Township Rural Enclave,United States Senate,,independent,"Orman, Greg",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States Senate,,Libertarian,"Batson, Randall",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States Senate,,Republican,"Roberts, Pat",0,00025B
+WASHINGTON,Washington City,United States Senate,,independent,"Orman, Greg",111,00026A
+WASHINGTON,Washington City,United States Senate,,Libertarian,"Batson, Randall",34,00026A
+WASHINGTON,Washington City,United States Senate,,Republican,"Roberts, Pat",293,00026A
+WASHINGTON,Washington City Exclave,United States Senate,,independent,"Orman, Greg",0,00026B
+WASHINGTON,Washington City Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00026B
+WASHINGTON,Washington City Exclave,United States Senate,,Republican,"Roberts, Pat",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,United States Senate,,independent,"Orman, Greg",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States Senate,,Libertarian,"Batson, Randall",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States Senate,,Republican,"Roberts, Pat",0,900010

--- a/2014/20141104__ks__general__wichita__precinct.csv
+++ b/2014/20141104__ks__general__wichita__precinct.csv
@@ -1,69 +1,52 @@
-county,precinct,office,district,party,candidate,votes
-Wichita,PRECINCT 1,Attorney General,,,A.J. Kotich,35
-Wichita,PRECINCT 2,Attorney General,,,A.J. Kotich,33
-Wichita,PRECINCT 3,Attorney General,,,A.J. Kotich,17
-Wichita,ADVANCE,Attorney General,,,A.J. Kotich,7
-Wichita,PRECINCT 1,Attorney General,,,Derek Schmidt,187
-Wichita,PRECINCT 2,Attorney General,,,Derek Schmidt,254
-Wichita,PRECINCT 3,Attorney General,,,Derek Schmidt,173
-Wichita,ADVANCE,Attorney General,,,Derek Schmidt,44
-Wichita,PRECINCT 1,U.S. House,1,,James Sherow,38
-Wichita,PRECINCT 2,U.S. House,1,,James Sherow,44
-Wichita,PRECINCT 3,U.S. House,1,,James Sherow,21
-Wichita,ADVANCE,U.S. House,1,,James Sherow,11
-Wichita,PRECINCT 1,U.S. House,1,,Tim Huelskamp,183
-Wichita,PRECINCT 2,U.S. House,1,,Tim Huelskamp,243
-Wichita,PRECINCT 3,U.S. House,1,,Tim Huelskamp,177
-Wichita,ADVANCE,U.S. House,1,,Tim Huelskamp,41
-Wichita,PRECINCT 1,Governor,,,Brownback/Colyer,168
-Wichita,PRECINCT 2,Governor,,,Brownback/Colyer,226
-Wichita,PRECINCT 3,Governor,,,Brownback/Colyer,164
-Wichita,ADVANCE,Governor,,,Brownback/Colyer,38
-Wichita,PRECINCT 1,Governor,,,Davis/Docking,47
-Wichita,PRECINCT 2,Governor,,,Davis/Docking,54
-Wichita,PRECINCT 3,Governor,,,Davis/Docking,26
-Wichita,ADVANCE,Governor,,,Davis/Docking,9
-Wichita,PRECINCT 1,Governor,,,Umbehr/Umbehr,11
-Wichita,PRECINCT 2,Governor,,,Umbehr/Umbehr,9
-Wichita,PRECINCT 3,Governor,,,Umbehr/Umbehr,6
-Wichita,ADVANCE,Governor,,,Umbehr/Umbehr,5
-Wichita,PRECINCT 1,Insurance Commissioner,,,Dennis Anderson,36
-Wichita,PRECINCT 2,Insurance Commissioner,,,Dennis Anderson,35
-Wichita,PRECINCT 3,Insurance Commissioner,,,Dennis Anderson,26
-Wichita,ADVANCE,Insurance Commissioner,,,Dennis Anderson,8
-Wichita,PRECINCT 1,Insurance Commissioner,,,Ken Selzer,176
-Wichita,PRECINCT 2,Insurance Commissioner,,,Ken Selzer,246
-Wichita,PRECINCT 3,Insurance Commissioner,,,Ken Selzer,162
-Wichita,ADVANCE,Insurance Commissioner,,,Ken Selzer,42
-Wichita,PRECINCT 1,Secretary of State,,,Jean Kurtis Schodorf,47
-Wichita,PRECINCT 2,Secretary of State,,,Jean Kurtis Schodorf,36
-Wichita,PRECINCT 3,Secretary of State,,,Jean Kurtis Schodorf,22
-Wichita,ADVANCE,Secretary of State,,,Jean Kurtis Schodorf,11
-Wichita,PRECINCT 1,Secretary of State,,,Kris Kobach,181
-Wichita,PRECINCT 2,Secretary of State,,,Kris Kobach,253
-Wichita,PRECINCT 3,Secretary of State,,,Kris Kobach,176
-Wichita,ADVANCE,Secretary of State,,,Kris Kobach,41
-Wichita,PRECINCT 1,State House,118,,Don Hineman,208
-Wichita,PRECINCT 2,State House,118,,Don Hineman,266
-Wichita,PRECINCT 3,State House,118,,Don Hineman,183
-Wichita,ADVANCE,State House,118,,Don Hineman,50
-Wichita,PRECINCT 1,State Treasurer,,,Carmen Alldritt,27
-Wichita,PRECINCT 2,State Treasurer,,,Carmen Alldritt,25
-Wichita,PRECINCT 3,State Treasurer,,,Carmen Alldritt,20
-Wichita,ADVANCE,State Treasurer,,,Carmen Alldritt,6
-Wichita,PRECINCT 1,State Treasurer,,,Ron Estes,195
-Wichita,PRECINCT 2,State Treasurer,,,Ron Estes,264
-Wichita,PRECINCT 3,State Treasurer,,,Ron Estes,173
-Wichita,ADVANCE,State Treasurer,,,Ron Estes,46
-Wichita,PRECINCT 1,U.S. Senate,,,Greg Orman,45
-Wichita,PRECINCT 2,U.S. Senate,,,Greg Orman,40
-Wichita,PRECINCT 3,U.S. Senate,,,Greg Orman,21
-Wichita,ADVANCE,U.S. Senate,,,Greg Orman,9
-Wichita,PRECINCT 1,U.S. Senate,,,Pat Roberts,170
-Wichita,PRECINCT 2,U.S. Senate,,,Pat Roberts,235
-Wichita,PRECINCT 3,U.S. Senate,,,Pat Roberts,170
-Wichita,ADVANCE,U.S. Senate,,,Pat Roberts,42
-Wichita,PRECINCT 1,U.S. Senate,,,Randall Batson,10
-Wichita,PRECINCT 2,U.S. Senate,,,Randall Batson,14
-Wichita,PRECINCT 3,U.S. Senate,,,Randall Batson,6
-Wichita,ADVANCE,U.S. Senate,,,Randall Batson,1
+county,precinct,office,district,party,candidate,votes,vtd
+WICHITA,Leoti Precinct 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",50,000010
+WICHITA,Leoti Precinct 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000010
+WICHITA,Leoti Precinct 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",178,000010
+WICHITA,Leoti Precinct 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",55,000020
+WICHITA,Leoti Precinct 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",10,000020
+WICHITA,Leoti Precinct 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",247,000020
+WICHITA,Leoti Precinct 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000030
+WICHITA,Leoti Precinct 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000030
+WICHITA,Leoti Precinct 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",171,000030
+WICHITA,Leoti Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",223,000010
+WICHITA,Leoti Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",288,000020
+WICHITA,Leoti Precinct 3,Kansas House of Representatives,118,Republican,"Hineman, Don",196,000030
+WICHITA,Leoti Precinct 1,United States House of Representatives,1,Democratic,"Sherow, James E.",42,000010
+WICHITA,Leoti Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",195,000010
+WICHITA,Leoti Precinct 2,United States House of Representatives,1,Democratic,"Sherow, James E.",45,000020
+WICHITA,Leoti Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",265,000020
+WICHITA,Leoti Precinct 3,United States House of Representatives,1,Democratic,"Sherow, James E.",27,000030
+WICHITA,Leoti Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",184,000030
+WICHITA,Leoti Precinct 1,Attorney General,,Democratic,"Kotich, A.J.",37,000010
+WICHITA,Leoti Precinct 1,Attorney General,,Republican,"Schmidt, Derek",201,000010
+WICHITA,Leoti Precinct 2,Attorney General,,Democratic,"Kotich, A.J.",34,000020
+WICHITA,Leoti Precinct 2,Attorney General,,Republican,"Schmidt, Derek",275,000020
+WICHITA,Leoti Precinct 3,Attorney General,,Democratic,"Kotich, A.J.",21,000030
+WICHITA,Leoti Precinct 3,Attorney General,,Republican,"Schmidt, Derek",182,000030
+WICHITA,Leoti Precinct 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000010
+WICHITA,Leoti Precinct 1,Commissioner of Insurance,,Republican,"Selzer, Ken",189,000010
+WICHITA,Leoti Precinct 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",36,000020
+WICHITA,Leoti Precinct 2,Commissioner of Insurance,,Republican,"Selzer, Ken",268,000020
+WICHITA,Leoti Precinct 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000030
+WICHITA,Leoti Precinct 3,Commissioner of Insurance,,Republican,"Selzer, Ken",169,000030
+WICHITA,Leoti Precinct 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",52,000010
+WICHITA,Leoti Precinct 1,Secretary of State,,Republican,"Kobach, Kris",193,000010
+WICHITA,Leoti Precinct 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",37,000020
+WICHITA,Leoti Precinct 2,Secretary of State,,Republican,"Kobach, Kris",275,000020
+WICHITA,Leoti Precinct 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",27,000030
+WICHITA,Leoti Precinct 3,Secretary of State,,Republican,"Kobach, Kris",183,000030
+WICHITA,Leoti Precinct 1,State Treasurer,,Democratic,"Alldritt, Carmen",28,000010
+WICHITA,Leoti Precinct 1,State Treasurer,,Republican,"Estes, Ron",210,000010
+WICHITA,Leoti Precinct 2,State Treasurer,,Democratic,"Alldritt, Carmen",26,000020
+WICHITA,Leoti Precinct 2,State Treasurer,,Republican,"Estes, Ron",285,000020
+WICHITA,Leoti Precinct 3,State Treasurer,,Democratic,"Alldritt, Carmen",24,000030
+WICHITA,Leoti Precinct 3,State Treasurer,,Republican,"Estes, Ron",183,000030
+WICHITA,Leoti Precinct 1,United States Senate,,independent,"Orman, Greg",48,000010
+WICHITA,Leoti Precinct 1,United States Senate,,Libertarian,"Batson, Randall",11,000010
+WICHITA,Leoti Precinct 1,United States Senate,,Republican,"Roberts, Pat",182,000010
+WICHITA,Leoti Precinct 2,United States Senate,,independent,"Orman, Greg",41,000020
+WICHITA,Leoti Precinct 2,United States Senate,,Libertarian,"Batson, Randall",14,000020
+WICHITA,Leoti Precinct 2,United States Senate,,Republican,"Roberts, Pat",257,000020
+WICHITA,Leoti Precinct 3,United States Senate,,independent,"Orman, Greg",26,000030
+WICHITA,Leoti Precinct 3,United States Senate,,Libertarian,"Batson, Randall",6,000030
+WICHITA,Leoti Precinct 3,United States Senate,,Republican,"Roberts, Pat",178,000030

--- a/2014/20141104__ks__general__wilson__precinct.csv
+++ b/2014/20141104__ks__general__wilson__precinct.csv
@@ -1,433 +1,523 @@
-county,precinct,office,district,party,candidate,votes
-Wilson,Cedar,U.S. Senate,,R,Pat Roberts,119
-Wilson,Center,U.S. Senate,,R,Pat Roberts,136
-Wilson,Chetopa,U.S. Senate,,R,Pat Roberts,53
-Wilson,Clifton,U.S. Senate,,R,Pat Roberts,65
-Wilson,Colfax,U.S. Senate,,R,Pat Roberts,100
-Wilson,Duck Creek,U.S. Senate,,R,Pat Roberts,29
-Wilson,Fall River,U.S. Senate,,R,Pat Roberts,112
-Wilson,Fredonia 1,U.S. Senate,,R,Pat Roberts,104
-Wilson,Fredonia 2,U.S. Senate,,R,Pat Roberts,42
-Wilson,Fredonia 3,U.S. Senate,,R,Pat Roberts,56
-Wilson,Fredonia 4,U.S. Senate,,R,Pat Roberts,215
-Wilson,Guilford,U.S. Senate,,R,Pat Roberts,43
-Wilson,Neodesha 1,U.S. Senate,,R,Pat Roberts,81
-Wilson,Neodesha 2,U.S. Senate,,R,Pat Roberts,78
-Wilson,Neodesha 3,U.S. Senate,,R,Pat Roberts,57
-Wilson,Neodesha 4,U.S. Senate,,R,Pat Roberts,145
-Wilson,Neodesha twp,U.S. Senate,,R,Pat Roberts,130
-Wilson,Newark,U.S. Senate,,R,Pat Roberts,56
-Wilson,Pleas Valley,U.S. Senate,,R,Pat Roberts,46
-Wilson,Prairie,U.S. Senate,,R,Pat Roberts,32
-Wilson,Talleyrand,U.S. Senate,,R,Pat Roberts,38
-Wilson,Verdigris,U.S. Senate,,R,Pat Roberts,45
-Wilson,Webster,U.S. Senate,,R,Pat Roberts,13
-Wilson,Adv/Prov,U.S. Senate,,R,Pat Roberts,4
-Wilson,Cedar,U.S. Senate,,Ind,Greg Orman,22
-Wilson,Center,U.S. Senate,,Ind,Greg Orman,53
-Wilson,Chetopa,U.S. Senate,,Ind,Greg Orman,10
-Wilson,Clifton,U.S. Senate,,Ind,Greg Orman,17
-Wilson,Colfax,U.S. Senate,,Ind,Greg Orman,41
-Wilson,Duck Creek,U.S. Senate,,Ind,Greg Orman,5
-Wilson,Fall River,U.S. Senate,,Ind,Greg Orman,12
-Wilson,Fredonia 1,U.S. Senate,,Ind,Greg Orman,40
-Wilson,Fredonia 2,U.S. Senate,,Ind,Greg Orman,15
-Wilson,Fredonia 3,U.S. Senate,,Ind,Greg Orman,14
-Wilson,Fredonia 4,U.S. Senate,,Ind,Greg Orman,93
-Wilson,Guilford,U.S. Senate,,Ind,Greg Orman,8
-Wilson,Neodesha 1,U.S. Senate,,Ind,Greg Orman,48
-Wilson,Neodesha 2,U.S. Senate,,Ind,Greg Orman,32
-Wilson,Neodesha 3,U.S. Senate,,Ind,Greg Orman,33
-Wilson,Neodesha 4,U.S. Senate,,Ind,Greg Orman,80
-Wilson,Neodesha twp,U.S. Senate,,Ind,Greg Orman,47
-Wilson,Newark,U.S. Senate,,Ind,Greg Orman,18
-Wilson,Pleas Valley,U.S. Senate,,Ind,Greg Orman,21
-Wilson,Prairie,U.S. Senate,,Ind,Greg Orman,7
-Wilson,Talleyrand,U.S. Senate,,Ind,Greg Orman,9
-Wilson,Verdigris,U.S. Senate,,Ind,Greg Orman,20
-Wilson,Webster,U.S. Senate,,Ind,Greg Orman,8
-Wilson,Adv/Prov,U.S. Senate,,Ind,Greg Orman,3
-Wilson,Cedar,U.S. Senate,,L,Randall Batson,9
-Wilson,Center,U.S. Senate,,L,Randall Batson,8
-Wilson,Chetopa,U.S. Senate,,L,Randall Batson,2
-Wilson,Clifton,U.S. Senate,,L,Randall Batson,9
-Wilson,Colfax,U.S. Senate,,L,Randall Batson,9
-Wilson,Duck Creek,U.S. Senate,,L,Randall Batson,0
-Wilson,Fall River,U.S. Senate,,L,Randall Batson,7
-Wilson,Fredonia 1,U.S. Senate,,L,Randall Batson,6
-Wilson,Fredonia 2,U.S. Senate,,L,Randall Batson,5
-Wilson,Fredonia 3,U.S. Senate,,L,Randall Batson,5
-Wilson,Fredonia 4,U.S. Senate,,L,Randall Batson,20
-Wilson,Guilford,U.S. Senate,,L,Randall Batson,1
-Wilson,Neodesha 1,U.S. Senate,,L,Randall Batson,12
-Wilson,Neodesha 2,U.S. Senate,,L,Randall Batson,11
-Wilson,Neodesha 3,U.S. Senate,,L,Randall Batson,3
-Wilson,Neodesha 4,U.S. Senate,,L,Randall Batson,13
-Wilson,Neodesha twp,U.S. Senate,,L,Randall Batson,6
-Wilson,Newark,U.S. Senate,,L,Randall Batson,4
-Wilson,Pleas Valley,U.S. Senate,,L,Randall Batson,2
-Wilson,Prairie,U.S. Senate,,L,Randall Batson,2
-Wilson,Talleyrand,U.S. Senate,,L,Randall Batson,3
-Wilson,Verdigris,U.S. Senate,,L,Randall Batson,9
-Wilson,Webster,U.S. Senate,,L,Randall Batson,0
-Wilson,Adv/Prov,U.S. Senate,,L,Randall Batson,1
-Wilson,Cedar,U.S. House,2,R,Lynn Jenkins,127
-Wilson,Center,U.S. House,2,R,Lynn Jenkins,160
-Wilson,Chetopa,U.S. House,2,R,Lynn Jenkins,55
-Wilson,Clifton,U.S. House,2,R,Lynn Jenkins,67
-Wilson,Colfax,U.S. House,2,R,Lynn Jenkins,116
-Wilson,Duck Creek,U.S. House,2,R,Lynn Jenkins,31
-Wilson,Fall River,U.S. House,2,R,Lynn Jenkins,118
-Wilson,Fredonia 1,U.S. House,2,R,Lynn Jenkins,107
-Wilson,Fredonia 2,U.S. House,2,R,Lynn Jenkins,50
-Wilson,Fredonia 3,U.S. House,2,R,Lynn Jenkins,63
-Wilson,Fredonia 4,U.S. House,2,R,Lynn Jenkins,246
-Wilson,Guilford,U.S. House,2,R,Lynn Jenkins,47
-Wilson,Neodesha 1,U.S. House,2,R,Lynn Jenkins,104
-Wilson,Neodesha 2,U.S. House,2,R,Lynn Jenkins,82
-Wilson,Neodesha 3,U.S. House,2,R,Lynn Jenkins,66
-Wilson,Neodesha 4,U.S. House,2,R,Lynn Jenkins,173
-Wilson,Neodesha twp,U.S. House,2,R,Lynn Jenkins,153
-Wilson,Newark,U.S. House,2,R,Lynn Jenkins,65
-Wilson,Pleas Valley,U.S. House,2,R,Lynn Jenkins,51
-Wilson,Prairie,U.S. House,2,R,Lynn Jenkins,36
-Wilson,Talleyrand,U.S. House,2,R,Lynn Jenkins,43
-Wilson,Verdigris,U.S. House,2,R,Lynn Jenkins,52
-Wilson,Webster,U.S. House,2,R,Lynn Jenkins,16
-Wilson,Adv/Prov,U.S. House,2,R,Lynn Jenkins,6
-Wilson,Cedar,U.S. House,2,D,Margie Wakefield,14
-Wilson,Center,U.S. House,2,D,Margie Wakefield,34
-Wilson,Chetopa,U.S. House,2,D,Margie Wakefield,7
-Wilson,Clifton,U.S. House,2,D,Margie Wakefield,17
-Wilson,Colfax,U.S. House,2,D,Margie Wakefield,28
-Wilson,Duck Creek,U.S. House,2,D,Margie Wakefield,2
-Wilson,Fall River,U.S. House,2,D,Margie Wakefield,9
-Wilson,Fredonia 1,U.S. House,2,D,Margie Wakefield,39
-Wilson,Fredonia 2,U.S. House,2,D,Margie Wakefield,12
-Wilson,Fredonia 3,U.S. House,2,D,Margie Wakefield,6
-Wilson,Fredonia 4,U.S. House,2,D,Margie Wakefield,77
-Wilson,Guilford,U.S. House,2,D,Margie Wakefield,5
-Wilson,Neodesha 1,U.S. House,2,D,Margie Wakefield,31
-Wilson,Neodesha 2,U.S. House,2,D,Margie Wakefield,31
-Wilson,Neodesha 3,U.S. House,2,D,Margie Wakefield,23
-Wilson,Neodesha 4,U.S. House,2,D,Margie Wakefield,55
-Wilson,Neodesha twp,U.S. House,2,D,Margie Wakefield,26
-Wilson,Newark,U.S. House,2,D,Margie Wakefield,9
-Wilson,Pleas Valley,U.S. House,2,D,Margie Wakefield,18
-Wilson,Prairie,U.S. House,2,D,Margie Wakefield,4
-Wilson,Talleyrand,U.S. House,2,D,Margie Wakefield,6
-Wilson,Verdigris,U.S. House,2,D,Margie Wakefield,17
-Wilson,Webster,U.S. House,2,D,Margie Wakefield,5
-Wilson,Adv/Prov,U.S. House,2,D,Margie Wakefield,2
-Wilson,Cedar,U.S. House,2,L,Christopher Clemmons,9
-Wilson,Center,U.S. House,2,L,Christopher Clemmons,5
-Wilson,Chetopa,U.S. House,2,L,Christopher Clemmons,3
-Wilson,Clifton,U.S. House,2,L,Christopher Clemmons,6
-Wilson,Colfax,U.S. House,2,L,Christopher Clemmons,10
-Wilson,Duck Creek,U.S. House,2,L,Christopher Clemmons,0
-Wilson,Fall River,U.S. House,2,L,Christopher Clemmons,5
-Wilson,Fredonia 1,U.S. House,2,L,Christopher Clemmons,6
-Wilson,Fredonia 2,U.S. House,2,L,Christopher Clemmons,1
-Wilson,Fredonia 3,U.S. House,2,L,Christopher Clemmons,5
-Wilson,Fredonia 4,U.S. House,2,L,Christopher Clemmons,14
-Wilson,Guilford,U.S. House,2,L,Christopher Clemmons,1
-Wilson,Neodesha 1,U.S. House,2,L,Christopher Clemmons,6
-Wilson,Neodesha 2,U.S. House,2,L,Christopher Clemmons,9
-Wilson,Neodesha 3,U.S. House,2,L,Christopher Clemmons,4
-Wilson,Neodesha 4,U.S. House,2,L,Christopher Clemmons,14
-Wilson,Neodesha twp,U.S. House,2,L,Christopher Clemmons,6
-Wilson,Newark,U.S. House,2,L,Christopher Clemmons,4
-Wilson,Pleas Valley,U.S. House,2,L,Christopher Clemmons,1
-Wilson,Prairie,U.S. House,2,L,Christopher Clemmons,2
-Wilson,Talleyrand,U.S. House,2,L,Christopher Clemmons,1
-Wilson,Verdigris,U.S. House,2,L,Christopher Clemmons,5
-Wilson,Webster,U.S. House,2,L,Christopher Clemmons,0
-Wilson,Adv/Prov,U.S. House,2,L,Christopher Clemmons,0
-Wilson,Cedar,Governor,,D,Paul Davis,23
-Wilson,Center,Governor,,D,Paul Davis,72
-Wilson,Chetopa,Governor,,D,Paul Davis,7
-Wilson,Clifton,Governor,,D,Paul Davis,22
-Wilson,Colfax,Governor,,D,Paul Davis,55
-Wilson,Duck Creek,Governor,,D,Paul Davis,5
-Wilson,Fall River,Governor,,D,Paul Davis,14
-Wilson,Fredonia 1,Governor,,D,Paul Davis,67
-Wilson,Fredonia 2,Governor,,D,Paul Davis,19
-Wilson,Fredonia 3,Governor,,D,Paul Davis,18
-Wilson,Fredonia 4,Governor,,D,Paul Davis,123
-Wilson,Guilford,Governor,,D,Paul Davis,10
-Wilson,Neodesha 1,Governor,,D,Paul Davis,45
-Wilson,Neodesha 2,Governor,,D,Paul Davis,44
-Wilson,Neodesha 3,Governor,,D,Paul Davis,31
-Wilson,Neodesha 4,Governor,,D,Paul Davis,92
-Wilson,Neodesha twp,Governor,,D,Paul Davis,53
-Wilson,Newark,Governor,,D,Paul Davis,20
-Wilson,Pleas Valley,Governor,,D,Paul Davis,27
-Wilson,Prairie,Governor,,D,Paul Davis,7
-Wilson,Talleyrand,Governor,,D,Paul Davis,11
-Wilson,Verdigris,Governor,,D,Paul Davis,26
-Wilson,Webster,Governor,,D,Paul Davis,13
-Wilson,Adv/Prov,Governor,,D,Paul Davis,2
-Wilson,Cedar,Governor,,R,Sam Brownback,115
-Wilson,Center,Governor,,R,Sam Brownback,121
-Wilson,Chetopa,Governor,,R,Sam Brownback,57
-Wilson,Clifton,Governor,,R,Sam Brownback,63
-Wilson,Colfax,Governor,,R,Sam Brownback,94
-Wilson,Duck Creek,Governor,,R,Sam Brownback,28
-Wilson,Fall River,Governor,,R,Sam Brownback,106
-Wilson,Fredonia 1,Governor,,R,Sam Brownback,79
-Wilson,Fredonia 2,Governor,,R,Sam Brownback,43
-Wilson,Fredonia 3,Governor,,R,Sam Brownback,55
-Wilson,Fredonia 4,Governor,,R,Sam Brownback,199
-Wilson,Guilford,Governor,,R,Sam Brownback,43
-Wilson,Neodesha 1,Governor,,R,Sam Brownback,84
-Wilson,Neodesha 2,Governor,,R,Sam Brownback,70
-Wilson,Neodesha 3,Governor,,R,Sam Brownback,59
-Wilson,Neodesha 4,Governor,,R,Sam Brownback,143
-Wilson,Neodesha twp,Governor,,R,Sam Brownback,126
-Wilson,Newark,Governor,,R,Sam Brownback,55
-Wilson,Pleas Valley,Governor,,R,Sam Brownback,39
-Wilson,Prairie,Governor,,R,Sam Brownback,33
-Wilson,Talleyrand,Governor,,R,Sam Brownback,38
-Wilson,Verdigris,Governor,,R,Sam Brownback,40
-Wilson,Webster,Governor,,R,Sam Brownback,8
-Wilson,Adv/Prov,Governor,,R,Sam Brownback,5
-Wilson,Cedar,Governor,,L,Keen Umbehr,13
-Wilson,Center,Governor,,L,Keen Umbehr,3
-Wilson,Chetopa,Governor,,L,Keen Umbehr,1
-Wilson,Clifton,Governor,,L,Keen Umbehr,5
-Wilson,Colfax,Governor,,L,Keen Umbehr,4
-Wilson,Duck Creek,Governor,,L,Keen Umbehr,0
-Wilson,Fall River,Governor,,L,Keen Umbehr,9
-Wilson,Fredonia 1,Governor,,L,Keen Umbehr,6
-Wilson,Fredonia 2,Governor,,L,Keen Umbehr,2
-Wilson,Fredonia 3,Governor,,L,Keen Umbehr,4
-Wilson,Fredonia 4,Governor,,L,Keen Umbehr,13
-Wilson,Guilford,Governor,,L,Keen Umbehr,0
-Wilson,Neodesha 1,Governor,,L,Keen Umbehr,12
-Wilson,Neodesha 2,Governor,,L,Keen Umbehr,7
-Wilson,Neodesha 3,Governor,,L,Keen Umbehr,3
-Wilson,Neodesha 4,Governor,,L,Keen Umbehr,3
-Wilson,Neodesha twp,Governor,,L,Keen Umbehr,2
-Wilson,Newark,Governor,,L,Keen Umbehr,3
-Wilson,Pleas Valley,Governor,,L,Keen Umbehr,3
-Wilson,Prairie,Governor,,L,Keen Umbehr,2
-Wilson,Talleyrand,Governor,,L,Keen Umbehr,1
-Wilson,Verdigris,Governor,,L,Keen Umbehr,9
-Wilson,Webster,Governor,,L,Keen Umbehr,0
-Wilson,Adv/Prov,Governor,,L,Keen Umbehr,1
-Wilson,Cedar,Secretary of State,,R,Kris Kobach,130
-Wilson,Center,Secretary of State,,R,Kris Kobach,143
-Wilson,Chetopa,Secretary of State,,R,Kris Kobach,58
-Wilson,Clifton,Secretary of State,,R,Kris Kobach,68
-Wilson,Colfax,Secretary of State,,R,Kris Kobach,109
-Wilson,Duck Creek,Secretary of State,,R,Kris Kobach,30
-Wilson,Fall River,Secretary of State,,R,Kris Kobach,114
-Wilson,Fredonia 1,Secretary of State,,R,Kris Kobach,91
-Wilson,Fredonia 2,Secretary of State,,R,Kris Kobach,39
-Wilson,Fredonia 3,Secretary of State,,R,Kris Kobach,58
-Wilson,Fredonia 4,Secretary of State,,R,Kris Kobach,230
-Wilson,Guilford,Secretary of State,,R,Kris Kobach,47
-Wilson,Neodesha 1,Secretary of State,,R,Kris Kobach,99
-Wilson,Neodesha 2,Secretary of State,,R,Kris Kobach,78
-Wilson,Neodesha 3,Secretary of State,,R,Kris Kobach,69
-Wilson,Neodesha 4,Secretary of State,,R,Kris Kobach,156
-Wilson,Neodesha twp,Secretary of State,,R,Kris Kobach,140
-Wilson,Newark,Secretary of State,,R,Kris Kobach,70
-Wilson,Pleas Valley,Secretary of State,,R,Kris Kobach,54
-Wilson,Prairie,Secretary of State,,R,Kris Kobach,36
-Wilson,Talleyrand,Secretary of State,,R,Kris Kobach,46
-Wilson,Verdigris,Secretary of State,,R,Kris Kobach,61
-Wilson,Webster,Secretary of State,,R,Kris Kobach,16
-Wilson,Adv/Prov,Secretary of State,,R,Kris Kobach,8
-Wilson,Cedar,Secretary of State,,D,Jean Schodorf,19
-Wilson,Center,Secretary of State,,D,Jean Schodorf,53
-Wilson,Chetopa,Secretary of State,,D,Jean Schodorf,6
-Wilson,Clifton,Secretary of State,,D,Jean Schodorf,19
-Wilson,Colfax,Secretary of State,,D,Jean Schodorf,39
-Wilson,Duck Creek,Secretary of State,,D,Jean Schodorf,3
-Wilson,Fall River,Secretary of State,,D,Jean Schodorf,18
-Wilson,Fredonia 1,Secretary of State,,D,Jean Schodorf,55
-Wilson,Fredonia 2,Secretary of State,,D,Jean Schodorf,24
-Wilson,Fredonia 3,Secretary of State,,D,Jean Schodorf,18
-Wilson,Fredonia 4,Secretary of State,,D,Jean Schodorf,101
-Wilson,Guilford,Secretary of State,,D,Jean Schodorf,5
-Wilson,Neodesha 1,Secretary of State,,D,Jean Schodorf,42
-Wilson,Neodesha 2,Secretary of State,,D,Jean Schodorf,43
-Wilson,Neodesha 3,Secretary of State,,D,Jean Schodorf,22
-Wilson,Neodesha 4,Secretary of State,,D,Jean Schodorf,82
-Wilson,Neodesha twp,Secretary of State,,D,Jean Schodorf,43
-Wilson,Newark,Secretary of State,,D,Jean Schodorf,8
-Wilson,Pleas Valley,Secretary of State,,D,Jean Schodorf,15
-Wilson,Prairie,Secretary of State,,D,Jean Schodorf,5
-Wilson,Talleyrand,Secretary of State,,D,Jean Schodorf,4
-Wilson,Verdigris,Secretary of State,,D,Jean Schodorf,13
-Wilson,Webster,Secretary of State,,D,Jean Schodorf,4
-Wilson,Adv/Prov,Secretary of State,,D,Jean Schodorf,0
-Wilson,Cedar,Attorney General,,R,Derek Schmidt,139
-Wilson,Center,Attorney General,,R,Derek Schmidt,172
-Wilson,Chetopa,Attorney General,,R,Derek Schmidt,58
-Wilson,Clifton,Attorney General,,R,Derek Schmidt,75
-Wilson,Colfax,Attorney General,,R,Derek Schmidt,127
-Wilson,Duck Creek,Attorney General,,R,Derek Schmidt,32
-Wilson,Fall River,Attorney General,,R,Derek Schmidt,126
-Wilson,Fredonia 1,Attorney General,,R,Derek Schmidt,120
-Wilson,Fredonia 2,Attorney General,,R,Derek Schmidt,53
-Wilson,Fredonia 3,Attorney General,,R,Derek Schmidt,68
-Wilson,Fredonia 4,Attorney General,,R,Derek Schmidt,277
-Wilson,Guilford,Attorney General,,R,Derek Schmidt,50
-Wilson,Neodesha 1,Attorney General,,R,Derek Schmidt,116
-Wilson,Neodesha 2,Attorney General,,R,Derek Schmidt,101
-Wilson,Neodesha 3,Attorney General,,R,Derek Schmidt,79
-Wilson,Neodesha 4,Attorney General,,R,Derek Schmidt,193
-Wilson,Neodesha twp,Attorney General,,R,Derek Schmidt,163
-Wilson,Newark,Attorney General,,R,Derek Schmidt,70
-Wilson,Pleas Valley,Attorney General,,R,Derek Schmidt,54
-Wilson,Prairie,Attorney General,,R,Derek Schmidt,36
-Wilson,Talleyrand,Attorney General,,R,Derek Schmidt,46
-Wilson,Verdigris,Attorney General,,R,Derek Schmidt,61
-Wilson,Webster,Attorney General,,R,Derek Schmidt,16
-Wilson,Adv/Prov,Attorney General,,R,Derek Schmidt,8
-Wilson,Cedar,Attorney General,,D,AJ Kotich,9
-Wilson,Center,Attorney General,,D,AJ Kotich,24
-Wilson,Chetopa,Attorney General,,D,AJ Kotich,7
-Wilson,Clifton,Attorney General,,D,AJ Kotich,13
-Wilson,Colfax,Attorney General,,D,AJ Kotich,26
-Wilson,Duck Creek,Attorney General,,D,AJ Kotich,2
-Wilson,Fall River,Attorney General,,D,AJ Kotich,6
-Wilson,Fredonia 1,Attorney General,,D,AJ Kotich,26
-Wilson,Fredonia 2,Attorney General,,D,AJ Kotich,11
-Wilson,Fredonia 3,Attorney General,,D,AJ Kotich,9
-Wilson,Fredonia 4,Attorney General,,D,AJ Kotich,57
-Wilson,Guilford,Attorney General,,D,AJ Kotich,3
-Wilson,Neodesha 1,Attorney General,,D,AJ Kotich,24
-Wilson,Neodesha 2,Attorney General,,D,AJ Kotich,23
-Wilson,Neodesha 3,Attorney General,,D,AJ Kotich,14
-Wilson,Neodesha 4,Attorney General,,D,AJ Kotich,46
-Wilson,Neodesha twp,Attorney General,,D,AJ Kotich,21
-Wilson,Newark,Attorney General,,D,AJ Kotich,8
-Wilson,Pleas Valley,Attorney General,,D,AJ Kotich,15
-Wilson,Prairie,Attorney General,,D,AJ Kotich,5
-Wilson,Talleyrand,Attorney General,,D,AJ Kotich,4
-Wilson,Verdigris,Attorney General,,D,AJ Kotich,13
-Wilson,Webster,Attorney General,,D,AJ Kotich,4
-Wilson,Adv/Prov,Attorney General,,D,AJ Kotich,0
-Wilson,Cedar,State Treasurer,,R,Ron Estes,139
-Wilson,Center,State Treasurer,,R,Ron Estes,164
-Wilson,Chetopa,State Treasurer,,R,Ron Estes,59
-Wilson,Clifton,State Treasurer,,R,Ron Estes,74
-Wilson,Colfax,State Treasurer,,R,Ron Estes,123
-Wilson,Duck Creek,State Treasurer,,R,Ron Estes,29
-Wilson,Fall River,State Treasurer,,R,Ron Estes,114
-Wilson,Fredonia 1,State Treasurer,,R,Ron Estes,119
-Wilson,Fredonia 2,State Treasurer,,R,Ron Estes,50
-Wilson,Fredonia 3,State Treasurer,,R,Ron Estes,63
-Wilson,Fredonia 4,State Treasurer,,R,Ron Estes,266
-Wilson,Guilford,State Treasurer,,R,Ron Estes,43
-Wilson,Neodesha 1,State Treasurer,,R,Ron Estes,115
-Wilson,Neodesha 2,State Treasurer,,R,Ron Estes,93
-Wilson,Neodesha 3,State Treasurer,,R,Ron Estes,73
-Wilson,Neodesha 4,State Treasurer,,R,Ron Estes,182
-Wilson,Neodesha twp,State Treasurer,,R,Ron Estes,160
-Wilson,Newark,State Treasurer,,R,Ron Estes,67
-Wilson,Pleas Valley,State Treasurer,,R,Ron Estes,54
-Wilson,Prairie,State Treasurer,,R,Ron Estes,34
-Wilson,Talleyrand,State Treasurer,,R,Ron Estes,40
-Wilson,Verdigris,State Treasurer,,R,Ron Estes,55
-Wilson,Webster,State Treasurer,,R,Ron Estes,15
-Wilson,Adv/Prov,State Treasurer,,R,Ron Estes,8
-Wilson,Cedar,State Treasurer,,D,Carmen Alldritt,12
-Wilson,Center,State Treasurer,,D,Carmen Alldritt,33
-Wilson,Chetopa,State Treasurer,,D,Carmen Alldritt,6
-Wilson,Clifton,State Treasurer,,D,Carmen Alldritt,14
-Wilson,Colfax,State Treasurer,,D,Carmen Alldritt,27
-Wilson,Duck Creek,State Treasurer,,D,Carmen Alldritt,4
-Wilson,Fall River,State Treasurer,,D,Carmen Alldritt,17
-Wilson,Fredonia 1,State Treasurer,,D,Carmen Alldritt,28
-Wilson,Fredonia 2,State Treasurer,,D,Carmen Alldritt,13
-Wilson,Fredonia 3,State Treasurer,,D,Carmen Alldritt,12
-Wilson,Fredonia 4,State Treasurer,,D,Carmen Alldritt,65
-Wilson,Guilford,State Treasurer,,D,Carmen Alldritt,10
-Wilson,Neodesha 1,State Treasurer,,D,Carmen Alldritt,23
-Wilson,Neodesha 2,State Treasurer,,D,Carmen Alldritt,29
-Wilson,Neodesha 3,State Treasurer,,D,Carmen Alldritt,19
-Wilson,Neodesha 4,State Treasurer,,D,Carmen Alldritt,55
-Wilson,Neodesha twp,State Treasurer,,D,Carmen Alldritt,23
-Wilson,Newark,State Treasurer,,D,Carmen Alldritt,11
-Wilson,Pleas Valley,State Treasurer,,D,Carmen Alldritt,16
-Wilson,Prairie,State Treasurer,,D,Carmen Alldritt,5
-Wilson,Talleyrand,State Treasurer,,D,Carmen Alldritt,8
-Wilson,Verdigris,State Treasurer,,D,Carmen Alldritt,17
-Wilson,Webster,State Treasurer,,D,Carmen Alldritt,5
-Wilson,Adv/Prov,State Treasurer,,D,Carmen Alldritt,0
-Wilson,Cedar,Insurance Commissioner,,R,Ken Selzer,126
-Wilson,Center,Insurance Commissioner,,R,Ken Selzer,154
-Wilson,Chetopa,Insurance Commissioner,,R,Ken Selzer,56
-Wilson,Clifton,Insurance Commissioner,,R,Ken Selzer,72
-Wilson,Colfax,Insurance Commissioner,,R,Ken Selzer,115
-Wilson,Duck Creek,Insurance Commissioner,,R,Ken Selzer,27
-Wilson,Fall River,Insurance Commissioner,,R,Ken Selzer,111
-Wilson,Fredonia 1,Insurance Commissioner,,R,Ken Selzer,102
-Wilson,Fredonia 2,Insurance Commissioner,,R,Ken Selzer,48
-Wilson,Fredonia 3,Insurance Commissioner,,R,Ken Selzer,60
-Wilson,Fredonia 4,Insurance Commissioner,,R,Ken Selzer,248
-Wilson,Guilford,Insurance Commissioner,,R,Ken Selzer,39
-Wilson,Neodesha 1,Insurance Commissioner,,R,Ken Selzer,100
-Wilson,Neodesha 2,Insurance Commissioner,,R,Ken Selzer,81
-Wilson,Neodesha 3,Insurance Commissioner,,R,Ken Selzer,67
-Wilson,Neodesha 4,Insurance Commissioner,,R,Ken Selzer,165
-Wilson,Neodesha twp,Insurance Commissioner,,R,Ken Selzer,150
-Wilson,Newark,Insurance Commissioner,,R,Ken Selzer,63
-Wilson,Pleas Valley,Insurance Commissioner,,R,Ken Selzer,46
-Wilson,Prairie,Insurance Commissioner,,R,Ken Selzer,29
-Wilson,Talleyrand,Insurance Commissioner,,R,Ken Selzer,39
-Wilson,Verdigris,Insurance Commissioner,,R,Ken Selzer,51
-Wilson,Webster,Insurance Commissioner,,R,Ken Selzer,13
-Wilson,Adv/Prov,Insurance Commissioner,,R,Ken Selzer,7
-Wilson,Cedar,Insurance Commissioner,,D,Dennis Anderson,22
-Wilson,Center,Insurance Commissioner,,D,Dennis Anderson,39
-Wilson,Chetopa,Insurance Commissioner,,D,Dennis Anderson,8
-Wilson,Clifton,Insurance Commissioner,,D,Dennis Anderson,16
-Wilson,Colfax,Insurance Commissioner,,D,Dennis Anderson,32
-Wilson,Duck Creek,Insurance Commissioner,,D,Dennis Anderson,4
-Wilson,Fall River,Insurance Commissioner,,D,Dennis Anderson,18
-Wilson,Fredonia 1,Insurance Commissioner,,D,Dennis Anderson,42
-Wilson,Fredonia 2,Insurance Commissioner,,D,Dennis Anderson,16
-Wilson,Fredonia 3,Insurance Commissioner,,D,Dennis Anderson,14
-Wilson,Fredonia 4,Insurance Commissioner,,D,Dennis Anderson,78
-Wilson,Guilford,Insurance Commissioner,,D,Dennis Anderson,12
-Wilson,Neodesha 1,Insurance Commissioner,,D,Dennis Anderson,35
-Wilson,Neodesha 2,Insurance Commissioner,,D,Dennis Anderson,33
-Wilson,Neodesha 3,Insurance Commissioner,,D,Dennis Anderson,24
-Wilson,Neodesha 4,Insurance Commissioner,,D,Dennis Anderson,67
-Wilson,Neodesha twp,Insurance Commissioner,,D,Dennis Anderson,31
-Wilson,Newark,Insurance Commissioner,,D,Dennis Anderson,13
-Wilson,Pleas Valley,Insurance Commissioner,,D,Dennis Anderson,21
-Wilson,Prairie,Insurance Commissioner,,D,Dennis Anderson,9
-Wilson,Talleyrand,Insurance Commissioner,,D,Dennis Anderson,9
-Wilson,Verdigris,Insurance Commissioner,,D,Dennis Anderson,19
-Wilson,Webster,Insurance Commissioner,,D,Dennis Anderson,8
-Wilson,Adv/Prov,Insurance Commissioner,,D,Dennis Anderson,1
-Wilson,Cedar,State House,13,R,Larry Hibbard,138
-Wilson,Center,State House,13,R,Larry Hibbard,188
-Wilson,Chetopa,State House,13,R,Larry Hibbard,59
-Wilson,Clifton,State House,13,R,Larry Hibbard,82
-Wilson,Colfax,State House,13,R,Larry Hibbard,128
-Wilson,Duck Creek,State House,13,R,Larry Hibbard,32
-Wilson,Fall River,State House,13,R,Larry Hibbard,124
-Wilson,Fredonia 1,State House,13,R,Larry Hibbard,140
-Wilson,Fredonia 2,State House,13,R,Larry Hibbard,59
-Wilson,Fredonia 3,State House,13,R,Larry Hibbard,71
-Wilson,Fredonia 4,State House,13,R,Larry Hibbard,309
-Wilson,Guilford,State House,13,R,Larry Hibbard,50
-Wilson,Neodesha 1,State House,13,R,Larry Hibbard,122
-Wilson,Neodesha 2,State House,13,R,Larry Hibbard,107
-Wilson,Neodesha 3,State House,13,R,Larry Hibbard,84
-Wilson,Neodesha 4,State House,13,R,Larry Hibbard,212
-Wilson,Neodesha twp,State House,13,R,Larry Hibbard,172
-Wilson,Newark,State House,13,R,Larry Hibbard,70
-Wilson,Pleas Valley,State House,13,R,Larry Hibbard,57
-Wilson,Prairie,State House,13,R,Larry Hibbard,37
-Wilson,Talleyrand,State House,13,R,Larry Hibbard,45
-Wilson,Verdigris,State House,13,R,Larry Hibbard,70
-Wilson,Webster,State House,13,R,Larry Hibbard,18
-Wilson,Adv/Prov,State House,13,R,Larry Hibbard,8
+county,precinct,office,district,party,candidate,votes,vtd
+WILSON,Cedar Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000010
+WILSON,Cedar Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",13,000010
+WILSON,Cedar Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",116,000010
+WILSON,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",72,000020
+WILSON,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000020
+WILSON,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",121,000020
+WILSON,Chetopa Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000030
+WILSON,Chetopa Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000030
+WILSON,Chetopa Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",58,000030
+WILSON,Clifton Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",22,000040
+WILSON,Clifton Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000040
+WILSON,Clifton Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",63,000040
+WILSON,Colfax Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",57,000050
+WILSON,Colfax Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000050
+WILSON,Colfax Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",94,000050
+WILSON,Duck Creek Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",5,000060
+WILSON,Duck Creek Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000060
+WILSON,Duck Creek Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",28,000060
+WILSON,Fall River Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",14,000070
+WILSON,Fall River Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000070
+WILSON,Fall River Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",106,000070
+WILSON,Fredonia Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",67,000080
+WILSON,Fredonia Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",6,000080
+WILSON,Fredonia Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",79,000080
+WILSON,Fredonia Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",19,000090
+WILSON,Fredonia Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000090
+WILSON,Fredonia Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",43,000090
+WILSON,Fredonia Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",18,00010A
+WILSON,Fredonia Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,00010A
+WILSON,Fredonia Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,00010A
+WILSON,Fredonia Ward 3 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00010B
+WILSON,Fredonia Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",123,000110
+WILSON,Fredonia Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",14,000110
+WILSON,Fredonia Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",200,000110
+WILSON,Guilford Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",10,000120
+WILSON,Guilford Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000120
+WILSON,Guilford Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",44,000120
+WILSON,Neodesha Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",53,000130
+WILSON,Neodesha Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000130
+WILSON,Neodesha Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",126,000130
+WILSON,Neodesha Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",45,00014A
+WILSON,Neodesha Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00014A
+WILSON,Neodesha Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",84,00014A
+WILSON,Neodesha Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00014B
+WILSON,Neodesha Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",44,000150
+WILSON,Neodesha Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",7,000150
+WILSON,Neodesha Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",71,000150
+WILSON,Neodesha Ward 3,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000160
+WILSON,Neodesha Ward 3,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000160
+WILSON,Neodesha Ward 3,Governor / Lt. Governor,,Republican,"Brownback, Sam",59,000160
+WILSON,Neodesha Ward 4,Governor / Lt. Governor,,Democratic,"Davis, Paul",92,000170
+WILSON,Neodesha Ward 4,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000170
+WILSON,Neodesha Ward 4,Governor / Lt. Governor,,Republican,"Brownback, Sam",143,000170
+WILSON,Newark Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",20,000180
+WILSON,Newark Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000180
+WILSON,Newark Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",55,000180
+WILSON,Pleasant Valley Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",27,000190
+WILSON,Pleasant Valley Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000190
+WILSON,Pleasant Valley Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",39,000190
+WILSON,Prairie Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",7,000200
+WILSON,Prairie Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",2,000200
+WILSON,Prairie Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000200
+WILSON,Talleyrand Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",11,000210
+WILSON,Talleyrand Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000210
+WILSON,Talleyrand Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",38,000210
+WILSON,Verdigris Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",26,000220
+WILSON,Verdigris Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000220
+WILSON,Verdigris Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",40,000220
+WILSON,Webster Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",13,000230
+WILSON,Webster Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000230
+WILSON,Webster Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",8,000230
+WILSON,Neodesha Ward 1 Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900030
+WILSON,Neodesha Ward 4 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900040
+WILSON,Neodesha Ward 4 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900040
+WILSON,Neodesha Ward 4 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900040
+WILSON,Cedar Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",139,000010
+WILSON,Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",188,000020
+WILSON,Chetopa Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",60,000030
+WILSON,Clifton Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",82,000040
+WILSON,Colfax Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",130,000050
+WILSON,Duck Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",32,000060
+WILSON,Fall River Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",124,000070
+WILSON,Fredonia Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",140,000080
+WILSON,Fredonia Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",59,000090
+WILSON,Fredonia Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",71,00010A
+WILSON,Fredonia Ward 3 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,00010B
+WILSON,Fredonia Ward 4,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",311,000110
+WILSON,Guilford Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",51,000120
+WILSON,Neodesha Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",172,000130
+WILSON,Neodesha Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",122,00014A
+WILSON,Neodesha Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,00014B
+WILSON,Neodesha Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",108,000150
+WILSON,Neodesha Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",84,000160
+WILSON,Neodesha Ward 4,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",212,000170
+WILSON,Newark Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",70,000180
+WILSON,Pleasant Valley Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",57,000190
+WILSON,Prairie Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",37,000200
+WILSON,Talleyrand Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",45,000210
+WILSON,Verdigris Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",70,000220
+WILSON,Webster Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",18,000230
+WILSON,Neodesha Ward 1 Exclave 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900030
+WILSON,Neodesha Ward 4 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900040
+WILSON,Cedar Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",14,000010
+WILSON,Cedar Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000010
+WILSON,Cedar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,000010
+WILSON,Center Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",34,000020
+WILSON,Center Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000020
+WILSON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",160,000020
+WILSON,Chetopa Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",7,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",3,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,000030
+WILSON,Clifton Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000040
+WILSON,Clifton Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000040
+WILSON,Clifton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,000040
+WILSON,Colfax Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",29,000050
+WILSON,Colfax Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",10,000050
+WILSON,Colfax Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,000050
+WILSON,Duck Creek Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",2,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000060
+WILSON,Fall River Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000070
+WILSON,Fall River Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000070
+WILSON,Fall River Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",118,000070
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",39,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",107,000080
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",12,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",50,000090
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,00010A
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",77,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",248,000110
+WILSON,Guilford Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,000120
+WILSON,Guilford Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000120
+WILSON,Guilford Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000120
+WILSON,Neodesha Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",26,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",153,000130
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,00014A
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00014B
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",31,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,000150
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Democratic,"Wakefield, Margie",23,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000160
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Democratic,"Wakefield, Margie",55,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",14,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",174,000170
+WILSON,Newark Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",9,000180
+WILSON,Newark Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",4,000180
+WILSON,Newark Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,000180
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",18,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,000190
+WILSON,Prairie Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",4,000200
+WILSON,Prairie Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000200
+WILSON,Prairie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,000200
+WILSON,Talleyrand Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",6,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,000210
+WILSON,Verdigris Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",5,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,000220
+WILSON,Webster Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",5,000230
+WILSON,Webster Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000230
+WILSON,Webster Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",16,000230
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+WILSON,Cedar Township,Attorney General,,Democratic,"Kotich, A.J.",9,000010
+WILSON,Cedar Township,Attorney General,,Republican,"Schmidt, Derek",140,000010
+WILSON,Center Township,Attorney General,,Democratic,"Kotich, A.J.",24,000020
+WILSON,Center Township,Attorney General,,Republican,"Schmidt, Derek",172,000020
+WILSON,Chetopa Township,Attorney General,,Democratic,"Kotich, A.J.",7,000030
+WILSON,Chetopa Township,Attorney General,,Republican,"Schmidt, Derek",59,000030
+WILSON,Clifton Township,Attorney General,,Democratic,"Kotich, A.J.",13,000040
+WILSON,Clifton Township,Attorney General,,Republican,"Schmidt, Derek",75,000040
+WILSON,Colfax Township,Attorney General,,Democratic,"Kotich, A.J.",26,000050
+WILSON,Colfax Township,Attorney General,,Republican,"Schmidt, Derek",129,000050
+WILSON,Duck Creek Township,Attorney General,,Democratic,"Kotich, A.J.",2,000060
+WILSON,Duck Creek Township,Attorney General,,Republican,"Schmidt, Derek",32,000060
+WILSON,Fall River Township,Attorney General,,Democratic,"Kotich, A.J.",6,000070
+WILSON,Fall River Township,Attorney General,,Republican,"Schmidt, Derek",126,000070
+WILSON,Fredonia Ward 1,Attorney General,,Democratic,"Kotich, A.J.",26,000080
+WILSON,Fredonia Ward 1,Attorney General,,Republican,"Schmidt, Derek",120,000080
+WILSON,Fredonia Ward 2,Attorney General,,Democratic,"Kotich, A.J.",11,000090
+WILSON,Fredonia Ward 2,Attorney General,,Republican,"Schmidt, Derek",53,000090
+WILSON,Fredonia Ward 3,Attorney General,,Democratic,"Kotich, A.J.",9,00010A
+WILSON,Fredonia Ward 3,Attorney General,,Republican,"Schmidt, Derek",68,00010A
+WILSON,Fredonia Ward 3 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00010B
+WILSON,Fredonia Ward 4,Attorney General,,Democratic,"Kotich, A.J.",57,000110
+WILSON,Fredonia Ward 4,Attorney General,,Republican,"Schmidt, Derek",279,000110
+WILSON,Guilford Township,Attorney General,,Democratic,"Kotich, A.J.",3,000120
+WILSON,Guilford Township,Attorney General,,Republican,"Schmidt, Derek",51,000120
+WILSON,Neodesha Township,Attorney General,,Democratic,"Kotich, A.J.",21,000130
+WILSON,Neodesha Township,Attorney General,,Republican,"Schmidt, Derek",163,000130
+WILSON,Neodesha Ward 1,Attorney General,,Democratic,"Kotich, A.J.",24,00014A
+WILSON,Neodesha Ward 1,Attorney General,,Republican,"Schmidt, Derek",116,00014A
+WILSON,Neodesha Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00014B
+WILSON,Neodesha Ward 2,Attorney General,,Democratic,"Kotich, A.J.",23,000150
+WILSON,Neodesha Ward 2,Attorney General,,Republican,"Schmidt, Derek",102,000150
+WILSON,Neodesha Ward 3,Attorney General,,Democratic,"Kotich, A.J.",14,000160
+WILSON,Neodesha Ward 3,Attorney General,,Republican,"Schmidt, Derek",79,000160
+WILSON,Neodesha Ward 4,Attorney General,,Democratic,"Kotich, A.J.",46,000170
+WILSON,Neodesha Ward 4,Attorney General,,Republican,"Schmidt, Derek",193,000170
+WILSON,Newark Township,Attorney General,,Democratic,"Kotich, A.J.",8,000180
+WILSON,Newark Township,Attorney General,,Republican,"Schmidt, Derek",70,000180
+WILSON,Pleasant Valley Township,Attorney General,,Democratic,"Kotich, A.J.",15,000190
+WILSON,Pleasant Valley Township,Attorney General,,Republican,"Schmidt, Derek",54,000190
+WILSON,Prairie Township,Attorney General,,Democratic,"Kotich, A.J.",5,000200
+WILSON,Prairie Township,Attorney General,,Republican,"Schmidt, Derek",36,000200
+WILSON,Talleyrand Township,Attorney General,,Democratic,"Kotich, A.J.",4,000210
+WILSON,Talleyrand Township,Attorney General,,Republican,"Schmidt, Derek",46,000210
+WILSON,Verdigris Township,Attorney General,,Democratic,"Kotich, A.J.",13,000220
+WILSON,Verdigris Township,Attorney General,,Republican,"Schmidt, Derek",61,000220
+WILSON,Webster Township,Attorney General,,Democratic,"Kotich, A.J.",4,000230
+WILSON,Webster Township,Attorney General,,Republican,"Schmidt, Derek",16,000230
+WILSON,Neodesha Ward 1 Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Attorney General,,Democratic,"Kotich, A.J.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Attorney General,,Republican,"Schmidt, Derek",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Attorney General,,Democratic,"Kotich, A.J.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Attorney General,,Republican,"Schmidt, Derek",0,900030
+WILSON,Neodesha Ward 4 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900040
+WILSON,Neodesha Ward 4 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900040
+WILSON,Cedar Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",22,000010
+WILSON,Cedar Township,Commissioner of Insurance,,Republican,"Selzer, Ken",127,000010
+WILSON,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",39,000020
+WILSON,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",154,000020
+WILSON,Chetopa Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000030
+WILSON,Chetopa Township,Commissioner of Insurance,,Republican,"Selzer, Ken",57,000030
+WILSON,Clifton Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000040
+WILSON,Clifton Township,Commissioner of Insurance,,Republican,"Selzer, Ken",72,000040
+WILSON,Colfax Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",32,000050
+WILSON,Colfax Township,Commissioner of Insurance,,Republican,"Selzer, Ken",117,000050
+WILSON,Duck Creek Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",4,000060
+WILSON,Duck Creek Township,Commissioner of Insurance,,Republican,"Selzer, Ken",27,000060
+WILSON,Fall River Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18,000070
+WILSON,Fall River Township,Commissioner of Insurance,,Republican,"Selzer, Ken",111,000070
+WILSON,Fredonia Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",42,000080
+WILSON,Fredonia Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",102,000080
+WILSON,Fredonia Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",16,000090
+WILSON,Fredonia Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",48,000090
+WILSON,Fredonia Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,00010A
+WILSON,Fredonia Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",60,00010A
+WILSON,Fredonia Ward 3 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00010B
+WILSON,Fredonia Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",78,000110
+WILSON,Fredonia Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",250,000110
+WILSON,Guilford Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000120
+WILSON,Guilford Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000120
+WILSON,Neodesha Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",31,000130
+WILSON,Neodesha Township,Commissioner of Insurance,,Republican,"Selzer, Ken",150,000130
+WILSON,Neodesha Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",35,00014A
+WILSON,Neodesha Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",100,00014A
+WILSON,Neodesha Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00014B
+WILSON,Neodesha Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",33,000150
+WILSON,Neodesha Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",82,000150
+WILSON,Neodesha Ward 3,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000160
+WILSON,Neodesha Ward 3,Commissioner of Insurance,,Republican,"Selzer, Ken",67,000160
+WILSON,Neodesha Ward 4,Commissioner of Insurance,,Democratic,"Anderson, Dennis",67,000170
+WILSON,Neodesha Ward 4,Commissioner of Insurance,,Republican,"Selzer, Ken",165,000170
+WILSON,Newark Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",13,000180
+WILSON,Newark Township,Commissioner of Insurance,,Republican,"Selzer, Ken",63,000180
+WILSON,Pleasant Valley Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",21,000190
+WILSON,Pleasant Valley Township,Commissioner of Insurance,,Republican,"Selzer, Ken",46,000190
+WILSON,Prairie Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000200
+WILSON,Prairie Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000200
+WILSON,Talleyrand Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000210
+WILSON,Talleyrand Township,Commissioner of Insurance,,Republican,"Selzer, Ken",39,000210
+WILSON,Verdigris Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",19,000220
+WILSON,Verdigris Township,Commissioner of Insurance,,Republican,"Selzer, Ken",51,000220
+WILSON,Webster Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",8,000230
+WILSON,Webster Township,Commissioner of Insurance,,Republican,"Selzer, Ken",13,000230
+WILSON,Neodesha Ward 1 Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900030
+WILSON,Neodesha Ward 4 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900040
+WILSON,Neodesha Ward 4 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900040
+WILSON,Cedar Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000010
+WILSON,Cedar Township,Secretary of State,,Republican,"Kobach, Kris",131,000010
+WILSON,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",53,000020
+WILSON,Center Township,Secretary of State,,Republican,"Kobach, Kris",143,000020
+WILSON,Chetopa Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000030
+WILSON,Chetopa Township,Secretary of State,,Republican,"Kobach, Kris",58,000030
+WILSON,Clifton Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",19,000040
+WILSON,Clifton Township,Secretary of State,,Republican,"Kobach, Kris",68,000040
+WILSON,Colfax Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",40,000050
+WILSON,Colfax Township,Secretary of State,,Republican,"Kobach, Kris",110,000050
+WILSON,Duck Creek Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",3,000060
+WILSON,Duck Creek Township,Secretary of State,,Republican,"Kobach, Kris",30,000060
+WILSON,Fall River Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000070
+WILSON,Fall River Township,Secretary of State,,Republican,"Kobach, Kris",114,000070
+WILSON,Fredonia Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",55,000080
+WILSON,Fredonia Ward 1,Secretary of State,,Republican,"Kobach, Kris",91,000080
+WILSON,Fredonia Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",24,000090
+WILSON,Fredonia Ward 2,Secretary of State,,Republican,"Kobach, Kris",39,000090
+WILSON,Fredonia Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,00010A
+WILSON,Fredonia Ward 3,Secretary of State,,Republican,"Kobach, Kris",58,00010A
+WILSON,Fredonia Ward 3 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00010B
+WILSON,Fredonia Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",101,000110
+WILSON,Fredonia Ward 4,Secretary of State,,Republican,"Kobach, Kris",232,000110
+WILSON,Guilford Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",5,000120
+WILSON,Guilford Township,Secretary of State,,Republican,"Kobach, Kris",48,000120
+WILSON,Neodesha Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000130
+WILSON,Neodesha Township,Secretary of State,,Republican,"Kobach, Kris",140,000130
+WILSON,Neodesha Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,00014A
+WILSON,Neodesha Ward 1,Secretary of State,,Republican,"Kobach, Kris",99,00014A
+WILSON,Neodesha Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00014B
+WILSON,Neodesha Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",43,000150
+WILSON,Neodesha Ward 2,Secretary of State,,Republican,"Kobach, Kris",79,000150
+WILSON,Neodesha Ward 3,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",22,000160
+WILSON,Neodesha Ward 3,Secretary of State,,Republican,"Kobach, Kris",69,000160
+WILSON,Neodesha Ward 4,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",82,000170
+WILSON,Neodesha Ward 4,Secretary of State,,Republican,"Kobach, Kris",156,000170
+WILSON,Newark Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",13,000180
+WILSON,Newark Township,Secretary of State,,Republican,"Kobach, Kris",64,000180
+WILSON,Pleasant Valley Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",17,000190
+WILSON,Pleasant Valley Township,Secretary of State,,Republican,"Kobach, Kris",53,000190
+WILSON,Prairie Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",10,000200
+WILSON,Prairie Township,Secretary of State,,Republican,"Kobach, Kris",30,000200
+WILSON,Talleyrand Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000210
+WILSON,Talleyrand Township,Secretary of State,,Republican,"Kobach, Kris",37,000210
+WILSON,Verdigris Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",23,000220
+WILSON,Verdigris Township,Secretary of State,,Republican,"Kobach, Kris",48,000220
+WILSON,Webster Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",6,000230
+WILSON,Webster Township,Secretary of State,,Republican,"Kobach, Kris",14,000230
+WILSON,Neodesha Ward 1 Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Secretary of State,,Republican,"Kobach, Kris",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Secretary of State,,Republican,"Kobach, Kris",0,900030
+WILSON,Neodesha Ward 4 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900040
+WILSON,Neodesha Ward 4 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900040
+WILSON,Cedar Township,State Treasurer,,Democratic,"Alldritt, Carmen",12,000010
+WILSON,Cedar Township,State Treasurer,,Republican,"Estes, Ron",140,000010
+WILSON,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",33,000020
+WILSON,Center Township,State Treasurer,,Republican,"Estes, Ron",164,000020
+WILSON,Chetopa Township,State Treasurer,,Democratic,"Alldritt, Carmen",6,000030
+WILSON,Chetopa Township,State Treasurer,,Republican,"Estes, Ron",60,000030
+WILSON,Clifton Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000040
+WILSON,Clifton Township,State Treasurer,,Republican,"Estes, Ron",74,000040
+WILSON,Colfax Township,State Treasurer,,Democratic,"Alldritt, Carmen",27,000050
+WILSON,Colfax Township,State Treasurer,,Republican,"Estes, Ron",125,000050
+WILSON,Duck Creek Township,State Treasurer,,Democratic,"Alldritt, Carmen",4,000060
+WILSON,Duck Creek Township,State Treasurer,,Republican,"Estes, Ron",29,000060
+WILSON,Fall River Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000070
+WILSON,Fall River Township,State Treasurer,,Republican,"Estes, Ron",114,000070
+WILSON,Fredonia Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",28,000080
+WILSON,Fredonia Ward 1,State Treasurer,,Republican,"Estes, Ron",119,000080
+WILSON,Fredonia Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",13,000090
+WILSON,Fredonia Ward 2,State Treasurer,,Republican,"Estes, Ron",50,000090
+WILSON,Fredonia Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",12,00010A
+WILSON,Fredonia Ward 3,State Treasurer,,Republican,"Estes, Ron",63,00010A
+WILSON,Fredonia Ward 3 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00010B
+WILSON,Fredonia Ward 3 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00010B
+WILSON,Fredonia Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",65,000110
+WILSON,Fredonia Ward 4,State Treasurer,,Republican,"Estes, Ron",268,000110
+WILSON,Guilford Township,State Treasurer,,Democratic,"Alldritt, Carmen",10,000120
+WILSON,Guilford Township,State Treasurer,,Republican,"Estes, Ron",44,000120
+WILSON,Neodesha Township,State Treasurer,,Democratic,"Alldritt, Carmen",23,000130
+WILSON,Neodesha Township,State Treasurer,,Republican,"Estes, Ron",160,000130
+WILSON,Neodesha Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",23,00014A
+WILSON,Neodesha Ward 1,State Treasurer,,Republican,"Estes, Ron",115,00014A
+WILSON,Neodesha Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00014B
+WILSON,Neodesha Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00014B
+WILSON,Neodesha Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",29,000150
+WILSON,Neodesha Ward 2,State Treasurer,,Republican,"Estes, Ron",94,000150
+WILSON,Neodesha Ward 3,State Treasurer,,Democratic,"Alldritt, Carmen",19,000160
+WILSON,Neodesha Ward 3,State Treasurer,,Republican,"Estes, Ron",73,000160
+WILSON,Neodesha Ward 4,State Treasurer,,Democratic,"Alldritt, Carmen",55,000170
+WILSON,Neodesha Ward 4,State Treasurer,,Republican,"Estes, Ron",182,000170
+WILSON,Newark Township,State Treasurer,,Democratic,"Alldritt, Carmen",11,000180
+WILSON,Newark Township,State Treasurer,,Republican,"Estes, Ron",67,000180
+WILSON,Pleasant Valley Township,State Treasurer,,Democratic,"Alldritt, Carmen",16,000190
+WILSON,Pleasant Valley Township,State Treasurer,,Republican,"Estes, Ron",54,000190
+WILSON,Prairie Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000200
+WILSON,Prairie Township,State Treasurer,,Republican,"Estes, Ron",34,000200
+WILSON,Talleyrand Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000210
+WILSON,Talleyrand Township,State Treasurer,,Republican,"Estes, Ron",40,000210
+WILSON,Verdigris Township,State Treasurer,,Democratic,"Alldritt, Carmen",17,000220
+WILSON,Verdigris Township,State Treasurer,,Republican,"Estes, Ron",55,000220
+WILSON,Webster Township,State Treasurer,,Democratic,"Alldritt, Carmen",5,000230
+WILSON,Webster Township,State Treasurer,,Republican,"Estes, Ron",15,000230
+WILSON,Neodesha Ward 1 Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,State Treasurer,,Democratic,"Alldritt, Carmen",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,State Treasurer,,Republican,"Estes, Ron",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,State Treasurer,,Democratic,"Alldritt, Carmen",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,State Treasurer,,Republican,"Estes, Ron",0,900030
+WILSON,Neodesha Ward 4 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900040
+WILSON,Neodesha Ward 4 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900040
+WILSON,Cedar Township,United States Senate,,independent,"Orman, Greg",22,000010
+WILSON,Cedar Township,United States Senate,,Libertarian,"Batson, Randall",9,000010
+WILSON,Cedar Township,United States Senate,,Republican,"Roberts, Pat",120,000010
+WILSON,Center Township,United States Senate,,independent,"Orman, Greg",53,000020
+WILSON,Center Township,United States Senate,,Libertarian,"Batson, Randall",8,000020
+WILSON,Center Township,United States Senate,,Republican,"Roberts, Pat",136,000020
+WILSON,Chetopa Township,United States Senate,,independent,"Orman, Greg",10,000030
+WILSON,Chetopa Township,United States Senate,,Libertarian,"Batson, Randall",2,000030
+WILSON,Chetopa Township,United States Senate,,Republican,"Roberts, Pat",53,000030
+WILSON,Clifton Township,United States Senate,,independent,"Orman, Greg",17,000040
+WILSON,Clifton Township,United States Senate,,Libertarian,"Batson, Randall",9,000040
+WILSON,Clifton Township,United States Senate,,Republican,"Roberts, Pat",65,000040
+WILSON,Colfax Township,United States Senate,,independent,"Orman, Greg",43,000050
+WILSON,Colfax Township,United States Senate,,Libertarian,"Batson, Randall",9,000050
+WILSON,Colfax Township,United States Senate,,Republican,"Roberts, Pat",100,000050
+WILSON,Duck Creek Township,United States Senate,,independent,"Orman, Greg",5,000060
+WILSON,Duck Creek Township,United States Senate,,Libertarian,"Batson, Randall",0,000060
+WILSON,Duck Creek Township,United States Senate,,Republican,"Roberts, Pat",29,000060
+WILSON,Fall River Township,United States Senate,,independent,"Orman, Greg",12,000070
+WILSON,Fall River Township,United States Senate,,Libertarian,"Batson, Randall",7,000070
+WILSON,Fall River Township,United States Senate,,Republican,"Roberts, Pat",112,000070
+WILSON,Fredonia Ward 1,United States Senate,,independent,"Orman, Greg",40,000080
+WILSON,Fredonia Ward 1,United States Senate,,Libertarian,"Batson, Randall",6,000080
+WILSON,Fredonia Ward 1,United States Senate,,Republican,"Roberts, Pat",104,000080
+WILSON,Fredonia Ward 2,United States Senate,,independent,"Orman, Greg",15,000090
+WILSON,Fredonia Ward 2,United States Senate,,Libertarian,"Batson, Randall",5,000090
+WILSON,Fredonia Ward 2,United States Senate,,Republican,"Roberts, Pat",42,000090
+WILSON,Fredonia Ward 3,United States Senate,,independent,"Orman, Greg",14,00010A
+WILSON,Fredonia Ward 3,United States Senate,,Libertarian,"Batson, Randall",5,00010A
+WILSON,Fredonia Ward 3,United States Senate,,Republican,"Roberts, Pat",56,00010A
+WILSON,Fredonia Ward 3 Exclave,United States Senate,,independent,"Orman, Greg",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00010B
+WILSON,Fredonia Ward 4,United States Senate,,independent,"Orman, Greg",94,000110
+WILSON,Fredonia Ward 4,United States Senate,,Libertarian,"Batson, Randall",20,000110
+WILSON,Fredonia Ward 4,United States Senate,,Republican,"Roberts, Pat",216,000110
+WILSON,Guilford Township,United States Senate,,independent,"Orman, Greg",8,000120
+WILSON,Guilford Township,United States Senate,,Libertarian,"Batson, Randall",2,000120
+WILSON,Guilford Township,United States Senate,,Republican,"Roberts, Pat",44,000120
+WILSON,Neodesha Township,United States Senate,,independent,"Orman, Greg",47,000130
+WILSON,Neodesha Township,United States Senate,,Libertarian,"Batson, Randall",6,000130
+WILSON,Neodesha Township,United States Senate,,Republican,"Roberts, Pat",130,000130
+WILSON,Neodesha Ward 1,United States Senate,,independent,"Orman, Greg",48,00014A
+WILSON,Neodesha Ward 1,United States Senate,,Libertarian,"Batson, Randall",12,00014A
+WILSON,Neodesha Ward 1,United States Senate,,Republican,"Roberts, Pat",81,00014A
+WILSON,Neodesha Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00014B
+WILSON,Neodesha Ward 2,United States Senate,,independent,"Orman, Greg",32,000150
+WILSON,Neodesha Ward 2,United States Senate,,Libertarian,"Batson, Randall",11,000150
+WILSON,Neodesha Ward 2,United States Senate,,Republican,"Roberts, Pat",79,000150
+WILSON,Neodesha Ward 3,United States Senate,,independent,"Orman, Greg",33,000160
+WILSON,Neodesha Ward 3,United States Senate,,Libertarian,"Batson, Randall",3,000160
+WILSON,Neodesha Ward 3,United States Senate,,Republican,"Roberts, Pat",57,000160
+WILSON,Neodesha Ward 4,United States Senate,,independent,"Orman, Greg",80,000170
+WILSON,Neodesha Ward 4,United States Senate,,Libertarian,"Batson, Randall",13,000170
+WILSON,Neodesha Ward 4,United States Senate,,Republican,"Roberts, Pat",145,000170
+WILSON,Newark Township,United States Senate,,independent,"Orman, Greg",18,000180
+WILSON,Newark Township,United States Senate,,Libertarian,"Batson, Randall",4,000180
+WILSON,Newark Township,United States Senate,,Republican,"Roberts, Pat",56,000180
+WILSON,Pleasant Valley Township,United States Senate,,independent,"Orman, Greg",21,000190
+WILSON,Pleasant Valley Township,United States Senate,,Libertarian,"Batson, Randall",2,000190
+WILSON,Pleasant Valley Township,United States Senate,,Republican,"Roberts, Pat",46,000190
+WILSON,Prairie Township,United States Senate,,independent,"Orman, Greg",7,000200
+WILSON,Prairie Township,United States Senate,,Libertarian,"Batson, Randall",2,000200
+WILSON,Prairie Township,United States Senate,,Republican,"Roberts, Pat",32,000200
+WILSON,Talleyrand Township,United States Senate,,independent,"Orman, Greg",9,000210
+WILSON,Talleyrand Township,United States Senate,,Libertarian,"Batson, Randall",3,000210
+WILSON,Talleyrand Township,United States Senate,,Republican,"Roberts, Pat",38,000210
+WILSON,Verdigris Township,United States Senate,,independent,"Orman, Greg",20,000220
+WILSON,Verdigris Township,United States Senate,,Libertarian,"Batson, Randall",9,000220
+WILSON,Verdigris Township,United States Senate,,Republican,"Roberts, Pat",45,000220
+WILSON,Webster Township,United States Senate,,independent,"Orman, Greg",8,000230
+WILSON,Webster Township,United States Senate,,Libertarian,"Batson, Randall",0,000230
+WILSON,Webster Township,United States Senate,,Republican,"Roberts, Pat",13,000230
+WILSON,Neodesha Ward 1 Exclave 2,United States Senate,,independent,"Orman, Greg",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,United States Senate,,independent,"Orman, Greg",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States Senate,,Libertarian,"Batson, Randall",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States Senate,,Republican,"Roberts, Pat",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,United States Senate,,independent,"Orman, Greg",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States Senate,,Libertarian,"Batson, Randall",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States Senate,,Republican,"Roberts, Pat",0,900030
+WILSON,Neodesha Ward 4 Exclave,United States Senate,,independent,"Orman, Greg",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900040

--- a/2014/20141104__ks__general__woodson__precinct.csv
+++ b/2014/20141104__ks__general__woodson__precinct.csv
@@ -1,163 +1,199 @@
-county,precinct,office,district,party,candidate,votes
-Woodson,Center,Attorney General,,D,A.J. Kotich,27
-Woodson,Liberty,Attorney General,,D,A.J. Kotich,14
-Woodson,Neosho Falls,Attorney General,,D,A.J. Kotich,13
-Woodson,North,Attorney General,,D,A.J. Kotich,1
-Woodson,Perry,Attorney General,,D,A.J. Kotich,7
-Woodson,Piqua,Attorney General,,D,A.J. Kotich,12
-Woodson,Toronto,Attorney General,,D,A.J. Kotich,35
-Woodson,Yates Center 1,Attorney General,,D,A.J. Kotich,47
-Woodson,Yates Center 2,Attorney General,,D,A.J. Kotich,35
-Woodson,Center,Attorney General,,R,Derek Schmidt,189
-Woodson,Liberty,Attorney General,,R,Derek Schmidt,53
-Woodson,Neosho Falls,Attorney General,,R,Derek Schmidt,15
-Woodson,North,Attorney General,,R,Derek Schmidt,33
-Woodson,Perry,Attorney General,,R,Derek Schmidt,35
-Woodson,Piqua,Attorney General,,R,Derek Schmidt,60
-Woodson,Toronto,Attorney General,,R,Derek Schmidt,141
-Woodson,Yates Center 1,Attorney General,,R,Derek Schmidt,167
-Woodson,Yates Center 2,Attorney General,,R,Derek Schmidt,181
-Woodson,Center,U.S. House,2,L,Christopher Clemmons,6
-Woodson,Liberty,U.S. House,2,L,Christopher Clemmons,9
-Woodson,Neosho Falls,U.S. House,2,L,Christopher Clemmons,1
-Woodson,North,U.S. House,2,L,Christopher Clemmons,0
-Woodson,Perry,U.S. House,2,L,Christopher Clemmons,1
-Woodson,Piqua,U.S. House,2,L,Christopher Clemmons,2
-Woodson,Toronto,U.S. House,2,L,Christopher Clemmons,17
-Woodson,Yates Center 1,U.S. House,2,L,Christopher Clemmons,17
-Woodson,Yates Center 2,U.S. House,2,L,Christopher Clemmons,8
-Woodson,Center,U.S. House,2,R,Lynn Jenkins,173
-Woodson,Liberty,U.S. House,2,R,Lynn Jenkins,41
-Woodson,Neosho Falls,U.S. House,2,R,Lynn Jenkins,11
-Woodson,North,U.S. House,2,R,Lynn Jenkins,33
-Woodson,Perry,U.S. House,2,R,Lynn Jenkins,27
-Woodson,Piqua,U.S. House,2,R,Lynn Jenkins,55
-Woodson,Toronto,U.S. House,2,R,Lynn Jenkins,119
-Woodson,Yates Center 1,U.S. House,2,R,Lynn Jenkins,144
-Woodson,Yates Center 2,U.S. House,2,R,Lynn Jenkins,149
-Woodson,Center,U.S. House,2,D,Margie Wakefield,38
-Woodson,Liberty,U.S. House,2,D,Margie Wakefield,17
-Woodson,Neosho Falls,U.S. House,2,D,Margie Wakefield,16
-Woodson,North,U.S. House,2,D,Margie Wakefield,2
-Woodson,Perry,U.S. House,2,D,Margie Wakefield,12
-Woodson,Piqua,U.S. House,2,D,Margie Wakefield,15
-Woodson,Toronto,U.S. House,2,D,Margie Wakefield,41
-Woodson,Yates Center 1,U.S. House,2,D,Margie Wakefield,55
-Woodson,Yates Center 2,U.S. House,2,D,Margie Wakefield,57
-Woodson,Center,Governor,,R,Brownback,153
-Woodson,Liberty,Governor,,R,Brownback,33
-Woodson,Neosho Falls,Governor,,R,Brownback,14
-Woodson,North,Governor,,R,Brownback,25
-Woodson,Perry,Governor,,R,Brownback,25
-Woodson,Piqua,Governor,,R,Brownback,46
-Woodson,Toronto,Governor,,R,Brownback,95
-Woodson,Yates Center 1,Governor,,R,Brownback,109
-Woodson,Yates Center 2,Governor,,R,Brownback,113
-Woodson,Center,Governor,,D,Davis,62
-Woodson,Liberty,Governor,,D,Davis,31
-Woodson,Neosho Falls,Governor,,D,Davis,15
-Woodson,North,Governor,,D,Davis,9
-Woodson,Perry,Governor,,D,Davis,15
-Woodson,Piqua,Governor,,D,Davis,23
-Woodson,Toronto,Governor,,D,Davis,71
-Woodson,Yates Center 1,Governor,,D,Davis,97
-Woodson,Yates Center 2,Governor,,D,Davis,95
-Woodson,Center,Governor,,L,Umbehr,4
-Woodson,Liberty,Governor,,L,Umbehr,5
-Woodson,Neosho Falls,Governor,,L,Umbehr,0
-Woodson,North,Governor,,L,Umbehr,1
-Woodson,Perry,Governor,,L,Umbehr,1
-Woodson,Piqua,Governor,,L,Umbehr,3
-Woodson,Toronto,Governor,,L,Umbehr,12
-Woodson,Yates Center 1,Governor,,L,Umbehr,12
-Woodson,Yates Center 2,Governor,,L,Umbehr,9
-Woodson,Center,Insurance Commissioner,,D,Dennis Anderson,38
-Woodson,Liberty,Insurance Commissioner,,D,Dennis Anderson,24
-Woodson,Neosho Falls,Insurance Commissioner,,D,Dennis Anderson,14
-Woodson,North,Insurance Commissioner,,D,Dennis Anderson,2
-Woodson,Perry,Insurance Commissioner,,D,Dennis Anderson,9
-Woodson,Piqua,Insurance Commissioner,,D,Dennis Anderson,20
-Woodson,Toronto,Insurance Commissioner,,D,Dennis Anderson,53
-Woodson,Yates Center 1,Insurance Commissioner,,D,Dennis Anderson,69
-Woodson,Yates Center 2,Insurance Commissioner,,D,Dennis Anderson,61
-Woodson,Center,Insurance Commissioner,,R,Ken Selzer,169
-Woodson,Liberty,Insurance Commissioner,,R,Ken Selzer,41
-Woodson,Neosho Falls,Insurance Commissioner,,R,Ken Selzer,14
-Woodson,North,Insurance Commissioner,,R,Ken Selzer,29
-Woodson,Perry,Insurance Commissioner,,R,Ken Selzer,32
-Woodson,Piqua,Insurance Commissioner,,R,Ken Selzer,49
-Woodson,Toronto,Insurance Commissioner,,R,Ken Selzer,116
-Woodson,Yates Center 1,Insurance Commissioner,,R,Ken Selzer,138
-Woodson,Yates Center 2,Insurance Commissioner,,R,Ken Selzer,143
-Woodson,Center,Secretary of State,,D,Jean Kurtis Schodorf,42
-Woodson,Liberty,Secretary of State,,D,Jean Kurtis Schodorf,18
-Woodson,Neosho Falls,Secretary of State,,D,Jean Kurtis Schodorf,15
-Woodson,North,Secretary of State,,D,Jean Kurtis Schodorf,7
-Woodson,Perry,Secretary of State,,D,Jean Kurtis Schodorf,12
-Woodson,Piqua,Secretary of State,,D,Jean Kurtis Schodorf,20
-Woodson,Toronto,Secretary of State,,D,Jean Kurtis Schodorf,57
-Woodson,Yates Center 1,Secretary of State,,D,Jean Kurtis Schodorf,70
-Woodson,Yates Center 2,Secretary of State,,D,Jean Kurtis Schodorf,62
-Woodson,Center,Secretary of State,,R,Kris Kobach,173
-Woodson,Liberty,Secretary of State,,R,Kris Kobach,48
-Woodson,Neosho Falls,Secretary of State,,R,Kris Kobach,13
-Woodson,North,Secretary of State,,R,Kris Kobach,26
-Woodson,Perry,Secretary of State,,R,Kris Kobach,29
-Woodson,Piqua,Secretary of State,,R,Kris Kobach,52
-Woodson,Toronto,Secretary of State,,R,Kris Kobach,118
-Woodson,Yates Center 1,Secretary of State,,R,Kris Kobach,147
-Woodson,Yates Center 2,Secretary of State,,R,Kris Kobach,149
-Woodson,Center,State House,13,R,Larry P. Hibbard,194
-Woodson,Liberty,State House,13,R,Larry P. Hibbard,63
-Woodson,Neosho Falls,State House,13,R,Larry P. Hibbard,21
-Woodson,North,State House,13,R,Larry P. Hibbard,33
-Woodson,Perry,State House,13,R,Larry P. Hibbard,39
-Woodson,Piqua,State House,13,R,Larry P. Hibbard,61
-Woodson,Toronto,State House,13,R,Larry P. Hibbard,165
-Woodson,Yates Center 1,State House,13,R,Larry P. Hibbard,194
-Woodson,Yates Center 2,State House,13,R,Larry P. Hibbard,192
-Woodson,Center,State Treasurer,,D,Carmen Alldritt,29
-Woodson,Liberty,State Treasurer,,D,Carmen Alldritt,13
-Woodson,Neosho Falls,State Treasurer,,D,Carmen Alldritt,14
-Woodson,North,State Treasurer,,D,Carmen Alldritt,3
-Woodson,Perry,State Treasurer,,D,Carmen Alldritt,8
-Woodson,Piqua,State Treasurer,,D,Carmen Alldritt,19
-Woodson,Toronto,State Treasurer,,D,Carmen Alldritt,48
-Woodson,Yates Center 1,State Treasurer,,D,Carmen Alldritt,55
-Woodson,Yates Center 2,State Treasurer,,D,Carmen Alldritt,36
-Woodson,Center,State Treasurer,,R,Ron Estes,182
-Woodson,Liberty,State Treasurer,,R,Ron Estes,53
-Woodson,Neosho Falls,State Treasurer,,R,Ron Estes,14
-Woodson,North,State Treasurer,,R,Ron Estes,30
-Woodson,Perry,State Treasurer,,R,Ron Estes,33
-Woodson,Piqua,State Treasurer,,R,Ron Estes,53
-Woodson,Toronto,State Treasurer,,R,Ron Estes,126
-Woodson,Yates Center 1,State Treasurer,,R,Ron Estes,157
-Woodson,Yates Center 2,State Treasurer,,R,Ron Estes,174
-Woodson,Center,U.S. Senate,,I,Greg Orman,45
-Woodson,Liberty,U.S. Senate,,I,Greg Orman,21
-Woodson,Neosho Falls,U.S. Senate,,I,Greg Orman,15
-Woodson,North,U.S. Senate,,I,Greg Orman,5
-Woodson,Perry,U.S. Senate,,I,Greg Orman,10
-Woodson,Piqua,U.S. Senate,,I,Greg Orman,18
-Woodson,Toronto,U.S. Senate,,I,Greg Orman,57
-Woodson,Yates Center 1,U.S. Senate,,I,Greg Orman,72
-Woodson,Yates Center 2,U.S. Senate,,I,Greg Orman,62
-Woodson,Center,U.S. Senate,,R,Pat Roberts,158
-Woodson,Liberty,U.S. Senate,,R,Pat Roberts,42
-Woodson,Neosho Falls,U.S. Senate,,R,Pat Roberts,13
-Woodson,North,U.S. Senate,,R,Pat Roberts,29
-Woodson,Perry,U.S. Senate,,R,Pat Roberts,27
-Woodson,Piqua,U.S. Senate,,R,Pat Roberts,51
-Woodson,Toronto,U.S. Senate,,R,Pat Roberts,99
-Woodson,Yates Center 1,U.S. Senate,,R,Pat Roberts,125
-Woodson,Yates Center 2,U.S. Senate,,R,Pat Roberts,132
-Woodson,Center,U.S. Senate,,L,Randall Batson,13
-Woodson,Liberty,U.S. Senate,,L,Randall Batson,5
-Woodson,Neosho Falls,U.S. Senate,,L,Randall Batson,0
-Woodson,North,U.S. Senate,,L,Randall Batson,1
-Woodson,Perry,U.S. Senate,,L,Randall Batson,4
-Woodson,Piqua,U.S. Senate,,L,Randall Batson,4
-Woodson,Toronto,U.S. Senate,,L,Randall Batson,21
-Woodson,Yates Center 1,U.S. Senate,,L,Randall Batson,20
-Woodson,Yates Center 2,U.S. Senate,,L,Randall Batson,17
+county,precinct,office,district,party,candidate,votes,vtd
+WOODSON,Center Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",62,000010
+WOODSON,Center Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",4,000010
+WOODSON,Center Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",153,000010
+WOODSON,Liberty Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",31,000020
+WOODSON,Liberty Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",5,000020
+WOODSON,Liberty Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",33,000020
+WOODSON,Neosho Falls Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000030
+WOODSON,Neosho Falls Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,000030
+WOODSON,Neosho Falls Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",14,000030
+WOODSON,North Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",9,000040
+WOODSON,North Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000040
+WOODSON,North Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000040
+WOODSON,Perry Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",15,000050
+WOODSON,Perry Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",1,000050
+WOODSON,Perry Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",25,000050
+WOODSON,Piqua Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",23,000060
+WOODSON,Piqua Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",3,000060
+WOODSON,Piqua Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",46,000060
+WOODSON,Toronto Township,Governor / Lt. Governor,,Democratic,"Davis, Paul",71,000070
+WOODSON,Toronto Township,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,000070
+WOODSON,Toronto Township,Governor / Lt. Governor,,Republican,"Brownback, Sam",95,000070
+WOODSON,Yates Center Ward 1,Governor / Lt. Governor,,Democratic,"Davis, Paul",97,00008A
+WOODSON,Yates Center Ward 1,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",12,00008A
+WOODSON,Yates Center Ward 1,Governor / Lt. Governor,,Republican,"Brownback, Sam",109,00008A
+WOODSON,Yates Center Ward 1 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,00008B
+WOODSON,Yates Center Ward 2,Governor / Lt. Governor,,Democratic,"Davis, Paul",95,000090
+WOODSON,Yates Center Ward 2,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",9,000090
+WOODSON,Yates Center Ward 2,Governor / Lt. Governor,,Republican,"Brownback, Sam",113,000090
+WOODSON,Yates Center Ward 2 Exclave,Governor / Lt. Governor,,Democratic,"Davis, Paul",0,900010
+WOODSON,Yates Center Ward 2 Exclave,Governor / Lt. Governor,,Libertarian,"Umbehr, Keen A.",0,900010
+WOODSON,Yates Center Ward 2 Exclave,Governor / Lt. Governor,,Republican,"Brownback, Sam",0,900010
+WOODSON,Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",194,000010
+WOODSON,Liberty Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",63,000020
+WOODSON,Neosho Falls Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",21,000030
+WOODSON,North Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",33,000040
+WOODSON,Perry Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",39,000050
+WOODSON,Piqua Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",61,000060
+WOODSON,Toronto Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",165,000070
+WOODSON,Yates Center Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",194,00008A
+WOODSON,Yates Center Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,00008B
+WOODSON,Yates Center Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",192,000090
+WOODSON,Yates Center Ward 2 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900010
+WOODSON,Center Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",38,000010
+WOODSON,Center Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",6,000010
+WOODSON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",173,000010
+WOODSON,Liberty Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",17,000020
+WOODSON,Liberty Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",9,000020
+WOODSON,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000020
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",16,000030
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000030
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",11,000030
+WOODSON,North Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",2,000040
+WOODSON,North Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,000040
+WOODSON,North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000040
+WOODSON,Perry Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",12,000050
+WOODSON,Perry Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",1,000050
+WOODSON,Perry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",27,000050
+WOODSON,Piqua Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",15,000060
+WOODSON,Piqua Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",2,000060
+WOODSON,Piqua Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000060
+WOODSON,Toronto Township,United States House of Representatives,2,Democratic,"Wakefield, Margie",41,000070
+WOODSON,Toronto Township,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,000070
+WOODSON,Toronto Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",119,000070
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Democratic,"Wakefield, Margie",55,00008A
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",17,00008A
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",144,00008A
+WOODSON,Yates Center Ward 1 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008B
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Democratic,"Wakefield, Margie",57,000090
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",8,000090
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",149,000090
+WOODSON,Yates Center Ward 2 Exclave,United States House of Representatives,2,Democratic,"Wakefield, Margie",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States House of Representatives,2,Libertarian,"Clemmons, Christopher",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+WOODSON,Center Township,Attorney General,,Democratic,"Kotich, A.J.",27,000010
+WOODSON,Center Township,Attorney General,,Republican,"Schmidt, Derek",189,000010
+WOODSON,Liberty Township,Attorney General,,Democratic,"Kotich, A.J.",14,000020
+WOODSON,Liberty Township,Attorney General,,Republican,"Schmidt, Derek",53,000020
+WOODSON,Neosho Falls Township,Attorney General,,Democratic,"Kotich, A.J.",13,000030
+WOODSON,Neosho Falls Township,Attorney General,,Republican,"Schmidt, Derek",15,000030
+WOODSON,North Township,Attorney General,,Democratic,"Kotich, A.J.",1,000040
+WOODSON,North Township,Attorney General,,Republican,"Schmidt, Derek",33,000040
+WOODSON,Perry Township,Attorney General,,Democratic,"Kotich, A.J.",7,000050
+WOODSON,Perry Township,Attorney General,,Republican,"Schmidt, Derek",35,000050
+WOODSON,Piqua Township,Attorney General,,Democratic,"Kotich, A.J.",12,000060
+WOODSON,Piqua Township,Attorney General,,Republican,"Schmidt, Derek",60,000060
+WOODSON,Toronto Township,Attorney General,,Democratic,"Kotich, A.J.",35,000070
+WOODSON,Toronto Township,Attorney General,,Republican,"Schmidt, Derek",141,000070
+WOODSON,Yates Center Ward 1,Attorney General,,Democratic,"Kotich, A.J.",47,00008A
+WOODSON,Yates Center Ward 1,Attorney General,,Republican,"Schmidt, Derek",167,00008A
+WOODSON,Yates Center Ward 1 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,00008B
+WOODSON,Yates Center Ward 2,Attorney General,,Democratic,"Kotich, A.J.",35,000090
+WOODSON,Yates Center Ward 2,Attorney General,,Republican,"Schmidt, Derek",181,000090
+WOODSON,Yates Center Ward 2 Exclave,Attorney General,,Democratic,"Kotich, A.J.",0,900010
+WOODSON,Yates Center Ward 2 Exclave,Attorney General,,Republican,"Schmidt, Derek",0,900010
+WOODSON,Center Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",38,000010
+WOODSON,Center Township,Commissioner of Insurance,,Republican,"Selzer, Ken",169,000010
+WOODSON,Liberty Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",24,000020
+WOODSON,Liberty Township,Commissioner of Insurance,,Republican,"Selzer, Ken",41,000020
+WOODSON,Neosho Falls Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",14,000030
+WOODSON,Neosho Falls Township,Commissioner of Insurance,,Republican,"Selzer, Ken",14,000030
+WOODSON,North Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",2,000040
+WOODSON,North Township,Commissioner of Insurance,,Republican,"Selzer, Ken",29,000040
+WOODSON,Perry Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",9,000050
+WOODSON,Perry Township,Commissioner of Insurance,,Republican,"Selzer, Ken",32,000050
+WOODSON,Piqua Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",20,000060
+WOODSON,Piqua Township,Commissioner of Insurance,,Republican,"Selzer, Ken",49,000060
+WOODSON,Toronto Township,Commissioner of Insurance,,Democratic,"Anderson, Dennis",53,000070
+WOODSON,Toronto Township,Commissioner of Insurance,,Republican,"Selzer, Ken",116,000070
+WOODSON,Yates Center Ward 1,Commissioner of Insurance,,Democratic,"Anderson, Dennis",69,00008A
+WOODSON,Yates Center Ward 1,Commissioner of Insurance,,Republican,"Selzer, Ken",138,00008A
+WOODSON,Yates Center Ward 1 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,00008B
+WOODSON,Yates Center Ward 2,Commissioner of Insurance,,Democratic,"Anderson, Dennis",61,000090
+WOODSON,Yates Center Ward 2,Commissioner of Insurance,,Republican,"Selzer, Ken",143,000090
+WOODSON,Yates Center Ward 2 Exclave,Commissioner of Insurance,,Democratic,"Anderson, Dennis",0,900010
+WOODSON,Yates Center Ward 2 Exclave,Commissioner of Insurance,,Republican,"Selzer, Ken",0,900010
+WOODSON,Center Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",42,000010
+WOODSON,Center Township,Secretary of State,,Republican,"Kobach, Kris",173,000010
+WOODSON,Liberty Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",18,000020
+WOODSON,Liberty Township,Secretary of State,,Republican,"Kobach, Kris",48,000020
+WOODSON,Neosho Falls Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",15,000030
+WOODSON,Neosho Falls Township,Secretary of State,,Republican,"Kobach, Kris",13,000030
+WOODSON,North Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",7,000040
+WOODSON,North Township,Secretary of State,,Republican,"Kobach, Kris",26,000040
+WOODSON,Perry Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",12,000050
+WOODSON,Perry Township,Secretary of State,,Republican,"Kobach, Kris",29,000050
+WOODSON,Piqua Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",20,000060
+WOODSON,Piqua Township,Secretary of State,,Republican,"Kobach, Kris",52,000060
+WOODSON,Toronto Township,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",57,000070
+WOODSON,Toronto Township,Secretary of State,,Republican,"Kobach, Kris",118,000070
+WOODSON,Yates Center Ward 1,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",70,00008A
+WOODSON,Yates Center Ward 1,Secretary of State,,Republican,"Kobach, Kris",147,00008A
+WOODSON,Yates Center Ward 1 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,00008B
+WOODSON,Yates Center Ward 2,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",62,000090
+WOODSON,Yates Center Ward 2,Secretary of State,,Republican,"Kobach, Kris",149,000090
+WOODSON,Yates Center Ward 2 Exclave,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",0,900010
+WOODSON,Yates Center Ward 2 Exclave,Secretary of State,,Republican,"Kobach, Kris",0,900010
+WOODSON,Center Township,State Treasurer,,Democratic,"Alldritt, Carmen",29,000010
+WOODSON,Center Township,State Treasurer,,Republican,"Estes, Ron",182,000010
+WOODSON,Liberty Township,State Treasurer,,Democratic,"Alldritt, Carmen",13,000020
+WOODSON,Liberty Township,State Treasurer,,Republican,"Estes, Ron",53,000020
+WOODSON,Neosho Falls Township,State Treasurer,,Democratic,"Alldritt, Carmen",14,000030
+WOODSON,Neosho Falls Township,State Treasurer,,Republican,"Estes, Ron",14,000030
+WOODSON,North Township,State Treasurer,,Democratic,"Alldritt, Carmen",3,000040
+WOODSON,North Township,State Treasurer,,Republican,"Estes, Ron",30,000040
+WOODSON,Perry Township,State Treasurer,,Democratic,"Alldritt, Carmen",8,000050
+WOODSON,Perry Township,State Treasurer,,Republican,"Estes, Ron",33,000050
+WOODSON,Piqua Township,State Treasurer,,Democratic,"Alldritt, Carmen",19,000060
+WOODSON,Piqua Township,State Treasurer,,Republican,"Estes, Ron",53,000060
+WOODSON,Toronto Township,State Treasurer,,Democratic,"Alldritt, Carmen",48,000070
+WOODSON,Toronto Township,State Treasurer,,Republican,"Estes, Ron",126,000070
+WOODSON,Yates Center Ward 1,State Treasurer,,Democratic,"Alldritt, Carmen",55,00008A
+WOODSON,Yates Center Ward 1,State Treasurer,,Republican,"Estes, Ron",157,00008A
+WOODSON,Yates Center Ward 1 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,State Treasurer,,Republican,"Estes, Ron",0,00008B
+WOODSON,Yates Center Ward 2,State Treasurer,,Democratic,"Alldritt, Carmen",36,000090
+WOODSON,Yates Center Ward 2,State Treasurer,,Republican,"Estes, Ron",174,000090
+WOODSON,Yates Center Ward 2 Exclave,State Treasurer,,Democratic,"Alldritt, Carmen",0,900010
+WOODSON,Yates Center Ward 2 Exclave,State Treasurer,,Republican,"Estes, Ron",0,900010
+WOODSON,Center Township,United States Senate,,independent,"Orman, Greg",45,000010
+WOODSON,Center Township,United States Senate,,Libertarian,"Batson, Randall",13,000010
+WOODSON,Center Township,United States Senate,,Republican,"Roberts, Pat",158,000010
+WOODSON,Liberty Township,United States Senate,,independent,"Orman, Greg",21,000020
+WOODSON,Liberty Township,United States Senate,,Libertarian,"Batson, Randall",5,000020
+WOODSON,Liberty Township,United States Senate,,Republican,"Roberts, Pat",42,000020
+WOODSON,Neosho Falls Township,United States Senate,,independent,"Orman, Greg",15,000030
+WOODSON,Neosho Falls Township,United States Senate,,Libertarian,"Batson, Randall",0,000030
+WOODSON,Neosho Falls Township,United States Senate,,Republican,"Roberts, Pat",13,000030
+WOODSON,North Township,United States Senate,,independent,"Orman, Greg",5,000040
+WOODSON,North Township,United States Senate,,Libertarian,"Batson, Randall",1,000040
+WOODSON,North Township,United States Senate,,Republican,"Roberts, Pat",29,000040
+WOODSON,Perry Township,United States Senate,,independent,"Orman, Greg",10,000050
+WOODSON,Perry Township,United States Senate,,Libertarian,"Batson, Randall",4,000050
+WOODSON,Perry Township,United States Senate,,Republican,"Roberts, Pat",27,000050
+WOODSON,Piqua Township,United States Senate,,independent,"Orman, Greg",18,000060
+WOODSON,Piqua Township,United States Senate,,Libertarian,"Batson, Randall",4,000060
+WOODSON,Piqua Township,United States Senate,,Republican,"Roberts, Pat",51,000060
+WOODSON,Toronto Township,United States Senate,,independent,"Orman, Greg",57,000070
+WOODSON,Toronto Township,United States Senate,,Libertarian,"Batson, Randall",21,000070
+WOODSON,Toronto Township,United States Senate,,Republican,"Roberts, Pat",99,000070
+WOODSON,Yates Center Ward 1,United States Senate,,independent,"Orman, Greg",72,00008A
+WOODSON,Yates Center Ward 1,United States Senate,,Libertarian,"Batson, Randall",20,00008A
+WOODSON,Yates Center Ward 1,United States Senate,,Republican,"Roberts, Pat",125,00008A
+WOODSON,Yates Center Ward 1 Exclave,United States Senate,,independent,"Orman, Greg",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States Senate,,Republican,"Roberts, Pat",0,00008B
+WOODSON,Yates Center Ward 2,United States Senate,,independent,"Orman, Greg",62,000090
+WOODSON,Yates Center Ward 2,United States Senate,,Libertarian,"Batson, Randall",17,000090
+WOODSON,Yates Center Ward 2,United States Senate,,Republican,"Roberts, Pat",132,000090
+WOODSON,Yates Center Ward 2 Exclave,United States Senate,,independent,"Orman, Greg",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States Senate,,Libertarian,"Batson, Randall",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States Senate,,Republican,"Roberts, Pat",0,900010

--- a/2014/20141104__ks__general__wyandotte__precinct.csv
+++ b/2014/20141104__ks__general__wyandotte__precinct.csv
@@ -1,3106 +1,586 @@
-county,precinct,office,district,party,candidate,votes
-Wyandotte,BS 1-1,Voters,,,Registration,1135
-Wyandotte,BS 2-1,Voters,,,Registration,885
-Wyandotte,BS 3-1,Voters,,,Registration,1111
-Wyandotte,BS 4-1,Voters,,,Registration,1229
-Wyandotte,DE 1-1,Voters,,,Registration,30
-Wyandotte,ED 1-1,Voters,,,Registration,2151
-Wyandotte,ED 2-1,Voters,,,Registration,366
-Wyandotte,KC 1-1,Voters,,,Registration,444
-Wyandotte,KC 1-2,Voters,,,Registration,379
-Wyandotte,KC 1-3,Voters,,,Registration,164
-Wyandotte,KC 2-1,Voters,,,Registration,440
-Wyandotte,KC 2-2,Voters,,,Registration,387
-Wyandotte,KC 2-3,Voters,,,Registration,120
-Wyandotte,KC 2-4,Voters,,,Registration,389
-Wyandotte,KC 2-5,Voters,,,Registration,708
-Wyandotte,KC 3-1,Voters,,,Registration,890
-Wyandotte,KC 3-2,Voters,,,Registration,1013
-Wyandotte,KC 3-3,Voters,,,Registration,224
-Wyandotte,KC 3-4,Voters,,,Registration,777
-Wyandotte,KC 4-1,Voters,,,Registration,663
-Wyandotte,KC 4-2,Voters,,,Registration,239
-Wyandotte,KC 4-3,Voters,,,Registration,445
-Wyandotte,KC 4-4,Voters,,,Registration,788
-Wyandotte,KC 5-1,Voters,,,Registration,730
-Wyandotte,KC 5-2,Voters,,,Registration,456
-Wyandotte,KC 5-3,Voters,,,Registration,421
-Wyandotte,KC 5-4,Voters,,,Registration,377
-Wyandotte,KC 5-5,Voters,,,Registration,467
-Wyandotte,KC 6-1,Voters,,,Registration,527
-Wyandotte,KC 6-2,Voters,,,Registration,232
-Wyandotte,KC 7-1,Voters,,,Registration,574
-Wyandotte,KC 7-2,Voters,,,Registration,399
-Wyandotte,KC 7-3,Voters,,,Registration,654
-Wyandotte,KC 7-4,Voters,,,Registration,879
-Wyandotte,KC 7-5,Voters,,,Registration,236
-Wyandotte,KC 7-6,Voters,,,Registration,986
-Wyandotte,KC 7-7,Voters,,,Registration,513
-Wyandotte,KC 7-8,Voters,,,Registration,1352
-Wyandotte,KC 7-9,Voters,,,Registration,1091
-Wyandotte,KC 8-1,Voters,,,Registration,819
-Wyandotte,KC 8-2,Voters,,,Registration,826
-Wyandotte,KC 8-3,Voters,,,Registration,1089
-Wyandotte,KC 8-4,Voters,,,Registration,919
-Wyandotte,KC 9-1,Voters,,,Registration,136
-Wyandotte,KC 9-2,Voters,,,Registration,693
-Wyandotte,KC 9-3,Voters,,,Registration,1468
-Wyandotte,KC 9-4,Voters,,,Registration,227
-Wyandotte,KC 9-5,Voters,,,Registration,61
-Wyandotte,KC 9-6,Voters,,,Registration,965
-Wyandotte,KC 9-7,Voters,,,Registration,1004
-Wyandotte,KC 9-8,Voters,,,Registration,439
-Wyandotte,KC 9-9,Voters,,,Registration,368
-Wyandotte,KC 9-10,Voters,,,Registration,961
-Wyandotte,KC 9-11,Voters,,,Registration,1105
-Wyandotte,KC 9-12,Voters,,,Registration,977
-Wyandotte,KC 9-13,Voters,,,Registration,738
-Wyandotte,KC 9-14,Voters,,,Registration,881
-Wyandotte,KC 9-15,Voters,,,Registration,1
-Wyandotte,KC 9-16,Voters,,,Registration,1082
-Wyandotte,KC 10-1,Voters,,,Registration,970
-Wyandotte,KC 10-2,Voters,,,Registration,1431
-Wyandotte,KC 10-3,Voters,,,Registration,64
-Wyandotte,KC 10-4,Voters,,,Registration,578
-Wyandotte,KC 10-5,Voters,,,Registration,996
-Wyandotte,KC 11-1,Voters,,,Registration,936
-Wyandotte,KC 11-2,Voters,,,Registration,815
-Wyandotte,KC 11-3,Voters,,,Registration,1091
-Wyandotte,KC 11-4,Voters,,,Registration,963
-Wyandotte,KC 11-5,Voters,,,Registration,1144
-Wyandotte,KC 11-6,Voters,,,Registration,787
-Wyandotte,KC 11-7,Voters,,,Registration,590
-Wyandotte,KC 11-8,Voters,,,Registration,1038
-Wyandotte,KC 11-9,Voters,,,Registration,781
-Wyandotte,KC 11-10,Voters,,,Registration,848
-Wyandotte,KC 11-11,Voters,,,Registration,1022
-Wyandotte,KC 11-12,Voters,,,Registration,176
-Wyandotte,KC 12-1,Voters,,,Registration,807
-Wyandotte,KC 12-2,Voters,,,Registration,525
-Wyandotte,KC 12-3,Voters,,,Registration,835
-Wyandotte,KC 12-4,Voters,,,Registration,885
-Wyandotte,KC 12-5,Voters,,,Registration,794
-Wyandotte,KC 12-6,Voters,,,Registration,828
-Wyandotte,KC 12-7,Voters,,,Registration,829
-Wyandotte,KC 12-8,Voters,,,Registration,824
-Wyandotte,KC 12-9,Voters,,,Registration,790
-Wyandotte,KC 12-10,Voters,,,Registration,518
-Wyandotte,KC 12-11,Voters,,,Registration,298
-Wyandotte,KC 13-1,Voters,,,Registration,1052
-Wyandotte,KC 13-2,Voters,,,Registration,801
-Wyandotte,KC 13-3,Voters,,,Registration,697
-Wyandotte,KC 13-4,Voters,,,Registration,582
-Wyandotte,KC 13-5,Voters,,,Registration,824
-Wyandotte,KC 13-6,Voters,,,Registration,787
-Wyandotte,KC 13-7,Voters,,,Registration,540
-Wyandotte,KC 13-8,Voters,,,Registration,656
-Wyandotte,KC 13-9,Voters,,,Registration,871
-Wyandotte,KC 14-1,Voters,,,Registration,815
-Wyandotte,KC 14-2,Voters,,,Registration,383
-Wyandotte,KC 14-3,Voters,,,Registration,366
-Wyandotte,KC 14-4,Voters,,,Registration,741
-Wyandotte,KC 14-5,Voters,,,Registration,688
-Wyandotte,KC 14-6,Voters,,,Registration,964
-Wyandotte,KC 14-7,Voters,,,Registration,1127
-Wyandotte,KC 14-8,Voters,,,Registration,860
-Wyandotte,KC 14-9,Voters,,,Registration,405
-Wyandotte,KC 14-10,Voters,,,Registration,1218
-Wyandotte,KC 14-11,Voters,,,Registration,741
-Wyandotte,KC 14-12,Voters,,,Registration,1175
-Wyandotte,KC 14-13,Voters,,,Registration,978
-Wyandotte,KC 14-14,Voters,,,Registration,1395
-Wyandotte,KC 14-15,Voters,,,Registration,1406
-Wyandotte,KC 14-16,Voters,,,Registration,417
-Wyandotte,OC 1-1,Voters,,,Registration,37
-Wyandotte,BS 1-1,Voters,,,Ballots,462
-Wyandotte,BS 2-1,Voters,,,Ballots,349
-Wyandotte,BS 3-1,Voters,,,Ballots,503
-Wyandotte,BS 4-1,Voters,,,Ballots,595
-Wyandotte,DE 1-1,Voters,,,Ballots,13
-Wyandotte,ED 1-1,Voters,,,Ballots,819
-Wyandotte,ED 2-1,Voters,,,Ballots,135
-Wyandotte,KC 1-1,Voters,,,Ballots,86
-Wyandotte,KC 1-2,Voters,,,Ballots,94
-Wyandotte,KC 1-3,Voters,,,Ballots,69
-Wyandotte,KC 2-1,Voters,,,Ballots,146
-Wyandotte,KC 2-2,Voters,,,Ballots,95
-Wyandotte,KC 2-3,Voters,,,Ballots,30
-Wyandotte,KC 2-4,Voters,,,Ballots,107
-Wyandotte,KC 2-5,Voters,,,Ballots,193
-Wyandotte,KC 3-1,Voters,,,Ballots,273
-Wyandotte,KC 3-2,Voters,,,Ballots,271
-Wyandotte,KC 3-3,Voters,,,Ballots,49
-Wyandotte,KC 3-4,Voters,,,Ballots,163
-Wyandotte,KC 4-1,Voters,,,Ballots,199
-Wyandotte,KC 4-2,Voters,,,Ballots,56
-Wyandotte,KC 4-3,Voters,,,Ballots,138
-Wyandotte,KC 4-4,Voters,,,Ballots,289
-Wyandotte,KC 5-1,Voters,,,Ballots,199
-Wyandotte,KC 5-2,Voters,,,Ballots,60
-Wyandotte,KC 5-3,Voters,,,Ballots,49
-Wyandotte,KC 5-4,Voters,,,Ballots,77
-Wyandotte,KC 5-5,Voters,,,Ballots,111
-Wyandotte,KC 6-1,Voters,,,Ballots,114
-Wyandotte,KC 6-2,Voters,,,Ballots,38
-Wyandotte,KC 7-1,Voters,,,Ballots,166
-Wyandotte,KC 7-2,Voters,,,Ballots,114
-Wyandotte,KC 7-3,Voters,,,Ballots,192
-Wyandotte,KC 7-4,Voters,,,Ballots,325
-Wyandotte,KC 7-5,Voters,,,Ballots,56
-Wyandotte,KC 7-6,Voters,,,Ballots,311
-Wyandotte,KC 7-7,Voters,,,Ballots,98
-Wyandotte,KC 7-8,Voters,,,Ballots,403
-Wyandotte,KC 7-9,Voters,,,Ballots,366
-Wyandotte,KC 8-1,Voters,,,Ballots,227
-Wyandotte,KC 8-2,Voters,,,Ballots,259
-Wyandotte,KC 8-3,Voters,,,Ballots,437
-Wyandotte,KC 8-4,Voters,,,Ballots,259
-Wyandotte,KC 9-1,Voters,,,Ballots,60
-Wyandotte,KC 9-2,Voters,,,Ballots,175
-Wyandotte,KC 9-3,Voters,,,Ballots,438
-Wyandotte,KC 9-4,Voters,,,Ballots,75
-Wyandotte,KC 9-5,Voters,,,Ballots,21
-Wyandotte,KC 9-6,Voters,,,Ballots,231
-Wyandotte,KC 9-7,Voters,,,Ballots,260
-Wyandotte,KC 9-8,Voters,,,Ballots,196
-Wyandotte,KC 9-9,Voters,,,Ballots,112
-Wyandotte,KC 9-10,Voters,,,Ballots,377
-Wyandotte,KC 9-11,Voters,,,Ballots,398
-Wyandotte,KC 9-12,Voters,,,Ballots,336
-Wyandotte,KC 9-13,Voters,,,Ballots,244
-Wyandotte,KC 9-14,Voters,,,Ballots,343
-Wyandotte,KC 9-15,Voters,,,Ballots,0
-Wyandotte,KC 9-16,Voters,,,Ballots,432
-Wyandotte,KC 10-1,Voters,,,Ballots,281
-Wyandotte,KC 10-2,Voters,,,Ballots,428
-Wyandotte,KC 10-3,Voters,,,Ballots,16
-Wyandotte,KC 10-4,Voters,,,Ballots,173
-Wyandotte,KC 10-5,Voters,,,Ballots,330
-Wyandotte,KC 11-1,Voters,,,Ballots,301
-Wyandotte,KC 11-2,Voters,,,Ballots,246
-Wyandotte,KC 11-3,Voters,,,Ballots,367
-Wyandotte,KC 11-4,Voters,,,Ballots,272
-Wyandotte,KC 11-5,Voters,,,Ballots,263
-Wyandotte,KC 11-6,Voters,,,Ballots,261
-Wyandotte,KC 11-7,Voters,,,Ballots,241
-Wyandotte,KC 11-8,Voters,,,Ballots,285
-Wyandotte,KC 11-9,Voters,,,Ballots,292
-Wyandotte,KC 11-10,Voters,,,Ballots,373
-Wyandotte,KC 11-11,Voters,,,Ballots,537
-Wyandotte,KC 11-12,Voters,,,Ballots,79
-Wyandotte,KC 12-1,Voters,,,Ballots,247
-Wyandotte,KC 12-2,Voters,,,Ballots,80
-Wyandotte,KC 12-3,Voters,,,Ballots,233
-Wyandotte,KC 12-4,Voters,,,Ballots,335
-Wyandotte,KC 12-5,Voters,,,Ballots,306
-Wyandotte,KC 12-6,Voters,,,Ballots,279
-Wyandotte,KC 12-7,Voters,,,Ballots,212
-Wyandotte,KC 12-8,Voters,,,Ballots,296
-Wyandotte,KC 12-9,Voters,,,Ballots,316
-Wyandotte,KC 12-10,Voters,,,Ballots,252
-Wyandotte,KC 12-11,Voters,,,Ballots,129
-Wyandotte,KC 13-1,Voters,,,Ballots,333
-Wyandotte,KC 13-2,Voters,,,Ballots,319
-Wyandotte,KC 13-3,Voters,,,Ballots,244
-Wyandotte,KC 13-4,Voters,,,Ballots,196
-Wyandotte,KC 13-5,Voters,,,Ballots,251
-Wyandotte,KC 13-6,Voters,,,Ballots,278
-Wyandotte,KC 13-7,Voters,,,Ballots,206
-Wyandotte,KC 13-8,Voters,,,Ballots,245
-Wyandotte,KC 13-9,Voters,,,Ballots,321
-Wyandotte,KC 14-1,Voters,,,Ballots,341
-Wyandotte,KC 14-2,Voters,,,Ballots,176
-Wyandotte,KC 14-3,Voters,,,Ballots,158
-Wyandotte,KC 14-4,Voters,,,Ballots,328
-Wyandotte,KC 14-5,Voters,,,Ballots,287
-Wyandotte,KC 14-6,Voters,,,Ballots,378
-Wyandotte,KC 14-7,Voters,,,Ballots,485
-Wyandotte,KC 14-8,Voters,,,Ballots,350
-Wyandotte,KC 14-9,Voters,,,Ballots,247
-Wyandotte,KC 14-10,Voters,,,Ballots,638
-Wyandotte,KC 14-11,Voters,,,Ballots,343
-Wyandotte,KC 14-12,Voters,,,Ballots,632
-Wyandotte,KC 14-13,Voters,,,Ballots,457
-Wyandotte,KC 14-14,Voters,,,Ballots,681
-Wyandotte,KC 14-15,Voters,,,Ballots,837
-Wyandotte,KC 14-16,Voters,,,Ballots,242
-Wyandotte,OC 1-1,Voters,,,Ballots,27
-Wyandotte,BS 1-1,U.S. Senate,,L,Randall Batson,18
-Wyandotte,BS 2-1,U.S. Senate,,L,Randall Batson,18
-Wyandotte,BS 3-1,U.S. Senate,,L,Randall Batson,17
-Wyandotte,BS 4-1,U.S. Senate,,L,Randall Batson,27
-Wyandotte,DE 1-1,U.S. Senate,,L,Randall Batson,0
-Wyandotte,ED 1-1,U.S. Senate,,L,Randall Batson,54
-Wyandotte,ED 2-1,U.S. Senate,,L,Randall Batson,10
-Wyandotte,KC 1-1,U.S. Senate,,L,Randall Batson,8
-Wyandotte,KC 1-2,U.S. Senate,,L,Randall Batson,1
-Wyandotte,KC 1-3,U.S. Senate,,L,Randall Batson,0
-Wyandotte,KC 2-1,U.S. Senate,,L,Randall Batson,10
-Wyandotte,KC 2-2,U.S. Senate,,L,Randall Batson,6
-Wyandotte,KC 2-3,U.S. Senate,,L,Randall Batson,3
-Wyandotte,KC 2-4,U.S. Senate,,L,Randall Batson,4
-Wyandotte,KC 2-5,U.S. Senate,,L,Randall Batson,17
-Wyandotte,KC 3-1,U.S. Senate,,L,Randall Batson,11
-Wyandotte,KC 3-2,U.S. Senate,,L,Randall Batson,18
-Wyandotte,KC 3-3,U.S. Senate,,L,Randall Batson,8
-Wyandotte,KC 3-4,U.S. Senate,,L,Randall Batson,16
-Wyandotte,KC 4-1,U.S. Senate,,L,Randall Batson,11
-Wyandotte,KC 4-2,U.S. Senate,,L,Randall Batson,4
-Wyandotte,KC 4-3,U.S. Senate,,L,Randall Batson,9
-Wyandotte,KC 4-4,U.S. Senate,,L,Randall Batson,8
-Wyandotte,KC 5-1,U.S. Senate,,L,Randall Batson,10
-Wyandotte,KC 5-2,U.S. Senate,,L,Randall Batson,6
-Wyandotte,KC 5-3,U.S. Senate,,L,Randall Batson,5
-Wyandotte,KC 5-4,U.S. Senate,,L,Randall Batson,4
-Wyandotte,KC 5-5,U.S. Senate,,L,Randall Batson,14
-Wyandotte,KC 6-1,U.S. Senate,,L,Randall Batson,6
-Wyandotte,KC 6-2,U.S. Senate,,L,Randall Batson,3
-Wyandotte,KC 7-1,U.S. Senate,,L,Randall Batson,11
-Wyandotte,KC 7-2,U.S. Senate,,L,Randall Batson,8
-Wyandotte,KC 7-3,U.S. Senate,,L,Randall Batson,9
-Wyandotte,KC 7-4,U.S. Senate,,L,Randall Batson,16
-Wyandotte,KC 7-5,U.S. Senate,,L,Randall Batson,1
-Wyandotte,KC 7-6,U.S. Senate,,L,Randall Batson,19
-Wyandotte,KC 7-7,U.S. Senate,,L,Randall Batson,7
-Wyandotte,KC 7-8,U.S. Senate,,L,Randall Batson,19
-Wyandotte,KC 7-9,U.S. Senate,,L,Randall Batson,13
-Wyandotte,KC 8-1,U.S. Senate,,L,Randall Batson,16
-Wyandotte,KC 8-2,U.S. Senate,,L,Randall Batson,6
-Wyandotte,KC 8-3,U.S. Senate,,L,Randall Batson,20
-Wyandotte,KC 8-4,U.S. Senate,,L,Randall Batson,15
-Wyandotte,KC 9-1,U.S. Senate,,L,Randall Batson,0
-Wyandotte,KC 9-2,U.S. Senate,,L,Randall Batson,4
-Wyandotte,KC 9-3,U.S. Senate,,L,Randall Batson,26
-Wyandotte,KC 9-4,U.S. Senate,,L,Randall Batson,4
-Wyandotte,KC 9-5,U.S. Senate,,L,Randall Batson,0
-Wyandotte,KC 9-6,U.S. Senate,,L,Randall Batson,20
-Wyandotte,KC 9-7,U.S. Senate,,L,Randall Batson,14
-Wyandotte,KC 9-8,U.S. Senate,,L,Randall Batson,10
-Wyandotte,KC 9-9,U.S. Senate,,L,Randall Batson,8
-Wyandotte,KC 9-10,U.S. Senate,,L,Randall Batson,20
-Wyandotte,KC 9-11,U.S. Senate,,L,Randall Batson,13
-Wyandotte,KC 9-12,U.S. Senate,,L,Randall Batson,15
-Wyandotte,KC 9-13,U.S. Senate,,L,Randall Batson,18
-Wyandotte,KC 9-14,U.S. Senate,,L,Randall Batson,11
-Wyandotte,KC 9-15,U.S. Senate,,L,Randall Batson,0
-Wyandotte,KC 9-16,U.S. Senate,,L,Randall Batson,11
-Wyandotte,KC 10-1,U.S. Senate,,L,Randall Batson,9
-Wyandotte,KC 10-2,U.S. Senate,,L,Randall Batson,18
-Wyandotte,KC 10-3,U.S. Senate,,L,Randall Batson,2
-Wyandotte,KC 10-4,U.S. Senate,,L,Randall Batson,9
-Wyandotte,KC 10-5,U.S. Senate,,L,Randall Batson,16
-Wyandotte,KC 11-1,U.S. Senate,,L,Randall Batson,5
-Wyandotte,KC 11-2,U.S. Senate,,L,Randall Batson,19
-Wyandotte,KC 11-3,U.S. Senate,,L,Randall Batson,19
-Wyandotte,KC 11-4,U.S. Senate,,L,Randall Batson,14
-Wyandotte,KC 11-5,U.S. Senate,,L,Randall Batson,15
-Wyandotte,KC 11-6,U.S. Senate,,L,Randall Batson,14
-Wyandotte,KC 11-7,U.S. Senate,,L,Randall Batson,17
-Wyandotte,KC 11-8,U.S. Senate,,L,Randall Batson,14
-Wyandotte,KC 11-9,U.S. Senate,,L,Randall Batson,19
-Wyandotte,KC 11-10,U.S. Senate,,L,Randall Batson,9
-Wyandotte,KC 11-11,U.S. Senate,,L,Randall Batson,28
-Wyandotte,KC 11-12,U.S. Senate,,L,Randall Batson,5
-Wyandotte,KC 12-1,U.S. Senate,,L,Randall Batson,20
-Wyandotte,KC 12-2,U.S. Senate,,L,Randall Batson,8
-Wyandotte,KC 12-3,U.S. Senate,,L,Randall Batson,4
-Wyandotte,KC 12-4,U.S. Senate,,L,Randall Batson,14
-Wyandotte,KC 12-5,U.S. Senate,,L,Randall Batson,17
-Wyandotte,KC 12-6,U.S. Senate,,L,Randall Batson,16
-Wyandotte,KC 12-7,U.S. Senate,,L,Randall Batson,18
-Wyandotte,KC 12-8,U.S. Senate,,L,Randall Batson,20
-Wyandotte,KC 12-9,U.S. Senate,,L,Randall Batson,15
-Wyandotte,KC 12-10,U.S. Senate,,L,Randall Batson,14
-Wyandotte,KC 12-11,U.S. Senate,,L,Randall Batson,3
-Wyandotte,KC 13-1,U.S. Senate,,L,Randall Batson,18
-Wyandotte,KC 13-2,U.S. Senate,,L,Randall Batson,25
-Wyandotte,KC 13-3,U.S. Senate,,L,Randall Batson,14
-Wyandotte,KC 13-4,U.S. Senate,,L,Randall Batson,10
-Wyandotte,KC 13-5,U.S. Senate,,L,Randall Batson,8
-Wyandotte,KC 13-6,U.S. Senate,,L,Randall Batson,21
-Wyandotte,KC 13-7,U.S. Senate,,L,Randall Batson,17
-Wyandotte,KC 13-8,U.S. Senate,,L,Randall Batson,20
-Wyandotte,KC 13-9,U.S. Senate,,L,Randall Batson,13
-Wyandotte,KC 14-1,U.S. Senate,,L,Randall Batson,12
-Wyandotte,KC 14-2,U.S. Senate,,L,Randall Batson,6
-Wyandotte,KC 14-3,U.S. Senate,,L,Randall Batson,9
-Wyandotte,KC 14-4,U.S. Senate,,L,Randall Batson,15
-Wyandotte,KC 14-5,U.S. Senate,,L,Randall Batson,10
-Wyandotte,KC 14-6,U.S. Senate,,L,Randall Batson,15
-Wyandotte,KC 14-7,U.S. Senate,,L,Randall Batson,21
-Wyandotte,KC 14-8,U.S. Senate,,L,Randall Batson,16
-Wyandotte,KC 14-9,U.S. Senate,,L,Randall Batson,7
-Wyandotte,KC 14-10,U.S. Senate,,L,Randall Batson,15
-Wyandotte,KC 14-11,U.S. Senate,,L,Randall Batson,12
-Wyandotte,KC 14-12,U.S. Senate,,L,Randall Batson,16
-Wyandotte,KC 14-13,U.S. Senate,,L,Randall Batson,19
-Wyandotte,KC 14-14,U.S. Senate,,L,Randall Batson,18
-Wyandotte,KC 14-15,U.S. Senate,,L,Randall Batson,30
-Wyandotte,KC 14-16,U.S. Senate,,L,Randall Batson,10
-Wyandotte,OC 1-1,U.S. Senate,,L,Randall Batson,0
-Wyandotte,BS 1-1,U.S. Senate,,I ,Greg Orman,242
-Wyandotte,BS 2-1,U.S. Senate,,I ,Greg Orman,166
-Wyandotte,BS 3-1,U.S. Senate,,I ,Greg Orman,255
-Wyandotte,BS 4-1,U.S. Senate,,I ,Greg Orman,292
-Wyandotte,DE 1-1,U.S. Senate,,I ,Greg Orman,5
-Wyandotte,ED 1-1,U.S. Senate,,I ,Greg Orman,355
-Wyandotte,ED 2-1,U.S. Senate,,I ,Greg Orman,63
-Wyandotte,KC 1-1,U.S. Senate,,I ,Greg Orman,59
-Wyandotte,KC 1-2,U.S. Senate,,I ,Greg Orman,82
-Wyandotte,KC 1-3,U.S. Senate,,I ,Greg Orman,51
-Wyandotte,KC 2-1,U.S. Senate,,I ,Greg Orman,108
-Wyandotte,KC 2-2,U.S. Senate,,I ,Greg Orman,69
-Wyandotte,KC 2-3,U.S. Senate,,I ,Greg Orman,23
-Wyandotte,KC 2-4,U.S. Senate,,I ,Greg Orman,90
-Wyandotte,KC 2-5,U.S. Senate,,I ,Greg Orman,136
-Wyandotte,KC 3-1,U.S. Senate,,I ,Greg Orman,199
-Wyandotte,KC 3-2,U.S. Senate,,I ,Greg Orman,222
-Wyandotte,KC 3-3,U.S. Senate,,I ,Greg Orman,35
-Wyandotte,KC 3-4,U.S. Senate,,I ,Greg Orman,124
-Wyandotte,KC 4-1,U.S. Senate,,I ,Greg Orman,145
-Wyandotte,KC 4-2,U.S. Senate,,I ,Greg Orman,30
-Wyandotte,KC 4-3,U.S. Senate,,I ,Greg Orman,84
-Wyandotte,KC 4-4,U.S. Senate,,I ,Greg Orman,186
-Wyandotte,KC 5-1,U.S. Senate,,I ,Greg Orman,138
-Wyandotte,KC 5-2,U.S. Senate,,I ,Greg Orman,41
-Wyandotte,KC 5-3,U.S. Senate,,I ,Greg Orman,30
-Wyandotte,KC 5-4,U.S. Senate,,I ,Greg Orman,47
-Wyandotte,KC 5-5,U.S. Senate,,I ,Greg Orman,68
-Wyandotte,KC 6-1,U.S. Senate,,I ,Greg Orman,62
-Wyandotte,KC 6-2,U.S. Senate,,I ,Greg Orman,20
-Wyandotte,KC 7-1,U.S. Senate,,I ,Greg Orman,104
-Wyandotte,KC 7-2,U.S. Senate,,I ,Greg Orman,68
-Wyandotte,KC 7-3,U.S. Senate,,I ,Greg Orman,126
-Wyandotte,KC 7-4,U.S. Senate,,I ,Greg Orman,175
-Wyandotte,KC 7-5,U.S. Senate,,I ,Greg Orman,44
-Wyandotte,KC 7-6,U.S. Senate,,I ,Greg Orman,201
-Wyandotte,KC 7-7,U.S. Senate,,I ,Greg Orman,58
-Wyandotte,KC 7-8,U.S. Senate,,I ,Greg Orman,227
-Wyandotte,KC 7-9,U.S. Senate,,I ,Greg Orman,222
-Wyandotte,KC 8-1,U.S. Senate,,I ,Greg Orman,157
-Wyandotte,KC 8-2,U.S. Senate,,I ,Greg Orman,215
-Wyandotte,KC 8-3,U.S. Senate,,I ,Greg Orman,328
-Wyandotte,KC 8-4,U.S. Senate,,I ,Greg Orman,167
-Wyandotte,KC 9-1,U.S. Senate,,I ,Greg Orman,36
-Wyandotte,KC 9-2,U.S. Senate,,I ,Greg Orman,99
-Wyandotte,KC 9-3,U.S. Senate,,I ,Greg Orman,286
-Wyandotte,KC 9-4,U.S. Senate,,I ,Greg Orman,47
-Wyandotte,KC 9-5,U.S. Senate,,I ,Greg Orman,7
-Wyandotte,KC 9-6,U.S. Senate,,I ,Greg Orman,157
-Wyandotte,KC 9-7,U.S. Senate,,I ,Greg Orman,135
-Wyandotte,KC 9-8,U.S. Senate,,I ,Greg Orman,134
-Wyandotte,KC 9-9,U.S. Senate,,I ,Greg Orman,54
-Wyandotte,KC 9-10,U.S. Senate,,I ,Greg Orman,223
-Wyandotte,KC 9-11,U.S. Senate,,I ,Greg Orman,273
-Wyandotte,KC 9-12,U.S. Senate,,I ,Greg Orman,178
-Wyandotte,KC 9-13,U.S. Senate,,I ,Greg Orman,135
-Wyandotte,KC 9-14,U.S. Senate,,I ,Greg Orman,193
-Wyandotte,KC 9-15,U.S. Senate,,I ,Greg Orman,0
-Wyandotte,KC 9-16,U.S. Senate,,I ,Greg Orman,252
-Wyandotte,KC 10-1,U.S. Senate,,I ,Greg Orman,240
-Wyandotte,KC 10-2,U.S. Senate,,I ,Greg Orman,346
-Wyandotte,KC 10-3,U.S. Senate,,I ,Greg Orman,14
-Wyandotte,KC 10-4,U.S. Senate,,I ,Greg Orman,132
-Wyandotte,KC 10-5,U.S. Senate,,I ,Greg Orman,236
-Wyandotte,KC 11-1,U.S. Senate,,I ,Greg Orman,230
-Wyandotte,KC 11-2,U.S. Senate,,I ,Greg Orman,178
-Wyandotte,KC 11-3,U.S. Senate,,I ,Greg Orman,261
-Wyandotte,KC 11-4,U.S. Senate,,I ,Greg Orman,204
-Wyandotte,KC 11-5,U.S. Senate,,I ,Greg Orman,171
-Wyandotte,KC 11-6,U.S. Senate,,I ,Greg Orman,198
-Wyandotte,KC 11-7,U.S. Senate,,I ,Greg Orman,160
-Wyandotte,KC 11-8,U.S. Senate,,I ,Greg Orman,217
-Wyandotte,KC 11-9,U.S. Senate,,I ,Greg Orman,195
-Wyandotte,KC 11-10,U.S. Senate,,I ,Greg Orman,275
-Wyandotte,KC 11-11,U.S. Senate,,I ,Greg Orman,355
-Wyandotte,KC 11-12,U.S. Senate,,I ,Greg Orman,40
-Wyandotte,KC 12-1,U.S. Senate,,I ,Greg Orman,150
-Wyandotte,KC 12-2,U.S. Senate,,I ,Greg Orman,47
-Wyandotte,KC 12-3,U.S. Senate,,I ,Greg Orman,153
-Wyandotte,KC 12-4,U.S. Senate,,I ,Greg Orman,198
-Wyandotte,KC 12-5,U.S. Senate,,I ,Greg Orman,145
-Wyandotte,KC 12-6,U.S. Senate,,I ,Greg Orman,155
-Wyandotte,KC 12-7,U.S. Senate,,I ,Greg Orman,108
-Wyandotte,KC 12-8,U.S. Senate,,I ,Greg Orman,163
-Wyandotte,KC 12-9,U.S. Senate,,I ,Greg Orman,170
-Wyandotte,KC 12-10,U.S. Senate,,I ,Greg Orman,114
-Wyandotte,KC 12-11,U.S. Senate,,I ,Greg Orman,60
-Wyandotte,KC 13-1,U.S. Senate,,I ,Greg Orman,249
-Wyandotte,KC 13-2,U.S. Senate,,I ,Greg Orman,192
-Wyandotte,KC 13-3,U.S. Senate,,I ,Greg Orman,169
-Wyandotte,KC 13-4,U.S. Senate,,I ,Greg Orman,159
-Wyandotte,KC 13-5,U.S. Senate,,I ,Greg Orman,160
-Wyandotte,KC 13-6,U.S. Senate,,I ,Greg Orman,166
-Wyandotte,KC 13-7,U.S. Senate,,I ,Greg Orman,108
-Wyandotte,KC 13-8,U.S. Senate,,I ,Greg Orman,155
-Wyandotte,KC 13-9,U.S. Senate,,I ,Greg Orman,225
-Wyandotte,KC 14-1,U.S. Senate,,I ,Greg Orman,180
-Wyandotte,KC 14-2,U.S. Senate,,I ,Greg Orman,113
-Wyandotte,KC 14-3,U.S. Senate,,I ,Greg Orman,105
-Wyandotte,KC 14-4,U.S. Senate,,I ,Greg Orman,227
-Wyandotte,KC 14-5,U.S. Senate,,I ,Greg Orman,180
-Wyandotte,KC 14-6,U.S. Senate,,I ,Greg Orman,234
-Wyandotte,KC 14-7,U.S. Senate,,I ,Greg Orman,303
-Wyandotte,KC 14-8,U.S. Senate,,I ,Greg Orman,217
-Wyandotte,KC 14-9,U.S. Senate,,I ,Greg Orman,123
-Wyandotte,KC 14-10,U.S. Senate,,I ,Greg Orman,351
-Wyandotte,KC 14-11,U.S. Senate,,I ,Greg Orman,199
-Wyandotte,KC 14-12,U.S. Senate,,I ,Greg Orman,338
-Wyandotte,KC 14-13,U.S. Senate,,I ,Greg Orman,275
-Wyandotte,KC 14-14,U.S. Senate,,I ,Greg Orman,319
-Wyandotte,KC 14-15,U.S. Senate,,I ,Greg Orman,400
-Wyandotte,KC 14-16,U.S. Senate,,I ,Greg Orman,137
-Wyandotte,OC 1-1,U.S. Senate,,I ,Greg Orman,11
-Wyandotte,BS 1-1,U.S. Senate,,R,Pat Roberts,196
-Wyandotte,BS 2-1,U.S. Senate,,R,Pat Roberts,160
-Wyandotte,BS 3-1,U.S. Senate,,R,Pat Roberts,219
-Wyandotte,BS 4-1,U.S. Senate,,R,Pat Roberts,266
-Wyandotte,DE 1-1,U.S. Senate,,R,Pat Roberts,8
-Wyandotte,ED 1-1,U.S. Senate,,R,Pat Roberts,401
-Wyandotte,ED 2-1,U.S. Senate,,R,Pat Roberts,62
-Wyandotte,KC 1-1,U.S. Senate,,R,Pat Roberts,6
-Wyandotte,KC 1-2,U.S. Senate,,R,Pat Roberts,7
-Wyandotte,KC 1-3,U.S. Senate,,R,Pat Roberts,18
-Wyandotte,KC 2-1,U.S. Senate,,R,Pat Roberts,23
-Wyandotte,KC 2-2,U.S. Senate,,R,Pat Roberts,10
-Wyandotte,KC 2-3,U.S. Senate,,R,Pat Roberts,1
-Wyandotte,KC 2-4,U.S. Senate,,R,Pat Roberts,5
-Wyandotte,KC 2-5,U.S. Senate,,R,Pat Roberts,18
-Wyandotte,KC 3-1,U.S. Senate,,R,Pat Roberts,19
-Wyandotte,KC 3-2,U.S. Senate,,R,Pat Roberts,12
-Wyandotte,KC 3-3,U.S. Senate,,R,Pat Roberts,1
-Wyandotte,KC 3-4,U.S. Senate,,R,Pat Roberts,12
-Wyandotte,KC 4-1,U.S. Senate,,R,Pat Roberts,38
-Wyandotte,KC 4-2,U.S. Senate,,R,Pat Roberts,18
-Wyandotte,KC 4-3,U.S. Senate,,R,Pat Roberts,40
-Wyandotte,KC 4-4,U.S. Senate,,R,Pat Roberts,87
-Wyandotte,KC 5-1,U.S. Senate,,R,Pat Roberts,45
-Wyandotte,KC 5-2,U.S. Senate,,R,Pat Roberts,10
-Wyandotte,KC 5-3,U.S. Senate,,R,Pat Roberts,11
-Wyandotte,KC 5-4,U.S. Senate,,R,Pat Roberts,22
-Wyandotte,KC 5-5,U.S. Senate,,R,Pat Roberts,28
-Wyandotte,KC 6-1,U.S. Senate,,R,Pat Roberts,42
-Wyandotte,KC 6-2,U.S. Senate,,R,Pat Roberts,13
-Wyandotte,KC 7-1,U.S. Senate,,R,Pat Roberts,45
-Wyandotte,KC 7-2,U.S. Senate,,R,Pat Roberts,32
-Wyandotte,KC 7-3,U.S. Senate,,R,Pat Roberts,48
-Wyandotte,KC 7-4,U.S. Senate,,R,Pat Roberts,130
-Wyandotte,KC 7-5,U.S. Senate,,R,Pat Roberts,9
-Wyandotte,KC 7-6,U.S. Senate,,R,Pat Roberts,81
-Wyandotte,KC 7-7,U.S. Senate,,R,Pat Roberts,22
-Wyandotte,KC 7-8,U.S. Senate,,R,Pat Roberts,144
-Wyandotte,KC 7-9,U.S. Senate,,R,Pat Roberts,125
-Wyandotte,KC 8-1,U.S. Senate,,R,Pat Roberts,50
-Wyandotte,KC 8-2,U.S. Senate,,R,Pat Roberts,32
-Wyandotte,KC 8-3,U.S. Senate,,R,Pat Roberts,84
-Wyandotte,KC 8-4,U.S. Senate,,R,Pat Roberts,71
-Wyandotte,KC 9-1,U.S. Senate,,R,Pat Roberts,21
-Wyandotte,KC 9-2,U.S. Senate,,R,Pat Roberts,71
-Wyandotte,KC 9-3,U.S. Senate,,R,Pat Roberts,113
-Wyandotte,KC 9-4,U.S. Senate,,R,Pat Roberts,23
-Wyandotte,KC 9-5,U.S. Senate,,R,Pat Roberts,14
-Wyandotte,KC 9-6,U.S. Senate,,R,Pat Roberts,44
-Wyandotte,KC 9-7,U.S. Senate,,R,Pat Roberts,106
-Wyandotte,KC 9-8,U.S. Senate,,R,Pat Roberts,47
-Wyandotte,KC 9-9,U.S. Senate,,R,Pat Roberts,45
-Wyandotte,KC 9-10,U.S. Senate,,R,Pat Roberts,124
-Wyandotte,KC 9-11,U.S. Senate,,R,Pat Roberts,97
-Wyandotte,KC 9-12,U.S. Senate,,R,Pat Roberts,131
-Wyandotte,KC 9-13,U.S. Senate,,R,Pat Roberts,88
-Wyandotte,KC 9-14,U.S. Senate,,R,Pat Roberts,134
-Wyandotte,KC 9-15,U.S. Senate,,R,Pat Roberts,0
-Wyandotte,KC 9-16,U.S. Senate,,R,Pat Roberts,161
-Wyandotte,KC 10-1,U.S. Senate,,R,Pat Roberts,12
-Wyandotte,KC 10-2,U.S. Senate,,R,Pat Roberts,28
-Wyandotte,KC 10-3,U.S. Senate,,R,Pat Roberts,0
-Wyandotte,KC 10-4,U.S. Senate,,R,Pat Roberts,25
-Wyandotte,KC 10-5,U.S. Senate,,R,Pat Roberts,71
-Wyandotte,KC 11-1,U.S. Senate,,R,Pat Roberts,53
-Wyandotte,KC 11-2,U.S. Senate,,R,Pat Roberts,34
-Wyandotte,KC 11-3,U.S. Senate,,R,Pat Roberts,71
-Wyandotte,KC 11-4,U.S. Senate,,R,Pat Roberts,44
-Wyandotte,KC 11-5,U.S. Senate,,R,Pat Roberts,57
-Wyandotte,KC 11-6,U.S. Senate,,R,Pat Roberts,31
-Wyandotte,KC 11-7,U.S. Senate,,R,Pat Roberts,52
-Wyandotte,KC 11-8,U.S. Senate,,R,Pat Roberts,34
-Wyandotte,KC 11-9,U.S. Senate,,R,Pat Roberts,57
-Wyandotte,KC 11-10,U.S. Senate,,R,Pat Roberts,77
-Wyandotte,KC 11-11,U.S. Senate,,R,Pat Roberts,147
-Wyandotte,KC 11-12,U.S. Senate,,R,Pat Roberts,32
-Wyandotte,KC 12-1,U.S. Senate,,R,Pat Roberts,74
-Wyandotte,KC 12-2,U.S. Senate,,R,Pat Roberts,23
-Wyandotte,KC 12-3,U.S. Senate,,R,Pat Roberts,76
-Wyandotte,KC 12-4,U.S. Senate,,R,Pat Roberts,121
-Wyandotte,KC 12-5,U.S. Senate,,R,Pat Roberts,139
-Wyandotte,KC 12-6,U.S. Senate,,R,Pat Roberts,107
-Wyandotte,KC 12-7,U.S. Senate,,R,Pat Roberts,83
-Wyandotte,KC 12-8,U.S. Senate,,R,Pat Roberts,108
-Wyandotte,KC 12-9,U.S. Senate,,R,Pat Roberts,123
-Wyandotte,KC 12-10,U.S. Senate,,R,Pat Roberts,122
-Wyandotte,KC 12-11,U.S. Senate,,R,Pat Roberts,65
-Wyandotte,KC 13-1,U.S. Senate,,R,Pat Roberts,41
-Wyandotte,KC 13-2,U.S. Senate,,R,Pat Roberts,89
-Wyandotte,KC 13-3,U.S. Senate,,R,Pat Roberts,51
-Wyandotte,KC 13-4,U.S. Senate,,R,Pat Roberts,17
-Wyandotte,KC 13-5,U.S. Senate,,R,Pat Roberts,76
-Wyandotte,KC 13-6,U.S. Senate,,R,Pat Roberts,80
-Wyandotte,KC 13-7,U.S. Senate,,R,Pat Roberts,77
-Wyandotte,KC 13-8,U.S. Senate,,R,Pat Roberts,61
-Wyandotte,KC 13-9,U.S. Senate,,R,Pat Roberts,64
-Wyandotte,KC 14-1,U.S. Senate,,R,Pat Roberts,144
-Wyandotte,KC 14-2,U.S. Senate,,R,Pat Roberts,49
-Wyandotte,KC 14-3,U.S. Senate,,R,Pat Roberts,40
-Wyandotte,KC 14-4,U.S. Senate,,R,Pat Roberts,73
-Wyandotte,KC 14-5,U.S. Senate,,R,Pat Roberts,88
-Wyandotte,KC 14-6,U.S. Senate,,R,Pat Roberts,124
-Wyandotte,KC 14-7,U.S. Senate,,R,Pat Roberts,147
-Wyandotte,KC 14-8,U.S. Senate,,R,Pat Roberts,105
-Wyandotte,KC 14-9,U.S. Senate,,R,Pat Roberts,114
-Wyandotte,KC 14-10,U.S. Senate,,R,Pat Roberts,264
-Wyandotte,KC 14-11,U.S. Senate,,R,Pat Roberts,124
-Wyandotte,KC 14-12,U.S. Senate,,R,Pat Roberts,267
-Wyandotte,KC 14-13,U.S. Senate,,R,Pat Roberts,157
-Wyandotte,KC 14-14,U.S. Senate,,R,Pat Roberts,326
-Wyandotte,KC 14-15,U.S. Senate,,R,Pat Roberts,399
-Wyandotte,KC 14-16,U.S. Senate,,R,Pat Roberts,87
-Wyandotte,OC 1-1,U.S. Senate,,R,Pat Roberts,16
-Wyandotte,BS 1-1,U.S. Senate,,,Write-ins,2
-Wyandotte,BS 2-1,U.S. Senate,,,Write-ins,0
-Wyandotte,BS 3-1,U.S. Senate,,,Write-ins,0
-Wyandotte,BS 4-1,U.S. Senate,,,Write-ins,1
-Wyandotte,DE 1-1,U.S. Senate,,,Write-ins,0
-Wyandotte,ED 1-1,U.S. Senate,,,Write-ins,2
-Wyandotte,ED 2-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 1-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 1-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 1-3,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 2-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 2-2,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 2-3,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 2-4,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 2-5,U.S. Senate,,,Write-ins,3
-Wyandotte,KC 3-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 3-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 3-3,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 3-4,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 4-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 4-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 4-3,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 4-4,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 5-1,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 5-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 5-3,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 5-4,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 5-5,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 6-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 6-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 7-1,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 7-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 7-3,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 7-4,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 7-5,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 7-6,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 7-7,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 7-8,U.S. Senate,,,Write-ins,4
-Wyandotte,KC 7-9,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 8-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 8-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 8-3,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 8-4,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 9-1,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 9-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-3,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-4,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-5,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-6,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 9-7,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 9-8,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-9,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 9-10,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 9-11,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 9-12,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-13,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-14,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-15,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 9-16,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 10-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 10-2,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 10-3,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 10-4,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 10-5,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 11-1,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 11-2,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 11-3,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 11-4,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 11-5,U.S. Senate,,,Write-ins,3
-Wyandotte,KC 11-6,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 11-7,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 11-8,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 11-9,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 11-10,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 11-11,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 11-12,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 12-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 12-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 12-3,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 12-4,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 12-5,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 12-6,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 12-7,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 12-8,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 12-9,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 12-10,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 12-11,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 13-1,U.S. Senate,,,Write-ins,3
-Wyandotte,KC 13-2,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 13-3,U.S. Senate,,,Write-ins,3
-Wyandotte,KC 13-4,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 13-5,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 13-6,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 13-7,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 13-8,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 13-9,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 14-1,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 14-2,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 14-3,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 14-4,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-5,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-6,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 14-7,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-8,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-9,U.S. Senate,,,Write-ins,0
-Wyandotte,KC 14-10,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-11,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-12,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-13,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-14,U.S. Senate,,,Write-ins,1
-Wyandotte,KC 14-15,U.S. Senate,,,Write-ins,2
-Wyandotte,KC 14-16,U.S. Senate,,,Write-ins,0
-Wyandotte,OC 1-1,U.S. Senate,,,Write-ins,0
-Wyandotte,BS 1-1,U.S. House,3,D,Kelly Kultala,203
-Wyandotte,BS 2-1,U.S. House,3,D,Kelly Kultala,148
-Wyandotte,BS 3-1,U.S. House,3,D,Kelly Kultala,238
-Wyandotte,BS 4-1,U.S. House,3,D,Kelly Kultala,274
-Wyandotte,DE 1-1,U.S. House,3,D,Kelly Kultala,5
-Wyandotte,ED 1-1,U.S. House,3,D,Kelly Kultala,307
-Wyandotte,ED 2-1,U.S. House,3,D,Kelly Kultala,54
-Wyandotte,KC 1-1,U.S. House,3,D,Kelly Kultala,71
-Wyandotte,KC 1-2,U.S. House,3,D,Kelly Kultala,81
-Wyandotte,KC 1-3,U.S. House,3,D,Kelly Kultala,44
-Wyandotte,KC 2-1,U.S. House,3,D,Kelly Kultala,105
-Wyandotte,KC 2-2,U.S. House,3,D,Kelly Kultala,78
-Wyandotte,KC 2-3,U.S. House,3,D,Kelly Kultala,27
-Wyandotte,KC 2-4,U.S. House,3,D,Kelly Kultala,90
-Wyandotte,KC 2-5,U.S. House,3,D,Kelly Kultala,156
-Wyandotte,KC 3-1,U.S. House,3,D,Kelly Kultala,228
-Wyandotte,KC 3-2,U.S. House,3,D,Kelly Kultala,233
-Wyandotte,KC 3-3,U.S. House,3,D,Kelly Kultala,44
-Wyandotte,KC 3-4,U.S. House,3,D,Kelly Kultala,136
-Wyandotte,KC 4-1,U.S. House,3,D,Kelly Kultala,136
-Wyandotte,KC 4-2,U.S. House,3,D,Kelly Kultala,35
-Wyandotte,KC 4-3,U.S. House,3,D,Kelly Kultala,84
-Wyandotte,KC 4-4,U.S. House,3,D,Kelly Kultala,195
-Wyandotte,KC 5-1,U.S. House,3,D,Kelly Kultala,127
-Wyandotte,KC 5-2,U.S. House,3,D,Kelly Kultala,41
-Wyandotte,KC 5-3,U.S. House,3,D,Kelly Kultala,31
-Wyandotte,KC 5-4,U.S. House,3,D,Kelly Kultala,42
-Wyandotte,KC 5-5,U.S. House,3,D,Kelly Kultala,69
-Wyandotte,KC 6-1,U.S. House,3,D,Kelly Kultala,53
-Wyandotte,KC 6-2,U.S. House,3,D,Kelly Kultala,21
-Wyandotte,KC 7-1,U.S. House,3,D,Kelly Kultala,99
-Wyandotte,KC 7-2,U.S. House,3,D,Kelly Kultala,67
-Wyandotte,KC 7-3,U.S. House,3,D,Kelly Kultala,118
-Wyandotte,KC 7-4,U.S. House,3,D,Kelly Kultala,143
-Wyandotte,KC 7-5,U.S. House,3,D,Kelly Kultala,35
-Wyandotte,KC 7-6,U.S. House,3,D,Kelly Kultala,182
-Wyandotte,KC 7-7,U.S. House,3,D,Kelly Kultala,58
-Wyandotte,KC 7-8,U.S. House,3,D,Kelly Kultala,204
-Wyandotte,KC 7-9,U.S. House,3,D,Kelly Kultala,185
-Wyandotte,KC 8-1,U.S. House,3,D,Kelly Kultala,159
-Wyandotte,KC 8-2,U.S. House,3,D,Kelly Kultala,203
-Wyandotte,KC 8-3,U.S. House,3,D,Kelly Kultala,312
-Wyandotte,KC 8-4,U.S. House,3,D,Kelly Kultala,150
-Wyandotte,KC 9-1,U.S. House,3,D,Kelly Kultala,32
-Wyandotte,KC 9-2,U.S. House,3,D,Kelly Kultala,80
-Wyandotte,KC 9-3,U.S. House,3,D,Kelly Kultala,271
-Wyandotte,KC 9-4,U.S. House,3,D,Kelly Kultala,48
-Wyandotte,KC 9-5,U.S. House,3,D,Kelly Kultala,4
-Wyandotte,KC 9-6,U.S. House,3,D,Kelly Kultala,163
-Wyandotte,KC 9-7,U.S. House,3,D,Kelly Kultala,118
-Wyandotte,KC 9-8,U.S. House,3,D,Kelly Kultala,125
-Wyandotte,KC 9-9,U.S. House,3,D,Kelly Kultala,58
-Wyandotte,KC 9-10,U.S. House,3,D,Kelly Kultala,226
-Wyandotte,KC 9-11,U.S. House,3,D,Kelly Kultala,264
-Wyandotte,KC 9-12,U.S. House,3,D,Kelly Kultala,168
-Wyandotte,KC 9-13,U.S. House,3,D,Kelly Kultala,118
-Wyandotte,KC 9-14,U.S. House,3,D,Kelly Kultala,167
-Wyandotte,KC 9-15,U.S. House,3,D,Kelly Kultala,0
-Wyandotte,KC 9-16,U.S. House,3,D,Kelly Kultala,240
-Wyandotte,KC 10-1,U.S. House,3,D,Kelly Kultala,243
-Wyandotte,KC 10-2,U.S. House,3,D,Kelly Kultala,365
-Wyandotte,KC 10-3,U.S. House,3,D,Kelly Kultala,15
-Wyandotte,KC 10-4,U.S. House,3,D,Kelly Kultala,131
-Wyandotte,KC 10-5,U.S. House,3,D,Kelly Kultala,226
-Wyandotte,KC 11-1,U.S. House,3,D,Kelly Kultala,226
-Wyandotte,KC 11-2,U.S. House,3,D,Kelly Kultala,178
-Wyandotte,KC 11-3,U.S. House,3,D,Kelly Kultala,256
-Wyandotte,KC 11-4,U.S. House,3,D,Kelly Kultala,198
-Wyandotte,KC 11-5,U.S. House,3,D,Kelly Kultala,161
-Wyandotte,KC 11-6,U.S. House,3,D,Kelly Kultala,218
-Wyandotte,KC 11-7,U.S. House,3,D,Kelly Kultala,167
-Wyandotte,KC 11-8,U.S. House,3,D,Kelly Kultala,215
-Wyandotte,KC 11-9,U.S. House,3,D,Kelly Kultala,199
-Wyandotte,KC 11-10,U.S. House,3,D,Kelly Kultala,260
-Wyandotte,KC 11-11,U.S. House,3,D,Kelly Kultala,338
-Wyandotte,KC 11-12,U.S. House,3,D,Kelly Kultala,45
-Wyandotte,KC 12-1,U.S. House,3,D,Kelly Kultala,148
-Wyandotte,KC 12-2,U.S. House,3,D,Kelly Kultala,48
-Wyandotte,KC 12-3,U.S. House,3,D,Kelly Kultala,141
-Wyandotte,KC 12-4,U.S. House,3,D,Kelly Kultala,170
-Wyandotte,KC 12-5,U.S. House,3,D,Kelly Kultala,129
-Wyandotte,KC 12-6,U.S. House,3,D,Kelly Kultala,136
-Wyandotte,KC 12-7,U.S. House,3,D,Kelly Kultala,89
-Wyandotte,KC 12-8,U.S. House,3,D,Kelly Kultala,144
-Wyandotte,KC 12-9,U.S. House,3,D,Kelly Kultala,154
-Wyandotte,KC 12-10,U.S. House,3,D,Kelly Kultala,107
-Wyandotte,KC 12-11,U.S. House,3,D,Kelly Kultala,44
-Wyandotte,KC 13-1,U.S. House,3,D,Kelly Kultala,264
-Wyandotte,KC 13-2,U.S. House,3,D,Kelly Kultala,188
-Wyandotte,KC 13-3,U.S. House,3,D,Kelly Kultala,171
-Wyandotte,KC 13-4,U.S. House,3,D,Kelly Kultala,164
-Wyandotte,KC 13-5,U.S. House,3,D,Kelly Kultala,149
-Wyandotte,KC 13-6,U.S. House,3,D,Kelly Kultala,158
-Wyandotte,KC 13-7,U.S. House,3,D,Kelly Kultala,101
-Wyandotte,KC 13-8,U.S. House,3,D,Kelly Kultala,155
-Wyandotte,KC 13-9,U.S. House,3,D,Kelly Kultala,219
-Wyandotte,KC 14-1,U.S. House,3,D,Kelly Kultala,166
-Wyandotte,KC 14-2,U.S. House,3,D,Kelly Kultala,106
-Wyandotte,KC 14-3,U.S. House,3,D,Kelly Kultala,103
-Wyandotte,KC 14-4,U.S. House,3,D,Kelly Kultala,216
-Wyandotte,KC 14-5,U.S. House,3,D,Kelly Kultala,183
-Wyandotte,KC 14-6,U.S. House,3,D,Kelly Kultala,216
-Wyandotte,KC 14-7,U.S. House,3,D,Kelly Kultala,309
-Wyandotte,KC 14-8,U.S. House,3,D,Kelly Kultala,216
-Wyandotte,KC 14-9,U.S. House,3,D,Kelly Kultala,102
-Wyandotte,KC 14-10,U.S. House,3,D,Kelly Kultala,309
-Wyandotte,KC 14-11,U.S. House,3,D,Kelly Kultala,197
-Wyandotte,KC 14-12,U.S. House,3,D,Kelly Kultala,319
-Wyandotte,KC 14-13,U.S. House,3,D,Kelly Kultala,256
-Wyandotte,KC 14-14,U.S. House,3,D,Kelly Kultala,313
-Wyandotte,KC 14-15,U.S. House,3,D,Kelly Kultala,366
-Wyandotte,KC 14-16,U.S. House,3,D,Kelly Kultala,130
-Wyandotte,OC 1-1,U.S. House,3,D,Kelly Kultala,7
-Wyandotte,BS 1-1,U.S. House,3,R,Kevin Yoder,252
-Wyandotte,BS 2-1,U.S. House,3,R,Kevin Yoder,195
-Wyandotte,BS 3-1,U.S. House,3,R,Kevin Yoder,258
-Wyandotte,BS 4-1,U.S. House,3,R,Kevin Yoder,309
-Wyandotte,DE 1-1,U.S. House,3,R,Kevin Yoder,8
-Wyandotte,ED 1-1,U.S. House,3,R,Kevin Yoder,495
-Wyandotte,ED 2-1,U.S. House,3,R,Kevin Yoder,76
-Wyandotte,KC 1-1,U.S. House,3,R,Kevin Yoder,12
-Wyandotte,KC 1-2,U.S. House,3,R,Kevin Yoder,9
-Wyandotte,KC 1-3,U.S. House,3,R,Kevin Yoder,21
-Wyandotte,KC 2-1,U.S. House,3,R,Kevin Yoder,39
-Wyandotte,KC 2-2,U.S. House,3,R,Kevin Yoder,13
-Wyandotte,KC 2-3,U.S. House,3,R,Kevin Yoder,2
-Wyandotte,KC 2-4,U.S. House,3,R,Kevin Yoder,12
-Wyandotte,KC 2-5,U.S. House,3,R,Kevin Yoder,24
-Wyandotte,KC 3-1,U.S. House,3,R,Kevin Yoder,27
-Wyandotte,KC 3-2,U.S. House,3,R,Kevin Yoder,26
-Wyandotte,KC 3-3,U.S. House,3,R,Kevin Yoder,2
-Wyandotte,KC 3-4,U.S. House,3,R,Kevin Yoder,18
-Wyandotte,KC 4-1,U.S. House,3,R,Kevin Yoder,60
-Wyandotte,KC 4-2,U.S. House,3,R,Kevin Yoder,20
-Wyandotte,KC 4-3,U.S. House,3,R,Kevin Yoder,52
-Wyandotte,KC 4-4,U.S. House,3,R,Kevin Yoder,92
-Wyandotte,KC 5-1,U.S. House,3,R,Kevin Yoder,65
-Wyandotte,KC 5-2,U.S. House,3,R,Kevin Yoder,15
-Wyandotte,KC 5-3,U.S. House,3,R,Kevin Yoder,17
-Wyandotte,KC 5-4,U.S. House,3,R,Kevin Yoder,30
-Wyandotte,KC 5-5,U.S. House,3,R,Kevin Yoder,42
-Wyandotte,KC 6-1,U.S. House,3,R,Kevin Yoder,58
-Wyandotte,KC 6-2,U.S. House,3,R,Kevin Yoder,15
-Wyandotte,KC 7-1,U.S. House,3,R,Kevin Yoder,62
-Wyandotte,KC 7-2,U.S. House,3,R,Kevin Yoder,42
-Wyandotte,KC 7-3,U.S. House,3,R,Kevin Yoder,68
-Wyandotte,KC 7-4,U.S. House,3,R,Kevin Yoder,178
-Wyandotte,KC 7-5,U.S. House,3,R,Kevin Yoder,17
-Wyandotte,KC 7-6,U.S. House,3,R,Kevin Yoder,124
-Wyandotte,KC 7-7,U.S. House,3,R,Kevin Yoder,35
-Wyandotte,KC 7-8,U.S. House,3,R,Kevin Yoder,187
-Wyandotte,KC 7-9,U.S. House,3,R,Kevin Yoder,176
-Wyandotte,KC 8-1,U.S. House,3,R,Kevin Yoder,65
-Wyandotte,KC 8-2,U.S. House,3,R,Kevin Yoder,44
-Wyandotte,KC 8-3,U.S. House,3,R,Kevin Yoder,119
-Wyandotte,KC 8-4,U.S. House,3,R,Kevin Yoder,95
-Wyandotte,KC 9-1,U.S. House,3,R,Kevin Yoder,25
-Wyandotte,KC 9-2,U.S. House,3,R,Kevin Yoder,90
-Wyandotte,KC 9-3,U.S. House,3,R,Kevin Yoder,159
-Wyandotte,KC 9-4,U.S. House,3,R,Kevin Yoder,25
-Wyandotte,KC 9-5,U.S. House,3,R,Kevin Yoder,17
-Wyandotte,KC 9-6,U.S. House,3,R,Kevin Yoder,61
-Wyandotte,KC 9-7,U.S. House,3,R,Kevin Yoder,135
-Wyandotte,KC 9-8,U.S. House,3,R,Kevin Yoder,61
-Wyandotte,KC 9-9,U.S. House,3,R,Kevin Yoder,52
-Wyandotte,KC 9-10,U.S. House,3,R,Kevin Yoder,145
-Wyandotte,KC 9-11,U.S. House,3,R,Kevin Yoder,124
-Wyandotte,KC 9-12,U.S. House,3,R,Kevin Yoder,160
-Wyandotte,KC 9-13,U.S. House,3,R,Kevin Yoder,120
-Wyandotte,KC 9-14,U.S. House,3,R,Kevin Yoder,168
-Wyandotte,KC 9-15,U.S. House,3,R,Kevin Yoder,0
-Wyandotte,KC 9-16,U.S. House,3,R,Kevin Yoder,183
-Wyandotte,KC 10-1,U.S. House,3,R,Kevin Yoder,25
-Wyandotte,KC 10-2,U.S. House,3,R,Kevin Yoder,45
-Wyandotte,KC 10-3,U.S. House,3,R,Kevin Yoder,1
-Wyandotte,KC 10-4,U.S. House,3,R,Kevin Yoder,37
-Wyandotte,KC 10-5,U.S. House,3,R,Kevin Yoder,94
-Wyandotte,KC 11-1,U.S. House,3,R,Kevin Yoder,70
-Wyandotte,KC 11-2,U.S. House,3,R,Kevin Yoder,60
-Wyandotte,KC 11-3,U.S. House,3,R,Kevin Yoder,97
-Wyandotte,KC 11-4,U.S. House,3,R,Kevin Yoder,68
-Wyandotte,KC 11-5,U.S. House,3,R,Kevin Yoder,89
-Wyandotte,KC 11-6,U.S. House,3,R,Kevin Yoder,38
-Wyandotte,KC 11-7,U.S. House,3,R,Kevin Yoder,69
-Wyandotte,KC 11-8,U.S. House,3,R,Kevin Yoder,54
-Wyandotte,KC 11-9,U.S. House,3,R,Kevin Yoder,74
-Wyandotte,KC 11-10,U.S. House,3,R,Kevin Yoder,101
-Wyandotte,KC 11-11,U.S. House,3,R,Kevin Yoder,183
-Wyandotte,KC 11-12,U.S. House,3,R,Kevin Yoder,34
-Wyandotte,KC 12-1,U.S. House,3,R,Kevin Yoder,95
-Wyandotte,KC 12-2,U.S. House,3,R,Kevin Yoder,26
-Wyandotte,KC 12-3,U.S. House,3,R,Kevin Yoder,90
-Wyandotte,KC 12-4,U.S. House,3,R,Kevin Yoder,156
-Wyandotte,KC 12-5,U.S. House,3,R,Kevin Yoder,173
-Wyandotte,KC 12-6,U.S. House,3,R,Kevin Yoder,139
-Wyandotte,KC 12-7,U.S. House,3,R,Kevin Yoder,117
-Wyandotte,KC 12-8,U.S. House,3,R,Kevin Yoder,147
-Wyandotte,KC 12-9,U.S. House,3,R,Kevin Yoder,155
-Wyandotte,KC 12-10,U.S. House,3,R,Kevin Yoder,143
-Wyandotte,KC 12-11,U.S. House,3,R,Kevin Yoder,79
-Wyandotte,KC 13-1,U.S. House,3,R,Kevin Yoder,57
-Wyandotte,KC 13-2,U.S. House,3,R,Kevin Yoder,123
-Wyandotte,KC 13-3,U.S. House,3,R,Kevin Yoder,66
-Wyandotte,KC 13-4,U.S. House,3,R,Kevin Yoder,29
-Wyandotte,KC 13-5,U.S. House,3,R,Kevin Yoder,97
-Wyandotte,KC 13-6,U.S. House,3,R,Kevin Yoder,111
-Wyandotte,KC 13-7,U.S. House,3,R,Kevin Yoder,101
-Wyandotte,KC 13-8,U.S. House,3,R,Kevin Yoder,83
-Wyandotte,KC 13-9,U.S. House,3,R,Kevin Yoder,94
-Wyandotte,KC 14-1,U.S. House,3,R,Kevin Yoder,173
-Wyandotte,KC 14-2,U.S. House,3,R,Kevin Yoder,66
-Wyandotte,KC 14-3,U.S. House,3,R,Kevin Yoder,50
-Wyandotte,KC 14-4,U.S. House,3,R,Kevin Yoder,104
-Wyandotte,KC 14-5,U.S. House,3,R,Kevin Yoder,101
-Wyandotte,KC 14-6,U.S. House,3,R,Kevin Yoder,152
-Wyandotte,KC 14-7,U.S. House,3,R,Kevin Yoder,168
-Wyandotte,KC 14-8,U.S. House,3,R,Kevin Yoder,128
-Wyandotte,KC 14-9,U.S. House,3,R,Kevin Yoder,143
-Wyandotte,KC 14-10,U.S. House,3,R,Kevin Yoder,311
-Wyandotte,KC 14-11,U.S. House,3,R,Kevin Yoder,146
-Wyandotte,KC 14-12,U.S. House,3,R,Kevin Yoder,307
-Wyandotte,KC 14-13,U.S. House,3,R,Kevin Yoder,193
-Wyandotte,KC 14-14,U.S. House,3,R,Kevin Yoder,357
-Wyandotte,KC 14-15,U.S. House,3,R,Kevin Yoder,463
-Wyandotte,KC 14-16,U.S. House,3,R,Kevin Yoder,103
-Wyandotte,OC 1-1,U.S. House,3,R,Kevin Yoder,20
-Wyandotte,BS 1-1,U.S. House,3,,Write-ins,1
-Wyandotte,BS 2-1,U.S. House,3,,Write-ins,0
-Wyandotte,BS 3-1,U.S. House,3,,Write-ins,0
-Wyandotte,BS 4-1,U.S. House,3,,Write-ins,1
-Wyandotte,DE 1-1,U.S. House,3,,Write-ins,0
-Wyandotte,ED 1-1,U.S. House,3,,Write-ins,1
-Wyandotte,ED 2-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 1-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 1-2,U.S. House,3,,Write-ins,0
-Wyandotte,KC 1-3,U.S. House,3,,Write-ins,1
-Wyandotte,KC 2-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 2-2,U.S. House,3,,Write-ins,1
-Wyandotte,KC 2-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 2-4,U.S. House,3,,Write-ins,0
-Wyandotte,KC 2-5,U.S. House,3,,Write-ins,0
-Wyandotte,KC 3-1,U.S. House,3,,Write-ins,1
-Wyandotte,KC 3-2,U.S. House,3,,Write-ins,0
-Wyandotte,KC 3-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 3-4,U.S. House,3,,Write-ins,3
-Wyandotte,KC 4-1,U.S. House,3,,Write-ins,1
-Wyandotte,KC 4-2,U.S. House,3,,Write-ins,0
-Wyandotte,KC 4-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 4-4,U.S. House,3,,Write-ins,1
-Wyandotte,KC 5-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 5-2,U.S. House,3,,Write-ins,1
-Wyandotte,KC 5-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 5-4,U.S. House,3,,Write-ins,0
-Wyandotte,KC 5-5,U.S. House,3,,Write-ins,0
-Wyandotte,KC 6-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 6-2,U.S. House,3,,Write-ins,0
-Wyandotte,KC 7-1,U.S. House,3,,Write-ins,2
-Wyandotte,KC 7-2,U.S. House,3,,Write-ins,0
-Wyandotte,KC 7-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 7-4,U.S. House,3,,Write-ins,0
-Wyandotte,KC 7-5,U.S. House,3,,Write-ins,0
-Wyandotte,KC 7-6,U.S. House,3,,Write-ins,0
-Wyandotte,KC 7-7,U.S. House,3,,Write-ins,1
-Wyandotte,KC 7-8,U.S. House,3,,Write-ins,1
-Wyandotte,KC 7-9,U.S. House,3,,Write-ins,0
-Wyandotte,KC 8-1,U.S. House,3,,Write-ins,1
-Wyandotte,KC 8-2,U.S. House,3,,Write-ins,0
-Wyandotte,KC 8-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 8-4,U.S. House,3,,Write-ins,1
-Wyandotte,KC 9-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-2,U.S. House,3,,Write-ins,1
-Wyandotte,KC 9-3,U.S. House,3,,Write-ins,1
-Wyandotte,KC 9-4,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-5,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-6,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-7,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-8,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-9,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-10,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-11,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-12,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-13,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-14,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-15,U.S. House,3,,Write-ins,0
-Wyandotte,KC 9-16,U.S. House,3,,Write-ins,0
-Wyandotte,KC 10-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 10-2,U.S. House,3,,Write-ins,0
-Wyandotte,KC 10-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 10-4,U.S. House,3,,Write-ins,1
-Wyandotte,KC 10-5,U.S. House,3,,Write-ins,1
-Wyandotte,KC 11-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 11-2,U.S. House,3,,Write-ins,2
-Wyandotte,KC 11-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 11-4,U.S. House,3,,Write-ins,0
-Wyandotte,KC 11-5,U.S. House,3,,Write-ins,0
-Wyandotte,KC 11-6,U.S. House,3,,Write-ins,0
-Wyandotte,KC 11-7,U.S. House,3,,Write-ins,2
-Wyandotte,KC 11-8,U.S. House,3,,Write-ins,0
-Wyandotte,KC 11-9,U.S. House,3,,Write-ins,1
-Wyandotte,KC 11-10,U.S. House,3,,Write-ins,1
-Wyandotte,KC 11-11,U.S. House,3,,Write-ins,2
-Wyandotte,KC 11-12,U.S. House,3,,Write-ins,0
-Wyandotte,KC 12-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 12-2,U.S. House,3,,Write-ins,1
-Wyandotte,KC 12-3,U.S. House,3,,Write-ins,1
-Wyandotte,KC 12-4,U.S. House,3,,Write-ins,1
-Wyandotte,KC 12-5,U.S. House,3,,Write-ins,1
-Wyandotte,KC 12-6,U.S. House,3,,Write-ins,0
-Wyandotte,KC 12-7,U.S. House,3,,Write-ins,0
-Wyandotte,KC 12-8,U.S. House,3,,Write-ins,0
-Wyandotte,KC 12-9,U.S. House,3,,Write-ins,0
-Wyandotte,KC 12-10,U.S. House,3,,Write-ins,1
-Wyandotte,KC 12-11,U.S. House,3,,Write-ins,1
-Wyandotte,KC 13-1,U.S. House,3,,Write-ins,0
-Wyandotte,KC 13-2,U.S. House,3,,Write-ins,0
-Wyandotte,KC 13-3,U.S. House,3,,Write-ins,1
-Wyandotte,KC 13-4,U.S. House,3,,Write-ins,0
-Wyandotte,KC 13-5,U.S. House,3,,Write-ins,0
-Wyandotte,KC 13-6,U.S. House,3,,Write-ins,1
-Wyandotte,KC 13-7,U.S. House,3,,Write-ins,1
-Wyandotte,KC 13-8,U.S. House,3,,Write-ins,1
-Wyandotte,KC 13-9,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-1,U.S. House,3,,Write-ins,1
-Wyandotte,KC 14-2,U.S. House,3,,Write-ins,1
-Wyandotte,KC 14-3,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-4,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-5,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-6,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-7,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-8,U.S. House,3,,Write-ins,3
-Wyandotte,KC 14-9,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-10,U.S. House,3,,Write-ins,2
-Wyandotte,KC 14-11,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-12,U.S. House,3,,Write-ins,0
-Wyandotte,KC 14-13,U.S. House,3,,Write-ins,1
-Wyandotte,KC 14-14,U.S. House,3,,Write-ins,1
-Wyandotte,KC 14-15,U.S. House,3,,Write-ins,1
-Wyandotte,KC 14-16,U.S. House,3,,Write-ins,1
-Wyandotte,OC 1-1,U.S. House,3,,Write-ins,0
-Wyandotte,BS 1-1,Governor,,R,Sam Brownback,208
-Wyandotte,BS 2-1,Governor,,R,Sam Brownback,161
-Wyandotte,BS 3-1,Governor,,R,Sam Brownback,224
-Wyandotte,BS 4-1,Governor,,R,Sam Brownback,253
-Wyandotte,DE 1-1,Governor,,R,Sam Brownback,7
-Wyandotte,ED 1-1,Governor,,R,Sam Brownback,419
-Wyandotte,ED 2-1,Governor,,R,Sam Brownback,68
-Wyandotte,KC 1-1,Governor,,R,Sam Brownback,7
-Wyandotte,KC 1-2,Governor,,R,Sam Brownback,9
-Wyandotte,KC 1-3,Governor,,R,Sam Brownback,19
-Wyandotte,KC 2-1,Governor,,R,Sam Brownback,28
-Wyandotte,KC 2-2,Governor,,R,Sam Brownback,11
-Wyandotte,KC 2-3,Governor,,R,Sam Brownback,2
-Wyandotte,KC 2-4,Governor,,R,Sam Brownback,6
-Wyandotte,KC 2-5,Governor,,R,Sam Brownback,23
-Wyandotte,KC 3-1,Governor,,R,Sam Brownback,19
-Wyandotte,KC 3-2,Governor,,R,Sam Brownback,15
-Wyandotte,KC 3-3,Governor,,R,Sam Brownback,2
-Wyandotte,KC 3-4,Governor,,R,Sam Brownback,11
-Wyandotte,KC 4-1,Governor,,R,Sam Brownback,38
-Wyandotte,KC 4-2,Governor,,R,Sam Brownback,17
-Wyandotte,KC 4-3,Governor,,R,Sam Brownback,38
-Wyandotte,KC 4-4,Governor,,R,Sam Brownback,84
-Wyandotte,KC 5-1,Governor,,R,Sam Brownback,47
-Wyandotte,KC 5-2,Governor,,R,Sam Brownback,11
-Wyandotte,KC 5-3,Governor,,R,Sam Brownback,14
-Wyandotte,KC 5-4,Governor,,R,Sam Brownback,21
-Wyandotte,KC 5-5,Governor,,R,Sam Brownback,28
-Wyandotte,KC 6-1,Governor,,R,Sam Brownback,41
-Wyandotte,KC 6-2,Governor,,R,Sam Brownback,16
-Wyandotte,KC 7-1,Governor,,R,Sam Brownback,48
-Wyandotte,KC 7-2,Governor,,R,Sam Brownback,33
-Wyandotte,KC 7-3,Governor,,R,Sam Brownback,53
-Wyandotte,KC 7-4,Governor,,R,Sam Brownback,141
-Wyandotte,KC 7-5,Governor,,R,Sam Brownback,14
-Wyandotte,KC 7-6,Governor,,R,Sam Brownback,92
-Wyandotte,KC 7-7,Governor,,R,Sam Brownback,24
-Wyandotte,KC 7-8,Governor,,R,Sam Brownback,142
-Wyandotte,KC 7-9,Governor,,R,Sam Brownback,121
-Wyandotte,KC 8-1,Governor,,R,Sam Brownback,47
-Wyandotte,KC 8-2,Governor,,R,Sam Brownback,30
-Wyandotte,KC 8-3,Governor,,R,Sam Brownback,93
-Wyandotte,KC 8-4,Governor,,R,Sam Brownback,70
-Wyandotte,KC 9-1,Governor,,R,Sam Brownback,22
-Wyandotte,KC 9-2,Governor,,R,Sam Brownback,72
-Wyandotte,KC 9-3,Governor,,R,Sam Brownback,109
-Wyandotte,KC 9-4,Governor,,R,Sam Brownback,25
-Wyandotte,KC 9-5,Governor,,R,Sam Brownback,14
-Wyandotte,KC 9-6,Governor,,R,Sam Brownback,41
-Wyandotte,KC 9-7,Governor,,R,Sam Brownback,109
-Wyandotte,KC 9-8,Governor,,R,Sam Brownback,43
-Wyandotte,KC 9-9,Governor,,R,Sam Brownback,47
-Wyandotte,KC 9-10,Governor,,R,Sam Brownback,112
-Wyandotte,KC 9-11,Governor,,R,Sam Brownback,90
-Wyandotte,KC 9-12,Governor,,R,Sam Brownback,130
-Wyandotte,KC 9-13,Governor,,R,Sam Brownback,88
-Wyandotte,KC 9-14,Governor,,R,Sam Brownback,133
-Wyandotte,KC 9-15,Governor,,R,Sam Brownback,0
-Wyandotte,KC 9-16,Governor,,R,Sam Brownback,157
-Wyandotte,KC 10-1,Governor,,R,Sam Brownback,14
-Wyandotte,KC 10-2,Governor,,R,Sam Brownback,28
-Wyandotte,KC 10-3,Governor,,R,Sam Brownback,1
-Wyandotte,KC 10-4,Governor,,R,Sam Brownback,26
-Wyandotte,KC 10-5,Governor,,R,Sam Brownback,65
-Wyandotte,KC 11-1,Governor,,R,Sam Brownback,50
-Wyandotte,KC 11-2,Governor,,R,Sam Brownback,40
-Wyandotte,KC 11-3,Governor,,R,Sam Brownback,62
-Wyandotte,KC 11-4,Governor,,R,Sam Brownback,45
-Wyandotte,KC 11-5,Governor,,R,Sam Brownback,60
-Wyandotte,KC 11-6,Governor,,R,Sam Brownback,22
-Wyandotte,KC 11-7,Governor,,R,Sam Brownback,45
-Wyandotte,KC 11-8,Governor,,R,Sam Brownback,39
-Wyandotte,KC 11-9,Governor,,R,Sam Brownback,53
-Wyandotte,KC 11-10,Governor,,R,Sam Brownback,74
-Wyandotte,KC 11-11,Governor,,R,Sam Brownback,138
-Wyandotte,KC 11-12,Governor,,R,Sam Brownback,27
-Wyandotte,KC 12-1,Governor,,R,Sam Brownback,77
-Wyandotte,KC 12-2,Governor,,R,Sam Brownback,23
-Wyandotte,KC 12-3,Governor,,R,Sam Brownback,74
-Wyandotte,KC 12-4,Governor,,R,Sam Brownback,121
-Wyandotte,KC 12-5,Governor,,R,Sam Brownback,144
-Wyandotte,KC 12-6,Governor,,R,Sam Brownback,113
-Wyandotte,KC 12-7,Governor,,R,Sam Brownback,84
-Wyandotte,KC 12-8,Governor,,R,Sam Brownback,115
-Wyandotte,KC 12-9,Governor,,R,Sam Brownback,127
-Wyandotte,KC 12-10,Governor,,R,Sam Brownback,117
-Wyandotte,KC 12-11,Governor,,R,Sam Brownback,67
-Wyandotte,KC 13-1,Governor,,R,Sam Brownback,40
-Wyandotte,KC 13-2,Governor,,R,Sam Brownback,80
-Wyandotte,KC 13-3,Governor,,R,Sam Brownback,51
-Wyandotte,KC 13-4,Governor,,R,Sam Brownback,10
-Wyandotte,KC 13-5,Governor,,R,Sam Brownback,81
-Wyandotte,KC 13-6,Governor,,R,Sam Brownback,85
-Wyandotte,KC 13-7,Governor,,R,Sam Brownback,82
-Wyandotte,KC 13-8,Governor,,R,Sam Brownback,64
-Wyandotte,KC 13-9,Governor,,R,Sam Brownback,71
-Wyandotte,KC 14-1,Governor,,R,Sam Brownback,149
-Wyandotte,KC 14-2,Governor,,R,Sam Brownback,59
-Wyandotte,KC 14-3,Governor,,R,Sam Brownback,40
-Wyandotte,KC 14-4,Governor,,R,Sam Brownback,75
-Wyandotte,KC 14-5,Governor,,R,Sam Brownback,83
-Wyandotte,KC 14-6,Governor,,R,Sam Brownback,114
-Wyandotte,KC 14-7,Governor,,R,Sam Brownback,138
-Wyandotte,KC 14-8,Governor,,R,Sam Brownback,106
-Wyandotte,KC 14-9,Governor,,R,Sam Brownback,119
-Wyandotte,KC 14-10,Governor,,R,Sam Brownback,242
-Wyandotte,KC 14-11,Governor,,R,Sam Brownback,118
-Wyandotte,KC 14-12,Governor,,R,Sam Brownback,267
-Wyandotte,KC 14-13,Governor,,R,Sam Brownback,154
-Wyandotte,KC 14-14,Governor,,R,Sam Brownback,303
-Wyandotte,KC 14-15,Governor,,R,Sam Brownback,384
-Wyandotte,KC 14-16,Governor,,R,Sam Brownback,77
-Wyandotte,OC 1-1,Governor,,R,Sam Brownback,12
-Wyandotte,BS 1-1,Governor,,D,Paul Davis,236
-Wyandotte,BS 2-1,Governor,,D,Paul Davis,168
-Wyandotte,BS 3-1,Governor,,D,Paul Davis,265
-Wyandotte,BS 4-1,Governor,,D,Paul Davis,313
-Wyandotte,DE 1-1,Governor,,D,Paul Davis,6
-Wyandotte,ED 1-1,Governor,,D,Paul Davis,342
-Wyandotte,ED 2-1,Governor,,D,Paul Davis,58
-Wyandotte,KC 1-1,Governor,,D,Paul Davis,72
-Wyandotte,KC 1-2,Governor,,D,Paul Davis,84
-Wyandotte,KC 1-3,Governor,,D,Paul Davis,50
-Wyandotte,KC 2-1,Governor,,D,Paul Davis,110
-Wyandotte,KC 2-2,Governor,,D,Paul Davis,79
-Wyandotte,KC 2-3,Governor,,D,Paul Davis,27
-Wyandotte,KC 2-4,Governor,,D,Paul Davis,94
-Wyandotte,KC 2-5,Governor,,D,Paul Davis,156
-Wyandotte,KC 3-1,Governor,,D,Paul Davis,247
-Wyandotte,KC 3-2,Governor,,D,Paul Davis,243
-Wyandotte,KC 3-3,Governor,,D,Paul Davis,42
-Wyandotte,KC 3-4,Governor,,D,Paul Davis,148
-Wyandotte,KC 4-1,Governor,,D,Paul Davis,149
-Wyandotte,KC 4-2,Governor,,D,Paul Davis,35
-Wyandotte,KC 4-3,Governor,,D,Paul Davis,92
-Wyandotte,KC 4-4,Governor,,D,Paul Davis,196
-Wyandotte,KC 5-1,Governor,,D,Paul Davis,140
-Wyandotte,KC 5-2,Governor,,D,Paul Davis,43
-Wyandotte,KC 5-3,Governor,,D,Paul Davis,29
-Wyandotte,KC 5-4,Governor,,D,Paul Davis,50
-Wyandotte,KC 5-5,Governor,,D,Paul Davis,79
-Wyandotte,KC 6-1,Governor,,D,Paul Davis,69
-Wyandotte,KC 6-2,Governor,,D,Paul Davis,22
-Wyandotte,KC 7-1,Governor,,D,Paul Davis,101
-Wyandotte,KC 7-2,Governor,,D,Paul Davis,75
-Wyandotte,KC 7-3,Governor,,D,Paul Davis,135
-Wyandotte,KC 7-4,Governor,,D,Paul Davis,170
-Wyandotte,KC 7-5,Governor,,D,Paul Davis,39
-Wyandotte,KC 7-6,Governor,,D,Paul Davis,205
-Wyandotte,KC 7-7,Governor,,D,Paul Davis,62
-Wyandotte,KC 7-8,Governor,,D,Paul Davis,240
-Wyandotte,KC 7-9,Governor,,D,Paul Davis,226
-Wyandotte,KC 8-1,Governor,,D,Paul Davis,167
-Wyandotte,KC 8-2,Governor,,D,Paul Davis,220
-Wyandotte,KC 8-3,Governor,,D,Paul Davis,334
-Wyandotte,KC 8-4,Governor,,D,Paul Davis,170
-Wyandotte,KC 9-1,Governor,,D,Paul Davis,36
-Wyandotte,KC 9-2,Governor,,D,Paul Davis,94
-Wyandotte,KC 9-3,Governor,,D,Paul Davis,309
-Wyandotte,KC 9-4,Governor,,D,Paul Davis,45
-Wyandotte,KC 9-5,Governor,,D,Paul Davis,6
-Wyandotte,KC 9-6,Governor,,D,Paul Davis,170
-Wyandotte,KC 9-7,Governor,,D,Paul Davis,129
-Wyandotte,KC 9-8,Governor,,D,Paul Davis,145
-Wyandotte,KC 9-9,Governor,,D,Paul Davis,55
-Wyandotte,KC 9-10,Governor,,D,Paul Davis,248
-Wyandotte,KC 9-11,Governor,,D,Paul Davis,287
-Wyandotte,KC 9-12,Governor,,D,Paul Davis,189
-Wyandotte,KC 9-13,Governor,,D,Paul Davis,137
-Wyandotte,KC 9-14,Governor,,D,Paul Davis,193
-Wyandotte,KC 9-15,Governor,,D,Paul Davis,0
-Wyandotte,KC 9-16,Governor,,D,Paul Davis,261
-Wyandotte,KC 10-1,Governor,,D,Paul Davis,254
-Wyandotte,KC 10-2,Governor,,D,Paul Davis,387
-Wyandotte,KC 10-3,Governor,,D,Paul Davis,14
-Wyandotte,KC 10-4,Governor,,D,Paul Davis,139
-Wyandotte,KC 10-5,Governor,,D,Paul Davis,255
-Wyandotte,KC 11-1,Governor,,D,Paul Davis,242
-Wyandotte,KC 11-2,Governor,,D,Paul Davis,199
-Wyandotte,KC 11-3,Governor,,D,Paul Davis,291
-Wyandotte,KC 11-4,Governor,,D,Paul Davis,210
-Wyandotte,KC 11-5,Governor,,D,Paul Davis,180
-Wyandotte,KC 11-6,Governor,,D,Paul Davis,235
-Wyandotte,KC 11-7,Governor,,D,Paul Davis,185
-Wyandotte,KC 11-8,Governor,,D,Paul Davis,231
-Wyandotte,KC 11-9,Governor,,D,Paul Davis,226
-Wyandotte,KC 11-10,Governor,,D,Paul Davis,290
-Wyandotte,KC 11-11,Governor,,D,Paul Davis,374
-Wyandotte,KC 11-12,Governor,,D,Paul Davis,48
-Wyandotte,KC 12-1,Governor,,D,Paul Davis,151
-Wyandotte,KC 12-2,Governor,,D,Paul Davis,49
-Wyandotte,KC 12-3,Governor,,D,Paul Davis,145
-Wyandotte,KC 12-4,Governor,,D,Paul Davis,186
-Wyandotte,KC 12-5,Governor,,D,Paul Davis,146
-Wyandotte,KC 12-6,Governor,,D,Paul Davis,146
-Wyandotte,KC 12-7,Governor,,D,Paul Davis,108
-Wyandotte,KC 12-8,Governor,,D,Paul Davis,161
-Wyandotte,KC 12-9,Governor,,D,Paul Davis,173
-Wyandotte,KC 12-10,Governor,,D,Paul Davis,125
-Wyandotte,KC 12-11,Governor,,D,Paul Davis,58
-Wyandotte,KC 13-1,Governor,,D,Paul Davis,269
-Wyandotte,KC 13-2,Governor,,D,Paul Davis,212
-Wyandotte,KC 13-3,Governor,,D,Paul Davis,185
-Wyandotte,KC 13-4,Governor,,D,Paul Davis,179
-Wyandotte,KC 13-5,Governor,,D,Paul Davis,162
-Wyandotte,KC 13-6,Governor,,D,Paul Davis,176
-Wyandotte,KC 13-7,Governor,,D,Paul Davis,111
-Wyandotte,KC 13-8,Governor,,D,Paul Davis,166
-Wyandotte,KC 13-9,Governor,,D,Paul Davis,238
-Wyandotte,KC 14-1,Governor,,D,Paul Davis,179
-Wyandotte,KC 14-2,Governor,,D,Paul Davis,109
-Wyandotte,KC 14-3,Governor,,D,Paul Davis,112
-Wyandotte,KC 14-4,Governor,,D,Paul Davis,242
-Wyandotte,KC 14-5,Governor,,D,Paul Davis,195
-Wyandotte,KC 14-6,Governor,,D,Paul Davis,246
-Wyandotte,KC 14-7,Governor,,D,Paul Davis,323
-Wyandotte,KC 14-8,Governor,,D,Paul Davis,234
-Wyandotte,KC 14-9,Governor,,D,Paul Davis,122
-Wyandotte,KC 14-10,Governor,,D,Paul Davis,375
-Wyandotte,KC 14-11,Governor,,D,Paul Davis,218
-Wyandotte,KC 14-12,Governor,,D,Paul Davis,343
-Wyandotte,KC 14-13,Governor,,D,Paul Davis,288
-Wyandotte,KC 14-14,Governor,,D,Paul Davis,352
-Wyandotte,KC 14-15,Governor,,D,Paul Davis,424
-Wyandotte,KC 14-16,Governor,,D,Paul Davis,153
-Wyandotte,OC 1-1,Governor,,D,Paul Davis,15
-Wyandotte,BS 1-1,Governor,,L,Keen Umbehr,12
-Wyandotte,BS 2-1,Governor,,L,Keen Umbehr,15
-Wyandotte,BS 3-1,Governor,,L,Keen Umbehr,8
-Wyandotte,BS 4-1,Governor,,L,Keen Umbehr,23
-Wyandotte,DE 1-1,Governor,,L,Keen Umbehr,0
-Wyandotte,ED 1-1,Governor,,L,Keen Umbehr,52
-Wyandotte,ED 2-1,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 1-1,Governor,,L,Keen Umbehr,4
-Wyandotte,KC 1-2,Governor,,L,Keen Umbehr,1
-Wyandotte,KC 1-3,Governor,,L,Keen Umbehr,0
-Wyandotte,KC 2-1,Governor,,L,Keen Umbehr,4
-Wyandotte,KC 2-2,Governor,,L,Keen Umbehr,1
-Wyandotte,KC 2-3,Governor,,L,Keen Umbehr,0
-Wyandotte,KC 2-4,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 2-5,Governor,,L,Keen Umbehr,8
-Wyandotte,KC 3-1,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 3-2,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 3-3,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 3-4,Governor,,L,Keen Umbehr,1
-Wyandotte,KC 4-1,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 4-2,Governor,,L,Keen Umbehr,2
-Wyandotte,KC 4-3,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 4-4,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 5-1,Governor,,L,Keen Umbehr,8
-Wyandotte,KC 5-2,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 5-3,Governor,,L,Keen Umbehr,4
-Wyandotte,KC 5-4,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 5-5,Governor,,L,Keen Umbehr,4
-Wyandotte,KC 6-1,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 6-2,Governor,,L,Keen Umbehr,0
-Wyandotte,KC 7-1,Governor,,L,Keen Umbehr,13
-Wyandotte,KC 7-2,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 7-3,Governor,,L,Keen Umbehr,1
-Wyandotte,KC 7-4,Governor,,L,Keen Umbehr,11
-Wyandotte,KC 7-5,Governor,,L,Keen Umbehr,11
-Wyandotte,KC 7-6,Governor,,L,Keen Umbehr,10
-Wyandotte,KC 7-7,Governor,,L,Keen Umbehr,7
-Wyandotte,KC 7-8,Governor,,L,Keen Umbehr,16
-Wyandotte,KC 7-9,Governor,,L,Keen Umbehr,15
-Wyandotte,KC 8-1,Governor,,L,Keen Umbehr,13
-Wyandotte,KC 8-2,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 8-3,Governor,,L,Keen Umbehr,10
-Wyandotte,KC 8-4,Governor,,L,Keen Umbehr,18
-Wyandotte,KC 9-1,Governor,,L,Keen Umbehr,1
-Wyandotte,KC 9-2,Governor,,L,Keen Umbehr,8
-Wyandotte,KC 9-3,Governor,,L,Keen Umbehr,11
-Wyandotte,KC 9-4,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 9-5,Governor,,L,Keen Umbehr,1
-Wyandotte,KC 9-6,Governor,,L,Keen Umbehr,14
-Wyandotte,KC 9-7,Governor,,L,Keen Umbehr,20
-Wyandotte,KC 9-8,Governor,,L,Keen Umbehr,4
-Wyandotte,KC 9-9,Governor,,L,Keen Umbehr,7
-Wyandotte,KC 9-10,Governor,,L,Keen Umbehr,13
-Wyandotte,KC 9-11,Governor,,L,Keen Umbehr,17
-Wyandotte,KC 9-12,Governor,,L,Keen Umbehr,13
-Wyandotte,KC 9-13,Governor,,L,Keen Umbehr,17
-Wyandotte,KC 9-14,Governor,,L,Keen Umbehr,14
-Wyandotte,KC 9-15,Governor,,L,Keen Umbehr,0
-Wyandotte,KC 9-16,Governor,,L,Keen Umbehr,13
-Wyandotte,KC 10-1,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 10-2,Governor,,L,Keen Umbehr,8
-Wyandotte,KC 10-3,Governor,,L,Keen Umbehr,1
-Wyandotte,KC 10-4,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 10-5,Governor,,L,Keen Umbehr,8
-Wyandotte,KC 11-1,Governor,,L,Keen Umbehr,7
-Wyandotte,KC 11-2,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 11-3,Governor,,L,Keen Umbehr,9
-Wyandotte,KC 11-4,Governor,,L,Keen Umbehr,9
-Wyandotte,KC 11-5,Governor,,L,Keen Umbehr,15
-Wyandotte,KC 11-6,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 11-7,Governor,,L,Keen Umbehr,9
-Wyandotte,KC 11-8,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 11-9,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 11-10,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 11-11,Governor,,L,Keen Umbehr,16
-Wyandotte,KC 11-12,Governor,,L,Keen Umbehr,4
-Wyandotte,KC 12-1,Governor,,L,Keen Umbehr,18
-Wyandotte,KC 12-2,Governor,,L,Keen Umbehr,7
-Wyandotte,KC 12-3,Governor,,L,Keen Umbehr,14
-Wyandotte,KC 12-4,Governor,,L,Keen Umbehr,25
-Wyandotte,KC 12-5,Governor,,L,Keen Umbehr,13
-Wyandotte,KC 12-6,Governor,,L,Keen Umbehr,18
-Wyandotte,KC 12-7,Governor,,L,Keen Umbehr,19
-Wyandotte,KC 12-8,Governor,,L,Keen Umbehr,17
-Wyandotte,KC 12-9,Governor,,L,Keen Umbehr,15
-Wyandotte,KC 12-10,Governor,,L,Keen Umbehr,10
-Wyandotte,KC 12-11,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 13-1,Governor,,L,Keen Umbehr,16
-Wyandotte,KC 13-2,Governor,,L,Keen Umbehr,22
-Wyandotte,KC 13-3,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 13-4,Governor,,L,Keen Umbehr,3
-Wyandotte,KC 13-5,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 13-6,Governor,,L,Keen Umbehr,13
-Wyandotte,KC 13-7,Governor,,L,Keen Umbehr,12
-Wyandotte,KC 13-8,Governor,,L,Keen Umbehr,13
-Wyandotte,KC 13-9,Governor,,L,Keen Umbehr,9
-Wyandotte,KC 14-1,Governor,,L,Keen Umbehr,12
-Wyandotte,KC 14-2,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 14-3,Governor,,L,Keen Umbehr,4
-Wyandotte,KC 14-4,Governor,,L,Keen Umbehr,9
-Wyandotte,KC 14-5,Governor,,L,Keen Umbehr,8
-Wyandotte,KC 14-6,Governor,,L,Keen Umbehr,17
-Wyandotte,KC 14-7,Governor,,L,Keen Umbehr,15
-Wyandotte,KC 14-8,Governor,,L,Keen Umbehr,10
-Wyandotte,KC 14-9,Governor,,L,Keen Umbehr,6
-Wyandotte,KC 14-10,Governor,,L,Keen Umbehr,16
-Wyandotte,KC 14-11,Governor,,L,Keen Umbehr,5
-Wyandotte,KC 14-12,Governor,,L,Keen Umbehr,15
-Wyandotte,KC 14-13,Governor,,L,Keen Umbehr,15
-Wyandotte,KC 14-14,Governor,,L,Keen Umbehr,19
-Wyandotte,KC 14-15,Governor,,L,Keen Umbehr,23
-Wyandotte,KC 14-16,Governor,,L,Keen Umbehr,7
-Wyandotte,OC 1-1,Governor,,L,Keen Umbehr,0
-Wyandotte,BS 1-1,Governor,,,Write-ins,1
-Wyandotte,BS 2-1,Governor,,,Write-ins,0
-Wyandotte,BS 3-1,Governor,,,Write-ins,0
-Wyandotte,BS 4-1,Governor,,,Write-ins,0
-Wyandotte,DE 1-1,Governor,,,Write-ins,0
-Wyandotte,ED 1-1,Governor,,,Write-ins,1
-Wyandotte,ED 2-1,Governor,,,Write-ins,0
-Wyandotte,KC 1-1,Governor,,,Write-ins,0
-Wyandotte,KC 1-2,Governor,,,Write-ins,0
-Wyandotte,KC 1-3,Governor,,,Write-ins,0
-Wyandotte,KC 2-1,Governor,,,Write-ins,0
-Wyandotte,KC 2-2,Governor,,,Write-ins,0
-Wyandotte,KC 2-3,Governor,,,Write-ins,0
-Wyandotte,KC 2-4,Governor,,,Write-ins,0
-Wyandotte,KC 2-5,Governor,,,Write-ins,2
-Wyandotte,KC 3-1,Governor,,,Write-ins,0
-Wyandotte,KC 3-2,Governor,,,Write-ins,0
-Wyandotte,KC 3-3,Governor,,,Write-ins,0
-Wyandotte,KC 3-4,Governor,,,Write-ins,2
-Wyandotte,KC 4-1,Governor,,,Write-ins,0
-Wyandotte,KC 4-2,Governor,,,Write-ins,0
-Wyandotte,KC 4-3,Governor,,,Write-ins,0
-Wyandotte,KC 4-4,Governor,,,Write-ins,0
-Wyandotte,KC 5-1,Governor,,,Write-ins,0
-Wyandotte,KC 5-2,Governor,,,Write-ins,0
-Wyandotte,KC 5-3,Governor,,,Write-ins,0
-Wyandotte,KC 5-4,Governor,,,Write-ins,0
-Wyandotte,KC 5-5,Governor,,,Write-ins,0
-Wyandotte,KC 6-1,Governor,,,Write-ins,0
-Wyandotte,KC 6-2,Governor,,,Write-ins,0
-Wyandotte,KC 7-1,Governor,,,Write-ins,2
-Wyandotte,KC 7-2,Governor,,,Write-ins,0
-Wyandotte,KC 7-3,Governor,,,Write-ins,0
-Wyandotte,KC 7-4,Governor,,,Write-ins,0
-Wyandotte,KC 7-5,Governor,,,Write-ins,0
-Wyandotte,KC 7-6,Governor,,,Write-ins,0
-Wyandotte,KC 7-7,Governor,,,Write-ins,1
-Wyandotte,KC 7-8,Governor,,,Write-ins,0
-Wyandotte,KC 7-9,Governor,,,Write-ins,0
-Wyandotte,KC 8-1,Governor,,,Write-ins,0
-Wyandotte,KC 8-2,Governor,,,Write-ins,0
-Wyandotte,KC 8-3,Governor,,,Write-ins,0
-Wyandotte,KC 8-4,Governor,,,Write-ins,0
-Wyandotte,KC 9-1,Governor,,,Write-ins,0
-Wyandotte,KC 9-2,Governor,,,Write-ins,0
-Wyandotte,KC 9-3,Governor,,,Write-ins,0
-Wyandotte,KC 9-4,Governor,,,Write-ins,0
-Wyandotte,KC 9-5,Governor,,,Write-ins,0
-Wyandotte,KC 9-6,Governor,,,Write-ins,0
-Wyandotte,KC 9-7,Governor,,,Write-ins,0
-Wyandotte,KC 9-8,Governor,,,Write-ins,0
-Wyandotte,KC 9-9,Governor,,,Write-ins,1
-Wyandotte,KC 9-10,Governor,,,Write-ins,0
-Wyandotte,KC 9-11,Governor,,,Write-ins,2
-Wyandotte,KC 9-12,Governor,,,Write-ins,0
-Wyandotte,KC 9-13,Governor,,,Write-ins,1
-Wyandotte,KC 9-14,Governor,,,Write-ins,0
-Wyandotte,KC 9-15,Governor,,,Write-ins,0
-Wyandotte,KC 9-16,Governor,,,Write-ins,0
-Wyandotte,KC 10-1,Governor,,,Write-ins,0
-Wyandotte,KC 10-2,Governor,,,Write-ins,0
-Wyandotte,KC 10-3,Governor,,,Write-ins,0
-Wyandotte,KC 10-4,Governor,,,Write-ins,0
-Wyandotte,KC 10-5,Governor,,,Write-ins,0
-Wyandotte,KC 11-1,Governor,,,Write-ins,0
-Wyandotte,KC 11-2,Governor,,,Write-ins,2
-Wyandotte,KC 11-3,Governor,,,Write-ins,0
-Wyandotte,KC 11-4,Governor,,,Write-ins,0
-Wyandotte,KC 11-5,Governor,,,Write-ins,1
-Wyandotte,KC 11-6,Governor,,,Write-ins,0
-Wyandotte,KC 11-7,Governor,,,Write-ins,0
-Wyandotte,KC 11-8,Governor,,,Write-ins,0
-Wyandotte,KC 11-9,Governor,,,Write-ins,1
-Wyandotte,KC 11-10,Governor,,,Write-ins,1
-Wyandotte,KC 11-11,Governor,,,Write-ins,1
-Wyandotte,KC 11-12,Governor,,,Write-ins,0
-Wyandotte,KC 12-1,Governor,,,Write-ins,1
-Wyandotte,KC 12-2,Governor,,,Write-ins,0
-Wyandotte,KC 12-3,Governor,,,Write-ins,0
-Wyandotte,KC 12-4,Governor,,,Write-ins,0
-Wyandotte,KC 12-5,Governor,,,Write-ins,0
-Wyandotte,KC 12-6,Governor,,,Write-ins,0
-Wyandotte,KC 12-7,Governor,,,Write-ins,0
-Wyandotte,KC 12-8,Governor,,,Write-ins,0
-Wyandotte,KC 12-9,Governor,,,Write-ins,0
-Wyandotte,KC 12-10,Governor,,,Write-ins,0
-Wyandotte,KC 12-11,Governor,,,Write-ins,0
-Wyandotte,KC 13-1,Governor,,,Write-ins,0
-Wyandotte,KC 13-2,Governor,,,Write-ins,0
-Wyandotte,KC 13-3,Governor,,,Write-ins,0
-Wyandotte,KC 13-4,Governor,,,Write-ins,0
-Wyandotte,KC 13-5,Governor,,,Write-ins,0
-Wyandotte,KC 13-6,Governor,,,Write-ins,0
-Wyandotte,KC 13-7,Governor,,,Write-ins,0
-Wyandotte,KC 13-8,Governor,,,Write-ins,0
-Wyandotte,KC 13-9,Governor,,,Write-ins,0
-Wyandotte,KC 14-1,Governor,,,Write-ins,0
-Wyandotte,KC 14-2,Governor,,,Write-ins,0
-Wyandotte,KC 14-3,Governor,,,Write-ins,0
-Wyandotte,KC 14-4,Governor,,,Write-ins,0
-Wyandotte,KC 14-5,Governor,,,Write-ins,0
-Wyandotte,KC 14-6,Governor,,,Write-ins,0
-Wyandotte,KC 14-7,Governor,,,Write-ins,1
-Wyandotte,KC 14-8,Governor,,,Write-ins,0
-Wyandotte,KC 14-9,Governor,,,Write-ins,0
-Wyandotte,KC 14-10,Governor,,,Write-ins,0
-Wyandotte,KC 14-11,Governor,,,Write-ins,0
-Wyandotte,KC 14-12,Governor,,,Write-ins,0
-Wyandotte,KC 14-13,Governor,,,Write-ins,0
-Wyandotte,KC 14-14,Governor,,,Write-ins,0
-Wyandotte,KC 14-15,Governor,,,Write-ins,0
-Wyandotte,KC 14-16,Governor,,,Write-ins,0
-Wyandotte,OC 1-1,Governor,,,Write-ins,0
-Wyandotte,BS 1-1,Secretary of State,,R,Kris Kobach,256
-Wyandotte,BS 2-1,Secretary of State,,R,Kris Kobach,206
-Wyandotte,BS 3-1,Secretary of State,,R,Kris Kobach,263
-Wyandotte,BS 4-1,Secretary of State,,R,Kris Kobach,333
-Wyandotte,DE 1-1,Secretary of State,,R,Kris Kobach,8
-Wyandotte,ED 1-1,Secretary of State,,R,Kris Kobach,511
-Wyandotte,ED 2-1,Secretary of State,,R,Kris Kobach,73
-Wyandotte,KC 1-1,Secretary of State,,R,Kris Kobach,9
-Wyandotte,KC 1-2,Secretary of State,,R,Kris Kobach,10
-Wyandotte,KC 1-3,Secretary of State,,R,Kris Kobach,19
-Wyandotte,KC 2-1,Secretary of State,,R,Kris Kobach,35
-Wyandotte,KC 2-2,Secretary of State,,R,Kris Kobach,12
-Wyandotte,KC 2-3,Secretary of State,,R,Kris Kobach,3
-Wyandotte,KC 2-4,Secretary of State,,R,Kris Kobach,9
-Wyandotte,KC 2-5,Secretary of State,,R,Kris Kobach,26
-Wyandotte,KC 3-1,Secretary of State,,R,Kris Kobach,24
-Wyandotte,KC 3-2,Secretary of State,,R,Kris Kobach,21
-Wyandotte,KC 3-3,Secretary of State,,R,Kris Kobach,5
-Wyandotte,KC 3-4,Secretary of State,,R,Kris Kobach,11
-Wyandotte,KC 4-1,Secretary of State,,R,Kris Kobach,52
-Wyandotte,KC 4-2,Secretary of State,,R,Kris Kobach,17
-Wyandotte,KC 4-3,Secretary of State,,R,Kris Kobach,51
-Wyandotte,KC 4-4,Secretary of State,,R,Kris Kobach,102
-Wyandotte,KC 5-1,Secretary of State,,R,Kris Kobach,55
-Wyandotte,KC 5-2,Secretary of State,,R,Kris Kobach,15
-Wyandotte,KC 5-3,Secretary of State,,R,Kris Kobach,17
-Wyandotte,KC 5-4,Secretary of State,,R,Kris Kobach,30
-Wyandotte,KC 5-5,Secretary of State,,R,Kris Kobach,38
-Wyandotte,KC 6-1,Secretary of State,,R,Kris Kobach,49
-Wyandotte,KC 6-2,Secretary of State,,R,Kris Kobach,17
-Wyandotte,KC 7-1,Secretary of State,,R,Kris Kobach,64
-Wyandotte,KC 7-2,Secretary of State,,R,Kris Kobach,41
-Wyandotte,KC 7-3,Secretary of State,,R,Kris Kobach,59
-Wyandotte,KC 7-4,Secretary of State,,R,Kris Kobach,159
-Wyandotte,KC 7-5,Secretary of State,,R,Kris Kobach,13
-Wyandotte,KC 7-6,Secretary of State,,R,Kris Kobach,107
-Wyandotte,KC 7-7,Secretary of State,,R,Kris Kobach,31
-Wyandotte,KC 7-8,Secretary of State,,R,Kris Kobach,183
-Wyandotte,KC 7-9,Secretary of State,,R,Kris Kobach,164
-Wyandotte,KC 8-1,Secretary of State,,R,Kris Kobach,62
-Wyandotte,KC 8-2,Secretary of State,,R,Kris Kobach,41
-Wyandotte,KC 8-3,Secretary of State,,R,Kris Kobach,108
-Wyandotte,KC 8-4,Secretary of State,,R,Kris Kobach,76
-Wyandotte,KC 9-1,Secretary of State,,R,Kris Kobach,26
-Wyandotte,KC 9-2,Secretary of State,,R,Kris Kobach,87
-Wyandotte,KC 9-3,Secretary of State,,R,Kris Kobach,148
-Wyandotte,KC 9-4,Secretary of State,,R,Kris Kobach,28
-Wyandotte,KC 9-5,Secretary of State,,R,Kris Kobach,15
-Wyandotte,KC 9-6,Secretary of State,,R,Kris Kobach,58
-Wyandotte,KC 9-7,Secretary of State,,R,Kris Kobach,138
-Wyandotte,KC 9-8,Secretary of State,,R,Kris Kobach,63
-Wyandotte,KC 9-9,Secretary of State,,R,Kris Kobach,59
-Wyandotte,KC 9-10,Secretary of State,,R,Kris Kobach,137
-Wyandotte,KC 9-11,Secretary of State,,R,Kris Kobach,128
-Wyandotte,KC 9-12,Secretary of State,,R,Kris Kobach,162
-Wyandotte,KC 9-13,Secretary of State,,R,Kris Kobach,113
-Wyandotte,KC 9-14,Secretary of State,,R,Kris Kobach,168
-Wyandotte,KC 9-15,Secretary of State,,R,Kris Kobach,0
-Wyandotte,KC 9-16,Secretary of State,,R,Kris Kobach,194
-Wyandotte,KC 10-1,Secretary of State,,R,Kris Kobach,23
-Wyandotte,KC 10-2,Secretary of State,,R,Kris Kobach,34
-Wyandotte,KC 10-3,Secretary of State,,R,Kris Kobach,1
-Wyandotte,KC 10-4,Secretary of State,,R,Kris Kobach,33
-Wyandotte,KC 10-5,Secretary of State,,R,Kris Kobach,85
-Wyandotte,KC 11-1,Secretary of State,,R,Kris Kobach,70
-Wyandotte,KC 11-2,Secretary of State,,R,Kris Kobach,55
-Wyandotte,KC 11-3,Secretary of State,,R,Kris Kobach,94
-Wyandotte,KC 11-4,Secretary of State,,R,Kris Kobach,54
-Wyandotte,KC 11-5,Secretary of State,,R,Kris Kobach,75
-Wyandotte,KC 11-6,Secretary of State,,R,Kris Kobach,26
-Wyandotte,KC 11-7,Secretary of State,,R,Kris Kobach,60
-Wyandotte,KC 11-8,Secretary of State,,R,Kris Kobach,55
-Wyandotte,KC 11-9,Secretary of State,,R,Kris Kobach,69
-Wyandotte,KC 11-10,Secretary of State,,R,Kris Kobach,98
-Wyandotte,KC 11-11,Secretary of State,,R,Kris Kobach,192
-Wyandotte,KC 11-12,Secretary of State,,R,Kris Kobach,31
-Wyandotte,KC 12-1,Secretary of State,,R,Kris Kobach,89
-Wyandotte,KC 12-2,Secretary of State,,R,Kris Kobach,30
-Wyandotte,KC 12-3,Secretary of State,,R,Kris Kobach,88
-Wyandotte,KC 12-4,Secretary of State,,R,Kris Kobach,154
-Wyandotte,KC 12-5,Secretary of State,,R,Kris Kobach,190
-Wyandotte,KC 12-6,Secretary of State,,R,Kris Kobach,138
-Wyandotte,KC 12-7,Secretary of State,,R,Kris Kobach,110
-Wyandotte,KC 12-8,Secretary of State,,R,Kris Kobach,141
-Wyandotte,KC 12-9,Secretary of State,,R,Kris Kobach,160
-Wyandotte,KC 12-10,Secretary of State,,R,Kris Kobach,143
-Wyandotte,KC 12-11,Secretary of State,,R,Kris Kobach,81
-Wyandotte,KC 13-1,Secretary of State,,R,Kris Kobach,52
-Wyandotte,KC 13-2,Secretary of State,,R,Kris Kobach,116
-Wyandotte,KC 13-3,Secretary of State,,R,Kris Kobach,64
-Wyandotte,KC 13-4,Secretary of State,,R,Kris Kobach,18
-Wyandotte,KC 13-5,Secretary of State,,R,Kris Kobach,92
-Wyandotte,KC 13-6,Secretary of State,,R,Kris Kobach,117
-Wyandotte,KC 13-7,Secretary of State,,R,Kris Kobach,99
-Wyandotte,KC 13-8,Secretary of State,,R,Kris Kobach,89
-Wyandotte,KC 13-9,Secretary of State,,R,Kris Kobach,97
-Wyandotte,KC 14-1,Secretary of State,,R,Kris Kobach,176
-Wyandotte,KC 14-2,Secretary of State,,R,Kris Kobach,70
-Wyandotte,KC 14-3,Secretary of State,,R,Kris Kobach,43
-Wyandotte,KC 14-4,Secretary of State,,R,Kris Kobach,110
-Wyandotte,KC 14-5,Secretary of State,,R,Kris Kobach,114
-Wyandotte,KC 14-6,Secretary of State,,R,Kris Kobach,155
-Wyandotte,KC 14-7,Secretary of State,,R,Kris Kobach,189
-Wyandotte,KC 14-8,Secretary of State,,R,Kris Kobach,139
-Wyandotte,KC 14-9,Secretary of State,,R,Kris Kobach,158
-Wyandotte,KC 14-10,Secretary of State,,R,Kris Kobach,337
-Wyandotte,KC 14-11,Secretary of State,,R,Kris Kobach,163
-Wyandotte,KC 14-12,Secretary of State,,R,Kris Kobach,352
-Wyandotte,KC 14-13,Secretary of State,,R,Kris Kobach,230
-Wyandotte,KC 14-14,Secretary of State,,R,Kris Kobach,423
-Wyandotte,KC 14-15,Secretary of State,,R,Kris Kobach,515
-Wyandotte,KC 14-16,Secretary of State,,R,Kris Kobach,112
-Wyandotte,OC 1-1,Secretary of State,,R,Kris Kobach,14
-Wyandotte,BS 1-1,Secretary of State,,D,Jean Schodorf,196
-Wyandotte,BS 2-1,Secretary of State,,D,Jean Schodorf,131
-Wyandotte,BS 3-1,Secretary of State,,D,Jean Schodorf,226
-Wyandotte,BS 4-1,Secretary of State,,D,Jean Schodorf,250
-Wyandotte,DE 1-1,Secretary of State,,D,Jean Schodorf,5
-Wyandotte,ED 1-1,Secretary of State,,D,Jean Schodorf,283
-Wyandotte,ED 2-1,Secretary of State,,D,Jean Schodorf,56
-Wyandotte,KC 1-1,Secretary of State,,D,Jean Schodorf,69
-Wyandotte,KC 1-2,Secretary of State,,D,Jean Schodorf,79
-Wyandotte,KC 1-3,Secretary of State,,D,Jean Schodorf,47
-Wyandotte,KC 2-1,Secretary of State,,D,Jean Schodorf,102
-Wyandotte,KC 2-2,Secretary of State,,D,Jean Schodorf,78
-Wyandotte,KC 2-3,Secretary of State,,D,Jean Schodorf,27
-Wyandotte,KC 2-4,Secretary of State,,D,Jean Schodorf,95
-Wyandotte,KC 2-5,Secretary of State,,D,Jean Schodorf,154
-Wyandotte,KC 3-1,Secretary of State,,D,Jean Schodorf,231
-Wyandotte,KC 3-2,Secretary of State,,D,Jean Schodorf,234
-Wyandotte,KC 3-3,Secretary of State,,D,Jean Schodorf,42
-Wyandotte,KC 3-4,Secretary of State,,D,Jean Schodorf,141
-Wyandotte,KC 4-1,Secretary of State,,D,Jean Schodorf,142
-Wyandotte,KC 4-2,Secretary of State,,D,Jean Schodorf,38
-Wyandotte,KC 4-3,Secretary of State,,D,Jean Schodorf,84
-Wyandotte,KC 4-4,Secretary of State,,D,Jean Schodorf,177
-Wyandotte,KC 5-1,Secretary of State,,D,Jean Schodorf,137
-Wyandotte,KC 5-2,Secretary of State,,D,Jean Schodorf,41
-Wyandotte,KC 5-3,Secretary of State,,D,Jean Schodorf,29
-Wyandotte,KC 5-4,Secretary of State,,D,Jean Schodorf,42
-Wyandotte,KC 5-5,Secretary of State,,D,Jean Schodorf,72
-Wyandotte,KC 6-1,Secretary of State,,D,Jean Schodorf,58
-Wyandotte,KC 6-2,Secretary of State,,D,Jean Schodorf,19
-Wyandotte,KC 7-1,Secretary of State,,D,Jean Schodorf,95
-Wyandotte,KC 7-2,Secretary of State,,D,Jean Schodorf,70
-Wyandotte,KC 7-3,Secretary of State,,D,Jean Schodorf,131
-Wyandotte,KC 7-4,Secretary of State,,D,Jean Schodorf,148
-Wyandotte,KC 7-5,Secretary of State,,D,Jean Schodorf,38
-Wyandotte,KC 7-6,Secretary of State,,D,Jean Schodorf,192
-Wyandotte,KC 7-7,Secretary of State,,D,Jean Schodorf,61
-Wyandotte,KC 7-8,Secretary of State,,D,Jean Schodorf,207
-Wyandotte,KC 7-9,Secretary of State,,D,Jean Schodorf,190
-Wyandotte,KC 8-1,Secretary of State,,D,Jean Schodorf,161
-Wyandotte,KC 8-2,Secretary of State,,D,Jean Schodorf,207
-Wyandotte,KC 8-3,Secretary of State,,D,Jean Schodorf,324
-Wyandotte,KC 8-4,Secretary of State,,D,Jean Schodorf,170
-Wyandotte,KC 9-1,Secretary of State,,D,Jean Schodorf,33
-Wyandotte,KC 9-2,Secretary of State,,D,Jean Schodorf,81
-Wyandotte,KC 9-3,Secretary of State,,D,Jean Schodorf,275
-Wyandotte,KC 9-4,Secretary of State,,D,Jean Schodorf,44
-Wyandotte,KC 9-5,Secretary of State,,D,Jean Schodorf,5
-Wyandotte,KC 9-6,Secretary of State,,D,Jean Schodorf,162
-Wyandotte,KC 9-7,Secretary of State,,D,Jean Schodorf,110
-Wyandotte,KC 9-8,Secretary of State,,D,Jean Schodorf,127
-Wyandotte,KC 9-9,Secretary of State,,D,Jean Schodorf,47
-Wyandotte,KC 9-10,Secretary of State,,D,Jean Schodorf,228
-Wyandotte,KC 9-11,Secretary of State,,D,Jean Schodorf,254
-Wyandotte,KC 9-12,Secretary of State,,D,Jean Schodorf,163
-Wyandotte,KC 9-13,Secretary of State,,D,Jean Schodorf,124
-Wyandotte,KC 9-14,Secretary of State,,D,Jean Schodorf,168
-Wyandotte,KC 9-15,Secretary of State,,D,Jean Schodorf,0
-Wyandotte,KC 9-16,Secretary of State,,D,Jean Schodorf,225
-Wyandotte,KC 10-1,Secretary of State,,D,Jean Schodorf,246
-Wyandotte,KC 10-2,Secretary of State,,D,Jean Schodorf,372
-Wyandotte,KC 10-3,Secretary of State,,D,Jean Schodorf,14
-Wyandotte,KC 10-4,Secretary of State,,D,Jean Schodorf,136
-Wyandotte,KC 10-5,Secretary of State,,D,Jean Schodorf,233
-Wyandotte,KC 11-1,Secretary of State,,D,Jean Schodorf,222
-Wyandotte,KC 11-2,Secretary of State,,D,Jean Schodorf,177
-Wyandotte,KC 11-3,Secretary of State,,D,Jean Schodorf,260
-Wyandotte,KC 11-4,Secretary of State,,D,Jean Schodorf,210
-Wyandotte,KC 11-5,Secretary of State,,D,Jean Schodorf,168
-Wyandotte,KC 11-6,Secretary of State,,D,Jean Schodorf,226
-Wyandotte,KC 11-7,Secretary of State,,D,Jean Schodorf,175
-Wyandotte,KC 11-8,Secretary of State,,D,Jean Schodorf,218
-Wyandotte,KC 11-9,Secretary of State,,D,Jean Schodorf,204
-Wyandotte,KC 11-10,Secretary of State,,D,Jean Schodorf,266
-Wyandotte,KC 11-11,Secretary of State,,D,Jean Schodorf,332
-Wyandotte,KC 11-12,Secretary of State,,D,Jean Schodorf,46
-Wyandotte,KC 12-1,Secretary of State,,D,Jean Schodorf,151
-Wyandotte,KC 12-2,Secretary of State,,D,Jean Schodorf,45
-Wyandotte,KC 12-3,Secretary of State,,D,Jean Schodorf,139
-Wyandotte,KC 12-4,Secretary of State,,D,Jean Schodorf,165
-Wyandotte,KC 12-5,Secretary of State,,D,Jean Schodorf,104
-Wyandotte,KC 12-6,Secretary of State,,D,Jean Schodorf,136
-Wyandotte,KC 12-7,Secretary of State,,D,Jean Schodorf,96
-Wyandotte,KC 12-8,Secretary of State,,D,Jean Schodorf,143
-Wyandotte,KC 12-9,Secretary of State,,D,Jean Schodorf,149
-Wyandotte,KC 12-10,Secretary of State,,D,Jean Schodorf,103
-Wyandotte,KC 12-11,Secretary of State,,D,Jean Schodorf,45
-Wyandotte,KC 13-1,Secretary of State,,D,Jean Schodorf,260
-Wyandotte,KC 13-2,Secretary of State,,D,Jean Schodorf,190
-Wyandotte,KC 13-3,Secretary of State,,D,Jean Schodorf,170
-Wyandotte,KC 13-4,Secretary of State,,D,Jean Schodorf,173
-Wyandotte,KC 13-5,Secretary of State,,D,Jean Schodorf,153
-Wyandotte,KC 13-6,Secretary of State,,D,Jean Schodorf,152
-Wyandotte,KC 13-7,Secretary of State,,D,Jean Schodorf,100
-Wyandotte,KC 13-8,Secretary of State,,D,Jean Schodorf,146
-Wyandotte,KC 13-9,Secretary of State,,D,Jean Schodorf,210
-Wyandotte,KC 14-1,Secretary of State,,D,Jean Schodorf,158
-Wyandotte,KC 14-2,Secretary of State,,D,Jean Schodorf,101
-Wyandotte,KC 14-3,Secretary of State,,D,Jean Schodorf,107
-Wyandotte,KC 14-4,Secretary of State,,D,Jean Schodorf,208
-Wyandotte,KC 14-5,Secretary of State,,D,Jean Schodorf,166
-Wyandotte,KC 14-6,Secretary of State,,D,Jean Schodorf,216
-Wyandotte,KC 14-7,Secretary of State,,D,Jean Schodorf,274
-Wyandotte,KC 14-8,Secretary of State,,D,Jean Schodorf,206
-Wyandotte,KC 14-9,Secretary of State,,D,Jean Schodorf,84
-Wyandotte,KC 14-10,Secretary of State,,D,Jean Schodorf,275
-Wyandotte,KC 14-11,Secretary of State,,D,Jean Schodorf,172
-Wyandotte,KC 14-12,Secretary of State,,D,Jean Schodorf,257
-Wyandotte,KC 14-13,Secretary of State,,D,Jean Schodorf,214
-Wyandotte,KC 14-14,Secretary of State,,D,Jean Schodorf,235
-Wyandotte,KC 14-15,Secretary of State,,D,Jean Schodorf,300
-Wyandotte,KC 14-16,Secretary of State,,D,Jean Schodorf,117
-Wyandotte,OC 1-1,Secretary of State,,D,Jean Schodorf,13
-Wyandotte,BS 1-1,Secretary of State,,,Write-ins,2
-Wyandotte,BS 2-1,Secretary of State,,,Write-ins,0
-Wyandotte,BS 3-1,Secretary of State,,,Write-ins,0
-Wyandotte,BS 4-1,Secretary of State,,,Write-ins,1
-Wyandotte,DE 1-1,Secretary of State,,,Write-ins,0
-Wyandotte,ED 1-1,Secretary of State,,,Write-ins,3
-Wyandotte,ED 2-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 1-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 1-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 1-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 2-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 2-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 2-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 2-4,Secretary of State,,,Write-ins,0
-Wyandotte,KC 2-5,Secretary of State,,,Write-ins,1
-Wyandotte,KC 3-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 3-2,Secretary of State,,,Write-ins,1
-Wyandotte,KC 3-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 3-4,Secretary of State,,,Write-ins,4
-Wyandotte,KC 4-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 4-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 4-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 4-4,Secretary of State,,,Write-ins,0
-Wyandotte,KC 5-1,Secretary of State,,,Write-ins,1
-Wyandotte,KC 5-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 5-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 5-4,Secretary of State,,,Write-ins,2
-Wyandotte,KC 5-5,Secretary of State,,,Write-ins,0
-Wyandotte,KC 6-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 6-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 7-1,Secretary of State,,,Write-ins,3
-Wyandotte,KC 7-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 7-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 7-4,Secretary of State,,,Write-ins,0
-Wyandotte,KC 7-5,Secretary of State,,,Write-ins,0
-Wyandotte,KC 7-6,Secretary of State,,,Write-ins,0
-Wyandotte,KC 7-7,Secretary of State,,,Write-ins,2
-Wyandotte,KC 7-8,Secretary of State,,,Write-ins,0
-Wyandotte,KC 7-9,Secretary of State,,,Write-ins,0
-Wyandotte,KC 8-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 8-2,Secretary of State,,,Write-ins,1
-Wyandotte,KC 8-3,Secretary of State,,,Write-ins,1
-Wyandotte,KC 8-4,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-3,Secretary of State,,,Write-ins,2
-Wyandotte,KC 9-4,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-5,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-6,Secretary of State,,,Write-ins,2
-Wyandotte,KC 9-7,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-8,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-9,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-10,Secretary of State,,,Write-ins,1
-Wyandotte,KC 9-11,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-12,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-13,Secretary of State,,,Write-ins,4
-Wyandotte,KC 9-14,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-15,Secretary of State,,,Write-ins,0
-Wyandotte,KC 9-16,Secretary of State,,,Write-ins,0
-Wyandotte,KC 10-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 10-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 10-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 10-4,Secretary of State,,,Write-ins,0
-Wyandotte,KC 10-5,Secretary of State,,,Write-ins,1
-Wyandotte,KC 11-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 11-2,Secretary of State,,,Write-ins,2
-Wyandotte,KC 11-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 11-4,Secretary of State,,,Write-ins,0
-Wyandotte,KC 11-5,Secretary of State,,,Write-ins,2
-Wyandotte,KC 11-6,Secretary of State,,,Write-ins,0
-Wyandotte,KC 11-7,Secretary of State,,,Write-ins,1
-Wyandotte,KC 11-8,Secretary of State,,,Write-ins,0
-Wyandotte,KC 11-9,Secretary of State,,,Write-ins,0
-Wyandotte,KC 11-10,Secretary of State,,,Write-ins,3
-Wyandotte,KC 11-11,Secretary of State,,,Write-ins,1
-Wyandotte,KC 11-12,Secretary of State,,,Write-ins,0
-Wyandotte,KC 12-1,Secretary of State,,,Write-ins,2
-Wyandotte,KC 12-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 12-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 12-4,Secretary of State,,,Write-ins,1
-Wyandotte,KC 12-5,Secretary of State,,,Write-ins,0
-Wyandotte,KC 12-6,Secretary of State,,,Write-ins,0
-Wyandotte,KC 12-7,Secretary of State,,,Write-ins,1
-Wyandotte,KC 12-8,Secretary of State,,,Write-ins,0
-Wyandotte,KC 12-9,Secretary of State,,,Write-ins,0
-Wyandotte,KC 12-10,Secretary of State,,,Write-ins,0
-Wyandotte,KC 12-11,Secretary of State,,,Write-ins,0
-Wyandotte,KC 13-1,Secretary of State,,,Write-ins,1
-Wyandotte,KC 13-2,Secretary of State,,,Write-ins,0
-Wyandotte,KC 13-3,Secretary of State,,,Write-ins,0
-Wyandotte,KC 13-4,Secretary of State,,,Write-ins,0
-Wyandotte,KC 13-5,Secretary of State,,,Write-ins,0
-Wyandotte,KC 13-6,Secretary of State,,,Write-ins,0
-Wyandotte,KC 13-7,Secretary of State,,,Write-ins,0
-Wyandotte,KC 13-8,Secretary of State,,,Write-ins,0
-Wyandotte,KC 13-9,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-1,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-2,Secretary of State,,,Write-ins,3
-Wyandotte,KC 14-3,Secretary of State,,,Write-ins,1
-Wyandotte,KC 14-4,Secretary of State,,,Write-ins,1
-Wyandotte,KC 14-5,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-6,Secretary of State,,,Write-ins,1
-Wyandotte,KC 14-7,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-8,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-9,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-10,Secretary of State,,,Write-ins,2
-Wyandotte,KC 14-11,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-12,Secretary of State,,,Write-ins,1
-Wyandotte,KC 14-13,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-14,Secretary of State,,,Write-ins,2
-Wyandotte,KC 14-15,Secretary of State,,,Write-ins,0
-Wyandotte,KC 14-16,Secretary of State,,,Write-ins,0
-Wyandotte,OC 1-1,Secretary of State,,,Write-ins,0
-Wyandotte,BS 1-1,Attorney General,,D,A J Kotich,202
-Wyandotte,BS 2-1,Attorney General,,D,A J Kotich,139
-Wyandotte,BS 3-1,Attorney General,,D,A J Kotich,219
-Wyandotte,BS 4-1,Attorney General,,D,A J Kotich,257
-Wyandotte,DE 1-1,Attorney General,,D,A J Kotich,6
-Wyandotte,ED 1-1,Attorney General,,D,A J Kotich,316
-Wyandotte,ED 2-1,Attorney General,,D,A J Kotich,53
-Wyandotte,KC 1-1,Attorney General,,D,A J Kotich,78
-Wyandotte,KC 1-2,Attorney General,,D,A J Kotich,78
-Wyandotte,KC 1-3,Attorney General,,D,A J Kotich,44
-Wyandotte,KC 2-1,Attorney General,,D,A J Kotich,104
-Wyandotte,KC 2-2,Attorney General,,D,A J Kotich,81
-Wyandotte,KC 2-3,Attorney General,,D,A J Kotich,25
-Wyandotte,KC 2-4,Attorney General,,D,A J Kotich,91
-Wyandotte,KC 2-5,Attorney General,,D,A J Kotich,154
-Wyandotte,KC 3-1,Attorney General,,D,A J Kotich,228
-Wyandotte,KC 3-2,Attorney General,,D,A J Kotich,240
-Wyandotte,KC 3-3,Attorney General,,D,A J Kotich,40
-Wyandotte,KC 3-4,Attorney General,,D,A J Kotich,141
-Wyandotte,KC 4-1,Attorney General,,D,A J Kotich,140
-Wyandotte,KC 4-2,Attorney General,,D,A J Kotich,39
-Wyandotte,KC 4-3,Attorney General,,D,A J Kotich,89
-Wyandotte,KC 4-4,Attorney General,,D,A J Kotich,168
-Wyandotte,KC 5-1,Attorney General,,D,A J Kotich,138
-Wyandotte,KC 5-2,Attorney General,,D,A J Kotich,39
-Wyandotte,KC 5-3,Attorney General,,D,A J Kotich,30
-Wyandotte,KC 5-4,Attorney General,,D,A J Kotich,49
-Wyandotte,KC 5-5,Attorney General,,D,A J Kotich,72
-Wyandotte,KC 6-1,Attorney General,,D,A J Kotich,67
-Wyandotte,KC 6-2,Attorney General,,D,A J Kotich,19
-Wyandotte,KC 7-1,Attorney General,,D,A J Kotich,96
-Wyandotte,KC 7-2,Attorney General,,D,A J Kotich,64
-Wyandotte,KC 7-3,Attorney General,,D,A J Kotich,137
-Wyandotte,KC 7-4,Attorney General,,D,A J Kotich,149
-Wyandotte,KC 7-5,Attorney General,,D,A J Kotich,35
-Wyandotte,KC 7-6,Attorney General,,D,A J Kotich,195
-Wyandotte,KC 7-7,Attorney General,,D,A J Kotich,72
-Wyandotte,KC 7-8,Attorney General,,D,A J Kotich,211
-Wyandotte,KC 7-9,Attorney General,,D,A J Kotich,219
-Wyandotte,KC 8-1,Attorney General,,D,A J Kotich,155
-Wyandotte,KC 8-2,Attorney General,,D,A J Kotich,202
-Wyandotte,KC 8-3,Attorney General,,D,A J Kotich,310
-Wyandotte,KC 8-4,Attorney General,,D,A J Kotich,163
-Wyandotte,KC 9-1,Attorney General,,D,A J Kotich,36
-Wyandotte,KC 9-2,Attorney General,,D,A J Kotich,91
-Wyandotte,KC 9-3,Attorney General,,D,A J Kotich,287
-Wyandotte,KC 9-4,Attorney General,,D,A J Kotich,41
-Wyandotte,KC 9-5,Attorney General,,D,A J Kotich,5
-Wyandotte,KC 9-6,Attorney General,,D,A J Kotich,171
-Wyandotte,KC 9-7,Attorney General,,D,A J Kotich,122
-Wyandotte,KC 9-8,Attorney General,,D,A J Kotich,140
-Wyandotte,KC 9-9,Attorney General,,D,A J Kotich,60
-Wyandotte,KC 9-10,Attorney General,,D,A J Kotich,239
-Wyandotte,KC 9-11,Attorney General,,D,A J Kotich,266
-Wyandotte,KC 9-12,Attorney General,,D,A J Kotich,177
-Wyandotte,KC 9-13,Attorney General,,D,A J Kotich,130
-Wyandotte,KC 9-14,Attorney General,,D,A J Kotich,181
-Wyandotte,KC 9-15,Attorney General,,D,A J Kotich,0
-Wyandotte,KC 9-16,Attorney General,,D,A J Kotich,225
-Wyandotte,KC 10-1,Attorney General,,D,A J Kotich,244
-Wyandotte,KC 10-2,Attorney General,,D,A J Kotich,370
-Wyandotte,KC 10-3,Attorney General,,D,A J Kotich,14
-Wyandotte,KC 10-4,Attorney General,,D,A J Kotich,148
-Wyandotte,KC 10-5,Attorney General,,D,A J Kotich,234
-Wyandotte,KC 11-1,Attorney General,,D,A J Kotich,226
-Wyandotte,KC 11-2,Attorney General,,D,A J Kotich,195
-Wyandotte,KC 11-3,Attorney General,,D,A J Kotich,263
-Wyandotte,KC 11-4,Attorney General,,D,A J Kotich,212
-Wyandotte,KC 11-5,Attorney General,,D,A J Kotich,166
-Wyandotte,KC 11-6,Attorney General,,D,A J Kotich,228
-Wyandotte,KC 11-7,Attorney General,,D,A J Kotich,173
-Wyandotte,KC 11-8,Attorney General,,D,A J Kotich,228
-Wyandotte,KC 11-9,Attorney General,,D,A J Kotich,212
-Wyandotte,KC 11-10,Attorney General,,D,A J Kotich,264
-Wyandotte,KC 11-11,Attorney General,,D,A J Kotich,332
-Wyandotte,KC 11-12,Attorney General,,D,A J Kotich,44
-Wyandotte,KC 12-1,Attorney General,,D,A J Kotich,145
-Wyandotte,KC 12-2,Attorney General,,D,A J Kotich,44
-Wyandotte,KC 12-3,Attorney General,,D,A J Kotich,140
-Wyandotte,KC 12-4,Attorney General,,D,A J Kotich,174
-Wyandotte,KC 12-5,Attorney General,,D,A J Kotich,131
-Wyandotte,KC 12-6,Attorney General,,D,A J Kotich,142
-Wyandotte,KC 12-7,Attorney General,,D,A J Kotich,95
-Wyandotte,KC 12-8,Attorney General,,D,A J Kotich,152
-Wyandotte,KC 12-9,Attorney General,,D,A J Kotich,157
-Wyandotte,KC 12-10,Attorney General,,D,A J Kotich,115
-Wyandotte,KC 12-11,Attorney General,,D,A J Kotich,56
-Wyandotte,KC 13-1,Attorney General,,D,A J Kotich,274
-Wyandotte,KC 13-2,Attorney General,,D,A J Kotich,209
-Wyandotte,KC 13-3,Attorney General,,D,A J Kotich,179
-Wyandotte,KC 13-4,Attorney General,,D,A J Kotich,175
-Wyandotte,KC 13-5,Attorney General,,D,A J Kotich,158
-Wyandotte,KC 13-6,Attorney General,,D,A J Kotich,170
-Wyandotte,KC 13-7,Attorney General,,D,A J Kotich,97
-Wyandotte,KC 13-8,Attorney General,,D,A J Kotich,159
-Wyandotte,KC 13-9,Attorney General,,D,A J Kotich,218
-Wyandotte,KC 14-1,Attorney General,,D,A J Kotich,159
-Wyandotte,KC 14-2,Attorney General,,D,A J Kotich,111
-Wyandotte,KC 14-3,Attorney General,,D,A J Kotich,102
-Wyandotte,KC 14-4,Attorney General,,D,A J Kotich,231
-Wyandotte,KC 14-5,Attorney General,,D,A J Kotich,177
-Wyandotte,KC 14-6,Attorney General,,D,A J Kotich,219
-Wyandotte,KC 14-7,Attorney General,,D,A J Kotich,297
-Wyandotte,KC 14-8,Attorney General,,D,A J Kotich,216
-Wyandotte,KC 14-9,Attorney General,,D,A J Kotich,91
-Wyandotte,KC 14-10,Attorney General,,D,A J Kotich,291
-Wyandotte,KC 14-11,Attorney General,,D,A J Kotich,191
-Wyandotte,KC 14-12,Attorney General,,D,A J Kotich,269
-Wyandotte,KC 14-13,Attorney General,,D,A J Kotich,230
-Wyandotte,KC 14-14,Attorney General,,D,A J Kotich,266
-Wyandotte,KC 14-15,Attorney General,,D,A J Kotich,326
-Wyandotte,KC 14-16,Attorney General,,D,A J Kotich,120
-Wyandotte,OC 1-1,Attorney General,,D,A J Kotich,6
-Wyandotte,BS 1-1,Attorney General,,R,Derek Schmidt,235
-Wyandotte,BS 2-1,Attorney General,,R,Derek Schmidt,195
-Wyandotte,BS 3-1,Attorney General,,R,Derek Schmidt,252
-Wyandotte,BS 4-1,Attorney General,,R,Derek Schmidt,312
-Wyandotte,DE 1-1,Attorney General,,R,Derek Schmidt,7
-Wyandotte,ED 1-1,Attorney General,,R,Derek Schmidt,458
-Wyandotte,ED 2-1,Attorney General,,R,Derek Schmidt,76
-Wyandotte,KC 1-1,Attorney General,,R,Derek Schmidt,6
-Wyandotte,KC 1-2,Attorney General,,R,Derek Schmidt,7
-Wyandotte,KC 1-3,Attorney General,,R,Derek Schmidt,21
-Wyandotte,KC 2-1,Attorney General,,R,Derek Schmidt,28
-Wyandotte,KC 2-2,Attorney General,,R,Derek Schmidt,7
-Wyandotte,KC 2-3,Attorney General,,R,Derek Schmidt,3
-Wyandotte,KC 2-4,Attorney General,,R,Derek Schmidt,10
-Wyandotte,KC 2-5,Attorney General,,R,Derek Schmidt,19
-Wyandotte,KC 3-1,Attorney General,,R,Derek Schmidt,18
-Wyandotte,KC 3-2,Attorney General,,R,Derek Schmidt,21
-Wyandotte,KC 3-3,Attorney General,,R,Derek Schmidt,4
-Wyandotte,KC 3-4,Attorney General,,R,Derek Schmidt,10
-Wyandotte,KC 4-1,Attorney General,,R,Derek Schmidt,49
-Wyandotte,KC 4-2,Attorney General,,R,Derek Schmidt,15
-Wyandotte,KC 4-3,Attorney General,,R,Derek Schmidt,46
-Wyandotte,KC 4-4,Attorney General,,R,Derek Schmidt,104
-Wyandotte,KC 5-1,Attorney General,,R,Derek Schmidt,56
-Wyandotte,KC 5-2,Attorney General,,R,Derek Schmidt,16
-Wyandotte,KC 5-3,Attorney General,,R,Derek Schmidt,15
-Wyandotte,KC 5-4,Attorney General,,R,Derek Schmidt,23
-Wyandotte,KC 5-5,Attorney General,,R,Derek Schmidt,36
-Wyandotte,KC 6-1,Attorney General,,R,Derek Schmidt,38
-Wyandotte,KC 6-2,Attorney General,,R,Derek Schmidt,18
-Wyandotte,KC 7-1,Attorney General,,R,Derek Schmidt,62
-Wyandotte,KC 7-2,Attorney General,,R,Derek Schmidt,47
-Wyandotte,KC 7-3,Attorney General,,R,Derek Schmidt,49
-Wyandotte,KC 7-4,Attorney General,,R,Derek Schmidt,149
-Wyandotte,KC 7-5,Attorney General,,R,Derek Schmidt,18
-Wyandotte,KC 7-6,Attorney General,,R,Derek Schmidt,100
-Wyandotte,KC 7-7,Attorney General,,R,Derek Schmidt,23
-Wyandotte,KC 7-8,Attorney General,,R,Derek Schmidt,171
-Wyandotte,KC 7-9,Attorney General,,R,Derek Schmidt,133
-Wyandotte,KC 8-1,Attorney General,,R,Derek Schmidt,64
-Wyandotte,KC 8-2,Attorney General,,R,Derek Schmidt,46
-Wyandotte,KC 8-3,Attorney General,,R,Derek Schmidt,119
-Wyandotte,KC 8-4,Attorney General,,R,Derek Schmidt,82
-Wyandotte,KC 9-1,Attorney General,,R,Derek Schmidt,20
-Wyandotte,KC 9-2,Attorney General,,R,Derek Schmidt,80
-Wyandotte,KC 9-3,Attorney General,,R,Derek Schmidt,142
-Wyandotte,KC 9-4,Attorney General,,R,Derek Schmidt,30
-Wyandotte,KC 9-5,Attorney General,,R,Derek Schmidt,16
-Wyandotte,KC 9-6,Attorney General,,R,Derek Schmidt,49
-Wyandotte,KC 9-7,Attorney General,,R,Derek Schmidt,126
-Wyandotte,KC 9-8,Attorney General,,R,Derek Schmidt,52
-Wyandotte,KC 9-9,Attorney General,,R,Derek Schmidt,43
-Wyandotte,KC 9-10,Attorney General,,R,Derek Schmidt,128
-Wyandotte,KC 9-11,Attorney General,,R,Derek Schmidt,118
-Wyandotte,KC 9-12,Attorney General,,R,Derek Schmidt,150
-Wyandotte,KC 9-13,Attorney General,,R,Derek Schmidt,110
-Wyandotte,KC 9-14,Attorney General,,R,Derek Schmidt,149
-Wyandotte,KC 9-15,Attorney General,,R,Derek Schmidt,0
-Wyandotte,KC 9-16,Attorney General,,R,Derek Schmidt,192
-Wyandotte,KC 10-1,Attorney General,,R,Derek Schmidt,21
-Wyandotte,KC 10-2,Attorney General,,R,Derek Schmidt,32
-Wyandotte,KC 10-3,Attorney General,,R,Derek Schmidt,1
-Wyandotte,KC 10-4,Attorney General,,R,Derek Schmidt,22
-Wyandotte,KC 10-5,Attorney General,,R,Derek Schmidt,86
-Wyandotte,KC 11-1,Attorney General,,R,Derek Schmidt,64
-Wyandotte,KC 11-2,Attorney General,,R,Derek Schmidt,42
-Wyandotte,KC 11-3,Attorney General,,R,Derek Schmidt,87
-Wyandotte,KC 11-4,Attorney General,,R,Derek Schmidt,55
-Wyandotte,KC 11-5,Attorney General,,R,Derek Schmidt,79
-Wyandotte,KC 11-6,Attorney General,,R,Derek Schmidt,24
-Wyandotte,KC 11-7,Attorney General,,R,Derek Schmidt,64
-Wyandotte,KC 11-8,Attorney General,,R,Derek Schmidt,45
-Wyandotte,KC 11-9,Attorney General,,R,Derek Schmidt,61
-Wyandotte,KC 11-10,Attorney General,,R,Derek Schmidt,92
-Wyandotte,KC 11-11,Attorney General,,R,Derek Schmidt,180
-Wyandotte,KC 11-12,Attorney General,,R,Derek Schmidt,31
-Wyandotte,KC 12-1,Attorney General,,R,Derek Schmidt,93
-Wyandotte,KC 12-2,Attorney General,,R,Derek Schmidt,28
-Wyandotte,KC 12-3,Attorney General,,R,Derek Schmidt,85
-Wyandotte,KC 12-4,Attorney General,,R,Derek Schmidt,149
-Wyandotte,KC 12-5,Attorney General,,R,Derek Schmidt,164
-Wyandotte,KC 12-6,Attorney General,,R,Derek Schmidt,122
-Wyandotte,KC 12-7,Attorney General,,R,Derek Schmidt,106
-Wyandotte,KC 12-8,Attorney General,,R,Derek Schmidt,127
-Wyandotte,KC 12-9,Attorney General,,R,Derek Schmidt,149
-Wyandotte,KC 12-10,Attorney General,,R,Derek Schmidt,133
-Wyandotte,KC 12-11,Attorney General,,R,Derek Schmidt,69
-Wyandotte,KC 13-1,Attorney General,,R,Derek Schmidt,44
-Wyandotte,KC 13-2,Attorney General,,R,Derek Schmidt,96
-Wyandotte,KC 13-3,Attorney General,,R,Derek Schmidt,54
-Wyandotte,KC 13-4,Attorney General,,R,Derek Schmidt,14
-Wyandotte,KC 13-5,Attorney General,,R,Derek Schmidt,88
-Wyandotte,KC 13-6,Attorney General,,R,Derek Schmidt,96
-Wyandotte,KC 13-7,Attorney General,,R,Derek Schmidt,95
-Wyandotte,KC 13-8,Attorney General,,R,Derek Schmidt,75
-Wyandotte,KC 13-9,Attorney General,,R,Derek Schmidt,86
-Wyandotte,KC 14-1,Attorney General,,R,Derek Schmidt,169
-Wyandotte,KC 14-2,Attorney General,,R,Derek Schmidt,56
-Wyandotte,KC 14-3,Attorney General,,R,Derek Schmidt,47
-Wyandotte,KC 14-4,Attorney General,,R,Derek Schmidt,79
-Wyandotte,KC 14-5,Attorney General,,R,Derek Schmidt,100
-Wyandotte,KC 14-6,Attorney General,,R,Derek Schmidt,146
-Wyandotte,KC 14-7,Attorney General,,R,Derek Schmidt,165
-Wyandotte,KC 14-8,Attorney General,,R,Derek Schmidt,125
-Wyandotte,KC 14-9,Attorney General,,R,Derek Schmidt,144
-Wyandotte,KC 14-10,Attorney General,,R,Derek Schmidt,313
-Wyandotte,KC 14-11,Attorney General,,R,Derek Schmidt,136
-Wyandotte,KC 14-12,Attorney General,,R,Derek Schmidt,334
-Wyandotte,KC 14-13,Attorney General,,R,Derek Schmidt,211
-Wyandotte,KC 14-14,Attorney General,,R,Derek Schmidt,374
-Wyandotte,KC 14-15,Attorney General,,R,Derek Schmidt,459
-Wyandotte,KC 14-16,Attorney General,,R,Derek Schmidt,105
-Wyandotte,OC 1-1,Attorney General,,R,Derek Schmidt,20
-Wyandotte,BS 1-1,Attorney General,,,Write-ins,1
-Wyandotte,BS 2-1,Attorney General,,,Write-ins,1
-Wyandotte,BS 3-1,Attorney General,,,Write-ins,0
-Wyandotte,BS 4-1,Attorney General,,,Write-ins,0
-Wyandotte,DE 1-1,Attorney General,,,Write-ins,0
-Wyandotte,ED 1-1,Attorney General,,,Write-ins,3
-Wyandotte,ED 2-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 1-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 1-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 1-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 2-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 2-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 2-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 2-4,Attorney General,,,Write-ins,0
-Wyandotte,KC 2-5,Attorney General,,,Write-ins,1
-Wyandotte,KC 3-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 3-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 3-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 3-4,Attorney General,,,Write-ins,3
-Wyandotte,KC 4-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 4-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 4-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 4-4,Attorney General,,,Write-ins,1
-Wyandotte,KC 5-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 5-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 5-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 5-4,Attorney General,,,Write-ins,0
-Wyandotte,KC 5-5,Attorney General,,,Write-ins,0
-Wyandotte,KC 6-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 6-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 7-1,Attorney General,,,Write-ins,3
-Wyandotte,KC 7-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 7-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 7-4,Attorney General,,,Write-ins,1
-Wyandotte,KC 7-5,Attorney General,,,Write-ins,0
-Wyandotte,KC 7-6,Attorney General,,,Write-ins,0
-Wyandotte,KC 7-7,Attorney General,,,Write-ins,1
-Wyandotte,KC 7-8,Attorney General,,,Write-ins,0
-Wyandotte,KC 7-9,Attorney General,,,Write-ins,0
-Wyandotte,KC 8-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 8-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 8-3,Attorney General,,,Write-ins,3
-Wyandotte,KC 8-4,Attorney General,,,Write-ins,1
-Wyandotte,KC 9-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-4,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-5,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-6,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-7,Attorney General,,,Write-ins,1
-Wyandotte,KC 9-8,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-9,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-10,Attorney General,,,Write-ins,1
-Wyandotte,KC 9-11,Attorney General,,,Write-ins,1
-Wyandotte,KC 9-12,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-13,Attorney General,,,Write-ins,1
-Wyandotte,KC 9-14,Attorney General,,,Write-ins,1
-Wyandotte,KC 9-15,Attorney General,,,Write-ins,0
-Wyandotte,KC 9-16,Attorney General,,,Write-ins,0
-Wyandotte,KC 10-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 10-2,Attorney General,,,Write-ins,1
-Wyandotte,KC 10-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 10-4,Attorney General,,,Write-ins,1
-Wyandotte,KC 10-5,Attorney General,,,Write-ins,2
-Wyandotte,KC 11-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 11-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 11-3,Attorney General,,,Write-ins,1
-Wyandotte,KC 11-4,Attorney General,,,Write-ins,0
-Wyandotte,KC 11-5,Attorney General,,,Write-ins,1
-Wyandotte,KC 11-6,Attorney General,,,Write-ins,0
-Wyandotte,KC 11-7,Attorney General,,,Write-ins,0
-Wyandotte,KC 11-8,Attorney General,,,Write-ins,0
-Wyandotte,KC 11-9,Attorney General,,,Write-ins,0
-Wyandotte,KC 11-10,Attorney General,,,Write-ins,1
-Wyandotte,KC 11-11,Attorney General,,,Write-ins,0
-Wyandotte,KC 11-12,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-4,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-5,Attorney General,,,Write-ins,1
-Wyandotte,KC 12-6,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-7,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-8,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-9,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-10,Attorney General,,,Write-ins,0
-Wyandotte,KC 12-11,Attorney General,,,Write-ins,0
-Wyandotte,KC 13-1,Attorney General,,,Write-ins,1
-Wyandotte,KC 13-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 13-3,Attorney General,,,Write-ins,1
-Wyandotte,KC 13-4,Attorney General,,,Write-ins,0
-Wyandotte,KC 13-5,Attorney General,,,Write-ins,0
-Wyandotte,KC 13-6,Attorney General,,,Write-ins,0
-Wyandotte,KC 13-7,Attorney General,,,Write-ins,0
-Wyandotte,KC 13-8,Attorney General,,,Write-ins,1
-Wyandotte,KC 13-9,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-1,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-2,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-3,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-4,Attorney General,,,Write-ins,1
-Wyandotte,KC 14-5,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-6,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-7,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-8,Attorney General,,,Write-ins,2
-Wyandotte,KC 14-9,Attorney General,,,Write-ins,1
-Wyandotte,KC 14-10,Attorney General,,,Write-ins,1
-Wyandotte,KC 14-11,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-12,Attorney General,,,Write-ins,1
-Wyandotte,KC 14-13,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-14,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-15,Attorney General,,,Write-ins,0
-Wyandotte,KC 14-16,Attorney General,,,Write-ins,0
-Wyandotte,OC 1-1,Attorney General,,,Write-ins,0
-Wyandotte,BS 1-1,State Treasurer,,D,Carmen Alldritt,198
-Wyandotte,BS 2-1,State Treasurer,,D,Carmen Alldritt,136
-Wyandotte,BS 3-1,State Treasurer,,D,Carmen Alldritt,208
-Wyandotte,BS 4-1,State Treasurer,,D,Carmen Alldritt,245
-Wyandotte,DE 1-1,State Treasurer,,D,Carmen Alldritt,6
-Wyandotte,ED 1-1,State Treasurer,,D,Carmen Alldritt,302
-Wyandotte,ED 2-1,State Treasurer,,D,Carmen Alldritt,52
-Wyandotte,KC 1-1,State Treasurer,,D,Carmen Alldritt,73
-Wyandotte,KC 1-2,State Treasurer,,D,Carmen Alldritt,78
-Wyandotte,KC 1-3,State Treasurer,,D,Carmen Alldritt,45
-Wyandotte,KC 2-1,State Treasurer,,D,Carmen Alldritt,102
-Wyandotte,KC 2-2,State Treasurer,,D,Carmen Alldritt,78
-Wyandotte,KC 2-3,State Treasurer,,D,Carmen Alldritt,24
-Wyandotte,KC 2-4,State Treasurer,,D,Carmen Alldritt,92
-Wyandotte,KC 2-5,State Treasurer,,D,Carmen Alldritt,161
-Wyandotte,KC 3-1,State Treasurer,,D,Carmen Alldritt,226
-Wyandotte,KC 3-2,State Treasurer,,D,Carmen Alldritt,244
-Wyandotte,KC 3-3,State Treasurer,,D,Carmen Alldritt,43
-Wyandotte,KC 3-4,State Treasurer,,D,Carmen Alldritt,140
-Wyandotte,KC 4-1,State Treasurer,,D,Carmen Alldritt,132
-Wyandotte,KC 4-2,State Treasurer,,D,Carmen Alldritt,39
-Wyandotte,KC 4-3,State Treasurer,,D,Carmen Alldritt,82
-Wyandotte,KC 4-4,State Treasurer,,D,Carmen Alldritt,166
-Wyandotte,KC 5-1,State Treasurer,,D,Carmen Alldritt,136
-Wyandotte,KC 5-2,State Treasurer,,D,Carmen Alldritt,43
-Wyandotte,KC 5-3,State Treasurer,,D,Carmen Alldritt,29
-Wyandotte,KC 5-4,State Treasurer,,D,Carmen Alldritt,50
-Wyandotte,KC 5-5,State Treasurer,,D,Carmen Alldritt,71
-Wyandotte,KC 6-1,State Treasurer,,D,Carmen Alldritt,61
-Wyandotte,KC 6-2,State Treasurer,,D,Carmen Alldritt,22
-Wyandotte,KC 7-1,State Treasurer,,D,Carmen Alldritt,102
-Wyandotte,KC 7-2,State Treasurer,,D,Carmen Alldritt,70
-Wyandotte,KC 7-3,State Treasurer,,D,Carmen Alldritt,132
-Wyandotte,KC 7-4,State Treasurer,,D,Carmen Alldritt,150
-Wyandotte,KC 7-5,State Treasurer,,D,Carmen Alldritt,38
-Wyandotte,KC 7-6,State Treasurer,,D,Carmen Alldritt,188
-Wyandotte,KC 7-7,State Treasurer,,D,Carmen Alldritt,69
-Wyandotte,KC 7-8,State Treasurer,,D,Carmen Alldritt,221
-Wyandotte,KC 7-9,State Treasurer,,D,Carmen Alldritt,199
-Wyandotte,KC 8-1,State Treasurer,,D,Carmen Alldritt,150
-Wyandotte,KC 8-2,State Treasurer,,D,Carmen Alldritt,197
-Wyandotte,KC 8-3,State Treasurer,,D,Carmen Alldritt,306
-Wyandotte,KC 8-4,State Treasurer,,D,Carmen Alldritt,163
-Wyandotte,KC 9-1,State Treasurer,,D,Carmen Alldritt,34
-Wyandotte,KC 9-2,State Treasurer,,D,Carmen Alldritt,90
-Wyandotte,KC 9-3,State Treasurer,,D,Carmen Alldritt,282
-Wyandotte,KC 9-4,State Treasurer,,D,Carmen Alldritt,46
-Wyandotte,KC 9-5,State Treasurer,,D,Carmen Alldritt,7
-Wyandotte,KC 9-6,State Treasurer,,D,Carmen Alldritt,169
-Wyandotte,KC 9-7,State Treasurer,,D,Carmen Alldritt,115
-Wyandotte,KC 9-8,State Treasurer,,D,Carmen Alldritt,137
-Wyandotte,KC 9-9,State Treasurer,,D,Carmen Alldritt,55
-Wyandotte,KC 9-10,State Treasurer,,D,Carmen Alldritt,230
-Wyandotte,KC 9-11,State Treasurer,,D,Carmen Alldritt,266
-Wyandotte,KC 9-12,State Treasurer,,D,Carmen Alldritt,170
-Wyandotte,KC 9-13,State Treasurer,,D,Carmen Alldritt,125
-Wyandotte,KC 9-14,State Treasurer,,D,Carmen Alldritt,170
-Wyandotte,KC 9-15,State Treasurer,,D,Carmen Alldritt,0
-Wyandotte,KC 9-16,State Treasurer,,D,Carmen Alldritt,213
-Wyandotte,KC 10-1,State Treasurer,,D,Carmen Alldritt,242
-Wyandotte,KC 10-2,State Treasurer,,D,Carmen Alldritt,369
-Wyandotte,KC 10-3,State Treasurer,,D,Carmen Alldritt,14
-Wyandotte,KC 10-4,State Treasurer,,D,Carmen Alldritt,140
-Wyandotte,KC 10-5,State Treasurer,,D,Carmen Alldritt,231
-Wyandotte,KC 11-1,State Treasurer,,D,Carmen Alldritt,226
-Wyandotte,KC 11-2,State Treasurer,,D,Carmen Alldritt,186
-Wyandotte,KC 11-3,State Treasurer,,D,Carmen Alldritt,264
-Wyandotte,KC 11-4,State Treasurer,,D,Carmen Alldritt,210
-Wyandotte,KC 11-5,State Treasurer,,D,Carmen Alldritt,175
-Wyandotte,KC 11-6,State Treasurer,,D,Carmen Alldritt,221
-Wyandotte,KC 11-7,State Treasurer,,D,Carmen Alldritt,172
-Wyandotte,KC 11-8,State Treasurer,,D,Carmen Alldritt,226
-Wyandotte,KC 11-9,State Treasurer,,D,Carmen Alldritt,203
-Wyandotte,KC 11-10,State Treasurer,,D,Carmen Alldritt,269
-Wyandotte,KC 11-11,State Treasurer,,D,Carmen Alldritt,324
-Wyandotte,KC 11-12,State Treasurer,,D,Carmen Alldritt,44
-Wyandotte,KC 12-1,State Treasurer,,D,Carmen Alldritt,142
-Wyandotte,KC 12-2,State Treasurer,,D,Carmen Alldritt,45
-Wyandotte,KC 12-3,State Treasurer,,D,Carmen Alldritt,137
-Wyandotte,KC 12-4,State Treasurer,,D,Carmen Alldritt,174
-Wyandotte,KC 12-5,State Treasurer,,D,Carmen Alldritt,118
-Wyandotte,KC 12-6,State Treasurer,,D,Carmen Alldritt,143
-Wyandotte,KC 12-7,State Treasurer,,D,Carmen Alldritt,97
-Wyandotte,KC 12-8,State Treasurer,,D,Carmen Alldritt,154
-Wyandotte,KC 12-9,State Treasurer,,D,Carmen Alldritt,156
-Wyandotte,KC 12-10,State Treasurer,,D,Carmen Alldritt,101
-Wyandotte,KC 12-11,State Treasurer,,D,Carmen Alldritt,52
-Wyandotte,KC 13-1,State Treasurer,,D,Carmen Alldritt,266
-Wyandotte,KC 13-2,State Treasurer,,D,Carmen Alldritt,193
-Wyandotte,KC 13-3,State Treasurer,,D,Carmen Alldritt,170
-Wyandotte,KC 13-4,State Treasurer,,D,Carmen Alldritt,173
-Wyandotte,KC 13-5,State Treasurer,,D,Carmen Alldritt,156
-Wyandotte,KC 13-6,State Treasurer,,D,Carmen Alldritt,168
-Wyandotte,KC 13-7,State Treasurer,,D,Carmen Alldritt,97
-Wyandotte,KC 13-8,State Treasurer,,D,Carmen Alldritt,155
-Wyandotte,KC 13-9,State Treasurer,,D,Carmen Alldritt,213
-Wyandotte,KC 14-1,State Treasurer,,D,Carmen Alldritt,149
-Wyandotte,KC 14-2,State Treasurer,,D,Carmen Alldritt,108
-Wyandotte,KC 14-3,State Treasurer,,D,Carmen Alldritt,103
-Wyandotte,KC 14-4,State Treasurer,,D,Carmen Alldritt,215
-Wyandotte,KC 14-5,State Treasurer,,D,Carmen Alldritt,171
-Wyandotte,KC 14-6,State Treasurer,,D,Carmen Alldritt,217
-Wyandotte,KC 14-7,State Treasurer,,D,Carmen Alldritt,283
-Wyandotte,KC 14-8,State Treasurer,,D,Carmen Alldritt,206
-Wyandotte,KC 14-9,State Treasurer,,D,Carmen Alldritt,93
-Wyandotte,KC 14-10,State Treasurer,,D,Carmen Alldritt,278
-Wyandotte,KC 14-11,State Treasurer,,D,Carmen Alldritt,183
-Wyandotte,KC 14-12,State Treasurer,,D,Carmen Alldritt,258
-Wyandotte,KC 14-13,State Treasurer,,D,Carmen Alldritt,228
-Wyandotte,KC 14-14,State Treasurer,,D,Carmen Alldritt,248
-Wyandotte,KC 14-15,State Treasurer,,D,Carmen Alldritt,312
-Wyandotte,KC 14-16,State Treasurer,,D,Carmen Alldritt,119
-Wyandotte,OC 1-1,State Treasurer,,D,Carmen Alldritt,6
-Wyandotte,BS 1-1,State Treasurer,,R,Ron Estes,237
-Wyandotte,BS 2-1,State Treasurer,,R,Ron Estes,196
-Wyandotte,BS 3-1,State Treasurer,,R,Ron Estes,263
-Wyandotte,BS 4-1,State Treasurer,,R,Ron Estes,323
-Wyandotte,DE 1-1,State Treasurer,,R,Ron Estes,7
-Wyandotte,ED 1-1,State Treasurer,,R,Ron Estes,475
-Wyandotte,ED 2-1,State Treasurer,,R,Ron Estes,77
-Wyandotte,KC 1-1,State Treasurer,,R,Ron Estes,10
-Wyandotte,KC 1-2,State Treasurer,,R,Ron Estes,7
-Wyandotte,KC 1-3,State Treasurer,,R,Ron Estes,17
-Wyandotte,KC 2-1,State Treasurer,,R,Ron Estes,32
-Wyandotte,KC 2-2,State Treasurer,,R,Ron Estes,10
-Wyandotte,KC 2-3,State Treasurer,,R,Ron Estes,4
-Wyandotte,KC 2-4,State Treasurer,,R,Ron Estes,7
-Wyandotte,KC 2-5,State Treasurer,,R,Ron Estes,17
-Wyandotte,KC 3-1,State Treasurer,,R,Ron Estes,23
-Wyandotte,KC 3-2,State Treasurer,,R,Ron Estes,15
-Wyandotte,KC 3-3,State Treasurer,,R,Ron Estes,3
-Wyandotte,KC 3-4,State Treasurer,,R,Ron Estes,7
-Wyandotte,KC 4-1,State Treasurer,,R,Ron Estes,52
-Wyandotte,KC 4-2,State Treasurer,,R,Ron Estes,15
-Wyandotte,KC 4-3,State Treasurer,,R,Ron Estes,50
-Wyandotte,KC 4-4,State Treasurer,,R,Ron Estes,103
-Wyandotte,KC 5-1,State Treasurer,,R,Ron Estes,53
-Wyandotte,KC 5-2,State Treasurer,,R,Ron Estes,10
-Wyandotte,KC 5-3,State Treasurer,,R,Ron Estes,16
-Wyandotte,KC 5-4,State Treasurer,,R,Ron Estes,22
-Wyandotte,KC 5-5,State Treasurer,,R,Ron Estes,37
-Wyandotte,KC 6-1,State Treasurer,,R,Ron Estes,42
-Wyandotte,KC 6-2,State Treasurer,,R,Ron Estes,15
-Wyandotte,KC 7-1,State Treasurer,,R,Ron Estes,52
-Wyandotte,KC 7-2,State Treasurer,,R,Ron Estes,36
-Wyandotte,KC 7-3,State Treasurer,,R,Ron Estes,53
-Wyandotte,KC 7-4,State Treasurer,,R,Ron Estes,146
-Wyandotte,KC 7-5,State Treasurer,,R,Ron Estes,15
-Wyandotte,KC 7-6,State Treasurer,,R,Ron Estes,104
-Wyandotte,KC 7-7,State Treasurer,,R,Ron Estes,26
-Wyandotte,KC 7-8,State Treasurer,,R,Ron Estes,165
-Wyandotte,KC 7-9,State Treasurer,,R,Ron Estes,150
-Wyandotte,KC 8-1,State Treasurer,,R,Ron Estes,68
-Wyandotte,KC 8-2,State Treasurer,,R,Ron Estes,48
-Wyandotte,KC 8-3,State Treasurer,,R,Ron Estes,122
-Wyandotte,KC 8-4,State Treasurer,,R,Ron Estes,82
-Wyandotte,KC 9-1,State Treasurer,,R,Ron Estes,24
-Wyandotte,KC 9-2,State Treasurer,,R,Ron Estes,79
-Wyandotte,KC 9-3,State Treasurer,,R,Ron Estes,137
-Wyandotte,KC 9-4,State Treasurer,,R,Ron Estes,27
-Wyandotte,KC 9-5,State Treasurer,,R,Ron Estes,14
-Wyandotte,KC 9-6,State Treasurer,,R,Ron Estes,55
-Wyandotte,KC 9-7,State Treasurer,,R,Ron Estes,134
-Wyandotte,KC 9-8,State Treasurer,,R,Ron Estes,51
-Wyandotte,KC 9-9,State Treasurer,,R,Ron Estes,51
-Wyandotte,KC 9-10,State Treasurer,,R,Ron Estes,134
-Wyandotte,KC 9-11,State Treasurer,,R,Ron Estes,117
-Wyandotte,KC 9-12,State Treasurer,,R,Ron Estes,153
-Wyandotte,KC 9-13,State Treasurer,,R,Ron Estes,110
-Wyandotte,KC 9-14,State Treasurer,,R,Ron Estes,157
-Wyandotte,KC 9-15,State Treasurer,,R,Ron Estes,0
-Wyandotte,KC 9-16,State Treasurer,,R,Ron Estes,197
-Wyandotte,KC 10-1,State Treasurer,,R,Ron Estes,18
-Wyandotte,KC 10-2,State Treasurer,,R,Ron Estes,29
-Wyandotte,KC 10-3,State Treasurer,,R,Ron Estes,1
-Wyandotte,KC 10-4,State Treasurer,,R,Ron Estes,27
-Wyandotte,KC 10-5,State Treasurer,,R,Ron Estes,88
-Wyandotte,KC 11-1,State Treasurer,,R,Ron Estes,64
-Wyandotte,KC 11-2,State Treasurer,,R,Ron Estes,46
-Wyandotte,KC 11-3,State Treasurer,,R,Ron Estes,86
-Wyandotte,KC 11-4,State Treasurer,,R,Ron Estes,53
-Wyandotte,KC 11-5,State Treasurer,,R,Ron Estes,73
-Wyandotte,KC 11-6,State Treasurer,,R,Ron Estes,28
-Wyandotte,KC 11-7,State Treasurer,,R,Ron Estes,60
-Wyandotte,KC 11-8,State Treasurer,,R,Ron Estes,46
-Wyandotte,KC 11-9,State Treasurer,,R,Ron Estes,68
-Wyandotte,KC 11-10,State Treasurer,,R,Ron Estes,88
-Wyandotte,KC 11-11,State Treasurer,,R,Ron Estes,190
-Wyandotte,KC 11-12,State Treasurer,,R,Ron Estes,30
-Wyandotte,KC 12-1,State Treasurer,,R,Ron Estes,91
-Wyandotte,KC 12-2,State Treasurer,,R,Ron Estes,27
-Wyandotte,KC 12-3,State Treasurer,,R,Ron Estes,89
-Wyandotte,KC 12-4,State Treasurer,,R,Ron Estes,150
-Wyandotte,KC 12-5,State Treasurer,,R,Ron Estes,175
-Wyandotte,KC 12-6,State Treasurer,,R,Ron Estes,123
-Wyandotte,KC 12-7,State Treasurer,,R,Ron Estes,100
-Wyandotte,KC 12-8,State Treasurer,,R,Ron Estes,122
-Wyandotte,KC 12-9,State Treasurer,,R,Ron Estes,153
-Wyandotte,KC 12-10,State Treasurer,,R,Ron Estes,144
-Wyandotte,KC 12-11,State Treasurer,,R,Ron Estes,70
-Wyandotte,KC 13-1,State Treasurer,,R,Ron Estes,49
-Wyandotte,KC 13-2,State Treasurer,,R,Ron Estes,103
-Wyandotte,KC 13-3,State Treasurer,,R,Ron Estes,64
-Wyandotte,KC 13-4,State Treasurer,,R,Ron Estes,16
-Wyandotte,KC 13-5,State Treasurer,,R,Ron Estes,87
-Wyandotte,KC 13-6,State Treasurer,,R,Ron Estes,97
-Wyandotte,KC 13-7,State Treasurer,,R,Ron Estes,97
-Wyandotte,KC 13-8,State Treasurer,,R,Ron Estes,81
-Wyandotte,KC 13-9,State Treasurer,,R,Ron Estes,89
-Wyandotte,KC 14-1,State Treasurer,,R,Ron Estes,177
-Wyandotte,KC 14-2,State Treasurer,,R,Ron Estes,62
-Wyandotte,KC 14-3,State Treasurer,,R,Ron Estes,48
-Wyandotte,KC 14-4,State Treasurer,,R,Ron Estes,92
-Wyandotte,KC 14-5,State Treasurer,,R,Ron Estes,107
-Wyandotte,KC 14-6,State Treasurer,,R,Ron Estes,141
-Wyandotte,KC 14-7,State Treasurer,,R,Ron Estes,176
-Wyandotte,KC 14-8,State Treasurer,,R,Ron Estes,132
-Wyandotte,KC 14-9,State Treasurer,,R,Ron Estes,142
-Wyandotte,KC 14-10,State Treasurer,,R,Ron Estes,309
-Wyandotte,KC 14-11,State Treasurer,,R,Ron Estes,145
-Wyandotte,KC 14-12,State Treasurer,,R,Ron Estes,333
-Wyandotte,KC 14-13,State Treasurer,,R,Ron Estes,210
-Wyandotte,KC 14-14,State Treasurer,,R,Ron Estes,387
-Wyandotte,KC 14-15,State Treasurer,,R,Ron Estes,466
-Wyandotte,KC 14-16,State Treasurer,,R,Ron Estes,101
-Wyandotte,OC 1-1,State Treasurer,,R,Ron Estes,18
-Wyandotte,BS 1-1,State Treasurer,,,Write-ins,1
-Wyandotte,BS 2-1,State Treasurer,,,Write-ins,1
-Wyandotte,BS 3-1,State Treasurer,,,Write-ins,0
-Wyandotte,BS 4-1,State Treasurer,,,Write-ins,2
-Wyandotte,DE 1-1,State Treasurer,,,Write-ins,0
-Wyandotte,ED 1-1,State Treasurer,,,Write-ins,1
-Wyandotte,ED 2-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 1-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 1-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 1-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 2-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 2-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 2-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 2-4,State Treasurer,,,Write-ins,1
-Wyandotte,KC 2-5,State Treasurer,,,Write-ins,0
-Wyandotte,KC 3-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 3-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 3-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 3-4,State Treasurer,,,Write-ins,3
-Wyandotte,KC 4-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 4-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 4-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 4-4,State Treasurer,,,Write-ins,0
-Wyandotte,KC 5-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 5-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 5-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 5-4,State Treasurer,,,Write-ins,0
-Wyandotte,KC 5-5,State Treasurer,,,Write-ins,0
-Wyandotte,KC 6-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 6-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 7-2,State Treasurer,,,Write-ins,23
-Wyandotte,KC 7-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 7-4,State Treasurer,,,Write-ins,0
-Wyandotte,KC 7-5,State Treasurer,,,Write-ins,0
-Wyandotte,KC 7-6,State Treasurer,,,Write-ins,0
-Wyandotte,KC 7-7,State Treasurer,,,Write-ins,0
-Wyandotte,KC 7-8,State Treasurer,,,Write-ins,1
-Wyandotte,KC 7-9,State Treasurer,,,Write-ins,0
-Wyandotte,KC 8-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 8-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 8-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 8-4,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-3,State Treasurer,,,Write-ins,2
-Wyandotte,KC 9-4,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-5,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-6,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-7,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-8,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-9,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-10,State Treasurer,,,Write-ins,1
-Wyandotte,KC 9-11,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-12,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-13,State Treasurer,,,Write-ins,1
-Wyandotte,KC 9-14,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-15,State Treasurer,,,Write-ins,0
-Wyandotte,KC 9-16,State Treasurer,,,Write-ins,0
-Wyandotte,KC 10-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 10-2,State Treasurer,,,Write-ins,2
-Wyandotte,KC 10-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 10-4,State Treasurer,,,Write-ins,0
-Wyandotte,KC 10-5,State Treasurer,,,Write-ins,1
-Wyandotte,KC 11-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 11-2,State Treasurer,,,Write-ins,1
-Wyandotte,KC 11-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 11-4,State Treasurer,,,Write-ins,2
-Wyandotte,KC 11-5,State Treasurer,,,Write-ins,1
-Wyandotte,KC 11-6,State Treasurer,,,Write-ins,0
-Wyandotte,KC 11-7,State Treasurer,,,Write-ins,0
-Wyandotte,KC 11-8,State Treasurer,,,Write-ins,0
-Wyandotte,KC 11-9,State Treasurer,,,Write-ins,0
-Wyandotte,KC 11-10,State Treasurer,,,Write-ins,1
-Wyandotte,KC 11-11,State Treasurer,,,Write-ins,1
-Wyandotte,KC 11-12,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-1,State Treasurer,,,Write-ins,1
-Wyandotte,KC 12-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-4,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-5,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-6,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-7,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-8,State Treasurer,,,Write-ins,1
-Wyandotte,KC 12-9,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-10,State Treasurer,,,Write-ins,0
-Wyandotte,KC 12-11,State Treasurer,,,Write-ins,0
-Wyandotte,KC 13-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 13-2,State Treasurer,,,Write-ins,1
-Wyandotte,KC 13-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 13-4,State Treasurer,,,Write-ins,0
-Wyandotte,KC 13-5,State Treasurer,,,Write-ins,0
-Wyandotte,KC 13-6,State Treasurer,,,Write-ins,0
-Wyandotte,KC 13-7,State Treasurer,,,Write-ins,0
-Wyandotte,KC 13-8,State Treasurer,,,Write-ins,0
-Wyandotte,KC 13-9,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-1,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-2,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-3,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-4,State Treasurer,,,Write-ins,1
-Wyandotte,KC 14-5,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-6,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-7,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-8,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-9,State Treasurer,,,Write-ins,1
-Wyandotte,KC 14-10,State Treasurer,,,Write-ins,1
-Wyandotte,KC 14-11,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-12,State Treasurer,,,Write-ins,2
-Wyandotte,KC 14-13,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-14,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-15,State Treasurer,,,Write-ins,0
-Wyandotte,KC 14-16,State Treasurer,,,Write-ins,0
-Wyandotte,OC 1-1,State Treasurer,,,Write-ins,0
-Wyandotte,BS 1-1,Insurance Commissioner,,D,Dennis Anderson,215
-Wyandotte,BS 2-1,Insurance Commissioner,,D,Dennis Anderson,153
-Wyandotte,BS 3-1,Insurance Commissioner,,D,Dennis Anderson,229
-Wyandotte,BS 4-1,Insurance Commissioner,,D,Dennis Anderson,258
-Wyandotte,DE 1-1,Insurance Commissioner,,D,Dennis Anderson,5
-Wyandotte,ED 1-1,Insurance Commissioner,,D,Dennis Anderson,316
-Wyandotte,ED 2-1,Insurance Commissioner,,D,Dennis Anderson,59
-Wyandotte,KC 1-1,Insurance Commissioner,,D,Dennis Anderson,75
-Wyandotte,KC 1-2,Insurance Commissioner,,D,Dennis Anderson,79
-Wyandotte,KC 1-3,Insurance Commissioner,,D,Dennis Anderson,50
-Wyandotte,KC 2-1,Insurance Commissioner,,D,Dennis Anderson,110
-Wyandotte,KC 2-2,Insurance Commissioner,,D,Dennis Anderson,82
-Wyandotte,KC 2-3,Insurance Commissioner,,D,Dennis Anderson,26
-Wyandotte,KC 2-4,Insurance Commissioner,,D,Dennis Anderson,92
-Wyandotte,KC 2-5,Insurance Commissioner,,D,Dennis Anderson,163
-Wyandotte,KC 3-1,Insurance Commissioner,,D,Dennis Anderson,232
-Wyandotte,KC 3-2,Insurance Commissioner,,D,Dennis Anderson,243
-Wyandotte,KC 3-3,Insurance Commissioner,,D,Dennis Anderson,41
-Wyandotte,KC 3-4,Insurance Commissioner,,D,Dennis Anderson,144
-Wyandotte,KC 4-1,Insurance Commissioner,,D,Dennis Anderson,141
-Wyandotte,KC 4-2,Insurance Commissioner,,D,Dennis Anderson,38
-Wyandotte,KC 4-3,Insurance Commissioner,,D,Dennis Anderson,93
-Wyandotte,KC 4-4,Insurance Commissioner,,D,Dennis Anderson,177
-Wyandotte,KC 5-1,Insurance Commissioner,,D,Dennis Anderson,136
-Wyandotte,KC 5-2,Insurance Commissioner,,D,Dennis Anderson,42
-Wyandotte,KC 5-3,Insurance Commissioner,,D,Dennis Anderson,30
-Wyandotte,KC 5-4,Insurance Commissioner,,D,Dennis Anderson,47
-Wyandotte,KC 5-5,Insurance Commissioner,,D,Dennis Anderson,77
-Wyandotte,KC 6-1,Insurance Commissioner,,D,Dennis Anderson,69
-Wyandotte,KC 6-2,Insurance Commissioner,,D,Dennis Anderson,20
-Wyandotte,KC 7-1,Insurance Commissioner,,D,Dennis Anderson,104
-Wyandotte,KC 7-2,Insurance Commissioner,,D,Dennis Anderson,75
-Wyandotte,KC 7-3,Insurance Commissioner,,D,Dennis Anderson,136
-Wyandotte,KC 7-4,Insurance Commissioner,,D,Dennis Anderson,161
-Wyandotte,KC 7-5,Insurance Commissioner,,D,Dennis Anderson,42
-Wyandotte,KC 7-6,Insurance Commissioner,,D,Dennis Anderson,205
-Wyandotte,KC 7-7,Insurance Commissioner,,D,Dennis Anderson,72
-Wyandotte,KC 7-8,Insurance Commissioner,,D,Dennis Anderson,237
-Wyandotte,KC 7-9,Insurance Commissioner,,D,Dennis Anderson,223
-Wyandotte,KC 8-1,Insurance Commissioner,,D,Dennis Anderson,166
-Wyandotte,KC 8-2,Insurance Commissioner,,D,Dennis Anderson,206
-Wyandotte,KC 8-3,Insurance Commissioner,,D,Dennis Anderson,313
-Wyandotte,KC 8-4,Insurance Commissioner,,D,Dennis Anderson,167
-Wyandotte,KC 9-1,Insurance Commissioner,,D,Dennis Anderson,35
-Wyandotte,KC 9-2,Insurance Commissioner,,D,Dennis Anderson,92
-Wyandotte,KC 9-3,Insurance Commissioner,,D,Dennis Anderson,297
-Wyandotte,KC 9-4,Insurance Commissioner,,D,Dennis Anderson,47
-Wyandotte,KC 9-5,Insurance Commissioner,,D,Dennis Anderson,5
-Wyandotte,KC 9-6,Insurance Commissioner,,D,Dennis Anderson,174
-Wyandotte,KC 9-7,Insurance Commissioner,,D,Dennis Anderson,127
-Wyandotte,KC 9-8,Insurance Commissioner,,D,Dennis Anderson,147
-Wyandotte,KC 9-9,Insurance Commissioner,,D,Dennis Anderson,60
-Wyandotte,KC 9-10,Insurance Commissioner,,D,Dennis Anderson,243
-Wyandotte,KC 9-11,Insurance Commissioner,,D,Dennis Anderson,279
-Wyandotte,KC 9-12,Insurance Commissioner,,D,Dennis Anderson,189
-Wyandotte,KC 9-13,Insurance Commissioner,,D,Dennis Anderson,135
-Wyandotte,KC 9-14,Insurance Commissioner,,D,Dennis Anderson,182
-Wyandotte,KC 9-15,Insurance Commissioner,,D,Dennis Anderson,0
-Wyandotte,KC 9-16,Insurance Commissioner,,D,Dennis Anderson,240
-Wyandotte,KC 10-1,Insurance Commissioner,,D,Dennis Anderson,249
-Wyandotte,KC 10-2,Insurance Commissioner,,D,Dennis Anderson,381
-Wyandotte,KC 10-3,Insurance Commissioner,,D,Dennis Anderson,14
-Wyandotte,KC 10-4,Insurance Commissioner,,D,Dennis Anderson,142
-Wyandotte,KC 10-5,Insurance Commissioner,,D,Dennis Anderson,234
-Wyandotte,KC 11-1,Insurance Commissioner,,D,Dennis Anderson,239
-Wyandotte,KC 11-2,Insurance Commissioner,,D,Dennis Anderson,198
-Wyandotte,KC 11-3,Insurance Commissioner,,D,Dennis Anderson,284
-Wyandotte,KC 11-4,Insurance Commissioner,,D,Dennis Anderson,212
-Wyandotte,KC 11-5,Insurance Commissioner,,D,Dennis Anderson,181
-Wyandotte,KC 11-6,Insurance Commissioner,,D,Dennis Anderson,227
-Wyandotte,KC 11-7,Insurance Commissioner,,D,Dennis Anderson,176
-Wyandotte,KC 11-8,Insurance Commissioner,,D,Dennis Anderson,233
-Wyandotte,KC 11-9,Insurance Commissioner,,D,Dennis Anderson,209
-Wyandotte,KC 11-10,Insurance Commissioner,,D,Dennis Anderson,275
-Wyandotte,KC 11-11,Insurance Commissioner,,D,Dennis Anderson,340
-Wyandotte,KC 11-12,Insurance Commissioner,,D,Dennis Anderson,44
-Wyandotte,KC 12-1,Insurance Commissioner,,D,Dennis Anderson,147
-Wyandotte,KC 12-2,Insurance Commissioner,,D,Dennis Anderson,48
-Wyandotte,KC 12-3,Insurance Commissioner,,D,Dennis Anderson,144
-Wyandotte,KC 12-4,Insurance Commissioner,,D,Dennis Anderson,188
-Wyandotte,KC 12-5,Insurance Commissioner,,D,Dennis Anderson,140
-Wyandotte,KC 12-6,Insurance Commissioner,,D,Dennis Anderson,152
-Wyandotte,KC 12-7,Insurance Commissioner,,D,Dennis Anderson,103
-Wyandotte,KC 12-8,Insurance Commissioner,,D,Dennis Anderson,166
-Wyandotte,KC 12-9,Insurance Commissioner,,D,Dennis Anderson,167
-Wyandotte,KC 12-10,Insurance Commissioner,,D,Dennis Anderson,116
-Wyandotte,KC 12-11,Insurance Commissioner,,D,Dennis Anderson,62
-Wyandotte,KC 13-1,Insurance Commissioner,,D,Dennis Anderson,277
-Wyandotte,KC 13-2,Insurance Commissioner,,D,Dennis Anderson,214
-Wyandotte,KC 13-3,Insurance Commissioner,,D,Dennis Anderson,184
-Wyandotte,KC 13-4,Insurance Commissioner,,D,Dennis Anderson,176
-Wyandotte,KC 13-5,Insurance Commissioner,,D,Dennis Anderson,159
-Wyandotte,KC 13-6,Insurance Commissioner,,D,Dennis Anderson,187
-Wyandotte,KC 13-7,Insurance Commissioner,,D,Dennis Anderson,112
-Wyandotte,KC 13-8,Insurance Commissioner,,D,Dennis Anderson,155
-Wyandotte,KC 13-9,Insurance Commissioner,,D,Dennis Anderson,224
-Wyandotte,KC 14-1,Insurance Commissioner,,D,Dennis Anderson,173
-Wyandotte,KC 14-2,Insurance Commissioner,,D,Dennis Anderson,114
-Wyandotte,KC 14-3,Insurance Commissioner,,D,Dennis Anderson,107
-Wyandotte,KC 14-4,Insurance Commissioner,,D,Dennis Anderson,232
-Wyandotte,KC 14-5,Insurance Commissioner,,D,Dennis Anderson,188
-Wyandotte,KC 14-6,Insurance Commissioner,,D,Dennis Anderson,228
-Wyandotte,KC 14-7,Insurance Commissioner,,D,Dennis Anderson,310
-Wyandotte,KC 14-8,Insurance Commissioner,,D,Dennis Anderson,217
-Wyandotte,KC 14-9,Insurance Commissioner,,D,Dennis Anderson,108
-Wyandotte,KC 14-10,Insurance Commissioner,,D,Dennis Anderson,309
-Wyandotte,KC 14-11,Insurance Commissioner,,D,Dennis Anderson,203
-Wyandotte,KC 14-12,Insurance Commissioner,,D,Dennis Anderson,289
-Wyandotte,KC 14-13,Insurance Commissioner,,D,Dennis Anderson,259
-Wyandotte,KC 14-14,Insurance Commissioner,,D,Dennis Anderson,275
-Wyandotte,KC 14-15,Insurance Commissioner,,D,Dennis Anderson,346
-Wyandotte,KC 14-16,Insurance Commissioner,,D,Dennis Anderson,136
-Wyandotte,OC 1-1,Insurance Commissioner,,D,Dennis Anderson,10
-Wyandotte,BS 1-1,Insurance Commissioner,,R,Ken Selzer,219
-Wyandotte,BS 2-1,Insurance Commissioner,,R,Ken Selzer,177
-Wyandotte,BS 3-1,Insurance Commissioner,,R,Ken Selzer,238
-Wyandotte,BS 4-1,Insurance Commissioner,,R,Ken Selzer,306
-Wyandotte,DE 1-1,Insurance Commissioner,,R,Ken Selzer,8
-Wyandotte,ED 1-1,Insurance Commissioner,,R,Ken Selzer,454
-Wyandotte,ED 2-1,Insurance Commissioner,,R,Ken Selzer,69
-Wyandotte,KC 1-1,Insurance Commissioner,,R,Ken Selzer,7
-Wyandotte,KC 1-2,Insurance Commissioner,,R,Ken Selzer,7
-Wyandotte,KC 1-3,Insurance Commissioner,,R,Ken Selzer,13
-Wyandotte,KC 2-1,Insurance Commissioner,,R,Ken Selzer,23
-Wyandotte,KC 2-2,Insurance Commissioner,,R,Ken Selzer,7
-Wyandotte,KC 2-3,Insurance Commissioner,,R,Ken Selzer,2
-Wyandotte,KC 2-4,Insurance Commissioner,,R,Ken Selzer,6
-Wyandotte,KC 2-5,Insurance Commissioner,,R,Ken Selzer,15
-Wyandotte,KC 3-1,Insurance Commissioner,,R,Ken Selzer,16
-Wyandotte,KC 3-2,Insurance Commissioner,,R,Ken Selzer,11
-Wyandotte,KC 3-3,Insurance Commissioner,,R,Ken Selzer,3
-Wyandotte,KC 3-4,Insurance Commissioner,,R,Ken Selzer,5
-Wyandotte,KC 4-1,Insurance Commissioner,,R,Ken Selzer,42
-Wyandotte,KC 4-2,Insurance Commissioner,,R,Ken Selzer,15
-Wyandotte,KC 4-3,Insurance Commissioner,,R,Ken Selzer,41
-Wyandotte,KC 4-4,Insurance Commissioner,,R,Ken Selzer,94
-Wyandotte,KC 5-1,Insurance Commissioner,,R,Ken Selzer,49
-Wyandotte,KC 5-2,Insurance Commissioner,,R,Ken Selzer,12
-Wyandotte,KC 5-3,Insurance Commissioner,,R,Ken Selzer,15
-Wyandotte,KC 5-4,Insurance Commissioner,,R,Ken Selzer,23
-Wyandotte,KC 5-5,Insurance Commissioner,,R,Ken Selzer,31
-Wyandotte,KC 6-1,Insurance Commissioner,,R,Ken Selzer,35
-Wyandotte,KC 6-2,Insurance Commissioner,,R,Ken Selzer,17
-Wyandotte,KC 7-1,Insurance Commissioner,,R,Ken Selzer,48
-Wyandotte,KC 7-2,Insurance Commissioner,,R,Ken Selzer,33
-Wyandotte,KC 7-3,Insurance Commissioner,,R,Ken Selzer,49
-Wyandotte,KC 7-4,Insurance Commissioner,,R,Ken Selzer,133
-Wyandotte,KC 7-5,Insurance Commissioner,,R,Ken Selzer,10
-Wyandotte,KC 7-6,Insurance Commissioner,,R,Ken Selzer,90
-Wyandotte,KC 7-7,Insurance Commissioner,,R,Ken Selzer,22
-Wyandotte,KC 7-8,Insurance Commissioner,,R,Ken Selzer,147
-Wyandotte,KC 7-9,Insurance Commissioner,,R,Ken Selzer,125
-Wyandotte,KC 8-1,Insurance Commissioner,,R,Ken Selzer,55
-Wyandotte,KC 8-2,Insurance Commissioner,,R,Ken Selzer,41
-Wyandotte,KC 8-3,Insurance Commissioner,,R,Ken Selzer,110
-Wyandotte,KC 8-4,Insurance Commissioner,,R,Ken Selzer,75
-Wyandotte,KC 9-1,Insurance Commissioner,,R,Ken Selzer,23
-Wyandotte,KC 9-2,Insurance Commissioner,,R,Ken Selzer,76
-Wyandotte,KC 9-3,Insurance Commissioner,,R,Ken Selzer,112
-Wyandotte,KC 9-4,Insurance Commissioner,,R,Ken Selzer,24
-Wyandotte,KC 9-5,Insurance Commissioner,,R,Ken Selzer,16
-Wyandotte,KC 9-6,Insurance Commissioner,,R,Ken Selzer,48
-Wyandotte,KC 9-7,Insurance Commissioner,,R,Ken Selzer,118
-Wyandotte,KC 9-8,Insurance Commissioner,,R,Ken Selzer,46
-Wyandotte,KC 9-9,Insurance Commissioner,,R,Ken Selzer,43
-Wyandotte,KC 9-10,Insurance Commissioner,,R,Ken Selzer,119
-Wyandotte,KC 9-11,Insurance Commissioner,,R,Ken Selzer,102
-Wyandotte,KC 9-12,Insurance Commissioner,,R,Ken Selzer,132
-Wyandotte,KC 9-13,Insurance Commissioner,,R,Ken Selzer,97
-Wyandotte,KC 9-14,Insurance Commissioner,,R,Ken Selzer,144
-Wyandotte,KC 9-15,Insurance Commissioner,,R,Ken Selzer,0
-Wyandotte,KC 9-16,Insurance Commissioner,,R,Ken Selzer,169
-Wyandotte,KC 10-1,Insurance Commissioner,,R,Ken Selzer,15
-Wyandotte,KC 10-2,Insurance Commissioner,,R,Ken Selzer,22
-Wyandotte,KC 10-3,Insurance Commissioner,,R,Ken Selzer,1
-Wyandotte,KC 10-4,Insurance Commissioner,,R,Ken Selzer,23
-Wyandotte,KC 10-5,Insurance Commissioner,,R,Ken Selzer,77
-Wyandotte,KC 11-1,Insurance Commissioner,,R,Ken Selzer,53
-Wyandotte,KC 11-2,Insurance Commissioner,,R,Ken Selzer,35
-Wyandotte,KC 11-3,Insurance Commissioner,,R,Ken Selzer,68
-Wyandotte,KC 11-4,Insurance Commissioner,,R,Ken Selzer,48
-Wyandotte,KC 11-5,Insurance Commissioner,,R,Ken Selzer,60
-Wyandotte,KC 11-6,Insurance Commissioner,,R,Ken Selzer,22
-Wyandotte,KC 11-7,Insurance Commissioner,,R,Ken Selzer,56
-Wyandotte,KC 11-8,Insurance Commissioner,,R,Ken Selzer,40
-Wyandotte,KC 11-9,Insurance Commissioner,,R,Ken Selzer,58
-Wyandotte,KC 11-10,Insurance Commissioner,,R,Ken Selzer,76
-Wyandotte,KC 11-11,Insurance Commissioner,,R,Ken Selzer,165
-Wyandotte,KC 11-12,Insurance Commissioner,,R,Ken Selzer,28
-Wyandotte,KC 12-1,Insurance Commissioner,,R,Ken Selzer,87
-Wyandotte,KC 12-2,Insurance Commissioner,,R,Ken Selzer,25
-Wyandotte,KC 12-3,Insurance Commissioner,,R,Ken Selzer,79
-Wyandotte,KC 12-4,Insurance Commissioner,,R,Ken Selzer,133
-Wyandotte,KC 12-5,Insurance Commissioner,,R,Ken Selzer,150
-Wyandotte,KC 12-6,Insurance Commissioner,,R,Ken Selzer,111
-Wyandotte,KC 12-7,Insurance Commissioner,,R,Ken Selzer,94
-Wyandotte,KC 12-8,Insurance Commissioner,,R,Ken Selzer,114
-Wyandotte,KC 12-9,Insurance Commissioner,,R,Ken Selzer,138
-Wyandotte,KC 12-10,Insurance Commissioner,,R,Ken Selzer,128
-Wyandotte,KC 12-11,Insurance Commissioner,,R,Ken Selzer,60
-Wyandotte,KC 13-1,Insurance Commissioner,,R,Ken Selzer,40
-Wyandotte,KC 13-2,Insurance Commissioner,,R,Ken Selzer,81
-Wyandotte,KC 13-3,Insurance Commissioner,,R,Ken Selzer,46
-Wyandotte,KC 13-4,Insurance Commissioner,,R,Ken Selzer,12
-Wyandotte,KC 13-5,Insurance Commissioner,,R,Ken Selzer,83
-Wyandotte,KC 13-6,Insurance Commissioner,,R,Ken Selzer,81
-Wyandotte,KC 13-7,Insurance Commissioner,,R,Ken Selzer,81
-Wyandotte,KC 13-8,Insurance Commissioner,,R,Ken Selzer,73
-Wyandotte,KC 13-9,Insurance Commissioner,,R,Ken Selzer,75
-Wyandotte,KC 14-1,Insurance Commissioner,,R,Ken Selzer,153
-Wyandotte,KC 14-2,Insurance Commissioner,,R,Ken Selzer,52
-Wyandotte,KC 14-3,Insurance Commissioner,,R,Ken Selzer,41
-Wyandotte,KC 14-4,Insurance Commissioner,,R,Ken Selzer,72
-Wyandotte,KC 14-5,Insurance Commissioner,,R,Ken Selzer,89
-Wyandotte,KC 14-6,Insurance Commissioner,,R,Ken Selzer,127
-Wyandotte,KC 14-7,Insurance Commissioner,,R,Ken Selzer,149
-Wyandotte,KC 14-8,Insurance Commissioner,,R,Ken Selzer,118
-Wyandotte,KC 14-9,Insurance Commissioner,,R,Ken Selzer,126
-Wyandotte,KC 14-10,Insurance Commissioner,,R,Ken Selzer,279
-Wyandotte,KC 14-11,Insurance Commissioner,,R,Ken Selzer,124
-Wyandotte,KC 14-12,Insurance Commissioner,,R,Ken Selzer,301
-Wyandotte,KC 14-13,Insurance Commissioner,,R,Ken Selzer,175
-Wyandotte,KC 14-14,Insurance Commissioner,,R,Ken Selzer,352
-Wyandotte,KC 14-15,Insurance Commissioner,,R,Ken Selzer,433
-Wyandotte,KC 14-16,Insurance Commissioner,,R,Ken Selzer,84
-Wyandotte,OC 1-1,Insurance Commissioner,,R,Ken Selzer,16
-Wyandotte,BS 1-1,Insurance Commissioner,,,Write-ins,3
-Wyandotte,BS 2-1,Insurance Commissioner,,,Write-ins,1
-Wyandotte,BS 3-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,BS 4-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,DE 1-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,ED 1-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,ED 2-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 1-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 1-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 1-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 2-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 2-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 2-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 2-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 2-5,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 3-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 3-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 3-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 3-4,Insurance Commissioner,,,Write-ins,3
-Wyandotte,KC 4-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 4-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 4-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 4-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 5-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 5-2,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 5-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 5-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 5-5,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 6-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 6-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 7-1,Insurance Commissioner,,,Write-ins,3
-Wyandotte,KC 7-2,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 7-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 7-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 7-5,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 7-6,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 7-7,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 7-8,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 7-9,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 8-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 8-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 8-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 8-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-3,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 9-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-5,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-6,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-7,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-8,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-9,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-10,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 9-11,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-12,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-13,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-14,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-15,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 9-16,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 10-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 10-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 10-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 10-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 10-5,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 11-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 11-2,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 11-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 11-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 11-5,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 11-6,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 11-7,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 11-8,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 11-9,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 11-10,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 11-11,Insurance Commissioner,,,Write-ins,2
-Wyandotte,KC 11-12,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-1,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 12-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-5,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-6,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-7,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-8,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-9,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-10,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 12-11,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 13-1,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 13-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 13-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 13-4,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 13-5,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 13-6,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 13-7,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 13-8,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 13-9,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-2,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-3,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-4,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 14-5,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-6,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 14-7,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-8,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-9,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 14-10,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-11,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-12,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 14-13,Insurance Commissioner,,,Write-ins,1
-Wyandotte,KC 14-14,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-15,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 14-16,Insurance Commissioner,,,Write-ins,0
-Wyandotte,OC 1-1,Insurance Commissioner,,,Write-ins,0
-Wyandotte,KC 7-1,State House,31,D,Louis Ruiz,116
-Wyandotte,KC 7-2,State House,31,D,Louis Ruiz,83
-Wyandotte,KC 7-3,State House,31,D,Louis Ruiz,155
-Wyandotte,KC 7-5,State House,31,D,Louis Ruiz,46
-Wyandotte,KC 7-6,State House,31,D,Louis Ruiz,237
-Wyandotte,KC 7-7,State House,31,D,Louis Ruiz,79
-Wyandotte,KC 8-1,State House,31,D,Louis Ruiz,181
-Wyandotte,KC 8-2,State House,31,D,Louis Ruiz,218
-Wyandotte,KC 8-3,State House,31,D,Louis Ruiz,367
-Wyandotte,KC 8-4,State House,31,D,Louis Ruiz,190
-Wyandotte,KC 12-1,State House,31,D,Louis Ruiz,171
-Wyandotte,KC 12-2,State House,31,D,Louis Ruiz,54
-Wyandotte,KC 12-3,State House,31,D,Louis Ruiz,160
-Wyandotte,KC 12-4,State House,31,D,Louis Ruiz,216
-Wyandotte,KC 12-5,State House,31,D,Louis Ruiz,190
-Wyandotte,KC 7-1,State House,31,,Write-ins,8
-Wyandotte,KC 7-2,State House,31,,Write-ins,4
-Wyandotte,KC 7-3,State House,31,,Write-ins,4
-Wyandotte,KC 7-5,State House,31,,Write-ins,0
-Wyandotte,KC 7-6,State House,31,,Write-ins,5
-Wyandotte,KC 7-7,State House,31,,Write-ins,2
-Wyandotte,KC 8-1,State House,31,,Write-ins,6
-Wyandotte,KC 8-2,State House,31,,Write-ins,1
-Wyandotte,KC 8-3,State House,31,,Write-ins,7
-Wyandotte,KC 8-4,State House,31,,Write-ins,9
-Wyandotte,KC 12-1,State House,31,,Write-ins,8
-Wyandotte,KC 12-2,State House,31,,Write-ins,5
-Wyandotte,KC 12-3,State House,31,,Write-ins,3
-Wyandotte,KC 12-4,State House,31,,Write-ins,12
-Wyandotte,KC 12-5,State House,31,,Write-ins,10
-Wyandotte,KC 1-3,State House,32,D,Pam Curtis,48
-Wyandotte,KC 4-1,State House,32,D,Pam Curtis,154
-Wyandotte,KC 4-2,State House,32,D,Pam Curtis,45
-Wyandotte,KC 4-3,State House,32,D,Pam Curtis,100
-Wyandotte,KC 4-4,State House,32,D,Pam Curtis,231
-Wyandotte,KC 5-1,State House,32,D,Pam Curtis,145
-Wyandotte,KC 5-2,State House,32,D,Pam Curtis,45
-Wyandotte,KC 5-3,State House,32,D,Pam Curtis,33
-Wyandotte,KC 5-4,State House,32,D,Pam Curtis,55
-Wyandotte,KC 5-5,State House,32,D,Pam Curtis,91
-Wyandotte,KC 6-1,State House,32,D,Pam Curtis,83
-Wyandotte,KC 6-2,State House,32,D,Pam Curtis,24
-Wyandotte,KC 9-1,State House,32,D,Pam Curtis,36
-Wyandotte,KC 9-2,State House,32,D,Pam Curtis,113
-Wyandotte,KC 1-3,State House,32,,Write-ins,4
-Wyandotte,KC 4-1,State House,32,,Write-ins,5
-Wyandotte,KC 4-2,State House,32,,Write-ins,3
-Wyandotte,KC 4-3,State House,32,,Write-ins,9
-Wyandotte,KC 4-4,State House,32,,Write-ins,15
-Wyandotte,KC 5-1,State House,32,,Write-ins,13
-Wyandotte,KC 5-2,State House,32,,Write-ins,4
-Wyandotte,KC 5-3,State House,32,,Write-ins,0
-Wyandotte,KC 5-4,State House,32,,Write-ins,2
-Wyandotte,KC 5-5,State House,32,,Write-ins,3
-Wyandotte,KC 6-1,State House,32,,Write-ins,5
-Wyandotte,KC 6-2,State House,32,,Write-ins,1
-Wyandotte,KC 9-1,State House,32,,Write-ins,1
-Wyandotte,KC 9-2,State House,32,,Write-ins,14
-Wyandotte,BS 1-1,State House,33,R,Sue Adams,250
-Wyandotte,BS 2-1,State House,33,R,Sue Adams,187
-Wyandotte,BS 3-1,State House,33,R,Sue Adams,248
-Wyandotte,BS 4-1,State House,33,R,Sue Adams,311
-Wyandotte,DE 1-1,State House,33,R,Sue Adams,8
-Wyandotte,ED 1-1,State House,33,R,Sue Adams,523
-Wyandotte,ED 2-1,State House,33,R,Sue Adams,73
-Wyandotte,KC 9-8,State House,33,R,Sue Adams,51
-Wyandotte,KC 9-9,State House,33,R,Sue Adams,49
-Wyandotte,KC 9-10,State House,33,R,Sue Adams,124
-Wyandotte,KC 9-11,State House,33,R,Sue Adams,101
-Wyandotte,KC 9-12,State House,33,R,Sue Adams,135
-Wyandotte,KC 9-13,State House,33,R,Sue Adams,107
-Wyandotte,KC 9-14,State House,33,R,Sue Adams,146
-Wyandotte,KC 9-16,State House,33,R,Sue Adams,174
-Wyandotte,KC 12-11,State House,33,R,Sue Adams,57
-Wyandotte,OC 1-1,State House,33,R,Sue Adams,16
-Wyandotte,BS 1-1,State House,33,D,Tom Burroughs,197
-Wyandotte,BS 2-1,State House,33,D,Tom Burroughs,150
-Wyandotte,BS 3-1,State House,33,D,Tom Burroughs,234
-Wyandotte,BS 4-1,State House,33,D,Tom Burroughs,261
-Wyandotte,DE 1-1,State House,33,D,Tom Burroughs,5
-Wyandotte,ED 1-1,State House,33,D,Tom Burroughs,274
-Wyandotte,ED 2-1,State House,33,D,Tom Burroughs,54
-Wyandotte,KC 9-8,State House,33,D,Tom Burroughs,138
-Wyandotte,KC 9-9,State House,33,D,Tom Burroughs,57
-Wyandotte,KC 9-10,State House,33,D,Tom Burroughs,237
-Wyandotte,KC 9-11,State House,33,D,Tom Burroughs,280
-Wyandotte,KC 9-12,State House,33,D,Tom Burroughs,187
-Wyandotte,KC 9-13,State House,33,D,Tom Burroughs,131
-Wyandotte,KC 9-14,State House,33,D,Tom Burroughs,187
-Wyandotte,KC 9-16,State House,33,D,Tom Burroughs,239
-Wyandotte,KC 12-11,State House,33,D,Tom Burroughs,64
-Wyandotte,OC 1-1,State House,33,D,Tom Burroughs,10
-Wyandotte,BS 1-1,State House,33,,Write-ins,1
-Wyandotte,BS 2-1,State House,33,,Write-ins,1
-Wyandotte,BS 3-1,State House,33,,Write-ins,0
-Wyandotte,BS 4-1,State House,33,,Write-ins,0
-Wyandotte,DE 1-1,State House,33,,Write-ins,0
-Wyandotte,ED 1-1,State House,33,,Write-ins,1
-Wyandotte,ED 2-1,State House,33,,Write-ins,0
-Wyandotte,KC 9-8,State House,33,,Write-ins,1
-Wyandotte,KC 9-9,State House,33,,Write-ins,0
-Wyandotte,KC 9-10,State House,33,,Write-ins,2
-Wyandotte,KC 9-11,State House,33,,Write-ins,0
-Wyandotte,KC 9-12,State House,33,,Write-ins,0
-Wyandotte,KC 9-13,State House,33,,Write-ins,0
-Wyandotte,KC 9-14,State House,33,,Write-ins,0
-Wyandotte,KC 9-16,State House,33,,Write-ins,1
-Wyandotte,KC 12-11,State House,33,,Write-ins,0
-Wyandotte,OC 1-1,State House,33,,Write-ins,0
-Wyandotte,KC 1-2,State House,34,D,Valdenia Winn,82
-Wyandotte,KC 2-3,State House,34,D,Valdenia Winn,26
-Wyandotte,KC 2-4,State House,34,D,Valdenia Winn,92
-Wyandotte,KC 2-5,State House,34,D,Valdenia Winn,164
-Wyandotte,KC 3-4,State House,34,D,Valdenia Winn,147
-Wyandotte,KC 10-3,State House,34,D,Valdenia Winn,15
-Wyandotte,KC 10-4,State House,34,D,Valdenia Winn,151
-Wyandotte,KC 10-5,State House,34,D,Valdenia Winn,265
-Wyandotte,KC 11-2,State House,34,D,Valdenia Winn,207
-Wyandotte,KC 11-3,State House,34,D,Valdenia Winn,297
-Wyandotte,KC 11-4,State House,34,D,Valdenia Winn,224
-Wyandotte,KC 11-5,State House,34,D,Valdenia Winn,187
-Wyandotte,KC 11-6,State House,34,D,Valdenia Winn,231
-Wyandotte,KC 11-7,State House,34,D,Valdenia Winn,194
-Wyandotte,KC 11-8,State House,34,D,Valdenia Winn,238
-Wyandotte,KC 13-4,State House,34,D,Valdenia Winn,175
-Wyandotte,KC 13-9,State House,34,D,Valdenia Winn,258
-Wyandotte,KC 1-2,State House,34,,Write-ins,0
-Wyandotte,KC 2-3,State House,34,,Write-ins,0
-Wyandotte,KC 2-4,State House,34,,Write-ins,2
-Wyandotte,KC 2-5,State House,34,,Write-ins,3
-Wyandotte,KC 3-4,State House,34,,Write-ins,2
-Wyandotte,KC 10-3,State House,34,,Write-ins,1
-Wyandotte,KC 10-4,State House,34,,Write-ins,0
-Wyandotte,KC 10-5,State House,34,,Write-ins,5
-Wyandotte,KC 11-2,State House,34,,Write-ins,3
-Wyandotte,KC 11-3,State House,34,,Write-ins,7
-Wyandotte,KC 11-4,State House,34,,Write-ins,6
-Wyandotte,KC 11-5,State House,34,,Write-ins,4
-Wyandotte,KC 11-6,State House,34,,Write-ins,4
-Wyandotte,KC 11-7,State House,34,,Write-ins,2
-Wyandotte,KC 11-8,State House,34,,Write-ins,1
-Wyandotte,KC 13-4,State House,34,,Write-ins,2
-Wyandotte,KC 13-9,State House,34,,Write-ins,6
-Wyandotte,KC 1-1,State House,35,,Broderick Henderson,75
-Wyandotte,KC 2-1,State House,35,,Broderick Henderson,115
-Wyandotte,KC 2-2,State House,35,,Broderick Henderson,84
-Wyandotte,KC 3-1,State House,35,,Broderick Henderson,240
-Wyandotte,KC 3-2,State House,35,,Broderick Henderson,232
-Wyandotte,KC 3-3,State House,35,,Broderick Henderson,42
-Wyandotte,KC 10-1,State House,35,,Broderick Henderson,260
-Wyandotte,KC 10-2,State House,35,,Broderick Henderson,379
-Wyandotte,KC 11-1,State House,35,,Broderick Henderson,244
-Wyandotte,KC 13-1,State House,35,,Broderick Henderson,285
-Wyandotte,KC 13-2,State House,35,,Broderick Henderson,240
-Wyandotte,KC 13-3,State House,35,,Broderick Henderson,191
-Wyandotte,KC 13-5,State House,35,,Broderick Henderson,170
-Wyandotte,KC 13-6,State House,35,,Broderick Henderson,193
-Wyandotte,KC 13-7,State House,35,,Broderick Henderson,130
-Wyandotte,KC 13-8,State House,35,,Broderick Henderson,179
-Wyandotte,KC 14-2,State House,35,,Broderick Henderson,123
-Wyandotte,KC 14-3,State House,35,,Broderick Henderson,115
-Wyandotte,KC 1-1,State House,35,,Write-ins,1
-Wyandotte,KC 2-1,State House,35,,Write-ins,3
-Wyandotte,KC 2-2,State House,35,,Write-ins,0
-Wyandotte,KC 3-1,State House,35,,Write-ins,4
-Wyandotte,KC 3-2,State House,35,,Write-ins,1
-Wyandotte,KC 3-3,State House,35,,Write-ins,1
-Wyandotte,KC 10-1,State House,35,,Write-ins,0
-Wyandotte,KC 10-2,State House,35,,Write-ins,3
-Wyandotte,KC 11-1,State House,35,,Write-ins,7
-Wyandotte,KC 13-1,State House,35,,Write-ins,2
-Wyandotte,KC 13-2,State House,35,,Write-ins,4
-Wyandotte,KC 13-3,State House,35,,Write-ins,7
-Wyandotte,KC 13-5,State House,35,,Write-ins,5
-Wyandotte,KC 13-6,State House,35,,Write-ins,6
-Wyandotte,KC 13-7,State House,35,,Write-ins,7
-Wyandotte,KC 13-8,State House,35,,Write-ins,4
-Wyandotte,KC 14-2,State House,35,,Write-ins,2
-Wyandotte,KC 14-3,State House,35,,Write-ins,2
-Wyandotte,KC 9-15,State House,36,L,Jeff Caldwell,0
-Wyandotte,KC 11-9,State House,36,L,Jeff Caldwell,10
-Wyandotte,KC 11-10,State House,36,L,Jeff Caldwell,10
-Wyandotte,KC 11-11,State House,36,L,Jeff Caldwell,17
-Wyandotte,KC 11-12,State House,36,L,Jeff Caldwell,6
-Wyandotte,KC 14-1,State House,36,L,Jeff Caldwell,17
-Wyandotte,KC 14-4,State House,36,L,Jeff Caldwell,13
-Wyandotte,KC 14-5,State House,36,L,Jeff Caldwell,18
-Wyandotte,KC 14-6,State House,36,L,Jeff Caldwell,19
-Wyandotte,KC 14-7,State House,36,L,Jeff Caldwell,16
-Wyandotte,KC 14-8,State House,36,L,Jeff Caldwell,20
-Wyandotte,KC 14-9,State House,36,L,Jeff Caldwell,9
-Wyandotte,KC 14-10,State House,36,L,Jeff Caldwell,16
-Wyandotte,KC 14-11,State House,36,L,Jeff Caldwell,17
-Wyandotte,KC 14-12,State House,36,L,Jeff Caldwell,21
-Wyandotte,KC 14-13,State House,36,L,Jeff Caldwell,18
-Wyandotte,KC 14-14,State House,36,L,Jeff Caldwell,24
-Wyandotte,KC 14-15,State House,36,L,Jeff Caldwell,25
-Wyandotte,KC 14-16,State House,36,L,Jeff Caldwell,7
-Wyandotte,KC 9-15,State House,36,R,Earl Freeman,0
-Wyandotte,KC 11-9,State House,36,R,Earl Freeman,45
-Wyandotte,KC 11-10,State House,36,R,Earl Freeman,65
-Wyandotte,KC 11-11,State House,36,R,Earl Freeman,147
-Wyandotte,KC 11-12,State House,36,R,Earl Freeman,27
-Wyandotte,KC 14-1,State House,36,R,Earl Freeman,136
-Wyandotte,KC 14-4,State House,36,R,Earl Freeman,73
-Wyandotte,KC 14-5,State House,36,R,Earl Freeman,75
-Wyandotte,KC 14-6,State House,36,R,Earl Freeman,112
-Wyandotte,KC 14-7,State House,36,R,Earl Freeman,114
-Wyandotte,KC 14-8,State House,36,R,Earl Freeman,100
-Wyandotte,KC 14-9,State House,36,R,Earl Freeman,119
-Wyandotte,KC 14-10,State House,36,R,Earl Freeman,242
-Wyandotte,KC 14-11,State House,36,R,Earl Freeman,95
-Wyandotte,KC 14-12,State House,36,R,Earl Freeman,236
-Wyandotte,KC 14-13,State House,36,R,Earl Freeman,142
-Wyandotte,KC 14-14,State House,36,R,Earl Freeman,303
-Wyandotte,KC 14-15,State House,36,R,Earl Freeman,426
-Wyandotte,KC 14-16,State House,36,R,Earl Freeman,67
-Wyandotte,KC 9-15,State House,36,D,Kathy Moore,0
-Wyandotte,KC 11-9,State House,36,D,Kathy Moore,227
-Wyandotte,KC 11-10,State House,36,D,Kathy Moore,291
-Wyandotte,KC 11-11,State House,36,D,Kathy Moore,365
-Wyandotte,KC 11-12,State House,36,D,Kathy Moore,43
-Wyandotte,KC 14-1,State House,36,D,Kathy Moore,176
-Wyandotte,KC 14-4,State House,36,D,Kathy Moore,231
-Wyandotte,KC 14-5,State House,36,D,Kathy Moore,189
-Wyandotte,KC 14-6,State House,36,D,Kathy Moore,235
-Wyandotte,KC 14-7,State House,36,D,Kathy Moore,344
-Wyandotte,KC 14-8,State House,36,D,Kathy Moore,227
-Wyandotte,KC 14-9,State House,36,D,Kathy Moore,114
-Wyandotte,KC 14-10,State House,36,D,Kathy Moore,366
-Wyandotte,KC 14-11,State House,36,D,Kathy Moore,227
-Wyandotte,KC 14-12,State House,36,D,Kathy Moore,365
-Wyandotte,KC 14-13,State House,36,D,Kathy Moore,291
-Wyandotte,KC 14-14,State House,36,D,Kathy Moore,337
-Wyandotte,KC 14-15,State House,36,D,Kathy Moore,372
-Wyandotte,KC 14-16,State House,36,D,Kathy Moore,154
-Wyandotte,KC 9-15,State House,36,,Write-ins,0
-Wyandotte,KC 11-9,State House,36,,Write-ins,0
-Wyandotte,KC 11-10,State House,36,,Write-ins,1
-Wyandotte,KC 11-11,State House,36,,Write-ins,0
-Wyandotte,KC 11-12,State House,36,,Write-ins,0
-Wyandotte,KC 14-1,State House,36,,Write-ins,0
-Wyandotte,KC 14-4,State House,36,,Write-ins,0
-Wyandotte,KC 14-5,State House,36,,Write-ins,0
-Wyandotte,KC 14-6,State House,36,,Write-ins,1
-Wyandotte,KC 14-7,State House,36,,Write-ins,0
-Wyandotte,KC 14-8,State House,36,,Write-ins,1
-Wyandotte,KC 14-9,State House,36,,Write-ins,1
-Wyandotte,KC 14-10,State House,36,,Write-ins,0
-Wyandotte,KC 14-11,State House,36,,Write-ins,0
-Wyandotte,KC 14-12,State House,36,,Write-ins,1
-Wyandotte,KC 14-13,State House,36,,Write-ins,0
-Wyandotte,KC 14-14,State House,36,,Write-ins,0
-Wyandotte,KC 14-15,State House,36,,Write-ins,0
-Wyandotte,KC 14-16,State House,36,,Write-ins,1
-Wyandotte,KC 7-4,State House,37,D,Stan Frownfelter,204
-Wyandotte,KC 7-8,State House,37,D,Stan Frownfelter,283
-Wyandotte,KC 7-9,State House,37,D,Stan Frownfelter,279
-Wyandotte,KC 9-3,State House,37,D,Stan Frownfelter,320
-Wyandotte,KC 9-4,State House,37,D,Stan Frownfelter,50
-Wyandotte,KC 9-5,State House,37,D,Stan Frownfelter,6
-Wyandotte,KC 9-6,State House,37,D,Stan Frownfelter,172
-Wyandotte,KC 9-7,State House,37,D,Stan Frownfelter,158
-Wyandotte,KC 12-6,State House,37,D,Stan Frownfelter,183
-Wyandotte,KC 12-7,State House,37,D,Stan Frownfelter,147
-Wyandotte,KC 12-8,State House,37,D,Stan Frownfelter,196
-Wyandotte,KC 12-9,State House,37,D,Stan Frownfelter,208
-Wyandotte,KC 12-10,State House,37,D,Stan Frownfelter,152
-Wyandotte,KC 7-4,State House,37,,Write-ins,12
-Wyandotte,KC 7-8,State House,37,,Write-ins,12
-Wyandotte,KC 7-9,State House,37,,Write-ins,6
-Wyandotte,KC 9-3,State House,37,,Write-ins,10
-Wyandotte,KC 9-4,State House,37,,Write-ins,2
-Wyandotte,KC 9-5,State House,37,,Write-ins,0
-Wyandotte,KC 9-6,State House,37,,Write-ins,3
-Wyandotte,KC 9-7,State House,37,,Write-ins,7
-Wyandotte,KC 12-6,State House,37,,Write-ins,4
-Wyandotte,KC 12-7,State House,37,,Write-ins,3
-Wyandotte,KC 12-8,State House,37,,Write-ins,8
-Wyandotte,KC 12-9,State House,37,,Write-ins,8
-Wyandotte,KC 12-10,State House,37,,Write-ins,11
+county,precinct,office,district,party,candidate,votes,vtd
+WYANDOTTE,ADVANCED,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",2463,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,32,Democratic,"Curtis, Pam",1203,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",2705,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,33,Republican,"Adams, Sue",2560,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",2953,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",3297,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",4554,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",283,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,36,Republican,"Freeman, Earl",2524,999998
+WYANDOTTE,ADVANCED,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan S.",2358,999998
+WYANDOTTE,Kansas City Ward 10 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",15,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",1,120060
+WYANDOTTE,Kansas City Ward 09 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",240,120080
+WYANDOTTE,Kansas City Ward 09 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",183,120080
+WYANDOTTE,Kansas City Ward 12 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",44,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",79,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",107,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",143,120110
+WYANDOTTE,Kansas City Ward 14 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",216,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",128,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",197,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",146,120140
+WYANDOTTE,Kansas City Ward 07 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",35,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",17,120160
+WYANDOTTE,Kansas City Ward 09 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",32,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",25,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",125,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",61,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",0,120210
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",274,140010
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",309,140010
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",307,140020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",495,140020
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",54,140030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",76,140030
+WYANDOTTE,Kansas City Ward 07 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",204,140040
+WYANDOTTE,Kansas City Ward 07 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",187,140040
+WYANDOTTE,Kansas City Ward 09 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",271,140050
+WYANDOTTE,Kansas City Ward 09 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",159,140050
+WYANDOTTE,Kansas City Ward 09 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",163,140060
+WYANDOTTE,Kansas City Ward 09 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",61,140060
+WYANDOTTE,Kansas City Ward 09 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",264,140070
+WYANDOTTE,Kansas City Ward 09 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",124,140070
+WYANDOTTE,Kansas City Ward 10 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",365,140080
+WYANDOTTE,Kansas City Ward 10 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",45,140080
+WYANDOTTE,Kansas City Ward 14 Precinct 16,United States House of Representatives,3,Democratic,"Kultala, Kelly",130,140090
+WYANDOTTE,Kansas City Ward 14 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",103,140090
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",203,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",252,600010
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",148,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",195,600020
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",238,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",258,600030
+WYANDOTTE,Delaware Township 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",5,600060
+WYANDOTTE,Delaware Township 01,United States House of Representatives,3,Republican,"Yoder, Kevin",8,600060
+WYANDOTTE,Kansas City Ward 01 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",71,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",12,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",81,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",9,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",44,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",21,600110
+WYANDOTTE,Kansas City Ward 02 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",105,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",39,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",78,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",13,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",27,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",2,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",90,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",12,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",156,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",24,600160
+WYANDOTTE,Kansas City Ward 03 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",228,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",27,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",233,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",26,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",44,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",2,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",136,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",18,600200
+WYANDOTTE,Kansas City Ward 04 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",136,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",60,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",35,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",20,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",84,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",52,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",195,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",92,600240
+WYANDOTTE,Kansas City Ward 05 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",127,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",65,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",41,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",15,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",31,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",17,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",42,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",30,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",69,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",42,600290
+WYANDOTTE,Kansas City Ward 06 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",53,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",58,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",21,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",15,600310
+WYANDOTTE,Kansas City Ward 07 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",99,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",62,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",67,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",42,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",118,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",68,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",143,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",178,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",182,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",124,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",58,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",35,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",185,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",176,600400
+WYANDOTTE,Kansas City Ward 08 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",159,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",65,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",203,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",44,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",312,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",119,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",150,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",95,600440
+WYANDOTTE,Kansas City Ward 09 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",80,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",90,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",48,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",25,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",4,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",17,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",118,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",135,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",58,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",52,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",226,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",145,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",168,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",160,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",118,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",120,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",167,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",168,600580
+WYANDOTTE,Kansas City Ward 10 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",243,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",25,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",131,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",37,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",226,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",94,600630
+WYANDOTTE,Kansas City Ward 11 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",226,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",70,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",178,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",60,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",256,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",97,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",198,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",68,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",161,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",89,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",218,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",38,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",167,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",69,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",215,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",54,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",199,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",74,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",260,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",101,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 11,United States House of Representatives,3,Democratic,"Kultala, Kelly",338,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",183,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",45,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",34,600750
+WYANDOTTE,Kansas City Ward 12 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",148,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",95,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",48,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",26,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",141,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",90,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",170,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",156,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",129,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",173,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",136,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",139,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",89,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",117,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",144,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",147,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",154,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",155,600850
+WYANDOTTE,Kansas City Ward 13 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",264,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",57,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",188,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",123,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",171,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",66,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",164,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",29,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",149,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",97,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",158,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",111,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",101,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",101,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 08,United States House of Representatives,3,Democratic,"Kultala, Kelly",155,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",83,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",219,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",94,600950
+WYANDOTTE,Kansas City Ward 14 Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",166,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",173,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 02,United States House of Representatives,3,Democratic,"Kultala, Kelly",106,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",66,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 03,United States House of Representatives,3,Democratic,"Kultala, Kelly",103,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",50,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 04,United States House of Representatives,3,Democratic,"Kultala, Kelly",216,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",104,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 05,United States House of Representatives,3,Democratic,"Kultala, Kelly",183,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",101,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 06,United States House of Representatives,3,Democratic,"Kultala, Kelly",216,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",152,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 07,United States House of Representatives,3,Democratic,"Kultala, Kelly",309,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",168,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 09,United States House of Representatives,3,Democratic,"Kultala, Kelly",102,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",143,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 10,United States House of Representatives,3,Democratic,"Kultala, Kelly",309,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",311,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 12,United States House of Representatives,3,Democratic,"Kultala, Kelly",319,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",307,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 13,United States House of Representatives,3,Democratic,"Kultala, Kelly",256,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",193,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 14,United States House of Representatives,3,Democratic,"Kultala, Kelly",313,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",357,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 15,United States House of Representatives,3,Democratic,"Kultala, Kelly",366,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",463,601100
+WYANDOTTE,Lake Quivira City Precinct 01,United States House of Representatives,3,Democratic,"Kultala, Kelly",7,601110
+WYANDOTTE,Lake Quivira City Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",20,601110
+WYANDOTTE,ADVANCED,United States House of Representatives,3,Democratic,"Kultala, Kelly",0,999998
+WYANDOTTE,ADVANCED,United States House of Representatives,3,Republican,"Yoder, Kevin",0,999998
+WYANDOTTE,ADVANCED,Attorney General,,Democratic,"Kotich, A.J.",17370,999998
+WYANDOTTE,ADVANCED,Attorney General,,Republican,"Schmidt, Derek",10415,999998
+WYANDOTTE,ADVANCED,Commissioner of Insurance,,Democratic,"Anderson, Dennis",18064,999998
+WYANDOTTE,ADVANCED,Commissioner of Insurance,,Republican,"Selzer, Ken",9396,999998
+WYANDOTTE,ADVANCED,Secretary of State,,Democratic,"Schodorf, Jean Kurtis",16763,999998
+WYANDOTTE,ADVANCED,Secretary of State,,Republican,"Kobach, Kris",11332,999998
+WYANDOTTE,ADVANCED,State Treasurer,,Democratic,"Alldritt, Carmen",16981,999998
+WYANDOTTE,ADVANCED,State Treasurer,,Republican,"Estes, Ron",10620,999998
+WYANDOTTE,Kansas City Ward 10 Precinct 03,United States Senate,,independent,"Orman, Greg",14,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",2,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,United States Senate,,Republican,"Roberts, Pat",0,120060
+WYANDOTTE,Kansas City Ward 09 Precinct 16,United States Senate,,independent,"Orman, Greg",252,120080
+WYANDOTTE,Kansas City Ward 09 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",11,120080
+WYANDOTTE,Kansas City Ward 09 Precinct 16,United States Senate,,Republican,"Roberts, Pat",161,120080
+WYANDOTTE,Kansas City Ward 12 Precinct 11,United States Senate,,independent,"Orman, Greg",60,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",3,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,United States Senate,,Republican,"Roberts, Pat",65,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 10,United States Senate,,independent,"Orman, Greg",114,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",14,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,United States Senate,,Republican,"Roberts, Pat",122,120110
+WYANDOTTE,Kansas City Ward 14 Precinct 08,United States Senate,,independent,"Orman, Greg",217,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",16,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,United States Senate,,Republican,"Roberts, Pat",105,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 11,United States Senate,,independent,"Orman, Greg",199,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",12,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,United States Senate,,Republican,"Roberts, Pat",124,120140
+WYANDOTTE,Kansas City Ward 07 Precinct 05,United States Senate,,independent,"Orman, Greg",44,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",1,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,United States Senate,,Republican,"Roberts, Pat",9,120160
+WYANDOTTE,Kansas City Ward 09 Precinct 01,United States Senate,,independent,"Orman, Greg",36,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,United States Senate,,Republican,"Roberts, Pat",21,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 08,United States Senate,,independent,"Orman, Greg",134,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",10,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,United States Senate,,Republican,"Roberts, Pat",47,120200
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",292,140010
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",27,140010
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",266,140010
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",355,140020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",54,140020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",401,140020
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",63,140030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",10,140030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",62,140030
+WYANDOTTE,Kansas City Ward 07 Precinct 08,United States Senate,,independent,"Orman, Greg",227,140040
+WYANDOTTE,Kansas City Ward 07 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",19,140040
+WYANDOTTE,Kansas City Ward 07 Precinct 08,United States Senate,,Republican,"Roberts, Pat",144,140040
+WYANDOTTE,Kansas City Ward 09 Precinct 03,United States Senate,,independent,"Orman, Greg",286,140050
+WYANDOTTE,Kansas City Ward 09 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",26,140050
+WYANDOTTE,Kansas City Ward 09 Precinct 03,United States Senate,,Republican,"Roberts, Pat",113,140050
+WYANDOTTE,Kansas City Ward 09 Precinct 06,United States Senate,,independent,"Orman, Greg",157,140060
+WYANDOTTE,Kansas City Ward 09 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",20,140060
+WYANDOTTE,Kansas City Ward 09 Precinct 06,United States Senate,,Republican,"Roberts, Pat",44,140060
+WYANDOTTE,Kansas City Ward 09 Precinct 11,United States Senate,,independent,"Orman, Greg",273,140070
+WYANDOTTE,Kansas City Ward 09 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",13,140070
+WYANDOTTE,Kansas City Ward 09 Precinct 11,United States Senate,,Republican,"Roberts, Pat",97,140070
+WYANDOTTE,Kansas City Ward 10 Precinct 02,United States Senate,,independent,"Orman, Greg",346,140080
+WYANDOTTE,Kansas City Ward 10 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",18,140080
+WYANDOTTE,Kansas City Ward 10 Precinct 02,United States Senate,,Republican,"Roberts, Pat",28,140080
+WYANDOTTE,Kansas City Ward 14 Precinct 16,United States Senate,,independent,"Orman, Greg",137,140090
+WYANDOTTE,Kansas City Ward 14 Precinct 16,United States Senate,,Libertarian,"Batson, Randall",10,140090
+WYANDOTTE,Kansas City Ward 14 Precinct 16,United States Senate,,Republican,"Roberts, Pat",87,140090
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",242,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",18,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",196,600010
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",166,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",18,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",160,600020
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",255,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",17,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",219,600030
+WYANDOTTE,Delaware Township 01,United States Senate,,independent,"Orman, Greg",5,600060
+WYANDOTTE,Delaware Township 01,United States Senate,,Libertarian,"Batson, Randall",0,600060
+WYANDOTTE,Delaware Township 01,United States Senate,,Republican,"Roberts, Pat",8,600060
+WYANDOTTE,Kansas City Ward 01 Precinct 01,United States Senate,,independent,"Orman, Greg",59,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",8,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,United States Senate,,Republican,"Roberts, Pat",6,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 02,United States Senate,,independent,"Orman, Greg",82,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",1,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,United States Senate,,Republican,"Roberts, Pat",7,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 03,United States Senate,,independent,"Orman, Greg",51,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,United States Senate,,Republican,"Roberts, Pat",18,600110
+WYANDOTTE,Kansas City Ward 02 Precinct 01,United States Senate,,independent,"Orman, Greg",108,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",10,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,United States Senate,,Republican,"Roberts, Pat",23,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 02,United States Senate,,independent,"Orman, Greg",69,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",6,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,United States Senate,,Republican,"Roberts, Pat",10,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 03,United States Senate,,independent,"Orman, Greg",23,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",3,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,United States Senate,,Republican,"Roberts, Pat",1,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 04,United States Senate,,independent,"Orman, Greg",90,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",4,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,United States Senate,,Republican,"Roberts, Pat",5,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 05,United States Senate,,independent,"Orman, Greg",136,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",17,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,United States Senate,,Republican,"Roberts, Pat",18,600160
+WYANDOTTE,Kansas City Ward 03 Precinct 01,United States Senate,,independent,"Orman, Greg",199,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",11,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,United States Senate,,Republican,"Roberts, Pat",19,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 02,United States Senate,,independent,"Orman, Greg",222,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",18,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,United States Senate,,Republican,"Roberts, Pat",12,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 03,United States Senate,,independent,"Orman, Greg",35,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",8,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,United States Senate,,Republican,"Roberts, Pat",1,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 04,United States Senate,,independent,"Orman, Greg",124,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",16,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,United States Senate,,Republican,"Roberts, Pat",12,600200
+WYANDOTTE,Kansas City Ward 04 Precinct 01,United States Senate,,independent,"Orman, Greg",145,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",11,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,United States Senate,,Republican,"Roberts, Pat",38,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 02,United States Senate,,independent,"Orman, Greg",30,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",4,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,United States Senate,,Republican,"Roberts, Pat",18,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 03,United States Senate,,independent,"Orman, Greg",84,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",9,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,United States Senate,,Republican,"Roberts, Pat",40,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 04,United States Senate,,independent,"Orman, Greg",186,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",8,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,United States Senate,,Republican,"Roberts, Pat",87,600240
+WYANDOTTE,Kansas City Ward 05 Precinct 01,United States Senate,,independent,"Orman, Greg",138,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",10,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,United States Senate,,Republican,"Roberts, Pat",45,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 02,United States Senate,,independent,"Orman, Greg",41,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",6,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,United States Senate,,Republican,"Roberts, Pat",10,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 03,United States Senate,,independent,"Orman, Greg",30,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",5,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,United States Senate,,Republican,"Roberts, Pat",11,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 04,United States Senate,,independent,"Orman, Greg",47,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",4,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,United States Senate,,Republican,"Roberts, Pat",22,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 05,United States Senate,,independent,"Orman, Greg",68,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",14,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,United States Senate,,Republican,"Roberts, Pat",28,600290
+WYANDOTTE,Kansas City Ward 06 Precinct 01,United States Senate,,independent,"Orman, Greg",62,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",6,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,United States Senate,,Republican,"Roberts, Pat",42,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 02,United States Senate,,independent,"Orman, Greg",20,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",3,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,United States Senate,,Republican,"Roberts, Pat",13,600310
+WYANDOTTE,Kansas City Ward 07 Precinct 01,United States Senate,,independent,"Orman, Greg",104,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",11,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,United States Senate,,Republican,"Roberts, Pat",45,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 02,United States Senate,,independent,"Orman, Greg",68,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",8,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,United States Senate,,Republican,"Roberts, Pat",32,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 03,United States Senate,,independent,"Orman, Greg",126,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",9,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,United States Senate,,Republican,"Roberts, Pat",48,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 04,United States Senate,,independent,"Orman, Greg",175,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",16,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,United States Senate,,Republican,"Roberts, Pat",130,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 06,United States Senate,,independent,"Orman, Greg",201,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",19,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,United States Senate,,Republican,"Roberts, Pat",81,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 07,United States Senate,,independent,"Orman, Greg",58,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",7,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,United States Senate,,Republican,"Roberts, Pat",22,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 09,United States Senate,,independent,"Orman, Greg",222,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",13,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,United States Senate,,Republican,"Roberts, Pat",125,600400
+WYANDOTTE,Kansas City Ward 08 Precinct 01,United States Senate,,independent,"Orman, Greg",157,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",16,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,United States Senate,,Republican,"Roberts, Pat",50,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 02,United States Senate,,independent,"Orman, Greg",215,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",6,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,United States Senate,,Republican,"Roberts, Pat",32,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 03,United States Senate,,independent,"Orman, Greg",328,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",20,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,United States Senate,,Republican,"Roberts, Pat",84,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 04,United States Senate,,independent,"Orman, Greg",167,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",15,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,United States Senate,,Republican,"Roberts, Pat",71,600440
+WYANDOTTE,Kansas City Ward 09 Precinct 02,United States Senate,,independent,"Orman, Greg",99,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",4,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,United States Senate,,Republican,"Roberts, Pat",71,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 04,United States Senate,,independent,"Orman, Greg",47,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",4,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,United States Senate,,Republican,"Roberts, Pat",23,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 05,United States Senate,,independent,"Orman, Greg",7,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,United States Senate,,Republican,"Roberts, Pat",14,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 07,United States Senate,,independent,"Orman, Greg",135,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",14,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,United States Senate,,Republican,"Roberts, Pat",106,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 09,United States Senate,,independent,"Orman, Greg",54,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",8,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,United States Senate,,Republican,"Roberts, Pat",45,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 10,United States Senate,,independent,"Orman, Greg",223,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",20,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,United States Senate,,Republican,"Roberts, Pat",124,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 12,United States Senate,,independent,"Orman, Greg",178,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",15,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,United States Senate,,Republican,"Roberts, Pat",131,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 13,United States Senate,,independent,"Orman, Greg",135,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",18,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,United States Senate,,Republican,"Roberts, Pat",88,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 14,United States Senate,,independent,"Orman, Greg",193,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",11,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,United States Senate,,Republican,"Roberts, Pat",134,600580
+WYANDOTTE,Kansas City Ward 10 Precinct 01,United States Senate,,independent,"Orman, Greg",240,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",9,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,United States Senate,,Republican,"Roberts, Pat",12,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 04,United States Senate,,independent,"Orman, Greg",132,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",9,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,United States Senate,,Republican,"Roberts, Pat",25,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 05,United States Senate,,independent,"Orman, Greg",236,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",16,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,United States Senate,,Republican,"Roberts, Pat",71,600630
+WYANDOTTE,Kansas City Ward 11 Precinct 01,United States Senate,,independent,"Orman, Greg",230,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",5,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,United States Senate,,Republican,"Roberts, Pat",53,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 02,United States Senate,,independent,"Orman, Greg",178,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",19,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,United States Senate,,Republican,"Roberts, Pat",34,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 03,United States Senate,,independent,"Orman, Greg",261,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",19,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,United States Senate,,Republican,"Roberts, Pat",71,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 04,United States Senate,,independent,"Orman, Greg",204,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",14,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,United States Senate,,Republican,"Roberts, Pat",44,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 05,United States Senate,,independent,"Orman, Greg",171,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",15,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,United States Senate,,Republican,"Roberts, Pat",57,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 06,United States Senate,,independent,"Orman, Greg",198,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",14,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,United States Senate,,Republican,"Roberts, Pat",31,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 07,United States Senate,,independent,"Orman, Greg",160,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",17,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,United States Senate,,Republican,"Roberts, Pat",52,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 08,United States Senate,,independent,"Orman, Greg",217,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",14,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,United States Senate,,Republican,"Roberts, Pat",34,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 09,United States Senate,,independent,"Orman, Greg",195,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",19,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,United States Senate,,Republican,"Roberts, Pat",57,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 10,United States Senate,,independent,"Orman, Greg",275,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",9,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,United States Senate,,Republican,"Roberts, Pat",77,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 11,United States Senate,,independent,"Orman, Greg",355,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,United States Senate,,Libertarian,"Batson, Randall",28,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,United States Senate,,Republican,"Roberts, Pat",147,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 12,United States Senate,,independent,"Orman, Greg",40,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",5,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,United States Senate,,Republican,"Roberts, Pat",32,600750
+WYANDOTTE,Kansas City Ward 12 Precinct 01,United States Senate,,independent,"Orman, Greg",150,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",20,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,United States Senate,,Republican,"Roberts, Pat",74,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 02,United States Senate,,independent,"Orman, Greg",47,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",8,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,United States Senate,,Republican,"Roberts, Pat",23,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 03,United States Senate,,independent,"Orman, Greg",153,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",4,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,United States Senate,,Republican,"Roberts, Pat",76,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 04,United States Senate,,independent,"Orman, Greg",198,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",14,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,United States Senate,,Republican,"Roberts, Pat",121,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 05,United States Senate,,independent,"Orman, Greg",145,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",17,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,United States Senate,,Republican,"Roberts, Pat",139,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 06,United States Senate,,independent,"Orman, Greg",155,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",16,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,United States Senate,,Republican,"Roberts, Pat",107,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 07,United States Senate,,independent,"Orman, Greg",108,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",18,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,United States Senate,,Republican,"Roberts, Pat",83,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 08,United States Senate,,independent,"Orman, Greg",163,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",20,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,United States Senate,,Republican,"Roberts, Pat",108,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 09,United States Senate,,independent,"Orman, Greg",170,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",15,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,United States Senate,,Republican,"Roberts, Pat",123,600850
+WYANDOTTE,Kansas City Ward 13 Precinct 01,United States Senate,,independent,"Orman, Greg",249,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",18,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,United States Senate,,Republican,"Roberts, Pat",41,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 02,United States Senate,,independent,"Orman, Greg",192,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",25,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,United States Senate,,Republican,"Roberts, Pat",89,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 03,United States Senate,,independent,"Orman, Greg",169,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",14,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,United States Senate,,Republican,"Roberts, Pat",51,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 04,United States Senate,,independent,"Orman, Greg",159,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",10,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,United States Senate,,Republican,"Roberts, Pat",17,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 05,United States Senate,,independent,"Orman, Greg",160,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",8,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,United States Senate,,Republican,"Roberts, Pat",76,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 06,United States Senate,,independent,"Orman, Greg",166,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",21,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,United States Senate,,Republican,"Roberts, Pat",80,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 07,United States Senate,,independent,"Orman, Greg",108,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",17,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,United States Senate,,Republican,"Roberts, Pat",77,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 08,United States Senate,,independent,"Orman, Greg",155,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,United States Senate,,Libertarian,"Batson, Randall",20,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,United States Senate,,Republican,"Roberts, Pat",61,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 09,United States Senate,,independent,"Orman, Greg",225,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",13,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,United States Senate,,Republican,"Roberts, Pat",64,600950
+WYANDOTTE,Kansas City Ward 14 Precinct 01,United States Senate,,independent,"Orman, Greg",180,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,United States Senate,,Libertarian,"Batson, Randall",12,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,United States Senate,,Republican,"Roberts, Pat",144,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 02,United States Senate,,independent,"Orman, Greg",113,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,United States Senate,,Libertarian,"Batson, Randall",6,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,United States Senate,,Republican,"Roberts, Pat",49,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 03,United States Senate,,independent,"Orman, Greg",105,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,United States Senate,,Libertarian,"Batson, Randall",9,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,United States Senate,,Republican,"Roberts, Pat",40,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 04,United States Senate,,independent,"Orman, Greg",227,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,United States Senate,,Libertarian,"Batson, Randall",15,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,United States Senate,,Republican,"Roberts, Pat",73,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 05,United States Senate,,independent,"Orman, Greg",180,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,United States Senate,,Libertarian,"Batson, Randall",10,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,United States Senate,,Republican,"Roberts, Pat",88,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 06,United States Senate,,independent,"Orman, Greg",234,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,United States Senate,,Libertarian,"Batson, Randall",15,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,United States Senate,,Republican,"Roberts, Pat",124,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 07,United States Senate,,independent,"Orman, Greg",303,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,United States Senate,,Libertarian,"Batson, Randall",21,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,United States Senate,,Republican,"Roberts, Pat",147,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 09,United States Senate,,independent,"Orman, Greg",123,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,United States Senate,,Libertarian,"Batson, Randall",7,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,United States Senate,,Republican,"Roberts, Pat",114,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 10,United States Senate,,independent,"Orman, Greg",351,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,United States Senate,,Libertarian,"Batson, Randall",15,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,United States Senate,,Republican,"Roberts, Pat",264,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 12,United States Senate,,independent,"Orman, Greg",338,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,United States Senate,,Libertarian,"Batson, Randall",16,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,United States Senate,,Republican,"Roberts, Pat",267,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 13,United States Senate,,independent,"Orman, Greg",275,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,United States Senate,,Libertarian,"Batson, Randall",19,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,United States Senate,,Republican,"Roberts, Pat",157,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 14,United States Senate,,independent,"Orman, Greg",319,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,United States Senate,,Libertarian,"Batson, Randall",18,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,United States Senate,,Republican,"Roberts, Pat",326,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 15,United States Senate,,independent,"Orman, Greg",400,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,United States Senate,,Libertarian,"Batson, Randall",30,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,United States Senate,,Republican,"Roberts, Pat",399,601100
+WYANDOTTE,Lake Quivira City Precinct 01,United States Senate,,independent,"Orman, Greg",11,601110
+WYANDOTTE,Lake Quivira City Precinct 01,United States Senate,,Libertarian,"Batson, Randall",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,United States Senate,,Republican,"Roberts, Pat",16,601110
+WYANDOTTE,ADVANCED,United States Senate,,independent,"Orman, Greg",0,999998
+WYANDOTTE,ADVANCED,United States Senate,,Libertarian,"Batson, Randall",0,999998
+WYANDOTTE,ADVANCED,United States Senate,,Republican,"Roberts, Pat",0,999998


### PR DESCRIPTION
All the 2014 precinct files were re-parsed with the command:

```bash
% ruby src/parse-csv.rb -d 20141104 -o 2014 -t general \
  ../openelections-sources-ks/2014/2014_general_governor_official_results.csv.gz \
  ../openelections-sources-ks/2014/2014_general_ks_house_official_results.csv.gz \
  ../openelections-sources-ks/2014/2014_general_us_house_official_results.csv.gz \
  ../openelections-sources-ks/2014/2014-General-Election---*csv.gz
```

Note that the new "totals" file is gleened from the original precinct files, in
order to preserve the Voter stats per-county. Instead of including the totals
within each county file (which mixed the content model), all the counties
that had totals are grouped in a single file.