### PR TITLE
Remove trailing almost-empty columns

### DIFF
--- a/2018/20180807__ks__primary__cherokee__precinct.csv
+++ b/2018/20180807__ks__primary__cherokee__precinct.csv
@@ -1,1441 +1,1441 @@
-county,precinct,office,district,party,candidate,votes,
-Cherokee,01 Baxter Sprs W1,Registered,,,Registered,658,
-Cherokee,01 Baxter Sprs W1,Ballots,,Dem,Ballots,30,
-Cherokee,01 Baxter Sprs W1,Ballots,,Rep,Ballots,52,
-Cherokee,01 Baxter Sprs W1,US House,2,Dem,Paul Davis,25,
-Cherokee,01 Baxter Sprs W1,Governor,,Dem,Arden Andersen,1,
-Cherokee,01 Baxter Sprs W1,Governor,,Dem,Jack Bergeson,3,
-Cherokee,01 Baxter Sprs W1,Governor,,Dem,Carl Brewer,1,
-Cherokee,01 Baxter Sprs W1,Governor,,Dem,Laura Kelly,7,
-Cherokee,01 Baxter Sprs W1,Governor,,Dem,Joshua Svaty,15,
-Cherokee,01 Baxter Sprs W1,Secretary of State,,Dem,Brian McClendon,24,
-Cherokee,01 Baxter Sprs W1,Attorney General,,Dem,Sarah Swain,26,
-Cherokee,01 Baxter Sprs W1,State Treasurer,,Dem,Marci Francisco,26,
-Cherokee,01 Baxter Sprs W1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,25,
-Cherokee,01 Baxter Sprs W1,State Senate,13,Dem,Bryan Hoffman,25,
-Cherokee,01 Baxter Sprs W1,State House,1,Dem,write-in,6,
-Cherokee,01 Baxter Sprs W1,US House,2,Rep,Vernon Fields,2,
-Cherokee,01 Baxter Sprs W1,US House,2,Rep,Steve Fitzgerald,4,
-Cherokee,01 Baxter Sprs W1,US House,2,Rep,Kevin Jones,5,
-Cherokee,01 Baxter Sprs W1,US House,2,Rep,Doug Mays,1,
-Cherokee,01 Baxter Sprs W1,US House,2,Rep,Dennis Pyle,8,
-Cherokee,01 Baxter Sprs W1,US House,2,Rep,Caron Tyson,10,
-Cherokee,01 Baxter Sprs W1,US House,2,Rep,Steve Watkins,19,
-Cherokee,01 Baxter Sprs W1,Governor,,Rep,Jim Barnett,2,
-Cherokee,01 Baxter Sprs W1,Governor,,Rep,Jeff Colyer,15,
-Cherokee,01 Baxter Sprs W1,Governor,,Rep,Kris Kobach,27,
-Cherokee,01 Baxter Sprs W1,Governor,,Rep,Patrick Kucera,0,
-Cherokee,01 Baxter Sprs W1,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,01 Baxter Sprs W1,Governor,,Rep,Ken Selzer,7,
-Cherokee,01 Baxter Sprs W1,Governor,,Rep,Joseph Tutera,0,
-Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Randy Duncan,10,
-Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Keith Esau,6,
-Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Craig McCullah,7,
-Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Scott Schwab,10,
-Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Dennis Taylor,14,
-Cherokee,01 Baxter Sprs W1,Attorney General,,Rep,Derek Schmidt,47,
-Cherokee,01 Baxter Sprs W1,State Treasurer,,Rep,Jake LaTurner,46,
-Cherokee,01 Baxter Sprs W1,Insurance Commissioner,,Rep,Vicki Schmidt,28,
-Cherokee,01 Baxter Sprs W1,Insurance Commissioner,,Rep,Clark Shultz,20,
-Cherokee,01 Baxter Sprs W1,State Senate,13,Rep,Richard Hilderbrand,47,
-Cherokee,01 Baxter Sprs W1,State House,1,Rep,Michael Houser,46,
-Cherokee,02 Baxter Sprs W2,Registered,,,Registered,760,
-Cherokee,02 Baxter Sprs W2,Ballots,,Dem,Ballots,11,
-Cherokee,02 Baxter Sprs W2,Ballots,,Rep,Ballots,39,
-Cherokee,02 Baxter Sprs W2,US House,2,Dem,Paul Davis,8,
-Cherokee,02 Baxter Sprs W2,Governor,,Dem,Arden Andersen,1,
-Cherokee,02 Baxter Sprs W2,Governor,,Dem,Jack Bergeson,1,
-Cherokee,02 Baxter Sprs W2,Governor,,Dem,Carl Brewer,1,
-Cherokee,02 Baxter Sprs W2,Governor,,Dem,Laura Kelly,1,
-Cherokee,02 Baxter Sprs W2,Governor,,Dem,Joshua Svaty,5,
-Cherokee,02 Baxter Sprs W2,Secretary of State,,Dem,Brian McClendon,10,
-Cherokee,02 Baxter Sprs W2,Attorney General,,Dem,Sarah Swain,10,
-Cherokee,02 Baxter Sprs W2,State Treasurer,,Dem,Marci Francisco,10,
-Cherokee,02 Baxter Sprs W2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,10,
-Cherokee,02 Baxter Sprs W2,State Senate,13,Dem,Bryan Hoffman,10,
-Cherokee,02 Baxter Sprs W2,State House,1,Dem,write-in,2,
-Cherokee,02 Baxter Sprs W2,US House,2,Rep,Vernon Fields,1,
-Cherokee,02 Baxter Sprs W2,US House,2,Rep,Steve Fitzgerald,8,
-Cherokee,02 Baxter Sprs W2,US House,2,Rep,Kevin Jones,3,
-Cherokee,02 Baxter Sprs W2,US House,2,Rep,Doug Mays,2,
-Cherokee,02 Baxter Sprs W2,US House,2,Rep,Dennis Pyle,6,
-Cherokee,02 Baxter Sprs W2,US House,2,Rep,Caron Tyson,7,
-Cherokee,02 Baxter Sprs W2,US House,2,Rep,Steve Watkins,11,
-Cherokee,02 Baxter Sprs W2,Governor,,Rep,Jim Barnett,2,
-Cherokee,02 Baxter Sprs W2,Governor,,Rep,Jeff Colyer,13,
-Cherokee,02 Baxter Sprs W2,Governor,,Rep,Kris Kobach,18,
-Cherokee,02 Baxter Sprs W2,Governor,,Rep,Patrick Kucera,1,
-Cherokee,02 Baxter Sprs W2,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,02 Baxter Sprs W2,Governor,,Rep,Ken Selzer,3,
-Cherokee,02 Baxter Sprs W2,Governor,,Rep,Joseph Tutera,0,
-Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Randy Duncan,8,
-Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Keith Esau,3,
-Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Craig McCullah,4,
-Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Scott Schwab,14,
-Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Dennis Taylor,8,
-Cherokee,02 Baxter Sprs W2,Attorney General,,Rep,Derek Schmidt,33,
-Cherokee,02 Baxter Sprs W2,State Treasurer,,Rep,Jake LaTurner,39,
-Cherokee,02 Baxter Sprs W2,Insurance Commissioner,,Rep,Vicki Schmidt,16,
-Cherokee,02 Baxter Sprs W2,Insurance Commissioner,,Rep,Clark Shultz,22,
-Cherokee,02 Baxter Sprs W2,State Senate,13,Rep,Richard Hilderbrand,35,
-Cherokee,02 Baxter Sprs W2,State House,1,Rep,Michael Houser,36,
-Cherokee,03 Baxter Sprs W3,Registered,,,Registered,1145,
-Cherokee,03 Baxter Sprs W3,Ballots,,Dem,Ballots,56,
-Cherokee,03 Baxter Sprs W3,Ballots,,Rep,Ballots,127,
-Cherokee,03 Baxter Sprs W3,US House,2,Dem,Paul Davis,47,
-Cherokee,03 Baxter Sprs W3,Governor,,Dem,Arden Andersen,2,
-Cherokee,03 Baxter Sprs W3,Governor,,Dem,Jack Bergeson,0,
-Cherokee,03 Baxter Sprs W3,Governor,,Dem,Carl Brewer,4,
-Cherokee,03 Baxter Sprs W3,Governor,,Dem,Laura Kelly,19,
-Cherokee,03 Baxter Sprs W3,Governor,,Dem,Joshua Svaty,29,
-Cherokee,03 Baxter Sprs W3,Secretary of State,,Dem,Brian McClendon,45,
-Cherokee,03 Baxter Sprs W3,Attorney General,,Dem,Sarah Swain,47,
-Cherokee,03 Baxter Sprs W3,State Treasurer,,Dem,Marci Francisco,46,
-Cherokee,03 Baxter Sprs W3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,46,
-Cherokee,03 Baxter Sprs W3,State Senate,13,Dem,Bryan Hoffman,46,
-Cherokee,03 Baxter Sprs W3,State House,1,Dem,write-in,6,
-Cherokee,03 Baxter Sprs W3,US House,2,Rep,Vernon Fields,1,
-Cherokee,03 Baxter Sprs W3,US House,2,Rep,Steve Fitzgerald,11,
-Cherokee,03 Baxter Sprs W3,US House,2,Rep,Kevin Jones,22,
-Cherokee,03 Baxter Sprs W3,US House,2,Rep,Doug Mays,4,
-Cherokee,03 Baxter Sprs W3,US House,2,Rep,Dennis Pyle,18,
-Cherokee,03 Baxter Sprs W3,US House,2,Rep,Caron Tyson,13,
-Cherokee,03 Baxter Sprs W3,US House,2,Rep,Steve Watkins,47,
-Cherokee,03 Baxter Sprs W3,Governor,,Rep,Jim Barnett,6,
-Cherokee,03 Baxter Sprs W3,Governor,,Rep,Jeff Colyer,41,
-Cherokee,03 Baxter Sprs W3,Governor,,Rep,Kris Kobach,58,
-Cherokee,03 Baxter Sprs W3,Governor,,Rep,Patrick Kucera,0,
-Cherokee,03 Baxter Sprs W3,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,03 Baxter Sprs W3,Governor,,Rep,Ken Selzer,16,
-Cherokee,03 Baxter Sprs W3,Governor,,Rep,Joseph Tutera,3,
-Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Randy Duncan,28,
-Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Keith Esau,12,
-Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Craig McCullah,11,
-Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Scott Schwab,35,
-Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Dennis Taylor,21,
-Cherokee,03 Baxter Sprs W3,Attorney General,,Rep,Derek Schmidt,98,
-Cherokee,03 Baxter Sprs W3,State Treasurer,,Rep,Jake LaTurner,110,
-Cherokee,03 Baxter Sprs W3,Insurance Commissioner,,Rep,Vicki Schmidt,54,
-Cherokee,03 Baxter Sprs W3,Insurance Commissioner,,Rep,Clark Shultz,62,
-Cherokee,03 Baxter Sprs W3,State Senate,13,Rep,Richard Hilderbrand,122,
-Cherokee,03 Baxter Sprs W3,State House,1,Rep,Michael Houser,103,
-Cherokee,04 Baxter Sprs W4,Registered,,,Registered,853,
-Cherokee,04 Baxter Sprs W4,Ballots,,Dem,Ballots,33,
-Cherokee,04 Baxter Sprs W4,Ballots,,Rep,Ballots,64,
-Cherokee,04 Baxter Sprs W4,US House,2,Dem,Paul Davis,31,
-Cherokee,04 Baxter Sprs W4,Governor,,Dem,Arden Andersen,4,
-Cherokee,04 Baxter Sprs W4,Governor,,Dem,Jack Bergeson,0,
-Cherokee,04 Baxter Sprs W4,Governor,,Dem,Carl Brewer,4,
-Cherokee,04 Baxter Sprs W4,Governor,,Dem,Laura Kelly,7,
-Cherokee,04 Baxter Sprs W4,Governor,,Dem,Joshua Svaty,17,
-Cherokee,04 Baxter Sprs W4,Secretary of State,,Dem,Brian McClendon,30,
-Cherokee,04 Baxter Sprs W4,Attorney General,,Dem,Sarah Swain,33,
-Cherokee,04 Baxter Sprs W4,State Treasurer,,Dem,Marci Francisco,33,
-Cherokee,04 Baxter Sprs W4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,33,
-Cherokee,04 Baxter Sprs W4,State Senate,13,Dem,Bryan Hoffman,33,
-Cherokee,04 Baxter Sprs W4,State House,1,Dem,write-in,7,
-Cherokee,04 Baxter Sprs W4,US House,2,Rep,Vernon Fields,2,
-Cherokee,04 Baxter Sprs W4,US House,2,Rep,Steve Fitzgerald,8,
-Cherokee,04 Baxter Sprs W4,US House,2,Rep,Kevin Jones,14,
-Cherokee,04 Baxter Sprs W4,US House,2,Rep,Doug Mays,1,
-Cherokee,04 Baxter Sprs W4,US House,2,Rep,Dennis Pyle,4,
-Cherokee,04 Baxter Sprs W4,US House,2,Rep,Caron Tyson,13,
-Cherokee,04 Baxter Sprs W4,US House,2,Rep,Steve Watkins,22,
-Cherokee,04 Baxter Sprs W4,Governor,,Rep,Jim Barnett,3,
-Cherokee,04 Baxter Sprs W4,Governor,,Rep,Jeff Colyer,29,
-Cherokee,04 Baxter Sprs W4,Governor,,Rep,Kris Kobach,26,
-Cherokee,04 Baxter Sprs W4,Governor,,Rep,Patrick Kucera,1,
-Cherokee,04 Baxter Sprs W4,Governor,,Rep,Tyler Ruzich,1,
-Cherokee,04 Baxter Sprs W4,Governor,,Rep,Ken Selzer,3,
-Cherokee,04 Baxter Sprs W4,Governor,,Rep,Joseph Tutera,0,
-Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Randy Duncan,13,
-Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Keith Esau,8,
-Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Craig McCullah,4,
-Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Scott Schwab,24,
-Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Dennis Taylor,10,
-Cherokee,04 Baxter Sprs W4,Attorney General,,Rep,Derek Schmidt,51,
-Cherokee,04 Baxter Sprs W4,State Treasurer,,Rep,Jake LaTurner,56,
-Cherokee,04 Baxter Sprs W4,Insurance Commissioner,,Rep,Vicki Schmidt,36,
-Cherokee,04 Baxter Sprs W4,Insurance Commissioner,,Rep,Clark Shultz,23,
-Cherokee,04 Baxter Sprs W4,State Senate,13,Rep,Richard Hilderbrand,60,
-Cherokee,04 Baxter Sprs W4,State House,1,Rep,Michael Houser,53,
-Cherokee,05 Columbus W1,Registered,,,Registered,421,
-Cherokee,05 Columbus W1,Ballots,,Dem,Ballots,26,
-Cherokee,05 Columbus W1,Ballots,,Rep,Ballots,45,
-Cherokee,05 Columbus W1,US House,2,Dem,Paul Davis,23,P20
-Cherokee,05 Columbus W1,Governor,,Dem,Arden Andersen,4,
-Cherokee,05 Columbus W1,Governor,,Dem,Jack Bergeson,2,
-Cherokee,05 Columbus W1,Governor,,Dem,Carl Brewer,4,
-Cherokee,05 Columbus W1,Governor,,Dem,Laura Kelly,9,
-Cherokee,05 Columbus W1,Governor,,Dem,Joshua Svaty,7,
-Cherokee,05 Columbus W1,Secretary of State,,Dem,Brian McClendon,24,
-Cherokee,05 Columbus W1,Attorney General,,Dem,Sarah Swain,24,
-Cherokee,05 Columbus W1,State Treasurer,,Dem,Marci Francisco,23,
-Cherokee,05 Columbus W1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,23,
-Cherokee,05 Columbus W1,State Senate,13,Dem,Bryan Hoffman,24,
-Cherokee,05 Columbus W1,State House,1,Dem,write-in,4,
-Cherokee,05 Columbus W1,US House,2,Rep,Vernon Fields,0,
-Cherokee,05 Columbus W1,US House,2,Rep,Steve Fitzgerald,9,
-Cherokee,05 Columbus W1,US House,2,Rep,Kevin Jones,4,
-Cherokee,05 Columbus W1,US House,2,Rep,Doug Mays,2,
-Cherokee,05 Columbus W1,US House,2,Rep,Dennis Pyle,3,
-Cherokee,05 Columbus W1,US House,2,Rep,Caron Tyson,8,
-Cherokee,05 Columbus W1,US House,2,Rep,Steve Watkins,18,
-Cherokee,05 Columbus W1,Governor,,Rep,Jim Barnett,3,
-Cherokee,05 Columbus W1,Governor,,Rep,Jeff Colyer,20,
-Cherokee,05 Columbus W1,Governor,,Rep,Kris Kobach,20,
-Cherokee,05 Columbus W1,Governor,,Rep,Patrick Kucera,1,
-Cherokee,05 Columbus W1,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,05 Columbus W1,Governor,,Rep,Ken Selzer,1,
-Cherokee,05 Columbus W1,Governor,,Rep,Joseph Tutera,0,
-Cherokee,05 Columbus W1,Secretary of  State,,Rep,Randy Duncan,10,
-Cherokee,05 Columbus W1,Secretary of  State,,Rep,Keith Esau,2,
-Cherokee,05 Columbus W1,Secretary of  State,,Rep,Craig McCullah,6,
-Cherokee,05 Columbus W1,Secretary of  State,,Rep,Scott Schwab,13,
-Cherokee,05 Columbus W1,Secretary of  State,,Rep,Dennis Taylor,9,
-Cherokee,05 Columbus W1,Attorney General,,Rep,Derek Schmidt,39,
-Cherokee,05 Columbus W1,State Treasurer,,Rep,Jake LaTurner,41,
-Cherokee,05 Columbus W1,Insurance Commissioner,,Rep,Vicki Schmidt,16,
-Cherokee,05 Columbus W1,Insurance Commissioner,,Rep,Clark Shultz,24,
-Cherokee,05 Columbus W1,State Senate,13,Rep,Richard Hilderbrand,39,
-Cherokee,05 Columbus W1,State House,1,Rep,Michael Houser,41,
-Cherokee,06 Columbus W2,Registered,,,Registered,482,
-Cherokee,06 Columbus W2,Ballots,,Dem,Ballots,47,
-Cherokee,06 Columbus W2,Ballots,,Rep,Ballots,78,
-Cherokee,06 Columbus W2,US House,2,Dem,Paul Davis,39,
-Cherokee,06 Columbus W2,Governor,,Dem,Arden Andersen,4,
-Cherokee,06 Columbus W2,Governor,,Dem,Jack Bergeson,1,
-Cherokee,06 Columbus W2,Governor,,Dem,Carl Brewer,2,
-Cherokee,06 Columbus W2,Governor,,Dem,Laura Kelly,18,
-Cherokee,06 Columbus W2,Governor,,Dem,Joshua Svaty,21,
-Cherokee,06 Columbus W2,Secretary of State,,Dem,Brian McClendon,39,
-Cherokee,06 Columbus W2,Attorney General,,Dem,Sarah Swain,40,
-Cherokee,06 Columbus W2,State Treasurer,,Dem,Marci Francisco,39,
-Cherokee,06 Columbus W2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,36,
-Cherokee,06 Columbus W2,State Senate,13,Dem,Bryan Hoffman,39,
-Cherokee,06 Columbus W2,State House,1,Dem,write-in,2,
-Cherokee,06 Columbus W2,US House,2,Rep,Vernon Fields,1,
-Cherokee,06 Columbus W2,US House,2,Rep,Steve Fitzgerald,7,
-Cherokee,06 Columbus W2,US House,2,Rep,Kevin Jones,4,
-Cherokee,06 Columbus W2,US House,2,Rep,Doug Mays,2,
-Cherokee,06 Columbus W2,US House,2,Rep,Dennis Pyle,11,
-Cherokee,06 Columbus W2,US House,2,Rep,Caron Tyson,26,
-Cherokee,06 Columbus W2,US House,2,Rep,Steve Watkins,25,
-Cherokee,06 Columbus W2,Governor,,Rep,Jim Barnett,1,
-Cherokee,06 Columbus W2,Governor,,Rep,Jeff Colyer,40,
-Cherokee,06 Columbus W2,Governor,,Rep,Kris Kobach,24,
-Cherokee,06 Columbus W2,Governor,,Rep,Patrick Kucera,0,
-Cherokee,06 Columbus W2,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,06 Columbus W2,Governor,,Rep,Ken Selzer,10,
-Cherokee,06 Columbus W2,Governor,,Rep,Joseph Tutera,0,
-Cherokee,06 Columbus W2,Secretary of  State,,Rep,Randy Duncan,26,
-Cherokee,06 Columbus W2,Secretary of  State,,Rep,Keith Esau,8,
-Cherokee,06 Columbus W2,Secretary of  State,,Rep,Craig McCullah,11,
-Cherokee,06 Columbus W2,Secretary of  State,,Rep,Scott Schwab,17,
-Cherokee,06 Columbus W2,Secretary of  State,,Rep,Dennis Taylor,10,
-Cherokee,06 Columbus W2,Attorney General,,Rep,Derek Schmidt,69,
-Cherokee,06 Columbus W2,State Treasurer,,Rep,Jake LaTurner,68,
-Cherokee,06 Columbus W2,Insurance Commissioner,,Rep,Vicki Schmidt,45,
-Cherokee,06 Columbus W2,Insurance Commissioner,,Rep,Clark Shultz,30,
-Cherokee,06 Columbus W2,State Senate,13,Rep,Richard Hilderbrand,67,
-Cherokee,06 Columbus W2,State House,1,Rep,Michael Houser,68,
-Cherokee,07 Columbus W3,Registered,,,Registered,457,
-Cherokee,07 Columbus W3,Ballots,,Dem,Ballots,37,
-Cherokee,07 Columbus W3,Ballots,,Rep,Ballots,69,
-Cherokee,07 Columbus W3,US House,2,Dem,Paul Davis,29,
-Cherokee,07 Columbus W3,Governor,,Dem,Arden Andersen,3,
-Cherokee,07 Columbus W3,Governor,,Dem,Jack Bergeson,3,
-Cherokee,07 Columbus W3,Governor,,Dem,Carl Brewer,4,
-Cherokee,07 Columbus W3,Governor,,Dem,Laura Kelly,14,
-Cherokee,07 Columbus W3,Governor,,Dem,Joshua Svaty,12,
-Cherokee,07 Columbus W3,Secretary of State,,Dem,Brian McClendon,31,
-Cherokee,07 Columbus W3,Attorney General,,Dem,Sarah Swain,34,
-Cherokee,07 Columbus W3,State Treasurer,,Dem,Marci Francisco,31,
-Cherokee,07 Columbus W3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,32,
-Cherokee,07 Columbus W3,State Senate,13,Dem,Bryan Hoffman,32,
-Cherokee,07 Columbus W3,State House,1,Dem,write-in,4,
-Cherokee,07 Columbus W3,US House,2,Rep,Vernon Fields,1,
-Cherokee,07 Columbus W3,US House,2,Rep,Steve Fitzgerald,7,
-Cherokee,07 Columbus W3,US House,2,Rep,Kevin Jones,11,
-Cherokee,07 Columbus W3,US House,2,Rep,Doug Mays,3,
-Cherokee,07 Columbus W3,US House,2,Rep,Dennis Pyle,4,
-Cherokee,07 Columbus W3,US House,2,Rep,Caron Tyson,17,
-Cherokee,07 Columbus W3,US House,2,Rep,Steve Watkins,26,
-Cherokee,07 Columbus W3,Governor,,Rep,Jim Barnett,7,
-Cherokee,07 Columbus W3,Governor,,Rep,Jeff Colyer,31,
-Cherokee,07 Columbus W3,Governor,,Rep,Kris Kobach,23,
-Cherokee,07 Columbus W3,Governor,,Rep,Patrick Kucera,2,
-Cherokee,07 Columbus W3,Governor,,Rep,Tyler Ruzich,1,
-Cherokee,07 Columbus W3,Governor,,Rep,Ken Selzer,4,
-Cherokee,07 Columbus W3,Governor,,Rep,Joseph Tutera,0,
-Cherokee,07 Columbus W3,Secretary of  State,,Rep,Randy Duncan,18,
-Cherokee,07 Columbus W3,Secretary of  State,,Rep,Keith Esau,6,
-Cherokee,07 Columbus W3,Secretary of  State,,Rep,Craig McCullah,7,
-Cherokee,07 Columbus W3,Secretary of  State,,Rep,Scott Schwab,18,
-Cherokee,07 Columbus W3,Secretary of  State,,Rep,Dennis Taylor,13,
-Cherokee,07 Columbus W3,Attorney General,,Rep,Derek Schmidt,63,
-Cherokee,07 Columbus W3,State Treasurer,,Rep,Jake LaTurner,64,
-Cherokee,07 Columbus W3,Insurance Commissioner,,Rep,Vicki Schmidt,40,
-Cherokee,07 Columbus W3,Insurance Commissioner,,Rep,Clark Shultz,28,
-Cherokee,07 Columbus W3,State Senate,13,Rep,Richard Hilderbrand,63,
-Cherokee,07 Columbus W3,State House,1,Rep,Michael Houser,63,
-Cherokee,08 Columbus W4,Registered,,,Registered,416,
-Cherokee,08 Columbus W4,Ballots,,Dem,Ballots,21,
-Cherokee,08 Columbus W4,Ballots,,Rep,Ballots,40,
-Cherokee,08 Columbus W4,US House,2,Dem,Paul Davis,19,
-Cherokee,08 Columbus W4,Governor,,Dem,Arden Andersen,0,
-Cherokee,08 Columbus W4,Governor,,Dem,Jack Bergeson,1,
-Cherokee,08 Columbus W4,Governor,,Dem,Carl Brewer,1,
-Cherokee,08 Columbus W4,Governor,,Dem,Laura Kelly,5,
-Cherokee,08 Columbus W4,Governor,,Dem,Joshua Svaty,14,
-Cherokee,08 Columbus W4,Secretary of State,,Dem,Brian McClendon,17,
-Cherokee,08 Columbus W4,Attorney General,,Dem,Sarah Swain,17,
-Cherokee,08 Columbus W4,State Treasurer,,Dem,Marci Francisco,17,
-Cherokee,08 Columbus W4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,17,
-Cherokee,08 Columbus W4,State Senate,13,Dem,Bryan Hoffman,19,
-Cherokee,08 Columbus W4,State House,1,Dem,write-in,2,
-Cherokee,08 Columbus W4,US House,2,Rep,Vernon Fields,0,
-Cherokee,08 Columbus W4,US House,2,Rep,Steve Fitzgerald,1,
-Cherokee,08 Columbus W4,US House,2,Rep,Kevin Jones,3,
-Cherokee,08 Columbus W4,US House,2,Rep,Doug Mays,2,
-Cherokee,08 Columbus W4,US House,2,Rep,Dennis Pyle,3,
-Cherokee,08 Columbus W4,US House,2,Rep,Caron Tyson,14,
-Cherokee,08 Columbus W4,US House,2,Rep,Steve Watkins,13,
-Cherokee,08 Columbus W4,Governor,,Rep,Jim Barnett,6,
-Cherokee,08 Columbus W4,Governor,,Rep,Jeff Colyer,14,
-Cherokee,08 Columbus W4,Governor,,Rep,Kris Kobach,15,
-Cherokee,08 Columbus W4,Governor,,Rep,Patrick Kucera,0,
-Cherokee,08 Columbus W4,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,08 Columbus W4,Governor,,Rep,Ken Selzer,2,
-Cherokee,08 Columbus W4,Governor,,Rep,Joseph Tutera,0,
-Cherokee,08 Columbus W4,Secretary of  State,,Rep,Randy Duncan,4,
-Cherokee,08 Columbus W4,Secretary of  State,,Rep,Keith Esau,8,
-Cherokee,08 Columbus W4,Secretary of  State,,Rep,Craig McCullah,1,
-Cherokee,08 Columbus W4,Secretary of  State,,Rep,Scott Schwab,12,
-Cherokee,08 Columbus W4,Secretary of  State,,Rep,Dennis Taylor,10,
-Cherokee,08 Columbus W4,Attorney General,,Rep,Derek Schmidt,30,
-Cherokee,08 Columbus W4,State Treasurer,,Rep,Jake LaTurner,32,
-Cherokee,08 Columbus W4,Insurance Commissioner,,Rep,Vicki Schmidt,20,
-Cherokee,08 Columbus W4,Insurance Commissioner,,Rep,Clark Shultz,15,
-Cherokee,08 Columbus W4,State Senate,13,Rep,Richard Hilderbrand,32,
-Cherokee,08 Columbus W4,State House,1,Rep,Michael Houser,32,
-Cherokee,09 Columbus W5,Registered,,,Registered,415,
-Cherokee,09 Columbus W5,Ballots,,Dem,Ballots,30,
-Cherokee,09 Columbus W5,Ballots,,Rep,Ballots,48,
-Cherokee,09 Columbus W5,US House,2,Dem,Paul Davis,23,
-Cherokee,09 Columbus W5,Governor,,Dem,Arden Andersen,6,
-Cherokee,09 Columbus W5,Governor,,Dem,Jack Bergeson,2,
-Cherokee,09 Columbus W5,Governor,,Dem,Carl Brewer,5,
-Cherokee,09 Columbus W5,Governor,,Dem,Laura Kelly,7,
-Cherokee,09 Columbus W5,Governor,,Dem,Joshua Svaty,6,
-Cherokee,09 Columbus W5,Secretary of State,,Dem,Brian McClendon,25,
-Cherokee,09 Columbus W5,Attorney General,,Dem,Sarah Swain,26,
-Cherokee,09 Columbus W5,State Treasurer,,Dem,Marci Francisco,26,
-Cherokee,09 Columbus W5,Insurance Commissioner,,Dem,Nathaniel McLaughlin,25,
-Cherokee,09 Columbus W5,State Senate,13,Dem,Bryan Hoffman,27,
-Cherokee,09 Columbus W5,State House,1,Dem,write-in,3,
-Cherokee,09 Columbus W5,US House,2,Rep,Vernon Fields,0,
-Cherokee,09 Columbus W5,US House,2,Rep,Steve Fitzgerald,3,
-Cherokee,09 Columbus W5,US House,2,Rep,Kevin Jones,10,
-Cherokee,09 Columbus W5,US House,2,Rep,Doug Mays,2,
-Cherokee,09 Columbus W5,US House,2,Rep,Dennis Pyle,2,
-Cherokee,09 Columbus W5,US House,2,Rep,Caron Tyson,15,
-Cherokee,09 Columbus W5,US House,2,Rep,Steve Watkins,14,
-Cherokee,09 Columbus W5,Governor,,Rep,Jim Barnett,7,
-Cherokee,09 Columbus W5,Governor,,Rep,Jeff Colyer,15,
-Cherokee,09 Columbus W5,Governor,,Rep,Kris Kobach,20,
-Cherokee,09 Columbus W5,Governor,,Rep,Patrick Kucera,0,
-Cherokee,09 Columbus W5,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,09 Columbus W5,Governor,,Rep,Ken Selzer,4,
-Cherokee,09 Columbus W5,Governor,,Rep,Joseph Tutera,0,
-Cherokee,09 Columbus W5,Secretary of  State,,Rep,Randy Duncan,15,
-Cherokee,09 Columbus W5,Secretary of  State,,Rep,Keith Esau,3,
-Cherokee,09 Columbus W5,Secretary of  State,,Rep,Craig McCullah,5,
-Cherokee,09 Columbus W5,Secretary of  State,,Rep,Scott Schwab,11,
-Cherokee,09 Columbus W5,Secretary of  State,,Rep,Dennis Taylor,8,
-Cherokee,09 Columbus W5,Attorney General,,Rep,Derek Schmidt,37,
-Cherokee,09 Columbus W5,State Treasurer,,Rep,Jake LaTurner,35,
-Cherokee,09 Columbus W5,Insurance Commissioner,,Rep,Vicki Schmidt,26,
-Cherokee,09 Columbus W5,Insurance Commissioner,,Rep,Clark Shultz,18,
-Cherokee,09 Columbus W5,State Senate,13,Rep,Richard Hilderbrand,40,
-Cherokee,09 Columbus W5,State House,1,Rep,Michael Houser,43,
-Cherokee,10 Galena W1,Registered,,,Registered,665,
-Cherokee,10 Galena W1,Ballots,,Dem,Ballots,21,
-Cherokee,10 Galena W1,Ballots,,Rep,Ballots,56,
-Cherokee,10 Galena W1,US House,2,Dem,Paul Davis,18,
-Cherokee,10 Galena W1,Governor,,Dem,Arden Andersen,4,
-Cherokee,10 Galena W1,Governor,,Dem,Jack Bergeson,4,
-Cherokee,10 Galena W1,Governor,,Dem,Carl Brewer,2,
-Cherokee,10 Galena W1,Governor,,Dem,Laura Kelly,8,
-Cherokee,10 Galena W1,Governor,,Dem,Joshua Svaty,3,
-Cherokee,10 Galena W1,Secretary of State,,Dem,Brian McClendon,16,
-Cherokee,10 Galena W1,Attorney General,,Dem,Sarah Swain,18,
-Cherokee,10 Galena W1,State Treasurer,,Dem,Marci Francisco,15,
-Cherokee,10 Galena W1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,18,
-Cherokee,10 Galena W1,State Senate,13,Dem,Bryan Hoffman,16,
-Cherokee,10 Galena W1,State House,1,Dem,write-in,3,
-Cherokee,10 Galena W1,US House,2,Rep,Vernon Fields,5,
-Cherokee,10 Galena W1,US House,2,Rep,Steve Fitzgerald,3,
-Cherokee,10 Galena W1,US House,2,Rep,Kevin Jones,3,
-Cherokee,10 Galena W1,US House,2,Rep,Doug Mays,5,
-Cherokee,10 Galena W1,US House,2,Rep,Dennis Pyle,4,
-Cherokee,10 Galena W1,US House,2,Rep,Caron Tyson,10,
-Cherokee,10 Galena W1,US House,2,Rep,Steve Watkins,15,
-Cherokee,10 Galena W1,Governor,,Rep,Jim Barnett,6,
-Cherokee,10 Galena W1,Governor,,Rep,Jeff Colyer,16,
-Cherokee,10 Galena W1,Governor,,Rep,Kris Kobach,24,
-Cherokee,10 Galena W1,Governor,,Rep,Patrick Kucera,1,
-Cherokee,10 Galena W1,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,10 Galena W1,Governor,,Rep,Ken Selzer,5,
-Cherokee,10 Galena W1,Governor,,Rep,Joseph Tutera,0,
-Cherokee,10 Galena W1,Secretary of  State,,Rep,Randy Duncan,18,
-Cherokee,10 Galena W1,Secretary of  State,,Rep,Keith Esau,5,
-Cherokee,10 Galena W1,Secretary of  State,,Rep,Craig McCullah,6,
-Cherokee,10 Galena W1,Secretary of  State,,Rep,Scott Schwab,9,
-Cherokee,10 Galena W1,Secretary of  State,,Rep,Dennis Taylor,6,
-Cherokee,10 Galena W1,Attorney General,,Rep,Derek Schmidt,44,
-Cherokee,10 Galena W1,State Treasurer,,Rep,Jake LaTurner,49,
-Cherokee,10 Galena W1,Insurance Commissioner,,Rep,Vicki Schmidt,26,
-Cherokee,10 Galena W1,Insurance Commissioner,,Rep,Clark Shultz,17,
-Cherokee,10 Galena W1,State Senate,13,Rep,Richard Hilderbrand,50,
-Cherokee,10 Galena W1,State House,1,Rep,Michael Houser,42,
-Cherokee,011 Galena W2,Registered,,,Registered,523,
-Cherokee,011 Galena W2,Ballots,,Dem,Ballots,24,
-Cherokee,011 Galena W2,Ballots,,Rep,Ballots,62,
-Cherokee,011 Galena W2,US House,2,Dem,Paul Davis,20,
-Cherokee,011 Galena W2,Governor,,Dem,Arden Andersen,2,
-Cherokee,011 Galena W2,Governor,,Dem,Jack Bergeson,5,
-Cherokee,011 Galena W2,Governor,,Dem,Carl Brewer,8,
-Cherokee,011 Galena W2,Governor,,Dem,Laura Kelly,6,
-Cherokee,011 Galena W2,Governor,,Dem,Joshua Svaty,3,
-Cherokee,011 Galena W2,Secretary of State,,Dem,Brian McClendon,22,
-Cherokee,011 Galena W2,Attorney General,,Dem,Sarah Swain,22,
-Cherokee,011 Galena W2,State Treasurer,,Dem,Marci Francisco,22,
-Cherokee,011 Galena W2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,22,
-Cherokee,011 Galena W2,State Senate,13,Dem,Bryan Hoffman,20,
-Cherokee,011 Galena W2,State House,1,Dem,write-in,4,
-Cherokee,011 Galena W2,US House,2,Rep,Vernon Fields,0,
-Cherokee,011 Galena W2,US House,2,Rep,Steve Fitzgerald,5,
-Cherokee,011 Galena W2,US House,2,Rep,Kevin Jones,8,
-Cherokee,011 Galena W2,US House,2,Rep,Doug Mays,6,
-Cherokee,011 Galena W2,US House,2,Rep,Dennis Pyle,9,
-Cherokee,011 Galena W2,US House,2,Rep,Caron Tyson,10,
-Cherokee,011 Galena W2,US House,2,Rep,Steve Watkins,18,
-Cherokee,011 Galena W2,Governor,,Rep,Jim Barnett,9,
-Cherokee,011 Galena W2,Governor,,Rep,Jeff Colyer,12,
-Cherokee,011 Galena W2,Governor,,Rep,Kris Kobach,27,
-Cherokee,011 Galena W2,Governor,,Rep,Patrick Kucera,3,
-Cherokee,011 Galena W2,Governor,,Rep,Tyler Ruzich,1,
-Cherokee,011 Galena W2,Governor,,Rep,Ken Selzer,3,
-Cherokee,011 Galena W2,Governor,,Rep,Joseph Tutera,0,
-Cherokee,011 Galena W2,Secretary of  State,,Rep,Randy Duncan,14,
-Cherokee,011 Galena W2,Secretary of  State,,Rep,Keith Esau,5,
-Cherokee,011 Galena W2,Secretary of  State,,Rep,Craig McCullah,8,
-Cherokee,011 Galena W2,Secretary of  State,,Rep,Scott Schwab,13,
-Cherokee,011 Galena W2,Secretary of  State,,Rep,Dennis Taylor,11,
-Cherokee,011 Galena W2,Attorney General,,Rep,Derek Schmidt,50,
-Cherokee,011 Galena W2,State Treasurer,,Rep,Jake LaTurner,48,
-Cherokee,011 Galena W2,Insurance Commissioner,,Rep,Vicki Schmidt,27,
-Cherokee,011 Galena W2,Insurance Commissioner,,Rep,Clark Shultz,25,
-Cherokee,011 Galena W2,State Senate,13,Rep,Richard Hilderbrand,50,
-Cherokee,011 Galena W2,State House,1,Rep,Michael Houser,44,
-Cherokee,012 Galena W3,Registered,,,Registered,747,
-Cherokee,012 Galena W3,Ballots,,Dem,Ballots,37,
-Cherokee,012 Galena W3,Ballots,,Rep,Ballots,98,
-Cherokee,012 Galena W3,US House,2,Dem,Paul Davis,30,
-Cherokee,012 Galena W3,Governor,,Dem,Arden Andersen,5,
-Cherokee,012 Galena W3,Governor,,Dem,Jack Bergeson,1,
-Cherokee,012 Galena W3,Governor,,Dem,Carl Brewer,1,
-Cherokee,012 Galena W3,Governor,,Dem,Laura Kelly,16,
-Cherokee,012 Galena W3,Governor,,Dem,Joshua Svaty,9,
-Cherokee,012 Galena W3,Secretary of State,,Dem,Brian McClendon,29,
-Cherokee,012 Galena W3,Attorney General,,Dem,Sarah Swain,30,
-Cherokee,012 Galena W3,State Treasurer,,Dem,Marci Francisco,31,
-Cherokee,012 Galena W3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,27,
-Cherokee,012 Galena W3,State Senate,13,Dem,Bryan Hoffman,31,
-Cherokee,012 Galena W3,State House,1,Dem,write-in,6,
-Cherokee,012 Galena W3,US House,2,Rep,Vernon Fields,1,
-Cherokee,012 Galena W3,US House,2,Rep,Steve Fitzgerald,10,
-Cherokee,012 Galena W3,US House,2,Rep,Kevin Jones,9,
-Cherokee,012 Galena W3,US House,2,Rep,Doug Mays,1,
-Cherokee,012 Galena W3,US House,2,Rep,Dennis Pyle,6,
-Cherokee,012 Galena W3,US House,2,Rep,Caron Tyson,15,
-Cherokee,012 Galena W3,US House,2,Rep,Steve Watkins,43,
-Cherokee,012 Galena W3,Governor,,Rep,Jim Barnett,9,
-Cherokee,012 Galena W3,Governor,,Rep,Jeff Colyer,32,
-Cherokee,012 Galena W3,Governor,,Rep,Kris Kobach,39,
-Cherokee,012 Galena W3,Governor,,Rep,Patrick Kucera,2,
-Cherokee,012 Galena W3,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,012 Galena W3,Governor,,Rep,Ken Selzer,7,
-Cherokee,012 Galena W3,Governor,,Rep,Joseph Tutera,2,
-Cherokee,012 Galena W3,Secretary of  State,,Rep,Randy Duncan,33,
-Cherokee,012 Galena W3,Secretary of  State,,Rep,Keith Esau,4,
-Cherokee,012 Galena W3,Secretary of  State,,Rep,Craig McCullah,5,
-Cherokee,012 Galena W3,Secretary of  State,,Rep,Scott Schwab,22,
-Cherokee,012 Galena W3,Secretary of  State,,Rep,Dennis Taylor,13,
-Cherokee,012 Galena W3,Attorney General,,Rep,Derek Schmidt,70,
-Cherokee,012 Galena W3,State Treasurer,,Rep,Jake LaTurner,80,
-Cherokee,012 Galena W3,Insurance Commissioner,,Rep,Vicki Schmidt,49,
-Cherokee,012 Galena W3,Insurance Commissioner,,Rep,Clark Shultz,31,
-Cherokee,012 Galena W3,State Senate,13,Rep,Richard Hilderbrand,85,
-Cherokee,012 Galena W3,State House,1,Rep,Michael Houser,75,
-Cherokee,013 Galena W4,Registered,,,Registered,462,
-Cherokee,013 Galena W4,Ballots,,Dem,Ballots,26,
-Cherokee,013 Galena W4,Ballots,,Rep,Ballots,42,
-Cherokee,013 Galena W4,US House,2,Dem,Paul Davis,23,
-Cherokee,013 Galena W4,Governor,,Dem,Arden Andersen,5,
-Cherokee,013 Galena W4,Governor,,Dem,Jack Bergeson,3,
-Cherokee,013 Galena W4,Governor,,Dem,Carl Brewer,3,
-Cherokee,013 Galena W4,Governor,,Dem,Laura Kelly,9,
-Cherokee,013 Galena W4,Governor,,Dem,Joshua Svaty,3,
-Cherokee,013 Galena W4,Secretary of State,,Dem,Brian McClendon,21,
-Cherokee,013 Galena W4,Attorney General,,Dem,Sarah Swain,20,
-Cherokee,013 Galena W4,State Treasurer,,Dem,Marci Francisco,22,
-Cherokee,013 Galena W4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,20,
-Cherokee,013 Galena W4,State Senate,13,Dem,Bryan Hoffman,22,
-Cherokee,013 Galena W4,State House,1,Dem,write-in,4,
-Cherokee,013 Galena W4,US House,2,Rep,Vernon Fields,0,
-Cherokee,013 Galena W4,US House,2,Rep,Steve Fitzgerald,4,
-Cherokee,013 Galena W4,US House,2,Rep,Kevin Jones,8,
-Cherokee,013 Galena W4,US House,2,Rep,Doug Mays,4,
-Cherokee,013 Galena W4,US House,2,Rep,Dennis Pyle,2,
-Cherokee,013 Galena W4,US House,2,Rep,Caron Tyson,8,
-Cherokee,013 Galena W4,US House,2,Rep,Steve Watkins,14,
-Cherokee,013 Galena W4,Governor,,Rep,Jim Barnett,3,
-Cherokee,013 Galena W4,Governor,,Rep,Jeff Colyer,15,
-Cherokee,013 Galena W4,Governor,,Rep,Kris Kobach,21,
-Cherokee,013 Galena W4,Governor,,Rep,Patrick Kucera,0,
-Cherokee,013 Galena W4,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,013 Galena W4,Governor,,Rep,Ken Selzer,1,
-Cherokee,013 Galena W4,Governor,,Rep,Joseph Tutera,0,
-Cherokee,013 Galena W4,Secretary of  State,,Rep,Randy Duncan,8,
-Cherokee,013 Galena W4,Secretary of  State,,Rep,Keith Esau,4,
-Cherokee,013 Galena W4,Secretary of  State,,Rep,Craig McCullah,6,
-Cherokee,013 Galena W4,Secretary of  State,,Rep,Scott Schwab,8,
-Cherokee,013 Galena W4,Secretary of  State,,Rep,Dennis Taylor,9,
-Cherokee,013 Galena W4,Attorney General,,Rep,Derek Schmidt,32,
-Cherokee,013 Galena W4,State Treasurer,,Rep,Jake LaTurner,42,
-Cherokee,013 Galena W4,Insurance Commissioner,,Rep,Vicki Schmidt,24,
-Cherokee,013 Galena W4,Insurance Commissioner,,Rep,Clark Shultz,14,
-Cherokee,013 Galena W4,State Senate,13,Rep,Richard Hilderbrand,39,
-Cherokee,013 Galena W4,State House,1,Rep,Michael Houser,36,
-Cherokee,014 Scammon W1,Registered,,,Registered,72,
-Cherokee,014 Scammon W1,Ballots,,Dem,Ballots,13,
-Cherokee,014 Scammon W1,Ballots,,Rep,Ballots,12,
-Cherokee,014 Scammon W1,US House,2,Dem,Paul Davis,13,
-Cherokee,014 Scammon W1,Governor,,Dem,Arden Andersen,1,
-Cherokee,014 Scammon W1,Governor,,Dem,Jack Bergeson,2,
-Cherokee,014 Scammon W1,Governor,,Dem,Carl Brewer,0,
-Cherokee,014 Scammon W1,Governor,,Dem,Laura Kelly,3,
-Cherokee,014 Scammon W1,Governor,,Dem,Joshua Svaty,7,
-Cherokee,014 Scammon W1,Secretary of State,,Dem,Brian McClendon,12,
-Cherokee,014 Scammon W1,Attorney General,,Dem,Sarah Swain,12,
-Cherokee,014 Scammon W1,State Treasurer,,Dem,Marci Francisco,13,
-Cherokee,014 Scammon W1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,12,
-Cherokee,014 Scammon W1,State Senate,13,Dem,Bryan Hoffman,12,
-Cherokee,014 Scammon W1,State House,1,Dem,write-in,5,
-Cherokee,014 Scammon W1,US House,2,Rep,Vernon Fields,0,
-Cherokee,014 Scammon W1,US House,2,Rep,Steve Fitzgerald,2,
-Cherokee,014 Scammon W1,US House,2,Rep,Kevin Jones,1,
-Cherokee,014 Scammon W1,US House,2,Rep,Doug Mays,0,
-Cherokee,014 Scammon W1,US House,2,Rep,Dennis Pyle,1,
-Cherokee,014 Scammon W1,US House,2,Rep,Caron Tyson,2,
-Cherokee,014 Scammon W1,US House,2,Rep,Steve Watkins,5,
-Cherokee,014 Scammon W1,Governor,,Rep,Jim Barnett,0,
-Cherokee,014 Scammon W1,Governor,,Rep,Jeff Colyer,6,
-Cherokee,014 Scammon W1,Governor,,Rep,Kris Kobach,5,
-Cherokee,014 Scammon W1,Governor,,Rep,Patrick Kucera,0,
-Cherokee,014 Scammon W1,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,014 Scammon W1,Governor,,Rep,Ken Selzer,1,
-Cherokee,014 Scammon W1,Governor,,Rep,Joseph Tutera,0,
-Cherokee,014 Scammon W1,Secretary of  State,,Rep,Randy Duncan,4,
-Cherokee,014 Scammon W1,Secretary of  State,,Rep,Keith Esau,0,
-Cherokee,014 Scammon W1,Secretary of  State,,Rep,Craig McCullah,3,
-Cherokee,014 Scammon W1,Secretary of  State,,Rep,Scott Schwab,2,
-Cherokee,014 Scammon W1,Secretary of  State,,Rep,Dennis Taylor,2,
-Cherokee,014 Scammon W1,Attorney General,,Rep,Derek Schmidt,11,
-Cherokee,014 Scammon W1,State Treasurer,,Rep,Jake LaTurner,12,
-Cherokee,014 Scammon W1,Insurance Commissioner,,Rep,Vicki Schmidt,8,
-Cherokee,014 Scammon W1,Insurance Commissioner,,Rep,Clark Shultz,4,
-Cherokee,014 Scammon W1,State Senate,13,Rep,Richard Hilderbrand,11,
-Cherokee,014 Scammon W1,State House,1,Rep,Michael Houser,12,
-Cherokee,015 Scammon W2,Registered,,,Registered,97,
-Cherokee,015 Scammon W2,Ballots,,Dem,Ballots,12,
-Cherokee,015 Scammon W2,Ballots,,Rep,Ballots,6,
-Cherokee,015 Scammon W2,US House,2,Dem,Paul Davis,8,
-Cherokee,015 Scammon W2,Governor,,Dem,Arden Andersen,1,
-Cherokee,015 Scammon W2,Governor,,Dem,Jack Bergeson,0,
-Cherokee,015 Scammon W2,Governor,,Dem,Carl Brewer,3,
-Cherokee,015 Scammon W2,Governor,,Dem,Laura Kelly,3,
-Cherokee,015 Scammon W2,Governor,,Dem,Joshua Svaty,3,
-Cherokee,015 Scammon W2,Secretary of State,,Dem,Brian McClendon,8,
-Cherokee,015 Scammon W2,Attorney General,,Dem,Sarah Swain,10,
-Cherokee,015 Scammon W2,State Treasurer,,Dem,Marci Francisco,7,
-Cherokee,015 Scammon W2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,9,
-Cherokee,015 Scammon W2,State Senate,13,Dem,Bryan Hoffman,10,
-Cherokee,015 Scammon W2,State House,1,Dem,write-in,2,
-Cherokee,015 Scammon W2,US House,2,Rep,Vernon Fields,0,
-Cherokee,015 Scammon W2,US House,2,Rep,Steve Fitzgerald,0,
-Cherokee,015 Scammon W2,US House,2,Rep,Kevin Jones,0,
-Cherokee,015 Scammon W2,US House,2,Rep,Doug Mays,0,
-Cherokee,015 Scammon W2,US House,2,Rep,Dennis Pyle,0,
-Cherokee,015 Scammon W2,US House,2,Rep,Caron Tyson,3,
-Cherokee,015 Scammon W2,US House,2,Rep,Steve Watkins,3,
-Cherokee,015 Scammon W2,Governor,,Rep,Jim Barnett,1,
-Cherokee,015 Scammon W2,Governor,,Rep,Jeff Colyer,3,
-Cherokee,015 Scammon W2,Governor,,Rep,Kris Kobach,2,
-Cherokee,015 Scammon W2,Governor,,Rep,Patrick Kucera,0,
-Cherokee,015 Scammon W2,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,015 Scammon W2,Governor,,Rep,Ken Selzer,0,
-Cherokee,015 Scammon W2,Governor,,Rep,Joseph Tutera,0,
-Cherokee,015 Scammon W2,Secretary of  State,,Rep,Randy Duncan,3,
-Cherokee,015 Scammon W2,Secretary of  State,,Rep,Keith Esau,0,
-Cherokee,015 Scammon W2,Secretary of  State,,Rep,Craig McCullah,0,
-Cherokee,015 Scammon W2,Secretary of  State,,Rep,Scott Schwab,3,
-Cherokee,015 Scammon W2,Secretary of  State,,Rep,Dennis Taylor,0,
-Cherokee,015 Scammon W2,Attorney General,,Rep,Derek Schmidt,6,
-Cherokee,015 Scammon W2,State Treasurer,,Rep,Jake LaTurner,6,
-Cherokee,015 Scammon W2,Insurance Commissioner,,Rep,Vicki Schmidt,6,
-Cherokee,015 Scammon W2,Insurance Commissioner,,Rep,Clark Shultz,0,
-Cherokee,015 Scammon W2,State Senate,13,Rep,Richard Hilderbrand,5,
-Cherokee,015 Scammon W2,State House,1,Rep,Michael Houser,6,
-Cherokee,016 Scammon W3,Registered,,,Registered,152,
-Cherokee,016 Scammon W3,Ballots,,Dem,Ballots,13,
-Cherokee,016 Scammon W3,Ballots,,Rep,Ballots,14,
-Cherokee,016 Scammon W3,US House,2,Dem,Paul Davis,12,
-Cherokee,016 Scammon W3,Governor,,Dem,Arden Andersen,2,
-Cherokee,016 Scammon W3,Governor,,Dem,Jack Bergeson,1,
-Cherokee,016 Scammon W3,Governor,,Dem,Carl Brewer,1,
-Cherokee,016 Scammon W3,Governor,,Dem,Laura Kelly,2,
-Cherokee,016 Scammon W3,Governor,,Dem,Joshua Svaty,6,
-Cherokee,016 Scammon W3,Secretary of State,,Dem,Brian McClendon,11,
-Cherokee,016 Scammon W3,Attorney General,,Dem,Sarah Swain,10,
-Cherokee,016 Scammon W3,State Treasurer,,Dem,Marci Francisco,11,
-Cherokee,016 Scammon W3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,10,
-Cherokee,016 Scammon W3,State Senate,13,Dem,Bryan Hoffman,11,
-Cherokee,016 Scammon W3,State House,1,Dem,write-in,1,
-Cherokee,016 Scammon W3,US House,2,Rep,Vernon Fields,0,
-Cherokee,016 Scammon W3,US House,2,Rep,Steve Fitzgerald,5,
-Cherokee,016 Scammon W3,US House,2,Rep,Kevin Jones,2,
-Cherokee,016 Scammon W3,US House,2,Rep,Doug Mays,0,
-Cherokee,016 Scammon W3,US House,2,Rep,Dennis Pyle,1,
-Cherokee,016 Scammon W3,US House,2,Rep,Caron Tyson,1,
-Cherokee,016 Scammon W3,US House,2,Rep,Steve Watkins,4,
-Cherokee,016 Scammon W3,Governor,,Rep,Jim Barnett,0,
-Cherokee,016 Scammon W3,Governor,,Rep,Jeff Colyer,3,
-Cherokee,016 Scammon W3,Governor,,Rep,Kris Kobach,7,
-Cherokee,016 Scammon W3,Governor,,Rep,Patrick Kucera,1,
-Cherokee,016 Scammon W3,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,016 Scammon W3,Governor,,Rep,Ken Selzer,1,
-Cherokee,016 Scammon W3,Governor,,Rep,Joseph Tutera,1,
-Cherokee,016 Scammon W3,Secretary of  State,,Rep,Randy Duncan,2,
-Cherokee,016 Scammon W3,Secretary of  State,,Rep,Keith Esau,3,
-Cherokee,016 Scammon W3,Secretary of  State,,Rep,Craig McCullah,1,
-Cherokee,016 Scammon W3,Secretary of  State,,Rep,Scott Schwab,2,
-Cherokee,016 Scammon W3,Secretary of  State,,Rep,Dennis Taylor,3,
-Cherokee,016 Scammon W3,Attorney General,,Rep,Derek Schmidt,13,
-Cherokee,016 Scammon W3,State Treasurer,,Rep,Jake LaTurner,13,
-Cherokee,016 Scammon W3,Insurance Commissioner,,Rep,Vicki Schmidt,5,
-Cherokee,016 Scammon W3,Insurance Commissioner,,Rep,Clark Shultz,7,
-Cherokee,016 Scammon W3,State Senate,13,Rep,Richard Hilderbrand,11,
-Cherokee,016 Scammon W3,State House,1,Rep,Michael Houser,11,
-Cherokee,017 Weir City,Registered,,,Registered,497,
-Cherokee,017 Weir City,Ballots,,Dem,Ballots,51,
-Cherokee,017 Weir City,Ballots,,Rep,Ballots,60,
-Cherokee,017 Weir City,US House,2,Dem,Paul Davis,42,
-Cherokee,017 Weir City,Governor,,Dem,Arden Andersen,1,
-Cherokee,017 Weir City,Governor,,Dem,Jack Bergeson,6,
-Cherokee,017 Weir City,Governor,,Dem,Carl Brewer,5,
-Cherokee,017 Weir City,Governor,,Dem,Laura Kelly,26,
-Cherokee,017 Weir City,Governor,,Dem,Joshua Svaty,10,
-Cherokee,017 Weir City,Secretary of State,,Dem,Brian McClendon,41,
-Cherokee,017 Weir City,Attorney General,,Dem,Sarah Swain,40,
-Cherokee,017 Weir City,State Treasurer,,Dem,Marci Francisco,42,
-Cherokee,017 Weir City,Insurance Commissioner,,Dem,Nathaniel McLaughlin,42,
-Cherokee,017 Weir City,State Senate,13,Dem,Bryan Hoffman,43,
-Cherokee,017 Weir City,State House,1,Dem,write-in,14,
-Cherokee,017 Weir City,US House,2,Rep,Vernon Fields,3,
-Cherokee,017 Weir City,US House,2,Rep,Steve Fitzgerald,2,
-Cherokee,017 Weir City,US House,2,Rep,Kevin Jones,11,
-Cherokee,017 Weir City,US House,2,Rep,Doug Mays,3,
-Cherokee,017 Weir City,US House,2,Rep,Dennis Pyle,9,
-Cherokee,017 Weir City,US House,2,Rep,Caron Tyson,9,
-Cherokee,017 Weir City,US House,2,Rep,Steve Watkins,22,
-Cherokee,017 Weir City,Governor,,Rep,Jim Barnett,2,
-Cherokee,017 Weir City,Governor,,Rep,Jeff Colyer,21,
-Cherokee,017 Weir City,Governor,,Rep,Kris Kobach,32,
-Cherokee,017 Weir City,Governor,,Rep,Patrick Kucera,1,
-Cherokee,017 Weir City,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,017 Weir City,Governor,,Rep,Ken Selzer,3,
-Cherokee,017 Weir City,Governor,,Rep,Joseph Tutera,0,
-Cherokee,017 Weir City,Secretary of  State,,Rep,Randy Duncan,15,
-Cherokee,017 Weir City,Secretary of  State,,Rep,Keith Esau,7,
-Cherokee,017 Weir City,Secretary of  State,,Rep,Craig McCullah,7,
-Cherokee,017 Weir City,Secretary of  State,,Rep,Scott Schwab,18,
-Cherokee,017 Weir City,Secretary of  State,,Rep,Dennis Taylor,7,
-Cherokee,017 Weir City,Attorney General,,Rep,Derek Schmidt,56,
-Cherokee,017 Weir City,State Treasurer,,Rep,Jake LaTurner,54,
-Cherokee,017 Weir City,Insurance Commissioner,,Rep,Vicki Schmidt,34,
-Cherokee,017 Weir City,Insurance Commissioner,,Rep,Clark Shultz,24,
-Cherokee,017 Weir City,State Senate,13,Rep,Richard Hilderbrand,54,
-Cherokee,017 Weir City,State House,1,Rep,Michael Houser,56,
-Cherokee,018 Cherokee,Registered,,,Registered,249,
-Cherokee,018 Cherokee,Ballots,,Dem,Ballots,27,
-Cherokee,018 Cherokee,Ballots,,Rep,Ballots,45,
-Cherokee,018 Cherokee,US House,2,Dem,Paul Davis,25,
-Cherokee,018 Cherokee,Governor,,Dem,Arden Andersen,2,
-Cherokee,018 Cherokee,Governor,,Dem,Jack Bergeson,1,
-Cherokee,018 Cherokee,Governor,,Dem,Carl Brewer,5,
-Cherokee,018 Cherokee,Governor,,Dem,Laura Kelly,13,
-Cherokee,018 Cherokee,Governor,,Dem,Joshua Svaty,5,
-Cherokee,018 Cherokee,Secretary of State,,Dem,Brian McClendon,24,
-Cherokee,018 Cherokee,Attorney General,,Dem,Sarah Swain,25,
-Cherokee,018 Cherokee,State Treasurer,,Dem,Marci Francisco,23,
-Cherokee,018 Cherokee,Insurance Commissioner,,Dem,Nathaniel McLaughlin,23,
-Cherokee,018 Cherokee,State Senate,13,Dem,Bryan Hoffman,25,
-Cherokee,018 Cherokee,State House,1,Dem,write-in,4,
-Cherokee,018 Cherokee,US House,2,Rep,Vernon Fields,0,
-Cherokee,018 Cherokee,US House,2,Rep,Steve Fitzgerald,3,
-Cherokee,018 Cherokee,US House,2,Rep,Kevin Jones,8,
-Cherokee,018 Cherokee,US House,2,Rep,Doug Mays,2,
-Cherokee,018 Cherokee,US House,2,Rep,Dennis Pyle,11,
-Cherokee,018 Cherokee,US House,2,Rep,Caron Tyson,11,
-Cherokee,018 Cherokee,US House,2,Rep,Steve Watkins,8,
-Cherokee,018 Cherokee,Governor,,Rep,Jim Barnett,0,
-Cherokee,018 Cherokee,Governor,,Rep,Jeff Colyer,22,
-Cherokee,018 Cherokee,Governor,,Rep,Kris Kobach,18,
-Cherokee,018 Cherokee,Governor,,Rep,Patrick Kucera,0,
-Cherokee,018 Cherokee,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,018 Cherokee,Governor,,Rep,Ken Selzer,5,
-Cherokee,018 Cherokee,Governor,,Rep,Joseph Tutera,0,
-Cherokee,018 Cherokee,Secretary of  State,,Rep,Randy Duncan,13,
-Cherokee,018 Cherokee,Secretary of  State,,Rep,Keith Esau,2,
-Cherokee,018 Cherokee,Secretary of  State,,Rep,Craig McCullah,3,
-Cherokee,018 Cherokee,Secretary of  State,,Rep,Scott Schwab,15,
-Cherokee,018 Cherokee,Secretary of  State,,Rep,Dennis Taylor,9,
-Cherokee,018 Cherokee,Attorney General,,Rep,Derek Schmidt,37,
-Cherokee,018 Cherokee,State Treasurer,,Rep,Jake LaTurner,40,
-Cherokee,018 Cherokee,Insurance Commissioner,,Rep,Vicki Schmidt,20,
-Cherokee,018 Cherokee,Insurance Commissioner,,Rep,Clark Shultz,19,
-Cherokee,018 Cherokee,State Senate,13,Rep,Richard Hilderbrand,38,
-Cherokee,018 Cherokee,State House,1,Rep,Michael Houser,40,
-Cherokee,019 Crawford,Registered,,,Registered,482,
-Cherokee,019 Crawford,Ballots,,Dem,Ballots,32,
-Cherokee,019 Crawford,Ballots,,Rep,Ballots,77,
-Cherokee,019 Crawford,US House,2,Dem,Paul Davis,29,
-Cherokee,019 Crawford,Governor,,Dem,Arden Andersen,1,
-Cherokee,019 Crawford,Governor,,Dem,Jack Bergeson,2,
-Cherokee,019 Crawford,Governor,,Dem,Carl Brewer,3,
-Cherokee,019 Crawford,Governor,,Dem,Laura Kelly,13,
-Cherokee,019 Crawford,Governor,,Dem,Joshua Svaty,13,
-Cherokee,019 Crawford,Secretary of State,,Dem,Brian McClendon,27,
-Cherokee,019 Crawford,Attorney General,,Dem,Sarah Swain,28,
-Cherokee,019 Crawford,State Treasurer,,Dem,Marci Francisco,27,
-Cherokee,019 Crawford,Insurance Commissioner,,Dem,Nathaniel McLaughlin,27,
-Cherokee,019 Crawford,State Senate,13,Dem,Bryan Hoffman,31,
-Cherokee,019 Crawford,State House,1,Dem,write-in,3,
-Cherokee,019 Crawford,US House,2,Rep,Vernon Fields,0,
-Cherokee,019 Crawford,US House,2,Rep,Steve Fitzgerald,4,
-Cherokee,019 Crawford,US House,2,Rep,Kevin Jones,10,
-Cherokee,019 Crawford,US House,2,Rep,Doug Mays,4,
-Cherokee,019 Crawford,US House,2,Rep,Dennis Pyle,11,
-Cherokee,019 Crawford,US House,2,Rep,Caron Tyson,33,
-Cherokee,019 Crawford,US House,2,Rep,Steve Watkins,12,
-Cherokee,019 Crawford,Governor,,Rep,Jim Barnett,3,
-Cherokee,019 Crawford,Governor,,Rep,Jeff Colyer,33,
-Cherokee,019 Crawford,Governor,,Rep,Kris Kobach,34,
-Cherokee,019 Crawford,Governor,,Rep,Patrick Kucera,0,
-Cherokee,019 Crawford,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,019 Crawford,Governor,,Rep,Ken Selzer,4,
-Cherokee,019 Crawford,Governor,,Rep,Joseph Tutera,1,
-Cherokee,019 Crawford,Secretary of  State,,Rep,Randy Duncan,22,
-Cherokee,019 Crawford,Secretary of  State,,Rep,Keith Esau,8,
-Cherokee,019 Crawford,Secretary of  State,,Rep,Craig McCullah,5,
-Cherokee,019 Crawford,Secretary of  State,,Rep,Scott Schwab,24,
-Cherokee,019 Crawford,Secretary of  State,,Rep,Dennis Taylor,12,
-Cherokee,019 Crawford,Attorney General,,Rep,Derek Schmidt,65,
-Cherokee,019 Crawford,State Treasurer,,Rep,Jake LaTurner,66,
-Cherokee,019 Crawford,Insurance Commissioner,,Rep,Vicki Schmidt,37,
-Cherokee,019 Crawford,Insurance Commissioner,,Rep,Clark Shultz,34,
-Cherokee,019 Crawford,State Senate,13,Rep,Richard Hilderbrand,69,
-Cherokee,019 Crawford,State House,1,Rep,Michael Houser,71,
-Cherokee,020 Garden-Lowell,Registered,,,Registered,1534,
-Cherokee,020 Garden-Lowell,Ballots,,Dem,Ballots,125,
-Cherokee,020 Garden-Lowell,Ballots,,Rep,Ballots,210,
-Cherokee,020 Garden-Lowell,US House,2,Dem,Paul Davis,110,
-Cherokee,020 Garden-Lowell,Governor,,Dem,Arden Andersen,7,
-Cherokee,020 Garden-Lowell,Governor,,Dem,Jack Bergeson,7,
-Cherokee,020 Garden-Lowell,Governor,,Dem,Carl Brewer,13,
-Cherokee,020 Garden-Lowell,Governor,,Dem,Laura Kelly,37,
-Cherokee,020 Garden-Lowell,Governor,,Dem,Joshua Svaty,58,
-Cherokee,020 Garden-Lowell,Secretary of State,,Dem,Brian McClendon,115,
-Cherokee,020 Garden-Lowell,Attorney General,,Dem,Sarah Swain,117,
-Cherokee,020 Garden-Lowell,State Treasurer,,Dem,Marci Francisco,114,
-Cherokee,020 Garden-Lowell,Insurance Commissioner,,Dem,Nathaniel McLaughlin,116,
-Cherokee,020 Garden-Lowell,State Senate,13,Dem,Bryan Hoffman,115,
-Cherokee,020 Garden-Lowell,State House,1,Dem,write-in,22,
-Cherokee,020 Garden-Lowell,US House,2,Rep,Vernon Fields,4,
-Cherokee,020 Garden-Lowell,US House,2,Rep,Steve Fitzgerald,19,
-Cherokee,020 Garden-Lowell,US House,2,Rep,Kevin Jones,52,
-Cherokee,020 Garden-Lowell,US House,2,Rep,Doug Mays,12,
-Cherokee,020 Garden-Lowell,US House,2,Rep,Dennis Pyle,25,
-Cherokee,020 Garden-Lowell,US House,2,Rep,Caron Tyson,35,
-Cherokee,020 Garden-Lowell,US House,2,Rep,Steve Watkins,57,
-Cherokee,020 Garden-Lowell,Governor,,Rep,Jim Barnett,10,
-Cherokee,020 Garden-Lowell,Governor,,Rep,Jeff Colyer,53,
-Cherokee,020 Garden-Lowell,Governor,,Rep,Kris Kobach,116,
-Cherokee,020 Garden-Lowell,Governor,,Rep,Patrick Kucera,2,
-Cherokee,020 Garden-Lowell,Governor,,Rep,Tyler Ruzich,2,
-Cherokee,020 Garden-Lowell,Governor,,Rep,Ken Selzer,20,
-Cherokee,020 Garden-Lowell,Governor,,Rep,Joseph Tutera,1,
-Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Randy Duncan,44,
-Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Keith Esau,33,
-Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Craig McCullah,22,
-Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Scott Schwab,52,
-Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Dennis Taylor,37,
-Cherokee,020 Garden-Lowell,Attorney General,,Rep,Derek Schmidt,179,
-Cherokee,020 Garden-Lowell,State Treasurer,,Rep,Jake LaTurner,182,
-Cherokee,020 Garden-Lowell,Insurance Commissioner,,Rep,Vicki Schmidt,100,
-Cherokee,020 Garden-Lowell,Insurance Commissioner,,Rep,Clark Shultz,87,
-Cherokee,020 Garden-Lowell,State Senate,13,Rep,Richard Hilderbrand,190,
-Cherokee,020 Garden-Lowell,State House,1,Rep,Michael Houser,182,
-Cherokee,021 Garden-Stanley Mines,Registered,,,Registered,520,
-Cherokee,021 Garden-Stanley Mines,Ballots,,Dem,Ballots,16,
-Cherokee,021 Garden-Stanley Mines,Ballots,,Rep,Ballots,87,
-Cherokee,021 Garden-Stanley Mines,US House,2,Dem,Paul Davis,14,
-Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Arden Andersen,2,
-Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Jack Bergeson,1,
-Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Carl Brewer,4,
-Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Laura Kelly,4,
-Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Joshua Svaty,5,
-Cherokee,021 Garden-Stanley Mines,Secretary of State,,Dem,Brian McClendon,14,
-Cherokee,021 Garden-Stanley Mines,Attorney General,,Dem,Sarah Swain,13,
-Cherokee,021 Garden-Stanley Mines,State Treasurer,,Dem,Marci Francisco,12,
-Cherokee,021 Garden-Stanley Mines,Insurance Commissioner,,Dem,Nathaniel McLaughlin,13,
-Cherokee,021 Garden-Stanley Mines,State Senate,13,Dem,Bryan Hoffman,13,
-Cherokee,021 Garden-Stanley Mines,State House,1,Dem,write-in,4,
-Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Vernon Fields,0,
-Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Steve Fitzgerald,6,
-Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Kevin Jones,22,
-Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Doug Mays,7,
-Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Dennis Pyle,10,
-Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Caron Tyson,9,
-Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Steve Watkins,25,
-Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Jim Barnett,8,
-Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Jeff Colyer,24,
-Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Kris Kobach,42,
-Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Patrick Kucera,1,
-Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Tyler Ruzich,1,
-Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Ken Selzer,6,
-Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Joseph Tutera,1,
-Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Randy Duncan,20,
-Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Keith Esau,4,
-Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Craig McCullah,12,
-Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Scott Schwab,22,
-Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Dennis Taylor,16,
-Cherokee,021 Garden-Stanley Mines,Attorney General,,Rep,Derek Schmidt,72,
-Cherokee,021 Garden-Stanley Mines,State Treasurer,,Rep,Jake LaTurner,70,
-Cherokee,021 Garden-Stanley Mines,Insurance Commissioner,,Rep,Vicki Schmidt,48,
-Cherokee,021 Garden-Stanley Mines,Insurance Commissioner,,Rep,Clark Shultz,28,
-Cherokee,021 Garden-Stanley Mines,State Senate,13,Rep,Richard Hilderbrand,79,
-Cherokee,021 Garden-Stanley Mines,State House,1,Rep,Michael Houser,70,
-Cherokee,022 Lola,Registered,,,Registered,238,
-Cherokee,022 Lola,Ballots,,Dem,Ballots,14,
-Cherokee,022 Lola,Ballots,,Rep,Ballots,31,
-Cherokee,022 Lola,US House,2,Dem,Paul Davis,13,
-Cherokee,022 Lola,Governor,,Dem,Arden Andersen,1,
-Cherokee,022 Lola,Governor,,Dem,Jack Bergeson,0,
-Cherokee,022 Lola,Governor,,Dem,Carl Brewer,2,
-Cherokee,022 Lola,Governor,,Dem,Laura Kelly,5,
-Cherokee,022 Lola,Governor,,Dem,Joshua Svaty,6,
-Cherokee,022 Lola,Secretary of State,,Dem,Brian McClendon,13,
-Cherokee,022 Lola,Attorney General,,Dem,Sarah Swain,12,
-Cherokee,022 Lola,State Treasurer,,Dem,Marci Francisco,13,
-Cherokee,022 Lola,Insurance Commissioner,,Dem,Nathaniel McLaughlin,13,
-Cherokee,022 Lola,State Senate,13,Dem,Bryan Hoffman,13,
-Cherokee,022 Lola,State House,1,Dem,write-in,1,
-Cherokee,022 Lola,US House,2,Rep,Vernon Fields,0,
-Cherokee,022 Lola,US House,2,Rep,Steve Fitzgerald,5,
-Cherokee,022 Lola,US House,2,Rep,Kevin Jones,7,
-Cherokee,022 Lola,US House,2,Rep,Doug Mays,2,
-Cherokee,022 Lola,US House,2,Rep,Dennis Pyle,3,
-Cherokee,022 Lola,US House,2,Rep,Caron Tyson,6,
-Cherokee,022 Lola,US House,2,Rep,Steve Watkins,8,
-Cherokee,022 Lola,Governor,,Rep,Jim Barnett,3,
-Cherokee,022 Lola,Governor,,Rep,Jeff Colyer,10,
-Cherokee,022 Lola,Governor,,Rep,Kris Kobach,13,
-Cherokee,022 Lola,Governor,,Rep,Patrick Kucera,0,
-Cherokee,022 Lola,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,022 Lola,Governor,,Rep,Ken Selzer,4,
-Cherokee,022 Lola,Governor,,Rep,Joseph Tutera,1,
-Cherokee,022 Lola,Secretary of  State,,Rep,Randy Duncan,3,
-Cherokee,022 Lola,Secretary of  State,,Rep,Keith Esau,5,
-Cherokee,022 Lola,Secretary of  State,,Rep,Craig McCullah,5,
-Cherokee,022 Lola,Secretary of  State,,Rep,Scott Schwab,7,
-Cherokee,022 Lola,Secretary of  State,,Rep,Dennis Taylor,6,
-Cherokee,022 Lola,Attorney General,,Rep,Derek Schmidt,27,
-Cherokee,022 Lola,State Treasurer,,Rep,Jake LaTurner,26,
-Cherokee,022 Lola,Insurance Commissioner,,Rep,Vicki Schmidt,13,
-Cherokee,022 Lola,Insurance Commissioner,,Rep,Clark Shultz,15,
-Cherokee,022 Lola,State Senate,13,Rep,Richard Hilderbrand,30,
-Cherokee,022 Lola,State House,1,Rep,Michael Houser,28,
-Cherokee,023 Lowell,Registered,,,Registered,510,
-Cherokee,023 Lowell,Ballots,,Dem,Ballots,38,
-Cherokee,023 Lowell,Ballots,,Rep,Ballots,91,
-Cherokee,023 Lowell,US House,2,Dem,Paul Davis,28,
-Cherokee,023 Lowell,Governor,,Dem,Arden Andersen,7,
-Cherokee,023 Lowell,Governor,,Dem,Jack Bergeson,5,
-Cherokee,023 Lowell,Governor,,Dem,Carl Brewer,2,
-Cherokee,023 Lowell,Governor,,Dem,Laura Kelly,6,
-Cherokee,023 Lowell,Governor,,Dem,Joshua Svaty,13,
-Cherokee,023 Lowell,Secretary of State,,Dem,Brian McClendon,32,
-Cherokee,023 Lowell,Attorney General,,Dem,Sarah Swain,31,
-Cherokee,023 Lowell,State Treasurer,,Dem,Marci Francisco,31,
-Cherokee,023 Lowell,Insurance Commissioner,,Dem,Nathaniel McLaughlin,30,
-Cherokee,023 Lowell,State Senate,13,Dem,Bryan Hoffman,30,
-Cherokee,023 Lowell,State House,1,Dem,write-in,3,
-Cherokee,023 Lowell,US House,2,Rep,Vernon Fields,1,
-Cherokee,023 Lowell,US House,2,Rep,Steve Fitzgerald,4,
-Cherokee,023 Lowell,US House,2,Rep,Kevin Jones,10,
-Cherokee,023 Lowell,US House,2,Rep,Doug Mays,2,
-Cherokee,023 Lowell,US House,2,Rep,Dennis Pyle,18,
-Cherokee,023 Lowell,US House,2,Rep,Caron Tyson,22,
-Cherokee,023 Lowell,US House,2,Rep,Steve Watkins,29,
-Cherokee,023 Lowell,Governor,,Rep,Jim Barnett,6,
-Cherokee,023 Lowell,Governor,,Rep,Jeff Colyer,34,
-Cherokee,023 Lowell,Governor,,Rep,Kris Kobach,41,
-Cherokee,023 Lowell,Governor,,Rep,Patrick Kucera,2,
-Cherokee,023 Lowell,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,023 Lowell,Governor,,Rep,Ken Selzer,3,
-Cherokee,023 Lowell,Governor,,Rep,Joseph Tutera,0,
-Cherokee,023 Lowell,Secretary of  State,,Rep,Randy Duncan,19,
-Cherokee,023 Lowell,Secretary of  State,,Rep,Keith Esau,13,
-Cherokee,023 Lowell,Secretary of  State,,Rep,Craig McCullah,15,
-Cherokee,023 Lowell,Secretary of  State,,Rep,Scott Schwab,14,
-Cherokee,023 Lowell,Secretary of  State,,Rep,Dennis Taylor,13,
-Cherokee,023 Lowell,Attorney General,,Rep,Derek Schmidt,76,
-Cherokee,023 Lowell,State Treasurer,,Rep,Jake LaTurner,80,
-Cherokee,023 Lowell,Insurance Commissioner,,Rep,Vicki Schmidt,51,
-Cherokee,023 Lowell,Insurance Commissioner,,Rep,Clark Shultz,26,
-Cherokee,023 Lowell,State Senate,13,Rep,Richard Hilderbrand,87,
-Cherokee,023 Lowell,State House,1,Rep,Michael Houser,77,
-Cherokee,024 Lyon-Lyon,Registered,,,Registered,276,
-Cherokee,024 Lyon-Lyon,Ballots,,Dem,Ballots,20,
-Cherokee,024 Lyon-Lyon,Ballots,,Rep,Ballots,47,
-Cherokee,024 Lyon-Lyon,US House,2,Dem,Paul Davis,13,
-Cherokee,024 Lyon-Lyon,Governor,,Dem,Arden Andersen,1,
-Cherokee,024 Lyon-Lyon,Governor,,Dem,Jack Bergeson,1,
-Cherokee,024 Lyon-Lyon,Governor,,Dem,Carl Brewer,6,
-Cherokee,024 Lyon-Lyon,Governor,,Dem,Laura Kelly,4,
-Cherokee,024 Lyon-Lyon,Governor,,Dem,Joshua Svaty,6,
-Cherokee,024 Lyon-Lyon,Secretary of State,,Dem,Brian McClendon,14,
-Cherokee,024 Lyon-Lyon,Attorney General,,Dem,Sarah Swain,16,
-Cherokee,024 Lyon-Lyon,State Treasurer,,Dem,Marci Francisco,16,
-Cherokee,024 Lyon-Lyon,Insurance Commissioner,,Dem,Nathaniel McLaughlin,14,
-Cherokee,024 Lyon-Lyon,State Senate,13,Dem,Bryan Hoffman,15,
-Cherokee,024 Lyon-Lyon,State House,1,Dem,write-in,1,
-Cherokee,024 Lyon-Lyon,US House,2,Rep,Vernon Fields,1,
-Cherokee,024 Lyon-Lyon,US House,2,Rep,Steve Fitzgerald,2,
-Cherokee,024 Lyon-Lyon,US House,2,Rep,Kevin Jones,5,
-Cherokee,024 Lyon-Lyon,US House,2,Rep,Doug Mays,0,
-Cherokee,024 Lyon-Lyon,US House,2,Rep,Dennis Pyle,8,
-Cherokee,024 Lyon-Lyon,US House,2,Rep,Caron Tyson,16,
-Cherokee,024 Lyon-Lyon,US House,2,Rep,Steve Watkins,15,
-Cherokee,024 Lyon-Lyon,Governor,,Rep,Jim Barnett,5,
-Cherokee,024 Lyon-Lyon,Governor,,Rep,Jeff Colyer,10,
-Cherokee,024 Lyon-Lyon,Governor,,Rep,Kris Kobach,28,
-Cherokee,024 Lyon-Lyon,Governor,,Rep,Patrick Kucera,0,
-Cherokee,024 Lyon-Lyon,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,024 Lyon-Lyon,Governor,,Rep,Ken Selzer,2,
-Cherokee,024 Lyon-Lyon,Governor,,Rep,Joseph Tutera,0,
-Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Randy Duncan,16,
-Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Keith Esau,4,
-Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Craig McCullah,6,
-Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Scott Schwab,12,
-Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Dennis Taylor,6,
-Cherokee,024 Lyon-Lyon,Attorney General,,Rep,Derek Schmidt,41,
-Cherokee,024 Lyon-Lyon,State Treasurer,,Rep,Jake LaTurner,44,
-Cherokee,024 Lyon-Lyon,Insurance Commissioner,,Rep,Vicki Schmidt,15,
-Cherokee,024 Lyon-Lyon,Insurance Commissioner,,Rep,Clark Shultz,28,
-Cherokee,024 Lyon-Lyon,State Senate,13,Rep,Richard Hilderbrand,39,
-Cherokee,024 Lyon-Lyon,State House,1,Rep,Michael Houser,40,
-Cherokee,025 Mineral,Registered,,,Registered,144,
-Cherokee,025 Mineral,Ballots,,Dem,Ballots,3,
-Cherokee,025 Mineral,Ballots,,Rep,Ballots,26,
-Cherokee,025 Mineral,US House,2,Dem,Paul Davis,2,
-Cherokee,025 Mineral,Governor,,Dem,Arden Andersen,0,
-Cherokee,025 Mineral,Governor,,Dem,Jack Bergeson,0,
-Cherokee,025 Mineral,Governor,,Dem,Carl Brewer,0,
-Cherokee,025 Mineral,Governor,,Dem,Laura Kelly,1,
-Cherokee,025 Mineral,Governor,,Dem,Joshua Svaty,2,
-Cherokee,025 Mineral,Secretary of State,,Dem,Brian McClendon,3,
-Cherokee,025 Mineral,Attorney General,,Dem,Sarah Swain,3,
-Cherokee,025 Mineral,State Treasurer,,Dem,Marci Francisco,3,
-Cherokee,025 Mineral,Insurance Commissioner,,Dem,Nathaniel McLaughlin,3,
-Cherokee,025 Mineral,State Senate,13,Dem,Bryan Hoffman,3,
-Cherokee,025 Mineral,State House,1,Dem,write-in,0,
-Cherokee,025 Mineral,US House,2,Rep,Vernon Fields,0,
-Cherokee,025 Mineral,US House,2,Rep,Steve Fitzgerald,3,
-Cherokee,025 Mineral,US House,2,Rep,Kevin Jones,3,
-Cherokee,025 Mineral,US House,2,Rep,Doug Mays,2,
-Cherokee,025 Mineral,US House,2,Rep,Dennis Pyle,1,
-Cherokee,025 Mineral,US House,2,Rep,Caron Tyson,14,
-Cherokee,025 Mineral,US House,2,Rep,Steve Watkins,0,
-Cherokee,025 Mineral,Governor,,Rep,Jim Barnett,0,
-Cherokee,025 Mineral,Governor,,Rep,Jeff Colyer,13,
-Cherokee,025 Mineral,Governor,,Rep,Kris Kobach,13,
-Cherokee,025 Mineral,Governor,,Rep,Patrick Kucera,0,
-Cherokee,025 Mineral,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,025 Mineral,Governor,,Rep,Ken Selzer,0,
-Cherokee,025 Mineral,Governor,,Rep,Joseph Tutera,0,
-Cherokee,025 Mineral,Secretary of  State,,Rep,Randy Duncan,9,
-Cherokee,025 Mineral,Secretary of  State,,Rep,Keith Esau,1,
-Cherokee,025 Mineral,Secretary of  State,,Rep,Craig McCullah,1,
-Cherokee,025 Mineral,Secretary of  State,,Rep,Scott Schwab,7,
-Cherokee,025 Mineral,Secretary of  State,,Rep,Dennis Taylor,3,
-Cherokee,025 Mineral,Attorney General,,Rep,Derek Schmidt,19,
-Cherokee,025 Mineral,State Treasurer,,Rep,Jake LaTurner,20,
-Cherokee,025 Mineral,Insurance Commissioner,,Rep,Vicki Schmidt,12,
-Cherokee,025 Mineral,Insurance Commissioner,,Rep,Clark Shultz,11,
-Cherokee,025 Mineral,State Senate,13,Rep,Richard Hilderbrand,19,
-Cherokee,025 Mineral,State House,1,Rep,Michael Houser,22,
-Cherokee,026 Neosho-Faulkner,Registered,,,Registered,85,
-Cherokee,026 Neosho-Faulkner,Ballots,,Dem,Ballots,2,
-Cherokee,026 Neosho-Faulkner,Ballots,,Rep,Ballots,12,
-Cherokee,026 Neosho-Faulkner,US House,2,Dem,Paul Davis,2,
-Cherokee,026 Neosho-Faulkner,Governor,,Dem,Arden Andersen,0,
-Cherokee,026 Neosho-Faulkner,Governor,,Dem,Jack Bergeson,0,
-Cherokee,026 Neosho-Faulkner,Governor,,Dem,Carl Brewer,0,
-Cherokee,026 Neosho-Faulkner,Governor,,Dem,Laura Kelly,1,
-Cherokee,026 Neosho-Faulkner,Governor,,Dem,Joshua Svaty,1,
-Cherokee,026 Neosho-Faulkner,Secretary of State,,Dem,Brian McClendon,2,
-Cherokee,026 Neosho-Faulkner,Attorney General,,Dem,Sarah Swain,2,
-Cherokee,026 Neosho-Faulkner,State Treasurer,,Dem,Marci Francisco,2,
-Cherokee,026 Neosho-Faulkner,Insurance Commissioner,,Dem,Nathaniel McLaughlin,2,
-Cherokee,026 Neosho-Faulkner,State Senate,13,Dem,Bryan Hoffman,2,
-Cherokee,026 Neosho-Faulkner,State House,1,Dem,write-in,0,
-Cherokee,026 Neosho-Faulkner,US House,2,Rep,Vernon Fields,0,
-Cherokee,026 Neosho-Faulkner,US House,2,Rep,Steve Fitzgerald,5,
-Cherokee,026 Neosho-Faulkner,US House,2,Rep,Kevin Jones,0,
-Cherokee,026 Neosho-Faulkner,US House,2,Rep,Doug Mays,0,
-Cherokee,026 Neosho-Faulkner,US House,2,Rep,Dennis Pyle,0,
-Cherokee,026 Neosho-Faulkner,US House,2,Rep,Caron Tyson,5,
-Cherokee,026 Neosho-Faulkner,US House,2,Rep,Steve Watkins,2,
-Cherokee,026 Neosho-Faulkner,Governor,,Rep,Jim Barnett,0,
-Cherokee,026 Neosho-Faulkner,Governor,,Rep,Jeff Colyer,6,
-Cherokee,026 Neosho-Faulkner,Governor,,Rep,Kris Kobach,5,
-Cherokee,026 Neosho-Faulkner,Governor,,Rep,Patrick Kucera,0,
-Cherokee,026 Neosho-Faulkner,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,026 Neosho-Faulkner,Governor,,Rep,Ken Selzer,1,
-Cherokee,026 Neosho-Faulkner,Governor,,Rep,Joseph Tutera,0,
-Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Randy Duncan,1,
-Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Keith Esau,1,
-Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Craig McCullah,0,
-Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Scott Schwab,6,
-Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Dennis Taylor,2,
-Cherokee,026 Neosho-Faulkner,Attorney General,,Rep,Derek Schmidt,11,
-Cherokee,026 Neosho-Faulkner,State Treasurer,,Rep,Jake LaTurner,11,
-Cherokee,026 Neosho-Faulkner,Insurance Commissioner,,Rep,Vicki Schmidt,6,
-Cherokee,026 Neosho-Faulkner,Insurance Commissioner,,Rep,Clark Shultz,5,
-Cherokee,026 Neosho-Faulkner,State Senate,13,Rep,Richard Hilderbrand,11,
-Cherokee,026 Neosho-Faulkner,State House,1,Rep,Michael Houser,11,
-Cherokee,027 Neosho-Melrose,Registered,,,Registered,118,p131
-Cherokee,027 Neosho-Melrose,Ballots,,Dem,Ballots,5,
-Cherokee,027 Neosho-Melrose,Ballots,,Rep,Ballots,16,
-Cherokee,027 Neosho-Melrose,US House,2,Dem,Paul Davis,3,
-Cherokee,027 Neosho-Melrose,Governor,,Dem,Arden Andersen,1,
-Cherokee,027 Neosho-Melrose,Governor,,Dem,Jack Bergeson,0,
-Cherokee,027 Neosho-Melrose,Governor,,Dem,Carl Brewer,3,
-Cherokee,027 Neosho-Melrose,Governor,,Dem,Laura Kelly,0,
-Cherokee,027 Neosho-Melrose,Governor,,Dem,Joshua Svaty,0,
-Cherokee,027 Neosho-Melrose,Secretary of State,,Dem,Brian McClendon,3,
-Cherokee,027 Neosho-Melrose,Attorney General,,Dem,Sarah Swain,3,
-Cherokee,027 Neosho-Melrose,State Treasurer,,Dem,Marci Francisco,3,
-Cherokee,027 Neosho-Melrose,Insurance Commissioner,,Dem,Nathaniel McLaughlin,3,
-Cherokee,027 Neosho-Melrose,State Senate,13,Dem,Bryan Hoffman,3,
-Cherokee,027 Neosho-Melrose,State House,1,Dem,write-in,1,
-Cherokee,027 Neosho-Melrose,US House,2,Rep,Vernon Fields,2,
-Cherokee,027 Neosho-Melrose,US House,2,Rep,Steve Fitzgerald,2,
-Cherokee,027 Neosho-Melrose,US House,2,Rep,Kevin Jones,5,
-Cherokee,027 Neosho-Melrose,US House,2,Rep,Doug Mays,1,
-Cherokee,027 Neosho-Melrose,US House,2,Rep,Dennis Pyle,3,
-Cherokee,027 Neosho-Melrose,US House,2,Rep,Caron Tyson,1,
-Cherokee,027 Neosho-Melrose,US House,2,Rep,Steve Watkins,2,
-Cherokee,027 Neosho-Melrose,Governor,,Rep,Jim Barnett,0,
-Cherokee,027 Neosho-Melrose,Governor,,Rep,Jeff Colyer,2,
-Cherokee,027 Neosho-Melrose,Governor,,Rep,Kris Kobach,12,
-Cherokee,027 Neosho-Melrose,Governor,,Rep,Patrick Kucera,0,
-Cherokee,027 Neosho-Melrose,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,027 Neosho-Melrose,Governor,,Rep,Ken Selzer,2,
-Cherokee,027 Neosho-Melrose,Governor,,Rep,Joseph Tutera,0,
-Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Randy Duncan,5,
-Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Keith Esau,1,
-Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Craig McCullah,1,
-Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Scott Schwab,6,
-Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Dennis Taylor,1,
-Cherokee,027 Neosho-Melrose,Attorney General,,Rep,Derek Schmidt,13,
-Cherokee,027 Neosho-Melrose,State Treasurer,,Rep,Jake LaTurner,14,
-Cherokee,027 Neosho-Melrose,Insurance Commissioner,,Rep,Vicki Schmidt,8,
-Cherokee,027 Neosho-Melrose,Insurance Commissioner,,Rep,Clark Shultz,8,
-Cherokee,027 Neosho-Melrose,State Senate,13,Rep,Richard Hilderbrand,15,
-Cherokee,027 Neosho-Melrose,State House,1,Rep,Michael Houser,13,
-Cherokee,028 Pleasant View,Registered,,,Registered,457,
-Cherokee,028 Pleasant View,Ballots,,Dem,Ballots,31,
-Cherokee,028 Pleasant View,Ballots,,Rep,Ballots,79,
-Cherokee,028 Pleasant View,US House,2,Dem,Paul Davis,27,
-Cherokee,028 Pleasant View,Governor,,Dem,Arden Andersen,6,
-Cherokee,028 Pleasant View,Governor,,Dem,Jack Bergeson,3,
-Cherokee,028 Pleasant View,Governor,,Dem,Carl Brewer,1,
-Cherokee,028 Pleasant View,Governor,,Dem,Laura Kelly,11,
-Cherokee,028 Pleasant View,Governor,,Dem,Joshua Svaty,8,
-Cherokee,028 Pleasant View,Secretary of State,,Dem,Brian McClendon,27,
-Cherokee,028 Pleasant View,Attorney General,,Dem,Sarah Swain,27,
-Cherokee,028 Pleasant View,State Treasurer,,Dem,Marci Francisco,29,
-Cherokee,028 Pleasant View,Insurance Commissioner,,Dem,Nathaniel McLaughlin,29,
-Cherokee,028 Pleasant View,State Senate,13,Dem,Bryan Hoffman,29,
-Cherokee,028 Pleasant View,State House,1,Dem,write-in,5,
-Cherokee,028 Pleasant View,US House,2,Rep,Vernon Fields,3,
-Cherokee,028 Pleasant View,US House,2,Rep,Steve Fitzgerald,7,
-Cherokee,028 Pleasant View,US House,2,Rep,Kevin Jones,6,
-Cherokee,028 Pleasant View,US House,2,Rep,Doug Mays,6,
-Cherokee,028 Pleasant View,US House,2,Rep,Dennis Pyle,8,
-Cherokee,028 Pleasant View,US House,2,Rep,Caron Tyson,29,
-Cherokee,028 Pleasant View,US House,2,Rep,Steve Watkins,18,
-Cherokee,028 Pleasant View,Governor,,Rep,Jim Barnett,10,
-Cherokee,028 Pleasant View,Governor,,Rep,Jeff Colyer,19,
-Cherokee,028 Pleasant View,Governor,,Rep,Kris Kobach,41,
-Cherokee,028 Pleasant View,Governor,,Rep,Patrick Kucera,0,
-Cherokee,028 Pleasant View,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,028 Pleasant View,Governor,,Rep,Ken Selzer,7,
-Cherokee,028 Pleasant View,Governor,,Rep,Joseph Tutera,0,
-Cherokee,028 Pleasant View,Secretary of  State,,Rep,Randy Duncan,26,
-Cherokee,028 Pleasant View,Secretary of  State,,Rep,Keith Esau,8,
-Cherokee,028 Pleasant View,Secretary of  State,,Rep,Craig McCullah,8,
-Cherokee,028 Pleasant View,Secretary of  State,,Rep,Scott Schwab,11,
-Cherokee,028 Pleasant View,Secretary of  State,,Rep,Dennis Taylor,14,
-Cherokee,028 Pleasant View,Attorney General,,Rep,Derek Schmidt,67,
-Cherokee,028 Pleasant View,State Treasurer,,Rep,Jake LaTurner,69,
-Cherokee,028 Pleasant View,Insurance Commissioner,,Rep,Vicki Schmidt,34,
-Cherokee,028 Pleasant View,Insurance Commissioner,,Rep,Clark Shultz,40,
-Cherokee,028 Pleasant View,State Senate,13,Rep,Richard Hilderbrand,67,
-Cherokee,028 Pleasant View,State House,1,Rep,Michael Houser,68,
-Cherokee,029 Ross-Belleview,Registered,,,Registered,134,
-Cherokee,029 Ross-Belleview,Ballots,,Dem,Ballots,7,
-Cherokee,029 Ross-Belleview,Ballots,,Rep,Ballots,24,
-Cherokee,029 Ross-Belleview,US House,2,Dem,Paul Davis,5,
-Cherokee,029 Ross-Belleview,Governor,,Dem,Arden Andersen,1,
-Cherokee,029 Ross-Belleview,Governor,,Dem,Jack Bergeson,1,
-Cherokee,029 Ross-Belleview,Governor,,Dem,Carl Brewer,1,
-Cherokee,029 Ross-Belleview,Governor,,Dem,Laura Kelly,2,
-Cherokee,029 Ross-Belleview,Governor,,Dem,Joshua Svaty,2,
-Cherokee,029 Ross-Belleview,Secretary of State,,Dem,Brian McClendon,4,
-Cherokee,029 Ross-Belleview,Attorney General,,Dem,Sarah Swain,5,
-Cherokee,029 Ross-Belleview,State Treasurer,,Dem,Marci Francisco,6,
-Cherokee,029 Ross-Belleview,Insurance Commissioner,,Dem,Nathaniel McLaughlin,5,
-Cherokee,029 Ross-Belleview,State Senate,13,Dem,Bryan Hoffman,6,
-Cherokee,029 Ross-Belleview,State House,1,Dem,write-in,1,
-Cherokee,029 Ross-Belleview,US House,2,Rep,Vernon Fields,2,
-Cherokee,029 Ross-Belleview,US House,2,Rep,Steve Fitzgerald,3,
-Cherokee,029 Ross-Belleview,US House,2,Rep,Kevin Jones,1,
-Cherokee,029 Ross-Belleview,US House,2,Rep,Doug Mays,3,
-Cherokee,029 Ross-Belleview,US House,2,Rep,Dennis Pyle,2,
-Cherokee,029 Ross-Belleview,US House,2,Rep,Caron Tyson,7,
-Cherokee,029 Ross-Belleview,US House,2,Rep,Steve Watkins,5,
-Cherokee,029 Ross-Belleview,Governor,,Rep,Jim Barnett,0,
-Cherokee,029 Ross-Belleview,Governor,,Rep,Jeff Colyer,11,
-Cherokee,029 Ross-Belleview,Governor,,Rep,Kris Kobach,10,
-Cherokee,029 Ross-Belleview,Governor,,Rep,Patrick Kucera,0,
-Cherokee,029 Ross-Belleview,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,029 Ross-Belleview,Governor,,Rep,Ken Selzer,2,
-Cherokee,029 Ross-Belleview,Governor,,Rep,Joseph Tutera,0,
-Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Randy Duncan,6,
-Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Keith Esau,2,
-Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Craig McCullah,2,
-Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Scott Schwab,9,
-Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Dennis Taylor,1,
-Cherokee,029 Ross-Belleview,Attorney General,,Rep,Derek Schmidt,18,
-Cherokee,029 Ross-Belleview,State Treasurer,,Rep,Jake LaTurner,21,
-Cherokee,029 Ross-Belleview,Insurance Commissioner,,Rep,Vicki Schmidt,14,
-Cherokee,029 Ross-Belleview,Insurance Commissioner,,Rep,Clark Shultz,8,
-Cherokee,029 Ross-Belleview,State Senate,13,Rep,Richard Hilderbrand,22,
-Cherokee,029 Ross-Belleview,State House,1,Rep,Michael Houser,23,
-Cherokee,030 Ross-Roseland,Registered,,,Registered,193,
-Cherokee,030 Ross-Roseland,Ballots,,Dem,Ballots,20,
-Cherokee,030 Ross-Roseland,Ballots,,Rep,Ballots,25,
-Cherokee,030 Ross-Roseland,US House,2,Dem,Paul Davis,17,
-Cherokee,030 Ross-Roseland,Governor,,Dem,Arden Andersen,2,
-Cherokee,030 Ross-Roseland,Governor,,Dem,Jack Bergeson,0,
-Cherokee,030 Ross-Roseland,Governor,,Dem,Carl Brewer,3,
-Cherokee,030 Ross-Roseland,Governor,,Dem,Laura Kelly,7,
-Cherokee,030 Ross-Roseland,Governor,,Dem,Joshua Svaty,7,
-Cherokee,030 Ross-Roseland,Secretary of State,,Dem,Brian McClendon,19,
-Cherokee,030 Ross-Roseland,Attorney General,,Dem,Sarah Swain,19,
-Cherokee,030 Ross-Roseland,State Treasurer,,Dem,Marci Francisco,19,
-Cherokee,030 Ross-Roseland,Insurance Commissioner,,Dem,Nathaniel McLaughlin,18,
-Cherokee,030 Ross-Roseland,State Senate,13,Dem,Bryan Hoffman,19,
-Cherokee,030 Ross-Roseland,State House,1,Dem,write-in,3,
-Cherokee,030 Ross-Roseland,US House,2,Rep,Vernon Fields,1,
-Cherokee,030 Ross-Roseland,US House,2,Rep,Steve Fitzgerald,0,
-Cherokee,030 Ross-Roseland,US House,2,Rep,Kevin Jones,4,
-Cherokee,030 Ross-Roseland,US House,2,Rep,Doug Mays,2,
-Cherokee,030 Ross-Roseland,US House,2,Rep,Dennis Pyle,4,
-Cherokee,030 Ross-Roseland,US House,2,Rep,Caron Tyson,8,
-Cherokee,030 Ross-Roseland,US House,2,Rep,Steve Watkins,4,
-Cherokee,030 Ross-Roseland,Governor,,Rep,Jim Barnett,1,
-Cherokee,030 Ross-Roseland,Governor,,Rep,Jeff Colyer,10,
-Cherokee,030 Ross-Roseland,Governor,,Rep,Kris Kobach,13,
-Cherokee,030 Ross-Roseland,Governor,,Rep,Patrick Kucera,0,
-Cherokee,030 Ross-Roseland,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,030 Ross-Roseland,Governor,,Rep,Ken Selzer,1,
-Cherokee,030 Ross-Roseland,Governor,,Rep,Joseph Tutera,0,
-Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Randy Duncan,9,
-Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Keith Esau,2,
-Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Craig McCullah,3,
-Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Scott Schwab,6,
-Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Dennis Taylor,2,
-Cherokee,030 Ross-Roseland,Attorney General,,Rep,Derek Schmidt,20,
-Cherokee,030 Ross-Roseland,State Treasurer,,Rep,Jake LaTurner,20,
-Cherokee,030 Ross-Roseland,Insurance Commissioner,,Rep,Vicki Schmidt,13,
-Cherokee,030 Ross-Roseland,Insurance Commissioner,,Rep,Clark Shultz,9,
-Cherokee,030 Ross-Roseland,State Senate,13,Rep,Richard Hilderbrand,21,
-Cherokee,030 Ross-Roseland,State House,1,Rep,Michael Houser,22,
-Cherokee,031 Ross-West Mineral,Registered,,,Registered,159,
-Cherokee,031 Ross-West Mineral,Ballots,,Dem,Ballots,25,
-Cherokee,031 Ross-West Mineral,Ballots,,Rep,Ballots,22,
-Cherokee,031 Ross-West Mineral,US House,2,Dem,Paul Davis,23,
-Cherokee,031 Ross-West Mineral,Governor,,Dem,Arden Andersen,6,
-Cherokee,031 Ross-West Mineral,Governor,,Dem,Jack Bergeson,2,
-Cherokee,031 Ross-West Mineral,Governor,,Dem,Carl Brewer,7,
-Cherokee,031 Ross-West Mineral,Governor,,Dem,Laura Kelly,3,
-Cherokee,031 Ross-West Mineral,Governor,,Dem,Joshua Svaty,4,
-Cherokee,031 Ross-West Mineral,Secretary of State,,Dem,Brian McClendon,22,
-Cherokee,031 Ross-West Mineral,Attorney General,,Dem,Sarah Swain,23,
-Cherokee,031 Ross-West Mineral,State Treasurer,,Dem,Marci Francisco,22,
-Cherokee,031 Ross-West Mineral,Insurance Commissioner,,Dem,Nathaniel McLaughlin,24,
-Cherokee,031 Ross-West Mineral,State Senate,13,Dem,Bryan Hoffman,23,
-Cherokee,031 Ross-West Mineral,State House,1,Dem,write-in,1,
-Cherokee,031 Ross-West Mineral,US House,2,Rep,Vernon Fields,0,
-Cherokee,031 Ross-West Mineral,US House,2,Rep,Steve Fitzgerald,4,
-Cherokee,031 Ross-West Mineral,US House,2,Rep,Kevin Jones,0,
-Cherokee,031 Ross-West Mineral,US House,2,Rep,Doug Mays,2,
-Cherokee,031 Ross-West Mineral,US House,2,Rep,Dennis Pyle,1,
-Cherokee,031 Ross-West Mineral,US House,2,Rep,Caron Tyson,6,
-Cherokee,031 Ross-West Mineral,US House,2,Rep,Steve Watkins,8,
-Cherokee,031 Ross-West Mineral,Governor,,Rep,Jim Barnett,1,
-Cherokee,031 Ross-West Mineral,Governor,,Rep,Jeff Colyer,5,
-Cherokee,031 Ross-West Mineral,Governor,,Rep,Kris Kobach,12,
-Cherokee,031 Ross-West Mineral,Governor,,Rep,Patrick Kucera,0,
-Cherokee,031 Ross-West Mineral,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,031 Ross-West Mineral,Governor,,Rep,Ken Selzer,2,
-Cherokee,031 Ross-West Mineral,Governor,,Rep,Joseph Tutera,1,
-Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Randy Duncan,1,
-Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Keith Esau,2,
-Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Craig McCullah,4,
-Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Scott Schwab,3,
-Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Dennis Taylor,6,
-Cherokee,031 Ross-West Mineral,Attorney General,,Rep,Derek Schmidt,17,
-Cherokee,031 Ross-West Mineral,State Treasurer,,Rep,Jake LaTurner,18,
-Cherokee,031 Ross-West Mineral,Insurance Commissioner,,Rep,Vicki Schmidt,8,
-Cherokee,031 Ross-West Mineral,Insurance Commissioner,,Rep,Clark Shultz,11,
-Cherokee,031 Ross-West Mineral,State Senate,13,Rep,Richard Hilderbrand,19,
-Cherokee,031 Ross-West Mineral,State House,1,Rep,Michael Houser,21,
-Cherokee,032 Salamanca,Registered,,,Registered,416,
-Cherokee,032 Salamanca,Ballots,,Dem,Ballots,31,
-Cherokee,032 Salamanca,Ballots,,Rep,Ballots,62,
-Cherokee,032 Salamanca,US House,2,Dem,Paul Davis,27,
-Cherokee,032 Salamanca,Governor,,Dem,Arden Andersen,5,
-Cherokee,032 Salamanca,Governor,,Dem,Jack Bergeson,0,
-Cherokee,032 Salamanca,Governor,,Dem,Carl Brewer,2,
-Cherokee,032 Salamanca,Governor,,Dem,Laura Kelly,10,
-Cherokee,032 Salamanca,Governor,,Dem,Joshua Svaty,14,
-Cherokee,032 Salamanca,Secretary of State,,Dem,Brian McClendon,27,
-Cherokee,032 Salamanca,Attorney General,,Dem,Sarah Swain,27,
-Cherokee,032 Salamanca,State Treasurer,,Dem,Marci Francisco,26,
-Cherokee,032 Salamanca,Insurance Commissioner,,Dem,Nathaniel McLaughlin,26,
-Cherokee,032 Salamanca,State Senate,13,Dem,Bryan Hoffman,27,
-Cherokee,032 Salamanca,State House,1,Dem,write-in,3,
-Cherokee,032 Salamanca,US House,2,Rep,Vernon Fields,0,
-Cherokee,032 Salamanca,US House,2,Rep,Steve Fitzgerald,7,
-Cherokee,032 Salamanca,US House,2,Rep,Kevin Jones,1,
-Cherokee,032 Salamanca,US House,2,Rep,Doug Mays,1,
-Cherokee,032 Salamanca,US House,2,Rep,Dennis Pyle,5,
-Cherokee,032 Salamanca,US House,2,Rep,Caron Tyson,32,
-Cherokee,032 Salamanca,US House,2,Rep,Steve Watkins,13,
-Cherokee,032 Salamanca,Governor,,Rep,Jim Barnett,2,
-Cherokee,032 Salamanca,Governor,,Rep,Jeff Colyer,23,
-Cherokee,032 Salamanca,Governor,,Rep,Kris Kobach,32,
-Cherokee,032 Salamanca,Governor,,Rep,Patrick Kucera,0,
-Cherokee,032 Salamanca,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,032 Salamanca,Governor,,Rep,Ken Selzer,4,
-Cherokee,032 Salamanca,Governor,,Rep,Joseph Tutera,0,
-Cherokee,032 Salamanca,Secretary of  State,,Rep,Randy Duncan,15,
-Cherokee,032 Salamanca,Secretary of  State,,Rep,Keith Esau,6,
-Cherokee,032 Salamanca,Secretary of  State,,Rep,Craig McCullah,5,
-Cherokee,032 Salamanca,Secretary of  State,,Rep,Scott Schwab,17,
-Cherokee,032 Salamanca,Secretary of  State,,Rep,Dennis Taylor,12,
-Cherokee,032 Salamanca,Attorney General,,Rep,Derek Schmidt,49,
-Cherokee,032 Salamanca,State Treasurer,,Rep,Jake LaTurner,52,
-Cherokee,032 Salamanca,Insurance Commissioner,,Rep,Vicki Schmidt,34,
-Cherokee,032 Salamanca,Insurance Commissioner,,Rep,Clark Shultz,23,
-Cherokee,032 Salamanca,State Senate,13,Rep,Richard Hilderbrand,53,
-Cherokee,032 Salamanca,State House,1,Rep,Michael Houser,53,
-Cherokee,033 Shawnee,Registered,,,Registered,349,
-Cherokee,033 Shawnee,Ballots,,Dem,Ballots,26,
-Cherokee,033 Shawnee,Ballots,,Rep,Ballots,97,
-Cherokee,033 Shawnee,US House,2,Dem,Paul Davis,19,
-Cherokee,033 Shawnee,Governor,,Dem,Arden Andersen,3,
-Cherokee,033 Shawnee,Governor,,Dem,Jack Bergeson,3,
-Cherokee,033 Shawnee,Governor,,Dem,Carl Brewer,5,
-Cherokee,033 Shawnee,Governor,,Dem,Laura Kelly,9,
-Cherokee,033 Shawnee,Governor,,Dem,Joshua Svaty,4,
-Cherokee,033 Shawnee,Secretary of State,,Dem,Brian McClendon,19,
-Cherokee,033 Shawnee,Attorney General,,Dem,Sarah Swain,21,
-Cherokee,033 Shawnee,State Treasurer,,Dem,Marci Francisco,20,
-Cherokee,033 Shawnee,Insurance Commissioner,,Dem,Nathaniel McLaughlin,20,
-Cherokee,033 Shawnee,State Senate,13,Dem,Bryan Hoffman,21,
-Cherokee,033 Shawnee,State House,1,Dem,write-in,3,
-Cherokee,033 Shawnee,US House,2,Rep,Vernon Fields,2,
-Cherokee,033 Shawnee,US House,2,Rep,Steve Fitzgerald,13,
-Cherokee,033 Shawnee,US House,2,Rep,Kevin Jones,22,
-Cherokee,033 Shawnee,US House,2,Rep,Doug Mays,1,
-Cherokee,033 Shawnee,US House,2,Rep,Dennis Pyle,12,
-Cherokee,033 Shawnee,US House,2,Rep,Caron Tyson,32,
-Cherokee,033 Shawnee,US House,2,Rep,Steve Watkins,10,
-Cherokee,033 Shawnee,Governor,,Rep,Jim Barnett,3,
-Cherokee,033 Shawnee,Governor,,Rep,Jeff Colyer,30,
-Cherokee,033 Shawnee,Governor,,Rep,Kris Kobach,52,
-Cherokee,033 Shawnee,Governor,,Rep,Patrick Kucera,3,
-Cherokee,033 Shawnee,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,033 Shawnee,Governor,,Rep,Ken Selzer,3,
-Cherokee,033 Shawnee,Governor,,Rep,Joseph Tutera,0,
-Cherokee,033 Shawnee,Secretary of  State,,Rep,Randy Duncan,31,
-Cherokee,033 Shawnee,Secretary of  State,,Rep,Keith Esau,8,
-Cherokee,033 Shawnee,Secretary of  State,,Rep,Craig McCullah,9,
-Cherokee,033 Shawnee,Secretary of  State,,Rep,Scott Schwab,27,
-Cherokee,033 Shawnee,Secretary of  State,,Rep,Dennis Taylor,10,
-Cherokee,033 Shawnee,Attorney General,,Rep,Derek Schmidt,81,
-Cherokee,033 Shawnee,State Treasurer,,Rep,Jake LaTurner,86,
-Cherokee,033 Shawnee,Insurance Commissioner,,Rep,Vicki Schmidt,50,
-Cherokee,033 Shawnee,Insurance Commissioner,,Rep,Clark Shultz,36,
-Cherokee,033 Shawnee,State Senate,13,Rep,Richard Hilderbrand,85,
-Cherokee,033 Shawnee,State House,1,Rep,Michael Houser,83,
-Cherokee,034 Sheridan,Registered,,,Registered,163,p165
-Cherokee,034 Sheridan,Ballots,,Dem,Ballots,11,
-Cherokee,034 Sheridan,Ballots,,Rep,Ballots,34,
-Cherokee,034 Sheridan,US House,2,Dem,Paul Davis,11,
-Cherokee,034 Sheridan,Governor,,Dem,Arden Andersen,1,
-Cherokee,034 Sheridan,Governor,,Dem,Jack Bergeson,0,
-Cherokee,034 Sheridan,Governor,,Dem,Carl Brewer,3,
-Cherokee,034 Sheridan,Governor,,Dem,Laura Kelly,4,
-Cherokee,034 Sheridan,Governor,,Dem,Joshua Svaty,3,
-Cherokee,034 Sheridan,Secretary of State,,Dem,Brian McClendon,10,
-Cherokee,034 Sheridan,Attorney General,,Dem,Sarah Swain,11,
-Cherokee,034 Sheridan,State Treasurer,,Dem,Marci Francisco,10,
-Cherokee,034 Sheridan,Insurance Commissioner,,Dem,Nathaniel McLaughlin,10,
-Cherokee,034 Sheridan,State Senate,13,Dem,Bryan Hoffman,11,
-Cherokee,034 Sheridan,State House,1,Dem,write-in,3,
-Cherokee,034 Sheridan,US House,2,Rep,Vernon Fields,0,
-Cherokee,034 Sheridan,US House,2,Rep,Steve Fitzgerald,6,
-Cherokee,034 Sheridan,US House,2,Rep,Kevin Jones,5,
-Cherokee,034 Sheridan,US House,2,Rep,Doug Mays,2,
-Cherokee,034 Sheridan,US House,2,Rep,Dennis Pyle,2,
-Cherokee,034 Sheridan,US House,2,Rep,Caron Tyson,17,
-Cherokee,034 Sheridan,US House,2,Rep,Steve Watkins,2,
-Cherokee,034 Sheridan,Governor,,Rep,Jim Barnett,1,
-Cherokee,034 Sheridan,Governor,,Rep,Jeff Colyer,18,
-Cherokee,034 Sheridan,Governor,,Rep,Kris Kobach,15,
-Cherokee,034 Sheridan,Governor,,Rep,Patrick Kucera,0,
-Cherokee,034 Sheridan,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,034 Sheridan,Governor,,Rep,Ken Selzer,0,
-Cherokee,034 Sheridan,Governor,,Rep,Joseph Tutera,0,
-Cherokee,034 Sheridan,Secretary of  State,,Rep,Randy Duncan,7,
-Cherokee,034 Sheridan,Secretary of  State,,Rep,Keith Esau,5,
-Cherokee,034 Sheridan,Secretary of  State,,Rep,Craig McCullah,3,
-Cherokee,034 Sheridan,Secretary of  State,,Rep,Scott Schwab,12,
-Cherokee,034 Sheridan,Secretary of  State,,Rep,Dennis Taylor,5,
-Cherokee,034 Sheridan,Attorney General,,Rep,Derek Schmidt,33,
-Cherokee,034 Sheridan,State Treasurer,,Rep,Jake LaTurner,32,
-Cherokee,034 Sheridan,Insurance Commissioner,,Rep,Vicki Schmidt,18,
-Cherokee,034 Sheridan,Insurance Commissioner,,Rep,Clark Shultz,15,
-Cherokee,034 Sheridan,State Senate,13,Rep,Richard Hilderbrand,31,
-Cherokee,034 Sheridan,State House,1,Rep,Michael Houser,32,
-Cherokee,035 Spring Valley-Neutral,Registered,,,Registered,471,
-Cherokee,035 Spring Valley-Neutral,Ballots,,Dem,Ballots,34,
-Cherokee,035 Spring Valley-Neutral,Ballots,,Rep,Ballots,72,
-Cherokee,035 Spring Valley-Neutral,US House,2,Dem,Paul Davis,29,
-Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Arden Andersen,0,
-Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Jack Bergeson,1,
-Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Carl Brewer,3,
-Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Laura Kelly,5,
-Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Joshua Svaty,23,
-Cherokee,035 Spring Valley-Neutral,Secretary of State,,Dem,Brian McClendon,29,
-Cherokee,035 Spring Valley-Neutral,Attorney General,,Dem,Sarah Swain,32,
-Cherokee,035 Spring Valley-Neutral,State Treasurer,,Dem,Marci Francisco,32,
-Cherokee,035 Spring Valley-Neutral,Insurance Commissioner,,Dem,Nathaniel McLaughlin,29,
-Cherokee,035 Spring Valley-Neutral,State Senate,13,Dem,Bryan Hoffman,30,
-Cherokee,035 Spring Valley-Neutral,State House,1,Dem,write-in,5,
-Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Vernon Fields,5,
-Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Steve Fitzgerald,7,
-Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Kevin Jones,9,
-Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Doug Mays,2,
-Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Dennis Pyle,10,
-Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Caron Tyson,16,
-Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Steve Watkins,22,
-Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Jim Barnett,3,
-Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Jeff Colyer,32,
-Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Kris Kobach,31,
-Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Patrick Kucera,2,
-Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Ken Selzer,3,
-Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Joseph Tutera,0,
-Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Randy Duncan,22,
-Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Keith Esau,3,
-Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Craig McCullah,8,
-Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Scott Schwab,20,
-Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Dennis Taylor,14,
-Cherokee,035 Spring Valley-Neutral,Attorney General,,Rep,Derek Schmidt,64,
-Cherokee,035 Spring Valley-Neutral,State Treasurer,,Rep,Jake LaTurner,63,
-Cherokee,035 Spring Valley-Neutral,Insurance Commissioner,,Rep,Vicki Schmidt,42,
-Cherokee,035 Spring Valley-Neutral,Insurance Commissioner,,Rep,Clark Shultz,29,
-Cherokee,035 Spring Valley-Neutral,State Senate,13,Rep,Richard Hilderbrand,65,
-Cherokee,035 Spring Valley-Neutral,State House,1,Rep,Michael Houser,64,
-Cherokee,036 Spring Valley-Spring Valley,Registered,,,Registered,345,
-Cherokee,036 Spring Valley-Spring Valley,Ballots,,Dem,Ballots,15,
-Cherokee,036 Spring Valley-Spring Valley,Ballots,,Rep,Ballots,43,
-Cherokee,036 Spring Valley-Spring Valley,US House,2,Dem,Paul Davis,11,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Arden Andersen,0,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Jack Bergeson,0,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Carl Brewer,0,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Laura Kelly,3,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Joshua Svaty,10,
-Cherokee,036 Spring Valley-Spring Valley,Secretary of State,,Dem,Brian McClendon,9,
-Cherokee,036 Spring Valley-Spring Valley,Attorney General,,Dem,Sarah Swain,11,
-Cherokee,036 Spring Valley-Spring Valley,State Treasurer,,Dem,Marci Francisco,10,
-Cherokee,036 Spring Valley-Spring Valley,Insurance Commissioner,,Dem,Nathaniel McLaughlin,10,
-Cherokee,036 Spring Valley-Spring Valley,State Senate,13,Dem,Bryan Hoffman,12,
-Cherokee,036 Spring Valley-Spring Valley,State House,1,Dem,write-in,2,
-Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Vernon Fields,1,
-Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Steve Fitzgerald,3,
-Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Kevin Jones,6,
-Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Doug Mays,1,
-Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Dennis Pyle,4,
-Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Caron Tyson,10,
-Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Steve Watkins,15,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Jim Barnett,0,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Jeff Colyer,14,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Kris Kobach,23,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Patrick Kucera,3,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Tyler Ruzich,0,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Ken Selzer,2,
-Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Joseph Tutera,0,
-Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Randy Duncan,17,
-Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Keith Esau,4,
-Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Craig McCullah,3,
-Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Scott Schwab,9,
-Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Dennis Taylor,3,
-Cherokee,036 Spring Valley-Spring Valley,Attorney General,,Rep,Derek Schmidt,37,
-Cherokee,036 Spring Valley-Spring Valley,State Treasurer,,Rep,Jake LaTurner,39,
-Cherokee,036 Spring Valley-Spring Valley,Insurance Commissioner,,Rep,Vicki Schmidt,18,
-Cherokee,036 Spring Valley-Spring Valley,Insurance Commissioner,,Rep,Clark Shultz,16,
-Cherokee,036 Spring Valley-Spring Valley,State Senate,13,Rep,Richard Hilderbrand,39,
-Cherokee,036 Spring Valley-Spring Valley,State House,1,Rep,Michael Houser,37,
+county,precinct,office,district,party,candidate,votes
+Cherokee,01 Baxter Sprs W1,Registered,,,Registered,658
+Cherokee,01 Baxter Sprs W1,Ballots,,Dem,Ballots,30
+Cherokee,01 Baxter Sprs W1,Ballots,,Rep,Ballots,52
+Cherokee,01 Baxter Sprs W1,US House,2,Dem,Paul Davis,25
+Cherokee,01 Baxter Sprs W1,Governor,,Dem,Arden Andersen,1
+Cherokee,01 Baxter Sprs W1,Governor,,Dem,Jack Bergeson,3
+Cherokee,01 Baxter Sprs W1,Governor,,Dem,Carl Brewer,1
+Cherokee,01 Baxter Sprs W1,Governor,,Dem,Laura Kelly,7
+Cherokee,01 Baxter Sprs W1,Governor,,Dem,Joshua Svaty,15
+Cherokee,01 Baxter Sprs W1,Secretary of State,,Dem,Brian McClendon,24
+Cherokee,01 Baxter Sprs W1,Attorney General,,Dem,Sarah Swain,26
+Cherokee,01 Baxter Sprs W1,State Treasurer,,Dem,Marci Francisco,26
+Cherokee,01 Baxter Sprs W1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,25
+Cherokee,01 Baxter Sprs W1,State Senate,13,Dem,Bryan Hoffman,25
+Cherokee,01 Baxter Sprs W1,State House,1,Dem,write-in,6
+Cherokee,01 Baxter Sprs W1,US House,2,Rep,Vernon Fields,2
+Cherokee,01 Baxter Sprs W1,US House,2,Rep,Steve Fitzgerald,4
+Cherokee,01 Baxter Sprs W1,US House,2,Rep,Kevin Jones,5
+Cherokee,01 Baxter Sprs W1,US House,2,Rep,Doug Mays,1
+Cherokee,01 Baxter Sprs W1,US House,2,Rep,Dennis Pyle,8
+Cherokee,01 Baxter Sprs W1,US House,2,Rep,Caron Tyson,10
+Cherokee,01 Baxter Sprs W1,US House,2,Rep,Steve Watkins,19
+Cherokee,01 Baxter Sprs W1,Governor,,Rep,Jim Barnett,2
+Cherokee,01 Baxter Sprs W1,Governor,,Rep,Jeff Colyer,15
+Cherokee,01 Baxter Sprs W1,Governor,,Rep,Kris Kobach,27
+Cherokee,01 Baxter Sprs W1,Governor,,Rep,Patrick Kucera,0
+Cherokee,01 Baxter Sprs W1,Governor,,Rep,Tyler Ruzich,0
+Cherokee,01 Baxter Sprs W1,Governor,,Rep,Ken Selzer,7
+Cherokee,01 Baxter Sprs W1,Governor,,Rep,Joseph Tutera,0
+Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Randy Duncan,10
+Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Keith Esau,6
+Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Craig McCullah,7
+Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Scott Schwab,10
+Cherokee,01 Baxter Sprs W1,Secretary of  State,,Rep,Dennis Taylor,14
+Cherokee,01 Baxter Sprs W1,Attorney General,,Rep,Derek Schmidt,47
+Cherokee,01 Baxter Sprs W1,State Treasurer,,Rep,Jake LaTurner,46
+Cherokee,01 Baxter Sprs W1,Insurance Commissioner,,Rep,Vicki Schmidt,28
+Cherokee,01 Baxter Sprs W1,Insurance Commissioner,,Rep,Clark Shultz,20
+Cherokee,01 Baxter Sprs W1,State Senate,13,Rep,Richard Hilderbrand,47
+Cherokee,01 Baxter Sprs W1,State House,1,Rep,Michael Houser,46
+Cherokee,02 Baxter Sprs W2,Registered,,,Registered,760
+Cherokee,02 Baxter Sprs W2,Ballots,,Dem,Ballots,11
+Cherokee,02 Baxter Sprs W2,Ballots,,Rep,Ballots,39
+Cherokee,02 Baxter Sprs W2,US House,2,Dem,Paul Davis,8
+Cherokee,02 Baxter Sprs W2,Governor,,Dem,Arden Andersen,1
+Cherokee,02 Baxter Sprs W2,Governor,,Dem,Jack Bergeson,1
+Cherokee,02 Baxter Sprs W2,Governor,,Dem,Carl Brewer,1
+Cherokee,02 Baxter Sprs W2,Governor,,Dem,Laura Kelly,1
+Cherokee,02 Baxter Sprs W2,Governor,,Dem,Joshua Svaty,5
+Cherokee,02 Baxter Sprs W2,Secretary of State,,Dem,Brian McClendon,10
+Cherokee,02 Baxter Sprs W2,Attorney General,,Dem,Sarah Swain,10
+Cherokee,02 Baxter Sprs W2,State Treasurer,,Dem,Marci Francisco,10
+Cherokee,02 Baxter Sprs W2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,10
+Cherokee,02 Baxter Sprs W2,State Senate,13,Dem,Bryan Hoffman,10
+Cherokee,02 Baxter Sprs W2,State House,1,Dem,write-in,2
+Cherokee,02 Baxter Sprs W2,US House,2,Rep,Vernon Fields,1
+Cherokee,02 Baxter Sprs W2,US House,2,Rep,Steve Fitzgerald,8
+Cherokee,02 Baxter Sprs W2,US House,2,Rep,Kevin Jones,3
+Cherokee,02 Baxter Sprs W2,US House,2,Rep,Doug Mays,2
+Cherokee,02 Baxter Sprs W2,US House,2,Rep,Dennis Pyle,6
+Cherokee,02 Baxter Sprs W2,US House,2,Rep,Caron Tyson,7
+Cherokee,02 Baxter Sprs W2,US House,2,Rep,Steve Watkins,11
+Cherokee,02 Baxter Sprs W2,Governor,,Rep,Jim Barnett,2
+Cherokee,02 Baxter Sprs W2,Governor,,Rep,Jeff Colyer,13
+Cherokee,02 Baxter Sprs W2,Governor,,Rep,Kris Kobach,18
+Cherokee,02 Baxter Sprs W2,Governor,,Rep,Patrick Kucera,1
+Cherokee,02 Baxter Sprs W2,Governor,,Rep,Tyler Ruzich,0
+Cherokee,02 Baxter Sprs W2,Governor,,Rep,Ken Selzer,3
+Cherokee,02 Baxter Sprs W2,Governor,,Rep,Joseph Tutera,0
+Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Randy Duncan,8
+Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Keith Esau,3
+Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Craig McCullah,4
+Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Scott Schwab,14
+Cherokee,02 Baxter Sprs W2,Secretary of  State,,Rep,Dennis Taylor,8
+Cherokee,02 Baxter Sprs W2,Attorney General,,Rep,Derek Schmidt,33
+Cherokee,02 Baxter Sprs W2,State Treasurer,,Rep,Jake LaTurner,39
+Cherokee,02 Baxter Sprs W2,Insurance Commissioner,,Rep,Vicki Schmidt,16
+Cherokee,02 Baxter Sprs W2,Insurance Commissioner,,Rep,Clark Shultz,22
+Cherokee,02 Baxter Sprs W2,State Senate,13,Rep,Richard Hilderbrand,35
+Cherokee,02 Baxter Sprs W2,State House,1,Rep,Michael Houser,36
+Cherokee,03 Baxter Sprs W3,Registered,,,Registered,1145
+Cherokee,03 Baxter Sprs W3,Ballots,,Dem,Ballots,56
+Cherokee,03 Baxter Sprs W3,Ballots,,Rep,Ballots,127
+Cherokee,03 Baxter Sprs W3,US House,2,Dem,Paul Davis,47
+Cherokee,03 Baxter Sprs W3,Governor,,Dem,Arden Andersen,2
+Cherokee,03 Baxter Sprs W3,Governor,,Dem,Jack Bergeson,0
+Cherokee,03 Baxter Sprs W3,Governor,,Dem,Carl Brewer,4
+Cherokee,03 Baxter Sprs W3,Governor,,Dem,Laura Kelly,19
+Cherokee,03 Baxter Sprs W3,Governor,,Dem,Joshua Svaty,29
+Cherokee,03 Baxter Sprs W3,Secretary of State,,Dem,Brian McClendon,45
+Cherokee,03 Baxter Sprs W3,Attorney General,,Dem,Sarah Swain,47
+Cherokee,03 Baxter Sprs W3,State Treasurer,,Dem,Marci Francisco,46
+Cherokee,03 Baxter Sprs W3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,46
+Cherokee,03 Baxter Sprs W3,State Senate,13,Dem,Bryan Hoffman,46
+Cherokee,03 Baxter Sprs W3,State House,1,Dem,write-in,6
+Cherokee,03 Baxter Sprs W3,US House,2,Rep,Vernon Fields,1
+Cherokee,03 Baxter Sprs W3,US House,2,Rep,Steve Fitzgerald,11
+Cherokee,03 Baxter Sprs W3,US House,2,Rep,Kevin Jones,22
+Cherokee,03 Baxter Sprs W3,US House,2,Rep,Doug Mays,4
+Cherokee,03 Baxter Sprs W3,US House,2,Rep,Dennis Pyle,18
+Cherokee,03 Baxter Sprs W3,US House,2,Rep,Caron Tyson,13
+Cherokee,03 Baxter Sprs W3,US House,2,Rep,Steve Watkins,47
+Cherokee,03 Baxter Sprs W3,Governor,,Rep,Jim Barnett,6
+Cherokee,03 Baxter Sprs W3,Governor,,Rep,Jeff Colyer,41
+Cherokee,03 Baxter Sprs W3,Governor,,Rep,Kris Kobach,58
+Cherokee,03 Baxter Sprs W3,Governor,,Rep,Patrick Kucera,0
+Cherokee,03 Baxter Sprs W3,Governor,,Rep,Tyler Ruzich,0
+Cherokee,03 Baxter Sprs W3,Governor,,Rep,Ken Selzer,16
+Cherokee,03 Baxter Sprs W3,Governor,,Rep,Joseph Tutera,3
+Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Randy Duncan,28
+Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Keith Esau,12
+Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Craig McCullah,11
+Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Scott Schwab,35
+Cherokee,03 Baxter Sprs W3,Secretary of  State,,Rep,Dennis Taylor,21
+Cherokee,03 Baxter Sprs W3,Attorney General,,Rep,Derek Schmidt,98
+Cherokee,03 Baxter Sprs W3,State Treasurer,,Rep,Jake LaTurner,110
+Cherokee,03 Baxter Sprs W3,Insurance Commissioner,,Rep,Vicki Schmidt,54
+Cherokee,03 Baxter Sprs W3,Insurance Commissioner,,Rep,Clark Shultz,62
+Cherokee,03 Baxter Sprs W3,State Senate,13,Rep,Richard Hilderbrand,122
+Cherokee,03 Baxter Sprs W3,State House,1,Rep,Michael Houser,103
+Cherokee,04 Baxter Sprs W4,Registered,,,Registered,853
+Cherokee,04 Baxter Sprs W4,Ballots,,Dem,Ballots,33
+Cherokee,04 Baxter Sprs W4,Ballots,,Rep,Ballots,64
+Cherokee,04 Baxter Sprs W4,US House,2,Dem,Paul Davis,31
+Cherokee,04 Baxter Sprs W4,Governor,,Dem,Arden Andersen,4
+Cherokee,04 Baxter Sprs W4,Governor,,Dem,Jack Bergeson,0
+Cherokee,04 Baxter Sprs W4,Governor,,Dem,Carl Brewer,4
+Cherokee,04 Baxter Sprs W4,Governor,,Dem,Laura Kelly,7
+Cherokee,04 Baxter Sprs W4,Governor,,Dem,Joshua Svaty,17
+Cherokee,04 Baxter Sprs W4,Secretary of State,,Dem,Brian McClendon,30
+Cherokee,04 Baxter Sprs W4,Attorney General,,Dem,Sarah Swain,33
+Cherokee,04 Baxter Sprs W4,State Treasurer,,Dem,Marci Francisco,33
+Cherokee,04 Baxter Sprs W4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,33
+Cherokee,04 Baxter Sprs W4,State Senate,13,Dem,Bryan Hoffman,33
+Cherokee,04 Baxter Sprs W4,State House,1,Dem,write-in,7
+Cherokee,04 Baxter Sprs W4,US House,2,Rep,Vernon Fields,2
+Cherokee,04 Baxter Sprs W4,US House,2,Rep,Steve Fitzgerald,8
+Cherokee,04 Baxter Sprs W4,US House,2,Rep,Kevin Jones,14
+Cherokee,04 Baxter Sprs W4,US House,2,Rep,Doug Mays,1
+Cherokee,04 Baxter Sprs W4,US House,2,Rep,Dennis Pyle,4
+Cherokee,04 Baxter Sprs W4,US House,2,Rep,Caron Tyson,13
+Cherokee,04 Baxter Sprs W4,US House,2,Rep,Steve Watkins,22
+Cherokee,04 Baxter Sprs W4,Governor,,Rep,Jim Barnett,3
+Cherokee,04 Baxter Sprs W4,Governor,,Rep,Jeff Colyer,29
+Cherokee,04 Baxter Sprs W4,Governor,,Rep,Kris Kobach,26
+Cherokee,04 Baxter Sprs W4,Governor,,Rep,Patrick Kucera,1
+Cherokee,04 Baxter Sprs W4,Governor,,Rep,Tyler Ruzich,1
+Cherokee,04 Baxter Sprs W4,Governor,,Rep,Ken Selzer,3
+Cherokee,04 Baxter Sprs W4,Governor,,Rep,Joseph Tutera,0
+Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Randy Duncan,13
+Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Keith Esau,8
+Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Craig McCullah,4
+Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Scott Schwab,24
+Cherokee,04 Baxter Sprs W4,Secretary of  State,,Rep,Dennis Taylor,10
+Cherokee,04 Baxter Sprs W4,Attorney General,,Rep,Derek Schmidt,51
+Cherokee,04 Baxter Sprs W4,State Treasurer,,Rep,Jake LaTurner,56
+Cherokee,04 Baxter Sprs W4,Insurance Commissioner,,Rep,Vicki Schmidt,36
+Cherokee,04 Baxter Sprs W4,Insurance Commissioner,,Rep,Clark Shultz,23
+Cherokee,04 Baxter Sprs W4,State Senate,13,Rep,Richard Hilderbrand,60
+Cherokee,04 Baxter Sprs W4,State House,1,Rep,Michael Houser,53
+Cherokee,05 Columbus W1,Registered,,,Registered,421
+Cherokee,05 Columbus W1,Ballots,,Dem,Ballots,26
+Cherokee,05 Columbus W1,Ballots,,Rep,Ballots,45
+Cherokee,05 Columbus W1,US House,2,Dem,Paul Davis,23
+Cherokee,05 Columbus W1,Governor,,Dem,Arden Andersen,4
+Cherokee,05 Columbus W1,Governor,,Dem,Jack Bergeson,2
+Cherokee,05 Columbus W1,Governor,,Dem,Carl Brewer,4
+Cherokee,05 Columbus W1,Governor,,Dem,Laura Kelly,9
+Cherokee,05 Columbus W1,Governor,,Dem,Joshua Svaty,7
+Cherokee,05 Columbus W1,Secretary of State,,Dem,Brian McClendon,24
+Cherokee,05 Columbus W1,Attorney General,,Dem,Sarah Swain,24
+Cherokee,05 Columbus W1,State Treasurer,,Dem,Marci Francisco,23
+Cherokee,05 Columbus W1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,23
+Cherokee,05 Columbus W1,State Senate,13,Dem,Bryan Hoffman,24
+Cherokee,05 Columbus W1,State House,1,Dem,write-in,4
+Cherokee,05 Columbus W1,US House,2,Rep,Vernon Fields,0
+Cherokee,05 Columbus W1,US House,2,Rep,Steve Fitzgerald,9
+Cherokee,05 Columbus W1,US House,2,Rep,Kevin Jones,4
+Cherokee,05 Columbus W1,US House,2,Rep,Doug Mays,2
+Cherokee,05 Columbus W1,US House,2,Rep,Dennis Pyle,3
+Cherokee,05 Columbus W1,US House,2,Rep,Caron Tyson,8
+Cherokee,05 Columbus W1,US House,2,Rep,Steve Watkins,18
+Cherokee,05 Columbus W1,Governor,,Rep,Jim Barnett,3
+Cherokee,05 Columbus W1,Governor,,Rep,Jeff Colyer,20
+Cherokee,05 Columbus W1,Governor,,Rep,Kris Kobach,20
+Cherokee,05 Columbus W1,Governor,,Rep,Patrick Kucera,1
+Cherokee,05 Columbus W1,Governor,,Rep,Tyler Ruzich,0
+Cherokee,05 Columbus W1,Governor,,Rep,Ken Selzer,1
+Cherokee,05 Columbus W1,Governor,,Rep,Joseph Tutera,0
+Cherokee,05 Columbus W1,Secretary of  State,,Rep,Randy Duncan,10
+Cherokee,05 Columbus W1,Secretary of  State,,Rep,Keith Esau,2
+Cherokee,05 Columbus W1,Secretary of  State,,Rep,Craig McCullah,6
+Cherokee,05 Columbus W1,Secretary of  State,,Rep,Scott Schwab,13
+Cherokee,05 Columbus W1,Secretary of  State,,Rep,Dennis Taylor,9
+Cherokee,05 Columbus W1,Attorney General,,Rep,Derek Schmidt,39
+Cherokee,05 Columbus W1,State Treasurer,,Rep,Jake LaTurner,41
+Cherokee,05 Columbus W1,Insurance Commissioner,,Rep,Vicki Schmidt,16
+Cherokee,05 Columbus W1,Insurance Commissioner,,Rep,Clark Shultz,24
+Cherokee,05 Columbus W1,State Senate,13,Rep,Richard Hilderbrand,39
+Cherokee,05 Columbus W1,State House,1,Rep,Michael Houser,41
+Cherokee,06 Columbus W2,Registered,,,Registered,482
+Cherokee,06 Columbus W2,Ballots,,Dem,Ballots,47
+Cherokee,06 Columbus W2,Ballots,,Rep,Ballots,78
+Cherokee,06 Columbus W2,US House,2,Dem,Paul Davis,39
+Cherokee,06 Columbus W2,Governor,,Dem,Arden Andersen,4
+Cherokee,06 Columbus W2,Governor,,Dem,Jack Bergeson,1
+Cherokee,06 Columbus W2,Governor,,Dem,Carl Brewer,2
+Cherokee,06 Columbus W2,Governor,,Dem,Laura Kelly,18
+Cherokee,06 Columbus W2,Governor,,Dem,Joshua Svaty,21
+Cherokee,06 Columbus W2,Secretary of State,,Dem,Brian McClendon,39
+Cherokee,06 Columbus W2,Attorney General,,Dem,Sarah Swain,40
+Cherokee,06 Columbus W2,State Treasurer,,Dem,Marci Francisco,39
+Cherokee,06 Columbus W2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,36
+Cherokee,06 Columbus W2,State Senate,13,Dem,Bryan Hoffman,39
+Cherokee,06 Columbus W2,State House,1,Dem,write-in,2
+Cherokee,06 Columbus W2,US House,2,Rep,Vernon Fields,1
+Cherokee,06 Columbus W2,US House,2,Rep,Steve Fitzgerald,7
+Cherokee,06 Columbus W2,US House,2,Rep,Kevin Jones,4
+Cherokee,06 Columbus W2,US House,2,Rep,Doug Mays,2
+Cherokee,06 Columbus W2,US House,2,Rep,Dennis Pyle,11
+Cherokee,06 Columbus W2,US House,2,Rep,Caron Tyson,26
+Cherokee,06 Columbus W2,US House,2,Rep,Steve Watkins,25
+Cherokee,06 Columbus W2,Governor,,Rep,Jim Barnett,1
+Cherokee,06 Columbus W2,Governor,,Rep,Jeff Colyer,40
+Cherokee,06 Columbus W2,Governor,,Rep,Kris Kobach,24
+Cherokee,06 Columbus W2,Governor,,Rep,Patrick Kucera,0
+Cherokee,06 Columbus W2,Governor,,Rep,Tyler Ruzich,0
+Cherokee,06 Columbus W2,Governor,,Rep,Ken Selzer,10
+Cherokee,06 Columbus W2,Governor,,Rep,Joseph Tutera,0
+Cherokee,06 Columbus W2,Secretary of  State,,Rep,Randy Duncan,26
+Cherokee,06 Columbus W2,Secretary of  State,,Rep,Keith Esau,8
+Cherokee,06 Columbus W2,Secretary of  State,,Rep,Craig McCullah,11
+Cherokee,06 Columbus W2,Secretary of  State,,Rep,Scott Schwab,17
+Cherokee,06 Columbus W2,Secretary of  State,,Rep,Dennis Taylor,10
+Cherokee,06 Columbus W2,Attorney General,,Rep,Derek Schmidt,69
+Cherokee,06 Columbus W2,State Treasurer,,Rep,Jake LaTurner,68
+Cherokee,06 Columbus W2,Insurance Commissioner,,Rep,Vicki Schmidt,45
+Cherokee,06 Columbus W2,Insurance Commissioner,,Rep,Clark Shultz,30
+Cherokee,06 Columbus W2,State Senate,13,Rep,Richard Hilderbrand,67
+Cherokee,06 Columbus W2,State House,1,Rep,Michael Houser,68
+Cherokee,07 Columbus W3,Registered,,,Registered,457
+Cherokee,07 Columbus W3,Ballots,,Dem,Ballots,37
+Cherokee,07 Columbus W3,Ballots,,Rep,Ballots,69
+Cherokee,07 Columbus W3,US House,2,Dem,Paul Davis,29
+Cherokee,07 Columbus W3,Governor,,Dem,Arden Andersen,3
+Cherokee,07 Columbus W3,Governor,,Dem,Jack Bergeson,3
+Cherokee,07 Columbus W3,Governor,,Dem,Carl Brewer,4
+Cherokee,07 Columbus W3,Governor,,Dem,Laura Kelly,14
+Cherokee,07 Columbus W3,Governor,,Dem,Joshua Svaty,12
+Cherokee,07 Columbus W3,Secretary of State,,Dem,Brian McClendon,31
+Cherokee,07 Columbus W3,Attorney General,,Dem,Sarah Swain,34
+Cherokee,07 Columbus W3,State Treasurer,,Dem,Marci Francisco,31
+Cherokee,07 Columbus W3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,32
+Cherokee,07 Columbus W3,State Senate,13,Dem,Bryan Hoffman,32
+Cherokee,07 Columbus W3,State House,1,Dem,write-in,4
+Cherokee,07 Columbus W3,US House,2,Rep,Vernon Fields,1
+Cherokee,07 Columbus W3,US House,2,Rep,Steve Fitzgerald,7
+Cherokee,07 Columbus W3,US House,2,Rep,Kevin Jones,11
+Cherokee,07 Columbus W3,US House,2,Rep,Doug Mays,3
+Cherokee,07 Columbus W3,US House,2,Rep,Dennis Pyle,4
+Cherokee,07 Columbus W3,US House,2,Rep,Caron Tyson,17
+Cherokee,07 Columbus W3,US House,2,Rep,Steve Watkins,26
+Cherokee,07 Columbus W3,Governor,,Rep,Jim Barnett,7
+Cherokee,07 Columbus W3,Governor,,Rep,Jeff Colyer,31
+Cherokee,07 Columbus W3,Governor,,Rep,Kris Kobach,23
+Cherokee,07 Columbus W3,Governor,,Rep,Patrick Kucera,2
+Cherokee,07 Columbus W3,Governor,,Rep,Tyler Ruzich,1
+Cherokee,07 Columbus W3,Governor,,Rep,Ken Selzer,4
+Cherokee,07 Columbus W3,Governor,,Rep,Joseph Tutera,0
+Cherokee,07 Columbus W3,Secretary of  State,,Rep,Randy Duncan,18
+Cherokee,07 Columbus W3,Secretary of  State,,Rep,Keith Esau,6
+Cherokee,07 Columbus W3,Secretary of  State,,Rep,Craig McCullah,7
+Cherokee,07 Columbus W3,Secretary of  State,,Rep,Scott Schwab,18
+Cherokee,07 Columbus W3,Secretary of  State,,Rep,Dennis Taylor,13
+Cherokee,07 Columbus W3,Attorney General,,Rep,Derek Schmidt,63
+Cherokee,07 Columbus W3,State Treasurer,,Rep,Jake LaTurner,64
+Cherokee,07 Columbus W3,Insurance Commissioner,,Rep,Vicki Schmidt,40
+Cherokee,07 Columbus W3,Insurance Commissioner,,Rep,Clark Shultz,28
+Cherokee,07 Columbus W3,State Senate,13,Rep,Richard Hilderbrand,63
+Cherokee,07 Columbus W3,State House,1,Rep,Michael Houser,63
+Cherokee,08 Columbus W4,Registered,,,Registered,416
+Cherokee,08 Columbus W4,Ballots,,Dem,Ballots,21
+Cherokee,08 Columbus W4,Ballots,,Rep,Ballots,40
+Cherokee,08 Columbus W4,US House,2,Dem,Paul Davis,19
+Cherokee,08 Columbus W4,Governor,,Dem,Arden Andersen,0
+Cherokee,08 Columbus W4,Governor,,Dem,Jack Bergeson,1
+Cherokee,08 Columbus W4,Governor,,Dem,Carl Brewer,1
+Cherokee,08 Columbus W4,Governor,,Dem,Laura Kelly,5
+Cherokee,08 Columbus W4,Governor,,Dem,Joshua Svaty,14
+Cherokee,08 Columbus W4,Secretary of State,,Dem,Brian McClendon,17
+Cherokee,08 Columbus W4,Attorney General,,Dem,Sarah Swain,17
+Cherokee,08 Columbus W4,State Treasurer,,Dem,Marci Francisco,17
+Cherokee,08 Columbus W4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,17
+Cherokee,08 Columbus W4,State Senate,13,Dem,Bryan Hoffman,19
+Cherokee,08 Columbus W4,State House,1,Dem,write-in,2
+Cherokee,08 Columbus W4,US House,2,Rep,Vernon Fields,0
+Cherokee,08 Columbus W4,US House,2,Rep,Steve Fitzgerald,1
+Cherokee,08 Columbus W4,US House,2,Rep,Kevin Jones,3
+Cherokee,08 Columbus W4,US House,2,Rep,Doug Mays,2
+Cherokee,08 Columbus W4,US House,2,Rep,Dennis Pyle,3
+Cherokee,08 Columbus W4,US House,2,Rep,Caron Tyson,14
+Cherokee,08 Columbus W4,US House,2,Rep,Steve Watkins,13
+Cherokee,08 Columbus W4,Governor,,Rep,Jim Barnett,6
+Cherokee,08 Columbus W4,Governor,,Rep,Jeff Colyer,14
+Cherokee,08 Columbus W4,Governor,,Rep,Kris Kobach,15
+Cherokee,08 Columbus W4,Governor,,Rep,Patrick Kucera,0
+Cherokee,08 Columbus W4,Governor,,Rep,Tyler Ruzich,0
+Cherokee,08 Columbus W4,Governor,,Rep,Ken Selzer,2
+Cherokee,08 Columbus W4,Governor,,Rep,Joseph Tutera,0
+Cherokee,08 Columbus W4,Secretary of  State,,Rep,Randy Duncan,4
+Cherokee,08 Columbus W4,Secretary of  State,,Rep,Keith Esau,8
+Cherokee,08 Columbus W4,Secretary of  State,,Rep,Craig McCullah,1
+Cherokee,08 Columbus W4,Secretary of  State,,Rep,Scott Schwab,12
+Cherokee,08 Columbus W4,Secretary of  State,,Rep,Dennis Taylor,10
+Cherokee,08 Columbus W4,Attorney General,,Rep,Derek Schmidt,30
+Cherokee,08 Columbus W4,State Treasurer,,Rep,Jake LaTurner,32
+Cherokee,08 Columbus W4,Insurance Commissioner,,Rep,Vicki Schmidt,20
+Cherokee,08 Columbus W4,Insurance Commissioner,,Rep,Clark Shultz,15
+Cherokee,08 Columbus W4,State Senate,13,Rep,Richard Hilderbrand,32
+Cherokee,08 Columbus W4,State House,1,Rep,Michael Houser,32
+Cherokee,09 Columbus W5,Registered,,,Registered,415
+Cherokee,09 Columbus W5,Ballots,,Dem,Ballots,30
+Cherokee,09 Columbus W5,Ballots,,Rep,Ballots,48
+Cherokee,09 Columbus W5,US House,2,Dem,Paul Davis,23
+Cherokee,09 Columbus W5,Governor,,Dem,Arden Andersen,6
+Cherokee,09 Columbus W5,Governor,,Dem,Jack Bergeson,2
+Cherokee,09 Columbus W5,Governor,,Dem,Carl Brewer,5
+Cherokee,09 Columbus W5,Governor,,Dem,Laura Kelly,7
+Cherokee,09 Columbus W5,Governor,,Dem,Joshua Svaty,6
+Cherokee,09 Columbus W5,Secretary of State,,Dem,Brian McClendon,25
+Cherokee,09 Columbus W5,Attorney General,,Dem,Sarah Swain,26
+Cherokee,09 Columbus W5,State Treasurer,,Dem,Marci Francisco,26
+Cherokee,09 Columbus W5,Insurance Commissioner,,Dem,Nathaniel McLaughlin,25
+Cherokee,09 Columbus W5,State Senate,13,Dem,Bryan Hoffman,27
+Cherokee,09 Columbus W5,State House,1,Dem,write-in,3
+Cherokee,09 Columbus W5,US House,2,Rep,Vernon Fields,0
+Cherokee,09 Columbus W5,US House,2,Rep,Steve Fitzgerald,3
+Cherokee,09 Columbus W5,US House,2,Rep,Kevin Jones,10
+Cherokee,09 Columbus W5,US House,2,Rep,Doug Mays,2
+Cherokee,09 Columbus W5,US House,2,Rep,Dennis Pyle,2
+Cherokee,09 Columbus W5,US House,2,Rep,Caron Tyson,15
+Cherokee,09 Columbus W5,US House,2,Rep,Steve Watkins,14
+Cherokee,09 Columbus W5,Governor,,Rep,Jim Barnett,7
+Cherokee,09 Columbus W5,Governor,,Rep,Jeff Colyer,15
+Cherokee,09 Columbus W5,Governor,,Rep,Kris Kobach,20
+Cherokee,09 Columbus W5,Governor,,Rep,Patrick Kucera,0
+Cherokee,09 Columbus W5,Governor,,Rep,Tyler Ruzich,0
+Cherokee,09 Columbus W5,Governor,,Rep,Ken Selzer,4
+Cherokee,09 Columbus W5,Governor,,Rep,Joseph Tutera,0
+Cherokee,09 Columbus W5,Secretary of  State,,Rep,Randy Duncan,15
+Cherokee,09 Columbus W5,Secretary of  State,,Rep,Keith Esau,3
+Cherokee,09 Columbus W5,Secretary of  State,,Rep,Craig McCullah,5
+Cherokee,09 Columbus W5,Secretary of  State,,Rep,Scott Schwab,11
+Cherokee,09 Columbus W5,Secretary of  State,,Rep,Dennis Taylor,8
+Cherokee,09 Columbus W5,Attorney General,,Rep,Derek Schmidt,37
+Cherokee,09 Columbus W5,State Treasurer,,Rep,Jake LaTurner,35
+Cherokee,09 Columbus W5,Insurance Commissioner,,Rep,Vicki Schmidt,26
+Cherokee,09 Columbus W5,Insurance Commissioner,,Rep,Clark Shultz,18
+Cherokee,09 Columbus W5,State Senate,13,Rep,Richard Hilderbrand,40
+Cherokee,09 Columbus W5,State House,1,Rep,Michael Houser,43
+Cherokee,10 Galena W1,Registered,,,Registered,665
+Cherokee,10 Galena W1,Ballots,,Dem,Ballots,21
+Cherokee,10 Galena W1,Ballots,,Rep,Ballots,56
+Cherokee,10 Galena W1,US House,2,Dem,Paul Davis,18
+Cherokee,10 Galena W1,Governor,,Dem,Arden Andersen,4
+Cherokee,10 Galena W1,Governor,,Dem,Jack Bergeson,4
+Cherokee,10 Galena W1,Governor,,Dem,Carl Brewer,2
+Cherokee,10 Galena W1,Governor,,Dem,Laura Kelly,8
+Cherokee,10 Galena W1,Governor,,Dem,Joshua Svaty,3
+Cherokee,10 Galena W1,Secretary of State,,Dem,Brian McClendon,16
+Cherokee,10 Galena W1,Attorney General,,Dem,Sarah Swain,18
+Cherokee,10 Galena W1,State Treasurer,,Dem,Marci Francisco,15
+Cherokee,10 Galena W1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,18
+Cherokee,10 Galena W1,State Senate,13,Dem,Bryan Hoffman,16
+Cherokee,10 Galena W1,State House,1,Dem,write-in,3
+Cherokee,10 Galena W1,US House,2,Rep,Vernon Fields,5
+Cherokee,10 Galena W1,US House,2,Rep,Steve Fitzgerald,3
+Cherokee,10 Galena W1,US House,2,Rep,Kevin Jones,3
+Cherokee,10 Galena W1,US House,2,Rep,Doug Mays,5
+Cherokee,10 Galena W1,US House,2,Rep,Dennis Pyle,4
+Cherokee,10 Galena W1,US House,2,Rep,Caron Tyson,10
+Cherokee,10 Galena W1,US House,2,Rep,Steve Watkins,15
+Cherokee,10 Galena W1,Governor,,Rep,Jim Barnett,6
+Cherokee,10 Galena W1,Governor,,Rep,Jeff Colyer,16
+Cherokee,10 Galena W1,Governor,,Rep,Kris Kobach,24
+Cherokee,10 Galena W1,Governor,,Rep,Patrick Kucera,1
+Cherokee,10 Galena W1,Governor,,Rep,Tyler Ruzich,0
+Cherokee,10 Galena W1,Governor,,Rep,Ken Selzer,5
+Cherokee,10 Galena W1,Governor,,Rep,Joseph Tutera,0
+Cherokee,10 Galena W1,Secretary of  State,,Rep,Randy Duncan,18
+Cherokee,10 Galena W1,Secretary of  State,,Rep,Keith Esau,5
+Cherokee,10 Galena W1,Secretary of  State,,Rep,Craig McCullah,6
+Cherokee,10 Galena W1,Secretary of  State,,Rep,Scott Schwab,9
+Cherokee,10 Galena W1,Secretary of  State,,Rep,Dennis Taylor,6
+Cherokee,10 Galena W1,Attorney General,,Rep,Derek Schmidt,44
+Cherokee,10 Galena W1,State Treasurer,,Rep,Jake LaTurner,49
+Cherokee,10 Galena W1,Insurance Commissioner,,Rep,Vicki Schmidt,26
+Cherokee,10 Galena W1,Insurance Commissioner,,Rep,Clark Shultz,17
+Cherokee,10 Galena W1,State Senate,13,Rep,Richard Hilderbrand,50
+Cherokee,10 Galena W1,State House,1,Rep,Michael Houser,42
+Cherokee,011 Galena W2,Registered,,,Registered,523
+Cherokee,011 Galena W2,Ballots,,Dem,Ballots,24
+Cherokee,011 Galena W2,Ballots,,Rep,Ballots,62
+Cherokee,011 Galena W2,US House,2,Dem,Paul Davis,20
+Cherokee,011 Galena W2,Governor,,Dem,Arden Andersen,2
+Cherokee,011 Galena W2,Governor,,Dem,Jack Bergeson,5
+Cherokee,011 Galena W2,Governor,,Dem,Carl Brewer,8
+Cherokee,011 Galena W2,Governor,,Dem,Laura Kelly,6
+Cherokee,011 Galena W2,Governor,,Dem,Joshua Svaty,3
+Cherokee,011 Galena W2,Secretary of State,,Dem,Brian McClendon,22
+Cherokee,011 Galena W2,Attorney General,,Dem,Sarah Swain,22
+Cherokee,011 Galena W2,State Treasurer,,Dem,Marci Francisco,22
+Cherokee,011 Galena W2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,22
+Cherokee,011 Galena W2,State Senate,13,Dem,Bryan Hoffman,20
+Cherokee,011 Galena W2,State House,1,Dem,write-in,4
+Cherokee,011 Galena W2,US House,2,Rep,Vernon Fields,0
+Cherokee,011 Galena W2,US House,2,Rep,Steve Fitzgerald,5
+Cherokee,011 Galena W2,US House,2,Rep,Kevin Jones,8
+Cherokee,011 Galena W2,US House,2,Rep,Doug Mays,6
+Cherokee,011 Galena W2,US House,2,Rep,Dennis Pyle,9
+Cherokee,011 Galena W2,US House,2,Rep,Caron Tyson,10
+Cherokee,011 Galena W2,US House,2,Rep,Steve Watkins,18
+Cherokee,011 Galena W2,Governor,,Rep,Jim Barnett,9
+Cherokee,011 Galena W2,Governor,,Rep,Jeff Colyer,12
+Cherokee,011 Galena W2,Governor,,Rep,Kris Kobach,27
+Cherokee,011 Galena W2,Governor,,Rep,Patrick Kucera,3
+Cherokee,011 Galena W2,Governor,,Rep,Tyler Ruzich,1
+Cherokee,011 Galena W2,Governor,,Rep,Ken Selzer,3
+Cherokee,011 Galena W2,Governor,,Rep,Joseph Tutera,0
+Cherokee,011 Galena W2,Secretary of  State,,Rep,Randy Duncan,14
+Cherokee,011 Galena W2,Secretary of  State,,Rep,Keith Esau,5
+Cherokee,011 Galena W2,Secretary of  State,,Rep,Craig McCullah,8
+Cherokee,011 Galena W2,Secretary of  State,,Rep,Scott Schwab,13
+Cherokee,011 Galena W2,Secretary of  State,,Rep,Dennis Taylor,11
+Cherokee,011 Galena W2,Attorney General,,Rep,Derek Schmidt,50
+Cherokee,011 Galena W2,State Treasurer,,Rep,Jake LaTurner,48
+Cherokee,011 Galena W2,Insurance Commissioner,,Rep,Vicki Schmidt,27
+Cherokee,011 Galena W2,Insurance Commissioner,,Rep,Clark Shultz,25
+Cherokee,011 Galena W2,State Senate,13,Rep,Richard Hilderbrand,50
+Cherokee,011 Galena W2,State House,1,Rep,Michael Houser,44
+Cherokee,012 Galena W3,Registered,,,Registered,747
+Cherokee,012 Galena W3,Ballots,,Dem,Ballots,37
+Cherokee,012 Galena W3,Ballots,,Rep,Ballots,98
+Cherokee,012 Galena W3,US House,2,Dem,Paul Davis,30
+Cherokee,012 Galena W3,Governor,,Dem,Arden Andersen,5
+Cherokee,012 Galena W3,Governor,,Dem,Jack Bergeson,1
+Cherokee,012 Galena W3,Governor,,Dem,Carl Brewer,1
+Cherokee,012 Galena W3,Governor,,Dem,Laura Kelly,16
+Cherokee,012 Galena W3,Governor,,Dem,Joshua Svaty,9
+Cherokee,012 Galena W3,Secretary of State,,Dem,Brian McClendon,29
+Cherokee,012 Galena W3,Attorney General,,Dem,Sarah Swain,30
+Cherokee,012 Galena W3,State Treasurer,,Dem,Marci Francisco,31
+Cherokee,012 Galena W3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,27
+Cherokee,012 Galena W3,State Senate,13,Dem,Bryan Hoffman,31
+Cherokee,012 Galena W3,State House,1,Dem,write-in,6
+Cherokee,012 Galena W3,US House,2,Rep,Vernon Fields,1
+Cherokee,012 Galena W3,US House,2,Rep,Steve Fitzgerald,10
+Cherokee,012 Galena W3,US House,2,Rep,Kevin Jones,9
+Cherokee,012 Galena W3,US House,2,Rep,Doug Mays,1
+Cherokee,012 Galena W3,US House,2,Rep,Dennis Pyle,6
+Cherokee,012 Galena W3,US House,2,Rep,Caron Tyson,15
+Cherokee,012 Galena W3,US House,2,Rep,Steve Watkins,43
+Cherokee,012 Galena W3,Governor,,Rep,Jim Barnett,9
+Cherokee,012 Galena W3,Governor,,Rep,Jeff Colyer,32
+Cherokee,012 Galena W3,Governor,,Rep,Kris Kobach,39
+Cherokee,012 Galena W3,Governor,,Rep,Patrick Kucera,2
+Cherokee,012 Galena W3,Governor,,Rep,Tyler Ruzich,0
+Cherokee,012 Galena W3,Governor,,Rep,Ken Selzer,7
+Cherokee,012 Galena W3,Governor,,Rep,Joseph Tutera,2
+Cherokee,012 Galena W3,Secretary of  State,,Rep,Randy Duncan,33
+Cherokee,012 Galena W3,Secretary of  State,,Rep,Keith Esau,4
+Cherokee,012 Galena W3,Secretary of  State,,Rep,Craig McCullah,5
+Cherokee,012 Galena W3,Secretary of  State,,Rep,Scott Schwab,22
+Cherokee,012 Galena W3,Secretary of  State,,Rep,Dennis Taylor,13
+Cherokee,012 Galena W3,Attorney General,,Rep,Derek Schmidt,70
+Cherokee,012 Galena W3,State Treasurer,,Rep,Jake LaTurner,80
+Cherokee,012 Galena W3,Insurance Commissioner,,Rep,Vicki Schmidt,49
+Cherokee,012 Galena W3,Insurance Commissioner,,Rep,Clark Shultz,31
+Cherokee,012 Galena W3,State Senate,13,Rep,Richard Hilderbrand,85
+Cherokee,012 Galena W3,State House,1,Rep,Michael Houser,75
+Cherokee,013 Galena W4,Registered,,,Registered,462
+Cherokee,013 Galena W4,Ballots,,Dem,Ballots,26
+Cherokee,013 Galena W4,Ballots,,Rep,Ballots,42
+Cherokee,013 Galena W4,US House,2,Dem,Paul Davis,23
+Cherokee,013 Galena W4,Governor,,Dem,Arden Andersen,5
+Cherokee,013 Galena W4,Governor,,Dem,Jack Bergeson,3
+Cherokee,013 Galena W4,Governor,,Dem,Carl Brewer,3
+Cherokee,013 Galena W4,Governor,,Dem,Laura Kelly,9
+Cherokee,013 Galena W4,Governor,,Dem,Joshua Svaty,3
+Cherokee,013 Galena W4,Secretary of State,,Dem,Brian McClendon,21
+Cherokee,013 Galena W4,Attorney General,,Dem,Sarah Swain,20
+Cherokee,013 Galena W4,State Treasurer,,Dem,Marci Francisco,22
+Cherokee,013 Galena W4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,20
+Cherokee,013 Galena W4,State Senate,13,Dem,Bryan Hoffman,22
+Cherokee,013 Galena W4,State House,1,Dem,write-in,4
+Cherokee,013 Galena W4,US House,2,Rep,Vernon Fields,0
+Cherokee,013 Galena W4,US House,2,Rep,Steve Fitzgerald,4
+Cherokee,013 Galena W4,US House,2,Rep,Kevin Jones,8
+Cherokee,013 Galena W4,US House,2,Rep,Doug Mays,4
+Cherokee,013 Galena W4,US House,2,Rep,Dennis Pyle,2
+Cherokee,013 Galena W4,US House,2,Rep,Caron Tyson,8
+Cherokee,013 Galena W4,US House,2,Rep,Steve Watkins,14
+Cherokee,013 Galena W4,Governor,,Rep,Jim Barnett,3
+Cherokee,013 Galena W4,Governor,,Rep,Jeff Colyer,15
+Cherokee,013 Galena W4,Governor,,Rep,Kris Kobach,21
+Cherokee,013 Galena W4,Governor,,Rep,Patrick Kucera,0
+Cherokee,013 Galena W4,Governor,,Rep,Tyler Ruzich,0
+Cherokee,013 Galena W4,Governor,,Rep,Ken Selzer,1
+Cherokee,013 Galena W4,Governor,,Rep,Joseph Tutera,0
+Cherokee,013 Galena W4,Secretary of  State,,Rep,Randy Duncan,8
+Cherokee,013 Galena W4,Secretary of  State,,Rep,Keith Esau,4
+Cherokee,013 Galena W4,Secretary of  State,,Rep,Craig McCullah,6
+Cherokee,013 Galena W4,Secretary of  State,,Rep,Scott Schwab,8
+Cherokee,013 Galena W4,Secretary of  State,,Rep,Dennis Taylor,9
+Cherokee,013 Galena W4,Attorney General,,Rep,Derek Schmidt,32
+Cherokee,013 Galena W4,State Treasurer,,Rep,Jake LaTurner,42
+Cherokee,013 Galena W4,Insurance Commissioner,,Rep,Vicki Schmidt,24
+Cherokee,013 Galena W4,Insurance Commissioner,,Rep,Clark Shultz,14
+Cherokee,013 Galena W4,State Senate,13,Rep,Richard Hilderbrand,39
+Cherokee,013 Galena W4,State House,1,Rep,Michael Houser,36
+Cherokee,014 Scammon W1,Registered,,,Registered,72
+Cherokee,014 Scammon W1,Ballots,,Dem,Ballots,13
+Cherokee,014 Scammon W1,Ballots,,Rep,Ballots,12
+Cherokee,014 Scammon W1,US House,2,Dem,Paul Davis,13
+Cherokee,014 Scammon W1,Governor,,Dem,Arden Andersen,1
+Cherokee,014 Scammon W1,Governor,,Dem,Jack Bergeson,2
+Cherokee,014 Scammon W1,Governor,,Dem,Carl Brewer,0
+Cherokee,014 Scammon W1,Governor,,Dem,Laura Kelly,3
+Cherokee,014 Scammon W1,Governor,,Dem,Joshua Svaty,7
+Cherokee,014 Scammon W1,Secretary of State,,Dem,Brian McClendon,12
+Cherokee,014 Scammon W1,Attorney General,,Dem,Sarah Swain,12
+Cherokee,014 Scammon W1,State Treasurer,,Dem,Marci Francisco,13
+Cherokee,014 Scammon W1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,12
+Cherokee,014 Scammon W1,State Senate,13,Dem,Bryan Hoffman,12
+Cherokee,014 Scammon W1,State House,1,Dem,write-in,5
+Cherokee,014 Scammon W1,US House,2,Rep,Vernon Fields,0
+Cherokee,014 Scammon W1,US House,2,Rep,Steve Fitzgerald,2
+Cherokee,014 Scammon W1,US House,2,Rep,Kevin Jones,1
+Cherokee,014 Scammon W1,US House,2,Rep,Doug Mays,0
+Cherokee,014 Scammon W1,US House,2,Rep,Dennis Pyle,1
+Cherokee,014 Scammon W1,US House,2,Rep,Caron Tyson,2
+Cherokee,014 Scammon W1,US House,2,Rep,Steve Watkins,5
+Cherokee,014 Scammon W1,Governor,,Rep,Jim Barnett,0
+Cherokee,014 Scammon W1,Governor,,Rep,Jeff Colyer,6
+Cherokee,014 Scammon W1,Governor,,Rep,Kris Kobach,5
+Cherokee,014 Scammon W1,Governor,,Rep,Patrick Kucera,0
+Cherokee,014 Scammon W1,Governor,,Rep,Tyler Ruzich,0
+Cherokee,014 Scammon W1,Governor,,Rep,Ken Selzer,1
+Cherokee,014 Scammon W1,Governor,,Rep,Joseph Tutera,0
+Cherokee,014 Scammon W1,Secretary of  State,,Rep,Randy Duncan,4
+Cherokee,014 Scammon W1,Secretary of  State,,Rep,Keith Esau,0
+Cherokee,014 Scammon W1,Secretary of  State,,Rep,Craig McCullah,3
+Cherokee,014 Scammon W1,Secretary of  State,,Rep,Scott Schwab,2
+Cherokee,014 Scammon W1,Secretary of  State,,Rep,Dennis Taylor,2
+Cherokee,014 Scammon W1,Attorney General,,Rep,Derek Schmidt,11
+Cherokee,014 Scammon W1,State Treasurer,,Rep,Jake LaTurner,12
+Cherokee,014 Scammon W1,Insurance Commissioner,,Rep,Vicki Schmidt,8
+Cherokee,014 Scammon W1,Insurance Commissioner,,Rep,Clark Shultz,4
+Cherokee,014 Scammon W1,State Senate,13,Rep,Richard Hilderbrand,11
+Cherokee,014 Scammon W1,State House,1,Rep,Michael Houser,12
+Cherokee,015 Scammon W2,Registered,,,Registered,97
+Cherokee,015 Scammon W2,Ballots,,Dem,Ballots,12
+Cherokee,015 Scammon W2,Ballots,,Rep,Ballots,6
+Cherokee,015 Scammon W2,US House,2,Dem,Paul Davis,8
+Cherokee,015 Scammon W2,Governor,,Dem,Arden Andersen,1
+Cherokee,015 Scammon W2,Governor,,Dem,Jack Bergeson,0
+Cherokee,015 Scammon W2,Governor,,Dem,Carl Brewer,3
+Cherokee,015 Scammon W2,Governor,,Dem,Laura Kelly,3
+Cherokee,015 Scammon W2,Governor,,Dem,Joshua Svaty,3
+Cherokee,015 Scammon W2,Secretary of State,,Dem,Brian McClendon,8
+Cherokee,015 Scammon W2,Attorney General,,Dem,Sarah Swain,10
+Cherokee,015 Scammon W2,State Treasurer,,Dem,Marci Francisco,7
+Cherokee,015 Scammon W2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,9
+Cherokee,015 Scammon W2,State Senate,13,Dem,Bryan Hoffman,10
+Cherokee,015 Scammon W2,State House,1,Dem,write-in,2
+Cherokee,015 Scammon W2,US House,2,Rep,Vernon Fields,0
+Cherokee,015 Scammon W2,US House,2,Rep,Steve Fitzgerald,0
+Cherokee,015 Scammon W2,US House,2,Rep,Kevin Jones,0
+Cherokee,015 Scammon W2,US House,2,Rep,Doug Mays,0
+Cherokee,015 Scammon W2,US House,2,Rep,Dennis Pyle,0
+Cherokee,015 Scammon W2,US House,2,Rep,Caron Tyson,3
+Cherokee,015 Scammon W2,US House,2,Rep,Steve Watkins,3
+Cherokee,015 Scammon W2,Governor,,Rep,Jim Barnett,1
+Cherokee,015 Scammon W2,Governor,,Rep,Jeff Colyer,3
+Cherokee,015 Scammon W2,Governor,,Rep,Kris Kobach,2
+Cherokee,015 Scammon W2,Governor,,Rep,Patrick Kucera,0
+Cherokee,015 Scammon W2,Governor,,Rep,Tyler Ruzich,0
+Cherokee,015 Scammon W2,Governor,,Rep,Ken Selzer,0
+Cherokee,015 Scammon W2,Governor,,Rep,Joseph Tutera,0
+Cherokee,015 Scammon W2,Secretary of  State,,Rep,Randy Duncan,3
+Cherokee,015 Scammon W2,Secretary of  State,,Rep,Keith Esau,0
+Cherokee,015 Scammon W2,Secretary of  State,,Rep,Craig McCullah,0
+Cherokee,015 Scammon W2,Secretary of  State,,Rep,Scott Schwab,3
+Cherokee,015 Scammon W2,Secretary of  State,,Rep,Dennis Taylor,0
+Cherokee,015 Scammon W2,Attorney General,,Rep,Derek Schmidt,6
+Cherokee,015 Scammon W2,State Treasurer,,Rep,Jake LaTurner,6
+Cherokee,015 Scammon W2,Insurance Commissioner,,Rep,Vicki Schmidt,6
+Cherokee,015 Scammon W2,Insurance Commissioner,,Rep,Clark Shultz,0
+Cherokee,015 Scammon W2,State Senate,13,Rep,Richard Hilderbrand,5
+Cherokee,015 Scammon W2,State House,1,Rep,Michael Houser,6
+Cherokee,016 Scammon W3,Registered,,,Registered,152
+Cherokee,016 Scammon W3,Ballots,,Dem,Ballots,13
+Cherokee,016 Scammon W3,Ballots,,Rep,Ballots,14
+Cherokee,016 Scammon W3,US House,2,Dem,Paul Davis,12
+Cherokee,016 Scammon W3,Governor,,Dem,Arden Andersen,2
+Cherokee,016 Scammon W3,Governor,,Dem,Jack Bergeson,1
+Cherokee,016 Scammon W3,Governor,,Dem,Carl Brewer,1
+Cherokee,016 Scammon W3,Governor,,Dem,Laura Kelly,2
+Cherokee,016 Scammon W3,Governor,,Dem,Joshua Svaty,6
+Cherokee,016 Scammon W3,Secretary of State,,Dem,Brian McClendon,11
+Cherokee,016 Scammon W3,Attorney General,,Dem,Sarah Swain,10
+Cherokee,016 Scammon W3,State Treasurer,,Dem,Marci Francisco,11
+Cherokee,016 Scammon W3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,10
+Cherokee,016 Scammon W3,State Senate,13,Dem,Bryan Hoffman,11
+Cherokee,016 Scammon W3,State House,1,Dem,write-in,1
+Cherokee,016 Scammon W3,US House,2,Rep,Vernon Fields,0
+Cherokee,016 Scammon W3,US House,2,Rep,Steve Fitzgerald,5
+Cherokee,016 Scammon W3,US House,2,Rep,Kevin Jones,2
+Cherokee,016 Scammon W3,US House,2,Rep,Doug Mays,0
+Cherokee,016 Scammon W3,US House,2,Rep,Dennis Pyle,1
+Cherokee,016 Scammon W3,US House,2,Rep,Caron Tyson,1
+Cherokee,016 Scammon W3,US House,2,Rep,Steve Watkins,4
+Cherokee,016 Scammon W3,Governor,,Rep,Jim Barnett,0
+Cherokee,016 Scammon W3,Governor,,Rep,Jeff Colyer,3
+Cherokee,016 Scammon W3,Governor,,Rep,Kris Kobach,7
+Cherokee,016 Scammon W3,Governor,,Rep,Patrick Kucera,1
+Cherokee,016 Scammon W3,Governor,,Rep,Tyler Ruzich,0
+Cherokee,016 Scammon W3,Governor,,Rep,Ken Selzer,1
+Cherokee,016 Scammon W3,Governor,,Rep,Joseph Tutera,1
+Cherokee,016 Scammon W3,Secretary of  State,,Rep,Randy Duncan,2
+Cherokee,016 Scammon W3,Secretary of  State,,Rep,Keith Esau,3
+Cherokee,016 Scammon W3,Secretary of  State,,Rep,Craig McCullah,1
+Cherokee,016 Scammon W3,Secretary of  State,,Rep,Scott Schwab,2
+Cherokee,016 Scammon W3,Secretary of  State,,Rep,Dennis Taylor,3
+Cherokee,016 Scammon W3,Attorney General,,Rep,Derek Schmidt,13
+Cherokee,016 Scammon W3,State Treasurer,,Rep,Jake LaTurner,13
+Cherokee,016 Scammon W3,Insurance Commissioner,,Rep,Vicki Schmidt,5
+Cherokee,016 Scammon W3,Insurance Commissioner,,Rep,Clark Shultz,7
+Cherokee,016 Scammon W3,State Senate,13,Rep,Richard Hilderbrand,11
+Cherokee,016 Scammon W3,State House,1,Rep,Michael Houser,11
+Cherokee,017 Weir City,Registered,,,Registered,497
+Cherokee,017 Weir City,Ballots,,Dem,Ballots,51
+Cherokee,017 Weir City,Ballots,,Rep,Ballots,60
+Cherokee,017 Weir City,US House,2,Dem,Paul Davis,42
+Cherokee,017 Weir City,Governor,,Dem,Arden Andersen,1
+Cherokee,017 Weir City,Governor,,Dem,Jack Bergeson,6
+Cherokee,017 Weir City,Governor,,Dem,Carl Brewer,5
+Cherokee,017 Weir City,Governor,,Dem,Laura Kelly,26
+Cherokee,017 Weir City,Governor,,Dem,Joshua Svaty,10
+Cherokee,017 Weir City,Secretary of State,,Dem,Brian McClendon,41
+Cherokee,017 Weir City,Attorney General,,Dem,Sarah Swain,40
+Cherokee,017 Weir City,State Treasurer,,Dem,Marci Francisco,42
+Cherokee,017 Weir City,Insurance Commissioner,,Dem,Nathaniel McLaughlin,42
+Cherokee,017 Weir City,State Senate,13,Dem,Bryan Hoffman,43
+Cherokee,017 Weir City,State House,1,Dem,write-in,14
+Cherokee,017 Weir City,US House,2,Rep,Vernon Fields,3
+Cherokee,017 Weir City,US House,2,Rep,Steve Fitzgerald,2
+Cherokee,017 Weir City,US House,2,Rep,Kevin Jones,11
+Cherokee,017 Weir City,US House,2,Rep,Doug Mays,3
+Cherokee,017 Weir City,US House,2,Rep,Dennis Pyle,9
+Cherokee,017 Weir City,US House,2,Rep,Caron Tyson,9
+Cherokee,017 Weir City,US House,2,Rep,Steve Watkins,22
+Cherokee,017 Weir City,Governor,,Rep,Jim Barnett,2
+Cherokee,017 Weir City,Governor,,Rep,Jeff Colyer,21
+Cherokee,017 Weir City,Governor,,Rep,Kris Kobach,32
+Cherokee,017 Weir City,Governor,,Rep,Patrick Kucera,1
+Cherokee,017 Weir City,Governor,,Rep,Tyler Ruzich,0
+Cherokee,017 Weir City,Governor,,Rep,Ken Selzer,3
+Cherokee,017 Weir City,Governor,,Rep,Joseph Tutera,0
+Cherokee,017 Weir City,Secretary of  State,,Rep,Randy Duncan,15
+Cherokee,017 Weir City,Secretary of  State,,Rep,Keith Esau,7
+Cherokee,017 Weir City,Secretary of  State,,Rep,Craig McCullah,7
+Cherokee,017 Weir City,Secretary of  State,,Rep,Scott Schwab,18
+Cherokee,017 Weir City,Secretary of  State,,Rep,Dennis Taylor,7
+Cherokee,017 Weir City,Attorney General,,Rep,Derek Schmidt,56
+Cherokee,017 Weir City,State Treasurer,,Rep,Jake LaTurner,54
+Cherokee,017 Weir City,Insurance Commissioner,,Rep,Vicki Schmidt,34
+Cherokee,017 Weir City,Insurance Commissioner,,Rep,Clark Shultz,24
+Cherokee,017 Weir City,State Senate,13,Rep,Richard Hilderbrand,54
+Cherokee,017 Weir City,State House,1,Rep,Michael Houser,56
+Cherokee,018 Cherokee,Registered,,,Registered,249
+Cherokee,018 Cherokee,Ballots,,Dem,Ballots,27
+Cherokee,018 Cherokee,Ballots,,Rep,Ballots,45
+Cherokee,018 Cherokee,US House,2,Dem,Paul Davis,25
+Cherokee,018 Cherokee,Governor,,Dem,Arden Andersen,2
+Cherokee,018 Cherokee,Governor,,Dem,Jack Bergeson,1
+Cherokee,018 Cherokee,Governor,,Dem,Carl Brewer,5
+Cherokee,018 Cherokee,Governor,,Dem,Laura Kelly,13
+Cherokee,018 Cherokee,Governor,,Dem,Joshua Svaty,5
+Cherokee,018 Cherokee,Secretary of State,,Dem,Brian McClendon,24
+Cherokee,018 Cherokee,Attorney General,,Dem,Sarah Swain,25
+Cherokee,018 Cherokee,State Treasurer,,Dem,Marci Francisco,23
+Cherokee,018 Cherokee,Insurance Commissioner,,Dem,Nathaniel McLaughlin,23
+Cherokee,018 Cherokee,State Senate,13,Dem,Bryan Hoffman,25
+Cherokee,018 Cherokee,State House,1,Dem,write-in,4
+Cherokee,018 Cherokee,US House,2,Rep,Vernon Fields,0
+Cherokee,018 Cherokee,US House,2,Rep,Steve Fitzgerald,3
+Cherokee,018 Cherokee,US House,2,Rep,Kevin Jones,8
+Cherokee,018 Cherokee,US House,2,Rep,Doug Mays,2
+Cherokee,018 Cherokee,US House,2,Rep,Dennis Pyle,11
+Cherokee,018 Cherokee,US House,2,Rep,Caron Tyson,11
+Cherokee,018 Cherokee,US House,2,Rep,Steve Watkins,8
+Cherokee,018 Cherokee,Governor,,Rep,Jim Barnett,0
+Cherokee,018 Cherokee,Governor,,Rep,Jeff Colyer,22
+Cherokee,018 Cherokee,Governor,,Rep,Kris Kobach,18
+Cherokee,018 Cherokee,Governor,,Rep,Patrick Kucera,0
+Cherokee,018 Cherokee,Governor,,Rep,Tyler Ruzich,0
+Cherokee,018 Cherokee,Governor,,Rep,Ken Selzer,5
+Cherokee,018 Cherokee,Governor,,Rep,Joseph Tutera,0
+Cherokee,018 Cherokee,Secretary of  State,,Rep,Randy Duncan,13
+Cherokee,018 Cherokee,Secretary of  State,,Rep,Keith Esau,2
+Cherokee,018 Cherokee,Secretary of  State,,Rep,Craig McCullah,3
+Cherokee,018 Cherokee,Secretary of  State,,Rep,Scott Schwab,15
+Cherokee,018 Cherokee,Secretary of  State,,Rep,Dennis Taylor,9
+Cherokee,018 Cherokee,Attorney General,,Rep,Derek Schmidt,37
+Cherokee,018 Cherokee,State Treasurer,,Rep,Jake LaTurner,40
+Cherokee,018 Cherokee,Insurance Commissioner,,Rep,Vicki Schmidt,20
+Cherokee,018 Cherokee,Insurance Commissioner,,Rep,Clark Shultz,19
+Cherokee,018 Cherokee,State Senate,13,Rep,Richard Hilderbrand,38
+Cherokee,018 Cherokee,State House,1,Rep,Michael Houser,40
+Cherokee,019 Crawford,Registered,,,Registered,482
+Cherokee,019 Crawford,Ballots,,Dem,Ballots,32
+Cherokee,019 Crawford,Ballots,,Rep,Ballots,77
+Cherokee,019 Crawford,US House,2,Dem,Paul Davis,29
+Cherokee,019 Crawford,Governor,,Dem,Arden Andersen,1
+Cherokee,019 Crawford,Governor,,Dem,Jack Bergeson,2
+Cherokee,019 Crawford,Governor,,Dem,Carl Brewer,3
+Cherokee,019 Crawford,Governor,,Dem,Laura Kelly,13
+Cherokee,019 Crawford,Governor,,Dem,Joshua Svaty,13
+Cherokee,019 Crawford,Secretary of State,,Dem,Brian McClendon,27
+Cherokee,019 Crawford,Attorney General,,Dem,Sarah Swain,28
+Cherokee,019 Crawford,State Treasurer,,Dem,Marci Francisco,27
+Cherokee,019 Crawford,Insurance Commissioner,,Dem,Nathaniel McLaughlin,27
+Cherokee,019 Crawford,State Senate,13,Dem,Bryan Hoffman,31
+Cherokee,019 Crawford,State House,1,Dem,write-in,3
+Cherokee,019 Crawford,US House,2,Rep,Vernon Fields,0
+Cherokee,019 Crawford,US House,2,Rep,Steve Fitzgerald,4
+Cherokee,019 Crawford,US House,2,Rep,Kevin Jones,10
+Cherokee,019 Crawford,US House,2,Rep,Doug Mays,4
+Cherokee,019 Crawford,US House,2,Rep,Dennis Pyle,11
+Cherokee,019 Crawford,US House,2,Rep,Caron Tyson,33
+Cherokee,019 Crawford,US House,2,Rep,Steve Watkins,12
+Cherokee,019 Crawford,Governor,,Rep,Jim Barnett,3
+Cherokee,019 Crawford,Governor,,Rep,Jeff Colyer,33
+Cherokee,019 Crawford,Governor,,Rep,Kris Kobach,34
+Cherokee,019 Crawford,Governor,,Rep,Patrick Kucera,0
+Cherokee,019 Crawford,Governor,,Rep,Tyler Ruzich,0
+Cherokee,019 Crawford,Governor,,Rep,Ken Selzer,4
+Cherokee,019 Crawford,Governor,,Rep,Joseph Tutera,1
+Cherokee,019 Crawford,Secretary of  State,,Rep,Randy Duncan,22
+Cherokee,019 Crawford,Secretary of  State,,Rep,Keith Esau,8
+Cherokee,019 Crawford,Secretary of  State,,Rep,Craig McCullah,5
+Cherokee,019 Crawford,Secretary of  State,,Rep,Scott Schwab,24
+Cherokee,019 Crawford,Secretary of  State,,Rep,Dennis Taylor,12
+Cherokee,019 Crawford,Attorney General,,Rep,Derek Schmidt,65
+Cherokee,019 Crawford,State Treasurer,,Rep,Jake LaTurner,66
+Cherokee,019 Crawford,Insurance Commissioner,,Rep,Vicki Schmidt,37
+Cherokee,019 Crawford,Insurance Commissioner,,Rep,Clark Shultz,34
+Cherokee,019 Crawford,State Senate,13,Rep,Richard Hilderbrand,69
+Cherokee,019 Crawford,State House,1,Rep,Michael Houser,71
+Cherokee,020 Garden-Lowell,Registered,,,Registered,1534
+Cherokee,020 Garden-Lowell,Ballots,,Dem,Ballots,125
+Cherokee,020 Garden-Lowell,Ballots,,Rep,Ballots,210
+Cherokee,020 Garden-Lowell,US House,2,Dem,Paul Davis,110
+Cherokee,020 Garden-Lowell,Governor,,Dem,Arden Andersen,7
+Cherokee,020 Garden-Lowell,Governor,,Dem,Jack Bergeson,7
+Cherokee,020 Garden-Lowell,Governor,,Dem,Carl Brewer,13
+Cherokee,020 Garden-Lowell,Governor,,Dem,Laura Kelly,37
+Cherokee,020 Garden-Lowell,Governor,,Dem,Joshua Svaty,58
+Cherokee,020 Garden-Lowell,Secretary of State,,Dem,Brian McClendon,115
+Cherokee,020 Garden-Lowell,Attorney General,,Dem,Sarah Swain,117
+Cherokee,020 Garden-Lowell,State Treasurer,,Dem,Marci Francisco,114
+Cherokee,020 Garden-Lowell,Insurance Commissioner,,Dem,Nathaniel McLaughlin,116
+Cherokee,020 Garden-Lowell,State Senate,13,Dem,Bryan Hoffman,115
+Cherokee,020 Garden-Lowell,State House,1,Dem,write-in,22
+Cherokee,020 Garden-Lowell,US House,2,Rep,Vernon Fields,4
+Cherokee,020 Garden-Lowell,US House,2,Rep,Steve Fitzgerald,19
+Cherokee,020 Garden-Lowell,US House,2,Rep,Kevin Jones,52
+Cherokee,020 Garden-Lowell,US House,2,Rep,Doug Mays,12
+Cherokee,020 Garden-Lowell,US House,2,Rep,Dennis Pyle,25
+Cherokee,020 Garden-Lowell,US House,2,Rep,Caron Tyson,35
+Cherokee,020 Garden-Lowell,US House,2,Rep,Steve Watkins,57
+Cherokee,020 Garden-Lowell,Governor,,Rep,Jim Barnett,10
+Cherokee,020 Garden-Lowell,Governor,,Rep,Jeff Colyer,53
+Cherokee,020 Garden-Lowell,Governor,,Rep,Kris Kobach,116
+Cherokee,020 Garden-Lowell,Governor,,Rep,Patrick Kucera,2
+Cherokee,020 Garden-Lowell,Governor,,Rep,Tyler Ruzich,2
+Cherokee,020 Garden-Lowell,Governor,,Rep,Ken Selzer,20
+Cherokee,020 Garden-Lowell,Governor,,Rep,Joseph Tutera,1
+Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Randy Duncan,44
+Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Keith Esau,33
+Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Craig McCullah,22
+Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Scott Schwab,52
+Cherokee,020 Garden-Lowell,Secretary of  State,,Rep,Dennis Taylor,37
+Cherokee,020 Garden-Lowell,Attorney General,,Rep,Derek Schmidt,179
+Cherokee,020 Garden-Lowell,State Treasurer,,Rep,Jake LaTurner,182
+Cherokee,020 Garden-Lowell,Insurance Commissioner,,Rep,Vicki Schmidt,100
+Cherokee,020 Garden-Lowell,Insurance Commissioner,,Rep,Clark Shultz,87
+Cherokee,020 Garden-Lowell,State Senate,13,Rep,Richard Hilderbrand,190
+Cherokee,020 Garden-Lowell,State House,1,Rep,Michael Houser,182
+Cherokee,021 Garden-Stanley Mines,Registered,,,Registered,520
+Cherokee,021 Garden-Stanley Mines,Ballots,,Dem,Ballots,16
+Cherokee,021 Garden-Stanley Mines,Ballots,,Rep,Ballots,87
+Cherokee,021 Garden-Stanley Mines,US House,2,Dem,Paul Davis,14
+Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Arden Andersen,2
+Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Jack Bergeson,1
+Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Carl Brewer,4
+Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Laura Kelly,4
+Cherokee,021 Garden-Stanley Mines,Governor,,Dem,Joshua Svaty,5
+Cherokee,021 Garden-Stanley Mines,Secretary of State,,Dem,Brian McClendon,14
+Cherokee,021 Garden-Stanley Mines,Attorney General,,Dem,Sarah Swain,13
+Cherokee,021 Garden-Stanley Mines,State Treasurer,,Dem,Marci Francisco,12
+Cherokee,021 Garden-Stanley Mines,Insurance Commissioner,,Dem,Nathaniel McLaughlin,13
+Cherokee,021 Garden-Stanley Mines,State Senate,13,Dem,Bryan Hoffman,13
+Cherokee,021 Garden-Stanley Mines,State House,1,Dem,write-in,4
+Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Vernon Fields,0
+Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Steve Fitzgerald,6
+Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Kevin Jones,22
+Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Doug Mays,7
+Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Dennis Pyle,10
+Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Caron Tyson,9
+Cherokee,021 Garden-Stanley Mines,US House,2,Rep,Steve Watkins,25
+Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Jim Barnett,8
+Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Jeff Colyer,24
+Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Kris Kobach,42
+Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Patrick Kucera,1
+Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Tyler Ruzich,1
+Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Ken Selzer,6
+Cherokee,021 Garden-Stanley Mines,Governor,,Rep,Joseph Tutera,1
+Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Randy Duncan,20
+Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Keith Esau,4
+Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Craig McCullah,12
+Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Scott Schwab,22
+Cherokee,021 Garden-Stanley Mines,Secretary of  State,,Rep,Dennis Taylor,16
+Cherokee,021 Garden-Stanley Mines,Attorney General,,Rep,Derek Schmidt,72
+Cherokee,021 Garden-Stanley Mines,State Treasurer,,Rep,Jake LaTurner,70
+Cherokee,021 Garden-Stanley Mines,Insurance Commissioner,,Rep,Vicki Schmidt,48
+Cherokee,021 Garden-Stanley Mines,Insurance Commissioner,,Rep,Clark Shultz,28
+Cherokee,021 Garden-Stanley Mines,State Senate,13,Rep,Richard Hilderbrand,79
+Cherokee,021 Garden-Stanley Mines,State House,1,Rep,Michael Houser,70
+Cherokee,022 Lola,Registered,,,Registered,238
+Cherokee,022 Lola,Ballots,,Dem,Ballots,14
+Cherokee,022 Lola,Ballots,,Rep,Ballots,31
+Cherokee,022 Lola,US House,2,Dem,Paul Davis,13
+Cherokee,022 Lola,Governor,,Dem,Arden Andersen,1
+Cherokee,022 Lola,Governor,,Dem,Jack Bergeson,0
+Cherokee,022 Lola,Governor,,Dem,Carl Brewer,2
+Cherokee,022 Lola,Governor,,Dem,Laura Kelly,5
+Cherokee,022 Lola,Governor,,Dem,Joshua Svaty,6
+Cherokee,022 Lola,Secretary of State,,Dem,Brian McClendon,13
+Cherokee,022 Lola,Attorney General,,Dem,Sarah Swain,12
+Cherokee,022 Lola,State Treasurer,,Dem,Marci Francisco,13
+Cherokee,022 Lola,Insurance Commissioner,,Dem,Nathaniel McLaughlin,13
+Cherokee,022 Lola,State Senate,13,Dem,Bryan Hoffman,13
+Cherokee,022 Lola,State House,1,Dem,write-in,1
+Cherokee,022 Lola,US House,2,Rep,Vernon Fields,0
+Cherokee,022 Lola,US House,2,Rep,Steve Fitzgerald,5
+Cherokee,022 Lola,US House,2,Rep,Kevin Jones,7
+Cherokee,022 Lola,US House,2,Rep,Doug Mays,2
+Cherokee,022 Lola,US House,2,Rep,Dennis Pyle,3
+Cherokee,022 Lola,US House,2,Rep,Caron Tyson,6
+Cherokee,022 Lola,US House,2,Rep,Steve Watkins,8
+Cherokee,022 Lola,Governor,,Rep,Jim Barnett,3
+Cherokee,022 Lola,Governor,,Rep,Jeff Colyer,10
+Cherokee,022 Lola,Governor,,Rep,Kris Kobach,13
+Cherokee,022 Lola,Governor,,Rep,Patrick Kucera,0
+Cherokee,022 Lola,Governor,,Rep,Tyler Ruzich,0
+Cherokee,022 Lola,Governor,,Rep,Ken Selzer,4
+Cherokee,022 Lola,Governor,,Rep,Joseph Tutera,1
+Cherokee,022 Lola,Secretary of  State,,Rep,Randy Duncan,3
+Cherokee,022 Lola,Secretary of  State,,Rep,Keith Esau,5
+Cherokee,022 Lola,Secretary of  State,,Rep,Craig McCullah,5
+Cherokee,022 Lola,Secretary of  State,,Rep,Scott Schwab,7
+Cherokee,022 Lola,Secretary of  State,,Rep,Dennis Taylor,6
+Cherokee,022 Lola,Attorney General,,Rep,Derek Schmidt,27
+Cherokee,022 Lola,State Treasurer,,Rep,Jake LaTurner,26
+Cherokee,022 Lola,Insurance Commissioner,,Rep,Vicki Schmidt,13
+Cherokee,022 Lola,Insurance Commissioner,,Rep,Clark Shultz,15
+Cherokee,022 Lola,State Senate,13,Rep,Richard Hilderbrand,30
+Cherokee,022 Lola,State House,1,Rep,Michael Houser,28
+Cherokee,023 Lowell,Registered,,,Registered,510
+Cherokee,023 Lowell,Ballots,,Dem,Ballots,38
+Cherokee,023 Lowell,Ballots,,Rep,Ballots,91
+Cherokee,023 Lowell,US House,2,Dem,Paul Davis,28
+Cherokee,023 Lowell,Governor,,Dem,Arden Andersen,7
+Cherokee,023 Lowell,Governor,,Dem,Jack Bergeson,5
+Cherokee,023 Lowell,Governor,,Dem,Carl Brewer,2
+Cherokee,023 Lowell,Governor,,Dem,Laura Kelly,6
+Cherokee,023 Lowell,Governor,,Dem,Joshua Svaty,13
+Cherokee,023 Lowell,Secretary of State,,Dem,Brian McClendon,32
+Cherokee,023 Lowell,Attorney General,,Dem,Sarah Swain,31
+Cherokee,023 Lowell,State Treasurer,,Dem,Marci Francisco,31
+Cherokee,023 Lowell,Insurance Commissioner,,Dem,Nathaniel McLaughlin,30
+Cherokee,023 Lowell,State Senate,13,Dem,Bryan Hoffman,30
+Cherokee,023 Lowell,State House,1,Dem,write-in,3
+Cherokee,023 Lowell,US House,2,Rep,Vernon Fields,1
+Cherokee,023 Lowell,US House,2,Rep,Steve Fitzgerald,4
+Cherokee,023 Lowell,US House,2,Rep,Kevin Jones,10
+Cherokee,023 Lowell,US House,2,Rep,Doug Mays,2
+Cherokee,023 Lowell,US House,2,Rep,Dennis Pyle,18
+Cherokee,023 Lowell,US House,2,Rep,Caron Tyson,22
+Cherokee,023 Lowell,US House,2,Rep,Steve Watkins,29
+Cherokee,023 Lowell,Governor,,Rep,Jim Barnett,6
+Cherokee,023 Lowell,Governor,,Rep,Jeff Colyer,34
+Cherokee,023 Lowell,Governor,,Rep,Kris Kobach,41
+Cherokee,023 Lowell,Governor,,Rep,Patrick Kucera,2
+Cherokee,023 Lowell,Governor,,Rep,Tyler Ruzich,0
+Cherokee,023 Lowell,Governor,,Rep,Ken Selzer,3
+Cherokee,023 Lowell,Governor,,Rep,Joseph Tutera,0
+Cherokee,023 Lowell,Secretary of  State,,Rep,Randy Duncan,19
+Cherokee,023 Lowell,Secretary of  State,,Rep,Keith Esau,13
+Cherokee,023 Lowell,Secretary of  State,,Rep,Craig McCullah,15
+Cherokee,023 Lowell,Secretary of  State,,Rep,Scott Schwab,14
+Cherokee,023 Lowell,Secretary of  State,,Rep,Dennis Taylor,13
+Cherokee,023 Lowell,Attorney General,,Rep,Derek Schmidt,76
+Cherokee,023 Lowell,State Treasurer,,Rep,Jake LaTurner,80
+Cherokee,023 Lowell,Insurance Commissioner,,Rep,Vicki Schmidt,51
+Cherokee,023 Lowell,Insurance Commissioner,,Rep,Clark Shultz,26
+Cherokee,023 Lowell,State Senate,13,Rep,Richard Hilderbrand,87
+Cherokee,023 Lowell,State House,1,Rep,Michael Houser,77
+Cherokee,024 Lyon-Lyon,Registered,,,Registered,276
+Cherokee,024 Lyon-Lyon,Ballots,,Dem,Ballots,20
+Cherokee,024 Lyon-Lyon,Ballots,,Rep,Ballots,47
+Cherokee,024 Lyon-Lyon,US House,2,Dem,Paul Davis,13
+Cherokee,024 Lyon-Lyon,Governor,,Dem,Arden Andersen,1
+Cherokee,024 Lyon-Lyon,Governor,,Dem,Jack Bergeson,1
+Cherokee,024 Lyon-Lyon,Governor,,Dem,Carl Brewer,6
+Cherokee,024 Lyon-Lyon,Governor,,Dem,Laura Kelly,4
+Cherokee,024 Lyon-Lyon,Governor,,Dem,Joshua Svaty,6
+Cherokee,024 Lyon-Lyon,Secretary of State,,Dem,Brian McClendon,14
+Cherokee,024 Lyon-Lyon,Attorney General,,Dem,Sarah Swain,16
+Cherokee,024 Lyon-Lyon,State Treasurer,,Dem,Marci Francisco,16
+Cherokee,024 Lyon-Lyon,Insurance Commissioner,,Dem,Nathaniel McLaughlin,14
+Cherokee,024 Lyon-Lyon,State Senate,13,Dem,Bryan Hoffman,15
+Cherokee,024 Lyon-Lyon,State House,1,Dem,write-in,1
+Cherokee,024 Lyon-Lyon,US House,2,Rep,Vernon Fields,1
+Cherokee,024 Lyon-Lyon,US House,2,Rep,Steve Fitzgerald,2
+Cherokee,024 Lyon-Lyon,US House,2,Rep,Kevin Jones,5
+Cherokee,024 Lyon-Lyon,US House,2,Rep,Doug Mays,0
+Cherokee,024 Lyon-Lyon,US House,2,Rep,Dennis Pyle,8
+Cherokee,024 Lyon-Lyon,US House,2,Rep,Caron Tyson,16
+Cherokee,024 Lyon-Lyon,US House,2,Rep,Steve Watkins,15
+Cherokee,024 Lyon-Lyon,Governor,,Rep,Jim Barnett,5
+Cherokee,024 Lyon-Lyon,Governor,,Rep,Jeff Colyer,10
+Cherokee,024 Lyon-Lyon,Governor,,Rep,Kris Kobach,28
+Cherokee,024 Lyon-Lyon,Governor,,Rep,Patrick Kucera,0
+Cherokee,024 Lyon-Lyon,Governor,,Rep,Tyler Ruzich,0
+Cherokee,024 Lyon-Lyon,Governor,,Rep,Ken Selzer,2
+Cherokee,024 Lyon-Lyon,Governor,,Rep,Joseph Tutera,0
+Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Randy Duncan,16
+Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Keith Esau,4
+Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Craig McCullah,6
+Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Scott Schwab,12
+Cherokee,024 Lyon-Lyon,Secretary of  State,,Rep,Dennis Taylor,6
+Cherokee,024 Lyon-Lyon,Attorney General,,Rep,Derek Schmidt,41
+Cherokee,024 Lyon-Lyon,State Treasurer,,Rep,Jake LaTurner,44
+Cherokee,024 Lyon-Lyon,Insurance Commissioner,,Rep,Vicki Schmidt,15
+Cherokee,024 Lyon-Lyon,Insurance Commissioner,,Rep,Clark Shultz,28
+Cherokee,024 Lyon-Lyon,State Senate,13,Rep,Richard Hilderbrand,39
+Cherokee,024 Lyon-Lyon,State House,1,Rep,Michael Houser,40
+Cherokee,025 Mineral,Registered,,,Registered,144
+Cherokee,025 Mineral,Ballots,,Dem,Ballots,3
+Cherokee,025 Mineral,Ballots,,Rep,Ballots,26
+Cherokee,025 Mineral,US House,2,Dem,Paul Davis,2
+Cherokee,025 Mineral,Governor,,Dem,Arden Andersen,0
+Cherokee,025 Mineral,Governor,,Dem,Jack Bergeson,0
+Cherokee,025 Mineral,Governor,,Dem,Carl Brewer,0
+Cherokee,025 Mineral,Governor,,Dem,Laura Kelly,1
+Cherokee,025 Mineral,Governor,,Dem,Joshua Svaty,2
+Cherokee,025 Mineral,Secretary of State,,Dem,Brian McClendon,3
+Cherokee,025 Mineral,Attorney General,,Dem,Sarah Swain,3
+Cherokee,025 Mineral,State Treasurer,,Dem,Marci Francisco,3
+Cherokee,025 Mineral,Insurance Commissioner,,Dem,Nathaniel McLaughlin,3
+Cherokee,025 Mineral,State Senate,13,Dem,Bryan Hoffman,3
+Cherokee,025 Mineral,State House,1,Dem,write-in,0
+Cherokee,025 Mineral,US House,2,Rep,Vernon Fields,0
+Cherokee,025 Mineral,US House,2,Rep,Steve Fitzgerald,3
+Cherokee,025 Mineral,US House,2,Rep,Kevin Jones,3
+Cherokee,025 Mineral,US House,2,Rep,Doug Mays,2
+Cherokee,025 Mineral,US House,2,Rep,Dennis Pyle,1
+Cherokee,025 Mineral,US House,2,Rep,Caron Tyson,14
+Cherokee,025 Mineral,US House,2,Rep,Steve Watkins,0
+Cherokee,025 Mineral,Governor,,Rep,Jim Barnett,0
+Cherokee,025 Mineral,Governor,,Rep,Jeff Colyer,13
+Cherokee,025 Mineral,Governor,,Rep,Kris Kobach,13
+Cherokee,025 Mineral,Governor,,Rep,Patrick Kucera,0
+Cherokee,025 Mineral,Governor,,Rep,Tyler Ruzich,0
+Cherokee,025 Mineral,Governor,,Rep,Ken Selzer,0
+Cherokee,025 Mineral,Governor,,Rep,Joseph Tutera,0
+Cherokee,025 Mineral,Secretary of  State,,Rep,Randy Duncan,9
+Cherokee,025 Mineral,Secretary of  State,,Rep,Keith Esau,1
+Cherokee,025 Mineral,Secretary of  State,,Rep,Craig McCullah,1
+Cherokee,025 Mineral,Secretary of  State,,Rep,Scott Schwab,7
+Cherokee,025 Mineral,Secretary of  State,,Rep,Dennis Taylor,3
+Cherokee,025 Mineral,Attorney General,,Rep,Derek Schmidt,19
+Cherokee,025 Mineral,State Treasurer,,Rep,Jake LaTurner,20
+Cherokee,025 Mineral,Insurance Commissioner,,Rep,Vicki Schmidt,12
+Cherokee,025 Mineral,Insurance Commissioner,,Rep,Clark Shultz,11
+Cherokee,025 Mineral,State Senate,13,Rep,Richard Hilderbrand,19
+Cherokee,025 Mineral,State House,1,Rep,Michael Houser,22
+Cherokee,026 Neosho-Faulkner,Registered,,,Registered,85
+Cherokee,026 Neosho-Faulkner,Ballots,,Dem,Ballots,2
+Cherokee,026 Neosho-Faulkner,Ballots,,Rep,Ballots,12
+Cherokee,026 Neosho-Faulkner,US House,2,Dem,Paul Davis,2
+Cherokee,026 Neosho-Faulkner,Governor,,Dem,Arden Andersen,0
+Cherokee,026 Neosho-Faulkner,Governor,,Dem,Jack Bergeson,0
+Cherokee,026 Neosho-Faulkner,Governor,,Dem,Carl Brewer,0
+Cherokee,026 Neosho-Faulkner,Governor,,Dem,Laura Kelly,1
+Cherokee,026 Neosho-Faulkner,Governor,,Dem,Joshua Svaty,1
+Cherokee,026 Neosho-Faulkner,Secretary of State,,Dem,Brian McClendon,2
+Cherokee,026 Neosho-Faulkner,Attorney General,,Dem,Sarah Swain,2
+Cherokee,026 Neosho-Faulkner,State Treasurer,,Dem,Marci Francisco,2
+Cherokee,026 Neosho-Faulkner,Insurance Commissioner,,Dem,Nathaniel McLaughlin,2
+Cherokee,026 Neosho-Faulkner,State Senate,13,Dem,Bryan Hoffman,2
+Cherokee,026 Neosho-Faulkner,State House,1,Dem,write-in,0
+Cherokee,026 Neosho-Faulkner,US House,2,Rep,Vernon Fields,0
+Cherokee,026 Neosho-Faulkner,US House,2,Rep,Steve Fitzgerald,5
+Cherokee,026 Neosho-Faulkner,US House,2,Rep,Kevin Jones,0
+Cherokee,026 Neosho-Faulkner,US House,2,Rep,Doug Mays,0
+Cherokee,026 Neosho-Faulkner,US House,2,Rep,Dennis Pyle,0
+Cherokee,026 Neosho-Faulkner,US House,2,Rep,Caron Tyson,5
+Cherokee,026 Neosho-Faulkner,US House,2,Rep,Steve Watkins,2
+Cherokee,026 Neosho-Faulkner,Governor,,Rep,Jim Barnett,0
+Cherokee,026 Neosho-Faulkner,Governor,,Rep,Jeff Colyer,6
+Cherokee,026 Neosho-Faulkner,Governor,,Rep,Kris Kobach,5
+Cherokee,026 Neosho-Faulkner,Governor,,Rep,Patrick Kucera,0
+Cherokee,026 Neosho-Faulkner,Governor,,Rep,Tyler Ruzich,0
+Cherokee,026 Neosho-Faulkner,Governor,,Rep,Ken Selzer,1
+Cherokee,026 Neosho-Faulkner,Governor,,Rep,Joseph Tutera,0
+Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Randy Duncan,1
+Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Keith Esau,1
+Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Craig McCullah,0
+Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Scott Schwab,6
+Cherokee,026 Neosho-Faulkner,Secretary of  State,,Rep,Dennis Taylor,2
+Cherokee,026 Neosho-Faulkner,Attorney General,,Rep,Derek Schmidt,11
+Cherokee,026 Neosho-Faulkner,State Treasurer,,Rep,Jake LaTurner,11
+Cherokee,026 Neosho-Faulkner,Insurance Commissioner,,Rep,Vicki Schmidt,6
+Cherokee,026 Neosho-Faulkner,Insurance Commissioner,,Rep,Clark Shultz,5
+Cherokee,026 Neosho-Faulkner,State Senate,13,Rep,Richard Hilderbrand,11
+Cherokee,026 Neosho-Faulkner,State House,1,Rep,Michael Houser,11
+Cherokee,027 Neosho-Melrose,Registered,,,Registered,118
+Cherokee,027 Neosho-Melrose,Ballots,,Dem,Ballots,5
+Cherokee,027 Neosho-Melrose,Ballots,,Rep,Ballots,16
+Cherokee,027 Neosho-Melrose,US House,2,Dem,Paul Davis,3
+Cherokee,027 Neosho-Melrose,Governor,,Dem,Arden Andersen,1
+Cherokee,027 Neosho-Melrose,Governor,,Dem,Jack Bergeson,0
+Cherokee,027 Neosho-Melrose,Governor,,Dem,Carl Brewer,3
+Cherokee,027 Neosho-Melrose,Governor,,Dem,Laura Kelly,0
+Cherokee,027 Neosho-Melrose,Governor,,Dem,Joshua Svaty,0
+Cherokee,027 Neosho-Melrose,Secretary of State,,Dem,Brian McClendon,3
+Cherokee,027 Neosho-Melrose,Attorney General,,Dem,Sarah Swain,3
+Cherokee,027 Neosho-Melrose,State Treasurer,,Dem,Marci Francisco,3
+Cherokee,027 Neosho-Melrose,Insurance Commissioner,,Dem,Nathaniel McLaughlin,3
+Cherokee,027 Neosho-Melrose,State Senate,13,Dem,Bryan Hoffman,3
+Cherokee,027 Neosho-Melrose,State House,1,Dem,write-in,1
+Cherokee,027 Neosho-Melrose,US House,2,Rep,Vernon Fields,2
+Cherokee,027 Neosho-Melrose,US House,2,Rep,Steve Fitzgerald,2
+Cherokee,027 Neosho-Melrose,US House,2,Rep,Kevin Jones,5
+Cherokee,027 Neosho-Melrose,US House,2,Rep,Doug Mays,1
+Cherokee,027 Neosho-Melrose,US House,2,Rep,Dennis Pyle,3
+Cherokee,027 Neosho-Melrose,US House,2,Rep,Caron Tyson,1
+Cherokee,027 Neosho-Melrose,US House,2,Rep,Steve Watkins,2
+Cherokee,027 Neosho-Melrose,Governor,,Rep,Jim Barnett,0
+Cherokee,027 Neosho-Melrose,Governor,,Rep,Jeff Colyer,2
+Cherokee,027 Neosho-Melrose,Governor,,Rep,Kris Kobach,12
+Cherokee,027 Neosho-Melrose,Governor,,Rep,Patrick Kucera,0
+Cherokee,027 Neosho-Melrose,Governor,,Rep,Tyler Ruzich,0
+Cherokee,027 Neosho-Melrose,Governor,,Rep,Ken Selzer,2
+Cherokee,027 Neosho-Melrose,Governor,,Rep,Joseph Tutera,0
+Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Randy Duncan,5
+Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Keith Esau,1
+Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Craig McCullah,1
+Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Scott Schwab,6
+Cherokee,027 Neosho-Melrose,Secretary of  State,,Rep,Dennis Taylor,1
+Cherokee,027 Neosho-Melrose,Attorney General,,Rep,Derek Schmidt,13
+Cherokee,027 Neosho-Melrose,State Treasurer,,Rep,Jake LaTurner,14
+Cherokee,027 Neosho-Melrose,Insurance Commissioner,,Rep,Vicki Schmidt,8
+Cherokee,027 Neosho-Melrose,Insurance Commissioner,,Rep,Clark Shultz,8
+Cherokee,027 Neosho-Melrose,State Senate,13,Rep,Richard Hilderbrand,15
+Cherokee,027 Neosho-Melrose,State House,1,Rep,Michael Houser,13
+Cherokee,028 Pleasant View,Registered,,,Registered,457
+Cherokee,028 Pleasant View,Ballots,,Dem,Ballots,31
+Cherokee,028 Pleasant View,Ballots,,Rep,Ballots,79
+Cherokee,028 Pleasant View,US House,2,Dem,Paul Davis,27
+Cherokee,028 Pleasant View,Governor,,Dem,Arden Andersen,6
+Cherokee,028 Pleasant View,Governor,,Dem,Jack Bergeson,3
+Cherokee,028 Pleasant View,Governor,,Dem,Carl Brewer,1
+Cherokee,028 Pleasant View,Governor,,Dem,Laura Kelly,11
+Cherokee,028 Pleasant View,Governor,,Dem,Joshua Svaty,8
+Cherokee,028 Pleasant View,Secretary of State,,Dem,Brian McClendon,27
+Cherokee,028 Pleasant View,Attorney General,,Dem,Sarah Swain,27
+Cherokee,028 Pleasant View,State Treasurer,,Dem,Marci Francisco,29
+Cherokee,028 Pleasant View,Insurance Commissioner,,Dem,Nathaniel McLaughlin,29
+Cherokee,028 Pleasant View,State Senate,13,Dem,Bryan Hoffman,29
+Cherokee,028 Pleasant View,State House,1,Dem,write-in,5
+Cherokee,028 Pleasant View,US House,2,Rep,Vernon Fields,3
+Cherokee,028 Pleasant View,US House,2,Rep,Steve Fitzgerald,7
+Cherokee,028 Pleasant View,US House,2,Rep,Kevin Jones,6
+Cherokee,028 Pleasant View,US House,2,Rep,Doug Mays,6
+Cherokee,028 Pleasant View,US House,2,Rep,Dennis Pyle,8
+Cherokee,028 Pleasant View,US House,2,Rep,Caron Tyson,29
+Cherokee,028 Pleasant View,US House,2,Rep,Steve Watkins,18
+Cherokee,028 Pleasant View,Governor,,Rep,Jim Barnett,10
+Cherokee,028 Pleasant View,Governor,,Rep,Jeff Colyer,19
+Cherokee,028 Pleasant View,Governor,,Rep,Kris Kobach,41
+Cherokee,028 Pleasant View,Governor,,Rep,Patrick Kucera,0
+Cherokee,028 Pleasant View,Governor,,Rep,Tyler Ruzich,0
+Cherokee,028 Pleasant View,Governor,,Rep,Ken Selzer,7
+Cherokee,028 Pleasant View,Governor,,Rep,Joseph Tutera,0
+Cherokee,028 Pleasant View,Secretary of  State,,Rep,Randy Duncan,26
+Cherokee,028 Pleasant View,Secretary of  State,,Rep,Keith Esau,8
+Cherokee,028 Pleasant View,Secretary of  State,,Rep,Craig McCullah,8
+Cherokee,028 Pleasant View,Secretary of  State,,Rep,Scott Schwab,11
+Cherokee,028 Pleasant View,Secretary of  State,,Rep,Dennis Taylor,14
+Cherokee,028 Pleasant View,Attorney General,,Rep,Derek Schmidt,67
+Cherokee,028 Pleasant View,State Treasurer,,Rep,Jake LaTurner,69
+Cherokee,028 Pleasant View,Insurance Commissioner,,Rep,Vicki Schmidt,34
+Cherokee,028 Pleasant View,Insurance Commissioner,,Rep,Clark Shultz,40
+Cherokee,028 Pleasant View,State Senate,13,Rep,Richard Hilderbrand,67
+Cherokee,028 Pleasant View,State House,1,Rep,Michael Houser,68
+Cherokee,029 Ross-Belleview,Registered,,,Registered,134
+Cherokee,029 Ross-Belleview,Ballots,,Dem,Ballots,7
+Cherokee,029 Ross-Belleview,Ballots,,Rep,Ballots,24
+Cherokee,029 Ross-Belleview,US House,2,Dem,Paul Davis,5
+Cherokee,029 Ross-Belleview,Governor,,Dem,Arden Andersen,1
+Cherokee,029 Ross-Belleview,Governor,,Dem,Jack Bergeson,1
+Cherokee,029 Ross-Belleview,Governor,,Dem,Carl Brewer,1
+Cherokee,029 Ross-Belleview,Governor,,Dem,Laura Kelly,2
+Cherokee,029 Ross-Belleview,Governor,,Dem,Joshua Svaty,2
+Cherokee,029 Ross-Belleview,Secretary of State,,Dem,Brian McClendon,4
+Cherokee,029 Ross-Belleview,Attorney General,,Dem,Sarah Swain,5
+Cherokee,029 Ross-Belleview,State Treasurer,,Dem,Marci Francisco,6
+Cherokee,029 Ross-Belleview,Insurance Commissioner,,Dem,Nathaniel McLaughlin,5
+Cherokee,029 Ross-Belleview,State Senate,13,Dem,Bryan Hoffman,6
+Cherokee,029 Ross-Belleview,State House,1,Dem,write-in,1
+Cherokee,029 Ross-Belleview,US House,2,Rep,Vernon Fields,2
+Cherokee,029 Ross-Belleview,US House,2,Rep,Steve Fitzgerald,3
+Cherokee,029 Ross-Belleview,US House,2,Rep,Kevin Jones,1
+Cherokee,029 Ross-Belleview,US House,2,Rep,Doug Mays,3
+Cherokee,029 Ross-Belleview,US House,2,Rep,Dennis Pyle,2
+Cherokee,029 Ross-Belleview,US House,2,Rep,Caron Tyson,7
+Cherokee,029 Ross-Belleview,US House,2,Rep,Steve Watkins,5
+Cherokee,029 Ross-Belleview,Governor,,Rep,Jim Barnett,0
+Cherokee,029 Ross-Belleview,Governor,,Rep,Jeff Colyer,11
+Cherokee,029 Ross-Belleview,Governor,,Rep,Kris Kobach,10
+Cherokee,029 Ross-Belleview,Governor,,Rep,Patrick Kucera,0
+Cherokee,029 Ross-Belleview,Governor,,Rep,Tyler Ruzich,0
+Cherokee,029 Ross-Belleview,Governor,,Rep,Ken Selzer,2
+Cherokee,029 Ross-Belleview,Governor,,Rep,Joseph Tutera,0
+Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Randy Duncan,6
+Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Keith Esau,2
+Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Craig McCullah,2
+Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Scott Schwab,9
+Cherokee,029 Ross-Belleview,Secretary of  State,,Rep,Dennis Taylor,1
+Cherokee,029 Ross-Belleview,Attorney General,,Rep,Derek Schmidt,18
+Cherokee,029 Ross-Belleview,State Treasurer,,Rep,Jake LaTurner,21
+Cherokee,029 Ross-Belleview,Insurance Commissioner,,Rep,Vicki Schmidt,14
+Cherokee,029 Ross-Belleview,Insurance Commissioner,,Rep,Clark Shultz,8
+Cherokee,029 Ross-Belleview,State Senate,13,Rep,Richard Hilderbrand,22
+Cherokee,029 Ross-Belleview,State House,1,Rep,Michael Houser,23
+Cherokee,030 Ross-Roseland,Registered,,,Registered,193
+Cherokee,030 Ross-Roseland,Ballots,,Dem,Ballots,20
+Cherokee,030 Ross-Roseland,Ballots,,Rep,Ballots,25
+Cherokee,030 Ross-Roseland,US House,2,Dem,Paul Davis,17
+Cherokee,030 Ross-Roseland,Governor,,Dem,Arden Andersen,2
+Cherokee,030 Ross-Roseland,Governor,,Dem,Jack Bergeson,0
+Cherokee,030 Ross-Roseland,Governor,,Dem,Carl Brewer,3
+Cherokee,030 Ross-Roseland,Governor,,Dem,Laura Kelly,7
+Cherokee,030 Ross-Roseland,Governor,,Dem,Joshua Svaty,7
+Cherokee,030 Ross-Roseland,Secretary of State,,Dem,Brian McClendon,19
+Cherokee,030 Ross-Roseland,Attorney General,,Dem,Sarah Swain,19
+Cherokee,030 Ross-Roseland,State Treasurer,,Dem,Marci Francisco,19
+Cherokee,030 Ross-Roseland,Insurance Commissioner,,Dem,Nathaniel McLaughlin,18
+Cherokee,030 Ross-Roseland,State Senate,13,Dem,Bryan Hoffman,19
+Cherokee,030 Ross-Roseland,State House,1,Dem,write-in,3
+Cherokee,030 Ross-Roseland,US House,2,Rep,Vernon Fields,1
+Cherokee,030 Ross-Roseland,US House,2,Rep,Steve Fitzgerald,0
+Cherokee,030 Ross-Roseland,US House,2,Rep,Kevin Jones,4
+Cherokee,030 Ross-Roseland,US House,2,Rep,Doug Mays,2
+Cherokee,030 Ross-Roseland,US House,2,Rep,Dennis Pyle,4
+Cherokee,030 Ross-Roseland,US House,2,Rep,Caron Tyson,8
+Cherokee,030 Ross-Roseland,US House,2,Rep,Steve Watkins,4
+Cherokee,030 Ross-Roseland,Governor,,Rep,Jim Barnett,1
+Cherokee,030 Ross-Roseland,Governor,,Rep,Jeff Colyer,10
+Cherokee,030 Ross-Roseland,Governor,,Rep,Kris Kobach,13
+Cherokee,030 Ross-Roseland,Governor,,Rep,Patrick Kucera,0
+Cherokee,030 Ross-Roseland,Governor,,Rep,Tyler Ruzich,0
+Cherokee,030 Ross-Roseland,Governor,,Rep,Ken Selzer,1
+Cherokee,030 Ross-Roseland,Governor,,Rep,Joseph Tutera,0
+Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Randy Duncan,9
+Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Keith Esau,2
+Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Craig McCullah,3
+Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Scott Schwab,6
+Cherokee,030 Ross-Roseland,Secretary of  State,,Rep,Dennis Taylor,2
+Cherokee,030 Ross-Roseland,Attorney General,,Rep,Derek Schmidt,20
+Cherokee,030 Ross-Roseland,State Treasurer,,Rep,Jake LaTurner,20
+Cherokee,030 Ross-Roseland,Insurance Commissioner,,Rep,Vicki Schmidt,13
+Cherokee,030 Ross-Roseland,Insurance Commissioner,,Rep,Clark Shultz,9
+Cherokee,030 Ross-Roseland,State Senate,13,Rep,Richard Hilderbrand,21
+Cherokee,030 Ross-Roseland,State House,1,Rep,Michael Houser,22
+Cherokee,031 Ross-West Mineral,Registered,,,Registered,159
+Cherokee,031 Ross-West Mineral,Ballots,,Dem,Ballots,25
+Cherokee,031 Ross-West Mineral,Ballots,,Rep,Ballots,22
+Cherokee,031 Ross-West Mineral,US House,2,Dem,Paul Davis,23
+Cherokee,031 Ross-West Mineral,Governor,,Dem,Arden Andersen,6
+Cherokee,031 Ross-West Mineral,Governor,,Dem,Jack Bergeson,2
+Cherokee,031 Ross-West Mineral,Governor,,Dem,Carl Brewer,7
+Cherokee,031 Ross-West Mineral,Governor,,Dem,Laura Kelly,3
+Cherokee,031 Ross-West Mineral,Governor,,Dem,Joshua Svaty,4
+Cherokee,031 Ross-West Mineral,Secretary of State,,Dem,Brian McClendon,22
+Cherokee,031 Ross-West Mineral,Attorney General,,Dem,Sarah Swain,23
+Cherokee,031 Ross-West Mineral,State Treasurer,,Dem,Marci Francisco,22
+Cherokee,031 Ross-West Mineral,Insurance Commissioner,,Dem,Nathaniel McLaughlin,24
+Cherokee,031 Ross-West Mineral,State Senate,13,Dem,Bryan Hoffman,23
+Cherokee,031 Ross-West Mineral,State House,1,Dem,write-in,1
+Cherokee,031 Ross-West Mineral,US House,2,Rep,Vernon Fields,0
+Cherokee,031 Ross-West Mineral,US House,2,Rep,Steve Fitzgerald,4
+Cherokee,031 Ross-West Mineral,US House,2,Rep,Kevin Jones,0
+Cherokee,031 Ross-West Mineral,US House,2,Rep,Doug Mays,2
+Cherokee,031 Ross-West Mineral,US House,2,Rep,Dennis Pyle,1
+Cherokee,031 Ross-West Mineral,US House,2,Rep,Caron Tyson,6
+Cherokee,031 Ross-West Mineral,US House,2,Rep,Steve Watkins,8
+Cherokee,031 Ross-West Mineral,Governor,,Rep,Jim Barnett,1
+Cherokee,031 Ross-West Mineral,Governor,,Rep,Jeff Colyer,5
+Cherokee,031 Ross-West Mineral,Governor,,Rep,Kris Kobach,12
+Cherokee,031 Ross-West Mineral,Governor,,Rep,Patrick Kucera,0
+Cherokee,031 Ross-West Mineral,Governor,,Rep,Tyler Ruzich,0
+Cherokee,031 Ross-West Mineral,Governor,,Rep,Ken Selzer,2
+Cherokee,031 Ross-West Mineral,Governor,,Rep,Joseph Tutera,1
+Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Randy Duncan,1
+Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Keith Esau,2
+Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Craig McCullah,4
+Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Scott Schwab,3
+Cherokee,031 Ross-West Mineral,Secretary of  State,,Rep,Dennis Taylor,6
+Cherokee,031 Ross-West Mineral,Attorney General,,Rep,Derek Schmidt,17
+Cherokee,031 Ross-West Mineral,State Treasurer,,Rep,Jake LaTurner,18
+Cherokee,031 Ross-West Mineral,Insurance Commissioner,,Rep,Vicki Schmidt,8
+Cherokee,031 Ross-West Mineral,Insurance Commissioner,,Rep,Clark Shultz,11
+Cherokee,031 Ross-West Mineral,State Senate,13,Rep,Richard Hilderbrand,19
+Cherokee,031 Ross-West Mineral,State House,1,Rep,Michael Houser,21
+Cherokee,032 Salamanca,Registered,,,Registered,416
+Cherokee,032 Salamanca,Ballots,,Dem,Ballots,31
+Cherokee,032 Salamanca,Ballots,,Rep,Ballots,62
+Cherokee,032 Salamanca,US House,2,Dem,Paul Davis,27
+Cherokee,032 Salamanca,Governor,,Dem,Arden Andersen,5
+Cherokee,032 Salamanca,Governor,,Dem,Jack Bergeson,0
+Cherokee,032 Salamanca,Governor,,Dem,Carl Brewer,2
+Cherokee,032 Salamanca,Governor,,Dem,Laura Kelly,10
+Cherokee,032 Salamanca,Governor,,Dem,Joshua Svaty,14
+Cherokee,032 Salamanca,Secretary of State,,Dem,Brian McClendon,27
+Cherokee,032 Salamanca,Attorney General,,Dem,Sarah Swain,27
+Cherokee,032 Salamanca,State Treasurer,,Dem,Marci Francisco,26
+Cherokee,032 Salamanca,Insurance Commissioner,,Dem,Nathaniel McLaughlin,26
+Cherokee,032 Salamanca,State Senate,13,Dem,Bryan Hoffman,27
+Cherokee,032 Salamanca,State House,1,Dem,write-in,3
+Cherokee,032 Salamanca,US House,2,Rep,Vernon Fields,0
+Cherokee,032 Salamanca,US House,2,Rep,Steve Fitzgerald,7
+Cherokee,032 Salamanca,US House,2,Rep,Kevin Jones,1
+Cherokee,032 Salamanca,US House,2,Rep,Doug Mays,1
+Cherokee,032 Salamanca,US House,2,Rep,Dennis Pyle,5
+Cherokee,032 Salamanca,US House,2,Rep,Caron Tyson,32
+Cherokee,032 Salamanca,US House,2,Rep,Steve Watkins,13
+Cherokee,032 Salamanca,Governor,,Rep,Jim Barnett,2
+Cherokee,032 Salamanca,Governor,,Rep,Jeff Colyer,23
+Cherokee,032 Salamanca,Governor,,Rep,Kris Kobach,32
+Cherokee,032 Salamanca,Governor,,Rep,Patrick Kucera,0
+Cherokee,032 Salamanca,Governor,,Rep,Tyler Ruzich,0
+Cherokee,032 Salamanca,Governor,,Rep,Ken Selzer,4
+Cherokee,032 Salamanca,Governor,,Rep,Joseph Tutera,0
+Cherokee,032 Salamanca,Secretary of  State,,Rep,Randy Duncan,15
+Cherokee,032 Salamanca,Secretary of  State,,Rep,Keith Esau,6
+Cherokee,032 Salamanca,Secretary of  State,,Rep,Craig McCullah,5
+Cherokee,032 Salamanca,Secretary of  State,,Rep,Scott Schwab,17
+Cherokee,032 Salamanca,Secretary of  State,,Rep,Dennis Taylor,12
+Cherokee,032 Salamanca,Attorney General,,Rep,Derek Schmidt,49
+Cherokee,032 Salamanca,State Treasurer,,Rep,Jake LaTurner,52
+Cherokee,032 Salamanca,Insurance Commissioner,,Rep,Vicki Schmidt,34
+Cherokee,032 Salamanca,Insurance Commissioner,,Rep,Clark Shultz,23
+Cherokee,032 Salamanca,State Senate,13,Rep,Richard Hilderbrand,53
+Cherokee,032 Salamanca,State House,1,Rep,Michael Houser,53
+Cherokee,033 Shawnee,Registered,,,Registered,349
+Cherokee,033 Shawnee,Ballots,,Dem,Ballots,26
+Cherokee,033 Shawnee,Ballots,,Rep,Ballots,97
+Cherokee,033 Shawnee,US House,2,Dem,Paul Davis,19
+Cherokee,033 Shawnee,Governor,,Dem,Arden Andersen,3
+Cherokee,033 Shawnee,Governor,,Dem,Jack Bergeson,3
+Cherokee,033 Shawnee,Governor,,Dem,Carl Brewer,5
+Cherokee,033 Shawnee,Governor,,Dem,Laura Kelly,9
+Cherokee,033 Shawnee,Governor,,Dem,Joshua Svaty,4
+Cherokee,033 Shawnee,Secretary of State,,Dem,Brian McClendon,19
+Cherokee,033 Shawnee,Attorney General,,Dem,Sarah Swain,21
+Cherokee,033 Shawnee,State Treasurer,,Dem,Marci Francisco,20
+Cherokee,033 Shawnee,Insurance Commissioner,,Dem,Nathaniel McLaughlin,20
+Cherokee,033 Shawnee,State Senate,13,Dem,Bryan Hoffman,21
+Cherokee,033 Shawnee,State House,1,Dem,write-in,3
+Cherokee,033 Shawnee,US House,2,Rep,Vernon Fields,2
+Cherokee,033 Shawnee,US House,2,Rep,Steve Fitzgerald,13
+Cherokee,033 Shawnee,US House,2,Rep,Kevin Jones,22
+Cherokee,033 Shawnee,US House,2,Rep,Doug Mays,1
+Cherokee,033 Shawnee,US House,2,Rep,Dennis Pyle,12
+Cherokee,033 Shawnee,US House,2,Rep,Caron Tyson,32
+Cherokee,033 Shawnee,US House,2,Rep,Steve Watkins,10
+Cherokee,033 Shawnee,Governor,,Rep,Jim Barnett,3
+Cherokee,033 Shawnee,Governor,,Rep,Jeff Colyer,30
+Cherokee,033 Shawnee,Governor,,Rep,Kris Kobach,52
+Cherokee,033 Shawnee,Governor,,Rep,Patrick Kucera,3
+Cherokee,033 Shawnee,Governor,,Rep,Tyler Ruzich,0
+Cherokee,033 Shawnee,Governor,,Rep,Ken Selzer,3
+Cherokee,033 Shawnee,Governor,,Rep,Joseph Tutera,0
+Cherokee,033 Shawnee,Secretary of  State,,Rep,Randy Duncan,31
+Cherokee,033 Shawnee,Secretary of  State,,Rep,Keith Esau,8
+Cherokee,033 Shawnee,Secretary of  State,,Rep,Craig McCullah,9
+Cherokee,033 Shawnee,Secretary of  State,,Rep,Scott Schwab,27
+Cherokee,033 Shawnee,Secretary of  State,,Rep,Dennis Taylor,10
+Cherokee,033 Shawnee,Attorney General,,Rep,Derek Schmidt,81
+Cherokee,033 Shawnee,State Treasurer,,Rep,Jake LaTurner,86
+Cherokee,033 Shawnee,Insurance Commissioner,,Rep,Vicki Schmidt,50
+Cherokee,033 Shawnee,Insurance Commissioner,,Rep,Clark Shultz,36
+Cherokee,033 Shawnee,State Senate,13,Rep,Richard Hilderbrand,85
+Cherokee,033 Shawnee,State House,1,Rep,Michael Houser,83
+Cherokee,034 Sheridan,Registered,,,Registered,163
+Cherokee,034 Sheridan,Ballots,,Dem,Ballots,11
+Cherokee,034 Sheridan,Ballots,,Rep,Ballots,34
+Cherokee,034 Sheridan,US House,2,Dem,Paul Davis,11
+Cherokee,034 Sheridan,Governor,,Dem,Arden Andersen,1
+Cherokee,034 Sheridan,Governor,,Dem,Jack Bergeson,0
+Cherokee,034 Sheridan,Governor,,Dem,Carl Brewer,3
+Cherokee,034 Sheridan,Governor,,Dem,Laura Kelly,4
+Cherokee,034 Sheridan,Governor,,Dem,Joshua Svaty,3
+Cherokee,034 Sheridan,Secretary of State,,Dem,Brian McClendon,10
+Cherokee,034 Sheridan,Attorney General,,Dem,Sarah Swain,11
+Cherokee,034 Sheridan,State Treasurer,,Dem,Marci Francisco,10
+Cherokee,034 Sheridan,Insurance Commissioner,,Dem,Nathaniel McLaughlin,10
+Cherokee,034 Sheridan,State Senate,13,Dem,Bryan Hoffman,11
+Cherokee,034 Sheridan,State House,1,Dem,write-in,3
+Cherokee,034 Sheridan,US House,2,Rep,Vernon Fields,0
+Cherokee,034 Sheridan,US House,2,Rep,Steve Fitzgerald,6
+Cherokee,034 Sheridan,US House,2,Rep,Kevin Jones,5
+Cherokee,034 Sheridan,US House,2,Rep,Doug Mays,2
+Cherokee,034 Sheridan,US House,2,Rep,Dennis Pyle,2
+Cherokee,034 Sheridan,US House,2,Rep,Caron Tyson,17
+Cherokee,034 Sheridan,US House,2,Rep,Steve Watkins,2
+Cherokee,034 Sheridan,Governor,,Rep,Jim Barnett,1
+Cherokee,034 Sheridan,Governor,,Rep,Jeff Colyer,18
+Cherokee,034 Sheridan,Governor,,Rep,Kris Kobach,15
+Cherokee,034 Sheridan,Governor,,Rep,Patrick Kucera,0
+Cherokee,034 Sheridan,Governor,,Rep,Tyler Ruzich,0
+Cherokee,034 Sheridan,Governor,,Rep,Ken Selzer,0
+Cherokee,034 Sheridan,Governor,,Rep,Joseph Tutera,0
+Cherokee,034 Sheridan,Secretary of  State,,Rep,Randy Duncan,7
+Cherokee,034 Sheridan,Secretary of  State,,Rep,Keith Esau,5
+Cherokee,034 Sheridan,Secretary of  State,,Rep,Craig McCullah,3
+Cherokee,034 Sheridan,Secretary of  State,,Rep,Scott Schwab,12
+Cherokee,034 Sheridan,Secretary of  State,,Rep,Dennis Taylor,5
+Cherokee,034 Sheridan,Attorney General,,Rep,Derek Schmidt,33
+Cherokee,034 Sheridan,State Treasurer,,Rep,Jake LaTurner,32
+Cherokee,034 Sheridan,Insurance Commissioner,,Rep,Vicki Schmidt,18
+Cherokee,034 Sheridan,Insurance Commissioner,,Rep,Clark Shultz,15
+Cherokee,034 Sheridan,State Senate,13,Rep,Richard Hilderbrand,31
+Cherokee,034 Sheridan,State House,1,Rep,Michael Houser,32
+Cherokee,035 Spring Valley-Neutral,Registered,,,Registered,471
+Cherokee,035 Spring Valley-Neutral,Ballots,,Dem,Ballots,34
+Cherokee,035 Spring Valley-Neutral,Ballots,,Rep,Ballots,72
+Cherokee,035 Spring Valley-Neutral,US House,2,Dem,Paul Davis,29
+Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Arden Andersen,0
+Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Jack Bergeson,1
+Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Carl Brewer,3
+Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Laura Kelly,5
+Cherokee,035 Spring Valley-Neutral,Governor,,Dem,Joshua Svaty,23
+Cherokee,035 Spring Valley-Neutral,Secretary of State,,Dem,Brian McClendon,29
+Cherokee,035 Spring Valley-Neutral,Attorney General,,Dem,Sarah Swain,32
+Cherokee,035 Spring Valley-Neutral,State Treasurer,,Dem,Marci Francisco,32
+Cherokee,035 Spring Valley-Neutral,Insurance Commissioner,,Dem,Nathaniel McLaughlin,29
+Cherokee,035 Spring Valley-Neutral,State Senate,13,Dem,Bryan Hoffman,30
+Cherokee,035 Spring Valley-Neutral,State House,1,Dem,write-in,5
+Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Vernon Fields,5
+Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Steve Fitzgerald,7
+Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Kevin Jones,9
+Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Doug Mays,2
+Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Dennis Pyle,10
+Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Caron Tyson,16
+Cherokee,035 Spring Valley-Neutral,US House,2,Rep,Steve Watkins,22
+Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Jim Barnett,3
+Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Jeff Colyer,32
+Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Kris Kobach,31
+Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Patrick Kucera,2
+Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Tyler Ruzich,0
+Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Ken Selzer,3
+Cherokee,035 Spring Valley-Neutral,Governor,,Rep,Joseph Tutera,0
+Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Randy Duncan,22
+Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Keith Esau,3
+Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Craig McCullah,8
+Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Scott Schwab,20
+Cherokee,035 Spring Valley-Neutral,Secretary of  State,,Rep,Dennis Taylor,14
+Cherokee,035 Spring Valley-Neutral,Attorney General,,Rep,Derek Schmidt,64
+Cherokee,035 Spring Valley-Neutral,State Treasurer,,Rep,Jake LaTurner,63
+Cherokee,035 Spring Valley-Neutral,Insurance Commissioner,,Rep,Vicki Schmidt,42
+Cherokee,035 Spring Valley-Neutral,Insurance Commissioner,,Rep,Clark Shultz,29
+Cherokee,035 Spring Valley-Neutral,State Senate,13,Rep,Richard Hilderbrand,65
+Cherokee,035 Spring Valley-Neutral,State House,1,Rep,Michael Houser,64
+Cherokee,036 Spring Valley-Spring Valley,Registered,,,Registered,345
+Cherokee,036 Spring Valley-Spring Valley,Ballots,,Dem,Ballots,15
+Cherokee,036 Spring Valley-Spring Valley,Ballots,,Rep,Ballots,43
+Cherokee,036 Spring Valley-Spring Valley,US House,2,Dem,Paul Davis,11
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Arden Andersen,0
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Jack Bergeson,0
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Carl Brewer,0
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Laura Kelly,3
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Dem,Joshua Svaty,10
+Cherokee,036 Spring Valley-Spring Valley,Secretary of State,,Dem,Brian McClendon,9
+Cherokee,036 Spring Valley-Spring Valley,Attorney General,,Dem,Sarah Swain,11
+Cherokee,036 Spring Valley-Spring Valley,State Treasurer,,Dem,Marci Francisco,10
+Cherokee,036 Spring Valley-Spring Valley,Insurance Commissioner,,Dem,Nathaniel McLaughlin,10
+Cherokee,036 Spring Valley-Spring Valley,State Senate,13,Dem,Bryan Hoffman,12
+Cherokee,036 Spring Valley-Spring Valley,State House,1,Dem,write-in,2
+Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Vernon Fields,1
+Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Steve Fitzgerald,3
+Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Kevin Jones,6
+Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Doug Mays,1
+Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Dennis Pyle,4
+Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Caron Tyson,10
+Cherokee,036 Spring Valley-Spring Valley,US House,2,Rep,Steve Watkins,15
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Jim Barnett,0
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Jeff Colyer,14
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Kris Kobach,23
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Patrick Kucera,3
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Tyler Ruzich,0
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Ken Selzer,2
+Cherokee,036 Spring Valley-Spring Valley,Governor,,Rep,Joseph Tutera,0
+Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Randy Duncan,17
+Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Keith Esau,4
+Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Craig McCullah,3
+Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Scott Schwab,9
+Cherokee,036 Spring Valley-Spring Valley,Secretary of  State,,Rep,Dennis Taylor,3
+Cherokee,036 Spring Valley-Spring Valley,Attorney General,,Rep,Derek Schmidt,37
+Cherokee,036 Spring Valley-Spring Valley,State Treasurer,,Rep,Jake LaTurner,39
+Cherokee,036 Spring Valley-Spring Valley,Insurance Commissioner,,Rep,Vicki Schmidt,18
+Cherokee,036 Spring Valley-Spring Valley,Insurance Commissioner,,Rep,Clark Shultz,16
+Cherokee,036 Spring Valley-Spring Valley,State Senate,13,Rep,Richard Hilderbrand,39
+Cherokee,036 Spring Valley-Spring Valley,State House,1,Rep,Michael Houser,37

--- a/2018/20180807__ks__primary__ford__precinct.csv
+++ b/2018/20180807__ks__primary__ford__precinct.csv
@@ -1,1056 +1,1056 @@
-county,precinct,office,district,party,candidate,votes,
-Ford,Dodge City 1,US House,1,Dem,Alan LaPolice,22,
-Ford,Dodge City 2,US House,1,Dem,Alan LaPolice,16,
-Ford,Dodge City 3,US House,1,Dem,Alan LaPolice,27,
-Ford,Dodge City 4,US House,1,Dem,Alan LaPolice,50,
-Ford,Dodge City 5,US House,1,Dem,Alan LaPolice,61,
-Ford,Dodge City 6,US House,1,Dem,Alan LaPolice,84,
-Ford,Dodge City 7,US House,1,Dem,Alan LaPolice,1,
-Ford,Dodge City 8,US House,1,Dem,Alan LaPolice,0,
-Ford,Dodge City 9,US House,1,Dem,Alan LaPolice,0,
-Ford,Bucklin  City,US House,1,Dem,Alan LaPolice,12,
-Ford,Ford  City,US House,1,Dem,Alan LaPolice,3,
-Ford,Spearville  City,US House,1,Dem,Alan LaPolice,22,
-Ford,Bloom  TWP,US House,1,Dem,Alan LaPolice,1,
-Ford,Bucklin  TWP,US House,1,Dem,Alan LaPolice,0,
-Ford,Concord  TWP,US House,1,Dem,Alan LaPolice,3,
-Ford,Dodge  TWP  H115,US House,1,Dem,Alan LaPolice,8,
-Ford,Dodge  TWP  H119,US House,1,Dem,Alan LaPolice,2,
-Ford,Dodge  TWP  W  H119,US House,1,Dem,Alan LaPolice,0,
-Ford,Dodge  TWP  I  H119,US House,1,Dem,Alan LaPolice,0,
-Ford,Enterprise  TWP  H115,US House,1,Dem,Alan LaPolice,11,
-Ford,Enterprise  TWP  H119,US House,1,Dem,Alan LaPolice,1,
-Ford,Fairview  TWP,US House,1,Dem,Alan LaPolice,1,
-Ford,Ford  TWP,US House,1,Dem,Alan LaPolice,1,
-Ford,Grandview  TWP  H115,US House,1,Dem,Alan LaPolice,11,
-Ford,Grandview  TWP  East  H119,US House,1,Dem,Alan LaPolice,0,
-Ford,Grandview  TWP-2,US House,1,Dem,Alan LaPolice,4,
-Ford,Grandview  TWP-2  H119,US House,1,Dem,Alan LaPolice,0,
-Ford,Richland  TWP,US House,1,Dem,Alan LaPolice,9,
-Ford,Royal  TWP,US House,1,Dem,Alan LaPolice,2,
-Ford,Sodville  TWP,US House,1,Dem,Alan LaPolice,1,
-Ford,Spearville  TWP,US House,1,Dem,Alan LaPolice,4,
-Ford,Wheatland  TWP,US House,1,Dem,Alan LaPolice,2,
-Ford,Wilburn  TWP,US House,1,Dem,Alan LaPolice,0,
-Ford,Dodge  TWP-3,US House,1,Dem,Alan LaPolice,0,
-Ford,FORD CO KS,US House,1,Dem,Alan LaPolice,359,
-Ford,Dodge City 1,US House,1,Rep,Roger Marshall,73,
-Ford,Dodge City 2,US House,1,Rep,Roger Marshall,32,
-Ford,Dodge City 3,US House,1,Rep,Roger Marshall,30,
-Ford,Dodge City 4,US House,1,Rep,Roger Marshall,121,
-Ford,Dodge City 5,US House,1,Rep,Roger Marshall,276,
-Ford,Dodge City 6,US House,1,Rep,Roger Marshall,408,
-Ford,Dodge City 7,US House,1,Rep,Roger Marshall,18,
-Ford,Dodge City 8,US House,1,Rep,Roger Marshall,0,
-Ford,Dodge City 9,US House,1,Rep,Roger Marshall,0,
-Ford,Bucklin  City,US House,1,Rep,Roger Marshall,91,
-Ford,Ford  City,US House,1,Rep,Roger Marshall,32,
-Ford,Spearville  City,US House,1,Rep,Roger Marshall,101,
-Ford,Bloom  TWP,US House,1,Rep,Roger Marshall,6,
-Ford,Bucklin  TWP,US House,1,Rep,Roger Marshall,26,
-Ford,Concord  TWP,US House,1,Rep,Roger Marshall,13,
-Ford,Dodge  TWP  H115,US House,1,Rep,Roger Marshall,39,
-Ford,Dodge  TWP  H119,US House,1,Rep,Roger Marshall,10,
-Ford,Dodge  TWP  W  H119,US House,1,Rep,Roger Marshall,0,
-Ford,Dodge  TWP  I  H119,US House,1,Rep,Roger Marshall,0,
-Ford,Enterprise  TWP  H115,US House,1,Rep,Roger Marshall,40,
-Ford,Enterprise  TWP  H119,US House,1,Rep,Roger Marshall,0,
-Ford,Fairview  TWP,US House,1,Rep,Roger Marshall,35,
-Ford,Ford  TWP,US House,1,Rep,Roger Marshall,24,
-Ford,Grandview  TWP  H115,US House,1,Rep,Roger Marshall,33,
-Ford,Grandview  TWP  East  H119,US House,1,Rep,Roger Marshall,0,
-Ford,Grandview  TWP-2,US House,1,Rep,Roger Marshall,7,
-Ford,Grandview  TWP-2  H119,US House,1,Rep,Roger Marshall,0,
-Ford,Richland  TWP,US House,1,Rep,Roger Marshall,35,
-Ford,Royal  TWP,US House,1,Rep,Roger Marshall,24,
-Ford,Sodville  TWP,US House,1,Rep,Roger Marshall,14,
-Ford,Spearville  TWP,US House,1,Rep,Roger Marshall,50,
-Ford,Wheatland  TWP,US House,1,Rep,Roger Marshall,16,
-Ford,Wilburn  TWP,US House,1,Rep,Roger Marshall,3,
-Ford,Dodge  TWP-3,US House,1,Rep,Roger Marshall,10,
-Ford,FORD CO KS,US House,1,Rep,Roger Marshall,1607,
-Ford,Dodge City 1,US House,1,Rep,Nick Reinecker,18,
-Ford,Dodge City 2,US House,1,Rep,Nick Reinecker,12,
-Ford,Dodge City 3,US House,1,Rep,Nick Reinecker,11,
-Ford,Dodge City 4,US House,1,Rep,Nick Reinecker,28,
-Ford,Dodge City 5,US House,1,Rep,Nick Reinecker,41,
-Ford,Dodge City 6,US House,1,Rep,Nick Reinecker,73,
-Ford,Dodge City 7,US House,1,Rep,Nick Reinecker,5,
-Ford,Dodge City 8,US House,1,Rep,Nick Reinecker,0,
-Ford,Dodge City 9,US House,1,Rep,Nick Reinecker,0,
-Ford,Bucklin  City,US House,1,Rep,Nick Reinecker,19,
-Ford,Ford  City,US House,1,Rep,Nick Reinecker,3,
-Ford,Spearville  City,US House,1,Rep,Nick Reinecker,5,
-Ford,Bloom  TWP,US House,1,Rep,Nick Reinecker,4,
-Ford,Bucklin  TWP,US House,1,Rep,Nick Reinecker,2,
-Ford,Concord  TWP,US House,1,Rep,Nick Reinecker,2,
-Ford,Dodge  TWP  H115,US House,1,Rep,Nick Reinecker,9,
-Ford,Dodge  TWP  H119,US House,1,Rep,Nick Reinecker,1,
-Ford,Dodge  TWP  W  H119,US House,1,Rep,Nick Reinecker,0,
-Ford,Dodge  TWP  I  H119,US House,1,Rep,Nick Reinecker,0,
-Ford,Enterprise  TWP  H115,US House,1,Rep,Nick Reinecker,4,
-Ford,Enterprise  TWP  H119,US House,1,Rep,Nick Reinecker,0,
-Ford,Fairview  TWP,US House,1,Rep,Nick Reinecker,5,
-Ford,Ford  TWP,US House,1,Rep,Nick Reinecker,1,
-Ford,Grandview  TWP  H115,US House,1,Rep,Nick Reinecker,6,
-Ford,Grandview  TWP  East  H119,US House,1,Rep,Nick Reinecker,0,
-Ford,Grandview  TWP-2,US House,1,Rep,Nick Reinecker,2,
-Ford,Grandview  TWP-2  H119,US House,1,Rep,Nick Reinecker,0,
-Ford,Richland  TWP,US House,1,Rep,Nick Reinecker,9,
-Ford,Royal  TWP,US House,1,Rep,Nick Reinecker,2,
-Ford,Sodville  TWP,US House,1,Rep,Nick Reinecker,4,
-Ford,Spearville  TWP,US House,1,Rep,Nick Reinecker,6,
-Ford,Wheatland  TWP,US House,1,Rep,Nick Reinecker,0,
-Ford,Wilburn  TWP,US House,1,Rep,Nick Reinecker,0,
-Ford,Dodge  TWP-3,US House,1,Rep,Nick Reinecker,5,
-Ford,FORD CO KS,US House,1,Rep,Nick Reinecker,277,
-Ford,Dodge City 1,Governor,,Dem,Carl Brewer,5,
-Ford,Dodge City 2,Governor,,Dem,Carl Brewer,8,
-Ford,Dodge City 3,Governor,,Dem,Carl Brewer,9,
-Ford,Dodge City 4,Governor,,Dem,Carl Brewer,17,
-Ford,Dodge City 5,Governor,,Dem,Carl Brewer,30,
-Ford,Dodge City 6,Governor,,Dem,Carl Brewer,38,
-Ford,Dodge City 7,Governor,,Dem,Carl Brewer,0,
-Ford,Dodge City 8,Governor,,Dem,Carl Brewer,0,
-Ford,Dodge City 9,Governor,,Dem,Carl Brewer,0,
-Ford,Bucklin  City,Governor,,Dem,Carl Brewer,3,
-Ford,Ford  City,Governor,,Dem,Carl Brewer,0,
-Ford,Spearville  City,Governor,,Dem,Carl Brewer,15,
-Ford,Bloom  TWP,Governor,,Dem,Carl Brewer,0,
-Ford,Bucklin  TWP,Governor,,Dem,Carl Brewer,0,
-Ford,Concord  TWP,Governor,,Dem,Carl Brewer,0,
-Ford,Dodge  TWP  H115,Governor,,Dem,Carl Brewer,4,
-Ford,Dodge  TWP  H119,Governor,,Dem,Carl Brewer,0,
-Ford,Dodge  TWP  W  H119,Governor,,Dem,Carl Brewer,0,
-Ford,Dodge  TWP  I  H119,Governor,,Dem,Carl Brewer,0,
-Ford,Enterprise  TWP  H115,Governor,,Dem,Carl Brewer,1,
-Ford,Enterprise  TWP  H119,Governor,,Dem,Carl Brewer,0,
-Ford,Fairview  TWP,Governor,,Dem,Carl Brewer,0,
-Ford,Ford  TWP,Governor,,Dem,Carl Brewer,1,
-Ford,Grandview  TWP  H115,Governor,,Dem,Carl Brewer,3,
-Ford,Grandview  TWP  East  H119,Governor,,Dem,Carl Brewer,0,
-Ford,Grandview  TWP-2,Governor,,Dem,Carl Brewer,1,
-Ford,Grandview  TWP-2  H119,Governor,,Dem,Carl Brewer,0,
-Ford,Richland  TWP,Governor,,Dem,Carl Brewer,3,
-Ford,Royal  TWP,Governor,,Dem,Carl Brewer,0,
-Ford,Sodville  TWP,Governor,,Dem,Carl Brewer,0,
-Ford,Spearville  TWP,Governor,,Dem,Carl Brewer,3,
-Ford,Wheatland  TWP,Governor,,Dem,Carl Brewer,1,
-Ford,Wilburn  TWP,Governor,,Dem,Carl Brewer,0,
-Ford,Dodge  TWP-3,Governor,,Dem,Carl Brewer,0,
-Ford,FORD CO KS,Governor,,Dem,Carl Brewer,142,
-Ford,Dodge City 1,Governor,,Dem,Laura Kelly,16,
-Ford,Dodge City 2,Governor,,Dem,Laura Kelly,10,
-Ford,Dodge City 3,Governor,,Dem,Laura Kelly,21,
-Ford,Dodge City 4,Governor,,Dem,Laura Kelly,25,
-Ford,Dodge City 5,Governor,,Dem,Laura Kelly,36,
-Ford,Dodge City 6,Governor,,Dem,Laura Kelly,48,
-Ford,Dodge City 7,Governor,,Dem,Laura Kelly,1,
-Ford,Dodge City 8,Governor,,Dem,Laura Kelly,0,
-Ford,Dodge City 9,Governor,,Dem,Laura Kelly,0,
-Ford,Bucklin  City,Governor,,Dem,Laura Kelly,7,
-Ford,Ford  City,Governor,,Dem,Laura Kelly,3,
-Ford,Spearville  City,Governor,,Dem,Laura Kelly,6,
-Ford,Bloom  TWP,Governor,,Dem,Laura Kelly,1,
-Ford,Bucklin  TWP,Governor,,Dem,Laura Kelly,0,
-Ford,Concord  TWP,Governor,,Dem,Laura Kelly,2,
-Ford,Dodge  TWP  H115,Governor,,Dem,Laura Kelly,4,
-Ford,Dodge  TWP  H119,Governor,,Dem,Laura Kelly,2,
-Ford,Dodge  TWP  W  H119,Governor,,Dem,Laura Kelly,0,
-Ford,Dodge  TWP  I  H119,Governor,,Dem,Laura Kelly,0,
-Ford,Enterprise  TWP  H115,Governor,,Dem,Laura Kelly,3,
-Ford,Enterprise  TWP  H119,Governor,,Dem,Laura Kelly,0,
-Ford,Fairview  TWP,Governor,,Dem,Laura Kelly,0,
-Ford,Ford  TWP,Governor,,Dem,Laura Kelly,1,
-Ford,Grandview  TWP  H115,Governor,,Dem,Laura Kelly,2,
-Ford,Grandview  TWP  East  H119,Governor,,Dem,Laura Kelly,0,
-Ford,Grandview  TWP-2,Governor,,Dem,Laura Kelly,4,
-Ford,Grandview  TWP-2  H119,Governor,,Dem,Laura Kelly,0,
-Ford,Richland  TWP,Governor,,Dem,Laura Kelly,4,
-Ford,Royal  TWP,Governor,,Dem,Laura Kelly,1,
-Ford,Sodville  TWP,Governor,,Dem,Laura Kelly,1,
-Ford,Spearville  TWP,Governor,,Dem,Laura Kelly,3,
-Ford,Wheatland  TWP,Governor,,Dem,Laura Kelly,1,
-Ford,Wilburn  TWP,Governor,,Dem,Laura Kelly,1,
-Ford,Dodge  TWP-3,Governor,,Dem,Laura Kelly,0,
-Ford,FORD CO KS,Governor,,Dem,Laura Kelly,203,
-Ford,Dodge City 1,Governor,,Dem,Joshua Svaty,1,
-Ford,Dodge City 2,Governor,,Dem,Joshua Svaty,0,
-Ford,Dodge City 3,Governor,,Dem,Joshua Svaty,5,
-Ford,Dodge City 4,Governor,,Dem,Joshua Svaty,8,
-Ford,Dodge City 5,Governor,,Dem,Joshua Svaty,6,
-Ford,Dodge City 6,Governor,,Dem,Joshua Svaty,9,
-Ford,Dodge City 7,Governor,,Dem,Joshua Svaty,0,
-Ford,Dodge City 8,Governor,,Dem,Joshua Svaty,0,
-Ford,Dodge City 9,Governor,,Dem,Joshua Svaty,0,
-Ford,Bucklin  City,Governor,,Dem,Joshua Svaty,3,
-Ford,Ford  City,Governor,,Dem,Joshua Svaty,0,
-Ford,Spearville  City,Governor,,Dem,Joshua Svaty,2,
-Ford,Bloom  TWP,Governor,,Dem,Joshua Svaty,0,
-Ford,Bucklin  TWP,Governor,,Dem,Joshua Svaty,0,
-Ford,Concord  TWP,Governor,,Dem,Joshua Svaty,0,
-Ford,Dodge  TWP  H115,Governor,,Dem,Joshua Svaty,0,
-Ford,Dodge  TWP  H119,Governor,,Dem,Joshua Svaty,0,
-Ford,Dodge  TWP  W  H119,Governor,,Dem,Joshua Svaty,0,
-Ford,Dodge  TWP  I  H119,Governor,,Dem,Joshua Svaty,0,
-Ford,Enterprise  TWP  H115,Governor,,Dem,Joshua Svaty,4,
-Ford,Enterprise  TWP  H119,Governor,,Dem,Joshua Svaty,0,
-Ford,Fairview  TWP,Governor,,Dem,Joshua Svaty,1,
-Ford,Ford  TWP,Governor,,Dem,Joshua Svaty,0,
-Ford,Grandview  TWP  H115,Governor,,Dem,Joshua Svaty,8,
-Ford,Grandview  TWP  East  H119,Governor,,Dem,Joshua Svaty,0,
-Ford,Grandview  TWP-2,Governor,,Dem,Joshua Svaty,1,
-Ford,Grandview  TWP-2  H119,Governor,,Dem,Joshua Svaty,0,
-Ford,Richland  TWP,Governor,,Dem,Joshua Svaty,2,
-Ford,Royal  TWP,Governor,,Dem,Joshua Svaty,1,
-Ford,Sodville  TWP,Governor,,Dem,Joshua Svaty,0,
-Ford,Spearville  TWP,Governor,,Dem,Joshua Svaty,0,
-Ford,Wheatland  TWP,Governor,,Dem,Joshua Svaty,0,
-Ford,Wilburn  TWP,Governor,,Dem,Joshua Svaty,0,
-Ford,Dodge  TWP-3,Governor,,Dem,Joshua Svaty,0,
-Ford,FORD CO KS,Governor,,Dem,Joshua Svaty,51,
-Ford,Dodge City 1,Governor,,Dem,Arden Andersen,0,
-Ford,Dodge City 2,Governor,,Dem,Arden Andersen,1,
-Ford,Dodge City 3,Governor,,Dem,Arden Andersen,2,
-Ford,Dodge City 4,Governor,,Dem,Arden Andersen,6,
-Ford,Dodge City 5,Governor,,Dem,Arden Andersen,2,
-Ford,Dodge City 6,Governor,,Dem,Arden Andersen,3,
-Ford,Dodge City 7,Governor,,Dem,Arden Andersen,0,
-Ford,Dodge City 8,Governor,,Dem,Arden Andersen,0,
-Ford,Dodge City 9,Governor,,Dem,Arden Andersen,0,
-Ford,Bucklin  City,Governor,,Dem,Arden Andersen,0,
-Ford,Ford  City,Governor,,Dem,Arden Andersen,0,
-Ford,Spearville  City,Governor,,Dem,Arden Andersen,2,
-Ford,Bloom  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Bucklin  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Concord  TWP,Governor,,Dem,Arden Andersen,1,
-Ford,Dodge  TWP  H115,Governor,,Dem,Arden Andersen,1,
-Ford,Dodge  TWP  H119,Governor,,Dem,Arden Andersen,0,
-Ford,Dodge  TWP  W  H119,Governor,,Dem,Arden Andersen,0,
-Ford,Dodge  TWP  I  H119,Governor,,Dem,Arden Andersen,0,
-Ford,Enterprise  TWP  H115,Governor,,Dem,Arden Andersen,2,
-Ford,Enterprise  TWP  H119,Governor,,Dem,Arden Andersen,1,
-Ford,Fairview  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Ford  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Grandview  TWP  H115,Governor,,Dem,Arden Andersen,1,
-Ford,Grandview  TWP  East  H119,Governor,,Dem,Arden Andersen,0,
-Ford,Grandview  TWP-2,Governor,,Dem,Arden Andersen,0,
-Ford,Grandview  TWP-2  H119,Governor,,Dem,Arden Andersen,0,
-Ford,Richland  TWP,Governor,,Dem,Arden Andersen,1,
-Ford,Royal  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Sodville  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Spearville  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Wheatland  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Wilburn  TWP,Governor,,Dem,Arden Andersen,0,
-Ford,Dodge  TWP-3,Governor,,Dem,Arden Andersen,0,
-Ford,FORD CO KS,Governor,,Dem,Arden Andersen,23,
-Ford,Dodge City 1,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge City 2,Governor,,Dem,Jack Bergeson,1,
-Ford,Dodge City 3,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge City 4,Governor,,Dem,Jack Bergeson,1,
-Ford,Dodge City 5,Governor,,Dem,Jack Bergeson,4,
-Ford,Dodge City 6,Governor,,Dem,Jack Bergeson,4,
-Ford,Dodge City 7,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge City 8,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge City 9,Governor,,Dem,Jack Bergeson,0,
-Ford,Bucklin  City,Governor,,Dem,Jack Bergeson,0,
-Ford,Ford  City,Governor,,Dem,Jack Bergeson,0,
-Ford,Spearville  City,Governor,,Dem,Jack Bergeson,0,
-Ford,Bloom  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Bucklin  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Concord  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge  TWP  H115,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge  TWP  H119,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge  TWP  W  H119,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge  TWP  I  H119,Governor,,Dem,Jack Bergeson,0,
-Ford,Enterprise  TWP  H115,Governor,,Dem,Jack Bergeson,1,
-Ford,Enterprise  TWP  H119,Governor,,Dem,Jack Bergeson,0,
-Ford,Fairview  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Ford  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Grandview  TWP  H115,Governor,,Dem,Jack Bergeson,0,
-Ford,Grandview  TWP  East  H119,Governor,,Dem,Jack Bergeson,0,
-Ford,Grandview  TWP-2,Governor,,Dem,Jack Bergeson,1,
-Ford,Grandview  TWP-2  H119,Governor,,Dem,Jack Bergeson,0,
-Ford,Richland  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Royal  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Sodville  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Spearville  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Wheatland  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Wilburn  TWP,Governor,,Dem,Jack Bergeson,0,
-Ford,Dodge  TWP-3,Governor,,Dem,Jack Bergeson,0,
-Ford,FORD CO KS,Governor,,Dem,Jack Bergeson,12,
-Ford,Dodge City 1,Governor,,Rep,Kris Kobach,58,
-Ford,Dodge City 2,Governor,,Rep,Kris Kobach,30,
-Ford,Dodge City 3,Governor,,Rep,Kris Kobach,21,
-Ford,Dodge City 4,Governor,,Rep,Kris Kobach,76,
-Ford,Dodge City 5,Governor,,Rep,Kris Kobach,168,
-Ford,Dodge City 6,Governor,,Rep,Kris Kobach,215,
-Ford,Dodge City 7,Governor,,Rep,Kris Kobach,4,
-Ford,Dodge City 8,Governor,,Rep,Kris Kobach,0,
-Ford,Dodge City 9,Governor,,Rep,Kris Kobach,0,
-Ford,Bucklin  City,Governor,,Rep,Kris Kobach,71,
-Ford,Ford  City,Governor,,Rep,Kris Kobach,18,
-Ford,Spearville  City,Governor,,Rep,Kris Kobach,39,
-Ford,Bloom  TWP,Governor,,Rep,Kris Kobach,7,
-Ford,Bucklin  TWP,Governor,,Rep,Kris Kobach,11,
-Ford,Concord  TWP,Governor,,Rep,Kris Kobach,11,
-Ford,Dodge  TWP  H115,Governor,,Rep,Kris Kobach,24,
-Ford,Dodge  TWP  H119,Governor,,Rep,Kris Kobach,7,
-Ford,Dodge  TWP  W  H119,Governor,,Rep,Kris Kobach,0,
-Ford,Dodge  TWP  I  H119,Governor,,Rep,Kris Kobach,0,
-Ford,Enterprise  TWP  H115,Governor,,Rep,Kris Kobach,20,
-Ford,Enterprise  TWP  H119,Governor,,Rep,Kris Kobach,0,
-Ford,Fairview  TWP,Governor,,Rep,Kris Kobach,20,
-Ford,Ford  TWP,Governor,,Rep,Kris Kobach,23,
-Ford,Grandview  TWP  H115,Governor,,Rep,Kris Kobach,23,
-Ford,Grandview  TWP  East  H119,Governor,,Rep,Kris Kobach,0,
-Ford,Grandview  TWP-2,Governor,,Rep,Kris Kobach,5,
-Ford,Grandview  TWP-2  H119,Governor,,Rep,Kris Kobach,0,
-Ford,Richland  TWP,Governor,,Rep,Kris Kobach,26,
-Ford,Royal  TWP,Governor,,Rep,Kris Kobach,11,
-Ford,Sodville  TWP,Governor,,Rep,Kris Kobach,7,
-Ford,Spearville  TWP,Governor,,Rep,Kris Kobach,31,
-Ford,Wheatland  TWP,Governor,,Rep,Kris Kobach,6,
-Ford,Wilburn  TWP,Governor,,Rep,Kris Kobach,2,
-Ford,Dodge  TWP-3,Governor,,Rep,Kris Kobach,9,
-Ford,FORD CO KS,Governor,,Rep,Kris Kobach,943,
-Ford,Dodge City 1,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge City 2,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge City 3,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge City 4,Governor,,Rep,Patrick Kucera,5,
-Ford,Dodge City 5,Governor,,Rep,Patrick Kucera,1,
-Ford,Dodge City 6,Governor,,Rep,Patrick Kucera,3,
-Ford,Dodge City 7,Governor,,Rep,Patrick Kucera,1,
-Ford,Dodge City 8,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge City 9,Governor,,Rep,Patrick Kucera,0,
-Ford,Bucklin  City,Governor,,Rep,Patrick Kucera,0,
-Ford,Ford  City,Governor,,Rep,Patrick Kucera,0,
-Ford,Spearville  City,Governor,,Rep,Patrick Kucera,0,
-Ford,Bloom  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Bucklin  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Concord  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge  TWP  H115,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge  TWP  H119,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge  TWP  W  H119,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge  TWP  I  H119,Governor,,Rep,Patrick Kucera,0,
-Ford,Enterprise  TWP  H115,Governor,,Rep,Patrick Kucera,1,
-Ford,Enterprise  TWP  H119,Governor,,Rep,Patrick Kucera,0,
-Ford,Fairview  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Ford  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Grandview  TWP  H115,Governor,,Rep,Patrick Kucera,0,
-Ford,Grandview  TWP  East  H119,Governor,,Rep,Patrick Kucera,0,
-Ford,Grandview  TWP-2,Governor,,Rep,Patrick Kucera,0,
-Ford,Grandview  TWP-2  H119,Governor,,Rep,Patrick Kucera,0,
-Ford,Richland  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Royal  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Sodville  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Spearville  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Wheatland  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Wilburn  TWP,Governor,,Rep,Patrick Kucera,0,
-Ford,Dodge  TWP-3,Governor,,Rep,Patrick Kucera,0,
-Ford,FORD CO KS,Governor,,Rep,Patrick Kucera,11,
-Ford,Dodge City 1,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge City 2,Governor,,Rep,Tyler Ruzich,1,
-Ford,Dodge City 3,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge City 4,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge City 5,Governor,,Rep,Tyler Ruzich,3,
-Ford,Dodge City 6,Governor,,Rep,Tyler Ruzich,4,
-Ford,Dodge City 7,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge City 8,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge City 9,Governor,,Rep,Tyler Ruzich,0,
-Ford,Bucklin  City,Governor,,Rep,Tyler Ruzich,0,
-Ford,Ford  City,Governor,,Rep,Tyler Ruzich,0,
-Ford,Spearville  City,Governor,,Rep,Tyler Ruzich,0,
-Ford,Bloom  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Bucklin  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Concord  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge  TWP  H115,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge  TWP  H119,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge  TWP  W  H119,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge  TWP  I  H119,Governor,,Rep,Tyler Ruzich,0,
-Ford,Enterprise  TWP  H115,Governor,,Rep,Tyler Ruzich,0,
-Ford,Enterprise  TWP  H119,Governor,,Rep,Tyler Ruzich,0,
-Ford,Fairview  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Ford  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Grandview  TWP  H115,Governor,,Rep,Tyler Ruzich,0,
-Ford,Grandview  TWP  East  H119,Governor,,Rep,Tyler Ruzich,0,
-Ford,Grandview  TWP-2,Governor,,Rep,Tyler Ruzich,0,
-Ford,Grandview  TWP-2  H119,Governor,,Rep,Tyler Ruzich,0,
-Ford,Richland  TWP,Governor,,Rep,Tyler Ruzich,1,
-Ford,Royal  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Sodville  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Spearville  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Wheatland  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Wilburn  TWP,Governor,,Rep,Tyler Ruzich,0,
-Ford,Dodge  TWP-3,Governor,,Rep,Tyler Ruzich,0,
-Ford,FORD CO KS,Governor,,Rep,Tyler Ruzich,9,
-Ford,Dodge City 1,Governor,,Rep,Ken Selzer,8,
-Ford,Dodge City 2,Governor,,Rep,Ken Selzer,1,
-Ford,Dodge City 3,Governor,,Rep,Ken Selzer,2,
-Ford,Dodge City 4,Governor,,Rep,Ken Selzer,9,
-Ford,Dodge City 5,Governor,,Rep,Ken Selzer,22,
-Ford,Dodge City 6,Governor,,Rep,Ken Selzer,46,
-Ford,Dodge City 7,Governor,,Rep,Ken Selzer,6,
-Ford,Dodge City 8,Governor,,Rep,Ken Selzer,0,
-Ford,Dodge City 9,Governor,,Rep,Ken Selzer,0,
-Ford,Bucklin  City,Governor,,Rep,Ken Selzer,5,
-Ford,Ford  City,Governor,,Rep,Ken Selzer,4,
-Ford,Spearville  City,Governor,,Rep,Ken Selzer,14,
-Ford,Bloom  TWP,Governor,,Rep,Ken Selzer,0,
-Ford,Bucklin  TWP,Governor,,Rep,Ken Selzer,6,
-Ford,Concord  TWP,Governor,,Rep,Ken Selzer,1,
-Ford,Dodge  TWP  H115,Governor,,Rep,Ken Selzer,2,
-Ford,Dodge  TWP  H119,Governor,,Rep,Ken Selzer,1,
-Ford,Dodge  TWP  W  H119,Governor,,Rep,Ken Selzer,0,
-Ford,Dodge  TWP  I  H119,Governor,,Rep,Ken Selzer,0,
-Ford,Enterprise  TWP  H115,Governor,,Rep,Ken Selzer,9,
-Ford,Enterprise  TWP  H119,Governor,,Rep,Ken Selzer,0,
-Ford,Fairview  TWP,Governor,,Rep,Ken Selzer,1,
-Ford,Ford  TWP,Governor,,Rep,Ken Selzer,2,
-Ford,Grandview  TWP  H115,Governor,,Rep,Ken Selzer,1,
-Ford,Grandview  TWP  East  H119,Governor,,Rep,Ken Selzer,0,
-Ford,Grandview  TWP-2,Governor,,Rep,Ken Selzer,1,
-Ford,Grandview  TWP-2  H119,Governor,,Rep,Ken Selzer,0,
-Ford,Richland  TWP,Governor,,Rep,Ken Selzer,4,
-Ford,Royal  TWP,Governor,,Rep,Ken Selzer,2,
-Ford,Sodville  TWP,Governor,,Rep,Ken Selzer,1,
-Ford,Spearville  TWP,Governor,,Rep,Ken Selzer,6,
-Ford,Wheatland  TWP,Governor,,Rep,Ken Selzer,2,
-Ford,Wilburn  TWP,Governor,,Rep,Ken Selzer,1,
-Ford,Dodge  TWP-3,Governor,,Rep,Ken Selzer,2,
-Ford,FORD CO KS,Governor,,Rep,Ken Selzer,159,
-Ford,Dodge City 1,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge City 2,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge City 3,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge City 4,Governor,,Rep,Joseph Tutera,1,
-Ford,Dodge City 5,Governor,,Rep,Joseph Tutera,1,
-Ford,Dodge City 6,Governor,,Rep,Joseph Tutera,1,
-Ford,Dodge City 7,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge City 8,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge City 9,Governor,,Rep,Joseph Tutera,0,
-Ford,Bucklin  City,Governor,,Rep,Joseph Tutera,0,
-Ford,Ford  City,Governor,,Rep,Joseph Tutera,0,
-Ford,Spearville  City,Governor,,Rep,Joseph Tutera,0,
-Ford,Bloom  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Bucklin  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Concord  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge  TWP  H115,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge  TWP  H119,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge  TWP  W  H119,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge  TWP  I  H119,Governor,,Rep,Joseph Tutera,0,
-Ford,Enterprise  TWP  H115,Governor,,Rep,Joseph Tutera,0,
-Ford,Enterprise  TWP  H119,Governor,,Rep,Joseph Tutera,0,
-Ford,Fairview  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Ford  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Grandview  TWP  H115,Governor,,Rep,Joseph Tutera,0,
-Ford,Grandview  TWP  East  H119,Governor,,Rep,Joseph Tutera,0,
-Ford,Grandview  TWP-2,Governor,,Rep,Joseph Tutera,2,
-Ford,Grandview  TWP-2  H119,Governor,,Rep,Joseph Tutera,0,
-Ford,Richland  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Royal  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Sodville  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Spearville  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Wheatland  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Wilburn  TWP,Governor,,Rep,Joseph Tutera,0,
-Ford,Dodge  TWP-3,Governor,,Rep,Joseph Tutera,0,
-Ford,FORD CO KS,Governor,,Rep,Joseph Tutera,5,
-Ford,Dodge City 1,Governor,,Rep,Jim Barnett,1,
-Ford,Dodge City 2,Governor,,Rep,Jim Barnett,1,
-Ford,Dodge City 3,Governor,,Rep,Jim Barnett,1,
-Ford,Dodge City 4,Governor,,Rep,Jim Barnett,14,
-Ford,Dodge City 5,Governor,,Rep,Jim Barnett,17,
-Ford,Dodge City 6,Governor,,Rep,Jim Barnett,40,
-Ford,Dodge City 7,Governor,,Rep,Jim Barnett,2,
-Ford,Dodge City 8,Governor,,Rep,Jim Barnett,0,
-Ford,Dodge City 9,Governor,,Rep,Jim Barnett,0,
-Ford,Bucklin  City,Governor,,Rep,Jim Barnett,4,
-Ford,Ford  City,Governor,,Rep,Jim Barnett,1,
-Ford,Spearville  City,Governor,,Rep,Jim Barnett,3,
-Ford,Bloom  TWP,Governor,,Rep,Jim Barnett,0,
-Ford,Bucklin  TWP,Governor,,Rep,Jim Barnett,4,
-Ford,Concord  TWP,Governor,,Rep,Jim Barnett,0,
-Ford,Dodge  TWP  H115,Governor,,Rep,Jim Barnett,2,
-Ford,Dodge  TWP  H119,Governor,,Rep,Jim Barnett,0,
-Ford,Dodge  TWP  W  H119,Governor,,Rep,Jim Barnett,0,
-Ford,Dodge  TWP  I  H119,Governor,,Rep,Jim Barnett,0,
-Ford,Enterprise  TWP  H115,Governor,,Rep,Jim Barnett,2,
-Ford,Enterprise  TWP  H119,Governor,,Rep,Jim Barnett,0,
-Ford,Fairview  TWP,Governor,,Rep,Jim Barnett,0,
-Ford,Ford  TWP,Governor,,Rep,Jim Barnett,0,
-Ford,Grandview  TWP  H115,Governor,,Rep,Jim Barnett,2,
-Ford,Grandview  TWP  East  H119,Governor,,Rep,Jim Barnett,0,
-Ford,Grandview  TWP-2,Governor,,Rep,Jim Barnett,1,
-Ford,Grandview  TWP-2  H119,Governor,,Rep,Jim Barnett,0,
-Ford,Richland  TWP,Governor,,Rep,Jim Barnett,1,
-Ford,Royal  TWP,Governor,,Rep,Jim Barnett,3,
-Ford,Sodville  TWP,Governor,,Rep,Jim Barnett,1,
-Ford,Spearville  TWP,Governor,,Rep,Jim Barnett,3,
-Ford,Wheatland  TWP,Governor,,Rep,Jim Barnett,1,
-Ford,Wilburn  TWP,Governor,,Rep,Jim Barnett,1,
-Ford,Dodge  TWP-3,Governor,,Rep,Jim Barnett,0,
-Ford,FORD CO KS,Governor,,Rep,Jim Barnett,105,
-Ford,Dodge City 1,Governor,,Rep,Jeff Colyer,27,
-Ford,Dodge City 2,Governor,,Rep,Jeff Colyer,15,
-Ford,Dodge City 3,Governor,,Rep,Jeff Colyer,19,
-Ford,Dodge City 4,Governor,,Rep,Jeff Colyer,49,
-Ford,Dodge City 5,Governor,,Rep,Jeff Colyer,122,
-Ford,Dodge City 6,Governor,,Rep,Jeff Colyer,191,
-Ford,Dodge City 7,Governor,,Rep,Jeff Colyer,11,
-Ford,Dodge City 8,Governor,,Rep,Jeff Colyer,0,
-Ford,Dodge City 9,Governor,,Rep,Jeff Colyer,0,
-Ford,Bucklin  City,Governor,,Rep,Jeff Colyer,41,
-Ford,Ford  City,Governor,,Rep,Jeff Colyer,11,
-Ford,Spearville  City,Governor,,Rep,Jeff Colyer,53,
-Ford,Bloom  TWP,Governor,,Rep,Jeff Colyer,4,
-Ford,Bucklin  TWP,Governor,,Rep,Jeff Colyer,8,
-Ford,Concord  TWP,Governor,,Rep,Jeff Colyer,4,
-Ford,Dodge  TWP  H115,Governor,,Rep,Jeff Colyer,21,
-Ford,Dodge  TWP  H119,Governor,,Rep,Jeff Colyer,4,
-Ford,Dodge  TWP  W  H119,Governor,,Rep,Jeff Colyer,0,
-Ford,Dodge  TWP  I  H119,Governor,,Rep,Jeff Colyer,0,
-Ford,Enterprise  TWP  H115,Governor,,Rep,Jeff Colyer,12,
-Ford,Enterprise  TWP  H119,Governor,,Rep,Jeff Colyer,0,
-Ford,Fairview  TWP,Governor,,Rep,Jeff Colyer,19,
-Ford,Ford  TWP,Governor,,Rep,Jeff Colyer,4,
-Ford,Grandview  TWP  H115,Governor,,Rep,Jeff Colyer,17,
-Ford,Grandview  TWP  East  H119,Governor,,Rep,Jeff Colyer,0,
-Ford,Grandview  TWP-2,Governor,,Rep,Jeff Colyer,4,
-Ford,Grandview  TWP-2  H119,Governor,,Rep,Jeff Colyer,0,
-Ford,Richland  TWP,Governor,,Rep,Jeff Colyer,15,
-Ford,Royal  TWP,Governor,,Rep,Jeff Colyer,10,
-Ford,Sodville  TWP,Governor,,Rep,Jeff Colyer,10,
-Ford,Spearville  TWP,Governor,,Rep,Jeff Colyer,19,
-Ford,Wheatland  TWP,Governor,,Rep,Jeff Colyer,9,
-Ford,Wilburn  TWP,Governor,,Rep,Jeff Colyer,1,
-Ford,Dodge  TWP-3,Governor,,Rep,Jeff Colyer,4,
-Ford,FORD CO KS,Governor,,Rep,Jeff Colyer,704,
-Ford,Dodge City 1,Secretary of State,,Dem,Brian McClendon,22,
-Ford,Dodge City 2,Secretary of State,,Dem,Brian McClendon,14,
-Ford,Dodge City 3,Secretary of State,,Dem,Brian McClendon,31,
-Ford,Dodge City 4,Secretary of State,,Dem,Brian McClendon,53,
-Ford,Dodge City 5,Secretary of State,,Dem,Brian McClendon,68,
-Ford,Dodge City 6,Secretary of State,,Dem,Brian McClendon,86,
-Ford,Dodge City 7,Secretary of State,,Dem,Brian McClendon,1,
-Ford,Dodge City 8,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Dodge City 9,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Bucklin  City,Secretary of State,,Dem,Brian McClendon,12,
-Ford,Ford  City,Secretary of State,,Dem,Brian McClendon,3,
-Ford,Spearville  City,Secretary of State,,Dem,Brian McClendon,22,
-Ford,Bloom  TWP,Secretary of State,,Dem,Brian McClendon,1,
-Ford,Bucklin  TWP,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Concord  TWP,Secretary of State,,Dem,Brian McClendon,3,
-Ford,Dodge  TWP  H115,Secretary of State,,Dem,Brian McClendon,9,
-Ford,Dodge  TWP  H119,Secretary of State,,Dem,Brian McClendon,2,
-Ford,Dodge  TWP  W  H119,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Dodge  TWP  I  H119,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Enterprise  TWP  H115,Secretary of State,,Dem,Brian McClendon,10,
-Ford,Enterprise  TWP  H119,Secretary of State,,Dem,Brian McClendon,1,
-Ford,Fairview  TWP,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Ford  TWP,Secretary of State,,Dem,Brian McClendon,1,
-Ford,Grandview  TWP  H115,Secretary of State,,Dem,Brian McClendon,13,
-Ford,Grandview  TWP  East  H119,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Grandview  TWP-2,Secretary of State,,Dem,Brian McClendon,5,
-Ford,Grandview  TWP-2  H119,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Richland  TWP,Secretary of State,,Dem,Brian McClendon,10,
-Ford,Royal  TWP,Secretary of State,,Dem,Brian McClendon,2,
-Ford,Sodville  TWP,Secretary of State,,Dem,Brian McClendon,1,
-Ford,Spearville  TWP,Secretary of State,,Dem,Brian McClendon,4,
-Ford,Wheatland  TWP,Secretary of State,,Dem,Brian McClendon,2,
-Ford,Wilburn  TWP,Secretary of State,,Dem,Brian McClendon,0,
-Ford,Dodge  TWP-3,Secretary of State,,Dem,Brian McClendon,0,
-Ford,FORD CO KS,Secretary of State,,Dem,Brian McClendon,376,
-Ford,Dodge City 1,Secretary of State,,Rep,Keith Esau,7,
-Ford,Dodge City 2,Secretary of State,,Rep,Keith Esau,6,
-Ford,Dodge City 3,Secretary of State,,Rep,Keith Esau,0,
-Ford,Dodge City 4,Secretary of State,,Rep,Keith Esau,8,
-Ford,Dodge City 5,Secretary of State,,Rep,Keith Esau,26,
-Ford,Dodge City 6,Secretary of State,,Rep,Keith Esau,28,
-Ford,Dodge City 7,Secretary of State,,Rep,Keith Esau,5,
-Ford,Dodge City 8,Secretary of State,,Rep,Keith Esau,0,
-Ford,Dodge City 9,Secretary of State,,Rep,Keith Esau,0,
-Ford,Bucklin  City,Secretary of State,,Rep,Keith Esau,12,
-Ford,Ford  City,Secretary of State,,Rep,Keith Esau,2,
-Ford,Spearville  City,Secretary of State,,Rep,Keith Esau,5,
-Ford,Bloom  TWP,Secretary of State,,Rep,Keith Esau,1,
-Ford,Bucklin  TWP,Secretary of State,,Rep,Keith Esau,2,
-Ford,Concord  TWP,Secretary of State,,Rep,Keith Esau,2,
-Ford,Dodge  TWP  H115,Secretary of State,,Rep,Keith Esau,5,
-Ford,Dodge  TWP  H119,Secretary of State,,Rep,Keith Esau,0,
-Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Keith Esau,0,
-Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Keith Esau,0,
-Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Keith Esau,1,
-Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Keith Esau,0,
-Ford,Fairview  TWP,Secretary of State,,Rep,Keith Esau,1,
-Ford,Ford  TWP,Secretary of State,,Rep,Keith Esau,1,
-Ford,Grandview  TWP  H115,Secretary of State,,Rep,Keith Esau,1,
-Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Keith Esau,0,
-Ford,Grandview  TWP-2,Secretary of State,,Rep,Keith Esau,0,
-Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Keith Esau,0,
-Ford,Richland  TWP,Secretary of State,,Rep,Keith Esau,1,
-Ford,Royal  TWP,Secretary of State,,Rep,Keith Esau,4,
-Ford,Sodville  TWP,Secretary of State,,Rep,Keith Esau,0,
-Ford,Spearville  TWP,Secretary of State,,Rep,Keith Esau,2,
-Ford,Wheatland  TWP,Secretary of State,,Rep,Keith Esau,0,
-Ford,Wilburn  TWP,Secretary of State,,Rep,Keith Esau,0,
-Ford,Dodge  TWP-3,Secretary of State,,Rep,Keith Esau,2,
-Ford,FORD CO KS,Secretary of State,,Rep,Keith Esau,122,
-Ford,Dodge City 1,Secretary of State,,Rep,Craig McCullah,10,
-Ford,Dodge City 2,Secretary of State,,Rep,Craig McCullah,6,
-Ford,Dodge City 3,Secretary of State,,Rep,Craig McCullah,10,
-Ford,Dodge City 4,Secretary of State,,Rep,Craig McCullah,19,
-Ford,Dodge City 5,Secretary of State,,Rep,Craig McCullah,32,
-Ford,Dodge City 6,Secretary of State,,Rep,Craig McCullah,47,
-Ford,Dodge City 7,Secretary of State,,Rep,Craig McCullah,1,
-Ford,Dodge City 8,Secretary of State,,Rep,Craig McCullah,0,
-Ford,Dodge City 9,Secretary of State,,Rep,Craig McCullah,0,
-Ford,Bucklin  City,Secretary of State,,Rep,Craig McCullah,10,
-Ford,Ford  City,Secretary of State,,Rep,Craig McCullah,5,
-Ford,Spearville  City,Secretary of State,,Rep,Craig McCullah,6,
-Ford,Bloom  TWP,Secretary of State,,Rep,Craig McCullah,2,
-Ford,Bucklin  TWP,Secretary of State,,Rep,Craig McCullah,3,
-Ford,Concord  TWP,Secretary of State,,Rep,Craig McCullah,4,
-Ford,Dodge  TWP  H115,Secretary of State,,Rep,Craig McCullah,3,
-Ford,Dodge  TWP  H119,Secretary of State,,Rep,Craig McCullah,1,
-Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Craig McCullah,0,
-Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Craig McCullah,0,
-Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Craig McCullah,7,
-Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Craig McCullah,0,
-Ford,Fairview  TWP,Secretary of State,,Rep,Craig McCullah,7,
-Ford,Ford  TWP,Secretary of State,,Rep,Craig McCullah,6,
-Ford,Grandview  TWP  H115,Secretary of State,,Rep,Craig McCullah,6,
-Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Craig McCullah,0,
-Ford,Grandview  TWP-2,Secretary of State,,Rep,Craig McCullah,0,
-Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Craig McCullah,0,
-Ford,Richland  TWP,Secretary of State,,Rep,Craig McCullah,6,
-Ford,Royal  TWP,Secretary of State,,Rep,Craig McCullah,3,
-Ford,Sodville  TWP,Secretary of State,,Rep,Craig McCullah,2,
-Ford,Spearville  TWP,Secretary of State,,Rep,Craig McCullah,6,
-Ford,Wheatland  TWP,Secretary of State,,Rep,Craig McCullah,2,
-Ford,Wilburn  TWP,Secretary of State,,Rep,Craig McCullah,1,
-Ford,Dodge  TWP-3,Secretary of State,,Rep,Craig McCullah,1,
-Ford,FORD CO KS,Secretary of State,,Rep,Craig McCullah,206,
-Ford,Dodge City 1,Secretary of State,,Rep,Scott Schwab,33,
-Ford,Dodge City 2,Secretary of State,,Rep,Scott Schwab,16,
-Ford,Dodge City 3,Secretary of State,,Rep,Scott Schwab,15,
-Ford,Dodge City 4,Secretary of State,,Rep,Scott Schwab,72,
-Ford,Dodge City 5,Secretary of State,,Rep,Scott Schwab,115,
-Ford,Dodge City 6,Secretary of State,,Rep,Scott Schwab,178,
-Ford,Dodge City 7,Secretary of State,,Rep,Scott Schwab,8,
-Ford,Dodge City 8,Secretary of State,,Rep,Scott Schwab,0,
-Ford,Dodge City 9,Secretary of State,,Rep,Scott Schwab,0,
-Ford,Bucklin  City,Secretary of State,,Rep,Scott Schwab,37,
-Ford,Ford  City,Secretary of State,,Rep,Scott Schwab,14,
-Ford,Spearville  City,Secretary of State,,Rep,Scott Schwab,40,
-Ford,Bloom  TWP,Secretary of State,,Rep,Scott Schwab,3,
-Ford,Bucklin  TWP,Secretary of State,,Rep,Scott Schwab,10,
-Ford,Concord  TWP,Secretary of State,,Rep,Scott Schwab,3,
-Ford,Dodge  TWP  H115,Secretary of State,,Rep,Scott Schwab,21,
-Ford,Dodge  TWP  H119,Secretary of State,,Rep,Scott Schwab,5,
-Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Scott Schwab,0,
-Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Scott Schwab,0,
-Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Scott Schwab,16,
-Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Scott Schwab,0,
-Ford,Fairview  TWP,Secretary of State,,Rep,Scott Schwab,13,
-Ford,Ford  TWP,Secretary of State,,Rep,Scott Schwab,6,
-Ford,Grandview  TWP  H115,Secretary of State,,Rep,Scott Schwab,12,
-Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Scott Schwab,0,
-Ford,Grandview  TWP-2,Secretary of State,,Rep,Scott Schwab,2,
-Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Scott Schwab,0,
-Ford,Richland  TWP,Secretary of State,,Rep,Scott Schwab,12,
-Ford,Royal  TWP,Secretary of State,,Rep,Scott Schwab,10,
-Ford,Sodville  TWP,Secretary of State,,Rep,Scott Schwab,4,
-Ford,Spearville  TWP,Secretary of State,,Rep,Scott Schwab,28,
-Ford,Wheatland  TWP,Secretary of State,,Rep,Scott Schwab,4,
-Ford,Wilburn  TWP,Secretary of State,,Rep,Scott Schwab,0,
-Ford,Dodge  TWP-3,Secretary of State,,Rep,Scott Schwab,2,
-Ford,FORD CO KS,Secretary of State,,Rep,Scott Schwab,679,
-Ford,Dodge City 1,Secretary of State,,Rep,Dennis Taylor,11,
-Ford,Dodge City 2,Secretary of State,,Rep,Dennis Taylor,5,
-Ford,Dodge City 3,Secretary of State,,Rep,Dennis Taylor,5,
-Ford,Dodge City 4,Secretary of State,,Rep,Dennis Taylor,15,
-Ford,Dodge City 5,Secretary of State,,Rep,Dennis Taylor,27,
-Ford,Dodge City 6,Secretary of State,,Rep,Dennis Taylor,60,
-Ford,Dodge City 7,Secretary of State,,Rep,Dennis Taylor,4,
-Ford,Dodge City 8,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Dodge City 9,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Bucklin  City,Secretary of State,,Rep,Dennis Taylor,9,
-Ford,Ford  City,Secretary of State,,Rep,Dennis Taylor,2,
-Ford,Spearville  City,Secretary of State,,Rep,Dennis Taylor,11,
-Ford,Bloom  TWP,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Bucklin  TWP,Secretary of State,,Rep,Dennis Taylor,2,
-Ford,Concord  TWP,Secretary of State,,Rep,Dennis Taylor,2,
-Ford,Dodge  TWP  H115,Secretary of State,,Rep,Dennis Taylor,4,
-Ford,Dodge  TWP  H119,Secretary of State,,Rep,Dennis Taylor,1,
-Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Dennis Taylor,5,
-Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Fairview  TWP,Secretary of State,,Rep,Dennis Taylor,4,
-Ford,Ford  TWP,Secretary of State,,Rep,Dennis Taylor,5,
-Ford,Grandview  TWP  H115,Secretary of State,,Rep,Dennis Taylor,1,
-Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Grandview  TWP-2,Secretary of State,,Rep,Dennis Taylor,5,
-Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Richland  TWP,Secretary of State,,Rep,Dennis Taylor,8,
-Ford,Royal  TWP,Secretary of State,,Rep,Dennis Taylor,1,
-Ford,Sodville  TWP,Secretary of State,,Rep,Dennis Taylor,3,
-Ford,Spearville  TWP,Secretary of State,,Rep,Dennis Taylor,3,
-Ford,Wheatland  TWP,Secretary of State,,Rep,Dennis Taylor,2,
-Ford,Wilburn  TWP,Secretary of State,,Rep,Dennis Taylor,0,
-Ford,Dodge  TWP-3,Secretary of State,,Rep,Dennis Taylor,4,
-Ford,FORD CO KS,Secretary of State,,Rep,Dennis Taylor,199,
-Ford,Dodge City 1,Secretary of State,,Rep,Randy Duncan,25,
-Ford,Dodge City 2,Secretary of State,,Rep,Randy Duncan,7,
-Ford,Dodge City 3,Secretary of State,,Rep,Randy Duncan,10,
-Ford,Dodge City 4,Secretary of State,,Rep,Randy Duncan,28,
-Ford,Dodge City 5,Secretary of State,,Rep,Randy Duncan,97,
-Ford,Dodge City 6,Secretary of State,,Rep,Randy Duncan,133,
-Ford,Dodge City 7,Secretary of State,,Rep,Randy Duncan,3,
-Ford,Dodge City 8,Secretary of State,,Rep,Randy Duncan,0,
-Ford,Dodge City 9,Secretary of State,,Rep,Randy Duncan,0,
-Ford,Bucklin  City,Secretary of State,,Rep,Randy Duncan,36,
-Ford,Ford  City,Secretary of State,,Rep,Randy Duncan,7,
-Ford,Spearville  City,Secretary of State,,Rep,Randy Duncan,33,
-Ford,Bloom  TWP,Secretary of State,,Rep,Randy Duncan,3,
-Ford,Bucklin  TWP,Secretary of State,,Rep,Randy Duncan,9,
-Ford,Concord  TWP,Secretary of State,,Rep,Randy Duncan,4,
-Ford,Dodge  TWP  H115,Secretary of State,,Rep,Randy Duncan,11,
-Ford,Dodge  TWP  H119,Secretary of State,,Rep,Randy Duncan,4,
-Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Randy Duncan,0,
-Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Randy Duncan,0,
-Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Randy Duncan,12,
-Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Randy Duncan,0,
-Ford,Fairview  TWP,Secretary of State,,Rep,Randy Duncan,10,
-Ford,Ford  TWP,Secretary of State,,Rep,Randy Duncan,4,
-Ford,Grandview  TWP  H115,Secretary of State,,Rep,Randy Duncan,15,
-Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Randy Duncan,0,
-Ford,Grandview  TWP-2,Secretary of State,,Rep,Randy Duncan,3,
-Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Randy Duncan,0,
-Ford,Richland  TWP,Secretary of State,,Rep,Randy Duncan,14,
-Ford,Royal  TWP,Secretary of State,,Rep,Randy Duncan,7,
-Ford,Sodville  TWP,Secretary of State,,Rep,Randy Duncan,6,
-Ford,Spearville  TWP,Secretary of State,,Rep,Randy Duncan,15,
-Ford,Wheatland  TWP,Secretary of State,,Rep,Randy Duncan,5,
-Ford,Wilburn  TWP,Secretary of State,,Rep,Randy Duncan,3,
-Ford,Dodge  TWP-3,Secretary of State,,Rep,Randy Duncan,4,
-Ford,FORD CO KS,Secretary of State,,Rep,Randy Duncan,508,
-Ford,Dodge City 1,Attorney General,,Dem,Sarah Swain,23,
-Ford,Dodge City 2,Attorney General,,Dem,Sarah Swain,15,
-Ford,Dodge City 3,Attorney General,,Dem,Sarah Swain,30,
-Ford,Dodge City 4,Attorney General,,Dem,Sarah Swain,54,
-Ford,Dodge City 5,Attorney General,,Dem,Sarah Swain,72,
-Ford,Dodge City 6,Attorney General,,Dem,Sarah Swain,92,
-Ford,Dodge City 7,Attorney General,,Dem,Sarah Swain,1,
-Ford,Dodge City 8,Attorney General,,Dem,Sarah Swain,0,
-Ford,Dodge City 9,Attorney General,,Dem,Sarah Swain,0,
-Ford,Bucklin  City,Attorney General,,Dem,Sarah Swain,11,
-Ford,Ford  City,Attorney General,,Dem,Sarah Swain,3,
-Ford,Spearville  City,Attorney General,,Dem,Sarah Swain,24,
-Ford,Bloom  TWP,Attorney General,,Dem,Sarah Swain,1,
-Ford,Bucklin  TWP,Attorney General,,Dem,Sarah Swain,0,
-Ford,Concord  TWP,Attorney General,,Dem,Sarah Swain,3,
-Ford,Dodge  TWP  H115,Attorney General,,Dem,Sarah Swain,9,
-Ford,Dodge  TWP  H119,Attorney General,,Dem,Sarah Swain,2,
-Ford,Dodge  TWP  W  H119,Attorney General,,Dem,Sarah Swain,0,
-Ford,Dodge  TWP  I  H119,Attorney General,,Dem,Sarah Swain,0,
-Ford,Enterprise  TWP  H115,Attorney General,,Dem,Sarah Swain,9,
-Ford,Enterprise  TWP  H119,Attorney General,,Dem,Sarah Swain,1,
-Ford,Fairview  TWP,Attorney General,,Dem,Sarah Swain,1,
-Ford,Ford  TWP,Attorney General,,Dem,Sarah Swain,2,
-Ford,Grandview  TWP  H115,Attorney General,,Dem,Sarah Swain,11,
-Ford,Grandview  TWP  East  H119,Attorney General,,Dem,Sarah Swain,0,
-Ford,Grandview  TWP-2,Attorney General,,Dem,Sarah Swain,5,
-Ford,Grandview  TWP-2  H119,Attorney General,,Dem,Sarah Swain,0,
-Ford,Richland  TWP,Attorney General,,Dem,Sarah Swain,9,
-Ford,Royal  TWP,Attorney General,,Dem,Sarah Swain,2,
-Ford,Sodville  TWP,Attorney General,,Dem,Sarah Swain,1,
-Ford,Spearville  TWP,Attorney General,,Dem,Sarah Swain,4,
-Ford,Wheatland  TWP,Attorney General,,Dem,Sarah Swain,2,
-Ford,Wilburn  TWP,Attorney General,,Dem,Sarah Swain,0,
-Ford,Dodge  TWP-3,Attorney General,,Dem,Sarah Swain,0,
-Ford,FORD CO KS,Attorney General,,Dem,Sarah Swain,387,
-Ford,Dodge City 1,Attorney General,,Rep,Derek Schmidt,82,
-Ford,Dodge City 2,Attorney General,,Rep,Derek Schmidt,42,
-Ford,Dodge City 3,Attorney General,,Rep,Derek Schmidt,38,
-Ford,Dodge City 4,Attorney General,,Rep,Derek Schmidt,140,
-Ford,Dodge City 5,Attorney General,,Rep,Derek Schmidt,291,
-Ford,Dodge City 6,Attorney General,,Rep,Derek Schmidt,444,
-Ford,Dodge City 7,Attorney General,,Rep,Derek Schmidt,22,
-Ford,Dodge City 8,Attorney General,,Rep,Derek Schmidt,0,
-Ford,Dodge City 9,Attorney General,,Rep,Derek Schmidt,0,
-Ford,Bucklin  City,Attorney General,,Rep,Derek Schmidt,103,
-Ford,Ford  City,Attorney General,,Rep,Derek Schmidt,32,
-Ford,Spearville  City,Attorney General,,Rep,Derek Schmidt,101,
-Ford,Bloom  TWP,Attorney General,,Rep,Derek Schmidt,9,
-Ford,Bucklin  TWP,Attorney General,,Rep,Derek Schmidt,27,
-Ford,Concord  TWP,Attorney General,,Rep,Derek Schmidt,15,
-Ford,Dodge  TWP  H115,Attorney General,,Rep,Derek Schmidt,48,
-Ford,Dodge  TWP  H119,Attorney General,,Rep,Derek Schmidt,11,
-Ford,Dodge  TWP  W  H119,Attorney General,,Rep,Derek Schmidt,0,
-Ford,Dodge  TWP  I  H119,Attorney General,,Rep,Derek Schmidt,0,
-Ford,Enterprise  TWP  H115,Attorney General,,Rep,Derek Schmidt,41,
-Ford,Enterprise  TWP  H119,Attorney General,,Rep,Derek Schmidt,0,
-Ford,Fairview  TWP,Attorney General,,Rep,Derek Schmidt,34,
-Ford,Ford  TWP,Attorney General,,Rep,Derek Schmidt,21,
-Ford,Grandview  TWP  H115,Attorney General,,Rep,Derek Schmidt,36,
-Ford,Grandview  TWP  East  H119,Attorney General,,Rep,Derek Schmidt,0,
-Ford,Grandview  TWP-2,Attorney General,,Rep,Derek Schmidt,10,
-Ford,Grandview  TWP-2  H119,Attorney General,,Rep,Derek Schmidt,0,
-Ford,Richland  TWP,Attorney General,,Rep,Derek Schmidt,44,
-Ford,Royal  TWP,Attorney General,,Rep,Derek Schmidt,24,
-Ford,Sodville  TWP,Attorney General,,Rep,Derek Schmidt,15,
-Ford,Spearville  TWP,Attorney General,,Rep,Derek Schmidt,56,
-Ford,Wheatland  TWP,Attorney General,,Rep,Derek Schmidt,12,
-Ford,Wilburn  TWP,Attorney General,,Rep,Derek Schmidt,4,
-Ford,Dodge  TWP-3,Attorney General,,Rep,Derek Schmidt,14,
-Ford,FORD CO KS,Attorney General,,Rep,Derek Schmidt,1716,
-Ford,Dodge City 1,Treasurer,,Dem,Marci Francisco,23,
-Ford,Dodge City 2,Treasurer,,Dem,Marci Francisco,16,
-Ford,Dodge City 3,Treasurer,,Dem,Marci Francisco,30,
-Ford,Dodge City 4,Treasurer,,Dem,Marci Francisco,51,
-Ford,Dodge City 5,Treasurer,,Dem,Marci Francisco,72,
-Ford,Dodge City 6,Treasurer,,Dem,Marci Francisco,94,
-Ford,Dodge City 7,Treasurer,,Dem,Marci Francisco,1,
-Ford,Dodge City 8,Treasurer,,Dem,Marci Francisco,0,
-Ford,Dodge City 9,Treasurer,,Dem,Marci Francisco,0,
-Ford,Bucklin  City,Treasurer,,Dem,Marci Francisco,11,
-Ford,Ford  City,Treasurer,,Dem,Marci Francisco,3,
-Ford,Spearville  City,Treasurer,,Dem,Marci Francisco,24,
-Ford,Bloom  TWP,Treasurer,,Dem,Marci Francisco,1,
-Ford,Bucklin  TWP,Treasurer,,Dem,Marci Francisco,0,
-Ford,Concord  TWP,Treasurer,,Dem,Marci Francisco,3,
-Ford,Dodge  TWP  H115,Treasurer,,Dem,Marci Francisco,9,
-Ford,Dodge  TWP  H119,Treasurer,,Dem,Marci Francisco,2,
-Ford,Dodge  TWP  W  H119,Treasurer,,Dem,Marci Francisco,0,
-Ford,Dodge  TWP  I  H119,Treasurer,,Dem,Marci Francisco,0,
-Ford,Enterprise  TWP  H115,Treasurer,,Dem,Marci Francisco,9,
-Ford,Enterprise  TWP  H119,Treasurer,,Dem,Marci Francisco,1,
-Ford,Fairview  TWP,Treasurer,,Dem,Marci Francisco,1,
-Ford,Ford  TWP,Treasurer,,Dem,Marci Francisco,1,
-Ford,Grandview  TWP  H115,Treasurer,,Dem,Marci Francisco,12,
-Ford,Grandview  TWP  East  H119,Treasurer,,Dem,Marci Francisco,0,
-Ford,Grandview  TWP-2,Treasurer,,Dem,Marci Francisco,5,
-Ford,Grandview  TWP-2  H119,Treasurer,,Dem,Marci Francisco,0,
-Ford,Richland  TWP,Treasurer,,Dem,Marci Francisco,8,
-Ford,Royal  TWP,Treasurer,,Dem,Marci Francisco,1,
-Ford,Sodville  TWP,Treasurer,,Dem,Marci Francisco,1,
-Ford,Spearville  TWP,Treasurer,,Dem,Marci Francisco,4,
-Ford,Wheatland  TWP,Treasurer,,Dem,Marci Francisco,1,
-Ford,Wilburn  TWP,Treasurer,,Dem,Marci Francisco,0,
-Ford,Dodge  TWP-3,Treasurer,,Dem,Marci Francisco,0,
-Ford,FORD CO KS,Treasurer,,Dem,Marci Francisco,385,
-Ford,Dodge City 1,Treasurer,,Rep,Jake LaTurner,79,
-Ford,Dodge City 2,Treasurer,,Rep,Jake LaTurner,37,
-Ford,Dodge City 3,Treasurer,,Rep,Jake LaTurner,35,
-Ford,Dodge City 4,Treasurer,,Rep,Jake LaTurner,133,
-Ford,Dodge City 5,Treasurer,,Rep,Jake LaTurner,286,
-Ford,Dodge City 6,Treasurer,,Rep,Jake LaTurner,416,
-Ford,Dodge City 7,Treasurer,,Rep,Jake LaTurner,21,
-Ford,Dodge City 8,Treasurer,,Rep,Jake LaTurner,0,
-Ford,Dodge City 9,Treasurer,,Rep,Jake LaTurner,0,
-Ford,Bucklin  City,Treasurer,,Rep,Jake LaTurner,98,
-Ford,Ford  City,Treasurer,,Rep,Jake LaTurner,26,
-Ford,Spearville  City,Treasurer,,Rep,Jake LaTurner,91,
-Ford,Bloom  TWP,Treasurer,,Rep,Jake LaTurner,9,
-Ford,Bucklin  TWP,Treasurer,,Rep,Jake LaTurner,26,
-Ford,Concord  TWP,Treasurer,,Rep,Jake LaTurner,14,
-Ford,Dodge  TWP  H115,Treasurer,,Rep,Jake LaTurner,46,
-Ford,Dodge  TWP  H119,Treasurer,,Rep,Jake LaTurner,10,
-Ford,Dodge  TWP  W  H119,Treasurer,,Rep,Jake LaTurner,0,
-Ford,Dodge  TWP  I  H119,Treasurer,,Rep,Jake LaTurner,0,
-Ford,Enterprise  TWP  H115,Treasurer,,Rep,Jake LaTurner,39,
-Ford,Enterprise  TWP  H119,Treasurer,,Rep,Jake LaTurner,0,
-Ford,Fairview  TWP,Treasurer,,Rep,Jake LaTurner,34,
-Ford,Ford  TWP,Treasurer,,Rep,Jake LaTurner,23,
-Ford,Grandview  TWP  H115,Treasurer,,Rep,Jake LaTurner,36,
-Ford,Grandview  TWP  East  H119,Treasurer,,Rep,Jake LaTurner,0,
-Ford,Grandview  TWP-2,Treasurer,,Rep,Jake LaTurner,9,
-Ford,Grandview  TWP-2  H119,Treasurer,,Rep,Jake LaTurner,0,
-Ford,Richland  TWP,Treasurer,,Rep,Jake LaTurner,39,
-Ford,Royal  TWP,Treasurer,,Rep,Jake LaTurner,24,
-Ford,Sodville  TWP,Treasurer,,Rep,Jake LaTurner,15,
-Ford,Spearville  TWP,Treasurer,,Rep,Jake LaTurner,52,
-Ford,Wheatland  TWP,Treasurer,,Rep,Jake LaTurner,12,
-Ford,Wilburn  TWP,Treasurer,,Rep,Jake LaTurner,4,
-Ford,Dodge  TWP-3,Treasurer,,Rep,Jake LaTurner,13,
-Ford,FORD CO KS,Treasurer,,Rep,Jake LaTurner,1627,
-Ford,Dodge City 1,Insurance,,Dem,Nathaniel McLaughlin,22,p8
-Ford,Dodge City 2,Insurance,,Dem,Nathaniel McLaughlin,14,
-Ford,Dodge City 3,Insurance,,Dem,Nathaniel McLaughlin,27,
-Ford,Dodge City 4,Insurance,,Dem,Nathaniel McLaughlin,51,
-Ford,Dodge City 5,Insurance,,Dem,Nathaniel McLaughlin,71,
-Ford,Dodge City 6,Insurance,,Dem,Nathaniel McLaughlin,93,
-Ford,Dodge City 7,Insurance,,Dem,Nathaniel McLaughlin,1,
-Ford,Dodge City 8,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Dodge City 9,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Bucklin  City,Insurance,,Dem,Nathaniel McLaughlin,12,
-Ford,Ford  City,Insurance,,Dem,Nathaniel McLaughlin,3,
-Ford,Spearville  City,Insurance,,Dem,Nathaniel McLaughlin,24,
-Ford,Bloom  TWP,Insurance,,Dem,Nathaniel McLaughlin,1,
-Ford,Bucklin  TWP,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Concord  TWP,Insurance,,Dem,Nathaniel McLaughlin,3,
-Ford,Dodge  TWP  H115,Insurance,,Dem,Nathaniel McLaughlin,7,
-Ford,Dodge  TWP  H119,Insurance,,Dem,Nathaniel McLaughlin,2,
-Ford,Dodge  TWP  W  H119,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Dodge  TWP  I  H119,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Enterprise  TWP  H115,Insurance,,Dem,Nathaniel McLaughlin,10,
-Ford,Enterprise  TWP  H119,Insurance,,Dem,Nathaniel McLaughlin,1,
-Ford,Fairview  TWP,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Ford  TWP,Insurance,,Dem,Nathaniel McLaughlin,1,
-Ford,Grandview  TWP  H115,Insurance,,Dem,Nathaniel McLaughlin,12,
-Ford,Grandview  TWP  East  H119,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Grandview  TWP-2,Insurance,,Dem,Nathaniel McLaughlin,7,
-Ford,Grandview  TWP-2  H119,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Richland  TWP,Insurance,,Dem,Nathaniel McLaughlin,10,
-Ford,Royal  TWP,Insurance,,Dem,Nathaniel McLaughlin,2,
-Ford,Sodville  TWP,Insurance,,Dem,Nathaniel McLaughlin,1,
-Ford,Spearville  TWP,Insurance,,Dem,Nathaniel McLaughlin,4,
-Ford,Wheatland  TWP,Insurance,,Dem,Nathaniel McLaughlin,1,
-Ford,Wilburn  TWP,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,Dodge  TWP-3,Insurance,,Dem,Nathaniel McLaughlin,0,
-Ford,FORD CO KS,Insurance,,Dem,Nathaniel McLaughlin,380,
-Ford,Dodge City 1,Insurance,,Rep,Vicki Schmidt,45,
-Ford,Dodge City 2,Insurance,,Rep,Vicki Schmidt,18,
-Ford,Dodge City 3,Insurance,,Rep,Vicki Schmidt,16,
-Ford,Dodge City 4,Insurance,,Rep,Vicki Schmidt,66,
-Ford,Dodge City 5,Insurance,,Rep,Vicki Schmidt,153,
-Ford,Dodge City 6,Insurance,,Rep,Vicki Schmidt,253,
-Ford,Dodge City 7,Insurance,,Rep,Vicki Schmidt,8,
-Ford,Dodge City 8,Insurance,,Rep,Vicki Schmidt,0,
-Ford,Dodge City 9,Insurance,,Rep,Vicki Schmidt,0,
-Ford,Bucklin  City,Insurance,,Rep,Vicki Schmidt,60,
-Ford,Ford  City,Insurance,,Rep,Vicki Schmidt,17,
-Ford,Spearville  City,Insurance,,Rep,Vicki Schmidt,61,
-Ford,Bloom  TWP,Insurance,,Rep,Vicki Schmidt,1,
-Ford,Bucklin  TWP,Insurance,,Rep,Vicki Schmidt,12,
-Ford,Concord  TWP,Insurance,,Rep,Vicki Schmidt,8,
-Ford,Dodge  TWP  H115,Insurance,,Rep,Vicki Schmidt,25,
-Ford,Dodge  TWP  H119,Insurance,,Rep,Vicki Schmidt,3,
-Ford,Dodge  TWP  W  H119,Insurance,,Rep,Vicki Schmidt,0,
-Ford,Dodge  TWP  I  H119,Insurance,,Rep,Vicki Schmidt,0,
-Ford,Enterprise  TWP  H115,Insurance,,Rep,Vicki Schmidt,24,
-Ford,Enterprise  TWP  H119,Insurance,,Rep,Vicki Schmidt,0,
-Ford,Fairview  TWP,Insurance,,Rep,Vicki Schmidt,19,
-Ford,Ford  TWP,Insurance,,Rep,Vicki Schmidt,13,
-Ford,Grandview  TWP  H115,Insurance,,Rep,Vicki Schmidt,16,
-Ford,Grandview  TWP  East  H119,Insurance,,Rep,Vicki Schmidt,0,
-Ford,Grandview  TWP-2,Insurance,,Rep,Vicki Schmidt,9,
-Ford,Grandview  TWP-2  H119,Insurance,,Rep,Vicki Schmidt,0,
-Ford,Richland  TWP,Insurance,,Rep,Vicki Schmidt,21,
-Ford,Royal  TWP,Insurance,,Rep,Vicki Schmidt,16,
-Ford,Sodville  TWP,Insurance,,Rep,Vicki Schmidt,4,
-Ford,Spearville  TWP,Insurance,,Rep,Vicki Schmidt,24,
-Ford,Wheatland  TWP,Insurance,,Rep,Vicki Schmidt,7,
-Ford,Wilburn  TWP,Insurance,,Rep,Vicki Schmidt,5,
-Ford,Dodge  TWP-3,Insurance,,Rep,Vicki Schmidt,11,
-Ford,FORD CO KS,Insurance,,Rep,Vicki Schmidt,915,
-Ford,Dodge City 1,Insurance,,Rep,Clark Shultz,44,
-Ford,Dodge City 2,Insurance,,Rep,Clark Shultz,27,
-Ford,Dodge City 3,Insurance,,Rep,Clark Shultz,23,
-Ford,Dodge City 4,Insurance,,Rep,Clark Shultz,78,
-Ford,Dodge City 5,Insurance,,Rep,Clark Shultz,156,
-Ford,Dodge City 6,Insurance,,Rep,Clark Shultz,223,
-Ford,Dodge City 7,Insurance,,Rep,Clark Shultz,12,
-Ford,Dodge City 8,Insurance,,Rep,Clark Shultz,0,
-Ford,Dodge City 9,Insurance,,Rep,Clark Shultz,0,
-Ford,Bucklin  City,Insurance,,Rep,Clark Shultz,51,
-Ford,Ford  City,Insurance,,Rep,Clark Shultz,14,
-Ford,Spearville  City,Insurance,,Rep,Clark Shultz,43,
-Ford,Bloom  TWP,Insurance,,Rep,Clark Shultz,9,
-Ford,Bucklin  TWP,Insurance,,Rep,Clark Shultz,15,
-Ford,Concord  TWP,Insurance,,Rep,Clark Shultz,5,
-Ford,Dodge  TWP  H115,Insurance,,Rep,Clark Shultz,21,
-Ford,Dodge  TWP  H119,Insurance,,Rep,Clark Shultz,9,
-Ford,Dodge  TWP  W  H119,Insurance,,Rep,Clark Shultz,0,
-Ford,Dodge  TWP  I  H119,Insurance,,Rep,Clark Shultz,0,
-Ford,Enterprise  TWP  H115,Insurance,,Rep,Clark Shultz,19,
-Ford,Enterprise  TWP  H119,Insurance,,Rep,Clark Shultz,0,
-Ford,Fairview  TWP,Insurance,,Rep,Clark Shultz,19,
-Ford,Ford  TWP,Insurance,,Rep,Clark Shultz,12,
-Ford,Grandview  TWP  H115,Insurance,,Rep,Clark Shultz,22,
-Ford,Grandview  TWP  East  H119,Insurance,,Rep,Clark Shultz,0,
-Ford,Grandview  TWP-2,Insurance,,Rep,Clark Shultz,2,
-Ford,Grandview  TWP-2  H119,Insurance,,Rep,Clark Shultz,0,
-Ford,Richland  TWP,Insurance,,Rep,Clark Shultz,20,
-Ford,Royal  TWP,Insurance,,Rep,Clark Shultz,9,
-Ford,Sodville  TWP,Insurance,,Rep,Clark Shultz,11,
-Ford,Spearville  TWP,Insurance,,Rep,Clark Shultz,32,
-Ford,Wheatland  TWP,Insurance,,Rep,Clark Shultz,8,
-Ford,Wilburn  TWP,Insurance,,Rep,Clark Shultz,0,
-Ford,Dodge  TWP-3,Insurance,,Rep,Clark Shultz,4,
-Ford,FORD CO KS,Insurance,,Rep,Clark Shultz,888,
-Ford,Dodge City 1,State House,115,Dem,write-in,2,
-Ford,Dodge City 9,State House,115,Dem,write-in,0,
-Ford,Concord  TWP,State House,115,Dem,write-in,1,
-Ford,Dodge  TWP  H115,State House,115,Dem,write-in,1,
-Ford,Enterprise  TWP  H115,State House,115,Dem,write-in,1,
-Ford,Fairview  TWP,State House,115,Dem,write-in,0,
-Ford,Grandview  TWP  H115,State House,115,Dem,write-in,0,
-Ford,Grandview  TWP-2,State House,115,Dem,write-in,0,
-Ford,Grandview  TWP-2  H119,State House,115,Dem,write-in,0,
-Ford,Richland  TWP,State House,115,Dem,write-in,0,
-Ford,Royal  TWP,State House,115,Dem,write-in,0,
-Ford,Wilburn  TWP,State House,115,Dem,write-in,0,
-Ford,FORD CO KS,State House,115,Dem,write-in,5,
-Ford,Dodge City 1,State House,115,Rep,Boyd Orr,82,
-Ford,Dodge City 9,State House,115,Rep,Boyd Orr,0,
-Ford,Concord  TWP,State House,115,Rep,Boyd Orr,13,
-Ford,Dodge  TWP  H115,State House,115,Rep,Boyd Orr,45,
-Ford,Enterprise  TWP  H115,State House,115,Rep,Boyd Orr,41,
-Ford,Fairview  TWP,State House,115,Rep,Boyd Orr,36,
-Ford,Grandview  TWP  H115,State House,115,Rep,Boyd Orr,34,
-Ford,Grandview  TWP-2,State House,115,Rep,Boyd Orr,8,
-Ford,Richland  TWP,State House,115,Rep,Boyd Orr,45,
-Ford,Royal  TWP,State House,115,Rep,Boyd Orr,26,
-Ford,Wilburn  TWP,State House,115,Rep,Boyd Orr,3,
-Ford,FORD CO KS,State House,115,Rep,Boyd Orr,333,
-Ford,Dodge City 2,State House,119,Dem,write-in,1,
-Ford,Dodge City 3,State House,119,Dem,write-in,3,
-Ford,Dodge City 4,State House,119,Dem,write-in,7,
-Ford,Dodge City 5,State House,119,Dem,write-in,8,
-Ford,Dodge City 6,State House,119,Dem,write-in,7,
-Ford,Dodge City 7,State House,119,Dem,write-in,0,
-Ford,Dodge City 8,State House,119,Dem,write-in,0,
-Ford,Dodge  TWP  H119,State House,119,Dem,write-in,0,
-Ford,Dodge  TWP  W  H119,State House,119,Dem,write-in,0,
-Ford,Dodge  TWP  I  H119,State House,119,Dem,write-in,0,
-Ford,Enterprise  TWP  H119,State House,119,Dem,write-in,0,
-Ford,Grandview  TWP  East  H119,State House,119,Dem,write-in,0,
-Ford,Grandview  TWP-2  H119,State House,119,Dem,write-in,0,
-Ford,Dodge  TWP-3,State House,119,Dem,write-in,0,
-Ford,FORD CO KS,State House,119,Dem,write-in,26,
-Ford,Dodge City 2,State House,119,Rep,Bradley Ralph,43,
-Ford,Dodge City 3,State House,119,Rep,Bradley Ralph,35,
-Ford,Dodge City 4,State House,119,Rep,Bradley Ralph,146,
-Ford,Dodge City 5,State House,119,Rep,Bradley Ralph,306,
-Ford,Dodge City 6,State House,119,Rep,Bradley Ralph,446,
-Ford,Dodge City 7,State House,119,Rep,Bradley Ralph,22,
-Ford,Dodge City 8,State House,119,Rep,Bradley Ralph,0,
-Ford,Dodge  TWP  H119,State House,119,Rep,Bradley Ralph,10,
-Ford,Dodge  TWP  W  H119,State House,119,Rep,Bradley Ralph,0,
-Ford,Dodge  TWP  I  H119,State House,119,Rep,Bradley Ralph,0,
-Ford,Enterprise  TWP  H119,State House,119,Rep,Bradley Ralph,0,
-Ford,Grandview  TWP  East  H119,State House,119,Rep,Bradley Ralph,0,
-Ford,Grandview  TWP-2  H119,State House,119,Rep,Bradley Ralph,0,
-Ford,Dodge  TWP-3,State House,119,Rep,Bradley Ralph,12,
-Ford,FORD CO KS,State House,119,Rep,Bradley Ralph,1020,
-Ford,Bucklin  City,State House,117,Dem,write-in,0,
-Ford,Ford  City,State House,117,Dem,write-in,0,
-Ford,Spearville  City,State House,117,Dem,write-in,1,
-Ford,Bloom  TWP,State House,117,Dem,write-in,0,
-Ford,Bucklin  TWP,State House,117,Dem,write-in,0,
-Ford,Ford  TWP,State House,117,Dem,write-in,0,
-Ford,Sodville  TWP,State House,117,Dem,write-in,0,
-Ford,Spearville  TWP,State House,117,Dem,write-in,0,
-Ford,Wheatland  TWP,State House,117,Dem,write-in,0,
-Ford,FORD CO KS,State House,117,Dem,write-in,0,
-Ford,Bucklin  City,State House,117,Rep,Leonard Mastroni,99,
-Ford,Ford  City,State House,117,Rep,Leonard Mastroni,28,
-Ford,Spearville  City,State House,117,Rep,Leonard Mastroni,91,
-Ford,Bloom  TWP,State House,117,Rep,Leonard Mastroni,7,
-Ford,Bucklin  TWP,State House,117,Rep,Leonard Mastroni,27,
-Ford,Ford  TWP,State House,117,Rep,Leonard Mastroni,21,
-Ford,Sodville  TWP,State House,117,Rep,Leonard Mastroni,14,
-Ford,Spearville  TWP,State House,117,Rep,Leonard Mastroni,51,
-Ford,Wheatland  TWP,State House,117,Rep,Leonard Mastroni,12,
-Ford,FORD CO KS,State House,117,Rep,Leonard Mastroni,350,
+county,precinct,office,district,party,candidate,votes
+Ford,Dodge City 1,US House,1,Dem,Alan LaPolice,22
+Ford,Dodge City 2,US House,1,Dem,Alan LaPolice,16
+Ford,Dodge City 3,US House,1,Dem,Alan LaPolice,27
+Ford,Dodge City 4,US House,1,Dem,Alan LaPolice,50
+Ford,Dodge City 5,US House,1,Dem,Alan LaPolice,61
+Ford,Dodge City 6,US House,1,Dem,Alan LaPolice,84
+Ford,Dodge City 7,US House,1,Dem,Alan LaPolice,1
+Ford,Dodge City 8,US House,1,Dem,Alan LaPolice,0
+Ford,Dodge City 9,US House,1,Dem,Alan LaPolice,0
+Ford,Bucklin  City,US House,1,Dem,Alan LaPolice,12
+Ford,Ford  City,US House,1,Dem,Alan LaPolice,3
+Ford,Spearville  City,US House,1,Dem,Alan LaPolice,22
+Ford,Bloom  TWP,US House,1,Dem,Alan LaPolice,1
+Ford,Bucklin  TWP,US House,1,Dem,Alan LaPolice,0
+Ford,Concord  TWP,US House,1,Dem,Alan LaPolice,3
+Ford,Dodge  TWP  H115,US House,1,Dem,Alan LaPolice,8
+Ford,Dodge  TWP  H119,US House,1,Dem,Alan LaPolice,2
+Ford,Dodge  TWP  W  H119,US House,1,Dem,Alan LaPolice,0
+Ford,Dodge  TWP  I  H119,US House,1,Dem,Alan LaPolice,0
+Ford,Enterprise  TWP  H115,US House,1,Dem,Alan LaPolice,11
+Ford,Enterprise  TWP  H119,US House,1,Dem,Alan LaPolice,1
+Ford,Fairview  TWP,US House,1,Dem,Alan LaPolice,1
+Ford,Ford  TWP,US House,1,Dem,Alan LaPolice,1
+Ford,Grandview  TWP  H115,US House,1,Dem,Alan LaPolice,11
+Ford,Grandview  TWP  East  H119,US House,1,Dem,Alan LaPolice,0
+Ford,Grandview  TWP-2,US House,1,Dem,Alan LaPolice,4
+Ford,Grandview  TWP-2  H119,US House,1,Dem,Alan LaPolice,0
+Ford,Richland  TWP,US House,1,Dem,Alan LaPolice,9
+Ford,Royal  TWP,US House,1,Dem,Alan LaPolice,2
+Ford,Sodville  TWP,US House,1,Dem,Alan LaPolice,1
+Ford,Spearville  TWP,US House,1,Dem,Alan LaPolice,4
+Ford,Wheatland  TWP,US House,1,Dem,Alan LaPolice,2
+Ford,Wilburn  TWP,US House,1,Dem,Alan LaPolice,0
+Ford,Dodge  TWP-3,US House,1,Dem,Alan LaPolice,0
+Ford,FORD CO KS,US House,1,Dem,Alan LaPolice,359
+Ford,Dodge City 1,US House,1,Rep,Roger Marshall,73
+Ford,Dodge City 2,US House,1,Rep,Roger Marshall,32
+Ford,Dodge City 3,US House,1,Rep,Roger Marshall,30
+Ford,Dodge City 4,US House,1,Rep,Roger Marshall,121
+Ford,Dodge City 5,US House,1,Rep,Roger Marshall,276
+Ford,Dodge City 6,US House,1,Rep,Roger Marshall,408
+Ford,Dodge City 7,US House,1,Rep,Roger Marshall,18
+Ford,Dodge City 8,US House,1,Rep,Roger Marshall,0
+Ford,Dodge City 9,US House,1,Rep,Roger Marshall,0
+Ford,Bucklin  City,US House,1,Rep,Roger Marshall,91
+Ford,Ford  City,US House,1,Rep,Roger Marshall,32
+Ford,Spearville  City,US House,1,Rep,Roger Marshall,101
+Ford,Bloom  TWP,US House,1,Rep,Roger Marshall,6
+Ford,Bucklin  TWP,US House,1,Rep,Roger Marshall,26
+Ford,Concord  TWP,US House,1,Rep,Roger Marshall,13
+Ford,Dodge  TWP  H115,US House,1,Rep,Roger Marshall,39
+Ford,Dodge  TWP  H119,US House,1,Rep,Roger Marshall,10
+Ford,Dodge  TWP  W  H119,US House,1,Rep,Roger Marshall,0
+Ford,Dodge  TWP  I  H119,US House,1,Rep,Roger Marshall,0
+Ford,Enterprise  TWP  H115,US House,1,Rep,Roger Marshall,40
+Ford,Enterprise  TWP  H119,US House,1,Rep,Roger Marshall,0
+Ford,Fairview  TWP,US House,1,Rep,Roger Marshall,35
+Ford,Ford  TWP,US House,1,Rep,Roger Marshall,24
+Ford,Grandview  TWP  H115,US House,1,Rep,Roger Marshall,33
+Ford,Grandview  TWP  East  H119,US House,1,Rep,Roger Marshall,0
+Ford,Grandview  TWP-2,US House,1,Rep,Roger Marshall,7
+Ford,Grandview  TWP-2  H119,US House,1,Rep,Roger Marshall,0
+Ford,Richland  TWP,US House,1,Rep,Roger Marshall,35
+Ford,Royal  TWP,US House,1,Rep,Roger Marshall,24
+Ford,Sodville  TWP,US House,1,Rep,Roger Marshall,14
+Ford,Spearville  TWP,US House,1,Rep,Roger Marshall,50
+Ford,Wheatland  TWP,US House,1,Rep,Roger Marshall,16
+Ford,Wilburn  TWP,US House,1,Rep,Roger Marshall,3
+Ford,Dodge  TWP-3,US House,1,Rep,Roger Marshall,10
+Ford,FORD CO KS,US House,1,Rep,Roger Marshall,1607
+Ford,Dodge City 1,US House,1,Rep,Nick Reinecker,18
+Ford,Dodge City 2,US House,1,Rep,Nick Reinecker,12
+Ford,Dodge City 3,US House,1,Rep,Nick Reinecker,11
+Ford,Dodge City 4,US House,1,Rep,Nick Reinecker,28
+Ford,Dodge City 5,US House,1,Rep,Nick Reinecker,41
+Ford,Dodge City 6,US House,1,Rep,Nick Reinecker,73
+Ford,Dodge City 7,US House,1,Rep,Nick Reinecker,5
+Ford,Dodge City 8,US House,1,Rep,Nick Reinecker,0
+Ford,Dodge City 9,US House,1,Rep,Nick Reinecker,0
+Ford,Bucklin  City,US House,1,Rep,Nick Reinecker,19
+Ford,Ford  City,US House,1,Rep,Nick Reinecker,3
+Ford,Spearville  City,US House,1,Rep,Nick Reinecker,5
+Ford,Bloom  TWP,US House,1,Rep,Nick Reinecker,4
+Ford,Bucklin  TWP,US House,1,Rep,Nick Reinecker,2
+Ford,Concord  TWP,US House,1,Rep,Nick Reinecker,2
+Ford,Dodge  TWP  H115,US House,1,Rep,Nick Reinecker,9
+Ford,Dodge  TWP  H119,US House,1,Rep,Nick Reinecker,1
+Ford,Dodge  TWP  W  H119,US House,1,Rep,Nick Reinecker,0
+Ford,Dodge  TWP  I  H119,US House,1,Rep,Nick Reinecker,0
+Ford,Enterprise  TWP  H115,US House,1,Rep,Nick Reinecker,4
+Ford,Enterprise  TWP  H119,US House,1,Rep,Nick Reinecker,0
+Ford,Fairview  TWP,US House,1,Rep,Nick Reinecker,5
+Ford,Ford  TWP,US House,1,Rep,Nick Reinecker,1
+Ford,Grandview  TWP  H115,US House,1,Rep,Nick Reinecker,6
+Ford,Grandview  TWP  East  H119,US House,1,Rep,Nick Reinecker,0
+Ford,Grandview  TWP-2,US House,1,Rep,Nick Reinecker,2
+Ford,Grandview  TWP-2  H119,US House,1,Rep,Nick Reinecker,0
+Ford,Richland  TWP,US House,1,Rep,Nick Reinecker,9
+Ford,Royal  TWP,US House,1,Rep,Nick Reinecker,2
+Ford,Sodville  TWP,US House,1,Rep,Nick Reinecker,4
+Ford,Spearville  TWP,US House,1,Rep,Nick Reinecker,6
+Ford,Wheatland  TWP,US House,1,Rep,Nick Reinecker,0
+Ford,Wilburn  TWP,US House,1,Rep,Nick Reinecker,0
+Ford,Dodge  TWP-3,US House,1,Rep,Nick Reinecker,5
+Ford,FORD CO KS,US House,1,Rep,Nick Reinecker,277
+Ford,Dodge City 1,Governor,,Dem,Carl Brewer,5
+Ford,Dodge City 2,Governor,,Dem,Carl Brewer,8
+Ford,Dodge City 3,Governor,,Dem,Carl Brewer,9
+Ford,Dodge City 4,Governor,,Dem,Carl Brewer,17
+Ford,Dodge City 5,Governor,,Dem,Carl Brewer,30
+Ford,Dodge City 6,Governor,,Dem,Carl Brewer,38
+Ford,Dodge City 7,Governor,,Dem,Carl Brewer,0
+Ford,Dodge City 8,Governor,,Dem,Carl Brewer,0
+Ford,Dodge City 9,Governor,,Dem,Carl Brewer,0
+Ford,Bucklin  City,Governor,,Dem,Carl Brewer,3
+Ford,Ford  City,Governor,,Dem,Carl Brewer,0
+Ford,Spearville  City,Governor,,Dem,Carl Brewer,15
+Ford,Bloom  TWP,Governor,,Dem,Carl Brewer,0
+Ford,Bucklin  TWP,Governor,,Dem,Carl Brewer,0
+Ford,Concord  TWP,Governor,,Dem,Carl Brewer,0
+Ford,Dodge  TWP  H115,Governor,,Dem,Carl Brewer,4
+Ford,Dodge  TWP  H119,Governor,,Dem,Carl Brewer,0
+Ford,Dodge  TWP  W  H119,Governor,,Dem,Carl Brewer,0
+Ford,Dodge  TWP  I  H119,Governor,,Dem,Carl Brewer,0
+Ford,Enterprise  TWP  H115,Governor,,Dem,Carl Brewer,1
+Ford,Enterprise  TWP  H119,Governor,,Dem,Carl Brewer,0
+Ford,Fairview  TWP,Governor,,Dem,Carl Brewer,0
+Ford,Ford  TWP,Governor,,Dem,Carl Brewer,1
+Ford,Grandview  TWP  H115,Governor,,Dem,Carl Brewer,3
+Ford,Grandview  TWP  East  H119,Governor,,Dem,Carl Brewer,0
+Ford,Grandview  TWP-2,Governor,,Dem,Carl Brewer,1
+Ford,Grandview  TWP-2  H119,Governor,,Dem,Carl Brewer,0
+Ford,Richland  TWP,Governor,,Dem,Carl Brewer,3
+Ford,Royal  TWP,Governor,,Dem,Carl Brewer,0
+Ford,Sodville  TWP,Governor,,Dem,Carl Brewer,0
+Ford,Spearville  TWP,Governor,,Dem,Carl Brewer,3
+Ford,Wheatland  TWP,Governor,,Dem,Carl Brewer,1
+Ford,Wilburn  TWP,Governor,,Dem,Carl Brewer,0
+Ford,Dodge  TWP-3,Governor,,Dem,Carl Brewer,0
+Ford,FORD CO KS,Governor,,Dem,Carl Brewer,142
+Ford,Dodge City 1,Governor,,Dem,Laura Kelly,16
+Ford,Dodge City 2,Governor,,Dem,Laura Kelly,10
+Ford,Dodge City 3,Governor,,Dem,Laura Kelly,21
+Ford,Dodge City 4,Governor,,Dem,Laura Kelly,25
+Ford,Dodge City 5,Governor,,Dem,Laura Kelly,36
+Ford,Dodge City 6,Governor,,Dem,Laura Kelly,48
+Ford,Dodge City 7,Governor,,Dem,Laura Kelly,1
+Ford,Dodge City 8,Governor,,Dem,Laura Kelly,0
+Ford,Dodge City 9,Governor,,Dem,Laura Kelly,0
+Ford,Bucklin  City,Governor,,Dem,Laura Kelly,7
+Ford,Ford  City,Governor,,Dem,Laura Kelly,3
+Ford,Spearville  City,Governor,,Dem,Laura Kelly,6
+Ford,Bloom  TWP,Governor,,Dem,Laura Kelly,1
+Ford,Bucklin  TWP,Governor,,Dem,Laura Kelly,0
+Ford,Concord  TWP,Governor,,Dem,Laura Kelly,2
+Ford,Dodge  TWP  H115,Governor,,Dem,Laura Kelly,4
+Ford,Dodge  TWP  H119,Governor,,Dem,Laura Kelly,2
+Ford,Dodge  TWP  W  H119,Governor,,Dem,Laura Kelly,0
+Ford,Dodge  TWP  I  H119,Governor,,Dem,Laura Kelly,0
+Ford,Enterprise  TWP  H115,Governor,,Dem,Laura Kelly,3
+Ford,Enterprise  TWP  H119,Governor,,Dem,Laura Kelly,0
+Ford,Fairview  TWP,Governor,,Dem,Laura Kelly,0
+Ford,Ford  TWP,Governor,,Dem,Laura Kelly,1
+Ford,Grandview  TWP  H115,Governor,,Dem,Laura Kelly,2
+Ford,Grandview  TWP  East  H119,Governor,,Dem,Laura Kelly,0
+Ford,Grandview  TWP-2,Governor,,Dem,Laura Kelly,4
+Ford,Grandview  TWP-2  H119,Governor,,Dem,Laura Kelly,0
+Ford,Richland  TWP,Governor,,Dem,Laura Kelly,4
+Ford,Royal  TWP,Governor,,Dem,Laura Kelly,1
+Ford,Sodville  TWP,Governor,,Dem,Laura Kelly,1
+Ford,Spearville  TWP,Governor,,Dem,Laura Kelly,3
+Ford,Wheatland  TWP,Governor,,Dem,Laura Kelly,1
+Ford,Wilburn  TWP,Governor,,Dem,Laura Kelly,1
+Ford,Dodge  TWP-3,Governor,,Dem,Laura Kelly,0
+Ford,FORD CO KS,Governor,,Dem,Laura Kelly,203
+Ford,Dodge City 1,Governor,,Dem,Joshua Svaty,1
+Ford,Dodge City 2,Governor,,Dem,Joshua Svaty,0
+Ford,Dodge City 3,Governor,,Dem,Joshua Svaty,5
+Ford,Dodge City 4,Governor,,Dem,Joshua Svaty,8
+Ford,Dodge City 5,Governor,,Dem,Joshua Svaty,6
+Ford,Dodge City 6,Governor,,Dem,Joshua Svaty,9
+Ford,Dodge City 7,Governor,,Dem,Joshua Svaty,0
+Ford,Dodge City 8,Governor,,Dem,Joshua Svaty,0
+Ford,Dodge City 9,Governor,,Dem,Joshua Svaty,0
+Ford,Bucklin  City,Governor,,Dem,Joshua Svaty,3
+Ford,Ford  City,Governor,,Dem,Joshua Svaty,0
+Ford,Spearville  City,Governor,,Dem,Joshua Svaty,2
+Ford,Bloom  TWP,Governor,,Dem,Joshua Svaty,0
+Ford,Bucklin  TWP,Governor,,Dem,Joshua Svaty,0
+Ford,Concord  TWP,Governor,,Dem,Joshua Svaty,0
+Ford,Dodge  TWP  H115,Governor,,Dem,Joshua Svaty,0
+Ford,Dodge  TWP  H119,Governor,,Dem,Joshua Svaty,0
+Ford,Dodge  TWP  W  H119,Governor,,Dem,Joshua Svaty,0
+Ford,Dodge  TWP  I  H119,Governor,,Dem,Joshua Svaty,0
+Ford,Enterprise  TWP  H115,Governor,,Dem,Joshua Svaty,4
+Ford,Enterprise  TWP  H119,Governor,,Dem,Joshua Svaty,0
+Ford,Fairview  TWP,Governor,,Dem,Joshua Svaty,1
+Ford,Ford  TWP,Governor,,Dem,Joshua Svaty,0
+Ford,Grandview  TWP  H115,Governor,,Dem,Joshua Svaty,8
+Ford,Grandview  TWP  East  H119,Governor,,Dem,Joshua Svaty,0
+Ford,Grandview  TWP-2,Governor,,Dem,Joshua Svaty,1
+Ford,Grandview  TWP-2  H119,Governor,,Dem,Joshua Svaty,0
+Ford,Richland  TWP,Governor,,Dem,Joshua Svaty,2
+Ford,Royal  TWP,Governor,,Dem,Joshua Svaty,1
+Ford,Sodville  TWP,Governor,,Dem,Joshua Svaty,0
+Ford,Spearville  TWP,Governor,,Dem,Joshua Svaty,0
+Ford,Wheatland  TWP,Governor,,Dem,Joshua Svaty,0
+Ford,Wilburn  TWP,Governor,,Dem,Joshua Svaty,0
+Ford,Dodge  TWP-3,Governor,,Dem,Joshua Svaty,0
+Ford,FORD CO KS,Governor,,Dem,Joshua Svaty,51
+Ford,Dodge City 1,Governor,,Dem,Arden Andersen,0
+Ford,Dodge City 2,Governor,,Dem,Arden Andersen,1
+Ford,Dodge City 3,Governor,,Dem,Arden Andersen,2
+Ford,Dodge City 4,Governor,,Dem,Arden Andersen,6
+Ford,Dodge City 5,Governor,,Dem,Arden Andersen,2
+Ford,Dodge City 6,Governor,,Dem,Arden Andersen,3
+Ford,Dodge City 7,Governor,,Dem,Arden Andersen,0
+Ford,Dodge City 8,Governor,,Dem,Arden Andersen,0
+Ford,Dodge City 9,Governor,,Dem,Arden Andersen,0
+Ford,Bucklin  City,Governor,,Dem,Arden Andersen,0
+Ford,Ford  City,Governor,,Dem,Arden Andersen,0
+Ford,Spearville  City,Governor,,Dem,Arden Andersen,2
+Ford,Bloom  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Bucklin  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Concord  TWP,Governor,,Dem,Arden Andersen,1
+Ford,Dodge  TWP  H115,Governor,,Dem,Arden Andersen,1
+Ford,Dodge  TWP  H119,Governor,,Dem,Arden Andersen,0
+Ford,Dodge  TWP  W  H119,Governor,,Dem,Arden Andersen,0
+Ford,Dodge  TWP  I  H119,Governor,,Dem,Arden Andersen,0
+Ford,Enterprise  TWP  H115,Governor,,Dem,Arden Andersen,2
+Ford,Enterprise  TWP  H119,Governor,,Dem,Arden Andersen,1
+Ford,Fairview  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Ford  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Grandview  TWP  H115,Governor,,Dem,Arden Andersen,1
+Ford,Grandview  TWP  East  H119,Governor,,Dem,Arden Andersen,0
+Ford,Grandview  TWP-2,Governor,,Dem,Arden Andersen,0
+Ford,Grandview  TWP-2  H119,Governor,,Dem,Arden Andersen,0
+Ford,Richland  TWP,Governor,,Dem,Arden Andersen,1
+Ford,Royal  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Sodville  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Spearville  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Wheatland  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Wilburn  TWP,Governor,,Dem,Arden Andersen,0
+Ford,Dodge  TWP-3,Governor,,Dem,Arden Andersen,0
+Ford,FORD CO KS,Governor,,Dem,Arden Andersen,23
+Ford,Dodge City 1,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge City 2,Governor,,Dem,Jack Bergeson,1
+Ford,Dodge City 3,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge City 4,Governor,,Dem,Jack Bergeson,1
+Ford,Dodge City 5,Governor,,Dem,Jack Bergeson,4
+Ford,Dodge City 6,Governor,,Dem,Jack Bergeson,4
+Ford,Dodge City 7,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge City 8,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge City 9,Governor,,Dem,Jack Bergeson,0
+Ford,Bucklin  City,Governor,,Dem,Jack Bergeson,0
+Ford,Ford  City,Governor,,Dem,Jack Bergeson,0
+Ford,Spearville  City,Governor,,Dem,Jack Bergeson,0
+Ford,Bloom  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Bucklin  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Concord  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge  TWP  H115,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge  TWP  H119,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge  TWP  W  H119,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge  TWP  I  H119,Governor,,Dem,Jack Bergeson,0
+Ford,Enterprise  TWP  H115,Governor,,Dem,Jack Bergeson,1
+Ford,Enterprise  TWP  H119,Governor,,Dem,Jack Bergeson,0
+Ford,Fairview  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Ford  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Grandview  TWP  H115,Governor,,Dem,Jack Bergeson,0
+Ford,Grandview  TWP  East  H119,Governor,,Dem,Jack Bergeson,0
+Ford,Grandview  TWP-2,Governor,,Dem,Jack Bergeson,1
+Ford,Grandview  TWP-2  H119,Governor,,Dem,Jack Bergeson,0
+Ford,Richland  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Royal  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Sodville  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Spearville  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Wheatland  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Wilburn  TWP,Governor,,Dem,Jack Bergeson,0
+Ford,Dodge  TWP-3,Governor,,Dem,Jack Bergeson,0
+Ford,FORD CO KS,Governor,,Dem,Jack Bergeson,12
+Ford,Dodge City 1,Governor,,Rep,Kris Kobach,58
+Ford,Dodge City 2,Governor,,Rep,Kris Kobach,30
+Ford,Dodge City 3,Governor,,Rep,Kris Kobach,21
+Ford,Dodge City 4,Governor,,Rep,Kris Kobach,76
+Ford,Dodge City 5,Governor,,Rep,Kris Kobach,168
+Ford,Dodge City 6,Governor,,Rep,Kris Kobach,215
+Ford,Dodge City 7,Governor,,Rep,Kris Kobach,4
+Ford,Dodge City 8,Governor,,Rep,Kris Kobach,0
+Ford,Dodge City 9,Governor,,Rep,Kris Kobach,0
+Ford,Bucklin  City,Governor,,Rep,Kris Kobach,71
+Ford,Ford  City,Governor,,Rep,Kris Kobach,18
+Ford,Spearville  City,Governor,,Rep,Kris Kobach,39
+Ford,Bloom  TWP,Governor,,Rep,Kris Kobach,7
+Ford,Bucklin  TWP,Governor,,Rep,Kris Kobach,11
+Ford,Concord  TWP,Governor,,Rep,Kris Kobach,11
+Ford,Dodge  TWP  H115,Governor,,Rep,Kris Kobach,24
+Ford,Dodge  TWP  H119,Governor,,Rep,Kris Kobach,7
+Ford,Dodge  TWP  W  H119,Governor,,Rep,Kris Kobach,0
+Ford,Dodge  TWP  I  H119,Governor,,Rep,Kris Kobach,0
+Ford,Enterprise  TWP  H115,Governor,,Rep,Kris Kobach,20
+Ford,Enterprise  TWP  H119,Governor,,Rep,Kris Kobach,0
+Ford,Fairview  TWP,Governor,,Rep,Kris Kobach,20
+Ford,Ford  TWP,Governor,,Rep,Kris Kobach,23
+Ford,Grandview  TWP  H115,Governor,,Rep,Kris Kobach,23
+Ford,Grandview  TWP  East  H119,Governor,,Rep,Kris Kobach,0
+Ford,Grandview  TWP-2,Governor,,Rep,Kris Kobach,5
+Ford,Grandview  TWP-2  H119,Governor,,Rep,Kris Kobach,0
+Ford,Richland  TWP,Governor,,Rep,Kris Kobach,26
+Ford,Royal  TWP,Governor,,Rep,Kris Kobach,11
+Ford,Sodville  TWP,Governor,,Rep,Kris Kobach,7
+Ford,Spearville  TWP,Governor,,Rep,Kris Kobach,31
+Ford,Wheatland  TWP,Governor,,Rep,Kris Kobach,6
+Ford,Wilburn  TWP,Governor,,Rep,Kris Kobach,2
+Ford,Dodge  TWP-3,Governor,,Rep,Kris Kobach,9
+Ford,FORD CO KS,Governor,,Rep,Kris Kobach,943
+Ford,Dodge City 1,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge City 2,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge City 3,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge City 4,Governor,,Rep,Patrick Kucera,5
+Ford,Dodge City 5,Governor,,Rep,Patrick Kucera,1
+Ford,Dodge City 6,Governor,,Rep,Patrick Kucera,3
+Ford,Dodge City 7,Governor,,Rep,Patrick Kucera,1
+Ford,Dodge City 8,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge City 9,Governor,,Rep,Patrick Kucera,0
+Ford,Bucklin  City,Governor,,Rep,Patrick Kucera,0
+Ford,Ford  City,Governor,,Rep,Patrick Kucera,0
+Ford,Spearville  City,Governor,,Rep,Patrick Kucera,0
+Ford,Bloom  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Bucklin  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Concord  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge  TWP  H115,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge  TWP  H119,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge  TWP  W  H119,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge  TWP  I  H119,Governor,,Rep,Patrick Kucera,0
+Ford,Enterprise  TWP  H115,Governor,,Rep,Patrick Kucera,1
+Ford,Enterprise  TWP  H119,Governor,,Rep,Patrick Kucera,0
+Ford,Fairview  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Ford  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Grandview  TWP  H115,Governor,,Rep,Patrick Kucera,0
+Ford,Grandview  TWP  East  H119,Governor,,Rep,Patrick Kucera,0
+Ford,Grandview  TWP-2,Governor,,Rep,Patrick Kucera,0
+Ford,Grandview  TWP-2  H119,Governor,,Rep,Patrick Kucera,0
+Ford,Richland  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Royal  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Sodville  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Spearville  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Wheatland  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Wilburn  TWP,Governor,,Rep,Patrick Kucera,0
+Ford,Dodge  TWP-3,Governor,,Rep,Patrick Kucera,0
+Ford,FORD CO KS,Governor,,Rep,Patrick Kucera,11
+Ford,Dodge City 1,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge City 2,Governor,,Rep,Tyler Ruzich,1
+Ford,Dodge City 3,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge City 4,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge City 5,Governor,,Rep,Tyler Ruzich,3
+Ford,Dodge City 6,Governor,,Rep,Tyler Ruzich,4
+Ford,Dodge City 7,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge City 8,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge City 9,Governor,,Rep,Tyler Ruzich,0
+Ford,Bucklin  City,Governor,,Rep,Tyler Ruzich,0
+Ford,Ford  City,Governor,,Rep,Tyler Ruzich,0
+Ford,Spearville  City,Governor,,Rep,Tyler Ruzich,0
+Ford,Bloom  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Bucklin  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Concord  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge  TWP  H115,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge  TWP  H119,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge  TWP  W  H119,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge  TWP  I  H119,Governor,,Rep,Tyler Ruzich,0
+Ford,Enterprise  TWP  H115,Governor,,Rep,Tyler Ruzich,0
+Ford,Enterprise  TWP  H119,Governor,,Rep,Tyler Ruzich,0
+Ford,Fairview  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Ford  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Grandview  TWP  H115,Governor,,Rep,Tyler Ruzich,0
+Ford,Grandview  TWP  East  H119,Governor,,Rep,Tyler Ruzich,0
+Ford,Grandview  TWP-2,Governor,,Rep,Tyler Ruzich,0
+Ford,Grandview  TWP-2  H119,Governor,,Rep,Tyler Ruzich,0
+Ford,Richland  TWP,Governor,,Rep,Tyler Ruzich,1
+Ford,Royal  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Sodville  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Spearville  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Wheatland  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Wilburn  TWP,Governor,,Rep,Tyler Ruzich,0
+Ford,Dodge  TWP-3,Governor,,Rep,Tyler Ruzich,0
+Ford,FORD CO KS,Governor,,Rep,Tyler Ruzich,9
+Ford,Dodge City 1,Governor,,Rep,Ken Selzer,8
+Ford,Dodge City 2,Governor,,Rep,Ken Selzer,1
+Ford,Dodge City 3,Governor,,Rep,Ken Selzer,2
+Ford,Dodge City 4,Governor,,Rep,Ken Selzer,9
+Ford,Dodge City 5,Governor,,Rep,Ken Selzer,22
+Ford,Dodge City 6,Governor,,Rep,Ken Selzer,46
+Ford,Dodge City 7,Governor,,Rep,Ken Selzer,6
+Ford,Dodge City 8,Governor,,Rep,Ken Selzer,0
+Ford,Dodge City 9,Governor,,Rep,Ken Selzer,0
+Ford,Bucklin  City,Governor,,Rep,Ken Selzer,5
+Ford,Ford  City,Governor,,Rep,Ken Selzer,4
+Ford,Spearville  City,Governor,,Rep,Ken Selzer,14
+Ford,Bloom  TWP,Governor,,Rep,Ken Selzer,0
+Ford,Bucklin  TWP,Governor,,Rep,Ken Selzer,6
+Ford,Concord  TWP,Governor,,Rep,Ken Selzer,1
+Ford,Dodge  TWP  H115,Governor,,Rep,Ken Selzer,2
+Ford,Dodge  TWP  H119,Governor,,Rep,Ken Selzer,1
+Ford,Dodge  TWP  W  H119,Governor,,Rep,Ken Selzer,0
+Ford,Dodge  TWP  I  H119,Governor,,Rep,Ken Selzer,0
+Ford,Enterprise  TWP  H115,Governor,,Rep,Ken Selzer,9
+Ford,Enterprise  TWP  H119,Governor,,Rep,Ken Selzer,0
+Ford,Fairview  TWP,Governor,,Rep,Ken Selzer,1
+Ford,Ford  TWP,Governor,,Rep,Ken Selzer,2
+Ford,Grandview  TWP  H115,Governor,,Rep,Ken Selzer,1
+Ford,Grandview  TWP  East  H119,Governor,,Rep,Ken Selzer,0
+Ford,Grandview  TWP-2,Governor,,Rep,Ken Selzer,1
+Ford,Grandview  TWP-2  H119,Governor,,Rep,Ken Selzer,0
+Ford,Richland  TWP,Governor,,Rep,Ken Selzer,4
+Ford,Royal  TWP,Governor,,Rep,Ken Selzer,2
+Ford,Sodville  TWP,Governor,,Rep,Ken Selzer,1
+Ford,Spearville  TWP,Governor,,Rep,Ken Selzer,6
+Ford,Wheatland  TWP,Governor,,Rep,Ken Selzer,2
+Ford,Wilburn  TWP,Governor,,Rep,Ken Selzer,1
+Ford,Dodge  TWP-3,Governor,,Rep,Ken Selzer,2
+Ford,FORD CO KS,Governor,,Rep,Ken Selzer,159
+Ford,Dodge City 1,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge City 2,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge City 3,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge City 4,Governor,,Rep,Joseph Tutera,1
+Ford,Dodge City 5,Governor,,Rep,Joseph Tutera,1
+Ford,Dodge City 6,Governor,,Rep,Joseph Tutera,1
+Ford,Dodge City 7,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge City 8,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge City 9,Governor,,Rep,Joseph Tutera,0
+Ford,Bucklin  City,Governor,,Rep,Joseph Tutera,0
+Ford,Ford  City,Governor,,Rep,Joseph Tutera,0
+Ford,Spearville  City,Governor,,Rep,Joseph Tutera,0
+Ford,Bloom  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Bucklin  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Concord  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge  TWP  H115,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge  TWP  H119,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge  TWP  W  H119,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge  TWP  I  H119,Governor,,Rep,Joseph Tutera,0
+Ford,Enterprise  TWP  H115,Governor,,Rep,Joseph Tutera,0
+Ford,Enterprise  TWP  H119,Governor,,Rep,Joseph Tutera,0
+Ford,Fairview  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Ford  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Grandview  TWP  H115,Governor,,Rep,Joseph Tutera,0
+Ford,Grandview  TWP  East  H119,Governor,,Rep,Joseph Tutera,0
+Ford,Grandview  TWP-2,Governor,,Rep,Joseph Tutera,2
+Ford,Grandview  TWP-2  H119,Governor,,Rep,Joseph Tutera,0
+Ford,Richland  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Royal  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Sodville  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Spearville  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Wheatland  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Wilburn  TWP,Governor,,Rep,Joseph Tutera,0
+Ford,Dodge  TWP-3,Governor,,Rep,Joseph Tutera,0
+Ford,FORD CO KS,Governor,,Rep,Joseph Tutera,5
+Ford,Dodge City 1,Governor,,Rep,Jim Barnett,1
+Ford,Dodge City 2,Governor,,Rep,Jim Barnett,1
+Ford,Dodge City 3,Governor,,Rep,Jim Barnett,1
+Ford,Dodge City 4,Governor,,Rep,Jim Barnett,14
+Ford,Dodge City 5,Governor,,Rep,Jim Barnett,17
+Ford,Dodge City 6,Governor,,Rep,Jim Barnett,40
+Ford,Dodge City 7,Governor,,Rep,Jim Barnett,2
+Ford,Dodge City 8,Governor,,Rep,Jim Barnett,0
+Ford,Dodge City 9,Governor,,Rep,Jim Barnett,0
+Ford,Bucklin  City,Governor,,Rep,Jim Barnett,4
+Ford,Ford  City,Governor,,Rep,Jim Barnett,1
+Ford,Spearville  City,Governor,,Rep,Jim Barnett,3
+Ford,Bloom  TWP,Governor,,Rep,Jim Barnett,0
+Ford,Bucklin  TWP,Governor,,Rep,Jim Barnett,4
+Ford,Concord  TWP,Governor,,Rep,Jim Barnett,0
+Ford,Dodge  TWP  H115,Governor,,Rep,Jim Barnett,2
+Ford,Dodge  TWP  H119,Governor,,Rep,Jim Barnett,0
+Ford,Dodge  TWP  W  H119,Governor,,Rep,Jim Barnett,0
+Ford,Dodge  TWP  I  H119,Governor,,Rep,Jim Barnett,0
+Ford,Enterprise  TWP  H115,Governor,,Rep,Jim Barnett,2
+Ford,Enterprise  TWP  H119,Governor,,Rep,Jim Barnett,0
+Ford,Fairview  TWP,Governor,,Rep,Jim Barnett,0
+Ford,Ford  TWP,Governor,,Rep,Jim Barnett,0
+Ford,Grandview  TWP  H115,Governor,,Rep,Jim Barnett,2
+Ford,Grandview  TWP  East  H119,Governor,,Rep,Jim Barnett,0
+Ford,Grandview  TWP-2,Governor,,Rep,Jim Barnett,1
+Ford,Grandview  TWP-2  H119,Governor,,Rep,Jim Barnett,0
+Ford,Richland  TWP,Governor,,Rep,Jim Barnett,1
+Ford,Royal  TWP,Governor,,Rep,Jim Barnett,3
+Ford,Sodville  TWP,Governor,,Rep,Jim Barnett,1
+Ford,Spearville  TWP,Governor,,Rep,Jim Barnett,3
+Ford,Wheatland  TWP,Governor,,Rep,Jim Barnett,1
+Ford,Wilburn  TWP,Governor,,Rep,Jim Barnett,1
+Ford,Dodge  TWP-3,Governor,,Rep,Jim Barnett,0
+Ford,FORD CO KS,Governor,,Rep,Jim Barnett,105
+Ford,Dodge City 1,Governor,,Rep,Jeff Colyer,27
+Ford,Dodge City 2,Governor,,Rep,Jeff Colyer,15
+Ford,Dodge City 3,Governor,,Rep,Jeff Colyer,19
+Ford,Dodge City 4,Governor,,Rep,Jeff Colyer,49
+Ford,Dodge City 5,Governor,,Rep,Jeff Colyer,122
+Ford,Dodge City 6,Governor,,Rep,Jeff Colyer,191
+Ford,Dodge City 7,Governor,,Rep,Jeff Colyer,11
+Ford,Dodge City 8,Governor,,Rep,Jeff Colyer,0
+Ford,Dodge City 9,Governor,,Rep,Jeff Colyer,0
+Ford,Bucklin  City,Governor,,Rep,Jeff Colyer,41
+Ford,Ford  City,Governor,,Rep,Jeff Colyer,11
+Ford,Spearville  City,Governor,,Rep,Jeff Colyer,53
+Ford,Bloom  TWP,Governor,,Rep,Jeff Colyer,4
+Ford,Bucklin  TWP,Governor,,Rep,Jeff Colyer,8
+Ford,Concord  TWP,Governor,,Rep,Jeff Colyer,4
+Ford,Dodge  TWP  H115,Governor,,Rep,Jeff Colyer,21
+Ford,Dodge  TWP  H119,Governor,,Rep,Jeff Colyer,4
+Ford,Dodge  TWP  W  H119,Governor,,Rep,Jeff Colyer,0
+Ford,Dodge  TWP  I  H119,Governor,,Rep,Jeff Colyer,0
+Ford,Enterprise  TWP  H115,Governor,,Rep,Jeff Colyer,12
+Ford,Enterprise  TWP  H119,Governor,,Rep,Jeff Colyer,0
+Ford,Fairview  TWP,Governor,,Rep,Jeff Colyer,19
+Ford,Ford  TWP,Governor,,Rep,Jeff Colyer,4
+Ford,Grandview  TWP  H115,Governor,,Rep,Jeff Colyer,17
+Ford,Grandview  TWP  East  H119,Governor,,Rep,Jeff Colyer,0
+Ford,Grandview  TWP-2,Governor,,Rep,Jeff Colyer,4
+Ford,Grandview  TWP-2  H119,Governor,,Rep,Jeff Colyer,0
+Ford,Richland  TWP,Governor,,Rep,Jeff Colyer,15
+Ford,Royal  TWP,Governor,,Rep,Jeff Colyer,10
+Ford,Sodville  TWP,Governor,,Rep,Jeff Colyer,10
+Ford,Spearville  TWP,Governor,,Rep,Jeff Colyer,19
+Ford,Wheatland  TWP,Governor,,Rep,Jeff Colyer,9
+Ford,Wilburn  TWP,Governor,,Rep,Jeff Colyer,1
+Ford,Dodge  TWP-3,Governor,,Rep,Jeff Colyer,4
+Ford,FORD CO KS,Governor,,Rep,Jeff Colyer,704
+Ford,Dodge City 1,Secretary of State,,Dem,Brian McClendon,22
+Ford,Dodge City 2,Secretary of State,,Dem,Brian McClendon,14
+Ford,Dodge City 3,Secretary of State,,Dem,Brian McClendon,31
+Ford,Dodge City 4,Secretary of State,,Dem,Brian McClendon,53
+Ford,Dodge City 5,Secretary of State,,Dem,Brian McClendon,68
+Ford,Dodge City 6,Secretary of State,,Dem,Brian McClendon,86
+Ford,Dodge City 7,Secretary of State,,Dem,Brian McClendon,1
+Ford,Dodge City 8,Secretary of State,,Dem,Brian McClendon,0
+Ford,Dodge City 9,Secretary of State,,Dem,Brian McClendon,0
+Ford,Bucklin  City,Secretary of State,,Dem,Brian McClendon,12
+Ford,Ford  City,Secretary of State,,Dem,Brian McClendon,3
+Ford,Spearville  City,Secretary of State,,Dem,Brian McClendon,22
+Ford,Bloom  TWP,Secretary of State,,Dem,Brian McClendon,1
+Ford,Bucklin  TWP,Secretary of State,,Dem,Brian McClendon,0
+Ford,Concord  TWP,Secretary of State,,Dem,Brian McClendon,3
+Ford,Dodge  TWP  H115,Secretary of State,,Dem,Brian McClendon,9
+Ford,Dodge  TWP  H119,Secretary of State,,Dem,Brian McClendon,2
+Ford,Dodge  TWP  W  H119,Secretary of State,,Dem,Brian McClendon,0
+Ford,Dodge  TWP  I  H119,Secretary of State,,Dem,Brian McClendon,0
+Ford,Enterprise  TWP  H115,Secretary of State,,Dem,Brian McClendon,10
+Ford,Enterprise  TWP  H119,Secretary of State,,Dem,Brian McClendon,1
+Ford,Fairview  TWP,Secretary of State,,Dem,Brian McClendon,0
+Ford,Ford  TWP,Secretary of State,,Dem,Brian McClendon,1
+Ford,Grandview  TWP  H115,Secretary of State,,Dem,Brian McClendon,13
+Ford,Grandview  TWP  East  H119,Secretary of State,,Dem,Brian McClendon,0
+Ford,Grandview  TWP-2,Secretary of State,,Dem,Brian McClendon,5
+Ford,Grandview  TWP-2  H119,Secretary of State,,Dem,Brian McClendon,0
+Ford,Richland  TWP,Secretary of State,,Dem,Brian McClendon,10
+Ford,Royal  TWP,Secretary of State,,Dem,Brian McClendon,2
+Ford,Sodville  TWP,Secretary of State,,Dem,Brian McClendon,1
+Ford,Spearville  TWP,Secretary of State,,Dem,Brian McClendon,4
+Ford,Wheatland  TWP,Secretary of State,,Dem,Brian McClendon,2
+Ford,Wilburn  TWP,Secretary of State,,Dem,Brian McClendon,0
+Ford,Dodge  TWP-3,Secretary of State,,Dem,Brian McClendon,0
+Ford,FORD CO KS,Secretary of State,,Dem,Brian McClendon,376
+Ford,Dodge City 1,Secretary of State,,Rep,Keith Esau,7
+Ford,Dodge City 2,Secretary of State,,Rep,Keith Esau,6
+Ford,Dodge City 3,Secretary of State,,Rep,Keith Esau,0
+Ford,Dodge City 4,Secretary of State,,Rep,Keith Esau,8
+Ford,Dodge City 5,Secretary of State,,Rep,Keith Esau,26
+Ford,Dodge City 6,Secretary of State,,Rep,Keith Esau,28
+Ford,Dodge City 7,Secretary of State,,Rep,Keith Esau,5
+Ford,Dodge City 8,Secretary of State,,Rep,Keith Esau,0
+Ford,Dodge City 9,Secretary of State,,Rep,Keith Esau,0
+Ford,Bucklin  City,Secretary of State,,Rep,Keith Esau,12
+Ford,Ford  City,Secretary of State,,Rep,Keith Esau,2
+Ford,Spearville  City,Secretary of State,,Rep,Keith Esau,5
+Ford,Bloom  TWP,Secretary of State,,Rep,Keith Esau,1
+Ford,Bucklin  TWP,Secretary of State,,Rep,Keith Esau,2
+Ford,Concord  TWP,Secretary of State,,Rep,Keith Esau,2
+Ford,Dodge  TWP  H115,Secretary of State,,Rep,Keith Esau,5
+Ford,Dodge  TWP  H119,Secretary of State,,Rep,Keith Esau,0
+Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Keith Esau,0
+Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Keith Esau,0
+Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Keith Esau,1
+Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Keith Esau,0
+Ford,Fairview  TWP,Secretary of State,,Rep,Keith Esau,1
+Ford,Ford  TWP,Secretary of State,,Rep,Keith Esau,1
+Ford,Grandview  TWP  H115,Secretary of State,,Rep,Keith Esau,1
+Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Keith Esau,0
+Ford,Grandview  TWP-2,Secretary of State,,Rep,Keith Esau,0
+Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Keith Esau,0
+Ford,Richland  TWP,Secretary of State,,Rep,Keith Esau,1
+Ford,Royal  TWP,Secretary of State,,Rep,Keith Esau,4
+Ford,Sodville  TWP,Secretary of State,,Rep,Keith Esau,0
+Ford,Spearville  TWP,Secretary of State,,Rep,Keith Esau,2
+Ford,Wheatland  TWP,Secretary of State,,Rep,Keith Esau,0
+Ford,Wilburn  TWP,Secretary of State,,Rep,Keith Esau,0
+Ford,Dodge  TWP-3,Secretary of State,,Rep,Keith Esau,2
+Ford,FORD CO KS,Secretary of State,,Rep,Keith Esau,122
+Ford,Dodge City 1,Secretary of State,,Rep,Craig McCullah,10
+Ford,Dodge City 2,Secretary of State,,Rep,Craig McCullah,6
+Ford,Dodge City 3,Secretary of State,,Rep,Craig McCullah,10
+Ford,Dodge City 4,Secretary of State,,Rep,Craig McCullah,19
+Ford,Dodge City 5,Secretary of State,,Rep,Craig McCullah,32
+Ford,Dodge City 6,Secretary of State,,Rep,Craig McCullah,47
+Ford,Dodge City 7,Secretary of State,,Rep,Craig McCullah,1
+Ford,Dodge City 8,Secretary of State,,Rep,Craig McCullah,0
+Ford,Dodge City 9,Secretary of State,,Rep,Craig McCullah,0
+Ford,Bucklin  City,Secretary of State,,Rep,Craig McCullah,10
+Ford,Ford  City,Secretary of State,,Rep,Craig McCullah,5
+Ford,Spearville  City,Secretary of State,,Rep,Craig McCullah,6
+Ford,Bloom  TWP,Secretary of State,,Rep,Craig McCullah,2
+Ford,Bucklin  TWP,Secretary of State,,Rep,Craig McCullah,3
+Ford,Concord  TWP,Secretary of State,,Rep,Craig McCullah,4
+Ford,Dodge  TWP  H115,Secretary of State,,Rep,Craig McCullah,3
+Ford,Dodge  TWP  H119,Secretary of State,,Rep,Craig McCullah,1
+Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Craig McCullah,0
+Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Craig McCullah,0
+Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Craig McCullah,7
+Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Craig McCullah,0
+Ford,Fairview  TWP,Secretary of State,,Rep,Craig McCullah,7
+Ford,Ford  TWP,Secretary of State,,Rep,Craig McCullah,6
+Ford,Grandview  TWP  H115,Secretary of State,,Rep,Craig McCullah,6
+Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Craig McCullah,0
+Ford,Grandview  TWP-2,Secretary of State,,Rep,Craig McCullah,0
+Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Craig McCullah,0
+Ford,Richland  TWP,Secretary of State,,Rep,Craig McCullah,6
+Ford,Royal  TWP,Secretary of State,,Rep,Craig McCullah,3
+Ford,Sodville  TWP,Secretary of State,,Rep,Craig McCullah,2
+Ford,Spearville  TWP,Secretary of State,,Rep,Craig McCullah,6
+Ford,Wheatland  TWP,Secretary of State,,Rep,Craig McCullah,2
+Ford,Wilburn  TWP,Secretary of State,,Rep,Craig McCullah,1
+Ford,Dodge  TWP-3,Secretary of State,,Rep,Craig McCullah,1
+Ford,FORD CO KS,Secretary of State,,Rep,Craig McCullah,206
+Ford,Dodge City 1,Secretary of State,,Rep,Scott Schwab,33
+Ford,Dodge City 2,Secretary of State,,Rep,Scott Schwab,16
+Ford,Dodge City 3,Secretary of State,,Rep,Scott Schwab,15
+Ford,Dodge City 4,Secretary of State,,Rep,Scott Schwab,72
+Ford,Dodge City 5,Secretary of State,,Rep,Scott Schwab,115
+Ford,Dodge City 6,Secretary of State,,Rep,Scott Schwab,178
+Ford,Dodge City 7,Secretary of State,,Rep,Scott Schwab,8
+Ford,Dodge City 8,Secretary of State,,Rep,Scott Schwab,0
+Ford,Dodge City 9,Secretary of State,,Rep,Scott Schwab,0
+Ford,Bucklin  City,Secretary of State,,Rep,Scott Schwab,37
+Ford,Ford  City,Secretary of State,,Rep,Scott Schwab,14
+Ford,Spearville  City,Secretary of State,,Rep,Scott Schwab,40
+Ford,Bloom  TWP,Secretary of State,,Rep,Scott Schwab,3
+Ford,Bucklin  TWP,Secretary of State,,Rep,Scott Schwab,10
+Ford,Concord  TWP,Secretary of State,,Rep,Scott Schwab,3
+Ford,Dodge  TWP  H115,Secretary of State,,Rep,Scott Schwab,21
+Ford,Dodge  TWP  H119,Secretary of State,,Rep,Scott Schwab,5
+Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Scott Schwab,0
+Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Scott Schwab,0
+Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Scott Schwab,16
+Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Scott Schwab,0
+Ford,Fairview  TWP,Secretary of State,,Rep,Scott Schwab,13
+Ford,Ford  TWP,Secretary of State,,Rep,Scott Schwab,6
+Ford,Grandview  TWP  H115,Secretary of State,,Rep,Scott Schwab,12
+Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Scott Schwab,0
+Ford,Grandview  TWP-2,Secretary of State,,Rep,Scott Schwab,2
+Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Scott Schwab,0
+Ford,Richland  TWP,Secretary of State,,Rep,Scott Schwab,12
+Ford,Royal  TWP,Secretary of State,,Rep,Scott Schwab,10
+Ford,Sodville  TWP,Secretary of State,,Rep,Scott Schwab,4
+Ford,Spearville  TWP,Secretary of State,,Rep,Scott Schwab,28
+Ford,Wheatland  TWP,Secretary of State,,Rep,Scott Schwab,4
+Ford,Wilburn  TWP,Secretary of State,,Rep,Scott Schwab,0
+Ford,Dodge  TWP-3,Secretary of State,,Rep,Scott Schwab,2
+Ford,FORD CO KS,Secretary of State,,Rep,Scott Schwab,679
+Ford,Dodge City 1,Secretary of State,,Rep,Dennis Taylor,11
+Ford,Dodge City 2,Secretary of State,,Rep,Dennis Taylor,5
+Ford,Dodge City 3,Secretary of State,,Rep,Dennis Taylor,5
+Ford,Dodge City 4,Secretary of State,,Rep,Dennis Taylor,15
+Ford,Dodge City 5,Secretary of State,,Rep,Dennis Taylor,27
+Ford,Dodge City 6,Secretary of State,,Rep,Dennis Taylor,60
+Ford,Dodge City 7,Secretary of State,,Rep,Dennis Taylor,4
+Ford,Dodge City 8,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Dodge City 9,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Bucklin  City,Secretary of State,,Rep,Dennis Taylor,9
+Ford,Ford  City,Secretary of State,,Rep,Dennis Taylor,2
+Ford,Spearville  City,Secretary of State,,Rep,Dennis Taylor,11
+Ford,Bloom  TWP,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Bucklin  TWP,Secretary of State,,Rep,Dennis Taylor,2
+Ford,Concord  TWP,Secretary of State,,Rep,Dennis Taylor,2
+Ford,Dodge  TWP  H115,Secretary of State,,Rep,Dennis Taylor,4
+Ford,Dodge  TWP  H119,Secretary of State,,Rep,Dennis Taylor,1
+Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Dennis Taylor,5
+Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Fairview  TWP,Secretary of State,,Rep,Dennis Taylor,4
+Ford,Ford  TWP,Secretary of State,,Rep,Dennis Taylor,5
+Ford,Grandview  TWP  H115,Secretary of State,,Rep,Dennis Taylor,1
+Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Grandview  TWP-2,Secretary of State,,Rep,Dennis Taylor,5
+Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Richland  TWP,Secretary of State,,Rep,Dennis Taylor,8
+Ford,Royal  TWP,Secretary of State,,Rep,Dennis Taylor,1
+Ford,Sodville  TWP,Secretary of State,,Rep,Dennis Taylor,3
+Ford,Spearville  TWP,Secretary of State,,Rep,Dennis Taylor,3
+Ford,Wheatland  TWP,Secretary of State,,Rep,Dennis Taylor,2
+Ford,Wilburn  TWP,Secretary of State,,Rep,Dennis Taylor,0
+Ford,Dodge  TWP-3,Secretary of State,,Rep,Dennis Taylor,4
+Ford,FORD CO KS,Secretary of State,,Rep,Dennis Taylor,199
+Ford,Dodge City 1,Secretary of State,,Rep,Randy Duncan,25
+Ford,Dodge City 2,Secretary of State,,Rep,Randy Duncan,7
+Ford,Dodge City 3,Secretary of State,,Rep,Randy Duncan,10
+Ford,Dodge City 4,Secretary of State,,Rep,Randy Duncan,28
+Ford,Dodge City 5,Secretary of State,,Rep,Randy Duncan,97
+Ford,Dodge City 6,Secretary of State,,Rep,Randy Duncan,133
+Ford,Dodge City 7,Secretary of State,,Rep,Randy Duncan,3
+Ford,Dodge City 8,Secretary of State,,Rep,Randy Duncan,0
+Ford,Dodge City 9,Secretary of State,,Rep,Randy Duncan,0
+Ford,Bucklin  City,Secretary of State,,Rep,Randy Duncan,36
+Ford,Ford  City,Secretary of State,,Rep,Randy Duncan,7
+Ford,Spearville  City,Secretary of State,,Rep,Randy Duncan,33
+Ford,Bloom  TWP,Secretary of State,,Rep,Randy Duncan,3
+Ford,Bucklin  TWP,Secretary of State,,Rep,Randy Duncan,9
+Ford,Concord  TWP,Secretary of State,,Rep,Randy Duncan,4
+Ford,Dodge  TWP  H115,Secretary of State,,Rep,Randy Duncan,11
+Ford,Dodge  TWP  H119,Secretary of State,,Rep,Randy Duncan,4
+Ford,Dodge  TWP  W  H119,Secretary of State,,Rep,Randy Duncan,0
+Ford,Dodge  TWP  I  H119,Secretary of State,,Rep,Randy Duncan,0
+Ford,Enterprise  TWP  H115,Secretary of State,,Rep,Randy Duncan,12
+Ford,Enterprise  TWP  H119,Secretary of State,,Rep,Randy Duncan,0
+Ford,Fairview  TWP,Secretary of State,,Rep,Randy Duncan,10
+Ford,Ford  TWP,Secretary of State,,Rep,Randy Duncan,4
+Ford,Grandview  TWP  H115,Secretary of State,,Rep,Randy Duncan,15
+Ford,Grandview  TWP  East  H119,Secretary of State,,Rep,Randy Duncan,0
+Ford,Grandview  TWP-2,Secretary of State,,Rep,Randy Duncan,3
+Ford,Grandview  TWP-2  H119,Secretary of State,,Rep,Randy Duncan,0
+Ford,Richland  TWP,Secretary of State,,Rep,Randy Duncan,14
+Ford,Royal  TWP,Secretary of State,,Rep,Randy Duncan,7
+Ford,Sodville  TWP,Secretary of State,,Rep,Randy Duncan,6
+Ford,Spearville  TWP,Secretary of State,,Rep,Randy Duncan,15
+Ford,Wheatland  TWP,Secretary of State,,Rep,Randy Duncan,5
+Ford,Wilburn  TWP,Secretary of State,,Rep,Randy Duncan,3
+Ford,Dodge  TWP-3,Secretary of State,,Rep,Randy Duncan,4
+Ford,FORD CO KS,Secretary of State,,Rep,Randy Duncan,508
+Ford,Dodge City 1,Attorney General,,Dem,Sarah Swain,23
+Ford,Dodge City 2,Attorney General,,Dem,Sarah Swain,15
+Ford,Dodge City 3,Attorney General,,Dem,Sarah Swain,30
+Ford,Dodge City 4,Attorney General,,Dem,Sarah Swain,54
+Ford,Dodge City 5,Attorney General,,Dem,Sarah Swain,72
+Ford,Dodge City 6,Attorney General,,Dem,Sarah Swain,92
+Ford,Dodge City 7,Attorney General,,Dem,Sarah Swain,1
+Ford,Dodge City 8,Attorney General,,Dem,Sarah Swain,0
+Ford,Dodge City 9,Attorney General,,Dem,Sarah Swain,0
+Ford,Bucklin  City,Attorney General,,Dem,Sarah Swain,11
+Ford,Ford  City,Attorney General,,Dem,Sarah Swain,3
+Ford,Spearville  City,Attorney General,,Dem,Sarah Swain,24
+Ford,Bloom  TWP,Attorney General,,Dem,Sarah Swain,1
+Ford,Bucklin  TWP,Attorney General,,Dem,Sarah Swain,0
+Ford,Concord  TWP,Attorney General,,Dem,Sarah Swain,3
+Ford,Dodge  TWP  H115,Attorney General,,Dem,Sarah Swain,9
+Ford,Dodge  TWP  H119,Attorney General,,Dem,Sarah Swain,2
+Ford,Dodge  TWP  W  H119,Attorney General,,Dem,Sarah Swain,0
+Ford,Dodge  TWP  I  H119,Attorney General,,Dem,Sarah Swain,0
+Ford,Enterprise  TWP  H115,Attorney General,,Dem,Sarah Swain,9
+Ford,Enterprise  TWP  H119,Attorney General,,Dem,Sarah Swain,1
+Ford,Fairview  TWP,Attorney General,,Dem,Sarah Swain,1
+Ford,Ford  TWP,Attorney General,,Dem,Sarah Swain,2
+Ford,Grandview  TWP  H115,Attorney General,,Dem,Sarah Swain,11
+Ford,Grandview  TWP  East  H119,Attorney General,,Dem,Sarah Swain,0
+Ford,Grandview  TWP-2,Attorney General,,Dem,Sarah Swain,5
+Ford,Grandview  TWP-2  H119,Attorney General,,Dem,Sarah Swain,0
+Ford,Richland  TWP,Attorney General,,Dem,Sarah Swain,9
+Ford,Royal  TWP,Attorney General,,Dem,Sarah Swain,2
+Ford,Sodville  TWP,Attorney General,,Dem,Sarah Swain,1
+Ford,Spearville  TWP,Attorney General,,Dem,Sarah Swain,4
+Ford,Wheatland  TWP,Attorney General,,Dem,Sarah Swain,2
+Ford,Wilburn  TWP,Attorney General,,Dem,Sarah Swain,0
+Ford,Dodge  TWP-3,Attorney General,,Dem,Sarah Swain,0
+Ford,FORD CO KS,Attorney General,,Dem,Sarah Swain,387
+Ford,Dodge City 1,Attorney General,,Rep,Derek Schmidt,82
+Ford,Dodge City 2,Attorney General,,Rep,Derek Schmidt,42
+Ford,Dodge City 3,Attorney General,,Rep,Derek Schmidt,38
+Ford,Dodge City 4,Attorney General,,Rep,Derek Schmidt,140
+Ford,Dodge City 5,Attorney General,,Rep,Derek Schmidt,291
+Ford,Dodge City 6,Attorney General,,Rep,Derek Schmidt,444
+Ford,Dodge City 7,Attorney General,,Rep,Derek Schmidt,22
+Ford,Dodge City 8,Attorney General,,Rep,Derek Schmidt,0
+Ford,Dodge City 9,Attorney General,,Rep,Derek Schmidt,0
+Ford,Bucklin  City,Attorney General,,Rep,Derek Schmidt,103
+Ford,Ford  City,Attorney General,,Rep,Derek Schmidt,32
+Ford,Spearville  City,Attorney General,,Rep,Derek Schmidt,101
+Ford,Bloom  TWP,Attorney General,,Rep,Derek Schmidt,9
+Ford,Bucklin  TWP,Attorney General,,Rep,Derek Schmidt,27
+Ford,Concord  TWP,Attorney General,,Rep,Derek Schmidt,15
+Ford,Dodge  TWP  H115,Attorney General,,Rep,Derek Schmidt,48
+Ford,Dodge  TWP  H119,Attorney General,,Rep,Derek Schmidt,11
+Ford,Dodge  TWP  W  H119,Attorney General,,Rep,Derek Schmidt,0
+Ford,Dodge  TWP  I  H119,Attorney General,,Rep,Derek Schmidt,0
+Ford,Enterprise  TWP  H115,Attorney General,,Rep,Derek Schmidt,41
+Ford,Enterprise  TWP  H119,Attorney General,,Rep,Derek Schmidt,0
+Ford,Fairview  TWP,Attorney General,,Rep,Derek Schmidt,34
+Ford,Ford  TWP,Attorney General,,Rep,Derek Schmidt,21
+Ford,Grandview  TWP  H115,Attorney General,,Rep,Derek Schmidt,36
+Ford,Grandview  TWP  East  H119,Attorney General,,Rep,Derek Schmidt,0
+Ford,Grandview  TWP-2,Attorney General,,Rep,Derek Schmidt,10
+Ford,Grandview  TWP-2  H119,Attorney General,,Rep,Derek Schmidt,0
+Ford,Richland  TWP,Attorney General,,Rep,Derek Schmidt,44
+Ford,Royal  TWP,Attorney General,,Rep,Derek Schmidt,24
+Ford,Sodville  TWP,Attorney General,,Rep,Derek Schmidt,15
+Ford,Spearville  TWP,Attorney General,,Rep,Derek Schmidt,56
+Ford,Wheatland  TWP,Attorney General,,Rep,Derek Schmidt,12
+Ford,Wilburn  TWP,Attorney General,,Rep,Derek Schmidt,4
+Ford,Dodge  TWP-3,Attorney General,,Rep,Derek Schmidt,14
+Ford,FORD CO KS,Attorney General,,Rep,Derek Schmidt,1716
+Ford,Dodge City 1,Treasurer,,Dem,Marci Francisco,23
+Ford,Dodge City 2,Treasurer,,Dem,Marci Francisco,16
+Ford,Dodge City 3,Treasurer,,Dem,Marci Francisco,30
+Ford,Dodge City 4,Treasurer,,Dem,Marci Francisco,51
+Ford,Dodge City 5,Treasurer,,Dem,Marci Francisco,72
+Ford,Dodge City 6,Treasurer,,Dem,Marci Francisco,94
+Ford,Dodge City 7,Treasurer,,Dem,Marci Francisco,1
+Ford,Dodge City 8,Treasurer,,Dem,Marci Francisco,0
+Ford,Dodge City 9,Treasurer,,Dem,Marci Francisco,0
+Ford,Bucklin  City,Treasurer,,Dem,Marci Francisco,11
+Ford,Ford  City,Treasurer,,Dem,Marci Francisco,3
+Ford,Spearville  City,Treasurer,,Dem,Marci Francisco,24
+Ford,Bloom  TWP,Treasurer,,Dem,Marci Francisco,1
+Ford,Bucklin  TWP,Treasurer,,Dem,Marci Francisco,0
+Ford,Concord  TWP,Treasurer,,Dem,Marci Francisco,3
+Ford,Dodge  TWP  H115,Treasurer,,Dem,Marci Francisco,9
+Ford,Dodge  TWP  H119,Treasurer,,Dem,Marci Francisco,2
+Ford,Dodge  TWP  W  H119,Treasurer,,Dem,Marci Francisco,0
+Ford,Dodge  TWP  I  H119,Treasurer,,Dem,Marci Francisco,0
+Ford,Enterprise  TWP  H115,Treasurer,,Dem,Marci Francisco,9
+Ford,Enterprise  TWP  H119,Treasurer,,Dem,Marci Francisco,1
+Ford,Fairview  TWP,Treasurer,,Dem,Marci Francisco,1
+Ford,Ford  TWP,Treasurer,,Dem,Marci Francisco,1
+Ford,Grandview  TWP  H115,Treasurer,,Dem,Marci Francisco,12
+Ford,Grandview  TWP  East  H119,Treasurer,,Dem,Marci Francisco,0
+Ford,Grandview  TWP-2,Treasurer,,Dem,Marci Francisco,5
+Ford,Grandview  TWP-2  H119,Treasurer,,Dem,Marci Francisco,0
+Ford,Richland  TWP,Treasurer,,Dem,Marci Francisco,8
+Ford,Royal  TWP,Treasurer,,Dem,Marci Francisco,1
+Ford,Sodville  TWP,Treasurer,,Dem,Marci Francisco,1
+Ford,Spearville  TWP,Treasurer,,Dem,Marci Francisco,4
+Ford,Wheatland  TWP,Treasurer,,Dem,Marci Francisco,1
+Ford,Wilburn  TWP,Treasurer,,Dem,Marci Francisco,0
+Ford,Dodge  TWP-3,Treasurer,,Dem,Marci Francisco,0
+Ford,FORD CO KS,Treasurer,,Dem,Marci Francisco,385
+Ford,Dodge City 1,Treasurer,,Rep,Jake LaTurner,79
+Ford,Dodge City 2,Treasurer,,Rep,Jake LaTurner,37
+Ford,Dodge City 3,Treasurer,,Rep,Jake LaTurner,35
+Ford,Dodge City 4,Treasurer,,Rep,Jake LaTurner,133
+Ford,Dodge City 5,Treasurer,,Rep,Jake LaTurner,286
+Ford,Dodge City 6,Treasurer,,Rep,Jake LaTurner,416
+Ford,Dodge City 7,Treasurer,,Rep,Jake LaTurner,21
+Ford,Dodge City 8,Treasurer,,Rep,Jake LaTurner,0
+Ford,Dodge City 9,Treasurer,,Rep,Jake LaTurner,0
+Ford,Bucklin  City,Treasurer,,Rep,Jake LaTurner,98
+Ford,Ford  City,Treasurer,,Rep,Jake LaTurner,26
+Ford,Spearville  City,Treasurer,,Rep,Jake LaTurner,91
+Ford,Bloom  TWP,Treasurer,,Rep,Jake LaTurner,9
+Ford,Bucklin  TWP,Treasurer,,Rep,Jake LaTurner,26
+Ford,Concord  TWP,Treasurer,,Rep,Jake LaTurner,14
+Ford,Dodge  TWP  H115,Treasurer,,Rep,Jake LaTurner,46
+Ford,Dodge  TWP  H119,Treasurer,,Rep,Jake LaTurner,10
+Ford,Dodge  TWP  W  H119,Treasurer,,Rep,Jake LaTurner,0
+Ford,Dodge  TWP  I  H119,Treasurer,,Rep,Jake LaTurner,0
+Ford,Enterprise  TWP  H115,Treasurer,,Rep,Jake LaTurner,39
+Ford,Enterprise  TWP  H119,Treasurer,,Rep,Jake LaTurner,0
+Ford,Fairview  TWP,Treasurer,,Rep,Jake LaTurner,34
+Ford,Ford  TWP,Treasurer,,Rep,Jake LaTurner,23
+Ford,Grandview  TWP  H115,Treasurer,,Rep,Jake LaTurner,36
+Ford,Grandview  TWP  East  H119,Treasurer,,Rep,Jake LaTurner,0
+Ford,Grandview  TWP-2,Treasurer,,Rep,Jake LaTurner,9
+Ford,Grandview  TWP-2  H119,Treasurer,,Rep,Jake LaTurner,0
+Ford,Richland  TWP,Treasurer,,Rep,Jake LaTurner,39
+Ford,Royal  TWP,Treasurer,,Rep,Jake LaTurner,24
+Ford,Sodville  TWP,Treasurer,,Rep,Jake LaTurner,15
+Ford,Spearville  TWP,Treasurer,,Rep,Jake LaTurner,52
+Ford,Wheatland  TWP,Treasurer,,Rep,Jake LaTurner,12
+Ford,Wilburn  TWP,Treasurer,,Rep,Jake LaTurner,4
+Ford,Dodge  TWP-3,Treasurer,,Rep,Jake LaTurner,13
+Ford,FORD CO KS,Treasurer,,Rep,Jake LaTurner,1627
+Ford,Dodge City 1,Insurance,,Dem,Nathaniel McLaughlin,22
+Ford,Dodge City 2,Insurance,,Dem,Nathaniel McLaughlin,14
+Ford,Dodge City 3,Insurance,,Dem,Nathaniel McLaughlin,27
+Ford,Dodge City 4,Insurance,,Dem,Nathaniel McLaughlin,51
+Ford,Dodge City 5,Insurance,,Dem,Nathaniel McLaughlin,71
+Ford,Dodge City 6,Insurance,,Dem,Nathaniel McLaughlin,93
+Ford,Dodge City 7,Insurance,,Dem,Nathaniel McLaughlin,1
+Ford,Dodge City 8,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Dodge City 9,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Bucklin  City,Insurance,,Dem,Nathaniel McLaughlin,12
+Ford,Ford  City,Insurance,,Dem,Nathaniel McLaughlin,3
+Ford,Spearville  City,Insurance,,Dem,Nathaniel McLaughlin,24
+Ford,Bloom  TWP,Insurance,,Dem,Nathaniel McLaughlin,1
+Ford,Bucklin  TWP,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Concord  TWP,Insurance,,Dem,Nathaniel McLaughlin,3
+Ford,Dodge  TWP  H115,Insurance,,Dem,Nathaniel McLaughlin,7
+Ford,Dodge  TWP  H119,Insurance,,Dem,Nathaniel McLaughlin,2
+Ford,Dodge  TWP  W  H119,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Dodge  TWP  I  H119,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Enterprise  TWP  H115,Insurance,,Dem,Nathaniel McLaughlin,10
+Ford,Enterprise  TWP  H119,Insurance,,Dem,Nathaniel McLaughlin,1
+Ford,Fairview  TWP,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Ford  TWP,Insurance,,Dem,Nathaniel McLaughlin,1
+Ford,Grandview  TWP  H115,Insurance,,Dem,Nathaniel McLaughlin,12
+Ford,Grandview  TWP  East  H119,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Grandview  TWP-2,Insurance,,Dem,Nathaniel McLaughlin,7
+Ford,Grandview  TWP-2  H119,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Richland  TWP,Insurance,,Dem,Nathaniel McLaughlin,10
+Ford,Royal  TWP,Insurance,,Dem,Nathaniel McLaughlin,2
+Ford,Sodville  TWP,Insurance,,Dem,Nathaniel McLaughlin,1
+Ford,Spearville  TWP,Insurance,,Dem,Nathaniel McLaughlin,4
+Ford,Wheatland  TWP,Insurance,,Dem,Nathaniel McLaughlin,1
+Ford,Wilburn  TWP,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,Dodge  TWP-3,Insurance,,Dem,Nathaniel McLaughlin,0
+Ford,FORD CO KS,Insurance,,Dem,Nathaniel McLaughlin,380
+Ford,Dodge City 1,Insurance,,Rep,Vicki Schmidt,45
+Ford,Dodge City 2,Insurance,,Rep,Vicki Schmidt,18
+Ford,Dodge City 3,Insurance,,Rep,Vicki Schmidt,16
+Ford,Dodge City 4,Insurance,,Rep,Vicki Schmidt,66
+Ford,Dodge City 5,Insurance,,Rep,Vicki Schmidt,153
+Ford,Dodge City 6,Insurance,,Rep,Vicki Schmidt,253
+Ford,Dodge City 7,Insurance,,Rep,Vicki Schmidt,8
+Ford,Dodge City 8,Insurance,,Rep,Vicki Schmidt,0
+Ford,Dodge City 9,Insurance,,Rep,Vicki Schmidt,0
+Ford,Bucklin  City,Insurance,,Rep,Vicki Schmidt,60
+Ford,Ford  City,Insurance,,Rep,Vicki Schmidt,17
+Ford,Spearville  City,Insurance,,Rep,Vicki Schmidt,61
+Ford,Bloom  TWP,Insurance,,Rep,Vicki Schmidt,1
+Ford,Bucklin  TWP,Insurance,,Rep,Vicki Schmidt,12
+Ford,Concord  TWP,Insurance,,Rep,Vicki Schmidt,8
+Ford,Dodge  TWP  H115,Insurance,,Rep,Vicki Schmidt,25
+Ford,Dodge  TWP  H119,Insurance,,Rep,Vicki Schmidt,3
+Ford,Dodge  TWP  W  H119,Insurance,,Rep,Vicki Schmidt,0
+Ford,Dodge  TWP  I  H119,Insurance,,Rep,Vicki Schmidt,0
+Ford,Enterprise  TWP  H115,Insurance,,Rep,Vicki Schmidt,24
+Ford,Enterprise  TWP  H119,Insurance,,Rep,Vicki Schmidt,0
+Ford,Fairview  TWP,Insurance,,Rep,Vicki Schmidt,19
+Ford,Ford  TWP,Insurance,,Rep,Vicki Schmidt,13
+Ford,Grandview  TWP  H115,Insurance,,Rep,Vicki Schmidt,16
+Ford,Grandview  TWP  East  H119,Insurance,,Rep,Vicki Schmidt,0
+Ford,Grandview  TWP-2,Insurance,,Rep,Vicki Schmidt,9
+Ford,Grandview  TWP-2  H119,Insurance,,Rep,Vicki Schmidt,0
+Ford,Richland  TWP,Insurance,,Rep,Vicki Schmidt,21
+Ford,Royal  TWP,Insurance,,Rep,Vicki Schmidt,16
+Ford,Sodville  TWP,Insurance,,Rep,Vicki Schmidt,4
+Ford,Spearville  TWP,Insurance,,Rep,Vicki Schmidt,24
+Ford,Wheatland  TWP,Insurance,,Rep,Vicki Schmidt,7
+Ford,Wilburn  TWP,Insurance,,Rep,Vicki Schmidt,5
+Ford,Dodge  TWP-3,Insurance,,Rep,Vicki Schmidt,11
+Ford,FORD CO KS,Insurance,,Rep,Vicki Schmidt,915
+Ford,Dodge City 1,Insurance,,Rep,Clark Shultz,44
+Ford,Dodge City 2,Insurance,,Rep,Clark Shultz,27
+Ford,Dodge City 3,Insurance,,Rep,Clark Shultz,23
+Ford,Dodge City 4,Insurance,,Rep,Clark Shultz,78
+Ford,Dodge City 5,Insurance,,Rep,Clark Shultz,156
+Ford,Dodge City 6,Insurance,,Rep,Clark Shultz,223
+Ford,Dodge City 7,Insurance,,Rep,Clark Shultz,12
+Ford,Dodge City 8,Insurance,,Rep,Clark Shultz,0
+Ford,Dodge City 9,Insurance,,Rep,Clark Shultz,0
+Ford,Bucklin  City,Insurance,,Rep,Clark Shultz,51
+Ford,Ford  City,Insurance,,Rep,Clark Shultz,14
+Ford,Spearville  City,Insurance,,Rep,Clark Shultz,43
+Ford,Bloom  TWP,Insurance,,Rep,Clark Shultz,9
+Ford,Bucklin  TWP,Insurance,,Rep,Clark Shultz,15
+Ford,Concord  TWP,Insurance,,Rep,Clark Shultz,5
+Ford,Dodge  TWP  H115,Insurance,,Rep,Clark Shultz,21
+Ford,Dodge  TWP  H119,Insurance,,Rep,Clark Shultz,9
+Ford,Dodge  TWP  W  H119,Insurance,,Rep,Clark Shultz,0
+Ford,Dodge  TWP  I  H119,Insurance,,Rep,Clark Shultz,0
+Ford,Enterprise  TWP  H115,Insurance,,Rep,Clark Shultz,19
+Ford,Enterprise  TWP  H119,Insurance,,Rep,Clark Shultz,0
+Ford,Fairview  TWP,Insurance,,Rep,Clark Shultz,19
+Ford,Ford  TWP,Insurance,,Rep,Clark Shultz,12
+Ford,Grandview  TWP  H115,Insurance,,Rep,Clark Shultz,22
+Ford,Grandview  TWP  East  H119,Insurance,,Rep,Clark Shultz,0
+Ford,Grandview  TWP-2,Insurance,,Rep,Clark Shultz,2
+Ford,Grandview  TWP-2  H119,Insurance,,Rep,Clark Shultz,0
+Ford,Richland  TWP,Insurance,,Rep,Clark Shultz,20
+Ford,Royal  TWP,Insurance,,Rep,Clark Shultz,9
+Ford,Sodville  TWP,Insurance,,Rep,Clark Shultz,11
+Ford,Spearville  TWP,Insurance,,Rep,Clark Shultz,32
+Ford,Wheatland  TWP,Insurance,,Rep,Clark Shultz,8
+Ford,Wilburn  TWP,Insurance,,Rep,Clark Shultz,0
+Ford,Dodge  TWP-3,Insurance,,Rep,Clark Shultz,4
+Ford,FORD CO KS,Insurance,,Rep,Clark Shultz,888
+Ford,Dodge City 1,State House,115,Dem,write-in,2
+Ford,Dodge City 9,State House,115,Dem,write-in,0
+Ford,Concord  TWP,State House,115,Dem,write-in,1
+Ford,Dodge  TWP  H115,State House,115,Dem,write-in,1
+Ford,Enterprise  TWP  H115,State House,115,Dem,write-in,1
+Ford,Fairview  TWP,State House,115,Dem,write-in,0
+Ford,Grandview  TWP  H115,State House,115,Dem,write-in,0
+Ford,Grandview  TWP-2,State House,115,Dem,write-in,0
+Ford,Grandview  TWP-2  H119,State House,115,Dem,write-in,0
+Ford,Richland  TWP,State House,115,Dem,write-in,0
+Ford,Royal  TWP,State House,115,Dem,write-in,0
+Ford,Wilburn  TWP,State House,115,Dem,write-in,0
+Ford,FORD CO KS,State House,115,Dem,write-in,5
+Ford,Dodge City 1,State House,115,Rep,Boyd Orr,82
+Ford,Dodge City 9,State House,115,Rep,Boyd Orr,0
+Ford,Concord  TWP,State House,115,Rep,Boyd Orr,13
+Ford,Dodge  TWP  H115,State House,115,Rep,Boyd Orr,45
+Ford,Enterprise  TWP  H115,State House,115,Rep,Boyd Orr,41
+Ford,Fairview  TWP,State House,115,Rep,Boyd Orr,36
+Ford,Grandview  TWP  H115,State House,115,Rep,Boyd Orr,34
+Ford,Grandview  TWP-2,State House,115,Rep,Boyd Orr,8
+Ford,Richland  TWP,State House,115,Rep,Boyd Orr,45
+Ford,Royal  TWP,State House,115,Rep,Boyd Orr,26
+Ford,Wilburn  TWP,State House,115,Rep,Boyd Orr,3
+Ford,FORD CO KS,State House,115,Rep,Boyd Orr,333
+Ford,Dodge City 2,State House,119,Dem,write-in,1
+Ford,Dodge City 3,State House,119,Dem,write-in,3
+Ford,Dodge City 4,State House,119,Dem,write-in,7
+Ford,Dodge City 5,State House,119,Dem,write-in,8
+Ford,Dodge City 6,State House,119,Dem,write-in,7
+Ford,Dodge City 7,State House,119,Dem,write-in,0
+Ford,Dodge City 8,State House,119,Dem,write-in,0
+Ford,Dodge  TWP  H119,State House,119,Dem,write-in,0
+Ford,Dodge  TWP  W  H119,State House,119,Dem,write-in,0
+Ford,Dodge  TWP  I  H119,State House,119,Dem,write-in,0
+Ford,Enterprise  TWP  H119,State House,119,Dem,write-in,0
+Ford,Grandview  TWP  East  H119,State House,119,Dem,write-in,0
+Ford,Grandview  TWP-2  H119,State House,119,Dem,write-in,0
+Ford,Dodge  TWP-3,State House,119,Dem,write-in,0
+Ford,FORD CO KS,State House,119,Dem,write-in,26
+Ford,Dodge City 2,State House,119,Rep,Bradley Ralph,43
+Ford,Dodge City 3,State House,119,Rep,Bradley Ralph,35
+Ford,Dodge City 4,State House,119,Rep,Bradley Ralph,146
+Ford,Dodge City 5,State House,119,Rep,Bradley Ralph,306
+Ford,Dodge City 6,State House,119,Rep,Bradley Ralph,446
+Ford,Dodge City 7,State House,119,Rep,Bradley Ralph,22
+Ford,Dodge City 8,State House,119,Rep,Bradley Ralph,0
+Ford,Dodge  TWP  H119,State House,119,Rep,Bradley Ralph,10
+Ford,Dodge  TWP  W  H119,State House,119,Rep,Bradley Ralph,0
+Ford,Dodge  TWP  I  H119,State House,119,Rep,Bradley Ralph,0
+Ford,Enterprise  TWP  H119,State House,119,Rep,Bradley Ralph,0
+Ford,Grandview  TWP  East  H119,State House,119,Rep,Bradley Ralph,0
+Ford,Grandview  TWP-2  H119,State House,119,Rep,Bradley Ralph,0
+Ford,Dodge  TWP-3,State House,119,Rep,Bradley Ralph,12
+Ford,FORD CO KS,State House,119,Rep,Bradley Ralph,1020
+Ford,Bucklin  City,State House,117,Dem,write-in,0
+Ford,Ford  City,State House,117,Dem,write-in,0
+Ford,Spearville  City,State House,117,Dem,write-in,1
+Ford,Bloom  TWP,State House,117,Dem,write-in,0
+Ford,Bucklin  TWP,State House,117,Dem,write-in,0
+Ford,Ford  TWP,State House,117,Dem,write-in,0
+Ford,Sodville  TWP,State House,117,Dem,write-in,0
+Ford,Spearville  TWP,State House,117,Dem,write-in,0
+Ford,Wheatland  TWP,State House,117,Dem,write-in,0
+Ford,FORD CO KS,State House,117,Dem,write-in,0
+Ford,Bucklin  City,State House,117,Rep,Leonard Mastroni,99
+Ford,Ford  City,State House,117,Rep,Leonard Mastroni,28
+Ford,Spearville  City,State House,117,Rep,Leonard Mastroni,91
+Ford,Bloom  TWP,State House,117,Rep,Leonard Mastroni,7
+Ford,Bucklin  TWP,State House,117,Rep,Leonard Mastroni,27
+Ford,Ford  TWP,State House,117,Rep,Leonard Mastroni,21
+Ford,Sodville  TWP,State House,117,Rep,Leonard Mastroni,14
+Ford,Spearville  TWP,State House,117,Rep,Leonard Mastroni,51
+Ford,Wheatland  TWP,State House,117,Rep,Leonard Mastroni,12
+Ford,FORD CO KS,State House,117,Rep,Leonard Mastroni,350

--- a/2018/20180807__ks__primary__riley__precinct.csv
+++ b/2018/20180807__ks__primary__riley__precinct.csv
@@ -1,1763 +1,1763 @@
-county,precinct,office,district,party,candidate,votes,
-Riley,W1P1,Registered Voters,,,Registered Voters,1218,
-Riley,W1P1,Ballots Cast,,Rep,Ballots Cast,112,
-Riley,W1P1,Ballots Cast,,Dem,Ballots Cast,159,
-Riley,W1P1,US House,1,Dem,Alan LaPolice,128,
-Riley,W1P1,Governor,,Dem,Joshua Svaty,66,
-Riley,W1P1,Governor,,Dem,Arden Andersen,2,
-Riley,W1P1,Governor,,Dem,Jack Bergeson,2,
-Riley,W1P1,Governor,,Dem,Carl Brewer,23,
-Riley,W1P1,Governor,,Dem,Laura Kelly,65,
-Riley,W1P1,Secretary of State,,Dem,Brian McClendon,132,
-Riley,W1P1,Attorney General,,Dem,Sarah Swain,133,
-Riley,W1P1,State Treasurer,,Dem,Marci Francisco,131,
-Riley,W1P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,127,
-Riley,W1P1,State House,66,Dem,Sydney Carlin,150,
-Riley,W1P1,US House,1,Rep,Nick Reinecker,41,
-Riley,W1P1,US House,1,Rep,Roger Marshall,60,
-Riley,W1P1,Governor,,Rep,Ken Selzer,10,
-Riley,W1P1,Governor,,Rep,Joseph Tutera,1,
-Riley,W1P1,Governor,,Rep,Jim Barnett,17,
-Riley,W1P1,Governor,,Rep,Jeff Colyer,46,
-Riley,W1P1,Governor,,Rep,Kris Kobach,36,
-Riley,W1P1,Governor,,Rep,Patrick Kucera,1,
-Riley,W1P1,Governor,,Rep,Tyler Ruzich,0,
-Riley,W1P1,Secretary of  State,,Rep,Dennis Taylor,29,
-Riley,W1P1,Secretary of  State,,Rep,Randy Duncan,24,
-Riley,W1P1,Secretary of  State,,Rep,Keith Esau,6,
-Riley,W1P1,Secretary of  State,,Rep,Craig McCullah,14,
-Riley,W1P1,Secretary of  State,,Rep,Scott Schwab,20,
-Riley,W1P1,Attorney General,,Rep,Derek Schmidt,85,
-Riley,W1P1,State Treasurer,,Rep,Jake LaTurner,77,
-Riley,W1P1,Insurance Commissioner,,Rep,Clark Shultz,49,
-Riley,W1P1,Insurance Commissioner,,Rep,Vicki Schmidt,48,
-Riley,W1P1,State House,66,Rep,write-in,11,
-Riley,W2P1,Registered Voters,,,Registered Voters,1353,
-Riley,W2P1,Ballots Cast,,Rep,Ballots Cast,64,
-Riley,W2P1,Ballots Cast,,Dem,Ballots Cast,108,
-Riley,W2P1,US House,1,Dem,Alan LaPolice,93,
-Riley,W2P1,Governor,,Dem,Joshua Svaty,51,
-Riley,W2P1,Governor,,Dem,Arden Andersen,3,
-Riley,W2P1,Governor,,Dem,Jack Bergeson,2,
-Riley,W2P1,Governor,,Dem,Carl Brewer,16,
-Riley,W2P1,Governor,,Dem,Laura Kelly,34,
-Riley,W2P1,Secretary of State,,Dem,Brian McClendon,92,
-Riley,W2P1,Attorney General,,Dem,Sarah Swain,95,
-Riley,W2P1,State Treasurer,,Dem,Marci Francisco,96,
-Riley,W2P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,93,
-Riley,W2P1,State House,66,Dem,Sydney Carlin,99,
-Riley,W2P1,US House,1,Rep,Nick Reinecker,20,
-Riley,W2P1,US House,1,Rep,Roger Marshall,38,
-Riley,W2P1,Governor,,Rep,Ken Selzer,5,
-Riley,W2P1,Governor,,Rep,Joseph Tutera,0,
-Riley,W2P1,Governor,,Rep,Jim Barnett,10,
-Riley,W2P1,Governor,,Rep,Jeff Colyer,25,
-Riley,W2P1,Governor,,Rep,Kris Kobach,21,
-Riley,W2P1,Governor,,Rep,Patrick Kucera,1,
-Riley,W2P1,Governor,,Rep,Tyler Ruzich,2,
-Riley,W2P1,Secretary of  State,,Rep,Dennis Taylor,15,
-Riley,W2P1,Secretary of  State,,Rep,Randy Duncan,11,
-Riley,W2P1,Secretary of  State,,Rep,Keith Esau,6,
-Riley,W2P1,Secretary of  State,,Rep,Craig McCullah,6,
-Riley,W2P1,Secretary of  State,,Rep,Scott Schwab,11,
-Riley,W2P1,Attorney General,,Rep,Derek Schmidt,48,
-Riley,W2P1,State Treasurer,,Rep,Jake LaTurner,43,
-Riley,W2P1,Insurance Commissioner,,Rep,Clark Shultz,23,
-Riley,W2P1,Insurance Commissioner,,Rep,Vicki Schmidt,29,
-Riley,W2P1,State House,66,Rep,write-in,4,
-Riley,W2P2,Registered Voters,,,Registered Voters,463,
-Riley,W2P2,Ballots Cast,,Rep,Ballots Cast,21,
-Riley,W2P2,Ballots Cast,,Dem,Ballots Cast,49,
-Riley,W2P2,US House,1,Dem,Alan LaPolice,27,
-Riley,W2P2,Governor,,Dem,Joshua Svaty,21,
-Riley,W2P2,Governor,,Dem,Arden Andersen,1,
-Riley,W2P2,Governor,,Dem,Jack Bergeson,0,
-Riley,W2P2,Governor,,Dem,Carl Brewer,10,
-Riley,W2P2,Governor,,Dem,Laura Kelly,17,
-Riley,W2P2,Secretary of State,,Dem,Brian McClendon,41,
-Riley,W2P2,Attorney General,,Dem,Sarah Swain,40,
-Riley,W2P2,State Treasurer,,Dem,Marci Francisco,40,
-Riley,W2P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,38,
-Riley,W2P2,State House,66,Dem,Sydney Carlin,44,
-Riley,W2P2,US House,1,Rep,Nick Reinecker,7,
-Riley,W2P2,US House,1,Rep,Roger Marshall,14,
-Riley,W2P2,Governor,,Rep,Ken Selzer,2,
-Riley,W2P2,Governor,,Rep,Joseph Tutera,0,
-Riley,W2P2,Governor,,Rep,Jim Barnett,2,
-Riley,W2P2,Governor,,Rep,Jeff Colyer,12,
-Riley,W2P2,Governor,,Rep,Kris Kobach,4,
-Riley,W2P2,Governor,,Rep,Patrick Kucera,0,
-Riley,W2P2,Governor,,Rep,Tyler Ruzich,1,
-Riley,W2P2,Secretary of  State,,Rep,Dennis Taylor,13,
-Riley,W2P2,Secretary of  State,,Rep,Randy Duncan,4,
-Riley,W2P2,Secretary of  State,,Rep,Keith Esau,0,
-Riley,W2P2,Secretary of  State,,Rep,Craig McCullah,2,
-Riley,W2P2,Secretary of  State,,Rep,Scott Schwab,2,
-Riley,W2P2,Attorney General,,Rep,Derek Schmidt,19,
-Riley,W2P2,State Treasurer,,Rep,Jake LaTurner,16,
-Riley,W2P2,Insurance Commissioner,,Rep,Clark Shultz,4,
-Riley,W2P2,Insurance Commissioner,,Rep,Vicki Schmidt,17,
-Riley,W2P2,State House,66,Rep,write-in,0,
-Riley,W2P3,Registered Voters,,,Registered Voters,1836,
-Riley,W2P3,Ballots Cast,,Rep,Ballots Cast,224,
-Riley,W2P3,Ballots Cast,,Dem,Ballots Cast,148,
-Riley,W2P3,US House,1,Dem,Alan LaPolice,126,
-Riley,W2P3,Governor,,Dem,Joshua Svaty,54,
-Riley,W2P3,Governor,,Dem,Arden Andersen,3,
-Riley,W2P3,Governor,,Dem,Jack Bergeson,1,
-Riley,W2P3,Governor,,Dem,Carl Brewer,15,
-Riley,W2P3,Governor,,Dem,Laura Kelly,73,
-Riley,W2P3,Secretary of State,,Dem,Brian McClendon,129,
-Riley,W2P3,Attorney General,,Dem,Sarah Swain,136,
-Riley,W2P3,State Treasurer,,Dem,Marci Francisco,129,
-Riley,W2P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,129,
-Riley,W2P3,State House,66,Dem,Sydney Carlin,142,
-Riley,W2P3,US House,1,Rep,Nick Reinecker,59,
-Riley,W2P3,US House,1,Rep,Roger Marshall,152,
-Riley,W2P3,Governor,,Rep,Ken Selzer,29,
-Riley,W2P3,Governor,,Rep,Joseph Tutera,1,
-Riley,W2P3,Governor,,Rep,Jim Barnett,20,
-Riley,W2P3,Governor,,Rep,Jeff Colyer,81,
-Riley,W2P3,Governor,,Rep,Kris Kobach,89,
-Riley,W2P3,Governor,,Rep,Patrick Kucera,1,
-Riley,W2P3,Governor,,Rep,Tyler Ruzich,1,
-Riley,W2P3,Secretary of  State,,Rep,Dennis Taylor,77,
-Riley,W2P3,Secretary of  State,,Rep,Randy Duncan,46,
-Riley,W2P3,Secretary of  State,,Rep,Keith Esau,7,
-Riley,W2P3,Secretary of  State,,Rep,Craig McCullah,43,
-Riley,W2P3,Secretary of  State,,Rep,Scott Schwab,41,
-Riley,W2P3,Attorney General,,Rep,Derek Schmidt,203,
-Riley,W2P3,State Treasurer,,Rep,Jake LaTurner,189,
-Riley,W2P3,Insurance Commissioner,,Rep,Clark Shultz,98,
-Riley,W2P3,Insurance Commissioner,,Rep,Vicki Schmidt,114,
-Riley,W2P3,State House,66,Rep,write-in,18,
-Riley,W2P4,Registered Voters,,,Registered Voters,1066,
-Riley,W2P4,Ballots Cast,,Rep,Ballots Cast,98,
-Riley,W2P4,Ballots Cast,,Dem,Ballots Cast,105,
-Riley,W2P4,US House,1,Dem,Alan LaPolice,88,
-Riley,W2P4,Governor,,Dem,Joshua Svaty,39,
-Riley,W2P4,Governor,,Dem,Arden Andersen,5,
-Riley,W2P4,Governor,,Dem,Jack Bergeson,2,
-Riley,W2P4,Governor,,Dem,Carl Brewer,17,
-Riley,W2P4,Governor,,Dem,Laura Kelly,42,
-Riley,W2P4,Secretary of State,,Dem,Brian McClendon,86,
-Riley,W2P4,Attorney General,,Dem,Sarah Swain,94,
-Riley,W2P4,State Treasurer,,Dem,Marci Francisco,88,
-Riley,W2P4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,86,
-Riley,W2P4,State House,66,Dem,Sydney Carlin,100,
-Riley,W2P4,US House,1,Rep,Nick Reinecker,20,
-Riley,W2P4,US House,1,Rep,Roger Marshall,76,
-Riley,W2P4,Governor,,Rep,Ken Selzer,12,
-Riley,W2P4,Governor,,Rep,Joseph Tutera,0,
-Riley,W2P4,Governor,,Rep,Jim Barnett,11,
-Riley,W2P4,Governor,,Rep,Jeff Colyer,31,
-Riley,W2P4,Governor,,Rep,Kris Kobach,39,
-Riley,W2P4,Governor,,Rep,Patrick Kucera,1,
-Riley,W2P4,Governor,,Rep,Tyler Ruzich,2,
-Riley,W2P4,Secretary of  State,,Rep,Dennis Taylor,28,
-Riley,W2P4,Secretary of  State,,Rep,Randy Duncan,19,
-Riley,W2P4,Secretary of  State,,Rep,Keith Esau,5,
-Riley,W2P4,Secretary of  State,,Rep,Craig McCullah,11,
-Riley,W2P4,Secretary of  State,,Rep,Scott Schwab,26,
-Riley,W2P4,Attorney General,,Rep,Derek Schmidt,85,
-Riley,W2P4,State Treasurer,,Rep,Jake LaTurner,86,
-Riley,W2P4,Insurance Commissioner,,Rep,Clark Shultz,48,
-Riley,W2P4,Insurance Commissioner,,Rep,Vicki Schmidt,45,
-Riley,W2P4,State House,66,Rep,write-in,6,
-Riley,W3P2,Registered Voters,,,Registered Voters,916,
-Riley,W3P2,Ballots Cast,,Rep,Ballots Cast,20,
-Riley,W3P2,Ballots Cast,,Dem,Ballots Cast,34,
-Riley,W3P2,US House,1,Dem,Alan LaPolice,31,
-Riley,W3P2,Governor,,Dem,Joshua Svaty,9,
-Riley,W3P2,Governor,,Dem,Arden Andersen,0,
-Riley,W3P2,Governor,,Dem,Jack Bergeson,0,
-Riley,W3P2,Governor,,Dem,Carl Brewer,5,
-Riley,W3P2,Governor,,Dem,Laura Kelly,20,
-Riley,W3P2,Secretary of State,,Dem,Brian McClendon,31,
-Riley,W3P2,Attorney General,,Dem,Sarah Swain,30,
-Riley,W3P2,State Treasurer,,Dem,Marci Francisco,31,
-Riley,W3P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,31,
-Riley,W3P2,State House,66,Dem,Sydney Carlin,32,
-Riley,W3P2,US House,1,Rep,Nick Reinecker,3,
-Riley,W3P2,US House,1,Rep,Roger Marshall,17,
-Riley,W3P2,Governor,,Rep,Ken Selzer,3,
-Riley,W3P2,Governor,,Rep,Joseph Tutera,0,
-Riley,W3P2,Governor,,Rep,Jim Barnett,5,
-Riley,W3P2,Governor,,Rep,Jeff Colyer,7,
-Riley,W3P2,Governor,,Rep,Kris Kobach,5,
-Riley,W3P2,Governor,,Rep,Patrick Kucera,0,
-Riley,W3P2,Governor,,Rep,Tyler Ruzich,0,
-Riley,W3P2,Secretary of  State,,Rep,Dennis Taylor,6,
-Riley,W3P2,Secretary of  State,,Rep,Randy Duncan,6,
-Riley,W3P2,Secretary of  State,,Rep,Keith Esau,1,
-Riley,W3P2,Secretary of  State,,Rep,Craig McCullah,3,
-Riley,W3P2,Secretary of  State,,Rep,Scott Schwab,3,
-Riley,W3P2,Attorney General,,Rep,Derek Schmidt,16,
-Riley,W3P2,State Treasurer,,Rep,Jake LaTurner,17,
-Riley,W3P2,Insurance Commissioner,,Rep,Clark Shultz,9,
-Riley,W3P2,Insurance Commissioner,,Rep,Vicki Schmidt,10,
-Riley,W3P2,State House,66,Rep,write-in,1,
-Riley,W3P3,Registered Voters,,,Registered Voters,1404,
-Riley,W3P3,Ballots Cast,,Rep,Ballots Cast,183,
-Riley,W3P3,Ballots Cast,,Dem,Ballots Cast,98,
-Riley,W3P3,US House,1,Dem,Alan LaPolice,81,
-Riley,W3P3,Governor,,Dem,Joshua Svaty,36,
-Riley,W3P3,Governor,,Dem,Arden Andersen,0,
-Riley,W3P3,Governor,,Dem,Jack Bergeson,3,
-Riley,W3P3,Governor,,Dem,Carl Brewer,6,
-Riley,W3P3,Governor,,Dem,Laura Kelly,50,
-Riley,W3P3,Secretary of State,,Dem,Brian McClendon,79,
-Riley,W3P3,Attorney General,,Dem,Sarah Swain,82,
-Riley,W3P3,State Treasurer,,Dem,Marci Francisco,81,
-Riley,W3P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,77,
-Riley,W3P3,State House,66,Dem,Sydney Carlin,94,
-Riley,W3P3,US House,1,Rep,Nick Reinecker,28,
-Riley,W3P3,US House,1,Rep,Roger Marshall,141,
-Riley,W3P3,Governor,,Rep,Ken Selzer,20,
-Riley,W3P3,Governor,,Rep,Joseph Tutera,1,
-Riley,W3P3,Governor,,Rep,Jim Barnett,25,
-Riley,W3P3,Governor,,Rep,Jeff Colyer,94,
-Riley,W3P3,Governor,,Rep,Kris Kobach,40,
-Riley,W3P3,Governor,,Rep,Patrick Kucera,1,
-Riley,W3P3,Governor,,Rep,Tyler Ruzich,2,
-Riley,W3P3,Secretary of  State,,Rep,Dennis Taylor,52,
-Riley,W3P3,Secretary of  State,,Rep,Randy Duncan,45,
-Riley,W3P3,Secretary of  State,,Rep,Keith Esau,4,
-Riley,W3P3,Secretary of  State,,Rep,Craig McCullah,16,
-Riley,W3P3,Secretary of  State,,Rep,Scott Schwab,34,
-Riley,W3P3,Attorney General,,Rep,Derek Schmidt,148,
-Riley,W3P3,State Treasurer,,Rep,Jake LaTurner,135,
-Riley,W3P3,Insurance Commissioner,,Rep,Clark Shultz,68,
-Riley,W3P3,Insurance Commissioner,,Rep,Vicki Schmidt,92,
-Riley,W3P3,State House,66,Rep,write-in,5,
-Riley,W4P2,Registered Voters,,,Registered Voters,326,
-Riley,W4P2,Ballots Cast,,Rep,Ballots Cast,59,
-Riley,W4P2,Ballots Cast,,Dem,Ballots Cast,39,
-Riley,W4P2,US House,1,Dem,Alan LaPolice,34,
-Riley,W4P2,Governor,,Dem,Joshua Svaty,14,
-Riley,W4P2,Governor,,Dem,Arden Andersen,0,
-Riley,W4P2,Governor,,Dem,Jack Bergeson,1,
-Riley,W4P2,Governor,,Dem,Carl Brewer,6,
-Riley,W4P2,Governor,,Dem,Laura Kelly,18,
-Riley,W4P2,Secretary of State,,Dem,Brian McClendon,36,
-Riley,W4P2,Attorney General,,Dem,Sarah Swain,37,
-Riley,W4P2,State Treasurer,,Dem,Marci Francisco,36,
-Riley,W4P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,35,
-Riley,W4P2,State House,66,Dem,Sydney Carlin,38,
-Riley,W4P2,US House,1,Rep,Nick Reinecker,19,
-Riley,W4P2,US House,1,Rep,Roger Marshall,36,
-Riley,W4P2,Governor,,Rep,Ken Selzer,5,
-Riley,W4P2,Governor,,Rep,Joseph Tutera,1,
-Riley,W4P2,Governor,,Rep,Jim Barnett,7,
-Riley,W4P2,Governor,,Rep,Jeff Colyer,22,
-Riley,W4P2,Governor,,Rep,Kris Kobach,23,
-Riley,W4P2,Governor,,Rep,Patrick Kucera,1,
-Riley,W4P2,Governor,,Rep,Tyler Ruzich,0,
-Riley,W4P2,Secretary of  State,,Rep,Dennis Taylor,27,
-Riley,W4P2,Secretary of  State,,Rep,Randy Duncan,12,
-Riley,W4P2,Secretary of  State,,Rep,Keith Esau,3,
-Riley,W4P2,Secretary of  State,,Rep,Craig McCullah,5,
-Riley,W4P2,Secretary of  State,,Rep,Scott Schwab,6,
-Riley,W4P2,Attorney General,,Rep,Derek Schmidt,46,
-Riley,W4P2,State Treasurer,,Rep,Jake LaTurner,41,
-Riley,W4P2,Insurance Commissioner,,Rep,Clark Shultz,18,
-Riley,W4P2,Insurance Commissioner,,Rep,Vicki Schmidt,32,
-Riley,W4P2,State House,66,Rep,write-in,3,
-Riley,W4P3,Registered Voters,,,Registered Voters,891,
-Riley,W4P3,Ballots Cast,,Rep,Ballots Cast,128,
-Riley,W4P3,Ballots Cast,,Dem,Ballots Cast,114,
-Riley,W4P3,US House,1,Dem,Alan LaPolice,101,
-Riley,W4P3,Governor,,Dem,Joshua Svaty,40,
-Riley,W4P3,Governor,,Dem,Arden Andersen,1,
-Riley,W4P3,Governor,,Dem,Jack Bergeson,0,
-Riley,W4P3,Governor,,Dem,Carl Brewer,12,
-Riley,W4P3,Governor,,Dem,Laura Kelly,59,
-Riley,W4P3,Secretary of State,,Dem,Brian McClendon,101,
-Riley,W4P3,Attorney General,,Dem,Sarah Swain,103,
-Riley,W4P3,State Treasurer,,Dem,Marci Francisco,100,
-Riley,W4P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,94,
-Riley,W4P3,State House,67,Dem,Alex Van Dyke,105,
-Riley,W4P3,US House,1,Rep,Nick Reinecker,34,
-Riley,W4P3,US House,1,Rep,Roger Marshall,84,
-Riley,W4P3,Governor,,Rep,Ken Selzer,16,
-Riley,W4P3,Governor,,Rep,Joseph Tutera,0,
-Riley,W4P3,Governor,,Rep,Jim Barnett,24,
-Riley,W4P3,Governor,,Rep,Jeff Colyer,45,
-Riley,W4P3,Governor,,Rep,Kris Kobach,38,
-Riley,W4P3,Governor,,Rep,Patrick Kucera,1,
-Riley,W4P3,Governor,,Rep,Tyler Ruzich,3,
-Riley,W4P3,Secretary of  State,,Rep,Dennis Taylor,44,
-Riley,W4P3,Secretary of  State,,Rep,Randy Duncan,26,
-Riley,W4P3,Secretary of  State,,Rep,Keith Esau,7,
-Riley,W4P3,Secretary of  State,,Rep,Craig McCullah,16,
-Riley,W4P3,Secretary of  State,,Rep,Scott Schwab,19,
-Riley,W4P3,Attorney General,,Rep,Derek Schmidt,110,
-Riley,W4P3,State Treasurer,,Rep,Jake LaTurner,101,
-Riley,W4P3,Insurance Commissioner,,Rep,Clark Shultz,51,
-Riley,W4P3,Insurance Commissioner,,Rep,Vicki Schmidt,63,
-Riley,W4P3,State House,67,Rep,Tom Phillips,117,
-Riley,W4P4,Registered Voters,,,Registered Voters,1686,
-Riley,W4P4,Ballots Cast,,Rep,Ballots Cast,338,
-Riley,W4P4,Ballots Cast,,Dem,Ballots Cast,148,
-Riley,W4P4,US House,1,Dem,Alan LaPolice,123,
-Riley,W4P4,Governor,,Dem,Joshua Svaty,57,
-Riley,W4P4,Governor,,Dem,Arden Andersen,2,
-Riley,W4P4,Governor,,Dem,Jack Bergeson,0,
-Riley,W4P4,Governor,,Dem,Carl Brewer,12,
-Riley,W4P4,Governor,,Dem,Laura Kelly,77,
-Riley,W4P4,Secretary of State,,Dem,Brian McClendon,127,
-Riley,W4P4,Attorney General,,Dem,Sarah Swain,130,
-Riley,W4P4,State Treasurer,,Dem,Marci Francisco,125,
-Riley,W4P4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,126,
-Riley,W4P4,State House,67,Dem,Alex Van Dyke,126,
-Riley,W4P4,US House,1,Rep,Nick Reinecker,80,
-Riley,W4P4,US House,1,Rep,Roger Marshall,246,
-Riley,W4P4,Governor,,Rep,Ken Selzer,37,
-Riley,W4P4,Governor,,Rep,Joseph Tutera,1,
-Riley,W4P4,Governor,,Rep,Jim Barnett,27,
-Riley,W4P4,Governor,,Rep,Jeff Colyer,171,
-Riley,W4P4,Governor,,Rep,Kris Kobach,95,
-Riley,W4P4,Governor,,Rep,Patrick Kucera,3,
-Riley,W4P4,Governor,,Rep,Tyler Ruzich,1,
-Riley,W4P4,Secretary of  State,,Rep,Dennis Taylor,110,
-Riley,W4P4,Secretary of  State,,Rep,Randy Duncan,69,
-Riley,W4P4,Secretary of  State,,Rep,Keith Esau,20,
-Riley,W4P4,Secretary of  State,,Rep,Craig McCullah,44,
-Riley,W4P4,Secretary of  State,,Rep,Scott Schwab,51,
-Riley,W4P4,Attorney General,,Rep,Derek Schmidt,288,
-Riley,W4P4,State Treasurer,,Rep,Jake LaTurner,268,
-Riley,W4P4,Insurance Commissioner,,Rep,Clark Shultz,147,
-Riley,W4P4,Insurance Commissioner,,Rep,Vicki Schmidt,158,
-Riley,W4P4,State House,67,Rep,Tom Phillips,298,
-Riley,W4P5,Registered Voters,,,Registered Voters,1025,
-Riley,W4P5,Ballots Cast,,Rep,Ballots Cast,177,
-Riley,W4P5,Ballots Cast,,Dem,Ballots Cast,85,
-Riley,W4P5,US House,1,Dem,Alan LaPolice,71,
-Riley,W4P5,Governor,,Dem,Joshua Svaty,34,
-Riley,W4P5,Governor,,Dem,Arden Andersen,2,
-Riley,W4P5,Governor,,Dem,Jack Bergeson,1,
-Riley,W4P5,Governor,,Dem,Carl Brewer,12,
-Riley,W4P5,Governor,,Dem,Laura Kelly,36,
-Riley,W4P5,Secretary of State,,Dem,Brian McClendon,76,
-Riley,W4P5,Attorney General,,Dem,Sarah Swain,77,
-Riley,W4P5,State Treasurer,,Dem,Marci Francisco,75,
-Riley,W4P5,Insurance Commissioner,,Dem,Nathaniel McLaughlin,77,
-Riley,W4P5,State House,67,Dem,Alex Van Dyke,76,
-Riley,W4P5,US House,1,Rep,Nick Reinecker,40,
-Riley,W4P5,US House,1,Rep,Roger Marshall,120,
-Riley,W4P5,Governor,,Rep,Ken Selzer,17,
-Riley,W4P5,Governor,,Rep,Joseph Tutera,2,
-Riley,W4P5,Governor,,Rep,Jim Barnett,19,
-Riley,W4P5,Governor,,Rep,Jeff Colyer,74,
-Riley,W4P5,Governor,,Rep,Kris Kobach,63,
-Riley,W4P5,Governor,,Rep,Patrick Kucera,1,
-Riley,W4P5,Governor,,Rep,Tyler Ruzich,1,
-Riley,W4P5,Secretary of  State,,Rep,Dennis Taylor,56,
-Riley,W4P5,Secretary of  State,,Rep,Randy Duncan,40,
-Riley,W4P5,Secretary of  State,,Rep,Keith Esau,17,
-Riley,W4P5,Secretary of  State,,Rep,Craig McCullah,16,
-Riley,W4P5,Secretary of  State,,Rep,Scott Schwab,25,
-Riley,W4P5,Attorney General,,Rep,Derek Schmidt,144,
-Riley,W4P5,State Treasurer,,Rep,Jake LaTurner,131,
-Riley,W4P5,Insurance Commissioner,,Rep,Clark Shultz,79,
-Riley,W4P5,Insurance Commissioner,,Rep,Vicki Schmidt,80,
-Riley,W4P5,State House,67,Rep,Tom Phillips,157,
-Riley,W4P6,Registered Voters,,,Registered Voters,651,p25
-Riley,W4P6,Ballots Cast,,Rep,Ballots Cast,123,
-Riley,W4P6,Ballots Cast,,Dem,Ballots Cast,55,
-Riley,W4P6,US House,1,Dem,Alan LaPolice,46,
-Riley,W4P6,Governor,,Dem,Joshua Svaty,30,
-Riley,W4P6,Governor,,Dem,Arden Andersen,0,
-Riley,W4P6,Governor,,Dem,Jack Bergeson,0,
-Riley,W4P6,Governor,,Dem,Carl Brewer,6,
-Riley,W4P6,Governor,,Dem,Laura Kelly,17,
-Riley,W4P6,Secretary of State,,Dem,Brian McClendon,47,
-Riley,W4P6,Attorney General,,Dem,Sarah Swain,50,
-Riley,W4P6,State Treasurer,,Dem,Marci Francisco,48,
-Riley,W4P6,Insurance Commissioner,,Dem,Nathaniel McLaughlin,46,
-Riley,W4P6,State House,67,Dem,Alex Van Dyke,49,
-Riley,W4P6,US House,1,Rep,Nick Reinecker,21,
-Riley,W4P6,US House,1,Rep,Roger Marshall,96,
-Riley,W4P6,Governor,,Rep,Ken Selzer,14,
-Riley,W4P6,Governor,,Rep,Joseph Tutera,0,
-Riley,W4P6,Governor,,Rep,Jim Barnett,10,
-Riley,W4P6,Governor,,Rep,Jeff Colyer,61,
-Riley,W4P6,Governor,,Rep,Kris Kobach,37,
-Riley,W4P6,Governor,,Rep,Patrick Kucera,0,
-Riley,W4P6,Governor,,Rep,Tyler Ruzich,0,
-Riley,W4P6,Secretary of  State,,Rep,Dennis Taylor,34,
-Riley,W4P6,Secretary of  State,,Rep,Randy Duncan,28,
-Riley,W4P6,Secretary of  State,,Rep,Keith Esau,2,
-Riley,W4P6,Secretary of  State,,Rep,Craig McCullah,11,
-Riley,W4P6,Secretary of  State,,Rep,Scott Schwab,23,
-Riley,W4P6,Attorney General,,Rep,Derek Schmidt,104,
-Riley,W4P6,State Treasurer,,Rep,Jake LaTurner,96,
-Riley,W4P6,Insurance Commissioner,,Rep,Clark Shultz,56,
-Riley,W4P6,Insurance Commissioner,,Rep,Vicki Schmidt,49,
-Riley,W4P6,State House,67,Rep,Tom Phillips,110,
-Riley,W4P7,Registered Voters,,,Registered Voters,53,
-Riley,W4P7,Ballots Cast,,Rep,Ballots Cast,13,
-Riley,W4P7,Ballots Cast,,Dem,Ballots Cast,2,
-Riley,W4P7,US House,1,Dem,Alan LaPolice,2,
-Riley,W4P7,Governor,,Dem,Joshua Svaty,2,
-Riley,W4P7,Governor,,Dem,Arden Andersen,0,
-Riley,W4P7,Governor,,Dem,Jack Bergeson,0,
-Riley,W4P7,Governor,,Dem,Carl Brewer,0,
-Riley,W4P7,Governor,,Dem,Laura Kelly,0,
-Riley,W4P7,Secretary of State,,Dem,Brian McClendon,2,
-Riley,W4P7,Attorney General,,Dem,Sarah Swain,2,
-Riley,W4P7,State Treasurer,,Dem,Marci Francisco,2,
-Riley,W4P7,Insurance Commissioner,,Dem,Nathaniel McLaughlin,1,
-Riley,W4P7,State House,67,Dem,Alex Van Dyke,2,
-Riley,W4P7,US House,1,Rep,Nick Reinecker,3,
-Riley,W4P7,US House,1,Rep,Roger Marshall,10,
-Riley,W4P7,Governor,,Rep,Ken Selzer,0,
-Riley,W4P7,Governor,,Rep,Joseph Tutera,0,
-Riley,W4P7,Governor,,Rep,Jim Barnett,2,
-Riley,W4P7,Governor,,Rep,Jeff Colyer,5,
-Riley,W4P7,Governor,,Rep,Kris Kobach,6,
-Riley,W4P7,Governor,,Rep,Patrick Kucera,0,
-Riley,W4P7,Governor,,Rep,Tyler Ruzich,0,
-Riley,W4P7,Secretary of  State,,Rep,Dennis Taylor,4,
-Riley,W4P7,Secretary of  State,,Rep,Randy Duncan,5,
-Riley,W4P7,Secretary of  State,,Rep,Keith Esau,0,
-Riley,W4P7,Secretary of  State,,Rep,Craig McCullah,1,
-Riley,W4P7,Secretary of  State,,Rep,Scott Schwab,2,
-Riley,W4P7,Attorney General,,Rep,Derek Schmidt,13,
-Riley,W4P7,State Treasurer,,Rep,Jake LaTurner,13,
-Riley,W4P7,Insurance Commissioner,,Rep,Clark Shultz,7,
-Riley,W4P7,Insurance Commissioner,,Rep,Vicki Schmidt,6,
-Riley,W4P7,State House,67,Rep,Tom Phillips,13,
-Riley,W5P2,Registered Voters,,,Registered Voters,1187,
-Riley,W5P2,Ballots Cast,,Rep,Ballots Cast,80,
-Riley,W5P2,Ballots Cast,,Dem,Ballots Cast,121,
-Riley,W5P2,US House,1,Dem,Alan LaPolice,103,
-Riley,W5P2,Governor,,Dem,Joshua Svaty,41,
-Riley,W5P2,Governor,,Dem,Arden Andersen,1,
-Riley,W5P2,Governor,,Dem,Jack Bergeson,0,
-Riley,W5P2,Governor,,Dem,Carl Brewer,21,
-Riley,W5P2,Governor,,Dem,Laura Kelly,58,
-Riley,W5P2,Secretary of State,,Dem,Brian McClendon,111,
-Riley,W5P2,Attorney General,,Dem,Sarah Swain,109,
-Riley,W5P2,State Treasurer,,Dem,Marci Francisco,108,
-Riley,W5P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,104,
-Riley,W5P2,State House,66,Dem,Sydney Carlin,117,
-Riley,W5P2,US House,1,Rep,Nick Reinecker,29,
-Riley,W5P2,US House,1,Rep,Roger Marshall,47,
-Riley,W5P2,Governor,,Rep,Ken Selzer,12,
-Riley,W5P2,Governor,,Rep,Joseph Tutera,0,
-Riley,W5P2,Governor,,Rep,Jim Barnett,4,
-Riley,W5P2,Governor,,Rep,Jeff Colyer,42,
-Riley,W5P2,Governor,,Rep,Kris Kobach,20,
-Riley,W5P2,Governor,,Rep,Patrick Kucera,2,
-Riley,W5P2,Governor,,Rep,Tyler Ruzich,0,
-Riley,W5P2,Secretary of  State,,Rep,Dennis Taylor,10,
-Riley,W5P2,Secretary of  State,,Rep,Randy Duncan,15,
-Riley,W5P2,Secretary of  State,,Rep,Keith Esau,12,
-Riley,W5P2,Secretary of  State,,Rep,Craig McCullah,17,
-Riley,W5P2,Secretary of  State,,Rep,Scott Schwab,15,
-Riley,W5P2,Attorney General,,Rep,Derek Schmidt,59,
-Riley,W5P2,State Treasurer,,Rep,Jake LaTurner,59,
-Riley,W5P2,Insurance Commissioner,,Rep,Clark Shultz,34,
-Riley,W5P2,Insurance Commissioner,,Rep,Vicki Schmidt,40,
-Riley,W5P2,State House,66,Rep,write-in,7,
-Riley,W5P3,Registered Voters,,,Registered Voters,1369,
-Riley,W5P3,Ballots Cast,,Rep,Ballots Cast,97,
-Riley,W5P3,Ballots Cast,,Dem,Ballots Cast,99,
-Riley,W5P3,US House,1,Dem,Alan LaPolice,91,
-Riley,W5P3,Governor,,Dem,Joshua Svaty,34,
-Riley,W5P3,Governor,,Dem,Arden Andersen,4,
-Riley,W5P3,Governor,,Dem,Jack Bergeson,0,
-Riley,W5P3,Governor,,Dem,Carl Brewer,12,
-Riley,W5P3,Governor,,Dem,Laura Kelly,49,
-Riley,W5P3,Secretary of State,,Dem,Brian McClendon,92,
-Riley,W5P3,Attorney General,,Dem,Sarah Swain,94,
-Riley,W5P3,State Treasurer,,Dem,Marci Francisco,92,
-Riley,W5P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,89,
-Riley,W5P3,State House,66,Dem,Sydney Carlin,92,
-Riley,W5P3,US House,1,Rep,Nick Reinecker,16,
-Riley,W5P3,US House,1,Rep,Roger Marshall,73,
-Riley,W5P3,Governor,,Rep,Ken Selzer,12,
-Riley,W5P3,Governor,,Rep,Joseph Tutera,0,
-Riley,W5P3,Governor,,Rep,Jim Barnett,12,
-Riley,W5P3,Governor,,Rep,Jeff Colyer,44,
-Riley,W5P3,Governor,,Rep,Kris Kobach,26,
-Riley,W5P3,Governor,,Rep,Patrick Kucera,1,
-Riley,W5P3,Governor,,Rep,Tyler Ruzich,1,
-Riley,W5P3,Secretary of  State,,Rep,Dennis Taylor,36,
-Riley,W5P3,Secretary of  State,,Rep,Randy Duncan,20,
-Riley,W5P3,Secretary of  State,,Rep,Keith Esau,3,
-Riley,W5P3,Secretary of  State,,Rep,Craig McCullah,6,
-Riley,W5P3,Secretary of  State,,Rep,Scott Schwab,19,
-Riley,W5P3,Attorney General,,Rep,Derek Schmidt,81,
-Riley,W5P3,State Treasurer,,Rep,Jake LaTurner,71,
-Riley,W5P3,Insurance Commissioner,,Rep,Clark Shultz,42,
-Riley,W5P3,Insurance Commissioner,,Rep,Vicki Schmidt,46,
-Riley,W5P3,State House,66,Rep,write-in,2,
-Riley,W5P5,Registered Voters,,,Registered Voters,595,
-Riley,W5P5,Ballots Cast,,Rep,Ballots Cast,81,
-Riley,W5P5,Ballots Cast,,Dem,Ballots Cast,59,
-Riley,W5P5,US House,1,Dem,Alan LaPolice,49,
-Riley,W5P5,Governor,,Dem,Joshua Svaty,20,
-Riley,W5P5,Governor,,Dem,Arden Andersen,1,
-Riley,W5P5,Governor,,Dem,Jack Bergeson,1,
-Riley,W5P5,Governor,,Dem,Carl Brewer,7,
-Riley,W5P5,Governor,,Dem,Laura Kelly,29,
-Riley,W5P5,Secretary of State,,Dem,Brian McClendon,45,
-Riley,W5P5,Attorney General,,Dem,Sarah Swain,47,
-Riley,W5P5,State Treasurer,,Dem,Marci Francisco,48,
-Riley,W5P5,Insurance Commissioner,,Dem,Nathaniel McLaughlin,45,
-Riley,W5P5,State House,67,Dem,Alex Van Dyke,50,
-Riley,W5P5,US House,1,Rep,Nick Reinecker,21,
-Riley,W5P5,US House,1,Rep,Roger Marshall,56,
-Riley,W5P5,Governor,,Rep,Ken Selzer,9,
-Riley,W5P5,Governor,,Rep,Joseph Tutera,1,
-Riley,W5P5,Governor,,Rep,Jim Barnett,7,
-Riley,W5P5,Governor,,Rep,Jeff Colyer,33,
-Riley,W5P5,Governor,,Rep,Kris Kobach,28,
-Riley,W5P5,Governor,,Rep,Patrick Kucera,2,
-Riley,W5P5,Governor,,Rep,Tyler Ruzich,0,
-Riley,W5P5,Secretary of  State,,Rep,Dennis Taylor,29,
-Riley,W5P5,Secretary of  State,,Rep,Randy Duncan,14,
-Riley,W5P5,Secretary of  State,,Rep,Keith Esau,5,
-Riley,W5P5,Secretary of  State,,Rep,Craig McCullah,13,
-Riley,W5P5,Secretary of  State,,Rep,Scott Schwab,13,
-Riley,W5P5,Attorney General,,Rep,Derek Schmidt,70,
-Riley,W5P5,State Treasurer,,Rep,Jake LaTurner,61,
-Riley,W5P5,Insurance Commissioner,,Rep,Clark Shultz,41,
-Riley,W5P5,Insurance Commissioner,,Rep,Vicki Schmidt,35,
-Riley,W5P5,State House,67,Rep,Tom Phillips,73,
-Riley,W5P6,Registered Voters,,,Registered Voters,1001,
-Riley,W5P6,Ballots Cast,,Rep,Ballots Cast,236,
-Riley,W5P6,Ballots Cast,,Dem,Ballots Cast,101,
-Riley,W5P6,US House,1,Dem,Alan LaPolice,87,
-Riley,W5P6,Governor,,Dem,Joshua Svaty,33,
-Riley,W5P6,Governor,,Dem,Arden Andersen,1,
-Riley,W5P6,Governor,,Dem,Jack Bergeson,0,
-Riley,W5P6,Governor,,Dem,Carl Brewer,15,
-Riley,W5P6,Governor,,Dem,Laura Kelly,51,
-Riley,W5P6,Secretary of State,,Dem,Brian McClendon,84,
-Riley,W5P6,Attorney General,,Dem,Sarah Swain,90,
-Riley,W5P6,State Treasurer,,Dem,Marci Francisco,89,
-Riley,W5P6,Insurance Commissioner,,Dem,Nathaniel McLaughlin,83,
-Riley,W5P6,State House,67,Dem,Alex Van Dyke,93,
-Riley,W5P6,US House,1,Rep,Nick Reinecker,51,
-Riley,W5P6,US House,1,Rep,Roger Marshall,177,
-Riley,W5P6,Governor,,Rep,Ken Selzer,25,
-Riley,W5P6,Governor,,Rep,Joseph Tutera,0,
-Riley,W5P6,Governor,,Rep,Jim Barnett,24,
-Riley,W5P6,Governor,,Rep,Jeff Colyer,103,
-Riley,W5P6,Governor,,Rep,Kris Kobach,81,
-Riley,W5P6,Governor,,Rep,Patrick Kucera,1,
-Riley,W5P6,Governor,,Rep,Tyler Ruzich,2,
-Riley,W5P6,Secretary of  State,,Rep,Dennis Taylor,82,
-Riley,W5P6,Secretary of  State,,Rep,Randy Duncan,42,
-Riley,W5P6,Secretary of  State,,Rep,Keith Esau,12,
-Riley,W5P6,Secretary of  State,,Rep,Craig McCullah,30,
-Riley,W5P6,Secretary of  State,,Rep,Scott Schwab,49,
-Riley,W5P6,Attorney General,,Rep,Derek Schmidt,201,
-Riley,W5P6,State Treasurer,,Rep,Jake LaTurner,194,
-Riley,W5P6,Insurance Commissioner,,Rep,Clark Shultz,104,
-Riley,W5P6,Insurance Commissioner,,Rep,Vicki Schmidt,115,
-Riley,W5P6,State House,67,Rep,Tom Phillips,209,
-Riley,W5P7,Registered Voters,,,Registered Voters,482,
-Riley,W5P7,Ballots Cast,,Rep,Ballots Cast,88,
-Riley,W5P7,Ballots Cast,,Dem,Ballots Cast,48,
-Riley,W5P7,US House,1,Dem,Alan LaPolice,43,
-Riley,W5P7,Governor,,Dem,Joshua Svaty,14,
-Riley,W5P7,Governor,,Dem,Arden Andersen,0,
-Riley,W5P7,Governor,,Dem,Jack Bergeson,1,
-Riley,W5P7,Governor,,Dem,Carl Brewer,6,
-Riley,W5P7,Governor,,Dem,Laura Kelly,27,
-Riley,W5P7,Secretary of State,,Dem,Brian McClendon,41,
-Riley,W5P7,Attorney General,,Dem,Sarah Swain,44,
-Riley,W5P7,State Treasurer,,Dem,Marci Francisco,42,
-Riley,W5P7,Insurance Commissioner,,Dem,Nathaniel McLaughlin,38,
-Riley,W5P7,State House,67,Dem,Alex Van Dyke,46,
-Riley,W5P7,US House,1,Rep,Nick Reinecker,21,
-Riley,W5P7,US House,1,Rep,Roger Marshall,63,
-Riley,W5P7,Governor,,Rep,Ken Selzer,12,
-Riley,W5P7,Governor,,Rep,Joseph Tutera,0,
-Riley,W5P7,Governor,,Rep,Jim Barnett,5,
-Riley,W5P7,Governor,,Rep,Jeff Colyer,41,
-Riley,W5P7,Governor,,Rep,Kris Kobach,28,
-Riley,W5P7,Governor,,Rep,Patrick Kucera,0,
-Riley,W5P7,Governor,,Rep,Tyler Ruzich,1,
-Riley,W5P7,Secretary of  State,,Rep,Dennis Taylor,28,
-Riley,W5P7,Secretary of  State,,Rep,Randy Duncan,18,
-Riley,W5P7,Secretary of  State,,Rep,Keith Esau,4,
-Riley,W5P7,Secretary of  State,,Rep,Craig McCullah,12,
-Riley,W5P7,Secretary of  State,,Rep,Scott Schwab,18,
-Riley,W5P7,Attorney General,,Rep,Derek Schmidt,73,
-Riley,W5P7,State Treasurer,,Rep,Jake LaTurner,71,
-Riley,W5P7,Insurance Commissioner,,Rep,Clark Shultz,41,
-Riley,W5P7,Insurance Commissioner,,Rep,Vicki Schmidt,41,
-Riley,W5P7,State House,67,Rep,Tom Phillips,77,
-Riley,W5P8,Registered Voters,,,Registered Voters,663,
-Riley,W5P8,Ballots Cast,,Rep,Ballots Cast,125,
-Riley,W5P8,Ballots Cast,,Dem,Ballots Cast,69,
-Riley,W5P8,US House,1,Dem,Alan LaPolice,65,
-Riley,W5P8,Governor,,Dem,Joshua Svaty,23,
-Riley,W5P8,Governor,,Dem,Arden Andersen,3,
-Riley,W5P8,Governor,,Dem,Jack Bergeson,0,
-Riley,W5P8,Governor,,Dem,Carl Brewer,7,
-Riley,W5P8,Governor,,Dem,Laura Kelly,36,
-Riley,W5P8,Secretary of State,,Dem,Brian McClendon,62,
-Riley,W5P8,Attorney General,,Dem,Sarah Swain,63,
-Riley,W5P8,State Treasurer,,Dem,Marci Francisco,64,
-Riley,W5P8,Insurance Commissioner,,Dem,Nathaniel McLaughlin,59,
-Riley,W5P8,State House,67,Dem,Alex Van Dyke,65,
-Riley,W5P8,US House,1,Rep,Nick Reinecker,21,
-Riley,W5P8,US House,1,Rep,Roger Marshall,100,
-Riley,W5P8,Governor,,Rep,Ken Selzer,16,
-Riley,W5P8,Governor,,Rep,Joseph Tutera,0,
-Riley,W5P8,Governor,,Rep,Jim Barnett,11,
-Riley,W5P8,Governor,,Rep,Jeff Colyer,78,
-Riley,W5P8,Governor,,Rep,Kris Kobach,19,
-Riley,W5P8,Governor,,Rep,Patrick Kucera,0,
-Riley,W5P8,Governor,,Rep,Tyler Ruzich,1,
-Riley,W5P8,Secretary of  State,,Rep,Dennis Taylor,33,
-Riley,W5P8,Secretary of  State,,Rep,Randy Duncan,16,
-Riley,W5P8,Secretary of  State,,Rep,Keith Esau,3,
-Riley,W5P8,Secretary of  State,,Rep,Craig McCullah,23,
-Riley,W5P8,Secretary of  State,,Rep,Scott Schwab,33,
-Riley,W5P8,Attorney General,,Rep,Derek Schmidt,109,
-Riley,W5P8,State Treasurer,,Rep,Jake LaTurner,102,
-Riley,W5P8,Insurance Commissioner,,Rep,Clark Shultz,61,
-Riley,W5P8,Insurance Commissioner,,Rep,Vicki Schmidt,53,
-Riley,W5P8,State House,67,Rep,Tom Phillips,116,
-Riley,W5P9,Registered Voters,,,Registered Voters,1654,
-Riley,W5P9,Ballots Cast,,Rep,Ballots Cast,405,
-Riley,W5P9,Ballots Cast,,Dem,Ballots Cast,169,
-Riley,W5P9,US House,1,Dem,Alan LaPolice,148,
-Riley,W5P9,Governor,,Dem,Joshua Svaty,61,
-Riley,W5P9,Governor,,Dem,Arden Andersen,4,
-Riley,W5P9,Governor,,Dem,Jack Bergeson,1,
-Riley,W5P9,Governor,,Dem,Carl Brewer,10,
-Riley,W5P9,Governor,,Dem,Laura Kelly,93,
-Riley,W5P9,Secretary of State,,Dem,Brian McClendon,152,
-Riley,W5P9,Attorney General,,Dem,Sarah Swain,150,
-Riley,W5P9,State Treasurer,,Dem,Marci Francisco,153,
-Riley,W5P9,Insurance Commissioner,,Dem,Nathaniel McLaughlin,143,
-Riley,W5P9,State House,67,Dem,Alex Van Dyke,153,
-Riley,W5P9,US House,1,Rep,Nick Reinecker,81,
-Riley,W5P9,US House,1,Rep,Roger Marshall,307,
-Riley,W5P9,Governor,,Rep,Ken Selzer,49,
-Riley,W5P9,Governor,,Rep,Joseph Tutera,1,
-Riley,W5P9,Governor,,Rep,Jim Barnett,35,
-Riley,W5P9,Governor,,Rep,Jeff Colyer,215,
-Riley,W5P9,Governor,,Rep,Kris Kobach,101,
-Riley,W5P9,Governor,,Rep,Patrick Kucera,0,
-Riley,W5P9,Governor,,Rep,Tyler Ruzich,2,
-Riley,W5P9,Secretary of  State,,Rep,Dennis Taylor,144,
-Riley,W5P9,Secretary of  State,,Rep,Randy Duncan,73,
-Riley,W5P9,Secretary of  State,,Rep,Keith Esau,23,
-Riley,W5P9,Secretary of  State,,Rep,Craig McCullah,45,
-Riley,W5P9,Secretary of  State,,Rep,Scott Schwab,67,
-Riley,W5P9,Attorney General,,Rep,Derek Schmidt,354,
-Riley,W5P9,State Treasurer,,Rep,Jake LaTurner,328,
-Riley,W5P9,Insurance Commissioner,,Rep,Clark Shultz,139,
-Riley,W5P9,Insurance Commissioner,,Rep,Vicki Schmidt,223,
-Riley,W5P9,State House,67,Rep,Tom Phillips,377,
-Riley,W5P10,Registered Voters,,,Registered Voters,1918,
-Riley,W5P10,Ballots Cast,,Rep,Ballots Cast,376,
-Riley,W5P10,Ballots Cast,,Dem,Ballots Cast,185,
-Riley,W5P10,US House,1,Dem,Alan LaPolice,164,
-Riley,W5P10,Governor,,Dem,Joshua Svaty,86,
-Riley,W5P10,Governor,,Dem,Arden Andersen,0,
-Riley,W5P10,Governor,,Dem,Jack Bergeson,2,
-Riley,W5P10,Governor,,Dem,Carl Brewer,9,
-Riley,W5P10,Governor,,Dem,Laura Kelly,83,
-Riley,W5P10,Secretary of State,,Dem,Brian McClendon,159,
-Riley,W5P10,Attorney General,,Dem,Sarah Swain,161,
-Riley,W5P10,State Treasurer,,Dem,Marci Francisco,157,
-Riley,W5P10,Insurance Commissioner,,Dem,Nathaniel McLaughlin,148,
-Riley,W5P10,State House,67,Dem,Alex Van Dyke,171,
-Riley,W5P10,US House,1,Rep,Nick Reinecker,71,
-Riley,W5P10,US House,1,Rep,Roger Marshall,274,
-Riley,W5P10,Governor,,Rep,Ken Selzer,55,
-Riley,W5P10,Governor,,Rep,Joseph Tutera,0,
-Riley,W5P10,Governor,,Rep,Jim Barnett,25,
-Riley,W5P10,Governor,,Rep,Jeff Colyer,199,
-Riley,W5P10,Governor,,Rep,Kris Kobach,92,
-Riley,W5P10,Governor,,Rep,Patrick Kucera,2,
-Riley,W5P10,Governor,,Rep,Tyler Ruzich,1,
-Riley,W5P10,Secretary of  State,,Rep,Dennis Taylor,128,
-Riley,W5P10,Secretary of  State,,Rep,Randy Duncan,69,
-Riley,W5P10,Secretary of  State,,Rep,Keith Esau,20,
-Riley,W5P10,Secretary of  State,,Rep,Craig McCullah,51,
-Riley,W5P10,Secretary of  State,,Rep,Scott Schwab,46,
-Riley,W5P10,Attorney General,,Rep,Derek Schmidt,319,
-Riley,W5P10,State Treasurer,,Rep,Jake LaTurner,306,
-Riley,W5P10,Insurance Commissioner,,Rep,Clark Shultz,145,
-Riley,W5P10,Insurance Commissioner,,Rep,Vicki Schmidt,193,
-Riley,W5P10,State House,67,Rep,Tom Phillips,340,
-Riley,W5P11,Registered Voters,,,Registered Voters,1937,
-Riley,W5P11,Ballots Cast,,Rep,Ballots Cast,358,
-Riley,W5P11,Ballots Cast,,Dem,Ballots Cast,134,
-Riley,W5P11,US House,1,Dem,Alan LaPolice,120,
-Riley,W5P11,Governor,,Dem,Joshua Svaty,52,
-Riley,W5P11,Governor,,Dem,Arden Andersen,1,
-Riley,W5P11,Governor,,Dem,Jack Bergeson,1,
-Riley,W5P11,Governor,,Dem,Carl Brewer,10,
-Riley,W5P11,Governor,,Dem,Laura Kelly,69,
-Riley,W5P11,Secretary of State,,Dem,Brian McClendon,118,
-Riley,W5P11,Attorney General,,Dem,Sarah Swain,122,
-Riley,W5P11,State Treasurer,,Dem,Marci Francisco,119,
-Riley,W5P11,Insurance Commissioner,,Dem,Nathaniel McLaughlin,113,
-Riley,W5P11,State House,67,Dem,Alex Van Dyke,120,
-Riley,W5P11,US House,1,Rep,Nick Reinecker,68,
-Riley,W5P11,US House,1,Rep,Roger Marshall,269,
-Riley,W5P11,Governor,,Rep,Ken Selzer,44,
-Riley,W5P11,Governor,,Rep,Joseph Tutera,0,
-Riley,W5P11,Governor,,Rep,Jim Barnett,29,
-Riley,W5P11,Governor,,Rep,Jeff Colyer,178,
-Riley,W5P11,Governor,,Rep,Kris Kobach,98,
-Riley,W5P11,Governor,,Rep,Patrick Kucera,4,
-Riley,W5P11,Governor,,Rep,Tyler Ruzich,5,
-Riley,W5P11,Secretary of  State,,Rep,Dennis Taylor,107,
-Riley,W5P11,Secretary of  State,,Rep,Randy Duncan,63,
-Riley,W5P11,Secretary of  State,,Rep,Keith Esau,16,
-Riley,W5P11,Secretary of  State,,Rep,Craig McCullah,69,
-Riley,W5P11,Secretary of  State,,Rep,Scott Schwab,62,
-Riley,W5P11,Attorney General,,Rep,Derek Schmidt,298,
-Riley,W5P11,State Treasurer,,Rep,Jake LaTurner,274,
-Riley,W5P11,Insurance Commissioner,,Rep,Clark Shultz,162,
-Riley,W5P11,Insurance Commissioner,,Rep,Vicki Schmidt,161,
-Riley,W5P11,State House,67,Rep,Tom Phillips,319,
-Riley,W6P1,Registered Voters,,,Registered Voters,50,
-Riley,W6P1,Ballots Cast,,Rep,Ballots Cast,0,
-Riley,W6P1,Ballots Cast,,Dem,Ballots Cast,0,
-Riley,W6P1,US House,1,Dem,Alan LaPolice,0,
-Riley,W6P1,Governor,,Dem,Joshua Svaty,0,
-Riley,W6P1,Governor,,Dem,Arden Andersen,0,
-Riley,W6P1,Governor,,Dem,Jack Bergeson,0,
-Riley,W6P1,Governor,,Dem,Carl Brewer,0,
-Riley,W6P1,Governor,,Dem,Laura Kelly,0,
-Riley,W6P1,Secretary of State,,Dem,Brian McClendon,0,
-Riley,W6P1,Attorney General,,Dem,Sarah Swain,0,
-Riley,W6P1,State Treasurer,,Dem,Marci Francisco,0,
-Riley,W6P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,0,
-Riley,W6P1,State House,64,Dem,Sydney Carlin,0,
-Riley,W6P1,US House,1,Rep,Nick Reinecker,0,
-Riley,W6P1,US House,1,Rep,Roger Marshall,0,
-Riley,W6P1,Governor,,Rep,Ken Selzer,0,
-Riley,W6P1,Governor,,Rep,Joseph Tutera,0,
-Riley,W6P1,Governor,,Rep,Jim Barnett,0,
-Riley,W6P1,Governor,,Rep,Jeff Colyer,0,
-Riley,W6P1,Governor,,Rep,Kris Kobach,0,
-Riley,W6P1,Governor,,Rep,Patrick Kucera,0,
-Riley,W6P1,Governor,,Rep,Tyler Ruzich,0,
-Riley,W6P1,Secretary of  State,,Rep,Dennis Taylor,0,
-Riley,W6P1,Secretary of  State,,Rep,Randy Duncan,0,
-Riley,W6P1,Secretary of  State,,Rep,Keith Esau,0,
-Riley,W6P1,Secretary of  State,,Rep,Craig McCullah,0,
-Riley,W6P1,Secretary of  State,,Rep,Scott Schwab,0,
-Riley,W6P1,Attorney General,,Rep,Derek Schmidt,0,
-Riley,W6P1,State Treasurer,,Rep,Jake LaTurner,0,
-Riley,W6P1,Insurance Commissioner,,Rep,Clark Shultz,0,
-Riley,W6P1,Insurance Commissioner,,Rep,Vicki Schmidt,0,
-Riley,W6P1,State House,64,Rep,Suzi Carlson,0,
-Riley,W6P1,State House,64,Rep,Kathy Martin,0,
-Riley,W8P1,Registered Voters,,,Registered Voters,433,
-Riley,W8P1,Ballots Cast,,Rep,Ballots Cast,26,
-Riley,W8P1,Ballots Cast,,Dem,Ballots Cast,23,
-Riley,W8P1,US House,1,Dem,Alan LaPolice,19,
-Riley,W8P1,Governor,,Dem,Joshua Svaty,9,
-Riley,W8P1,Governor,,Dem,Arden Andersen,0,
-Riley,W8P1,Governor,,Dem,Jack Bergeson,0,
-Riley,W8P1,Governor,,Dem,Carl Brewer,4,
-Riley,W8P1,Governor,,Dem,Laura Kelly,10,
-Riley,W8P1,Secretary of State,,Dem,Brian McClendon,20,
-Riley,W8P1,Attorney General,,Dem,Sarah Swain,20,
-Riley,W8P1,State Treasurer,,Dem,Marci Francisco,20,
-Riley,W8P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,17,
-Riley,W8P1,State House,66,Dem,Sydney Carlin,21,
-Riley,W8P1,US House,1,Rep,Nick Reinecker,10,
-Riley,W8P1,US House,1,Rep,Roger Marshall,15,
-Riley,W8P1,Governor,,Rep,Ken Selzer,6,
-Riley,W8P1,Governor,,Rep,Joseph Tutera,0,
-Riley,W8P1,Governor,,Rep,Jim Barnett,0,
-Riley,W8P1,Governor,,Rep,Jeff Colyer,10,
-Riley,W8P1,Governor,,Rep,Kris Kobach,9,
-Riley,W8P1,Governor,,Rep,Patrick Kucera,0,
-Riley,W8P1,Governor,,Rep,Tyler Ruzich,1,
-Riley,W8P1,Secretary of  State,,Rep,Dennis Taylor,10,
-Riley,W8P1,Secretary of  State,,Rep,Randy Duncan,5,
-Riley,W8P1,Secretary of  State,,Rep,Keith Esau,1,
-Riley,W8P1,Secretary of  State,,Rep,Craig McCullah,6,
-Riley,W8P1,Secretary of  State,,Rep,Scott Schwab,3,
-Riley,W8P1,Attorney General,,Rep,Derek Schmidt,23,
-Riley,W8P1,State Treasurer,,Rep,Jake LaTurner,20,
-Riley,W8P1,Insurance Commissioner,,Rep,Clark Shultz,6,
-Riley,W8P1,Insurance Commissioner,,Rep,Vicki Schmidt,19,
-Riley,W8P1,State House,66,Rep,write-in,1,
-Riley,W8P3,Registered Voters,,,Registered Voters,784,
-Riley,W8P3,Ballots Cast,,Rep,Ballots Cast,39,
-Riley,W8P3,Ballots Cast,,Dem,Ballots Cast,48,
-Riley,W8P3,US House,1,Dem,Alan LaPolice,44,
-Riley,W8P3,Governor,,Dem,Joshua Svaty,18,
-Riley,W8P3,Governor,,Dem,Arden Andersen,1,
-Riley,W8P3,Governor,,Dem,Jack Bergeson,1,
-Riley,W8P3,Governor,,Dem,Carl Brewer,8,
-Riley,W8P3,Governor,,Dem,Laura Kelly,20,
-Riley,W8P3,Secretary of State,,Dem,Brian McClendon,48,
-Riley,W8P3,Attorney General,,Dem,Sarah Swain,47,
-Riley,W8P3,State Treasurer,,Dem,Marci Francisco,46,
-Riley,W8P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,42,
-Riley,W8P3,State House,66,Dem,Sydney Carlin,45,
-Riley,W8P3,US House,1,Rep,Nick Reinecker,13,
-Riley,W8P3,US House,1,Rep,Roger Marshall,21,
-Riley,W8P3,Governor,,Rep,Ken Selzer,5,
-Riley,W8P3,Governor,,Rep,Joseph Tutera,0,
-Riley,W8P3,Governor,,Rep,Jim Barnett,1,
-Riley,W8P3,Governor,,Rep,Jeff Colyer,15,
-Riley,W8P3,Governor,,Rep,Kris Kobach,15,
-Riley,W8P3,Governor,,Rep,Patrick Kucera,0,
-Riley,W8P3,Governor,,Rep,Tyler Ruzich,2,
-Riley,W8P3,Secretary of  State,,Rep,Dennis Taylor,10,
-Riley,W8P3,Secretary of  State,,Rep,Randy Duncan,8,
-Riley,W8P3,Secretary of  State,,Rep,Keith Esau,3,
-Riley,W8P3,Secretary of  State,,Rep,Craig McCullah,2,
-Riley,W8P3,Secretary of  State,,Rep,Scott Schwab,5,
-Riley,W8P3,Attorney General,,Rep,Derek Schmidt,30,
-Riley,W8P3,State Treasurer,,Rep,Jake LaTurner,27,
-Riley,W8P3,Insurance Commissioner,,Rep,Clark Shultz,14,
-Riley,W8P3,Insurance Commissioner,,Rep,Vicki Schmidt,19,
-Riley,W8P3,State House,66,Rep,write-in,1,
-Riley,W9P1,Registered Voters,,,Registered Voters,195,
-Riley,W9P1,Ballots Cast,,Rep,Ballots Cast,40,
-Riley,W9P1,Ballots Cast,,Dem,Ballots Cast,29,
-Riley,W9P1,US House,1,Dem,Alan LaPolice,25,
-Riley,W9P1,Governor,,Dem,Joshua Svaty,8,
-Riley,W9P1,Governor,,Dem,Arden Andersen,1,
-Riley,W9P1,Governor,,Dem,Jack Bergeson,0,
-Riley,W9P1,Governor,,Dem,Carl Brewer,0,
-Riley,W9P1,Governor,,Dem,Laura Kelly,19,
-Riley,W9P1,Secretary of State,,Dem,Brian McClendon,27,
-Riley,W9P1,Attorney General,,Dem,Sarah Swain,27,
-Riley,W9P1,State Treasurer,,Dem,Marci Francisco,27,
-Riley,W9P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,27,
-Riley,W9P1,State House,66,Dem,Sydney Carlin,28,
-Riley,W9P1,US House,1,Rep,Nick Reinecker,10,
-Riley,W9P1,US House,1,Rep,Roger Marshall,27,
-Riley,W9P1,Governor,,Rep,Ken Selzer,5,
-Riley,W9P1,Governor,,Rep,Joseph Tutera,0,
-Riley,W9P1,Governor,,Rep,Jim Barnett,7,
-Riley,W9P1,Governor,,Rep,Jeff Colyer,21,
-Riley,W9P1,Governor,,Rep,Kris Kobach,7,
-Riley,W9P1,Governor,,Rep,Patrick Kucera,0,
-Riley,W9P1,Governor,,Rep,Tyler Ruzich,0,
-Riley,W9P1,Secretary of  State,,Rep,Dennis Taylor,23,
-Riley,W9P1,Secretary of  State,,Rep,Randy Duncan,6,
-Riley,W9P1,Secretary of  State,,Rep,Keith Esau,1,
-Riley,W9P1,Secretary of  State,,Rep,Craig McCullah,2,
-Riley,W9P1,Secretary of  State,,Rep,Scott Schwab,2,
-Riley,W9P1,Attorney General,,Rep,Derek Schmidt,33,
-Riley,W9P1,State Treasurer,,Rep,Jake LaTurner,28,
-Riley,W9P1,Insurance Commissioner,,Rep,Clark Shultz,16,
-Riley,W9P1,Insurance Commissioner,,Rep,Vicki Schmidt,19,
-Riley,W9P1,State House,66,Rep,write-in,0,
-Riley,W9P2,Registered Voters,,,Registered Voters,142,p59
-Riley,W9P2,Ballots Cast,,Rep,Ballots Cast,52,
-Riley,W9P2,Ballots Cast,,Dem,Ballots Cast,23,
-Riley,W9P2,US House,1,Dem,Alan LaPolice,20,
-Riley,W9P2,Governor,,Dem,Joshua Svaty,7,
-Riley,W9P2,Governor,,Dem,Arden Andersen,0,
-Riley,W9P2,Governor,,Dem,Jack Bergeson,1,
-Riley,W9P2,Governor,,Dem,Carl Brewer,4,
-Riley,W9P2,Governor,,Dem,Laura Kelly,11,
-Riley,W9P2,Secretary of State,,Dem,Brian McClendon,19,
-Riley,W9P2,Attorney General,,Dem,Sarah Swain,21,
-Riley,W9P2,State Treasurer,,Dem,Marci Francisco,19,
-Riley,W9P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,18,
-Riley,W9P2,State House,66,Dem,Sydney Carlin,22,
-Riley,W9P2,US House,1,Rep,Nick Reinecker,20,
-Riley,W9P2,US House,1,Rep,Roger Marshall,29,
-Riley,W9P2,Governor,,Rep,Ken Selzer,7,
-Riley,W9P2,Governor,,Rep,Joseph Tutera,0,
-Riley,W9P2,Governor,,Rep,Jim Barnett,1,
-Riley,W9P2,Governor,,Rep,Jeff Colyer,28,
-Riley,W9P2,Governor,,Rep,Kris Kobach,15,
-Riley,W9P2,Governor,,Rep,Patrick Kucera,1,
-Riley,W9P2,Governor,,Rep,Tyler Ruzich,0,
-Riley,W9P2,Secretary of  State,,Rep,Dennis Taylor,16,
-Riley,W9P2,Secretary of  State,,Rep,Randy Duncan,11,
-Riley,W9P2,Secretary of  State,,Rep,Keith Esau,4,
-Riley,W9P2,Secretary of  State,,Rep,Craig McCullah,8,
-Riley,W9P2,Secretary of  State,,Rep,Scott Schwab,10,
-Riley,W9P2,Attorney General,,Rep,Derek Schmidt,41,
-Riley,W9P2,State Treasurer,,Rep,Jake LaTurner,38,
-Riley,W9P2,Insurance Commissioner,,Rep,Clark Shultz,19,
-Riley,W9P2,Insurance Commissioner,,Rep,Vicki Schmidt,30,
-Riley,W9P2,State House,66,Rep,write-in,4,
-Riley,W9P3,Registered Voters,,,Registered Voters,78,
-Riley,W9P3,Ballots Cast,,Rep,Ballots Cast,17,
-Riley,W9P3,Ballots Cast,,Dem,Ballots Cast,7,
-Riley,W9P3,US House,1,Dem,Alan LaPolice,6,
-Riley,W9P3,Governor,,Dem,Joshua Svaty,5,
-Riley,W9P3,Governor,,Dem,Arden Andersen,0,
-Riley,W9P3,Governor,,Dem,Jack Bergeson,0,
-Riley,W9P3,Governor,,Dem,Carl Brewer,0,
-Riley,W9P3,Governor,,Dem,Laura Kelly,2,
-Riley,W9P3,Secretary of State,,Dem,Brian McClendon,7,
-Riley,W9P3,Attorney General,,Dem,Sarah Swain,7,
-Riley,W9P3,State Treasurer,,Dem,Marci Francisco,7,
-Riley,W9P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,6,
-Riley,W9P3,State House,67,Dem,Alex Van Dyke,6,
-Riley,W9P3,US House,1,Rep,Nick Reinecker,2,
-Riley,W9P3,US House,1,Rep,Roger Marshall,15,
-Riley,W9P3,Governor,,Rep,Ken Selzer,1,
-Riley,W9P3,Governor,,Rep,Joseph Tutera,0,
-Riley,W9P3,Governor,,Rep,Jim Barnett,2,
-Riley,W9P3,Governor,,Rep,Jeff Colyer,9,
-Riley,W9P3,Governor,,Rep,Kris Kobach,5,
-Riley,W9P3,Governor,,Rep,Patrick Kucera,0,
-Riley,W9P3,Governor,,Rep,Tyler Ruzich,0,
-Riley,W9P3,Secretary of  State,,Rep,Dennis Taylor,3,
-Riley,W9P3,Secretary of  State,,Rep,Randy Duncan,5,
-Riley,W9P3,Secretary of  State,,Rep,Keith Esau,1,
-Riley,W9P3,Secretary of  State,,Rep,Craig McCullah,1,
-Riley,W9P3,Secretary of  State,,Rep,Scott Schwab,6,
-Riley,W9P3,Attorney General,,Rep,Derek Schmidt,17,
-Riley,W9P3,State Treasurer,,Rep,Jake LaTurner,14,
-Riley,W9P3,Insurance Commissioner,,Rep,Clark Shultz,10,
-Riley,W9P3,Insurance Commissioner,,Rep,Vicki Schmidt,6,
-Riley,W9P3,State House,67,Rep,Tom Phillips,16,
-Riley,W10P1,Registered Voters,,,Registered Voters,204,
-Riley,W10P1,Ballots Cast,,Rep,Ballots Cast,37,
-Riley,W10P1,Ballots Cast,,Dem,Ballots Cast,12,
-Riley,W10P1,US House,1,Dem,Alan LaPolice,12,
-Riley,W10P1,Governor,,Dem,Joshua Svaty,4,
-Riley,W10P1,Governor,,Dem,Arden Andersen,0,
-Riley,W10P1,Governor,,Dem,Jack Bergeson,0,
-Riley,W10P1,Governor,,Dem,Carl Brewer,0,
-Riley,W10P1,Governor,,Dem,Laura Kelly,8,
-Riley,W10P1,Secretary of State,,Dem,Brian McClendon,11,
-Riley,W10P1,Attorney General,,Dem,Sarah Swain,12,
-Riley,W10P1,State Treasurer,,Dem,Marci Francisco,11,
-Riley,W10P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,11,
-Riley,W10P1,State House,67,Dem,Alex Van Dyke,12,
-Riley,W10P1,US House,1,Rep,Nick Reinecker,6,
-Riley,W10P1,US House,1,Rep,Roger Marshall,28,
-Riley,W10P1,Governor,,Rep,Ken Selzer,7,
-Riley,W10P1,Governor,,Rep,Joseph Tutera,0,
-Riley,W10P1,Governor,,Rep,Jim Barnett,3,
-Riley,W10P1,Governor,,Rep,Jeff Colyer,14,
-Riley,W10P1,Governor,,Rep,Kris Kobach,11,
-Riley,W10P1,Governor,,Rep,Patrick Kucera,1,
-Riley,W10P1,Governor,,Rep,Tyler Ruzich,1,
-Riley,W10P1,Secretary of  State,,Rep,Dennis Taylor,17,
-Riley,W10P1,Secretary of  State,,Rep,Randy Duncan,7,
-Riley,W10P1,Secretary of  State,,Rep,Keith Esau,3,
-Riley,W10P1,Secretary of  State,,Rep,Craig McCullah,4,
-Riley,W10P1,Secretary of  State,,Rep,Scott Schwab,4,
-Riley,W10P1,Attorney General,,Rep,Derek Schmidt,33,
-Riley,W10P1,State Treasurer,,Rep,Jake LaTurner,33,
-Riley,W10P1,Insurance Commissioner,,Rep,Clark Shultz,10,
-Riley,W10P1,Insurance Commissioner,,Rep,Vicki Schmidt,24,
-Riley,W10P1,State House,67,Rep,Tom Phillips,35,
-Riley,W11P1,Registered Voters,,,Registered Voters,629,
-Riley,W11P1,Ballots Cast,,Rep,Ballots Cast,30,
-Riley,W11P1,Ballots Cast,,Dem,Ballots Cast,26,
-Riley,W11P1,US House,1,Dem,Alan LaPolice,25,
-Riley,W11P1,Governor,,Dem,Joshua Svaty,10,
-Riley,W11P1,Governor,,Dem,Arden Andersen,0,
-Riley,W11P1,Governor,,Dem,Jack Bergeson,0,
-Riley,W11P1,Governor,,Dem,Carl Brewer,3,
-Riley,W11P1,Governor,,Dem,Laura Kelly,13,
-Riley,W11P1,Secretary of State,,Dem,Brian McClendon,25,
-Riley,W11P1,Attorney General,,Dem,Sarah Swain,24,
-Riley,W11P1,State Treasurer,,Dem,Marci Francisco,24,
-Riley,W11P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,23,
-Riley,W11P1,State House,67,Dem,Alex Van Dyke,24,
-Riley,W11P1,US House,1,Rep,Nick Reinecker,9,
-Riley,W11P1,US House,1,Rep,Roger Marshall,19,
-Riley,W11P1,Governor,,Rep,Ken Selzer,5,
-Riley,W11P1,Governor,,Rep,Joseph Tutera,0,
-Riley,W11P1,Governor,,Rep,Jim Barnett,1,
-Riley,W11P1,Governor,,Rep,Jeff Colyer,13,
-Riley,W11P1,Governor,,Rep,Kris Kobach,11,
-Riley,W11P1,Governor,,Rep,Patrick Kucera,0,
-Riley,W11P1,Governor,,Rep,Tyler Ruzich,0,
-Riley,W11P1,Secretary of  State,,Rep,Dennis Taylor,10,
-Riley,W11P1,Secretary of  State,,Rep,Randy Duncan,6,
-Riley,W11P1,Secretary of  State,,Rep,Keith Esau,1,
-Riley,W11P1,Secretary of  State,,Rep,Craig McCullah,2,
-Riley,W11P1,Secretary of  State,,Rep,Scott Schwab,7,
-Riley,W11P1,Attorney General,,Rep,Derek Schmidt,27,
-Riley,W11P1,State Treasurer,,Rep,Jake LaTurner,25,
-Riley,W11P1,Insurance Commissioner,,Rep,Clark Shultz,19,
-Riley,W11P1,Insurance Commissioner,,Rep,Vicki Schmidt,8,
-Riley,W11P1,State House,67,Rep,Tom Phillips,28,
-Riley,W11P1B,Registered Voters,,,Registered Voters,386,
-Riley,W11P1B,Ballots Cast,,Rep,Ballots Cast,33,
-Riley,W11P1B,Ballots Cast,,Dem,Ballots Cast,19,
-Riley,W11P1B,US House,1,Dem,Alan LaPolice,15,
-Riley,W11P1B,Governor,,Dem,Joshua Svaty,8,
-Riley,W11P1B,Governor,,Dem,Arden Andersen,2,
-Riley,W11P1B,Governor,,Dem,Jack Bergeson,2,
-Riley,W11P1B,Governor,,Dem,Carl Brewer,1,
-Riley,W11P1B,Governor,,Dem,Laura Kelly,5,
-Riley,W11P1B,Secretary of State,,Dem,Brian McClendon,16,
-Riley,W11P1B,Attorney General,,Dem,Sarah Swain,17,
-Riley,W11P1B,State Treasurer,,Dem,Marci Francisco,15,
-Riley,W11P1B,Insurance Commissioner,,Dem,Nathaniel McLaughlin,16,
-Riley,W11P1B,State House,67,Dem,Tom Phillips,16,
-Riley,W11P1B,US House,1,Rep,Nick Reinecker,9,
-Riley,W11P1B,US House,1,Rep,Roger Marshall,24,
-Riley,W11P1B,Governor,,Rep,Ken Selzer,1,
-Riley,W11P1B,Governor,,Rep,Joseph Tutera,0,
-Riley,W11P1B,Governor,,Rep,Jim Barnett,3,
-Riley,W11P1B,Governor,,Rep,Jeff Colyer,16,
-Riley,W11P1B,Governor,,Rep,Kris Kobach,13,
-Riley,W11P1B,Governor,,Rep,Patrick Kucera,0,
-Riley,W11P1B,Governor,,Rep,Tyler Ruzich,0,
-Riley,W11P1B,Secretary of  State,,Rep,Dennis Taylor,11,
-Riley,W11P1B,Secretary of  State,,Rep,Randy Duncan,5,
-Riley,W11P1B,Secretary of  State,,Rep,Keith Esau,1,
-Riley,W11P1B,Secretary of  State,,Rep,Craig McCullah,8,
-Riley,W11P1B,Secretary of  State,,Rep,Scott Schwab,7,
-Riley,W11P1B,Attorney General,,Rep,Derek Schmidt,29,
-Riley,W11P1B,State Treasurer,,Rep,Jake LaTurner,30,
-Riley,W11P1B,Insurance Commissioner,,Rep,Clark Shultz,13,
-Riley,W11P1B,Insurance Commissioner,,Rep,Vicki Schmidt,19,
-Riley,W11P1B,State House,67,Rep,Tom Phillips,32,
-Riley,W11P3,Registered Voters,,,Registered Voters,96,
-Riley,W11P3,Ballots Cast,,Rep,Ballots Cast,8,
-Riley,W11P3,Ballots Cast,,Dem,Ballots Cast,3,
-Riley,W11P3,US House,1,Dem,Alan LaPolice,3,
-Riley,W11P3,Governor,,Dem,Joshua Svaty,0,
-Riley,W11P3,Governor,,Dem,Arden Andersen,0,
-Riley,W11P3,Governor,,Dem,Jack Bergeson,0,
-Riley,W11P3,Governor,,Dem,Carl Brewer,0,
-Riley,W11P3,Governor,,Dem,Laura Kelly,3,
-Riley,W11P3,Secretary of State,,Dem,Brian McClendon,3,
-Riley,W11P3,Attorney General,,Dem,Sarah Swain,3,
-Riley,W11P3,State Treasurer,,Dem,Marci Francisco,3,
-Riley,W11P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,3,
-Riley,W11P3,State House,67,Dem,Alex Van Dyke,3,
-Riley,W11P3,US House,1,Rep,Nick Reinecker,2,
-Riley,W11P3,US House,1,Rep,Roger Marshall,5,
-Riley,W11P3,Governor,,Rep,Ken Selzer,3,
-Riley,W11P3,Governor,,Rep,Joseph Tutera,0,
-Riley,W11P3,Governor,,Rep,Jim Barnett,0,
-Riley,W11P3,Governor,,Rep,Jeff Colyer,1,
-Riley,W11P3,Governor,,Rep,Kris Kobach,4,
-Riley,W11P3,Governor,,Rep,Patrick Kucera,0,
-Riley,W11P3,Governor,,Rep,Tyler Ruzich,0,
-Riley,W11P3,Secretary of  State,,Rep,Dennis Taylor,0,
-Riley,W11P3,Secretary of  State,,Rep,Randy Duncan,5,
-Riley,W11P3,Secretary of  State,,Rep,Keith Esau,1,
-Riley,W11P3,Secretary of  State,,Rep,Craig McCullah,0,
-Riley,W11P3,Secretary of  State,,Rep,Scott Schwab,1,
-Riley,W11P3,Attorney General,,Rep,Derek Schmidt,7,
-Riley,W11P3,State Treasurer,,Rep,Jake LaTurner,6,
-Riley,W11P3,Insurance Commissioner,,Rep,Clark Shultz,6,
-Riley,W11P3,Insurance Commissioner,,Rep,Vicki Schmidt,2,
-Riley,W11P3,State House,67,Rep,Tom Phillips,7,
-Riley,Ashland twp,Registered Voters,,,Registered Voters,115,p74
-Riley,Ashland twp,Ballots Cast,,Rep,Ballots Cast,39,
-Riley,Ashland twp,Ballots Cast,,Dem,Ballots Cast,14,
-Riley,Ashland twp,US House,1,Dem,Alan LaPolice,13,
-Riley,Ashland twp,Governor,,Dem,Joshua Svaty,7,
-Riley,Ashland twp,Governor,,Dem,Arden Andersen,0,
-Riley,Ashland twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Ashland twp,Governor,,Dem,Carl Brewer,0,
-Riley,Ashland twp,Governor,,Dem,Laura Kelly,7,
-Riley,Ashland twp,Secretary of State,,Dem,Brian McClendon,12,
-Riley,Ashland twp,Attorney General,,Dem,Sarah Swain,13,
-Riley,Ashland twp,State Treasurer,,Dem,Marci Francisco,12,
-Riley,Ashland twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,11,
-Riley,Ashland twp,State House,67,Dem,Alex Van Dyke,13,
-Riley,Ashland twp,US House,1,Rep,Nick Reinecker,5,
-Riley,Ashland twp,US House,1,Rep,Roger Marshall,31,
-Riley,Ashland twp,Governor,,Rep,Ken Selzer,4,
-Riley,Ashland twp,Governor,,Rep,Joseph Tutera,0,
-Riley,Ashland twp,Governor,,Rep,Jim Barnett,0,
-Riley,Ashland twp,Governor,,Rep,Jeff Colyer,18,
-Riley,Ashland twp,Governor,,Rep,Kris Kobach,16,
-Riley,Ashland twp,Governor,,Rep,Patrick Kucera,0,
-Riley,Ashland twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,Ashland twp,Secretary of  State,,Rep,Dennis Taylor,10,
-Riley,Ashland twp,Secretary of  State,,Rep,Randy Duncan,7,
-Riley,Ashland twp,Secretary of  State,,Rep,Keith Esau,2,
-Riley,Ashland twp,Secretary of  State,,Rep,Craig McCullah,7,
-Riley,Ashland twp,Secretary of  State,,Rep,Scott Schwab,8,
-Riley,Ashland twp,Attorney General,,Rep,Derek Schmidt,33,
-Riley,Ashland twp,State Treasurer,,Rep,Jake LaTurner,30,
-Riley,Ashland twp,Insurance Commissioner,,Rep,Clark Shultz,24,
-Riley,Ashland twp,Insurance Commissioner,,Rep,Vicki Schmidt,11,
-Riley,Ashland twp,State House,67,Rep,Tom Phillips,31,
-Riley,Bala twp,Registered Voters,,,Registered Voters,438,
-Riley,Bala twp,Ballots Cast,,Rep,Ballots Cast,134,
-Riley,Bala twp,Ballots Cast,,Dem,Ballots Cast,24,
-Riley,Bala twp,US House,1,Dem,Alan LaPolice,22,
-Riley,Bala twp,Governor,,Dem,Joshua Svaty,9,
-Riley,Bala twp,Governor,,Dem,Arden Andersen,1,
-Riley,Bala twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Bala twp,Governor,,Dem,Carl Brewer,2,
-Riley,Bala twp,Governor,,Dem,Laura Kelly,12,
-Riley,Bala twp,Secretary of State,,Dem,Brian McClendon,22,
-Riley,Bala twp,Attorney General,,Dem,Sarah Swain,24,
-Riley,Bala twp,State Treasurer,,Dem,Marci Francisco,22,
-Riley,Bala twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,23,
-Riley,Bala twp,State House,64,Dem,write-in,0,
-Riley,Bala twp,US House,1,Rep,Nick Reinecker,19,
-Riley,Bala twp,US House,1,Rep,Roger Marshall,112,
-Riley,Bala twp,Governor,,Rep,Ken Selzer,7,
-Riley,Bala twp,Governor,,Rep,Joseph Tutera,0,
-Riley,Bala twp,Governor,,Rep,Jim Barnett,7,
-Riley,Bala twp,Governor,,Rep,Jeff Colyer,57,
-Riley,Bala twp,Governor,,Rep,Kris Kobach,62,
-Riley,Bala twp,Governor,,Rep,Patrick Kucera,0,
-Riley,Bala twp,Governor,,Rep,Tyler Ruzich,1,
-Riley,Bala twp,Secretary of  State,,Rep,Dennis Taylor,48,
-Riley,Bala twp,Secretary of  State,,Rep,Randy Duncan,39,
-Riley,Bala twp,Secretary of  State,,Rep,Keith Esau,1,
-Riley,Bala twp,Secretary of  State,,Rep,Craig McCullah,21,
-Riley,Bala twp,Secretary of  State,,Rep,Scott Schwab,22,
-Riley,Bala twp,Attorney General,,Rep,Derek Schmidt,119,
-Riley,Bala twp,State Treasurer,,Rep,Jake LaTurner,114,
-Riley,Bala twp,Insurance Commissioner,,Rep,Clark Shultz,66,
-Riley,Bala twp,Insurance Commissioner,,Rep,Vicki Schmidt,62,
-Riley,Bala twp,State House,64,Rep,Suzi Carlson,43,
-Riley,Bala twp,State House,64,Rep,Kathy Martin,91,
-Riley,Center twp,Registered Voters,,,Registered Voters,47,
-Riley,Center twp,Ballots Cast,,Rep,Ballots Cast,15,
-Riley,Center twp,Ballots Cast,,Dem,Ballots Cast,3,
-Riley,Center twp,US House,1,Dem,Alan LaPolice,2,
-Riley,Center twp,Governor,,Dem,Joshua Svaty,3,
-Riley,Center twp,Governor,,Dem,Arden Andersen,0,
-Riley,Center twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Center twp,Governor,,Dem,Carl Brewer,0,
-Riley,Center twp,Governor,,Dem,Laura Kelly,0,
-Riley,Center twp,Secretary of State,,Dem,Brian McClendon,1,
-Riley,Center twp,Attorney General,,Dem,Sarah Swain,1,
-Riley,Center twp,State Treasurer,,Dem,Marci Francisco,2,
-Riley,Center twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,2,
-Riley,Center twp,State House,64,Dem,write-in,0,
-Riley,Center twp,US House,1,Rep,Nick Reinecker,2,
-Riley,Center twp,US House,1,Rep,Roger Marshall,13,
-Riley,Center twp,Governor,,Rep,Ken Selzer,1,
-Riley,Center twp,Governor,,Rep,Joseph Tutera,0,
-Riley,Center twp,Governor,,Rep,Jim Barnett,0,
-Riley,Center twp,Governor,,Rep,Jeff Colyer,6,
-Riley,Center twp,Governor,,Rep,Kris Kobach,6,
-Riley,Center twp,Governor,,Rep,Patrick Kucera,0,
-Riley,Center twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,Center twp,Secretary of  State,,Rep,Dennis Taylor,7,
-Riley,Center twp,Secretary of  State,,Rep,Randy Duncan,4,
-Riley,Center twp,Secretary of  State,,Rep,Keith Esau,0,
-Riley,Center twp,Secretary of  State,,Rep,Craig McCullah,0,
-Riley,Center twp,Secretary of  State,,Rep,Scott Schwab,2,
-Riley,Center twp,Attorney General,,Rep,Derek Schmidt,13,
-Riley,Center twp,State Treasurer,,Rep,Jake LaTurner,12,
-Riley,Center twp,Insurance Commissioner,,Rep,Clark Shultz,8,
-Riley,Center twp,Insurance Commissioner,,Rep,Vicki Schmidt,4,
-Riley,Center twp,State House,64,Rep,Suzi Carlson,6,
-Riley,Center twp,State House,64,Rep,Kathy Martin,7,
-Riley,Fancy Creek twp,Registered Voters,,,Registered Voters,70,
-Riley,Fancy Creek twp,Ballots Cast,,Rep,Ballots Cast,36,
-Riley,Fancy Creek twp,Ballots Cast,,Dem,Ballots Cast,1,
-Riley,Fancy Creek twp,US House,1,Dem,Alan LaPolice,1,
-Riley,Fancy Creek twp,Governor,,Dem,Joshua Svaty,0,
-Riley,Fancy Creek twp,Governor,,Dem,Arden Andersen,0,
-Riley,Fancy Creek twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Fancy Creek twp,Governor,,Dem,Carl Brewer,0,
-Riley,Fancy Creek twp,Governor,,Dem,Laura Kelly,1,
-Riley,Fancy Creek twp,Secretary of State,,Dem,Brian McClendon,1,
-Riley,Fancy Creek twp,Attorney General,,Dem,Sarah Swain,1,
-Riley,Fancy Creek twp,State Treasurer,,Dem,Marci Francisco,1,
-Riley,Fancy Creek twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,1,
-Riley,Fancy Creek twp,State House,64,Dem,write-in,0,
-Riley,Fancy Creek twp,US House,1,Rep,Nick Reinecker,10,
-Riley,Fancy Creek twp,US House,1,Rep,Roger Marshall,24,
-Riley,Fancy Creek twp,Governor,,Rep,Ken Selzer,8,
-Riley,Fancy Creek twp,Governor,,Rep,Joseph Tutera,0,
-Riley,Fancy Creek twp,Governor,,Rep,Jim Barnett,1,
-Riley,Fancy Creek twp,Governor,,Rep,Jeff Colyer,8,
-Riley,Fancy Creek twp,Governor,,Rep,Kris Kobach,19,
-Riley,Fancy Creek twp,Governor,,Rep,Patrick Kucera,0,
-Riley,Fancy Creek twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,Fancy Creek twp,Secretary of  State,,Rep,Dennis Taylor,11,
-Riley,Fancy Creek twp,Secretary of  State,,Rep,Randy Duncan,5,
-Riley,Fancy Creek twp,Secretary of  State,,Rep,Keith Esau,1,
-Riley,Fancy Creek twp,Secretary of  State,,Rep,Craig McCullah,5,
-Riley,Fancy Creek twp,Secretary of  State,,Rep,Scott Schwab,11,
-Riley,Fancy Creek twp,Attorney General,,Rep,Derek Schmidt,30,
-Riley,Fancy Creek twp,State Treasurer,,Rep,Jake LaTurner,29,
-Riley,Fancy Creek twp,Insurance Commissioner,,Rep,Clark Shultz,25,
-Riley,Fancy Creek twp,Insurance Commissioner,,Rep,Vicki Schmidt,9,
-Riley,Fancy Creek twp,State House,64,Rep,Suzi Carlson,7,
-Riley,Fancy Creek twp,State House,64,Rep,Kathy Martin,26,
-Riley,Grant twp,Registered Voters,,,Registered Voters,761,
-Riley,Grant twp,Ballots Cast,,Rep,Ballots Cast,214,
-Riley,Grant twp,Ballots Cast,,Dem,Ballots Cast,59,
-Riley,Grant twp,US House,1,Dem,Alan LaPolice,47,
-Riley,Grant twp,Governor,,Dem,Joshua Svaty,15,
-Riley,Grant twp,Governor,,Dem,Arden Andersen,0,
-Riley,Grant twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Grant twp,Governor,,Dem,Carl Brewer,7,
-Riley,Grant twp,Governor,,Dem,Laura Kelly,37,
-Riley,Grant twp,Secretary of State,,Dem,Brian McClendon,50,
-Riley,Grant twp,Attorney General,,Dem,Sarah Swain,51,
-Riley,Grant twp,State Treasurer,,Dem,Marci Francisco,51,
-Riley,Grant twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,50,
-Riley,Grant twp,State House,67,Dem,Alex Van Dyke,53,
-Riley,Grant twp,US House,1,Rep,Nick Reinecker,52,
-Riley,Grant twp,US House,1,Rep,Roger Marshall,156,
-Riley,Grant twp,Governor,,Rep,Ken Selzer,40,
-Riley,Grant twp,Governor,,Rep,Joseph Tutera,1,
-Riley,Grant twp,Governor,,Rep,Jim Barnett,9,
-Riley,Grant twp,Governor,,Rep,Jeff Colyer,83,
-Riley,Grant twp,Governor,,Rep,Kris Kobach,78,
-Riley,Grant twp,Governor,,Rep,Patrick Kucera,3,
-Riley,Grant twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,Grant twp,Secretary of  State,,Rep,Dennis Taylor,69,
-Riley,Grant twp,Secretary of  State,,Rep,Randy Duncan,37,
-Riley,Grant twp,Secretary of  State,,Rep,Keith Esau,13,
-Riley,Grant twp,Secretary of  State,,Rep,Craig McCullah,36,
-Riley,Grant twp,Secretary of  State,,Rep,Scott Schwab,46,
-Riley,Grant twp,Attorney General,,Rep,Derek Schmidt,192,
-Riley,Grant twp,State Treasurer,,Rep,Jake LaTurner,181,
-Riley,Grant twp,Insurance Commissioner,,Rep,Clark Shultz,109,
-Riley,Grant twp,Insurance Commissioner,,Rep,Vicki Schmidt,94,
-Riley,Grant twp,State House,67,Rep,Tom Phillips,189,
-Riley,Jackson twp,Registered Voters,,,Registered Voters,221,
-Riley,Jackson twp,Ballots Cast,,Rep,Ballots Cast,69,
-Riley,Jackson twp,Ballots Cast,,Dem,Ballots Cast,12,
-Riley,Jackson twp,US House,1,Dem,Alan LaPolice,10,
-Riley,Jackson twp,Governor,,Dem,Joshua Svaty,6,
-Riley,Jackson twp,Governor,,Dem,Arden Andersen,0,
-Riley,Jackson twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Jackson twp,Governor,,Dem,Carl Brewer,0,
-Riley,Jackson twp,Governor,,Dem,Laura Kelly,5,
-Riley,Jackson twp,Secretary of State,,Dem,Brian McClendon,11,
-Riley,Jackson twp,Attorney General,,Dem,Sarah Swain,11,
-Riley,Jackson twp,State Treasurer,,Dem,Marci Francisco,11,
-Riley,Jackson twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,8,
-Riley,Jackson twp,State House,64,Dem,write-in,1,
-Riley,Jackson twp,US House,1,Rep,Nick Reinecker,9,
-Riley,Jackson twp,US House,1,Rep,Roger Marshall,53,
-Riley,Jackson twp,Governor,,Rep,Ken Selzer,15,
-Riley,Jackson twp,Governor,,Rep,Joseph Tutera,0,
-Riley,Jackson twp,Governor,,Rep,Jim Barnett,4,
-Riley,Jackson twp,Governor,,Rep,Jeff Colyer,26,
-Riley,Jackson twp,Governor,,Rep,Kris Kobach,23,
-Riley,Jackson twp,Governor,,Rep,Patrick Kucera,1,
-Riley,Jackson twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,Jackson twp,Secretary of  State,,Rep,Dennis Taylor,24,
-Riley,Jackson twp,Secretary of  State,,Rep,Randy Duncan,16,
-Riley,Jackson twp,Secretary of  State,,Rep,Keith Esau,0,
-Riley,Jackson twp,Secretary of  State,,Rep,Craig McCullah,6,
-Riley,Jackson twp,Secretary of  State,,Rep,Scott Schwab,13,
-Riley,Jackson twp,Attorney General,,Rep,Derek Schmidt,57,
-Riley,Jackson twp,State Treasurer,,Rep,Jake LaTurner,56,
-Riley,Jackson twp,Insurance Commissioner,,Rep,Clark Shultz,35,
-Riley,Jackson twp,Insurance Commissioner,,Rep,Vicki Schmidt,25,
-Riley,Jackson twp,State House,64,Rep,Suzi Carlson,42,
-Riley,Jackson twp,State House,64,Rep,Kathy Martin,20,
-Riley,Madison twp H64,Registered Voters,,,Registered Voters,746,
-Riley,Madison twp H64,Ballots Cast,,Rep,Ballots Cast,180,
-Riley,Madison twp H64,Ballots Cast,,Dem,Ballots Cast,39,
-Riley,Madison twp H64,US House,1,Dem,Alan LaPolice,34,
-Riley,Madison twp H64,Governor,,Dem,Joshua Svaty,11,
-Riley,Madison twp H64,Governor,,Dem,Arden Andersen,1,
-Riley,Madison twp H64,Governor,,Dem,Jack Bergeson,1,
-Riley,Madison twp H64,Governor,,Dem,Carl Brewer,2,
-Riley,Madison twp H64,Governor,,Dem,Laura Kelly,21,
-Riley,Madison twp H64,Secretary of State,,Dem,Brian McClendon,32,
-Riley,Madison twp H64,Attorney General,,Dem,Sarah Swain,34,
-Riley,Madison twp H64,State Treasurer,,Dem,Marci Francisco,33,
-Riley,Madison twp H64,Insurance Commissioner,,Dem,Nathaniel McLaughlin,33,
-Riley,Madison twp H64,State House,64,Dem,write-in,1,
-Riley,Madison twp H64,US House,1,Rep,Nick Reinecker,46,
-Riley,Madison twp H64,US House,1,Rep,Roger Marshall,127,
-Riley,Madison twp H64,Governor,,Rep,Ken Selzer,17,
-Riley,Madison twp H64,Governor,,Rep,Joseph Tutera,0,
-Riley,Madison twp H64,Governor,,Rep,Jim Barnett,15,
-Riley,Madison twp H64,Governor,,Rep,Jeff Colyer,78,
-Riley,Madison twp H64,Governor,,Rep,Kris Kobach,70,
-Riley,Madison twp H64,Governor,,Rep,Patrick Kucera,0,
-Riley,Madison twp H64,Governor,,Rep,Tyler Ruzich,0,
-Riley,Madison twp H64,Secretary of  State,,Rep,Dennis Taylor,63,
-Riley,Madison twp H64,Secretary of  State,,Rep,Randy Duncan,43,
-Riley,Madison twp H64,Secretary of  State,,Rep,Keith Esau,9,
-Riley,Madison twp H64,Secretary of  State,,Rep,Craig McCullah,22,
-Riley,Madison twp H64,Secretary of  State,,Rep,Scott Schwab,26,
-Riley,Madison twp H64,Attorney General,,Rep,Derek Schmidt,163,
-Riley,Madison twp H64,State Treasurer,,Rep,Jake LaTurner,155,
-Riley,Madison twp H64,Insurance Commissioner,,Rep,Clark Shultz,79,
-Riley,Madison twp H64,Insurance Commissioner,,Rep,Vicki Schmidt,91,
-Riley,Madison twp H64,State House,64,Rep,Suzi Carlson,98,
-Riley,Madison twp H64,State House,64,Rep,Kathy Martin,77,
-Riley,Madison twp H67,Registered Voters,,,Registered Voters,23,
-Riley,Madison twp H67,Ballots Cast,,Rep,Ballots Cast,8,
-Riley,Madison twp H67,Ballots Cast,,Dem,Ballots Cast,0,
-Riley,Madison twp H67,US House,1,Dem,Alan LaPolice,0,
-Riley,Madison twp H67,Governor,,Dem,Joshua Svaty,0,
-Riley,Madison twp H67,Governor,,Dem,Arden Andersen,0,
-Riley,Madison twp H67,Governor,,Dem,Jack Bergeson,0,
-Riley,Madison twp H67,Governor,,Dem,Carl Brewer,0,
-Riley,Madison twp H67,Governor,,Dem,Laura Kelly,0,
-Riley,Madison twp H67,Secretary of State,,Dem,Brian McClendon,0,
-Riley,Madison twp H67,Attorney General,,Dem,Sarah Swain,0,
-Riley,Madison twp H67,State Treasurer,,Dem,Marci Francisco,0,
-Riley,Madison twp H67,Insurance Commissioner,,Dem,Nathaniel McLaughlin,0,
-Riley,Madison twp H67,State House,67,Dem,Alex Van Dyke,0,
-Riley,Madison twp H67,US House,1,Rep,Nick Reinecker,2,
-Riley,Madison twp H67,US House,1,Rep,Roger Marshall,5,
-Riley,Madison twp H67,Governor,,Rep,Ken Selzer,1,
-Riley,Madison twp H67,Governor,,Rep,Joseph Tutera,0,
-Riley,Madison twp H67,Governor,,Rep,Jim Barnett,0,
-Riley,Madison twp H67,Governor,,Rep,Jeff Colyer,5,
-Riley,Madison twp H67,Governor,,Rep,Kris Kobach,2,
-Riley,Madison twp H67,Governor,,Rep,Patrick Kucera,0,
-Riley,Madison twp H67,Governor,,Rep,Tyler Ruzich,0,
-Riley,Madison twp H67,Secretary of  State,,Rep,Dennis Taylor,4,
-Riley,Madison twp H67,Secretary of  State,,Rep,Randy Duncan,1,
-Riley,Madison twp H67,Secretary of  State,,Rep,Keith Esau,0,
-Riley,Madison twp H67,Secretary of  State,,Rep,Craig McCullah,0,
-Riley,Madison twp H67,Secretary of  State,,Rep,Scott Schwab,1,
-Riley,Madison twp H67,Attorney General,,Rep,Derek Schmidt,7,
-Riley,Madison twp H67,State Treasurer,,Rep,Jake LaTurner,5,
-Riley,Madison twp H67,Insurance Commissioner,,Rep,Clark Shultz,4,
-Riley,Madison twp H67,Insurance Commissioner,,Rep,Vicki Schmidt,3,
-Riley,Madison twp H67,State House,67,Rep,Tom Phillips,8,
-Riley,Manhattan twp 1,Registered Voters,,,Registered Voters,376,
-Riley,Manhattan twp 1,Ballots Cast,,Rep,Ballots Cast,102,
-Riley,Manhattan twp 1,Ballots Cast,,Dem,Ballots Cast,28,
-Riley,Manhattan twp 1,US House,1,Dem,Alan LaPolice,27,
-Riley,Manhattan twp 1,Governor,,Dem,Joshua Svaty,12,
-Riley,Manhattan twp 1,Governor,,Dem,Arden Andersen,0,
-Riley,Manhattan twp 1,Governor,,Dem,Jack Bergeson,0,
-Riley,Manhattan twp 1,Governor,,Dem,Carl Brewer,1,
-Riley,Manhattan twp 1,Governor,,Dem,Laura Kelly,15,
-Riley,Manhattan twp 1,Secretary of State,,Dem,Brian McClendon,26,
-Riley,Manhattan twp 1,Attorney General,,Dem,Sarah Swain,26,
-Riley,Manhattan twp 1,State Treasurer,,Dem,Marci Francisco,26,
-Riley,Manhattan twp 1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,24,
-Riley,Manhattan twp 1,State House,66,Dem,Sydney Carlin,28,
-Riley,Manhattan twp 1,US House,1,Rep,Nick Reinecker,19,
-Riley,Manhattan twp 1,US House,1,Rep,Roger Marshall,81,
-Riley,Manhattan twp 1,Governor,,Rep,Ken Selzer,12,
-Riley,Manhattan twp 1,Governor,,Rep,Joseph Tutera,1,
-Riley,Manhattan twp 1,Governor,,Rep,Jim Barnett,13,
-Riley,Manhattan twp 1,Governor,,Rep,Jeff Colyer,40,
-Riley,Manhattan twp 1,Governor,,Rep,Kris Kobach,33,
-Riley,Manhattan twp 1,Governor,,Rep,Patrick Kucera,1,
-Riley,Manhattan twp 1,Governor,,Rep,Tyler Ruzich,1,
-Riley,Manhattan twp 1,Secretary of  State,,Rep,Dennis Taylor,34,
-Riley,Manhattan twp 1,Secretary of  State,,Rep,Randy Duncan,23,
-Riley,Manhattan twp 1,Secretary of  State,,Rep,Keith Esau,3,
-Riley,Manhattan twp 1,Secretary of  State,,Rep,Craig McCullah,12,
-Riley,Manhattan twp 1,Secretary of  State,,Rep,Scott Schwab,19,
-Riley,Manhattan twp 1,Attorney General,,Rep,Derek Schmidt,83,
-Riley,Manhattan twp 1,State Treasurer,,Rep,Jake LaTurner,77,
-Riley,Manhattan twp 1,Insurance Commissioner,,Rep,Clark Shultz,43,
-Riley,Manhattan twp 1,Insurance Commissioner,,Rep,Vicki Schmidt,51,
-Riley,Manhattan twp 1,State House,66,Rep,write-in,3,
-Riley,Manhattan twp 2,Registered Voters,,,Registered Voters,390,
-Riley,Manhattan twp 2,Ballots Cast,,Rep,Ballots Cast,85,
-Riley,Manhattan twp 2,Ballots Cast,,Dem,Ballots Cast,39,
-Riley,Manhattan twp 2,US House,1,Dem,Alan LaPolice,32,
-Riley,Manhattan twp 2,Governor,,Dem,Joshua Svaty,8,
-Riley,Manhattan twp 2,Governor,,Dem,Arden Andersen,0,
-Riley,Manhattan twp 2,Governor,,Dem,Jack Bergeson,1,
-Riley,Manhattan twp 2,Governor,,Dem,Carl Brewer,3,
-Riley,Manhattan twp 2,Governor,,Dem,Laura Kelly,27,
-Riley,Manhattan twp 2,Secretary of State,,Dem,Brian McClendon,33,
-Riley,Manhattan twp 2,Attorney General,,Dem,Sarah Swain,33,
-Riley,Manhattan twp 2,State Treasurer,,Dem,Marci Francisco,34,
-Riley,Manhattan twp 2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,33,
-Riley,Manhattan twp 2,State House,67,Dem,Alex Van Dyke,36,
-Riley,Manhattan twp 2,US House,1,Rep,Nick Reinecker,13,
-Riley,Manhattan twp 2,US House,1,Rep,Roger Marshall,67,
-Riley,Manhattan twp 2,Governor,,Rep,Ken Selzer,8,
-Riley,Manhattan twp 2,Governor,,Rep,Joseph Tutera,0,
-Riley,Manhattan twp 2,Governor,,Rep,Jim Barnett,4,
-Riley,Manhattan twp 2,Governor,,Rep,Jeff Colyer,45,
-Riley,Manhattan twp 2,Governor,,Rep,Kris Kobach,28,
-Riley,Manhattan twp 2,Governor,,Rep,Patrick Kucera,0,
-Riley,Manhattan twp 2,Governor,,Rep,Tyler Ruzich,0,
-Riley,Manhattan twp 2,Secretary of  State,,Rep,Dennis Taylor,34,
-Riley,Manhattan twp 2,Secretary of  State,,Rep,Randy Duncan,18,
-Riley,Manhattan twp 2,Secretary of  State,,Rep,Keith Esau,3,
-Riley,Manhattan twp 2,Secretary of  State,,Rep,Craig McCullah,14,
-Riley,Manhattan twp 2,Secretary of  State,,Rep,Scott Schwab,10,
-Riley,Manhattan twp 2,Attorney General,,Rep,Derek Schmidt,72,
-Riley,Manhattan twp 2,State Treasurer,,Rep,Jake LaTurner,68,
-Riley,Manhattan twp 2,Insurance Commissioner,,Rep,Clark Shultz,32,
-Riley,Manhattan twp 2,Insurance Commissioner,,Rep,Vicki Schmidt,47,
-Riley,Manhattan twp 2,State House,67,Rep,Tom Phillips,76,
-Riley,Manhattan twp 3,Registered Voters,,,Registered Voters,159,
-Riley,Manhattan twp 3,Ballots Cast,,Rep,Ballots Cast,35,
-Riley,Manhattan twp 3,Ballots Cast,,Dem,Ballots Cast,16,
-Riley,Manhattan twp 3,US House,1,Dem,Alan LaPolice,14,
-Riley,Manhattan twp 3,Governor,,Dem,Joshua Svaty,7,
-Riley,Manhattan twp 3,Governor,,Dem,Arden Andersen,1,
-Riley,Manhattan twp 3,Governor,,Dem,Jack Bergeson,0,
-Riley,Manhattan twp 3,Governor,,Dem,Carl Brewer,0,
-Riley,Manhattan twp 3,Governor,,Dem,Laura Kelly,8,
-Riley,Manhattan twp 3,Secretary of State,,Dem,Brian McClendon,15,
-Riley,Manhattan twp 3,Attorney General,,Dem,Sarah Swain,16,
-Riley,Manhattan twp 3,State Treasurer,,Dem,Marci Francisco,15,
-Riley,Manhattan twp 3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,15,
-Riley,Manhattan twp 3,State House,67,Dem,Alex Van Dyke,16,
-Riley,Manhattan twp 3,US House,1,Rep,Nick Reinecker,8,
-Riley,Manhattan twp 3,US House,1,Rep,Roger Marshall,25,
-Riley,Manhattan twp 3,Governor,,Rep,Ken Selzer,1,
-Riley,Manhattan twp 3,Governor,,Rep,Joseph Tutera,0,
-Riley,Manhattan twp 3,Governor,,Rep,Jim Barnett,6,
-Riley,Manhattan twp 3,Governor,,Rep,Jeff Colyer,16,
-Riley,Manhattan twp 3,Governor,,Rep,Kris Kobach,11,
-Riley,Manhattan twp 3,Governor,,Rep,Patrick Kucera,1,
-Riley,Manhattan twp 3,Governor,,Rep,Tyler Ruzich,0,
-Riley,Manhattan twp 3,Secretary of  State,,Rep,Dennis Taylor,18,
-Riley,Manhattan twp 3,Secretary of  State,,Rep,Randy Duncan,5,
-Riley,Manhattan twp 3,Secretary of  State,,Rep,Keith Esau,2,
-Riley,Manhattan twp 3,Secretary of  State,,Rep,Craig McCullah,2,
-Riley,Manhattan twp 3,Secretary of  State,,Rep,Scott Schwab,5,
-Riley,Manhattan twp 3,Attorney General,,Rep,Derek Schmidt,25,
-Riley,Manhattan twp 3,State Treasurer,,Rep,Jake LaTurner,21,
-Riley,Manhattan twp 3,Insurance Commissioner,,Rep,Clark Shultz,11,
-Riley,Manhattan twp 3,Insurance Commissioner,,Rep,Vicki Schmidt,21,
-Riley,Manhattan twp 3,State House,67,Rep,Tom Phillips,30,
-Riley,Manhattan twp 4,Registered Voters,,,Registered Voters,533,
-Riley,Manhattan twp 4,Ballots Cast,,Rep,Ballots Cast,66,
-Riley,Manhattan twp 4,Ballots Cast,,Dem,Ballots Cast,32,
-Riley,Manhattan twp 4,US House,1,Dem,Alan LaPolice,26,
-Riley,Manhattan twp 4,Governor,,Dem,Joshua Svaty,12,
-Riley,Manhattan twp 4,Governor,,Dem,Arden Andersen,3,
-Riley,Manhattan twp 4,Governor,,Dem,Jack Bergeson,0,
-Riley,Manhattan twp 4,Governor,,Dem,Carl Brewer,4,
-Riley,Manhattan twp 4,Governor,,Dem,Laura Kelly,12,
-Riley,Manhattan twp 4,Secretary of State,,Dem,Brian McClendon,26,
-Riley,Manhattan twp 4,Attorney General,,Dem,Sarah Swain,28,
-Riley,Manhattan twp 4,State Treasurer,,Dem,Marci Francisco,26,
-Riley,Manhattan twp 4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,28,
-Riley,Manhattan twp 4,State House,66,Dem,Sydney Carlin,28,
-Riley,Manhattan twp 4,US House,1,Rep,Nick Reinecker,15,
-Riley,Manhattan twp 4,US House,1,Rep,Roger Marshall,49,
-Riley,Manhattan twp 4,Governor,,Rep,Ken Selzer,8,
-Riley,Manhattan twp 4,Governor,,Rep,Joseph Tutera,1,
-Riley,Manhattan twp 4,Governor,,Rep,Jim Barnett,7,
-Riley,Manhattan twp 4,Governor,,Rep,Jeff Colyer,21,
-Riley,Manhattan twp 4,Governor,,Rep,Kris Kobach,28,
-Riley,Manhattan twp 4,Governor,,Rep,Patrick Kucera,0,
-Riley,Manhattan twp 4,Governor,,Rep,Tyler Ruzich,1,
-Riley,Manhattan twp 4,Secretary of  State,,Rep,Dennis Taylor,30,
-Riley,Manhattan twp 4,Secretary of  State,,Rep,Randy Duncan,12,
-Riley,Manhattan twp 4,Secretary of  State,,Rep,Keith Esau,0,
-Riley,Manhattan twp 4,Secretary of  State,,Rep,Craig McCullah,12,
-Riley,Manhattan twp 4,Secretary of  State,,Rep,Scott Schwab,5,
-Riley,Manhattan twp 4,Attorney General,,Rep,Derek Schmidt,60,
-Riley,Manhattan twp 4,State Treasurer,,Rep,Jake LaTurner,53,
-Riley,Manhattan twp 4,Insurance Commissioner,,Rep,Clark Shultz,31,
-Riley,Manhattan twp 4,Insurance Commissioner,,Rep,Vicki Schmidt,29,
-Riley,Manhattan twp 4,State House,66,Rep,write-in,6,
-Riley,May Day twp,Registered Voters,,,Registered Voters,45,
-Riley,May Day twp,Ballots Cast,,Rep,Ballots Cast,16,
-Riley,May Day twp,Ballots Cast,,Dem,Ballots Cast,3,
-Riley,May Day twp,US House,1,Dem,Alan LaPolice,2,
-Riley,May Day twp,Governor,,Dem,Joshua Svaty,1,
-Riley,May Day twp,Governor,,Dem,Arden Andersen,0,
-Riley,May Day twp,Governor,,Dem,Jack Bergeson,1,
-Riley,May Day twp,Governor,,Dem,Carl Brewer,0,
-Riley,May Day twp,Governor,,Dem,Laura Kelly,1,
-Riley,May Day twp,Secretary of State,,Dem,Brian McClendon,2,
-Riley,May Day twp,Attorney General,,Dem,Sarah Swain,3,
-Riley,May Day twp,State Treasurer,,Dem,Marci Francisco,2,
-Riley,May Day twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,2,
-Riley,May Day twp,State House,64,Dem,write-in,1,
-Riley,May Day twp,US House,1,Rep,Nick Reinecker,2,
-Riley,May Day twp,US House,1,Rep,Roger Marshall,13,
-Riley,May Day twp,Governor,,Rep,Ken Selzer,1,
-Riley,May Day twp,Governor,,Rep,Joseph Tutera,0,
-Riley,May Day twp,Governor,,Rep,Jim Barnett,1,
-Riley,May Day twp,Governor,,Rep,Jeff Colyer,11,
-Riley,May Day twp,Governor,,Rep,Kris Kobach,3,
-Riley,May Day twp,Governor,,Rep,Patrick Kucera,0,
-Riley,May Day twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,May Day twp,Secretary of  State,,Rep,Dennis Taylor,5,
-Riley,May Day twp,Secretary of  State,,Rep,Randy Duncan,6,
-Riley,May Day twp,Secretary of  State,,Rep,Keith Esau,0,
-Riley,May Day twp,Secretary of  State,,Rep,Craig McCullah,2,
-Riley,May Day twp,Secretary of  State,,Rep,Scott Schwab,2,
-Riley,May Day twp,Attorney General,,Rep,Derek Schmidt,15,
-Riley,May Day twp,State Treasurer,,Rep,Jake LaTurner,15,
-Riley,May Day twp,Insurance Commissioner,,Rep,Clark Shultz,4,
-Riley,May Day twp,Insurance Commissioner,,Rep,Vicki Schmidt,11,
-Riley,May Day twp,State House,64,Rep,Suzi Carlson,11,
-Riley,May Day twp,State House,64,Rep,Kathy Martin,5,
-Riley,Ogden twp,Registered Voters,,,Registered Voters,286,
-Riley,Ogden twp,Ballots Cast,,Rep,Ballots Cast,71,
-Riley,Ogden twp,Ballots Cast,,Dem,Ballots Cast,12,
-Riley,Ogden twp,US House,1,Dem,Alan LaPolice,12,
-Riley,Ogden twp,Governor,,Dem,Joshua Svaty,5,
-Riley,Ogden twp,Governor,,Dem,Arden Andersen,0,
-Riley,Ogden twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Ogden twp,Governor,,Dem,Carl Brewer,3,
-Riley,Ogden twp,Governor,,Dem,Laura Kelly,4,
-Riley,Ogden twp,Secretary of State,,Dem,Brian McClendon,11,
-Riley,Ogden twp,Attorney General,,Dem,Sarah Swain,12,
-Riley,Ogden twp,State Treasurer,,Dem,Marci Francisco,11,
-Riley,Ogden twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,12,
-Riley,Ogden twp,State House,64,Dem,write-in,0,
-Riley,Ogden twp,US House,1,Rep,Nick Reinecker,24,
-Riley,Ogden twp,US House,1,Rep,Roger Marshall,44,
-Riley,Ogden twp,Governor,,Rep,Ken Selzer,10,
-Riley,Ogden twp,Governor,,Rep,Joseph Tutera,0,
-Riley,Ogden twp,Governor,,Rep,Jim Barnett,9,
-Riley,Ogden twp,Governor,,Rep,Jeff Colyer,19,
-Riley,Ogden twp,Governor,,Rep,Kris Kobach,32,
-Riley,Ogden twp,Governor,,Rep,Patrick Kucera,1,
-Riley,Ogden twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,Ogden twp,Secretary of  State,,Rep,Dennis Taylor,20,
-Riley,Ogden twp,Secretary of  State,,Rep,Randy Duncan,11,
-Riley,Ogden twp,Secretary of  State,,Rep,Keith Esau,5,
-Riley,Ogden twp,Secretary of  State,,Rep,Craig McCullah,11,
-Riley,Ogden twp,Secretary of  State,,Rep,Scott Schwab,12,
-Riley,Ogden twp,Attorney General,,Rep,Derek Schmidt,62,
-Riley,Ogden twp,State Treasurer,,Rep,Jake LaTurner,59,
-Riley,Ogden twp,Insurance Commissioner,,Rep,Clark Shultz,31,
-Riley,Ogden twp,Insurance Commissioner,,Rep,Vicki Schmidt,35,
-Riley,Ogden twp,State House,64,Rep,Suzi Carlson,30,
-Riley,Ogden twp,State House,64,Rep,Kathy Martin,35,
-Riley,Ogden Ft Riley A,Registered Voters,,,Registered Voters,776,
-Riley,Ogden Ft Riley A,Ballots Cast,,Rep,Ballots Cast,63,
-Riley,Ogden Ft Riley A,Ballots Cast,,Dem,Ballots Cast,37,
-Riley,Ogden Ft Riley A,US House,1,Dem,Alan LaPolice,27,
-Riley,Ogden Ft Riley A,Governor,,Dem,Joshua Svaty,10,
-Riley,Ogden Ft Riley A,Governor,,Dem,Arden Andersen,3,
-Riley,Ogden Ft Riley A,Governor,,Dem,Jack Bergeson,2,
-Riley,Ogden Ft Riley A,Governor,,Dem,Carl Brewer,9,
-Riley,Ogden Ft Riley A,Governor,,Dem,Laura Kelly,13,
-Riley,Ogden Ft Riley A,Secretary of State,,Dem,Brian McClendon,31,
-Riley,Ogden Ft Riley A,Attorney General,,Dem,Sarah Swain,27,
-Riley,Ogden Ft Riley A,State Treasurer,,Dem,Marci Francisco,27,
-Riley,Ogden Ft Riley A,Insurance Commissioner,,Dem,Nathaniel McLaughlin,29,
-Riley,Ogden Ft Riley A,State House,64,Dem,write-in,2,
-Riley,Ogden Ft Riley A,US House,1,Rep,Nick Reinecker,17,
-Riley,Ogden Ft Riley A,US House,1,Rep,Roger Marshall,42,
-Riley,Ogden Ft Riley A,Governor,,Rep,Ken Selzer,5,
-Riley,Ogden Ft Riley A,Governor,,Rep,Joseph Tutera,0,
-Riley,Ogden Ft Riley A,Governor,,Rep,Jim Barnett,9,
-Riley,Ogden Ft Riley A,Governor,,Rep,Jeff Colyer,16,
-Riley,Ogden Ft Riley A,Governor,,Rep,Kris Kobach,32,
-Riley,Ogden Ft Riley A,Governor,,Rep,Patrick Kucera,0,
-Riley,Ogden Ft Riley A,Governor,,Rep,Tyler Ruzich,1,
-Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Dennis Taylor,18,
-Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Randy Duncan,15,
-Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Keith Esau,2,
-Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Craig McCullah,10,
-Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Scott Schwab,13,
-Riley,Ogden Ft Riley A,Attorney General,,Rep,Derek Schmidt,54,
-Riley,Ogden Ft Riley A,State Treasurer,,Rep,Jake LaTurner,51,
-Riley,Ogden Ft Riley A,Insurance Commissioner,,Rep,Clark Shultz,24,
-Riley,Ogden Ft Riley A,Insurance Commissioner,,Rep,Vicki Schmidt,36,
-Riley,Ogden Ft Riley A,State House,64,Rep,Suzi Carlson,24,
-Riley,Ogden Ft Riley A,State House,64,Rep,Kathy Martin,34,
-Riley,Sherman twp,Registered Voters,,,Registered Voters,430,p108
-Riley,Sherman twp,Ballots Cast,,Rep,Ballots Cast,90,
-Riley,Sherman twp,Ballots Cast,,Dem,Ballots Cast,19,
-Riley,Sherman twp,US House,1,Dem,Alan LaPolice,14,
-Riley,Sherman twp,Governor,,Dem,Joshua Svaty,3,
-Riley,Sherman twp,Governor,,Dem,Arden Andersen,1,
-Riley,Sherman twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Sherman twp,Governor,,Dem,Carl Brewer,1,
-Riley,Sherman twp,Governor,,Dem,Laura Kelly,13,
-Riley,Sherman twp,Secretary of State,,Dem,Brian McClendon,14,
-Riley,Sherman twp,Attorney General,,Dem,Sarah Swain,15,
-Riley,Sherman twp,State Treasurer,,Dem,Marci Francisco,14,
-Riley,Sherman twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,15,
-Riley,Sherman twp,State House,64,Dem,write-in,0,
-Riley,Sherman twp,US House,1,Rep,Nick Reinecker,19,
-Riley,Sherman twp,US House,1,Rep,Roger Marshall,68,
-Riley,Sherman twp,Governor,,Rep,Ken Selzer,13,
-Riley,Sherman twp,Governor,,Rep,Joseph Tutera,1,
-Riley,Sherman twp,Governor,,Rep,Jim Barnett,10,
-Riley,Sherman twp,Governor,,Rep,Jeff Colyer,37,
-Riley,Sherman twp,Governor,,Rep,Kris Kobach,29,
-Riley,Sherman twp,Governor,,Rep,Patrick Kucera,0,
-Riley,Sherman twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,Sherman twp,Secretary of  State,,Rep,Dennis Taylor,25,
-Riley,Sherman twp,Secretary of  State,,Rep,Randy Duncan,24,
-Riley,Sherman twp,Secretary of  State,,Rep,Keith Esau,7,
-Riley,Sherman twp,Secretary of  State,,Rep,Craig McCullah,8,
-Riley,Sherman twp,Secretary of  State,,Rep,Scott Schwab,14,
-Riley,Sherman twp,Attorney General,,Rep,Derek Schmidt,77,
-Riley,Sherman twp,State Treasurer,,Rep,Jake LaTurner,76,
-Riley,Sherman twp,Insurance Commissioner,,Rep,Clark Shultz,46,
-Riley,Sherman twp,Insurance Commissioner,,Rep,Vicki Schmidt,39,
-Riley,Sherman twp,State House,64,Rep,Suzi Carlson,46,
-Riley,Sherman twp,State House,64,Rep,Kathy Martin,40,
-Riley,Swede Creek,Registered Voters,,,Registered Voters,100,
-Riley,Swede Creek,Ballots Cast,,Rep,Ballots Cast,24,
-Riley,Swede Creek,Ballots Cast,,Dem,Ballots Cast,7,
-Riley,Swede Creek,US House,1,Dem,Alan LaPolice,3,
-Riley,Swede Creek,Governor,,Dem,Joshua Svaty,2,
-Riley,Swede Creek,Governor,,Dem,Arden Andersen,0,
-Riley,Swede Creek,Governor,,Dem,Jack Bergeson,0,
-Riley,Swede Creek,Governor,,Dem,Carl Brewer,0,
-Riley,Swede Creek,Governor,,Dem,Laura Kelly,4,
-Riley,Swede Creek,Secretary of State,,Dem,Brian McClendon,4,
-Riley,Swede Creek,Attorney General,,Dem,Sarah Swain,6,
-Riley,Swede Creek,State Treasurer,,Dem,Marci Francisco,4,
-Riley,Swede Creek,Insurance Commissioner,,Dem,Nathaniel McLaughlin,5,
-Riley,Swede Creek,State House,64,Dem,write-in,0,
-Riley,Swede Creek,US House,1,Rep,Nick Reinecker,7,
-Riley,Swede Creek,US House,1,Rep,Roger Marshall,16,
-Riley,Swede Creek,Governor,,Rep,Ken Selzer,3,
-Riley,Swede Creek,Governor,,Rep,Joseph Tutera,0,
-Riley,Swede Creek,Governor,,Rep,Jim Barnett,1,
-Riley,Swede Creek,Governor,,Rep,Jeff Colyer,15,
-Riley,Swede Creek,Governor,,Rep,Kris Kobach,3,
-Riley,Swede Creek,Governor,,Rep,Patrick Kucera,1,
-Riley,Swede Creek,Governor,,Rep,Tyler Ruzich,0,
-Riley,Swede Creek,Secretary of  State,,Rep,Dennis Taylor,10,
-Riley,Swede Creek,Secretary of  State,,Rep,Randy Duncan,7,
-Riley,Swede Creek,Secretary of  State,,Rep,Keith Esau,0,
-Riley,Swede Creek,Secretary of  State,,Rep,Craig McCullah,0,
-Riley,Swede Creek,Secretary of  State,,Rep,Scott Schwab,2,
-Riley,Swede Creek,Attorney General,,Rep,Derek Schmidt,22,
-Riley,Swede Creek,State Treasurer,,Rep,Jake LaTurner,22,
-Riley,Swede Creek,Insurance Commissioner,,Rep,Clark Shultz,13,
-Riley,Swede Creek,Insurance Commissioner,,Rep,Vicki Schmidt,9,
-Riley,Swede Creek,State House,64,Rep,Suzi Carlson,17,
-Riley,Swede Creek,State House,64,Rep,Kathy Martin,7,
-Riley,Wildcat twp,Registered Voters,,,Registered Voters,633,
-Riley,Wildcat twp,Ballots Cast,,Rep,Ballots Cast,184,
-Riley,Wildcat twp,Ballots Cast,,Dem,Ballots Cast,33,
-Riley,Wildcat twp,US House,1,Dem,Alan LaPolice,28,
-Riley,Wildcat twp,Governor,,Dem,Joshua Svaty,7,
-Riley,Wildcat twp,Governor,,Dem,Arden Andersen,0,
-Riley,Wildcat twp,Governor,,Dem,Jack Bergeson,1,
-Riley,Wildcat twp,Governor,,Dem,Carl Brewer,3,
-Riley,Wildcat twp,Governor,,Dem,Laura Kelly,22,
-Riley,Wildcat twp,Secretary of State,,Dem,Brian McClendon,28,
-Riley,Wildcat twp,Attorney General,,Dem,Sarah Swain,29,
-Riley,Wildcat twp,State Treasurer,,Dem,Marci Francisco,28,
-Riley,Wildcat twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,29,
-Riley,Wildcat twp,State House,67,Dem,Alex Van Dyke,29,
-Riley,Wildcat twp,US House,1,Rep,Nick Reinecker,32,
-Riley,Wildcat twp,US House,1,Rep,Roger Marshall,140,
-Riley,Wildcat twp,Governor,,Rep,Ken Selzer,23,
-Riley,Wildcat twp,Governor,,Rep,Joseph Tutera,1,
-Riley,Wildcat twp,Governor,,Rep,Jim Barnett,6,
-Riley,Wildcat twp,Governor,,Rep,Jeff Colyer,85,
-Riley,Wildcat twp,Governor,,Rep,Kris Kobach,64,
-Riley,Wildcat twp,Governor,,Rep,Patrick Kucera,3,
-Riley,Wildcat twp,Governor,,Rep,Tyler Ruzich,1,
-Riley,Wildcat twp,Secretary of  State,,Rep,Dennis Taylor,70,
-Riley,Wildcat twp,Secretary of  State,,Rep,Randy Duncan,35,
-Riley,Wildcat twp,Secretary of  State,,Rep,Keith Esau,6,
-Riley,Wildcat twp,Secretary of  State,,Rep,Craig McCullah,16,
-Riley,Wildcat twp,Secretary of  State,,Rep,Scott Schwab,40,
-Riley,Wildcat twp,Attorney General,,Rep,Derek Schmidt,162,
-Riley,Wildcat twp,State Treasurer,,Rep,Jake LaTurner,150,
-Riley,Wildcat twp,Insurance Commissioner,,Rep,Clark Shultz,83,
-Riley,Wildcat twp,Insurance Commissioner,,Rep,Vicki Schmidt,86,
-Riley,Wildcat twp,State House,67,Rep,Tom Phillips,169,
-Riley,Zeandale twp,Registered Voters,,,Registered Voters,257,
-Riley,Zeandale twp,Ballots Cast,,Rep,Ballots Cast,82,
-Riley,Zeandale twp,Ballots Cast,,Dem,Ballots Cast,21,
-Riley,Zeandale twp,US House,1,Dem,Alan LaPolice,13,
-Riley,Zeandale twp,Governor,,Dem,Joshua Svaty,4,
-Riley,Zeandale twp,Governor,,Dem,Arden Andersen,1,
-Riley,Zeandale twp,Governor,,Dem,Jack Bergeson,0,
-Riley,Zeandale twp,Governor,,Dem,Carl Brewer,2,
-Riley,Zeandale twp,Governor,,Dem,Laura Kelly,14,
-Riley,Zeandale twp,Secretary of State,,Dem,Brian McClendon,16,
-Riley,Zeandale twp,Attorney General,,Dem,Sarah Swain,16,
-Riley,Zeandale twp,State Treasurer,,Dem,Marci Francisco,16,
-Riley,Zeandale twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,13,
-Riley,Zeandale twp,State House,51,Dem,Noah Wright,17,
-Riley,Zeandale twp,US House,1,Rep,Nick Reinecker,15,
-Riley,Zeandale twp,US House,1,Rep,Roger Marshall,66,
-Riley,Zeandale twp,Governor,,Rep,Ken Selzer,7,
-Riley,Zeandale twp,Governor,,Rep,Joseph Tutera,0,
-Riley,Zeandale twp,Governor,,Rep,Jim Barnett,7,
-Riley,Zeandale twp,Governor,,Rep,Jeff Colyer,34,
-Riley,Zeandale twp,Governor,,Rep,Kris Kobach,34,
-Riley,Zeandale twp,Governor,,Rep,Patrick Kucera,0,
-Riley,Zeandale twp,Governor,,Rep,Tyler Ruzich,0,
-Riley,Zeandale twp,Secretary of  State,,Rep,Dennis Taylor,22,
-Riley,Zeandale twp,Secretary of  State,,Rep,Randy Duncan,13,
-Riley,Zeandale twp,Secretary of  State,,Rep,Keith Esau,8,
-Riley,Zeandale twp,Secretary of  State,,Rep,Craig McCullah,17,
-Riley,Zeandale twp,Secretary of  State,,Rep,Scott Schwab,15,
-Riley,Zeandale twp,Attorney General,,Rep,Derek Schmidt,72,
-Riley,Zeandale twp,State Treasurer,,Rep,Jake LaTurner,65,
-Riley,Zeandale twp,Insurance Commissioner,,Rep,Clark Shultz,41,
-Riley,Zeandale twp,Insurance Commissioner,,Rep,Vicki Schmidt,39,
-Riley,Zeandale twp,State House,67,Rep,Ron Highland,72,
-Riley,Mad Ft Riley A,Registered Voters,,,Registered Voters,471,
-Riley,Mad Ft Riley A,Ballots Cast,,Rep,Ballots Cast,1,
-Riley,Mad Ft Riley A,Ballots Cast,,Dem,Ballots Cast,1,
-Riley,Mad Ft Riley A,US House,1,Dem,Alan LaPolice,0,
-Riley,Mad Ft Riley A,Governor,,Dem,Joshua Svaty,0,
-Riley,Mad Ft Riley A,Governor,,Dem,Arden Andersen,0,
-Riley,Mad Ft Riley A,Governor,,Dem,Jack Bergeson,0,
-Riley,Mad Ft Riley A,Governor,,Dem,Carl Brewer,0,
-Riley,Mad Ft Riley A,Governor,,Dem,Laura Kelly,1,
-Riley,Mad Ft Riley A,Secretary of State,,Dem,Brian McClendon,0,
-Riley,Mad Ft Riley A,Attorney General,,Dem,Sarah Swain,1,
-Riley,Mad Ft Riley A,State Treasurer,,Dem,Marci Francisco,0,
-Riley,Mad Ft Riley A,Insurance Commissioner,,Dem,Nathaniel McLaughlin,0,
-Riley,Mad Ft Riley A,State House,64,Dem,write-in,0,
-Riley,Mad Ft Riley A,US House,1,Rep,Nick Reinecker,1,
-Riley,Mad Ft Riley A,US House,1,Rep,Roger Marshall,0,
-Riley,Mad Ft Riley A,Governor,,Rep,Ken Selzer,1,
-Riley,Mad Ft Riley A,Governor,,Rep,Joseph Tutera,0,
-Riley,Mad Ft Riley A,Governor,,Rep,Jim Barnett,0,
-Riley,Mad Ft Riley A,Governor,,Rep,Jeff Colyer,0,
-Riley,Mad Ft Riley A,Governor,,Rep,Kris Kobach,0,
-Riley,Mad Ft Riley A,Governor,,Rep,Patrick Kucera,0,
-Riley,Mad Ft Riley A,Governor,,Rep,Tyler Ruzich,0,
-Riley,Mad Ft Riley A,Secretary of  State,,Rep,Dennis Taylor,0,
-Riley,Mad Ft Riley A,Secretary of  State,,Rep,Randy Duncan,1,
-Riley,Mad Ft Riley A,Secretary of  State,,Rep,Keith Esau,0,
-Riley,Mad Ft Riley A,Secretary of  State,,Rep,Craig McCullah,0,
-Riley,Mad Ft Riley A,Secretary of  State,,Rep,Scott Schwab,0,
-Riley,Mad Ft Riley A,Attorney General,,Rep,Derek Schmidt,1,
-Riley,Mad Ft Riley A,State Treasurer,,Rep,Jake LaTurner,1,
-Riley,Mad Ft Riley A,Insurance Commissioner,,Rep,Clark Shultz,1,
-Riley,Mad Ft Riley A,Insurance Commissioner,,Rep,Vicki Schmidt,0,
-Riley,Mad Ft Riley A,State House,64,Rep,Suzi Carlson,0,
-Riley,Mad Ft Riley A,State House,64,Rep,Kathy Martin,1,
-Riley,Mad Ft Riley B,Registered Voters,,,Registered Voters,233,
-Riley,Mad Ft Riley B,Ballots Cast,,Rep,Ballots Cast,0,
-Riley,Mad Ft Riley B,Ballots Cast,,Dem,Ballots Cast,2,
-Riley,Mad Ft Riley B,US House,1,Dem,Alan LaPolice,2,
-Riley,Mad Ft Riley B,Governor,,Dem,Joshua Svaty,1,
-Riley,Mad Ft Riley B,Governor,,Dem,Arden Andersen,0,
-Riley,Mad Ft Riley B,Governor,,Dem,Jack Bergeson,0,
-Riley,Mad Ft Riley B,Governor,,Dem,Carl Brewer,0,
-Riley,Mad Ft Riley B,Governor,,Dem,Laura Kelly,1,
-Riley,Mad Ft Riley B,Secretary of State,,Dem,Brian McClendon,2,
-Riley,Mad Ft Riley B,Attorney General,,Dem,Sarah Swain,2,
-Riley,Mad Ft Riley B,State Treasurer,,Dem,Marci Francisco,2,
-Riley,Mad Ft Riley B,Insurance Commissioner,,Dem,Nathaniel McLaughlin,2,
-Riley,Mad Ft Riley B,State House,64,Dem,write-in,0,
-Riley,Mad Ft Riley B,US House,1,Rep,Nick Reinecker,0,
-Riley,Mad Ft Riley B,US House,1,Rep,Roger Marshall,0,
-Riley,Mad Ft Riley B,Governor,,Rep,Ken Selzer,0,
-Riley,Mad Ft Riley B,Governor,,Rep,Joseph Tutera,0,
-Riley,Mad Ft Riley B,Governor,,Rep,Jim Barnett,0,
-Riley,Mad Ft Riley B,Governor,,Rep,Jeff Colyer,0,
-Riley,Mad Ft Riley B,Governor,,Rep,Kris Kobach,0,
-Riley,Mad Ft Riley B,Governor,,Rep,Patrick Kucera,0,
-Riley,Mad Ft Riley B,Governor,,Rep,Tyler Ruzich,0,
-Riley,Mad Ft Riley B,Secretary of  State,,Rep,Dennis Taylor,0,
-Riley,Mad Ft Riley B,Secretary of  State,,Rep,Randy Duncan,0,
-Riley,Mad Ft Riley B,Secretary of  State,,Rep,Keith Esau,0,
-Riley,Mad Ft Riley B,Secretary of  State,,Rep,Craig McCullah,0,
-Riley,Mad Ft Riley B,Secretary of  State,,Rep,Scott Schwab,0,
-Riley,Mad Ft Riley B,Attorney General,,Rep,Derek Schmidt,0,
-Riley,Mad Ft Riley B,State Treasurer,,Rep,Jake LaTurner,0,
-Riley,Mad Ft Riley B,Insurance Commissioner,,Rep,Clark Shultz,0,
-Riley,Mad Ft Riley B,Insurance Commissioner,,Rep,Vicki Schmidt,0,
-Riley,Mad Ft Riley B,State House,64,Rep,Suzi Carlson,0,
-Riley,Mad Ft Riley B,State House,64,Rep,Kathy Martin,0,
+county,precinct,office,district,party,candidate,votes
+Riley,W1P1,Registered Voters,,,Registered Voters,1218
+Riley,W1P1,Ballots Cast,,Rep,Ballots Cast,112
+Riley,W1P1,Ballots Cast,,Dem,Ballots Cast,159
+Riley,W1P1,US House,1,Dem,Alan LaPolice,128
+Riley,W1P1,Governor,,Dem,Joshua Svaty,66
+Riley,W1P1,Governor,,Dem,Arden Andersen,2
+Riley,W1P1,Governor,,Dem,Jack Bergeson,2
+Riley,W1P1,Governor,,Dem,Carl Brewer,23
+Riley,W1P1,Governor,,Dem,Laura Kelly,65
+Riley,W1P1,Secretary of State,,Dem,Brian McClendon,132
+Riley,W1P1,Attorney General,,Dem,Sarah Swain,133
+Riley,W1P1,State Treasurer,,Dem,Marci Francisco,131
+Riley,W1P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,127
+Riley,W1P1,State House,66,Dem,Sydney Carlin,150
+Riley,W1P1,US House,1,Rep,Nick Reinecker,41
+Riley,W1P1,US House,1,Rep,Roger Marshall,60
+Riley,W1P1,Governor,,Rep,Ken Selzer,10
+Riley,W1P1,Governor,,Rep,Joseph Tutera,1
+Riley,W1P1,Governor,,Rep,Jim Barnett,17
+Riley,W1P1,Governor,,Rep,Jeff Colyer,46
+Riley,W1P1,Governor,,Rep,Kris Kobach,36
+Riley,W1P1,Governor,,Rep,Patrick Kucera,1
+Riley,W1P1,Governor,,Rep,Tyler Ruzich,0
+Riley,W1P1,Secretary of  State,,Rep,Dennis Taylor,29
+Riley,W1P1,Secretary of  State,,Rep,Randy Duncan,24
+Riley,W1P1,Secretary of  State,,Rep,Keith Esau,6
+Riley,W1P1,Secretary of  State,,Rep,Craig McCullah,14
+Riley,W1P1,Secretary of  State,,Rep,Scott Schwab,20
+Riley,W1P1,Attorney General,,Rep,Derek Schmidt,85
+Riley,W1P1,State Treasurer,,Rep,Jake LaTurner,77
+Riley,W1P1,Insurance Commissioner,,Rep,Clark Shultz,49
+Riley,W1P1,Insurance Commissioner,,Rep,Vicki Schmidt,48
+Riley,W1P1,State House,66,Rep,write-in,11
+Riley,W2P1,Registered Voters,,,Registered Voters,1353
+Riley,W2P1,Ballots Cast,,Rep,Ballots Cast,64
+Riley,W2P1,Ballots Cast,,Dem,Ballots Cast,108
+Riley,W2P1,US House,1,Dem,Alan LaPolice,93
+Riley,W2P1,Governor,,Dem,Joshua Svaty,51
+Riley,W2P1,Governor,,Dem,Arden Andersen,3
+Riley,W2P1,Governor,,Dem,Jack Bergeson,2
+Riley,W2P1,Governor,,Dem,Carl Brewer,16
+Riley,W2P1,Governor,,Dem,Laura Kelly,34
+Riley,W2P1,Secretary of State,,Dem,Brian McClendon,92
+Riley,W2P1,Attorney General,,Dem,Sarah Swain,95
+Riley,W2P1,State Treasurer,,Dem,Marci Francisco,96
+Riley,W2P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,93
+Riley,W2P1,State House,66,Dem,Sydney Carlin,99
+Riley,W2P1,US House,1,Rep,Nick Reinecker,20
+Riley,W2P1,US House,1,Rep,Roger Marshall,38
+Riley,W2P1,Governor,,Rep,Ken Selzer,5
+Riley,W2P1,Governor,,Rep,Joseph Tutera,0
+Riley,W2P1,Governor,,Rep,Jim Barnett,10
+Riley,W2P1,Governor,,Rep,Jeff Colyer,25
+Riley,W2P1,Governor,,Rep,Kris Kobach,21
+Riley,W2P1,Governor,,Rep,Patrick Kucera,1
+Riley,W2P1,Governor,,Rep,Tyler Ruzich,2
+Riley,W2P1,Secretary of  State,,Rep,Dennis Taylor,15
+Riley,W2P1,Secretary of  State,,Rep,Randy Duncan,11
+Riley,W2P1,Secretary of  State,,Rep,Keith Esau,6
+Riley,W2P1,Secretary of  State,,Rep,Craig McCullah,6
+Riley,W2P1,Secretary of  State,,Rep,Scott Schwab,11
+Riley,W2P1,Attorney General,,Rep,Derek Schmidt,48
+Riley,W2P1,State Treasurer,,Rep,Jake LaTurner,43
+Riley,W2P1,Insurance Commissioner,,Rep,Clark Shultz,23
+Riley,W2P1,Insurance Commissioner,,Rep,Vicki Schmidt,29
+Riley,W2P1,State House,66,Rep,write-in,4
+Riley,W2P2,Registered Voters,,,Registered Voters,463
+Riley,W2P2,Ballots Cast,,Rep,Ballots Cast,21
+Riley,W2P2,Ballots Cast,,Dem,Ballots Cast,49
+Riley,W2P2,US House,1,Dem,Alan LaPolice,27
+Riley,W2P2,Governor,,Dem,Joshua Svaty,21
+Riley,W2P2,Governor,,Dem,Arden Andersen,1
+Riley,W2P2,Governor,,Dem,Jack Bergeson,0
+Riley,W2P2,Governor,,Dem,Carl Brewer,10
+Riley,W2P2,Governor,,Dem,Laura Kelly,17
+Riley,W2P2,Secretary of State,,Dem,Brian McClendon,41
+Riley,W2P2,Attorney General,,Dem,Sarah Swain,40
+Riley,W2P2,State Treasurer,,Dem,Marci Francisco,40
+Riley,W2P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,38
+Riley,W2P2,State House,66,Dem,Sydney Carlin,44
+Riley,W2P2,US House,1,Rep,Nick Reinecker,7
+Riley,W2P2,US House,1,Rep,Roger Marshall,14
+Riley,W2P2,Governor,,Rep,Ken Selzer,2
+Riley,W2P2,Governor,,Rep,Joseph Tutera,0
+Riley,W2P2,Governor,,Rep,Jim Barnett,2
+Riley,W2P2,Governor,,Rep,Jeff Colyer,12
+Riley,W2P2,Governor,,Rep,Kris Kobach,4
+Riley,W2P2,Governor,,Rep,Patrick Kucera,0
+Riley,W2P2,Governor,,Rep,Tyler Ruzich,1
+Riley,W2P2,Secretary of  State,,Rep,Dennis Taylor,13
+Riley,W2P2,Secretary of  State,,Rep,Randy Duncan,4
+Riley,W2P2,Secretary of  State,,Rep,Keith Esau,0
+Riley,W2P2,Secretary of  State,,Rep,Craig McCullah,2
+Riley,W2P2,Secretary of  State,,Rep,Scott Schwab,2
+Riley,W2P2,Attorney General,,Rep,Derek Schmidt,19
+Riley,W2P2,State Treasurer,,Rep,Jake LaTurner,16
+Riley,W2P2,Insurance Commissioner,,Rep,Clark Shultz,4
+Riley,W2P2,Insurance Commissioner,,Rep,Vicki Schmidt,17
+Riley,W2P2,State House,66,Rep,write-in,0
+Riley,W2P3,Registered Voters,,,Registered Voters,1836
+Riley,W2P3,Ballots Cast,,Rep,Ballots Cast,224
+Riley,W2P3,Ballots Cast,,Dem,Ballots Cast,148
+Riley,W2P3,US House,1,Dem,Alan LaPolice,126
+Riley,W2P3,Governor,,Dem,Joshua Svaty,54
+Riley,W2P3,Governor,,Dem,Arden Andersen,3
+Riley,W2P3,Governor,,Dem,Jack Bergeson,1
+Riley,W2P3,Governor,,Dem,Carl Brewer,15
+Riley,W2P3,Governor,,Dem,Laura Kelly,73
+Riley,W2P3,Secretary of State,,Dem,Brian McClendon,129
+Riley,W2P3,Attorney General,,Dem,Sarah Swain,136
+Riley,W2P3,State Treasurer,,Dem,Marci Francisco,129
+Riley,W2P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,129
+Riley,W2P3,State House,66,Dem,Sydney Carlin,142
+Riley,W2P3,US House,1,Rep,Nick Reinecker,59
+Riley,W2P3,US House,1,Rep,Roger Marshall,152
+Riley,W2P3,Governor,,Rep,Ken Selzer,29
+Riley,W2P3,Governor,,Rep,Joseph Tutera,1
+Riley,W2P3,Governor,,Rep,Jim Barnett,20
+Riley,W2P3,Governor,,Rep,Jeff Colyer,81
+Riley,W2P3,Governor,,Rep,Kris Kobach,89
+Riley,W2P3,Governor,,Rep,Patrick Kucera,1
+Riley,W2P3,Governor,,Rep,Tyler Ruzich,1
+Riley,W2P3,Secretary of  State,,Rep,Dennis Taylor,77
+Riley,W2P3,Secretary of  State,,Rep,Randy Duncan,46
+Riley,W2P3,Secretary of  State,,Rep,Keith Esau,7
+Riley,W2P3,Secretary of  State,,Rep,Craig McCullah,43
+Riley,W2P3,Secretary of  State,,Rep,Scott Schwab,41
+Riley,W2P3,Attorney General,,Rep,Derek Schmidt,203
+Riley,W2P3,State Treasurer,,Rep,Jake LaTurner,189
+Riley,W2P3,Insurance Commissioner,,Rep,Clark Shultz,98
+Riley,W2P3,Insurance Commissioner,,Rep,Vicki Schmidt,114
+Riley,W2P3,State House,66,Rep,write-in,18
+Riley,W2P4,Registered Voters,,,Registered Voters,1066
+Riley,W2P4,Ballots Cast,,Rep,Ballots Cast,98
+Riley,W2P4,Ballots Cast,,Dem,Ballots Cast,105
+Riley,W2P4,US House,1,Dem,Alan LaPolice,88
+Riley,W2P4,Governor,,Dem,Joshua Svaty,39
+Riley,W2P4,Governor,,Dem,Arden Andersen,5
+Riley,W2P4,Governor,,Dem,Jack Bergeson,2
+Riley,W2P4,Governor,,Dem,Carl Brewer,17
+Riley,W2P4,Governor,,Dem,Laura Kelly,42
+Riley,W2P4,Secretary of State,,Dem,Brian McClendon,86
+Riley,W2P4,Attorney General,,Dem,Sarah Swain,94
+Riley,W2P4,State Treasurer,,Dem,Marci Francisco,88
+Riley,W2P4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,86
+Riley,W2P4,State House,66,Dem,Sydney Carlin,100
+Riley,W2P4,US House,1,Rep,Nick Reinecker,20
+Riley,W2P4,US House,1,Rep,Roger Marshall,76
+Riley,W2P4,Governor,,Rep,Ken Selzer,12
+Riley,W2P4,Governor,,Rep,Joseph Tutera,0
+Riley,W2P4,Governor,,Rep,Jim Barnett,11
+Riley,W2P4,Governor,,Rep,Jeff Colyer,31
+Riley,W2P4,Governor,,Rep,Kris Kobach,39
+Riley,W2P4,Governor,,Rep,Patrick Kucera,1
+Riley,W2P4,Governor,,Rep,Tyler Ruzich,2
+Riley,W2P4,Secretary of  State,,Rep,Dennis Taylor,28
+Riley,W2P4,Secretary of  State,,Rep,Randy Duncan,19
+Riley,W2P4,Secretary of  State,,Rep,Keith Esau,5
+Riley,W2P4,Secretary of  State,,Rep,Craig McCullah,11
+Riley,W2P4,Secretary of  State,,Rep,Scott Schwab,26
+Riley,W2P4,Attorney General,,Rep,Derek Schmidt,85
+Riley,W2P4,State Treasurer,,Rep,Jake LaTurner,86
+Riley,W2P4,Insurance Commissioner,,Rep,Clark Shultz,48
+Riley,W2P4,Insurance Commissioner,,Rep,Vicki Schmidt,45
+Riley,W2P4,State House,66,Rep,write-in,6
+Riley,W3P2,Registered Voters,,,Registered Voters,916
+Riley,W3P2,Ballots Cast,,Rep,Ballots Cast,20
+Riley,W3P2,Ballots Cast,,Dem,Ballots Cast,34
+Riley,W3P2,US House,1,Dem,Alan LaPolice,31
+Riley,W3P2,Governor,,Dem,Joshua Svaty,9
+Riley,W3P2,Governor,,Dem,Arden Andersen,0
+Riley,W3P2,Governor,,Dem,Jack Bergeson,0
+Riley,W3P2,Governor,,Dem,Carl Brewer,5
+Riley,W3P2,Governor,,Dem,Laura Kelly,20
+Riley,W3P2,Secretary of State,,Dem,Brian McClendon,31
+Riley,W3P2,Attorney General,,Dem,Sarah Swain,30
+Riley,W3P2,State Treasurer,,Dem,Marci Francisco,31
+Riley,W3P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,31
+Riley,W3P2,State House,66,Dem,Sydney Carlin,32
+Riley,W3P2,US House,1,Rep,Nick Reinecker,3
+Riley,W3P2,US House,1,Rep,Roger Marshall,17
+Riley,W3P2,Governor,,Rep,Ken Selzer,3
+Riley,W3P2,Governor,,Rep,Joseph Tutera,0
+Riley,W3P2,Governor,,Rep,Jim Barnett,5
+Riley,W3P2,Governor,,Rep,Jeff Colyer,7
+Riley,W3P2,Governor,,Rep,Kris Kobach,5
+Riley,W3P2,Governor,,Rep,Patrick Kucera,0
+Riley,W3P2,Governor,,Rep,Tyler Ruzich,0
+Riley,W3P2,Secretary of  State,,Rep,Dennis Taylor,6
+Riley,W3P2,Secretary of  State,,Rep,Randy Duncan,6
+Riley,W3P2,Secretary of  State,,Rep,Keith Esau,1
+Riley,W3P2,Secretary of  State,,Rep,Craig McCullah,3
+Riley,W3P2,Secretary of  State,,Rep,Scott Schwab,3
+Riley,W3P2,Attorney General,,Rep,Derek Schmidt,16
+Riley,W3P2,State Treasurer,,Rep,Jake LaTurner,17
+Riley,W3P2,Insurance Commissioner,,Rep,Clark Shultz,9
+Riley,W3P2,Insurance Commissioner,,Rep,Vicki Schmidt,10
+Riley,W3P2,State House,66,Rep,write-in,1
+Riley,W3P3,Registered Voters,,,Registered Voters,1404
+Riley,W3P3,Ballots Cast,,Rep,Ballots Cast,183
+Riley,W3P3,Ballots Cast,,Dem,Ballots Cast,98
+Riley,W3P3,US House,1,Dem,Alan LaPolice,81
+Riley,W3P3,Governor,,Dem,Joshua Svaty,36
+Riley,W3P3,Governor,,Dem,Arden Andersen,0
+Riley,W3P3,Governor,,Dem,Jack Bergeson,3
+Riley,W3P3,Governor,,Dem,Carl Brewer,6
+Riley,W3P3,Governor,,Dem,Laura Kelly,50
+Riley,W3P3,Secretary of State,,Dem,Brian McClendon,79
+Riley,W3P3,Attorney General,,Dem,Sarah Swain,82
+Riley,W3P3,State Treasurer,,Dem,Marci Francisco,81
+Riley,W3P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,77
+Riley,W3P3,State House,66,Dem,Sydney Carlin,94
+Riley,W3P3,US House,1,Rep,Nick Reinecker,28
+Riley,W3P3,US House,1,Rep,Roger Marshall,141
+Riley,W3P3,Governor,,Rep,Ken Selzer,20
+Riley,W3P3,Governor,,Rep,Joseph Tutera,1
+Riley,W3P3,Governor,,Rep,Jim Barnett,25
+Riley,W3P3,Governor,,Rep,Jeff Colyer,94
+Riley,W3P3,Governor,,Rep,Kris Kobach,40
+Riley,W3P3,Governor,,Rep,Patrick Kucera,1
+Riley,W3P3,Governor,,Rep,Tyler Ruzich,2
+Riley,W3P3,Secretary of  State,,Rep,Dennis Taylor,52
+Riley,W3P3,Secretary of  State,,Rep,Randy Duncan,45
+Riley,W3P3,Secretary of  State,,Rep,Keith Esau,4
+Riley,W3P3,Secretary of  State,,Rep,Craig McCullah,16
+Riley,W3P3,Secretary of  State,,Rep,Scott Schwab,34
+Riley,W3P3,Attorney General,,Rep,Derek Schmidt,148
+Riley,W3P3,State Treasurer,,Rep,Jake LaTurner,135
+Riley,W3P3,Insurance Commissioner,,Rep,Clark Shultz,68
+Riley,W3P3,Insurance Commissioner,,Rep,Vicki Schmidt,92
+Riley,W3P3,State House,66,Rep,write-in,5
+Riley,W4P2,Registered Voters,,,Registered Voters,326
+Riley,W4P2,Ballots Cast,,Rep,Ballots Cast,59
+Riley,W4P2,Ballots Cast,,Dem,Ballots Cast,39
+Riley,W4P2,US House,1,Dem,Alan LaPolice,34
+Riley,W4P2,Governor,,Dem,Joshua Svaty,14
+Riley,W4P2,Governor,,Dem,Arden Andersen,0
+Riley,W4P2,Governor,,Dem,Jack Bergeson,1
+Riley,W4P2,Governor,,Dem,Carl Brewer,6
+Riley,W4P2,Governor,,Dem,Laura Kelly,18
+Riley,W4P2,Secretary of State,,Dem,Brian McClendon,36
+Riley,W4P2,Attorney General,,Dem,Sarah Swain,37
+Riley,W4P2,State Treasurer,,Dem,Marci Francisco,36
+Riley,W4P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,35
+Riley,W4P2,State House,66,Dem,Sydney Carlin,38
+Riley,W4P2,US House,1,Rep,Nick Reinecker,19
+Riley,W4P2,US House,1,Rep,Roger Marshall,36
+Riley,W4P2,Governor,,Rep,Ken Selzer,5
+Riley,W4P2,Governor,,Rep,Joseph Tutera,1
+Riley,W4P2,Governor,,Rep,Jim Barnett,7
+Riley,W4P2,Governor,,Rep,Jeff Colyer,22
+Riley,W4P2,Governor,,Rep,Kris Kobach,23
+Riley,W4P2,Governor,,Rep,Patrick Kucera,1
+Riley,W4P2,Governor,,Rep,Tyler Ruzich,0
+Riley,W4P2,Secretary of  State,,Rep,Dennis Taylor,27
+Riley,W4P2,Secretary of  State,,Rep,Randy Duncan,12
+Riley,W4P2,Secretary of  State,,Rep,Keith Esau,3
+Riley,W4P2,Secretary of  State,,Rep,Craig McCullah,5
+Riley,W4P2,Secretary of  State,,Rep,Scott Schwab,6
+Riley,W4P2,Attorney General,,Rep,Derek Schmidt,46
+Riley,W4P2,State Treasurer,,Rep,Jake LaTurner,41
+Riley,W4P2,Insurance Commissioner,,Rep,Clark Shultz,18
+Riley,W4P2,Insurance Commissioner,,Rep,Vicki Schmidt,32
+Riley,W4P2,State House,66,Rep,write-in,3
+Riley,W4P3,Registered Voters,,,Registered Voters,891
+Riley,W4P3,Ballots Cast,,Rep,Ballots Cast,128
+Riley,W4P3,Ballots Cast,,Dem,Ballots Cast,114
+Riley,W4P3,US House,1,Dem,Alan LaPolice,101
+Riley,W4P3,Governor,,Dem,Joshua Svaty,40
+Riley,W4P3,Governor,,Dem,Arden Andersen,1
+Riley,W4P3,Governor,,Dem,Jack Bergeson,0
+Riley,W4P3,Governor,,Dem,Carl Brewer,12
+Riley,W4P3,Governor,,Dem,Laura Kelly,59
+Riley,W4P3,Secretary of State,,Dem,Brian McClendon,101
+Riley,W4P3,Attorney General,,Dem,Sarah Swain,103
+Riley,W4P3,State Treasurer,,Dem,Marci Francisco,100
+Riley,W4P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,94
+Riley,W4P3,State House,67,Dem,Alex Van Dyke,105
+Riley,W4P3,US House,1,Rep,Nick Reinecker,34
+Riley,W4P3,US House,1,Rep,Roger Marshall,84
+Riley,W4P3,Governor,,Rep,Ken Selzer,16
+Riley,W4P3,Governor,,Rep,Joseph Tutera,0
+Riley,W4P3,Governor,,Rep,Jim Barnett,24
+Riley,W4P3,Governor,,Rep,Jeff Colyer,45
+Riley,W4P3,Governor,,Rep,Kris Kobach,38
+Riley,W4P3,Governor,,Rep,Patrick Kucera,1
+Riley,W4P3,Governor,,Rep,Tyler Ruzich,3
+Riley,W4P3,Secretary of  State,,Rep,Dennis Taylor,44
+Riley,W4P3,Secretary of  State,,Rep,Randy Duncan,26
+Riley,W4P3,Secretary of  State,,Rep,Keith Esau,7
+Riley,W4P3,Secretary of  State,,Rep,Craig McCullah,16
+Riley,W4P3,Secretary of  State,,Rep,Scott Schwab,19
+Riley,W4P3,Attorney General,,Rep,Derek Schmidt,110
+Riley,W4P3,State Treasurer,,Rep,Jake LaTurner,101
+Riley,W4P3,Insurance Commissioner,,Rep,Clark Shultz,51
+Riley,W4P3,Insurance Commissioner,,Rep,Vicki Schmidt,63
+Riley,W4P3,State House,67,Rep,Tom Phillips,117
+Riley,W4P4,Registered Voters,,,Registered Voters,1686
+Riley,W4P4,Ballots Cast,,Rep,Ballots Cast,338
+Riley,W4P4,Ballots Cast,,Dem,Ballots Cast,148
+Riley,W4P4,US House,1,Dem,Alan LaPolice,123
+Riley,W4P4,Governor,,Dem,Joshua Svaty,57
+Riley,W4P4,Governor,,Dem,Arden Andersen,2
+Riley,W4P4,Governor,,Dem,Jack Bergeson,0
+Riley,W4P4,Governor,,Dem,Carl Brewer,12
+Riley,W4P4,Governor,,Dem,Laura Kelly,77
+Riley,W4P4,Secretary of State,,Dem,Brian McClendon,127
+Riley,W4P4,Attorney General,,Dem,Sarah Swain,130
+Riley,W4P4,State Treasurer,,Dem,Marci Francisco,125
+Riley,W4P4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,126
+Riley,W4P4,State House,67,Dem,Alex Van Dyke,126
+Riley,W4P4,US House,1,Rep,Nick Reinecker,80
+Riley,W4P4,US House,1,Rep,Roger Marshall,246
+Riley,W4P4,Governor,,Rep,Ken Selzer,37
+Riley,W4P4,Governor,,Rep,Joseph Tutera,1
+Riley,W4P4,Governor,,Rep,Jim Barnett,27
+Riley,W4P4,Governor,,Rep,Jeff Colyer,171
+Riley,W4P4,Governor,,Rep,Kris Kobach,95
+Riley,W4P4,Governor,,Rep,Patrick Kucera,3
+Riley,W4P4,Governor,,Rep,Tyler Ruzich,1
+Riley,W4P4,Secretary of  State,,Rep,Dennis Taylor,110
+Riley,W4P4,Secretary of  State,,Rep,Randy Duncan,69
+Riley,W4P4,Secretary of  State,,Rep,Keith Esau,20
+Riley,W4P4,Secretary of  State,,Rep,Craig McCullah,44
+Riley,W4P4,Secretary of  State,,Rep,Scott Schwab,51
+Riley,W4P4,Attorney General,,Rep,Derek Schmidt,288
+Riley,W4P4,State Treasurer,,Rep,Jake LaTurner,268
+Riley,W4P4,Insurance Commissioner,,Rep,Clark Shultz,147
+Riley,W4P4,Insurance Commissioner,,Rep,Vicki Schmidt,158
+Riley,W4P4,State House,67,Rep,Tom Phillips,298
+Riley,W4P5,Registered Voters,,,Registered Voters,1025
+Riley,W4P5,Ballots Cast,,Rep,Ballots Cast,177
+Riley,W4P5,Ballots Cast,,Dem,Ballots Cast,85
+Riley,W4P5,US House,1,Dem,Alan LaPolice,71
+Riley,W4P5,Governor,,Dem,Joshua Svaty,34
+Riley,W4P5,Governor,,Dem,Arden Andersen,2
+Riley,W4P5,Governor,,Dem,Jack Bergeson,1
+Riley,W4P5,Governor,,Dem,Carl Brewer,12
+Riley,W4P5,Governor,,Dem,Laura Kelly,36
+Riley,W4P5,Secretary of State,,Dem,Brian McClendon,76
+Riley,W4P5,Attorney General,,Dem,Sarah Swain,77
+Riley,W4P5,State Treasurer,,Dem,Marci Francisco,75
+Riley,W4P5,Insurance Commissioner,,Dem,Nathaniel McLaughlin,77
+Riley,W4P5,State House,67,Dem,Alex Van Dyke,76
+Riley,W4P5,US House,1,Rep,Nick Reinecker,40
+Riley,W4P5,US House,1,Rep,Roger Marshall,120
+Riley,W4P5,Governor,,Rep,Ken Selzer,17
+Riley,W4P5,Governor,,Rep,Joseph Tutera,2
+Riley,W4P5,Governor,,Rep,Jim Barnett,19
+Riley,W4P5,Governor,,Rep,Jeff Colyer,74
+Riley,W4P5,Governor,,Rep,Kris Kobach,63
+Riley,W4P5,Governor,,Rep,Patrick Kucera,1
+Riley,W4P5,Governor,,Rep,Tyler Ruzich,1
+Riley,W4P5,Secretary of  State,,Rep,Dennis Taylor,56
+Riley,W4P5,Secretary of  State,,Rep,Randy Duncan,40
+Riley,W4P5,Secretary of  State,,Rep,Keith Esau,17
+Riley,W4P5,Secretary of  State,,Rep,Craig McCullah,16
+Riley,W4P5,Secretary of  State,,Rep,Scott Schwab,25
+Riley,W4P5,Attorney General,,Rep,Derek Schmidt,144
+Riley,W4P5,State Treasurer,,Rep,Jake LaTurner,131
+Riley,W4P5,Insurance Commissioner,,Rep,Clark Shultz,79
+Riley,W4P5,Insurance Commissioner,,Rep,Vicki Schmidt,80
+Riley,W4P5,State House,67,Rep,Tom Phillips,157
+Riley,W4P6,Registered Voters,,,Registered Voters,651
+Riley,W4P6,Ballots Cast,,Rep,Ballots Cast,123
+Riley,W4P6,Ballots Cast,,Dem,Ballots Cast,55
+Riley,W4P6,US House,1,Dem,Alan LaPolice,46
+Riley,W4P6,Governor,,Dem,Joshua Svaty,30
+Riley,W4P6,Governor,,Dem,Arden Andersen,0
+Riley,W4P6,Governor,,Dem,Jack Bergeson,0
+Riley,W4P6,Governor,,Dem,Carl Brewer,6
+Riley,W4P6,Governor,,Dem,Laura Kelly,17
+Riley,W4P6,Secretary of State,,Dem,Brian McClendon,47
+Riley,W4P6,Attorney General,,Dem,Sarah Swain,50
+Riley,W4P6,State Treasurer,,Dem,Marci Francisco,48
+Riley,W4P6,Insurance Commissioner,,Dem,Nathaniel McLaughlin,46
+Riley,W4P6,State House,67,Dem,Alex Van Dyke,49
+Riley,W4P6,US House,1,Rep,Nick Reinecker,21
+Riley,W4P6,US House,1,Rep,Roger Marshall,96
+Riley,W4P6,Governor,,Rep,Ken Selzer,14
+Riley,W4P6,Governor,,Rep,Joseph Tutera,0
+Riley,W4P6,Governor,,Rep,Jim Barnett,10
+Riley,W4P6,Governor,,Rep,Jeff Colyer,61
+Riley,W4P6,Governor,,Rep,Kris Kobach,37
+Riley,W4P6,Governor,,Rep,Patrick Kucera,0
+Riley,W4P6,Governor,,Rep,Tyler Ruzich,0
+Riley,W4P6,Secretary of  State,,Rep,Dennis Taylor,34
+Riley,W4P6,Secretary of  State,,Rep,Randy Duncan,28
+Riley,W4P6,Secretary of  State,,Rep,Keith Esau,2
+Riley,W4P6,Secretary of  State,,Rep,Craig McCullah,11
+Riley,W4P6,Secretary of  State,,Rep,Scott Schwab,23
+Riley,W4P6,Attorney General,,Rep,Derek Schmidt,104
+Riley,W4P6,State Treasurer,,Rep,Jake LaTurner,96
+Riley,W4P6,Insurance Commissioner,,Rep,Clark Shultz,56
+Riley,W4P6,Insurance Commissioner,,Rep,Vicki Schmidt,49
+Riley,W4P6,State House,67,Rep,Tom Phillips,110
+Riley,W4P7,Registered Voters,,,Registered Voters,53
+Riley,W4P7,Ballots Cast,,Rep,Ballots Cast,13
+Riley,W4P7,Ballots Cast,,Dem,Ballots Cast,2
+Riley,W4P7,US House,1,Dem,Alan LaPolice,2
+Riley,W4P7,Governor,,Dem,Joshua Svaty,2
+Riley,W4P7,Governor,,Dem,Arden Andersen,0
+Riley,W4P7,Governor,,Dem,Jack Bergeson,0
+Riley,W4P7,Governor,,Dem,Carl Brewer,0
+Riley,W4P7,Governor,,Dem,Laura Kelly,0
+Riley,W4P7,Secretary of State,,Dem,Brian McClendon,2
+Riley,W4P7,Attorney General,,Dem,Sarah Swain,2
+Riley,W4P7,State Treasurer,,Dem,Marci Francisco,2
+Riley,W4P7,Insurance Commissioner,,Dem,Nathaniel McLaughlin,1
+Riley,W4P7,State House,67,Dem,Alex Van Dyke,2
+Riley,W4P7,US House,1,Rep,Nick Reinecker,3
+Riley,W4P7,US House,1,Rep,Roger Marshall,10
+Riley,W4P7,Governor,,Rep,Ken Selzer,0
+Riley,W4P7,Governor,,Rep,Joseph Tutera,0
+Riley,W4P7,Governor,,Rep,Jim Barnett,2
+Riley,W4P7,Governor,,Rep,Jeff Colyer,5
+Riley,W4P7,Governor,,Rep,Kris Kobach,6
+Riley,W4P7,Governor,,Rep,Patrick Kucera,0
+Riley,W4P7,Governor,,Rep,Tyler Ruzich,0
+Riley,W4P7,Secretary of  State,,Rep,Dennis Taylor,4
+Riley,W4P7,Secretary of  State,,Rep,Randy Duncan,5
+Riley,W4P7,Secretary of  State,,Rep,Keith Esau,0
+Riley,W4P7,Secretary of  State,,Rep,Craig McCullah,1
+Riley,W4P7,Secretary of  State,,Rep,Scott Schwab,2
+Riley,W4P7,Attorney General,,Rep,Derek Schmidt,13
+Riley,W4P7,State Treasurer,,Rep,Jake LaTurner,13
+Riley,W4P7,Insurance Commissioner,,Rep,Clark Shultz,7
+Riley,W4P7,Insurance Commissioner,,Rep,Vicki Schmidt,6
+Riley,W4P7,State House,67,Rep,Tom Phillips,13
+Riley,W5P2,Registered Voters,,,Registered Voters,1187
+Riley,W5P2,Ballots Cast,,Rep,Ballots Cast,80
+Riley,W5P2,Ballots Cast,,Dem,Ballots Cast,121
+Riley,W5P2,US House,1,Dem,Alan LaPolice,103
+Riley,W5P2,Governor,,Dem,Joshua Svaty,41
+Riley,W5P2,Governor,,Dem,Arden Andersen,1
+Riley,W5P2,Governor,,Dem,Jack Bergeson,0
+Riley,W5P2,Governor,,Dem,Carl Brewer,21
+Riley,W5P2,Governor,,Dem,Laura Kelly,58
+Riley,W5P2,Secretary of State,,Dem,Brian McClendon,111
+Riley,W5P2,Attorney General,,Dem,Sarah Swain,109
+Riley,W5P2,State Treasurer,,Dem,Marci Francisco,108
+Riley,W5P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,104
+Riley,W5P2,State House,66,Dem,Sydney Carlin,117
+Riley,W5P2,US House,1,Rep,Nick Reinecker,29
+Riley,W5P2,US House,1,Rep,Roger Marshall,47
+Riley,W5P2,Governor,,Rep,Ken Selzer,12
+Riley,W5P2,Governor,,Rep,Joseph Tutera,0
+Riley,W5P2,Governor,,Rep,Jim Barnett,4
+Riley,W5P2,Governor,,Rep,Jeff Colyer,42
+Riley,W5P2,Governor,,Rep,Kris Kobach,20
+Riley,W5P2,Governor,,Rep,Patrick Kucera,2
+Riley,W5P2,Governor,,Rep,Tyler Ruzich,0
+Riley,W5P2,Secretary of  State,,Rep,Dennis Taylor,10
+Riley,W5P2,Secretary of  State,,Rep,Randy Duncan,15
+Riley,W5P2,Secretary of  State,,Rep,Keith Esau,12
+Riley,W5P2,Secretary of  State,,Rep,Craig McCullah,17
+Riley,W5P2,Secretary of  State,,Rep,Scott Schwab,15
+Riley,W5P2,Attorney General,,Rep,Derek Schmidt,59
+Riley,W5P2,State Treasurer,,Rep,Jake LaTurner,59
+Riley,W5P2,Insurance Commissioner,,Rep,Clark Shultz,34
+Riley,W5P2,Insurance Commissioner,,Rep,Vicki Schmidt,40
+Riley,W5P2,State House,66,Rep,write-in,7
+Riley,W5P3,Registered Voters,,,Registered Voters,1369
+Riley,W5P3,Ballots Cast,,Rep,Ballots Cast,97
+Riley,W5P3,Ballots Cast,,Dem,Ballots Cast,99
+Riley,W5P3,US House,1,Dem,Alan LaPolice,91
+Riley,W5P3,Governor,,Dem,Joshua Svaty,34
+Riley,W5P3,Governor,,Dem,Arden Andersen,4
+Riley,W5P3,Governor,,Dem,Jack Bergeson,0
+Riley,W5P3,Governor,,Dem,Carl Brewer,12
+Riley,W5P3,Governor,,Dem,Laura Kelly,49
+Riley,W5P3,Secretary of State,,Dem,Brian McClendon,92
+Riley,W5P3,Attorney General,,Dem,Sarah Swain,94
+Riley,W5P3,State Treasurer,,Dem,Marci Francisco,92
+Riley,W5P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,89
+Riley,W5P3,State House,66,Dem,Sydney Carlin,92
+Riley,W5P3,US House,1,Rep,Nick Reinecker,16
+Riley,W5P3,US House,1,Rep,Roger Marshall,73
+Riley,W5P3,Governor,,Rep,Ken Selzer,12
+Riley,W5P3,Governor,,Rep,Joseph Tutera,0
+Riley,W5P3,Governor,,Rep,Jim Barnett,12
+Riley,W5P3,Governor,,Rep,Jeff Colyer,44
+Riley,W5P3,Governor,,Rep,Kris Kobach,26
+Riley,W5P3,Governor,,Rep,Patrick Kucera,1
+Riley,W5P3,Governor,,Rep,Tyler Ruzich,1
+Riley,W5P3,Secretary of  State,,Rep,Dennis Taylor,36
+Riley,W5P3,Secretary of  State,,Rep,Randy Duncan,20
+Riley,W5P3,Secretary of  State,,Rep,Keith Esau,3
+Riley,W5P3,Secretary of  State,,Rep,Craig McCullah,6
+Riley,W5P3,Secretary of  State,,Rep,Scott Schwab,19
+Riley,W5P3,Attorney General,,Rep,Derek Schmidt,81
+Riley,W5P3,State Treasurer,,Rep,Jake LaTurner,71
+Riley,W5P3,Insurance Commissioner,,Rep,Clark Shultz,42
+Riley,W5P3,Insurance Commissioner,,Rep,Vicki Schmidt,46
+Riley,W5P3,State House,66,Rep,write-in,2
+Riley,W5P5,Registered Voters,,,Registered Voters,595
+Riley,W5P5,Ballots Cast,,Rep,Ballots Cast,81
+Riley,W5P5,Ballots Cast,,Dem,Ballots Cast,59
+Riley,W5P5,US House,1,Dem,Alan LaPolice,49
+Riley,W5P5,Governor,,Dem,Joshua Svaty,20
+Riley,W5P5,Governor,,Dem,Arden Andersen,1
+Riley,W5P5,Governor,,Dem,Jack Bergeson,1
+Riley,W5P5,Governor,,Dem,Carl Brewer,7
+Riley,W5P5,Governor,,Dem,Laura Kelly,29
+Riley,W5P5,Secretary of State,,Dem,Brian McClendon,45
+Riley,W5P5,Attorney General,,Dem,Sarah Swain,47
+Riley,W5P5,State Treasurer,,Dem,Marci Francisco,48
+Riley,W5P5,Insurance Commissioner,,Dem,Nathaniel McLaughlin,45
+Riley,W5P5,State House,67,Dem,Alex Van Dyke,50
+Riley,W5P5,US House,1,Rep,Nick Reinecker,21
+Riley,W5P5,US House,1,Rep,Roger Marshall,56
+Riley,W5P5,Governor,,Rep,Ken Selzer,9
+Riley,W5P5,Governor,,Rep,Joseph Tutera,1
+Riley,W5P5,Governor,,Rep,Jim Barnett,7
+Riley,W5P5,Governor,,Rep,Jeff Colyer,33
+Riley,W5P5,Governor,,Rep,Kris Kobach,28
+Riley,W5P5,Governor,,Rep,Patrick Kucera,2
+Riley,W5P5,Governor,,Rep,Tyler Ruzich,0
+Riley,W5P5,Secretary of  State,,Rep,Dennis Taylor,29
+Riley,W5P5,Secretary of  State,,Rep,Randy Duncan,14
+Riley,W5P5,Secretary of  State,,Rep,Keith Esau,5
+Riley,W5P5,Secretary of  State,,Rep,Craig McCullah,13
+Riley,W5P5,Secretary of  State,,Rep,Scott Schwab,13
+Riley,W5P5,Attorney General,,Rep,Derek Schmidt,70
+Riley,W5P5,State Treasurer,,Rep,Jake LaTurner,61
+Riley,W5P5,Insurance Commissioner,,Rep,Clark Shultz,41
+Riley,W5P5,Insurance Commissioner,,Rep,Vicki Schmidt,35
+Riley,W5P5,State House,67,Rep,Tom Phillips,73
+Riley,W5P6,Registered Voters,,,Registered Voters,1001
+Riley,W5P6,Ballots Cast,,Rep,Ballots Cast,236
+Riley,W5P6,Ballots Cast,,Dem,Ballots Cast,101
+Riley,W5P6,US House,1,Dem,Alan LaPolice,87
+Riley,W5P6,Governor,,Dem,Joshua Svaty,33
+Riley,W5P6,Governor,,Dem,Arden Andersen,1
+Riley,W5P6,Governor,,Dem,Jack Bergeson,0
+Riley,W5P6,Governor,,Dem,Carl Brewer,15
+Riley,W5P6,Governor,,Dem,Laura Kelly,51
+Riley,W5P6,Secretary of State,,Dem,Brian McClendon,84
+Riley,W5P6,Attorney General,,Dem,Sarah Swain,90
+Riley,W5P6,State Treasurer,,Dem,Marci Francisco,89
+Riley,W5P6,Insurance Commissioner,,Dem,Nathaniel McLaughlin,83
+Riley,W5P6,State House,67,Dem,Alex Van Dyke,93
+Riley,W5P6,US House,1,Rep,Nick Reinecker,51
+Riley,W5P6,US House,1,Rep,Roger Marshall,177
+Riley,W5P6,Governor,,Rep,Ken Selzer,25
+Riley,W5P6,Governor,,Rep,Joseph Tutera,0
+Riley,W5P6,Governor,,Rep,Jim Barnett,24
+Riley,W5P6,Governor,,Rep,Jeff Colyer,103
+Riley,W5P6,Governor,,Rep,Kris Kobach,81
+Riley,W5P6,Governor,,Rep,Patrick Kucera,1
+Riley,W5P6,Governor,,Rep,Tyler Ruzich,2
+Riley,W5P6,Secretary of  State,,Rep,Dennis Taylor,82
+Riley,W5P6,Secretary of  State,,Rep,Randy Duncan,42
+Riley,W5P6,Secretary of  State,,Rep,Keith Esau,12
+Riley,W5P6,Secretary of  State,,Rep,Craig McCullah,30
+Riley,W5P6,Secretary of  State,,Rep,Scott Schwab,49
+Riley,W5P6,Attorney General,,Rep,Derek Schmidt,201
+Riley,W5P6,State Treasurer,,Rep,Jake LaTurner,194
+Riley,W5P6,Insurance Commissioner,,Rep,Clark Shultz,104
+Riley,W5P6,Insurance Commissioner,,Rep,Vicki Schmidt,115
+Riley,W5P6,State House,67,Rep,Tom Phillips,209
+Riley,W5P7,Registered Voters,,,Registered Voters,482
+Riley,W5P7,Ballots Cast,,Rep,Ballots Cast,88
+Riley,W5P7,Ballots Cast,,Dem,Ballots Cast,48
+Riley,W5P7,US House,1,Dem,Alan LaPolice,43
+Riley,W5P7,Governor,,Dem,Joshua Svaty,14
+Riley,W5P7,Governor,,Dem,Arden Andersen,0
+Riley,W5P7,Governor,,Dem,Jack Bergeson,1
+Riley,W5P7,Governor,,Dem,Carl Brewer,6
+Riley,W5P7,Governor,,Dem,Laura Kelly,27
+Riley,W5P7,Secretary of State,,Dem,Brian McClendon,41
+Riley,W5P7,Attorney General,,Dem,Sarah Swain,44
+Riley,W5P7,State Treasurer,,Dem,Marci Francisco,42
+Riley,W5P7,Insurance Commissioner,,Dem,Nathaniel McLaughlin,38
+Riley,W5P7,State House,67,Dem,Alex Van Dyke,46
+Riley,W5P7,US House,1,Rep,Nick Reinecker,21
+Riley,W5P7,US House,1,Rep,Roger Marshall,63
+Riley,W5P7,Governor,,Rep,Ken Selzer,12
+Riley,W5P7,Governor,,Rep,Joseph Tutera,0
+Riley,W5P7,Governor,,Rep,Jim Barnett,5
+Riley,W5P7,Governor,,Rep,Jeff Colyer,41
+Riley,W5P7,Governor,,Rep,Kris Kobach,28
+Riley,W5P7,Governor,,Rep,Patrick Kucera,0
+Riley,W5P7,Governor,,Rep,Tyler Ruzich,1
+Riley,W5P7,Secretary of  State,,Rep,Dennis Taylor,28
+Riley,W5P7,Secretary of  State,,Rep,Randy Duncan,18
+Riley,W5P7,Secretary of  State,,Rep,Keith Esau,4
+Riley,W5P7,Secretary of  State,,Rep,Craig McCullah,12
+Riley,W5P7,Secretary of  State,,Rep,Scott Schwab,18
+Riley,W5P7,Attorney General,,Rep,Derek Schmidt,73
+Riley,W5P7,State Treasurer,,Rep,Jake LaTurner,71
+Riley,W5P7,Insurance Commissioner,,Rep,Clark Shultz,41
+Riley,W5P7,Insurance Commissioner,,Rep,Vicki Schmidt,41
+Riley,W5P7,State House,67,Rep,Tom Phillips,77
+Riley,W5P8,Registered Voters,,,Registered Voters,663
+Riley,W5P8,Ballots Cast,,Rep,Ballots Cast,125
+Riley,W5P8,Ballots Cast,,Dem,Ballots Cast,69
+Riley,W5P8,US House,1,Dem,Alan LaPolice,65
+Riley,W5P8,Governor,,Dem,Joshua Svaty,23
+Riley,W5P8,Governor,,Dem,Arden Andersen,3
+Riley,W5P8,Governor,,Dem,Jack Bergeson,0
+Riley,W5P8,Governor,,Dem,Carl Brewer,7
+Riley,W5P8,Governor,,Dem,Laura Kelly,36
+Riley,W5P8,Secretary of State,,Dem,Brian McClendon,62
+Riley,W5P8,Attorney General,,Dem,Sarah Swain,63
+Riley,W5P8,State Treasurer,,Dem,Marci Francisco,64
+Riley,W5P8,Insurance Commissioner,,Dem,Nathaniel McLaughlin,59
+Riley,W5P8,State House,67,Dem,Alex Van Dyke,65
+Riley,W5P8,US House,1,Rep,Nick Reinecker,21
+Riley,W5P8,US House,1,Rep,Roger Marshall,100
+Riley,W5P8,Governor,,Rep,Ken Selzer,16
+Riley,W5P8,Governor,,Rep,Joseph Tutera,0
+Riley,W5P8,Governor,,Rep,Jim Barnett,11
+Riley,W5P8,Governor,,Rep,Jeff Colyer,78
+Riley,W5P8,Governor,,Rep,Kris Kobach,19
+Riley,W5P8,Governor,,Rep,Patrick Kucera,0
+Riley,W5P8,Governor,,Rep,Tyler Ruzich,1
+Riley,W5P8,Secretary of  State,,Rep,Dennis Taylor,33
+Riley,W5P8,Secretary of  State,,Rep,Randy Duncan,16
+Riley,W5P8,Secretary of  State,,Rep,Keith Esau,3
+Riley,W5P8,Secretary of  State,,Rep,Craig McCullah,23
+Riley,W5P8,Secretary of  State,,Rep,Scott Schwab,33
+Riley,W5P8,Attorney General,,Rep,Derek Schmidt,109
+Riley,W5P8,State Treasurer,,Rep,Jake LaTurner,102
+Riley,W5P8,Insurance Commissioner,,Rep,Clark Shultz,61
+Riley,W5P8,Insurance Commissioner,,Rep,Vicki Schmidt,53
+Riley,W5P8,State House,67,Rep,Tom Phillips,116
+Riley,W5P9,Registered Voters,,,Registered Voters,1654
+Riley,W5P9,Ballots Cast,,Rep,Ballots Cast,405
+Riley,W5P9,Ballots Cast,,Dem,Ballots Cast,169
+Riley,W5P9,US House,1,Dem,Alan LaPolice,148
+Riley,W5P9,Governor,,Dem,Joshua Svaty,61
+Riley,W5P9,Governor,,Dem,Arden Andersen,4
+Riley,W5P9,Governor,,Dem,Jack Bergeson,1
+Riley,W5P9,Governor,,Dem,Carl Brewer,10
+Riley,W5P9,Governor,,Dem,Laura Kelly,93
+Riley,W5P9,Secretary of State,,Dem,Brian McClendon,152
+Riley,W5P9,Attorney General,,Dem,Sarah Swain,150
+Riley,W5P9,State Treasurer,,Dem,Marci Francisco,153
+Riley,W5P9,Insurance Commissioner,,Dem,Nathaniel McLaughlin,143
+Riley,W5P9,State House,67,Dem,Alex Van Dyke,153
+Riley,W5P9,US House,1,Rep,Nick Reinecker,81
+Riley,W5P9,US House,1,Rep,Roger Marshall,307
+Riley,W5P9,Governor,,Rep,Ken Selzer,49
+Riley,W5P9,Governor,,Rep,Joseph Tutera,1
+Riley,W5P9,Governor,,Rep,Jim Barnett,35
+Riley,W5P9,Governor,,Rep,Jeff Colyer,215
+Riley,W5P9,Governor,,Rep,Kris Kobach,101
+Riley,W5P9,Governor,,Rep,Patrick Kucera,0
+Riley,W5P9,Governor,,Rep,Tyler Ruzich,2
+Riley,W5P9,Secretary of  State,,Rep,Dennis Taylor,144
+Riley,W5P9,Secretary of  State,,Rep,Randy Duncan,73
+Riley,W5P9,Secretary of  State,,Rep,Keith Esau,23
+Riley,W5P9,Secretary of  State,,Rep,Craig McCullah,45
+Riley,W5P9,Secretary of  State,,Rep,Scott Schwab,67
+Riley,W5P9,Attorney General,,Rep,Derek Schmidt,354
+Riley,W5P9,State Treasurer,,Rep,Jake LaTurner,328
+Riley,W5P9,Insurance Commissioner,,Rep,Clark Shultz,139
+Riley,W5P9,Insurance Commissioner,,Rep,Vicki Schmidt,223
+Riley,W5P9,State House,67,Rep,Tom Phillips,377
+Riley,W5P10,Registered Voters,,,Registered Voters,1918
+Riley,W5P10,Ballots Cast,,Rep,Ballots Cast,376
+Riley,W5P10,Ballots Cast,,Dem,Ballots Cast,185
+Riley,W5P10,US House,1,Dem,Alan LaPolice,164
+Riley,W5P10,Governor,,Dem,Joshua Svaty,86
+Riley,W5P10,Governor,,Dem,Arden Andersen,0
+Riley,W5P10,Governor,,Dem,Jack Bergeson,2
+Riley,W5P10,Governor,,Dem,Carl Brewer,9
+Riley,W5P10,Governor,,Dem,Laura Kelly,83
+Riley,W5P10,Secretary of State,,Dem,Brian McClendon,159
+Riley,W5P10,Attorney General,,Dem,Sarah Swain,161
+Riley,W5P10,State Treasurer,,Dem,Marci Francisco,157
+Riley,W5P10,Insurance Commissioner,,Dem,Nathaniel McLaughlin,148
+Riley,W5P10,State House,67,Dem,Alex Van Dyke,171
+Riley,W5P10,US House,1,Rep,Nick Reinecker,71
+Riley,W5P10,US House,1,Rep,Roger Marshall,274
+Riley,W5P10,Governor,,Rep,Ken Selzer,55
+Riley,W5P10,Governor,,Rep,Joseph Tutera,0
+Riley,W5P10,Governor,,Rep,Jim Barnett,25
+Riley,W5P10,Governor,,Rep,Jeff Colyer,199
+Riley,W5P10,Governor,,Rep,Kris Kobach,92
+Riley,W5P10,Governor,,Rep,Patrick Kucera,2
+Riley,W5P10,Governor,,Rep,Tyler Ruzich,1
+Riley,W5P10,Secretary of  State,,Rep,Dennis Taylor,128
+Riley,W5P10,Secretary of  State,,Rep,Randy Duncan,69
+Riley,W5P10,Secretary of  State,,Rep,Keith Esau,20
+Riley,W5P10,Secretary of  State,,Rep,Craig McCullah,51
+Riley,W5P10,Secretary of  State,,Rep,Scott Schwab,46
+Riley,W5P10,Attorney General,,Rep,Derek Schmidt,319
+Riley,W5P10,State Treasurer,,Rep,Jake LaTurner,306
+Riley,W5P10,Insurance Commissioner,,Rep,Clark Shultz,145
+Riley,W5P10,Insurance Commissioner,,Rep,Vicki Schmidt,193
+Riley,W5P10,State House,67,Rep,Tom Phillips,340
+Riley,W5P11,Registered Voters,,,Registered Voters,1937
+Riley,W5P11,Ballots Cast,,Rep,Ballots Cast,358
+Riley,W5P11,Ballots Cast,,Dem,Ballots Cast,134
+Riley,W5P11,US House,1,Dem,Alan LaPolice,120
+Riley,W5P11,Governor,,Dem,Joshua Svaty,52
+Riley,W5P11,Governor,,Dem,Arden Andersen,1
+Riley,W5P11,Governor,,Dem,Jack Bergeson,1
+Riley,W5P11,Governor,,Dem,Carl Brewer,10
+Riley,W5P11,Governor,,Dem,Laura Kelly,69
+Riley,W5P11,Secretary of State,,Dem,Brian McClendon,118
+Riley,W5P11,Attorney General,,Dem,Sarah Swain,122
+Riley,W5P11,State Treasurer,,Dem,Marci Francisco,119
+Riley,W5P11,Insurance Commissioner,,Dem,Nathaniel McLaughlin,113
+Riley,W5P11,State House,67,Dem,Alex Van Dyke,120
+Riley,W5P11,US House,1,Rep,Nick Reinecker,68
+Riley,W5P11,US House,1,Rep,Roger Marshall,269
+Riley,W5P11,Governor,,Rep,Ken Selzer,44
+Riley,W5P11,Governor,,Rep,Joseph Tutera,0
+Riley,W5P11,Governor,,Rep,Jim Barnett,29
+Riley,W5P11,Governor,,Rep,Jeff Colyer,178
+Riley,W5P11,Governor,,Rep,Kris Kobach,98
+Riley,W5P11,Governor,,Rep,Patrick Kucera,4
+Riley,W5P11,Governor,,Rep,Tyler Ruzich,5
+Riley,W5P11,Secretary of  State,,Rep,Dennis Taylor,107
+Riley,W5P11,Secretary of  State,,Rep,Randy Duncan,63
+Riley,W5P11,Secretary of  State,,Rep,Keith Esau,16
+Riley,W5P11,Secretary of  State,,Rep,Craig McCullah,69
+Riley,W5P11,Secretary of  State,,Rep,Scott Schwab,62
+Riley,W5P11,Attorney General,,Rep,Derek Schmidt,298
+Riley,W5P11,State Treasurer,,Rep,Jake LaTurner,274
+Riley,W5P11,Insurance Commissioner,,Rep,Clark Shultz,162
+Riley,W5P11,Insurance Commissioner,,Rep,Vicki Schmidt,161
+Riley,W5P11,State House,67,Rep,Tom Phillips,319
+Riley,W6P1,Registered Voters,,,Registered Voters,50
+Riley,W6P1,Ballots Cast,,Rep,Ballots Cast,0
+Riley,W6P1,Ballots Cast,,Dem,Ballots Cast,0
+Riley,W6P1,US House,1,Dem,Alan LaPolice,0
+Riley,W6P1,Governor,,Dem,Joshua Svaty,0
+Riley,W6P1,Governor,,Dem,Arden Andersen,0
+Riley,W6P1,Governor,,Dem,Jack Bergeson,0
+Riley,W6P1,Governor,,Dem,Carl Brewer,0
+Riley,W6P1,Governor,,Dem,Laura Kelly,0
+Riley,W6P1,Secretary of State,,Dem,Brian McClendon,0
+Riley,W6P1,Attorney General,,Dem,Sarah Swain,0
+Riley,W6P1,State Treasurer,,Dem,Marci Francisco,0
+Riley,W6P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,0
+Riley,W6P1,State House,64,Dem,Sydney Carlin,0
+Riley,W6P1,US House,1,Rep,Nick Reinecker,0
+Riley,W6P1,US House,1,Rep,Roger Marshall,0
+Riley,W6P1,Governor,,Rep,Ken Selzer,0
+Riley,W6P1,Governor,,Rep,Joseph Tutera,0
+Riley,W6P1,Governor,,Rep,Jim Barnett,0
+Riley,W6P1,Governor,,Rep,Jeff Colyer,0
+Riley,W6P1,Governor,,Rep,Kris Kobach,0
+Riley,W6P1,Governor,,Rep,Patrick Kucera,0
+Riley,W6P1,Governor,,Rep,Tyler Ruzich,0
+Riley,W6P1,Secretary of  State,,Rep,Dennis Taylor,0
+Riley,W6P1,Secretary of  State,,Rep,Randy Duncan,0
+Riley,W6P1,Secretary of  State,,Rep,Keith Esau,0
+Riley,W6P1,Secretary of  State,,Rep,Craig McCullah,0
+Riley,W6P1,Secretary of  State,,Rep,Scott Schwab,0
+Riley,W6P1,Attorney General,,Rep,Derek Schmidt,0
+Riley,W6P1,State Treasurer,,Rep,Jake LaTurner,0
+Riley,W6P1,Insurance Commissioner,,Rep,Clark Shultz,0
+Riley,W6P1,Insurance Commissioner,,Rep,Vicki Schmidt,0
+Riley,W6P1,State House,64,Rep,Suzi Carlson,0
+Riley,W6P1,State House,64,Rep,Kathy Martin,0
+Riley,W8P1,Registered Voters,,,Registered Voters,433
+Riley,W8P1,Ballots Cast,,Rep,Ballots Cast,26
+Riley,W8P1,Ballots Cast,,Dem,Ballots Cast,23
+Riley,W8P1,US House,1,Dem,Alan LaPolice,19
+Riley,W8P1,Governor,,Dem,Joshua Svaty,9
+Riley,W8P1,Governor,,Dem,Arden Andersen,0
+Riley,W8P1,Governor,,Dem,Jack Bergeson,0
+Riley,W8P1,Governor,,Dem,Carl Brewer,4
+Riley,W8P1,Governor,,Dem,Laura Kelly,10
+Riley,W8P1,Secretary of State,,Dem,Brian McClendon,20
+Riley,W8P1,Attorney General,,Dem,Sarah Swain,20
+Riley,W8P1,State Treasurer,,Dem,Marci Francisco,20
+Riley,W8P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,17
+Riley,W8P1,State House,66,Dem,Sydney Carlin,21
+Riley,W8P1,US House,1,Rep,Nick Reinecker,10
+Riley,W8P1,US House,1,Rep,Roger Marshall,15
+Riley,W8P1,Governor,,Rep,Ken Selzer,6
+Riley,W8P1,Governor,,Rep,Joseph Tutera,0
+Riley,W8P1,Governor,,Rep,Jim Barnett,0
+Riley,W8P1,Governor,,Rep,Jeff Colyer,10
+Riley,W8P1,Governor,,Rep,Kris Kobach,9
+Riley,W8P1,Governor,,Rep,Patrick Kucera,0
+Riley,W8P1,Governor,,Rep,Tyler Ruzich,1
+Riley,W8P1,Secretary of  State,,Rep,Dennis Taylor,10
+Riley,W8P1,Secretary of  State,,Rep,Randy Duncan,5
+Riley,W8P1,Secretary of  State,,Rep,Keith Esau,1
+Riley,W8P1,Secretary of  State,,Rep,Craig McCullah,6
+Riley,W8P1,Secretary of  State,,Rep,Scott Schwab,3
+Riley,W8P1,Attorney General,,Rep,Derek Schmidt,23
+Riley,W8P1,State Treasurer,,Rep,Jake LaTurner,20
+Riley,W8P1,Insurance Commissioner,,Rep,Clark Shultz,6
+Riley,W8P1,Insurance Commissioner,,Rep,Vicki Schmidt,19
+Riley,W8P1,State House,66,Rep,write-in,1
+Riley,W8P3,Registered Voters,,,Registered Voters,784
+Riley,W8P3,Ballots Cast,,Rep,Ballots Cast,39
+Riley,W8P3,Ballots Cast,,Dem,Ballots Cast,48
+Riley,W8P3,US House,1,Dem,Alan LaPolice,44
+Riley,W8P3,Governor,,Dem,Joshua Svaty,18
+Riley,W8P3,Governor,,Dem,Arden Andersen,1
+Riley,W8P3,Governor,,Dem,Jack Bergeson,1
+Riley,W8P3,Governor,,Dem,Carl Brewer,8
+Riley,W8P3,Governor,,Dem,Laura Kelly,20
+Riley,W8P3,Secretary of State,,Dem,Brian McClendon,48
+Riley,W8P3,Attorney General,,Dem,Sarah Swain,47
+Riley,W8P3,State Treasurer,,Dem,Marci Francisco,46
+Riley,W8P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,42
+Riley,W8P3,State House,66,Dem,Sydney Carlin,45
+Riley,W8P3,US House,1,Rep,Nick Reinecker,13
+Riley,W8P3,US House,1,Rep,Roger Marshall,21
+Riley,W8P3,Governor,,Rep,Ken Selzer,5
+Riley,W8P3,Governor,,Rep,Joseph Tutera,0
+Riley,W8P3,Governor,,Rep,Jim Barnett,1
+Riley,W8P3,Governor,,Rep,Jeff Colyer,15
+Riley,W8P3,Governor,,Rep,Kris Kobach,15
+Riley,W8P3,Governor,,Rep,Patrick Kucera,0
+Riley,W8P3,Governor,,Rep,Tyler Ruzich,2
+Riley,W8P3,Secretary of  State,,Rep,Dennis Taylor,10
+Riley,W8P3,Secretary of  State,,Rep,Randy Duncan,8
+Riley,W8P3,Secretary of  State,,Rep,Keith Esau,3
+Riley,W8P3,Secretary of  State,,Rep,Craig McCullah,2
+Riley,W8P3,Secretary of  State,,Rep,Scott Schwab,5
+Riley,W8P3,Attorney General,,Rep,Derek Schmidt,30
+Riley,W8P3,State Treasurer,,Rep,Jake LaTurner,27
+Riley,W8P3,Insurance Commissioner,,Rep,Clark Shultz,14
+Riley,W8P3,Insurance Commissioner,,Rep,Vicki Schmidt,19
+Riley,W8P3,State House,66,Rep,write-in,1
+Riley,W9P1,Registered Voters,,,Registered Voters,195
+Riley,W9P1,Ballots Cast,,Rep,Ballots Cast,40
+Riley,W9P1,Ballots Cast,,Dem,Ballots Cast,29
+Riley,W9P1,US House,1,Dem,Alan LaPolice,25
+Riley,W9P1,Governor,,Dem,Joshua Svaty,8
+Riley,W9P1,Governor,,Dem,Arden Andersen,1
+Riley,W9P1,Governor,,Dem,Jack Bergeson,0
+Riley,W9P1,Governor,,Dem,Carl Brewer,0
+Riley,W9P1,Governor,,Dem,Laura Kelly,19
+Riley,W9P1,Secretary of State,,Dem,Brian McClendon,27
+Riley,W9P1,Attorney General,,Dem,Sarah Swain,27
+Riley,W9P1,State Treasurer,,Dem,Marci Francisco,27
+Riley,W9P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,27
+Riley,W9P1,State House,66,Dem,Sydney Carlin,28
+Riley,W9P1,US House,1,Rep,Nick Reinecker,10
+Riley,W9P1,US House,1,Rep,Roger Marshall,27
+Riley,W9P1,Governor,,Rep,Ken Selzer,5
+Riley,W9P1,Governor,,Rep,Joseph Tutera,0
+Riley,W9P1,Governor,,Rep,Jim Barnett,7
+Riley,W9P1,Governor,,Rep,Jeff Colyer,21
+Riley,W9P1,Governor,,Rep,Kris Kobach,7
+Riley,W9P1,Governor,,Rep,Patrick Kucera,0
+Riley,W9P1,Governor,,Rep,Tyler Ruzich,0
+Riley,W9P1,Secretary of  State,,Rep,Dennis Taylor,23
+Riley,W9P1,Secretary of  State,,Rep,Randy Duncan,6
+Riley,W9P1,Secretary of  State,,Rep,Keith Esau,1
+Riley,W9P1,Secretary of  State,,Rep,Craig McCullah,2
+Riley,W9P1,Secretary of  State,,Rep,Scott Schwab,2
+Riley,W9P1,Attorney General,,Rep,Derek Schmidt,33
+Riley,W9P1,State Treasurer,,Rep,Jake LaTurner,28
+Riley,W9P1,Insurance Commissioner,,Rep,Clark Shultz,16
+Riley,W9P1,Insurance Commissioner,,Rep,Vicki Schmidt,19
+Riley,W9P1,State House,66,Rep,write-in,0
+Riley,W9P2,Registered Voters,,,Registered Voters,142
+Riley,W9P2,Ballots Cast,,Rep,Ballots Cast,52
+Riley,W9P2,Ballots Cast,,Dem,Ballots Cast,23
+Riley,W9P2,US House,1,Dem,Alan LaPolice,20
+Riley,W9P2,Governor,,Dem,Joshua Svaty,7
+Riley,W9P2,Governor,,Dem,Arden Andersen,0
+Riley,W9P2,Governor,,Dem,Jack Bergeson,1
+Riley,W9P2,Governor,,Dem,Carl Brewer,4
+Riley,W9P2,Governor,,Dem,Laura Kelly,11
+Riley,W9P2,Secretary of State,,Dem,Brian McClendon,19
+Riley,W9P2,Attorney General,,Dem,Sarah Swain,21
+Riley,W9P2,State Treasurer,,Dem,Marci Francisco,19
+Riley,W9P2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,18
+Riley,W9P2,State House,66,Dem,Sydney Carlin,22
+Riley,W9P2,US House,1,Rep,Nick Reinecker,20
+Riley,W9P2,US House,1,Rep,Roger Marshall,29
+Riley,W9P2,Governor,,Rep,Ken Selzer,7
+Riley,W9P2,Governor,,Rep,Joseph Tutera,0
+Riley,W9P2,Governor,,Rep,Jim Barnett,1
+Riley,W9P2,Governor,,Rep,Jeff Colyer,28
+Riley,W9P2,Governor,,Rep,Kris Kobach,15
+Riley,W9P2,Governor,,Rep,Patrick Kucera,1
+Riley,W9P2,Governor,,Rep,Tyler Ruzich,0
+Riley,W9P2,Secretary of  State,,Rep,Dennis Taylor,16
+Riley,W9P2,Secretary of  State,,Rep,Randy Duncan,11
+Riley,W9P2,Secretary of  State,,Rep,Keith Esau,4
+Riley,W9P2,Secretary of  State,,Rep,Craig McCullah,8
+Riley,W9P2,Secretary of  State,,Rep,Scott Schwab,10
+Riley,W9P2,Attorney General,,Rep,Derek Schmidt,41
+Riley,W9P2,State Treasurer,,Rep,Jake LaTurner,38
+Riley,W9P2,Insurance Commissioner,,Rep,Clark Shultz,19
+Riley,W9P2,Insurance Commissioner,,Rep,Vicki Schmidt,30
+Riley,W9P2,State House,66,Rep,write-in,4
+Riley,W9P3,Registered Voters,,,Registered Voters,78
+Riley,W9P3,Ballots Cast,,Rep,Ballots Cast,17
+Riley,W9P3,Ballots Cast,,Dem,Ballots Cast,7
+Riley,W9P3,US House,1,Dem,Alan LaPolice,6
+Riley,W9P3,Governor,,Dem,Joshua Svaty,5
+Riley,W9P3,Governor,,Dem,Arden Andersen,0
+Riley,W9P3,Governor,,Dem,Jack Bergeson,0
+Riley,W9P3,Governor,,Dem,Carl Brewer,0
+Riley,W9P3,Governor,,Dem,Laura Kelly,2
+Riley,W9P3,Secretary of State,,Dem,Brian McClendon,7
+Riley,W9P3,Attorney General,,Dem,Sarah Swain,7
+Riley,W9P3,State Treasurer,,Dem,Marci Francisco,7
+Riley,W9P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,6
+Riley,W9P3,State House,67,Dem,Alex Van Dyke,6
+Riley,W9P3,US House,1,Rep,Nick Reinecker,2
+Riley,W9P3,US House,1,Rep,Roger Marshall,15
+Riley,W9P3,Governor,,Rep,Ken Selzer,1
+Riley,W9P3,Governor,,Rep,Joseph Tutera,0
+Riley,W9P3,Governor,,Rep,Jim Barnett,2
+Riley,W9P3,Governor,,Rep,Jeff Colyer,9
+Riley,W9P3,Governor,,Rep,Kris Kobach,5
+Riley,W9P3,Governor,,Rep,Patrick Kucera,0
+Riley,W9P3,Governor,,Rep,Tyler Ruzich,0
+Riley,W9P3,Secretary of  State,,Rep,Dennis Taylor,3
+Riley,W9P3,Secretary of  State,,Rep,Randy Duncan,5
+Riley,W9P3,Secretary of  State,,Rep,Keith Esau,1
+Riley,W9P3,Secretary of  State,,Rep,Craig McCullah,1
+Riley,W9P3,Secretary of  State,,Rep,Scott Schwab,6
+Riley,W9P3,Attorney General,,Rep,Derek Schmidt,17
+Riley,W9P3,State Treasurer,,Rep,Jake LaTurner,14
+Riley,W9P3,Insurance Commissioner,,Rep,Clark Shultz,10
+Riley,W9P3,Insurance Commissioner,,Rep,Vicki Schmidt,6
+Riley,W9P3,State House,67,Rep,Tom Phillips,16
+Riley,W10P1,Registered Voters,,,Registered Voters,204
+Riley,W10P1,Ballots Cast,,Rep,Ballots Cast,37
+Riley,W10P1,Ballots Cast,,Dem,Ballots Cast,12
+Riley,W10P1,US House,1,Dem,Alan LaPolice,12
+Riley,W10P1,Governor,,Dem,Joshua Svaty,4
+Riley,W10P1,Governor,,Dem,Arden Andersen,0
+Riley,W10P1,Governor,,Dem,Jack Bergeson,0
+Riley,W10P1,Governor,,Dem,Carl Brewer,0
+Riley,W10P1,Governor,,Dem,Laura Kelly,8
+Riley,W10P1,Secretary of State,,Dem,Brian McClendon,11
+Riley,W10P1,Attorney General,,Dem,Sarah Swain,12
+Riley,W10P1,State Treasurer,,Dem,Marci Francisco,11
+Riley,W10P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,11
+Riley,W10P1,State House,67,Dem,Alex Van Dyke,12
+Riley,W10P1,US House,1,Rep,Nick Reinecker,6
+Riley,W10P1,US House,1,Rep,Roger Marshall,28
+Riley,W10P1,Governor,,Rep,Ken Selzer,7
+Riley,W10P1,Governor,,Rep,Joseph Tutera,0
+Riley,W10P1,Governor,,Rep,Jim Barnett,3
+Riley,W10P1,Governor,,Rep,Jeff Colyer,14
+Riley,W10P1,Governor,,Rep,Kris Kobach,11
+Riley,W10P1,Governor,,Rep,Patrick Kucera,1
+Riley,W10P1,Governor,,Rep,Tyler Ruzich,1
+Riley,W10P1,Secretary of  State,,Rep,Dennis Taylor,17
+Riley,W10P1,Secretary of  State,,Rep,Randy Duncan,7
+Riley,W10P1,Secretary of  State,,Rep,Keith Esau,3
+Riley,W10P1,Secretary of  State,,Rep,Craig McCullah,4
+Riley,W10P1,Secretary of  State,,Rep,Scott Schwab,4
+Riley,W10P1,Attorney General,,Rep,Derek Schmidt,33
+Riley,W10P1,State Treasurer,,Rep,Jake LaTurner,33
+Riley,W10P1,Insurance Commissioner,,Rep,Clark Shultz,10
+Riley,W10P1,Insurance Commissioner,,Rep,Vicki Schmidt,24
+Riley,W10P1,State House,67,Rep,Tom Phillips,35
+Riley,W11P1,Registered Voters,,,Registered Voters,629
+Riley,W11P1,Ballots Cast,,Rep,Ballots Cast,30
+Riley,W11P1,Ballots Cast,,Dem,Ballots Cast,26
+Riley,W11P1,US House,1,Dem,Alan LaPolice,25
+Riley,W11P1,Governor,,Dem,Joshua Svaty,10
+Riley,W11P1,Governor,,Dem,Arden Andersen,0
+Riley,W11P1,Governor,,Dem,Jack Bergeson,0
+Riley,W11P1,Governor,,Dem,Carl Brewer,3
+Riley,W11P1,Governor,,Dem,Laura Kelly,13
+Riley,W11P1,Secretary of State,,Dem,Brian McClendon,25
+Riley,W11P1,Attorney General,,Dem,Sarah Swain,24
+Riley,W11P1,State Treasurer,,Dem,Marci Francisco,24
+Riley,W11P1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,23
+Riley,W11P1,State House,67,Dem,Alex Van Dyke,24
+Riley,W11P1,US House,1,Rep,Nick Reinecker,9
+Riley,W11P1,US House,1,Rep,Roger Marshall,19
+Riley,W11P1,Governor,,Rep,Ken Selzer,5
+Riley,W11P1,Governor,,Rep,Joseph Tutera,0
+Riley,W11P1,Governor,,Rep,Jim Barnett,1
+Riley,W11P1,Governor,,Rep,Jeff Colyer,13
+Riley,W11P1,Governor,,Rep,Kris Kobach,11
+Riley,W11P1,Governor,,Rep,Patrick Kucera,0
+Riley,W11P1,Governor,,Rep,Tyler Ruzich,0
+Riley,W11P1,Secretary of  State,,Rep,Dennis Taylor,10
+Riley,W11P1,Secretary of  State,,Rep,Randy Duncan,6
+Riley,W11P1,Secretary of  State,,Rep,Keith Esau,1
+Riley,W11P1,Secretary of  State,,Rep,Craig McCullah,2
+Riley,W11P1,Secretary of  State,,Rep,Scott Schwab,7
+Riley,W11P1,Attorney General,,Rep,Derek Schmidt,27
+Riley,W11P1,State Treasurer,,Rep,Jake LaTurner,25
+Riley,W11P1,Insurance Commissioner,,Rep,Clark Shultz,19
+Riley,W11P1,Insurance Commissioner,,Rep,Vicki Schmidt,8
+Riley,W11P1,State House,67,Rep,Tom Phillips,28
+Riley,W11P1B,Registered Voters,,,Registered Voters,386
+Riley,W11P1B,Ballots Cast,,Rep,Ballots Cast,33
+Riley,W11P1B,Ballots Cast,,Dem,Ballots Cast,19
+Riley,W11P1B,US House,1,Dem,Alan LaPolice,15
+Riley,W11P1B,Governor,,Dem,Joshua Svaty,8
+Riley,W11P1B,Governor,,Dem,Arden Andersen,2
+Riley,W11P1B,Governor,,Dem,Jack Bergeson,2
+Riley,W11P1B,Governor,,Dem,Carl Brewer,1
+Riley,W11P1B,Governor,,Dem,Laura Kelly,5
+Riley,W11P1B,Secretary of State,,Dem,Brian McClendon,16
+Riley,W11P1B,Attorney General,,Dem,Sarah Swain,17
+Riley,W11P1B,State Treasurer,,Dem,Marci Francisco,15
+Riley,W11P1B,Insurance Commissioner,,Dem,Nathaniel McLaughlin,16
+Riley,W11P1B,State House,67,Dem,Tom Phillips,16
+Riley,W11P1B,US House,1,Rep,Nick Reinecker,9
+Riley,W11P1B,US House,1,Rep,Roger Marshall,24
+Riley,W11P1B,Governor,,Rep,Ken Selzer,1
+Riley,W11P1B,Governor,,Rep,Joseph Tutera,0
+Riley,W11P1B,Governor,,Rep,Jim Barnett,3
+Riley,W11P1B,Governor,,Rep,Jeff Colyer,16
+Riley,W11P1B,Governor,,Rep,Kris Kobach,13
+Riley,W11P1B,Governor,,Rep,Patrick Kucera,0
+Riley,W11P1B,Governor,,Rep,Tyler Ruzich,0
+Riley,W11P1B,Secretary of  State,,Rep,Dennis Taylor,11
+Riley,W11P1B,Secretary of  State,,Rep,Randy Duncan,5
+Riley,W11P1B,Secretary of  State,,Rep,Keith Esau,1
+Riley,W11P1B,Secretary of  State,,Rep,Craig McCullah,8
+Riley,W11P1B,Secretary of  State,,Rep,Scott Schwab,7
+Riley,W11P1B,Attorney General,,Rep,Derek Schmidt,29
+Riley,W11P1B,State Treasurer,,Rep,Jake LaTurner,30
+Riley,W11P1B,Insurance Commissioner,,Rep,Clark Shultz,13
+Riley,W11P1B,Insurance Commissioner,,Rep,Vicki Schmidt,19
+Riley,W11P1B,State House,67,Rep,Tom Phillips,32
+Riley,W11P3,Registered Voters,,,Registered Voters,96
+Riley,W11P3,Ballots Cast,,Rep,Ballots Cast,8
+Riley,W11P3,Ballots Cast,,Dem,Ballots Cast,3
+Riley,W11P3,US House,1,Dem,Alan LaPolice,3
+Riley,W11P3,Governor,,Dem,Joshua Svaty,0
+Riley,W11P3,Governor,,Dem,Arden Andersen,0
+Riley,W11P3,Governor,,Dem,Jack Bergeson,0
+Riley,W11P3,Governor,,Dem,Carl Brewer,0
+Riley,W11P3,Governor,,Dem,Laura Kelly,3
+Riley,W11P3,Secretary of State,,Dem,Brian McClendon,3
+Riley,W11P3,Attorney General,,Dem,Sarah Swain,3
+Riley,W11P3,State Treasurer,,Dem,Marci Francisco,3
+Riley,W11P3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,3
+Riley,W11P3,State House,67,Dem,Alex Van Dyke,3
+Riley,W11P3,US House,1,Rep,Nick Reinecker,2
+Riley,W11P3,US House,1,Rep,Roger Marshall,5
+Riley,W11P3,Governor,,Rep,Ken Selzer,3
+Riley,W11P3,Governor,,Rep,Joseph Tutera,0
+Riley,W11P3,Governor,,Rep,Jim Barnett,0
+Riley,W11P3,Governor,,Rep,Jeff Colyer,1
+Riley,W11P3,Governor,,Rep,Kris Kobach,4
+Riley,W11P3,Governor,,Rep,Patrick Kucera,0
+Riley,W11P3,Governor,,Rep,Tyler Ruzich,0
+Riley,W11P3,Secretary of  State,,Rep,Dennis Taylor,0
+Riley,W11P3,Secretary of  State,,Rep,Randy Duncan,5
+Riley,W11P3,Secretary of  State,,Rep,Keith Esau,1
+Riley,W11P3,Secretary of  State,,Rep,Craig McCullah,0
+Riley,W11P3,Secretary of  State,,Rep,Scott Schwab,1
+Riley,W11P3,Attorney General,,Rep,Derek Schmidt,7
+Riley,W11P3,State Treasurer,,Rep,Jake LaTurner,6
+Riley,W11P3,Insurance Commissioner,,Rep,Clark Shultz,6
+Riley,W11P3,Insurance Commissioner,,Rep,Vicki Schmidt,2
+Riley,W11P3,State House,67,Rep,Tom Phillips,7
+Riley,Ashland twp,Registered Voters,,,Registered Voters,115
+Riley,Ashland twp,Ballots Cast,,Rep,Ballots Cast,39
+Riley,Ashland twp,Ballots Cast,,Dem,Ballots Cast,14
+Riley,Ashland twp,US House,1,Dem,Alan LaPolice,13
+Riley,Ashland twp,Governor,,Dem,Joshua Svaty,7
+Riley,Ashland twp,Governor,,Dem,Arden Andersen,0
+Riley,Ashland twp,Governor,,Dem,Jack Bergeson,0
+Riley,Ashland twp,Governor,,Dem,Carl Brewer,0
+Riley,Ashland twp,Governor,,Dem,Laura Kelly,7
+Riley,Ashland twp,Secretary of State,,Dem,Brian McClendon,12
+Riley,Ashland twp,Attorney General,,Dem,Sarah Swain,13
+Riley,Ashland twp,State Treasurer,,Dem,Marci Francisco,12
+Riley,Ashland twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,11
+Riley,Ashland twp,State House,67,Dem,Alex Van Dyke,13
+Riley,Ashland twp,US House,1,Rep,Nick Reinecker,5
+Riley,Ashland twp,US House,1,Rep,Roger Marshall,31
+Riley,Ashland twp,Governor,,Rep,Ken Selzer,4
+Riley,Ashland twp,Governor,,Rep,Joseph Tutera,0
+Riley,Ashland twp,Governor,,Rep,Jim Barnett,0
+Riley,Ashland twp,Governor,,Rep,Jeff Colyer,18
+Riley,Ashland twp,Governor,,Rep,Kris Kobach,16
+Riley,Ashland twp,Governor,,Rep,Patrick Kucera,0
+Riley,Ashland twp,Governor,,Rep,Tyler Ruzich,0
+Riley,Ashland twp,Secretary of  State,,Rep,Dennis Taylor,10
+Riley,Ashland twp,Secretary of  State,,Rep,Randy Duncan,7
+Riley,Ashland twp,Secretary of  State,,Rep,Keith Esau,2
+Riley,Ashland twp,Secretary of  State,,Rep,Craig McCullah,7
+Riley,Ashland twp,Secretary of  State,,Rep,Scott Schwab,8
+Riley,Ashland twp,Attorney General,,Rep,Derek Schmidt,33
+Riley,Ashland twp,State Treasurer,,Rep,Jake LaTurner,30
+Riley,Ashland twp,Insurance Commissioner,,Rep,Clark Shultz,24
+Riley,Ashland twp,Insurance Commissioner,,Rep,Vicki Schmidt,11
+Riley,Ashland twp,State House,67,Rep,Tom Phillips,31
+Riley,Bala twp,Registered Voters,,,Registered Voters,438
+Riley,Bala twp,Ballots Cast,,Rep,Ballots Cast,134
+Riley,Bala twp,Ballots Cast,,Dem,Ballots Cast,24
+Riley,Bala twp,US House,1,Dem,Alan LaPolice,22
+Riley,Bala twp,Governor,,Dem,Joshua Svaty,9
+Riley,Bala twp,Governor,,Dem,Arden Andersen,1
+Riley,Bala twp,Governor,,Dem,Jack Bergeson,0
+Riley,Bala twp,Governor,,Dem,Carl Brewer,2
+Riley,Bala twp,Governor,,Dem,Laura Kelly,12
+Riley,Bala twp,Secretary of State,,Dem,Brian McClendon,22
+Riley,Bala twp,Attorney General,,Dem,Sarah Swain,24
+Riley,Bala twp,State Treasurer,,Dem,Marci Francisco,22
+Riley,Bala twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,23
+Riley,Bala twp,State House,64,Dem,write-in,0
+Riley,Bala twp,US House,1,Rep,Nick Reinecker,19
+Riley,Bala twp,US House,1,Rep,Roger Marshall,112
+Riley,Bala twp,Governor,,Rep,Ken Selzer,7
+Riley,Bala twp,Governor,,Rep,Joseph Tutera,0
+Riley,Bala twp,Governor,,Rep,Jim Barnett,7
+Riley,Bala twp,Governor,,Rep,Jeff Colyer,57
+Riley,Bala twp,Governor,,Rep,Kris Kobach,62
+Riley,Bala twp,Governor,,Rep,Patrick Kucera,0
+Riley,Bala twp,Governor,,Rep,Tyler Ruzich,1
+Riley,Bala twp,Secretary of  State,,Rep,Dennis Taylor,48
+Riley,Bala twp,Secretary of  State,,Rep,Randy Duncan,39
+Riley,Bala twp,Secretary of  State,,Rep,Keith Esau,1
+Riley,Bala twp,Secretary of  State,,Rep,Craig McCullah,21
+Riley,Bala twp,Secretary of  State,,Rep,Scott Schwab,22
+Riley,Bala twp,Attorney General,,Rep,Derek Schmidt,119
+Riley,Bala twp,State Treasurer,,Rep,Jake LaTurner,114
+Riley,Bala twp,Insurance Commissioner,,Rep,Clark Shultz,66
+Riley,Bala twp,Insurance Commissioner,,Rep,Vicki Schmidt,62
+Riley,Bala twp,State House,64,Rep,Suzi Carlson,43
+Riley,Bala twp,State House,64,Rep,Kathy Martin,91
+Riley,Center twp,Registered Voters,,,Registered Voters,47
+Riley,Center twp,Ballots Cast,,Rep,Ballots Cast,15
+Riley,Center twp,Ballots Cast,,Dem,Ballots Cast,3
+Riley,Center twp,US House,1,Dem,Alan LaPolice,2
+Riley,Center twp,Governor,,Dem,Joshua Svaty,3
+Riley,Center twp,Governor,,Dem,Arden Andersen,0
+Riley,Center twp,Governor,,Dem,Jack Bergeson,0
+Riley,Center twp,Governor,,Dem,Carl Brewer,0
+Riley,Center twp,Governor,,Dem,Laura Kelly,0
+Riley,Center twp,Secretary of State,,Dem,Brian McClendon,1
+Riley,Center twp,Attorney General,,Dem,Sarah Swain,1
+Riley,Center twp,State Treasurer,,Dem,Marci Francisco,2
+Riley,Center twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,2
+Riley,Center twp,State House,64,Dem,write-in,0
+Riley,Center twp,US House,1,Rep,Nick Reinecker,2
+Riley,Center twp,US House,1,Rep,Roger Marshall,13
+Riley,Center twp,Governor,,Rep,Ken Selzer,1
+Riley,Center twp,Governor,,Rep,Joseph Tutera,0
+Riley,Center twp,Governor,,Rep,Jim Barnett,0
+Riley,Center twp,Governor,,Rep,Jeff Colyer,6
+Riley,Center twp,Governor,,Rep,Kris Kobach,6
+Riley,Center twp,Governor,,Rep,Patrick Kucera,0
+Riley,Center twp,Governor,,Rep,Tyler Ruzich,0
+Riley,Center twp,Secretary of  State,,Rep,Dennis Taylor,7
+Riley,Center twp,Secretary of  State,,Rep,Randy Duncan,4
+Riley,Center twp,Secretary of  State,,Rep,Keith Esau,0
+Riley,Center twp,Secretary of  State,,Rep,Craig McCullah,0
+Riley,Center twp,Secretary of  State,,Rep,Scott Schwab,2
+Riley,Center twp,Attorney General,,Rep,Derek Schmidt,13
+Riley,Center twp,State Treasurer,,Rep,Jake LaTurner,12
+Riley,Center twp,Insurance Commissioner,,Rep,Clark Shultz,8
+Riley,Center twp,Insurance Commissioner,,Rep,Vicki Schmidt,4
+Riley,Center twp,State House,64,Rep,Suzi Carlson,6
+Riley,Center twp,State House,64,Rep,Kathy Martin,7
+Riley,Fancy Creek twp,Registered Voters,,,Registered Voters,70
+Riley,Fancy Creek twp,Ballots Cast,,Rep,Ballots Cast,36
+Riley,Fancy Creek twp,Ballots Cast,,Dem,Ballots Cast,1
+Riley,Fancy Creek twp,US House,1,Dem,Alan LaPolice,1
+Riley,Fancy Creek twp,Governor,,Dem,Joshua Svaty,0
+Riley,Fancy Creek twp,Governor,,Dem,Arden Andersen,0
+Riley,Fancy Creek twp,Governor,,Dem,Jack Bergeson,0
+Riley,Fancy Creek twp,Governor,,Dem,Carl Brewer,0
+Riley,Fancy Creek twp,Governor,,Dem,Laura Kelly,1
+Riley,Fancy Creek twp,Secretary of State,,Dem,Brian McClendon,1
+Riley,Fancy Creek twp,Attorney General,,Dem,Sarah Swain,1
+Riley,Fancy Creek twp,State Treasurer,,Dem,Marci Francisco,1
+Riley,Fancy Creek twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,1
+Riley,Fancy Creek twp,State House,64,Dem,write-in,0
+Riley,Fancy Creek twp,US House,1,Rep,Nick Reinecker,10
+Riley,Fancy Creek twp,US House,1,Rep,Roger Marshall,24
+Riley,Fancy Creek twp,Governor,,Rep,Ken Selzer,8
+Riley,Fancy Creek twp,Governor,,Rep,Joseph Tutera,0
+Riley,Fancy Creek twp,Governor,,Rep,Jim Barnett,1
+Riley,Fancy Creek twp,Governor,,Rep,Jeff Colyer,8
+Riley,Fancy Creek twp,Governor,,Rep,Kris Kobach,19
+Riley,Fancy Creek twp,Governor,,Rep,Patrick Kucera,0
+Riley,Fancy Creek twp,Governor,,Rep,Tyler Ruzich,0
+Riley,Fancy Creek twp,Secretary of  State,,Rep,Dennis Taylor,11
+Riley,Fancy Creek twp,Secretary of  State,,Rep,Randy Duncan,5
+Riley,Fancy Creek twp,Secretary of  State,,Rep,Keith Esau,1
+Riley,Fancy Creek twp,Secretary of  State,,Rep,Craig McCullah,5
+Riley,Fancy Creek twp,Secretary of  State,,Rep,Scott Schwab,11
+Riley,Fancy Creek twp,Attorney General,,Rep,Derek Schmidt,30
+Riley,Fancy Creek twp,State Treasurer,,Rep,Jake LaTurner,29
+Riley,Fancy Creek twp,Insurance Commissioner,,Rep,Clark Shultz,25
+Riley,Fancy Creek twp,Insurance Commissioner,,Rep,Vicki Schmidt,9
+Riley,Fancy Creek twp,State House,64,Rep,Suzi Carlson,7
+Riley,Fancy Creek twp,State House,64,Rep,Kathy Martin,26
+Riley,Grant twp,Registered Voters,,,Registered Voters,761
+Riley,Grant twp,Ballots Cast,,Rep,Ballots Cast,214
+Riley,Grant twp,Ballots Cast,,Dem,Ballots Cast,59
+Riley,Grant twp,US House,1,Dem,Alan LaPolice,47
+Riley,Grant twp,Governor,,Dem,Joshua Svaty,15
+Riley,Grant twp,Governor,,Dem,Arden Andersen,0
+Riley,Grant twp,Governor,,Dem,Jack Bergeson,0
+Riley,Grant twp,Governor,,Dem,Carl Brewer,7
+Riley,Grant twp,Governor,,Dem,Laura Kelly,37
+Riley,Grant twp,Secretary of State,,Dem,Brian McClendon,50
+Riley,Grant twp,Attorney General,,Dem,Sarah Swain,51
+Riley,Grant twp,State Treasurer,,Dem,Marci Francisco,51
+Riley,Grant twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,50
+Riley,Grant twp,State House,67,Dem,Alex Van Dyke,53
+Riley,Grant twp,US House,1,Rep,Nick Reinecker,52
+Riley,Grant twp,US House,1,Rep,Roger Marshall,156
+Riley,Grant twp,Governor,,Rep,Ken Selzer,40
+Riley,Grant twp,Governor,,Rep,Joseph Tutera,1
+Riley,Grant twp,Governor,,Rep,Jim Barnett,9
+Riley,Grant twp,Governor,,Rep,Jeff Colyer,83
+Riley,Grant twp,Governor,,Rep,Kris Kobach,78
+Riley,Grant twp,Governor,,Rep,Patrick Kucera,3
+Riley,Grant twp,Governor,,Rep,Tyler Ruzich,0
+Riley,Grant twp,Secretary of  State,,Rep,Dennis Taylor,69
+Riley,Grant twp,Secretary of  State,,Rep,Randy Duncan,37
+Riley,Grant twp,Secretary of  State,,Rep,Keith Esau,13
+Riley,Grant twp,Secretary of  State,,Rep,Craig McCullah,36
+Riley,Grant twp,Secretary of  State,,Rep,Scott Schwab,46
+Riley,Grant twp,Attorney General,,Rep,Derek Schmidt,192
+Riley,Grant twp,State Treasurer,,Rep,Jake LaTurner,181
+Riley,Grant twp,Insurance Commissioner,,Rep,Clark Shultz,109
+Riley,Grant twp,Insurance Commissioner,,Rep,Vicki Schmidt,94
+Riley,Grant twp,State House,67,Rep,Tom Phillips,189
+Riley,Jackson twp,Registered Voters,,,Registered Voters,221
+Riley,Jackson twp,Ballots Cast,,Rep,Ballots Cast,69
+Riley,Jackson twp,Ballots Cast,,Dem,Ballots Cast,12
+Riley,Jackson twp,US House,1,Dem,Alan LaPolice,10
+Riley,Jackson twp,Governor,,Dem,Joshua Svaty,6
+Riley,Jackson twp,Governor,,Dem,Arden Andersen,0
+Riley,Jackson twp,Governor,,Dem,Jack Bergeson,0
+Riley,Jackson twp,Governor,,Dem,Carl Brewer,0
+Riley,Jackson twp,Governor,,Dem,Laura Kelly,5
+Riley,Jackson twp,Secretary of State,,Dem,Brian McClendon,11
+Riley,Jackson twp,Attorney General,,Dem,Sarah Swain,11
+Riley,Jackson twp,State Treasurer,,Dem,Marci Francisco,11
+Riley,Jackson twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,8
+Riley,Jackson twp,State House,64,Dem,write-in,1
+Riley,Jackson twp,US House,1,Rep,Nick Reinecker,9
+Riley,Jackson twp,US House,1,Rep,Roger Marshall,53
+Riley,Jackson twp,Governor,,Rep,Ken Selzer,15
+Riley,Jackson twp,Governor,,Rep,Joseph Tutera,0
+Riley,Jackson twp,Governor,,Rep,Jim Barnett,4
+Riley,Jackson twp,Governor,,Rep,Jeff Colyer,26
+Riley,Jackson twp,Governor,,Rep,Kris Kobach,23
+Riley,Jackson twp,Governor,,Rep,Patrick Kucera,1
+Riley,Jackson twp,Governor,,Rep,Tyler Ruzich,0
+Riley,Jackson twp,Secretary of  State,,Rep,Dennis Taylor,24
+Riley,Jackson twp,Secretary of  State,,Rep,Randy Duncan,16
+Riley,Jackson twp,Secretary of  State,,Rep,Keith Esau,0
+Riley,Jackson twp,Secretary of  State,,Rep,Craig McCullah,6
+Riley,Jackson twp,Secretary of  State,,Rep,Scott Schwab,13
+Riley,Jackson twp,Attorney General,,Rep,Derek Schmidt,57
+Riley,Jackson twp,State Treasurer,,Rep,Jake LaTurner,56
+Riley,Jackson twp,Insurance Commissioner,,Rep,Clark Shultz,35
+Riley,Jackson twp,Insurance Commissioner,,Rep,Vicki Schmidt,25
+Riley,Jackson twp,State House,64,Rep,Suzi Carlson,42
+Riley,Jackson twp,State House,64,Rep,Kathy Martin,20
+Riley,Madison twp H64,Registered Voters,,,Registered Voters,746
+Riley,Madison twp H64,Ballots Cast,,Rep,Ballots Cast,180
+Riley,Madison twp H64,Ballots Cast,,Dem,Ballots Cast,39
+Riley,Madison twp H64,US House,1,Dem,Alan LaPolice,34
+Riley,Madison twp H64,Governor,,Dem,Joshua Svaty,11
+Riley,Madison twp H64,Governor,,Dem,Arden Andersen,1
+Riley,Madison twp H64,Governor,,Dem,Jack Bergeson,1
+Riley,Madison twp H64,Governor,,Dem,Carl Brewer,2
+Riley,Madison twp H64,Governor,,Dem,Laura Kelly,21
+Riley,Madison twp H64,Secretary of State,,Dem,Brian McClendon,32
+Riley,Madison twp H64,Attorney General,,Dem,Sarah Swain,34
+Riley,Madison twp H64,State Treasurer,,Dem,Marci Francisco,33
+Riley,Madison twp H64,Insurance Commissioner,,Dem,Nathaniel McLaughlin,33
+Riley,Madison twp H64,State House,64,Dem,write-in,1
+Riley,Madison twp H64,US House,1,Rep,Nick Reinecker,46
+Riley,Madison twp H64,US House,1,Rep,Roger Marshall,127
+Riley,Madison twp H64,Governor,,Rep,Ken Selzer,17
+Riley,Madison twp H64,Governor,,Rep,Joseph Tutera,0
+Riley,Madison twp H64,Governor,,Rep,Jim Barnett,15
+Riley,Madison twp H64,Governor,,Rep,Jeff Colyer,78
+Riley,Madison twp H64,Governor,,Rep,Kris Kobach,70
+Riley,Madison twp H64,Governor,,Rep,Patrick Kucera,0
+Riley,Madison twp H64,Governor,,Rep,Tyler Ruzich,0
+Riley,Madison twp H64,Secretary of  State,,Rep,Dennis Taylor,63
+Riley,Madison twp H64,Secretary of  State,,Rep,Randy Duncan,43
+Riley,Madison twp H64,Secretary of  State,,Rep,Keith Esau,9
+Riley,Madison twp H64,Secretary of  State,,Rep,Craig McCullah,22
+Riley,Madison twp H64,Secretary of  State,,Rep,Scott Schwab,26
+Riley,Madison twp H64,Attorney General,,Rep,Derek Schmidt,163
+Riley,Madison twp H64,State Treasurer,,Rep,Jake LaTurner,155
+Riley,Madison twp H64,Insurance Commissioner,,Rep,Clark Shultz,79
+Riley,Madison twp H64,Insurance Commissioner,,Rep,Vicki Schmidt,91
+Riley,Madison twp H64,State House,64,Rep,Suzi Carlson,98
+Riley,Madison twp H64,State House,64,Rep,Kathy Martin,77
+Riley,Madison twp H67,Registered Voters,,,Registered Voters,23
+Riley,Madison twp H67,Ballots Cast,,Rep,Ballots Cast,8
+Riley,Madison twp H67,Ballots Cast,,Dem,Ballots Cast,0
+Riley,Madison twp H67,US House,1,Dem,Alan LaPolice,0
+Riley,Madison twp H67,Governor,,Dem,Joshua Svaty,0
+Riley,Madison twp H67,Governor,,Dem,Arden Andersen,0
+Riley,Madison twp H67,Governor,,Dem,Jack Bergeson,0
+Riley,Madison twp H67,Governor,,Dem,Carl Brewer,0
+Riley,Madison twp H67,Governor,,Dem,Laura Kelly,0
+Riley,Madison twp H67,Secretary of State,,Dem,Brian McClendon,0
+Riley,Madison twp H67,Attorney General,,Dem,Sarah Swain,0
+Riley,Madison twp H67,State Treasurer,,Dem,Marci Francisco,0
+Riley,Madison twp H67,Insurance Commissioner,,Dem,Nathaniel McLaughlin,0
+Riley,Madison twp H67,State House,67,Dem,Alex Van Dyke,0
+Riley,Madison twp H67,US House,1,Rep,Nick Reinecker,2
+Riley,Madison twp H67,US House,1,Rep,Roger Marshall,5
+Riley,Madison twp H67,Governor,,Rep,Ken Selzer,1
+Riley,Madison twp H67,Governor,,Rep,Joseph Tutera,0
+Riley,Madison twp H67,Governor,,Rep,Jim Barnett,0
+Riley,Madison twp H67,Governor,,Rep,Jeff Colyer,5
+Riley,Madison twp H67,Governor,,Rep,Kris Kobach,2
+Riley,Madison twp H67,Governor,,Rep,Patrick Kucera,0
+Riley,Madison twp H67,Governor,,Rep,Tyler Ruzich,0
+Riley,Madison twp H67,Secretary of  State,,Rep,Dennis Taylor,4
+Riley,Madison twp H67,Secretary of  State,,Rep,Randy Duncan,1
+Riley,Madison twp H67,Secretary of  State,,Rep,Keith Esau,0
+Riley,Madison twp H67,Secretary of  State,,Rep,Craig McCullah,0
+Riley,Madison twp H67,Secretary of  State,,Rep,Scott Schwab,1
+Riley,Madison twp H67,Attorney General,,Rep,Derek Schmidt,7
+Riley,Madison twp H67,State Treasurer,,Rep,Jake LaTurner,5
+Riley,Madison twp H67,Insurance Commissioner,,Rep,Clark Shultz,4
+Riley,Madison twp H67,Insurance Commissioner,,Rep,Vicki Schmidt,3
+Riley,Madison twp H67,State House,67,Rep,Tom Phillips,8
+Riley,Manhattan twp 1,Registered Voters,,,Registered Voters,376
+Riley,Manhattan twp 1,Ballots Cast,,Rep,Ballots Cast,102
+Riley,Manhattan twp 1,Ballots Cast,,Dem,Ballots Cast,28
+Riley,Manhattan twp 1,US House,1,Dem,Alan LaPolice,27
+Riley,Manhattan twp 1,Governor,,Dem,Joshua Svaty,12
+Riley,Manhattan twp 1,Governor,,Dem,Arden Andersen,0
+Riley,Manhattan twp 1,Governor,,Dem,Jack Bergeson,0
+Riley,Manhattan twp 1,Governor,,Dem,Carl Brewer,1
+Riley,Manhattan twp 1,Governor,,Dem,Laura Kelly,15
+Riley,Manhattan twp 1,Secretary of State,,Dem,Brian McClendon,26
+Riley,Manhattan twp 1,Attorney General,,Dem,Sarah Swain,26
+Riley,Manhattan twp 1,State Treasurer,,Dem,Marci Francisco,26
+Riley,Manhattan twp 1,Insurance Commissioner,,Dem,Nathaniel McLaughlin,24
+Riley,Manhattan twp 1,State House,66,Dem,Sydney Carlin,28
+Riley,Manhattan twp 1,US House,1,Rep,Nick Reinecker,19
+Riley,Manhattan twp 1,US House,1,Rep,Roger Marshall,81
+Riley,Manhattan twp 1,Governor,,Rep,Ken Selzer,12
+Riley,Manhattan twp 1,Governor,,Rep,Joseph Tutera,1
+Riley,Manhattan twp 1,Governor,,Rep,Jim Barnett,13
+Riley,Manhattan twp 1,Governor,,Rep,Jeff Colyer,40
+Riley,Manhattan twp 1,Governor,,Rep,Kris Kobach,33
+Riley,Manhattan twp 1,Governor,,Rep,Patrick Kucera,1
+Riley,Manhattan twp 1,Governor,,Rep,Tyler Ruzich,1
+Riley,Manhattan twp 1,Secretary of  State,,Rep,Dennis Taylor,34
+Riley,Manhattan twp 1,Secretary of  State,,Rep,Randy Duncan,23
+Riley,Manhattan twp 1,Secretary of  State,,Rep,Keith Esau,3
+Riley,Manhattan twp 1,Secretary of  State,,Rep,Craig McCullah,12
+Riley,Manhattan twp 1,Secretary of  State,,Rep,Scott Schwab,19
+Riley,Manhattan twp 1,Attorney General,,Rep,Derek Schmidt,83
+Riley,Manhattan twp 1,State Treasurer,,Rep,Jake LaTurner,77
+Riley,Manhattan twp 1,Insurance Commissioner,,Rep,Clark Shultz,43
+Riley,Manhattan twp 1,Insurance Commissioner,,Rep,Vicki Schmidt,51
+Riley,Manhattan twp 1,State House,66,Rep,write-in,3
+Riley,Manhattan twp 2,Registered Voters,,,Registered Voters,390
+Riley,Manhattan twp 2,Ballots Cast,,Rep,Ballots Cast,85
+Riley,Manhattan twp 2,Ballots Cast,,Dem,Ballots Cast,39
+Riley,Manhattan twp 2,US House,1,Dem,Alan LaPolice,32
+Riley,Manhattan twp 2,Governor,,Dem,Joshua Svaty,8
+Riley,Manhattan twp 2,Governor,,Dem,Arden Andersen,0
+Riley,Manhattan twp 2,Governor,,Dem,Jack Bergeson,1
+Riley,Manhattan twp 2,Governor,,Dem,Carl Brewer,3
+Riley,Manhattan twp 2,Governor,,Dem,Laura Kelly,27
+Riley,Manhattan twp 2,Secretary of State,,Dem,Brian McClendon,33
+Riley,Manhattan twp 2,Attorney General,,Dem,Sarah Swain,33
+Riley,Manhattan twp 2,State Treasurer,,Dem,Marci Francisco,34
+Riley,Manhattan twp 2,Insurance Commissioner,,Dem,Nathaniel McLaughlin,33
+Riley,Manhattan twp 2,State House,67,Dem,Alex Van Dyke,36
+Riley,Manhattan twp 2,US House,1,Rep,Nick Reinecker,13
+Riley,Manhattan twp 2,US House,1,Rep,Roger Marshall,67
+Riley,Manhattan twp 2,Governor,,Rep,Ken Selzer,8
+Riley,Manhattan twp 2,Governor,,Rep,Joseph Tutera,0
+Riley,Manhattan twp 2,Governor,,Rep,Jim Barnett,4
+Riley,Manhattan twp 2,Governor,,Rep,Jeff Colyer,45
+Riley,Manhattan twp 2,Governor,,Rep,Kris Kobach,28
+Riley,Manhattan twp 2,Governor,,Rep,Patrick Kucera,0
+Riley,Manhattan twp 2,Governor,,Rep,Tyler Ruzich,0
+Riley,Manhattan twp 2,Secretary of  State,,Rep,Dennis Taylor,34
+Riley,Manhattan twp 2,Secretary of  State,,Rep,Randy Duncan,18
+Riley,Manhattan twp 2,Secretary of  State,,Rep,Keith Esau,3
+Riley,Manhattan twp 2,Secretary of  State,,Rep,Craig McCullah,14
+Riley,Manhattan twp 2,Secretary of  State,,Rep,Scott Schwab,10
+Riley,Manhattan twp 2,Attorney General,,Rep,Derek Schmidt,72
+Riley,Manhattan twp 2,State Treasurer,,Rep,Jake LaTurner,68
+Riley,Manhattan twp 2,Insurance Commissioner,,Rep,Clark Shultz,32
+Riley,Manhattan twp 2,Insurance Commissioner,,Rep,Vicki Schmidt,47
+Riley,Manhattan twp 2,State House,67,Rep,Tom Phillips,76
+Riley,Manhattan twp 3,Registered Voters,,,Registered Voters,159
+Riley,Manhattan twp 3,Ballots Cast,,Rep,Ballots Cast,35
+Riley,Manhattan twp 3,Ballots Cast,,Dem,Ballots Cast,16
+Riley,Manhattan twp 3,US House,1,Dem,Alan LaPolice,14
+Riley,Manhattan twp 3,Governor,,Dem,Joshua Svaty,7
+Riley,Manhattan twp 3,Governor,,Dem,Arden Andersen,1
+Riley,Manhattan twp 3,Governor,,Dem,Jack Bergeson,0
+Riley,Manhattan twp 3,Governor,,Dem,Carl Brewer,0
+Riley,Manhattan twp 3,Governor,,Dem,Laura Kelly,8
+Riley,Manhattan twp 3,Secretary of State,,Dem,Brian McClendon,15
+Riley,Manhattan twp 3,Attorney General,,Dem,Sarah Swain,16
+Riley,Manhattan twp 3,State Treasurer,,Dem,Marci Francisco,15
+Riley,Manhattan twp 3,Insurance Commissioner,,Dem,Nathaniel McLaughlin,15
+Riley,Manhattan twp 3,State House,67,Dem,Alex Van Dyke,16
+Riley,Manhattan twp 3,US House,1,Rep,Nick Reinecker,8
+Riley,Manhattan twp 3,US House,1,Rep,Roger Marshall,25
+Riley,Manhattan twp 3,Governor,,Rep,Ken Selzer,1
+Riley,Manhattan twp 3,Governor,,Rep,Joseph Tutera,0
+Riley,Manhattan twp 3,Governor,,Rep,Jim Barnett,6
+Riley,Manhattan twp 3,Governor,,Rep,Jeff Colyer,16
+Riley,Manhattan twp 3,Governor,,Rep,Kris Kobach,11
+Riley,Manhattan twp 3,Governor,,Rep,Patrick Kucera,1
+Riley,Manhattan twp 3,Governor,,Rep,Tyler Ruzich,0
+Riley,Manhattan twp 3,Secretary of  State,,Rep,Dennis Taylor,18
+Riley,Manhattan twp 3,Secretary of  State,,Rep,Randy Duncan,5
+Riley,Manhattan twp 3,Secretary of  State,,Rep,Keith Esau,2
+Riley,Manhattan twp 3,Secretary of  State,,Rep,Craig McCullah,2
+Riley,Manhattan twp 3,Secretary of  State,,Rep,Scott Schwab,5
+Riley,Manhattan twp 3,Attorney General,,Rep,Derek Schmidt,25
+Riley,Manhattan twp 3,State Treasurer,,Rep,Jake LaTurner,21
+Riley,Manhattan twp 3,Insurance Commissioner,,Rep,Clark Shultz,11
+Riley,Manhattan twp 3,Insurance Commissioner,,Rep,Vicki Schmidt,21
+Riley,Manhattan twp 3,State House,67,Rep,Tom Phillips,30
+Riley,Manhattan twp 4,Registered Voters,,,Registered Voters,533
+Riley,Manhattan twp 4,Ballots Cast,,Rep,Ballots Cast,66
+Riley,Manhattan twp 4,Ballots Cast,,Dem,Ballots Cast,32
+Riley,Manhattan twp 4,US House,1,Dem,Alan LaPolice,26
+Riley,Manhattan twp 4,Governor,,Dem,Joshua Svaty,12
+Riley,Manhattan twp 4,Governor,,Dem,Arden Andersen,3
+Riley,Manhattan twp 4,Governor,,Dem,Jack Bergeson,0
+Riley,Manhattan twp 4,Governor,,Dem,Carl Brewer,4
+Riley,Manhattan twp 4,Governor,,Dem,Laura Kelly,12
+Riley,Manhattan twp 4,Secretary of State,,Dem,Brian McClendon,26
+Riley,Manhattan twp 4,Attorney General,,Dem,Sarah Swain,28
+Riley,Manhattan twp 4,State Treasurer,,Dem,Marci Francisco,26
+Riley,Manhattan twp 4,Insurance Commissioner,,Dem,Nathaniel McLaughlin,28
+Riley,Manhattan twp 4,State House,66,Dem,Sydney Carlin,28
+Riley,Manhattan twp 4,US House,1,Rep,Nick Reinecker,15
+Riley,Manhattan twp 4,US House,1,Rep,Roger Marshall,49
+Riley,Manhattan twp 4,Governor,,Rep,Ken Selzer,8
+Riley,Manhattan twp 4,Governor,,Rep,Joseph Tutera,1
+Riley,Manhattan twp 4,Governor,,Rep,Jim Barnett,7
+Riley,Manhattan twp 4,Governor,,Rep,Jeff Colyer,21
+Riley,Manhattan twp 4,Governor,,Rep,Kris Kobach,28
+Riley,Manhattan twp 4,Governor,,Rep,Patrick Kucera,0
+Riley,Manhattan twp 4,Governor,,Rep,Tyler Ruzich,1
+Riley,Manhattan twp 4,Secretary of  State,,Rep,Dennis Taylor,30
+Riley,Manhattan twp 4,Secretary of  State,,Rep,Randy Duncan,12
+Riley,Manhattan twp 4,Secretary of  State,,Rep,Keith Esau,0
+Riley,Manhattan twp 4,Secretary of  State,,Rep,Craig McCullah,12
+Riley,Manhattan twp 4,Secretary of  State,,Rep,Scott Schwab,5
+Riley,Manhattan twp 4,Attorney General,,Rep,Derek Schmidt,60
+Riley,Manhattan twp 4,State Treasurer,,Rep,Jake LaTurner,53
+Riley,Manhattan twp 4,Insurance Commissioner,,Rep,Clark Shultz,31
+Riley,Manhattan twp 4,Insurance Commissioner,,Rep,Vicki Schmidt,29
+Riley,Manhattan twp 4,State House,66,Rep,write-in,6
+Riley,May Day twp,Registered Voters,,,Registered Voters,45
+Riley,May Day twp,Ballots Cast,,Rep,Ballots Cast,16
+Riley,May Day twp,Ballots Cast,,Dem,Ballots Cast,3
+Riley,May Day twp,US House,1,Dem,Alan LaPolice,2
+Riley,May Day twp,Governor,,Dem,Joshua Svaty,1
+Riley,May Day twp,Governor,,Dem,Arden Andersen,0
+Riley,May Day twp,Governor,,Dem,Jack Bergeson,1
+Riley,May Day twp,Governor,,Dem,Carl Brewer,0
+Riley,May Day twp,Governor,,Dem,Laura Kelly,1
+Riley,May Day twp,Secretary of State,,Dem,Brian McClendon,2
+Riley,May Day twp,Attorney General,,Dem,Sarah Swain,3
+Riley,May Day twp,State Treasurer,,Dem,Marci Francisco,2
+Riley,May Day twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,2
+Riley,May Day twp,State House,64,Dem,write-in,1
+Riley,May Day twp,US House,1,Rep,Nick Reinecker,2
+Riley,May Day twp,US House,1,Rep,Roger Marshall,13
+Riley,May Day twp,Governor,,Rep,Ken Selzer,1
+Riley,May Day twp,Governor,,Rep,Joseph Tutera,0
+Riley,May Day twp,Governor,,Rep,Jim Barnett,1
+Riley,May Day twp,Governor,,Rep,Jeff Colyer,11
+Riley,May Day twp,Governor,,Rep,Kris Kobach,3
+Riley,May Day twp,Governor,,Rep,Patrick Kucera,0
+Riley,May Day twp,Governor,,Rep,Tyler Ruzich,0
+Riley,May Day twp,Secretary of  State,,Rep,Dennis Taylor,5
+Riley,May Day twp,Secretary of  State,,Rep,Randy Duncan,6
+Riley,May Day twp,Secretary of  State,,Rep,Keith Esau,0
+Riley,May Day twp,Secretary of  State,,Rep,Craig McCullah,2
+Riley,May Day twp,Secretary of  State,,Rep,Scott Schwab,2
+Riley,May Day twp,Attorney General,,Rep,Derek Schmidt,15
+Riley,May Day twp,State Treasurer,,Rep,Jake LaTurner,15
+Riley,May Day twp,Insurance Commissioner,,Rep,Clark Shultz,4
+Riley,May Day twp,Insurance Commissioner,,Rep,Vicki Schmidt,11
+Riley,May Day twp,State House,64,Rep,Suzi Carlson,11
+Riley,May Day twp,State House,64,Rep,Kathy Martin,5
+Riley,Ogden twp,Registered Voters,,,Registered Voters,286
+Riley,Ogden twp,Ballots Cast,,Rep,Ballots Cast,71
+Riley,Ogden twp,Ballots Cast,,Dem,Ballots Cast,12
+Riley,Ogden twp,US House,1,Dem,Alan LaPolice,12
+Riley,Ogden twp,Governor,,Dem,Joshua Svaty,5
+Riley,Ogden twp,Governor,,Dem,Arden Andersen,0
+Riley,Ogden twp,Governor,,Dem,Jack Bergeson,0
+Riley,Ogden twp,Governor,,Dem,Carl Brewer,3
+Riley,Ogden twp,Governor,,Dem,Laura Kelly,4
+Riley,Ogden twp,Secretary of State,,Dem,Brian McClendon,11
+Riley,Ogden twp,Attorney General,,Dem,Sarah Swain,12
+Riley,Ogden twp,State Treasurer,,Dem,Marci Francisco,11
+Riley,Ogden twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,12
+Riley,Ogden twp,State House,64,Dem,write-in,0
+Riley,Ogden twp,US House,1,Rep,Nick Reinecker,24
+Riley,Ogden twp,US House,1,Rep,Roger Marshall,44
+Riley,Ogden twp,Governor,,Rep,Ken Selzer,10
+Riley,Ogden twp,Governor,,Rep,Joseph Tutera,0
+Riley,Ogden twp,Governor,,Rep,Jim Barnett,9
+Riley,Ogden twp,Governor,,Rep,Jeff Colyer,19
+Riley,Ogden twp,Governor,,Rep,Kris Kobach,32
+Riley,Ogden twp,Governor,,Rep,Patrick Kucera,1
+Riley,Ogden twp,Governor,,Rep,Tyler Ruzich,0
+Riley,Ogden twp,Secretary of  State,,Rep,Dennis Taylor,20
+Riley,Ogden twp,Secretary of  State,,Rep,Randy Duncan,11
+Riley,Ogden twp,Secretary of  State,,Rep,Keith Esau,5
+Riley,Ogden twp,Secretary of  State,,Rep,Craig McCullah,11
+Riley,Ogden twp,Secretary of  State,,Rep,Scott Schwab,12
+Riley,Ogden twp,Attorney General,,Rep,Derek Schmidt,62
+Riley,Ogden twp,State Treasurer,,Rep,Jake LaTurner,59
+Riley,Ogden twp,Insurance Commissioner,,Rep,Clark Shultz,31
+Riley,Ogden twp,Insurance Commissioner,,Rep,Vicki Schmidt,35
+Riley,Ogden twp,State House,64,Rep,Suzi Carlson,30
+Riley,Ogden twp,State House,64,Rep,Kathy Martin,35
+Riley,Ogden Ft Riley A,Registered Voters,,,Registered Voters,776
+Riley,Ogden Ft Riley A,Ballots Cast,,Rep,Ballots Cast,63
+Riley,Ogden Ft Riley A,Ballots Cast,,Dem,Ballots Cast,37
+Riley,Ogden Ft Riley A,US House,1,Dem,Alan LaPolice,27
+Riley,Ogden Ft Riley A,Governor,,Dem,Joshua Svaty,10
+Riley,Ogden Ft Riley A,Governor,,Dem,Arden Andersen,3
+Riley,Ogden Ft Riley A,Governor,,Dem,Jack Bergeson,2
+Riley,Ogden Ft Riley A,Governor,,Dem,Carl Brewer,9
+Riley,Ogden Ft Riley A,Governor,,Dem,Laura Kelly,13
+Riley,Ogden Ft Riley A,Secretary of State,,Dem,Brian McClendon,31
+Riley,Ogden Ft Riley A,Attorney General,,Dem,Sarah Swain,27
+Riley,Ogden Ft Riley A,State Treasurer,,Dem,Marci Francisco,27
+Riley,Ogden Ft Riley A,Insurance Commissioner,,Dem,Nathaniel McLaughlin,29
+Riley,Ogden Ft Riley A,State House,64,Dem,write-in,2
+Riley,Ogden Ft Riley A,US House,1,Rep,Nick Reinecker,17
+Riley,Ogden Ft Riley A,US House,1,Rep,Roger Marshall,42
+Riley,Ogden Ft Riley A,Governor,,Rep,Ken Selzer,5
+Riley,Ogden Ft Riley A,Governor,,Rep,Joseph Tutera,0
+Riley,Ogden Ft Riley A,Governor,,Rep,Jim Barnett,9
+Riley,Ogden Ft Riley A,Governor,,Rep,Jeff Colyer,16
+Riley,Ogden Ft Riley A,Governor,,Rep,Kris Kobach,32
+Riley,Ogden Ft Riley A,Governor,,Rep,Patrick Kucera,0
+Riley,Ogden Ft Riley A,Governor,,Rep,Tyler Ruzich,1
+Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Dennis Taylor,18
+Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Randy Duncan,15
+Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Keith Esau,2
+Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Craig McCullah,10
+Riley,Ogden Ft Riley A,Secretary of  State,,Rep,Scott Schwab,13
+Riley,Ogden Ft Riley A,Attorney General,,Rep,Derek Schmidt,54
+Riley,Ogden Ft Riley A,State Treasurer,,Rep,Jake LaTurner,51
+Riley,Ogden Ft Riley A,Insurance Commissioner,,Rep,Clark Shultz,24
+Riley,Ogden Ft Riley A,Insurance Commissioner,,Rep,Vicki Schmidt,36
+Riley,Ogden Ft Riley A,State House,64,Rep,Suzi Carlson,24
+Riley,Ogden Ft Riley A,State House,64,Rep,Kathy Martin,34
+Riley,Sherman twp,Registered Voters,,,Registered Voters,430
+Riley,Sherman twp,Ballots Cast,,Rep,Ballots Cast,90
+Riley,Sherman twp,Ballots Cast,,Dem,Ballots Cast,19
+Riley,Sherman twp,US House,1,Dem,Alan LaPolice,14
+Riley,Sherman twp,Governor,,Dem,Joshua Svaty,3
+Riley,Sherman twp,Governor,,Dem,Arden Andersen,1
+Riley,Sherman twp,Governor,,Dem,Jack Bergeson,0
+Riley,Sherman twp,Governor,,Dem,Carl Brewer,1
+Riley,Sherman twp,Governor,,Dem,Laura Kelly,13
+Riley,Sherman twp,Secretary of State,,Dem,Brian McClendon,14
+Riley,Sherman twp,Attorney General,,Dem,Sarah Swain,15
+Riley,Sherman twp,State Treasurer,,Dem,Marci Francisco,14
+Riley,Sherman twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,15
+Riley,Sherman twp,State House,64,Dem,write-in,0
+Riley,Sherman twp,US House,1,Rep,Nick Reinecker,19
+Riley,Sherman twp,US House,1,Rep,Roger Marshall,68
+Riley,Sherman twp,Governor,,Rep,Ken Selzer,13
+Riley,Sherman twp,Governor,,Rep,Joseph Tutera,1
+Riley,Sherman twp,Governor,,Rep,Jim Barnett,10
+Riley,Sherman twp,Governor,,Rep,Jeff Colyer,37
+Riley,Sherman twp,Governor,,Rep,Kris Kobach,29
+Riley,Sherman twp,Governor,,Rep,Patrick Kucera,0
+Riley,Sherman twp,Governor,,Rep,Tyler Ruzich,0
+Riley,Sherman twp,Secretary of  State,,Rep,Dennis Taylor,25
+Riley,Sherman twp,Secretary of  State,,Rep,Randy Duncan,24
+Riley,Sherman twp,Secretary of  State,,Rep,Keith Esau,7
+Riley,Sherman twp,Secretary of  State,,Rep,Craig McCullah,8
+Riley,Sherman twp,Secretary of  State,,Rep,Scott Schwab,14
+Riley,Sherman twp,Attorney General,,Rep,Derek Schmidt,77
+Riley,Sherman twp,State Treasurer,,Rep,Jake LaTurner,76
+Riley,Sherman twp,Insurance Commissioner,,Rep,Clark Shultz,46
+Riley,Sherman twp,Insurance Commissioner,,Rep,Vicki Schmidt,39
+Riley,Sherman twp,State House,64,Rep,Suzi Carlson,46
+Riley,Sherman twp,State House,64,Rep,Kathy Martin,40
+Riley,Swede Creek,Registered Voters,,,Registered Voters,100
+Riley,Swede Creek,Ballots Cast,,Rep,Ballots Cast,24
+Riley,Swede Creek,Ballots Cast,,Dem,Ballots Cast,7
+Riley,Swede Creek,US House,1,Dem,Alan LaPolice,3
+Riley,Swede Creek,Governor,,Dem,Joshua Svaty,2
+Riley,Swede Creek,Governor,,Dem,Arden Andersen,0
+Riley,Swede Creek,Governor,,Dem,Jack Bergeson,0
+Riley,Swede Creek,Governor,,Dem,Carl Brewer,0
+Riley,Swede Creek,Governor,,Dem,Laura Kelly,4
+Riley,Swede Creek,Secretary of State,,Dem,Brian McClendon,4
+Riley,Swede Creek,Attorney General,,Dem,Sarah Swain,6
+Riley,Swede Creek,State Treasurer,,Dem,Marci Francisco,4
+Riley,Swede Creek,Insurance Commissioner,,Dem,Nathaniel McLaughlin,5
+Riley,Swede Creek,State House,64,Dem,write-in,0
+Riley,Swede Creek,US House,1,Rep,Nick Reinecker,7
+Riley,Swede Creek,US House,1,Rep,Roger Marshall,16
+Riley,Swede Creek,Governor,,Rep,Ken Selzer,3
+Riley,Swede Creek,Governor,,Rep,Joseph Tutera,0
+Riley,Swede Creek,Governor,,Rep,Jim Barnett,1
+Riley,Swede Creek,Governor,,Rep,Jeff Colyer,15
+Riley,Swede Creek,Governor,,Rep,Kris Kobach,3
+Riley,Swede Creek,Governor,,Rep,Patrick Kucera,1
+Riley,Swede Creek,Governor,,Rep,Tyler Ruzich,0
+Riley,Swede Creek,Secretary of  State,,Rep,Dennis Taylor,10
+Riley,Swede Creek,Secretary of  State,,Rep,Randy Duncan,7
+Riley,Swede Creek,Secretary of  State,,Rep,Keith Esau,0
+Riley,Swede Creek,Secretary of  State,,Rep,Craig McCullah,0
+Riley,Swede Creek,Secretary of  State,,Rep,Scott Schwab,2
+Riley,Swede Creek,Attorney General,,Rep,Derek Schmidt,22
+Riley,Swede Creek,State Treasurer,,Rep,Jake LaTurner,22
+Riley,Swede Creek,Insurance Commissioner,,Rep,Clark Shultz,13
+Riley,Swede Creek,Insurance Commissioner,,Rep,Vicki Schmidt,9
+Riley,Swede Creek,State House,64,Rep,Suzi Carlson,17
+Riley,Swede Creek,State House,64,Rep,Kathy Martin,7
+Riley,Wildcat twp,Registered Voters,,,Registered Voters,633
+Riley,Wildcat twp,Ballots Cast,,Rep,Ballots Cast,184
+Riley,Wildcat twp,Ballots Cast,,Dem,Ballots Cast,33
+Riley,Wildcat twp,US House,1,Dem,Alan LaPolice,28
+Riley,Wildcat twp,Governor,,Dem,Joshua Svaty,7
+Riley,Wildcat twp,Governor,,Dem,Arden Andersen,0
+Riley,Wildcat twp,Governor,,Dem,Jack Bergeson,1
+Riley,Wildcat twp,Governor,,Dem,Carl Brewer,3
+Riley,Wildcat twp,Governor,,Dem,Laura Kelly,22
+Riley,Wildcat twp,Secretary of State,,Dem,Brian McClendon,28
+Riley,Wildcat twp,Attorney General,,Dem,Sarah Swain,29
+Riley,Wildcat twp,State Treasurer,,Dem,Marci Francisco,28
+Riley,Wildcat twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,29
+Riley,Wildcat twp,State House,67,Dem,Alex Van Dyke,29
+Riley,Wildcat twp,US House,1,Rep,Nick Reinecker,32
+Riley,Wildcat twp,US House,1,Rep,Roger Marshall,140
+Riley,Wildcat twp,Governor,,Rep,Ken Selzer,23
+Riley,Wildcat twp,Governor,,Rep,Joseph Tutera,1
+Riley,Wildcat twp,Governor,,Rep,Jim Barnett,6
+Riley,Wildcat twp,Governor,,Rep,Jeff Colyer,85
+Riley,Wildcat twp,Governor,,Rep,Kris Kobach,64
+Riley,Wildcat twp,Governor,,Rep,Patrick Kucera,3
+Riley,Wildcat twp,Governor,,Rep,Tyler Ruzich,1
+Riley,Wildcat twp,Secretary of  State,,Rep,Dennis Taylor,70
+Riley,Wildcat twp,Secretary of  State,,Rep,Randy Duncan,35
+Riley,Wildcat twp,Secretary of  State,,Rep,Keith Esau,6
+Riley,Wildcat twp,Secretary of  State,,Rep,Craig McCullah,16
+Riley,Wildcat twp,Secretary of  State,,Rep,Scott Schwab,40
+Riley,Wildcat twp,Attorney General,,Rep,Derek Schmidt,162
+Riley,Wildcat twp,State Treasurer,,Rep,Jake LaTurner,150
+Riley,Wildcat twp,Insurance Commissioner,,Rep,Clark Shultz,83
+Riley,Wildcat twp,Insurance Commissioner,,Rep,Vicki Schmidt,86
+Riley,Wildcat twp,State House,67,Rep,Tom Phillips,169
+Riley,Zeandale twp,Registered Voters,,,Registered Voters,257
+Riley,Zeandale twp,Ballots Cast,,Rep,Ballots Cast,82
+Riley,Zeandale twp,Ballots Cast,,Dem,Ballots Cast,21
+Riley,Zeandale twp,US House,1,Dem,Alan LaPolice,13
+Riley,Zeandale twp,Governor,,Dem,Joshua Svaty,4
+Riley,Zeandale twp,Governor,,Dem,Arden Andersen,1
+Riley,Zeandale twp,Governor,,Dem,Jack Bergeson,0
+Riley,Zeandale twp,Governor,,Dem,Carl Brewer,2
+Riley,Zeandale twp,Governor,,Dem,Laura Kelly,14
+Riley,Zeandale twp,Secretary of State,,Dem,Brian McClendon,16
+Riley,Zeandale twp,Attorney General,,Dem,Sarah Swain,16
+Riley,Zeandale twp,State Treasurer,,Dem,Marci Francisco,16
+Riley,Zeandale twp,Insurance Commissioner,,Dem,Nathaniel McLaughlin,13
+Riley,Zeandale twp,State House,51,Dem,Noah Wright,17
+Riley,Zeandale twp,US House,1,Rep,Nick Reinecker,15
+Riley,Zeandale twp,US House,1,Rep,Roger Marshall,66
+Riley,Zeandale twp,Governor,,Rep,Ken Selzer,7
+Riley,Zeandale twp,Governor,,Rep,Joseph Tutera,0
+Riley,Zeandale twp,Governor,,Rep,Jim Barnett,7
+Riley,Zeandale twp,Governor,,Rep,Jeff Colyer,34
+Riley,Zeandale twp,Governor,,Rep,Kris Kobach,34
+Riley,Zeandale twp,Governor,,Rep,Patrick Kucera,0
+Riley,Zeandale twp,Governor,,Rep,Tyler Ruzich,0
+Riley,Zeandale twp,Secretary of  State,,Rep,Dennis Taylor,22
+Riley,Zeandale twp,Secretary of  State,,Rep,Randy Duncan,13
+Riley,Zeandale twp,Secretary of  State,,Rep,Keith Esau,8
+Riley,Zeandale twp,Secretary of  State,,Rep,Craig McCullah,17
+Riley,Zeandale twp,Secretary of  State,,Rep,Scott Schwab,15
+Riley,Zeandale twp,Attorney General,,Rep,Derek Schmidt,72
+Riley,Zeandale twp,State Treasurer,,Rep,Jake LaTurner,65
+Riley,Zeandale twp,Insurance Commissioner,,Rep,Clark Shultz,41
+Riley,Zeandale twp,Insurance Commissioner,,Rep,Vicki Schmidt,39
+Riley,Zeandale twp,State House,67,Rep,Ron Highland,72
+Riley,Mad Ft Riley A,Registered Voters,,,Registered Voters,471
+Riley,Mad Ft Riley A,Ballots Cast,,Rep,Ballots Cast,1
+Riley,Mad Ft Riley A,Ballots Cast,,Dem,Ballots Cast,1
+Riley,Mad Ft Riley A,US House,1,Dem,Alan LaPolice,0
+Riley,Mad Ft Riley A,Governor,,Dem,Joshua Svaty,0
+Riley,Mad Ft Riley A,Governor,,Dem,Arden Andersen,0
+Riley,Mad Ft Riley A,Governor,,Dem,Jack Bergeson,0
+Riley,Mad Ft Riley A,Governor,,Dem,Carl Brewer,0
+Riley,Mad Ft Riley A,Governor,,Dem,Laura Kelly,1
+Riley,Mad Ft Riley A,Secretary of State,,Dem,Brian McClendon,0
+Riley,Mad Ft Riley A,Attorney General,,Dem,Sarah Swain,1
+Riley,Mad Ft Riley A,State Treasurer,,Dem,Marci Francisco,0
+Riley,Mad Ft Riley A,Insurance Commissioner,,Dem,Nathaniel McLaughlin,0
+Riley,Mad Ft Riley A,State House,64,Dem,write-in,0
+Riley,Mad Ft Riley A,US House,1,Rep,Nick Reinecker,1
+Riley,Mad Ft Riley A,US House,1,Rep,Roger Marshall,0
+Riley,Mad Ft Riley A,Governor,,Rep,Ken Selzer,1
+Riley,Mad Ft Riley A,Governor,,Rep,Joseph Tutera,0
+Riley,Mad Ft Riley A,Governor,,Rep,Jim Barnett,0
+Riley,Mad Ft Riley A,Governor,,Rep,Jeff Colyer,0
+Riley,Mad Ft Riley A,Governor,,Rep,Kris Kobach,0
+Riley,Mad Ft Riley A,Governor,,Rep,Patrick Kucera,0
+Riley,Mad Ft Riley A,Governor,,Rep,Tyler Ruzich,0
+Riley,Mad Ft Riley A,Secretary of  State,,Rep,Dennis Taylor,0
+Riley,Mad Ft Riley A,Secretary of  State,,Rep,Randy Duncan,1
+Riley,Mad Ft Riley A,Secretary of  State,,Rep,Keith Esau,0
+Riley,Mad Ft Riley A,Secretary of  State,,Rep,Craig McCullah,0
+Riley,Mad Ft Riley A,Secretary of  State,,Rep,Scott Schwab,0
+Riley,Mad Ft Riley A,Attorney General,,Rep,Derek Schmidt,1
+Riley,Mad Ft Riley A,State Treasurer,,Rep,Jake LaTurner,1
+Riley,Mad Ft Riley A,Insurance Commissioner,,Rep,Clark Shultz,1
+Riley,Mad Ft Riley A,Insurance Commissioner,,Rep,Vicki Schmidt,0
+Riley,Mad Ft Riley A,State House,64,Rep,Suzi Carlson,0
+Riley,Mad Ft Riley A,State House,64,Rep,Kathy Martin,1
+Riley,Mad Ft Riley B,Registered Voters,,,Registered Voters,233
+Riley,Mad Ft Riley B,Ballots Cast,,Rep,Ballots Cast,0
+Riley,Mad Ft Riley B,Ballots Cast,,Dem,Ballots Cast,2
+Riley,Mad Ft Riley B,US House,1,Dem,Alan LaPolice,2
+Riley,Mad Ft Riley B,Governor,,Dem,Joshua Svaty,1
+Riley,Mad Ft Riley B,Governor,,Dem,Arden Andersen,0
+Riley,Mad Ft Riley B,Governor,,Dem,Jack Bergeson,0
+Riley,Mad Ft Riley B,Governor,,Dem,Carl Brewer,0
+Riley,Mad Ft Riley B,Governor,,Dem,Laura Kelly,1
+Riley,Mad Ft Riley B,Secretary of State,,Dem,Brian McClendon,2
+Riley,Mad Ft Riley B,Attorney General,,Dem,Sarah Swain,2
+Riley,Mad Ft Riley B,State Treasurer,,Dem,Marci Francisco,2
+Riley,Mad Ft Riley B,Insurance Commissioner,,Dem,Nathaniel McLaughlin,2
+Riley,Mad Ft Riley B,State House,64,Dem,write-in,0
+Riley,Mad Ft Riley B,US House,1,Rep,Nick Reinecker,0
+Riley,Mad Ft Riley B,US House,1,Rep,Roger Marshall,0
+Riley,Mad Ft Riley B,Governor,,Rep,Ken Selzer,0
+Riley,Mad Ft Riley B,Governor,,Rep,Joseph Tutera,0
+Riley,Mad Ft Riley B,Governor,,Rep,Jim Barnett,0
+Riley,Mad Ft Riley B,Governor,,Rep,Jeff Colyer,0
+Riley,Mad Ft Riley B,Governor,,Rep,Kris Kobach,0
+Riley,Mad Ft Riley B,Governor,,Rep,Patrick Kucera,0
+Riley,Mad Ft Riley B,Governor,,Rep,Tyler Ruzich,0
+Riley,Mad Ft Riley B,Secretary of  State,,Rep,Dennis Taylor,0
+Riley,Mad Ft Riley B,Secretary of  State,,Rep,Randy Duncan,0
+Riley,Mad Ft Riley B,Secretary of  State,,Rep,Keith Esau,0
+Riley,Mad Ft Riley B,Secretary of  State,,Rep,Craig McCullah,0
+Riley,Mad Ft Riley B,Secretary of  State,,Rep,Scott Schwab,0
+Riley,Mad Ft Riley B,Attorney General,,Rep,Derek Schmidt,0
+Riley,Mad Ft Riley B,State Treasurer,,Rep,Jake LaTurner,0
+Riley,Mad Ft Riley B,Insurance Commissioner,,Rep,Clark Shultz,0
+Riley,Mad Ft Riley B,Insurance Commissioner,,Rep,Vicki Schmidt,0
+Riley,Mad Ft Riley B,State House,64,Rep,Suzi Carlson,0
+Riley,Mad Ft Riley B,State House,64,Rep,Kathy Martin,0


### PR DESCRIPTION
This removes some trailing columns that were essentially empty, except for a few rows.  The extra value in these rows (`p` or `P` followed by a number) do not appear to correspond to anything from the source files.  Since the header for this column was also missing, we removed this column to avoid potential confusion.


https://github.com/openelections/openelections-data-ks/blob/913c5c0931fb217b03c026b895d15036e4d71b11/2018/20180807__ks__primary__cherokee__precinct.csv#L164-L166
https://github.com/openelections/openelections-data-ks/blob/913c5c0931fb217b03c026b895d15036e4d71b11/2018/20180807__ks__primary__cherokee__precinct.csv#L1041-L1043
https://github.com/openelections/openelections-data-ks/blob/913c5c0931fb217b03c026b895d15036e4d71b11/2018/20180807__ks__primary__cherokee__precinct.csv#L1321-L1323
https://github.com/openelections/openelections-data-ks/blob/913c5c0931fb217b03c026b895d15036e4d71b11/2018/20180807__ks__primary__ford__precinct.csv#L876-L878
https://github.com/openelections/openelections-data-ks/blob/913c5c0931fb217b03c026b895d15036e4d71b11/2018/20180807__ks__primary__riley__precinct.csv#L364-L366
https://github.com/openelections/openelections-data-ks/blob/913c5c0931fb217b03c026b895d15036e4d71b11/2018/20180807__ks__primary__riley__precinct.csv#L860-L862
https://github.com/openelections/openelections-data-ks/blob/913c5c0931fb217b03c026b895d15036e4d71b11/2018/20180807__ks__primary__riley__precinct.csv#L1058-L1060
https://github.com/openelections/openelections-data-ks/blob/913c5c0931fb217b03c026b895d15036e4d71b11/2018/20180807__ks__primary__riley__precinct.csv#L1561-L1563
