### PR TITLE
Fix spelling error in column header

### DIFF
--- a/2018/20180807__ks__primary__allen__precinct.csv
+++ b/2018/20180807__ks__primary__allen__precinct.csv
@@ -1,4 +1,4 @@
-county,precinct,office,district,prty,candidate,votes,early_voting,election_day,hand,wed_fri,provisional
+county,precinct,office,district,party,candidate,votes,early_voting,election_day,hand,wed_fri,provisional
 Allen,0001 CARLYLE TWP,REGISTERED VOTERS,,,REGISTERED VOTERS - TOTAL,217,,,,,
 Allen,0001 CARLYLE TWP,BALLOTS CAST - Dem,,Dem,BALLOTS CAST - Democratic,7,2,5,0,0,0
 Allen,0001 CARLYLE TWP,BALLOTS CAST - Rep,,Rep,BALLOTS CAST - Republican,83,17,64,0,0,2


### PR DESCRIPTION
This fixes a spelling error in a column header (`prty` should be `party`).